### PR TITLE
Unifying floating point properties

### DIFF
--- a/stan/math/fwd/core/fvar.hpp
+++ b/stan/math/fwd/core/fvar.hpp
@@ -3,7 +3,6 @@
 
 #include <stan/math/prim/scal/meta/likely.hpp>
 #include <stan/math/prim/scal/fun/is_nan.hpp>
-#include <boost/math/special_functions/fpclassify.hpp>
 #include <ostream>
 
 namespace stan {

--- a/stan/math/fwd/core/fvar.hpp
+++ b/stan/math/fwd/core/fvar.hpp
@@ -2,6 +2,7 @@
 #define STAN_MATH_FWD_CORE_FVAR_HPP
 
 #include <stan/math/prim/scal/meta/likely.hpp>
+#include <stan/math/prim/scal/fun/is_nan.hpp>
 #include <boost/math/special_functions/fpclassify.hpp>
 #include <ostream>
 
@@ -27,7 +28,7 @@ namespace stan {
       // TV and TD must be assignable to T
       template <typename TV, typename TD>
       fvar(const TV& val, const TD& deriv) : val_(val), d_(deriv) {
-        if (unlikely(boost::math::isnan(val)))
+        if (unlikely(is_nan(val)))
           d_ = val;
       }
 
@@ -35,7 +36,7 @@ namespace stan {
       template <typename TV>
       fvar(const TV& val)  // NOLINT
         : val_(val), d_(0.0) {
-        if (unlikely(boost::math::isnan(val)))
+        if (unlikely(is_nan(val)))
           d_ = val;
       }
 

--- a/stan/math/fwd/scal/fun/fabs.hpp
+++ b/stan/math/fwd/scal/fun/fabs.hpp
@@ -3,6 +3,7 @@
 
 #include <stan/math/fwd/core.hpp>
 #include <stan/math/prim/scal/fun/constants.hpp>
+#include <stan/math/prim/scal/fun/is_nan.hpp>
 #include <stan/math/prim/scal/fun/value_of.hpp>
 #include <stan/math/prim/scal/meta/likely.hpp>
 #include <cmath>
@@ -14,7 +15,7 @@ namespace stan {
     inline fvar<T> fabs(const fvar<T>& x) {
       using std::fabs;
 
-      if (unlikely(boost::math::isnan(value_of(x.val_))))
+      if (unlikely(is_nan(value_of(x.val_))))
         return fvar<T>(fabs(x.val_), NOT_A_NUMBER);
       else if (x.val_ > 0.0)
         return x;

--- a/stan/math/fwd/scal/fun/fmax.hpp
+++ b/stan/math/fwd/scal/fun/fmax.hpp
@@ -4,6 +4,7 @@
 #include <math.h>
 #include <stan/math/fwd/core.hpp>
 #include <stan/math/prim/scal/fun/constants.hpp>
+#include <stan/math/prim/scal/fun/is_nan.hpp>
 #include <stan/math/prim/scal/meta/likely.hpp>
 
 namespace stan {
@@ -12,12 +13,12 @@ namespace stan {
     template <typename T>
     inline fvar<T> fmax(const fvar<T>& x1, const fvar<T>& x2) {
       using ::fmax;
-      if (unlikely(boost::math::isnan(x1.val_))) {
-        if (boost::math::isnan(x2.val_))
+      if (unlikely(is_nan(x1.val_))) {
+        if (is_nan(x2.val_))
           return fvar<T>(fmax(x1.val_, x2.val_), NOT_A_NUMBER);
         else
           return fvar<T>(x2.val_, x2.d_);
-      } else if (unlikely(boost::math::isnan(x2.val_))) {
+      } else if (unlikely(is_nan(x2.val_))) {
         return fvar<T>(x1.val_, x1.d_);
       } else if (x1.val_ > x2.val_) {
         return fvar<T>(x1.val_, x1.d_);
@@ -31,12 +32,12 @@ namespace stan {
     template <typename T>
     inline fvar<T> fmax(const double x1, const fvar<T>& x2) {
       using ::fmax;
-      if (unlikely(boost::math::isnan(x1))) {
-        if (boost::math::isnan(x2.val_))
+      if (unlikely(is_nan(x1))) {
+        if (is_nan(x2.val_))
           return fvar<T>(fmax(x1, x2.val_), NOT_A_NUMBER);
         else
           return fvar<T>(x2.val_, x2.d_);
-      } else if (unlikely(boost::math::isnan(x2.val_))) {
+      } else if (unlikely(is_nan(x2.val_))) {
         return fvar<T>(x1, 0.0);
       } else if (x1 > x2.val_) {
         return fvar<T>(x1, 0.0);
@@ -50,12 +51,12 @@ namespace stan {
     template <typename T>
     inline fvar<T> fmax(const fvar<T>& x1, const double x2) {
       using ::fmax;
-      if (unlikely(boost::math::isnan(x1.val_))) {
-        if (boost::math::isnan(x2))
+      if (unlikely(is_nan(x1.val_))) {
+        if (is_nan(x2))
           return fvar<T>(fmax(x1.val_, x2), NOT_A_NUMBER);
         else
           return fvar<T>(x2, 0.0);
-      } else if (unlikely(boost::math::isnan(x2))) {
+      } else if (unlikely(is_nan(x2))) {
         return fvar<T>(x1.val_, x1.d_);
       } else if (x1.val_ > x2) {
         return fvar<T>(x1.val_, x1.d_);

--- a/stan/math/fwd/scal/fun/fmin.hpp
+++ b/stan/math/fwd/scal/fun/fmin.hpp
@@ -4,6 +4,7 @@
 #include <math.h>
 #include <stan/math/fwd/core.hpp>
 #include <stan/math/prim/scal/fun/constants.hpp>
+#include <stan/math/prim/scal/fun/is_nan.hpp>
 #include <stan/math/prim/scal/meta/likely.hpp>
 
 namespace stan {
@@ -12,12 +13,12 @@ namespace stan {
     template <typename T>
     inline fvar<T> fmin(const fvar<T>& x1, const fvar<T>& x2) {
       using ::fmin;
-      if (unlikely(boost::math::isnan(x1.val_))) {
-        if (boost::math::isnan(x2.val_))
+      if (unlikely(is_nan(x1.val_))) {
+        if (is_nan(x2.val_))
           return fvar<T>(fmin(x1.val_, x2.val_), NOT_A_NUMBER);
         else
           return fvar<T>(x2.val_, x2.d_);
-      } else if (unlikely(boost::math::isnan(x2.val_))) {
+      } else if (unlikely(is_nan(x2.val_))) {
         return fvar<T>(x1.val_, x1.d_);
       } else if (x1.val_ < x2.val_) {
         return fvar<T>(x1.val_, x1.d_);
@@ -31,12 +32,12 @@ namespace stan {
     template <typename T>
     inline fvar<T> fmin(const double x1, const fvar<T>& x2) {
       using ::fmin;
-      if (unlikely(boost::math::isnan(x1))) {
-        if (boost::math::isnan(x2.val_))
+      if (unlikely(is_nan(x1))) {
+        if (is_nan(x2.val_))
           return fvar<T>(fmin(x1, x2.val_), NOT_A_NUMBER);
         else
           return fvar<T>(x2.val_, x2.d_);
-      } else if (unlikely(boost::math::isnan(x2.val_))) {
+      } else if (unlikely(is_nan(x2.val_))) {
         return fvar<T>(x1, 0.0);
       } else if (x1 < x2.val_) {
         return fvar<T>(x1, 0.0);
@@ -50,12 +51,12 @@ namespace stan {
     template <typename T>
     inline fvar<T> fmin(const fvar<T>& x1, const double x2) {
       using ::fmin;
-      if (unlikely(boost::math::isnan(x1.val_))) {
-        if (boost::math::isnan(x2))
+      if (unlikely(is_nan(x1.val_))) {
+        if (is_nan(x2))
           return fvar<T>(fmin(x1.val_, x2), NOT_A_NUMBER);
         else
           return fvar<T>(x2, 0.0);
-      } else if (unlikely(boost::math::isnan(x2))) {
+      } else if (unlikely(is_nan(x2))) {
         return fvar<T>(x1.val_, x1.d_);
       } else if (x1.val_ < x2) {
         return fvar<T>(x1.val_, x1.d_);

--- a/stan/math/fwd/scal/fun/fmod.hpp
+++ b/stan/math/fwd/scal/fun/fmod.hpp
@@ -2,8 +2,9 @@
 #define STAN_MATH_FWD_SCAL_FUN_FMOD_HPP
 
 #include <stan/math/fwd/core.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
 #include <stan/math/prim/scal/fun/constants.hpp>
+#include <stan/math/prim/scal/fun/is_nan.hpp>
+#include <stan/math/prim/scal/fun/value_of.hpp>
 
 namespace stan {
   namespace math {
@@ -23,8 +24,8 @@ namespace stan {
     fvar<T>
     fmod(const fvar<T>& x1, const double x2) {
       using std::fmod;
-      if (unlikely(boost::math::isnan(value_of(x1.val_))
-                   || boost::math::isnan(x2)))
+      if (unlikely(is_nan(value_of(x1.val_))
+                   || is_nan(x2)))
         return fvar<T>(fmod(x1.val_, x2), NOT_A_NUMBER);
       else
         return fvar<T>(fmod(x1.val_, x2), x1.d_ / x2);

--- a/stan/math/prim/mat/prob/multi_student_t_log.hpp
+++ b/stan/math/prim/mat/prob/multi_student_t_log.hpp
@@ -17,7 +17,6 @@
 #include <stan/math/prim/scal/fun/log1p.hpp>
 #include <stan/math/prim/scal/meta/include_summand.hpp>
 #include <boost/math/special_functions/gamma.hpp>
-#include <boost/math/special_functions/fpclassify.hpp>
 #include <boost/random/variate_generator.hpp>
 #include <cmath>
 #include <cstdlib>

--- a/stan/math/prim/mat/prob/multi_student_t_log.hpp
+++ b/stan/math/prim/mat/prob/multi_student_t_log.hpp
@@ -12,8 +12,9 @@
 #include <stan/math/prim/scal/err/check_finite.hpp>
 #include <stan/math/prim/scal/err/check_not_nan.hpp>
 #include <stan/math/prim/scal/err/check_positive.hpp>
-#include <stan/math/prim/scal/fun/log1p.hpp>
 #include <stan/math/prim/scal/fun/constants.hpp>
+#include <stan/math/prim/scal/fun/is_inf.hpp>
+#include <stan/math/prim/scal/fun/log1p.hpp>
 #include <stan/math/prim/scal/meta/include_summand.hpp>
 #include <boost/math/special_functions/gamma.hpp>
 #include <boost/math/special_functions/fpclassify.hpp>
@@ -49,9 +50,7 @@ namespace stan {
       check_not_nan(function, "Degrees of freedom parameter", nu);
       check_positive(function, "Degrees of freedom parameter", nu);
 
-      using boost::math::isinf;
-
-      if (isinf(nu))
+      if (is_inf(nu))
         return multi_normal_log(y, mu, Sigma);
 
       using Eigen::Matrix;

--- a/stan/math/prim/mat/prob/multi_student_t_rng.hpp
+++ b/stan/math/prim/mat/prob/multi_student_t_rng.hpp
@@ -2,7 +2,6 @@
 #define STAN_MATH_PRIM_MAT_PROB_MULTI_STUDENT_T_RNG_HPP
 
 #include <boost/math/special_functions/gamma.hpp>
-#include <boost/math/special_functions/fpclassify.hpp>
 #include <boost/random/variate_generator.hpp>
 #include <stan/math/prim/mat/err/check_ldlt_factor.hpp>
 #include <stan/math/prim/scal/err/check_size_match.hpp>

--- a/stan/math/prim/scal/err/check_not_nan.hpp
+++ b/stan/math/prim/scal/err/check_not_nan.hpp
@@ -7,7 +7,6 @@
 #include <stan/math/prim/scal/err/domain_error_vec.hpp>
 #include <stan/math/prim/scal/fun/value_of_rec.hpp>
 #include <stan/math/prim/scal/fun/is_nan.hpp>
-#include <boost/math/special_functions/fpclassify.hpp>
 
 namespace stan {
   namespace math {

--- a/stan/math/prim/scal/err/check_not_nan.hpp
+++ b/stan/math/prim/scal/err/check_not_nan.hpp
@@ -6,6 +6,7 @@
 #include <stan/math/prim/scal/err/domain_error.hpp>
 #include <stan/math/prim/scal/err/domain_error_vec.hpp>
 #include <stan/math/prim/scal/fun/value_of_rec.hpp>
+#include <stan/math/prim/scal/fun/is_nan.hpp>
 #include <boost/math/special_functions/fpclassify.hpp>
 
 namespace stan {
@@ -17,7 +18,7 @@ namespace stan {
         static bool check(const char* function,
                           const char* name,
                           const T_y& y) {
-          if ((boost::math::isnan)(value_of_rec(y)))
+          if (is_nan(value_of_rec(y)))
             domain_error(function, name, y,
                          "is ", ", but must not be nan!");
           return true;
@@ -30,7 +31,7 @@ namespace stan {
                           const char* name,
                           const T_y& y) {
           for (size_t n = 0; n < stan::length(y); n++) {
-            if ((boost::math::isnan)(value_of_rec(stan::get(y, n))))
+            if (is_nan(value_of_rec(stan::get(y, n))))
               domain_error_vec(function, name, y, n,
                                "is ", ", but must not be nan!");
           }

--- a/stan/math/prim/scal/fun/fdim.hpp
+++ b/stan/math/prim/scal/fun/fdim.hpp
@@ -2,7 +2,6 @@
 #define STAN_MATH_PRIM_SCAL_FUN_FDIM_HPP
 
 #include <stan/math/prim/scal/fun/is_nan.hpp>
-#include <boost/math/special_functions/fpclassify.hpp>
 #include <boost/math/tools/promotion.hpp>
 #include <math.h>
 #include <cmath>

--- a/stan/math/prim/scal/fun/fdim.hpp
+++ b/stan/math/prim/scal/fun/fdim.hpp
@@ -1,9 +1,10 @@
 #ifndef STAN_MATH_PRIM_SCAL_FUN_FDIM_HPP
 #define STAN_MATH_PRIM_SCAL_FUN_FDIM_HPP
 
-#include <math.h>
+#include <stan/math/prim/scal/fun/is_nan.hpp>
 #include <boost/math/special_functions/fpclassify.hpp>
 #include <boost/math/tools/promotion.hpp>
+#include <math.h>
 #include <cmath>
 #include <limits>
 
@@ -27,7 +28,7 @@ namespace stan {
       using ::fdim;
       using std::numeric_limits;
       using boost::math::tools::promote_args;
-      if (boost::math::isnan(a) || boost::math::isnan(b))
+      if (is_nan(a) || is_nan(b))
         return numeric_limits<typename promote_args<T1, T2>::type>::quiet_NaN();
       return fdim(a, b);
     }

--- a/stan/math/prim/scal/fun/grad_reg_inc_gamma.hpp
+++ b/stan/math/prim/scal/fun/grad_reg_inc_gamma.hpp
@@ -4,6 +4,7 @@
 #include <stan/math/prim/scal/err/domain_error.hpp>
 #include <stan/math/prim/scal/fun/gamma_p.hpp>
 #include <stan/math/prim/scal/fun/gamma_q.hpp>
+#include <stan/math/prim/scal/fun/is_inf.hpp>
 #include <stan/math/prim/scal/fun/square.hpp>
 #include <cmath>
 
@@ -37,7 +38,6 @@ namespace stan {
      */
     template<typename T>
     T grad_reg_inc_gamma(T a, T z, T g, T dig, double precision = 1e-6) {
-      using boost::math::isinf;
       using std::domain_error;
       using std::exp;
       using std::fabs;
@@ -63,7 +63,7 @@ namespace stan {
           fac *= a_minus_one_minus_k;
           delta = dfac / zpow;
 
-          if (isinf(delta))
+          if (is_inf(delta))
             stan::math::domain_error("grad_reg_inc_gamma",
                                      "is not converging", "", "");
         }
@@ -81,7 +81,7 @@ namespace stan {
           ++k;
           s *= - z / k;
           delta = s / square(k + a);
-          if (isinf(delta))
+          if (is_inf(delta))
             stan::math::domain_error("grad_reg_inc_gamma",
                                      "is not converging", "", "");
         }

--- a/stan/math/prim/scal/prob/exp_mod_normal_ccdf_log.hpp
+++ b/stan/math/prim/scal/prob/exp_mod_normal_ccdf_log.hpp
@@ -13,7 +13,6 @@
 #include <stan/math/prim/scal/meta/include_summand.hpp>
 #include <stan/math/prim/scal/fun/value_of.hpp>
 #include <boost/random/normal_distribution.hpp>
-#include <boost/math/special_functions/fpclassify.hpp>
 #include <boost/random/variate_generator.hpp>
 #include <cmath>
 

--- a/stan/math/prim/scal/prob/exp_mod_normal_ccdf_log.hpp
+++ b/stan/math/prim/scal/prob/exp_mod_normal_ccdf_log.hpp
@@ -9,6 +9,7 @@
 #include <stan/math/prim/scal/err/check_not_nan.hpp>
 #include <stan/math/prim/scal/err/check_positive_finite.hpp>
 #include <stan/math/prim/scal/fun/constants.hpp>
+#include <stan/math/prim/scal/fun/is_inf.hpp>
 #include <stan/math/prim/scal/meta/include_summand.hpp>
 #include <stan/math/prim/scal/fun/value_of.hpp>
 #include <boost/random/normal_distribution.hpp>
@@ -62,7 +63,7 @@ namespace stan {
       size_t N = max_size(y, mu, sigma, lambda);
       const double sqrt_pi = std::sqrt(pi());
       for (size_t n = 0; n < N; n++) {
-        if (boost::math::isinf(y_vec[n])) {
+        if (is_inf(y_vec[n])) {
           if (y_vec[n] > 0.0)
             return operands_and_partials.value(negative_infinity());
           else

--- a/stan/math/prim/scal/prob/exp_mod_normal_cdf.hpp
+++ b/stan/math/prim/scal/prob/exp_mod_normal_cdf.hpp
@@ -13,7 +13,6 @@
 #include <stan/math/prim/scal/meta/include_summand.hpp>
 #include <stan/math/prim/scal/fun/value_of.hpp>
 #include <boost/random/normal_distribution.hpp>
-#include <boost/math/special_functions/fpclassify.hpp>
 #include <boost/random/variate_generator.hpp>
 #include <cmath>
 

--- a/stan/math/prim/scal/prob/exp_mod_normal_cdf.hpp
+++ b/stan/math/prim/scal/prob/exp_mod_normal_cdf.hpp
@@ -9,6 +9,7 @@
 #include <stan/math/prim/scal/err/check_not_nan.hpp>
 #include <stan/math/prim/scal/err/check_positive_finite.hpp>
 #include <stan/math/prim/scal/fun/constants.hpp>
+#include <stan/math/prim/scal/fun/is_inf.hpp>
 #include <stan/math/prim/scal/meta/include_summand.hpp>
 #include <stan/math/prim/scal/fun/value_of.hpp>
 #include <boost/random/normal_distribution.hpp>
@@ -60,7 +61,7 @@ namespace stan {
       size_t N = max_size(y, mu, sigma, lambda);
       const double sqrt_pi = std::sqrt(pi());
       for (size_t n = 0; n < N; n++) {
-        if (boost::math::isinf(y_vec[n])) {
+        if (is_inf(y_vec[n])) {
           if (y_vec[n] < 0.0)
             return operands_and_partials.value(0.0);
         }

--- a/stan/math/prim/scal/prob/exp_mod_normal_cdf_log.hpp
+++ b/stan/math/prim/scal/prob/exp_mod_normal_cdf_log.hpp
@@ -9,6 +9,7 @@
 #include <stan/math/prim/scal/err/check_not_nan.hpp>
 #include <stan/math/prim/scal/err/check_positive_finite.hpp>
 #include <stan/math/prim/scal/fun/constants.hpp>
+#include <stan/math/prim/scal/fun/is_inf.hpp>
 #include <stan/math/prim/scal/meta/include_summand.hpp>
 #include <stan/math/prim/scal/fun/value_of.hpp>
 #include <boost/random/normal_distribution.hpp>
@@ -62,7 +63,7 @@ namespace stan {
       size_t N = max_size(y, mu, sigma, lambda);
       const double sqrt_pi = std::sqrt(pi());
       for (size_t n = 0; n < N; n++) {
-        if (boost::math::isinf(y_vec[n])) {
+        if (is_inf(y_vec[n])) {
           if (y_vec[n] < 0.0)
             return operands_and_partials.value(negative_infinity());
           else

--- a/stan/math/prim/scal/prob/exp_mod_normal_cdf_log.hpp
+++ b/stan/math/prim/scal/prob/exp_mod_normal_cdf_log.hpp
@@ -13,7 +13,6 @@
 #include <stan/math/prim/scal/meta/include_summand.hpp>
 #include <stan/math/prim/scal/fun/value_of.hpp>
 #include <boost/random/normal_distribution.hpp>
-#include <boost/math/special_functions/fpclassify.hpp>
 #include <boost/random/variate_generator.hpp>
 #include <cmath>
 

--- a/stan/math/prim/scal/prob/exp_mod_normal_log.hpp
+++ b/stan/math/prim/scal/prob/exp_mod_normal_log.hpp
@@ -12,7 +12,6 @@
 #include <stan/math/prim/scal/meta/include_summand.hpp>
 #include <stan/math/prim/scal/fun/value_of.hpp>
 #include <boost/random/normal_distribution.hpp>
-#include <boost/math/special_functions/fpclassify.hpp>
 #include <boost/random/variate_generator.hpp>
 #include <cmath>
 

--- a/stan/math/prim/scal/prob/exp_mod_normal_rng.hpp
+++ b/stan/math/prim/scal/prob/exp_mod_normal_rng.hpp
@@ -14,7 +14,6 @@
 #include <stan/math/prim/scal/meta/include_summand.hpp>
 #include <stan/math/prim/scal/fun/value_of.hpp>
 #include <boost/random/normal_distribution.hpp>
-#include <boost/math/special_functions/fpclassify.hpp>
 #include <boost/random/variate_generator.hpp>
 
 namespace stan {

--- a/stan/math/prim/scal/prob/poisson_ccdf_log.hpp
+++ b/stan/math/prim/scal/prob/poisson_ccdf_log.hpp
@@ -12,7 +12,6 @@
 #include <stan/math/prim/scal/fun/multiply_log.hpp>
 #include <stan/math/prim/scal/fun/gamma_q.hpp>
 #include <stan/math/prim/scal/fun/value_of.hpp>
-#include <boost/math/special_functions/fpclassify.hpp>
 #include <boost/random/poisson_distribution.hpp>
 #include <boost/random/variate_generator.hpp>
 #include <cmath>

--- a/stan/math/prim/scal/prob/poisson_cdf.hpp
+++ b/stan/math/prim/scal/prob/poisson_cdf.hpp
@@ -12,7 +12,6 @@
 #include <stan/math/prim/scal/fun/multiply_log.hpp>
 #include <stan/math/prim/scal/fun/gamma_q.hpp>
 #include <stan/math/prim/scal/fun/value_of.hpp>
-#include <boost/math/special_functions/fpclassify.hpp>
 #include <boost/random/poisson_distribution.hpp>
 #include <boost/random/variate_generator.hpp>
 #include <cmath>

--- a/stan/math/prim/scal/prob/poisson_cdf_log.hpp
+++ b/stan/math/prim/scal/prob/poisson_cdf_log.hpp
@@ -12,7 +12,6 @@
 #include <stan/math/prim/scal/fun/multiply_log.hpp>
 #include <stan/math/prim/scal/fun/gamma_q.hpp>
 #include <stan/math/prim/scal/fun/value_of.hpp>
-#include <boost/math/special_functions/fpclassify.hpp>
 #include <boost/random/poisson_distribution.hpp>
 #include <boost/random/variate_generator.hpp>
 #include <cmath>

--- a/stan/math/prim/scal/prob/poisson_log.hpp
+++ b/stan/math/prim/scal/prob/poisson_log.hpp
@@ -15,7 +15,6 @@
 #include <stan/math/prim/scal/fun/value_of.hpp>
 #include <stan/math/prim/scal/meta/include_summand.hpp>
 #include <stan/math/prim/scal/meta/VectorView.hpp>
-#include <boost/math/special_functions/fpclassify.hpp>
 #include <boost/random/poisson_distribution.hpp>
 #include <boost/random/variate_generator.hpp>
 #include <limits>

--- a/stan/math/prim/scal/prob/poisson_log.hpp
+++ b/stan/math/prim/scal/prob/poisson_log.hpp
@@ -9,6 +9,7 @@
 #include <stan/math/prim/scal/err/check_nonnegative.hpp>
 #include <stan/math/prim/scal/err/check_not_nan.hpp>
 #include <stan/math/prim/scal/fun/constants.hpp>
+#include <stan/math/prim/scal/fun/is_inf.hpp>
 #include <stan/math/prim/scal/fun/multiply_log.hpp>
 #include <stan/math/prim/scal/fun/gamma_q.hpp>
 #include <stan/math/prim/scal/fun/value_of.hpp>
@@ -54,7 +55,7 @@ namespace stan {
       size_t size = max_size(n, lambda);
 
       for (size_t i = 0; i < size; i++)
-        if (boost::math::isinf(lambda_vec[i]))
+        if (is_inf(lambda_vec[i]))
           return LOG_ZERO;
       for (size_t i = 0; i < size; i++)
         if (lambda_vec[i] == 0 && n_vec[i] != 0)

--- a/stan/math/prim/scal/prob/poisson_log_log.hpp
+++ b/stan/math/prim/scal/prob/poisson_log_log.hpp
@@ -15,7 +15,6 @@
 #include <stan/math/prim/scal/meta/include_summand.hpp>
 #include <stan/math/prim/scal/meta/VectorView.hpp>
 #include <stan/math/prim/scal/meta/VectorBuilder.hpp>
-#include <boost/math/special_functions/fpclassify.hpp>
 #include <boost/random/poisson_distribution.hpp>
 #include <boost/random/variate_generator.hpp>
 #include <cmath>

--- a/stan/math/prim/scal/prob/poisson_log_rng.hpp
+++ b/stan/math/prim/scal/prob/poisson_log_rng.hpp
@@ -9,7 +9,6 @@
 #include <stan/math/prim/scal/fun/multiply_log.hpp>
 #include <stan/math/prim/scal/fun/gamma_q.hpp>
 #include <stan/math/prim/scal/fun/value_of.hpp>
-#include <boost/math/special_functions/fpclassify.hpp>
 #include <boost/random/poisson_distribution.hpp>
 #include <boost/random/variate_generator.hpp>
 #include <limits>

--- a/stan/math/prim/scal/prob/poisson_rng.hpp
+++ b/stan/math/prim/scal/prob/poisson_rng.hpp
@@ -9,7 +9,6 @@
 #include <stan/math/prim/scal/fun/multiply_log.hpp>
 #include <stan/math/prim/scal/fun/gamma_q.hpp>
 #include <stan/math/prim/scal/fun/value_of.hpp>
-#include <boost/math/special_functions/fpclassify.hpp>
 #include <boost/random/poisson_distribution.hpp>
 #include <boost/random/variate_generator.hpp>
 #include <cmath>

--- a/stan/math/prim/scal/prob/wiener_log.hpp
+++ b/stan/math/prim/scal/prob/wiener_log.hpp
@@ -74,8 +74,6 @@ namespace stan {
                const T_beta& beta, const T_delta& delta) {
       static const char* function("wiener_log(%1%)");
 
-      using boost::math::tools::promote_args;
-      using boost::math::isfinite;
       using std::log;
       using std::exp;
       using std::pow;

--- a/stan/math/prim/scal/prob/wiener_log.hpp
+++ b/stan/math/prim/scal/prob/wiener_log.hpp
@@ -75,7 +75,6 @@ namespace stan {
       static const char* function("wiener_log(%1%)");
 
       using boost::math::tools::promote_args;
-      using boost::math::isinf;
       using boost::math::isfinite;
       using std::log;
       using std::exp;

--- a/stan/math/rev/core/operator_addition.hpp
+++ b/stan/math/rev/core/operator_addition.hpp
@@ -5,7 +5,6 @@
 #include <stan/math/rev/core/vv_vari.hpp>
 #include <stan/math/rev/core/vd_vari.hpp>
 #include <stan/math/prim/scal/fun/is_nan.hpp>
-#include <boost/math/special_functions/fpclassify.hpp>
 #include <limits>
 
 namespace stan {

--- a/stan/math/rev/core/operator_addition.hpp
+++ b/stan/math/rev/core/operator_addition.hpp
@@ -4,6 +4,7 @@
 #include <stan/math/rev/core/var.hpp>
 #include <stan/math/rev/core/vv_vari.hpp>
 #include <stan/math/rev/core/vd_vari.hpp>
+#include <stan/math/prim/scal/fun/is_nan.hpp>
 #include <boost/math/special_functions/fpclassify.hpp>
 #include <limits>
 
@@ -17,8 +18,8 @@ namespace stan {
           op_vv_vari(avi->val_ + bvi->val_, avi, bvi) {
         }
         void chain() {
-          if (unlikely(boost::math::isnan(avi_->val_)
-                       || boost::math::isnan(bvi_->val_))) {
+          if (unlikely(is_nan(avi_->val_)
+                       || is_nan(bvi_->val_))) {
             avi_->adj_ = std::numeric_limits<double>::quiet_NaN();
             bvi_->adj_ = std::numeric_limits<double>::quiet_NaN();
           } else {
@@ -34,8 +35,8 @@ namespace stan {
           op_vd_vari(avi->val_ + b, avi, b) {
         }
         void chain() {
-          if (unlikely(boost::math::isnan(avi_->val_)
-                       || boost::math::isnan(bd_)))
+          if (unlikely(is_nan(avi_->val_)
+                       || is_nan(bd_)))
             avi_->adj_ = std::numeric_limits<double>::quiet_NaN();
           else
             avi_->adj_ += adj_;

--- a/stan/math/rev/core/operator_division.hpp
+++ b/stan/math/rev/core/operator_division.hpp
@@ -6,7 +6,6 @@
 #include <stan/math/rev/core/vd_vari.hpp>
 #include <stan/math/rev/core/dv_vari.hpp>
 #include <stan/math/prim/scal/fun/is_nan.hpp>
-#include <boost/math/special_functions/fpclassify.hpp>
 #include <limits>
 
 namespace stan {

--- a/stan/math/rev/core/operator_division.hpp
+++ b/stan/math/rev/core/operator_division.hpp
@@ -5,6 +5,7 @@
 #include <stan/math/rev/core/vv_vari.hpp>
 #include <stan/math/rev/core/vd_vari.hpp>
 #include <stan/math/rev/core/dv_vari.hpp>
+#include <stan/math/prim/scal/fun/is_nan.hpp>
 #include <boost/math/special_functions/fpclassify.hpp>
 #include <limits>
 
@@ -19,8 +20,8 @@ namespace stan {
           op_vv_vari(avi->val_ / bvi->val_, avi, bvi) {
         }
         void chain() {
-          if (unlikely(boost::math::isnan(avi_->val_)
-                       || boost::math::isnan(bvi_->val_))) {
+          if (unlikely(is_nan(avi_->val_)
+                       || is_nan(bvi_->val_))) {
             avi_->adj_ = std::numeric_limits<double>::quiet_NaN();
             bvi_->adj_ = std::numeric_limits<double>::quiet_NaN();
           } else {
@@ -36,8 +37,8 @@ namespace stan {
           op_vd_vari(avi->val_ / b, avi, b) {
         }
         void chain() {
-          if (unlikely(boost::math::isnan(avi_->val_)
-                       || boost::math::isnan(bd_)))
+          if (unlikely(is_nan(avi_->val_)
+                       || is_nan(bd_)))
             avi_->adj_ = std::numeric_limits<double>::quiet_NaN();
           else
             avi_->adj_ += adj_ / bd_;

--- a/stan/math/rev/core/operator_multiplication.hpp
+++ b/stan/math/rev/core/operator_multiplication.hpp
@@ -5,7 +5,6 @@
 #include <stan/math/rev/core/vv_vari.hpp>
 #include <stan/math/rev/core/vd_vari.hpp>
 #include <stan/math/prim/scal/fun/is_nan.hpp>
-#include <boost/math/special_functions/fpclassify.hpp>
 #include <limits>
 
 namespace stan {

--- a/stan/math/rev/core/operator_multiplication.hpp
+++ b/stan/math/rev/core/operator_multiplication.hpp
@@ -4,6 +4,7 @@
 #include <stan/math/rev/core/var.hpp>
 #include <stan/math/rev/core/vv_vari.hpp>
 #include <stan/math/rev/core/vd_vari.hpp>
+#include <stan/math/prim/scal/fun/is_nan.hpp>
 #include <boost/math/special_functions/fpclassify.hpp>
 #include <limits>
 
@@ -17,8 +18,8 @@ namespace stan {
           op_vv_vari(avi->val_ * bvi->val_, avi, bvi) {
         }
         void chain() {
-          if (unlikely(boost::math::isnan(avi_->val_)
-                       || boost::math::isnan(bvi_->val_))) {
+          if (unlikely(is_nan(avi_->val_)
+                       || is_nan(bvi_->val_))) {
             avi_->adj_ = std::numeric_limits<double>::quiet_NaN();
             bvi_->adj_ = std::numeric_limits<double>::quiet_NaN();
           } else {
@@ -34,8 +35,8 @@ namespace stan {
           op_vd_vari(avi->val_ * b, avi, b) {
         }
         void chain() {
-          if (unlikely(boost::math::isnan(avi_->val_)
-                       || boost::math::isnan(bd_)))
+          if (unlikely(is_nan(avi_->val_)
+                       || is_nan(bd_)))
             avi_->adj_ = std::numeric_limits<double>::quiet_NaN();
           else
             avi_->adj_ += adj_ * bd_;

--- a/stan/math/rev/core/operator_subtraction.hpp
+++ b/stan/math/rev/core/operator_subtraction.hpp
@@ -5,6 +5,7 @@
 #include <stan/math/rev/core/vv_vari.hpp>
 #include <stan/math/rev/core/vd_vari.hpp>
 #include <stan/math/rev/core/dv_vari.hpp>
+#include <stan/math/prim/scal/fun/is_nan.hpp>
 #include <boost/math/special_functions/fpclassify.hpp>
 #include <limits>
 
@@ -18,8 +19,8 @@ namespace stan {
           op_vv_vari(avi->val_ - bvi->val_, avi, bvi) {
         }
         void chain() {
-          if (unlikely(boost::math::isnan(avi_->val_)
-                       || boost::math::isnan(bvi_->val_))) {
+          if (unlikely(is_nan(avi_->val_)
+                       || is_nan(bvi_->val_))) {
             avi_->adj_ = std::numeric_limits<double>::quiet_NaN();
             bvi_->adj_ = std::numeric_limits<double>::quiet_NaN();
           } else {
@@ -35,8 +36,8 @@ namespace stan {
           op_vd_vari(avi->val_ - b, avi, b) {
         }
         void chain() {
-          if (unlikely(boost::math::isnan(avi_->val_)
-                       || boost::math::isnan(bd_)))
+          if (unlikely(is_nan(avi_->val_)
+                       || is_nan(bd_)))
             avi_->adj_ = std::numeric_limits<double>::quiet_NaN();
           else
             avi_->adj_ += adj_;
@@ -49,8 +50,8 @@ namespace stan {
           op_dv_vari(a - bvi->val_, a, bvi) {
         }
         void chain() {
-          if (unlikely(boost::math::isnan(ad_)
-                       || boost::math::isnan(bvi_->val_)))
+          if (unlikely(is_nan(ad_)
+                       || is_nan(bvi_->val_)))
             bvi_->adj_ = std::numeric_limits<double>::quiet_NaN();
           else
             bvi_->adj_ -= adj_;

--- a/stan/math/rev/core/operator_subtraction.hpp
+++ b/stan/math/rev/core/operator_subtraction.hpp
@@ -6,7 +6,6 @@
 #include <stan/math/rev/core/vd_vari.hpp>
 #include <stan/math/rev/core/dv_vari.hpp>
 #include <stan/math/prim/scal/fun/is_nan.hpp>
-#include <boost/math/special_functions/fpclassify.hpp>
 #include <limits>
 
 namespace stan {

--- a/stan/math/rev/core/operator_unary_decrement.hpp
+++ b/stan/math/rev/core/operator_unary_decrement.hpp
@@ -4,7 +4,6 @@
 #include <stan/math/rev/core/var.hpp>
 #include <stan/math/rev/core/v_vari.hpp>
 #include <stan/math/prim/scal/fun/is_nan.hpp>
-#include <boost/math/special_functions/fpclassify.hpp>
 #include <limits>
 
 namespace stan {

--- a/stan/math/rev/core/operator_unary_decrement.hpp
+++ b/stan/math/rev/core/operator_unary_decrement.hpp
@@ -3,6 +3,7 @@
 
 #include <stan/math/rev/core/var.hpp>
 #include <stan/math/rev/core/v_vari.hpp>
+#include <stan/math/prim/scal/fun/is_nan.hpp>
 #include <boost/math/special_functions/fpclassify.hpp>
 #include <limits>
 
@@ -16,7 +17,7 @@ namespace stan {
           op_v_vari(avi->val_ - 1.0, avi) {
         }
         void chain() {
-          if (unlikely(boost::math::isnan(avi_->val_)))
+          if (unlikely(is_nan(avi_->val_)))
             avi_->adj_ = std::numeric_limits<double>::quiet_NaN();
           else
             avi_->adj_ += adj_;

--- a/stan/math/rev/core/operator_unary_increment.hpp
+++ b/stan/math/rev/core/operator_unary_increment.hpp
@@ -4,7 +4,6 @@
 #include <stan/math/rev/core/var.hpp>
 #include <stan/math/rev/core/v_vari.hpp>
 #include <stan/math/prim/scal/fun/is_nan.hpp>
-#include <boost/math/special_functions/fpclassify.hpp>
 #include <limits>
 
 namespace stan {

--- a/stan/math/rev/core/operator_unary_increment.hpp
+++ b/stan/math/rev/core/operator_unary_increment.hpp
@@ -3,6 +3,7 @@
 
 #include <stan/math/rev/core/var.hpp>
 #include <stan/math/rev/core/v_vari.hpp>
+#include <stan/math/prim/scal/fun/is_nan.hpp>
 #include <boost/math/special_functions/fpclassify.hpp>
 #include <limits>
 
@@ -16,7 +17,7 @@ namespace stan {
           op_v_vari(avi->val_ + 1.0, avi) {
         }
         void chain() {
-          if (unlikely(boost::math::isnan(avi_->val_)))
+          if (unlikely(is_nan(avi_->val_)))
             avi_->adj_ = std::numeric_limits<double>::quiet_NaN();
           else
             avi_->adj_ += adj_;

--- a/stan/math/rev/core/operator_unary_negative.hpp
+++ b/stan/math/rev/core/operator_unary_negative.hpp
@@ -4,7 +4,6 @@
 #include <stan/math/rev/core/var.hpp>
 #include <stan/math/rev/core/v_vari.hpp>
 #include <stan/math/prim/scal/fun/is_nan.hpp>
-#include <boost/math/special_functions/fpclassify.hpp>
 #include <limits>
 
 namespace stan {

--- a/stan/math/rev/core/operator_unary_negative.hpp
+++ b/stan/math/rev/core/operator_unary_negative.hpp
@@ -3,6 +3,7 @@
 
 #include <stan/math/rev/core/var.hpp>
 #include <stan/math/rev/core/v_vari.hpp>
+#include <stan/math/prim/scal/fun/is_nan.hpp>
 #include <boost/math/special_functions/fpclassify.hpp>
 #include <limits>
 
@@ -16,7 +17,7 @@ namespace stan {
           op_v_vari(-(avi->val_), avi) {
         }
         void chain() {
-          if (unlikely(boost::math::isnan(avi_->val_)))
+          if (unlikely(is_nan(avi_->val_)))
             avi_->adj_ = std::numeric_limits<double>::quiet_NaN();
           else
             avi_->adj_ -= adj_;

--- a/stan/math/rev/core/operator_unary_plus.hpp
+++ b/stan/math/rev/core/operator_unary_plus.hpp
@@ -2,9 +2,10 @@
 #define STAN_MATH_REV_CORE_OPERATOR_UNARY_PLUS_HPP
 
 #include <stan/math/rev/core/var.hpp>
-#include <boost/math/special_functions/fpclassify.hpp>
+#include <stan/math/prim/scal/fun/is_nan.hpp>
 #include <stan/math/rev/core/precomp_v_vari.hpp>
 #include <stan/math/prim/scal/fun/constants.hpp>
+#include <boost/math/special_functions/fpclassify.hpp>
 
 namespace stan {
   namespace math {
@@ -41,7 +42,7 @@ namespace stan {
      * @return The input reference.
      */
     inline var operator+(const var& a) {
-      if (unlikely(boost::math::isnan(a.vi_->val_)))
+      if (unlikely(is_nan(a.vi_->val_)))
         return var(new precomp_v_vari(NOT_A_NUMBER,
                                       a.vi_,
                                       NOT_A_NUMBER));

--- a/stan/math/rev/core/operator_unary_plus.hpp
+++ b/stan/math/rev/core/operator_unary_plus.hpp
@@ -5,7 +5,6 @@
 #include <stan/math/prim/scal/fun/is_nan.hpp>
 #include <stan/math/rev/core/precomp_v_vari.hpp>
 #include <stan/math/prim/scal/fun/constants.hpp>
-#include <boost/math/special_functions/fpclassify.hpp>
 
 namespace stan {
   namespace math {

--- a/stan/math/rev/core/std_isinf.hpp
+++ b/stan/math/rev/core/std_isinf.hpp
@@ -1,23 +1,20 @@
 #ifndef STAN_MATH_REV_CORE_STD_ISINF_HPP
 #define STAN_MATH_REV_CORE_STD_ISINF_HPP
 
+#include <stan/math/prim/scal/fun/is_inf.hpp>
 #include <stan/math/rev/core/var.hpp>
-#include <stan/math/rev/scal/fun/is_inf.hpp>
-#include <cmath>
 
 namespace std {
 
   /**
-   * Checks if the given number is infinite.
+   * Return <code>1</code> if the specified argument is positive
+   * infinity or negative infinity and <code>0</code> otherwise.
    *
-   * Return <code>true</code> if the value of the
-   * a is positive or negative infinity.
-   *
-   * @param a Variable to test.
-   * @return <code>true</code> if value is infinite.
+   * @param a Argument.
+   * @return 1 if argument is infinite and 0 otherwise.
    */
   inline int isinf(const stan::math::var& a) {
-    return is_inf(a);
+    return stan::math::is_inf(a.val());
   }
 
 }

--- a/stan/math/rev/core/std_isinf.hpp
+++ b/stan/math/rev/core/std_isinf.hpp
@@ -2,6 +2,7 @@
 #define STAN_MATH_REV_CORE_STD_ISINF_HPP
 
 #include <stan/math/rev/core/var.hpp>
+#include <stan/math/rev/scal/fun/is_inf.hpp>
 #include <cmath>
 
 namespace std {
@@ -16,7 +17,7 @@ namespace std {
    * @return <code>true</code> if value is infinite.
    */
   inline int isinf(const stan::math::var& a) {
-    return isinf(a.val());
+    return is_inf(a);
   }
 
 }

--- a/stan/math/rev/mat/fun/log_determinant_spd.hpp
+++ b/stan/math/rev/mat/fun/log_determinant_spd.hpp
@@ -3,6 +3,7 @@
 
 #include <boost/math/special_functions/fpclassify.hpp>
 #include <stan/math/prim/scal/err/domain_error.hpp>
+#include <stan/math/prim/scal/err/check_finite.hpp>
 #include <stan/math/prim/mat/err/check_square.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/rev/core.hpp>
@@ -14,7 +15,7 @@ namespace stan {
     inline var log_determinant_spd(const Eigen::Matrix<var, R, C>& m) {
       using Eigen::Matrix;
 
-      math::check_square("log_determinant_spd", "m", m);
+      check_square("log_determinant_spd", "m", m);
 
       Matrix<double, R, C> m_d(m.rows(), m.cols());
       for (int i = 0; i < m.size(); ++i)
@@ -41,12 +42,7 @@ namespace stan {
 
       double val = ldlt.vectorD().array().log().sum();
 
-      if (!boost::math::isfinite(val)) {
-        double y = 0;
-        domain_error("log_determinant_spd",
-                "matrix argument", y,
-                "log determininant is infinite");
-      }
+      check_finite("log_determinant_spd", "log determininant of the matrix argument", val);
 
       vari** operands = ChainableStack::memalloc_
         .alloc_array<vari*>(m.size());

--- a/stan/math/rev/mat/fun/log_determinant_spd.hpp
+++ b/stan/math/rev/mat/fun/log_determinant_spd.hpp
@@ -1,7 +1,6 @@
 #ifndef STAN_MATH_REV_MAT_FUN_LOG_DETERMINANT_SPD_HPP
 #define STAN_MATH_REV_MAT_FUN_LOG_DETERMINANT_SPD_HPP
 
-#include <boost/math/special_functions/fpclassify.hpp>
 #include <stan/math/prim/scal/err/domain_error.hpp>
 #include <stan/math/prim/scal/err/check_finite.hpp>
 #include <stan/math/prim/mat/err/check_square.hpp>

--- a/stan/math/rev/mat/fun/log_determinant_spd.hpp
+++ b/stan/math/rev/mat/fun/log_determinant_spd.hpp
@@ -41,7 +41,8 @@ namespace stan {
 
       double val = ldlt.vectorD().array().log().sum();
 
-      check_finite("log_determinant_spd", "log determininant of the matrix argument", val);
+      check_finite("log_determinant_spd",
+                   "log determininant of the matrix argument", val);
 
       vari** operands = ChainableStack::memalloc_
         .alloc_array<vari*>(m.size());

--- a/stan/math/rev/scal/fun/acosh.hpp
+++ b/stan/math/rev/scal/fun/acosh.hpp
@@ -4,7 +4,6 @@
 #include <math.h>
 #include <stan/math/rev/core.hpp>
 #include <stan/math/prim/scal/fun/is_inf.hpp>
-#include <boost/math/special_functions/fpclassify.hpp>
 #include <cmath>
 
 #ifdef _MSC_VER

--- a/stan/math/rev/scal/fun/acosh.hpp
+++ b/stan/math/rev/scal/fun/acosh.hpp
@@ -3,6 +3,7 @@
 
 #include <math.h>
 #include <stan/math/rev/core.hpp>
+#include <stan/math/prim/scal/fun/is_inf.hpp>
 #include <boost/math/special_functions/fpclassify.hpp>
 #include <cmath>
 
@@ -66,7 +67,7 @@ namespace stan {
      * @return Inverse hyperbolic cosine of the variable.
      */
     inline var acosh(const var& a) {
-      if (boost::math::isinf(a.val()) && a > 0.0)
+      if (is_inf(a.val()) && a > 0.0)
         return var(new acosh_vari(a.val(), a.vi_));
       return var(new acosh_vari(::acosh(a.val()), a.vi_));
     }

--- a/stan/math/rev/scal/fun/asinh.hpp
+++ b/stan/math/rev/scal/fun/asinh.hpp
@@ -4,7 +4,6 @@
 #include <math.h>
 #include <stan/math/rev/core.hpp>
 #include <stan/math/prim/scal/fun/is_inf.hpp>
-#include <boost/math/special_functions/fpclassify.hpp>
 #include <cmath>
 #include <valarray>
 

--- a/stan/math/rev/scal/fun/asinh.hpp
+++ b/stan/math/rev/scal/fun/asinh.hpp
@@ -3,6 +3,7 @@
 
 #include <math.h>
 #include <stan/math/rev/core.hpp>
+#include <stan/math/prim/scal/fun/is_inf.hpp>
 #include <boost/math/special_functions/fpclassify.hpp>
 #include <cmath>
 #include <valarray>
@@ -65,7 +66,7 @@ namespace stan {
      * @return Inverse hyperbolic sine of the variable.
      */
     inline var asinh(const var& a) {
-      if (boost::math::isinf(a.val()))
+      if (is_inf(a.val()))
         return var(new asinh_vari(a.val(), a.vi_));
       return var(new asinh_vari(::asinh(a.val()), a.vi_));
     }

--- a/stan/math/rev/scal/fun/ceil.hpp
+++ b/stan/math/rev/scal/fun/ceil.hpp
@@ -2,6 +2,7 @@
 #define STAN_MATH_REV_SCAL_FUN_CEIL_HPP
 
 #include <stan/math/rev/core.hpp>
+#include <stan/math/prim/scal/fun/is_nan.hpp>
 #include <stan/math/prim/scal/meta/likely.hpp>
 #include <boost/math/special_functions/fpclassify.hpp>
 #include <cmath>
@@ -17,7 +18,7 @@ namespace stan {
           op_v_vari(std::ceil(avi->val_), avi) {
         }
         void chain() {
-          if (unlikely(boost::math::isnan(avi_->val_)))
+          if (unlikely(is_nan(avi_->val_)))
             avi_->adj_ = std::numeric_limits<double>::quiet_NaN();
         }
       };

--- a/stan/math/rev/scal/fun/ceil.hpp
+++ b/stan/math/rev/scal/fun/ceil.hpp
@@ -4,7 +4,6 @@
 #include <stan/math/rev/core.hpp>
 #include <stan/math/prim/scal/fun/is_nan.hpp>
 #include <stan/math/prim/scal/meta/likely.hpp>
-#include <boost/math/special_functions/fpclassify.hpp>
 #include <cmath>
 #include <limits>
 

--- a/stan/math/rev/scal/fun/fdim.hpp
+++ b/stan/math/rev/scal/fun/fdim.hpp
@@ -4,7 +4,6 @@
 #include <stan/math/rev/core.hpp>
 #include <stan/math/prim/scal/fun/is_nan.hpp>
 #include <stan/math/prim/scal/meta/likely.hpp>
-#include <boost/math/special_functions/fpclassify.hpp>
 #include <limits>
 
 namespace stan {

--- a/stan/math/rev/scal/fun/fdim.hpp
+++ b/stan/math/rev/scal/fun/fdim.hpp
@@ -2,8 +2,9 @@
 #define STAN_MATH_REV_SCAL_FUN_FDIM_HPP
 
 #include <stan/math/rev/core.hpp>
-#include <boost/math/special_functions/fpclassify.hpp>
+#include <stan/math/prim/scal/fun/is_nan.hpp>
 #include <stan/math/prim/scal/meta/likely.hpp>
+#include <boost/math/special_functions/fpclassify.hpp>
 #include <limits>
 
 namespace stan {
@@ -16,8 +17,8 @@ namespace stan {
           op_vv_vari(avi->val_ - bvi->val_, avi, bvi) {
         }
         void chain() {
-          if (unlikely(boost::math::isnan(avi_->val_)
-                       || boost::math::isnan(bvi_->val_))) {
+          if (unlikely(is_nan(avi_->val_)
+                       || is_nan(bvi_->val_))) {
             avi_->adj_ = std::numeric_limits<double>::quiet_NaN();
             bvi_->adj_ = std::numeric_limits<double>::quiet_NaN();
           } else {
@@ -33,8 +34,8 @@ namespace stan {
           op_vd_vari(avi->val_ - b, avi, b) {
         }
         void chain() {
-          if (unlikely(boost::math::isnan(avi_->val_)
-                       || boost::math::isnan(bd_)))
+          if (unlikely(is_nan(avi_->val_)
+                       || is_nan(bd_)))
             avi_->adj_ = std::numeric_limits<double>::quiet_NaN();
           else
             avi_->adj_ += adj_;
@@ -47,8 +48,8 @@ namespace stan {
           op_dv_vari(a - bvi->val_, a, bvi) {
         }
         void chain() {
-          if (unlikely(boost::math::isnan(bvi_->val_)
-                       || boost::math::isnan(ad_)))
+          if (unlikely(is_nan(bvi_->val_)
+                       || is_nan(ad_)))
             bvi_->adj_ = std::numeric_limits<double>::quiet_NaN();
           else
             bvi_->adj_ -= adj_;

--- a/stan/math/rev/scal/fun/floor.hpp
+++ b/stan/math/rev/scal/fun/floor.hpp
@@ -4,7 +4,6 @@
 #include <stan/math/rev/core.hpp>
 #include <stan/math/prim/scal/fun/is_nan.hpp>
 #include <stan/math/prim/scal/meta/likely.hpp>
-#include <boost/math/special_functions/fpclassify.hpp>
 #include <cmath>
 #include <limits>
 

--- a/stan/math/rev/scal/fun/floor.hpp
+++ b/stan/math/rev/scal/fun/floor.hpp
@@ -2,8 +2,9 @@
 #define STAN_MATH_REV_SCAL_FUN_FLOOR_HPP
 
 #include <stan/math/rev/core.hpp>
-#include <boost/math/special_functions/fpclassify.hpp>
+#include <stan/math/prim/scal/fun/is_nan.hpp>
 #include <stan/math/prim/scal/meta/likely.hpp>
+#include <boost/math/special_functions/fpclassify.hpp>
 #include <cmath>
 #include <limits>
 
@@ -17,7 +18,7 @@ namespace stan {
           op_v_vari(std::floor(avi->val_), avi) {
         }
         void chain() {
-          if (unlikely(boost::math::isnan(avi_->val_)))
+          if (unlikely(is_nan(avi_->val_)))
             avi_->adj_ = std::numeric_limits<double>::quiet_NaN();
         }
       };

--- a/stan/math/rev/scal/fun/fma.hpp
+++ b/stan/math/rev/scal/fun/fma.hpp
@@ -5,7 +5,6 @@
 #include <stan/math/rev/core.hpp>
 #include <stan/math/prim/scal/fun/constants.hpp>
 #include <stan/math/prim/scal/fun/is_nan.hpp>
-#include <boost/math/special_functions/fpclassify.hpp>
 #include <stan/math/prim/scal/meta/likely.hpp>
 #include <valarray>
 #include <limits>

--- a/stan/math/rev/scal/fun/fma.hpp
+++ b/stan/math/rev/scal/fun/fma.hpp
@@ -4,6 +4,7 @@
 #include <math.h>
 #include <stan/math/rev/core.hpp>
 #include <stan/math/prim/scal/fun/constants.hpp>
+#include <stan/math/prim/scal/fun/is_nan.hpp>
 #include <boost/math/special_functions/fpclassify.hpp>
 #include <stan/math/prim/scal/meta/likely.hpp>
 #include <valarray>
@@ -27,9 +28,9 @@ namespace stan {
                       avi, bvi, cvi) {
         }
         void chain() {
-          if (unlikely(boost::math::isnan(avi_->val_)
-                       || boost::math::isnan(bvi_->val_)
-                       || boost::math::isnan(cvi_->val_))) {
+          if (unlikely(is_nan(avi_->val_)
+                       || is_nan(bvi_->val_)
+                       || is_nan(cvi_->val_))) {
             avi_->adj_ = std::numeric_limits<double>::quiet_NaN();
             bvi_->adj_ = std::numeric_limits<double>::quiet_NaN();
             cvi_->adj_ = std::numeric_limits<double>::quiet_NaN();
@@ -48,9 +49,9 @@ namespace stan {
                       avi, bvi, c) {
         }
         void chain() {
-          if (unlikely(boost::math::isnan(avi_->val_)
-                       || boost::math::isnan(bvi_->val_)
-                       || boost::math::isnan(cd_))) {
+          if (unlikely(is_nan(avi_->val_)
+                       || is_nan(bvi_->val_)
+                       || is_nan(cd_))) {
             avi_->adj_ = std::numeric_limits<double>::quiet_NaN();
             bvi_->adj_ = std::numeric_limits<double>::quiet_NaN();
           } else {
@@ -67,9 +68,9 @@ namespace stan {
                       avi, b, cvi) {
         }
         void chain() {
-          if (unlikely(boost::math::isnan(avi_->val_)
-                       || boost::math::isnan(cvi_->val_)
-                       || boost::math::isnan(bd_))) {
+          if (unlikely(is_nan(avi_->val_)
+                       || is_nan(cvi_->val_)
+                       || is_nan(bd_))) {
             avi_->adj_ = std::numeric_limits<double>::quiet_NaN();
             cvi_->adj_ = std::numeric_limits<double>::quiet_NaN();
           } else {
@@ -86,9 +87,9 @@ namespace stan {
                       avi, b, c) {
         }
         void chain() {
-          if (unlikely(boost::math::isnan(avi_->val_)
-                       || boost::math::isnan(bd_)
-                       || boost::math::isnan(cd_)))
+          if (unlikely(is_nan(avi_->val_)
+                       || is_nan(bd_)
+                       || is_nan(cd_)))
             avi_->adj_ = std::numeric_limits<double>::quiet_NaN();
           else
             avi_->adj_ += adj_ * bd_;
@@ -102,9 +103,9 @@ namespace stan {
                       a, b, cvi) {
         }
         void chain() {
-          if (unlikely(boost::math::isnan(cvi_->val_)
-                       || boost::math::isnan(ad_)
-                       || boost::math::isnan(bd_)))
+          if (unlikely(is_nan(cvi_->val_)
+                       || is_nan(ad_)
+                       || is_nan(bd_)))
             cvi_->adj_ = std::numeric_limits<double>::quiet_NaN();
           else
             cvi_->adj_ += adj_;

--- a/stan/math/rev/scal/fun/fmax.hpp
+++ b/stan/math/rev/scal/fun/fmax.hpp
@@ -4,7 +4,6 @@
 #include <stan/math/rev/core.hpp>
 #include <stan/math/rev/scal/fun/is_nan.hpp>
 #include <stan/math/prim/scal/fun/is_nan.hpp>
-#include <boost/math/special_functions/fpclassify.hpp>
 #include <stan/math/prim/scal/fun/constants.hpp>
 #include <stan/math/prim/scal/meta/likely.hpp>
 

--- a/stan/math/rev/scal/fun/fmin.hpp
+++ b/stan/math/rev/scal/fun/fmin.hpp
@@ -2,7 +2,6 @@
 #define STAN_MATH_REV_SCAL_FUN_FMIN_HPP
 
 #include <stan/math/rev/core.hpp>
-#include <boost/math/special_functions/fpclassify.hpp>
 #include <stan/math/prim/scal/fun/constants.hpp>
 #include <stan/math/prim/scal/meta/likely.hpp>
 #include <stan/math/rev/scal/fun/is_nan.hpp>

--- a/stan/math/rev/scal/fun/fmod.hpp
+++ b/stan/math/rev/scal/fun/fmod.hpp
@@ -2,6 +2,7 @@
 #define STAN_MATH_REV_SCAL_FUN_FMOD_HPP
 
 #include <stan/math/rev/core.hpp>
+#include <stan/math/prim/scal/fun/is_nan.hpp>
 #include <boost/math/special_functions/fpclassify.hpp>
 #include <cmath>
 #include <limits>
@@ -16,8 +17,8 @@ namespace stan {
           op_vv_vari(std::fmod(avi->val_, bvi->val_), avi, bvi) {
         }
         void chain() {
-          if (unlikely(boost::math::isnan(avi_->val_)
-                       || boost::math::isnan(bvi_->val_))) {
+          if (unlikely(is_nan(avi_->val_)
+                       || is_nan(bvi_->val_))) {
             avi_->adj_ = std::numeric_limits<double>::quiet_NaN();
             bvi_->adj_ = std::numeric_limits<double>::quiet_NaN();
           } else {
@@ -33,8 +34,8 @@ namespace stan {
           op_vd_vari(std::fmod(avi->val_, b), avi, b) {
         }
         void chain() {
-          if (unlikely(boost::math::isnan(avi_->val_)
-                       || boost::math::isnan(bd_)))
+          if (unlikely(is_nan(avi_->val_)
+                       || is_nan(bd_)))
             avi_->adj_ = std::numeric_limits<double>::quiet_NaN();
           else
             avi_->adj_ += adj_;
@@ -47,8 +48,8 @@ namespace stan {
           op_dv_vari(std::fmod(a, bvi->val_), a, bvi) {
         }
         void chain() {
-          if (unlikely(boost::math::isnan(bvi_->val_)
-                       || boost::math::isnan(ad_))) {
+          if (unlikely(is_nan(bvi_->val_)
+                       || is_nan(ad_))) {
             bvi_->adj_ = std::numeric_limits<double>::quiet_NaN();
           } else {
             int d = static_cast<int>(ad_ / bvi_->val_);

--- a/stan/math/rev/scal/fun/fmod.hpp
+++ b/stan/math/rev/scal/fun/fmod.hpp
@@ -3,7 +3,6 @@
 
 #include <stan/math/rev/core.hpp>
 #include <stan/math/prim/scal/fun/is_nan.hpp>
-#include <boost/math/special_functions/fpclassify.hpp>
 #include <cmath>
 #include <limits>
 

--- a/stan/math/rev/scal/fun/ibeta.hpp
+++ b/stan/math/rev/scal/fun/ibeta.hpp
@@ -1,10 +1,11 @@
 #ifndef STAN_MATH_REV_SCAL_FUN_IBETA_HPP
 #define STAN_MATH_REV_SCAL_FUN_IBETA_HPP
 
-#include <boost/math/special_functions/digamma.hpp>
-#include <boost/math/special_functions/gamma.hpp>
 #include <stan/math/rev/core.hpp>
 #include <stan/math/prim/scal/fun/ibeta.hpp>
+#include <stan/math/prim/scal/fun/is_nan.hpp>
+#include <boost/math/special_functions/digamma.hpp>
+#include <boost/math/special_functions/gamma.hpp>
 
 namespace stan {
   namespace math {
@@ -25,7 +26,7 @@ namespace stan {
         double bprod = 1;
         while (std::abs(diff) > precision
                && ++k < max_steps
-               && !std::isnan(diff)) {
+               && !is_nan(diff)) {
           val += diff;
           bprod *= b+k-1.0;
           diff = a_2 * std::pow(a+k, -2) * bprod * std::pow(z, k)

--- a/stan/math/rev/scal/fun/ibeta.hpp
+++ b/stan/math/rev/scal/fun/ibeta.hpp
@@ -3,7 +3,6 @@
 
 #include <stan/math/rev/core.hpp>
 #include <stan/math/prim/scal/fun/ibeta.hpp>
-#include <stan/math/prim/scal/fun/is_nan.hpp>
 #include <boost/math/special_functions/digamma.hpp>
 #include <boost/math/special_functions/gamma.hpp>
 
@@ -22,15 +21,13 @@ namespace stan {
         double val = 0;
         double diff = 1;
         double k = 0;
-        double a_2 = a*a;
+        double a_2 = a * a;
         double bprod = 1;
-        while (std::abs(diff) > precision
-               && ++k < max_steps
-               && !is_nan(diff)) {
+        while (std::abs(diff) > precision && ++k < max_steps) {
           val += diff;
-          bprod *= b+k-1.0;
-          diff = a_2 * std::pow(a+k, -2) * bprod * std::pow(z, k)
-            / boost::math::tgamma(k+1);
+          bprod *= b + k - 1.0;
+          diff = a_2 * std::pow(a + k, -2) * bprod * std::pow(z, k)
+            / boost::math::tgamma(k + 1);
         }
         return val;
       }

--- a/stan/math/rev/scal/fun/is_inf.hpp
+++ b/stan/math/rev/scal/fun/is_inf.hpp
@@ -17,9 +17,7 @@ namespace stan {
      *
      * @return <code>1</code> if the value is infinite and <code>0</code> otherwise.
      */
-    inline
-    int
-    is_inf(const var& v) {
+    inline int is_inf(const var& v) {
       return is_inf(v.val());
     }
 

--- a/stan/math/rev/scal/fun/log_falling_factorial.hpp
+++ b/stan/math/rev/scal/fun/log_falling_factorial.hpp
@@ -5,7 +5,6 @@
 #include <stan/math/prim/scal/fun/log_falling_factorial.hpp>
 #include <stan/math/prim/scal/fun/is_nan.hpp>
 #include <boost/math/special_functions/digamma.hpp>
-#include <boost/math/special_functions/fpclassify.hpp>
 #include <limits>
 
 namespace stan {

--- a/stan/math/rev/scal/fun/log_falling_factorial.hpp
+++ b/stan/math/rev/scal/fun/log_falling_factorial.hpp
@@ -3,6 +3,7 @@
 
 #include <stan/math/rev/core.hpp>
 #include <stan/math/prim/scal/fun/log_falling_factorial.hpp>
+#include <stan/math/prim/scal/fun/is_nan.hpp>
 #include <boost/math/special_functions/digamma.hpp>
 #include <boost/math/special_functions/fpclassify.hpp>
 #include <limits>
@@ -19,8 +20,8 @@ namespace stan {
                      avi, bvi) {
         }
         void chain() {
-          if (unlikely(boost::math::isnan(avi_->val_)
-                       || boost::math::isnan(bvi_->val_))) {
+          if (unlikely(is_nan(avi_->val_)
+                       || is_nan(bvi_->val_))) {
             avi_->adj_ = std::numeric_limits<double>::quiet_NaN();
             bvi_->adj_ = std::numeric_limits<double>::quiet_NaN();
           } else {
@@ -39,8 +40,8 @@ namespace stan {
           op_vd_vari(log_falling_factorial(avi->val_, b), avi, b) {
         }
         void chain() {
-          if (unlikely(boost::math::isnan(avi_->val_)
-                       || boost::math::isnan(bd_)))
+          if (unlikely(is_nan(avi_->val_)
+                       || is_nan(bd_)))
             avi_->adj_ = std::numeric_limits<double>::quiet_NaN();
           else
             avi_->adj_ += adj_
@@ -55,8 +56,8 @@ namespace stan {
           op_dv_vari(log_falling_factorial(a, bvi->val_), a, bvi) {
         }
         void chain() {
-          if (unlikely(boost::math::isnan(ad_)
-                       || boost::math::isnan(bvi_->val_)))
+          if (unlikely(is_nan(ad_)
+                       || is_nan(bvi_->val_)))
             bvi_->adj_ = std::numeric_limits<double>::quiet_NaN();
           else
             bvi_->adj_ += adj_

--- a/stan/math/rev/scal/fun/multiply_log.hpp
+++ b/stan/math/rev/scal/fun/multiply_log.hpp
@@ -4,7 +4,6 @@
 #include <stan/math/rev/core.hpp>
 #include <stan/math/rev/scal/fun/log.hpp>
 #include <stan/math/prim/scal/fun/multiply_log.hpp>
-#include <boost/math/special_functions/fpclassify.hpp>
 #include <limits>
 
 namespace stan {

--- a/stan/math/rev/scal/fun/multiply_log.hpp
+++ b/stan/math/rev/scal/fun/multiply_log.hpp
@@ -18,8 +18,8 @@ namespace stan {
         }
         void chain() {
           using std::log;
-          if (unlikely(boost::math::isnan(avi_->val_)
-                       || boost::math::isnan(bvi_->val_))) {
+          if (unlikely(is_nan(avi_->val_)
+                       || is_nan(bvi_->val_))) {
             avi_->adj_ = std::numeric_limits<double>::quiet_NaN();
             bvi_->adj_ = std::numeric_limits<double>::quiet_NaN();
           } else {
@@ -38,8 +38,8 @@ namespace stan {
         }
         void chain() {
           using std::log;
-          if (unlikely(boost::math::isnan(avi_->val_)
-                       || boost::math::isnan(bd_)))
+          if (unlikely(is_nan(avi_->val_)
+                       || is_nan(bd_)))
             avi_->adj_ = std::numeric_limits<double>::quiet_NaN();
           else
             avi_->adj_ += adj_ * log(bd_);

--- a/stan/math/rev/scal/fun/pow.hpp
+++ b/stan/math/rev/scal/fun/pow.hpp
@@ -4,7 +4,6 @@
 #include <stan/math/rev/core.hpp>
 #include <stan/math/rev/scal/fun/sqrt.hpp>
 #include <stan/math/prim/scal/fun/is_nan.hpp>
-#include <boost/math/special_functions/fpclassify.hpp>
 #include <cmath>
 #include <limits>
 

--- a/stan/math/rev/scal/fun/pow.hpp
+++ b/stan/math/rev/scal/fun/pow.hpp
@@ -3,6 +3,7 @@
 
 #include <stan/math/rev/core.hpp>
 #include <stan/math/rev/scal/fun/sqrt.hpp>
+#include <stan/math/prim/scal/fun/is_nan.hpp>
 #include <boost/math/special_functions/fpclassify.hpp>
 #include <cmath>
 #include <limits>
@@ -17,8 +18,8 @@ namespace stan {
           op_vv_vari(std::pow(avi->val_, bvi->val_), avi, bvi) {
         }
         void chain() {
-          if (unlikely(boost::math::isnan(avi_->val_)
-                       || boost::math::isnan(bvi_->val_))) {
+          if (unlikely(is_nan(avi_->val_)
+                       || is_nan(bvi_->val_))) {
             avi_->adj_ = std::numeric_limits<double>::quiet_NaN();
             bvi_->adj_ = std::numeric_limits<double>::quiet_NaN();
           } else {
@@ -35,8 +36,8 @@ namespace stan {
           op_vd_vari(std::pow(avi->val_, b), avi, b) {
         }
         void chain() {
-          if (unlikely(boost::math::isnan(avi_->val_)
-                       || boost::math::isnan(bd_))) {
+          if (unlikely(is_nan(avi_->val_)
+                       || is_nan(bd_))) {
             avi_->adj_ = std::numeric_limits<double>::quiet_NaN();
           } else {
             if (avi_->val_ == 0.0) return;  // partials zero, avoids 0 & log(0)
@@ -51,8 +52,8 @@ namespace stan {
           op_dv_vari(std::pow(a, bvi->val_), a, bvi) {
         }
         void chain() {
-          if (unlikely(boost::math::isnan(bvi_->val_)
-                       || boost::math::isnan(ad_))) {
+          if (unlikely(is_nan(bvi_->val_)
+                       || is_nan(ad_))) {
             bvi_->adj_ = std::numeric_limits<double>::quiet_NaN();
           } else {
             if (ad_ == 0.0) return;  // partials zero, avoids 0 & log(0)

--- a/stan/math/rev/scal/fun/round.hpp
+++ b/stan/math/rev/scal/fun/round.hpp
@@ -4,7 +4,6 @@
 #include <math.h>
 #include <stan/math/rev/core.hpp>
 #include <stan/math/prim/scal/fun/is_nan.hpp>
-#include <boost/math/special_functions/fpclassify.hpp>
 #include <limits>
 
 namespace stan {

--- a/stan/math/rev/scal/fun/round.hpp
+++ b/stan/math/rev/scal/fun/round.hpp
@@ -3,6 +3,7 @@
 
 #include <math.h>
 #include <stan/math/rev/core.hpp>
+#include <stan/math/prim/scal/fun/is_nan.hpp>
 #include <boost/math/special_functions/fpclassify.hpp>
 #include <limits>
 
@@ -16,7 +17,7 @@ namespace stan {
           op_v_vari(::round(avi->val_), avi) {
         }
         void chain() {
-          if (unlikely(boost::math::isnan(avi_->val_)))
+          if (unlikely(is_nan(avi_->val_)))
             avi_->adj_ = std::numeric_limits<double>::quiet_NaN();
         }
       };

--- a/stan/math/rev/scal/fun/trunc.hpp
+++ b/stan/math/rev/scal/fun/trunc.hpp
@@ -3,6 +3,7 @@
 
 #include <math.h>
 #include <stan/math/rev/core.hpp>
+#include <stan/math/prim/scal/fun/is_nan.hpp>
 #include <boost/math/special_functions/fpclassify.hpp>
 #include <limits>
 
@@ -21,7 +22,7 @@ namespace stan {
           op_v_vari(::trunc(avi->val_), avi) {
         }
         void chain() {
-          if (unlikely(boost::math::isnan(avi_->val_)))
+          if (unlikely(is_nan(avi_->val_)))
             avi_->adj_ = std::numeric_limits<double>::quiet_NaN();
         }
       };

--- a/stan/math/rev/scal/fun/trunc.hpp
+++ b/stan/math/rev/scal/fun/trunc.hpp
@@ -4,7 +4,6 @@
 #include <math.h>
 #include <stan/math/rev/core.hpp>
 #include <stan/math/prim/scal/fun/is_nan.hpp>
-#include <boost/math/special_functions/fpclassify.hpp>
 #include <limits>
 
 #ifdef _MSC_VER

--- a/test/unit/math/rev/core/var_test.cpp
+++ b/test/unit/math/rev/core/var_test.cpp
@@ -1,7 +1,6 @@
-#include <stan/math/rev/core.hpp>
+#include <stan/math.hpp>
 #include <gtest/gtest.h>
 #include <stan/math/prim/mat/fun/Eigen.hpp>  // only used for stack tests
-#include <stan/math/rev/mat/fun/multiply.hpp>
 #include <stan/math/rev/mat/fun/quad_form.hpp>
 #include <test/unit/math/rev/mat/fun/util.hpp>
 


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary:
Unifies use of floating point properties functions. Instead of using `boost::math::isinf` or `isnan`, we now use `stan::math::is_inf` and `is_nan`.

#### Intended Effect:
Code cleanup.

#### How to Verify:
Look at diff.

#### Side Effects:
None.

#### Documentation:
None.

#### Reviewer Suggestions: 
Anyone.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
