### PR TITLE
Changing int division and int modulus implementations

### DIFF
--- a/stan/math/prim/scal/fun/divide.hpp
+++ b/stan/math/prim/scal/fun/divide.hpp
@@ -26,7 +26,7 @@ namespace stan {
     inline int divide(const int x, const int y) {
       if (unlikely(y == 0))
         domain_error("divide", "denominator is", y, "");
-      return std::div(x, y).quot;
+      return x / y;
     }
 
   }

--- a/stan/math/prim/scal/fun/divide.hpp
+++ b/stan/math/prim/scal/fun/divide.hpp
@@ -31,5 +31,4 @@ namespace stan {
 
   }
 }
-
 #endif

--- a/stan/math/prim/scal/fun/modulus.hpp
+++ b/stan/math/prim/scal/fun/modulus.hpp
@@ -1,6 +1,8 @@
 #ifndef STAN_MATH_PRIM_SCAL_FUN_MODULUS_HPP
 #define STAN_MATH_PRIM_SCAL_FUN_MODULUS_HPP
 
+#include <stan/math/prim/scal/err/domain_error.hpp>
+#include <stan/math/prim/scal/meta/likely.hpp>
 #include <cstddef>
 #include <cstdlib>
 
@@ -8,7 +10,9 @@ namespace stan {
   namespace math {
 
     inline int modulus(const int x, const int y) {
-      return std::div(x, y).rem;
+      if (unlikely(y == 0))
+        domain_error("modulus", "divisor is", 0, "");
+      return x % y;
     }
 
   }

--- a/stan/math/prim/scal/fun/modulus.hpp
+++ b/stan/math/prim/scal/fun/modulus.hpp
@@ -17,5 +17,4 @@ namespace stan {
 
   }
 }
-
 #endif

--- a/test/unit/math/prim/scal/fun/modulus_test.cpp
+++ b/test/unit/math/prim/scal/fun/modulus_test.cpp
@@ -34,3 +34,10 @@ TEST(MathFunctions, modulus) {
   EXPECT_EQ(-6, modulus(-34, 7));
   EXPECT_EQ(-10, modulus(-44, 17));
 }
+
+TEST(MathFunctions, int_modulus_0) {
+  int x = 1;
+  int y = 0;
+  int z;
+  EXPECT_THROW(z = stan::math::modulus(x, y), std::domain_error);
+}


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary:
Changing `stan::math::divide(int x, int y)` and `stan::math::modulus(int x, int y)` implementations to use the C++ operators.

#### Intended Effect:
Implementation change. No change to behavior. Additional checks for 0 are necessary to maintain existing behavior.

#### How to Verify:
Run new tests. Look at code.

#### Side Effects:
None.

#### Documentation:
None.

#### Reviewer Suggestions: 
Anyone. This is a quick review; shouldn't take more than a couple mins.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
