### PR TITLE
Remove bool returns from check functions

### DIFF
--- a/stan/math/prim/arr/err/check_matching_sizes.hpp
+++ b/stan/math/prim/arr/err/check_matching_sizes.hpp
@@ -8,7 +8,7 @@ namespace stan {
   namespace math {
 
     /**
-     * Return <code>true</code> if two structures at the same size.
+     * Check if two structures at the same size.
      *
      * This function only checks the runtime sizes for variables that
      * implement a <code>size()</code> method.
@@ -22,11 +22,10 @@ namespace stan {
      * @param name2 Second variable name (for error messages)
      * @param y2 Second variable
      *
-     * @return <code>true</code> if the sizes match
      * @throw <code>std::invalid_argument</code> if the sizes do not match
      */
     template <typename T_y1, typename T_y2>
-    inline bool check_matching_sizes(const char* function,
+    inline void check_matching_sizes(const char* function,
                                      const char* name1,
                                      const T_y1& y1,
                                      const char* name2,
@@ -34,7 +33,6 @@ namespace stan {
       check_size_match(function,
                        "size of ", name1, y1.size(),
                        "size of ", name2, y2.size());
-      return true;
     }
 
   }

--- a/stan/math/prim/arr/err/check_nonzero_size.hpp
+++ b/stan/math/prim/arr/err/check_nonzero_size.hpp
@@ -8,7 +8,7 @@ namespace stan {
   namespace math {
 
     /**
-     * Return <code>true</code> if the specified matrix/vector is of
+     * Check if the specified matrix/vector is of
      * non-zero size.
      *
      * Throws a std:invalid_argument otherwise. The message
@@ -20,22 +20,19 @@ namespace stan {
      * @param name Variable name (for error messages)
      * @param y Container to test. This will accept matrices and vectors
      *
-     * @return <code>true</code> if the the specified matrix/vector is
-     * of non-zero size
      * @throw <code>std::invalid_argument</code> if the specified matrix/vector
      *   has zero size
      */
     template <typename T_y>
-    inline bool check_nonzero_size(const char* function,
+    inline void check_nonzero_size(const char* function,
                                    const char* name,
                                    const T_y& y) {
       if (y.size() > 0)
-        return true;
+        return;
 
       invalid_argument(function, name, 0,
                        "has size ",
                        ", but must have a non-zero size");
-      return false;
     }
 
   }

--- a/stan/math/prim/arr/err/check_ordered.hpp
+++ b/stan/math/prim/arr/err/check_ordered.hpp
@@ -12,7 +12,7 @@ namespace stan {
   namespace math {
 
     /**
-     * Return <code>true</code> if the specified vector is sorted into
+     * Check if the specified vector is sorted into
      * strictly increasing order.
      *
      * @tparam T_y Type of scalar
@@ -21,17 +21,16 @@ namespace stan {
      * @param name Variable name (for error messages)
      * @param y <code>std::vector</code> to test
      *
-     * @return <code>true</code> if the vector is ordered
      * @throw <code>std::domain_error</code> if the vector elements are
      *   not ordered, if there are duplicated
      *   values, or if any element is <code>NaN</code>.
      */
     template <typename T_y>
-    bool check_ordered(const char* function,
+    void check_ordered(const char* function,
                        const char* name,
                        const std::vector<T_y>& y) {
       if (y.size() == 0)
-        return true;
+        return;
 
       for (size_t n = 1; n < y.size(); n++) {
         if (!(y[n] > y[n-1])) {
@@ -46,10 +45,8 @@ namespace stan {
           std::string msg2_str(msg2.str());
           domain_error(function, name, y[n],
                        msg1_str.c_str(), msg2_str.c_str());
-          return false;
         }
       }
-      return true;
     }
   }
 }

--- a/stan/math/prim/arr/err/check_ordered.hpp
+++ b/stan/math/prim/arr/err/check_ordered.hpp
@@ -29,9 +29,6 @@ namespace stan {
     void check_ordered(const char* function,
                        const char* name,
                        const std::vector<T_y>& y) {
-      if (y.size() == 0)
-        return;
-
       for (size_t n = 1; n < y.size(); n++) {
         if (!(y[n] > y[n-1])) {
           std::ostringstream msg1;

--- a/stan/math/prim/mat/err/check_cholesky_factor.hpp
+++ b/stan/math/prim/mat/err/check_cholesky_factor.hpp
@@ -9,7 +9,7 @@
 namespace stan {
   namespace math {
     /**
-     * Return <code>true</code> if the specified matrix is a valid
+     * Check if the specified matrix is a valid
      * Cholesky factor.
      *
      * A Cholesky factor is a lower triangular matrix whose diagonal
@@ -23,19 +23,15 @@ namespace stan {
      * @param name Variable name (for error messages)
      * @param y Matrix to test
      *
-     * @return <code>true</code> if the matrix is a valid Cholesky factor
-     * @throw <code>std::domain_error</code> if y is not a valid Choleksy factor,
-     *   if number of rows is less than the number of columns,
-     *   if there are 0 columns,
-     *   or if any element in matrix is NaN
+     * @throw <code>std::domain_error</code> if y is not a valid Choleksy
+     *   factor, if number of rows is less than the number of columns,
+     *   if there are 0 columns, or if any element in matrix is NaN
      */
     template <typename T_y>
-    inline bool
-    check_cholesky_factor(
-      const char* function,
-      const char* name,
-      const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>& y
-    ) {
+    inline void
+    check_cholesky_factor(const char* function,
+                          const char* name,
+                  const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>& y) {
       check_less_or_equal(function, "columns and rows of Cholesky factor",
                           y.cols(), y.rows());
       check_positive(function, "columns of Cholesky factor", y.cols());
@@ -43,7 +39,6 @@ namespace stan {
       for (int i = 0; i < y.cols(); ++i)
         // FIXME:  should report row
         check_positive(function, name, y(i, i));
-      return true;
     }
 
   }

--- a/stan/math/prim/mat/err/check_cholesky_factor_corr.hpp
+++ b/stan/math/prim/mat/err/check_cholesky_factor_corr.hpp
@@ -11,7 +11,7 @@
 namespace stan {
   namespace math {
     /**
-     * Return <code>true</code> if the specified matrix is a valid
+     * Check if the specified matrix is a valid
      * Cholesky factor of a correlation matrix.
      *
      * A Cholesky factor is a lower triangular matrix whose diagonal
@@ -26,20 +26,15 @@ namespace stan {
      * @param function Function name (for error messages)
      * @param name Variable name (for error messages)
      * @param y Matrix to test
-     * @return <code>true</code> if the matrix is a valid Cholesky factor
-     *   of a correlation matrix
-     * @throw <code>std::domain_error</code> if y is not a valid Choleksy factor,
-     *   if number of rows is less than the number of columns,
-     *   if there are 0 columns,
-     *   or if any element in matrix is NaN
+     * @throw <code>std::domain_error</code> if y is not a valid Choleksy
+     *   factor, if number of rows is less than the number of columns,
+     *   if there are 0 columns, or if any element in matrix is NaN
      */
     template <typename T_y>
-    bool
-    check_cholesky_factor_corr(
-      const char* function,
-      const char* name,
-      const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>& y
-    ) {
+    void
+    check_cholesky_factor_corr(const char* function,
+                               const char* name,
+                  const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>& y) {
       using Eigen::Dynamic;
       check_square(function, name, y);
       check_lower_triangular(function, name, y);
@@ -50,7 +45,6 @@ namespace stan {
           y_i = y.row(i).transpose();
         check_unit_vector(function, name, y_i);
       }
-      return true;
     }
 
   }

--- a/stan/math/prim/mat/err/check_column_index.hpp
+++ b/stan/math/prim/mat/err/check_column_index.hpp
@@ -11,7 +11,7 @@ namespace stan {
   namespace math {
 
     /**
-     * Return <code>true</code> if the specified index is a valid
+     * Check if the specified index is a valid
      * column of the matrix.
      *
      * By default, this is a 1-indexed check (as opposed to
@@ -29,27 +29,21 @@ namespace stan {
      * @param y Matrix
      * @param i Index to check
      *
-     * @return <code>true</code> if the index is a valid column index
-     *   of the matrix.
      * @throw std::out_of_range if index is an invalid column index
      */
     template <typename T_y, int R, int C>
-    inline bool check_column_index(const char* function,
+    inline void check_column_index(const char* function,
                                    const char* name,
                                    const Eigen::Matrix<T_y, R, C>& y,
                                    const size_t i) {
       if (i >= stan::error_index::value
           && i < static_cast<size_t>(y.cols()) + stan::error_index::value)
-        return true;
+        return;
 
       std::stringstream msg;
       msg << " for columns of " << name;
       std::string msg_str(msg.str());
-      out_of_range(function,
-                   y.cols(),
-                   i,
-                   msg_str.c_str());
-      return false;
+      out_of_range(function, y.cols(), i, msg_str.c_str());
     }
 
   }

--- a/stan/math/prim/mat/err/check_corr_matrix.hpp
+++ b/stan/math/prim/mat/err/check_corr_matrix.hpp
@@ -17,7 +17,7 @@ namespace stan {
   namespace math {
 
     /**
-     * Return <code>true</code> if the specified matrix is a valid
+     * Check if the specified matrix is a valid
      * correlation matrix.
      *
      * A valid correlation matrix is symmetric, has a unit diagonal
@@ -33,8 +33,6 @@ namespace stan {
      * @param name Name of the variable
      * @param y Matrix to test
      *
-     * @return <code>true</code> if the specified matrix is a valid
-     * correlation matrix
      * @throw <code>std::invalid_argument</code> if the matrix is not square
      *   or if the matrix is 0x0
      * @throw <code>std::domain_error</code> if the matrix is non-symmetric,
@@ -42,9 +40,9 @@ namespace stan {
      *   elements nan.
      */
     template <typename T_y>
-    inline bool
+    inline void
     check_corr_matrix(const char* function,
-        const char* name,
+                      const char* name,
         const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>& y) {
       using Eigen::Matrix;
 
@@ -68,11 +66,9 @@ namespace stan {
           domain_error(function, name, y(k, k),
                        msg_str.c_str(),
                        ", but should be near 1.0");
-          return false;
         }
       }
       check_pos_definite(function, "y", y);
-      return true;
     }
 
   }

--- a/stan/math/prim/mat/err/check_cov_matrix.hpp
+++ b/stan/math/prim/mat/err/check_cov_matrix.hpp
@@ -7,7 +7,7 @@
 namespace stan {
   namespace math {
     /**
-     * Return <code>true</code> if the specified matrix is a valid
+     * Check if the specified matrix is a valid
      * covariance matrix.
      *
      * A valid covariance matrix is a square, symmetric matrix that is
@@ -19,7 +19,6 @@ namespace stan {
      * @param name Variable name (for error messages)
      * @param y Matrix to test
      *
-     * @return <code>true</code> if the matrix is a valid covariance matrix
      * @throw <code>std::invalid_argument</code> if the matrix is not square
      *   or if the matrix is 0x0
      * @throw <code>std::domain_error</code> if the matrix is not symmetric,
@@ -27,14 +26,11 @@ namespace stan {
      *   or if any element of the matrix is nan
      */
     template <typename T_y>
-    inline bool
-    check_cov_matrix(
-      const char* function,
-      const char* name,
-      const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>& y
-    ) {
+    inline void
+    check_cov_matrix(const char* function,
+                     const char* name,
+                  const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>& y) {
       check_pos_definite(function, name, y);
-      return true;
     }
 
   }

--- a/stan/math/prim/mat/err/check_ldlt_factor.hpp
+++ b/stan/math/prim/mat/err/check_ldlt_factor.hpp
@@ -11,7 +11,7 @@ namespace stan {
   namespace math {
 
     /**
-     * Return <code>true</code> if the argument is a valid
+     * Check if the argument is a valid
      * <code>LDLT_factor</code>.
      *
      * <code>LDLT_factor</code> can be constructed in an invalid
@@ -26,12 +26,11 @@ namespace stan {
      * @param name Variable name (for error messages)
      * @param A <code>LDLT_factor</code> to check for validity.
      *
-     * @return <code>true</code> if the matrix is positive definite.
-     * @return throws <code>std::domain_error</code> the LDLT_factor was
+     * @throws <code>std::domain_error</code> the LDLT_factor was
      *   created improperly (A.success() == false)
      */
     template <typename T, int R, int C>
-    inline bool check_ldlt_factor(const char* function,
+    inline void check_ldlt_factor(const char* function,
                                   const char* name,
                                   LDLT_factor<T, R, C> &A) {
       if (!A.success()) {
@@ -42,9 +41,7 @@ namespace stan {
         const T too_small = A.vectorD().tail(1)(0);
         domain_error(function, name, too_small,
                      msg_str.c_str(), ".");
-        return false;
       }
-      return true;
     }
 
   }

--- a/stan/math/prim/mat/err/check_lower_triangular.hpp
+++ b/stan/math/prim/mat/err/check_lower_triangular.hpp
@@ -10,7 +10,7 @@
 namespace stan {
   namespace math {
     /**
-     * Return <code>true</code> if the specified matrix is lower
+     * Check if the specified matrix is lower
      * triangular.
      *
      * A matrix x is not lower triangular if there is a non-zero entry
@@ -23,18 +23,15 @@ namespace stan {
      * @param name Variable name (for error messages)
      * @param y Matrix to test
      *
-     * @return <code>true</code> if the matrix is lower triangular.
      * @throw <code>std::domain_error</code> if the matrix is not
      *   lower triangular or if any element in the upper triangular
      *   portion is NaN
      */
     template <typename T_y>
-    inline bool
-    check_lower_triangular(
-      const char* function,
-      const char* name,
-      const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>& y
-    ) {
+    inline void
+    check_lower_triangular(const char* function,
+                           const char* name,
+                  const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>& y) {
       for (int n = 1; n < y.cols(); ++n) {
         for (int m = 0; m < n && m < y.rows(); ++m) {
           if (y(m, n) != 0) {
@@ -45,11 +42,9 @@ namespace stan {
             std::string msg_str(msg.str());
             domain_error(function, name, y(m, n),
                          msg_str.c_str());
-            return false;
           }
         }
       }
-      return true;
     }
 
   }

--- a/stan/math/prim/mat/err/check_matching_dims.hpp
+++ b/stan/math/prim/mat/err/check_matching_dims.hpp
@@ -10,7 +10,7 @@ namespace stan {
   namespace math {
 
     /**
-     * Return <code>true</code> if the two matrices are of the same size.
+     * Check if the two matrices are of the same size.
      *
      * This function checks not only the runtime sizes, but the static
      * sizes as well. For example, a 4x1 matrix is not the same as a vector
@@ -29,12 +29,11 @@ namespace stan {
      * @param name2 Variable name for the second matrix (for error messages)
      * @param y2 Second matrix
      *
-     * @return <code>true</code> if the dimensions of the two matrices match
      * @throw <code>std::invalid_argument</code> if the dimensions of the matrices
      *   do not match
      */
     template <typename T1, typename T2, int R1, int C1, int R2, int C2>
-    inline bool check_matching_dims(const char* function,
+    inline void check_matching_dims(const char* function,
                                     const char* name1,
                                     const Eigen::Matrix<T1, R1, C1>& y1,
                                     const char* name2,
@@ -45,7 +44,6 @@ namespace stan {
       check_size_match(function,
                        "Columns of ", name1, y1.cols(),
                        "columns of ", name2, y2.cols());
-      return true;
     }
 
   }

--- a/stan/math/prim/mat/err/check_multiplicable.hpp
+++ b/stan/math/prim/mat/err/check_multiplicable.hpp
@@ -9,7 +9,7 @@ namespace stan {
   namespace math {
 
     /**
-     * Return <code>true</code> if the matrices can be multiplied.
+     * Check if the matrices can be multiplied.
      *
      * This checks the runtime sizes to determine whether the two
      * matrices are multiplicable. This allows Eigen matrices,
@@ -24,12 +24,11 @@ namespace stan {
      * @param name2 Variable name for the second matrix (for error messages)
      * @param y2 Second matrix
      *
-     * @return <code>true</code> if the two matrices are multiplicable
      * @throw <code>std::invalid_argument</code> if the matrices are not
      *   multiplicable or if either matrix is size 0 for either rows or columns
      */
     template <typename T1, typename T2>
-    inline bool check_multiplicable(const char* function,
+    inline void check_multiplicable(const char* function,
                                     const char* name1,
                                     const T1& y1,
                                     const char* name2,
@@ -40,7 +39,6 @@ namespace stan {
                        "Columns of ", name1, y1.cols(),
                        "Rows of ", name2, y2.rows());
       check_positive_size(function, name1, "cols()", y1.cols());
-      return true;
     }
   }
 }

--- a/stan/math/prim/mat/err/check_ordered.hpp
+++ b/stan/math/prim/mat/err/check_ordered.hpp
@@ -13,7 +13,7 @@ namespace stan {
   namespace math {
 
     /**
-     * Return <code>true</code> if the specified vector is sorted into
+     * Check if the specified vector is sorted into
      * strictly increasing order.
      *
      * @tparam T_y Type of scalar
@@ -22,13 +22,12 @@ namespace stan {
      * @param name Variable name (for error messages)
      * @param y Vector to test
      *
-     * @return <code>true</code> if the vector is ordered
      * @throw <code>std::domain_error</code> if the vector elements are
      *   not ordered, if there are duplicated
      *   values, or if any element is <code>NaN</code>.
      */
     template <typename T_y>
-    bool check_ordered(const char* function,
+    void check_ordered(const char* function,
                        const char* name,
                        const Eigen::Matrix<T_y, Eigen::Dynamic, 1>& y) {
       using Eigen::Dynamic;
@@ -37,7 +36,7 @@ namespace stan {
       typedef typename index_type<Matrix<T_y, Dynamic, 1> >::type size_t;
 
       if (y.size() == 0)
-        return true;
+        return;
 
       for (size_t n = 1; n < y.size(); n++) {
         if (!(y[n] > y[n-1])) {
@@ -52,10 +51,8 @@ namespace stan {
           std::string msg2_str(msg2.str());
           domain_error(function, name, y[n],
                        msg1_str.c_str(), msg2_str.c_str());
-          return false;
         }
       }
-      return true;
     }
 
   }

--- a/stan/math/prim/mat/err/check_ordered.hpp
+++ b/stan/math/prim/mat/err/check_ordered.hpp
@@ -35,9 +35,6 @@ namespace stan {
 
       typedef typename index_type<Matrix<T_y, Dynamic, 1> >::type size_t;
 
-      if (y.size() == 0)
-        return;
-
       for (size_t n = 1; n < y.size(); n++) {
         if (!(y[n] > y[n-1])) {
           std::ostringstream msg1;

--- a/stan/math/prim/mat/err/check_pos_definite.hpp
+++ b/stan/math/prim/mat/err/check_pos_definite.hpp
@@ -12,25 +12,25 @@
 #include <stan/math/prim/scal/err/check_positive_size.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/mat/fun/value_of_rec.hpp>
+
 namespace stan {
   namespace math {
 
     /**
-     * Return <code>true</code> if the specified square, symmetric
+     * Check if the specified square, symmetric
      * matrix is positive definite.
      *
      * @tparam T_y Type of scalar of the matrix
      * @param function Function name (for error messages)
      * @param name Variable name (for error messages)
      * @param y Matrix to test
-     * @return <code>true</code> if the matrix is positive definite
      * @throw <code>std::invalid_argument</code> if the matrix is not square
      * or if the matrix has 0 size.
      * @throw <code>std::domain_error</code> if the matrix is not symmetric,
      * if it is not positive definite, or if any element is <code>NaN</code>.
      */
     template <typename T_y>
-    inline bool check_pos_definite(const char* function, const char* name,
+    inline void check_pos_definite(const char* function, const char* name,
                                    const Eigen::Matrix<T_y, -1, -1>& y) {
       check_symmetric(function, name, y);
       check_positive_size(function, name, "rows", y.rows());
@@ -43,11 +43,10 @@ namespace stan {
           || (cholesky.vectorD().array() <= 0.0).any())
         domain_error(function, name, "is not positive definite.", "");
       check_not_nan(function, name, y);
-      return true;
     }
 
     /**
-     * Return <code>true</code> if the specified LDLT transform of a matrix
+     * Check if the specified LDLT transform of a matrix
      * is positive definite.
      *
      * @tparam Derived Derived type of the Eigen::LDLT transform.
@@ -55,22 +54,20 @@ namespace stan {
      * @param name Variable name (for error messages)
      * @param cholesky Eigen::LDLT to test, whose progenitor 
      * must not have any NaN elements
-     * @return <code>true</code> if the matrix is positive definite
      * @throw <code>std::domain_error</code> if the matrix is not
      * positive definite.
      */
     template <typename Derived>
-    inline bool check_pos_definite(const char* function, const char* name,
+    inline void check_pos_definite(const char* function, const char* name,
                                    const Eigen::LDLT<Derived>& cholesky) {
       if (cholesky.info() != Eigen::Success
           || !cholesky.isPositive()
           || !(cholesky.vectorD().array() > 0.0).all())
         domain_error(function, "LDLT decomposition of", " failed", name);
-      return true;
     }
 
     /**
-     * Return <code>true</code> if the specified LLT decomposition 
+     * Check if the specified LLT decomposition 
      * transform resulted in <code>Eigen::Success</code>
      *
      * @tparam Derived Derived type of the Eigen::LLT transform.
@@ -80,17 +77,15 @@ namespace stan {
      * @param cholesky Eigen::LLT to test, whose progenitor 
      * must not have any NaN elements
      *
-     * @return <code>true</code> if the matrix is positive definite
      * @throw <code>std::domain_error</code> if the diagonal of the
      * L matrix is not positive.
      */
     template <typename Derived>
-    inline bool check_pos_definite(const char* function, const char* name,
+    inline void check_pos_definite(const char* function, const char* name,
                                    const Eigen::LLT<Derived>& cholesky) {
       if (cholesky.info() != Eigen::Success
           || !(cholesky.matrixLLT().diagonal().array() > 0.0).all())
         domain_error(function, "Matrix", " is not positive definite", name);
-      return true;
     }
 
   }

--- a/stan/math/prim/mat/err/check_pos_semidefinite.hpp
+++ b/stan/math/prim/mat/err/check_pos_semidefinite.hpp
@@ -13,8 +13,9 @@
 
 namespace stan {
   namespace math {
+
     /**
-     * Return <code>true</code> if the specified matrix is positive definite
+     * Check if the specified matrix is positive definite
      *
      * @tparam T_y scalar type of the matrix
      *
@@ -22,7 +23,6 @@ namespace stan {
      * @param name Variable name (for error messages)
      * @param y Matrix to test
      *
-     * @return <code>true</code> if the matrix is positive semi-definite.
      * @throw <code>std::invalid_argument</code> if the matrix is not square
      *   or if the matrix has 0 size.
      * @throw <code>std::domain_error</code> if the matrix is not symmetric,
@@ -30,12 +30,10 @@ namespace stan {
      *   or if any element of the matrix is <code>NaN</code>.
      */
     template <typename T_y>
-    inline bool
-    check_pos_semidefinite(
-      const char* function,
-      const char* name,
-      const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>& y
-    ) {
+    inline void
+    check_pos_semidefinite(const char* function,
+                           const char* name,
+                  const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>& y) {
       check_symmetric(function, name, y);
       check_positive_size(function, name, "rows", y.rows());
 
@@ -51,7 +49,6 @@ namespace stan {
           || (cholesky.vectorD().array() < 0.0).any())
         domain_error(function, name, "is not positive semi-definite.", "");
       check_not_nan(function, name, y);
-      return true;
     }
 
   }

--- a/stan/math/prim/mat/err/check_positive_ordered.hpp
+++ b/stan/math/prim/mat/err/check_positive_ordered.hpp
@@ -5,7 +5,6 @@
 #include <stan/math/prim/mat/err/check_ordered.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/mat/meta/index_type.hpp>
-
 #include <sstream>
 #include <string>
 
@@ -13,7 +12,7 @@ namespace stan {
   namespace math {
 
     /**
-     * Return <code>true</code> if the specified vector contains
+     * Check if the specified vector contains
      * non-negative values and is sorted into strictly increasing
      * order.
      *
@@ -21,22 +20,21 @@ namespace stan {
      * @param name Variable name (for error messages)
      * @param y Vector to test
      *
-     * @return <code>true</code> if the vector is positive, ordered
      * @throw <code>std::domain_error</code> if the vector contains non-positive
      *   values, if the values are not ordered, if there are duplicated
      *   values, or if any element is <code>NaN</code>.
      */
     template <typename T_y>
-    bool
+    void
     check_positive_ordered(const char* function,
                            const char* name,
                            const Eigen::Matrix<T_y, Eigen::Dynamic, 1>& y) {
       using Eigen::Dynamic;
       using Eigen::Matrix;
 
-      if (y.size() == 0) {
-        return true;
-      }
+      if (y.size() == 0)
+        return;
+
       if (y[0] < 0) {
         std::ostringstream msg;
         msg << "is not a valid positive_ordered vector."
@@ -45,10 +43,8 @@ namespace stan {
         std::string msg_str(msg.str());
         domain_error(function, name, y[0],
                      msg_str.c_str(), ", but should be postive.");
-        return false;
       }
       check_ordered(function, name, y);
-      return true;
     }
   }
 }

--- a/stan/math/prim/mat/err/check_range.hpp
+++ b/stan/math/prim/mat/err/check_range.hpp
@@ -11,7 +11,7 @@ namespace stan {
   namespace math {
 
     /**
-     * Return <code>true</code> if specified index is within range.
+     * Check if specified index is within range.
      *
      * This check is 1-indexed by default. This behavior can be
      * changed by setting <code>stan::error_index::value</code>.
@@ -23,10 +23,9 @@ namespace stan {
      * @param nested_level Nested level (for error messages)
      * @param error_msg Additional error message (for error messages)
      *
-     * @return <code>true</code> if the index is within range
      * @throw <code>std::out_of_range</code> if the index is not in range
      */
-    inline bool check_range(const char* function,
+    inline void check_range(const char* function,
                             const char* name,
                             const int max,
                             const int index,
@@ -34,18 +33,17 @@ namespace stan {
                             const char* error_msg) {
       if ((index >= stan::error_index::value)
           && (index < max + stan::error_index::value))
-        return true;
+        return;
 
       std::stringstream msg;
       msg << "; index position = " << nested_level;
       std::string msg_str(msg.str());
 
       out_of_range(function, max, index, msg_str.c_str(), error_msg);
-      return false;
     }
 
     /**
-     * Return <code>true</code> if specified index is within range.
+     * Check if specified index is within range.
      *
      * This check is 1-indexed by default. This behavior can be
      * changed by setting <code>stan::error_index::value</code>.
@@ -56,24 +54,22 @@ namespace stan {
      * @param index Index to check
      * @param error_msg Additional error message (for error messages)
      *
-     * @return <code>true</code> if the index is within range
      * @throw <code>std::out_of_range</code> if the index is not in range
      */
-    inline bool check_range(const char* function,
+    inline void check_range(const char* function,
                             const char* name,
                             const int max,
                             const int index,
                             const char* error_msg) {
       if ((index >= stan::error_index::value)
           && (index < max + stan::error_index::value))
-        return true;
+        return;
 
       out_of_range(function, max, index, error_msg);
-      return false;
     }
 
     /**
-     * Return <code>true</code> if specified index is within range.
+     * Check if specified index is within range.
      *
      * This check is 1-indexed by default. This behavior can be
      * changed by setting <code>stan::error_index::value</code>.
@@ -83,19 +79,17 @@ namespace stan {
      * @param max Maximum size of the variable
      * @param index Index to check
      *
-     * @return <code>true</code> if the index is within range
      * @throw <code>std::out_of_range</code> if the index is not in range
      */
-    inline bool check_range(const char* function,
+    inline void check_range(const char* function,
                             const char* name,
                             const int max,
                             const int index) {
       if ((index >= stan::error_index::value)
           && (index < max + stan::error_index::value))
-        return true;
+        return;
 
       out_of_range(function, max, index);
-      return false;
     }
 
   }

--- a/stan/math/prim/mat/err/check_row_index.hpp
+++ b/stan/math/prim/mat/err/check_row_index.hpp
@@ -3,7 +3,6 @@
 
 #include <stan/math/prim/scal/err/out_of_range.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
-
 #include <sstream>
 #include <string>
 
@@ -11,7 +10,7 @@ namespace stan {
   namespace math {
 
     /**
-     * Return <code>true</code> if the specified index is a valid row of the matrix
+     * Check if the specified index is a valid row of the matrix
      *
      * This check is 1-indexed by default. This behavior can be changed
      * by setting <code>stan::error_index::value</code>.
@@ -25,26 +24,21 @@ namespace stan {
      * @param y Matrix to test
      * @param i is index
      *
-     * @return <code>true</code> if the index is a valid row index in the matrix
      * @throw <code>std::out_of_range</code> if the index is out of range.
      */
     template <typename T_y, int R, int C>
-    inline bool check_row_index(const char* function,
+    inline void check_row_index(const char* function,
                                 const char* name,
                                 const Eigen::Matrix<T_y, R, C>& y,
                                 size_t i) {
       if (i >= stan::error_index::value
           && i < static_cast<size_t>(y.rows()) + stan::error_index::value)
-        return true;
+        return;
 
       std::stringstream msg;
       msg << " for rows of " << name;
       std::string msg_str(msg.str());
-      out_of_range(function,
-                   y.rows(),
-                   i,
-                   msg_str.c_str());
-      return false;
+      out_of_range(function, y.rows(), i, msg_str.c_str());
     }
 
   }

--- a/stan/math/prim/mat/err/check_simplex.hpp
+++ b/stan/math/prim/mat/err/check_simplex.hpp
@@ -14,7 +14,7 @@ namespace stan {
   namespace math {
 
     /**
-     * Return <code>true</code> if the specified vector is simplex.
+     * Check if the specified vector is simplex.
      * To be a simplex, all values must be greater than or equal to 0
      * and the values must sum to 1.
      *
@@ -30,14 +30,13 @@ namespace stan {
      * @param name Variable name (for error messages)
      * @param theta Vector to test.
      *
-     * @return <code>true</code> if the vector is a simplex
      * @throw <code>std::invalid_argument</code> if <code>theta</code>
      *   is a 0-vector.
      * @throw <code>std::domain_error</code> if the vector is not a
      *   simplex or if any element is <code>NaN</code>.
      */
     template <typename T_prob>
-    bool check_simplex(const char* function,
+    void check_simplex(const char* function,
                        const char* name,
                        const Eigen::Matrix<T_prob, Eigen::Dynamic, 1>& theta) {
       using Eigen::Dynamic;
@@ -56,7 +55,6 @@ namespace stan {
         std::string msg_str(msg.str());
         domain_error(function, name, 1.0,
                      msg_str.c_str());
-        return false;
       }
       for (size_t n = 0; n < theta.size(); n++) {
         if (!(theta[n] >= 0)) {
@@ -68,10 +66,8 @@ namespace stan {
           domain_error(function, name, theta[n],
                        msg_str.c_str(),
                        ", but should be greater than or equal to 0");
-          return false;
         }
       }
-      return true;
     }
   }
 }

--- a/stan/math/prim/mat/err/check_spsd_matrix.hpp
+++ b/stan/math/prim/mat/err/check_spsd_matrix.hpp
@@ -10,7 +10,7 @@
 namespace stan {
   namespace math {
     /**
-     * Return <code>true</code> if the specified matrix is a
+     * Check if the specified matrix is a
      * square, symmetric, and positive semi-definite.
      *
      * @tparam T Scalar type of the matrix
@@ -19,25 +19,20 @@ namespace stan {
      * @param name Variable name (for error messages)
      * @param y Matrix to test
      *
-     * @return <code>true</code> if the matrix is a square, symmetric,
-     *   and positive semi-definite.
      * @throw <code>std::invalid_argument</code> if the matrix is not square
      *   or if the matrix is 0x0
      * @throw <code>std::domain_error</code> if the matrix is not symmetric
      *   or if the matrix is not positive semi-definite
      */
     template <typename T_y>
-    inline bool
-    check_spsd_matrix(
-      const char* function,
-      const char* name,
-      const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>& y
-    ) {
+    inline void
+    check_spsd_matrix(const char* function,
+                      const char* name,
+                  const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>& y) {
       check_square(function, name, y);
       check_positive_size(function, name, "rows()", y.rows());
       check_symmetric(function, name, y);
       check_pos_semidefinite(function, name, y);
-      return true;
     }
 
   }

--- a/stan/math/prim/mat/err/check_square.hpp
+++ b/stan/math/prim/mat/err/check_square.hpp
@@ -9,7 +9,7 @@ namespace stan {
   namespace math {
 
     /**
-     * Return <code>true</code> if the specified matrix is square.
+     * Check if the specified matrix is square.
      *
      * This check allows 0x0 matrices.
      *
@@ -19,19 +19,17 @@ namespace stan {
      * @param name Variable name (for error messages)
      * @param y Matrix to test
      *
-     * @return <code>true</code> if the matrix is a square matrix.
      * @throw <code>std::invalid_argument</code> if the matrix
      *    is not square
      */
     template <typename T_y>
-    inline bool
+    inline void
     check_square(const char* function,
                  const char* name,
                  const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>& y) {
       check_size_match(function,
                        "Expecting a square matrix; rows of ", name, y.rows(),
                        "columns of ", name, y.cols());
-      return true;
     }
 
   }

--- a/stan/math/prim/mat/err/check_std_vector_index.hpp
+++ b/stan/math/prim/mat/err/check_std_vector_index.hpp
@@ -11,7 +11,7 @@ namespace stan {
   namespace math {
 
     /**
-     * Return <code>true</code> if the specified index is valid in std vector
+     * Check if the specified index is valid in std vector
      *
      * This check is 1-indexed by default. This behavior can be changed
      * by setting <code>stan::error_index::value</code>.
@@ -23,23 +23,21 @@ namespace stan {
      * @param y <code>std::vector</code> to test
      * @param i Index
      *
-     * @return <code>true</code> if the index is a valid in std vector.
      * @throw <code>std::out_of_range</code> if the index is out of range.
      */
     template <typename T>
-    inline bool check_std_vector_index(const char* function,
+    inline void check_std_vector_index(const char* function,
                                        const char* name,
                                        const std::vector<T>& y,
                                        int i) {
       if (i >= static_cast<int>(stan::error_index::value)
           && i < static_cast<int>(y.size() + stan::error_index::value))
-        return true;
+        return;
 
       std::stringstream msg;
       msg << " for " << name;
       std::string msg_str(msg.str());
       out_of_range(function, y.size(), i, msg_str.c_str());
-      return false;
     }
 
   }

--- a/stan/math/prim/mat/err/check_symmetric.hpp
+++ b/stan/math/prim/mat/err/check_symmetric.hpp
@@ -15,7 +15,7 @@ namespace stan {
   namespace math {
 
     /**
-     * Return <code>true</code> if the specified matrix is symmetric.
+     * Check if the specified matrix is symmetric.
      *
      * The error message is either 0 or 1 indexed, specified by
      * <code>stan::error_index::value</code>.
@@ -26,18 +26,15 @@ namespace stan {
      * @param name Variable name (for error messages)
      * @param y Matrix to test
      *
-     * @return <code>true</code> if the matrix is symmetric
      * @throw <code>std::invalid_argument</code> if the matrix is not square.
      * @throw <code>std::domain_error</code> if any element not on the
      *   main diagonal is <code>NaN</code>
      */
     template <typename T_y>
-    inline bool
-    check_symmetric(
-      const char* function,
-      const char* name,
-      const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>& y
-    ) {
+    inline void
+    check_symmetric(const char* function,
+                    const char* name,
+                  const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>& y) {
       check_square(function, name, y);
 
       using Eigen::Matrix;
@@ -49,7 +46,7 @@ namespace stan {
 
       size_type k = y.rows();
       if (k == 1)
-        return true;
+        return;
       for (size_type m = 0; m < k; ++m) {
         for (size_type n = m + 1; n < k; ++n) {
           if (!(fabs(value_of(y(m, n)) - value_of(y(n, m)))
@@ -67,11 +64,9 @@ namespace stan {
             std::string msg2_str(msg2.str());
             domain_error(function, name, y(m, n),
                          msg1_str.c_str(), msg2_str.c_str());
-            return false;
           }
         }
       }
-      return true;
     }
 
   }

--- a/stan/math/prim/mat/err/check_unit_vector.hpp
+++ b/stan/math/prim/mat/err/check_unit_vector.hpp
@@ -11,7 +11,7 @@
 namespace stan {
   namespace math {
     /**
-     * Return <code>true</code> if the specified vector is unit vector.
+     * Check if the specified vector is unit vector.
      *
      * A valid unit vector is one where the square of the elements
      * summed is equal to 1. This function tests that the sum is within the
@@ -25,14 +25,13 @@ namespace stan {
      * @param name Variable name (for error messages)
      * @param theta Vector to test.
      *
-     * @return <code>true</code> if the vector is a unit vector.
      * @throw <code>std::invalid_argument</code> if <code>theta</code>
      *   is a 0-vector.
      * @throw <code>std::domain_error</code> if the vector is not a unit
      *   vector or if any element is <code>NaN</code>.
      */
     template <typename T_prob>
-    bool check_unit_vector(const char* function,
+    void check_unit_vector(const char* function,
                            const char* name,
                            const Eigen::Matrix<T_prob,
                              Eigen::Dynamic, 1>& theta) {
@@ -45,7 +44,6 @@ namespace stan {
         std::string msg_str(msg.str());
         domain_error(function, name, ssq, msg_str.c_str());
       }
-      return true;
     }
 
   }

--- a/stan/math/prim/mat/err/check_vector.hpp
+++ b/stan/math/prim/mat/err/check_vector.hpp
@@ -1,7 +1,6 @@
 #ifndef STAN_MATH_PRIM_MAT_ERR_CHECK_VECTOR_HPP
 #define STAN_MATH_PRIM_MAT_ERR_CHECK_VECTOR_HPP
 
-#include <stan/math/prim/scal/meta/return_type.hpp>
 #include <stan/math/prim/scal/meta/scalar_type.hpp>
 #include <stan/math/prim/scal/err/invalid_argument.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
@@ -12,7 +11,7 @@ namespace stan {
   namespace math {
 
     /**
-     * Return <code>true</code> if the matrix is either a
+     * Check if the matrix is either a
      * row vector or column vector.
      *
      * This function checks the runtime size of the matrix to check
@@ -26,20 +25,19 @@ namespace stan {
      * @param name Variable name (for error messages)
      * @param x Matrix
      *
-     * @return <code>true</code> if x either has 1 columns or 1 rows
      * @throw <code>std::invalid_argument</code> if x is not a row or column
      *   vector.
      */
     template <typename T, int R, int C>
-    inline bool check_vector(const char* function,
+    inline void check_vector(const char* function,
                              const char* name,
                              const Eigen::Matrix<T, R, C>& x) {
       if (R == 1)
-        return true;
+        return;
       if (C == 1)
-        return true;
+        return;
       if (x.rows() == 1 || x.cols() == 1)
-        return true;
+        return;
 
       std::ostringstream msg;
       msg << ") has " << x.rows() << " rows and "
@@ -50,7 +48,6 @@ namespace stan {
                        name,
                        typename scalar_type<T>::type(),
                        "(", msg_str.c_str());
-      return false;
     }
 
   }

--- a/stan/math/prim/mat/prob/categorical_log.hpp
+++ b/stan/math/prim/mat/prob/categorical_log.hpp
@@ -32,14 +32,7 @@ namespace stan {
 
       T_prob lp = 0.0;
       check_bounded(function, "Number of categories", n, lb, theta.size());
-
-      if (!stan::is_constant_struct<T_prob>::value) {
-        if (!check_simplex(function, "Probabilities parameter", theta))
-          return lp;
-      } else {
-        if (!check_simplex(function, "Probabilities parameter", theta))
-          return lp;
-      }
+      check_simplex(function, "Probabilities parameter", theta);
 
       if (include_summand<propto, T_prob>::value)
         return log(theta(n-1));
@@ -73,13 +66,7 @@ namespace stan {
         check_bounded(function, "element of outcome array", ns[i],
                       lb, theta.size());
 
-      if (!stan::is_constant_struct<T_prob>::value) {
-        if (!check_simplex(function, "Probabilities parameter", theta))
-          return lp;
-      } else {
-        if (!check_simplex(function, "Probabilities parameter", theta))
-          return lp;
-      }
+      check_simplex(function, "Probabilities parameter", theta);
 
       if (!include_summand<propto, T_prob>::value)
         return 0.0;

--- a/stan/math/prim/mat/prob/categorical_log.hpp
+++ b/stan/math/prim/mat/prob/categorical_log.hpp
@@ -30,7 +30,6 @@ namespace stan {
 
       int lb = 1;
 
-      T_prob lp = 0.0;
       check_bounded(function, "Number of categories", n, lb, theta.size());
       check_simplex(function, "Probabilities parameter", theta);
 
@@ -61,7 +60,6 @@ namespace stan {
 
       int lb = 1;
 
-      T_prob lp = 0.0;
       for (size_t i = 0; i < ns.size(); ++i)
         check_bounded(function, "element of outcome array", ns[i],
                       lb, theta.size());

--- a/stan/math/prim/mat/prob/gaussian_dlm_obs_log.hpp
+++ b/stan/math/prim/mat/prob/gaussian_dlm_obs_log.hpp
@@ -23,6 +23,7 @@
 #include <stan/math/prim/mat/fun/transpose.hpp>
 #include <stan/math/prim/scal/fun/constants.hpp>
 #include <stan/math/prim/scal/meta/include_summand.hpp>
+#include <stan/math/prim/scal/meta/return_type.hpp>
 
 /*
   TODO: time-varying system matrices
@@ -30,7 +31,6 @@
   covariance.
   TODO: add constant terms in observation.
 */
-
 namespace stan {
   namespace math {
     /**

--- a/stan/math/prim/mat/prob/multi_normal_cholesky_log.hpp
+++ b/stan/math/prim/mat/prob/multi_normal_cholesky_log.hpp
@@ -19,6 +19,7 @@
 #include <stan/math/prim/scal/fun/constants.hpp>
 #include <stan/math/prim/scal/meta/max_size_mvt.hpp>
 #include <stan/math/prim/scal/meta/include_summand.hpp>
+#include <stan/math/prim/scal/meta/return_type.hpp>
 #include <boost/random/normal_distribution.hpp>
 #include <boost/random/variate_generator.hpp>
 

--- a/stan/math/prim/mat/prob/multi_normal_prec_log.hpp
+++ b/stan/math/prim/mat/prob/multi_normal_prec_log.hpp
@@ -24,6 +24,7 @@
 #include <stan/math/prim/scal/fun/constants.hpp>
 #include <stan/math/prim/scal/meta/max_size_mvt.hpp>
 #include <stan/math/prim/scal/meta/include_summand.hpp>
+#include <stan/math/prim/scal/meta/return_type.hpp>
 
 namespace stan {
   namespace math {

--- a/stan/math/prim/mat/prob/wishart_log.hpp
+++ b/stan/math/prim/mat/prob/wishart_log.hpp
@@ -73,14 +73,12 @@ namespace stan {
                        "columns of scale parameter", S.rows());
 
       LDLT_factor<T_y, Eigen::Dynamic, Eigen::Dynamic> ldlt_W(W);
-      if (!check_ldlt_factor(function, "LDLT_Factor of random variable",
-                             ldlt_W))
-        return lp;
+      check_ldlt_factor(function, "LDLT_Factor of random variable",
+                        ldlt_W);
 
       LDLT_factor<T_scale, Eigen::Dynamic, Eigen::Dynamic> ldlt_S(S);
-      if (!check_ldlt_factor(function, "LDLT_Factor of scale parameter",
-                             ldlt_S))
-        return lp;
+      check_ldlt_factor(function, "LDLT_Factor of scale parameter",
+                        ldlt_S);
 
       if (include_summand<propto, T_dof>::value)
         lp += nu * k * NEG_LOG_TWO_OVER_TWO;

--- a/stan/math/prim/scal/err/check_bounded.hpp
+++ b/stan/math/prim/scal/err/check_bounded.hpp
@@ -19,10 +19,9 @@ namespace stan {
       // be either scalar or vector
       //
       // throws if y, low, or high is nan
-      template <typename T_y, typename T_low, typename T_high,
-                bool y_is_vec>
+      template <typename T_y, typename T_low, typename T_high, bool y_is_vec>
       struct bounded {
-        static bool check(const char* function,
+        static void check(const char* function,
                           const char* name,
                           const T_y& y,
                           const T_low& low,
@@ -41,13 +40,12 @@ namespace stan {
                            "is ", msg_str.c_str());
             }
           }
-          return true;
         }
       };
 
       template <typename T_y, typename T_low, typename T_high>
       struct bounded<T_y, T_low, T_high, true> {
-        static bool check(const char* function,
+        static void check(const char* function,
                           const char* name,
                           const T_y& y,
                           const T_low& low,
@@ -67,13 +65,12 @@ namespace stan {
                                "is ", msg_str.c_str());
             }
           }
-          return true;
         }
       };
     }
 
     /**
-     * Return <code>true</code> if the value is between the low and high
+     * Check if the value is between the low and high
      * values, inclusively.
      *
      * @tparam T_y Type of value
@@ -86,19 +83,16 @@ namespace stan {
      * @param low Low bound
      * @param high High bound
      *
-     * @return <code>true</code> if the value is between low and high,
-     *   inclusively.
      * @throw <code>std::domain_error</code> otherwise. This also throws
      *   if any of the arguments are NaN.
      */
     template <typename T_y, typename T_low, typename T_high>
-    inline bool check_bounded(const char* function,
+    inline void check_bounded(const char* function,
                               const char* name,
                               const T_y& y,
                               const T_low& low,
                               const T_high& high) {
-      return detail::bounded<T_y, T_low, T_high,
-                             is_vector_like<T_y>::value>
+      detail::bounded<T_y, T_low, T_high, is_vector_like<T_y>::value>
         ::check(function, name, y, low, high);
     }
 

--- a/stan/math/prim/scal/err/check_consistent_size.hpp
+++ b/stan/math/prim/scal/err/check_consistent_size.hpp
@@ -10,7 +10,7 @@ namespace stan {
   namespace math {
 
     /**
-     * Return <code>true</code> if the dimension of x is consistent, which
+     * Check if the dimension of x is consistent, which
      * is defined to be <code>expected_size</code> if x is a vector or 1 if x
      * is not a vector.
      *
@@ -21,19 +21,17 @@ namespace stan {
      * @param x Variable to check for consistent size
      * @param expected_size Expected size if x is a vector
      *
-     * @return <code>true</code> if x is scalar or if x is vector-like and
-     *   has size of <code>expected_size</code>
      * @throw <code>invalid_argument</code> if the size is inconsistent
      */
     template <typename T>
-    inline bool check_consistent_size(const char* function,
+    inline void check_consistent_size(const char* function,
                                       const char* name,
                                       const T& x,
                                       size_t expected_size) {
       if (!is_vector<T>::value)
-        return true;
+        return;
       if (is_vector<T>::value && expected_size == stan::size_of(x))
-        return true;
+        return;
 
       std::stringstream msg;
       msg << ", expecting dimension = "
@@ -47,7 +45,6 @@ namespace stan {
       invalid_argument(function, name, stan::size_of(x),
                        "has dimension = ",
                        msg_str.c_str());
-      return false;
     }
 
   }

--- a/stan/math/prim/scal/err/check_consistent_sizes.hpp
+++ b/stan/math/prim/scal/err/check_consistent_sizes.hpp
@@ -9,7 +9,7 @@ namespace stan {
   namespace math {
 
     /**
-     * Return <code>true</code> if the dimension of x1 is consistent
+     * Check if the dimension of x1 is consistent
      * with x2.
      *
      * Consistent size is defined as having the same size if vector-like or
@@ -24,11 +24,10 @@ namespace stan {
      * @param name2 Variable name (for error messages)
      * @param x2 Variable to check for consistent size
      *
-     * @return <code>true</code> if x1 and x2 have consistent sizes
      * @throw <code>invalid_argument</code> if sizes are inconsistent
      */
     template <typename T1, typename T2>
-    inline bool check_consistent_sizes(const char* function,
+    inline void check_consistent_sizes(const char* function,
                                        const char* name1,
                                        const T1& x1,
                                        const char* name2,
@@ -36,12 +35,12 @@ namespace stan {
       using stan::is_vector;
       size_t max_size = std::max(is_vector<T1>::value * size_of(x1),
                                  is_vector<T2>::value * size_of(x2));
-      return check_consistent_size(function, name1, x1, max_size)
-        && check_consistent_size(function, name2, x2, max_size);
+      check_consistent_size(function, name1, x1, max_size);
+      check_consistent_size(function, name2, x2, max_size);
     }
 
     /**
-     * Return <code>true</code> if the dimension of x1, x2, and x3 are
+     * Check if the dimension of x1, x2, and x3 are
      * consistent.
      *
      * Consistent size is defined as having the same size if vector-like or
@@ -59,11 +58,10 @@ namespace stan {
      * @param name3 Variable name (for error messages)
      * @param x3 Variable to check for consistent size
      *
-     * @return <code>true</code> if x1, x2, and x3 have consistent sizes
      * @throw <code>invalid_argument</code> if sizes are inconsistent
      */
     template <typename T1, typename T2, typename T3>
-    inline bool check_consistent_sizes(const char* function,
+    inline void check_consistent_sizes(const char* function,
                                        const char* name1,
                                        const T1& x1,
                                        const char* name2,
@@ -73,13 +71,13 @@ namespace stan {
       size_t max_size = std::max(is_vector<T1>::value * size_of(x1),
                                  std::max(is_vector<T2>::value * size_of(x2),
                                           is_vector<T3>::value * size_of(x3)));
-      return check_consistent_size(function, name1, x1, max_size)
-        && check_consistent_size(function, name2, x2, max_size)
-        && check_consistent_size(function, name3, x3, max_size);
+      check_consistent_size(function, name1, x1, max_size);
+      check_consistent_size(function, name2, x2, max_size);
+      check_consistent_size(function, name3, x3, max_size);
     }
 
     /**
-     * Return <code>true</code> if the dimension of x1, x2, x3, and x4
+     * Check if the dimension of x1, x2, x3, and x4
      * are consistent.
      *
      * Consistent size is defined as having the same size if
@@ -100,11 +98,10 @@ namespace stan {
      * @param name4 Variable name (for error messages)
      * @param x4 Variable to check for consistent size
      *
-     * @return <code>true</code> if x1, x2, x3, and x4 have consistent sizes
      * @throw <code>invalid_argument</code> if sizes are inconsistent
      */
     template <typename T1, typename T2, typename T3, typename T4>
-    inline bool check_consistent_sizes(const char* function,
+    inline void check_consistent_sizes(const char* function,
                                        const char* name1,
                                        const T1& x1,
                                        const char* name2,
@@ -118,14 +115,14 @@ namespace stan {
                    std::max(is_vector<T2>::value * size_of(x2),
                             std::max(is_vector<T3>::value * size_of(x3),
                                      is_vector<T4>::value * size_of(x4))));
-      return check_consistent_size(function, name1, x1, max_size)
-        && check_consistent_size(function, name2, x2, max_size)
-        && check_consistent_size(function, name3, x3, max_size)
-        && check_consistent_size(function, name4, x4, max_size);
+      check_consistent_size(function, name1, x1, max_size);
+      check_consistent_size(function, name2, x2, max_size);
+      check_consistent_size(function, name3, x3, max_size);
+      check_consistent_size(function, name4, x4, max_size);
     }
     template <typename T1, typename T2, typename T3, typename T4,
               typename T5>
-    inline bool check_consistent_sizes(const char* function,
+    inline void check_consistent_sizes(const char* function,
                                        const char* name1,
                                        const T1& x1,
                                        const char* name2,
@@ -141,11 +138,11 @@ namespace stan {
                                           std::max(size_of(x3),
                                             std::max(size_of(x4),
                                                      size_of(x5)))));
-      return check_consistent_size(function, name1, x1, max_size)
-        && check_consistent_size(function, name2, x2, max_size)
-        && check_consistent_size(function, name3, x3, max_size)
-        && check_consistent_size(function, name4, x4, max_size)
-        && check_consistent_size(function, name5, x5, max_size);
+      check_consistent_size(function, name1, x1, max_size);
+      check_consistent_size(function, name2, x2, max_size);
+      check_consistent_size(function, name3, x3, max_size);
+      check_consistent_size(function, name4, x4, max_size);
+      check_consistent_size(function, name5, x5, max_size);
     }
 
   }

--- a/stan/math/prim/scal/err/check_equal.hpp
+++ b/stan/math/prim/scal/err/check_equal.hpp
@@ -12,11 +12,9 @@ namespace stan {
   namespace math {
 
     namespace {
-      template <typename T_y,
-                typename T_eq,
-                bool is_vec>
+      template <typename T_y, typename T_eq, bool is_vec>
       struct equal {
-        static bool check(const char* function,
+        static void check(const char* function,
                           const char* name,
                           const T_y& y,
                           const T_eq& eq) {
@@ -33,14 +31,12 @@ namespace stan {
                            "is ", msg_str.c_str());
             }
           }
-          return true;
         }
       };
 
-      template <typename T_y,
-                typename T_eq>
+      template <typename T_y, typename T_eq>
       struct equal<T_y, T_eq, true> {
-        static bool check(const char* function,
+        static void check(const char* function,
                           const char* name,
                           const T_y& y,
                           const T_eq& eq) {
@@ -57,13 +53,12 @@ namespace stan {
                                "is ", msg_str.c_str());
             }
           }
-          return true;
         }
       };
     }
 
     /**
-     * Return <code>true</code> if <code>y</code> is equal to
+     * Check if <code>y</code> is equal to
      * <code>eq</code>.
      *
      * This function is vectorized over both <code>y</code> and
@@ -81,16 +76,15 @@ namespace stan {
      * @param y Variable to check equality
      * @param eq Expected value for y
      *
-     * @return <code>true</code> if y is equal to eq
      * @throw <code>std::domain_error</code> if y is unequal to eq or
      *    if any element of y or eq is NaN.
      */
     template <typename T_y, typename T_eq>
-    inline bool check_equal(const char* function,
+    inline void check_equal(const char* function,
                             const char* name,
                             const T_y& y,
                             const T_eq& eq) {
-      return equal<T_y, T_eq, is_vector_like<T_y>::value>
+      equal<T_y, T_eq, is_vector_like<T_y>::value>
         ::check(function, name, y, eq);
     }
   }

--- a/stan/math/prim/scal/err/check_finite.hpp
+++ b/stan/math/prim/scal/err/check_finite.hpp
@@ -14,19 +14,18 @@ namespace stan {
     namespace {
       template <typename T_y, bool is_vec>
       struct finite {
-        static bool check(const char* function,
+        static void check(const char* function,
                           const char* name,
                           const T_y& y) {
           if (!(boost::math::isfinite)(value_of_rec(y)))
             domain_error(function, name, y,
                          "is ", ", but must be finite!");
-          return true;
         }
       };
 
       template <typename T_y>
       struct finite<T_y, true> {
-        static bool check(const char* function,
+        static void check(const char* function,
                           const char* name,
                           const T_y& y) {
           using stan::length;
@@ -35,13 +34,12 @@ namespace stan {
               domain_error_vec(function, name, y, n,
                                "is ", ", but must be finite!");
           }
-          return true;
         }
       };
     }
 
     /**
-     * Return <code>true</code> if <code>y</code> is finite.
+     * Check if <code>y</code> is finite.
      *
      * This function is vectorized and will check each element of
      * <code>y</code>.
@@ -52,15 +50,14 @@ namespace stan {
      * @param name Variable name (for error messages)
      * @param y Variable to check
      *
-     * @return <code>true</code> if y is finite.
      * @throw <code>domain_error</code> if y is infinity, -infinity, or
      *   NaN.
      */
     template <typename T_y>
-    inline bool check_finite(const char* function,
+    inline void check_finite(const char* function,
                              const char* name,
                              const T_y& y) {
-      return finite<T_y, is_vector_like<T_y>::value>
+      finite<T_y, is_vector_like<T_y>::value>
         ::check(function, name, y);
     }
   }

--- a/stan/math/prim/scal/err/check_greater.hpp
+++ b/stan/math/prim/scal/err/check_greater.hpp
@@ -13,11 +13,9 @@ namespace stan {
   namespace math {
 
     namespace {
-      template <typename T_y,
-                typename T_low,
-                bool is_vec>
+      template <typename T_y, typename T_low, bool is_vec>
       struct greater {
-        static bool check(const char* function,
+        static void check(const char* function,
                           const char* name,
                           const T_y& y,
                           const T_low& low) {
@@ -33,14 +31,12 @@ namespace stan {
                            "is ", msg_str.c_str());
             }
           }
-          return true;
         }
       };
 
-      template <typename T_y,
-                typename T_low>
+      template <typename T_y, typename T_low>
       struct greater<T_y, T_low, true> {
-        static bool check(const char* function,
+        static void check(const char* function,
                           const char* name,
                           const T_y& y,
                           const T_low& low) {
@@ -56,13 +52,12 @@ namespace stan {
                                "is ", msg_str.c_str());
             }
           }
-          return true;
         }
       };
     }
 
     /**
-     * Return <code>true</code> if <code>y</code> is strictly greater
+     * Check if <code>y</code> is strictly greater
      * than <code>low</code>.
      *
      * This function is vectorized and will check each element of
@@ -76,16 +71,15 @@ namespace stan {
      * @param y Variable to check
      * @param low Lower bound
      *
-     * @return <code>true</code> if y is strictly greater than low.
      * @throw <code>domain_error</code> if y is not greater than low or
      *   if any element of y or low is NaN.
      */
     template <typename T_y, typename T_low>
-    inline bool check_greater(const char* function,
+    inline void check_greater(const char* function,
                               const char* name,
                               const T_y& y,
                               const T_low& low) {
-      return greater<T_y, T_low, is_vector_like<T_y>::value>
+      greater<T_y, T_low, is_vector_like<T_y>::value>
         ::check(function, name, y, low);
     }
   }

--- a/stan/math/prim/scal/err/check_greater_or_equal.hpp
+++ b/stan/math/prim/scal/err/check_greater_or_equal.hpp
@@ -12,11 +12,9 @@ namespace stan {
   namespace math {
 
     namespace {
-      template <typename T_y,
-                typename T_low,
-                bool is_vec>
+      template <typename T_y, typename T_low, bool is_vec>
       struct greater_or_equal {
-        static bool check(const char* function,
+        static void check(const char* function,
                           const char* name,
                           const T_y& y,
                           const T_low& low) {
@@ -32,14 +30,12 @@ namespace stan {
                            "is ", msg_str.c_str());
             }
           }
-          return true;
         }
       };
 
-      template <typename T_y,
-                typename T_low>
+      template <typename T_y, typename T_low>
       struct greater_or_equal<T_y, T_low, true> {
-        static bool check(const char* function,
+        static void check(const char* function,
                           const char* name,
                           const T_y& y,
                           const T_low& low) {
@@ -56,13 +52,12 @@ namespace stan {
                                "is ", msg_str.c_str());
             }
           }
-          return true;
         }
       };
     }
 
     /**
-     * Return <code>true</code> if <code>y</code> is greater or equal
+     * Check if <code>y</code> is greater or equal
      * than <code>low</code>.
      *
      * This function is vectorized and will check each element of
@@ -76,16 +71,15 @@ namespace stan {
      * @param y Variable to check
      * @param low Lower bound
      *
-     * @return <code>true</code> if y is greater or equal than low.
      * @throw <code>domain_error</code> if y is not greater or equal to low or
      *   if any element of y or low is NaN.
      */
     template <typename T_y, typename T_low>
-    inline bool check_greater_or_equal(const char* function,
+    inline void check_greater_or_equal(const char* function,
                                        const char* name,
                                        const T_y& y,
                                        const T_low& low) {
-      return greater_or_equal<T_y, T_low, is_vector_like<T_y>::value>
+      greater_or_equal<T_y, T_low, is_vector_like<T_y>::value>
         ::check(function, name, y, low);
     }
   }

--- a/stan/math/prim/scal/err/check_less.hpp
+++ b/stan/math/prim/scal/err/check_less.hpp
@@ -15,7 +15,7 @@ namespace stan {
     namespace {
       template <typename T_y, typename T_high, bool is_vec>
       struct less {
-        static bool check(const char* function,
+        static void check(const char* function,
                           const char* name,
                           const T_y& y,
                           const T_high& high) {
@@ -31,13 +31,12 @@ namespace stan {
                            "is ", msg_str.c_str());
             }
           }
-          return true;
         }
       };
 
       template <typename T_y, typename T_high>
       struct less<T_y, T_high, true> {
-        static bool check(const char* function,
+        static void check(const char* function,
                           const char* name,
                           const T_y& y,
                           const T_high& high) {
@@ -53,13 +52,12 @@ namespace stan {
                                "is ", msg_str.c_str());
             }
           }
-          return true;
         }
       };
     }
 
     /**
-     * Return <code>true</code> if <code>y</code> is strictly less
+     * Check if <code>y</code> is strictly less
      * than <code>high</code>.
      *
      * This function is vectorized and will check each element of
@@ -73,16 +71,15 @@ namespace stan {
      * @param y Variable to check
      * @param high Upper bound
      *
-     * @return <code>true</code> if y is strictly less than low.
      * @throw <code>domain_error</code> if y is not less than low
      *   or if any element of y or high is NaN.
      */
     template <typename T_y, typename T_high>
-    inline bool check_less(const char* function,
+    inline void check_less(const char* function,
                            const char* name,
                            const T_y& y,
                            const T_high& high) {
-      return less<T_y, T_high, is_vector_like<T_y>::value>
+      less<T_y, T_high, is_vector_like<T_y>::value>
         ::check(function, name, y, high);
     }
   }

--- a/stan/math/prim/scal/err/check_less_or_equal.hpp
+++ b/stan/math/prim/scal/err/check_less_or_equal.hpp
@@ -15,7 +15,7 @@ namespace stan {
     namespace {
       template <typename T_y, typename T_high, bool is_vec>
       struct less_or_equal {
-        static bool check(const char* function,
+        static void check(const char* function,
                           const char* name,
                           const T_y& y,
                           const T_high& high) {
@@ -31,13 +31,12 @@ namespace stan {
                            "is ", msg_str.c_str());
             }
           }
-          return true;
         }
       };
 
       template <typename T_y, typename T_high>
       struct less_or_equal<T_y, T_high, true> {
-        static bool check(const char* function,
+        static void check(const char* function,
                           const char* name,
                           const T_y& y,
                           const T_high& high) {
@@ -53,13 +52,12 @@ namespace stan {
                                "is ", msg_str.c_str());
             }
           }
-          return true;
         }
       };
     }
 
     /**
-     * Return <code>true</code> if <code>y</code> is less or equal to
+     * Check if <code>y</code> is less or equal to
      * <code>high</code>.
      *
      * This function is vectorized and will check each element of
@@ -73,16 +71,15 @@ namespace stan {
      * @param y Variable to check
      * @param high Upper bound
      *
-     * @return <code>true</code> if y is less than or equal to low.
-     * @throw <code>std::domain_error</code> if y is not less than or equal to low
-     *   or if any element of y or high is NaN.
+     * @throw <code>std::domain_error</code> if y is not less than or equal
+     *   to low or if any element of y or high is NaN.
      */
     template <typename T_y, typename T_high>
-    inline bool check_less_or_equal(const char* function,
+    inline void check_less_or_equal(const char* function,
                                     const char* name,
                                     const T_y& y,
                                     const T_high& high) {
-      return less_or_equal<T_y, T_high, is_vector_like<T_y>::value>
+      less_or_equal<T_y, T_high, is_vector_like<T_y>::value>
         ::check(function, name, y, high);
     }
   }

--- a/stan/math/prim/scal/err/check_nonnegative.hpp
+++ b/stan/math/prim/scal/err/check_nonnegative.hpp
@@ -14,7 +14,7 @@ namespace stan {
     namespace {
       template <typename T_y, bool is_vec>
       struct nonnegative {
-        static bool check(const char* function,
+        static void check(const char* function,
                           const char* name,
                           const T_y& y) {
           // have to use not is_unsigned. is_signed will be false
@@ -22,13 +22,12 @@ namespace stan {
           if (!boost::is_unsigned<T_y>::value && !(y >= 0))
             domain_error(function, name, y,
                          "is ", ", but must be >= 0!");
-          return true;
         }
       };
 
       template <typename T_y>
       struct nonnegative<T_y, true> {
-        static bool check(const char* function,
+        static void check(const char* function,
                           const char* name,
                           const T_y& y) {
           using stan::length;
@@ -39,13 +38,12 @@ namespace stan {
               domain_error_vec(function, name, y, n,
                                "is ", ", but must be >= 0!");
           }
-          return true;
         }
       };
     }
 
     /**
-     * Return <code>true</code> if <code>y</code> is non-negative.
+     * Check if <code>y</code> is non-negative.
      *
      * This function is vectorized and will check each element of
      * <code>y</code>.
@@ -56,16 +54,14 @@ namespace stan {
      * @param name Variable name (for error messages)
      * @param y Variable to check
      *
-     * @return <code>true</code> if y is greater than or equal to 0.
      * @throw <code>domain_error</code> if y is negative or
      *   if any element of y is NaN.
      */
     template <typename T_y>
-    inline bool check_nonnegative(const char* function,
+    inline void check_nonnegative(const char* function,
                                   const char* name,
                                   const T_y& y) {
-      return nonnegative<T_y, is_vector_like<T_y>::value>
-        ::check(function, name, y);
+      nonnegative<T_y, is_vector_like<T_y>::value>::check(function, name, y);
     }
   }
 }

--- a/stan/math/prim/scal/err/check_not_nan.hpp
+++ b/stan/math/prim/scal/err/check_not_nan.hpp
@@ -14,19 +14,18 @@ namespace stan {
     namespace {
       template <typename T_y, bool is_vec>
       struct not_nan {
-        static bool check(const char* function,
+        static void check(const char* function,
                           const char* name,
                           const T_y& y) {
           if (is_nan(value_of_rec(y)))
             domain_error(function, name, y,
                          "is ", ", but must not be nan!");
-          return true;
         }
       };
 
       template <typename T_y>
       struct not_nan<T_y, true> {
-        static bool check(const char* function,
+        static void check(const char* function,
                           const char* name,
                           const T_y& y) {
           for (size_t n = 0; n < stan::length(y); n++) {
@@ -34,13 +33,12 @@ namespace stan {
               domain_error_vec(function, name, y, n,
                                "is ", ", but must not be nan!");
           }
-          return true;
         }
       };
     }
 
     /**
-     * Return <code>true</code> if <code>y</code> is not
+     * Check if <code>y</code> is not
      * <code>NaN</code>.
      *
      * This function is vectorized and will check each element of
@@ -53,15 +51,13 @@ namespace stan {
      * @param name Variable name (for error messages)
      * @param y Variable to check
      *
-     * @return <code>true</code> if y is not NaN.
      * @throw <code>domain_error</code> if any element of y is NaN.
      */
     template <typename T_y>
-    inline bool check_not_nan(const char* function,
+    inline void check_not_nan(const char* function,
                               const char* name,
                               const T_y& y) {
-      return not_nan<T_y, is_vector_like<T_y>::value>
-        ::check(function, name, y);
+      not_nan<T_y, is_vector_like<T_y>::value>::check(function, name, y);
     }
 
   }

--- a/stan/math/prim/scal/err/check_positive.hpp
+++ b/stan/math/prim/scal/err/check_positive.hpp
@@ -16,7 +16,7 @@ namespace stan {
 
       template <typename T_y, bool is_vec>
       struct positive {
-        static bool check(const char* function,
+        static void check(const char* function,
                           const char* name,
                           const T_y& y) {
           // have to use not is_unsigned. is_signed will be false
@@ -24,13 +24,12 @@ namespace stan {
           if (!boost::is_unsigned<T_y>::value && !(y > 0))
             domain_error(function, name, y,
                          "is ", ", but must be > 0!");
-          return true;
         }
       };
 
       template <typename T_y>
       struct positive<T_y, true> {
-        static bool check(const char* function,
+        static void check(const char* function,
                           const char* name,
                           const T_y& y) {
           using stan::length;
@@ -40,14 +39,13 @@ namespace stan {
               domain_error_vec(function, name, y, n,
                                "is ", ", but must be > 0!");
           }
-          return true;
         }
       };
 
     }
 
     /**
-     * Return <code>true</code> if <code>y</code> is positive.
+     * Check if <code>y</code> is positive.
      *
      * This function is vectorized and will check each element of
      * <code>y</code>.
@@ -58,16 +56,14 @@ namespace stan {
      * @param name Variable name (for error messages)
      * @param y Variable to check
      *
-     * @return <code>true</code> if y is greater than 0.
      * @throw <code>domain_error</code> if y is negative or zero or
      *   if any element of y is NaN.
      */
     template <typename T_y>
-    inline bool check_positive(const char* function,
+    inline void check_positive(const char* function,
                                const char* name,
                                const T_y& y) {
-      return positive<T_y, is_vector_like<T_y>::value>
-        ::check(function, name, y);
+      positive<T_y, is_vector_like<T_y>::value>::check(function, name, y);
     }
 
   }

--- a/stan/math/prim/scal/err/check_positive_finite.hpp
+++ b/stan/math/prim/scal/err/check_positive_finite.hpp
@@ -8,7 +8,7 @@ namespace stan {
   namespace math {
 
     /**
-     * Return <code>true</code> if <code>y</code> is positive and finite.
+     * Check if <code>y</code> is positive and finite.
      *
      * This function is vectorized and will check each element of
      * <code>y</code>.
@@ -19,19 +19,15 @@ namespace stan {
      * @param name Variable name (for error messages)
      * @param y Variable to check
      *
-     * @return <code>true</code> if every element of y is greater than 0
-     *   and y is not infinite.
      * @throw <code>domain_error</code> if any element of y is not positive or
      *   if any element of y is NaN.
      */
     template <typename T_y>
-    inline bool check_positive_finite(const char* function,
+    inline void check_positive_finite(const char* function,
                                       const char* name,
                                       const T_y& y) {
       check_positive(function, name, y);
       check_finite(function, name, y);
-
-      return true;
     }
 
   }

--- a/stan/math/prim/scal/err/check_positive_size.hpp
+++ b/stan/math/prim/scal/err/check_positive_size.hpp
@@ -9,18 +9,17 @@ namespace stan {
   namespace math {
 
     /**
-     * Return <code>true</code> if <code>size</code> is positive.
+     * Check if <code>size</code> is positive.
      *
      * @param function Function name (for error messages)
      * @param name Variable name (for error messages)
      * @param expr Expression for the dimension size (for error messages)
      * @param size Size value to check
      *
-     * @return <code>true</code> if <code>size</code> is greater than 0.
      * @throw <code>std::invalid_argument</code> if <code>size</code> is
      *   zero or negative.
      */
-    inline bool check_positive_size(const char* function,
+    inline void check_positive_size(const char* function,
                                     const char* name,
                                     const char* expr,
                                     const int size) {
@@ -32,7 +31,6 @@ namespace stan {
                          "must have a positive size, but is ",
                          msg_str.c_str());
       }
-      return true;
     }
 
   }

--- a/stan/math/prim/scal/err/check_size_match.hpp
+++ b/stan/math/prim/scal/err/check_size_match.hpp
@@ -11,7 +11,7 @@ namespace stan {
   namespace math {
 
     /**
-     * Return <code>true</code> if the provided sizes match.
+     * Check if the provided sizes match.
      *
      * @tparam T_size1 Type of size 1
      * @tparam T_size2 Type of size 2
@@ -22,18 +22,17 @@ namespace stan {
      * @param name_j Variable name 2 (for error messages)
      * @param j Size 2
      *
-     * @return <code>true</code> if the sizes match
      * @throw <code>std::invalid_argument</code> if the sizes
      *   do not match
      */
     template <typename T_size1, typename T_size2>
-    inline bool check_size_match(const char* function,
+    inline void check_size_match(const char* function,
                                  const char* name_i,
                                  T_size1 i,
                                  const char* name_j,
                                  T_size2 j) {
       if (likely(i == static_cast<T_size1>(j)))
-        return true;
+        return;
 
       std::ostringstream msg;
       msg << ") and "
@@ -41,11 +40,10 @@ namespace stan {
       std::string msg_str(msg.str());
       invalid_argument(function, name_i, i,
                        "(", msg_str.c_str());
-      return false;
     }
 
     /**
-     * Return <code>true</code> if the provided sizes match.
+     * Check if the provided sizes match.
      *
      * @tparam T_size1 Type of size 1
      * @tparam T_size2 Type of size 2
@@ -58,12 +56,11 @@ namespace stan {
      * @param name_j Variable name 2 (for error messages)
      * @param j Size 2
      *
-     * @return <code>true</code> if the sizes match
      * @throw <code>std::invalid_argument</code> if the sizes
      *   do not match
      */
     template <typename T_size1, typename T_size2>
-    inline bool check_size_match(const char* function,
+    inline void check_size_match(const char* function,
                                  const char* expr_i,
                                  const char* name_i,
                                  T_size1 i,
@@ -71,7 +68,7 @@ namespace stan {
                                  const char* name_j,
                                  T_size2 j) {
       if (likely(i == static_cast<T_size1>(j)))
-        return true;
+        return;
       std::ostringstream updated_name;
       updated_name << expr_i << name_i;
       std::string updated_name_str(updated_name.str());
@@ -82,7 +79,6 @@ namespace stan {
       std::string msg_str(msg.str());
       invalid_argument(function, updated_name_str.c_str(), i,
                        "(", msg_str.c_str());
-      return false;
     }
 
   }

--- a/test/unit/math/prim/arr/err/check_finite_test.cpp
+++ b/test/unit/math/prim/arr/err/check_finite_test.cpp
@@ -13,7 +13,7 @@ TEST(ErrorHandlingScalar,CheckFinite_Vector) {
   x.push_back (-1);
   x.push_back (0);
   x.push_back (1);
-  ASSERT_TRUE(check_finite(function, "x", x)) 
+  ASSERT_NO_THROW(check_finite(function, "x", x)) 
     << "check_finite should be true with finite x";
 
   x.clear();

--- a/test/unit/math/prim/arr/err/check_matching_sizes_test.cpp
+++ b/test/unit/math/prim/arr/err/check_matching_sizes_test.cpp
@@ -5,38 +5,38 @@ TEST(ErrorHandling, checkMatchingSizes) {
   std::vector<double> a;
   std::vector<double> b;
 
-  EXPECT_TRUE(stan::math::check_matching_sizes("checkMatchingSizes", "a", a,
-                                               "b", b));
+  EXPECT_NO_THROW(stan::math::check_matching_sizes("checkMatchingSizes", "a", a,
+                                                   "b", b));
 
   a.push_back(3.0);
   a.push_back(3.0);
 
   EXPECT_THROW(stan::math::check_matching_sizes("checkMatchingSizes", "a", a,
-                                                          "b", b),
+                                                "b", b),
                std::invalid_argument);
 
   b.push_back(3.0);
   b.push_back(3.0);
-  EXPECT_TRUE(stan::math::check_matching_sizes("checkMatchingSizes", "a", a,
-                                                         "b", b));
+  EXPECT_NO_THROW(stan::math::check_matching_sizes("checkMatchingSizes", "a", a,
+                                                   "b", b));
 }
 
 TEST(ErrorHandling, checkMatchingSizes_nan) {
   double nan = std::numeric_limits<double>::quiet_NaN();
   std::vector<double> a;
   std::vector<double> b;
-  EXPECT_TRUE(stan::math::check_matching_sizes("checkMatchingSizes", "a", a,
-                                                         "b", b));
+  EXPECT_NO_THROW(stan::math::check_matching_sizes("checkMatchingSizes", "a", a,
+                                                   "b", b));
 
   a.push_back(nan);
   a.push_back(nan);
   EXPECT_THROW(stan::math::check_matching_sizes("checkMatchingSizes", "a", a,
-                                                          "b", b),
+                                                "b", b),
                std::invalid_argument);
 
   b.push_back(nan);
   b.push_back(nan);
-  EXPECT_TRUE(stan::math::check_matching_sizes("checkMatchingSizes", "a", a,
-                                                         "b", b));
+  EXPECT_NO_THROW(stan::math::check_matching_sizes("checkMatchingSizes", "a", a,
+                                                   "b", b));
 }
 

--- a/test/unit/math/prim/arr/err/check_nonnegative_test.cpp
+++ b/test/unit/math/prim/arr/err/check_nonnegative_test.cpp
@@ -9,11 +9,11 @@ TEST(ErrorHandlingScalar,CheckNonnegativeVectorized) {
   std::vector<double> x(N);
 
   x.assign(N, 0);
-  EXPECT_TRUE(check_nonnegative(function, "x", x)) 
+  EXPECT_NO_THROW(check_nonnegative(function, "x", x)) 
     << "check_nonnegative(vector) should be true with finite x: " << x[0];
 
   x.assign(N, std::numeric_limits<double>::infinity());
-  EXPECT_TRUE(check_nonnegative(function, "x", x)) 
+  EXPECT_NO_THROW(check_nonnegative(function, "x", x)) 
     << "check_nonnegative(vector) should be true with x = Inf: " << x[0];
 
   x.assign(N, -0.01);

--- a/test/unit/math/prim/arr/err/check_nonzero_size_test.cpp
+++ b/test/unit/math/prim/arr/err/check_nonzero_size_test.cpp
@@ -12,12 +12,12 @@ TEST(ErrorHandlingMatrix, checkNonzeroSizeMatrix) {
   a.push_back(3.0);
 
 
-  EXPECT_TRUE(stan::math::check_nonzero_size("checkNonzeroSize",
-                                             "a", a));
+  EXPECT_NO_THROW(stan::math::check_nonzero_size("checkNonzeroSize",
+                                                 "a", a));
 
   a.resize(2);
-  EXPECT_TRUE(stan::math::check_nonzero_size("checkNonzeroSize",
-                                             "a", a));
+  EXPECT_NO_THROW(stan::math::check_nonzero_size("checkNonzeroSize",
+                                                 "a", a));
 
   a.resize(0);
   EXPECT_THROW_MSG(stan::math::check_nonzero_size("checkNonzeroSize", "a", a), 
@@ -34,12 +34,12 @@ TEST(ErrorHandlingMatrix, checkNonzeroSizeMatrix_nan) {
   a.push_back(nan);
   a.push_back(nan);
 
-  EXPECT_TRUE(stan::math::check_nonzero_size("checkNonzeroSize",
-                                             "a", a));
+  EXPECT_NO_THROW(stan::math::check_nonzero_size("checkNonzeroSize",
+                                                 "a", a));
 
   a.resize(2);
-  EXPECT_TRUE(stan::math::check_nonzero_size("checkNonzeroSize",
-                                             "a", a));
+  EXPECT_NO_THROW(stan::math::check_nonzero_size("checkNonzeroSize",
+                                                 "a", a));
 
   a.resize(0);
   EXPECT_THROW_MSG(stan::math::check_nonzero_size("checkNonzeroSize", "a", a), 

--- a/test/unit/math/prim/arr/err/check_not_nan_test.cpp
+++ b/test/unit/math/prim/arr/err/check_not_nan_test.cpp
@@ -9,15 +9,15 @@ TEST(ErrorHandlingScalar,CheckNotNanVectorized) {
   std::vector<double> x(N);
 
   x.assign(N, 0);
-  EXPECT_TRUE(check_not_nan(function, "x", x)) 
+  EXPECT_NO_THROW(check_not_nan(function, "x", x)) 
     << "check_not_nan(vector) should be true with finite x: " << x[0];
 
   x.assign(N, std::numeric_limits<double>::infinity());
-  EXPECT_TRUE(check_not_nan(function, "x", x)) 
+  EXPECT_NO_THROW(check_not_nan(function, "x", x)) 
     << "check_not_nan(vector) should be true with x = Inf: " << x[0];
 
   x.assign(N, -std::numeric_limits<double>::infinity());
-  EXPECT_TRUE(check_not_nan(function, "x", x)) 
+  EXPECT_NO_THROW(check_not_nan(function, "x", x)) 
     << "check_not_nan(vector) should be true with x = -Inf: " << x[0];
 
   x.assign(N, std::numeric_limits<double>::quiet_NaN());

--- a/test/unit/math/prim/arr/err/check_ordered_test.cpp
+++ b/test/unit/math/prim/arr/err/check_ordered_test.cpp
@@ -8,16 +8,16 @@ TEST(ErrorHandling, checkOrdered) {
   y_.push_back(0.0);
   y_.push_back(1.0);
   y_.push_back(2.0);
-  EXPECT_TRUE(check_ordered("check_ordered", "y", y_));
+  EXPECT_NO_THROW(check_ordered("check_ordered", "y", y_));
 
   y_[2] = std::numeric_limits<double>::infinity();
-  EXPECT_TRUE(check_ordered("check_ordered", "y", y_));
+  EXPECT_NO_THROW(check_ordered("check_ordered", "y", y_));
 
   y_[0] = -10.0;
-  EXPECT_TRUE(check_ordered("check_ordered", "y", y_));
+  EXPECT_NO_THROW(check_ordered("check_ordered", "y", y_));
 
   y_[0] = -std::numeric_limits<double>::infinity();
-  EXPECT_TRUE(check_ordered("check_ordered", "y", y_));
+  EXPECT_NO_THROW(check_ordered("check_ordered", "y", y_));
 
   y_[0] = 0.0;
   y_[1] = 0.0;

--- a/test/unit/math/prim/arr/err/check_positive_finite_test.cpp
+++ b/test/unit/math/prim/arr/err/check_positive_finite_test.cpp
@@ -11,7 +11,7 @@ TEST(ErrorHandlingScalar,CheckPositiveFinite_Vector) {
   x.push_back (1.5);
   x.push_back (0.1);
   x.push_back (1);
-  ASSERT_TRUE(check_positive_finite(function, "x", x)) 
+  ASSERT_NO_THROW(check_positive_finite(function, "x", x)) 
     << "check_positive_finite should be true with finite x";
 
   x.clear();

--- a/test/unit/math/prim/arr/err/check_positive_test.cpp
+++ b/test/unit/math/prim/arr/err/check_positive_test.cpp
@@ -11,7 +11,7 @@ TEST(ErrorHandlingScalar,CheckPositive) {
   x.push_back(3.0);
 
   for (size_t i = 0; i < x.size(); i++) {
-    EXPECT_TRUE(check_positive(function, "x", x));
+    EXPECT_NO_THROW(check_positive(function, "x", x));
   }
 
 }

--- a/test/unit/math/prim/mat/err/check_cholesky_factor_corr_test.cpp
+++ b/test/unit/math/prim/mat/err/check_cholesky_factor_corr_test.cpp
@@ -9,16 +9,16 @@ TEST(ErrorHandlingMatrix, checkCorrCholeskyMatrix) {
 
   y.resize(1,1);
   y << 1;
-  EXPECT_TRUE(check_cholesky_factor_corr("checkCorrCholeskyMatrix",
-                                         "y", y));
+  EXPECT_NO_THROW(check_cholesky_factor_corr("checkCorrCholeskyMatrix",
+                                             "y", y));
   
   y.resize(3,3);
   y << 
     1, 0, 0,
     sqrt(0.5), sqrt(0.5), 0,
     sqrt(0.25), sqrt(0.25), sqrt(0.5);
-  EXPECT_TRUE(check_cholesky_factor_corr("checkCorrCholeskyMatrix",
-                                         "y", y));
+  EXPECT_NO_THROW(check_cholesky_factor_corr("checkCorrCholeskyMatrix",
+                                             "y", y));
 
   // not positive
   y.resize(1,1);
@@ -93,8 +93,8 @@ TEST(ErrorHandlingMatrix, checkCorrCholeskyMatrix_nan) {
     1, 0, 0,
     sqrt(0.5), sqrt(0.5), 0,
     sqrt(0.25), sqrt(0.25), sqrt(0.5);
-  EXPECT_TRUE(check_cholesky_factor_corr("checkCorrCholeskyMatrix",
-                                         "y", y));
+  EXPECT_NO_THROW(check_cholesky_factor_corr("checkCorrCholeskyMatrix",
+                                             "y", y));
 
   for (int i = 0 ; i < y.size(); i++) {
     y(i) = nan;

--- a/test/unit/math/prim/mat/err/check_cholesky_factor_test.cpp
+++ b/test/unit/math/prim/mat/err/check_cholesky_factor_test.cpp
@@ -8,16 +8,16 @@ TEST(ErrorHandlingMatrix, checkCovCholeskyMatrix) {
 
   y.resize(1,1);
   y << 1;
-  EXPECT_TRUE(check_cholesky_factor("checkCovCholeskyMatrix",
-                                    "y", y));
+  EXPECT_NO_THROW(check_cholesky_factor("checkCovCholeskyMatrix",
+                                        "y", y));
   
   y.resize(3,3);
   y << 
     1, 0, 0,
     1, 1, 0,
     1, 1, 1;
-  EXPECT_TRUE(check_cholesky_factor("checkCovCholeskyMatrix",
-                                    "y", y));
+  EXPECT_NO_THROW(check_cholesky_factor("checkCovCholeskyMatrix",
+                                        "y", y));
 
   // not positive
   y.resize(1,1);
@@ -57,8 +57,8 @@ TEST(ErrorHandlingMatrix, checkCovCholeskyMatrix) {
     1, 0,
     2, 3,
     4, 5;
-  EXPECT_TRUE(check_cholesky_factor("checkCovCholeskyMatrix",
-                                    "y", y));
+  EXPECT_NO_THROW(check_cholesky_factor("checkCovCholeskyMatrix",
+                                        "y", y));
   y(0,1) = 1.5;
   EXPECT_THROW(check_cholesky_factor("checkCovCholeskyMatrix", 
                                      "y", y),

--- a/test/unit/math/prim/mat/err/check_column_index_test.cpp
+++ b/test/unit/math/prim/mat/err/check_column_index_test.cpp
@@ -7,20 +7,20 @@ TEST(ErrorHandlingMatrix, checkColumnIndexMatrix) {
   
   i=2;
   y.resize(3,3);
-  EXPECT_TRUE(stan::math::check_column_index("checkColumnIndexMatrix",
-                                                       "i", y, i));
+  EXPECT_NO_THROW(stan::math::check_column_index("checkColumnIndexMatrix",
+                                                 "i", y, i));
   i=3;
-  EXPECT_TRUE(stan::math::check_column_index("checkColumnIndexMatrix",
-                                                       "i", y, i));
+  EXPECT_NO_THROW(stan::math::check_column_index("checkColumnIndexMatrix",
+                                                 "i", y, i));
 
   y.resize(3, 2);
   EXPECT_THROW(stan::math::check_column_index("checkColumnIndexMatrix",
-                                                        "i", y, i), 
+                                              "i", y, i), 
                std::out_of_range);
 
   i=0;
   EXPECT_THROW(stan::math::check_column_index("checkColumnIndexMatrix",
-                                                        "i", y, i), 
+                                              "i", y, i), 
                std::out_of_range);
 }
 
@@ -32,20 +32,20 @@ TEST(ErrorHandlingMatrix, checkColumnIndexMatrix_nan) {
   i=2;
   y.resize(3,3);
   y << nan, nan, nan, nan, nan, nan, nan, nan, nan;
-  EXPECT_TRUE(stan::math::check_column_index("checkColumnIndexMatrix",
-                                                       "i", y, i));
+  EXPECT_NO_THROW(stan::math::check_column_index("checkColumnIndexMatrix",
+                                                 "i", y, i));
   i=3;
-  EXPECT_TRUE(stan::math::check_column_index("checkColumnIndexMatrix",
-                                                       "i", y, i));
+  EXPECT_NO_THROW(stan::math::check_column_index("checkColumnIndexMatrix",
+                                                 "i", y, i));
 
   y.resize(3, 2);
   y << nan, nan, nan, nan, nan, nan;
   EXPECT_THROW(stan::math::check_column_index("checkColumnIndexMatrix",
-                                                        "i", y, i), 
+                                              "i", y, i), 
                std::out_of_range);
 
   i=0;
   EXPECT_THROW(stan::math::check_column_index("checkColumnIndexMatrix",
-                                                        "i", y, i), 
+                                              "i", y, i), 
                std::out_of_range);
 }

--- a/test/unit/math/prim/mat/err/check_corr_matrix_test.cpp
+++ b/test/unit/math/prim/mat/err/check_corr_matrix_test.cpp
@@ -8,7 +8,7 @@ TEST(ErrorHandlingMatrix, CheckCorrMatrix) {
   y.resize(2,2);
   
   y << 1, 0, 0, 1;
-  EXPECT_TRUE(check_corr_matrix("test", "y", y));
+  EXPECT_NO_THROW(check_corr_matrix("test", "y", y));
 
   y << 10, 0, 0, 10;
   EXPECT_THROW(check_corr_matrix("test", "y", y), 

--- a/test/unit/math/prim/mat/err/check_cov_matrix_test.cpp
+++ b/test/unit/math/prim/mat/err/check_cov_matrix_test.cpp
@@ -6,8 +6,8 @@ TEST(ErrorHandlingMatrix, checkCovMatrix) {
   
   y.resize(3,3);
   y << 2, -1, 0, -1, 2, -1, 0, -1, 2;
-  EXPECT_TRUE(stan::math::check_cov_matrix("checkCovMatrix",
-                                           "y", y));
+  EXPECT_NO_THROW(stan::math::check_cov_matrix("checkCovMatrix",
+                                               "y", y));
 
   y << 1, 2, 3, 2, 1, 2, 3, 2, 1;
   EXPECT_THROW(stan::math::check_cov_matrix("checkCovMatrix", "y", y), 
@@ -20,8 +20,8 @@ TEST(ErrorHandlingMatrix, checkCovMatrix_nan) {
 
   y.resize(3,3);
   y << 2, -1, 0, -1, 2, -1, 0, -1, 2;
-  EXPECT_TRUE(stan::math::check_cov_matrix("checkCovMatrix",
-                                           "y", y));
+  EXPECT_NO_THROW(stan::math::check_cov_matrix("checkCovMatrix",
+                                               "y", y));
   
   for (int i = 0; i < y.size(); i++) {
     y.resize(3,3);

--- a/test/unit/math/prim/mat/err/check_equal_test.cpp
+++ b/test/unit/math/prim/mat/err/check_equal_test.cpp
@@ -13,7 +13,7 @@ TEST(ErrorHandlingScalar,CheckEqualMatrix) {
   // x_vec, low_vec
   x_vec   << -1, 0, 1;
   eq_vec << -1, 0, 1;
-  EXPECT_TRUE(check_equal(function, "x", x_vec, eq_vec)) 
+  EXPECT_NO_THROW(check_equal(function, "x", x_vec, eq_vec)) 
     << "check_equal: matrix<3,1>, matrix<3,1>";
 
   x_vec   <<   -1,    0,   1;

--- a/test/unit/math/prim/mat/err/check_finite_test.cpp
+++ b/test/unit/math/prim/mat/err/check_finite_test.cpp
@@ -10,7 +10,7 @@ TEST(ErrorHandlingScalar,CheckFinite_Matrix) {
   
   x.resize(3);
   x << -1, 0, 1;
-  ASSERT_TRUE(check_finite(function, "x", x))
+  ASSERT_NO_THROW(check_finite(function, "x", x))
     << "check_finite should be true with finite x";
 
   x.resize(3);

--- a/test/unit/math/prim/mat/err/check_greater_or_equal_test.cpp
+++ b/test/unit/math/prim/mat/err/check_greater_or_equal_test.cpp
@@ -15,23 +15,23 @@ TEST(ErrorHandlingScalar,CheckGreaterOrEqualMatrix) {
   // x_vec, low_vec
   x_vec   << -1, 0, 1;
   low_vec << -2, -1, 0;
-  EXPECT_TRUE(check_greater_or_equal(function, "x", x_vec, low_vec)) 
+  EXPECT_NO_THROW(check_greater_or_equal(function, "x", x_vec, low_vec)) 
     << "check_greater_or_equal: matrix<3,1>, matrix<3,1>";
 
   x_vec   <<   -1,    0,   1;
   low_vec << -1.1, -0.1, 0.9;
-  EXPECT_TRUE(check_greater_or_equal(function, "x", x_vec, low_vec)) 
+  EXPECT_NO_THROW(check_greater_or_equal(function, "x", x_vec, low_vec)) 
     << "check_greater_or_equal: matrix<3,1>, matrix<3,1>";
 
 
   x_vec   << -1, 0, std::numeric_limits<double>::infinity();
   low_vec << -2, -1, 0;
-  EXPECT_TRUE(check_greater_or_equal(function, "x", x_vec, low_vec)) 
+  EXPECT_NO_THROW(check_greater_or_equal(function, "x", x_vec, low_vec)) 
     << "check_greater_or_equal: matrix<3,1>, matrix<3,1>, y has infinity";
   
   x_vec   << -1, 0, 1;
   low_vec << -2, 0, 0;
-  EXPECT_TRUE(check_greater_or_equal(function, "x", x_vec, low_vec))
+  EXPECT_NO_THROW(check_greater_or_equal(function, "x", x_vec, low_vec))
     << "check_greater_or_equal: matrix<3,1>, matrix<3,1>, should pass for index 1";
   
   x_vec   << -1, 0,  1;
@@ -42,23 +42,23 @@ TEST(ErrorHandlingScalar,CheckGreaterOrEqualMatrix) {
   
   x_vec   << -1, 0,  std::numeric_limits<double>::infinity();
   low_vec << -2, -1, std::numeric_limits<double>::infinity();
-  EXPECT_TRUE(check_greater_or_equal(function, "x", x_vec, low_vec))
+  EXPECT_NO_THROW(check_greater_or_equal(function, "x", x_vec, low_vec))
     << "check_greater_or_equal: matrix<3,1>, matrix<3,1>, both bound and value infinity";
   
   x_vec   << -1, 0,  1;
   low_vec << -2, -1, -std::numeric_limits<double>::infinity();
-  EXPECT_TRUE(check_greater_or_equal(function, "x", x_vec, low_vec))
+  EXPECT_NO_THROW(check_greater_or_equal(function, "x", x_vec, low_vec))
     << "check_greater_or_equal: matrix<3,1>, matrix<3,1>, should pass with -infinity";
 
   // x_vec, low
   x_vec   << -1, 0, 1;
   low = -2;
-  EXPECT_TRUE(check_greater_or_equal(function, "x", x_vec, low)) 
+  EXPECT_NO_THROW(check_greater_or_equal(function, "x", x_vec, low)) 
     << "check_greater_or_equal: matrix<3,1>, double";
 
   x_vec   <<   -1,    0,   1;
   low = -std::numeric_limits<double>::infinity();
-  EXPECT_TRUE(check_greater_or_equal(function, "x", x_vec, low)) 
+  EXPECT_NO_THROW(check_greater_or_equal(function, "x", x_vec, low)) 
     << "check_greater_or_equal: matrix<3,1>, double";
 
   x_vec   << -1, 0, 1;
@@ -76,12 +76,12 @@ TEST(ErrorHandlingScalar,CheckGreaterOrEqualMatrix) {
   // x, low_vec
   x = 2;
   low_vec << -1, 0, 1;
-  EXPECT_TRUE(check_greater_or_equal(function, "x", x, low_vec)) 
+  EXPECT_NO_THROW(check_greater_or_equal(function, "x", x, low_vec)) 
     << "check_greater_or_equal: double, matrix<3,1>";
 
   x = 10;
   low_vec << -1, 0, -std::numeric_limits<double>::infinity();
-  EXPECT_TRUE(check_greater_or_equal(function, "x", x, low_vec)) 
+  EXPECT_NO_THROW(check_greater_or_equal(function, "x", x, low_vec)) 
     << "check_greater_or_equal: double, matrix<3,1>, low has -inf";
 
   x = 10;
@@ -92,17 +92,17 @@ TEST(ErrorHandlingScalar,CheckGreaterOrEqualMatrix) {
   
   x = std::numeric_limits<double>::infinity();
   low_vec << -1, 0, std::numeric_limits<double>::infinity();
-  EXPECT_TRUE(check_greater_or_equal(function, "x", x, low_vec))
+  EXPECT_NO_THROW(check_greater_or_equal(function, "x", x, low_vec))
     << "check_greater_or_equal: double, matrix<3,1>, x is inf, low has inf";
   
   x = std::numeric_limits<double>::infinity();
   low_vec << -1, 0, 1;
-  EXPECT_TRUE(check_greater_or_equal(function, "x", x, low_vec)) 
+  EXPECT_NO_THROW(check_greater_or_equal(function, "x", x, low_vec)) 
     << "check_greater_or_equal: double, matrix<3,1>, x is inf";
 
   x = 1.1;
   low_vec << -1, 0, 1;
-  EXPECT_TRUE(check_greater_or_equal(function, "x", x, low_vec)) 
+  EXPECT_NO_THROW(check_greater_or_equal(function, "x", x, low_vec)) 
     << "check_greater_or_equal: double, matrix<3,1>";
   
   x = 0.9;

--- a/test/unit/math/prim/mat/err/check_greater_test.cpp
+++ b/test/unit/math/prim/mat/err/check_greater_test.cpp
@@ -14,18 +14,18 @@ TEST(ErrorHandlingScalar,CheckGreater_Matrix) {
   // x_vec, low_vec
   x_vec   << -1, 0, 1;
   low_vec << -2, -1, 0;
-  EXPECT_TRUE(check_greater(function, "x", x_vec, low_vec)) 
+  EXPECT_NO_THROW(check_greater(function, "x", x_vec, low_vec)) 
     << "check_greater: matrix<3,1>, matrix<3,1>";
 
   x_vec   <<   -1,    0,   1;
   low_vec << -1.1, -0.1, 0.9;
-  EXPECT_TRUE(check_greater(function, "x", x_vec, low_vec)) 
+  EXPECT_NO_THROW(check_greater(function, "x", x_vec, low_vec)) 
     << "check_greater: matrix<3,1>, matrix<3,1>";
 
 
   x_vec   << -1, 0, std::numeric_limits<double>::infinity();
   low_vec << -2, -1, 0;
-  EXPECT_TRUE(check_greater(function, "x", x_vec, low_vec)) 
+  EXPECT_NO_THROW(check_greater(function, "x", x_vec, low_vec)) 
     << "check_greater: matrix<3,1>, matrix<3,1>, y has infinity";
   
   x_vec   << -1, 0, 1;
@@ -45,18 +45,18 @@ TEST(ErrorHandlingScalar,CheckGreater_Matrix) {
   
   x_vec   << -1, 0,  1;
   low_vec << -2, -1, -std::numeric_limits<double>::infinity();
-  EXPECT_TRUE(check_greater(function, "x", x_vec, low_vec))
+  EXPECT_NO_THROW(check_greater(function, "x", x_vec, low_vec))
     << "check_greater: matrix<3,1>, matrix<3,1>, should pass with -infinity";
 
   // x_vec, low
   x_vec   << -1, 0, 1;
   low = -2;
-  EXPECT_TRUE(check_greater(function, "x", x_vec, low)) 
+  EXPECT_NO_THROW(check_greater(function, "x", x_vec, low)) 
     << "check_greater: matrix<3,1>, double";
 
   x_vec   <<   -1,    0,   1;
   low = -std::numeric_limits<double>::infinity();
-  EXPECT_TRUE(check_greater(function, "x", x_vec, low)) 
+  EXPECT_NO_THROW(check_greater(function, "x", x_vec, low)) 
     << "check_greater: matrix<3,1>, double";
 
   x_vec   << -1, 0, 1;
@@ -72,12 +72,12 @@ TEST(ErrorHandlingScalar,CheckGreater_Matrix) {
   // x, low_vec
   x = 2;
   low_vec << -1, 0, 1;
-  EXPECT_TRUE(check_greater(function, "x", x, low_vec)) 
+  EXPECT_NO_THROW(check_greater(function, "x", x, low_vec)) 
     << "check_greater: double, matrix<3,1>";
 
   x = 10;
   low_vec << -1, 0, -std::numeric_limits<double>::infinity();
-  EXPECT_TRUE(check_greater(function, "x", x, low_vec)) 
+  EXPECT_NO_THROW(check_greater(function, "x", x, low_vec)) 
     << "check_greater: double, matrix<3,1>, low has -inf";
 
   x = 10;
@@ -92,12 +92,12 @@ TEST(ErrorHandlingScalar,CheckGreater_Matrix) {
   
   x = std::numeric_limits<double>::infinity();
   low_vec << -1, 0, 1;
-  EXPECT_TRUE(check_greater(function, "x", x, low_vec)) 
+  EXPECT_NO_THROW(check_greater(function, "x", x, low_vec)) 
     << "check_greater: double, matrix<3,1>, x is inf";
 
   x = 1.1;
   low_vec << -1, 0, 1;
-  EXPECT_TRUE(check_greater(function, "x", x, low_vec)) 
+  EXPECT_NO_THROW(check_greater(function, "x", x, low_vec)) 
     << "check_greater: double, matrix<3,1>";
   
   x = 0.9;

--- a/test/unit/math/prim/mat/err/check_ldlt_factor_test.cpp
+++ b/test/unit/math/prim/mat/err/check_ldlt_factor_test.cpp
@@ -17,7 +17,7 @@ TEST(ErrorHandlingMatrix, CheckLDLTFactor_nan) {
 
   x << 3, nan, 1, 3;
   ldlt_x.compute(x);
-  ASSERT_TRUE(ldlt_x.success());
+  ASSERT_NO_THROW(ldlt_x.success());
   EXPECT_NO_THROW(check_ldlt_factor("checkLDLTFactorMatrix", 
                                     "ldlt_x", ldlt_x));
 

--- a/test/unit/math/prim/mat/err/check_less_or_equal_test.cpp
+++ b/test/unit/math/prim/mat/err/check_less_or_equal_test.cpp
@@ -16,15 +16,15 @@ TEST(ErrorHandlingScalar,CheckLessOrEqual_Matrix) {
   // x_vec, high
   x_vec << -5, 0, 5;
   high = 10;
-  EXPECT_TRUE(check_less_or_equal(function, "x", x_vec, high));
+  EXPECT_NO_THROW(check_less_or_equal(function, "x", x_vec, high));
 
   x_vec << -5, 0, 5;
   high = std::numeric_limits<double>::infinity();
-  EXPECT_TRUE(check_less_or_equal(function, "x", x_vec, high));
+  EXPECT_NO_THROW(check_less_or_equal(function, "x", x_vec, high));
 
   x_vec << -5, 0, 5;
   high = 5;
-  EXPECT_TRUE(check_less_or_equal(function, "x", x_vec, high));
+  EXPECT_NO_THROW(check_less_or_equal(function, "x", x_vec, high));
   
   x_vec << -5, 0, std::numeric_limits<double>::infinity();
   high = 5;
@@ -33,20 +33,20 @@ TEST(ErrorHandlingScalar,CheckLessOrEqual_Matrix) {
 
   x_vec << -5, 0, std::numeric_limits<double>::infinity();
   high = std::numeric_limits<double>::infinity();
-  EXPECT_TRUE(check_less_or_equal(function, "x", x_vec, high));
+  EXPECT_NO_THROW(check_less_or_equal(function, "x", x_vec, high));
   
   // x_vec, high_vec
   x_vec << -5, 0, 5;
   high_vec << 0, 5, 10;
-  EXPECT_TRUE(check_less_or_equal(function, "x", x_vec, high_vec));
+  EXPECT_NO_THROW(check_less_or_equal(function, "x", x_vec, high_vec));
 
   x_vec << -5, 0, 5;
   high_vec << std::numeric_limits<double>::infinity(), 10, 10;
-  EXPECT_TRUE(check_less_or_equal(function, "x", x_vec, high_vec));
+  EXPECT_NO_THROW(check_less_or_equal(function, "x", x_vec, high_vec));
 
   x_vec << -5, 0, 5;
   high_vec << 10, 10, 5;
-  EXPECT_TRUE(check_less_or_equal(function, "x", x_vec, high_vec));
+  EXPECT_NO_THROW(check_less_or_equal(function, "x", x_vec, high_vec));
   
   x_vec << -5, 0, std::numeric_limits<double>::infinity();
   high_vec << 10, 10, 10;
@@ -55,21 +55,21 @@ TEST(ErrorHandlingScalar,CheckLessOrEqual_Matrix) {
 
   x_vec << -5, 0, std::numeric_limits<double>::infinity();
   high_vec << 10, 10, std::numeric_limits<double>::infinity();
-  EXPECT_TRUE(check_less_or_equal(function, "x", x_vec, high_vec));
+  EXPECT_NO_THROW(check_less_or_equal(function, "x", x_vec, high_vec));
 
   
   // x, high_vec
   x = -100;
   high_vec << 0, 5, 10;
-  EXPECT_TRUE(check_less_or_equal(function, "x", x, high_vec));
+  EXPECT_NO_THROW(check_less_or_equal(function, "x", x, high_vec));
 
   x = 10;
   high_vec << 100, 200, std::numeric_limits<double>::infinity();
-  EXPECT_TRUE(check_less_or_equal(function, "x", x, high_vec));
+  EXPECT_NO_THROW(check_less_or_equal(function, "x", x, high_vec));
 
   x = 5;
   high_vec << 100, 200, 5;
-  EXPECT_TRUE(check_less_or_equal(function, "x", x, high_vec));
+  EXPECT_NO_THROW(check_less_or_equal(function, "x", x, high_vec));
   
   x = std::numeric_limits<double>::infinity();
   high_vec << 10, 20, 30;
@@ -80,7 +80,7 @@ TEST(ErrorHandlingScalar,CheckLessOrEqual_Matrix) {
   high_vec << std::numeric_limits<double>::infinity(), 
     std::numeric_limits<double>::infinity(), 
     std::numeric_limits<double>::infinity();
-  EXPECT_TRUE(check_less_or_equal(function, "x", x, high_vec));
+  EXPECT_NO_THROW(check_less_or_equal(function, "x", x, high_vec));
 }
 
 TEST(ErrorHandlingScalar,CheckLessOrEqual_Matrix_one_indexed_message) {

--- a/test/unit/math/prim/mat/err/check_less_test.cpp
+++ b/test/unit/math/prim/mat/err/check_less_test.cpp
@@ -16,11 +16,11 @@ TEST(ErrorHandlingScalar,CheckLess_Matrix) {
   // x_vec, high
   x_vec << -5, 0, 5;
   high = 10;
-  EXPECT_TRUE(check_less(function, "x", x_vec, high));
+  EXPECT_NO_THROW(check_less(function, "x", x_vec, high));
 
   x_vec << -5, 0, 5;
   high = std::numeric_limits<double>::infinity();
-  EXPECT_TRUE(check_less(function, "x", x_vec, high));
+  EXPECT_NO_THROW(check_less(function, "x", x_vec, high));
 
   x_vec << -5, 0, 5;
   high = 5;
@@ -40,11 +40,11 @@ TEST(ErrorHandlingScalar,CheckLess_Matrix) {
   // x_vec, high_vec
   x_vec << -5, 0, 5;
   high_vec << 0, 5, 10;
-  EXPECT_TRUE(check_less(function, "x", x_vec, high_vec));
+  EXPECT_NO_THROW(check_less(function, "x", x_vec, high_vec));
 
   x_vec << -5, 0, 5;
   high_vec << std::numeric_limits<double>::infinity(), 10, 10;
-  EXPECT_TRUE(check_less(function, "x", x_vec, high_vec));
+  EXPECT_NO_THROW(check_less(function, "x", x_vec, high_vec));
 
   x_vec << -5, 0, 5;
   high_vec << 10, 10, 5;
@@ -65,11 +65,11 @@ TEST(ErrorHandlingScalar,CheckLess_Matrix) {
   // x, high_vec
   x = -100;
   high_vec << 0, 5, 10;
-  EXPECT_TRUE(check_less(function, "x", x, high_vec));
+  EXPECT_NO_THROW(check_less(function, "x", x, high_vec));
 
   x = 10;
   high_vec << 100, 200, std::numeric_limits<double>::infinity();
-  EXPECT_TRUE(check_less(function, "x", x, high_vec));
+  EXPECT_NO_THROW(check_less(function, "x", x, high_vec));
 
   x = 5;
   high_vec << 100, 200, 5;

--- a/test/unit/math/prim/mat/err/check_lower_triangular_test.cpp
+++ b/test/unit/math/prim/mat/err/check_lower_triangular_test.cpp
@@ -7,11 +7,11 @@ TEST(ErrorHandlingMatrix, checkLowerTriangular) {
   
   y.resize(1,1);
   y << 1;
-  EXPECT_TRUE(check_lower_triangular("checkLowerTriangular", "y", y));
+  EXPECT_NO_THROW(check_lower_triangular("checkLowerTriangular", "y", y));
 
   y.resize(1,2);
   y << 1, 0;
-  EXPECT_TRUE(check_lower_triangular("checkLowerTriangular", "y", y));
+  EXPECT_NO_THROW(check_lower_triangular("checkLowerTriangular", "y", y));
 
   y(0,1) = 1;
   EXPECT_THROW(check_lower_triangular("checkLowerTriangular", "y", y), 
@@ -21,7 +21,7 @@ TEST(ErrorHandlingMatrix, checkLowerTriangular) {
 
   y.resize(2,2);
   y << 1, 0, 2, 3;
-  EXPECT_TRUE(check_lower_triangular("checkLowerTriangular", "y", y));
+  EXPECT_NO_THROW(check_lower_triangular("checkLowerTriangular", "y", y));
 
   y << 1, 2, 3, 4;
   EXPECT_THROW(check_lower_triangular("checkLowerTriangular", "y", y), 
@@ -31,7 +31,7 @@ TEST(ErrorHandlingMatrix, checkLowerTriangular) {
   y << 1, 0,
     2, 3,
     4, 5;
-  EXPECT_TRUE(check_lower_triangular("checkLowerTriangular", "y", y));
+  EXPECT_NO_THROW(check_lower_triangular("checkLowerTriangular", "y", y));
   
   y(0,1) = 1.5;
   EXPECT_THROW(check_lower_triangular("checkLowerTriangular", "y", y), 
@@ -41,7 +41,7 @@ TEST(ErrorHandlingMatrix, checkLowerTriangular) {
   y << 
     1, 0, 0,
     4, 5, 0;
-  EXPECT_TRUE(check_lower_triangular("checkLowerTriangular", "y", y));
+  EXPECT_NO_THROW(check_lower_triangular("checkLowerTriangular", "y", y));
   y(0,2) = 3;
 }
 
@@ -71,15 +71,15 @@ TEST(ErrorHandlingMatrix, checkLowerTriangular_one_indexed_message) {
 TEST(ErrorHandlingMatrix, checkLowerTriangular_nan) {
   using stan::math::check_lower_triangular;
   Eigen::Matrix<double,Eigen::Dynamic,Eigen::Dynamic> y;
-    double nan = std::numeric_limits<double>::quiet_NaN();
+  double nan = std::numeric_limits<double>::quiet_NaN();
 
   y.resize(1,1);
   y << nan;
-  EXPECT_TRUE(check_lower_triangular("checkLowerTriangular", "y", y));
+  EXPECT_NO_THROW(check_lower_triangular("checkLowerTriangular", "y", y));
 
   y.resize(1,2);
   y << nan, 0;
-  EXPECT_TRUE(check_lower_triangular("checkLowerTriangular", "y", y));
+  EXPECT_NO_THROW(check_lower_triangular("checkLowerTriangular", "y", y));
 
   y(0,1) = nan;
   EXPECT_THROW(check_lower_triangular("checkLowerTriangular", "y", y), 
@@ -89,17 +89,17 @@ TEST(ErrorHandlingMatrix, checkLowerTriangular_nan) {
 
   y.resize(2,2);
   y << nan, 0, nan, nan;
-  EXPECT_TRUE(check_lower_triangular("checkLowerTriangular", "y", y));
+  EXPECT_NO_THROW(check_lower_triangular("checkLowerTriangular", "y", y));
 
   y << 1, nan, nan, 4;
-              EXPECT_THROW(check_lower_triangular("checkLowerTriangular", "y", y), 
+  EXPECT_THROW(check_lower_triangular("checkLowerTriangular", "y", y), 
                std::domain_error);
 
   y.resize(3,2);
   y << nan, 0,
     2, nan,
     4, 5;
-  EXPECT_TRUE(check_lower_triangular("checkLowerTriangular", "y", y));
+  EXPECT_NO_THROW(check_lower_triangular("checkLowerTriangular", "y", y));
   
   y(0,1) = nan;
   EXPECT_THROW(check_lower_triangular("checkLowerTriangular", "y", y), 
@@ -109,7 +109,7 @@ TEST(ErrorHandlingMatrix, checkLowerTriangular_nan) {
   y << 
     nan, 0, 0,
     4, nan, 0;
-  EXPECT_TRUE(check_lower_triangular("checkLowerTriangular", "y", y));
+  EXPECT_NO_THROW(check_lower_triangular("checkLowerTriangular", "y", y));
 
   y(0,2) = nan;
   EXPECT_THROW(check_lower_triangular("checkLowerTriangular", "y", y), 

--- a/test/unit/math/prim/mat/err/check_matching_dims_test.cpp
+++ b/test/unit/math/prim/mat/err/check_matching_dims_test.cpp
@@ -8,21 +8,21 @@ TEST(ErrorHandlingMatrix, checkMatchingDimsMatrix) {
   
   y.resize(3,3);
   x.resize(3,3);
-  EXPECT_TRUE(stan::math::check_matching_dims("checkMatchingDims", "x", x,
-                                                        "y", y));
+  EXPECT_NO_THROW(stan::math::check_matching_dims("checkMatchingDims", "x", x,
+                                                  "y", y));
   x.resize(0,0);
   y.resize(0,0);
-  EXPECT_TRUE(stan::math::check_matching_dims("checkMatchingDims", "x", x,
-                                                        "y", y));
+  EXPECT_NO_THROW(stan::math::check_matching_dims("checkMatchingDims", "x", x,
+                                                  "y", y));
 
   y.resize(1,2);
   EXPECT_THROW(stan::math::check_matching_dims("checkMatchingDims", "x", x,
-                                                         "y", y), 
+                                               "y", y), 
                std::invalid_argument);
 
   x.resize(2,1);
   EXPECT_THROW(stan::math::check_matching_dims("checkMatchingDims", "x", x,
-                                                         "y", y), 
+                                               "y", y), 
                std::invalid_argument);
 }
 
@@ -35,23 +35,23 @@ TEST(ErrorHandlingMatrix, checkMatchingDimsMatrix_nan) {
   x.resize(3,3);
   y << nan, nan, nan,nan, nan, nan,nan, nan, nan;
   x << nan, nan, nan,nan, nan, nan,nan, nan, nan;
-  EXPECT_TRUE(stan::math::check_matching_dims("checkMatchingDims", "x", x,
-                                                        "y", y));
+  EXPECT_NO_THROW(stan::math::check_matching_dims("checkMatchingDims", "x", x,
+                                                  "y", y));
   x.resize(0,0);
   y.resize(0,0);
-  EXPECT_TRUE(stan::math::check_matching_dims("checkMatchingDims", "x", x,
-                                                        "y", y));
+  EXPECT_NO_THROW(stan::math::check_matching_dims("checkMatchingDims", "x", x,
+                                                  "y", y));
 
   y.resize(1,2);
   y << nan, nan;
   EXPECT_THROW(stan::math::check_matching_dims("checkMatchingDims", "x", x,
-                                                         "y", y), 
+                                               "y", y), 
                std::invalid_argument);
 
   x.resize(2,1);
   x << nan, nan;
   EXPECT_THROW(stan::math::check_matching_dims("checkMatchingDims", "x", x,
-                                                         "y", y), 
+                                               "y", y), 
                std::invalid_argument);
 }
 
@@ -65,8 +65,8 @@ TEST(ErrorHandlingMatrix, checkMatchingDims_compile_time_sizes) {
 
 
   m_dynamic.resize(2,2);
-  EXPECT_TRUE(check_matching_dims("check_matching_dims", "dynamic", m_dynamic,
-                                  "2x2", m_2x2));
+  EXPECT_NO_THROW(check_matching_dims("check_matching_dims", "dynamic", m_dynamic,
+                                      "2x2", m_2x2));
 
   m_dynamic.resize(3,3);
   EXPECT_THROW_MSG(check_matching_dims("check_matching_dims", "dynamic", m_dynamic,
@@ -75,8 +75,8 @@ TEST(ErrorHandlingMatrix, checkMatchingDims_compile_time_sizes) {
                    "check_matching_dims: Rows of dynamic (3) and rows of 2x2 (2) must match in size");
 
   m_dynamic.resize(4,1);  
-  EXPECT_TRUE(check_matching_dims("check_matching_dims", "dynamic", m_dynamic,
-                                  "vector", vector));
+  EXPECT_NO_THROW(check_matching_dims("check_matching_dims", "dynamic", m_dynamic,
+                                      "vector", vector));
 
   m_dynamic.resize(3,1);  
   EXPECT_THROW_MSG(check_matching_dims("check_matching_dims", "dynamic", m_dynamic,
@@ -86,8 +86,8 @@ TEST(ErrorHandlingMatrix, checkMatchingDims_compile_time_sizes) {
 
 
   m_dynamic.resize(1,4);  
-  EXPECT_TRUE(check_matching_dims("check_matching_dims", "dynamic", m_dynamic,
-                                  "rowvector", rowvector));
+  EXPECT_NO_THROW(check_matching_dims("check_matching_dims", "dynamic", m_dynamic,
+                                      "rowvector", rowvector));
 
   m_dynamic.resize(1,3);  
   EXPECT_THROW_MSG(check_matching_dims("check_matching_dims", "dynamic", m_dynamic,

--- a/test/unit/math/prim/mat/err/check_matching_sizes_test.cpp
+++ b/test/unit/math/prim/mat/err/check_matching_sizes_test.cpp
@@ -7,36 +7,36 @@ TEST(ErrorHandlingMatrix, checkMatchingSizesMatrix) {
   
   y.resize(3,3);
   x.resize(3,3);
-  EXPECT_TRUE(stan::math::check_matching_sizes("checkMatchingSizes", "x", x,
-                                                         "y", y));
+  EXPECT_NO_THROW(stan::math::check_matching_sizes("checkMatchingSizes", "x", x,
+                                                   "y", y));
   x.resize(0,0);
   y.resize(0,0);
-  EXPECT_TRUE(stan::math::check_matching_sizes("checkMatchingSizes", "x", x,
-                                                         "y", y));
+  EXPECT_NO_THROW(stan::math::check_matching_sizes("checkMatchingSizes", "x", x,
+                                                   "y", y));
 
   y.resize(1,2);
 
 
   EXPECT_THROW(stan::math::check_matching_sizes("checkMatchingSizes", "x", x,
-                                                          "y", y), 
+                                                "y", y), 
                std::invalid_argument);
 
   x.resize(2,1);
-  EXPECT_TRUE(stan::math::check_matching_sizes("checkMatchingSizes", "x", x,
-                                                         "y", y));
+  EXPECT_NO_THROW(stan::math::check_matching_sizes("checkMatchingSizes", "x", x,
+                                                   "y", y));
 
   std::vector<double> a;
   std::vector<double> b;
   x.resize(0,0);
 
-  EXPECT_TRUE(stan::math::check_matching_sizes("checkMatchingSizes", "a", a,
-                                                         "b", b));
-  EXPECT_TRUE(stan::math::check_matching_sizes("checkMatchingSizes", "x", x,
-                                                         "b", b));
-  EXPECT_TRUE(stan::math::check_matching_sizes("checkMatchingSizes", "a", a,
-                                                         "x", x));
+  EXPECT_NO_THROW(stan::math::check_matching_sizes("checkMatchingSizes", "a", a,
+                                                   "b", b));
+  EXPECT_NO_THROW(stan::math::check_matching_sizes("checkMatchingSizes", "x", x,
+                                                   "b", b));
+  EXPECT_NO_THROW(stan::math::check_matching_sizes("checkMatchingSizes", "a", a,
+                                                   "x", x));
   EXPECT_THROW(stan::math::check_matching_sizes("checkMatchingSizes", "a", a,
-                                                          "y", y),
+                                                "y", y),
                std::invalid_argument);
 
 
@@ -44,17 +44,17 @@ TEST(ErrorHandlingMatrix, checkMatchingSizesMatrix) {
   a.push_back(3.0);
 
   EXPECT_THROW(stan::math::check_matching_sizes("checkMatchingSizes", "a", a,
-                                                          "b", b),
+                                                "b", b),
                std::invalid_argument);
 
   b.push_back(3.0);
   b.push_back(3.0);
   x.resize(2,1);
 
-  EXPECT_TRUE(stan::math::check_matching_sizes("checkMatchingSizes", "a", a,
-                                                         "b", b));
-  EXPECT_TRUE(stan::math::check_matching_sizes("checkMatchingSizes", "x", x,
-                                                         "b", b));
+  EXPECT_NO_THROW(stan::math::check_matching_sizes("checkMatchingSizes", "a", a,
+                                                   "b", b));
+  EXPECT_NO_THROW(stan::math::check_matching_sizes("checkMatchingSizes", "x", x,
+                                                   "b", b));
 }
 
 TEST(ErrorHandlingMatrix, checkMatchingSizesMatrix_nan) {
@@ -66,51 +66,51 @@ TEST(ErrorHandlingMatrix, checkMatchingSizesMatrix_nan) {
   x.resize(3,3);
   y << nan, nan, nan,nan, nan, nan,nan, nan, nan;
   x << nan, nan, nan,nan, nan, nan,nan, nan, nan;
-  EXPECT_TRUE(stan::math::check_matching_sizes("checkMatchingSizes", "x", x,
-                                                         "y", y));
+  EXPECT_NO_THROW(stan::math::check_matching_sizes("checkMatchingSizes", "x", x,
+                                                   "y", y));
   x.resize(0,0);
   y.resize(0,0);
-  EXPECT_TRUE(stan::math::check_matching_sizes("checkMatchingSizes", "x", x,
-                                                         "y", y));
+  EXPECT_NO_THROW(stan::math::check_matching_sizes("checkMatchingSizes", "x", x,
+                                                   "y", y));
 
   y.resize(1,2);
   y << nan, nan;
   EXPECT_THROW(stan::math::check_matching_sizes("checkMatchingSizes", "x", x,
-                                                          "y", y), 
+                                                "y", y), 
                std::invalid_argument);
 
   x.resize(2,1);
   x << nan, nan;
-  EXPECT_TRUE(stan::math::check_matching_sizes("checkMatchingSizes", "x", x,
-                                                         "y", y));
+  EXPECT_NO_THROW(stan::math::check_matching_sizes("checkMatchingSizes", "x", x,
+                                                   "y", y));
 
   std::vector<double> a;
   std::vector<double> b;
   x.resize(0,0);
-  EXPECT_TRUE(stan::math::check_matching_sizes("checkMatchingSizes", "a", a,
-                                                         "b", b));
-  EXPECT_TRUE(stan::math::check_matching_sizes("checkMatchingSizes", "x", x,
-                                                         "b", b));
-  EXPECT_TRUE(stan::math::check_matching_sizes("checkMatchingSizes", "a", a,
-                                                         "x", x));
+  EXPECT_NO_THROW(stan::math::check_matching_sizes("checkMatchingSizes", "a", a,
+                                                   "b", b));
+  EXPECT_NO_THROW(stan::math::check_matching_sizes("checkMatchingSizes", "x", x,
+                                                   "b", b));
+  EXPECT_NO_THROW(stan::math::check_matching_sizes("checkMatchingSizes", "a", a,
+                                                   "x", x));
   EXPECT_THROW(stan::math::check_matching_sizes("checkMatchingSizes", "a", a,
-                                                          "y", y),
+                                                "y", y),
                std::invalid_argument);
 
 
   a.push_back(nan);
   a.push_back(nan);
   EXPECT_THROW(stan::math::check_matching_sizes("checkMatchingSizes", "a", a,
-                                                          "b", b),
+                                                "b", b),
                std::invalid_argument);
 
   b.push_back(nan);
   b.push_back(nan);
   x.resize(2,1);
   x << nan, nan;
-  EXPECT_TRUE(stan::math::check_matching_sizes("checkMatchingSizes", "a", a,
-                                                         "b", b));
-  EXPECT_TRUE(stan::math::check_matching_sizes("checkMatchingSizes", "x", x,
-                                                         "b", b));
+  EXPECT_NO_THROW(stan::math::check_matching_sizes("checkMatchingSizes", "a", a,
+                                                   "b", b));
+  EXPECT_NO_THROW(stan::math::check_matching_sizes("checkMatchingSizes", "x", x,
+                                                   "b", b));
 }
 

--- a/test/unit/math/prim/mat/err/check_multiplicable_test.cpp
+++ b/test/unit/math/prim/mat/err/check_multiplicable_test.cpp
@@ -8,21 +8,21 @@ TEST(ErrorHandlingMatrix, checkMultiplicableMatrix) {
   
   y.resize(3,3);
   x.resize(3,3);
-  EXPECT_TRUE(stan::math::check_multiplicable("checkMultiplicable", "x", x,
-                                                        "y", y));
+  EXPECT_NO_THROW(stan::math::check_multiplicable("checkMultiplicable", "x", x,
+                                                  "y", y));
   x.resize(3,2);
   y.resize(2,4);
-  EXPECT_TRUE(stan::math::check_multiplicable("checkMultiplicable", "x", x,
-                                                        "y", y));
+  EXPECT_NO_THROW(stan::math::check_multiplicable("checkMultiplicable", "x", x,
+                                                  "y", y));
 
   y.resize(1,2);
   EXPECT_THROW(stan::math::check_multiplicable("checkMultiplicable", "x", x,
-                                                         "y", y), 
+                                               "y", y), 
                std::invalid_argument);
 
   x.resize(2,2);
   EXPECT_THROW(stan::math::check_multiplicable("checkMultiplicable", "x", x,
-                                                         "y", y), 
+                                               "y", y), 
                std::invalid_argument);
 }
 
@@ -33,19 +33,19 @@ TEST(ErrorHandlingMatrix, checkMultiplicableMatrix_0) {
   x.resize(3,0);
   y.resize(0,3);
   EXPECT_THROW(stan::math::check_multiplicable("checkMultiplicable", "x", x,
-                                                         "y", y),
+                                               "y", y),
                std::invalid_argument);
 
   x.resize(0,4);
   y.resize(4,3);
   EXPECT_THROW(stan::math::check_multiplicable("checkMultiplicable", "x", x,
-                                                         "y", y),
+                                               "y", y),
                std::invalid_argument);
 
   x.resize(3,4);
   y.resize(4,0);
   EXPECT_THROW(stan::math::check_multiplicable("checkMultiplicable", "x", x,
-                                                         "y", y),
+                                               "y", y),
                std::invalid_argument);
 }
 
@@ -58,24 +58,24 @@ TEST(ErrorHandlingMatrix, checkMultiplicableMatrix_nan) {
   x.resize(3,3);
   y << nan, nan, nan,nan, nan, nan,nan, nan, nan;
   x << nan, nan, nan,nan, nan, nan,nan, nan, nan;
-  EXPECT_TRUE(stan::math::check_multiplicable("checkMultiplicable", "x", x,
-                                                        "y", y));
+  EXPECT_NO_THROW(stan::math::check_multiplicable("checkMultiplicable", "x", x,
+                                                  "y", y));
   x.resize(3,2);
   y.resize(2,4);
   y << nan, nan, nan,nan, nan, nan,nan, nan;
   x << nan, nan, nan,nan, nan, nan;
-  EXPECT_TRUE(stan::math::check_multiplicable("checkMultiplicable", "x", x,
-                                                        "y", y));
+  EXPECT_NO_THROW(stan::math::check_multiplicable("checkMultiplicable", "x", x,
+                                                  "y", y));
 
   y.resize(1,2);
   y << nan, nan;
   EXPECT_THROW(stan::math::check_multiplicable("checkMultiplicable", "x", x,
-                                                         "y", y), 
+                                               "y", y), 
                std::invalid_argument);
 
   x.resize(2,2);
   x << nan, nan, nan, nan;
   EXPECT_THROW(stan::math::check_multiplicable("checkMultiplicable", "x", x,
-                                                         "y", y), 
+                                               "y", y), 
                std::invalid_argument);
 }

--- a/test/unit/math/prim/mat/err/check_nonzero_size_test.cpp
+++ b/test/unit/math/prim/mat/err/check_nonzero_size_test.cpp
@@ -7,11 +7,11 @@ TEST(ErrorHandlingMatrix, checkNonzeroSizeMatrix) {
   using stan::math::check_nonzero_size;
   
   y.resize(3,3);
-  EXPECT_TRUE(check_nonzero_size("checkNonzeroSize",
-                                 "y", y));
+  EXPECT_NO_THROW(check_nonzero_size("checkNonzeroSize",
+                                     "y", y));
   y.resize(2, 3);
-  EXPECT_TRUE(check_nonzero_size("checkNonzeroSize",
-                                 "y", y));
+  EXPECT_NO_THROW(check_nonzero_size("checkNonzeroSize",
+                                     "y", y));
 
   y.resize(0,0);
   EXPECT_THROW_MSG(check_nonzero_size("checkNonzeroSize",
@@ -26,12 +26,12 @@ TEST(ErrorHandlingMatrix, checkNonzeroSizeMatrix_nan) {
 
   y.resize(3,3);
   y << nan, nan, nan,nan, nan, nan,nan, nan, nan;
-  EXPECT_TRUE(stan::math::check_nonzero_size("checkNonzeroSize",
-                                             "y", y));
+  EXPECT_NO_THROW(stan::math::check_nonzero_size("checkNonzeroSize",
+                                                 "y", y));
   y.resize(2, 3);
   y << nan, nan, nan,nan, nan, nan;
-  EXPECT_TRUE(stan::math::check_nonzero_size("checkNonzeroSize",
-                                             "y", y));
+  EXPECT_NO_THROW(stan::math::check_nonzero_size("checkNonzeroSize",
+                                                 "y", y));
 
   y.resize(0,0);
   EXPECT_THROW_MSG(stan::math::check_nonzero_size("checkNonzeroSize", "y", y), 

--- a/test/unit/math/prim/mat/err/check_not_nan_test.cpp
+++ b/test/unit/math/prim/mat/err/check_not_nan_test.cpp
@@ -6,10 +6,10 @@ TEST(ErrorHandlingMatrix, checkNotNanEigenRow) {
   stan::math::vector_d y;
   y.resize(3);
   
-  EXPECT_TRUE(stan::math::check_not_nan("checkNotNanEigenRow(%1)",
-                                        "y", y));
-  EXPECT_TRUE(stan::math::check_not_nan("checkNotNanEigenRow(%1)",
-                                        "y", y));
+  EXPECT_NO_THROW(stan::math::check_not_nan("checkNotNanEigenRow(%1)",
+                                            "y", y));
+  EXPECT_NO_THROW(stan::math::check_not_nan("checkNotNanEigenRow(%1)",
+                                            "y", y));
   
   y(1) = std::numeric_limits<double>::quiet_NaN();
   EXPECT_THROW(stan::math::check_not_nan("checkNotNanEigenRow", "y", y), 

--- a/test/unit/math/prim/mat/err/check_ordered_test.cpp
+++ b/test/unit/math/prim/mat/err/check_ordered_test.cpp
@@ -8,16 +8,16 @@ TEST(ErrorHandlingMatrix, checkOrdered) {
   y.resize(3);
 
   y << 0, 1, 2;
-  EXPECT_TRUE(check_ordered("check_ordered", "y", y));
+  EXPECT_NO_THROW(check_ordered("check_ordered", "y", y));
 
   y << 0, 10, std::numeric_limits<double>::infinity();
-  EXPECT_TRUE(check_ordered("check_ordered", "y", y));
+  EXPECT_NO_THROW(check_ordered("check_ordered", "y", y));
 
   y << -10, 10, std::numeric_limits<double>::infinity();
-  EXPECT_TRUE(check_ordered("check_ordered", "y", y));
+  EXPECT_NO_THROW(check_ordered("check_ordered", "y", y));
 
   y << -std::numeric_limits<double>::infinity(), 10, std::numeric_limits<double>::infinity();
-  EXPECT_TRUE(check_ordered("check_ordered", "y", y));
+  EXPECT_NO_THROW(check_ordered("check_ordered", "y", y));
 
   y << 0, 0, 0;
   EXPECT_THROW(check_ordered("check_ordered", "y", y),

--- a/test/unit/math/prim/mat/err/check_pos_definite_test.cpp
+++ b/test/unit/math/prim/mat/err/check_pos_definite_test.cpp
@@ -17,26 +17,26 @@ TEST_F(ErrorHandlingMatrix, checkPosDefinite) {
 
   y.resize(1,1);
   y << 1;
-  EXPECT_TRUE(check_pos_definite(function, "y", y));
+  EXPECT_NO_THROW(check_pos_definite(function, "y", y));
 
   Eigen::LLT<Eigen::Matrix<double,Eigen::Dynamic,Eigen::Dynamic> > llt_1(y); 
-  EXPECT_TRUE(check_pos_definite(function, "y", llt_1));
+  EXPECT_NO_THROW(check_pos_definite(function, "y", llt_1));
 
   Eigen::LDLT<Eigen::Matrix<double,Eigen::Dynamic,Eigen::Dynamic> > ldlt_1 = y.ldlt(); 
-  EXPECT_TRUE(check_pos_definite(function, "y", ldlt_1));
+  EXPECT_NO_THROW(check_pos_definite(function, "y", ldlt_1));
 
   y.resize(3,3);
   y << 
     1, 0, 0,
     0, 1, 0,
     0, 0, 1;
-  EXPECT_TRUE(check_pos_definite(function, "y", y));
+  EXPECT_NO_THROW(check_pos_definite(function, "y", y));
 
   Eigen::LLT<Eigen::Matrix<double,Eigen::Dynamic,Eigen::Dynamic> > llt_2(y); 
-  EXPECT_TRUE(check_pos_definite(function, "y", llt_2));
+  EXPECT_NO_THROW(check_pos_definite(function, "y", llt_2));
 
   Eigen::LDLT<Eigen::Matrix<double,Eigen::Dynamic,Eigen::Dynamic> > ldlt_2 = y.ldlt(); 
-  EXPECT_TRUE(check_pos_definite(function, "y", ldlt_2));
+  EXPECT_NO_THROW(check_pos_definite(function, "y", ldlt_2));
 }
 
 TEST_F(ErrorHandlingMatrix, checkPosDefinite_not_square) {
@@ -188,8 +188,8 @@ TEST_F(ErrorHandlingMatrix, checkPosDefinite_nan) {
   y << 2, -1, 0,
     -1, 2, -1,
     0, -1, 2;
-  EXPECT_TRUE(check_pos_definite(function, 
-                                 "y", y));
+  EXPECT_NO_THROW(check_pos_definite(function, 
+                                     "y", y));
   for (int i = 0; i < y.rows(); i++)
     for (int j = 0; j < y.cols(); j++) {
       y << 2, -1, 0, -1, 2, -1, 0, -1, 2;

--- a/test/unit/math/prim/mat/err/check_pos_semidefinite_test.cpp
+++ b/test/unit/math/prim/mat/err/check_pos_semidefinite_test.cpp
@@ -17,7 +17,7 @@ TEST_F(ErrorHandlingMatrix, checkPosSemidefinite_size_1) {
   y.resize(1, 1);
 
   y << 0.0;
-  EXPECT_TRUE(check_pos_semidefinite(function, "y", y));  
+  EXPECT_NO_THROW(check_pos_semidefinite(function, "y", y));  
 
   y << -1.0;
   EXPECT_THROW_MSG(check_pos_semidefinite(function, "y", y),
@@ -45,7 +45,7 @@ TEST_F(ErrorHandlingMatrix, checkPosSemidefinite) {
   y.resize(2, 2);
   
   y << 1, 0, 0, 1;
-  EXPECT_TRUE(check_pos_semidefinite(function, "y", y));  
+  EXPECT_NO_THROW(check_pos_semidefinite(function, "y", y));  
 
   y << -1, 0, 0, 1;
   EXPECT_THROW_MSG(check_pos_semidefinite(function, "y", y),
@@ -61,7 +61,7 @@ TEST_F(ErrorHandlingMatrix, checkPosSemidefinite_nan) {
   y << 2, -1, 0,
     -1, 2, -1,
     0, -1, 2;
-  EXPECT_TRUE(check_pos_semidefinite(function, "y", y));
+  EXPECT_NO_THROW(check_pos_semidefinite(function, "y", y));
   for (int i = 0; i < y.rows(); i++)
     for (int j = 0; j < y.cols(); j++) {
       y << 2, -1, 0, -1, 2, -1, 0, -1, 2;

--- a/test/unit/math/prim/mat/err/check_positive_finite_test.cpp
+++ b/test/unit/math/prim/mat/err/check_positive_finite_test.cpp
@@ -9,7 +9,7 @@ TEST(ErrorHandlingScalar,CheckPositiveFinite_Matrix) {
   
   x.resize(3);
   x << 3, 2, 1;
-  ASSERT_TRUE(check_positive_finite(function, "x", x))
+  ASSERT_NO_THROW(check_positive_finite(function, "x", x))
     << "check_positive_finite should be true with finite x";
 
   x.resize(3);

--- a/test/unit/math/prim/mat/err/check_positive_ordered_test.cpp
+++ b/test/unit/math/prim/mat/err/check_positive_ordered_test.cpp
@@ -8,10 +8,10 @@ TEST(ErrorHandlingMatrix, checkPositiveOrdered) {
   y.resize(3);
 
   y << 0, 1, 2;
-  EXPECT_TRUE(check_positive_ordered("check_positive_ordered", "y", y));
+  EXPECT_NO_THROW(check_positive_ordered("check_positive_ordered", "y", y));
 
   y << 0, 10, std::numeric_limits<double>::infinity();
-  EXPECT_TRUE(check_positive_ordered("check_positive_ordered", "y", y));
+  EXPECT_NO_THROW(check_positive_ordered("check_positive_ordered", "y", y));
 
   y << 0, 0, 0;
   EXPECT_THROW(check_positive_ordered("check_positive_ordered", "y", y),

--- a/test/unit/math/prim/mat/err/check_positive_test.cpp
+++ b/test/unit/math/prim/mat/err/check_positive_test.cpp
@@ -8,7 +8,7 @@ TEST(ErrorHandlingScalar,CheckPositive) {
   Eigen::Matrix<double,Eigen::Dynamic,1> x_mat(3);
   x_mat << 1, 2, 3;
   for (int i = 0; i < x_mat.size(); i++) {
-    EXPECT_TRUE(check_positive(function, "x", x_mat));
+    EXPECT_NO_THROW(check_positive(function, "x", x_mat));
   }
 
   x_mat(0) = 0;

--- a/test/unit/math/prim/mat/err/check_range_test.cpp
+++ b/test/unit/math/prim/mat/err/check_range_test.cpp
@@ -3,47 +3,47 @@
 #include <test/unit/util.hpp>
 
 TEST(ErrorHandlingMatrix, checkRange_6_arg_std_vector) {
-    using stan::math::check_range;
-    std::vector<double> x;
+  using stan::math::check_range;
+  std::vector<double> x;
 
-    x.resize(4);
+  x.resize(4);
   
-    EXPECT_TRUE(check_range("function", "x", 4, 1, 4, ""));
-    EXPECT_TRUE(check_range("function", "x", 4, 2, 4, ""));
-    EXPECT_TRUE(check_range("function", "x", 4, 3, 4, ""));
-    EXPECT_TRUE(check_range("function", "x", 4, 4, 4, ""));
+  EXPECT_NO_THROW(check_range("function", "x", 4, 1, 4, ""));
+  EXPECT_NO_THROW(check_range("function", "x", 4, 2, 4, ""));
+  EXPECT_NO_THROW(check_range("function", "x", 4, 3, 4, ""));
+  EXPECT_NO_THROW(check_range("function", "x", 4, 4, 4, ""));
 
 
-    std::string expected_message;
-    expected_message = 
-      "function: accessing element out of range. "
-      "index 12 out of range; "
-      "expecting index to be between 1 and 4; "
-      "index position = 4";
-    EXPECT_THROW_MSG(check_range("function", "x", 4, 12, 4, ""),
-                     std::out_of_range,
-                     expected_message);
+  std::string expected_message;
+  expected_message = 
+    "function: accessing element out of range. "
+    "index 12 out of range; "
+    "expecting index to be between 1 and 4; "
+    "index position = 4";
+  EXPECT_THROW_MSG(check_range("function", "x", 4, 12, 4, ""),
+                   std::out_of_range,
+                   expected_message);
     
 }
 
 TEST(ErrorHandlingMatrix, checkRange_4_arg_std_vector) {
-    using stan::math::check_range;
-    std::vector<double> x;
+  using stan::math::check_range;
+  std::vector<double> x;
 
-    x.resize(4);
+  x.resize(4);
   
-    EXPECT_TRUE(check_range("function", "x", 4, 1));
-    EXPECT_TRUE(check_range("function", "x", 4, 2));
-    EXPECT_TRUE(check_range("function", "x", 4, 3));
-    EXPECT_TRUE(check_range("function", "x", 4, 4));
+  EXPECT_NO_THROW(check_range("function", "x", 4, 1));
+  EXPECT_NO_THROW(check_range("function", "x", 4, 2));
+  EXPECT_NO_THROW(check_range("function", "x", 4, 3));
+  EXPECT_NO_THROW(check_range("function", "x", 4, 4));
 
 
-    std::string expected_message;
-    expected_message = 
-      "function: accessing element out of range. "
-      "index 12 out of range; "
-      "expecting index to be between 1 and 4";
-    EXPECT_THROW_MSG(check_range("function", "x", 4, 12),
-                     std::out_of_range,
-                     expected_message);
+  std::string expected_message;
+  expected_message = 
+    "function: accessing element out of range. "
+    "index 12 out of range; "
+    "expecting index to be between 1 and 4";
+  EXPECT_THROW_MSG(check_range("function", "x", 4, 12),
+                   std::out_of_range,
+                   expected_message);
 }

--- a/test/unit/math/prim/mat/err/check_row_index_test.cpp
+++ b/test/unit/math/prim/mat/err/check_row_index_test.cpp
@@ -7,20 +7,20 @@ TEST(ErrorHandlingMatrix, checkRowIndexMatrix) {
   
   i=2;
   y.resize(3,3);
-  EXPECT_TRUE(stan::math::check_row_index("checkRowIndexMatrix",
-                                                    "i", y, i));
+  EXPECT_NO_THROW(stan::math::check_row_index("checkRowIndexMatrix",
+                                              "i", y, i));
   i=3;
-  EXPECT_TRUE(stan::math::check_row_index("checkRowIndexMatrix",
-                                                    "i", y, i));
+  EXPECT_NO_THROW(stan::math::check_row_index("checkRowIndexMatrix",
+                                              "i", y, i));
 
   y.resize(2, 3);
   EXPECT_THROW(stan::math::check_row_index("checkRowIndexMatrix",
-                                                     "i", y, i), 
+                                           "i", y, i), 
                std::out_of_range);
 
   i=0;
   EXPECT_THROW(stan::math::check_row_index("checkRowIndexMatrix",
-                                                     "i", y, i), 
+                                           "i", y, i), 
                std::out_of_range);
 }
 
@@ -32,20 +32,20 @@ TEST(ErrorHandlingMatrix, checkRowIndexMatrix_nan) {
   i=2;
   y.resize(3,3);
   y << nan, nan, nan,nan, nan, nan,nan, nan, nan;
-  EXPECT_TRUE(stan::math::check_row_index("checkRowIndexMatrix",
-                                                    "i", y, i));
+  EXPECT_NO_THROW(stan::math::check_row_index("checkRowIndexMatrix",
+                                              "i", y, i));
   i=3;
-  EXPECT_TRUE(stan::math::check_row_index("checkRowIndexMatrix",
-                                                    "i", y, i));
+  EXPECT_NO_THROW(stan::math::check_row_index("checkRowIndexMatrix",
+                                              "i", y, i));
 
   y.resize(2, 3);
   y << nan, nan, nan,nan, nan, nan;
   EXPECT_THROW(stan::math::check_row_index("checkRowIndexMatrix",
-                                                     "i", y, i), 
+                                           "i", y, i), 
                std::out_of_range);
 
   i=0;
   EXPECT_THROW(stan::math::check_row_index("checkRowIndexMatrix",
-                                                     "i", y, i), 
+                                           "i", y, i), 
                std::out_of_range);
 }

--- a/test/unit/math/prim/mat/err/check_simplex_test.cpp
+++ b/test/unit/math/prim/mat/err/check_simplex_test.cpp
@@ -7,12 +7,12 @@ TEST(ErrorHandlingMatrix, checkSimplex) {
   y.setZero();
   y << 0.5, 0.5;
   
-  EXPECT_TRUE(stan::math::check_simplex("checkSimplex",
-                                                  "y", y));
+  EXPECT_NO_THROW(stan::math::check_simplex("checkSimplex",
+                                            "y", y));
                   
   y[1] = 0.55;
   EXPECT_THROW(stan::math::check_simplex("checkSimplex", 
-                                                   "y", y), 
+                                         "y", y), 
                std::domain_error);
 }
 
@@ -26,7 +26,7 @@ TEST(ErrorHandlingMatrix, checkSimplex_message_negative_value) {
   y[1] = 1.1;
   try {
     stan::math::check_simplex("checkSimplex",
-                                        "y", y);
+                              "y", y);
     FAIL() << "should have thrown";
   } catch (std::domain_error& e) {
     message = e.what();
@@ -34,10 +34,10 @@ TEST(ErrorHandlingMatrix, checkSimplex_message_negative_value) {
     FAIL() << "threw the wrong error";
   }
 
-  EXPECT_TRUE(std::string::npos != message.find(" y is not a valid simplex"))
+  EXPECT_NO_THROW(std::string::npos != message.find(" y is not a valid simplex"))
     << message;
 
-  EXPECT_TRUE(std::string::npos != message.find("y[1] = -0.1"))
+  EXPECT_NO_THROW(std::string::npos != message.find("y[1] = -0.1"))
     << message;
 
 
@@ -48,7 +48,7 @@ TEST(ErrorHandlingMatrix, checkSimplex_message_negative_value) {
   y[2] = 1.0;
   try {
     stan::math::check_simplex("checkSimplex",
-                                        "y", y);
+                              "y", y);
     FAIL() << "should have thrown";
   } catch (std::domain_error& e) {
     message = e.what();
@@ -56,10 +56,10 @@ TEST(ErrorHandlingMatrix, checkSimplex_message_negative_value) {
     FAIL() << "threw the wrong error";
   }
 
-  EXPECT_TRUE(std::string::npos != message.find(" y is not a valid simplex"))
+  EXPECT_NO_THROW(std::string::npos != message.find(" y is not a valid simplex"))
     << message;
 
-  EXPECT_TRUE(std::string::npos != message.find(" y[2] = -0.1"))
+  EXPECT_NO_THROW(std::string::npos != message.find(" y[2] = -0.1"))
     << message;
 }
 
@@ -72,7 +72,7 @@ TEST(ErrorHandlingMatrix, checkSimplex_message_sum) {
 
   try {
     stan::math::check_simplex("checkSimplex",
-                                        "y", y);
+                              "y", y);
     FAIL() << "should have thrown";
   } catch (std::domain_error& e) {
     message = e.what();
@@ -80,10 +80,10 @@ TEST(ErrorHandlingMatrix, checkSimplex_message_sum) {
     FAIL() << "threw the wrong error";
   }
 
-  EXPECT_TRUE(std::string::npos != message.find(" y is not a valid simplex"))
+  EXPECT_NO_THROW(std::string::npos != message.find(" y is not a valid simplex"))
     << message;
 
-  EXPECT_TRUE(std::string::npos != message.find("sum(y) = 0.9"))
+  EXPECT_NO_THROW(std::string::npos != message.find("sum(y) = 0.9"))
     << message;
 }
 
@@ -108,22 +108,22 @@ TEST(ErrorHandlingMatrix, checkSimplex_nan) {
   y << nan, 0.5;
   
   EXPECT_THROW(stan::math::check_simplex("checkSimplex",
-                                                   "y", y),
+                                         "y", y),
                std::domain_error);
                   
   y[1] = 0.55;
   EXPECT_THROW(stan::math::check_simplex("checkSimplex", 
-                                                   "y", y), 
+                                         "y", y), 
                std::domain_error);
 
   y[0] = 0.5;
   y[1] = nan;
   EXPECT_THROW(stan::math::check_simplex("checkSimplex", 
-                                                   "y", y), 
+                                         "y", y), 
                std::domain_error);
 
   y[0] = nan;
   EXPECT_THROW(stan::math::check_simplex("checkSimplex", 
-                                                   "y", y), 
+                                         "y", y), 
                std::domain_error);
 }

--- a/test/unit/math/prim/mat/err/check_simplex_test.cpp
+++ b/test/unit/math/prim/mat/err/check_simplex_test.cpp
@@ -34,10 +34,10 @@ TEST(ErrorHandlingMatrix, checkSimplex_message_negative_value) {
     FAIL() << "threw the wrong error";
   }
 
-  EXPECT_NO_THROW(std::string::npos != message.find(" y is not a valid simplex"))
+  EXPECT_TRUE(std::string::npos != message.find(" y is not a valid simplex"))
     << message;
 
-  EXPECT_NO_THROW(std::string::npos != message.find("y[1] = -0.1"))
+  EXPECT_TRUE(std::string::npos != message.find("y[1] = -0.1"))
     << message;
 
 
@@ -56,10 +56,10 @@ TEST(ErrorHandlingMatrix, checkSimplex_message_negative_value) {
     FAIL() << "threw the wrong error";
   }
 
-  EXPECT_NO_THROW(std::string::npos != message.find(" y is not a valid simplex"))
+  EXPECT_TRUE(std::string::npos != message.find(" y is not a valid simplex"))
     << message;
 
-  EXPECT_NO_THROW(std::string::npos != message.find(" y[2] = -0.1"))
+  EXPECT_TRUE(std::string::npos != message.find(" y[2] = -0.1"))
     << message;
 }
 
@@ -80,10 +80,10 @@ TEST(ErrorHandlingMatrix, checkSimplex_message_sum) {
     FAIL() << "threw the wrong error";
   }
 
-  EXPECT_NO_THROW(std::string::npos != message.find(" y is not a valid simplex"))
+  EXPECT_TRUE(std::string::npos != message.find(" y is not a valid simplex"))
     << message;
 
-  EXPECT_NO_THROW(std::string::npos != message.find("sum(y) = 0.9"))
+  EXPECT_TRUE(std::string::npos != message.find("sum(y) = 0.9"))
     << message;
 }
 

--- a/test/unit/math/prim/mat/err/check_spsd_matrix_test.cpp
+++ b/test/unit/math/prim/mat/err/check_spsd_matrix_test.cpp
@@ -6,21 +6,21 @@ TEST(ErrorHandlingMatrix, checkSpsdMatrixPosDef) {
   
   y.resize(3,3);
   y << 2, -1, 0, -1, 2, -1, 0, -1, 2;
-  EXPECT_TRUE(stan::math::check_spsd_matrix("checkSpsdMatrix",
-                                                      "y", y));
+  EXPECT_NO_THROW(stan::math::check_spsd_matrix("checkSpsdMatrix",
+                                                "y", y));
 
   y << 1, 2, 3, 2, 1, 2, 3, 2, 1;
   EXPECT_THROW(stan::math::check_spsd_matrix("checkSpsdMatrix", "y", y), 
                std::domain_error);
 
   y.setZero();
-  EXPECT_TRUE(stan::math::check_spsd_matrix("checkSpsdMatrix", "y", y));
+  EXPECT_NO_THROW(stan::math::check_spsd_matrix("checkSpsdMatrix", "y", y));
 }
 
 TEST(ErrorHandlingMatrix, checkSpsdMatrixZero) {
   Eigen::Matrix<double,Eigen::Dynamic,Eigen::Dynamic> y = 
     Eigen::Matrix<double,Eigen::Dynamic,Eigen::Dynamic>::Zero(3,3);
-  EXPECT_TRUE(stan::math::check_spsd_matrix("checkSpsdMatrix", "y", y));
+  EXPECT_NO_THROW(stan::math::check_spsd_matrix("checkSpsdMatrix", "y", y));
 }
 
 TEST(ErrorHandlingMatrix, checkSpsdNotSquare) {
@@ -36,23 +36,23 @@ TEST(ErrorHandlingMatrix, checkSpsdMatrixPosDef_nan) {
 
   y.resize(3,3);
   y << 2, -1, 0, -1, 2, -1, 0, -1, 2;
-  EXPECT_TRUE(stan::math::check_spsd_matrix("checkSpsdMatrix",
-                                           "y", y));
+  EXPECT_NO_THROW(stan::math::check_spsd_matrix("checkSpsdMatrix",
+                                                "y", y));
 
   y.setZero();
-  EXPECT_TRUE(stan::math::check_spsd_matrix("checkSpsdMatrix", "y", y));
+  EXPECT_NO_THROW(stan::math::check_spsd_matrix("checkSpsdMatrix", "y", y));
 
   for (int i = 0; i < y.size(); i++) {
     y << 2, -1, 0, -1, 2, -1, 0, -1, 2;
     y(i) = nan;
     EXPECT_THROW(stan::math::check_spsd_matrix("checkSpsdMatrix",
-                                                         "y", y),
+                                               "y", y),
                  std::domain_error);
 
     y.setZero();
     y(i) = nan;
     EXPECT_THROW(stan::math::check_spsd_matrix("checkSpsdMatrix",
-                                                         "y", y),
+                                               "y", y),
                  std::domain_error);
   }
 }

--- a/test/unit/math/prim/mat/err/check_square_test.cpp
+++ b/test/unit/math/prim/mat/err/check_square_test.cpp
@@ -5,8 +5,8 @@ TEST(ErrorHandlingMatrix, checkSquareMatrix) {
   Eigen::Matrix<double,Eigen::Dynamic,Eigen::Dynamic> y;
   
   y.resize(3,3);
-  EXPECT_TRUE(stan::math::check_square("checkSquareMatrix",
-                                                 "y", y));
+  EXPECT_NO_THROW(stan::math::check_square("checkSquareMatrix",
+                                           "y", y));
 
   y.resize(3, 2);
   EXPECT_THROW(stan::math::check_square("checkSquareMatrix", "y", y), 
@@ -19,8 +19,8 @@ TEST(ErrorHandlingMatrix, checkSquareMatrix_nan) {
 
   y.resize(3,3);
   y << nan, nan, nan,nan, nan, nan,nan, nan, nan;
-  EXPECT_TRUE(stan::math::check_square("checkSquareMatrix",
-                                                 "y", y));
+  EXPECT_NO_THROW(stan::math::check_square("checkSquareMatrix",
+                                           "y", y));
 
   y.resize(3, 2);
   y << nan, nan, nan,nan, nan, nan;
@@ -32,8 +32,8 @@ TEST(ErrorHandlingMatrix, checkSquareMatrix_0x0) {
   Eigen::Matrix<double,Eigen::Dynamic,Eigen::Dynamic> y;
   
   y.resize(0,0);
-  EXPECT_TRUE(stan::math::check_square("checkSquareMatrix",
-                                                 "y", y));
+  EXPECT_NO_THROW(stan::math::check_square("checkSquareMatrix",
+                                           "y", y));
 }
 
 TEST(ErrorHandlingMatrix, checkSquareMatrix_0_size) {
@@ -41,12 +41,12 @@ TEST(ErrorHandlingMatrix, checkSquareMatrix_0_size) {
   
   y.resize(0,10);
   EXPECT_THROW(stan::math::check_square("checkSquareMatrix",
-                                                  "y", y),
+                                        "y", y),
                std::invalid_argument);
 
   y.resize(10,0);
   EXPECT_THROW(stan::math::check_square("checkSquareMatrix",
-                                                  "y", y),
+                                        "y", y),
                std::invalid_argument);
 
 }

--- a/test/unit/math/prim/mat/err/check_std_vector_index_test.cpp
+++ b/test/unit/math/prim/mat/err/check_std_vector_index_test.cpp
@@ -11,20 +11,20 @@ TEST(ErrorHandlingMatrix, checkStdVectorIndexMatrix) {
   
   i=2;
   y.resize(3);
-  EXPECT_TRUE(stan::math::check_std_vector_index("checkStdVectorIndexMatrix",
-                                                           "i", y, i));
+  EXPECT_NO_THROW(stan::math::check_std_vector_index("checkStdVectorIndexMatrix",
+                                                     "i", y, i));
   i=3;
-  EXPECT_TRUE(stan::math::check_std_vector_index("checkStdVectorIndexMatrix",
-                                                           "i", y, i));
+  EXPECT_NO_THROW(stan::math::check_std_vector_index("checkStdVectorIndexMatrix",
+                                                     "i", y, i));
 
   y.resize(2);
   EXPECT_THROW(stan::math::check_std_vector_index("checkStdVectorIndexMatrix",
-                                                            "i", y, i),
+                                                  "i", y, i),
                std::out_of_range);
 
   i=0;
   EXPECT_THROW(stan::math::check_std_vector_index("checkStdVectorIndexMatrix",
-                                                            "i", y, i),
+                                                  "i", y, i),
                std::out_of_range);
 }
 
@@ -39,19 +39,19 @@ TEST(ErrorHandlingMatrix, checkStdVectorIndexMatrix_nan) {
   
   i=2;
   y.resize(3);
-  EXPECT_TRUE(stan::math::check_std_vector_index("checkStdVectorIndexMatrix",
-                                                           "i", y, i));
+  EXPECT_NO_THROW(stan::math::check_std_vector_index("checkStdVectorIndexMatrix",
+                                                     "i", y, i));
   i=3;
-  EXPECT_TRUE(stan::math::check_std_vector_index("checkStdVectorIndexMatrix",
-                                                           "i", y, i));
+  EXPECT_NO_THROW(stan::math::check_std_vector_index("checkStdVectorIndexMatrix",
+                                                     "i", y, i));
 
   y.resize(2);
   EXPECT_THROW(stan::math::check_std_vector_index("checkStdVectorIndexMatrix",
-                                                            "i", y, i),
+                                                  "i", y, i),
                std::out_of_range);
 
   i=0;
   EXPECT_THROW(stan::math::check_std_vector_index("checkStdVectorIndexMatrix",
-                                                            "i", y, i),
+                                                  "i", y, i),
                std::out_of_range);
 }

--- a/test/unit/math/prim/mat/err/check_symmetric_test.cpp
+++ b/test/unit/math/prim/mat/err/check_symmetric_test.cpp
@@ -6,8 +6,8 @@ TEST(ErrorHandlingMatrix, checkSymmetric) {
   
   y.resize(2,2);
   y << 1, 3, 3, 1;
-  EXPECT_TRUE(stan::math::check_symmetric("checkSymmetric",
-                                                    "y", y));
+  EXPECT_NO_THROW(stan::math::check_symmetric("checkSymmetric",
+                                              "y", y));
 
   y(0,1) = 3.5;
   EXPECT_THROW(stan::math::check_symmetric("checkSymmetric", "y", y),
@@ -42,16 +42,16 @@ TEST(ErrorHandlingMatrix, checkSymmetric_nan) {
   y.resize(2,2);
   y << 1, nan, 3, 1;
   EXPECT_THROW(stan::math::check_symmetric("checkSymmetric",
-                                                     "y", y),
+                                           "y", y),
                std::domain_error);
   y << nan, 3, 3, 1;
-  EXPECT_TRUE(stan::math::check_symmetric("checkSymmetric",
-                                                    "y", y));
+  EXPECT_NO_THROW(stan::math::check_symmetric("checkSymmetric",
+                                              "y", y));
 
   y.resize(1,1);
   y << nan;
-  EXPECT_TRUE(stan::math::check_symmetric("checkSymmetric",
-                                                    "y", y));
+  EXPECT_NO_THROW(stan::math::check_symmetric("checkSymmetric",
+                                              "y", y));
 }
 
 TEST(ErrorHandlingMatrix, checkSymmetric_non_square) {
@@ -59,7 +59,7 @@ TEST(ErrorHandlingMatrix, checkSymmetric_non_square) {
   
   y.resize(2,3);
   EXPECT_THROW(stan::math::check_symmetric("checkSymmetric",
-                                                     "y", y),
+                                           "y", y),
                std::invalid_argument);
 
 }

--- a/test/unit/math/prim/mat/err/check_unit_vector_test.cpp
+++ b/test/unit/math/prim/mat/err/check_unit_vector_test.cpp
@@ -6,8 +6,8 @@ TEST(ErrorHandlingMatrix, checkUnitVector) {
   Eigen::Matrix<double,Eigen::Dynamic,1> y(2);
   y << sqrt(0.5), sqrt(0.5);
   
-  EXPECT_TRUE(stan::math::check_unit_vector("checkUnitVector",
-                                                      "y", y));
+  EXPECT_NO_THROW(stan::math::check_unit_vector("checkUnitVector",
+                                                "y", y));
 
   y[1] = 0;
   EXPECT_THROW(stan::math::check_unit_vector("checkUnitVector", "y", y),

--- a/test/unit/math/prim/mat/err/check_vector_test.cpp
+++ b/test/unit/math/prim/mat/err/check_vector_test.cpp
@@ -12,10 +12,10 @@ TEST(ErrorHandlingMatrix, checkVectorMatrix) {
                std::invalid_argument);
 
   x.resize(1,5);
-  EXPECT_TRUE(stan::math::check_vector("checkVector", "x", x));
+  EXPECT_NO_THROW(stan::math::check_vector("checkVector", "x", x));
 
   x.resize(5,1);
-  EXPECT_TRUE(stan::math::check_vector("checkVector", "x", x));
+  EXPECT_NO_THROW(stan::math::check_vector("checkVector", "x", x));
 }
 
 TEST(ErrorHandlingMatrix, checkVectorMatrix_nan) {
@@ -32,9 +32,9 @@ TEST(ErrorHandlingMatrix, checkVectorMatrix_nan) {
 
   x.resize(1,5);
   x << nan, nan, nan,nan, nan;
-  EXPECT_TRUE(stan::math::check_vector("checkVector", "x", x));
+  EXPECT_NO_THROW(stan::math::check_vector("checkVector", "x", x));
 
   x.resize(5,1);
   x << nan, nan, nan,nan, nan;
-  EXPECT_TRUE(stan::math::check_vector("checkVector", "x", x));
+  EXPECT_NO_THROW(stan::math::check_vector("checkVector", "x", x));
 }

--- a/test/unit/math/prim/scal/err/check_bounded_test.cpp
+++ b/test/unit/math/prim/scal/err/check_bounded_test.cpp
@@ -10,15 +10,15 @@ TEST(ErrorHandlingScalar,CheckBounded_x) {
   double low = -1;
   double high = 1;
  
-  EXPECT_TRUE(check_bounded(function, name, x, low, high))
+  EXPECT_NO_THROW(check_bounded(function, name, x, low, high))
     << "check_bounded should be TRUE with x: " << x << " and bounds: " << low << ", " << high;
   
   x = low;
-  EXPECT_TRUE(check_bounded(function, name, x, low, high)) 
+  EXPECT_NO_THROW(check_bounded(function, name, x, low, high)) 
     << "check_bounded should be TRUE with x: " << x << " equal to the lower bound: " << low;
 
   x = high;
-  EXPECT_TRUE(check_bounded(function, name, x, low, high)) 
+  EXPECT_NO_THROW(check_bounded(function, name, x, low, high)) 
     << "check_bounded should be TRUE with x: " << x << " equal to the lower bound: " << low;
 
   x = low-1;
@@ -49,11 +49,11 @@ TEST(ErrorHandlingScalar,CheckBounded_Low) {
   double low = -1;
   double high = 1;
  
-  EXPECT_TRUE(check_bounded(function, name, x, low, high))
+  EXPECT_NO_THROW(check_bounded(function, name, x, low, high))
     << "check_bounded should be true x: " << x << " and bounds: " << low << ", " << high;
   
   low = -std::numeric_limits<double>::infinity();
-  EXPECT_TRUE(check_bounded(function, name, x, low, high))
+  EXPECT_NO_THROW(check_bounded(function, name, x, low, high))
     << "check_bounded should be TRUE with x: " << x << " and bounds: " << low << ", " << high;
 
   low = std::numeric_limits<double>::quiet_NaN();
@@ -72,11 +72,11 @@ TEST(ErrorHandlingScalar,CheckBounded_High) {
   double low = -1;
   double high = 1;
  
-  EXPECT_TRUE(check_bounded(function, name, x, low, high))
+  EXPECT_NO_THROW(check_bounded(function, name, x, low, high))
     << "check_bounded should be true x: " << x << " and bounds: " << low << ", " << high;
 
   high = std::numeric_limits<double>::infinity();
-  EXPECT_TRUE(check_bounded(function, name, x, low, high)) 
+  EXPECT_NO_THROW(check_bounded(function, name, x, low, high)) 
     << "check_bounded should be TRUE with x: " << x << " and bounds: " << low << ", " << high;
   
   high = std::numeric_limits<double>::quiet_NaN();

--- a/test/unit/math/prim/scal/err/check_equal_test.cpp
+++ b/test/unit/math/prim/scal/err/check_equal_test.cpp
@@ -8,7 +8,7 @@ TEST(ErrorHandlingScalar,CheckEqual) {
   double x = 0.0;
   double eq = 0.0;
  
-  EXPECT_TRUE(check_equal(function, "x", x, eq))
+  EXPECT_NO_THROW(check_equal(function, "x", x, eq))
     << "check_equal should be true with x = eq";
   
   x = -1.0;

--- a/test/unit/math/prim/scal/err/check_finite_test.cpp
+++ b/test/unit/math/prim/scal/err/check_finite_test.cpp
@@ -7,7 +7,7 @@ TEST(ErrorHandlingScalar,CheckFinite) {
   const char* function = "check_finite";
   double x = 0;
  
-  EXPECT_TRUE(check_finite(function, "x", x))
+  EXPECT_NO_THROW(check_finite(function, "x", x))
     << "check_finite should be true with finite x: " << x;
   x = std::numeric_limits<double>::infinity();
   EXPECT_THROW(check_finite(function, "x", x), std::domain_error)

--- a/test/unit/math/prim/scal/err/check_greater_or_equal_test.cpp
+++ b/test/unit/math/prim/scal/err/check_greater_or_equal_test.cpp
@@ -8,7 +8,7 @@ TEST(ErrorHandlingScalar,CheckGreaterOrEqual) {
   double x = 10.0;
   double lb = 0.0;
  
-  EXPECT_TRUE(check_greater_or_equal(function, "x", x, lb)) 
+  EXPECT_NO_THROW(check_greater_or_equal(function, "x", x, lb)) 
     << "check_greater_or_equal should be true with x > lb";
   
   x = -1.0;
@@ -21,7 +21,7 @@ TEST(ErrorHandlingScalar,CheckGreaterOrEqual) {
     << "check_greater_or_equal should not throw an exception with x == lb";
 
   x = std::numeric_limits<double>::infinity();
-  EXPECT_TRUE(check_greater_or_equal(function, "x", x, lb))
+  EXPECT_NO_THROW(check_greater_or_equal(function, "x", x, lb))
     << "check_greater should be true with x == Inf and lb = 0.0";
 
   x = 10.0;

--- a/test/unit/math/prim/scal/err/check_greater_test.cpp
+++ b/test/unit/math/prim/scal/err/check_greater_test.cpp
@@ -8,7 +8,7 @@ TEST(ErrorHandlingScalar,CheckGreater) {
   double x = 10.0;
   double lb = 0.0;
  
-  EXPECT_TRUE(check_greater(function, "x", x, lb)) 
+  EXPECT_NO_THROW(check_greater(function, "x", x, lb)) 
     << "check_greater should be true with x > lb";
   
   x = -1.0;
@@ -20,7 +20,7 @@ TEST(ErrorHandlingScalar,CheckGreater) {
     << "check_greater should throw an exception with x == lb";
 
   x = std::numeric_limits<double>::infinity();
-  EXPECT_TRUE(check_greater(function, "x", x, lb))
+  EXPECT_NO_THROW(check_greater(function, "x", x, lb))
     << "check_greater should be true with x == Inf and lb = 0.0";
 
   x = 10.0;

--- a/test/unit/math/prim/scal/err/check_less_or_equal_test.cpp
+++ b/test/unit/math/prim/scal/err/check_less_or_equal_test.cpp
@@ -8,7 +8,7 @@ TEST(ErrorHandlingScalar,CheckLessOrEqual) {
   double x = -10.0;
   double lb = 0.0;
  
-  EXPECT_TRUE(check_less_or_equal(function, "x", x, lb))
+  EXPECT_NO_THROW(check_less_or_equal(function, "x", x, lb))
     << "check_less_or_equal should be true with x < lb";
   
   x = 1.0;
@@ -21,7 +21,7 @@ TEST(ErrorHandlingScalar,CheckLessOrEqual) {
     << "check_less_or_equal should not throw an exception with x == lb";
 
   x = -std::numeric_limits<double>::infinity();
-  EXPECT_TRUE(check_less_or_equal(function, "x", x, lb))
+  EXPECT_NO_THROW(check_less_or_equal(function, "x", x, lb))
     << "check_less should be true with x == -Inf and lb = 0.0";
 
   x = -10.0;

--- a/test/unit/math/prim/scal/err/check_less_test.cpp
+++ b/test/unit/math/prim/scal/err/check_less_test.cpp
@@ -8,7 +8,7 @@ TEST(ErrorHandlingScalar,CheckLess) {
   double x = -10.0;
   double lb = 0.0;
  
-  EXPECT_TRUE(check_less(function, "x", x, lb)) 
+  EXPECT_NO_THROW(check_less(function, "x", x, lb)) 
     << "check_less should be true with x < lb";
   
   x = 1.0;
@@ -20,7 +20,7 @@ TEST(ErrorHandlingScalar,CheckLess) {
     << "check_less should throw an exception with x == lb";
 
   x = -std::numeric_limits<double>::infinity();
-  EXPECT_TRUE(check_less(function, "x", x, lb))
+  EXPECT_NO_THROW(check_less(function, "x", x, lb))
     << "check_less should be true with x == -Inf and lb = 0.0";
 
   x = -10.0;

--- a/test/unit/math/prim/scal/err/check_nonnegative_test.cpp
+++ b/test/unit/math/prim/scal/err/check_nonnegative_test.cpp
@@ -7,11 +7,11 @@ TEST(ErrorHandlingScalar,CheckNonnegative) {
   const char* function = "check_nonnegative";
   double x = 0;
 
-  EXPECT_TRUE(check_nonnegative(function, "x", x)) 
+  EXPECT_NO_THROW(check_nonnegative(function, "x", x)) 
     << "check_nonnegative should be true with finite x: " << x;
 
   x = std::numeric_limits<double>::infinity();
-  EXPECT_TRUE(check_nonnegative(function, "x", x)) 
+  EXPECT_NO_THROW(check_nonnegative(function, "x", x)) 
     << "check_nonnegative should be true with x = Inf: " << x;
 
   x = -0.01;

--- a/test/unit/math/prim/scal/err/check_not_nan_test.cpp
+++ b/test/unit/math/prim/scal/err/check_not_nan_test.cpp
@@ -7,15 +7,15 @@ TEST(ErrorHandlingScalar,CheckNotNan) {
   const char* function = "check_not_nan";
   double x = 0;
 
-  EXPECT_TRUE(check_not_nan(function, "x", x))
+  EXPECT_NO_THROW(check_not_nan(function, "x", x))
     << "check_not_nan should be true with finite x: " << x;
 
   x = std::numeric_limits<double>::infinity();
-  EXPECT_TRUE(check_not_nan(function, "x", x))
+  EXPECT_NO_THROW(check_not_nan(function, "x", x))
     << "check_not_nan should be true with x = Inf: " << x;
 
   x = -std::numeric_limits<double>::infinity();
-  EXPECT_TRUE(check_not_nan(function, "x", x))
+  EXPECT_NO_THROW(check_not_nan(function, "x", x))
     << "check_not_nan should be true with x = -Inf: " << x;
 
   x = std::numeric_limits<double>::quiet_NaN();

--- a/test/unit/math/prim/scal/err/check_positive_finite_test.cpp
+++ b/test/unit/math/prim/scal/err/check_positive_finite_test.cpp
@@ -7,7 +7,7 @@ TEST(ErrorHandlingScalar,CheckPositiveFinite) {
   const char* function = "check_positive_finite";
   double x = 1;
  
-  EXPECT_TRUE(check_positive_finite(function, "x", x))
+  EXPECT_NO_THROW(check_positive_finite(function, "x", x))
     << "check_positive_finite should be true with finite x: " << x;
   x = -1;
   EXPECT_THROW(check_positive_finite(function, "x", x), std::domain_error)

--- a/test/unit/math/prim/scal/err/check_positive_size_test.cpp
+++ b/test/unit/math/prim/scal/err/check_positive_size_test.cpp
@@ -10,7 +10,7 @@ TEST(ErrorHandlingScalar, CheckPositiveSize) {
   std::string expected_msg;
 
   
-  EXPECT_TRUE(check_positive_size(function, name, expr, 10));
+  EXPECT_NO_THROW(check_positive_size(function, name, expr, 10));
 
   
   expected_msg = "name must have a positive size, but is 0; "

--- a/test/unit/math/prim/scal/err/check_positive_test.cpp
+++ b/test/unit/math/prim/scal/err/check_positive_test.cpp
@@ -5,7 +5,7 @@ TEST(ErrorHandlingScalar,CheckPositive) {
   using stan::math::check_positive;
   const char* function = "check_positive";
 
-  EXPECT_TRUE(check_positive(function, "x", nan));
+  EXPECT_NO_THROW(check_positive(function, "x", nan));
 }
 
 TEST(ErrorHandlingScalar,CheckPositive_nan) {

--- a/test/unit/math/prim/scal/err/check_size_match_test.cpp
+++ b/test/unit/math/prim/scal/err/check_size_match_test.cpp
@@ -29,9 +29,9 @@ TEST(ErrorHandlingMatrix, checkSizeMatch) {
 
   x = 2;
   y = 2;
-  EXPECT_TRUE(check_size_match("checkSizeMatch", "x", x, "y", y));
-  EXPECT_TRUE(check_size_match("checkSizeMatch", "expr_x ", "x", x, "expr_y ", "y", y));
-  EXPECT_TRUE(check_size_match("checkSizeMatch", "y", y, "x", x));
-  EXPECT_TRUE(check_size_match("checkSizeMatch", "expr_y ", "y", y, "expr_x", "x", x));
+  EXPECT_NO_THROW(check_size_match("checkSizeMatch", "x", x, "y", y));
+  EXPECT_NO_THROW(check_size_match("checkSizeMatch", "expr_x ", "x", x, "expr_y ", "y", y));
+  EXPECT_NO_THROW(check_size_match("checkSizeMatch", "y", y, "x", x));
+  EXPECT_NO_THROW(check_size_match("checkSizeMatch", "expr_y ", "y", y, "expr_x", "x", x));
 }
 

--- a/test/unit/math/rev/arr/err/check_bounded_test.cpp
+++ b/test/unit/math/rev/arr/err/check_bounded_test.cpp
@@ -11,12 +11,12 @@ TEST(AgradRevErrorHandlingScalar, CheckBoundedVarCheckVectorized) {
   vector<var> a;
 
   for (int i = 0; i < N; ++i)
-   a.push_back(var(i));
+    a.push_back(var(i));
 
   size_t stack_size = stan::math::ChainableStack::var_stack_.size();
 
   EXPECT_EQ(5U,stack_size);
-  EXPECT_TRUE(check_bounded(function,"a",a,-1.0,6.0));
+  EXPECT_NO_THROW(check_bounded(function,"a",a,-1.0,6.0));
 
   size_t stack_size_after_call = stan::math::ChainableStack::var_stack_.size();
   EXPECT_EQ(5U,stack_size_after_call);

--- a/test/unit/math/rev/arr/err/check_consistent_size_test.cpp
+++ b/test/unit/math/rev/arr/err/check_consistent_size_test.cpp
@@ -11,12 +11,12 @@ TEST(AgradRevErrorHandlingScalar, CheckConsistentSizeVarCheckVectorized) {
   vector<var> a;
 
   for (int i = 0; i < N; ++i)
-   a.push_back(var(i));
+    a.push_back(var(i));
 
   size_t stack_size = stan::math::ChainableStack::var_stack_.size();
 
   EXPECT_EQ(5U,stack_size);
-  EXPECT_TRUE(check_consistent_size(function,"a",a,5U));
+  EXPECT_NO_THROW(check_consistent_size(function,"a",a,5U));
 
   size_t stack_size_after_call = stan::math::ChainableStack::var_stack_.size();
   EXPECT_EQ(5U,stack_size_after_call);

--- a/test/unit/math/rev/arr/err/check_consistent_sizes_test.cpp
+++ b/test/unit/math/rev/arr/err/check_consistent_sizes_test.cpp
@@ -12,14 +12,14 @@ TEST(AgradRevErrorHandlingScalar, CheckConsistentSizeVarCheckVectorized) {
   vector<var> b;
 
   for (int i = 0; i < N; ++i){
-   b.push_back(var(i+1));
-   a.push_back(var(i));
+    b.push_back(var(i+1));
+    a.push_back(var(i));
   }
 
   size_t stack_size = stan::math::ChainableStack::var_stack_.size();
 
   EXPECT_EQ(10U,stack_size);
-  EXPECT_TRUE(check_consistent_sizes(function,"a",a,"b",b));
+  EXPECT_NO_THROW(check_consistent_sizes(function,"a",a,"b",b));
 
   size_t stack_size_after_call = stan::math::ChainableStack::var_stack_.size();
   EXPECT_EQ(10U,stack_size_after_call);

--- a/test/unit/math/rev/arr/err/check_equal_test.cpp
+++ b/test/unit/math/rev/arr/err/check_equal_test.cpp
@@ -13,14 +13,14 @@ TEST(AgradRevErrorHandlingScalar, CheckNotNanVarCheckVectorized) {
   vector<var> b;
 
   for (int i = 0; i < N; ++i){
-   a.push_back(var(i));
-   b.push_back(var(i));
+    a.push_back(var(i));
+    b.push_back(var(i));
   }
 
   size_t stack_size = stan::math::ChainableStack::var_stack_.size();
 
   EXPECT_EQ(10U,stack_size);
-  EXPECT_TRUE(check_equal(function,"a",a,b));
+  EXPECT_NO_THROW(check_equal(function,"a",a,b));
 
   size_t stack_size_after_call = stan::math::ChainableStack::var_stack_.size();
   EXPECT_EQ(10U,stack_size_after_call);

--- a/test/unit/math/rev/arr/err/check_finite_test.cpp
+++ b/test/unit/math/rev/arr/err/check_finite_test.cpp
@@ -11,12 +11,12 @@ TEST(AgradRevErrorHandlingScalar, CheckFiniteVarCheckVectorized) {
   vector<var> a;
 
   for (int i = 0; i < N; ++i)
-   a.push_back(var(i));
+    a.push_back(var(i));
 
   size_t stack_size = stan::math::ChainableStack::var_stack_.size();
 
   EXPECT_EQ(5U,stack_size);
-  EXPECT_TRUE(check_finite(function,"a",a));
+  EXPECT_NO_THROW(check_finite(function,"a",a));
 
   size_t stack_size_after_call = stan::math::ChainableStack::var_stack_.size();
   EXPECT_EQ(5U,stack_size_after_call);

--- a/test/unit/math/rev/arr/err/check_greater_or_equal_test.cpp
+++ b/test/unit/math/rev/arr/err/check_greater_or_equal_test.cpp
@@ -14,12 +14,12 @@ TEST(AgradRevErrorHandlingScalar, CheckFiniteVarCheckVectorized) {
   vector<var> a;
 
   for (int i = 0; i < N; ++i)
-   a.push_back(var(i));
+    a.push_back(var(i));
 
   size_t stack_size = stan::math::ChainableStack::var_stack_.size();
 
   EXPECT_EQ(5U,stack_size);
-  EXPECT_TRUE(check_greater_or_equal(function,"a",a,-1.0));
+  EXPECT_NO_THROW(check_greater_or_equal(function,"a",a,-1.0));
 
   size_t stack_size_after_call = stan::math::ChainableStack::var_stack_.size();
   EXPECT_EQ(5U,stack_size_after_call);

--- a/test/unit/math/rev/arr/err/check_greater_test.cpp
+++ b/test/unit/math/rev/arr/err/check_greater_test.cpp
@@ -14,12 +14,12 @@ TEST(AgradRevErrorHandlingScalar, CheckGreaterVarCheckVectorized) {
   vector<var> a;
 
   for (int i = 0; i < N; ++i)
-   a.push_back(var(i));
+    a.push_back(var(i));
 
   size_t stack_size = stan::math::ChainableStack::var_stack_.size();
 
   EXPECT_EQ(5U,stack_size);
-  EXPECT_TRUE(check_greater(function,"a",a,-1.0));
+  EXPECT_NO_THROW(check_greater(function,"a",a,-1.0));
 
   size_t stack_size_after_call = stan::math::ChainableStack::var_stack_.size();
   EXPECT_EQ(5U,stack_size_after_call);

--- a/test/unit/math/rev/arr/err/check_less_or_equal_test.cpp
+++ b/test/unit/math/rev/arr/err/check_less_or_equal_test.cpp
@@ -14,12 +14,12 @@ TEST(AgradRevErrorHandlingScalar, CheckLessOrEqualVarCheckVectorized) {
   vector<var> a;
 
   for (int i = 0; i < N; ++i)
-   a.push_back(var(i));
+    a.push_back(var(i));
 
   size_t stack_size = stan::math::ChainableStack::var_stack_.size();
 
   EXPECT_EQ(5U,stack_size);
-  EXPECT_TRUE(check_less_or_equal(function,"a",a,10.0));
+  EXPECT_NO_THROW(check_less_or_equal(function,"a",a,10.0));
 
   size_t stack_size_after_call = stan::math::ChainableStack::var_stack_.size();
   EXPECT_EQ(5U,stack_size_after_call);

--- a/test/unit/math/rev/arr/err/check_less_test.cpp
+++ b/test/unit/math/rev/arr/err/check_less_test.cpp
@@ -14,12 +14,12 @@ TEST(AgradRevErrorHandlingScalar, CheckLessVarCheckVectorized) {
   vector<var> a;
 
   for (int i = 0; i < N; ++i)
-   a.push_back(var(i));
+    a.push_back(var(i));
 
   size_t stack_size = stan::math::ChainableStack::var_stack_.size();
 
   EXPECT_EQ(5U,stack_size);
-  EXPECT_TRUE(check_less(function,"a",a,10.0));
+  EXPECT_NO_THROW(check_less(function,"a",a,10.0));
 
   size_t stack_size_after_call = stan::math::ChainableStack::var_stack_.size();
   EXPECT_EQ(5U,stack_size_after_call);

--- a/test/unit/math/rev/arr/err/check_nonnegative_test.cpp
+++ b/test/unit/math/rev/arr/err/check_nonnegative_test.cpp
@@ -10,11 +10,11 @@ TEST(AgradRevErrorHandlingScalar,CheckNonnegativeVectorized) {
   std::vector<var> x(N);
 
   x.assign(N, 0);
-  EXPECT_TRUE(check_nonnegative(function, "x", x)) 
+  EXPECT_NO_THROW(check_nonnegative(function, "x", x)) 
     << "check_nonnegative(vector) should be true with finite x: " << x[0];
 
   x.assign(N, std::numeric_limits<double>::infinity());
-  EXPECT_TRUE(check_nonnegative(function, "x", x)) 
+  EXPECT_NO_THROW(check_nonnegative(function, "x", x)) 
     << "check_nonnegative(vector) should be true with x = Inf: " << x[0];
 
   x.assign(N, -0.01);
@@ -42,18 +42,18 @@ TEST(AgradRevErrorHandlingScalar, CheckNonnegativeVarCheckVectorized) {
   vector<var> a;
 
   for (int i = 0; i < N; ++i)
-   a.push_back(var(i));
+    a.push_back(var(i));
 
   size_t stack_size = stan::math::ChainableStack::var_stack_.size();
 
   EXPECT_EQ(5U,stack_size);
-  EXPECT_TRUE(check_nonnegative(function,"a",a));
+  EXPECT_NO_THROW(check_nonnegative(function,"a",a));
 
   size_t stack_size_after_call = stan::math::ChainableStack::var_stack_.size();
   EXPECT_EQ(5U,stack_size_after_call);
 
   a[1] = std::numeric_limits<double>::infinity();
-  EXPECT_TRUE(check_nonnegative(function,"a",a));
+  EXPECT_NO_THROW(check_nonnegative(function,"a",a));
   stack_size_after_call = stan::math::ChainableStack::var_stack_.size();
   EXPECT_EQ(6U,stack_size_after_call);
 
@@ -63,7 +63,7 @@ TEST(AgradRevErrorHandlingScalar, CheckNonnegativeVarCheckVectorized) {
   EXPECT_EQ(7U,stack_size_after_call);
 
   a[1] = 0.0;
-  EXPECT_TRUE(check_nonnegative(function,"a",a));
+  EXPECT_NO_THROW(check_nonnegative(function,"a",a));
   stack_size_after_call = stan::math::ChainableStack::var_stack_.size();
   EXPECT_EQ(8U,stack_size_after_call);
 

--- a/test/unit/math/rev/arr/err/check_not_nan_test.cpp
+++ b/test/unit/math/rev/arr/err/check_not_nan_test.cpp
@@ -11,12 +11,12 @@ TEST(AgradRevErrorHandlingScalar, CheckNotNanVarCheckVectorized) {
   vector<var> a;
 
   for (int i = 0; i < N; ++i)
-   a.push_back(var(i));
+    a.push_back(var(i));
 
   size_t stack_size = stan::math::ChainableStack::var_stack_.size();
 
   EXPECT_EQ(5U,stack_size);
-  EXPECT_TRUE(check_not_nan(function,"a",a));
+  EXPECT_NO_THROW(check_not_nan(function,"a",a));
 
   size_t stack_size_after_call = stan::math::ChainableStack::var_stack_.size();
   EXPECT_EQ(5U,stack_size_after_call);
@@ -33,14 +33,14 @@ TEST(ErrorHandlingScalar, CheckNotNanVarCheckVectorized) {
   vector<var> a;
 
   for (int i = 0; i < N; ++i)
-   a.push_back(var(i));
+    a.push_back(var(i));
 
   size_t stack_size = stan::math::ChainableStack::var_stack_.size();
 
-  EXPECT_TRUE(5U == stack_size);
-  EXPECT_TRUE(check_not_nan(function,"a",a));
+  EXPECT_NO_THROW(5U == stack_size);
+  EXPECT_NO_THROW(check_not_nan(function,"a",a));
 
   size_t stack_size_after_call = stan::math::ChainableStack::var_stack_.size();
-  EXPECT_TRUE(5U == stack_size_after_call);
+  EXPECT_NO_THROW(5U == stack_size_after_call);
   stan::math::recover_memory();
 }

--- a/test/unit/math/rev/arr/err/check_not_nan_test.cpp
+++ b/test/unit/math/rev/arr/err/check_not_nan_test.cpp
@@ -37,10 +37,10 @@ TEST(ErrorHandlingScalar, CheckNotNanVarCheckVectorized) {
 
   size_t stack_size = stan::math::ChainableStack::var_stack_.size();
 
-  EXPECT_NO_THROW(5U == stack_size);
+  EXPECT_TRUE(5U == stack_size);
   EXPECT_NO_THROW(check_not_nan(function,"a",a));
 
   size_t stack_size_after_call = stan::math::ChainableStack::var_stack_.size();
-  EXPECT_NO_THROW(5U == stack_size_after_call);
+  EXPECT_TRUE(5U == stack_size_after_call);
   stan::math::recover_memory();
 }

--- a/test/unit/math/rev/arr/err/check_positive_finite_test.cpp
+++ b/test/unit/math/rev/arr/err/check_positive_finite_test.cpp
@@ -12,7 +12,7 @@ TEST(AgradRevErrorHandlingScalar,CheckPositiveFinite_Vector) {
   x.push_back (1.5);
   x.push_back (0.1);
   x.push_back (1);
-  ASSERT_TRUE(check_positive_finite(function, "x", x)) 
+  ASSERT_NO_THROW(check_positive_finite(function, "x", x)) 
     << "check_positive_finite should be true with finite x";
 
   x.clear();
@@ -48,7 +48,7 @@ TEST(AgradRevErrorHandlingScalar,CheckPositiveFinite_Vector) {
   x.push_back(2);
   x.push_back(std::numeric_limits<double>::quiet_NaN());
   EXPECT_THROW(check_positive_finite(function, "x", x), std::domain_error)
- << "check_positive_finite should throw exception on NaN";
+    << "check_positive_finite should throw exception on NaN";
   stan::math::recover_memory();
 }
 
@@ -62,13 +62,13 @@ TEST(AgradRevErrorHandlingScalar, CheckPositiveFiniteVarCheckVectorized) {
   vector<var> a;
 
   for (int i = 0; i < N; ++i)
-   a.push_back(var(i));
+    a.push_back(var(i));
 
   size_t stack_size = stan::math::ChainableStack::var_stack_.size();
 
   EXPECT_EQ(5U,stack_size);
   EXPECT_THROW(check_positive_finite(function,"a",a),std::domain_error);
-  EXPECT_TRUE(check_positive_finite(function,"a",a[2]));
+  EXPECT_NO_THROW(check_positive_finite(function,"a",a[2]));
 
   size_t stack_size_after_call = stan::math::ChainableStack::var_stack_.size();
   EXPECT_EQ(5U,stack_size_after_call);

--- a/test/unit/math/rev/arr/err/check_positive_test.cpp
+++ b/test/unit/math/rev/arr/err/check_positive_test.cpp
@@ -12,7 +12,7 @@ TEST(AgradRevErrorHandlingScalar,CheckPositive) {
   x.push_back(var(2.0));
   x.push_back(var(3.0));
 
-  EXPECT_TRUE(check_positive(function, "x", x));
+  EXPECT_NO_THROW(check_positive(function, "x", x));
 
   stan::math::recover_memory();
 }

--- a/test/unit/math/rev/mat/err/check_consistent_size_test.cpp
+++ b/test/unit/math/rev/mat/err/check_consistent_size_test.cpp
@@ -15,7 +15,7 @@ TEST(AgradRevErrorHandlingScalar, checkConsistentSize) {
   Matrix<var,Dynamic,1> v1(4);
   v1 << 4.0,5.0,6.0,7.0;
   EXPECT_EQ(4U, size_of(v1));
-  EXPECT_TRUE(check_consistent_size(function, name1, v1, 4U));
+  EXPECT_NO_THROW(check_consistent_size(function, name1, v1, 4U));
   EXPECT_THROW(check_consistent_size(function, name1, v1, 2U), std::invalid_argument);
   stan::math::recover_memory();
 }
@@ -35,7 +35,7 @@ TEST(AgradRevErrorHandlingScalar, checkConsistentSize_nan) {
   Matrix<var,Dynamic,1> v1(4);
   v1 << nan,nan,4,nan;
   EXPECT_EQ(4U, size_of(v1));
-  EXPECT_TRUE(check_consistent_size(function, name1, v1, 4U));
+  EXPECT_NO_THROW(check_consistent_size(function, name1, v1, 4U));
   EXPECT_THROW(check_consistent_size(function, name1, v1, 2U), std::invalid_argument);
   stan::math::recover_memory();
 }

--- a/test/unit/math/rev/mat/err/check_consistent_sizes_test.cpp
+++ b/test/unit/math/rev/mat/err/check_consistent_sizes_test.cpp
@@ -23,9 +23,9 @@ TEST(AgradRevErrorHandlingScalar, checkConsistentSizes) {
   ASSERT_EQ(4U, size_of(v2));
   ASSERT_EQ(4U, size_of(v3));
   ASSERT_EQ(4U, size_of(v4));
-  EXPECT_TRUE(check_consistent_sizes(function, name1, v1, name2, v2));
-  EXPECT_TRUE(check_consistent_sizes(function, name1, v1, name2, v2, name3, v3));
-  EXPECT_TRUE(check_consistent_sizes(function, name1, v1, name2, v2, name3, v3, name4, v4));
+  EXPECT_NO_THROW(check_consistent_sizes(function, name1, v1, name2, v2));
+  EXPECT_NO_THROW(check_consistent_sizes(function, name1, v1, name2, v2, name3, v3));
+  EXPECT_NO_THROW(check_consistent_sizes(function, name1, v1, name2, v2, name3, v3, name4, v4));
   
   Matrix<var,Dynamic,1> v(3);
   

--- a/test/unit/math/rev/mat/err/check_equal_test.cpp
+++ b/test/unit/math/rev/mat/err/check_equal_test.cpp
@@ -14,7 +14,7 @@ TEST(AgradRevErrorHandlingScalar,CheckEqualMatrix) {
   // x_vec, low_vec
   x_vec   << -1, 0, 1;
   eq_vec << -1, 0, 1;
-  EXPECT_TRUE(check_equal(function, "x", x_vec, eq_vec)) 
+  EXPECT_NO_THROW(check_equal(function, "x", x_vec, eq_vec)) 
     << "check_equal: matrix<3,1>, matrix<3,1>";
 
   x_vec   <<   -1,    0,   1;
@@ -50,7 +50,7 @@ TEST(AgradRevErrorHandlingScalar, CheckEqualVarCheckMatrix) {
   size_t stack_size_expected = 2 * N * N;
 
   EXPECT_EQ(stack_size_expected,stack_size);
-  EXPECT_TRUE(check_equal(function,"a",a,b));
+  EXPECT_NO_THROW(check_equal(function,"a",a,b));
 
   size_t stack_size_after_call = stan::math::ChainableStack::var_stack_.size();
   EXPECT_EQ(stack_size_expected,stack_size_after_call);

--- a/test/unit/math/rev/mat/err/check_greater_or_equal_test.cpp
+++ b/test/unit/math/rev/mat/err/check_greater_or_equal_test.cpp
@@ -16,23 +16,23 @@ TEST(AgradRevErrorHandlingScalar,CheckGreaterOrEqualMatrix) {
   // x_vec, low_vec
   x_vec   << -1, 0, 1;
   low_vec << -2, -1, 0;
-  EXPECT_TRUE(check_greater_or_equal(function, "x", x_vec, low_vec)) 
+  EXPECT_NO_THROW(check_greater_or_equal(function, "x", x_vec, low_vec)) 
     << "check_greater_or_equal: matrix<3,1>, matrix<3,1>";
 
   x_vec   <<   -1,    0,   1;
   low_vec << -1.1, -0.1, 0.9;
-  EXPECT_TRUE(check_greater_or_equal(function, "x", x_vec, low_vec)) 
+  EXPECT_NO_THROW(check_greater_or_equal(function, "x", x_vec, low_vec)) 
     << "check_greater_or_equal: matrix<3,1>, matrix<3,1>";
 
 
   x_vec   << -1, 0, std::numeric_limits<double>::infinity();
   low_vec << -2, -1, 0;
-  EXPECT_TRUE(check_greater_or_equal(function, "x", x_vec, low_vec)) 
+  EXPECT_NO_THROW(check_greater_or_equal(function, "x", x_vec, low_vec)) 
     << "check_greater_or_equal: matrix<3,1>, matrix<3,1>, y has infinity";
   
   x_vec   << -1, 0, 1;
   low_vec << -2, 0, 0;
-  EXPECT_TRUE(check_greater_or_equal(function, "x", x_vec, low_vec))
+  EXPECT_NO_THROW(check_greater_or_equal(function, "x", x_vec, low_vec))
     << "check_greater_or_equal: matrix<3,1>, matrix<3,1>, should pass for index 1";
   
   x_vec   << -1, 0,  1;
@@ -43,23 +43,23 @@ TEST(AgradRevErrorHandlingScalar,CheckGreaterOrEqualMatrix) {
   
   x_vec   << -1, 0,  std::numeric_limits<double>::infinity();
   low_vec << -2, -1, std::numeric_limits<double>::infinity();
-  EXPECT_TRUE(check_greater_or_equal(function, "x", x_vec, low_vec))
+  EXPECT_NO_THROW(check_greater_or_equal(function, "x", x_vec, low_vec))
     << "check_greater_or_equal: matrix<3,1>, matrix<3,1>, both bound and value infinity";
   
   x_vec   << -1, 0,  1;
   low_vec << -2, -1, -std::numeric_limits<double>::infinity();
-  EXPECT_TRUE(check_greater_or_equal(function, "x", x_vec, low_vec))
-  << "check_greater_or_equal: matrix<3,1>, matrix<3,1>, should pass with -infinity";
+  EXPECT_NO_THROW(check_greater_or_equal(function, "x", x_vec, low_vec))
+    << "check_greater_or_equal: matrix<3,1>, matrix<3,1>, should pass with -infinity";
 
   // x_vec, low
   x_vec   << -1, 0, 1;
   low = -2;
-  EXPECT_TRUE(check_greater_or_equal(function, "x", x_vec, low)) 
+  EXPECT_NO_THROW(check_greater_or_equal(function, "x", x_vec, low)) 
     << "check_greater_or_equal: matrix<3,1>, double";
 
   x_vec   <<   -1,    0,   1;
   low = -std::numeric_limits<double>::infinity();
-  EXPECT_TRUE(check_greater_or_equal(function, "x", x_vec, low)) 
+  EXPECT_NO_THROW(check_greater_or_equal(function, "x", x_vec, low)) 
     << "check_greater_or_equal: matrix<3,1>, double";
 
   x_vec   << -1, 0, 1;
@@ -77,12 +77,12 @@ TEST(AgradRevErrorHandlingScalar,CheckGreaterOrEqualMatrix) {
   // x, low_vec
   x = 2;
   low_vec << -1, 0, 1;
-  EXPECT_TRUE(check_greater_or_equal(function, "x", x, low_vec)) 
+  EXPECT_NO_THROW(check_greater_or_equal(function, "x", x, low_vec)) 
     << "check_greater_or_equal: double, matrix<3,1>";
 
   x = 10;
   low_vec << -1, 0, -std::numeric_limits<double>::infinity();
-  EXPECT_TRUE(check_greater_or_equal(function, "x", x, low_vec)) 
+  EXPECT_NO_THROW(check_greater_or_equal(function, "x", x, low_vec)) 
     << "check_greater_or_equal: double, matrix<3,1>, low has -inf";
 
   x = 10;
@@ -93,17 +93,17 @@ TEST(AgradRevErrorHandlingScalar,CheckGreaterOrEqualMatrix) {
   
   x = std::numeric_limits<double>::infinity();
   low_vec << -1, 0, std::numeric_limits<double>::infinity();
-  EXPECT_TRUE(check_greater_or_equal(function, "x", x, low_vec))
+  EXPECT_NO_THROW(check_greater_or_equal(function, "x", x, low_vec))
     << "check_greater_or_equal: double, matrix<3,1>, x is inf, low has inf";
   
   x = std::numeric_limits<double>::infinity();
   low_vec << -1, 0, 1;
-  EXPECT_TRUE(check_greater_or_equal(function, "x", x, low_vec)) 
+  EXPECT_NO_THROW(check_greater_or_equal(function, "x", x, low_vec)) 
     << "check_greater_or_equal: double, matrix<3,1>, x is inf";
 
   x = 1.1;
   low_vec << -1, 0, 1;
-  EXPECT_TRUE(check_greater_or_equal(function, "x", x, low_vec)) 
+  EXPECT_NO_THROW(check_greater_or_equal(function, "x", x, low_vec)) 
     << "check_greater_or_equal: double, matrix<3,1>";
   
   x = 0.9;

--- a/test/unit/math/rev/mat/err/check_greater_test.cpp
+++ b/test/unit/math/rev/mat/err/check_greater_test.cpp
@@ -16,18 +16,18 @@ TEST(AgradRevErrorHandlingScalar,CheckGreaterMatrix) {
   // x_vec, low_vec
   x_vec   << -1, 0, 1;
   low_vec << -2, -1, 0;
-  EXPECT_TRUE(check_greater(function, "x", x_vec, low_vec)) 
+  EXPECT_NO_THROW(check_greater(function, "x", x_vec, low_vec)) 
     << "check_greater: matrix<3,1>, matrix<3,1>";
 
   x_vec   <<   -1,    0,   1;
   low_vec << -1.1, -0.1, 0.9;
-  EXPECT_TRUE(check_greater(function, "x", x_vec, low_vec)) 
+  EXPECT_NO_THROW(check_greater(function, "x", x_vec, low_vec)) 
     << "check_greater: matrix<3,1>, matrix<3,1>";
 
 
   x_vec   << -1, 0, std::numeric_limits<double>::infinity();
   low_vec << -2, -1, 0;
-  EXPECT_TRUE(check_greater(function, "x", x_vec, low_vec)) 
+  EXPECT_NO_THROW(check_greater(function, "x", x_vec, low_vec)) 
     << "check_greater: matrix<3,1>, matrix<3,1>, y has infinity";
   
   x_vec   << -1, 0, 1;
@@ -48,18 +48,18 @@ TEST(AgradRevErrorHandlingScalar,CheckGreaterMatrix) {
   
   x_vec   << -1, 0,  1;
   low_vec << -2, -1, -std::numeric_limits<double>::infinity();
-  EXPECT_TRUE(check_greater(function, "x", x_vec, low_vec))
-  << "check_greater: matrix<3,1>, matrix<3,1>, should pass with -infinity";
+  EXPECT_NO_THROW(check_greater(function, "x", x_vec, low_vec))
+    << "check_greater: matrix<3,1>, matrix<3,1>, should pass with -infinity";
 
   // x_vec, low
   x_vec   << -1, 0, 1;
   low = -2;
-  EXPECT_TRUE(check_greater(function, "x", x_vec, low)) 
+  EXPECT_NO_THROW(check_greater(function, "x", x_vec, low)) 
     << "check_greater: matrix<3,1>, double";
 
   x_vec   <<   -1,    0,   1;
   low = -std::numeric_limits<double>::infinity();
-  EXPECT_TRUE(check_greater(function, "x", x_vec, low)) 
+  EXPECT_NO_THROW(check_greater(function, "x", x_vec, low)) 
     << "check_greater: matrix<3,1>, double";
 
   x_vec   << -1, 0, 1;
@@ -77,7 +77,7 @@ TEST(AgradRevErrorHandlingScalar,CheckGreaterMatrix) {
   // x, low_vec
   x = 2;
   low_vec << -1, 0, 1;
-  EXPECT_TRUE(check_greater(function, "x", x, low_vec)) 
+  EXPECT_NO_THROW(check_greater(function, "x", x, low_vec)) 
     << "check_greater: double, matrix<3,1>";
 
   x = 0;
@@ -98,12 +98,12 @@ TEST(AgradRevErrorHandlingScalar,CheckGreaterMatrix) {
   
   x = std::numeric_limits<double>::infinity();
   low_vec << -1, 0, 1;
-  EXPECT_TRUE(check_greater(function, "x", x, low_vec)) 
+  EXPECT_NO_THROW(check_greater(function, "x", x, low_vec)) 
     << "check_greater: double, matrix<3,1>, x is inf";
 
   x = 1.1;
   low_vec << -1, 0, 1;
-  EXPECT_TRUE(check_greater(function, "x", x, low_vec)) 
+  EXPECT_NO_THROW(check_greater(function, "x", x, low_vec)) 
     << "check_greater: double, matrix<3,1>";
   
   x = 0.9;

--- a/test/unit/math/rev/mat/err/check_less_or_equal_test.cpp
+++ b/test/unit/math/rev/mat/err/check_less_or_equal_test.cpp
@@ -17,15 +17,15 @@ TEST(AgradRevErrorHandlingScalar,CheckLessOrEqual_Matrix) {
   // x_vec, high
   x_vec << -5, 0, 5;
   high = 10;
-  EXPECT_TRUE(check_less_or_equal(function, "x", x_vec, high));
+  EXPECT_NO_THROW(check_less_or_equal(function, "x", x_vec, high));
 
   x_vec << -5, 0, 5;
   high = std::numeric_limits<double>::infinity();
-  EXPECT_TRUE(check_less_or_equal(function, "x", x_vec, high));
+  EXPECT_NO_THROW(check_less_or_equal(function, "x", x_vec, high));
 
   x_vec << -5, 0, 5;
   high = 5;
-  EXPECT_TRUE(check_less_or_equal(function, "x", x_vec, high));
+  EXPECT_NO_THROW(check_less_or_equal(function, "x", x_vec, high));
   
   x_vec << -5, 0, std::numeric_limits<double>::infinity();
   high = 5;
@@ -34,20 +34,20 @@ TEST(AgradRevErrorHandlingScalar,CheckLessOrEqual_Matrix) {
 
   x_vec << -5, 0, std::numeric_limits<double>::infinity();
   high = std::numeric_limits<double>::infinity();
-  EXPECT_TRUE(check_less_or_equal(function, "x", x_vec, high));
+  EXPECT_NO_THROW(check_less_or_equal(function, "x", x_vec, high));
   
   // x_vec, high_vec
   x_vec << -5, 0, 5;
   high_vec << 0, 5, 10;
-  EXPECT_TRUE(check_less_or_equal(function, "x", x_vec, high_vec));
+  EXPECT_NO_THROW(check_less_or_equal(function, "x", x_vec, high_vec));
 
   x_vec << -5, 0, 5;
   high_vec << std::numeric_limits<double>::infinity(), 10, 10;
-  EXPECT_TRUE(check_less_or_equal(function, "x", x_vec, high_vec));
+  EXPECT_NO_THROW(check_less_or_equal(function, "x", x_vec, high_vec));
 
   x_vec << -5, 0, 5;
   high_vec << 10, 10, 5;
-  EXPECT_TRUE(check_less_or_equal(function, "x", x_vec, high_vec));
+  EXPECT_NO_THROW(check_less_or_equal(function, "x", x_vec, high_vec));
   
   x_vec << -5, 0, std::numeric_limits<double>::infinity();
   high_vec << 10, 10, 10;
@@ -56,21 +56,21 @@ TEST(AgradRevErrorHandlingScalar,CheckLessOrEqual_Matrix) {
 
   x_vec << -5, 0, std::numeric_limits<double>::infinity();
   high_vec << 10, 10, std::numeric_limits<double>::infinity();
-  EXPECT_TRUE(check_less_or_equal(function, "x", x_vec, high_vec));
+  EXPECT_NO_THROW(check_less_or_equal(function, "x", x_vec, high_vec));
 
   
   // x, high_vec
   x = -100;
   high_vec << 0, 5, 10;
-  EXPECT_TRUE(check_less_or_equal(function, "x", x, high_vec));
+  EXPECT_NO_THROW(check_less_or_equal(function, "x", x, high_vec));
 
   x = 10;
   high_vec << 100, 200, std::numeric_limits<double>::infinity();
-  EXPECT_TRUE(check_less_or_equal(function, "x", x, high_vec));
+  EXPECT_NO_THROW(check_less_or_equal(function, "x", x, high_vec));
 
   x = 5;
   high_vec << 100, 200, 5;
-  EXPECT_TRUE(check_less_or_equal(function, "x", x, high_vec));
+  EXPECT_NO_THROW(check_less_or_equal(function, "x", x, high_vec));
   
   x = std::numeric_limits<double>::infinity();
   high_vec << 10, 20, 30;
@@ -81,6 +81,6 @@ TEST(AgradRevErrorHandlingScalar,CheckLessOrEqual_Matrix) {
   high_vec << std::numeric_limits<double>::infinity(), 
     std::numeric_limits<double>::infinity(), 
     std::numeric_limits<double>::infinity();
-  EXPECT_TRUE(check_less_or_equal(function, "x", x, high_vec));
+  EXPECT_NO_THROW(check_less_or_equal(function, "x", x, high_vec));
   stan::math::recover_memory();
 }

--- a/test/unit/math/rev/mat/err/check_less_test.cpp
+++ b/test/unit/math/rev/mat/err/check_less_test.cpp
@@ -17,11 +17,11 @@ TEST(AgradRevErrorHandlingScalar,CheckLess_Matrix) {
   // x_vec, high
   x_vec << -5, 0, 5;
   high = 10;
-  EXPECT_TRUE(check_less(function, "x", x_vec, high));
+  EXPECT_NO_THROW(check_less(function, "x", x_vec, high));
 
   x_vec << -5, 0, 5;
   high = std::numeric_limits<double>::infinity();
-  EXPECT_TRUE(check_less(function, "x", x_vec, high));
+  EXPECT_NO_THROW(check_less(function, "x", x_vec, high));
 
   x_vec << -5, 0, 5;
   high = 5;
@@ -41,11 +41,11 @@ TEST(AgradRevErrorHandlingScalar,CheckLess_Matrix) {
   // x_vec, high_vec
   x_vec << -5, 0, 5;
   high_vec << 0, 5, 10;
-  EXPECT_TRUE(check_less(function, "x", x_vec, high_vec));
+  EXPECT_NO_THROW(check_less(function, "x", x_vec, high_vec));
 
   x_vec << -5, 0, 5;
   high_vec << std::numeric_limits<double>::infinity(), 10, 10;
-  EXPECT_TRUE(check_less(function, "x", x_vec, high_vec));
+  EXPECT_NO_THROW(check_less(function, "x", x_vec, high_vec));
 
   x_vec << -5, 0, 5;
   high_vec << 10, 10, 5;
@@ -66,11 +66,11 @@ TEST(AgradRevErrorHandlingScalar,CheckLess_Matrix) {
   // x, high_vec
   x = -100;
   high_vec << 0, 5, 10;
-  EXPECT_TRUE(check_less(function, "x", x, high_vec));
+  EXPECT_NO_THROW(check_less(function, "x", x, high_vec));
 
   x = 10;
   high_vec << 100, 200, std::numeric_limits<double>::infinity();
-  EXPECT_TRUE(check_less(function, "x", x, high_vec));
+  EXPECT_NO_THROW(check_less(function, "x", x, high_vec));
 
   x = 5;
   high_vec << 100, 200, 5;

--- a/test/unit/math/rev/mat/err/check_nonzero_size_test.cpp
+++ b/test/unit/math/rev/mat/err/check_nonzero_size_test.cpp
@@ -9,9 +9,9 @@ TEST(AgradRevErrorHandlingMatrix, checkNonzeroSizeMatrix) {
   var result;
   
   y.resize(3,3);
-  EXPECT_TRUE(check_nonzero_size("checkNonzeroSize", "y", y));
+  EXPECT_NO_THROW(check_nonzero_size("checkNonzeroSize", "y", y));
   y.resize(2, 3);
-  EXPECT_TRUE(check_nonzero_size("checkNonzeroSize", "y", y));
+  EXPECT_NO_THROW(check_nonzero_size("checkNonzeroSize", "y", y));
 
   y.resize(0,0);
   EXPECT_THROW_MSG(check_nonzero_size("checkNonzeroSize", "y", y),
@@ -24,12 +24,12 @@ TEST(AgradRevErrorHandlingMatrix, checkNonzeroSizeMatrix) {
   a.push_back(3.0);
 
 
-  EXPECT_TRUE(stan::math::check_nonzero_size("checkNonzeroSize",
-                                                       "a", a));
+  EXPECT_NO_THROW(stan::math::check_nonzero_size("checkNonzeroSize",
+                                                 "a", a));
 
   a.resize(2);
-  EXPECT_TRUE(stan::math::check_nonzero_size("checkNonzeroSize",
-                                                       "a", a));
+  EXPECT_NO_THROW(stan::math::check_nonzero_size("checkNonzeroSize",
+                                                 "a", a));
 
   a.resize(0);
   EXPECT_THROW_MSG(stan::math::check_nonzero_size("checkNonzeroSize", "a", a),
@@ -45,12 +45,12 @@ TEST(AgradRevErrorHandlingMatrix, checkNonzeroSizeMatrix_nan) {
 
   y.resize(3,3);
   y << nan, nan, nan,nan, nan, nan,nan, nan, nan;
-  EXPECT_TRUE(stan::math::check_nonzero_size("checkNonzeroSize",
-                                                       "y", y));
+  EXPECT_NO_THROW(stan::math::check_nonzero_size("checkNonzeroSize",
+                                                 "y", y));
   y.resize(2, 3);
   y << nan, nan, nan,nan, nan, nan;
-  EXPECT_TRUE(stan::math::check_nonzero_size("checkNonzeroSize",
-                                                       "y", y));
+  EXPECT_NO_THROW(stan::math::check_nonzero_size("checkNonzeroSize",
+                                                 "y", y));
 
   y.resize(0,0);
   EXPECT_THROW_MSG(stan::math::check_nonzero_size("checkNonzeroSize", "y", y),
@@ -63,12 +63,12 @@ TEST(AgradRevErrorHandlingMatrix, checkNonzeroSizeMatrix_nan) {
   a.push_back(nan);
   a.push_back(nan);
 
-  EXPECT_TRUE(stan::math::check_nonzero_size("checkNonzeroSize",
-                                                       "a", a));
+  EXPECT_NO_THROW(stan::math::check_nonzero_size("checkNonzeroSize",
+                                                 "a", a));
 
   a.resize(2);
-  EXPECT_TRUE(stan::math::check_nonzero_size("checkNonzeroSize",
-                                                       "a", a));
+  EXPECT_NO_THROW(stan::math::check_nonzero_size("checkNonzeroSize",
+                                                 "a", a));
 
   a.resize(0);
   EXPECT_THROW_MSG(stan::math::check_nonzero_size("checkNonzeroSize","a", a),

--- a/test/unit/math/rev/mat/err/check_pos_definite_test.cpp
+++ b/test/unit/math/rev/mat/err/check_pos_definite_test.cpp
@@ -19,7 +19,7 @@ TEST(AgradRevErrorHandlingMatrix, checkPosDefiniteMatrix_nan) {
   y << 2, -1, 0,
     -1, 2, -1,
     0, -1, 2;
-  EXPECT_TRUE(check_pos_definite("checkPosDefiniteMatrix", "y", y));
+  EXPECT_NO_THROW(check_pos_definite("checkPosDefiniteMatrix", "y", y));
                                  
   for (int i = 0; i < y.rows(); i++)
     for (int j = 0; j < y.cols(); j++) {

--- a/test/unit/math/rev/mat/err/check_pos_semidefinite_test.cpp
+++ b/test/unit/math/rev/mat/err/check_pos_semidefinite_test.cpp
@@ -19,7 +19,7 @@ TEST(AgradRevErrorHandlingMatrix, checkPosDefiniteMatrix_nan) {
   y << 2, -1, 0,
     -1, 2, -1,
     0, -1, 2;
-  EXPECT_TRUE(check_pos_semidefinite("checkPosDefiniteMatrix", "y", y));
+  EXPECT_NO_THROW(check_pos_semidefinite("checkPosDefiniteMatrix", "y", y));
                                  
   for (int i = 0; i < y.rows(); i++)
     for (int j = 0; j < y.cols(); j++) {
@@ -31,7 +31,7 @@ TEST(AgradRevErrorHandlingMatrix, checkPosDefiniteMatrix_nan) {
     }
 
   y << 0, 0, 0, 0, 0, 0, 0, 0, 0;
-  EXPECT_TRUE(check_pos_semidefinite("checkPosDefiniteMatrix", "y", y));
+  EXPECT_NO_THROW(check_pos_semidefinite("checkPosDefiniteMatrix", "y", y));
   stan::math::recover_memory();
 }
 
@@ -57,7 +57,7 @@ TEST(AgradRevErrorHandlingMatrix, CheckPosDefiniteMatrixVarCheck) {
   size_t stack_before_call = stan::math::ChainableStack::var_stack_.size();
   EXPECT_EQ(10U,stack_before_call);
 
-  EXPECT_TRUE(check_pos_semidefinite("checkPosDefiniteMatrix", "y", y));
+  EXPECT_NO_THROW(check_pos_semidefinite("checkPosDefiniteMatrix", "y", y));
   size_t stack_after_call = stan::math::ChainableStack::var_stack_.size();
 
   EXPECT_EQ(10U,stack_after_call);

--- a/test/unit/math/rev/mat/err/check_positive_finite_test.cpp
+++ b/test/unit/math/rev/mat/err/check_positive_finite_test.cpp
@@ -10,7 +10,7 @@ TEST(AgradRevErrorHandlingScalar,CheckPositiveFinite_Matrix) {
   
   x.resize(3);
   x << 3, 2, 1;
-  ASSERT_TRUE(check_positive_finite(function, "x", x))
+  ASSERT_NO_THROW(check_positive_finite(function, "x", x))
     << "check_positive_finite should be true with finite x";
 
   x.resize(3);

--- a/test/unit/math/rev/mat/err/check_positive_test.cpp
+++ b/test/unit/math/rev/mat/err/check_positive_test.cpp
@@ -10,7 +10,7 @@ TEST(AgradRevErrorHandlingScalar,CheckPositive) {
   Eigen::Matrix<var,Eigen::Dynamic,1> x_mat(3);
   x_mat   << 1, 2, 3;
   for (int i = 0; i < x_mat.size(); i++) {
-    EXPECT_TRUE(check_positive(function, "x", x_mat));
+    EXPECT_NO_THROW(check_positive(function, "x", x_mat));
   }
 
   x_mat(0) = 0;

--- a/test/unit/math/rev/scal/err/check_bounded_test.cpp
+++ b/test/unit/math/rev/scal/err/check_bounded_test.cpp
@@ -11,15 +11,15 @@ TEST(AgradRevErrorHandlingScalar,CheckBounded_X) {
   var low = -1;
   var high = 1;
  
-  EXPECT_TRUE(check_bounded(function, name, x, low, high)) 
+  EXPECT_NO_THROW(check_bounded(function, name, x, low, high)) 
     << "check_bounded should be TRUE with x: " << x << " and bounds: " << low << ", " << high;
   
   x = low;
-  EXPECT_TRUE(check_bounded(function, name, x, low, high)) 
+  EXPECT_NO_THROW(check_bounded(function, name, x, low, high)) 
     << "check_bounded should be TRUE with x: " << x << " equal to the lower bound: " << low;
 
   x = high;
-  EXPECT_TRUE(check_bounded(function, name, x, low, high)) 
+  EXPECT_NO_THROW(check_bounded(function, name, x, low, high)) 
     << "check_bounded should be TRUE with x: " << x << " equal to the lower bound: " << low;
 
   x = low-1;
@@ -56,11 +56,11 @@ TEST(AgradRevErrorHandlingScalar,CheckBounded_Low) {
   var low = -1;
   var high = 1;
  
-  EXPECT_TRUE(check_bounded(function, name, x, low, high)) 
+  EXPECT_NO_THROW(check_bounded(function, name, x, low, high)) 
     << "check_bounded should be true x: " << x << " and bounds: " << low << ", " << high;
   
   low = -std::numeric_limits<var>::infinity();
-  EXPECT_TRUE(check_bounded(function, name, x, low, high)) 
+  EXPECT_NO_THROW(check_bounded(function, name, x, low, high)) 
     << "check_bounded should be TRUE with x: " << x << " and bounds: " << low << ", " << high;
 
   low = std::numeric_limits<var>::quiet_NaN();
@@ -82,11 +82,11 @@ TEST(AgradRevErrorHandlingScalar,CheckBounded_High) {
   var low = -1;
   var high = 1;
  
-  EXPECT_TRUE(check_bounded(function, name, x, low, high)) 
+  EXPECT_NO_THROW(check_bounded(function, name, x, low, high)) 
     << "check_bounded should be true x: " << x << " and bounds: " << low << ", " << high;
 
   high = std::numeric_limits<var>::infinity();
-  EXPECT_TRUE(check_bounded(function, name, x, low, high)) 
+  EXPECT_NO_THROW(check_bounded(function, name, x, low, high)) 
     << "check_bounded should be TRUE with x: " << x << " and bounds: " << low << ", " << high;
   
   high = std::numeric_limits<var>::quiet_NaN();
@@ -109,7 +109,7 @@ TEST(AgradRevErrorHandlingScalar, CheckBoundedVarCheckUnivariate) {
   size_t stack_size = stan::math::ChainableStack::var_stack_.size();
 
   EXPECT_EQ(1U,stack_size);
-  EXPECT_TRUE(check_bounded(function,"a",a,4.0,6.0));
+  EXPECT_NO_THROW(check_bounded(function,"a",a,4.0,6.0));
 
   size_t stack_size_after_call = stan::math::ChainableStack::var_stack_.size();
   EXPECT_EQ(1U,stack_size_after_call);

--- a/test/unit/math/rev/scal/err/check_equal_test.cpp
+++ b/test/unit/math/rev/scal/err/check_equal_test.cpp
@@ -9,7 +9,7 @@ TEST(AgradRevErrorHandlingScalar,CheckEqual) {
   var x = 0.0;
   var eq = 0.0;
  
-  EXPECT_TRUE(check_equal(function, "x", x, eq))
+  EXPECT_NO_THROW(check_equal(function, "x", x, eq))
     << "check_equal should be true with x = eq";
   
   x = -1.0;
@@ -55,7 +55,7 @@ TEST(AgradRevErrorHandlingScalar, CheckEqualVarCheckUnivariate) {
   EXPECT_EQ(2U,stack_size_after_call);
 
   b = 5.0;
-  EXPECT_TRUE(check_equal(function,"a",a,b));
+  EXPECT_NO_THROW(check_equal(function,"a",a,b));
   stack_size_after_call = stan::math::ChainableStack::var_stack_.size();
   EXPECT_EQ(3U,stack_size_after_call);
 

--- a/test/unit/math/rev/scal/err/check_finite_test.cpp
+++ b/test/unit/math/rev/scal/err/check_finite_test.cpp
@@ -9,7 +9,7 @@ TEST(AgradRevErrorHandlingScalar,CheckFinite) {
   const char* name = "x";
   var x = 0;
  
-  EXPECT_TRUE(check_finite(function, name, x)) 
+  EXPECT_NO_THROW(check_finite(function, name, x)) 
     << "check_finite should be TRUE with x: " << x;
   
   x = std::numeric_limits<double>::quiet_NaN();
@@ -36,7 +36,7 @@ TEST(AgradRevErrorHandlingScalar, CheckFiniteVarCheckUnivariate) {
   size_t stack_size = stan::math::ChainableStack::var_stack_.size();
 
   EXPECT_EQ(1U,stack_size);
-  EXPECT_TRUE(check_finite(function,"a",a));
+  EXPECT_NO_THROW(check_finite(function,"a",a));
 
   size_t stack_size_after_call = stan::math::ChainableStack::var_stack_.size();
   EXPECT_EQ(1U,stack_size_after_call);

--- a/test/unit/math/rev/scal/err/check_greater_or_equal_test.cpp
+++ b/test/unit/math/rev/scal/err/check_greater_or_equal_test.cpp
@@ -9,7 +9,7 @@ TEST(AgradRevErrorHandlingScalar,CheckGreaterOrEqual) {
   var x = 10.0;
   var lb = 0.0;
  
-  EXPECT_TRUE(check_greater_or_equal(function, "x", x, lb)) 
+  EXPECT_NO_THROW(check_greater_or_equal(function, "x", x, lb)) 
     << "check_greater_or_equal should be true with x > lb";
   
   x = -1.0;
@@ -22,7 +22,7 @@ TEST(AgradRevErrorHandlingScalar,CheckGreaterOrEqual) {
     << "check_greater_or_equal should not throw an exception with x == lb";
 
   x = std::numeric_limits<double>::infinity();
-  EXPECT_TRUE(check_greater_or_equal(function, "x", x, lb))
+  EXPECT_NO_THROW(check_greater_or_equal(function, "x", x, lb))
     << "check_greater should be true with x == Inf and lb = 0.0";
 
   x = 10.0;
@@ -49,7 +49,7 @@ TEST(AgradRevErrorHandlingScalar, CheckGreaterOrEqualVarCheckUnivariate) {
   size_t stack_size = stan::math::ChainableStack::var_stack_.size();
 
   EXPECT_EQ(1U,stack_size);
-  EXPECT_TRUE(check_greater_or_equal(function,"a",a,2.0));
+  EXPECT_NO_THROW(check_greater_or_equal(function,"a",a,2.0));
 
   size_t stack_size_after_call = stan::math::ChainableStack::var_stack_.size();
   EXPECT_EQ(1U,stack_size_after_call);

--- a/test/unit/math/rev/scal/err/check_greater_test.cpp
+++ b/test/unit/math/rev/scal/err/check_greater_test.cpp
@@ -9,7 +9,7 @@ TEST(AgradRevErrorHandlingScalar,CheckGreater) {
   var x = 10.0;
   var lb = 0.0;
  
-  EXPECT_TRUE(check_greater(function, "x", x, lb)) 
+  EXPECT_NO_THROW(check_greater(function, "x", x, lb)) 
     << "check_greater should be true with x > lb";
   
   x = -1.0;
@@ -22,7 +22,7 @@ TEST(AgradRevErrorHandlingScalar,CheckGreater) {
     << "check_greater should throw an exception with x == lb";
 
   x = std::numeric_limits<double>::infinity();
-  EXPECT_TRUE(check_greater(function, "x", x, lb))
+  EXPECT_NO_THROW(check_greater(function, "x", x, lb))
     << "check_greater should be true with x == Inf and lb = 0.0";
 
   x = 10.0;
@@ -48,7 +48,7 @@ TEST(AgradRevErrorHandlingScalar, CheckGreaterVarCheckUnivariate) {
   size_t stack_size = stan::math::ChainableStack::var_stack_.size();
 
   EXPECT_EQ(1U,stack_size);
-  EXPECT_TRUE(check_greater(function,"a",a,2.0));
+  EXPECT_NO_THROW(check_greater(function,"a",a,2.0));
 
   size_t stack_size_after_call = stan::math::ChainableStack::var_stack_.size();
   EXPECT_EQ(1U,stack_size_after_call);

--- a/test/unit/math/rev/scal/err/check_less_or_equal_test.cpp
+++ b/test/unit/math/rev/scal/err/check_less_or_equal_test.cpp
@@ -9,7 +9,7 @@ TEST(AgradRevErrorHandlingScalar,CheckLessOrEqual) {
   var x = -10.0;
   var lb = 0.0;
  
-  EXPECT_TRUE(check_less_or_equal(function, "x", x, lb))
+  EXPECT_NO_THROW(check_less_or_equal(function, "x", x, lb))
     << "check_less_or_equal should be true with x < lb";
   
   x = 1.0;
@@ -22,7 +22,7 @@ TEST(AgradRevErrorHandlingScalar,CheckLessOrEqual) {
     << "check_less_or_equal should not throw an exception with x == lb";
 
   x = -std::numeric_limits<double>::infinity();
-  EXPECT_TRUE(check_less_or_equal(function, "x", x, lb))
+  EXPECT_NO_THROW(check_less_or_equal(function, "x", x, lb))
     << "check_less should be true with x == -Inf and lb = 0.0";
 
   x = -10.0;
@@ -53,12 +53,12 @@ TEST(AgradRevErrorHandlingScalar, CheckLessOrEqualVarCheckUnivariate) {
   size_t stack_size_after_call = stan::math::ChainableStack::var_stack_.size();
   EXPECT_EQ(1U,stack_size_after_call);
 
-  EXPECT_TRUE(check_less_or_equal(function,"a",a,5.0));
+  EXPECT_NO_THROW(check_less_or_equal(function,"a",a,5.0));
 
   stack_size_after_call = stan::math::ChainableStack::var_stack_.size();
   EXPECT_EQ(1U,stack_size_after_call);
 
-  EXPECT_TRUE(check_less_or_equal(function,"a",a,10.0));
+  EXPECT_NO_THROW(check_less_or_equal(function,"a",a,10.0));
   stack_size_after_call = stan::math::ChainableStack::var_stack_.size();
   EXPECT_EQ(1U,stack_size_after_call);
 

--- a/test/unit/math/rev/scal/err/check_less_test.cpp
+++ b/test/unit/math/rev/scal/err/check_less_test.cpp
@@ -9,7 +9,7 @@ TEST(AgradRevErrorHandlingScalar,CheckLess) {
   var x = -10.0;
   var lb = 0.0;
  
-  EXPECT_TRUE(check_less(function, "x", x, lb)) 
+  EXPECT_NO_THROW(check_less(function, "x", x, lb)) 
     << "check_less should be true with x < lb";
   
   x = 1.0;
@@ -21,7 +21,7 @@ TEST(AgradRevErrorHandlingScalar,CheckLess) {
     << "check_less should throw an exception with x == lb";
 
   x = -std::numeric_limits<double>::infinity();
-  EXPECT_TRUE(check_less(function, "x", x, lb))
+  EXPECT_NO_THROW(check_less(function, "x", x, lb))
     << "check_less should be true with x == -Inf and lb = 0.0";
 
   x = -10.0;
@@ -51,7 +51,7 @@ TEST(AgradRevErrorHandlingScalar, CheckLessVarCheckUnivariate) {
   size_t stack_size_after_call = stan::math::ChainableStack::var_stack_.size();
   EXPECT_EQ(1U,stack_size_after_call);
 
-  EXPECT_TRUE(check_less(function,"a",a,10.0));
+  EXPECT_NO_THROW(check_less(function,"a",a,10.0));
   stack_size_after_call = stan::math::ChainableStack::var_stack_.size();
   EXPECT_EQ(1U,stack_size_after_call);
 

--- a/test/unit/math/rev/scal/err/check_nonnegative_test.cpp
+++ b/test/unit/math/rev/scal/err/check_nonnegative_test.cpp
@@ -8,11 +8,11 @@ TEST(AgradRevErrorHandlingScalar,CheckNonnegative) {
   const char* function = "check_nonnegative";
   var x = 0;
 
-  EXPECT_TRUE(check_nonnegative(function, "x", x)) 
+  EXPECT_NO_THROW(check_nonnegative(function, "x", x)) 
     << "check_nonnegative should be true with finite x: " << x;
 
   x = std::numeric_limits<double>::infinity();
-  EXPECT_TRUE(check_nonnegative(function, "x", x)) 
+  EXPECT_NO_THROW(check_nonnegative(function, "x", x)) 
     << "check_nonnegative should be true with x = Inf: " << x;
 
   x = -0.01;
@@ -39,18 +39,18 @@ TEST(AgradRevErrorHandlingScalar, CheckNonnegativeVarCheckUnivariate) {
   size_t stack_size = stan::math::ChainableStack::var_stack_.size();
 
   EXPECT_EQ(1U,stack_size);
-  EXPECT_TRUE(check_nonnegative(function,"a",a));
+  EXPECT_NO_THROW(check_nonnegative(function,"a",a));
 
   size_t stack_size_after_call = stan::math::ChainableStack::var_stack_.size();
   EXPECT_EQ(1U,stack_size_after_call);
 
   a = std::numeric_limits<double>::infinity();
-  EXPECT_TRUE(check_nonnegative(function,"a",a));
+  EXPECT_NO_THROW(check_nonnegative(function,"a",a));
   stack_size_after_call = stan::math::ChainableStack::var_stack_.size();
   EXPECT_EQ(2U,stack_size_after_call);
 
   a = 0.0;
-  EXPECT_TRUE(check_nonnegative(function,"a",a));
+  EXPECT_NO_THROW(check_nonnegative(function,"a",a));
   stack_size_after_call = stan::math::ChainableStack::var_stack_.size();
   EXPECT_EQ(3U,stack_size_after_call);
 

--- a/test/unit/math/rev/scal/err/check_not_nan_test.cpp
+++ b/test/unit/math/rev/scal/err/check_not_nan_test.cpp
@@ -64,11 +64,11 @@ TEST(ErrorHandlingScalar, CheckNotNanVarCheckUnivariate) {
 
   size_t stack_size = stan::math::ChainableStack::var_stack_.size();
 
-  EXPECT_NO_THROW(1U == stack_size);
+  EXPECT_TRUE(1U == stack_size);
   EXPECT_NO_THROW(check_not_nan(function,"a",a));
 
   size_t stack_size_after_call = stan::math::ChainableStack::var_stack_.size();
-  EXPECT_NO_THROW(1U == stack_size_after_call);
+  EXPECT_TRUE(1U == stack_size_after_call);
 
   stan::math::recover_memory();
 }

--- a/test/unit/math/rev/scal/err/check_not_nan_test.cpp
+++ b/test/unit/math/rev/scal/err/check_not_nan_test.cpp
@@ -9,23 +9,23 @@ TEST(AgradRevErrorHandlingScalar,CheckNotNan) {
   var x = 0;
   double x_d = 0;
  
-  EXPECT_TRUE(check_not_nan(function, "x", x))
+  EXPECT_NO_THROW(check_not_nan(function, "x", x))
     << "check_not_nan should be true with finite x: " << x;
-  EXPECT_TRUE(check_not_nan(function, "x", x_d))
+  EXPECT_NO_THROW(check_not_nan(function, "x", x_d))
     << "check_not_nan should be true with finite x: " << x_d;
   
   x = std::numeric_limits<var>::infinity();
   x_d = std::numeric_limits<double>::infinity();
-  EXPECT_TRUE(check_not_nan(function, "x", x))
+  EXPECT_NO_THROW(check_not_nan(function, "x", x))
     << "check_not_nan should be true with x = Inf: " << x;
-  EXPECT_TRUE(check_not_nan(function, "x", x_d))
+  EXPECT_NO_THROW(check_not_nan(function, "x", x_d))
     << "check_not_nan should be true with x = Inf: " << x_d;
 
   x = -std::numeric_limits<var>::infinity();
   x_d = -std::numeric_limits<double>::infinity();
-  EXPECT_TRUE(check_not_nan(function, "x", x))
+  EXPECT_NO_THROW(check_not_nan(function, "x", x))
     << "check_not_nan should be true with x = -Inf: " << x;
-  EXPECT_TRUE(check_not_nan(function, "x", x_d))
+  EXPECT_NO_THROW(check_not_nan(function, "x", x_d))
     << "check_not_nan should be true with x = -Inf: " << x_d;
 
   x = std::numeric_limits<var>::quiet_NaN();
@@ -47,7 +47,7 @@ TEST(AgradRevErrorHandlingScalar, CheckNotNanVarCheckUnivariate) {
   size_t stack_size = stan::math::ChainableStack::var_stack_.size();
 
   EXPECT_EQ(1U,stack_size);
-  EXPECT_TRUE(check_not_nan(function,"a",a));
+  EXPECT_NO_THROW(check_not_nan(function,"a",a));
 
   size_t stack_size_after_call = stan::math::ChainableStack::var_stack_.size();
   EXPECT_EQ(1U,stack_size_after_call);
@@ -64,11 +64,11 @@ TEST(ErrorHandlingScalar, CheckNotNanVarCheckUnivariate) {
 
   size_t stack_size = stan::math::ChainableStack::var_stack_.size();
 
-  EXPECT_TRUE(1U == stack_size);
-  EXPECT_TRUE(check_not_nan(function,"a",a));
+  EXPECT_NO_THROW(1U == stack_size);
+  EXPECT_NO_THROW(check_not_nan(function,"a",a));
 
   size_t stack_size_after_call = stan::math::ChainableStack::var_stack_.size();
-  EXPECT_TRUE(1U == stack_size_after_call);
+  EXPECT_NO_THROW(1U == stack_size_after_call);
 
   stan::math::recover_memory();
 }

--- a/test/unit/math/rev/scal/err/check_positive_finite_test.cpp
+++ b/test/unit/math/rev/scal/err/check_positive_finite_test.cpp
@@ -8,7 +8,7 @@ TEST(AgradRevErrorHandlingScalar,CheckPositiveFinite) {
   const char* function = "check_positive_finite";
   var x = 1;
  
-  EXPECT_TRUE(check_positive_finite(function, "x", x))
+  EXPECT_NO_THROW(check_positive_finite(function, "x", x))
     << "check_positive_finite should be true with finite x: " << x;
   x = -1;
   EXPECT_THROW(check_positive_finite(function, "x", x), std::domain_error)
@@ -40,7 +40,7 @@ TEST(AgradRevErrorHandlingScalar, CheckPositiveFiniteVarCheckUnivariate) {
   size_t stack_size = stan::math::ChainableStack::var_stack_.size();
 
   EXPECT_EQ(1U,stack_size);
-  EXPECT_TRUE(check_positive_finite(function,"a",a));
+  EXPECT_NO_THROW(check_positive_finite(function,"a",a));
 
   size_t stack_size_after_call = stan::math::ChainableStack::var_stack_.size();
   EXPECT_EQ(1U,stack_size_after_call);

--- a/test/unit/math/rev/scal/err/check_positive_test.cpp
+++ b/test/unit/math/rev/scal/err/check_positive_test.cpp
@@ -7,7 +7,7 @@ TEST(AgradRevErrorHandlingScalar,CheckPositive) {
   using stan::math::check_positive;
   const char* function = "check_positive";
 
-  EXPECT_TRUE(check_positive(function, "x", nan));
+  EXPECT_NO_THROW(check_positive(function, "x", nan));
 
   stan::math::recover_memory();
 }
@@ -22,7 +22,7 @@ TEST(AgradRevErrorHandlingScalar, CheckPositiveVarCheckUnivariate) {
   size_t stack_size = stan::math::ChainableStack::var_stack_.size();
 
   EXPECT_EQ(1U,stack_size);
-  EXPECT_TRUE(check_positive(function,"a",a));
+  EXPECT_NO_THROW(check_positive(function,"a",a));
 
   size_t stack_size_after_call = stan::math::ChainableStack::var_stack_.size();
   EXPECT_EQ(1U,stack_size_after_call);


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

- Changed all return types from `bool` to `void` for the `check_*` functions.
- Updated doxygen documentation.
- Updated calls that expected a `bool` return.

#### Intended Effect:

Make the math library cleaner.
I didn't change any of the implementation.

#### How to Verify:

Look at the diff. Lots of files, but it should be easy to see what's going on.

#### Side Effects:
Places that call the check functions and expect a boolean return will fail to compile. I found all the places in the math library. There may be some places upstream that will need to be fixed.

#### Documentation:
Included in the updates to the doxygen documentation.

#### Reviewer Suggestions: 
Anyone.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
