### PR TITLE
Added tests for csr_* sparse functions.

### DIFF
--- a/test/unit/math/prim/mat/fun/csr_extract_u_test.cpp
+++ b/test/unit/math/prim/mat/fun/csr_extract_u_test.cpp
@@ -1,0 +1,64 @@
+#include <stan/math.hpp>
+#include <gtest/gtest.h>
+#include <vector>
+
+// Test that start of each row's values in NZE vector (w) is correctly
+// extracted from a dense matrix in sparse format.
+TEST(SparseStuff, csr_extract_u_dense) {
+  stan::math::matrix_d m(2, 3);
+  Eigen::SparseMatrix<double, Eigen::RowMajor> a;
+  m << 2.0, 4.0, 6.0, 8.0, 10.0, 12.0;
+  a = m.sparseView();
+  std::vector<int> result = stan::math::csr_extract_u(a);
+  EXPECT_EQ(1, result[0]);
+  EXPECT_EQ(4, result[1]);
+  EXPECT_EQ(7, result[2]);
+}
+
+// Test that start of each row's values in NZE vector (w) is correctly
+// extracted from a dense matrix in sparse format after
+// makeCompressed().
+TEST(SparseStuff, csr_extract_u_dense_compressed) {
+  stan::math::matrix_d m(2, 3);
+  Eigen::SparseMatrix<double, Eigen::RowMajor> a;
+  m << 2.0, 4.0, 6.0, 8.0, 10.0, 12.0;
+  a = m.sparseView();
+  a.makeCompressed();
+  std::vector<int> result = stan::math::csr_extract_u(a);
+  EXPECT_EQ(1, result[0]);
+  EXPECT_EQ(4, result[1]);
+  EXPECT_EQ(7, result[2]);
+}
+
+// Test that start of each row's values in NZE vector (w) is correctly
+// extracted from a sparse matrix in sparse format.
+TEST(SparseStuff, csr_extract_u_sparse) {
+  stan::math::matrix_d m(2, 3);
+  Eigen::SparseMatrix<double, Eigen::RowMajor> a;
+  m << 2.0, 4.0, 6.0, 0.0, 0.0, 0.0;
+  a = m.sparseView();
+  std::vector<int> result = stan::math::csr_extract_u(a);
+  EXPECT_EQ(1, result[0]);
+  EXPECT_EQ(4, result[1]);
+  EXPECT_EQ(4, result[2]);
+  EXPECT_EQ(3, result.size());
+}
+
+// Test that start of each row's values in NZE vector (w) is correctly
+// extracted from a dense matrix in sparse format after
+// makeCompressed().
+TEST(SparseStuff, csr_extract_u_sparse_compressed) {
+  stan::math::matrix_d m(2, 3);
+  Eigen::SparseMatrix<double, Eigen::RowMajor> a;
+  m << 2.0, 4.0, 6.0, 0.0, 0.0, 0.0;
+  a = m.sparseView();
+  a.makeCompressed();
+  std::vector<int> result = stan::math::csr_extract_u(a);
+  EXPECT_EQ(1, result[0]);
+  EXPECT_EQ(4, result[1]);
+  EXPECT_EQ(4, result[2]);
+  EXPECT_EQ(3, result.size());
+}
+
+
+

