### PR TITLE
Issue 151 int returns

### DIFF
--- a/stan/math/prim/mat/fun/cols.hpp
+++ b/stan/math/prim/mat/fun/cols.hpp
@@ -6,10 +6,18 @@
 namespace stan {
   namespace math {
 
+    /**
+     * Return the number of columns in the specified
+     * matrix, vector, or row vector.
+     *
+     * @tparam T Type of matrix entries.
+     * @tparam R Row type of matrix.
+     * @tparam C Column type of matrix.
+     * @param[in] m Input matrix, vector, or row vector.
+     * @return Number of columns.
+     */
     template <typename T, int R, int C>
-    inline
-    size_t
-    cols(const Eigen::Matrix<T, R, C>& m) {
+    inline int cols(const Eigen::Matrix<T, R, C>& m) {
       return m.cols();
     }
 

--- a/stan/math/prim/mat/fun/rank.hpp
+++ b/stan/math/prim/mat/fun/rank.hpp
@@ -1,8 +1,8 @@
 #ifndef STAN_MATH_PRIM_MAT_FUN_RANK_HPP
 #define STAN_MATH_PRIM_MAT_FUN_RANK_HPP
 
-#include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/mat/err/check_range.hpp>
+#include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <vector>
 
 namespace stan {
@@ -11,42 +11,45 @@ namespace stan {
     /**
      * Return the number of components of v less than v[s].
      *
+     * @tparam T Type of elements.
+     * @param[in] v Input vector.
+     * @param[in] s Position in vector.
      * @return Number of components of v less than v[s].
-     * @tparam T Type of elements of the vector.
      */
     template <typename T>
-    inline size_t rank(const std::vector<T> & v, int s) {
+    inline int rank(const std::vector<T> & v, int s) {
       using stan::math::check_range;
-      size_t size = v.size();
+      int size = static_cast<int>(v.size());
       check_range("rank", "v", size, s);
-      s--;
-      size_t count(0U);
+      --s;
+      int count(0U);
       T compare(v[s]);
-      for (size_t i = 0U; i < size; ++i)
+      for (int i = 0U; i < size; ++i)
         if (v[i] < compare)
-          count++;
+          ++count;
       return count;
     }
 
     /**
      * Return the number of components of v less than v[s].
      *
-     * @return Number of components of v less than v[s].
      * @tparam T Type of elements of the vector.
+     * @param[in] v Input vector.
+     * @param s Index for input vector.
+     * @return Number of components of v less than v[s].
      */
     template <typename T, int R, int C>
-    inline size_t rank(const Eigen::Matrix<T, R, C> & v, int s) {
+    inline int rank(const Eigen::Matrix<T, R, C> & v, int s) {
       using stan::math::check_range;
-      size_t size = v.size();
-
+      int size = v.size();
       check_range("rank", "v", size, s);
-      s--;
+      --s;
       const T * vv = v.data();
-      size_t count(0U);
+      int count(0U);
       T compare(vv[s]);
-      for (size_t i = 0U; i < size; ++i)
+      for (int i = 0U; i < size; ++i)
         if (vv[i] < compare)
-          count++;
+          ++count;
       return count;
     }
 

--- a/stan/math/prim/mat/fun/rank.hpp
+++ b/stan/math/prim/mat/fun/rank.hpp
@@ -22,9 +22,9 @@ namespace stan {
       int size = static_cast<int>(v.size());
       check_range("rank", "v", size, s);
       --s;
-      int count(0U);
+      int count(0);
       T compare(v[s]);
-      for (int i = 0U; i < size; ++i)
+      for (int i = 0; i < size; ++i)
         if (v[i] < compare)
           ++count;
       return count;
@@ -45,9 +45,9 @@ namespace stan {
       check_range("rank", "v", size, s);
       --s;
       const T * vv = v.data();
-      int count(0U);
+      int count(0);
       T compare(vv[s]);
-      for (int i = 0U; i < size; ++i)
+      for (int i = 0; i < size; ++i)
         if (vv[i] < compare)
           ++count;
       return count;

--- a/stan/math/prim/mat/fun/rows.hpp
+++ b/stan/math/prim/mat/fun/rows.hpp
@@ -6,10 +6,18 @@
 namespace stan {
   namespace math {
 
+    /**
+     * Return the number of rows in the specified
+     * matrix, vector, or row vector.
+     *
+     * @tparam T Type of matrix entries.
+     * @tparam R Row type of matrix.
+     * @tparam C Column type of matrix.
+     * @param[in] m Input matrix, vector, or row vector.
+     * @return Number of rows.
+     */
     template <typename T, int R, int C>
-    inline
-    size_t
-    rows(const Eigen::Matrix<T, R, C>& m) {
+    inline int rows(const Eigen::Matrix<T, R, C>& m) {
       return m.rows();
     }
 

--- a/stan/math/prim/mat/fun/size.hpp
+++ b/stan/math/prim/mat/fun/size.hpp
@@ -6,10 +6,16 @@
 namespace stan {
   namespace math {
 
+    /**
+     * Return the size of the specified standard vector.
+     *
+     * @tparam T Type of elements.
+     * @param[in] x Input vector.
+     * @return Size of input vector.
+     */
     template <typename T>
-    inline int
-    size(const std::vector<T>& x) {
-      return x.size();
+    inline int size(const std::vector<T>& x) {
+      return static_cast<int>(x.size());
     }
 
   }

--- a/test/unit/math/prim/mat/fun/cols_test.cpp
+++ b/test/unit/math/prim/mat/fun/cols_test.cpp
@@ -1,3 +1,30 @@
 #include <stan/math/prim/mat/fun/cols.hpp>
 #include <gtest/gtest.h>
 
+TEST(primMatFunCols, matrix) {
+  using Eigen::MatrixXd;
+  using stan::math::cols;
+  MatrixXd m(3, 2);
+  EXPECT_EQ(2, cols(m));
+
+  MatrixXd m2(3, 1);
+  EXPECT_EQ(1, cols(m2));
+}
+TEST(primMatFunCols, vector) {
+  using Eigen::VectorXd;
+  using stan::math::cols;
+  VectorXd v(2);
+  EXPECT_EQ(1, cols(v));
+
+  VectorXd u(1);
+  EXPECT_EQ(1, cols(u));
+}
+TEST(primMatFunCols, rowVector) {
+  using Eigen::RowVectorXd;
+  using stan::math::cols;
+  RowVectorXd v(2);
+  EXPECT_EQ(2, cols(v));
+
+  RowVectorXd u(1);
+  EXPECT_EQ(1, cols(u));
+}

--- a/test/unit/math/prim/mat/fun/rows_test.cpp
+++ b/test/unit/math/prim/mat/fun/rows_test.cpp
@@ -1,3 +1,30 @@
 #include <stan/math/prim/mat/fun/rows.hpp>
 #include <gtest/gtest.h>
 
+TEST(primMatFunRows, matrix) {
+  using Eigen::MatrixXd;
+  using stan::math::rows;
+  MatrixXd m(3, 2);
+  EXPECT_EQ(3, rows(m));
+
+  MatrixXd m2(1, 2);
+  EXPECT_EQ(1, rows(m2));
+}
+TEST(primMatFunRows, vector) {
+  using Eigen::VectorXd;
+  using stan::math::rows;
+  VectorXd v(2);
+  EXPECT_EQ(2, rows(v));
+
+  VectorXd u(1);
+  EXPECT_EQ(1, rows(u));
+}
+TEST(primMatFunRows, rowVector) {
+  using Eigen::RowVectorXd;
+  using stan::math::rows;
+  RowVectorXd v(2);
+  EXPECT_EQ(1, rows(v));
+
+  RowVectorXd u(1);
+  EXPECT_EQ(1, rows(u));
+}


### PR DESCRIPTION
#### Summary:

Convert return types from `size_t` to `int` for  functions `rows()`, `cols()`, and `rank()`, plus doc for all `int`-returning size-like functions.  Also reviewed that all other return types are `int` --- it's easy to scan in the index of the doc.

#### Intended Effect:

Remove mismatched sign types for comparisons.

#### How to Verify:

New unit tests, look at return types.

#### Side Effects:

Other functions calling these functions may get type warnings now.

#### Documentation:

Added relevant doxygen doc to the functions.

#### Reviewer Suggestions:

Anyone.