### PR TITLE
Bugfix/issue 153

### DIFF
--- a/test/unit/math/mix/mat/fun/mdivide_right_spd_test.cpp
+++ b/test/unit/math/mix/mat/fun/mdivide_right_spd_test.cpp
@@ -1463,7 +1463,8 @@ TEST(AgradMixMatrixMdivideRightSPD,ffv_exceptions) {
   matrix_d fd1(3,3), fd2(4,4);
   row_vector_d rvd1(3), rvd2(4);
   row_vector_d vd1(3), vd2(4);
-
+  fd1.setZero();
+  fd2.setZero();
   EXPECT_THROW(mdivide_right_spd(fd2, fv1), std::invalid_argument);
   EXPECT_THROW(mdivide_right_spd(fv2, fd1), std::invalid_argument);
   EXPECT_THROW(mdivide_right_spd(fv2, fv1), std::invalid_argument);

--- a/test/unit/math/mix/mat/fun/mdivide_right_spd_test.cpp
+++ b/test/unit/math/mix/mat/fun/mdivide_right_spd_test.cpp
@@ -1463,8 +1463,7 @@ TEST(AgradMixMatrixMdivideRightSPD,ffv_exceptions) {
   matrix_d fd1(3,3), fd2(4,4);
   row_vector_d rvd1(3), rvd2(4);
   row_vector_d vd1(3), vd2(4);
-  fd1.setZero();
-  fd2.setZero();
+
   EXPECT_THROW(mdivide_right_spd(fd2, fv1), std::invalid_argument);
   EXPECT_THROW(mdivide_right_spd(fv2, fd1), std::invalid_argument);
   EXPECT_THROW(mdivide_right_spd(fv2, fv1), std::invalid_argument);

--- a/test/unit/math/mix/mat/fun/mdivide_right_spd_test.cpp
+++ b/test/unit/math/mix/mat/fun/mdivide_right_spd_test.cpp
@@ -1458,9 +1458,11 @@ TEST(AgradMixMatrixMdivideRightSPD,ffv_exceptions) {
   using stan::math::mdivide_right_spd;
 
   matrix_ffv fv1(3,3), fv2(4,4);
+  fv1.setZero(); fv2.setZero();
   row_vector_ffv rvf1(3), rvf2(4);
   row_vector_ffv vf1(3), vf2(4);
   matrix_d fd1(3,3), fd2(4,4);
+  fd1.setZero(); fd2.setZero();
   row_vector_d rvd1(3), rvd2(4);
   row_vector_d vd1(3), vd2(4);
 


### PR DESCRIPTION
This initializes a few matrices to zero before testing if they are positive definite. It only changes two lines of one test, so you just need to run
```
 ./runTests.py test/unit/math/mix/mat/fun/mdivide_right_spd_test.cpp
``` 
to verify that it is correct. Verifying that it is incorrect without this patch is system dependent.