### PR TITLE
completes #146 --- better assignment error messages

### DIFF
--- a/stan/math/prim/mat/fun/assign.hpp
+++ b/stan/math/prim/mat/fun/assign.hpp
@@ -24,7 +24,7 @@ namespace stan {
      * @return String representing size.
      */
     void print_mat_size(int n, std::ostream& o) {
-      if (n == Eigen::Dynamic) 
+      if (n == Eigen::Dynamic)
         o << "dynamically sized";
       else
         o << n;

--- a/stan/math/prim/mat/fun/assign.hpp
+++ b/stan/math/prim/mat/fun/assign.hpp
@@ -3,6 +3,7 @@
 
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/scal/err/invalid_argument.hpp>
+#include <stan/math/prim/scal/err/check_size_match.hpp>
 #include <stan/math/prim/mat/err/check_matching_sizes.hpp>
 #include <stan/math/prim/mat/err/check_matching_dims.hpp>
 #include <iostream>
@@ -14,6 +15,20 @@
 namespace stan {
 
   namespace math {
+
+    /**
+     * Helper function to return the matrix size as either "dynamic" or "1".
+     *
+     * @param n Eigen matrix size specification.
+     * @param o Output stream.
+     * @return String representing size.
+     */
+    void print_mat_size(int n, std::ostream& o) {
+      if (n == Eigen::Dynamic) 
+        o << "dynamically sized";
+      else
+        o << n;
+    }
 
     // Recursive assignment with size match checking and promotion
 
@@ -63,10 +78,14 @@ namespace stan {
            const Eigen::Matrix<RHS, R2, C2>& y) {
       std::stringstream ss;
       ss << "shapes must match, but found"
-         << " R1=" << R1
-         << "; C1=" << C1
-         << "; R2=" << R2
-         << "; C2=" << C2;
+         << " left-hand side rows=";
+      print_mat_size(R1, ss);
+      ss << "; left-hand side cols=";
+      print_mat_size(C1, ss);
+      ss << "; right-hand side rows=";
+      print_mat_size(R2, ss);
+      ss << "; right-hand side cols=";
+      print_mat_size(C2, ss);
       std::string ss_str(ss.str());
       invalid_argument("assign(Eigen::Matrix, Eigen::Matrix)",
                        "", "", ss_str.c_str());
@@ -94,8 +113,8 @@ namespace stan {
     assign(Eigen::Matrix<LHS, R, C>& x,
            const Eigen::Matrix<RHS, R, C>& y) {
       stan::math::check_matching_dims("assign",
-                                                "x", x,
-                                                "y", y);
+                                      "left-hand-side", x,
+                                      "right-hand-side", y);
       for (int i = 0; i < x.size(); ++i)
         assign(x(i), y(i));
     }
@@ -122,9 +141,12 @@ namespace stan {
     inline void
     assign(Eigen::Block<LHS> x,
            const Eigen::Matrix<RHS, R, C>& y) {
-      stan::math::check_matching_sizes("assign",
-                                                 "x", x,
-                                                 "y", y);
+      stan::math::check_size_match("assign",
+                                   "left-hand side rows", x.rows(),
+                                   "right-hand side rows", y.rows());
+      stan::math::check_size_match("assign",
+                                   "left-hand side cols", x.cols(),
+                                   "right-hand side cols", y.cols());
       for (int n = 0; n < y.cols(); ++n)
         for (int m = 0; m < y.rows(); ++m)
           assign(x(m, n), y(m, n));
@@ -154,12 +176,11 @@ namespace stan {
     inline void
     assign(std::vector<LHS>& x, const std::vector<RHS>& y) {
       stan::math::check_matching_sizes("assign",
-                                                 "x", x,
-                                                 "y", y);
+                                       "left-hand side", x,
+                                       "right-hand side", y);
       for (size_t i = 0; i < x.size(); ++i)
         assign(x[i], y[i]);
     }
-
 
   }
 }

--- a/test/unit/math/prim/mat/fun/assign_test.cpp
+++ b/test/unit/math/prim/mat/fun/assign_test.cpp
@@ -1,10 +1,75 @@
+#include <sstream>
 #include <stdexcept>
 #include <vector>
 #include <stan/math/prim/mat/fun/assign.hpp>
 #include <stan/math/prim/mat/fun/get_base1_lhs.hpp>
+#include <test/unit/util.hpp>
 #include <gtest/gtest.h>
 
-TEST(MathMatrixAssign,int) {
+void test_print_mat_size(int n, const std::string& expected) {
+  using stan::math::print_mat_size;
+  std::stringstream ss;
+  stan::math::print_mat_size(n, ss);
+  EXPECT_EQ(expected, ss.str());
+}
+
+TEST(MathMatrixAssign, print_mat_size) {
+  test_print_mat_size(-1, "dynamically sized");
+  test_print_mat_size(0, "0");
+  test_print_mat_size(1, "1");
+  test_print_mat_size(10, "10");
+}
+
+TEST(MathMatrixAssign, realToDouble) {
+  double a = 2.7;
+  int b = 0;
+  EXPECT_NO_THROW(stan::math::assign(b, a));
+  EXPECT_NO_THROW(stan::math::assign(a, b));
+}
+
+TEST(MathMatrixAssign, matSizeMismatch) {
+  using Eigen::Matrix;
+  using stan::math::assign;
+  Matrix<double, 1, -1> x(3);
+  Matrix<double, 1, -1> y(3);
+  EXPECT_NO_THROW(assign(x, y));
+  Matrix<double, 1, -1> z(10);
+  EXPECT_THROW_MSG(assign(x, z), std::exception,
+                   "Columns of left-hand-side (3) and columns"
+                   " of right-hand-side (10) must match in size");
+
+  Matrix<double, -1, 1> a(5);
+  Matrix<double, -1, 1> b(6);
+  EXPECT_THROW_MSG(assign(a, b), std::exception,
+                   "Rows of left-hand-side (5) and rows"
+                   " of right-hand-side (6) must match in size");
+
+  std::vector<double> u(5);
+  std::vector<double> v(7);
+  EXPECT_THROW_MSG(assign(u, v), std::exception,
+                   "size of left-hand side (5) and size of"
+                   " right-hand side (7) must match in size");
+
+  Matrix<double, -1, -1> m1(4, 5);
+  Matrix<double, -1, -1> m2(5, 4);
+  EXPECT_THROW_MSG(assign(m1, m2), std::exception,
+                   "Rows of left-hand-side (4) and rows of"
+                   " right-hand-side (5) must match in size");
+
+  Matrix<double, -1, -1> m3(10, 10);
+  Matrix<double, -1, -1> m4(2, 3);
+  EXPECT_THROW_MSG(assign(m3.block(1,1,7,3), m4), std::exception,
+                   "left-hand side rows (7) and right-hand"
+                   " side rows (2) must match in size");
+  
+  EXPECT_THROW_MSG(assign(m3.block(1,1,2,5), m4), std::exception,
+                   "assign: left-hand side cols (5) and"
+                   " right-hand side cols (3) must match in size");
+}
+
+
+
+TEST(MathMatrixAssign,test_int) {
   using stan::math::assign;
   int a;
   int b = 5;
@@ -15,7 +80,7 @@ TEST(MathMatrixAssign,int) {
   assign(a,12);
   EXPECT_EQ(a,12);
 }
-TEST(MathMatrixAssign,double) {
+TEST(MathMatrixAssign,test_double) {
   using stan::math::assign;
 
   double a;


### PR DESCRIPTION
#### Summary:

Better assignment error messages for mismatched matrix and array sizes using left-hand side and right-hand side terminology and cleaning up sizes of matrices to indicate dynamic vs. 1.

#### Intended Effect:

Make it easier for users to understand error messages.

#### How to Verify:

Unit tests.

#### Side Effects:

No (unless something's depending on exact text of error messages).

#### Documentation:

No.

#### Reviewer Suggestions:

anyone