### PR TITLE
Updating probability functions. 7/10 pull requests.

### DIFF
--- a/stan/math/prim/scal.hpp
+++ b/stan/math/prim/scal.hpp
@@ -305,21 +305,32 @@
 #include <stan/math/prim/scal/prob/student_t_ccdf_log.hpp>
 #include <stan/math/prim/scal/prob/student_t_cdf.hpp>
 #include <stan/math/prim/scal/prob/student_t_cdf_log.hpp>
+#include <stan/math/prim/scal/prob/student_t_lccdf.hpp>
+#include <stan/math/prim/scal/prob/student_t_lcdf.hpp>
 #include <stan/math/prim/scal/prob/student_t_log.hpp>
+#include <stan/math/prim/scal/prob/student_t_lpdf.hpp>
 #include <stan/math/prim/scal/prob/student_t_rng.hpp>
 #include <stan/math/prim/scal/prob/uniform_ccdf_log.hpp>
 #include <stan/math/prim/scal/prob/uniform_cdf.hpp>
 #include <stan/math/prim/scal/prob/uniform_cdf_log.hpp>
+#include <stan/math/prim/scal/prob/uniform_lccdf.hpp>
+#include <stan/math/prim/scal/prob/uniform_lcdf.hpp>
 #include <stan/math/prim/scal/prob/uniform_log.hpp>
+#include <stan/math/prim/scal/prob/uniform_lpdf.hpp>
 #include <stan/math/prim/scal/prob/uniform_rng.hpp>
 #include <stan/math/prim/scal/prob/von_mises_log.hpp>
+#include <stan/math/prim/scal/prob/von_mises_lpdf.hpp>
 #include <stan/math/prim/scal/prob/von_mises_rng.hpp>
 #include <stan/math/prim/scal/prob/weibull_ccdf_log.hpp>
 #include <stan/math/prim/scal/prob/weibull_cdf.hpp>
 #include <stan/math/prim/scal/prob/weibull_cdf_log.hpp>
+#include <stan/math/prim/scal/prob/weibull_lccdf.hpp>
+#include <stan/math/prim/scal/prob/weibull_lcdf.hpp>
 #include <stan/math/prim/scal/prob/weibull_log.hpp>
+#include <stan/math/prim/scal/prob/weibull_lpdf.hpp>
 #include <stan/math/prim/scal/prob/weibull_rng.hpp>
 #include <stan/math/prim/scal/prob/wiener_log.hpp>
+#include <stan/math/prim/scal/prob/wiener_lpdf.hpp>
 
 #include <cmath>
 

--- a/stan/math/prim/scal/prob/student_t_lccdf.hpp
+++ b/stan/math/prim/scal/prob/student_t_lccdf.hpp
@@ -1,0 +1,190 @@
+#ifndef STAN_MATH_PRIM_SCAL_PROB_STUDENT_T_LCCDF_HPP
+#define STAN_MATH_PRIM_SCAL_PROB_STUDENT_T_LCCDF_HPP
+
+#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
+#include <stan/math/prim/scal/meta/partials_return_type.hpp>
+#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
+#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
+#include <stan/math/prim/scal/err/check_finite.hpp>
+#include <stan/math/prim/scal/err/check_not_nan.hpp>
+#include <stan/math/prim/scal/err/check_positive_finite.hpp>
+#include <stan/math/prim/scal/fun/constants.hpp>
+#include <stan/math/prim/scal/fun/square.hpp>
+#include <stan/math/prim/scal/fun/value_of.hpp>
+#include <stan/math/prim/scal/fun/lbeta.hpp>
+#include <stan/math/prim/scal/fun/lgamma.hpp>
+#include <stan/math/prim/scal/fun/digamma.hpp>
+#include <stan/math/prim/scal/meta/length.hpp>
+#include <stan/math/prim/scal/fun/grad_reg_inc_beta.hpp>
+#include <stan/math/prim/scal/fun/inc_beta.hpp>
+#include <stan/math/prim/scal/meta/include_summand.hpp>
+#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
+#include <boost/random/student_t_distribution.hpp>
+#include <boost/random/variate_generator.hpp>
+#include <limits>
+#include <cmath>
+
+namespace stan {
+  namespace math {
+
+    template <typename T_y, typename T_dof, typename T_loc, typename T_scale>
+    typename return_type<T_y, T_dof, T_loc, T_scale>::type
+    student_t_lccdf(const T_y& y, const T_dof& nu, const T_loc& mu,
+                       const T_scale& sigma) {
+      typedef
+        typename stan::partials_return_type<T_y, T_dof, T_loc, T_scale>::type
+        T_partials_return;
+
+      if (!(stan::length(y) && stan::length(nu) && stan::length(mu)
+            && stan::length(sigma)))
+        return 0.0;
+
+      static const char* function("student_t_lccdf");
+
+      using std::exp;
+
+      T_partials_return P(0.0);
+
+      check_not_nan(function, "Random variable", y);
+      check_positive_finite(function, "Degrees of freedom parameter", nu);
+      check_finite(function, "Location parameter", mu);
+      check_positive_finite(function, "Scale parameter", sigma);
+
+      VectorView<const T_y> y_vec(y);
+      VectorView<const T_dof> nu_vec(nu);
+      VectorView<const T_loc> mu_vec(mu);
+      VectorView<const T_scale> sigma_vec(sigma);
+      size_t N = max_size(y, nu, mu, sigma);
+
+      OperandsAndPartials<T_y, T_dof, T_loc, T_scale>
+        operands_and_partials(y, nu, mu, sigma);
+
+      // Explicit return for extreme values
+      // The gradients are technically ill-defined, but treated as zero
+      for (size_t i = 0; i < stan::length(y); i++) {
+        if (value_of(y_vec[i]) == -std::numeric_limits<double>::infinity())
+          return operands_and_partials.value(0.0);
+      }
+
+      using std::pow;
+      using std::exp;
+      using std::log;
+
+      T_partials_return digammaHalf = 0;
+
+      VectorBuilder<!is_constant_struct<T_dof>::value,
+                    T_partials_return, T_dof>
+        digamma_vec(stan::length(nu));
+      VectorBuilder<!is_constant_struct<T_dof>::value,
+                    T_partials_return, T_dof>
+        digammaNu_vec(stan::length(nu));
+      VectorBuilder<!is_constant_struct<T_dof>::value,
+                    T_partials_return, T_dof>
+        digammaNuPlusHalf_vec(stan::length(nu));
+
+      if (!is_constant_struct<T_dof>::value) {
+        digammaHalf = digamma(0.5);
+
+        for (size_t i = 0; i < stan::length(nu); i++) {
+          const T_partials_return nu_dbl = value_of(nu_vec[i]);
+
+          digammaNu_vec[i] = digamma(0.5 * nu_dbl);
+          digammaNuPlusHalf_vec[i] = digamma(0.5 + 0.5 * nu_dbl);
+        }
+      }
+
+      for (size_t n = 0; n < N; n++) {
+        // Explicit results for extreme values
+        // The gradients are technically ill-defined, but treated as zero
+        if (value_of(y_vec[n]) == std::numeric_limits<double>::infinity()) {
+          return operands_and_partials.value(negative_infinity());
+        }
+
+        const T_partials_return sigma_inv = 1.0 / value_of(sigma_vec[n]);
+        const T_partials_return t = (value_of(y_vec[n]) - value_of(mu_vec[n]))
+          * sigma_inv;
+        const T_partials_return nu_dbl = value_of(nu_vec[n]);
+        const T_partials_return q = nu_dbl / (t * t);
+        const T_partials_return r = 1.0 / (1.0 + q);
+        const T_partials_return J = 2 * r * r * q / t;
+        const T_partials_return betaNuHalf = exp(lbeta(0.5, 0.5 * nu_dbl));
+        T_partials_return zJacobian = t > 0 ? - 0.5 : 0.5;
+
+        if (q < 2) {
+          T_partials_return z = inc_beta(0.5 * nu_dbl, (T_partials_return)0.5,
+                                         1.0 - r);
+          const T_partials_return Pn = t > 0 ? 0.5 * z : 1.0 - 0.5 * z;
+          const T_partials_return d_ibeta = pow(r, -0.5)
+            * pow(1.0 - r, 0.5*nu_dbl - 1) / betaNuHalf;
+
+          P += log(Pn);
+
+          if (!is_constant_struct<T_y>::value)
+            operands_and_partials.d_x1[n]
+              += zJacobian * d_ibeta * J * sigma_inv / Pn;
+
+          if (!is_constant_struct<T_dof>::value) {
+            T_partials_return g1 = 0;
+            T_partials_return g2 = 0;
+
+            grad_reg_inc_beta(g1, g2, 0.5 * nu_dbl,
+                              (T_partials_return)0.5, 1.0 - r,
+                              digammaNu_vec[n], digammaHalf,
+                              digammaNuPlusHalf_vec[n],
+                              betaNuHalf);
+
+            operands_and_partials.d_x2[n]
+              -= zJacobian * (d_ibeta * (r / t) * (r / t) + 0.5 * g1) / Pn;
+          }
+
+          if (!is_constant_struct<T_loc>::value)
+            operands_and_partials.d_x3[n]
+              -= zJacobian * d_ibeta * J * sigma_inv / Pn;
+          if (!is_constant_struct<T_scale>::value)
+            operands_and_partials.d_x4[n]
+              -= zJacobian * d_ibeta * J * sigma_inv * t / Pn;
+
+        } else {
+          T_partials_return z = 1.0 - inc_beta((T_partials_return)0.5,
+                                               0.5*nu_dbl, r);
+          zJacobian *= -1;
+
+          const T_partials_return Pn = t > 0 ? 0.5 * z : 1.0 - 0.5 * z;
+
+          T_partials_return d_ibeta = pow(1.0-r, 0.5*nu_dbl-1) * pow(r, -0.5)
+            / betaNuHalf;
+
+          P += log(Pn);
+
+          if (!is_constant_struct<T_y>::value)
+            operands_and_partials.d_x1[n]
+              -= zJacobian * d_ibeta * J * sigma_inv / Pn;
+
+          if (!is_constant_struct<T_dof>::value) {
+            T_partials_return g1 = 0;
+            T_partials_return g2 = 0;
+
+            grad_reg_inc_beta(g1, g2, (T_partials_return)0.5,
+                              0.5 * nu_dbl, r,
+                              digammaHalf, digammaNu_vec[n],
+                              digammaNuPlusHalf_vec[n],
+                              betaNuHalf);
+
+            operands_and_partials.d_x2[n]
+              -= zJacobian * (- d_ibeta * (r / t) * (r / t) + 0.5 * g2) / Pn;
+          }
+
+          if (!is_constant_struct<T_loc>::value)
+            operands_and_partials.d_x3[n]
+              += zJacobian * d_ibeta * J * sigma_inv / Pn;
+          if (!is_constant_struct<T_scale>::value)
+            operands_and_partials.d_x4[n]
+              += zJacobian * d_ibeta * J * sigma_inv * t / Pn;
+        }
+      }
+      return operands_and_partials.value(P);
+    }
+
+  }
+}
+#endif

