### PR TITLE
Fixes #321. Adding test for int divide

### DIFF
--- a/stan/math/prim/scal/fun/divide.hpp
+++ b/stan/math/prim/scal/fun/divide.hpp
@@ -1,6 +1,8 @@
 #ifndef STAN_MATH_PRIM_SCAL_FUN_DIVIDE_HPP
 #define STAN_MATH_PRIM_SCAL_FUN_DIVIDE_HPP
 
+#include <stan/math/prim/scal/err/domain_error.hpp>
+#include <stan/math/prim/scal/meta/likely.hpp>
 #include <stan/math/prim/scal/meta/return_type.hpp>
 #include <cstddef>
 #include <cstdlib>
@@ -22,6 +24,8 @@ namespace stan {
     }
 
     inline int divide(const int x, const int y) {
+      if (unlikely(y == 0))
+        domain_error("divide", "denominator is", y, "");
       return std::div(x, y).quot;
     }
 

--- a/test/unit/math/prim/scal/fun/divide_test.cpp
+++ b/test/unit/math/prim/scal/fun/divide_test.cpp
@@ -46,3 +46,10 @@ TEST(MathFunctions, divide_modulus) {
     for(int j = 1; j < 50; j++)
       test_divide_modulus(i, j);
 }
+
+TEST(MathFunctions, int_divide_by_0) {
+  int x = 1;
+  int y = 0;
+  int z;
+  EXPECT_THROW(z = stan::math::divide(x, y), std::domain_error);
+}


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

An int div by 0 currently throws an error in C++ (not an exception). This patch fixes it by testing for a 0 denominator for int division and throws a domain error with the message:
```
divide: denominator is 0
```

#### Intended Effect:
Stops all the interfaces from crashing on int div by 0.

#### How to Verify:
Run a model with int `1 / 0`.

#### Documentation:
None.

#### Reviewer Suggestions: 
Anyone.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Columbia University.

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

