### PR TITLE
Feature/issue 408 const

### DIFF
--- a/stan/math/fwd/core/operator_addition.hpp
+++ b/stan/math/fwd/core/operator_addition.hpp
@@ -16,14 +16,14 @@ namespace stan {
     template <typename T>
     inline
     fvar<T>
-    operator+(const double x1, const fvar<T>& x2) {
+    operator+(double x1, const fvar<T>& x2) {
       return fvar<T>(x1 + x2.val_, x2.d_);
     }
 
     template <typename T>
     inline
     fvar<T>
-    operator+(const fvar<T>& x1, const double x2) {
+    operator+(const fvar<T>& x1, double x2) {
       return fvar<T>(x1.val_ + x2, x1.d_);
     }
   }

--- a/stan/math/fwd/core/operator_division.hpp
+++ b/stan/math/fwd/core/operator_division.hpp
@@ -17,7 +17,7 @@ namespace stan {
     template <typename T>
     inline
     fvar<T>
-    operator/(const fvar<T>& x1, const double x2) {
+    operator/(const fvar<T>& x1, double x2) {
       return fvar<T>(x1.val_ / x2,
                      x1.d_ / x2);
     }
@@ -25,7 +25,7 @@ namespace stan {
     template <typename T>
     inline
     fvar<T>
-    operator/(const double x1, const fvar<T>& x2) {
+    operator/(double x1, const fvar<T>& x2) {
       return fvar<T>(x1 / x2.val_,
                      - x1 * x2.d_ / (x2.val_ * x2.val_));
     }

--- a/stan/math/fwd/core/operator_subtraction.hpp
+++ b/stan/math/fwd/core/operator_subtraction.hpp
@@ -16,14 +16,14 @@ namespace stan {
     template <typename T>
     inline
     fvar<T>
-    operator-(const double x1, const fvar<T>& x2) {
+    operator-(double x1, const fvar<T>& x2) {
       return fvar<T>(x1 - x2.val_, -x2.d_);
     }
 
     template <typename T>
     inline
     fvar<T>
-    operator-(const fvar<T>& x1, const double x2) {
+    operator-(const fvar<T>& x1, double x2) {
       return fvar<T>(x1.val_ - x2, x1.d_);
     }
   }

--- a/stan/math/fwd/mat/fun/divide.hpp
+++ b/stan/math/fwd/mat/fun/divide.hpp
@@ -24,7 +24,7 @@ namespace stan {
 
     template <typename T, int R, int C>
     inline Eigen::Matrix<fvar<T>, R, C>
-    divide(const Eigen::Matrix<fvar<T>, R, C>& v, const double c) {
+    divide(const Eigen::Matrix<fvar<T>, R, C>& v, double c) {
       Eigen::Matrix<fvar<T>, R, C>
         res(v.rows(), v.cols());
       for (int i = 0; i < v.rows(); i++) {
@@ -54,7 +54,7 @@ namespace stan {
 
     template <typename T, int R, int C>
     inline Eigen::Matrix<fvar<T>, R, C>
-    operator/(const Eigen::Matrix<fvar<T>, R, C>& v, const double c) {
+    operator/(const Eigen::Matrix<fvar<T>, R, C>& v, double c) {
       return divide(v, c);
     }
 

--- a/stan/math/fwd/mat/fun/multiply.hpp
+++ b/stan/math/fwd/mat/fun/multiply.hpp
@@ -29,7 +29,7 @@ namespace stan {
     template<typename T, int R2, int C2>
     inline
     Eigen::Matrix<fvar<T>, R2, C2>
-    multiply(const Eigen::Matrix<fvar<T>, R2, C2>& m, const double c) {
+    multiply(const Eigen::Matrix<fvar<T>, R2, C2>& m, double c) {
       Eigen::Matrix<fvar<T>, R2, C2> res(m.rows(), m.cols());
       for (int i = 0; i < m.rows(); i++) {
         for (int j = 0; j < m.cols(); j++)
@@ -60,7 +60,7 @@ namespace stan {
     template<typename T, int R1, int C1>
     inline
     Eigen::Matrix<fvar<T>, R1, C1>
-    multiply(const double c, const Eigen::Matrix<fvar<T>, R1, C1>& m) {
+    multiply(double c, const Eigen::Matrix<fvar<T>, R1, C1>& m) {
       return multiply(m, c);
     }
 

--- a/stan/math/fwd/scal/fun/atan2.hpp
+++ b/stan/math/fwd/scal/fun/atan2.hpp
@@ -17,14 +17,14 @@ namespace stan {
     }
 
     template <typename T>
-    inline fvar<T> atan2(const double x1, const fvar<T>& x2) {
+    inline fvar<T> atan2(double x1, const fvar<T>& x2) {
       using std::atan2;
       return fvar<T>(atan2(x1, x2.val_),
                      (-x1 * x2.d_) / (square(x1) + square(x2.val_)));
     }
 
     template <typename T>
-    inline fvar<T> atan2(const fvar<T>& x1, const double x2) {
+    inline fvar<T> atan2(const fvar<T>& x1, double x2) {
       using std::atan2;
       return fvar<T>(atan2(x1.val_, x2),
                      (x1.d_ * x2) / (square(x2) + square(x1.val_)));

--- a/stan/math/fwd/scal/fun/binary_log_loss.hpp
+++ b/stan/math/fwd/scal/fun/binary_log_loss.hpp
@@ -10,7 +10,7 @@ namespace stan {
     template <typename T>
     inline
     fvar<T>
-    binary_log_loss(const int y, const fvar<T>& y_hat) {
+    binary_log_loss(int y, const fvar<T>& y_hat) {
       if (y)
         return fvar<T>(binary_log_loss(y, y_hat.val_),
                        -y_hat.d_ / y_hat.val_);

--- a/stan/math/fwd/scal/fun/binomial_coefficient_log.hpp
+++ b/stan/math/fwd/scal/fun/binomial_coefficient_log.hpp
@@ -41,7 +41,7 @@ namespace stan {
     template <typename T>
     inline
     fvar<T>
-    binomial_coefficient_log(const fvar<T>& x1, const double x2) {
+    binomial_coefficient_log(const fvar<T>& x1, double x2) {
       using boost::math::digamma;
       using std::log;
       const double cutoff = 1000;
@@ -64,7 +64,7 @@ namespace stan {
     template <typename T>
     inline
     fvar<T>
-    binomial_coefficient_log(const double x1, const fvar<T>& x2) {
+    binomial_coefficient_log(double x1, const fvar<T>& x2) {
       using boost::math::digamma;
       using std::log;
       const double cutoff = 1000;

--- a/stan/math/fwd/scal/fun/falling_factorial.hpp
+++ b/stan/math/fwd/scal/fun/falling_factorial.hpp
@@ -25,7 +25,7 @@ namespace stan {
 
     template<typename T>
     inline fvar<T>
-    falling_factorial(const fvar<T>& x, const double n) {
+    falling_factorial(const fvar<T>& x, double n) {
       using boost::math::digamma;
 
       T falling_fact(falling_factorial(x.val_, n));
@@ -37,7 +37,7 @@ namespace stan {
 
     template<typename T>
     inline fvar<T>
-    falling_factorial(const double x, const fvar<T>& n) {
+    falling_factorial(double x, const fvar<T>& n) {
       using boost::math::digamma;
 
       T falling_fact(falling_factorial(x, n.val_));

--- a/stan/math/fwd/scal/fun/fdim.hpp
+++ b/stan/math/fwd/scal/fun/fdim.hpp
@@ -35,7 +35,7 @@ namespace stan {
      * positive and 0 otherwise.
      */
     template <typename T>
-    inline fvar<T> fdim(const fvar<T>& x, const double y) {
+    inline fvar<T> fdim(const fvar<T>& x, double y) {
       if (x.val_ < y)
         return fvar<T>(fdim(x.val_, y), 0);
       else
@@ -52,7 +52,7 @@ namespace stan {
      * positive and 0 otherwise.
      */
     template <typename T>
-    inline fvar<T> fdim(const double x, const fvar<T>& y) {
+    inline fvar<T> fdim(double x, const fvar<T>& y) {
       if (x < y.val_)
         return fvar<T>(fdim(x, y.val_), 0);
       else

--- a/stan/math/fwd/scal/fun/fmax.hpp
+++ b/stan/math/fwd/scal/fun/fmax.hpp
@@ -46,7 +46,7 @@ namespace stan {
      * @return maximum of arguments, and if one is NaN return the other
      */
     template <typename T>
-    inline fvar<T> fmax(const double x1, const fvar<T>& x2) {
+    inline fvar<T> fmax(double x1, const fvar<T>& x2) {
       if (unlikely(is_nan(x1))) {
         if (is_nan(x2.val_))
           return fvar<T>(fmax(x1, x2.val_), NOT_A_NUMBER);
@@ -72,7 +72,7 @@ namespace stan {
      * @return maximum of arguments, and if one is NaN return the other
      */
     template <typename T>
-    inline fvar<T> fmax(const fvar<T>& x1, const double x2) {
+    inline fvar<T> fmax(const fvar<T>& x1, double x2) {
       if (unlikely(is_nan(x1.val_))) {
         if (is_nan(x2))
           return fvar<T>(fmax(x1.val_, x2), NOT_A_NUMBER);

--- a/stan/math/fwd/scal/fun/fmin.hpp
+++ b/stan/math/fwd/scal/fun/fmin.hpp
@@ -29,7 +29,7 @@ namespace stan {
     }
 
     template <typename T>
-    inline fvar<T> fmin(const double x1, const fvar<T>& x2) {
+    inline fvar<T> fmin(double x1, const fvar<T>& x2) {
       if (unlikely(is_nan(x1))) {
         if (is_nan(x2.val_))
           return fvar<T>(fmin(x1, x2.val_), NOT_A_NUMBER);
@@ -47,7 +47,7 @@ namespace stan {
     }
 
     template <typename T>
-    inline fvar<T> fmin(const fvar<T>& x1, const double x2) {
+    inline fvar<T> fmin(const fvar<T>& x1, double x2) {
       if (unlikely(is_nan(x1.val_))) {
         if (is_nan(x2))
           return fvar<T>(fmin(x1.val_, x2), NOT_A_NUMBER);

--- a/stan/math/fwd/scal/fun/fmod.hpp
+++ b/stan/math/fwd/scal/fun/fmod.hpp
@@ -22,7 +22,7 @@ namespace stan {
     template <typename T>
     inline
     fvar<T>
-    fmod(const fvar<T>& x1, const double x2) {
+    fmod(const fvar<T>& x1, double x2) {
       using std::fmod;
       if (unlikely(is_nan(value_of(x1.val_))
                    || is_nan(x2)))
@@ -34,7 +34,7 @@ namespace stan {
     template <typename T>
     inline
     fvar<T>
-    fmod(const double x1, const fvar<T>& x2) {
+    fmod(double x1, const fvar<T>& x2) {
       using std::fmod;
       using std::floor;
       return fvar<T>(fmod(x1, x2.val_), -x2.d_ * floor(x1 / x2.val_));

--- a/stan/math/fwd/scal/fun/gamma_p.hpp
+++ b/stan/math/fwd/scal/fun/gamma_p.hpp
@@ -46,7 +46,7 @@ namespace stan {
     template <typename T>
     inline
     fvar<T>
-    gamma_p(const fvar<T>& x1, const double x2) {
+    gamma_p(const fvar<T>& x1, double x2) {
       using std::log;
       using std::exp;
       using std::pow;
@@ -80,7 +80,7 @@ namespace stan {
     template <typename T>
     inline
     fvar<T>
-    gamma_p(const double x1, const fvar<T>& x2) {
+    gamma_p(double x1, const fvar<T>& x2) {
       using std::exp;
       using std::pow;
 

--- a/stan/math/fwd/scal/fun/gamma_q.hpp
+++ b/stan/math/fwd/scal/fun/gamma_q.hpp
@@ -46,7 +46,7 @@ namespace stan {
     template <typename T>
     inline
     fvar<T>
-    gamma_q(const fvar<T>& x1, const double x2) {
+    gamma_q(const fvar<T>& x1, double x2) {
       using std::log;
       using std::exp;
       using std::pow;
@@ -80,7 +80,7 @@ namespace stan {
     template <typename T>
     inline
     fvar<T>
-    gamma_q(const double x1, const fvar<T>& x2) {
+    gamma_q(double x1, const fvar<T>& x2) {
       using std::exp;
       using std::pow;
 

--- a/stan/math/fwd/scal/fun/hypot.hpp
+++ b/stan/math/fwd/scal/fun/hypot.hpp
@@ -42,7 +42,7 @@ namespace stan {
      * and adjacent side lengths x1 and x2.
      */
     template <typename T>
-    inline fvar<T> hypot(const fvar<T>& x1, const double x2) {
+    inline fvar<T> hypot(const fvar<T>& x1, double x2) {
       using std::sqrt;
       T u = hypot(x1.val_, x2);
       return fvar<T>(u, (x1.d_ * x1.val_) / u);
@@ -62,7 +62,7 @@ namespace stan {
      * and adjacent side lengths x1 and x2.
      */
     template <typename T>
-    inline fvar<T> hypot(const double x1, const fvar<T>& x2) {
+    inline fvar<T> hypot(double x1, const fvar<T>& x2) {
       using std::sqrt;
       T u = hypot(x1, x2.val_);
       return fvar<T>(u, (x2.d_ * x2.val_) / u);

--- a/stan/math/fwd/scal/fun/lbeta.hpp
+++ b/stan/math/fwd/scal/fun/lbeta.hpp
@@ -23,7 +23,7 @@ namespace stan {
     template <typename T>
     inline
     fvar<T>
-    lbeta(const double x1, const fvar<T>& x2) {
+    lbeta(double x1, const fvar<T>& x2) {
       using boost::math::digamma;
       return fvar<T>(lbeta(x1, x2.val_),
                      x2.d_ * digamma(x2.val_) - x2.d_ * digamma(x1 + x2.val_));
@@ -32,7 +32,7 @@ namespace stan {
     template <typename T>
     inline
     fvar<T>
-    lbeta(const fvar<T>& x1, const double x2) {
+    lbeta(const fvar<T>& x1, double x2) {
       using boost::math::digamma;
       return fvar<T>(lbeta(x1.val_, x2),
                      x1.d_ * digamma(x1.val_) - x1.d_ * digamma(x1.val_ + x2));

--- a/stan/math/fwd/scal/fun/log_falling_factorial.hpp
+++ b/stan/math/fwd/scal/fun/log_falling_factorial.hpp
@@ -22,7 +22,7 @@ namespace stan {
 
     template<typename T>
     inline fvar<T>
-    log_falling_factorial(const double x, const fvar<T>& n) {
+    log_falling_factorial(double x, const fvar<T>& n) {
       using boost::math::digamma;
 
       return fvar<T>(log_falling_factorial(x, n.val_),
@@ -31,7 +31,7 @@ namespace stan {
 
     template<typename T>
     inline fvar<T>
-    log_falling_factorial(const fvar<T>& x, const double n) {
+    log_falling_factorial(const fvar<T>& x, double n) {
       using boost::math::digamma;
 
       return fvar<T>(log_falling_factorial(x.val_, n),

--- a/stan/math/fwd/scal/fun/log_mix.hpp
+++ b/stan/math/fwd/scal/fun/log_mix.hpp
@@ -137,7 +137,7 @@ namespace stan {
     inline
     fvar<T>
     log_mix(const fvar<T>& theta, const fvar<T>& lambda1,
-            const double lambda2) {
+            double lambda2) {
       if (lambda1.val_ > lambda2) {
         fvar<T> partial_deriv_array[2];
         log_mix_partial_helper(theta, lambda1, lambda2,
@@ -158,7 +158,7 @@ namespace stan {
     template<typename T>
     inline
     fvar<T>
-    log_mix(const fvar<T>& theta, const double lambda1,
+    log_mix(const fvar<T>& theta, double lambda1,
             const fvar<T>& lambda2) {
       if (lambda1 > lambda2.val_) {
         fvar<T> partial_deriv_array[2];
@@ -180,7 +180,7 @@ namespace stan {
     template<typename T>
     inline
     fvar<T>
-    log_mix(const double theta, const fvar<T>& lambda1,
+    log_mix(double theta, const fvar<T>& lambda1,
             const fvar<T>& lambda2) {
       if (lambda1.val_ > lambda2.val_) {
         fvar<T> partial_deriv_array[2];
@@ -201,7 +201,7 @@ namespace stan {
     template<typename T>
     inline
     fvar<T>
-    log_mix(const fvar<T>& theta, const double lambda1, const double lambda2) {
+    log_mix(const fvar<T>& theta, double lambda1, double lambda2) {
       if (lambda1 > lambda2) {
         fvar<T> partial_deriv_array[1];
         log_mix_partial_helper(theta, lambda1, lambda2, partial_deriv_array);
@@ -219,7 +219,7 @@ namespace stan {
     template<typename T>
     inline
     fvar<T>
-    log_mix(const double theta, const fvar<T>& lambda1, const double lambda2) {
+    log_mix(double theta, const fvar<T>& lambda1, double lambda2) {
       if (lambda1.val_ > lambda2) {
         fvar<T> partial_deriv_array[1];
         log_mix_partial_helper(theta, lambda1, lambda2, partial_deriv_array);
@@ -237,7 +237,7 @@ namespace stan {
     template<typename T>
     inline
     fvar<T>
-    log_mix(const double theta, const double lambda1, const fvar<T>& lambda2) {
+    log_mix(double theta, double lambda1, const fvar<T>& lambda2) {
       if (lambda1 > lambda2.val_) {
         fvar<T> partial_deriv_array[1];
         log_mix_partial_helper(theta, lambda1, lambda2, partial_deriv_array);

--- a/stan/math/fwd/scal/fun/log_rising_factorial.hpp
+++ b/stan/math/fwd/scal/fun/log_rising_factorial.hpp
@@ -17,13 +17,13 @@ namespace stan {
     }
 
     template<typename T>
-    inline fvar<T> log_rising_factorial(const fvar<T>& x, const double n) {
+    inline fvar<T> log_rising_factorial(const fvar<T>& x, double n) {
       return fvar<T>(log_rising_factorial(x.val_, n),
                      (digamma(x.val_ + n) - digamma(x.val_)) * x.d_);
     }
 
     template<typename T>
-    inline fvar<T> log_rising_factorial(const double x, const fvar<T>& n) {
+    inline fvar<T> log_rising_factorial(double x, const fvar<T>& n) {
       return fvar<T>(log_rising_factorial(x, n.val_),
                      digamma(x + n.val_) * n.d_);
     }

--- a/stan/math/fwd/scal/fun/log_sum_exp.hpp
+++ b/stan/math/fwd/scal/fun/log_sum_exp.hpp
@@ -21,7 +21,7 @@ namespace stan {
     template <typename T>
     inline
     fvar<T>
-    log_sum_exp(const double x1, const fvar<T>& x2) {
+    log_sum_exp(double x1, const fvar<T>& x2) {
       using std::exp;
       return fvar<T>(log_sum_exp(x1, x2.val_),
                      x2.d_ / (exp(x1 - x2.val_) + 1));
@@ -30,7 +30,7 @@ namespace stan {
     template <typename T>
     inline
     fvar<T>
-    log_sum_exp(const fvar<T>& x1, const double x2) {
+    log_sum_exp(const fvar<T>& x1, double x2) {
       using std::exp;
       return fvar<T>(log_sum_exp(x1.val_, x2),
                      x1.d_ / (1 + exp(x2 - x1.val_)));

--- a/stan/math/fwd/scal/fun/multiply_log.hpp
+++ b/stan/math/fwd/scal/fun/multiply_log.hpp
@@ -20,7 +20,7 @@ namespace stan {
     template <typename T>
     inline
     fvar<T>
-    multiply_log(const double x1, const fvar<T>& x2) {
+    multiply_log(double x1, const fvar<T>& x2) {
       using std::log;
       return fvar<T>(multiply_log(x1, x2.val_),
                      x1 * x2.d_ / x2.val_);
@@ -29,7 +29,7 @@ namespace stan {
     template <typename T>
     inline
     fvar<T>
-    multiply_log(const fvar<T>& x1, const double x2) {
+    multiply_log(const fvar<T>& x1, double x2) {
       using std::log;
       return fvar<T>(multiply_log(x1.val_, x2),
                      x1.d_ * log(x2));

--- a/stan/math/fwd/scal/fun/owens_t.hpp
+++ b/stan/math/fwd/scal/fun/owens_t.hpp
@@ -41,7 +41,7 @@ namespace stan {
      * @return Owen's T function applied to the specified arguments.
      */
     template <typename T>
-    inline fvar<T> owens_t(const double x1, const fvar<T>& x2) {
+    inline fvar<T> owens_t(double x1, const fvar<T>& x2) {
       using std::exp;
 
       T neg_x1_sq_div_2 = -square(x1) * 0.5;
@@ -59,7 +59,7 @@ namespace stan {
      * @return Owen's T function applied to the specified arguments.
      */
     template <typename T>
-    inline fvar<T> owens_t(const fvar<T>& x1, const double x2) {
+    inline fvar<T> owens_t(const fvar<T>& x1, double x2) {
       using std::exp;
 
       T neg_x1_sq_div_2 = -square(x1.val_) * 0.5;

--- a/stan/math/fwd/scal/fun/pow.hpp
+++ b/stan/math/fwd/scal/fun/pow.hpp
@@ -26,7 +26,7 @@ namespace stan {
     template <typename T>
     inline
     fvar<T>
-    pow(const double x1, const fvar<T>& x2) {
+    pow(double x1, const fvar<T>& x2) {
       using std::pow;
       using std::log;
       T u = pow(x1, x2.val_);
@@ -36,7 +36,7 @@ namespace stan {
     template <typename T>
     inline
     fvar<T>
-    pow(const fvar<T>& x1, const double x2) {
+    pow(const fvar<T>& x1, double x2) {
       using std::pow;
       using std::sqrt;
 

--- a/stan/math/fwd/scal/fun/rising_factorial.hpp
+++ b/stan/math/fwd/scal/fun/rising_factorial.hpp
@@ -22,7 +22,7 @@ namespace stan {
     template<typename T>
     inline
     fvar<T>
-    rising_factorial(const fvar<T>& x, const double n) {
+    rising_factorial(const fvar<T>& x, double n) {
       using boost::math::digamma;
 
       T rising_fact(rising_factorial(x.val_, n));
@@ -34,7 +34,7 @@ namespace stan {
     template<typename T>
     inline
     fvar<T>
-    rising_factorial(const double x, const fvar<T>& n) {
+    rising_factorial(double x, const fvar<T>& n) {
       using boost::math::digamma;
 
       T rising_fact(rising_factorial(x, n.val_));

--- a/stan/math/mix/mat/functor/finite_diff_grad_hessian.hpp
+++ b/stan/math/mix/mat/functor/finite_diff_grad_hessian.hpp
@@ -45,7 +45,7 @@ namespace stan {
                              Eigen::Matrix<double, -1, -1>& hess,
                              std::vector<Eigen::Matrix<double, -1, -1> >&
                              grad_hess_fx,
-                             const double epsilon = 1e-04) {
+                             double epsilon = 1e-04) {
       using Eigen::Matrix;
       using Eigen::Dynamic;
 

--- a/stan/math/prim/arr/fun/scaled_add.hpp
+++ b/stan/math/prim/arr/fun/scaled_add.hpp
@@ -9,7 +9,7 @@ namespace stan {
 
     inline void scaled_add(std::vector<double>& x,
                            const std::vector<double>& y,
-                           const double lambda) {
+                           double lambda) {
       for (size_t i = 0; i < x.size(); ++i)
         x[i] += lambda * y[i];
     }

--- a/stan/math/prim/arr/functor/coupled_ode_observer.hpp
+++ b/stan/math/prim/arr/functor/coupled_ode_observer.hpp
@@ -33,7 +33,7 @@ namespace stan {
        * @param t time of solution.
        */
       void operator()(const std::vector<double>& coupled_state,
-                      const double t) {
+                      double t) {
         y_coupled_[n_] = coupled_state;
         n_++;
       }

--- a/stan/math/prim/arr/functor/integrate_ode_rk45.hpp
+++ b/stan/math/prim/arr/functor/integrate_ode_rk45.hpp
@@ -65,7 +65,7 @@ namespace stan {
     std::vector<std::vector<typename stan::return_type<T1, T2>::type> >
     integrate_ode_rk45(const F& f,
                        const std::vector<T1> y0,
-                       const double t0,
+                       double t0,
                        const std::vector<double>& ts,
                        const std::vector<T2>& theta,
                        const std::vector<double>& x,

--- a/stan/math/prim/mat/err/check_column_index.hpp
+++ b/stan/math/prim/mat/err/check_column_index.hpp
@@ -35,7 +35,7 @@ namespace stan {
     inline void check_column_index(const char* function,
                                    const char* name,
                                    const Eigen::Matrix<T_y, R, C>& y,
-                                   const size_t i) {
+                                   size_t i) {
       if (i >= stan::error_index::value
           && i < static_cast<size_t>(y.cols()) + stan::error_index::value)
         return;

--- a/stan/math/prim/mat/err/check_range.hpp
+++ b/stan/math/prim/mat/err/check_range.hpp
@@ -27,9 +27,9 @@ namespace stan {
      */
     inline void check_range(const char* function,
                             const char* name,
-                            const int max,
-                            const int index,
-                            const int nested_level,
+                            int max,
+                            int index,
+                            int nested_level,
                             const char* error_msg) {
       if ((index >= stan::error_index::value)
           && (index < max + stan::error_index::value))
@@ -58,8 +58,8 @@ namespace stan {
      */
     inline void check_range(const char* function,
                             const char* name,
-                            const int max,
-                            const int index,
+                            int max,
+                            int index,
                             const char* error_msg) {
       if ((index >= stan::error_index::value)
           && (index < max + stan::error_index::value))
@@ -83,8 +83,8 @@ namespace stan {
      */
     inline void check_range(const char* function,
                             const char* name,
-                            const int max,
-                            const int index) {
+                            int max,
+                            int index) {
       if ((index >= stan::error_index::value)
           && (index < max + stan::error_index::value))
         return;

--- a/stan/math/prim/mat/fun/make_nu.hpp
+++ b/stan/math/prim/mat/fun/make_nu.hpp
@@ -18,7 +18,7 @@ namespace stan {
      */
     template<typename T>
     const Eigen::Array<T, Eigen::Dynamic, 1>
-    make_nu(const T eta, const size_t K) {
+    make_nu(const T eta, size_t K) {
       using Eigen::Array;
       using Eigen::Dynamic;
       using Eigen::Matrix;

--- a/stan/math/prim/mat/fun/read_corr_L.hpp
+++ b/stan/math/prim/mat/fun/read_corr_L.hpp
@@ -35,7 +35,7 @@ namespace stan {
     template <typename T>
     Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>
     read_corr_L(const Eigen::Array<T, Eigen::Dynamic, 1>& CPCs,  // on (-1, 1)
-                const size_t K) {
+                size_t K) {
       Eigen::Array<T, Eigen::Dynamic, 1> temp;
       Eigen::Array<T, Eigen::Dynamic, 1> acc(K-1);
       acc.setOnes();
@@ -88,7 +88,7 @@ namespace stan {
     template <typename T>
     Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>
     read_corr_L(const Eigen::Array<T, Eigen::Dynamic, 1>& CPCs,
-                const size_t K,
+                size_t K,
                 T& log_prob) {
       Eigen::Matrix<T, Eigen::Dynamic, 1> values(CPCs.rows() - 1);
       size_t pos = 0;

--- a/stan/math/prim/mat/fun/read_corr_matrix.hpp
+++ b/stan/math/prim/mat/fun/read_corr_matrix.hpp
@@ -24,7 +24,7 @@ namespace stan {
     template <typename T>
     Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>
     read_corr_matrix(const Eigen::Array<T, Eigen::Dynamic, 1>& CPCs,
-                     const size_t K) {
+                     size_t K) {
       Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> L
         = read_corr_L(CPCs, K);
       return multiply_lower_tri_self_transpose(L);
@@ -51,7 +51,7 @@ namespace stan {
     template <typename T>
     Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>
     read_corr_matrix(const Eigen::Array<T, Eigen::Dynamic, 1>& CPCs,
-                     const size_t K,
+                     size_t K,
                      T& log_prob) {
       Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> L
         = read_corr_L(CPCs, K, log_prob);

--- a/stan/math/prim/mat/functor/finite_diff_gradient.hpp
+++ b/stan/math/prim/mat/functor/finite_diff_gradient.hpp
@@ -39,7 +39,7 @@ namespace stan {
                          const Eigen::Matrix<double, -1, 1>& x,
                          double& fx,
                          Eigen::Matrix<double, -1, 1>& grad_fx,
-                         const double epsilon = 1e-03) {
+                         double epsilon = 1e-03) {
       using Eigen::Matrix;
       using Eigen::Dynamic;
       Matrix<double, Dynamic, 1> x_temp(x);

--- a/stan/math/prim/mat/functor/finite_diff_hessian.hpp
+++ b/stan/math/prim/mat/functor/finite_diff_hessian.hpp
@@ -11,7 +11,7 @@ namespace stan {
     double
     finite_diff_hess_helper(const F& f,
                             const Eigen::Matrix<double, Eigen::Dynamic, 1>& x,
-                            const int lambda,
+                            int lambda,
                             double epsilon = 1e-03) {
       using Eigen::Matrix;
       using Eigen::Dynamic;

--- a/stan/math/prim/mat/functor/finite_diff_hessian.hpp
+++ b/stan/math/prim/mat/functor/finite_diff_hessian.hpp
@@ -12,7 +12,7 @@ namespace stan {
     finite_diff_hess_helper(const F& f,
                             const Eigen::Matrix<double, Eigen::Dynamic, 1>& x,
                             const int lambda,
-                            const double epsilon = 1e-03) {
+                            double epsilon = 1e-03) {
       using Eigen::Matrix;
       using Eigen::Dynamic;
 
@@ -68,7 +68,7 @@ namespace stan {
                         double& fx,
                         Eigen::Matrix<double, -1, 1>& grad_fx,
                         Eigen::Matrix<double, -1, -1>& hess_fx,
-                        const double epsilon = 1e-03) {
+                        double epsilon = 1e-03) {
       using Eigen::Matrix;
       using Eigen::Dynamic;
 

--- a/stan/math/prim/mat/prob/inv_wishart_rng.hpp
+++ b/stan/math/prim/mat/prob/inv_wishart_rng.hpp
@@ -12,7 +12,7 @@ namespace stan {
 
     template <class RNG>
     inline Eigen::MatrixXd
-    inv_wishart_rng(const double nu, const Eigen::MatrixXd& S, RNG& rng) {
+    inv_wishart_rng(double nu, const Eigen::MatrixXd& S, RNG& rng) {
       static const char* function("inv_wishart_rng");
 
       using Eigen::MatrixXd;

--- a/stan/math/prim/mat/prob/lkj_corr_cholesky_rng.hpp
+++ b/stan/math/prim/mat/prob/lkj_corr_cholesky_rng.hpp
@@ -49,8 +49,8 @@ namespace stan {
 
     template <class RNG>
     inline Eigen::MatrixXd
-    lkj_corr_cholesky_rng(const size_t K,
-                          const double eta,
+    lkj_corr_cholesky_rng(size_t K,
+                          double eta,
                           RNG& rng) {
       static const char* function("lkj_corr_cholesky_rng");
 

--- a/stan/math/prim/mat/prob/multi_student_t_rng.hpp
+++ b/stan/math/prim/mat/prob/multi_student_t_rng.hpp
@@ -24,7 +24,7 @@ namespace stan {
 
     template <class RNG>
     inline Eigen::VectorXd
-    multi_student_t_rng(const double nu,
+    multi_student_t_rng(double nu,
           const Eigen::Matrix<double, Eigen::Dynamic, 1>& mu,
           const Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>& s,
           RNG& rng) {

--- a/stan/math/prim/mat/prob/multinomial_rng.hpp
+++ b/stan/math/prim/mat/prob/multinomial_rng.hpp
@@ -20,7 +20,7 @@ namespace stan {
     template <class RNG>
     inline std::vector<int>
     multinomial_rng(const Eigen::Matrix<double, Eigen::Dynamic, 1>& theta,
-                    const int N,
+                    int N,
                     RNG& rng) {
       static const char* function("multinomial_rng");
 

--- a/stan/math/prim/mat/prob/ordered_logistic_rng.hpp
+++ b/stan/math/prim/mat/prob/ordered_logistic_rng.hpp
@@ -20,7 +20,7 @@ namespace stan {
 
     template <class RNG>
     inline int
-    ordered_logistic_rng(const double eta,
+    ordered_logistic_rng(double eta,
                          const Eigen::Matrix<double, Eigen::Dynamic, 1>& c,
                          RNG& rng) {
       using boost::variate_generator;

--- a/stan/math/prim/scal/err/check_positive_size.hpp
+++ b/stan/math/prim/scal/err/check_positive_size.hpp
@@ -22,7 +22,7 @@ namespace stan {
     inline void check_positive_size(const char* function,
                                     const char* name,
                                     const char* expr,
-                                    const int size) {
+                                    int size) {
       if (size <= 0) {
         std::stringstream msg;
         msg << "; dimension size expression = " << expr;

--- a/stan/math/prim/scal/err/domain_error_vec.hpp
+++ b/stan/math/prim/scal/err/domain_error_vec.hpp
@@ -37,7 +37,7 @@ namespace stan {
     inline void domain_error_vec(const char* function,
                                  const char* name,
                                  const T& y,
-                                 const size_t i,
+                                 size_t i,
                                  const char* msg1,
                                  const char* msg2) {
       std::ostringstream vec_name_stream;
@@ -72,7 +72,7 @@ namespace stan {
     inline void domain_error_vec(const char* function,
                                  const char* name,
                                  const T& y,
-                                 const size_t i,
+                                 size_t i,
                                  const char* msg) {
       domain_error_vec(function, name, y, i, msg, "");
     }

--- a/stan/math/prim/scal/err/invalid_argument_vec.hpp
+++ b/stan/math/prim/scal/err/invalid_argument_vec.hpp
@@ -37,7 +37,7 @@ namespace stan {
     inline void invalid_argument_vec(const char* function,
                                      const char* name,
                                      const T& y,
-                                     const size_t i,
+                                     size_t i,
                                      const char* msg1,
                                      const char* msg2) {
       std::ostringstream vec_name_stream;
@@ -73,7 +73,7 @@ namespace stan {
     inline void invalid_argument_vec(const char* function,
                                      const char* name,
                                      const T& y,
-                                     const size_t i,
+                                     size_t i,
                                      const char* msg) {
       invalid_argument_vec(function, name, y, i, msg, "");
     }

--- a/stan/math/prim/scal/err/out_of_range.hpp
+++ b/stan/math/prim/scal/err/out_of_range.hpp
@@ -29,8 +29,8 @@ namespace stan {
      * @throw std::out_of_range with message.
      */
     inline void out_of_range(const char* function,
-                             const int max,
-                             const int index,
+                             int max,
+                             int index,
                              const char* msg1 = "",
                              const char* msg2 = "") {
       std::ostringstream message;

--- a/stan/math/prim/scal/fun/Phi.hpp
+++ b/stan/math/prim/scal/fun/Phi.hpp
@@ -25,7 +25,7 @@ namespace stan {
      * @param x Argument.
      * @return Probability random sample is less than or equal to argument.
      */
-    inline double Phi(const double x) {
+    inline double Phi(double x) {
       check_not_nan("Phi",  "x", x);
       if (x < -37.5)
         return 0;

--- a/stan/math/prim/scal/fun/bessel_first_kind.hpp
+++ b/stan/math/prim/scal/fun/bessel_first_kind.hpp
@@ -37,7 +37,7 @@ namespace stan {
      */
     template<typename T2>
     inline T2
-    bessel_first_kind(const int v, const T2 z) {
+    bessel_first_kind(int v, const T2 z) {
       check_not_nan("bessel_first_kind", "z", z);
       return boost::math::cyl_bessel_j(v, z);
     }

--- a/stan/math/prim/scal/fun/bessel_second_kind.hpp
+++ b/stan/math/prim/scal/fun/bessel_second_kind.hpp
@@ -37,7 +37,7 @@ namespace stan {
      */
     template <typename T2>
     inline T2
-    bessel_second_kind(const int v, const T2 z) {
+    bessel_second_kind(int v, const T2 z) {
       return boost::math::cyl_neumann(v, z);
     }
 

--- a/stan/math/prim/scal/fun/binary_log_loss.hpp
+++ b/stan/math/prim/scal/fun/binary_log_loss.hpp
@@ -23,7 +23,7 @@ namespace stan {
      */
     template <typename T>
     inline typename boost::math::tools::promote_args<T>::type
-    binary_log_loss(const int y, const T y_hat) {
+    binary_log_loss(int y, const T y_hat) {
       using std::log;
       return -log(y ? y_hat : (1.0 - y_hat));
     }

--- a/stan/math/prim/scal/fun/divide.hpp
+++ b/stan/math/prim/scal/fun/divide.hpp
@@ -23,7 +23,7 @@ namespace stan {
       return x / y;
     }
 
-    inline int divide(const int x, const int y) {
+    inline int divide(int x, int y) {
       if (unlikely(y == 0))
         domain_error("divide", "denominator is", y, "");
       return x / y;

--- a/stan/math/prim/scal/fun/ibeta.hpp
+++ b/stan/math/prim/scal/fun/ibeta.hpp
@@ -20,9 +20,9 @@ namespace stan {
      *
      * @return The normalized incomplete beta function.
      */
-    inline double ibeta(const double a,
-                        const double b,
-                        const double x) {
+    inline double ibeta(double a,
+                        double b,
+                        double x) {
       check_not_nan("ibeta", "a", a);
       check_not_nan("ibeta", "b", b);
       check_not_nan("ibeta", "x", x);

--- a/stan/math/prim/scal/fun/inv.hpp
+++ b/stan/math/prim/scal/fun/inv.hpp
@@ -4,7 +4,7 @@
 namespace stan {
   namespace math {
 
-    inline double inv(const double x) {
+    inline double inv(double x) {
       return 1.0 / x;
     }
 

--- a/stan/math/prim/scal/fun/inv_cloglog.hpp
+++ b/stan/math/prim/scal/fun/inv_cloglog.hpp
@@ -44,7 +44,7 @@ namespace stan {
      * @param x Argument.
      * @return Inverse complementary log-log of the argument.
      */
-    inline double inv_cloglog(const double x) {
+    inline double inv_cloglog(double x) {
       using std::exp;
       return 1 - exp(-exp(x));
     }

--- a/stan/math/prim/scal/fun/inv_logit.hpp
+++ b/stan/math/prim/scal/fun/inv_logit.hpp
@@ -46,7 +46,7 @@ namespace stan {
      * @param a Argument.
      * @return Inverse logit of argument.
      */
-    inline double inv_logit(const double a) {
+    inline double inv_logit(double a) {
       using std::exp;
       return 1.0 / (1.0 + exp(-a));
     }

--- a/stan/math/prim/scal/fun/inv_sqrt.hpp
+++ b/stan/math/prim/scal/fun/inv_sqrt.hpp
@@ -6,7 +6,7 @@
 namespace stan {
   namespace math {
 
-    inline double inv_sqrt(const double x) {
+    inline double inv_sqrt(double x) {
       using std::sqrt;
       return 1.0 / sqrt(x);
     }

--- a/stan/math/prim/scal/fun/inv_square.hpp
+++ b/stan/math/prim/scal/fun/inv_square.hpp
@@ -4,7 +4,7 @@
 namespace stan {
   namespace math {
 
-    inline double inv_square(const double x) {
+    inline double inv_square(double x) {
       return 1.0 / (x * x);
     }
   }

--- a/stan/math/prim/scal/fun/is_inf.hpp
+++ b/stan/math/prim/scal/fun/is_inf.hpp
@@ -15,7 +15,7 @@ namespace stan {
      * @return <code>1</code> if the value is infinite.
      */
     inline int
-    is_inf(const double x) {
+    is_inf(double x) {
       return boost::math::isinf(x);
     }
 

--- a/stan/math/prim/scal/fun/lmgamma.hpp
+++ b/stan/math/prim/scal/fun/lmgamma.hpp
@@ -53,7 +53,7 @@ namespace stan {
      */
     template <typename T>
     inline typename boost::math::tools::promote_args<T>::type
-    lmgamma(const int k, T x) {
+    lmgamma(int k, T x) {
       using boost::math::lgamma;
       typename boost::math::tools::promote_args<T>::type result
         = k * (k - 1) * LOG_PI_OVER_FOUR;

--- a/stan/math/prim/scal/fun/log1m.hpp
+++ b/stan/math/prim/scal/fun/log1m.hpp
@@ -36,7 +36,7 @@ namespace stan {
      * @throw std::domain_error If the argument is greater than 1.
      * @throw std::overflow_error If the computation overflows.
      */
-    inline double log1m(const double x) {
+    inline double log1m(double x) {
       return stan::math::log1p(-x);
     }
 

--- a/stan/math/prim/scal/fun/log1p_exp.hpp
+++ b/stan/math/prim/scal/fun/log1p_exp.hpp
@@ -39,7 +39,7 @@ namespace stan {
        \f]
      *
      */
-    inline double log1p_exp(const double a) {
+    inline double log1p_exp(double a) {
       using std::exp;
       // like log_sum_exp below with b=0.0; prevents underflow
       if (a > 0.0)

--- a/stan/math/prim/scal/fun/modified_bessel_first_kind.hpp
+++ b/stan/math/prim/scal/fun/modified_bessel_first_kind.hpp
@@ -36,7 +36,7 @@ namespace stan {
      */
     template<typename T2>
     inline T2
-    modified_bessel_first_kind(const int v, const T2 z) {
+    modified_bessel_first_kind(int v, const T2 z) {
       check_not_nan("modified_bessel_first_kind", "z", z);
 
       return boost::math::cyl_bessel_i(v, z);

--- a/stan/math/prim/scal/fun/modified_bessel_second_kind.hpp
+++ b/stan/math/prim/scal/fun/modified_bessel_second_kind.hpp
@@ -39,7 +39,7 @@ namespace stan {
      */
     template<typename T2>
     inline T2
-    modified_bessel_second_kind(const int v, const T2 z) {
+    modified_bessel_second_kind(int v, const T2 z) {
       return boost::math::cyl_bessel_k(v, z);
     }
 

--- a/stan/math/prim/scal/fun/modulus.hpp
+++ b/stan/math/prim/scal/fun/modulus.hpp
@@ -9,7 +9,7 @@
 namespace stan {
   namespace math {
 
-    inline int modulus(const int x, const int y) {
+    inline int modulus(int x, int y) {
       if (unlikely(y == 0))
         domain_error("modulus", "divisor is", 0, "");
       return x % y;

--- a/stan/math/prim/scal/fun/owens_t.hpp
+++ b/stan/math/prim/scal/fun/owens_t.hpp
@@ -56,7 +56,7 @@ namespace stan {
      * @return Owen's T function applied to the arguments.
      */
     inline
-    double owens_t(const double h, const double a) {
+    double owens_t(double h, double a) {
       return boost::math::owens_t(h, a);
     }
   }

--- a/stan/math/prim/scal/fun/square.hpp
+++ b/stan/math/prim/scal/fun/square.hpp
@@ -17,7 +17,7 @@ namespace stan {
      * @param x Input to square.
      * @return Square of input.
      */
-    inline double square(const double x) {
+    inline double square(double x) {
       return x * x;
     }
 

--- a/stan/math/prim/scal/fun/value_of.hpp
+++ b/stan/math/prim/scal/fun/value_of.hpp
@@ -36,7 +36,7 @@ namespace stan {
      * @return Specified value.
      */
     template <>
-    inline double value_of<double>(const double x) {
+    inline double value_of<double>(double x) {
       return x;
     }
 

--- a/stan/math/prim/scal/fun/value_of_rec.hpp
+++ b/stan/math/prim/scal/fun/value_of_rec.hpp
@@ -36,7 +36,7 @@ namespace stan {
      * @return Specified value.
      */
     template <>
-    inline double value_of_rec<double>(const double x) {
+    inline double value_of_rec<double>(double x) {
       return x;
     }
 

--- a/stan/math/prim/scal/prob/bernoulli_rng.hpp
+++ b/stan/math/prim/scal/prob/bernoulli_rng.hpp
@@ -18,7 +18,7 @@ namespace stan {
 
     template <class RNG>
     inline int
-    bernoulli_rng(const double theta,
+    bernoulli_rng(double theta,
                   RNG& rng) {
       using boost::variate_generator;
       using boost::bernoulli_distribution;

--- a/stan/math/prim/scal/prob/beta_binomial_rng.hpp
+++ b/stan/math/prim/scal/prob/beta_binomial_rng.hpp
@@ -21,9 +21,9 @@ namespace stan {
 
     template <class RNG>
     inline int
-    beta_binomial_rng(const int N,
-                      const double alpha,
-                      const double beta,
+    beta_binomial_rng(int N,
+                      double alpha,
+                      double beta,
                       RNG& rng) {
       static const char* function("beta_binomial_rng");
 

--- a/stan/math/prim/scal/prob/beta_rng.hpp
+++ b/stan/math/prim/scal/prob/beta_rng.hpp
@@ -25,8 +25,8 @@ namespace stan {
 
     template <class RNG>
     inline double
-    beta_rng(const double alpha,
-             const double beta,
+    beta_rng(double alpha,
+             double beta,
              RNG& rng) {
       using boost::variate_generator;
       using boost::random::gamma_distribution;

--- a/stan/math/prim/scal/prob/binomial_rng.hpp
+++ b/stan/math/prim/scal/prob/binomial_rng.hpp
@@ -25,8 +25,8 @@ namespace stan {
 
     template <class RNG>
     inline int
-    binomial_rng(const int N,
-                 const double theta,
+    binomial_rng(int N,
+                 double theta,
                  RNG& rng) {
       using boost::variate_generator;
       using boost::binomial_distribution;

--- a/stan/math/prim/scal/prob/cauchy_rng.hpp
+++ b/stan/math/prim/scal/prob/cauchy_rng.hpp
@@ -18,8 +18,8 @@ namespace stan {
 
     template <class RNG>
     inline double
-    cauchy_rng(const double mu,
-               const double sigma,
+    cauchy_rng(double mu,
+               double sigma,
                RNG& rng) {
       using boost::variate_generator;
       using boost::random::cauchy_distribution;

--- a/stan/math/prim/scal/prob/chi_square_rng.hpp
+++ b/stan/math/prim/scal/prob/chi_square_rng.hpp
@@ -20,7 +20,7 @@ namespace stan {
 
     template <class RNG>
     inline double
-    chi_square_rng(const double nu,
+    chi_square_rng(double nu,
                    RNG& rng) {
       using boost::variate_generator;
       using boost::random::chi_squared_distribution;

--- a/stan/math/prim/scal/prob/double_exponential_rng.hpp
+++ b/stan/math/prim/scal/prob/double_exponential_rng.hpp
@@ -19,8 +19,8 @@ namespace stan {
 
     template <class RNG>
     inline double
-    double_exponential_rng(const double mu,
-                           const double sigma,
+    double_exponential_rng(double mu,
+                           double sigma,
                            RNG& rng) {
       static const char* function("double_exponential_rng");
 

--- a/stan/math/prim/scal/prob/exp_mod_normal_rng.hpp
+++ b/stan/math/prim/scal/prob/exp_mod_normal_rng.hpp
@@ -21,9 +21,9 @@ namespace stan {
 
     template <class RNG>
     inline double
-    exp_mod_normal_rng(const double mu,
-                       const double sigma,
-                       const double lambda,
+    exp_mod_normal_rng(double mu,
+                       double sigma,
+                       double lambda,
                        RNG& rng) {
       static const char* function("exp_mod_normal_rng");
 

--- a/stan/math/prim/scal/prob/exponential_rng.hpp
+++ b/stan/math/prim/scal/prob/exponential_rng.hpp
@@ -20,7 +20,7 @@ namespace stan {
 
     template <class RNG>
     inline double
-    exponential_rng(const double beta,
+    exponential_rng(double beta,
                     RNG& rng) {
       using boost::variate_generator;
       using boost::exponential_distribution;

--- a/stan/math/prim/scal/prob/frechet_rng.hpp
+++ b/stan/math/prim/scal/prob/frechet_rng.hpp
@@ -23,8 +23,8 @@ namespace stan {
 
     template <class RNG>
     inline double
-    frechet_rng(const double alpha,
-                const double sigma,
+    frechet_rng(double alpha,
+                double sigma,
                 RNG& rng) {
       using boost::variate_generator;
       using boost::random::weibull_distribution;

--- a/stan/math/prim/scal/prob/gamma_rng.hpp
+++ b/stan/math/prim/scal/prob/gamma_rng.hpp
@@ -26,8 +26,8 @@ namespace stan {
 
     template <class RNG>
     inline double
-    gamma_rng(const double alpha,
-              const double beta,
+    gamma_rng(double alpha,
+              double beta,
               RNG& rng) {
       using boost::variate_generator;
       using boost::gamma_distribution;

--- a/stan/math/prim/scal/prob/gumbel_rng.hpp
+++ b/stan/math/prim/scal/prob/gumbel_rng.hpp
@@ -20,8 +20,8 @@ namespace stan {
 
     template <class RNG>
     inline double
-    gumbel_rng(const double mu,
-               const double beta,
+    gumbel_rng(double mu,
+               double beta,
                RNG& rng) {
       using boost::variate_generator;
       using boost::uniform_01;

--- a/stan/math/prim/scal/prob/inv_chi_square_rng.hpp
+++ b/stan/math/prim/scal/prob/inv_chi_square_rng.hpp
@@ -24,7 +24,7 @@ namespace stan {
 
     template <class RNG>
     inline double
-    inv_chi_square_rng(const double nu,
+    inv_chi_square_rng(double nu,
                        RNG& rng) {
       using boost::variate_generator;
       using boost::random::chi_squared_distribution;

--- a/stan/math/prim/scal/prob/inv_gamma_rng.hpp
+++ b/stan/math/prim/scal/prob/inv_gamma_rng.hpp
@@ -26,8 +26,8 @@ namespace stan {
 
     template <class RNG>
     inline double
-    inv_gamma_rng(const double alpha,
-                  const double beta,
+    inv_gamma_rng(double alpha,
+                  double beta,
                   RNG& rng) {
       using boost::variate_generator;
       using boost::random::gamma_distribution;

--- a/stan/math/prim/scal/prob/logistic_rng.hpp
+++ b/stan/math/prim/scal/prob/logistic_rng.hpp
@@ -21,8 +21,8 @@ namespace stan {
 
     template <class RNG>
     inline double
-    logistic_rng(const double mu,
-                 const double sigma,
+    logistic_rng(double mu,
+                 double sigma,
                  RNG& rng) {
       using boost::variate_generator;
       using boost::random::exponential_distribution;

--- a/stan/math/prim/scal/prob/lognormal_rng.hpp
+++ b/stan/math/prim/scal/prob/lognormal_rng.hpp
@@ -18,8 +18,8 @@ namespace stan {
 
     template <class RNG>
     inline double
-    lognormal_rng(const double mu,
-                  const double sigma,
+    lognormal_rng(double mu,
+                  double sigma,
                   RNG& rng) {
       using boost::variate_generator;
       using boost::random::lognormal_distribution;

--- a/stan/math/prim/scal/prob/neg_binomial_2_log_rng.hpp
+++ b/stan/math/prim/scal/prob/neg_binomial_2_log_rng.hpp
@@ -24,8 +24,8 @@ namespace stan {
 
     template <class RNG>
     inline int
-    neg_binomial_2_log_rng(const double eta,
-                           const double phi,
+    neg_binomial_2_log_rng(double eta,
+                           double phi,
                            RNG& rng) {
       using boost::variate_generator;
       using boost::random::negative_binomial_distribution;

--- a/stan/math/prim/scal/prob/neg_binomial_2_rng.hpp
+++ b/stan/math/prim/scal/prob/neg_binomial_2_rng.hpp
@@ -24,8 +24,8 @@ namespace stan {
 
     template <class RNG>
     inline int
-    neg_binomial_2_rng(const double mu,
-                       const double phi,
+    neg_binomial_2_rng(double mu,
+                       double phi,
                        RNG& rng) {
       using boost::variate_generator;
       using boost::random::negative_binomial_distribution;

--- a/stan/math/prim/scal/prob/neg_binomial_rng.hpp
+++ b/stan/math/prim/scal/prob/neg_binomial_rng.hpp
@@ -25,8 +25,8 @@ namespace stan {
 
     template <class RNG>
     inline int
-    neg_binomial_rng(const double alpha,
-                     const double beta,
+    neg_binomial_rng(double alpha,
+                     double beta,
                      RNG& rng) {
       using boost::variate_generator;
       using boost::random::negative_binomial_distribution;

--- a/stan/math/prim/scal/prob/normal_rng.hpp
+++ b/stan/math/prim/scal/prob/normal_rng.hpp
@@ -15,8 +15,8 @@ namespace stan {
 
     template <class RNG>
     inline double
-    normal_rng(const double mu,
-               const double sigma,
+    normal_rng(double mu,
+               double sigma,
                RNG& rng) {
       using boost::variate_generator;
       using boost::normal_distribution;

--- a/stan/math/prim/scal/prob/pareto_rng.hpp
+++ b/stan/math/prim/scal/prob/pareto_rng.hpp
@@ -17,8 +17,8 @@ namespace stan {
 
     template <class RNG>
     inline double
-    pareto_rng(const double y_min,
-               const double alpha,
+    pareto_rng(double y_min,
+               double alpha,
                RNG& rng) {
       using boost::variate_generator;
       using boost::exponential_distribution;

--- a/stan/math/prim/scal/prob/pareto_type_2_rng.hpp
+++ b/stan/math/prim/scal/prob/pareto_type_2_rng.hpp
@@ -18,9 +18,9 @@ namespace stan {
 
     template <class RNG>
     inline double
-    pareto_type_2_rng(const double mu,
-                      const double lambda,
-                      const double alpha,
+    pareto_type_2_rng(double mu,
+                      double lambda,
+                      double alpha,
                       RNG& rng) {
       static const char* function("pareto_type_2_rng");
 

--- a/stan/math/prim/scal/prob/poisson_log_rng.hpp
+++ b/stan/math/prim/scal/prob/poisson_log_rng.hpp
@@ -18,7 +18,7 @@ namespace stan {
 
     template <class RNG>
     inline int
-    poisson_log_rng(const double alpha,
+    poisson_log_rng(double alpha,
                     RNG& rng) {
       using boost::variate_generator;
       using boost::random::poisson_distribution;

--- a/stan/math/prim/scal/prob/poisson_rng.hpp
+++ b/stan/math/prim/scal/prob/poisson_rng.hpp
@@ -19,7 +19,7 @@ namespace stan {
 
     template <class RNG>
     inline int
-    poisson_rng(const double lambda,
+    poisson_rng(double lambda,
                 RNG& rng) {
       using boost::variate_generator;
       using boost::random::poisson_distribution;

--- a/stan/math/prim/scal/prob/rayleigh_rng.hpp
+++ b/stan/math/prim/scal/prob/rayleigh_rng.hpp
@@ -20,7 +20,7 @@ namespace stan {
 
     template <class RNG>
     inline double
-    rayleigh_rng(const double sigma,
+    rayleigh_rng(double sigma,
                  RNG& rng) {
       using boost::variate_generator;
       using boost::random::uniform_real_distribution;

--- a/stan/math/prim/scal/prob/scaled_inv_chi_square_rng.hpp
+++ b/stan/math/prim/scal/prob/scaled_inv_chi_square_rng.hpp
@@ -24,8 +24,8 @@ namespace stan {
 
     template <class RNG>
     inline double
-    scaled_inv_chi_square_rng(const double nu,
-                              const double s,
+    scaled_inv_chi_square_rng(double nu,
+                              double s,
                               RNG& rng) {
       using boost::variate_generator;
       using boost::random::chi_squared_distribution;

--- a/stan/math/prim/scal/prob/skew_normal_rng.hpp
+++ b/stan/math/prim/scal/prob/skew_normal_rng.hpp
@@ -18,9 +18,9 @@ namespace stan {
 
     template <class RNG>
     inline double
-    skew_normal_rng(const double mu,
-                    const double sigma,
-                    const double alpha,
+    skew_normal_rng(double mu,
+                    double sigma,
+                    double alpha,
                     RNG& rng) {
       boost::math::skew_normal_distribution<> dist(mu, sigma, alpha);
 

--- a/stan/math/prim/scal/prob/student_t_rng.hpp
+++ b/stan/math/prim/scal/prob/student_t_rng.hpp
@@ -24,9 +24,9 @@ namespace stan {
 
     template <class RNG>
     inline double
-    student_t_rng(const double nu,
-                  const double mu,
-                  const double sigma,
+    student_t_rng(double nu,
+                  double mu,
+                  double sigma,
                   RNG& rng) {
       using boost::variate_generator;
       using boost::random::student_t_distribution;

--- a/stan/math/prim/scal/prob/uniform_rng.hpp
+++ b/stan/math/prim/scal/prob/uniform_rng.hpp
@@ -17,8 +17,8 @@ namespace stan {
 
     template <class RNG>
     inline double
-    uniform_rng(const double alpha,
-                const double beta,
+    uniform_rng(double alpha,
+                double beta,
                 RNG& rng) {
       using boost::variate_generator;
       using boost::random::uniform_real_distribution;

--- a/stan/math/prim/scal/prob/von_mises_rng.hpp
+++ b/stan/math/prim/scal/prob/von_mises_rng.hpp
@@ -27,8 +27,8 @@ namespace stan {
 
     template <class RNG>
     inline double
-    von_mises_rng(const double mu,
-                  const double kappa,
+    von_mises_rng(double mu,
+                  double kappa,
                   RNG& rng) {
       using boost::variate_generator;
       using std::fmod;

--- a/stan/math/prim/scal/prob/weibull_rng.hpp
+++ b/stan/math/prim/scal/prob/weibull_rng.hpp
@@ -19,8 +19,8 @@ namespace stan {
 
     template <class RNG>
     inline double
-    weibull_rng(const double alpha,
-                const double sigma,
+    weibull_rng(double alpha,
+                double sigma,
                 RNG& rng) {
       using boost::variate_generator;
       using boost::random::weibull_distribution;

--- a/stan/math/rev/core/operator_addition.hpp
+++ b/stan/math/rev/core/operator_addition.hpp
@@ -96,7 +96,7 @@ namespace stan {
      * @param b Second scalar operand.
      * @return Result of adding variable and scalar.
      */
-    inline var operator+(const var& a, const double b) {
+    inline var operator+(const var& a, double b) {
       if (b == 0.0)
         return a;
       return var(new add_vd_vari(a.vi_, b));
@@ -113,7 +113,7 @@ namespace stan {
      * @param b Second variable operand.
      * @return Result of adding variable and scalar.
      */
-    inline var operator+(const double a, const var& b) {
+    inline var operator+(double a, const var& b) {
       if (a == 0.0)
         return b;
       return var(new add_vd_vari(b.vi_, a));  // by symmetry

--- a/stan/math/rev/core/operator_divide_equal.hpp
+++ b/stan/math/rev/core/operator_divide_equal.hpp
@@ -12,7 +12,7 @@ namespace stan {
       return *this;
     }
 
-    inline var& var::operator/=(const double b) {
+    inline var& var::operator/=(double b) {
       if (b == 1.0)
         return *this;
       vi_ = new divide_vd_vari(vi_, b);

--- a/stan/math/rev/core/operator_division.hpp
+++ b/stan/math/rev/core/operator_division.hpp
@@ -108,7 +108,7 @@ namespace stan {
      * @param b Scalar operand.
      * @return Variable result of dividing the variable by the scalar.
      */
-    inline var operator/(const var& a, const double b) {
+    inline var operator/(const var& a, double b) {
       if (b == 1.0)
         return a;
       return var(new divide_vd_vari(a.vi_, b));
@@ -125,7 +125,7 @@ namespace stan {
      * @param b Variable operand.
      * @return Variable result of dividing the scalar by the variable.
      */
-    inline var operator/(const double a, const var& b) {
+    inline var operator/(double a, const var& b) {
       return var(new divide_dv_vari(a, b.vi_));
     }
 

--- a/stan/math/rev/core/operator_equal.hpp
+++ b/stan/math/rev/core/operator_equal.hpp
@@ -36,7 +36,7 @@ namespace stan {
      * @return True if the first variable's value is the same as the
      * second value.
      */
-    inline bool operator==(const var& a, const double b) {
+    inline bool operator==(const var& a, double b) {
       return a.val() == b;
     }
 
@@ -48,7 +48,7 @@ namespace stan {
      * @param b Second variable.
      * @return True if the variable's value is equal to the scalar.
      */
-    inline bool operator==(const double a, const var& b) {
+    inline bool operator==(double a, const var& b) {
       return a == b.val();
     }
 

--- a/stan/math/rev/core/operator_greater_than.hpp
+++ b/stan/math/rev/core/operator_greater_than.hpp
@@ -34,7 +34,7 @@ namespace stan {
      * @param b Second value.
      * @return True if first variable's value is greater than second value.
      */
-    inline bool operator>(const var& a, const double b) {
+    inline bool operator>(const var& a, double b) {
       return a.val() > b;
     }
 
@@ -46,7 +46,7 @@ namespace stan {
      * @param b Second variable.
      * @return True if first value is greater than second variable's value.
      */
-    inline bool operator>(const double a, const var& b) {
+    inline bool operator>(double a, const var& b) {
       return a > b.val();
     }
 

--- a/stan/math/rev/core/operator_greater_than_or_equal.hpp
+++ b/stan/math/rev/core/operator_greater_than_or_equal.hpp
@@ -37,7 +37,7 @@ namespace stan {
      * @return True if first variable's value is greater than or equal
      * to second value.
      */
-    inline bool operator>=(const var& a, const double b) {
+    inline bool operator>=(const var& a, double b) {
       return a.val() >= b;
     }
 
@@ -50,7 +50,7 @@ namespace stan {
      * @return True if the first value is greater than or equal to the
      * second variable's value.
      */
-    inline bool operator>=(const double a, const var& b) {
+    inline bool operator>=(double a, const var& b) {
       return a >= b.val();
     }
 

--- a/stan/math/rev/core/operator_less_than.hpp
+++ b/stan/math/rev/core/operator_less_than.hpp
@@ -33,7 +33,7 @@ namespace stan {
      * @param b Second value.
      * @return True if first variable's value is less than second value.
      */
-    inline bool operator<(const var& a, const double b) {
+    inline bool operator<(const var& a, double b) {
       return a.val() < b;
     }
 
@@ -45,7 +45,7 @@ namespace stan {
      * @param b Second variable.
      * @return True if first value is less than second variable's value.
      */
-    inline bool operator<(const double a, const var& b) {
+    inline bool operator<(double a, const var& b) {
       return a < b.val();
     }
 

--- a/stan/math/rev/core/operator_less_than_or_equal.hpp
+++ b/stan/math/rev/core/operator_less_than_or_equal.hpp
@@ -36,7 +36,7 @@ namespace stan {
      * @return True if first variable's value is less than or equal to
      * the second value.
      */
-    inline bool operator<=(const var& a, const double b) {
+    inline bool operator<=(const var& a, double b) {
       return a.val() <= b;
     }
 
@@ -49,7 +49,7 @@ namespace stan {
      * @return True if first value is less than or equal to the second
      * variable's value.
      */
-    inline bool operator<=(const double a, const var& b) {
+    inline bool operator<=(double a, const var& b) {
       return a <= b.val();
     }
 

--- a/stan/math/rev/core/operator_minus_equal.hpp
+++ b/stan/math/rev/core/operator_minus_equal.hpp
@@ -12,7 +12,7 @@ namespace stan {
       return *this;
     }
 
-    inline var& var::operator-=(const double b) {
+    inline var& var::operator-=(double b) {
       if (b == 0.0)
         return *this;
       vi_ = new subtract_vd_vari(vi_, b);

--- a/stan/math/rev/core/operator_multiplication.hpp
+++ b/stan/math/rev/core/operator_multiplication.hpp
@@ -95,7 +95,7 @@ namespace stan {
      * @param b Scalar operand.
      * @return Variable result of multiplying operands.
      */
-    inline var operator*(const var& a, const double b) {
+    inline var operator*(const var& a, double b) {
       if (b == 1.0)
         return a;
       return var(new multiply_vd_vari(a.vi_, b));
@@ -112,7 +112,7 @@ namespace stan {
      * @param b Variable operand.
      * @return Variable result of multiplying the operands.
      */
-    inline var operator*(const double a, const var& b) {
+    inline var operator*(double a, const var& b) {
       if (a == 1.0)
         return b;
       return var(new multiply_vd_vari(b.vi_, a));  // by symmetry

--- a/stan/math/rev/core/operator_multiply_equal.hpp
+++ b/stan/math/rev/core/operator_multiply_equal.hpp
@@ -12,7 +12,7 @@ namespace stan {
       return *this;
     }
 
-    inline var& var::operator*=(const double b) {
+    inline var& var::operator*=(double b) {
       if (b == 1.0)
         return *this;
       vi_ = new multiply_vd_vari(vi_, b);

--- a/stan/math/rev/core/operator_not_equal.hpp
+++ b/stan/math/rev/core/operator_not_equal.hpp
@@ -36,7 +36,7 @@ namespace stan {
      * @return True if the first variable's value is not the same as the
      * second value.
      */
-    inline bool operator!=(const var& a, const double b) {
+    inline bool operator!=(const var& a, double b) {
       return a.val() != b;
     }
 
@@ -49,7 +49,7 @@ namespace stan {
      * @return True if the first value is not the same as the
      * second variable's value.
      */
-    inline bool operator!=(const double a, const var& b) {
+    inline bool operator!=(double a, const var& b) {
       return a != b.val();
     }
 

--- a/stan/math/rev/core/operator_plus_equal.hpp
+++ b/stan/math/rev/core/operator_plus_equal.hpp
@@ -12,7 +12,7 @@ namespace stan {
       return *this;
     }
 
-    inline var& var::operator+=(const double b) {
+    inline var& var::operator+=(double b) {
       if (b == 0.0)
         return *this;
       vi_ = new add_vd_vari(vi_, b);

--- a/stan/math/rev/core/operator_subtraction.hpp
+++ b/stan/math/rev/core/operator_subtraction.hpp
@@ -111,7 +111,7 @@ namespace stan {
      * @param b Second scalar operand.
      * @return Result of subtracting the scalar from the variable.
      */
-    inline var operator-(const var& a, const double b) {
+    inline var operator-(const var& a, double b) {
       if (b == 0.0)
         return a;
       return var(new subtract_vd_vari(a.vi_, b));
@@ -128,7 +128,7 @@ namespace stan {
      * @param b Second variable operand.
      * @return Result of sutracting a variable from a scalar.
      */
-    inline var operator-(const double a, const var& b) {
+    inline var operator-(double a, const var& b) {
       return var(new subtract_dv_vari(a, b.vi_));
     }
 

--- a/stan/math/rev/core/precomputed_gradients.hpp
+++ b/stan/math/rev/core/precomputed_gradients.hpp
@@ -92,7 +92,7 @@ namespace stan {
      * @return An auto-diff variable that uses the precomputed
      *   gradients provided.
      */
-    inline var precomputed_gradients(const double value,
+    inline var precomputed_gradients(double value,
                               const std::vector<var>& operands,
                               const std::vector<double>& gradients) {
       return var(new precomputed_gradients_vari(value, operands, gradients));

--- a/stan/math/rev/core/var.hpp
+++ b/stan/math/rev/core/var.hpp
@@ -328,7 +328,7 @@ namespace stan {
        * @param b The scalar to add to this variable.
        * @return The result of adding the specified variable to this variable.
        */
-      inline var& operator+=(const double b);
+      inline var& operator+=(double b);
 
       /**
        * The compound subtract/assignment operator for variables (C++).
@@ -354,7 +354,7 @@ namespace stan {
        * @return The result of subtracting the specified variable from this
        * variable.
        */
-      inline var& operator-=(const double b);
+      inline var& operator-=(double b);
 
       /**
        * The compound multiply/assignment operator for variables (C++).
@@ -380,7 +380,7 @@ namespace stan {
        * @return The result of multplying this variable by the specified
        * variable.
        */
-      inline var& operator*=(const double b);
+      inline var& operator*=(double b);
 
       /**
        * The compound divide/assignment operator for variables (C++).  If this
@@ -405,7 +405,7 @@ namespace stan {
        * @return The result of dividing this variable by the specified
        * variable.
        */
-      inline var& operator/=(const double b);
+      inline var& operator/=(double b);
 
       /**
        * Write the value of this auto-dif variable and its adjoint to

--- a/stan/math/rev/core/vari.hpp
+++ b/stan/math/rev/core/vari.hpp
@@ -55,13 +55,13 @@ namespace stan {
        *
        * @param x Value of the constructed variable.
        */
-      explicit vari(const double x):
+      explicit vari(double x):
         val_(x),
         adj_(0.0) {
         ChainableStack::var_stack_.push_back(this);
       }
 
-      vari(const double x, bool stacked):
+      vari(double x, bool stacked):
         val_(x),
         adj_(0.0) {
         if (stacked)

--- a/stan/math/rev/mat/fun/cov_exp_quad.hpp
+++ b/stan/math/rev/mat/fun/cov_exp_quad.hpp
@@ -155,7 +155,7 @@ namespace stan {
        * @param l length scale
        */
       cov_exp_quad_vari(const std::vector<T_x>& x,
-                        const double sigma,
+                        double sigma,
                         const T_l& l)
         : vari(0.0),
           size_(x.size()),

--- a/stan/math/rev/mat/fun/trace_inv_quad_form_ldlt.hpp
+++ b/stan/math/rev/mat/fun/trace_inv_quad_form_ldlt.hpp
@@ -94,20 +94,20 @@ namespace stan {
       protected:
         static inline
         void
-        chainA(const double &adj,
+        chainA(double adj,
                trace_inv_quad_form_ldlt_impl<double, R2, C2, T3, R3, C3>
                *impl) {
         }
         static inline
         void
-        chainB(const double &adj,
+        chainB(double adj,
                trace_inv_quad_form_ldlt_impl<T2, R2, C2, double, R3, C3>
                *impl) {
         }
 
         static inline
         void
-        chainA(const double &adj,
+        chainA(double adj,
                trace_inv_quad_form_ldlt_impl<var, R2, C2, T3, R3, C3> *impl) {
           Eigen::Matrix<double, R2, C2> aA;
 
@@ -123,7 +123,7 @@ namespace stan {
         }
         static inline
         void
-        chainB(const double &adj,
+        chainB(double adj,
                trace_inv_quad_form_ldlt_impl<T2, R2, C2, var, R3, C3> *impl) {
           Eigen::Matrix<double, R3, C3> aB;
 

--- a/stan/math/rev/mat/fun/unit_vector_constrain.hpp
+++ b/stan/math/rev/mat/fun/unit_vector_constrain.hpp
@@ -28,7 +28,7 @@ namespace stan {
                              const double* unit_vector_y,
                              int size,
                              int idx,
-                             const double norm)
+                             double norm)
           : vari(val),
             y_(y),
             unit_vector_y_(unit_vector_y),

--- a/stan/math/rev/mat/functor/cvodes_ode_data.hpp
+++ b/stan/math/rev/mat/functor/cvodes_ode_data.hpp
@@ -139,7 +139,7 @@ namespace stan {
        */
       void rhs_sens(const std::vector<var>& initial,
                     const std::vector<var>& param,
-                    const double t, const std::vector<double>& y,
+                    double t, const std::vector<double>& y,
                     N_Vector *yS, N_Vector *ySdot) const {
         Eigen::VectorXd dy_dt(N_);
         Eigen::MatrixXd Jy(N_, N_);
@@ -162,7 +162,7 @@ namespace stan {
        */
       void rhs_sens(const std::vector<double>& initial,
                     const std::vector<var>& param,
-                    const double t, const std::vector<double>& y,
+                    double t, const std::vector<double>& y,
                     N_Vector *yS, N_Vector *ySdot) const {
         Eigen::VectorXd dy_dt(N_);
         Eigen::MatrixXd Jy(N_, N_);
@@ -184,7 +184,7 @@ namespace stan {
        */
       void rhs_sens(const std::vector<var>& initial,
                     const std::vector<double>& param,
-                    const double t, const std::vector<double>& y,
+                    double t, const std::vector<double>& y,
                     N_Vector *yS, N_Vector *ySdot) const {
         Eigen::VectorXd dy_dt(N_);
         Eigen::MatrixXd Jy(N_, N_);
@@ -205,7 +205,7 @@ namespace stan {
        */
       void rhs_sens(const std::vector<double>& initial,
                     const std::vector<double>& param,
-                    const double t, const std::vector<double>& y,
+                    double t, const std::vector<double>& y,
                     N_Vector *yS, N_Vector *ySdot) const {
       }
     };

--- a/stan/math/rev/mat/functor/integrate_ode_bdf.hpp
+++ b/stan/math/rev/mat/functor/integrate_ode_bdf.hpp
@@ -82,7 +82,7 @@ namespace stan {
                                                        T_param>::type> >
     integrate_ode_bdf(const F& f,
                       const std::vector<T_initial>& y0,
-                      const double t0,
+                      double t0,
                       const std::vector<double>& ts,
                       const std::vector<T_param>& theta,
                       const std::vector<double>& x,

--- a/stan/math/rev/mat/functor/ode_system.hpp
+++ b/stan/math/rev/mat/functor/ode_system.hpp
@@ -48,7 +48,7 @@ namespace stan {
        * @param[in] y state of the ode system at time t.
        * @param[out] dy_dt ODE RHS
        */
-      inline void operator()(const double t, const std::vector<double>& y,
+      inline void operator()(double t, const std::vector<double>& y,
                              std::vector<double>& dy_dt) const {
         dy_dt = f_(t, y, theta_, x_, x_int_, msgs_);
       }
@@ -64,7 +64,7 @@ namespace stan {
        * @param[out] Jy Jacobian of ODE RHS wrt to y.
        */
       template <typename Derived1, typename Derived2>
-      void jacobian(const double t, const std::vector<double>& y,
+      void jacobian(double t, const std::vector<double>& y,
                     Eigen::MatrixBase<Derived1>& dy_dt,
                     Eigen::MatrixBase<Derived2>& Jy) const {
         using Eigen::Matrix;
@@ -103,7 +103,7 @@ namespace stan {
        * @param[out] Jtheta Jacobian of ODE RHS wrt to theta.
        */
       template <typename Derived1, typename Derived2>
-      void jacobian(const double t, const std::vector<double>& y,
+      void jacobian(double t, const std::vector<double>& y,
                     Eigen::MatrixBase<Derived1>& dy_dt,
                     Eigen::MatrixBase<Derived2>& Jy,
                     Eigen::MatrixBase<Derived2>& Jtheta) const {

--- a/stan/math/rev/scal/fun/atan2.hpp
+++ b/stan/math/rev/scal/fun/atan2.hpp
@@ -75,7 +75,7 @@ namespace stan {
      * @param b Denominator scalar.
      * @return The arc tangent of the fraction, in radians.
      */
-    inline var atan2(const var& a, const double b) {
+    inline var atan2(const var& a, double b) {
       return var(new atan2_vd_vari(a.vi_, b));
     }
 
@@ -116,7 +116,7 @@ namespace stan {
      * @param b Denominator variable.
      * @return The arc tangent of the fraction, in radians.
      */
-    inline var atan2(const double a, const var& b) {
+    inline var atan2(double a, const var& b) {
       return var(new atan2_dv_vari(a, b.vi_));
     }
 

--- a/stan/math/rev/scal/fun/binary_log_loss.hpp
+++ b/stan/math/rev/scal/fun/binary_log_loss.hpp
@@ -65,7 +65,7 @@ namespace stan {
      * @param y_hat Response variable.
      * @return Log loss of response versus reference value.
      */
-    inline var binary_log_loss(const int y, const var& y_hat) {
+    inline var binary_log_loss(int y, const var& y_hat) {
       if (y == 0)
         return var(new binary_log_loss_0_vari(y_hat.vi_));
       else

--- a/stan/math/rev/scal/fun/fmod.hpp
+++ b/stan/math/rev/scal/fun/fmod.hpp
@@ -117,7 +117,7 @@ namespace stan {
      * @return Floating pointer remainder of dividing the first variable by
      * the second scalar.
      */
-    inline var fmod(const var& a, const double b) {
+    inline var fmod(const var& a, double b) {
       return var(new fmod_vd_vari(a.vi_, b));
     }
 
@@ -134,7 +134,7 @@ namespace stan {
      * @return Floating pointer remainder of dividing first scalar by
      * the second variable.
      */
-    inline var fmod(const double a, const var& b) {
+    inline var fmod(double a, const var& b) {
       return var(new fmod_dv_vari(a, b.vi_));
     }
 

--- a/stan/math/rev/scal/fun/if_else.hpp
+++ b/stan/math/rev/scal/fun/if_else.hpp
@@ -41,7 +41,7 @@ namespace stan {
      * @param y_true Variable to return if condition is true.
      * @param y_false Value to promote to variable and return if condition is false.
      */
-    inline var if_else(bool c, const var& y_true, const double y_false) {
+    inline var if_else(bool c, const var& y_true, double y_false) {
       if (c)
         return y_true;
       else

--- a/stan/math/rev/scal/fun/multiply_log.hpp
+++ b/stan/math/rev/scal/fun/multiply_log.hpp
@@ -83,7 +83,7 @@ namespace stan {
      * @param b Second scalar.
      * @return Value of a*log(b)
      */
-    inline var multiply_log(const var& a, const double b) {
+    inline var multiply_log(const var& a, double b) {
       return var(new multiply_log_vd_vari(a.vi_, b));
     }
     /**
@@ -97,7 +97,7 @@ namespace stan {
      * @param b Second variable.
      * @return Value of a*log(b)
      */
-    inline var multiply_log(const double a, const var& b) {
+    inline var multiply_log(double a, const var& b) {
       if (a == 1.0)
         return log(b);
       return var(new multiply_log_dv_vari(a, b.vi_));

--- a/stan/math/rev/scal/fun/pow.hpp
+++ b/stan/math/rev/scal/fun/pow.hpp
@@ -116,7 +116,7 @@ namespace stan {
      * @param exponent Exponent scalar.
      * @return Base raised to the exponent.
      */
-    inline var pow(const var& base, const double exponent) {
+    inline var pow(const var& base, double exponent) {
       if (exponent == 0.5)
         return sqrt(base);
       if (exponent == 1.0)
@@ -138,7 +138,7 @@ namespace stan {
      * @param exponent Exponent variable.
      * @return Base raised to the exponent.
      */
-    inline var pow(const double base, const var& exponent) {
+    inline var pow(double base, const var& exponent) {
       return var(new pow_dv_vari(base, exponent.vi_));
     }
 


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary:
Removed `const` modifier for primitive types in function arguments.

#### Intended Effect:
This should just make the code base neater.
Most of the fixes changed `const double` and some of the fixes changed `const int` and `const size_t`.
There were a handful of changes to `const double&` to `double`.
I didn't change anything else in the codebase.

#### How to Verify:
Look at the diff.

#### Side Effects:
None.

#### Documentation:
None.

#### Reviewer Suggestions: 
Anyone. It shouldn't take more than 5 minutes to walk through all the changes.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Columbia University.

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
