### PR TITLE
Changes input error checking for a handful of functions

### DIFF
--- a/stan/math/fwd/mat/fun/dot_product.hpp
+++ b/stan/math/fwd/mat/fun/dot_product.hpp
@@ -4,7 +4,7 @@
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/mat/fun/typedefs.hpp>
 #include <stan/math/prim/mat/err/check_vector.hpp>
-#include <stan/math/prim/mat/err/check_matching_sizes.hpp>
+#include <stan/math/prim/arr/err/check_matching_sizes.hpp>
 #include <stan/math/fwd/mat/fun/typedefs.hpp>
 #include <stan/math/fwd/mat/fun/to_fvar.hpp>
 #include <vector>

--- a/stan/math/fwd/mat/fun/multiply.hpp
+++ b/stan/math/fwd/mat/fun/multiply.hpp
@@ -9,7 +9,6 @@
 #include <stan/math/fwd/mat/fun/to_fvar.hpp>
 #include <stan/math/fwd/mat/fun/dot_product.hpp>
 #include <boost/math/tools/promotion.hpp>
-#include <stdexcept>
 #include <vector>
 
 namespace stan {
@@ -130,9 +129,7 @@ namespace stan {
     fvar<T>
     multiply(const Eigen::Matrix<fvar<T>, 1, C1>& rv,
              const Eigen::Matrix<fvar<T>, R2, 1>& v) {
-      if (rv.size() != v.size())
-        throw std::domain_error("row vector and vector must be same length "
-                                "in multiply");
+      check_multiplicable("multiply", "rv", rv, "v", v);
       return dot_product(rv, v);
     }
 
@@ -141,9 +138,7 @@ namespace stan {
     fvar<T>
     multiply(const Eigen::Matrix<fvar<T>, 1, C1>& rv,
              const Eigen::Matrix<double, R2, 1>& v) {
-      if (rv.size() != v.size())
-        throw std::domain_error("row vector and vector must be same length "
-                                "in multiply");
+      check_multiplicable("multiply", "rv", rv, "v", v);
       return dot_product(rv, v);
     }
 
@@ -152,9 +147,7 @@ namespace stan {
     fvar<T>
     multiply(const Eigen::Matrix<double, 1, C1>& rv,
              const Eigen::Matrix<fvar<T>, R2, 1>& v) {
-      if (rv.size() != v.size())
-        throw std::domain_error("row vector and vector must be same length "
-                                "in multiply");
+      check_multiplicable("multiply", "rv", rv, "v", v);
       return dot_product(rv, v);
     }
 

--- a/stan/math/fwd/mat/fun/squared_distance.hpp
+++ b/stan/math/fwd/mat/fun/squared_distance.hpp
@@ -3,7 +3,7 @@
 
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/mat/err/check_vector.hpp>
-#include <stan/math/prim/mat/err/check_matching_sizes.hpp>
+#include <stan/math/prim/arr/err/check_matching_sizes.hpp>
 #include <stan/math/fwd/core/operator_subtraction.hpp>
 #include <stan/math/fwd/mat/fun/dot_self.hpp>
 #include <stan/math/fwd/mat/fun/to_fvar.hpp>

--- a/stan/math/prim/arr.hpp
+++ b/stan/math/prim/arr.hpp
@@ -11,12 +11,14 @@
 #include <stan/math/prim/arr/meta/VectorBuilderHelper.hpp>
 #include <stan/math/prim/arr/meta/VectorView.hpp>
 
+#include <stan/math/prim/arr/err/check_matching_sizes.hpp>
 #include <stan/math/prim/arr/err/check_nonzero_size.hpp>
 #include <stan/math/prim/arr/err/check_ordered.hpp>
 
 #include <stan/math/prim/arr/fun/dot.hpp>
 #include <stan/math/prim/arr/fun/dot_self.hpp>
 #include <stan/math/prim/arr/fun/fill.hpp>
+#include <stan/math/prim/arr/fun/inverse_softmax.hpp>
 #include <stan/math/prim/arr/fun/log_sum_exp.hpp>
 #include <stan/math/prim/arr/fun/promote_scalar.hpp>
 #include <stan/math/prim/arr/fun/promote_scalar_type.hpp>

--- a/stan/math/prim/arr/err/check_matching_sizes.hpp
+++ b/stan/math/prim/arr/err/check_matching_sizes.hpp
@@ -1,5 +1,5 @@
-#ifndef STAN_MATH_PRIM_MAT_ERR_CHECK_MATCHING_SIZES_HPP
-#define STAN_MATH_PRIM_MAT_ERR_CHECK_MATCHING_SIZES_HPP
+#ifndef STAN_MATH_PRIM_ARR_ERR_CHECK_MATCHING_SIZES_HPP
+#define STAN_MATH_PRIM_ARR_ERR_CHECK_MATCHING_SIZES_HPP
 
 #include <stan/math/prim/scal/err/domain_error.hpp>
 #include <stan/math/prim/scal/err/check_size_match.hpp>

--- a/stan/math/prim/arr/fun/inverse_softmax.hpp
+++ b/stan/math/prim/arr/fun/inverse_softmax.hpp
@@ -1,7 +1,7 @@
-#ifndef STAN_MATH_PRIM_SCAL_FUN_INVERSE_SOFTMAX_HPP
-#define STAN_MATH_PRIM_SCAL_FUN_INVERSE_SOFTMAX_HPP
+#ifndef STAN_MATH_ARR_SCAL_FUN_INVERSE_SOFTMAX_HPP
+#define STAN_MATH_ARR_SCAL_FUN_INVERSE_SOFTMAX_HPP
 
-#include <stan/math/prim/mat/err/check_matching_sizes.hpp>
+#include <stan/math/prim/arr/err/check_matching_sizes.hpp>
 #include <cmath>
 
 namespace stan {

--- a/stan/math/prim/mat.hpp
+++ b/stan/math/prim/mat.hpp
@@ -28,7 +28,6 @@
 #include <stan/math/prim/mat/err/check_ldlt_factor.hpp>
 #include <stan/math/prim/mat/err/check_lower_triangular.hpp>
 #include <stan/math/prim/mat/err/check_matching_dims.hpp>
-#include <stan/math/prim/mat/err/check_matching_sizes.hpp>
 #include <stan/math/prim/mat/err/check_multiplicable.hpp>
 #include <stan/math/prim/mat/err/check_ordered.hpp>
 #include <stan/math/prim/mat/err/check_pos_definite.hpp>

--- a/stan/math/prim/mat/fun/assign.hpp
+++ b/stan/math/prim/mat/fun/assign.hpp
@@ -4,7 +4,7 @@
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/scal/err/invalid_argument.hpp>
 #include <stan/math/prim/scal/err/check_size_match.hpp>
-#include <stan/math/prim/mat/err/check_matching_sizes.hpp>
+#include <stan/math/prim/arr/err/check_matching_sizes.hpp>
 #include <stan/math/prim/mat/err/check_matching_dims.hpp>
 #include <iostream>
 #include <sstream>

--- a/stan/math/prim/mat/fun/cholesky_corr_constrain.hpp
+++ b/stan/math/prim/mat/fun/cholesky_corr_constrain.hpp
@@ -2,18 +2,17 @@
 #define STAN_MATH_PRIM_MAT_FUN_CHOLESKY_CORR_CONSTRAIN_HPP
 
 #include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <stan/math/prim/scal/err/check_size_match.hpp>
 #include <stan/math/prim/scal/fun/log1m.hpp>
 #include <stan/math/prim/scal/fun/square.hpp>
 #include <stan/math/prim/scal/fun/corr_constrain.hpp>
 #include <cmath>
 #include <iostream>
-#include <stdexcept>
 
 namespace stan {
   namespace math {
 
     // CHOLESKY CORRELATION MATRIX
-
     template <typename T>
     Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>
     cholesky_corr_constrain(const Eigen::Matrix<T, Eigen::Dynamic, 1>& y,
@@ -22,11 +21,9 @@ namespace stan {
       using Eigen::Matrix;
       using Eigen::Dynamic;
       int k_choose_2 = (K * (K - 1)) / 2;
-      if (k_choose_2 != y.size()) {
-        throw std::domain_error("y is not a valid unconstrained cholesky "
-                                "correlation matrix."
-                                "Require (K choose 2) elements in y.");
-      }
+      check_size_match("cholesky_corr_constrain",
+                       "y.size()", y.size(),
+                       "k_choose_2", k_choose_2);
       Matrix<T, Dynamic, 1> z(k_choose_2);
       for (int i = 0; i < k_choose_2; ++i)
         z(i) = corr_constrain(y(i));
@@ -60,11 +57,9 @@ namespace stan {
       using Eigen::Matrix;
       using Eigen::Dynamic;
       int k_choose_2 = (K * (K - 1)) / 2;
-      if (k_choose_2 != y.size()) {
-        throw std::domain_error("y is not a valid unconstrained cholesky "
-                                "correlation matrix."
-                                " Require (K choose 2) elements in y.");
-      }
+      check_size_match("cholesky_corr_constrain",
+                       "y.size()", y.size(),
+                       "k_choose_2", k_choose_2);
       Matrix<T, Dynamic, 1> z(k_choose_2);
       for (int i = 0; i < k_choose_2; ++i)
         z(i) = corr_constrain(y(i), lp);
@@ -90,7 +85,5 @@ namespace stan {
     }
 
   }
-
 }
-
 #endif

--- a/stan/math/prim/mat/fun/cholesky_factor_constrain.hpp
+++ b/stan/math/prim/mat/fun/cholesky_factor_constrain.hpp
@@ -3,6 +3,8 @@
 
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/mat/fun/sum.hpp>
+#include <stan/math/prim/scal/err/check_greater.hpp>
+#include <stan/math/prim/scal/err/check_size_match.hpp>
 #include <cmath>
 #include <stdexcept>
 #include <vector>
@@ -29,12 +31,13 @@ namespace stan {
                               int M,
                               int N) {
       using std::exp;
-      if (M < N)
-        throw std::domain_error("cholesky_factor_constrain: "
-                                "num rows must be >= num cols");
-      if (x.size() != ((N * (N + 1)) / 2 + (M - N) * N))
-        throw std::domain_error("cholesky_factor_constrain: x.size() must"
-                                " be (N * (N + 1)) / 2 + (M - N) * N");
+      check_greater("cholesky_factor_constrain",
+                    "num rows (must be greater than num cols)",
+                    M, N);
+      check_size_match("cholesky_factor_constrain",
+                       "x.size()", x.size(),
+                       "((N * (N + 1)) / 2 + (M - N) * N)",
+                       ((N * (N + 1)) / 2 + (M - N) * N));
       Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> y(M, N);
       T zero(0);
       int pos = 0;
@@ -56,8 +59,8 @@ namespace stan {
     /**
      * Return the Cholesky factor of the specified size read from the
      * specified vector and increment the specified log probability
-     * reference with the log Jacobian adjustment of the transform.  A
-     * total of (N choose 2) + N + N * (M - N) free parameters are required to read
+     * reference with the log Jacobian adjustment of the transform.  A total
+     * of (N choose 2) + N + N * (M - N) free parameters are required to read
      * an M by N Cholesky factor.
      *
      * @tparam T Type of scalars in matrix
@@ -74,10 +77,10 @@ namespace stan {
                               int N,
                               T& lp) {
       // cut-and-paste from above, so checks twice
-
-      if (x.size() != ((N * (N + 1)) / 2 + (M - N) * N))
-        throw std::domain_error("cholesky_factor_constrain: x.size() "
-                                "must be (k choose 2) + k");
+      check_size_match("cholesky_factor_constrain",
+                       "x.size()", x.size(),
+                       "((N * (N + 1)) / 2 + (M - N) * N)",
+                       ((N * (N + 1)) / 2 + (M - N) * N));
       int pos = 0;
       std::vector<T> log_jacobians(N);
       for (int n = 0; n < N; ++n) {
@@ -89,7 +92,5 @@ namespace stan {
     }
 
   }
-
 }
-
 #endif

--- a/stan/math/prim/mat/fun/cholesky_factor_constrain.hpp
+++ b/stan/math/prim/mat/fun/cholesky_factor_constrain.hpp
@@ -3,7 +3,7 @@
 
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/mat/fun/sum.hpp>
-#include <stan/math/prim/scal/err/check_greater.hpp>
+#include <stan/math/prim/scal/err/check_greater_or_equal.hpp>
 #include <stan/math/prim/scal/err/check_size_match.hpp>
 #include <cmath>
 #include <stdexcept>
@@ -31,9 +31,9 @@ namespace stan {
                               int M,
                               int N) {
       using std::exp;
-      check_greater("cholesky_factor_constrain",
-                    "num rows (must be greater than num cols)",
-                    M, N);
+      check_greater_or_equal("cholesky_factor_constrain",
+                             "num rows (must be greater or equal to num cols)",
+                             M, N);
       check_size_match("cholesky_factor_constrain",
                        "x.size()", x.size(),
                        "((N * (N + 1)) / 2 + (M - N) * N)",

--- a/stan/math/prim/mat/fun/cholesky_factor_free.hpp
+++ b/stan/math/prim/mat/fun/cholesky_factor_free.hpp
@@ -23,9 +23,7 @@ namespace stan {
     cholesky_factor_free(const Eigen::Matrix
                          <T, Eigen::Dynamic, Eigen::Dynamic>& y) {
       using std::log;
-      if (!check_cholesky_factor("cholesky_factor_free", "y", y))
-        throw std::domain_error("cholesky_factor_free: "
-                                "y is not a Cholesky factor");
+      check_cholesky_factor("cholesky_factor_free", "y", y);
       int M = y.rows();
       int N = y.cols();
       Eigen::Matrix<T, Eigen::Dynamic, 1> x((N * (N + 1)) / 2 + (M - N) * N);

--- a/stan/math/prim/mat/fun/columns_dot_product.hpp
+++ b/stan/math/prim/mat/fun/columns_dot_product.hpp
@@ -3,7 +3,7 @@
 
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/mat/fun/typedefs.hpp>
-#include <stan/math/prim/mat/err/check_matching_sizes.hpp>
+#include <stan/math/prim/arr/err/check_matching_sizes.hpp>
 
 namespace stan {
   namespace math {

--- a/stan/math/prim/mat/fun/corr_matrix_constrain.hpp
+++ b/stan/math/prim/mat/fun/corr_matrix_constrain.hpp
@@ -3,6 +3,7 @@
 
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/mat/meta/index_type.hpp>
+#include <stan/math/prim/scal/err/check_size_match.hpp>
 #include <stan/math/prim/scal/fun/corr_constrain.hpp>
 #include <stan/math/prim/mat/fun/read_corr_matrix.hpp>
 #include <stdexcept>
@@ -44,8 +45,9 @@ namespace stan {
       typedef typename index_type<Matrix<T, Dynamic, 1> >::type size_type;
 
       size_type k_choose_2 = (k * (k - 1)) / 2;
-      if (k_choose_2 != x.size())
-        throw std::invalid_argument("x is not a valid correlation matrix");
+      check_size_match("cov_matrix_constrain",
+                       "x.size()", x.size(),
+                       "k_choose_2", k_choose_2);
       Eigen::Array<T, Eigen::Dynamic, 1> cpcs(k_choose_2);
       for (size_type i = 0; i < k_choose_2; ++i)
         cpcs[i] = corr_constrain(x[i]);
@@ -83,8 +85,9 @@ namespace stan {
       typedef typename index_type<Matrix<T, Dynamic, 1> >::type size_type;
 
       size_type k_choose_2 = (k * (k - 1)) / 2;
-      if (k_choose_2 != x.size())
-        throw std::invalid_argument("x is not a valid correlation matrix");
+      check_size_match("cov_matrix_constrain",
+                       "x.size()", x.size(),
+                       "k_choose_2", k_choose_2);
       Array<T, Dynamic, 1> cpcs(k_choose_2);
       for (size_type i = 0; i < k_choose_2; ++i)
         cpcs[i] = corr_constrain(x[i], lp);
@@ -92,7 +95,5 @@ namespace stan {
     }
 
   }
-
 }
-
 #endif

--- a/stan/math/prim/mat/fun/corr_matrix_free.hpp
+++ b/stan/math/prim/mat/fun/corr_matrix_free.hpp
@@ -1,14 +1,14 @@
 #ifndef STAN_MATH_PRIM_MAT_FUN_CORR_MATRIX_FREE_HPP
 #define STAN_MATH_PRIM_MAT_FUN_CORR_MATRIX_FREE_HPP
 
+#include <stan/math/prim/arr/err/check_nonzero_size.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
-#include <stan/math/prim/mat/meta/index_type.hpp>
 #include <stan/math/prim/mat/err/constraint_tolerance.hpp>
+#include <stan/math/prim/mat/err/check_square.hpp>
+#include <stan/math/prim/scal/err/domain_error.hpp>
 #include <stan/math/prim/mat/fun/factor_cov_matrix.hpp>
-#include <boost/throw_exception.hpp>
+#include <stan/math/prim/mat/meta/index_type.hpp>
 #include <cmath>
-#include <sstream>
-#include <stdexcept>
 
 namespace stan {
   namespace math {
@@ -37,35 +37,29 @@ namespace stan {
     Eigen::Matrix<T, Eigen::Dynamic, 1>
     corr_matrix_free(const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>&
                      y) {
+      check_square("corr_matrix_free", "y", y);
+      check_nonzero_size("corr_matrix_free", "y", y);
+
       using Eigen::Array;
       using Eigen::Dynamic;
       using Eigen::Matrix;
       typedef typename index_type<Matrix<T, Dynamic, 1> >::type size_type;
 
       size_type k = y.rows();
-      if (y.cols() != k)
-        throw std::domain_error("y is not a square matrix");
-      if (k == 0)
-        throw std::domain_error("y has no elements");
       size_type k_choose_2 = (k * (k-1)) / 2;
       Array<T, Dynamic, 1> x(k_choose_2);
       Array<T, Dynamic, 1> sds(k);
       bool successful = factor_cov_matrix(y, x, sds);
       if (!successful)
-        throw std::runtime_error("factor_cov_matrix failed on y");
+        domain_error("corr_matrix_free",
+                     "factor_cov_matrix failed on y", y, "");
       for (size_type i = 0; i < k; ++i) {
         // sds on log scale unconstrained
-        if (fabs(sds[i] - 0.0) >= CONSTRAINT_TOLERANCE) {
-          std::stringstream s;
-          s << "all standard deviations must be zero."
-            << " found log(sd[" << i << "])=" << sds[i] << std::endl;
-          BOOST_THROW_EXCEPTION(std::runtime_error(s.str()));
-        }
+        check_bounded("corr_matrix_free", "log(sd)",
+                      sds[i], -CONSTRAINT_TOLERANCE, CONSTRAINT_TOLERANCE);
       }
       return x.matrix();
     }
   }
-
 }
-
 #endif

--- a/stan/math/prim/mat/fun/cov_matrix_constrain.hpp
+++ b/stan/math/prim/mat/fun/cov_matrix_constrain.hpp
@@ -4,9 +4,9 @@
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/mat/meta/index_type.hpp>
 #include <stan/math/prim/scal/fun/constants.hpp>
+#include <stan/math/prim/scal/err/check_size_match.hpp>
 #include <stan/math/prim/mat/fun/multiply_lower_tri_self_transpose.hpp>
 #include <cmath>
-#include <stdexcept>
 
 namespace stan {
   namespace math {
@@ -21,7 +21,7 @@ namespace stan {
      * @param x The vector to convert to a covariance matrix.
      * @param K The number of rows and columns of the resulting
      * covariance matrix.
-     * @throws std::domain_error if (x.size() != K + (K choose 2)).
+     * @throws std::invalid_argument if (x.size() != K + (K choose 2)).
      */
     template <typename T>
     Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>
@@ -35,8 +35,9 @@ namespace stan {
       typedef typename index_type<Matrix<T, Dynamic, Dynamic> >::type size_type;
 
       Matrix<T, Dynamic, Dynamic> L(K, K);
-      if (x.size() != (K * (K + 1)) / 2)
-        throw std::domain_error("x.size() != K + (K choose 2)");
+      check_size_match("cov_matrix_constrain",
+                       "x.size()", x.size(),
+                       "K + (K choose 2)", (K * (K + 1)) / 2);
       int i = 0;
       for (size_type m = 0; m < K; ++m) {
         for (int n = 0; n < m; ++n)
@@ -74,8 +75,9 @@ namespace stan {
       using Eigen::Matrix;
       typedef typename index_type<Matrix<T, Dynamic, Dynamic> >::type size_type;
 
-      if (x.size() != (K * (K + 1)) / 2)
-        throw std::domain_error("x.size() != K + (K choose 2)");
+      check_size_match("cov_matrix_constrain",
+                       "x.size()", x.size(),
+                       "K + (K choose 2)", (K * (K + 1)) / 2);
       Matrix<T, Dynamic, Dynamic> L(K, K);
       int i = 0;
       for (size_type m = 0; m < K; ++m) {

--- a/stan/math/prim/mat/fun/cov_matrix_free.hpp
+++ b/stan/math/prim/mat/fun/cov_matrix_free.hpp
@@ -1,10 +1,12 @@
 #ifndef STAN_MATH_PRIM_MAT_FUN_COV_MATRIX_FREE_HPP
 #define STAN_MATH_PRIM_MAT_FUN_COV_MATRIX_FREE_HPP
 
+#include <stan/math/prim/arr/err/check_nonzero_size.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/mat/meta/index_type.hpp>
+#include <stan/math/prim/mat/err/check_square.hpp>
+#include <stan/math/prim/scal/err/check_positive.hpp>
 #include <cmath>
-#include <stdexcept>
 
 namespace stan {
   namespace math {
@@ -34,15 +36,13 @@ namespace stan {
     template <typename T>
     Eigen::Matrix<T, Eigen::Dynamic, 1>
     cov_matrix_free(const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& y) {
+      check_square("cov_matrix_free", "y", y);
+      check_nonzero_size("cov_matrix_free", "y", y);
+
       using std::log;
       int K = y.rows();
-      if (y.cols() != K)
-        throw std::domain_error("y is not a square matrix");
-      if (K == 0)
-        throw std::domain_error("y has no elements");
       for (int k = 0; k < K; ++k)
-        if (!(y(k, k) > 0.0))
-          throw std::domain_error("y has non-positive diagonal");
+        check_positive("cov_matrix_free", "y", y(k, k));
       Eigen::Matrix<T, Eigen::Dynamic, 1> x((K * (K + 1)) / 2);
       // FIXME: see Eigen LDLT for rank-revealing version -- use that
       // even if less efficient?
@@ -60,7 +60,5 @@ namespace stan {
     }
 
   }
-
 }
-
 #endif

--- a/stan/math/prim/mat/fun/cov_matrix_free_lkj.hpp
+++ b/stan/math/prim/mat/fun/cov_matrix_free_lkj.hpp
@@ -1,9 +1,11 @@
 #ifndef STAN_MATH_PRIM_MAT_FUN_COV_MATRIX_FREE_LKJ_HPP
 #define STAN_MATH_PRIM_MAT_FUN_COV_MATRIX_FREE_LKJ_HPP
 
+#include <stan/math/prim/mat/err/check_square.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/mat/meta/index_type.hpp>
-#include <stdexcept>
+#include <stan/math/prim/arr/err/check_nonzero_size.hpp>
+#include <stan/math/prim/scal/err/domain_error.hpp>
 
 namespace stan {
   namespace math {
@@ -35,17 +37,16 @@ namespace stan {
       using Eigen::Matrix;
       typedef typename index_type<Matrix<T, Dynamic, Dynamic> >::type size_type;
 
+      check_nonzero_size("cov_matrix_free_lkj", "y", y);
+      check_square("cov_matrix_free_lkj", "y", y);
       size_type k = y.rows();
-      if (y.cols() != k)
-        throw std::domain_error("y is not a square matrix");
-      if (k == 0)
-        throw std::domain_error("y has no elements");
       size_type k_choose_2 = (k * (k-1)) / 2;
       Array<T, Dynamic, 1> cpcs(k_choose_2);
       Array<T, Dynamic, 1> sds(k);
       bool successful = factor_cov_matrix(y, cpcs, sds);
       if (!successful)
-        throw std::runtime_error("factor_cov_matrix failed on y");
+        domain_error("cov_matrix_free_lkj",
+                     "factor_cov_matrix failed on y", "", "");
       Matrix<T, Dynamic, 1> x(k_choose_2 + k);
       size_type pos = 0;
       for (size_type i = 0; i < k_choose_2; ++i)
@@ -56,7 +57,5 @@ namespace stan {
     }
 
   }
-
 }
-
 #endif

--- a/stan/math/prim/mat/fun/diag_post_multiply.hpp
+++ b/stan/math/prim/mat/fun/diag_post_multiply.hpp
@@ -1,9 +1,10 @@
 #ifndef STAN_MATH_PRIM_MAT_FUN_DIAG_POST_MULTIPLY_HPP
 #define STAN_MATH_PRIM_MAT_FUN_DIAG_POST_MULTIPLY_HPP
 
+#include <stan/math/prim/mat/err/check_vector.hpp>
+#include <stan/math/prim/scal/err/check_size_match.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <boost/math/tools/promotion.hpp>
-#include <stdexcept>
 
 namespace stan {
   namespace math {
@@ -13,11 +14,11 @@ namespace stan {
                   R1, C1>
     diag_post_multiply(const Eigen::Matrix<T1, R1, C1>& m1,
                   const Eigen::Matrix<T2, R2, C2>& m2) {
-      if (m2.cols() != 1 && m2.rows() != 1)
-        throw std::domain_error("m2 must be a vector");
+      check_vector("diag_post_multiply", "m2", m2);
       int m1_cols = m1.cols();
-      if (m2.size() != m1_cols)
-        throw std::domain_error("m2 must have same length as m1 has columns");
+      check_size_match("diag_post_multiply",
+                       "m2.size()", m2.size(),
+                       "m1.cols()", m1_cols);
       int m1_rows = m1.rows();
       Eigen::Matrix<typename boost::math::tools::promote_args<T1, T2>::type,
                     R1, C1>

--- a/stan/math/prim/mat/fun/diag_pre_multiply.hpp
+++ b/stan/math/prim/mat/fun/diag_pre_multiply.hpp
@@ -1,9 +1,10 @@
 #ifndef STAN_MATH_PRIM_MAT_FUN_DIAG_PRE_MULTIPLY_HPP
 #define STAN_MATH_PRIM_MAT_FUN_DIAG_PRE_MULTIPLY_HPP
 
+#include <stan/math/prim/mat/err/check_vector.hpp>
+#include <stan/math/prim/scal/err/check_size_match.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <boost/math/tools/promotion.hpp>
-#include <stdexcept>
 
 namespace stan {
   namespace math {
@@ -13,11 +14,11 @@ namespace stan {
                   R2, C2>
     diag_pre_multiply(const Eigen::Matrix<T1, R1, C1>& m1,
                   const Eigen::Matrix<T2, R2, C2>& m2) {
-      if (m1.cols() != 1 && m1.rows() != 1)
-        throw std::domain_error("m1 must be a vector");
+      check_vector("diag_pre_multiply", "m1", m1);
       int m2_rows = m2.rows();
-      if (m1.size() != m2_rows)
-        throw std::domain_error("m1 must have same length as m2 has rows");
+      check_size_match("diag_pre_multiply",
+                       "m1.size()", m1.size(),
+                       "m2.rows()", m2_rows);
       int m2_cols = m2.cols();
       Eigen::Matrix<typename boost::math::tools::promote_args<T1, T2>::type,
                     R2, C2>

--- a/stan/math/prim/mat/fun/distance.hpp
+++ b/stan/math/prim/mat/fun/distance.hpp
@@ -4,7 +4,7 @@
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/mat/fun/squared_distance.hpp>
 #include <stan/math/prim/mat/err/check_vector.hpp>
-#include <stan/math/prim/mat/err/check_matching_sizes.hpp>
+#include <stan/math/prim/arr/err/check_matching_sizes.hpp>
 #include <boost/math/tools/promotion.hpp>
 
 namespace stan {

--- a/stan/math/prim/mat/fun/dot_product.hpp
+++ b/stan/math/prim/mat/fun/dot_product.hpp
@@ -3,7 +3,7 @@
 
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/mat/err/check_vector.hpp>
-#include <stan/math/prim/mat/err/check_matching_sizes.hpp>
+#include <stan/math/prim/arr/err/check_matching_sizes.hpp>
 #include <vector>
 
 namespace stan {

--- a/stan/math/prim/mat/fun/inverse_spd.hpp
+++ b/stan/math/prim/mat/fun/inverse_spd.hpp
@@ -4,7 +4,7 @@
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/mat/err/check_square.hpp>
 #include <stan/math/prim/mat/err/check_symmetric.hpp>
-#include <stdexcept>
+#include <stan/math/prim/scal/err/domain_error.hpp>
 
 namespace stan {
   namespace math {
@@ -27,16 +27,13 @@ namespace stan {
       // mmt = T(0.5) * mmt;
       LDLT<Matrix<T, Dynamic, Dynamic> > ldlt(mmt);  // 0.5*(m+m.transpose()));
       if (ldlt.info() != Eigen::Success)
-        throw std::domain_error("Error in inverse_spd, LDLT "
-                                "factorization failed");
+        domain_error("invese_spd", "LDLT factor failed", "", "");
       if (!ldlt.isPositive())
-        throw std::domain_error("Error in inverse_spd, matrix "
-                                "not positive definite");
+        domain_error("invese_spd", "matrix not positive definite", "", "");
       Matrix<T, Dynamic, 1> diag_ldlt = ldlt.vectorD();
       for (int i = 0; i < diag_ldlt.size(); ++i)
         if (diag_ldlt(i) <= 0)
-          throw std::domain_error("Error in inverse_spd, matrix "
-                                  "not positive definite");
+          domain_error("invese_spd", "matrix not positive definite", "", "");
       return ldlt.solve(Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>
                         ::Identity(m.rows(), m.cols()));
     }

--- a/stan/math/prim/mat/fun/max.hpp
+++ b/stan/math/prim/mat/fun/max.hpp
@@ -1,6 +1,7 @@
 #ifndef STAN_MATH_PRIM_MAT_FUN_MAX_HPP
 #define STAN_MATH_PRIM_MAT_FUN_MAX_HPP
 
+#include <stan/math/prim/arr/err/check_nonzero_size.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <algorithm>
 #include <limits>
@@ -19,8 +20,7 @@ namespace stan {
      * @throw std::domain_error If the size of the vector is zero.
      */
     inline int max(const std::vector<int>& x) {
-      if (x.size() == 0)
-        throw std::domain_error("error: cannot take max of empty int vector");
+      check_nonzero_size("max", "int vector", x);
       int max = x[0];
       for (size_t i = 1; i < x.size(); ++i)
         if (x[i] > max)

--- a/stan/math/prim/mat/fun/mdivide_right_tri.hpp
+++ b/stan/math/prim/mat/fun/mdivide_right_tri.hpp
@@ -6,8 +6,8 @@
 #include <stan/math/prim/mat/fun/transpose.hpp>
 #include <stan/math/prim/mat/err/check_multiplicable.hpp>
 #include <stan/math/prim/mat/err/check_square.hpp>
+#include <stan/math/prim/scal/err/domain_error.hpp>
 #include <boost/math/tools/promotion.hpp>
-#include <stdexcept>
 
 namespace stan {
   namespace math {
@@ -38,10 +38,11 @@ namespace stan {
       } else if (TriView == Eigen::Upper) {
         return transpose(mdivide_left_tri<Eigen::Lower>(transpose(A),
                                                         transpose(b)));
-      } else {
-        throw std::domain_error("triangular view must be Eigen::Lower or "
-                                "Eigen::Upper");
       }
+
+      domain_error("mdivide_left_tri",
+                   "triangular view must be Eigen::Lower or Eigen::Upper",
+                   "", "");
     }
 
   }

--- a/stan/math/prim/mat/fun/min.hpp
+++ b/stan/math/prim/mat/fun/min.hpp
@@ -1,10 +1,10 @@
 #ifndef STAN_MATH_PRIM_MAT_FUN_MIN_HPP
 #define STAN_MATH_PRIM_MAT_FUN_MIN_HPP
 
+#include <stan/math/prim/arr/err/check_nonzero_size.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <algorithm>
 #include <limits>
-#include <stdexcept>
 #include <vector>
 
 namespace stan {
@@ -18,8 +18,7 @@ namespace stan {
      * @tparam Type of values being compared and returned
      */
     inline int min(const std::vector<int>& x) {
-      if (x.size() == 0)
-        throw std::domain_error("error: cannot take min of empty int vector");
+      check_nonzero_size("min", "int vector", x);
       int min = x[0];
       for (size_t i = 1; i < x.size(); ++i)
         if (x[i] < min)

--- a/stan/math/prim/mat/fun/multiply.hpp
+++ b/stan/math/prim/mat/fun/multiply.hpp
@@ -6,7 +6,6 @@
 #include <stan/math/prim/mat/err/check_multiplicable.hpp>
 #include <boost/type_traits/is_arithmetic.hpp>
 #include <boost/utility/enable_if.hpp>
-#include <stdexcept>
 
 namespace stan {
   namespace math {
@@ -83,8 +82,6 @@ namespace stan {
       check_matching_sizes("multiply",
                            "rv", rv,
                            "v", v);
-      if (rv.size() != v.size())
-        throw std::domain_error("rv.size() != v.size()");
       return rv.dot(v);
     }
 

--- a/stan/math/prim/mat/fun/multiply.hpp
+++ b/stan/math/prim/mat/fun/multiply.hpp
@@ -2,7 +2,7 @@
 #define STAN_MATH_PRIM_MAT_FUN_MULTIPLY_HPP
 
 #include <stan/math/prim/mat/fun/Eigen.hpp>
-#include <stan/math/prim/mat/err/check_matching_sizes.hpp>
+#include <stan/math/prim/arr/err/check_matching_sizes.hpp>
 #include <stan/math/prim/mat/err/check_multiplicable.hpp>
 #include <boost/type_traits/is_arithmetic.hpp>
 #include <boost/utility/enable_if.hpp>

--- a/stan/math/prim/mat/fun/rows_dot_product.hpp
+++ b/stan/math/prim/mat/fun/rows_dot_product.hpp
@@ -3,7 +3,7 @@
 
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/mat/fun/typedefs.hpp>
-#include <stan/math/prim/mat/err/check_matching_sizes.hpp>
+#include <stan/math/prim/arr/err/check_matching_sizes.hpp>
 
 namespace stan {
   namespace math {

--- a/stan/math/prim/mat/fun/squared_distance.hpp
+++ b/stan/math/prim/mat/fun/squared_distance.hpp
@@ -3,7 +3,7 @@
 
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/mat/err/check_vector.hpp>
-#include <stan/math/prim/mat/err/check_matching_sizes.hpp>
+#include <stan/math/prim/arr/err/check_matching_sizes.hpp>
 #include <stan/math/prim/scal/fun/squared_distance.hpp>
 
 namespace stan {

--- a/stan/math/prim/scal.hpp
+++ b/stan/math/prim/scal.hpp
@@ -91,7 +91,6 @@
 #include <stan/math/prim/scal/fun/inv_Phi.hpp>
 #include <stan/math/prim/scal/fun/inv_sqrt.hpp>
 #include <stan/math/prim/scal/fun/inv_square.hpp>
-#include <stan/math/prim/scal/fun/inverse_softmax.hpp>
 #include <stan/math/prim/scal/fun/is_inf.hpp>
 #include <stan/math/prim/scal/fun/is_nan.hpp>
 #include <stan/math/prim/scal/fun/is_uninitialized.hpp>

--- a/stan/math/prim/scal/fun/grad_reg_inc_gamma.hpp
+++ b/stan/math/prim/scal/fun/grad_reg_inc_gamma.hpp
@@ -1,9 +1,9 @@
 #ifndef STAN_MATH_PRIM_SCAL_FUN_GRAD_REG_INC_GAMMA_HPP
 #define STAN_MATH_PRIM_SCAL_FUN_GRAD_REG_INC_GAMMA_HPP
 
+#include <stan/math/prim/scal/err/domain_error.hpp>
 #include <stan/math/prim/scal/fun/gamma_p.hpp>
 #include <cmath>
-#include <stdexcept>
 
 namespace stan {
   namespace math {
@@ -31,7 +31,8 @@ namespace stan {
         s *= - z / k;
         delta = s / ((k + a) * (k + a));
         if (isinf(delta))
-          throw domain_error("gradRegIncGamma not converging");
+          domain_error("grad_reg_inc_gamma",
+                       "is not converging", "", "");
       }
       return gamma_p(a, z) * ( dig - l ) + exp( a * l ) * S / g;
     }

--- a/stan/math/prim/scal/fun/grad_reg_inc_gamma.hpp
+++ b/stan/math/prim/scal/fun/grad_reg_inc_gamma.hpp
@@ -31,8 +31,8 @@ namespace stan {
         s *= - z / k;
         delta = s / ((k + a) * (k + a));
         if (isinf(delta))
-          domain_error("grad_reg_inc_gamma",
-                       "is not converging", "", "");
+          stan::math::domain_error("grad_reg_inc_gamma",
+                                   "is not converging", "", "");
       }
       return gamma_p(a, z) * ( dig - l ) + exp( a * l ) * S / g;
     }

--- a/stan/math/prim/scal/fun/inc_beta_dda.hpp
+++ b/stan/math/prim/scal/fun/inc_beta_dda.hpp
@@ -1,10 +1,10 @@
 #ifndef STAN_MATH_PRIM_SCAL_FUN_INC_BETA_DDA_HPP
 #define STAN_MATH_PRIM_SCAL_FUN_INC_BETA_DDA_HPP
 
+#include <stan/math/prim/scal/err/domain_error.hpp>
 #include <stan/math/prim/scal/fun/inc_beta.hpp>
 #include <stan/math/prim/scal/fun/inc_beta_ddb.hpp>
 #include <cmath>
-#include <stdexcept>
 
 namespace stan {
   namespace math {
@@ -83,8 +83,8 @@ namespace stan {
         summand *= z / k;
 
         if (k > 1e5)
-          throw std::domain_error("inc_beta_dda did "
-                                  "not converge within 100000 iterations");
+          domain_error("inc_beta_dda",
+                       "did not converge within 10000 iterations", "", "");
       }
       return inc_beta(a, b, z) * (log(z) + sum_numer / sum_denom);
     }

--- a/stan/math/prim/scal/fun/inc_beta_ddb.hpp
+++ b/stan/math/prim/scal/fun/inc_beta_ddb.hpp
@@ -77,7 +77,7 @@ namespace stan {
 
         if (k > 1e5)
           domain_error("inc_beta_ddb",
-                       "did not converge within 10000 iterations", "", "");
+                       "did not converge within 100000 iterations", "", "");
       }
 
       return inc_beta(a, b, z)

--- a/stan/math/prim/scal/fun/inc_beta_ddb.hpp
+++ b/stan/math/prim/scal/fun/inc_beta_ddb.hpp
@@ -1,10 +1,10 @@
 #ifndef STAN_MATH_PRIM_SCAL_FUN_INC_BETA_DDB_HPP
 #define STAN_MATH_PRIM_SCAL_FUN_INC_BETA_DDB_HPP
 
+#include <stan/math/prim/scal/err/domain_error.hpp>
 #include <stan/math/prim/scal/fun/inc_beta.hpp>
 #include <stan/math/prim/scal/fun/inc_beta_dda.hpp>
 #include <cmath>
-#include <stdexcept>
 
 namespace stan {
   namespace math {
@@ -76,8 +76,8 @@ namespace stan {
         summand *= z / k;
 
         if (k > 1e5)
-          throw std::domain_error("inc_beta_ddb did "
-                                  "not converge within 100000 iterations");
+          domain_error("inc_beta_ddb",
+                       "did not converge within 10000 iterations", "", "");
       }
 
       return inc_beta(a, b, z)

--- a/stan/math/prim/scal/fun/inverse_softmax.hpp
+++ b/stan/math/prim/scal/fun/inverse_softmax.hpp
@@ -1,9 +1,8 @@
 #ifndef STAN_MATH_PRIM_SCAL_FUN_INVERSE_SOFTMAX_HPP
 #define STAN_MATH_PRIM_SCAL_FUN_INVERSE_SOFTMAX_HPP
 
-#include <boost/math/tools/promotion.hpp>
-#include <boost/throw_exception.hpp>
-#include <stdexcept>
+#include <stan/math/prim/mat/err/check_matching_sizes.hpp>
+#include <cmath>
 
 namespace stan {
   namespace math {
@@ -28,14 +27,15 @@ namespace stan {
      *
      * @param simplex Simplex vector input.
      * @param y Vector into which the inverse softmax is written.
-     * @throw std::invalid_argument if size of the input and output vectors differ.
+     * @throw std::invalid_argument if size of the input and
+     *    output vectors differ.
      */
     template <typename Vector>
     void inverse_softmax(const Vector& simplex, Vector& y) {
       using std::log;
-      if (simplex.size() != y.size())
-        BOOST_THROW_EXCEPTION(std::invalid_argument
-                              ("simplex.size() != y.size()"));
+      check_matching_sizes("inverse_softmax",
+                           "simplex", simplex,
+                           "y", y);
       for (size_t i = 0; i < simplex.size(); ++i)
         y[i] = log(simplex[i]);
     }

--- a/stan/math/prim/scal/fun/lub_constrain.hpp
+++ b/stan/math/prim/scal/fun/lub_constrain.hpp
@@ -7,10 +7,10 @@
 #include <boost/math/tools/promotion.hpp>
 #include <cmath>
 #include <limits>
-#include <stdexcept>
 
 namespace stan {
   namespace math {
+
     /**
      * Return the lower- and upper-bounded scalar derived by
      * transforming the specified free scalar given the specified
@@ -114,12 +114,7 @@ namespace stan {
     lub_constrain(const T x, const TL lb, const TU ub, T& lp) {
       using std::log;
       using std::exp;
-      if (!(lb < ub)) {
-        std::stringstream s;
-        s << "domain error in lub_constrain;  lower bound = " << lb
-          << " must be strictly less than upper bound = " << ub;
-        throw std::domain_error(s.str());
-      }
+      check_less("lub_constrain", "lb", lb, ub);
       if (lb == -std::numeric_limits<double>::infinity())
         return ub_constrain(x, ub, lp);
       if (ub == std::numeric_limits<double>::infinity())

--- a/stan/math/rev/core/precomputed_gradients.hpp
+++ b/stan/math/rev/core/precomputed_gradients.hpp
@@ -1,10 +1,10 @@
 #ifndef STAN_MATH_REV_CORE_PRECOMPUTED_GRADIENTS_HPP
 #define STAN_MATH_REV_CORE_PRECOMPUTED_GRADIENTS_HPP
 
+#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
 #include <stan/math/rev/core/vari.hpp>
 #include <stan/math/rev/core/var.hpp>
 #include <algorithm>
-#include <stdexcept>
 #include <vector>
 
 namespace stan {
@@ -63,9 +63,8 @@ namespace stan {
                  .alloc_array<vari*>(vars.size())),
           gradients_(ChainableStack::memalloc_
                      .alloc_array<double>(vars.size())) {
-        if (vars.size() != gradients.size())
-          throw std::invalid_argument("sizes of vars and gradients"
-                                      " do not match");
+        check_consistent_sizes("precomputed_gradients_vari",
+                               "vars", vars, "gradients", gradients);
         for (size_t i = 0; i < vars.size(); ++i)
           varis_[i] = vars[i].vi_;
         std::copy(gradients.begin(), gradients.end(), gradients_);

--- a/stan/math/rev/mat/fun/columns_dot_product.hpp
+++ b/stan/math/rev/mat/fun/columns_dot_product.hpp
@@ -4,7 +4,7 @@
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/mat/fun/typedefs.hpp>
 #include <stan/math/prim/mat/err/check_vector.hpp>
-#include <stan/math/prim/mat/err/check_matching_sizes.hpp>
+#include <stan/math/prim/arr/err/check_matching_sizes.hpp>
 #include <stan/math/prim/scal/fun/value_of.hpp>
 #include <stan/math/rev/core.hpp>
 #include <stan/math/rev/mat/fun/typedefs.hpp>

--- a/stan/math/rev/mat/fun/dot_product.hpp
+++ b/stan/math/rev/mat/fun/dot_product.hpp
@@ -4,7 +4,7 @@
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/mat/fun/typedefs.hpp>
 #include <stan/math/prim/mat/err/check_vector.hpp>
-#include <stan/math/prim/mat/err/check_matching_sizes.hpp>
+#include <stan/math/prim/arr/err/check_matching_sizes.hpp>
 #include <stan/math/prim/scal/fun/value_of.hpp>
 #include <stan/math/rev/core.hpp>
 #include <stan/math/rev/mat/fun/typedefs.hpp>

--- a/stan/math/rev/mat/fun/log_softmax.hpp
+++ b/stan/math/rev/mat/fun/log_softmax.hpp
@@ -7,7 +7,6 @@
 #include <stan/math/prim/mat/fun/softmax.hpp>
 #include <stan/math/rev/core.hpp>
 #include <cmath>
-#include <stdexcept>
 #include <vector>
 
 namespace stan {
@@ -62,16 +61,6 @@ namespace stan {
       using Eigen::Dynamic;
 
       check_nonzero_size("log_softmax", "alpha", alpha);
-
-      if (alpha.size() == 0)
-        throw std::domain_error("arg vector to log_softmax() "
-                                "must have size > 0");
-      if (alpha.size() == 0)
-        throw std::domain_error("arg vector to log_softmax() "
-                                "must have size > 0");
-      if (alpha.size() == 0)
-        throw std::domain_error("arg vector to log_softmax() "
-                                "must have size > 0");
 
       // TODO(carpenter): replace with array alloc
       vari** alpha_vi_array

--- a/stan/math/rev/mat/fun/multiply.hpp
+++ b/stan/math/rev/mat/fun/multiply.hpp
@@ -12,7 +12,6 @@
 #include <boost/utility/enable_if.hpp>
 #include <boost/type_traits.hpp>
 #include <boost/math/tools/promotion.hpp>
-#include <stdexcept>
 
 namespace stan {
   namespace math {
@@ -128,9 +127,9 @@ namespace stan {
     boost::is_same<T2, var>::value, var >::type
       multiply(const Eigen::Matrix<T1, 1, C1>& rv,
                const Eigen::Matrix<T2, R2, 1>& v) {
-      if (rv.size() != v.size())
-        throw std::domain_error("row vector and vector must be same length "
-                                "in multiply");
+      check_multiplicable("multiply",
+                          "rv", rv,
+                          "v", v);
       return dot_product(rv, v);
     }
 

--- a/stan/math/rev/mat/fun/rows_dot_product.hpp
+++ b/stan/math/rev/mat/fun/rows_dot_product.hpp
@@ -4,7 +4,7 @@
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/mat/fun/typedefs.hpp>
 #include <stan/math/prim/mat/err/check_vector.hpp>
-#include <stan/math/prim/mat/err/check_matching_sizes.hpp>
+#include <stan/math/prim/arr/err/check_matching_sizes.hpp>
 #include <stan/math/prim/scal/fun/value_of.hpp>
 #include <stan/math/rev/core.hpp>
 #include <stan/math/rev/mat/fun/typedefs.hpp>

--- a/stan/math/rev/mat/fun/squared_distance.hpp
+++ b/stan/math/rev/mat/fun/squared_distance.hpp
@@ -5,7 +5,7 @@
 #include <stan/math/rev/scal/fun/sqrt.hpp>
 #include <stan/math/rev/mat/fun/typedefs.hpp>
 #include <stan/math/prim/mat/err/check_vector.hpp>
-#include <stan/math/prim/mat/err/check_matching_sizes.hpp>
+#include <stan/math/prim/arr/err/check_matching_sizes.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/mat/fun/typedefs.hpp>
 #include <stan/math/prim/mat/meta/index_type.hpp>

--- a/test/unit/math/fwd/mat/fun/diag_post_multiply_test.cpp
+++ b/test/unit/math/fwd/mat/fun/diag_post_multiply_test.cpp
@@ -300,15 +300,15 @@ TEST(AgradFwdMatrixDiagPostMultiply, exceptions) {
   vector_fd rvf(2);
   rvf << -1.7, 111.2;
 
-  EXPECT_THROW(diag_post_multiply(mf,mf), std::domain_error);
+  EXPECT_THROW(diag_post_multiply(mf,mf), std::invalid_argument);
 
-  EXPECT_THROW(diag_post_multiply(mf,v), std::domain_error);
-  EXPECT_THROW(diag_post_multiply(m,vf), std::domain_error);
-  EXPECT_THROW(diag_post_multiply(mf,vf), std::domain_error);
+  EXPECT_THROW(diag_post_multiply(mf,v), std::invalid_argument);
+  EXPECT_THROW(diag_post_multiply(m,vf), std::invalid_argument);
+  EXPECT_THROW(diag_post_multiply(mf,vf), std::invalid_argument);
 
-  EXPECT_THROW(diag_post_multiply(mf,rv), std::domain_error);
-  EXPECT_THROW(diag_post_multiply(m,rvf), std::domain_error);
-  EXPECT_THROW(diag_post_multiply(mf,rvf), std::domain_error);
+  EXPECT_THROW(diag_post_multiply(mf,rv), std::invalid_argument);
+  EXPECT_THROW(diag_post_multiply(m,rvf), std::invalid_argument);
+  EXPECT_THROW(diag_post_multiply(mf,rvf), std::invalid_argument);
 }
 
 TEST(AgradFwdMatrixDiagPostMultiply, vector_ffd) {
@@ -378,10 +378,10 @@ TEST(AgradFwdMatrixDiagPostMultiply, vector_ffd_exception) {
   vector_ffd B(3);
   vector_ffd C(4);
 
-  EXPECT_THROW(stan::math::diag_post_multiply(B,Y), std::domain_error);
-  EXPECT_THROW(stan::math::diag_post_multiply(C,Y), std::domain_error);
-  EXPECT_THROW(stan::math::diag_post_multiply(Z,Y), std::domain_error);
-  EXPECT_THROW(stan::math::diag_post_multiply(Y,Z), std::domain_error);
+  EXPECT_THROW(stan::math::diag_post_multiply(B,Y), std::invalid_argument);
+  EXPECT_THROW(stan::math::diag_post_multiply(C,Y), std::invalid_argument);
+  EXPECT_THROW(stan::math::diag_post_multiply(Z,Y), std::invalid_argument);
+  EXPECT_THROW(stan::math::diag_post_multiply(Y,Z), std::invalid_argument);
 }
 
 TEST(AgradFwdMatrixDiagPostMultiply, rowvector_ffd) {
@@ -451,8 +451,8 @@ TEST(AgradFwdMatrixDiagPostMultiply, rowvector_ffd_exception) {
   row_vector_ffd B(3);
   row_vector_ffd C(4);
 
-  EXPECT_THROW(stan::math::diag_post_multiply(B,Y), std::domain_error);
-  EXPECT_THROW(stan::math::diag_post_multiply(Y,C), std::domain_error);
-  EXPECT_THROW(stan::math::diag_post_multiply(Z,Y), std::domain_error);
-  EXPECT_THROW(stan::math::diag_post_multiply(Y,Z), std::domain_error);
+  EXPECT_THROW(stan::math::diag_post_multiply(B,Y), std::invalid_argument);
+  EXPECT_THROW(stan::math::diag_post_multiply(Y,C), std::invalid_argument);
+  EXPECT_THROW(stan::math::diag_post_multiply(Z,Y), std::invalid_argument);
+  EXPECT_THROW(stan::math::diag_post_multiply(Y,Z), std::invalid_argument);
 }

--- a/test/unit/math/fwd/mat/fun/diag_pre_multiply_test.cpp
+++ b/test/unit/math/fwd/mat/fun/diag_pre_multiply_test.cpp
@@ -60,10 +60,10 @@ TEST(AgradFwdMatrixDiagPreMultiply, vector_fd_exception) {
   vector_fd B(3);
   vector_fd C(4);
 
-  EXPECT_THROW(stan::math::diag_pre_multiply(Y,B), std::domain_error);
-  EXPECT_THROW(stan::math::diag_pre_multiply(C,Y), std::domain_error);
-  EXPECT_THROW(stan::math::diag_pre_multiply(Z,Y), std::domain_error);
-  EXPECT_THROW(stan::math::diag_pre_multiply(Y,Z), std::domain_error);
+  EXPECT_THROW(stan::math::diag_pre_multiply(Y,B), std::invalid_argument);
+  EXPECT_THROW(stan::math::diag_pre_multiply(C,Y), std::invalid_argument);
+  EXPECT_THROW(stan::math::diag_pre_multiply(Z,Y), std::invalid_argument);
+  EXPECT_THROW(stan::math::diag_pre_multiply(Y,Z), std::invalid_argument);
 }
 TEST(AgradFwdMatrixDiagPreMultiply, rowvector_fd) {
   using stan::math::matrix_fd;
@@ -124,10 +124,10 @@ TEST(AgradFwdMatrixDiagPreMultiply, rowvector_fd_exception) {
   row_vector_fd B(3);
   row_vector_fd C(4);
 
-  EXPECT_THROW(stan::math::diag_pre_multiply(Y,B), std::domain_error);
-  EXPECT_THROW(stan::math::diag_pre_multiply(C,Y), std::domain_error);
-  EXPECT_THROW(stan::math::diag_pre_multiply(Z,Y), std::domain_error);
-  EXPECT_THROW(stan::math::diag_pre_multiply(Y,Z), std::domain_error);
+  EXPECT_THROW(stan::math::diag_pre_multiply(Y,B), std::invalid_argument);
+  EXPECT_THROW(stan::math::diag_pre_multiply(C,Y), std::invalid_argument);
+  EXPECT_THROW(stan::math::diag_pre_multiply(Z,Y), std::invalid_argument);
+  EXPECT_THROW(stan::math::diag_pre_multiply(Y,Z), std::invalid_argument);
 }
 TEST(AgradFwdMatrixDiagPreMultiply, vector_ffd) {
   using stan::math::matrix_ffd;
@@ -196,10 +196,10 @@ TEST(AgradFwdMatrixDiagPreMultiply, vector_ffd_exception) {
   vector_ffd B(3);
   vector_ffd C(4);
 
-  EXPECT_THROW(stan::math::diag_pre_multiply(Y,B), std::domain_error);
-  EXPECT_THROW(stan::math::diag_pre_multiply(C,Y), std::domain_error);
-  EXPECT_THROW(stan::math::diag_pre_multiply(Z,Y), std::domain_error);
-  EXPECT_THROW(stan::math::diag_pre_multiply(Y,Z), std::domain_error);
+  EXPECT_THROW(stan::math::diag_pre_multiply(Y,B), std::invalid_argument);
+  EXPECT_THROW(stan::math::diag_pre_multiply(C,Y), std::invalid_argument);
+  EXPECT_THROW(stan::math::diag_pre_multiply(Z,Y), std::invalid_argument);
+  EXPECT_THROW(stan::math::diag_pre_multiply(Y,Z), std::invalid_argument);
 }
 TEST(AgradFwdMatrixDiagPreMultiply, rowvector_ffd) {
   using stan::math::matrix_ffd;
@@ -268,8 +268,8 @@ TEST(AgradFwdMatrixDiagPreMultiply, rowvector_ffd_exception) {
   row_vector_ffd B(3);
   row_vector_ffd C(4);
 
-  EXPECT_THROW(stan::math::diag_pre_multiply(Y,B), std::domain_error);
-  EXPECT_THROW(stan::math::diag_pre_multiply(C,Y), std::domain_error);
-  EXPECT_THROW(stan::math::diag_pre_multiply(Z,Y), std::domain_error);
-  EXPECT_THROW(stan::math::diag_pre_multiply(Y,Z), std::domain_error);
+  EXPECT_THROW(stan::math::diag_pre_multiply(Y,B), std::invalid_argument);
+  EXPECT_THROW(stan::math::diag_pre_multiply(C,Y), std::invalid_argument);
+  EXPECT_THROW(stan::math::diag_pre_multiply(Z,Y), std::invalid_argument);
+  EXPECT_THROW(stan::math::diag_pre_multiply(Y,Z), std::invalid_argument);
 }

--- a/test/unit/math/fwd/mat/fun/operator_multiplication_test.cpp
+++ b/test/unit/math/fwd/mat/fun/operator_multiplication_test.cpp
@@ -250,9 +250,9 @@ TEST(AgradFwdMatrixOperatorMultiplication,fd_rowvector_vector) {
 
   d1.resize(1);
   v1.resize(1);
-  EXPECT_THROW(multiply(v1, v2), std::domain_error);
-  EXPECT_THROW(multiply(v1, d2), std::domain_error);
-  EXPECT_THROW(multiply(d1, v2), std::domain_error);
+  EXPECT_THROW(multiply(v1, v2), std::invalid_argument);
+  EXPECT_THROW(multiply(v1, d2), std::invalid_argument);
+  EXPECT_THROW(multiply(d1, v2), std::invalid_argument);
 }
 TEST(AgradFwdMatrixOperatorMultiplication,fd_vector_rowvector) {
   using stan::math::matrix_fd;
@@ -811,9 +811,9 @@ TEST(AgradFwdMatrixOperatorMultiplication,ffd_rowvector_vector) {
 
   d1.resize(1);
   v1.resize(1);
-  EXPECT_THROW(multiply(v1, v2), std::domain_error);
-  EXPECT_THROW(multiply(v1, d2), std::domain_error);
-  EXPECT_THROW(multiply(d1, v2), std::domain_error);
+  EXPECT_THROW(multiply(v1, v2), std::invalid_argument);
+  EXPECT_THROW(multiply(v1, d2), std::invalid_argument);
+  EXPECT_THROW(multiply(d1, v2), std::invalid_argument);
 }
 TEST(AgradFwdMatrixOperatorMultiplication,ffd_vector_rowvector) {
   using stan::math::matrix_ffd;

--- a/test/unit/math/mix/mat/fun/diag_post_multiply_test.cpp
+++ b/test/unit/math/mix/mat/fun/diag_post_multiply_test.cpp
@@ -105,10 +105,10 @@ TEST(AgradMixMatrixDiagPostMultiply, vector_fv_exception) {
   vector_fv B(3);
   vector_fv C(4);
 
-  EXPECT_THROW(stan::math::diag_post_multiply(B,Y), std::domain_error);
-  EXPECT_THROW(stan::math::diag_post_multiply(Y,C), std::domain_error);
-  EXPECT_THROW(stan::math::diag_post_multiply(Z,Y), std::domain_error);
-  EXPECT_THROW(stan::math::diag_post_multiply(Y,Z), std::domain_error);
+  EXPECT_THROW(stan::math::diag_post_multiply(B,Y), std::invalid_argument);
+  EXPECT_THROW(stan::math::diag_post_multiply(Y,C), std::invalid_argument);
+  EXPECT_THROW(stan::math::diag_post_multiply(Z,Y), std::invalid_argument);
+  EXPECT_THROW(stan::math::diag_post_multiply(Y,Z), std::invalid_argument);
 }
 
 TEST(AgradMixMatrixDiagPostMultiply, rowvector_fv_1stDeriv) {
@@ -208,10 +208,10 @@ TEST(AgradMixMatrixDiagPostMultiply, rowvector_fv_exception) {
   row_vector_fv B(3);
   row_vector_fv C(4);
 
-  EXPECT_THROW(stan::math::diag_post_multiply(B,Y), std::domain_error);
-  EXPECT_THROW(stan::math::diag_post_multiply(C,Y), std::domain_error);
-  EXPECT_THROW(stan::math::diag_post_multiply(Z,Y), std::domain_error);
-  EXPECT_THROW(stan::math::diag_post_multiply(Y,Z), std::domain_error);
+  EXPECT_THROW(stan::math::diag_post_multiply(B,Y), std::invalid_argument);
+  EXPECT_THROW(stan::math::diag_post_multiply(C,Y), std::invalid_argument);
+  EXPECT_THROW(stan::math::diag_post_multiply(Z,Y), std::invalid_argument);
+  EXPECT_THROW(stan::math::diag_post_multiply(Y,Z), std::invalid_argument);
 }
 TEST(AgradMixMatrixDiagPostMultiply, vector_ffv_1stDeriv) {
   using stan::math::matrix_ffv;
@@ -381,10 +381,10 @@ TEST(AgradMixMatrixDiagPostMultiply, vector_ffv_exception) {
   vector_ffv B(3);
   vector_ffv C(4);
 
-  EXPECT_THROW(stan::math::diag_post_multiply(B,Y), std::domain_error);
-  EXPECT_THROW(stan::math::diag_post_multiply(Y,C), std::domain_error);
-  EXPECT_THROW(stan::math::diag_post_multiply(Z,Y), std::domain_error);
-  EXPECT_THROW(stan::math::diag_post_multiply(Y,Z), std::domain_error);
+  EXPECT_THROW(stan::math::diag_post_multiply(B,Y), std::invalid_argument);
+  EXPECT_THROW(stan::math::diag_post_multiply(Y,C), std::invalid_argument);
+  EXPECT_THROW(stan::math::diag_post_multiply(Z,Y), std::invalid_argument);
+  EXPECT_THROW(stan::math::diag_post_multiply(Y,Z), std::invalid_argument);
 }
 
 TEST(AgradMixMatrixDiagPostMultiply, rowvector_ffv_1stDeriv) {
@@ -554,8 +554,8 @@ TEST(AgradMixMatrixDiagPostMultiply, rowvector_ffv_exception) {
   row_vector_ffv B(3);
   row_vector_ffv C(4);
 
-  EXPECT_THROW(stan::math::diag_post_multiply(B,Y), std::domain_error);
-  EXPECT_THROW(stan::math::diag_post_multiply(Y,C), std::domain_error);
-  EXPECT_THROW(stan::math::diag_post_multiply(Z,Y), std::domain_error);
-  EXPECT_THROW(stan::math::diag_post_multiply(Y,Z), std::domain_error);
+  EXPECT_THROW(stan::math::diag_post_multiply(B,Y), std::invalid_argument);
+  EXPECT_THROW(stan::math::diag_post_multiply(Y,C), std::invalid_argument);
+  EXPECT_THROW(stan::math::diag_post_multiply(Z,Y), std::invalid_argument);
+  EXPECT_THROW(stan::math::diag_post_multiply(Y,Z), std::invalid_argument);
 }

--- a/test/unit/math/mix/mat/fun/diag_pre_multiply_test.cpp
+++ b/test/unit/math/mix/mat/fun/diag_pre_multiply_test.cpp
@@ -99,10 +99,10 @@ TEST(AgradMixMatrixDiagPreMultiply, vector_fv_exception) {
   vector_fv B(3);
   vector_fv C(4);
 
-  EXPECT_THROW(stan::math::diag_pre_multiply(Y,B), std::domain_error);
-  EXPECT_THROW(stan::math::diag_pre_multiply(C,Y), std::domain_error);
-  EXPECT_THROW(stan::math::diag_pre_multiply(Z,Y), std::domain_error);
-  EXPECT_THROW(stan::math::diag_pre_multiply(Y,Z), std::domain_error);
+  EXPECT_THROW(stan::math::diag_pre_multiply(Y,B), std::invalid_argument);
+  EXPECT_THROW(stan::math::diag_pre_multiply(C,Y), std::invalid_argument);
+  EXPECT_THROW(stan::math::diag_pre_multiply(Z,Y), std::invalid_argument);
+  EXPECT_THROW(stan::math::diag_pre_multiply(Y,Z), std::invalid_argument);
 }
 TEST(AgradMixMatrixDiagPreMultiply, rowvector_fv_1stDeriv) {
   using stan::math::matrix_fv;
@@ -201,10 +201,10 @@ TEST(AgradMixMatrixDiagPreMultiply, rowvector_fv_exception) {
   row_vector_fv B(3);
   row_vector_fv C(4);
 
-  EXPECT_THROW(stan::math::diag_pre_multiply(Y,B), std::domain_error);
-  EXPECT_THROW(stan::math::diag_pre_multiply(C,Y), std::domain_error);
-  EXPECT_THROW(stan::math::diag_pre_multiply(Z,Y), std::domain_error);
-  EXPECT_THROW(stan::math::diag_pre_multiply(Y,Z), std::domain_error);
+  EXPECT_THROW(stan::math::diag_pre_multiply(Y,B), std::invalid_argument);
+  EXPECT_THROW(stan::math::diag_pre_multiply(C,Y), std::invalid_argument);
+  EXPECT_THROW(stan::math::diag_pre_multiply(Z,Y), std::invalid_argument);
+  EXPECT_THROW(stan::math::diag_pre_multiply(Y,Z), std::invalid_argument);
 }
 TEST(AgradMixMatrixDiagPreMultiply, vector_ffv_1stDeriv) {
   using stan::math::matrix_ffv;
@@ -373,10 +373,10 @@ TEST(AgradMixMatrixDiagPreMultiply, vector_ffv_exception) {
   vector_ffv B(3);
   vector_ffv C(4);
 
-  EXPECT_THROW(stan::math::diag_pre_multiply(Y,B), std::domain_error);
-  EXPECT_THROW(stan::math::diag_pre_multiply(C,Y), std::domain_error);
-  EXPECT_THROW(stan::math::diag_pre_multiply(Z,Y), std::domain_error);
-  EXPECT_THROW(stan::math::diag_pre_multiply(Y,Z), std::domain_error);
+  EXPECT_THROW(stan::math::diag_pre_multiply(Y,B), std::invalid_argument);
+  EXPECT_THROW(stan::math::diag_pre_multiply(C,Y), std::invalid_argument);
+  EXPECT_THROW(stan::math::diag_pre_multiply(Z,Y), std::invalid_argument);
+  EXPECT_THROW(stan::math::diag_pre_multiply(Y,Z), std::invalid_argument);
 }
 
 TEST(AgradMixMatrixDiagPreMultiply, rowvector_ffv_1stDeriv) {
@@ -546,8 +546,8 @@ TEST(AgradMixMatrixDiagPreMultiply, rowvector_ffv_exception) {
   row_vector_ffv B(3);
   row_vector_ffv C(4);
 
-  EXPECT_THROW(stan::math::diag_pre_multiply(Y,B), std::domain_error);
-  EXPECT_THROW(stan::math::diag_pre_multiply(C,Y), std::domain_error);
-  EXPECT_THROW(stan::math::diag_pre_multiply(Z,Y), std::domain_error);
-  EXPECT_THROW(stan::math::diag_pre_multiply(Y,Z), std::domain_error);
+  EXPECT_THROW(stan::math::diag_pre_multiply(Y,B), std::invalid_argument);
+  EXPECT_THROW(stan::math::diag_pre_multiply(C,Y), std::invalid_argument);
+  EXPECT_THROW(stan::math::diag_pre_multiply(Z,Y), std::invalid_argument);
+  EXPECT_THROW(stan::math::diag_pre_multiply(Y,Z), std::invalid_argument);
 }

--- a/test/unit/math/mix/mat/fun/operator_multiplication_test.cpp
+++ b/test/unit/math/mix/mat/fun/operator_multiplication_test.cpp
@@ -357,9 +357,9 @@ TEST(AgradMixMatrixOperatorMultiplication,fv_rowvector_vector_1stDeriv) {
 
   d1.resize(1);
   v1.resize(1);
-  EXPECT_THROW(multiply(v1, v2), std::domain_error);
-  EXPECT_THROW(multiply(v1, d2), std::domain_error);
-  EXPECT_THROW(multiply(d1, v2), std::domain_error);
+  EXPECT_THROW(multiply(v1, v2), std::invalid_argument);
+  EXPECT_THROW(multiply(v1, d2), std::invalid_argument);
+  EXPECT_THROW(multiply(d1, v2), std::invalid_argument);
 }
 TEST(AgradMixMatrixOperatorMultiplication,fv_rowvector_vector_2ndDeriv) {
   using stan::math::vector_d;
@@ -1367,9 +1367,9 @@ TEST(AgradMixMatrixOperatorMultiplication,ffv_rowvector_vector_1stDeriv) {
 
   d1.resize(1);
   v1.resize(1);
-  EXPECT_THROW(multiply(v1, v2), std::domain_error);
-  EXPECT_THROW(multiply(v1, d2), std::domain_error);
-  EXPECT_THROW(multiply(d1, v2), std::domain_error);
+  EXPECT_THROW(multiply(v1, v2), std::invalid_argument);
+  EXPECT_THROW(multiply(v1, d2), std::invalid_argument);
+  EXPECT_THROW(multiply(d1, v2), std::invalid_argument);
 }
 TEST(AgradMixMatrixOperatorMultiplication,ffv_rowvector_vector_2ndDeriv_1) {
   using stan::math::vector_d;

--- a/test/unit/math/prim/arr/err/check_matching_sizes_test.cpp
+++ b/test/unit/math/prim/arr/err/check_matching_sizes_test.cpp
@@ -1,0 +1,42 @@
+#include <stan/math/prim/arr.hpp>
+#include <gtest/gtest.h>
+
+TEST(ErrorHandling, checkMatchingSizes) {
+  std::vector<double> a;
+  std::vector<double> b;
+
+  EXPECT_TRUE(stan::math::check_matching_sizes("checkMatchingSizes", "a", a,
+                                               "b", b));
+
+  a.push_back(3.0);
+  a.push_back(3.0);
+
+  EXPECT_THROW(stan::math::check_matching_sizes("checkMatchingSizes", "a", a,
+                                                          "b", b),
+               std::invalid_argument);
+
+  b.push_back(3.0);
+  b.push_back(3.0);
+  EXPECT_TRUE(stan::math::check_matching_sizes("checkMatchingSizes", "a", a,
+                                                         "b", b));
+}
+
+TEST(ErrorHandling, checkMatchingSizes_nan) {
+  double nan = std::numeric_limits<double>::quiet_NaN();
+  std::vector<double> a;
+  std::vector<double> b;
+  EXPECT_TRUE(stan::math::check_matching_sizes("checkMatchingSizes", "a", a,
+                                                         "b", b));
+
+  a.push_back(nan);
+  a.push_back(nan);
+  EXPECT_THROW(stan::math::check_matching_sizes("checkMatchingSizes", "a", a,
+                                                          "b", b),
+               std::invalid_argument);
+
+  b.push_back(nan);
+  b.push_back(nan);
+  EXPECT_TRUE(stan::math::check_matching_sizes("checkMatchingSizes", "a", a,
+                                                         "b", b));
+}
+

--- a/test/unit/math/prim/arr/fun/inverse_softmax_test.cpp
+++ b/test/unit/math/prim/arr/fun/inverse_softmax_test.cpp
@@ -1,4 +1,4 @@
-#include <stan/math/prim/scal.hpp>
+#include <stan/math/prim/arr.hpp>
 #include <boost/math/special_functions/fpclassify.hpp>
 #include <gtest/gtest.h>
 

--- a/test/unit/math/prim/mat/fun/cholesky_factor_transform_test.cpp
+++ b/test/unit/math/prim/mat/fun/cholesky_factor_transform_test.cpp
@@ -77,7 +77,7 @@ TEST(ProbTransform,choleskyFactorConstrainError) {
   x << 1, 2, 3;
   EXPECT_THROW(cholesky_factor_constrain(x,9,9), std::invalid_argument);
   double lp = 0;
-  EXPECT_THROW(cholesky_factor_constrain(x,9,9,lp),std::invalid_argument);
+  EXPECT_THROW(cholesky_factor_constrain(x,9,9,lp), std::invalid_argument);
 }
 TEST(ProbTransform,choleskyFactorFreeError) {
   using Eigen::Matrix;

--- a/test/unit/math/prim/mat/fun/cholesky_factor_transform_test.cpp
+++ b/test/unit/math/prim/mat/fun/cholesky_factor_transform_test.cpp
@@ -75,9 +75,9 @@ TEST(ProbTransform,choleskyFactorConstrainError) {
 
   Matrix<double,Dynamic,1> x(3);
   x << 1, 2, 3;
-  EXPECT_THROW(cholesky_factor_constrain(x,9,9),std::domain_error);
+  EXPECT_THROW(cholesky_factor_constrain(x,9,9), std::invalid_argument);
   double lp = 0;
-  EXPECT_THROW(cholesky_factor_constrain(x,9,9,lp),std::domain_error);
+  EXPECT_THROW(cholesky_factor_constrain(x,9,9,lp),std::invalid_argument);
 }
 TEST(ProbTransform,choleskyFactorFreeError) {
   using Eigen::Matrix;
@@ -87,14 +87,15 @@ TEST(ProbTransform,choleskyFactorFreeError) {
   Matrix<double,Dynamic,Dynamic> y(1,1);
   y.resize(1,1);
   y << -2;
-  EXPECT_THROW(cholesky_factor_free(y),std::domain_error);
+  EXPECT_THROW(cholesky_factor_free(y), std::domain_error);
 
   y.resize(2,2);
   y << 1, 2, 3, 4;
-  EXPECT_THROW(cholesky_factor_free(y),std::domain_error);
+  EXPECT_THROW(cholesky_factor_free(y), std::domain_error);
 
   y.resize(2,3);
   y << 1, 0, 0,
     2, 3, 0;
-  EXPECT_THROW(cholesky_factor_free(y),std::domain_error);
+  EXPECT_THROW(cholesky_factor_free(y), std::domain_error);
 }
+

--- a/test/unit/math/prim/mat/fun/corr_matrix_transform_test.cpp
+++ b/test/unit/math/prim/mat/fun/corr_matrix_transform_test.cpp
@@ -60,16 +60,16 @@ TEST(prob_transform,corr_matrix_rt) {
 }
 TEST(prob_transform,corr_matrix_free_exception) {
   Matrix<double,Dynamic,Dynamic> y;
-  
-  EXPECT_THROW(stan::math::corr_matrix_free(y), std::domain_error);
+
+  EXPECT_THROW(stan::math::corr_matrix_free(y), std::invalid_argument);
   y.resize(0,10);
-  EXPECT_THROW(stan::math::corr_matrix_free(y), std::domain_error);
+  EXPECT_THROW(stan::math::corr_matrix_free(y), std::invalid_argument);
   y.resize(10,0);
-  EXPECT_THROW(stan::math::corr_matrix_free(y), std::domain_error);
+  EXPECT_THROW(stan::math::corr_matrix_free(y), std::invalid_argument);
   y.resize(1,2);
-  EXPECT_THROW(stan::math::corr_matrix_free(y), std::domain_error);
+  EXPECT_THROW(stan::math::corr_matrix_free(y), std::invalid_argument);
 
   y.resize(2,2);
   y << 0, 0, 0, 0;
-  EXPECT_THROW(stan::math::corr_matrix_free(y), std::runtime_error);
+  EXPECT_THROW(stan::math::corr_matrix_free(y), std::domain_error);
 }

--- a/test/unit/math/prim/mat/fun/cov_matrix_transform_test.cpp
+++ b/test/unit/math/prim/mat/fun/cov_matrix_transform_test.cpp
@@ -21,17 +21,17 @@ TEST(prob_transform,lkj_cov_matrix_rt) {
 TEST(prob_transform,lkj_cov_matrix_free_exception) {
   Matrix<double,Dynamic,Dynamic> y(0,0);
   
-  EXPECT_THROW(stan::math::cov_matrix_free_lkj(y), std::domain_error);
+  EXPECT_THROW(stan::math::cov_matrix_free_lkj(y), std::invalid_argument);
   y.resize(0,10);
-  EXPECT_THROW(stan::math::cov_matrix_free_lkj(y), std::domain_error);
+  EXPECT_THROW(stan::math::cov_matrix_free_lkj(y), std::invalid_argument);
   y.resize(10,0);
-  EXPECT_THROW(stan::math::cov_matrix_free_lkj(y), std::domain_error);
+  EXPECT_THROW(stan::math::cov_matrix_free_lkj(y), std::invalid_argument);
   y.resize(1,2);
-  EXPECT_THROW(stan::math::cov_matrix_free_lkj(y), std::domain_error);
+  EXPECT_THROW(stan::math::cov_matrix_free_lkj(y), std::invalid_argument);
 
   y.resize(2,2);
   y << 0, 0, 0, 0;
-  EXPECT_THROW(stan::math::cov_matrix_free_lkj(y), std::runtime_error);
+  EXPECT_THROW(stan::math::cov_matrix_free_lkj(y), std::domain_error);
 }
 
 TEST(prob_transform,cov_matrix_rt) {
@@ -50,18 +50,18 @@ TEST(prob_transform,cov_matrix_rt) {
 TEST(prob_transform,cov_matrix_constrain_exception) {
   Matrix<double,Dynamic,1> x(7);
   int K = 12;
-  EXPECT_THROW(stan::math::cov_matrix_constrain(x,K), std::domain_error);
+  EXPECT_THROW(stan::math::cov_matrix_constrain(x,K), std::invalid_argument);
 }
 TEST(prob_transform,cov_matrix_free_exception) {
   Matrix<double,Dynamic,Dynamic> y(0,0);
   
-  EXPECT_THROW(stan::math::cov_matrix_free(y), std::domain_error);
+  EXPECT_THROW(stan::math::cov_matrix_free(y), std::invalid_argument);
   y.resize(0,10);
-  EXPECT_THROW(stan::math::cov_matrix_free(y), std::domain_error);
+  EXPECT_THROW(stan::math::cov_matrix_free(y), std::invalid_argument);
   y.resize(10,0);
-  EXPECT_THROW(stan::math::cov_matrix_free(y), std::domain_error);
+  EXPECT_THROW(stan::math::cov_matrix_free(y), std::invalid_argument);
   y.resize(1,2);
-  EXPECT_THROW(stan::math::cov_matrix_free(y), std::domain_error);
+  EXPECT_THROW(stan::math::cov_matrix_free(y), std::invalid_argument);
 
   y.resize(2,2);
   y << 0, 0, 0, 0;

--- a/test/unit/math/prim/mat/fun/diag_post_multiply_test.cpp
+++ b/test/unit/math/prim/mat/fun/diag_post_multiply_test.cpp
@@ -46,9 +46,9 @@ TEST(MathMatrix,diagPostMultiplyException) {
   m << 
     2, 3,
     4, 5;
-  EXPECT_THROW(diag_post_multiply(m,m), std::domain_error);
+  EXPECT_THROW(diag_post_multiply(m,m), std::invalid_argument);
 
   Matrix<double,Dynamic,1> v(3);
   v << 1, 2, 3;
-  EXPECT_THROW(diag_post_multiply(m,v), std::domain_error);
+  EXPECT_THROW(diag_post_multiply(m,v), std::invalid_argument);
 }

--- a/test/unit/math/prim/mat/fun/diag_pre_multiply_test.cpp
+++ b/test/unit/math/prim/mat/fun/diag_pre_multiply_test.cpp
@@ -44,11 +44,11 @@ TEST(MathMatrix,diagPreMultiplyException) {
   m << 
     2, 3,
     4, 5;
-  EXPECT_THROW(diag_pre_multiply(m,m), std::domain_error);
+  EXPECT_THROW(diag_pre_multiply(m,m), std::invalid_argument);
 
   Matrix<double,Dynamic,1> v(3);
   v << 1, 2, 3;
-  EXPECT_THROW(diag_pre_multiply(v,m), std::domain_error);
+  EXPECT_THROW(diag_pre_multiply(v,m), std::invalid_argument);
 }
 
 

--- a/test/unit/math/prim/mat/fun/lkj_cov_matrix_transform_test.cpp
+++ b/test/unit/math/prim/mat/fun/lkj_cov_matrix_transform_test.cpp
@@ -21,15 +21,15 @@ TEST(prob_transform,lkj_cov_matrix_rt) {
 TEST(prob_transform,lkj_cov_matrix_free_exception) {
   Matrix<double,Dynamic,Dynamic> y(0,0);
   
-  EXPECT_THROW(stan::math::cov_matrix_free_lkj(y), std::domain_error);
+  EXPECT_THROW(stan::math::cov_matrix_free_lkj(y), std::invalid_argument);
   y.resize(0,10);
-  EXPECT_THROW(stan::math::cov_matrix_free_lkj(y), std::domain_error);
+  EXPECT_THROW(stan::math::cov_matrix_free_lkj(y), std::invalid_argument);
   y.resize(10,0);
-  EXPECT_THROW(stan::math::cov_matrix_free_lkj(y), std::domain_error);
+  EXPECT_THROW(stan::math::cov_matrix_free_lkj(y), std::invalid_argument);
   y.resize(1,2);
-  EXPECT_THROW(stan::math::cov_matrix_free_lkj(y), std::domain_error);
+  EXPECT_THROW(stan::math::cov_matrix_free_lkj(y), std::invalid_argument);
 
   y.resize(2,2);
   y << 0, 0, 0, 0;
-  EXPECT_THROW(stan::math::cov_matrix_free_lkj(y), std::runtime_error);
+  EXPECT_THROW(stan::math::cov_matrix_free_lkj(y), std::domain_error);
 }

--- a/test/unit/math/prim/mat/fun/max_test.cpp
+++ b/test/unit/math/prim/mat/fun/max_test.cpp
@@ -4,7 +4,7 @@
 TEST(MathMatrix, max) {
   using stan::math::max;
   std::vector<int> n;
-  EXPECT_THROW(max(n),std::domain_error);
+  EXPECT_THROW(max(n),std::invalid_argument);
   n.push_back(1);
   EXPECT_EQ(1,max(n));
   n.push_back(2);

--- a/test/unit/math/prim/mat/fun/min_test.cpp
+++ b/test/unit/math/prim/mat/fun/min_test.cpp
@@ -4,7 +4,7 @@
 TEST(MathMatrix, min) {
   using stan::math::min;
   std::vector<int> n;
-  EXPECT_THROW(min(n),std::domain_error);
+  EXPECT_THROW(min(n),std::invalid_argument);
   n.push_back(1);
   EXPECT_EQ(1,min(n));
   n.push_back(2);

--- a/test/unit/math/rev/core/precomputed_gradients_test.cpp
+++ b/test/unit/math/rev/core/precomputed_gradients_test.cpp
@@ -1,4 +1,4 @@
-#include <stan/math/rev/core.hpp>
+#include <stan/math/rev/arr.hpp>
 #include <gtest/gtest.h>
 
 

--- a/test/unit/math/rev/mat/fun/diag_post_multiply_test.cpp
+++ b/test/unit/math/rev/mat/fun/diag_post_multiply_test.cpp
@@ -217,9 +217,9 @@ TEST(MathMatrix,diagPostMultiplyException) {
   m << 
     2, 3,
     4, 5;
-  EXPECT_THROW(diag_post_multiply(m,m), std::domain_error);
+  EXPECT_THROW(diag_post_multiply(m,m), std::invalid_argument);
 
   Matrix<var,Dynamic,1> v(3);
   v << 1, 2, 3;
-  EXPECT_THROW(diag_post_multiply(m,v), std::domain_error);
+  EXPECT_THROW(diag_post_multiply(m,v), std::invalid_argument);
 }

--- a/test/unit/math/rev/mat/fun/diag_pre_multiply_test.cpp
+++ b/test/unit/math/rev/mat/fun/diag_pre_multiply_test.cpp
@@ -216,9 +216,9 @@ TEST(MathMatrix,diagPreMultiplyException) {
   m << 
     2, 3,
     4, 5;
-  EXPECT_THROW(diag_pre_multiply(m,m), std::domain_error);
+  EXPECT_THROW(diag_pre_multiply(m,m), std::invalid_argument);
 
   Matrix<var,Dynamic,1> v(3);
   v << 1, 2, 3;
-  EXPECT_THROW(diag_pre_multiply(v,m), std::domain_error);
+  EXPECT_THROW(diag_pre_multiply(v,m), std::invalid_argument);
 }

--- a/test/unit/math/rev/mat/fun/multiply_test.cpp
+++ b/test/unit/math/rev/mat/fun/multiply_test.cpp
@@ -316,9 +316,9 @@ TEST(AgradRevMatrix, multiply_rowvector_vector) {
   
   d1.resize(1);
   v1.resize(1);
-  EXPECT_THROW(multiply(v1, v2), std::domain_error);
-  EXPECT_THROW(multiply(v1, d2), std::domain_error);
-  EXPECT_THROW(multiply(d1, v2), std::domain_error);
+  EXPECT_THROW(multiply(v1, v2), std::invalid_argument);
+  EXPECT_THROW(multiply(v1, d2), std::invalid_argument);
+  EXPECT_THROW(multiply(d1, v2), std::invalid_argument);
 }
 TEST(AgradRevMatrix, multiply_vector_rowvector) {
   using stan::math::matrix_v;


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

Changes input error handling for functions that were throwing exceptions directly. We have been moving away from that.

#### Intended Effect:

Clean up code.

#### How to Verify:

Run tests.

#### Side Effects:

There are a couple of these functions that now throw `std::invalid_argument` instead of `std::domain_error`. This only happens when there are things like mismatched sizes.

#### Documentation:

None required.

#### Reviewer Suggestions: 

Anyone.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

