### PR TITLE
Feature/issue 179 robust integrator (2)

### DIFF
--- a/stan/math/prim/arr/functor/coupled_ode_system.hpp
+++ b/stan/math/prim/arr/functor/coupled_ode_system.hpp
@@ -2,6 +2,7 @@
 #define STAN_MATH_PRIM_ARR_FUNCTOR_COUPLED_ODE_SYSTEM_HPP
 
 #include <stan/math/prim/mat/err/check_matching_sizes.hpp>
+#include <stan/math/prim/scal/err/check_less.hpp>
 #include <ostream>
 #include <vector>
 
@@ -47,6 +48,7 @@ namespace stan {
       const int N_;
       const int M_;
       const int size_;
+      size_t evals_;
       std::ostream* msgs_;
 
       /**
@@ -75,6 +77,7 @@ namespace stan {
           N_(y0.size()),
           M_(theta.size()),
           size_(N_),
+	  evals_(0),
           msgs_(msgs) {
       }
 
@@ -96,6 +99,9 @@ namespace stan {
       void operator()(const std::vector<double>& y,
                       std::vector<double>& dy_dt,
                       double t) {
+
+	stan::math::check_less("coupled_ode_system", "too much work: ODE system functor evaluations", ++evals_, 1E5);
+	
         dy_dt = f_(t, y, theta_dbl_, x_, x_int_, msgs_);
         stan::math::check_matching_sizes("coupled_ode_system",
                                                    "y", y,

--- a/stan/math/prim/arr/functor/coupled_ode_system.hpp
+++ b/stan/math/prim/arr/functor/coupled_ode_system.hpp
@@ -48,6 +48,7 @@ namespace stan {
       const int N_;
       const int M_;
       const int size_;
+      const size_t max_evals_;
       size_t evals_;
       std::ostream* msgs_;
 
@@ -61,6 +62,7 @@ namespace stan {
        * @param[in] theta parameters of the base ode.
        * @param[in] x  real data.
        * @param[in] x_int integer data.
+       * @param[in] max_evals Maximal number of functor calls
        * @param[in, out] msgs print stream.
        */
       coupled_ode_system(const F& f,
@@ -68,6 +70,7 @@ namespace stan {
                          const std::vector<double>& theta,
                          const std::vector<double>& x,
                          const std::vector<int>& x_int,
+			 const size_t max_evals,
                          std::ostream* msgs)
         : f_(f),
           y0_dbl_(y0),
@@ -77,6 +80,7 @@ namespace stan {
           N_(y0.size()),
           M_(theta.size()),
           size_(N_),
+	  max_evals_(max_evals),
 	  evals_(0),
           msgs_(msgs) {
       }
@@ -100,7 +104,7 @@ namespace stan {
                       std::vector<double>& dy_dt,
                       double t) {
 
-	stan::math::check_less("coupled_ode_system", "too much work: ODE system functor evaluations", ++evals_, 1E5);
+	stan::math::check_less("coupled_ode_system", "too much work: ODE system functor evaluations", ++evals_, max_evals_);
 	
         dy_dt = f_(t, y, theta_dbl_, x_, x_int_, msgs_);
         stan::math::check_matching_sizes("coupled_ode_system",

--- a/stan/math/prim/arr/functor/coupled_ode_system.hpp
+++ b/stan/math/prim/arr/functor/coupled_ode_system.hpp
@@ -105,7 +105,7 @@ namespace stan {
                       double t) {
 
 	stan::math::check_less("coupled_ode_system", "too much work: ODE system functor evaluations", ++evals_, max_evals_);
-	
+
         dy_dt = f_(t, y, theta_dbl_, x_, x_int_, msgs_);
         stan::math::check_matching_sizes("coupled_ode_system",
                                                    "y", y,

--- a/stan/math/prim/arr/functor/integrate_ode.hpp
+++ b/stan/math/prim/arr/functor/integrate_ode.hpp
@@ -83,10 +83,13 @@ namespace stan {
       const double absolute_tolerance = 1e-6;
       const double relative_tolerance = 1e-6;
       const double step_size = 0.1;
+      // maximal number of system functor evaluations set to 1E3 *
+      // number of time-points
+      const size_t max_evals = 1E3 * (ts.size()+1);
 
       // creates basic or coupled system by template specializations
       coupled_ode_system<F, T1, T2>
-        coupled_system(f, y0, theta, x, x_int, msgs);
+        coupled_system(f, y0, theta, x, x_int, max_evals, msgs);
 
       // first time in the vector must be time of initial state
       std::vector<double> ts_vec(ts.size() + 1);

--- a/stan/math/prim/arr/functor/integrate_ode.hpp
+++ b/stan/math/prim/arr/functor/integrate_ode.hpp
@@ -107,7 +107,7 @@ namespace stan {
                                                            double,
                                                            std::vector<double>,
                                                            double>() ),
-                      coupled_system,
+                      boost::ref(coupled_system),
                       initial_coupled_state,
                       boost::begin(ts_vec), boost::end(ts_vec),
                       step_size,

--- a/stan/math/rev/arr/functor/coupled_ode_system.hpp
+++ b/stan/math/rev/arr/functor/coupled_ode_system.hpp
@@ -74,6 +74,7 @@ namespace stan {
       const size_t N_;
       const size_t M_;
       const size_t size_;
+      const size_t max_evals_;
       size_t evals_;
       std::ostream* msgs_;
 
@@ -87,6 +88,7 @@ namespace stan {
        * @param[in] theta parameters of the base ode.
        * @param[in] x real data.
        * @param[in] x_int integer data.
+       * @param[in] max_evals Maximal number of functor calls
        * @param[in, out] msgs stream to which messages are printed.
        */
       coupled_ode_system(const F& f,
@@ -94,6 +96,7 @@ namespace stan {
                          const std::vector<stan::math::var>& theta,
                          const std::vector<double>& x,
                          const std::vector<int>& x_int,
+			 const size_t max_evals,
                          std::ostream* msgs)
         : f_(f),
           y0_dbl_(y0),
@@ -104,8 +107,9 @@ namespace stan {
           N_(y0.size()),
           M_(theta.size()),
           size_(N_ + N_ * M_),
+	  max_evals_(max_evals),
 	  evals_(0),
-                msgs_(msgs) {
+	  msgs_(msgs) {
         for (size_t m = 0; m < M_; m++)
           theta_dbl_[m] = stan::math::value_of(theta[m]);
       }
@@ -133,7 +137,7 @@ namespace stan {
         using std::vector;
         using stan::math::var;
 
-	stan::math::check_less("coupled_ode_system", "too much work: ODE system functor evaluations", ++evals_, 1E5);
+	stan::math::check_less("coupled_ode_system", "too much work: ODE system functor evaluations", ++evals_, max_evals_);
 	
         vector<double> y(z.begin(), z.begin() + N_);
         dz_dt = f_(t, y, theta_dbl_, x_, x_int_, msgs_);
@@ -284,6 +288,7 @@ namespace stan {
       const size_t N_;
       const size_t M_;
       const size_t size_;
+      const size_t max_evals_;
       size_t evals_;
 
       /**
@@ -297,6 +302,7 @@ namespace stan {
        * @param[in] theta system parameters.
        * @param[in] x real data.
        * @param[in] x_int integer data.
+       * @param[in] max_evals Maximal number of functor calls
        * @param[in, out] msgs output stream for messages.
        */
       coupled_ode_system(const F& f,
@@ -304,6 +310,7 @@ namespace stan {
                          const std::vector<double>& theta,
                          const std::vector<double>& x,
                          const std::vector<int>& x_int,
+			 const size_t max_evals,
                          std::ostream* msgs)
         : f_(f),
           y0_(y0),
@@ -315,6 +322,7 @@ namespace stan {
           N_(y0.size()),
 	  M_(theta.size()),
 	  size_(N_ + N_ * N_),
+	  max_evals_(max_evals),
 	  evals_(0)
       {
         for (size_t n = 0; n < N_; n++)
@@ -343,7 +351,7 @@ namespace stan {
         using std::vector;
         using stan::math::var;
 
-	stan::math::check_less("coupled_ode_system", "too much work: ODE system functor evaluations", ++evals_, 1E5);
+	stan::math::check_less("coupled_ode_system", "too much work: ODE system functor evaluations", ++evals_, max_evals_);
 	
         std::vector<double> y(z.begin(), z.begin() + N_);
         for (size_t n = 0; n < N_; n++)
@@ -506,6 +514,7 @@ namespace stan {
       const size_t N_;
       const size_t M_;
       const size_t size_;
+      const size_t max_evals_;
       size_t evals_;
       std::ostream* msgs_;
 
@@ -520,6 +529,7 @@ namespace stan {
        * @param[in] theta parameters of the base ode.
        * @param[in] x real data.
        * @param[in] x_int integer data.
+       * @param[in] max_evals Maximal number of functor calls
        * @param[in, out] msgs output stream to which to print messages.
        */
       coupled_ode_system(const F& f,
@@ -527,6 +537,7 @@ namespace stan {
                          const std::vector<stan::math::var>& theta,
                          const std::vector<double>& x,
                          const std::vector<int>& x_int,
+			 const size_t max_evals,
                          std::ostream* msgs)
         : f_(f),
           y0_(y0),
@@ -538,6 +549,7 @@ namespace stan {
           N_(y0.size()),
           M_(theta.size()),
           size_(N_ + N_ * (N_ + M_)),
+	  max_evals_(max_evals),
 	  evals_(0),
           msgs_(msgs) {
         for (size_t n = 0; n < N_; n++)
@@ -569,7 +581,7 @@ namespace stan {
         using std::vector;
         using stan::math::var;
 
-	stan::math::check_less("coupled_ode_system", "too much work: ODE system functor evaluations", ++evals_, 1E5);
+	stan::math::check_less("coupled_ode_system", "too much work: ODE system functor evaluations", ++evals_, max_evals_);
 	
         vector<double> y(z.begin(), z.begin() + N_);
         for (size_t n = 0; n < N_; n++)

--- a/stan/math/rev/arr/functor/coupled_ode_system.hpp
+++ b/stan/math/rev/arr/functor/coupled_ode_system.hpp
@@ -10,9 +10,11 @@
 #include <stan/math/rev/scal/fun/value_of.hpp>
 #include <stan/math/rev/core.hpp>
 #include <stan/math/prim/scal/err/check_equal.hpp>
+#include <stan/math/prim/scal/err/check_less.hpp>
 #include <stan/math/prim/arr/functor/coupled_ode_system.hpp>
 #include <ostream>
 #include <vector>
+#include <iostream>
 
 namespace stan {
 
@@ -73,6 +75,7 @@ namespace stan {
       const size_t N_;
       const size_t M_;
       const size_t size_;
+      size_t evals_;
       std::ostream* msgs_;
 
       /**
@@ -102,6 +105,7 @@ namespace stan {
           N_(y0.size()),
           M_(theta.size()),
           size_(N_ + N_ * M_),
+	  evals_(0),
                 msgs_(msgs) {
         for (size_t m = 0; m < M_; m++)
           theta_dbl_[m] = stan::math::value_of(theta[m]);
@@ -130,6 +134,8 @@ namespace stan {
         using std::vector;
         using stan::math::var;
 
+	stan::math::check_less("coupled_ode_system", "too much work: ODE system functor evaluations", ++evals_, 1E5);
+	
         vector<double> y(z.begin(), z.begin() + N_);
         dz_dt = f_(t, y, theta_dbl_, x_, x_int_, msgs_);
         stan::math::check_equal("coupled_ode_system",
@@ -279,6 +285,7 @@ namespace stan {
       const size_t N_;
       const size_t M_;
       const size_t size_;
+      size_t evals_;
 
       /**
        * Construct a coupled ODE system for an unknown initial state
@@ -307,8 +314,10 @@ namespace stan {
           x_int_(x_int),
           msgs_(msgs),
           N_(y0.size()),
-        M_(theta.size()),
-        size_(N_ + N_ * N_) {
+	  M_(theta.size()),
+	  size_(N_ + N_ * N_),
+	  evals_(0)
+      {
         for (size_t n = 0; n < N_; n++)
           y0_dbl_[n] = stan::math::value_of(y0_[n]);
       }
@@ -335,6 +344,8 @@ namespace stan {
         using std::vector;
         using stan::math::var;
 
+	stan::math::check_less("coupled_ode_system", "too much work: ODE system functor evaluations", ++evals_, 1E5);
+	
         std::vector<double> y(z.begin(), z.begin() + N_);
         for (size_t n = 0; n < N_; n++)
           y[n] += y0_dbl_[n];
@@ -496,6 +507,7 @@ namespace stan {
       const size_t N_;
       const size_t M_;
       const size_t size_;
+      size_t evals_;
       std::ostream* msgs_;
 
       /**
@@ -527,6 +539,7 @@ namespace stan {
           N_(y0.size()),
           M_(theta.size()),
           size_(N_ + N_ * (N_ + M_)),
+	  evals_(0),
           msgs_(msgs) {
         for (size_t n = 0; n < N_; n++)
           y0_dbl_[n] = stan::math::value_of(y0[n]);
@@ -557,6 +570,8 @@ namespace stan {
         using std::vector;
         using stan::math::var;
 
+	stan::math::check_less("coupled_ode_system", "too much work: ODE system functor evaluations", ++evals_, 1E5);
+	
         vector<double> y(z.begin(), z.begin() + N_);
         for (size_t n = 0; n < N_; n++)
           y[n] += y0_dbl_[n];

--- a/stan/math/rev/arr/functor/coupled_ode_system.hpp
+++ b/stan/math/rev/arr/functor/coupled_ode_system.hpp
@@ -14,7 +14,6 @@
 #include <stan/math/prim/arr/functor/coupled_ode_system.hpp>
 #include <ostream>
 #include <vector>
-#include <iostream>
 
 namespace stan {
 

--- a/test/unit/math/rev/arr/functor/coupled_ode_system_test.cpp
+++ b/test/unit/math/rev/arr/functor/coupled_ode_system_test.cpp
@@ -41,7 +41,7 @@ TEST_F(StanAgradRevOde, coupled_ode_system_dv) {
   coupled_y0.push_back(2.0);
 
   coupled_ode_system<harm_osc_ode_fun, double, stan::math::var> 
-    system(harm_osc, y0, theta, x, x_int, &msgs);
+    system(harm_osc, y0, theta, x, x_int, 1E5, &msgs);
 
   system(coupled_y0, dy_dt, t0);
 
@@ -67,7 +67,7 @@ TEST_F(StanAgradRevOde, decouple_states_dv) {
   theta[0] = 0.15;
   
   coupled_ode_system<mock_ode_functor, double, var> 
-    coupled_system(mock_ode, y0, theta, x, x_int, &msgs);
+    coupled_system(mock_ode, y0, theta, x, x_int, 1E5, &msgs);
 
   size_t k = 0;
   std::vector<std::vector<double> > ys_coupled(T);
@@ -106,7 +106,7 @@ TEST_F(StanAgradRevOde, initial_state_dv) {
     theta_v[m] = 10 * (m+1);
      
   coupled_ode_system<mock_ode_functor, double, var>
-    coupled_system_dv(base_ode, y0_d, theta_v, x, x_int, &msgs);
+    coupled_system_dv(base_ode, y0_d, theta_v, x, x_int, 1E5, &msgs);
 
   std::vector<double> state = coupled_system_dv.initial_state();
   for (size_t n = 0; n < N; n++) 
@@ -127,7 +127,7 @@ TEST_F(StanAgradRevOde, size_dv) {
   std::vector<var> theta_v(M, 0.0);
 
   coupled_ode_system<mock_ode_functor, double, var>
-    coupled_system_dv(base_ode, y0_d, theta_v, x, x_int, &msgs);
+    coupled_system_dv(base_ode, y0_d, theta_v, x, x_int, 1E5, &msgs);
 
   EXPECT_EQ(N + N*M, coupled_system_dv.size());
 }
@@ -144,7 +144,7 @@ TEST_F(StanAgradRevOde, memory_recovery_dv) {
   std::vector<var> theta_v(M, 0.0);
 
   coupled_ode_system<mock_ode_functor, double, var>
-    coupled_system_dv(base_ode, y0_d, theta_v, x, x_int, &msgs);
+    coupled_system_dv(base_ode, y0_d, theta_v, x, x_int, 1E5, &msgs);
 
   std::vector<double> y(3,0);
   std::vector<double> dy_dt(3,0);
@@ -172,7 +172,7 @@ TEST_F(StanAgradRevOde, memory_recovery_exception_dv) {
     std::vector<var> theta_v(M, 0.0);
     
     coupled_ode_system<mock_throwing_ode_functor<std::logic_error>, double, var>
-      coupled_system_dv(throwing_ode, y0_d, theta_v, x, x_int, &msgs);
+      coupled_system_dv(throwing_ode, y0_d, theta_v, x, x_int, 1E5, &msgs);
     
     std::vector<double> y(3,0);
     std::vector<double> dy_dt(3,0);
@@ -216,7 +216,7 @@ TEST_F(StanAgradRevOde, coupled_ode_system_vd) {
   y0_var.push_back(0.5);
   
   coupled_ode_system<harm_osc_ode_fun, stan::math::var, double> 
-    system(harm_osc, y0_var, theta, x, x_int, &msgs);
+    system(harm_osc, y0_var, theta, x, x_int, 1E5, &msgs);
 
   system(coupled_y0, dy_dt, t0);
 
@@ -242,7 +242,7 @@ TEST_F(StanAgradRevOde, decouple_states_vd) {
   theta[0] = 0.15;
       
   coupled_ode_system<mock_ode_functor, var, double>
-    coupled_system(mock_ode, y0, theta, x, x_int, &msgs);
+    coupled_system(mock_ode, y0, theta, x, x_int, 1E5, &msgs);
       
   size_t k = 0;
   std::vector<std::vector<double> > ys_coupled(T);
@@ -282,7 +282,7 @@ TEST_F(StanAgradRevOde, initial_state_vd) {
     theta_d[m] = 10 * (m+1);
      
   coupled_ode_system<mock_ode_functor, var, double>
-    coupled_system_vd(base_ode, y0_v, theta_d, x, x_int, &msgs);
+    coupled_system_vd(base_ode, y0_v, theta_d, x, x_int, 1E5, &msgs);
 
   std::vector<double> state;
 
@@ -305,7 +305,7 @@ TEST_F(StanAgradRevOde, size_vd) {
   std::vector<double> theta_d(M, 0.0);
 
   coupled_ode_system<mock_ode_functor, var, double>
-    coupled_system_vd(base_ode, y0_v, theta_d, x, x_int, &msgs);
+    coupled_system_vd(base_ode, y0_v, theta_d, x, x_int, 1E5, &msgs);
 
   EXPECT_EQ(N + N*N, coupled_system_vd.size());
 }
@@ -322,7 +322,7 @@ TEST_F(StanAgradRevOde, memory_recovery_vd) {
   std::vector<double> theta_d(M, 0.0);
 
   coupled_ode_system<mock_ode_functor, var, double>
-    coupled_system_vd(base_ode, y0_v, theta_d, x, x_int, &msgs);
+    coupled_system_vd(base_ode, y0_v, theta_d, x, x_int, 1E5, &msgs);
 
   std::vector<double> y(3,0);
   std::vector<double> dy_dt(3,0);
@@ -350,7 +350,7 @@ TEST_F(StanAgradRevOde, memory_recovery_exception_vd) {
     std::vector<double> theta_d(M, 0.0);
     
     coupled_ode_system<mock_throwing_ode_functor<std::logic_error>, var, double>
-      coupled_system_vd(throwing_ode, y0_v, theta_d, x, x_int, &msgs);
+      coupled_system_vd(throwing_ode, y0_v, theta_d, x, x_int, 1E5, &msgs);
     
     std::vector<double> y(3,0);
     std::vector<double> dy_dt(3,0);
@@ -379,7 +379,7 @@ TEST_F(StanAgradRevOde, coupled_ode_system_vv) {
 
   harm_osc_ode_fun harm_osc;
   coupled_ode_system<harm_osc_ode_fun, stan::math::var, stan::math::var> 
-    system(harm_osc, y0_var, theta_var, x, x_int, &msgs);
+    system(harm_osc, y0_var, theta_var, x, x_int, 1E5, &msgs);
   
   std::vector<double> coupled_y0(8, 0);
   
@@ -422,7 +422,7 @@ TEST_F(StanAgradRevOde, decouple_states_vv) {
   theta[0] = 0.15;
   
   coupled_ode_system<harm_osc_ode_fun, var, var>
-    coupled_system(harm_osc, y0, theta, x, x_int, &msgs);
+    coupled_system(harm_osc, y0, theta, x, x_int, 1E5, &msgs);
 
   size_t T = 10;
   size_t k = 0;
@@ -463,7 +463,7 @@ TEST_F(StanAgradRevOde, initial_state_vv) {
     theta_v[m] = 10 * (m+1);
      
   coupled_ode_system<mock_ode_functor, var, var>
-    coupled_system_vv(base_ode, y0_v, theta_v, x, x_int, &msgs);
+    coupled_system_vv(base_ode, y0_v, theta_v, x, x_int, 1E5, &msgs);
 
   std::vector<double>  state = coupled_system_vv.initial_state();
   for (size_t n = 0; n < N; n++) 
@@ -484,7 +484,7 @@ TEST_F(StanAgradRevOde, size_vv) {
   std::vector<var> theta_v(M, 0.0);
 
   coupled_ode_system<mock_ode_functor, var, var>
-    coupled_system_vv(base_ode, y0_v, theta_v, x, x_int, &msgs);
+    coupled_system_vv(base_ode, y0_v, theta_v, x, x_int, 1E5, &msgs);
 
   EXPECT_EQ(N + N*N + N*M, coupled_system_vv.size());
 }
@@ -501,7 +501,7 @@ TEST_F(StanAgradRevOde, memory_recovery_vv) {
   std::vector<var> theta_v(M, 0.0);
 
   coupled_ode_system<mock_ode_functor, var, var>
-    coupled_system_vv(base_ode, y0_v, theta_v, x, x_int, &msgs);
+    coupled_system_vv(base_ode, y0_v, theta_v, x, x_int, 1E5, &msgs);
 
   std::vector<double> y(3,0);
   std::vector<double> dy_dt(3,0);
@@ -529,7 +529,7 @@ TEST_F(StanAgradRevOde, memory_recovery_exception_vv) {
     std::vector<var> theta_v(M, 0.0);
     
     coupled_ode_system<mock_throwing_ode_functor<std::logic_error>, var, var>
-      coupled_system_vv(throwing_ode, y0_v, theta_v, x, x_int, &msgs);
+      coupled_system_vv(throwing_ode, y0_v, theta_v, x, x_int, 1E5, &msgs);
     
     std::vector<double> y(3,0);
     std::vector<double> dy_dt(3,0);


### PR DESCRIPTION
#### Summary:
Include in the coupled_ode_system object an evaluation counter and throw an exception of "too much work" whenever the counter reaches an upper threshold of max_evals which is passed in as argument to the constructor.

#### Intended Effect:
Make the integrator fail whenever a too much work condition arises due to too stiff parameter values for the integrator given desired accuracy. This makes Stan robust wrt to difficult ODE systems.

#### How to Verify:
Run current *_ode_test.cpp files. In addition a new test has been created in test/unit/math/prim/arr/functor/coupled_ode_system_test.cpp which tests explicitly the new behavior.

#### Side Effects
- couple_ode_system constructor gains an additional max_evals argument which must be set. Since the user cannot set this, no error checking that this number is larger than 0 is done.
- coupled_ode_system throws an exception whenever "too much" work has to be done
- coupled_ode_system must be passed to integrate_times using boost::ref to avoid copying the object instance inside odeint which would lead to a counter reset.

#### Documentation:
The extra argument to coupled_ode_system has been added do doxygen.

#### Reviewer Suggestions:

@syclik @bob-carpenter 