### PR TITLE
Bugfix/0327 log int

### DIFF
--- a/stan/math/prim/mat/err/check_positive_ordered.hpp
+++ b/stan/math/prim/mat/err/check_positive_ordered.hpp
@@ -34,7 +34,6 @@ namespace stan {
       using Eigen::Dynamic;
       using Eigen::Matrix;
 
-      typedef typename index_type<Matrix<T_y, Dynamic, 1> >::type size_type;
       if (y.size() == 0) {
         return true;
       }

--- a/stan/math/prim/mat/fun/exp.hpp
+++ b/stan/math/prim/mat/fun/exp.hpp
@@ -2,18 +2,24 @@
 #define STAN_MATH_PRIM_MAT_FUN_EXP_HPP
 
 #include <stan/math/prim/mat/vectorize/apply_scalar_unary.hpp>
+#include <stan/math/prim/scal/fun/exp.hpp>
 #include <cmath>
 
 namespace stan {
   namespace math {
 
     /**
-     * Structure to wrap exp() so that it can be vectorized.
-     * @param x Variable.
-     * @tparam T Variable type.
-     * @return Natural exponential of x. 
+     * Structure to wrap <code>exp()</code> so that it can be
+     * vectorized.
      */
     struct exp_fun {
+      /**
+       * Return the exponential of the specified scalar argument.
+       *
+       * @tparam T Scalar argument type.
+       * @param[in] x Argument.
+       * @return Exponential of argument.
+       */
       template <typename T>
       static inline T fun(const T& x) {
         using std::exp;
@@ -22,10 +28,13 @@ namespace stan {
     };
 
     /**
-     * Vectorized version of exp().
-     * @param x Container.
-     * @tparam T Container type.
-     * @return Natural exponential applied to each value in x. 
+     * Return the elementwise exponentiation of the specified argument,
+     * which may be a scalar or any Stan container of numeric scalars.
+     * The return type is the same as the argument type.
+     *
+     * @tparam T Argument type.
+     * @param[in] x Argument.
+     * @return Elementwise application of exponentiation to the argument.
      */
     template <typename T>
     inline typename apply_scalar_unary<exp_fun, T>::return_t

--- a/stan/math/prim/mat/fun/log.hpp
+++ b/stan/math/prim/mat/fun/log.hpp
@@ -14,6 +14,10 @@ namespace stan {
      * @return Natural log of x.
      */
     struct log_fun {
+      static double fun(int x) {
+        return std::log(static_cast<double>(x));
+      }
+
       template <typename T>
       static inline T fun(const T& x) {
         using std::log;

--- a/stan/math/prim/mat/fun/log.hpp
+++ b/stan/math/prim/mat/fun/log.hpp
@@ -2,6 +2,7 @@
 #define STAN_MATH_PRIM_MAT_FUN_LOG_HPP
 
 #include <stan/math/prim/mat/vectorize/apply_scalar_unary.hpp>
+#include <stan/math/prim/scal/fun/log.hpp>
 #include <cmath>
 
 namespace stan {
@@ -9,15 +10,15 @@ namespace stan {
 
     /**
      * Structure to wrap log() so that it can be vectorized.
-     * @param x Variable.
-     * @tparam T Variable type.
-     * @return Natural log of x.
      */
     struct log_fun {
-      static double fun(int x) {
-        return std::log(static_cast<double>(x));
-      }
-
+      /** 
+       * Return natural log of specified argument.
+       *
+       * @tparam T Scalar argument type.
+       * @param[in] x Argument.
+       * @return Natural log of x.
+       */
       template <typename T>
       static inline T fun(const T& x) {
         using std::log;
@@ -26,10 +27,13 @@ namespace stan {
     };
 
     /**
-     * Vectorized version of log().
-     * @param x Container.
-     * @tparam T Container type.
-     * @return Natural log applied to each value in x.
+     * Return the elementwise natural log of the specified argument,
+     * which may be a scalar or any Stan container of numeric scalars.
+     * The return type is the same as the argument type.
+     *
+     * @tparam T Argument type.
+     * @param[in] x Argument.
+     * @return Elementwise application of natural log to the argument.
      */
     template <typename T>
     inline typename apply_scalar_unary<log_fun, T>::return_t
@@ -39,5 +43,4 @@ namespace stan {
 
   }
 }
-
 #endif

--- a/stan/math/prim/scal.hpp
+++ b/stan/math/prim/scal.hpp
@@ -68,6 +68,7 @@
 #include <stan/math/prim/scal/fun/digamma.hpp>
 #include <stan/math/prim/scal/fun/divide.hpp>
 #include <stan/math/prim/scal/fun/exp2.hpp>
+#include <stan/math/prim/scal/fun/exp.hpp>
 #include <stan/math/prim/scal/fun/F32.hpp>
 #include <stan/math/prim/scal/fun/falling_factorial.hpp>
 #include <stan/math/prim/scal/fun/fdim.hpp>
@@ -99,6 +100,7 @@
 #include <stan/math/prim/scal/fun/lbeta.hpp>
 #include <stan/math/prim/scal/fun/lgamma.hpp>
 #include <stan/math/prim/scal/fun/lmgamma.hpp>
+#include <stan/math/prim/scal/fun/log.hpp>
 #include <stan/math/prim/scal/fun/log1m.hpp>
 #include <stan/math/prim/scal/fun/log1m_exp.hpp>
 #include <stan/math/prim/scal/fun/log1m_inv_logit.hpp>

--- a/stan/math/prim/scal/fun/exp.hpp
+++ b/stan/math/prim/scal/fun/exp.hpp
@@ -1,0 +1,22 @@
+#ifndef STAN_MATH_PRIM_SCAL_FUN_EXP_HPP
+#define STAN_MATH_PRIM_SCAL_FUN_EXP_HPP
+
+#include <cmath>
+
+namespace stan {
+  namespace math {
+
+    /**
+     * Return the natural exponential of the specified argument.  This
+     * version is required to disambiguate <code>exp(int)</code>.
+     *
+     * @param[in] x Argument.
+     * @return Natural exponential of argument.
+     */
+    inline double exp(int x) {
+      return std::exp(static_cast<double>(x));
+    }
+
+  }
+}
+#endif

--- a/stan/math/prim/scal/fun/log.hpp
+++ b/stan/math/prim/scal/fun/log.hpp
@@ -1,0 +1,22 @@
+#ifndef STAN_MATH_PRIM_SCAL_FUN_LOG_HPP
+#define STAN_MATH_PRIM_SCAL_FUN_LOG_HPP
+
+#include <cmath>
+
+namespace stan {
+  namespace math {
+
+    /**
+     * Return the natural log of the specified argument.  This version
+     * is required to disambiguate <code>log(int)</code>.
+     *
+     * @param[in] x Argument.
+     * @return Natural log of argument.
+     */
+    inline double log(int x) {
+      return std::log(static_cast<double>(x));
+    }
+
+  }
+}
+#endif

--- a/stan/math/prim/scal/fun/log1p.hpp
+++ b/stan/math/prim/scal/fun/log1p.hpp
@@ -36,7 +36,7 @@ namespace stan {
      */
     template <typename T>
     inline typename boost::math::tools::promote_args<T>::type
-    log1p(const T x) {
+    log1p(const T& x) {
       using std::log;
       if (!(x >= -1.0))
         return std::numeric_limits<double>::quiet_NaN();
@@ -47,6 +47,18 @@ namespace stan {
         return x - 0.5 * x * x;  // 2nd order Taylor, if close to 1
       else
         return x;                // 1st order Taylor, if very close to 1
+    }
+
+    /**
+     * Return the natural logarithm of one plus the specified
+     * argument.  This version is required to disambiguate
+     * <code>log1p(int)</code>.
+     *
+     * @param[in] x Argument.
+     * @return Natural logarithm of one plus the argument.
+     */
+    inline double log1p(int x) {
+      return log1p(static_cast<double>(x));
     }
 
   }

--- a/stan/math/prim/scal/fun/log2.hpp
+++ b/stan/math/prim/scal/fun/log2.hpp
@@ -3,6 +3,7 @@
 
 #include <stan/math/prim/scal/fun/constants.hpp>
 #include <boost/math/tools/promotion.hpp>
+#include <math.h>
 #include <stdexcept>
 
 namespace stan {
@@ -21,9 +22,21 @@ namespace stan {
      */
     template <typename T>
     inline typename boost::math::tools::promote_args<T>::type
-    log2(const T a) {
+    log2(const T& a) {
       using std::log;
       return log(a) / LOG_2;
+    }
+
+    /**
+     * Return the base two logarithm of the specified
+     * argument.  This version is required to disambiguate
+     * <code>log2(int)</code>.
+     *
+     * @param[in] x Argument.
+     * @return Base two logarithm of the argument.
+     */
+    inline double log2(int x) {
+      return log2(static_cast<double>(x));
     }
 
     /**

--- a/stan/math/prim/scal/fun/positive_constrain.hpp
+++ b/stan/math/prim/scal/fun/positive_constrain.hpp
@@ -17,8 +17,8 @@ namespace stan {
      * @return Input transformed to be positive.
      */
     template <typename T>
-    inline
-    T positive_constrain(const T x) {
+    inline T positive_constrain(const T x) {
+      using std::exp;
       return exp(x);
     }
 
@@ -39,8 +39,8 @@ namespace stan {
      * @tparam T Type of scalar.
      */
     template <typename T>
-    inline
-    T positive_constrain(const T x, T& lp) {
+    inline T positive_constrain(const T x, T& lp) {
+      using std::exp;
       lp += x;
       return exp(x);
     }

--- a/stan/math/prim/scal/fun/positive_free.hpp
+++ b/stan/math/prim/scal/fun/positive_free.hpp
@@ -26,6 +26,7 @@ namespace stan {
     template <typename T>
     inline
     T positive_free(const T y) {
+      using std::log;
       check_positive("positive_free",
                      "Positive variable", y);
       return log(y);

--- a/test/unit/math/prim/scal/fun/exp_test.cpp
+++ b/test/unit/math/prim/scal/fun/exp_test.cpp
@@ -1,0 +1,9 @@
+#include <stan/math.hpp>
+#include <gtest/gtest.h>
+
+TEST(MathFunctions, expInt) {
+  using std::exp;
+  using stan::math::exp;
+  EXPECT_FLOAT_EQ(std::exp(3), exp(3));
+  EXPECT_FLOAT_EQ(std::exp(3.0), exp(3.0));
+}

--- a/test/unit/math/prim/scal/fun/log_test.cpp
+++ b/test/unit/math/prim/scal/fun/log_test.cpp
@@ -1,0 +1,9 @@
+#include <stan/math.hpp>
+#include <gtest/gtest.h>
+
+TEST(MathFunctions, logInt) {
+  using std::log;
+  using stan::math::log;
+  EXPECT_FLOAT_EQ(std::log(3), log(3));
+  EXPECT_FLOAT_EQ(std::log(3.0), log(3.0));
+}

--- a/test/unit/math/rev/mat/functor/integrate_ode_bdf_prim_test.cpp
+++ b/test/unit/math/rev/mat/functor/integrate_ode_bdf_prim_test.cpp
@@ -1,18 +1,14 @@
 #include <stan/math/rev/mat.hpp>
+#include <boost/numeric/odeint.hpp>
 #include <gtest/gtest.h>
+
+#include <test/unit/math/prim/arr/functor/harmonic_oscillator.hpp>
+#include <test/unit/math/prim/arr/functor/lorenz.hpp>
+#include <test/unit/util.hpp>
 
 #include <iostream>
 #include <sstream>
 #include <vector>
-
-#include <boost/numeric/odeint.hpp>
-
-
-#include <test/unit/math/prim/arr/functor/harmonic_oscillator.hpp>
-#include <test/unit/math/prim/arr/functor/lorenz.hpp>
-
-#include <test/unit/util.hpp>
-
 
 template <typename F>
 void sho_death_test(F harm_osc,
@@ -145,21 +141,24 @@ TEST(StanMathOde_integrate_ode_bdf, error_conditions) {
                    std::domain_error,
                    "times is not a valid ordered vector");
 
+  
+  // FIXME(carpenter): g++6 failure
+  // std::vector<double> theta_bad;
+  // EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0, t0, ts, theta_bad, x, x_int, 0, 1e-8, 1e-10, 1e6),
+  //                  std::out_of_range,
+  //                  "vector");
 
-  std::vector<double> theta_bad;
-  EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0, t0, ts, theta_bad, x, x_int, 0, 1e-8, 1e-10, 1e6),
-                   std::out_of_range,
-                   "vector");
+  // FIXME(carpenter): g++6 failure
+  // std::vector<double> x_bad;
+  // EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0, t0, ts, theta, x_bad, x_int, 0, 1e-8, 1e-10, 1e6),
+  //                  std::out_of_range,
+  //                  "vector");
 
-  std::vector<double> x_bad;
-  EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0, t0, ts, theta, x_bad, x_int, 0, 1e-8, 1e-10, 1e6),
-                   std::out_of_range,
-                   "vector");
 
-  std::vector<int> x_int_bad;
-  EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0, t0, ts, theta, x, x_int_bad, 0, 1e-8, 1e-10, 1e6),
-                   std::out_of_range,
-                   "vector");
+  // std::vector<int> x_int_bad;
+  // EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0, t0, ts, theta, x, x_int_bad, 0, 1e-8, 1e-10, 1e6),
+  //                  std::out_of_range,
+  //                  "vector");
 
   EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0, t0, ts, theta, x, x_int,
                                      0, -1, 1e-6, 10),

--- a/test/unit/math/rev/mat/functor/integrate_ode_bdf_prim_test.cpp
+++ b/test/unit/math/rev/mat/functor/integrate_ode_bdf_prim_test.cpp
@@ -118,47 +118,55 @@ TEST(StanMathOde_integrate_ode_bdf, error_conditions) {
   std::vector<double> x(3,1);
   std::vector<int> x_int(2,0);
 
-  ASSERT_NO_THROW(integrate_ode_bdf(harm_osc, y0, t0, ts, theta, x, x_int, 0, 1e-8, 1e-10, 1e6));
+  ASSERT_NO_THROW(integrate_ode_bdf(harm_osc, y0, t0, ts, theta, x, x_int,
+                                    0, 1e-8, 1e-10, 1e6));
 
   std::vector<double> y0_bad;
-  EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0_bad, t0, ts, theta, x, x_int, 0, 1e-8, 1e-10, 1e6),
+  EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0_bad, t0, ts, theta, x,
+                                     x_int, 0, 1e-8, 1e-10, 1e6),
                    std::invalid_argument,
                    "initial state has size 0");
 
   double t0_bad = 2.0;
-  EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0, t0_bad, ts, theta, x, x_int, 0, 1e-8, 1e-10, 1e6),
+  EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0, t0_bad, ts, theta, x,
+                                     x_int, 0, 1e-8, 1e-10, 1e6),
                    std::domain_error,
                    "initial time is 2, but must be less than 0.1");
 
   std::vector<double> ts_bad;
-  EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0, t0, ts_bad, theta, x, x_int, 0, 1e-8, 1e-10, 1e6),
+  EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0, t0, ts_bad, theta, x,
+                                     x_int, 0, 1e-8, 1e-10, 1e6),
                    std::invalid_argument,
                    "times has size 0");
 
   ts_bad.push_back(3);
   ts_bad.push_back(1);
-  EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0, t0, ts_bad, theta, x, x_int, 0, 1e-8, 1e-10, 1e6),
+  EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0, t0, ts_bad, theta, x,
+                                     x_int, 0, 1e-8, 1e-10, 1e6),
                    std::domain_error,
                    "times is not a valid ordered vector");
 
   
-  // FIXME(carpenter): g++6 failure
-  // std::vector<double> theta_bad;
-  // EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0, t0, ts, theta_bad, x, x_int, 0, 1e-8, 1e-10, 1e6),
-  //                  std::out_of_range,
-  //                  "vector");
+  // TODO(carpenter): g++6 failure
+  std::vector<double> theta_bad;
+  EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0, t0, ts, theta_bad,
+                                     x, x_int, 0, 1e-8, 1e-10, 1e6),
+                   std::out_of_range,
+                   "vector");
 
-  // FIXME(carpenter): g++6 failure
-  // std::vector<double> x_bad;
-  // EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0, t0, ts, theta, x_bad, x_int, 0, 1e-8, 1e-10, 1e6),
-  //                  std::out_of_range,
-  //                  "vector");
+  // TODO(carpenter): g++6 failure
+  std::vector<double> x_bad;
+  EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0, t0, ts, theta,
+                                     x_bad, x_int, 0, 1e-8, 1e-10, 1e6),
+                   std::out_of_range,
+                   "vector");
 
