### PR TITLE
feature/issue-258 add bernoulli_logit_rng

### DIFF
--- a/stan/math/prim/scal.hpp
+++ b/stan/math/prim/scal.hpp
@@ -172,6 +172,7 @@
 #include <stan/math/prim/scal/prob/bernoulli_log.hpp>
 #include <stan/math/prim/scal/prob/bernoulli_logit_log.hpp>
 #include <stan/math/prim/scal/prob/bernoulli_rng.hpp>
+#include <stan/math/prim/scal/prob/bernoulli_logit_rng.hpp>
 #include <stan/math/prim/scal/prob/beta_binomial_ccdf_log.hpp>
 #include <stan/math/prim/scal/prob/beta_binomial_cdf.hpp>
 #include <stan/math/prim/scal/prob/beta_binomial_cdf_log.hpp>

--- a/stan/math/prim/scal/prob/bernoulli_logit_rng.hpp
+++ b/stan/math/prim/scal/prob/bernoulli_logit_rng.hpp
@@ -32,9 +32,7 @@ namespace stan {
       using boost::bernoulli_distribution;
       using stan::math::inv_logit;
 
-      static const char* function("bernoulli_logit_rng");
-
-      check_finite(function, "Logit transformed probability parameter", t);
+      check_finite("bernoulli_logit_rng", "Logit transformed probability parameter", t);
 
       variate_generator<RNG&, bernoulli_distribution<> >
         bernoulli_rng(rng, bernoulli_distribution<>(inv_logit(t)));

--- a/stan/math/prim/scal/prob/bernoulli_logit_rng.hpp
+++ b/stan/math/prim/scal/prob/bernoulli_logit_rng.hpp
@@ -1,0 +1,38 @@
+#ifndef STAN_MATH_PRIM_SCAL_PROB_BERNOULLI_LOGIT_RNG_HPP
+#define STAN_MATH_PRIM_SCAL_PROB_BERNOULLI_LOGIT_RNG_HPP
+
+#include <boost/random/bernoulli_distribution.hpp>
+#include <boost/random/variate_generator.hpp>
+#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
+#include <stan/math/prim/scal/err/check_bounded.hpp>
+#include <stan/math/prim/scal/err/check_finite.hpp>
+#include <stan/math/prim/scal/err/check_not_nan.hpp>
+#include <stan/math/prim/scal/fun/constants.hpp>
+#include <stan/math/prim/scal/fun/inv_logit.hpp>
+#include <stan/math/prim/scal/fun/log1m.hpp>
+#include <stan/math/prim/scal/fun/value_of.hpp>
+#include <stan/math/prim/scal/meta/include_summand.hpp>
+
+namespace stan {
+  namespace math {
+
+    template <class RNG>
+    inline int
+    bernoulli_logit_rng(const double t,
+                  RNG& rng) {
+      using boost::variate_generator;
+      using boost::bernoulli_distribution;
+      using stan::math::inv_logit;
+
+      static const char* function("bernoulli_rng");
+
+      check_finite(function, "Logit transformed probability parameter", t);
+
+      variate_generator<RNG&, bernoulli_distribution<> >
+        bernoulli_rng(rng, bernoulli_distribution<>(inv_logit(t)));
+      return bernoulli_rng();
+    }
+
+  }
+}
+#endif

--- a/stan/math/prim/scal/prob/bernoulli_logit_rng.hpp
+++ b/stan/math/prim/scal/prob/bernoulli_logit_rng.hpp
@@ -20,15 +20,14 @@ namespace stan {
      * A Bernoulli random number generator which takes as its argument the
      * often more convenient logit-parametrization.
      * 
+     * @tparam RNG Random number generator type.
      * @param t logit-transformed probability parameter.
      * @param rng pseudorandom number generator.
-     * @tparam RNG Random number generator type.
      * @return Bernoulli(logit^{-1}(t)) generated random number, either 0 or 1.
      */
     template <class RNG>
     inline int
-    bernoulli_logit_rng(const double t,
-                  RNG& rng) {
+    bernoulli_logit_rng(double t, RNG& rng) {
       using boost::variate_generator;
       using boost::bernoulli_distribution;
       using stan::math::inv_logit;

--- a/stan/math/prim/scal/prob/bernoulli_logit_rng.hpp
+++ b/stan/math/prim/scal/prob/bernoulli_logit_rng.hpp
@@ -24,7 +24,7 @@ namespace stan {
       using boost::bernoulli_distribution;
       using stan::math::inv_logit;
 
-      static const char* function("bernoulli_rng");
+      static const char* function("bernoulli_logit_rng");
 
       check_finite(function, "Logit transformed probability parameter", t);
 

--- a/stan/math/prim/scal/prob/bernoulli_logit_rng.hpp
+++ b/stan/math/prim/scal/prob/bernoulli_logit_rng.hpp
@@ -16,6 +16,15 @@
 namespace stan {
   namespace math {
 
+    /**
+     * A Bernoulli random number generator which takes as its argument the
+     * often more convenient logit-parametrization.
+     * 
+     * @param t logit-transformed probability parameter.
+     * @param rng pseudorandom number generator.
+     * @tparam RNG Random number generator type.
+     * @return Bernoulli(logit^{-1}(t)) generated random number, either 0 or 1.
+     */
     template <class RNG>
     inline int
     bernoulli_logit_rng(const double t,

--- a/stan/math/prim/scal/prob/bernoulli_logit_rng.hpp
+++ b/stan/math/prim/scal/prob/bernoulli_logit_rng.hpp
@@ -32,7 +32,8 @@ namespace stan {
       using boost::bernoulli_distribution;
       using stan::math::inv_logit;
 
-      check_finite("bernoulli_logit_rng", "Logit transformed probability parameter", t);
+      check_finite("bernoulli_logit_rng",
+                   "Logit transformed probability parameter", t);
 
       variate_generator<RNG&, bernoulli_distribution<> >
         bernoulli_rng(rng, bernoulli_distribution<>(inv_logit(t)));

--- a/test/unit/math/prim/scal/prob/bernoulli_logit_test.cpp
+++ b/test/unit/math/prim/scal/prob/bernoulli_logit_test.cpp
@@ -1,0 +1,51 @@
+#include <stan/math/prim/scal.hpp>
+#include <gtest/gtest.h>
+#include <boost/random/mersenne_twister.hpp>
+#include <boost/math/distributions.hpp>
+
+TEST(ProbDistributionsBernoulliLogit, error_check) {
+  boost::random::mt19937 rng;
+
+  EXPECT_NO_THROW(stan::math::bernoulli_logit_rng(-3.5,rng));
+  EXPECT_THROW(stan::math::bernoulli_logit_rng(stan::math::positive_infinity(),rng),
+               std::domain_error);
+}
+
+/*
+ * Uses a chi-squared test to check that counts are reasonably consistent
+ * with draws from a Bernoulli distribution..
+ */
+void assert_bernoulli(const std::vector<int>& counts, const std::vector<double>& expected_counts, double tolerance) {
+  boost::math::chi_squared dist(1);
+  
+  EXPECT_EQ(counts.size(), 2);
+  EXPECT_EQ(expected_counts.size(), 2);
+  
+  double chi = 0;
+  for (int i=0; i<2; ++i) {
+    const double discrepancy = expected_counts[i] - counts[i];
+    chi += discrepancy * discrepancy / expected_counts[i];
+  }
+  
+  const double chi_threshold = quantile(complement(dist, tolerance));
+  EXPECT_TRUE(chi < chi_threshold);
+}
+
+TEST(ProbDistributionsBernoulliLogit, logitChiSquareGoodnessFitTest) {
+  boost::random::mt19937 rng;
+  int N = 10000; // number of samples
+ 
+  double parameter = -0.5; // logit-transformed probability
+  double prob = stan::math::inv_logit(-0.5); // actual probability
+
+  const int tmp1[2] = {0, 0};
+  std::vector<int> counts(tmp1, tmp1 + 2);
+
+  const double tmp2[2] = {N * (1 - prob), N * prob};
+  const std::vector<double> expected_counts(tmp2, tmp2 + 2);
+
+  for (int i=0; i<N; ++i) {
+    ++counts[stan::math::bernoulli_logit_rng(parameter, rng)];
+  }
+  assert_bernoulli(counts, expected_counts, 1e-6);
+}

--- a/test/unit/math/prim/scal/prob/bernoulli_test.cpp
+++ b/test/unit/math/prim/scal/prob/bernoulli_test.cpp
@@ -19,7 +19,6 @@ TEST(ProbDistributionsBernoulli, error_check) {
 TEST(ProbDistributionsBernoulli, chiSquareGoodnessFitTest) {
   boost::random::mt19937 rng;
   int N = 10000;
-  boost::math::bernoulli_distribution<>dist (0.4);
   boost::math::chi_squared mydist(1);
  
   int bin[2] = {0, 0};
@@ -48,7 +47,6 @@ TEST(ProbDistributionsBernoulli, chiSquareGoodnessFitTest) {
 TEST(ProbDistributionsBernoulli, logitChiSquareGoodnessFitTest) {
   boost::random::mt19937 rng;
   int N = 10000;
-  boost::math::bernoulli_distribution<>dist (0.4);
   boost::math::chi_squared mydist(1);
  
   double parameter = -0.5;

--- a/test/unit/math/prim/scal/prob/bernoulli_test.cpp
+++ b/test/unit/math/prim/scal/prob/bernoulli_test.cpp
@@ -6,10 +6,13 @@
 TEST(ProbDistributionsBernoulli, error_check) {
   boost::random::mt19937 rng;
   EXPECT_NO_THROW(stan::math::bernoulli_rng(0.6,rng));
+  EXPECT_NO_THROW(stan::math::bernoulli_logit_rng(-3.5,rng));
 
   EXPECT_THROW(stan::math::bernoulli_rng(1.6,rng),std::domain_error);
   EXPECT_THROW(stan::math::bernoulli_rng(-0.6,rng),std::domain_error);
   EXPECT_THROW(stan::math::bernoulli_rng(stan::math::positive_infinity(),rng),
+               std::domain_error);
+  EXPECT_THROW(stan::math::bernoulli_logit_rng(stan::math::positive_infinity(),rng),
                std::domain_error);
 }
 
@@ -26,6 +29,37 @@ TEST(ProbDistributionsBernoulli, chiSquareGoodnessFitTest) {
 
   while (count < N) {
     int a = stan::math::bernoulli_rng(0.4,rng);
+    if(a == 1)
+      ++bin[1];
+    else
+      ++bin[0];
+    count++;
+   }
+
+  double chi = 0;
+
+  for(int j = 0; j < 2; j++)
+    chi += ((bin[j] - expect[j]) * (bin[j] - expect[j]) / expect[j]);
+
+  EXPECT_TRUE(chi < quantile(complement(mydist, 1e-6)));
+}
+
+
+TEST(ProbDistributionsBernoulli, logitChiSquareGoodnessFitTest) {
+  boost::random::mt19937 rng;
+  int N = 10000;
+  boost::math::bernoulli_distribution<>dist (0.4);
+  boost::math::chi_squared mydist(1);
+ 
+  double parameter = -0.5;
+  double prob = stan::math::inv_logit(-0.5);
+  int bin[2] = {0, 0};
+  double expect [2] = {N * (1 - prob), N * prob};
+
+  int count = 0;
+
+  while (count < N) {
+    int a = stan::math::bernoulli_logit_rng(parameter,rng);
     if(a == 1)
       ++bin[1];
     else

--- a/test/unit/math/prim/scal/prob/bernoulli_test.cpp
+++ b/test/unit/math/prim/scal/prob/bernoulli_test.cpp
@@ -6,68 +6,37 @@
 TEST(ProbDistributionsBernoulli, error_check) {
   boost::random::mt19937 rng;
   EXPECT_NO_THROW(stan::math::bernoulli_rng(0.6,rng));
-  EXPECT_NO_THROW(stan::math::bernoulli_logit_rng(-3.5,rng));
 
   EXPECT_THROW(stan::math::bernoulli_rng(1.6,rng),std::domain_error);
   EXPECT_THROW(stan::math::bernoulli_rng(-0.6,rng),std::domain_error);
   EXPECT_THROW(stan::math::bernoulli_rng(stan::math::positive_infinity(),rng),
                std::domain_error);
-  EXPECT_THROW(stan::math::bernoulli_logit_rng(stan::math::positive_infinity(),rng),
-               std::domain_error);
-}
-
-/*
- * Uses a chi-squared test to check that counts are reasonably consistent
- * with draws from a Bernoulli distribution..
- */
-void assert_bernoulli(const std::vector<int>& counts, const std::vector<double>& expected_counts, double tolerance) {
-  boost::math::chi_squared dist(1);
-  
-  EXPECT_EQ(counts.size(), 2);
-  EXPECT_EQ(expected_counts.size(), 2);
-  
-  double chi = 0;
-  for (int i=0; i<2; ++i) {
-    const double discrepancy = expected_counts[i] - counts[i];
-    chi += discrepancy * discrepancy / expected_counts[i];
-  }
-  
-  const double chi_threshold = quantile(complement(dist, tolerance));
-  EXPECT_TRUE(chi < chi_threshold);
 }
 
 TEST(ProbDistributionsBernoulli, chiSquareGoodnessFitTest) {
   boost::random::mt19937 rng;
   int N = 10000;
-
-  const int tmp1[2] = {0, 0};
-  std::vector<int> counts(tmp1, tmp1 + 2);
-
-  const double tmp2[2] = {N * (1 - 0.4), N * 0.4};
-  const std::vector<double> expected_counts(tmp2, tmp2 + 2);
-
-  for (int i=0; i<N; ++i) {
-    ++counts[stan::math::bernoulli_rng(0.4, rng)];
-  }
-  assert_bernoulli(counts, expected_counts, 1e-6);
-}
-
-
-TEST(ProbDistributionsBernoulli, logitChiSquareGoodnessFitTest) {
-  boost::random::mt19937 rng;
-  int N = 10000; // number of samples
+  boost::math::bernoulli_distribution<>dist (0.4);
+  boost::math::chi_squared mydist(1);
  
-  double parameter = -0.5; // logit-transformed probability
-  double prob = stan::math::inv_logit(-0.5); // actual probability
+  int bin[2] = {0, 0};
+  double expect [2] = {N * (1 - 0.4), N * (0.4)};
 
-  const int tmp1[2] = {0, 0};
-  std::vector<int> counts(tmp1, tmp1 + 2);
+  int count = 0;
 
-  const double tmp2[2] = {N * (1 - prob), N * prob};
-  const std::vector<double> expected_counts(tmp2, tmp2 + 2);
+  while (count < N) {
+    int a = stan::math::bernoulli_rng(0.4,rng);
+    if(a == 1)
+      ++bin[1];
+    else
+      ++bin[0];
+    count++;
+   }
 
-  for (int i=0; i<N; ++i) {
-    ++counts[stan::math::bernoulli_logit_rng(parameter, rng)];
-  }
-  assert_bernoulli(counts, expected_counts, 1e-6);
+  double chi = 0;
+
+  for(int j = 0; j < 2; j++)
+    chi += ((bin[j] - expect[j]) * (bin[j] - expect[j]) / expect[j]);
+
+  EXPECT_TRUE(chi < quantile(complement(mydist, 1e-6)));
 }

--- a/test/unit/math/prim/scal/prob/bernoulli_test.cpp
+++ b/test/unit/math/prim/scal/prob/bernoulli_test.cpp
@@ -16,59 +16,58 @@ TEST(ProbDistributionsBernoulli, error_check) {
                std::domain_error);
 }
 
+/*
+ * Uses a chi-squared test to check that counts are reasonably consistent
+ * with draws from a Bernoulli distribution..
+ */
+void assert_bernoulli(const std::vector<int>& counts, const std::vector<double>& expected_counts, double tolerance) {
+  boost::math::chi_squared dist(1);
+  
+  EXPECT_EQ(counts.size(), 2);
+  EXPECT_EQ(expected_counts.size(), 2);
+  
+  double chi = 0;
+  for (int i=0; i<2; ++i) {
+    const double discrepancy = expected_counts[i] - counts[i];
+    chi += discrepancy * discrepancy / expected_counts[i];
+  }
+  
+  const double chi_threshold = quantile(complement(dist, tolerance));
+  EXPECT_TRUE(chi < chi_threshold);
+}
+
 TEST(ProbDistributionsBernoulli, chiSquareGoodnessFitTest) {
   boost::random::mt19937 rng;
   int N = 10000;
-  boost::math::chi_squared mydist(1);
- 
-  int bin[2] = {0, 0};
-  double expect [2] = {N * (1 - 0.4), N * (0.4)};
 
-  int count = 0;
+  const int tmp1[2] = {0, 0};
+  std::vector<int> counts(tmp1, tmp1 + 2);
 
-  while (count < N) {
-    int a = stan::math::bernoulli_rng(0.4,rng);
-    if(a == 1)
-      ++bin[1];
-    else
-      ++bin[0];
-    count++;
-   }
+  const double tmp2[2] = {N * (1 - 0.4), N * 0.4};
+  const std::vector<double> expected_counts(tmp2, tmp2 + 2);
 
-  double chi = 0;
-
-  for(int j = 0; j < 2; j++)
-    chi += ((bin[j] - expect[j]) * (bin[j] - expect[j]) / expect[j]);
-
-  EXPECT_TRUE(chi < quantile(complement(mydist, 1e-6)));
+  for (int i=0; i<N; ++i) {
+    ++counts[stan::math::bernoulli_rng(0.4, rng)];
+  }
+  assert_bernoulli(counts, expected_counts, 1e-6);
 }
 
 
 TEST(ProbDistributionsBernoulli, logitChiSquareGoodnessFitTest) {
   boost::random::mt19937 rng;
-  int N = 10000;
-  boost::math::chi_squared mydist(1);
+  int N = 10000; // number of samples
  
-  double parameter = -0.5;
-  double prob = stan::math::inv_logit(-0.5);
-  int bin[2] = {0, 0};
-  double expect [2] = {N * (1 - prob), N * prob};
+  double parameter = -0.5; // logit-transformed probability
+  double prob = stan::math::inv_logit(-0.5); // actual probability
 
-  int count = 0;
+  const int tmp1[2] = {0, 0};
+  std::vector<int> counts(tmp1, tmp1 + 2);
 
-  while (count < N) {
-    int a = stan::math::bernoulli_logit_rng(parameter,rng);
-    if(a == 1)
-      ++bin[1];
-    else
-      ++bin[0];
-    count++;
-   }
+  const double tmp2[2] = {N * (1 - prob), N * prob};
+  const std::vector<double> expected_counts(tmp2, tmp2 + 2);
 
-  double chi = 0;
-
-  for(int j = 0; j < 2; j++)
-    chi += ((bin[j] - expect[j]) * (bin[j] - expect[j]) / expect[j]);
-
-  EXPECT_TRUE(chi < quantile(complement(mydist, 1e-6)));
+  for (int i=0; i<N; ++i) {
+    ++counts[stan::math::bernoulli_logit_rng(parameter, rng)];
+  }
+  assert_bernoulli(counts, expected_counts, 1e-6);
 }


### PR DESCRIPTION
#### Summary:

Adding Logit Parametrization for Bernoulli random number generators, resolving https://github.com/stan-dev/math/issues/258

#### Intended Effect:

Adds the ability to generate bernoulli random numbers in a different parametrization.

#### How to Verify:

Added a unit test at:

`./runTests.py test/unit/math/prim/scal/prob/bernoulli_test.cpp`

#### Side Effects:

None, function is not called. Will follow this with a pull request adding the function to stan.

#### Documentation:

Doxygen

#### Reviewer Suggestions: 

This is my first pull request on stan, so scrutiny is appreciated.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses: 
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
