### PR TITLE
Updating probability functions. 9/10 pull requests.

### DIFF
--- a/stan/math/prim/scal/prob/double_exponential_ccdf_log.hpp
+++ b/stan/math/prim/scal/prob/double_exponential_ccdf_log.hpp
@@ -1,91 +1,19 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_DOUBLE_EXPONENTIAL_CCDF_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_DOUBLE_EXPONENTIAL_CCDF_LOG_HPP
 
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_finite.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/err/check_positive_finite.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/fun/log1m.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <stan/math/prim/scal/fun/sign.hpp>
-#include <boost/random/uniform_01.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <cmath>
+#include <stan/math/prim/scal/prob/double_exponential_lccdf.hpp>
 
 namespace stan {
   namespace math {
 
+    /**
+     * @deprecated use <code>double_exponential_lccdf</code>
+     */
     template <typename T_y, typename T_loc, typename T_scale>
     typename return_type<T_y, T_loc, T_scale>::type
     double_exponential_ccdf_log(const T_y& y, const T_loc& mu,
                                 const T_scale& sigma) {
-      static const char* function("double_exponential_ccdf_log");
-      typedef typename stan::partials_return_type<T_y, T_loc, T_scale>::type
-        T_partials_return;
-
-      T_partials_return ccdf_log(0.0);
-
-      if (!(stan::length(y)
-            && stan::length(mu)
-            && stan::length(sigma)))
-        return ccdf_log;
-
-      check_not_nan(function, "Random variable", y);
-      check_finite(function, "Location parameter", mu);
-      check_positive_finite(function, "Scale parameter", sigma);
-      check_consistent_sizes(function,
-                             "Random variable", y,
-                             "Location parameter", mu,
-                             "Scale Parameter", sigma);
-
-      using std::log;
-      using std::exp;
-      using std::exp;
-
-      OperandsAndPartials<T_y, T_loc, T_scale>
-        operands_and_partials(y, mu, sigma);
-
-      VectorView<const T_y> y_vec(y);
-      VectorView<const T_loc> mu_vec(mu);
-      VectorView<const T_scale> sigma_vec(sigma);
-      const double log_half = std::log(0.5);
-      size_t N = max_size(y, mu, sigma);
-
-      for (size_t n = 0; n < N; n++) {
-        const T_partials_return y_dbl = value_of(y_vec[n]);
-        const T_partials_return mu_dbl = value_of(mu_vec[n]);
-        const T_partials_return sigma_dbl = value_of(sigma_vec[n]);
-        const T_partials_return scaled_diff = (y_dbl - mu_dbl) / sigma_dbl;
-        const T_partials_return inv_sigma = 1.0 / sigma_dbl;
-        if (y_dbl < mu_dbl) {
-          ccdf_log += log1m(0.5 * exp(scaled_diff));
-
-          const T_partials_return rep_deriv = 1.0
-            / (2.0 * exp(-scaled_diff) - 1.0);
-          if (!is_constant_struct<T_y>::value)
-            operands_and_partials.d_x1[n] -= rep_deriv * inv_sigma;
-          if (!is_constant_struct<T_loc>::value)
-            operands_and_partials.d_x2[n] += rep_deriv * inv_sigma;
-          if (!is_constant_struct<T_scale>::value)
-            operands_and_partials.d_x3[n] += rep_deriv * scaled_diff
-              * inv_sigma;
-        } else {
-          ccdf_log += log_half - scaled_diff;
-
-          if (!is_constant_struct<T_y>::value)
-            operands_and_partials.d_x1[n] -= inv_sigma;
-          if (!is_constant_struct<T_loc>::value)
-            operands_and_partials.d_x2[n] += inv_sigma;
-          if (!is_constant_struct<T_scale>::value)
-            operands_and_partials.d_x3[n] += scaled_diff * inv_sigma;
-        }
-      }
-      return operands_and_partials.value(ccdf_log);
+      return double_exponential_lccdf<T_y, T_loc, T_scale>(y, mu, sigma);
     }
 
   }

--- a/stan/math/prim/scal/prob/double_exponential_cdf_log.hpp
+++ b/stan/math/prim/scal/prob/double_exponential_cdf_log.hpp
@@ -1,91 +1,19 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_DOUBLE_EXPONENTIAL_CDF_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_DOUBLE_EXPONENTIAL_CDF_LOG_HPP
 
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_finite.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/err/check_positive_finite.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/fun/log1m.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <stan/math/prim/scal/fun/sign.hpp>
-#include <boost/random/uniform_01.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <cmath>
+#include <stan/math/prim/scal/prob/double_exponential_lcdf.hpp>
 
 namespace stan {
   namespace math {
 
+    /**
+     * @deprecated use <code>double_exponential_lcdf</code>
+     */
     template <typename T_y, typename T_loc, typename T_scale>
     typename return_type<T_y, T_loc, T_scale>::type
     double_exponential_cdf_log(const T_y& y, const T_loc& mu,
                                const T_scale& sigma) {
-      static const char* function("double_exponential_cdf_log");
-      typedef typename stan::partials_return_type<T_y, T_loc, T_scale>::type
-        T_partials_return;
-
-      T_partials_return cdf_log(0.0);
-
-      if (!(stan::length(y)
-            && stan::length(mu)
-            && stan::length(sigma)))
-        return cdf_log;
-
-      check_not_nan(function, "Random variable", y);
-      check_finite(function, "Location parameter", mu);
-      check_positive_finite(function, "Scale parameter", sigma);
-      check_consistent_sizes(function,
-                             "Random variable", y,
-                             "Location parameter", mu,
-                             "Scale Parameter", sigma);
-
-      using std::log;
-      using std::exp;
-      using std::exp;
-
-      OperandsAndPartials<T_y, T_loc, T_scale>
-        operands_and_partials(y, mu, sigma);
-
-      VectorView<const T_y> y_vec(y);
-      VectorView<const T_loc> mu_vec(mu);
-      VectorView<const T_scale> sigma_vec(sigma);
-      const double log_half = std::log(0.5);
-      size_t N = max_size(y, mu, sigma);
-
-      for (size_t n = 0; n < N; n++) {
-        const T_partials_return y_dbl = value_of(y_vec[n]);
-        const T_partials_return mu_dbl = value_of(mu_vec[n]);
-        const T_partials_return sigma_dbl = value_of(sigma_vec[n]);
-        const T_partials_return scaled_diff = (y_dbl - mu_dbl) / sigma_dbl;
-        const T_partials_return inv_sigma = 1.0 / sigma_dbl;
-        if (y_dbl < mu_dbl) {
-          cdf_log += log_half + scaled_diff;
-
-          if (!is_constant_struct<T_y>::value)
-            operands_and_partials.d_x1[n] += inv_sigma;
-          if (!is_constant_struct<T_loc>::value)
-            operands_and_partials.d_x2[n] -= inv_sigma;
-          if (!is_constant_struct<T_scale>::value)
-            operands_and_partials.d_x3[n] -= scaled_diff * inv_sigma;
-        } else {
-          cdf_log += log1m(0.5 * exp(-scaled_diff));
-
-          const T_partials_return rep_deriv = 1.0
-            / (2.0 * exp(scaled_diff) - 1.0);
-          if (!is_constant_struct<T_y>::value)
-            operands_and_partials.d_x1[n] += rep_deriv * inv_sigma;
-          if (!is_constant_struct<T_loc>::value)
-            operands_and_partials.d_x2[n] -= rep_deriv * inv_sigma;
-          if (!is_constant_struct<T_scale>::value)
-            operands_and_partials.d_x3[n] -= rep_deriv * scaled_diff
-              * inv_sigma;
-        }
-      }
-      return operands_and_partials.value(cdf_log);
+      return double_exponential_lcdf<T_y, T_loc, T_scale>(y, mu, sigma);
     }
   }
 }

--- a/stan/math/prim/scal/prob/double_exponential_log.hpp
+++ b/stan/math/prim/scal/prob/double_exponential_log.hpp
@@ -1,119 +1,30 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_DOUBLE_EXPONENTIAL_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_DOUBLE_EXPONENTIAL_LOG_HPP
 
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_finite.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/err/check_positive_finite.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/fun/log1m.hpp>
-#include <stan/math/prim/scal/meta/contains_nonconstant_struct.hpp>
-#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <stan/math/prim/scal/fun/sign.hpp>
-#include <boost/random/uniform_01.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <cmath>
+#include <stan/math/prim/scal/prob/double_exponential_lpdf.hpp>
 
 namespace stan {
   namespace math {
 
-    // DoubleExponential(y|mu, sigma)  [sigma > 0]
-    // FIXME: add documentation
+    /**
+     * @deprecated use <code>double_exponential_lpdf</code>
+     */
     template <bool propto,
               typename T_y, typename T_loc, typename T_scale>
     typename return_type<T_y, T_loc, T_scale>::type
     double_exponential_log(const T_y& y,
                            const T_loc& mu, const T_scale& sigma) {
-      static const char* function("double_exponential_log");
-      typedef typename stan::partials_return_type<T_y, T_loc, T_scale>::type
-        T_partials_return;
-
-      using stan::is_constant_struct;
-      using std::log;
-      using std::fabs;
-      using std::log;
-
-      if (!(stan::length(y)
-            && stan::length(mu)
-            && stan::length(sigma)))
-        return 0.0;
-
-      T_partials_return logp(0.0);
-      check_finite(function, "Random variable", y);
-      check_finite(function, "Location parameter", mu);
-      check_positive_finite(function, "Scale parameter", sigma);
-      check_consistent_sizes(function,
-                             "Random variable", y,
-                             "Location parameter", mu,
-                             "Shape parameter", sigma);
-
-      if (!include_summand<propto, T_y, T_loc, T_scale>::value)
-        return 0.0;
-
-      VectorView<const T_y> y_vec(y);
-      VectorView<const T_loc> mu_vec(mu);
-      VectorView<const T_scale> sigma_vec(sigma);
-      size_t N = max_size(y, mu, sigma);
-      OperandsAndPartials<T_y, T_loc, T_scale>
-        operands_and_partials(y, mu, sigma);
-
-      VectorBuilder<include_summand<propto, T_y, T_loc, T_scale>::value,
-                    T_partials_return, T_scale> inv_sigma(length(sigma));
-      VectorBuilder<!is_constant_struct<T_scale>::value,
-                    T_partials_return, T_scale>
-        inv_sigma_squared(length(sigma));
-      VectorBuilder<include_summand<propto, T_scale>::value,
-                    T_partials_return, T_scale> log_sigma(length(sigma));
-      for (size_t i = 0; i < length(sigma); i++) {
-        const T_partials_return sigma_dbl = value_of(sigma_vec[i]);
-        if (include_summand<propto, T_y, T_loc, T_scale>::value)
-          inv_sigma[i] = 1.0 / sigma_dbl;
-        if (include_summand<propto, T_scale>::value)
-          log_sigma[i] = log(value_of(sigma_vec[i]));
-        if (!is_constant_struct<T_scale>::value)
-          inv_sigma_squared[i] = inv_sigma[i] * inv_sigma[i];
-      }
-
-      for (size_t n = 0; n < N; n++) {
-        const T_partials_return y_dbl = value_of(y_vec[n]);
-        const T_partials_return mu_dbl = value_of(mu_vec[n]);
-
-        const T_partials_return y_m_mu = y_dbl - mu_dbl;
-        const T_partials_return fabs_y_m_mu = fabs(y_m_mu);
-
-        if (include_summand<propto>::value)
-          logp += NEG_LOG_TWO;
-        if (include_summand<propto, T_scale>::value)
-          logp -= log_sigma[n];
-        if (include_summand<propto, T_y, T_loc, T_scale>::value)
-          logp -= fabs_y_m_mu * inv_sigma[n];
-
-        T_partials_return sign_y_m_mu_times_inv_sigma(0);
-        if (contains_nonconstant_struct<T_y, T_loc>::value)
-          sign_y_m_mu_times_inv_sigma = sign(y_m_mu) * inv_sigma[n];
-        if (!is_constant_struct<T_y>::value) {
-          operands_and_partials.d_x1[n] -= sign_y_m_mu_times_inv_sigma;
-        }
-        if (!is_constant_struct<T_loc>::value) {
-          operands_and_partials.d_x2[n] += sign_y_m_mu_times_inv_sigma;
-        }
-        if (!is_constant_struct<T_scale>::value)
-          operands_and_partials.d_x3[n] += -inv_sigma[n] + fabs_y_m_mu
-            * inv_sigma_squared[n];
-      }
-      return operands_and_partials.value(logp);
+      return double_exponential_lpdf<propto, T_y, T_loc, T_scale>(y, mu, sigma);
     }
 
+    /**
+     * @deprecated use <code>double_exponential_lpdf</code>
+     */
     template <typename T_y, typename T_loc, typename T_scale>
     typename return_type<T_y, T_loc, T_scale>::type
     double_exponential_log(const T_y& y, const T_loc& mu,
                            const T_scale& sigma) {
-      return double_exponential_log<false>(y, mu, sigma);
+      return double_exponential_lpdf<T_y, T_loc, T_scale>(y, mu, sigma);
     }
 
   }

--- a/stan/math/prim/scal/prob/exp_mod_normal_ccdf_log.hpp
+++ b/stan/math/prim/scal/prob/exp_mod_normal_ccdf_log.hpp
@@ -1,128 +1,23 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_EXP_MOD_NORMAL_CCDF_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_EXP_MOD_NORMAL_CCDF_LOG_HPP
 
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_finite.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/err/check_positive_finite.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/fun/is_inf.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <boost/random/normal_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <cmath>
+#include <stan/math/prim/scal/prob/exp_mod_normal_lccdf.hpp>
 
 namespace stan {
   namespace math {
 
+    /**
+     * @deprecated use <code>exp_mod_normal_lccdf</code>
+     */
     template <typename T_y, typename T_loc, typename T_scale,
               typename T_inv_scale>
     typename return_type<T_y, T_loc, T_scale, T_inv_scale>::type
     exp_mod_normal_ccdf_log(const T_y& y, const T_loc& mu, const T_scale& sigma,
                             const T_inv_scale& lambda) {
-      static const char* function("exp_mod_normal_ccdf_log");
-      typedef typename stan::partials_return_type<T_y, T_loc, T_scale,
-                                                  T_inv_scale>::type
-        T_partials_return;
-
-      T_partials_return ccdf_log(0.0);
-      if (!(stan::length(y)
-            && stan::length(mu)
-            && stan::length(sigma)
-            && stan::length(lambda)))
-        return ccdf_log;
-
-      check_not_nan(function, "Random variable", y);
-      check_finite(function, "Location parameter", mu);
-      check_not_nan(function, "Scale parameter", sigma);
-      check_positive_finite(function, "Scale parameter", sigma);
-      check_positive_finite(function, "Inv_scale parameter", lambda);
-      check_not_nan(function, "Inv_scale parameter", lambda);
-      check_consistent_sizes(function,
-                             "Random variable", y,
-                             "Location parameter", mu,
-                             "Scale parameter", sigma,
-                             "Inv_scale paramter", lambda);
-
-      OperandsAndPartials<T_y, T_loc, T_scale, T_inv_scale>
-        operands_and_partials(y, mu, sigma, lambda);
-
-      using std::log;
-      using std::log;
-      using std::exp;
-
-      VectorView<const T_y> y_vec(y);
-      VectorView<const T_loc> mu_vec(mu);
-      VectorView<const T_scale> sigma_vec(sigma);
-      VectorView<const T_inv_scale> lambda_vec(lambda);
-      size_t N = max_size(y, mu, sigma, lambda);
-      const double sqrt_pi = std::sqrt(pi());
-      for (size_t n = 0; n < N; n++) {
-        if (is_inf(y_vec[n])) {
-          if (y_vec[n] > 0.0)
-            return operands_and_partials.value(negative_infinity());
-          else
-            return operands_and_partials.value(0.0);
-        }
-
-        const T_partials_return y_dbl = value_of(y_vec[n]);
-        const T_partials_return mu_dbl = value_of(mu_vec[n]);
-        const T_partials_return sigma_dbl = value_of(sigma_vec[n]);
-        const T_partials_return lambda_dbl = value_of(lambda_vec[n]);
-        const T_partials_return u = lambda_dbl * (y_dbl - mu_dbl);
-        const T_partials_return v = lambda_dbl * sigma_dbl;
-        const T_partials_return v_sq = v * v;
-        const T_partials_return scaled_diff = (y_dbl - mu_dbl)
-          / (SQRT_2 * sigma_dbl);
-        const T_partials_return scaled_diff_sq = scaled_diff * scaled_diff;
-        const T_partials_return erf_calc1 = 0.5 * (1 + erf(u / (v * SQRT_2)));
-        const T_partials_return erf_calc2 = 0.5 * (1 + erf(u / (v * SQRT_2)
-                                                           - v / SQRT_2));
-
-        const T_partials_return deriv_1 = lambda_dbl * exp(0.5 * v_sq - u)
-          * erf_calc2;
-        const T_partials_return deriv_2 = SQRT_2 / sqrt_pi * 0.5
-          * exp(0.5 * v_sq
-                - (-scaled_diff + (v / SQRT_2)) * (-scaled_diff
-                                                   + (v / SQRT_2)) - u)
-          / sigma_dbl;
-        const T_partials_return deriv_3 = SQRT_2 / sqrt_pi * 0.5
-          * exp(-scaled_diff_sq) / sigma_dbl;
-
-        const T_partials_return ccdf_ = 1.0 - erf_calc1 + exp(-u + v_sq * 0.5)
-          * (erf_calc2);
-
-        ccdf_log += log(ccdf_);
-
-        if (!is_constant_struct<T_y>::value)
-          operands_and_partials.d_x1[n]
-            -= (deriv_1 - deriv_2 + deriv_3) / ccdf_;
-        if (!is_constant_struct<T_loc>::value)
-          operands_and_partials.d_x2[n]
-            -= (-deriv_1 + deriv_2 - deriv_3) / ccdf_;
-        if (!is_constant_struct<T_scale>::value)
-          operands_and_partials.d_x3[n]
-            -= (-deriv_1 * v - deriv_3 * scaled_diff * SQRT_2 - deriv_2
-                * sigma_dbl * SQRT_2
-                * (-SQRT_2 * 0.5 * (-lambda_dbl + scaled_diff * SQRT_2
-                                    / sigma_dbl)
-                   - SQRT_2 * lambda_dbl))
-            / ccdf_;
-        if (!is_constant_struct<T_inv_scale>::value)
-          operands_and_partials.d_x4[n] -= exp(0.5 * v_sq - u)
-            * (SQRT_2 / sqrt_pi * 0.5 * sigma_dbl
-               * exp(-(v / SQRT_2 - scaled_diff) * (v / SQRT_2 - scaled_diff))
-               - (v * sigma_dbl + mu_dbl - y_dbl) * erf_calc2)
-            / ccdf_;
-      }
-      return operands_and_partials.value(ccdf_log);
+      return exp_mod_normal_lccdf<T_y, T_loc,
+                                  T_scale, T_inv_scale>(y, mu, sigma, lambda);
     }
 
   }
 }
 #endif
-

--- a/stan/math/prim/scal/prob/exp_mod_normal_cdf_log.hpp
+++ b/stan/math/prim/scal/prob/exp_mod_normal_cdf_log.hpp
@@ -1,129 +1,23 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_EXP_MOD_NORMAL_CDF_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_EXP_MOD_NORMAL_CDF_LOG_HPP
 
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_finite.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/err/check_positive_finite.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/fun/is_inf.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <boost/random/normal_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <cmath>
+#include <stan/math/prim/scal/prob/exp_mod_normal_lcdf.hpp>
 
 namespace stan {
   namespace math {
 
+    /**
+     * @deprecated use <code>exp_mod_normal_lcdf</code>
+     */
     template <typename T_y, typename T_loc, typename T_scale,
               typename T_inv_scale>
     typename return_type<T_y, T_loc, T_scale, T_inv_scale>::type
     exp_mod_normal_cdf_log(const T_y& y, const T_loc& mu, const T_scale& sigma,
                            const T_inv_scale& lambda) {
-      static const char* function("exp_mod_normal_cdf_log");
-      typedef typename stan::partials_return_type<T_y, T_loc, T_scale,
-                                                  T_inv_scale>::type
-        T_partials_return;
-
-      T_partials_return cdf_log(0.0);
-      if (!(stan::length(y)
-            && stan::length(mu)
-            && stan::length(sigma)
-            && stan::length(lambda)))
-        return cdf_log;
-
-      check_not_nan(function, "Random variable", y);
-      check_finite(function, "Location parameter", mu);
-      check_not_nan(function, "Scale parameter", sigma);
-      check_positive_finite(function, "Scale parameter", sigma);
-      check_positive_finite(function, "Inv_scale parameter", lambda);
-      check_not_nan(function, "Inv_scale parameter", lambda);
-      check_consistent_sizes(function,
-                             "Random variable", y,
-                             "Location parameter", mu,
-                             "Scale parameter", sigma,
-                             "Inv_scale paramter", lambda);
-
-      OperandsAndPartials<T_y, T_loc, T_scale, T_inv_scale>
-        operands_and_partials(y, mu, sigma, lambda);
-
-      using std::log;
-      using std::log;
-      using std::exp;
-
-      VectorView<const T_y> y_vec(y);
-      VectorView<const T_loc> mu_vec(mu);
-      VectorView<const T_scale> sigma_vec(sigma);
-      VectorView<const T_inv_scale> lambda_vec(lambda);
-      size_t N = max_size(y, mu, sigma, lambda);
-      const double sqrt_pi = std::sqrt(pi());
-      for (size_t n = 0; n < N; n++) {
-        if (is_inf(y_vec[n])) {
-          if (y_vec[n] < 0.0)
-            return operands_and_partials.value(negative_infinity());
-          else
-            return operands_and_partials.value(0.0);
-        }
-
-        const T_partials_return y_dbl = value_of(y_vec[n]);
-        const T_partials_return mu_dbl = value_of(mu_vec[n]);
-        const T_partials_return sigma_dbl = value_of(sigma_vec[n]);
-        const T_partials_return lambda_dbl = value_of(lambda_vec[n]);
-        const T_partials_return u = lambda_dbl * (y_dbl - mu_dbl);
-        const T_partials_return v = lambda_dbl * sigma_dbl;
-        const T_partials_return v_sq = v * v;
-        const T_partials_return scaled_diff = (y_dbl - mu_dbl)
-          / (SQRT_2 * sigma_dbl);
-        const T_partials_return scaled_diff_sq = scaled_diff * scaled_diff;
-        const T_partials_return erf_calc1 = 0.5 * (1 + erf(u / (v * SQRT_2)));
-        const T_partials_return erf_calc2 = 0.5 * (1 + erf(u / (v * SQRT_2) - v
-                                                           / SQRT_2));
-        const T_partials_return deriv_1 = lambda_dbl * exp(0.5 * v_sq - u)
-          * erf_calc2;
-        const T_partials_return deriv_2 = SQRT_2 / sqrt_pi * 0.5
-          * exp(0.5 * v_sq - (-scaled_diff + (v / SQRT_2))
-                * (-scaled_diff + (v / SQRT_2)) - u) / sigma_dbl;
-        const T_partials_return deriv_3 = SQRT_2 / sqrt_pi * 0.5
-          * exp(-scaled_diff_sq) / sigma_dbl;
-
-        const T_partials_return denom = erf_calc1 - erf_calc2
-          * exp(0.5 * v_sq - u);
-        const T_partials_return cdf_ = erf_calc1 - exp(-u + v_sq * 0.5)
-          * (erf_calc2);
-
-        cdf_log += log(cdf_);
-
-        if (!is_constant_struct<T_y>::value)
-          operands_and_partials.d_x1[n] += (deriv_1 - deriv_2 + deriv_3)
-            / denom;
-        if (!is_constant_struct<T_loc>::value)
-          operands_and_partials.d_x2[n] += (-deriv_1 + deriv_2 - deriv_3)
-            / denom;
-        if (!is_constant_struct<T_scale>::value)
-          operands_and_partials.d_x3[n]
-            += (-deriv_1 * v - deriv_3 * scaled_diff
-                * SQRT_2 - deriv_2 * sigma_dbl * SQRT_2
-                * (-SQRT_2 * 0.5 * (-lambda_dbl + scaled_diff * SQRT_2
-                                    / sigma_dbl)
-                   - SQRT_2 * lambda_dbl))
-            / denom;
-        if (!is_constant_struct<T_inv_scale>::value)
-          operands_and_partials.d_x4[n]
-            += exp(0.5 * v_sq - u)
-            * (SQRT_2 / sqrt_pi * 0.5 * sigma_dbl
-               * exp(-(v / SQRT_2 - scaled_diff)
-                     * (v / SQRT_2 - scaled_diff))
-               - (v * sigma_dbl + mu_dbl - y_dbl) * erf_calc2)
-            / denom;
-      }
-      return operands_and_partials.value(cdf_log);
+      return exp_mod_normal_lcdf<T_y, T_loc, T_scale,
+                                 T_inv_scale>(y, mu, sigma, lambda);
     }
 
   }
 }
 #endif
-

--- a/stan/math/prim/scal/prob/exp_mod_normal_log.hpp
+++ b/stan/math/prim/scal/prob/exp_mod_normal_log.hpp
@@ -1,130 +1,35 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_EXP_MOD_NORMAL_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_EXP_MOD_NORMAL_LOG_HPP
 
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_finite.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/err/check_positive_finite.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <boost/random/normal_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <cmath>
+#include <stan/math/prim/scal/prob/exp_mod_normal_lpdf.hpp>
 
 namespace stan {
   namespace math {
 
+    /**
+     * @deprecated use <code>exp_mod_normal_lpdf</code>
+     */
     template <bool propto,
               typename T_y, typename T_loc, typename T_scale,
               typename T_inv_scale>
     typename return_type<T_y, T_loc, T_scale, T_inv_scale>::type
     exp_mod_normal_log(const T_y& y, const T_loc& mu, const T_scale& sigma,
                        const T_inv_scale& lambda) {
-      static const char* function("exp_mod_normal_log");
-      typedef typename stan::partials_return_type<T_y, T_loc, T_scale,
-                                                  T_inv_scale>::type
-        T_partials_return;
-
-      using stan::is_constant_struct;
-      using std::log;
-
-      if (!(stan::length(y)
-            && stan::length(mu)
-            && stan::length(sigma)
-            && stan::length(lambda)))
-        return 0.0;
-
-      T_partials_return logp(0.0);
-
-      check_not_nan(function, "Random variable", y);
-      check_finite(function, "Location parameter", mu);
-      check_positive_finite(function, "Inv_scale parameter", lambda);
-      check_positive_finite(function, "Scale parameter", sigma);
-      check_consistent_sizes(function,
-                             "Random variable", y,
-                             "Location parameter", mu,
-                             "Scale parameter", sigma,
-                             "Inv_scale paramter", lambda);
-
-      if (!include_summand<propto, T_y, T_loc, T_scale, T_inv_scale>::value)
-        return 0.0;
-
-      using boost::math::erfc;
-      using std::sqrt;
-      using std::log;
-      using std::exp;
-
-      OperandsAndPartials<T_y, T_loc, T_scale, T_inv_scale>
-        operands_and_partials(y, mu, sigma, lambda);
-
-      VectorView<const T_y> y_vec(y);
-      VectorView<const T_loc> mu_vec(mu);
-      VectorView<const T_scale> sigma_vec(sigma);
-      VectorView<const T_inv_scale> lambda_vec(lambda);
-      size_t N = max_size(y, mu, sigma, lambda);
-
-      for (size_t n = 0; n < N; n++) {
-        const T_partials_return y_dbl = value_of(y_vec[n]);
-        const T_partials_return mu_dbl = value_of(mu_vec[n]);
-        const T_partials_return sigma_dbl = value_of(sigma_vec[n]);
-        const T_partials_return lambda_dbl = value_of(lambda_vec[n]);
-
-        const T_partials_return pi_dbl = boost::math::constants::pi<double>();
-
-        if (include_summand<propto>::value)
-          logp -= log(2.0);
-        if (include_summand<propto, T_inv_scale>::value)
-          logp += log(lambda_dbl);
-        if (include_summand<propto, T_y, T_loc, T_scale, T_inv_scale>::value)
-          logp += lambda_dbl
-            * (mu_dbl + 0.5 * lambda_dbl * sigma_dbl * sigma_dbl - y_dbl)
-            + log(erfc((mu_dbl + lambda_dbl * sigma_dbl
-                        * sigma_dbl - y_dbl)
-                       / (sqrt(2.0) * sigma_dbl)));
-
-        const T_partials_return deriv_logerfc
-          = -2.0 / sqrt(pi_dbl)
-          * exp(-(mu_dbl + lambda_dbl * sigma_dbl * sigma_dbl - y_dbl)
-                / (std::sqrt(2.0) * sigma_dbl)
-                * (mu_dbl + lambda_dbl * sigma_dbl * sigma_dbl - y_dbl)
-                / (sigma_dbl * std::sqrt(2.0)))
-          / erfc((mu_dbl + lambda_dbl * sigma_dbl * sigma_dbl
-                  - y_dbl) / (sigma_dbl * std::sqrt(2.0)));
-
-        if (!is_constant_struct<T_y>::value)
-          operands_and_partials.d_x1[n]
-            += -lambda_dbl
-            + deriv_logerfc * -1.0 / (sigma_dbl * std::sqrt(2.0));
-        if (!is_constant_struct<T_loc>::value)
-          operands_and_partials.d_x2[n]
-            += lambda_dbl
-            + deriv_logerfc / (sigma_dbl * std::sqrt(2.0));
-        if (!is_constant_struct<T_scale>::value)
-          operands_and_partials.d_x3[n]
-            += sigma_dbl * lambda_dbl * lambda_dbl
-            + deriv_logerfc
-            * (-mu_dbl / (sigma_dbl * sigma_dbl * std::sqrt(2.0))
-               + lambda_dbl / std::sqrt(2.0)
-               + y_dbl / (sigma_dbl * sigma_dbl * std::sqrt(2.0)));
-        if (!is_constant_struct<T_inv_scale>::value)
-          operands_and_partials.d_x4[n]
-            += 1 / lambda_dbl + lambda_dbl * sigma_dbl * sigma_dbl
-            + mu_dbl - y_dbl + deriv_logerfc * sigma_dbl / std::sqrt(2.0);
-      }
-      return operands_and_partials.value(logp);
+      return exp_mod_normal_lpdf<propto, T_y, T_loc,
+                                 T_scale, T_inv_scale>(y, mu, sigma, lambda);
     }
 
+    /**
+     * @deprecated use <code>exp_mod_normal_lpdf</code>
+     */
     template <typename T_y, typename T_loc, typename T_scale,
               typename T_inv_scale>
     inline
     typename return_type<T_y, T_loc, T_scale, T_inv_scale>::type
     exp_mod_normal_log(const T_y& y, const T_loc& mu, const T_scale& sigma,
                        const T_inv_scale& lambda) {
-      return exp_mod_normal_log<false>(y, mu, sigma, lambda);
+      return exp_mod_normal_lpdf<T_y, T_loc,
+                                 T_scale, T_inv_scale>(y, mu, sigma, lambda);
     }
 
   }

--- a/stan/math/prim/scal/prob/exponential_ccdf_log.hpp
+++ b/stan/math/prim/scal/prob/exponential_ccdf_log.hpp
@@ -1,62 +1,18 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_EXPONENTIAL_CCDF_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_EXPONENTIAL_CCDF_LOG_HPP
 
-#include <boost/random/exponential_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_nonnegative.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/err/check_positive_finite.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/meta/length.hpp>
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/VectorView.hpp>
-#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/return_type.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
+#include <stan/math/prim/scal/prob/exponential_lccdf.hpp>
 
 namespace stan {
   namespace math {
 
+    /**
+     * @deprecated use <code>exponential_lccdf</code>
+     */
     template <typename T_y, typename T_inv_scale>
     typename return_type<T_y, T_inv_scale>::type
     exponential_ccdf_log(const T_y& y, const T_inv_scale& beta) {
-      typedef typename stan::partials_return_type<T_y, T_inv_scale>::type
-        T_partials_return;
-
-      static const char* function("exponential_ccdf_log");
-
-      using boost::math::tools::promote_args;
-
-      T_partials_return ccdf_log(0.0);
-      if (!(stan::length(y)
-            && stan::length(beta)))
-        return ccdf_log;
-
-      check_not_nan(function, "Random variable", y);
-      check_nonnegative(function, "Random variable", y);
-      check_positive_finite(function, "Inverse scale parameter", beta);
-
-      OperandsAndPartials<T_y, T_inv_scale>
-        operands_and_partials(y, beta);
-
-      VectorView<const T_y> y_vec(y);
-      VectorView<const T_inv_scale> beta_vec(beta);
-      size_t N = max_size(y, beta);
-      for (size_t n = 0; n < N; n++) {
-        const T_partials_return beta_dbl = value_of(beta_vec[n]);
-        const T_partials_return y_dbl = value_of(y_vec[n]);
-        ccdf_log += -beta_dbl * y_dbl;
-
-        if (!is_constant_struct<T_y>::value)
-          operands_and_partials.d_x1[n] -= beta_dbl;
-        if (!is_constant_struct<T_inv_scale>::value)
-          operands_and_partials.d_x2[n] -= y_dbl;
-      }
-      return operands_and_partials.value(ccdf_log);
+      return exponential_lccdf<T_y, T_inv_scale>(y, beta);
     }
 
   }

--- a/stan/math/prim/scal/prob/exponential_cdf_log.hpp
+++ b/stan/math/prim/scal/prob/exponential_cdf_log.hpp
@@ -1,68 +1,18 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_EXPONENTIAL_CDF_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_EXPONENTIAL_CDF_LOG_HPP
 
-#include <boost/random/exponential_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_nonnegative.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/err/check_positive_finite.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/meta/length.hpp>
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/VectorView.hpp>
-#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/return_type.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <cmath>
+#include <stan/math/prim/scal/prob/exponential_lcdf.hpp>
 
 namespace stan {
   namespace math {
 
+    /**
+     * @deprecated use <code>exponential_lcdf</code>
+     */
     template <typename T_y, typename T_inv_scale>
     typename return_type<T_y, T_inv_scale>::type
     exponential_cdf_log(const T_y& y, const T_inv_scale& beta) {
-      typedef
-        typename stan::partials_return_type<T_y, T_inv_scale>::type
-        T_partials_return;
-
-      static const char* function("exponential_cdf_log");
-
-      using boost::math::tools::promote_args;
-      using std::log;
-      using std::exp;
-
-      T_partials_return cdf_log(0.0);
-      if (!(stan::length(y)
-            && stan::length(beta)))
-        return cdf_log;
-
-      check_not_nan(function, "Random variable", y);
-      check_nonnegative(function, "Random variable", y);
-      check_positive_finite(function, "Inverse scale parameter", beta);
-
-      OperandsAndPartials<T_y, T_inv_scale>
-        operands_and_partials(y, beta);
-
-      VectorView<const T_y> y_vec(y);
-      VectorView<const T_inv_scale> beta_vec(beta);
-      size_t N = max_size(y, beta);
-      for (size_t n = 0; n < N; n++) {
-        const T_partials_return beta_dbl = value_of(beta_vec[n]);
-        const T_partials_return y_dbl = value_of(y_vec[n]);
-        T_partials_return one_m_exp = 1.0 - exp(-beta_dbl * y_dbl);
-        cdf_log += log(one_m_exp);
-
-        T_partials_return rep_deriv = -exp(-beta_dbl * y_dbl) / one_m_exp;
-        if (!is_constant_struct<T_y>::value)
-          operands_and_partials.d_x1[n] -= rep_deriv * beta_dbl;
-        if (!is_constant_struct<T_inv_scale>::value)
-          operands_and_partials.d_x2[n] -= rep_deriv * y_dbl;
-      }
-      return operands_and_partials.value(cdf_log);
+      return exponential_lcdf<T_y, T_inv_scale>(y, beta);
     }
 
   }

--- a/stan/math/prim/scal/prob/exponential_log.hpp
+++ b/stan/math/prim/scal/prob/exponential_log.hpp
@@ -1,23 +1,7 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_EXPONENTIAL_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_EXPONENTIAL_LOG_HPP
 
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_nonnegative.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/err/check_positive_finite.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/meta/length.hpp>
-#include <stan/math/prim/scal/meta/VectorView.hpp>
-#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/return_type.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <boost/random/exponential_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <cmath>
+#include <stan/math/prim/scal/prob/exponential_lpdf.hpp>
 
 namespace stan {
   namespace math {
@@ -41,6 +25,8 @@ namespace stan {
      \mathrm{where} \; y > 0
      \f}
      *
+     * @deprecated use <code>exponential_lpdf</code>     
+     *
      * @param y A scalar variable.
      * @param beta Inverse scale parameter.
      * @throw std::domain_error if beta is not greater than 0.
@@ -51,57 +37,17 @@ namespace stan {
     template <bool propto, typename T_y, typename T_inv_scale>
     typename return_type<T_y, T_inv_scale>::type
     exponential_log(const T_y& y, const T_inv_scale& beta) {
-      static const char* function("exponential_log");
-      typedef typename stan::partials_return_type<T_y, T_inv_scale>::type
-        T_partials_return;
-
-      if (!(stan::length(y)
-            && stan::length(beta)))
-        return 0.0;
-
-      using std::log;
-
-      T_partials_return logp(0.0);
-      check_nonnegative(function, "Random variable", y);
-      check_positive_finite(function, "Inverse scale parameter", beta);
-      check_consistent_sizes(function,
-                             "Random variable", y,
-                             "Inverse scale parameter", beta);
-
-      VectorView<const T_y> y_vec(y);
-      VectorView<const T_inv_scale> beta_vec(beta);
-      size_t N = max_size(y, beta);
-
-      VectorBuilder<include_summand<propto, T_inv_scale>::value,
-                    T_partials_return, T_inv_scale> log_beta(length(beta));
-      for (size_t i = 0; i < length(beta); i++)
-        if (include_summand<propto, T_inv_scale>::value)
-          log_beta[i] = log(value_of(beta_vec[i]));
-
-      OperandsAndPartials<T_y, T_inv_scale>
-        operands_and_partials(y, beta);
-
-      for (size_t n = 0; n < N; n++) {
-        const T_partials_return beta_dbl = value_of(beta_vec[n]);
-        const T_partials_return y_dbl = value_of(y_vec[n]);
-        if (include_summand<propto, T_inv_scale>::value)
-          logp += log_beta[n];
-        if (include_summand<propto, T_y, T_inv_scale>::value)
-          logp -= beta_dbl * y_dbl;
-
-        if (!is_constant_struct<T_y>::value)
-          operands_and_partials.d_x1[n] -= beta_dbl;
-        if (!is_constant_struct<T_inv_scale>::value)
-          operands_and_partials.d_x2[n] += 1 / beta_dbl - y_dbl;
-      }
-      return operands_and_partials.value(logp);
+      return exponential_lpdf<propto, T_y, T_inv_scale>(y, beta);
     }
 
+    /**
+     * @deprecated use <code>exponential_lpdf</code>
+     */
     template <typename T_y, typename T_inv_scale>
     inline
     typename return_type<T_y, T_inv_scale>::type
     exponential_log(const T_y& y, const T_inv_scale& beta) {
-      return exponential_log<false>(y, beta);
+      return exponential_lpdf<T_y, T_inv_scale>(y, beta);
     }
 
   }

--- a/stan/math/prim/scal/prob/frechet_ccdf_log.hpp
+++ b/stan/math/prim/scal/prob/frechet_ccdf_log.hpp
@@ -1,78 +1,18 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_FRECHET_CCDF_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_FRECHET_CCDF_LOG_HPP
 
-#include <boost/random/weibull_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_nonnegative.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/err/check_positive.hpp>
-#include <stan/math/prim/scal/err/check_positive_finite.hpp>
-#include <stan/math/prim/scal/fun/log1m.hpp>
-#include <stan/math/prim/scal/fun/multiply_log.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/meta/length.hpp>
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/VectorView.hpp>
-#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/return_type.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <cmath>
+#include <stan/math/prim/scal/prob/frechet_lccdf.hpp>
 
 namespace stan {
   namespace math {
 
+    /**
+     * @deprecated use <code>frechet_lccdf</code>
+     */
     template <typename T_y, typename T_shape, typename T_scale>
     typename return_type<T_y, T_shape, T_scale>::type
     frechet_ccdf_log(const T_y& y, const T_shape& alpha, const T_scale& sigma) {
-      typedef typename stan::partials_return_type<T_y, T_shape, T_scale>::type
-        T_partials_return;
-
-      static const char* function("frechet_ccdf_log");
-
-      using boost::math::tools::promote_args;
-
-      if (!(stan::length(y)
-            && stan::length(alpha)
-            && stan::length(sigma)))
-        return 0.0;
-
-      T_partials_return ccdf_log(0.0);
-      check_positive(function, "Random variable", y);
-      check_positive_finite(function, "Shape parameter", alpha);
-      check_positive_finite(function, "Scale parameter", sigma);
-
-      OperandsAndPartials<T_y, T_shape, T_scale>
-        operands_and_partials(y, alpha, sigma);
-
-      using std::log;
-      using std::exp;
-      VectorView<const T_y> y_vec(y);
-      VectorView<const T_scale> sigma_vec(sigma);
-      VectorView<const T_shape> alpha_vec(alpha);
-      size_t N = max_size(y, sigma, alpha);
-
-      for (size_t n = 0; n < N; n++) {
-        const T_partials_return y_dbl = value_of(y_vec[n]);
-        const T_partials_return sigma_dbl = value_of(sigma_vec[n]);
-        const T_partials_return alpha_dbl = value_of(alpha_vec[n]);
-        const T_partials_return pow_ = pow(sigma_dbl / y_dbl, alpha_dbl);
-        const T_partials_return exp_ = exp(-pow_);
-
-        ccdf_log += log1m(exp_);
-
-        const T_partials_return rep_deriv_ = pow_ / (1.0 / exp_ - 1);
-        if (!is_constant_struct<T_y>::value)
-          operands_and_partials.d_x1[n] -= alpha_dbl / y_dbl * rep_deriv_;
-        if (!is_constant_struct<T_shape>::value)
-          operands_and_partials.d_x2[n] -= log(y_dbl / sigma_dbl) * rep_deriv_;
-        if (!is_constant_struct<T_scale>::value)
-          operands_and_partials.d_x3[n] += alpha_dbl / sigma_dbl * rep_deriv_;
-      }
-      return operands_and_partials.value(ccdf_log);
+      return frechet_lccdf<T_y, T_shape, T_scale>(y, alpha, sigma);
     }
 
   }

--- a/stan/math/prim/scal/prob/frechet_cdf_log.hpp
+++ b/stan/math/prim/scal/prob/frechet_cdf_log.hpp
@@ -1,74 +1,18 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_FRECHET_CDF_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_FRECHET_CDF_LOG_HPP
 
-#include <boost/random/weibull_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_nonnegative.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/err/check_positive.hpp>
-#include <stan/math/prim/scal/err/check_positive_finite.hpp>
-#include <stan/math/prim/scal/fun/log1m.hpp>
-#include <stan/math/prim/scal/fun/multiply_log.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/meta/length.hpp>
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/VectorView.hpp>
-#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/return_type.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <cmath>
+#include <stan/math/prim/scal/prob/frechet_lcdf.hpp>
 
 namespace stan {
   namespace math {
 
+    /**
+     * @deprecated use <code>frechet_lcdf</code>
+     */
     template <typename T_y, typename T_shape, typename T_scale>
     typename return_type<T_y, T_shape, T_scale>::type
     frechet_cdf_log(const T_y& y, const T_shape& alpha, const T_scale& sigma) {
-      typedef typename stan::partials_return_type<T_y, T_shape, T_scale>::type
-        T_partials_return;
-
-      static const char* function("frechet_cdf_log");
-
-      using boost::math::tools::promote_args;
-      using std::log;
-
-      if (!(stan::length(y)
-            && stan::length(alpha)
-            && stan::length(sigma)))
-        return 0.0;
-
-      T_partials_return cdf_log(0.0);
-      check_positive(function, "Random variable", y);
-      check_positive_finite(function, "Shape parameter", alpha);
-      check_positive_finite(function, "Scale parameter", sigma);
-
-      OperandsAndPartials<T_y, T_shape, T_scale>
-        operands_and_partials(y, alpha, sigma);
-
-      VectorView<const T_y> y_vec(y);
-      VectorView<const T_scale> sigma_vec(sigma);
-      VectorView<const T_shape> alpha_vec(alpha);
-      size_t N = max_size(y, sigma, alpha);
-      for (size_t n = 0; n < N; n++) {
-        const T_partials_return y_dbl = value_of(y_vec[n]);
-        const T_partials_return sigma_dbl = value_of(sigma_vec[n]);
-        const T_partials_return alpha_dbl = value_of(alpha_vec[n]);
-        const T_partials_return pow_ = pow(sigma_dbl / y_dbl, alpha_dbl);
-
-        cdf_log -= pow_;
-
-        if (!is_constant_struct<T_y>::value)
-          operands_and_partials.d_x1[n] += pow_ * alpha_dbl / y_dbl;
-        if (!is_constant_struct<T_shape>::value)
-          operands_and_partials.d_x2[n] += pow_ * log(y_dbl / sigma_dbl);
-        if (!is_constant_struct<T_scale>::value)
-          operands_and_partials.d_x3[n] -= pow_ * alpha_dbl / sigma_dbl;
-      }
-      return operands_and_partials.value(cdf_log);
+      return frechet_lcdf<T_y, T_shape, T_scale>(y, alpha, sigma);
     }
 
   }

--- a/stan/math/prim/scal/prob/frechet_log.hpp
+++ b/stan/math/prim/scal/prob/frechet_log.hpp
@@ -1,134 +1,29 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_FRECHET_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_FRECHET_LOG_HPP
 
-#include <boost/random/weibull_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_nonnegative.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/err/check_positive.hpp>
-#include <stan/math/prim/scal/err/check_positive_finite.hpp>
-#include <stan/math/prim/scal/fun/log1m.hpp>
-#include <stan/math/prim/scal/fun/multiply_log.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/meta/length.hpp>
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/VectorView.hpp>
-#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/return_type.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <cmath>
+#include <stan/math/prim/scal/prob/frechet_lpdf.hpp>
 
 namespace stan {
   namespace math {
 
-    // Frechet(y|alpha, sigma)     [y > 0;  alpha > 0;  sigma > 0]
-    // FIXME: document
+    /**
+     * @deprecated use <code>frechet_lpdf</code>
+     */
     template <bool propto,
               typename T_y, typename T_shape, typename T_scale>
     typename return_type<T_y, T_shape, T_scale>::type
     frechet_log(const T_y& y, const T_shape& alpha, const T_scale& sigma) {
-      static const char* function("frechet_log");
-      typedef typename stan::partials_return_type<T_y, T_shape, T_scale>::type
-        T_partials_return;
-
-      using std::log;
-
-      if (!(stan::length(y)
-            && stan::length(alpha)
-            && stan::length(sigma)))
-        return 0.0;
-
-      T_partials_return logp(0.0);
-      check_positive(function, "Random variable", y);
-      check_positive_finite(function, "Shape parameter", alpha);
-      check_positive_finite(function, "Scale parameter", sigma);
-      check_consistent_sizes(function,
-                             "Random variable", y,
-                             "Shape parameter", alpha,
-                             "Scale parameter", sigma);
-
-      if (!include_summand<propto, T_y, T_shape, T_scale>::value)
-        return 0.0;
-
-      VectorView<const T_y> y_vec(y);
-      VectorView<const T_shape> alpha_vec(alpha);
-      VectorView<const T_scale> sigma_vec(sigma);
-      size_t N = max_size(y, alpha, sigma);
-
-      VectorBuilder<include_summand<propto, T_shape>::value,
-                    T_partials_return, T_shape> log_alpha(length(alpha));
-      for (size_t i = 0; i < length(alpha); i++)
-        if (include_summand<propto, T_shape>::value)
-          log_alpha[i] = log(value_of(alpha_vec[i]));
-
-      VectorBuilder<include_summand<propto, T_y, T_shape>::value,
-                    T_partials_return, T_y> log_y(length(y));
-      for (size_t i = 0; i < length(y); i++)
-        if (include_summand<propto, T_y, T_shape>::value)
-          log_y[i] = log(value_of(y_vec[i]));
-
-      VectorBuilder<include_summand<propto, T_shape, T_scale>::value,
-                    T_partials_return, T_scale> log_sigma(length(sigma));
-      for (size_t i = 0; i < length(sigma); i++)
-        if (include_summand<propto, T_shape, T_scale>::value)
-          log_sigma[i] = log(value_of(sigma_vec[i]));
-
-      VectorBuilder<include_summand<propto, T_y, T_shape, T_scale>::value,
-                    T_partials_return, T_y> inv_y(length(y));
-      for (size_t i = 0; i < length(y); i++)
-        if (include_summand<propto, T_y, T_shape, T_scale>::value)
-          inv_y[i] = 1.0 / value_of(y_vec[i]);
-
-      VectorBuilder<include_summand<propto, T_y, T_shape, T_scale>::value,
-                    T_partials_return, T_y, T_shape, T_scale>
-        sigma_div_y_pow_alpha(N);
-      for (size_t i = 0; i < N; i++)
-        if (include_summand<propto, T_y, T_shape, T_scale>::value) {
-          const T_partials_return alpha_dbl = value_of(alpha_vec[i]);
-          sigma_div_y_pow_alpha[i] = pow(inv_y[i] * value_of(sigma_vec[i]),
-                                         alpha_dbl);
-        }
-
-      OperandsAndPartials<T_y, T_shape, T_scale>
-        operands_and_partials(y, alpha, sigma);
-      for (size_t n = 0; n < N; n++) {
-        const T_partials_return alpha_dbl = value_of(alpha_vec[n]);
-        if (include_summand<propto, T_shape>::value)
-          logp += log_alpha[n];
-        if (include_summand<propto, T_y, T_shape>::value)
-          logp -= (alpha_dbl+1.0)*log_y[n];
-        if (include_summand<propto, T_shape, T_scale>::value)
-          logp += alpha_dbl*log_sigma[n];
-        if (include_summand<propto, T_y, T_shape, T_scale>::value)
-          logp -= sigma_div_y_pow_alpha[n];
-
-        if (!is_constant_struct<T_y>::value) {
-          const T_partials_return inv_y_dbl = value_of(inv_y[n]);
-          operands_and_partials.d_x1[n]
-            += -(alpha_dbl+1.0) * inv_y_dbl
-            + alpha_dbl * sigma_div_y_pow_alpha[n] * inv_y_dbl;
-        }
-        if (!is_constant_struct<T_shape>::value)
-          operands_and_partials.d_x2[n]
-            += 1.0/alpha_dbl
-            + (1.0 - sigma_div_y_pow_alpha[n]) * (log_sigma[n] - log_y[n]);
-        if (!is_constant_struct<T_scale>::value)
-          operands_and_partials.d_x3[n]
-            += alpha_dbl / value_of(sigma_vec[n])
-            * (1 - sigma_div_y_pow_alpha[n]);
-      }
-      return operands_and_partials.value(logp);
+      return frechet_lpdf<propto, T_y, T_shape, T_scale>(y, alpha, sigma);
     }
 
+    /**
+     * @deprecated use <code>frechet_lpdf</code>
+     */
     template <typename T_y, typename T_shape, typename T_scale>
     inline
     typename return_type<T_y, T_shape, T_scale>::type
     frechet_log(const T_y& y, const T_shape& alpha, const T_scale& sigma) {
-      return frechet_log<false>(y, alpha, sigma);
+      return frechet_lpdf<T_y, T_shape, T_scale>(y, alpha, sigma);
     }
 
   }

--- a/stan/math/prim/scal/prob/gamma_ccdf_log.hpp
+++ b/stan/math/prim/scal/prob/gamma_ccdf_log.hpp
@@ -1,122 +1,19 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_GAMMA_CCDF_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_GAMMA_CCDF_LOG_HPP
 
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_greater_or_equal.hpp>
-#include <stan/math/prim/scal/err/check_less_or_equal.hpp>
-#include <stan/math/prim/scal/err/check_nonnegative.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/err/check_positive_finite.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/fun/multiply_log.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/fun/gamma_q.hpp>
-#include <stan/math/prim/scal/fun/digamma.hpp>
-#include <stan/math/prim/scal/meta/length.hpp>
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/VectorView.hpp>
-#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/return_type.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <stan/math/prim/scal/fun/grad_reg_inc_gamma.hpp>
-#include <boost/random/gamma_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <cmath>
-#include <limits>
+#include <stan/math/prim/scal/prob/gamma_lccdf.hpp>
 
 namespace stan {
   namespace math {
 
+    /**
+     * @deprecated use <code>gamma_lccdf</code>
+     */
     template <typename T_y, typename T_shape, typename T_inv_scale>
     typename return_type<T_y, T_shape, T_inv_scale>::type
     gamma_ccdf_log(const T_y& y, const T_shape& alpha,
                    const T_inv_scale& beta) {
-      if (!(stan::length(y) && stan::length(alpha) && stan::length(beta)))
-        return 0.0;
-
-      typedef typename stan::partials_return_type<T_y, T_shape,
-                                                  T_inv_scale>::type
-        T_partials_return;
-
-      static const char* function("gamma_ccdf_log");
-
-      using boost::math::tools::promote_args;
-      using std::exp;
-
-      T_partials_return P(0.0);
-
-      check_positive_finite(function, "Shape parameter", alpha);
-      check_positive_finite(function, "Scale parameter", beta);
-      check_not_nan(function, "Random variable", y);
-      check_nonnegative(function, "Random variable", y);
-      check_consistent_sizes(function,
-                             "Random variable", y,
-                             "Shape parameter", alpha,
-                             "Scale Parameter", beta);
-
-      VectorView<const T_y> y_vec(y);
-      VectorView<const T_shape> alpha_vec(alpha);
-      VectorView<const T_inv_scale> beta_vec(beta);
-      size_t N = max_size(y, alpha, beta);
-
-      OperandsAndPartials<T_y, T_shape, T_inv_scale>
-        operands_and_partials(y, alpha, beta);
-
-      // Explicit return for extreme values
-      // The gradients are technically ill-defined, but treated as zero
-      for (size_t i = 0; i < stan::length(y); i++) {
-        if (value_of(y_vec[i]) == 0)
-          return operands_and_partials.value(0.0);
-      }
-
-      using boost::math::tgamma;
-      using std::exp;
-      using std::pow;
-      using std::log;
-
-      VectorBuilder<!is_constant_struct<T_shape>::value,
-                    T_partials_return, T_shape> gamma_vec(stan::length(alpha));
-      VectorBuilder<!is_constant_struct<T_shape>::value,
-                    T_partials_return, T_shape>
-        digamma_vec(stan::length(alpha));
-
-      if (!is_constant_struct<T_shape>::value) {
-        for (size_t i = 0; i < stan::length(alpha); i++) {
-          const T_partials_return alpha_dbl = value_of(alpha_vec[i]);
-          gamma_vec[i] = tgamma(alpha_dbl);
-          digamma_vec[i] = digamma(alpha_dbl);
-        }
-      }
-
-      for (size_t n = 0; n < N; n++) {
-        // Explicit results for extreme values
-        // The gradients are technically ill-defined, but treated as zero
-        if (value_of(y_vec[n]) == std::numeric_limits<double>::infinity())
-          return operands_and_partials.value(negative_infinity());
-
-        const T_partials_return y_dbl = value_of(y_vec[n]);
-        const T_partials_return alpha_dbl = value_of(alpha_vec[n]);
-        const T_partials_return beta_dbl = value_of(beta_vec[n]);
-
-        const T_partials_return Pn = gamma_q(alpha_dbl, beta_dbl * y_dbl);
-
-        P += log(Pn);
-
-        if (!is_constant_struct<T_y>::value)
-          operands_and_partials.d_x1[n] -= beta_dbl * exp(-beta_dbl * y_dbl)
-            * pow(beta_dbl * y_dbl, alpha_dbl-1) / tgamma(alpha_dbl) / Pn;
-        if (!is_constant_struct<T_shape>::value)
-          operands_and_partials.d_x2[n]
-            += grad_reg_inc_gamma(alpha_dbl, beta_dbl
-                                  * y_dbl, gamma_vec[n],
-                                  digamma_vec[n]) / Pn;
-        if (!is_constant_struct<T_inv_scale>::value)
-          operands_and_partials.d_x3[n] -= y_dbl * exp(-beta_dbl * y_dbl)
-            * pow(beta_dbl * y_dbl, alpha_dbl-1) / tgamma(alpha_dbl) / Pn;
-      }
-      return operands_and_partials.value(P);
+      return gamma_lccdf<T_y, T_shape, T_inv_scale>(y, alpha, beta);
     }
 
   }

--- a/stan/math/prim/scal/prob/gamma_cdf_log.hpp
+++ b/stan/math/prim/scal/prob/gamma_cdf_log.hpp
@@ -1,120 +1,18 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_GAMMA_CDF_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_GAMMA_CDF_LOG_HPP
 
-#include <boost/random/gamma_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_greater_or_equal.hpp>
-#include <stan/math/prim/scal/err/check_less_or_equal.hpp>
-#include <stan/math/prim/scal/err/check_nonnegative.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/err/check_positive_finite.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/fun/multiply_log.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/fun/gamma_p.hpp>
-#include <stan/math/prim/scal/fun/digamma.hpp>
-#include <stan/math/prim/scal/meta/length.hpp>
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/VectorView.hpp>
-#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/return_type.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <stan/math/prim/scal/fun/grad_reg_inc_gamma.hpp>
-#include <cmath>
-#include <limits>
+#include <stan/math/prim/scal/prob/gamma_lcdf.hpp>
 
 namespace stan {
   namespace math {
 
+    /**
+     * @deprecated use <code>gamma_lcdf</code>
+     */
     template <typename T_y, typename T_shape, typename T_inv_scale>
     typename return_type<T_y, T_shape, T_inv_scale>::type
     gamma_cdf_log(const T_y& y, const T_shape& alpha, const T_inv_scale& beta) {
-      if (!(stan::length(y) && stan::length(alpha) && stan::length(beta)))
-        return 0.0;
-      typedef typename stan::partials_return_type<T_y, T_shape,
-                                                  T_inv_scale>::type
-        T_partials_return;
-
-      static const char* function("gamma_cdf_log");
-
-      using boost::math::tools::promote_args;
-      using std::exp;
-
-      T_partials_return P(0.0);
-
-      check_positive_finite(function, "Shape parameter", alpha);
-      check_positive_finite(function, "Scale parameter", beta);
-      check_not_nan(function, "Random variable", y);
-      check_nonnegative(function, "Random variable", y);
-      check_consistent_sizes(function,
-                             "Random variable", y,
-                             "Shape parameter", alpha,
-                             "Scale Parameter", beta);
-
-      VectorView<const T_y> y_vec(y);
-      VectorView<const T_shape> alpha_vec(alpha);
-      VectorView<const T_inv_scale> beta_vec(beta);
-      size_t N = max_size(y, alpha, beta);
-
-      OperandsAndPartials<T_y, T_shape, T_inv_scale>
-        operands_and_partials(y, alpha, beta);
-
-      // Explicit return for extreme values
-      // The gradients are technically ill-defined, but treated as zero
-      for (size_t i = 0; i < stan::length(y); i++) {
-        if (value_of(y_vec[i]) == 0)
-          return operands_and_partials.value(negative_infinity());
-      }
-
-      using boost::math::tgamma;
-      using std::exp;
-      using std::pow;
-      using std::log;
-
-      VectorBuilder<!is_constant_struct<T_shape>::value,
-                    T_partials_return, T_shape> gamma_vec(stan::length(alpha));
-      VectorBuilder<!is_constant_struct<T_shape>::value,
-                    T_partials_return, T_shape>
-        digamma_vec(stan::length(alpha));
-
-      if (!is_constant_struct<T_shape>::value) {
-        for (size_t i = 0; i < stan::length(alpha); i++) {
-          const T_partials_return alpha_dbl = value_of(alpha_vec[i]);
-          gamma_vec[i] = tgamma(alpha_dbl);
-          digamma_vec[i] = digamma(alpha_dbl);
-        }
-      }
-
-      for (size_t n = 0; n < N; n++) {
-        // Explicit results for extreme values
-        // The gradients are technically ill-defined, but treated as zero
-        if (value_of(y_vec[n]) == std::numeric_limits<double>::infinity())
-          return operands_and_partials.value(0.0);
-
-        const T_partials_return y_dbl = value_of(y_vec[n]);
-        const T_partials_return alpha_dbl = value_of(alpha_vec[n]);
-        const T_partials_return beta_dbl = value_of(beta_vec[n]);
-
-        const T_partials_return Pn = gamma_p(alpha_dbl, beta_dbl * y_dbl);
-
-        P += log(Pn);
-
-        if (!is_constant_struct<T_y>::value)
-          operands_and_partials.d_x1[n] += beta_dbl * exp(-beta_dbl * y_dbl)
-            * pow(beta_dbl * y_dbl, alpha_dbl-1) / tgamma(alpha_dbl) / Pn;
-        if (!is_constant_struct<T_shape>::value)
-          operands_and_partials.d_x2[n]
-            -= grad_reg_inc_gamma(alpha_dbl, beta_dbl
-                                  * y_dbl, gamma_vec[n],
-                                  digamma_vec[n]) / Pn;
-        if (!is_constant_struct<T_inv_scale>::value)
-          operands_and_partials.d_x3[n] += y_dbl * exp(-beta_dbl * y_dbl)
-            * pow(beta_dbl * y_dbl, alpha_dbl-1) / tgamma(alpha_dbl) / Pn;
-      }
-      return operands_and_partials.value(P);
+      return gamma_lcdf<T_y, T_shape, T_inv_scale>(y, alpha, beta);
     }
 
   }

--- a/stan/math/prim/scal/prob/gamma_log.hpp
+++ b/stan/math/prim/scal/prob/gamma_log.hpp
@@ -1,26 +1,7 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_GAMMA_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_GAMMA_LOG_HPP
 
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_greater_or_equal.hpp>
-#include <stan/math/prim/scal/err/check_less_or_equal.hpp>
-#include <stan/math/prim/scal/err/check_nonnegative.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/err/check_positive_finite.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/fun/multiply_log.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/fun/gamma_p.hpp>
-#include <stan/math/prim/scal/fun/digamma.hpp>
-#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <stan/math/prim/scal/fun/grad_reg_inc_gamma.hpp>
-#include <boost/random/gamma_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <cmath>
+#include <stan/math/prim/scal/prob/gamma_lpdf.hpp>
 
 namespace stan {
   namespace math {
@@ -37,6 +18,9 @@ namespace stan {
      &=& \alpha \log(\beta) - \log(\Gamma(\alpha)) + (\alpha - 1) \log(y) - \beta y\\
      & & \mathrm{where} \; y > 0
      \f}
+     *
+     * @deprecated use <code>gamma_lpdf</code>
+     *
      * @param y A scalar variable.
      * @param alpha Shape parameter.
      * @param beta Inverse scale parameter.
@@ -51,106 +35,17 @@ namespace stan {
               typename T_y, typename T_shape, typename T_inv_scale>
     typename return_type<T_y, T_shape, T_inv_scale>::type
     gamma_log(const T_y& y, const T_shape& alpha, const T_inv_scale& beta) {
-      static const char* function("gamma_log");
-      typedef typename stan::partials_return_type<T_y, T_shape,
-                                                  T_inv_scale>::type
-        T_partials_return;
-
-      using stan::is_constant_struct;
-
-      if (!(stan::length(y)
-            && stan::length(alpha)
-            && stan::length(beta)))
-        return 0.0;
-
-      T_partials_return logp(0.0);
-
-      check_not_nan(function, "Random variable", y);
-      check_positive_finite(function, "Shape parameter", alpha);
-      check_positive_finite(function, "Inverse scale parameter", beta);
-      check_consistent_sizes(function,
-                             "Random variable", y,
-                             "Shape parameter", alpha,
-                             "Inverse scale parameter", beta);
-
-      if (!include_summand<propto, T_y, T_shape, T_inv_scale>::value)
-        return 0.0;
-
-      VectorView<const T_y> y_vec(y);
-      VectorView<const T_shape> alpha_vec(alpha);
-      VectorView<const T_inv_scale> beta_vec(beta);
-
-      for (size_t n = 0; n < length(y); n++) {
-        const T_partials_return y_dbl = value_of(y_vec[n]);
-        if (y_dbl < 0)
-          return LOG_ZERO;
-      }
-
-      size_t N = max_size(y, alpha, beta);
-      OperandsAndPartials<T_y, T_shape, T_inv_scale>
-        operands_and_partials(y, alpha, beta);
-
-      using boost::math::lgamma;
-      using boost::math::digamma;
-      using std::log;
-
-      VectorBuilder<include_summand<propto, T_y, T_shape>::value,
-                    T_partials_return, T_y> log_y(length(y));
-      if (include_summand<propto, T_y, T_shape>::value) {
-        for (size_t n = 0; n < length(y); n++) {
-          if (value_of(y_vec[n]) > 0)
-            log_y[n] = log(value_of(y_vec[n]));
-        }
-      }
-
-      VectorBuilder<include_summand<propto, T_shape>::value,
-                    T_partials_return, T_shape> lgamma_alpha(length(alpha));
-      VectorBuilder<!is_constant_struct<T_shape>::value,
-                    T_partials_return, T_shape> digamma_alpha(length(alpha));
-      for (size_t n = 0; n < length(alpha); n++) {
-        if (include_summand<propto, T_shape>::value)
-          lgamma_alpha[n] = lgamma(value_of(alpha_vec[n]));
-        if (!is_constant_struct<T_shape>::value)
-          digamma_alpha[n] = digamma(value_of(alpha_vec[n]));
-      }
-
-      VectorBuilder<include_summand<propto, T_shape, T_inv_scale>::value,
-                    T_partials_return, T_inv_scale> log_beta(length(beta));
-      if (include_summand<propto, T_shape, T_inv_scale>::value) {
-        for (size_t n = 0; n < length(beta); n++)
-          log_beta[n] = log(value_of(beta_vec[n]));
-      }
-
-      for (size_t n = 0; n < N; n++) {
-        const T_partials_return y_dbl = value_of(y_vec[n]);
-        const T_partials_return alpha_dbl = value_of(alpha_vec[n]);
-        const T_partials_return beta_dbl = value_of(beta_vec[n]);
-
-        if (include_summand<propto, T_shape>::value)
-          logp -= lgamma_alpha[n];
-        if (include_summand<propto, T_shape, T_inv_scale>::value)
-          logp += alpha_dbl * log_beta[n];
-        if (include_summand<propto, T_y, T_shape>::value)
-          logp += (alpha_dbl-1.0) * log_y[n];
-        if (include_summand<propto, T_y, T_inv_scale>::value)
-          logp -= beta_dbl * y_dbl;
-
-        if (!is_constant_struct<T_y>::value)
-          operands_and_partials.d_x1[n] += (alpha_dbl-1)/y_dbl - beta_dbl;
-        if (!is_constant_struct<T_shape>::value)
-          operands_and_partials.d_x2[n] += -digamma_alpha[n] + log_beta[n]
-            + log_y[n];
-        if (!is_constant_struct<T_inv_scale>::value)
-          operands_and_partials.d_x3[n] += alpha_dbl / beta_dbl - y_dbl;
-      }
-      return operands_and_partials.value(logp);
+      return gamma_lpdf<propto, T_y, T_shape, T_inv_scale>(y, alpha, beta);
     }
 
+    /**
+     * @deprecated use <code>gamma_lpdf</code>
+     */
     template <typename T_y, typename T_shape, typename T_inv_scale>
     inline
     typename return_type<T_y, T_shape, T_inv_scale>::type
     gamma_log(const T_y& y, const T_shape& alpha, const T_inv_scale& beta) {
-      return gamma_log<false>(y, alpha, beta);
+      return gamma_lpdf<T_y, T_shape, T_inv_scale>(y, alpha, beta);
     }
 
   }

--- a/stan/math/prim/scal/prob/gumbel_ccdf_log.hpp
+++ b/stan/math/prim/scal/prob/gumbel_ccdf_log.hpp
@@ -1,80 +1,18 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_GUMBEL_CCDF_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_GUMBEL_CCDF_LOG_HPP
 
-#include <boost/random/uniform_01.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_finite.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/err/check_positive.hpp>
-#include <stan/math/prim/scal/meta/length.hpp>
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/VectorView.hpp>
-#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/return_type.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <cmath>
+#include <stan/math/prim/scal/prob/gumbel_lccdf.hpp>
 
 namespace stan {
   namespace math {
 
+    /**
+     * @deprecated use <code>gumbel_lccdf</code>
+     */
     template <typename T_y, typename T_loc, typename T_scale>
     typename return_type<T_y, T_loc, T_scale>::type
     gumbel_ccdf_log(const T_y& y, const T_loc& mu, const T_scale& beta) {
-      static const char* function("gumbel_ccdf_log");
-      typedef typename stan::partials_return_type<T_y, T_loc, T_scale>::type
-        T_partials_return;
-
-      using std::log;
-      using std::exp;
-
-      T_partials_return ccdf_log(0.0);
-      if (!(stan::length(y)
-            && stan::length(mu)
-            && stan::length(beta)))
-        return ccdf_log;
-
-      check_not_nan(function, "Random variable", y);
-      check_finite(function, "Location parameter", mu);
-      check_not_nan(function, "Scale parameter", beta);
-      check_positive(function, "Scale parameter", beta);
-      check_consistent_sizes(function,
-                             "Random variable", y,
-                             "Location parameter", mu,
-                             "Scale parameter", beta);
-
-      OperandsAndPartials<T_y, T_loc, T_scale>
-        operands_and_partials(y, mu, beta);
-
-      VectorView<const T_y> y_vec(y);
-      VectorView<const T_loc> mu_vec(mu);
-      VectorView<const T_scale> beta_vec(beta);
-      size_t N = max_size(y, mu, beta);
-
-      for (size_t n = 0; n < N; n++) {
-        const T_partials_return y_dbl = value_of(y_vec[n]);
-        const T_partials_return mu_dbl = value_of(mu_vec[n]);
-        const T_partials_return beta_dbl = value_of(beta_vec[n]);
-        const T_partials_return scaled_diff = (y_dbl - mu_dbl) / beta_dbl;
-        const T_partials_return rep_deriv = exp(-scaled_diff
-                                                - exp(-scaled_diff))
-          / beta_dbl;
-        const T_partials_return ccdf_log_ = 1.0 - exp(-exp(-scaled_diff));
-        ccdf_log += log(ccdf_log_);
-
-        if (!is_constant_struct<T_y>::value)
-          operands_and_partials.d_x1[n] -= rep_deriv / ccdf_log_;
-        if (!is_constant_struct<T_loc>::value)
-          operands_and_partials.d_x2[n] += rep_deriv / ccdf_log_;
-        if (!is_constant_struct<T_scale>::value)
-          operands_and_partials.d_x3[n] += rep_deriv * scaled_diff / ccdf_log_;
-      }
-
-      return operands_and_partials.value(ccdf_log);
+      return gumbel_lccdf<T_y, T_loc, T_scale>(y, mu, beta);
     }
 
   }

--- a/stan/math/prim/scal/prob/gumbel_cdf_log.hpp
+++ b/stan/math/prim/scal/prob/gumbel_cdf_log.hpp
@@ -1,75 +1,18 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_GUMBEL_CDF_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_GUMBEL_CDF_LOG_HPP
 
-#include <boost/random/uniform_01.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_finite.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/err/check_positive.hpp>
-#include <stan/math/prim/scal/meta/length.hpp>
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/VectorView.hpp>
-#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/return_type.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <cmath>
+#include <stan/math/prim/scal/prob/gumbel_lcdf.hpp>
 
 namespace stan {
   namespace math {
 
+    /**
+     * @deprecated use <code>gumbel_lcdf</code>
+     */
     template <typename T_y, typename T_loc, typename T_scale>
     typename return_type<T_y, T_loc, T_scale>::type
     gumbel_cdf_log(const T_y& y, const T_loc& mu, const T_scale& beta) {
-      static const char* function("gumbel_cdf_log");
-      typedef typename stan::partials_return_type<T_y, T_loc, T_scale>::type
-        T_partials_return;
-
-      using std::exp;
-
-      T_partials_return cdf_log(0.0);
-      if (!(stan::length(y)
-            && stan::length(mu)
-            && stan::length(beta)))
-        return cdf_log;
-
-      check_not_nan(function, "Random variable", y);
-      check_finite(function, "Location parameter", mu);
-      check_not_nan(function, "Scale parameter", beta);
-      check_positive(function, "Scale parameter", beta);
-      check_consistent_sizes(function,
-                             "Random variable", y,
-                             "Location parameter", mu,
-                             "Scale parameter", beta);
-
-      OperandsAndPartials<T_y, T_loc, T_scale>
-        operands_and_partials(y, mu, beta);
-
-      VectorView<const T_y> y_vec(y);
-      VectorView<const T_loc> mu_vec(mu);
-      VectorView<const T_scale> beta_vec(beta);
-      size_t N = max_size(y, mu, beta);
-
-      for (size_t n = 0; n < N; n++) {
-        const T_partials_return y_dbl = value_of(y_vec[n]);
-        const T_partials_return mu_dbl = value_of(mu_vec[n]);
-        const T_partials_return beta_dbl = value_of(beta_vec[n]);
-        const T_partials_return scaled_diff = (y_dbl - mu_dbl) / beta_dbl;
-        const T_partials_return rep_deriv = exp(-scaled_diff) / beta_dbl;
-        cdf_log -= exp(-scaled_diff);
-
-        if (!is_constant_struct<T_y>::value)
-          operands_and_partials.d_x1[n] += rep_deriv;
-        if (!is_constant_struct<T_loc>::value)
-          operands_and_partials.d_x2[n] -= rep_deriv;
-        if (!is_constant_struct<T_scale>::value)
-          operands_and_partials.d_x3[n] -= rep_deriv * scaled_diff;
-      }
-      return operands_and_partials.value(cdf_log);
+      return gumbel_lcdf<T_y, T_loc, T_scale>(y, mu, beta);
     }
 
   }

--- a/stan/math/prim/scal/prob/gumbel_log.hpp
+++ b/stan/math/prim/scal/prob/gumbel_log.hpp
@@ -1,104 +1,28 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_GUMBEL_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_GUMBEL_LOG_HPP
 
-#include <boost/random/uniform_01.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_finite.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/err/check_positive.hpp>
-#include <stan/math/prim/scal/meta/length.hpp>
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/VectorView.hpp>
-#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/return_type.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <cmath>
+#include <stan/math/prim/scal/prob/gumbel_lpdf.hpp>
 
 namespace stan {
   namespace math {
 
+    /**
+     * @deprecated use <code>gumbel_lpdf</code>
+     */
     template <bool propto, typename T_y, typename T_loc, typename T_scale>
     typename return_type<T_y, T_loc, T_scale>::type
     gumbel_log(const T_y& y, const T_loc& mu, const T_scale& beta) {
-      static const char* function("gumbel_log");
-      typedef typename stan::partials_return_type<T_y, T_loc, T_scale>::type
-        T_partials_return;
-
-      using std::log;
-      using std::exp;
-      using stan::is_constant_struct;
-
-      if (!(stan::length(y)
-            && stan::length(mu)
-            && stan::length(beta)))
-        return 0.0;
-
-      T_partials_return logp(0.0);
-
-      check_not_nan(function, "Random variable", y);
-      check_finite(function, "Location parameter", mu);
-      check_positive(function, "Scale parameter", beta);
-      check_consistent_sizes(function,
-                             "Random variable", y,
-                             "Location parameter", mu,
-                             "Scale parameter", beta);
-
-      if (!include_summand<propto, T_y, T_loc, T_scale>::value)
-        return 0.0;
-
-      OperandsAndPartials<T_y, T_loc, T_scale>
-        operands_and_partials(y, mu, beta);
-
-      VectorView<const T_y> y_vec(y);
-      VectorView<const T_loc> mu_vec(mu);
-      VectorView<const T_scale> beta_vec(beta);
-      size_t N = max_size(y, mu, beta);
-
-      VectorBuilder<true, T_partials_return, T_scale> inv_beta(length(beta));
-      VectorBuilder<include_summand<propto, T_scale>::value,
-                    T_partials_return, T_scale> log_beta(length(beta));
-      for (size_t i = 0; i < length(beta); i++) {
-        inv_beta[i] = 1.0 / value_of(beta_vec[i]);
-        if (include_summand<propto, T_scale>::value)
-          log_beta[i] = log(value_of(beta_vec[i]));
-      }
-
-      for (size_t n = 0; n < N; n++) {
-        const T_partials_return y_dbl = value_of(y_vec[n]);
-        const T_partials_return mu_dbl = value_of(mu_vec[n]);
-
-        const T_partials_return y_minus_mu_over_beta
-          = (y_dbl - mu_dbl) * inv_beta[n];
-
-        if (include_summand<propto, T_scale>::value)
-          logp -= log_beta[n];
-        if (include_summand<propto, T_y, T_loc, T_scale>::value)
-          logp += -y_minus_mu_over_beta - exp(-y_minus_mu_over_beta);
-
-        T_partials_return scaled_diff = inv_beta[n]
-          * exp(-y_minus_mu_over_beta);
-        if (!is_constant_struct<T_y>::value)
-          operands_and_partials.d_x1[n] -= inv_beta[n] - scaled_diff;
-        if (!is_constant_struct<T_loc>::value)
-          operands_and_partials.d_x2[n] += inv_beta[n] - scaled_diff;
-        if (!is_constant_struct<T_scale>::value)
-          operands_and_partials.d_x3[n]
-            += -inv_beta[n] + y_minus_mu_over_beta * inv_beta[n]
-            - scaled_diff * y_minus_mu_over_beta;
-      }
-      return operands_and_partials.value(logp);
+      return gumbel_lpdf<propto, T_y, T_loc, T_scale>(y, mu, beta);
     }
 
+    /**
+     * @deprecated use <code>gumbel_lpdf</code>
+     */
     template <typename T_y, typename T_loc, typename T_scale>
     inline
     typename return_type<T_y, T_loc, T_scale>::type
     gumbel_log(const T_y& y, const T_loc& mu, const T_scale& beta) {
-      return gumbel_log<false>(y, mu, beta);
+      return gumbel_lpdf<T_y, T_loc, T_scale>(y, mu, beta);
     }
 
   }

--- a/stan/math/prim/scal/prob/hypergeometric_log.hpp
+++ b/stan/math/prim/scal/prob/hypergeometric_log.hpp
@@ -1,71 +1,26 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_HYPERGEOMETRIC_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_HYPERGEOMETRIC_LOG_HPP
 
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_bounded.hpp>
-#include <stan/math/prim/scal/err/check_finite.hpp>
-#include <stan/math/prim/scal/err/check_greater.hpp>
-#include <stan/math/prim/scal/err/check_positive.hpp>
-#include <stan/math/prim/scal/fun/binomial_coefficient_log.hpp>
-#include <stan/math/prim/scal/meta/length.hpp>
-#include <stan/math/prim/scal/meta/VectorView.hpp>
-#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
-#include <stan/math/prim/scal/meta/return_type.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <boost/math/distributions.hpp>
+#include <stan/math/prim/scal/prob/hypergeometric_lpmf.hpp>
 
 namespace stan {
   namespace math {
 
-    // Hypergeometric(n|N, a, b)  [0 <= n <= a;  0 <= N-n <= b;  0 <= N <= a+b]
-    // n: #white balls drawn;  N: #balls drawn;
-    // a: #white balls;  b: #black balls
+    /**
+     * @deprecated use <code>hypergeometric_lpmf</code>
+     */
     template <bool propto,
               typename T_n, typename T_N,
               typename T_a, typename T_b>
     double
     hypergeometric_log(const T_n& n, const T_N& N,
                        const T_a& a, const T_b& b) {
-      static const char* function("hypergeometric_log");
-
-      if (!(stan::length(n)
-            && stan::length(N)
-            && stan::length(a)
-            && stan::length(b)))
-        return 0.0;
-
-      VectorView<const T_n> n_vec(n);
-      VectorView<const T_N> N_vec(N);
-      VectorView<const T_a> a_vec(a);
-      VectorView<const T_b> b_vec(b);
-      size_t size = max_size(n, N, a, b);
-
-      double logp(0.0);
-      check_bounded(function, "Successes variable", n, 0, a);
-      check_greater(function, "Draws parameter", N, n);
-      for (size_t i = 0; i < size; i++) {
-        check_bounded(function, "Draws parameter minus successes variable",
-                      N_vec[i]-n_vec[i], 0, b_vec[i]);
-        check_bounded(function, "Draws parameter", N_vec[i], 0,
-                      a_vec[i]+b_vec[i]);
-      }
-      check_consistent_sizes(function,
-                             "Successes variable", n,
-                             "Draws parameter", N,
-                             "Successes in population parameter", a,
-                             "Failures in population parameter", b);
-
-      if (!include_summand<propto>::value)
-        return 0.0;
-
-      for (size_t i = 0; i < size; i++)
-        logp += math::binomial_coefficient_log(a_vec[i], n_vec[i])
-          + math::binomial_coefficient_log(b_vec[i], N_vec[i]-n_vec[i])
-          - math::binomial_coefficient_log(a_vec[i]+b_vec[i], N_vec[i]);
-      return logp;
+      return hypergeometric_lpmf<propto, T_n, T_N, T_a, T_b>(n, N, a, b);
     }
 
+    /**
+     * @deprecated use <code>hypergeometric_lpmf</code>
+     */
     template <typename T_n,
               typename T_N,
               typename T_a,
@@ -76,7 +31,7 @@ namespace stan {
                        const T_N& N,
                        const T_a& a,
                        const T_b& b) {
-      return hypergeometric_log<false>(n, N, a, b);
+      return hypergeometric_lpmf<T_n, T_N, T_a, T_b>(n, N, a, b);
     }
 
   }

--- a/stan/math/prim/scal/prob/inv_chi_square_ccdf_log.hpp
+++ b/stan/math/prim/scal/prob/inv_chi_square_ccdf_log.hpp
@@ -1,112 +1,18 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_INV_CHI_SQUARE_CCDF_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_INV_CHI_SQUARE_CCDF_LOG_HPP
 
-#include <boost/random/chi_squared_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_nonnegative.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/err/check_positive_finite.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/fun/multiply_log.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/fun/gamma_p.hpp>
-#include <stan/math/prim/scal/fun/digamma.hpp>
-#include <stan/math/prim/scal/meta/length.hpp>
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/VectorView.hpp>
-#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/return_type.hpp>
-#include <stan/math/prim/scal/fun/grad_reg_inc_gamma.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <cmath>
-#include <limits>
+#include <stan/math/prim/scal/prob/inv_chi_square_lccdf.hpp>
 
 namespace stan {
   namespace math {
 
+    /**
+     * @deprecated use <code>inv_chi_square_lccdf</code>
+     */
     template <typename T_y, typename T_dof>
     typename return_type<T_y, T_dof>::type
     inv_chi_square_ccdf_log(const T_y& y, const T_dof& nu) {
-      typedef typename stan::partials_return_type<T_y, T_dof>::type
-        T_partials_return;
-
-      if ( !( stan::length(y) && stan::length(nu) ) ) return 0.0;
-
-      static const char* function("inv_chi_square_ccdf_log");
-
-      using boost::math::tools::promote_args;
-      using std::exp;
-
-      T_partials_return P(0.0);
-
-      check_positive_finite(function, "Degrees of freedom parameter", nu);
-      check_not_nan(function, "Random variable", y);
-      check_nonnegative(function, "Random variable", y);
-      check_consistent_sizes(function,
-                             "Random variable", y,
-                             "Degrees of freedom parameter", nu);
-
-      VectorView<const T_y> y_vec(y);
-      VectorView<const T_dof> nu_vec(nu);
-      size_t N = max_size(y, nu);
-
-      OperandsAndPartials<T_y, T_dof> operands_and_partials(y, nu);
-
-      // Explicit return for extreme values
-      // The gradients are technically ill-defined, but treated as zero
-      for (size_t i = 0; i < stan::length(y); i++)
-        if (value_of(y_vec[i]) == 0)
-          return operands_and_partials.value(0.0);
-
-      using boost::math::tgamma;
-      using std::exp;
-      using std::pow;
-      using std::log;
-
-      VectorBuilder<!is_constant_struct<T_dof>::value,
-                    T_partials_return, T_dof> gamma_vec(stan::length(nu));
-      VectorBuilder<!is_constant_struct<T_dof>::value,
-                    T_partials_return, T_dof> digamma_vec(stan::length(nu));
-
-      if (!is_constant_struct<T_dof>::value)  {
-        for (size_t i = 0; i < stan::length(nu); i++) {
-          const T_partials_return nu_dbl = value_of(nu_vec[i]);
-          gamma_vec[i] = tgamma(0.5 * nu_dbl);
-          digamma_vec[i] = digamma(0.5 * nu_dbl);
-        }
-      }
-
-      for (size_t n = 0; n < N; n++) {
-        // Explicit results for extreme values
-        // The gradients are technically ill-defined, but treated as zero
-        if (value_of(y_vec[n]) == std::numeric_limits<double>::infinity()) {
-          return operands_and_partials.value(negative_infinity());
-        }
-
-        const T_partials_return y_dbl = value_of(y_vec[n]);
-        const T_partials_return y_inv_dbl = 1.0 / y_dbl;
-        const T_partials_return nu_dbl = value_of(nu_vec[n]);
-
-        const T_partials_return Pn = gamma_p(0.5 * nu_dbl, 0.5
-                                             * y_inv_dbl);
-
-        P += log(Pn);
-
-        if (!is_constant_struct<T_y>::value)
-          operands_and_partials.d_x1[n] -= 0.5 * y_inv_dbl * y_inv_dbl
-            * exp(-0.5*y_inv_dbl) * pow(0.5*y_inv_dbl, 0.5*nu_dbl-1)
-            / tgamma(0.5*nu_dbl) / Pn;
-        if (!is_constant_struct<T_dof>::value)
-          operands_and_partials.d_x2[n]
-            -= 0.5 * grad_reg_inc_gamma(0.5 * nu_dbl,
-                                        0.5 * y_inv_dbl,
-                                        gamma_vec[n],
-                                        digamma_vec[n]) / Pn;
-      }
-      return operands_and_partials.value(P);
+      return inv_chi_square_lccdf<T_y, T_dof>(y, nu);
     }
 
   }

--- a/stan/math/prim/scal/prob/inv_chi_square_cdf_log.hpp
+++ b/stan/math/prim/scal/prob/inv_chi_square_cdf_log.hpp
@@ -1,111 +1,18 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_INV_CHI_SQUARE_CDF_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_INV_CHI_SQUARE_CDF_LOG_HPP
 
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_nonnegative.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/err/check_positive_finite.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/fun/multiply_log.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/fun/gamma_q.hpp>
-#include <stan/math/prim/scal/fun/digamma.hpp>
-#include <stan/math/prim/scal/meta/length.hpp>
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/VectorView.hpp>
-#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/return_type.hpp>
-#include <stan/math/prim/scal/fun/grad_reg_inc_gamma.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <boost/random/chi_squared_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <cmath>
-#include <limits>
+#include <stan/math/prim/scal/prob/inv_chi_square_lcdf.hpp>
 
 namespace stan {
   namespace math {
 
+    /**
+     * @deprecated use <code>inv_chi_square_lcdf</code>
+     */
     template <typename T_y, typename T_dof>
     typename return_type<T_y, T_dof>::type
     inv_chi_square_cdf_log(const T_y& y, const T_dof& nu) {
-      typedef typename stan::partials_return_type<T_y, T_dof>::type
-        T_partials_return;
-
-      if ( !( stan::length(y) && stan::length(nu) ) ) return 0.0;
-
-      static const char* function("inv_chi_square_cdf_log");
-
-      using boost::math::tools::promote_args;
-      using std::exp;
-
-      T_partials_return P(0.0);
-
-      check_positive_finite(function, "Degrees of freedom parameter", nu);
-      check_not_nan(function, "Random variable", y);
-      check_nonnegative(function, "Random variable", y);
-      check_consistent_sizes(function,
-                             "Random variable", y,
-                             "Degrees of freedom parameter", nu);
-
-      VectorView<const T_y> y_vec(y);
-      VectorView<const T_dof> nu_vec(nu);
-      size_t N = max_size(y, nu);
-
-      OperandsAndPartials<T_y, T_dof> operands_and_partials(y, nu);
-
-      // Explicit return for extreme values
-      // The gradients are technically ill-defined, but treated as zero
-      for (size_t i = 0; i < stan::length(y); i++)
-        if (value_of(y_vec[i]) == 0)
-          return operands_and_partials.value(negative_infinity());
-
-      using boost::math::tgamma;
-      using std::exp;
-      using std::pow;
-      using std::log;
-
-      VectorBuilder<!is_constant_struct<T_dof>::value,
-                    T_partials_return, T_dof> gamma_vec(stan::length(nu));
-      VectorBuilder<!is_constant_struct<T_dof>::value,
-                    T_partials_return, T_dof> digamma_vec(stan::length(nu));
-
-      if (!is_constant_struct<T_dof>::value)  {
-        for (size_t i = 0; i < stan::length(nu); i++) {
-          const T_partials_return nu_dbl = value_of(nu_vec[i]);
-          gamma_vec[i] = tgamma(0.5 * nu_dbl);
-          digamma_vec[i] = digamma(0.5 * nu_dbl);
-        }
-      }
-
-      for (size_t n = 0; n < N; n++) {
-        // Explicit results for extreme values
-        // The gradients are technically ill-defined, but treated as zero
-        if (value_of(y_vec[n]) == std::numeric_limits<double>::infinity()) {
-          continue;
-        }
-
-        const T_partials_return y_dbl = value_of(y_vec[n]);
-        const T_partials_return y_inv_dbl = 1.0 / y_dbl;
-        const T_partials_return nu_dbl = value_of(nu_vec[n]);
-
-        const T_partials_return Pn = gamma_q(0.5 * nu_dbl, 0.5 * y_inv_dbl);
-
-        P += log(Pn);
-
-        if (!is_constant_struct<T_y>::value)
-          operands_and_partials.d_x1[n] += 0.5 * y_inv_dbl * y_inv_dbl
-            * exp(-0.5*y_inv_dbl) * pow(0.5*y_inv_dbl, 0.5*nu_dbl-1)
-            / tgamma(0.5*nu_dbl) / Pn;
-        if (!is_constant_struct<T_dof>::value)
-          operands_and_partials.d_x2[n]
-            += 0.5 * grad_reg_inc_gamma(0.5 * nu_dbl,
-                                        0.5 * y_inv_dbl,
-                                        gamma_vec[n],
-                                        digamma_vec[n]) / Pn;
-      }
-      return operands_and_partials.value(P);
+      return inv_chi_square_lcdf<T_y, T_dof>(y, nu);
     }
 
   }

--- a/stan/math/prim/scal/prob/inv_chi_square_log.hpp
+++ b/stan/math/prim/scal/prob/inv_chi_square_log.hpp
@@ -1,27 +1,7 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_INV_CHI_SQUARE_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_INV_CHI_SQUARE_LOG_HPP
 
-#include <boost/random/chi_squared_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_nonnegative.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/err/check_positive_finite.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/fun/multiply_log.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/fun/gamma_q.hpp>
-#include <stan/math/prim/scal/fun/digamma.hpp>
-#include <stan/math/prim/scal/meta/length.hpp>
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/VectorView.hpp>
-#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/return_type.hpp>
-#include <stan/math/prim/scal/fun/grad_reg_inc_gamma.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <cmath>
+#include <stan/math/prim/scal/prob/inv_chi_square_lpdf.hpp>
 
 namespace stan {
   namespace math {
@@ -38,6 +18,9 @@ namespace stan {
      &=& - \frac{\nu}{2} \log(2) - \log (\Gamma (\nu / 2)) - (\frac{\nu}{2} + 1) \log(y) - \frac{1}{2y} \\
      & & \mathrm{ where } \; y > 0
      \f}
+     *
+     * @deprecated use <code>inv_chi_square_lpdf</code>
+     *
      * @param y A scalar variable.
      * @param nu Degrees of freedom.
      * @throw std::domain_error if nu is not greater than or equal to 0
@@ -49,88 +32,17 @@ namespace stan {
               typename T_y, typename T_dof>
     typename return_type<T_y, T_dof>::type
     inv_chi_square_log(const T_y& y, const T_dof& nu) {
-      static const char* function("inv_chi_square_log");
-      typedef typename stan::partials_return_type<T_y, T_dof>::type
-        T_partials_return;
-
-      if (!(stan::length(y)
-            && stan::length(nu)))
-        return 0.0;
-
-      T_partials_return logp(0.0);
-      check_positive_finite(function, "Degrees of freedom parameter", nu);
-      check_not_nan(function, "Random variable", y);
-      check_consistent_sizes(function,
-                             "Random variable", y,
-                             "Degrees of freedom parameter", nu);
-
-      VectorView<const T_y> y_vec(y);
-      VectorView<const T_dof> nu_vec(nu);
-      size_t N = max_size(y, nu);
-
-      for (size_t n = 0; n < length(y); n++)
-        if (value_of(y_vec[n]) <= 0)
-          return LOG_ZERO;
-
-      using boost::math::digamma;
-      using boost::math::lgamma;
-      using std::log;
-
-      VectorBuilder<include_summand<propto, T_y, T_dof>::value,
-                    T_partials_return, T_y> log_y(length(y));
-      for (size_t i = 0; i < length(y); i++)
-        if (include_summand<propto, T_y, T_dof>::value)
-          log_y[i] = log(value_of(y_vec[i]));
-
-      VectorBuilder<include_summand<propto, T_y>::value,
-                    T_partials_return, T_y> inv_y(length(y));
-      for (size_t i = 0; i < length(y); i++)
-        if (include_summand<propto, T_y>::value)
-          inv_y[i] = 1.0 / value_of(y_vec[i]);
-
-      VectorBuilder<include_summand<propto, T_dof>::value,
-                    T_partials_return, T_dof> lgamma_half_nu(length(nu));
-      VectorBuilder<!is_constant_struct<T_dof>::value,
-                    T_partials_return, T_dof>
-        digamma_half_nu_over_two(length(nu));
-      for (size_t i = 0; i < length(nu); i++) {
-        T_partials_return half_nu = 0.5 * value_of(nu_vec[i]);
-        if (include_summand<propto, T_dof>::value)
-          lgamma_half_nu[i] = lgamma(half_nu);
-        if (!is_constant_struct<T_dof>::value)
-          digamma_half_nu_over_two[i] = digamma(half_nu) * 0.5;
-      }
-
-      OperandsAndPartials<T_y, T_dof> operands_and_partials(y, nu);
-      for (size_t n = 0; n < N; n++) {
-        const T_partials_return nu_dbl = value_of(nu_vec[n]);
-        const T_partials_return half_nu = 0.5 * nu_dbl;
-
-        if (include_summand<propto, T_dof>::value)
-          logp += nu_dbl * NEG_LOG_TWO_OVER_TWO - lgamma_half_nu[n];
-        if (include_summand<propto, T_y, T_dof>::value)
-          logp -= (half_nu+1.0) * log_y[n];
-        if (include_summand<propto, T_y>::value)
-          logp -= 0.5 * inv_y[n];
-
-        if (!is_constant_struct<T_y>::value) {
-          operands_and_partials.d_x1[n]
-            += -(half_nu+1.0) * inv_y[n] + 0.5 * inv_y[n] * inv_y[n];
-        }
-        if (!is_constant_struct<T_dof>::value) {
-          operands_and_partials.d_x2[n]
-            += NEG_LOG_TWO_OVER_TWO - digamma_half_nu_over_two[n]
-            - 0.5*log_y[n];
-        }
-      }
-      return operands_and_partials.value(logp);
+      return inv_chi_square_lpdf<propto, T_y, T_dof>(y, nu);
     }
 
+    /**
+     * @deprecated use <code>inv_chi_square_lpdf</code>
+     */
     template <typename T_y, typename T_dof>
     inline
     typename return_type<T_y, T_dof>::type
     inv_chi_square_log(const T_y& y, const T_dof& nu) {
-      return inv_chi_square_log<false>(y, nu);
+      return inv_chi_square_lpdf<T_y, T_dof>(y, nu);
     }
 
   }

--- a/stan/math/prim/scal/prob/inv_gamma_ccdf_log.hpp
+++ b/stan/math/prim/scal/prob/inv_gamma_ccdf_log.hpp
@@ -1,127 +1,19 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_INV_GAMMA_CCDF_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_INV_GAMMA_CCDF_LOG_HPP
 
-#include <boost/random/gamma_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_greater_or_equal.hpp>
-#include <stan/math/prim/scal/err/check_less_or_equal.hpp>
-#include <stan/math/prim/scal/err/check_nonnegative.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/err/check_positive_finite.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/fun/lgamma.hpp>
-#include <stan/math/prim/scal/fun/gamma_p.hpp>
-#include <stan/math/prim/scal/fun/digamma.hpp>
-#include <stan/math/prim/scal/meta/length.hpp>
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/VectorView.hpp>
-#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/return_type.hpp>
-#include <stan/math/prim/scal/fun/grad_reg_inc_gamma.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <cmath>
-#include <limits>
+#include <stan/math/prim/scal/prob/inv_gamma_lccdf.hpp>
 
 namespace stan {
   namespace math {
 
+    /**
+     * @deprecated use <code>inv_gamma_lccdf</code>
+     */
     template <typename T_y, typename T_shape, typename T_scale>
     typename return_type<T_y, T_shape, T_scale>::type
     inv_gamma_ccdf_log(const T_y& y, const T_shape& alpha,
                        const T_scale& beta) {
-      typedef typename stan::partials_return_type<T_y, T_shape, T_scale>::type
-        T_partials_return;
-
-      if (!(stan::length(y) && stan::length(alpha) && stan::length(beta)))
-        return 0.0;
-
-      static const char* function("inv_gamma_ccdf_log");
-
-      using boost::math::tools::promote_args;
-      using std::exp;
-
-      T_partials_return P(0.0);
-
-      check_positive_finite(function, "Shape parameter", alpha);
-      check_positive_finite(function, "Scale parameter", beta);
-      check_not_nan(function, "Random variable", y);
-      check_nonnegative(function, "Random variable", y);
-      check_consistent_sizes(function,
-                             "Random variable", y,
-                             "Shape parameter", alpha,
-                             "Scale Parameter", beta);
-
-      VectorView<const T_y> y_vec(y);
-      VectorView<const T_shape> alpha_vec(alpha);
-      VectorView<const T_scale> beta_vec(beta);
-      size_t N = max_size(y, alpha, beta);
-
-      OperandsAndPartials<T_y, T_shape, T_scale>
-        operands_and_partials(y, alpha, beta);
-
-      // Explicit return for extreme values
-      // The gradients are technically ill-defined, but treated as zero
-      for (size_t i = 0; i < stan::length(y); i++) {
-        if (value_of(y_vec[i]) == 0)
-          return operands_and_partials.value(0.0);
-      }
-
-      using boost::math::tgamma;
-      using std::exp;
-      using std::pow;
-      using std::log;
-
-      VectorBuilder<!is_constant_struct<T_shape>::value,
-                    T_partials_return, T_shape> gamma_vec(stan::length(alpha));
-      VectorBuilder<!is_constant_struct<T_shape>::value,
-                    T_partials_return, T_shape>
-        digamma_vec(stan::length(alpha));
-
-      if (!is_constant_struct<T_shape>::value) {
-        for (size_t i = 0; i < stan::length(alpha); i++) {
-          const T_partials_return alpha_dbl = value_of(alpha_vec[i]);
-          gamma_vec[i] = tgamma(alpha_dbl);
-          digamma_vec[i] = digamma(alpha_dbl);
-        }
-      }
-
-      for (size_t n = 0; n < N; n++) {
-        // Explicit results for extreme values
-        // The gradients are technically ill-defined, but treated as zero
-        if (value_of(y_vec[n]) == std::numeric_limits<double>::infinity())
-          return operands_and_partials.value(negative_infinity());
-
-        const T_partials_return y_dbl = value_of(y_vec[n]);
-        const T_partials_return y_inv_dbl = 1.0 / y_dbl;
-        const T_partials_return alpha_dbl = value_of(alpha_vec[n]);
-        const T_partials_return beta_dbl = value_of(beta_vec[n]);
-
-        const T_partials_return Pn = gamma_p(alpha_dbl, beta_dbl
-                                             * y_inv_dbl);
-
-        P += log(Pn);
-
-        if (!is_constant_struct<T_y>::value)
-          operands_and_partials.d_x1[n] -= beta_dbl * y_inv_dbl * y_inv_dbl
-            * exp(-beta_dbl * y_inv_dbl) * pow(beta_dbl * y_inv_dbl,
-                                               alpha_dbl-1)
-            / tgamma(alpha_dbl) / Pn;
-        if (!is_constant_struct<T_shape>::value)
-          operands_and_partials.d_x2[n]
-            -= grad_reg_inc_gamma(alpha_dbl, beta_dbl
-                                  * y_inv_dbl, gamma_vec[n],
-                                  digamma_vec[n]) / Pn;
-        if (!is_constant_struct<T_scale>::value)
-          operands_and_partials.d_x3[n] += y_inv_dbl
-            * exp(-beta_dbl * y_inv_dbl)
-            * pow(beta_dbl * y_inv_dbl, alpha_dbl-1)
-            / tgamma(alpha_dbl) / Pn;
-      }
-      return operands_and_partials.value(P);
+      return inv_gamma_lccdf<T_y, T_shape, T_scale>(y, alpha, beta);
     }
 
   }

--- a/stan/math/prim/scal/prob/inv_gamma_cdf_log.hpp
+++ b/stan/math/prim/scal/prob/inv_gamma_cdf_log.hpp
@@ -1,126 +1,19 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_INV_GAMMA_CDF_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_INV_GAMMA_CDF_LOG_HPP
 
-#include <boost/random/gamma_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_greater_or_equal.hpp>
-#include <stan/math/prim/scal/err/check_less_or_equal.hpp>
-#include <stan/math/prim/scal/err/check_nonnegative.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/err/check_positive_finite.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/fun/lgamma.hpp>
-#include <stan/math/prim/scal/fun/gamma_q.hpp>
-#include <stan/math/prim/scal/fun/digamma.hpp>
-#include <stan/math/prim/scal/fun/tgamma.hpp>
-#include <stan/math/prim/scal/meta/length.hpp>
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/VectorView.hpp>
-#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/return_type.hpp>
-#include <stan/math/prim/scal/fun/grad_reg_inc_gamma.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <cmath>
-#include <limits>
+#include <stan/math/prim/scal/prob/inv_gamma_lcdf.hpp>
 
 namespace stan {
   namespace math {
 
+    /**
+     * @deprecated use <code>inv_gamma_lcdf</code>
+     */
     template <typename T_y, typename T_shape, typename T_scale>
     typename return_type<T_y, T_shape, T_scale>::type
     inv_gamma_cdf_log(const T_y& y, const T_shape& alpha,
                       const T_scale& beta) {
-      typedef typename stan::partials_return_type<T_y, T_shape, T_scale>::type
-        T_partials_return;
-
-      if (!(stan::length(y) && stan::length(alpha) && stan::length(beta)))
-        return 0.0;
-
-      static const char* function("inv_gamma_cdf_log");
-
-      using boost::math::tools::promote_args;
-      using std::exp;
-
-      T_partials_return P(0.0);
-
-      check_positive_finite(function, "Shape parameter", alpha);
-      check_positive_finite(function, "Scale parameter", beta);
-      check_not_nan(function, "Random variable", y);
-      check_nonnegative(function, "Random variable", y);
-      check_consistent_sizes(function,
-                             "Random variable", y,
-                             "Shape parameter", alpha,
-                             "Scale Parameter", beta);
-
-      VectorView<const T_y> y_vec(y);
-      VectorView<const T_shape> alpha_vec(alpha);
-      VectorView<const T_scale> beta_vec(beta);
-      size_t N = max_size(y, alpha, beta);
-
-      OperandsAndPartials<T_y, T_shape, T_scale>
-        operands_and_partials(y, alpha, beta);
-
-      // Explicit return for extreme values
-      // The gradients are technically ill-defined, but treated as zero
-      for (size_t i = 0; i < stan::length(y); i++) {
-        if (value_of(y_vec[i]) == 0)
-          return operands_and_partials.value(negative_infinity());
-      }
-
-      using std::exp;
-      using std::pow;
-      using std::log;
-
-      VectorBuilder<!is_constant_struct<T_shape>::value,
-                    T_partials_return, T_shape> gamma_vec(stan::length(alpha));
-      VectorBuilder<!is_constant_struct<T_shape>::value,
-                    T_partials_return, T_shape>
-        digamma_vec(stan::length(alpha));
-
-      if (!is_constant_struct<T_shape>::value) {
-        for (size_t i = 0; i < stan::length(alpha); i++) {
-          const T_partials_return alpha_dbl = value_of(alpha_vec[i]);
-          gamma_vec[i] = tgamma(alpha_dbl);
-          digamma_vec[i] = digamma(alpha_dbl);
-        }
-      }
-
-      for (size_t n = 0; n < N; n++) {
-        // Explicit results for extreme values
-        // The gradients are technically ill-defined, but treated as zero
-        if (value_of(y_vec[n]) == std::numeric_limits<double>::infinity())
-          continue;
-
-        const T_partials_return y_dbl = value_of(y_vec[n]);
-        const T_partials_return y_inv_dbl = 1.0 / y_dbl;
-        const T_partials_return alpha_dbl = value_of(alpha_vec[n]);
-        const T_partials_return beta_dbl = value_of(beta_vec[n]);
-
-        const T_partials_return Pn = gamma_q(alpha_dbl, beta_dbl * y_inv_dbl);
-
-        P += log(Pn);
-
-        if (!is_constant_struct<T_y>::value)
-          operands_and_partials.d_x1[n] += beta_dbl * y_inv_dbl * y_inv_dbl
-            * exp(-beta_dbl * y_inv_dbl) * pow(beta_dbl * y_inv_dbl,
-                                               alpha_dbl-1)
-            / tgamma(alpha_dbl) / Pn;
-        if (!is_constant_struct<T_shape>::value)
-          operands_and_partials.d_x2[n]
-            += grad_reg_inc_gamma(alpha_dbl, beta_dbl
-                                  * y_inv_dbl, gamma_vec[n],
-                                  digamma_vec[n]) / Pn;
-        if (!is_constant_struct<T_scale>::value)
-          operands_and_partials.d_x3[n] += - y_inv_dbl
-            * exp(-beta_dbl * y_inv_dbl)
-            * pow(beta_dbl * y_inv_dbl, alpha_dbl-1)
-            / tgamma(alpha_dbl) / Pn;
-      }
-      return operands_and_partials.value(P);
+      return inv_gamma_lcdf<T_y, T_shape, T_scale>(y, alpha, beta);
     }
 
   }

--- a/stan/math/prim/scal/prob/inv_gamma_log.hpp
+++ b/stan/math/prim/scal/prob/inv_gamma_log.hpp
@@ -1,29 +1,7 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_INV_GAMMA_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_INV_GAMMA_LOG_HPP
 
-#include <boost/random/gamma_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_greater_or_equal.hpp>
-#include <stan/math/prim/scal/err/check_less_or_equal.hpp>
-#include <stan/math/prim/scal/err/check_nonnegative.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/err/check_positive_finite.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/fun/lgamma.hpp>
-#include <stan/math/prim/scal/fun/gamma_q.hpp>
-#include <stan/math/prim/scal/fun/digamma.hpp>
-#include <stan/math/prim/scal/meta/length.hpp>
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/VectorView.hpp>
-#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/return_type.hpp>
-#include <stan/math/prim/scal/fun/grad_reg_inc_gamma.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <cmath>
+#include <stan/math/prim/scal/prob/inv_gamma_lpdf.hpp>
 
 namespace stan {
   namespace math {
@@ -33,6 +11,8 @@ namespace stan {
      * shape and scale parameters.
      * Shape and scale parameters must be greater than 0.
      * y must be greater than 0.
+     *
+     * @deprecated use <code>inv_gamma_lpdf</code>
      *
      * @param y A scalar variable.
      * @param alpha Shape parameter.
@@ -48,107 +28,17 @@ namespace stan {
               typename T_y, typename T_shape, typename T_scale>
     typename return_type<T_y, T_shape, T_scale>::type
     inv_gamma_log(const T_y& y, const T_shape& alpha, const T_scale& beta) {
-      static const char* function("inv_gamma_log");
-      typedef typename stan::partials_return_type<T_y, T_shape, T_scale>::type
-        T_partials_return;
-
-      using stan::is_constant_struct;
-      using boost::math::tools::promote_args;
-
-      if (!(stan::length(y)
-            && stan::length(alpha)
-            && stan::length(beta)))
-        return 0.0;
-
-      T_partials_return logp(0.0);
-
-      check_not_nan(function, "Random variable", y);
-      check_positive_finite(function, "Shape parameter", alpha);
-      check_positive_finite(function, "Scale parameter", beta);
-      check_consistent_sizes(function,
-                             "Random variable", y,
-                             "Shape parameter", alpha,
-                             "Scale parameter", beta);
-
-      if (!include_summand<propto, T_y, T_shape, T_scale>::value)
-        return 0.0;
-
-      VectorView<const T_y> y_vec(y);
-      VectorView<const T_shape> alpha_vec(alpha);
-      VectorView<const T_scale> beta_vec(beta);
-
-      for (size_t n = 0; n < length(y); n++) {
-        const T_partials_return y_dbl = value_of(y_vec[n]);
-        if (y_dbl <= 0)
-          return LOG_ZERO;
-      }
-
-      size_t N = max_size(y, alpha, beta);
-      OperandsAndPartials<T_y, T_shape, T_scale>
-        operands_and_partials(y, alpha, beta);
-
-      using std::log;
-
-      VectorBuilder<include_summand<propto, T_y, T_shape>::value,
-                    T_partials_return, T_y> log_y(length(y));
-      VectorBuilder<include_summand<propto, T_y, T_scale>::value,
-                    T_partials_return, T_y> inv_y(length(y));
-      for (size_t n = 0; n < length(y); n++) {
-        if (include_summand<propto, T_y, T_shape>::value)
-          if (value_of(y_vec[n]) > 0)
-            log_y[n] = log(value_of(y_vec[n]));
-        if (include_summand<propto, T_y, T_scale>::value)
-          inv_y[n] = 1.0 / value_of(y_vec[n]);
-      }
-
-      VectorBuilder<include_summand<propto, T_shape>::value,
-                    T_partials_return, T_shape> lgamma_alpha(length(alpha));
-      VectorBuilder<!is_constant_struct<T_shape>::value,
-                    T_partials_return, T_shape> digamma_alpha(length(alpha));
-      for (size_t n = 0; n < length(alpha); n++) {
-        if (include_summand<propto, T_shape>::value)
-          lgamma_alpha[n] = lgamma(value_of(alpha_vec[n]));
-        if (!is_constant_struct<T_shape>::value)
-          digamma_alpha[n] = digamma(value_of(alpha_vec[n]));
-      }
-
-      VectorBuilder<include_summand<propto, T_shape, T_scale>::value,
-                    T_partials_return, T_scale> log_beta(length(beta));
-      if (include_summand<propto, T_shape, T_scale>::value) {
-        for (size_t n = 0; n < length(beta); n++)
-          log_beta[n] = log(value_of(beta_vec[n]));
-      }
-
-      for (size_t n = 0; n < N; n++) {
-        const T_partials_return alpha_dbl = value_of(alpha_vec[n]);
-        const T_partials_return beta_dbl = value_of(beta_vec[n]);
-
-        if (include_summand<propto, T_shape>::value)
-          logp -= lgamma_alpha[n];
-        if (include_summand<propto, T_shape, T_scale>::value)
-          logp += alpha_dbl * log_beta[n];
-        if (include_summand<propto, T_y, T_shape>::value)
-          logp -= (alpha_dbl+1.0) * log_y[n];
-        if (include_summand<propto, T_y, T_scale>::value)
-          logp -= beta_dbl * inv_y[n];
-
-        if (!is_constant<typename is_vector<T_y>::type>::value)
-          operands_and_partials.d_x1[n]
-            += -(alpha_dbl+1) * inv_y[n] + beta_dbl * inv_y[n] * inv_y[n];
-        if (!is_constant<typename is_vector<T_shape>::type>::value)
-          operands_and_partials.d_x2[n]
-            += -digamma_alpha[n] + log_beta[n] - log_y[n];
-        if (!is_constant<typename is_vector<T_scale>::type>::value)
-          operands_and_partials.d_x3[n] += alpha_dbl / beta_dbl - inv_y[n];
-      }
-      return operands_and_partials.value(logp);
+      return inv_gamma_lpdf<propto, T_y, T_shape, T_scale>(y, alpha, beta);
     }
 
+    /**
+     * @deprecated use <code>inv_gamma_lpdf</code>
+     */
     template <typename T_y, typename T_shape, typename T_scale>
     inline
     typename return_type<T_y, T_shape, T_scale>::type
     inv_gamma_log(const T_y& y, const T_shape& alpha, const T_scale& beta) {
-      return inv_gamma_log<false>(y, alpha, beta);
+      return inv_gamma_lpdf<T_y, T_shape, T_scale>(y, alpha, beta);
     }
 
   }

--- a/stan/math/prim/scal/prob/logistic_ccdf_log.hpp
+++ b/stan/math/prim/scal/prob/logistic_ccdf_log.hpp
@@ -1,98 +1,18 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_LOGISTIC_CCDF_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_LOGISTIC_CCDF_LOG_HPP
 
-#include <boost/random/exponential_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_finite.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/err/check_positive_finite.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/fun/log1p.hpp>
-#include <stan/math/prim/scal/meta/length.hpp>
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/VectorView.hpp>
-#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
-#include <stan/math/prim/scal/meta/contains_nonconstant_struct.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/return_type.hpp>
-#include <stan/math/prim/scal/prob/logistic_log.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <cmath>
-#include <limits>
+#include <stan/math/prim/scal/prob/logistic_lccdf.hpp>
 
 namespace stan {
   namespace math {
 
+    /**
+     * @deprecated use <code>logistic_lccdf</code>
+     */
     template <typename T_y, typename T_loc, typename T_scale>
     typename return_type<T_y, T_loc, T_scale>::type
     logistic_ccdf_log(const T_y& y, const T_loc& mu, const T_scale& sigma) {
-      typedef typename stan::partials_return_type<T_y, T_loc, T_scale>::type
-        T_partials_return;
-
-      if ( !( stan::length(y) && stan::length(mu) && stan::length(sigma) ) )
-        return 0.0;
-
-      static const char* function("logistic_ccdf_log");
-
-      using boost::math::tools::promote_args;
-      using std::log;
-      using std::exp;
-
-      T_partials_return P(0.0);
-
-      check_not_nan(function, "Random variable", y);
-      check_finite(function, "Location parameter", mu);
-      check_positive_finite(function, "Scale parameter", sigma);
-      check_consistent_sizes(function,
-                             "Random variable", y,
-                             "Location parameter", mu,
-                             "Scale parameter", sigma);
-
-      VectorView<const T_y> y_vec(y);
-      VectorView<const T_loc> mu_vec(mu);
-      VectorView<const T_scale> sigma_vec(sigma);
-      size_t N = max_size(y, mu, sigma);
-
-      OperandsAndPartials<T_y, T_loc, T_scale>
-        operands_and_partials(y, mu, sigma);
-
-      // Explicit return for extreme values
-      // The gradients are technically ill-defined, but treated as zero
-      for (size_t i = 0; i < stan::length(y); i++) {
-        if (value_of(y_vec[i]) == -std::numeric_limits<double>::infinity())
-          return operands_and_partials.value(0.0);
-      }
-
-      for (size_t n = 0; n < N; n++) {
-        // Explicit results for extreme values
-        // The gradients are technically ill-defined, but treated as zero
-        if (value_of(y_vec[n]) == std::numeric_limits<double>::infinity()) {
-          return operands_and_partials.value(negative_infinity());
-        }
-
-        const T_partials_return y_dbl = value_of(y_vec[n]);
-        const T_partials_return mu_dbl = value_of(mu_vec[n]);
-        const T_partials_return sigma_dbl = value_of(sigma_vec[n]);
-        const T_partials_return sigma_inv_vec = 1.0 / value_of(sigma_vec[n]);
-
-        const T_partials_return Pn = 1.0 - 1.0 / (1.0 + exp(-(y_dbl - mu_dbl)
-                                                            * sigma_inv_vec));
-        P += log(Pn);
-
-        if (!is_constant_struct<T_y>::value)
-          operands_and_partials.d_x1[n]
-            -= exp(logistic_log(y_dbl, mu_dbl, sigma_dbl)) / Pn;
-        if (!is_constant_struct<T_loc>::value)
-          operands_and_partials.d_x2[n]
-            -= - exp(logistic_log(y_dbl, mu_dbl, sigma_dbl)) / Pn;
-        if (!is_constant_struct<T_scale>::value)
-          operands_and_partials.d_x3[n] -= - (y_dbl - mu_dbl) * sigma_inv_vec
-            * exp(logistic_log(y_dbl, mu_dbl, sigma_dbl)) / Pn;
-      }
-      return operands_and_partials.value(P);
+      return logistic_lccdf<T_y, T_loc, T_scale>(y, mu, sigma);
     }
 
   }

--- a/stan/math/prim/scal/prob/logistic_cdf_log.hpp
+++ b/stan/math/prim/scal/prob/logistic_cdf_log.hpp
@@ -1,98 +1,18 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_LOGISTIC_CDF_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_LOGISTIC_CDF_LOG_HPP
 
-#include <boost/random/exponential_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_finite.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/err/check_positive_finite.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/fun/log1p.hpp>
-#include <stan/math/prim/scal/prob/logistic_log.hpp>
-#include <stan/math/prim/scal/meta/length.hpp>
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/VectorView.hpp>
-#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/return_type.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <cmath>
-#include <limits>
+#include <stan/math/prim/scal/prob/logistic_lcdf.hpp>
 
 namespace stan {
   namespace math {
 
+    /**
+     * @deprecated use <code>logistic_lcdf</code>
+     */
     template <typename T_y, typename T_loc, typename T_scale>
     typename return_type<T_y, T_loc, T_scale>::type
     logistic_cdf_log(const T_y& y, const T_loc& mu, const T_scale& sigma) {
-      typedef typename stan::partials_return_type<T_y, T_loc, T_scale>::type
-        T_partials_return;
-
-      if ( !( stan::length(y) && stan::length(mu) && stan::length(sigma) ) )
-        return 0.0;
-
-      static const char* function("logistic_cdf_log");
-
-      using boost::math::tools::promote_args;
-      using std::log;
-      using std::exp;
-
-      T_partials_return P(0.0);
-
-      check_not_nan(function, "Random variable", y);
-      check_finite(function, "Location parameter", mu);
-      check_positive_finite(function, "Scale parameter", sigma);
-      check_consistent_sizes(function,
-                             "Random variable", y,
-                             "Location parameter", mu,
-                             "Scale parameter", sigma);
-
-      VectorView<const T_y> y_vec(y);
-      VectorView<const T_loc> mu_vec(mu);
-      VectorView<const T_scale> sigma_vec(sigma);
-      size_t N = max_size(y, mu, sigma);
-
-      OperandsAndPartials<T_y, T_loc, T_scale>
-        operands_and_partials(y, mu, sigma);
-
-      // Explicit return for extreme values
-      // The gradients are technically ill-defined, but treated as zero
-      for (size_t i = 0; i < stan::length(y); i++) {
-        if (value_of(y_vec[i]) == -std::numeric_limits<double>::infinity())
-          return operands_and_partials
-            .value(-std::numeric_limits<double>::infinity());
-      }
-
-      for (size_t n = 0; n < N; n++) {
-        // Explicit results for extreme values
-        // The gradients are technically ill-defined, but treated as zero
-        if (value_of(y_vec[n]) == std::numeric_limits<double>::infinity()) {
-          continue;
-        }
-
-        const T_partials_return y_dbl = value_of(y_vec[n]);
-        const T_partials_return mu_dbl = value_of(mu_vec[n]);
-        const T_partials_return sigma_dbl = value_of(sigma_vec[n]);
-        const T_partials_return sigma_inv_vec = 1.0 / value_of(sigma_vec[n]);
-
-        const T_partials_return Pn = 1.0 / (1.0 + exp(-(y_dbl - mu_dbl)
-                                                      *sigma_inv_vec));
-        P += log(Pn);
-
-        if (!is_constant_struct<T_y>::value)
-          operands_and_partials.d_x1[n]
-            += exp(logistic_log(y_dbl, mu_dbl, sigma_dbl)) / Pn;
-        if (!is_constant_struct<T_loc>::value)
-          operands_and_partials.d_x2[n]
-            += - exp(logistic_log(y_dbl, mu_dbl, sigma_dbl)) / Pn;
-        if (!is_constant_struct<T_scale>::value)
-          operands_and_partials.d_x3[n]  += - (y_dbl - mu_dbl) * sigma_inv_vec
-            * exp(logistic_log(y_dbl, mu_dbl, sigma_dbl)) / Pn;
-      }
-      return operands_and_partials.value(P);
+      return logistic_lcdf<T_y, T_loc, T_scale>(y, mu, sigma);
     }
 
   }

--- a/stan/math/prim/scal/prob/logistic_log.hpp
+++ b/stan/math/prim/scal/prob/logistic_log.hpp
@@ -1,133 +1,29 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_LOGISTIC_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_LOGISTIC_LOG_HPP
 
-#include <boost/random/exponential_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_finite.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/err/check_positive_finite.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/fun/log1p.hpp>
-#include <stan/math/prim/scal/meta/length.hpp>
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/VectorView.hpp>
-#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
-#include <stan/math/prim/scal/meta/contains_nonconstant_struct.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/return_type.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <cmath>
+#include <stan/math/prim/scal/prob/logistic_lpdf.hpp>
 
 namespace stan {
   namespace math {
 
-    // Logistic(y|mu, sigma)    [sigma > 0]
+    /**
+     * @deprecated use <code>logistic_lpdf</code>
+     */
     template <bool propto,
               typename T_y, typename T_loc, typename T_scale>
     typename return_type<T_y, T_loc, T_scale>::type
     logistic_log(const T_y& y, const T_loc& mu, const T_scale& sigma) {
-      static const char* function("logistic_log");
-      typedef typename stan::partials_return_type<T_y, T_loc, T_scale>::type
-        T_partials_return;
-
-      using std::log;
-      using std::exp;
-
-      if (!(stan::length(y)
-            && stan::length(mu)
-            && stan::length(sigma)))
-        return 0.0;
-
-      T_partials_return logp(0.0);
-
-      check_finite(function, "Random variable", y);
-      check_finite(function, "Location parameter", mu);
-      check_positive_finite(function, "Scale parameter", sigma);
-      check_consistent_sizes(function,
-                             "Random variable", y,
-                             "Location parameter", mu,
-                             "Scale parameter", sigma);
-
-      if (!include_summand<propto, T_y, T_loc, T_scale>::value)
-        return 0.0;
-
-      OperandsAndPartials<T_y, T_loc, T_scale>
-        operands_and_partials(y, mu, sigma);
-
-      VectorView<const T_y> y_vec(y);
-      VectorView<const T_loc> mu_vec(mu);
-      VectorView<const T_scale> sigma_vec(sigma);
-      size_t N = max_size(y, mu, sigma);
-
-      VectorBuilder<true, T_partials_return, T_scale> inv_sigma(length(sigma));
-      VectorBuilder<include_summand<propto, T_scale>::value,
-                    T_partials_return, T_scale> log_sigma(length(sigma));
-      for (size_t i = 0; i < length(sigma); i++) {
-        inv_sigma[i] = 1.0 / value_of(sigma_vec[i]);
-        if (include_summand<propto, T_scale>::value)
-          log_sigma[i] = log(value_of(sigma_vec[i]));
-      }
-
-      VectorBuilder<!is_constant_struct<T_loc>::value,
-                    T_partials_return, T_loc, T_scale>
-        exp_mu_div_sigma(max_size(mu, sigma));
-      VectorBuilder<!is_constant_struct<T_loc>::value,
-                    T_partials_return, T_y, T_scale>
-        exp_y_div_sigma(max_size(y, sigma));
-      if (!is_constant_struct<T_loc>::value) {
-        for (size_t n = 0; n < max_size(mu, sigma); n++)
-          exp_mu_div_sigma[n] = exp(value_of(mu_vec[n])
-                                    / value_of(sigma_vec[n]));
-        for (size_t n = 0; n < max_size(y, sigma); n++)
-          exp_y_div_sigma[n] = exp(value_of(y_vec[n])
-                                   / value_of(sigma_vec[n]));
-      }
-
-      for (size_t n = 0; n < N; n++) {
-        const T_partials_return y_dbl = value_of(y_vec[n]);
-        const T_partials_return mu_dbl = value_of(mu_vec[n]);
-
-        const T_partials_return y_minus_mu = y_dbl - mu_dbl;
-        const T_partials_return y_minus_mu_div_sigma = y_minus_mu
-          * inv_sigma[n];
-        T_partials_return exp_m_y_minus_mu_div_sigma(0);
-        if (include_summand<propto, T_y, T_loc, T_scale>::value)
-          exp_m_y_minus_mu_div_sigma = exp(-y_minus_mu_div_sigma);
-        T_partials_return inv_1p_exp_y_minus_mu_div_sigma(0);
-        if (contains_nonconstant_struct<T_y, T_scale>::value)
-          inv_1p_exp_y_minus_mu_div_sigma = 1 / (1 + exp(y_minus_mu_div_sigma));
-
-        if (include_summand<propto, T_y, T_loc, T_scale>::value)
-          logp -= y_minus_mu_div_sigma;
-        if (include_summand<propto, T_scale>::value)
-          logp -= log_sigma[n];
-        if (include_summand<propto, T_y, T_loc, T_scale>::value)
-          logp -= 2.0 * log1p(exp_m_y_minus_mu_div_sigma);
-
-        if (!is_constant_struct<T_y>::value)
-          operands_and_partials.d_x1[n]
-            += (2 * inv_1p_exp_y_minus_mu_div_sigma - 1) * inv_sigma[n];
-        if (!is_constant_struct<T_loc>::value)
-          operands_and_partials.d_x2[n] +=
-            (1 - 2 * exp_mu_div_sigma[n] / (exp_mu_div_sigma[n]
-                                            + exp_y_div_sigma[n]))
-            * inv_sigma[n];
-        if (!is_constant_struct<T_scale>::value)
-          operands_and_partials.d_x3[n] +=
-            ((1 - 2 * inv_1p_exp_y_minus_mu_div_sigma)
-             *y_minus_mu*inv_sigma[n] - 1) * inv_sigma[n];
-      }
-      return operands_and_partials.value(logp);
+      return logistic_lpdf<propto, T_y, T_loc, T_scale>(y, mu, sigma);
     }
 
+    /**
+     * @deprecated use <code>logistic_lpdf</code>
+     */
     template <typename T_y, typename T_loc, typename T_scale>
     inline
     typename return_type<T_y, T_loc, T_scale>::type
     logistic_log(const T_y& y, const T_loc& mu, const T_scale& sigma) {
-      return logistic_log<false>(y, mu, sigma);
+      return logistic_lpdf<T_y, T_loc, T_scale>(y, mu, sigma);
     }
 
   }

--- a/stan/math/prim/scal/prob/lognormal_ccdf_log.hpp
+++ b/stan/math/prim/scal/prob/lognormal_ccdf_log.hpp
@@ -1,86 +1,18 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_LOGNORMAL_CCDF_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_LOGNORMAL_CCDF_LOG_HPP
 
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_finite.hpp>
-#include <stan/math/prim/scal/err/check_nonnegative.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/err/check_positive_finite.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/fun/square.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <boost/random/lognormal_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <cmath>
+#include <stan/math/prim/scal/prob/lognormal_lccdf.hpp>
 
 namespace stan {
   namespace math {
 
+    /**
+     * @deprecated use <code>lognormal_lccdf</code>
+     */
     template <typename T_y, typename T_loc, typename T_scale>
     typename return_type<T_y, T_loc, T_scale>::type
     lognormal_ccdf_log(const T_y& y, const T_loc& mu, const T_scale& sigma) {
-      static const char* function("lognormal_ccdf_log");
-      typedef typename stan::partials_return_type<T_y, T_loc, T_scale>::type
-        T_partials_return;
-
-      T_partials_return ccdf_log = 0.0;
-
-      using boost::math::tools::promote_args;
-      using std::log;
-      using std::exp;
-
-      if (!(stan::length(y)
-            && stan::length(mu)
-            && stan::length(sigma)))
-        return ccdf_log;
-
-      check_not_nan(function, "Random variable", y);
-      check_nonnegative(function, "Random variable", y);
-      check_finite(function, "Location parameter", mu);
-      check_positive_finite(function, "Scale parameter", sigma);
-
-      OperandsAndPartials<T_y, T_loc, T_scale>
-        operands_and_partials(y, mu, sigma);
-
-      VectorView<const T_y> y_vec(y);
-      VectorView<const T_loc> mu_vec(mu);
-      VectorView<const T_scale> sigma_vec(sigma);
-      size_t N = max_size(y, mu, sigma);
-
-      const double sqrt_pi = std::sqrt(pi());
-
-      for (size_t i = 0; i < stan::length(y); i++) {
-        if (value_of(y_vec[i]) == 0.0)
-          return operands_and_partials.value(0.0);
-      }
-
-      const double log_half = std::log(0.5);
-
-      for (size_t n = 0; n < N; n++) {
-        const T_partials_return y_dbl = value_of(y_vec[n]);
-        const T_partials_return mu_dbl = value_of(mu_vec[n]);
-        const T_partials_return sigma_dbl = value_of(sigma_vec[n]);
-        const T_partials_return scaled_diff = (log(y_dbl) - mu_dbl)
-          / (sigma_dbl * SQRT_2);
-        const T_partials_return rep_deriv = SQRT_2 / sqrt_pi
-          * exp(-scaled_diff * scaled_diff) / sigma_dbl;
-
-        const T_partials_return erfc_calc = erfc(scaled_diff);
-        ccdf_log += log_half + log(erfc_calc);
-
-        if (!is_constant_struct<T_y>::value)
-          operands_and_partials.d_x1[n] -= rep_deriv / erfc_calc / y_dbl;
-        if (!is_constant_struct<T_loc>::value)
-          operands_and_partials.d_x2[n] += rep_deriv / erfc_calc;
-        if (!is_constant_struct<T_scale>::value)
-          operands_and_partials.d_x3[n] += rep_deriv * scaled_diff * SQRT_2
-            / erfc_calc;
-      }
-      return operands_and_partials.value(ccdf_log);
+      return lognormal_lccdf<T_y, T_loc, T_scale>(y, mu, sigma);
     }
 
   }

--- a/stan/math/prim/scal/prob/lognormal_cdf_log.hpp
+++ b/stan/math/prim/scal/prob/lognormal_cdf_log.hpp
@@ -1,86 +1,18 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_LOGNORMAL_CDF_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_LOGNORMAL_CDF_LOG_HPP
 
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_finite.hpp>
-#include <stan/math/prim/scal/err/check_nonnegative.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/err/check_positive_finite.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/fun/square.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <boost/random/lognormal_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <cmath>
+#include <stan/math/prim/scal/prob/lognormal_lcdf.hpp>
 
 namespace stan {
   namespace math {
 
+    /**
+     * @deprecated use <code>lognormal_lcdf</code>
+     */
     template <typename T_y, typename T_loc, typename T_scale>
     typename return_type<T_y, T_loc, T_scale>::type
     lognormal_cdf_log(const T_y& y, const T_loc& mu, const T_scale& sigma) {
-      static const char* function("lognormal_cdf_log");
-      typedef typename stan::partials_return_type<T_y, T_loc, T_scale>::type
-        T_partials_return;
-
-      T_partials_return cdf_log = 0.0;
-
-      using boost::math::tools::promote_args;
-      using std::log;
-      using std::exp;
-
-      if (!(stan::length(y)
-            && stan::length(mu)
-            && stan::length(sigma)))
-        return cdf_log;
-
-      check_not_nan(function, "Random variable", y);
-      check_nonnegative(function, "Random variable", y);
-      check_finite(function, "Location parameter", mu);
-      check_positive_finite(function, "Scale parameter", sigma);
-
-      OperandsAndPartials<T_y, T_loc, T_scale>
-        operands_and_partials(y, mu, sigma);
-
-      VectorView<const T_y> y_vec(y);
-      VectorView<const T_loc> mu_vec(mu);
-      VectorView<const T_scale> sigma_vec(sigma);
-      size_t N = max_size(y, mu, sigma);
-
-      const double sqrt_pi = std::sqrt(pi());
-
-      for (size_t i = 0; i < stan::length(y); i++) {
-        if (value_of(y_vec[i]) == 0.0)
-          return operands_and_partials.value(negative_infinity());
-      }
-
-      const double log_half = std::log(0.5);
-
-      for (size_t n = 0; n < N; n++) {
-        const T_partials_return y_dbl = value_of(y_vec[n]);
-        const T_partials_return mu_dbl = value_of(mu_vec[n]);
-        const T_partials_return sigma_dbl = value_of(sigma_vec[n]);
-        const T_partials_return scaled_diff = (log(y_dbl) - mu_dbl)
-          / (sigma_dbl * SQRT_2);
-        const T_partials_return rep_deriv = SQRT_2 / sqrt_pi
-          * exp(-scaled_diff * scaled_diff) / sigma_dbl;
-
-        const T_partials_return erfc_calc = erfc(-scaled_diff);
-        cdf_log += log_half + log(erfc_calc);
-
-        if (!is_constant_struct<T_y>::value)
-          operands_and_partials.d_x1[n] += rep_deriv / erfc_calc / y_dbl;
-        if (!is_constant_struct<T_loc>::value)
-          operands_and_partials.d_x2[n] -= rep_deriv / erfc_calc;
-        if (!is_constant_struct<T_scale>::value)
-          operands_and_partials.d_x3[n] -= rep_deriv * scaled_diff * SQRT_2
-            / erfc_calc;
-      }
-      return operands_and_partials.value(cdf_log);
+      return lognormal_lcdf<T_y, T_loc, T_scale>(y, mu, sigma);
     }
 
   }

--- a/stan/math/prim/scal/prob/lognormal_log.hpp
+++ b/stan/math/prim/scal/prob/lognormal_log.hpp
@@ -1,144 +1,29 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_LOGNORMAL_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_LOGNORMAL_LOG_HPP
 
-#include <boost/random/lognormal_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_finite.hpp>
-#include <stan/math/prim/scal/err/check_nonnegative.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/err/check_positive_finite.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/fun/square.hpp>
-#include <stan/math/prim/scal/meta/length.hpp>
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/contains_nonconstant_struct.hpp>
-#include <stan/math/prim/scal/meta/VectorView.hpp>
-#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/return_type.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <cmath>
+#include <stan/math/prim/scal/prob/lognormal_lpdf.hpp>
 
 namespace stan {
   namespace math {
 
-    // LogNormal(y|mu, sigma)  [y >= 0;  sigma > 0]
+    /**
+     * @deprecated use <code>lognormal_lpdf</code>
+     */
     template <bool propto,
               typename T_y, typename T_loc, typename T_scale>
     typename return_type<T_y, T_loc, T_scale>::type
     lognormal_log(const T_y& y, const T_loc& mu, const T_scale& sigma) {
-      static const char* function("lognormal_log");
-      typedef typename stan::partials_return_type<T_y, T_loc, T_scale>::type
-        T_partials_return;
-
-      using stan::is_constant_struct;
-
-      if (!(stan::length(y)
-            && stan::length(mu)
-            && stan::length(sigma)))
-        return 0.0;
-
-      T_partials_return logp(0.0);
-
-      check_not_nan(function, "Random variable", y);
-      check_nonnegative(function, "Random variable", y);
-      check_finite(function, "Location parameter", mu);
-      check_positive_finite(function, "Scale parameter", sigma);
-      check_consistent_sizes(function,
-                             "Random variable", y,
-                             "Location parameter", mu,
-                             "Scale parameter", sigma);
-
-      VectorView<const T_y> y_vec(y);
-      VectorView<const T_loc> mu_vec(mu);
-      VectorView<const T_scale> sigma_vec(sigma);
-      size_t N = max_size(y, mu, sigma);
-
-      for (size_t n = 0; n < length(y); n++)
-        if (value_of(y_vec[n]) <= 0)
-          return LOG_ZERO;
-
-      OperandsAndPartials<T_y, T_loc, T_scale>
-        operands_and_partials(y, mu, sigma);
-
-      using std::log;
-      using std::log;
-
-      VectorBuilder<include_summand<propto, T_scale>::value,
-                    T_partials_return, T_scale> log_sigma(length(sigma));
-      if (include_summand<propto, T_scale>::value) {
-        for (size_t n = 0; n < length(sigma); n++)
-          log_sigma[n] = log(value_of(sigma_vec[n]));
-      }
-
-      VectorBuilder<include_summand<propto, T_y, T_loc, T_scale>::value,
-                    T_partials_return, T_scale> inv_sigma(length(sigma));
-      VectorBuilder<include_summand<propto, T_y, T_loc, T_scale>::value,
-                    T_partials_return, T_scale> inv_sigma_sq(length(sigma));
-      if (include_summand<propto, T_y, T_loc, T_scale>::value) {
-        for (size_t n = 0; n < length(sigma); n++)
-          inv_sigma[n] = 1 / value_of(sigma_vec[n]);
-      }
-      if (include_summand<propto, T_y, T_loc, T_scale>::value) {
-        for (size_t n = 0; n < length(sigma); n++)
-          inv_sigma_sq[n] = inv_sigma[n] * inv_sigma[n];
-      }
-
-      VectorBuilder<include_summand<propto, T_y, T_loc, T_scale>::value,
-                    T_partials_return, T_y> log_y(length(y));
-      if (include_summand<propto, T_y, T_loc, T_scale>::value) {
-        for (size_t n = 0; n < length(y); n++)
-          log_y[n] = log(value_of(y_vec[n]));
-      }
-
-      VectorBuilder<!is_constant_struct<T_y>::value,
-                    T_partials_return, T_y> inv_y(length(y));
-      if (!is_constant_struct<T_y>::value) {
-        for (size_t n = 0; n < length(y); n++)
-          inv_y[n] = 1 / value_of(y_vec[n]);
-      }
-
-      if (include_summand<propto>::value)
-        logp += N * NEG_LOG_SQRT_TWO_PI;
-
-      for (size_t n = 0; n < N; n++) {
-        const T_partials_return mu_dbl = value_of(mu_vec[n]);
-
-        T_partials_return logy_m_mu(0);
-        if (include_summand<propto, T_y, T_loc, T_scale>::value)
-          logy_m_mu = log_y[n] - mu_dbl;
-
-        T_partials_return logy_m_mu_sq = logy_m_mu * logy_m_mu;
-        T_partials_return logy_m_mu_div_sigma(0);
-        if (contains_nonconstant_struct<T_y, T_loc, T_scale>::value)
-          logy_m_mu_div_sigma = logy_m_mu * inv_sigma_sq[n];
-
-        if (include_summand<propto, T_scale>::value)
-          logp -= log_sigma[n];
-        if (include_summand<propto, T_y>::value)
-          logp -= log_y[n];
-        if (include_summand<propto, T_y, T_loc, T_scale>::value)
-          logp -= 0.5 * logy_m_mu_sq * inv_sigma_sq[n];
-
-        if (!is_constant_struct<T_y>::value)
-          operands_and_partials.d_x1[n] -= (1 + logy_m_mu_div_sigma) * inv_y[n];
-        if (!is_constant_struct<T_loc>::value)
-          operands_and_partials.d_x2[n] += logy_m_mu_div_sigma;
-        if (!is_constant_struct<T_scale>::value)
-          operands_and_partials.d_x3[n]
-            += (logy_m_mu_div_sigma * logy_m_mu - 1) * inv_sigma[n];
-      }
-      return operands_and_partials.value(logp);
+      return lognormal_lpdf<propto, T_y, T_loc, T_scale>(y, mu, sigma);
     }
 
+    /**
+     * @deprecated use <code>lognormal_lpdf</code>
+     */
     template <typename T_y, typename T_loc, typename T_scale>
     inline
     typename return_type<T_y, T_loc, T_scale>::type
     lognormal_log(const T_y& y, const T_loc& mu, const T_scale& sigma) {
-      return lognormal_log<false>(y, mu, sigma);
+      return lognormal_lpdf<T_y, T_loc, T_scale>(y, mu, sigma);
     }
 
   }

--- a/stan/math/prim/scal/prob/neg_binomial_2_ccdf_log.hpp
+++ b/stan/math/prim/scal/prob/neg_binomial_2_ccdf_log.hpp
@@ -1,48 +1,20 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_NEG_BINOMIAL_2_CCDF_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_NEG_BINOMIAL_2_CCDF_LOG_HPP
 
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/err/check_positive_finite.hpp>
-#include <stan/math/prim/scal/fun/grad_reg_inc_beta.hpp>
-#include <stan/math/prim/scal/meta/length.hpp>
-#include <stan/math/prim/scal/prob/neg_binomial_ccdf_log.hpp>
+#include <stan/math/prim/scal/prob/neg_binomial_2_lccdf.hpp>
 
 namespace stan {
   namespace math {
 
-    // Temporary neg_binomial_2_ccdf implementation that
-    // transforms the input parameters and calls neg_binomial_ccdf
+    /**
+     * @deprecated use <code>neg_binomial_2_lccdf</code>
+     */
     template <typename T_n, typename T_location, typename T_precision>
     typename return_type<T_location, T_precision>::type
     neg_binomial_2_ccdf_log(const T_n& n,
                             const T_location& mu,
                             const T_precision& phi) {
-      if (!(stan::length(n)
-            && stan::length(mu)
-            && stan::length(phi)))
-        return 0.0;
-
-      static const char* function("neg_binomial_2_ccdf_log");
-      check_positive_finite(function, "Location parameter", mu);
-      check_positive_finite(function, "Precision parameter", phi);
-      check_not_nan(function, "Random variable", n);
-      check_consistent_sizes(function,
-                             "Random variable", n,
-                             "Location parameter", mu,
-                             "Precision Parameter", phi);
-
-      VectorView<const T_location> mu_vec(mu);
-      VectorView<const T_precision> phi_vec(phi);
-
-      size_t size_beta = max_size(mu, phi);
-
-      VectorBuilder<true, typename return_type<T_location, T_precision>::type,
-                    T_location, T_precision> beta_vec(size_beta);
-      for (size_t i = 0; i < size_beta; ++i)
-        beta_vec[i] = phi_vec[i] / mu_vec[i];
-
-      return neg_binomial_ccdf_log(n, phi, beta_vec.data());
+      return neg_binomial_2_lccdf<T_n, T_location, T_precision>(n, mu, phi);
     }
 
   }

--- a/stan/math/prim/scal/prob/neg_binomial_2_cdf_log.hpp
+++ b/stan/math/prim/scal/prob/neg_binomial_2_cdf_log.hpp
@@ -1,60 +1,21 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_NEG_BINOMIAL_2_CDF_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_NEG_BINOMIAL_2_CDF_LOG_HPP
 
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/err/check_positive_finite.hpp>
-#include <stan/math/prim/scal/meta/length.hpp>
-#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
-#include <stan/math/prim/scal/meta/VectorView.hpp>
-#include <stan/math/prim/scal/prob/beta_cdf_log.hpp>
-#include <cmath>
+#include <stan/math/prim/scal/prob/neg_binomial_2_lcdf.hpp>
 
 namespace stan {
   namespace math {
 
+    /**
+     * @deprecated use <code>neg_binomial_2_lcdf</code>
+     */
     template <typename T_n, typename T_location,
               typename T_precision>
     typename return_type<T_location, T_precision>::type
     neg_binomial_2_cdf_log(const T_n& n,
                            const T_location& mu,
                            const T_precision& phi) {
-      using std::log;
-
-      if (!(stan::length(n)
-            && stan::length(mu)
-            && stan::length(phi)))
-        return 0.0;
-
-      static const char* function("neg_binomial_2_cdf_log");
-      check_positive_finite(function, "Location parameter", mu);
-      check_positive_finite(function, "Precision parameter", phi);
-      check_not_nan(function, "Random variable", n);
-      check_consistent_sizes(function,
-                             "Random variable", n,
-                             "Location parameter", mu,
-                             "Precision Parameter", phi);
-
-      VectorView<const T_n> n_vec(n);
-      VectorView<const T_location> mu_vec(mu);
-      VectorView<const T_precision> phi_vec(phi);
-
-      size_t size_phi_mu = max_size(mu, phi);
-      VectorBuilder<true, typename return_type<T_location, T_precision>::type,
-                    T_location, T_precision> phi_mu(size_phi_mu);
-      for (size_t i = 0; i < size_phi_mu; i++)
-        phi_mu[i] = phi_vec[i] / (phi_vec[i] + mu_vec[i]);
-
-      size_t size_n = length(n);
-      VectorBuilder<true, typename return_type<T_n>::type,
-                    T_n> np1(size_n);
-      for (size_t i = 0; i < size_n; i++)
-        if (n_vec[i] < 0)
-          return log(0.0);
-        else
-          np1[i] = n_vec[i] + 1.0;
-
-      return beta_cdf_log(phi_mu.data(), phi, np1.data());
+      return neg_binomial_2_lcdf<T_n, T_location, T_precision>(n, mu, phi);
     }
 
   }

--- a/stan/math/prim/scal/prob/neg_binomial_2_log.hpp
+++ b/stan/math/prim/scal/prob/neg_binomial_2_log.hpp
@@ -1,34 +1,14 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_NEG_BINOMIAL_2_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_NEG_BINOMIAL_2_LOG_HPP
 
-#include <boost/math/special_functions/digamma.hpp>
-#include <boost/random/negative_binomial_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_positive_finite.hpp>
-#include <stan/math/prim/scal/err/check_nonnegative.hpp>
-#include <stan/math/prim/scal/err/check_less.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/fun/binomial_coefficient_log.hpp>
-#include <stan/math/prim/scal/fun/multiply_log.hpp>
-#include <stan/math/prim/scal/fun/digamma.hpp>
-#include <stan/math/prim/scal/fun/lgamma.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/meta/length.hpp>
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/VectorView.hpp>
-#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/return_type.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <stan/math/prim/scal/fun/grad_reg_inc_beta.hpp>
-#include <cmath>
+#include <stan/math/prim/scal/prob/neg_binomial_2_lpmf.hpp>
 
 namespace stan {
   namespace math {
 
-    // NegBinomial(n|mu, phi)  [mu >= 0; phi > 0;  n >= 0]
+    /**
+     * @deprecated use <code>neg_binomial_2_lpmf</code>
+     */
     template <bool propto,
               typename T_n,
               typename T_location, typename T_precision>
@@ -36,91 +16,13 @@ namespace stan {
     neg_binomial_2_log(const T_n& n,
                        const T_location& mu,
                        const T_precision& phi) {
-      typedef typename stan::partials_return_type<T_n, T_location,
-                                                  T_precision>::type
-        T_partials_return;
-
-      static const char* function("neg_binomial_2_log");
-
-      if (!(stan::length(n)
-            && stan::length(mu)
-            && stan::length(phi)))
-        return 0.0;
-
-      T_partials_return logp(0.0);
-      check_nonnegative(function, "Failures variable", n);
-      check_positive_finite(function, "Location parameter", mu);
-      check_positive_finite(function, "Precision parameter", phi);
-      check_consistent_sizes(function,
-                             "Failures variable", n,
-                             "Location parameter", mu,
-                             "Precision parameter", phi);
-
-      if (!include_summand<propto, T_location, T_precision>::value)
-        return 0.0;
-
-      using std::log;
-      using std::log;
-
-      VectorView<const T_n> n_vec(n);
-      VectorView<const T_location> mu_vec(mu);
-      VectorView<const T_precision> phi_vec(phi);
-      size_t size = max_size(n, mu, phi);
-
-      OperandsAndPartials<T_location, T_precision>
-        operands_and_partials(mu, phi);
-
-      size_t len_ep = max_size(mu, phi);
-      size_t len_np = max_size(n, phi);
-
-      VectorBuilder<true, T_partials_return, T_location> mu__(length(mu));
-      for (size_t i = 0, size = length(mu); i < size; ++i)
-        mu__[i] = value_of(mu_vec[i]);
-
-      VectorBuilder<true, T_partials_return, T_precision> phi__(length(phi));
-      for (size_t i = 0, size = length(phi); i < size; ++i)
-        phi__[i] = value_of(phi_vec[i]);
-
-      VectorBuilder<true, T_partials_return, T_precision> log_phi(length(phi));
-      for (size_t i = 0, size = length(phi); i < size; ++i)
-        log_phi[i] = log(phi__[i]);
-
-      VectorBuilder<true, T_partials_return, T_location, T_precision>
-        log_mu_plus_phi(len_ep);
-      for (size_t i = 0; i < len_ep; ++i)
-        log_mu_plus_phi[i] = log(mu__[i] + phi__[i]);
-
-      VectorBuilder<true, T_partials_return, T_n, T_precision>
-        n_plus_phi(len_np);
-      for (size_t i = 0; i < len_np; ++i)
-        n_plus_phi[i] = n_vec[i] + phi__[i];
-
-      for (size_t i = 0; i < size; i++) {
-        if (include_summand<propto>::value)
-          logp -= lgamma(n_vec[i] + 1.0);
-        if (include_summand<propto, T_precision>::value)
-          logp += multiply_log(phi__[i], phi__[i]) - lgamma(phi__[i]);
-        if (include_summand<propto, T_location, T_precision>::value)
-          logp -= (n_plus_phi[i])*log_mu_plus_phi[i];
-        if (include_summand<propto, T_location>::value)
-          logp += multiply_log(n_vec[i], mu__[i]);
-        if (include_summand<propto, T_precision>::value)
-          logp += lgamma(n_plus_phi[i]);
-
-        if (!is_constant_struct<T_location>::value)
-          operands_and_partials.d_x1[i]
-            += n_vec[i]/mu__[i]
-            - (n_vec[i] + phi__[i])
-            / (mu__[i] + phi__[i]);
-        if (!is_constant_struct<T_precision>::value)
-          operands_and_partials.d_x2[i]
-            += 1.0 - n_plus_phi[i]/(mu__[i] + phi__[i])
-            + log_phi[i] - log_mu_plus_phi[i] - digamma(phi__[i])
-            + digamma(n_plus_phi[i]);
-      }
-      return operands_and_partials.value(logp);
+      return neg_binomial_2_lpmf<propto, T_n,
+                                 T_location, T_precision>(n, mu, phi);
     }
 
+    /**
+     * @deprecated use <code>neg_binomial_2_lpmf</code>
+     */
     template <typename T_n,
               typename T_location, typename T_precision>
     inline
@@ -128,7 +30,7 @@ namespace stan {
     neg_binomial_2_log(const T_n& n,
                        const T_location& mu,
                        const T_precision& phi) {
-      return neg_binomial_2_log<false>(n, mu, phi);
+      return neg_binomial_2_lpmf<T_n, T_location, T_precision>(n, mu, phi);
     }
 
   }

--- a/stan/math/prim/scal/prob/neg_binomial_2_log_log.hpp
+++ b/stan/math/prim/scal/prob/neg_binomial_2_log_log.hpp
@@ -1,32 +1,14 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_NEG_BINOMIAL_2_LOG_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_NEG_BINOMIAL_2_LOG_LOG_HPP
 
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_positive_finite.hpp>
-#include <stan/math/prim/scal/err/check_nonnegative.hpp>
-#include <stan/math/prim/scal/err/check_less.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/fun/binomial_coefficient_log.hpp>
-#include <stan/math/prim/scal/fun/multiply_log.hpp>
-#include <stan/math/prim/scal/fun/digamma.hpp>
-#include <stan/math/prim/scal/fun/lgamma.hpp>
-#include <stan/math/prim/scal/fun/log_sum_exp.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <stan/math/prim/scal/fun/grad_reg_inc_beta.hpp>
-#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
-#include <boost/math/special_functions/digamma.hpp>
-#include <boost/random/negative_binomial_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <cmath>
+#include <stan/math/prim/scal/prob/neg_binomial_2_log_lpmf.hpp>
 
 namespace stan {
   namespace math {
 
-    // NegBinomial(n|eta, phi)  [phi > 0;  n >= 0]
+    /**
+     * @deprecated use <code>neg_binomial_2_log_lpmf</code>
+     */
     template <bool propto,
               typename T_n,
               typename T_log_location, typename T_precision>
@@ -34,91 +16,13 @@ namespace stan {
     neg_binomial_2_log_log(const T_n& n,
                            const T_log_location& eta,
                            const T_precision& phi) {
-      typedef typename stan::partials_return_type<T_n, T_log_location,
-                                                  T_precision>::type
-        T_partials_return;
-
-      static const char* function("neg_binomial_2_log_log");
-
-      if (!(stan::length(n)
-            && stan::length(eta)
-            && stan::length(phi)))
-        return 0.0;
-
-      T_partials_return logp(0.0);
-      check_nonnegative(function, "Failures variable", n);
-      check_finite(function, "Log location parameter", eta);
-      check_positive_finite(function, "Precision parameter", phi);
-      check_consistent_sizes(function,
-                             "Failures variable", n,
-                             "Log location parameter", eta,
-                             "Precision parameter", phi);
-
-      if (!include_summand<propto, T_log_location, T_precision>::value)
-        return 0.0;
-
-      using std::exp;
-      using std::log;
-
-      VectorView<const T_n> n_vec(n);
-      VectorView<const T_log_location> eta_vec(eta);
-      VectorView<const T_precision> phi_vec(phi);
-      size_t size = max_size(n, eta, phi);
-
-      OperandsAndPartials<T_log_location, T_precision>
-        operands_and_partials(eta, phi);
-
-      size_t len_ep = max_size(eta, phi);
-      size_t len_np = max_size(n, phi);
-
-      VectorBuilder<true, T_partials_return, T_log_location> eta__(length(eta));
-      for (size_t i = 0, size = length(eta); i < size; ++i)
-        eta__[i] = value_of(eta_vec[i]);
-
-      VectorBuilder<true, T_partials_return, T_precision> phi__(length(phi));
-      for (size_t i = 0, size = length(phi); i < size; ++i)
-        phi__[i] = value_of(phi_vec[i]);
-
-      VectorBuilder<true, T_partials_return, T_precision>
-        log_phi(length(phi));
-      for (size_t i = 0, size = length(phi); i < size; ++i)
-        log_phi[i] = log(phi__[i]);
-
-      VectorBuilder<true, T_partials_return, T_log_location, T_precision>
-        logsumexp_eta_logphi(len_ep);
-      for (size_t i = 0; i < len_ep; ++i)
-        logsumexp_eta_logphi[i] = log_sum_exp(eta__[i], log_phi[i]);
-
-      VectorBuilder<true, T_partials_return, T_n, T_precision>
-        n_plus_phi(len_np);
-      for (size_t i = 0; i < len_np; ++i)
-        n_plus_phi[i] = n_vec[i] + phi__[i];
-
-      for (size_t i = 0; i < size; i++) {
-        if (include_summand<propto>::value)
-          logp -= lgamma(n_vec[i] + 1.0);
-        if (include_summand<propto, T_precision>::value)
-          logp += multiply_log(phi__[i], phi__[i]) - lgamma(phi__[i]);
-        if (include_summand<propto, T_log_location, T_precision>::value)
-          logp -= (n_plus_phi[i])*logsumexp_eta_logphi[i];
-        if (include_summand<propto, T_log_location>::value)
-          logp += n_vec[i]*eta__[i];
-        if (include_summand<propto, T_precision>::value)
-          logp += lgamma(n_plus_phi[i]);
-
-        if (!is_constant_struct<T_log_location>::value)
-          operands_and_partials.d_x1[i]
-            += n_vec[i] - n_plus_phi[i]
-            / (phi__[i]/exp(eta__[i]) + 1.0);
-        if (!is_constant_struct<T_precision>::value)
-          operands_and_partials.d_x2[i]
-            += 1.0 - n_plus_phi[i]/(exp(eta__[i]) + phi__[i])
-            + log_phi[i] - logsumexp_eta_logphi[i] - digamma(phi__[i])
-            + digamma(n_plus_phi[i]);
-      }
-      return operands_and_partials.value(logp);
+      return neg_binomial_2_log_lpmf<propto, T_n,
+                                     T_log_location, T_precision>(n, eta, phi);
     }
 
+    /**
+     * @deprecated use <code>neg_binomial_2_log_lpmf</code>
+     */
     template <typename T_n,
               typename T_log_location, typename T_precision>
     inline
@@ -126,7 +30,8 @@ namespace stan {
     neg_binomial_2_log_log(const T_n& n,
                            const T_log_location& eta,
                            const T_precision& phi) {
-      return neg_binomial_2_log_log<false>(n, eta, phi);
+      return neg_binomial_2_log_lpmf<T_n,
+                                     T_log_location, T_precision>(n, eta, phi);
     }
   }
 }

--- a/stan/math/prim/scal/prob/neg_binomial_ccdf_log.hpp
+++ b/stan/math/prim/scal/prob/neg_binomial_ccdf_log.hpp
@@ -1,131 +1,20 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_NEG_BINOMIAL_CCDF_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_NEG_BINOMIAL_CCDF_LOG_HPP
 
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_nonnegative.hpp>
-#include <stan/math/prim/scal/err/check_positive_finite.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/fun/binomial_coefficient_log.hpp>
-#include <stan/math/prim/scal/fun/multiply_log.hpp>
-#include <stan/math/prim/scal/fun/digamma.hpp>
-#include <stan/math/prim/scal/fun/lgamma.hpp>
-#include <stan/math/prim/scal/fun/lbeta.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <stan/math/prim/scal/fun/grad_reg_inc_beta.hpp>
-#include <stan/math/prim/scal/fun/inc_beta.hpp>
-#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
-#include <boost/math/special_functions/digamma.hpp>
-#include <boost/random/negative_binomial_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <cmath>
-#include <limits>
+#include <stan/math/prim/scal/prob/neg_binomial_lccdf.hpp>
 
 namespace stan {
   namespace math {
 
+    /**
+     * @deprecated use <code>neg_binomial_lccdf</code>
+     */
     template <typename T_n, typename T_shape,
               typename T_inv_scale>
     typename return_type<T_shape, T_inv_scale>::type
     neg_binomial_ccdf_log(const T_n& n, const T_shape& alpha,
                           const T_inv_scale& beta) {
-      static const char* function("neg_binomial_ccdf_log");
-      typedef typename stan::partials_return_type<T_n, T_shape,
-                                                  T_inv_scale>::type
-        T_partials_return;
-
-      if (!(stan::length(n) && stan::length(alpha) && stan::length(beta)))
-        return 0.0;
-
-      T_partials_return P(0.0);
-
-      check_positive_finite(function, "Shape parameter", alpha);
-      check_positive_finite(function, "Inverse scale parameter", beta);
-      check_consistent_sizes(function,
-                             "Failures variable", n,
-                             "Shape parameter", alpha,
-                             "Inverse scale parameter", beta);
-
-      VectorView<const T_n> n_vec(n);
-      VectorView<const T_shape> alpha_vec(alpha);
-      VectorView<const T_inv_scale> beta_vec(beta);
-      size_t size = max_size(n, alpha, beta);
-
-      using std::exp;
-      using std::pow;
-      using std::log;
-      using std::exp;
-
-      OperandsAndPartials<T_shape, T_inv_scale>
-        operands_and_partials(alpha, beta);
-
-      // Explicit return for extreme values
-      // The gradients are technically ill-defined, but treated as zero
-      for (size_t i = 0; i < stan::length(n); i++) {
-        if (value_of(n_vec[i]) < 0)
-          return operands_and_partials.value(0.0);
-      }
-
-      VectorBuilder<!is_constant_struct<T_shape>::value,
-                    T_partials_return, T_shape>
-        digammaN_vec(stan::length(alpha));
-      VectorBuilder<!is_constant_struct<T_shape>::value,
-                    T_partials_return, T_shape>
-        digammaAlpha_vec(stan::length(alpha));
-      VectorBuilder<!is_constant_struct<T_shape>::value,
-                    T_partials_return, T_shape>
-        digammaSum_vec(stan::length(alpha));
-
-      if (!is_constant_struct<T_shape>::value) {
-        for (size_t i = 0; i < stan::length(alpha); i++) {
-          const T_partials_return n_dbl = value_of(n_vec[i]);
-          const T_partials_return alpha_dbl = value_of(alpha_vec[i]);
-
-          digammaN_vec[i] = digamma(n_dbl + 1);
-          digammaAlpha_vec[i] = digamma(alpha_dbl);
-          digammaSum_vec[i] = digamma(n_dbl + alpha_dbl + 1);
-        }
-      }
-
-      for (size_t i = 0; i < size; i++) {
-        // Explicit results for extreme values
-        // The gradients are technically ill-defined, but treated as zero
-        if (value_of(n_vec[i]) == std::numeric_limits<int>::max())
-          return operands_and_partials.value(negative_infinity());
-
-        const T_partials_return n_dbl = value_of(n_vec[i]);
-        const T_partials_return alpha_dbl = value_of(alpha_vec[i]);
-        const T_partials_return beta_dbl = value_of(beta_vec[i]);
-        const T_partials_return p_dbl = beta_dbl / (1.0 + beta_dbl);
-        const T_partials_return d_dbl = 1.0 / ( (1.0 + beta_dbl)
-                                                * (1.0 + beta_dbl) );
-        const T_partials_return Pi = 1.0 - inc_beta(alpha_dbl, n_dbl + 1.0,
-                                                    p_dbl);
-        const T_partials_return beta_func = exp(lbeta(n_dbl + 1, alpha_dbl));
-
-        P += log(Pi);
-
-        if (!is_constant_struct<T_shape>::value) {
-          T_partials_return g1 = 0;
-          T_partials_return g2 = 0;
-
-          grad_reg_inc_beta(g1, g2, alpha_dbl,
-                            n_dbl + 1, p_dbl,
-                            digammaAlpha_vec[i],
-                            digammaN_vec[i],
-                            digammaSum_vec[i],
-                            beta_func);
-          operands_and_partials.d_x1[i] -= g1 / Pi;
-        }
-        if (!is_constant_struct<T_inv_scale>::value)
-          operands_and_partials.d_x2[i] -= d_dbl * pow(1-p_dbl, n_dbl)
-            * pow(p_dbl, alpha_dbl-1) / beta_func / Pi;
-      }
-
-      return operands_and_partials.value(P);
+      return neg_binomial_lccdf<T_n, T_shape, T_inv_scale>(n, alpha, beta);
     }
 
   }

--- a/stan/math/prim/scal/prob/neg_binomial_cdf_log.hpp
+++ b/stan/math/prim/scal/prob/neg_binomial_cdf_log.hpp
@@ -1,130 +1,20 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_NEG_BINOMIAL_CDF_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_NEG_BINOMIAL_CDF_LOG_HPP
 
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_nonnegative.hpp>
-#include <stan/math/prim/scal/err/check_positive_finite.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/fun/binomial_coefficient_log.hpp>
-#include <stan/math/prim/scal/fun/multiply_log.hpp>
-#include <stan/math/prim/scal/fun/digamma.hpp>
-#include <stan/math/prim/scal/fun/lgamma.hpp>
-#include <stan/math/prim/scal/fun/lbeta.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
-#include <stan/math/prim/scal/fun/grad_reg_inc_beta.hpp>
-#include <stan/math/prim/scal/fun/inc_beta.hpp>
-#include <boost/math/special_functions/digamma.hpp>
-#include <boost/random/negative_binomial_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <cmath>
-#include <limits>
+#include <stan/math/prim/scal/prob/neg_binomial_lcdf.hpp>
 
 namespace stan {
   namespace math {
 
+    /**
+     * @deprecated use <code>neg_binomial_lcdf</code>
+     */
     template <typename T_n, typename T_shape,
               typename T_inv_scale>
     typename return_type<T_shape, T_inv_scale>::type
     neg_binomial_cdf_log(const T_n& n, const T_shape& alpha,
                          const T_inv_scale& beta) {
-      static const char* function("neg_binomial_cdf_log");
-      typedef typename stan::partials_return_type<T_n, T_shape,
-                                                  T_inv_scale>::type
-        T_partials_return;
-
-      if (!(stan::length(n) && stan::length(alpha) && stan::length(beta)))
-        return 0.0;
-
-      T_partials_return P(0.0);
-
-      check_positive_finite(function, "Shape parameter", alpha);
-      check_positive_finite(function, "Inverse scale parameter", beta);
-      check_consistent_sizes(function,
-                             "Failures variable", n,
-                             "Shape parameter", alpha,
-                             "Inverse scale parameter", beta);
-
-      VectorView<const T_n> n_vec(n);
-      VectorView<const T_shape> alpha_vec(alpha);
-      VectorView<const T_inv_scale> beta_vec(beta);
-      size_t size = max_size(n, alpha, beta);
-
-      using std::exp;
-      using std::pow;
-      using std::log;
-      using std::exp;
-
-      OperandsAndPartials<T_shape, T_inv_scale>
-        operands_and_partials(alpha, beta);
-
-      // Explicit return for extreme values
-      // The gradients are technically ill-defined, but treated as zero
-      for (size_t i = 0; i < stan::length(n); i++) {
-        if (value_of(n_vec[i]) < 0)
-          return operands_and_partials.value(negative_infinity());
-      }
-
-      VectorBuilder<!is_constant_struct<T_shape>::value,
-                    T_partials_return, T_shape>
-        digammaN_vec(stan::length(alpha));
-      VectorBuilder<!is_constant_struct<T_shape>::value,
-                    T_partials_return, T_shape>
-        digammaAlpha_vec(stan::length(alpha));
-      VectorBuilder<!is_constant_struct<T_shape>::value,
-                    T_partials_return, T_shape>
-        digammaSum_vec(stan::length(alpha));
-
-      if (!is_constant_struct<T_shape>::value) {
-        for (size_t i = 0; i < stan::length(alpha); i++) {
-          const T_partials_return n_dbl = value_of(n_vec[i]);
-          const T_partials_return alpha_dbl = value_of(alpha_vec[i]);
-
-          digammaN_vec[i] = digamma(n_dbl + 1);
-          digammaAlpha_vec[i] = digamma(alpha_dbl);
-          digammaSum_vec[i] = digamma(n_dbl + alpha_dbl + 1);
-        }
-      }
-
-      for (size_t i = 0; i < size; i++) {
-        // Explicit results for extreme values
-        // The gradients are technically ill-defined, but treated as zero
-        if (value_of(n_vec[i]) == std::numeric_limits<int>::max())
-          return operands_and_partials.value(0.0);
-
-        const T_partials_return n_dbl = value_of(n_vec[i]);
-        const T_partials_return alpha_dbl = value_of(alpha_vec[i]);
-        const T_partials_return beta_dbl = value_of(beta_vec[i]);
-        const T_partials_return p_dbl = beta_dbl / (1.0 + beta_dbl);
-        const T_partials_return d_dbl = 1.0 / ( (1.0 + beta_dbl)
-                                                * (1.0 + beta_dbl) );
-        const T_partials_return Pi = inc_beta(alpha_dbl, n_dbl + 1.0, p_dbl);
-        const T_partials_return beta_func = exp(lbeta(n_dbl + 1, alpha_dbl));
-
-        P += log(Pi);
-
-        if (!is_constant_struct<T_shape>::value) {
-          T_partials_return g1 = 0;
-          T_partials_return g2 = 0;
-
-          grad_reg_inc_beta(g1, g2, alpha_dbl,
-                            n_dbl + 1, p_dbl,
-                            digammaAlpha_vec[i],
-                            digammaN_vec[i],
-                            digammaSum_vec[i],
-                            beta_func);
-          operands_and_partials.d_x1[i] += g1 / Pi;
-        }
-        if (!is_constant_struct<T_inv_scale>::value)
-          operands_and_partials.d_x2[i]  += d_dbl * pow(1-p_dbl, n_dbl)
-            * pow(p_dbl, alpha_dbl-1) / beta_func / Pi;
-      }
-
-      return operands_and_partials.value(P);
+      return neg_binomial_lcdf<T_n, T_shape, T_inv_scale>(n, alpha, beta);
     }
 
   }

--- a/stan/math/prim/scal/prob/neg_binomial_log.hpp
+++ b/stan/math/prim/scal/prob/neg_binomial_log.hpp
@@ -1,36 +1,14 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_NEG_BINOMIAL_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_NEG_BINOMIAL_LOG_HPP
 
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_nonnegative.hpp>
-#include <stan/math/prim/scal/err/check_positive_finite.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/fun/binomial_coefficient_log.hpp>
-#include <stan/math/prim/scal/fun/multiply_log.hpp>
-#include <stan/math/prim/scal/fun/digamma.hpp>
-#include <stan/math/prim/scal/fun/lgamma.hpp>
-#include <stan/math/prim/scal/fun/lbeta.hpp>
-#include <stan/math/prim/scal/meta/length.hpp>
-#include <stan/math/prim/scal/meta/VectorView.hpp>
-#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/return_type.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <stan/math/prim/scal/fun/grad_reg_inc_beta.hpp>
-#include <stan/math/prim/scal/fun/inc_beta.hpp>
-#include <stan/math/prim/scal/meta/max_size.hpp>
-#include <boost/math/special_functions/digamma.hpp>
-#include <boost/random/negative_binomial_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <cmath>
+#include <stan/math/prim/scal/prob/neg_binomial_lpmf.hpp>
 
 namespace stan {
   namespace math {
 
-    // NegBinomial(n|alpha, beta)  [alpha > 0;  beta > 0;  n >= 0]
+    /**
+     * @deprecated use <code>neg_binomial_lpmf</code>
+     */
     template <bool propto,
               typename T_n,
               typename T_shape, typename T_inv_scale>
@@ -38,130 +16,13 @@ namespace stan {
     neg_binomial_log(const T_n& n,
                      const T_shape& alpha,
                      const T_inv_scale& beta) {
-      typedef typename stan::partials_return_type<T_n, T_shape,
-                                                  T_inv_scale>::type
-        T_partials_return;
-
-      static const char* function("neg_binomial_log");
-
-      if (!(stan::length(n)
-            && stan::length(alpha)
-            && stan::length(beta)))
-        return 0.0;
-
-      T_partials_return logp(0.0);
-      check_nonnegative(function, "Failures variable", n);
-      check_positive_finite(function, "Shape parameter", alpha);
-      check_positive_finite(function, "Inverse scale parameter", beta);
-      check_consistent_sizes(function,
-                             "Failures variable", n,
-                             "Shape parameter", alpha,
-                             "Inverse scale parameter", beta);
-
-      if (!include_summand<propto, T_shape, T_inv_scale>::value)
-        return 0.0;
-
-      using std::log;
-      using std::log;
-
-      VectorView<const T_n> n_vec(n);
-      VectorView<const T_shape> alpha_vec(alpha);
-      VectorView<const T_inv_scale> beta_vec(beta);
-      size_t size = max_size(n, alpha, beta);
-
-      OperandsAndPartials<T_shape, T_inv_scale>
-        operands_and_partials(alpha, beta);
-
-      size_t len_ab = max_size(alpha, beta);
-      VectorBuilder<true, T_partials_return, T_shape, T_inv_scale>
-        lambda(len_ab);
-      for (size_t i = 0; i < len_ab; ++i)
-        lambda[i] = value_of(alpha_vec[i]) / value_of(beta_vec[i]);
-
-      VectorBuilder<true, T_partials_return, T_inv_scale>
-        log1p_beta(length(beta));
-      for (size_t i = 0; i < length(beta); ++i)
-        log1p_beta[i] = log1p(value_of(beta_vec[i]));
-
-      VectorBuilder<true, T_partials_return, T_inv_scale>
-        log_beta_m_log1p_beta(length(beta));
-      for (size_t i = 0; i < length(beta); ++i)
-        log_beta_m_log1p_beta[i] = log(value_of(beta_vec[i])) - log1p_beta[i];
-
-      VectorBuilder<true, T_partials_return, T_inv_scale, T_shape>
-        alpha_times_log_beta_over_1p_beta(len_ab);
-      for (size_t i = 0; i < len_ab; ++i)
-        alpha_times_log_beta_over_1p_beta[i]
-          = value_of(alpha_vec[i])
-          * log(value_of(beta_vec[i])
-                / (1.0 + value_of(beta_vec[i])));
-
-      VectorBuilder<!is_constant_struct<T_shape>::value,
-                    T_partials_return, T_shape>
-        digamma_alpha(length(alpha));
-      if (!is_constant_struct<T_shape>::value) {
-        for (size_t i = 0; i < length(alpha); ++i)
-          digamma_alpha[i] = digamma(value_of(alpha_vec[i]));
-      }
-
-      VectorBuilder<!is_constant_struct<T_shape>::value,
-                    T_partials_return, T_inv_scale> log_beta(length(beta));
-      if (!is_constant_struct<T_shape>::value) {
-        for (size_t i = 0; i < length(beta); ++i)
-          log_beta[i] = log(value_of(beta_vec[i]));
-      }
-
-      VectorBuilder<!is_constant_struct<T_inv_scale>::value,
-                    T_partials_return, T_shape, T_inv_scale>
-        lambda_m_alpha_over_1p_beta(len_ab);
-      if (!is_constant_struct<T_inv_scale>::value) {
-        for (size_t i = 0; i < len_ab; ++i)
-          lambda_m_alpha_over_1p_beta[i] =
-            lambda[i]
-            - (value_of(alpha_vec[i])
-               / (1.0 + value_of(beta_vec[i])));
-      }
-
-      for (size_t i = 0; i < size; i++) {
-        if (alpha_vec[i] > 1e10) {  // reduces numerically to Poisson
-          if (include_summand<propto>::value)
-            logp -= lgamma(n_vec[i] + 1.0);
-          if (include_summand<propto, T_shape, T_inv_scale>::value)
-            logp += multiply_log(n_vec[i], lambda[i]) - lambda[i];
-
-          if (!is_constant_struct<T_shape>::value)
-            operands_and_partials.d_x1[i]
-              += n_vec[i] / value_of(alpha_vec[i])
-              - 1.0 / value_of(beta_vec[i]);
-          if (!is_constant_struct<T_inv_scale>::value)
-            operands_and_partials.d_x2[i]
-              += (lambda[i] - n_vec[i]) / value_of(beta_vec[i]);
-        } else {  // standard density definition
-          if (include_summand<propto, T_shape>::value)
-            if (n_vec[i] != 0)
-              logp += binomial_coefficient_log(n_vec[i]
-                                               + value_of(alpha_vec[i])
-                                               - 1.0,
-                                               n_vec[i]);
-          if (include_summand<propto, T_shape, T_inv_scale>::value)
-            logp +=
-              alpha_times_log_beta_over_1p_beta[i]
-              - n_vec[i] * log1p_beta[i];
-
-          if (!is_constant_struct<T_shape>::value)
-            operands_and_partials.d_x1[i]
-              += digamma(value_of(alpha_vec[i]) + n_vec[i])
-              - digamma_alpha[i]
-              + log_beta_m_log1p_beta[i];
-          if (!is_constant_struct<T_inv_scale>::value)
-            operands_and_partials.d_x2[i]
-              += lambda_m_alpha_over_1p_beta[i]
-              - n_vec[i]  / (value_of(beta_vec[i]) + 1.0);
-        }
-      }
-      return operands_and_partials.value(logp);
+      return neg_binomial_lpmf<propto, T_n,
+                               T_shape, T_inv_scale>(n, alpha, beta);
     }
 
+    /**
+     * @deprecated use <code>neg_binomial_lpmf</code>
+     */
     template <typename T_n,
               typename T_shape, typename T_inv_scale>
     inline
@@ -169,7 +30,7 @@ namespace stan {
     neg_binomial_log(const T_n& n,
                      const T_shape& alpha,
                      const T_inv_scale& beta) {
-      return neg_binomial_log<false>(n, alpha, beta);
+      return neg_binomial_lpmf<T_n, T_shape, T_inv_scale>(n, alpha, beta);
     }
 
   }

--- a/stan/math/prim/scal/prob/normal_ccdf_log.hpp
+++ b/stan/math/prim/scal/prob/normal_ccdf_log.hpp
@@ -1,96 +1,18 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_NORMAL_CCDF_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_NORMAL_CCDF_LOG_HPP
 
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_finite.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/err/check_positive.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/meta/contains_nonconstant_struct.hpp>
-#include <stan/math/prim/scal/meta/max_size.hpp>
-#include <boost/random/normal_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <cmath>
-#include <limits>
+#include <stan/math/prim/scal/prob/normal_lccdf.hpp>
 
 namespace stan {
   namespace math {
 
+    /**
+     * @deprecated use <code>normal_lccdf</code>
+     */
     template <typename T_y, typename T_loc, typename T_scale>
     typename return_type<T_y, T_loc, T_scale>::type
     normal_ccdf_log(const T_y& y, const T_loc& mu, const T_scale& sigma) {
-      static const char* function("normal_ccdf_log");
-      typedef typename stan::partials_return_type<T_y, T_loc, T_scale>::type
-        T_partials_return;
-
-      using std::log;
-      using std::exp;
-
-      T_partials_return ccdf_log(0.0);
-      if (!(stan::length(y)
-            && stan::length(mu)
-            && stan::length(sigma)))
-        return ccdf_log;
-
-      check_not_nan(function, "Random variable", y);
-      check_finite(function, "Location parameter", mu);
-      check_not_nan(function, "Scale parameter", sigma);
-      check_positive(function, "Scale parameter", sigma);
-      check_consistent_sizes(function,
-                             "Random variable", y,
-                             "Location parameter", mu,
-                             "Scale parameter", sigma);
-
-      OperandsAndPartials<T_y, T_loc, T_scale>
-        operands_and_partials(y, mu, sigma);
-
-      VectorView<const T_y> y_vec(y);
-      VectorView<const T_loc> mu_vec(mu);
-      VectorView<const T_scale> sigma_vec(sigma);
-      size_t N = max_size(y, mu, sigma);
-      double log_half = std::log(0.5);
-
-      const double SQRT_TWO_OVER_PI = std::sqrt(2.0 / pi());
-      for (size_t n = 0; n < N; n++) {
-        const T_partials_return y_dbl = value_of(y_vec[n]);
-        const T_partials_return mu_dbl = value_of(mu_vec[n]);
-        const T_partials_return sigma_dbl = value_of(sigma_vec[n]);
-
-        const T_partials_return scaled_diff = (y_dbl - mu_dbl)
-          / (sigma_dbl * SQRT_2);
-
-        T_partials_return one_m_erf;
-        if (scaled_diff < -37.5 * INV_SQRT_2)
-          one_m_erf = 2.0;
-        else if (scaled_diff < -5.0 * INV_SQRT_2)
-          one_m_erf =  2.0 - erfc(-scaled_diff);
-        else if (scaled_diff > 8.25 * INV_SQRT_2)
-          one_m_erf = 0.0;
-        else
-          one_m_erf = 1.0 - erf(scaled_diff);
-
-        ccdf_log += log_half + log(one_m_erf);
-
-        if (contains_nonconstant_struct<T_y, T_loc, T_scale>::value) {
-          const T_partials_return rep_deriv_div_sigma
-            = scaled_diff > 8.25 * INV_SQRT_2
-            ? std::numeric_limits<double>::infinity()
-            : SQRT_TWO_OVER_PI * exp(-scaled_diff * scaled_diff)
-            / one_m_erf / sigma_dbl;
-          if (!is_constant_struct<T_y>::value)
-            operands_and_partials.d_x1[n] -= rep_deriv_div_sigma;
-          if (!is_constant_struct<T_loc>::value)
-            operands_and_partials.d_x2[n] += rep_deriv_div_sigma;
-          if (!is_constant_struct<T_scale>::value)
-            operands_and_partials.d_x3[n] += rep_deriv_div_sigma
-              * scaled_diff * SQRT_2;
-        }
-      }
-      return operands_and_partials.value(ccdf_log);
+      return normal_lccdf<T_y, T_loc, T_scale>(y, mu, sigma);
     }
 
   }

--- a/stan/math/prim/scal/prob/normal_cdf_log.hpp
+++ b/stan/math/prim/scal/prob/normal_cdf_log.hpp
@@ -1,95 +1,18 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_NORMAL_CDF_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_NORMAL_CDF_LOG_HPP
 
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_finite.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/err/check_positive.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/meta/max_size.hpp>
-#include <stan/math/prim/scal/meta/contains_nonconstant_struct.hpp>
-#include <boost/random/normal_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <cmath>
-#include <limits>
+#include <stan/math/prim/scal/prob/normal_lcdf.hpp>
 
 namespace stan {
   namespace math {
 
+    /**
+     * @deprecated use <code>normal_lcdf</code>
+     */
     template <typename T_y, typename T_loc, typename T_scale>
     typename return_type<T_y, T_loc, T_scale>::type
     normal_cdf_log(const T_y& y, const T_loc& mu, const T_scale& sigma) {
-      static const char* function("normal_cdf_log");
-      typedef typename stan::partials_return_type<T_y, T_loc, T_scale>::type
-        T_partials_return;
-
-      using std::log;
-      using std::exp;
-
-      T_partials_return cdf_log(0.0);
-      if (!(stan::length(y)
-            && stan::length(mu)
-            && stan::length(sigma)))
-        return cdf_log;
-
-      check_not_nan(function, "Random variable", y);
-      check_finite(function, "Location parameter", mu);
-      check_not_nan(function, "Scale parameter", sigma);
-      check_positive(function, "Scale parameter", sigma);
-      check_consistent_sizes(function,
-                             "Random variable", y,
-                             "Location parameter", mu,
-                             "Scale parameter", sigma);
-
-      OperandsAndPartials<T_y, T_loc, T_scale>
-        operands_and_partials(y, mu, sigma);
-
-      VectorView<const T_y> y_vec(y);
-      VectorView<const T_loc> mu_vec(mu);
-      VectorView<const T_scale> sigma_vec(sigma);
-      size_t N = max_size(y, mu, sigma);
-
-      const double SQRT_TWO_OVER_PI = std::sqrt(2.0 / pi());
-      for (size_t n = 0; n < N; n++) {
-        const T_partials_return y_dbl = value_of(y_vec[n]);
-        const T_partials_return mu_dbl = value_of(mu_vec[n]);
-        const T_partials_return sigma_dbl = value_of(sigma_vec[n]);
-
-        const T_partials_return scaled_diff = (y_dbl - mu_dbl)
-          / (sigma_dbl * SQRT_2);
-
-        T_partials_return one_p_erf;
-        if (scaled_diff < -37.5 * INV_SQRT_2)
-          one_p_erf = 0.0;
-        else if (scaled_diff < -5.0 * INV_SQRT_2)
-          one_p_erf =  erfc(-scaled_diff);
-        else if (scaled_diff > 8.25 * INV_SQRT_2)
-          one_p_erf = 2.0;
-        else
-          one_p_erf = 1.0 + erf(scaled_diff);
-
-        cdf_log += LOG_HALF + log(one_p_erf);
-
-        if (contains_nonconstant_struct<T_y, T_loc, T_scale>::value) {
-          const T_partials_return rep_deriv_div_sigma
-            = scaled_diff < -37.5 * INV_SQRT_2
-                            ? std::numeric_limits<double>::infinity()
-                            : SQRT_TWO_OVER_PI * exp(-scaled_diff * scaled_diff)
-                            / sigma_dbl / one_p_erf;
-          if (!is_constant_struct<T_y>::value)
-            operands_and_partials.d_x1[n] += rep_deriv_div_sigma;
-          if (!is_constant_struct<T_loc>::value)
-            operands_and_partials.d_x2[n] -= rep_deriv_div_sigma;
-          if (!is_constant_struct<T_scale>::value)
-            operands_and_partials.d_x3[n] -= rep_deriv_div_sigma
-                            * scaled_diff * SQRT_2;
-        }
-      }
-      return operands_and_partials.value(cdf_log);
+      return normal_lcdf<T_y, T_loc, T_scale>(y, mu, sigma);
     }
 
   }

--- a/stan/math/prim/scal/prob/normal_log.hpp
+++ b/stan/math/prim/scal/prob/normal_log.hpp
@@ -1,21 +1,7 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_NORMAL_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_NORMAL_LOG_HPP
 
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_finite.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/err/check_positive.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
-#include <stan/math/prim/scal/meta/max_size.hpp>
-#include <boost/random/normal_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <cmath>
+#include <stan/math/prim/scal/prob/normal_lpdf.hpp>
 
 namespace stan {
   namespace math {
@@ -28,6 +14,9 @@ namespace stan {
      *
      * <p>The result log probability is defined to be the sum of the
      * log probabilities for each observation/mean/deviation triple.
+     *
+     * @deprecated use <code>normal_lpdf</code>
+     *
      * @param y (Sequence of) scalar(s).
      * @param mu (Sequence of) location parameter(s)
      * for the normal distribution.
@@ -42,83 +31,17 @@ namespace stan {
               typename T_y, typename T_loc, typename T_scale>
     typename return_type<T_y, T_loc, T_scale>::type
     normal_log(const T_y& y, const T_loc& mu, const T_scale& sigma) {
-      static const char* function("normal_log");
-      typedef typename stan::partials_return_type<T_y, T_loc, T_scale>::type
-        T_partials_return;
-
-      using std::log;
-      using stan::is_constant_struct;
-      using std::log;
-
-      if (!(stan::length(y)
-            && stan::length(mu)
-            && stan::length(sigma)))
-        return 0.0;
-
-      T_partials_return logp(0.0);
-
-      check_not_nan(function, "Random variable", y);
-      check_finite(function, "Location parameter", mu);
-      check_positive(function, "Scale parameter", sigma);
-      check_consistent_sizes(function,
-                             "Random variable", y,
-                             "Location parameter", mu,
-                             "Scale parameter", sigma);
-      if (!include_summand<propto, T_y, T_loc, T_scale>::value)
-        return 0.0;
-
-      OperandsAndPartials<T_y, T_loc, T_scale>
-        operands_and_partials(y, mu, sigma);
-
-      VectorView<const T_y> y_vec(y);
-      VectorView<const T_loc> mu_vec(mu);
-      VectorView<const T_scale> sigma_vec(sigma);
-      size_t N = max_size(y, mu, sigma);
-
-      VectorBuilder<true, T_partials_return, T_scale> inv_sigma(length(sigma));
-      VectorBuilder<include_summand<propto, T_scale>::value,
-                    T_partials_return, T_scale> log_sigma(length(sigma));
-      for (size_t i = 0; i < length(sigma); i++) {
-        inv_sigma[i] = 1.0 / value_of(sigma_vec[i]);
-        if (include_summand<propto, T_scale>::value)
-          log_sigma[i] = log(value_of(sigma_vec[i]));
-      }
-
-      for (size_t n = 0; n < N; n++) {
-        const T_partials_return y_dbl = value_of(y_vec[n]);
-        const T_partials_return mu_dbl = value_of(mu_vec[n]);
-
-        const T_partials_return y_minus_mu_over_sigma
-          = (y_dbl - mu_dbl) * inv_sigma[n];
-        const T_partials_return y_minus_mu_over_sigma_squared
-          = y_minus_mu_over_sigma * y_minus_mu_over_sigma;
-
-        static double NEGATIVE_HALF = - 0.5;
-
-        if (include_summand<propto>::value)
-          logp += NEG_LOG_SQRT_TWO_PI;
-        if (include_summand<propto, T_scale>::value)
-          logp -= log_sigma[n];
-        if (include_summand<propto, T_y, T_loc, T_scale>::value)
-          logp += NEGATIVE_HALF * y_minus_mu_over_sigma_squared;
-
-        T_partials_return scaled_diff = inv_sigma[n] * y_minus_mu_over_sigma;
-        if (!is_constant_struct<T_y>::value)
-          operands_and_partials.d_x1[n] -= scaled_diff;
-        if (!is_constant_struct<T_loc>::value)
-          operands_and_partials.d_x2[n] += scaled_diff;
-        if (!is_constant_struct<T_scale>::value)
-          operands_and_partials.d_x3[n]
-            += -inv_sigma[n] + inv_sigma[n] * y_minus_mu_over_sigma_squared;
-      }
-      return operands_and_partials.value(logp);
+      return normal_lpdf<propto, T_y, T_loc, T_scale>(y, mu, sigma);
     }
 
+    /**
+     * @deprecated use <code>normal_lpdf</code>
+     */
     template <typename T_y, typename T_loc, typename T_scale>
     inline
     typename return_type<T_y, T_loc, T_scale>::type
     normal_log(const T_y& y, const T_loc& mu, const T_scale& sigma) {
-      return normal_log<false>(y, mu, sigma);
+      return normal_lpdf<T_y, T_loc, T_scale>(y, mu, sigma);
     }
 
   }


### PR DESCRIPTION
#### Note on the 10 related pull requests
This is staged as follows:
- pull requests 1-7 will be adding new functions that mirror the old `_log` functions without altering the `_log` functions (except in situations where there are multiple definitions)
- pull requests 8-10 will deprecate the old functions and have the old functions call the new functions.
- This should wait on PRs: #441, #442, #443, #444, #445, #446, #447.

#### Submisison Checklist

- [x] Run unit tests: `./runTests.py test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary:
This pull request deprecates the `_log` functions by calling the new `_lpdf` / `_lpmf` / `_lcdf` / `_lccdf` function.

#### How to Verify:
Look at code and run code.

#### Side Effects:
None.

#### Documentation:
Doxygen doc deprecating the `_log` function.

#### Reviewer Suggestions: 
Anyone.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Columbia University.

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
