### PR TITLE
Removing compiler warning

### DIFF
--- a/stan/math/fwd/scal/meta/OperandsAndPartials.hpp
+++ b/stan/math/fwd/scal/meta/OperandsAndPartials.hpp
@@ -178,7 +178,7 @@ namespace stan {
       }
 
       ~OperandsAndPartials() {
-        delete all_partials;
+        delete[] all_partials;
       }
     };
 


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

Squashes a compiler warning.

#### How to Verify:

Run:
`./runTests.py test/unit/math/fwd/arr/meta/OperandsAndPartials_test.cpp`

There should be no compiler warnings. In the current develop branch, there is a warning.

#### Side Effects:

This isn't actually used in Stan yet, so there should be no side-effects.

#### Documentation:

None required.

#### Reviewer Suggestions: 

Anyone.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