--- a/stan/math/prim/scal/prob/student_t_lcdf.hpp
+++ b/stan/math/prim/scal/prob/student_t_lcdf.hpp
@@ -1,0 +1,190 @@
+#ifndef STAN_MATH_PRIM_SCAL_PROB_STUDENT_T_LCDF_HPP
+#define STAN_MATH_PRIM_SCAL_PROB_STUDENT_T_LCDF_HPP
+
+#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
+#include <stan/math/prim/scal/meta/partials_return_type.hpp>
+#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
+#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
+#include <stan/math/prim/scal/err/check_finite.hpp>
+#include <stan/math/prim/scal/err/check_not_nan.hpp>
+#include <stan/math/prim/scal/err/check_positive_finite.hpp>
+#include <stan/math/prim/scal/fun/constants.hpp>
+#include <stan/math/prim/scal/fun/square.hpp>
+#include <stan/math/prim/scal/fun/value_of.hpp>
+#include <stan/math/prim/scal/fun/lbeta.hpp>
+#include <stan/math/prim/scal/fun/lgamma.hpp>
+#include <stan/math/prim/scal/fun/digamma.hpp>
+#include <stan/math/prim/scal/meta/length.hpp>
+#include <stan/math/prim/scal/fun/grad_reg_inc_beta.hpp>
+#include <stan/math/prim/scal/fun/inc_beta.hpp>
+#include <stan/math/prim/scal/meta/include_summand.hpp>
+#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
+#include <boost/random/student_t_distribution.hpp>
+#include <boost/random/variate_generator.hpp>
+#include <limits>
+#include <cmath>
+
+namespace stan {
+  namespace math {
+
+    template <typename T_y, typename T_dof, typename T_loc, typename T_scale>
+    typename return_type<T_y, T_dof, T_loc, T_scale>::type
+    student_t_lcdf(const T_y& y, const T_dof& nu, const T_loc& mu,
+                      const T_scale& sigma) {
+      typedef typename
+        stan::partials_return_type<T_y, T_dof, T_loc, T_scale>::type
+        T_partials_return;
+
+      if (!(stan::length(y) && stan::length(nu) && stan::length(mu)
+            && stan::length(sigma)))
+        return 0.0;
+
+      static const char* function("student_t_lcdf");
+
+      using std::exp;
+
+      T_partials_return P(0.0);
+
+      check_not_nan(function, "Random variable", y);
+      check_positive_finite(function, "Degrees of freedom parameter", nu);
+      check_finite(function, "Location parameter", mu);
+      check_positive_finite(function, "Scale parameter", sigma);
+
+      VectorView<const T_y> y_vec(y);
+      VectorView<const T_dof> nu_vec(nu);
+      VectorView<const T_loc> mu_vec(mu);
+      VectorView<const T_scale> sigma_vec(sigma);
+      size_t N = max_size(y, nu, mu, sigma);
+
+      OperandsAndPartials<T_y, T_dof, T_loc, T_scale>
+        operands_and_partials(y, nu, mu, sigma);
+
+      // Explicit return for extreme values
+      // The gradients are technically ill-defined, but treated as zero
+      for (size_t i = 0; i < stan::length(y); i++) {
+        if (value_of(y_vec[i]) == -std::numeric_limits<double>::infinity())
+          return operands_and_partials.value(negative_infinity());
+      }
+
+      using std::pow;
+      using std::exp;
+      using std::log;
+
+      T_partials_return digammaHalf = 0;
+
+      VectorBuilder<!is_constant_struct<T_dof>::value,
+                    T_partials_return, T_dof>
+        digamma_vec(stan::length(nu));
+      VectorBuilder<!is_constant_struct<T_dof>::value,
+                    T_partials_return, T_dof>
+        digammaNu_vec(stan::length(nu));
+      VectorBuilder<!is_constant_struct<T_dof>::value,
+                    T_partials_return, T_dof>
+        digammaNuPlusHalf_vec(stan::length(nu));
+
+      if (!is_constant_struct<T_dof>::value) {
+        digammaHalf = digamma(0.5);
+
+        for (size_t i = 0; i < stan::length(nu); i++) {
+          const T_partials_return nu_dbl = value_of(nu_vec[i]);
+
+          digammaNu_vec[i] = digamma(0.5 * nu_dbl);
+          digammaNuPlusHalf_vec[i] = digamma(0.5 + 0.5 * nu_dbl);
+        }
+      }
+
+      for (size_t n = 0; n < N; n++) {
+        // Explicit results for extreme values
+        // The gradients are technically ill-defined, but treated as zero
+        if (value_of(y_vec[n]) == std::numeric_limits<double>::infinity()) {
+          continue;
+        }
+
+        const T_partials_return sigma_inv = 1.0 / value_of(sigma_vec[n]);
+        const T_partials_return t = (value_of(y_vec[n]) - value_of(mu_vec[n]))
+          * sigma_inv;
+        const T_partials_return nu_dbl = value_of(nu_vec[n]);
+        const T_partials_return q = nu_dbl / (t * t);
+        const T_partials_return r = 1.0 / (1.0 + q);
+        const T_partials_return J = 2 * r * r * q / t;
+        const T_partials_return betaNuHalf = exp(lbeta(0.5, 0.5 * nu_dbl));
+        T_partials_return zJacobian = t > 0 ? - 0.5 : 0.5;
+
+        if (q < 2) {
+          T_partials_return z
+            = inc_beta(0.5 * nu_dbl, (T_partials_return)0.5, 1.0 - r);
+          const T_partials_return Pn = t > 0 ? 1.0 - 0.5 * z : 0.5 * z;
+          const T_partials_return d_ibeta = pow(r, -0.5)
+            * pow(1.0 - r, 0.5*nu_dbl - 1) / betaNuHalf;
+
+          P += log(Pn);
+
+          if (!is_constant_struct<T_y>::value)
+            operands_and_partials.d_x1[n]
+              += - zJacobian * d_ibeta * J * sigma_inv / Pn;
+
+          if (!is_constant_struct<T_dof>::value) {
+            T_partials_return g1 = 0;
+            T_partials_return g2 = 0;
+
+            grad_reg_inc_beta(g1, g2, 0.5 * nu_dbl,
+                              (T_partials_return)0.5, 1.0 - r,
+                              digammaNu_vec[n], digammaHalf,
+                              digammaNuPlusHalf_vec[n],
+                              betaNuHalf);
+
+            operands_and_partials.d_x2[n]
+              += zJacobian * (d_ibeta * (r / t) * (r / t) + 0.5 * g1) / Pn;
+          }
+
+          if (!is_constant_struct<T_loc>::value)
+            operands_and_partials.d_x3[n]
+              += zJacobian * d_ibeta * J * sigma_inv / Pn;
+          if (!is_constant_struct<T_scale>::value)
+            operands_and_partials.d_x4[n]
+              += zJacobian * d_ibeta * J * sigma_inv * t / Pn;
+
+        } else {
+          T_partials_return z = 1.0 - inc_beta((T_partials_return)0.5,
+                                               0.5*nu_dbl, r);
+          zJacobian *= -1;
+
+          const T_partials_return Pn = t > 0 ? 1.0 - 0.5 * z : 0.5 * z;
+
+          T_partials_return d_ibeta = pow(1.0-r, 0.5*nu_dbl-1) * pow(r, -0.5)
+            / betaNuHalf;
+
+          P += log(Pn);
+
+          if (!is_constant_struct<T_y>::value)
+            operands_and_partials.d_x1[n]
+              += zJacobian * d_ibeta * J * sigma_inv / Pn;
+
+          if (!is_constant_struct<T_dof>::value) {
+            T_partials_return g1 = 0;
+            T_partials_return g2 = 0;
+
+            grad_reg_inc_beta(g1, g2, (T_partials_return)0.5,
+                              0.5 * nu_dbl, r,
+                              digammaHalf, digammaNu_vec[n],
+                              digammaNuPlusHalf_vec[n],
+                              betaNuHalf);
+
+            operands_and_partials.d_x2[n]
+              += zJacobian * (- d_ibeta * (r / t) * (r / t) + 0.5 * g2) / Pn;
+          }
+
+          if (!is_constant_struct<T_loc>::value)
+            operands_and_partials.d_x3[n]
+              += - zJacobian * d_ibeta * J * sigma_inv / Pn;
+          if (!is_constant_struct<T_scale>::value)
+            operands_and_partials.d_x4[n]
+              += - zJacobian * d_ibeta * J * sigma_inv * t / Pn;
+        }
+      }
+      return operands_and_partials.value(P);
+    }
+
+  }
+}
+#endif