--- a/test/unit/math/prim/mat/fun/csr_extract_v_test.cpp
+++ b/test/unit/math/prim/mat/fun/csr_extract_v_test.cpp
@@ -1,0 +1,68 @@
+#include <stan/math.hpp>
+#include <gtest/gtest.h>
+#include <vector>
+
+// Test that column indexes of values from dense matrix in sparse
+// format are extracted.
+TEST(SparseStuff, csr_extract_v_dense) {
+  stan::math::matrix_d m(2, 3);
+  Eigen::SparseMatrix<double, Eigen::RowMajor> a;
+  m << 2.0, 4.0, 6.0, 8.0, 10.0, 12.0;
+  a = m.sparseView();
+  std::vector<int> result = stan::math::csr_extract_v(a);
+  EXPECT_EQ(1, result[0]);
+  EXPECT_EQ(2, result[1]);
+  EXPECT_EQ(3, result[2]);
+  EXPECT_EQ(1, result[3]);
+  EXPECT_EQ(2, result[4]);
+  EXPECT_EQ(3, result[5]);
+}
+
+// Test that column indexes of values from dense matrix in sparse
+// format are extracted after makeCompressed().
+TEST(SparseStuff, csr_extract_v_dense_compressed) {
+  stan::math::matrix_d m(2, 3);
+  Eigen::SparseMatrix<double, Eigen::RowMajor> a;
+  m << 2.0, 4.0, 6.0, 8.0, 10.0, 12.0;
+  a = m.sparseView();
+  a.makeCompressed();
+  std::vector<int> result = stan::math::csr_extract_v(a);
+  EXPECT_EQ(1, result[0]);
+  EXPECT_EQ(2, result[1]);
+  EXPECT_EQ(3, result[2]);
+  EXPECT_EQ(1, result[3]);
+  EXPECT_EQ(2, result[4]);
+  EXPECT_EQ(3, result[5]);
+}
+
+// Test that column indexes of values from sparse matrix in sparse
+// format are extracted.
+TEST(SparseStuff, csr_extract_v_sparse) {
+  stan::math::matrix_d m(2, 3);
+  Eigen::SparseMatrix<double, Eigen::RowMajor> a;
+  m << 2.0, 4.0, 6.0, 0.0, 0.0, 0.0;
+  a = m.sparseView();
+  std::vector<int> result = stan::math::csr_extract_v(a);
+  EXPECT_EQ(1, result[0]);
+  EXPECT_EQ(2, result[1]);
+  EXPECT_EQ(3, result[2]);
+  EXPECT_EQ(3, result.size());
+}
+
+// Test that column indexes of values from sparse matrix in sparse
+// format are extracted after makeCompressed().
+TEST(SparseStuff, csr_extract_v_sparse_compressed) {
+  stan::math::matrix_d m(2, 3);
+  Eigen::SparseMatrix<double, Eigen::RowMajor> a;
+  m << 2.0, 4.0, 6.0, 0.0, 0.0, 0.0;
+  a = m.sparseView();
+  a.makeCompressed();
+  std::vector<int> result = stan::math::csr_extract_v(a);
+  EXPECT_EQ(1, result[0]);
+  EXPECT_EQ(2, result[1]);
+  EXPECT_EQ(3, result[2]);
+  EXPECT_EQ(3, result.size());
+}
+
+
+

