### PR TITLE
grad_reg_inc_gamma: more accurate for large z

### DIFF
--- a/stan/math/prim/scal/fun/grad_reg_inc_gamma.hpp
+++ b/stan/math/prim/scal/fun/grad_reg_inc_gamma.hpp
@@ -21,6 +21,7 @@ namespace stan {
      * @param z   location z >= 0
      * @param g   boost::math::tgamma(a) (precomputed value)
      * @param dig boost::math::digamma(a) (precomputed value)
+     * @param precision required precision; applies to series expansion only
      *
      * For the asymptotic expansion, the gradient is given by:
        \f[

--- a/stan/math/prim/scal/fun/grad_reg_inc_gamma.hpp
+++ b/stan/math/prim/scal/fun/grad_reg_inc_gamma.hpp
@@ -3,18 +3,39 @@
 
 #include <stan/math/prim/scal/fun/gamma_p.hpp>
 #include <stan/math/prim/scal/fun/gamma_q.hpp>
+#include <stan/math/prim/scal/fun/square.hpp>
 #include <cmath>
 #include <stdexcept>
 
 namespace stan {
   namespace math {
 
-    // Gradient of the regularized incomplete gamma functions igamma(a, g)
-    // Precomputed values
-    // g   = boost::math::tgamma(a)
-    // dig = boost::math::digamma(a)
+    /**
+     * Gradient of the regularized incomplete gamma functions igamma(a, z)
+     *
+     * For small z, the gradient is computed via the series expansion;
+     * for large z, the series is numerically inaccurate due to cancellation
+     * and the asymptotic expansion is used.
+     *
+     * @param a   shape parameter, a > 0
+     * @param z   location z >= 0
+     * @param g   boost::math::tgamma(a) (precomputed value)
+     * @param dig boost::math::digamma(a) (precomputed value)
+     *
+     * For the asymptotic expansion, the gradient is given by:
+       \f[
+       \begin{array}{rcl}
+       \Gamma(a, z) & = & z^{a-1}e^{-z} \sum_{k=0}^N \frac{(a-1)_k}{z^k} \qquad , z \gg a\\
+       Q(a, z) & = & \frac{z^{a-1}e^{-z}}{\Gamma(a)} \sum_{k=0}^N \frac{(a-1)_k}{z^k}\\
+       (a)_k & = & (a)_{k-1}(a-k)\\
+       \frac{d}{da} (a)_k & = & (a)_{k-1} + (a-k)\frac{d}{da} (a)_{k-1}\\
+       \frac{d}{da}Q(a, z) & = & (log(z) - \psi(a)) Q(a, z)\\
+       && + \frac{z^{a-1}e^{-z}}{\Gamma(a)} \sum_{k=0}^N \left(\frac{d}{da} (a-1)_k\right) \frac{1}{z^k}
+       \end{array}
+       \f]
+     */
     template<typename T>
-    T grad_reg_inc_gamma(T a, T z, T g, T dig, T precision = 1e-6) {
+    T grad_reg_inc_gamma(T a, T z, T g, T dig, double precision = 1e-6) {
       using boost::math::isinf;
       using std::domain_error;
       using std::exp;
@@ -22,40 +43,42 @@ namespace stan {
       using std::log;
 
       T l = log(z);
-      if (z >= a && z >= (T)8) {
-        // large values of z, compute gradient based on the asymptotic expansion
-        // http://dlmf.nist.gov/8.11#E2
+      if (z >= a && z >= 8) {
+        // asymptotic expansion http://dlmf.nist.gov/8.11#E2
         T S = 0;
-        T fac = a-1;  // falling_factorial(a-1, k)
+        T a_minus_one_minus_k = a - 1;
+        T fac = a_minus_one_minus_k;  // falling_factorial(a-1, k)
         T dfac = 1;   // d/da[falling_factorial(a-1, k)]
         T zpow = z;   // z ** k
         T delta = dfac / zpow;
 
         for (int k = 1; k < 10; ++k) {
+          a_minus_one_minus_k -= 1;
+
           S += delta;
 
           zpow *= z;
-          dfac = (a-1-k)*dfac + fac;
-          fac *= a-1-k;
+          dfac = a_minus_one_minus_k * dfac + fac;
+          fac *= a_minus_one_minus_k;
           delta = dfac / zpow;
 
           if (isinf(delta))
             throw domain_error("gradRegIncGamma not converging");
         }
 
-        return gamma_q(a, z) * (l - dig) + exp(-z + (a-1)*l) * S / g;
+        return gamma_q(a, z) * (l - dig) + exp(-z + (a - 1) * l) * S / g;
       } else {
         // gradient of series expansion http://dlmf.nist.gov/8.7#E3
 
         T S = 0;
         T s = 1;
         int k = 0;
-        T delta = s / (a * a);
+        T delta = s / square(a);
         while (fabs(delta) > precision) {
           S += delta;
           ++k;
           s *= - z / k;
-          delta = s / ((k + a) * (k + a));
+          delta = s / square(k + a);
           if (isinf(delta))
             throw domain_error("gradRegIncGamma not converging");
         }

--- a/stan/math/prim/scal/prob/chi_square_ccdf_log.hpp
+++ b/stan/math/prim/scal/prob/chi_square_ccdf_log.hpp
@@ -11,7 +11,7 @@
 #include <stan/math/prim/scal/fun/constants.hpp>
 #include <stan/math/prim/scal/fun/multiply_log.hpp>
 #include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/fun/gamma_p.hpp>
+#include <stan/math/prim/scal/fun/gamma_q.hpp>
 #include <stan/math/prim/scal/fun/digamma.hpp>
 #include <stan/math/prim/scal/meta/VectorBuilder.hpp>
 #include <stan/math/prim/scal/fun/grad_reg_inc_gamma.hpp>
@@ -93,7 +93,7 @@ namespace stan {
         const T_partials_return beta_dbl = 0.5;
 
         // Compute
-        const T_partials_return Pn = 1.0 - gamma_p(alpha_dbl, beta_dbl * y_dbl);
+        const T_partials_return Pn = gamma_q(alpha_dbl, beta_dbl * y_dbl);
 
         ccdf_log += log(Pn);
 

--- a/stan/math/prim/scal/prob/gamma_ccdf_log.hpp
+++ b/stan/math/prim/scal/prob/gamma_ccdf_log.hpp
@@ -11,7 +11,7 @@
 #include <stan/math/prim/scal/fun/constants.hpp>
 #include <stan/math/prim/scal/fun/multiply_log.hpp>
 #include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/fun/gamma_p.hpp>
+#include <stan/math/prim/scal/fun/gamma_q.hpp>
 #include <stan/math/prim/scal/fun/digamma.hpp>
 #include <stan/math/prim/scal/meta/length.hpp>
 #include <stan/math/prim/scal/meta/is_constant_struct.hpp>
@@ -109,7 +109,7 @@ namespace stan {
         const T_partials_return beta_dbl = value_of(beta_vec[n]);
 
         // Compute
-        const T_partials_return Pn = 1.0 - gamma_p(alpha_dbl, beta_dbl * y_dbl);
+        const T_partials_return Pn = gamma_q(alpha_dbl, beta_dbl * y_dbl);
 
         P += log(Pn);
 

--- a/stan/math/prim/scal/prob/inv_chi_square_ccdf_log.hpp
+++ b/stan/math/prim/scal/prob/inv_chi_square_ccdf_log.hpp
@@ -11,7 +11,7 @@
 #include <stan/math/prim/scal/fun/constants.hpp>
 #include <stan/math/prim/scal/fun/multiply_log.hpp>
 #include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/fun/gamma_q.hpp>
+#include <stan/math/prim/scal/fun/gamma_p.hpp>
 #include <stan/math/prim/scal/fun/digamma.hpp>
 #include <stan/math/prim/scal/meta/length.hpp>
 #include <stan/math/prim/scal/meta/is_constant_struct.hpp>
@@ -99,8 +99,8 @@ namespace stan {
         const T_partials_return nu_dbl = value_of(nu_vec[n]);
 
         // Compute
-        const T_partials_return Pn = 1.0 - gamma_q(0.5 * nu_dbl, 0.5
-                                                   * y_inv_dbl);
+        const T_partials_return Pn = gamma_p(0.5 * nu_dbl, 0.5
+                                             * y_inv_dbl);
 
         P += log(Pn);
 

--- a/stan/math/prim/scal/prob/inv_gamma_ccdf_log.hpp
+++ b/stan/math/prim/scal/prob/inv_gamma_ccdf_log.hpp
@@ -13,7 +13,7 @@
 #include <stan/math/prim/scal/fun/constants.hpp>
 #include <stan/math/prim/scal/fun/value_of.hpp>
 #include <stan/math/prim/scal/fun/lgamma.hpp>
-#include <stan/math/prim/scal/fun/gamma_q.hpp>
+#include <stan/math/prim/scal/fun/gamma_p.hpp>
 #include <stan/math/prim/scal/fun/digamma.hpp>
 #include <stan/math/prim/scal/meta/length.hpp>
 #include <stan/math/prim/scal/meta/is_constant_struct.hpp>
@@ -109,8 +109,8 @@ namespace stan {
         const T_partials_return beta_dbl = value_of(beta_vec[n]);
 
         // Compute
-        const T_partials_return Pn = 1.0 - gamma_q(alpha_dbl, beta_dbl
-                                                   * y_inv_dbl);
+        const T_partials_return Pn = gamma_p(alpha_dbl, beta_dbl
+                                             * y_inv_dbl);
 
         P += log(Pn);
 

--- a/stan/math/prim/scal/prob/scaled_inv_chi_square_ccdf_log.hpp
+++ b/stan/math/prim/scal/prob/scaled_inv_chi_square_ccdf_log.hpp
@@ -10,7 +10,7 @@
 #include <stan/math/prim/scal/err/check_positive_finite.hpp>
 #include <stan/math/prim/scal/fun/constants.hpp>
 #include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/fun/gamma_q.hpp>
+#include <stan/math/prim/scal/fun/gamma_p.hpp>
 #include <stan/math/prim/scal/fun/digamma.hpp>
 #include <stan/math/prim/scal/fun/lgamma.hpp>
 #include <stan/math/prim/scal/fun/square.hpp>
@@ -108,8 +108,8 @@ namespace stan {
           = 2.0 * half_nu_dbl * half_s2_overx_dbl;
 
         // Compute
-        const T_partials_return Pn = 1.0 - gamma_q(half_nu_dbl,
-                                                   half_nu_s2_overx_dbl);
+        const T_partials_return Pn = gamma_p(half_nu_dbl,
+                                             half_nu_s2_overx_dbl);
         const T_partials_return gamma_p_deriv = exp(-half_nu_s2_overx_dbl)
           * pow(half_nu_s2_overx_dbl, half_nu_dbl-1) / tgamma(half_nu_dbl);
 

--- a/test/prob/chi_square/chi_square_ccdf_log_test.hpp
+++ b/test/prob/chi_square/chi_square_ccdf_log_test.hpp
@@ -64,10 +64,9 @@ public:
   typename stan::return_type<T_y, T_dof, T2>::type 
   ccdf_log_function(const T_y& y, const T_dof& nu, 
                     const T2&, const T3&, const T4&, const T5&) {
-    using stan::math::gamma_p;
-    using stan::math::gamma_p;
+    using stan::math::gamma_q;
     using std::log;
 
-    return log(1.0 - gamma_p(nu * 0.5, y * 0.5));
+    return log(gamma_q(nu * 0.5, y * 0.5));
   }
 };

--- a/test/prob/gamma/gamma_ccdf_log_test.hpp
+++ b/test/prob/gamma/gamma_ccdf_log_test.hpp
@@ -89,10 +89,10 @@ public:
   typename stan::return_type<T_y, T_shape, T_inv_scale>::type 
   ccdf_log_function(const T_y& y, const T_shape& alpha, const T_inv_scale& beta,
                     const T3&, const T4&, const T5&) {
-    using stan::math::gamma_p;
-    using boost::math::gamma_p;
+    using stan::math::gamma_q;
+    using boost::math::gamma_q;
     using std::log;
 
-    return log(1.0 - gamma_p(alpha, beta * y));
+    return log(gamma_q(alpha, beta * y));
   }
 };

--- a/test/prob/gamma/gamma_ccdf_log_test.hpp
+++ b/test/prob/gamma/gamma_ccdf_log_test.hpp
@@ -28,6 +28,12 @@ public:
     param[2] = 1.0;                 // beta
     parameters.push_back(param);
     ccdf_log.push_back(std::log(1.0 - 0.6321205588285576659757));       // expected ccdf_log
+
+    param[0] = 16.0;                // y
+    param[1] = 3.0;                 // alpha
+    param[2] = 3.0;                 // beta
+    parameters.push_back(param);
+    ccdf_log.push_back(std::log(1.7116220633718619e-18));       // expected ccdf_log
   }
  
   void invalid_values(vector<size_t>& index, 

--- a/test/prob/inv_chi_square/inv_chi_square_ccdf_log_test.hpp
+++ b/test/prob/inv_chi_square/inv_chi_square_ccdf_log_test.hpp
@@ -64,9 +64,8 @@ public:
   typename stan::return_type<T_y, T_dof>::type 
   ccdf_log_function(const T_y& y, const T_dof& nu, const T2&,
                     const T3&, const T4&, const T5&) {
-    using stan::math::gamma_q;
-    using stan::math::gamma_q;
+    using stan::math::gamma_p;
     
-    return log(1.0 - gamma_q(0.5 * nu, 0.5 / y));  
+    return log(1.0 - gamma_p(0.5 * nu, 0.5 / y));
   }
 };

--- a/test/prob/inv_gamma/inv_gamma_ccdf_log_test.hpp
+++ b/test/prob/inv_gamma/inv_gamma_ccdf_log_test.hpp
@@ -74,9 +74,8 @@ public:
   typename stan::return_type<T_y, T_shape, T_scale>::type 
   ccdf_log_function(const T_y& y, const T_shape& alpha, const T_scale& beta,
                     const T3&, const T4&, const T5&) {
-    using stan::math::gamma_q;
-    using stan::math::gamma_q;
+    using stan::math::gamma_p;
 
-    return log(1.0 - gamma_q(alpha, beta / y));  }
+    return log(gamma_p(alpha, beta / y));  }
     
 };

--- a/test/prob/scaled_inv_chi_square/scaled_inv_chi_square_ccdf_log_test.hpp
+++ b/test/prob/scaled_inv_chi_square/scaled_inv_chi_square_ccdf_log_test.hpp
@@ -76,8 +76,7 @@ public:
   ccdf_log_function(const T_y& y, const T_dof& nu, const T_scale& s,
                     const T3&, const T4&, const T5&) {
     using stan::math::gamma_q;
-    using stan::math::gamma_q;
 
-    return log(1.0 - gamma_q(nu * 0.5, 0.5 * nu * s * s / y)); 
+    return log(gamma_p(nu * 0.5, 0.5 * nu * s * s / y));
   }
 };

--- a/test/unit/math/mix/scal/fun/grad_reg_inc_gamma_test.cpp
+++ b/test/unit/math/mix/scal/fun/grad_reg_inc_gamma_test.cpp
@@ -17,9 +17,18 @@ TEST(ProbInternalMath, gradRegIncGamma_infLoopInVersion2_0_1) {
   double g = 5143.28;
   double dig = 2.01698;
   
-  EXPECT_THROW(stan::math::grad_reg_inc_gamma(a, b, g, dig),
-               std::domain_error);
+  EXPECT_FLOAT_EQ(0, stan::math::grad_reg_inc_gamma(a, b, g, dig));
 }
+
+TEST(ProbInternalMath, gradRegIncGamma_largeZ) {
+  double a = 3;
+  double z = 48;
+  double g = 2.0;
+  double dig = 0.9227843;
+
+  EXPECT_FLOAT_EQ(5.08294581508e-18, stan::math::grad_reg_inc_gamma(a, z, g, dig));
+}
+
 TEST(ProbInternalMath, gradRegIncGamma_fd) {
   using stan::math::fvar;
 

--- a/test/unit/math/rev/scal/fun/gamma_q_test.cpp
+++ b/test/unit/math/rev/scal/fun/gamma_q_test.cpp
@@ -23,24 +23,24 @@ TEST(AgradRev,gamma_q_var_var) {
   EXPECT_THROW(gamma_q(a,b), std::domain_error);
 }
 TEST(AgradRevGammaQ,infLoopInVersion2_0_1_var_var) {
-  // FIXME: causes infinite loop in 2.0.1 gradient calcs
   AVAR a = 8.01006;
   AVAR b = 2.47579e+215;
   AVEC x = createAVEC(a,b);
 
   AVAR f = gamma_q(a,b);
   VEC g;
-  EXPECT_THROW(f.grad(x,g), std::domain_error);
+  f.grad(x,g);
+  EXPECT_FLOAT_EQ(0, g[0]);
 }
 TEST(AgradRevGammaQ,infLoopInVersion2_0_1_var_double) {
-  // FIXME: causes infinite loop in 2.0.1 gradient calcs
   AVAR a = 8.01006;
   double b = 2.47579e+215;
   AVEC x = createAVEC(a);
 
   AVAR f = gamma_q(a,b);
   VEC g;
-  EXPECT_THROW(f.grad(x,g), std::domain_error);
+  f.grad(x,g);
+  EXPECT_FLOAT_EQ(0, g[0]);
 }
 TEST(AgradRev,gamma_q_double_var) {
   double a = 0.5;


### PR DESCRIPTION
#### Submisison Checklist

- [X] Run unit tests: `./runTests.py test/unit`
- [X] Run cpplint: `make cpplint`
- [X] Declare copyright holder and open-source license: see below

#### Summary:
Compute the gradient of the asymptotic expansion of the
incomplete gamma, for use when z is large.

This was motivated by seeing inaccurate gradients in
gamma_ccdf_log(16,3,3), failing the testcase I was trying to add. This
was due to accumulated error in the series expansion when z is large.
    
Though the asymptotic expansion doesn't appear common (e.g. scipy uses
continued fractions instead), it is simple to differentiate.
Numerical accuracy was checked using sympy as a reference,
comparing the accuracy of the series expansion to the asymptotic
expansion. Over a grid (50 evenly-logspaced values of A between
0.001 and 1000), the cutoff (z>=a)&&(z>=8) was found to be a
sufficient condition.

Analysis:
http://nbviewer.jupyter.org/gist/b11z/4f49105acbe90cab29a9c3ae56590e4a

#### Intended Effect:
Accurate CCDF and gradient for the testcase `gamma_ccdf_log(16,3,3)`.

#### How to Verify:
Testcases added for `gamma_ccdf_log(16,3,3)` and `grad_reg_inc_gamma(3,48)`.

#### Side Effects:

#### Documentation:
http://nbviewer.jupyter.org/gist/b11z/4f49105acbe90cab29a9c3ae56590e4a

#### Reviewer Suggestions: 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Brian Bloniarz

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