--- a/stan/math/prim/scal/prob/student_t_lpdf.hpp
+++ b/stan/math/prim/scal/prob/student_t_lpdf.hpp
@@ -1,0 +1,216 @@
+#ifndef STAN_MATH_PRIM_SCAL_PROB_STUDENT_T_LPDF_HPP
+#define STAN_MATH_PRIM_SCAL_PROB_STUDENT_T_LPDF_HPP
+
+#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
+#include <stan/math/prim/scal/meta/partials_return_type.hpp>
+#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
+#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
+#include <stan/math/prim/scal/err/check_finite.hpp>
+#include <stan/math/prim/scal/err/check_not_nan.hpp>
+#include <stan/math/prim/scal/err/check_positive_finite.hpp>
+#include <stan/math/prim/scal/fun/constants.hpp>
+#include <stan/math/prim/scal/fun/square.hpp>
+#include <stan/math/prim/scal/fun/value_of.hpp>
+#include <stan/math/prim/scal/fun/lbeta.hpp>
+#include <stan/math/prim/scal/fun/lgamma.hpp>
+#include <stan/math/prim/scal/fun/digamma.hpp>
+#include <stan/math/prim/scal/meta/length.hpp>
+#include <stan/math/prim/scal/fun/grad_reg_inc_beta.hpp>
+#include <stan/math/prim/scal/fun/inc_beta.hpp>
+#include <stan/math/prim/scal/meta/include_summand.hpp>
+#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
+#include <boost/random/student_t_distribution.hpp>
+#include <boost/random/variate_generator.hpp>
+#include <cmath>
+
+namespace stan {
+  namespace math {
+
+    /**
+     * The log of the Student-t density for the given y, nu, mean, and
+     * scale parameter.  The scale parameter must be greater
+     * than 0.
+     *
+     * \f{eqnarray*}{
+     y &\sim& t_{\nu} (\mu, \sigma^2) \\
+     \log (p (y \, |\, \nu, \mu, \sigma) ) &=& \log \left( \frac{\Gamma((\nu + 1) /2)}
+     {\Gamma(\nu/2)\sqrt{\nu \pi} \sigma} \left( 1 + \frac{1}{\nu} (\frac{y - \mu}{\sigma})^2 \right)^{-(\nu + 1)/2} \right) \\
+     &=& \log( \Gamma( (\nu+1)/2 )) - \log (\Gamma (\nu/2) - \frac{1}{2} \log(\nu \pi) - \log(\sigma)
+     -\frac{\nu + 1}{2} \log (1 + \frac{1}{\nu} (\frac{y - \mu}{\sigma})^2)
+     \f}
+     *
+     * @param y A scalar variable.
+     * @param nu Degrees of freedom.
+     * @param mu The mean of the Student-t distribution.
+     * @param sigma The scale parameter of the Student-t distribution.
+     * @return The log of the Student-t density at y.
+     * @throw std::domain_error if sigma is not greater than 0.
+     * @throw std::domain_error if nu is not greater than 0.
+     * @tparam T_y Type of scalar.
+     * @tparam T_dof Type of degrees of freedom.
+     * @tparam T_loc Type of location.
+     * @tparam T_scale Type of scale.
+     */
+    template <bool propto, typename T_y, typename T_dof,
+              typename T_loc, typename T_scale>
+    typename return_type<T_y, T_dof, T_loc, T_scale>::type
+    student_t_lpdf(const T_y& y, const T_dof& nu, const T_loc& mu,
+                  const T_scale& sigma) {
+      static const char* function("student_t_lpdf");
+      typedef typename stan::partials_return_type<T_y, T_dof, T_loc,
+                                                  T_scale>::type
+        T_partials_return;
+
+      if (!(stan::length(y)
+            && stan::length(nu)
+            && stan::length(mu)
+            && stan::length(sigma)))
+        return 0.0;
+
+      T_partials_return logp(0.0);
+
+      check_not_nan(function, "Random variable", y);
+      check_positive_finite(function, "Degrees of freedom parameter", nu);
+      check_finite(function, "Location parameter", mu);
+      check_positive_finite(function, "Scale parameter", sigma);
+      check_consistent_sizes(function,
+                             "Random variable", y,
+                             "Degrees of freedom parameter", nu,
+                             "Location parameter", mu,
+                             "Scale parameter", sigma);
+
+      if (!include_summand<propto, T_y, T_dof, T_loc, T_scale>::value)
+        return 0.0;
+
+      VectorView<const T_y> y_vec(y);
+      VectorView<const T_dof> nu_vec(nu);
+      VectorView<const T_loc> mu_vec(mu);
+      VectorView<const T_scale> sigma_vec(sigma);
+      size_t N = max_size(y, nu, mu, sigma);
+
+      using std::log;
+      using std::log;
+
+      VectorBuilder<include_summand<propto, T_y, T_dof, T_loc, T_scale>::value,
+                    T_partials_return, T_dof> half_nu(length(nu));
+      for (size_t i = 0; i < length(nu); i++)
+        if (include_summand<propto, T_y, T_dof, T_loc, T_scale>::value)
+          half_nu[i] = 0.5 * value_of(nu_vec[i]);
+
+      VectorBuilder<include_summand<propto, T_dof>::value,
+                    T_partials_return, T_dof> lgamma_half_nu(length(nu));
+      VectorBuilder<include_summand<propto, T_dof>::value,
+                    T_partials_return, T_dof>
+        lgamma_half_nu_plus_half(length(nu));
+      if (include_summand<propto, T_dof>::value) {
+        for (size_t i = 0; i < length(nu); i++) {
+          lgamma_half_nu[i] = lgamma(half_nu[i]);
+          lgamma_half_nu_plus_half[i] = lgamma(half_nu[i] + 0.5);
+        }
+      }
+
+      VectorBuilder<!is_constant_struct<T_dof>::value,
+                    T_partials_return, T_dof> digamma_half_nu(length(nu));
+      VectorBuilder<!is_constant_struct<T_dof>::value,
+                    T_partials_return, T_dof>
+        digamma_half_nu_plus_half(length(nu));
+      if (!is_constant_struct<T_dof>::value) {
+        for (size_t i = 0; i < length(nu); i++) {
+          digamma_half_nu[i] = digamma(half_nu[i]);
+          digamma_half_nu_plus_half[i] = digamma(half_nu[i] + 0.5);
+        }
+      }
+
+      VectorBuilder<include_summand<propto, T_dof>::value,
+                    T_partials_return, T_dof> log_nu(length(nu));
+      for (size_t i = 0; i < length(nu); i++)
+        if (include_summand<propto, T_dof>::value)
+          log_nu[i] = log(value_of(nu_vec[i]));
+
+      VectorBuilder<include_summand<propto, T_scale>::value,
+                    T_partials_return, T_scale> log_sigma(length(sigma));
+      for (size_t i = 0; i < length(sigma); i++)
+        if (include_summand<propto, T_scale>::value)
+          log_sigma[i] = log(value_of(sigma_vec[i]));
+
+      VectorBuilder<include_summand<propto, T_y, T_dof, T_loc, T_scale>::value,
+                    T_partials_return, T_y, T_dof, T_loc, T_scale>
+        square_y_minus_mu_over_sigma__over_nu(N);
+
+      VectorBuilder<include_summand<propto, T_y, T_dof, T_loc, T_scale>::value,
+                    T_partials_return, T_y, T_dof, T_loc, T_scale>
+        log1p_exp(N);
+
+      for (size_t i = 0; i < N; i++)
+        if (include_summand<propto, T_y, T_dof, T_loc, T_scale>::value) {
+          const T_partials_return y_dbl = value_of(y_vec[i]);
+          const T_partials_return mu_dbl = value_of(mu_vec[i]);
+          const T_partials_return sigma_dbl = value_of(sigma_vec[i]);
+          const T_partials_return nu_dbl = value_of(nu_vec[i]);
+          square_y_minus_mu_over_sigma__over_nu[i]
+            = square((y_dbl - mu_dbl) / sigma_dbl) / nu_dbl;
+          log1p_exp[i] = log1p(square_y_minus_mu_over_sigma__over_nu[i]);
+        }
+
+      OperandsAndPartials<T_y, T_dof, T_loc, T_scale>
+        operands_and_partials(y, nu, mu, sigma);
+      for (size_t n = 0; n < N; n++) {
+        const T_partials_return y_dbl = value_of(y_vec[n]);
+        const T_partials_return mu_dbl = value_of(mu_vec[n]);
+        const T_partials_return sigma_dbl = value_of(sigma_vec[n]);
+        const T_partials_return nu_dbl = value_of(nu_vec[n]);
+        if (include_summand<propto>::value)
+          logp += NEG_LOG_SQRT_PI;
+        if (include_summand<propto, T_dof>::value)
+          logp += lgamma_half_nu_plus_half[n] - lgamma_half_nu[n]
+            -  0.5 * log_nu[n];
+        if (include_summand<propto, T_scale>::value)
+          logp -= log_sigma[n];
+        if (include_summand<propto, T_y, T_dof, T_loc, T_scale>::value)
+          logp -= (half_nu[n] + 0.5)
+            * log1p_exp[n];
+
+        if (!is_constant_struct<T_y>::value) {
+          operands_and_partials.d_x1[n]
+            += -(half_nu[n]+0.5)
+            * 1.0 / (1.0 + square_y_minus_mu_over_sigma__over_nu[n])
+            * (2.0 * (y_dbl - mu_dbl) / square(sigma_dbl) / nu_dbl);
+        }
+        if (!is_constant_struct<T_dof>::value) {
+          const T_partials_return inv_nu = 1.0 / nu_dbl;
+          operands_and_partials.d_x2[n]
+            += 0.5*digamma_half_nu_plus_half[n] - 0.5*digamma_half_nu[n]
+            - 0.5 * inv_nu
+            - 0.5*log1p_exp[n]
+            + (half_nu[n] + 0.5)
+            * (1.0/(1.0 + square_y_minus_mu_over_sigma__over_nu[n])
+               * square_y_minus_mu_over_sigma__over_nu[n] * inv_nu);
+        }
+        if (!is_constant_struct<T_loc>::value) {
+          operands_and_partials.d_x3[n]
+            -= (half_nu[n] + 0.5)
+            / (1.0 + square_y_minus_mu_over_sigma__over_nu[n])
+            * (2.0 * (mu_dbl - y_dbl) / (sigma_dbl*sigma_dbl*nu_dbl));
+        }
+        if (!is_constant_struct<T_scale>::value) {
+          const T_partials_return inv_sigma = 1.0 / sigma_dbl;
+          operands_and_partials.d_x4[n]
+            += -inv_sigma
+            + (nu_dbl + 1.0) / (1.0 + square_y_minus_mu_over_sigma__over_nu[n])
+            * (square_y_minus_mu_over_sigma__over_nu[n] * inv_sigma);
+        }
+      }
+      return operands_and_partials.value(logp);
+    }
+
+    template <typename T_y, typename T_dof, typename T_loc, typename T_scale>
+    inline
+    typename return_type<T_y, T_dof, T_loc, T_scale>::type
+    student_t_lpdf(const T_y& y, const T_dof& nu, const T_loc& mu,
+                  const T_scale& sigma) {
+      return student_t_lpdf<false>(y, nu, mu, sigma);
+    }
+
+  }
+}
+#endif

--- a/stan/math/prim/scal/prob/uniform_lccdf.hpp
+++ b/stan/math/prim/scal/prob/uniform_lccdf.hpp
@@ -1,0 +1,85 @@
+#ifndef STAN_MATH_PRIM_SCAL_PROB_UNIFORM_LCCDF_HPP
+#define STAN_MATH_PRIM_SCAL_PROB_UNIFORM_LCCDF_HPP
+
+#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
+#include <stan/math/prim/scal/meta/partials_return_type.hpp>
+#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
+#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
+#include <stan/math/prim/scal/err/check_finite.hpp>
+#include <stan/math/prim/scal/err/check_greater.hpp>
+#include <stan/math/prim/scal/err/check_not_nan.hpp>
+#include <stan/math/prim/scal/fun/constants.hpp>
+#include <stan/math/prim/scal/fun/value_of.hpp>
+#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
+#include <stan/math/prim/scal/meta/include_summand.hpp>
+#include <boost/random/uniform_real_distribution.hpp>
+#include <boost/random/variate_generator.hpp>
+#include <cmath>
+
+namespace stan {
+  namespace math {
+
+    template <typename T_y, typename T_low, typename T_high>
+    typename return_type<T_y, T_low, T_high>::type
+    uniform_lccdf(const T_y& y, const T_low& alpha, const T_high& beta) {
+      static const char* function("uniform_lccdf");
+      typedef typename stan::partials_return_type<T_y, T_low, T_high>::type
+        T_partials_return;
+
+      using std::log;
+
+      if (!(stan::length(y)
+            && stan::length(alpha)
+            && stan::length(beta)))
+        return 0.0;
+
+      T_partials_return ccdf_log(0.0);
+      check_not_nan(function, "Random variable", y);
+      check_finite(function, "Lower bound parameter", alpha);
+      check_finite(function, "Upper bound parameter", beta);
+      check_greater(function, "Upper bound parameter", beta, alpha);
+      check_consistent_sizes(function,
+                             "Random variable", y,
+                             "Lower bound parameter", alpha,
+                             "Upper bound parameter", beta);
+
+      VectorView<const T_y> y_vec(y);
+      VectorView<const T_low> alpha_vec(alpha);
+      VectorView<const T_high> beta_vec(beta);
+      size_t N = max_size(y, alpha, beta);
+
+      for (size_t n = 0; n < N; n++) {
+        const T_partials_return y_dbl = value_of(y_vec[n]);
+        if (y_dbl < value_of(alpha_vec[n])
+            || y_dbl > value_of(beta_vec[n]))
+          return 0.0;
+        if (y_dbl == value_of(beta_vec[n]))
+          return LOG_ZERO;
+      }
+
+      OperandsAndPartials<T_y, T_low, T_high>
+        operands_and_partials(y, alpha, beta);
+      for (size_t n = 0; n < N; n++) {
+        const T_partials_return y_dbl = value_of(y_vec[n]);
+        const T_partials_return alpha_dbl = value_of(alpha_vec[n]);
+        const T_partials_return beta_dbl = value_of(beta_vec[n]);
+        const T_partials_return b_min_a = beta_dbl - alpha_dbl;
+        const T_partials_return ccdf_log_ = 1.0 - (y_dbl - alpha_dbl) / b_min_a;
+
+        ccdf_log += log(ccdf_log_);
+
+        if (!is_constant_struct<T_y>::value)
+          operands_and_partials.d_x1[n] -= 1.0 / b_min_a / ccdf_log_;
+        if (!is_constant_struct<T_low>::value)
+          operands_and_partials.d_x2[n] -= (y_dbl - beta_dbl) / b_min_a
+            / b_min_a / ccdf_log_;
+        if (!is_constant_struct<T_high>::value)
+          operands_and_partials.d_x3[n] += (y_dbl - alpha_dbl) / b_min_a
+            / b_min_a / ccdf_log_;
+      }
+      return operands_and_partials.value(ccdf_log);
+    }
+
+  }
+}
+#endif

