### PR TITLE
#include <stdexcept>

### DIFF
--- a/stan/math/prim/scal/meta/container_view.hpp
+++ b/stan/math/prim/scal/meta/container_view.hpp
@@ -1,8 +1,8 @@
 #ifndef STAN_MATH_PRIM_SCAL_META_CONTAINER_VIEW_HPP
 #define STAN_MATH_PRIM_SCAL_META_CONTAINER_VIEW_HPP
 
-#include <stdexcept>
 #include <stan/math/prim/scal/meta/scalar_type.hpp>
+#include <stdexcept>
 
 namespace stan {
 

--- a/stan/math/prim/scal/meta/container_view.hpp
+++ b/stan/math/prim/scal/meta/container_view.hpp
@@ -1,6 +1,7 @@
 #ifndef STAN_MATH_PRIM_SCAL_META_CONTAINER_VIEW_HPP
 #define STAN_MATH_PRIM_SCAL_META_CONTAINER_VIEW_HPP
 
+#include <stdexcept>
 #include <stan/math/prim/scal/meta/scalar_type.hpp>
 
 namespace stan {


### PR DESCRIPTION
It's needed in `stan/math/prim/scal/meta/container_view.hpp`.

Closes #223 