### PR TITLE
Efficient value_of and value_of_rec for matrices

### DIFF
--- a/stan/math/prim/mat/fun/value_of.hpp
+++ b/stan/math/prim/mat/fun/value_of.hpp
@@ -21,18 +21,14 @@ namespace stan {
      * @return Matrix of values
      **/
     template <typename T, int R, int C>
-    inline typename Eigen::Matrix<typename child_type<T>::type, R, C>
+    inline Eigen::Matrix<typename child_type<T>::type, R, C>
     value_of(const Eigen::Matrix<T, R, C>& M) {
-      Eigen::Matrix<typename child_type<T>::type, R, C>
-        result(M.rows(), M.cols());
-
-      typename child_type<T>::type * data_r = result.data();
-      const T * data_m = M.data();
-
-      int S = M.size();
-      for (int i=0; i < S; i++)
-        data_r[i] = value_of(data_m[i]);
-      return result;
+      using stan::math::value_of;
+      Eigen::Matrix<typename child_type<T>::type, R, C> Md(M.rows(), M.cols());
+      for (int j = 0; j < M.cols(); j++)
+        for (int i = 0; i < M.rows(); i++)
+          Md(i, j) = value_of(M(i, j));
+      return Md;
     }
 
     /**
@@ -51,7 +47,6 @@ namespace stan {
     value_of(const Eigen::Matrix<double, R, C>& x) {
       return x;
     }
-
   }
 }
 

--- a/stan/math/prim/mat/fun/value_of.hpp
+++ b/stan/math/prim/mat/fun/value_of.hpp
@@ -21,15 +21,37 @@ namespace stan {
      * @return Matrix of values
      **/
     template <typename T, int R, int C>
-    inline Eigen::Matrix<typename child_type<T>::type, R, C>
+    inline typename Eigen::Matrix<typename child_type<T>::type, R, C>
     value_of(const Eigen::Matrix<T, R, C>& M) {
-      using stan::math::value_of;
-      Eigen::Matrix<typename child_type<T>::type, R, C> Md(M.rows(), M.cols());
-      for (int j = 0; j < M.cols(); j++)
-        for (int i = 0; i < M.rows(); i++)
-          Md(i, j) = value_of(M(i, j));
-      return Md;
+      Eigen::Matrix<typename child_type<T>::type, R, C>
+        result(M.rows(), M.cols());
+
+      typename child_type<T>::type * data_r = result.data();
+      const T * data_m = M.data();
+
+      int S = M.size();
+      for (int i=0; i < S; i++)
+        data_r[i] = value_of(data_m[i]);
+      return result;
     }
+
+    /**
+     * Return the specified argument.
+     *
+     * <p>See <code>value_of(T)</code> for a polymorphic
+     * implementation using static casts.
+     *
+     * <p>This inline pass-through no-op should be compiled away.
+     *
+     * @param x Specified matrix.
+     * @return Specified matrix.
+     */
+    template <int R, int C>
+    inline typename Eigen::Matrix<double, R, C>
+    value_of(const Eigen::Matrix<double, R, C>& x) {
+      return x;
+    }
+
   }
 }
 

--- a/stan/math/prim/mat/fun/value_of_rec.hpp
+++ b/stan/math/prim/mat/fun/value_of_rec.hpp
@@ -22,16 +22,12 @@ namespace stan {
     template <typename T, int R, int C>
     inline Eigen::Matrix<double, R, C>
     value_of_rec(const Eigen::Matrix<T, R, C>& M) {
-      Eigen::Matrix<double, R, C>
-        result(M.rows(), M.cols());
-
-      double * data_r = result.data();
-      const T * data_m = M.data();
-
-      int S = M.size();
-      for (int i=0; i < S; i++)
-        data_r[i] = value_of_rec(data_m[i]);
-      return result;
+      using stan::math::value_of_rec;
+      Eigen::Matrix<double, R, C> Md(M.rows(), M.cols());
+      for (int j = 0; j < M.cols(); j++)
+        for (int i = 0; i < M.rows(); i++)
+          Md(i, j) = value_of_rec(M(i, j));
+      return Md;
     }
 
     /**

--- a/stan/math/prim/mat/fun/value_of_rec.hpp
+++ b/stan/math/prim/mat/fun/value_of_rec.hpp
@@ -33,6 +33,23 @@ namespace stan {
         data_r[i] = value_of_rec(data_m[i]);
       return result;
     }
+
+    /**
+     * Return the specified argument.
+     *
+     * <p>See <code>value_of_rec(T)</code> for a polymorphic
+     * implementation using static casts.
+     *
+     * <p>This inline pass-through no-op should be compiled away.
+     *
+     * @param x Specified matrix.
+     * @return Specified matrix.
+     */
+    template <int R, int C>
+    inline typename Eigen::Matrix<double, R, C>
+    value_of_rec(const Eigen::Matrix<double, R, C>& x) {
+      return x;
+    }
   }
 }
 

--- a/stan/math/prim/mat/fun/value_of_rec.hpp
+++ b/stan/math/prim/mat/fun/value_of_rec.hpp
@@ -22,12 +22,16 @@ namespace stan {
     template <typename T, int R, int C>
     inline Eigen::Matrix<double, R, C>
     value_of_rec(const Eigen::Matrix<T, R, C>& M) {
-      using stan::math::value_of_rec;
-      Eigen::Matrix<double, R, C> Md(M.rows(), M.cols());
-      for (int j = 0; j < M.cols(); j++)
-        for (int i = 0; i < M.rows(); i++)
-          Md(i, j) = value_of_rec(M(i, j));
-      return Md;
+      Eigen::Matrix<double, R, C>
+        result(M.rows(), M.cols());
+
+      double * data_r = result.data();
+      const T * data_m = M.data();
+
+      int S = M.size();
+      for (int i=0; i < S; i++)
+        data_r[i] = value_of_rec(data_m[i]);
+      return result;
     }
   }
 }


### PR DESCRIPTION
#### Summary:
Fix issue #249

#### Intended Effect:
Write value_of and value_of_rec for matrix in a more efficient way.

`value_of` and `value_of_rec` for matrix are written in a inefficient way that calls `mat(i, j)`, `mat.rows()` and `mat.cols()` on each iteration of the loop.

Sizes should be stored in a temporary `int` and the matrix data pointer in a temporary `T*`.

#### How to Verify:
Code review.

#### Side Effects:
None.

#### Documentation:
Not applicable.

#### Reviewer Suggestions: 
@rtrangucci 