--- a/stan/math/prim/scal/prob/uniform_lcdf.hpp
+++ b/stan/math/prim/scal/prob/uniform_lcdf.hpp
@@ -1,0 +1,85 @@
+#ifndef STAN_MATH_PRIM_SCAL_PROB_UNIFORM_LCDF_HPP
+#define STAN_MATH_PRIM_SCAL_PROB_UNIFORM_LCDF_HPP
+
+#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
+#include <stan/math/prim/scal/meta/partials_return_type.hpp>
+#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
+#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
+#include <stan/math/prim/scal/err/check_finite.hpp>
+#include <stan/math/prim/scal/err/check_greater.hpp>
+#include <stan/math/prim/scal/err/check_not_nan.hpp>
+#include <stan/math/prim/scal/fun/constants.hpp>
+#include <stan/math/prim/scal/fun/value_of.hpp>
+#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
+#include <stan/math/prim/scal/meta/include_summand.hpp>
+#include <boost/random/uniform_real_distribution.hpp>
+#include <boost/random/variate_generator.hpp>
+#include <cmath>
+
+namespace stan {
+  namespace math {
+
+    template <typename T_y, typename T_low, typename T_high>
+    typename return_type<T_y, T_low, T_high>::type
+    uniform_lcdf(const T_y& y, const T_low& alpha, const T_high& beta) {
+      static const char* function("uniform_lcdf");
+      typedef typename stan::partials_return_type<T_y, T_low, T_high>::type
+        T_partials_return;
+
+      using std::log;
+
+      if (!(stan::length(y)
+            && stan::length(alpha)
+            && stan::length(beta)))
+        return 0.0;
+
+      T_partials_return cdf_log(0.0);
+      check_not_nan(function, "Random variable", y);
+      check_finite(function, "Lower bound parameter", alpha);
+      check_finite(function, "Upper bound parameter", beta);
+      check_greater(function, "Upper bound parameter", beta, alpha);
+      check_consistent_sizes(function,
+                             "Random variable", y,
+                             "Lower bound parameter", alpha,
+                             "Upper bound parameter", beta);
+
+      VectorView<const T_y> y_vec(y);
+      VectorView<const T_low> alpha_vec(alpha);
+      VectorView<const T_high> beta_vec(beta);
+      size_t N = max_size(y, alpha, beta);
+
+      OperandsAndPartials<T_y, T_low, T_high>
+        operands_and_partials(y, alpha, beta);
+
+      for (size_t n = 0; n < N; n++) {
+        const T_partials_return y_dbl = value_of(y_vec[n]);
+        if (y_dbl < value_of(alpha_vec[n])
+            || y_dbl > value_of(beta_vec[n]))
+          return negative_infinity();
+        if (y_dbl == value_of(beta_vec[n]))
+          return operands_and_partials.value(0.0);
+      }
+
+      for (size_t n = 0; n < N; n++) {
+        const T_partials_return y_dbl = value_of(y_vec[n]);
+        const T_partials_return alpha_dbl = value_of(alpha_vec[n]);
+        const T_partials_return beta_dbl = value_of(beta_vec[n]);
+        const T_partials_return b_min_a = beta_dbl - alpha_dbl;
+        const T_partials_return cdf_log_ = (y_dbl - alpha_dbl) / b_min_a;
+
+        cdf_log += log(cdf_log_);
+
+        if (!is_constant_struct<T_y>::value)
+          operands_and_partials.d_x1[n] += 1.0 / b_min_a / cdf_log_;
+        if (!is_constant_struct<T_low>::value)
+          operands_and_partials.d_x2[n] += (y_dbl - beta_dbl) / b_min_a
+            / b_min_a / cdf_log_;
+        if (!is_constant_struct<T_high>::value)
+          operands_and_partials.d_x3[n] -= 1.0 / b_min_a;
+      }
+      return operands_and_partials.value(cdf_log);
+    }
+
+  }
+}
+#endif

--- a/stan/math/prim/scal/prob/uniform_lpdf.hpp
+++ b/stan/math/prim/scal/prob/uniform_lpdf.hpp
@@ -1,0 +1,122 @@
+#ifndef STAN_MATH_PRIM_SCAL_PROB_UNIFORM_LPDF_HPP
+#define STAN_MATH_PRIM_SCAL_PROB_UNIFORM_LPDF_HPP
+
+#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
+#include <stan/math/prim/scal/meta/partials_return_type.hpp>
+#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
+#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
+#include <stan/math/prim/scal/err/check_finite.hpp>
+#include <stan/math/prim/scal/err/check_greater.hpp>
+#include <stan/math/prim/scal/err/check_not_nan.hpp>
+#include <stan/math/prim/scal/fun/constants.hpp>
+#include <stan/math/prim/scal/fun/value_of.hpp>
+#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
+#include <stan/math/prim/scal/meta/include_summand.hpp>
+#include <boost/random/uniform_real_distribution.hpp>
+#include <boost/random/variate_generator.hpp>
+#include <cmath>
+
+namespace stan {
+  namespace math {
+
+    /**
+     * The log of a uniform density for the given
+     * y, lower, and upper bound.
+     *
+     \f{eqnarray*}{
+     y &\sim& \mbox{\sf{U}}(\alpha, \beta) \\
+     \log (p (y \, |\, \alpha, \beta)) &=& \log \left( \frac{1}{\beta-\alpha} \right) \\
+     &=& \log (1) - \log (\beta - \alpha) \\
+     &=& -\log (\beta - \alpha) \\
+     & & \mathrm{ where } \; y \in [\alpha, \beta], \log(0) \; \mathrm{otherwise}
+     \f}
+     *
+     * @param y A scalar variable.
+     * @param alpha Lower bound.
+     * @param beta Upper bound.
+     * @throw std::invalid_argument if the lower bound is greater than
+     *    or equal to the lower bound
+     * @tparam T_y Type of scalar.
+     * @tparam T_low Type of lower bound.
+     * @tparam T_high Type of upper bound.
+     */
+    template <bool propto,
+              typename T_y, typename T_low, typename T_high>
+    typename return_type<T_y, T_low, T_high>::type
+    uniform_lpdf(const T_y& y, const T_low& alpha, const T_high& beta) {
+      static const char* function("uniform_lpdf");
+      typedef typename stan::partials_return_type<T_y, T_low, T_high>::type
+        T_partials_return;
+
+      using std::log;
+
+      if (!(stan::length(y)
+            && stan::length(alpha)
+            && stan::length(beta)))
+        return 0.0;
+
+      T_partials_return logp(0.0);
+      check_not_nan(function, "Random variable", y);
+      check_finite(function, "Lower bound parameter", alpha);
+      check_finite(function, "Upper bound parameter", beta);
+      check_greater(function, "Upper bound parameter", beta, alpha);
+      check_consistent_sizes(function,
+                             "Random variable", y,
+                             "Lower bound parameter", alpha,
+                             "Upper bound parameter", beta);
+
+      if (!include_summand<propto, T_y, T_low, T_high>::value)
+        return 0.0;
+
+      VectorView<const T_y> y_vec(y);
+      VectorView<const T_low> alpha_vec(alpha);
+      VectorView<const T_high> beta_vec(beta);
+      size_t N = max_size(y, alpha, beta);
+
+      for (size_t n = 0; n < N; n++) {
+        const T_partials_return y_dbl = value_of(y_vec[n]);
+        if (y_dbl < value_of(alpha_vec[n])
+            || y_dbl > value_of(beta_vec[n]))
+          return LOG_ZERO;
+      }
+
+      VectorBuilder<include_summand<propto, T_low, T_high>::value,
+                    T_partials_return, T_low, T_high>
+        inv_beta_minus_alpha(max_size(alpha, beta));
+      for (size_t i = 0; i < max_size(alpha, beta); i++)
+        if (include_summand<propto, T_low, T_high>::value)
+          inv_beta_minus_alpha[i]
+            = 1.0 / (value_of(beta_vec[i]) - value_of(alpha_vec[i]));
+
+      VectorBuilder<include_summand<propto, T_low, T_high>::value,
+                    T_partials_return, T_low, T_high>
+        log_beta_minus_alpha(max_size(alpha, beta));
+      for (size_t i = 0; i < max_size(alpha, beta); i++)
+        if (include_summand<propto, T_low, T_high>::value)
+          log_beta_minus_alpha[i]
+            = log(value_of(beta_vec[i]) - value_of(alpha_vec[i]));
+
+      OperandsAndPartials<T_y, T_low, T_high>
+        operands_and_partials(y, alpha, beta);
+      for (size_t n = 0; n < N; n++) {
+        if (include_summand<propto, T_low, T_high>::value)
+          logp -= log_beta_minus_alpha[n];
+
+        if (!is_constant_struct<T_low>::value)
+          operands_and_partials.d_x2[n] += inv_beta_minus_alpha[n];
+        if (!is_constant_struct<T_high>::value)
+          operands_and_partials.d_x3[n] -= inv_beta_minus_alpha[n];
+      }
+      return operands_and_partials.value(logp);
+    }
+
+    template <typename T_y, typename T_low, typename T_high>
+    inline
+    typename return_type<T_y, T_low, T_high>::type
+    uniform_lpdf(const T_y& y, const T_low& alpha, const T_high& beta) {
+      return uniform_lpdf<false>(y, alpha, beta);
+    }
+
+  }
+}
+#endif

