### PR TITLE
introduce choose() function

### DIFF
--- a/stan/math/prim/scal.hpp
+++ b/stan/math/prim/scal.hpp
@@ -62,6 +62,7 @@
 #include <stan/math/prim/scal/fun/bessel_second_kind.hpp>
 #include <stan/math/prim/scal/fun/binary_log_loss.hpp>
 #include <stan/math/prim/scal/fun/binomial_coefficient_log.hpp>
+#include <stan/math/prim/scal/fun/choose.hpp>
 #include <stan/math/prim/scal/fun/constants.hpp>
 #include <stan/math/prim/scal/fun/corr_constrain.hpp>
 #include <stan/math/prim/scal/fun/corr_free.hpp>

--- a/stan/math/prim/scal/fun/choose.hpp
+++ b/stan/math/prim/scal/fun/choose.hpp
@@ -1,0 +1,39 @@
+#ifndef STAN_MATH_PRIM_SCAL_FUN_CHOOSE_HPP
+#define STAN_MATH_PRIM_SCAL_FUN_CHOOSE_HPP
+
+#include <stan/math/prim/scal/err/check_nonnegative.hpp>
+#include <stan/math/prim/scal/err/check_less_or_equal.hpp>
+#include <boost/math/special_functions/binomial.hpp>
+#include <limits>
+
+namespace stan {
+  namespace math {
+    /**
+     * Return the binomial coefficient for the specified integer
+     * arguments.
+     *
+     * The binomial coefficient, \f${n \choose k}\f$, read "n choose k", is
+     * defined for \f$0 \leq k \leq n\f$ (otherwise return 0) by
+     *
+     * \f${n \choose k} = \frac{n!}{k! (n-k)!}\f$.
+     *
+     * @param n total number of objects.
+     * @param k number of objects chosen.
+     * @return n choose k or 0 iff k > n unless it overflows
+     */
+    inline int
+    choose(const int n, const int k) {
+      using stan::math::check_nonnegative;
+      using stan::math::check_less_or_equal;
+      check_nonnegative("choose", "n", n);
+      check_nonnegative("choose", "k", k);
+      if (k > n) return 0;
+      const double choices = boost::math::binomial_coefficient<double>(n, k);
+      check_less_or_equal("choose", "n choose k", choices,
+                          std::numeric_limits<int>::max());
+      return std::floor(choices);
+    }
+
+  }
+}
+#endif

--- a/stan/math/prim/scal/fun/choose.hpp
+++ b/stan/math/prim/scal/fun/choose.hpp
@@ -8,6 +8,7 @@
 
 namespace stan {
   namespace math {
+
     /**
      * Return the binomial coefficient for the specified integer
      * arguments.
@@ -17,12 +18,13 @@ namespace stan {
      *
      * \f${n \choose k} = \frac{n!}{k! (n-k)!}\f$.
      *
-     * @param n total number of objects.
-     * @param k number of objects chosen.
-     * @return n choose k or 0 iff k > n unless it overflows
+     * @param n total number of objects
+     * @param k number of objects chosen
+     * @return n choose k or 0 iff k > n
+     * @throw std::domain_error if either argument is negative or the
+     * result will not fit in an int type
      */
-    inline int
-    choose(const int n, const int k) {
+    inline int choose(int n, int k) {
       using stan::math::check_nonnegative;
       using stan::math::check_less_or_equal;
       check_nonnegative("choose", "n", n);
@@ -31,7 +33,8 @@ namespace stan {
       const double choices = boost::math::binomial_coefficient<double>(n, k);
       check_less_or_equal("choose", "n choose k", choices,
                           std::numeric_limits<int>::max());
-      return std::floor(choices);
+      // won't get proper round until C++11
+      return static_cast<int>(choices < 0 ? choices - 0.5 : choices + 0.5);
     }
 
   }

--- a/test/unit/math/prim/scal/fun/choose_test.cpp
+++ b/test/unit/math/prim/scal/fun/choose_test.cpp
@@ -1,0 +1,35 @@
+#include <stan/math/prim/scal.hpp>
+#include <boost/math/special_functions/fpclassify.hpp>
+#include <gtest/gtest.h>
+
+template <typename T_N, typename T_n>
+void test_choose(const T_N& N, const T_n& n) {
+  using stan::math::choose;
+  EXPECT_FLOAT_EQ(std::exp(lgamma(N + 1) - lgamma(n + 1) - lgamma(N - n + 1)),
+                  choose(N, n));
+}
+
+
+TEST(MathFunctions, choose) {
+  using stan::math::choose;
+  EXPECT_EQ(1, choose(2, 2));
+  EXPECT_EQ(2, choose(2, 1));
+  EXPECT_EQ(3, choose(3, 1));
+  EXPECT_EQ(3, choose(3, 2));
+  EXPECT_EQ(0, choose(2, 3));
+  for (int n = 0; n < 32; ++n) {
+    test_choose(32, n);
+  }
+  EXPECT_THROW(choose(36, 18), std::domain_error);
+}
+
+TEST(MathFunctions, choose_nan) {
+  using stan::math::choose;
+  int nan = std::numeric_limits<int>::quiet_NaN() - 1;
+  // quiet_NaN() returns 0 which would otherwise be valid
+  EXPECT_THROW(choose(2, nan), std::domain_error);
+  EXPECT_THROW(choose(nan, 2), std::domain_error);
+  EXPECT_THROW(choose(nan, nan), std::domain_error);
+
+}
+


### PR DESCRIPTION
#### Submisison Checklist

- [X] Run unit tests: `./runTests.py test/unit`
- [X] Run cpplint: `make cpplint`
- [X] Declare copyright holder and open-source license: see below

#### Summary:

Introduces a `int choose(int n, int k)` function

#### Intended Effect:

Avoid parser warnings from doing `(n * (n - 1)) / k` in Stan programs

#### How to Verify:

Call `choose(n, k)` in a Stan program

#### Side Effects:

None 

#### Documentation:

None

#### Reviewer Suggestions: 

Anyone

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Trustees of Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

