### PR TITLE
Rewrite specialization for Eigen::NumTraits for stan::math::var and stan::math::fvar

### DIFF
--- a/stan/math/fwd/mat/fun/Eigen_NumTraits.hpp
+++ b/stan/math/fwd/mat/fun/Eigen_NumTraits.hpp
@@ -2,6 +2,7 @@
 #define STAN_MATH_FWD_MAT_FUN_EIGEN_NUMTRAITS_HPP
 
 #include <stan/math/fwd/core.hpp>
+#include <stan/math/fwd/core/std_numeric_limits.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <limits>
 
@@ -12,78 +13,21 @@ namespace Eigen {
    * gradient variables.
    */
   template <typename T>
-  struct NumTraits<stan::math::fvar<T> > {
-    /**
-     * Real-valued variables.
-     *
-     * Required for numerical traits.
-     */
-    typedef stan::math::fvar<T> Real;
+  struct NumTraits<stan::math::fvar<T> >
+    : GenericNumTraits<stan::math::fvar<T> > {
 
-    /**
-     * Non-integer valued variables.
-     *
-     * Required for numerical traits.
-     */
-    typedef stan::math::fvar<T> NonInteger;
-
-    /**
-     * Nested variables.
-     *
-     * Required for numerical traits.
-     */
-    typedef stan::math::fvar<T> Nested;
-
-    /**
-     * Return standard library's epsilon for double-precision floating
-     * point, <code>std::numeric_limits<double>::epsilon()</code>.
-     *
-     * @return Same epsilon as a <code>double</code>.
-     */
-    inline static Real epsilon() {
-      return std::numeric_limits<double>::epsilon();
-    }
-
-    /**
-     * Return dummy precision
-     */
-    inline static Real dummy_precision() {
-      return 1e-12;  // copied from NumTraits.h values for double
-    }
-
-    /**
-     * Return standard library's highest for double-precision floating
-     * point, <code>std::numeric_limits&lt;double&gt;::max()</code>.
-     *
-     * @return Same highest value as a <code>double</code>.
-     */
-    inline static Real highest() {
-      return std::numeric_limits<double>::max();
-    }
-
-    /**
-     * Return standard library's lowest for double-precision floating
-     * point, <code>&#45;std::numeric_limits&lt;double&gt;::max()</code>.
-     *
-     * @return Same lowest value as a <code>double</code>.
-     */
-    inline static Real lowest() {
-      return -std::numeric_limits<double>::max();
-    }
-
-    /**
-     * Properties for automatic differentiation variables
-     * read by Eigen matrix library.
-     */
     enum {
-      IsInteger = 0,
-      IsSigned = 1,
-      IsComplex = 0,
       RequireInitialization = 1,
-      ReadCost = 1,
-      AddCost = 1,
-      MulCost = 1,
-      HasFloatingPoint = 1
+      // ReadCost = twice the cost to copy a double
+      ReadCost = 2 * NumTraits<double>::ReadCost,
+      // AddCost: 2 * AddCost
+      // (a + b) = a + b
+      // (a + b)' = a' + b'
+      AddCost = 2 * NumTraits<T>::AddCost,
+      // MulCost: 3 * MulCost + AddCost
+      // (a * b) = a * b
+      // (a * b)' = a' * b + a * b'
+      MulCost = 3 * NumTraits<T>::MulCost + NumTraits<T>::AddCost
     };
   };
 

--- a/stan/math/rev/mat/fun/Eigen_NumTraits.hpp
+++ b/stan/math/rev/mat/fun/Eigen_NumTraits.hpp
@@ -1,9 +1,9 @@
 #ifndef STAN_MATH_REV_MAT_FUN_EIGEN_NUMTRAITS_HPP
 #define STAN_MATH_REV_MAT_FUN_EIGEN_NUMTRAITS_HPP
 
-#include <stan/math/rev/core.hpp>
-#include <stan/math/rev/core/gevv_vvv_vari.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <stan/math/rev/core.hpp>
+#include <stan/math/rev/core/std_numeric_limits.hpp>
 #include <limits>
 
 namespace Eigen {
@@ -11,80 +11,24 @@ namespace Eigen {
   /**
    * Numerical traits template override for Eigen for automatic
    * gradient variables.
+   *
+   * Documentation here: 
+   *   http://eigen.tuxfamily.org/dox/structEigen_1_1NumTraits.html
    */
-  template <>
-  struct NumTraits<stan::math::var> {
-    /**
-     * Real-valued variables.
-     *
-     * Required for numerical traits.
-     */
-    typedef stan::math::var Real;
-
-    /**
-     * Non-integer valued variables.
-     *
-     * Required for numerical traits.
-     */
-    typedef stan::math::var NonInteger;
-
-    /**
-     * Nested variables.
-     *
-     * Required for numerical traits.
-     */
-    typedef stan::math::var Nested;
-
-    /**
-     * Return standard library's epsilon for double-precision floating
-     * point, <code>std::numeric_limits<double>::epsilon()</code>.
-     *
-     * @return Same epsilon as a <code>double</code>.
-     */
-    inline static Real epsilon() {
-      return std::numeric_limits<double>::epsilon();
+  template<> struct NumTraits<stan::math::var>
+    : GenericNumTraits<stan::math::var> {
+    static inline stan::math::var dummy_precision() {
+      return NumTraits<double>::dummy_precision();
     }
 
-    /**
-     * Return dummy precision
-     */
-    inline static Real dummy_precision() {
-      return 1e-12;  // copied from NumTraits.h values for double
-    }
-
-    /**
-     * Return standard library's highest for double-precision floating
-     * point, <code>std::numeric_limits&lt;double&gt;::max()</code>.
-     *
-     * @return Same highest value as a <code>double</code>.
-     */
-    inline static Real highest() {
-      return std::numeric_limits<double>::max();
-    }
-
-    /**
-     * Return standard library's lowest for double-precision floating
-     * point, <code>&#45;std::numeric_limits&lt;double&gt;::max()</code>.
-     *
-     * @return Same lowest value as a <code>double</code>.
-     */
-    inline static Real lowest() {
-      return -std::numeric_limits<double>::max();
-    }
-
-    /**
-     * Properties for automatic differentiation variables
-     * read by Eigen matrix library.
-     */
     enum {
-      IsInteger = 0,
-      IsSigned = 1,
-      IsComplex = 0,
       RequireInitialization = 0,
-      ReadCost = 1,
-      AddCost = 1,
-      MulCost = 1,
-      HasFloatingPoint = 1
+      // ReadCost = twice the cost to copy a double
+      ReadCost = 2 * NumTraits<double>::ReadCost,
+      // AddCost = single addition going forward
+      AddCost = NumTraits<double>::AddCost,
+      // MulCost = single multiplication going forward
+      MulCost = NumTraits<double>::MulCost
     };
   };
 


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

The old specialization for `Eigen::NumTraits` didn't have the costs set up properly.

#### Intended Effect:

Fixes the `Eigen::NumTraits` for the math autodiff variables. Also simplifies the code by removing things that didn't need to be specialized.

#### How to Verify:

All unit tests pass. Just check the diff to see what's changed.

#### Side Effects:

Might be a difference in speed. @rtrangucci has some timing scripts and will run them to see if this has a speed difference. Hopefully this doesn't or improves speed.

#### Documentation:

Included in C++.

#### Reviewer Suggestions: 

@rtrangucci and @bob-carpenter 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
