### PR TITLE
Squashing unused-local-typedef warning from clang++

### DIFF
--- a/make/os_mac
+++ b/make/os_mac
@@ -16,10 +16,12 @@ endif
 ifeq (clang++,$(CC_TYPE))
   CFLAGS_GTEST += -Wc++11-extensions
   CFLAGS_GTEST += -Wno-c++11-long-long
+  CFLAGS += -Wno-unknown-warning-option
   CFLAGS += -Wno-unused-function
   CFLAGS += -Wno-tautological-compare
   CFLAGS += -Wno-c++11-long-long
   CFLAGS += -Wsign-compare
+  CFLAGS += -Wno-unused-local-typedef
   ifeq (true,$(C++11))
     CFLAGS += -stdlib=libc++ -std=c++11
   endif

--- a/test/unit/math/fwd/mat/fun/mdivide_left_ldlt_test.cpp
+++ b/test/unit/math/fwd/mat/fun/mdivide_left_ldlt_test.cpp
@@ -194,12 +194,20 @@ TEST(AgradFwdMatrixMdivideLeftLDLT,fd_exceptions) {
   fv1_ << 1,2,3,4,5,6,7,8,9;
   fv2_ << 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16;
   row_vector_fd rvf1(3), rvf2(4);
+  rvf1.setZero();
+  rvf2.setZero();
   vector_fd vf1(3), vf2(4);
+  vf1.setZero();
+  vf2.setZero();
   matrix_d fd1_(3,3), fd2_(4,4);
   fd1_ << 1,2,3,4,5,6,7,8,9;
   fd2_ << 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16;
   row_vector_d rvd1(3), rvd2(4);
+  rvd1.setZero();
+  rvd2.setZero();
   vector_d vd1(3), vd2(4);
+  vd1.setZero();
+  vd2.setZero();
 
   stan::math::LDLT_factor<fvar<double>,-1,-1> fv1;
   stan::math::LDLT_factor<fvar<double>,-1,-1> fv2;
@@ -421,12 +429,20 @@ TEST(AgradFwdMatrixMdivideLeftLDLT,ffd_exceptions) {
   fv1_ << 1,2,3,4,5,6,7,8,9;
   fv2_ << 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16;
   row_vector_ffd rvf1(3), rvf2(4);
+  rvf1.setZero();
+  rvf2.setZero();
   vector_ffd vf1(3), vf2(4);
+  vf1.setZero();
+  vf2.setZero();
   matrix_d fd1_(3,3), fd2_(4,4);
   fd1_ << 1,2,3,4,5,6,7,8,9;
   fd2_ << 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16;
   row_vector_d rvd1(3), rvd2(4);
+  rvd1.setZero();
+  rvd2.setZero();
   vector_d vd1(3), vd2(4);
+  vd1.setZero();
+  vd2.setZero();
 
   stan::math::LDLT_factor<fvar<fvar<double> >,-1,-1> fv1;
   stan::math::LDLT_factor<fvar<fvar<double> >,-1,-1> fv2;

--- a/test/unit/math/fwd/mat/fun/mdivide_left_spd_test.cpp
+++ b/test/unit/math/fwd/mat/fun/mdivide_left_spd_test.cpp
@@ -182,21 +182,21 @@ TEST(AgradFwdMatrixMdivideLeftSPD,fd_exceptions) {
   using stan::math::mdivide_left_spd;
 
   matrix_fd fv1(3,3), fv2(4,4);
-  row_vector_fd rvf1(3), rvf2(4);
-  vector_fd vf1(3), vf2(4);
-  matrix_d fd1(3,3), fd2(4,4);
-  row_vector_d rvd1(3), rvd2(4);
-  vector_d vd1(3), vd2(4);
   fv1.setZero();
   fv2.setZero();
+  row_vector_fd rvf1(3), rvf2(4);
   rvf1.setZero();
   rvf2.setZero();
+  vector_fd vf1(3), vf2(4);
   vf1.setZero();
   vf2.setZero();
+  matrix_d fd1(3,3), fd2(4,4);
   fd1.setZero();
   fd2.setZero();
+  row_vector_d rvd1(3), rvd2(4);
   rvd1.setZero();
   rvd2.setZero();
+  vector_d vd1(3), vd2(4);
   vd1.setZero();
   vd2.setZero();
 
@@ -394,23 +394,24 @@ TEST(AgradFwdMatrixMdivideLeftSPD,ffd_exceptions) {
   using stan::math::mdivide_left_spd;
 
   matrix_ffd fv1(3,3), fv2(4,4);
-  row_vector_ffd rvf1(3), rvf2(4);
-  vector_ffd vf1(3), vf2(4);
-  matrix_d fd1(3,3), fd2(4,4);
-  row_vector_d rvd1(3), rvd2(4);
-  vector_d vd1(3), vd2(4);
   fv1.setZero();
   fv2.setZero();
+  row_vector_ffd rvf1(3), rvf2(4);
   rvf1.setZero();
   rvf2.setZero();
+  vector_ffd vf1(3), vf2(4);
   vf1.setZero();
   vf2.setZero();
+  matrix_d fd1(3,3), fd2(4,4);
   fd1.setZero();
   fd2.setZero();
+  row_vector_d rvd1(3), rvd2(4);
   rvd1.setZero();
   rvd2.setZero();
+  vector_d vd1(3), vd2(4);
   vd1.setZero();
   vd2.setZero();
+
   EXPECT_THROW(mdivide_left_spd(fv1, fd2), std::domain_error);
   EXPECT_THROW(mdivide_left_spd(fd1, fv2), std::domain_error);
   EXPECT_THROW(mdivide_left_spd(fv1, fv2), std::domain_error);

--- a/test/unit/math/fwd/mat/fun/mdivide_left_test.cpp
+++ b/test/unit/math/fwd/mat/fun/mdivide_left_test.cpp
@@ -114,11 +114,23 @@ TEST(AgradFwdMatrixMdivideLeft,fd_exceptions) {
   using stan::math::mdivide_left;
 
   matrix_fd fv1(3,3), fv2(4,4);
+  fv1.setZero();
+  fv2.setZero();
   row_vector_fd rvf1(3), rvf2(4);
+  rvf1.setZero();
+  rvf2.setZero();
   vector_fd vf1(3), vf2(4);
+  vf1.setZero();
+  vf2.setZero();
   matrix_d fd1(3,3), fd2(4,4);
+  fd1.setZero();
+  fd2.setZero();
   row_vector_d rvd1(3), rvd2(4);
+  rvd1.setZero();
+  rvd2.setZero();
   vector_d vd1(3), vd2(4);
+  vd1.setZero();
+  vd2.setZero();
 
   EXPECT_THROW(mdivide_left(fv1, fd2), std::invalid_argument);
   EXPECT_THROW(mdivide_left(fd1, fv2), std::invalid_argument);
@@ -260,11 +272,23 @@ TEST(AgradFwdMatrixMdivideLeft,ffd_exceptions) {
   using stan::math::mdivide_left;
 
   matrix_ffd fv1(3,3), fv2(4,4);
+  fv1.setZero();
+  fv2.setZero();
   row_vector_ffd rvf1(3), rvf2(4);
+  rvf1.setZero();
+  rvf2.setZero();
   vector_ffd vf1(3), vf2(4);
+  vf1.setZero();
+  vf2.setZero();
   matrix_d fd1(3,3), fd2(4,4);
+  fd1.setZero();
+  fd2.setZero();
   row_vector_d rvd1(3), rvd2(4);
+  rvd1.setZero();
+  rvd2.setZero();
   vector_d vd1(3), vd2(4);
+  vd1.setZero();
+  vd2.setZero();
 
   EXPECT_THROW(mdivide_left(fv1, fd2), std::invalid_argument);
   EXPECT_THROW(mdivide_left(fd1, fv2), std::invalid_argument);

--- a/test/unit/math/fwd/mat/fun/mdivide_left_tri_low_test.cpp
+++ b/test/unit/math/fwd/mat/fun/mdivide_left_tri_low_test.cpp
@@ -250,9 +250,17 @@ TEST(AgradFwdMatrixMdivideLeftTriLow,fd_vector_matrix_exceptions) {
   using stan::math::mdivide_left_tri_low;
 
   vector_fd fv1(4), fv2(3);
+  fv1.setZero();
+  fv2.setZero();
   vector_d v1(4), v2(3);
+  v1.setZero();
+  v2.setZero();
   matrix_fd fvm1(4,4), fvm2(3,3);
+  fvm1.setZero();
+  fvm2.setZero();
   matrix_d vm1(4,4), vm2(3,3);
+  vm1.setZero();
+  vm2.setZero();
 
   EXPECT_THROW(mdivide_left_tri_low(fvm2, fv1), std::invalid_argument);
   EXPECT_THROW(mdivide_left_tri_low(vm2,fv1), std::invalid_argument);
@@ -267,7 +275,11 @@ TEST(AgradFwdMatrixMdivideLeftTriLow,fd_matrix_matrix_exceptions) {
   using stan::math::mdivide_left_tri_low;
 
   matrix_fd fvm1(4,4), fvm2(3,3);
+  fvm1.setZero();
+  fvm2.setZero();
   matrix_d vm1(4,4), vm2(3,3);
+  vm1.setZero();
+  vm2.setZero();
 
   EXPECT_THROW(mdivide_left_tri_low(fvm1,fvm2), std::invalid_argument);
   EXPECT_THROW(mdivide_left_tri_low(fvm1,vm2), std::invalid_argument);
@@ -541,9 +553,17 @@ TEST(AgradFwdMatrixMdivideLeftTriLow,ffd_vector_matrix_exceptions) {
   using stan::math::mdivide_left_tri_low;
 
   vector_ffd fv1(4), fv2(3);
+  fv1.setZero();
+  fv2.setZero();
   vector_d v1(4), v2(3);
+  v1.setZero();
+  v2.setZero();
   matrix_ffd fvm1(4,4), fvm2(3,3);
+  fvm1.setZero();
+  fvm2.setZero();
   matrix_d vm1(4,4), vm2(3,3);
+  vm1.setZero();
+  vm2.setZero();
 
   EXPECT_THROW(mdivide_left_tri_low(fvm2, fv1), std::invalid_argument);
   EXPECT_THROW(mdivide_left_tri_low(vm2,fv1), std::invalid_argument);
@@ -558,7 +578,11 @@ TEST(AgradFwdMatrixMdivideLeftTriLow,ffd_matrix_matrix_exceptions) {
   using stan::math::mdivide_left_tri_low;
 
   matrix_ffd fvm1(4,4), fvm2(3,3);
+  fvm1.setZero();
+  fvm2.setZero();
   matrix_d vm1(4,4), vm2(3,3);
+  vm1.setZero();
+  vm2.setZero();
 
   EXPECT_THROW(mdivide_left_tri_low(fvm1,fvm2), std::invalid_argument);
   EXPECT_THROW(mdivide_left_tri_low(fvm1,vm2), std::invalid_argument);

--- a/test/unit/math/fwd/mat/fun/mdivide_left_tri_test.cpp
+++ b/test/unit/math/fwd/mat/fun/mdivide_left_tri_test.cpp
@@ -180,11 +180,23 @@ TEST(AgradFwdMatrixMdivideLeftTri,fd_exceptions_lower) {
   using stan::math::mdivide_left_tri;
 
   matrix_fd fv1(3,3), fv2(4,4);
+  fv1.setZero();
+  fv2.setZero();
   row_vector_fd rvf1(3), rvf2(4);
+  rvf1.setZero();
+  rvf2.setZero();
   vector_fd vf1(3), vf2(4);
+  vf1.setZero();
+  vf2.setZero();
   matrix_d fd1(3,3), fd2(4,4);
+  fd1.setZero();
+  fd2.setZero();
   row_vector_d rvd1(3), rvd2(4);
+  rvd1.setZero();
+  rvd2.setZero();
   vector_d vd1(3), vd2(4);
+  vd1.setZero();
+  vd2.setZero();
 
   EXPECT_THROW(mdivide_left_tri<Eigen::Lower>(fv1, fd2), std::invalid_argument);
   EXPECT_THROW(mdivide_left_tri<Eigen::Lower>(fd1, fv2), std::invalid_argument);
@@ -380,11 +392,23 @@ TEST(AgradFwdMatrixMdivideLeftTri,ffd_exceptions_lower) {
   using stan::math::mdivide_left_tri;
 
   matrix_ffd fv1(3,3), fv2(4,4);
+  fv1.setZero();
+  fv2.setZero();
   row_vector_ffd rvf1(3), rvf2(4);
+  rvf1.setZero();
+  rvf2.setZero();
   vector_ffd vf1(3), vf2(4);
+  vf1.setZero();
+  vf2.setZero();
   matrix_d fd1(3,3), fd2(4,4);
+  fd1.setZero();
+  fd2.setZero();
   row_vector_d rvd1(3), rvd2(4);
+  rvd1.setZero();
+  rvd2.setZero();
   vector_d vd1(3), vd2(4);
+  vd1.setZero();
+  vd2.setZero();
 
   EXPECT_THROW(mdivide_left_tri<Eigen::Lower>(fv1, fd2), std::invalid_argument);
   EXPECT_THROW(mdivide_left_tri<Eigen::Lower>(fd1, fv2), std::invalid_argument);
@@ -580,11 +604,23 @@ TEST(AgradFwdMatrixMdivideLeftTri,fd_exceptions_upper) {
   using stan::math::mdivide_left_tri;
 
   matrix_fd fv1(3,3), fv2(4,4);
+  fv1.setZero();
+  fv2.setZero();
   row_vector_fd rvf1(3), rvf2(4);
+  rvf1.setZero();
+  rvf2.setZero();
   vector_fd vf1(3), vf2(4);
+  vf1.setZero();
+  vf2.setZero();
   matrix_d fd1(3,3), fd2(4,4);
+  fd1.setZero();
+  fd2.setZero();
   row_vector_d rvd1(3), rvd2(4);
+  rvd1.setZero();
+  rvd2.setZero();
   vector_d vd1(3), vd2(4);
+  vd1.setZero();
+  vd2.setZero();
 
   EXPECT_THROW(mdivide_left_tri<Eigen::Upper>(fv1, fd2), std::invalid_argument);
   EXPECT_THROW(mdivide_left_tri<Eigen::Upper>(fd1, fv2), std::invalid_argument);
@@ -780,11 +816,23 @@ TEST(AgradFwdMatrixMdivideLeftTri,ffd_exceptions_upper) {
   using stan::math::mdivide_left_tri;
 
   matrix_ffd fv1(3,3), fv2(4,4);
+  fv1.setZero();
+  fv2.setZero();
   row_vector_ffd rvf1(3), rvf2(4);
+  rvf1.setZero();
+  rvf2.setZero();
   vector_ffd vf1(3), vf2(4);
+  vf1.setZero();
+  vf2.setZero();
   matrix_d fd1(3,3), fd2(4,4);
+  fd1.setZero();
+  fd2.setZero();
   row_vector_d rvd1(3), rvd2(4);
+  rvd1.setZero();
+  rvd2.setZero();
   vector_d vd1(3), vd2(4);
+  vd1.setZero();
+  vd2.setZero();
 
   EXPECT_THROW(mdivide_left_tri<Eigen::Upper>(fv1, fd2), std::invalid_argument);
   EXPECT_THROW(mdivide_left_tri<Eigen::Upper>(fd1, fv2), std::invalid_argument);

--- a/test/unit/math/fwd/mat/fun/mdivide_right_ldlt_test.cpp
+++ b/test/unit/math/fwd/mat/fun/mdivide_right_ldlt_test.cpp
@@ -199,12 +199,20 @@ TEST(AgradFwdMatrixMdivideRightLDLT,fd_exceptions) {
   fv1_ << 1,2,3,4,5,6,7,8,9;
   fv2_ << 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16;
   vector_fd rvf1(3), rvf2(4);
+  rvf1.setZero();
+  rvf2.setZero();
   row_vector_fd vf1(3), vf2(4);
+  vf1.setZero();
+  vf2.setZero();
   matrix_d fd1_(3,3), fd2_(4,4);
   fd1_ << 1,2,3,4,5,6,7,8,9;
   fd2_ << 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16;
   vector_d rvd1(3), rvd2(4);
+  rvd1.setZero();
+  rvd2.setZero();
   row_vector_d vd1(3), vd2(4);
+  vd1.setZero();
+  vd2.setZero();
 
   stan::math::LDLT_factor<fvar<double>,-1,-1> fv1;
   stan::math::LDLT_factor<fvar<double>,-1,-1> fv2;
@@ -425,12 +433,20 @@ TEST(AgradFwdMatrixMdivideRightLDLT,ffd_exceptions) {
   fv1_ << 1,2,3,4,5,6,7,8,9;
   fv2_ << 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16;
   vector_ffd rvf1(3), rvf2(4);
+  rvf1.setZero();
+  rvf2.setZero();
   row_vector_ffd vf1(3), vf2(4);
+  vf1.setZero();
+  vf2.setZero();
   matrix_d fd1_(3,3), fd2_(4,4);
   fd1_ << 1,2,3,4,5,6,7,8,9;
   fd2_ << 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16;
   vector_d rvd1(3), rvd2(4);
+  rvd1.setZero();
+  rvd2.setZero();
   row_vector_d vd1(3), vd2(4);
+  vd1.setZero();
+  vd2.setZero();
 
   stan::math::LDLT_factor<fvar<fvar<double> >,-1,-1> fv1;
   stan::math::LDLT_factor<fvar<fvar<double> >,-1,-1> fv2;

--- a/test/unit/math/fwd/mat/fun/mdivide_right_spd_test.cpp
+++ b/test/unit/math/fwd/mat/fun/mdivide_right_spd_test.cpp
@@ -185,23 +185,24 @@ TEST(AgradFwdMatrixMdivideRightSPD,fd_exceptions) {
   using stan::math::mdivide_right_spd;
 
   matrix_fd fv1(3,3), fv2(4,4);
-  row_vector_fd rvf1(3), rvf2(4);
-  row_vector_fd vf1(3), vf2(4);
-  matrix_d fd1(3,3), fd2(4,4);
-  row_vector_d rvd1(3), rvd2(4);
-  row_vector_d vd1(3), vd2(4);
   fv1.setZero();
   fv2.setZero();
+  row_vector_fd rvf1(3), rvf2(4);
   rvf1.setZero();
   rvf2.setZero();
+  row_vector_fd vf1(3), vf2(4);
   vf1.setZero();
   vf2.setZero();
+  matrix_d fd1(3,3), fd2(4,4);
   fd1.setZero();
   fd2.setZero();
+  row_vector_d rvd1(3), rvd2(4);
   rvd1.setZero();
   rvd2.setZero();
+  row_vector_d vd1(3), vd2(4);
   vd1.setZero();
   vd2.setZero();
+
   EXPECT_THROW(mdivide_right_spd(fd2, fv1), std::invalid_argument);
   EXPECT_THROW(mdivide_right_spd(fv2, fd1), std::invalid_argument);
   EXPECT_THROW(mdivide_right_spd(fv2, fv1), std::invalid_argument);
@@ -394,11 +395,23 @@ TEST(AgradFwdMatrixMdivideRightSPD,ffd_exceptions) {
   using stan::math::mdivide_right_spd;
 
   matrix_ffd fv1(3,3), fv2(4,4);
+  fv1.setZero();
+  fv2.setZero();
   row_vector_ffd rvf1(3), rvf2(4);
+  rvf1.setZero();
+  rvf2.setZero();
   row_vector_ffd vf1(3), vf2(4);
+  vf1.setZero();
+  vf2.setZero();
   matrix_d fd1(3,3), fd2(4,4);
+  fd1.setZero();
+  fd2.setZero();
   row_vector_d rvd1(3), rvd2(4);
+  rvd1.setZero();
+  rvd2.setZero();
   row_vector_d vd1(3), vd2(4);
+  vd1.setZero();
+  vd2.setZero();
 
   EXPECT_THROW(mdivide_right_spd(fd2, fv1), std::invalid_argument);
   EXPECT_THROW(mdivide_right_spd(fv2, fd1), std::invalid_argument);

--- a/test/unit/math/fwd/mat/fun/mdivide_right_test.cpp
+++ b/test/unit/math/fwd/mat/fun/mdivide_right_test.cpp
@@ -115,11 +115,23 @@ TEST(AgradFwdMatrixMdivideRight,fd_exceptions) {
   using stan::math::mdivide_right;
 
   matrix_fd fv1(3,3), fv2(4,4);
+  fv1.setZero();
+  fv2.setZero();
   row_vector_fd rvf1(3), rvf2(4);
+  rvf1.setZero();
+  rvf2.setZero();
   vector_fd vf1(3), vf2(4);
+  vf1.setZero();
+  vf2.setZero();
   matrix_d fd1(3,3), fd2(4,4);
+  fd1.setZero();
+  fd2.setZero();
   row_vector_d rvd1(3), rvd2(4);
+  rvd1.setZero();
+  rvd2.setZero();
   vector_d vd1(3), vd2(4);
+  vd1.setZero();
+  vd2.setZero();
 
   EXPECT_THROW(mdivide_right(fv1, fd2), std::invalid_argument);
   EXPECT_THROW(mdivide_right(fd1, fv2), std::invalid_argument);
@@ -261,11 +273,23 @@ TEST(AgradFwdMatrixMdivideRight,ffd_exceptions) {
   using stan::math::mdivide_right;
 
   matrix_ffd fv1(3,3), fv2(4,4);
+  fv1.setZero();
+  fv2.setZero();
   row_vector_ffd rvf1(3), rvf2(4);
+  rvf1.setZero();
+  rvf2.setZero();
   vector_ffd vf1(3), vf2(4);
+  vf1.setZero();
+  vf2.setZero();
   matrix_d fd1(3,3), fd2(4,4);
+  fd1.setZero();
+  fd2.setZero();
   row_vector_d rvd1(3), rvd2(4);
+  rvd1.setZero();
+  rvd2.setZero();
   vector_d vd1(3), vd2(4);
+  vd1.setZero();
+  vd2.setZero();
 
   EXPECT_THROW(mdivide_right(fv1, fd2), std::invalid_argument);
   EXPECT_THROW(mdivide_right(fd1, fv2), std::invalid_argument);

--- a/test/unit/math/fwd/mat/fun/mdivide_right_tri_low_test.cpp
+++ b/test/unit/math/fwd/mat/fun/mdivide_right_tri_low_test.cpp
@@ -250,9 +250,17 @@ TEST(AgradFwdMatrixMdivideRightTriLow,fd__rowvector_matrix_exceptions) {
   using stan::math::mdivide_right_tri_low;
 
   row_vector_fd fv1(4), fv2(3);
+  fv1.setZero();
+  fv2.setZero();
   row_vector_d v1(4), v2(3);
+  v1.setZero();
+  v2.setZero();
   matrix_fd fvm1(4,4), fvm2(3,3);
+  fvm1.setZero();
+  fvm2.setZero();
   matrix_d vm1(4,4), vm2(3,3);
+  vm1.setZero();
+  vm2.setZero();
 
   EXPECT_THROW(mdivide_right_tri_low(fv1,fvm2), std::invalid_argument);
   EXPECT_THROW(mdivide_right_tri_low(fv1,vm2), std::invalid_argument);
@@ -267,7 +275,11 @@ TEST(AgradFwdMatrixMdivideRightTriLow,fd__matrix_matrix_exceptions) {
   using stan::math::mdivide_right_tri_low;
 
   matrix_fd fvm1(4,4), fvm2(3,3);
+  fvm1.setZero();
+  fvm2.setZero();
   matrix_d vm1(4,4), vm2(3,3);
+  vm1.setZero();
+  vm2.setZero();
 
   EXPECT_THROW(mdivide_right_tri_low(fvm1,fvm2), std::invalid_argument);
   EXPECT_THROW(mdivide_right_tri_low(fvm1,vm2), std::invalid_argument);
@@ -547,9 +559,17 @@ TEST(AgradFwdMatrixMdivideRightTriLow,ffd__rowvector_matrix_exceptions) {
   using stan::math::mdivide_right_tri_low;
 
   row_vector_ffd fv1(4), fv2(3);
+  fv1.setZero();
+  fv2.setZero();
   row_vector_d v1(4), v2(3);
+  v1.setZero();
+  v2.setZero();
   matrix_ffd fvm1(4,4), fvm2(3,3);
+  fvm1.setZero();
+  fvm2.setZero();
   matrix_d vm1(4,4), vm2(3,3);
+  vm1.setZero();
+  vm2.setZero();
 
   EXPECT_THROW(mdivide_right_tri_low(fv1,fvm2), std::invalid_argument);
   EXPECT_THROW(mdivide_right_tri_low(fv1,vm2), std::invalid_argument);
@@ -564,7 +584,11 @@ TEST(AgradFwdMatrixMdivideRightTriLow,ffd__matrix_matrix_exceptions) {
   using stan::math::mdivide_right_tri_low;
 
   matrix_ffd fvm1(4,4), fvm2(3,3);
+  fvm1.setZero();
+  fvm2.setZero();
   matrix_d vm1(4,4), vm2(3,3);
+  vm1.setZero();
+  vm2.setZero();
 
   EXPECT_THROW(mdivide_right_tri_low(fvm1,fvm2), std::invalid_argument);
   EXPECT_THROW(mdivide_right_tri_low(fvm1,vm2), std::invalid_argument);

--- a/test/unit/math/fwd/mat/fun/mdivide_right_tri_test.cpp
+++ b/test/unit/math/fwd/mat/fun/mdivide_right_tri_test.cpp
@@ -180,11 +180,23 @@ TEST(AgradFwdMatrixMdivideRightTri,fd_exceptions_lower) {
   using stan::math::mdivide_right_tri;
 
   matrix_fd fv1(3,3), fv2(4,4);
+  fv1.setZero();
+  fv2.setZero();
   row_vector_fd rvf1(3), rvf2(4);
+  rvf1.setZero();
+  rvf2.setZero();
   row_vector_fd vf1(3), vf2(4);
+  vf1.setZero();
+  vf2.setZero();
   matrix_d fd1(3,3), fd2(4,4);
+  fd1.setZero();
+  fd2.setZero();
   row_vector_d rvd1(3), rvd2(4);
+  rvd1.setZero();
+  rvd2.setZero();
   row_vector_d vd1(3), vd2(4);
+  vd1.setZero();
+  vd2.setZero();
 
   EXPECT_THROW(mdivide_right_tri<Eigen::Lower>(fv1, fd2), std::invalid_argument);
   EXPECT_THROW(mdivide_right_tri<Eigen::Lower>(fd1, fv2), std::invalid_argument);
@@ -375,11 +387,23 @@ TEST(AgradFwdMatrixMdivideRightTri,ffd_exceptions_lower) {
   using stan::math::mdivide_right_tri;
 
   matrix_ffd fv1(3,3), fv2(4,4);
+  fv1.setZero();
+  fv2.setZero();
   row_vector_ffd rvf1(3), rvf2(4);
+  rvf1.setZero();
+  rvf2.setZero();
   row_vector_ffd vf1(3), vf2(4);
+  vf1.setZero();
+  vf2.setZero();
   matrix_d fd1(3,3), fd2(4,4);
+  fd1.setZero();
+  fd2.setZero();
   row_vector_d rvd1(3), rvd2(4);
+  rvd1.setZero();
+  rvd2.setZero();
   row_vector_d vd1(3), vd2(4);
+  vd1.setZero();
+  vd2.setZero();
 
   EXPECT_THROW(mdivide_right_tri<Eigen::Lower>(fv1, fd2), std::invalid_argument);
   EXPECT_THROW(mdivide_right_tri<Eigen::Lower>(fd1, fv2), std::invalid_argument);

--- a/test/unit/math/fwd/mat/fun/trace_inv_quad_form_ldlt_test.cpp
+++ b/test/unit/math/fwd/mat/fun/trace_inv_quad_form_ldlt_test.cpp
@@ -164,12 +164,20 @@ TEST(AgradFwdMatrixTraceInvQuadFormLDLT,fd_exceptions) {
   fv1_ << 1,2,3,4,5,6,7,8,9;
   fv2_ << 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16;
   row_vector_fd rvf1(3), rvf2(4);
+  rvf1.setZero();
+  rvf2.setZero();
   vector_fd vf1(3), vf2(4);
+  vf1.setZero();
+  vf2.setZero();
   matrix_d fd1_(3,3), fd2_(4,4);
   fd1_ << 1,2,3,4,5,6,7,8,9;
   fd2_ << 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16;
   row_vector_d rvd1(3), rvd2(4);
+  rvd1.setZero();
+  rvd2.setZero();
   vector_d vd1(3), vd2(4);
+  vd1.setZero();
+  vd2.setZero();
 
   stan::math::LDLT_factor<fvar<double>,-1,-1> fv1;
   stan::math::LDLT_factor<fvar<double>,-1,-1> fv2;
@@ -360,12 +368,20 @@ TEST(AgradFwdMatrixTraceInvQuadFormLDLT,ffd_exceptions) {
   fv1_ << 1,2,3,4,5,6,7,8,9;
   fv2_ << 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16;
   row_vector_ffd rvf1(3), rvf2(4);
+  rvf1.setZero();
+  rvf2.setZero();
   vector_ffd vf1(3), vf2(4);
+  vf1.setZero();
+  vf2.setZero();
   matrix_d fd1_(3,3), fd2_(4,4);
   fd1_ << 1,2,3,4,5,6,7,8,9;
   fd2_ << 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16;
   row_vector_d rvd1(3), rvd2(4);
+  rvd1.setZero();
+  rvd2.setZero();
   vector_d vd1(3), vd2(4);
+  vd1.setZero();
+  vd2.setZero();
 
   stan::math::LDLT_factor<fvar<fvar<double> >,-1,-1> fv1;
   stan::math::LDLT_factor<fvar<fvar<double> >,-1,-1> fv2;

--- a/test/unit/math/mix/mat/fun/columns_dot_product_test.cpp
+++ b/test/unit/math/mix/mat/fun/columns_dot_product_test.cpp
@@ -82,9 +82,13 @@ TEST(AgradMixMatrixColumnsDotProduct, vector_vector_fv_exception) {
   using stan::math::var;
 
   vector_d d1(3);
+  d1.setZero();
   vector_fv v1(3);
+  v1.setZero();
   vector_d d2(2);
+  d2.setZero();
   vector_fv v2(4);
+  v2.setZero();
 
   EXPECT_THROW(columns_dot_product(v1, d2), std::invalid_argument);
   EXPECT_THROW(columns_dot_product(d1, v2), std::invalid_argument);
@@ -99,9 +103,13 @@ TEST(AgradMixMatrixColumnsDotProduct, rowvector_vector_fv_exceptions) {
   using stan::math::var;
 
   row_vector_d d1(3);
+  d1.setZero();
   row_vector_fv v1(3);
+  v1.setZero();
   vector_d d2(3);
+  d2.setZero();
   vector_fv v2(3);
+  v2.setZero();
 
   EXPECT_THROW(columns_dot_product(v1,d2), std::invalid_argument);
   EXPECT_THROW(columns_dot_product(d1,v2), std::invalid_argument);
@@ -116,9 +124,13 @@ TEST(AgradMixMatrixColumnsDotProduct, vector_rowvector_fv_exceptions) {
   using stan::math::var;
 
   vector_d d1(3);
+  d1.setZero();
   vector_fv v1(3);
+  v1.setZero();
   row_vector_d d2(3);
+  d2.setZero();
   row_vector_fv v2(3);
+  v2.setZero();
 
   EXPECT_THROW(columns_dot_product(v1,d2), std::invalid_argument);
   EXPECT_THROW(columns_dot_product(d1,v2), std::invalid_argument);
@@ -509,9 +521,13 @@ TEST(AgradMixMatrixColumnsDotProduct, rowvector_vector_ffv_exceptions) {
   using stan::math::var;
 
   row_vector_d d1(3);
+  d1.setZero();
   row_vector_ffv v1(3);
+  v1.setZero();
   vector_d d2(3);
+  d2.setZero();
   vector_ffv v2(3);
+  v2.setZero();
 
   EXPECT_THROW(columns_dot_product(v1,d2), std::invalid_argument);
   EXPECT_THROW(columns_dot_product(d1,v2), std::invalid_argument);
@@ -526,9 +542,13 @@ TEST(AgradMixMatrixColumnsDotProduct, vector_rowvector_ffv_exceptions) {
   using stan::math::var;
 
   vector_d d1(3);
+  d1.setZero();
   vector_ffv v1(3);
+  v1.setZero();
   row_vector_d d2(3);
+  d2.setZero();
   row_vector_ffv v2(3);
+  v2.setZero();
 
   EXPECT_THROW(columns_dot_product(v1,d2), std::invalid_argument);
   EXPECT_THROW(columns_dot_product(d1,v2), std::invalid_argument);

--- a/test/unit/math/mix/mat/fun/mdivide_left_ldlt_test.cpp
+++ b/test/unit/math/mix/mat/fun/mdivide_left_ldlt_test.cpp
@@ -494,12 +494,20 @@ TEST(AgradMixMatrixMdivideLeftLDLT,fv_exceptions) {
   fv1_ << 1,2,3,4,5,6,7,8,9;
   fv2_ << 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16;
   row_vector_fv rvf1(3), rvf2(4);
+  rvf1.setZero();
+  rvf2.setZero();
   vector_fv vf1(3), vf2(4);
+  vf1.setZero();
+  vf2.setZero();
   matrix_d fd1_(3,3), fd2_(4,4);
   fd1_ << 1,2,3,4,5,6,7,8,9;
   fd2_ << 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16;
   row_vector_d rvd1(3), rvd2(4);
+  rvd1.setZero();
+  rvd2.setZero();
   vector_d vd1(3), vd2(4);
+  vd1.setZero();
+  vd2.setZero();
 
   stan::math::LDLT_factor<fvar<var>,-1,-1> fv1;
   stan::math::LDLT_factor<fvar<var>,-1,-1> fv2;
@@ -1483,12 +1491,20 @@ TEST(AgradMixMatrixMdivideLeftLDLT,ffv_exceptions) {
   fv1_ << 1,2,3,4,5,6,7,8,9;
   fv2_ << 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16;
   row_vector_ffv rvf1(3), rvf2(4);
+  rvf1.setZero();
+  rvf2.setZero();
   vector_ffv vf1(3), vf2(4);
+  vf1.setZero();
+  vf2.setZero();
   matrix_d fd1_(3,3), fd2_(4,4);
   fd1_ << 1,2,3,4,5,6,7,8,9;
   fd2_ << 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16;
   row_vector_d rvd1(3), rvd2(4);
+  rvd1.setZero();
+  rvd2.setZero();
   vector_d vd1(3), vd2(4);
+  vd1.setZero();
+  vd2.setZero();
 
   stan::math::LDLT_factor<fvar<fvar<var> >,-1,-1> fv1;
   stan::math::LDLT_factor<fvar<fvar<var> >,-1,-1> fv2;

--- a/test/unit/math/mix/mat/fun/mdivide_left_spd_test.cpp
+++ b/test/unit/math/mix/mat/fun/mdivide_left_spd_test.cpp
@@ -496,11 +496,23 @@ TEST(AgradMixMatrixMdivideLeftSPD,fv_exceptions) {
   using stan::math::mdivide_left_spd;
 
   matrix_fv fv1(3,3), fv2(4,4);
+  fv1.setZero();
+  fv2.setZero();
   row_vector_fv rvf1(3), rvf2(4);
+  rvf1.setZero();
+  rvf2.setZero();
   vector_fv vf1(3), vf2(4);
+  vf1.setZero();
+  vf2.setZero();
   matrix_d fd1(3,3), fd2(4,4);
+  fd1.setZero();
+  fd2.setZero();
   row_vector_d rvd1(3), rvd2(4);
+  rvd1.setZero();
+  rvd2.setZero();
   vector_d vd1(3), vd2(4);
+  vd1.setZero();
+  vd2.setZero();
 
   EXPECT_THROW(mdivide_left_spd(fv1, fd2), std::domain_error);
   EXPECT_THROW(mdivide_left_spd(fd1, fv2), std::domain_error);
@@ -1463,11 +1475,23 @@ TEST(AgradMixMatrixMdivideLeftSPD,ffv_exceptions) {
   using stan::math::mdivide_left_spd;
 
   matrix_ffv fv1(3,3), fv2(4,4);
+  fv1.setZero();
+  fv2.setZero();
   row_vector_ffv rvf1(3), rvf2(4);
+  rvf1.setZero();
+  rvf2.setZero();
   vector_ffv vf1(3), vf2(4);
+  vf1.setZero();
+  vf2.setZero();
   matrix_d fd1(3,3), fd2(4,4);
+  fd1.setZero();
+  fd2.setZero();
   row_vector_d rvd1(3), rvd2(4);
+  rvd1.setZero();
+  rvd2.setZero();
   vector_d vd1(3), vd2(4);
+  vd1.setZero();
+  vd2.setZero();
 
   EXPECT_THROW(mdivide_left_spd(fv1, fd2), std::domain_error);
   EXPECT_THROW(mdivide_left_spd(fd1, fv2), std::domain_error);

--- a/test/unit/math/mix/mat/fun/mdivide_left_test.cpp
+++ b/test/unit/math/mix/mat/fun/mdivide_left_test.cpp
@@ -211,11 +211,23 @@ TEST(AgradMixMatrixMdivideLeft,fv_exceptions) {
   using stan::math::mdivide_left;
 
   matrix_fv fv1(3,3), fv2(4,4);
+  fv1.setZero();
+  fv2.setZero();
   row_vector_fv rvf1(3), rvf2(4);
+  rvf1.setZero();
+  rvf2.setZero();
   vector_fv vf1(3), vf2(4);
+  vf1.setZero();
+  vf2.setZero();
   matrix_d fd1(3,3), fd2(4,4);
+  fd1.setZero();
+  fd2.setZero();
   row_vector_d rvd1(3), rvd2(4);
+  rvd1.setZero();
+  rvd2.setZero();
   vector_d vd1(3), vd2(4);
+  vd1.setZero();
+  vd2.setZero();
 
   EXPECT_THROW(mdivide_left(fv1, fd2), std::invalid_argument);
   EXPECT_THROW(mdivide_left(fd1, fv2), std::invalid_argument);
@@ -570,11 +582,23 @@ TEST(AgradMixMatrixMdivideLeft,ffv_exceptions) {
   using stan::math::mdivide_left;
 
   matrix_ffv fv1(3,3), fv2(4,4);
+  fv1.setZero();
+  fv2.setZero();
   row_vector_ffv rvf1(3), rvf2(4);
+  rvf1.setZero();
+  rvf2.setZero();
   vector_ffv vf1(3), vf2(4);
+  vf1.setZero();
+  vf2.setZero();
   matrix_d fd1(3,3), fd2(4,4);
+  fd1.setZero();
+  fd2.setZero();
   row_vector_d rvd1(3), rvd2(4);
+  rvd1.setZero();
+  rvd2.setZero();
   vector_d vd1(3), vd2(4);
+  vd1.setZero();
+  vd2.setZero();
 
   EXPECT_THROW(mdivide_left(fv1, fd2), std::invalid_argument);
   EXPECT_THROW(mdivide_left(fd1, fv2), std::invalid_argument);

--- a/test/unit/math/mix/mat/fun/mdivide_left_tri_low_test.cpp
+++ b/test/unit/math/mix/mat/fun/mdivide_left_tri_low_test.cpp
@@ -532,9 +532,17 @@ TEST(AgradMixMatrixMdivideLeftTriLow,fv_vector_matrix_exceptions) {
   using stan::math::mdivide_left_tri_low;
 
   vector_fv fv1(4), fv2(3);
+  fv1.setZero();
+  fv2.setZero();
   vector_d v1(4), v2(3);
+  v1.setZero();
+  v2.setZero();
   matrix_fv fvm1(4,4), fvm2(3,3);
+  fvm1.setZero();
+  fvm2.setZero();
   matrix_d vm1(4,4), vm2(3,3);
+  vm1.setZero();
+  vm2.setZero();
 
   EXPECT_THROW(mdivide_left_tri_low(fvm2, fv1), std::invalid_argument);
   EXPECT_THROW(mdivide_left_tri_low(vm2,fv1), std::invalid_argument);
@@ -549,7 +557,11 @@ TEST(AgradMixMatrixMdivideLeftTriLow,fv_matrix_matrix_exceptions) {
   using stan::math::mdivide_left_tri_low;
 
   matrix_fv fvm1(4,4), fvm2(3,3);
+  fvm1.setZero();
+  fvm2.setZero();
   matrix_d vm1(4,4), vm2(3,3);
+  vm1.setZero();
+  vm2.setZero();
 
   EXPECT_THROW(mdivide_left_tri_low(fvm1,fvm2), std::invalid_argument);
   EXPECT_THROW(mdivide_left_tri_low(fvm1,vm2), std::invalid_argument);
@@ -1542,9 +1554,17 @@ TEST(AgradMixMatrixMdivideLeftTriLow,ffv_vector_matrix_exceptions) {
   using stan::math::mdivide_left_tri_low;
 
   vector_ffv fv1(4), fv2(3);
+  fv1.setZero();
+  fv2.setZero();
   vector_d v1(4), v2(3);
+  v1.setZero();
+  v2.setZero();
   matrix_ffv fvm1(4,4), fvm2(3,3);
+  fvm1.setZero();
+  fvm2.setZero();
   matrix_d vm1(4,4), vm2(3,3);
+  vm1.setZero();
+  vm2.setZero();
 
   EXPECT_THROW(mdivide_left_tri_low(fvm2, fv1), std::invalid_argument);
   EXPECT_THROW(mdivide_left_tri_low(vm2,fv1), std::invalid_argument);
@@ -1559,7 +1579,11 @@ TEST(AgradMixMatrixMdivideLeftTriLow,ffv_matrix_matrix_exceptions) {
   using stan::math::mdivide_left_tri_low;
 
   matrix_ffv fvm1(4,4), fvm2(3,3);
+  fvm1.setZero();
+  fvm2.setZero();
   matrix_d vm1(4,4), vm2(3,3);
+  vm1.setZero();
+  vm2.setZero();
 
   EXPECT_THROW(mdivide_left_tri_low(fvm1,fvm2), std::invalid_argument);
   EXPECT_THROW(mdivide_left_tri_low(fvm1,vm2), std::invalid_argument);

--- a/test/unit/math/mix/mat/fun/mdivide_left_tri_test.cpp
+++ b/test/unit/math/mix/mat/fun/mdivide_left_tri_test.cpp
@@ -496,11 +496,23 @@ TEST(AgradMixMatrixMdivideLeftTri,fv_exceptions_lower) {
   using stan::math::mdivide_left_tri;
 
   matrix_fv fv1(3,3), fv2(4,4);
+  fv1.setZero();
+  fv2.setZero();
   row_vector_fv rvf1(3), rvf2(4);
+  rvf1.setZero();
+  rvf2.setZero();
   vector_fv vf1(3), vf2(4);
+  vf1.setZero();
+  vf2.setZero();
   matrix_d fd1(3,3), fd2(4,4);
+  fd1.setZero();
+  fd2.setZero();
   row_vector_d rvd1(3), rvd2(4);
+  rvd1.setZero();
+  rvd2.setZero();
   vector_d vd1(3), vd2(4);
+  vd1.setZero();
+  vd2.setZero();
 
   EXPECT_THROW(mdivide_left_tri<Eigen::Lower>(fv1, fd2), std::invalid_argument);
   EXPECT_THROW(mdivide_left_tri<Eigen::Lower>(fd1, fv2), std::invalid_argument);
@@ -1463,11 +1475,23 @@ TEST(AgradMixMatrixMdivideLeftTri,ffv_exceptions_lower) {
   using stan::math::mdivide_left_tri;
 
   matrix_ffv fv1(3,3), fv2(4,4);
+  fv1.setZero();
+  fv2.setZero();
   row_vector_ffv rvf1(3), rvf2(4);
+  rvf1.setZero();
+  rvf2.setZero();
   vector_ffv vf1(3), vf2(4);
+  vf1.setZero();
+  vf2.setZero();
   matrix_d fd1(3,3), fd2(4,4);
+  fd1.setZero();
+  fd2.setZero();
   row_vector_d rvd1(3), rvd2(4);
+  rvd1.setZero();
+  rvd2.setZero();
   vector_d vd1(3), vd2(4);
+  vd1.setZero();
+  vd2.setZero();
 
   EXPECT_THROW(mdivide_left_tri<Eigen::Lower>(fv1, fd2), std::invalid_argument);
   EXPECT_THROW(mdivide_left_tri<Eigen::Lower>(fd1, fv2), std::invalid_argument);
@@ -1969,11 +1993,23 @@ TEST(AgradMixMatrixMdivideLeftTri,fv_exceptions_upper) {
   using stan::math::mdivide_left_tri;
 
   matrix_fv fv1(3,3), fv2(4,4);
+  fv1.setZero();
+  fv2.setZero();
   row_vector_fv rvf1(3), rvf2(4);
+  rvf1.setZero();
+  rvf2.setZero();
   vector_fv vf1(3), vf2(4);
+  vf1.setZero();
+  vf2.setZero();
   matrix_d fd1(3,3), fd2(4,4);
+  fd1.setZero();
+  fd2.setZero();
   row_vector_d rvd1(3), rvd2(4);
+  rvd1.setZero();
+  rvd2.setZero();
   vector_d vd1(3), vd2(4);
+  vd1.setZero();
+  vd2.setZero();
 
   EXPECT_THROW(mdivide_left_tri<Eigen::Upper>(fv1, fd2), std::invalid_argument);
   EXPECT_THROW(mdivide_left_tri<Eigen::Upper>(fd1, fv2), std::invalid_argument);
@@ -2936,11 +2972,23 @@ TEST(AgradMixMatrixMdivideLeftTri,ffv_exceptions_upper) {
   using stan::math::mdivide_left_tri;
 
   matrix_ffv fv1(3,3), fv2(4,4);
+  fv1.setZero();
+  fv2.setZero();
   row_vector_ffv rvf1(3), rvf2(4);
+  rvf1.setZero();
+  rvf2.setZero();
   vector_ffv vf1(3), vf2(4);
+  vf1.setZero();
+  vf2.setZero();
   matrix_d fd1(3,3), fd2(4,4);
+  fd1.setZero();
+  fd2.setZero();
   row_vector_d rvd1(3), rvd2(4);
+  rvd1.setZero();
+  rvd2.setZero();
   vector_d vd1(3), vd2(4);
+  vd1.setZero();
+  vd2.setZero();
 
   EXPECT_THROW(mdivide_left_tri<Eigen::Upper>(fv1, fd2), std::invalid_argument);
   EXPECT_THROW(mdivide_left_tri<Eigen::Upper>(fd1, fv2), std::invalid_argument);

--- a/test/unit/math/mix/mat/fun/mdivide_right_ldlt_test.cpp
+++ b/test/unit/math/mix/mat/fun/mdivide_right_ldlt_test.cpp
@@ -503,12 +503,20 @@ TEST(AgradMixMatrixMdivideRightLDLT,fv_exceptions) {
   fv1_ << 1,2,3,4,5,6,7,8,9;
   fv2_ << 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16;
   vector_fv rvf1(3), rvf2(4);
+  rvf1.setZero();
+  rvf2.setZero();
   row_vector_fv vf1(3), vf2(4);
+  vf1.setZero();
+  vf2.setZero();
   matrix_d fd1_(3,3), fd2_(4,4);
   fd1_ << 1,2,3,4,5,6,7,8,9;
   fd2_ << 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16;
   vector_d rvd1(3), rvd2(4);
+  rvd1.setZero();
+  rvd2.setZero();
   row_vector_d vd1(3), vd2(4);
+  vd1.setZero();
+  vd2.setZero();
 
   stan::math::LDLT_factor<fvar<var>,-1,-1> fv1;
   stan::math::LDLT_factor<fvar<var>,-1,-1> fv2;
@@ -1491,12 +1499,20 @@ TEST(AgradMixMatrixMdivideRightLDLT,ffv_exceptions) {
   fv1_ << 1,2,3,4,5,6,7,8,9;
   fv2_ << 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16;
   vector_ffv rvf1(3), rvf2(4);
+  rvf1.setZero();
+  rvf2.setZero();
   row_vector_ffv vf1(3), vf2(4);
+  vf1.setZero();
+  vf2.setZero();
   matrix_d fd1_(3,3), fd2_(4,4);
   fd1_ << 1,2,3,4,5,6,7,8,9;
   fd2_ << 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16;
   vector_d rvd1(3), rvd2(4);
+  rvd1.setZero();
+  rvd2.setZero();
   row_vector_d vd1(3), vd2(4);
+  vd1.setZero();
+  vd2.setZero();
 
   stan::math::LDLT_factor<fvar<fvar<var> >,-1,-1> fv1;
   stan::math::LDLT_factor<fvar<fvar<var> >,-1,-1> fv2;

--- a/test/unit/math/mix/mat/fun/mdivide_right_spd_test.cpp
+++ b/test/unit/math/mix/mat/fun/mdivide_right_spd_test.cpp
@@ -493,11 +493,24 @@ TEST(AgradMixMatrixMdivideRightSPD,fv_exceptions) {
   using stan::math::mdivide_right_spd;
 
   matrix_fv fv1(3,3), fv2(4,4);
+  fv1.setZero();
+  fv2.setZero();
   row_vector_fv rvf1(3), rvf2(4);
+  rvf1.setZero();
+  rvf2.setZero();
   row_vector_fv vf1(3), vf2(4);
+  vf1.setZero();
+  vf2.setZero();
   matrix_d fd1(3,3), fd2(4,4);
+  fd1.setZero();
+  fd2.setZero();
   row_vector_d rvd1(3), rvd2(4);
+  rvd1.setZero();
+  rvd2.setZero();
   row_vector_d vd1(3), vd2(4);
+  vd1.setZero();
+  vd2.setZero();
+
 
   EXPECT_THROW(mdivide_right_spd(fd2, fv1), std::invalid_argument);
   EXPECT_THROW(mdivide_right_spd(fv2, fd1), std::invalid_argument);
@@ -1458,13 +1471,23 @@ TEST(AgradMixMatrixMdivideRightSPD,ffv_exceptions) {
   using stan::math::mdivide_right_spd;
 
   matrix_ffv fv1(3,3), fv2(4,4);
-  fv1.setZero(); fv2.setZero();
+  fv1.setZero();
+  fv2.setZero();
   row_vector_ffv rvf1(3), rvf2(4);
+  rvf1.setZero();
+  rvf2.setZero();
   row_vector_ffv vf1(3), vf2(4);
+  vf1.setZero();
+  vf2.setZero();
   matrix_d fd1(3,3), fd2(4,4);
-  fd1.setZero(); fd2.setZero();
+  fd1.setZero();
+  fd2.setZero();
   row_vector_d rvd1(3), rvd2(4);
+  rvd1.setZero();
+  rvd2.setZero();
   row_vector_d vd1(3), vd2(4);
+  vd1.setZero();
+  vd2.setZero();
 
   EXPECT_THROW(mdivide_right_spd(fd2, fv1), std::invalid_argument);
   EXPECT_THROW(mdivide_right_spd(fv2, fd1), std::invalid_argument);

--- a/test/unit/math/mix/mat/fun/mdivide_right_test.cpp
+++ b/test/unit/math/mix/mat/fun/mdivide_right_test.cpp
@@ -191,11 +191,23 @@ TEST(AgradMixMatrixMdivideRight,fv_exceptions) {
   using stan::math::mdivide_right;
 
   matrix_fv fv1(3,3), fv2(4,4);
+  fv1.setZero();
+  fv2.setZero();
   row_vector_fv rvf1(3), rvf2(4);
+  rvf1.setZero();
+  rvf2.setZero();
   vector_fv vf1(3), vf2(4);
+  vf1.setZero();
+  vf2.setZero();
   matrix_d fd1(3,3), fd2(4,4);
+  fd1.setZero();
+  fd2.setZero();
   row_vector_d rvd1(3), rvd2(4);
+  rvd1.setZero();
+  rvd2.setZero();
   vector_d vd1(3), vd2(4);
+  vd1.setZero();
+  vd2.setZero();
 
   EXPECT_THROW(mdivide_right(fv1, fd2), std::invalid_argument);
   EXPECT_THROW(mdivide_right(fd1, fv2), std::invalid_argument);
@@ -500,11 +512,23 @@ TEST(AgradMixMatrixMdivideRight,ffv_exceptions) {
   using stan::math::mdivide_right;
 
   matrix_ffv fv1(3,3), fv2(4,4);
+  fv1.setZero();
+  fv2.setZero();
   row_vector_ffv rvf1(3), rvf2(4);
+  rvf1.setZero();
+  rvf2.setZero();
   vector_ffv vf1(3), vf2(4);
+  vf1.setZero();
+  vf2.setZero();
   matrix_d fd1(3,3), fd2(4,4);
+  fd1.setZero();
+  fd2.setZero();
   row_vector_d rvd1(3), rvd2(4);
+  rvd1.setZero();
+  rvd2.setZero();
   vector_d vd1(3), vd2(4);
+  vd1.setZero();
+  vd2.setZero();
 
   EXPECT_THROW(mdivide_right(fv1, fd2), std::invalid_argument);
   EXPECT_THROW(mdivide_right(fd1, fv2), std::invalid_argument);

--- a/test/unit/math/mix/mat/fun/mdivide_right_tri_low_test.cpp
+++ b/test/unit/math/mix/mat/fun/mdivide_right_tri_low_test.cpp
@@ -526,9 +526,17 @@ TEST(AgradMixMatrixMdivideRightTriLow,fv__rowvector_matrix_exceptions) {
   using stan::math::mdivide_right_tri_low;
 
   row_vector_fv fv1(4), fv2(3);
+  fv1.setZero();
+  fv2.setZero();
   row_vector_d v1(4), v2(3);
+  v1.setZero();
+  v2.setZero();
   matrix_fv fvm1(4,4), fvm2(3,3);
+  fvm1.setZero();
+  fvm2.setZero();
   matrix_d vm1(4,4), vm2(3,3);
+  vm1.setZero();
+  vm2.setZero();
 
   EXPECT_THROW(mdivide_right_tri_low(fv1,fvm2), std::invalid_argument);
   EXPECT_THROW(mdivide_right_tri_low(fv1,vm2), std::invalid_argument);
@@ -543,7 +551,11 @@ TEST(AgradMixMatrixMdivideRightTriLow,fv__matrix_matrix_exceptions) {
   using stan::math::mdivide_right_tri_low;
 
   matrix_fv fvm1(4,4), fvm2(3,3);
+  fvm1.setZero();
+  fvm2.setZero();
   matrix_d vm1(4,4), vm2(3,3);
+  vm1.setZero();
+  vm2.setZero();
 
   EXPECT_THROW(mdivide_right_tri_low(fvm1,fvm2), std::invalid_argument);
   EXPECT_THROW(mdivide_right_tri_low(fvm1,vm2), std::invalid_argument);
@@ -1535,9 +1547,17 @@ TEST(AgradMixMatrixMdivideRightTriLow,ffv__rowvector_matrix_exceptions) {
   using stan::math::mdivide_right_tri_low;
 
   row_vector_ffv fv1(4), fv2(3);
+  fv1.setZero();
+  fv2.setZero();
   row_vector_d v1(4), v2(3);
+  v1.setZero();
+  v2.setZero();
   matrix_ffv fvm1(4,4), fvm2(3,3);
+  fvm1.setZero();
+  fvm2.setZero();
   matrix_d vm1(4,4), vm2(3,3);
+  vm1.setZero();
+  vm2.setZero();
 
   EXPECT_THROW(mdivide_right_tri_low(fv1,fvm2), std::invalid_argument);
   EXPECT_THROW(mdivide_right_tri_low(fv1,vm2), std::invalid_argument);
@@ -1552,7 +1572,11 @@ TEST(AgradMixMatrixMdivideRightTriLow,ffv__matrix_matrix_exceptions) {
   using stan::math::mdivide_right_tri_low;
 
   matrix_ffv fvm1(4,4), fvm2(3,3);
+  fvm1.setZero();
+  fvm2.setZero();
   matrix_d vm1(4,4), vm2(3,3);
+  vm1.setZero();
+  vm2.setZero();
 
   EXPECT_THROW(mdivide_right_tri_low(fvm1,fvm2), std::invalid_argument);
   EXPECT_THROW(mdivide_right_tri_low(fvm1,vm2), std::invalid_argument);

--- a/test/unit/math/mix/mat/fun/mdivide_right_tri_test.cpp
+++ b/test/unit/math/mix/mat/fun/mdivide_right_tri_test.cpp
@@ -488,11 +488,23 @@ TEST(AgradMixMatrixMdivideRightTri,fv_exceptions_lower) {
   using stan::math::mdivide_right_tri;
 
   matrix_fv fv1(3,3), fv2(4,4);
+  fv1.setZero();
+  fv2.setZero();
   row_vector_fv rvf1(3), rvf2(4);
+  rvf1.setZero();
+  rvf2.setZero();
   row_vector_fv vf1(3), vf2(4);
+  vf1.setZero();
+  vf2.setZero();
   matrix_d fd1(3,3), fd2(4,4);
+  fd1.setZero();
+  fd2.setZero();
   row_vector_d rvd1(3), rvd2(4);
+  rvd1.setZero();
+  rvd2.setZero();
   row_vector_d vd1(3), vd2(4);
+  vd1.setZero();
+  vd2.setZero();
 
   EXPECT_THROW(mdivide_right_tri<Eigen::Lower>(fv1, fd2), std::invalid_argument);
   EXPECT_THROW(mdivide_right_tri<Eigen::Lower>(fd1, fv2), std::invalid_argument);
@@ -1446,11 +1458,23 @@ TEST(AgradMixMatrixMdivideRightTri,ffv_exceptions_lower) {
   using stan::math::mdivide_right_tri;
 
   matrix_ffv fv1(3,3), fv2(4,4);
+  fv1.setZero();
+  fv2.setZero();
   row_vector_ffv rvf1(3), rvf2(4);
+  rvf1.setZero();
+  rvf2.setZero();
   row_vector_ffv vf1(3), vf2(4);
+  vf1.setZero();
+  vf2.setZero();
   matrix_d fd1(3,3), fd2(4,4);
+  fd1.setZero();
+  fd2.setZero();
   row_vector_d rvd1(3), rvd2(4);
+  rvd1.setZero();
+  rvd2.setZero();
   row_vector_d vd1(3), vd2(4);
+  vd1.setZero();
+  vd2.setZero();
 
   EXPECT_THROW(mdivide_right_tri<Eigen::Lower>(fv1, fd2), std::invalid_argument);
   EXPECT_THROW(mdivide_right_tri<Eigen::Lower>(fd1, fv2), std::invalid_argument);
@@ -1947,11 +1971,23 @@ TEST(AgradMixMatrixMdivideRightTri,fv_exceptions_upper) {
   using stan::math::mdivide_right_tri;
 
   matrix_fv fv1(3,3), fv2(4,4);
+  fv1.setZero();
+  fv2.setZero();
   row_vector_fv rvf1(3), rvf2(4);
+  rvf1.setZero();
+  rvf2.setZero();
   row_vector_fv vf1(3), vf2(4);
+  vf1.setZero();
+  vf2.setZero();
   matrix_d fd1(3,3), fd2(4,4);
+  fd1.setZero();
+  fd2.setZero();
   row_vector_d rvd1(3), rvd2(4);
+  rvd1.setZero();
+  rvd2.setZero();
   row_vector_d vd1(3), vd2(4);
+  vd1.setZero();
+  vd2.setZero();
 
   EXPECT_THROW(mdivide_right_tri<Eigen::Upper>(fv1, fd2), std::invalid_argument);
   EXPECT_THROW(mdivide_right_tri<Eigen::Upper>(fd1, fv2), std::invalid_argument);
@@ -2909,11 +2945,23 @@ TEST(AgradMixMatrixMdivideRightTri,ffv_exceptions_upper) {
   using stan::math::mdivide_right_tri;
 
   matrix_ffv fv1(3,3), fv2(4,4);
+  fv1.setZero();
+  fv2.setZero();
   row_vector_ffv rvf1(3), rvf2(4);
+  rvf1.setZero();
+  rvf2.setZero();
   row_vector_ffv vf1(3), vf2(4);
+  vf1.setZero();
+  vf2.setZero();
   matrix_d fd1(3,3), fd2(4,4);
+  fd1.setZero();
+  fd2.setZero();
   row_vector_d rvd1(3), rvd2(4);
+  rvd1.setZero();
+  rvd2.setZero();
   row_vector_d vd1(3), vd2(4);
+  vd1.setZero();
+  vd2.setZero();
 
   EXPECT_THROW(mdivide_right_tri<Eigen::Upper>(fv1, fd2), std::invalid_argument);
   EXPECT_THROW(mdivide_right_tri<Eigen::Upper>(fd1, fv2), std::invalid_argument);

--- a/test/unit/math/mix/mat/fun/trace_inv_quad_form_ldlt_test.cpp
+++ b/test/unit/math/mix/mat/fun/trace_inv_quad_form_ldlt_test.cpp
@@ -468,12 +468,20 @@ TEST(AgradMixMatrixTraceInvQuadFormLDLT,fv_exceptions) {
   fv1_ << 1,2,3,4,5,6,7,8,9;
   fv2_ << 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16;
   row_vector_fv rvf1(3), rvf2(4);
+  rvf1.setZero();
+  rvf2.setZero();
   vector_fv vf1(3), vf2(4);
+  vf1.setZero();
+  vf2.setZero();
   matrix_d fd1_(3,3), fd2_(4,4);
   fd1_ << 1,2,3,4,5,6,7,8,9;
   fd2_ << 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16;
   row_vector_d rvd1(3), rvd2(4);
+  rvd1.setZero();
+  rvd2.setZero();
   vector_d vd1(3), vd2(4);
+  vd1.setZero();
+  vd2.setZero();
 
   stan::math::LDLT_factor<fvar<var>,-1,-1> fv1;
   stan::math::LDLT_factor<fvar<var>,-1,-1> fv2;
@@ -1427,12 +1435,20 @@ TEST(AgradMixMatrixTraceInvQuadFormLDLT,ffv_exceptions) {
   fv1_ << 1,2,3,4,5,6,7,8,9;
   fv2_ << 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16;
   row_vector_ffv rvf1(3), rvf2(4);
+  rvf1.setZero();
+  rvf2.setZero();
   vector_ffv vf1(3), vf2(4);
+  vf1.setZero();
+  vf2.setZero();
   matrix_d fd1_(3,3), fd2_(4,4);
   fd1_ << 1,2,3,4,5,6,7,8,9;
   fd2_ << 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16;
   row_vector_d rvd1(3), rvd2(4);
+  rvd1.setZero();
+  rvd2.setZero();
   vector_d vd1(3), vd2(4);
+  vd1.setZero();
+  vd2.setZero();
 
   stan::math::LDLT_factor<fvar<fvar<var> >,-1,-1> fv1;
   stan::math::LDLT_factor<fvar<fvar<var> >,-1,-1> fv2;


### PR DESCRIPTION
#### Summary:

Reduce warnings from the new clang++ distributed with XCode on Mac.

#### How to Verify:

Jenkins should show fewer warnings.

#### Side Effects:

None.

#### Documentation:

None.

#### Reviewer Suggestions: 

None.