### PR TITLE
Fixes #373. Add -j2 to the travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,4 +28,4 @@ env:
   - TESTFOLDER=test/unit/math/fwd/mat
  # - TESTFOLDER=test/unit/math/mix  ## commenting this out due to segfault on travis
 
-script: ./runTests.py $TESTFOLDER
+script: ./runTests.py -j2 $TESTFOLDER


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary:
Adding `-j2` flag for travis builds.

#### Intended Effect:
Makes it a little faster.

#### How to Verify:
Just wait for Travis.

#### Side Effects:
None.

#### Documentation:
None.

#### Reviewer Suggestions: 
Anyone.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Columbia University.

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