--- a/test/unit/math/prim/mat/fun/csr_extract_w_test.cpp
+++ b/test/unit/math/prim/mat/fun/csr_extract_w_test.cpp
@@ -1,0 +1,64 @@
+#include <stan/math/prim/mat/fun/assign.hpp>
+#include <stan/math/prim/mat/fun/csr_extract_w.hpp>
+#include <stan/math/prim/mat/fun/typedefs.hpp>
+#include <gtest/gtest.h>
+#include <vector>
+
+// Test that values from a dense matrix in sparse format are extracted.
+TEST(SparseStuff, csr_extract_w_dense) {
+  stan::math::matrix_d m(2, 3);
+  Eigen::SparseMatrix<double, Eigen::RowMajor> a;
+  m << 2.0, 4.0, 6.0, 8.0, 10.0, 12.0;
+  a = m.sparseView();
+  stan::math::vector_d result = stan::math::csr_extract_w(a);
+  EXPECT_FLOAT_EQ( 2.0, result(0));
+  EXPECT_FLOAT_EQ( 4.0, result(1));
+  EXPECT_FLOAT_EQ( 6.0, result(2));
+  EXPECT_FLOAT_EQ( 8.0, result(3));
+  EXPECT_FLOAT_EQ(10.0, result(4));
+  EXPECT_FLOAT_EQ(12.0, result(5));
+}
+
+// Test that values from a dense matrix in sparse format are extracted
+// after A.makeCompressed();
+TEST(SparseStuff, csr_extract_w_dense_compressed) {
+  stan::math::matrix_d m(2, 3);
+  Eigen::SparseMatrix<double, Eigen::RowMajor> a;
+  m << 2.0, 4.0, 6.0, 8.0, 10.0, 12.0;
+  a = m.sparseView();
+  a.makeCompressed();
+  stan::math::vector_d result = stan::math::csr_extract_w(a);
+  EXPECT_FLOAT_EQ( 2.0, result(0));
+  EXPECT_FLOAT_EQ( 4.0, result(1));
+  EXPECT_FLOAT_EQ( 6.0, result(2));
+  EXPECT_FLOAT_EQ( 8.0, result(3));
+  EXPECT_FLOAT_EQ(10.0, result(4));
+  EXPECT_FLOAT_EQ(12.0, result(5));
+}
+
+// Test that values from a sparse matrix in sparse format are extracted
+TEST(SparseStuff, csr_extract_w_sparse) {
+  stan::math::matrix_d m(2, 3);
+  Eigen::SparseMatrix<double, Eigen::RowMajor> a;
+  m << 2.0, 4.0, 6.0, 0.0, 0.0, 0.0;
+  a = m.sparseView();
+  stan::math::vector_d result = stan::math::csr_extract_w(a);
+  EXPECT_FLOAT_EQ(2.0, result(0));
+  EXPECT_FLOAT_EQ(4.0, result(1));
+  EXPECT_FLOAT_EQ(6.0, result(2));
+}
+
+
+// Test that values from a sparse matrix in sparse format are extracted
+// after A.makeCompressed()
+TEST(SparseStuff, csr_extract_w_sparse_compressed) {
+  stan::math::matrix_d m(2, 3);
+  Eigen::SparseMatrix<double, Eigen::RowMajor> a;
+  m << 2.0, 4.0, 6.0, 0.0, 0.0, 0.0;
+  a = m.sparseView();
+  stan::math::vector_d result = stan::math::csr_extract_w(a);
+  EXPECT_FLOAT_EQ( 2.0, result(0));
+  EXPECT_FLOAT_EQ( 4.0, result(1));
+  EXPECT_FLOAT_EQ( 6.0, result(2));
+}
+

--- a/test/unit/math/prim/mat/fun/csr_extract_z_test.cpp
+++ b/test/unit/math/prim/mat/fun/csr_extract_z_test.cpp
@@ -1,0 +1,55 @@
+#include <stan/math.hpp>
+#include <gtest/gtest.h>
+#include <vector>
+
+// Test that non-zero entry counts of values from dense matrix in
+// sparse format are extracted.
+TEST(SparseStuff, csr_extract_z_dense) {
+  stan::math::matrix_d m(2, 3);
+  Eigen::SparseMatrix<double, Eigen::RowMajor> a;
+  m << 2.0, 4.0, 6.0, 8.0, 10.0, 12.0;
+  a = m.sparseView();
+  std::vector<int> result = stan::math::csr_extract_z(a);
+  EXPECT_EQ(3, result[0]);
+  EXPECT_EQ(3, result[1]);
+}
+
+// Test that non-zero entry counts of values from dense matrix in
+// sparse format are extracted after makeCompressed();
+TEST(SparseStuff, csr_extract_z_dense_compressed) {
+  stan::math::matrix_d m(2, 3);
+  Eigen::SparseMatrix<double, Eigen::RowMajor> a;
+  m << 2.0, 4.0, 6.0, 8.0, 10.0, 12.0;
+  a = m.sparseView();
+  a.makeCompressed();
+  std::vector<int> result = stan::math::csr_extract_z(a);
+  EXPECT_EQ(3, result[0]);
+  EXPECT_EQ(3, result[1]);
+}
+
+
+// Test that non-zero entry counts of values from sparse matrix in
+// sparse format are extracted.
+TEST(SparseStuff, csr_extract_z_sparse) {
+  stan::math::matrix_d m(2, 3);
+  Eigen::SparseMatrix<double, Eigen::RowMajor> a;
+  m << 2.0, 4.0, 6.0, 0.0, 0.0, 0.0;
+  a = m.sparseView();
+  std::vector<int> result = stan::math::csr_extract_z(a);
+  EXPECT_EQ(3, result[0]);
+  EXPECT_EQ(0, result[1]);
+}
+
+// Test that non-zero entry counts of values from sparse matrix in
+// sparse format are extracted after makeCompressed();
+TEST(SparseStuff, csr_extract_z_sparse_compressed) {
+  stan::math::matrix_d m(2, 3);
+  Eigen::SparseMatrix<double, Eigen::RowMajor> a;
+  m << 2.0, 4.0, 6.0, 0.0, 0.0, 0.0;
+  a = m.sparseView();
+  a.makeCompressed();
+  std::vector<int> result = stan::math::csr_extract_z(a);
+  EXPECT_EQ(3, result[0]);
+  EXPECT_EQ(0, result[1]);
+}
+