--- a/stan/math/prim/scal/prob/von_mises_lpdf.hpp
+++ b/stan/math/prim/scal/prob/von_mises_lpdf.hpp
@@ -1,0 +1,120 @@
+#ifndef STAN_MATH_PRIM_SCAL_PROB_VON_MISES_LPDF_HPP
+#define STAN_MATH_PRIM_SCAL_PROB_VON_MISES_LPDF_HPP
+
+#include <stan/math/prim/scal/meta/partials_return_type.hpp>
+#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
+#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
+#include <stan/math/prim/scal/err/check_finite.hpp>
+#include <stan/math/prim/scal/err/check_greater.hpp>
+#include <stan/math/prim/scal/err/check_nonnegative.hpp>
+#include <stan/math/prim/scal/err/check_positive_finite.hpp>
+#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
+#include <stan/math/prim/scal/fun/modified_bessel_first_kind.hpp>
+#include <stan/math/prim/scal/fun/constants.hpp>
+#include <stan/math/prim/scal/meta/include_summand.hpp>
+#include <stan/math/prim/scal/meta/VectorView.hpp>
+#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
+#include <stan/math/prim/scal/fun/value_of.hpp>
+#include <cmath>
+
+namespace stan {
+  namespace math {
+
+    template<bool propto,
+             typename T_y, typename T_loc, typename T_scale>
+    typename return_type<T_y, T_loc, T_scale>::type
+    von_mises_lpdf(T_y const& y, T_loc const& mu, T_scale const& kappa) {
+      static char const* const function = "von_mises_lpdf";
+      typedef typename stan::partials_return_type<T_y, T_loc, T_scale>::type
+        T_partials_return;
+
+      if (!(stan::length(y)
+            && stan::length(mu)
+            && stan::length(kappa)))
+        return 0.0;
+
+      using stan::is_constant_struct;
+
+      using std::log;
+
+      T_partials_return logp = 0.0;
+
+      check_finite(function, "Random variable", y);
+      check_finite(function, "Location paramter", mu);
+      check_positive_finite(function, "Scale parameter", kappa);
+      check_consistent_sizes(function,
+                             "Random variable", y,
+                             "Location parameter", mu,
+                             "Scale parameter", kappa);
+
+      if (!include_summand<propto, T_y, T_loc, T_scale>::value)
+        return logp;
+
+      const bool y_const = is_constant_struct<T_y>::value;
+      const bool mu_const = is_constant_struct<T_loc>::value;
+      const bool kappa_const = is_constant_struct<T_scale>::value;
+
+      const bool compute_bessel0 = include_summand<propto, T_scale>::value;
+      const bool compute_bessel1 = !kappa_const;
+      const double TWO_PI = 2.0 * pi();
+
+      VectorView<const T_y> y_vec(y);
+      VectorView<const T_loc> mu_vec(mu);
+      VectorView<const T_scale> kappa_vec(kappa);
+
+      VectorBuilder<true, T_partials_return, T_scale> kappa_dbl(length(kappa));
+      VectorBuilder<include_summand<propto, T_scale>::value,
+                    T_partials_return, T_scale> log_bessel0(length(kappa));
+      for (size_t i = 0; i < length(kappa); i++) {
+        kappa_dbl[i] = value_of(kappa_vec[i]);
+        if (include_summand<propto, T_scale>::value)
+          log_bessel0[i]
+            = log(modified_bessel_first_kind(0, value_of(kappa_vec[i])));
+      }
+
+      OperandsAndPartials<T_y, T_loc, T_scale>
+        operands_and_partials(y, mu, kappa);
+
+      size_t N = max_size(y, mu, kappa);
+
+      for (size_t n = 0; n < N; n++) {
+        const T_partials_return y_ = value_of(y_vec[n]);
+        const T_partials_return y_dbl =  y_ - floor(y_ / TWO_PI) * TWO_PI;
+        const T_partials_return mu_dbl = value_of(mu_vec[n]);
+
+        T_partials_return bessel0 = 0;
+        if (compute_bessel0)
+          bessel0 = modified_bessel_first_kind(0, kappa_dbl[n]);
+        T_partials_return bessel1 = 0;
+        if (compute_bessel1)
+          bessel1 = modified_bessel_first_kind(-1, kappa_dbl[n]);
+        const T_partials_return kappa_sin = kappa_dbl[n] * sin(mu_dbl - y_dbl);
+        const T_partials_return kappa_cos = kappa_dbl[n] * cos(mu_dbl - y_dbl);
+
+        if (include_summand<propto>::value)
+          logp -= LOG_TWO_PI;
+        if (include_summand<propto, T_scale>::value)
+          logp -= log_bessel0[n];
+        if (include_summand<propto, T_y, T_loc, T_scale>::value)
+          logp += kappa_cos;
+
+        if (!y_const)
+          operands_and_partials.d_x1[n] += kappa_sin;
+        if (!mu_const)
+          operands_and_partials.d_x2[n] -= kappa_sin;
+        if (!kappa_const)
+          operands_and_partials.d_x3[n] += kappa_cos / kappa_dbl[n]
+            - bessel1 / bessel0;
+      }
+      return operands_and_partials.value(logp);
+    }
+
+    template<typename T_y, typename T_loc, typename T_scale>
+    inline typename return_type<T_y, T_loc, T_scale>::type
+    von_mises_lpdf(T_y const& y, T_loc const& mu, T_scale const& kappa) {
+      return von_mises_lpdf<false>(y, mu, kappa);
+    }
+
+  }
+}
+#endif

--- a/stan/math/prim/scal/prob/weibull_lccdf.hpp
+++ b/stan/math/prim/scal/prob/weibull_lccdf.hpp
@@ -1,0 +1,74 @@
+#ifndef STAN_MATH_PRIM_SCAL_PROB_WEIBULL_LCCDF_HPP
+#define STAN_MATH_PRIM_SCAL_PROB_WEIBULL_LCCDF_HPP
+
+#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
+#include <stan/math/prim/scal/meta/partials_return_type.hpp>
+#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
+#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
+#include <stan/math/prim/scal/err/check_finite.hpp>
+#include <stan/math/prim/scal/err/check_nonnegative.hpp>
+#include <stan/math/prim/scal/err/check_not_nan.hpp>
+#include <stan/math/prim/scal/err/check_positive_finite.hpp>
+#include <stan/math/prim/scal/fun/multiply_log.hpp>
+#include <stan/math/prim/scal/fun/value_of.hpp>
+#include <stan/math/prim/scal/meta/length.hpp>
+#include <stan/math/prim/scal/fun/constants.hpp>
+#include <stan/math/prim/scal/meta/include_summand.hpp>
+#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
+#include <stan/math/prim/scal/meta/VectorView.hpp>
+#include <boost/random/weibull_distribution.hpp>
+#include <boost/random/variate_generator.hpp>
+#include <cmath>
+
+namespace stan {
+  namespace math {
+
+    template <typename T_y, typename T_shape, typename T_scale>
+    typename return_type<T_y, T_shape, T_scale>::type
+    weibull_lccdf(const T_y& y, const T_shape& alpha, const T_scale& sigma) {
+      typedef typename stan::partials_return_type<T_y, T_shape, T_scale>::type
+        T_partials_return;
+
+      static const char* function("weibull_lccdf");
+
+      using boost::math::tools::promote_args;
+      using std::log;
+
+      if (!(stan::length(y)
+            && stan::length(alpha)
+            && stan::length(sigma)))
+        return 0.0;
+
+      T_partials_return ccdf_log(0.0);
+      check_nonnegative(function, "Random variable", y);
+      check_positive_finite(function, "Shape parameter", alpha);
+      check_positive_finite(function, "Scale parameter", sigma);
+
+      OperandsAndPartials<T_y, T_shape, T_scale>
+        operands_and_partials(y, alpha, sigma);
+
+      VectorView<const T_y> y_vec(y);
+      VectorView<const T_scale> sigma_vec(sigma);
+      VectorView<const T_shape> alpha_vec(alpha);
+      size_t N = max_size(y, sigma, alpha);
+      for (size_t n = 0; n < N; n++) {
+        const T_partials_return y_dbl = value_of(y_vec[n]);
+        const T_partials_return sigma_dbl = value_of(sigma_vec[n]);
+        const T_partials_return alpha_dbl = value_of(alpha_vec[n]);
+        const T_partials_return pow_ = pow(y_dbl / sigma_dbl, alpha_dbl);
+
+        ccdf_log -= pow_;
+
+        if (!is_constant_struct<T_y>::value)
+          operands_and_partials.d_x1[n] -= alpha_dbl / y_dbl * pow_;
+        if (!is_constant_struct<T_shape>::value)
+          operands_and_partials.d_x2[n] -= log(y_dbl / sigma_dbl) * pow_;
+        if (!is_constant_struct<T_scale>::value)
+          operands_and_partials.d_x3[n] += alpha_dbl / sigma_dbl * pow_;
+      }
+      return operands_and_partials.value(ccdf_log);
+    }
+
+  }
+}
+#endif

--- a/stan/math/prim/scal/prob/weibull_lcdf.hpp
+++ b/stan/math/prim/scal/prob/weibull_lcdf.hpp
@@ -1,0 +1,78 @@
+#ifndef STAN_MATH_PRIM_SCAL_PROB_WEIBULL_LCDF_HPP
+#define STAN_MATH_PRIM_SCAL_PROB_WEIBULL_LCDF_HPP
+
+#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
+#include <stan/math/prim/scal/meta/partials_return_type.hpp>
+#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
+#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
+#include <stan/math/prim/scal/err/check_finite.hpp>
+#include <stan/math/prim/scal/err/check_nonnegative.hpp>
+#include <stan/math/prim/scal/err/check_not_nan.hpp>
+#include <stan/math/prim/scal/err/check_positive_finite.hpp>
+#include <stan/math/prim/scal/fun/multiply_log.hpp>
+#include <stan/math/prim/scal/fun/value_of.hpp>
+#include <stan/math/prim/scal/meta/length.hpp>
+#include <stan/math/prim/scal/fun/constants.hpp>
+#include <stan/math/prim/scal/meta/include_summand.hpp>
+#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
+#include <stan/math/prim/scal/meta/VectorView.hpp>
+#include <boost/random/weibull_distribution.hpp>
+#include <boost/random/variate_generator.hpp>
+#include <cmath>
+
+namespace stan {
+  namespace math {
+
+    template <typename T_y, typename T_shape, typename T_scale>
+    typename return_type<T_y, T_shape, T_scale>::type
+    weibull_lcdf(const T_y& y, const T_shape& alpha, const T_scale& sigma) {
+      typedef typename stan::partials_return_type<T_y, T_shape, T_scale>::type
+        T_partials_return;
+
+      static const char* function("weibull_lcdf");
+
+      using boost::math::tools::promote_args;
+      using std::log;
+      using std::exp;
+
+      if (!(stan::length(y)
+            && stan::length(alpha)
+            && stan::length(sigma)))
+        return 0.0;
+
+      T_partials_return cdf_log(0.0);
+      check_nonnegative(function, "Random variable", y);
+      check_positive_finite(function, "Shape parameter", alpha);
+      check_positive_finite(function, "Scale parameter", sigma);
+
+      OperandsAndPartials<T_y, T_shape, T_scale>
+        operands_and_partials(y, alpha, sigma);
+
+      VectorView<const T_y> y_vec(y);
+      VectorView<const T_scale> sigma_vec(sigma);
+      VectorView<const T_shape> alpha_vec(alpha);
+      size_t N = max_size(y, sigma, alpha);
+      for (size_t n = 0; n < N; n++) {
+        const T_partials_return y_dbl = value_of(y_vec[n]);
+        const T_partials_return sigma_dbl = value_of(sigma_vec[n]);
+        const T_partials_return alpha_dbl = value_of(alpha_vec[n]);
+        const T_partials_return pow_ = pow(y_dbl / sigma_dbl, alpha_dbl);
+        const T_partials_return exp_ = exp(-pow_);
+        const T_partials_return cdf_ = 1.0 - exp_;
+
+        cdf_log += log(cdf_);
+
+        const T_partials_return rep_deriv = pow_ / (1.0 / exp_ - 1.0);
+        if (!is_constant_struct<T_y>::value)
+          operands_and_partials.d_x1[n] += rep_deriv * alpha_dbl / y_dbl;
+        if (!is_constant_struct<T_shape>::value)
+          operands_and_partials.d_x2[n] += rep_deriv * log(y_dbl / sigma_dbl);
+        if (!is_constant_struct<T_scale>::value)
+          operands_and_partials.d_x3[n] -= rep_deriv * alpha_dbl / sigma_dbl;
+      }
+      return operands_and_partials.value(cdf_log);
+    }
+
+  }
+}
+#endif

