### PR TITLE
forcing floating point arithemtic for binomial_coefficient_log

### DIFF
--- a/stan/math/prim/scal/fun/binomial_coefficient_log.hpp
+++ b/stan/math/prim/scal/fun/binomial_coefficient_log.hpp
@@ -68,11 +68,8 @@ namespace stan {
       if ((N < cutoff) || (N - n < cutoff)) {
         return lgamma(N + 1.0) - lgamma(n + 1.0) - lgamma(N - n + 1.0);
       } else {
-        typename return_type<T_N, T_n>::type N_m_n(N - n);
-        typename return_type<T_N, T_n>::type log_N_m_n(log(N_m_n));
-
-        return n * log(N_m_n) + (N + 0.5) * (log(N) - log_N_m_n)
-          + 1 / (12 * N) - n - 1 / (12 * N_m_n) - lgamma(n + 1.0);
+        return n * log(N - n) + (N + 0.5) * (log(N) - log(N - n))
+          + 1 / (12 * N) - n - 1 / (12 * (N - n)) - lgamma(n + 1.0);
       }
     }
 

--- a/stan/math/prim/scal/fun/binomial_coefficient_log.hpp
+++ b/stan/math/prim/scal/fun/binomial_coefficient_log.hpp
@@ -68,8 +68,24 @@ namespace stan {
       if ((N < cutoff) || (N - n < cutoff)) {
         return lgamma(N + 1.0) - lgamma(n + 1.0) - lgamma(N - n + 1.0);
       } else {
-        return n * log(N - n) + (N + 0.5) * log(N/(N - n + 0.0))
-          + 1.0 / (12 * N) - n - 1.0 / (12 * (N - n)) - lgamma(n + 1.0);
+        return n * log(N - n) + (N + 0.5) * log(N / (N - n))
+          + 1 / (12 * N) - n - 1 / (12 * (N - n)) - lgamma(n + 1.0);
+      }
+    }
+
+
+    template <>
+    inline double
+    binomial_coefficient_log<int, int>(const int N, const int n) {
+      using std::log;
+      using boost::math::lgamma;
+
+      const double cutoff = 1000;
+      if ((N < cutoff) || (N - n < cutoff)) {
+        return lgamma(N + 1.0) - lgamma(n + 1.0) - lgamma(N - n + 1.0);
+      } else {
+        return n * log(N - n) + (N + 0.5) * log(N / static_cast<double>(N - n))
+          + 1 / (12 * N) - n - 1 / (12 * (N - n)) - lgamma(n + 1.0);
       }
     }
 

--- a/stan/math/prim/scal/fun/binomial_coefficient_log.hpp
+++ b/stan/math/prim/scal/fun/binomial_coefficient_log.hpp
@@ -1,8 +1,8 @@
 #ifndef STAN_MATH_PRIM_SCAL_FUN_BINOMIAL_COEFFICIENT_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_FUN_BINOMIAL_COEFFICIENT_LOG_HPP
 
+#include <stan/math/prim/scal/meta/return_type.hpp>
 #include <boost/math/special_functions/gamma.hpp>