--- a/test/unit/math/prim/mat/fun/csr_matrix_times_vector_test.cpp
+++ b/test/unit/math/prim/mat/fun/csr_matrix_times_vector_test.cpp
@@ -1,0 +1,219 @@
+#include <stan/math.hpp>
+#include <gtest/gtest.h>
+#include <vector>
+
+// Test that dense multiplication results is correct (CSR).
+TEST(SparseStuff, csr_matrix_times_vector_dense_multiply) {
+  stan::math::matrix_d m(2, 3);
+  Eigen::SparseMatrix<double, Eigen::RowMajor> a;
+  m << 2.0, 4.0, 6.0, 8.0, 10.0, 12.0;
+  a = m.sparseView();
+  
+  stan::math::vector_d X_w = stan::math::csr_extract_w(a);
+  std::vector<int> X_v = stan::math::csr_extract_v(a);
+  std::vector<int> X_u = stan::math::csr_extract_u(a);
+  std::vector<int> X_z = stan::math::csr_extract_z(a);
+
+  stan::math::vector_d b(3);
+  b << 22, 33, 44;
+
+  stan::math::vector_d result = stan::math::csr_matrix_times_vector(
+      2, 3, X_w, X_v, X_u, X_z, b);
+
+  EXPECT_FLOAT_EQ( 440.0, result(0));
+  EXPECT_FLOAT_EQ(1034.0, result(1));
+}
+
+// Test that sparse multiplication is correct when columns are all zero.
+TEST(SparseStuff, csr_matrix_times_vector_empty_row_multiply) {
+  stan::math::matrix_d m(2, 3);
+  Eigen::SparseMatrix<double, Eigen::RowMajor> a;
+  m << 2.0, 4.0, 0.0, 8.0, 10.0, 0.0;
+  a = m.sparseView();
+  
+  stan::math::vector_d X_w = stan::math::csr_extract_w(a);
+  std::vector<int> X_v = stan::math::csr_extract_v(a);
+  std::vector<int> X_u = stan::math::csr_extract_u(a);
+  std::vector<int> X_z = stan::math::csr_extract_z(a);
+
+  stan::math::vector_d b(3);
+  b << 22, 33, 44;
+
+  stan::math::vector_d result = stan::math::csr_matrix_times_vector(
+      2, 3, X_w, X_v, X_u, X_z, b);
+
+  EXPECT_FLOAT_EQ( 176.0, result(0));
+  EXPECT_FLOAT_EQ( 506.0, result(1));
+}
+
+// Test that sparse multiplication is correct when columns are all zero.
+TEST(SparseStuff, csr_matrix_times_vector_empty_column_multiply) {
+  stan::math::matrix_d m(2, 3);
+  Eigen::SparseMatrix<double, Eigen::RowMajor> a;
+  m << 2.0, 0.0, 6.0, 8.0, 0.0, 12.0;
+  a = m.sparseView();
+  
+  stan::math::vector_d X_w = stan::math::csr_extract_w(a);
+  std::vector<int> X_v = stan::math::csr_extract_v(a);
+  std::vector<int> X_u = stan::math::csr_extract_u(a);
+  std::vector<int> X_z = stan::math::csr_extract_z(a);
+
+  stan::math::vector_d b(3);
+  b << 22, 33, 44;
+
+  stan::math::vector_d result = stan::math::csr_matrix_times_vector(
+      2, 3, X_w, X_v, X_u, X_z, b);
+
+  EXPECT_FLOAT_EQ( 308.0, result(0));
+  EXPECT_FLOAT_EQ( 704.0, result(1));
+}
+
+// Test that m=0 throws (CSR).
+TEST(SparseStuff, csr_matrix_times_vector_m0) {
+  stan::math::matrix_d m(2, 3);
+  Eigen::SparseMatrix<double, Eigen::RowMajor> a;
+  m << 2.0, 4.0, 6.0, 8.0, 10.0, 12.0;
+  a = m.sparseView();
+
+  stan::math::vector_d X_w = stan::math::csr_extract_w(a);
+  std::vector<int> X_v = stan::math::csr_extract_v(a);
+  std::vector<int> X_u = stan::math::csr_extract_u(a);
+  std::vector<int> X_z = stan::math::csr_extract_z(a);
+
+  stan::math::vector_d b(3);
+  b << 22, 33, 44;
+
+  EXPECT_THROW({
+  stan::math::vector_d result = stan::math::csr_matrix_times_vector(0, 3, X_w, X_v, X_u, X_z, b);},
+  std::domain_error);
+}
+
+// Test that n=0 throws (CSR).
+TEST(SparseStuff, csr_matrix_times_vector_n0) {
+  stan::math::matrix_d m(2, 3);
+  Eigen::SparseMatrix<double, Eigen::RowMajor> a;
+  m << 2.0, 4.0, 6.0, 8.0, 10.0, 12.0;
+  a = m.sparseView();
+
+  stan::math::vector_d X_w = stan::math::csr_extract_w(a);
+  std::vector<int> X_v = stan::math::csr_extract_v(a);
+  std::vector<int> X_u = stan::math::csr_extract_u(a);
+  std::vector<int> X_z = stan::math::csr_extract_z(a);
+
+  stan::math::vector_d b(3);
+  b << 22, 33, 44;
+
+  EXPECT_THROW({
+  stan::math::vector_d result = stan::math::csr_matrix_times_vector(2, 0, X_w, X_v, X_u, X_z, b);},
+  std::domain_error);
+}
+
+// Test that short b throws (CSR).
+TEST(SparseStuff, csr_matrix_times_vector_b_short) {
+  stan::math::matrix_d m(2, 3);
+  Eigen::SparseMatrix<double, Eigen::RowMajor> a;
+  m << 2.0, 4.0, 6.0, 8.0, 10.0, 12.0;
+  a = m.sparseView();
+
+  stan::math::vector_d X_w = stan::math::csr_extract_w(a);
+  std::vector<int> X_v = stan::math::csr_extract_v(a);
+  std::vector<int> X_u = stan::math::csr_extract_u(a);
+  std::vector<int> X_z = stan::math::csr_extract_z(a);
+
+  stan::math::vector_d b(2);  // short b
+  b << 22, 33;
+
+  EXPECT_THROW({
+  stan::math::vector_d result = stan::math::csr_matrix_times_vector(2, 3, X_w, X_v, X_u, X_z, b);},
+  std::invalid_argument);
+}
+
+// Test that short u throws (CSR).
+TEST(SparseStuff, csr_matrix_times_vector_u_short) {
+  stan::math::matrix_d m(2, 3);
+  Eigen::SparseMatrix<double, Eigen::RowMajor> a;
+  m << 2.0, 4.0, 6.0, 8.0, 10.0, 12.0;
+  a = m.sparseView();
+
+  stan::math::vector_d X_w = stan::math::csr_extract_w(a);
+  std::vector<int> X_v = stan::math::csr_extract_v(a);
+  std::vector<int> X_u = stan::math::csr_extract_u(a);
+  std::vector<int> X_z = stan::math::csr_extract_z(a);
+
+  X_u.erase(X_u.begin());  // make a short u:
+
+  stan::math::vector_d b(3);
+  b << 22, 33, 44;
+
+  EXPECT_THROW({
+  stan::math::vector_d result = stan::math::csr_matrix_times_vector(2, 3, X_w, X_v, X_u, X_z, b);},
+  std::invalid_argument);
+}
+
+// Test that short z throws (CSR).
+TEST(SparseStuff, csr_matrix_times_vector_z_short) {
+  stan::math::matrix_d m(2, 3);
+  Eigen::SparseMatrix<double, Eigen::RowMajor> a;
+  m << 2.0, 4.0, 6.0, 8.0, 10.0, 12.0;
+  a = m.sparseView();
+
+  stan::math::vector_d X_w = stan::math::csr_extract_w(a);
+  std::vector<int> X_v = stan::math::csr_extract_v(a);
+  std::vector<int> X_u = stan::math::csr_extract_u(a);
+  std::vector<int> X_z = stan::math::csr_extract_z(a);
+
+  X_z.erase(X_z.begin());  // make a short z:
+
+  stan::math::vector_d b(3);
+  b << 22, 33, 44;
+
+  EXPECT_THROW({
+  stan::math::vector_d result = stan::math::csr_matrix_times_vector(2, 3, X_w, X_v, X_u, X_z, b);},
+  std::invalid_argument);
+}
+
+// Test that short v throws (CSR).
+TEST(SparseStuff, csr_matrix_times_vector_v_short) {
+  stan::math::matrix_d m(2, 3);
+  Eigen::SparseMatrix<double, Eigen::RowMajor> a;
+  m << 2.0, 4.0, 6.0, 8.0, 10.0, 12.0;
+  a = m.sparseView();
+
+  stan::math::vector_d X_w = stan::math::csr_extract_w(a);
+  std::vector<int> X_v = stan::math::csr_extract_v(a);
+  std::vector<int> X_u = stan::math::csr_extract_u(a);
+  std::vector<int> X_z = stan::math::csr_extract_z(a);
+
+  X_v.erase(X_v.begin()+4);  // make a short v:
+
+  stan::math::vector_d b(3);
+  b << 22, 33, 44;
+
+  EXPECT_THROW({
+  stan::math::vector_d result = stan::math::csr_matrix_times_vector(2, 3, X_w, X_v, X_u, X_z, b);},
+  std::invalid_argument);
+}
+
+// Test that wrong z throws (CSR).
+TEST(SparseStuff, csr_matrix_times_vector_z_wrong) {
+  stan::math::matrix_d m(2, 3);
+  Eigen::SparseMatrix<double, Eigen::RowMajor> a;
+  m << 2.0, 4.0, 6.0, 8.0, 10.0, 12.0;
+  a = m.sparseView();
+
+  stan::math::vector_d X_w = stan::math::csr_extract_w(a);
+  std::vector<int> X_v = stan::math::csr_extract_v(a);
+  std::vector<int> X_u = stan::math::csr_extract_u(a);
+  std::vector<int> X_z = stan::math::csr_extract_z(a);
+
+  X_z[X_z.size()-1] += 1;  // make a wrong z:
+
+  stan::math::vector_d b(3);
+  b << 22, 33, 44;
+
+  EXPECT_THROW({
+  stan::math::vector_d result = stan::math::csr_matrix_times_vector(2, 3, X_w, X_v, X_u, X_z, b);},
+  std::invalid_argument);
+}
+
+

