### PR TITLE
bugfix/issue-17 fvar specialization fix for trace_quad_form

### DIFF
--- a/stan/math/fwd/mat/fun/trace_quad_form.hpp
+++ b/stan/math/fwd/mat/fun/trace_quad_form.hpp
@@ -19,10 +19,10 @@ namespace stan {
                     const Eigen::Matrix<fvar<T>, RB, CB> &B) {
       check_square("trace_quad_form", "A", A);
       check_multiplicable("trace_quad_form",
-                                      "A", A,
-                                      "B", B);
+                          "A", A,
+                          "B", B);
       return trace(multiply(transpose(B),
-                                        multiply(A, B)));
+                            multiply(A, B)));
     }
 
     template<int RA, int CA, int RB, int CB, typename T>
@@ -31,10 +31,10 @@ namespace stan {
                     const Eigen::Matrix<double, RB, CB> &B) {
       check_square("trace_quad_form", "A", A);
       check_multiplicable("trace_quad_form",
-                                      "A", A,
-                                      "B", B);
+                          "A", A,
+                          "B", B);
       return trace(multiply(transpose(B),
-                                        multiply(A, B)));
+                            multiply(A, B)));
     }
 
     template<int RA, int CA, int RB, int CB, typename T>
@@ -43,10 +43,10 @@ namespace stan {
                     const Eigen::Matrix<fvar<T>, RB, CB> &B) {
       check_square("trace_quad_form", "A", A);
       check_multiplicable("trace_quad_form",
-                                      "A", A,
-                                      "B", B);
+                          "A", A,
+                          "B", B);
       return trace(multiply(transpose(B),
-                                        multiply(A, B)));
+                            multiply(A, B)));
     }
   }
 }