-
-  // std::vector<int> x_int_bad;
-  // EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0, t0, ts, theta, x, x_int_bad, 0, 1e-8, 1e-10, 1e6),
-  //                  std::out_of_range,
-  //                  "vector");
+  // TODO(carpenter): g++6 failure
+  std::vector<int> x_int_bad;
+  EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0, t0, ts, theta, x,
+                                     x_int_bad, 0, 1e-8, 1e-10, 1e6),
+                   std::out_of_range,
+                   "vector");
 
   EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0, t0, ts, theta, x, x_int,
                                      0, -1, 1e-6, 10),
@@ -196,7 +204,8 @@ TEST(StanMathOde_integrate_ode_bdf, error_conditions_nan) {
   std::vector<double> x(3,1);
   std::vector<int> x_int(2,0);
 
-  ASSERT_NO_THROW(integrate_ode_bdf(harm_osc, y0, t0, ts, theta, x, x_int, 0, 1e-8, 1e-10, 1e6));
+  ASSERT_NO_THROW(integrate_ode_bdf(harm_osc, y0, t0, ts, theta, x, x_int,
+                                    0, 1e-8, 1e-10, 1e6));
 
   double nan = std::numeric_limits<double>::quiet_NaN();
   std::stringstream expected_is_nan;
@@ -204,46 +213,56 @@ TEST(StanMathOde_integrate_ode_bdf, error_conditions_nan) {
 
   std::vector<double> y0_bad = y0;
   y0_bad[0] = nan;
-  EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0_bad, t0, ts, theta, x, x_int, 0, 1e-8, 1e-10, 1e6),
+  EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0_bad, t0, ts, theta, x,
+                                     x_int, 0, 1e-8, 1e-10, 1e6),
                    std::domain_error,
                    "initial state");
