### PR TITLE
Bugfix/issue 168 fig extractor add tests

### DIFF
--- a/stan/math/prim/mat/fun/csr_extract_v.hpp
+++ b/stan/math/prim/mat/fun/csr_extract_v.hpp
@@ -43,7 +43,7 @@ namespace stan {
      */
     template <typename T, int R, int C>
     const vector<int>
-    csr_extract_w(const Matrix<T,  R, C>& A) {
+    csr_extract_v(const Matrix<T,  R, C>& A) {
       SparseMatrix<T, RowMajor> B = A.sparseView();
       vector<int> v = csr_extract_v(B);
       return v;

--- a/test/unit/math/prim/mat/fun/csr_extract_u_test.cpp
+++ b/test/unit/math/prim/mat/fun/csr_extract_u_test.cpp
@@ -16,6 +16,17 @@ TEST(SparseStuff, csr_extract_u_dense) {
 }
 
 // Test that start of each row's values in NZE vector (w) is correctly
+// extracted from a dense matrix in sparse format.
+TEST(SparseStuff, csr_extract_u_dense_dense) {
+  stan::math::matrix_d m(2, 3);
+  m << 2.0, 4.0, 6.0, 8.0, 10.0, 12.0;
+  std::vector<int> result = stan::math::csr_extract_u(m);
+  EXPECT_EQ(1, result[0]);
+  EXPECT_EQ(4, result[1]);
+  EXPECT_EQ(7, result[2]);
+}
+
+// Test that start of each row's values in NZE vector (w) is correctly
 // extracted from a dense matrix in sparse format after
 // makeCompressed().
 TEST(SparseStuff, csr_extract_u_dense_compressed) {

--- a/test/unit/math/prim/mat/fun/csr_extract_v_test.cpp
+++ b/test/unit/math/prim/mat/fun/csr_extract_v_test.cpp
@@ -18,6 +18,20 @@ TEST(SparseStuff, csr_extract_v_dense) {
   EXPECT_EQ(3, result[5]);
 }
 
+// Test that column indexes of values from dense matrix in dense
+// format are extracted.
+TEST(SparseStuff, csr_extract_v_dense_dense) {
+  stan::math::matrix_d m(2, 3);
+  m << 2.0, 4.0, 6.0, 8.0, 10.0, 12.0;
+  std::vector<int> result = stan::math::csr_extract_v(m);
+  EXPECT_EQ(1, result[0]);
+  EXPECT_EQ(2, result[1]);
+  EXPECT_EQ(3, result[2]);
+  EXPECT_EQ(1, result[3]);
+  EXPECT_EQ(2, result[4]);
+  EXPECT_EQ(3, result[5]);
+}
+
 // Test that column indexes of values from dense matrix in sparse
 // format are extracted after makeCompressed().
 TEST(SparseStuff, csr_extract_v_dense_compressed) {

--- a/test/unit/math/prim/mat/fun/csr_extract_w_test.cpp
+++ b/test/unit/math/prim/mat/fun/csr_extract_w_test.cpp
@@ -19,6 +19,19 @@ TEST(SparseStuff, csr_extract_w_dense) {
   EXPECT_FLOAT_EQ(12.0, result(5));
 }
 
+// Test that values from a dense matrix are extracted.
+TEST(SparseStuff, csr_extract_w_dense_dense) {
+  stan::math::matrix_d m(2, 3);
+  m << 2.0, 4.0, 6.0, 8.0, 10.0, 12.0;
+  stan::math::vector_d result = stan::math::csr_extract_w(m);
+  EXPECT_FLOAT_EQ( 2.0, result(0));
+  EXPECT_FLOAT_EQ( 4.0, result(1));
+  EXPECT_FLOAT_EQ( 6.0, result(2));
+  EXPECT_FLOAT_EQ( 8.0, result(3));
+  EXPECT_FLOAT_EQ(10.0, result(4));
+  EXPECT_FLOAT_EQ(12.0, result(5));
+}
+
 // Test that values from a dense matrix in sparse format are extracted
 // after A.makeCompressed();
 TEST(SparseStuff, csr_extract_w_dense_compressed) {

--- a/test/unit/math/prim/mat/fun/csr_extract_z_test.cpp
+++ b/test/unit/math/prim/mat/fun/csr_extract_z_test.cpp
@@ -15,6 +15,16 @@ TEST(SparseStuff, csr_extract_z_dense) {
 }
 
 // Test that non-zero entry counts of values from dense matrix in
+// sparse format are extracted.
+TEST(SparseStuff, csr_extract_z_dense_dense) {
+  stan::math::matrix_d m(2, 3);
+  m << 2.0, 4.0, 6.0, 8.0, 10.0, 12.0;
+  std::vector<int> result = stan::math::csr_extract_z(m);
+  EXPECT_EQ(3, result[0]);
+  EXPECT_EQ(3, result[1]);
+}
+
+// Test that non-zero entry counts of values from dense matrix in
 // sparse format are extracted after makeCompressed();
 TEST(SparseStuff, csr_extract_z_dense_compressed) {
   stan::math::matrix_d m(2, 3);


### PR DESCRIPTION
Fixes one broken signature for extract_v and extract_w that was making tests fail in stan-dev/stan, also adds math library tests for these signatures (w/v/u/z components extracted from dense matrix in dense format) so that breaking them in the future causes the tests to fail.  

All the tests that this touches locally now pass.  New good model parsing tests in stan-dev/stan now pass.