--- a/stan/math/fwd/mat/fun/trace_quad_form.hpp
+++ b/stan/math/fwd/mat/fun/trace_quad_form.hpp
@@ -14,44 +14,41 @@ namespace stan {
   namespace math {
 
     template<int RA, int CA, int RB, int CB, typename T>
-    inline stan::math::fvar<T>
-    trace_quad_form(const Eigen::Matrix<stan::math::fvar<T>, RA, CA> &A,
-                    const Eigen::Matrix<stan::math::fvar<T>, RB, CB> &B) {
+    inline fvar<T>
+    trace_quad_form(const Eigen::Matrix<fvar<T>, RA, CA> &A,
+                    const Eigen::Matrix<fvar<T>, RB, CB> &B) {
       using stan::math::multiply;
-      using stan::math::multiply;
-      stan::math::check_square("trace_quad_form", "A", A);
-      stan::math::check_multiplicable("trace_quad_form",
+      check_square("trace_quad_form", "A", A);
+      check_multiplicable("trace_quad_form",
                                       "A", A,
                                       "B", B);
-      return stan::math::trace(multiply(stan::math::transpose(B),
+      return trace(multiply(transpose(B),
                                         multiply(A, B)));
     }
 
     template<int RA, int CA, int RB, int CB, typename T>
-    inline stan::math::fvar<T>
-    trace_quad_form(const Eigen::Matrix<stan::math::fvar<T>, RA, CA> &A,
+    inline fvar<T>
+    trace_quad_form(const Eigen::Matrix<fvar<T>, RA, CA> &A,
                     const Eigen::Matrix<double, RB, CB> &B) {
       using stan::math::multiply;
-      using stan::math::multiply;
-      stan::math::check_square("trace_quad_form", "A", A);
-      stan::math::check_multiplicable("trace_quad_form",
+      check_square("trace_quad_form", "A", A);
+      check_multiplicable("trace_quad_form",
                                       "A", A,
                                       "B", B);
-      return stan::math::trace(multiply(stan::math::transpose(B),
+      return trace(multiply(transpose(B),
                                         multiply(A, B)));
     }
 
     template<int RA, int CA, int RB, int CB, typename T>
-    inline stan::math::fvar<T>
+    inline fvar<T>
     trace_quad_form(const Eigen::Matrix<double, RA, CA> &A,
-                    const Eigen::Matrix<stan::math::fvar<T>, RB, CB> &B) {
+                    const Eigen::Matrix<fvar<T>, RB, CB> &B) {
       using stan::math::multiply;
-      using stan::math::multiply;
-      stan::math::check_square("trace_quad_form", "A", A);
-      stan::math::check_multiplicable("trace_quad_form",
+      check_square("trace_quad_form", "A", A);
+      check_multiplicable("trace_quad_form",
                                       "A", A,
                                       "B", B);
-      return stan::math::trace(multiply(stan::math::transpose(B),
+      return trace(multiply(transpose(B),
                                         multiply(A, B)));
     }
   }

--- a/stan/math/fwd/mat/fun/trace_quad_form.hpp
+++ b/stan/math/fwd/mat/fun/trace_quad_form.hpp
@@ -17,7 +17,6 @@ namespace stan {
     inline fvar<T>
     trace_quad_form(const Eigen::Matrix<fvar<T>, RA, CA> &A,
                     const Eigen::Matrix<fvar<T>, RB, CB> &B) {
-      using stan::math::multiply;
       check_square("trace_quad_form", "A", A);
       check_multiplicable("trace_quad_form",
                                       "A", A,
@@ -30,7 +29,6 @@ namespace stan {
     inline fvar<T>
     trace_quad_form(const Eigen::Matrix<fvar<T>, RA, CA> &A,
                     const Eigen::Matrix<double, RB, CB> &B) {
-      using stan::math::multiply;
       check_square("trace_quad_form", "A", A);
       check_multiplicable("trace_quad_form",
                                       "A", A,
@@ -43,7 +41,6 @@ namespace stan {
     inline fvar<T>
     trace_quad_form(const Eigen::Matrix<double, RA, CA> &A,
                     const Eigen::Matrix<fvar<T>, RB, CB> &B) {
-      using stan::math::multiply;
       check_square("trace_quad_form", "A", A);
       check_multiplicable("trace_quad_form",
                                       "A", A,

--- a/stan/math/fwd/mat/fun/trace_quad_form.hpp
+++ b/stan/math/fwd/mat/fun/trace_quad_form.hpp
@@ -26,6 +26,34 @@ namespace stan {
       return stan::math::trace(multiply(stan::math::transpose(B),
                                         multiply(A, B)));
     }
+
+    template<int RA, int CA, int RB, int CB, typename T>
+    inline stan::math::fvar<T>
+    trace_quad_form(const Eigen::Matrix<stan::math::fvar<T>, RA, CA> &A,
+                    const Eigen::Matrix<double, RB, CB> &B) {
+      using stan::math::multiply;
+      using stan::math::multiply;
+      stan::math::check_square("trace_quad_form", "A", A);
+      stan::math::check_multiplicable("trace_quad_form",
+                                      "A", A,
+                                      "B", B);
+      return stan::math::trace(multiply(stan::math::transpose(B),
+                                        multiply(A, B)));
+    }
+
+    template<int RA, int CA, int RB, int CB, typename T>
+    inline stan::math::fvar<T>
+    trace_quad_form(const Eigen::Matrix<double, RA, CA> &A,
+                    const Eigen::Matrix<stan::math::fvar<T>, RB, CB> &B) {
+      using stan::math::multiply;
+      using stan::math::multiply;
+      stan::math::check_square("trace_quad_form", "A", A);
+      stan::math::check_multiplicable("trace_quad_form",
+                                      "A", A,
+                                      "B", B);
+      return stan::math::trace(multiply(stan::math::transpose(B),
+                                        multiply(A, B)));
+    }
   }
 }
 

--- a/test/unit/math/fwd/mat/fun/trace_quad_form_test.cpp
+++ b/test/unit/math/fwd/mat/fun/trace_quad_form_test.cpp
@@ -52,6 +52,77 @@ TEST(AgradFwdMatrixTraceQuadForm, mat_fd) {
   EXPECT_FLOAT_EQ(16126, res.d_);
 }
 
+TEST(AgradFwdMatrixTraceQuadForm, mat_d_mat_fd) {
+  using stan::math::trace_quad_form;
+  using stan::math::matrix_fd;
+  
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> ad(4,4);
+  matrix_fd bd(4,2);
+  fvar<double> res;
+  bd << 100, 10,
+          0,  1,
+         -3, -3,
+          5,  2;
+  ad << 2.0,  3.0, 4.0,   5.0, 
+  6.0, 10.0, 2.0,   2.0,
+  7.0,  2.0, 7.0,   1.0,
+  8.0,  2.0, 1.0, 112.0;
+  
+  bd(0,0).d_ = 1.0;
+  bd(0,1).d_ = 1.0;
+  bd(1,0).d_ = 1.0;
+  bd(1,1).d_ = 1.0;
+  bd(2,0).d_ = 1.0;
+  bd(2,1).d_ = 1.0;
+  bd(3,0).d_ = 1.0;
+  bd(3,1).d_ = 1.0;
+
+  // fvar<double> - fvar<double>
+  res = trace_quad_form(ad,bd);
+  EXPECT_FLOAT_EQ(26758, res.val_);
+  EXPECT_FLOAT_EQ(5622, res.d_);
+}
+
+TEST(AgradFwdMatrixTraceQuadForm, mat_fd_mat_d) {
+
+  using stan::math::trace_quad_form;
+  using stan::math::matrix_fd;
+  
+  matrix_fd ad(4,4);
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> bd(4,2);
+  fvar<double> res;
+  bd << 100, 10,
+          0,  1,
+         -3, -3,
+          5,  2;
+  ad << 2.0,  3.0, 4.0,   5.0, 
+  6.0, 10.0, 2.0,   2.0,
+  7.0,  2.0, 7.0,   1.0,
+  8.0,  2.0, 1.0, 112.0;
+  
+  ad(0,0).d_ = 1.0;
+  ad(0,1).d_ = 1.0;
+  ad(0,2).d_ = 1.0;
+  ad(0,3).d_ = 1.0;
+  ad(1,0).d_ = 1.0;
+  ad(1,1).d_ = 1.0;
+  ad(1,2).d_ = 1.0;
+  ad(1,3).d_ = 1.0;
+  ad(2,0).d_ = 1.0;
+  ad(2,1).d_ = 1.0;
+  ad(2,2).d_ = 1.0;
+  ad(2,3).d_ = 1.0;
+  ad(3,0).d_ = 1.0;
+  ad(3,1).d_ = 1.0;
+  ad(3,2).d_ = 1.0;
+  ad(3,3).d_ = 1.0;
+
+  // fvar<double> - fvar<double>
+  res = trace_quad_form(ad,bd);
+  EXPECT_FLOAT_EQ(26758, res.val_);
+  EXPECT_FLOAT_EQ(10504, res.d_);
+}
+
 TEST(AgradFwdMatrixTraceQuadForm, mat_ffd) {
   using stan::math::trace_quad_form;
   using stan::math::matrix_ffd;

--- a/test/unit/math/mix/mat/fun/trace_quad_form_test.cpp
+++ b/test/unit/math/mix/mat/fun/trace_quad_form_test.cpp
@@ -1,4 +1,7 @@
 #include <stan/math/fwd/mat/fun/trace_quad_form.hpp>
+#include <stan/math/prim/scal/err/check_not_nan.hpp>
+#include <stan/math/rev/scal/fun/value_of_rec.hpp>
+#include <stan/math/fwd/scal/fun/value_of_rec.hpp>
 #include <stan/math/fwd/mat/fun/typedefs.hpp>
 #include <stan/math/mix/mat/fun/typedefs.hpp>
 #include <test/unit/math/rev/mat/fun/util.hpp>
@@ -113,6 +116,7 @@ TEST(AgradMixMatrixTraceQuadForm, mat_fv_1st_deriv) {
 TEST(AgradMixMatrixTraceQuadForm, mat_dfv_instant) {
   using stan::math::trace_quad_form;
   using stan::math::matrix_fv;
+  using stan::math::check_not_nan;
   
   Eigen::Matrix<double, -1, -1> ad(4,4);
   matrix_fv bd(4,2);
@@ -129,11 +133,13 @@ TEST(AgradMixMatrixTraceQuadForm, mat_dfv_instant) {
 
   // fvar<var> - fvar<var>
   res = trace_quad_form(ad,bd);
+  EXPECT_NO_THROW(check_not_nan("trace_quad_form","res",res));
 }
 
 TEST(AgradMixMatrixTraceQuadForm, mat_fvd_instant) {
   using stan::math::trace_quad_form;
   using stan::math::matrix_fv;
+  using stan::math::check_not_nan;
   
   matrix_fv ad(4,4);
   Eigen::Matrix<double, -1, -1> bd(4,2);
@@ -150,11 +156,13 @@ TEST(AgradMixMatrixTraceQuadForm, mat_fvd_instant) {
 
   // fvar<var> - fvar<var>
   res = trace_quad_form(ad,bd);
+  EXPECT_NO_THROW(check_not_nan("trace_quad_form","res",res));
 }
 
 TEST(AgradMixMatrixTraceQuadForm, mat_dffv_instant) {
   using stan::math::trace_quad_form;
   using stan::math::matrix_ffv;
+  using stan::math::check_not_nan;
   
   Eigen::Matrix<double, -1, -1> ad(4,4);
   matrix_ffv bd(4,2);
@@ -171,11 +179,13 @@ TEST(AgradMixMatrixTraceQuadForm, mat_dffv_instant) {
 
   // fvar<var> - fvar<var>
   res = trace_quad_form(ad,bd);
+  EXPECT_NO_THROW(check_not_nan("trace_quad_form","res",res));
 }
 
 TEST(AgradMixMatrixTraceQuadForm, mat_ffvd_instant) {
   using stan::math::trace_quad_form;
   using stan::math::matrix_ffv;
+  using stan::math::check_not_nan;
   
   matrix_ffv ad(4,4);
   Eigen::Matrix<double, -1, -1> bd(4,2);
@@ -192,6 +202,7 @@ TEST(AgradMixMatrixTraceQuadForm, mat_ffvd_instant) {
 
   // fvar<var> - fvar<var>
   res = trace_quad_form(ad,bd);
+  EXPECT_NO_THROW(check_not_nan("trace_quad_form","res",res));
 }
 
 TEST(AgradMixMatrixTraceQuadForm, mat_fv_2nd_deriv) {

--- a/test/unit/math/mix/mat/fun/trace_quad_form_test.cpp
+++ b/test/unit/math/mix/mat/fun/trace_quad_form_test.cpp
@@ -110,6 +110,89 @@ TEST(AgradMixMatrixTraceQuadForm, mat_fv_1st_deriv) {
   EXPECT_FLOAT_EQ(576,h[23]);
 }
 
+TEST(AgradMixMatrixTraceQuadForm, mat_dfv_instant) {
+  using stan::math::trace_quad_form;
+  using stan::math::matrix_fv;
+  
+  Eigen::Matrix<double, -1, -1> ad(4,4);
+  matrix_fv bd(4,2);
+  fvar<var> res;
+  bd << 100, 10,
+          0,  1,
+         -3, -3,
+          5,  2;
+  ad << 2.0,  3.0, 4.0,   5.0, 
+  6.0, 10.0, 2.0,   2.0,
+  7.0,  2.0, 7.0,   1.0,
+  8.0,  2.0, 1.0, 112.0;
+  
+
+  // fvar<var> - fvar<var>
+  res = trace_quad_form(ad,bd);
+}
+
+TEST(AgradMixMatrixTraceQuadForm, mat_fvd_instant) {
+  using stan::math::trace_quad_form;
+  using stan::math::matrix_fv;
+  
+  matrix_fv ad(4,4);
+  Eigen::Matrix<double, -1, -1> bd(4,2);
+  fvar<var> res;
+  bd << 100, 10,
+          0,  1,
+         -3, -3,
+          5,  2;
+  ad << 2.0,  3.0, 4.0,   5.0, 
+  6.0, 10.0, 2.0,   2.0,
+  7.0,  2.0, 7.0,   1.0,
+  8.0,  2.0, 1.0, 112.0;
+  
+
+  // fvar<var> - fvar<var>
+  res = trace_quad_form(ad,bd);
+}
+
+TEST(AgradMixMatrixTraceQuadForm, mat_dffv_instant) {
+  using stan::math::trace_quad_form;
+  using stan::math::matrix_ffv;
+  
+  Eigen::Matrix<double, -1, -1> ad(4,4);
+  matrix_ffv bd(4,2);
+  fvar<fvar<var> > res;
+  bd << 100, 10,
+          0,  1,
+         -3, -3,
+          5,  2;
+  ad << 2.0,  3.0, 4.0,   5.0, 
+  6.0, 10.0, 2.0,   2.0,
+  7.0,  2.0, 7.0,   1.0,
+  8.0,  2.0, 1.0, 112.0;
+  
+
+  // fvar<var> - fvar<var>
+  res = trace_quad_form(ad,bd);
+}
+
+TEST(AgradMixMatrixTraceQuadForm, mat_ffvd_instant) {
+  using stan::math::trace_quad_form;
+  using stan::math::matrix_ffv;
+  
+  matrix_ffv ad(4,4);
+  Eigen::Matrix<double, -1, -1> bd(4,2);
+  fvar<fvar<var> > res;
+  bd << 100, 10,
+          0,  1,
+         -3, -3,
+          5,  2;
+  ad << 2.0,  3.0, 4.0,   5.0, 
+  6.0, 10.0, 2.0,   2.0,
+  7.0,  2.0, 7.0,   1.0,
+  8.0,  2.0, 1.0, 112.0;
+  
+
+  // fvar<var> - fvar<var>
+  res = trace_quad_form(ad,bd);
+}
 
 TEST(AgradMixMatrixTraceQuadForm, mat_fv_2nd_deriv) {
   using stan::math::trace_quad_form;


### PR DESCRIPTION
#### Summary:

Introduces Matrix<double, -1, -1>, Matrix<fvar<T>, -1, -1> specialization of trace_quad_form

#### Intended Effect:

Admits higher-order autodiff of trace_quad_form for mixed type arguments (e.g. Matrix<double, -1, -1>, Matrix<fvar<var>, -1, -1>). Allows for fvar<T> instantiation of multi_normal_prec_log.

#### How to Verify:

./runTests.py test/unit/math/mix/mat/fun/trace_quad_form_test.cpp
./runTests.py test/unit/math/fwd/mat/fun/trace_quad_form_test.cpp

These should fail in the current math branch.

#### Side Effects:

None.

#### Documentation:

None.

#### Reviewer Suggestions:

Anyone