### PR TITLE
Bugfix/415 cholesky decompose

### DIFF
--- a/stan/math/memory/stack_alloc.hpp
+++ b/stan/math/memory/stack_alloc.hpp
@@ -247,13 +247,31 @@ namespace stan {
        *
        * @return number of bytes allocated to this instance
        */
-      size_t bytes_allocated() {
+      inline size_t bytes_allocated() const {
         size_t sum = 0;
         for (size_t i = 0; i <= cur_block_; ++i) {
           sum += sizes_[i];
         }
         return sum;
       }
+
+      /**
+       * Indicates whether the memory in the pointer
+       * is in the stack.
+       *
+       * @param[in] ptr memory location
+       * @return true if the pointer is in the stack,
+       *    false otherwise.
+       */
+      inline bool in_stack(const void* ptr) const {
+        for (size_t i = 0; i < cur_block_; ++i)
+          if (ptr >= blocks_[i] && ptr <= blocks_[i] + sizes_[i])
+            return true;
+        if (ptr >= blocks_[cur_block_] && ptr < next_loc_)
+          return true;
+        return false;
+      }
+
     };
 
   }

--- a/stan/math/memory/stack_alloc.hpp
+++ b/stan/math/memory/stack_alloc.hpp
@@ -265,7 +265,7 @@ namespace stan {
        */
       inline bool in_stack(const void* ptr) const {
         for (size_t i = 0; i < cur_block_; ++i)
-          if (ptr >= blocks_[i] && ptr <= blocks_[i] + sizes_[i])
+          if (ptr >= blocks_[i] && ptr < blocks_[i] + sizes_[i])
             return true;
         if (ptr >= blocks_[cur_block_] && ptr < next_loc_)
           return true;

--- a/stan/math/memory/stack_alloc.hpp
+++ b/stan/math/memory/stack_alloc.hpp
@@ -271,7 +271,6 @@ namespace stan {
           return true;
         return false;
       }
-
     };
 
   }

--- a/stan/math/rev/mat/fun/cholesky_decompose.hpp
+++ b/stan/math/rev/mat/fun/cholesky_decompose.hpp
@@ -144,7 +144,7 @@ namespace stan {
       // arena allocator.
       cholesky_decompose_v_vari *baseVari
         = new cholesky_decompose_v_vari(A, L_A);
-      vari dummy(0.0, false);
+      vari* dummy = new vari(0.0, false);
       Eigen::Matrix<var, -1, -1> L(A.rows(), A.cols());
       size_t accum = 0;
       size_t accum_i = accum;
@@ -155,7 +155,7 @@ namespace stan {
           L.coeffRef(i, j).vi_ = baseVari->variRefL_[pos];
         }
         for (size_type k = 0; k < j; ++k)
-          L.coeffRef(k, j).vi_ = &dummy;
+          L.coeffRef(k, j).vi_ = dummy;
         accum += j;
         accum_i = accum;
       }

--- a/test/unit/math/memory/stack_alloc_test.cpp
+++ b/test/unit/math/memory/stack_alloc_test.cpp
@@ -91,3 +91,13 @@ TEST(stack_alloc,alloc) {
   allocator.recover_all();
 
 }
+
+TEST(stack_alloc, in_stack) {
+  stan::math::stack_alloc allocator;
+
+  double* x = allocator.alloc_array<double>(10U);
+  double y = 0;
+
+  EXPECT_TRUE(allocator.in_stack(x));
+  EXPECT_FALSE(allocator.in_stack(&y));
+}

--- a/test/unit/math/memory/stack_alloc_test.cpp
+++ b/test/unit/math/memory/stack_alloc_test.cpp
@@ -101,3 +101,21 @@ TEST(stack_alloc, in_stack) {
   EXPECT_TRUE(allocator.in_stack(x));
   EXPECT_FALSE(allocator.in_stack(&y));
 }
+
+
+TEST(stack_alloc, in_stack_second_block) {
+  stan::math::stack_alloc allocator;
+
+  char* x = allocator.alloc_array<char>(stan::math::DEFAULT_INITIAL_NBYTES);
+  EXPECT_TRUE(allocator.in_stack(x));
+  EXPECT_FALSE(allocator.in_stack(x + stan::math::DEFAULT_INITIAL_NBYTES));
+
+  char* y = allocator.alloc_array<char>(1);
+  EXPECT_TRUE(allocator.in_stack(x));
+  EXPECT_TRUE(allocator.in_stack(y));
+  EXPECT_FALSE(allocator.in_stack(y + 1));
+
+  allocator.recover_all();
+  EXPECT_FALSE(allocator.in_stack(x));
+  EXPECT_FALSE(allocator.in_stack(y));
+}

--- a/test/unit/math/rev/arr/fun/log_sum_exp_test.cpp
+++ b/test/unit/math/rev/arr/fun/log_sum_exp_test.cpp
@@ -1,6 +1,7 @@
 #include <stan/math/rev/arr.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/math/rev/arr/fun/util.hpp>
