### PR TITLE
symmetry for cov matrix inv transform, finish #1995

### DIFF
--- a/stan/math/prim/mat/fun/multiply_lower_tri_self_transpose.hpp
+++ b/stan/math/prim/mat/fun/multiply_lower_tri_self_transpose.hpp
@@ -2,6 +2,7 @@
 #define STAN_MATH_PRIM_MAT_FUN_MULTIPLY_LOWER_TRI_SELF_TRANSPOSE_HPP
 
 #include <stan/math/prim/mat/fun/typedefs.hpp>
+#include <stan/math/prim/scal/fun/square.hpp>
 
 namespace stan {
   namespace math {

--- a/stan/math/prim/mat/fun/multiply_lower_tri_self_transpose.hpp
+++ b/stan/math/prim/mat/fun/multiply_lower_tri_self_transpose.hpp
@@ -17,25 +17,21 @@ namespace stan {
     inline matrix_d
     multiply_lower_tri_self_transpose(const matrix_d& L) {
       int K = L.rows();
-      int J = L.cols();
-      int k;
-      matrix_d LLt(K, K);
-      matrix_d Lt = L.transpose();
-
       if (K == 0)
-        return matrix_d(0, 0);
+        return L;
       if (K == 1) {
         matrix_d result(1, 1);
-        result(0, 0) = L(0, 0) * L(0, 0);
+        result(0) = square(L(0));  // first elt, so don't need double idx
         return result;
       }
-
+      int J = L.cols();
+      matrix_d LLt(K, K);
+      matrix_d Lt = L.transpose();
       for (int m = 0; m < K; ++m) {
-        k = (J < m + 1) ? J : m + 1;
+        int k = (J < m + 1) ? J : m + 1;
         LLt(m, m) = Lt.col(m).head(k).squaredNorm();
-        for (int n = (m + 1); n < K; ++n) {
+        for (int n = (m + 1); n < K; ++n)
           LLt(n, m) = LLt(m, n) = Lt.col(m).head(k).dot(Lt.col(n).head(k));
-        }
       }
       return LLt;
     }

--- a/test/unit/math/prim/mat/fun/cov_matrix_transform_test.cpp
+++ b/test/unit/math/prim/mat/fun/cov_matrix_transform_test.cpp
@@ -4,6 +4,8 @@
 
 using Eigen::Matrix;
 using Eigen::Dynamic;
+using Eigen::MatrixXd;
+using Eigen::VectorXd;
 
 TEST(prob_transform,lkj_cov_matrix_rt) {
   unsigned int K = 4;
@@ -67,3 +69,19 @@ TEST(prob_transform,cov_matrix_free_exception) {
   y << 0, 0, 0, 0;
   EXPECT_THROW(stan::math::cov_matrix_free(y), std::domain_error);
 }
+TEST(covMatrixTransform, symmetry) {
+  using stan::math::cov_matrix_constrain;
+  for (int K = 1; K <= 50; ++K) {
+    int N = (K * (K + 1)) / 2;
+    VectorXd v(N);
+    for (int n = 0; n < N; ++n)
+      v(n) = (n - 0.5 * N) / 10;
+    MatrixXd Sigma = cov_matrix_constrain(v, K);
+    EXPECT_EQ(K, Sigma.rows());
+    EXPECT_EQ(K, Sigma.cols());
+    for (int i = 1; i < K; ++i)
+      for (int j = 0; j < i; ++j)
+        EXPECT_EQ(Sigma(i,j), Sigma(j, i));  // hard equality
+  }
+}
+


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

Use `multiply_lower_tri_self_transpose()` in `cov_matrix_constrain()` to enforce symmetry in inverse transform from unconstrained to constrained space.

#### Intended Effect:

Make sure a `cov_matrix` data type in Stan is symmetric.  Still no guarantees on positive definiteness. 

#### How to Verify:

New unit test for symmetry.

#### Side Effects:

No side effects, but results will now be different for `cov_matrix` types due to enforced symmetry.

#### Documentation:

Brings code up to match doc.

#### Reviewer Suggestions: 

Anyone.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

