### PR TITLE
Fixes for MSVC 2008 and 2010

### DIFF
--- a/stan/math/rev/scal/fun/acosh.hpp
+++ b/stan/math/rev/scal/fun/acosh.hpp
@@ -6,6 +6,11 @@
 #include <boost/math/special_functions/fpclassify.hpp>
 #include <cmath>
 
+#ifdef _MSC_VER
+#include <boost/math/special_functions/acosh.hpp>
+using boost::math::acosh;
+#endif
+
 namespace stan {
   namespace math {
 

--- a/stan/math/rev/scal/fun/asinh.hpp
+++ b/stan/math/rev/scal/fun/asinh.hpp
@@ -7,6 +7,11 @@
 #include <cmath>
 #include <valarray>
 
+#ifdef _MSC_VER
+#include <boost/math/special_functions/asinh.hpp>
+using boost::math::asinh;
+#endif
+
 namespace stan {
   namespace math {
 

--- a/stan/math/rev/scal/fun/atanh.hpp
+++ b/stan/math/rev/scal/fun/atanh.hpp
@@ -6,6 +6,11 @@
 #include <cmath>
 #include <limits>
 
+#ifdef _MSC_VER
+#include <boost/math/special_functions/atanh.hpp>
+using boost::math::atanh;
+#endif
+
 namespace stan {
   namespace math {
 

--- a/stan/math/rev/scal/fun/cbrt.hpp
+++ b/stan/math/rev/scal/fun/cbrt.hpp
@@ -4,6 +4,12 @@
 #include <math.h>
 #include <stan/math/rev/core.hpp>
 
+#ifdef _MSC_VER
+#include <boost/math/special_functions/cbrt.hpp>
+using boost::math::cbrt;
+#endif
+
+
 namespace stan {
   namespace math {
 

--- a/stan/math/rev/scal/fun/erf.hpp
+++ b/stan/math/rev/scal/fun/erf.hpp
@@ -7,6 +7,11 @@
 #include <cmath>
 #include <valarray>
 
+#ifdef _MSC_VER
+#include <boost/math/special_functions/erf.hpp>
+using boost::math::erf;
+#endif
+
 namespace stan {
   namespace math {
 

--- a/stan/math/rev/scal/fun/erfc.hpp
+++ b/stan/math/rev/scal/fun/erfc.hpp
@@ -7,6 +7,11 @@
 #include <cmath>
 #include <valarray>
 
+#ifdef _MSC_VER
+#include <boost/math/special_functions/erf.hpp>
+using boost::math::erfc;
+#endif
+
 namespace stan {
   namespace math {
 

--- a/stan/math/rev/scal/fun/expm1.hpp
+++ b/stan/math/rev/scal/fun/expm1.hpp
@@ -7,6 +7,11 @@
 #include <cmath>
 #include <valarray>
 
+#ifdef _MSC_VER
+#include <boost/math/special_functions/expm1.hpp>
+using boost::math::expm1;
+#endif
+
 namespace stan {
   namespace math {
 

--- a/stan/math/rev/scal/fun/fma.hpp
+++ b/stan/math/rev/scal/fun/fma.hpp
@@ -9,6 +9,13 @@
 #include <valarray>
 #include <limits>
 
+#ifdef _MSC_VER
+template<typename T> 
+T fma(T x, T y, T z) {
+    return x*y+z;
+}
+#endif
+
 namespace stan {
   namespace math {
 

--- a/stan/math/rev/scal/fun/log1m_exp.hpp
+++ b/stan/math/rev/scal/fun/log1m_exp.hpp
@@ -6,6 +6,11 @@
 #include <stan/math/rev/scal/fun/calculate_chain.hpp>
 #include <cmath>
 
+#ifdef _MSC_VER
+#include <boost/math/special_functions/expm1.hpp>
+using boost::math::expm1;
+#endif
+
 namespace stan {
   namespace math {
 

--- a/stan/math/rev/scal/fun/log_diff_exp.hpp
+++ b/stan/math/rev/scal/fun/log_diff_exp.hpp
@@ -6,6 +6,11 @@
 #include <stan/math/prim/scal/fun/log_diff_exp.hpp>
 #include <cmath>
 
+#ifdef _MSC_VER
+#include <boost/math/special_functions/expm1.hpp>
+using boost::math::expm1;
+#endif
+
 namespace stan {
   namespace math {
 

--- a/stan/math/rev/scal/fun/owens_t.hpp
+++ b/stan/math/rev/scal/fun/owens_t.hpp
@@ -8,6 +8,11 @@
 #include <boost/math/special_functions/owens_t.hpp>
 #include <cmath>
 
+#ifdef _MSC_VER
+#include <boost/math/special_functions/erf.hpp>
+using boost::math::erf;
+#endif
+
 namespace stan {
   namespace math {
 

--- a/stan/math/rev/scal/fun/trunc.hpp
+++ b/stan/math/rev/scal/fun/trunc.hpp
@@ -6,6 +6,11 @@
 #include <boost/math/special_functions/fpclassify.hpp>
 #include <limits>
 
+#ifdef _MSC_VER
+#include <boost/math/special_functions/trunc.hpp>
+using boost::math::trunc;
+#endif
+
 namespace stan {
   namespace math {
 


### PR DESCRIPTION
MSVC pre-2015 is not C99/C11/C++11/C++14 compliant and therefore
does not contain a lot of the standard library math functions
that are present in compilers such as clang and gcc. Luckily,
boost provides implementations of all of these functions, so
we can just import them if we are using MSVC. However,
the one issue is FMA - which is just templated back to x*y+z,
which obviously negates the advantage of the function in the
first place.

@ariddell This is needed for PyStan to compile properly!