### PR TITLE
make clean-all now removes built CVODES binaries

### DIFF
--- a/make/libraries
+++ b/make/libraries
@@ -32,3 +32,7 @@ $(CVODES)/lib/libsundials_nvecserial.a: $(SUNDIALS_NVECSERIAL)
 	$(AR) -rs $@ $^
 
 LIBCVODES = $(CVODES)/lib/libsundials_nvecserial.a $(CVODES)/lib/libsundials_cvodes.a
+
+.PHONY: clean-libraries
+clean-libraries:
+	$(RM) $(sort $(SUNDIALS_CVODES) $(SUNDIALS_NVECSERIAL) $(LIBCVODES))

--- a/makefile
+++ b/makefile
@@ -132,7 +132,7 @@ endif
 	@echo '  - clean         : Basic clean. Leaves doc and compiled libraries intact.'
 	@echo '  - clean-deps    : Removes dependency files for tests. If tests stop building,'
 	@echo '                    run this target.'
-	@echo '  - clean-cvodes  : Removes binaries built for CVODES.'
+	@echo '  - clean-libraries : Removes binaries built for libraries including CVODES.'
 	@echo '  - clean-all     : Cleans up all of Stan.'
 	@echo ''
 	@echo '--------------------------------------------------------------------------------'
@@ -146,7 +146,7 @@ doxygen:
 ##
 # Clean up.
 ##
-.PHONY: clean clean-doxygen clean-deps clean-cvodes clean-all
+.PHONY: clean clean-doxygen clean-deps clean-all
 clean:
 	@echo '  removing test executables'
 	$(shell find test -type f -name "*_test$(EXE)" -exec rm {} +)
@@ -163,11 +163,7 @@ clean-deps:
 	$(shell find . -type f -name '*.d.*' -exec rm {} +)
 	$(RM) $(shell find stan -type f -name '*.dSYM') $(shell find stan -type f -name '*.d.*')
 
-clean-cvodes:
-	$(RM) $(wildcard $(CVODES)/lib/*)
-	$(RM) $(wildcard $(CVODES)/src/*/*.o)
-
-clean-all: clean clean-doxygen clean-deps clean-cvodes
+clean-all: clean clean-doxygen clean-deps clean-libraries
 	@echo '  removing generated test files'
 	$(shell find test/prob -name '*_generated_*_test.cpp' -type f -exec rm {} +)
 	$(RM) $(wildcard test/gtest.o test/libgtest* test/prob/generate_tests$(EXE))

--- a/makefile
+++ b/makefile
@@ -132,6 +132,7 @@ endif
 	@echo '  - clean         : Basic clean. Leaves doc and compiled libraries intact.'
 	@echo '  - clean-deps    : Removes dependency files for tests. If tests stop building,'
 	@echo '                    run this target.'
+	@echo '  - clean-cvodes  : Removes binaries built for CVODES.'
 	@echo '  - clean-all     : Cleans up all of Stan.'
 	@echo ''
 	@echo '--------------------------------------------------------------------------------'
@@ -145,7 +146,7 @@ doxygen:
 ##
 # Clean up.
 ##
-.PHONY: clean clean-doxygen clean-deps clean-all
+.PHONY: clean clean-doxygen clean-deps clean-cvodes clean-all
 clean:
 	@echo '  removing test executables'
 	$(shell find test -type f -name "*_test$(EXE)" -exec rm {} +)
@@ -162,8 +163,11 @@ clean-deps:
 	$(shell find . -type f -name '*.d.*' -exec rm {} +)
 	$(RM) $(shell find stan -type f -name '*.dSYM') $(shell find stan -type f -name '*.d.*')
 
-clean-all: clean clean-doxygen clean-deps
+clean-cvodes:
+	$(RM) $(wildcard $(CVODES)/lib/*)
+	$(RM) $(wildcard $(CVODES)/src/*/*.o)
+
+clean-all: clean clean-doxygen clean-deps clean-cvodes
 	@echo '  removing generated test files'
 	$(shell find test/prob -name '*_generated_*_test.cpp' -type f -exec rm {} +)
 	$(RM) $(wildcard test/gtest.o test/libgtest* test/prob/generate_tests$(EXE))
-	$(RM) $(wildcard $(CVODES)/lib/*)


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary:
`make clean-all` now clears out all the CVODES binaries.

#### Side Effects:
None.

#### Documentation:
Added to the default target of `make`.

#### Reviewer Suggestions: 
Anyone.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