--- a/test/unit/math/prim/mat/fun/csr_to_dense_matrix_test.cpp
+++ b/test/unit/math/prim/mat/fun/csr_to_dense_matrix_test.cpp
@@ -1,0 +1,184 @@
+#include <stan/math.hpp>
+#include <gtest/gtest.h>
+#include <vector>
+
+
+// Test that sparse and dense multiplication results is the same after
+// plumbing through csr_extract_*.
+TEST(SparseStuff, csr_to_dense_matrix_two_route) {
+  stan::math::matrix_d m(2, 3);
+  Eigen::SparseMatrix<double, Eigen::RowMajor> a;
+  m << 2.0, 4.0, 6.0, 8.0, 10.0, 12.0;
+  a = m.sparseView();
+  
+  stan::math::vector_d X_w = stan::math::csr_extract_w(a);
+  std::vector<int> X_v = stan::math::csr_extract_v(a);
+  std::vector<int> X_u = stan::math::csr_extract_u(a);
+  std::vector<int> X_z = stan::math::csr_extract_z(a);
+  Eigen::Matrix<double, 2, 3> A = stan::math::csr_to_dense_matrix(2, 3, X_w, X_v, X_u, X_z);
+
+  stan::math::vector_d b(3);
+  b << 22, 33, 44;
+
+  stan::math::vector_d result_sparse = stan::math::csr_matrix_times_vector(
+      2, 3, X_w, X_v, X_u, X_z, b);
+  stan::math::vector_d result_dense = A * b;
+  stan::math::vector_d result_straight_dense = m * b;
+
+  EXPECT_FLOAT_EQ(result_dense(0), result_sparse(0));
+  EXPECT_FLOAT_EQ(result_dense(1), result_sparse(1));
+  EXPECT_FLOAT_EQ(result_dense(0), result_straight_dense(0));
+  EXPECT_FLOAT_EQ(result_dense(1), result_straight_dense(1));
+}
+
+// Test that sparse and dense multiplication results is the same after
+// plumbing through csr_extract_* with sparse test matrix.
+TEST(SparseStuff, csr_to_dense_matrix_two_route_sparse) {
+  stan::math::matrix_d m(2, 3);
+  Eigen::SparseMatrix<double, Eigen::RowMajor> a;
+  m << 2.0, 4.0, 0.0, 0.0, 0.0, 0.0;
+  a = m.sparseView();
+  
+  stan::math::vector_d X_w = stan::math::csr_extract_w(a);
+  std::vector<int> X_v = stan::math::csr_extract_v(a);
+  std::vector<int> X_u = stan::math::csr_extract_u(a);
+  std::vector<int> X_z = stan::math::csr_extract_z(a);
+  Eigen::Matrix<double, 2, 3> A = stan::math::csr_to_dense_matrix(2, 3, X_w, X_v, X_u, X_z);
+
+  stan::math::vector_d b(3);
+  b << 22, 33, 44;
+
+  stan::math::vector_d result_sparse = stan::math::csr_matrix_times_vector(
+      2, 3, X_w, X_v, X_u, X_z, b);
+  stan::math::vector_d result_dense = A * b;
+  stan::math::vector_d result_straight_dense = m * b;
+
+  EXPECT_FLOAT_EQ(result_dense(0), result_sparse(0));
+  EXPECT_FLOAT_EQ(result_dense(1), result_sparse(1));
+  EXPECT_FLOAT_EQ(result_dense(0), result_straight_dense(0));
+  EXPECT_FLOAT_EQ(result_dense(1), result_straight_dense(1));
+}
+
+// Test that m=0 throws (CSR).
+TEST(SparseStuff, csr_to_dense_matrix_m0) {
+  stan::math::matrix_d m(2, 3);
+  Eigen::SparseMatrix<double, Eigen::RowMajor> a;
+  m << 2.0, 4.0, 6.0, 8.0, 10.0, 12.0;
+  a = m.sparseView();
+
+  stan::math::vector_d X_w = stan::math::csr_extract_w(a);
+  std::vector<int> X_v = stan::math::csr_extract_v(a);
+  std::vector<int> X_u = stan::math::csr_extract_u(a);
+  std::vector<int> X_z = stan::math::csr_extract_z(a);
+
+  Eigen::Matrix<double, 2, 3> result;
+
+  EXPECT_THROW({
+  result = stan::math::csr_to_dense_matrix(0, 3, X_w, X_v, X_u, X_z);},
+  std::domain_error);
+}
+
+// Test that n=0 throws (CSR).
+TEST(SparseStuff, csr_to_dense_matrix_n0) {
+  stan::math::matrix_d m(2, 3);
+  Eigen::SparseMatrix<double, Eigen::RowMajor> a;
+  m << 2.0, 4.0, 6.0, 8.0, 10.0, 12.0;
+  a = m.sparseView();
+
+  stan::math::vector_d X_w = stan::math::csr_extract_w(a);
+  std::vector<int> X_v = stan::math::csr_extract_v(a);
+  std::vector<int> X_u = stan::math::csr_extract_u(a);
+  std::vector<int> X_z = stan::math::csr_extract_z(a);
+
+  Eigen::Matrix<double, 2, 3> result;
+
+  EXPECT_THROW({
+  result = stan::math::csr_to_dense_matrix(2, 0, X_w, X_v, X_u, X_z);},
+  std::domain_error);
+}
+
+// Test that short u throws (CSR).
+TEST(SparseStuff, csr_to_dense_matrix_u_short) {
+  stan::math::matrix_d m(2, 3);
+  Eigen::SparseMatrix<double, Eigen::RowMajor> a;
+  m << 2.0, 4.0, 6.0, 8.0, 10.0, 12.0;
+  a = m.sparseView();
+
+  stan::math::vector_d X_w = stan::math::csr_extract_w(a);
+  std::vector<int> X_v = stan::math::csr_extract_v(a);
+  std::vector<int> X_u = stan::math::csr_extract_u(a);
+  std::vector<int> X_z = stan::math::csr_extract_z(a);
+
+  X_u.erase(X_u.begin());  // make a short u:
+
+  Eigen::Matrix<double, 2, 3> result;
+
+  EXPECT_THROW({
+  result = stan::math::csr_to_dense_matrix(2, 3, X_w, X_v, X_u, X_z);},
+  std::invalid_argument);
+}
+
+// Test that short z throws (CSR).
+TEST(SparseStuff, csr_to_dense_matrix_z_short) {
+  stan::math::matrix_d m(2, 3);
+  Eigen::SparseMatrix<double, Eigen::RowMajor> a;
+  m << 2.0, 4.0, 6.0, 8.0, 10.0, 12.0;
+  a = m.sparseView();
+
+  stan::math::vector_d X_w = stan::math::csr_extract_w(a);
+  std::vector<int> X_v = stan::math::csr_extract_v(a);
+  std::vector<int> X_u = stan::math::csr_extract_u(a);
+  std::vector<int> X_z = stan::math::csr_extract_z(a);
+
+  X_z.erase(X_z.begin());  // make a short z:
+
+  Eigen::Matrix<double, 2, 3> result;
+
+  EXPECT_THROW({
+  result = stan::math::csr_to_dense_matrix(2, 3, X_w, X_v, X_u, X_z);},
+  std::invalid_argument);
+}
+
+// Test that short v throws (CSR).
+TEST(SparseStuff, csr_to_dense_matrix_v_short) {
+  stan::math::matrix_d m(2, 3);
+  Eigen::SparseMatrix<double, Eigen::RowMajor> a;
+  m << 2.0, 4.0, 6.0, 8.0, 10.0, 12.0;
+  a = m.sparseView();
+
+  stan::math::vector_d X_w = stan::math::csr_extract_w(a);
+  std::vector<int> X_v = stan::math::csr_extract_v(a);
+  std::vector<int> X_u = stan::math::csr_extract_u(a);
+  std::vector<int> X_z = stan::math::csr_extract_z(a);
+
+  X_v.erase(X_v.begin()+4);  // make a short v:
+
+  Eigen::Matrix<double, 2, 3> result;
+
+  EXPECT_THROW({
+  result = stan::math::csr_to_dense_matrix(2, 3, X_w, X_v, X_u, X_z);},
+  std::invalid_argument);
+}
+
+// Test that wrong z throws (CSR).
+TEST(SparseStuff, csr_to_dense_matrix_z_wrong) {
+  stan::math::matrix_d m(2, 3);
+  Eigen::SparseMatrix<double, Eigen::RowMajor> a;
+  m << 2.0, 4.0, 6.0, 8.0, 10.0, 12.0;
+  a = m.sparseView();
+
+  stan::math::vector_d X_w = stan::math::csr_extract_w(a);
+  std::vector<int> X_v = stan::math::csr_extract_v(a);
+  std::vector<int> X_u = stan::math::csr_extract_u(a);
+  std::vector<int> X_z = stan::math::csr_extract_z(a);
+
+  X_z[X_z.size()-1] += 1;  // make a wrong z:
+
+  Eigen::Matrix<double, 2, 3> result;
+
+  EXPECT_THROW({
+  result = stan::math::csr_to_dense_matrix(2, 3, X_w, X_v, X_u, X_z);},
+  std::invalid_argument);
+}
+
+


### PR DESCRIPTION
The original [pull request](https://github.com/stan-dev/math/commit/7064675f82479bd1fe1138ccea43552e262bb5e0?diff=unified) for the csr_* sparse functions failed to bring in the related tests for some reason.  Can't figure out why since I saw them in Jenkins testing output but here they are.