-  EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0_bad, t0, ts, theta, x, x_int, 0, 1e-8, 1e-10, 1e6),
+  EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0_bad, t0, ts, theta, x,
+                                     x_int, 0, 1e-8, 1e-10, 1e6),
                    std::domain_error,
                    expected_is_nan.str());
 
   double t0_bad = nan;
-  EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0, t0_bad, ts, theta, x, x_int, 0, 1e-8, 1e-10, 1e6),
+  EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0, t0_bad, ts, theta,
+                                     x, x_int, 0, 1e-8, 1e-10, 1e6),
                    std::domain_error,
                    "initial time");
-  EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0, t0_bad, ts, theta, x, x_int, 0, 1e-8, 1e-10, 1e6),
+  EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0, t0_bad, ts, theta,
+                                     x, x_int, 0, 1e-8, 1e-10, 1e6),
                    std::domain_error,
                    expected_is_nan.str());
 
   std::vector<double> ts_bad = ts;
   ts_bad[0] = nan;
-  EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0, t0, ts_bad, theta, x, x_int, 0, 1e-8, 1e-10, 1e6),
+  EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0, t0, ts_bad, theta,
+                                     x, x_int, 0, 1e-8, 1e-10, 1e6),
                    std::domain_error,
                    "times");
-  EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0, t0, ts_bad, theta, x, x_int, 0, 1e-8, 1e-10, 1e6),
+  EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0, t0, ts_bad, theta,
+                                     x, x_int, 0, 1e-8, 1e-10, 1e6),
                    std::domain_error,
                    expected_is_nan.str());
 
   std::vector<double> theta_bad = theta;
   theta_bad[0] = nan;
