### PR TITLE
Fix typos in function names for error reporting

### DIFF
--- a/stan/math/prim/scal/prob/beta_ccdf_log.hpp
+++ b/stan/math/prim/scal/prob/beta_ccdf_log.hpp
@@ -42,7 +42,7 @@ namespace stan {
               && stan::length(beta) ) )
         return 0.0;
 
-      static const char* function("beta_cdf");
+      static const char* function("beta_ccdf_log");
 
       using boost::math::tools::promote_args;
 

--- a/stan/math/prim/scal/prob/beta_cdf_log.hpp
+++ b/stan/math/prim/scal/prob/beta_cdf_log.hpp
@@ -41,7 +41,7 @@ namespace stan {
               && stan::length(beta) ) )
         return 0.0;
 
-      static const char* function("beta_cdf");
+      static const char* function("beta_cdf_log");
 
       using boost::math::tools::promote_args;
 

--- a/stan/math/prim/scal/prob/cauchy_ccdf_log.hpp
+++ b/stan/math/prim/scal/prob/cauchy_ccdf_log.hpp
@@ -30,7 +30,7 @@ namespace stan {
               && stan::length(sigma) ) )
         return 0.0;
 
-      static const char* function("cauchy_cdf");
+      static const char* function("cauchy_ccdf_log");
 
       using boost::math::tools::promote_args;
 

--- a/stan/math/prim/scal/prob/cauchy_cdf_log.hpp
+++ b/stan/math/prim/scal/prob/cauchy_cdf_log.hpp
@@ -30,7 +30,7 @@ namespace stan {
               && stan::length(sigma) ) )
         return 0.0;
 
-      static const char* function("cauchy_cdf");
+      static const char* function("cauchy_cdf_log");
 
       using boost::math::tools::promote_args;
 

--- a/stan/math/prim/scal/prob/logistic_ccdf_log.hpp
+++ b/stan/math/prim/scal/prob/logistic_ccdf_log.hpp
@@ -35,7 +35,7 @@ namespace stan {
       if ( !( stan::length(y) && stan::length(mu) && stan::length(sigma) ) )
         return 0.0;
 
-      static const char* function("logistic_cdf_log");
+      static const char* function("logistic_ccdf_log");
 
       using boost::math::tools::promote_args;
       using std::log;

--- a/stan/math/prim/scal/prob/neg_binomial_2_ccdf_log.hpp
+++ b/stan/math/prim/scal/prob/neg_binomial_2_ccdf_log.hpp
@@ -23,7 +23,7 @@ namespace stan {
             && stan::length(phi)))
         return 0.0;
 
-      static const char* function("neg_binomial_2_cdf");
+      static const char* function("neg_binomial_2_ccdf_log");
       check_positive_finite(function, "Location parameter", mu);
       check_positive_finite(function, "Precision parameter", phi);
       check_not_nan(function, "Random variable", n);

--- a/stan/math/prim/scal/prob/neg_binomial_2_cdf.hpp
+++ b/stan/math/prim/scal/prob/neg_binomial_2_cdf.hpp
@@ -26,7 +26,7 @@ namespace stan {
     neg_binomial_2_cdf(const T_n& n,
                        const T_location& mu,
                        const T_precision& phi) {
-      static const char* function("stan::prob::neg_binomial_2_cdf");
+      static const char* function("neg_binomial_2_cdf");
       typedef typename stan::partials_return_type<T_n, T_location,
                                                   T_precision>::type
         T_partials_return;

--- a/stan/math/prim/scal/prob/neg_binomial_2_cdf_log.hpp
+++ b/stan/math/prim/scal/prob/neg_binomial_2_cdf_log.hpp
@@ -26,7 +26,7 @@ namespace stan {
             && stan::length(phi)))
         return 0.0;
 
-      static const char* function("neg_binomial_2_cdf");
+      static const char* function("neg_binomial_2_cdf_log");
       check_positive_finite(function, "Location parameter", mu);
       check_positive_finite(function, "Precision parameter", phi);
       check_not_nan(function, "Random variable", n);

--- a/stan/math/prim/scal/prob/neg_binomial_2_log_log.hpp
+++ b/stan/math/prim/scal/prob/neg_binomial_2_log_log.hpp
@@ -38,7 +38,7 @@ namespace stan {
                                                   T_precision>::type
         T_partials_return;
 
-      static const char* function("stan::prob::neg_binomial_2_log_log");
+      static const char* function("neg_binomial_2_log_log");
 
       if (!(stan::length(n)
             && stan::length(eta)


### PR DESCRIPTION
#### Summary:
For some functions in `stan/math/prim/scal/prob` the string used for reporting errors doesn't match the actual function name.
#### Intended Effect:
Fix those typos.
#### How to Verify:
Review.
#### Side Effects:
None
#### Documentation:
N/A
#### Reviewer Suggestions: 
None
#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

C. Hoeppler

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

