### PR TITLE
replace operator/ with math::divide in elt_divide, fixing #290

### DIFF
--- a/stan/math/prim/mat/fun/elt_divide.hpp
+++ b/stan/math/prim/mat/fun/elt_divide.hpp
@@ -3,6 +3,7 @@
 
 #include <boost/math/tools/promotion.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <stan/math/prim/mat/fun/divide.hpp>
 #include <stan/math/prim/mat/err/check_matching_dims.hpp>
 
 namespace stan {
@@ -48,7 +49,7 @@ namespace stan {
     template <typename T1, typename T2, int R, int C>
     Eigen::Matrix<typename boost::math::tools::promote_args<T1, T2>::type, R, C>
     elt_divide(const Eigen::Matrix<T1, R, C>& m, T2 s) {
-      return m / s;
+      return divide(m, s);  // TODO(carp): stan::math::divide(m, s);
     }
 
      /**

--- a/test/unit/math/rev/mat/fun/elt_divide_test.cpp
+++ b/test/unit/math/rev/mat/fun/elt_divide_test.cpp
@@ -173,3 +173,48 @@ TEST(AgradRevMatrix,elt_divide_mat_dv) {
   EXPECT_FLOAT_EQ(2.0 / (- 10.0 * 10.0), g[0]);
   EXPECT_FLOAT_EQ(0.0,g[1]);
 }
+TEST(AgradRevMatrix,elt_divide_mat_scal_dv) {
+  using stan::math::elt_divide;
+  using stan::math::matrix_d;
+  using stan::math::matrix_v;
+  using stan::math::var;
+
+  matrix_d x(2,3);
+  x << 2, 5, 7, 13, 29, 112;
+
+  var y = 10;
+
+  matrix_v z = elt_divide(x, y);
+  z.sum().grad();
+  EXPECT_FLOAT_EQ(x.sum() * (-1.0 / 100),  y.adj());
+}
+TEST(AgradRevMatrix,elt_divide_vec_scal_dv) {
+  using stan::math::elt_divide;
+  using stan::math::vector_d;
+  using stan::math::vector_v;
+  using stan::math::var;
+
+  vector_d x(6);
+  x << 2, 5, 7, 13, 29, 112;
+
+  var y = 10;
+
+  vector_v z = elt_divide(x, y);
+  z.sum().grad();
+  EXPECT_FLOAT_EQ(x.sum() * (-1.0 / 100),  y.adj());
+}
+TEST(AgradRevMatrix,elt_divide_row_vec_scal_dv) {
+  using stan::math::elt_divide;
+  using stan::math::row_vector_d;
+  using stan::math::row_vector_v;
+  using stan::math::var;
+
+  row_vector_d x(6);
+  x << 2, 5, 7, 13, 29, 112;
+
+  var y = 10;
+
+  row_vector_v z = elt_divide(x, y);
+  z.sum().grad();
+  EXPECT_FLOAT_EQ(x.sum() * (-1.0 / 100),  y.adj());
+}


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

Fixes `elt_divide` by calling `math::divide` rather than `operator`.

#### Intended Effect:

Allow models to compile that were not compiling as in issue report.

#### How to Verify:

Model from original Stan issue compiles;  unit tests for all matrix types.

#### Side Effects:

No.

#### Documentation:

No.

#### Reviewer Suggestions: 

Anyone.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