-  EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0, t0, ts, theta_bad, x, x_int, 0, 1e-8, 1e-10, 1e6),
+  EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0, t0, ts, theta_bad,
+                                     x, x_int, 0, 1e-8, 1e-10, 1e6),
                    std::domain_error,
                    "parameter vector");
-  EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0, t0, ts, theta_bad, x, x_int, 0, 1e-8, 1e-10, 1e6),
+  EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0, t0, ts, theta_bad, x,
+                                     x_int, 0, 1e-8, 1e-10, 1e6),
                    std::domain_error,
                    expected_is_nan.str());
 
   if (x.size() > 0) {
     std::vector<double> x_bad = x;
     x_bad[0] = nan;
-    EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0, t0, ts, theta, x_bad, x_int, 0, 1e-8, 1e-10, 1e6),
+    EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0, t0, ts, theta, x_bad,
+                                       x_int, 0, 1e-8, 1e-10, 1e6),
                      std::domain_error,
                      "continuous data");
-    EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0, t0, ts, theta, x_bad, x_int, 0, 1e-8, 1e-10, 1e6),
+    EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0, t0, ts, theta, x_bad,
+                                       x_int, 0, 1e-8, 1e-10, 1e6),
                      std::domain_error,
                      expected_is_nan.str());
   }
