### PR TITLE
Fixes #304. Inlining CVODES functions to allow compiling a Stan progr…

### DIFF
--- a/stan/math/rev/mat/functor/cvodes_utils.hpp
+++ b/stan/math/rev/mat/functor/cvodes_utils.hpp
@@ -15,12 +15,12 @@ namespace stan {
     // no-op error handler to silence CVodes error output;  errors handled
     // directly by Stan
     extern "C"
-    void cvodes_silent_err_handler(int error_code, const char *module,
+    inline void cvodes_silent_err_handler(int error_code, const char *module,
                                    const char *function, char *msg,
                                    void *eh_data) {
     }
 
-    void cvodes_check_flag(int flag, const std::string& func_name) {
+    inline void cvodes_check_flag(int flag, const std::string& func_name) {
       if (flag < 0) {
         std::ostringstream ss;
         ss << func_name << " failed with error flag " << flag;
@@ -28,8 +28,10 @@ namespace stan {
       }
     }
 
-    void cvodes_set_options(void* cvodes_mem, double rel_tol, double abs_tol,
-                            long int max_num_steps) {   // NOLINT(runtime/int)
+    inline void cvodes_set_options(void* cvodes_mem,
+                                   double rel_tol, double abs_tol,
+                                   // NOLINTNEXTLINE(runtime/int)
+                                   long int max_num_steps) {
       // forward CVode errors to noop error handler
       CVodeSetErrHandlerFn(cvodes_mem, cvodes_silent_err_handler, 0);
 

--- a/stan/math/rev/mat/functor/integrate_ode_bdf.hpp
+++ b/stan/math/rev/mat/functor/integrate_ode_bdf.hpp
@@ -20,20 +20,20 @@
 #include <vector>
 
 namespace stan {
-
   namespace math {
 
     /**
      * Free memory allocated for CVODES state, sensitivity, and
-     * general memory.  
+     * general memory.
      *
      * @param[in] cvodes_state State vector.
      * @param[in] cvodes_state_sens Sensivity vector.
      * @param[in] cvodes_mem Memory held for CVODES.
      * @param[in] S Number of sensitivities being calculated.
      */
-    void free_cvodes_memory(N_Vector& cvodes_state, N_Vector* cvodes_state_sens,
-                            void* cvodes_mem, size_t S) {
+    inline void free_cvodes_memory(N_Vector& cvodes_state,
+                                   N_Vector* cvodes_state_sens,
+                                   void* cvodes_mem, size_t S) {
       N_VDestroy_Serial(cvodes_state);
       if (cvodes_state_sens != NULL)
         N_VDestroyVectorArray_Serial(cvodes_state_sens, S);


### PR DESCRIPTION
#### Submisison Checklist

- [ ] Run unit tests: `./runTests.py test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary:
Inlining a few functions to allow CmdStan and other interfaces to compile models without linking CVODES libraries if CVODES isn't being used.

#### Intended Effect:
Allows simpler compilation.

#### How to Verify:
From CmdStan, use this branch to build a Stan program without the CVODES branch. (I've done it.)

#### Side Effects:
No known side-effects.

#### Documentation:
None.

#### Reviewer Suggestions: 
Anyone.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Columbia University.

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

…am without CVODES.