### PR TITLE
range checks throw std::out_of_range

### DIFF
--- a/stan/math/prim/mat/fun/block.hpp
+++ b/stan/math/prim/mat/fun/block.hpp
@@ -11,12 +11,13 @@ namespace stan {
     /**
      * Return a nrows x ncols submatrix starting at (i-1, j-1).
      *
-     * @param m Matrix
-     * @param i Starting row
-     * @param j Starting column
-     * @param nrows Number of rows in block
-     * @param ncols Number of columns in block
-     **/
+     * @param m Matrix.
+     * @param i Starting row.
+     * @param j Starting column.
+     * @param nrows Number of rows in block.
+     * @param ncols Number of columns in block.
+     * @throw std::out_of_range if either index is out of range.
+     */
     template <typename T>
     inline
     Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>

--- a/stan/math/prim/mat/fun/col.hpp
+++ b/stan/math/prim/mat/fun/col.hpp
@@ -17,6 +17,7 @@ namespace stan {
      * @param m Matrix.
      * @param j Column index (count from 1).
      * @return Specified column of the matrix.
+     * @throw std::out_of_range if j is out of range.
      */
     template <typename T>
     inline

--- a/stan/math/prim/mat/fun/csr_matrix_times_vector.hpp
+++ b/stan/math/prim/mat/fun/csr_matrix_times_vector.hpp
@@ -64,10 +64,11 @@ namespace stan {
      * @throw std::domain_error if m and n are not positive or are nan.
      * @throw std::domain_error if the implied sparse matrix and b are
      *                          not multiplicable.
-     * @throw std::domain_error if m/n/w/v/u are not internally
-     * consistent, as defined by the indexing scheme.  Extractors are
-     * defined in Stan which guarantee a consistent set of m/n/w/v/u
-     * for a given sparse matrix.
+     * @throw std::invalid_argument if m/n/w/v/u are not internally
+     *   consistent, as defined by the indexing scheme.  Extractors are
+     *   defined in Stan which guarantee a consistent set of m/n/w/v/u
+     *   for a given sparse matrix.
+     * @throw std::out_of_range if any of the indexes are out of range.
      */
     /** \addtogroup csr_format
      */
@@ -113,7 +114,6 @@ namespace stan {
       }
       return result;
     }
-
     /** @}*/   // end of csr_format group
 
   }

--- a/stan/math/prim/mat/fun/csr_to_dense_matrix.hpp
+++ b/stan/math/prim/mat/fun/csr_to_dense_matrix.hpp
@@ -15,9 +15,7 @@ namespace stan {
     /** \addtogroup csr_format
      *  @{
      */
-
     /** 
-     **
      * Construct a dense Eigen matrix from the CSR format components.
      *
      * @tparam T Type of matrix entries.
@@ -28,7 +26,12 @@ namespace stan {
      * @param[in] u Index of where each row starts in w.
      * @return Dense matrix defined by previous arguments.
      * @throw std::domain_error If the arguments do not define a matrix.
-    */
+     * @throw std::invalid_argument if m/n/w/v/u are not internally
+     *   consistent, as defined by the indexing scheme.  Extractors are
+     *   defined in Stan which guarantee a consistent set of m/n/w/v/u
+     *   for a given sparse matrix.
+     * @throw std::out_of_range if any of the indices are out of range.
+     */
     template <typename T>
     inline Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>
     csr_to_dense_matrix(int m,
@@ -64,7 +67,6 @@ namespace stan {
       }
       return result;
     }
-
     /** @} */   // end of csr_format group
 
   }

--- a/stan/math/prim/mat/fun/csr_u_to_z.hpp
+++ b/stan/math/prim/mat/fun/csr_u_to_z.hpp
@@ -20,6 +20,8 @@ namespace stan {
      * @param[in] u U vector.
      * @param[in] i Index into resulting z vector.
      * @return z[i] where z is conversion from u.
+     * @throw std::domain_error if u is zero length.
+     * @throw std::out_of_range if i is out of range.
      */
     inline int csr_u_to_z(const std::vector<int>& u, int i) {
       check_positive("csr_u_to_z", "u.size()", u.size());

--- a/stan/math/prim/mat/fun/get_base1.hpp
+++ b/stan/math/prim/mat/fun/get_base1.hpp
@@ -21,6 +21,7 @@ namespace stan {
      * the index is out of range.
      * @return Value of vector at <code>i - 1</code>
      * @tparam T type of value.
+     * @throw std::out_of_range if idx is out of range.
      */
     template <typename T>
     inline const T&
@@ -46,6 +47,7 @@ namespace stan {
      * the index is out of range.
      * @return Value of vector at indexes.
      * @tparam T type of value.
+     * @throw std::out_of_range if idx is out of range.
      */
     template <typename T>
     inline const T&
@@ -73,6 +75,7 @@ namespace stan {
      * the index is out of range.
      * @return Value of vector at indexes.
      * @tparam T type of value.
+     * @throw std::out_of_range if idx is out of range.
      */
     template <typename T>
     inline const T&
@@ -102,6 +105,7 @@ namespace stan {
      * the index is out of range.
      * @return Value of vector at indexes.
      * @tparam T type of value.
+     * @throw std::out_of_range if idx is out of range.
      */
     template <typename T>
     inline const T&
@@ -133,6 +137,7 @@ namespace stan {
      * the index is out of range.
      * @return Value of vector at indexes.
      * @tparam T type of value.
+     * @throw std::out_of_range if idx is out of range.
      */
     template <typename T>
     inline const T&
@@ -167,6 +172,7 @@ namespace stan {
      * the index is out of range.
      * @return Value of vector at indexes.
      * @tparam T type of value.
+     * @throw std::out_of_range if idx is out of range.
      */
     template <typename T>
     inline const T&
@@ -203,6 +209,7 @@ namespace stan {
      * the index is out of range.
      * @return Value of vector at indexes.
      * @tparam T type of value.
+     * @throw std::out_of_range if idx is out of range.
      */
     template <typename T>
     inline const T&
@@ -241,6 +248,7 @@ namespace stan {
      * the index is out of range.
      * @return Value of vector at indexes.
      * @tparam T type of value.
+     * @throw std::out_of_range if idx is out of range.
      */
     template <typename T>
     inline const T&
@@ -279,6 +287,7 @@ namespace stan {
      * the index is out of range.
      * @return Row of matrix at <code>i - 1</code>.
      * @tparam T type of value.
+     * @throw std::out_of_range if idx is out of range.
      */
     template <typename T>
     inline Eigen::Matrix<T, 1, Eigen::Dynamic>
@@ -305,6 +314,7 @@ namespace stan {
      * @return Value of matrix at row <code>m - 1</code> and column
      * <code>n - 1</code>.
      * @tparam T type of value.
+     * @throw std::out_of_range if idx is out of range.
      */
     template <typename T>
     inline const T&
@@ -331,6 +341,7 @@ namespace stan {
      * the index is out of range.
      * @return Value of column vector at row <code>m - 1</code>.
      * @tparam T type of value.
+     * @throw std::out_of_range if idx is out of range.
      */
     template <typename T>
     inline
@@ -355,6 +366,7 @@ namespace stan {
      * the index is out of range.
      * @return Value of row vector at column <code>n - 1</code>.
      * @tparam T type of value.
+     * @throw std::out_of_range if idx is out of range.     
      */
     template <typename T>
     inline const T&

--- a/stan/math/prim/mat/fun/get_base1_lhs.hpp
+++ b/stan/math/prim/mat/fun/get_base1_lhs.hpp
@@ -21,6 +21,7 @@ namespace stan {
      * the index is out of range.
      * @return Value of vector at <code>i - 1</code>
      * @tparam T type of value.
+     * @throw std::out_of_range if idx is out of range.     
      */
     template <typename T>
     inline
@@ -46,6 +47,7 @@ namespace stan {
      * the index is out of range.
      * @return Value of vector at indexes.
      * @tparam T type of value.
+     * @throw std::out_of_range if idx is out of range.
      */
     template <typename T>
     inline
@@ -73,6 +75,7 @@ namespace stan {
      * the index is out of range.
      * @return Value of vector at indexes.
      * @tparam T type of value.
+     * @throw std::out_of_range if idx is out of range.
      */
     template <typename T>
     inline
@@ -102,6 +105,7 @@ namespace stan {
      * the index is out of range.
      * @return Value of vector at indexes.
      * @tparam T type of value.
+     * @throw std::out_of_range if idx is out of range.
      */
     template <typename T>
     inline
@@ -134,6 +138,7 @@ namespace stan {
      * the index is out of range.
      * @return Value of vector at indexes.
      * @tparam T type of value.
+     * @throw std::out_of_range if idx is out of range.
      */
     template <typename T>
     inline
@@ -168,6 +173,7 @@ namespace stan {
      * the index is out of range.
      * @return Value of vector at indexes.
      * @tparam T type of value.
+     * @throw std::out_of_range if idx is out of range.
      */
     template <typename T>
     inline
@@ -204,6 +210,7 @@ namespace stan {
      * the index is out of range.
      * @return Value of vector at indexes.
      * @tparam T type of value.
+     * @throw std::out_of_range if idx is out of range.
      */
     template <typename T>
     inline
@@ -243,6 +250,7 @@ namespace stan {
      * the index is out of range.
      * @return Value of vector at indexes.
      * @tparam T type of value.
+     * @throw std::out_of_range if idx is out of range.
      */
     template <typename T>
     inline
@@ -282,6 +290,7 @@ namespace stan {
      * the index is out of range.
      * @return Row of matrix at <code>i - 1</code>.
      * @tparam T type of value.
+     * @throw std::out_of_range if idx is out of range.
      */
     template <typename T>
     inline
@@ -309,6 +318,7 @@ namespace stan {
      * @return Value of matrix at row <code>m - 1</code> and column
      * <code>n - 1</code>.
      * @tparam T type of value.
+     * @throw std::out_of_range if idx is out of range.
      */
     template <typename T>
     inline
@@ -335,6 +345,7 @@ namespace stan {
      * the index is out of range.
      * @return Value of column vector at row <code>m - 1</code>.
      * @tparam T type of value.
+     * @throw std::out_of_range if idx is out of range.
      */
     template <typename T>
     inline
@@ -359,6 +370,7 @@ namespace stan {
      * the index is out of range.
      * @return Value of row vector at column <code>n - 1</code>.
      * @tparam T type of value.
+     * @throw std::out_of_range if idx is out of range.
      */
     template <typename T>
     inline

--- a/stan/math/prim/mat/fun/head.hpp
+++ b/stan/math/prim/mat/fun/head.hpp
@@ -13,10 +13,12 @@ namespace stan {
     /**
      * Return the specified number of elements as a vector
      * from the front of the specified vector.
-     * @tparam T Type of value in vector
-     * @param v Vector input
-     * @param n Size of return
-     * @return The first n elements of v
+     *
+     * @tparam T Type of value in vector.
+     * @param v Vector input.
+     * @param n Size of return.
+     * @return The first n elements of v.
+     * @throw std::out_of_range if n is out of range.
      */
     template <typename T>
     inline
@@ -31,10 +33,12 @@ namespace stan {
     /**
      * Return the specified number of elements as a row vector
      * from the front of the specified row vector.
-     * @tparam T Type of value in vector
-     * @param rv Row vector
-     * @param n Size of return row vector
-     * @return The first n elements of rv
+     *
+     * @tparam T Type of value in vector.
+     * @param rv Row vector.
+     * @param n Size of return row vector.
+     * @return The first n elements of rv.
+     * @throw std::out_of_range if n is out of range.
      */
     template <typename T>
     inline
@@ -49,10 +53,12 @@ namespace stan {
     /**
      * Return the specified number of elements as a standard vector
      * from the front of the specified standard vector.
-     * @tparam T Type of value in vector
-     * @param sv Standard vector
-     * @param n Size of return
-     * @return The first n elements of sv
+     *
+     * @tparam T Type of value in vector.
+     * @param sv Standard vector.
+     * @param n Size of return.
+     * @return The first n elements of sv.
+     * @throw std::out_of_range if n is out of range.     
      */
     template <typename T>
     std::vector<T> head(const std::vector<T>& sv,

--- a/stan/math/prim/mat/fun/rank.hpp
+++ b/stan/math/prim/mat/fun/rank.hpp
@@ -15,6 +15,7 @@ namespace stan {
      * @param[in] v Input vector.
      * @param[in] s Position in vector.
      * @return Number of components of v less than v[s].
+     * @throw std::out_of_range if s is out of range.
      */
     template <typename T>
     inline int rank(const std::vector<T> & v, int s) {
@@ -36,6 +37,7 @@ namespace stan {
      * @param[in] v Input vector.
      * @param s Index for input vector.
      * @return Number of components of v less than v[s].
+     * @throw std::out_of_range if s is out of range.
      */
     template <typename T, int R, int C>
     inline int rank(const Eigen::Matrix<T, R, C> & v, int s) {

--- a/stan/math/prim/mat/fun/row.hpp
+++ b/stan/math/prim/mat/fun/row.hpp
@@ -18,13 +18,14 @@ namespace stan {
      * @param m Matrix.
      * @param i Row index (count from 1).
      * @return Specified row of the matrix.
+     * @throw std::out_of_range if i is out of range.
      */
     template <typename T>
     inline
     Eigen::Matrix<T, 1, Eigen::Dynamic>
     row(const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& m,
         size_t i) {
-      check_row_index("row", "j", m, i);
+      check_row_index("row", "i", m, i);
 
       return m.row(i - 1);
     }

--- a/stan/math/prim/mat/fun/sub_col.hpp
+++ b/stan/math/prim/mat/fun/sub_col.hpp
@@ -11,11 +11,12 @@ namespace stan {
     /**
      * Return a nrows x 1 subcolumn starting at (i-1, j-1).
      *
-     * @param m Matrix
-     * @param i Starting row + 1
-     * @param j Starting column + 1
-     * @param nrows Number of rows in block
-     **/
+     * @param m Matrix.
+     * @param i Starting row + 1.
+     * @param j Starting column + 1.
+     * @param nrows Number of rows in block.
+     * @throw std::out_of_range if either index is out of range.
+     */
     template <typename T>
     inline
     Eigen::Matrix<T, Eigen::Dynamic, 1>

--- a/stan/math/prim/mat/fun/sub_row.hpp
+++ b/stan/math/prim/mat/fun/sub_row.hpp
@@ -11,10 +11,11 @@ namespace stan {
     /**
      * Return a 1 x nrows subrow starting at (i-1, j-1).
      *
-     * @param m Matrix
-     * @param i Starting row + 1
-     * @param j Starting column + 1
-     * @param ncols Number of columns in block
+     * @param m Matrix Input matrix.
+     * @param i Starting row + 1.
+     * @param j Starting column + 1.
+     * @param ncols Number of columns in block.
+     * @throw std::out_of_range if either index is out of range.
      **/
     template <typename T>
     inline

--- a/stan/math/prim/mat/fun/sub_row.hpp
+++ b/stan/math/prim/mat/fun/sub_row.hpp
@@ -16,7 +16,7 @@ namespace stan {
      * @param j Starting column + 1.
      * @param ncols Number of columns in block.
      * @throw std::out_of_range if either index is out of range.
-     **/
+     */
     template <typename T>
     inline
     Eigen::Matrix<T, 1, Eigen::Dynamic>

--- a/stan/math/prim/mat/fun/tail.hpp
+++ b/stan/math/prim/mat/fun/tail.hpp
@@ -15,6 +15,12 @@ namespace stan {
     /**
      * Return the specified number of elements as a vector
      * from the back of the specified vector.
+     *
+     * @tparam T Type of value in vector.
+     * @param v Vector input.
+     * @param n Size of return.
+     * @return The last n elements of v.
+     * @throw std::out_of_range if n is out of range.
      */
     template <typename T>
     inline
@@ -29,6 +35,12 @@ namespace stan {
     /**
      * Return the specified number of elements as a row vector
      * from the back of the specified row vector.
+     *
+     * @tparam T Type of value in vector.
+     * @param rv Row vector.
+     * @param n Size of return row vector.
+     * @return The last n elements of rv.
+     * @throw std::out_of_range if n is out of range.
      */
     template <typename T>
     inline
@@ -40,6 +52,16 @@ namespace stan {
       return rv.tail(n);
     }
 
+    /**
+     * Return the specified number of elements as a standard vector
+     * from the back of the specified standard vector.
+     *
+     * @tparam T Type of value in vector.
+     * @param sv Standard vector.
+     * @param n Size of return.
+     * @return The last n elements of sv.
+     * @throw std::out_of_range if n is out of range.     
+     */
     template <typename T>
     std::vector<T> tail(const std::vector<T>& sv,
                         size_t n) {
@@ -54,5 +76,4 @@ namespace stan {
 
   }
 }
-
 #endif

--- a/stan/math/prim/mat/meta/VectorViewMvt.hpp
+++ b/stan/math/prim/mat/meta/VectorViewMvt.hpp
@@ -59,6 +59,7 @@ namespace stan {
       else
         return x_[0];
     }
+
   private:
     matrix_t* x_;
   };
@@ -95,6 +96,7 @@ namespace stan {
       else
         return x_[0];
     }
+
   private:
     const matrix_t* x_;
   };

--- a/stan/math/prim/mat/meta/VectorViewMvt.hpp
+++ b/stan/math/prim/mat/meta/VectorViewMvt.hpp
@@ -9,6 +9,19 @@
 
 namespace stan {
 
+
+  /**
+   * VectorViewMvt is a template expression that wraps either an
+   * Eigen::Matrix or a std::vector<Eigen::Matrix> and allows the
+   * template expression to be used as an array using
+   * <code>operator[]</code>.
+   *
+   * @tparam T Type of scalar of the matrix being wrapped.  
+   * @tparam is_array True if underlying type T can be indexed with
+   * operator[].  
+   * @tparam throw_if_accessed True if the behavior is to
+   * throw an exception whenever <code>operator[]</code> is called.
+   */
   template <typename T, bool is_array
             = stan::is_vector_like
             <typename stan::math::value_type<T>::type>::value,
@@ -17,10 +30,27 @@ namespace stan {
   public:
     typedef typename scalar_type_pre<T>::type matrix_t;
 
+    /**
+     * Constructor.
+     */
     explicit VectorViewMvt(matrix_t& m) : x_(&m) { }
 
+    /**
+     * Constructor.
+     */
     explicit VectorViewMvt(std::vector<matrix_t>& vm) : x_(&vm[0]) { }
 
+    /**
+     * Allows the structure to be accessed like an array. If is_array
+     * is false, this will return the matrix it was constructed
+     * with. If is_array is true, This does not check bounds and will
+     * likely segfault if the index is out of range.
+     *
+     * @param i index. Only used if access is true.
+     * @return Reference to a matrix.
+     * @throw std::out_of_range if the template parameter, 
+     * throw_if_accessed, is true.
+     */
     matrix_t& operator[](int i) {
       if (throw_if_accessed)
         throw std::out_of_range("VectorViewMvt: this cannot be accessed");
@@ -34,8 +64,8 @@ namespace stan {
   };
 
   /**
+   * VectorViewMvt with const correctness.
    *
-   *  VectorViewMvt that has const correctness.
    */
   template <typename T, bool is_array, bool throw_if_accessed>
   class VectorViewMvt<const T, is_array, throw_if_accessed> {
@@ -46,6 +76,17 @@ namespace stan {
 
     explicit VectorViewMvt(const std::vector<matrix_t>& vm) : x_(&vm[0]) { }
 
+    /**
+     * Allows the structure to be accessed like an array. If is_array
+     * is false, this will return the matrix it was constructed
+     * with. If is_array is true, This does not check bounds and will
+     * likely segfault if the index is out of range.
+     *
+     * @param i index. Only used if access is true.
+     * @return Reference to a matrix.
+     * @throw std::out_of_range if the template parameter, 
+     * throw_if_accessed, is true.
+     */
     const matrix_t& operator[](int i) const {
       if (throw_if_accessed)
         throw std::out_of_range("VectorViewMvt: this cannot be accessed");

--- a/stan/math/prim/mat/meta/VectorViewMvt.hpp
+++ b/stan/math/prim/mat/meta/VectorViewMvt.hpp
@@ -18,9 +18,9 @@ namespace stan {
    *
    * @tparam T Type of scalar of the matrix being wrapped.  
    * @tparam is_array True if underlying type T can be indexed with
-   * operator[].  
+   *   operator[].  
    * @tparam throw_if_accessed True if the behavior is to
-   * throw an exception whenever <code>operator[]</code> is called.
+   *   throw an exception whenever <code>operator[]</code> is called.
    */
   template <typename T, bool is_array
             = stan::is_vector_like
@@ -49,7 +49,7 @@ namespace stan {
      * @param i index. Only used if access is true.
      * @return Reference to a matrix.
      * @throw std::out_of_range if the template parameter, 
-     * throw_if_accessed, is true.
+     *   throw_if_accessed, is true.
      */
     matrix_t& operator[](int i) {
       if (throw_if_accessed)
@@ -85,7 +85,7 @@ namespace stan {
      * @param i index. Only used if access is true.
      * @return Reference to a matrix.
      * @throw std::out_of_range if the template parameter, 
-     * throw_if_accessed, is true.
+     *   throw_if_accessed, is true.
      */
     const matrix_t& operator[](int i) const {
       if (throw_if_accessed)

--- a/stan/math/prim/scal/err/out_of_range.hpp
+++ b/stan/math/prim/scal/err/out_of_range.hpp
@@ -26,6 +26,7 @@ namespace stan {
      * @param index Index
      * @param msg1 Message to print. Default is "".
      * @param msg2 Message to print. Default is "".
+     * @throw std::out_of_range with message.
      */
     inline void out_of_range(const char* function,
                              const int max,

--- a/stan/math/prim/scal/meta/VectorView.hpp
+++ b/stan/math/prim/scal/meta/VectorView.hpp
@@ -39,7 +39,7 @@ namespace stan {
    * @tparam T  Type of scalar or container being wrapped.
    * @tparam is_array True if underlying type T can be indexed with
    * operator[].
-   * @tparam throw_if_accessed True if the behaviro is to throw an
+   * @tparam throw_if_accessed True if the behavior is to throw an
    * exception whenever <code>operator[]</code> is called.
    */
   template <typename T,

--- a/stan/math/prim/scal/meta/container_view.hpp
+++ b/stan/math/prim/scal/meta/container_view.hpp
@@ -15,31 +15,30 @@ namespace stan {
      * @tparam T1 type of view.
      * @tparam T2 type of scalar returned by view.
      */
-
     template <typename T1, typename T2>
     class container_view {
-      public:
+    public:
       /**
        * Constructor
        *
        * @param x object from which size is to be inferred
        * @param y underlying array 
        */
-        container_view(const T1& x, T2* y) : y_(y) { }
+      container_view(const T1& x, T2* y) : y_(y) { }
 
-        /**
-         * operator[](int i) returns reference to view, 
-         * indexed by i
-         * Specialization handle appropriate broadcasting
-         * if size of x is 1
-         *
-         * @param i index
-         */
-        T2& operator[](int i) {
-          return y_[0];
-        }
-      private:
-        T2* y_;
+      /**
+       * operator[](int i) returns reference to view, 
+       * indexed by i
+       * Specialization handle appropriate broadcasting
+       * if size of x is 1
+       *
+       * @param i index
+       */
+      T2& operator[](int i) {
+        return y_[0];
+      }
+    private:
+      T2* y_;
     };
 
     /**
@@ -59,27 +58,27 @@ namespace stan {
      */
     template <typename T2>
     class container_view<dummy, T2> {
-      public:
-        typedef typename stan::scalar_type<T2>::type scalar_t;
-        template <typename T1>
+    public:
+      typedef typename stan::scalar_type<T2>::type scalar_t;
+      template <typename T1>
 
-        /**
-         * Nothing initialized
-         *
-         * @param x input object
-         * @param y underlying array 
-         */
-        container_view(const T1& x, scalar_t* y) { }
+      /**
+       * Nothing initialized
+       *
+       * @param x input object
+       * @param y underlying array 
+       */
+      container_view(const T1& x, scalar_t* y) { }
 
-        /**
-         * operator[](int i)
-         *
-         * @param n index
-         * @throw std::out_of_range regardless of the input.
-         */
-        scalar_t operator[](int n) const {
-          throw std::out_of_range("can't access dummy elements.");
-        }
+      /**
+       * operator[](int i)
+       *
+       * @param n index
+       * @throw std::out_of_range regardless of the input.
+       */
+      scalar_t operator[](int n) const {
+        throw std::out_of_range("can't access dummy elements.");
+      }
     };
   }
 }

--- a/stan/math/prim/scal/meta/container_view.hpp
+++ b/stan/math/prim/scal/meta/container_view.hpp
@@ -72,10 +72,10 @@ namespace stan {
         container_view(const T1& x, scalar_t* y) { }
 
         /**
-         * operator[](int i) 
-         * throws exception
+         * operator[](int i)
          *
          * @param n index
+         * @throw std::out_of_range regardless of the input.
          */
         scalar_t operator[](int n) const {
           throw std::out_of_range("can't access dummy elements.");

--- a/stan/math/prim/scal/meta/length_mvt.hpp
+++ b/stan/math/prim/scal/meta/length_mvt.hpp
@@ -5,9 +5,20 @@
 
 namespace stan {
 
+  /**
+   * length_mvt provides the length of a multivariate argument.
+   *
+   * This is the default template function. For any scalar type, this
+   * will throw an std::invalid_argument exception since a scalar is not
+   * a multivariate structure.
+   *
+   * @tparam T type to take length of. The default template function should
+   *   only match scalars.
+   * @throw std::invalid_argument since the type is a scalar.
+   */
   template <typename T>
   size_t length_mvt(const T& ) {
-    throw std::out_of_range("length_mvt passed to an unrecognized type.");
+    throw std::invalid_argument("length_mvt passed to an unrecognized type.");
     return 1U;
   }
 


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary:
I reviewed all the `check_*` functions and make sure all the ones that should throw `std::out_of_range` throws that exception. I documented the ones that throw `std::out_of_range` and the functions that call these functions.

#### Intended Effect:
We need to update Stan to stop when it sees an exception other than `std::domain_error`.

#### How to Verify:
Run tests.

#### Side Effects:
One of the functions, `length_mvt()`, was changed from throwing `std::out_of_range` to `std::invalid_argument`.

#### Documentation:
Included.

#### Reviewer Suggestions: 
Anyone.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Columbia University.

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
