### PR TITLE
Correct URL link to 'new BSD license'

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ The <b>Stan Math Library</b> is a C++, reverse-mode automatic differentiation li
 
 Licensing
 ---------
-The Stan Math Library is licensed under the [new BSD license](https://raw.githubusercontent.com/stan-dev/math/develop/licenses/math-license.txt).
+The Stan Math Library is licensed under the [new BSD license](https://raw.githubusercontent.com/stan-dev/math/develop/licenses/stan-math-library-license.txt).
 
 Required Libraries
 ------------------


### PR DESCRIPTION
The link was not going to the file, but presumably pointed to a by-now-renamed file in the correct directly.