@@ -273,70 +292,87 @@ TEST(StanMathOde_integrate_ode_bdf, error_conditions_inf) {
   std::vector<double> x(3,1);
   std::vector<int> x_int(2,0);
 
-  ASSERT_NO_THROW(integrate_ode_bdf(harm_osc, y0, t0, ts, theta, x, x_int, 0, 1e-8, 1e-10, 1e6));
+  ASSERT_NO_THROW(integrate_ode_bdf(harm_osc, y0, t0, ts, theta, x, x_int,
+                                    0, 1e-8, 1e-10, 1e6));
 
   double inf = std::numeric_limits<double>::infinity();
   std::vector<double> y0_bad = y0;
   y0_bad[0] = inf;
-  EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0_bad, t0, ts, theta, x, x_int, 0, 1e-8, 1e-10, 1e6),
+  EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0_bad, t0, ts, theta, x,
+                                     x_int, 0, 1e-8, 1e-10, 1e6),
                    std::domain_error,
                    "initial state");
-  EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0_bad, t0, ts, theta, x, x_int, 0, 1e-8, 1e-10, 1e6),
+  EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0_bad, t0, ts, theta, x,
+                                     x_int, 0, 1e-8, 1e-10, 1e6),
                    std::domain_error,
                    expected_is_inf.str());
 
   y0_bad[0] = -inf;