--- a/stan/math/prim/scal/prob/weibull_lpdf.hpp
+++ b/stan/math/prim/scal/prob/weibull_lpdf.hpp
@@ -1,0 +1,138 @@
+#ifndef STAN_MATH_PRIM_SCAL_PROB_WEIBULL_LPDF_HPP
+#define STAN_MATH_PRIM_SCAL_PROB_WEIBULL_LPDF_HPP
+
+#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
+#include <stan/math/prim/scal/meta/partials_return_type.hpp>
+#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
+#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
+#include <stan/math/prim/scal/err/check_finite.hpp>
+#include <stan/math/prim/scal/err/check_nonnegative.hpp>
+#include <stan/math/prim/scal/err/check_not_nan.hpp>
+#include <stan/math/prim/scal/err/check_positive_finite.hpp>
+#include <stan/math/prim/scal/fun/multiply_log.hpp>
+#include <stan/math/prim/scal/fun/value_of.hpp>
+#include <stan/math/prim/scal/meta/length.hpp>
+#include <stan/math/prim/scal/fun/constants.hpp>
+#include <stan/math/prim/scal/meta/include_summand.hpp>
+#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
+#include <stan/math/prim/scal/meta/VectorView.hpp>
+#include <boost/random/weibull_distribution.hpp>
+#include <boost/random/variate_generator.hpp>
+#include <cmath>
+
+namespace stan {
+  namespace math {
+
+    // Weibull(y|alpha, sigma)     [y >= 0;  alpha > 0;  sigma > 0]
+    template <bool propto,
+              typename T_y, typename T_shape, typename T_scale>
+    typename return_type<T_y, T_shape, T_scale>::type
+    weibull_lpdf(const T_y& y, const T_shape& alpha, const T_scale& sigma) {
+      static const char* function("weibull_lpdf");
+      typedef typename stan::partials_return_type<T_y, T_shape, T_scale>::type
+        T_partials_return;
+
+      using std::log;
+
+      if (!(stan::length(y)
+            && stan::length(alpha)
+            && stan::length(sigma)))
+        return 0.0;
+
+      T_partials_return logp(0.0);
+      check_finite(function, "Random variable", y);
+      check_positive_finite(function, "Shape parameter", alpha);
+      check_positive_finite(function, "Scale parameter", sigma);
+      check_consistent_sizes(function,
+                             "Random variable", y,
+                             "Shape parameter", alpha,
+                             "Scale parameter", sigma);
+
+      if (!include_summand<propto, T_y, T_shape, T_scale>::value)
+        return 0.0;
+
+      VectorView<const T_y> y_vec(y);
+      VectorView<const T_shape> alpha_vec(alpha);
+      VectorView<const T_scale> sigma_vec(sigma);
+      size_t N = max_size(y, alpha, sigma);
+
+      for (size_t n = 0; n < N; n++) {
+        const T_partials_return y_dbl = value_of(y_vec[n]);
+        if (y_dbl < 0)
+          return LOG_ZERO;
+      }
+
+      VectorBuilder<include_summand<propto, T_shape>::value,
+                    T_partials_return, T_shape> log_alpha(length(alpha));
+      for (size_t i = 0; i < length(alpha); i++)
+        if (include_summand<propto, T_shape>::value)
+          log_alpha[i] = log(value_of(alpha_vec[i]));
+
+      VectorBuilder<include_summand<propto, T_y, T_shape>::value,
+                    T_partials_return, T_y> log_y(length(y));
+      for (size_t i = 0; i < length(y); i++)
+        if (include_summand<propto, T_y, T_shape>::value)
+          log_y[i] = log(value_of(y_vec[i]));
+
+      VectorBuilder<include_summand<propto, T_shape, T_scale>::value,
+                    T_partials_return, T_scale> log_sigma(length(sigma));
+      for (size_t i = 0; i < length(sigma); i++)
+        if (include_summand<propto, T_shape, T_scale>::value)
+          log_sigma[i] = log(value_of(sigma_vec[i]));
+
+      VectorBuilder<include_summand<propto, T_y, T_shape, T_scale>::value,
+                    T_partials_return, T_scale> inv_sigma(length(sigma));
+      for (size_t i = 0; i < length(sigma); i++)
+        if (include_summand<propto, T_y, T_shape, T_scale>::value)
+          inv_sigma[i] = 1.0 / value_of(sigma_vec[i]);
+
+      VectorBuilder<include_summand<propto, T_y, T_shape, T_scale>::value,
+                    T_partials_return, T_y, T_shape, T_scale>
+        y_div_sigma_pow_alpha(N);
+      for (size_t i = 0; i < N; i++)
+        if (include_summand<propto, T_y, T_shape, T_scale>::value) {
+          const T_partials_return y_dbl = value_of(y_vec[i]);
+          const T_partials_return alpha_dbl = value_of(alpha_vec[i]);
+          y_div_sigma_pow_alpha[i] = pow(y_dbl * inv_sigma[i], alpha_dbl);
+        }
+
+      OperandsAndPartials<T_y, T_shape, T_scale>
+        operands_and_partials(y, alpha, sigma);
+      for (size_t n = 0; n < N; n++) {
+        const T_partials_return alpha_dbl = value_of(alpha_vec[n]);
+        if (include_summand<propto, T_shape>::value)
+          logp += log_alpha[n];
+        if (include_summand<propto, T_y, T_shape>::value)
+          logp += (alpha_dbl-1.0)*log_y[n];
+        if (include_summand<propto, T_shape, T_scale>::value)
+          logp -= alpha_dbl*log_sigma[n];
+        if (include_summand<propto, T_y, T_shape, T_scale>::value)
+          logp -= y_div_sigma_pow_alpha[n];
+
+        if (!is_constant_struct<T_y>::value) {
+          const T_partials_return inv_y = 1.0 / value_of(y_vec[n]);
+          operands_and_partials.d_x1[n]
+            += (alpha_dbl-1.0) * inv_y
+            - alpha_dbl * y_div_sigma_pow_alpha[n] * inv_y;
+        }
+        if (!is_constant_struct<T_shape>::value)
+          operands_and_partials.d_x2[n]
+            += 1.0/alpha_dbl
+            + (1.0 - y_div_sigma_pow_alpha[n]) * (log_y[n] - log_sigma[n]);
+        if (!is_constant_struct<T_scale>::value)
+          operands_and_partials.d_x3[n]
+            += alpha_dbl * inv_sigma[n] * (y_div_sigma_pow_alpha[n] - 1.0);
+      }
+      return operands_and_partials.value(logp);
+    }
+
+    template <typename T_y, typename T_shape, typename T_scale>
+    inline
+    typename return_type<T_y, T_shape, T_scale>::type
+    weibull_lpdf(const T_y& y, const T_shape& alpha, const T_scale& sigma) {
+      return weibull_lpdf<false>(y, alpha, sigma);
+    }
+
+  }
+}
+#endif

