### PR TITLE
More informative exception message for check_bounded

### DIFF
--- a/stan/math/prim/scal/err/check_bounded.hpp
+++ b/stan/math/prim/scal/err/check_bounded.hpp
@@ -34,8 +34,8 @@ namespace stan {
           for (size_t n = 0; n < max_size(low, high); n++) {
             if (!(low_vec[n] <= y && y <= high_vec[n])) {
               std::stringstream msg;
-              msg << ", but must be between ";
-              msg << "(" << low_vec[n] << ", " << high_vec[n] << ")";
+              msg << ", but must be in the interval ";
+              msg << "[" << low_vec[n] << ", " << high_vec[n] << "]";
               std::string msg_str(msg.str());
               domain_error(function, name, y,
                            "is ", msg_str.c_str());
@@ -60,8 +60,8 @@ namespace stan {
           for (size_t n = 0; n < length(y); n++) {
             if (!(low_vec[n] <= get(y, n) && get(y, n) <= high_vec[n])) {
               std::stringstream msg;
-              msg << ", but must be between ";
-              msg << "(" << low_vec[n] << ", " << high_vec[n] << ")";
+              msg << ", but must be in the interval ";
+              msg << "[" << low_vec[n] << ", " << high_vec[n] << "]";
               std::string msg_str(msg.str());
               domain_error_vec(function, name, y, n,
                                "is ", msg_str.c_str());


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

Just updates the ```check_bounded``` exception message to be more clear that the function checks the interval inclusive of the endpoints.  Related to #332.

#### Intended Effect:

More clear error message.

#### How to Verify:

Call ```stan::math::check_bounded("function_name", "name", 2, 0, 1)```.  This can also be triggered by running a stan model with ```bernoulli_rng(1.1)``` in the generated quantities.

#### Side Effects:

None.

#### Documentation:

None.

#### Reviewer Suggestions: 

Anyone.

#### Copyright and Licensing

Copyright: University of Warwick

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
