### PR TITLE
Bugfix/qr fix 286

### DIFF
--- a/stan/math/prim/mat/fun/qr_Q.hpp
+++ b/stan/math/prim/mat/fun/qr_Q.hpp
@@ -22,7 +22,7 @@ namespace stan {
       qr.compute(m);
       matrix_t Q = qr.householderQ();
       for (int i = 0; i < m.cols(); i++)
-        if (qr.matrixQR()(i, i) < 0)
+        if (qr.matrixQR().coeff(i, i) < 0)
           Q.col(i) *= -1.0;
       return Q;
     }

--- a/stan/math/prim/mat/fun/qr_R.hpp
+++ b/stan/math/prim/mat/fun/qr_R.hpp
@@ -22,7 +22,7 @@ namespace stan {
       qr.compute(m);
       matrix_t R = qr.matrixQR().topLeftCorner(m.rows(), m.cols());
       for (int i = 0; i < R.rows(); i++) {
-        for (int j = 0; j < i; j++)
+        for (int j = 0; j < std::min(static_cast<int>(R.cols()), i); j++)
           R(i, j) = 0.0;
         if (i < R.cols() && R(i, i) < 0)
           R.row(i) *= -1.0;

--- a/stan/math/prim/mat/fun/qr_R.hpp
+++ b/stan/math/prim/mat/fun/qr_R.hpp
@@ -20,10 +20,12 @@ namespace stan {
                                          static_cast<size_t>(m.cols()));
       Eigen::HouseholderQR<matrix_t> qr(m.rows(), m.cols());
       qr.compute(m);
-      matrix_t R = qr.matrixQR().topLeftCorner(m.rows(), m.cols());
-      for (int i = 0; i < R.rows(); i++) {
-        for (int j = 0; j < std::min(static_cast<int>(R.cols()), i); j++)
-          R(i, j) = 0.0;
+      matrix_t R = qr.matrixQR();
+      if (m.rows() > m.cols())
+        R.bottomRows(m.rows() - m.cols()).setZero();
+      for (int i = 0; i < R.cols(); i++) {
+        for (int j = 0; j < i; j++)
+          R.coeffRef(i, j) = 0.0;
         if (i < R.cols() && R(i, i) < 0)
           R.row(i) *= -1.0;
       }

--- a/stan/math/prim/mat/fun/qr_R.hpp
+++ b/stan/math/prim/mat/fun/qr_R.hpp
@@ -26,7 +26,7 @@ namespace stan {
       for (int i = 0; i < R.cols(); i++) {
         for (int j = 0; j < i; j++)
           R.coeffRef(i, j) = 0.0;
-        if (i < R.cols() && R(i, i) < 0)
+        if (R(i, i) < 0)
           R.row(i) *= -1.0;
       }
       return R;

--- a/test/unit/math/prim/mat/fun/qr_R_test.cpp
+++ b/test/unit/math/prim/mat/fun/qr_R_test.cpp
@@ -3,8 +3,8 @@
 
 TEST(MathMatrix, qr_R) {
   stan::math::matrix_d m0(0,0);
-  stan::math::matrix_d m1(3,2);
-  m1 << 1, 2, 3, 4, 5, 6;
+  stan::math::matrix_d m1(4,2);
+  m1 << 1, 2, 3, 4, 5, 6, 7, 8;
 
   using stan::math::qr_R;
   using stan::math::qr_Q;
@@ -12,11 +12,11 @@ TEST(MathMatrix, qr_R) {
   EXPECT_THROW(qr_R(m0), std::invalid_argument);
   EXPECT_NO_THROW(qr_R(m1));
 
-  stan::math::matrix_d m2(3,2);
+  stan::math::matrix_d m2(4,2);
   m2 = qr_Q(m1) * qr_R(m1);
   for (unsigned int i=0; i<m1.rows(); i++) {
     for (unsigned int j=0; j<m1.cols(); j++) {
-      EXPECT_NEAR(m1(i,j), m2(i,j), 1e-8);
+      EXPECT_NEAR(m1(i,j), m2(i,j), 1e-12);
     }
   }
   EXPECT_THROW(qr_R(transpose(m1)),std::domain_error);

--- a/test/unit/math/prim/mat/fun/qr_R_test.cpp
+++ b/test/unit/math/prim/mat/fun/qr_R_test.cpp
@@ -13,7 +13,11 @@ TEST(MathMatrix, qr_R) {
   EXPECT_NO_THROW(qr_R(m1));
 
   stan::math::matrix_d m2(4,2);
-  m2 = qr_Q(m1) * qr_R(m1);
+  stan::math::matrix_d Q(4,4);
+  stan::math::matrix_d R(4,2);
+  Q = qr_Q(m1);
+  R = qr_R(m1);
+  m2 = Q * R;
   for (unsigned int i=0; i<m1.rows(); i++) {
     for (unsigned int j=0; j<m1.cols(); j++) {
       EXPECT_NEAR(m1(i,j), m2(i,j), 1e-12);


### PR DESCRIPTION
#### Submisison Checklist

- [*] Run unit tests: `./runTests.py test/unit`
- [*] Run cpplint: `make cpplint`
- [*] Declare copyright holder and open-source license: see below

#### Summary:

Fix segfault when `qr_R` is called on a non-square matrix

#### Intended Effect:

Prevent the aforementioned segfault

#### How to Verify:

Run `./runTests.py test/unit/math/prim/mat/fun/qr_R_test.cpp`

#### Side Effects:

Doesn't segfault

#### Documentation:

Needs another pull request for stan

#### Reviewer Suggestions: 

Anyone

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Benjamin Goodrich

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