--- a/stan/math/prim/scal/prob/wiener_lpdf.hpp
+++ b/stan/math/prim/scal/prob/wiener_lpdf.hpp
@@ -1,0 +1,213 @@
+// Original code from which Stan's code is derived:
+// Copyright (c) 2013, Joachim Vandekerckhove.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted
+// provided that the following conditions are met:
+//
+//   * Redistributions of source code must retain the above copyright notice,
+//   * this list of conditions and the following disclaimer.
+//   * Redistributions in binary form must reproduce the above copyright notice,
+//   * this list of conditions and the following disclaimer in the
+//   * documentation and/or other materials provided with the distribution.
+//   * Neither the name of the University of California, Irvine nor the names
+//   * of its contributors may be used to endorse or promote products derived
+//   * from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef STAN_MATH_PRIM_MAT_PROB_WIENER_LPDF_HPP
+#define STAN_MATH_PRIM_MAT_PROB_WIENER_LPDF_HPP
+
+#include <stan/math/prim/scal/fun/constants.hpp>
+#include <stan/math/prim/scal/fun/square.hpp>
+#include <stan/math/prim/scal/fun/value_of.hpp>
+#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
+#include <stan/math/prim/scal/err/check_bounded.hpp>
+#include <stan/math/prim/scal/err/check_finite.hpp>
+#include <stan/math/prim/scal/err/check_not_nan.hpp>
+#include <stan/math/prim/scal/err/check_positive.hpp>
+#include <stan/math/prim/scal/meta/return_type.hpp>
+#include <stan/math/prim/scal/meta/include_summand.hpp>
+#include <boost/math/distributions.hpp>
+#include <algorithm>
+#include <cmath>
+#include <string>
+
+namespace stan {
+  namespace math {
+
+    /**
+     * The log of the first passage time density function for a (Wiener)
+     *  drift diffusion model for the given \f$y\f$,
+     * boundary separation \f$\alpha\f$, nondecision time \f$\tau\f$,
+     * relative bias \f$\beta\f$, and drift rate \f$\delta\f$.
+     * \f$\alpha\f$ and \f$\tau\f$ must be greater than 0, and
+     * \f$\beta\f$ must be between 0 and 1. \f$y\f$ should contain
+     * reaction times in seconds (strictly positive) with
+     * upper-boundary responses.
+     *
+     * @param y A scalar variate.
+     * @param alpha The boundary separation.
+     * @param tau The nondecision time.
+     * @param beta The relative bias.
+     * @param delta The drift rate.
+     * @return The log of the Wiener first passage time density of
+     *  the specified arguments.
+     */
+    template <bool propto,
+              typename T_y, typename T_alpha, typename T_tau,
+              typename T_beta, typename T_delta>
+    typename return_type<T_y, T_alpha, T_tau, T_beta, T_delta>::type
+    wiener_lpdf(const T_y& y, const T_alpha& alpha, const T_tau& tau,
+               const T_beta& beta, const T_delta& delta) {
+      static const char* function("wiener_lpdf(%1%)");
+
+      using std::log;
+      using std::exp;
+      using std::pow;
+
+      static const double WIENER_ERR = 0.000001;
+      static const double PI_TIMES_WIENER_ERR = pi() * WIENER_ERR;
+      static const double LOG_PI_LOG_WIENER_ERR =
+        LOG_PI + log(WIENER_ERR);
+      static const double
+        TWO_TIMES_SQRT_2_TIMES_SQRT_PI_TIMES_WIENER_ERR =
+        2.0 * SQRT_2_TIMES_SQRT_PI * WIENER_ERR;
+      static const double LOG_TWO_OVER_TWO_PLUS_LOG_SQRT_PI =
+        LOG_TWO / 2 + LOG_SQRT_PI;
+      static const double SQUARE_PI_OVER_TWO = square(pi()) * 0.5;
+      static const double TWO_TIMES_LOG_SQRT_PI = 2.0 * LOG_SQRT_PI;
+
+      if (!(stan::length(y)
+            && stan::length(alpha)
+            && stan::length(beta)
+            && stan::length(tau)
+            && stan::length(delta)))
+        return 0.0;
+
+      typedef typename return_type<T_y, T_alpha, T_tau,
+                                   T_beta, T_delta>::type T_return_type;
+      T_return_type lp(0.0);
+
+      check_not_nan(function, "Random variable", y);
+      check_not_nan(function, "Boundary separation", alpha);
+      check_not_nan(function, "A-priori bias", beta);
+      check_not_nan(function, "Nondecision time", tau);
+      check_not_nan(function, "Drift rate", delta);
+      check_finite(function, "Boundary separation", alpha);
+      check_finite(function, "A-priori bias", beta);
+      check_finite(function, "Nondecision time", tau);
+      check_finite(function, "Drift rate", delta);
+      check_positive(function, "Random variable", y);
+      check_positive(function, "Boundary separation", alpha);
+      check_positive(function, "Nondecision time", tau);
+      check_bounded(function, "A-priori bias", beta , 0, 1);
+      check_consistent_sizes(function, "Random variable", y,
+                             "Boundary separation", alpha,
+                             "A-priori bias", beta,
+                             "Nondecision time", tau, "Drift rate", delta);
+
+      size_t N = std::max(max_size(y, alpha, beta), max_size(tau, delta));
+      if (!N) return 0.0;
+
+      VectorView<const T_y> y_vec(y);
+      VectorView<const T_alpha> alpha_vec(alpha);
+      VectorView<const T_beta> beta_vec(beta);
+      VectorView<const T_tau> tau_vec(tau);
+      VectorView<const T_delta> delta_vec(delta);
+
+      size_t N_y_tau = max_size(y, tau);
+      for (size_t i = 0; i < N_y_tau; ++i) {
+        if (y_vec[i] <= tau_vec[i]) {
+          std::stringstream msg;
+          msg << ", but must be greater than nondecision time = " << tau_vec[i];
+          std::string msg_str(msg.str());
+          domain_error(function, "Random variable", y_vec[i], " = ",
+                       msg_str.c_str());
+        }
+      }
+
+      if (!include_summand<propto, T_y, T_alpha, T_tau, T_beta, T_delta>::value)
+        return 0;
+
+      for (size_t i = 0; i < N; i++) {
+        typename scalar_type<T_beta>::type one_minus_beta = 1.0 - beta_vec[i];
+        typename scalar_type<T_alpha>::type alpha2 = square(alpha_vec[i]);
+        T_return_type x = (y_vec[i] - tau_vec[i]) / alpha2;
+        T_return_type kl, ks, tmp = 0;
+        T_return_type k, K;
+        T_return_type sqrt_x = sqrt(x);
+        T_return_type log_x = log(x);
+        T_return_type one_over_pi_times_sqrt_x = 1.0 / pi() * sqrt_x;
+
+        // calculate number of terms needed for large t:
+        // if error threshold is set low enough
+        if (PI_TIMES_WIENER_ERR * x < 1) {
+          // compute bound
+          kl = sqrt(-2.0 * SQRT_PI * (LOG_PI_LOG_WIENER_ERR + log_x)) / sqrt_x;
+          // ensure boundary conditions met
+          kl = (kl > one_over_pi_times_sqrt_x) ? kl : one_over_pi_times_sqrt_x;
+        } else {
+          kl = one_over_pi_times_sqrt_x;  // set to boundary condition
+        }
+        // calculate number of terms needed for small t:
+        // if error threshold is set low enough
+        T_return_type tmp_expr0
+          = TWO_TIMES_SQRT_2_TIMES_SQRT_PI_TIMES_WIENER_ERR * sqrt_x;
+        if (tmp_expr0 < 1) {
+          // compute bound
+          ks = 2.0 +  sqrt_x * sqrt(-2 * log(tmp_expr0));
+          // ensure boundary conditions are met
+          T_return_type sqrt_x_plus_one = sqrt_x + 1.0;
+          ks = (ks > sqrt_x_plus_one) ? ks : sqrt_x_plus_one;
+        } else {  // if error threshold was set too high
+          ks = 2.0;  // minimal kappa for that case
+        }
+        if (ks < kl) {  // small t
+          K = ceil(ks);  // round to smallest integer meeting error
+          T_return_type tmp_expr1 = (K - 1.0) / 2.0;
+          T_return_type tmp_expr2 = ceil(tmp_expr1);
+          for (k = -floor(tmp_expr1); k <= tmp_expr2; k++)
+            tmp += (one_minus_beta + 2.0 * k) *
+              exp(-(square(one_minus_beta + 2.0 * k)) * 0.5 / x);
+          tmp = log(tmp) - LOG_TWO_OVER_TWO_PLUS_LOG_SQRT_PI - 1.5 * log_x;
+        } else {  // if large t is better...
+          K = ceil(kl);  // round to smallest integer meeting error
+          for (k = 1; k <= K; ++k)
+            tmp += k * exp(-(square(k)) * (SQUARE_PI_OVER_TWO * x))
+              * sin(k * pi() * one_minus_beta);
+          tmp = log(tmp) + TWO_TIMES_LOG_SQRT_PI;
+        }
+
+        // convert to f(t|v,a,w) and return result
+        lp += delta_vec[i] * alpha_vec[i] * one_minus_beta
+          - square(delta_vec[i]) * x * alpha2 / 2.0
+          - log(alpha2) + tmp;
+      }
+      return lp;
+    }
+
+    template <typename T_y, typename T_alpha, typename T_tau,
+              typename T_beta, typename T_delta>
+    inline
+    typename return_type<T_y, T_alpha, T_tau, T_beta, T_delta>::type
+    wiener_lpdf(const T_y& y, const T_alpha& alpha, const T_tau& tau,
+               const T_beta& beta, const T_delta& delta) {
+      return wiener_lpdf<false>(y, alpha, tau, beta, delta);
+    }
+
+  }
+}
+#endif

--- a/test/unit/math/prim/scal/prob/student_t_ccdf_log_test.cpp
+++ b/test/unit/math/prim/scal/prob/student_t_ccdf_log_test.cpp
@@ -1,0 +1,14 @@
+#include <stan/math/prim/scal.hpp>
+#include <gtest/gtest.h>
+
+TEST(ProbStudentT, ccdf_log_matches_lccdf) {
+  double y = 0.8;
+  double nu = 4.8;
+  double mu = 2;
+  double sigma = 2.3;
+
+  EXPECT_FLOAT_EQ((stan::math::student_t_lccdf(y, nu, mu, sigma)),
+                  (stan::math::student_t_ccdf_log(y, nu, mu, sigma)));
+  EXPECT_FLOAT_EQ((stan::math::student_t_lccdf<double, double, double, double>(y, nu, mu, sigma)),
+                  (stan::math::student_t_ccdf_log<double, double, double, double>(y, nu, mu, sigma)));
+}

--- a/test/unit/math/prim/scal/prob/student_t_cdf_log_test.cpp
+++ b/test/unit/math/prim/scal/prob/student_t_cdf_log_test.cpp
@@ -1,0 +1,14 @@
+#include <stan/math/prim/scal.hpp>
+#include <gtest/gtest.h>
+
+TEST(ProbStudentT, cdf_log_matches_lcdf) {
+  double y = 0.8;
+  double nu = 4.8;
+  double mu = 2;
+  double sigma = 2.3;
+
+  EXPECT_FLOAT_EQ((stan::math::student_t_lcdf(y, nu, mu, sigma)),
+                  (stan::math::student_t_cdf_log(y, nu, mu, sigma)));
+  EXPECT_FLOAT_EQ((stan::math::student_t_lcdf<double, double, double, double>(y, nu, mu, sigma)),
+                  (stan::math::student_t_cdf_log<double, double, double, double>(y, nu, mu, sigma)));
+}

--- a/test/unit/math/prim/scal/prob/student_t_log_test.cpp
+++ b/test/unit/math/prim/scal/prob/student_t_log_test.cpp
@@ -1,0 +1,22 @@
+#include <stan/math/prim/scal.hpp>
+#include <gtest/gtest.h>
+
+TEST(ProbStudentT, log_matches_lpdf) {
+  double y = 0.8;
+  double nu = 4.8;
+  double mu = 2;
+  double sigma = 2.3;
+
+  EXPECT_FLOAT_EQ((stan::math::student_t_lpdf(y, nu, mu, sigma)),
+                  (stan::math::student_t_log(y, nu, mu, sigma)));
+  EXPECT_FLOAT_EQ((stan::math::student_t_lpdf<true>(y, nu, mu, sigma)),
+                  (stan::math::student_t_log<true>(y, nu, mu, sigma)));
+  EXPECT_FLOAT_EQ((stan::math::student_t_lpdf<false>(y, nu, mu, sigma)),
+                  (stan::math::student_t_log<false>(y, nu, mu, sigma)));
+  EXPECT_FLOAT_EQ((stan::math::student_t_lpdf<true, double, double, double, double>(y, nu, mu, sigma)),
+                  (stan::math::student_t_log<true, double, double, double, double>(y, nu, mu, sigma)));
+  EXPECT_FLOAT_EQ((stan::math::student_t_lpdf<false, double, double, double, double>(y, nu, mu, sigma)),
+                  (stan::math::student_t_log<false, double, double, double, double>(y, nu, mu, sigma)));
+  EXPECT_FLOAT_EQ((stan::math::student_t_lpdf<double, double, double, double>(y, nu, mu, sigma)),
+                  (stan::math::student_t_log<double, double, double, double>(y, nu, mu, sigma)));
+}