-#include <boost/math/tools/promotion.hpp>
 
 namespace stan {
 
@@ -59,7 +59,7 @@ namespace stan {
      * @return log (N choose n).
      */
     template <typename T_N, typename T_n>
-    inline typename boost::math::tools::promote_args<T_N, T_n>::type
+    inline typename return_type<T_N, T_n>::type
     binomial_coefficient_log(const T_N N, const T_n n) {
       using std::log;
       using boost::math::lgamma;
@@ -68,28 +68,14 @@ namespace stan {
       if ((N < cutoff) || (N - n < cutoff)) {
         return lgamma(N + 1.0) - lgamma(n + 1.0) - lgamma(N - n + 1.0);
       } else {
-        return n * log(N - n) + (N + 0.5) * log(N / (N - n))
-          + 1 / (12 * N) - n - 1 / (12 * (N - n)) - lgamma(n + 1.0);
-      }
-    }
+        typename return_type<T_N, T_n>::type N_m_n(N - n);
+        typename return_type<T_N, T_n>::type log_N_m_n(log(N_m_n));
 
-
-    template <>
-    inline double
-    binomial_coefficient_log<int, int>(const int N, const int n) {
-      using std::log;
-      using boost::math::lgamma;
-
-      const double cutoff = 1000;
-      if ((N < cutoff) || (N - n < cutoff)) {
-        return lgamma(N + 1.0) - lgamma(n + 1.0) - lgamma(N - n + 1.0);
-      } else {
-        return n * log(N - n) + (N + 0.5) * log(N / static_cast<double>(N - n))
-          + 1 / (12 * N) - n - 1 / (12 * (N - n)) - lgamma(n + 1.0);
+        return n * log(N_m_n) + (N + 0.5) * (log(N) - log_N_m_n)
+          + 1 / (12 * N) - n - 1 / (12 * N_m_n) - lgamma(n + 1.0);
       }
     }
 
   }
 }
-
 #endif

--- a/stan/math/prim/scal/fun/binomial_coefficient_log.hpp
+++ b/stan/math/prim/scal/fun/binomial_coefficient_log.hpp
@@ -68,8 +68,8 @@ namespace stan {
       if ((N < cutoff) || (N - n < cutoff)) {
         return lgamma(N + 1.0) - lgamma(n + 1.0) - lgamma(N - n + 1.0);
       } else {
-        return n * log(N - n) + (N + 0.5) * log(N/(N-n))
-          + 1/(12*N) - n - 1/(12*(N-n)) - lgamma(n + 1.0);
+        return n * log(N - n) + (N + 0.5) * log(N/(N - n + 0.0))
+          + 1.0 / (12 * N) - n - 1.0 / (12 * (N - n)) - lgamma(n + 1.0);
       }
     }
 

--- a/test/unit/math/prim/scal/fun/binomial_coefficient_log_test.cpp
+++ b/test/unit/math/prim/scal/fun/binomial_coefficient_log_test.cpp
@@ -2,6 +2,14 @@
 #include <boost/math/special_functions/fpclassify.hpp>
 #include <gtest/gtest.h>
 
+template <typename T_N, typename T_n> 
+void test_binom_coefficient(const T_N& N, const T_n& n) {
+  using stan::math::binomial_coefficient_log;
+  EXPECT_FLOAT_EQ(lgamma(N + 1) - lgamma(n + 1) - lgamma(N - n + 1),
+                  binomial_coefficient_log(N, n));
+}
+
+
 TEST(MathFunctions, binomial_coefficient_log) {
   using stan::math::binomial_coefficient_log;
   EXPECT_FLOAT_EQ(1.0, exp(binomial_coefficient_log(2.0,2.0)));
@@ -10,6 +18,16 @@ TEST(MathFunctions, binomial_coefficient_log) {
   EXPECT_NEAR(3.0, exp(binomial_coefficient_log(3.0,2.0)),0.0001);
 
   EXPECT_FLOAT_EQ(29979.16, binomial_coefficient_log(100000, 91116));
+
+  for (int n = 0; n < 1010; ++n) {
+    test_binom_coefficient(1010, n);
+    test_binom_coefficient(1010.0, n);
+    test_binom_coefficient(1010, static_cast<double>(n));
+    test_binom_coefficient(1010.0, static_cast<double>(n));
+  }
+
+  test_binom_coefficient(1e9, 1e5);
+  test_binom_coefficient(1e50, 1e45);
 }
 
 TEST(MathFunctions, binomial_coefficient_log_nan) {

--- a/test/unit/math/prim/scal/fun/binomial_coefficient_log_test.cpp
+++ b/test/unit/math/prim/scal/fun/binomial_coefficient_log_test.cpp
@@ -8,6 +8,8 @@ TEST(MathFunctions, binomial_coefficient_log) {
   EXPECT_FLOAT_EQ(2.0, exp(binomial_coefficient_log(2.0,1.0)));
   EXPECT_FLOAT_EQ(3.0, exp(binomial_coefficient_log(3.0,1.0)));
   EXPECT_NEAR(3.0, exp(binomial_coefficient_log(3.0,2.0)),0.0001);
+
+  EXPECT_FLOAT_EQ(29979.16, binomial_coefficient_log(100000, 91116));
 }
 
 TEST(MathFunctions, binomial_coefficient_log_nan) {


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py src/test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

When both arguments are `int`, the `log(N / (N - n))` term uses integer division for the inner term. This pull request forces floating point division in that term and a couple other places.

#### Intended Effect:

Fixes a bug where int values are different than double values.

#### How to Verify:

Run tests.

#### Side Effects:

None. 

#### Documentation:

None necessary.

#### Reviewer Suggestions: 

Anyone.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