-  EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0_bad, t0, ts, theta, x, x_int, 0, 1e-8, 1e-10, 1e6),
+  EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0_bad, t0, ts, theta, x,
+                                     x_int, 0, 1e-8, 1e-10, 1e6),
                    std::domain_error,
                    "initial state");
-  EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0_bad, t0, ts, theta, x, x_int, 0, 1e-8, 1e-10, 1e6),
+  EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0_bad, t0, ts, theta, x,
+                                     x_int, 0, 1e-8, 1e-10, 1e6),
                    std::domain_error,
                    expected_is_neg_inf.str());
 
   double t0_bad = inf;
-  EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0, t0_bad, ts, theta, x, x_int, 0, 1e-8, 1e-10, 1e6),
+  EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0, t0_bad, ts, theta, x,
+                                     x_int, 0, 1e-8, 1e-10, 1e6),
                    std::domain_error,
                    "initial time");
-  EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0, t0_bad, ts, theta, x, x_int, 0, 1e-8, 1e-10, 1e6),
+  EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0, t0_bad, ts, theta, x,
+                                     x_int, 0, 1e-8, 1e-10, 1e6),
                    std::domain_error,
                    expected_is_inf.str());
   t0_bad = -inf;
-  EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0, t0_bad, ts, theta, x, x_int, 0, 1e-8, 1e-10, 1e6),
+  EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0, t0_bad, ts, theta, x,
+                                     x_int, 0, 1e-8, 1e-10, 1e6),
                    std::domain_error,
                    "initial time");
-  EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0, t0_bad, ts, theta, x, x_int, 0, 1e-8, 1e-10, 1e6),
+  EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0, t0_bad, ts, theta, x,
+                                     x_int, 0, 1e-8, 1e-10, 1e6),
                    std::domain_error,
                    expected_is_neg_inf.str());
 
   std::vector<double> ts_bad = ts;
   ts_bad.push_back(inf);
-  EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0, t0, ts_bad, theta, x, x_int, 0, 1e-8, 1e-10, 1e6),
+  EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0, t0, ts_bad, theta, x,
+                                     x_int, 0, 1e-8, 1e-10, 1e6),
                    std::domain_error,
                    "times");
-  EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0, t0, ts_bad, theta, x, x_int, 0, 1e-8, 1e-10, 1e6),
+  EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0, t0, ts_bad, theta, x,
+                                     x_int, 0, 1e-8, 1e-10, 1e6),
                    std::domain_error,
                    expected_is_inf.str());
   ts_bad[0] = -inf;
-  EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0, t0, ts_bad, theta, x, x_int, 0, 1e-8, 1e-10, 1e6),
+  EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0, t0, ts_bad, theta, x,
+                                     x_int, 0, 1e-8, 1e-10, 1e6),
                    std::domain_error,
                    "times");
-  EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0, t0, ts_bad, theta, x, x_int, 0, 1e-8, 1e-10, 1e6),
+  EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0, t0, ts_bad, theta, x,
+                                     x_int, 0, 1e-8, 1e-10, 1e6),
                    std::domain_error,
                    expected_is_neg_inf.str());
 
   std::vector<double> theta_bad = theta;
   theta_bad[0] = inf;
-  EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0, t0, ts, theta_bad, x, x_int, 0, 1e-8, 1e-10, 1e6),
+  EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0, t0, ts, theta_bad, x,
+                                     x_int, 0, 1e-8, 1e-10, 1e6),
                    std::domain_error,
                    "parameter vector");
-  EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0, t0, ts, theta_bad, x, x_int, 0, 1e-8, 1e-10, 1e6),
+  EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0, t0, ts, theta_bad, x,
+                                     x_int, 0, 1e-8, 1e-10, 1e6),
                    std::domain_error,
                    expected_is_inf.str());
   theta_bad[0] = -inf;
-  EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0, t0, ts, theta_bad, x, x_int, 0, 1e-8, 1e-10, 1e6),
+  EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0, t0, ts, theta_bad, x,
+                                     x_int, 0, 1e-8, 1e-10, 1e6),
                    std::domain_error,
                    "parameter vector");