--- a/test/unit/math/prim/scal/prob/uniform_ccdf_log_test.cpp
+++ b/test/unit/math/prim/scal/prob/uniform_ccdf_log_test.cpp
@@ -1,0 +1,13 @@
+#include <stan/math/prim/scal.hpp>
+#include <gtest/gtest.h>
+
+TEST(ProbUniform, ccdf_log_matches_lccdf) {
+  double y = 0.8;
+  double alpha = 0.4;
+  double beta = 2.3;
+
+  EXPECT_FLOAT_EQ((stan::math::uniform_lccdf(y, alpha, beta)),
+                  (stan::math::uniform_ccdf_log(y, alpha, beta)));
+  EXPECT_FLOAT_EQ((stan::math::uniform_lccdf<double, double, double>(y, alpha, beta)),
+                  (stan::math::uniform_ccdf_log<double, double, double>(y, alpha, beta)));
+}

--- a/test/unit/math/prim/scal/prob/uniform_cdf_log_test.cpp
+++ b/test/unit/math/prim/scal/prob/uniform_cdf_log_test.cpp
@@ -1,0 +1,13 @@
+#include <stan/math/prim/scal.hpp>
+#include <gtest/gtest.h>
+
+TEST(ProbUniform, cdf_log_matches_lcdf) {
+  double y = 0.8;
+  double alpha = 0.4;
+  double beta = 2.3;
+
+  EXPECT_FLOAT_EQ((stan::math::uniform_lcdf(y, alpha, beta)),
+                  (stan::math::uniform_cdf_log(y, alpha, beta)));
+  EXPECT_FLOAT_EQ((stan::math::uniform_lcdf<double, double, double>(y, alpha, beta)),
+                  (stan::math::uniform_cdf_log<double, double, double>(y, alpha, beta)));
+}

--- a/test/unit/math/prim/scal/prob/uniform_log_test.cpp
+++ b/test/unit/math/prim/scal/prob/uniform_log_test.cpp
@@ -1,0 +1,21 @@
+#include <stan/math/prim/scal.hpp>
+#include <gtest/gtest.h>
+
+TEST(ProbUniform, log_matches_lpdf) {
+  double y = 0.8;
+  double alpha = 0.4;
+  double beta = 2.3;
+
+  EXPECT_FLOAT_EQ((stan::math::uniform_lpdf(y, alpha, beta)),
+                  (stan::math::uniform_log(y, alpha, beta)));
+  EXPECT_FLOAT_EQ((stan::math::uniform_lpdf<true>(y, alpha, beta)),
+                  (stan::math::uniform_log<true>(y, alpha, beta)));
+  EXPECT_FLOAT_EQ((stan::math::uniform_lpdf<false>(y, alpha, beta)),
+                  (stan::math::uniform_log<false>(y, alpha, beta)));
+  EXPECT_FLOAT_EQ((stan::math::uniform_lpdf<true, double, double, double>(y, alpha, beta)),
+                  (stan::math::uniform_log<true, double, double, double>(y, alpha, beta)));
+  EXPECT_FLOAT_EQ((stan::math::uniform_lpdf<false, double, double, double>(y, alpha, beta)),
+                  (stan::math::uniform_log<false, double, double, double>(y, alpha, beta)));
+  EXPECT_FLOAT_EQ((stan::math::uniform_lpdf<double, double, double>(y, alpha, beta)),
+                  (stan::math::uniform_log<double, double, double>(y, alpha, beta)));
+}

--- a/test/unit/math/prim/scal/prob/von_mises_log_test.cpp
+++ b/test/unit/math/prim/scal/prob/von_mises_log_test.cpp
@@ -1,0 +1,21 @@
+#include <stan/math/prim/scal.hpp>
+#include <gtest/gtest.h>
+
+TEST(ProbVonMises, log_matches_lpdf) {
+  double y = -0.8;
+  double mu = 0.4;
+  double kappa = 2.3;
+
+  EXPECT_FLOAT_EQ((stan::math::von_mises_lpdf(y, mu, kappa)),
+                  (stan::math::von_mises_log(y, mu, kappa)));
+  EXPECT_FLOAT_EQ((stan::math::von_mises_lpdf<true>(y, mu, kappa)),
+                  (stan::math::von_mises_log<true>(y, mu, kappa)));
+  EXPECT_FLOAT_EQ((stan::math::von_mises_lpdf<false>(y, mu, kappa)),
+                  (stan::math::von_mises_log<false>(y, mu, kappa)));
+  EXPECT_FLOAT_EQ((stan::math::von_mises_lpdf<true, double, double, double>(y, mu, kappa)),
+                  (stan::math::von_mises_log<true, double, double, double>(y, mu, kappa)));
+  EXPECT_FLOAT_EQ((stan::math::von_mises_lpdf<false, double, double, double>(y, mu, kappa)),
+                  (stan::math::von_mises_log<false, double, double, double>(y, mu, kappa)));
+  EXPECT_FLOAT_EQ((stan::math::von_mises_lpdf<double, double, double>(y, mu, kappa)),
+                  (stan::math::von_mises_log<double, double, double>(y, mu, kappa)));
+}

--- a/test/unit/math/prim/scal/prob/weibull_ccdf_log_test.cpp
+++ b/test/unit/math/prim/scal/prob/weibull_ccdf_log_test.cpp
@@ -1,0 +1,13 @@
+#include <stan/math/prim/scal.hpp>
+#include <gtest/gtest.h>
+
+TEST(ProbWeibull, ccdf_log_matches_lccdf) {
+  double y = 0.8;
+  double alpha = 1.1;
+  double sigma = 2.3;
+
+  EXPECT_FLOAT_EQ((stan::math::weibull_lccdf(y, alpha, sigma)),
+                  (stan::math::weibull_ccdf_log(y, alpha, sigma)));
+  EXPECT_FLOAT_EQ((stan::math::weibull_lccdf<double, double, double>(y, alpha, sigma)),
+                  (stan::math::weibull_ccdf_log<double, double, double>(y, alpha, sigma)));
+}

--- a/test/unit/math/prim/scal/prob/weibull_cdf_log_test.cpp
+++ b/test/unit/math/prim/scal/prob/weibull_cdf_log_test.cpp
@@ -1,0 +1,13 @@
+#include <stan/math/prim/scal.hpp>
+#include <gtest/gtest.h>
+
+TEST(ProbWeibull, cdf_log_matches_lcdf) {
+  double y = 0.8;
+  double alpha = 1.1;
+  double sigma = 2.3;
+
+  EXPECT_FLOAT_EQ((stan::math::weibull_lcdf(y, alpha, sigma)),
+                  (stan::math::weibull_cdf_log(y, alpha, sigma)));
+  EXPECT_FLOAT_EQ((stan::math::weibull_lcdf<double, double, double>(y, alpha, sigma)),
+                  (stan::math::weibull_cdf_log<double, double, double>(y, alpha, sigma)));
+}

--- a/test/unit/math/prim/scal/prob/weibull_log_test.cpp
+++ b/test/unit/math/prim/scal/prob/weibull_log_test.cpp
@@ -1,0 +1,21 @@
+#include <stan/math/prim/scal.hpp>
+#include <gtest/gtest.h>
+
+TEST(ProbWeibull, log_matches_lpdf) {
+  double y = 0.8;
+  double alpha = 1.1;
+  double sigma = 2.3;
+
+  EXPECT_FLOAT_EQ((stan::math::weibull_lpdf(y, alpha, sigma)),
+                  (stan::math::weibull_log(y, alpha, sigma)));
+  EXPECT_FLOAT_EQ((stan::math::weibull_lpdf<true>(y, alpha, sigma)),
+                  (stan::math::weibull_log<true>(y, alpha, sigma)));
+  EXPECT_FLOAT_EQ((stan::math::weibull_lpdf<false>(y, alpha, sigma)),
+                  (stan::math::weibull_log<false>(y, alpha, sigma)));
+  EXPECT_FLOAT_EQ((stan::math::weibull_lpdf<true, double, double, double>(y, alpha, sigma)),
+                  (stan::math::weibull_log<true, double, double, double>(y, alpha, sigma)));
+  EXPECT_FLOAT_EQ((stan::math::weibull_lpdf<false, double, double, double>(y, alpha, sigma)),
+                  (stan::math::weibull_log<false, double, double, double>(y, alpha, sigma)));
+  EXPECT_FLOAT_EQ((stan::math::weibull_lpdf<double, double, double>(y, alpha, sigma)),
+                  (stan::math::weibull_log<double, double, double>(y, alpha, sigma)));
+}

--- a/test/unit/math/prim/scal/prob/wiener_log_test.cpp
+++ b/test/unit/math/prim/scal/prob/wiener_log_test.cpp
@@ -1,0 +1,23 @@
+#include <stan/math/prim/scal.hpp>
+#include <gtest/gtest.h>
+
+TEST(ProbWiener, log_matches_lpdf) {
+  double y = 2.4;
+  double alpha = 2;
+  double tau = 1.2;
+  double beta = 0.3;
+  double delta = -5;
+
+  EXPECT_FLOAT_EQ((stan::math::wiener_lpdf(y, alpha, tau, beta, delta)),
+                  (stan::math::wiener_log(y, alpha, tau, beta, delta)));
+  EXPECT_FLOAT_EQ((stan::math::wiener_lpdf<true>(y, alpha, tau, beta, delta)),
+                  (stan::math::wiener_log<true>(y, alpha, tau, beta, delta)));
+  EXPECT_FLOAT_EQ((stan::math::wiener_lpdf<false>(y, alpha, tau, beta, delta)),
+                  (stan::math::wiener_log<false>(y, alpha, tau, beta, delta)));
+  EXPECT_FLOAT_EQ((stan::math::wiener_lpdf<true, double, double, double, double, double>(y, alpha, tau, beta, delta)),
+                  (stan::math::wiener_log<true, double, double, double, double, double>(y, alpha, tau, beta, delta)));
+  EXPECT_FLOAT_EQ((stan::math::wiener_lpdf<false, double, double, double, double, double>(y, alpha, tau, beta, delta)),
+                  (stan::math::wiener_log<false, double, double, double, double, double>(y, alpha, tau, beta, delta)));
+  EXPECT_FLOAT_EQ((stan::math::wiener_lpdf<double, double, double, double, double>(y, alpha, tau, beta, delta)),
+                  (stan::math::wiener_log<double, double, double, double, double>(y, alpha, tau, beta, delta)));
+}


### PR DESCRIPTION
#### Note on the 10 related pull requests
This is staged as follows:
- pull requests 1-7 will be adding new functions that mirror the old `_log` functions without altering the `_log` functions (except in situations where there are multiple definitions)
- pull requests 8-10 will deprecate the old functions and have the old functions call the new functions.

#### Submisison Checklist

- [x] Run unit tests: `./runTests.py test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary:
This pull request adds `_lpdf` and `_lpmf` functions that copy the original `_log` functions.
This function also adds tests that compare the original function with the new implementation.

#### How to Verify:
Look at code and run code.

#### Side Effects:
None.

#### Documentation:
As much doc as there was before.

#### Reviewer Suggestions: 
Anyone.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Columbia University.

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
