### PR TITLE
feature/issue 419 - defer beta_rng implementation to dirichlet_rng

### DIFF
--- a/stan/math/prim/scal/prob/beta_rng.hpp
+++ b/stan/math/prim/scal/prob/beta_rng.hpp
@@ -19,6 +19,7 @@
 #include <stan/math/prim/scal/meta/include_summand.hpp>
 #include <stan/math/prim/scal/fun/grad_reg_inc_beta.hpp>
 #include <stan/math/prim/scal/fun/inc_beta.hpp>
+#include <stan/math/prim/mat/prob/dirichlet_rng.hpp>
 
 namespace stan {
   namespace math {
@@ -28,19 +29,18 @@ namespace stan {
     beta_rng(double alpha,
              double beta,
              RNG& rng) {
-      using boost::variate_generator;
-      using boost::random::gamma_distribution;
+      using Eigen::Dynamic;
+      using Eigen::Matrix;
+      using stan::math::dirichlet_rng;
+      
       static const char* function("beta_rng");
-      check_positive_finite(function, "First shape parameter", alpha);
-      check_positive_finite(function, "Second shape parameter", beta);
 
-      variate_generator<RNG&, gamma_distribution<> >
-        rng_gamma_alpha(rng, gamma_distribution<>(alpha, 1.0));
-      variate_generator<RNG&, gamma_distribution<> >
-        rng_gamma_beta(rng, gamma_distribution<>(beta, 1.0));
-      double a = rng_gamma_alpha();
-      double b = rng_gamma_beta();
-      return a / (a + b);
+      check_positive_finite(function, "shape parameter", alpha);
+      check_positive_finite(function, "shape parameter", beta);
+
+      Matrix<double, Dynamic, 1> dirichlet_params(2, 1);
+      dirichlet_params << alpha, beta;
+      return dirichlet_rng(dirichlet_params, rng)[0];
     }
 
   }

--- a/stan/math/prim/scal/prob/beta_rng.hpp
+++ b/stan/math/prim/scal/prob/beta_rng.hpp
@@ -32,7 +32,7 @@ namespace stan {
       using Eigen::Dynamic;
       using Eigen::Matrix;
       using stan::math::dirichlet_rng;
-      
+
       static const char* function("beta_rng");
 
       check_positive_finite(function, "shape parameter", alpha);

--- a/test/unit/math/prim/scal/prob/beta_test.cpp
+++ b/test/unit/math/prim/scal/prob/beta_test.cpp
@@ -14,6 +14,7 @@ TEST(ProbDistributionsBeta, error_check) {
                std::domain_error);
   EXPECT_THROW(stan::math::beta_rng(2,stan::math::positive_infinity(),rng),
                std::domain_error);
+  EXPECT_FALSE(std::isnan(stan::math::beta_rng(1e-7, 1e-7, rng)));
 }
 
 TEST(ProbDistributionsBeta, chiSquareGoodnessFitTest) {


### PR DESCRIPTION
#### Submisison Checklist
- [x] Run unit tests: `./runTests.py test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below
#### Summary:

Computing a beta random variable in the textbook way as a quotient of gammas can lead to underflow issues when the shape parameters are extremely small. This PR defers our beta_rng to the more carefully written dirichlet_rng, which works in log space for small parameters.
#### Intended Effect:

Resolves https://github.com/stan-dev/math/issues/419 

Otherwise none.
#### How to Verify:

Visually inspect, run tests
#### Documentation:
#### Reviewer Suggestions:
#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