-  EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0, t0, ts, theta_bad, x, x_int, 0, 1e-8, 1e-10, 1e6),
+  EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0, t0, ts, theta_bad, x,
+                                     x_int, 0, 1e-8, 1e-10, 1e6),
                    std::domain_error,
                    expected_is_neg_inf.str());
 
@@ -344,17 +380,21 @@ TEST(StanMathOde_integrate_ode_bdf, error_conditions_inf) {
   if (x.size() > 0) {
     std::vector<double> x_bad = x;
     x_bad[0] = inf;
-    EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0, t0, ts, theta, x_bad, x_int, 0, 1e-8, 1e-10, 1e6),
+    EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0, t0, ts, theta, x_bad,
+                                       x_int, 0, 1e-8, 1e-10, 1e6),
                      std::domain_error,
                      "continuous data");
-    EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0, t0, ts, theta, x_bad, x_int, 0, 1e-8, 1e-10, 1e6),
+    EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0, t0, ts, theta, x_bad,
+                                       x_int, 0, 1e-8, 1e-10, 1e6),
                      std::domain_error,
                      expected_is_inf.str());
     x_bad[0] = -inf;
-    EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0, t0, ts, theta, x_bad, x_int, 0, 1e-8, 1e-10, 1e6),
+    EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0, t0, ts, theta, x_bad,
+                                       x_int, 0, 1e-8, 1e-10, 1e6),
                      std::domain_error,
                      "continuous data");
-    EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0, t0, ts, theta, x_bad, x_int, 0, 1e-8, 1e-10, 1e6),
+    EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0, t0, ts, theta, x_bad,
+                                       x_int, 0, 1e-8, 1e-10, 1e6),
                      std::domain_error,
                      expected_is_neg_inf.str());
   }

--- a/test/unit/math/rev/mat/functor/integrate_ode_bdf_rev_test.cpp
+++ b/test/unit/math/rev/mat/functor/integrate_ode_bdf_rev_test.cpp
@@ -94,38 +94,40 @@ void sho_data_finite_diff_test(double t0) {
 }
 
 
-TEST(StanAgradRevOde_integrate_ode, harmonic_oscillator_finite_diff) {
-  sho_finite_diff_test(0);
-  sho_finite_diff_test(1.0);
-  sho_finite_diff_test(-1.0);
+// FIXME(carpenter): g++6 failure
+// TEST(StanAgradRevOde_integrate_ode, harmonic_oscillator_finite_diff) {
+//   sho_finite_diff_test(0);
+//   sho_finite_diff_test(1.0);
+//   sho_finite_diff_test(-1.0);
 
-  sho_data_finite_diff_test(0);
-  sho_data_finite_diff_test(1.0);
-  sho_data_finite_diff_test(-1.0);
-}
+//   sho_data_finite_diff_test(0);
+//   sho_data_finite_diff_test(1.0);
+//   sho_data_finite_diff_test(-1.0);
+// }
 
-TEST(StanAgradRevOde_integrate_ode, lorenz_finite_diff) {
-  lorenz_ode_fun lorenz;
+// FIXME(carpenter): g++6 failure
+// TEST(StanAgradRevOde_integrate_ode, lorenz_finite_diff) {
+//   lorenz_ode_fun lorenz;
 
-  std::vector<double> y0;
-  std::vector<double> theta;
-  double t0;
-  std::vector<double> ts;
+//   std::vector<double> y0;
+//   std::vector<double> theta;
+//   double t0;
+//   std::vector<double> ts;
 
-  t0 = 0;
+//   t0 = 0;
 
-  theta.push_back(10.0);
-  theta.push_back(28.0);
-  theta.push_back(8.0/3.0);
-  y0.push_back(10.0);
-  y0.push_back(1.0);
-  y0.push_back(1.0);
+//   theta.push_back(10.0);
+//   theta.push_back(28.0);
+//   theta.push_back(8.0/3.0);
+//   y0.push_back(10.0);
+//   y0.push_back(1.0);
+//   y0.push_back(1.0);
 
-  std::vector<double> x;
-  std::vector<int> x_int;
+//   std::vector<double> x;
+//   std::vector<int> x_int;
 
-  for (int i = 0; i < 100; i++)
-    ts.push_back(0.1*(i+1));
+//   for (int i = 0; i < 100; i++)
+//     ts.push_back(0.1*(i+1));
 
-  test_ode_cvode(lorenz, t0, ts, y0, theta, x, x_int, 1e-8, 1e-1);
-}
+//   test_ode_cvode(lorenz, t0, ts, y0, theta, x, x_int, 1e-8, 1e-1);
+// }

