### PR TITLE
No longer support Microsoft VS2008 idiosyncrasies

### DIFF
--- a/stan/math/memory/stack_alloc.hpp
+++ b/stan/math/memory/stack_alloc.hpp
@@ -3,11 +3,7 @@
 
 // TODO(Bob): <cstddef> replaces this ifdef in C++11, until then this
 //            is best we can do to get safe pointer casts to uints.
-#if defined(_MSC_VER)
-    #include <msinttypes.h>  // Microsoft Visual Studio lacks full stdint.h
-#else
-    #include <stdint.h>
-#endif
+#include <stdint.h>
 #include <stan/math/prim/scal/meta/likely.hpp>
 #include <cstdlib>
 #include <cstddef>


### PR DESCRIPTION
This was added in #633 (issue #632) to support
building Stan with Microsoft Visual Studio 2008 (needed
for Python versions 2.7 to 3.4).

For Python 3.5, Microsoft Visual Studio 2014 is now the relevant version
of Microsoft Visual Studio which needs to be supported.

Paired with removal of msinttypes.h from stan-dev/stan