### PR TITLE
Cleanup/issue 207 scrape and replace namespace level "using" statements

### DIFF
--- a/stan/math/fwd/mat/functor/gradient.hpp
+++ b/stan/math/fwd/mat/functor/gradient.hpp
@@ -8,8 +8,6 @@ namespace stan {
 
   namespace math {
 
-    using Eigen::Dynamic;
-
     /**
      * Calculate the value and the gradient of the specified function
      * at the specified argument.
@@ -42,10 +40,10 @@ namespace stan {
     template <typename T, typename F>
     void
     gradient(const F& f,
-             const Eigen::Matrix<T, Dynamic, 1>& x,
+             const Eigen::Matrix<T, Eigen::Dynamic, 1>& x,
              T& fx,
-             Eigen::Matrix<T, Dynamic, 1>& grad_fx) {
-      Eigen::Matrix<fvar<T>, Dynamic, 1> x_fvar(x.size());
+             Eigen::Matrix<T, Eigen::Dynamic, 1>& grad_fx) {
+      Eigen::Matrix<fvar<T>, Eigen::Dynamic, 1> x_fvar(x.size());
       grad_fx.resize(x.size());
       for (int i = 0; i < x.size(); ++i) {
         for (int k = 0; k < x.size(); ++k)

--- a/stan/math/fwd/mat/functor/jacobian.hpp
+++ b/stan/math/fwd/mat/functor/jacobian.hpp
@@ -9,15 +9,14 @@ namespace stan {
 
   namespace math {
 
-    using Eigen::Dynamic;
-
     template <typename T, typename F>
     void
     jacobian(const F& f,
-             const Eigen::Matrix<T, Dynamic, 1>& x,
-             Eigen::Matrix<T, Dynamic, 1>& fx,
-             Eigen::Matrix<T, Dynamic, Dynamic>& J) {
+             const Eigen::Matrix<T, Eigen::Dynamic, 1>& x,
+             Eigen::Matrix<T, Eigen::Dynamic, 1>& fx,
+             Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& J) {
       using Eigen::Matrix;
+      using Eigen::Dynamic;
       using stan::math::fvar;
       Matrix<fvar<T>, Dynamic, 1> x_fvar(x.size());
       for (int i = 0; i < x.size(); ++i) {

--- a/stan/math/fwd/scal/fun/log_mix.hpp
+++ b/stan/math/fwd/scal/fun/log_mix.hpp
@@ -10,8 +10,6 @@
 namespace stan {
 
   namespace math {
-    using boost::math::tools::promote_args;
-    using boost::is_same;
 
     /* Returns an array of size N with partials of log_mix wrt to its
      * parameters instantiated as fvar<T>
@@ -32,11 +30,13 @@ namespace stan {
                            const T_lambda1& lambda1,
                            const T_lambda2& lambda2,
                            typename
-                           promote_args<T_theta, T_lambda1, T_lambda2>::type
+                           boost::math::tools::promote_args<T_theta, T_lambda1, T_lambda2>::type
                            (&partials_array)[N]) {
+      using std::exp;
+      using boost::is_same;
+      using boost::math::tools::promote_args;
       typedef typename promote_args<T_theta, T_lambda1, T_lambda2>::type
         partial_return_type;
-      using std::exp;
 
       typename promote_args<T_lambda1, T_lambda2>::type lam2_m_lam1
         = lambda2 - lambda1;

--- a/stan/math/fwd/scal/fun/log_mix.hpp
+++ b/stan/math/fwd/scal/fun/log_mix.hpp
@@ -30,7 +30,8 @@ namespace stan {
                            const T_lambda1& lambda1,
                            const T_lambda2& lambda2,
                            typename
-                           boost::math::tools::promote_args<T_theta, T_lambda1, T_lambda2>::type
+                           boost::math::tools::promote_args<
+                             T_theta, T_lambda1, T_lambda2>::type
                            (&partials_array)[N]) {
       using std::exp;
       using boost::is_same;

--- a/stan/math/mix/mat/functor/derivative.hpp
+++ b/stan/math/mix/mat/functor/derivative.hpp
@@ -10,8 +10,6 @@ namespace stan {
 
   namespace math {
 
-    using Eigen::Dynamic;
-
     /**
      * Return the derivative of the specified univariate function at
      * the specified argument.

--- a/stan/math/mix/mat/functor/grad_hessian.hpp
+++ b/stan/math/mix/mat/functor/grad_hessian.hpp
@@ -45,7 +45,8 @@ namespace stan {
                  const Eigen::Matrix<double, Eigen::Dynamic, 1>& x,
                  double& fx,
                  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>& H,
-                 std::vector<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> >&
+                 std::vector<Eigen::Matrix<double,
+                   Eigen::Dynamic, Eigen::Dynamic> >&
                  grad_H) {
       using Eigen::Matrix;
       using Eigen::Dynamic;

--- a/stan/math/mix/mat/functor/grad_hessian.hpp
+++ b/stan/math/mix/mat/functor/grad_hessian.hpp
@@ -10,8 +10,6 @@ namespace stan {
 
   namespace math {
 
-    using Eigen::Dynamic;
-
     /**
      * Calculate the value, the Hessian, and the gradient of the Hessian
      * of the specified function at the specified argument.
@@ -44,12 +42,13 @@ namespace stan {
     template <typename F>
     void
     grad_hessian(const F& f,
-                 const Eigen::Matrix<double, Dynamic, 1>& x,
+                 const Eigen::Matrix<double, Eigen::Dynamic, 1>& x,
                  double& fx,
-                 Eigen::Matrix<double, Dynamic, Dynamic>& H,
-                 std::vector<Eigen::Matrix<double, Dynamic, Dynamic> >&
+                 Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>& H,
+                 std::vector<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> >&
                  grad_H) {
       using Eigen::Matrix;
+      using Eigen::Dynamic;
       fx = f(x);
       int d = x.size();
       H.resize(d, d);

--- a/stan/math/mix/mat/functor/grad_tr_mat_times_hessian.hpp
+++ b/stan/math/mix/mat/functor/grad_tr_mat_times_hessian.hpp
@@ -11,17 +11,19 @@ namespace stan {
 
   namespace math {
 
-    using Eigen::Dynamic;
 
     // FIXME: add other results that are easy to extract
     // // N * (fwd(2) + bk)
     template <typename F>
     void
-    grad_tr_mat_times_hessian(const F& f,
-                              const Eigen::Matrix<double, Dynamic, 1>& x,
-                              const Eigen::Matrix<double, Dynamic, Dynamic>& M,
-                              Eigen::Matrix<double, Dynamic, 1>& grad_tr_MH) {
+    grad_tr_mat_times_hessian(
+      const F& f,
+      const Eigen::Matrix<double, Eigen::Dynamic, 1>& x,
+      const Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>& M,
+      Eigen::Matrix<double, Eigen::Dynamic, 1>& grad_tr_MH
+    ) {
       using Eigen::Matrix;
+      using Eigen::Dynamic;
       start_nested();
       try {
         grad_tr_MH.resize(x.size());

--- a/stan/math/mix/mat/functor/gradient_dot_vector.hpp
+++ b/stan/math/mix/mat/functor/gradient_dot_vector.hpp
@@ -10,21 +10,19 @@ namespace stan {
 
   namespace math {
 
-    using Eigen::Dynamic;
-
     // aka directional derivative (not length normalized)
     // T2 must be assignable to T1
     template <typename T1, typename T2, typename F>
     void
     gradient_dot_vector(const F& f,
-                        const Eigen::Matrix<T1, Dynamic, 1>& x,
-                        const Eigen::Matrix<T2, Dynamic, 1>& v,
+                        const Eigen::Matrix<T1, Eigen::Dynamic, 1>& x,
+                        const Eigen::Matrix<T2, Eigen::Dynamic, 1>& v,
                         T1& fx,
                         T1& grad_fx_dot_v) {
       using stan::math::fvar;
       using stan::math::var;
       using Eigen::Matrix;
-      Matrix<fvar<T1>, Dynamic, 1> x_fvar(x.size());
+      Matrix<fvar<T1>, Eigen::Dynamic, 1> x_fvar(x.size());
       for (int i = 0; i < x.size(); ++i)
         x_fvar(i) = fvar<T1>(x(i), v(i));
       fvar<T1> fx_fvar = f(x_fvar);

--- a/stan/math/mix/mat/functor/hessian.hpp
+++ b/stan/math/mix/mat/functor/hessian.hpp
@@ -10,8 +10,6 @@ namespace stan {
 
   namespace math {
 
-    using Eigen::Dynamic;
-
     /**
      * Calculate the value, the gradient, and the Hessian,
      * of the specified function at the specified argument in
@@ -44,16 +42,16 @@ namespace stan {
     template <typename F>
     void
     hessian(const F& f,
-            const Eigen::Matrix<double, Dynamic, 1>& x,
+            const Eigen::Matrix<double, Eigen::Dynamic, 1>& x,
             double& fx,
-            Eigen::Matrix<double, Dynamic, 1>& grad,
-            Eigen::Matrix<double, Dynamic, Dynamic>& H) {
+            Eigen::Matrix<double, Eigen::Dynamic, 1>& grad,
+            Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>& H) {
       H.resize(x.size(), x.size());
       grad.resize(x.size());
       try {
         for (int i = 0; i < x.size(); ++i) {
           start_nested();
-          Eigen::Matrix<fvar<var>, Dynamic, 1> x_fvar(x.size());
+          Eigen::Matrix<fvar<var>, Eigen::Dynamic, 1> x_fvar(x.size());
           for (int j = 0; j < x.size(); ++j)
             x_fvar(j) = fvar<var>(x(j), i == j);
           fvar<var> fx_fvar = f(x_fvar);
@@ -73,13 +71,13 @@ namespace stan {
     template <typename T, typename F>
     void
     hessian(const F& f,
-            const Eigen::Matrix<T, Dynamic, 1>& x,
+            const Eigen::Matrix<T, Eigen::Dynamic, 1>& x,
             T& fx,
-            Eigen::Matrix<T, Dynamic, 1>& grad,
-            Eigen::Matrix<T, Dynamic, Dynamic>& H) {
+            Eigen::Matrix<T, Eigen::Dynamic, 1>& grad,
+            Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& H) {
       H.resize(x.size(), x.size());
       grad.resize(x.size());
-      Eigen::Matrix<fvar<fvar<T> >, Dynamic, 1> x_fvar(x.size());
+      Eigen::Matrix<fvar<fvar<T> >, Eigen::Dynamic, 1> x_fvar(x.size());
       for (int i = 0; i < x.size(); ++i) {
         for (int j = i; j < x.size(); ++j) {
           for (int k = 0; k < x.size(); ++k)

--- a/stan/math/mix/mat/functor/hessian_times_vector.hpp
+++ b/stan/math/mix/mat/functor/hessian_times_vector.hpp
@@ -10,21 +10,19 @@ namespace stan {
 
   namespace math {
 
-    using Eigen::Dynamic;
-
     template <typename F>
     void
     hessian_times_vector(const F& f,
-                         const Eigen::Matrix<double, Dynamic, 1>& x,
-                         const Eigen::Matrix<double, Dynamic, 1>& v,
+                         const Eigen::Matrix<double, Eigen::Dynamic, 1>& x,
+                         const Eigen::Matrix<double, Eigen::Dynamic, 1>& v,
                          double& fx,
-                         Eigen::Matrix<double, Dynamic, 1>& Hv) {
+                         Eigen::Matrix<double, Eigen::Dynamic, 1>& Hv) {
       using stan::math::fvar;
       using stan::math::var;
       using Eigen::Matrix;
       start_nested();
       try {
-        Matrix<var, Dynamic, 1> x_var(x.size());
+        Matrix<var, Eigen::Dynamic, 1> x_var(x.size());
         for (int i = 0; i < x_var.size(); ++i)
           x_var(i) = x(i);
         var fx_var;
@@ -44,13 +42,13 @@ namespace stan {
     template <typename T, typename F>
     void
     hessian_times_vector(const F& f,
-                         const Eigen::Matrix<T, Dynamic, 1>& x,
-                         const Eigen::Matrix<T, Dynamic, 1>& v,
+                         const Eigen::Matrix<T, Eigen::Dynamic, 1>& x,
+                         const Eigen::Matrix<T, Eigen::Dynamic, 1>& v,
                          T& fx,
-                         Eigen::Matrix<T, Dynamic, 1>& Hv) {
+                         Eigen::Matrix<T, Eigen::Dynamic, 1>& Hv) {
       using Eigen::Matrix;
-      Matrix<T, Dynamic, 1> grad;
-      Matrix<T, Dynamic, Dynamic> H;
+      Matrix<T, Eigen::Dynamic, 1> grad;
+      Matrix<T, Eigen::Dynamic, Eigen::Dynamic> H;
       hessian(f, x, fx, grad, H);
       Hv = H * v;
     }

--- a/stan/math/mix/mat/functor/partial_derivative.hpp
+++ b/stan/math/mix/mat/functor/partial_derivative.hpp
@@ -10,8 +10,6 @@ namespace stan {
 
   namespace math {
 
-    using Eigen::Dynamic;
-
     /**
      * Return the partial derivative of the specified multiivariate
      * function at the specified argument.
@@ -27,11 +25,11 @@ namespace stan {
     template <typename T, typename F>
     void
     partial_derivative(const F& f,
-                       const Eigen::Matrix<T, Dynamic, 1>& x,
+                       const Eigen::Matrix<T, Eigen::Dynamic, 1>& x,
                        int n,
                        T& fx,
                        T& dfx_dxn) {
-      Eigen::Matrix<fvar<T>, Dynamic, 1> x_fvar(x.size());
+      Eigen::Matrix<fvar<T>, Eigen::Dynamic, 1> x_fvar(x.size());
       for (int i = 0; i < x.size(); ++i)
         x_fvar(i) = fvar<T>(x(i), i == n);
       fvar<T> fx_fvar = f(x_fvar);

--- a/stan/math/prim/mat/err/check_cholesky_factor.hpp
+++ b/stan/math/prim/mat/err/check_cholesky_factor.hpp
@@ -9,7 +9,6 @@
 
 namespace stan {
   namespace math {
-    using Eigen::Dynamic;
     /**
      * Return <code>true</code> if the specified matrix is a valid
      * Cholesky factor.
@@ -33,9 +32,11 @@ namespace stan {
      */
     template <typename T_y>
     inline bool
-    check_cholesky_factor(const char* function,
-                          const char* name,
-                          const Eigen::Matrix<T_y, Dynamic, Dynamic>& y) {
+    check_cholesky_factor(
+      const char* function,
+      const char* name,
+      const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>& y
+    ) {
       check_less_or_equal(function, "columns and rows of Cholesky factor",
                           y.cols(), y.rows());
       check_positive(function, "columns of Cholesky factor", y.cols());

--- a/stan/math/prim/mat/err/check_cholesky_factor_corr.hpp
+++ b/stan/math/prim/mat/err/check_cholesky_factor_corr.hpp
@@ -11,7 +11,6 @@
 namespace stan {
 
   namespace math {
-    using Eigen::Dynamic;
     /**
      * Return <code>true</code> if the specified matrix is a valid
      * Cholesky factor of a correlation matrix.
@@ -37,9 +36,12 @@ namespace stan {
      */
     template <typename T_y>
     bool
-    check_cholesky_factor_corr(const char* function,
-                               const char* name,
-                               const Eigen::Matrix<T_y, Dynamic, Dynamic>& y) {
+    check_cholesky_factor_corr(
+      const char* function,
+      const char* name,
+      const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>& y
+    ) {
+      using Eigen::Dynamic;
       check_square(function, name, y);
       check_lower_triangular(function, name, y);
       for (int i = 0; i < y.rows(); ++i)

--- a/stan/math/prim/mat/err/check_corr_matrix.hpp
+++ b/stan/math/prim/mat/err/check_corr_matrix.hpp
@@ -16,7 +16,6 @@
 namespace stan {
 
   namespace math {
-    using Eigen::Dynamic;
     /**
      * Return <code>true</code> if the specified matrix is a valid
      * correlation matrix.
@@ -43,13 +42,16 @@ namespace stan {
      */
     template <typename T_y>
     inline bool
-    check_corr_matrix(const char* function,
-                      const char* name,
-                      const Eigen::Matrix<T_y, Dynamic, Dynamic>& y) {
+    check_corr_matrix(
+      const char* function,
+      const char* name,
+      const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>& y
+    ) {
       using Eigen::Matrix;
       using stan::math::index_type;
 
-      typedef typename index_type<Matrix<T_y, Dynamic, Dynamic> >::type size_t;
+      typedef typename index_type<Matrix<
+        T_y, Eigen::Dynamic, Eigen::Dynamic> >::type size_t;
 
       check_size_match(function,
                        "Rows of correlation matrix", y.rows(),

--- a/stan/math/prim/mat/err/check_cov_matrix.hpp
+++ b/stan/math/prim/mat/err/check_cov_matrix.hpp
@@ -6,7 +6,6 @@
 
 namespace stan {
   namespace math {
-    using Eigen::Dynamic;
     /**
      * Return <code>true</code> if the specified matrix is a valid
      * covariance matrix.
@@ -29,9 +28,11 @@ namespace stan {
      */
     template <typename T_y>
     inline bool
-    check_cov_matrix(const char* function,
-                     const char* name,
-                     const Eigen::Matrix<T_y, Dynamic, Dynamic>& y) {
+    check_cov_matrix(
+      const char* function,
+      const char* name,
+      const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>& y
+    ) {
       check_pos_definite(function, name, y);
       return true;
     }

--- a/stan/math/prim/mat/err/check_lower_triangular.hpp
+++ b/stan/math/prim/mat/err/check_lower_triangular.hpp
@@ -10,7 +10,6 @@
 namespace stan {
 
   namespace math {
-    using Eigen::Dynamic;
     /**
      * Return <code>true</code> if the specified matrix is lower
      * triangular.
@@ -32,9 +31,11 @@ namespace stan {
      */
     template <typename T_y>
     inline bool
-    check_lower_triangular(const char* function,
-                           const char* name,
-                           const Eigen::Matrix<T_y, Dynamic, Dynamic>& y) {
+    check_lower_triangular(
+      const char* function,
+      const char* name,
+      const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>& y
+    ) {
       for (int n = 1; n < y.cols(); ++n) {
         for (int m = 0; m < n && m < y.rows(); ++m) {
           if (y(m, n) != 0) {

--- a/stan/math/prim/mat/err/check_pos_definite.hpp
+++ b/stan/math/prim/mat/err/check_pos_definite.hpp
@@ -15,7 +15,6 @@
 namespace stan {
 
   namespace math {
-    using Eigen::Dynamic;
 
     /**
      * Return <code>true</code> if the specified square, symmetric
@@ -35,9 +34,11 @@ namespace stan {
      */
     template <typename T_y>
     inline bool
-    check_pos_definite(const char* function,
-                       const char* name,
-                       const Eigen::Matrix<T_y, Dynamic, Dynamic>& y) {
+    check_pos_definite(
+      const char* function,
+      const char* name,
+      const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>& y
+    ) {
       check_symmetric(function, name, y);
       check_positive_size(function, name, "rows", y.rows());
 

--- a/stan/math/prim/mat/err/check_pos_semidefinite.hpp
+++ b/stan/math/prim/mat/err/check_pos_semidefinite.hpp
@@ -14,7 +14,6 @@
 namespace stan {
 
   namespace math {
-    using Eigen::Dynamic;
     /**
      * Return <code>true</code> if the specified matrix is positive definite
      *
@@ -33,9 +32,11 @@ namespace stan {
      */
     template <typename T_y>
     inline bool
-    check_pos_semidefinite(const char* function,
-                           const char* name,
-                           const Eigen::Matrix<T_y, Dynamic, Dynamic>& y) {
+    check_pos_semidefinite(
+      const char* function,
+      const char* name,
+      const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>& y
+    ) {
       check_symmetric(function, name, y);
       check_positive_size(function, name, "rows", y.rows());
 

--- a/stan/math/prim/mat/err/check_spsd_matrix.hpp
+++ b/stan/math/prim/mat/err/check_spsd_matrix.hpp
@@ -9,7 +9,6 @@
 
 namespace stan {
   namespace math {
-    using Eigen::Dynamic;
     /**
      * Return <code>true</code> if the specified matrix is a
      * square, symmetric, and positive semi-definite.
@@ -29,9 +28,11 @@ namespace stan {
      */
     template <typename T_y>
     inline bool
-    check_spsd_matrix(const char* function,
-                      const char* name,
-                      const Eigen::Matrix<T_y, Dynamic, Dynamic>& y) {
+    check_spsd_matrix(
+      const char* function,
+      const char* name,
+      const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>& y
+    ) {
       check_square(function, name, y);
       check_positive_size(function, name, "rows()", y.rows());
       check_symmetric(function, name, y);

--- a/stan/math/prim/mat/err/check_symmetric.hpp
+++ b/stan/math/prim/mat/err/check_symmetric.hpp
@@ -14,7 +14,6 @@
 namespace stan {
 
   namespace math {
-    using Eigen::Dynamic;
 
     /**
      * Return <code>true</code> if the specified matrix is symmetric.
@@ -35,14 +34,17 @@ namespace stan {
      */
     template <typename T_y>
     inline bool
-    check_symmetric(const char* function,
-                    const char* name,
-                    const Eigen::Matrix<T_y, Dynamic, Dynamic>& y) {
+    check_symmetric(
+      const char* function,
+      const char* name,
+      const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>& y
+    ) {
       check_square(function, name, y);
 
       using Eigen::Matrix;
       using stan::math::index_type;
       using std::fabs;
+      using Eigen::Dynamic;
 
       typedef typename index_type<Matrix<T_y, Dynamic, Dynamic> >::type
         size_type;

--- a/stan/math/prim/mat/err/check_unit_vector.hpp
+++ b/stan/math/prim/mat/err/check_unit_vector.hpp
@@ -35,7 +35,8 @@ namespace stan {
     template <typename T_prob>
     bool check_unit_vector(const char* function,
                            const char* name,
-                           const Eigen::Matrix<T_prob, Eigen::Dynamic, 1>& theta) {
+                           const Eigen::Matrix<T_prob,
+                             Eigen::Dynamic, 1>& theta) {
       check_nonzero_size(function, name, theta);
       T_prob ssq = theta.squaredNorm();
       if (!(fabs(1.0 - ssq) <= CONSTRAINT_TOLERANCE)) {

--- a/stan/math/prim/mat/err/check_unit_vector.hpp
+++ b/stan/math/prim/mat/err/check_unit_vector.hpp
@@ -11,8 +11,6 @@
 namespace stan {
 
   namespace math {
-    using Eigen::Dynamic;
-
     /**
      * Return <code>true</code> if the specified vector is unit vector.
      *
@@ -37,7 +35,7 @@ namespace stan {
     template <typename T_prob>
     bool check_unit_vector(const char* function,
                            const char* name,
-                           const Eigen::Matrix<T_prob, Dynamic, 1>& theta) {
+                           const Eigen::Matrix<T_prob, Eigen::Dynamic, 1>& theta) {
       check_nonzero_size(function, name, theta);
       T_prob ssq = theta.squaredNorm();
       if (!(fabs(1.0 - ssq) <= CONSTRAINT_TOLERANCE)) {

--- a/stan/math/prim/mat/fun/quad_form_diag.hpp
+++ b/stan/math/prim/mat/fun/quad_form_diag.hpp
@@ -11,8 +11,9 @@ namespace stan {
   namespace math {
 
     template <typename T1, typename T2, int R, int C>
-    inline Eigen::Matrix
-    <typename boost::math::tools::promote_args<T1, T2>::type, Eigen::Dynamic, Eigen::Dynamic>
+    inline Eigen::Matrix <
+    typename boost::math::tools::promote_args<T1, T2>::type, 
+      Eigen::Dynamic, Eigen::Dynamic>
     quad_form_diag(const Eigen::Matrix<T1, Eigen::Dynamic, Eigen::Dynamic>& mat,
                    const Eigen::Matrix<T2, R, C>& vec) {
       using boost::math::tools::promote_args;
@@ -21,8 +22,8 @@ namespace stan {
       int size = vec.size();
       stan::math::check_equal("quad_form_diag", "matrix size", mat.rows(),
                               size);
-      Eigen::Matrix<typename promote_args<T1, T2>::type, Eigen::Dynamic, Eigen::Dynamic>
-        result(size, size);
+      Eigen::Matrix<typename promote_args<T1, T2>::type, 
+        Eigen::Dynamic, Eigen::Dynamic> result(size, size);
       for (int i = 0; i < size; i++) {
         result(i, i) = vec(i)*vec(i)*mat(i, i);
         for (int j = i+1; j < size; ++j) {

--- a/stan/math/prim/mat/fun/quad_form_diag.hpp
+++ b/stan/math/prim/mat/fun/quad_form_diag.hpp
@@ -10,21 +10,18 @@
 namespace stan {
   namespace math {
 
-    using Eigen::Dynamic;
-    using Eigen::Matrix;
-    using boost::math::tools::promote_args;
-
     template <typename T1, typename T2, int R, int C>
-    inline Matrix
-    <typename promote_args<T1, T2>::type, Dynamic, Dynamic>
-    quad_form_diag(const Matrix<T1, Dynamic, Dynamic>& mat,
-                   const Matrix<T2, R, C>& vec) {
+    inline Eigen::Matrix
+    <typename boost::math::tools::promote_args<T1, T2>::type, Eigen::Dynamic, Eigen::Dynamic>
+    quad_form_diag(const Eigen::Matrix<T1, Eigen::Dynamic, Eigen::Dynamic>& mat,
+                   const Eigen::Matrix<T2, R, C>& vec) {
+      using boost::math::tools::promote_args;
       stan::math::check_vector("quad_form_diag", "vec", vec);
       stan::math::check_square("quad_form_diag", "mat", mat);
       int size = vec.size();
       stan::math::check_equal("quad_form_diag", "matrix size", mat.rows(),
                               size);
-      Matrix<typename promote_args<T1, T2>::type, Dynamic, Dynamic>
+      Eigen::Matrix<typename promote_args<T1, T2>::type, Eigen::Dynamic, Eigen::Dynamic>
         result(size, size);
       for (int i = 0; i < size; i++) {
         result(i, i) = vec(i)*vec(i)*mat(i, i);

--- a/stan/math/prim/mat/fun/quad_form_diag.hpp
+++ b/stan/math/prim/mat/fun/quad_form_diag.hpp
@@ -12,7 +12,7 @@ namespace stan {
 
     template <typename T1, typename T2, int R, int C>
     inline Eigen::Matrix <
-    typename boost::math::tools::promote_args<T1, T2>::type, 
+    typename boost::math::tools::promote_args<T1, T2>::type,
       Eigen::Dynamic, Eigen::Dynamic>
     quad_form_diag(const Eigen::Matrix<T1, Eigen::Dynamic, Eigen::Dynamic>& mat,
                    const Eigen::Matrix<T2, R, C>& vec) {
@@ -22,7 +22,7 @@ namespace stan {
       int size = vec.size();
       stan::math::check_equal("quad_form_diag", "matrix size", mat.rows(),
                               size);
-      Eigen::Matrix<typename promote_args<T1, T2>::type, 
+      Eigen::Matrix<typename promote_args<T1, T2>::type,
         Eigen::Dynamic, Eigen::Dynamic> result(size, size);
       for (int i = 0; i < size; i++) {
         result(i, i) = vec(i)*vec(i)*mat(i, i);

--- a/stan/math/prim/mat/fun/to_array_1d.hpp
+++ b/stan/math/prim/mat/fun/to_array_1d.hpp
@@ -8,18 +8,16 @@
 namespace stan {
   namespace math {
 
-    using Eigen::Dynamic;
-    using Eigen::Matrix;
-    using std::vector;
-
     // real[] to_array_1d(matrix)
-    // real[] to_array_1d(row_vector)
-    // real[] to_array_1d(vector)
+    // real[] to_array_1d(row_std::vector)
+    // real[] to_array_1d(std::vector)
     template <typename T, int R, int C>
-    inline vector<T> to_array_1d(const Matrix<T, R, C> & matrix) {
+    inline std::vector<T> to_array_1d(
+      const Eigen::Matrix<T, R, C> & matrix
+    ) {
       const T* datap = matrix.data();
       int size = matrix.size();
-      vector<T> result(size);
+      std::vector<T> result(size);
       for (int i=0; i < size; i++)
         result[i] = datap[i];
       return result;
@@ -27,20 +25,20 @@ namespace stan {
 
     // real[] to_array_1d(...)
     template <typename T>
-    inline vector<T>
-    to_array_1d(const vector<T> & x) {
+    inline std::vector<T>
+    to_array_1d(const std::vector<T> & x) {
       return x;
     }
 
     // real[] to_array_1d(...)
     template <typename T>
-    inline vector<typename scalar_type<T>::type>
-    to_array_1d(const vector< vector<T> > & x) {
+    inline std::vector<typename scalar_type<T>::type>
+    to_array_1d(const std::vector< std::vector<T> > & x) {
       size_t size1 = x.size();
       size_t size2 = 0;
       if (size1 != 0)
         size2 = x[0].size();
-      vector<T> y(size1*size2);
+      std::vector<T> y(size1*size2);
       for (size_t i = 0, ij = 0; i < size1; i++)
         for (size_t j = 0; j < size2; j++, ij++)
           y[ij] = x[i][j];

--- a/stan/math/prim/mat/fun/to_array_1d.hpp
+++ b/stan/math/prim/mat/fun/to_array_1d.hpp
@@ -9,8 +9,8 @@ namespace stan {
   namespace math {
 
     // real[] to_array_1d(matrix)
-    // real[] to_array_1d(row_std::vector)
-    // real[] to_array_1d(std::vector)
+    // real[] to_array_1d(row_vector)
+    // real[] to_array_1d(vector)
     template <typename T, int R, int C>
     inline std::vector<T> to_array_1d(
       const Eigen::Matrix<T, R, C> & matrix

--- a/stan/math/prim/mat/fun/to_array_2d.hpp
+++ b/stan/math/prim/mat/fun/to_array_2d.hpp
@@ -7,14 +7,11 @@
 namespace stan {
   namespace math {
 
-    using Eigen::Dynamic;
-    using Eigen::Matrix;
-    using std::vector;
-
     // real[, ] to_array_2d(matrix)
     template <typename T>
-    inline vector< vector<T> >
-    to_array_2d(const Matrix<T, Dynamic, Dynamic> & matrix) {
+    inline std::vector< std::vector<T> >
+    to_array_2d(const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> & matrix) {
+      using std::vector;
       const T* datap = matrix.data();
       int C = matrix.cols();
       int R = matrix.rows();

--- a/stan/math/prim/mat/fun/to_array_2d.hpp
+++ b/stan/math/prim/mat/fun/to_array_2d.hpp
@@ -10,7 +10,9 @@ namespace stan {
     // real[, ] to_array_2d(matrix)
     template <typename T>
     inline std::vector< std::vector<T> >
-    to_array_2d(const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> & matrix) {
+    to_array_2d(
+      const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> & matrix
+    ) {
       using std::vector;
       const T* datap = matrix.data();
       int C = matrix.cols();

--- a/stan/math/prim/mat/fun/to_matrix.hpp
+++ b/stan/math/prim/mat/fun/to_matrix.hpp
@@ -8,51 +8,47 @@
 namespace stan {
   namespace math {
 
-    using Eigen::Dynamic;
-    using Eigen::Matrix;
-    using std::vector;
-
     // matrix to_matrix(matrix)
     // matrix to_matrix(vector)
     // matrix to_matrix(row_vector)
     template <typename T, int R, int C>
-    inline Matrix<T, Dynamic, Dynamic>
-    to_matrix(Matrix<T, R, C> matrix) {
+    inline Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>
+    to_matrix(Eigen::Matrix<T, R, C> matrix) {
       return matrix;
     }
 
     // matrix to_matrix(real[, ])
     template <typename T>
-    inline Matrix<T, Dynamic, Dynamic>
-    to_matrix(const vector< vector<T> > & vec) {
+    inline Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>
+    to_matrix(const std::vector< std::vector<T> > & vec) {
       size_t R = vec.size();
       if (R != 0) {
         size_t C = vec[0].size();
-        Matrix<T, Dynamic, Dynamic> result(R, C);
+        Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> result(R, C);
         T* datap = result.data();
         for (size_t i=0, ij=0; i < C; i++)
           for (size_t j=0; j < R; j++, ij++)
             datap[ij] = vec[j][i];
         return result;
       } else {
-        return Matrix<T, Dynamic, Dynamic> (0, 0);
+        return Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> (0, 0);
       }
     }
 
     // matrix to_matrix(int[, ])
-    inline Matrix<double, Dynamic, Dynamic>
-    to_matrix(const vector< vector<int> > & vec) {
+    inline Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>
+    to_matrix(const std::vector< std::vector<int> > & vec) {
       size_t R = vec.size();
       if (R != 0) {
         size_t C = vec[0].size();
-        Matrix<double, Dynamic, Dynamic> result(R, C);
+        Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> result(R, C);
         double* datap = result.data();
         for (size_t i=0, ij=0; i < C; i++)
           for (size_t j=0; j < R; j++, ij++)
             datap[ij] = vec[j][i];
         return result;
       } else {
-        return Matrix<double, Dynamic, Dynamic> (0, 0);
+        return Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> (0, 0);
       }
     }
 

--- a/stan/math/prim/mat/fun/to_row_vector.hpp
+++ b/stan/math/prim/mat/fun/to_row_vector.hpp
@@ -2,12 +2,12 @@
 #define STAN_MATH_PRIM_MAT_FUN_TO_ROW_VECTOR_HPP
 
 #include <stan/math/prim/mat/fun/Eigen.hpp>
- // stan::scalar_type
+// stan::scalar_type
 #include <vector>
 
 namespace stan {
   namespace math {
-   
+
     // row_vector to_row_vector(matrix)
     // row_vector to_row_vector(vector)
     // row_vector to_row_vector(row_vector)

--- a/stan/math/prim/mat/fun/to_row_vector.hpp
+++ b/stan/math/prim/mat/fun/to_row_vector.hpp
@@ -7,33 +7,29 @@
 
 namespace stan {
   namespace math {
-
-    using Eigen::Dynamic;
-    using Eigen::Matrix;
-    using std::vector;
-
+   
     // row_vector to_row_vector(matrix)
     // row_vector to_row_vector(vector)
     // row_vector to_row_vector(row_vector)
     template <typename T, int R, int C>
-    inline Matrix<T, 1, Dynamic>
-    to_row_vector(const Matrix<T, R, C>& matrix) {
-      return Matrix<T, 1, Dynamic>::Map(matrix.data(),
+    inline Eigen::Matrix<T, 1, Eigen::Dynamic>
+    to_row_vector(const Eigen::Matrix<T, R, C>& matrix) {
+      return Eigen::Matrix<T, 1, Eigen::Dynamic>::Map(matrix.data(),
                                         matrix.rows()*matrix.cols());
     }
 
     // row_vector to_row_vector(real[])
     template <typename T>
-    inline Matrix<T, 1, Dynamic>
-    to_row_vector(const vector<T> & vec) {
-      return Matrix<T, 1, Dynamic>::Map(vec.data(), vec.size());
+    inline Eigen::Matrix<T, 1, Eigen::Dynamic>
+    to_row_vector(const std::vector<T> & vec) {
+      return Eigen::Matrix<T, 1, Eigen::Dynamic>::Map(vec.data(), vec.size());
     }
 
     // row_vector to_row_vector(int[])
-    inline Matrix<double, 1, Dynamic>
-    to_row_vector(const vector<int> & vec) {
+    inline Eigen::Matrix<double, 1, Eigen::Dynamic>
+    to_row_vector(const std::vector<int> & vec) {
       int C = vec.size();
-      Matrix<double, 1, Dynamic> result(C);
+      Eigen::Matrix<double, 1, Eigen::Dynamic> result(C);
       double* datap = result.data();
       for (int i=0; i < C; i++)
         datap[i] = vec[i];

--- a/stan/math/prim/mat/fun/to_vector.hpp
+++ b/stan/math/prim/mat/fun/to_vector.hpp
@@ -7,33 +7,29 @@
 
 namespace stan {
   namespace math {
-
-    using Eigen::Dynamic;
-    using Eigen::Matrix;
-    using std::vector;
-
+    
     // vector to_vector(matrix)
     // vector to_vector(row_vector)
     // vector to_vector(vector)
     template <typename T, int R, int C>
-    inline Matrix<T, Dynamic, 1>
-    to_vector(const Matrix<T, R, C>& matrix) {
-      return Matrix<T, Dynamic, 1>::Map(matrix.data(),
+    inline Eigen::Matrix<T, Eigen::Dynamic, 1>
+    to_vector(const Eigen::Matrix<T, R, C>& matrix) {
+      return Eigen::Matrix<T, Eigen::Dynamic, 1>::Map(matrix.data(),
                                         matrix.rows()*matrix.cols());
     }
 
     // vector to_vector(real[])
     template <typename T>
-    inline Matrix<T, Dynamic, 1>
-    to_vector(const vector<T> & vec) {
-      return Matrix<T, Dynamic, 1>::Map(vec.data(), vec.size());
+    inline Eigen::Matrix<T, Eigen::Dynamic, 1>
+    to_vector(const std::vector<T> & vec) {
+      return Eigen::Matrix<T, Eigen::Dynamic, 1>::Map(vec.data(), vec.size());
     }
 
     // vector to_vector(int[])
-    inline Matrix<double, Dynamic, 1>
-    to_vector(const vector<int> & vec) {
+    inline Eigen::Matrix<double, Eigen::Dynamic, 1>
+    to_vector(const std::vector<int> & vec) {
       int R = vec.size();
-      Matrix<double, Dynamic, 1> result(R);
+      Eigen::Matrix<double, Eigen::Dynamic, 1> result(R);
       double* datap = result.data();
       for (int i=0; i < R; i++)
         datap[i] = vec[i];

--- a/stan/math/prim/mat/fun/to_vector.hpp
+++ b/stan/math/prim/mat/fun/to_vector.hpp
@@ -7,7 +7,7 @@
 
 namespace stan {
   namespace math {
-    
+
     // vector to_vector(matrix)
     // vector to_vector(row_vector)
     // vector to_vector(vector)

--- a/stan/math/prim/mat/prob/multi_normal_cholesky_log.hpp
+++ b/stan/math/prim/mat/prob/multi_normal_cholesky_log.hpp
@@ -127,8 +127,8 @@ namespace stan {
       if (include_summand<propto, T_y, T_loc, T_covar_elem>::value) {
         lp_type sum_lp_vec(0.0);
         for (size_t i = 0; i < size_vec; i++) {
-          Eigen::Matrix<typename return_type<T_y, T_loc>::type, Eigen::Dynamic, 1>
-            y_minus_mu(size_y);
+          Eigen::Matrix<typename return_type<T_y, T_loc>::type,
+            Eigen::Dynamic, 1> y_minus_mu(size_y);
           for (int j = 0; j < size_y; j++)
             y_minus_mu(j) = y_vec[i](j)-mu_vec[i](j);
           Eigen::Matrix<typename return_type<T_y, T_loc, T_covar>::type,

--- a/stan/math/prim/mat/prob/multi_normal_cholesky_log.hpp
+++ b/stan/math/prim/mat/prob/multi_normal_cholesky_log.hpp
@@ -25,8 +25,6 @@
 namespace stan {
 
   namespace math {
-    using Eigen::Dynamic;
-
     /**
      * The log of the multivariate normal density for the given y, mu, and
      * a Cholesky factor L of the variance matrix.
@@ -129,19 +127,19 @@ namespace stan {
       if (include_summand<propto, T_y, T_loc, T_covar_elem>::value) {
         lp_type sum_lp_vec(0.0);
         for (size_t i = 0; i < size_vec; i++) {
-          Eigen::Matrix<typename return_type<T_y, T_loc>::type, Dynamic, 1>
+          Eigen::Matrix<typename return_type<T_y, T_loc>::type, Eigen::Dynamic, 1>
             y_minus_mu(size_y);
           for (int j = 0; j < size_y; j++)
             y_minus_mu(j) = y_vec[i](j)-mu_vec[i](j);
           Eigen::Matrix<typename return_type<T_y, T_loc, T_covar>::type,
-                        Dynamic, 1>
+                        Eigen::Dynamic, 1>
             half(mdivide_left_tri_low(L, y_minus_mu));
           // FIXME: this code does not compile. revert after fixing subtract()
           // Eigen::Matrix<typename
           //               boost::math::tools::promote_args<T_covar,
           //                 typename value_type<T_loc>::type,
           //                 typename value_type<T_y>::type>::type>::type,
-          //               Dynamic, 1>
+          //               Eigen::Dynamic, 1>
           //   half(mdivide_left_tri_low(L, subtract(y, mu)));
           sum_lp_vec += dot_self(half);
         }

--- a/stan/math/prim/mat/prob/multi_normal_cholesky_rng.hpp
+++ b/stan/math/prim/mat/prob/multi_normal_cholesky_rng.hpp
@@ -24,13 +24,13 @@
 namespace stan {
 
   namespace math {
-    using Eigen::Dynamic;
-
     template <class RNG>
     inline Eigen::VectorXd
-    multi_normal_cholesky_rng(const Eigen::Matrix<double, Dynamic, 1>& mu,
-                              const Eigen::Matrix<double, Dynamic, Dynamic>& S,
-                              RNG& rng) {
+    multi_normal_cholesky_rng(
+      const Eigen::Matrix<double, Eigen::Dynamic, 1>& mu,
+      const Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>& S,
+      RNG& rng
+    ) {
       using boost::variate_generator;
       using boost::normal_distribution;
 

--- a/stan/math/prim/mat/prob/multi_normal_log.hpp
+++ b/stan/math/prim/mat/prob/multi_normal_log.hpp
@@ -20,7 +20,6 @@
 namespace stan {
 
   namespace math {
-    using Eigen::Dynamic;
 
     template <bool propto,
               typename T_y, typename T_loc, typename T_covar>
@@ -39,6 +38,7 @@ namespace stan {
       using stan::math::check_positive;
       using stan::math::check_symmetric;
       using stan::math::check_ldlt_factor;
+      using Eigen::Dynamic;
 
       check_positive(function, "Covariance matrix rows", Sigma.rows());
       check_symmetric(function, "Covariance matrix", Sigma);

--- a/stan/math/prim/mat/prob/multi_normal_prec_log.hpp
+++ b/stan/math/prim/mat/prob/multi_normal_prec_log.hpp
@@ -54,7 +54,8 @@ namespace stan {
       check_positive(function, "Precision matrix rows", Sigma.rows());
       check_symmetric(function, "Precision matrix", Sigma);
 
-      LDLT_factor<T_covar_elem, Eigen::Dynamic, Eigen::Dynamic> ldlt_Sigma(Sigma);
+      LDLT_factor<T_covar_elem,
+        Eigen::Dynamic, Eigen::Dynamic> ldlt_Sigma(Sigma);
       check_ldlt_factor(function, "LDLT_Factor of precision parameter",
                         ldlt_Sigma);
 
@@ -125,8 +126,8 @@ namespace stan {
       if (include_summand<propto, T_y, T_loc, T_covar_elem>::value) {
         lp_type sum_lp_vec(0.0);
         for (size_t i = 0; i < size_vec; i++) {
-          Eigen::Matrix<typename return_type<T_y, T_loc>::type, Eigen::Dynamic, 1>
-            y_minus_mu(size_y);
+          Eigen::Matrix<typename return_type<T_y, T_loc>::type,
+            Eigen::Dynamic, 1> y_minus_mu(size_y);
           for (int j = 0; j < size_y; j++)
             y_minus_mu(j) = y_vec[i](j) - mu_vec[i](j);
           sum_lp_vec += trace_quad_form(Sigma, y_minus_mu);

--- a/stan/math/prim/mat/prob/multi_normal_prec_log.hpp
+++ b/stan/math/prim/mat/prob/multi_normal_prec_log.hpp
@@ -28,7 +28,6 @@
 namespace stan {
 
   namespace math {
-    using Eigen::Dynamic;
 
     template <bool propto,
               typename T_y, typename T_loc, typename T_covar>
@@ -55,7 +54,7 @@ namespace stan {
       check_positive(function, "Precision matrix rows", Sigma.rows());
       check_symmetric(function, "Precision matrix", Sigma);
 
-      LDLT_factor<T_covar_elem, Dynamic, Dynamic> ldlt_Sigma(Sigma);
+      LDLT_factor<T_covar_elem, Eigen::Dynamic, Eigen::Dynamic> ldlt_Sigma(Sigma);
       check_ldlt_factor(function, "LDLT_Factor of precision parameter",
                         ldlt_Sigma);
 
@@ -126,7 +125,7 @@ namespace stan {
       if (include_summand<propto, T_y, T_loc, T_covar_elem>::value) {
         lp_type sum_lp_vec(0.0);
         for (size_t i = 0; i < size_vec; i++) {
-          Eigen::Matrix<typename return_type<T_y, T_loc>::type, Dynamic, 1>
+          Eigen::Matrix<typename return_type<T_y, T_loc>::type, Eigen::Dynamic, 1>
             y_minus_mu(size_y);
           for (int j = 0; j < size_y; j++)
             y_minus_mu(j) = y_vec[i](j) - mu_vec[i](j);

--- a/stan/math/prim/mat/prob/multi_normal_rng.hpp
+++ b/stan/math/prim/mat/prob/multi_normal_rng.hpp
@@ -18,13 +18,14 @@
 namespace stan {
 
   namespace math {
-    using Eigen::Dynamic;
 
     template <class RNG>
     inline Eigen::VectorXd
-    multi_normal_rng(const Eigen::Matrix<double, Dynamic, 1>& mu,
-                     const Eigen::Matrix<double, Dynamic, Dynamic>& S,
-                     RNG& rng) {
+    multi_normal_rng(
+      const Eigen::Matrix<double, Eigen::Dynamic, 1>& mu,
+      const Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>& S,
+      RNG& rng
+    ) {
       using boost::variate_generator;
       using boost::normal_distribution;
 

--- a/stan/math/prim/mat/prob/multi_student_t_log.hpp
+++ b/stan/math/prim/mat/prob/multi_student_t_log.hpp
@@ -124,7 +124,8 @@ namespace stan {
       check_symmetric(function, "Scale parameter", Sigma);
 
 
-      LDLT_factor<T_scale_elem, Eigen::Dynamic, Eigen::Dynamic> ldlt_Sigma(Sigma);
+      LDLT_factor<T_scale_elem,
+        Eigen::Dynamic, Eigen::Dynamic> ldlt_Sigma(Sigma);
       check_ldlt_factor(function, "LDLT_Factor of scale parameter", ldlt_Sigma);
 
       if (size_y == 0)  // y_vec[0].size() == 0
@@ -152,8 +153,8 @@ namespace stan {
       if (include_summand<propto, T_y, T_dof, T_loc, T_scale_elem>::value) {
         lp_type sum_lp_vec(0.0);
         for (size_t i = 0; i < size_vec; i++) {
-          Eigen::Matrix<typename return_type<T_y, T_loc>::type, Eigen::Dynamic, 1>
-            y_minus_mu(size_y);
+          Eigen::Matrix<typename return_type<T_y, T_loc>::type,
+            Eigen::Dynamic, 1> y_minus_mu(size_y);
           for (int j = 0; j < size_y; j++)
             y_minus_mu(j) = y_vec[i](j)-mu_vec[i](j);
           sum_lp_vec += log1p(trace_inv_quad_form_ldlt(ldlt_Sigma, y_minus_mu)

--- a/stan/math/prim/mat/prob/multi_student_t_log.hpp
+++ b/stan/math/prim/mat/prob/multi_student_t_log.hpp
@@ -24,7 +24,6 @@
 namespace stan {
 
   namespace math {
-    using Eigen::Dynamic;
     /**
      * Return the log of the multivariate Student t distribution
      * at the specified arguments.
@@ -125,7 +124,7 @@ namespace stan {
       check_symmetric(function, "Scale parameter", Sigma);
 
 
-      LDLT_factor<T_scale_elem, Dynamic, Dynamic> ldlt_Sigma(Sigma);
+      LDLT_factor<T_scale_elem, Eigen::Dynamic, Eigen::Dynamic> ldlt_Sigma(Sigma);
       check_ldlt_factor(function, "LDLT_Factor of scale parameter", ldlt_Sigma);
 
       if (size_y == 0)  // y_vec[0].size() == 0
@@ -153,7 +152,7 @@ namespace stan {
       if (include_summand<propto, T_y, T_dof, T_loc, T_scale_elem>::value) {
         lp_type sum_lp_vec(0.0);
         for (size_t i = 0; i < size_vec; i++) {
-          Eigen::Matrix<typename return_type<T_y, T_loc>::type, Dynamic, 1>
+          Eigen::Matrix<typename return_type<T_y, T_loc>::type, Eigen::Dynamic, 1>
             y_minus_mu(size_y);
           for (int j = 0; j < size_y; j++)
             y_minus_mu(j) = y_vec[i](j)-mu_vec[i](j);

--- a/stan/math/prim/mat/prob/multi_student_t_rng.hpp
+++ b/stan/math/prim/mat/prob/multi_student_t_rng.hpp
@@ -23,7 +23,7 @@
 namespace stan {
 
   namespace math {
-    
+
     template <class RNG>
     inline Eigen::VectorXd
     multi_student_t_rng(

--- a/stan/math/prim/mat/prob/multi_student_t_rng.hpp
+++ b/stan/math/prim/mat/prob/multi_student_t_rng.hpp
@@ -23,14 +23,15 @@
 namespace stan {
 
   namespace math {
-    using Eigen::Dynamic;
-
+    
     template <class RNG>
     inline Eigen::VectorXd
-    multi_student_t_rng(const double nu,
-                        const Eigen::Matrix<double, Dynamic, 1>& mu,
-                        const Eigen::Matrix<double, Dynamic, Dynamic>& s,
-                        RNG& rng) {
+    multi_student_t_rng(
+      const double nu,
+      const Eigen::Matrix<double, Eigen::Dynamic, 1>& mu,
+      const Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>& s,
+      RNG& rng
+    ) {
       static const char* function("stan::math::multi_student_t_rng");
 
       using stan::math::check_finite;

--- a/stan/math/rev/mat/functor/gradient.hpp
+++ b/stan/math/rev/mat/functor/gradient.hpp
@@ -8,8 +8,6 @@ namespace stan {
 
   namespace math {
 
-    using Eigen::Dynamic;
-
     /**
      * Calculate the value and the gradient of the specified function
      * at the specified argument.
@@ -42,13 +40,13 @@ namespace stan {
     template <typename F>
     void
     gradient(const F& f,
-             const Eigen::Matrix<double, Dynamic, 1>& x,
+             const Eigen::Matrix<double, Eigen::Dynamic, 1>& x,
              double& fx,
-             Eigen::Matrix<double, Dynamic, 1>& grad_fx) {
+             Eigen::Matrix<double, Eigen::Dynamic, 1>& grad_fx) {
       using stan::math::var;
       start_nested();
       try {
-        Eigen::Matrix<var, Dynamic, 1> x_var(x.size());
+        Eigen::Matrix<var, Eigen::Dynamic, 1> x_var(x.size());
         for (int i = 0; i < x.size(); ++i)
           x_var(i) = x(i);
         var fx_var = f(x_var);

--- a/stan/math/rev/mat/functor/jacobian.hpp
+++ b/stan/math/rev/mat/functor/jacobian.hpp
@@ -8,15 +8,15 @@
 namespace stan {
 
   namespace math {
-    using Eigen::Dynamic;
 
     template <typename F>
     void
     jacobian(const F& f,
-             const Eigen::Matrix<double, Dynamic, 1>& x,
-             Eigen::Matrix<double, Dynamic, 1>& fx,
-             Eigen::Matrix<double, Dynamic, Dynamic>& J) {
+             const Eigen::Matrix<double, Eigen::Dynamic, 1>& x,
+             Eigen::Matrix<double, Eigen::Dynamic, 1>& fx,
+             Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>& J) {
       using Eigen::Matrix;
+      using Eigen::Dynamic;
       using stan::math::var;
       start_nested();
       try {


### PR DESCRIPTION
Locally passes all math unit tests, I assume this means I didn't leave a meaningless name anywhere...  this only catches the stray namespace-level 'using' statements that follow within five lines of a namespace statement so it might miss some.  