### PR TITLE
Adding documentation for is_vector_like template metaprogram

### DIFF
--- a/stan/math/prim/mat/meta/is_vector_like.hpp
+++ b/stan/math/prim/mat/meta/is_vector_like.hpp
@@ -6,7 +6,18 @@
 
 namespace stan {
 
-  // handles eigen matrix
+  /**
+   * Template metaprogram indicates whether a type is vector_like.
+   *
+   * A type is vector_like if an instance can be accessed like a
+   * vector, i.e. square brackets.
+   *
+   * Access is_vector_like::value for the result.
+   *
+   * This metaprogram removes the const qualifier.
+   *
+   * @tparam T Type to test
+   */
   template <typename T>
   struct is_vector_like<Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> > {
     enum { value = true };

--- a/stan/math/prim/scal/meta/is_vector_like.hpp
+++ b/stan/math/prim/scal/meta/is_vector_like.hpp
@@ -5,18 +5,51 @@
 
 namespace stan {
 
-  // ****************** additions for new VV *************************
-
-  // handles scalar, eigen vec, eigen row vec, std vec
+  /**
+   * Template metaprogram indicates whether a type is vector_like.
+   *
+   * A type is vector_like if an instance can be accessed like a
+   * vector, i.e. square brackets.
+   *
+   * Access is_vector_like::value for the result.
+   *
+   * Default behavior is to use the is_vector template metaprogram.
+   *
+   * @tparam T Type to test
+   */
   template <typename T>
   struct is_vector_like {
     enum { value = stan::is_vector<T>::value };
   };
+
+  /**
+   * Template metaprogram indicates whether a type is vector_like.
+   *
+   * A type is vector_like if an instance can be accessed like a
+   * vector, i.e. square brackets.
+   *
+   * A C++ array of T is vector_like.
+   *
+   * @tparam T Type to test
+   */
   template <typename T>
   struct is_vector_like<T*> {
     enum { value = true };
   };
-  // handles const
+
+
+  /**
+   * Template metaprogram indicates whether a type is vector_like.
+   *
+   * A type is vector_like if an instance can be accessed like a
+   * vector, i.e. square brackets.
+   *
+   * Access is_vector_like::value for the result.
+   *
+   * This metaprogram removes the const qualifier.
+   *
+   * @tparam T Type to test
+   */
   template <typename T>
   struct is_vector_like<const T> {
     enum { value = stan::is_vector_like<T>::value };

--- a/test/unit/math/prim/mat/meta/is_vector_like_test.cpp
+++ b/test/unit/math/prim/mat/meta/is_vector_like_test.cpp
@@ -1,11 +1,11 @@
-#include <stan/math/prim/scal/meta/is_vector_like.hpp>
 #include <stan/math/prim/mat/meta/is_vector.hpp>
 #include <stan/math/prim/arr/meta/is_vector.hpp>
+#include <stan/math/prim/mat/meta/is_vector_like.hpp>
 #include <gtest/gtest.h>
 #include <vector>
 
 TEST(is_vector_like, MatrixXd) {
-  EXPECT_FALSE(stan::is_vector_like<Eigen::MatrixXd>::value);
+  EXPECT_TRUE(stan::is_vector_like<Eigen::MatrixXd>::value);
 }
 
 TEST(is_vector_like, vector_of_MatrixXd) {


### PR DESCRIPTION
#### Summary:

Adding documentation for `is_vector_like`. 

The `value` of the metaprogram is `true` when an object of the type can be accessed like a vector and `false` otherwise.

The matrix test didn't include the matrix specialization of the template metaprogram and was expecting `is_vector_like<Eigen::Matrix<T, -1, -1> >::value` to be `false`. This has been fixed to expect `true` by including the correct header.

#### Intended Effect:

Makes it easier for other developers to understand the code.

#### How to Verify:

Read the doc. Run the test.

#### Side Effects:

None.

#### Documentation:

Done.

#### Reviewer Suggestions: 

@bob-carpenter -- is this clear enough for doc? Is there a better way to write this out?