### PR TITLE
Feature/issue 145 print

### DIFF
--- a/stan/math/prim/mat/err/check_pos_definite.hpp
+++ b/stan/math/prim/mat/err/check_pos_definite.hpp
@@ -42,7 +42,7 @@ namespace stan {
       check_positive_size(function, name, "rows", y.rows());
 
       if (y.rows() == 1 && !(y(0, 0) > CONSTRAINT_TOLERANCE))
-        domain_error(function, name, y, "is not positive definite: ");
+        domain_error(function, name, "is not positive definite.", "");
 
       using Eigen::LDLT;
       using Eigen::Matrix;
@@ -52,7 +52,7 @@ namespace stan {
       if (cholesky.info() != Eigen::Success
           || !cholesky.isPositive()
           || (cholesky.vectorD().array() <= 0.0).any())
-        domain_error(function, name, y, "is not positive definite:\n");
+        domain_error(function, name, "is not positive definite.", "");
       check_not_nan(function, name, y);
       return true;
     }

--- a/stan/math/prim/mat/err/check_pos_semidefinite.hpp
+++ b/stan/math/prim/mat/err/check_pos_semidefinite.hpp
@@ -40,7 +40,7 @@ namespace stan {
       check_positive_size(function, name, "rows", y.rows());
 
       if (y.rows() == 1 && !(y(0, 0) >= 0.0))
-        domain_error(function, name, y, "is not positive semi-definite: ");
+        domain_error(function, name, "is not positive semi-definite.", "");
 
       using Eigen::LDLT;
       using Eigen::Matrix;
@@ -49,7 +49,7 @@ namespace stan {
         = value_of_rec(y).ldlt();
       if (cholesky.info() != Eigen::Success
           || (cholesky.vectorD().array() < 0.0).any())
-        domain_error(function, name, y, "is not positive semi-definite:\n");
+        domain_error(function, name, "is not positive semi-definite.", "");
       check_not_nan(function, name, y);
       return true;
     }

--- a/test/unit/math/prim/mat/err/check_pos_definite_test.cpp
+++ b/test/unit/math/prim/mat/err/check_pos_definite_test.cpp
@@ -114,9 +114,8 @@ TEST_F(ErrorHandlingMatrix, checkPosDefinite_non_pos_definite) {
     -1, 0, 0,
     0, -1, 0,
     0, 0, -1;
-  
-  expected_msg1_mat << "function: y is not positive definite:\n" << 
-    "-1  0  0\n 0 -1  0\n 0  0 -1";
+
+  expected_msg1_mat << "function: y is not positive definite.";
   EXPECT_THROW_MSG(check_pos_definite(function, "y", y),
                    std::domain_error,
                    expected_msg1_mat.str());
@@ -135,8 +134,7 @@ TEST_F(ErrorHandlingMatrix, checkPosDefinite_non_pos_definite) {
   y <<
     1, 2, 
     2, 1; 
-  expected_msg2_mat << "function: y is not positive definite:\n" <<
-    "1 2\n2 1";
+  expected_msg2_mat << "function: y is not positive definite.";
   EXPECT_THROW_MSG(check_pos_definite(function, "y", y),
                    std::domain_error,
                    expected_msg2_mat.str());
@@ -152,8 +150,7 @@ TEST_F(ErrorHandlingMatrix, checkPosDefinite_non_pos_definite) {
   y <<
     1, 1, 
     1, 1; 
-  expected_msg3_mat << "function: y is not positive definite:\n" <<
-    "1 1\n1 1";
+  expected_msg3_mat << "function: y is not positive definite.";
   EXPECT_THROW_MSG(check_pos_definite(function, "y", y),
                    std::domain_error,
                    expected_msg3_mat.str());
@@ -176,8 +173,7 @@ TEST_F(ErrorHandlingMatrix, checkPosDefinite_nan) {
   y << nan;
 
   std::stringstream expected_msg;
-  expected_msg << "function: y is not positive definite: "
-               << nan;
+  expected_msg << "function: y is not positive definite.";
   EXPECT_THROW_MSG(check_pos_definite(function, "y", y), 
                    std::domain_error,
                    expected_msg.str());
@@ -226,8 +222,7 @@ TEST_F(ErrorHandlingMatrix, checkPosDefinite_nan) {
 
   y << 0, 0, 0, 0, 0, 0, 0, 0, 0;
   expected_msg.str("");
-  expected_msg << "function: y is not positive definite:\n"
-               << y;
+  expected_msg << "function: y is not positive definite.";
   EXPECT_THROW_MSG(check_pos_definite(function, "y", y), 
                    std::domain_error,
                    expected_msg.str());

--- a/test/unit/math/prim/mat/err/check_pos_semidefinite_test.cpp
+++ b/test/unit/math/prim/mat/err/check_pos_semidefinite_test.cpp
@@ -22,7 +22,7 @@ TEST_F(ErrorHandlingMatrix, checkPosSemidefinite_size_1) {
   y << -1.0;
   EXPECT_THROW_MSG(check_pos_semidefinite(function, "y", y),
                    std::domain_error,
-                   "function: y is not positive semi-definite: -1");
+                   "function: y is not positive semi-definite.");
 }
 
 TEST_F(ErrorHandlingMatrix, checkPosSemidefinite_bad_sizes) {
@@ -50,7 +50,7 @@ TEST_F(ErrorHandlingMatrix, checkPosSemidefinite) {
   y << -1, 0, 0, 1;
   EXPECT_THROW_MSG(check_pos_semidefinite(function, "y", y),
                    std::domain_error,
-                   "function: y is not positive semi-definite:\n-1  0\n 0  1");
+                   "function: y is not positive semi-definite.");
 }
 
 TEST_F(ErrorHandlingMatrix, checkPosSemidefinite_nan) {


### PR DESCRIPTION
#### Submisison Checklist

- [ ] Run unit tests: `./runTests.py test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary:
Change error messages for `check_pos_definite()` and `check_pos_semidefinite()` to not print the matrix.


#### Intended Effect:
This will make parsing errors easier.

#### How to Verify:
Run unit tests.

#### Side Effects:
None.

#### Documentation:
None required.

#### Reviewer Suggestions: 
@bgoodri. Is it good to just omit the matrix completely?

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Columbia University.

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
