### PR TITLE
Feature/issue 179 robust integrator 3

### DIFF
--- a/stan/math/prim/arr/functor/integrate_ode.hpp
+++ b/stan/math/prim/arr/functor/integrate_ode.hpp
@@ -68,6 +68,7 @@ namespace stan {
       using boost::numeric::odeint::integrate_times;
       using boost::numeric::odeint::make_dense_output;
       using boost::numeric::odeint::runge_kutta_dopri5;
+      using boost::numeric::odeint::max_step_checker;
 
       stan::math::check_finite("integrate_ode", "initial state", y0);
       stan::math::check_finite("integrate_ode", "initial time", t0);
@@ -83,6 +84,7 @@ namespace stan {
       const double absolute_tolerance = 1e-6;
       const double relative_tolerance = 1e-6;
       const double step_size = 0.1;
+      const int max_num_steps = 1E6;
 
       // creates basic or coupled system by template specializations
       coupled_ode_system<F, T1, T2>
@@ -111,7 +113,8 @@ namespace stan {
                       initial_coupled_state,
                       boost::begin(ts_vec), boost::end(ts_vec),
                       step_size,
-                      observer);
+                      observer,
+		      max_step_checker(max_num_steps));
 
       // remove the first state corresponding to the initial value
       y_coupled.erase(y_coupled.begin());

--- a/stan/math/prim/arr/functor/integrate_ode.hpp
+++ b/stan/math/prim/arr/functor/integrate_ode.hpp
@@ -114,7 +114,7 @@ namespace stan {
                       boost::begin(ts_vec), boost::end(ts_vec),
                       step_size,
                       observer,
-		      max_step_checker(max_num_steps));
+                      max_step_checker(max_num_steps));
 
       // remove the first state corresponding to the initial value
       y_coupled.erase(y_coupled.begin());

--- a/test/unit/math/rev/arr/functor/coupled_mm.hpp
+++ b/test/unit/math/rev/arr/functor/coupled_mm.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <stan/math/prim/arr/functor/integrate_ode.hpp>
+#include <stan/math/rev/core.hpp>
+#include <stan/math/rev/scal/fun/value_of_rec.hpp>
+#include <stan/math/rev/scal/fun/pow.hpp>
+
+#define act parms[0] 
+ #define KmA parms[1] 
+ #define deact parms[2] 
+ #define KmAp parms[3] 
+
+struct coupled_mm_ode_fun {
+  template <typename T0, typename T1, typename T2>
+  inline
+  std::vector<typename stan::return_type<T1,T2>::type>
+  operator()(const T0& t_in, // initial time
+             const std::vector<T1>& y, //initial positions
+             const std::vector<T2>& parms, // parameters
+             const std::vector<double>& sx, // double data
+             const std::vector<int>& sx_int,
+             std::ostream* msgs) const { // integer data
+    using std::pow;
+    std::vector<typename stan::return_type<T1,T2>::type> ydot(2);
+
+    ydot[0] = -1*(act*y[0]/(KmA+y[0]))+1*(deact*y[1]/(KmAp+y[1]));
+    ydot[1] = 1*(act*y[0]/(KmA+y[0]))-1*(deact*y[1]/(KmAp+y[1]));
+
+    return(ydot);
+  }
+};

--- a/test/unit/math/rev/arr/functor/coupled_mm.hpp
+++ b/test/unit/math/rev/arr/functor/coupled_mm.hpp
@@ -1,14 +1,7 @@
-#pragma once
+#ifndef TEST_UNIT_MATH_REV_ARR_FUNCTOR_COUPLED_MM_HPP
+#define TEST_UNIT_MATH_REV_ARR_FUNCTOR_COUPLED_MM_HPP
 
-#include <stan/math/prim/arr/functor/integrate_ode.hpp>
 #include <stan/math/rev/core.hpp>
-#include <stan/math/rev/scal/fun/value_of_rec.hpp>
-#include <stan/math/rev/scal/fun/pow.hpp>
-
-#define act parms[0] 
- #define KmA parms[1] 
- #define deact parms[2] 
- #define KmAp parms[3] 
 
 struct coupled_mm_ode_fun {
   template <typename T0, typename T1, typename T2>
@@ -20,12 +13,18 @@ struct coupled_mm_ode_fun {
              const std::vector<double>& sx, // double data
              const std::vector<int>& sx_int,
              std::ostream* msgs) const { // integer data
-    using std::pow;
     std::vector<typename stan::return_type<T1,T2>::type> ydot(2);
 
+    const T2 act   = parms[0];
+    const T2 KmA   = parms[1];
+    const T2 deact = parms[2];
+    const T2 KmAp  = parms[3];
+
     ydot[0] = -1*(act*y[0]/(KmA+y[0]))+1*(deact*y[1]/(KmAp+y[1]));
-    ydot[1] = 1*(act*y[0]/(KmA+y[0]))-1*(deact*y[1]/(KmAp+y[1]));
+    ydot[1] =  1*(act*y[0]/(KmA+y[0]))-1*(deact*y[1]/(KmAp+y[1]));
 
     return(ydot);
   }
 };
