### PR TITLE
include make/local in make/tests

### DIFF
--- a/make/tests
+++ b/make/tests
@@ -1,4 +1,5 @@
 N_TESTS = 100 # override this in make/local. If <= 0, N_TESTS + 1 is interpreted as the number of batches to group the tests into
+include make/local
 
 ##
 # LIBGTEST is the google test library

--- a/make/tests
+++ b/make/tests
@@ -1,5 +1,4 @@
-N_TESTS = 100 # override this in make/local. If <= 0, N_TESTS + 1 is interpreted as the number of batches to group the tests into
-include make/local
+N_TESTS ?= 100 # override this in make/local. If <= 0, N_TESTS + 1 is interpreted as the number of batches to group the tests into
 
 ##
 # LIBGTEST is the google test library


### PR DESCRIPTION
#### Submisison Checklist

- [ ] Run unit tests: `./runTests.py test/unit` Doesn't affect test/unit only test/prob
- [ ] Run cpplint: `make cpplint` Doesn't touch C++ code
- [X] Declare copyright holder and open-source license: see below

#### Summary:

include make/local in make/tests

#### Intended Effect:

Use the value of N_TESTS in make/local

#### How to Verify:

1. Take N_TESTS out of make/local
2. Run `make clean-all && make generate-tests -s`
3. Run `find test/prob/ -type f -name "*.cpp" -print | wc -l`, which should be something like 6673
4. Set N_TESTS=750 in make/local
5. Run `make clean-all && make generate-tests -s`
6. Run `find test/prob/ -type f -name "*.cpp" -print | wc -l`, which should be something like 1227

On develop, (6) would yield 6673 because N_TESTS in make/local is ignored by make/tests.

#### Side Effects:

Makes test/prob faster

#### Documentation:

None

#### Reviewer Suggestions: 

@syclik 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): The Trustees of Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

