### PR TITLE
add and utilize NO_FPRINTF_OUTPUT

### DIFF
--- a/lib/cvode_2.8.2/src/nvec_ser/nvector_serial.c
+++ b/lib/cvode_2.8.2/src/nvec_ser/nvector_serial.c
@@ -248,6 +248,7 @@ void N_VDestroyVectorArray_Serial(N_Vector *vs, int count)
  
 void N_VPrint_Serial(N_Vector x)
 {
+#ifndef NO_FPRINTF_OUTPUT
   long int i, N;
   realtype *xd;
 
@@ -266,7 +267,7 @@ void N_VPrint_Serial(N_Vector x)
 #endif
   }
   printf("\n");
-
+#endif
   return;
 }
 

--- a/lib/cvode_2.8.2/src/sundials/sundials_direct.c
+++ b/lib/cvode_2.8.2/src/sundials/sundials_direct.c
@@ -306,6 +306,7 @@ void SetToZero(DlsMat A)
 
 void PrintMat(DlsMat A)
 {
+#ifndef NO_FPRINTF_OUTPUT
   long int i, j, start, finish;
   realtype **a;
 
@@ -354,7 +355,7 @@ void PrintMat(DlsMat A)
     break;
 
   }
-
+#endif
 }
 
 

--- a/lib/cvode_2.8.2/src/sundials/sundials_sparse.c
+++ b/lib/cvode_2.8.2/src/sundials/sundials_sparse.c
@@ -681,6 +681,7 @@ Prints the nonzero entries of a sparse matrix to screen.
 */
 void PrintSparseMat(SlsMat A)
 {
+#ifndef NO_FPRINTF_OUTPUT
   int i,j, M, N, NNZ;
   int *colptrs;
 
@@ -707,6 +708,6 @@ void PrintSparseMat(SlsMat A)
     printf("\n");
   }
   printf("\n");
-    
+#endif
 }
 

--- a/makefile
+++ b/makefile
@@ -30,7 +30,7 @@ include make/libraries
 ##
 # Set default compiler options.
 ##
-CFLAGS = -I . -isystem $(EIGEN) -isystem $(BOOST) -Wall -DBOOST_RESULT_OF_USE_TR1 -DBOOST_NO_DECLTYPE -DBOOST_DISABLE_ASSERTS -pipe -I$(CVODE)/include
+CFLAGS = -I . -isystem $(EIGEN) -isystem $(BOOST) -Wall -DBOOST_RESULT_OF_USE_TR1 -DBOOST_NO_DECLTYPE -DBOOST_DISABLE_ASSERTS -DNO_FPRINTF_OUTPUT -pipe -I$(CVODE)/include
 CFLAGS_GTEST = -DGTEST_USE_OWN_TR1_TUPLE
 LDLIBS =
 EXE =


### PR DESCRIPTION
#### Summary:

This adds some `ifndef NO_FRPINTF_OUTPUT` statements to Sundials functions that use `printf`, which is what the rest of the CVODE code does to prevent `printf` statements from being called.

#### Intended Effect:

To eliminate warnings from R CMD check StanHeaders*.zip on Windows

#### How to Verify:

See http://win-builder.r-project.org/Tec3WlMiz8m7/00check.log
Or do R CMD check StanHeaders*.zip on Windows

#### Side Effects:

None

#### Documentation:

None

#### Reviewer Suggestions: 

@syclik 
