### PR TITLE
Updating probability functions. 8/10 pull requests.

### DIFF
--- a/stan/math/prim/mat/prob/categorical_log.hpp
+++ b/stan/math/prim/mat/prob/categorical_log.hpp
@@ -1,43 +1,26 @@
 #ifndef STAN_MATH_PRIM_MAT_PROB_CATEGORICAL_LOG_HPP
 #define STAN_MATH_PRIM_MAT_PROB_CATEGORICAL_LOG_HPP
 
-#include <stan/math/prim/mat/err/check_simplex.hpp>
-#include <stan/math/prim/scal/err/check_bounded.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/mat/fun/sum.hpp>
-#include <stan/math/prim/mat/meta/index_type.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <boost/random/uniform_01.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <cmath>
+#include <stan/math/prim/mat/prob/categorical_lpmf.hpp>
 #include <vector>
 
 namespace stan {
   namespace math {
 
-    // Categorical(n|theta)  [0 < n <= N;   0 <= theta[n] <= 1;  SUM theta = 1]
+    /**
+     * @deprecated use <code>categorical_lpmf</code>
+     */
     template <bool propto,
               typename T_prob>
     typename boost::math::tools::promote_args<T_prob>::type
     categorical_log(int n,
                     const Eigen::Matrix<T_prob, Eigen::Dynamic, 1>& theta) {
-      static const char* function("categorical_log");
-
-      using boost::math::tools::promote_args;
-      using std::log;
-
-      int lb = 1;
-
-      check_bounded(function, "Number of categories", n, lb, theta.size());
-      check_simplex(function, "Probabilities parameter", theta);
-
-      if (include_summand<propto, T_prob>::value)
-        return log(theta(n-1));
-      return 0.0;
+      return categorical_lpmf<propto, T_prob>(n, theta);
     }
 
+    /**
+     * @deprecated use <code>categorical_lpmf</code>
+     */
     template <typename T_prob>
     inline
     typename boost::math::tools::promote_args<T_prob>::type
@@ -45,51 +28,29 @@ namespace stan {
                     math::index_type<Eigen::Matrix<T_prob,
                     Eigen::Dynamic, 1> >::type n,
                     const Eigen::Matrix<T_prob, Eigen::Dynamic, 1>& theta) {
-      return categorical_log<false>(n, theta);
+      return categorical_lpmf<T_prob>(n, theta);
     }
 
+    /**
+     * @deprecated use <code>categorical_lpmf</code>
+     */
     template <bool propto,
               typename T_prob>
     typename boost::math::tools::promote_args<T_prob>::type
     categorical_log(const std::vector<int>& ns,
                     const Eigen::Matrix<T_prob, Eigen::Dynamic, 1>& theta) {
-      static const char* function("categorical_log");
-
-      using boost::math::tools::promote_args;
-      using std::log;
-
-      int lb = 1;
-
-      for (size_t i = 0; i < ns.size(); ++i)
-        check_bounded(function, "element of outcome array", ns[i],
-                      lb, theta.size());
-
-      check_simplex(function, "Probabilities parameter", theta);
-
-      if (!include_summand<propto, T_prob>::value)
-        return 0.0;
-
-      if (ns.size() == 0)
-        return 0.0;
-
-      Eigen::Matrix<T_prob, Eigen::Dynamic, 1> log_theta(theta.size());
-      for (int i = 0; i < theta.size(); ++i)
-        log_theta(i) = log(theta(i));
-
-      Eigen::Matrix<typename boost::math::tools::promote_args<T_prob>::type,
-                    Eigen::Dynamic, 1> log_theta_ns(ns.size());
-      for (size_t i = 0; i < ns.size(); ++i)
-        log_theta_ns(i) = log_theta(ns[i] - 1);
-
-      return sum(log_theta_ns);
+      return categorical_lpmf<propto, T_prob>(ns, theta);
     }
 
+    /**
+     * @deprecated use <code>categorical_lpmf</code>
+     */
     template <typename T_prob>
     inline
     typename boost::math::tools::promote_args<T_prob>::type
     categorical_log(const std::vector<int>& ns,
                     const Eigen::Matrix<T_prob, Eigen::Dynamic, 1>& theta) {
-      return categorical_log<false>(ns, theta);
+      return categorical_lpmf<false>(ns, theta);
     }
 
   }

--- a/stan/math/prim/mat/prob/categorical_logit_log.hpp
+++ b/stan/math/prim/mat/prob/categorical_logit_log.hpp
@@ -1,85 +1,58 @@
 #ifndef STAN_MATH_PRIM_MAT_PROB_CATEGORICAL_LOGIT_LOG_HPP
 #define STAN_MATH_PRIM_MAT_PROB_CATEGORICAL_LOGIT_LOG_HPP
 
-#include <stan/math/prim/scal/err/check_bounded.hpp>
-#include <stan/math/prim/scal/err/check_finite.hpp>
-#include <stan/math/prim/arr/fun/log_sum_exp.hpp>
-#include <stan/math/prim/mat/fun/log_softmax.hpp>
-#include <stan/math/prim/mat/fun/log_sum_exp.hpp>
-#include <stan/math/prim/mat/fun/sum.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <boost/math/tools/promotion.hpp>
+#include <stan/math/prim/mat/prob/categorical_logit_lpmf.hpp>
 #include <vector>
 
 namespace stan {
   namespace math {
 
-    // CategoricalLog(n|theta)  [0 < n <= N, theta unconstrained], no checking
+    /**
+     * @deprecated use <code>categorical_logit_lpmf</code>
+     */
     template <bool propto,
               typename T_prob>
     typename boost::math::tools::promote_args<T_prob>::type
     categorical_logit_log(int n,
                           const Eigen::Matrix<T_prob, Eigen::Dynamic, 1>&
                           beta) {
-      static const char* function("categorical_logit_log");
-
-      check_bounded(function, "categorical outcome out of support", n,
-                    1, beta.size());
-      check_finite(function, "log odds parameter", beta);
-
-      if (!include_summand<propto, T_prob>::value)
-        return 0.0;
-
-      // FIXME:  wasteful vs. creating term (n-1) if not vectorized
-      return beta(n-1) - log_sum_exp(beta);  // == log_softmax(beta)(n-1);
+      return categorical_logit_lpmf<propto, T_prob>(n, beta);
     }
 
+    /**
+     * @deprecated use <code>categorical_logit_lpmf</code>
+     */
     template <typename T_prob>
     inline
     typename boost::math::tools::promote_args<T_prob>::type
     categorical_logit_log(int n,
                           const Eigen::Matrix<T_prob, Eigen::Dynamic, 1>&
                           beta) {
-      return categorical_logit_log<false>(n, beta);
+      return categorical_logit_lpmf<T_prob>(n, beta);
     }
 
+    /**
+     * @deprecated use <code>categorical_logit_lpmf</code>
+     */
     template <bool propto,
               typename T_prob>
     typename boost::math::tools::promote_args<T_prob>::type
     categorical_logit_log(const std::vector<int>& ns,
                           const Eigen::Matrix<T_prob, Eigen::Dynamic, 1>&
                           beta) {
-      static const char* function("categorical_logit_log");
-
-      for (size_t k = 0; k < ns.size(); ++k)
-        check_bounded(function, "categorical outcome out of support",
-                      ns[k], 1, beta.size());
-      check_finite(function, "log odds parameter", beta);
-
-      if (!include_summand<propto, T_prob>::value)
-        return 0.0;
-
-      if (ns.size() == 0)
-        return 0.0;
-
-      Eigen::Matrix<T_prob, Eigen::Dynamic, 1> log_softmax_beta
-        = log_softmax(beta);
-
-      // FIXME:  replace with more efficient sum()
-      Eigen::Matrix<typename boost::math::tools::promote_args<T_prob>::type,
-                    Eigen::Dynamic, 1> results(ns.size());
-      for (size_t i = 0; i < ns.size(); ++i)
-        results[i] = log_softmax_beta(ns[i] - 1);
-      return sum(results);
+      return categorical_logit_lpmf<propto, T_prob>(ns, beta);
     }
 
+    /**
+     * @deprecated use <code>categorical_logit_lpmf</code>
+     */
     template <typename T_prob>
     inline
     typename boost::math::tools::promote_args<T_prob>::type
     categorical_logit_log(const std::vector<int>& ns,
                           const Eigen::Matrix<T_prob, Eigen::Dynamic, 1>&
                           beta) {
-      return categorical_logit_log<false>(ns, beta);
+      return categorical_logit_lpmf<T_prob>(ns, beta);
     }
 
   }

--- a/stan/math/prim/mat/prob/dirichlet_log.hpp
+++ b/stan/math/prim/mat/prob/dirichlet_log.hpp
@@ -1,15 +1,7 @@
 #ifndef STAN_MATH_PRIM_MAT_PROB_DIRICHLET_LOG_HPP
 #define STAN_MATH_PRIM_MAT_PROB_DIRICHLET_LOG_HPP
 
-#include <boost/math/special_functions/gamma.hpp>
-#include <boost/random/gamma_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <stan/math/prim/mat/err/check_simplex.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_positive.hpp>
-#include <stan/math/prim/scal/fun/multiply_log.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
+#include <stan/math/prim/mat/prob/dirichlet_lpmf.hpp>
 
 namespace stan {
   namespace math {
@@ -21,13 +13,7 @@ namespace stan {
      * Each element of theta must be greater than or 0.
      * Theta sums to 1.
      *
-     * \f{eqnarray*}{
-     \theta &\sim& \mbox{\sf{Dirichlet}} (\alpha_1, \ldots, \alpha_k) \\
-     \log (p (\theta \, |\, \alpha_1, \ldots, \alpha_k) ) &=& \log \left( \frac{\Gamma(\alpha_1 + \cdots + \alpha_k)}{\Gamma(\alpha_1) \cdots \Gamma(\alpha_k)}
-     \theta_1^{\alpha_1 - 1} \cdots \theta_k^{\alpha_k - 1} \right) \\
-     &=& \log (\Gamma(\alpha_1 + \cdots + \alpha_k)) - \log(\Gamma(\alpha_1)) - \cdots - \log(\Gamma(\alpha_k)) +
-     (\alpha_1 - 1) \log (\theta_1) + \cdots + (\alpha_k - 1) \log (\theta_k)
-     \f}
+     * @deprecated use <code>dirichlet_lpmf</code>
      *
      * @param theta A scalar vector.
      * @param alpha Prior sample sizes.
@@ -45,36 +31,19 @@ namespace stan {
     dirichlet_log(const Eigen::Matrix<T_prob, Eigen::Dynamic, 1>& theta,
                   const Eigen::Matrix
                   <T_prior_sample_size, Eigen::Dynamic, 1>& alpha) {
-      static const char* function("dirichlet_log");
-      using boost::math::lgamma;
-      using boost::math::tools::promote_args;
-
-      typename promote_args<T_prob, T_prior_sample_size>::type lp(0.0);
-      check_consistent_sizes(function,
-                             "probabilities", theta,
-                             "prior sample sizes", alpha);
-      check_positive(function, "prior sample sizes", alpha);
-      check_simplex(function, "probabilities", theta);
-
-      if (include_summand<propto, T_prior_sample_size>::value) {
-        lp += lgamma(alpha.sum());
-        for (int k = 0; k < alpha.rows(); ++k)
-          lp -= lgamma(alpha[k]);
-      }
-      if (include_summand<propto, T_prob, T_prior_sample_size>::value) {
-        for (int k = 0; k < theta.rows(); ++k)
-          lp += multiply_log(alpha[k]-1, theta[k]);
-      }
-      return lp;
+      return dirichlet_lpmf<propto, T_prob, T_prior_sample_size>(theta, alpha);
     }
 
+    /**
+     * @deprecated use <code>dirichlet_lpmf</code>
+     */
     template <typename T_prob, typename T_prior_sample_size>
     inline
     typename boost::math::tools::promote_args<T_prob, T_prior_sample_size>::type
     dirichlet_log(const Eigen::Matrix<T_prob, Eigen::Dynamic, 1>& theta,
                   const Eigen::Matrix
                   <T_prior_sample_size, Eigen::Dynamic, 1>& alpha) {
-      return dirichlet_log<false>(theta, alpha);
+      return dirichlet_lpmf<T_prob, T_prior_sample_size>(theta, alpha);
     }
 
   }

--- a/stan/math/prim/mat/prob/gaussian_dlm_obs_log.hpp
+++ b/stan/math/prim/mat/prob/gaussian_dlm_obs_log.hpp
@@ -1,36 +1,8 @@
 #ifndef STAN_MATH_PRIM_MAT_PROB_GAUSSIAN_DLM_OBS_LOG_HPP
 #define STAN_MATH_PRIM_MAT_PROB_GAUSSIAN_DLM_OBS_LOG_HPP
 
-#include <boost/random/normal_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <stan/math/prim/mat/err/check_cov_matrix.hpp>
-#include <stan/math/prim/scal/err/check_size_match.hpp>
-#include <stan/math/prim/mat/err/check_spsd_matrix.hpp>
-#include <stan/math/prim/scal/err/check_finite.hpp>
-#include <stan/math/prim/scal/err/check_nonnegative.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/mat/fun/add.hpp>
-#include <stan/math/prim/mat/fun/dot_product.hpp>
-#include <stan/math/prim/mat/fun/inverse_spd.hpp>
-#include <stan/math/prim/mat/fun/log.hpp>
-#include <stan/math/prim/mat/fun/log_determinant_spd.hpp>
-#include <stan/math/prim/mat/fun/multiply.hpp>
-#include <stan/math/prim/mat/fun/quad_form.hpp>
-#include <stan/math/prim/mat/fun/quad_form_sym.hpp>
-#include <stan/math/prim/mat/fun/subtract.hpp>
-#include <stan/math/prim/mat/fun/tcrossprod.hpp>
-#include <stan/math/prim/mat/fun/trace_quad_form.hpp>
-#include <stan/math/prim/mat/fun/transpose.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <stan/math/prim/scal/meta/return_type.hpp>
+#include <stan/math/prim/mat/prob/gaussian_dlm_obs_lpdf.hpp>
 
-/*
-  TODO: time-varying system matrices
-  TODO: use sequential processing even for non-diagonal obs
-  covariance.
-  TODO: add constant terms in observation.
-*/
 namespace stan {
   namespace math {
     /**
@@ -44,6 +16,8 @@ namespace stan {
      *
      * If V is a vector, then the Kalman filter is applied
      * sequentially.
+     *
+     * @deprecated use <code>gaussian_dlm_obs_lpdf</code>
      *
      * @param y A r x T matrix of observations. Rows are variables,
      * columns are observations.
@@ -88,108 +62,13 @@ namespace stan {
                          const Eigen::Matrix<T_m0, Eigen::Dynamic, 1>& m0,
                          const Eigen::Matrix
                          <T_C0, Eigen::Dynamic, Eigen::Dynamic>& C0) {
-      static const char* function("gaussian_dlm_obs_log");
-      typedef typename return_type<
-        T_y,
-        typename return_type<T_F, T_G, T_V, T_W, T_m0, T_C0>::type>::type T_lp;
-      T_lp lp(0.0);
-
-      int r = y.rows();  // number of variables
-      int T = y.cols();  // number of observations
-      int n = G.rows();  // number of states
-
-      check_finite(function, "y", y);
-      check_not_nan(function, "y", y);
-      check_size_match(function,
-                       "columns of F", F.cols(),
-                       "rows of y", y.rows());
-      check_size_match(function,
-                       "rows of F", F.rows(),
-                       "rows of G", G.rows());
-      check_finite(function, "F", F);
-      check_square(function, "G", G);
-      check_finite(function, "G", G);
-      check_size_match(function,
-                       "rows of V", V.rows(),
-                       "rows of y", y.rows());
-      // TODO(anyone): incorporate support for infinite V
-      check_finite(function, "V", V);
-      check_spsd_matrix(function, "V", V);
-      check_size_match(function,
-                       "rows of W", W.rows(),
-                       "rows of G", G.rows());
-      // TODO(anyone): incorporate support for infinite W
-      check_finite(function, "W", W);
-      check_spsd_matrix(function, "W", W);
-      check_size_match(function,
-                       "size of m0", m0.size(),
-                       "rows of G", G.rows());
-      check_finite(function, "m0", m0);
-      check_size_match(function,
-                       "rows of C0", C0.rows(),
-                       "rows of G", G.rows());
-      check_cov_matrix(function, "C0", C0);
-      check_finite(function, "C0", C0);
-
-      if (y.cols() == 0 || y.rows() == 0)
-        return lp;
-
-      if (include_summand<propto>::value) {
-        lp -= 0.5 * LOG_TWO_PI * r * T;
-      }
-
-      if (include_summand<propto, T_y, T_F, T_G, T_V, T_W, T_m0, T_C0>::value) {
-        Eigen::Matrix<T_lp, Eigen::Dynamic, 1> m(n);
-        Eigen::Matrix<T_lp, Eigen::Dynamic, Eigen::Dynamic> C(n, n);
-
-        // TODO(anyone): how to recast matrices
-        for (int i = 0; i < m0.size(); i++) {
-          m(i) = m0(i);
-        }
-        for (int i = 0; i < C0.rows(); i++) {
-          for (int j = 0; j < C0.cols(); j++) {
-            C(i, j) = C0(i, j);
-          }
-        }
-
-        Eigen::Matrix<typename return_type<T_y>::type,
-                      Eigen::Dynamic, 1> yi(r);
-        Eigen::Matrix<T_lp, Eigen::Dynamic, 1> a(n);
-        Eigen::Matrix<T_lp, Eigen::Dynamic, Eigen::Dynamic> R(n, n);
-        Eigen::Matrix<T_lp, Eigen::Dynamic, 1> f(r);
-        Eigen::Matrix<T_lp, Eigen::Dynamic, Eigen::Dynamic> Q(r, r);
-        Eigen::Matrix<T_lp, Eigen::Dynamic, Eigen::Dynamic> Q_inv(r, r);
-        Eigen::Matrix<T_lp, Eigen::Dynamic, 1> e(r);
-        Eigen::Matrix<T_lp, Eigen::Dynamic, Eigen::Dynamic> A(n, r);
-
-        for (int i = 0; i < y.cols(); i++) {
-          yi = y.col(i);
-          // // Predict state
-          // a_t = G_t m_{t-1}
-          a = multiply(G, m);
-          // R_t = G_t C_{t-1} G_t' + W_t
-          R = add(quad_form_sym(C, transpose(G)), W);
-          // // predict observation
-          // f_t = F_t' a_t
-          f = multiply(transpose(F), a);
-          // Q_t = F'_t R_t F_t + V_t
-          Q = add(quad_form_sym(R, F), V);
-          Q_inv = inverse_spd(Q);
-          // // filtered state
-          // e_t = y_t - f_t
-          e = subtract(yi, f);
-          // A_t = R_t F_t Q^{-1}_t
-          A = multiply(multiply(R, F), Q_inv);
-          // m_t = a_t + A_t e_t
-          m = add(a, multiply(A, e));
-          // C = R_t - A_t Q_t A_t'
-          C = subtract(R, quad_form_sym(Q, transpose(A)));
-          lp -= 0.5 * (log_determinant_spd(Q) + trace_quad_form(Q_inv, e));
-        }
-      }
-      return lp;
+      return gaussian_dlm_obs_lpdf<propto, T_y, T_F, T_G,
+                                   T_V, T_W, T_m0, T_C0>(y, F, G, V, W, m0, C0);
     }
 
+    /**
+     * @deprecated use <code>gaussian_dlm_obs_lpdf</code>
+     */
     template <typename T_y,
               typename T_F, typename T_G,
               typename T_V, typename T_W,
@@ -212,7 +91,8 @@ namespace stan {
                          const Eigen::Matrix<T_m0, Eigen::Dynamic, 1>& m0,
                          const Eigen::Matrix
                          <T_C0, Eigen::Dynamic, Eigen::Dynamic>& C0) {
-      return gaussian_dlm_obs_log<false>(y, F, G, V, W, m0, C0);
+      return gaussian_dlm_obs_lpdf<T_y, T_F, T_G,
+                                   T_V, T_W, T_m0, T_C0>(y, F, G, V, W, m0, C0);
     }
 
     /**
@@ -227,6 +107,8 @@ namespace stan {
      *
      * If V is a vector, then the Kalman filter is applied
      * sequentially.
+     *
+     * @deprecated use <code>gaussian_dlm_obs_lpdf</code>
      *
      * @param y A r x T matrix of observations. Rows are variables,
      * columns are observations.
@@ -271,122 +153,13 @@ namespace stan {
                          const Eigen::Matrix<T_m0, Eigen::Dynamic, 1>& m0,
                          const Eigen::Matrix
                          <T_C0, Eigen::Dynamic, Eigen::Dynamic>& C0) {
-      static const char* function("gaussian_dlm_obs_log");
-      typedef
-        typename return_type
-        <T_y, typename return_type<T_F, T_G, T_V, T_W, T_m0, T_C0>::type>::type
-        T_lp;
-      T_lp lp(0.0);
-
-      using std::log;
-
-      int r = y.rows();  // number of variables
-      int T = y.cols();  // number of observations
-      int n = G.rows();  // number of states
-
-      check_finite(function, "y", y);
-      check_not_nan(function, "y", y);
-      check_size_match(function,
-                       "columns of F", F.cols(),
-                       "rows of y", y.rows());
-      check_size_match(function,
-                       "rows of F", F.rows(),
-                       "rows of G", G.rows());
-      check_finite(function, "F", F);
-      check_not_nan(function, "F", F);
-      check_size_match(function,
-                       "rows of G", G.rows(),
-                       "columns of G", G.cols());
-      check_finite(function, "G", G);
-      check_not_nan(function, "G", G);
-      check_nonnegative(function, "V", V);
-      check_size_match(function,
-                       "size of V", V.size(),
-                       "rows of y", y.rows());
-      // TODO(anyone): support infinite V
-      check_finite(function, "V", V);
-      check_not_nan(function, "V", V);
-      check_spsd_matrix(function, "W", W);
-      check_size_match(function,
-                       "rows of W", W.rows(),
-                       "rows of G", G.rows());
-      // TODO(anyone): support infinite W
-      check_finite(function, "W", W);
-      check_not_nan(function, "W", W);
-      check_size_match(function,
-                       "size of m0", m0.size(),
-                       "rows of G", G.rows());
-      check_finite(function, "m0", m0);
-      check_not_nan(function, "m0", m0);
-      check_cov_matrix(function, "C0", C0);
-      check_size_match(function,
-                       "rows of C0", C0.rows(),
-                       "rows of G", G.rows());
-      check_finite(function, "C0", C0);
-      check_not_nan(function, "C0", C0);
-
-      if (y.cols() == 0 || y.rows() == 0)
-        return lp;
-
-      if (include_summand<propto>::value) {
-        lp += 0.5 * NEG_LOG_TWO_PI * r * T;
-      }
-
-      if (include_summand<propto, T_y, T_F, T_G, T_V, T_W, T_m0, T_C0>::value) {
-        T_lp f;
-        T_lp Q;
-        T_lp Q_inv;
-        T_lp e;
-        Eigen::Matrix<T_lp, Eigen::Dynamic, 1> A(n);
-        Eigen::Matrix<T_lp, Eigen::Dynamic, 1> Fj(n);
-        Eigen::Matrix<T_lp, Eigen::Dynamic, 1> m(n);
-        Eigen::Matrix<T_lp, Eigen::Dynamic, Eigen::Dynamic> C(n, n);
-
-        // TODO(anyone): how to recast matrices
-        for (int i = 0; i < m0.size(); i++) {
-          m(i) = m0(i);
-        }
-        for (int i = 0; i < C0.rows(); i++) {
-          for (int j = 0; j < C0.cols(); j++) {
-            C(i, j) = C0(i, j);
-          }
-        }
-
-        for (int i = 0; i < y.cols(); i++) {
-          // Predict state
-          // reuse m and C instead of using a and R
-          m = multiply(G, m);
-          C = add(quad_form_sym(C, transpose(G)), W);
-          for (int j = 0; j < y.rows(); ++j) {
-            // predict observation
-            T_lp yij(y(j, i));
-            // dim Fj = (n, 1)
-            for (int k = 0; k < F.rows(); ++k) {
-              Fj(k) = F(k, j);
-            }
-            // f_{t, i} = F_{t, i}' m_{t, i-1}
-            f = dot_product(Fj, m);
-            Q = trace_quad_form(C, Fj) + V(j);
-            Q_inv = 1.0 / Q;
-            // filtered observation
-            // e_{t, i} = y_{t, i} - f_{t, i}
-            e = yij - f;
-            // A_{t, i} = C_{t, i-1} F_{t, i} Q_{t, i}^{-1}
-            A = multiply(multiply(C, Fj), Q_inv);
-            // m_{t, i} = m_{t, i-1} + A_{t, i} e_{t, i}
-            m += multiply(A, e);
-            // c_{t, i} = C_{t, i-1} - Q_{t, i} A_{t, i} A_{t, i}'
-            // tcrossprod throws an error (ambiguous)
-            // C = subtract(C, multiply(Q, tcrossprod(A)));
-            C -= multiply(Q, multiply(A, transpose(A)));
-            C = 0.5 * add(C, transpose(C));
-            lp -= 0.5 * (log(Q) + pow(e, 2) * Q_inv);
-          }
-        }
-      }
-      return lp;
+      return gaussian_dlm_obs_lpdf<propto, T_y, T_F, T_G,
+                                   T_V, T_W, T_m0, T_C0>(y, F, G, V, W, m0, C0);
     }
 
+    /**
+     * @deprecated use <code>gaussian_dlm_obs_lpdf</code>
+     */
     template <typename T_y,
               typename T_F, typename T_G,
               typename T_V, typename T_W,
@@ -402,7 +175,8 @@ namespace stan {
      const Eigen::Matrix<T_W, Eigen::Dynamic, Eigen::Dynamic>& W,
      const Eigen::Matrix<T_m0, Eigen::Dynamic, 1>& m0,
      const Eigen::Matrix<T_C0, Eigen::Dynamic, Eigen::Dynamic>& C0) {
-      return gaussian_dlm_obs_log<false>(y, F, G, V, W, m0, C0);
+      return gaussian_dlm_obs_lpdf<T_y, T_F, T_G,
+                                   T_V, T_W, T_m0, T_C0>(y, F, G, V, W, m0, C0);
     }
 
   }

--- a/stan/math/prim/mat/prob/inv_wishart_log.hpp
+++ b/stan/math/prim/mat/prob/inv_wishart_log.hpp
@@ -1,20 +1,11 @@
 #ifndef STAN_MATH_PRIM_MAT_PROB_INV_WISHART_LOG_HPP
 #define STAN_MATH_PRIM_MAT_PROB_INV_WISHART_LOG_HPP
 
-#include <stan/math/prim/mat/err/check_ldlt_factor.hpp>
-#include <stan/math/prim/scal/err/check_greater.hpp>
-#include <stan/math/prim/scal/err/check_size_match.hpp>
-#include <stan/math/prim/mat/err/check_square.hpp>
-#include <stan/math/prim/mat/meta/index_type.hpp>
-#include <stan/math/prim/mat/fun/log_determinant_ldlt.hpp>
-#include <stan/math/prim/mat/fun/mdivide_left_ldlt.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <stan/math/prim/scal/fun/lmgamma.hpp>
-#include <stan/math/prim/mat/fun/trace.hpp>
+#include <stan/math/prim/mat/prob/inv_wishart_lpdf.hpp>
 
 namespace stan {
   namespace math {
+
     /**
      * The log of the Inverse-Wishart density for the given W, degrees
      * of freedom, and scale matrix.
@@ -22,14 +13,7 @@ namespace stan {
      * The scale matrix, S, must be k x k, symmetric, and semi-positive
      * definite.
      *
-     * \f{eqnarray*}{
-     W &\sim& \mbox{\sf{Inv-Wishart}}_{\nu} (S) \\
-     \log (p (W \, |\, \nu, S) ) &=& \log \left( \left(2^{\nu k/2} \pi^{k (k-1) /4} \prod_{i=1}^k{\Gamma (\frac{\nu + 1 - i}{2})} \right)^{-1}
-     \times \left| S \right|^{\nu/2} \left| W \right|^{-(\nu + k + 1) / 2}
-     \times \exp (-\frac{1}{2} \mbox{tr} (S W^{-1})) \right) \\
-     &=& -\frac{\nu k}{2}\log(2) - \frac{k (k-1)}{4} \log(\pi) - \sum_{i=1}^{k}{\log (\Gamma (\frac{\nu+1-i}{2}))}
-     +\frac{\nu}{2} \log(\det(S)) - \frac{\nu+k+1}{2}\log (\det(W)) - \frac{1}{2} \mbox{tr}(S W^{-1})
-     \f}
+     * @deprecated use <code>inverse_wishart_lpdf</code>
      *
      * @param W A scalar matrix
      * @param nu Degrees of freedom
@@ -49,59 +33,12 @@ namespace stan {
                     const T_dof& nu,
                     const Eigen::Matrix
                     <T_scale, Eigen::Dynamic, Eigen::Dynamic>& S) {
-      static const char* function("inv_wishart_log");
-
-      using boost::math::tools::promote_args;
-      using Eigen::Dynamic;
-      using Eigen::Matrix;
-
-      typename index_type<Matrix<T_scale, Dynamic, Dynamic> >::type k
-        = S.rows();
-      typename promote_args<T_y, T_dof, T_scale>::type lp(0.0);
-
-      check_greater(function, "Degrees of freedom parameter", nu, k-1);
-      check_square(function, "random variable", W);
-      check_square(function, "scale parameter", S);
-      check_size_match(function,
-                       "Rows of random variable", W.rows(),
-                       "columns of scale parameter", S.rows());
-
-      LDLT_factor<T_y, Eigen::Dynamic, Eigen::Dynamic> ldlt_W(W);
-      check_ldlt_factor(function, "LDLT_Factor of random variable", ldlt_W);
-      LDLT_factor<T_scale, Eigen::Dynamic, Eigen::Dynamic> ldlt_S(S);
-      check_ldlt_factor(function, "LDLT_Factor of scale parameter", ldlt_S);
-
-      if (include_summand<propto, T_dof>::value)
-        lp -= lmgamma(k, 0.5 * nu);
-      if (include_summand<propto, T_dof, T_scale>::value) {
-        lp += 0.5 * nu * log_determinant_ldlt(ldlt_S);
-      }
-      if (include_summand<propto, T_y, T_dof, T_scale>::value) {
-        lp -= 0.5 * (nu + k + 1.0) * log_determinant_ldlt(ldlt_W);
-      }
-      if (include_summand<propto, T_y, T_scale>::value) {
-        //    L = crossprod(mdivide_left_tri_low(L));
-        //    Eigen::Matrix<T_y, Eigen::Dynamic, 1> W_inv_vec = Eigen::Map<
-        //      const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic> >(
-        //      &L(0), L.size(), 1);
-        //    Eigen::Matrix<T_scale, Eigen::Dynamic, 1> S_vec = Eigen::Map<
-        //      const Eigen::Matrix<T_scale, Eigen::Dynamic, Eigen::Dynamic> >(
-        //      &S(0), S.size(), 1);
-        //    lp -= 0.5 * dot_product(S_vec, W_inv_vec); // trace(S * W^-1)
-        Eigen::Matrix<typename promote_args<T_y, T_scale>::type,
-                      Eigen::Dynamic, Eigen::Dynamic>
-          Winv_S(mdivide_left_ldlt
-                 (ldlt_W,
-                  static_cast<Eigen::Matrix
-                  <T_scale, Eigen::Dynamic, Eigen::Dynamic> >
-                  (S.template selfadjointView<Eigen::Lower>())));
-        lp -= 0.5*trace(Winv_S);
-      }
-      if (include_summand<propto, T_dof, T_scale>::value)
-        lp += nu * k * NEG_LOG_TWO_OVER_TWO;
-      return lp;
+      return inv_wishart_lpdf<propto, T_y, T_dof, T_scale>(W, nu, S);
     }
 
+    /**
+     * @deprecated use <code>inverse_wishart_lpdf</code>
+     */       
     template <typename T_y, typename T_dof, typename T_scale>
     inline
     typename boost::math::tools::promote_args<T_y, T_dof, T_scale>::type
@@ -109,7 +46,7 @@ namespace stan {
                     const T_dof& nu,
                     const Eigen::Matrix
                     <T_scale, Eigen::Dynamic, Eigen::Dynamic>& S) {
-      return inv_wishart_log<false>(W, nu, S);
+      return inv_wishart_lpdf<T_y, T_dof, T_scale>(W, nu, S);
     }
 
   }

--- a/stan/math/prim/mat/prob/lkj_corr_cholesky_log.hpp
+++ b/stan/math/prim/mat/prob/lkj_corr_cholesky_log.hpp
@@ -1,102 +1,33 @@
 #ifndef STAN_MATH_PRIM_MAT_PROB_LKJ_CORR_CHOLESKY_LOG_HPP
 #define STAN_MATH_PRIM_MAT_PROB_LKJ_CORR_CHOLESKY_LOG_HPP
 
-#include <stan/math/prim/scal/err/check_finite.hpp>
-#include <stan/math/prim/scal/err/check_positive.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <stan/math/prim/mat/fun/factor_cov_matrix.hpp>
-#include <stan/math/prim/mat/fun/factor_U.hpp>
-#include <stan/math/prim/mat/fun/read_corr_L.hpp>
-#include <stan/math/prim/mat/fun/read_corr_matrix.hpp>
-#include <stan/math/prim/mat/fun/read_cov_L.hpp>
-#include <stan/math/prim/mat/fun/read_cov_matrix.hpp>
-#include <stan/math/prim/mat/fun/make_nu.hpp>
-#include <stan/math/prim/scal/fun/identity_constrain.hpp>
-#include <stan/math/prim/scal/fun/identity_free.hpp>
-#include <stan/math/prim/scal/fun/positive_constrain.hpp>
-#include <stan/math/prim/scal/fun/positive_free.hpp>
-#include <stan/math/prim/scal/fun/lb_constrain.hpp>
-#include <stan/math/prim/scal/fun/lb_free.hpp>
-#include <stan/math/prim/scal/fun/ub_constrain.hpp>
-#include <stan/math/prim/scal/fun/ub_free.hpp>
-#include <stan/math/prim/scal/fun/lub_constrain.hpp>
-#include <stan/math/prim/scal/fun/lub_free.hpp>
-#include <stan/math/prim/scal/fun/prob_constrain.hpp>
-#include <stan/math/prim/scal/fun/prob_free.hpp>
-#include <stan/math/prim/scal/fun/corr_constrain.hpp>
-#include <stan/math/prim/scal/fun/corr_free.hpp>
-#include <stan/math/prim/mat/fun/simplex_constrain.hpp>
-#include <stan/math/prim/mat/fun/simplex_free.hpp>
-#include <stan/math/prim/mat/fun/ordered_constrain.hpp>
-#include <stan/math/prim/mat/fun/ordered_free.hpp>
-#include <stan/math/prim/mat/fun/positive_ordered_constrain.hpp>
-#include <stan/math/prim/mat/fun/positive_ordered_free.hpp>
-#include <stan/math/prim/mat/fun/cholesky_factor_constrain.hpp>
-#include <stan/math/prim/mat/fun/cholesky_factor_free.hpp>
-#include <stan/math/prim/mat/fun/cholesky_corr_constrain.hpp>
-#include <stan/math/prim/mat/fun/cholesky_corr_free.hpp>
-#include <stan/math/prim/mat/fun/corr_matrix_constrain.hpp>
-#include <stan/math/prim/mat/fun/corr_matrix_free.hpp>
-#include <stan/math/prim/mat/fun/cov_matrix_constrain.hpp>
-#include <stan/math/prim/mat/fun/cov_matrix_free.hpp>
-#include <stan/math/prim/mat/fun/cov_matrix_constrain_lkj.hpp>
-#include <stan/math/prim/mat/fun/cov_matrix_free_lkj.hpp>
-#include <stan/math/prim/mat/prob/lkj_corr_log.hpp>
-#include <stan/math/prim/mat/fun/multiply.hpp>
+#include <stan/math/prim/mat/prob/lkj_corr_cholesky_lpdf.hpp>
 
 namespace stan {
   namespace math {
 
-    // LKJ_Corr(L|eta) [ L Cholesky factor of correlation matrix
-    //                  eta > 0; eta == 1 <-> uniform]
+    /**
+     * @deprecated use <code>lkj_corr_cholesky_lpdf</code>
+     */
     template <bool propto,
               typename T_covar, typename T_shape>
     typename boost::math::tools::promote_args<T_covar, T_shape>::type
     lkj_corr_cholesky_log(const Eigen::Matrix
                           <T_covar, Eigen::Dynamic, Eigen::Dynamic>& L,
                           const T_shape& eta) {
-      static const char* function("lkj_corr_cholesky_log");
-
-      using boost::math::tools::promote_args;
-
-      typedef typename promote_args<T_covar, T_shape>::type lp_ret;
-      lp_ret lp(0.0);
-      check_positive(function, "Shape parameter", eta);
-      check_lower_triangular(function, "Random variable", L);
-
-      const unsigned int K = L.rows();
-      if (K == 0)
-        return 0.0;
-
-      if (include_summand<propto, T_shape>::value)
-        lp += do_lkj_constant(eta, K);
-      if (include_summand<propto, T_covar, T_shape>::value) {
-        const int Km1 = K - 1;
-        Eigen::Matrix<T_covar, Eigen::Dynamic, 1> log_diagonals =
-          L.diagonal().tail(Km1).array().log();
-        Eigen::Matrix<lp_ret, Eigen::Dynamic, 1> values(Km1);
-        for (int k = 0; k < Km1; k++)
-          values(k) = (Km1 - k - 1) * log_diagonals(k);
-        if ( (eta == 1.0) &&
-             stan::is_constant<typename stan::scalar_type<T_shape> >::value) {
-          lp += sum(values);
-          return(lp);
-        }
-        values += multiply(2.0 * eta - 2.0, log_diagonals);
-        lp += sum(values);
-      }
-
-      return lp;
+      return lkj_corr_cholesky_lpdf<propto, T_covar, T_shape>(L, eta);
     }
 
+    /**
+     * @deprecated use <code>lkj_corr_cholesky_lpdf</code>
+     */
     template <typename T_covar, typename T_shape>
     inline
     typename boost::math::tools::promote_args<T_covar, T_shape>::type
     lkj_corr_cholesky_log(const Eigen::Matrix
                           <T_covar, Eigen::Dynamic, Eigen::Dynamic>& L,
                           const T_shape& eta) {
-      return lkj_corr_cholesky_log<false>(L, eta);
+      return lkj_corr_cholesky_lpdf<T_covar, T_shape>(L, eta);
     }
 
   }

--- a/stan/math/prim/mat/prob/lkj_corr_log.hpp
+++ b/stan/math/prim/mat/prob/lkj_corr_log.hpp
@@ -1,121 +1,31 @@
 #ifndef STAN_MATH_PRIM_MAT_PROB_LKJ_CORR_LOG_HPP
 #define STAN_MATH_PRIM_MAT_PROB_LKJ_CORR_LOG_HPP
 
-#include <stan/math/prim/mat/err/check_corr_matrix.hpp>
-#include <stan/math/prim/scal/err/check_finite.hpp>
-#include <stan/math/prim/scal/err/check_positive.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <stan/math/prim/scal/fun/lgamma.hpp>
-#include <stan/math/prim/mat/fun/factor_cov_matrix.hpp>
-#include <stan/math/prim/mat/fun/factor_U.hpp>
-#include <stan/math/prim/mat/fun/read_corr_L.hpp>
-#include <stan/math/prim/mat/fun/read_corr_matrix.hpp>
-#include <stan/math/prim/mat/fun/read_cov_L.hpp>
-#include <stan/math/prim/mat/fun/read_cov_matrix.hpp>
-#include <stan/math/prim/mat/fun/make_nu.hpp>
-#include <stan/math/prim/scal/fun/identity_constrain.hpp>
-#include <stan/math/prim/scal/fun/identity_free.hpp>
-#include <stan/math/prim/scal/fun/positive_constrain.hpp>
-#include <stan/math/prim/scal/fun/positive_free.hpp>
-#include <stan/math/prim/scal/fun/lb_constrain.hpp>
-#include <stan/math/prim/scal/fun/lb_free.hpp>
-#include <stan/math/prim/scal/fun/ub_constrain.hpp>
-#include <stan/math/prim/scal/fun/ub_free.hpp>
-#include <stan/math/prim/scal/fun/lub_constrain.hpp>
-#include <stan/math/prim/scal/fun/lub_free.hpp>
-#include <stan/math/prim/scal/fun/prob_constrain.hpp>
-#include <stan/math/prim/scal/fun/prob_free.hpp>
-#include <stan/math/prim/scal/fun/corr_constrain.hpp>
-#include <stan/math/prim/scal/fun/corr_free.hpp>
-#include <stan/math/prim/mat/fun/simplex_constrain.hpp>
-#include <stan/math/prim/mat/fun/simplex_free.hpp>
-#include <stan/math/prim/mat/fun/ordered_constrain.hpp>
-#include <stan/math/prim/mat/fun/ordered_free.hpp>
-#include <stan/math/prim/mat/fun/positive_ordered_constrain.hpp>
-#include <stan/math/prim/mat/fun/positive_ordered_free.hpp>
-#include <stan/math/prim/mat/fun/cholesky_factor_constrain.hpp>
-#include <stan/math/prim/mat/fun/cholesky_factor_free.hpp>
-#include <stan/math/prim/mat/fun/cholesky_corr_constrain.hpp>
-#include <stan/math/prim/mat/fun/cholesky_corr_free.hpp>
-#include <stan/math/prim/mat/fun/corr_matrix_constrain.hpp>
-#include <stan/math/prim/mat/fun/corr_matrix_free.hpp>
-#include <stan/math/prim/mat/fun/cov_matrix_constrain.hpp>
-#include <stan/math/prim/mat/fun/cov_matrix_free.hpp>
-#include <stan/math/prim/mat/fun/cov_matrix_constrain_lkj.hpp>
-#include <stan/math/prim/mat/fun/cov_matrix_free_lkj.hpp>
-#include <stan/math/prim/mat/fun/sum.hpp>
+#include <stan/math/prim/mat/prob/lkj_corr_lpdf.hpp>
 
 namespace stan {
   namespace math {
 
-    template <typename T_shape>
-    T_shape do_lkj_constant(const T_shape& eta, const unsigned int& K) {
-      // Lewandowski, Kurowicka, and Joe (2009) theorem 5
-      T_shape constant;
-      const int Km1 = K - 1;
-      if (eta == 1.0) {
-        // C++ integer division is appropriate in this block
-        Eigen::VectorXd numerator(Km1 / 2);
-        for (int k = 1; k <= numerator.rows(); k++)
-          numerator(k - 1) = lgamma(2.0 * k);
-        constant = sum(numerator);
-        if ((K % 2) == 1)
-          constant += 0.25 * (K * K - 1) * LOG_PI
-            - 0.25 * (Km1 * Km1) * LOG_TWO - Km1 * lgamma(0.5 * (K + 1));
-        else
-          constant += 0.25 * K * (K - 2) * LOG_PI
-            + 0.25 * (3 * K * K - 4 * K) * LOG_TWO
-            + K * lgamma(0.5 * K) - Km1 * lgamma(static_cast<double>(K));
-      } else {
-        constant = -Km1 * lgamma(eta + 0.5 * Km1);
-        for (int k = 1; k <= Km1; k++)
-          constant += 0.5 * k * LOG_PI + lgamma(eta + 0.5 * (Km1 - k));
-      }
-      return constant;
-    }
-
-    // LKJ_Corr(y|eta) [ y correlation matrix (not covariance matrix)
-    //                  eta > 0; eta == 1 <-> uniform]
+    /**
+     * @deprecated use <code>lkj_corr_lpdf</code>
+     */
     template <bool propto,
               typename T_y, typename T_shape>
     typename boost::math::tools::promote_args<T_y, T_shape>::type
     lkj_corr_log(const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>& y,
                  const T_shape& eta) {
-      static const char* function("lkj_corr_log");
-
-      using boost::math::tools::promote_args;
-
-      typename promote_args<T_y, T_shape>::type lp(0.0);
-      check_positive(function, "Shape parameter", eta);
-      check_corr_matrix(function, "Correlation matrix", y);
-
-      const unsigned int K = y.rows();
-      if (K == 0)
-        return 0.0;
-
-      if (include_summand<propto, T_shape>::value)
-        lp += do_lkj_constant(eta, K);
-
-      if ( (eta == 1.0) &&
-           stan::is_constant<typename stan::scalar_type<T_shape> >::value )
-        return lp;
-
-      if (!include_summand<propto, T_y, T_shape>::value)
-        return lp;
-
-      Eigen::Matrix<T_y, Eigen::Dynamic, 1> values =
-        y.ldlt().vectorD().array().log().matrix();
-      lp += (eta - 1.0) * sum(values);
-      return lp;
+      return lkj_corr_lpdf<propto, T_y, T_shape>(y, eta);
     }
 
+    /**
+     * @deprecated use <code>lkj_corr_lpdf</code>
+     */
     template <typename T_y, typename T_shape>
     inline
     typename boost::math::tools::promote_args<T_y, T_shape>::type
     lkj_corr_log(const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>& y,
                  const T_shape& eta) {
-      return lkj_corr_log<false>(y, eta);
+      return lkj_corr_lpdf<T_y, T_shape>(y, eta);
     }
 
   }

--- a/stan/math/prim/mat/prob/lkj_cov_log.hpp
+++ b/stan/math/prim/mat/prob/lkj_cov_log.hpp
@@ -1,20 +1,14 @@
 #ifndef STAN_MATH_PRIM_MAT_PROB_LKJ_COV_LOG_HPP
 #define STAN_MATH_PRIM_MAT_PROB_LKJ_COV_LOG_HPP
 
-#include <stan/math/prim/scal/err/check_size_match.hpp>
-#include <stan/math/prim/mat/err/check_square.hpp>
-#include <stan/math/prim/scal/err/check_finite.hpp>
-#include <stan/math/prim/scal/err/check_positive.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/prob/lognormal_log.hpp>
-#include <stan/math/prim/mat/prob/lkj_corr_log.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
+#include <stan/math/prim/mat/prob/lkj_cov_lpdf.hpp>
 
 namespace stan {
   namespace math {
 
-    // LKJ_cov(y|mu, sigma, eta) [ y covariance matrix (not correlation matrix)
-    //                         mu vector, sigma > 0 vector, eta > 0 ]
+    /**
+     * @deprecated use <code>lkj_cov_lpdf</code>
+     */
     template <bool propto,
               typename T_y, typename T_loc, typename T_scale, typename T_shape>
     typename
@@ -23,43 +17,13 @@ namespace stan {
                 const Eigen::Matrix<T_loc, Eigen::Dynamic, 1>& mu,
                 const Eigen::Matrix<T_scale, Eigen::Dynamic, 1>& sigma,
                 const T_shape& eta) {
-      static const char* function("lkj_cov_log");
-
-      using boost::math::tools::promote_args;
-
-      typename promote_args<T_y, T_loc, T_scale, T_shape>::type lp(0.0);
-      check_size_match(function,
-                       "Rows of location parameter", mu.rows(),
-                       "columns of scale parameter", sigma.rows());
-      check_square(function, "random variable", y);
-      check_size_match(function,
-                       "Rows of random variable", y.rows(),
-                       "rows of location parameter", mu.rows());
-      check_positive(function, "Shape parameter", eta);
-      check_finite(function, "Location parameter", mu);
-      check_finite(function, "Scale parameter", sigma);
-      for (int m = 0; m < y.rows(); ++m)
-        for (int n = 0; n < y.cols(); ++n)
-          check_finite(function, "Covariance matrix", y(m, n));
-
-      const unsigned int K = y.rows();
-      const Eigen::Array<T_y, Eigen::Dynamic, 1> sds
-        = y.diagonal().array().sqrt();
-      for (unsigned int k = 0; k < K; k++) {
-        lp += lognormal_log<propto>(sds(k), mu(k), sigma(k));
-      }
-      if (stan::is_constant<typename stan::scalar_type<T_shape> >::value
-          && eta == 1.0) {
-        // no need to rescale y into a correlation matrix
-        lp += lkj_corr_log<propto, T_y, T_shape>(y, eta);
-        return lp;
-      }
-      Eigen::DiagonalMatrix<T_y, Eigen::Dynamic> D(K);
-      D.diagonal() = sds.inverse();
-      lp += lkj_corr_log<propto, T_y, T_shape>(D * y * D, eta);
-      return lp;
+      return lkj_cov_lpdf<propto, T_y, T_loc,
+                          T_scale, T_shape>(y, mu, sigma, eta);
     }
 
+    /**
+     * @deprecated use <code>lkj_cov_lpdf</code>
+     */
     template <typename T_y, typename T_loc, typename T_scale, typename T_shape>
     inline
     typename
@@ -68,11 +32,12 @@ namespace stan {
                 const Eigen::Matrix<T_loc, Eigen::Dynamic, 1>& mu,
                 const Eigen::Matrix<T_scale, Eigen::Dynamic, 1>& sigma,
                 const T_shape& eta) {
-      return lkj_cov_log<false>(y, mu, sigma, eta);
+      return lkj_cov_lpdf<T_y, T_loc, T_scale, T_shape>(y, mu, sigma, eta);
     }
 
-    // LKJ_Cov(y|mu, sigma, eta) [ y covariance matrix (not correlation matrix)
-    //                         mu scalar, sigma > 0 scalar, eta > 0 ]
+    /**
+     * @deprecated use <code>lkj_corr_cholesky_lpdf</code>
+     */
     template <bool propto,
               typename T_y, typename T_loc, typename T_scale, typename T_shape>
     typename
@@ -81,33 +46,13 @@ namespace stan {
                 const T_loc& mu,
                 const T_scale& sigma,
                 const T_shape& eta) {
-      static const char* function("lkj_cov_log");
-
-      using boost::math::tools::promote_args;
-
-      typename promote_args<T_y, T_loc, T_scale, T_shape>::type lp(0.0);
-      check_positive(function, "Shape parameter", eta);
-      check_finite(function, "Location parameter", mu);
-      check_finite(function, "Scale parameter", sigma);
-
-      const unsigned int K = y.rows();
-      const Eigen::Array<T_y, Eigen::Dynamic, 1> sds
-        = y.diagonal().array().sqrt();
-      for (unsigned int k = 0; k < K; k++) {
-        lp += lognormal_log<propto>(sds(k), mu, sigma);
-      }
-      if (stan::is_constant<typename stan::scalar_type<T_shape> >::value
-          && eta == 1.0) {
-        // no need to rescale y into a correlation matrix
-        lp += lkj_corr_log<propto>(y, eta);
-        return lp;
-      }
-      Eigen::DiagonalMatrix<T_y, Eigen::Dynamic> D(K);
-      D.diagonal() = sds.inverse();
-      lp += lkj_corr_log<propto, T_y, T_shape>(D * y * D, eta);
-      return lp;
+      return lkj_cov_lpdf<propto, T_y, T_loc,
+                          T_scale, T_shape>(y, mu, sigma, eta);
     }
 
+    /**
+     * @deprecated use <code>lkj_corr_cholesky_lpdf</code>
+     */
     template <typename T_y, typename T_loc, typename T_scale, typename T_shape>
     inline
     typename boost::math::tools::promote_args
@@ -116,7 +61,8 @@ namespace stan {
                 const T_loc& mu,
                 const T_scale& sigma,
                 const T_shape& eta) {
-      return lkj_cov_log<false>(y, mu, sigma, eta);
+      return lkj_cov_lpdf<T_y, T_loc,
+                          T_scale, T_shape>(y, mu, sigma, eta);
     }
 
   }

--- a/stan/math/prim/mat/prob/matrix_normal_prec_log.hpp
+++ b/stan/math/prim/mat/prob/matrix_normal_prec_log.hpp
@@ -1,33 +1,23 @@
 #ifndef STAN_MATH_PRIM_MAT_PROB_MATRIX_NORMAL_PREC_LOG_HPP
 #define STAN_MATH_PRIM_MAT_PROB_MATRIX_NORMAL_PREC_LOG_HPP
 
-#include <stan/math/prim/mat/err/check_ldlt_factor.hpp>
-#include <stan/math/prim/scal/err/check_size_match.hpp>
-#include <stan/math/prim/mat/err/check_symmetric.hpp>
-#include <stan/math/prim/scal/err/check_finite.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/err/check_positive.hpp>
-#include <stan/math/prim/mat/fun/log.hpp>
-#include <stan/math/prim/mat/fun/log_determinant.hpp>
-#include <stan/math/prim/mat/fun/log_determinant_ldlt.hpp>
-#include <stan/math/prim/mat/fun/subtract.hpp>
-#include <stan/math/prim/mat/fun/trace_quad_form.hpp>
-#include <stan/math/prim/mat/fun/trace_gen_quad_form.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
+#include <stan/math/prim/mat/prob/matrix_normal_prec_lpdf.hpp>
 
 namespace stan {
   namespace math {
     /**
      * The log of the matrix normal density for the given y, mu, Sigma and D
-     * where Sigma and D are given as precision matrices, not covariance matrices.
+     * where Sigma and D are given as precision matrices, not covariance
+     * matrices.
+     *
+     * @deprecated use <code>matrix_normal_prec_lpdf</code>
      *
      * @param y An mxn matrix.
      * @param Mu The mean matrix.
-     * @param Sigma The mxm inverse covariance matrix (i.e., the precision matrix) of the
-     * rows of y.
-     * @param D The nxn inverse covariance matrix (i.e., the precision matrix) of the
-     * columns of y.
+     * @param Sigma The mxm inverse covariance matrix (i.e., the precision
+     *   matrix) of the rows of y.
+     * @param D The nxn inverse covariance matrix (i.e., the precision
+     *   matrix) of the columns of y.
      * @return The log of the matrix normal density.
      * @throw std::domain_error if Sigma or D are not square, not symmetric,
      * or not semi-positive definite.
@@ -47,54 +37,13 @@ namespace stan {
                            <T_Sigma, Eigen::Dynamic, Eigen::Dynamic>& Sigma,
                            const Eigen::Matrix
                            <T_D, Eigen::Dynamic, Eigen::Dynamic>& D) {
-      static const char* function("matrix_normal_prec_log");
-      typename
-        boost::math::tools::promote_args<T_y, T_Mu, T_Sigma, T_D>::type lp(0.0);
-
-      check_positive(function, "Sigma rows", Sigma.rows());
-      check_finite(function, "Sigma", Sigma);
-      check_symmetric(function, "Sigma", Sigma);
-
-      LDLT_factor<T_Sigma, Eigen::Dynamic, Eigen::Dynamic> ldlt_Sigma(Sigma);
-      check_ldlt_factor(function, "LDLT_Factor of Sigma", ldlt_Sigma);
-      check_positive(function, "D rows", D.rows());
-      check_finite(function, "D", D);
-      check_symmetric(function, "Sigma", D);
-
-      LDLT_factor<T_D, Eigen::Dynamic, Eigen::Dynamic> ldlt_D(D);
-      check_ldlt_factor(function, "LDLT_Factor of D", ldlt_D);
-      check_size_match(function,
-                       "Rows of random variable", y.rows(),
-                       "Rows of location parameter", Mu.rows());
-      check_size_match(function,
-                       "Columns of random variable", y.cols(),
-                       "Columns of location parameter", Mu.cols());
-      check_size_match(function,
-                       "Rows of random variable", y.rows(),
-                       "Rows of Sigma", Sigma.rows());
-      check_size_match(function,
-                       "Columns of random variable", y.cols(),
-                       "Rows of D", D.rows());
-      check_finite(function, "Location parameter", Mu);
-      check_finite(function, "Random variable", y);
-
-      if (include_summand<propto>::value)
-        lp += NEG_LOG_SQRT_TWO_PI * y.cols() * y.rows();
-
-      if (include_summand<propto, T_Sigma>::value) {
-        lp += log_determinant_ldlt(ldlt_Sigma) * (0.5 * y.rows());
-      }
-
-      if (include_summand<propto, T_D>::value) {
-        lp += log_determinant_ldlt(ldlt_D) * (0.5 * y.cols());
-      }
-
-      if (include_summand<propto, T_y, T_Mu, T_Sigma, T_D>::value) {
-        lp -= 0.5 * trace_gen_quad_form(D, Sigma, subtract(y, Mu));
-      }
-      return lp;
+      return matrix_normal_prec_lpdf<propto,
+                                     T_y, T_Mu, T_Sigma, T_D>(y, Mu, Sigma, D);
     }
 
+    /**
+     * @deprecated use <code>matrix_normal_prec_lpdf</code>
+     */
     template <typename T_y, typename T_Mu, typename T_Sigma, typename T_D>
     typename boost::math::tools::promote_args<T_y, T_Mu, T_Sigma, T_D>::type
     matrix_normal_prec_log(const Eigen::Matrix
@@ -105,7 +54,7 @@ namespace stan {
                            <T_Sigma, Eigen::Dynamic, Eigen::Dynamic>& Sigma,
                            const Eigen::Matrix
                            <T_D, Eigen::Dynamic, Eigen::Dynamic>& D) {
-      return matrix_normal_prec_log<false>(y, Mu, Sigma, D);
+      return matrix_normal_prec_lpdf<T_y, T_Mu, T_Sigma, T_D>(y, Mu, Sigma, D);
     }
 
   }

--- a/stan/math/prim/mat/prob/multi_gp_cholesky_log.hpp
+++ b/stan/math/prim/mat/prob/multi_gp_cholesky_log.hpp
@@ -1,17 +1,7 @@
 #ifndef STAN_MATH_PRIM_MAT_PROB_MULTI_GP_CHOLESKY_LOG_HPP
 #define STAN_MATH_PRIM_MAT_PROB_MULTI_GP_CHOLESKY_LOG_HPP
 
-#include <stan/math/prim/scal/err/check_size_match.hpp>
-#include <stan/math/prim/scal/err/check_finite.hpp>
-#include <stan/math/prim/scal/err/check_positive.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <stan/math/prim/mat/fun/dot_self.hpp>
-#include <stan/math/prim/mat/fun/log.hpp>
-#include <stan/math/prim/mat/fun/mdivide_left_tri_low.hpp>
-#include <stan/math/prim/mat/fun/multiply.hpp>
-#include <stan/math/prim/mat/fun/row.hpp>
-#include <stan/math/prim/mat/fun/sum.hpp>
+#include <stan/math/prim/mat/prob/multi_gp_cholesky_lpdf.hpp>
 
 namespace stan {
   namespace math {
@@ -24,6 +14,8 @@ namespace stan {
      * have a scaled kernel matrix with a different scale for each output dimension.
      * This distribution is equivalent to:
      *    for (i in 1:d) row(y, i) ~ multi_normal(0, (1/w[i])*LL').
+     *
+     * @deprecated use <code>multi_gp_cholesky_lpdf</code>
      *
      * @param y A dxN matrix
      * @param L The Cholesky decomposition of a kernel matrix
@@ -43,53 +35,12 @@ namespace stan {
                           const Eigen::Matrix
                           <T_covar, Eigen::Dynamic, Eigen::Dynamic>& L,
                           const Eigen::Matrix<T_w, Eigen::Dynamic, 1>& w) {
-      static const char* function("multi_gp_cholesky_log");
-      typedef
-        typename boost::math::tools::promote_args<T_y, T_covar, T_w>::type T_lp;
-      T_lp lp(0.0);
-
-
-      check_size_match(function,
-                       "Size of random variable (rows y)", y.rows(),
-                       "Size of kernel scales (w)", w.size());
-      check_size_match(function,
-                       "Size of random variable", y.cols(),
-                       "rows of covariance parameter", L.rows());
-      check_finite(function, "Kernel scales", w);
-      check_positive(function, "Kernel scales", w);
-      check_finite(function, "Random variable", y);
-
-      if (y.rows() == 0)
-        return lp;
-
-      if (include_summand<propto>::value) {
-        lp += NEG_LOG_SQRT_TWO_PI * y.rows() * y.cols();
-      }
-
-      if (include_summand<propto, T_covar>::value) {
-        lp -= L.diagonal().array().log().sum() * y.rows();
-      }
-
-      if (include_summand<propto, T_w>::value) {
-        lp += 0.5 * y.cols() * sum(log(w));
-      }
-
-      if (include_summand<propto, T_y, T_w, T_covar>::value) {
-        T_lp sum_lp_vec(0.0);
-        for (int i = 0; i < y.rows(); i++) {
-          Eigen::Matrix<T_y, Eigen::Dynamic, 1> y_row(y.row(i));
-          Eigen::Matrix<typename boost::math::tools::promote_args
-                        <T_y, T_covar>::type,
-                        Eigen::Dynamic, 1>
-            half(mdivide_left_tri_low(L, y_row));
-          sum_lp_vec += w(i) * dot_self(half);
-        }
-        lp -= 0.5*sum_lp_vec;
-      }
-
-      return lp;
+      return multi_gp_cholesky_lpdf<propto, T_y, T_covar, T_w>(y, L, w);
     }
 
+    /**
+     * @deprecated use <code>multi_gp_cholesky_lpdf</code>
+     */
     template <typename T_y, typename T_covar, typename T_w>
     inline
     typename boost::math::tools::promote_args<T_y, T_covar, T_w>::type
@@ -98,7 +49,7 @@ namespace stan {
                           const Eigen::Matrix
                           <T_covar, Eigen::Dynamic, Eigen::Dynamic>& L,
                           const Eigen::Matrix<T_w, Eigen::Dynamic, 1>& w) {
-      return multi_gp_cholesky_log<false>(y, L, w);
+      return multi_gp_cholesky_lpdf<T_y, T_covar, T_w>(y, L, w);
     }
 
   }

--- a/stan/math/prim/mat/prob/multi_gp_log.hpp
+++ b/stan/math/prim/mat/prob/multi_gp_log.hpp
@@ -1,23 +1,11 @@
 #ifndef STAN_MATH_PRIM_MAT_PROB_MULTI_GP_LOG_HPP
 #define STAN_MATH_PRIM_MAT_PROB_MULTI_GP_LOG_HPP
 
-#include <stan/math/prim/mat/err/check_ldlt_factor.hpp>
-#include <stan/math/prim/scal/err/check_size_match.hpp>
-#include <stan/math/prim/mat/err/check_symmetric.hpp>
-#include <stan/math/prim/scal/err/check_finite.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/err/check_positive.hpp>
-#include <stan/math/prim/scal/err/check_positive_finite.hpp>
-#include <stan/math/prim/mat/fun/log.hpp>
-#include <stan/math/prim/mat/fun/log_determinant_ldlt.hpp>
-#include <stan/math/prim/mat/fun/multiply.hpp>
-#include <stan/math/prim/mat/fun/sum.hpp>
-#include <stan/math/prim/mat/fun/trace_gen_inv_quad_form_ldlt.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
+#include <stan/math/prim/mat/prob/multi_gp_lpdf.hpp>
 
 namespace stan {
   namespace math {
+
     /**
      * The log of a multivariate Gaussian Process for the given y, Sigma, and
      * w.  y is a dxN matrix, where each column is a different observation and each
@@ -25,6 +13,8 @@ namespace stan {
      * have a scaled kernel matrix with a different scale for each output dimension.
      * This distribution is equivalent to:
      *    for (i in 1:d) row(y, i) ~ multi_normal(0, (1/w[i])*Sigma).
+     *
+     * @deprecated use <code>multi_gp_lpdf</code>
      *
      * @param y A dxN matrix
      * @param Sigma The NxN kernel matrix
@@ -43,53 +33,12 @@ namespace stan {
                  const Eigen::Matrix
                  <T_covar, Eigen::Dynamic, Eigen::Dynamic>& Sigma,
                  const Eigen::Matrix<T_w, Eigen::Dynamic, 1>& w) {
-      static const char* function("multi_gp_log");
-      typedef typename boost::math::tools::promote_args<T_y, T_covar, T_w>::type
-        T_lp;
-      T_lp lp(0.0);
-
-
-      check_positive(function, "Kernel rows", Sigma.rows());
-      check_finite(function, "Kernel", Sigma);
-      check_symmetric(function, "Kernel", Sigma);
-
-      LDLT_factor<T_covar, Eigen::Dynamic, Eigen::Dynamic> ldlt_Sigma(Sigma);
-      check_ldlt_factor(function, "LDLT_Factor of Sigma", ldlt_Sigma);
-
-      check_size_match(function,
-                       "Size of random variable (rows y)", y.rows(),
-                       "Size of kernel scales (w)", w.size());
-      check_size_match(function,
-                       "Size of random variable", y.cols(),
-                       "rows of covariance parameter", Sigma.rows());
-      check_positive_finite(function, "Kernel scales", w);
-      check_finite(function, "Random variable", y);
-
-      if (y.rows() == 0)
-        return lp;
-
-      if (include_summand<propto>::value) {
-        lp += NEG_LOG_SQRT_TWO_PI * y.rows() * y.cols();
-      }
-
-      if (include_summand<propto, T_covar>::value) {
-        lp -= 0.5 * log_determinant_ldlt(ldlt_Sigma) * y.rows();
-      }
-
-      if (include_summand<propto, T_w>::value) {
-        lp += (0.5 * y.cols()) * sum(log(w));
-      }
-
-      if (include_summand<propto, T_y, T_w, T_covar>::value) {
-        Eigen::Matrix<T_w, Eigen::Dynamic, Eigen::Dynamic>
-          w_mat(w.asDiagonal());
-        Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic> yT(y.transpose());
-        lp -= 0.5 * trace_gen_inv_quad_form_ldlt(w_mat, ldlt_Sigma, yT);
-      }
-
-      return lp;
+      return multi_gp_lpdf<propto, T_y, T_covar, T_w>(y, Sigma, w);
     }
 
+    /**
+     * @deprecated use <code>multi_gp_lpdf</code>
+     */
     template <typename T_y, typename T_covar, typename T_w>
     inline
     typename boost::math::tools::promote_args<T_y, T_covar, T_w>::type
@@ -97,7 +46,7 @@ namespace stan {
                  const Eigen::Matrix<T_covar, Eigen::Dynamic, Eigen::Dynamic>&
                  Sigma,
                  const Eigen::Matrix<T_w, Eigen::Dynamic, 1>& w) {
-      return multi_gp_log<false>(y, Sigma, w);
+      return multi_gp_lpdf<T_y, T_covar, T_w>(y, Sigma, w);
     }
 
   }

--- a/stan/math/prim/mat/prob/multi_normal_cholesky_log.hpp
+++ b/stan/math/prim/mat/prob/multi_normal_cholesky_log.hpp
@@ -1,27 +1,7 @@
 #ifndef STAN_MATH_PRIM_MAT_PROB_MULTI_NORMAL_CHOLESKY_LOG_HPP
 #define STAN_MATH_PRIM_MAT_PROB_MULTI_NORMAL_CHOLESKY_LOG_HPP
 
-#include <stan/math/prim/mat/fun/columns_dot_product.hpp>
-#include <stan/math/prim/mat/fun/columns_dot_self.hpp>
-#include <stan/math/prim/mat/fun/dot_product.hpp>
-#include <stan/math/prim/mat/fun/dot_self.hpp>
-#include <stan/math/prim/mat/fun/log.hpp>
-#include <stan/math/prim/mat/fun/log_determinant.hpp>
-#include <stan/math/prim/mat/fun/mdivide_left_spd.hpp>
-#include <stan/math/prim/mat/fun/mdivide_left_tri_low.hpp>
-#include <stan/math/prim/mat/fun/multiply.hpp>
-#include <stan/math/prim/mat/fun/subtract.hpp>
-#include <stan/math/prim/mat/fun/sum.hpp>
-#include <stan/math/prim/mat/meta/VectorViewMvt.hpp>
-#include <stan/math/prim/scal/err/check_size_match.hpp>
-#include <stan/math/prim/scal/err/check_finite.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/meta/max_size_mvt.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <stan/math/prim/scal/meta/return_type.hpp>
-#include <boost/random/normal_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
+#include <stan/math/prim/mat/prob/multi_normal_cholesky_lpdf.hpp>
 
 namespace stan {
   namespace math {
@@ -30,6 +10,7 @@ namespace stan {
      * a Cholesky factor L of the variance matrix.
      * Sigma = LL', a square, semi-positive definite matrix.
      *
+     * @deprecated use <code>multi_normal_cholesky_lpdf</code>
      *
      * @param y A scalar vector
      * @param mu The mean vector of the multivariate normal distribution.
@@ -48,100 +29,17 @@ namespace stan {
     multi_normal_cholesky_log(const T_y& y,
                               const T_loc& mu,
                               const T_covar& L) {
-      static const char* function("multi_normal_cholesky_log");
-      typedef typename scalar_type<T_covar>::type T_covar_elem;
-      typedef typename return_type<T_y, T_loc, T_covar>::type lp_type;
-      lp_type lp(0.0);
-
-
-      VectorViewMvt<const T_y> y_vec(y);
-      VectorViewMvt<const T_loc> mu_vec(mu);
-      size_t size_vec = max_size_mvt(y, mu);
-
-      int size_y = y_vec[0].size();
-      int size_mu = mu_vec[0].size();
-      if (size_vec > 1) {
-        int size_y_old = size_y;
-        int size_y_new;
-        for (size_t i = 1, size_ = length_mvt(y); i < size_; i++) {
-          int size_y_new = y_vec[i].size();
-          check_size_match(function,
-                           "Size of one of the vectors of "
-                           "the random variable", size_y_new,
-                           "Size of another vector of the "
-                           "random variable", size_y_old);
-          size_y_old = size_y_new;
-        }
-        int size_mu_old = size_mu;
-        int size_mu_new;
-        for (size_t i = 1, size_ = length_mvt(mu); i < size_; i++) {
-          int size_mu_new = mu_vec[i].size();
-          check_size_match(function,
-                           "Size of one of the vectors of "
-                           "the location variable", size_mu_new,
-                           "Size of another vector of the "
-                           "location variable", size_mu_old);
-          size_mu_old = size_mu_new;
-        }
-        (void) size_y_old;
-        (void) size_y_new;
-        (void) size_mu_old;
-        (void) size_mu_new;
-      }
-
-      check_size_match(function,
-                       "Size of random variable", size_y,
-                       "size of location parameter", size_mu);
-      check_size_match(function,
-                       "Size of random variable", size_y,
-                       "rows of covariance parameter", L.rows());
-      check_size_match(function,
-                       "Size of random variable", size_y,
-                       "columns of covariance parameter", L.cols());
-
-      for (size_t i = 0; i < size_vec; i++) {
-        check_finite(function, "Location parameter", mu_vec[i]);
-        check_not_nan(function, "Random variable", y_vec[i]);
-      }
-
-      if (size_y == 0)
-        return lp;
-
-      if (include_summand<propto>::value)
-        lp += NEG_LOG_SQRT_TWO_PI * size_y * size_vec;
-
-      if (include_summand<propto, T_covar_elem>::value)
-        lp -= L.diagonal().array().log().sum() * size_vec;
-
-      if (include_summand<propto, T_y, T_loc, T_covar_elem>::value) {
-        lp_type sum_lp_vec(0.0);
-        for (size_t i = 0; i < size_vec; i++) {
-          Eigen::Matrix<typename return_type<T_y, T_loc>::type,
-                        Eigen::Dynamic, 1> y_minus_mu(size_y);
-          for (int j = 0; j < size_y; j++)
-            y_minus_mu(j) = y_vec[i](j)-mu_vec[i](j);
-          Eigen::Matrix<typename return_type<T_y, T_loc, T_covar>::type,
-                        Eigen::Dynamic, 1>
-            half(mdivide_left_tri_low(L, y_minus_mu));
-          // FIXME: this code does not compile. revert after fixing subtract()
-          // Eigen::Matrix<typename
-          //               boost::math::tools::promote_args<T_covar,
-          //                 typename value_type<T_loc>::type,
-          //                 typename value_type<T_y>::type>::type>::type,
-          //               Eigen::Dynamic, 1>
-          //   half(mdivide_left_tri_low(L, subtract(y, mu)));
-          sum_lp_vec += dot_self(half);
-        }
-        lp -= 0.5*sum_lp_vec;
-      }
-      return lp;
+      return multi_normal_cholesky_lpdf<propto, T_y, T_loc, T_covar>(y, mu, L);
     }
 
+    /**
+     * @deprecated use <code>multi_normal_cholesky_lpdf</code>
+     */
     template <typename T_y, typename T_loc, typename T_covar>
     inline
     typename return_type<T_y, T_loc, T_covar>::type
     multi_normal_cholesky_log(const T_y& y, const T_loc& mu, const T_covar& L) {
-      return multi_normal_cholesky_log<false>(y, mu, L);
+      return multi_normal_cholesky_lpdf<T_y, T_loc, T_covar>(y, mu, L);
     }
 
   }

--- a/stan/math/prim/mat/prob/multi_normal_log.hpp
+++ b/stan/math/prim/mat/prob/multi_normal_log.hpp
@@ -1,125 +1,33 @@
 #ifndef STAN_MATH_PRIM_MAT_PROB_MULTI_NORMAL_LOG_HPP
 #define STAN_MATH_PRIM_MAT_PROB_MULTI_NORMAL_LOG_HPP
 
-#include <stan/math/prim/mat/err/check_ldlt_factor.hpp>
-#include <stan/math/prim/mat/err/check_symmetric.hpp>
-#include <stan/math/prim/mat/fun/trace_inv_quad_form_ldlt.hpp>
-#include <stan/math/prim/mat/fun/log_determinant_ldlt.hpp>
-#include <stan/math/prim/mat/meta/VectorViewMvt.hpp>
-#include <stan/math/prim/scal/err/check_size_match.hpp>
-#include <stan/math/prim/scal/err/check_finite.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/err/check_positive.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/meta/return_type.hpp>
-#include <stan/math/prim/scal/meta/max_size_mvt.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <boost/random/normal_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
+#include <stan/math/prim/mat/prob/multi_normal_lpdf.hpp>
 
 namespace stan {
   namespace math {
 
+    /**
+     * @deprecated use <code>matrix_normal_lpdf</code>
+     */
     template <bool propto,
               typename T_y, typename T_loc, typename T_covar>
     typename return_type<T_y, T_loc, T_covar>::type
     multi_normal_log(const T_y& y,
                      const T_loc& mu,
                      const T_covar& Sigma) {
-      static const char* function("multi_normal_log");
-      typedef typename scalar_type<T_covar>::type T_covar_elem;
-      typedef typename return_type<T_y, T_loc, T_covar>::type lp_type;
-      lp_type lp(0.0);
-
-      using Eigen::Dynamic;
-
-      check_positive(function, "Covariance matrix rows", Sigma.rows());
-      check_symmetric(function, "Covariance matrix", Sigma);
-
-      LDLT_factor<T_covar_elem, Dynamic, Dynamic> ldlt_Sigma(Sigma);
-      check_ldlt_factor(function,
-                        "LDLT_Factor of covariance parameter", ldlt_Sigma);
-
-      VectorViewMvt<const T_y> y_vec(y);
-      VectorViewMvt<const T_loc> mu_vec(mu);
-      size_t size_vec = max_size_mvt(y, mu);
-
-      int size_y = y_vec[0].size();
-      int size_mu = mu_vec[0].size();
-      if (size_vec > 1) {
-        int size_y_old = size_y;
-        int size_y_new;
-        for (size_t i = 1, size_ = length_mvt(y); i < size_; i++) {
-          int size_y_new = y_vec[i].size();
-          check_size_match(function,
-                           "Size of one of the vectors of "
-                           "the random variable", size_y_new,
-                           "Size of another vector of the "
-                           "random variable", size_y_old);
-          size_y_old = size_y_new;
-        }
-        int size_mu_old = size_mu;
-        int size_mu_new;
-        for (size_t i = 1, size_ = length_mvt(mu); i < size_; i++) {
-          int size_mu_new = mu_vec[i].size();
-          check_size_match(function,
-                           "Size of one of the vectors of "
-                           "the location variable", size_mu_new,
-                           "Size of another vector of the "
-                           "location variable", size_mu_old);
-          size_mu_old = size_mu_new;
-        }
-        (void) size_y_old;
-        (void) size_y_new;
-        (void) size_mu_old;
-        (void) size_mu_new;
-      }
-
-      check_size_match(function,
-                       "Size of random variable", size_y,
-                       "size of location parameter", size_mu);
-      check_size_match(function,
-                       "Size of random variable", size_y,
-                       "rows of covariance parameter", Sigma.rows());
-      check_size_match(function,
-                       "Size of random variable", size_y,
-                       "columns of covariance parameter", Sigma.cols());
-
-      for (size_t i = 0; i < size_vec; i++) {
-        check_finite(function, "Location parameter", mu_vec[i]);
-        check_not_nan(function, "Random variable", y_vec[i]);
-      }
-
-      if (size_y == 0)
-        return lp;
-
-      if (include_summand<propto>::value)
-        lp += NEG_LOG_SQRT_TWO_PI * size_y * size_vec;
-
-      if (include_summand<propto, T_covar_elem>::value)
-        lp -= 0.5 * log_determinant_ldlt(ldlt_Sigma) * size_vec;
-
-      if (include_summand<propto, T_y, T_loc, T_covar_elem>::value) {
-        lp_type sum_lp_vec(0.0);
-        for (size_t i = 0; i < size_vec; i++) {
-          Eigen::Matrix<typename return_type<T_y, T_loc>::type, Dynamic, 1>
-            y_minus_mu(size_y);
-          for (int j = 0; j < size_y; j++)
-            y_minus_mu(j) = y_vec[i](j)-mu_vec[i](j);
-          sum_lp_vec += trace_inv_quad_form_ldlt(ldlt_Sigma, y_minus_mu);
-        }
-        lp -= 0.5*sum_lp_vec;
-      }
-      return lp;
+      return multi_normal_lpdf<propto, T_y, T_loc, T_covar>(y, mu, Sigma);
     }
 
+    /**
+     * @deprecated use <code>matrix_normal_lpdf</code>
+     */
     template <typename T_y, typename T_loc, typename T_covar>
     inline
     typename return_type<T_y, T_loc, T_covar>::type
     multi_normal_log(const T_y& y,
                      const T_loc& mu,
                      const T_covar& Sigma) {
-      return multi_normal_log<false>(y, mu, Sigma);
+      return multi_normal_lpdf<T_y, T_loc, T_covar>(y, mu, Sigma);
     }
 
   }

--- a/stan/math/prim/mat/prob/multi_normal_prec_log.hpp
+++ b/stan/math/prim/mat/prob/multi_normal_prec_log.hpp
@@ -1,133 +1,31 @@
 #ifndef STAN_MATH_PRIM_MAT_PROB_MULTI_NORMAL_PREC_LOG_HPP
 #define STAN_MATH_PRIM_MAT_PROB_MULTI_NORMAL_PREC_LOG_HPP
 
-#include <stan/math/prim/mat/err/check_ldlt_factor.hpp>
-#include <stan/math/prim/mat/err/check_symmetric.hpp>
-#include <stan/math/prim/mat/fun/columns_dot_product.hpp>
-#include <stan/math/prim/mat/fun/columns_dot_self.hpp>
-#include <stan/math/prim/mat/fun/dot_product.hpp>
-#include <stan/math/prim/mat/fun/dot_self.hpp>
-#include <stan/math/prim/mat/fun/log_determinant_ldlt.hpp>
-#include <stan/math/prim/mat/fun/log.hpp>
-#include <stan/math/prim/mat/fun/log_determinant.hpp>
-#include <stan/math/prim/mat/fun/mdivide_left_spd.hpp>
-#include <stan/math/prim/mat/fun/mdivide_left_tri_low.hpp>
-#include <stan/math/prim/mat/fun/multiply.hpp>
-#include <stan/math/prim/mat/fun/subtract.hpp>
-#include <stan/math/prim/mat/fun/sum.hpp>
-#include <stan/math/prim/mat/fun/trace_quad_form.hpp>
-#include <stan/math/prim/mat/meta/VectorViewMvt.hpp>
-#include <stan/math/prim/scal/err/check_size_match.hpp>
-#include <stan/math/prim/scal/err/check_finite.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/err/check_positive.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/meta/max_size_mvt.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <stan/math/prim/scal/meta/return_type.hpp>
+#include <stan/math/prim/mat/prob/multi_normal_prec_lpdf.hpp>
 
 namespace stan {
   namespace math {
 
+    /**
+     * @deprecated use <code>multi_normal_prec_lpdf</code>
+     */
     template <bool propto,
               typename T_y, typename T_loc, typename T_covar>
     typename return_type<T_y, T_loc, T_covar>::type
     multi_normal_prec_log(const T_y& y,
                           const T_loc& mu,
                           const T_covar& Sigma) {
-      static const char* function("multi_normal_prec_log");
-      typedef typename scalar_type<T_covar>::type T_covar_elem;
-      typedef typename return_type<T_y, T_loc, T_covar>::type lp_type;
-      lp_type lp(0.0);
-
-      check_positive(function, "Precision matrix rows", Sigma.rows());
-      check_symmetric(function, "Precision matrix", Sigma);
-
-      LDLT_factor<T_covar_elem,
-                  Eigen::Dynamic, Eigen::Dynamic> ldlt_Sigma(Sigma);
-      check_ldlt_factor(function, "LDLT_Factor of precision parameter",
-                        ldlt_Sigma);
-
-      using Eigen::Matrix;
-      using std::vector;
-      VectorViewMvt<const T_y> y_vec(y);
-      VectorViewMvt<const T_loc> mu_vec(mu);
-      size_t size_vec = max_size_mvt(y, mu);
-
-      int size_y = y_vec[0].size();
-      int size_mu = mu_vec[0].size();
-      if (size_vec > 1) {
-        int size_y_old = size_y;
-        int size_y_new;
-        for (size_t i = 1, size_ = length_mvt(y); i < size_; i++) {
-          int size_y_new = y_vec[i].size();
-          check_size_match(function,
-                           "Size of one of the vectors "
-                           "of the random variable", size_y_new,
-                           "Size of another vector of "
-                           "the random variable", size_y_old);
-          size_y_old = size_y_new;
-        }
-        int size_mu_old = size_mu;
-        int size_mu_new;
-        for (size_t i = 1, size_ = length_mvt(mu); i < size_; i++) {
-          int size_mu_new = mu_vec[i].size();
-          check_size_match(function,
-                           "Size of one of the vectors "
-                           "of the location variable", size_mu_new,
-                           "Size of another vector of "
-                           "the location variable", size_mu_old);
-          size_mu_old = size_mu_new;
-        }
-        (void) size_y_old;
-        (void) size_y_new;
-        (void) size_mu_old;
-        (void) size_mu_new;
-      }
-
-      check_size_match(function,
-                       "Size of random variable", size_y,
-                       "size of location parameter", size_mu);
-      check_size_match(function,
-                       "Size of random variable", size_y,
-                       "rows of covariance parameter", Sigma.rows());
-      check_size_match(function,
-                       "Size of random variable", size_y,
-                       "columns of covariance parameter", Sigma.cols());
-
-      for (size_t i = 0; i < size_vec; i++) {
-        check_finite(function, "Location parameter", mu_vec[i]);
-        check_not_nan(function, "Random variable", y_vec[i]);
-      }
-
-      if (size_y == 0)
-        return lp;
-
-      if (include_summand<propto, T_covar_elem>::value)
-        lp += 0.5 * log_determinant_ldlt(ldlt_Sigma) * size_vec;
-
-      if (include_summand<propto>::value)
-        lp += NEG_LOG_SQRT_TWO_PI * size_y * size_vec;
-
-      if (include_summand<propto, T_y, T_loc, T_covar_elem>::value) {
-        lp_type sum_lp_vec(0.0);
-        for (size_t i = 0; i < size_vec; i++) {
-          Eigen::Matrix<typename return_type<T_y, T_loc>::type,
-                        Eigen::Dynamic, 1> y_minus_mu(size_y);
-          for (int j = 0; j < size_y; j++)
-            y_minus_mu(j) = y_vec[i](j) - mu_vec[i](j);
-          sum_lp_vec += trace_quad_form(Sigma, y_minus_mu);
-        }
-        lp -= 0.5*sum_lp_vec;
-      }
-      return lp;
+      return multi_normal_prec_lpdf<propto, T_y, T_loc, T_covar>(y, mu, Sigma);
     }
 
+    /**
+     * @deprecated use <code>multi_normal_prec_lpdf</code>
+     */
     template <typename T_y, typename T_loc, typename T_covar>
     inline
     typename return_type<T_y, T_loc, T_covar>::type
     multi_normal_prec_log(const T_y& y, const T_loc& mu, const T_covar& Sigma) {
-      return multi_normal_prec_log<false>(y, mu, Sigma);
+      return multi_normal_prec_lpdf<T_y, T_loc, T_covar>(y, mu, Sigma);
     }
 
   }

--- a/stan/math/prim/mat/prob/multi_student_t_log.hpp
+++ b/stan/math/prim/mat/prob/multi_student_t_log.hpp
@@ -1,25 +1,7 @@
 #ifndef STAN_MATH_PRIM_MAT_PROB_MULTI_STUDENT_T_LOG_HPP
 #define STAN_MATH_PRIM_MAT_PROB_MULTI_STUDENT_T_LOG_HPP
 
-#include <stan/math/prim/mat/err/check_ldlt_factor.hpp>
-#include <stan/math/prim/mat/err/check_symmetric.hpp>
-#include <stan/math/prim/mat/fun/multiply.hpp>
-#include <stan/math/prim/mat/fun/dot_product.hpp>
-#include <stan/math/prim/mat/fun/subtract.hpp>
-#include <stan/math/prim/mat/meta/VectorViewMvt.hpp>
-#include <stan/math/prim/mat/prob/multi_normal_log.hpp>
-#include <stan/math/prim/scal/err/check_size_match.hpp>
-#include <stan/math/prim/scal/err/check_finite.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/err/check_positive.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/fun/is_inf.hpp>
-#include <stan/math/prim/scal/fun/log1p.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <boost/math/special_functions/gamma.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <cmath>
-#include <cstdlib>
+#include <stan/math/prim/mat/prob/multi_student_t_lpdf.hpp>
 
 namespace stan {
   namespace math {
@@ -27,6 +9,8 @@ namespace stan {
     /**
      * Return the log of the multivariate Student t distribution
      * at the specified arguments.
+     *
+     * @deprecated use <code>multi_student_t_lpdf</code>
      *
      * @tparam propto Carry out calculations up to a proportion
      */
@@ -37,119 +21,19 @@ namespace stan {
                         const T_dof& nu,
                         const T_loc& mu,
                         const T_scale& Sigma) {
-      static const char* function("multi_student_t");
-
-      using boost::math::lgamma;
-      using std::log;
-
-      typedef typename scalar_type<T_scale>::type T_scale_elem;
-      typedef typename return_type<T_y, T_dof, T_loc, T_scale>::type lp_type;
-      lp_type lp(0.0);
-
-      check_not_nan(function, "Degrees of freedom parameter", nu);
-      check_positive(function, "Degrees of freedom parameter", nu);
-
-      if (is_inf(nu))
-        return multi_normal_log(y, mu, Sigma);
-
-      using Eigen::Matrix;
-      using std::vector;
-      VectorViewMvt<const T_y> y_vec(y);
-      VectorViewMvt<const T_loc> mu_vec(mu);
-      size_t size_vec = max_size_mvt(y, mu);
-
-      int size_y = y_vec[0].size();
-      int size_mu = mu_vec[0].size();
-      if (size_vec > 1) {
-        int size_y_old = size_y;
-        int size_y_new;
-        for (size_t i = 1, size_ = length_mvt(y); i < size_; i++) {
-          int size_y_new = y_vec[i].size();
-          check_size_match(function,
-                           "Size of one of the vectors of the random variable",
-                           size_y_new,
-                           "Size of another vector of the random variable",
-                           size_y_old);
-          size_y_old = size_y_new;
-        }
-        int size_mu_old = size_mu;
-        int size_mu_new;
-        for (size_t i = 1, size_ = length_mvt(mu); i < size_; i++) {
-          int size_mu_new = mu_vec[i].size();
-          check_size_match(function,
-                           "Size of one of the vectors "
-                           "of the location variable",
-                           size_mu_new,
-                           "Size of another vector of "
-                           "the location variable",
-                           size_mu_old);
-          size_mu_old = size_mu_new;
-        }
-        (void) size_y_old;
-        (void) size_y_new;
-        (void) size_mu_old;
-        (void) size_mu_new;
-      }
-
-      check_size_match(function,
-                       "Size of random variable", size_y,
-                       "size of location parameter", size_mu);
-      check_size_match(function,
-                       "Size of random variable", size_y,
-                       "rows of scale parameter", Sigma.rows());
-      check_size_match(function,
-                       "Size of random variable", size_y,
-                       "columns of scale parameter", Sigma.cols());
-
-      for (size_t i = 0; i < size_vec; i++) {
-        check_finite(function, "Location parameter", mu_vec[i]);
-        check_not_nan(function, "Random variable", y_vec[i]);
-      }
-      check_symmetric(function, "Scale parameter", Sigma);
-
-      LDLT_factor<T_scale_elem,
-                  Eigen::Dynamic, Eigen::Dynamic> ldlt_Sigma(Sigma);
-      check_ldlt_factor(function, "LDLT_Factor of scale parameter", ldlt_Sigma);
-
-      if (size_y == 0)
-        return lp;
-
-      if (include_summand<propto, T_dof>::value) {
-        lp += lgamma(0.5 * (nu + size_y)) * size_vec;
-        lp -= lgamma(0.5 * nu) * size_vec;
-        lp -= (0.5 * size_y) * log(nu) * size_vec;
-      }
-
-      if (include_summand<propto>::value)
-        lp -= (0.5 * size_y) * LOG_PI * size_vec;
-
-      using Eigen::Array;
-
-      if (include_summand<propto, T_scale_elem>::value) {
-        lp -= 0.5 * log_determinant_ldlt(ldlt_Sigma) * size_vec;
-      }
-
-      if (include_summand<propto, T_y, T_dof, T_loc, T_scale_elem>::value) {
-        lp_type sum_lp_vec(0.0);
-        for (size_t i = 0; i < size_vec; i++) {
-          Eigen::Matrix<typename return_type<T_y, T_loc>::type,
-                        Eigen::Dynamic, 1> y_minus_mu(size_y);
-          for (int j = 0; j < size_y; j++)
-            y_minus_mu(j) = y_vec[i](j)-mu_vec[i](j);
-          sum_lp_vec += log1p(trace_inv_quad_form_ldlt(ldlt_Sigma, y_minus_mu)
-                              / nu);
-        }
-        lp -= 0.5 * (nu + size_y) * sum_lp_vec;
-      }
-      return lp;
+      return multi_student_t_lpdf<propto,
+                                  T_y, T_dof, T_loc, T_scale>(y, nu, mu, Sigma);
     }
 
+    /**
+     * @deprecated use <code>multi_student_t_lpdf</code>
+     */
     template <typename T_y, typename T_dof, typename T_loc, typename T_scale>
     inline
     typename return_type<T_y, T_dof, T_loc, T_scale>::type
     multi_student_t_log(const T_y& y, const T_dof& nu, const T_loc& mu,
                         const T_scale& Sigma) {
-      return multi_student_t_log<false>(y, nu, mu, Sigma);
+      return multi_student_t_lpdf<T_y, T_dof, T_loc, T_scale>(y, nu, mu, Sigma);
     }
 
   }

--- a/stan/math/prim/mat/prob/multinomial_log.hpp
+++ b/stan/math/prim/mat/prob/multinomial_log.hpp
@@ -1,59 +1,31 @@
 #ifndef STAN_MATH_PRIM_MAT_PROB_MULTINOMIAL_LOG_HPP
 #define STAN_MATH_PRIM_MAT_PROB_MULTINOMIAL_LOG_HPP
 
-#include <boost/math/special_functions/gamma.hpp>
-#include <boost/random/uniform_01.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <stan/math/prim/mat/err/check_simplex.hpp>
-#include <stan/math/prim/scal/err/check_size_match.hpp>
-#include <stan/math/prim/scal/err/check_nonnegative.hpp>
-#include <stan/math/prim/scal/err/check_positive.hpp>
-#include <stan/math/prim/scal/fun/multiply_log.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
+#include <stan/math/prim/mat/prob/multinomial_lpmf.hpp>
 #include <vector>
 
 namespace stan {
   namespace math {
-    // Multinomial(ns|N, theta)   [0 <= n <= N;  SUM ns = N;
-    //                            0 <= theta[n] <= 1;  SUM theta = 1]
+
+    /**
+     * @deprecated use <code>multinomial_lpmf</code>
+     */
     template <bool propto,
               typename T_prob>
     typename boost::math::tools::promote_args<T_prob>::type
     multinomial_log(const std::vector<int>& ns,
                     const Eigen::Matrix<T_prob, Eigen::Dynamic, 1>& theta) {
-      static const char* function("multinomial_log");
-
-      using boost::math::tools::promote_args;
-      using boost::math::lgamma;
-
-      typename promote_args<T_prob>::type lp(0.0);
-      check_nonnegative(function, "Number of trials variable", ns);
-      check_simplex(function, "Probabilites parameter", theta);
-      check_size_match(function,
-                       "Size of number of trials variable", ns.size(),
-                       "rows of probabilities parameter", theta.rows());
-
-      if (include_summand<propto>::value) {
-        double sum = 1.0;
-        for (unsigned int i = 0; i < ns.size(); ++i)
-          sum += ns[i];
-        lp += lgamma(sum);
-        for (unsigned int i = 0; i < ns.size(); ++i)
-          lp -= lgamma(ns[i] + 1.0);
-      }
-      if (include_summand<propto, T_prob>::value) {
-        for (unsigned int i = 0; i < ns.size(); ++i)
-          lp += multiply_log(ns[i], theta[i]);
-      }
-      return lp;
+      return multinomial_lpmf<propto, T_prob>(ns, theta);
     }
 
+    /**
+     * @deprecated use <code>multinomial_lpmf</code>
+     */
     template <typename T_prob>
     typename boost::math::tools::promote_args<T_prob>::type
     multinomial_log(const std::vector<int>& ns,
                     const Eigen::Matrix<T_prob, Eigen::Dynamic, 1>& theta) {
-      return multinomial_log<false>(ns, theta);
+      return multinomial_lpmf<false>(ns, theta);
     }
 
   }

--- a/stan/math/prim/mat/prob/ordered_logistic_log.hpp
+++ b/stan/math/prim/mat/prob/ordered_logistic_log.hpp
@@ -1,32 +1,10 @@
 #ifndef STAN_MATH_PRIM_MAT_PROB_ORDERED_LOGISTIC_LOG_HPP
 #define STAN_MATH_PRIM_MAT_PROB_ORDERED_LOGISTIC_LOG_HPP
 
-#include <boost/random/uniform_01.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <stan/math/prim/scal/fun/inv_logit.hpp>
-#include <stan/math/prim/scal/fun/log1m.hpp>
-#include <stan/math/prim/scal/fun/log1m_exp.hpp>
-#include <stan/math/prim/scal/fun/log1p_exp.hpp>
-#include <stan/math/prim/scal/err/check_bounded.hpp>
-#include <stan/math/prim/scal/err/check_finite.hpp>
-#include <stan/math/prim/scal/err/check_greater.hpp>
-#include <stan/math/prim/scal/err/check_less.hpp>
-#include <stan/math/prim/scal/err/check_less_or_equal.hpp>
-#include <stan/math/prim/scal/err/check_nonnegative.hpp>
-#include <stan/math/prim/scal/err/check_positive.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/mat/prob/categorical_rng.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
+#include <stan/math/prim/mat/prob/ordered_logistic_lpmf.hpp>
 
 namespace stan {
   namespace math {
-
-    template <typename T>
-    inline T log_inv_logit_diff(const T& alpha, const T& beta) {
-      using std::exp;
-      return beta + log1m_exp(alpha - beta) - log1p_exp(alpha)
-        - log1p_exp(beta);
-    }
 
     /**
      * Returns the (natural) log probability of the specified integer
@@ -37,6 +15,8 @@ namespace stan {
      * will be the dot product of a vector of regression coefficients
      * and a vector of predictors for the outcome.
      *
+     * @deprecated use <code>ordered_logistic_lpmf</code>
+     *
      * @tparam propto True if calculating up to a proportion.
      * @tparam T_loc Location type.
      * @tparam T_cut Cut-point type.
@@ -45,7 +25,7 @@ namespace stan {
      * @param c Positive increasing vector of cutpoints.
      * @return Log probability of outcome given location and
      * cutpoints.
-
+     *
      * @throw std::domain_error If the outcome is not between 1 and
      * the number of cutpoints plus 2; if the cutpoint vector is
      * empty; if the cutpoint vector contains a non-positive,
@@ -56,42 +36,17 @@ namespace stan {
     typename boost::math::tools::promote_args<T_lambda, T_cut>::type
     ordered_logistic_log(int y, const T_lambda& lambda,
                          const Eigen::Matrix<T_cut, Eigen::Dynamic, 1>& c) {
-      using std::exp;
-      using std::log;
-
-      static const char* function("ordered_logistic");
-
-      int K = c.size() + 1;
-
-      check_bounded(function, "Random variable", y, 1, K);
-      check_finite(function, "Location parameter", lambda);
-      check_greater(function, "Size of cut points parameter", c.size(), 0);
-      for (int i = 1; i < c.size(); ++i)
-        check_greater(function, "Cut points parameter", c(i), c(i - 1));
-
-      check_finite(function, "Cut points parameter", c(c.size()-1));
-      check_finite(function, "Cut points parameter", c(0));
-
-      // log(1 - inv_logit(lambda))
-      if (y == 1)
-        return -log1p_exp(lambda - c(0));
-
-      // log(inv_logit(lambda - c(K-3)));
-      if (y == K) {
-        return -log1p_exp(c(K-2) - lambda);
-      }
-
-      // if (2 < y < K) { ... }
-      // log(inv_logit(lambda - c(y-2)) - inv_logit(lambda - c(y-1)))
-      return log_inv_logit_diff(c(y-2) - lambda,
-                                c(y-1) - lambda);
+      return ordered_logistic_lpmf<propto, T_lambda, T_cut>(y, lambda, c);
     }
 
+    /**
+     * @deprecated use <code>ordered_logistic_lpmf</code>
+     */
     template <typename T_lambda, typename T_cut>
     typename boost::math::tools::promote_args<T_lambda, T_cut>::type
     ordered_logistic_log(int y, const T_lambda& lambda,
                          const Eigen::Matrix<T_cut, Eigen::Dynamic, 1>& c) {
-      return ordered_logistic_log<false>(y, lambda, c);
+      return ordered_logistic_lpmf<T_lambda, T_cut>(y, lambda, c);
     }
 
   }

--- a/stan/math/prim/mat/prob/wishart_log.hpp
+++ b/stan/math/prim/mat/prob/wishart_log.hpp
@@ -1,22 +1,7 @@
 #ifndef STAN_MATH_PRIM_MAT_PROB_WISHART_LOG_HPP
 #define STAN_MATH_PRIM_MAT_PROB_WISHART_LOG_HPP
 
-#include <stan/math/prim/scal/err/check_size_match.hpp>
-#include <stan/math/prim/mat/err/check_ldlt_factor.hpp>
-#include <stan/math/prim/mat/err/check_square.hpp>
-#include <stan/math/prim/scal/err/check_greater.hpp>
-#include <stan/math/prim/scal/fun/lmgamma.hpp>
-#include <stan/math/prim/mat/fun/crossprod.hpp>
-#include <stan/math/prim/mat/fun/columns_dot_product.hpp>
-#include <stan/math/prim/mat/fun/trace.hpp>
-#include <stan/math/prim/mat/fun/log_determinant_ldlt.hpp>
-#include <stan/math/prim/mat/fun/mdivide_left_ldlt.hpp>
-#include <stan/math/prim/mat/fun/dot_product.hpp>
-#include <stan/math/prim/mat/fun/mdivide_left_tri_low.hpp>
-#include <stan/math/prim/mat/fun/multiply_lower_tri_self_transpose.hpp>
-#include <stan/math/prim/mat/meta/index_type.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
+#include <stan/math/prim/mat/prob/wishart_lpdf.hpp>
 
 namespace stan {
   namespace math {
@@ -38,6 +23,8 @@ namespace stan {
      -\frac{\nu}{2} \log(\det(S)) + \frac{\nu-k-1}{2}\log (\det(W)) - \frac{1}{2} \mbox{tr} (S^{-1}W)
      \f}
      *
+     * @deprecated use <code>wishart_lpdf</code>
+     *
      * @param W A scalar matrix
      * @param nu Degrees of freedom
      * @param S The scale matrix
@@ -55,54 +42,12 @@ namespace stan {
                 const T_dof& nu,
                 const Eigen::Matrix<T_scale, Eigen::Dynamic, Eigen::Dynamic>&
                 S) {
-      static const char* function("wishart_log");
-
-      using boost::math::tools::promote_args;
-      using Eigen::Dynamic;
-      using Eigen::Lower;
-      using Eigen::Matrix;
-
-      typename index_type<Matrix<T_scale, Dynamic, Dynamic> >::type k
-        = W.rows();
-      typename promote_args<T_y, T_dof, T_scale>::type lp(0.0);
-      check_greater(function, "Degrees of freedom parameter", nu, k-1);
-      check_square(function, "random variable", W);
-      check_square(function, "scale parameter", S);
-      check_size_match(function,
-                       "Rows of random variable", W.rows(),
-                       "columns of scale parameter", S.rows());
-
-      LDLT_factor<T_y, Eigen::Dynamic, Eigen::Dynamic> ldlt_W(W);
-      check_ldlt_factor(function, "LDLT_Factor of random variable",
-                        ldlt_W);
-
-      LDLT_factor<T_scale, Eigen::Dynamic, Eigen::Dynamic> ldlt_S(S);
-      check_ldlt_factor(function, "LDLT_Factor of scale parameter",
-                        ldlt_S);
-
-      if (include_summand<propto, T_dof>::value)
-        lp += nu * k * NEG_LOG_TWO_OVER_TWO;
-
-      if (include_summand<propto, T_dof>::value)
-        lp -= lmgamma(k, 0.5 * nu);
-
-      if (include_summand<propto, T_dof, T_scale>::value)
-        lp -= 0.5 * nu * log_determinant_ldlt(ldlt_S);
-
-      if (include_summand<propto, T_scale, T_y>::value) {
-        Matrix<typename promote_args<T_y, T_scale>::type, Dynamic, Dynamic>
-          Sinv_W(mdivide_left_ldlt
-                 (ldlt_S,
-                  static_cast<Matrix<T_y, Dynamic, Dynamic> >
-                  (W.template selfadjointView<Lower>())));
-        lp -= 0.5 * trace(Sinv_W);
-      }
-
-      if (include_summand<propto, T_y, T_dof>::value && nu != (k + 1))
-        lp += 0.5 * (nu - k - 1.0) * log_determinant_ldlt(ldlt_W);
-      return lp;
+      return wishart_lpdf<propto, T_y, T_dof, T_scale>(W, nu, S);
     }
 
+    /**
+     * @deprecated use <code>wishart_lpdf</code>
+     */
     template <typename T_y, typename T_dof, typename T_scale>
     inline
     typename boost::math::tools::promote_args<T_y, T_dof, T_scale>::type
@@ -110,7 +55,7 @@ namespace stan {
                 const T_dof& nu,
                 const Eigen::Matrix
                 <T_scale, Eigen::Dynamic, Eigen::Dynamic>& S) {
-      return wishart_log<false>(W, nu, S);
+      return wishart_lpdf<T_y, T_dof, T_scale>(W, nu, S);
     }
 
   }

--- a/stan/math/prim/scal/prob/bernoulli_ccdf_log.hpp
+++ b/stan/math/prim/scal/prob/bernoulli_ccdf_log.hpp
@@ -1,73 +1,18 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_BERNOULLI_CCDF_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_BERNOULLI_CCDF_LOG_HPP
 
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_bounded.hpp>
-#include <stan/math/prim/scal/err/check_finite.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/fun/inv_logit.hpp>
-#include <stan/math/prim/scal/fun/log1m.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <boost/random/bernoulli_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <cmath>
+#include <stan/math/prim/scal/prob/bernoulli_lccdf.hpp>
 
 namespace stan {
   namespace math {
 
+    /**
+     * @deprecated use <code>bernoulli_lccdf</code>
+     */
     template <typename T_n, typename T_prob>
     typename return_type<T_prob>::type
     bernoulli_ccdf_log(const T_n& n, const T_prob& theta) {
-      static const char* function("bernoulli_ccdf_log");
-      typedef typename stan::partials_return_type<T_n, T_prob>::type
-        T_partials_return;
-
-      if (!(stan::length(n) && stan::length(theta)))
-        return 0.0;
-
-      T_partials_return P(0.0);
-
-      check_finite(function, "Probability parameter", theta);
-      check_bounded(function, "Probability parameter", theta, 0.0, 1.0);
-      check_consistent_sizes(function,
-                             "Random variable", n,
-                             "Probability parameter", theta);
-
-      VectorView<const T_n> n_vec(n);
-      VectorView<const T_prob> theta_vec(theta);
-      size_t size = max_size(n, theta);
-
-      using std::log;
-      OperandsAndPartials<T_prob> operands_and_partials(theta);
-
-      // Explicit return for extreme values
-      // The gradients are technically ill-defined, but treated as zero
-      for (size_t i = 0; i < stan::length(n); i++) {
-        if (value_of(n_vec[i]) < 0)
-          return operands_and_partials.value(0.0);
-      }
-
-      for (size_t i = 0; i < size; i++) {
-        // Explicit results for extreme values
-        // The gradients are technically ill-defined, but treated as zero
-        if (value_of(n_vec[i]) >= 1) {
-          return operands_and_partials.value(negative_infinity());
-        } else {
-          const T_partials_return Pi = value_of(theta_vec[i]);
-
-          P += log(Pi);
-
-          if (!is_constant_struct<T_prob>::value)
-            operands_and_partials.d_x1[i] += 1 / Pi;
-        }
-      }
-
-      return operands_and_partials.value(P);
+      return bernoulli_lccdf<T_n, T_prob>(n, theta);
     }
   }
 }

--- a/stan/math/prim/scal/prob/bernoulli_cdf_log.hpp
+++ b/stan/math/prim/scal/prob/bernoulli_cdf_log.hpp
@@ -1,72 +1,18 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_BERNOULLI_CDF_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_BERNOULLI_CDF_LOG_HPP
 
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_bounded.hpp>
-#include <stan/math/prim/scal/err/check_finite.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/fun/inv_logit.hpp>
-#include <stan/math/prim/scal/fun/log1m.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <boost/random/bernoulli_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <cmath>
+#include <stan/math/prim/scal/prob/bernoulli_lcdf.hpp>
 
 namespace stan {
   namespace math {
 
+    /**
+     * @deprecated use <code>bernoulli_lcdf</code>
+     */
     template <typename T_n, typename T_prob>
     typename return_type<T_prob>::type
     bernoulli_cdf_log(const T_n& n, const T_prob& theta) {
-      static const char* function("bernoulli_cdf_log");
-      typedef typename stan::partials_return_type<T_n, T_prob>::type
-        T_partials_return;
-
-      if (!(stan::length(n) && stan::length(theta)))
-        return 0.0;
-
-      T_partials_return P(0.0);
-
-      check_finite(function, "Probability parameter", theta);
-      check_bounded(function, "Probability parameter", theta, 0.0, 1.0);
-      check_consistent_sizes(function,
-                             "Random variable", n,
-                             "Probability parameter", theta);
-
-      VectorView<const T_n> n_vec(n);
-      VectorView<const T_prob> theta_vec(theta);
-      size_t size = max_size(n, theta);
-
-      using std::log;
-      OperandsAndPartials<T_prob> operands_and_partials(theta);
-
-      // Explicit return for extreme values
-      // The gradients are technically ill-defined, but treated as zero
-      for (size_t i = 0; i < stan::length(n); i++) {
-        if (value_of(n_vec[i]) < 0)
-          return operands_and_partials.value(negative_infinity());
-      }
-
-      for (size_t i = 0; i < size; i++) {
-        // Explicit results for extreme values
-        // The gradients are technically ill-defined, but treated as zero
-        if (value_of(n_vec[i]) >= 1)
-          continue;
-
-        const T_partials_return Pi = 1 - value_of(theta_vec[i]);
-
-        P += log(Pi);
-
-        if (!is_constant_struct<T_prob>::value)
-          operands_and_partials.d_x1[i] -= 1 / Pi;
-      }
-
-      return operands_and_partials.value(P);
+      return bernoulli_lcdf<T_n, T_prob>(n, theta);
     }
 
   }

--- a/stan/math/prim/scal/prob/bernoulli_log.hpp
+++ b/stan/math/prim/scal/prob/bernoulli_log.hpp
@@ -1,112 +1,30 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_BERNOULLI_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_BERNOULLI_LOG_HPP
 
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_bounded.hpp>
-#include <stan/math/prim/scal/err/check_finite.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/fun/inv_logit.hpp>
-#include <stan/math/prim/scal/fun/log1m.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <boost/random/bernoulli_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <cmath>
+#include <stan/math/prim/scal/prob/bernoulli_lpmf.hpp>
 
 namespace stan {
   namespace math {
 
-    // Bernoulli(n|theta)   [0 <= n <= 1;   0 <= theta <= 1]
-    // FIXME: documentation
+    /**
+     * @deprecated use <code>bernoulli_lpmf</code>
+     */
     template <bool propto, typename T_n, typename T_prob>
     typename return_type<T_prob>::type
     bernoulli_log(const T_n& n,
                   const T_prob& theta) {
-      static const char* function("bernoulli_log");
-      typedef typename stan::partials_return_type<T_n, T_prob>::type
-        T_partials_return;
-
-      using std::log;
-
-      if (!(stan::length(n)
-            && stan::length(theta)))
-        return 0.0;
-
-      T_partials_return logp(0.0);
-
-      check_bounded(function, "n", n, 0, 1);
-      check_finite(function, "Probability parameter", theta);
-      check_bounded(function, "Probability parameter", theta, 0.0, 1.0);
-      check_consistent_sizes(function,
-                             "Random variable", n,
-                             "Probability parameter", theta);
-
-      if (!include_summand<propto, T_prob>::value)
-        return 0.0;
-
-      VectorView<const T_n> n_vec(n);
-      VectorView<const T_prob> theta_vec(theta);
-      size_t N = max_size(n, theta);
-      OperandsAndPartials<T_prob> operands_and_partials(theta);
-
-      if (length(theta) == 1) {
-        size_t sum = 0;
-        for (size_t n = 0; n < N; n++) {
-          sum += value_of(n_vec[n]);
-        }
-        const T_partials_return theta_dbl = value_of(theta_vec[0]);
-        // avoid nans when sum == N or sum == 0
-        if (sum == N) {
-          logp += N * log(theta_dbl);
-          if (!is_constant_struct<T_prob>::value)
-            operands_and_partials.d_x1[0] += N / theta_dbl;
-        } else if (sum == 0) {
-          logp += N * log1m(theta_dbl);
-          if (!is_constant_struct<T_prob>::value)
-            operands_and_partials.d_x1[0] += N / (theta_dbl - 1);
-        } else {
-          const T_partials_return log_theta = log(theta_dbl);
-          const T_partials_return log1m_theta = log1m(theta_dbl);
-
-          logp += sum * log_theta;
-          logp += (N - sum) * log1m_theta;
-
-          if (!is_constant_struct<T_prob>::value) {
-            operands_and_partials.d_x1[0] += sum / theta_dbl;
-            operands_and_partials.d_x1[0] += (N - sum) / (theta_dbl - 1);
-          }
-        }
-      } else {
-        for (size_t n = 0; n < N; n++) {
-          const int n_int = value_of(n_vec[n]);
-          const T_partials_return theta_dbl = value_of(theta_vec[n]);
-
-          if (n_int == 1)
-            logp += log(theta_dbl);
-          else
-            logp += log1m(theta_dbl);
-
-          if (!is_constant_struct<T_prob>::value) {
-            if (n_int == 1)
-              operands_and_partials.d_x1[n] += 1.0 / theta_dbl;
-            else
-              operands_and_partials.d_x1[n] += 1.0 / (theta_dbl - 1);
-          }
-        }
-      }
-      return operands_and_partials.value(logp);
+      return bernoulli_lpmf<propto, T_n, T_prob>(n, theta);
     }
 
+    /**
+     * @deprecated use <code>bernoulli_lpmf</code>
+     */
     template <typename T_y, typename T_prob>
     inline
     typename return_type<T_prob>::type
     bernoulli_log(const T_y& n,
                   const T_prob& theta) {
-      return bernoulli_log<false>(n, theta);
+      return bernoulli_lpmf<T_y, T_prob>(n, theta);
     }
 
   }

--- a/stan/math/prim/scal/prob/bernoulli_logit_log.hpp
+++ b/stan/math/prim/scal/prob/bernoulli_logit_log.hpp
@@ -1,95 +1,29 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_BERNOULLI_LOGIT_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_BERNOULLI_LOGIT_LOG_HPP
 
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_bounded.hpp>
-#include <stan/math/prim/scal/err/check_finite.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/fun/inv_logit.hpp>
-#include <stan/math/prim/scal/fun/log1m.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <boost/random/bernoulli_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <cmath>
+#include <stan/math/prim/scal/prob/bernoulli_logit_lpmf.hpp>
 
 namespace stan {
   namespace math {
 
-    // Bernoulli(n|inv_logit(theta))   [0 <= n <= 1;   -inf <= theta <= inf]
-    // FIXME: documentation
+    /**
+     * @deprecated use <code>bernoulli_logit_lpmf</code>
+     */
     template <bool propto, typename T_n, typename T_prob>
     typename return_type<T_prob>::type
     bernoulli_logit_log(const T_n& n, const T_prob& theta) {
-      static const char* function("bernoulli_logit_log");
-      typedef typename stan::partials_return_type<T_n, T_prob>::type
-        T_partials_return;
-
-      using stan::is_constant_struct;
-      using std::exp;
-
-      if (!(stan::length(n)
-            && stan::length(theta)))
-        return 0.0;
-
-      T_partials_return logp(0.0);
-
-      check_bounded(function, "n", n, 0, 1);
-      check_not_nan(function, "Logit transformed probability parameter", theta);
-      check_consistent_sizes(function,
-                             "Random variable", n,
-                             "Probability parameter", theta);
-
-      if (!include_summand<propto, T_prob>::value)
-        return 0.0;
-
-      VectorView<const T_n> n_vec(n);
-      VectorView<const T_prob> theta_vec(theta);
-      size_t N = max_size(n, theta);
-      OperandsAndPartials<T_prob> operands_and_partials(theta);
-
-      for (size_t n = 0; n < N; n++) {
-        const int n_int = value_of(n_vec[n]);
-        const T_partials_return theta_dbl = value_of(theta_vec[n]);
-
-        const int sign = 2*n_int-1;
-        const T_partials_return ntheta = sign * theta_dbl;
-        const T_partials_return exp_m_ntheta = exp(-ntheta);
-
-        // Handle extreme values gracefully using Taylor approximations.
-        static const double cutoff = 20.0;
-        if (ntheta > cutoff)
-          logp -= exp_m_ntheta;
-        else if (ntheta < -cutoff)
-          logp += ntheta;
-        else
-          logp -= log1p(exp_m_ntheta);
-
-        if (!is_constant_struct<T_prob>::value) {
-          static const double cutoff = 20.0;
-          if (ntheta > cutoff)
-            operands_and_partials.d_x1[n] -= exp_m_ntheta;
-          else if (ntheta < -cutoff)
-            operands_and_partials.d_x1[n] += sign;
-          else
-            operands_and_partials.d_x1[n] += sign * exp_m_ntheta
-              / (exp_m_ntheta + 1);
-        }
-      }
-      return operands_and_partials.value(logp);
+      return bernoulli_logit_lpmf<propto, T_n, T_prob>(n, theta);
     }
 
-    template <typename T_n,
-              typename T_prob>
+    /**
+     * @deprecated use <code>bernoulli_logit_lpmf</code>
+     */
+    template <typename T_n, typename T_prob>
     inline
     typename return_type<T_prob>::type
     bernoulli_logit_log(const T_n& n,
                         const T_prob& theta) {
-      return bernoulli_logit_log<false>(n, theta);
+      return bernoulli_logit_lpmf<T_n, T_prob>(n, theta);
     }
 
   }

--- a/stan/math/prim/scal/prob/beta_binomial_ccdf_log.hpp
+++ b/stan/math/prim/scal/prob/beta_binomial_ccdf_log.hpp
@@ -1,132 +1,20 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_BETA_BINOMIAL_CCDF_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_BETA_BINOMIAL_CCDF_LOG_HPP
 
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_nonnegative.hpp>
-#include <stan/math/prim/scal/err/check_positive_finite.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/fun/binomial_coefficient_log.hpp>
-#include <stan/math/prim/scal/fun/lbeta.hpp>
-#include <stan/math/prim/scal/fun/digamma.hpp>
-#include <stan/math/prim/scal/fun/lgamma.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/meta/contains_nonconstant_struct.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <stan/math/prim/scal/prob/beta_rng.hpp>
-#include <stan/math/prim/scal/fun/F32.hpp>
-#include <stan/math/prim/scal/fun/grad_F32.hpp>
-#include <cmath>
+#include <stan/math/prim/scal/prob/beta_binomial_lccdf.hpp>
 
 namespace stan {
   namespace math {
 
+    /**
+     * @deprecated use <code>beta_binomial_lccdf</code>
+     */
     template <typename T_n, typename T_N,
               typename T_size1, typename T_size2>
     typename return_type<T_size1, T_size2>::type
     beta_binomial_ccdf_log(const T_n& n, const T_N& N, const T_size1& alpha,
                            const T_size2& beta) {
-      static const char* function("beta_binomial_ccdf_log");
-      typedef typename stan::partials_return_type<T_n, T_N, T_size1,
-                                                  T_size2>::type
-        T_partials_return;
-
-      if (!(stan::length(n) && stan::length(N) && stan::length(alpha)
-            && stan::length(beta)))
-        return 0.0;
-
-      T_partials_return P(0.0);
-
-      check_nonnegative(function, "Population size parameter", N);
-      check_positive_finite(function,
-                            "First prior sample size parameter", alpha);
-      check_positive_finite(function,
-                            "Second prior sample size parameter", beta);
-      check_consistent_sizes(function,
-                             "Successes variable", n,
-                             "Population size parameter", N,
-                             "First prior sample size parameter", alpha,
-                             "Second prior sample size parameter", beta);
-
-      VectorView<const T_n> n_vec(n);
-      VectorView<const T_N> N_vec(N);
-      VectorView<const T_size1> alpha_vec(alpha);
-      VectorView<const T_size2> beta_vec(beta);
-      size_t size = max_size(n, N, alpha, beta);
-
-      using std::exp;
-      using std::log;
-      using std::exp;
-
-      OperandsAndPartials<T_size1, T_size2>
-        operands_and_partials(alpha, beta);
-
-      // Explicit return for extreme values
-      // The gradients are technically ill-defined, but treated as neg infinity
-      for (size_t i = 0; i < stan::length(n); i++) {
-        if (value_of(n_vec[i]) <= 0)
-          return operands_and_partials.value(0.0);
-      }
-
-      for (size_t i = 0; i < size; i++) {
-        // Explicit results for extreme values
-        // The gradients are technically ill-defined, but treated as zero
-        if (value_of(n_vec[i]) >= value_of(N_vec[i])) {
-          return operands_and_partials.value(negative_infinity());
-        }
-
-        const T_partials_return n_dbl = value_of(n_vec[i]);
-        const T_partials_return N_dbl = value_of(N_vec[i]);
-        const T_partials_return alpha_dbl = value_of(alpha_vec[i]);
-        const T_partials_return beta_dbl = value_of(beta_vec[i]);
-
-        const T_partials_return mu = alpha_dbl + n_dbl + 1;
-        const T_partials_return nu = beta_dbl + N_dbl - n_dbl - 1;
-
-        const T_partials_return F = F32((T_partials_return)1, mu,
-                                        -N_dbl + n_dbl + 1,
-                                        n_dbl + 2, 1 - nu,
-                                        (T_partials_return)1);
-
-        T_partials_return C = lgamma(nu) - lgamma(N_dbl - n_dbl);
-        C += lgamma(mu) - lgamma(n_dbl + 2);
-        C += lgamma(N_dbl + 2) - lgamma(N_dbl + alpha_dbl + beta_dbl);
-        C = exp(C);
-
-        C *= F / exp(lbeta(alpha_dbl, beta_dbl));
-        C /= N_dbl + 1;
-
-        const T_partials_return Pi = C;
-
-        P += log(Pi);
-
-        T_partials_return dF[6];
-        T_partials_return digammaOne = 0;
-        T_partials_return digammaTwo = 0;
-
-        if (contains_nonconstant_struct<T_size1, T_size2>::value) {
-          digammaOne = digamma(mu + nu);
-          digammaTwo = digamma(alpha_dbl + beta_dbl);
-          grad_F32(dF, (T_partials_return)1, mu, -N_dbl + n_dbl + 1,
-                   n_dbl + 2, 1 - nu, (T_partials_return)1);
-        }
-        if (!is_constant_struct<T_size1>::value) {
-          const T_partials_return g
-            = - C * (digamma(mu) - digammaOne + dF[1] / F
-                     - digamma(alpha_dbl) + digammaTwo);
-          operands_and_partials.d_x1[i] -= g / Pi;
-        }
-        if (!is_constant_struct<T_size2>::value) {
-          const T_partials_return g
-            = - C * (digamma(nu) - digammaOne - dF[4] / F - digamma(beta_dbl)
-                     + digammaTwo);
-          operands_and_partials.d_x2[i] -= g / Pi;
-        }
-      }
-
-      return operands_and_partials.value(P);
+      return beta_binomial_lccdf<T_n, T_N, T_size1, T_size2>(n, N, alpha, beta);
     }
 
   }

--- a/stan/math/prim/scal/prob/beta_binomial_cdf_log.hpp
+++ b/stan/math/prim/scal/prob/beta_binomial_cdf_log.hpp
@@ -1,132 +1,20 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_BETA_BINOMIAL_CDF_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_BETA_BINOMIAL_CDF_LOG_HPP
 
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_nonnegative.hpp>
-#include <stan/math/prim/scal/err/check_positive_finite.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/fun/binomial_coefficient_log.hpp>
-#include <stan/math/prim/scal/fun/lbeta.hpp>
-#include <stan/math/prim/scal/fun/digamma.hpp>
-#include <stan/math/prim/scal/fun/lgamma.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/meta/contains_nonconstant_struct.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <stan/math/prim/scal/prob/beta_rng.hpp>
-#include <stan/math/prim/scal/fun/F32.hpp>
-#include <stan/math/prim/scal/fun/grad_F32.hpp>
-#include <cmath>
+#include <stan/math/prim/scal/prob/beta_binomial_lcdf.hpp>
 
 namespace stan {
   namespace math {
 
+    /**
+     * @deprecated use <code>beta_binomial_lcdf</code>
+     */
     template <typename T_n, typename T_N,
               typename T_size1, typename T_size2>
     typename return_type<T_size1, T_size2>::type
     beta_binomial_cdf_log(const T_n& n, const T_N& N, const T_size1& alpha,
                           const T_size2& beta) {
-      static const char* function("beta_binomial_cdf_log");
-      typedef typename stan::partials_return_type<T_n, T_N, T_size1,
-                                                  T_size2>::type
-        T_partials_return;
-
-      if (!(stan::length(n) && stan::length(N) && stan::length(alpha)
-            && stan::length(beta)))
-        return 0.0;
-
-      T_partials_return P(0.0);
-
-      check_nonnegative(function, "Population size parameter", N);
-      check_positive_finite(function,
-                            "First prior sample size parameter", alpha);
-      check_positive_finite(function,
-                            "Second prior sample size parameter", beta);
-      check_consistent_sizes(function,
-                             "Successes variable", n,
-                             "Population size parameter", N,
-                             "First prior sample size parameter", alpha,
-                             "Second prior sample size parameter", beta);
-
-      VectorView<const T_n> n_vec(n);
-      VectorView<const T_N> N_vec(N);
-      VectorView<const T_size1> alpha_vec(alpha);
-      VectorView<const T_size2> beta_vec(beta);
-      size_t size = max_size(n, N, alpha, beta);
-
-      using std::exp;
-      using std::log;
-      using std::exp;
-
-      OperandsAndPartials<T_size1, T_size2>
-        operands_and_partials(alpha, beta);
-
-      // Explicit return for extreme values
-      // The gradients are technically ill-defined, but treated as neg infinity
-      for (size_t i = 0; i < stan::length(n); i++) {
-        if (value_of(n_vec[i]) <= 0)
-          return operands_and_partials.value(negative_infinity());
-      }
-
-      for (size_t i = 0; i < size; i++) {
-        // Explicit results for extreme values
-        // The gradients are technically ill-defined, but treated as zero
-        if (value_of(n_vec[i]) >= value_of(N_vec[i])) {
-          continue;
-        }
-
-        const T_partials_return n_dbl = value_of(n_vec[i]);
-        const T_partials_return N_dbl = value_of(N_vec[i]);
-        const T_partials_return alpha_dbl = value_of(alpha_vec[i]);
-        const T_partials_return beta_dbl = value_of(beta_vec[i]);
-
-        const T_partials_return mu = alpha_dbl + n_dbl + 1;
-        const T_partials_return nu = beta_dbl + N_dbl - n_dbl - 1;
-
-        const T_partials_return F = F32((T_partials_return)1, mu,
-                                                    -N_dbl + n_dbl + 1,
-                                                    n_dbl + 2, 1 - nu,
-                                                    (T_partials_return)1);
-
-        T_partials_return C = lgamma(nu) - lgamma(N_dbl - n_dbl);
-        C += lgamma(mu) - lgamma(n_dbl + 2);
-        C += lgamma(N_dbl + 2) - lgamma(N_dbl + alpha_dbl + beta_dbl);
-        C = exp(C);
-
-        C *= F / exp(lbeta(alpha_dbl, beta_dbl));
-        C /= N_dbl + 1;
-
-        const T_partials_return Pi = 1 - C;
-
-        P += log(Pi);
-
-        T_partials_return dF[6];
-        T_partials_return digammaOne = 0;
-        T_partials_return digammaTwo = 0;
-
-        if (contains_nonconstant_struct<T_size1, T_size2>::value) {
-          digammaOne = digamma(mu + nu);
-          digammaTwo = digamma(alpha_dbl + beta_dbl);
-          grad_F32(dF, (T_partials_return)1, mu, -N_dbl + n_dbl + 1,
-                               n_dbl + 2, 1 - nu, (T_partials_return)1);
-        }
-        if (!is_constant_struct<T_size1>::value) {
-          const T_partials_return g
-            = - C * (digamma(mu) - digammaOne + dF[1] / F
-                     - digamma(alpha_dbl) + digammaTwo);
-          operands_and_partials.d_x1[i] += g / Pi;
-        }
-        if (!is_constant_struct<T_size2>::value) {
-          const T_partials_return g
-            = - C * (digamma(nu) - digammaOne - dF[4] / F - digamma(beta_dbl)
-                     + digammaTwo);
-          operands_and_partials.d_x2[i] += g / Pi;
-        }
-      }
-
-      return operands_and_partials.value(P);
+      return beta_binomial_lcdf<T_n, T_N, T_size1, T_size2>(n, N, alpha, beta);
     }
 
   }

--- a/stan/math/prim/scal/prob/beta_binomial_log.hpp
+++ b/stan/math/prim/scal/prob/beta_binomial_log.hpp
@@ -1,29 +1,14 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_BETA_BINOMIAL_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_BETA_BINOMIAL_LOG_HPP
 
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_nonnegative.hpp>
-#include <stan/math/prim/scal/err/check_positive_finite.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/fun/lbeta.hpp>
-#include <stan/math/prim/scal/fun/digamma.hpp>
-#include <stan/math/prim/scal/fun/lgamma.hpp>
-#include <stan/math/prim/scal/fun/binomial_coefficient_log.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/meta/contains_nonconstant_struct.hpp>
-#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <stan/math/prim/scal/prob/beta_rng.hpp>
-#include <stan/math/prim/scal/fun/F32.hpp>
-#include <stan/math/prim/scal/fun/grad_F32.hpp>
+#include <stan/math/prim/scal/prob/beta_binomial_lpmf.hpp>
 
 namespace stan {
   namespace math {
 
-    // BetaBinomial(n|alpha, beta) [alpha > 0;  beta > 0;  n >= 0]
+    /**
+     * @deprecated use <code>beta_binomial_lpmf</code>
+     */
     template <bool propto,
               typename T_n, typename T_N,
               typename T_size1, typename T_size2>
@@ -32,130 +17,13 @@ namespace stan {
                       const T_N& N,
                       const T_size1& alpha,
                       const T_size2& beta) {
-      static const char* function("beta_binomial_log");
-      typedef typename stan::partials_return_type<T_size1, T_size2>::type
-        T_partials_return;
-
-      if (!(stan::length(n)
-            && stan::length(N)
-            && stan::length(alpha)
-            && stan::length(beta)))
-        return 0.0;
-
-      T_partials_return logp(0.0);
-      check_nonnegative(function, "Population size parameter", N);
-      check_positive_finite(function,
-                            "First prior sample size parameter", alpha);
-      check_positive_finite(function,
-                            "Second prior sample size parameter", beta);
-      check_consistent_sizes(function,
-                             "Successes variable", n,
-                             "Population size parameter", N,
-                             "First prior sample size parameter", alpha,
-                             "Second prior sample size parameter", beta);
-
-      if (!include_summand<propto, T_size1, T_size2>::value)
-        return 0.0;
-
-      OperandsAndPartials<T_size1, T_size2>
-        operands_and_partials(alpha, beta);
-
-      VectorView<const T_n> n_vec(n);
-      VectorView<const T_N> N_vec(N);
-      VectorView<const T_size1> alpha_vec(alpha);
-      VectorView<const T_size2> beta_vec(beta);
-      size_t size = max_size(n, N, alpha, beta);
-
-      for (size_t i = 0; i < size; i++) {
-        if (n_vec[i] < 0 || n_vec[i] > N_vec[i])
-          return operands_and_partials.value(LOG_ZERO);
-      }
-
-      VectorBuilder<include_summand<propto>::value,
-                    T_partials_return, T_n, T_N>
-        normalizing_constant(max_size(N, n));
-      for (size_t i = 0; i < max_size(N, n); i++)
-        if (include_summand<propto>::value)
-          normalizing_constant[i]
-            = binomial_coefficient_log(N_vec[i], n_vec[i]);
-
-      VectorBuilder<include_summand<propto, T_size1, T_size2>::value,
-                    T_partials_return, T_n, T_N, T_size1, T_size2>
-        lbeta_numerator(size);
-      for (size_t i = 0; i < size; i++)
-        if (include_summand<propto, T_size1, T_size2>::value)
-          lbeta_numerator[i] = lbeta(n_vec[i] + value_of(alpha_vec[i]),
-                                     N_vec[i] - n_vec[i]
-                                     + value_of(beta_vec[i]));
-
-      VectorBuilder<include_summand<propto, T_size1, T_size2>::value,
-                    T_partials_return, T_size1, T_size2>
-        lbeta_denominator(max_size(alpha, beta));
-      for (size_t i = 0; i < max_size(alpha, beta); i++)
-        if (include_summand<propto, T_size1, T_size2>::value)
-          lbeta_denominator[i] = lbeta(value_of(alpha_vec[i]),
-                                       value_of(beta_vec[i]));
-
-      VectorBuilder<!is_constant_struct<T_size1>::value,
-                    T_partials_return, T_n, T_size1>
-        digamma_n_plus_alpha(max_size(n, alpha));
-      for (size_t i = 0; i < max_size(n, alpha); i++)
-        if (!is_constant_struct<T_size1>::value)
-          digamma_n_plus_alpha[i]
-            = digamma(n_vec[i] + value_of(alpha_vec[i]));
-
-      VectorBuilder<contains_nonconstant_struct<T_size1, T_size2>::value,
-                    T_partials_return, T_N, T_size1, T_size2>
-        digamma_N_plus_alpha_plus_beta(max_size(N, alpha, beta));
-      for (size_t i = 0; i < max_size(N, alpha, beta); i++)
-        if (contains_nonconstant_struct<T_size1, T_size2>::value)
-          digamma_N_plus_alpha_plus_beta[i]
-            = digamma(N_vec[i] + value_of(alpha_vec[i])
-                      + value_of(beta_vec[i]));
-
-      VectorBuilder<contains_nonconstant_struct<T_size1, T_size2>::value,
-                    T_partials_return, T_size1, T_size2>
-        digamma_alpha_plus_beta(max_size(alpha, beta));
-      for (size_t i = 0; i < max_size(alpha, beta); i++)
-        if (contains_nonconstant_struct<T_size1, T_size2>::value)
-          digamma_alpha_plus_beta[i]
-            = digamma(value_of(alpha_vec[i]) + value_of(beta_vec[i]));
-
-      VectorBuilder<!is_constant_struct<T_size1>::value,
-                    T_partials_return, T_size1> digamma_alpha(length(alpha));
-      for (size_t i = 0; i < length(alpha); i++)
-        if (!is_constant_struct<T_size1>::value)
-          digamma_alpha[i] = digamma(value_of(alpha_vec[i]));
-
-      VectorBuilder<!is_constant_struct<T_size2>::value,
-                    T_partials_return, T_size2>
-        digamma_beta(length(beta));
-      for (size_t i = 0; i < length(beta); i++)
-        if (!is_constant_struct<T_size2>::value)
-          digamma_beta[i] = digamma(value_of(beta_vec[i]));
-
-      for (size_t i = 0; i < size; i++) {
-        if (include_summand<propto>::value)
-          logp += normalizing_constant[i];
-        if (include_summand<propto, T_size1, T_size2>::value)
-          logp += lbeta_numerator[i] - lbeta_denominator[i];
-
-        if (!is_constant_struct<T_size1>::value)
-          operands_and_partials.d_x1[i]
-            += digamma_n_plus_alpha[i]
-            - digamma_N_plus_alpha_plus_beta[i]
-            + digamma_alpha_plus_beta[i]
-            - digamma_alpha[i];
-        if (!is_constant_struct<T_size2>::value)
-          operands_and_partials.d_x2[i]
-            += digamma(value_of(N_vec[i]-n_vec[i]+beta_vec[i]))
-            - digamma_N_plus_alpha_plus_beta[i]
-            + digamma_alpha_plus_beta[i]
-            - digamma_beta[i];
-      }
-      return operands_and_partials.value(logp);
+      return beta_binomial_lpmf<propto,
+                                T_n, T_N, T_size1, T_size2>(n, N, alpha, beta);
     }
 
+    /**
+     * @deprecated use <code>beta_binomial_lpmf</code>
+     */
     template <typename T_n,
               typename T_N,
               typename T_size1,
@@ -163,7 +31,7 @@ namespace stan {
     typename return_type<T_size1, T_size2>::type
     beta_binomial_log(const T_n& n, const T_N& N,
                       const T_size1& alpha, const T_size2& beta) {
-      return beta_binomial_log<false>(n, N, alpha, beta);
+      return beta_binomial_lpmf<T_n, T_N, T_size1, T_size2>(n, N, alpha, beta);
     }
 
   }

--- a/stan/math/prim/scal/prob/beta_ccdf_log.hpp
+++ b/stan/math/prim/scal/prob/beta_ccdf_log.hpp
@@ -1,130 +1,19 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_BETA_CCDF_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_BETA_CCDF_LOG_HPP
 
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_less_or_equal.hpp>
-#include <stan/math/prim/scal/err/check_nonnegative.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/err/check_positive_finite.hpp>
-#include <stan/math/prim/scal/fun/log1m.hpp>
-#include <stan/math/prim/scal/fun/multiply_log.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/fun/digamma.hpp>
-#include <stan/math/prim/scal/fun/lgamma.hpp>
-#include <stan/math/prim/scal/fun/lbeta.hpp>
-#include <stan/math/prim/scal/meta/contains_nonconstant_struct.hpp>
-#include <stan/math/prim/scal/meta/VectorView.hpp>
-#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <stan/math/prim/scal/fun/grad_reg_inc_beta.hpp>
-#include <stan/math/prim/scal/fun/inc_beta.hpp>
-#include <boost/math/special_functions/gamma.hpp>
-#include <boost/random/gamma_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <cmath>
+#include <stan/math/prim/scal/prob/beta_lccdf.hpp>
 
 namespace stan {
   namespace math {
 
+    /**
+     * @deprecated use <code>beta_lccdf</code>
+     */
     template <typename T_y, typename T_scale_succ, typename T_scale_fail>
     typename return_type<T_y, T_scale_succ, T_scale_fail>::type
     beta_ccdf_log(const T_y& y, const T_scale_succ& alpha,
                   const T_scale_fail& beta) {
-      typedef typename stan::partials_return_type<T_y, T_scale_succ,
-                                                  T_scale_fail>::type
-        T_partials_return;
-
-      if ( !( stan::length(y) && stan::length(alpha)
-              && stan::length(beta) ) )
-        return 0.0;
-
-      static const char* function("beta_ccdf_log");
-
-      using boost::math::tools::promote_args;
-
-      T_partials_return ccdf_log(0.0);
-
-      check_positive_finite(function, "First shape parameter", alpha);
-      check_positive_finite(function, "Second shape parameter", beta);
-      check_not_nan(function, "Random variable", y);
-      check_nonnegative(function, "Random variable", y);
-      check_less_or_equal(function, "Random variable", y, 1);
-      check_consistent_sizes(function,
-                             "Random variable", y,
-                             "First shape parameter", alpha,
-                             "Second shape parameter", beta);
-
-      VectorView<const T_y> y_vec(y);
-      VectorView<const T_scale_succ> alpha_vec(alpha);
-      VectorView<const T_scale_fail> beta_vec(beta);
-      size_t N = max_size(y, alpha, beta);
-
-      OperandsAndPartials<T_y, T_scale_succ, T_scale_fail>
-        operands_and_partials(y, alpha, beta);
-
-      using std::pow;
-      using std::exp;
-      using std::log;
-      using std::exp;
-
-      VectorBuilder<contains_nonconstant_struct<T_scale_succ,
-                                                T_scale_fail>::value,
-                    T_partials_return, T_scale_succ, T_scale_fail>
-        digamma_alpha_vec(max_size(alpha, beta));
-      VectorBuilder<contains_nonconstant_struct<T_scale_succ,
-                                                T_scale_fail>::value,
-                    T_partials_return, T_scale_succ, T_scale_fail>
-        digamma_beta_vec(max_size(alpha, beta));
-      VectorBuilder<contains_nonconstant_struct<T_scale_succ,
-                                                T_scale_fail>::value,
-                    T_partials_return, T_scale_succ, T_scale_fail>
-        digamma_sum_vec(max_size(alpha, beta));
-
-      if (contains_nonconstant_struct<T_scale_succ, T_scale_fail>::value) {
-        for (size_t i = 0; i < N; i++) {
-          const T_partials_return alpha_dbl = value_of(alpha_vec[i]);
-          const T_partials_return beta_dbl = value_of(beta_vec[i]);
-
-          digamma_alpha_vec[i] = digamma(alpha_dbl);
-          digamma_beta_vec[i] = digamma(beta_dbl);
-          digamma_sum_vec[i] = digamma(alpha_dbl + beta_dbl);
-        }
-      }
-
-      for (size_t n = 0; n < N; n++) {
-        const T_partials_return y_dbl = value_of(y_vec[n]);
-        const T_partials_return alpha_dbl = value_of(alpha_vec[n]);
-        const T_partials_return beta_dbl = value_of(beta_vec[n]);
-        const T_partials_return betafunc_dbl = exp(lbeta(alpha_dbl, beta_dbl));
-
-        const T_partials_return Pn = 1.0 - inc_beta(alpha_dbl, beta_dbl, y_dbl);
-
-        ccdf_log += log(Pn);
-
-        if (!is_constant_struct<T_y>::value)
-          operands_and_partials.d_x1[n] -= pow(1-y_dbl, beta_dbl-1)
-            * pow(y_dbl, alpha_dbl-1) / betafunc_dbl / Pn;
-
-        T_partials_return g1 = 0;
-        T_partials_return g2 = 0;
-
-        if (contains_nonconstant_struct<T_scale_succ, T_scale_fail>::value) {
-          grad_reg_inc_beta(g1, g2, alpha_dbl, beta_dbl, y_dbl,
-                            digamma_alpha_vec[n],
-                            digamma_beta_vec[n],
-                            digamma_sum_vec[n],
-                            betafunc_dbl);
-        }
-        if (!is_constant_struct<T_scale_succ>::value)
-          operands_and_partials.d_x2[n] -= g1 / Pn;
-        if (!is_constant_struct<T_scale_fail>::value)
-          operands_and_partials.d_x3[n] -= g2 / Pn;
-      }
-      return operands_and_partials.value(ccdf_log);
+      return beta_lccdf<T_y, T_scale_succ, T_scale_fail>(y, alpha, beta);
     }
 
   }

--- a/stan/math/prim/scal/prob/beta_cdf_log.hpp
+++ b/stan/math/prim/scal/prob/beta_cdf_log.hpp
@@ -1,130 +1,19 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_BETA_CDF_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_BETA_CDF_LOG_HPP
 
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_less_or_equal.hpp>
-#include <stan/math/prim/scal/err/check_nonnegative.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/err/check_positive_finite.hpp>
-#include <stan/math/prim/scal/fun/log1m.hpp>
-#include <stan/math/prim/scal/fun/multiply_log.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/fun/digamma.hpp>
-#include <stan/math/prim/scal/fun/lgamma.hpp>
-#include <stan/math/prim/scal/fun/lbeta.hpp>
-#include <stan/math/prim/scal/meta/contains_nonconstant_struct.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
-#include <stan/math/prim/scal/fun/grad_reg_inc_beta.hpp>
-#include <stan/math/prim/scal/fun/inc_beta.hpp>
-#include <boost/math/special_functions/gamma.hpp>
-#include <boost/random/gamma_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <cmath>
+#include <stan/math/prim/scal/prob/beta_lcdf.hpp>
 
 namespace stan {
   namespace math {
 
+    /**
+     * @deprecated use <code>beta_lcdf</code>
+     */
     template <typename T_y, typename T_scale_succ, typename T_scale_fail>
     typename return_type<T_y, T_scale_succ, T_scale_fail>::type
     beta_cdf_log(const T_y& y, const T_scale_succ& alpha,
                  const T_scale_fail& beta) {
-      typedef typename stan::partials_return_type<T_y, T_scale_succ,
-                                                  T_scale_fail>::type
-        T_partials_return;
-
-      if ( !( stan::length(y) && stan::length(alpha)
-              && stan::length(beta) ) )
-        return 0.0;
-
-      static const char* function("beta_cdf_log");
-
-      using boost::math::tools::promote_args;
-
-      T_partials_return cdf_log(0.0);
-
-      check_positive_finite(function, "First shape parameter", alpha);
-      check_positive_finite(function, "Second shape parameter", beta);
-      check_not_nan(function, "Random variable", y);
-      check_nonnegative(function, "Random variable", y);
-      check_less_or_equal(function, "Random variable", y, 1);
-      check_consistent_sizes(function,
-                             "Random variable", y,
-                             "First shape parameter", alpha,
-                             "Second shape parameter", beta);
-
-      VectorView<const T_y> y_vec(y);
-      VectorView<const T_scale_succ> alpha_vec(alpha);
-      VectorView<const T_scale_fail> beta_vec(beta);
-      size_t N = max_size(y, alpha, beta);
-
-      OperandsAndPartials<T_y, T_scale_succ, T_scale_fail>
-        operands_and_partials(y, alpha, beta);
-
-      using std::pow;
-      using std::exp;
-      using std::log;
-      using std::exp;
-
-      VectorBuilder<contains_nonconstant_struct<T_scale_succ,
-                                                T_scale_fail>::value,
-                    T_partials_return, T_scale_succ, T_scale_fail>
-        digamma_alpha_vec(max_size(alpha, beta));
-
-      VectorBuilder<contains_nonconstant_struct<T_scale_succ,
-                                                T_scale_fail>::value,
-                    T_partials_return, T_scale_succ, T_scale_fail>
-        digamma_beta_vec(max_size(alpha, beta));
-
-      VectorBuilder<contains_nonconstant_struct<T_scale_succ,
-                                                T_scale_fail>::value,
-                    T_partials_return, T_scale_succ, T_scale_fail>
-        digamma_sum_vec(max_size(alpha, beta));
-
-      if (contains_nonconstant_struct<T_scale_succ, T_scale_fail>::value) {
-        for (size_t i = 0; i < N; i++) {
-          const T_partials_return alpha_dbl = value_of(alpha_vec[i]);
-          const T_partials_return beta_dbl = value_of(beta_vec[i]);
-
-          digamma_alpha_vec[i] = digamma(alpha_dbl);
-          digamma_beta_vec[i] = digamma(beta_dbl);
-          digamma_sum_vec[i] = digamma(alpha_dbl + beta_dbl);
-        }
-      }
-
-      for (size_t n = 0; n < N; n++) {
-        const T_partials_return y_dbl = value_of(y_vec[n]);
-        const T_partials_return alpha_dbl = value_of(alpha_vec[n]);
-        const T_partials_return beta_dbl = value_of(beta_vec[n]);
-        const T_partials_return betafunc_dbl = exp(lbeta(alpha_dbl, beta_dbl));
-        const T_partials_return Pn = inc_beta(alpha_dbl, beta_dbl, y_dbl);
-
-        cdf_log += log(Pn);
-
-        if (!is_constant_struct<T_y>::value)
-          operands_and_partials.d_x1[n] += pow(1-y_dbl, beta_dbl-1)
-            * pow(y_dbl, alpha_dbl-1) / betafunc_dbl / Pn;
-
-        T_partials_return g1 = 0;
-        T_partials_return g2 = 0;
-
-        if (contains_nonconstant_struct<T_scale_succ, T_scale_fail>::value) {
-          grad_reg_inc_beta(g1, g2, alpha_dbl, beta_dbl, y_dbl,
-                            digamma_alpha_vec[n],
-                            digamma_beta_vec[n], digamma_sum_vec[n],
-                            betafunc_dbl);
-        }
-        if (!is_constant_struct<T_scale_succ>::value)
-          operands_and_partials.d_x2[n] += g1 / Pn;
-        if (!is_constant_struct<T_scale_fail>::value)
-          operands_and_partials.d_x3[n]  += g2 / Pn;
-      }
-
-      return operands_and_partials.value(cdf_log);
+      return beta_lcdf<T_y, T_scale_succ, T_scale_fail>(y, alpha, beta);
     }
 
   }

--- a/stan/math/prim/scal/prob/beta_log.hpp
+++ b/stan/math/prim/scal/prob/beta_log.hpp
@@ -1,30 +1,7 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_BETA_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_BETA_LOG_HPP
 
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_less_or_equal.hpp>
-#include <stan/math/prim/scal/err/check_nonnegative.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/err/check_positive_finite.hpp>
-#include <stan/math/prim/scal/fun/log1m.hpp>
-#include <stan/math/prim/scal/fun/multiply_log.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/fun/digamma.hpp>
-#include <stan/math/prim/scal/fun/lgamma.hpp>
-#include <stan/math/prim/scal/fun/lbeta.hpp>
-#include <stan/math/prim/scal/meta/contains_nonconstant_struct.hpp>
-#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <stan/math/prim/scal/fun/grad_reg_inc_beta.hpp>
-#include <stan/math/prim/scal/fun/inc_beta.hpp>
-#include <boost/math/special_functions/gamma.hpp>
-#include <boost/random/gamma_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <cmath>
+#include <stan/math/prim/scal/prob/beta_lpdf.hpp>
 
 namespace stan {
   namespace math {
@@ -39,6 +16,8 @@ namespace stan {
      *
      * Prior sample sizes, alpha and beta, must be greater than 0.
      *
+     * @deprecated use <code>beta_lpdf</code>
+     *
      * @param y (Sequence of) scalar(s).
      * @param alpha (Sequence of) prior sample size(s).
      * @param beta (Sequence of) prior sample size(s).
@@ -52,144 +31,17 @@ namespace stan {
     typename return_type<T_y, T_scale_succ, T_scale_fail>::type
     beta_log(const T_y& y,
              const T_scale_succ& alpha, const T_scale_fail& beta) {
-      static const char* function("beta_log");
-
-      typedef typename stan::partials_return_type<T_y,
-                                                  T_scale_succ,
-                                                  T_scale_fail>::type
-        T_partials_return;
-
-      using stan::is_constant_struct;
-      using stan::is_vector;
-      using std::log;
-
-      if (!(stan::length(y)
-            && stan::length(alpha)
-            && stan::length(beta)))
-        return 0.0;
-
-      T_partials_return logp(0.0);
-
-      check_positive_finite(function, "First shape parameter", alpha);
-      check_positive_finite(function, "Second shape parameter", beta);
-      check_not_nan(function, "Random variable", y);
-      check_consistent_sizes(function,
-                             "Random variable", y,
-                             "First shape parameter", alpha,
-                             "Second shape parameter", beta);
-      check_nonnegative(function, "Random variable", y);
-      check_less_or_equal(function, "Random variable", y, 1);
-
-      if (!include_summand<propto, T_y, T_scale_succ, T_scale_fail>::value)
-        return 0.0;
-
-      VectorView<const T_y> y_vec(y);
-      VectorView<const T_scale_succ> alpha_vec(alpha);
-      VectorView<const T_scale_fail> beta_vec(beta);
-      size_t N = max_size(y, alpha, beta);
-
-      for (size_t n = 0; n < N; n++) {
-        const T_partials_return y_dbl = value_of(y_vec[n]);
-        if (y_dbl < 0 || y_dbl > 1)
-          return LOG_ZERO;
-      }
-
-      OperandsAndPartials<T_y, T_scale_succ, T_scale_fail>
-        operands_and_partials(y, alpha, beta);
-
-      VectorBuilder<include_summand<propto, T_y, T_scale_succ>::value,
-                    T_partials_return, T_y>
-        log_y(length(y));
-      VectorBuilder<include_summand<propto, T_y, T_scale_fail>::value,
-                    T_partials_return, T_y>
-        log1m_y(length(y));
-
-      for (size_t n = 0; n < length(y); n++) {
-        if (include_summand<propto, T_y, T_scale_succ>::value)
-          log_y[n] = log(value_of(y_vec[n]));
-        if (include_summand<propto, T_y, T_scale_fail>::value)
-          log1m_y[n] = log1m(value_of(y_vec[n]));
-      }
-
-      VectorBuilder<include_summand<propto, T_scale_succ>::value,
-                    T_partials_return, T_scale_succ>
-        lgamma_alpha(length(alpha));
-      VectorBuilder<!is_constant_struct<T_scale_succ>::value,
-                    T_partials_return, T_scale_succ>
-        digamma_alpha(length(alpha));
-      for (size_t n = 0; n < length(alpha); n++) {
-        if (include_summand<propto, T_scale_succ>::value)
-          lgamma_alpha[n] = lgamma(value_of(alpha_vec[n]));
-        if (!is_constant_struct<T_scale_succ>::value)
-          digamma_alpha[n] = digamma(value_of(alpha_vec[n]));
-      }
-
-      VectorBuilder<include_summand<propto, T_scale_fail>::value,
-                    T_partials_return, T_scale_fail>
-        lgamma_beta(length(beta));
-      VectorBuilder<!is_constant_struct<T_scale_fail>::value,
-                    T_partials_return, T_scale_fail>
-        digamma_beta(length(beta));
-
-      for (size_t n = 0; n < length(beta); n++) {
-        if (include_summand<propto, T_scale_fail>::value)
-          lgamma_beta[n] = lgamma(value_of(beta_vec[n]));
-        if (!is_constant_struct<T_scale_fail>::value)
-          digamma_beta[n] = digamma(value_of(beta_vec[n]));
-      }
-
-      VectorBuilder<include_summand<propto, T_scale_succ, T_scale_fail>::value,
-                    T_partials_return, T_scale_succ, T_scale_fail>
-        lgamma_alpha_beta(max_size(alpha, beta));
-
-      VectorBuilder<contains_nonconstant_struct<T_scale_succ,
-                                                T_scale_fail>::value,
-                    T_partials_return, T_scale_succ, T_scale_fail>
-        digamma_alpha_beta(max_size(alpha, beta));
-
-      for (size_t n = 0; n < max_size(alpha, beta); n++) {
-        const T_partials_return alpha_beta = value_of(alpha_vec[n])
-          + value_of(beta_vec[n]);
-        if (include_summand<propto, T_scale_succ, T_scale_fail>::value)
-          lgamma_alpha_beta[n] = lgamma(alpha_beta);
-        if (contains_nonconstant_struct<T_scale_succ, T_scale_fail>::value)
-          digamma_alpha_beta[n] = digamma(alpha_beta);
-      }
-
-      for (size_t n = 0; n < N; n++) {
-        const T_partials_return y_dbl = value_of(y_vec[n]);
-        const T_partials_return alpha_dbl = value_of(alpha_vec[n]);
-        const T_partials_return beta_dbl = value_of(beta_vec[n]);
-
-        if (include_summand<propto, T_scale_succ, T_scale_fail>::value)
-          logp += lgamma_alpha_beta[n];
-        if (include_summand<propto, T_scale_succ>::value)
-          logp -= lgamma_alpha[n];
-        if (include_summand<propto, T_scale_fail>::value)
-          logp -= lgamma_beta[n];
-        if (include_summand<propto, T_y, T_scale_succ>::value)
-          logp += (alpha_dbl-1.0) * log_y[n];
-        if (include_summand<propto, T_y, T_scale_fail>::value)
-          logp += (beta_dbl-1.0) * log1m_y[n];
-
-        if (!is_constant_struct<T_y>::value)
-          operands_and_partials.d_x1[n] += (alpha_dbl-1)/y_dbl
-            + (beta_dbl-1)/(y_dbl-1);
-        if (!is_constant_struct<T_scale_succ>::value)
-          operands_and_partials.d_x2[n]
-            += log_y[n] + digamma_alpha_beta[n] - digamma_alpha[n];
-        if (!is_constant_struct<T_scale_fail>::value)
-          operands_and_partials.d_x3[n]
-            += log1m_y[n] + digamma_alpha_beta[n] - digamma_beta[n];
-      }
-      return operands_and_partials.value(logp);
+      return beta_lpdf<propto, T_y, T_scale_succ, T_scale_fail>(y, alpha, beta);
     }
 
+    /**
+     * @deprecated use <code>beta_lpdf</code>
+     */
     template <typename T_y, typename T_scale_succ, typename T_scale_fail>
     inline typename return_type<T_y, T_scale_succ, T_scale_fail>::type
     beta_log(const T_y& y, const T_scale_succ& alpha,
              const T_scale_fail& beta) {
-      return beta_log<false>(y, alpha, beta);
+      return beta_lpdf<T_y, T_scale_succ, T_scale_fail>(y, alpha, beta);
     }
 
   }

--- a/stan/math/prim/scal/prob/binomial_ccdf_log.hpp
+++ b/stan/math/prim/scal/prob/binomial_ccdf_log.hpp
@@ -1,93 +1,18 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_BINOMIAL_CCDF_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_BINOMIAL_CCDF_LOG_HPP
 
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_bounded.hpp>
-#include <stan/math/prim/scal/err/check_finite.hpp>
-#include <stan/math/prim/scal/err/check_greater_or_equal.hpp>
-#include <stan/math/prim/scal/err/check_less_or_equal.hpp>
-#include <stan/math/prim/scal/err/check_nonnegative.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/fun/inv_logit.hpp>
-#include <stan/math/prim/scal/fun/log1m.hpp>
-#include <stan/math/prim/scal/fun/log_inv_logit.hpp>
-#include <stan/math/prim/scal/fun/multiply_log.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/fun/binomial_coefficient_log.hpp>
-#include <stan/math/prim/scal/fun/lbeta.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <stan/math/prim/scal/fun/inc_beta.hpp>
-#include <boost/random/binomial_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <cmath>
+#include <stan/math/prim/scal/prob/binomial_lccdf.hpp>
 
 namespace stan {
   namespace math {
 
+    /**
+     * @deprecated use <code>binomial_lccdf</code>
+     */
     template <typename T_n, typename T_N, typename T_prob>
     typename return_type<T_prob>::type
     binomial_ccdf_log(const T_n& n, const T_N& N, const T_prob& theta) {
-      static const char* function("binomial_ccdf_log");
-      typedef typename stan::partials_return_type<T_n, T_N, T_prob>::type
-        T_partials_return;
-
-      if (!(stan::length(n) && stan::length(N) && stan::length(theta)))
-        return 0.0;
-
-      T_partials_return P(0.0);
-
-      check_nonnegative(function, "Population size parameter", N);
-      check_finite(function, "Probability parameter", theta);
-      check_bounded(function, "Probability parameter", theta, 0.0, 1.0);
-      check_consistent_sizes(function,
-                             "Successes variable", n,
-                             "Population size parameter", N,
-                             "Probability parameter", theta);
-
-      VectorView<const T_n> n_vec(n);
-      VectorView<const T_N> N_vec(N);
-      VectorView<const T_prob> theta_vec(theta);
-      size_t size = max_size(n, N, theta);
-
-      using std::exp;
-      using std::pow;
-      using std::log;
-      using std::exp;
-
-      OperandsAndPartials<T_prob> operands_and_partials(theta);
-
-      // Explicit return for extreme values
-      // The gradients are technically ill-defined,
-      // but treated as negative infinity
-      for (size_t i = 0; i < stan::length(n); i++) {
-        if (value_of(n_vec[i]) < 0)
-          return operands_and_partials.value(0.0);
-      }
-
-      for (size_t i = 0; i < size; i++) {
-        // Explicit results for extreme values
-        // The gradients are technically ill-defined, but treated as zero
-        if (value_of(n_vec[i]) >= value_of(N_vec[i])) {
-          return operands_and_partials.value(negative_infinity());
-        }
-        const T_partials_return n_dbl = value_of(n_vec[i]);
-        const T_partials_return N_dbl = value_of(N_vec[i]);
-        const T_partials_return theta_dbl = value_of(theta_vec[i]);
-        const T_partials_return betafunc = exp(lbeta(N_dbl-n_dbl, n_dbl+1));
-        const T_partials_return Pi = 1.0 - inc_beta(N_dbl - n_dbl, n_dbl + 1,
-                                                    1 - theta_dbl);
-
-        P += log(Pi);
-
-        if (!is_constant_struct<T_prob>::value)
-          operands_and_partials.d_x1[i] += pow(theta_dbl, n_dbl)
-            * pow(1-theta_dbl, N_dbl-n_dbl-1) / betafunc / Pi;
-      }
-
-      return operands_and_partials.value(P);
+      return binomial_lccdf<T_n, T_N, T_prob>(n, N, theta);
     }
 
   }

--- a/stan/math/prim/scal/prob/binomial_cdf_log.hpp
+++ b/stan/math/prim/scal/prob/binomial_cdf_log.hpp
@@ -1,92 +1,18 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_BINOMIAL_CDF_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_BINOMIAL_CDF_LOG_HPP
 
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_bounded.hpp>
-#include <stan/math/prim/scal/err/check_finite.hpp>
-#include <stan/math/prim/scal/err/check_greater_or_equal.hpp>
-#include <stan/math/prim/scal/err/check_less_or_equal.hpp>
-#include <stan/math/prim/scal/err/check_nonnegative.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/fun/inv_logit.hpp>
-#include <stan/math/prim/scal/fun/log1m.hpp>
-#include <stan/math/prim/scal/fun/log_inv_logit.hpp>
-#include <stan/math/prim/scal/fun/multiply_log.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/fun/binomial_coefficient_log.hpp>
-#include <stan/math/prim/scal/fun/lbeta.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <stan/math/prim/scal/fun/inc_beta.hpp>
-#include <boost/random/binomial_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <cmath>
+#include <stan/math/prim/scal/prob/binomial_lcdf.hpp>
 
 namespace stan {
   namespace math {
 
+    /**
+     * @deprecated use <code>binomial_lcdf</code>
+     */
     template <typename T_n, typename T_N, typename T_prob>
     typename return_type<T_prob>::type
     binomial_cdf_log(const T_n& n, const T_N& N, const T_prob& theta) {
-      static const char* function("binomial_cdf_log");
-      typedef typename stan::partials_return_type<T_n, T_N, T_prob>::type
-        T_partials_return;
-
-      if (!(stan::length(n) && stan::length(N) && stan::length(theta)))
-        return 0.0;
-
-      T_partials_return P(0.0);
-
-      check_nonnegative(function, "Population size parameter", N);
-      check_finite(function, "Probability parameter", theta);
-      check_bounded(function, "Probability parameter", theta, 0.0, 1.0);
-      check_consistent_sizes(function,
-                             "Successes variable", n,
-                             "Population size parameter", N,
-                             "Probability parameter", theta);
-
-      VectorView<const T_n> n_vec(n);
-      VectorView<const T_N> N_vec(N);
-      VectorView<const T_prob> theta_vec(theta);
-      size_t size = max_size(n, N, theta);
-
-      using std::exp;
-      using std::pow;
-      using std::log;
-      using std::exp;
-
-      OperandsAndPartials<T_prob> operands_and_partials(theta);
-
-      // Explicit return for extreme values
-      // The gradients are technically ill-defined,
-      // but treated as negative infinity
-      for (size_t i = 0; i < stan::length(n); i++) {
-        if (value_of(n_vec[i]) < 0)
-          return operands_and_partials.value(negative_infinity());
-      }
-
-      for (size_t i = 0; i < size; i++) {
-        // Explicit results for extreme values
-        // The gradients are technically ill-defined, but treated as zero
-        if (value_of(n_vec[i]) >= value_of(N_vec[i])) {
-          continue;
-        }
-        const T_partials_return n_dbl = value_of(n_vec[i]);
-        const T_partials_return N_dbl = value_of(N_vec[i]);
-        const T_partials_return theta_dbl = value_of(theta_vec[i]);
-        const T_partials_return betafunc = exp(lbeta(N_dbl-n_dbl, n_dbl+1));
-        const T_partials_return Pi = inc_beta(N_dbl - n_dbl, n_dbl + 1,
-                                              1 - theta_dbl);
-
-        P += log(Pi);
-
-        if (!is_constant_struct<T_prob>::value)
-          operands_and_partials.d_x1[i] -= pow(theta_dbl, n_dbl)
-            * pow(1-theta_dbl, N_dbl-n_dbl-1) / betafunc / Pi;
-      }
-      return operands_and_partials.value(P);
+      return binomial_lcdf<T_n, T_N, T_prob>(n, N, theta);
     }
 
   }

--- a/stan/math/prim/scal/prob/binomial_log.hpp
+++ b/stan/math/prim/scal/prob/binomial_log.hpp
@@ -1,33 +1,14 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_BINOMIAL_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_BINOMIAL_LOG_HPP
 
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_bounded.hpp>
-#include <stan/math/prim/scal/err/check_finite.hpp>
-#include <stan/math/prim/scal/err/check_greater_or_equal.hpp>
-#include <stan/math/prim/scal/err/check_less_or_equal.hpp>
-#include <stan/math/prim/scal/err/check_nonnegative.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/fun/inv_logit.hpp>
-#include <stan/math/prim/scal/fun/log1m.hpp>
-#include <stan/math/prim/scal/fun/log_inv_logit.hpp>
-#include <stan/math/prim/scal/fun/multiply_log.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/fun/binomial_coefficient_log.hpp>
-#include <stan/math/prim/scal/fun/lbeta.hpp>
-#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <stan/math/prim/scal/fun/inc_beta.hpp>
-#include <boost/random/binomial_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
+#include <stan/math/prim/scal/prob/binomial_lpmf.hpp>
 
 namespace stan {
   namespace math {
 
-    // Binomial(n|N, theta)  [N >= 0;  0 <= n <= N;  0 <= theta <= 1]
+    /**
+     * @deprecated use <code>binomial_lpmf</code>
+     */
     template <bool propto,
               typename T_n,
               typename T_N,
@@ -36,73 +17,12 @@ namespace stan {
     binomial_log(const T_n& n,
                  const T_N& N,
                  const T_prob& theta) {
-      typedef typename stan::partials_return_type<T_n, T_N, T_prob>::type
-        T_partials_return;
-
-      static const char* function("binomial_log");
-
-      if (!(stan::length(n)
-            && stan::length(N)
-            && stan::length(theta)))
-        return 0.0;
-
-      T_partials_return logp = 0;
-      check_bounded(function, "Successes variable", n, 0, N);
-      check_nonnegative(function, "Population size parameter", N);
-      check_finite(function, "Probability parameter", theta);
-      check_bounded(function, "Probability parameter", theta, 0.0, 1.0);
-      check_consistent_sizes(function,
-                             "Successes variable", n,
-                             "Population size parameter", N,
-                             "Probability parameter", theta);
-
-      if (!include_summand<propto, T_prob>::value)
-        return 0.0;
-
-      VectorView<const T_n> n_vec(n);
-      VectorView<const T_N> N_vec(N);
-      VectorView<const T_prob> theta_vec(theta);
-      size_t size = max_size(n, N, theta);
-
-      OperandsAndPartials<T_prob> operands_and_partials(theta);
-
-      if (include_summand<propto>::value) {
-        for (size_t i = 0; i < size; ++i)
-          logp += binomial_coefficient_log(N_vec[i], n_vec[i]);
-      }
-
-      VectorBuilder<true, T_partials_return, T_prob> log1m_theta(length(theta));
-      for (size_t i = 0; i < length(theta); ++i)
-        log1m_theta[i] = log1m(value_of(theta_vec[i]));
-
-      for (size_t i = 0; i < size; ++i)
-        logp += multiply_log(n_vec[i], value_of(theta_vec[i]))
-          + (N_vec[i] - n_vec[i]) * log1m_theta[i];
-
-      if (length(theta) == 1) {
-        T_partials_return temp1 = 0;
-        T_partials_return temp2 = 0;
-        for (size_t i = 0; i < size; ++i) {
-          temp1 += n_vec[i];
-          temp2 += N_vec[i] - n_vec[i];
-        }
-        if (!is_constant_struct<T_prob>::value) {
-          operands_and_partials.d_x1[0]
-            += temp1 / value_of(theta_vec[0])
-            - temp2 / (1.0 - value_of(theta_vec[0]));
-        }
-      } else {
-        if (!is_constant_struct<T_prob>::value) {
-          for (size_t i = 0; i < size; ++i)
-            operands_and_partials.d_x1[i]
-              += n_vec[i] / value_of(theta_vec[i])
-              - (N_vec[i] - n_vec[i]) / (1.0 - value_of(theta_vec[i]));
-        }
-      }
-
-      return operands_and_partials.value(logp);
+      return binomial_lpmf<propto, T_n, T_N, T_prob>(n, N, theta);
     }
 
+    /**
+     * @deprecated use <code>binomial_lpmf</code>
+     */
     template <typename T_n,
               typename T_N,
               typename T_prob>
@@ -111,7 +31,7 @@ namespace stan {
     binomial_log(const T_n& n,
                  const T_N& N,
                  const T_prob& theta) {
-      return binomial_log<false>(n, N, theta);
+      return binomial_lpmf<T_n, T_N, T_prob>(n, N, theta);
     }
 
   }

--- a/stan/math/prim/scal/prob/binomial_logit_log.hpp
+++ b/stan/math/prim/scal/prob/binomial_logit_log.hpp
@@ -1,34 +1,14 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_BINOMIAL_LOGIT_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_BINOMIAL_LOGIT_LOG_HPP
 
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_bounded.hpp>
-#include <stan/math/prim/scal/err/check_finite.hpp>
-#include <stan/math/prim/scal/err/check_greater_or_equal.hpp>
-#include <stan/math/prim/scal/err/check_less_or_equal.hpp>
-#include <stan/math/prim/scal/err/check_nonnegative.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/fun/inv_logit.hpp>
-#include <stan/math/prim/scal/fun/log1m.hpp>
-#include <stan/math/prim/scal/fun/log_inv_logit.hpp>
-#include <stan/math/prim/scal/fun/multiply_log.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/fun/binomial_coefficient_log.hpp>
-#include <stan/math/prim/scal/fun/lbeta.hpp>
-#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <stan/math/prim/scal/fun/inc_beta.hpp>
-#include <boost/random/binomial_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
+#include <stan/math/prim/scal/prob/binomial_logit_lpmf.hpp>
 
 namespace stan {
   namespace math {
 
-    // BinomialLogit(n|N, alpha)  [N >= 0;  0 <= n <= N]
-    // BinomialLogit(n|N, alpha) = Binomial(n|N, inv_logit(alpha))
+    /**
+     * @deprecated use <code>binomial_logit_lpmf</code>
+     */
     template <bool propto,
               typename T_n,
               typename T_N,
@@ -37,78 +17,12 @@ namespace stan {
     binomial_logit_log(const T_n& n,
                        const T_N& N,
                        const T_prob& alpha) {
-      typedef typename stan::partials_return_type<T_n, T_N, T_prob>::type
-        T_partials_return;
-
-      static const char* function("binomial_logit_log");
-
-      if (!(stan::length(n)
-            && stan::length(N)
-            && stan::length(alpha)))
-        return 0.0;
-
-      T_partials_return logp = 0;
-      check_bounded(function, "Successes variable", n, 0, N);
-      check_nonnegative(function, "Population size parameter", N);
-      check_finite(function, "Probability parameter", alpha);
-      check_consistent_sizes(function,
-                             "Successes variable", n,
-                             "Population size parameter", N,
-                             "Probability parameter", alpha);
-
-      if (!include_summand<propto, T_prob>::value)
-        return 0.0;
-
-      VectorView<const T_n> n_vec(n);
-      VectorView<const T_N> N_vec(N);
-      VectorView<const T_prob> alpha_vec(alpha);
-      size_t size = max_size(n, N, alpha);
-
-      OperandsAndPartials<T_prob> operands_and_partials(alpha);
-
-      if (include_summand<propto>::value) {
-        for (size_t i = 0; i < size; ++i)
-          logp += binomial_coefficient_log(N_vec[i], n_vec[i]);
-      }
-
-      VectorBuilder<true, T_partials_return, T_prob>
-        log_inv_logit_alpha(length(alpha));
-      for (size_t i = 0; i < length(alpha); ++i)
-        log_inv_logit_alpha[i] = log_inv_logit(value_of(alpha_vec[i]));
-
-      VectorBuilder<true, T_partials_return, T_prob>
-        log_inv_logit_neg_alpha(length(alpha));
-      for (size_t i = 0; i < length(alpha); ++i)
-        log_inv_logit_neg_alpha[i] = log_inv_logit(-value_of(alpha_vec[i]));
-
-      for (size_t i = 0; i < size; ++i)
-        logp += n_vec[i] * log_inv_logit_alpha[i]
-          + (N_vec[i] - n_vec[i]) * log_inv_logit_neg_alpha[i];
-
-      if (length(alpha) == 1) {
-        T_partials_return temp1 = 0;
-        T_partials_return temp2 = 0;
-        for (size_t i = 0; i < size; ++i) {
-          temp1 += n_vec[i];
-          temp2 += N_vec[i] - n_vec[i];
-        }
-        if (!is_constant_struct<T_prob>::value) {
-          operands_and_partials.d_x1[0]
-            += temp1 * inv_logit(-value_of(alpha_vec[0]))
-            - temp2 * inv_logit(value_of(alpha_vec[0]));
-        }
-      } else {
-        if (!is_constant_struct<T_prob>::value) {
-          for (size_t i = 0; i < size; ++i)
-            operands_and_partials.d_x1[i]
-              += n_vec[i] * inv_logit(-value_of(alpha_vec[i]))
-              - (N_vec[i] - n_vec[i]) * inv_logit(value_of(alpha_vec[i]));
-        }
-      }
-
-      return operands_and_partials.value(logp);
+      return binomial_logit_lpmf<propto, T_n, T_N, T_prob>(n, N, alpha);
     }
 
+    /**
+     * @deprecated use <code>binomial_logit_lpmf</code>
+     */
     template <typename T_n,
               typename T_N,
               typename T_prob>
@@ -117,7 +31,7 @@ namespace stan {
     binomial_logit_log(const T_n& n,
                        const T_N& N,
                        const T_prob& alpha) {
-      return binomial_logit_log<false>(n, N, alpha);
+      return binomial_logit_lpmf<T_n, T_N, T_prob>(n, N, alpha);
     }
 
   }

--- a/stan/math/prim/scal/prob/cauchy_ccdf_log.hpp
+++ b/stan/math/prim/scal/prob/cauchy_ccdf_log.hpp
@@ -1,81 +1,18 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_CAUCHY_CCDF_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_CAUCHY_CCDF_LOG_HPP
 
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_finite.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/err/check_positive_finite.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/fun/log1p.hpp>
-#include <stan/math/prim/scal/fun/square.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <boost/random/cauchy_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <cmath>
+#include <stan/math/prim/scal/prob/cauchy_lccdf.hpp>
 
 namespace stan {
   namespace math {
 
+    /**
+     * @deprecated use <code>cauchy_lccdf</code>
+     */
     template <typename T_y, typename T_loc, typename T_scale>
     typename return_type<T_y, T_loc, T_scale>::type
     cauchy_ccdf_log(const T_y& y, const T_loc& mu, const T_scale& sigma) {
-      typedef typename stan::partials_return_type<T_y, T_loc, T_scale>::type
-        T_partials_return;
-
-      if ( !( stan::length(y) && stan::length(mu)
-              && stan::length(sigma) ) )
-        return 0.0;
-
-      static const char* function("cauchy_ccdf_log");
-
-      using boost::math::tools::promote_args;
-
-      T_partials_return ccdf_log(0.0);
-
-      check_not_nan(function, "Random variable", y);
-      check_finite(function, "Location parameter", mu);
-      check_positive_finite(function, "Scale parameter", sigma);
-      check_consistent_sizes(function,
-                             "Random variable", y,
-                             "Location parameter", mu,
-                             "Scale Parameter", sigma);
-
-      VectorView<const T_y> y_vec(y);
-      VectorView<const T_loc> mu_vec(mu);
-      VectorView<const T_scale> sigma_vec(sigma);
-      size_t N = max_size(y, mu, sigma);
-
-      OperandsAndPartials<T_y, T_loc, T_scale>
-        operands_and_partials(y, mu, sigma);
-
-      using std::atan;
-      using std::log;
-
-      for (size_t n = 0; n < N; n++) {
-        const T_partials_return y_dbl = value_of(y_vec[n]);
-        const T_partials_return mu_dbl = value_of(mu_vec[n]);
-        const T_partials_return sigma_inv_dbl = 1.0 / value_of(sigma_vec[n]);
-        const T_partials_return sigma_dbl = value_of(sigma_vec[n]);
-        const T_partials_return z = (y_dbl - mu_dbl) * sigma_inv_dbl;
-
-        const T_partials_return Pn = 0.5 - atan(z) / pi();
-        ccdf_log += log(Pn);
-
-        const T_partials_return rep_deriv = 1.0 / (Pn * pi()
-                                                   * (z * z * sigma_dbl
-                                                      + sigma_dbl));
-        if (!is_constant_struct<T_y>::value)
-          operands_and_partials.d_x1[n] -= rep_deriv;
-        if (!is_constant_struct<T_loc>::value)
-          operands_and_partials.d_x2[n] += rep_deriv;
-        if (!is_constant_struct<T_scale>::value)
-          operands_and_partials.d_x3[n] += rep_deriv * z;
-      }
-      return operands_and_partials.value(ccdf_log);
+      return cauchy_lccdf<T_y, T_loc, T_scale>(y, mu, sigma);
     }
 
   }

--- a/stan/math/prim/scal/prob/cauchy_cdf_log.hpp
+++ b/stan/math/prim/scal/prob/cauchy_cdf_log.hpp
@@ -1,81 +1,18 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_CAUCHY_CDF_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_CAUCHY_CDF_LOG_HPP
 
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_finite.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/err/check_positive_finite.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/fun/square.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/fun/log1p.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <boost/random/cauchy_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <cmath>
+#include <stan/math/prim/scal/prob/cauchy_lcdf.hpp>
 
 namespace stan {
   namespace math {
 
+    /**
+     * @deprecated use <code>cauchy_lcdf</code>
+     */
     template <typename T_y, typename T_loc, typename T_scale>
     typename return_type<T_y, T_loc, T_scale>::type
     cauchy_cdf_log(const T_y& y, const T_loc& mu, const T_scale& sigma) {
-      typedef typename stan::partials_return_type<T_y, T_loc, T_scale>::type
-        T_partials_return;
-
-      if ( !( stan::length(y) && stan::length(mu)
-              && stan::length(sigma) ) )
-        return 0.0;
-
-      static const char* function("cauchy_cdf_log");
-
-      using boost::math::tools::promote_args;
-
-      T_partials_return cdf_log(0.0);
-
-      check_not_nan(function, "Random variable", y);
-      check_finite(function, "Location parameter", mu);
-      check_positive_finite(function, "Scale parameter", sigma);
-      check_consistent_sizes(function,
-                             "Random variable", y,
-                             "Location parameter", mu,
-                             "Scale Parameter", sigma);
-
-      VectorView<const T_y> y_vec(y);
-      VectorView<const T_loc> mu_vec(mu);
-      VectorView<const T_scale> sigma_vec(sigma);
-      size_t N = max_size(y, mu, sigma);
-
-      OperandsAndPartials<T_y, T_loc, T_scale>
-        operands_and_partials(y, mu, sigma);
-
-      using std::atan;
-      using std::log;
-
-      for (size_t n = 0; n < N; n++) {
-        const T_partials_return y_dbl = value_of(y_vec[n]);
-        const T_partials_return mu_dbl = value_of(mu_vec[n]);
-        const T_partials_return sigma_inv_dbl = 1.0 / value_of(sigma_vec[n]);
-        const T_partials_return sigma_dbl = value_of(sigma_vec[n]);
-
-        const T_partials_return z = (y_dbl - mu_dbl) * sigma_inv_dbl;
-
-        const T_partials_return Pn = atan(z) / pi() + 0.5;
-        cdf_log += log(Pn);
-
-        const T_partials_return rep_deriv
-          = 1.0 / (pi() * Pn * (z * z * sigma_dbl + sigma_dbl));
-        if (!is_constant_struct<T_y>::value)
-          operands_and_partials.d_x1[n] += rep_deriv;
-        if (!is_constant_struct<T_loc>::value)
-          operands_and_partials.d_x2[n] -= rep_deriv;
-        if (!is_constant_struct<T_scale>::value)
-          operands_and_partials.d_x3[n] -= rep_deriv * z;
-      }
-      return operands_and_partials.value(cdf_log);
+      return cauchy_lcdf<T_y, T_loc, T_scale>(y, mu, sigma);
     }
 
   }

--- a/stan/math/prim/scal/prob/cauchy_log.hpp
+++ b/stan/math/prim/scal/prob/cauchy_log.hpp
@@ -1,22 +1,7 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_CAUCHY_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_CAUCHY_LOG_HPP
 
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_finite.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/err/check_positive_finite.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/fun/square.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/fun/log1p.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
-#include <boost/random/cauchy_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <cmath>
+#include <stan/math/prim/scal/prob/cauchy_lpdf.hpp>
 
 namespace stan {
   namespace math {
@@ -30,6 +15,8 @@ namespace stan {
      * <p> The result log probability is defined to be the sum of
      * the log probabilities for each observation/mu/sigma triple.
      *
+     * @deprecated use <code>cauchy_lpdf</code>
+     *
      * @param y (Sequence of) scalar(s).
      * @param mu (Sequence of) location(s).
      * @param sigma (Sequence of) scale(s).
@@ -42,93 +29,17 @@ namespace stan {
               typename T_y, typename T_loc, typename T_scale>
     typename return_type<T_y, T_loc, T_scale>::type
     cauchy_log(const T_y& y, const T_loc& mu, const T_scale& sigma) {
-      static const char* function("cauchy_log");
-      typedef typename stan::partials_return_type<T_y, T_loc, T_scale>::type
-        T_partials_return;
-
-      using stan::is_constant_struct;
-
-      if (!(stan::length(y)
-            && stan::length(mu)
-            && stan::length(sigma)))
-        return 0.0;
-
-      T_partials_return logp(0.0);
-
-      check_not_nan(function, "Random variable", y);
-      check_finite(function, "Location parameter", mu);
-      check_positive_finite(function, "Scale parameter", sigma);
-      check_consistent_sizes(function,
-                             "Random variable", y,
-                             "Location parameter", mu,
-                             "Scale parameter", sigma);
-
-      if (!include_summand<propto, T_y, T_loc, T_scale>::value)
-        return 0.0;
-
-      using std::log;
-
-      VectorView<const T_y> y_vec(y);
-      VectorView<const T_loc> mu_vec(mu);
-      VectorView<const T_scale> sigma_vec(sigma);
-      size_t N = max_size(y, mu, sigma);
-
-      VectorBuilder<true, T_partials_return, T_scale> inv_sigma(length(sigma));
-      VectorBuilder<true, T_partials_return,
-                    T_scale> sigma_squared(length(sigma));
-      VectorBuilder<include_summand<propto, T_scale>::value,
-                    T_partials_return, T_scale> log_sigma(length(sigma));
-      for (size_t i = 0; i < length(sigma); i++) {
-        const T_partials_return sigma_dbl = value_of(sigma_vec[i]);
-        inv_sigma[i] = 1.0 / sigma_dbl;
-        sigma_squared[i] = sigma_dbl * sigma_dbl;
-        if (include_summand<propto, T_scale>::value) {
-          log_sigma[i] = log(sigma_dbl);
-        }
-      }
-
-      OperandsAndPartials<T_y, T_loc, T_scale>
-        operands_and_partials(y, mu, sigma);
-
-      for (size_t n = 0; n < N; n++) {
-        const T_partials_return y_dbl = value_of(y_vec[n]);
-        const T_partials_return mu_dbl = value_of(mu_vec[n]);
-
-        const T_partials_return y_minus_mu
-          = y_dbl - mu_dbl;
-        const T_partials_return y_minus_mu_squared
-          = y_minus_mu * y_minus_mu;
-        const T_partials_return y_minus_mu_over_sigma
-          = y_minus_mu * inv_sigma[n];
-        const T_partials_return y_minus_mu_over_sigma_squared
-          = y_minus_mu_over_sigma * y_minus_mu_over_sigma;
-
-        if (include_summand<propto>::value)
-          logp += NEG_LOG_PI;
-        if (include_summand<propto, T_scale>::value)
-          logp -= log_sigma[n];
-        if (include_summand<propto, T_y, T_loc, T_scale>::value)
-          logp -= log1p(y_minus_mu_over_sigma_squared);
-
-        if (!is_constant_struct<T_y>::value)
-          operands_and_partials.d_x1[n] -= 2 * y_minus_mu
-            / (sigma_squared[n] + y_minus_mu_squared);
-        if (!is_constant_struct<T_loc>::value)
-          operands_and_partials.d_x2[n] += 2 * y_minus_mu
-            / (sigma_squared[n] + y_minus_mu_squared);
-        if (!is_constant_struct<T_scale>::value)
-          operands_and_partials.d_x3[n]
-            += (y_minus_mu_squared - sigma_squared[n])
-            * inv_sigma[n] / (sigma_squared[n] + y_minus_mu_squared);
-      }
-      return operands_and_partials.value(logp);
+      return cauchy_lpdf<propto, T_y, T_loc, T_scale>(y, mu, sigma);
     }
 
+    /**
+     * @deprecated use <code>cauchy_lpdf</code>
+     */
     template <typename T_y, typename T_loc, typename T_scale>
     inline
     typename return_type<T_y, T_loc, T_scale>::type
     cauchy_log(const T_y& y, const T_loc& mu, const T_scale& sigma) {
-      return cauchy_log<false>(y, mu, sigma);
+      return cauchy_lpdf<T_y, T_loc, T_scale>(y, mu, sigma);
     }
 
   }

--- a/stan/math/prim/scal/prob/chi_square_ccdf_log.hpp
+++ b/stan/math/prim/scal/prob/chi_square_ccdf_log.hpp
@@ -1,105 +1,18 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_CHI_SQUARE_CCDF_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_CHI_SQUARE_CCDF_LOG_HPP
 
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_nonnegative.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/err/check_positive_finite.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/fun/multiply_log.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/fun/gamma_q.hpp>
-#include <stan/math/prim/scal/fun/digamma.hpp>
-#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
-#include <stan/math/prim/scal/fun/grad_reg_inc_gamma.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <boost/random/chi_squared_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <cmath>
-#include <limits>
+#include <stan/math/prim/scal/prob/chi_square_lccdf.hpp>
 
 namespace stan {
   namespace math {
 
+    /**
+     * @deprecated use <code>chi_square_lccdf</code>
+     */
     template <typename T_y, typename T_dof>
     typename return_type<T_y, T_dof>::type
     chi_square_ccdf_log(const T_y& y, const T_dof& nu) {
-      static const char* function("chi_square_ccdf_log");
-      typedef typename stan::partials_return_type<T_y, T_dof>::type
-        T_partials_return;
-
-      T_partials_return ccdf_log(0.0);
-
-      if (!(stan::length(y) && stan::length(nu)))
-        return ccdf_log;
-
-      check_not_nan(function, "Random variable", y);
-      check_nonnegative(function, "Random variable", y);
-      check_positive_finite(function, "Degrees of freedom parameter", nu);
-      check_consistent_sizes(function,
-                             "Random variable", y,
-                             "Degrees of freedom parameter", nu);
-
-      VectorView<const T_y> y_vec(y);
-      VectorView<const T_dof> nu_vec(nu);
-      size_t N = max_size(y, nu);
-
-      OperandsAndPartials<T_y, T_dof>
-        operands_and_partials(y, nu);
-
-      // Explicit return for extreme values
-      // The gradients are technically ill-defined, but treated as zero
-      for (size_t i = 0; i < stan::length(y); i++) {
-        if (value_of(y_vec[i]) == 0)
-          return operands_and_partials.value(0.0);
-      }
-
-      using boost::math::tgamma;
-      using std::exp;
-      using std::pow;
-      using std::log;
-      using std::exp;
-
-      VectorBuilder<!is_constant_struct<T_dof>::value,
-                    T_partials_return, T_dof> gamma_vec(stan::length(nu));
-      VectorBuilder<!is_constant_struct<T_dof>::value,
-                    T_partials_return, T_dof> digamma_vec(stan::length(nu));
-
-      if (!is_constant_struct<T_dof>::value) {
-        for (size_t i = 0; i < stan::length(nu); i++) {
-          const T_partials_return alpha_dbl = value_of(nu_vec[i]) * 0.5;
-          gamma_vec[i] = tgamma(alpha_dbl);
-          digamma_vec[i] = digamma(alpha_dbl);
-        }
-      }
-
-      for (size_t n = 0; n < N; n++) {
-        // Explicit results for extreme values
-        // The gradients are technically ill-defined, but treated as zero
-        if (value_of(y_vec[n]) == std::numeric_limits<double>::infinity())
-          return operands_and_partials.value(negative_infinity());
-
-        const T_partials_return y_dbl = value_of(y_vec[n]);
-        const T_partials_return alpha_dbl = value_of(nu_vec[n]) * 0.5;
-        const T_partials_return beta_dbl = 0.5;
-
-        const T_partials_return Pn = gamma_q(alpha_dbl, beta_dbl * y_dbl);
-
-        ccdf_log += log(Pn);
-
-        if (!is_constant_struct<T_y>::value)
-          operands_and_partials.d_x1[n] -= beta_dbl * exp(-beta_dbl * y_dbl)
-            * pow(beta_dbl * y_dbl, alpha_dbl-1) / tgamma(alpha_dbl) / Pn;
-        if (!is_constant_struct<T_dof>::value)
-          operands_and_partials.d_x2[n]
-            += 0.5 * grad_reg_inc_gamma(alpha_dbl, beta_dbl
-                                        * y_dbl, gamma_vec[n],
-                                        digamma_vec[n]) / Pn;
-      }
-      return operands_and_partials.value(ccdf_log);
+      return chi_square_lccdf<T_y, T_dof>(y, nu);
     }
 
   }

--- a/stan/math/prim/scal/prob/chi_square_cdf_log.hpp
+++ b/stan/math/prim/scal/prob/chi_square_cdf_log.hpp
@@ -1,105 +1,18 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_CHI_SQUARE_CDF_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_CHI_SQUARE_CDF_LOG_HPP
 
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_nonnegative.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/err/check_positive_finite.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/fun/multiply_log.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/fun/gamma_p.hpp>
-#include <stan/math/prim/scal/fun/digamma.hpp>
-#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
-#include <stan/math/prim/scal/fun/grad_reg_inc_gamma.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <boost/random/chi_squared_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <cmath>
-#include <limits>
+#include <stan/math/prim/scal/prob/chi_square_lcdf.hpp>
 
 namespace stan {
   namespace math {
 
+    /**
+     * @deprecated use <code>chi_square_lcdf</code>
+     */
     template <typename T_y, typename T_dof>
     typename return_type<T_y, T_dof>::type
     chi_square_cdf_log(const T_y& y, const T_dof& nu) {
-      static const char* function("chi_square_cdf_log");
-      typedef typename stan::partials_return_type<T_y, T_dof>::type
-        T_partials_return;
-
-      T_partials_return cdf_log(0.0);
-
-      if (!(stan::length(y) && stan::length(nu)))
-        return cdf_log;
-
-      check_not_nan(function, "Random variable", y);
-      check_nonnegative(function, "Random variable", y);
-      check_positive_finite(function, "Degrees of freedom parameter", nu);
-      check_consistent_sizes(function,
-                             "Random variable", y,
-                             "Degrees of freedom parameter", nu);
-
-      VectorView<const T_y> y_vec(y);
-      VectorView<const T_dof> nu_vec(nu);
-      size_t N = max_size(y, nu);
-
-      OperandsAndPartials<T_y, T_dof>
-        operands_and_partials(y, nu);
-
-      // Explicit return for extreme values
-      // The gradients are technically ill-defined, but treated as zero
-      for (size_t i = 0; i < stan::length(y); i++) {
-        if (value_of(y_vec[i]) == 0)
-          return operands_and_partials.value(negative_infinity());
-      }
-
-      using boost::math::tgamma;
-      using std::exp;
-      using std::pow;
-      using std::log;
-      using std::exp;
-
-      VectorBuilder<!is_constant_struct<T_dof>::value,
-                    T_partials_return, T_dof> gamma_vec(stan::length(nu));
-      VectorBuilder<!is_constant_struct<T_dof>::value,
-                    T_partials_return, T_dof> digamma_vec(stan::length(nu));
-
-      if (!is_constant_struct<T_dof>::value) {
-        for (size_t i = 0; i < stan::length(nu); i++) {
-          const T_partials_return alpha_dbl = value_of(nu_vec[i]) * 0.5;
-          gamma_vec[i] = tgamma(alpha_dbl);
-          digamma_vec[i] = digamma(alpha_dbl);
-        }
-      }
-
-      for (size_t n = 0; n < N; n++) {
-        // Explicit results for extreme values
-        // The gradients are technically ill-defined, but treated as zero
-        if (value_of(y_vec[n]) == std::numeric_limits<double>::infinity())
-          return operands_and_partials.value(0.0);
-
-        const T_partials_return y_dbl = value_of(y_vec[n]);
-        const T_partials_return alpha_dbl = value_of(nu_vec[n]) * 0.5;
-        const T_partials_return beta_dbl = 0.5;
-
-        const T_partials_return Pn = gamma_p(alpha_dbl, beta_dbl * y_dbl);
-
-        cdf_log += log(Pn);
-
-        if (!is_constant_struct<T_y>::value)
-          operands_and_partials.d_x1[n] += beta_dbl * exp(-beta_dbl * y_dbl)
-            * pow(beta_dbl * y_dbl, alpha_dbl-1) / tgamma(alpha_dbl) / Pn;
-        if (!is_constant_struct<T_dof>::value)
-          operands_and_partials.d_x2[n]
-            -= 0.5 * grad_reg_inc_gamma(alpha_dbl, beta_dbl
-                                        * y_dbl, gamma_vec[n],
-                                        digamma_vec[n]) / Pn;
-      }
-      return operands_and_partials.value(cdf_log);
+      return chi_square_lcdf<T_y, T_dof>(y, nu);
     }
 
   }

--- a/stan/math/prim/scal/prob/chi_square_log.hpp
+++ b/stan/math/prim/scal/prob/chi_square_log.hpp
@@ -1,24 +1,7 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_CHI_SQUARE_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_CHI_SQUARE_LOG_HPP
 
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_nonnegative.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/err/check_positive_finite.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/fun/multiply_log.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/fun/gamma_p.hpp>
-#include <stan/math/prim/scal/fun/digamma.hpp>
-#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
-#include <stan/math/prim/scal/fun/grad_reg_inc_gamma.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <boost/random/chi_squared_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <cmath>
+#include <stan/math/prim/scal/prob/chi_square_lpdf.hpp>
 
 namespace stan {
   namespace math {
@@ -35,6 +18,8 @@ namespace stan {
      &=& - \frac{\nu}{2} \log(2) - \log (\Gamma (\nu / 2)) + (\frac{\nu}{2} - 1) \log(y) - \frac{y}{2} \\
      & & \mathrm{ where } \; y \ge 0
      \f}
+     *
+     * @deprecated use <code>chi_square_lpdf</code>
      * @param y A scalar variable.
      * @param nu Degrees of freedom.
      * @throw std::domain_error if nu is not greater than or equal to 0
@@ -46,93 +31,17 @@ namespace stan {
               typename T_y, typename T_dof>
     typename return_type<T_y, T_dof>::type
     chi_square_log(const T_y& y, const T_dof& nu) {
-      static const char* function("chi_square_log");
-      typedef typename stan::partials_return_type<T_y, T_dof>::type
-        T_partials_return;
-
-      if (!(stan::length(y)
-            && stan::length(nu)))
-        return 0.0;
-
-      T_partials_return logp(0.0);
-      check_not_nan(function, "Random variable", y);
-      check_nonnegative(function, "Random variable", y);
-      check_positive_finite(function, "Degrees of freedom parameter", nu);
-      check_consistent_sizes(function,
-                             "Random variable", y,
-                             "Degrees of freedom parameter", nu);
-
-      VectorView<const T_y> y_vec(y);
-      VectorView<const T_dof> nu_vec(nu);
-      size_t N = max_size(y, nu);
-
-      for (size_t n = 0; n < length(y); n++)
-        if (value_of(y_vec[n]) < 0)
-          return LOG_ZERO;
-
-      if (!include_summand<propto, T_y, T_dof>::value)
-        return 0.0;
-
-      using boost::math::digamma;
-      using boost::math::lgamma;
-      using std::log;
-
-      VectorBuilder<include_summand<propto, T_y, T_dof>::value,
-                    T_partials_return, T_y> log_y(length(y));
-      for (size_t i = 0; i < length(y); i++)
-        if (include_summand<propto, T_y, T_dof>::value)
-          log_y[i] = log(value_of(y_vec[i]));
-
-      VectorBuilder<include_summand<propto, T_y>::value,
-                    T_partials_return, T_y> inv_y(length(y));
-      for (size_t i = 0; i < length(y); i++)
-        if (include_summand<propto, T_y>::value)
-          inv_y[i] = 1.0 / value_of(y_vec[i]);
-
-      VectorBuilder<include_summand<propto, T_dof>::value,
-                    T_partials_return, T_dof> lgamma_half_nu(length(nu));
-      VectorBuilder<!is_constant_struct<T_dof>::value,
-                    T_partials_return, T_dof>
-        digamma_half_nu_over_two(length(nu));
-
-      for (size_t i = 0; i < length(nu); i++) {
-        T_partials_return half_nu = 0.5 * value_of(nu_vec[i]);
-        if (include_summand<propto, T_dof>::value)
-          lgamma_half_nu[i] = lgamma(half_nu);
-        if (!is_constant_struct<T_dof>::value)
-          digamma_half_nu_over_two[i] = digamma(half_nu) * 0.5;
-      }
-
-      OperandsAndPartials<T_y, T_dof> operands_and_partials(y, nu);
-
-      for (size_t n = 0; n < N; n++) {
-        const T_partials_return y_dbl = value_of(y_vec[n]);
-        const T_partials_return half_y = 0.5 * y_dbl;
-        const T_partials_return nu_dbl = value_of(nu_vec[n]);
-        const T_partials_return half_nu = 0.5 * nu_dbl;
-        if (include_summand<propto, T_dof>::value)
-          logp += nu_dbl * NEG_LOG_TWO_OVER_TWO - lgamma_half_nu[n];
-        if (include_summand<propto, T_y, T_dof>::value)
-          logp += (half_nu-1.0) * log_y[n];
-        if (include_summand<propto, T_y>::value)
-          logp -= half_y;
-
-        if (!is_constant_struct<T_y>::value) {
-          operands_and_partials.d_x1[n] += (half_nu-1.0)*inv_y[n] - 0.5;
-        }
-        if (!is_constant_struct<T_dof>::value) {
-          operands_and_partials.d_x2[n] += NEG_LOG_TWO_OVER_TWO
-            - digamma_half_nu_over_two[n] + log_y[n]*0.5;
-        }
-      }
-      return operands_and_partials.value(logp);
+      return chi_square_lpdf<propto, T_y, T_dof>(y, nu);
     }
 
+    /**
+     * @deprecated use <code>chi_square_lpdf</code>
+     */
     template <typename T_y, typename T_dof>
     inline
     typename return_type<T_y, T_dof>::type
     chi_square_log(const T_y& y, const T_dof& nu) {
-      return chi_square_log<false>(y, nu);
+      return chi_square_lpdf<T_y, T_dof>(y, nu);
     }
 
   }


### PR DESCRIPTION
#### Note on the 10 related pull requests
This is staged as follows:
- pull requests 1-7 will be adding new functions that mirror the old `_log` functions without altering the `_log` functions (except in situations where there are multiple definitions)
- pull requests 8-10 will deprecate the old functions and have the old functions call the new functions.
- This should wait on PRs: #441, #442, #443, #444, #445, #446, #447.

#### Submisison Checklist

- [x] Run unit tests: `./runTests.py test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary:
This pull request deprecates the `_log` functions by calling the new `_lpdf` / `_lpmf` / `_lcdf` / `_lccdf` function.

#### How to Verify:
Look at code and run code.

#### Side Effects:
None.

#### Documentation:
Doxygen doc deprecating the `_log` function.

#### Reviewer Suggestions: 
Anyone.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Columbia University.

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
