### PR TITLE
Fix overflow in poisson_cdf

### DIFF
--- a/stan/math/prim/scal/prob/poisson_ccdf_log.hpp
+++ b/stan/math/prim/scal/prob/poisson_ccdf_log.hpp
@@ -54,10 +54,8 @@ namespace stan {
 
       // Compute vectorized cdf_log and gradient
       using stan::math::value_of;
-      using stan::math::gamma_q;
-      using boost::math::tgamma;
-      using std::exp;
-      using std::pow;
+      using boost::math::gamma_p;
+      using boost::math::lgamma;
       using std::log;
       using std::exp;
 
@@ -78,13 +76,13 @@ namespace stan {
 
         const T_partials_return n_dbl = value_of(n_vec[i]);
         const T_partials_return lambda_dbl = value_of(lambda_vec[i]);
-        const T_partials_return Pi = 1.0 - gamma_q(n_dbl+1, lambda_dbl);
+        const T_partials_return log_Pi = log(gamma_p(n_dbl+1, lambda_dbl));
 
-        P += log(Pi);
+        P += log_Pi;
 
         if (!is_constant_struct<T_rate>::value)
-          operands_and_partials.d_x1[i] += exp(-lambda_dbl)
-            * pow(lambda_dbl, n_dbl) / tgamma(n_dbl+1) / Pi;
+          operands_and_partials.d_x1[i] += exp(n_dbl * log(lambda_dbl)
+            - lambda_dbl - lgamma(n_dbl+1) - log_Pi);
       }
 
       return operands_and_partials.value(P);

--- a/stan/math/prim/scal/prob/poisson_cdf_log.hpp
+++ b/stan/math/prim/scal/prob/poisson_cdf_log.hpp
@@ -54,10 +54,8 @@ namespace stan {
 
       // Compute vectorized cdf_log and gradient
       using stan::math::value_of;
-      using stan::math::gamma_q;
-      using boost::math::tgamma;
-      using std::exp;
-      using std::pow;
+      using boost::math::gamma_q;
+      using boost::math::lgamma;
       using std::log;
       using std::exp;
 
@@ -78,13 +76,13 @@ namespace stan {
 
         const T_partials_return n_dbl = value_of(n_vec[i]);
         const T_partials_return lambda_dbl = value_of(lambda_vec[i]);
-        const T_partials_return Pi = gamma_q(n_dbl+1, lambda_dbl);
+        const T_partials_return log_Pi = log(gamma_q(n_dbl+1, lambda_dbl));
 
-        P += log(Pi);
+        P += log_Pi;
 
         if (!is_constant_struct<T_rate>::value)
-          operands_and_partials.d_x1[i] -= exp(-lambda_dbl)
-            * pow(lambda_dbl, n_dbl) / tgamma(n_dbl+1) / Pi;
+          operands_and_partials.d_x1[i] += - exp(n_dbl * log(lambda_dbl)
+            - lambda_dbl - lgamma(n_dbl+1) - log_Pi);
       }
 
       return operands_and_partials.value(P);

--- a/test/prob/poisson/poisson_ccdf_log_test.hpp
+++ b/test/prob/poisson/poisson_ccdf_log_test.hpp
@@ -15,7 +15,12 @@ public:
     param[1] = 13.0;         // lambda
     parameters.push_back(param);
     ccdf_log.push_back(std::log(1.0 - 0.8904649795242025600572)); // expected ccdf_log
-    
+
+    param[0] = 82;           // n
+    param[1] = 42.0;         // lambda
+    parameters.push_back(param);
+    ccdf_log.push_back(std::log(1.0 - 0.9999999845303266798879)); // expected ccdf_log
+
     param[0] = 0.0;          // n
     param[1] = 3.0;          // lambda
     parameters.push_back(param);

--- a/test/unit/math/fwd/mat/vectorize/expect_fwd_matrix_value.hpp
+++ b/test/unit/math/fwd/mat/vectorize/expect_fwd_matrix_value.hpp
@@ -1,7 +1,7 @@
 #ifndef TEST_UNIT_MATH_FWD_MAT_VECTORIZE_EXPECT_FWD_MATRIX_VALUE_HPP
 #define TEST_UNIT_MATH_FWD_MAT_VECTORIZE_EXPECT_FWD_MATRIX_VALUE_HPP
 
-#include <stan/math/fwd/mat.hpP>
+#include <stan/math/fwd/mat.hpp>
 #include <vector>
 #include <Eigen/Dense>
 #include <test/unit/math/fwd/mat/vectorize/build_fwd_matrix.hpp>


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py test/unit`.
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license

#### Summary:

`poisson_cdf_log` and `poisson_ccdf_log` compute gamma(n), which overflows pretty quickly. This makes truncated/censored poisson models difficult to implement in stan.

This patch does most of the computation on a log scale.

#### Side Effects:

Extreme values return 0 or -inf instead of raising an exception.

#### Copyright and Licensing

Copyright holder would be Adrian Seyboldt, if you fell this is necessary for such a small patch :-)

By submitting this pull request, I agree to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)