+
+#endif

--- a/test/unit/math/rev/arr/functor/integrate_ode_tooMuchWork_test.cpp
+++ b/test/unit/math/rev/arr/functor/integrate_ode_tooMuchWork_test.cpp
@@ -1,0 +1,49 @@
+#include <stan/math/rev/arr.hpp>
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+#include <boost/numeric/odeint.hpp>
+
+// very small michaelis menten example
+#include <test/unit/math/rev/arr/functor/coupled_mm.hpp>
+
+#include <test/unit/util.hpp>
+
+// test which triggers the too much work exception from odeint
+TEST(StanOde_tooMuchWork_test, odeint_coupled_mm) {
+
+  coupled_mm_ode_fun f_;
+
+  // initial value and parameters from model definition
+  std::vector<stan::math::var> y0_v(2);
+  y0_v[0] = 1.0;
+  y0_v[1] = 1E-3;
+
+  double t0 = 0;
+
+  std::vector<double> ts_long;
+  ts_long.push_back(1E10);
+
+  std::vector<double> ts_short;
+  ts_short.push_back(10);
+  
+  std::vector<stan::math::var> theta_v(4);
+
+  theta_v[0] = 1.0;
+  theta_v[1] = 0.5;
+  theta_v[2] = 0.5;
+  theta_v[3] = 0.1;
+
+  std::vector<double> data;
+
+  std::vector<int> data_int;
+
+  EXPECT_THROW_MSG(stan::math::integrate_ode(f_, y0_v, t0, ts_long, theta_v, data, data_int, 0),
+                   boost::numeric::odeint::no_progress_error,
+                   "Max number of iterations exceeded (1000000).");
+
+  EXPECT_NO_THROW(stan::math::integrate_ode(f_, y0_v, t0, ts_short, theta_v, data, data_int, 0));
+  
+}

--- a/test/unit/math/rev/arr/functor/integrate_ode_tooMuchWork_test.cpp
+++ b/test/unit/math/rev/arr/functor/integrate_ode_tooMuchWork_test.cpp
@@ -18,8 +18,8 @@ TEST(StanOde_tooMuchWork_test, odeint_coupled_mm) {
 
   // initial value and parameters from model definition
   std::vector<stan::math::var> y0_v(2);
-  y0_v[0] = 1.0;
-  y0_v[1] = 1E-3;
+  y0_v[0] = 1E5;
+  y0_v[1] = 1E-1;
 
   double t0 = 0;
 
@@ -27,7 +27,7 @@ TEST(StanOde_tooMuchWork_test, odeint_coupled_mm) {
   ts_long.push_back(1E10);
 
   std::vector<double> ts_short;
-  ts_short.push_back(10);
+  ts_short.push_back(1);
   
   std::vector<stan::math::var> theta_v(4);
 


### PR DESCRIPTION
#### Submisison Checklist

- [x ] Run unit tests: `./runTests.py src/test/unit`
- [x ] Run cpplint: `make cpplint`
- [x ] Declare copyright holder and open-source license: see below

#### Summary:

Enable the max_step_checker interface of odeint to make the RK45 integrator fail if extreme parameter values are tried during sampling.

#### Intended Effect:
Make the integrator throw an exception if too much work is on the non-stiff solver (more than 1E6 steps between two time-points). This way Stan does not appear to freeze when Stan explores (very) stiff parameter spaces which may happen during warmup for ODE systems which are borderline non-stiff/stiff.

#### How to Verify:
Currently we have no tests for too much work and due to the inability of the current design, I cannot set a small max_num_step value to make the integrator fail with non-stiff problems. I expect that the ODE stiff benchmark models would trigger the exception. So for now we can verfiy by running all the integrate_ode* tests.

#### Side Effects:
None.

#### Documentation:
I am open for suggestions where to doc this.

#### Reviewer Suggestions: 
@syclik @bob-carpenter @betanalpha 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Sebastian Weber

By submitting this pull request, the copyright holder requires that the code is to be licensed under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