+#include <test/unit/math/rev/arr/util.hpp>
 
 TEST(AgradRev,log_sum_exp_vector) {
   // simple test
@@ -141,4 +142,11 @@ TEST(AgradRev, log_sum_exp_vec_3) {
   EXPECT_FLOAT_EQ(g[0],g2[0]);
   EXPECT_FLOAT_EQ(g[1],g2[1]);
   EXPECT_FLOAT_EQ(g[2],g2[2]);
+}
+
+TEST(AgradRev, check_varis_on_stack) {
+  std::vector<stan::math::var> x;
+  x.push_back(5.0);
+  x.push_back(2.0);
+  test::check_varis_on_stack(stan::math::log_sum_exp(x));
 }

--- a/test/unit/math/rev/arr/fun/sum_test.cpp
+++ b/test/unit/math/rev/arr/fun/sum_test.cpp
@@ -1,5 +1,6 @@
 #include <stan/math/rev/arr.hpp>
 #include <gtest/gtest.h>
+#include <test/unit/math/rev/arr/util.hpp>
 
 TEST(AgradRev, sum_std_vector) {
   using stan::math::sum;
@@ -21,4 +22,11 @@ TEST(AgradRev, sum_std_vector) {
 
   x = vector<var>();
   EXPECT_FLOAT_EQ(0.0, sum(x).val());
+}
+
+TEST(AgradRev, check_varis_on_stack) {
+  std::vector<stan::math::var> x;
+  for (size_t i = 0; i < 6; ++i)
+    x.push_back(i + 1);
+  test::check_varis_on_stack(stan::math::sum(x));
 }

--- a/test/unit/math/rev/arr/fun/util.hpp
+++ b/test/unit/math/rev/arr/fun/util.hpp
@@ -3,6 +3,7 @@
 
 #include <vector>
 #include <test/unit/math/rev/scal/fun/util.hpp>
+#include <test/unit/math/rev/arr/util.hpp>
 
 typedef std::vector<AVAR> AVEC;
 typedef std::vector<double> VEC;

--- a/test/unit/math/rev/arr/util.hpp
+++ b/test/unit/math/rev/arr/util.hpp
@@ -1,0 +1,17 @@
+#ifndef TEST_UNIT_MATH_REV_ARR_UTIL_HPP
+#define TEST_UNIT_MATH_REV_ARR_UTIL_HPP
+
+#include <stan/math/rev/arr.hpp>
+#include <gtest/gtest.h>
+#include <test/unit/math/rev/scal/util.hpp>
+
+namespace test {
+
+  void check_varis_on_stack(const std::vector<stan::math::var>& x) {
+    for (size_t n = 0; n < x.size(); ++n)
+      EXPECT_TRUE(stan::math::ChainableStack::memalloc_.in_stack(x[n].vi_))
+        << n << " is not on the stack";
+  }
+  
+}
+#endif

--- a/test/unit/math/rev/mat/fun/accumulator_test.cpp
+++ b/test/unit/math/rev/mat/fun/accumulator_test.cpp
@@ -1,6 +1,7 @@
 #include <stan/math/rev/mat.hpp>
 #include <gtest/gtest.h>
 #include <vector>
+#include <test/unit/math/rev/mat/util.hpp>
 
 // test sum of first n numbers for sum of a
 void test_sum(stan::math::accumulator<stan::math::var>& a,
@@ -130,3 +131,9 @@ TEST(AgradRevMathMatrix,accumulateCollection) {
 
 
 
+TEST(AgradRevMatrix, check_varis_on_stack) {
+  stan::math::accumulator<stan::math::var> a;
+  test::check_varis_on_stack(a.sum());
+  a.add(1);
+  test::check_varis_on_stack(a.sum());
+}

--- a/test/unit/math/rev/mat/fun/add_test.cpp
+++ b/test/unit/math/rev/mat/fun/add_test.cpp
@@ -1,6 +1,7 @@
 #include <stan/math/rev/mat.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/math/rev/mat/fun/util.hpp>
+#include <test/unit/math/rev/mat/util.hpp>
 
 TEST(AgradRevMatrix,add_scalar) {
   using stan::math::matrix_v;
@@ -193,4 +194,20 @@ TEST(AgradRevMatrix, add_matrix_matrix_exception) {
   EXPECT_THROW(add(d1, v2), std::invalid_argument);
   EXPECT_THROW(add(v1, d2), std::invalid_argument);
   EXPECT_THROW(add(v1, v2), std::invalid_argument);
+}
+TEST(AgradRevMatrix, check_varis_on_stack) {
+  stan::math::matrix_v m(2, 2);
+  m << 1, 2, 3, 4;
+
+  stan::math::vector_v v(3);
+  v << 1, 2, 3;
+
+  stan::math::row_vector_v rv(2);
+  rv << 1, 2;
+
+  test::check_varis_on_stack(stan::math::add(m, m));
+  test::check_varis_on_stack(stan::math::add(v, v));
+  test::check_varis_on_stack(stan::math::add(rv, rv));
+  test::check_varis_on_stack(stan::math::add(m, 2.0));
+  test::check_varis_on_stack(stan::math::add(1.0, m));
 }

--- a/test/unit/math/rev/mat/fun/append_col_test.cpp
+++ b/test/unit/math/rev/mat/fun/append_col_test.cpp
@@ -2,6 +2,7 @@
 #include <gtest/gtest.h>
 #include <iostream>
 #include <test/unit/math/rev/mat/fun/util.hpp>
+#include <test/unit/math/rev/mat/util.hpp>
 
 using stan::math::sum;
 using stan::math::append_col;
@@ -220,4 +221,19 @@ TEST(MathMatrix, append_col_different_types) {
   correct_type_matrix(append_col(vv3b, vv3));
   correct_type_row_vector(append_col(vrv3, vrv3b));
   correct_type_row_vector(append_col(vrv3b, vrv3));
+}
+TEST(AgradRevMatrix, check_varis_on_stack) {
+  using stan::math::to_var;
+  stan::math::matrix_d a(2,2);
+  stan::math::matrix_d b(2,2);
+
+  a << 2.0, 3.0,
+       9.0, -1.0;
+
+  b << 4.0, 3.0,
+       0.0, 1.0;
+  
+  test::check_varis_on_stack(stan::math::append_col(to_var(a), to_var(b)));
+  test::check_varis_on_stack(stan::math::append_col(to_var(a), b));
+  test::check_varis_on_stack(stan::math::append_col(a, to_var(b)));
 }

--- a/test/unit/math/rev/mat/fun/append_row_test.cpp
+++ b/test/unit/math/rev/mat/fun/append_row_test.cpp
@@ -1,6 +1,7 @@
 #include <stan/math/rev/mat.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/math/rev/mat/fun/util.hpp>
+#include <test/unit/math/rev/mat/util.hpp>
 
 using stan::math::sum;
 using stan::math::append_row;
@@ -218,4 +219,19 @@ TEST(MathMatrix, append_row_different_types) {
   correct_type_matrix(append_row(vrv3b, vrv3));
   correct_type_vector(append_row(vv3, vv3b));
   correct_type_vector(append_row(vv3b, vv3));
+}
+TEST(AgradRevMatrix, check_varis_on_stack) {
+  using stan::math::to_var;
+  stan::math::matrix_d a(2,2);
+  stan::math::matrix_d b(2,2);
+
+  a << 2.0, 3.0,
+       9.0, -1.0;
+
+  b << 4.0, 3.0,
+       0.0, 1.0;
+  
+  test::check_varis_on_stack(stan::math::append_row(to_var(a), to_var(b)));
+  test::check_varis_on_stack(stan::math::append_row(to_var(a), b));
+  test::check_varis_on_stack(stan::math::append_row(a, to_var(b)));
 }

--- a/test/unit/math/rev/mat/fun/cholesky_corr_transform_test.cpp
+++ b/test/unit/math/rev/mat/fun/cholesky_corr_transform_test.cpp
@@ -1,6 +1,7 @@
 #include <stan/math/rev/mat.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/math/rev/mat/fun/jacobian.hpp>
+#include <test/unit/math/rev/mat/util.hpp>
 
 void 
 test_cholesky_correlation_jacobian(const Eigen::Matrix<stan::math::var,
@@ -67,4 +68,11 @@ TEST(probTransform,choleskyCorrJacobian) {
   Matrix<var,Dynamic,1> y4(6);
   y4 << 1.0, 2.0, -3.0, 1.5, 0.2, 2.0;
   test_cholesky_correlation_jacobian(y4,4);
+}
+TEST(AgradRevMatrix, check_varis_on_stack) {
+  stan::math::vector_v y(3);
+  y << -1.7, 2.9, 0.01;
+  stan::math::var lp(0);
+
+  test::check_varis_on_stack(stan::math::cholesky_corr_constrain(y, 3, lp));
 }

--- a/test/unit/math/rev/mat/fun/cholesky_corr_transform_test.cpp
+++ b/test/unit/math/rev/mat/fun/cholesky_corr_transform_test.cpp
@@ -75,4 +75,5 @@ TEST(AgradRevMatrix, check_varis_on_stack) {
   stan::math::var lp(0);
 
   test::check_varis_on_stack(stan::math::cholesky_corr_constrain(y, 3, lp));
+  test::check_varis_on_stack(stan::math::cholesky_corr_constrain(y, 3));
 }

--- a/test/unit/math/rev/mat/fun/cholesky_decompose_test.cpp
+++ b/test/unit/math/rev/mat/fun/cholesky_decompose_test.cpp
@@ -219,20 +219,8 @@ TEST(AgradRevMatrix, mat_cholesky_1st_deriv) {
 }
 
 TEST(AgradRevMatrix, check_varis_on_stack) {
-  using stan::math::matrix_v;
-  using stan::math::transpose;
-  using stan::math::cholesky_decompose;
-  using stan::math::singular_values;
+  stan::math::matrix_v X(2,2);
+  X << 3, -1, -1, 1;
 
-  // symmetric
-  matrix_v X(2,2);
-  AVAR a = 3.0;
-  AVAR b = -1.0;
-  AVAR c = -1.0;
-  AVAR d = 1.0;
-  X << a, b, 
-    c, d;
-
-  matrix_v L = cholesky_decompose(X);
-  test::check_varis_on_stack(L);
+  test::check_varis_on_stack(stan::math::cholesky_decompose(X));
 }

--- a/test/unit/math/rev/mat/fun/cholesky_decompose_test.cpp
+++ b/test/unit/math/rev/mat/fun/cholesky_decompose_test.cpp
@@ -217,3 +217,22 @@ TEST(AgradRevMatrix, mat_cholesky_1st_deriv) {
   test_gradients_simple(10);
   test_gradient(50);
 }
+
+TEST(AgradRevMatrix, check_varis_on_stack) {
+  using stan::math::matrix_v;
+  using stan::math::transpose;
+  using stan::math::cholesky_decompose;
+  using stan::math::singular_values;
+
+  // symmetric
+  matrix_v X(2,2);
+  AVAR a = 3.0;
+  AVAR b = -1.0;
+  AVAR c = -1.0;
+  AVAR d = 1.0;
+  X << a, b, 
+    c, d;
+
+  matrix_v L = cholesky_decompose(X);
+  test::check_varis_on_stack(L);
+}

--- a/test/unit/math/rev/mat/fun/col_test.cpp
+++ b/test/unit/math/rev/mat/fun/col_test.cpp
@@ -1,6 +1,7 @@
 #include <stan/math/rev/mat.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/math/rev/mat/fun/util.hpp>
+#include <test/unit/math/rev/mat/util.hpp>
 
 TEST(AgradRevMatrix,col_v) {
   using stan::math::col;
@@ -36,4 +37,9 @@ TEST(AgradRevMatrix,col_v_excHigh) {
   y << 1, 2, 3, 4, 5, 6;
   EXPECT_THROW(col(y,0),std::out_of_range);
   EXPECT_THROW(col(y,5),std::out_of_range);
+}
+TEST(AgradRevMatrix, check_varis_on_stack) {
+  stan::math::matrix_v y(2,3);
+  y << 1, 2, 3, 4, 5, 6;
+  test::check_varis_on_stack(stan::math::col(y, 2));
 }

--- a/test/unit/math/rev/mat/fun/corr_matrix_transform_test.cpp
+++ b/test/unit/math/rev/mat/fun/corr_matrix_transform_test.cpp
@@ -1,6 +1,7 @@
 #include <stan/math/rev/mat.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/math/rev/mat/fun/jacobian.hpp>
+#include <test/unit/math/rev/mat/util.hpp>
 
 using Eigen::Matrix;
 using Eigen::Dynamic;
@@ -36,4 +37,12 @@ TEST(prob_transform,corr_matrix_jacobian) {
 
   double log_abs_jacobian_det = log(fabs(determinant(J)));
   EXPECT_FLOAT_EQ(log_abs_jacobian_det,lp.val());
+}
+TEST(AgradRevMatrix, check_varis_on_stack) {
+  int K = 4;
+  int K_choose_2 = 6;
+  Eigen::Matrix<stan::math::var,Eigen::Dynamic,1> X(K_choose_2);
+  X << 1.0, 2.0, -3.0, 1.7, 9.8, -1.2;
+  stan::math::var lp = 0.0;
+  test::check_varis_on_stack(stan::math::corr_matrix_constrain(X,K,lp));
 }

--- a/test/unit/math/rev/mat/fun/corr_matrix_transform_test.cpp
+++ b/test/unit/math/rev/mat/fun/corr_matrix_transform_test.cpp
@@ -44,5 +44,6 @@ TEST(AgradRevMatrix, check_varis_on_stack) {
   Eigen::Matrix<stan::math::var,Eigen::Dynamic,1> X(K_choose_2);
   X << 1.0, 2.0, -3.0, 1.7, 9.8, -1.2;
   stan::math::var lp = 0.0;
-  test::check_varis_on_stack(stan::math::corr_matrix_constrain(X,K,lp));
+  test::check_varis_on_stack(stan::math::corr_matrix_constrain(X, K, lp));
+  test::check_varis_on_stack(stan::math::corr_matrix_constrain(X, K));
 }

--- a/test/unit/math/rev/mat/fun/cov_exp_quad_test.cpp
+++ b/test/unit/math/rev/mat/fun/cov_exp_quad_test.cpp
@@ -1,5 +1,6 @@
 #include <stan/math/rev/mat.hpp>
 #include <gtest/gtest.h>
+#include <test/unit/math/rev/mat/util.hpp>
 
 TEST(RevMath, cov_exp_quad_vvv) {
   Eigen::Matrix<stan::math::var, Eigen::Dynamic, Eigen::Dynamic> cov;
@@ -1223,4 +1224,21 @@ TEST(RevMath, cov_exp_quad2_dim_mismatch_vec_eigen_mixed) {
 
   EXPECT_THROW(stan::math::cov_exp_quad(x_rvec_2, x_vec_2, sigma, l), std::invalid_argument);
   EXPECT_THROW(stan::math::cov_exp_quad(x_vec_2, x_rvec_2, sigma, l), std::invalid_argument);
+}
+TEST(AgradRevMatrix, check_varis_on_stack) {
+  using stan::math::to_var;
+  std::vector<double> x(3);
+  double sigma = 0.2;
+  double l = 5;
+  x[0] = -2;
+  x[1] = -1;
+  x[2] = -0.5;
+
+  test::check_varis_on_stack(stan::math::cov_exp_quad(to_var(x), to_var(sigma), to_var(l)));
+  test::check_varis_on_stack(stan::math::cov_exp_quad(to_var(x), to_var(sigma), l));
+  test::check_varis_on_stack(stan::math::cov_exp_quad(to_var(x), sigma, to_var(l)));
+  test::check_varis_on_stack(stan::math::cov_exp_quad(to_var(x), sigma, l));
+  test::check_varis_on_stack(stan::math::cov_exp_quad(x, to_var(sigma), to_var(l)));
+  test::check_varis_on_stack(stan::math::cov_exp_quad(x, to_var(sigma), l));
+  test::check_varis_on_stack(stan::math::cov_exp_quad(x, sigma, to_var(l)));
 }

--- a/test/unit/math/rev/mat/fun/cov_matrix_transform_test.cpp
+++ b/test/unit/math/rev/mat/fun/cov_matrix_transform_test.cpp
@@ -1,6 +1,7 @@
 #include <stan/math/rev/mat.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/math/rev/mat/fun/jacobian.hpp>
+#include <test/unit/math/rev/mat/util.hpp>
 
 using Eigen::Matrix;
 using Eigen::Dynamic;
@@ -37,4 +38,15 @@ TEST(prob_transform,cov_matrix_jacobian) {
 
   double log_abs_jacobian_det = log(fabs(determinant(J)));
   EXPECT_FLOAT_EQ(log_abs_jacobian_det,lp.val());
+}
+
+TEST(prob_transform, check_varis_on_stack) {
+  using stan::math::var;
+  int K = 4;
+  unsigned int K_choose_2 = 6;
+  Eigen::Matrix<var,Eigen::Dynamic,1> X(K_choose_2 + K);
+  X << 1.0, 2.0, -3.0, 1.7, 9.8, 
+    -12.2, 0.4, 0.2, 1.2, 2.7;
+  var lp = 0.0;
+  test::check_varis_on_stack(stan::math::cov_matrix_constrain(X,K,lp));
 }

--- a/test/unit/math/rev/mat/fun/cov_matrix_transform_test.cpp
+++ b/test/unit/math/rev/mat/fun/cov_matrix_transform_test.cpp
@@ -48,5 +48,7 @@ TEST(prob_transform, check_varis_on_stack) {
   X << 1.0, 2.0, -3.0, 1.7, 9.8, 
     -12.2, 0.4, 0.2, 1.2, 2.7;
   var lp = 0.0;
-  test::check_varis_on_stack(stan::math::cov_matrix_constrain(X,K,lp));
+
+  test::check_varis_on_stack(stan::math::cov_matrix_constrain(X, K, lp));
+  test::check_varis_on_stack(stan::math::cov_matrix_constrain(X, K));
 }

--- a/test/unit/math/rev/mat/fun/crossprod_test.cpp
+++ b/test/unit/math/rev/mat/fun/crossprod_test.cpp
@@ -1,6 +1,7 @@
 #include <stan/math/rev/mat.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/math/rev/mat/fun/util.hpp>
+#include <test/unit/math/rev/mat/util.hpp>
 
 void test_crossprod(const stan::math::matrix_v& L) {
   using stan::math::matrix_v;
@@ -39,4 +40,13 @@ TEST(AgradRevMatrix, crossprod) {
   test_crossprod(K);
   //  test_tcrossprod_grad(K, K.rows(), K.cols());
 
+}
+TEST(AgradRevMatrix, check_varis_on_stack) {
+  using stan::math::matrix_v;
+
+  matrix_v L(3,3);
+  L << 1, 0, 0,
+    2, 3, 0,
+    4, 5, 6;
+  test::check_varis_on_stack(stan::math::crossprod(L));
 }

--- a/test/unit/math/rev/mat/fun/cumulative_sum_test.cpp
+++ b/test/unit/math/rev/mat/fun/cumulative_sum_test.cpp
@@ -1,6 +1,7 @@
 #include <stan/math/rev/mat.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/math/rev/mat/fun/util.hpp>
+#include <test/unit/math/rev/mat/util.hpp>
 
 template <typename T>
 void test_cumulative_sum() {
@@ -57,3 +58,8 @@ TEST(AgradRevMatrix, cumulative_sum) {
   test_cumulative_sum<Eigen::Matrix<var,1,Eigen::Dynamic> >();
 }
 
+TEST(AgradRevMatrix, check_varis_on_stack) {
+  stan::math::vector_v x(2);
+  x << 1, 2;
+  test::check_varis_on_stack(stan::math::cumulative_sum(x));
+}

--- a/test/unit/math/rev/mat/fun/determinant_test.cpp
+++ b/test/unit/math/rev/mat/fun/determinant_test.cpp
@@ -1,6 +1,7 @@
 #include <stan/math/rev/mat.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/math/rev/mat/fun/util.hpp>
+#include <test/unit/math/rev/mat/util.hpp>
 
 TEST(AgradRevMatrix,determinant) {
   using stan::math::matrix_v;
@@ -68,4 +69,9 @@ TEST(AgradRevMatrix,determinant3by3) {
       Z(i,j) = i * j + 1;
   AVAR h = determinant(Z);
   h = h; // supresses set but not used warning
+}
+TEST(AgradRevMatrix, check_varis_on_stack) {
+  stan::math::matrix_v X(2,2);
+  X <<  2, 3, 5, 7;
+  test::check_varis_on_stack(stan::math::determinant(X));
 }

--- a/test/unit/math/rev/mat/fun/diag_matrix_test.cpp
+++ b/test/unit/math/rev/mat/fun/diag_matrix_test.cpp
@@ -1,6 +1,7 @@
 #include <stan/math/rev/mat.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/math/rev/mat/fun/util.hpp>
+#include <test/unit/math/rev/mat/util.hpp>
 
 TEST(AgradRevMatrix,diagMatrix) {
   using stan::math::diag_matrix;
@@ -19,4 +20,10 @@ TEST(AgradRevMatrix,diagMatrix) {
   EXPECT_EQ(1,m(0,0).val());
   EXPECT_EQ(4,m(1,1).val());
   EXPECT_EQ(9,m(2,2).val());
+}
+
+TEST(AgradRevMatrix, check_varis_on_stack) {
+  stan::math::vector_v v(3);
+  v << 1, 4, 9;
+  test::check_varis_on_stack(stan::math::diag_matrix(v));
 }

--- a/test/unit/math/rev/mat/fun/diag_post_multiply_test.cpp
+++ b/test/unit/math/rev/mat/fun/diag_post_multiply_test.cpp
@@ -2,7 +2,7 @@
 #include <gtest/gtest.h>
 #include <vector>
 #include <test/unit/math/rev/mat/fun/expect_matrix_eq.hpp>
-
+#include <test/unit/math/rev/mat/util.hpp>
 
 using Eigen::Matrix;
 using Eigen::Dynamic;
@@ -222,4 +222,13 @@ TEST(MathMatrix,diagPostMultiplyException) {
   Matrix<var,Dynamic,1> v(3);
   v << 1, 2, 3;
   EXPECT_THROW(diag_post_multiply(m,v), std::invalid_argument);
+}
+
+TEST(AgradRevMatrix, check_varis_on_stack) {
+  stan::math::matrix_v m(3, 3);
+  m << 1, 2, 3, 4, 5, 6, 7, 8, 9;
+  stan::math::vector_v v(3);
+  v << 1, 2, 3;
+
+  test::check_varis_on_stack(stan::math::diag_post_multiply(m, v));
 }

--- a/test/unit/math/rev/mat/fun/diag_pre_multiply_test.cpp
+++ b/test/unit/math/rev/mat/fun/diag_pre_multiply_test.cpp
@@ -2,6 +2,7 @@
 #include <gtest/gtest.h>
 #include <vector>
 #include <test/unit/math/rev/mat/fun/expect_matrix_eq.hpp>
+#include <test/unit/math/rev/mat/util.hpp>
 
 using Eigen::Matrix;
 using Eigen::Dynamic;
@@ -221,4 +222,13 @@ TEST(MathMatrix,diagPreMultiplyException) {
   Matrix<var,Dynamic,1> v(3);
   v << 1, 2, 3;
   EXPECT_THROW(diag_pre_multiply(v,m), std::invalid_argument);
+}
+
+TEST(AgradRevMatrix, check_varis_on_stack) {
+  stan::math::matrix_v m(3,3);
+  m << 1, 2, 3, 4, 5, 6, 7, 8, 9;
+  stan::math::vector_v v(3);
+  v << 1, 2, 3;
+
+  test::check_varis_on_stack(stan::math::diag_pre_multiply(v,m));
 }

--- a/test/unit/math/rev/mat/fun/distance_test.cpp
+++ b/test/unit/math/rev/mat/fun/distance_test.cpp
@@ -1,6 +1,7 @@
 #include <stan/math/rev/mat.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/math/rev/mat/fun/util.hpp>
+#include <test/unit/math/rev/mat/util.hpp>
 
 TEST(AgradRevMatrix, distance_vector_vector) {
   using stan::math::vector_d;
@@ -200,4 +201,12 @@ TEST(AgradRevMatrix, distance_vd) {
   EXPECT_FLOAT_EQ((a(0).val() - b(0)) / 3.464102, grad[0]);
   EXPECT_FLOAT_EQ((a(1).val() - b(1)) / 3.464102, grad[1]);
   EXPECT_FLOAT_EQ((a(2).val() - b(2)) / 3.464102, grad[2]);
+}
+
+TEST(AgradRevMatrix, check_varis_on_stack) {
+  stan::math::vector_v v1(3), v2(3);
+  v1 << 1, 3, -5;
+  v2 << 4, -2, -1;
+
+  test::check_varis_on_stack(stan::math::distance(v1, v2));
 }

--- a/test/unit/math/rev/mat/fun/divide_test.cpp
+++ b/test/unit/math/rev/mat/fun/divide_test.cpp
@@ -1,6 +1,7 @@
 #include <stan/math/rev/mat.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/math/rev/mat/fun/util.hpp>
+#include <test/unit/math/rev/mat/util.hpp>
 
 TEST(AgradRevMatrix, divide_scalar) {
   using stan::math::divide;
@@ -215,4 +216,18 @@ TEST(AgradRevMatrix, divide_matrix) {
   EXPECT_TRUE (std::isnan(output(0,1).val()));
   EXPECT_FLOAT_EQ(-std::numeric_limits<double>::infinity(), output(1,0).val());
   EXPECT_FLOAT_EQ(std::numeric_limits<double>::infinity(), output(1,1).val());
+}
+
+TEST(AgradRevMatrix, check_varis_on_stack) {
+  stan::math::var x = 10;
+  stan::math::vector_v v(3);
+  v << -100, 0, 1;
+  stan::math::row_vector_v rv(3);
+  rv << -100, 0, 1;
+  stan::math::matrix_v m(2, 3);
+  m << -100, 0, 1, 20, -40, 2;
+  
+  test::check_varis_on_stack(stan::math::divide(v, x));
+  test::check_varis_on_stack(stan::math::divide(rv, x));
+  test::check_varis_on_stack(stan::math::divide(m, x));
 }

--- a/test/unit/math/rev/mat/fun/divide_test.cpp
+++ b/test/unit/math/rev/mat/fun/divide_test.cpp
@@ -219,6 +219,7 @@ TEST(AgradRevMatrix, divide_matrix) {
 }
 
 TEST(AgradRevMatrix, check_varis_on_stack) {
+  using stan::math::value_of;
   stan::math::var x = 10;
   stan::math::vector_v v(3);
   v << -100, 0, 1;
@@ -228,6 +229,14 @@ TEST(AgradRevMatrix, check_varis_on_stack) {
   m << -100, 0, 1, 20, -40, 2;
   
   test::check_varis_on_stack(stan::math::divide(v, x));
+  test::check_varis_on_stack(stan::math::divide(v, value_of(x)));
+  test::check_varis_on_stack(stan::math::divide(value_of(v), x));
+
   test::check_varis_on_stack(stan::math::divide(rv, x));
+  test::check_varis_on_stack(stan::math::divide(rv, value_of(x)));
+  test::check_varis_on_stack(stan::math::divide(value_of(rv), x));
+
   test::check_varis_on_stack(stan::math::divide(m, x));
+  test::check_varis_on_stack(stan::math::divide(m, value_of(x)));
+  test::check_varis_on_stack(stan::math::divide(value_of(m), x));
 }

--- a/test/unit/math/rev/mat/fun/dot_product_test.cpp
+++ b/test/unit/math/rev/mat/fun/dot_product_test.cpp
@@ -1,6 +1,7 @@
 #include <stan/math/rev/mat.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/math/rev/mat/fun/util.hpp>
+#include <test/unit/math/rev/mat/util.hpp>
 
 TEST(AgradRevMatrix, dot_product_vector_vector) {
   using stan::math::vector_d;
@@ -240,3 +241,10 @@ TEST(AgradRevMatrix, dot_product_vd_vec) {
   EXPECT_EQ(grad[2], 3);
 }
 
+TEST(AgradRevMatrix, check_varis_on_stack) {
+  stan::math::vector_v v1(3), v2(3);
+  v1 << 1, 3, -5;
+  v2 << 4, -2, -1;
+  
+  test::check_varis_on_stack(stan::math::dot_product(v1, v2));
+}

--- a/test/unit/math/rev/mat/fun/dot_product_test.cpp
+++ b/test/unit/math/rev/mat/fun/dot_product_test.cpp
@@ -242,9 +242,12 @@ TEST(AgradRevMatrix, dot_product_vd_vec) {
 }
 
 TEST(AgradRevMatrix, check_varis_on_stack) {
+  using stan::math::value_of;
   stan::math::vector_v v1(3), v2(3);
   v1 << 1, 3, -5;
   v2 << 4, -2, -1;
   
   test::check_varis_on_stack(stan::math::dot_product(v1, v2));
+  test::check_varis_on_stack(stan::math::dot_product(v1, value_of(v2)));
+  test::check_varis_on_stack(stan::math::dot_product(value_of(v1), v2));
 }

--- a/test/unit/math/rev/mat/fun/dot_self_test.cpp
+++ b/test/unit/math/rev/mat/fun/dot_self_test.cpp
@@ -1,6 +1,7 @@
 #include <stan/math/rev/mat.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/math/rev/mat/fun/util.hpp>
+#include <test/unit/math/rev/mat/util.hpp>
 
 template <int R, int C>
 void assert_val_grad(Eigen::Matrix<stan::math::var,R,C>& v) {
@@ -65,4 +66,10 @@ TEST(AgradRevMatrix,columns_dot_self) {
 
   Eigen::Matrix<AVAR,Eigen::Dynamic,Eigen::Dynamic> vvvv(1,3);
   assert_val_grad(vvvv);
+}
+
+TEST(AgradRevMatrix, check_varis_on_stack) {
+  Eigen::Matrix<AVAR,Eigen::Dynamic,1> v2(2);
+  v2 << 2.0, 3.0;
+  test::check_varis_on_stack(stan::math::dot_self(v2));
 }

--- a/test/unit/math/rev/mat/fun/eigenvalues_sym_test.cpp
+++ b/test/unit/math/rev/mat/fun/eigenvalues_sym_test.cpp
@@ -1,6 +1,7 @@
 #include <stan/math/rev/mat.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/math/rev/mat/fun/util.hpp>
+#include <test/unit/math/rev/mat/util.hpp>
 
 TEST(AgradRevMatrix,eigenval_sum) {
   using stan::math::sum;
@@ -31,4 +32,15 @@ TEST(AgradRevMatrix,eigenval_sum) {
   EXPECT_NEAR(0.0,g[3],1.0E-10);
   EXPECT_NEAR(0.0,g[4],1.0E-10);
   EXPECT_NEAR(0.0,g[5],1.0E-10);
+}
+TEST(AgradRevMatrix, check_varis_on_stack) {
+  using stan::math::matrix_v;
+  using stan::math::eigenvalues_sym;
+
+  matrix_v a(3,3);
+  a << 
+    1.0, 2.0, 3.0,
+    2.0, 5.0, 7.9,
+    3.0, 7.9, 1.08;
+  test::check_varis_on_stack(stan::math::eigenvalues_sym(a));
 }

--- a/test/unit/math/rev/mat/fun/elt_divide_test.cpp
+++ b/test/unit/math/rev/mat/fun/elt_divide_test.cpp
@@ -1,6 +1,7 @@
 #include <stan/math/rev/mat.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/math/rev/mat/fun/util.hpp>
+#include <test/unit/math/rev/mat/util.hpp>
 
 TEST(AgradRevMatrix,elt_divide_vec_vv) {
   using stan::math::elt_divide;
@@ -217,4 +218,14 @@ TEST(AgradRevMatrix,elt_divide_row_vec_scal_dv) {
   row_vector_v z = elt_divide(x, y);
   z.sum().grad();
   EXPECT_FLOAT_EQ(x.sum() * (-1.0 / 100),  y.adj());
+}
+TEST(AgradRevMatrix, check_varis_on_stack) {
+  using stan::math::elt_divide;
+  using stan::math::vector_v;
+  vector_v x(2);
+  x << 2, 5;
+  vector_v y(2);
+  y << 10, 100;
+
+  test::check_varis_on_stack(stan::math::elt_divide(x,y));
 }

--- a/test/unit/math/rev/mat/fun/elt_divide_test.cpp
+++ b/test/unit/math/rev/mat/fun/elt_divide_test.cpp
@@ -220,6 +220,7 @@ TEST(AgradRevMatrix,elt_divide_row_vec_scal_dv) {
   EXPECT_FLOAT_EQ(x.sum() * (-1.0 / 100),  y.adj());
 }
 TEST(AgradRevMatrix, check_varis_on_stack) {
+  using stan::math::value_of;
   using stan::math::elt_divide;
   using stan::math::vector_v;
   vector_v x(2);
@@ -227,5 +228,7 @@ TEST(AgradRevMatrix, check_varis_on_stack) {
   vector_v y(2);
   y << 10, 100;
 
-  test::check_varis_on_stack(stan::math::elt_divide(x,y));
+  test::check_varis_on_stack(stan::math::elt_divide(x, y));
+  test::check_varis_on_stack(stan::math::elt_divide(x, value_of(y)));
+  test::check_varis_on_stack(stan::math::elt_divide(value_of(x), y));
 }

--- a/test/unit/math/rev/mat/fun/elt_multiply_test.cpp
+++ b/test/unit/math/rev/mat/fun/elt_multiply_test.cpp
@@ -1,6 +1,7 @@
 #include <stan/math/rev/mat.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/math/rev/mat/fun/util.hpp>
+#include <test/unit/math/rev/mat/util.hpp>
 
 TEST(AgradRevMatrix,elt_multiply_vec_vv) {
   using stan::math::elt_multiply;
@@ -175,4 +176,13 @@ TEST(AgradRevMatrix,elt_multiply_matrix_dv) {
   VEC g = cgradvec(z(0,0),x_ind);
   EXPECT_FLOAT_EQ(2.0,g[0]);
   EXPECT_FLOAT_EQ(0.0,g[1]);
+}
+TEST(AgradRevMatrix, check_varis_on_stack) {
+  using stan::math::elt_multiply;
+  using stan::math::vector_v;
+  vector_v x(2);
+  x << 2, 5;
+  vector_v y(2);
+  y << 10, 100;
+  test::check_varis_on_stack(stan::math::elt_multiply(x,y));
 }

--- a/test/unit/math/rev/mat/fun/elt_multiply_test.cpp
+++ b/test/unit/math/rev/mat/fun/elt_multiply_test.cpp
@@ -178,11 +178,15 @@ TEST(AgradRevMatrix,elt_multiply_matrix_dv) {
   EXPECT_FLOAT_EQ(0.0,g[1]);
 }
 TEST(AgradRevMatrix, check_varis_on_stack) {
+  using stan::math::value_of;
   using stan::math::elt_multiply;
   using stan::math::vector_v;
   vector_v x(2);
   x << 2, 5;
   vector_v y(2);
   y << 10, 100;
-  test::check_varis_on_stack(stan::math::elt_multiply(x,y));
+
+  test::check_varis_on_stack(stan::math::elt_multiply(x, y));
+  test::check_varis_on_stack(stan::math::elt_multiply(x, value_of(y)));
+  test::check_varis_on_stack(stan::math::elt_multiply(value_of(x), y));
 }

--- a/test/unit/math/rev/mat/fun/get_lp_test.cpp
+++ b/test/unit/math/rev/mat/fun/get_lp_test.cpp
@@ -1,5 +1,6 @@
 #include <stan/math/rev/mat.hpp>
 #include <gtest/gtest.h>
+#include <test/unit/math/rev/mat/util.hpp>
 
 
 TEST(mathMatrix,getLp) {
@@ -16,3 +17,14 @@ TEST(mathMatrix,getLp) {
   EXPECT_FLOAT_EQ(17.5, get_lp(lp,lp_accum).val());
 }
 
+TEST(AgradRevMatrix, check_varis_on_stack) {
+  using stan::math::accumulator;
+  using stan::math::get_lp;
+  using stan::math::var;
+
+  var lp = 12.5;
+  accumulator<var> lp_accum;
+  lp_accum.add(2);
+  lp_accum.add(3);
+  test::check_varis_on_stack(stan::math::get_lp(lp,lp_accum));
+}

--- a/test/unit/math/rev/mat/fun/inverse_spd_test.cpp
+++ b/test/unit/math/rev/mat/fun/inverse_spd_test.cpp
@@ -1,6 +1,7 @@
 #include <stan/math/rev/mat.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/math/rev/mat/fun/util.hpp>
+#include <test/unit/math/rev/mat/util.hpp>
 
 TEST(AgradRevMatrix,inverse_spd_val) {
   using stan::math::inverse_spd;
@@ -89,4 +90,15 @@ TEST(AgradRevMatrix,inverse_spd_inverse_spd_sum) {
       k++;
     }
   }
+}
+
+TEST(AgradRevMatrix, check_varis_on_stack) {
+  using stan::math::inverse_spd;
+  using stan::math::matrix_v;
+
+  matrix_v a(2,2);
+  a << 2.0, 3.0, 
+    3.0, 7.0;
+
+  test::check_varis_on_stack(stan::math::inverse_spd(a));
 }

--- a/test/unit/math/rev/mat/fun/inverse_test.cpp
+++ b/test/unit/math/rev/mat/fun/inverse_test.cpp
@@ -1,6 +1,7 @@
 #include <stan/math/rev/mat.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/math/rev/mat/fun/util.hpp>
+#include <test/unit/math/rev/mat/util.hpp>
 
 TEST(AgradRevMatrix,inverse_val) {
   using stan::math::inverse;
@@ -73,4 +74,15 @@ TEST(AgradRevMatrix,inverse_inverse_sum) {
 
   for (size_t k = 0; k < x.size(); ++k)
     EXPECT_FLOAT_EQ(1.0,g[k]);
+}
+
+TEST(AgradRevMatrix, check_varis_on_stack) {
+  using stan::math::inverse;
+  using stan::math::matrix_v;
+
+  matrix_v a(2,2);
+  a << 2.0, 3.0, 
+    5.0, 7.0;
+
+  test::check_varis_on_stack(stan::math::inverse(a));
 }

--- a/test/unit/math/rev/mat/fun/log_determinant_ldlt_test.cpp
+++ b/test/unit/math/rev/mat/fun/log_determinant_ldlt_test.cpp
@@ -1,6 +1,7 @@
 #include <stan/math/rev/mat.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/math/rev/mat/fun/util.hpp>
+#include <test/unit/math/rev/mat/util.hpp>
 
 TEST(AgradRevMatrix,log_determinant_ldlt_diff) {
   using stan::math::matrix_v;
@@ -55,4 +56,12 @@ TEST(AgradRevMatrix,log_determinant_ldlt) {
   EXPECT_FLOAT_EQ(0, grad[1]);
   EXPECT_FLOAT_EQ(0, grad[2]);
   EXPECT_FLOAT_EQ(1.0/3.0, grad[3]);
+}
+
+TEST(AgradRevMatrix, check_varis_on_stack) {
+  stan::math::matrix_v v2(2,2);
+  v2 << 2, 1, 1, 3;
+  stan::math::LDLT_factor<stan::math::var,-1,-1> ldlt_v;
+  ldlt_v.compute(v2);
+  test::check_varis_on_stack(stan::math::log_determinant_ldlt(ldlt_v));
 }

--- a/test/unit/math/rev/mat/fun/log_determinant_spd_test.cpp
+++ b/test/unit/math/rev/mat/fun/log_determinant_spd_test.cpp
@@ -1,6 +1,7 @@
 #include <stan/math/rev/mat.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/math/rev/mat/fun/util.hpp>
+#include <test/unit/math/rev/mat/util.hpp>
 
 TEST(AgradRevMatrix,log_determinant_spd_diff) {
   using stan::math::matrix_v;
@@ -40,6 +41,13 @@ TEST(AgradRevMatrix,log_determinant_spd) {
   det = log_determinant_spd(v);
   EXPECT_FLOAT_EQ(std::log(3.0), det.val());
 }
+
+TEST(AgradRevMatrix, check_varis_on_stack) {
+  stan::math::matrix_v v2(2,2);
+  v2 << 2, 1, 1, 3;
+  test::check_varis_on_stack(stan::math::log_determinant_spd(v2));
+}
+
 #if 0
 TEST(AgradRevMatrix,log_deteriminant_exception) {
   using stan::math::matrix_v;

--- a/test/unit/math/rev/mat/fun/log_determinant_test.cpp
+++ b/test/unit/math/rev/mat/fun/log_determinant_test.cpp
@@ -1,6 +1,7 @@
 #include <stan/math/rev/mat.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/math/rev/mat/fun/util.hpp>
+#include <test/unit/math/rev/mat/util.hpp>
 
 TEST(AgradRevMatrix,log_determinant_diff) {
   using stan::math::matrix_v;
@@ -72,4 +73,10 @@ TEST(AgradRevMatrix,log_determinant_grad) {
   EXPECT_FLOAT_EQ(5.0,g[1]);
   EXPECT_FLOAT_EQ(3.0,g[2]);
   EXPECT_FLOAT_EQ(-2.0,g[3]);
+}
+
+TEST(AgradRevMatrix, check_varis_on_stack) {
+  stan::math::matrix_v X(2, 2);
+  X << 2, 3, 6, 7;
+  test::check_varis_on_stack(stan::math::log_determinant(X));
 }

--- a/test/unit/math/rev/mat/fun/log_softmax_test.cpp
+++ b/test/unit/math/rev/mat/fun/log_softmax_test.cpp
@@ -1,6 +1,7 @@
 #include <stan/math/rev/mat.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/math/rev/mat/fun/util.hpp>
+#include <test/unit/math/rev/mat/util.hpp>
 
 TEST(AgradRevMatrix,logSoftmaxLeak) {
   // FIXME: very brittle test depending on unrelated constants of 
@@ -104,4 +105,10 @@ TEST(AgradRevLogSoftmax, Grad) {
     for (size_t i = 0; i < grad_expected.size(); ++i)
       EXPECT_FLOAT_EQ(grad_expected[i], grad[i]);
   }
+}
+
+TEST(AgradRevMatrix, check_varis_on_stack) {
+  stan::math::vector_v x(2);
+  x << -1.0, 1.0;
+  test::check_varis_on_stack(stan::math::log_softmax(x));
 }

--- a/test/unit/math/rev/mat/fun/log_sum_exp_test.cpp
+++ b/test/unit/math/rev/mat/fun/log_sum_exp_test.cpp
@@ -2,6 +2,7 @@
 #include <gtest/gtest.h>
 #include <cmath>
 #include <test/unit/math/rev/mat/fun/util.hpp>
+#include <test/unit/math/rev/mat/util.hpp>
 
 using Eigen::Matrix;
 using Eigen::Dynamic;
@@ -57,7 +58,10 @@ TEST(AgradRev,logSumExpMatrix) {
   Matrix<double,Dynamic,Dynamic> d(3,2);
   d << -1, -2, -4, 5, 6, 4;
   test_log_sum_exp_matrix(d);
-  
+}
 
-  
+TEST(AgradRevMatrix, check_varis_on_stack) {
+  stan::math::vector_v a(2);
+  a << 5, 2;
+  test::check_varis_on_stack(stan::math::log_sum_exp(a));
 }

--- a/test/unit/math/rev/mat/fun/max_test.cpp
+++ b/test/unit/math/rev/mat/fun/max_test.cpp
@@ -1,6 +1,7 @@
 #include <stan/math/rev/mat.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/math/rev/mat/fun/util.hpp>
+#include <test/unit/math/rev/mat/util.hpp>
 
 TEST(AgradRevMatrix, max_vector) {
   using stan::math::max;
@@ -76,4 +77,16 @@ TEST(AgradRevMatrix, max_matrix_exception) {
   
   matrix_v v;
   EXPECT_EQ(-std::numeric_limits<double>::infinity(), max(v).val());
+}
+TEST(AgradRevMatrix, check_varis_on_stack) {
+  stan::math::vector_v v(3);
+  v << -100, 0, 1;
+  stan::math::row_vector_v rv(3);
+  rv << -100, 0, 1;
+  stan::math::matrix_v m(2, 3);
+  m << -100, 0, 1, 20, -40, 2;
+  
+  test::check_varis_on_stack(stan::math::max(v));
+  test::check_varis_on_stack(stan::math::max(rv));
+  test::check_varis_on_stack(stan::math::max(m));
 }

--- a/test/unit/math/rev/mat/fun/mdivide_left_ldlt_test.cpp
+++ b/test/unit/math/rev/mat/fun/mdivide_left_ldlt_test.cpp
@@ -375,11 +375,20 @@ TEST(AgradRevMatrix,mdivide_left_ldlt_finite_diff_vd) {
 }
 
 TEST(AgradRevMatrix, check_varis_on_stack) {
+  using stan::math::value_of;
   stan::math::LDLT_factor<stan::math::var,-1,-1> ldlt_Av;
   stan::math::matrix_v Av(2,2);
   Av << 2.0, 3.0, 
     3.0, 7.0;
   ldlt_Av.compute(Av);
 
-  test::check_varis_on_stack(stan::math::mdivide_left_ldlt(ldlt_Av,Av));
+  stan::math::LDLT_factor<double,-1,-1> ldlt_Ad;
+  stan::math::matrix_d Ad(2,2);
+  Ad << 2.0, 3.0, 
+    3.0, 7.0;
+  ldlt_Ad.compute(Ad);
+  
+  test::check_varis_on_stack(stan::math::mdivide_left_ldlt(ldlt_Av, Av));
+  test::check_varis_on_stack(stan::math::mdivide_left_ldlt(ldlt_Av, Ad));
+  test::check_varis_on_stack(stan::math::mdivide_left_ldlt(ldlt_Ad, Av));
 }

--- a/test/unit/math/rev/mat/fun/mdivide_left_ldlt_test.cpp
+++ b/test/unit/math/rev/mat/fun/mdivide_left_ldlt_test.cpp
@@ -1,6 +1,7 @@
 #include <stan/math/rev/mat.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/math/rev/mat/fun/util.hpp>
+#include <test/unit/math/rev/mat/util.hpp>
 
 std::vector<double> finite_differences(const size_t row, const size_t col,
                                          const stan::math::matrix_d A,
@@ -373,3 +374,12 @@ TEST(AgradRevMatrix,mdivide_left_ldlt_finite_diff_vd) {
   }
 }
 
+TEST(AgradRevMatrix, check_varis_on_stack) {
+  stan::math::LDLT_factor<stan::math::var,-1,-1> ldlt_Av;
+  stan::math::matrix_v Av(2,2);
+  Av << 2.0, 3.0, 
+    3.0, 7.0;
+  ldlt_Av.compute(Av);
+
+  test::check_varis_on_stack(stan::math::mdivide_left_ldlt(ldlt_Av,Av));
+}

--- a/test/unit/math/rev/mat/fun/mdivide_left_spd_test.cpp
+++ b/test/unit/math/rev/mat/fun/mdivide_left_spd_test.cpp
@@ -175,8 +175,11 @@ TEST(AgradRevMatrix,mdivide_left_spd_grad_vd) {
 }
 
 TEST(AgradRevMatrix, check_varis_on_stack) {
+  using stan::math::value_of;
   stan::math::matrix_v A(2, 2);
   A << 2.0, 3.0, 
     3.0, 7.0;
   test::check_varis_on_stack(stan::math::mdivide_left_spd(A, A));
+  test::check_varis_on_stack(stan::math::mdivide_left_spd(A, value_of(A)));
+  test::check_varis_on_stack(stan::math::mdivide_left_spd(value_of(A), A));
 }

--- a/test/unit/math/rev/mat/fun/mdivide_left_spd_test.cpp
+++ b/test/unit/math/rev/mat/fun/mdivide_left_spd_test.cpp
@@ -1,6 +1,7 @@
 #include <stan/math/rev/mat.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/math/rev/mat/fun/util.hpp>
+#include <test/unit/math/rev/mat/util.hpp>
 
 TEST(AgradRevMatrix,mdivide_left_spd_val) {
   using stan::math::matrix_d;
@@ -171,4 +172,11 @@ TEST(AgradRevMatrix,mdivide_left_spd_grad_vd) {
       }
     }
   }
+}
+
+TEST(AgradRevMatrix, check_varis_on_stack) {
+  stan::math::matrix_v A(2, 2);
+  A << 2.0, 3.0, 
+    3.0, 7.0;
+  test::check_varis_on_stack(stan::math::mdivide_left_spd(A, A));
 }

--- a/test/unit/math/rev/mat/fun/mdivide_left_test.cpp
+++ b/test/unit/math/rev/mat/fun/mdivide_left_test.cpp
@@ -175,8 +175,12 @@ TEST(AgradRevMatrix,mdivide_left_grad_vd) {
 }
 
 TEST(AgradRevMatrix, check_varis_on_stack) {
+  using stan::math::value_of;
   stan::math::matrix_v A(2,2);
   A << 2.0, 3.0, 
     5.0, 7.0;
+
   test::check_varis_on_stack(stan::math::mdivide_left(A, A));
+  test::check_varis_on_stack(stan::math::mdivide_left(A, value_of(A)));
+  test::check_varis_on_stack(stan::math::mdivide_left(value_of(A), A));
 }

--- a/test/unit/math/rev/mat/fun/mdivide_left_test.cpp
+++ b/test/unit/math/rev/mat/fun/mdivide_left_test.cpp
@@ -1,6 +1,7 @@
 #include <stan/math/rev/mat.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/math/rev/mat/fun/util.hpp>
+#include <test/unit/math/rev/mat/util.hpp>
 
 TEST(AgradRevMatrix,mdivide_left_val) {
   using stan::math::matrix_d;
@@ -171,4 +172,11 @@ TEST(AgradRevMatrix,mdivide_left_grad_vd) {
       }
     }
   }
+}
+
+TEST(AgradRevMatrix, check_varis_on_stack) {
+  stan::math::matrix_v A(2,2);
+  A << 2.0, 3.0, 
+    5.0, 7.0;
+  test::check_varis_on_stack(stan::math::mdivide_left(A, A));
 }

--- a/test/unit/math/rev/mat/fun/mdivide_left_tri_test.cpp
+++ b/test/unit/math/rev/mat/fun/mdivide_left_tri_test.cpp
@@ -358,22 +358,13 @@ TEST(AgradRevMatrix,mdivide_left_tri_upper_grad_vd) {
 }
 
 TEST(AgradRevMatrix, check_varis_on_stack) {
+  using stan::math::value_of;
   stan::math::matrix_v A(2,2);
   A << 2.0, 0.0,
     5.0, 7.0;
-  test::check_varis_on_stack(stan::math::mdivide_left_tri<Eigen::Lower>(A, A));
-}
 
-// // FIXME:  Fails in g++ 4.2 -- can't find agrad version of mdivide_left_tri
-// //         Works in clang++ and later g++
-// // TEST(AgradRevMatrix,mdivide_left_tri2) {
-// //   using stan::math::mdivide_left_tri;
-// //   using stan::math::mdivide_left_tri;
-// //   int k = 3;
-// //   Eigen::Matrix<stan::math::var,Eigen::Dynamic,Eigen::Dynamic> L(k,k);
-// //   L << 1, 2, 3, 4, 5, 6, 7, 8, 9;
-// //   Eigen::Matrix<stan::math::var,Eigen::Dynamic,Eigen::Dynamic> I(k,k);
-// //   I.setIdentity();
-// //   L = mdivide_left_tri<Eigen::Lower>(L, I);
-// // }
+  test::check_varis_on_stack(stan::math::mdivide_left_tri<Eigen::Lower>(A, A));
+  test::check_varis_on_stack(stan::math::mdivide_left_tri<Eigen::Lower>(A, value_of(A)));
+  test::check_varis_on_stack(stan::math::mdivide_left_tri<Eigen::Lower>(value_of(A), A));
+}
 

--- a/test/unit/math/rev/mat/fun/mdivide_left_tri_test.cpp
+++ b/test/unit/math/rev/mat/fun/mdivide_left_tri_test.cpp
@@ -1,6 +1,7 @@
 #include <stan/math/rev/mat.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/math/rev/mat/fun/util.hpp>
+#include <test/unit/math/rev/mat/util.hpp>
 
 TEST(AgradRevMatrix,mdivide_left_tri_val) {
   using stan::math::matrix_d;
@@ -355,6 +356,14 @@ TEST(AgradRevMatrix,mdivide_left_tri_upper_grad_vd) {
     }
   }
 }
+
+TEST(AgradRevMatrix, check_varis_on_stack) {
+  stan::math::matrix_v A(2,2);
+  A << 2.0, 0.0,
+    5.0, 7.0;
+  test::check_varis_on_stack(stan::math::mdivide_left_tri<Eigen::Lower>(A, A));
+}
+
 // // FIXME:  Fails in g++ 4.2 -- can't find agrad version of mdivide_left_tri
 // //         Works in clang++ and later g++
 // // TEST(AgradRevMatrix,mdivide_left_tri2) {
@@ -367,3 +376,4 @@ TEST(AgradRevMatrix,mdivide_left_tri_upper_grad_vd) {
 // //   I.setIdentity();
 // //   L = mdivide_left_tri<Eigen::Lower>(L, I);
 // // }
+

--- a/test/unit/math/rev/mat/fun/mdivide_right_ldlt_test.cpp
+++ b/test/unit/math/rev/mat/fun/mdivide_right_ldlt_test.cpp
@@ -1,5 +1,6 @@
 #include <stan/math/rev/mat.hpp>
 #include <gtest/gtest.h>
+#include <test/unit/math/rev/mat/util.hpp>
 
 TEST(AgradRevMatrix, mdivide_right_ldlt_vv) {
   using stan::math::var;
@@ -252,3 +253,18 @@ TEST(AgradRevMatrix, mdivide_right_ldlt_dv) {
 }
 
 
+TEST(AgradRevMatrix, check_varis_on_stack) {
+  stan::math::row_vector_v b(5);
+  b << 62, 84, 84, 76, 108;
+  stan::math::matrix_v A(5, 5);
+  A << 
+    20, 8, -9,  7,  5, 
+    8, 20,  0,  4,  4, 
+    -9, 0,  20,  2,  5, 
+    7, 4,  2,  20, -5, 
+    5, 4,  5, -5,  20;
+  stan::math::LDLT_factor<stan::math::var, -1, -1> ldlt_A;
+  ldlt_A.compute(A);
+  
+  test::check_varis_on_stack(stan::math::mdivide_right_ldlt(b, ldlt_A));
+}

--- a/test/unit/math/rev/mat/fun/mdivide_right_ldlt_test.cpp
+++ b/test/unit/math/rev/mat/fun/mdivide_right_ldlt_test.cpp
@@ -254,6 +254,7 @@ TEST(AgradRevMatrix, mdivide_right_ldlt_dv) {
 
 
 TEST(AgradRevMatrix, check_varis_on_stack) {
+  using stan::math::value_of;
   stan::math::row_vector_v b(5);
   b << 62, 84, 84, 76, 108;
   stan::math::matrix_v A(5, 5);
@@ -267,4 +268,6 @@ TEST(AgradRevMatrix, check_varis_on_stack) {
   ldlt_A.compute(A);
   
   test::check_varis_on_stack(stan::math::mdivide_right_ldlt(b, ldlt_A));
+  test::check_varis_on_stack(stan::math::mdivide_right_ldlt(b, value_of(ldlt_A)));
+  test::check_varis_on_stack(stan::math::mdivide_right_ldlt(value_of(b), ldlt_A));
 }

--- a/test/unit/math/rev/mat/fun/mdivide_right_ldlt_test.cpp
+++ b/test/unit/math/rev/mat/fun/mdivide_right_ldlt_test.cpp
@@ -9,7 +9,7 @@ TEST(AgradRevMatrix, mdivide_right_ldlt_vv) {
   using stan::math::row_vector_d;
   using stan::math::mdivide_right_spd;
   using stan::math::mdivide_right_ldlt;
-  using stan::math::LDLT_factor;  
+  using stan::math::LDLT_factor;
   using stan::math::value_of;
   using std::vector;
 
@@ -20,17 +20,17 @@ TEST(AgradRevMatrix, mdivide_right_ldlt_vv) {
   row_vector_d expected(5);
   vector<var> vars;
   vector<double> grad, grad_basic;
-  
+
   expected << 1, 2, 3, 4, 5;
-  
+
   for (int i = 0; i < b.size(); i++) {
     // solve using mdivide_right_ldlt
     b << 62, 84, 84, 76, 108;
-    A << 
-      20, 8, -9,  7,  5, 
-      8, 20,  0,  4,  4, 
-     -9, 0,  20,  2,  5, 
-      7, 4,  2,  20, -5, 
+    A <<
+      20, 8, -9,  7,  5,
+      8, 20,  0,  4,  4,
+     -9, 0,  20,  2,  5,
+      7, 4,  2,  20, -5,
       5, 4,  5, -5,  20;
     LDLT_factor<var,-1,-1> ldlt_A;
     ldlt_A.compute(A);
@@ -56,11 +56,11 @@ TEST(AgradRevMatrix, mdivide_right_ldlt_vv) {
 
     // solve using basic math
     b << 62, 84, 84, 76, 108;
-    A << 
-      20, 8, -9,  7,  5, 
-      8, 20,  0,  4,  4, 
-     -9, 0,  20,  2,  5, 
-      7, 4,  2,  20, -5, 
+    A <<
+      20, 8, -9,  7,  5,
+      8, 20,  0,  4,  4,
+     -9, 0,  20,  2,  5,
+      7, 4,  2,  20, -5,
       5, 4,  5, -5,  20;
     x_basic = mdivide_right_spd(b,A);
     x_basic_val = value_of(x_basic);
@@ -96,7 +96,7 @@ TEST(AgradRevMatrix, mdivide_right_ldlt_vd) {
   using stan::math::matrix_d;
   using stan::math::row_vector_d;
   using stan::math::mdivide_right_ldlt;
-  using stan::math::LDLT_factor;  
+  using stan::math::LDLT_factor;
   using stan::math::mdivide_right_spd;
   using std::vector;
   using stan::math::value_of;
@@ -108,17 +108,17 @@ TEST(AgradRevMatrix, mdivide_right_ldlt_vd) {
   row_vector_d expected(5);
   vector<var> vars;
   vector<double> grad, grad_basic;
-  
+
   expected << 1, 2, 3, 4, 5;
-  
+
   for (int i = 0; i < b.size(); i++) {
     // solve using mdivide_right_ldlt
     b << 62, 84, 84, 76, 108;
-    A << 
-      20, 8, -9,  7,  5, 
-      8, 20,  0,  4,  4, 
-     -9, 0,  20,  2,  5, 
-      7, 4,  2,  20, -5, 
+    A <<
+      20, 8, -9,  7,  5,
+      8, 20,  0,  4,  4,
+     -9, 0,  20,  2,  5,
+      7, 4,  2,  20, -5,
       5, 4,  5, -5,  20;
     LDLT_factor<double,-1,-1> ldlt_A;
     ldlt_A.compute(A);
@@ -141,11 +141,11 @@ TEST(AgradRevMatrix, mdivide_right_ldlt_vd) {
 
     // solve using basic math
     b << 62, 84, 84, 76, 108;
-    A << 
-      20, 8, -9,  7,  5, 
-      8, 20,  0,  4,  4, 
-     -9, 0,  20,  2,  5, 
-      7, 4,  2,  20, -5, 
+    A <<
+      20, 8, -9,  7,  5,
+      8, 20,  0,  4,  4,
+     -9, 0,  20,  2,  5,
+      7, 4,  2,  20, -5,
       5, 4,  5, -5,  20;
     x_basic = mdivide_right_spd(b ,stan::math::to_var(A));
     x_basic_val = value_of(x_basic);
@@ -177,7 +177,7 @@ TEST(AgradRevMatrix, mdivide_right_ldlt_dv) {
   using stan::math::matrix_v;
   using stan::math::row_vector_d;
   using stan::math::mdivide_right_ldlt;
-  using stan::math::LDLT_factor;  
+  using stan::math::LDLT_factor;
   using stan::math::mdivide_right_spd;
   using stan::math::value_of;
   using std::vector;
@@ -189,17 +189,17 @@ TEST(AgradRevMatrix, mdivide_right_ldlt_dv) {
   row_vector_d expected(5);
   vector<var> vars;
   vector<double> grad, grad_basic;
-  
+
   expected << 1, 2, 3, 4, 5;
-  
+
   for (int i = 0; i < b.size(); i++) {
     // solve using mdivide_right_ldlt
     b << 62, 84, 84, 76, 108;
-    A << 
-      20, 8, -9,  7,  5, 
-      8, 20,  0,  4,  4, 
-     -9, 0,  20,  2,  5, 
-      7, 4,  2,  20, -5, 
+    A <<
+      20, 8, -9,  7,  5,
+      8, 20,  0,  4,  4,
+     -9, 0,  20,  2,  5,
+      7, 4,  2,  20, -5,
       5, 4,  5, -5,  20;
     LDLT_factor<var,-1,-1> ldlt_A;
     ldlt_A.compute(A);
@@ -222,11 +222,11 @@ TEST(AgradRevMatrix, mdivide_right_ldlt_dv) {
 
     // solve using basic math
     b << 62, 84, 84, 76, 108;
-    A << 
-      20, 8, -9,  7,  5, 
-      8, 20,  0,  4,  4, 
-     -9, 0,  20,  2,  5, 
-      7, 4,  2,  20, -5, 
+    A <<
+      20, 8, -9,  7,  5,
+      8, 20,  0,  4,  4,
+     -9, 0,  20,  2,  5,
+      7, 4,  2,  20, -5,
       5, 4,  5, -5,  20;
     x_basic = mdivide_right_spd(stan::math::to_var(b),A);
     x_basic_val = value_of(x_basic);
@@ -258,16 +258,18 @@ TEST(AgradRevMatrix, check_varis_on_stack) {
   stan::math::row_vector_v b(5);
   b << 62, 84, 84, 76, 108;
   stan::math::matrix_v A(5, 5);
-  A << 
-    20, 8, -9,  7,  5, 
-    8, 20,  0,  4,  4, 
-    -9, 0,  20,  2,  5, 
-    7, 4,  2,  20, -5, 
+  A <<
+    20, 8, -9,  7,  5,
+    8, 20,  0,  4,  4,
+    -9, 0,  20,  2,  5,
+    7, 4,  2,  20, -5,
     5, 4,  5, -5,  20;
   stan::math::LDLT_factor<stan::math::var, -1, -1> ldlt_A;
   ldlt_A.compute(A);
-  
+  stan::math::LDLT_factor<double, -1, -1> ldlt_Ad;
+  ldlt_Ad.compute(value_of(A));
+
   test::check_varis_on_stack(stan::math::mdivide_right_ldlt(b, ldlt_A));
-  test::check_varis_on_stack(stan::math::mdivide_right_ldlt(b, value_of(ldlt_A)));
+  test::check_varis_on_stack(stan::math::mdivide_right_ldlt(b, ldlt_Ad));
   test::check_varis_on_stack(stan::math::mdivide_right_ldlt(value_of(b), ldlt_A));
 }

--- a/test/unit/math/rev/mat/fun/mdivide_right_test.cpp
+++ b/test/unit/math/rev/mat/fun/mdivide_right_test.cpp
@@ -37,8 +37,12 @@ TEST(AgradRevMatrix,mdivide_right_val) {
 }
 
 TEST(AgradRevMatrix, check_varis_on_stack) {
+  using stan::math::value_of;
   stan::math::matrix_v m(2,2);
   m << 2.0, 3.0, 
     5.0, 7.0;
+
   test::check_varis_on_stack(stan::math::mdivide_right(m, m));
+  test::check_varis_on_stack(stan::math::mdivide_right(m, value_of(m)));
+  test::check_varis_on_stack(stan::math::mdivide_right(value_of(m), m));
 }

--- a/test/unit/math/rev/mat/fun/mdivide_right_test.cpp
+++ b/test/unit/math/rev/mat/fun/mdivide_right_test.cpp
@@ -1,6 +1,7 @@
 #include <stan/math/rev/mat.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/math/rev/mat/fun/util.hpp>
+#include <test/unit/math/rev/mat/util.hpp>
 
 TEST(AgradRevMatrix,mdivide_right_val) {
   using stan::math::matrix_d;
@@ -33,4 +34,11 @@ TEST(AgradRevMatrix,mdivide_right_val) {
   EXPECT_NEAR(0.0,I(0,1).val(),1.0E-12);
   EXPECT_NEAR(0.0,I(1,0).val(),1.0E-12);
   EXPECT_NEAR(1.0,I(1,1).val(),1.0e-12);
+}
+
+TEST(AgradRevMatrix, check_varis_on_stack) {
+  stan::math::matrix_v m(2,2);
+  m << 2.0, 3.0, 
+    5.0, 7.0;
+  test::check_varis_on_stack(stan::math::mdivide_right(m, m));
 }

--- a/test/unit/math/rev/mat/fun/mean_test.cpp
+++ b/test/unit/math/rev/mat/fun/mean_test.cpp
@@ -1,6 +1,7 @@
 #include <stan/math/rev/mat.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/math/rev/mat/fun/util.hpp>
+#include <test/unit/math/rev/mat/util.hpp>
 
 TEST(AgradRevMatrix, mean_vector) {
   using stan::math::mean;
@@ -101,4 +102,15 @@ TEST(AgradRevMatrix, meanStdVector) {
   EXPECT_FLOAT_EQ(0.5, grad[0]);
   EXPECT_FLOAT_EQ(0.5, grad[1]);
   EXPECT_EQ(2U, grad.size());
+}
+TEST(AgradRevMatrix, check_varis_on_stack) {
+  stan::math::vector_v v(3);
+  v << -100, 0, 1;
+  stan::math::row_vector_v rv(3);
+  rv << -100, 0, 1;
+  stan::math::matrix_v m(2, 3);
+  m << -100, 0, 1, 20, -40, 2;
+  test::check_varis_on_stack(stan::math::mean(v));
+  test::check_varis_on_stack(stan::math::mean(rv));
+  test::check_varis_on_stack(stan::math::mean(m));
 }

--- a/test/unit/math/rev/mat/fun/min_test.cpp
+++ b/test/unit/math/rev/mat/fun/min_test.cpp
@@ -1,6 +1,7 @@
 #include <stan/math/rev/mat.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/math/rev/mat/fun/util.hpp>
+#include <test/unit/math/rev/mat/util.hpp>
 
 TEST(AgradRevMatrix, min_vector) {
   using stan::math::min;
@@ -80,4 +81,16 @@ TEST(AgradRevMatrix, min_matrix_exception) {
 
   matrix_v v;
   EXPECT_FLOAT_EQ(std::numeric_limits<double>::infinity(), min(v).val());
+}
+TEST(AgradRevMatrix, check_varis_on_stack) {
+  stan::math::vector_v v(3);
+  v << -100, 0, 1;
+  stan::math::row_vector_v rv(3);
+  rv << -100, 0, 1;
+  stan::math::matrix_v m(2, 3);
+  m << -100, 0, 1, 20, -40, 2;
+  
+  test::check_varis_on_stack(stan::math::min(v));
+  test::check_varis_on_stack(stan::math::min(rv));
+  test::check_varis_on_stack(stan::math::min(m));
 }

--- a/test/unit/math/rev/mat/fun/minus_test.cpp
+++ b/test/unit/math/rev/mat/fun/minus_test.cpp
@@ -1,6 +1,7 @@
 #include <stan/math/rev/mat.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/math/rev/mat/fun/util.hpp>
+#include <test/unit/math/rev/mat/util.hpp>
 
 TEST(AgradRevMatrix, minus_scalar) {
   using stan::math::minus;
@@ -82,4 +83,18 @@ TEST(AgradRevMatrix, minus_matrix) {
   EXPECT_FLOAT_EQ(-20, output(1,0).val());
   EXPECT_FLOAT_EQ( 40, output(1,1).val());
   EXPECT_FLOAT_EQ( -2, output(1,2).val());
+}
+TEST(AgradRevMatrix, check_varis_on_stack) {
+  stan::math::var x = 10;
+  stan::math::vector_v v(3);
+  v << -100, 0, 1;
+  stan::math::row_vector_v rv(3);
+  rv << -100, 0, 1;
+  stan::math::matrix_v m(2, 3);
+  m << -100, 0, 1, 20, -40, 2;
+  
+  test::check_varis_on_stack(stan::math::minus(x));
+  test::check_varis_on_stack(stan::math::minus(v));
+  test::check_varis_on_stack(stan::math::minus(rv));
+  test::check_varis_on_stack(stan::math::minus(m));
 }

--- a/test/unit/math/rev/mat/fun/multiply_lower_tri_self_transpose_test.cpp
+++ b/test/unit/math/rev/mat/fun/multiply_lower_tri_self_transpose_test.cpp
@@ -2,6 +2,7 @@
 #include <gtest/gtest.h>
 #include <test/unit/math/rev/mat/fun/util.hpp>
 #include <test/unit/math/rev/mat/fun/jacobian.hpp>
+#include <test/unit/math/rev/mat/util.hpp>
 
 stan::math::matrix_v generate_large_L_tri_mat(){
   using stan::math::matrix_v;
@@ -265,4 +266,14 @@ TEST(AgradRevMatrix, multiplyLowerTriSelfTranspose) {
 
   matrix_v K(0,0);
   test_mult_LLT(K);
+}
+TEST(AgradRevMatrix, check_varis_on_stack) {
+  using stan::math::matrix_v;
+
+  stan::math::matrix_v L(3, 3);
+  L << 1, 0, 0,   
+    2, 3, 0,   
+    4, 5, 6;
+
+  test::check_varis_on_stack(stan::math::multiply_lower_tri_self_transpose(L));
 }

--- a/test/unit/math/rev/mat/fun/multiply_test.cpp
+++ b/test/unit/math/rev/mat/fun/multiply_test.cpp
@@ -1671,6 +1671,7 @@ TEST(AgradRevMatrix, multiply_vector_row_vector_grad_ex_vd) {
   }
 }
 TEST(AgradRevMatrix, check_varis_on_stack) {
+  using stan::math::value_of;
   stan::math::matrix_v m(3, 3);
   m << 1, 2, 3, 4, 5, 6, 7, 8, 9;
   stan::math::vector_v v(3);
@@ -1678,15 +1679,48 @@ TEST(AgradRevMatrix, check_varis_on_stack) {
   stan::math::row_vector_v rv(3);
   rv << 100, 200, 300;
   stan::math::var s = 1;
+
   test::check_varis_on_stack(stan::math::multiply(m, m));
+  test::check_varis_on_stack(stan::math::multiply(m, value_of(m)));
+  test::check_varis_on_stack(stan::math::multiply(value_of(m), m));
+
   test::check_varis_on_stack(stan::math::multiply(m, v));
+  test::check_varis_on_stack(stan::math::multiply(m, value_of(v)));
+  test::check_varis_on_stack(stan::math::multiply(value_of(m), v));
+
   test::check_varis_on_stack(stan::math::multiply(rv, m));
+  test::check_varis_on_stack(stan::math::multiply(rv, value_of(m)));
+  test::check_varis_on_stack(stan::math::multiply(value_of(rv), m));
+
   test::check_varis_on_stack(stan::math::multiply(rv, v));
+  test::check_varis_on_stack(stan::math::multiply(rv, value_of(v)));
+  test::check_varis_on_stack(stan::math::multiply(value_of(rv), v));
+
   test::check_varis_on_stack(stan::math::multiply(s, m));
+  test::check_varis_on_stack(stan::math::multiply(s, value_of(m)));
+  test::check_varis_on_stack(stan::math::multiply(value_of(s), m));
+
   test::check_varis_on_stack(stan::math::multiply(s, rv));
+  test::check_varis_on_stack(stan::math::multiply(s, value_of(rv)));
+  test::check_varis_on_stack(stan::math::multiply(value_of(s), rv));
+
   test::check_varis_on_stack(stan::math::multiply(s, v));
+  test::check_varis_on_stack(stan::math::multiply(s, value_of(v)));
+  test::check_varis_on_stack(stan::math::multiply(value_of(s), v));
+
   test::check_varis_on_stack(stan::math::multiply(m, s));
+  test::check_varis_on_stack(stan::math::multiply(m, value_of(s)));
+  test::check_varis_on_stack(stan::math::multiply(value_of(m), s));
+
   test::check_varis_on_stack(stan::math::multiply(rv, s));
+  test::check_varis_on_stack(stan::math::multiply(rv, value_of(s)));
+  test::check_varis_on_stack(stan::math::multiply(value_of(rv), s));
+
   test::check_varis_on_stack(stan::math::multiply(v, s));
+  test::check_varis_on_stack(stan::math::multiply(v, value_of(s)));
+  test::check_varis_on_stack(stan::math::multiply(value_of(v), s));
+
   test::check_varis_on_stack(stan::math::multiply(s, s));
+  test::check_varis_on_stack(stan::math::multiply(s, value_of(s)));
+  test::check_varis_on_stack(stan::math::multiply(value_of(s), s));
 }

--- a/test/unit/math/rev/mat/fun/multiply_test.cpp
+++ b/test/unit/math/rev/mat/fun/multiply_test.cpp
@@ -1,6 +1,7 @@
 #include <stan/math/rev/mat.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/math/rev/mat/fun/util.hpp>
+#include <test/unit/math/rev/mat/util.hpp>
 
 // multiply operates on two matrices A X B 
 // A (n, m)
@@ -1668,4 +1669,24 @@ TEST(AgradRevMatrix, multiply_vector_row_vector_grad_ex_vd) {
       EXPECT_FLOAT_EQ((grad_A - grad_A_ex).lpNorm<Infinity>(), 0);
     }
   }
+}
+TEST(AgradRevMatrix, check_varis_on_stack) {
+  stan::math::matrix_v m(3, 3);
+  m << 1, 2, 3, 4, 5, 6, 7, 8, 9;
+  stan::math::vector_v v(3);
+  v << 10, 20, 30;
+  stan::math::row_vector_v rv(3);
+  rv << 100, 200, 300;
+  stan::math::var s = 1;
+  test::check_varis_on_stack(stan::math::multiply(m, m));
+  test::check_varis_on_stack(stan::math::multiply(m, v));
+  test::check_varis_on_stack(stan::math::multiply(rv, m));
+  test::check_varis_on_stack(stan::math::multiply(rv, v));
+  test::check_varis_on_stack(stan::math::multiply(s, m));
+  test::check_varis_on_stack(stan::math::multiply(s, rv));
+  test::check_varis_on_stack(stan::math::multiply(s, v));
+  test::check_varis_on_stack(stan::math::multiply(m, s));
+  test::check_varis_on_stack(stan::math::multiply(rv, s));
+  test::check_varis_on_stack(stan::math::multiply(v, s));
+  test::check_varis_on_stack(stan::math::multiply(s, s));
 }

--- a/test/unit/math/rev/mat/fun/ordered_transform_test.cpp
+++ b/test/unit/math/rev/mat/fun/ordered_transform_test.cpp
@@ -47,7 +47,10 @@ TEST(prob_transform,ordered_jacobian_ad) {
 
 TEST(AgradRevMatrix, check_varis_on_stack) {
   Eigen::Matrix<stan::math::var,Eigen::Dynamic,1> x(3);
+
   x << -12.0, 3.0, -1.9;
   stan::math::var lp = 0.0;
-  test::check_varis_on_stack(stan::math::ordered_constrain(x,lp));
+
+  test::check_varis_on_stack(stan::math::ordered_constrain(x, lp));
+  test::check_varis_on_stack(stan::math::ordered_constrain(x));
 }

--- a/test/unit/math/rev/mat/fun/ordered_transform_test.cpp
+++ b/test/unit/math/rev/mat/fun/ordered_transform_test.cpp
@@ -1,6 +1,7 @@
 #include <stan/math/rev/mat.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/math/rev/mat/fun/jacobian.hpp>
+#include <test/unit/math/rev/mat/util.hpp>
 
 TEST(prob_transform,ordered_jacobian_ad) {
   using stan::math::var;
@@ -44,3 +45,9 @@ TEST(prob_transform,ordered_jacobian_ad) {
   EXPECT_FLOAT_EQ(log_abs_jacobian_det, lp);
 }
 
+TEST(AgradRevMatrix, check_varis_on_stack) {
+  Eigen::Matrix<stan::math::var,Eigen::Dynamic,1> x(3);
+  x << -12.0, 3.0, -1.9;
+  stan::math::var lp = 0.0;
+  test::check_varis_on_stack(stan::math::ordered_constrain(x,lp));
+}

--- a/test/unit/math/rev/mat/fun/positive_ordered_transform_test.cpp
+++ b/test/unit/math/rev/mat/fun/positive_ordered_transform_test.cpp
@@ -1,6 +1,7 @@
 #include <stan/math/rev/mat.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/math/rev/mat/fun/jacobian.hpp>
+#include <test/unit/math/rev/mat/util.hpp>
 
 TEST(prob_transform,positive_ordered_jacobian_ad) {
   using stan::math::var;
@@ -42,4 +43,11 @@ TEST(prob_transform,positive_ordered_jacobian_ad) {
   
   double log_abs_jacobian_det = log(fabs(determinant(J)));
   EXPECT_FLOAT_EQ(log_abs_jacobian_det, lp);
+}
+
+TEST(AgradRevMatrix, check_varis_on_stack) {
+  Eigen::Matrix<stan::math::var,Eigen::Dynamic,1> x(3);
+  x << -12.0, 3.0, -1.9;
+  stan::math::var lp = 0.0;
+  test::check_varis_on_stack(stan::math::positive_ordered_constrain(x,lp));
 }

--- a/test/unit/math/rev/mat/fun/positive_ordered_transform_test.cpp
+++ b/test/unit/math/rev/mat/fun/positive_ordered_transform_test.cpp
@@ -49,5 +49,7 @@ TEST(AgradRevMatrix, check_varis_on_stack) {
   Eigen::Matrix<stan::math::var,Eigen::Dynamic,1> x(3);
   x << -12.0, 3.0, -1.9;
   stan::math::var lp = 0.0;
-  test::check_varis_on_stack(stan::math::positive_ordered_constrain(x,lp));
+
+  test::check_varis_on_stack(stan::math::positive_ordered_constrain(x, lp));
+  test::check_varis_on_stack(stan::math::positive_ordered_constrain(x));
 }

--- a/test/unit/math/rev/mat/fun/prod_test.cpp
+++ b/test/unit/math/rev/mat/fun/prod_test.cpp
@@ -1,6 +1,7 @@
 #include <stan/math/rev/mat.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/math/rev/mat/fun/util.hpp>
+#include <test/unit/math/rev/mat/util.hpp>
 
 TEST(AgradRevMatrix,prod) {
   using stan::math::prod;
@@ -33,4 +34,9 @@ TEST(AgradRevMatrix,prod) {
   f.grad(x,g);
   EXPECT_FLOAT_EQ(3.0,g[0]);
   EXPECT_FLOAT_EQ(2.0,g[1]);
+}
+TEST(AgradRevMatrix, check_varis_on_stack) {
+  stan::math::vector_v v(1);
+  v << 2.0;
+  test::check_varis_on_stack(stan::math::prod(v));
 }

--- a/test/unit/math/rev/mat/fun/qr_Q_test.cpp
+++ b/test/unit/math/rev/mat/fun/qr_Q_test.cpp
@@ -1,6 +1,7 @@
 #include <stan/math/rev/mat.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/math/rev/mat/fun/util.hpp>
+#include <test/unit/math/rev/mat/util.hpp>
 
 TEST(MathMatrix, qr_Q) {
   stan::math::matrix_v m0(0,0);
@@ -12,4 +13,9 @@ TEST(MathMatrix, qr_Q) {
   EXPECT_THROW(qr_Q(m0),std::invalid_argument);
   EXPECT_NO_THROW(qr_Q(m1));
   EXPECT_THROW(qr_Q(transpose(m1)),std::domain_error);
+}
+TEST(AgradRevMatrix, check_varis_on_stack) {
+  stan::math::matrix_v m1(3,2);
+  m1 << 1, 2, 3, 4, 5, 6;
+  test::check_varis_on_stack(stan::math::qr_Q(m1));
 }

--- a/test/unit/math/rev/mat/fun/qr_R_test.cpp
+++ b/test/unit/math/rev/mat/fun/qr_R_test.cpp
@@ -1,6 +1,7 @@
 #include <stan/math/rev/mat.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/math/rev/mat/fun/util.hpp>
+#include <test/unit/math/rev/mat/util.hpp>
 
 TEST(MathMatrix, qr_R) {
   stan::math::matrix_v m0(0,0);
@@ -21,4 +22,9 @@ TEST(MathMatrix, qr_R) {
     }
   }
   EXPECT_THROW(qr_R(transpose(m1)),std::domain_error);
+}
+TEST(AgradRevMatrix, check_varis_on_stack) {
+  stan::math::matrix_v m1(3,2);
+  m1 << 1, 2, 3, 4, 5, 6;
+  test::check_varis_on_stack(stan::math::qr_R(m1));
 }

--- a/test/unit/math/rev/mat/fun/quad_form_diag_test.cpp
+++ b/test/unit/math/rev/mat/fun/quad_form_diag_test.cpp
@@ -2,6 +2,7 @@
 #include <gtest/gtest.h>
 #include <vector>
 #include <test/unit/math/rev/mat/fun/expect_matrix_eq.hpp>
+#include <test/unit/math/rev/mat/util.hpp>
 
 using Eigen::Matrix;
 using Eigen::Dynamic;
@@ -221,4 +222,16 @@ TEST(MathMatrix,quadFormDiagException) {
   Matrix<var,Dynamic,1> v(3);
   v << 1, 2, 3;
   EXPECT_THROW(quad_form_diag(m,v), std::domain_error);
+}
+
+TEST(AgradRevMatrix, check_varis_on_stack) {
+  using stan::math::to_var;
+  stan::math::matrix_d m(3,3);
+  m << 1, 2, 3, 4, 5, 6, 7, 8, 9;
+
+  stan::math::vector_d v(3);
+  v << 1, 2, 3;
+  test::check_varis_on_stack(stan::math::quad_form_diag(to_var(m), to_var(v)));
+  test::check_varis_on_stack(stan::math::quad_form_diag(to_var(m), v));
+  test::check_varis_on_stack(stan::math::quad_form_diag(m, to_var(v)));
 }

--- a/test/unit/math/rev/mat/fun/quad_form_test.cpp
+++ b/test/unit/math/rev/mat/fun/quad_form_test.cpp
@@ -1,6 +1,7 @@
 #include <stan/math/rev/mat.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/math/rev/mat/fun/util.hpp>
+#include <test/unit/math/rev/mat/util.hpp>
 
 TEST(AgradRevMatrix, quad_form_mat) {
   using stan::math::quad_form;
@@ -768,3 +769,19 @@ TEST(AgradRevMatrix, quad_form_sym_vec_grad_vv) {
       EXPECT_FLOAT_EQ(grad[pos], dqda(i,j));
 }
 
+TEST(AgradRevMatrix, check_varis_on_stack) {
+  using stan::math::to_var;
+  stan::math::matrix_d a(4,4);
+  stan::math::matrix_d b(4,2);
+  a << 2.0,  3.0, 4.0,   5.0, 
+    6.0, 10.0, 2.0,   2.0,
+    7.0,  2.0, 7.0,   1.0,
+    8.0,  2.0, 1.0, 112.0;
+  b << 100, 10,
+    0,  1,
+    -3, -3,
+    5,  2;
+  test::check_varis_on_stack(stan::math::quad_form(to_var(a), to_var(b)));
+  test::check_varis_on_stack(stan::math::quad_form(to_var(a), b));
+  test::check_varis_on_stack(stan::math::quad_form(a, to_var(b)));
+}

--- a/test/unit/math/rev/mat/fun/row_test.cpp
+++ b/test/unit/math/rev/mat/fun/row_test.cpp
@@ -1,6 +1,7 @@
 #include <stan/math/rev/mat.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/math/rev/mat/fun/util.hpp>
+#include <test/unit/math/rev/mat/util.hpp>
 
 TEST(AgradRevMatrix,row_v) {
   using stan::math::row;
@@ -38,4 +39,11 @@ TEST(AgradRevMatrix,row_v_excHigh) {
   y << 1, 2, 3, 4, 5, 6;
   EXPECT_THROW(row(y,0),std::out_of_range);
   EXPECT_THROW(row(y,5),std::out_of_range);
+}
+
+TEST(AgradRevMatrix, check_varis_on_stack) {
+  stan::math::matrix_v y(2,3);
+  y << 1, 2, 3, 4, 5, 6;
+
+  test::check_varis_on_stack(stan::math::row(y, 1));
 }

--- a/test/unit/math/rev/mat/fun/sd_test.cpp
+++ b/test/unit/math/rev/mat/fun/sd_test.cpp
@@ -1,9 +1,8 @@
 #include <stan/math/rev/mat.hpp>
 #include <gtest/gtest.h>
-
 #include <iostream>
-
 #include <test/unit/math/rev/mat/fun/util.hpp>
+#include <test/unit/math/rev/mat/util.hpp>
 
 TEST(AgradRevMatrix, sd_eq) {
   using stan::math::sd;
@@ -187,4 +186,9 @@ TEST(AgradRevSd, finiteDiffsMatchAnalytic) {
     double finite_diff = (sd_y_plus_epsilon - sd_y) / epsilon;
     EXPECT_FLOAT_EQ(analytic, finite_diff);
   }
+}
+TEST(AgradRevMatrix, check_varis_on_stack) {
+  stan::math::vector_v v(6);
+  v << 1, 2, 3, 4, 5, 6;
+  test::check_varis_on_stack(stan::math::sd(v));
 }

--- a/test/unit/math/rev/mat/fun/simplex_transform_test.cpp
+++ b/test/unit/math/rev/mat/fun/simplex_transform_test.cpp
@@ -48,4 +48,5 @@ TEST(AgradRevMatrix, check_varis_on_stack) {
   y << 2, 3, -1;
   stan::math::var lp = 0;
   test::check_varis_on_stack(stan::math::simplex_constrain(y, lp));
+  test::check_varis_on_stack(stan::math::simplex_constrain(y));
 }

--- a/test/unit/math/rev/mat/fun/simplex_transform_test.cpp
+++ b/test/unit/math/rev/mat/fun/simplex_transform_test.cpp
@@ -1,6 +1,7 @@
 #include <stan/math/rev/mat.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/math/rev/mat/fun/jacobian.hpp>
+#include <test/unit/math/rev/mat/util.hpp>
 
 using Eigen::Matrix;
 using Eigen::Dynamic;
@@ -41,4 +42,10 @@ TEST(probTransform,simplex_jacobian) {
   double log_det_J = log(det_J);
 
   EXPECT_FLOAT_EQ(log_det_J, lp.val());
+}
+TEST(AgradRevMatrix, check_varis_on_stack) {
+  stan::math::vector_v y(3);
+  y << 2, 3, -1;
+  stan::math::var lp = 0;
+  test::check_varis_on_stack(stan::math::simplex_constrain(y, lp));
 }

--- a/test/unit/math/rev/mat/fun/softmax_test.cpp
+++ b/test/unit/math/rev/mat/fun/softmax_test.cpp
@@ -1,6 +1,7 @@
 #include <stan/math/rev/mat.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/math/rev/mat/fun/util.hpp>
+#include <test/unit/math/rev/mat/util.hpp>
 
 TEST(AgradRevMatrix,softmaxLeak) {
   // FIXME: very brittle test depending on unrelated constants of 
@@ -102,4 +103,9 @@ TEST(AgradRevSoftmax, Grad) {
     for (size_t i = 0; i < grad_expected.size(); ++i)
       EXPECT_FLOAT_EQ(grad_expected[i], grad[i]);
   }
+}
+TEST(AgradRevMatrix, check_varis_on_stack) {
+  Eigen::Matrix<stan::math::var,Eigen::Dynamic,1> alpha(3);
+  alpha << 0.0, 3.0, -1.0;
+  test::check_varis_on_stack(stan::math::softmax(alpha));
 }

--- a/test/unit/math/rev/mat/fun/sort_test.cpp
+++ b/test/unit/math/rev/mat/fun/sort_test.cpp
@@ -2,8 +2,7 @@
 #include <gtest/gtest.h>
 #include <test/unit/math/rev/mat/fun/util.hpp>
 #include <test/unit/math/prim/mat/fun/sort_test_util.hpp>
-
-
+#include <test/unit/math/rev/mat/util.hpp>
 
 void test_sort_asc(VEC val) {
   using stan::math::sort_asc;
@@ -189,4 +188,15 @@ TEST(MathMatrix, sortDescEigenVecNan) {
 }
 TEST(MathMatrix, sortDescEigenRowVecNan) {
   test_sort_desc_throws<Eigen::Matrix<stan::math::var, 1, -1> >();
+}
+TEST(AgradRevMatrix, check_varis_on_stack) {
+  using stan::math::var;
+  using stan::math::to_var;
+
+  std::vector<stan::math::var> x(3);
+  x[0] = 0;
+  x[1] = 2;
+  x[2] = 100;
+  test::check_varis_on_stack(stan::math::sort_asc(x));
+  test::check_varis_on_stack(stan::math::sort_desc(x));
 }

--- a/test/unit/math/rev/mat/fun/squared_distance_test.cpp
+++ b/test/unit/math/rev/mat/fun/squared_distance_test.cpp
@@ -1,6 +1,7 @@
 #include <stan/math/rev/mat.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/math/rev/mat/fun/util.hpp>
+#include <test/unit/math/rev/mat/util.hpp>
 
 TEST(AgradRevMatrix, squared_distance_vector_vector) {
   using stan::math::vector_d;
@@ -199,4 +200,15 @@ TEST(AgradRevMatrix, squared_distance_vd) {
   EXPECT_FLOAT_EQ(2*(a(0).val() - b(0)), grad[0]);
   EXPECT_FLOAT_EQ(2*(a(1).val() - b(1)), grad[1]);
   EXPECT_FLOAT_EQ(2*(a(2).val() - b(2)), grad[2]);
+}
+TEST(AgradRevMatrix, check_varis_on_stack) {
+  using stan::math::to_var;
+  stan::math::vector_d v1(3), v2(3);
+  
+  v1 << 1, 3, -5;
+  v2 << 4, -2, -1;
+  
+  test::check_varis_on_stack(stan::math::squared_distance(to_var(v1), to_var(v2)));
+  test::check_varis_on_stack(stan::math::squared_distance(to_var(v1), v2));
+  test::check_varis_on_stack(stan::math::squared_distance(v1, to_var(v2)));
 }

--- a/test/unit/math/rev/mat/fun/stored_gradient_vari_test.cpp
+++ b/test/unit/math/rev/mat/fun/stored_gradient_vari_test.cpp
@@ -1,7 +1,7 @@
 #include <stan/math/rev/mat.hpp>
 #include <gtest/gtest.h>
-
 #include <vector>
+#include <test/unit/math/rev/mat/util.hpp>
 
 TEST(StoredGradientVari, propagate3) {
   using stan::math::var;
@@ -58,4 +58,23 @@ TEST(StoredGradientVari, propagate0) {
   EXPECT_EQ(3U, g.size());
   for (int i = 0; i < 3; ++i)
     EXPECT_FLOAT_EQ(0, g[i]);
+}
+TEST(AgradRevMatrix, check_varis_on_stack) {
+  using stan::math::var;
+  using stan::math::vari;
+  vari** xs
+    = (vari**) stan::math::ChainableStack::memalloc_.alloc(3 * sizeof(vari*));
+  var xs1 = 1; // value not used here
+  var xs2 = 4; // value not used here
+  var xs3 = 9; // value not used here
+  xs[0] = xs1.vi_;
+  xs[1] = xs2.vi_;
+  xs[2] = xs3.vi_;
+  double* partials = (double*) stan::math::ChainableStack::memalloc_.alloc(3 * sizeof(double));
+  partials[0] = 10;
+  partials[1] = 100;
+  partials[2] = 1000;
+
+  var sum = var(new stan::math::stored_gradient_vari(-14.7, 3, xs, partials));
+  test::check_varis_on_stack(sum);
 }

--- a/test/unit/math/rev/mat/fun/subtract_test.cpp
+++ b/test/unit/math/rev/mat/fun/subtract_test.cpp
@@ -1,6 +1,7 @@
 #include <stan/math/rev/mat.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/math/rev/mat/fun/util.hpp>
+#include <test/unit/math/rev/mat/util.hpp>
 
 TEST(AgradRevMatrix,subtract_scalar) {
   using stan::math::subtract;
@@ -198,4 +199,20 @@ TEST(AgradRevMatrix, subtract_matrix_matrix_exception) {
   EXPECT_THROW( subtract(d1, v2), std::invalid_argument);
   EXPECT_THROW( subtract(v1, d2), std::invalid_argument);
   EXPECT_THROW( subtract(v1, v2), std::invalid_argument);
+}
+TEST(AgradRevMatrix, check_varis_on_stack) {
+  stan::math::matrix_v m(2, 2);
+  m << 1, 2, 3, 4;
+
+  stan::math::vector_v v(3);
+  v << 1, 2, 3;
+
+  stan::math::row_vector_v rv(2);
+  rv << 1, 2;
+
+  test::check_varis_on_stack(stan::math::subtract(m, m));
+  test::check_varis_on_stack(stan::math::subtract(v, v));
+  test::check_varis_on_stack(stan::math::subtract(rv, rv));
+  test::check_varis_on_stack(stan::math::subtract(m, 2.0));
+  test::check_varis_on_stack(stan::math::subtract(1.0, m));
 }

--- a/test/unit/math/rev/mat/fun/subtract_test.cpp
+++ b/test/unit/math/rev/mat/fun/subtract_test.cpp
@@ -201,6 +201,7 @@ TEST(AgradRevMatrix, subtract_matrix_matrix_exception) {
   EXPECT_THROW( subtract(v1, v2), std::invalid_argument);
 }
 TEST(AgradRevMatrix, check_varis_on_stack) {
+  using stan::math::value_of;
   stan::math::matrix_v m(2, 2);
   m << 1, 2, 3, 4;
 
@@ -210,9 +211,41 @@ TEST(AgradRevMatrix, check_varis_on_stack) {
   stan::math::row_vector_v rv(2);
   rv << 1, 2;
 
+  stan::math::var s(2);
+
   test::check_varis_on_stack(stan::math::subtract(m, m));
+  test::check_varis_on_stack(stan::math::subtract(m, value_of(m)));
+  test::check_varis_on_stack(stan::math::subtract(value_of(m), m));
+
   test::check_varis_on_stack(stan::math::subtract(v, v));
+  test::check_varis_on_stack(stan::math::subtract(v, value_of(v)));
+  test::check_varis_on_stack(stan::math::subtract(value_of(v), v));
+
   test::check_varis_on_stack(stan::math::subtract(rv, rv));
-  test::check_varis_on_stack(stan::math::subtract(m, 2.0));
-  test::check_varis_on_stack(stan::math::subtract(1.0, m));
+  test::check_varis_on_stack(stan::math::subtract(rv, value_of(rv)));
+  test::check_varis_on_stack(stan::math::subtract(value_of(rv), rv));
+
+  test::check_varis_on_stack(stan::math::subtract(m, s));
+  test::check_varis_on_stack(stan::math::subtract(m, value_of(s)));
+  test::check_varis_on_stack(stan::math::subtract(value_of(m), s));
+
+  test::check_varis_on_stack(stan::math::subtract(v, s));
+  test::check_varis_on_stack(stan::math::subtract(v, value_of(s)));
+  test::check_varis_on_stack(stan::math::subtract(value_of(v), s));
+
+  test::check_varis_on_stack(stan::math::subtract(rv, s));
+  test::check_varis_on_stack(stan::math::subtract(rv, value_of(s)));
+  test::check_varis_on_stack(stan::math::subtract(value_of(rv), s));
+
+  test::check_varis_on_stack(stan::math::subtract(s, m));
+  test::check_varis_on_stack(stan::math::subtract(s, value_of(m)));
+  test::check_varis_on_stack(stan::math::subtract(value_of(s), m));
+
+  test::check_varis_on_stack(stan::math::subtract(s, v));
+  test::check_varis_on_stack(stan::math::subtract(s, value_of(v)));
+  test::check_varis_on_stack(stan::math::subtract(value_of(s), v));
+
+  test::check_varis_on_stack(stan::math::subtract(s, rv));
+  test::check_varis_on_stack(stan::math::subtract(s, value_of(rv)));
+  test::check_varis_on_stack(stan::math::subtract(value_of(s), rv));
 }

--- a/test/unit/math/rev/mat/fun/sum_test.cpp
+++ b/test/unit/math/rev/mat/fun/sum_test.cpp
@@ -1,6 +1,7 @@
 #include <stan/math/rev/mat.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/math/rev/mat/fun/util.hpp>
+#include <test/unit/math/rev/mat/util.hpp>
 
 TEST(AgradRevMatrix, sum_vector) {
   using stan::math::sum;
@@ -79,4 +80,19 @@ TEST(AgradRevMatrix, sum_matrix) {
   v.resize(0, 0);
   EXPECT_FLOAT_EQ(0.0, sum(d));
   EXPECT_FLOAT_EQ(0.0, sum(v).val());
+}
+
+TEST(AgradRevMatrix, check_varis_on_stack) {
+  stan::math::matrix_v m(2, 2);
+  m << 1, 2, 3, 4;
+
+  stan::math::vector_v v(3);
+  v << 1, 2, 3;
+
+  stan::math::row_vector_v rv(2);
+  rv << 1, 2;
+
+  test::check_varis_on_stack(stan::math::sum(m));
+  test::check_varis_on_stack(stan::math::sum(v));
+  test::check_varis_on_stack(stan::math::sum(rv));
 }

--- a/test/unit/math/rev/mat/fun/tcrossprod_test.cpp
+++ b/test/unit/math/rev/mat/fun/tcrossprod_test.cpp
@@ -2,6 +2,7 @@
 #include <gtest/gtest.h>
 #include <test/unit/math/rev/mat/fun/util.hpp>
 #include <test/unit/math/rev/mat/fun/jacobian.hpp>
+#include <test/unit/math/rev/mat/util.hpp>
 
 void test_tcrossprod(const stan::math::matrix_v& L) {
   using stan::math::matrix_v;
@@ -235,4 +236,13 @@ TEST(AgradRevMatrix, tcrossprodGrad3) {
   EXPECT_FLOAT_EQ(8.0,J[8][3]);
   EXPECT_FLOAT_EQ(10.0,J[8][4]);
   EXPECT_FLOAT_EQ(12.0,J[8][5]);
+}
+
+TEST(AgradRevMatrix, check_varis_on_stack) {
+  stan::math::matrix_v L(3,3);
+  L << 1, 0, 0,
+    2, 3, 0,
+    4, 5, 6;
+
+  test::check_varis_on_stack(stan::math::tcrossprod(L));
 }

--- a/test/unit/math/rev/mat/fun/to_var_test.cpp
+++ b/test/unit/math/rev/mat/fun/to_var_test.cpp
@@ -1,6 +1,7 @@
 #include <stan/math/rev/mat.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/math/rev/mat/fun/util.hpp>
+#include <test/unit/math/rev/mat/util.hpp>
 
 TEST(AgradRevMatrix,to_var_scalar) {
   double d = 5.0;
@@ -74,3 +75,17 @@ TEST(AgradRevMatrix,to_var_rowvector) {
   EXPECT_FLOAT_EQ(5, output(4).val());
 }
 
+TEST(AgradRevMatrix, check_varis_on_stack) {
+  stan::math::matrix_v m(2, 2);
+  m << 1, 2, 3, 4;
+
+  stan::math::vector_v v(3);
+  v << 1, 2, 3;
+
+  stan::math::row_vector_v rv(2);
+  rv << 1, 2;
+  
+  test::check_varis_on_stack(stan::math::to_var(m));
+  test::check_varis_on_stack(stan::math::to_var(v));
+  test::check_varis_on_stack(stan::math::to_var(rv));
+}

--- a/test/unit/math/rev/mat/fun/trace_gen_quad_form_test.cpp
+++ b/test/unit/math/rev/mat/fun/trace_gen_quad_form_test.cpp
@@ -1,6 +1,7 @@
 #include <stan/math/rev/mat.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/math/rev/mat/fun/util.hpp>
+#include <test/unit/math/rev/mat/util.hpp>
 
 TEST(AgradRevMatrix, trace_gen_quad_form_mat) {
   using stan::math::trace_gen_quad_form;
@@ -475,3 +476,27 @@ TEST(AgradRevMatrix, trace_gen_quad_form_mat_grad_vvv) {
 }
 
 
+TEST(AgradRevMatrix, check_varis_on_stack) {
+  stan::math::matrix_d a(4,4);
+  stan::math::matrix_d b(4,2);
+  stan::math::matrix_d c(2,2);
+
+  b << 100, 10,
+    0,  1,
+    -3, -3,
+    5,  2;
+  a << 2.0,  3.0, 4.0,   5.0, 
+    6.0, 10.0, 2.0,   2.0,
+    7.0,  2.0, 7.0,   1.0,
+    8.0,  2.0, 1.0, 112.0;
+  c.setIdentity(2,2);  
+
+  using stan::math::to_var;
+  test::check_varis_on_stack(stan::math::trace_gen_quad_form(to_var(c), to_var(a), to_var(b)));
+  test::check_varis_on_stack(stan::math::trace_gen_quad_form(to_var(c), to_var(a), b));
+  test::check_varis_on_stack(stan::math::trace_gen_quad_form(to_var(c), a, to_var(b)));
+  test::check_varis_on_stack(stan::math::trace_gen_quad_form(to_var(c), a, b));
+  test::check_varis_on_stack(stan::math::trace_gen_quad_form(c, to_var(a), to_var(b)));
+  test::check_varis_on_stack(stan::math::trace_gen_quad_form(c, to_var(a), b));
+  test::check_varis_on_stack(stan::math::trace_gen_quad_form(c, a, to_var(b)));
+}

--- a/test/unit/math/rev/mat/fun/trace_inv_quad_form_ldlt_test.cpp
+++ b/test/unit/math/rev/mat/fun/trace_inv_quad_form_ldlt_test.cpp
@@ -1,6 +1,7 @@
 #include <stan/math/rev/mat.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/math/rev/mat/fun/util.hpp>
+#include <test/unit/math/rev/mat/util.hpp>
 
 TEST(AgradRevMatrix, trace_inv_quad_form_ldlt_mat) {
   using stan::math::matrix_v;
@@ -426,3 +427,27 @@ TEST(AgradRevMatrix, trace_quad_form_ldlt_dv_basic) {
     EXPECT_FLOAT_EQ(grad_basic[n], grad[n]);
 }
 
+TEST(AgradRevMatrix, check_varis_on_stack) {
+  using stan::math::to_var;
+
+  stan::math::matrix_d a(4,4);
+  stan::math::matrix_d b(4,2);
+  
+  b << 100, 10,
+          0,  1,
+         -3, -3,
+          5,  2;
+  a << 9.0,  3.0, 3.0,   3.0, 
+        3.0, 10.0, 2.0,   2.0,
+        3.0,  2.0, 7.0,   1.0,
+        3.0,  2.0, 1.0, 112.0;
+
+  stan::math::LDLT_factor<double,-1,-1> ldlt_a;
+  stan::math::LDLT_factor<stan::math::var,-1,-1> ldlt_av;
+  ldlt_av.compute(to_var(a));
+  ldlt_a.compute(a);
+  
+  test::check_varis_on_stack(stan::math::trace_inv_quad_form_ldlt(ldlt_av, to_var(b)));
+  test::check_varis_on_stack(stan::math::trace_inv_quad_form_ldlt(ldlt_av, b));
+  test::check_varis_on_stack(stan::math::trace_inv_quad_form_ldlt(ldlt_a, to_var(b)));
+}

--- a/test/unit/math/rev/mat/fun/trace_quad_form_test.cpp
+++ b/test/unit/math/rev/mat/fun/trace_quad_form_test.cpp
@@ -1,6 +1,7 @@
 #include <stan/math/rev/mat.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/math/rev/mat/fun/util.hpp>
+#include <test/unit/math/rev/mat/util.hpp>
 
 TEST(AgradRevMatrix, trace_quad_form_mat) {
   using stan::math::trace_quad_form;
@@ -17,21 +18,21 @@ TEST(AgradRevMatrix, trace_quad_form_mat) {
   
   
   bd << 100, 10,
-          0,  1,
-         -3, -3,
-          5,  2;
+    0,  1,
+    -3, -3,
+    5,  2;
   bv << 100, 10,
-          0,  1,
-         -3, -3,
-          5,  2;
+    0,  1,
+    -3, -3,
+    5,  2;
   ad << 2.0,  3.0, 4.0,   5.0, 
-  6.0, 10.0, 2.0,   2.0,
-  7.0,  2.0, 7.0,   1.0,
-  8.0,  2.0, 1.0, 112.0;
+    6.0, 10.0, 2.0,   2.0,
+    7.0,  2.0, 7.0,   1.0,
+    8.0,  2.0, 1.0, 112.0;
   av << 2.0,  3.0, 4.0,   5.0, 
-  6.0, 10.0, 2.0,   2.0,
-  7.0,  2.0, 7.0,   1.0,
-  8.0,  2.0, 1.0, 112.0;
+    6.0, 10.0, 2.0,   2.0,
+    7.0,  2.0, 7.0,   1.0,
+    8.0,  2.0, 1.0, 112.0;
   
   // double-double
   res = trace_quad_form(ad,bd);
@@ -66,17 +67,17 @@ TEST(AgradRevMatrix, trace_quad_form_mat_grad_vd) {
   
   
   bd << 100, 10,
-  0,  1,
-  -3, -3,
-  5,  2;
+    0,  1,
+    -3, -3,
+    5,  2;
   ad << 2.0,  3.0, 4.0,   5.0, 
-  6.0, 10.0, 2.0,   2.0,
-  7.0,  2.0, 7.0,   1.0,
-  8.0,  2.0, 1.0, 112.0;
+    6.0, 10.0, 2.0,   2.0,
+    7.0,  2.0, 7.0,   1.0,
+    8.0,  2.0, 1.0, 112.0;
   av << 2.0,  3.0, 4.0,   5.0, 
-  6.0, 10.0, 2.0,   2.0,
-  7.0,  2.0, 7.0,   1.0,
-  8.0,  2.0, 1.0, 112.0;
+    6.0, 10.0, 2.0,   2.0,
+    7.0,  2.0, 7.0,   1.0,
+    8.0,  2.0, 1.0, 112.0;
   
   matrix_d dqda(bd*bd.transpose());
   
@@ -110,17 +111,17 @@ TEST(AgradRevMatrix, trace_quad_form_mat_grad_dv) {
   
   
   bd << 100, 10,
-  0,  1,
-  -3, -3,
-  5,  2;
+    0,  1,
+    -3, -3,
+    5,  2;
   bv << 100, 10,
-  0,  1,
-  -3, -3,
-  5,  2;
+    0,  1,
+    -3, -3,
+    5,  2;
   ad << 2.0,  3.0, 4.0,   5.0, 
-  6.0, 10.0, 2.0,   2.0,
-  7.0,  2.0, 7.0,   1.0,
-  8.0,  2.0, 1.0, 112.0;
+    6.0, 10.0, 2.0,   2.0,
+    7.0,  2.0, 7.0,   1.0,
+    8.0,  2.0, 1.0, 112.0;
   
   matrix_d dqdb(ad*bd + ad.transpose()*bd);
   
@@ -155,21 +156,21 @@ TEST(AgradRevMatrix, trace_quad_form_mat_grad_vv) {
   
   
   bd << 100, 10,
-  0,  1,
-  -3, -3,
-  5,  2;
+    0,  1,
+    -3, -3,
+    5,  2;
   bv << 100, 10,
-  0,  1,
-  -3, -3,
-  5,  2;
+    0,  1,
+    -3, -3,
+    5,  2;
   ad << 2.0,  3.0, 4.0,   5.0, 
-  6.0, 10.0, 2.0,   2.0,
-  7.0,  2.0, 7.0,   1.0,
-  8.0,  2.0, 1.0, 112.0;
+    6.0, 10.0, 2.0,   2.0,
+    7.0,  2.0, 7.0,   1.0,
+    8.0,  2.0, 1.0, 112.0;
   av << 2.0,  3.0, 4.0,   5.0, 
-  6.0, 10.0, 2.0,   2.0,
-  7.0,  2.0, 7.0,   1.0,
-  8.0,  2.0, 1.0, 112.0;
+    6.0, 10.0, 2.0,   2.0,
+    7.0,  2.0, 7.0,   1.0,
+    8.0,  2.0, 1.0, 112.0;
   
   matrix_d dqda(bd*bd.transpose());
   matrix_d dqdb(ad*bd + ad.transpose()*bd);
@@ -194,3 +195,21 @@ TEST(AgradRevMatrix, trace_quad_form_mat_grad_vv) {
       EXPECT_FLOAT_EQ(grad[pos], dqda(i,j));
 }
 
+TEST(AgradRevMatrix, check_varis_on_stack) {
+  using stan::math::to_var;
+
+  stan::math::matrix_d a(4,4);
+  stan::math::matrix_d b(4,2);
+  b << 100, 10,
+    0,  1,
+    -3, -3,
+    5,  2;
+  a << 2.0,  3.0, 4.0,   5.0, 
+    6.0, 10.0, 2.0,   2.0,
+    7.0,  2.0, 7.0,   1.0,
+    8.0,  2.0, 1.0, 112.0;
+  
+  test::check_varis_on_stack(stan::math::trace_quad_form(to_var(a), to_var(b)));
+  test::check_varis_on_stack(stan::math::trace_quad_form(to_var(a), b));
+  test::check_varis_on_stack(stan::math::trace_quad_form(a, to_var(b)));
+}

--- a/test/unit/math/rev/mat/fun/trace_test.cpp
+++ b/test/unit/math/rev/mat/fun/trace_test.cpp
@@ -1,6 +1,7 @@
 #include <stan/math/rev/mat.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/math/rev/mat/fun/util.hpp>
+#include <test/unit/math/rev/mat/util.hpp>
 
 TEST(AgradRevMatrix,mv_trace) {
   using stan::math::trace;
@@ -21,3 +22,10 @@ TEST(AgradRevMatrix,mv_trace) {
   EXPECT_FLOAT_EQ(0.0, g[2]);
   EXPECT_FLOAT_EQ(1.0, g[3]);
 }  
+
+TEST(AgradRevMatrix, check_varis_on_stack) {
+  stan::math::matrix_v a(2,2);
+  a << -1.0, 2.0, 
+    5.0, 10.0;
+  test::check_varis_on_stack(stan::math::trace(a));
+}

--- a/test/unit/math/rev/mat/fun/transpose_test.cpp
+++ b/test/unit/math/rev/mat/fun/transpose_test.cpp
@@ -1,6 +1,7 @@
 #include <stan/math/rev/mat.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/math/rev/mat/fun/util.hpp>
+#include <test/unit/math/rev/mat/util.hpp>
 
 TEST(AgradRevMatrix,transpose_matrix) {
   using stan::math::matrix_d;
@@ -67,4 +68,18 @@ TEST(AgradRevMatrix,transpose_row_vector) {
   EXPECT_FLOAT_EQ(0.0,g[0]);
   EXPECT_FLOAT_EQ(1.0,g[1]);
   EXPECT_FLOAT_EQ(0.0,g[2]);
+}
+
+TEST(AgradRevMatrix, check_varis_on_stack) {
+  stan::math::row_vector_v a(3);
+  a << 1.0, 2.0, 3.0;
+  stan::math::vector_v b(3);
+  b << 1.0, 2.0, 3.0;
+  stan::math::matrix_v c(2,3);
+  c << -1.0, 2.0, -3.0, 
+    5.0, 10.0, 100.0;
+  
+  test::check_varis_on_stack(stan::math::transpose(a));
+  test::check_varis_on_stack(stan::math::transpose(b));
+  test::check_varis_on_stack(stan::math::transpose(c));
 }

--- a/test/unit/math/rev/mat/fun/unit_vector_constrain_test.cpp
+++ b/test/unit/math/rev/mat/fun/unit_vector_constrain_test.cpp
@@ -1,6 +1,7 @@
 #include <stan/math/rev/mat.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/math/rev/mat/fun/util.hpp>
+#include <test/unit/math/rev/mat/util.hpp>
 
 std::vector<double>
 unit_vector_grad(Eigen::Matrix<double,Eigen::Dynamic,1>& y_dbl,
@@ -57,4 +58,13 @@ TEST(AgradRevUnitVectorConstrain, exceptions) {
   EXPECT_THROW(unit_vector_constrain(x),std::domain_error);
   x(0) = std::numeric_limits<var>::infinity();
   EXPECT_THROW(unit_vector_constrain(x),std::domain_error);
+}
+
+TEST(AgradRevMatrix, check_varis_on_stack) {
+  using stan::math::var;
+  using stan::math::to_var;
+  Eigen::Matrix<var, Eigen::Dynamic, 1> y(3);
+  y << 0.0, 3.0, -1.0;
+
+  test::check_varis_on_stack(stan::math::unit_vector_constrain(y));
 }

--- a/test/unit/math/rev/mat/fun/unit_vector_constrain_test.cpp
+++ b/test/unit/math/rev/mat/fun/unit_vector_constrain_test.cpp
@@ -65,6 +65,8 @@ TEST(AgradRevMatrix, check_varis_on_stack) {
   using stan::math::to_var;
   Eigen::Matrix<var, Eigen::Dynamic, 1> y(3);
   y << 0.0, 3.0, -1.0;
-
+  var lp(0);
+  
+  test::check_varis_on_stack(stan::math::unit_vector_constrain(y, lp));
   test::check_varis_on_stack(stan::math::unit_vector_constrain(y));
 }

--- a/test/unit/math/rev/mat/fun/unit_vector_transform_test.cpp
+++ b/test/unit/math/rev/mat/fun/unit_vector_transform_test.cpp
@@ -1,6 +1,7 @@
 #include <stan/math/rev/mat.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/math/rev/mat/fun/jacobian.hpp>
+#include <test/unit/math/rev/mat/util.hpp>
 
 using Eigen::Matrix;
 using Eigen::Dynamic;
@@ -49,3 +50,12 @@ TEST(probTransform,unit_vector_jacobian) {
     << "x = " << x.transpose();
 }
 
+TEST(probTransform, check_varis_on_stack) {
+  using stan::math::to_var;
+  using stan::math::var;
+  Matrix<var,Dynamic,1> y(3);
+  y << 2, 3, -1;
+  
+  var lp(0);
+  test::check_varis_on_stack(stan::math::unit_vector_constrain(y, lp));
+}

--- a/test/unit/math/rev/mat/fun/unit_vector_transform_test.cpp
+++ b/test/unit/math/rev/mat/fun/unit_vector_transform_test.cpp
@@ -51,11 +51,11 @@ TEST(probTransform,unit_vector_jacobian) {
 }
 
 TEST(probTransform, check_varis_on_stack) {
-  using stan::math::to_var;
   using stan::math::var;
   Matrix<var,Dynamic,1> y(3);
   y << 2, 3, -1;
   
   var lp(0);
   test::check_varis_on_stack(stan::math::unit_vector_constrain(y, lp));
+  test::check_varis_on_stack(stan::math::unit_vector_constrain(y));
 }

--- a/test/unit/math/rev/mat/fun/util.hpp
+++ b/test/unit/math/rev/mat/fun/util.hpp
@@ -4,6 +4,7 @@
 #include <vector>
 #include <test/unit/math/rev/arr/fun/util.hpp>
 #include <stan/math/rev/mat.hpp>
+#include <test/unit/math/rev/mat/util.hpp>
 
 typedef stan::math::index_type<Eigen::Matrix<double,-1,-1> >::type size_type;
 

--- a/test/unit/math/rev/mat/fun/variance_test.cpp
+++ b/test/unit/math/rev/mat/fun/variance_test.cpp
@@ -1,7 +1,7 @@
 #include <stan/math/rev/mat.hpp>
 #include <gtest/gtest.h>
-
 #include <test/unit/math/rev/mat/fun/util.hpp>
+#include <test/unit/math/rev/mat/util.hpp>
 
 TEST(AgradRevMatrix, varianceZeroBoundaryCase) {
   using stan::math::variance;
@@ -157,4 +157,14 @@ TEST(AgradRevMatrix, varianceStdVector) {
   for (size_t i = 0; i < 3; ++i) {
     EXPECT_FLOAT_EQ(grad2[i], grad1[i]);
   }
+}
+
+TEST(AgradRevMatrix, check_varis_on_stack) {
+  stan::math::vector_v v1(6);
+  v1 << 1, 2, 3, 4, 5, 6;
+  stan::math::row_vector_v v2(6);
+  v2 << 1, 2, 3, 4, 5, 6;
+
+  test::check_varis_on_stack(stan::math::variance(v1));
+  test::check_varis_on_stack(stan::math::variance(v2));
 }

--- a/test/unit/math/rev/mat/prob/inv_wishart2_test.cpp
+++ b/test/unit/math/rev/mat/prob/inv_wishart2_test.cpp
@@ -1,7 +1,7 @@
 #include <stan/math/rev/mat.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/math/rev/mat/prob/expect_eq_diffs.hpp>
-
+#include <test/unit/math/rev/mat/util.hpp>
 
 template <typename T_y, typename T_dof, typename T_scale>
 void expect_propto(T_y W1, T_dof nu1, T_scale S1,
@@ -83,3 +83,30 @@ TEST_F(AgradDistributionsInvWishart,ProptoSigma) {
                 "var: sigma");
 }
 
+TEST(InvWishart, check_varis_on_stack) {
+  Eigen::MatrixXd W(2, 2);
+  W <<  2.011108, -11.20661,
+    -11.206611, 112.94139;
+  
+  double nu = 3;
+  
+  Eigen::MatrixXd S(2, 2);
+  S << 1.848220, 1.899623, 
+    1.899623, 12.751941;
+  
+  test::check_varis_on_stack(stan::math::inv_wishart_log<false>(to_var(W), to_var(nu), to_var(S)));
+  test::check_varis_on_stack(stan::math::inv_wishart_log<false>(to_var(W), to_var(nu), S));
+  test::check_varis_on_stack(stan::math::inv_wishart_log<false>(to_var(W), nu, to_var(S)));
+  test::check_varis_on_stack(stan::math::inv_wishart_log<false>(to_var(W), nu, S));
+  test::check_varis_on_stack(stan::math::inv_wishart_log<false>(W, to_var(nu), to_var(S)));
+  test::check_varis_on_stack(stan::math::inv_wishart_log<false>(W, to_var(nu), S));
+  test::check_varis_on_stack(stan::math::inv_wishart_log<false>(W, nu, to_var(S)));
+
+  test::check_varis_on_stack(stan::math::inv_wishart_log<true>(to_var(W), to_var(nu), to_var(S)));
+  test::check_varis_on_stack(stan::math::inv_wishart_log<true>(to_var(W), to_var(nu), S));
+  test::check_varis_on_stack(stan::math::inv_wishart_log<true>(to_var(W), nu, to_var(S)));
+  test::check_varis_on_stack(stan::math::inv_wishart_log<true>(to_var(W), nu, S));
+  test::check_varis_on_stack(stan::math::inv_wishart_log<true>(W, to_var(nu), to_var(S)));
+  test::check_varis_on_stack(stan::math::inv_wishart_log<true>(W, to_var(nu), S));
+  test::check_varis_on_stack(stan::math::inv_wishart_log<true>(W, nu, to_var(S)));
+}

--- a/test/unit/math/rev/mat/prob/lkj_corr_test.cpp
+++ b/test/unit/math/rev/mat/prob/lkj_corr_test.cpp
@@ -5,6 +5,7 @@
 #include <boost/math/distributions.hpp>
 #include <test/unit/math/rev/mat/prob/lkj_corr_cholesky_test_functors.hpp>
 #include <test/unit/math/rev/mat/prob/test_gradients.hpp>
+#include <test/unit/math/rev/mat/util.hpp>
 
 TEST(ProbDistributionsLkjCorr,var) {
   using stan::math::var;
@@ -105,3 +106,4 @@ TEST(ProbDistributionsLkjCorrCholesky,gradients) {
   test_grad_eq(grad_1, grad_ad_1);
   EXPECT_FLOAT_EQ(fx, fx_ad);
 }
+

--- a/test/unit/math/rev/mat/prob/multi_gp2_test.cpp
+++ b/test/unit/math/rev/mat/prob/multi_gp2_test.cpp
@@ -220,11 +220,20 @@ TEST(MultiGP, check_varis_on_stack) {
   Sigma << 9.0, -3.0, 0.0,
           -3.0,  4.0, 0.0,
            0.0, 0.0, 5.0;
-  test::check_varis_on_stack(stan::math::multi_gp_log(to_var(y), to_var(Sigma), to_var(w)));
-  test::check_varis_on_stack(stan::math::multi_gp_log(to_var(y), to_var(Sigma), w));
-  test::check_varis_on_stack(stan::math::multi_gp_log(to_var(y), Sigma, to_var(w)));
-  test::check_varis_on_stack(stan::math::multi_gp_log(to_var(y), Sigma, w));
-  test::check_varis_on_stack(stan::math::multi_gp_log(y, to_var(Sigma), to_var(w)));
-  test::check_varis_on_stack(stan::math::multi_gp_log(y, to_var(Sigma), w));
-  test::check_varis_on_stack(stan::math::multi_gp_log(y, Sigma, to_var(w)));
+
+  test::check_varis_on_stack(stan::math::multi_gp_log<true>(to_var(y), to_var(Sigma), to_var(w)));
+  test::check_varis_on_stack(stan::math::multi_gp_log<true>(to_var(y), to_var(Sigma), w));
+  test::check_varis_on_stack(stan::math::multi_gp_log<true>(to_var(y), Sigma, to_var(w)));
+  test::check_varis_on_stack(stan::math::multi_gp_log<true>(to_var(y), Sigma, w));
+  test::check_varis_on_stack(stan::math::multi_gp_log<true>(y, to_var(Sigma), to_var(w)));
+  test::check_varis_on_stack(stan::math::multi_gp_log<true>(y, to_var(Sigma), w));
+  test::check_varis_on_stack(stan::math::multi_gp_log<true>(y, Sigma, to_var(w)));
+
+  test::check_varis_on_stack(stan::math::multi_gp_log<false>(to_var(y), to_var(Sigma), to_var(w)));
+  test::check_varis_on_stack(stan::math::multi_gp_log<false>(to_var(y), to_var(Sigma), w));
+  test::check_varis_on_stack(stan::math::multi_gp_log<false>(to_var(y), Sigma, to_var(w)));
+  test::check_varis_on_stack(stan::math::multi_gp_log<false>(to_var(y), Sigma, w));
+  test::check_varis_on_stack(stan::math::multi_gp_log<false>(y, to_var(Sigma), to_var(w)));
+  test::check_varis_on_stack(stan::math::multi_gp_log<false>(y, to_var(Sigma), w));
+  test::check_varis_on_stack(stan::math::multi_gp_log<false>(y, Sigma, to_var(w)));
 }

--- a/test/unit/math/rev/mat/prob/multi_gp2_test.cpp
+++ b/test/unit/math/rev/mat/prob/multi_gp2_test.cpp
@@ -1,11 +1,10 @@
 #include <stan/math/rev/mat.hpp>
 #include <gtest/gtest.h>
-
-// UTILITY FUNCTIONS FOR TESTING
 #include <vector>
 #include <test/unit/math/rev/mat/prob/expect_eq_diffs.hpp>
 #include <test/unit/math/rev/mat/prob/test_gradients.hpp>
 #include <test/unit/math/prim/mat/prob/agrad_distributions_multi_gp.hpp>
+#include <test/unit/math/rev/mat/util.hpp>
 
 using Eigen::Dynamic;
 using Eigen::Matrix;
@@ -207,4 +206,25 @@ TEST(MultiGP, TestGradFunctional) {
   u[2] = 2.7;
   
   test_grad(multi_gp_fun(1,1), u);
+}
+
+TEST(MultiGP, check_varis_on_stack) {
+  using stan::math::to_var;
+  Matrix<double,Dynamic,Dynamic> y(3,3);
+  y <<  2.0, -2.0, 11.0,
+       -4.0, 0.0, 2.0,
+        1.0, 5.0, 3.3;
+  Matrix<double,Dynamic,1> w(3,1);
+  w << 1.0, 0.5, 3.0;
+  Matrix<double,Dynamic,Dynamic> Sigma(3,3);
+  Sigma << 9.0, -3.0, 0.0,
+          -3.0,  4.0, 0.0,
+           0.0, 0.0, 5.0;
+  test::check_varis_on_stack(stan::math::multi_gp_log(to_var(y), to_var(Sigma), to_var(w)));
+  test::check_varis_on_stack(stan::math::multi_gp_log(to_var(y), to_var(Sigma), w));
+  test::check_varis_on_stack(stan::math::multi_gp_log(to_var(y), Sigma, to_var(w)));
+  test::check_varis_on_stack(stan::math::multi_gp_log(to_var(y), Sigma, w));
+  test::check_varis_on_stack(stan::math::multi_gp_log(y, to_var(Sigma), to_var(w)));
+  test::check_varis_on_stack(stan::math::multi_gp_log(y, to_var(Sigma), w));
+  test::check_varis_on_stack(stan::math::multi_gp_log(y, Sigma, to_var(w)));
 }

--- a/test/unit/math/rev/mat/prob/multi_gp_cholesky2_test.cpp
+++ b/test/unit/math/rev/mat/prob/multi_gp_cholesky2_test.cpp
@@ -1,12 +1,10 @@
 #include <stan/math/rev/mat.hpp>
 #include <gtest/gtest.h>
-
-
-// UTILITY FUNCTIONS FOR TESTING
 #include <vector>
 #include <test/unit/math/rev/mat/prob/expect_eq_diffs.hpp>
 #include <test/unit/math/rev/mat/prob/test_gradients.hpp>
 #include <test/unit/math/prim/mat/prob/agrad_distributions_multi_gp_cholesky.hpp>
+#include <test/unit/math/rev/mat/util.hpp>
 
 using Eigen::Dynamic;
 using Eigen::Matrix;
@@ -210,4 +208,27 @@ TEST(MultiGPCholesky, TestGradFunctional) {
   u[2] = 2.7;
   
   test_grad(multi_gp_cholesky_fun(1,1), u);
+}
+
+
+TEST(ProbDistributionsMultiGPCholesky, check_varis_on_stack) {
+  using stan::math::to_var;
+  Matrix<double,Dynamic,Dynamic> y(3,3);
+  y <<  2.0, -2.0, 11.0,
+       -4.0, 0.0, 2.0,
+        1.0, 5.0, 3.3;
+  Matrix<double,Dynamic,1> w(3,1);
+  w << 1.0, 0.5, 3.0;
+  Matrix<double,Dynamic,Dynamic> Sigma(3,3);
+  Sigma << 9.0, -3.0, 0.0,
+          -3.0,  4.0, 0.0,
+           0.0, 0.0, 5.0;
+  Matrix<double,Dynamic,Dynamic> L = Sigma.llt().matrixL();
+  test::check_varis_on_stack(stan::math::multi_gp_cholesky_log(to_var(y), to_var(L), to_var(w)));
+  test::check_varis_on_stack(stan::math::multi_gp_cholesky_log(to_var(y), to_var(L), w));
+  test::check_varis_on_stack(stan::math::multi_gp_cholesky_log(to_var(y), L, to_var(w)));
+  test::check_varis_on_stack(stan::math::multi_gp_cholesky_log(to_var(y), L, w));
+  test::check_varis_on_stack(stan::math::multi_gp_cholesky_log(y, to_var(L), to_var(w)));
+  test::check_varis_on_stack(stan::math::multi_gp_cholesky_log(y, to_var(L), w));
+  test::check_varis_on_stack(stan::math::multi_gp_cholesky_log(y, L, to_var(w)));
 }

--- a/test/unit/math/rev/mat/prob/multi_gp_cholesky2_test.cpp
+++ b/test/unit/math/rev/mat/prob/multi_gp_cholesky2_test.cpp
@@ -224,11 +224,20 @@ TEST(ProbDistributionsMultiGPCholesky, check_varis_on_stack) {
           -3.0,  4.0, 0.0,
            0.0, 0.0, 5.0;
   Matrix<double,Dynamic,Dynamic> L = Sigma.llt().matrixL();
-  test::check_varis_on_stack(stan::math::multi_gp_cholesky_log(to_var(y), to_var(L), to_var(w)));
-  test::check_varis_on_stack(stan::math::multi_gp_cholesky_log(to_var(y), to_var(L), w));
-  test::check_varis_on_stack(stan::math::multi_gp_cholesky_log(to_var(y), L, to_var(w)));
-  test::check_varis_on_stack(stan::math::multi_gp_cholesky_log(to_var(y), L, w));
-  test::check_varis_on_stack(stan::math::multi_gp_cholesky_log(y, to_var(L), to_var(w)));
-  test::check_varis_on_stack(stan::math::multi_gp_cholesky_log(y, to_var(L), w));
-  test::check_varis_on_stack(stan::math::multi_gp_cholesky_log(y, L, to_var(w)));
+
+  test::check_varis_on_stack(stan::math::multi_gp_cholesky_log<true>(to_var(y), to_var(L), to_var(w)));
+  test::check_varis_on_stack(stan::math::multi_gp_cholesky_log<true>(to_var(y), to_var(L), w));
+  test::check_varis_on_stack(stan::math::multi_gp_cholesky_log<true>(to_var(y), L, to_var(w)));
+  test::check_varis_on_stack(stan::math::multi_gp_cholesky_log<true>(to_var(y), L, w));
+  test::check_varis_on_stack(stan::math::multi_gp_cholesky_log<true>(y, to_var(L), to_var(w)));
+  test::check_varis_on_stack(stan::math::multi_gp_cholesky_log<true>(y, to_var(L), w));
+  test::check_varis_on_stack(stan::math::multi_gp_cholesky_log<true>(y, L, to_var(w)));
+
+  test::check_varis_on_stack(stan::math::multi_gp_cholesky_log<false>(to_var(y), to_var(L), to_var(w)));
+  test::check_varis_on_stack(stan::math::multi_gp_cholesky_log<false>(to_var(y), to_var(L), w));
+  test::check_varis_on_stack(stan::math::multi_gp_cholesky_log<false>(to_var(y), L, to_var(w)));
+  test::check_varis_on_stack(stan::math::multi_gp_cholesky_log<false>(to_var(y), L, w));
+  test::check_varis_on_stack(stan::math::multi_gp_cholesky_log<false>(y, to_var(L), to_var(w)));
+  test::check_varis_on_stack(stan::math::multi_gp_cholesky_log<false>(y, to_var(L), w));
+  test::check_varis_on_stack(stan::math::multi_gp_cholesky_log<false>(y, L, to_var(w)));
 }

--- a/test/unit/math/rev/mat/prob/multi_normal_cholesky_test.cpp
+++ b/test/unit/math/rev/mat/prob/multi_normal_cholesky_test.cpp
@@ -32,11 +32,19 @@ TEST(AgradRev, check_varis_on_stack) {
     -3.0,  4.0, 0.0,
     0.0, 0.0, 5.0;
   Matrix<double,Dynamic,Dynamic> L = Sigma.llt().matrixL();
-  test::check_varis_on_stack(stan::math::multi_normal_cholesky_log(to_var(y), to_var(mu), to_var(L)));
-  test::check_varis_on_stack(stan::math::multi_normal_cholesky_log(to_var(y), to_var(mu), L));
-  test::check_varis_on_stack(stan::math::multi_normal_cholesky_log(to_var(y), mu, to_var(L)));
-  test::check_varis_on_stack(stan::math::multi_normal_cholesky_log(to_var(y), mu, L));
-  test::check_varis_on_stack(stan::math::multi_normal_cholesky_log(y, to_var(mu), to_var(L)));
-  test::check_varis_on_stack(stan::math::multi_normal_cholesky_log(y, to_var(mu), L));
-  test::check_varis_on_stack(stan::math::multi_normal_cholesky_log(y, mu, to_var(L)));
+  test::check_varis_on_stack(stan::math::multi_normal_cholesky_log<true>(to_var(y), to_var(mu), to_var(L)));
+  test::check_varis_on_stack(stan::math::multi_normal_cholesky_log<true>(to_var(y), to_var(mu), L));
+  test::check_varis_on_stack(stan::math::multi_normal_cholesky_log<true>(to_var(y), mu, to_var(L)));
+  test::check_varis_on_stack(stan::math::multi_normal_cholesky_log<true>(to_var(y), mu, L));
+  test::check_varis_on_stack(stan::math::multi_normal_cholesky_log<true>(y, to_var(mu), to_var(L)));
+  test::check_varis_on_stack(stan::math::multi_normal_cholesky_log<true>(y, to_var(mu), L));
+  test::check_varis_on_stack(stan::math::multi_normal_cholesky_log<true>(y, mu, to_var(L)));
+
+  test::check_varis_on_stack(stan::math::multi_normal_cholesky_log<false>(to_var(y), to_var(mu), to_var(L)));
+  test::check_varis_on_stack(stan::math::multi_normal_cholesky_log<false>(to_var(y), to_var(mu), L));
+  test::check_varis_on_stack(stan::math::multi_normal_cholesky_log<false>(to_var(y), mu, to_var(L)));
+  test::check_varis_on_stack(stan::math::multi_normal_cholesky_log<false>(to_var(y), mu, L));
+  test::check_varis_on_stack(stan::math::multi_normal_cholesky_log<false>(y, to_var(mu), to_var(L)));
+  test::check_varis_on_stack(stan::math::multi_normal_cholesky_log<false>(y, to_var(mu), L));
+  test::check_varis_on_stack(stan::math::multi_normal_cholesky_log<false>(y, mu, to_var(L)));
 }

--- a/test/unit/math/rev/mat/prob/multi_normal_cholesky_test.cpp
+++ b/test/unit/math/rev/mat/prob/multi_normal_cholesky_test.cpp
@@ -1,7 +1,6 @@
 #include <stan/math/rev/mat.hpp>
 #include <gtest/gtest.h>
-#include <boost/random/mersenne_twister.hpp>
-#include <boost/math/distributions.hpp>
+#include <test/unit/math/rev/mat/util.hpp>
 
 using Eigen::Dynamic;
 using Eigen::Matrix;
@@ -19,4 +18,25 @@ TEST(ProbDistributionsMultiNormalCholesky,MultiNormalVar) {
     0.0, 0.0, 5.0;
   Matrix<var,Dynamic,Dynamic> L = Sigma.llt().matrixL();
   EXPECT_FLOAT_EQ(-11.73908, stan::math::multi_normal_cholesky_log(y,mu,L).val());
+}
+
+
+TEST(AgradRev, check_varis_on_stack) {
+  using stan::math::to_var;
+  Matrix<double,Dynamic,1> y(3,1);
+  y << 2.0, -2.0, 11.0;
+  Matrix<double,Dynamic,1> mu(3,1);
+  mu << 1.0, -1.0, 3.0;
+  Matrix<double,Dynamic,Dynamic> Sigma(3,3);
+  Sigma << 9.0, -3.0, 0.0,
+    -3.0,  4.0, 0.0,
+    0.0, 0.0, 5.0;
+  Matrix<double,Dynamic,Dynamic> L = Sigma.llt().matrixL();
+  test::check_varis_on_stack(stan::math::multi_normal_cholesky_log(to_var(y), to_var(mu), to_var(L)));
+  test::check_varis_on_stack(stan::math::multi_normal_cholesky_log(to_var(y), to_var(mu), L));
+  test::check_varis_on_stack(stan::math::multi_normal_cholesky_log(to_var(y), mu, to_var(L)));
+  test::check_varis_on_stack(stan::math::multi_normal_cholesky_log(to_var(y), mu, L));
+  test::check_varis_on_stack(stan::math::multi_normal_cholesky_log(y, to_var(mu), to_var(L)));
+  test::check_varis_on_stack(stan::math::multi_normal_cholesky_log(y, to_var(mu), L));
+  test::check_varis_on_stack(stan::math::multi_normal_cholesky_log(y, mu, to_var(L)));
 }

--- a/test/unit/math/rev/mat/prob/multi_normal_prec_test.cpp
+++ b/test/unit/math/rev/mat/prob/multi_normal_prec_test.cpp
@@ -1,5 +1,6 @@
 #include <stan/math/rev/mat.hpp>
 #include <gtest/gtest.h>
+#include <test/unit/math/rev/mat/util.hpp>
 
 using Eigen::Dynamic;
 using Eigen::Matrix;
@@ -17,4 +18,24 @@ TEST(ProbDistributionsMultiNormalPrec,MultiNormalVar) {
     0.0, 0.0, 5.0;
   Matrix<var,Dynamic,Dynamic> L = Sigma.inverse();
   EXPECT_FLOAT_EQ(-11.73908, stan::math::multi_normal_prec_log(y,mu,L).val());
+}
+
+TEST(AgradRev, check_varis_on_stack) {
+  using stan::math::to_var;
+  Matrix<double,Dynamic,1> y(3,1);
+  y << 2.0, -2.0, 11.0;
+  Matrix<double,Dynamic,1> mu(3,1);
+  mu << 1.0, -1.0, 3.0;
+  Matrix<double,Dynamic,Dynamic> Sigma(3,3);
+  Sigma << 9.0, -3.0, 0.0,
+    -3.0,  4.0, 0.0,
+    0.0, 0.0, 5.0;
+  Matrix<double,Dynamic,Dynamic> L = Sigma.inverse();
+  test::check_varis_on_stack(stan::math::multi_normal_prec_log(to_var(y), to_var(mu), to_var(L)));
+  test::check_varis_on_stack(stan::math::multi_normal_prec_log(to_var(y), to_var(mu), L));
+  test::check_varis_on_stack(stan::math::multi_normal_prec_log(to_var(y), mu, to_var(L)));
+  test::check_varis_on_stack(stan::math::multi_normal_prec_log(to_var(y), mu, L));
+  test::check_varis_on_stack(stan::math::multi_normal_prec_log(y, to_var(mu), to_var(L)));
+  test::check_varis_on_stack(stan::math::multi_normal_prec_log(y, to_var(mu), L));
+  test::check_varis_on_stack(stan::math::multi_normal_prec_log(y, mu, to_var(L)));
 }

--- a/test/unit/math/rev/mat/prob/multi_normal_prec_test.cpp
+++ b/test/unit/math/rev/mat/prob/multi_normal_prec_test.cpp
@@ -31,11 +31,20 @@ TEST(AgradRev, check_varis_on_stack) {
     -3.0,  4.0, 0.0,
     0.0, 0.0, 5.0;
   Matrix<double,Dynamic,Dynamic> L = Sigma.inverse();
-  test::check_varis_on_stack(stan::math::multi_normal_prec_log(to_var(y), to_var(mu), to_var(L)));
-  test::check_varis_on_stack(stan::math::multi_normal_prec_log(to_var(y), to_var(mu), L));
-  test::check_varis_on_stack(stan::math::multi_normal_prec_log(to_var(y), mu, to_var(L)));
-  test::check_varis_on_stack(stan::math::multi_normal_prec_log(to_var(y), mu, L));
-  test::check_varis_on_stack(stan::math::multi_normal_prec_log(y, to_var(mu), to_var(L)));
-  test::check_varis_on_stack(stan::math::multi_normal_prec_log(y, to_var(mu), L));
-  test::check_varis_on_stack(stan::math::multi_normal_prec_log(y, mu, to_var(L)));
+  
+  test::check_varis_on_stack(stan::math::multi_normal_prec_log<true>(to_var(y), to_var(mu), to_var(L)));
+  test::check_varis_on_stack(stan::math::multi_normal_prec_log<true>(to_var(y), to_var(mu), L));
+  test::check_varis_on_stack(stan::math::multi_normal_prec_log<true>(to_var(y), mu, to_var(L)));
+  test::check_varis_on_stack(stan::math::multi_normal_prec_log<true>(to_var(y), mu, L));
+  test::check_varis_on_stack(stan::math::multi_normal_prec_log<true>(y, to_var(mu), to_var(L)));
+  test::check_varis_on_stack(stan::math::multi_normal_prec_log<true>(y, to_var(mu), L));
+  test::check_varis_on_stack(stan::math::multi_normal_prec_log<true>(y, mu, to_var(L)));
+
+  test::check_varis_on_stack(stan::math::multi_normal_prec_log<false>(to_var(y), to_var(mu), to_var(L)));
+  test::check_varis_on_stack(stan::math::multi_normal_prec_log<false>(to_var(y), to_var(mu), L));
+  test::check_varis_on_stack(stan::math::multi_normal_prec_log<false>(to_var(y), mu, to_var(L)));
+  test::check_varis_on_stack(stan::math::multi_normal_prec_log<false>(to_var(y), mu, L));
+  test::check_varis_on_stack(stan::math::multi_normal_prec_log<false>(y, to_var(mu), to_var(L)));
+  test::check_varis_on_stack(stan::math::multi_normal_prec_log<false>(y, to_var(mu), L));
+  test::check_varis_on_stack(stan::math::multi_normal_prec_log<false>(y, mu, to_var(L)));
 }

--- a/test/unit/math/rev/mat/prob/multi_student_t2_test.cpp
+++ b/test/unit/math/rev/mat/prob/multi_student_t2_test.cpp
@@ -1,13 +1,11 @@
 #include <stan/math/rev/mat.hpp>
 #include <gtest/gtest.h>
-
-
-// UTILITY FUNCTIONS FOR TESTING
 #include <vector>
 #include <test/unit/math/rev/mat/prob/expect_eq_diffs.hpp>
 #include <test/unit/math/rev/mat/prob/test_gradients.hpp>
 #include <test/unit/math/rev/mat/prob/test_gradients_multi_student_t.hpp>
 #include <test/unit/math/prim/mat/prob/agrad_distributions_multi_student_t.hpp>
+#include <test/unit/math/rev/mat/util.hpp>
 
 using Eigen::Dynamic;
 using Eigen::Matrix;
@@ -437,4 +435,50 @@ TEST(MultiNormal, TestGradFunctionalVectorized) {
   test_all<1,-1>();
   test_all<-1,1>();
   test_all<-1,-1>();
+}
+
+TEST(MultiNormal, check_varis_on_stack) {
+  double nu(5);
+  Matrix<double,Dynamic,1> y(3,1);
+  y << 2.0, -2.0, 11.0;
+  Matrix<double,Dynamic,1> mu(3,1);
+  mu << 1.0, -1.0, 3.0;
+  Matrix<double,Dynamic,Dynamic> Sigma(3,3);
+  Sigma << 9.0, -3.0, 0.0,
+    -3.0,  4.0, 0.0,
+    0.0, 0.0, 5.0;
+
+
+  using stan::math::multi_student_t_log;
+  using stan::math::to_var;
+  test::check_varis_on_stack(multi_student_t_log<false>(to_var(y), to_var(nu), to_var(mu), to_var(Sigma)));
+  test::check_varis_on_stack(multi_student_t_log<false>(to_var(y), to_var(nu), to_var(mu), Sigma));
+  test::check_varis_on_stack(multi_student_t_log<false>(to_var(y), to_var(nu), mu, to_var(Sigma)));
+  test::check_varis_on_stack(multi_student_t_log<false>(to_var(y), to_var(nu), mu, Sigma));
+  test::check_varis_on_stack(multi_student_t_log<false>(to_var(y), nu, to_var(mu), to_var(Sigma)));
+  test::check_varis_on_stack(multi_student_t_log<false>(to_var(y), nu, to_var(mu), Sigma));
+  test::check_varis_on_stack(multi_student_t_log<false>(to_var(y), nu, mu, to_var(Sigma)));
+  test::check_varis_on_stack(multi_student_t_log<false>(to_var(y), nu, mu, Sigma));
+  test::check_varis_on_stack(multi_student_t_log<false>(y, to_var(nu), to_var(mu), to_var(Sigma)));
+  test::check_varis_on_stack(multi_student_t_log<false>(y, to_var(nu), to_var(mu), Sigma));
+  test::check_varis_on_stack(multi_student_t_log<false>(y, to_var(nu), mu, to_var(Sigma)));
+  test::check_varis_on_stack(multi_student_t_log<false>(y, to_var(nu), mu, Sigma));
+  test::check_varis_on_stack(multi_student_t_log<false>(y, nu, to_var(mu), to_var(Sigma)));
+  test::check_varis_on_stack(multi_student_t_log<false>(y, nu, to_var(mu), Sigma));
+  test::check_varis_on_stack(multi_student_t_log<false>(y, nu, mu, to_var(Sigma)));
+  test::check_varis_on_stack(multi_student_t_log<true>(to_var(y), to_var(nu), to_var(mu), to_var(Sigma)));
+  test::check_varis_on_stack(multi_student_t_log<true>(to_var(y), to_var(nu), to_var(mu), Sigma));
+  test::check_varis_on_stack(multi_student_t_log<true>(to_var(y), to_var(nu), mu, to_var(Sigma)));
+  test::check_varis_on_stack(multi_student_t_log<true>(to_var(y), to_var(nu), mu, Sigma));
+  test::check_varis_on_stack(multi_student_t_log<true>(to_var(y), nu, to_var(mu), to_var(Sigma)));
+  test::check_varis_on_stack(multi_student_t_log<true>(to_var(y), nu, to_var(mu), Sigma));
+  test::check_varis_on_stack(multi_student_t_log<true>(to_var(y), nu, mu, to_var(Sigma)));
+  test::check_varis_on_stack(multi_student_t_log<true>(to_var(y), nu, mu, Sigma));
+  test::check_varis_on_stack(multi_student_t_log<true>(y, to_var(nu), to_var(mu), to_var(Sigma)));
+  test::check_varis_on_stack(multi_student_t_log<true>(y, to_var(nu), to_var(mu), Sigma));
+  test::check_varis_on_stack(multi_student_t_log<true>(y, to_var(nu), mu, to_var(Sigma)));
+  test::check_varis_on_stack(multi_student_t_log<true>(y, to_var(nu), mu, Sigma));
+  test::check_varis_on_stack(multi_student_t_log<true>(y, nu, to_var(mu), to_var(Sigma)));
+  test::check_varis_on_stack(multi_student_t_log<true>(y, nu, to_var(mu), Sigma));
+  test::check_varis_on_stack(multi_student_t_log<true>(y, nu, mu, to_var(Sigma)));
 }

--- a/test/unit/math/rev/mat/prob/multinomial_test.cpp
+++ b/test/unit/math/rev/mat/prob/multinomial_test.cpp
@@ -1,6 +1,7 @@
 #include <stan/math/rev/mat.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/math/rev/mat/prob/expect_eq_diffs.hpp>
+#include <test/unit/math/rev/mat/util.hpp>
 
 template <typename T_prob>
 void expect_propto(std::vector<int>& ns1, T_prob theta1, 
@@ -31,4 +32,16 @@ TEST(AgradDistributionsMultinomial,Propto) {
   expect_propto(ns, theta1,
                 ns, theta2,
                 "var: theta");
+}
+
+TEST(AgradDistributionsMultinomial, check_varis_on_stack) {
+  std::vector<int> ns;
+  ns.push_back(1);
+  ns.push_back(2);
+  ns.push_back(3);
+  Matrix<var,Dynamic,1> theta(3,1);
+  theta << 0.3, 0.5, 0.2;
+
+  test::check_varis_on_stack(stan::math::multinomial_log<false>(ns, theta));
+  test::check_varis_on_stack(stan::math::multinomial_log<true>(ns, theta));
 }

--- a/test/unit/math/rev/mat/prob/wishart_test.cpp
+++ b/test/unit/math/rev/mat/prob/wishart_test.cpp
@@ -1,7 +1,7 @@
 #include <stan/math/rev/mat.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/math/rev/mat/prob/expect_eq_diffs.hpp>
-
+#include <test/unit/math/rev/mat/util.hpp>
 
 template <typename T_y, typename T_dof, typename T_scale>
 void expect_propto(T_y W1, T_dof nu1, T_scale S1,
@@ -83,3 +83,31 @@ TEST_F(AgradDistributionsWishart,ProptoSigma) {
                 "var: sigma");
 }
 
+
+TEST(Wishart, check_varis_on_stack) {
+  Eigen::MatrixXd W(2, 2);
+  W <<  2.011108, -11.20661,
+    -11.206611, 112.94139;
+  
+  double nu = 3;
+  
+  Eigen::MatrixXd S(2, 2);
+  S << 1.848220, 1.899623, 
+    1.899623, 12.751941;
+  
+  test::check_varis_on_stack(stan::math::wishart_log<false>(to_var(W), to_var(nu), to_var(S)));
+  test::check_varis_on_stack(stan::math::wishart_log<false>(to_var(W), to_var(nu), S));
+  test::check_varis_on_stack(stan::math::wishart_log<false>(to_var(W), nu, to_var(S)));
+  test::check_varis_on_stack(stan::math::wishart_log<false>(to_var(W), nu, S));
+  test::check_varis_on_stack(stan::math::wishart_log<false>(W, to_var(nu), to_var(S)));
+  test::check_varis_on_stack(stan::math::wishart_log<false>(W, to_var(nu), S));
+  test::check_varis_on_stack(stan::math::wishart_log<false>(W, nu, to_var(S)));
+
+  test::check_varis_on_stack(stan::math::wishart_log<true>(to_var(W), to_var(nu), to_var(S)));
+  test::check_varis_on_stack(stan::math::wishart_log<true>(to_var(W), to_var(nu), S));
+  test::check_varis_on_stack(stan::math::wishart_log<true>(to_var(W), nu, to_var(S)));
+  test::check_varis_on_stack(stan::math::wishart_log<true>(to_var(W), nu, S));
+  test::check_varis_on_stack(stan::math::wishart_log<true>(W, to_var(nu), to_var(S)));
+  test::check_varis_on_stack(stan::math::wishart_log<true>(W, to_var(nu), S));
+  test::check_varis_on_stack(stan::math::wishart_log<true>(W, nu, to_var(S)));
+}

--- a/test/unit/math/rev/mat/util.hpp
+++ b/test/unit/math/rev/mat/util.hpp
@@ -7,24 +7,13 @@
 
 namespace test {
 
-  void check_varis_on_stack(const stan::math::matrix_v& x) {
+  template <int R, int C>
+  void check_varis_on_stack(const Eigen::Matrix<stan::math::var, R, C>& x) {
     for (int j = 0; j < x.cols(); ++j)
       for (int i = 0; i < x.rows(); ++i) 
         EXPECT_TRUE(stan::math::ChainableStack::memalloc_.in_stack(x(i, j).vi_))
           << i << ", " << j << " is not on the stack";
   }
 
-  void check_varis_on_stack(const stan::math::vector_v& x) {
-    for (int i = 0; i < x.rows(); ++i)
-      EXPECT_TRUE(stan::math::ChainableStack::memalloc_.in_stack(x(i).vi_))
-        << i << " is not on the stack";
-  }
-
-  void check_varis_on_stack(const stan::math::row_vector_v& x) {
-    for (int j = 0; j < x.cols(); ++j)
-      EXPECT_TRUE(stan::math::ChainableStack::memalloc_.in_stack(x(j).vi_))
-        << j << ", " << j << " is not on the stack";
-  }
-  
 }
 #endif

--- a/test/unit/math/rev/mat/util.hpp
+++ b/test/unit/math/rev/mat/util.hpp
@@ -1,0 +1,30 @@
+#ifndef TEST_UNIT_MATH_REV_MAT_UTIL_HPP
+#define TEST_UNIT_MATH_REV_MAT_UTIL_HPP
+
+#include <stan/math/rev/mat.hpp>
+#include <gtest/gtest.h>
+#include <test/unit/math/rev/arr/util.hpp>
+
+namespace test {
+
+  void check_varis_on_stack(const stan::math::matrix_v& x) {
+    for (int j = 0; j < x.cols(); ++j)
+      for (int i = 0; i < x.rows(); ++i) 
+        EXPECT_TRUE(stan::math::ChainableStack::memalloc_.in_stack(x(i, j).vi_))
+          << i << ", " << j << " is not on the stack";
+  }
+
+  void check_varis_on_stack(const stan::math::vector_v& x) {
+    for (int i = 0; i < x.rows(); ++i)
+      EXPECT_TRUE(stan::math::ChainableStack::memalloc_.in_stack(x(i).vi_))
+        << i << " is not on the stack";
+  }
+
+  void check_varis_on_stack(const stan::math::row_vector_v& x) {
+    for (int j = 0; j < x.cols(); ++j)
+      EXPECT_TRUE(stan::math::ChainableStack::memalloc_.in_stack(x(j).vi_))
+        << j << ", " << j << " is not on the stack";
+  }
+  
+}
+#endif

--- a/test/unit/math/rev/scal/fun/Phi_approx_test.cpp
+++ b/test/unit/math/rev/scal/fun/Phi_approx_test.cpp
@@ -1,7 +1,7 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
-#include <test/unit/math/rev/mat/fun/util.hpp>
 #include <test/unit/math/rev/scal/fun/nan_util.hpp>
+#include <test/unit/math/rev/scal/util.hpp>
 #include <vector>
 
 TEST(AgradRev, Phi_approx) {
@@ -53,4 +53,9 @@ struct Phi_approx_fun {
 TEST(AgradRev,Phi_approx_NaN) {
   Phi_approx_fun Phi_approx_;
   test_nan(Phi_approx_,false,true);
+}
+
+TEST(AgradRev, check_varis_on_stack) {
+  stan::math::var y(0);
+  test::check_varis_on_stack(stan::math::Phi_approx(y));
 }

--- a/test/unit/math/rev/scal/fun/Phi_test.cpp
+++ b/test/unit/math/rev/scal/fun/Phi_test.cpp
@@ -1,7 +1,7 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
-#include <test/unit/math/rev/mat/fun/util.hpp>
 #include <test/unit/math/rev/scal/fun/nan_util.hpp>
+#include <test/unit/math/rev/scal/util.hpp>
 #include <vector>
 
 TEST(AgradRev, Phi) {
@@ -155,3 +155,7 @@ TEST(AgradRev,Phi_NaN) {
   test_nan(Phi_,true,false);
 }
 
+TEST(AgradRev, check_varis_on_stack) {
+  stan::math::var y = 0;
+  test::check_varis_on_stack(stan::math::Phi(y));
+}

--- a/test/unit/math/rev/scal/fun/abs_test.cpp
+++ b/test/unit/math/rev/scal/fun/abs_test.cpp
@@ -1,8 +1,8 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
 #include <limits>
-#include <test/unit/math/rev/mat/fun/util.hpp>
 #include <test/unit/math/rev/scal/fun/nan_util.hpp>
+#include <test/unit/math/rev/scal/util.hpp>
 
 TEST(AgradRev,abs_var) {
   AVAR a = 0.68;
@@ -73,4 +73,9 @@ struct abs_fun {
 TEST(AgradRev,abs_NaN) {
   abs_fun abs_;
   test_nan(abs_,false,true);
+}
+
+TEST(AgradRev, check_varis_on_stack) {
+  AVAR a = 0.68;
+  test::check_varis_on_stack(stan::math::abs(a));
 }

--- a/test/unit/math/rev/scal/fun/acos_test.cpp
+++ b/test/unit/math/rev/scal/fun/acos_test.cpp
@@ -1,7 +1,7 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
-#include <test/unit/math/rev/mat/fun/util.hpp>
 #include <test/unit/math/rev/scal/fun/nan_util.hpp>
+#include <test/unit/math/rev/scal/util.hpp>
 
 
 TEST(AgradRev,acos_var) {
@@ -70,4 +70,9 @@ struct acos_fun {
 TEST(AgradRev,acos_NaN) {
   acos_fun acos_;
   test_nan(acos_,false,true);
+}
+
+TEST(AgradRev, check_varis_on_stack) {
+  AVAR a = 0.68;
+  test::check_varis_on_stack(stan::math::acos(a));
 }

--- a/test/unit/math/rev/scal/fun/acosh_test.cpp
+++ b/test/unit/math/rev/scal/fun/acosh_test.cpp
@@ -1,7 +1,7 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
-#include <test/unit/math/rev/mat/fun/util.hpp>
 #include <test/unit/math/rev/scal/fun/nan_util.hpp>
+#include <test/unit/math/rev/scal/util.hpp>
 #include <cmath>
 #include <limits>
 
@@ -56,4 +56,9 @@ struct acosh_fun {
 TEST(AgradRev,acosh_NaN) {
   acosh_fun acosh_;
   test_nan(acosh_, false, true);
+}
+
+TEST(AgradRev, check_varis_on_stack) {
+  AVAR a = 1.3;
+  test::check_varis_on_stack(stan::math::acosh(a));
 }

--- a/test/unit/math/rev/scal/fun/as_bool_test.cpp
+++ b/test/unit/math/rev/scal/fun/as_bool_test.cpp
@@ -1,6 +1,6 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
-#include <test/unit/math/rev/mat/fun/util.hpp>
+#include <test/unit/math/rev/scal/fun/util.hpp>
 
 TEST(AgradRev,asBool) {
   using stan::math::as_bool;
@@ -21,5 +21,5 @@ TEST(AgradRev,asBool) {
 }
 TEST(AgradRev,as_bool_nan) {
   stan::math::var nan = std::numeric_limits<double>::quiet_NaN();
-EXPECT_TRUE(stan::math::as_bool(nan));
+  EXPECT_TRUE(stan::math::as_bool(nan));
 }

--- a/test/unit/math/rev/scal/fun/asin_test.cpp
+++ b/test/unit/math/rev/scal/fun/asin_test.cpp
@@ -1,7 +1,7 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
-#include <test/unit/math/rev/mat/fun/util.hpp>
 #include <test/unit/math/rev/scal/fun/nan_util.hpp>
+#include <test/unit/math/rev/scal/util.hpp>
 
 TEST(AgradRev,asin_var) {
   AVAR a = 0.68;
@@ -68,4 +68,9 @@ struct asin_fun {
 TEST(AgradRev,asin_NaN) {
   asin_fun asin_;
   test_nan(asin_,false,true);
+}
+
+TEST(AgradRev, check_varis_on_stack) {
+  AVAR a = 0.68;
+  test::check_varis_on_stack(stan::math::asin(a));
 }

--- a/test/unit/math/rev/scal/fun/asinh_test.cpp
+++ b/test/unit/math/rev/scal/fun/asinh_test.cpp
@@ -1,7 +1,7 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
-#include <test/unit/math/rev/mat/fun/util.hpp>
 #include <test/unit/math/rev/scal/fun/nan_util.hpp>
+#include <test/unit/math/rev/scal/util.hpp>
 
 TEST(AgradRev,asinh_val) {
   AVAR a = 0.2;
@@ -55,4 +55,9 @@ struct asinh_fun {
 TEST(AgradRev,asinh_NaN) {
   asinh_fun asinh_;
   test_nan(asinh_,false,true);
+}
+
+TEST(AgradRev, check_varis_on_stack) {
+  AVAR a = 0.2;
+  test::check_varis_on_stack(stan::math::asinh(a));
 }

--- a/test/unit/math/rev/scal/fun/atan2_test.cpp
+++ b/test/unit/math/rev/scal/fun/atan2_test.cpp
@@ -1,8 +1,8 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
 #include <boost/math/special_functions/fpclassify.hpp>
-#include <test/unit/math/rev/mat/fun/util.hpp>
 #include <test/unit/math/rev/scal/fun/nan_util.hpp>
+#include <test/unit/math/rev/scal/util.hpp>
 
 TEST(AgradRev,atan2_var_var) {
   AVAR a = 1.2;
@@ -86,4 +86,12 @@ TEST(AgradRev, atan2_nan) {
   atan2_fun atan2_;
   test_nan(atan2_,3.0,5.0,false,true);
 
+}
+
+TEST(AgradRev, check_varis_on_stack) {
+  AVAR a = 1.2;
+  AVAR b = 3.9;
+  test::check_varis_on_stack(stan::math::atan2(a, b));
+  test::check_varis_on_stack(stan::math::atan2(a, 3.9));
+  test::check_varis_on_stack(stan::math::atan2(1.2, b));
 }

--- a/test/unit/math/rev/scal/fun/atan_test.cpp
+++ b/test/unit/math/rev/scal/fun/atan_test.cpp
@@ -1,8 +1,8 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
 #include <boost/math/special_functions/fpclassify.hpp>
-#include <test/unit/math/rev/mat/fun/util.hpp>
 #include <test/unit/math/rev/scal/fun/nan_util.hpp>
+#include <test/unit/math/rev/scal/util.hpp>
 
 TEST(AgradRev,atan_1) {
   AVAR a = 1;
@@ -56,4 +56,9 @@ struct atan_fun {
 TEST(AgradRev,atan_NaN) {
   atan_fun atan_;
   test_nan(atan_,false,true);
+}
+
+TEST(AgradRev, check_varis_on_stack) {
+  AVAR a = 1;
+  test::check_varis_on_stack(stan::math::atan(a));
 }

--- a/test/unit/math/rev/scal/fun/atanh_test.cpp
+++ b/test/unit/math/rev/scal/fun/atanh_test.cpp
@@ -1,7 +1,7 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
-#include <test/unit/math/rev/mat/fun/util.hpp>
 #include <test/unit/math/rev/scal/fun/nan_util.hpp>
+#include <test/unit/math/rev/scal/util.hpp>
 
 TEST(AgradRev,atanh) {
   AVAR a = 0.3;
@@ -55,4 +55,9 @@ struct atanh_fun {
 TEST(AgradRev,atanh_NaN) {
   atanh_fun atanh_;
   test_nan(atanh_,false,true);
+}
+
+TEST(AgradRev, check_varis_on_stack) {
+  AVAR a = 0.3;
+  test::check_varis_on_stack(stan::math::atanh(a));
 }

--- a/test/unit/math/rev/scal/fun/bessel_first_kind_test.cpp
+++ b/test/unit/math/rev/scal/fun/bessel_first_kind_test.cpp
@@ -1,7 +1,7 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
-#include <test/unit/math/rev/mat/fun/util.hpp>
 #include <test/unit/math/rev/scal/fun/nan_util.hpp>
+#include <test/unit/math/rev/scal/util.hpp>
 
 TEST(AgradRev,bessel_first_kind_int_var) {
   int a(0);
@@ -39,4 +39,9 @@ struct bessel_first_kind_fun {
 TEST(AgradRev,bessel_first_kind_NaN) {
   bessel_first_kind_fun bessel_first_kind_;
   test_nan(bessel_first_kind_,true,false);
+}
+
+TEST(AgradRev, check_varis_on_stack) {
+  AVAR b(4.0);
+  test::check_varis_on_stack(stan::math::bessel_first_kind(0, b));
 }

--- a/test/unit/math/rev/scal/fun/bessel_second_kind_test.cpp
+++ b/test/unit/math/rev/scal/fun/bessel_second_kind_test.cpp
@@ -1,7 +1,7 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
-#include <test/unit/math/rev/mat/fun/util.hpp>
 #include <test/unit/math/rev/scal/fun/nan_util.hpp>
+#include <test/unit/math/rev/scal/util.hpp>
 
 TEST(AgradRev,bessel_second_kind_int_var) {
   int a(0);
@@ -43,4 +43,9 @@ struct bessel_second_kind_fun {
 TEST(AgradRev,bessel_second_kind_NaN) {
   bessel_second_kind_fun bessel_second_kind_;
   test_nan(bessel_second_kind_,false,true);
+}
+
+TEST(AgradRev, check_varis_on_stack) {
+  AVAR b = 4.0;
+  test::check_varis_on_stack(stan::math::bessel_second_kind(0, b));
 }

--- a/test/unit/math/rev/scal/fun/binary_log_loss_test.cpp
+++ b/test/unit/math/rev/scal/fun/binary_log_loss_test.cpp
@@ -1,7 +1,7 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
-#include <test/unit/math/rev/mat/fun/util.hpp>
 #include <test/unit/math/rev/scal/fun/nan_util.hpp>
+#include <test/unit/math/rev/scal/util.hpp>
 
 double inf = std::numeric_limits<double>::infinity();
 
@@ -94,4 +94,9 @@ struct binary_log_loss_fun {
 TEST(AgradRev,binary_log_loss_NaN) {
   binary_log_loss_fun binary_log_loss_;
   test_nan(binary_log_loss_,false,true);
+}
+
+TEST(AgradRev, check_varis_on_stack) {
+  AVAR y_hat = 0.0;
+  test::check_varis_on_stack(stan::math::binary_log_loss(0, y_hat));
 }

--- a/test/unit/math/rev/scal/fun/binary_log_loss_test.cpp
+++ b/test/unit/math/rev/scal/fun/binary_log_loss_test.cpp
@@ -99,4 +99,5 @@ TEST(AgradRev,binary_log_loss_NaN) {
 TEST(AgradRev, check_varis_on_stack) {
   AVAR y_hat = 0.0;
   test::check_varis_on_stack(stan::math::binary_log_loss(0, y_hat));
+  test::check_varis_on_stack(stan::math::binary_log_loss(1, y_hat));
 }

--- a/test/unit/math/rev/scal/fun/cbrt_test.cpp
+++ b/test/unit/math/rev/scal/fun/cbrt_test.cpp
@@ -1,7 +1,7 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
-#include <test/unit/math/rev/mat/fun/util.hpp>
 #include <test/unit/math/rev/scal/fun/nan_util.hpp>
+#include <test/unit/math/rev/scal/util.hpp>
 
 TEST(AgradRev,cbrt) {
   AVAR a = 27.0;
@@ -25,4 +25,9 @@ struct cbrt_fun {
 TEST(AgradRev,cbrt_NaN) {
   cbrt_fun cbrt_;
   test_nan(cbrt_,false,true);
+}
+
+TEST(AgradRev, check_varis_on_stack) {
+  AVAR a = 27;
+  test::check_varis_on_stack(stan::math::cbrt(a));
 }

--- a/test/unit/math/rev/scal/fun/ceil_test.cpp
+++ b/test/unit/math/rev/scal/fun/ceil_test.cpp
@@ -1,7 +1,7 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
-#include <test/unit/math/rev/mat/fun/util.hpp>
 #include <test/unit/math/rev/scal/fun/nan_util.hpp>
+#include <test/unit/math/rev/scal/util.hpp>
 
 TEST(AgradRev,ceil_var) {
   AVAR a = 1.9;
@@ -25,4 +25,9 @@ struct ceil_fun {
 TEST(AgradRev,ceil_NaN) {
   ceil_fun ceil_;
   test_nan(ceil_,false,true);
+}
+
+TEST(AgradRev, check_varis_on_stack) {
+  AVAR a = 1.9;
+  test::check_varis_on_stack(stan::math::ceil(a));
 }

--- a/test/unit/math/rev/scal/fun/cos_test.cpp
+++ b/test/unit/math/rev/scal/fun/cos_test.cpp
@@ -1,7 +1,7 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
-#include <test/unit/math/rev/mat/fun/util.hpp>
 #include <test/unit/math/rev/scal/fun/nan_util.hpp>
+#include <test/unit/math/rev/scal/util.hpp>
 
 TEST(AgradRev,cos_var) {
   AVAR a = 0.49;
@@ -45,4 +45,9 @@ struct cos_fun {
 TEST(AgradRev,cos_NaN) {
   cos_fun cos_;
   test_nan(cos_,false,true);
+}
+
+TEST(AgradRev, check_varis_on_stack) {
+  AVAR a = 0.49;
+  test::check_varis_on_stack(stan::math::cos(a));
 }

--- a/test/unit/math/rev/scal/fun/cosh_test.cpp
+++ b/test/unit/math/rev/scal/fun/cosh_test.cpp
@@ -1,6 +1,6 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
-#include <test/unit/math/rev/mat/fun/util.hpp>
+#include <test/unit/math/rev/scal/util.hpp>
 #include <test/unit/math/rev/scal/fun/nan_util.hpp>
 #include <cmath>
 
@@ -61,4 +61,9 @@ struct cosh_fun {
 TEST(AgradRev,cosh_NaN) {
   cosh_fun cosh_;
   test_nan(cosh_,false,true);
+}
+
+TEST(AgradRev, check_varis_on_stack) {
+  AVAR a = 0.68;
+  test::check_varis_on_stack(stan::math::cosh(a));
 }

--- a/test/unit/math/rev/scal/fun/digamma_test.cpp
+++ b/test/unit/math/rev/scal/fun/digamma_test.cpp
@@ -1,9 +1,9 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
-#include <test/unit/math/rev/mat/fun/util.hpp>
+#include <test/unit/math/rev/scal/fun/nan_util.hpp>
+#include <test/unit/math/rev/scal/util.hpp>
 #include <boost/math/special_functions/digamma.hpp>
 #include <boost/math/special_functions/zeta.hpp>
-#include <test/unit/math/rev/scal/fun/nan_util.hpp>
 
 TEST(AgradRev,digamma) {
   AVAR a = 0.5;
@@ -27,4 +27,9 @@ struct digamma_fun {
 TEST(AgradRev,digamma_NaN) {
   digamma_fun digamma_;
   test_nan(digamma_,false,true);
+}
+
+TEST(AgradRev, check_varis_on_stack) {
+  AVAR a = 0.5;
+  test::check_varis_on_stack(stan::math::digamma(a));
 }

--- a/test/unit/math/rev/scal/fun/erf_test.cpp
+++ b/test/unit/math/rev/scal/fun/erf_test.cpp
@@ -1,8 +1,8 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
-#include <test/unit/math/rev/mat/fun/util.hpp>
-#include <boost/math/special_functions/erf.hpp>
 #include <test/unit/math/rev/scal/fun/nan_util.hpp>
+#include <test/unit/math/rev/scal/util.hpp>
+#include <boost/math/special_functions/erf.hpp>
 
 TEST(AgradRev,erf) {
   AVAR a = 1.3;
@@ -25,4 +25,9 @@ struct erf_fun {
 TEST(AgradRev,erf_NaN) {
   erf_fun erf_;
   test_nan(erf_,false,true);
+}
+
+TEST(AgradRev, check_varis_on_stack) {
+  AVAR a = 1.3;
+  test::check_varis_on_stack(stan::math::erf(a));
 }

--- a/test/unit/math/rev/scal/fun/erfc_test.cpp
+++ b/test/unit/math/rev/scal/fun/erfc_test.cpp
@@ -1,7 +1,7 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
-#include <test/unit/math/rev/mat/fun/util.hpp>
 #include <test/unit/math/rev/scal/fun/nan_util.hpp>
+#include <test/unit/math/rev/scal/util.hpp>
 
 TEST(AgradRev,erfc) {
   AVAR a = 1.3;
@@ -25,4 +25,9 @@ struct erfc_fun {
 TEST(AgradRev,erfc_NaN) {
   erfc_fun erfc_;
   test_nan(erfc_,false,true);
+}
+
+TEST(AgradRev, check_varis_on_stack) {
+  AVAR a = 1.3;
+  test::check_varis_on_stack(stan::math::erfc(a));
 }

--- a/test/unit/math/rev/scal/fun/exp2_test.cpp
+++ b/test/unit/math/rev/scal/fun/exp2_test.cpp
@@ -1,7 +1,7 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
-#include <test/unit/math/rev/mat/fun/util.hpp>
 #include <test/unit/math/rev/scal/fun/nan_util.hpp>
+#include <test/unit/math/rev/scal/util.hpp>
 
 TEST(AgradRev,exp2) {
   AVAR a = 1.3;
@@ -29,4 +29,9 @@ struct exp2_fun {
 TEST(AgradRev,exp2_NaN) {
   exp2_fun exp2_;
   test_nan(exp2_,false,true);
+}
+
+TEST(AgradRev, check_varis_on_stack) {
+  AVAR a = 1.3;
+  test::check_varis_on_stack(stan::math::exp2(a));
 }

--- a/test/unit/math/rev/scal/fun/exp_test.cpp
+++ b/test/unit/math/rev/scal/fun/exp_test.cpp
@@ -1,7 +1,7 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
-#include <test/unit/math/rev/mat/fun/util.hpp>
 #include <test/unit/math/rev/scal/fun/nan_util.hpp>
+#include <test/unit/math/rev/scal/util.hpp>
 
 TEST(AgradRev,exp_a) {
   AVAR a(6.0);
@@ -24,4 +24,9 @@ struct exp_fun {
 TEST(AgradRev,exp_NaN) {
   exp_fun exp_;
   test_nan(exp_,false,true);
+}
+
+TEST(AgradRev, check_varis_on_stack) {
+  AVAR a(6.0);
+  test::check_varis_on_stack(stan::math::exp(a));
 }

--- a/test/unit/math/rev/scal/fun/expm1_test.cpp
+++ b/test/unit/math/rev/scal/fun/expm1_test.cpp
@@ -1,8 +1,8 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
-#include <test/unit/math/rev/mat/fun/util.hpp>
-#include <boost/math/special_functions/expm1.hpp>
 #include <test/unit/math/rev/scal/fun/nan_util.hpp>
+#include <test/unit/math/rev/scal/util.hpp>
+#include <boost/math/special_functions/expm1.hpp>
 
 TEST(AgradRev,expm1) {
   AVAR a = 1.3;
@@ -26,4 +26,9 @@ struct expm1_fun {
 TEST(AgradRev,expm1_NaN) {
   expm1_fun expm1_;
   test_nan(expm1_,false,true);
+}
+
+TEST(AgradRev, check_varis_on_stack) {
+  AVAR a = 1.3;
+  test::check_varis_on_stack(expm1(a));
 }

--- a/test/unit/math/rev/scal/fun/fabs_test.cpp
+++ b/test/unit/math/rev/scal/fun/fabs_test.cpp
@@ -1,8 +1,8 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
 #include <limits>
-#include <test/unit/math/rev/mat/fun/util.hpp>
 #include <test/unit/math/rev/scal/fun/nan_util.hpp>
+#include <test/unit/math/rev/scal/util.hpp>
 
 TEST(AgradRev,fabs_var) {
   AVAR a = 0.68;
@@ -48,4 +48,9 @@ struct fabs_fun {
 TEST(AgradRev,fabs_NaN) {
   fabs_fun fabs_;
   test_nan(fabs_,false,true);
+}
+
+TEST(AgradRev, check_varis_on_stack) {
+  AVAR a = 0.68;
+  test::check_varis_on_stack(stan::math::fabs(a));
 }

--- a/test/unit/math/rev/scal/fun/falling_factorial_test.cpp
+++ b/test/unit/math/rev/scal/fun/falling_factorial_test.cpp
@@ -1,8 +1,8 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
-#include <test/unit/math/rev/mat/fun/util.hpp>
-#include <boost/math/special_functions/digamma.hpp>
 #include <test/unit/math/rev/scal/fun/nan_util.hpp>
+#include <test/unit/math/rev/scal/util.hpp>
+#include <boost/math/special_functions/digamma.hpp>
 
 TEST(AgradRev,falling_factorial_var_double) {
   double a(2);
@@ -81,4 +81,12 @@ TEST(AgradRev, falling_factorial_nan) {
   falling_factorial_fun falling_factorial_;
   test_nan(falling_factorial_,4.0,1.0,false,true);
 
+}
+
+TEST(AgradRev, check_varis_on_stack) {
+  AVAR a(2);
+  AVAR b(4.0);
+  test::check_varis_on_stack(stan::math::falling_factorial(b,a));
+  test::check_varis_on_stack(stan::math::falling_factorial(b,2));
+  test::check_varis_on_stack(stan::math::falling_factorial(4,a));
 }

--- a/test/unit/math/rev/scal/fun/fdim_test.cpp
+++ b/test/unit/math/rev/scal/fun/fdim_test.cpp
@@ -1,7 +1,7 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
-#include <test/unit/math/rev/mat/fun/util.hpp>
 #include <test/unit/math/rev/scal/fun/nan_util.hpp>
+#include <test/unit/math/rev/scal/util.hpp>
 
 TEST(AgradRev,fdim_vv) {
   using stan::math::fdim;
@@ -126,4 +126,12 @@ struct fdim_fun {
 TEST(AgradRev, fdim_nan) {
   fdim_fun fdim_;
   test_nan(fdim_, 3.0, 5.0, false, true);
+}
+
+TEST(AgradRev, check_varis_on_stack) {
+  AVAR a = 3.0;
+  AVAR b = 4.0;
+  test::check_varis_on_stack(stan::math::fdim(a, b));
+  test::check_varis_on_stack(stan::math::fdim(a, 4.0));
+  test::check_varis_on_stack(stan::math::fdim(3.0, b));
 }

--- a/test/unit/math/rev/scal/fun/floor_test.cpp
+++ b/test/unit/math/rev/scal/fun/floor_test.cpp
@@ -1,7 +1,7 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
-#include <test/unit/math/rev/mat/fun/util.hpp>
 #include <test/unit/math/rev/scal/fun/nan_util.hpp>
+#include <test/unit/math/rev/scal/util.hpp>
 
 TEST(AgradRev,floor_var) {
   AVAR a = 1.2;
@@ -25,4 +25,9 @@ struct floor_fun {
 TEST(AgradRev,floor_NaN) {
   floor_fun floor_;
   test_nan(floor_,false,true);
+}
+
+TEST(AgradRev, check_varis_on_stack) {
+  AVAR a = 1.2;
+  test::check_varis_on_stack(stan::math::floor(a));
 }

--- a/test/unit/math/rev/scal/fun/fma_test.cpp
+++ b/test/unit/math/rev/scal/fun/fma_test.cpp
@@ -1,8 +1,8 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
 #include <cmath>
-#include <test/unit/math/rev/mat/fun/util.hpp>
 #include <test/unit/math/rev/scal/fun/nan_util.hpp>
+#include <test/unit/math/rev/scal/util.hpp>
 
 TEST(AgradRev,fma_vvv) {
   AVAR a = 3.0;
@@ -108,4 +108,17 @@ struct fma_fun {
 TEST(AgradRev,fma_NaN) {
   fma_fun fma_;
   test_nan(fma_,0.6,0.3,0.5,false,true);
+}
+
+TEST(, check_varis_on_stack) {
+  AVAR a = 3.0;
+  AVAR b = 5.0;
+  AVAR c = 7.0;
+  test::check_varis_on_stack(stan::math::fma(a, b, c));
+  test::check_varis_on_stack(stan::math::fma(a, b, 7));
+  test::check_varis_on_stack(stan::math::fma(a, 5, c));
+  test::check_varis_on_stack(stan::math::fma(a, 5, 7));
+  test::check_varis_on_stack(stan::math::fma(3, b, c));
+  test::check_varis_on_stack(stan::math::fma(3, b, 7));
+  test::check_varis_on_stack(stan::math::fma(3, 5, c));
 }

--- a/test/unit/math/rev/scal/fun/fmax_test.cpp
+++ b/test/unit/math/rev/scal/fun/fmax_test.cpp
@@ -1,7 +1,7 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
-#include <test/unit/math/rev/mat/fun/util.hpp>
 #include <test/unit/math/rev/scal/fun/nan_util.hpp>
+#include <test/unit/math/rev/scal/util.hpp>
 
 TEST(AgradRev,fmax_vv) {
   AVAR a = 1.3;
@@ -132,4 +132,12 @@ TEST(AgradRev, fmax_nan) {
   test_nan_vv(fmax_,nan,nan,false, true);
   test_nan_dv(fmax_,nan,nan,false, true);
   test_nan_vd(fmax_,nan,nan,false, true);
+}
+
+TEST(AgradRev, check_varis_on_stack) {
+  AVAR a = 1.3;
+  AVAR b = 2.0;
+  test::check_varis_on_stack(stan::math::fmax(a, b));
+  test::check_varis_on_stack(stan::math::fmax(a, 2.0));
+  test::check_varis_on_stack(stan::math::fmax(1.3, b));
 }

--- a/test/unit/math/rev/scal/fun/fmin_test.cpp
+++ b/test/unit/math/rev/scal/fun/fmin_test.cpp
@@ -1,7 +1,7 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
-#include <test/unit/math/rev/mat/fun/util.hpp>
 #include <test/unit/math/rev/scal/fun/nan_util.hpp>
+#include <test/unit/math/rev/scal/util.hpp>
 
 TEST(AgradRev,fmin_vv) {
   AVAR a = 1.3;
@@ -132,4 +132,12 @@ TEST(AgradRev, fmin_nan) {
   test_nan_vv(fmin_,nan,nan,false, true);
   test_nan_dv(fmin_,nan,nan,false, true);
   test_nan_vd(fmin_,nan,nan,false, true);
+}
+
+TEST(AgradRev, check_varis_on_stack) {
+  AVAR a = 1.3;
+  AVAR b = 2.0;
+  test::check_varis_on_stack(stan::math::fmin(a, b));
+  test::check_varis_on_stack(stan::math::fmin(a, 2.0));
+  test::check_varis_on_stack(stan::math::fmin(1.3, b));
 }

--- a/test/unit/math/rev/scal/fun/fmod_test.cpp
+++ b/test/unit/math/rev/scal/fun/fmod_test.cpp
@@ -1,7 +1,7 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
-#include <test/unit/math/rev/mat/fun/util.hpp>
 #include <test/unit/math/rev/scal/fun/nan_util.hpp>
+#include <test/unit/math/rev/scal/util.hpp>
 
 TEST(AgradRev,fmod_var_var) {
   AVAR a = 2.7;
@@ -53,4 +53,12 @@ struct fmod_fun {
 TEST(AgradRev, fmod_nan) {
   fmod_fun fmod_;
   test_nan(fmod_,3.0,5.0,false, true);
+}
+
+TEST(AgradRev, check_varis_on_stack) {
+  AVAR a = 2.7;
+  AVAR b = 1.3;
+  test::check_varis_on_stack(stan::math::fmod(a, b));
+  test::check_varis_on_stack(stan::math::fmod(a, 1.3));
+  test::check_varis_on_stack(stan::math::fmod(2.7, b));
 }

--- a/test/unit/math/rev/scal/fun/gamma_p_test.cpp
+++ b/test/unit/math/rev/scal/fun/gamma_p_test.cpp
@@ -1,8 +1,8 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
 #include <boost/math/special_functions/gamma.hpp>
-#include <test/unit/math/rev/mat/fun/util.hpp>
 #include <test/unit/math/rev/scal/fun/nan_util.hpp>
+#include <test/unit/math/rev/scal/util.hpp>
 
 TEST(AgradRev,gamma_p_var_var) {
   AVAR a = 0.5;
@@ -70,4 +70,12 @@ struct gamma_p_fun {
 TEST(AgradRev, gamma_p_nan) {
   gamma_p_fun gamma_p_;
   test_nan(gamma_p_,0.5,1.0,false,true);
+}
+
+TEST(AgradRev, check_varis_on_stack) {
+  AVAR a = 0.5;
+  AVAR b = 1.0;
+  test::check_varis_on_stack(stan::math::gamma_p(a, b));
+  test::check_varis_on_stack(stan::math::gamma_p(a, 1.0));
+  test::check_varis_on_stack(stan::math::gamma_p(0.5, b));
 }

--- a/test/unit/math/rev/scal/fun/gamma_q_test.cpp
+++ b/test/unit/math/rev/scal/fun/gamma_q_test.cpp
@@ -1,8 +1,8 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
 #include <boost/math/special_functions/gamma.hpp>
-#include <test/unit/math/rev/mat/fun/util.hpp>
 #include <test/unit/math/rev/scal/fun/nan_util.hpp>
+#include <test/unit/math/rev/scal/util.hpp>
 
 TEST(AgradRev,gamma_q_var_var) {
   AVAR a = 0.5;
@@ -90,4 +90,12 @@ struct gamma_q_fun {
 TEST(AgradRev, gamma_q_nan) {
   gamma_q_fun gamma_q_;
   test_nan(gamma_q_,3.0,5.0,false,true);
+}
+
+TEST(AgradRev, check_varis_on_stack) {
+  AVAR a = 0.5;
+  AVAR b = 1.0;
+  test::check_varis_on_stack(stan::math::gamma_q(a,b));
+  test::check_varis_on_stack(stan::math::gamma_q(a,1.0));
+  test::check_varis_on_stack(stan::math::gamma_q(0.5,b));
 }

--- a/test/unit/math/rev/scal/fun/gamma_q_test.cpp
+++ b/test/unit/math/rev/scal/fun/gamma_q_test.cpp
@@ -95,7 +95,7 @@ TEST(AgradRev, gamma_q_nan) {
 TEST(AgradRev, check_varis_on_stack) {
   AVAR a = 0.5;
   AVAR b = 1.0;
-  test::check_varis_on_stack(stan::math::gamma_q(a,b));
-  test::check_varis_on_stack(stan::math::gamma_q(a,1.0));
-  test::check_varis_on_stack(stan::math::gamma_q(0.5,b));
+  test::check_varis_on_stack(stan::math::gamma_q(a, b));
+  test::check_varis_on_stack(stan::math::gamma_q(a, 1.0));
+  test::check_varis_on_stack(stan::math::gamma_q(0.5, b));
 }

--- a/test/unit/math/rev/scal/fun/hypot_test.cpp
+++ b/test/unit/math/rev/scal/fun/hypot_test.cpp
@@ -1,7 +1,7 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
-#include <test/unit/math/rev/mat/fun/util.hpp>
 #include <test/unit/math/rev/scal/fun/nan_util.hpp>
+#include <test/unit/math/rev/scal/util.hpp>
 
 TEST(AgradRev,hypot_vv) {
   AVAR a = 3.0;
@@ -56,4 +56,12 @@ struct hypot_fun {
 TEST(AgradRev, hypot_nan) {
   hypot_fun hypot_;
   test_nan(hypot_,3.0,5.0,false, true);
+}
+
+TEST(AgradRev, check_varis_on_stack) {
+  AVAR a = 3.0;
+  AVAR b = 4.0;
+  test::check_varis_on_stack(stan::math::hypot(a, b));
+  test::check_varis_on_stack(stan::math::hypot(a, 4.0));
+  test::check_varis_on_stack(stan::math::hypot(3.0, b));
 }

--- a/test/unit/math/rev/scal/fun/ibeta_test.cpp
+++ b/test/unit/math/rev/scal/fun/ibeta_test.cpp
@@ -1,7 +1,7 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
-#include <test/unit/math/rev/mat/fun/util.hpp>
 #include <test/unit/math/rev/scal/fun/nan_util.hpp>
+#include <test/unit/math/rev/scal/util.hpp>
 #include <boost/math/special_functions/beta.hpp>
 
 TEST(AgradRev,ibeta_vvv) {
@@ -218,4 +218,17 @@ struct ibeta_fun {
 TEST(AgradRev,ibeta_NaN) {
   ibeta_fun ibeta_;
   test_nan(ibeta_,0.6,0.3,0.5,true,false);
+}
+
+TEST(AgradRev, check_varis_on_stack) {
+  AVAR a = 0.6;
+  AVAR b = 0.3;
+  AVAR c = 0.5;
+  test::check_varis_on_stack(stan::math::ibeta(a, b, c));
+  test::check_varis_on_stack(stan::math::ibeta(a, b, 0.5));
+  test::check_varis_on_stack(stan::math::ibeta(a, 0.3, c));
+  test::check_varis_on_stack(stan::math::ibeta(a, 0.3, 0.5));
+  test::check_varis_on_stack(stan::math::ibeta(0.6, b, c));
+  test::check_varis_on_stack(stan::math::ibeta(0.6, b, 0.5));
+  test::check_varis_on_stack(stan::math::ibeta(0.6, 0.3, c));
 }

--- a/test/unit/math/rev/scal/fun/if_else_test.cpp
+++ b/test/unit/math/rev/scal/fun/if_else_test.cpp
@@ -1,6 +1,6 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
-#include <test/unit/math/rev/mat/fun/util.hpp>
+#include <test/unit/math/rev/scal/util.hpp>
 #include <boost/math/special_functions/fpclassify.hpp>
 
 TEST(AgradRev,if_else) {
@@ -59,4 +59,15 @@ TEST(AgradRev, if_else_nan) {
                if_else(false, nan_v, nan).val());
   EXPECT_PRED1(boost::math::isnan<double>,
                if_else(false, nan_v, nan_v).val());
+}
+
+TEST(AgradRev, check_varis_on_stack) {
+  stan::math::var x = 1.0;
+  stan::math::var y = 2.0;
+  test::check_varis_on_stack(stan::math::if_else(true, x, y));
+  test::check_varis_on_stack(stan::math::if_else(false, x, y));
+  test::check_varis_on_stack(stan::math::if_else(true, x, 2.0));
+  test::check_varis_on_stack(stan::math::if_else(false, x, 2.0));
+  test::check_varis_on_stack(stan::math::if_else(true, 1.0, y));
+  test::check_varis_on_stack(stan::math::if_else(false, 1.0, y));
 }

--- a/test/unit/math/rev/scal/fun/int_step_test.cpp
+++ b/test/unit/math/rev/scal/fun/int_step_test.cpp
@@ -1,6 +1,6 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
-#include <test/unit/math/rev/mat/fun/util.hpp>
+#include <test/unit/math/rev/scal/fun/util.hpp>
 
 TEST(AgradRev,int_step) {
   using stan::math::int_step;

--- a/test/unit/math/rev/scal/fun/inv_Phi_test.cpp
+++ b/test/unit/math/rev/scal/fun/inv_Phi_test.cpp
@@ -1,7 +1,7 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
-#include <test/unit/math/rev/mat/fun/util.hpp>
 #include <test/unit/math/rev/scal/fun/nan_util.hpp>
+#include <test/unit/math/rev/scal/util.hpp>
 #include <vector>
 
 TEST(MathFunctions, inv_Phi) {
@@ -75,3 +75,8 @@ TEST(AgradRev,inv_Phi_NaN) {
   test_nan(foo,true,false);
 }
 
+
+TEST(AgradRev, check_varis_on_stack) {
+  stan::math::var p = 0.5;
+  test::check_varis_on_stack(stan::math::inv_Phi(p));
+}

--- a/test/unit/math/rev/scal/fun/inv_cloglog_test.cpp
+++ b/test/unit/math/rev/scal/fun/inv_cloglog_test.cpp
@@ -1,7 +1,7 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
-#include <test/unit/math/rev/mat/fun/util.hpp>
 #include <test/unit/math/rev/scal/fun/nan_util.hpp>
+#include <test/unit/math/rev/scal/util.hpp>
 
 TEST(AgradRev,inv_cloglog) {
   using std::exp;
@@ -35,4 +35,9 @@ struct inv_cloglog_fun {
 TEST(AgradRev,inv_cloglog_NaN) {
   inv_cloglog_fun inv_cloglog_;
   test_nan(inv_cloglog_,false,true);
+}
+
+TEST(AgradRev, check_varis_on_stack) {
+  AVAR a = 2.7;
+  test::check_varis_on_stack(stan::math::inv_cloglog(a));
 }

--- a/test/unit/math/rev/scal/fun/inv_logit_test.cpp
+++ b/test/unit/math/rev/scal/fun/inv_logit_test.cpp
@@ -1,7 +1,7 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
-#include <test/unit/math/rev/mat/fun/util.hpp>
 #include <test/unit/math/rev/scal/fun/nan_util.hpp>
+#include <test/unit/math/rev/scal/util.hpp>
 
 TEST(AgradRev,inv_logit) {
   AVAR a = 2.0;
@@ -26,4 +26,9 @@ struct inv_logit_fun {
 TEST(AgradRev,inv_logit_NaN) {
   inv_logit_fun inv_logit_;
   test_nan(inv_logit_,false,true);
+}
+
+TEST(AgradRev, check_varis_on_stack) {
+  AVAR a = 2.0;
+  test::check_varis_on_stack(stan::math::inv_logit(a));
 }

--- a/test/unit/math/rev/scal/fun/inv_sqrt_test.cpp
+++ b/test/unit/math/rev/scal/fun/inv_sqrt_test.cpp
@@ -1,7 +1,7 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
-#include <test/unit/math/rev/mat/fun/util.hpp>
 #include <test/unit/math/rev/scal/fun/nan_util.hpp>
+#include <test/unit/math/rev/scal/util.hpp>
 
 TEST(AgradRev,inv_sqrt) {
   AVAR a = 49.0;
@@ -42,4 +42,9 @@ struct inv_sqrt_fun {
 TEST(AgradRev,inv_sqrt_NaN) {
   inv_sqrt_fun inv_sqrt_;
   test_nan(inv_sqrt_,false,true);
+}
+
+TEST(AgradRev, check_varis_on_stack) {
+  AVAR a = 49.0;
+  test::check_varis_on_stack(stan::math::inv_sqrt(a));
 }

--- a/test/unit/math/rev/scal/fun/inv_square_test.cpp
+++ b/test/unit/math/rev/scal/fun/inv_square_test.cpp
@@ -1,7 +1,7 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
-#include <test/unit/math/rev/mat/fun/util.hpp>
 #include <test/unit/math/rev/scal/fun/nan_util.hpp>
+#include <test/unit/math/rev/scal/util.hpp>
 
 TEST(AgradRev,inv_square) {
   AVAR a = 7.0;
@@ -34,4 +34,9 @@ struct inv_square_fun {
 TEST(AgradRev,inv_square_NaN) {
   inv_square_fun inv_square_;
   test_nan(inv_square_,false,true);
+}
+
+TEST(AgradRev, check_varis_on_stack) {
+  AVAR a = 7.0;
+  test::check_varis_on_stack(inv_square(a));
 }

--- a/test/unit/math/rev/scal/fun/inv_test.cpp
+++ b/test/unit/math/rev/scal/fun/inv_test.cpp
@@ -1,7 +1,7 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
-#include <test/unit/math/rev/mat/fun/util.hpp>
 #include <test/unit/math/rev/scal/fun/nan_util.hpp>
+#include <test/unit/math/rev/scal/util.hpp>
 
 TEST(AgradRev,inv) {
   AVAR a = 7.0;
@@ -34,4 +34,9 @@ struct inv_fun {
 TEST(AgradRev,inv_NaN) {
   inv_fun inv_;
   test_nan(inv_,false,true);
+}
+
+TEST(AgradRev, check_varis_on_stack) {
+  AVAR a = 7.0;
+  test::check_varis_on_stack(stan::math::inv(a));
 }

--- a/test/unit/math/rev/scal/fun/lgamma_test.cpp
+++ b/test/unit/math/rev/scal/fun/lgamma_test.cpp
@@ -1,7 +1,7 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
-#include <test/unit/math/rev/mat/fun/util.hpp>
 #include <test/unit/math/rev/scal/fun/nan_util.hpp>
+#include <test/unit/math/rev/scal/util.hpp>
 #include <boost/math/special_functions/digamma.hpp>
 
 TEST(AgradRev,lgamma) {
@@ -26,4 +26,9 @@ struct lgamma_fun {
 TEST(AgradRev,lgamma_NaN) {
   lgamma_fun lgamma_;
   test_nan(lgamma_,false,true);
+}
+
+TEST(AgradRev, check_varis_on_stack) {
+  AVAR a = 3.0;  
+  test::check_varis_on_stack(stan::math::lgamma(a));
 }

--- a/test/unit/math/rev/scal/fun/lmgamma_test.cpp
+++ b/test/unit/math/rev/scal/fun/lmgamma_test.cpp
@@ -1,7 +1,7 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
-#include <test/unit/math/rev/mat/fun/util.hpp>
 #include <test/unit/math/rev/scal/fun/nan_util.hpp>
+#include <test/unit/math/rev/scal/util.hpp>
 
 TEST(AgradRev,lmgamma) {
   using stan::math::lmgamma;
@@ -26,4 +26,9 @@ struct lmgamma_fun {
 TEST(AgradRev,lmgamma_NaN) {
   lmgamma_fun lmgamma_;
   test_nan(lmgamma_,false,true);
+}
+
+TEST(AgradRev, check_varis_on_stack) {
+  stan::math::var a = 3.2;
+  test::check_varis_on_stack(stan::math::lmgamma(3, a));
 }

--- a/test/unit/math/rev/scal/fun/log10_test.cpp
+++ b/test/unit/math/rev/scal/fun/log10_test.cpp
@@ -1,7 +1,7 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
-#include <test/unit/math/rev/mat/fun/util.hpp>
 #include <test/unit/math/rev/scal/fun/nan_util.hpp>
+#include <test/unit/math/rev/scal/util.hpp>
 
 TEST(AgradRev,log10_a) {
   AVAR a(5.0);
@@ -24,4 +24,9 @@ struct log10_fun {
 TEST(AgradRev,log10_NaN) {
   log10_fun log10_;
   test_nan(log10_,false,true);
+}
+
+TEST(AgradRev, check_varis_on_stack) {
+  stan::math::var x = 4.0;
+  test::check_varis_on_stack(stan::math::log10(x));
 }

--- a/test/unit/math/rev/scal/fun/log1m_exp_test.cpp
+++ b/test/unit/math/rev/scal/fun/log1m_exp_test.cpp
@@ -1,7 +1,7 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
-#include <test/unit/math/rev/mat/fun/util.hpp>
 #include <test/unit/math/rev/scal/fun/nan_util.hpp>
+#include <test/unit/math/rev/scal/util.hpp>
 
 void test_log1m_exp(double val) {
   using stan::math::log1m_exp;
@@ -55,4 +55,9 @@ struct log1m_exp_fun {
 TEST(AgradRev,log1m_exp_NaN) {
   log1m_exp_fun log1m_exp_;
   test_nan(log1m_exp_,false,true);
+}
+
+TEST(AgradRev, check_varis_on_stack) {
+  stan::math::var a = -2.0;
+  test::check_varis_on_stack(stan::math::log1m_exp(a));
 }

--- a/test/unit/math/rev/scal/fun/log1m_inv_logit_test.cpp
+++ b/test/unit/math/rev/scal/fun/log1m_inv_logit_test.cpp
@@ -1,7 +1,7 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
-#include <test/unit/math/rev/mat/fun/util.hpp>
 #include <test/unit/math/rev/scal/fun/nan_util.hpp>
+#include <test/unit/math/rev/scal/util.hpp>
 #include <vector>
 
 void test_log1m_inv_logit(const double x) {
@@ -48,4 +48,9 @@ struct log1m_inv_logit_fun {
 TEST(AgradRev,log1m_inv_logit_NaN) {
   log1m_inv_logit_fun log1m_inv_logit_;
   test_nan(log1m_inv_logit_,false,true);
+}
+
+TEST(AgradRev, check_varis_on_stack) {
+  stan::math::var x = -7.2;
+  test::check_varis_on_stack(stan::math::log1m_inv_logit(x));
 }

--- a/test/unit/math/rev/scal/fun/log1m_test.cpp
+++ b/test/unit/math/rev/scal/fun/log1m_test.cpp
@@ -1,7 +1,7 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
-#include <test/unit/math/rev/mat/fun/util.hpp>
 #include <test/unit/math/rev/scal/fun/nan_util.hpp>
+#include <test/unit/math/rev/scal/util.hpp>
 
 TEST(AgradRev,log1m) {
   using stan::math::log1m;
@@ -35,4 +35,9 @@ struct log1m_fun {
 TEST(AgradRev,log1m_NaN) {
   log1m_fun log1m_;
   test_nan(log1m_,false,true);
+}
+
+TEST(AgradRev, check_varis_on_stack) {
+  AVAR a = 0.1;
+  test::check_varis_on_stack(stan::math::log1m(a));
 }

--- a/test/unit/math/rev/scal/fun/log1p_exp_test.cpp
+++ b/test/unit/math/rev/scal/fun/log1p_exp_test.cpp
@@ -1,7 +1,7 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
-#include <test/unit/math/rev/mat/fun/util.hpp>
 #include <test/unit/math/rev/scal/fun/nan_util.hpp>
+#include <test/unit/math/rev/scal/util.hpp>
 
 void test_log1p_exp(double val) {
   using stan::math::log1p_exp;
@@ -51,4 +51,9 @@ struct log1p_exp_fun {
 TEST(AgradRev,log1p_exp_NaN) {
   log1p_exp_fun log1p_exp_;
   test_nan(log1p_exp_,false,true);
+}
+
+TEST(AgradRev, check_varis_on_stack) {
+  AVAR a(-15);   
+  test::check_varis_on_stack(stan::math::log1p_exp(a));
 }

--- a/test/unit/math/rev/scal/fun/log1p_test.cpp
+++ b/test/unit/math/rev/scal/fun/log1p_test.cpp
@@ -1,7 +1,7 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
-#include <test/unit/math/rev/mat/fun/util.hpp>
 #include <test/unit/math/rev/scal/fun/nan_util.hpp>
+#include <test/unit/math/rev/scal/util.hpp>
 #include <stdexcept>
 
 TEST(AgradRev,log1p) {
@@ -39,4 +39,9 @@ struct log1p_fun {
 TEST(AgradRev,log1p_NaN) {
   log1p_fun log1p_;
   test_nan(log1p_,false,true);
+}
+
+TEST(AgradRev, check_varis_on_stack) {
+  AVAR a = 0.1;
+  test::check_varis_on_stack(stan::math::log1p(a));
 }

--- a/test/unit/math/rev/scal/fun/log2_test.cpp
+++ b/test/unit/math/rev/scal/fun/log2_test.cpp
@@ -1,7 +1,7 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
-#include <test/unit/math/rev/mat/fun/util.hpp>
 #include <test/unit/math/rev/scal/fun/nan_util.hpp>
+#include <test/unit/math/rev/scal/util.hpp>
 
 TEST(AgradRev,log2) {
   AVAR a = 3.0;
@@ -29,4 +29,9 @@ struct log2_fun {
 TEST(AgradRev,log2_NaN) {
   log2_fun log2_;
   test_nan(log2_,false,true);
+}
+
+TEST(AgradRev, check_varis_on_stack) {
+  AVAR a = 3.0;
+  test::check_varis_on_stack(stan::math::log2(a));
 }

--- a/test/unit/math/rev/scal/fun/log_diff_exp_test.cpp
+++ b/test/unit/math/rev/scal/fun/log_diff_exp_test.cpp
@@ -1,7 +1,7 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
-#include <test/unit/math/rev/mat/fun/util.hpp>
 #include <test/unit/math/rev/scal/fun/nan_util.hpp>
+#include <test/unit/math/rev/scal/util.hpp>
 
 TEST(AgradRev, log_diff_exp_vv) {
   AVAR a = 5.0;
@@ -190,4 +190,12 @@ struct log_diff_exp_fun {
 TEST(AgradRev, log_diff_exp_nan) {
   log_diff_exp_fun log_diff_exp_;
   test_nan(log_diff_exp_,3.0,5.0,false,true);
+}
+
+TEST(AgradRev, check_varis_on_stack) {
+  stan::math::var a = 5.0;
+  stan::math::var b = 2.0;
+  test::check_varis_on_stack(stan::math::log_diff_exp(a, b));
+  test::check_varis_on_stack(stan::math::log_diff_exp(a, 2.0));
+  test::check_varis_on_stack(stan::math::log_diff_exp(5.0, b));
 }

--- a/test/unit/math/rev/scal/fun/log_falling_factorial_test.cpp
+++ b/test/unit/math/rev/scal/fun/log_falling_factorial_test.cpp
@@ -1,7 +1,7 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
-#include <test/unit/math/rev/mat/fun/util.hpp>
 #include <test/unit/math/rev/scal/fun/nan_util.hpp>
+#include <test/unit/math/rev/scal/util.hpp>
 
 TEST(AgradRev,log_falling_factorial_var_double) {
   double a(2);
@@ -80,4 +80,12 @@ struct log_falling_factorial_fun {
 TEST(AgradRev, log_falling_factorial_nan) {
   log_falling_factorial_fun log_falling_factorial_;
   test_nan(log_falling_factorial_,4.0,4.0,false,true);
+}
+
+TEST(AgradRev, check_varis_on_stack) {
+  AVAR a(2.0);
+  AVAR b(4.0);
+  test::check_varis_on_stack(stan::math::log_falling_factorial(b, a));
+  test::check_varis_on_stack(stan::math::log_falling_factorial(b, 2.0));
+  test::check_varis_on_stack(stan::math::log_falling_factorial(4.0, a));
 }

--- a/test/unit/math/rev/scal/fun/log_inv_logit_test.cpp
+++ b/test/unit/math/rev/scal/fun/log_inv_logit_test.cpp
@@ -1,7 +1,7 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
-#include <test/unit/math/rev/mat/fun/util.hpp>
 #include <test/unit/math/rev/scal/fun/nan_util.hpp>
+#include <test/unit/math/rev/scal/util.hpp>
 #include <vector>
 
 void test_log_inv_logit(const double x) {
@@ -48,4 +48,9 @@ struct log_inv_logit_fun {
 TEST(AgradRev,log_inv_logit_NaN) {
   log_inv_logit_fun log_inv_logit_;
   test_nan(log_inv_logit_,false,true);
+}
+
+TEST(AgradRev, check_varis_on_stack) {
+  stan::math::var x = 0;
+  test::check_varis_on_stack(stan::math::log_inv_logit(x));
 }

--- a/test/unit/math/rev/scal/fun/log_mix_test.cpp
+++ b/test/unit/math/rev/scal/fun/log_mix_test.cpp
@@ -1,7 +1,7 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
-#include <test/unit/math/rev/mat/fun/util.hpp>
 #include <test/unit/math/rev/scal/fun/nan_util.hpp>
+#include <test/unit/math/rev/scal/util.hpp>
 #include <vector>
 
 void test_log_mix_vvv(double theta, double lambda1, double lambda2) {
@@ -319,4 +319,17 @@ struct log_mix_fun {
 TEST(AgradRev,log_mix_NaN) {
   log_mix_fun log_mix_;
   test_nan(log_mix_,0.6,0.3,0.5,true,false);
+}
+
+TEST(AgradRev, check_varis_on_stack) {
+  stan::math::var theta = 0.5;
+  stan::math::var x = 10.0;
+  stan::math::var y = 4.0;
+  test::check_varis_on_stack(stan::math::log_mix(theta, x, y));
+  test::check_varis_on_stack(stan::math::log_mix(theta, x, 4.0));
+  test::check_varis_on_stack(stan::math::log_mix(theta, 10.0, y));
+  test::check_varis_on_stack(stan::math::log_mix(theta, 10.0, 4.0));
+  test::check_varis_on_stack(stan::math::log_mix(0.5, x, y));
+  test::check_varis_on_stack(stan::math::log_mix(0.5, x, 4.0));
+  test::check_varis_on_stack(stan::math::log_mix(0.5, 10.0, y));
 }

--- a/test/unit/math/rev/scal/fun/log_rising_factorial_test.cpp
+++ b/test/unit/math/rev/scal/fun/log_rising_factorial_test.cpp
@@ -1,8 +1,8 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
-#include <test/unit/math/rev/mat/fun/util.hpp>
 #include <boost/math/special_functions/digamma.hpp>
 #include <test/unit/math/rev/scal/fun/nan_util.hpp>
+#include <test/unit/math/rev/scal/util.hpp>
 
 TEST(AgradRev,log_rising_factorial_var_double) {
   double a(1);
@@ -79,4 +79,12 @@ struct log_rising_factorial_fun {
 TEST(AgradRev, log_rising_factorial_nan) {
   log_rising_factorial_fun log_rising_factorial_;
   test_nan(log_rising_factorial_,3.0,5.0,false,true);
+}
+
+TEST(AgradRev, check_varis_on_stack) {
+  AVAR a(1.0);
+  AVAR b(4.0);
+  test::check_varis_on_stack(stan::math::log_rising_factorial(b, a));
+  test::check_varis_on_stack(stan::math::log_rising_factorial(b, 1.0));
+  test::check_varis_on_stack(stan::math::log_rising_factorial(4.0, a));
 }

--- a/test/unit/math/rev/scal/fun/log_sum_exp_test.cpp
+++ b/test/unit/math/rev/scal/fun/log_sum_exp_test.cpp
@@ -3,6 +3,7 @@
 #include <test/unit/math/rev/scal/fun/nan_util.hpp>
 #include <test/unit/math/rev/scal/fun/util.hpp>
 #include <test/unit/math/rev/arr/fun/util.hpp>
+#include <test/unit/math/rev/scal/util.hpp>
 
 TEST(AgradRev,log_sum_exp_vv) {
   AVAR a = 5.0;
@@ -179,4 +180,12 @@ struct log_sum_exp_fun {
 TEST(AgradRev, log_sum_exp_nan) {
   log_sum_exp_fun log_sum_exp_;
   test_nan(log_sum_exp_,3.0,5.0,false,true);
+}
+
+TEST(AgradRev, check_varis_on_stack) {
+  AVAR a = 5.0;
+  AVAR b = 2.0;
+  test::check_varis_on_stack(log_sum_exp(a, b));
+  test::check_varis_on_stack(log_sum_exp(5.0, b));
+  test::check_varis_on_stack(log_sum_exp(a, 2.0));
 }

--- a/test/unit/math/rev/scal/fun/log_test.cpp
+++ b/test/unit/math/rev/scal/fun/log_test.cpp
@@ -1,7 +1,7 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
-#include <test/unit/math/rev/mat/fun/util.hpp>
 #include <test/unit/math/rev/scal/fun/nan_util.hpp>
+#include <test/unit/math/rev/scal/util.hpp>
 
 TEST(AgradRev,log_a) {
   AVAR a(5.0);
@@ -40,4 +40,9 @@ struct log_fun {
 TEST(AgradRev,log_NaN) {
   log_fun log_;
   test_nan(log_,false,true);
+}
+
+TEST(AgradRev, check_varis_on_stack) {
+  AVAR a(5.0);
+  test::check_varis_on_stack(stan::math::log(a));
 }

--- a/test/unit/math/rev/scal/fun/logit_test.cpp
+++ b/test/unit/math/rev/scal/fun/logit_test.cpp
@@ -1,7 +1,8 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
-#include <test/unit/math/rev/mat/fun/util.hpp>
 #include <test/unit/math/rev/scal/fun/nan_util.hpp>
+#include <test/unit/math/rev/scal/util.hpp>
+#include <test/unit/math/rev/mat/fun/util.hpp>
 
 void test_logit(double u) {
   using stan::math::log;
@@ -42,4 +43,9 @@ struct logit_fun {
 TEST(AgradRev,inv_logit_NaN) {
   logit_fun logit_;
   test_nan(logit_, false, true);
+}
+
+TEST(AgradRev, check_varis_on_stack) {
+  AVAR u = 0.3;
+  test::check_varis_on_stack(stan::math::logit(u));
 }

--- a/test/unit/math/rev/scal/fun/modified_bessel_first_kind_test.cpp
+++ b/test/unit/math/rev/scal/fun/modified_bessel_first_kind_test.cpp
@@ -1,7 +1,7 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
-#include <test/unit/math/rev/mat/fun/util.hpp>
 #include <test/unit/math/rev/scal/fun/nan_util.hpp>
+#include <test/unit/math/rev/scal/util.hpp>
 
 TEST(AgradRev,modified_bessel_first_kind_int_var) {
   int a(1);
@@ -39,4 +39,11 @@ struct modified_bessel_first_kind_fun {
 TEST(AgradRev,modified_bessel_first_kind_NaN) {
   modified_bessel_first_kind_fun modified_bessel_first_kind_;
   test_nan(modified_bessel_first_kind_,true,false);
+}
+
+TEST(AgradRev, check_varis_on_stack) {
+  int a(1);
+  AVAR b(4.0);
+
+  test::check_varis_on_stack(stan::math::modified_bessel_first_kind(a,b));
 }

--- a/test/unit/math/rev/scal/fun/modified_bessel_second_kind_test.cpp
+++ b/test/unit/math/rev/scal/fun/modified_bessel_second_kind_test.cpp
@@ -39,5 +39,5 @@ TEST(AgradRev,modified_bessel_second_kind_NaN) {
 TEST(AgradRev, check_varis_on_stack) {
   int a(1);
   AVAR b(4.0);
-  test::check_varis_on_stack(stan::math::modified_bessel_second_kind(a,b));
+  test::check_varis_on_stack(stan::math::modified_bessel_second_kind(a, b));
 }

--- a/test/unit/math/rev/scal/fun/modified_bessel_second_kind_test.cpp
+++ b/test/unit/math/rev/scal/fun/modified_bessel_second_kind_test.cpp
@@ -1,7 +1,7 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
-#include <test/unit/math/rev/mat/fun/util.hpp>
 #include <test/unit/math/rev/scal/fun/nan_util.hpp>
+#include <test/unit/math/rev/scal/util.hpp>
 
 TEST(AgradRev,modified_bessel_second_kind_int_var) {
   int a(1);
@@ -34,4 +34,10 @@ struct modified_bessel_second_kind_fun {
 TEST(AgradRev,modified_bessel_second_kind_NaN) {
   modified_bessel_second_kind_fun modified_bessel_second_kind_;
   test_nan(modified_bessel_second_kind_,false,true);
+}
+
+TEST(AgradRev, check_varis_on_stack) {
+  int a(1);
+  AVAR b(4.0);
+  test::check_varis_on_stack(stan::math::modified_bessel_second_kind(a,b));
 }

--- a/test/unit/math/rev/scal/fun/multiply_log_test.cpp
+++ b/test/unit/math/rev/scal/fun/multiply_log_test.cpp
@@ -1,7 +1,7 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/math/rev/scal/fun/nan_util.hpp>
-#include <test/unit/math/rev/mat/fun/util.hpp>
+#include <test/unit/math/rev/scal/util.hpp>
 
 TEST(AgradRev,multiplyLogChainVV) {
   AVAR a = 19.7;
@@ -117,4 +117,12 @@ struct multiply_log_fun {
 TEST(AgradRev, multiply_log_nan) {
   multiply_log_fun multiply_log_;
   test_nan(multiply_log_,3.0,5.0,false, true);
+}
+
+TEST(AgradRev, check_varis_on_stack) {
+  AVAR a = 19.7;
+  AVAR b = 1299.1;
+  test::check_varis_on_stack(multiply_log(a, b));
+  test::check_varis_on_stack(multiply_log(2.0, b));
+  test::check_varis_on_stack(multiply_log(a, 3.0));
 }

--- a/test/unit/math/rev/scal/fun/owens_t_test.cpp
+++ b/test/unit/math/rev/scal/fun/owens_t_test.cpp
@@ -1,8 +1,7 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
-#include <test/unit/math/rev/mat/fun/util.hpp>
 #include <test/unit/math/rev/scal/fun/nan_util.hpp>
-
+#include <test/unit/math/rev/scal/util.hpp>
 TEST(AgradRev,owens_t_vv) {
   using stan::math::var;
   using stan::math::owens_t;
@@ -65,4 +64,12 @@ struct owens_t_fun {
 TEST(AgradRev, owens_t_nan) {
   owens_t_fun owens_t_;
   test_nan(owens_t_,1.0,2.0,false, true);
+}
+
+TEST(AgradRev, check_varis_on_stack) {
+  stan::math::var h = 1.0;
+  stan::math::var a = 2.0;
+  test::check_varis_on_stack(stan::math::owens_t(h, a));
+  test::check_varis_on_stack(stan::math::owens_t(1.0, a));
+  test::check_varis_on_stack(stan::math::owens_t(h, 2.0));
 }

--- a/test/unit/math/rev/scal/fun/pow_test.cpp
+++ b/test/unit/math/rev/scal/fun/pow_test.cpp
@@ -1,7 +1,7 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
-#include <test/unit/math/rev/mat/fun/util.hpp>
 #include <test/unit/math/rev/scal/fun/nan_util.hpp>
+#include <test/unit/math/rev/scal/util.hpp>
 
 TEST(AgradRev,pow_var_var) {
   AVAR a(3.0);
@@ -75,4 +75,12 @@ TEST(AgradRev, pow_nan) {
   pow_fun pow_;
   test_nan(pow_,3.0,5.0,false, true);
   test_nan(pow_,0.0,5.0,false, true);
+}
+
+TEST(AgradRev, check_varis_on_stack) {
+  AVAR a(3.0);
+  AVAR b(4.0);
+  test::check_varis_on_stack(stan::math::pow(a, b));
+  test::check_varis_on_stack(stan::math::pow(3.0, b));
+  test::check_varis_on_stack(stan::math::pow(a, 4.0));
 }

--- a/test/unit/math/rev/scal/fun/rising_factorial_test.cpp
+++ b/test/unit/math/rev/scal/fun/rising_factorial_test.cpp
@@ -84,7 +84,11 @@ TEST(AgradRev, rising_factorial_nan) {
 }
 
 TEST(AgradRev, check_varis_on_stack) {
-  double a(1);
-  AVAR b(4.0);
-  test::check_varis_on_stack(stan::math::rising_factorial(b,a));
+  using stan::math::value_of;
+  stan::math::var a(1);
+  stan::math::var b(4.0);
+  
+  test::check_varis_on_stack(stan::math::rising_factorial(b, a));
+  test::check_varis_on_stack(stan::math::rising_factorial(b, value_of(a)));
+  test::check_varis_on_stack(stan::math::rising_factorial(value_of(b), a));
 }

--- a/test/unit/math/rev/scal/fun/rising_factorial_test.cpp
+++ b/test/unit/math/rev/scal/fun/rising_factorial_test.cpp
@@ -1,7 +1,7 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/math/rev/scal/fun/nan_util.hpp>
-#include <test/unit/math/rev/mat/fun/util.hpp>
+#include <test/unit/math/rev/scal/util.hpp>
 
 TEST(AgradRev,rising_factorial_var_double) {
   using boost::math::digamma;
@@ -81,4 +81,10 @@ struct rising_factorial_fun {
 TEST(AgradRev, rising_factorial_nan) {
   rising_factorial_fun rising_factorial_;
   test_nan(rising_factorial_,3.0,5.0,false,true);
+}
+
+TEST(AgradRev, check_varis_on_stack) {
+  double a(1);
+  AVAR b(4.0);
+  test::check_varis_on_stack(stan::math::rising_factorial(b,a));
 }

--- a/test/unit/math/rev/scal/fun/round_test.cpp
+++ b/test/unit/math/rev/scal/fun/round_test.cpp
@@ -1,7 +1,7 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/math/rev/scal/fun/nan_util.hpp>
-#include <test/unit/math/rev/mat/fun/util.hpp>
+#include <test/unit/math/rev/scal/util.hpp>
 
 TEST(AgradRev,round) {
   AVAR a = 1.2;
@@ -59,4 +59,9 @@ struct round_fun {
 TEST(AgradRev,round_NaN) {
   round_fun round_;
   test_nan(round_,false,true);
+}
+
+TEST(AgradRev, check_varis_on_stack) {
+  AVAR a = 1.2;
+  test::check_varis_on_stack(stan::math::round(a));
 }

--- a/test/unit/math/rev/scal/fun/sign_test.cpp
+++ b/test/unit/math/rev/scal/fun/sign_test.cpp
@@ -1,5 +1,6 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
+#include <test/unit/math/rev/scal/util.hpp>
 
 TEST(MathFunctions, sign) {
   using stan::math::var;
@@ -10,4 +11,9 @@ TEST(MathFunctions, sign) {
   EXPECT_EQ(1, stan::math::sign(x));
   x = -0.001;
   EXPECT_EQ(-1, stan::math::sign(x));
+}
+
+TEST(MathFunctions, check_varis_on_stack) {
+  stan::math::var x = 0;
+  test::check_varis_on_stack(stan::math::sign(x));
 }

--- a/test/unit/math/rev/scal/fun/sin_test.cpp
+++ b/test/unit/math/rev/scal/fun/sin_test.cpp
@@ -1,7 +1,7 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
-#include <test/unit/math/rev/mat/fun/util.hpp>
 #include <test/unit/math/rev/scal/fun/nan_util.hpp>
+#include <test/unit/math/rev/scal/util.hpp>
 
 TEST(AgradRev,sin_var) {
   AVAR a = 0.49;
@@ -45,4 +45,9 @@ struct sin_fun {
 TEST(AgradRev,sin_NaN) {
   sin_fun sin_;
   test_nan(sin_,false,true);
+}
+
+TEST(AgradRev, check_varis_on_stack) {
+  AVAR a = 0.49;
+  test::check_varis_on_stack(stan::math::sin(a));
 }

--- a/test/unit/math/rev/scal/fun/sinh_test.cpp
+++ b/test/unit/math/rev/scal/fun/sinh_test.cpp
@@ -1,7 +1,7 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/math/rev/scal/fun/nan_util.hpp>
-#include <test/unit/math/rev/mat/fun/util.hpp>
+#include <test/unit/math/rev/scal/util.hpp>
 
 TEST(AgradRev,sinh_var) {
   AVAR a = 0.68;
@@ -60,4 +60,9 @@ struct sinh_fun {
 TEST(AgradRev,sinh_NaN) {
   sinh_fun sinh_;
   test_nan(sinh_,false,true);
+}
+
+TEST(AgradRev, check_varis_on_stack) {
+  AVAR a = 0.68;
+  test::check_varis_on_stack(stan::math::sinh(a));
 }

--- a/test/unit/math/rev/scal/fun/sqrt_test.cpp
+++ b/test/unit/math/rev/scal/fun/sqrt_test.cpp
@@ -1,6 +1,7 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/math/rev/scal/fun/nan_util.hpp>
+#include <test/unit/math/rev/scal/util.hpp>
 
 TEST(AgradRev,sqrt_a) {
   AVAR a(5.0);
@@ -55,4 +56,9 @@ struct sqrt_fun {
 TEST(AgradRev,sqrt_NaN) {
   sqrt_fun sqrt_;
   test_nan(sqrt_,false,true);
+}
+
+TEST(AgradRev, check_varis_on_stack) {
+  AVAR a(5.0);
+  test::check_varis_on_stack(stan::math::sqrt(a));
 }

--- a/test/unit/math/rev/scal/fun/square_test.cpp
+++ b/test/unit/math/rev/scal/fun/square_test.cpp
@@ -1,6 +1,7 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/math/rev/scal/fun/nan_util.hpp>
+#include <test/unit/math/rev/scal/util.hpp>
 
 TEST(AgradRev,square) {
   AVAR a = 7.0;
@@ -25,4 +26,9 @@ struct square_fun {
 TEST(AgradRev,square_NaN) {
   square_fun square_;
   test_nan(square_,false,true);
+}
+
+TEST(AgradRev, check_varis_on_stack) {
+  AVAR a = 7.0;
+  test::check_varis_on_stack(stan::math::square(a));
 }

--- a/test/unit/math/rev/scal/fun/squared_distance_test.cpp
+++ b/test/unit/math/rev/scal/fun/squared_distance_test.cpp
@@ -1,5 +1,6 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
+#include <test/unit/math/rev/scal/util.hpp>
 
 TEST(MathRev, squared_distance) {
   double x1 = 1;
@@ -102,3 +103,8 @@ TEST(MathRev, squared_distance_inf) {
                std::domain_error);
 }
 
+TEST(MathRev, check_varis_on_stack) {
+  stan::math::var v1 = 1;
+  stan::math::var v2 = 4;
+  test::check_varis_on_stack(stan::math::squared_distance(v1, v2));
+}

--- a/test/unit/math/rev/scal/fun/step_test.cpp
+++ b/test/unit/math/rev/scal/fun/step_test.cpp
@@ -1,6 +1,7 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/math/rev/arr/fun/util.hpp>
+#include <test/unit/math/rev/scal/util.hpp>
 
 TEST(AgradRev,step) {
   AVAR a = 3.5;
@@ -38,4 +39,9 @@ TEST(AgradRev,step_nan) {
   stan::math::var nan = std::numeric_limits<double>::quiet_NaN();
   
   EXPECT_EQ(1U, stan::math::step(nan).val());
+}
+
+TEST(AgradRev, check_varis_on_stack) {
+  AVAR a = 3.5;
+  test::check_varis_on_stack(stan::math::step(a));
 }

--- a/test/unit/math/rev/scal/fun/tan_test.cpp
+++ b/test/unit/math/rev/scal/fun/tan_test.cpp
@@ -1,7 +1,7 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/math/rev/scal/fun/nan_util.hpp>
-#include <test/unit/math/rev/mat/fun/util.hpp>
+#include <test/unit/math/rev/scal/util.hpp>
 
 TEST(AgradRev,tan_var) {
   AVAR a = 0.68;
@@ -47,4 +47,9 @@ struct tan_fun {
 TEST(AgradRev,tan_NaN) {
   tan_fun tan_;
   test_nan(tan_,false,true);
+}
+
+TEST(AgradRev, check_varis_on_stack) {
+  AVAR a = 0.68;
+  test::check_varis_on_stack(stan::math::tan(a));
 }

--- a/test/unit/math/rev/scal/fun/tanh_test.cpp
+++ b/test/unit/math/rev/scal/fun/tanh_test.cpp
@@ -1,7 +1,7 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/math/rev/scal/fun/nan_util.hpp>
-#include <test/unit/math/rev/mat/fun/util.hpp>
+#include <test/unit/math/rev/scal/util.hpp>
 
 TEST(AgradRev,tanh_var) {
   AVAR a = 0.68;
@@ -60,4 +60,9 @@ struct tanh_fun {
 TEST(AgradRev,tanh_NaN) {
   tanh_fun tanh_;
   test_nan(tanh_,false,true);
+}
+
+TEST(AgradRev, check_varis_on_stack) {
+  AVAR a = 0.68;
+  test::check_varis_on_stack(stan::math::tanh(a));
 }

--- a/test/unit/math/rev/scal/fun/tgamma_test.cpp
+++ b/test/unit/math/rev/scal/fun/tgamma_test.cpp
@@ -1,11 +1,11 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/math/rev/scal/fun/nan_util.hpp>
-#include <test/unit/math/rev/mat/fun/util.hpp>
+#include <test/unit/math/rev/scal/util.hpp>
 
 TEST(AgradRev,tgamma) {
   AVAR a = 3.5;
-  AVAR f = tgamma(a);
+  AVAR f = stan::math::tgamma(a);
   EXPECT_FLOAT_EQ(boost::math::tgamma(3.5),f.val());
 
   AVEC x = createAVEC(a);
@@ -25,4 +25,9 @@ struct tgamma_fun {
 TEST(AgradRev,tgamma_NaN) {
   tgamma_fun tgamma_;
   test_nan(tgamma_,false,true);
+}
+
+TEST(AgradRev, check_varis_on_stack) {
+  AVAR a = 3.5;
+  test::check_varis_on_stack(stan::math::tgamma(a));
 }

--- a/test/unit/math/rev/scal/fun/trigamma_test.cpp
+++ b/test/unit/math/rev/scal/fun/trigamma_test.cpp
@@ -1,7 +1,7 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/math/rev/scal/fun/nan_util.hpp>
-#include <test/unit/math/rev/mat/fun/util.hpp>
+#include <test/unit/math/rev/scal/util.hpp>
 
 TEST(AgradRev,trigamma) {
   AVAR a = 0.5;
@@ -25,4 +25,9 @@ struct trigamma_fun {
 TEST(AgradRev,trigamma_NaN) {
   trigamma_fun trigamma_;
   test_nan(trigamma_,false,true);
+}
+
+TEST(AgradRev, check_varis_on_stack) {
+  AVAR a = 0.5;  
+  test::check_varis_on_stack(stan::math::trigamma(a));
 }

--- a/test/unit/math/rev/scal/fun/trunc_test.cpp
+++ b/test/unit/math/rev/scal/fun/trunc_test.cpp
@@ -1,7 +1,7 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/math/rev/scal/fun/nan_util.hpp>
-#include <boost/math/special_functions/fpclassify.hpp>
+#include <test/unit/math/rev/scal/util.hpp>
 
 TEST(AgradRev,trunc) {
   AVAR a = 1.2;
@@ -36,4 +36,9 @@ struct trunc_fun {
 TEST(AgradRev,trunc_NaN) {
   trunc_fun trunc_;
   test_nan(trunc_,false,true);
+}
+
+TEST(AgradRev, check_varis_on_stack) {
+  AVAR a = -1.2;
+  test::check_varis_on_stack(stan::math::trunc(a));
 }

--- a/test/unit/math/rev/scal/fun/util.hpp
+++ b/test/unit/math/rev/scal/fun/util.hpp
@@ -2,6 +2,7 @@
 #define TEST_UNIT_MATH_REV_SCAL_FUN_UTIL_HPP
 
 #include <stan/math/rev/scal.hpp>
+#include <test/unit/math/rev/scal/util.hpp>
 
 typedef stan::math::var AVAR;
 typedef std::vector<AVAR> AVEC;

--- a/test/unit/math/rev/scal/util.hpp
+++ b/test/unit/math/rev/scal/util.hpp
@@ -1,0 +1,15 @@
+#ifndef TEST_UNIT_MATH_REV_SCAL_UTIL_HPP
+#define TEST_UNIT_MATH_REV_SCAL_UTIL_HPP
+
+#include <stan/math/rev/scal.hpp>
+#include <gtest/gtest.h>
+
+namespace test {
+
+  void check_varis_on_stack(const stan::math::var& x) {
+    EXPECT_TRUE(stan::math::ChainableStack::memalloc_.in_stack(x.vi_))
+      << "not on the stack";
+  }
+  
+}
+#endif


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary:
- Fixes #415. Fixes the implementation of `cholesky_decompose` so the upper-triangular elements have a `vari` on the autodiff stack.
- Adds tests to check that functions that return `stan::math::var` have `vari`s that are on the autodiff stack.

#### Intended Effect:
Fixes bug in implementation.

#### How to Verify:
To verify that `cholesky_decompose` is fixed, run:
```
./runTests.py test/unit/math/rev/mat/fun/cholesky_decompose_test.cpp
```

Run the rest of the changed tests.

#### Side Effects:
Fixes a bug.

#### Documentation:
None.

#### Reviewer Suggestions: 
@rtrangucci 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
