### PR TITLE
Bugfix/issue 278 jacobian nested

### DIFF
--- a/stan/math/rev/core/set_zero_all_adjoints_nested.hpp
+++ b/stan/math/rev/core/set_zero_all_adjoints_nested.hpp
@@ -20,12 +20,12 @@ namespace stan {
                                " set_zero_all_adjoints_nested()");
       size_t start1 = ChainableStack::nested_var_stack_sizes_.back();
       // avoid wrap with unsigned when start1 == 0
-      for (size_t i = (start1 == 0) ? 0 : (start1 - 1);
+      for (size_t i = (start1 == 0U) ? 0U : (start1 - 1);
            i < ChainableStack::var_stack_.size(); ++i)
         ChainableStack::var_stack_[i]->set_zero_adjoint();
 
       size_t start2 = ChainableStack::nested_var_nochain_stack_sizes_.back();
-      for (size_t i = (start2 == 0) ? 0U : start2 - 1;
+      for (size_t i = (start2 == 0U) ? 0U : (start2 - 1);
            i < ChainableStack::var_nochain_stack_.size(); ++i) {
         ChainableStack::var_nochain_stack_[i]->set_zero_adjoint();
       }

--- a/stan/math/rev/core/set_zero_all_adjoints_nested.hpp
+++ b/stan/math/rev/core/set_zero_all_adjoints_nested.hpp
@@ -19,14 +19,16 @@ namespace stan {
         throw std::logic_error("empty_nested() must be false before calling"
                                " set_zero_all_adjoints_nested()");
       size_t start1 = ChainableStack::nested_var_stack_sizes_.back();
-      for (size_t i = start1 - 1; i < ChainableStack::var_stack_.size(); ++i)
+      // avoid wrap with unsigned when start1 == 0
+      for (size_t i = (start1 == 0) ? 0 : (start1 - 1);
+           i < ChainableStack::var_stack_.size(); ++i)
         ChainableStack::var_stack_[i]->set_zero_adjoint();
 
-
       size_t start2 = ChainableStack::nested_var_nochain_stack_sizes_.back();
-      for (size_t i = start2 - 1;
-           i < ChainableStack::var_nochain_stack_.size(); ++i)
+      for (size_t i = (start2 == 0) ? 0U : start2 - 1;
+           i < ChainableStack::var_nochain_stack_.size(); ++i) {
         ChainableStack::var_nochain_stack_[i]->set_zero_adjoint();
+      }
     }
 
   }

--- a/test/unit/math/mix/mat/functor/autodiff_test.cpp
+++ b/test/unit/math/mix/mat/functor/autodiff_test.cpp
@@ -1,3 +1,4 @@
+#include <iostream>
 #include <stan/math/mix/mat.hpp>
 #include <gtest/gtest.h>
 #include <stdexcept>
@@ -55,166 +56,161 @@ TEST(AgradAutoDiff,derivative) {
 }
 
 TEST(AgradAutoDiff,partialDerivative) {
-
-
   fun1 f;
-  Matrix<double,Dynamic,1> x(2);
+  Matrix<double, Dynamic, 1> x(2);
   x << 5, 7;
 
   double fx;
   double d;
-  stan::math::partial_derivative(f,x,0,fx,d);
-  EXPECT_FLOAT_EQ(5 * 5 * 7 + 3 * 7 * 7,fx);
+  stan::math::partial_derivative(f, x, 0, fx, d);
+  EXPECT_FLOAT_EQ(5 * 5 * 7 + 3 * 7 * 7, fx);
   EXPECT_FLOAT_EQ(2 * 5 * 7, d);
 
   double fx2;
   double d2;
-  stan::math::partial_derivative(f,x,1,fx2,d2);
-  EXPECT_FLOAT_EQ(5 * 5 * 7 + 3 * 7 * 7,fx);
-  EXPECT_FLOAT_EQ(5 * 5 + 3 * 2 * 7,d2);
+  stan::math::partial_derivative(f, x, 1, fx2, d2);
+  EXPECT_FLOAT_EQ(5 * 5 * 7 + 3 * 7 * 7, fx);
+  EXPECT_FLOAT_EQ(5 * 5 + 3 * 2 * 7, d2);
 }
 
-TEST(AgradAutoDiff,gradientDotVector) {
-
+TEST(AgradAutoDiff, gradientDotVector) {
   using stan::math::var;
   fun1 f;
-  Matrix<double,Dynamic,1> x(2);
+  Matrix<double, Dynamic, 1> x(2);
   x << 5, 7;
-  Matrix<double,Dynamic,1> v(2);
+  Matrix<double, Dynamic, 1> v(2);
   v << 11, 13;
   double fx;
   double grad_fx_dot_v;
-  stan::math::gradient_dot_vector(f,x,v,fx,grad_fx_dot_v);
+  stan::math::gradient_dot_vector(f, x, v, fx, grad_fx_dot_v);
 
   double fx_expected;
-  Matrix<double,Dynamic,1> grad_fx;
-  stan::math::gradient(f,x,fx_expected,grad_fx);
+  Matrix<double, Dynamic, 1> grad_fx;
+  stan::math::gradient(f, x, fx_expected, grad_fx);
   double grad_fx_dot_v_expected = grad_fx.dot(v);
 
   EXPECT_FLOAT_EQ(grad_fx_dot_v_expected, grad_fx_dot_v);
 }
-TEST(AgradAutoDiff,hessianTimesVector) {
+TEST(AgradAutoDiff, hessianTimesVector) {
   using stan::math::hessian_times_vector;
-
 
   fun1 f;
 
-  Matrix<double,Dynamic,1> x(2);
+  Matrix<double, Dynamic, 1> x(2);
   x << 2, -3;
 
-  Matrix<double,Dynamic,1> v(2);
+  Matrix<double, Dynamic, 1> v(2);
   v << 8, 5;
 
-  Matrix<double,Dynamic,1> Hv;
+  Matrix<double, Dynamic, 1> Hv;
   double fx;
-  stan::math::hessian_times_vector(f,x,v,fx,Hv);
+  stan::math::hessian_times_vector(f, x, v, fx, Hv);
 
   EXPECT_FLOAT_EQ(2 * 2 * -3 + 3.0 * -3 * -3, fx);
 
-  EXPECT_EQ(2,Hv.size());
+  EXPECT_EQ(2, Hv.size());
   EXPECT_FLOAT_EQ(2 * x(1) * v(0) + 2 * x(0) * v(1), Hv(0));
   EXPECT_FLOAT_EQ(2 * x(0) * v(0) + 6 * v(1), Hv(1));
 }
-TEST(AgradAutoDiff,jacobian) {
 
+TEST(AgradAutoDiff, jacobian) {
   using stan::math::jacobian;
 
   fun2 f;
-  Matrix<double,Dynamic,1> x(2);
+  Matrix<double, Dynamic, 1> x(2);
   x << 2, -3;
 
-  Matrix<double,Dynamic,1> fx;
-  Matrix<double,Dynamic,Dynamic> J;
-  jacobian(f,x,fx,J);
+  Matrix<double, Dynamic, 1> fx;
+  Matrix<double, Dynamic, Dynamic> J;
+  jacobian(f, x, fx, J);
 
-  EXPECT_EQ(2,fx.size());
+  EXPECT_EQ(2, fx.size());
   EXPECT_FLOAT_EQ(2 * 2, fx(0));
   EXPECT_FLOAT_EQ(3 * 2 * -3, fx(1));
 
-  EXPECT_FLOAT_EQ(2, J(0,0));
-  EXPECT_FLOAT_EQ(-9, J(1,0));
-  EXPECT_FLOAT_EQ(0, J(0,1));
-  EXPECT_FLOAT_EQ(6, J(1,1));
+  EXPECT_FLOAT_EQ(2, J(0, 0));
+  EXPECT_FLOAT_EQ(-9, J(1, 0));
+  EXPECT_FLOAT_EQ(0, J(0, 1));
+  EXPECT_FLOAT_EQ(6, J(1, 1));
 
+  Matrix<double, Dynamic, 1> fx_rev;
+  Matrix<double, Dynamic, Dynamic> J_rev;
+  jacobian<double>(f, x, fx_rev, J_rev);
 
-  Matrix<double,Dynamic,1> fx_rev;
-  Matrix<double,Dynamic,Dynamic> J_rev;
-  jacobian<double>(f,x,fx_rev,J_rev);
-
-  EXPECT_EQ(2,fx_rev.size());
+  EXPECT_EQ(2, fx_rev.size());
   EXPECT_FLOAT_EQ(2 * 2, fx_rev(0));
   EXPECT_FLOAT_EQ(3 * 2 * -3, fx_rev(1));
 
-  EXPECT_FLOAT_EQ(2, J_rev(0,0));
-  EXPECT_FLOAT_EQ(-9, J_rev(1,0));
-  EXPECT_FLOAT_EQ(0, J_rev(0,1));
-  EXPECT_FLOAT_EQ(6, J_rev(1,1));
+  EXPECT_FLOAT_EQ(2, J_rev(0, 0));
+  EXPECT_FLOAT_EQ(-9, J_rev(1, 0));
+  EXPECT_FLOAT_EQ(0, J_rev(0, 1));
+  EXPECT_FLOAT_EQ(6, J_rev(1, 1));
 }
 
-TEST(AgradAutoDiff,hessian) {
+TEST(AgradAutoDiff, hessian) {
 
   fun1 f;
-  Matrix<double,Dynamic,1> x(2);
+  Matrix<double, Dynamic, 1> x(2);
   x << 5, 7;
   double fx(0);
-  Matrix<double,Dynamic,1> grad;
-  Matrix<double,Dynamic,Dynamic> H;
-  stan::math::hessian(f,x,fx,grad,H);
+  Matrix<double, Dynamic, 1> grad;
+  Matrix<double, Dynamic, Dynamic> H;
+  stan::math::hessian(f, x, fx, grad, H);
 
   // x^2 * y + 3 * y^2
   EXPECT_FLOAT_EQ(5 * 5 * 7 + 3 * 7  * 7, fx);
 
-  EXPECT_FLOAT_EQ(2,grad.size());
+  EXPECT_FLOAT_EQ(2, grad.size());
   EXPECT_FLOAT_EQ(2 * x(0) * x(1), grad(0));
   EXPECT_FLOAT_EQ(x(0) * x(0) + 3 * 2 * x(1), grad(1));
 
-  EXPECT_EQ(2,H.rows());
-  EXPECT_EQ(2,H.cols());
-  EXPECT_FLOAT_EQ(2 * 7, H(0,0));
-  EXPECT_FLOAT_EQ(2 * 5, H(0,1));
-  EXPECT_FLOAT_EQ(2 * 5, H(1,0));
-  EXPECT_FLOAT_EQ(2 * 3, H(1,1));
+  EXPECT_EQ(2, H.rows());
+  EXPECT_EQ(2, H.cols());
+  EXPECT_FLOAT_EQ(2 * 7, H(0, 0));
+  EXPECT_FLOAT_EQ(2 * 5, H(0, 1));
+  EXPECT_FLOAT_EQ(2 * 5, H(1, 0));
+  EXPECT_FLOAT_EQ(2 * 3, H(1, 1));
 
   double fx2;
-  Matrix<double,Dynamic,1> grad2;
-  Matrix<double,Dynamic,Dynamic> H2;
-  stan::math::hessian<double>(f,x,fx2,grad2,H2);
+  Matrix<double, Dynamic, 1> grad2;
+  Matrix<double, Dynamic, Dynamic> H2;
+  stan::math::hessian<double>(f, x, fx2, grad2, H2);
 
   EXPECT_FLOAT_EQ(5 * 5 * 7 + 3 * 7  * 7, fx2);
 
-  EXPECT_FLOAT_EQ(2,grad2.size());
+  EXPECT_FLOAT_EQ(2, grad2.size());
   EXPECT_FLOAT_EQ(2 * x(0) * x(1), grad2(0));
   EXPECT_FLOAT_EQ(x(0) * x(0) + 3 * 2 * x(1), grad2(1));
 
-  EXPECT_EQ(2,H2.rows());
-  EXPECT_EQ(2,H2.cols());
-  EXPECT_FLOAT_EQ(2 * 7, H2(0,0));
-  EXPECT_FLOAT_EQ(2 * 5, H2(0,1));
-  EXPECT_FLOAT_EQ(2 * 5, H2(1,0));
-  EXPECT_FLOAT_EQ(2 * 3, H2(1,1));
+  EXPECT_EQ(2, H2.rows());
+  EXPECT_EQ(2, H2.cols());
+  EXPECT_FLOAT_EQ(2 * 7, H2(0, 0));
+  EXPECT_FLOAT_EQ(2 * 5, H2(0, 1));
+  EXPECT_FLOAT_EQ(2 * 5, H2(1, 0));
+  EXPECT_FLOAT_EQ(2 * 3, H2(1, 1));
 
 }
 
-TEST(AgradAutoDiff,GradientTraceMatrixTimesHessian) {
-  Matrix<double,Dynamic,Dynamic> M(2,2);
+TEST(AgradAutoDiff, GradientTraceMatrixTimesHessian) {
+  Matrix<double, Dynamic, Dynamic> M(2, 2);
   M << 11, 13, 17, 23;
   fun1 f;
-  Matrix<double,Dynamic,1> x(2);
+  Matrix<double, Dynamic, 1> x(2);
   x << 5, 7;
-  Matrix<double,Dynamic,1> grad_tr_MH;
-  stan::math::grad_tr_mat_times_hessian(f,x,M,grad_tr_MH);
+  Matrix<double, Dynamic, 1> grad_tr_MH;
+  stan::math::grad_tr_mat_times_hessian(f, x, M, grad_tr_MH);
 
-  EXPECT_EQ(2,grad_tr_MH.size());
-  EXPECT_FLOAT_EQ(60,grad_tr_MH(0));
-  EXPECT_FLOAT_EQ(22,grad_tr_MH(1));
+  EXPECT_EQ(2, grad_tr_MH.size());
+  EXPECT_FLOAT_EQ(60, grad_tr_MH(0));
+  EXPECT_FLOAT_EQ(22, grad_tr_MH(1));
 }
 
-TEST(AgradAutoDiff,GradientHessian){
+TEST(AgradAutoDiff, GradientHessian){
   norm_functor log_normal_density;
   third_order_mixed mixed_third_poly;
 
-  Matrix<double,Dynamic,1> normal_eval_vec(3);
-  Matrix<double,Dynamic,1> poly_eval_vec(3);
+  Matrix<double, Dynamic, 1> normal_eval_vec(3);
+  Matrix<double, Dynamic, 1> poly_eval_vec(3);
 
   normal_eval_vec << 0.7, 0.5, 0.9;
   poly_eval_vec << 1.5, 7.1, 3.1;
@@ -228,60 +224,66 @@ TEST(AgradAutoDiff,GradientHessian){
   double normal_eval_analytic;
   double poly_eval_analytic;
 
-  Matrix<double,Dynamic,Dynamic> norm_hess_agrad;
-  Matrix<double,Dynamic,Dynamic> poly_hess_agrad;
+  Matrix<double, Dynamic, Dynamic> norm_hess_agrad;
+  Matrix<double, Dynamic, Dynamic> poly_hess_agrad;
 
-  Matrix<double,Dynamic,Dynamic> norm_hess_agrad_hessian;
-  Matrix<double,Dynamic,Dynamic> poly_hess_agrad_hessian;
+  Matrix<double, Dynamic, Dynamic> norm_hess_agrad_hessian;
+  Matrix<double, Dynamic, Dynamic> poly_hess_agrad_hessian;
 
-  Matrix<double,Dynamic,1> norm_grad_agrad_hessian;
-  Matrix<double,Dynamic,1> poly_grad_agrad_hessian;
+  Matrix<double, Dynamic, 1> norm_grad_agrad_hessian;
+  Matrix<double, Dynamic, 1> poly_grad_agrad_hessian;
 
-  stan::math::hessian(log_normal_density,normal_eval_vec,
-                       normal_eval_agrad_hessian,
-                       norm_grad_agrad_hessian,
+  stan::math::hessian(log_normal_density, normal_eval_vec, 
+                       normal_eval_agrad_hessian, 
+                       norm_grad_agrad_hessian, 
                        norm_hess_agrad_hessian);
 
-  stan::math::hessian(mixed_third_poly,poly_eval_vec,
-                       poly_eval_agrad_hessian,
-                       poly_grad_agrad_hessian,
+  stan::math::hessian(mixed_third_poly, poly_eval_vec, 
+                       poly_eval_agrad_hessian, 
+                       poly_grad_agrad_hessian, 
                        poly_hess_agrad_hessian);
 
-  Matrix<double,Dynamic,Dynamic> norm_hess_analytic;
-  Matrix<double,Dynamic,Dynamic> poly_hess_analytic;
+  Matrix<double, Dynamic, Dynamic> norm_hess_analytic;
+  Matrix<double, Dynamic, Dynamic> poly_hess_analytic;
 
-  std::vector<Matrix<double,Dynamic,Dynamic> > norm_grad_hess_agrad;
-  std::vector<Matrix<double,Dynamic,Dynamic> > poly_grad_hess_agrad;
+  std::vector<Matrix<double, Dynamic, Dynamic> > norm_grad_hess_agrad;
+  std::vector<Matrix<double, Dynamic, Dynamic> > poly_grad_hess_agrad;
 
-  std::vector<Matrix<double,Dynamic,Dynamic> > norm_grad_hess_analytic;
-  std::vector<Matrix<double,Dynamic,Dynamic> > poly_grad_hess_analytic;
+  std::vector<Matrix<double, Dynamic, Dynamic> > norm_grad_hess_analytic;
+  std::vector<Matrix<double, Dynamic, Dynamic> > poly_grad_hess_analytic;
 
   normal_eval_analytic = log_normal_density(normal_eval_vec);
   poly_eval_analytic = mixed_third_poly(poly_eval_vec);
 
-  stan::math::grad_hessian(log_normal_density,normal_eval_vec,
-                            normal_eval_agrad,norm_hess_agrad,norm_grad_hess_agrad);
-  stan::math::grad_hessian(mixed_third_poly,poly_eval_vec,
-                            poly_eval_agrad,poly_hess_agrad,poly_grad_hess_agrad);
+  stan::math::grad_hessian(log_normal_density, normal_eval_vec, 
+                            normal_eval_agrad, norm_hess_agrad,
+                           norm_grad_hess_agrad);
+  stan::math::grad_hessian(mixed_third_poly, poly_eval_vec, 
+                            poly_eval_agrad, poly_hess_agrad,
+                           poly_grad_hess_agrad);
   norm_hess_analytic = norm_hess(normal_eval_vec);
   poly_hess_analytic = third_order_mixed_hess(poly_eval_vec);
 
   norm_grad_hess_analytic = norm_grad_hess(normal_eval_vec);
   poly_grad_hess_analytic = third_order_mixed_grad_hess(poly_eval_vec);
 
-  EXPECT_FLOAT_EQ(normal_eval_analytic,normal_eval_agrad);
-  EXPECT_FLOAT_EQ(poly_eval_analytic,poly_eval_agrad);
+  EXPECT_FLOAT_EQ(normal_eval_analytic, normal_eval_agrad);
+  EXPECT_FLOAT_EQ(poly_eval_analytic, poly_eval_agrad);
 
   for (size_t i = 0; i < 3; ++i)
     for (int j = 0; j < 3; ++j)
       for (int k = 0; k < 3; ++k) {
         if (i == 0){
-          EXPECT_FLOAT_EQ(norm_hess_agrad_hessian(j,k),norm_hess_analytic(j,k));
-          EXPECT_FLOAT_EQ(poly_hess_agrad_hessian(j,k),poly_hess_analytic(j,k));
-          EXPECT_FLOAT_EQ(norm_hess_analytic(j,k),norm_hess_agrad(j,k));
-          EXPECT_FLOAT_EQ(poly_hess_analytic(j,k),poly_hess_agrad(j,k));
+          EXPECT_FLOAT_EQ(norm_hess_agrad_hessian(j, k),
+                          norm_hess_analytic(j, k));
+          EXPECT_FLOAT_EQ(poly_hess_agrad_hessian(j, k),
+                          poly_hess_analytic(j, k));
+          EXPECT_FLOAT_EQ(norm_hess_analytic(j, k), norm_hess_agrad(j, k));
+          EXPECT_FLOAT_EQ(poly_hess_analytic(j, k), poly_hess_agrad(j, k));
         }
-        EXPECT_FLOAT_EQ(norm_grad_hess_analytic[i](j,k),norm_grad_hess_agrad[i](j,k));
-        EXPECT_FLOAT_EQ(poly_grad_hess_analytic[i](j,k),poly_grad_hess_agrad[i](j,k));
+        EXPECT_FLOAT_EQ(norm_grad_hess_analytic[i](j, k),
+                        norm_grad_hess_agrad[i](j, k));
+        EXPECT_FLOAT_EQ(poly_grad_hess_analytic[i](j, k),
+                        poly_grad_hess_agrad[i](j, k));
       }
 }

--- a/test/unit/math/mix/mat/functor/autodiff_test.cpp
+++ b/test/unit/math/mix/mat/functor/autodiff_test.cpp
@@ -119,11 +119,6 @@ TEST(AgradAutoDiff,jacobian) {
 
   using stan::math::jacobian;
 
-  // nested AD calls within jacobian functions only give correct
-  // results when the AD stack was initialized before with something
-  stan::math::var dummy;
-  dummy = 1;
-
   fun2 f;
   Matrix<double,Dynamic,1> x(2);
   x << 2, -3;


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

Fixed error with autodiff stack behavior when nesting begins before anything else is on the stack.

#### Intended Effect:

Allow nested Jacobian calculations.

#### How to Verify:

The current unit test fails before this patch.

#### Side Effects:

Makes nesting more robust outside of Jacobian context, too.

#### Documentation:

No, just bug fix.

#### Reviewer Suggestions: 

Anyone.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
