### PR TITLE
Feature/issue 204 unit transform

### DIFF
--- a/stan/math/fwd/mat/fun/unit_vector_constrain.hpp
+++ b/stan/math/fwd/mat/fun/unit_vector_constrain.hpp
@@ -2,8 +2,11 @@
 #define STAN_MATH_FWD_MAT_FUN_UNIT_VECTOR_CONSTRAIN_HPP
 
 #include <stan/math/fwd/core.hpp>
+#include <stan/math/fwd/mat/fun/divide.hpp>
 #include <stan/math/fwd/mat/fun/dot_self.hpp>
+#include <stan/math/fwd/mat/fun/tcrossprod.hpp>
 #include <stan/math/fwd/scal/fun/sqrt.hpp>
+#include <stan/math/prim/mat/fun/divide.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/mat/fun/tcrossprod.hpp>
 #include <stan/math/prim/mat/fun/unit_vector_constrain.hpp>
@@ -32,7 +35,7 @@ namespace stan {
       const T norm = sqrt(squared_norm);
       const T inv_norm = inv(norm);
       Matrix<T, Eigen::Dynamic, Eigen::Dynamic> J
-        = tcrossprod(y_t) / (-norm * squared_norm);
+        = divide(tcrossprod(y_t),  -norm * squared_norm);
 
       // for each input position
       for (int m = 0; m < y.size(); ++m) {

--- a/stan/math/fwd/mat/fun/unit_vector_constrain.hpp
+++ b/stan/math/fwd/mat/fun/unit_vector_constrain.hpp
@@ -2,14 +2,12 @@
 #define STAN_MATH_FWD_MAT_FUN_UNIT_VECTOR_CONSTRAIN_HPP
 
 #include <stan/math/fwd/core.hpp>
-#include <stan/math/fwd/scal/fun/sqrt.hpp>
-#include <stan/math/rev/scal/fun/sqrt.hpp>
-#include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/fwd/mat/fun/dot_self.hpp>
-#include <stan/math/prim/scal/fun/inv.hpp>
+#include <stan/math/fwd/scal/fun/sqrt.hpp>
+#include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/mat/fun/tcrossprod.hpp>
-#include <stan/math/rev/mat/fun/unit_vector_constrain.hpp>
 #include <stan/math/prim/mat/fun/unit_vector_constrain.hpp>
+#include <stan/math/prim/scal/fun/inv.hpp>
 
 namespace stan {
   namespace math {

--- a/stan/math/fwd/mat/fun/unit_vector_constrain.hpp
+++ b/stan/math/fwd/mat/fun/unit_vector_constrain.hpp
@@ -21,7 +21,7 @@ namespace stan {
       Matrix<T, R, C> y_t(y.size());
       for (int k = 0; k < y.size(); ++k)
         y_t.coeffRef(k) = y.coeff(k).val_;
-      
+
       Matrix<T, R, C> unit_vector_y_t
         = unit_vector_constrain(y_t);
       Matrix<fvar<T>, R, C> unit_vector_y(y.size());

--- a/stan/math/fwd/mat/fun/unit_vector_constrain.hpp
+++ b/stan/math/fwd/mat/fun/unit_vector_constrain.hpp
@@ -15,15 +15,13 @@ namespace stan {
     template <typename T, int R, int C>
     inline Eigen::Matrix<fvar<T>, R, C>
     unit_vector_constrain(const Eigen::Matrix<fvar<T>, R, C>& y) {
+      using std::sqrt;
       using Eigen::Matrix;
-      using stan::math::tcrossprod;
-      using stan::math::dot_self;
-      using stan::math::unit_vector_constrain;
 
       Matrix<T, R, C> y_t(y.size());
       for (int k = 0; k < y.size(); ++k)
         y_t.coeffRef(k) = y.coeff(k).val_;
-
+      
       Matrix<T, R, C> unit_vector_y_t
         = unit_vector_constrain(y_t);
       Matrix<fvar<T>, R, C> unit_vector_y(y.size());
@@ -51,7 +49,6 @@ namespace stan {
     template <typename T, int R, int C>
     inline Eigen::Matrix<fvar<T>, R, C>
     unit_vector_constrain(const Eigen::Matrix<fvar<T>, R, C>& y, fvar<T>& lp) {
-      using stan::math::dot_self;
       const fvar<T> squared_norm = dot_self(y);
       lp -= 0.5 * squared_norm;
       return unit_vector_constrain(y);

--- a/stan/math/fwd/mat/fun/unit_vector_constrain.hpp
+++ b/stan/math/fwd/mat/fun/unit_vector_constrain.hpp
@@ -1,0 +1,64 @@
+#ifndef STAN_MATH_FWD_MAT_FUN_UNIT_VECTOR_CONSTRAIN_HPP
+#define STAN_MATH_FWD_MAT_FUN_UNIT_VECTOR_CONSTRAIN_HPP
+
+#include <stan/math/fwd/core.hpp>
+#include <stan/math/fwd/scal/fun/sqrt.hpp>
+#include <stan/math/rev/scal/fun/sqrt.hpp>
+#include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <stan/math/fwd/mat/fun/dot_self.hpp>
+#include <stan/math/prim/scal/fun/inv.hpp>
+#include <stan/math/prim/mat/fun/tcrossprod.hpp>
+#include <stan/math/rev/mat/fun/unit_vector_constrain.hpp>
+#include <stan/math/prim/mat/fun/unit_vector_constrain.hpp>
+
+namespace stan {
+  namespace math {
+
+    template <typename T, int R, int C>
+    inline Eigen::Matrix<fvar<T>, R, C>
+    unit_vector_constrain(const Eigen::Matrix<fvar<T>, R, C>& y) {
+      using Eigen::Matrix;
+      using stan::math::tcrossprod;
+      using stan::math::dot_self;
+      using stan::math::unit_vector_constrain;
+
+      Matrix<T,R,C> y_t(y.size());
+      for (int k = 0; k < y.size(); ++k)
+        y_t.coeffRef(k) = y.coeff(k).val_;
+
+      Matrix<T,R,C> unit_vector_y_t
+        = unit_vector_constrain(y_t);
+      Matrix<fvar<T>, R, C> unit_vector_y(y.size());
+      for (int k = 0; k < y.size(); ++k)
+        unit_vector_y.coeffRef(k).val_ = unit_vector_y_t.coeff(k);
+
+      const T squared_norm = dot_self(y_t);
+      const T norm = sqrt(squared_norm);
+      const T inv_norm = inv(norm);
+      Matrix<T,Eigen::Dynamic,Eigen::Dynamic> J
+        = tcrossprod(y_t) / (-norm * squared_norm);
+
+      // for each input position
+      for (int m = 0; m < y.size(); ++m) {
+        J.coeffRef(m,m) += inv_norm;
+        // for each output position
+        for (int k = 0; k < y.size(); ++k) {
+          // chain from input to output
+          unit_vector_y.coeffRef(k).d_ = J.coeff(k,m);
+        }
+      }
+      return unit_vector_y;
+    }
+
+    template <typename T, int R, int C>
+    inline Eigen::Matrix<fvar<T>, R, C>
+    unit_vector_constrain(const Eigen::Matrix<fvar<T>, R, C>& y, fvar<T>& lp) {
+      using stan::math::dot_self;
+      const fvar<T> squared_norm = dot_self(y);
+      lp -= 0.5 * squared_norm;
+      return unit_vector_constrain(y);
+    }
+
+  }
+}
+#endif

--- a/stan/math/fwd/mat/fun/unit_vector_constrain.hpp
+++ b/stan/math/fwd/mat/fun/unit_vector_constrain.hpp
@@ -20,11 +20,11 @@ namespace stan {
       using stan::math::dot_self;
       using stan::math::unit_vector_constrain;
 
-      Matrix<T,R,C> y_t(y.size());
+      Matrix<T, R, C> y_t(y.size());
       for (int k = 0; k < y.size(); ++k)
         y_t.coeffRef(k) = y.coeff(k).val_;
 
-      Matrix<T,R,C> unit_vector_y_t
+      Matrix<T, R, C> unit_vector_y_t
         = unit_vector_constrain(y_t);
       Matrix<fvar<T>, R, C> unit_vector_y(y.size());
       for (int k = 0; k < y.size(); ++k)
@@ -33,16 +33,16 @@ namespace stan {
       const T squared_norm = dot_self(y_t);
       const T norm = sqrt(squared_norm);
       const T inv_norm = inv(norm);
-      Matrix<T,Eigen::Dynamic,Eigen::Dynamic> J
+      Matrix<T, Eigen::Dynamic, Eigen::Dynamic> J
         = tcrossprod(y_t) / (-norm * squared_norm);
 
       // for each input position
       for (int m = 0; m < y.size(); ++m) {
-        J.coeffRef(m,m) += inv_norm;
+        J.coeffRef(m, m) += inv_norm;
         // for each output position
         for (int k = 0; k < y.size(); ++k) {
           // chain from input to output
-          unit_vector_y.coeffRef(k).d_ = J.coeff(k,m);
+          unit_vector_y.coeffRef(k).d_ = J.coeff(k, m);
         }
       }
       return unit_vector_y;

--- a/stan/math/prim/mat/fun/unit_vector_constrain.hpp
+++ b/stan/math/prim/mat/fun/unit_vector_constrain.hpp
@@ -2,73 +2,46 @@
 #define STAN_MATH_PRIM_MAT_FUN_UNIT_VECTOR_CONSTRAIN_HPP
 
 #include <stan/math/prim/mat/fun/Eigen.hpp>
-#include <stan/math/prim/mat/meta/index_type.hpp>
+#include <stan/math/prim/mat/fun/dot_self.hpp>
+#include <stan/math/prim/scal/err/check_positive.hpp>
+#include <stan/math/prim/scal/err/check_positive_finite.hpp>
+#include <stan/math/prim/scal/err/check_nonzero_size.hpp>
+#include <stan/math/prim/mat/err/check_vector.hpp>
 #include <cmath>
 
 namespace stan {
-
   namespace math {
 
-    // Unit vector
-
     /**
      * Return the unit length vector corresponding to the free vector y.
-     * The free vector contains K-1 spherical coordinates.
+     * See https://en.wikipedia.org/wiki/N-sphere#Generating_random_points
      *
-     * @param y of K - 1 spherical coordinates
-     * @return Unit length vector of dimension K
-     * @tparam T Scalar type.
-     **/
-    template <typename T>
-    Eigen::Matrix<T, Eigen::Dynamic, 1>
-    unit_vector_constrain(const Eigen::Matrix<T, Eigen::Dynamic, 1>& y) {
-      using Eigen::Matrix;
-      using Eigen::Dynamic;
-      using stan::math::index_type;
-      typedef typename index_type<Matrix<T, Dynamic, 1> >::type size_type;
-      int Km1 = y.size();
-      Matrix<T, Dynamic, 1> x(Km1 + 1);
-      x(0) = 1.0;
-      const T half_pi = T(M_PI/2.0);
-      for (size_type k = 1; k <= Km1; ++k) {
-        T yk_1 = y(k-1) + half_pi;
-        T sin_yk_1 = sin(yk_1);
-        x(k) = x(k-1)*sin_yk_1;
-        x(k-1) *= cos(yk_1);
-      }
-      return x;
-    }
-
-    /**
-     * Return the unit length vector corresponding to the free vector y.
-     * The free vector contains K-1 spherical coordinates.
-     *
-     * @param y of K - 1 spherical coordinates
+     * @param y vector of K unrestricted variables
      * @return Unit length vector of dimension K
      * @param lp Log probability reference to increment.
      * @tparam T Scalar type.
      **/
-    template <typename T>
-    Eigen::Matrix<T, Eigen::Dynamic, 1>
-    unit_vector_constrain(const Eigen::Matrix<T, Eigen::Dynamic, 1>& y, T &lp) {
-      using Eigen::Matrix;
-      using Eigen::Dynamic;
-      using stan::math::index_type;
-      typedef typename index_type<Matrix<T, Dynamic, 1> >::type size_type;
+    template <typename T, int R, int C>
+    Eigen::Matrix<T, R, C>
+    unit_vector_constrain(Eigen::Matrix<T, R, C>& y) {
+      stan::math::check_vector("unit_vector_constrain", "y", y);
+      stan::math::check_nonzero_size("unit_vector_constrain", "y", y);
+      using stan::math::dot_self;
+      const T SN = dot_self(y);
+      stan::math::check_positive("unit_vector_constrain", "norm", SN);
+      return y / sqrt(SN);
+    }
 
-      int Km1 = y.size();
-      Matrix<T, Dynamic, 1> x(Km1 + 1);
-      x(0) = 1.0;
-      const T half_pi = T(0.5 * M_PI);
-      for (size_type k = 1; k <= Km1; ++k) {
-        T yk_1 = y(k-1) + half_pi;
-        T sin_yk_1 = sin(yk_1);
-        x(k) = x(k-1) * sin_yk_1;
-        x(k-1) *= cos(yk_1);
-        if (k < Km1)
-          lp += (Km1 - k) * log(fabs(sin_yk_1));
-      }
-      return x;
+    template <typename T, int R, int C>
+    Eigen::Matrix<T, R, C>
+    unit_vector_constrain(const Eigen::Matrix<T, R, C>& y, T& lp) {
+      stan::math::check_vector("unit_vector_constrain", "y", y);
+      stan::math::check_nonzero_size("unit_vector_constrain", "y", y);
+      using stan::math::dot_self;
+      const T SN = dot_self(y);
+      stan::math::check_positive_finite("unit_vector_constrain", "norm", SN);
+      lp -= 0.5 * SN;
+      return y / sqrt(SN);
     }
 
   }

--- a/stan/math/prim/mat/fun/unit_vector_constrain.hpp
+++ b/stan/math/prim/mat/fun/unit_vector_constrain.hpp
@@ -18,7 +18,6 @@ namespace stan {
      *
      * @param y vector of K unrestricted variables
      * @return Unit length vector of dimension K
-     * @param lp Log probability reference to increment.
      * @tparam T Scalar type.
      **/
     template <typename T, int R, int C>
@@ -32,6 +31,15 @@ namespace stan {
       return y / sqrt(SN);
     }
 
+    /**
+     * Return the unit length vector corresponding to the free vector y.
+     * See https://en.wikipedia.org/wiki/N-sphere#Generating_random_points
+     *
+     * @param y vector of K unrestricted variables
+     * @return Unit length vector of dimension K
+     * @param lp Log probability reference to increment.
+     * @tparam T Scalar type.
+     **/
     template <typename T, int R, int C>
     Eigen::Matrix<T, R, C>
     unit_vector_constrain(const Eigen::Matrix<T, R, C>& y, T& lp) {

--- a/stan/math/prim/mat/fun/unit_vector_constrain.hpp
+++ b/stan/math/prim/mat/fun/unit_vector_constrain.hpp
@@ -27,7 +27,7 @@ namespace stan {
       check_vector("unit_vector_constrain", "y", y);
       check_nonzero_size("unit_vector_constrain", "y", y);
       const T SN = dot_self(y);
-      check_positive("unit_vector_constrain", "norm", SN);
+      check_positive_finite("unit_vector_constrain", "norm", SN);
       return y / sqrt(SN);
     }
 

--- a/stan/math/prim/mat/fun/unit_vector_constrain.hpp
+++ b/stan/math/prim/mat/fun/unit_vector_constrain.hpp
@@ -22,12 +22,12 @@ namespace stan {
      **/
     template <typename T, int R, int C>
     Eigen::Matrix<T, R, C>
-    unit_vector_constrain(Eigen::Matrix<T, R, C>& y) {
-      stan::math::check_vector("unit_vector_constrain", "y", y);
-      stan::math::check_nonzero_size("unit_vector_constrain", "y", y);
-      using stan::math::dot_self;
+    unit_vector_constrain(const Eigen::Matrix<T, R, C>& y) {
+      using std::sqrt;
+      check_vector("unit_vector_constrain", "y", y);
+      check_nonzero_size("unit_vector_constrain", "y", y);
       const T SN = dot_self(y);
-      stan::math::check_positive("unit_vector_constrain", "norm", SN);
+      check_positive("unit_vector_constrain", "norm", SN);
       return y / sqrt(SN);
     }
 
@@ -43,11 +43,11 @@ namespace stan {
     template <typename T, int R, int C>
     Eigen::Matrix<T, R, C>
     unit_vector_constrain(const Eigen::Matrix<T, R, C>& y, T& lp) {
-      stan::math::check_vector("unit_vector_constrain", "y", y);
-      stan::math::check_nonzero_size("unit_vector_constrain", "y", y);
-      using stan::math::dot_self;
+      using std::sqrt;
+      check_vector("unit_vector_constrain", "y", y);
+      check_nonzero_size("unit_vector_constrain", "y", y);
       const T SN = dot_self(y);
-      stan::math::check_positive_finite("unit_vector_constrain", "norm", SN);
+      check_positive_finite("unit_vector_constrain", "norm", SN);
       lp -= 0.5 * SN;
       return y / sqrt(SN);
     }

--- a/stan/math/prim/mat/fun/unit_vector_free.hpp
+++ b/stan/math/prim/mat/fun/unit_vector_free.hpp
@@ -10,24 +10,21 @@ namespace stan {
 
   namespace math {
 
-
+    /**
+     * Transformation of a unit length vector to a "free" vector
+     * However, we are just fixing the unidentified radius to 1.
+     * Thus, the transformation is just the identity
+     *
+     * @param x unit vector of dimension K
+     * @return Unit vector of dimension K considered "free"
+     * @tparam T Scalar type.
+     **/
     template <typename T>
     Eigen::Matrix<T, Eigen::Dynamic, 1>
     unit_vector_free(const Eigen::Matrix<T, Eigen::Dynamic, 1>& x) {
-      using Eigen::Matrix;
-      using Eigen::Dynamic;
-
       stan::math::check_unit_vector("stan::math::unit_vector_free",
-                                              "Unit vector variable", x);
-      int Km1 = x.size() - 1;
-      Matrix<T, Dynamic, 1> y(Km1);
-      T sumSq = x(Km1)*x(Km1);
-      const T half_pi = T(M_PI/2.0);
-      for (int k = Km1; --k >= 0; ) {
-        y(k) = atan2(sqrt(sumSq), x(k)) - half_pi;
-        sumSq += x(k)*x(k);
-      }
-      return y;
+                                    "Unit vector variable", x);
+      return x;
     }
 
   }

--- a/stan/math/prim/mat/prob/lkj_corr_cholesky_log.hpp
+++ b/stan/math/prim/mat/prob/lkj_corr_cholesky_log.hpp
@@ -26,8 +26,6 @@
 #include <stan/math/prim/scal/fun/prob_free.hpp>
 #include <stan/math/prim/scal/fun/corr_constrain.hpp>
 #include <stan/math/prim/scal/fun/corr_free.hpp>
-#include <stan/math/prim/mat/fun/unit_vector_constrain.hpp>
-#include <stan/math/prim/mat/fun/unit_vector_free.hpp>
 #include <stan/math/prim/mat/fun/simplex_constrain.hpp>
 #include <stan/math/prim/mat/fun/simplex_free.hpp>
 #include <stan/math/prim/mat/fun/ordered_constrain.hpp>

--- a/stan/math/prim/mat/prob/lkj_corr_cholesky_rng.hpp
+++ b/stan/math/prim/mat/prob/lkj_corr_cholesky_rng.hpp
@@ -27,8 +27,6 @@
 #include <stan/math/prim/scal/fun/prob_free.hpp>
 #include <stan/math/prim/scal/fun/corr_constrain.hpp>
 #include <stan/math/prim/scal/fun/corr_free.hpp>
-#include <stan/math/prim/mat/fun/unit_vector_constrain.hpp>
-#include <stan/math/prim/mat/fun/unit_vector_free.hpp>
 #include <stan/math/prim/mat/fun/simplex_constrain.hpp>
 #include <stan/math/prim/mat/fun/simplex_free.hpp>
 #include <stan/math/prim/mat/fun/ordered_constrain.hpp>

--- a/stan/math/prim/mat/prob/lkj_corr_log.hpp
+++ b/stan/math/prim/mat/prob/lkj_corr_log.hpp
@@ -28,8 +28,6 @@
 #include <stan/math/prim/scal/fun/prob_free.hpp>
 #include <stan/math/prim/scal/fun/corr_constrain.hpp>
 #include <stan/math/prim/scal/fun/corr_free.hpp>
-#include <stan/math/prim/mat/fun/unit_vector_constrain.hpp>
-#include <stan/math/prim/mat/fun/unit_vector_free.hpp>
 #include <stan/math/prim/mat/fun/simplex_constrain.hpp>
 #include <stan/math/prim/mat/fun/simplex_free.hpp>
 #include <stan/math/prim/mat/fun/ordered_constrain.hpp>

--- a/stan/math/prim/mat/prob/lkj_corr_rng.hpp
+++ b/stan/math/prim/mat/prob/lkj_corr_rng.hpp
@@ -26,8 +26,6 @@
 #include <stan/math/prim/scal/fun/prob_free.hpp>
 #include <stan/math/prim/scal/fun/corr_constrain.hpp>
 #include <stan/math/prim/scal/fun/corr_free.hpp>
-#include <stan/math/prim/mat/fun/unit_vector_constrain.hpp>
-#include <stan/math/prim/mat/fun/unit_vector_free.hpp>
 #include <stan/math/prim/mat/fun/simplex_constrain.hpp>
 #include <stan/math/prim/mat/fun/simplex_free.hpp>
 #include <stan/math/prim/mat/fun/ordered_constrain.hpp>

--- a/stan/math/rev/mat/fun/unit_vector_constrain.hpp
+++ b/stan/math/rev/mat/fun/unit_vector_constrain.hpp
@@ -1,0 +1,121 @@
+#ifndef STAN_MATH_PRIM_MAT_FUN_UNIT_VECTOR_CONSTRAIN_HPP
+#define STAN_MATH_PRIM_MAT_FUN_UNIT_VECTOR_CONSTRAIN_HPP
+
+#include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <stan/math/prim/mat/fun/dot_self.hpp>
+#include <stan/math/rev/mat/fun/dot_self.hpp>
+#include <stan/math/prim/scal/err/check_positive_finite.hpp>
+#include <stan/math/prim/scal/err/check_nonzero_size.hpp>
+#include <stan/math/prim/mat/err/check_vector.hpp>
+#include <stan/math/rev/core.hpp>
+#include <cmath>
+
+namespace stan {
+  namespace math {
+
+    namespace {
+      class unit_vector_elt_vari : public vari {
+      private:
+        vari** y_;
+        const double* unit_vector_y_;
+        const int size_;
+        const int idx_;
+        const double norm_;
+
+      public:
+        unit_vector_elt_vari(double val,
+                             vari** y,
+                             const double* unit_vector_y,
+                             int size,
+                             int idx,
+                             const double norm)
+          : vari(val),
+            y_(y),
+            unit_vector_y_(unit_vector_y),
+            size_(size),
+            idx_(idx),
+            norm_(norm) {
+        }
+        void chain() {
+          const double cubed_norm = norm_ * norm_ * norm_;
+          for (int m = 0; m < size_; ++m) {
+            y_[m]->adj_
+              -= adj_ * unit_vector_y_[m] * unit_vector_y_[idx_] / cubed_norm;
+            if (m == idx_)
+              y_[m]->adj_ +=  adj_ / norm_;
+          }
+        }
+      };
+    }
+
+
+    // Unit vector
+
+    /**
+     * Return the unit length vector corresponding to the free vector y.
+     * See https://en.wikipedia.org/wiki/N-sphere#Generating_random_points
+     *
+     * @param y vector of K unrestricted variables
+     * @return Unit length vector of dimension K
+     * @tparam T Scalar type.
+     **/
+    template <int R, int C>
+    Eigen::Matrix<var, R, C>
+    unit_vector_constrain(const Eigen::Matrix<var, R, C>& y) {
+      stan::math::check_vector("unit_vector", "y", y);
+      stan::math::check_nonzero_size("unit_vector", "y", y);
+
+      vari** y_vi_array
+        = reinterpret_cast<vari**>(ChainableStack::memalloc_
+                                   .alloc(sizeof(vari*) * y.size()));
+      for (int i = 0; i < y.size(); ++i)
+        y_vi_array[i] = y.coeff(i).vi_;
+
+      Eigen::VectorXd y_d(y.size());
+      for (int i = 0; i < y.size(); ++i)
+        y_d.coeffRef(i) = y.coeff(i).val();
+
+
+      const double norm = y_d.norm();
+      stan::math::check_positive_finite("unit_vector", "norm", norm);
+      Eigen::VectorXd unit_vector_d = y_d / norm;
+
+      double* unit_vector_y_d_array
+        = reinterpret_cast<double*>(ChainableStack::memalloc_
+                                    .alloc(sizeof(double) * y_d.size()));
+      for (int i = 0; i < y_d.size(); ++i)
+        unit_vector_y_d_array[i] = unit_vector_d.coeff(i);
+
+      Eigen::Matrix<var, R, C> unit_vector_y(y.size());
+      for (int k = 0; k < y.size(); ++k)
+        unit_vector_y.coeffRef(k) = var(new unit_vector_elt_vari(unit_vector_d[k],
+                                                                 y_vi_array,
+                                                                 unit_vector_y_d_array,
+                                                                 y.size(),
+                                                                 k,
+                                                                 norm));
+      return unit_vector_y;
+    }
+
+    /**
+     * Return the unit length vector corresponding to the free vector y.
+     * See https://en.wikipedia.org/wiki/N-sphere#Generating_random_points
+     *
+     * @param y vector of K unrestricted variables
+     * @return Unit length vector of dimension K
+     * @param lp Log probability reference to increment.
+     * @tparam T Scalar type.
+     **/
+    template <int R, int C>
+    Eigen::Matrix<var, R, C>
+    unit_vector_constrain(const Eigen::Matrix<var, R, C>& y, var &lp) {
+      Eigen::Matrix<var, R, C> x = unit_vector_constrain(y);
+      lp -= 0.5 * stan::math::dot_self(y);
+      return x;
+    }
+
+  }
+
+}
+
+#endif

--- a/stan/math/rev/mat/fun/unit_vector_constrain.hpp
+++ b/stan/math/rev/mat/fun/unit_vector_constrain.hpp
@@ -3,11 +3,11 @@
 
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/mat/fun/dot_self.hpp>
-#include <stan/math/rev/mat/fun/dot_self.hpp>
+#include <stan/math/prim/mat/err/check_vector.hpp>
 #include <stan/math/prim/scal/err/check_positive_finite.hpp>
 #include <stan/math/prim/scal/err/check_nonzero_size.hpp>
-#include <stan/math/prim/mat/err/check_vector.hpp>
 #include <stan/math/rev/core.hpp>
+#include <stan/math/rev/mat/fun/dot_self.hpp>
 #include <cmath>
 
 namespace stan {

--- a/stan/math/rev/mat/fun/unit_vector_constrain.hpp
+++ b/stan/math/rev/mat/fun/unit_vector_constrain.hpp
@@ -88,12 +88,13 @@ namespace stan {
 
       Eigen::Matrix<var, R, C> unit_vector_y(y.size());
       for (int k = 0; k < y.size(); ++k)
-        unit_vector_y.coeffRef(k) = var(new unit_vector_elt_vari(unit_vector_d[k],
-                                                                 y_vi_array,
-                                                                 unit_vector_y_d_array,
-                                                                 y.size(),
-                                                                 k,
-                                                                 norm));
+        unit_vector_y.coeffRef(k)
+          = var(new unit_vector_elt_vari(unit_vector_d[k],
+                                         y_vi_array,
+                                         unit_vector_y_d_array,
+                                         y.size(),
+                                         k,
+                                         norm));
       return unit_vector_y;
     }
 

--- a/test/unit/math/fwd/mat/fun/unit_vector_constrain_test.cpp
+++ b/test/unit/math/fwd/mat/fun/unit_vector_constrain_test.cpp
@@ -58,7 +58,7 @@ TEST(AgradFwdMatrixSoftmax,ffd) {
   Matrix<fvar<fvar<double> >,Dynamic,1> theta = unit_vector_constrain(x);
   EXPECT_EQ(1,theta.size());
   EXPECT_FLOAT_EQ(1.0,theta[0].val_.val());
-  EXPECT_FLOAT_EQ(0.0,theta[0].d_.val());
+  EXPECT_NEAR(0.0,theta[0].d_.val(), 3e-16);
 
   Matrix<fvar<fvar<double> >,Dynamic,1> x3(3);
   x3.setRandom();
@@ -78,6 +78,7 @@ TEST(AgradFwdMatrixSoftmax,ffd) {
     Matrix<double,Dynamic,1> d = ((cx3 / sqrt(SN)) / eps).imag();
     EXPECT_FLOAT_EQ(d.coeff(i), theta3[i].d_.val());
   }
+
 }
 
 

--- a/test/unit/math/fwd/mat/fun/unit_vector_constrain_test.cpp
+++ b/test/unit/math/fwd/mat/fun/unit_vector_constrain_test.cpp
@@ -9,6 +9,7 @@ TEST(AgradFwdMatrixUnitVectorConstrain,fd) {
   using Eigen::Dynamic;
   using stan::math::vector_fd;
   using stan::math::fvar;
+  using std::sqrt;
 
 //  EXPECT_THROW(unit_vector_constrain(vector_fd()),std::invalid_argument);
 

--- a/test/unit/math/fwd/mat/fun/unit_vector_constrain_test.cpp
+++ b/test/unit/math/fwd/mat/fun/unit_vector_constrain_test.cpp
@@ -81,4 +81,3 @@ TEST(AgradFwdMatrixSoftmax,ffd) {
 
 }
 
-

--- a/test/unit/math/fwd/mat/fun/unit_vector_constrain_test.cpp
+++ b/test/unit/math/fwd/mat/fun/unit_vector_constrain_test.cpp
@@ -1,0 +1,82 @@
+#include <gtest/gtest.h>
+#include <stan/math/fwd/mat/fun/unit_vector_constrain.hpp>
+#include <stan/math/fwd/mat/fun/typedefs.hpp>
+#include <stan/math/fwd/core.hpp>
+
+TEST(AgradFwdMatrixUnitVectorConstrain,fd) {
+  using stan::math::unit_vector_constrain;
+  using Eigen::Matrix;
+  using Eigen::Dynamic;
+  using stan::math::vector_fd;
+  using stan::math::fvar;
+
+//  EXPECT_THROW(unit_vector_constrain(vector_fd()),std::invalid_argument);
+
+  Matrix<fvar<double>,Dynamic,1> x(1);
+  x << 0.7;
+  x(0).d_ = 1.0;
+
+  Matrix<fvar<double>,Dynamic,1> theta = unit_vector_constrain(x);
+  EXPECT_EQ(1,theta.size());
+  EXPECT_FLOAT_EQ(1.0,theta[0].val_);
+  EXPECT_NEAR(0.0,theta[0].d_, 3e-16);
+
+  Matrix<fvar<double>,Dynamic,1> x3(3);
+  x3.setRandom();
+  for (int i = 0; i < x3.size(); ++ i) x3(i).d_ = 1.0;
+
+  Matrix<fvar<double>,Dynamic,1> theta3 = unit_vector_constrain(x3);
+  EXPECT_EQ(3,theta3.size());
+  const double eps = 10e-20;
+  for (int i = 0; i < x3.size(); ++i) {
+    Eigen::VectorXcd cx3(x3.size());
+    for (int j = 0; j < x3.size(); ++j)
+      cx3.real().coeffRef(j) = x3(j).val_;
+    cx3.imag().setZero();
+    cx3.imag().coeffRef(2) = eps;
+    std::complex<double> SN(0.0); // should be cx3.squaredNorm() but Eigen has a bug?
+    for (int j = 0; j < x3.size(); ++j) SN += cx3(j) * cx3(j);
+    Matrix<double,Dynamic,1> d = ((cx3 / sqrt(SN)) / eps).imag();
+    EXPECT_FLOAT_EQ(d.coeff(i), theta3[i].d_);
+  }
+}
+/*
+TEST(AgradFwdMatrixSoftmax,ffd) {
+  using stan::math::unit_vector_constrain;
+  using Eigen::Matrix;
+  using Eigen::Dynamic;
+  using stan::math::vector_ffd;
+  using stan::math::fvar;
+
+//  EXPECT_THROW(unit_vector_constrain(vector_ffd()),std::invalid_argument);
+
+  Matrix<fvar<fvar<double> >,Dynamic,1> x(1);
+  x << 0.7;
+   x(0).d_ = 1.0;
+
+  Matrix<fvar<fvar<double> >,Dynamic,1> theta = unit_vector_constrain(x);
+  EXPECT_EQ(1,theta.size());
+  EXPECT_FLOAT_EQ(1.0,theta[0].val_.val());
+  EXPECT_FLOAT_EQ(0.0,theta[0].d_.val());
+
+  Matrix<fvar<fvar<double> >,Dynamic,1> x3(3);
+  x3.setRandom();
+  for (int i = 0; i < x3.size(); ++ i) x3(i).d_ = 1.0;
+
+  Matrix<fvar<fvar<double> >,Dynamic,1> theta3 = unit_vector_constrain(x3);
+  EXPECT_EQ(3,theta3.size());
+  const double eps = 10e-20;
+  for (int i = 0; i < x3.size(); ++i) {
+    Eigen::VectorXcd cx3(x3.size());
+    for (int j = 0; j < x3.size(); ++j)
+      cx3.real().coeffRef(j) = x3(j).val_.val();
+    cx3.imag().setZero();
+    cx3.imag().coeffRef(2) = eps;
+    std::complex<double> SN(0.0); // should be cx3.squaredNorm() but Eigen has a bug?
+    for (int j = 0; j < x3.size(); ++j) SN += cx3(j) * cx3(j);
+    Matrix<double,Dynamic,1> d = ((cx3 / sqrt(SN)) / eps).imag();
+    EXPECT_FLOAT_EQ(d.coeff(i), theta3[i].d_.val());
+  }
+}
+*/
+

--- a/test/unit/math/fwd/mat/fun/unit_vector_constrain_test.cpp
+++ b/test/unit/math/fwd/mat/fun/unit_vector_constrain_test.cpp
@@ -11,7 +11,7 @@ TEST(AgradFwdMatrixUnitVectorConstrain,fd) {
   using stan::math::fvar;
   using std::sqrt;
 
-//  EXPECT_THROW(unit_vector_constrain(vector_fd()),std::invalid_argument);
+  EXPECT_THROW(unit_vector_constrain(vector_fd()),std::invalid_argument);
 
   Matrix<fvar<double>,Dynamic,1> x(1);
   x << 0.7;
@@ -41,7 +41,7 @@ TEST(AgradFwdMatrixUnitVectorConstrain,fd) {
     EXPECT_FLOAT_EQ(d.coeff(i), theta3[i].d_);
   }
 }
-/*
+
 TEST(AgradFwdMatrixSoftmax,ffd) {
   using stan::math::unit_vector_constrain;
   using Eigen::Matrix;
@@ -49,7 +49,7 @@ TEST(AgradFwdMatrixSoftmax,ffd) {
   using stan::math::vector_ffd;
   using stan::math::fvar;
 
-//  EXPECT_THROW(unit_vector_constrain(vector_ffd()),std::invalid_argument);
+  EXPECT_THROW(unit_vector_constrain(vector_ffd()),std::invalid_argument);
 
   Matrix<fvar<fvar<double> >,Dynamic,1> x(1);
   x << 0.7;
@@ -79,5 +79,5 @@ TEST(AgradFwdMatrixSoftmax,ffd) {
     EXPECT_FLOAT_EQ(d.coeff(i), theta3[i].d_.val());
   }
 }
-*/
+
 

--- a/test/unit/math/prim/scal/fun/transform_test.cpp
+++ b/test/unit/math/prim/scal/fun/transform_test.cpp
@@ -614,16 +614,16 @@ TEST(prob_transform,simplex_f_exception) {
 
 TEST(prob_transform,unit_vector_rt0) {
   Matrix<double,Dynamic,1> x(4);
-  x << 0.0, 0.0, 0.0, 0.0;
-  Matrix<double,Dynamic,1> y = stan::math::unit_vector_constrain(x);
-  EXPECT_NEAR(0, y(0), 1e-8);
-  EXPECT_NEAR(0, y(1), 1e-8);
-  EXPECT_NEAR(0, y(2), 1e-8);
-  EXPECT_NEAR(0, y(3), 1e-8);
-  EXPECT_NEAR(1.0, y(4), 1e-8);
+  x << sqrt(0.1), -sqrt(0.2), -sqrt(0.3), sqrt(0.4);
+  using stan::math::unit_vector_constrain;
+  Matrix<double,Dynamic,1> y = unit_vector_constrain(x);
+  EXPECT_NEAR(x(0), y(0), 1e-8);
+  EXPECT_NEAR(x(1), y(1), 1e-8);
+  EXPECT_NEAR(x(2), y(2), 1e-8);
+  EXPECT_NEAR(x(3), y(3), 1e-8);
 
   Matrix<double,Dynamic,1> xrt = stan::math::unit_vector_free(y);
-  EXPECT_EQ(x.size()+1,y.size());
+  EXPECT_EQ(x.size(),y.size());
   EXPECT_EQ(x.size(),xrt.size());
   for (int i = 0; i < x.size(); ++i) {
     EXPECT_NEAR(x[i],xrt[i],1E-10);
@@ -632,23 +632,25 @@ TEST(prob_transform,unit_vector_rt0) {
 TEST(prob_transform,unit_vector_rt) {
   Matrix<double,Dynamic,1> x(3);
   x << 1.0, -1.0, 1.0;
-  Matrix<double,Dynamic,1> y = stan::math::unit_vector_constrain(x);
+  using stan::math::unit_vector_constrain;
+  Matrix<double,Dynamic,1> y = unit_vector_constrain(x);
   Matrix<double,Dynamic,1> xrt = stan::math::unit_vector_free(y);
-  EXPECT_EQ(x.size()+1,y.size());
+  EXPECT_EQ(x.size(),y.size());
   EXPECT_EQ(x.size(),xrt.size());
   for (int i = 0; i < x.size(); ++i) {
-    EXPECT_FLOAT_EQ(x[i],xrt[i]) << "error in component " << i;
+    EXPECT_FLOAT_EQ(y[i],xrt[i]) << "error in component " << i;
   }
 }
 TEST(prob_transform,unit_vector_match) {
   Matrix<double,Dynamic,1> x(3);
   x << 1.0, -1.0, 2.0;
   double lp;
-  Matrix<double,Dynamic,1> y = stan::math::unit_vector_constrain(x);
+  using stan::math::unit_vector_constrain;
+  Matrix<double,Dynamic,1> y = unit_vector_constrain(x);
   Matrix<double,Dynamic,1> y2 = stan::math::unit_vector_constrain(x,lp);
 
-  EXPECT_EQ(4,y.size());
-  EXPECT_EQ(4,y2.size());
+  EXPECT_EQ(3,y.size());
+  EXPECT_EQ(3,y2.size());
   for (int i = 0; i < x.size(); ++i)
     EXPECT_FLOAT_EQ(y[i],y2[i]) << "error in component " << i;
 }
@@ -657,6 +659,10 @@ TEST(prob_transform,unit_vector_f_exception) {
   y << 0.5, 0.55;
   EXPECT_THROW(stan::math::unit_vector_free(y), std::domain_error);
   y << 1.1, -0.1;
+  EXPECT_THROW(stan::math::unit_vector_free(y), std::domain_error);
+  y << 0.0, 0.0;
+  EXPECT_THROW(stan::math::unit_vector_free(y), std::domain_error);
+  y << 1.0, 1.0 / 0.0;
   EXPECT_THROW(stan::math::unit_vector_free(y), std::domain_error);
 }
 

--- a/test/unit/math/prim/scal/fun/transform_test.cpp
+++ b/test/unit/math/prim/scal/fun/transform_test.cpp
@@ -662,10 +662,12 @@ TEST(prob_transform,unit_vector_f_exception) {
   EXPECT_THROW(stan::math::unit_vector_free(y), std::domain_error);
   y << 0.0, 0.0;
   EXPECT_THROW(stan::math::unit_vector_free(y), std::domain_error);
-  y << 1.0, 1.0 / 0.0;
+  y(0) = std::numeric_limits<double>::quiet_NaN();
+  y(1) = 1.0;
+  EXPECT_THROW(stan::math::unit_vector_free(y), std::domain_error);
+  y(0) = std::numeric_limits<double>::infinity();
   EXPECT_THROW(stan::math::unit_vector_free(y), std::domain_error);
 }
-
 
 TEST(ProbTransform,choleskyFactor) {
   using Eigen::Matrix;

--- a/test/unit/math/rev/mat/fun/unit_vector_constrain_test.cpp
+++ b/test/unit/math/rev/mat/fun/unit_vector_constrain_test.cpp
@@ -59,4 +59,5 @@ TEST(AgradRevUnitVectorConstrain, exceptions) {
   x(0) = std::numeric_limits<var>::quiet_NaN();
   EXPECT_THROW(unit_vector_constrain(x),std::domain_error);
   x(0) = std::numeric_limits<var>::infinity();
+  EXPECT_THROW(unit_vector_constrain(x),std::domain_error);
 }

--- a/test/unit/math/rev/mat/fun/unit_vector_constrain_test.cpp
+++ b/test/unit/math/rev/mat/fun/unit_vector_constrain_test.cpp
@@ -1,0 +1,62 @@
+#include <gtest/gtest.h>
+#include <stan/math/rev/core.hpp>
+#include <stan/math/rev/mat/fun/typedefs.hpp>
+#include <test/unit/math/rev/mat/fun/util.hpp>
+#include <stan/math/rev/mat/fun/unit_vector_constrain.hpp>
+#include <stan/math/prim/mat/fun/unit_vector_constrain.hpp>
+
+std::vector<double>
+unit_vector_grad(Eigen::Matrix<double,Eigen::Dynamic,1>& y_dbl,
+                 int k) {
+  using Eigen::Matrix;
+  using Eigen::Dynamic;
+  using stan::math::var;
+  Matrix<var,Dynamic,1> y(y_dbl.size());
+  for (int i = 0; i < y.size(); ++i)
+    y(i) = y_dbl(i);
+
+  std::vector<var> x(y.size());
+  for (size_t i = 0; i < x.size(); ++i)
+    x[i] = y(i);
+
+  var fx_k = stan::math::unit_vector_constrain(y)[k];
+  std::vector<double> grad(y.size());
+  fx_k.grad(x,grad);
+  return grad;
+}
+TEST(AgradRevUnitVectorConstrain, Grad) {
+  using stan::math::unit_vector_constrain;
+  using stan::math::var;
+  using Eigen::Matrix;
+  using Eigen::Dynamic;
+  for (int k = 0; k < 3; ++k) {
+    Matrix<AVAR,Dynamic,1> y(3);
+    y << 0.0, 3.0, -1.0;
+    Matrix<double,Dynamic,1> y_dbl(3);
+    y_dbl << 0.0, 3.0, -1.0;
+
+    AVEC x(3);
+    for (int i = 0; i < 3; ++i)
+      x[i] = y(i);
+    Matrix<AVAR,Dynamic,1> theta = unit_vector_constrain(y);
+    AVAR fx_k = theta(k);
+    std::vector<double> grad;
+    fx_k.grad(x,grad);
+
+    std::vector<double> grad_expected = unit_vector_grad(y_dbl,k);
+    EXPECT_EQ(grad_expected.size(), grad.size());
+    for (size_t i = 0; i < grad_expected.size(); ++i)
+      EXPECT_FLOAT_EQ(grad_expected[i], grad[i]);
+  }
+}
+TEST(AgradRevUnitVectorConstrain, exceptions) {
+  using stan::math::unit_vector_constrain;
+  using stan::math::var;
+  Eigen::Matrix<var, Eigen::Dynamic, 1> x(3);
+  x.setZero();
+  EXPECT_THROW(unit_vector_constrain(x),std::domain_error);
+  x.setOnes();
+  x(0) = std::numeric_limits<var>::quiet_NaN();
+  EXPECT_THROW(unit_vector_constrain(x),std::domain_error);
+  x(0) = std::numeric_limits<var>::infinity();
+}

--- a/test/unit/math/rev/scal/fun/transform_test.cpp
+++ b/test/unit/math/rev/scal/fun/transform_test.cpp
@@ -34,7 +34,7 @@
 #include <stan/math/prim/scal/fun/prob_free.hpp>
 #include <stan/math/prim/scal/fun/corr_constrain.hpp>
 #include <stan/math/prim/scal/fun/corr_free.hpp>
-#include <stan/math/prim/mat/fun/unit_vector_constrain.hpp>
+#include <stan/math/rev/mat/fun/unit_vector_constrain.hpp>
 #include <stan/math/prim/mat/fun/unit_vector_free.hpp>
 #include <stan/math/prim/mat/fun/simplex_constrain.hpp>
 #include <stan/math/prim/mat/fun/simplex_free.hpp>
@@ -264,7 +264,8 @@ TEST(probTransform,unit_vector_jacobian) {
   var lp(0);
   Matrix<var,Dynamic,1> x 
     = stan::math::unit_vector_constrain(y,lp);
-  
+  const var r2 = stan::math::dot_self(y);
+
   vector<var> indeps;
   indeps.push_back(a);
   indeps.push_back(b);
@@ -273,24 +274,22 @@ TEST(probTransform,unit_vector_jacobian) {
   vector<var> deps;
   deps.push_back(x(0));
   deps.push_back(x(1));
-  deps.push_back(x(2));
-  deps.push_back(x(3));
+  deps.push_back(r2);
   
   vector<vector<double> > jacobian;
   stan::math::jacobian(deps,indeps,jacobian);
 
-  Matrix<double,Dynamic,Dynamic> J(4,4);
-  for (int m = 0; m < 4; ++m) {
+  Matrix<double,Dynamic,Dynamic> J(3,3);
+  for (int m = 0; m < 3; ++m) {
     for (int n = 0; n < 3; ++n) {
       J(m,n) = jacobian[m][n];
     }
-    J(m,3) = x(m).val(); 
   }
   
   double det_J = J.determinant();
   double log_det_J = log(fabs(det_J));
 
-  EXPECT_FLOAT_EQ(log_det_J, lp.val()) << "J = " << J << std::endl << "det_J = " << det_J;
+  EXPECT_FLOAT_EQ(1.0 / det_J, lp.val()) << "J = " << std::endl << J << std::endl << "det_J = " << det_J << std::endl << "x = " << x.transpose();
   
 }
 

--- a/test/unit/math/rev/scal/fun/transform_test.cpp
+++ b/test/unit/math/rev/scal/fun/transform_test.cpp
@@ -287,7 +287,6 @@ TEST(probTransform,unit_vector_jacobian) {
   }
   
   double det_J = J.determinant();
-  double log_det_J = log(fabs(det_J));
 
   EXPECT_FLOAT_EQ(1.0 / det_J, lp.val()) << "J = " << std::endl << J << std::endl << "det_J = " << det_J << std::endl << "x = " << x.transpose();
   


### PR DESCRIPTION
This is not ready to be merged yet. Can someone who understands fwd mode fix `stan/math/fwd/mat/fun/unit_vector_constrain.hpp`? If I `#include <stan/math/rev/mat/fun/unit_vector_constrain.hpp>` before `#include <stan/math/prim/mat/fun/unit_vector_constrain.hpp>` the test fails to compile saying 
```
./stan/math/fwd/mat/fun/unit_vector_constrain.hpp:30:11: error: no matching function for call to 'unit_vector_constrain'
        = unit_vector_constrain(y_t);
          ^~~~~~~~~~~~~~~~~~~~~
test/unit/math/fwd/mat/fun/unit_vector_constrain_test.cpp:19:42: note: in instantiation of function template specialization 'stan::math::unit_vector_constrain<double, -1, 1>' requested here
  Matrix<fvar<double>,Dynamic,1> theta = unit_vector_constrain(x);
                                         ^
./stan/math/rev/mat/fun/unit_vector_constrain.hpp:64:5: note: candidate template ignored: could not match 'stan::math::var' against 'double'
    unit_vector_constrain(const Eigen::Matrix<var, R, C>& y) {
    ^
./stan/math/fwd/mat/fun/unit_vector_constrain.hpp:19:5: note: candidate template ignored: could not match 'fvar<type-parameter-0-0>' against 'double'
    unit_vector_constrain(const Eigen::Matrix<fvar<T>, R, C>& y) {
    ^
./stan/math/rev/mat/fun/unit_vector_constrain.hpp:111:5: note: candidate function template not viable: requires 2 arguments, but 1 was provided
    unit_vector_constrain(const Eigen::Matrix<var, R, C>& y, var &lp) {
    ^
In file included from test/unit/math/fwd/mat/fun/unit_vector_constrain_test.cpp:2:
./stan/math/fwd/mat/fun/unit_vector_constrain.hpp:36:15: error: no viable conversion from 'stan::math::var' to 'const double'
      const T norm = sqrt(squared_norm);
              ^      ~~~~~~~~~~~~~~~~~~
```
If I reverse the order of the includes, then the test builds but does not call the fwd specialization and consequently does not yield the right derivatives. Also, calling check_positive_finite does not work in fwd mode; specifically the positive part works but the finite part does not because it can't find what it needs to test whether a `fvar<>` is finite with Boost.