### PR TITLE
Update gitignore to ignore temporary dependency files generated by make

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,7 +43,7 @@
 
 # depedencies files
 *.d
-*.hpp.d.*
+*.d.*
 .Rproj.user
 .kdev4/
 .Rapp.history


### PR DESCRIPTION
#### Summary:

Fixes #228. Updates the gitignore file to ignore dependency files.

#### How to Verify:

Create a file called `foo.d.123` in any directory and it should be gitignored.

#### Side Effects:

None.

#### Documentation:

None.

#### Reviewer Suggestions: 

Anyone.