### PR TITLE
feature/issue 419 - fix beta_rng for small parameters

### DIFF
--- a/stan/math/prim/scal/prob/beta_rng.hpp
+++ b/stan/math/prim/scal/prob/beta_rng.hpp
@@ -3,6 +3,7 @@
 
 #include <boost/math/special_functions/gamma.hpp>
 #include <boost/random/gamma_distribution.hpp>
+#include <boost/random/uniform_real_distribution.hpp>
 #include <boost/random/variate_generator.hpp>
 #include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
 #include <stan/math/prim/scal/err/check_less_or_equal.hpp>
@@ -11,6 +12,7 @@
 #include <stan/math/prim/scal/err/check_positive_finite.hpp>
 #include <stan/math/prim/scal/fun/log1m.hpp>
 #include <stan/math/prim/scal/fun/multiply_log.hpp>
+#include <stan/math/prim/scal/fun/log_sum_exp.hpp>
 #include <stan/math/prim/scal/fun/value_of.hpp>
 #include <stan/math/prim/scal/fun/digamma.hpp>
 #include <stan/math/prim/scal/fun/lgamma.hpp>
@@ -30,17 +32,36 @@ namespace stan {
              RNG& rng) {
       using boost::variate_generator;
       using boost::random::gamma_distribution;
+      using boost::random::uniform_real_distribution;
+      using std::log;
+      using std::exp;
       static const char* function("beta_rng");
       check_positive_finite(function, "First shape parameter", alpha);
       check_positive_finite(function, "Second shape parameter", beta);
 
-      variate_generator<RNG&, gamma_distribution<> >
-        rng_gamma_alpha(rng, gamma_distribution<>(alpha, 1.0));
-      variate_generator<RNG&, gamma_distribution<> >
-        rng_gamma_beta(rng, gamma_distribution<>(beta, 1.0));
-      double a = rng_gamma_alpha();
-      double b = rng_gamma_beta();
-      return a / (a + b);
+      // If alpha and beta are large, trust the usual ratio of gammas
+      // method for generating beta random variables. If any parameter
+      // is small, work in log space and use Marsaglia and Tsang's trick
+      if (alpha > 1.0 && beta > 1.0) {
+        variate_generator<RNG&, gamma_distribution<> >
+          rng_gamma_alpha(rng, gamma_distribution<>(alpha, 1.0));
+        variate_generator<RNG&, gamma_distribution<> >
+          rng_gamma_beta(rng, gamma_distribution<>(beta, 1.0));
+        double a = rng_gamma_alpha();
+        double b = rng_gamma_beta();
+        return a / (a + b);
+      } else {
+        variate_generator<RNG&, uniform_real_distribution<> >
+          uniform_rng(rng, uniform_real_distribution<>(0.0, 1.0));
+        variate_generator<RNG&, gamma_distribution<> >
+          rng_gamma_alpha(rng, gamma_distribution<>(alpha + 1, 1.0));
+        variate_generator<RNG&, gamma_distribution<> >
+          rng_gamma_beta(rng, gamma_distribution<>(beta + 1, 1.0));
+        double log_a = log(uniform_rng()) / alpha + log(rng_gamma_alpha());
+        double log_b = log(uniform_rng()) / beta + log(rng_gamma_beta());
+        double log_sum = log_sum_exp(log_a, log_b);
+        return exp(log_a - log_sum);
+      }
     }
 
   }

--- a/test/unit/math/prim/scal/prob/beta_test.cpp
+++ b/test/unit/math/prim/scal/prob/beta_test.cpp
@@ -40,3 +40,26 @@ TEST(ProbDistributionsBeta, chiSquareGoodnessFitTest) {
   //Assert that they match
   assert_matches_quantiles(samples, quantiles, 1e-6);
 }
+
+TEST(ProbDistributionsBeta, chiSquareGoodnessFitTestSmallParameters) {
+  boost::random::mt19937 rng;
+  int N = 10000;
+  int K = boost::math::round(2 * std::pow(N, 0.4));
+
+  std::vector<double> samples;
+  for (int i=0; i<N; ++i) {
+    samples.push_back(stan::math::beta_rng(0.2, 0.3, rng));
+  }
+
+  //Generate quantiles from boost's beta distribution
+  boost::math::beta_distribution<>dist (0.2, 0.3);
+  std::vector<double> quantiles;
+  for (int i=1; i<K; ++i) {
+    double frac = static_cast<double>(i) / K;
+    quantiles.push_back(quantile(dist, frac));
+  }
+  quantiles.push_back(std::numeric_limits<double>::max());
+
+  //Assert that they match
+  assert_matches_quantiles(samples, quantiles, 1e-6);
+}

--- a/test/unit/math/prim/scal/prob/beta_test.cpp
+++ b/test/unit/math/prim/scal/prob/beta_test.cpp
@@ -7,6 +7,7 @@
 TEST(ProbDistributionsBeta, error_check) {
   boost::random::mt19937 rng;
   EXPECT_NO_THROW(stan::math::beta_rng(2.0, 1.0, rng));
+  EXPECT_NO_THROW(stan::math::beta_rng(1e-10, 1e-10, rng));
 
   EXPECT_THROW(stan::math::beta_rng(2.0,-1.0, rng),std::domain_error);
   EXPECT_THROW(stan::math::beta_rng(-2.0, 1.0, rng),std::domain_error);


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary:
I wanted to defer beta_rng to dirichlet_rng but couldn't for dependency reasons. Just using the same trick instead.

#### Intended Effect:

Fixes an underflow problem where beta_rng could return NaN for ultra-small choices of parameter. Closes PR https://github.com/stan-dev/math/pull/424 and resolves issue https://github.com/stan-dev/math/issues/419

#### How to Verify:

Added some ultra-small parameters to check that nothing is thrown and added a test of correctness in the small parameters case. Can just run the tests.

#### Side Effects:

#### Documentation:

#### Reviewer Suggestions: 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

…ers, similar to fix in dirichlet. add test for small params