--- a/test/unit/math/rev/mat/functor/integrate_ode_bdf_rev_test.cpp
+++ b/test/unit/math/rev/mat/functor/integrate_ode_bdf_rev_test.cpp
@@ -88,46 +88,49 @@ void sho_data_finite_diff_test(double t0) {
 
   test_ode_cvode(harm_osc, t0, ts, y0, theta, x, x_int, 1e-8, 1e-4);
 
-  sho_value_test<harm_osc_ode_data_fun,double,var>(harm_osc, y0, t0, ts, theta, x, x_int);
-  sho_value_test<harm_osc_ode_data_fun,var,double>(harm_osc, y0, t0, ts, theta, x, x_int);
-  sho_value_test<harm_osc_ode_data_fun,var,var>(harm_osc, y0, t0, ts, theta, x, x_int);
+  sho_value_test<harm_osc_ode_data_fun,double,var>(harm_osc, y0, t0, ts,
+                                                   theta, x, x_int);
+  sho_value_test<harm_osc_ode_data_fun,var,double>(harm_osc, y0, t0, ts,
+                                                   theta, x, x_int);
+  sho_value_test<harm_osc_ode_data_fun,var,var>(harm_osc, y0, t0, ts,
+                                                theta, x, x_int);
 }
 
 
-// FIXME(carpenter): g++6 failure
-// TEST(StanAgradRevOde_integrate_ode, harmonic_oscillator_finite_diff) {
-//   sho_finite_diff_test(0);
-//   sho_finite_diff_test(1.0);
-//   sho_finite_diff_test(-1.0);
+// TODO(carpenter): g++6 failure
+TEST(StanAgradRevOde_integrate_ode, harmonic_oscillator_finite_diff) {
+  sho_finite_diff_test(0);
+  sho_finite_diff_test(1.0);
+  sho_finite_diff_test(-1.0);
 
-//   sho_data_finite_diff_test(0);
-//   sho_data_finite_diff_test(1.0);
-//   sho_data_finite_diff_test(-1.0);
-// }
+  sho_data_finite_diff_test(0);
+  sho_data_finite_diff_test(1.0);
+  sho_data_finite_diff_test(-1.0);
+}
 
-// FIXME(carpenter): g++6 failure
-// TEST(StanAgradRevOde_integrate_ode, lorenz_finite_diff) {
-//   lorenz_ode_fun lorenz;
+// TODO(carpenter): g++6 failure
+TEST(StanAgradRevOde_integrate_ode, lorenz_finite_diff) {
+  lorenz_ode_fun lorenz;
 
-//   std::vector<double> y0;
-//   std::vector<double> theta;
-//   double t0;
-//   std::vector<double> ts;
+  std::vector<double> y0;
+  std::vector<double> theta;
+  double t0;
+  std::vector<double> ts;
 
-//   t0 = 0;
+  t0 = 0;
 
-//   theta.push_back(10.0);
-//   theta.push_back(28.0);
-//   theta.push_back(8.0/3.0);
-//   y0.push_back(10.0);
-//   y0.push_back(1.0);
-//   y0.push_back(1.0);
+  theta.push_back(10.0);
+  theta.push_back(28.0);
+  theta.push_back(8.0/3.0);
+  y0.push_back(10.0);
+  y0.push_back(1.0);
+  y0.push_back(1.0);
 
-//   std::vector<double> x;
-//   std::vector<int> x_int;
+  std::vector<double> x;
+  std::vector<int> x_int;
 
-//   for (int i = 0; i < 100; i++)
-//     ts.push_back(0.1*(i+1));
+  for (int i = 0; i < 100; i++)
+    ts.push_back(0.1*(i+1));
 
-//   test_ode_cvode(lorenz, t0, ts, y0, theta, x, x_int, 1e-8, 1e-1);
-// }
+  test_ode_cvode(lorenz, t0, ts, y0, theta, x, x_int, 1e-8, 1e-1);
+}


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

Add `int` overload for `log()`, `exp()`, `log2()` and `log1p()` to resolve ambiguity with `int` arguments.

#### Intended Effect:

One step toward supporting g++6.

#### How to Verify:

Run unit tests with g++6 and try models (I made sure stan-dev/stan unit and integration tests still passed and that you could build models with `int` arguments to the above function susing g++6 in stan-dev/cmdstan.

#### Side Effects:

Not a side effect of this patch, but #348 is still an issue for g++6.  This patch solves the `int` ambiguity problem, but not the problem described in #348.


#### Documentation:

Not required.

#### Reviewer Suggestions: 

@bgoodri 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
