### PR TITLE
Deprecating _log functions. 1/10

### DIFF
--- a/stan/math/prim/mat/prob/categorical_log.hpp
+++ b/stan/math/prim/mat/prob/categorical_log.hpp
@@ -1,43 +1,26 @@
 #ifndef STAN_MATH_PRIM_MAT_PROB_CATEGORICAL_LOG_HPP
 #define STAN_MATH_PRIM_MAT_PROB_CATEGORICAL_LOG_HPP
 
-#include <stan/math/prim/mat/err/check_simplex.hpp>
-#include <stan/math/prim/scal/err/check_bounded.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/mat/fun/sum.hpp>
-#include <stan/math/prim/mat/meta/index_type.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <boost/random/uniform_01.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <cmath>
+#include <stan/math/prim/mat/prob/categorical_lpmf.hpp>
 #include <vector>
 
 namespace stan {
   namespace math {
 
-    // Categorical(n|theta)  [0 < n <= N;   0 <= theta[n] <= 1;  SUM theta = 1]
+    /**
+     * @deprecated use <code>categorical_lpmf</code>
+     */
     template <bool propto,
               typename T_prob>
     typename boost::math::tools::promote_args<T_prob>::type
     categorical_log(int n,
                     const Eigen::Matrix<T_prob, Eigen::Dynamic, 1>& theta) {
-      static const char* function("categorical_log");
-
-      using boost::math::tools::promote_args;
-      using std::log;
-
-      int lb = 1;
-
-      check_bounded(function, "Number of categories", n, lb, theta.size());
-      check_simplex(function, "Probabilities parameter", theta);
-
-      if (include_summand<propto, T_prob>::value)
-        return log(theta(n-1));
-      return 0.0;
+      return categorical_lpmf<propto, T_prob>(n, theta);
     }
 
+    /**
+     * @deprecated use <code>categorical_lpmf</code>
+     */
     template <typename T_prob>
     inline
     typename boost::math::tools::promote_args<T_prob>::type
@@ -45,51 +28,29 @@ namespace stan {
                     math::index_type<Eigen::Matrix<T_prob,
                     Eigen::Dynamic, 1> >::type n,
                     const Eigen::Matrix<T_prob, Eigen::Dynamic, 1>& theta) {
-      return categorical_log<false>(n, theta);
+      return categorical_lpmf<T_prob>(n, theta);
     }
 
+    /**
+     * @deprecated use <code>categorical_lpmf</code>
+     */
     template <bool propto,
               typename T_prob>
     typename boost::math::tools::promote_args<T_prob>::type
     categorical_log(const std::vector<int>& ns,
                     const Eigen::Matrix<T_prob, Eigen::Dynamic, 1>& theta) {
-      static const char* function("categorical_log");
-
-      using boost::math::tools::promote_args;
-      using std::log;
-
-      int lb = 1;
-
-      for (size_t i = 0; i < ns.size(); ++i)
-        check_bounded(function, "element of outcome array", ns[i],
-                      lb, theta.size());
-
-      check_simplex(function, "Probabilities parameter", theta);
-
-      if (!include_summand<propto, T_prob>::value)
-        return 0.0;
-
-      if (ns.size() == 0)
-        return 0.0;
-
-      Eigen::Matrix<T_prob, Eigen::Dynamic, 1> log_theta(theta.size());
-      for (int i = 0; i < theta.size(); ++i)
-        log_theta(i) = log(theta(i));
-
-      Eigen::Matrix<typename boost::math::tools::promote_args<T_prob>::type,
-                    Eigen::Dynamic, 1> log_theta_ns(ns.size());
-      for (size_t i = 0; i < ns.size(); ++i)
-        log_theta_ns(i) = log_theta(ns[i] - 1);
-
-      return sum(log_theta_ns);
+      return categorical_lpmf<propto, T_prob>(ns, theta);
     }
 
+    /**
+     * @deprecated use <code>categorical_lpmf</code>
+     */
     template <typename T_prob>
     inline
     typename boost::math::tools::promote_args<T_prob>::type
     categorical_log(const std::vector<int>& ns,
                     const Eigen::Matrix<T_prob, Eigen::Dynamic, 1>& theta) {
-      return categorical_log<false>(ns, theta);
+      return categorical_lpmf<false>(ns, theta);
     }
 
   }

--- a/stan/math/prim/mat/prob/categorical_logit_log.hpp
+++ b/stan/math/prim/mat/prob/categorical_logit_log.hpp
@@ -1,85 +1,58 @@
 #ifndef STAN_MATH_PRIM_MAT_PROB_CATEGORICAL_LOGIT_LOG_HPP
 #define STAN_MATH_PRIM_MAT_PROB_CATEGORICAL_LOGIT_LOG_HPP
 
-#include <stan/math/prim/scal/err/check_bounded.hpp>
-#include <stan/math/prim/scal/err/check_finite.hpp>
-#include <stan/math/prim/arr/fun/log_sum_exp.hpp>
-#include <stan/math/prim/mat/fun/log_softmax.hpp>
-#include <stan/math/prim/mat/fun/log_sum_exp.hpp>
-#include <stan/math/prim/mat/fun/sum.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <boost/math/tools/promotion.hpp>
+#include <stan/math/prim/mat/prob/categorical_logit_lpmf.hpp>
 #include <vector>
 
 namespace stan {
   namespace math {
 
-    // CategoricalLog(n|theta)  [0 < n <= N, theta unconstrained], no checking
+    /**
+     * @deprecated use <code>categorical_logit_lpmf</code>
+     */
     template <bool propto,
               typename T_prob>
     typename boost::math::tools::promote_args<T_prob>::type
     categorical_logit_log(int n,
                           const Eigen::Matrix<T_prob, Eigen::Dynamic, 1>&
                           beta) {
-      static const char* function("categorical_logit_log");
-
-      check_bounded(function, "categorical outcome out of support", n,
-                    1, beta.size());
-      check_finite(function, "log odds parameter", beta);
-
-      if (!include_summand<propto, T_prob>::value)
-        return 0.0;
-
-      // FIXME:  wasteful vs. creating term (n-1) if not vectorized
-      return beta(n-1) - log_sum_exp(beta);  // == log_softmax(beta)(n-1);
+      return categorical_logit_lpmf<propto, T_prob>(n, beta);
     }
 
+    /**
+     * @deprecated use <code>categorical_logit_lpmf</code>
+     */
     template <typename T_prob>
     inline
     typename boost::math::tools::promote_args<T_prob>::type
     categorical_logit_log(int n,
                           const Eigen::Matrix<T_prob, Eigen::Dynamic, 1>&
                           beta) {
-      return categorical_logit_log<false>(n, beta);
+      return categorical_logit_lpmf<T_prob>(n, beta);
     }
 
+    /**
+     * @deprecated use <code>categorical_logit_lpmf</code>
+     */
     template <bool propto,
               typename T_prob>
     typename boost::math::tools::promote_args<T_prob>::type
     categorical_logit_log(const std::vector<int>& ns,
                           const Eigen::Matrix<T_prob, Eigen::Dynamic, 1>&
                           beta) {
-      static const char* function("categorical_logit_log");
-
-      for (size_t k = 0; k < ns.size(); ++k)
-        check_bounded(function, "categorical outcome out of support",
-                      ns[k], 1, beta.size());
-      check_finite(function, "log odds parameter", beta);
-
-      if (!include_summand<propto, T_prob>::value)
-        return 0.0;
-
-      if (ns.size() == 0)
-        return 0.0;
-
-      Eigen::Matrix<T_prob, Eigen::Dynamic, 1> log_softmax_beta
-        = log_softmax(beta);
-
-      // FIXME:  replace with more efficient sum()
-      Eigen::Matrix<typename boost::math::tools::promote_args<T_prob>::type,
-                    Eigen::Dynamic, 1> results(ns.size());
-      for (size_t i = 0; i < ns.size(); ++i)
-        results[i] = log_softmax_beta(ns[i] - 1);
-      return sum(results);
+      return categorical_logit_lpmf<propto, T_prob>(ns, beta);
     }
 
+    /**
+     * @deprecated use <code>categorical_logit_lpmf</code>
+     */
     template <typename T_prob>
     inline
     typename boost::math::tools::promote_args<T_prob>::type
     categorical_logit_log(const std::vector<int>& ns,
                           const Eigen::Matrix<T_prob, Eigen::Dynamic, 1>&
                           beta) {
-      return categorical_logit_log<false>(ns, beta);
+      return categorical_logit_lpmf<T_prob>(ns, beta);
     }
 
   }

--- a/stan/math/prim/mat/prob/categorical_logit_lpmf.hpp
+++ b/stan/math/prim/mat/prob/categorical_logit_lpmf.hpp
@@ -1,0 +1,87 @@
+#ifndef STAN_MATH_PRIM_MAT_PROB_CATEGORICAL_LOGIT_LPMF_HPP
+#define STAN_MATH_PRIM_MAT_PROB_CATEGORICAL_LOGIT_LPMF_HPP
+
+#include <stan/math/prim/scal/err/check_bounded.hpp>
+#include <stan/math/prim/scal/err/check_finite.hpp>
+#include <stan/math/prim/arr/fun/log_sum_exp.hpp>
+#include <stan/math/prim/mat/fun/log_softmax.hpp>
+#include <stan/math/prim/mat/fun/log_sum_exp.hpp>
+#include <stan/math/prim/mat/fun/sum.hpp>
+#include <stan/math/prim/scal/meta/include_summand.hpp>
+#include <boost/math/tools/promotion.hpp>
+#include <vector>
+
+namespace stan {
+  namespace math {
+
+    // CategoricalLog(n|theta)  [0 < n <= N, theta unconstrained], no checking
+    template <bool propto,
+              typename T_prob>
+    typename boost::math::tools::promote_args<T_prob>::type
+    categorical_logit_lpmf(int n,
+                          const Eigen::Matrix<T_prob, Eigen::Dynamic, 1>&
+                          beta) {
+      static const char* function("categorical_logit_lpmf");
+
+      check_bounded(function, "categorical outcome out of support", n,
+                    1, beta.size());
+      check_finite(function, "log odds parameter", beta);
+
+      if (!include_summand<propto, T_prob>::value)
+        return 0.0;
+
+      // FIXME:  wasteful vs. creating term (n-1) if not vectorized
+      return beta(n-1) - log_sum_exp(beta);  // == log_softmax(beta)(n-1);
+    }
+
+    template <typename T_prob>
+    inline
+    typename boost::math::tools::promote_args<T_prob>::type
+    categorical_logit_lpmf(int n,
+                          const Eigen::Matrix<T_prob, Eigen::Dynamic, 1>&
+                          beta) {
+      return categorical_logit_lpmf<false>(n, beta);
+    }
+
+    template <bool propto,
+              typename T_prob>
+    typename boost::math::tools::promote_args<T_prob>::type
+    categorical_logit_lpmf(const std::vector<int>& ns,
+                          const Eigen::Matrix<T_prob, Eigen::Dynamic, 1>&
+                          beta) {
+      static const char* function("categorical_logit_lpmf");
+
+      for (size_t k = 0; k < ns.size(); ++k)
+        check_bounded(function, "categorical outcome out of support",
+                      ns[k], 1, beta.size());
+      check_finite(function, "log odds parameter", beta);
+
+      if (!include_summand<propto, T_prob>::value)
+        return 0.0;
+
+      if (ns.size() == 0)
+        return 0.0;
+
+      Eigen::Matrix<T_prob, Eigen::Dynamic, 1> log_softmax_beta
+        = log_softmax(beta);
+
+      // FIXME:  replace with more efficient sum()
+      Eigen::Matrix<typename boost::math::tools::promote_args<T_prob>::type,
+                    Eigen::Dynamic, 1> results(ns.size());
+      for (size_t i = 0; i < ns.size(); ++i)
+        results[i] = log_softmax_beta(ns[i] - 1);
+      return sum(results);
+    }
+
+    template <typename T_prob>
+    inline
+    typename boost::math::tools::promote_args<T_prob>::type
+    categorical_logit_lpmf(const std::vector<int>& ns,
+                          const Eigen::Matrix<T_prob, Eigen::Dynamic, 1>&
+                          beta) {
+      return categorical_logit_lpmf<false>(ns, beta);
+    }
+
+  }
+}
+#endif

--- a/stan/math/prim/mat/prob/categorical_lpmf.hpp
+++ b/stan/math/prim/mat/prob/categorical_lpmf.hpp
@@ -1,0 +1,97 @@
+#ifndef STAN_MATH_PRIM_MAT_PROB_CATEGORICAL_LPMF_HPP
+#define STAN_MATH_PRIM_MAT_PROB_CATEGORICAL_LPMF_HPP
+
+#include <stan/math/prim/mat/err/check_simplex.hpp>
+#include <stan/math/prim/scal/err/check_bounded.hpp>
+#include <stan/math/prim/scal/fun/value_of.hpp>
+#include <stan/math/prim/mat/fun/sum.hpp>
+#include <stan/math/prim/mat/meta/index_type.hpp>
+#include <stan/math/prim/scal/fun/constants.hpp>
+#include <stan/math/prim/scal/meta/include_summand.hpp>
+#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
+#include <boost/random/uniform_01.hpp>
+#include <boost/random/variate_generator.hpp>
+#include <cmath>
+#include <vector>
+
+namespace stan {
+  namespace math {
+
+    // Categorical(n|theta)  [0 < n <= N;   0 <= theta[n] <= 1;  SUM theta = 1]
+    template <bool propto,
+              typename T_prob>
+    typename boost::math::tools::promote_args<T_prob>::type
+    categorical_lpmf(int n,
+                    const Eigen::Matrix<T_prob, Eigen::Dynamic, 1>& theta) {
+      static const char* function("categorical_lpmf");
+
+      using boost::math::tools::promote_args;
+      using std::log;
+
+      int lb = 1;
+
+      check_bounded(function, "Number of categories", n, lb, theta.size());
+      check_simplex(function, "Probabilities parameter", theta);
+
+      if (include_summand<propto, T_prob>::value)
+        return log(theta(n-1));
+      return 0.0;
+    }
+
+    template <typename T_prob>
+    inline
+    typename boost::math::tools::promote_args<T_prob>::type
+    categorical_lpmf(const typename
+                    math::index_type<Eigen::Matrix<T_prob,
+                    Eigen::Dynamic, 1> >::type n,
+                    const Eigen::Matrix<T_prob, Eigen::Dynamic, 1>& theta) {
+      return categorical_lpmf<false>(n, theta);
+    }
+
+    template <bool propto,
+              typename T_prob>
+    typename boost::math::tools::promote_args<T_prob>::type
+    categorical_lpmf(const std::vector<int>& ns,
+                    const Eigen::Matrix<T_prob, Eigen::Dynamic, 1>& theta) {
+      static const char* function("categorical_lpmf");
+
+      using boost::math::tools::promote_args;
+      using std::log;
+
+      int lb = 1;
+
+      for (size_t i = 0; i < ns.size(); ++i)
+        check_bounded(function, "element of outcome array", ns[i],
+                      lb, theta.size());
+
+      check_simplex(function, "Probabilities parameter", theta);
+
+      if (!include_summand<propto, T_prob>::value)
+        return 0.0;
+
+      if (ns.size() == 0)
+        return 0.0;
+
+      Eigen::Matrix<T_prob, Eigen::Dynamic, 1> log_theta(theta.size());
+      for (int i = 0; i < theta.size(); ++i)
+        log_theta(i) = log(theta(i));
+
+      Eigen::Matrix<typename boost::math::tools::promote_args<T_prob>::type,
+                    Eigen::Dynamic, 1> log_theta_ns(ns.size());
+      for (size_t i = 0; i < ns.size(); ++i)
+        log_theta_ns(i) = log_theta(ns[i] - 1);
+
+      return sum(log_theta_ns);
+    }
+
+    template <typename T_prob>
+    inline
+    typename boost::math::tools::promote_args<T_prob>::type
+    categorical_lpmf(const std::vector<int>& ns,
+                    const Eigen::Matrix<T_prob, Eigen::Dynamic, 1>& theta) {
+      return categorical_lpmf<false>(ns, theta);
+    }
+
+  }
+}
+#endif

--- a/stan/math/prim/mat/prob/dirichlet_log.hpp
+++ b/stan/math/prim/mat/prob/dirichlet_log.hpp
@@ -1,15 +1,7 @@
 #ifndef STAN_MATH_PRIM_MAT_PROB_DIRICHLET_LOG_HPP
 #define STAN_MATH_PRIM_MAT_PROB_DIRICHLET_LOG_HPP
 
-#include <boost/math/special_functions/gamma.hpp>
-#include <boost/random/gamma_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <stan/math/prim/mat/err/check_simplex.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_positive.hpp>
-#include <stan/math/prim/scal/fun/multiply_log.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
+#include <stan/math/prim/mat/prob/dirichlet_lpmf.hpp>
 
 namespace stan {
   namespace math {
@@ -21,13 +13,7 @@ namespace stan {
      * Each element of theta must be greater than or 0.
      * Theta sums to 1.
      *
-     * \f{eqnarray*}{
-     \theta &\sim& \mbox{\sf{Dirichlet}} (\alpha_1, \ldots, \alpha_k) \\
-     \log (p (\theta \, |\, \alpha_1, \ldots, \alpha_k) ) &=& \log \left( \frac{\Gamma(\alpha_1 + \cdots + \alpha_k)}{\Gamma(\alpha_1) \cdots \Gamma(\alpha_k)}
-     \theta_1^{\alpha_1 - 1} \cdots \theta_k^{\alpha_k - 1} \right) \\
-     &=& \log (\Gamma(\alpha_1 + \cdots + \alpha_k)) - \log(\Gamma(\alpha_1)) - \cdots - \log(\Gamma(\alpha_k)) +
-     (\alpha_1 - 1) \log (\theta_1) + \cdots + (\alpha_k - 1) \log (\theta_k)
-     \f}
+     * @deprecated use <code>dirichlet_lpmf</code>
      *
      * @param theta A scalar vector.
      * @param alpha Prior sample sizes.
@@ -45,36 +31,19 @@ namespace stan {
     dirichlet_log(const Eigen::Matrix<T_prob, Eigen::Dynamic, 1>& theta,
                   const Eigen::Matrix
                   <T_prior_sample_size, Eigen::Dynamic, 1>& alpha) {
-      static const char* function("dirichlet_log");
-      using boost::math::lgamma;
-      using boost::math::tools::promote_args;
-
-      typename promote_args<T_prob, T_prior_sample_size>::type lp(0.0);
-      check_consistent_sizes(function,
-                             "probabilities", theta,
-                             "prior sample sizes", alpha);
-      check_positive(function, "prior sample sizes", alpha);
-      check_simplex(function, "probabilities", theta);
-
-      if (include_summand<propto, T_prior_sample_size>::value) {
-        lp += lgamma(alpha.sum());
-        for (int k = 0; k < alpha.rows(); ++k)
-          lp -= lgamma(alpha[k]);
-      }
-      if (include_summand<propto, T_prob, T_prior_sample_size>::value) {
-        for (int k = 0; k < theta.rows(); ++k)
-          lp += multiply_log(alpha[k]-1, theta[k]);
-      }
-      return lp;
+      return dirichlet_lpmf<propto, T_prob, T_prior_sample_size>(theta, alpha);
     }
 
+    /**
+     * @deprecated use <code>dirichlet_lpmf</code>
+     */
     template <typename T_prob, typename T_prior_sample_size>
     inline
     typename boost::math::tools::promote_args<T_prob, T_prior_sample_size>::type
     dirichlet_log(const Eigen::Matrix<T_prob, Eigen::Dynamic, 1>& theta,
                   const Eigen::Matrix
                   <T_prior_sample_size, Eigen::Dynamic, 1>& alpha) {
-      return dirichlet_log<false>(theta, alpha);
+      return dirichlet_lpmf<T_prob, T_prior_sample_size>(theta, alpha);
     }
 
   }

--- a/stan/math/prim/mat/prob/dirichlet_lpmf.hpp
+++ b/stan/math/prim/mat/prob/dirichlet_lpmf.hpp
@@ -1,0 +1,82 @@
+#ifndef STAN_MATH_PRIM_MAT_PROB_DIRICHLET_LPMF_HPP
+#define STAN_MATH_PRIM_MAT_PROB_DIRICHLET_LPMF_HPP
+
+#include <boost/math/special_functions/gamma.hpp>
+#include <boost/random/gamma_distribution.hpp>
+#include <boost/random/variate_generator.hpp>
+#include <stan/math/prim/mat/err/check_simplex.hpp>
+#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
+#include <stan/math/prim/scal/err/check_positive.hpp>
+#include <stan/math/prim/scal/fun/multiply_log.hpp>
+#include <stan/math/prim/scal/fun/constants.hpp>
+#include <stan/math/prim/scal/meta/include_summand.hpp>
+
+namespace stan {
+  namespace math {
+
+    /**
+     * The log of the Dirichlet density for the given theta and
+     * a vector of prior sample sizes, alpha.
+     * Each element of alpha must be greater than 0.
+     * Each element of theta must be greater than or 0.
+     * Theta sums to 1.
+     *
+     * \f{eqnarray*}{
+     \theta &\sim& \mbox{\sf{Dirichlet}} (\alpha_1, \ldots, \alpha_k) \\
+     \log (p (\theta \, |\, \alpha_1, \ldots, \alpha_k) ) &=& \log \left( \frac{\Gamma(\alpha_1 + \cdots + \alpha_k)}{\Gamma(\alpha_1) \cdots \Gamma(\alpha_k)}
+     \theta_1^{\alpha_1 - 1} \cdots \theta_k^{\alpha_k - 1} \right) \\
+     &=& \log (\Gamma(\alpha_1 + \cdots + \alpha_k)) - \log(\Gamma(\alpha_1)) - \cdots - \log(\Gamma(\alpha_k)) +
+     (\alpha_1 - 1) \log (\theta_1) + \cdots + (\alpha_k - 1) \log (\theta_k)
+     \f}
+     *
+     * @param theta A scalar vector.
+     * @param alpha Prior sample sizes.
+     * @return The log of the Dirichlet density.
+     * @throw std::domain_error if any element of alpha is less than
+     * or equal to 0.
+     * @throw std::domain_error if any element of theta is less than 0.
+     * @throw std::domain_error if the sum of theta is not 1.
+     * @tparam T_prob Type of scalar.
+     * @tparam T_prior_sample_size Type of prior sample sizes.
+     */
+    template <bool propto,
+              typename T_prob, typename T_prior_sample_size>
+    typename boost::math::tools::promote_args<T_prob, T_prior_sample_size>::type
+    dirichlet_lpmf(const Eigen::Matrix<T_prob, Eigen::Dynamic, 1>& theta,
+                  const Eigen::Matrix
+                  <T_prior_sample_size, Eigen::Dynamic, 1>& alpha) {
+      static const char* function("dirichlet_lpmf");
+      using boost::math::lgamma;
+      using boost::math::tools::promote_args;
+
+      typename promote_args<T_prob, T_prior_sample_size>::type lp(0.0);
+      check_consistent_sizes(function,
+                             "probabilities", theta,
+                             "prior sample sizes", alpha);
+      check_positive(function, "prior sample sizes", alpha);
+      check_simplex(function, "probabilities", theta);
+
+      if (include_summand<propto, T_prior_sample_size>::value) {
+        lp += lgamma(alpha.sum());
+        for (int k = 0; k < alpha.rows(); ++k)
+          lp -= lgamma(alpha[k]);
+      }
+      if (include_summand<propto, T_prob, T_prior_sample_size>::value) {
+        for (int k = 0; k < theta.rows(); ++k)
+          lp += multiply_log(alpha[k]-1, theta[k]);
+      }
+      return lp;
+    }
+
+    template <typename T_prob, typename T_prior_sample_size>
+    inline
+    typename boost::math::tools::promote_args<T_prob, T_prior_sample_size>::type
+    dirichlet_lpmf(const Eigen::Matrix<T_prob, Eigen::Dynamic, 1>& theta,
+                  const Eigen::Matrix
+                  <T_prior_sample_size, Eigen::Dynamic, 1>& alpha) {
+      return dirichlet_lpmf<false>(theta, alpha);
+    }
+
+  }
+}
+#endif

--- a/stan/math/prim/mat/prob/gaussian_dlm_obs_log.hpp
+++ b/stan/math/prim/mat/prob/gaussian_dlm_obs_log.hpp
@@ -1,36 +1,8 @@
 #ifndef STAN_MATH_PRIM_MAT_PROB_GAUSSIAN_DLM_OBS_LOG_HPP
 #define STAN_MATH_PRIM_MAT_PROB_GAUSSIAN_DLM_OBS_LOG_HPP
 
-#include <boost/random/normal_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <stan/math/prim/mat/err/check_cov_matrix.hpp>
-#include <stan/math/prim/scal/err/check_size_match.hpp>
-#include <stan/math/prim/mat/err/check_spsd_matrix.hpp>
-#include <stan/math/prim/scal/err/check_finite.hpp>
-#include <stan/math/prim/scal/err/check_nonnegative.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/mat/fun/add.hpp>
-#include <stan/math/prim/mat/fun/dot_product.hpp>
-#include <stan/math/prim/mat/fun/inverse_spd.hpp>
-#include <stan/math/prim/mat/fun/log.hpp>
-#include <stan/math/prim/mat/fun/log_determinant_spd.hpp>
-#include <stan/math/prim/mat/fun/multiply.hpp>
-#include <stan/math/prim/mat/fun/quad_form.hpp>
-#include <stan/math/prim/mat/fun/quad_form_sym.hpp>
-#include <stan/math/prim/mat/fun/subtract.hpp>
-#include <stan/math/prim/mat/fun/tcrossprod.hpp>
-#include <stan/math/prim/mat/fun/trace_quad_form.hpp>
-#include <stan/math/prim/mat/fun/transpose.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <stan/math/prim/scal/meta/return_type.hpp>
+#include <stan/math/prim/mat/prob/gaussian_dlm_obs_lpdf.hpp>
 
-/*
-  TODO: time-varying system matrices
-  TODO: use sequential processing even for non-diagonal obs
-  covariance.
-  TODO: add constant terms in observation.
-*/
 namespace stan {
   namespace math {
     /**
@@ -44,6 +16,8 @@ namespace stan {
      *
      * If V is a vector, then the Kalman filter is applied
      * sequentially.
+     *
+     * @deprecated use <code>gaussian_dlm_obs_lpdf</code>
      *
      * @param y A r x T matrix of observations. Rows are variables,
      * columns are observations.
@@ -88,108 +62,13 @@ namespace stan {
                          const Eigen::Matrix<T_m0, Eigen::Dynamic, 1>& m0,
                          const Eigen::Matrix
                          <T_C0, Eigen::Dynamic, Eigen::Dynamic>& C0) {
-      static const char* function("gaussian_dlm_obs_log");
-      typedef typename return_type<
-        T_y,
-        typename return_type<T_F, T_G, T_V, T_W, T_m0, T_C0>::type>::type T_lp;
-      T_lp lp(0.0);
-
-      int r = y.rows();  // number of variables
-      int T = y.cols();  // number of observations
-      int n = G.rows();  // number of states
-
-      check_finite(function, "y", y);
-      check_not_nan(function, "y", y);
-      check_size_match(function,
-                       "columns of F", F.cols(),
-                       "rows of y", y.rows());
-      check_size_match(function,
-                       "rows of F", F.rows(),
-                       "rows of G", G.rows());
-      check_finite(function, "F", F);
-      check_square(function, "G", G);
-      check_finite(function, "G", G);
-      check_size_match(function,
-                       "rows of V", V.rows(),
-                       "rows of y", y.rows());
-      // TODO(anyone): incorporate support for infinite V
-      check_finite(function, "V", V);
-      check_spsd_matrix(function, "V", V);
-      check_size_match(function,
-                       "rows of W", W.rows(),
-                       "rows of G", G.rows());
-      // TODO(anyone): incorporate support for infinite W
-      check_finite(function, "W", W);
-      check_spsd_matrix(function, "W", W);
-      check_size_match(function,
-                       "size of m0", m0.size(),
-                       "rows of G", G.rows());
-      check_finite(function, "m0", m0);
-      check_size_match(function,
-                       "rows of C0", C0.rows(),
-                       "rows of G", G.rows());
-      check_cov_matrix(function, "C0", C0);
-      check_finite(function, "C0", C0);
-
-      if (y.cols() == 0 || y.rows() == 0)
-        return lp;
-
-      if (include_summand<propto>::value) {
-        lp -= 0.5 * LOG_TWO_PI * r * T;
-      }
-
-      if (include_summand<propto, T_y, T_F, T_G, T_V, T_W, T_m0, T_C0>::value) {
-        Eigen::Matrix<T_lp, Eigen::Dynamic, 1> m(n);
-        Eigen::Matrix<T_lp, Eigen::Dynamic, Eigen::Dynamic> C(n, n);
-
-        // TODO(anyone): how to recast matrices
-        for (int i = 0; i < m0.size(); i++) {
-          m(i) = m0(i);
-        }
-        for (int i = 0; i < C0.rows(); i++) {
-          for (int j = 0; j < C0.cols(); j++) {
-            C(i, j) = C0(i, j);
-          }
-        }
-
-        Eigen::Matrix<typename return_type<T_y>::type,
-                      Eigen::Dynamic, 1> yi(r);
-        Eigen::Matrix<T_lp, Eigen::Dynamic, 1> a(n);
-        Eigen::Matrix<T_lp, Eigen::Dynamic, Eigen::Dynamic> R(n, n);
-        Eigen::Matrix<T_lp, Eigen::Dynamic, 1> f(r);
-        Eigen::Matrix<T_lp, Eigen::Dynamic, Eigen::Dynamic> Q(r, r);
-        Eigen::Matrix<T_lp, Eigen::Dynamic, Eigen::Dynamic> Q_inv(r, r);
-        Eigen::Matrix<T_lp, Eigen::Dynamic, 1> e(r);
-        Eigen::Matrix<T_lp, Eigen::Dynamic, Eigen::Dynamic> A(n, r);
-
-        for (int i = 0; i < y.cols(); i++) {
-          yi = y.col(i);
-          // // Predict state
-          // a_t = G_t m_{t-1}
-          a = multiply(G, m);
-          // R_t = G_t C_{t-1} G_t' + W_t
-          R = add(quad_form_sym(C, transpose(G)), W);
-          // // predict observation
-          // f_t = F_t' a_t
-          f = multiply(transpose(F), a);
-          // Q_t = F'_t R_t F_t + V_t
-          Q = add(quad_form_sym(R, F), V);
-          Q_inv = inverse_spd(Q);
-          // // filtered state
-          // e_t = y_t - f_t
-          e = subtract(yi, f);
-          // A_t = R_t F_t Q^{-1}_t
-          A = multiply(multiply(R, F), Q_inv);
-          // m_t = a_t + A_t e_t
-          m = add(a, multiply(A, e));
-          // C = R_t - A_t Q_t A_t'
-          C = subtract(R, quad_form_sym(Q, transpose(A)));
-          lp -= 0.5 * (log_determinant_spd(Q) + trace_quad_form(Q_inv, e));
-        }
-      }
-      return lp;
+      return gaussian_dlm_obs_lpdf<propto, T_y, T_F, T_G,
+                                   T_V, T_W, T_m0, T_C0>(y, F, G, V, W, m0, C0);
     }
 
+    /**
+     * @deprecated use <code>gaussian_dlm_obs_lpdf</code>
+     */
     template <typename T_y,
               typename T_F, typename T_G,
               typename T_V, typename T_W,
@@ -212,7 +91,8 @@ namespace stan {
                          const Eigen::Matrix<T_m0, Eigen::Dynamic, 1>& m0,
                          const Eigen::Matrix
                          <T_C0, Eigen::Dynamic, Eigen::Dynamic>& C0) {
-      return gaussian_dlm_obs_log<false>(y, F, G, V, W, m0, C0);
+      return gaussian_dlm_obs_lpdf<T_y, T_F, T_G,
+                                   T_V, T_W, T_m0, T_C0>(y, F, G, V, W, m0, C0);
     }
 
     /**
@@ -227,6 +107,8 @@ namespace stan {
      *
      * If V is a vector, then the Kalman filter is applied
      * sequentially.
+     *
+     * @deprecated use <code>gaussian_dlm_obs_lpdf</code>
      *
      * @param y A r x T matrix of observations. Rows are variables,
      * columns are observations.
@@ -271,122 +153,13 @@ namespace stan {
                          const Eigen::Matrix<T_m0, Eigen::Dynamic, 1>& m0,
                          const Eigen::Matrix
                          <T_C0, Eigen::Dynamic, Eigen::Dynamic>& C0) {
-      static const char* function("gaussian_dlm_obs_log");
-      typedef
-        typename return_type
-        <T_y, typename return_type<T_F, T_G, T_V, T_W, T_m0, T_C0>::type>::type
-        T_lp;
-      T_lp lp(0.0);
-
-      using std::log;
-
-      int r = y.rows();  // number of variables
-      int T = y.cols();  // number of observations
-      int n = G.rows();  // number of states
-
-      check_finite(function, "y", y);
-      check_not_nan(function, "y", y);
-      check_size_match(function,
-                       "columns of F", F.cols(),
-                       "rows of y", y.rows());
-      check_size_match(function,
-                       "rows of F", F.rows(),
-                       "rows of G", G.rows());
-      check_finite(function, "F", F);
-      check_not_nan(function, "F", F);
-      check_size_match(function,
-                       "rows of G", G.rows(),
-                       "columns of G", G.cols());
-      check_finite(function, "G", G);
-      check_not_nan(function, "G", G);
-      check_nonnegative(function, "V", V);
-      check_size_match(function,
-                       "size of V", V.size(),
-                       "rows of y", y.rows());
-      // TODO(anyone): support infinite V
-      check_finite(function, "V", V);
-      check_not_nan(function, "V", V);
-      check_spsd_matrix(function, "W", W);
-      check_size_match(function,
-                       "rows of W", W.rows(),
-                       "rows of G", G.rows());
-      // TODO(anyone): support infinite W
-      check_finite(function, "W", W);
-      check_not_nan(function, "W", W);
-      check_size_match(function,
-                       "size of m0", m0.size(),
-                       "rows of G", G.rows());
-      check_finite(function, "m0", m0);
-      check_not_nan(function, "m0", m0);
-      check_cov_matrix(function, "C0", C0);
-      check_size_match(function,
-                       "rows of C0", C0.rows(),
-                       "rows of G", G.rows());
-      check_finite(function, "C0", C0);
-      check_not_nan(function, "C0", C0);
-
-      if (y.cols() == 0 || y.rows() == 0)
-        return lp;
-
-      if (include_summand<propto>::value) {
-        lp += 0.5 * NEG_LOG_TWO_PI * r * T;
-      }
-
-      if (include_summand<propto, T_y, T_F, T_G, T_V, T_W, T_m0, T_C0>::value) {
-        T_lp f;
-        T_lp Q;
-        T_lp Q_inv;
-        T_lp e;
-        Eigen::Matrix<T_lp, Eigen::Dynamic, 1> A(n);
-        Eigen::Matrix<T_lp, Eigen::Dynamic, 1> Fj(n);
-        Eigen::Matrix<T_lp, Eigen::Dynamic, 1> m(n);
-        Eigen::Matrix<T_lp, Eigen::Dynamic, Eigen::Dynamic> C(n, n);
-
-        // TODO(anyone): how to recast matrices
-        for (int i = 0; i < m0.size(); i++) {
-          m(i) = m0(i);
-        }
-        for (int i = 0; i < C0.rows(); i++) {
-          for (int j = 0; j < C0.cols(); j++) {
-            C(i, j) = C0(i, j);
-          }
-        }
-
-        for (int i = 0; i < y.cols(); i++) {
-          // Predict state
-          // reuse m and C instead of using a and R
-          m = multiply(G, m);
-          C = add(quad_form_sym(C, transpose(G)), W);
-          for (int j = 0; j < y.rows(); ++j) {
-            // predict observation
-            T_lp yij(y(j, i));
-            // dim Fj = (n, 1)
-            for (int k = 0; k < F.rows(); ++k) {
-              Fj(k) = F(k, j);
-            }
-            // f_{t, i} = F_{t, i}' m_{t, i-1}
-            f = dot_product(Fj, m);
-            Q = trace_quad_form(C, Fj) + V(j);
-            Q_inv = 1.0 / Q;
-            // filtered observation
-            // e_{t, i} = y_{t, i} - f_{t, i}
-            e = yij - f;
-            // A_{t, i} = C_{t, i-1} F_{t, i} Q_{t, i}^{-1}
-            A = multiply(multiply(C, Fj), Q_inv);
-            // m_{t, i} = m_{t, i-1} + A_{t, i} e_{t, i}
-            m += multiply(A, e);
-            // c_{t, i} = C_{t, i-1} - Q_{t, i} A_{t, i} A_{t, i}'
-            // tcrossprod throws an error (ambiguous)
-            // C = subtract(C, multiply(Q, tcrossprod(A)));
-            C -= multiply(Q, multiply(A, transpose(A)));
-            C = 0.5 * add(C, transpose(C));
-            lp -= 0.5 * (log(Q) + pow(e, 2) * Q_inv);
-          }
-        }
-      }
-      return lp;
+      return gaussian_dlm_obs_lpdf<propto, T_y, T_F, T_G,
+                                   T_V, T_W, T_m0, T_C0>(y, F, G, V, W, m0, C0);
     }
 
+    /**
+     * @deprecated use <code>gaussian_dlm_obs_lpdf</code>
+     */
     template <typename T_y,
               typename T_F, typename T_G,
               typename T_V, typename T_W,
@@ -402,7 +175,8 @@ namespace stan {
      const Eigen::Matrix<T_W, Eigen::Dynamic, Eigen::Dynamic>& W,
      const Eigen::Matrix<T_m0, Eigen::Dynamic, 1>& m0,
      const Eigen::Matrix<T_C0, Eigen::Dynamic, Eigen::Dynamic>& C0) {
-      return gaussian_dlm_obs_log<false>(y, F, G, V, W, m0, C0);
+      return gaussian_dlm_obs_lpdf<T_y, T_F, T_G,
+                                   T_V, T_W, T_m0, T_C0>(y, F, G, V, W, m0, C0);
     }
 
   }

--- a/stan/math/prim/mat/prob/gaussian_dlm_obs_lpdf.hpp
+++ b/stan/math/prim/mat/prob/gaussian_dlm_obs_lpdf.hpp
@@ -1,0 +1,410 @@
+#ifndef STAN_MATH_PRIM_MAT_PROB_GAUSSIAN_DLM_OBS_LPDF_HPP
+#define STAN_MATH_PRIM_MAT_PROB_GAUSSIAN_DLM_OBS_LPDF_HPP
+
+#include <boost/random/normal_distribution.hpp>
+#include <boost/random/variate_generator.hpp>
+#include <stan/math/prim/mat/err/check_cov_matrix.hpp>
+#include <stan/math/prim/scal/err/check_size_match.hpp>
+#include <stan/math/prim/mat/err/check_spsd_matrix.hpp>
+#include <stan/math/prim/scal/err/check_finite.hpp>
+#include <stan/math/prim/scal/err/check_nonnegative.hpp>
+#include <stan/math/prim/scal/err/check_not_nan.hpp>
+#include <stan/math/prim/mat/fun/add.hpp>
+#include <stan/math/prim/mat/fun/dot_product.hpp>
+#include <stan/math/prim/mat/fun/inverse_spd.hpp>
+#include <stan/math/prim/mat/fun/log.hpp>
+#include <stan/math/prim/mat/fun/log_determinant_spd.hpp>
+#include <stan/math/prim/mat/fun/multiply.hpp>
+#include <stan/math/prim/mat/fun/quad_form.hpp>
+#include <stan/math/prim/mat/fun/quad_form_sym.hpp>
+#include <stan/math/prim/mat/fun/subtract.hpp>
+#include <stan/math/prim/mat/fun/tcrossprod.hpp>
+#include <stan/math/prim/mat/fun/trace_quad_form.hpp>
+#include <stan/math/prim/mat/fun/transpose.hpp>
+#include <stan/math/prim/scal/fun/constants.hpp>
+#include <stan/math/prim/scal/meta/include_summand.hpp>
+#include <stan/math/prim/scal/meta/return_type.hpp>
+
+/*
+  TODO: time-varying system matrices
+  TODO: use sequential processing even for non-diagonal obs
+  covariance.
+  TODO: add constant terms in observation.
+*/
+namespace stan {
+  namespace math {
+    /**
+     * The log of a Gaussian dynamic linear model (GDLM).
+     * This distribution is equivalent to, for \f$t = 1:T\f$,
+     * \f{eqnarray*}{
+     * y_t & \sim N(F' \theta_t, V) \\
+     * \theta_t & \sim N(G \theta_{t-1}, W) \\
+     * \theta_0 & \sim N(m_0, C_0)
+     * \f}
+     *
+     * If V is a vector, then the Kalman filter is applied
+     * sequentially.
+     *
+     * @param y A r x T matrix of observations. Rows are variables,
+     * columns are observations.
+     * @param F A n x r matrix. The design matrix.
+     * @param G A n x n matrix. The transition matrix.
+     * @param V A r x r matrix. The observation covariance matrix.
+     * @param W A n x n matrix. The state covariance matrix.
+     * @param m0 A n x 1 matrix. The mean vector of the distribution
+     * of the initial state.
+     * @param C0 A n x n matrix. The covariance matrix of the
+     * distribution of the initial state.
+     * @return The log of the joint density of the GDLM.
+     * @throw std::domain_error if a matrix in the Kalman filter is
+     * not positive semi-definite.
+     * @tparam T_y Type of scalar.
+     * @tparam T_F Type of design matrix.
+     * @tparam T_G Type of transition matrix.
+     * @tparam T_V Type of observation covariance matrix.
+     * @tparam T_W Type of state covariance matrix.
+     * @tparam T_m0 Type of initial state mean vector.
+     * @tparam T_C0 Type of initial state covariance matrix.
+     */
+    template <bool propto,
+              typename T_y,
+              typename T_F, typename T_G,
+              typename T_V, typename T_W,
+              typename T_m0, typename T_C0
+              >
+    typename return_type<
+      T_y,
+      typename return_type<T_F, T_G, T_V, T_W, T_m0, T_C0>::type >::type
+    gaussian_dlm_obs_lpdf(const Eigen::Matrix
+                         <T_y, Eigen::Dynamic, Eigen::Dynamic>& y,
+                         const Eigen::Matrix
+                         <T_F, Eigen::Dynamic, Eigen::Dynamic>& F,
+                         const Eigen::Matrix
+                         <T_G, Eigen::Dynamic, Eigen::Dynamic>& G,
+                         const Eigen::Matrix
+                         <T_V, Eigen::Dynamic, Eigen::Dynamic>& V,
+                         const Eigen::Matrix
+                         <T_W, Eigen::Dynamic, Eigen::Dynamic>& W,
+                         const Eigen::Matrix<T_m0, Eigen::Dynamic, 1>& m0,
+                         const Eigen::Matrix
+                         <T_C0, Eigen::Dynamic, Eigen::Dynamic>& C0) {
+      static const char* function("gaussian_dlm_obs_lpdf");
+      typedef typename return_type<
+        T_y,
+        typename return_type<T_F, T_G, T_V, T_W, T_m0, T_C0>::type>::type T_lp;
+      T_lp lp(0.0);
+
+      int r = y.rows();  // number of variables
+      int T = y.cols();  // number of observations
+      int n = G.rows();  // number of states
+
+      check_finite(function, "y", y);
+      check_not_nan(function, "y", y);
+      check_size_match(function,
+                       "columns of F", F.cols(),
+                       "rows of y", y.rows());
+      check_size_match(function,
+                       "rows of F", F.rows(),
+                       "rows of G", G.rows());
+      check_finite(function, "F", F);
+      check_square(function, "G", G);
+      check_finite(function, "G", G);
+      check_size_match(function,
+                       "rows of V", V.rows(),
+                       "rows of y", y.rows());
+      // TODO(anyone): incorporate support for infinite V
+      check_finite(function, "V", V);
+      check_spsd_matrix(function, "V", V);
+      check_size_match(function,
+                       "rows of W", W.rows(),
+                       "rows of G", G.rows());
+      // TODO(anyone): incorporate support for infinite W
+      check_finite(function, "W", W);
+      check_spsd_matrix(function, "W", W);
+      check_size_match(function,
+                       "size of m0", m0.size(),
+                       "rows of G", G.rows());
+      check_finite(function, "m0", m0);
+      check_size_match(function,
+                       "rows of C0", C0.rows(),
+                       "rows of G", G.rows());
+      check_cov_matrix(function, "C0", C0);
+      check_finite(function, "C0", C0);
+
+      if (y.cols() == 0 || y.rows() == 0)
+        return lp;
+
+      if (include_summand<propto>::value) {
+        lp -= 0.5 * LOG_TWO_PI * r * T;
+      }
+
+      if (include_summand<propto, T_y, T_F, T_G, T_V, T_W, T_m0, T_C0>::value) {
+        Eigen::Matrix<T_lp, Eigen::Dynamic, 1> m(n);
+        Eigen::Matrix<T_lp, Eigen::Dynamic, Eigen::Dynamic> C(n, n);
+
+        // TODO(anyone): how to recast matrices
+        for (int i = 0; i < m0.size(); i++) {
+          m(i) = m0(i);
+        }
+        for (int i = 0; i < C0.rows(); i++) {
+          for (int j = 0; j < C0.cols(); j++) {
+            C(i, j) = C0(i, j);
+          }
+        }
+
+        Eigen::Matrix<typename return_type<T_y>::type,
+                      Eigen::Dynamic, 1> yi(r);
+        Eigen::Matrix<T_lp, Eigen::Dynamic, 1> a(n);
+        Eigen::Matrix<T_lp, Eigen::Dynamic, Eigen::Dynamic> R(n, n);
+        Eigen::Matrix<T_lp, Eigen::Dynamic, 1> f(r);
+        Eigen::Matrix<T_lp, Eigen::Dynamic, Eigen::Dynamic> Q(r, r);
+        Eigen::Matrix<T_lp, Eigen::Dynamic, Eigen::Dynamic> Q_inv(r, r);
+        Eigen::Matrix<T_lp, Eigen::Dynamic, 1> e(r);
+        Eigen::Matrix<T_lp, Eigen::Dynamic, Eigen::Dynamic> A(n, r);
+
+        for (int i = 0; i < y.cols(); i++) {
+          yi = y.col(i);
+          // // Predict state
+          // a_t = G_t m_{t-1}
+          a = multiply(G, m);
+          // R_t = G_t C_{t-1} G_t' + W_t
+          R = add(quad_form_sym(C, transpose(G)), W);
+          // // predict observation
+          // f_t = F_t' a_t
+          f = multiply(transpose(F), a);
+          // Q_t = F'_t R_t F_t + V_t
+          Q = add(quad_form_sym(R, F), V);
+          Q_inv = inverse_spd(Q);
+          // // filtered state
+          // e_t = y_t - f_t
+          e = subtract(yi, f);
+          // A_t = R_t F_t Q^{-1}_t
+          A = multiply(multiply(R, F), Q_inv);
+          // m_t = a_t + A_t e_t
+          m = add(a, multiply(A, e));
+          // C = R_t - A_t Q_t A_t'
+          C = subtract(R, quad_form_sym(Q, transpose(A)));
+          lp -= 0.5 * (log_determinant_spd(Q) + trace_quad_form(Q_inv, e));
+        }
+      }
+      return lp;
+    }
+
+    template <typename T_y,
+              typename T_F, typename T_G,
+              typename T_V, typename T_W,
+              typename T_m0, typename T_C0
+              >
+    inline
+    typename return_type<
+      T_y,
+      typename return_type<T_F, T_G, T_V, T_W, T_m0, T_C0>::type >::type
+    gaussian_dlm_obs_lpdf(const Eigen::Matrix
+                         <T_y, Eigen::Dynamic, Eigen::Dynamic>& y,
+                         const Eigen::Matrix
+                         <T_F, Eigen::Dynamic, Eigen::Dynamic>& F,
+                         const Eigen::Matrix
+                         <T_G, Eigen::Dynamic, Eigen::Dynamic>& G,
+                         const Eigen::Matrix
+                         <T_V, Eigen::Dynamic, Eigen::Dynamic>& V,
+                         const Eigen::Matrix
+                         <T_W, Eigen::Dynamic, Eigen::Dynamic>& W,
+                         const Eigen::Matrix<T_m0, Eigen::Dynamic, 1>& m0,
+                         const Eigen::Matrix
+                         <T_C0, Eigen::Dynamic, Eigen::Dynamic>& C0) {
+      return gaussian_dlm_obs_lpdf<false>(y, F, G, V, W, m0, C0);
+    }
+
+    /**
+     * The log of a Gaussian dynamic linear model (GDLM) with
+     * uncorrelated observation disturbances.
+     * This distribution is equivalent to, for \f$t = 1:T\f$,
+     * \f{eqnarray*}{
+     * y_t & \sim N(F' \theta_t, diag(V)) \\
+     * \theta_t & \sim N(G \theta_{t-1}, W) \\
+     * \theta_0 & \sim N(m_0, C_0)
+     * \f}
+     *
+     * If V is a vector, then the Kalman filter is applied
+     * sequentially.
+     *
+     * @param y A r x T matrix of observations. Rows are variables,
+     * columns are observations.
+     * @param F A n x r matrix. The design matrix.
+     * @param G A n x n matrix. The transition matrix.
+     * @param V A size r vector. The diagonal of the observation
+     * covariance matrix.
+     * @param W A n x n matrix. The state covariance matrix.
+     * @param m0 A n x 1 matrix. The mean vector of the distribution
+     * of the initial state.
+     * @param C0 A n x n matrix. The covariance matrix of the
+     * distribution of the initial state.
+     * @return The log of the joint density of the GDLM.
+     * @throw std::domain_error if a matrix in the Kalman filter is
+     * not semi-positive definite.
+     * @tparam T_y Type of scalar.
+     * @tparam T_F Type of design matrix.
+     * @tparam T_G Type of transition matrix.
+     * @tparam T_V Type of observation variances
+     * @tparam T_W Type of state covariance matrix.
+     * @tparam T_m0 Type of initial state mean vector.
+     * @tparam T_C0 Type of initial state covariance matrix.
+     */
+    template <bool propto,
+              typename T_y,
+              typename T_F, typename T_G,
+              typename T_V, typename T_W,
+              typename T_m0, typename T_C0
+              >
+    typename return_type<
+      T_y,
+      typename return_type<T_F, T_G, T_V, T_W, T_m0, T_C0>::type >::type
+    gaussian_dlm_obs_lpdf(const Eigen::Matrix
+                         <T_y, Eigen::Dynamic, Eigen::Dynamic>& y,
+                         const Eigen::Matrix
+                         <T_F, Eigen::Dynamic, Eigen::Dynamic>& F,
+                         const Eigen::Matrix
+                         <T_G, Eigen::Dynamic, Eigen::Dynamic>& G,
+                         const Eigen::Matrix<T_V, Eigen::Dynamic, 1>& V,
+                         const Eigen::Matrix
+                         <T_W, Eigen::Dynamic, Eigen::Dynamic>& W,
+                         const Eigen::Matrix<T_m0, Eigen::Dynamic, 1>& m0,
+                         const Eigen::Matrix
+                         <T_C0, Eigen::Dynamic, Eigen::Dynamic>& C0) {
+      static const char* function("gaussian_dlm_obs_lpdf");
+      typedef
+        typename return_type
+        <T_y, typename return_type<T_F, T_G, T_V, T_W, T_m0, T_C0>::type>::type
+        T_lp;
+      T_lp lp(0.0);
+
+      using std::log;
+
+      int r = y.rows();  // number of variables
+      int T = y.cols();  // number of observations
+      int n = G.rows();  // number of states
+
+      check_finite(function, "y", y);
+      check_not_nan(function, "y", y);
+      check_size_match(function,
+                       "columns of F", F.cols(),
+                       "rows of y", y.rows());
+      check_size_match(function,
+                       "rows of F", F.rows(),
+                       "rows of G", G.rows());
+      check_finite(function, "F", F);
+      check_not_nan(function, "F", F);
+      check_size_match(function,
+                       "rows of G", G.rows(),
+                       "columns of G", G.cols());
+      check_finite(function, "G", G);
+      check_not_nan(function, "G", G);
+      check_nonnegative(function, "V", V);
+      check_size_match(function,
+                       "size of V", V.size(),
+                       "rows of y", y.rows());
+      // TODO(anyone): support infinite V
+      check_finite(function, "V", V);
+      check_not_nan(function, "V", V);
+      check_spsd_matrix(function, "W", W);
+      check_size_match(function,
+                       "rows of W", W.rows(),
+                       "rows of G", G.rows());
+      // TODO(anyone): support infinite W
+      check_finite(function, "W", W);
+      check_not_nan(function, "W", W);
+      check_size_match(function,
+                       "size of m0", m0.size(),
+                       "rows of G", G.rows());
+      check_finite(function, "m0", m0);
+      check_not_nan(function, "m0", m0);
+      check_cov_matrix(function, "C0", C0);
+      check_size_match(function,
+                       "rows of C0", C0.rows(),
+                       "rows of G", G.rows());
+      check_finite(function, "C0", C0);
+      check_not_nan(function, "C0", C0);
+
+      if (y.cols() == 0 || y.rows() == 0)
+        return lp;
+
+      if (include_summand<propto>::value) {
+        lp += 0.5 * NEG_LOG_TWO_PI * r * T;
+      }
+
+      if (include_summand<propto, T_y, T_F, T_G, T_V, T_W, T_m0, T_C0>::value) {
+        T_lp f;
+        T_lp Q;
+        T_lp Q_inv;
+        T_lp e;
+        Eigen::Matrix<T_lp, Eigen::Dynamic, 1> A(n);
+        Eigen::Matrix<T_lp, Eigen::Dynamic, 1> Fj(n);
+        Eigen::Matrix<T_lp, Eigen::Dynamic, 1> m(n);
+        Eigen::Matrix<T_lp, Eigen::Dynamic, Eigen::Dynamic> C(n, n);
+
+        // TODO(anyone): how to recast matrices
+        for (int i = 0; i < m0.size(); i++) {
+          m(i) = m0(i);
+        }
+        for (int i = 0; i < C0.rows(); i++) {
+          for (int j = 0; j < C0.cols(); j++) {
+            C(i, j) = C0(i, j);
+          }
+        }
+
+        for (int i = 0; i < y.cols(); i++) {
+          // Predict state
+          // reuse m and C instead of using a and R
+          m = multiply(G, m);
+          C = add(quad_form_sym(C, transpose(G)), W);
+          for (int j = 0; j < y.rows(); ++j) {
+            // predict observation
+            T_lp yij(y(j, i));
+            // dim Fj = (n, 1)
+            for (int k = 0; k < F.rows(); ++k) {
+              Fj(k) = F(k, j);
+            }
+            // f_{t, i} = F_{t, i}' m_{t, i-1}
+            f = dot_product(Fj, m);
+            Q = trace_quad_form(C, Fj) + V(j);
+            Q_inv = 1.0 / Q;
+            // filtered observation
+            // e_{t, i} = y_{t, i} - f_{t, i}
+            e = yij - f;
+            // A_{t, i} = C_{t, i-1} F_{t, i} Q_{t, i}^{-1}
+            A = multiply(multiply(C, Fj), Q_inv);
+            // m_{t, i} = m_{t, i-1} + A_{t, i} e_{t, i}
+            m += multiply(A, e);
+            // c_{t, i} = C_{t, i-1} - Q_{t, i} A_{t, i} A_{t, i}'
+            // tcrossprod throws an error (ambiguous)
+            // C = subtract(C, multiply(Q, tcrossprod(A)));
+            C -= multiply(Q, multiply(A, transpose(A)));
+            C = 0.5 * add(C, transpose(C));
+            lp -= 0.5 * (log(Q) + pow(e, 2) * Q_inv);
+          }
+        }
+      }
+      return lp;
+    }
+
+    template <typename T_y,
+              typename T_F, typename T_G,
+              typename T_V, typename T_W,
+              typename T_m0, typename T_C0>
+    inline
+    typename return_type
+    <T_y, typename return_type<T_F, T_G, T_V, T_W, T_m0, T_C0>::type>::type
+    gaussian_dlm_obs_lpdf
+    (const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>& y,
+     const Eigen::Matrix<T_F, Eigen::Dynamic, Eigen::Dynamic>& F,
+     const Eigen::Matrix<T_G, Eigen::Dynamic, Eigen::Dynamic>& G,
+     const Eigen::Matrix<T_V, Eigen::Dynamic, 1>& V,
+     const Eigen::Matrix<T_W, Eigen::Dynamic, Eigen::Dynamic>& W,
+     const Eigen::Matrix<T_m0, Eigen::Dynamic, 1>& m0,
+     const Eigen::Matrix<T_C0, Eigen::Dynamic, Eigen::Dynamic>& C0) {
+      return gaussian_dlm_obs_lpdf<false>(y, F, G, V, W, m0, C0);
+    }
+
+  }
+}
+#endif

--- a/stan/math/prim/mat/prob/inv_wishart_log.hpp
+++ b/stan/math/prim/mat/prob/inv_wishart_log.hpp
@@ -1,20 +1,11 @@
 #ifndef STAN_MATH_PRIM_MAT_PROB_INV_WISHART_LOG_HPP
 #define STAN_MATH_PRIM_MAT_PROB_INV_WISHART_LOG_HPP
 
-#include <stan/math/prim/mat/err/check_ldlt_factor.hpp>
-#include <stan/math/prim/scal/err/check_greater.hpp>
-#include <stan/math/prim/scal/err/check_size_match.hpp>
-#include <stan/math/prim/mat/err/check_square.hpp>
-#include <stan/math/prim/mat/meta/index_type.hpp>
-#include <stan/math/prim/mat/fun/log_determinant_ldlt.hpp>
-#include <stan/math/prim/mat/fun/mdivide_left_ldlt.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <stan/math/prim/scal/fun/lmgamma.hpp>
-#include <stan/math/prim/mat/fun/trace.hpp>
+#include <stan/math/prim/mat/prob/inv_wishart_lpdf.hpp>
 
 namespace stan {
   namespace math {
+
     /**
      * The log of the Inverse-Wishart density for the given W, degrees
      * of freedom, and scale matrix.
@@ -22,14 +13,7 @@ namespace stan {
      * The scale matrix, S, must be k x k, symmetric, and semi-positive
      * definite.
      *
-     * \f{eqnarray*}{
-     W &\sim& \mbox{\sf{Inv-Wishart}}_{\nu} (S) \\
-     \log (p (W \, |\, \nu, S) ) &=& \log \left( \left(2^{\nu k/2} \pi^{k (k-1) /4} \prod_{i=1}^k{\Gamma (\frac{\nu + 1 - i}{2})} \right)^{-1}
-     \times \left| S \right|^{\nu/2} \left| W \right|^{-(\nu + k + 1) / 2}
-     \times \exp (-\frac{1}{2} \mbox{tr} (S W^{-1})) \right) \\
-     &=& -\frac{\nu k}{2}\log(2) - \frac{k (k-1)}{4} \log(\pi) - \sum_{i=1}^{k}{\log (\Gamma (\frac{\nu+1-i}{2}))}
-     +\frac{\nu}{2} \log(\det(S)) - \frac{\nu+k+1}{2}\log (\det(W)) - \frac{1}{2} \mbox{tr}(S W^{-1})
-     \f}
+     * @deprecated use <code>inverse_wishart_lpdf</code>
      *
      * @param W A scalar matrix
      * @param nu Degrees of freedom
@@ -49,59 +33,12 @@ namespace stan {
                     const T_dof& nu,
                     const Eigen::Matrix
                     <T_scale, Eigen::Dynamic, Eigen::Dynamic>& S) {
-      static const char* function("inv_wishart_log");
-
-      using boost::math::tools::promote_args;
-      using Eigen::Dynamic;
-      using Eigen::Matrix;
-
-      typename index_type<Matrix<T_scale, Dynamic, Dynamic> >::type k
-        = S.rows();
-      typename promote_args<T_y, T_dof, T_scale>::type lp(0.0);
-
-      check_greater(function, "Degrees of freedom parameter", nu, k-1);
-      check_square(function, "random variable", W);
-      check_square(function, "scale parameter", S);
-      check_size_match(function,
-                       "Rows of random variable", W.rows(),
-                       "columns of scale parameter", S.rows());
-
-      LDLT_factor<T_y, Eigen::Dynamic, Eigen::Dynamic> ldlt_W(W);
-      check_ldlt_factor(function, "LDLT_Factor of random variable", ldlt_W);
-      LDLT_factor<T_scale, Eigen::Dynamic, Eigen::Dynamic> ldlt_S(S);
-      check_ldlt_factor(function, "LDLT_Factor of scale parameter", ldlt_S);
-
-      if (include_summand<propto, T_dof>::value)
-        lp -= lmgamma(k, 0.5 * nu);
-      if (include_summand<propto, T_dof, T_scale>::value) {
-        lp += 0.5 * nu * log_determinant_ldlt(ldlt_S);
-      }
-      if (include_summand<propto, T_y, T_dof, T_scale>::value) {
-        lp -= 0.5 * (nu + k + 1.0) * log_determinant_ldlt(ldlt_W);
-      }
-      if (include_summand<propto, T_y, T_scale>::value) {
-        //    L = crossprod(mdivide_left_tri_low(L));
-        //    Eigen::Matrix<T_y, Eigen::Dynamic, 1> W_inv_vec = Eigen::Map<
-        //      const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic> >(
-        //      &L(0), L.size(), 1);
-        //    Eigen::Matrix<T_scale, Eigen::Dynamic, 1> S_vec = Eigen::Map<
-        //      const Eigen::Matrix<T_scale, Eigen::Dynamic, Eigen::Dynamic> >(
-        //      &S(0), S.size(), 1);
-        //    lp -= 0.5 * dot_product(S_vec, W_inv_vec); // trace(S * W^-1)
-        Eigen::Matrix<typename promote_args<T_y, T_scale>::type,
-                      Eigen::Dynamic, Eigen::Dynamic>
-          Winv_S(mdivide_left_ldlt
-                 (ldlt_W,
-                  static_cast<Eigen::Matrix
-                  <T_scale, Eigen::Dynamic, Eigen::Dynamic> >
-                  (S.template selfadjointView<Eigen::Lower>())));
-        lp -= 0.5*trace(Winv_S);
-      }
-      if (include_summand<propto, T_dof, T_scale>::value)
-        lp += nu * k * NEG_LOG_TWO_OVER_TWO;
-      return lp;
+      return inv_wishart_lpdf<propto, T_y, T_dof, T_scale>(W, nu, S);
     }
 
+    /**
+     * @deprecated use <code>inverse_wishart_lpdf</code>
+     */       
     template <typename T_y, typename T_dof, typename T_scale>
     inline
     typename boost::math::tools::promote_args<T_y, T_dof, T_scale>::type
@@ -109,7 +46,7 @@ namespace stan {
                     const T_dof& nu,
                     const Eigen::Matrix
                     <T_scale, Eigen::Dynamic, Eigen::Dynamic>& S) {
-      return inv_wishart_log<false>(W, nu, S);
+      return inv_wishart_lpdf<T_y, T_dof, T_scale>(W, nu, S);
     }
 
   }

--- a/stan/math/prim/mat/prob/inv_wishart_lpdf.hpp
+++ b/stan/math/prim/mat/prob/inv_wishart_lpdf.hpp
@@ -1,0 +1,119 @@
+#ifndef STAN_MATH_PRIM_MAT_PROB_INV_WISHART_LPDF_HPP
+#define STAN_MATH_PRIM_MAT_PROB_INV_WISHART_LPDF_HPP
+
+#include <stan/math/prim/mat/err/check_ldlt_factor.hpp>
+#include <stan/math/prim/scal/err/check_greater.hpp>
+#include <stan/math/prim/scal/err/check_size_match.hpp>
+#include <stan/math/prim/mat/err/check_square.hpp>
+#include <stan/math/prim/mat/meta/index_type.hpp>
+#include <stan/math/prim/mat/fun/log_determinant_ldlt.hpp>
+#include <stan/math/prim/mat/fun/mdivide_left_ldlt.hpp>
+#include <stan/math/prim/scal/fun/constants.hpp>
+#include <stan/math/prim/scal/meta/include_summand.hpp>
+#include <stan/math/prim/scal/fun/lmgamma.hpp>
+#include <stan/math/prim/mat/fun/trace.hpp>
+
+namespace stan {
+  namespace math {
+    /**
+     * The log of the Inverse-Wishart density for the given W, degrees
+     * of freedom, and scale matrix.
+     *
+     * The scale matrix, S, must be k x k, symmetric, and semi-positive
+     * definite.
+     *
+     * \f{eqnarray*}{
+     W &\sim& \mbox{\sf{Inv-Wishart}}_{\nu} (S) \\
+     \log (p (W \, |\, \nu, S) ) &=& \log \left( \left(2^{\nu k/2} \pi^{k (k-1) /4} \prod_{i=1}^k{\Gamma (\frac{\nu + 1 - i}{2})} \right)^{-1}
+     \times \left| S \right|^{\nu/2} \left| W \right|^{-(\nu + k + 1) / 2}
+     \times \exp (-\frac{1}{2} \mbox{tr} (S W^{-1})) \right) \\
+     &=& -\frac{\nu k}{2}\log(2) - \frac{k (k-1)}{4} \log(\pi) - \sum_{i=1}^{k}{\log (\Gamma (\frac{\nu+1-i}{2}))}
+     +\frac{\nu}{2} \log(\det(S)) - \frac{\nu+k+1}{2}\log (\det(W)) - \frac{1}{2} \mbox{tr}(S W^{-1})
+     \f}
+     *
+     * @param W A scalar matrix
+     * @param nu Degrees of freedom
+     * @param S The scale matrix
+     * @return The log of the Inverse-Wishart density at W given nu and S.
+     * @throw std::domain_error if nu is not greater than k-1
+     * @throw std::domain_error if S is not square, not symmetric, or not
+     * semi-positive definite.
+     * @tparam T_y Type of scalar.
+     * @tparam T_dof Type of degrees of freedom.
+     * @tparam T_scale Type of scale.
+     */
+    template <bool propto,
+              typename T_y, typename T_dof, typename T_scale>
+    typename boost::math::tools::promote_args<T_y, T_dof, T_scale>::type
+    inv_wishart_lpdf(const
+                     Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>& W,
+                     const T_dof& nu,
+                     const Eigen::Matrix
+                     <T_scale, Eigen::Dynamic, Eigen::Dynamic>& S) {
+      static const char* function("inv_wishart_lpdf");
+
+      using boost::math::tools::promote_args;
+      using Eigen::Dynamic;
+      using Eigen::Matrix;
+
+      typename index_type<Matrix<T_scale, Dynamic, Dynamic> >::type k
+        = S.rows();
+      typename promote_args<T_y, T_dof, T_scale>::type lp(0.0);
+
+      check_greater(function, "Degrees of freedom parameter", nu, k-1);
+      check_square(function, "random variable", W);
+      check_square(function, "scale parameter", S);
+      check_size_match(function,
+                       "Rows of random variable", W.rows(),
+                       "columns of scale parameter", S.rows());
+
+      LDLT_factor<T_y, Eigen::Dynamic, Eigen::Dynamic> ldlt_W(W);
+      check_ldlt_factor(function, "LDLT_Factor of random variable", ldlt_W);
+      LDLT_factor<T_scale, Eigen::Dynamic, Eigen::Dynamic> ldlt_S(S);
+      check_ldlt_factor(function, "LDLT_Factor of scale parameter", ldlt_S);
+
+      if (include_summand<propto, T_dof>::value)
+        lp -= lmgamma(k, 0.5 * nu);
+      if (include_summand<propto, T_dof, T_scale>::value) {
+        lp += 0.5 * nu * log_determinant_ldlt(ldlt_S);
+      }
+      if (include_summand<propto, T_y, T_dof, T_scale>::value) {
+        lp -= 0.5 * (nu + k + 1.0) * log_determinant_ldlt(ldlt_W);
+      }
+      if (include_summand<propto, T_y, T_scale>::value) {
+        //    L = crossprod(mdivide_left_tri_low(L));
+        //    Eigen::Matrix<T_y, Eigen::Dynamic, 1> W_inv_vec = Eigen::Map<
+        //      const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic> >(
+        //      &L(0), L.size(), 1);
+        //    Eigen::Matrix<T_scale, Eigen::Dynamic, 1> S_vec = Eigen::Map<
+        //      const Eigen::Matrix<T_scale, Eigen::Dynamic, Eigen::Dynamic> >(
+        //      &S(0), S.size(), 1);
+        //    lp -= 0.5 * dot_product(S_vec, W_inv_vec); // trace(S * W^-1)
+        Eigen::Matrix<typename promote_args<T_y, T_scale>::type,
+                      Eigen::Dynamic, Eigen::Dynamic>
+          Winv_S(mdivide_left_ldlt
+                 (ldlt_W,
+                  static_cast<Eigen::Matrix
+                  <T_scale, Eigen::Dynamic, Eigen::Dynamic> >
+                  (S.template selfadjointView<Eigen::Lower>())));
+        lp -= 0.5*trace(Winv_S);
+      }
+      if (include_summand<propto, T_dof, T_scale>::value)
+        lp += nu * k * NEG_LOG_TWO_OVER_TWO;
+      return lp;
+    }
+
+    template <typename T_y, typename T_dof, typename T_scale>
+    inline
+    typename boost::math::tools::promote_args<T_y, T_dof, T_scale>::type
+    inv_wishart_lpdf(const
+                     Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>& W,
+                     const T_dof& nu,
+                     const Eigen::Matrix
+                     <T_scale, Eigen::Dynamic, Eigen::Dynamic>& S) {
+      return inv_wishart_lpdf<false>(W, nu, S);
+    }
+
+  }
+}
+#endif

--- a/stan/math/prim/mat/prob/lkj_corr_cholesky_log.hpp
+++ b/stan/math/prim/mat/prob/lkj_corr_cholesky_log.hpp
@@ -1,102 +1,33 @@
 #ifndef STAN_MATH_PRIM_MAT_PROB_LKJ_CORR_CHOLESKY_LOG_HPP
 #define STAN_MATH_PRIM_MAT_PROB_LKJ_CORR_CHOLESKY_LOG_HPP
 
-#include <stan/math/prim/scal/err/check_finite.hpp>
-#include <stan/math/prim/scal/err/check_positive.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <stan/math/prim/mat/fun/factor_cov_matrix.hpp>
-#include <stan/math/prim/mat/fun/factor_U.hpp>
-#include <stan/math/prim/mat/fun/read_corr_L.hpp>
-#include <stan/math/prim/mat/fun/read_corr_matrix.hpp>
-#include <stan/math/prim/mat/fun/read_cov_L.hpp>
-#include <stan/math/prim/mat/fun/read_cov_matrix.hpp>
-#include <stan/math/prim/mat/fun/make_nu.hpp>
-#include <stan/math/prim/scal/fun/identity_constrain.hpp>
-#include <stan/math/prim/scal/fun/identity_free.hpp>
-#include <stan/math/prim/scal/fun/positive_constrain.hpp>
-#include <stan/math/prim/scal/fun/positive_free.hpp>
-#include <stan/math/prim/scal/fun/lb_constrain.hpp>
-#include <stan/math/prim/scal/fun/lb_free.hpp>
-#include <stan/math/prim/scal/fun/ub_constrain.hpp>
-#include <stan/math/prim/scal/fun/ub_free.hpp>
-#include <stan/math/prim/scal/fun/lub_constrain.hpp>
-#include <stan/math/prim/scal/fun/lub_free.hpp>
-#include <stan/math/prim/scal/fun/prob_constrain.hpp>
-#include <stan/math/prim/scal/fun/prob_free.hpp>
-#include <stan/math/prim/scal/fun/corr_constrain.hpp>
-#include <stan/math/prim/scal/fun/corr_free.hpp>
-#include <stan/math/prim/mat/fun/simplex_constrain.hpp>
-#include <stan/math/prim/mat/fun/simplex_free.hpp>
-#include <stan/math/prim/mat/fun/ordered_constrain.hpp>
-#include <stan/math/prim/mat/fun/ordered_free.hpp>
-#include <stan/math/prim/mat/fun/positive_ordered_constrain.hpp>
-#include <stan/math/prim/mat/fun/positive_ordered_free.hpp>
-#include <stan/math/prim/mat/fun/cholesky_factor_constrain.hpp>
-#include <stan/math/prim/mat/fun/cholesky_factor_free.hpp>
-#include <stan/math/prim/mat/fun/cholesky_corr_constrain.hpp>
-#include <stan/math/prim/mat/fun/cholesky_corr_free.hpp>
-#include <stan/math/prim/mat/fun/corr_matrix_constrain.hpp>
-#include <stan/math/prim/mat/fun/corr_matrix_free.hpp>
-#include <stan/math/prim/mat/fun/cov_matrix_constrain.hpp>
-#include <stan/math/prim/mat/fun/cov_matrix_free.hpp>
-#include <stan/math/prim/mat/fun/cov_matrix_constrain_lkj.hpp>
-#include <stan/math/prim/mat/fun/cov_matrix_free_lkj.hpp>
-#include <stan/math/prim/mat/prob/lkj_corr_log.hpp>
-#include <stan/math/prim/mat/fun/multiply.hpp>
+#include <stan/math/prim/mat/prob/lkj_corr_cholesky_lpdf.hpp>
 
 namespace stan {
   namespace math {
 
-    // LKJ_Corr(L|eta) [ L Cholesky factor of correlation matrix
-    //                  eta > 0; eta == 1 <-> uniform]
+    /**
+     * @deprecated use <code>lkj_corr_cholesky_lpdf</code>
+     */
     template <bool propto,
               typename T_covar, typename T_shape>
     typename boost::math::tools::promote_args<T_covar, T_shape>::type
     lkj_corr_cholesky_log(const Eigen::Matrix
                           <T_covar, Eigen::Dynamic, Eigen::Dynamic>& L,
                           const T_shape& eta) {
-      static const char* function("lkj_corr_cholesky_log");
-
-      using boost::math::tools::promote_args;
-
-      typedef typename promote_args<T_covar, T_shape>::type lp_ret;
-      lp_ret lp(0.0);
-      check_positive(function, "Shape parameter", eta);
-      check_lower_triangular(function, "Random variable", L);
-
-      const unsigned int K = L.rows();
-      if (K == 0)
-        return 0.0;
-
-      if (include_summand<propto, T_shape>::value)
-        lp += do_lkj_constant(eta, K);
-      if (include_summand<propto, T_covar, T_shape>::value) {
-        const int Km1 = K - 1;
-        Eigen::Matrix<T_covar, Eigen::Dynamic, 1> log_diagonals =
-          L.diagonal().tail(Km1).array().log();
-        Eigen::Matrix<lp_ret, Eigen::Dynamic, 1> values(Km1);
-        for (int k = 0; k < Km1; k++)
-          values(k) = (Km1 - k - 1) * log_diagonals(k);
-        if ( (eta == 1.0) &&
-             stan::is_constant<typename stan::scalar_type<T_shape> >::value) {
-          lp += sum(values);
-          return(lp);
-        }
-        values += multiply(2.0 * eta - 2.0, log_diagonals);
-        lp += sum(values);
-      }
-
-      return lp;
+      return lkj_corr_cholesky_lpdf<propto, T_covar, T_shape>(L, eta);
     }
 
+    /**
+     * @deprecated use <code>lkj_corr_cholesky_lpdf</code>
+     */
     template <typename T_covar, typename T_shape>
     inline
     typename boost::math::tools::promote_args<T_covar, T_shape>::type
     lkj_corr_cholesky_log(const Eigen::Matrix
                           <T_covar, Eigen::Dynamic, Eigen::Dynamic>& L,
                           const T_shape& eta) {
-      return lkj_corr_cholesky_log<false>(L, eta);
+      return lkj_corr_cholesky_lpdf<T_covar, T_shape>(L, eta);
     }
 
   }

--- a/stan/math/prim/mat/prob/lkj_corr_cholesky_lpdf.hpp
+++ b/stan/math/prim/mat/prob/lkj_corr_cholesky_lpdf.hpp
@@ -1,0 +1,104 @@
+#ifndef STAN_MATH_PRIM_MAT_PROB_LKJ_CORR_CHOLESKY_LPDF_HPP
+#define STAN_MATH_PRIM_MAT_PROB_LKJ_CORR_CHOLESKY_LPDF_HPP
+
+#include <stan/math/prim/scal/err/check_finite.hpp>
+#include <stan/math/prim/scal/err/check_positive.hpp>
+#include <stan/math/prim/scal/fun/constants.hpp>
+#include <stan/math/prim/scal/meta/include_summand.hpp>
+#include <stan/math/prim/mat/fun/factor_cov_matrix.hpp>
+#include <stan/math/prim/mat/fun/factor_U.hpp>
+#include <stan/math/prim/mat/fun/read_corr_L.hpp>
+#include <stan/math/prim/mat/fun/read_corr_matrix.hpp>
+#include <stan/math/prim/mat/fun/read_cov_L.hpp>
+#include <stan/math/prim/mat/fun/read_cov_matrix.hpp>
+#include <stan/math/prim/mat/fun/make_nu.hpp>
+#include <stan/math/prim/scal/fun/identity_constrain.hpp>
+#include <stan/math/prim/scal/fun/identity_free.hpp>
+#include <stan/math/prim/scal/fun/positive_constrain.hpp>
+#include <stan/math/prim/scal/fun/positive_free.hpp>
+#include <stan/math/prim/scal/fun/lb_constrain.hpp>
+#include <stan/math/prim/scal/fun/lb_free.hpp>
+#include <stan/math/prim/scal/fun/ub_constrain.hpp>
+#include <stan/math/prim/scal/fun/ub_free.hpp>
+#include <stan/math/prim/scal/fun/lub_constrain.hpp>
+#include <stan/math/prim/scal/fun/lub_free.hpp>
+#include <stan/math/prim/scal/fun/prob_constrain.hpp>
+#include <stan/math/prim/scal/fun/prob_free.hpp>
+#include <stan/math/prim/scal/fun/corr_constrain.hpp>
+#include <stan/math/prim/scal/fun/corr_free.hpp>
+#include <stan/math/prim/mat/fun/simplex_constrain.hpp>
+#include <stan/math/prim/mat/fun/simplex_free.hpp>
+#include <stan/math/prim/mat/fun/ordered_constrain.hpp>
+#include <stan/math/prim/mat/fun/ordered_free.hpp>
+#include <stan/math/prim/mat/fun/positive_ordered_constrain.hpp>
+#include <stan/math/prim/mat/fun/positive_ordered_free.hpp>
+#include <stan/math/prim/mat/fun/cholesky_factor_constrain.hpp>
+#include <stan/math/prim/mat/fun/cholesky_factor_free.hpp>
+#include <stan/math/prim/mat/fun/cholesky_corr_constrain.hpp>
+#include <stan/math/prim/mat/fun/cholesky_corr_free.hpp>
+#include <stan/math/prim/mat/fun/corr_matrix_constrain.hpp>
+#include <stan/math/prim/mat/fun/corr_matrix_free.hpp>
+#include <stan/math/prim/mat/fun/cov_matrix_constrain.hpp>
+#include <stan/math/prim/mat/fun/cov_matrix_free.hpp>
+#include <stan/math/prim/mat/fun/cov_matrix_constrain_lkj.hpp>
+#include <stan/math/prim/mat/fun/cov_matrix_free_lkj.hpp>
+#include <stan/math/prim/mat/prob/lkj_corr_log.hpp>
+#include <stan/math/prim/mat/fun/multiply.hpp>
+
+namespace stan {
+  namespace math {
+
+    // LKJ_Corr(L|eta) [ L Cholesky factor of correlation matrix
+    //                  eta > 0; eta == 1 <-> uniform]
+    template <bool propto,
+              typename T_covar, typename T_shape>
+    typename boost::math::tools::promote_args<T_covar, T_shape>::type
+    lkj_corr_cholesky_lpdf(const Eigen::Matrix
+                          <T_covar, Eigen::Dynamic, Eigen::Dynamic>& L,
+                          const T_shape& eta) {
+      static const char* function("lkj_corr_cholesky_lpdf");
+
+      using boost::math::tools::promote_args;
+
+      typedef typename promote_args<T_covar, T_shape>::type lp_ret;
+      lp_ret lp(0.0);
+      check_positive(function, "Shape parameter", eta);
+      check_lower_triangular(function, "Random variable", L);
+
+      const unsigned int K = L.rows();
+      if (K == 0)
+        return 0.0;
+
+      if (include_summand<propto, T_shape>::value)
+        lp += do_lkj_constant(eta, K);
+      if (include_summand<propto, T_covar, T_shape>::value) {
+        const int Km1 = K - 1;
+        Eigen::Matrix<T_covar, Eigen::Dynamic, 1> log_diagonals =
+          L.diagonal().tail(Km1).array().log();
+        Eigen::Matrix<lp_ret, Eigen::Dynamic, 1> values(Km1);
+        for (int k = 0; k < Km1; k++)
+          values(k) = (Km1 - k - 1) * log_diagonals(k);
+        if ( (eta == 1.0) &&
+             stan::is_constant<typename stan::scalar_type<T_shape> >::value) {
+          lp += sum(values);
+          return(lp);
+        }
+        values += multiply(2.0 * eta - 2.0, log_diagonals);
+        lp += sum(values);
+      }
+
+      return lp;
+    }
+
+    template <typename T_covar, typename T_shape>
+    inline
+    typename boost::math::tools::promote_args<T_covar, T_shape>::type
+    lkj_corr_cholesky_lpdf(const Eigen::Matrix
+                          <T_covar, Eigen::Dynamic, Eigen::Dynamic>& L,
+                          const T_shape& eta) {
+      return lkj_corr_cholesky_lpdf<false>(L, eta);
+    }
+
+  }
+}
+#endif

--- a/stan/math/prim/mat/prob/lkj_corr_log.hpp
+++ b/stan/math/prim/mat/prob/lkj_corr_log.hpp
@@ -1,121 +1,31 @@
 #ifndef STAN_MATH_PRIM_MAT_PROB_LKJ_CORR_LOG_HPP
 #define STAN_MATH_PRIM_MAT_PROB_LKJ_CORR_LOG_HPP
 
-#include <stan/math/prim/mat/err/check_corr_matrix.hpp>
-#include <stan/math/prim/scal/err/check_finite.hpp>
-#include <stan/math/prim/scal/err/check_positive.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <stan/math/prim/scal/fun/lgamma.hpp>
-#include <stan/math/prim/mat/fun/factor_cov_matrix.hpp>
-#include <stan/math/prim/mat/fun/factor_U.hpp>
-#include <stan/math/prim/mat/fun/read_corr_L.hpp>
-#include <stan/math/prim/mat/fun/read_corr_matrix.hpp>
-#include <stan/math/prim/mat/fun/read_cov_L.hpp>
-#include <stan/math/prim/mat/fun/read_cov_matrix.hpp>
-#include <stan/math/prim/mat/fun/make_nu.hpp>
-#include <stan/math/prim/scal/fun/identity_constrain.hpp>
-#include <stan/math/prim/scal/fun/identity_free.hpp>
-#include <stan/math/prim/scal/fun/positive_constrain.hpp>
-#include <stan/math/prim/scal/fun/positive_free.hpp>
-#include <stan/math/prim/scal/fun/lb_constrain.hpp>
-#include <stan/math/prim/scal/fun/lb_free.hpp>
-#include <stan/math/prim/scal/fun/ub_constrain.hpp>
-#include <stan/math/prim/scal/fun/ub_free.hpp>
-#include <stan/math/prim/scal/fun/lub_constrain.hpp>
-#include <stan/math/prim/scal/fun/lub_free.hpp>
-#include <stan/math/prim/scal/fun/prob_constrain.hpp>
-#include <stan/math/prim/scal/fun/prob_free.hpp>
-#include <stan/math/prim/scal/fun/corr_constrain.hpp>
-#include <stan/math/prim/scal/fun/corr_free.hpp>
-#include <stan/math/prim/mat/fun/simplex_constrain.hpp>
-#include <stan/math/prim/mat/fun/simplex_free.hpp>
-#include <stan/math/prim/mat/fun/ordered_constrain.hpp>
-#include <stan/math/prim/mat/fun/ordered_free.hpp>
-#include <stan/math/prim/mat/fun/positive_ordered_constrain.hpp>
-#include <stan/math/prim/mat/fun/positive_ordered_free.hpp>
-#include <stan/math/prim/mat/fun/cholesky_factor_constrain.hpp>
-#include <stan/math/prim/mat/fun/cholesky_factor_free.hpp>
-#include <stan/math/prim/mat/fun/cholesky_corr_constrain.hpp>
-#include <stan/math/prim/mat/fun/cholesky_corr_free.hpp>
-#include <stan/math/prim/mat/fun/corr_matrix_constrain.hpp>
-#include <stan/math/prim/mat/fun/corr_matrix_free.hpp>
-#include <stan/math/prim/mat/fun/cov_matrix_constrain.hpp>
-#include <stan/math/prim/mat/fun/cov_matrix_free.hpp>
-#include <stan/math/prim/mat/fun/cov_matrix_constrain_lkj.hpp>
-#include <stan/math/prim/mat/fun/cov_matrix_free_lkj.hpp>
-#include <stan/math/prim/mat/fun/sum.hpp>
+#include <stan/math/prim/mat/prob/lkj_corr_lpdf.hpp>
 
 namespace stan {
   namespace math {
 
-    template <typename T_shape>
-    T_shape do_lkj_constant(const T_shape& eta, const unsigned int& K) {
-      // Lewandowski, Kurowicka, and Joe (2009) theorem 5
-      T_shape constant;
-      const int Km1 = K - 1;
-      if (eta == 1.0) {
-        // C++ integer division is appropriate in this block
-        Eigen::VectorXd numerator(Km1 / 2);
-        for (int k = 1; k <= numerator.rows(); k++)
-          numerator(k - 1) = lgamma(2.0 * k);
-        constant = sum(numerator);
-        if ((K % 2) == 1)
-          constant += 0.25 * (K * K - 1) * LOG_PI
-            - 0.25 * (Km1 * Km1) * LOG_TWO - Km1 * lgamma(0.5 * (K + 1));
-        else
-          constant += 0.25 * K * (K - 2) * LOG_PI
-            + 0.25 * (3 * K * K - 4 * K) * LOG_TWO
-            + K * lgamma(0.5 * K) - Km1 * lgamma(static_cast<double>(K));
-      } else {
-        constant = -Km1 * lgamma(eta + 0.5 * Km1);
-        for (int k = 1; k <= Km1; k++)
-          constant += 0.5 * k * LOG_PI + lgamma(eta + 0.5 * (Km1 - k));
-      }
-      return constant;
-    }
-
-    // LKJ_Corr(y|eta) [ y correlation matrix (not covariance matrix)
-    //                  eta > 0; eta == 1 <-> uniform]
+    /**
+     * @deprecated use <code>lkj_corr_lpdf</code>
+     */
     template <bool propto,
               typename T_y, typename T_shape>
     typename boost::math::tools::promote_args<T_y, T_shape>::type
     lkj_corr_log(const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>& y,
                  const T_shape& eta) {
-      static const char* function("lkj_corr_log");
-
-      using boost::math::tools::promote_args;
-
-      typename promote_args<T_y, T_shape>::type lp(0.0);
-      check_positive(function, "Shape parameter", eta);
-      check_corr_matrix(function, "Correlation matrix", y);
-
-      const unsigned int K = y.rows();
-      if (K == 0)
-        return 0.0;
-
-      if (include_summand<propto, T_shape>::value)
-        lp += do_lkj_constant(eta, K);
-
-      if ( (eta == 1.0) &&
-           stan::is_constant<typename stan::scalar_type<T_shape> >::value )
-        return lp;
-
-      if (!include_summand<propto, T_y, T_shape>::value)
-        return lp;
-
-      Eigen::Matrix<T_y, Eigen::Dynamic, 1> values =
-        y.ldlt().vectorD().array().log().matrix();
-      lp += (eta - 1.0) * sum(values);
-      return lp;
+      return lkj_corr_lpdf<propto, T_y, T_shape>(y, eta);
     }
 
+    /**
+     * @deprecated use <code>lkj_corr_lpdf</code>
+     */
     template <typename T_y, typename T_shape>
     inline
     typename boost::math::tools::promote_args<T_y, T_shape>::type
     lkj_corr_log(const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>& y,
                  const T_shape& eta) {
-      return lkj_corr_log<false>(y, eta);
+      return lkj_corr_lpdf<T_y, T_shape>(y, eta);
     }
 
   }

--- a/stan/math/prim/mat/prob/lkj_corr_lpdf.hpp
+++ b/stan/math/prim/mat/prob/lkj_corr_lpdf.hpp
@@ -1,0 +1,123 @@
+#ifndef STAN_MATH_PRIM_MAT_PROB_LKJ_CORR_LPDF_HPP
+#define STAN_MATH_PRIM_MAT_PROB_LKJ_CORR_LPDF_HPP
+
+#include <stan/math/prim/mat/err/check_corr_matrix.hpp>
+#include <stan/math/prim/scal/err/check_finite.hpp>
+#include <stan/math/prim/scal/err/check_positive.hpp>
+#include <stan/math/prim/scal/fun/constants.hpp>
+#include <stan/math/prim/scal/meta/include_summand.hpp>
+#include <stan/math/prim/scal/fun/lgamma.hpp>
+#include <stan/math/prim/mat/fun/factor_cov_matrix.hpp>
+#include <stan/math/prim/mat/fun/factor_U.hpp>
+#include <stan/math/prim/mat/fun/read_corr_L.hpp>
+#include <stan/math/prim/mat/fun/read_corr_matrix.hpp>
+#include <stan/math/prim/mat/fun/read_cov_L.hpp>
+#include <stan/math/prim/mat/fun/read_cov_matrix.hpp>
+#include <stan/math/prim/mat/fun/make_nu.hpp>
+#include <stan/math/prim/scal/fun/identity_constrain.hpp>
+#include <stan/math/prim/scal/fun/identity_free.hpp>
+#include <stan/math/prim/scal/fun/positive_constrain.hpp>
+#include <stan/math/prim/scal/fun/positive_free.hpp>
+#include <stan/math/prim/scal/fun/lb_constrain.hpp>
+#include <stan/math/prim/scal/fun/lb_free.hpp>
+#include <stan/math/prim/scal/fun/ub_constrain.hpp>
+#include <stan/math/prim/scal/fun/ub_free.hpp>
+#include <stan/math/prim/scal/fun/lub_constrain.hpp>
+#include <stan/math/prim/scal/fun/lub_free.hpp>
+#include <stan/math/prim/scal/fun/prob_constrain.hpp>
+#include <stan/math/prim/scal/fun/prob_free.hpp>
+#include <stan/math/prim/scal/fun/corr_constrain.hpp>
+#include <stan/math/prim/scal/fun/corr_free.hpp>
+#include <stan/math/prim/mat/fun/simplex_constrain.hpp>
+#include <stan/math/prim/mat/fun/simplex_free.hpp>
+#include <stan/math/prim/mat/fun/ordered_constrain.hpp>
+#include <stan/math/prim/mat/fun/ordered_free.hpp>
+#include <stan/math/prim/mat/fun/positive_ordered_constrain.hpp>
+#include <stan/math/prim/mat/fun/positive_ordered_free.hpp>
+#include <stan/math/prim/mat/fun/cholesky_factor_constrain.hpp>
+#include <stan/math/prim/mat/fun/cholesky_factor_free.hpp>
+#include <stan/math/prim/mat/fun/cholesky_corr_constrain.hpp>
+#include <stan/math/prim/mat/fun/cholesky_corr_free.hpp>
+#include <stan/math/prim/mat/fun/corr_matrix_constrain.hpp>
+#include <stan/math/prim/mat/fun/corr_matrix_free.hpp>
+#include <stan/math/prim/mat/fun/cov_matrix_constrain.hpp>
+#include <stan/math/prim/mat/fun/cov_matrix_free.hpp>
+#include <stan/math/prim/mat/fun/cov_matrix_constrain_lkj.hpp>
+#include <stan/math/prim/mat/fun/cov_matrix_free_lkj.hpp>
+#include <stan/math/prim/mat/fun/sum.hpp>
+
+namespace stan {
+  namespace math {
+
+    template <typename T_shape>
+    T_shape do_lkj_constant(const T_shape& eta, const unsigned int& K) {
+      // Lewandowski, Kurowicka, and Joe (2009) theorem 5
+      T_shape constant;
+      const int Km1 = K - 1;
+      if (eta == 1.0) {
+        // C++ integer division is appropriate in this block
+        Eigen::VectorXd numerator(Km1 / 2);
+        for (int k = 1; k <= numerator.rows(); k++)
+          numerator(k - 1) = lgamma(2.0 * k);
+        constant = sum(numerator);
+        if ((K % 2) == 1)
+          constant += 0.25 * (K * K - 1) * LOG_PI
+            - 0.25 * (Km1 * Km1) * LOG_TWO - Km1 * lgamma(0.5 * (K + 1));
+        else
+          constant += 0.25 * K * (K - 2) * LOG_PI
+            + 0.25 * (3 * K * K - 4 * K) * LOG_TWO
+            + K * lgamma(0.5 * K) - Km1 * lgamma(static_cast<double>(K));
+      } else {
+        constant = -Km1 * lgamma(eta + 0.5 * Km1);
+        for (int k = 1; k <= Km1; k++)
+          constant += 0.5 * k * LOG_PI + lgamma(eta + 0.5 * (Km1 - k));
+      }
+      return constant;
+    }
+
+    // LKJ_Corr(y|eta) [ y correlation matrix (not covariance matrix)
+    //                  eta > 0; eta == 1 <-> uniform]
+    template <bool propto,
+              typename T_y, typename T_shape>
+    typename boost::math::tools::promote_args<T_y, T_shape>::type
+    lkj_corr_lpdf(const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>& y,
+                 const T_shape& eta) {
+      static const char* function("lkj_corr_lpdf");
+
+      using boost::math::tools::promote_args;
+
+      typename promote_args<T_y, T_shape>::type lp(0.0);
+      check_positive(function, "Shape parameter", eta);
+      check_corr_matrix(function, "Correlation matrix", y);
+
+      const unsigned int K = y.rows();
+      if (K == 0)
+        return 0.0;
+
+      if (include_summand<propto, T_shape>::value)
+        lp += do_lkj_constant(eta, K);
+
+      if ( (eta == 1.0) &&
+           stan::is_constant<typename stan::scalar_type<T_shape> >::value )
+        return lp;
+
+      if (!include_summand<propto, T_y, T_shape>::value)
+        return lp;
+
+      Eigen::Matrix<T_y, Eigen::Dynamic, 1> values =
+        y.ldlt().vectorD().array().log().matrix();
+      lp += (eta - 1.0) * sum(values);
+      return lp;
+    }
+
+    template <typename T_y, typename T_shape>
+    inline
+    typename boost::math::tools::promote_args<T_y, T_shape>::type
+    lkj_corr_lpdf(const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>& y,
+                 const T_shape& eta) {
+      return lkj_corr_lpdf<false>(y, eta);
+    }
+
+  }
+}
+#endif

--- a/stan/math/prim/mat/prob/lkj_cov_log.hpp
+++ b/stan/math/prim/mat/prob/lkj_cov_log.hpp
@@ -1,20 +1,14 @@
 #ifndef STAN_MATH_PRIM_MAT_PROB_LKJ_COV_LOG_HPP
 #define STAN_MATH_PRIM_MAT_PROB_LKJ_COV_LOG_HPP
 
-#include <stan/math/prim/scal/err/check_size_match.hpp>
-#include <stan/math/prim/mat/err/check_square.hpp>
-#include <stan/math/prim/scal/err/check_finite.hpp>
-#include <stan/math/prim/scal/err/check_positive.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/prob/lognormal_log.hpp>
-#include <stan/math/prim/mat/prob/lkj_corr_log.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
+#include <stan/math/prim/mat/prob/lkj_cov_lpdf.hpp>
 
 namespace stan {
   namespace math {
 
-    // LKJ_cov(y|mu, sigma, eta) [ y covariance matrix (not correlation matrix)
-    //                         mu vector, sigma > 0 vector, eta > 0 ]
+    /**
+     * @deprecated use <code>lkj_cov_lpdf</code>
+     */
     template <bool propto,
               typename T_y, typename T_loc, typename T_scale, typename T_shape>
     typename
@@ -23,43 +17,13 @@ namespace stan {
                 const Eigen::Matrix<T_loc, Eigen::Dynamic, 1>& mu,
                 const Eigen::Matrix<T_scale, Eigen::Dynamic, 1>& sigma,
                 const T_shape& eta) {
-      static const char* function("lkj_cov_log");
-
-      using boost::math::tools::promote_args;
-
-      typename promote_args<T_y, T_loc, T_scale, T_shape>::type lp(0.0);
-      check_size_match(function,
-                       "Rows of location parameter", mu.rows(),
-                       "columns of scale parameter", sigma.rows());
-      check_square(function, "random variable", y);
-      check_size_match(function,
-                       "Rows of random variable", y.rows(),
-                       "rows of location parameter", mu.rows());
-      check_positive(function, "Shape parameter", eta);
-      check_finite(function, "Location parameter", mu);
-      check_finite(function, "Scale parameter", sigma);
-      for (int m = 0; m < y.rows(); ++m)
-        for (int n = 0; n < y.cols(); ++n)
-          check_finite(function, "Covariance matrix", y(m, n));
-
-      const unsigned int K = y.rows();
-      const Eigen::Array<T_y, Eigen::Dynamic, 1> sds
-        = y.diagonal().array().sqrt();
-      for (unsigned int k = 0; k < K; k++) {
-        lp += lognormal_log<propto>(sds(k), mu(k), sigma(k));
-      }
-      if (stan::is_constant<typename stan::scalar_type<T_shape> >::value
-          && eta == 1.0) {
-        // no need to rescale y into a correlation matrix
-        lp += lkj_corr_log<propto, T_y, T_shape>(y, eta);
-        return lp;
-      }
-      Eigen::DiagonalMatrix<T_y, Eigen::Dynamic> D(K);
-      D.diagonal() = sds.inverse();
-      lp += lkj_corr_log<propto, T_y, T_shape>(D * y * D, eta);
-      return lp;
+      return lkj_cov_lpdf<propto, T_y, T_loc,
+                          T_scale, T_shape>(y, mu, sigma, eta);
     }
 
+    /**
+     * @deprecated use <code>lkj_cov_lpdf</code>
+     */
     template <typename T_y, typename T_loc, typename T_scale, typename T_shape>
     inline
     typename
@@ -68,11 +32,12 @@ namespace stan {
                 const Eigen::Matrix<T_loc, Eigen::Dynamic, 1>& mu,
                 const Eigen::Matrix<T_scale, Eigen::Dynamic, 1>& sigma,
                 const T_shape& eta) {
-      return lkj_cov_log<false>(y, mu, sigma, eta);
+      return lkj_cov_lpdf<T_y, T_loc, T_scale, T_shape>(y, mu, sigma, eta);
     }
 
-    // LKJ_Cov(y|mu, sigma, eta) [ y covariance matrix (not correlation matrix)
-    //                         mu scalar, sigma > 0 scalar, eta > 0 ]
+    /**
+     * @deprecated use <code>lkj_corr_cholesky_lpdf</code>
+     */
     template <bool propto,
               typename T_y, typename T_loc, typename T_scale, typename T_shape>
     typename
@@ -81,33 +46,13 @@ namespace stan {
                 const T_loc& mu,
                 const T_scale& sigma,
                 const T_shape& eta) {
-      static const char* function("lkj_cov_log");
-
-      using boost::math::tools::promote_args;
-
-      typename promote_args<T_y, T_loc, T_scale, T_shape>::type lp(0.0);
-      check_positive(function, "Shape parameter", eta);
-      check_finite(function, "Location parameter", mu);
-      check_finite(function, "Scale parameter", sigma);
-
-      const unsigned int K = y.rows();
-      const Eigen::Array<T_y, Eigen::Dynamic, 1> sds
-        = y.diagonal().array().sqrt();
-      for (unsigned int k = 0; k < K; k++) {
-        lp += lognormal_log<propto>(sds(k), mu, sigma);
-      }
-      if (stan::is_constant<typename stan::scalar_type<T_shape> >::value
-          && eta == 1.0) {
-        // no need to rescale y into a correlation matrix
-        lp += lkj_corr_log<propto>(y, eta);
-        return lp;
-      }
-      Eigen::DiagonalMatrix<T_y, Eigen::Dynamic> D(K);
-      D.diagonal() = sds.inverse();
-      lp += lkj_corr_log<propto, T_y, T_shape>(D * y * D, eta);
-      return lp;
+      return lkj_cov_lpdf<propto, T_y, T_loc,
+                          T_scale, T_shape>(y, mu, sigma, eta);
     }
 
+    /**
+     * @deprecated use <code>lkj_corr_cholesky_lpdf</code>
+     */
     template <typename T_y, typename T_loc, typename T_scale, typename T_shape>
     inline
     typename boost::math::tools::promote_args
@@ -116,7 +61,8 @@ namespace stan {
                 const T_loc& mu,
                 const T_scale& sigma,
                 const T_shape& eta) {
-      return lkj_cov_log<false>(y, mu, sigma, eta);
+      return lkj_cov_lpdf<T_y, T_loc,
+                          T_scale, T_shape>(y, mu, sigma, eta);
     }
 
   }

--- a/stan/math/prim/mat/prob/lkj_cov_lpdf.hpp
+++ b/stan/math/prim/mat/prob/lkj_cov_lpdf.hpp
@@ -1,0 +1,124 @@
+#ifndef STAN_MATH_PRIM_MAT_PROB_LKJ_COV_LPDF_HPP
+#define STAN_MATH_PRIM_MAT_PROB_LKJ_COV_LPDF_HPP
+
+#include <stan/math/prim/scal/err/check_size_match.hpp>
+#include <stan/math/prim/mat/err/check_square.hpp>
+#include <stan/math/prim/scal/err/check_finite.hpp>
+#include <stan/math/prim/scal/err/check_positive.hpp>
+#include <stan/math/prim/scal/fun/constants.hpp>
+#include <stan/math/prim/scal/prob/lognormal_lpdf.hpp>
+#include <stan/math/prim/mat/prob/lkj_corr_lpdf.hpp>
+#include <stan/math/prim/scal/meta/include_summand.hpp>
+
+namespace stan {
+  namespace math {
+
+    // LKJ_cov(y|mu, sigma, eta) [ y covariance matrix (not correlation matrix)
+    //                         mu vector, sigma > 0 vector, eta > 0 ]
+    template <bool propto,
+              typename T_y, typename T_loc, typename T_scale, typename T_shape>
+    typename
+    boost::math::tools::promote_args<T_y, T_loc, T_scale, T_shape>::type
+    lkj_cov_lpdf(const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>& y,
+                const Eigen::Matrix<T_loc, Eigen::Dynamic, 1>& mu,
+                const Eigen::Matrix<T_scale, Eigen::Dynamic, 1>& sigma,
+                const T_shape& eta) {
+      static const char* function("lkj_cov_lpdf");
+
+      using boost::math::tools::promote_args;
+
+      typename promote_args<T_y, T_loc, T_scale, T_shape>::type lp(0.0);
+      check_size_match(function,
+                       "Rows of location parameter", mu.rows(),
+                       "columns of scale parameter", sigma.rows());
+      check_square(function, "random variable", y);
+      check_size_match(function,
+                       "Rows of random variable", y.rows(),
+                       "rows of location parameter", mu.rows());
+      check_positive(function, "Shape parameter", eta);
+      check_finite(function, "Location parameter", mu);
+      check_finite(function, "Scale parameter", sigma);
+      for (int m = 0; m < y.rows(); ++m)
+        for (int n = 0; n < y.cols(); ++n)
+          check_finite(function, "Covariance matrix", y(m, n));
+
+      const unsigned int K = y.rows();
+      const Eigen::Array<T_y, Eigen::Dynamic, 1> sds
+        = y.diagonal().array().sqrt();
+      for (unsigned int k = 0; k < K; k++) {
+        lp += lognormal_lpdf<propto>(sds(k), mu(k), sigma(k));
+      }
+      if (stan::is_constant<typename stan::scalar_type<T_shape> >::value
+          && eta == 1.0) {
+        // no need to rescale y into a correlation matrix
+        lp += lkj_corr_lpdf<propto, T_y, T_shape>(y, eta);
+        return lp;
+      }
+      Eigen::DiagonalMatrix<T_y, Eigen::Dynamic> D(K);
+      D.diagonal() = sds.inverse();
+      lp += lkj_corr_lpdf<propto, T_y, T_shape>(D * y * D, eta);
+      return lp;
+    }
+
+    template <typename T_y, typename T_loc, typename T_scale, typename T_shape>
+    inline
+    typename
+    boost::math::tools::promote_args<T_y, T_loc, T_scale, T_shape>::type
+    lkj_cov_lpdf(const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>& y,
+                const Eigen::Matrix<T_loc, Eigen::Dynamic, 1>& mu,
+                const Eigen::Matrix<T_scale, Eigen::Dynamic, 1>& sigma,
+                const T_shape& eta) {
+      return lkj_cov_lpdf<false>(y, mu, sigma, eta);
+    }
+
+    // LKJ_Cov(y|mu, sigma, eta) [ y covariance matrix (not correlation matrix)
+    //                         mu scalar, sigma > 0 scalar, eta > 0 ]
+    template <bool propto,
+              typename T_y, typename T_loc, typename T_scale, typename T_shape>
+    typename
+    boost::math::tools::promote_args<T_y, T_loc, T_scale, T_shape>::type
+    lkj_cov_lpdf(const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>& y,
+                const T_loc& mu,
+                const T_scale& sigma,
+                const T_shape& eta) {
+      static const char* function("lkj_cov_lpdf");
+
+      using boost::math::tools::promote_args;
+
+      typename promote_args<T_y, T_loc, T_scale, T_shape>::type lp(0.0);
+      check_positive(function, "Shape parameter", eta);
+      check_finite(function, "Location parameter", mu);
+      check_finite(function, "Scale parameter", sigma);
+
+      const unsigned int K = y.rows();
+      const Eigen::Array<T_y, Eigen::Dynamic, 1> sds
+        = y.diagonal().array().sqrt();
+      for (unsigned int k = 0; k < K; k++) {
+        lp += lognormal_lpdf<propto>(sds(k), mu, sigma);
+      }
+      if (stan::is_constant<typename stan::scalar_type<T_shape> >::value
+          && eta == 1.0) {
+        // no need to rescale y into a correlation matrix
+        lp += lkj_corr_lpdf<propto>(y, eta);
+        return lp;
+      }
+      Eigen::DiagonalMatrix<T_y, Eigen::Dynamic> D(K);
+      D.diagonal() = sds.inverse();
+      lp += lkj_corr_lpdf<propto, T_y, T_shape>(D * y * D, eta);
+      return lp;
+    }
+
+    template <typename T_y, typename T_loc, typename T_scale, typename T_shape>
+    inline
+    typename boost::math::tools::promote_args
+    <T_y, T_loc, T_scale, T_shape>::type
+    lkj_cov_lpdf(const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>& y,
+                const T_loc& mu,
+                const T_scale& sigma,
+                const T_shape& eta) {
+      return lkj_cov_lpdf<false>(y, mu, sigma, eta);
+    }
+
+  }
+}
+#endif

--- a/stan/math/prim/mat/prob/matrix_normal_prec_log.hpp
+++ b/stan/math/prim/mat/prob/matrix_normal_prec_log.hpp
@@ -1,33 +1,23 @@
 #ifndef STAN_MATH_PRIM_MAT_PROB_MATRIX_NORMAL_PREC_LOG_HPP
 #define STAN_MATH_PRIM_MAT_PROB_MATRIX_NORMAL_PREC_LOG_HPP
 
-#include <stan/math/prim/mat/err/check_ldlt_factor.hpp>
-#include <stan/math/prim/scal/err/check_size_match.hpp>
-#include <stan/math/prim/mat/err/check_symmetric.hpp>
-#include <stan/math/prim/scal/err/check_finite.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/err/check_positive.hpp>
-#include <stan/math/prim/mat/fun/log.hpp>
-#include <stan/math/prim/mat/fun/log_determinant.hpp>
-#include <stan/math/prim/mat/fun/log_determinant_ldlt.hpp>
-#include <stan/math/prim/mat/fun/subtract.hpp>
-#include <stan/math/prim/mat/fun/trace_quad_form.hpp>
-#include <stan/math/prim/mat/fun/trace_gen_quad_form.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
+#include <stan/math/prim/mat/prob/matrix_normal_prec_lpdf.hpp>
 
 namespace stan {
   namespace math {
     /**
      * The log of the matrix normal density for the given y, mu, Sigma and D
-     * where Sigma and D are given as precision matrices, not covariance matrices.
+     * where Sigma and D are given as precision matrices, not covariance
+     * matrices.
+     *
+     * @deprecated use <code>matrix_normal_prec_lpdf</code>
      *
      * @param y An mxn matrix.
      * @param Mu The mean matrix.
-     * @param Sigma The mxm inverse covariance matrix (i.e., the precision matrix) of the
-     * rows of y.
-     * @param D The nxn inverse covariance matrix (i.e., the precision matrix) of the
-     * columns of y.
+     * @param Sigma The mxm inverse covariance matrix (i.e., the precision
+     *   matrix) of the rows of y.
+     * @param D The nxn inverse covariance matrix (i.e., the precision
+     *   matrix) of the columns of y.
      * @return The log of the matrix normal density.
      * @throw std::domain_error if Sigma or D are not square, not symmetric,
      * or not semi-positive definite.
@@ -47,54 +37,13 @@ namespace stan {
                            <T_Sigma, Eigen::Dynamic, Eigen::Dynamic>& Sigma,
                            const Eigen::Matrix
                            <T_D, Eigen::Dynamic, Eigen::Dynamic>& D) {
-      static const char* function("matrix_normal_prec_log");
-      typename
-        boost::math::tools::promote_args<T_y, T_Mu, T_Sigma, T_D>::type lp(0.0);
-
-      check_positive(function, "Sigma rows", Sigma.rows());
-      check_finite(function, "Sigma", Sigma);
-      check_symmetric(function, "Sigma", Sigma);
-
-      LDLT_factor<T_Sigma, Eigen::Dynamic, Eigen::Dynamic> ldlt_Sigma(Sigma);
-      check_ldlt_factor(function, "LDLT_Factor of Sigma", ldlt_Sigma);
-      check_positive(function, "D rows", D.rows());
-      check_finite(function, "D", D);
-      check_symmetric(function, "Sigma", D);
-
-      LDLT_factor<T_D, Eigen::Dynamic, Eigen::Dynamic> ldlt_D(D);
-      check_ldlt_factor(function, "LDLT_Factor of D", ldlt_D);
-      check_size_match(function,
-                       "Rows of random variable", y.rows(),
-                       "Rows of location parameter", Mu.rows());
-      check_size_match(function,
-                       "Columns of random variable", y.cols(),
-                       "Columns of location parameter", Mu.cols());
-      check_size_match(function,
-                       "Rows of random variable", y.rows(),
-                       "Rows of Sigma", Sigma.rows());
-      check_size_match(function,
-                       "Columns of random variable", y.cols(),
-                       "Rows of D", D.rows());
-      check_finite(function, "Location parameter", Mu);
-      check_finite(function, "Random variable", y);
-
-      if (include_summand<propto>::value)
-        lp += NEG_LOG_SQRT_TWO_PI * y.cols() * y.rows();
-
-      if (include_summand<propto, T_Sigma>::value) {
-        lp += log_determinant_ldlt(ldlt_Sigma) * (0.5 * y.rows());
-      }
-
-      if (include_summand<propto, T_D>::value) {
-        lp += log_determinant_ldlt(ldlt_D) * (0.5 * y.cols());
-      }
-
-      if (include_summand<propto, T_y, T_Mu, T_Sigma, T_D>::value) {
-        lp -= 0.5 * trace_gen_quad_form(D, Sigma, subtract(y, Mu));
-      }
-      return lp;
+      return matrix_normal_prec_lpdf<propto,
+                                     T_y, T_Mu, T_Sigma, T_D>(y, Mu, Sigma, D);
     }
 
+    /**
+     * @deprecated use <code>matrix_normal_prec_lpdf</code>
+     */
     template <typename T_y, typename T_Mu, typename T_Sigma, typename T_D>
     typename boost::math::tools::promote_args<T_y, T_Mu, T_Sigma, T_D>::type
     matrix_normal_prec_log(const Eigen::Matrix
@@ -105,7 +54,7 @@ namespace stan {
                            <T_Sigma, Eigen::Dynamic, Eigen::Dynamic>& Sigma,
                            const Eigen::Matrix
                            <T_D, Eigen::Dynamic, Eigen::Dynamic>& D) {
-      return matrix_normal_prec_log<false>(y, Mu, Sigma, D);
+      return matrix_normal_prec_lpdf<T_y, T_Mu, T_Sigma, T_D>(y, Mu, Sigma, D);
     }
 
   }

--- a/stan/math/prim/mat/prob/matrix_normal_prec_lpdf.hpp
+++ b/stan/math/prim/mat/prob/matrix_normal_prec_lpdf.hpp
@@ -1,0 +1,113 @@
+#ifndef STAN_MATH_PRIM_MAT_PROB_MATRIX_NORMAL_PREC_LPDF_HPP
+#define STAN_MATH_PRIM_MAT_PROB_MATRIX_NORMAL_PREC_LPDF_HPP
+
+#include <stan/math/prim/mat/err/check_ldlt_factor.hpp>
+#include <stan/math/prim/scal/err/check_size_match.hpp>
+#include <stan/math/prim/mat/err/check_symmetric.hpp>
+#include <stan/math/prim/scal/err/check_finite.hpp>
+#include <stan/math/prim/scal/err/check_not_nan.hpp>
+#include <stan/math/prim/scal/err/check_positive.hpp>
+#include <stan/math/prim/mat/fun/log.hpp>
+#include <stan/math/prim/mat/fun/log_determinant.hpp>
+#include <stan/math/prim/mat/fun/log_determinant_ldlt.hpp>
+#include <stan/math/prim/mat/fun/subtract.hpp>
+#include <stan/math/prim/mat/fun/trace_quad_form.hpp>
+#include <stan/math/prim/mat/fun/trace_gen_quad_form.hpp>
+#include <stan/math/prim/scal/fun/constants.hpp>
+#include <stan/math/prim/scal/meta/include_summand.hpp>
+
+namespace stan {
+  namespace math {
+    /**
+     * The log of the matrix normal density for the given y, mu, Sigma and D
+     * where Sigma and D are given as precision matrices, not covariance matrices.
+     *
+     * @param y An mxn matrix.
+     * @param Mu The mean matrix.
+     * @param Sigma The mxm inverse covariance matrix (i.e., the precision matrix) of the
+     * rows of y.
+     * @param D The nxn inverse covariance matrix (i.e., the precision matrix) of the
+     * columns of y.
+     * @return The log of the matrix normal density.
+     * @throw std::domain_error if Sigma or D are not square, not symmetric,
+     * or not semi-positive definite.
+     * @tparam T_y Type of scalar.
+     * @tparam T_Mu Type of location.
+     * @tparam T_Sigma Type of Sigma.
+     * @tparam T_D Type of D.
+     */
+    template <bool propto,
+              typename T_y, typename T_Mu, typename T_Sigma, typename T_D>
+    typename boost::math::tools::promote_args<T_y, T_Mu, T_Sigma, T_D>::type
+    matrix_normal_prec_lpdf(const Eigen::Matrix
+                           <T_y, Eigen::Dynamic, Eigen::Dynamic>& y,
+                           const Eigen::Matrix
+                           <T_Mu, Eigen::Dynamic, Eigen::Dynamic>& Mu,
+                           const Eigen::Matrix
+                           <T_Sigma, Eigen::Dynamic, Eigen::Dynamic>& Sigma,
+                           const Eigen::Matrix
+                           <T_D, Eigen::Dynamic, Eigen::Dynamic>& D) {
+      static const char* function("matrix_normal_prec_lpdf");
+      typename
+        boost::math::tools::promote_args<T_y, T_Mu, T_Sigma, T_D>::type lp(0.0);
+
+      check_positive(function, "Sigma rows", Sigma.rows());
+      check_finite(function, "Sigma", Sigma);
+      check_symmetric(function, "Sigma", Sigma);
+
+      LDLT_factor<T_Sigma, Eigen::Dynamic, Eigen::Dynamic> ldlt_Sigma(Sigma);
+      check_ldlt_factor(function, "LDLT_Factor of Sigma", ldlt_Sigma);
+      check_positive(function, "D rows", D.rows());
+      check_finite(function, "D", D);
+      check_symmetric(function, "Sigma", D);
+
+      LDLT_factor<T_D, Eigen::Dynamic, Eigen::Dynamic> ldlt_D(D);
+      check_ldlt_factor(function, "LDLT_Factor of D", ldlt_D);
+      check_size_match(function,
+                       "Rows of random variable", y.rows(),
+                       "Rows of location parameter", Mu.rows());
+      check_size_match(function,
+                       "Columns of random variable", y.cols(),
+                       "Columns of location parameter", Mu.cols());
+      check_size_match(function,
+                       "Rows of random variable", y.rows(),
+                       "Rows of Sigma", Sigma.rows());
+      check_size_match(function,
+                       "Columns of random variable", y.cols(),
+                       "Rows of D", D.rows());
+      check_finite(function, "Location parameter", Mu);
+      check_finite(function, "Random variable", y);
+
+      if (include_summand<propto>::value)
+        lp += NEG_LOG_SQRT_TWO_PI * y.cols() * y.rows();
+
+      if (include_summand<propto, T_Sigma>::value) {
+        lp += log_determinant_ldlt(ldlt_Sigma) * (0.5 * y.rows());
+      }
+
+      if (include_summand<propto, T_D>::value) {
+        lp += log_determinant_ldlt(ldlt_D) * (0.5 * y.cols());
+      }
+
+      if (include_summand<propto, T_y, T_Mu, T_Sigma, T_D>::value) {
+        lp -= 0.5 * trace_gen_quad_form(D, Sigma, subtract(y, Mu));
+      }
+      return lp;
+    }
+
+    template <typename T_y, typename T_Mu, typename T_Sigma, typename T_D>
+    typename boost::math::tools::promote_args<T_y, T_Mu, T_Sigma, T_D>::type
+    matrix_normal_prec_lpdf(const Eigen::Matrix
+                           <T_y, Eigen::Dynamic, Eigen::Dynamic>& y,
+                           const Eigen::Matrix
+                           <T_Mu, Eigen::Dynamic, Eigen::Dynamic>& Mu,
+                           const Eigen::Matrix
+                           <T_Sigma, Eigen::Dynamic, Eigen::Dynamic>& Sigma,
+                           const Eigen::Matrix
+                           <T_D, Eigen::Dynamic, Eigen::Dynamic>& D) {
+      return matrix_normal_prec_lpdf<false>(y, Mu, Sigma, D);
+    }
+
+  }
+}
+#endif

--- a/stan/math/prim/scal/prob/lognormal_ccdf_log.hpp
+++ b/stan/math/prim/scal/prob/lognormal_ccdf_log.hpp
@@ -1,86 +1,18 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_LOGNORMAL_CCDF_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_LOGNORMAL_CCDF_LOG_HPP
 
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_finite.hpp>
-#include <stan/math/prim/scal/err/check_nonnegative.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/err/check_positive_finite.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/fun/square.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <boost/random/lognormal_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <cmath>
+#include <stan/math/prim/scal/prob/lognormal_lccdf.hpp>
 
 namespace stan {
   namespace math {
 
+    /**
+     * @deprecated use <code>lognormal_lccdf</code>
+     */
     template <typename T_y, typename T_loc, typename T_scale>
     typename return_type<T_y, T_loc, T_scale>::type
     lognormal_ccdf_log(const T_y& y, const T_loc& mu, const T_scale& sigma) {
-      static const char* function("lognormal_ccdf_log");
-      typedef typename stan::partials_return_type<T_y, T_loc, T_scale>::type
-        T_partials_return;
-
-      T_partials_return ccdf_log = 0.0;
-
-      using boost::math::tools::promote_args;
-      using std::log;
-      using std::exp;
-
-      if (!(stan::length(y)
-            && stan::length(mu)
-            && stan::length(sigma)))
-        return ccdf_log;
-
-      check_not_nan(function, "Random variable", y);
-      check_nonnegative(function, "Random variable", y);
-      check_finite(function, "Location parameter", mu);
-      check_positive_finite(function, "Scale parameter", sigma);
-
-      OperandsAndPartials<T_y, T_loc, T_scale>
-        operands_and_partials(y, mu, sigma);
-
-      VectorView<const T_y> y_vec(y);
-      VectorView<const T_loc> mu_vec(mu);
-      VectorView<const T_scale> sigma_vec(sigma);
-      size_t N = max_size(y, mu, sigma);
-
-      const double sqrt_pi = std::sqrt(pi());
-
-      for (size_t i = 0; i < stan::length(y); i++) {
-        if (value_of(y_vec[i]) == 0.0)
-          return operands_and_partials.value(0.0);
-      }
-
-      const double log_half = std::log(0.5);
-
-      for (size_t n = 0; n < N; n++) {
-        const T_partials_return y_dbl = value_of(y_vec[n]);
-        const T_partials_return mu_dbl = value_of(mu_vec[n]);
-        const T_partials_return sigma_dbl = value_of(sigma_vec[n]);
-        const T_partials_return scaled_diff = (log(y_dbl) - mu_dbl)
-          / (sigma_dbl * SQRT_2);
-        const T_partials_return rep_deriv = SQRT_2 / sqrt_pi
-          * exp(-scaled_diff * scaled_diff) / sigma_dbl;
-
-        const T_partials_return erfc_calc = erfc(scaled_diff);
-        ccdf_log += log_half + log(erfc_calc);
-
-        if (!is_constant_struct<T_y>::value)
-          operands_and_partials.d_x1[n] -= rep_deriv / erfc_calc / y_dbl;
-        if (!is_constant_struct<T_loc>::value)
-          operands_and_partials.d_x2[n] += rep_deriv / erfc_calc;
-        if (!is_constant_struct<T_scale>::value)
-          operands_and_partials.d_x3[n] += rep_deriv * scaled_diff * SQRT_2
-            / erfc_calc;
-      }
-      return operands_and_partials.value(ccdf_log);
+      return lognormal_lccdf<T_y, T_loc, T_scale>(y, mu, sigma);
     }
 
   }

--- a/stan/math/prim/scal/prob/lognormal_cdf_log.hpp
+++ b/stan/math/prim/scal/prob/lognormal_cdf_log.hpp
@@ -1,86 +1,18 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_LOGNORMAL_CDF_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_LOGNORMAL_CDF_LOG_HPP
 
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_finite.hpp>
-#include <stan/math/prim/scal/err/check_nonnegative.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/err/check_positive_finite.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/fun/square.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <boost/random/lognormal_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <cmath>
+#include <stan/math/prim/scal/prob/lognormal_lcdf.hpp>
 
 namespace stan {
   namespace math {
 
+    /**
+     * @deprecated use <code>lognormal_lcdf</code>
+     */
     template <typename T_y, typename T_loc, typename T_scale>
     typename return_type<T_y, T_loc, T_scale>::type
     lognormal_cdf_log(const T_y& y, const T_loc& mu, const T_scale& sigma) {
-      static const char* function("lognormal_cdf_log");
-      typedef typename stan::partials_return_type<T_y, T_loc, T_scale>::type
-        T_partials_return;
-
-      T_partials_return cdf_log = 0.0;
-
-      using boost::math::tools::promote_args;
-      using std::log;
-      using std::exp;
-
-      if (!(stan::length(y)
-            && stan::length(mu)
-            && stan::length(sigma)))
-        return cdf_log;
-
-      check_not_nan(function, "Random variable", y);
-      check_nonnegative(function, "Random variable", y);
-      check_finite(function, "Location parameter", mu);
-      check_positive_finite(function, "Scale parameter", sigma);
-
-      OperandsAndPartials<T_y, T_loc, T_scale>
-        operands_and_partials(y, mu, sigma);
-
-      VectorView<const T_y> y_vec(y);
-      VectorView<const T_loc> mu_vec(mu);
-      VectorView<const T_scale> sigma_vec(sigma);
-      size_t N = max_size(y, mu, sigma);
-
-      const double sqrt_pi = std::sqrt(pi());
-
-      for (size_t i = 0; i < stan::length(y); i++) {
-        if (value_of(y_vec[i]) == 0.0)
-          return operands_and_partials.value(negative_infinity());
-      }
-
-      const double log_half = std::log(0.5);
-
-      for (size_t n = 0; n < N; n++) {
-        const T_partials_return y_dbl = value_of(y_vec[n]);
-        const T_partials_return mu_dbl = value_of(mu_vec[n]);
-        const T_partials_return sigma_dbl = value_of(sigma_vec[n]);
-        const T_partials_return scaled_diff = (log(y_dbl) - mu_dbl)
-          / (sigma_dbl * SQRT_2);
-        const T_partials_return rep_deriv = SQRT_2 / sqrt_pi
-          * exp(-scaled_diff * scaled_diff) / sigma_dbl;
-
-        const T_partials_return erfc_calc = erfc(-scaled_diff);
-        cdf_log += log_half + log(erfc_calc);
-
-        if (!is_constant_struct<T_y>::value)
-          operands_and_partials.d_x1[n] += rep_deriv / erfc_calc / y_dbl;
-        if (!is_constant_struct<T_loc>::value)
-          operands_and_partials.d_x2[n] -= rep_deriv / erfc_calc;
-        if (!is_constant_struct<T_scale>::value)
-          operands_and_partials.d_x3[n] -= rep_deriv * scaled_diff * SQRT_2
-            / erfc_calc;
-      }
-      return operands_and_partials.value(cdf_log);
+      return lognormal_lcdf<T_y, T_loc, T_scale>(y, mu, sigma);
     }
 
   }

--- a/stan/math/prim/scal/prob/lognormal_lccdf.hpp
+++ b/stan/math/prim/scal/prob/lognormal_lccdf.hpp
@@ -1,0 +1,88 @@
+#ifndef STAN_MATH_PRIM_SCAL_PROB_LOGNORMAL_LCCDF_HPP
+#define STAN_MATH_PRIM_SCAL_PROB_LOGNORMAL_LCCDF_HPP
+
+#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
+#include <stan/math/prim/scal/meta/partials_return_type.hpp>
+#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
+#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
+#include <stan/math/prim/scal/err/check_finite.hpp>
+#include <stan/math/prim/scal/err/check_nonnegative.hpp>
+#include <stan/math/prim/scal/err/check_not_nan.hpp>
+#include <stan/math/prim/scal/err/check_positive_finite.hpp>
+#include <stan/math/prim/scal/fun/constants.hpp>
+#include <stan/math/prim/scal/fun/value_of.hpp>
+#include <stan/math/prim/scal/fun/square.hpp>
+#include <stan/math/prim/scal/meta/include_summand.hpp>
+#include <boost/random/lognormal_distribution.hpp>
+#include <boost/random/variate_generator.hpp>
+#include <cmath>
+
+namespace stan {
+  namespace math {
+
+    template <typename T_y, typename T_loc, typename T_scale>
+    typename return_type<T_y, T_loc, T_scale>::type
+    lognormal_lccdf(const T_y& y, const T_loc& mu, const T_scale& sigma) {
+      static const char* function("lognormal_lccdf");
+      typedef typename stan::partials_return_type<T_y, T_loc, T_scale>::type
+        T_partials_return;
+
+      T_partials_return ccdf_log = 0.0;
+
+      using boost::math::tools::promote_args;
+      using std::log;
+      using std::exp;
+
+      if (!(stan::length(y)
+            && stan::length(mu)
+            && stan::length(sigma)))
+        return ccdf_log;
+
+      check_not_nan(function, "Random variable", y);
+      check_nonnegative(function, "Random variable", y);
+      check_finite(function, "Location parameter", mu);
+      check_positive_finite(function, "Scale parameter", sigma);
+
+      OperandsAndPartials<T_y, T_loc, T_scale>
+        operands_and_partials(y, mu, sigma);
+
+      VectorView<const T_y> y_vec(y);
+      VectorView<const T_loc> mu_vec(mu);
+      VectorView<const T_scale> sigma_vec(sigma);
+      size_t N = max_size(y, mu, sigma);
+
+      const double sqrt_pi = std::sqrt(pi());
+
+      for (size_t i = 0; i < stan::length(y); i++) {
+        if (value_of(y_vec[i]) == 0.0)
+          return operands_and_partials.value(0.0);
+      }
+
+      const double log_half = std::log(0.5);
+
+      for (size_t n = 0; n < N; n++) {
+        const T_partials_return y_dbl = value_of(y_vec[n]);
+        const T_partials_return mu_dbl = value_of(mu_vec[n]);
+        const T_partials_return sigma_dbl = value_of(sigma_vec[n]);
+        const T_partials_return scaled_diff = (log(y_dbl) - mu_dbl)
+          / (sigma_dbl * SQRT_2);
+        const T_partials_return rep_deriv = SQRT_2 / sqrt_pi
+          * exp(-scaled_diff * scaled_diff) / sigma_dbl;
+
+        const T_partials_return erfc_calc = erfc(scaled_diff);
+        ccdf_log += log_half + log(erfc_calc);
+
+        if (!is_constant_struct<T_y>::value)
+          operands_and_partials.d_x1[n] -= rep_deriv / erfc_calc / y_dbl;
+        if (!is_constant_struct<T_loc>::value)
+          operands_and_partials.d_x2[n] += rep_deriv / erfc_calc;
+        if (!is_constant_struct<T_scale>::value)
+          operands_and_partials.d_x3[n] += rep_deriv * scaled_diff * SQRT_2
+            / erfc_calc;
+      }
+      return operands_and_partials.value(ccdf_log);
+    }
+
+  }
+}
+#endif

--- a/stan/math/prim/scal/prob/lognormal_lcdf.hpp
+++ b/stan/math/prim/scal/prob/lognormal_lcdf.hpp
@@ -1,0 +1,88 @@
+#ifndef STAN_MATH_PRIM_SCAL_PROB_LOGNORMAL_LCDF_HPP
+#define STAN_MATH_PRIM_SCAL_PROB_LOGNORMAL_LCDF_HPP
+
+#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
+#include <stan/math/prim/scal/meta/partials_return_type.hpp>
+#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
+#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
+#include <stan/math/prim/scal/err/check_finite.hpp>
+#include <stan/math/prim/scal/err/check_nonnegative.hpp>
+#include <stan/math/prim/scal/err/check_not_nan.hpp>
+#include <stan/math/prim/scal/err/check_positive_finite.hpp>
+#include <stan/math/prim/scal/fun/constants.hpp>
+#include <stan/math/prim/scal/fun/value_of.hpp>
+#include <stan/math/prim/scal/fun/square.hpp>
+#include <stan/math/prim/scal/meta/include_summand.hpp>
+#include <boost/random/lognormal_distribution.hpp>
+#include <boost/random/variate_generator.hpp>
+#include <cmath>
+
+namespace stan {
+  namespace math {
+
+    template <typename T_y, typename T_loc, typename T_scale>
+    typename return_type<T_y, T_loc, T_scale>::type
+    lognormal_lcdf(const T_y& y, const T_loc& mu, const T_scale& sigma) {
+      static const char* function("lognormal_lcdf");
+      typedef typename stan::partials_return_type<T_y, T_loc, T_scale>::type
+        T_partials_return;
+
+      T_partials_return cdf_log = 0.0;
+
+      using boost::math::tools::promote_args;
+      using std::log;
+      using std::exp;
+
+      if (!(stan::length(y)
+            && stan::length(mu)
+            && stan::length(sigma)))
+        return cdf_log;
+
+      check_not_nan(function, "Random variable", y);
+      check_nonnegative(function, "Random variable", y);
+      check_finite(function, "Location parameter", mu);
+      check_positive_finite(function, "Scale parameter", sigma);
+
+      OperandsAndPartials<T_y, T_loc, T_scale>
+        operands_and_partials(y, mu, sigma);
+
+      VectorView<const T_y> y_vec(y);
+      VectorView<const T_loc> mu_vec(mu);
+      VectorView<const T_scale> sigma_vec(sigma);
+      size_t N = max_size(y, mu, sigma);
+
+      const double sqrt_pi = std::sqrt(pi());
+
+      for (size_t i = 0; i < stan::length(y); i++) {
+        if (value_of(y_vec[i]) == 0.0)
+          return operands_and_partials.value(negative_infinity());
+      }
+
+      const double log_half = std::log(0.5);
+
+      for (size_t n = 0; n < N; n++) {
+        const T_partials_return y_dbl = value_of(y_vec[n]);
+        const T_partials_return mu_dbl = value_of(mu_vec[n]);
+        const T_partials_return sigma_dbl = value_of(sigma_vec[n]);
+        const T_partials_return scaled_diff = (log(y_dbl) - mu_dbl)
+          / (sigma_dbl * SQRT_2);
+        const T_partials_return rep_deriv = SQRT_2 / sqrt_pi
+          * exp(-scaled_diff * scaled_diff) / sigma_dbl;
+
+        const T_partials_return erfc_calc = erfc(-scaled_diff);
+        cdf_log += log_half + log(erfc_calc);
+
+        if (!is_constant_struct<T_y>::value)
+          operands_and_partials.d_x1[n] += rep_deriv / erfc_calc / y_dbl;
+        if (!is_constant_struct<T_loc>::value)
+          operands_and_partials.d_x2[n] -= rep_deriv / erfc_calc;
+        if (!is_constant_struct<T_scale>::value)
+          operands_and_partials.d_x3[n] -= rep_deriv * scaled_diff * SQRT_2
+            / erfc_calc;
+      }
+      return operands_and_partials.value(cdf_log);
+    }
+
+  }
+}
+#endif

--- a/stan/math/prim/scal/prob/lognormal_log.hpp
+++ b/stan/math/prim/scal/prob/lognormal_log.hpp
@@ -1,144 +1,29 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_LOGNORMAL_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_LOGNORMAL_LOG_HPP
 
-#include <boost/random/lognormal_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_finite.hpp>
-#include <stan/math/prim/scal/err/check_nonnegative.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/err/check_positive_finite.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/fun/square.hpp>
-#include <stan/math/prim/scal/meta/length.hpp>
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/contains_nonconstant_struct.hpp>
-#include <stan/math/prim/scal/meta/VectorView.hpp>
-#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/return_type.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <cmath>
+#include <stan/math/prim/scal/prob/lognormal_lpdf.hpp>
 
 namespace stan {
   namespace math {
 
-    // LogNormal(y|mu, sigma)  [y >= 0;  sigma > 0]
+    /**
+     * @deprecated use <code>lognormal_lpdf</code>
+     */
     template <bool propto,
               typename T_y, typename T_loc, typename T_scale>
     typename return_type<T_y, T_loc, T_scale>::type
     lognormal_log(const T_y& y, const T_loc& mu, const T_scale& sigma) {
-      static const char* function("lognormal_log");
-      typedef typename stan::partials_return_type<T_y, T_loc, T_scale>::type
-        T_partials_return;
-
-      using stan::is_constant_struct;
-
-      if (!(stan::length(y)
-            && stan::length(mu)
-            && stan::length(sigma)))
-        return 0.0;
-
-      T_partials_return logp(0.0);
-
-      check_not_nan(function, "Random variable", y);
-      check_nonnegative(function, "Random variable", y);
-      check_finite(function, "Location parameter", mu);
-      check_positive_finite(function, "Scale parameter", sigma);
-      check_consistent_sizes(function,
-                             "Random variable", y,
-                             "Location parameter", mu,
-                             "Scale parameter", sigma);
-
-      VectorView<const T_y> y_vec(y);
-      VectorView<const T_loc> mu_vec(mu);
-      VectorView<const T_scale> sigma_vec(sigma);
-      size_t N = max_size(y, mu, sigma);
-
-      for (size_t n = 0; n < length(y); n++)
-        if (value_of(y_vec[n]) <= 0)
-          return LOG_ZERO;
-
-      OperandsAndPartials<T_y, T_loc, T_scale>
-        operands_and_partials(y, mu, sigma);
-
-      using std::log;
-      using std::log;
-
-      VectorBuilder<include_summand<propto, T_scale>::value,
-                    T_partials_return, T_scale> log_sigma(length(sigma));
-      if (include_summand<propto, T_scale>::value) {
-        for (size_t n = 0; n < length(sigma); n++)
-          log_sigma[n] = log(value_of(sigma_vec[n]));
-      }
-
-      VectorBuilder<include_summand<propto, T_y, T_loc, T_scale>::value,
-                    T_partials_return, T_scale> inv_sigma(length(sigma));
-      VectorBuilder<include_summand<propto, T_y, T_loc, T_scale>::value,
-                    T_partials_return, T_scale> inv_sigma_sq(length(sigma));
-      if (include_summand<propto, T_y, T_loc, T_scale>::value) {
-        for (size_t n = 0; n < length(sigma); n++)
-          inv_sigma[n] = 1 / value_of(sigma_vec[n]);
-      }
-      if (include_summand<propto, T_y, T_loc, T_scale>::value) {
-        for (size_t n = 0; n < length(sigma); n++)
-          inv_sigma_sq[n] = inv_sigma[n] * inv_sigma[n];
-      }
-
-      VectorBuilder<include_summand<propto, T_y, T_loc, T_scale>::value,
-                    T_partials_return, T_y> log_y(length(y));
-      if (include_summand<propto, T_y, T_loc, T_scale>::value) {
-        for (size_t n = 0; n < length(y); n++)
-          log_y[n] = log(value_of(y_vec[n]));
-      }
-
-      VectorBuilder<!is_constant_struct<T_y>::value,
-                    T_partials_return, T_y> inv_y(length(y));
-      if (!is_constant_struct<T_y>::value) {
-        for (size_t n = 0; n < length(y); n++)
-          inv_y[n] = 1 / value_of(y_vec[n]);
-      }
-
-      if (include_summand<propto>::value)
-        logp += N * NEG_LOG_SQRT_TWO_PI;
-
-      for (size_t n = 0; n < N; n++) {
-        const T_partials_return mu_dbl = value_of(mu_vec[n]);
-
-        T_partials_return logy_m_mu(0);
-        if (include_summand<propto, T_y, T_loc, T_scale>::value)
-          logy_m_mu = log_y[n] - mu_dbl;
-
-        T_partials_return logy_m_mu_sq = logy_m_mu * logy_m_mu;
-        T_partials_return logy_m_mu_div_sigma(0);
-        if (contains_nonconstant_struct<T_y, T_loc, T_scale>::value)
-          logy_m_mu_div_sigma = logy_m_mu * inv_sigma_sq[n];
-
-        if (include_summand<propto, T_scale>::value)
-          logp -= log_sigma[n];
-        if (include_summand<propto, T_y>::value)
-          logp -= log_y[n];
-        if (include_summand<propto, T_y, T_loc, T_scale>::value)
-          logp -= 0.5 * logy_m_mu_sq * inv_sigma_sq[n];
-
-        if (!is_constant_struct<T_y>::value)
-          operands_and_partials.d_x1[n] -= (1 + logy_m_mu_div_sigma) * inv_y[n];
-        if (!is_constant_struct<T_loc>::value)
-          operands_and_partials.d_x2[n] += logy_m_mu_div_sigma;
-        if (!is_constant_struct<T_scale>::value)
-          operands_and_partials.d_x3[n]
-            += (logy_m_mu_div_sigma * logy_m_mu - 1) * inv_sigma[n];
-      }
-      return operands_and_partials.value(logp);
+      return lognormal_lpdf<propto, T_y, T_loc, T_scale>(y, mu, sigma);
     }
 
+    /**
+     * @deprecated use <code>lognormal_lpdf</code>
+     */
     template <typename T_y, typename T_loc, typename T_scale>
     inline
     typename return_type<T_y, T_loc, T_scale>::type
     lognormal_log(const T_y& y, const T_loc& mu, const T_scale& sigma) {
-      return lognormal_log<false>(y, mu, sigma);
+      return lognormal_lpdf<T_y, T_loc, T_scale>(y, mu, sigma);
     }
 
   }

--- a/stan/math/prim/scal/prob/lognormal_lpdf.hpp
+++ b/stan/math/prim/scal/prob/lognormal_lpdf.hpp
@@ -1,0 +1,146 @@
+#ifndef STAN_MATH_PRIM_SCAL_PROB_LOGNORMAL_LPDF_HPP
+#define STAN_MATH_PRIM_SCAL_PROB_LOGNORMAL_LPDF_HPP
+
+#include <boost/random/lognormal_distribution.hpp>
+#include <boost/random/variate_generator.hpp>
+#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
+#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
+#include <stan/math/prim/scal/err/check_finite.hpp>
+#include <stan/math/prim/scal/err/check_nonnegative.hpp>
+#include <stan/math/prim/scal/err/check_not_nan.hpp>
+#include <stan/math/prim/scal/err/check_positive_finite.hpp>
+#include <stan/math/prim/scal/fun/constants.hpp>
+#include <stan/math/prim/scal/fun/value_of.hpp>
+#include <stan/math/prim/scal/fun/square.hpp>
+#include <stan/math/prim/scal/meta/length.hpp>
+#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
+#include <stan/math/prim/scal/meta/contains_nonconstant_struct.hpp>
+#include <stan/math/prim/scal/meta/VectorView.hpp>
+#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
+#include <stan/math/prim/scal/meta/partials_return_type.hpp>
+#include <stan/math/prim/scal/meta/return_type.hpp>
+#include <stan/math/prim/scal/meta/include_summand.hpp>
+#include <cmath>
+
+namespace stan {
+  namespace math {
+
+    // LogNormal(y|mu, sigma)  [y >= 0;  sigma > 0]
+    template <bool propto,
+              typename T_y, typename T_loc, typename T_scale>
+    typename return_type<T_y, T_loc, T_scale>::type
+    lognormal_lpdf(const T_y& y, const T_loc& mu, const T_scale& sigma) {
+      static const char* function("lognormal_lpdf");
+      typedef typename stan::partials_return_type<T_y, T_loc, T_scale>::type
+        T_partials_return;
+
+      using stan::is_constant_struct;
+
+      if (!(stan::length(y)
+            && stan::length(mu)
+            && stan::length(sigma)))
+        return 0.0;
+
+      T_partials_return logp(0.0);
+
+      check_not_nan(function, "Random variable", y);
+      check_nonnegative(function, "Random variable", y);
+      check_finite(function, "Location parameter", mu);
+      check_positive_finite(function, "Scale parameter", sigma);
+      check_consistent_sizes(function,
+                             "Random variable", y,
+                             "Location parameter", mu,
+                             "Scale parameter", sigma);
+
+      VectorView<const T_y> y_vec(y);
+      VectorView<const T_loc> mu_vec(mu);
+      VectorView<const T_scale> sigma_vec(sigma);
+      size_t N = max_size(y, mu, sigma);
+
+      for (size_t n = 0; n < length(y); n++)
+        if (value_of(y_vec[n]) <= 0)
+          return LOG_ZERO;
+
+      OperandsAndPartials<T_y, T_loc, T_scale>
+        operands_and_partials(y, mu, sigma);
+
+      using std::log;
+      using std::log;
+
+      VectorBuilder<include_summand<propto, T_scale>::value,
+                    T_partials_return, T_scale> log_sigma(length(sigma));
+      if (include_summand<propto, T_scale>::value) {
+        for (size_t n = 0; n < length(sigma); n++)
+          log_sigma[n] = log(value_of(sigma_vec[n]));
+      }
+
+      VectorBuilder<include_summand<propto, T_y, T_loc, T_scale>::value,
+                    T_partials_return, T_scale> inv_sigma(length(sigma));
+      VectorBuilder<include_summand<propto, T_y, T_loc, T_scale>::value,
+                    T_partials_return, T_scale> inv_sigma_sq(length(sigma));
+      if (include_summand<propto, T_y, T_loc, T_scale>::value) {
+        for (size_t n = 0; n < length(sigma); n++)
+          inv_sigma[n] = 1 / value_of(sigma_vec[n]);
+      }
+      if (include_summand<propto, T_y, T_loc, T_scale>::value) {
+        for (size_t n = 0; n < length(sigma); n++)
+          inv_sigma_sq[n] = inv_sigma[n] * inv_sigma[n];
+      }
+
+      VectorBuilder<include_summand<propto, T_y, T_loc, T_scale>::value,
+                    T_partials_return, T_y> log_y(length(y));
+      if (include_summand<propto, T_y, T_loc, T_scale>::value) {
+        for (size_t n = 0; n < length(y); n++)
+          log_y[n] = log(value_of(y_vec[n]));
+      }
+
+      VectorBuilder<!is_constant_struct<T_y>::value,
+                    T_partials_return, T_y> inv_y(length(y));
+      if (!is_constant_struct<T_y>::value) {
+        for (size_t n = 0; n < length(y); n++)
+          inv_y[n] = 1 / value_of(y_vec[n]);
+      }
+
+      if (include_summand<propto>::value)
+        logp += N * NEG_LOG_SQRT_TWO_PI;
+
+      for (size_t n = 0; n < N; n++) {
+        const T_partials_return mu_dbl = value_of(mu_vec[n]);
+
+        T_partials_return logy_m_mu(0);
+        if (include_summand<propto, T_y, T_loc, T_scale>::value)
+          logy_m_mu = log_y[n] - mu_dbl;
+
+        T_partials_return logy_m_mu_sq = logy_m_mu * logy_m_mu;
+        T_partials_return logy_m_mu_div_sigma(0);
+        if (contains_nonconstant_struct<T_y, T_loc, T_scale>::value)
+          logy_m_mu_div_sigma = logy_m_mu * inv_sigma_sq[n];
+
+        if (include_summand<propto, T_scale>::value)
+          logp -= log_sigma[n];
+        if (include_summand<propto, T_y>::value)
+          logp -= log_y[n];
+        if (include_summand<propto, T_y, T_loc, T_scale>::value)
+          logp -= 0.5 * logy_m_mu_sq * inv_sigma_sq[n];
+
+        if (!is_constant_struct<T_y>::value)
+          operands_and_partials.d_x1[n] -= (1 + logy_m_mu_div_sigma) * inv_y[n];
+        if (!is_constant_struct<T_loc>::value)
+          operands_and_partials.d_x2[n] += logy_m_mu_div_sigma;
+        if (!is_constant_struct<T_scale>::value)
+          operands_and_partials.d_x3[n]
+            += (logy_m_mu_div_sigma * logy_m_mu - 1) * inv_sigma[n];
+      }
+      return operands_and_partials.value(logp);
+    }
+
+    template <typename T_y, typename T_loc, typename T_scale>
+    inline
+    typename return_type<T_y, T_loc, T_scale>::type
+    lognormal_lpdf(const T_y& y, const T_loc& mu, const T_scale& sigma) {
+      return lognormal_lpdf<false>(y, mu, sigma);
+    }
+
+  }
+}
+#endif

--- a/test/unit/math/prim/mat/prob/categorical_log_test.cpp
+++ b/test/unit/math/prim/mat/prob/categorical_log_test.cpp
@@ -1,0 +1,40 @@
+#include <stan/math/prim/mat.hpp>
+#include <gtest/gtest.h>
+
+TEST(ProbDistributionsCategorical, log_matches_lpmf) {
+  Eigen::Matrix<double, Eigen::Dynamic, 1> theta(3,1);
+  theta << 0.3, 0.5, 0.2;
+
+  EXPECT_FLOAT_EQ((stan::math::categorical_lpmf<true, double>(1, theta)),
+                  (stan::math::categorical_log<true, double>(1, theta)));
+  EXPECT_FLOAT_EQ((stan::math::categorical_lpmf<false, double>(1, theta)),
+                  (stan::math::categorical_log<false, double>(1, theta)));
+  EXPECT_FLOAT_EQ((stan::math::categorical_lpmf<double>(1, theta)),
+                  (stan::math::categorical_log<double>(1, theta)));
+  EXPECT_FLOAT_EQ((stan::math::categorical_lpmf(1, theta)),
+                  (stan::math::categorical_log(1, theta)));
+  EXPECT_FLOAT_EQ((stan::math::categorical_lpmf<true>(1, theta)),
+                  (stan::math::categorical_log<true>(1, theta)));
+  EXPECT_FLOAT_EQ((stan::math::categorical_lpmf<false>(1, theta)),
+                  (stan::math::categorical_log<false>(1, theta)));
+  
+
+  std::vector<int> ns(5);
+  ns[0] = 1;
+  ns[1] = 2;
+  ns[2] = 2;
+  ns[3] = 1;
+  ns[4] = 3;
+  EXPECT_FLOAT_EQ((stan::math::categorical_lpmf<true, double>(ns, theta)),
+                  (stan::math::categorical_log<true, double>(ns, theta)));
+  EXPECT_FLOAT_EQ((stan::math::categorical_lpmf<false, double>(ns, theta)),
+                  (stan::math::categorical_log<false, double>(ns, theta)));
+  EXPECT_FLOAT_EQ((stan::math::categorical_lpmf<double>(ns, theta)),
+                  (stan::math::categorical_log<double>(ns, theta)));
+  EXPECT_FLOAT_EQ((stan::math::categorical_lpmf(ns, theta)),
+                  (stan::math::categorical_log(ns, theta)));
+  EXPECT_FLOAT_EQ((stan::math::categorical_lpmf<true>(ns, theta)),
+                  (stan::math::categorical_log<true>(ns, theta)));
+  EXPECT_FLOAT_EQ((stan::math::categorical_lpmf<false>(ns, theta)),
+                  (stan::math::categorical_log<false>(ns, theta)));
+}

--- a/test/unit/math/prim/mat/prob/categorical_logit_log_test.cpp
+++ b/test/unit/math/prim/mat/prob/categorical_logit_log_test.cpp
@@ -1,0 +1,40 @@
+#include <stan/math/prim/mat.hpp>
+#include <gtest/gtest.h>
+
+TEST(ProbCategoricalLogit, log_matches_lpmf) {
+  Eigen::Matrix<double,Eigen::Dynamic,1> theta(3,1);
+  theta << -1, 2, -10;
+
+  EXPECT_FLOAT_EQ((stan::math::categorical_logit_lpmf<true, double>(1, theta)),
+                  (stan::math::categorical_logit_log<true, double>(1, theta)));
+  EXPECT_FLOAT_EQ((stan::math::categorical_logit_lpmf<false, double>(1, theta)),
+                  (stan::math::categorical_logit_log<false, double>(1, theta)));
+  EXPECT_FLOAT_EQ((stan::math::categorical_logit_lpmf<double>(1, theta)),
+                  (stan::math::categorical_logit_log<double>(1, theta)));
+  EXPECT_FLOAT_EQ((stan::math::categorical_logit_lpmf(1, theta)),
+                  (stan::math::categorical_logit_log(1, theta)));
+  EXPECT_FLOAT_EQ((stan::math::categorical_logit_lpmf<true>(1, theta)),
+                  (stan::math::categorical_logit_log<true>(1, theta)));
+  EXPECT_FLOAT_EQ((stan::math::categorical_logit_lpmf<false>(1, theta)),
+                  (stan::math::categorical_logit_log<false>(1, theta)));
+  
+  std::vector<int> ns(5);
+  ns[0] = 1;
+  ns[1] = 1;
+  ns[2] = 3;
+  ns[3] = 2;
+  ns[4] = 3;
+  
+  EXPECT_FLOAT_EQ((stan::math::categorical_logit_lpmf<true, double>(ns, theta)),
+                  (stan::math::categorical_logit_log<true, double>(ns, theta)));
+  EXPECT_FLOAT_EQ((stan::math::categorical_logit_lpmf<false, double>(ns, theta)),
+                  (stan::math::categorical_logit_log<false, double>(ns, theta)));
+  EXPECT_FLOAT_EQ((stan::math::categorical_logit_lpmf<double>(ns, theta)),
+                  (stan::math::categorical_logit_log<double>(ns, theta)));
+  EXPECT_FLOAT_EQ((stan::math::categorical_logit_lpmf(ns, theta)),
+                  (stan::math::categorical_logit_log(ns, theta)));
+  EXPECT_FLOAT_EQ((stan::math::categorical_logit_lpmf<true>(ns, theta)),
+                  (stan::math::categorical_logit_log<true>(ns, theta)));
+  EXPECT_FLOAT_EQ((stan::math::categorical_logit_lpmf<false>(ns, theta)),
+                  (stan::math::categorical_logit_log<false>(ns, theta)));
+}

--- a/test/unit/math/prim/mat/prob/dirichlet_log_test.cpp
+++ b/test/unit/math/prim/mat/prob/dirichlet_log_test.cpp
@@ -1,0 +1,21 @@
+#include <stan/math/prim/mat.hpp>
+#include <gtest/gtest.h>
+
+TEST(ProbDirichlet, log_matches_lpmf) {
+  Eigen::Matrix<double, Eigen::Dynamic, 1> theta(3,1);
+  theta << 0.2, 0.3, 0.5;
+  Eigen::Matrix<double, Eigen::Dynamic, 1> alpha(3,1);
+  alpha << 1.0, 1.0, 1.0;
+  EXPECT_FLOAT_EQ((stan::math::dirichlet_lpmf<true, double, double>(theta, alpha)),
+                  (stan::math::dirichlet_log<true, double, double>(theta,alpha)));
+  EXPECT_FLOAT_EQ((stan::math::dirichlet_lpmf<false, double, double>(theta, alpha)),
+                  (stan::math::dirichlet_log<false, double, double>(theta,alpha)));
+  EXPECT_FLOAT_EQ((stan::math::dirichlet_lpmf<double, double>(theta, alpha)),
+                  (stan::math::dirichlet_log<double, double>(theta,alpha)));
+  EXPECT_FLOAT_EQ((stan::math::dirichlet_lpmf(theta, alpha)),
+                  (stan::math::dirichlet_log(theta,alpha)));
+  EXPECT_FLOAT_EQ((stan::math::dirichlet_lpmf<true>(theta, alpha)),
+                  (stan::math::dirichlet_log<true>(theta,alpha)));
+  EXPECT_FLOAT_EQ((stan::math::dirichlet_lpmf<false>(theta, alpha)),
+                  (stan::math::dirichlet_log<false>(theta,alpha)));
+}

--- a/test/unit/math/prim/mat/prob/gaussian_dlm_obs_log_test.cpp
+++ b/test/unit/math/prim/mat/prob/gaussian_dlm_obs_log_test.cpp
@@ -1,0 +1,32 @@
+#include <stan/math/prim/mat.hpp>
+#include <gtest/gtest.h>
+
+TEST(ProbGaussianDlmObs, log_matches_lpmf) {
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> y(1, 10);
+  y << -0.286804393606091, 1.30654039013044, 0.184631538931975, 1.76116251447979, 1.64691178557684, 0.0599998209370169, -0.498099220647035, 1.77794756092381, -0.435458550812876, 1.17332931763075;
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> F(1, 1);
+  F << 0.585528817843856;
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> G(1, 1);
+  G << -0.109303314681054;
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> V(1, 1);
+  V << 2.25500747900521;
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> W(1, 1);
+  W << 0.461487989960454;
+  Eigen::Matrix<double, Eigen::Dynamic, 1> m0(1);
+  m0 << 11.5829455171551;
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> C0(1, 1);
+  C0 << 65.2373490156606;
+
+  EXPECT_FLOAT_EQ((stan::math::gaussian_dlm_obs_lpdf<true, double, double, double, double, double, double, double>(y, F, G, V, W, m0, C0)),
+                  (stan::math::gaussian_dlm_obs_log<true, double, double, double, double, double, double, double>(y, F, G, V, W, m0, C0)));
+  EXPECT_FLOAT_EQ((stan::math::gaussian_dlm_obs_lpdf<false, double, double, double, double, double, double, double>(y, F, G, V, W, m0, C0)),
+                  (stan::math::gaussian_dlm_obs_log<false, double, double, double, double, double, double, double>(y, F, G, V, W, m0, C0)));
+  EXPECT_FLOAT_EQ((stan::math::gaussian_dlm_obs_lpdf<double, double, double, double, double, double, double>(y, F, G, V, W, m0, C0)),
+                  (stan::math::gaussian_dlm_obs_log<double, double, double, double, double, double, double>(y, F, G, V, W, m0, C0)));
+  EXPECT_FLOAT_EQ((stan::math::gaussian_dlm_obs_lpdf(y, F, G, V, W, m0, C0)),
+                  (stan::math::gaussian_dlm_obs_log(y, F, G, V, W, m0, C0)));
+  EXPECT_FLOAT_EQ((stan::math::gaussian_dlm_obs_lpdf<true>(y, F, G, V, W, m0, C0)),
+                  (stan::math::gaussian_dlm_obs_log<true>(y, F, G, V, W, m0, C0)));
+  EXPECT_FLOAT_EQ((stan::math::gaussian_dlm_obs_lpdf<false>(y, F, G, V, W, m0, C0)),
+                  (stan::math::gaussian_dlm_obs_log<false>(y, F, G, V, W, m0, C0)));
+}

--- a/test/unit/math/prim/mat/prob/inv_wishart_log_test.cpp
+++ b/test/unit/math/prim/mat/prob/inv_wishart_log_test.cpp
@@ -1,0 +1,27 @@
+#include <stan/math/prim/mat.hpp>
+#include <gtest/gtest.h>
+
+TEST(ProbInvWishart, log_matches_lpmf) {
+  Eigen::MatrixXd Y(4,4);
+  Eigen::MatrixXd Sigma(4,4);
+  Y << 7.988168,  -10.955605, -14.47483,   4.395895,
+    -9.555605,  44.750570,  49.21577, -15.454186,
+    -14.474830,  49.215769,  60.08987, -20.481079,
+    4.395895, -18.454186, -21.48108, 7.885833;
+  Sigma << 2.9983662,  0.2898776, -2.650523,  0.1055911,
+    0.2898776, 11.4803610,  7.157993, -3.1129955,
+    -2.6505229,  7.1579931, 11.676181, -3.5866852,
+    0.1055911, -3.1129955, -3.586685,  1.4482736;
+  unsigned int dof = 5;
+  
+  EXPECT_FLOAT_EQ((stan::math::inv_wishart_lpdf(Y, dof, Sigma)),
+                  (stan::math::inv_wishart_log(Y, dof, Sigma)));
+  EXPECT_FLOAT_EQ((stan::math::inv_wishart_lpdf<true>(Y, dof, Sigma)),
+                  (stan::math::inv_wishart_log<true>(Y, dof, Sigma)));
+  EXPECT_FLOAT_EQ((stan::math::inv_wishart_lpdf<false>(Y, dof, Sigma)),
+                  (stan::math::inv_wishart_log<false>(Y, dof, Sigma)));
+  EXPECT_FLOAT_EQ((stan::math::inv_wishart_lpdf<true, double, double>(Y, dof, Sigma)),
+                  (stan::math::inv_wishart_log<true, double, double>(Y, dof, Sigma)));
+  EXPECT_FLOAT_EQ((stan::math::inv_wishart_lpdf<false, double, double>(Y, dof, Sigma)),
+                  (stan::math::inv_wishart_log<false, double, double>(Y, dof, Sigma)));
+}

--- a/test/unit/math/prim/mat/prob/lkj_corr_cholesky_log_test.cpp
+++ b/test/unit/math/prim/mat/prob/lkj_corr_cholesky_log_test.cpp
@@ -1,0 +1,20 @@
+#include <stan/math/prim/mat.hpp>
+#include <gtest/gtest.h>
+
+TEST(ProbLkjCorrCholesky, log_matches_lpmf) {
+  unsigned int K = 4;
+  Eigen::MatrixXd Sigma(K,K);
+  double eta = 1.2;
+  Sigma.setZero();
+  Sigma.diagonal().setOnes();
+  EXPECT_FLOAT_EQ((stan::math::lkj_corr_cholesky_lpdf(Sigma, eta)),
+                  (stan::math::lkj_corr_cholesky_log(Sigma, eta)));
+  EXPECT_FLOAT_EQ((stan::math::lkj_corr_cholesky_lpdf<true>(Sigma, eta)),
+                  (stan::math::lkj_corr_cholesky_log<true>(Sigma, eta)));
+  EXPECT_FLOAT_EQ((stan::math::lkj_corr_cholesky_lpdf<false>(Sigma, eta)),
+                  (stan::math::lkj_corr_cholesky_log<false>(Sigma, eta)));
+  EXPECT_FLOAT_EQ((stan::math::lkj_corr_cholesky_lpdf<true, double, double>(Sigma, eta)),
+                  (stan::math::lkj_corr_cholesky_log<true, double, double>(Sigma, eta)));
+  EXPECT_FLOAT_EQ((stan::math::lkj_corr_cholesky_lpdf<false, double, double>(Sigma, eta)),
+                  (stan::math::lkj_corr_cholesky_log<false, double, double>(Sigma, eta)));
+}

--- a/test/unit/math/prim/mat/prob/lkj_corr_log_test.cpp
+++ b/test/unit/math/prim/mat/prob/lkj_corr_log_test.cpp
@@ -1,0 +1,21 @@
+#include <stan/math/prim/mat.hpp>
+#include <gtest/gtest.h>
+
+TEST(ProbLkjCorr, log_matches_lpmf) {
+  unsigned int K = 4;
+  Eigen::MatrixXd Sigma(K,K);
+  Sigma.setZero();
+  Sigma.diagonal().setOnes();
+  double eta = 1.2;
+
+  EXPECT_FLOAT_EQ((stan::math::lkj_corr_lpdf(Sigma, eta)),
+                  (stan::math::lkj_corr_log(Sigma, eta)));
+  EXPECT_FLOAT_EQ((stan::math::lkj_corr_lpdf<true>(Sigma, eta)),
+                  (stan::math::lkj_corr_log<true>(Sigma, eta)));
+  EXPECT_FLOAT_EQ((stan::math::lkj_corr_lpdf<false>(Sigma, eta)),
+                  (stan::math::lkj_corr_log<false>(Sigma, eta)));
+  EXPECT_FLOAT_EQ((stan::math::lkj_corr_lpdf<true, double, double>(Sigma, eta)),
+                  (stan::math::lkj_corr_log<true, double, double>(Sigma, eta)));
+  EXPECT_FLOAT_EQ((stan::math::lkj_corr_lpdf<false, double, double>(Sigma, eta)),
+                  (stan::math::lkj_corr_log<false, double, double>(Sigma, eta)));
+}

--- a/test/unit/math/prim/mat/prob/lkj_cov_log_test.cpp
+++ b/test/unit/math/prim/mat/prob/lkj_cov_log_test.cpp
@@ -1,0 +1,25 @@
+#include <stan/math/prim/mat.hpp>
+#include <gtest/gtest.h>
+
+TEST(ProbLkjCov, log_matches_lpmf) {
+  unsigned int K = 4;
+  Eigen::MatrixXd y(K, K);
+  Eigen::VectorXd mu(K);
+  Eigen::VectorXd sigma(K);
+  y.setZero();
+  y.diagonal().setOnes();
+  mu << 0.1, 0.2, -1.2, 0.3;
+  sigma << 1, 0.2, 4, 0.5;
+  double eta = 1.2;
+  
+  EXPECT_FLOAT_EQ((stan::math::lkj_cov_lpdf(y, mu, sigma, eta)),
+                  (stan::math::lkj_cov_log(y, mu, sigma, eta)));
+  EXPECT_FLOAT_EQ((stan::math::lkj_cov_lpdf<true>(y, mu, sigma, eta)),
+                  (stan::math::lkj_cov_log<true>(y, mu, sigma, eta)));
+  EXPECT_FLOAT_EQ((stan::math::lkj_cov_lpdf<false>(y, mu, sigma, eta)),
+                  (stan::math::lkj_cov_log<false>(y, mu, sigma, eta)));
+  EXPECT_FLOAT_EQ((stan::math::lkj_cov_lpdf<true, double, double>(y, mu, sigma, eta)),
+                  (stan::math::lkj_cov_log<true, double, double>(y, mu, sigma, eta)));
+  EXPECT_FLOAT_EQ((stan::math::lkj_cov_lpdf<false, double, double>(y, mu, sigma, eta)),
+                  (stan::math::lkj_cov_log<false, double, double>(y, mu, sigma, eta)));
+}

--- a/test/unit/math/prim/mat/prob/matrix_normal_prec_log_test.cpp
+++ b/test/unit/math/prim/mat/prob/matrix_normal_prec_log_test.cpp
@@ -1,0 +1,38 @@
+#include <stan/math/prim/mat.hpp>
+#include <gtest/gtest.h>
+
+TEST(ProbMatrixNormalPrec, log_matches_lpmf) {
+  Eigen::Matrix<double,Eigen::Dynamic,Eigen::Dynamic> mu(3,5);
+  mu.setZero();
+  
+  Eigen::Matrix<double,Eigen::Dynamic,Eigen::Dynamic> y(3,5);
+  y << 2.0, -2.0, 11.0, 4.0, -2.0,
+       11.0, 2.0, -5.0, 11.0, 0.0,
+       -2.0, 11.0, 2.0, -2.0, -11.0;
+
+  Eigen::Matrix<double,Eigen::Dynamic,Eigen::Dynamic> Sigma(5,5);
+  Sigma << 9.0, -3.0, 0.0,  0.0, 0.0,
+          -3.0,  4.0, 0.0,  0.0, 0.0,
+           0.0,  0.0, 5.0,  1.0, 0.0,
+           0.0,  0.0, 1.0, 10.0, 0.0,
+           0.0,  0.0, 0.0,  0.0, 2.0;
+
+  Eigen::Matrix<double,Eigen::Dynamic,Eigen::Dynamic> D(3,3);
+  D << 1.0, 0.5, 0.1,
+       0.5, 1.0, 0.2,
+       0.1, 0.2, 1.0;
+  
+  EXPECT_FLOAT_EQ((stan::math::matrix_normal_prec_lpdf(y,mu,D,Sigma)),
+                  (stan::math::matrix_normal_prec_log(y,mu,D,Sigma)));
+  EXPECT_FLOAT_EQ((stan::math::matrix_normal_prec_lpdf<true>(y,mu,D,Sigma)),
+                  (stan::math::matrix_normal_prec_log<true>(y,mu,D,Sigma)));
+  EXPECT_FLOAT_EQ((stan::math::matrix_normal_prec_lpdf<false>(y,mu,D,Sigma)),
+                  (stan::math::matrix_normal_prec_log<false>(y,mu,D,Sigma)));
+  EXPECT_FLOAT_EQ((stan::math::matrix_normal_prec_lpdf<true, double, double, double>(y,mu,D,Sigma)),
+                  (stan::math::matrix_normal_prec_log<true, double, double, double>(y,mu,D,Sigma)));
+  EXPECT_FLOAT_EQ((stan::math::matrix_normal_prec_lpdf<false, double, double, double>(y,mu,D,Sigma)),
+                  (stan::math::matrix_normal_prec_log<false, double, double, double>(y,mu,D,Sigma)));
+  EXPECT_FLOAT_EQ((stan::math::matrix_normal_prec_lpdf<double, double, double>(y,mu,D,Sigma)),
+                  (stan::math::matrix_normal_prec_log<double, double, double>(y,mu,D,Sigma)));
+
+}

--- a/test/unit/math/prim/scal/prob/lognormal_ccdf_log_test.cpp
+++ b/test/unit/math/prim/scal/prob/lognormal_ccdf_log_test.cpp
@@ -1,0 +1,13 @@
+#include <stan/math/prim/scal.hpp>
+#include <gtest/gtest.h>
+
+TEST(ProbLognormal, ccdf_log_matches_lccdf) {
+  double y = 0.8;
+  double mu = 1.1;
+  double sigma = 2.3;
+
+  EXPECT_FLOAT_EQ((stan::math::lognormal_lccdf(y, mu, sigma)),
+                  (stan::math::lognormal_ccdf_log(y, mu, sigma)));
+  EXPECT_FLOAT_EQ((stan::math::lognormal_lccdf<double, double, double>(y, mu, sigma)),
+                  (stan::math::lognormal_ccdf_log<double, double, double>(y, mu, sigma)));
+}

--- a/test/unit/math/prim/scal/prob/lognormal_cdf_log_test.cpp
+++ b/test/unit/math/prim/scal/prob/lognormal_cdf_log_test.cpp
@@ -1,0 +1,13 @@
+#include <stan/math/prim/scal.hpp>
+#include <gtest/gtest.h>
+
+TEST(ProbLognormal, cdf_log_matches_lcdf) {
+  double y = 0.8;
+  double mu = 1.1;
+  double sigma = 2.3;
+
+  EXPECT_FLOAT_EQ((stan::math::lognormal_lcdf(y, mu, sigma)),
+                  (stan::math::lognormal_cdf_log(y, mu, sigma)));
+  EXPECT_FLOAT_EQ((stan::math::lognormal_lcdf<double, double, double>(y, mu, sigma)),
+                  (stan::math::lognormal_cdf_log<double, double, double>(y, mu, sigma)));
+}

--- a/test/unit/math/prim/scal/prob/lognormal_log_test.cpp
+++ b/test/unit/math/prim/scal/prob/lognormal_log_test.cpp
@@ -1,0 +1,21 @@
+#include <stan/math/prim/scal.hpp>
+#include <gtest/gtest.h>
+
+TEST(ProbLognormal, log_matches_lpdf) {
+  double y = 0.8;
+  double mu = 1.1;
+  double sigma = 2.3;
+
+  EXPECT_FLOAT_EQ((stan::math::lognormal_lpdf(y, mu, sigma)),
+                  (stan::math::lognormal_log(y, mu, sigma)));
+  EXPECT_FLOAT_EQ((stan::math::lognormal_lpdf<true>(y, mu, sigma)),
+                  (stan::math::lognormal_log<true>(y, mu, sigma)));
+  EXPECT_FLOAT_EQ((stan::math::lognormal_lpdf<false>(y, mu, sigma)),
+                  (stan::math::lognormal_log<false>(y, mu, sigma)));
+  EXPECT_FLOAT_EQ((stan::math::lognormal_lpdf<true, double, double, double>(y, mu, sigma)),
+                  (stan::math::lognormal_log<true, double, double, double>(y, mu, sigma)));
+  EXPECT_FLOAT_EQ((stan::math::lognormal_lpdf<false, double, double, double>(y, mu, sigma)),
+                  (stan::math::lognormal_log<false, double, double, double>(y, mu, sigma)));
+  EXPECT_FLOAT_EQ((stan::math::lognormal_lpdf<double, double, double>(y, mu, sigma)),
+                  (stan::math::lognormal_log<double, double, double>(y, mu, sigma)));
+}


### PR DESCRIPTION
#### Notes
This is 1 of 10 pull requests. I intentionally did not update `stan/math/mat.hpp` and `stan/math/prim.hpp`. Those files will be updated with the last pull request. The pull request will still work without those files updated.


#### Submisison Checklist

- [x] Run unit tests: `./runTests.py test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary:
- Adding `_ldf` / `_lpmf` functions. 
- Adding `_lcdf` and `_lccdf` functions. 
- Deprecating `_log` functions.
- Adding tests that verify `_log` functions match direct calls to underlying functions.

#### Intended Effect:
This will make Stan generator easier.

#### How to Verify:
By eye. The tests should pass.

#### Side Effects:
None.

#### Documentation:
Only added deprecation warnings. I tried to leave everything else alone so we can track through the changes.

#### Reviewer Suggestions: 
Anyone.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Columbia University.

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

