### PR TITLE
Updating probability functions. 10/10 pull requests.

### DIFF
--- a/stan/math/prim/scal/prob/pareto_ccdf_log.hpp
+++ b/stan/math/prim/scal/prob/pareto_ccdf_log.hpp
@@ -1,89 +1,19 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_PARETO_CCDF_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_PARETO_CCDF_LOG_HPP
 
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_greater_or_equal.hpp>
-#include <stan/math/prim/scal/err/check_nonnegative.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/err/check_positive_finite.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/fun/multiply_log.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <boost/random/exponential_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <cmath>
-#include <limits>
+#include <stan/math/prim/scal/prob/pareto_lccdf.hpp>
 
 namespace stan {
   namespace math {
 
+    /**
+     * @deprecated use <code>pareto_lccdf</code>
+     */
     template <typename T_y, typename T_scale, typename T_shape>
     typename return_type<T_y, T_scale, T_shape>::type
     pareto_ccdf_log(const T_y& y, const T_scale& y_min,
                     const T_shape& alpha) {
-      typedef typename stan::partials_return_type<T_y, T_scale, T_shape>::type
-        T_partials_return;
-
-      if ( !( stan::length(y) && stan::length(y_min) && stan::length(alpha) ) )
-        return 0.0;
-
-      static const char* function("pareto_ccdf_log");
-
-      using std::log;
-      using std::exp;
-
-      T_partials_return P(0.0);
-
-      check_not_nan(function, "Random variable", y);
-      check_nonnegative(function, "Random variable", y);
-      check_positive_finite(function, "Scale parameter", y_min);
-      check_positive_finite(function, "Shape parameter", alpha);
-      check_consistent_sizes(function,
-                             "Random variable", y,
-                             "Scale parameter", y_min,
-                             "Shape parameter", alpha);
-
-      VectorView<const T_y> y_vec(y);
-      VectorView<const T_scale> y_min_vec(y_min);
-      VectorView<const T_shape> alpha_vec(alpha);
-      size_t N = max_size(y, y_min, alpha);
-
-      OperandsAndPartials<T_y, T_scale, T_shape>
-        operands_and_partials(y, y_min, alpha);
-
-      // Explicit return for extreme values
-      // The gradients are technically ill-defined, but treated as zero
-      for (size_t i = 0; i < stan::length(y); i++) {
-        if (value_of(y_vec[i]) < value_of(y_min_vec[i]))
-          return operands_and_partials.value(0.0);
-      }
-
-      for (size_t n = 0; n < N; n++) {
-        // Explicit results for extreme values
-        // The gradients are technically ill-defined, but treated as zero
-        if (value_of(y_vec[n]) == std::numeric_limits<double>::infinity()) {
-          return operands_and_partials.value(negative_infinity());
-        }
-
-        const T_partials_return log_dbl = log(value_of(y_min_vec[n])
-                                              / value_of(y_vec[n]));
-        const T_partials_return y_min_inv_dbl = 1.0 / value_of(y_min_vec[n]);
-        const T_partials_return alpha_dbl = value_of(alpha_vec[n]);
-
-        P += alpha_dbl * log_dbl;
-
-        if (!is_constant_struct<T_y>::value)
-          operands_and_partials.d_x1[n] -= alpha_dbl * y_min_inv_dbl
-            * exp(log_dbl);
-        if (!is_constant_struct<T_scale>::value)
-          operands_and_partials.d_x2[n] += alpha_dbl * y_min_inv_dbl;
-        if (!is_constant_struct<T_shape>::value)
-          operands_and_partials.d_x3[n] += log_dbl;
-      }
-      return operands_and_partials.value(P);
+      return pareto_lccdf<T_y, T_scale, T_shape>(y, y_min, alpha);
     }
 
   }

--- a/stan/math/prim/scal/prob/pareto_cdf_log.hpp
+++ b/stan/math/prim/scal/prob/pareto_cdf_log.hpp
@@ -1,92 +1,18 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_PARETO_CDF_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_PARETO_CDF_LOG_HPP
 
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_greater_or_equal.hpp>
-#include <stan/math/prim/scal/err/check_nonnegative.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/err/check_positive_finite.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/fun/multiply_log.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <boost/random/exponential_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <cmath>
-#include <limits>
+#include <stan/math/prim/scal/prob/pareto_lcdf.hpp>
 
 namespace stan {
   namespace math {
 
+    /**
+     * @deprecated use <code>pareto_lcdf</code>
+     */
     template <typename T_y, typename T_scale, typename T_shape>
     typename return_type<T_y, T_scale, T_shape>::type
     pareto_cdf_log(const T_y& y, const T_scale& y_min, const T_shape& alpha) {
-      typedef typename stan::partials_return_type<T_y, T_scale, T_shape>::type
-        T_partials_return;
-
-      if ( !( stan::length(y) && stan::length(y_min) && stan::length(alpha) ) )
-        return 0.0;
-
-      static const char* function("pareto_cdf_log");
-
-      using std::log;
-      using std::exp;
-
-      T_partials_return P(0.0);
-
-      check_not_nan(function, "Random variable", y);
-      check_nonnegative(function, "Random variable", y);
-      check_positive_finite(function, "Scale parameter", y_min);
-      check_positive_finite(function, "Shape parameter", alpha);
-      check_consistent_sizes(function,
-                             "Random variable", y,
-                             "Scale parameter", y_min,
-                             "Shape parameter", alpha);
-
-      VectorView<const T_y> y_vec(y);
-      VectorView<const T_scale> y_min_vec(y_min);
-      VectorView<const T_shape> alpha_vec(alpha);
-      size_t N = max_size(y, y_min, alpha);
-
-      OperandsAndPartials<T_y, T_scale, T_shape>
-        operands_and_partials(y, y_min, alpha);
-
-      // Explicit return for extreme values
-      // The gradients are technically ill-defined, but treated as zero
-      for (size_t i = 0; i < stan::length(y); i++) {
-        if (value_of(y_vec[i]) < value_of(y_min_vec[i]))
-          return operands_and_partials.value(negative_infinity());
-      }
-
-      for (size_t n = 0; n < N; n++) {
-        // Explicit results for extreme values
-        // The gradients are technically ill-defined, but treated as zero
-        if (value_of(y_vec[n]) == std::numeric_limits<double>::infinity()) {
-          return operands_and_partials.value(0.0);
-        }
-
-        const T_partials_return log_dbl = log(value_of(y_min_vec[n])
-                                              / value_of(y_vec[n]));
-        const T_partials_return y_min_inv_dbl = 1.0 / value_of(y_min_vec[n]);
-        const T_partials_return alpha_dbl = value_of(alpha_vec[n]);
-
-        const T_partials_return Pn = 1.0 - exp(alpha_dbl * log_dbl);
-
-        P += log(Pn);
-
-        if (!is_constant_struct<T_y>::value)
-          operands_and_partials.d_x1[n]
-            += alpha_dbl * y_min_inv_dbl * exp((alpha_dbl + 1) * log_dbl) / Pn;
-        if (!is_constant_struct<T_scale>::value)
-          operands_and_partials.d_x2[n]
-            -= alpha_dbl * y_min_inv_dbl * exp(alpha_dbl * log_dbl) / Pn;
-        if (!is_constant_struct<T_shape>::value)
-          operands_and_partials.d_x3[n]
-            -= exp(alpha_dbl * log_dbl) * log_dbl / Pn;
-      }
-      return operands_and_partials.value(P);
+      return pareto_lcdf<T_y, T_scale, T_shape>(y, y_min, alpha);
     }
 
   }

--- a/stan/math/prim/scal/prob/pareto_log.hpp
+++ b/stan/math/prim/scal/prob/pareto_log.hpp
@@ -1,123 +1,29 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_PARETO_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_PARETO_LOG_HPP
 
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_greater_or_equal.hpp>
-#include <stan/math/prim/scal/err/check_nonnegative.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/err/check_positive_finite.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/fun/multiply_log.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <stan/math/prim/scal/meta/contains_nonconstant_struct.hpp>
-#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
-#include <boost/random/exponential_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <cmath>
+#include <stan/math/prim/scal/prob/pareto_lpdf.hpp>
 
 namespace stan {
   namespace math {
 
-    // Pareto(y|y_m, alpha)  [y > y_m;  y_m > 0;  alpha > 0]
+    /**
+     * @deprecated use <code>pareto_lpdf</code>
+     */
     template <bool propto,
               typename T_y, typename T_scale, typename T_shape>
     typename return_type<T_y, T_scale, T_shape>::type
     pareto_log(const T_y& y, const T_scale& y_min, const T_shape& alpha) {
-      static const char* function("pareto_log");
-      typedef typename stan::partials_return_type<T_y, T_scale, T_shape>::type
-        T_partials_return;
-
-      using std::log;
-
-      if (!(stan::length(y)
-            && stan::length(y_min)
-            && stan::length(alpha)))
-        return 0.0;
-
-      T_partials_return logp(0.0);
-
-      check_not_nan(function, "Random variable", y);
-      check_positive_finite(function, "Scale parameter", y_min);
-      check_positive_finite(function, "Shape parameter", alpha);
-      check_consistent_sizes(function,
-                             "Random variable", y,
-                             "Scale parameter", y_min,
-                             "Shape parameter", alpha);
-
-      if (!include_summand<propto, T_y, T_scale, T_shape>::value)
-        return 0.0;
-
-      VectorView<const T_y> y_vec(y);
-      VectorView<const T_scale> y_min_vec(y_min);
-      VectorView<const T_shape> alpha_vec(alpha);
-      size_t N = max_size(y, y_min, alpha);
-
-      for (size_t n = 0; n < N; n++) {
-        if (y_vec[n] < y_min_vec[n])
-          return LOG_ZERO;
-      }
-
-      OperandsAndPartials<T_y, T_scale, T_shape>
-        operands_and_partials(y, y_min, alpha);
-
-      VectorBuilder<include_summand<propto, T_y, T_shape>::value,
-                    T_partials_return, T_y> log_y(length(y));
-      if (include_summand<propto, T_y, T_shape>::value) {
-        for (size_t n = 0; n < length(y); n++)
-          log_y[n] = log(value_of(y_vec[n]));
-      }
-
-      VectorBuilder<contains_nonconstant_struct<T_y, T_shape>::value,
-                    T_partials_return, T_y> inv_y(length(y));
-      if (contains_nonconstant_struct<T_y, T_shape>::value) {
-        for (size_t n = 0; n < length(y); n++)
-          inv_y[n] = 1 / value_of(y_vec[n]);
-      }
-
-      VectorBuilder<include_summand<propto, T_scale, T_shape>::value,
-                    T_partials_return, T_scale>
-        log_y_min(length(y_min));
-      if (include_summand<propto, T_scale, T_shape>::value) {
-        for (size_t n = 0; n < length(y_min); n++)
-          log_y_min[n] = log(value_of(y_min_vec[n]));
-      }
-
-      VectorBuilder<include_summand<propto, T_shape>::value,
-                    T_partials_return, T_shape> log_alpha(length(alpha));
-      if (include_summand<propto, T_shape>::value) {
-        for (size_t n = 0; n < length(alpha); n++)
-          log_alpha[n] = log(value_of(alpha_vec[n]));
-      }
-
-      for (size_t n = 0; n < N; n++) {
-        const T_partials_return alpha_dbl = value_of(alpha_vec[n]);
-        if (include_summand<propto, T_shape>::value)
-          logp += log_alpha[n];
-        if (include_summand<propto, T_scale, T_shape>::value)
-          logp += alpha_dbl * log_y_min[n];
-        if (include_summand<propto, T_y, T_shape>::value)
-          logp -= alpha_dbl * log_y[n] + log_y[n];
-
-        if (!is_constant_struct<T_y>::value)
-          operands_and_partials.d_x1[n] -= alpha_dbl * inv_y[n] + inv_y[n];
-        if (!is_constant_struct<T_scale>::value)
-          operands_and_partials.d_x2[n] += alpha_dbl / value_of(y_min_vec[n]);
-        if (!is_constant_struct<T_shape>::value)
-          operands_and_partials.d_x3[n]
-            += 1 / alpha_dbl + log_y_min[n] - log_y[n];
-      }
-      return operands_and_partials.value(logp);
+      return pareto_lpdf<propto, T_y, T_scale, T_shape>(y, y_min, alpha);
     }
 
+    /**
+     * @deprecated use <code>pareto_lpdf</code>
+     */
     template <typename T_y, typename T_scale, typename T_shape>
     inline
     typename return_type<T_y, T_scale, T_shape>::type
     pareto_log(const T_y& y, const T_scale& y_min, const T_shape& alpha) {
-      return pareto_log<false>(y, y_min, alpha);
+      return pareto_lpdf<T_y, T_scale, T_shape>(y, y_min, alpha);
     }
 
   }

--- a/stan/math/prim/scal/prob/pareto_type_2_ccdf_log.hpp
+++ b/stan/math/prim/scal/prob/pareto_type_2_ccdf_log.hpp
@@ -1,113 +1,20 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_PARETO_TYPE_2_CCDF_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_PARETO_TYPE_2_CCDF_LOG_HPP
 
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_finite.hpp>
-#include <stan/math/prim/scal/err/check_greater_or_equal.hpp>
-#include <stan/math/prim/scal/err/check_nonnegative.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/err/check_positive_finite.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/fun/log1m.hpp>
-#include <stan/math/prim/scal/meta/contains_nonconstant_struct.hpp>
-#include <stan/math/prim/scal/meta/VectorView.hpp>
-#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <cmath>
+#include <stan/math/prim/scal/prob/pareto_type_2_lccdf.hpp>
 
 namespace stan {
   namespace math {
 
+    /**
+     * @deprecated use <code>pareto_type_2_lccdf</code>
+     */
     template <typename T_y, typename T_loc, typename T_scale, typename T_shape>
     typename return_type<T_y, T_loc, T_scale, T_shape>::type
     pareto_type_2_ccdf_log(const T_y& y, const T_loc& mu,
                            const T_scale& lambda, const T_shape& alpha) {
-      typedef
-        typename stan::partials_return_type<T_y, T_loc, T_scale, T_shape>::type
-        T_partials_return;
-
-      if ( !( stan::length(y)
-              && stan::length(mu)
-              && stan::length(lambda)
-              && stan::length(alpha) ) )
-        return 0.0;
-
-      static const char* function("pareto_type_2_ccdf_log");
-
-      using std::log;
-
-      T_partials_return P(0.0);
-
-      check_greater_or_equal(function, "Random variable", y, mu);
-      check_not_nan(function, "Random variable", y);
-      check_nonnegative(function, "Random variable", y);
-      check_positive_finite(function, "Scale parameter", lambda);
-      check_positive_finite(function, "Shape parameter", alpha);
-      check_consistent_sizes(function,
-                             "Random variable", y,
-                             "Scale parameter", lambda,
-                             "Shape parameter", alpha);
-
-      VectorView<const T_y> y_vec(y);
-      VectorView<const T_loc> mu_vec(mu);
-      VectorView<const T_scale> lambda_vec(lambda);
-      VectorView<const T_shape> alpha_vec(alpha);
-      size_t N = max_size(y, mu, lambda, alpha);
-
-      OperandsAndPartials<T_y, T_loc, T_scale, T_shape>
-        operands_and_partials(y, mu, lambda, alpha);
-
-      VectorBuilder<true, T_partials_return,
-                    T_y, T_loc, T_scale, T_shape>
-        ccdf_log(N);
-
-      VectorBuilder<contains_nonconstant_struct<T_y, T_loc, T_scale,
-                                                T_shape>::value,
-                    T_partials_return, T_y, T_loc, T_scale, T_shape>
-        a_over_lambda_plus_y(N);
-
-      VectorBuilder<!is_constant_struct<T_shape>::value,
-                    T_partials_return, T_y, T_loc, T_scale, T_shape>
-        log_1p_y_over_lambda(N);
-
-      for (size_t i = 0; i < N; i++) {
-        const T_partials_return y_dbl = value_of(y_vec[i]);
-        const T_partials_return mu_dbl = value_of(mu_vec[i]);
-        const T_partials_return lambda_dbl = value_of(lambda_vec[i]);
-        const T_partials_return alpha_dbl = value_of(alpha_vec[i]);
-        const T_partials_return temp = 1.0 + (y_dbl - mu_dbl) / lambda_dbl;
-        const T_partials_return log_temp = log(temp);
-
-        ccdf_log[i] = -alpha_dbl * log_temp;
-
-        if (contains_nonconstant_struct<T_y, T_loc, T_scale, T_shape>::value)
-          a_over_lambda_plus_y[i] = alpha_dbl / (y_dbl - mu_dbl + lambda_dbl);
-
-        if (!is_constant_struct<T_shape>::value)
-          log_1p_y_over_lambda[i] = log_temp;
-      }
-
-      for (size_t n = 0; n < N; n++) {
-        const T_partials_return y_dbl = value_of(y_vec[n]);
-        const T_partials_return mu_dbl = value_of(mu_vec[n]);
-        const T_partials_return lambda_dbl = value_of(lambda_vec[n]);
-
-        P += ccdf_log[n];
-
-        if (!is_constant_struct<T_y>::value)
-          operands_and_partials.d_x1[n] -= a_over_lambda_plus_y[n];
-        if (!is_constant_struct<T_loc>::value)
-          operands_and_partials.d_x2[n] += a_over_lambda_plus_y[n];
-        if (!is_constant_struct<T_scale>::value)
-          operands_and_partials.d_x3[n] += a_over_lambda_plus_y[n]
-            * (y_dbl - mu_dbl) / lambda_dbl;
-        if (!is_constant_struct<T_shape>::value)
-          operands_and_partials.d_x4[n] -= log_1p_y_over_lambda[n];
-      }
-      return operands_and_partials.value(P);
+      return pareto_type_2_lccdf<T_y, T_loc,
+                                 T_scale, T_shape>(y, mu, lambda, alpha);
     }
 
   }

--- a/stan/math/prim/scal/prob/pareto_type_2_cdf_log.hpp
+++ b/stan/math/prim/scal/prob/pareto_type_2_cdf_log.hpp
@@ -1,114 +1,20 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_PARETO_TYPE_2_CDF_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_PARETO_TYPE_2_CDF_LOG_HPP
 
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_finite.hpp>
-#include <stan/math/prim/scal/err/check_greater_or_equal.hpp>
-#include <stan/math/prim/scal/err/check_nonnegative.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/err/check_positive_finite.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/fun/log1m.hpp>
-#include <stan/math/prim/scal/meta/VectorView.hpp>
-#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <cmath>
+#include <stan/math/prim/scal/prob/pareto_type_2_lcdf.hpp>
 
 namespace stan {
   namespace math {
 
+    /**
+     * @deprecated use <code>pareto_type_2_lcdf</code>
+     */
     template <typename T_y, typename T_loc, typename T_scale, typename T_shape>
     typename return_type<T_y, T_loc, T_scale, T_shape>::type
     pareto_type_2_cdf_log(const T_y& y, const T_loc& mu,
                           const T_scale& lambda, const T_shape& alpha) {
-      typedef
-        typename stan::partials_return_type<T_y, T_loc, T_scale, T_shape>::type
-        T_partials_return;
-
-      if ( !( stan::length(y)
-              && stan::length(mu)
-              && stan::length(lambda)
-              && stan::length(alpha) ) )
-        return 0.0;
-
-      static const char* function("pareto_type_2_cdf_log");
-
-      using std::log;
-
-      T_partials_return P(0.0);
-
-      check_greater_or_equal(function, "Random variable", y, mu);
-      check_not_nan(function, "Random variable", y);
-      check_nonnegative(function, "Random variable", y);
-      check_positive_finite(function, "Scale parameter", lambda);
-      check_positive_finite(function, "Shape parameter", alpha);
-      check_consistent_sizes(function,
-                             "Random variable", y,
-                             "Scale parameter", lambda,
-                             "Shape parameter", alpha);
-
-      VectorView<const T_y> y_vec(y);
-      VectorView<const T_loc> mu_vec(mu);
-      VectorView<const T_scale> lambda_vec(lambda);
-      VectorView<const T_shape> alpha_vec(alpha);
-      size_t N = max_size(y, mu, lambda, alpha);
-
-      OperandsAndPartials<T_y, T_loc, T_scale, T_shape>
-        operands_and_partials(y, mu, lambda, alpha);
-
-      VectorBuilder<true, T_partials_return,
-                    T_y, T_loc, T_scale, T_shape>
-        cdf_log(N);
-
-      VectorBuilder<true, T_partials_return,
-                    T_y, T_loc, T_scale, T_shape>
-        inv_p1_pow_alpha_minus_one(N);
-
-      VectorBuilder<!is_constant_struct<T_shape>::value,
-                    T_partials_return, T_y, T_loc, T_scale, T_shape>
-        log_1p_y_over_lambda(N);
-
-      for (size_t i = 0; i < N; i++) {
-        const T_partials_return temp = 1.0 + (value_of(y_vec[i])
-                                              - value_of(mu_vec[i]))
-          / value_of(lambda_vec[i]);
-        const T_partials_return p1_pow_alpha
-          = pow(temp, value_of(alpha_vec[i]));
-        cdf_log[i] = log1m(1.0 / p1_pow_alpha);
-
-        inv_p1_pow_alpha_minus_one[i] = 1.0 / (p1_pow_alpha - 1.0);
-
-        if (!is_constant_struct<T_shape>::value)
-          log_1p_y_over_lambda[i] = log(temp);
-      }
-
-      for (size_t n = 0; n < N; n++) {
-        const T_partials_return y_dbl = value_of(y_vec[n]);
-        const T_partials_return mu_dbl = value_of(mu_vec[n]);
-        const T_partials_return lambda_dbl = value_of(lambda_vec[n]);
-        const T_partials_return alpha_dbl = value_of(alpha_vec[n]);
-
-        const T_partials_return grad_1_2 =  alpha_dbl
-          * inv_p1_pow_alpha_minus_one[n] / (lambda_dbl - mu_dbl + y_dbl);
-
-        P += cdf_log[n];
-
-        if (!is_constant_struct<T_y>::value)
-          operands_and_partials.d_x1[n] += grad_1_2;
-        if (!is_constant_struct<T_loc>::value)
-          operands_and_partials.d_x2[n] -= grad_1_2;
-        if (!is_constant_struct<T_scale>::value)
-          operands_and_partials.d_x3[n] += (mu_dbl - y_dbl) * grad_1_2
-            / lambda_dbl;
-        if (!is_constant_struct<T_shape>::value)
-          operands_and_partials.d_x4[n] += log_1p_y_over_lambda[n]
-            * inv_p1_pow_alpha_minus_one[n];
-      }
-      return operands_and_partials.value(P);
+      return pareto_type_2_lcdf<T_y, T_loc,
+                                T_scale, T_shape>(y, mu, lambda, alpha);
     }
 
   }

--- a/stan/math/prim/scal/prob/pareto_type_2_log.hpp
+++ b/stan/math/prim/scal/prob/pareto_type_2_log.hpp
@@ -1,138 +1,34 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_PARETO_TYPE_2_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_PARETO_TYPE_2_LOG_HPP
 
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_finite.hpp>
-#include <stan/math/prim/scal/err/check_greater_or_equal.hpp>
-#include <stan/math/prim/scal/err/check_nonnegative.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/err/check_positive_finite.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/fun/log1m.hpp>
-#include <stan/math/prim/scal/meta/VectorView.hpp>
-#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <cmath>
+#include <stan/math/prim/scal/prob/pareto_type_2_lpdf.hpp>
 
 namespace stan {
   namespace math {
 
-    // pareto_type_2(y|lambda, alpha)  [y >= 0;  lambda > 0;  alpha > 0]
+    /**
+     * @deprecated use <code>pareto_type_2_lpdf</code>
+     */
     template <bool propto,
               typename T_y, typename T_loc, typename T_scale, typename T_shape>
     typename return_type<T_y, T_loc, T_scale, T_shape>::type
     pareto_type_2_log(const T_y& y, const T_loc& mu, const T_scale& lambda,
                       const T_shape& alpha) {
-      static const char* function("pareto_type_2_log");
-      typedef
-        typename stan::partials_return_type<T_y, T_loc, T_scale, T_shape>::type
-        T_partials_return;
-
-      using std::log;
-      using std::log;
-
-      if (!(stan::length(y)
-            && stan::length(mu)
-            && stan::length(lambda)
-            && stan::length(alpha)))
-        return 0.0;
-
-      T_partials_return logp(0.0);
-
-      check_greater_or_equal(function, "Random variable", y, mu);
-      check_not_nan(function, "Random variable", y);
-      check_positive_finite(function, "Scale parameter", lambda);
-      check_positive_finite(function, "Shape parameter", alpha);
-      check_consistent_sizes(function,
-                             "Random variable", y,
-                             "Scale parameter", lambda,
-                             "Shape parameter", alpha);
-
-      if (!include_summand<propto, T_y, T_loc, T_scale, T_shape>::value)
-        return 0.0;
-
-      VectorView<const T_y> y_vec(y);
-      VectorView<const T_loc> mu_vec(mu);
-      VectorView<const T_scale> lambda_vec(lambda);
-      VectorView<const T_shape> alpha_vec(alpha);
-      size_t N = max_size(y, mu, lambda, alpha);
-
-      OperandsAndPartials<T_y, T_loc, T_scale, T_shape>
-        operands_and_partials(y, mu, lambda, alpha);
-
-      VectorBuilder<include_summand<propto, T_y, T_loc, T_scale, T_shape>
-                    ::value,
-                    T_partials_return, T_y, T_loc, T_scale>
-        log1p_scaled_diff(N);
-      if (include_summand<propto, T_y, T_loc, T_scale, T_shape>::value) {
-        for (size_t n = 0; n < N; n++)
-          log1p_scaled_diff[n] = log1p((value_of(y_vec[n])
-                                        - value_of(mu_vec[n]))
-                                       / value_of(lambda_vec[n]));
-      }
-
-      VectorBuilder<include_summand<propto, T_scale>::value,
-                    T_partials_return, T_scale> log_lambda(length(lambda));
-      if (include_summand<propto, T_scale>::value) {
-        for (size_t n = 0; n < length(lambda); n++)
-          log_lambda[n] = log(value_of(lambda_vec[n]));
-      }
-
-      VectorBuilder<include_summand<propto, T_shape>::value,
-                    T_partials_return, T_shape> log_alpha(length(alpha));
-      if (include_summand<propto, T_shape>::value) {
-        for (size_t n = 0; n < length(alpha); n++)
-          log_alpha[n] = log(value_of(alpha_vec[n]));
-      }
-
-      VectorBuilder<!is_constant_struct<T_shape>::value,
-                    T_partials_return, T_shape> inv_alpha(length(alpha));
-      if (!is_constant_struct<T_shape>::value) {
-        for (size_t n = 0; n < length(alpha); n++)
-          inv_alpha[n] = 1 / value_of(alpha_vec[n]);
-      }
-
-      for (size_t n = 0; n < N; n++) {
-        const T_partials_return y_dbl = value_of(y_vec[n]);
-        const T_partials_return mu_dbl = value_of(mu_vec[n]);
-        const T_partials_return lambda_dbl = value_of(lambda_vec[n]);
-        const T_partials_return alpha_dbl = value_of(alpha_vec[n]);
-        const T_partials_return sum_dbl = lambda_dbl + y_dbl - mu_dbl;
-        const T_partials_return inv_sum = 1.0 / sum_dbl;
-        const T_partials_return alpha_div_sum = alpha_dbl / sum_dbl;
-        const T_partials_return deriv_1_2 = inv_sum + alpha_div_sum;
-
-        if (include_summand<propto, T_shape>::value)
-          logp += log_alpha[n];
-        if (include_summand<propto, T_scale>::value)
-          logp -= log_lambda[n];
-        if (include_summand<propto, T_y, T_scale, T_shape>::value)
-          logp -= (alpha_dbl + 1.0) * log1p_scaled_diff[n];
-
-        if (!is_constant_struct<T_y>::value)
-          operands_and_partials.d_x1[n] -= deriv_1_2;
-        if (!is_constant_struct<T_loc>::value)
-          operands_and_partials.d_x2[n] += deriv_1_2;
-        if (!is_constant_struct<T_scale>::value)
-          operands_and_partials.d_x3[n] -= alpha_div_sum * (mu_dbl - y_dbl)
-            / lambda_dbl + inv_sum;
-        if (!is_constant_struct<T_shape>::value)
-          operands_and_partials.d_x4[n] += inv_alpha[n] - log1p_scaled_diff[n];
-      }
-      return operands_and_partials.value(logp);
+      return pareto_type_2_lpdf<propto, T_y, T_loc,
+                                T_scale, T_shape>(y, mu, lambda, alpha);
     }
 
+    /**
+     * @deprecated use <code>pareto_type_2_lpdf</code>
+     */
     template <typename T_y, typename T_loc, typename T_scale, typename T_shape>
     inline
     typename return_type<T_y, T_loc, T_scale, T_shape>::type
-    pareto_type_2_log(const T_y& y, const T_loc& mu,
+    pareto_type_2_log(
+                      const T_y& y, const T_loc& mu,
                       const T_scale& lambda, const T_shape& alpha) {
-      return pareto_type_2_log<false>(y, mu, lambda, alpha);
+      return pareto_type_2_lpdf<T_y, T_loc,
+                                T_scale, T_shape>(y, mu, lambda, alpha);
     }
 
   }

--- a/stan/math/prim/scal/prob/poisson_ccdf_log.hpp
+++ b/stan/math/prim/scal/prob/poisson_ccdf_log.hpp
@@ -1,79 +1,18 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_POISSON_CCDF_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_POISSON_CCDF_LOG_HPP
 
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_less.hpp>
-#include <stan/math/prim/scal/err/check_nonnegative.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/fun/multiply_log.hpp>
-#include <stan/math/prim/scal/fun/gamma_p.hpp>
-#include <stan/math/prim/scal/fun/gamma_q.hpp>
-#include <stan/math/prim/scal/fun/lgamma.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <boost/random/poisson_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <cmath>
-#include <limits>
+#include <stan/math/prim/scal/prob/poisson_lccdf.hpp>
 
 namespace stan {
   namespace math {
 
+    /**
+     * @deprecated use <code>poisson_lccdf</code>
+     */
     template <typename T_n, typename T_rate>
     typename return_type<T_rate>::type
     poisson_ccdf_log(const T_n& n, const T_rate& lambda) {
-      static const char* function("poisson_ccdf_log");
-      typedef typename stan::partials_return_type<T_n, T_rate>::type
-        T_partials_return;
-
-      if (!(stan::length(n) && stan::length(lambda)))
-        return 0.0;
-
-      T_partials_return P(0.0);
-
-      check_not_nan(function, "Rate parameter", lambda);
-      check_nonnegative(function, "Rate parameter", lambda);
-      check_consistent_sizes(function,
-                             "Random variable", n,
-                             "Rate parameter", lambda);
-
-      VectorView<const T_n> n_vec(n);
-      VectorView<const T_rate> lambda_vec(lambda);
-      size_t size = max_size(n, lambda);
-
-      using std::log;
-      using std::exp;
-
-      OperandsAndPartials<T_rate> operands_and_partials(lambda);
-
-      // Explicit return for extreme values
-      // The gradients are technically ill-defined, but treated as neg infinity
-      for (size_t i = 0; i < stan::length(n); i++) {
-        if (value_of(n_vec[i]) < 0)
-          return operands_and_partials.value(0.0);
-      }
-
-      for (size_t i = 0; i < size; i++) {
-        // Explicit results for extreme values
-        // The gradients are technically ill-defined, but treated as zero
-        if (value_of(n_vec[i]) == std::numeric_limits<int>::max())
-          return operands_and_partials.value(negative_infinity());
-
-        const T_partials_return n_dbl = value_of(n_vec[i]);
-        const T_partials_return lambda_dbl = value_of(lambda_vec[i]);
-        const T_partials_return log_Pi = log(gamma_p(n_dbl+1, lambda_dbl));
-
-        P += log_Pi;
-
-        if (!is_constant_struct<T_rate>::value)
-          operands_and_partials.d_x1[i] += exp(n_dbl * log(lambda_dbl)
-                                               - lambda_dbl - lgamma(n_dbl+1)
-                                               - log_Pi);
-      }
-      return operands_and_partials.value(P);
+      return poisson_lccdf<T_n, T_rate>(n, lambda);
     }
 
   }

--- a/stan/math/prim/scal/prob/poisson_cdf_log.hpp
+++ b/stan/math/prim/scal/prob/poisson_cdf_log.hpp
@@ -1,78 +1,18 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_POISSON_CDF_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_POISSON_CDF_LOG_HPP
 
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_less.hpp>
-#include <stan/math/prim/scal/err/check_nonnegative.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/fun/multiply_log.hpp>
-#include <stan/math/prim/scal/fun/gamma_q.hpp>
-#include <stan/math/prim/scal/fun/lgamma.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <boost/random/poisson_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <cmath>
-#include <limits>
+#include <stan/math/prim/scal/prob/poisson_lcdf.hpp>
 
 namespace stan {
   namespace math {
 
+    /**
+     * @deprecated use <code>poisson_lcdf</code>
+     */
     template <typename T_n, typename T_rate>
     typename return_type<T_rate>::type
     poisson_cdf_log(const T_n& n, const T_rate& lambda) {
-      static const char* function("poisson_cdf_log");
-      typedef typename stan::partials_return_type<T_n, T_rate>::type
-        T_partials_return;
-
-      if (!(stan::length(n) && stan::length(lambda)))
-        return 0.0;
-
-      T_partials_return P(0.0);
-
-      check_not_nan(function, "Rate parameter", lambda);
-      check_nonnegative(function, "Rate parameter", lambda);
-      check_consistent_sizes(function,
-                             "Random variable", n,
-                             "Rate parameter", lambda);
-
-      VectorView<const T_n> n_vec(n);
-      VectorView<const T_rate> lambda_vec(lambda);
-      size_t size = max_size(n, lambda);
-
-      using std::log;
-      using std::exp;
-
-      OperandsAndPartials<T_rate> operands_and_partials(lambda);
-
-      // Explicit return for extreme values
-      // The gradients are technically ill-defined, but treated as neg infinity
-      for (size_t i = 0; i < stan::length(n); i++) {
-        if (value_of(n_vec[i]) < 0)
-          return operands_and_partials.value(negative_infinity());
-      }
-
-      for (size_t i = 0; i < size; i++) {
-        // Explicit results for extreme values
-        // The gradients are technically ill-defined, but treated as zero
-        if (value_of(n_vec[i]) == std::numeric_limits<int>::max())
-          continue;
-
-        const T_partials_return n_dbl = value_of(n_vec[i]);
-        const T_partials_return lambda_dbl = value_of(lambda_vec[i]);
-        const T_partials_return log_Pi = log(gamma_q(n_dbl+1, lambda_dbl));
-
-        P += log_Pi;
-
-        if (!is_constant_struct<T_rate>::value)
-          operands_and_partials.d_x1[i] += - exp(n_dbl * log(lambda_dbl)
-                                                 - lambda_dbl - lgamma(n_dbl+1)
-                                                 - log_Pi);
-      }
-      return operands_and_partials.value(P);
+      return poisson_lcdf<T_n, T_rate>(n, lambda);
     }
 
   }

--- a/stan/math/prim/scal/prob/poisson_log.hpp
+++ b/stan/math/prim/scal/prob/poisson_log.hpp
@@ -1,88 +1,29 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_POISSON_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_POISSON_LOG_HPP
 
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_less.hpp>
-#include <stan/math/prim/scal/err/check_nonnegative.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/fun/is_inf.hpp>
-#include <stan/math/prim/scal/fun/multiply_log.hpp>
-#include <stan/math/prim/scal/fun/gamma_q.hpp>
-#include <stan/math/prim/scal/fun/lgamma.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <stan/math/prim/scal/meta/VectorView.hpp>
-#include <boost/random/poisson_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <limits>
+#include <stan/math/prim/scal/prob/poisson_lpmf.hpp>
 
 namespace stan {
   namespace math {
 
-    // Poisson(n|lambda)  [lambda > 0;  n >= 0]
+    /**
+     * @deprecated use <code>poisson_lpmf</code>
+     */
     template <bool propto, typename T_n, typename T_rate>
     typename return_type<T_rate>::type
     poisson_log(const T_n& n, const T_rate& lambda) {
-      typedef typename stan::partials_return_type<T_n, T_rate>::type
-        T_partials_return;
-
-      static const char* function("poisson_log");
-
-      if (!(stan::length(n)
-            && stan::length(lambda)))
-        return 0.0;
-
-      T_partials_return logp(0.0);
-
-      check_nonnegative(function, "Random variable", n);
-      check_not_nan(function, "Rate parameter", lambda);
-      check_nonnegative(function, "Rate parameter", lambda);
-      check_consistent_sizes(function,
-                             "Random variable", n,
-                             "Rate parameter", lambda);
-
-      if (!include_summand<propto, T_rate>::value)
-        return 0.0;
-
-      VectorView<const T_n> n_vec(n);
-      VectorView<const T_rate> lambda_vec(lambda);
-      size_t size = max_size(n, lambda);
-
-      for (size_t i = 0; i < size; i++)
-        if (is_inf(lambda_vec[i]))
-          return LOG_ZERO;
-      for (size_t i = 0; i < size; i++)
-        if (lambda_vec[i] == 0 && n_vec[i] != 0)
-          return LOG_ZERO;
-
-      OperandsAndPartials<T_rate> operands_and_partials(lambda);
-
-      for (size_t i = 0; i < size; i++) {
-        if (!(lambda_vec[i] == 0 && n_vec[i] == 0)) {
-          if (include_summand<propto>::value)
-            logp -= lgamma(n_vec[i] + 1.0);
-          if (include_summand<propto, T_rate>::value)
-            logp += multiply_log(n_vec[i], value_of(lambda_vec[i]))
-              - value_of(lambda_vec[i]);
-        }
-
-        if (!is_constant_struct<T_rate>::value)
-          operands_and_partials.d_x1[i]
-            += n_vec[i] / value_of(lambda_vec[i]) - 1.0;
-      }
-      return operands_and_partials.value(logp);
+      return poisson_lpmf<propto, T_n, T_rate>(n, lambda);
     }
 
+    /**
+     * @deprecated use <code>poisson_lpmf</code>
+     */
     template <typename T_n,
               typename T_rate>
     inline
     typename return_type<T_rate>::type
     poisson_log(const T_n& n, const T_rate& lambda) {
-      return poisson_log<false>(n, lambda);
+      return poisson_lpmf<T_n, T_rate>(n, lambda);
     }
 
   }

--- a/stan/math/prim/scal/prob/poisson_log_log.hpp
+++ b/stan/math/prim/scal/prob/poisson_log_log.hpp
@@ -1,100 +1,30 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_POISSON_LOG_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_POISSON_LOG_LOG_HPP
 
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_less.hpp>
-#include <stan/math/prim/scal/err/check_nonnegative.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/fun/multiply_log.hpp>
-#include <stan/math/prim/scal/fun/gamma_q.hpp>
-#include <stan/math/prim/scal/fun/lgamma.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <stan/math/prim/scal/meta/VectorView.hpp>
-#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
-#include <boost/random/poisson_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <cmath>
-#include <limits>
+#include <stan/math/prim/scal/prob/poisson_log_lpmf.hpp>
 
 namespace stan {
   namespace math {
 
-    // PoissonLog(n|alpha)  [n >= 0]   = Poisson(n|exp(alpha))
+    /**
+     * @deprecated use <code>poisson_log_lpmf</code>
+     */
     template <bool propto,
               typename T_n, typename T_log_rate>
     typename return_type<T_log_rate>::type
     poisson_log_log(const T_n& n, const T_log_rate& alpha) {
-      typedef typename stan::partials_return_type<T_n, T_log_rate>::type
-        T_partials_return;
-
-      static const char* function("poisson_log_log");
-
-      using std::exp;
-
-      if (!(stan::length(n)
-            && stan::length(alpha)))
-        return 0.0;
-
-      T_partials_return logp(0.0);
-
-      check_nonnegative(function, "Random variable", n);
-      check_not_nan(function, "Log rate parameter", alpha);
-      check_consistent_sizes(function,
-                             "Random variable", n,
-                             "Log rate parameter", alpha);
-
-      if (!include_summand<propto, T_log_rate>::value)
-        return 0.0;
-
-      VectorView<const T_n> n_vec(n);
-      VectorView<const T_log_rate> alpha_vec(alpha);
-      size_t size = max_size(n, alpha);
-
-      // FIXME: first loop size of alpha_vec, second loop if-ed for size==1
-      for (size_t i = 0; i < size; i++)
-        if (std::numeric_limits<double>::infinity() == alpha_vec[i])
-          return LOG_ZERO;
-      for (size_t i = 0; i < size; i++)
-        if (-std::numeric_limits<double>::infinity() == alpha_vec[i]
-            && n_vec[i] != 0)
-          return LOG_ZERO;
-
-      OperandsAndPartials<T_log_rate> operands_and_partials(alpha);
-
-      // FIXME: cache value_of for alpha_vec?  faster if only one?
-      VectorBuilder<include_summand<propto, T_log_rate>::value,
-                    T_partials_return, T_log_rate>
-        exp_alpha(length(alpha));
-      for (size_t i = 0; i < length(alpha); i++)
-        if (include_summand<propto, T_log_rate>::value)
-          exp_alpha[i] = exp(value_of(alpha_vec[i]));
-
-      for (size_t i = 0; i < size; i++) {
-        if (!(alpha_vec[i] == -std::numeric_limits<double>::infinity()
-              && n_vec[i] == 0)) {
-          if (include_summand<propto>::value)
-            logp -= lgamma(n_vec[i] + 1.0);
-          if (include_summand<propto, T_log_rate>::value)
-            logp += n_vec[i] * value_of(alpha_vec[i]) - exp_alpha[i];
-        }
-
-        if (!is_constant_struct<T_log_rate>::value)
-          operands_and_partials.d_x1[i] += n_vec[i] - exp_alpha[i];
-      }
-      return operands_and_partials.value(logp);
+      return poisson_log_lpmf<propto, T_n, T_log_rate>(n, alpha);
     }
 
+    /**
+     * @deprecated use <code>poisson_log_lpmf</code>
+     */
     template <typename T_n,
               typename T_log_rate>
     inline
     typename return_type<T_log_rate>::type
     poisson_log_log(const T_n& n, const T_log_rate& alpha) {
-      return poisson_log_log<false>(n, alpha);
+      return poisson_log_lpmf<T_n, T_log_rate>(n, alpha);
     }
 
   }

--- a/stan/math/prim/scal/prob/rayleigh_ccdf_log.hpp
+++ b/stan/math/prim/scal/prob/rayleigh_ccdf_log.hpp
@@ -1,74 +1,18 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_RAYLEIGH_CCDF_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_RAYLEIGH_CCDF_LOG_HPP
 
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_nonnegative.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/err/check_positive.hpp>
-#include <stan/math/prim/scal/fun/log1m.hpp>
-#include <stan/math/prim/scal/fun/square.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/meta/length.hpp>
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
-#include <boost/random/uniform_real_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
+#include <stan/math/prim/scal/prob/rayleigh_lccdf.hpp>
 
 namespace stan {
   namespace math {
 
+    /**
+     * @deprecated use <code>rayleigh_lccdf</code>
+     */
     template <typename T_y, typename T_scale>
     typename return_type<T_y, T_scale>::type
     rayleigh_ccdf_log(const T_y& y, const T_scale& sigma) {
-      static const char* function("rayleigh_ccdf_log");
-      typedef typename stan::partials_return_type<T_y, T_scale>::type
-        T_partials_return;
-
-      using stan::is_constant_struct;
-
-      T_partials_return ccdf_log(0.0);
-
-      if (!(stan::length(y) && stan::length(sigma)))
-        return ccdf_log;
-
-      check_not_nan(function, "Random variable", y);
-      check_nonnegative(function, "Random variable", y);
-      check_not_nan(function, "Scale parameter", sigma);
-      check_positive(function, "Scale parameter", sigma);
-      check_consistent_sizes(function,
-                             "Random variable", y,
-                             "Scale parameter", sigma);
-
-      OperandsAndPartials<T_y, T_scale> operands_and_partials(y, sigma);
-
-      VectorView<const T_y> y_vec(y);
-      VectorView<const T_scale> sigma_vec(sigma);
-      size_t N = max_size(y, sigma);
-
-      VectorBuilder<true, T_partials_return, T_scale> inv_sigma(length(sigma));
-      for (size_t i = 0; i < length(sigma); i++) {
-        inv_sigma[i] = 1.0 / value_of(sigma_vec[i]);
-      }
-
-      for (size_t n = 0; n < N; n++) {
-        const T_partials_return y_dbl = value_of(y_vec[n]);
-        const T_partials_return y_sqr = y_dbl * y_dbl;
-        const T_partials_return inv_sigma_sqr = inv_sigma[n] * inv_sigma[n];
-
-        if (include_summand<false, T_y, T_scale>::value)
-          ccdf_log += -0.5 * y_sqr * inv_sigma_sqr;
-
-        if (!is_constant_struct<T_y>::value)
-          operands_and_partials.d_x1[n] -= y_dbl * inv_sigma_sqr;
-        if (!is_constant_struct<T_scale>::value)
-          operands_and_partials.d_x2[n] += y_sqr * inv_sigma_sqr
-            * inv_sigma[n];
-      }
-      return operands_and_partials.value(ccdf_log);
+      return rayleigh_lccdf<T_y, T_scale>(y, sigma);
     }
 
   }

--- a/stan/math/prim/scal/prob/rayleigh_cdf_log.hpp
+++ b/stan/math/prim/scal/prob/rayleigh_cdf_log.hpp
@@ -1,79 +1,18 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_RAYLEIGH_CDF_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_RAYLEIGH_CDF_LOG_HPP
 
-#include <boost/random/uniform_real_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_nonnegative.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/err/check_positive.hpp>
-#include <stan/math/prim/scal/fun/log1m.hpp>
-#include <stan/math/prim/scal/fun/square.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/meta/length.hpp>
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
-#include <cmath>
+#include <stan/math/prim/scal/prob/rayleigh_lcdf.hpp>
 
 namespace stan {
   namespace math {
 
+    /**
+     * @deprecated use <code>rayleigh_lcdf</code>
+     */
     template <typename T_y, typename T_scale>
     typename return_type<T_y, T_scale>::type
     rayleigh_cdf_log(const T_y& y, const T_scale& sigma) {
-      static const char* function("rayleigh_cdf_log");
-      typedef typename stan::partials_return_type<T_y, T_scale>::type
-        T_partials_return;
-
-      using stan::is_constant_struct;
-      using std::exp;
-
-      T_partials_return cdf_log(0.0);
-
-      if (!(stan::length(y) && stan::length(sigma)))
-        return cdf_log;
-
-      check_not_nan(function, "Random variable", y);
-      check_nonnegative(function, "Random variable", y);
-      check_not_nan(function, "Scale parameter", sigma);
-      check_positive(function, "Scale parameter", sigma);
-      check_consistent_sizes(function,
-                             "Random variable", y,
-                             "Scale parameter", sigma);
-
-      OperandsAndPartials<T_y, T_scale> operands_and_partials(y, sigma);
-
-      VectorView<const T_y> y_vec(y);
-      VectorView<const T_scale> sigma_vec(sigma);
-      size_t N = max_size(y, sigma);
-
-      VectorBuilder<true, T_partials_return, T_scale> inv_sigma(length(sigma));
-      for (size_t i = 0; i < length(sigma); i++) {
-        inv_sigma[i] = 1.0 / value_of(sigma_vec[i]);
-      }
-
-      for (size_t n = 0; n < N; n++) {
-        const T_partials_return y_dbl = value_of(y_vec[n]);
-        const T_partials_return y_sqr = y_dbl * y_dbl;
-        const T_partials_return inv_sigma_sqr = inv_sigma[n] * inv_sigma[n];
-        const T_partials_return exp_val = exp(-0.5 * y_sqr * inv_sigma_sqr);
-        const T_partials_return exp_div_1m_exp = exp_val / (1.0 - exp_val);
-
-        if (include_summand<false, T_y, T_scale>::value)
-          cdf_log += log1m(exp_val);
-
-        if (!is_constant_struct<T_y>::value)
-          operands_and_partials.d_x1[n] += y_dbl * inv_sigma_sqr
-            * exp_div_1m_exp;
-        if (!is_constant_struct<T_scale>::value)
-          operands_and_partials.d_x2[n] -= y_sqr * inv_sigma_sqr
-            * inv_sigma[n] * exp_div_1m_exp;
-      }
-      return operands_and_partials.value(cdf_log);
+      return rayleigh_lcdf<T_y, T_scale>(y, sigma);
     }
 
   }

--- a/stan/math/prim/scal/prob/rayleigh_log.hpp
+++ b/stan/math/prim/scal/prob/rayleigh_log.hpp
@@ -1,95 +1,29 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_RAYLEIGH_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_RAYLEIGH_LOG_HPP
 
-#include <boost/random/uniform_real_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_nonnegative.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/err/check_positive.hpp>
-#include <stan/math/prim/scal/fun/log1m.hpp>
-#include <stan/math/prim/scal/fun/square.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/meta/length.hpp>
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
-#include <cmath>
+#include <stan/math/prim/scal/prob/rayleigh_lpdf.hpp>
 
 namespace stan {
   namespace math {
 
+    /**
+     * @deprecated use <code>rayleigh_lpdf</code>
+     */
     template <bool propto,
               typename T_y, typename T_scale>
     typename return_type<T_y, T_scale>::type
     rayleigh_log(const T_y& y, const T_scale& sigma) {
-      static const char* function("rayleigh_log");
-      typedef typename stan::partials_return_type<T_y, T_scale>::type
-        T_partials_return;
-
-      using std::log;
-      using stan::is_constant_struct;
-      using std::log;
-
-      if (!(stan::length(y) && stan::length(sigma)))
-        return 0.0;
-
-      T_partials_return logp(0.0);
-
-      check_not_nan(function, "Random variable", y);
-      check_positive(function, "Scale parameter", sigma);
-      check_positive(function, "Random variable", y);
-      check_consistent_sizes(function,
-                             "Random variable", y,
-                             "Scale parameter", sigma);
-
-      if (!include_summand<propto, T_y, T_scale>::value)
-        return 0.0;
-
-      OperandsAndPartials<T_y, T_scale> operands_and_partials(y, sigma);
-
-      VectorView<const T_y> y_vec(y);
-      VectorView<const T_scale> sigma_vec(sigma);
-      size_t N = max_size(y, sigma);
-
-      VectorBuilder<true, T_partials_return, T_scale> inv_sigma(length(sigma));
-      VectorBuilder<include_summand<propto, T_scale>::value,
-                    T_partials_return, T_scale> log_sigma(length(sigma));
-      for (size_t i = 0; i < length(sigma); i++) {
-        inv_sigma[i] = 1.0 / value_of(sigma_vec[i]);
-        if (include_summand<propto, T_scale>::value)
-          log_sigma[i] = log(value_of(sigma_vec[i]));
-      }
-
-      for (size_t n = 0; n < N; n++) {
-        const T_partials_return y_dbl = value_of(y_vec[n]);
-        const T_partials_return y_over_sigma = y_dbl * inv_sigma[n];
-        static double NEGATIVE_HALF = -0.5;
-
-        if (include_summand<propto, T_scale>::value)
-          logp -= 2.0 * log_sigma[n];
-        if (include_summand<propto, T_y>::value)
-          logp += log(y_dbl);
-        logp += NEGATIVE_HALF * y_over_sigma * y_over_sigma;
-
-        T_partials_return scaled_diff = inv_sigma[n] * y_over_sigma;
-        if (!is_constant_struct<T_y>::value)
-          operands_and_partials.d_x1[n] += 1.0 / y_dbl - scaled_diff;
-        if (!is_constant_struct<T_scale>::value)
-          operands_and_partials.d_x2[n]
-            += y_over_sigma * scaled_diff - 2.0 * inv_sigma[n];
-      }
-      return operands_and_partials.value(logp);
+      return rayleigh_lpdf<propto, T_y, T_scale>(y, sigma);
     }
 
+    /**
+     * @deprecated use <code>rayleigh_lpdf</code>
+     */
     template <typename T_y, typename T_scale>
     inline
     typename return_type<T_y, T_scale>::type
     rayleigh_log(const T_y& y, const T_scale& sigma) {
-      return rayleigh_log<false>(y, sigma);
+      return rayleigh_lpdf<T_y, T_scale>(y, sigma);
     }
 
   }

--- a/stan/math/prim/scal/prob/scaled_inv_chi_square_ccdf_log.hpp
+++ b/stan/math/prim/scal/prob/scaled_inv_chi_square_ccdf_log.hpp
@@ -1,129 +1,19 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_SCALED_INV_CHI_SQUARE_CCDF_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_SCALED_INV_CHI_SQUARE_CCDF_LOG_HPP
 
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_nonnegative.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/err/check_positive_finite.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/fun/gamma_p.hpp>
-#include <stan/math/prim/scal/fun/digamma.hpp>
-#include <stan/math/prim/scal/fun/lgamma.hpp>
-#include <stan/math/prim/scal/fun/square.hpp>
-#include <stan/math/prim/scal/fun/tgamma.hpp>
-#include <stan/math/prim/scal/meta/VectorView.hpp>
-#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
-#include <stan/math/prim/scal/meta/length.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <stan/math/prim/scal/fun/grad_reg_inc_gamma.hpp>
-#include <boost/random/chi_squared_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <limits>
-#include <cmath>
+#include <stan/math/prim/scal/prob/scaled_inv_chi_square_lccdf.hpp>
 
 namespace stan {
   namespace math {
 
+    /**
+     * @deprecated use <code>scaled_inv_chi_square_lccdf</code>
+     */
     template <typename T_y, typename T_dof, typename T_scale>
     typename return_type<T_y, T_dof, T_scale>::type
     scaled_inv_chi_square_ccdf_log(const T_y& y, const T_dof& nu,
                                    const T_scale& s) {
-      typedef typename stan::partials_return_type<T_y, T_dof, T_scale>::type
-        T_partials_return;
-
-      if (!(stan::length(y) && stan::length(nu) && stan::length(s)))
-        return 0.0;
-
-      static const char* function("scaled_inv_chi_square_ccdf_log");
-
-      using std::exp;
-
-      T_partials_return P(0.0);
-
-      check_not_nan(function, "Random variable", y);
-      check_nonnegative(function, "Random variable", y);
-      check_positive_finite(function, "Degrees of freedom parameter", nu);
-      check_positive_finite(function, "Scale parameter", s);
-      check_consistent_sizes(function,
-                             "Random variable", y,
-                             "Degrees of freedom parameter", nu,
-                             "Scale parameter", s);
-
-      VectorView<const T_y> y_vec(y);
-      VectorView<const T_dof> nu_vec(nu);
-      VectorView<const T_scale> s_vec(s);
-      size_t N = max_size(y, nu, s);
-
-      OperandsAndPartials<T_y, T_dof, T_scale>
-        operands_and_partials(y, nu, s);
-
-      // Explicit return for extreme values
-      // The gradients are technically ill-defined, but treated as zero
-      for (size_t i = 0; i < stan::length(y); i++) {
-        if (value_of(y_vec[i]) == 0)
-          return operands_and_partials.value(0.0);
-      }
-
-      using std::exp;
-      using std::pow;
-      using std::log;
-
-      VectorBuilder<!is_constant_struct<T_dof>::value,
-                    T_partials_return, T_dof> gamma_vec(stan::length(nu));
-      VectorBuilder<!is_constant_struct<T_dof>::value,
-                    T_partials_return, T_dof> digamma_vec(stan::length(nu));
-
-      if (!is_constant_struct<T_dof>::value) {
-        for (size_t i = 0; i < stan::length(nu); i++) {
-          const T_partials_return half_nu_dbl = 0.5 * value_of(nu_vec[i]);
-          gamma_vec[i] = tgamma(half_nu_dbl);
-          digamma_vec[i] = digamma(half_nu_dbl);
-        }
-      }
-
-      for (size_t n = 0; n < N; n++) {
-        // Explicit results for extreme values
-        // The gradients are technically ill-defined, but treated as zero
-        if (value_of(y_vec[n]) == std::numeric_limits<double>::infinity()) {
-          return operands_and_partials.value(negative_infinity());
-        }
-
-        const T_partials_return y_dbl = value_of(y_vec[n]);
-        const T_partials_return y_inv_dbl = 1.0 / y_dbl;
-        const T_partials_return half_nu_dbl = 0.5 * value_of(nu_vec[n]);
-        const T_partials_return s_dbl = value_of(s_vec[n]);
-        const T_partials_return half_s2_overx_dbl = 0.5 * s_dbl * s_dbl
-          * y_inv_dbl;
-        const T_partials_return half_nu_s2_overx_dbl
-          = 2.0 * half_nu_dbl * half_s2_overx_dbl;
-
-        const T_partials_return Pn = gamma_p(half_nu_dbl,
-                                             half_nu_s2_overx_dbl);
-        const T_partials_return gamma_p_deriv = exp(-half_nu_s2_overx_dbl)
-          * pow(half_nu_s2_overx_dbl, half_nu_dbl-1) / tgamma(half_nu_dbl);
-
-        P += log(Pn);
-
-        if (!is_constant_struct<T_y>::value)
-          operands_and_partials.d_x1[n] -= half_nu_s2_overx_dbl * y_inv_dbl
-            * gamma_p_deriv / Pn;
-        if (!is_constant_struct<T_dof>::value)
-          operands_and_partials.d_x2[n]
-            -= (0.5 * grad_reg_inc_gamma(half_nu_dbl,
-                                         half_nu_s2_overx_dbl,
-                                         gamma_vec[n],
-                                         digamma_vec[n])
-                - half_s2_overx_dbl * gamma_p_deriv)
-            / Pn;
-        if (!is_constant_struct<T_scale>::value)
-          operands_and_partials.d_x3[n] += 2.0 * half_nu_dbl * s_dbl * y_inv_dbl
-            * gamma_p_deriv / Pn;
-      }
-      return operands_and_partials.value(P);
+      return scaled_inv_chi_square_lccdf<T_y, T_dof, T_scale>(y, nu, s);
     }
 
   }

--- a/stan/math/prim/scal/prob/scaled_inv_chi_square_cdf_log.hpp
+++ b/stan/math/prim/scal/prob/scaled_inv_chi_square_cdf_log.hpp
@@ -1,128 +1,19 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_SCALED_INV_CHI_SQUARE_CDF_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_SCALED_INV_CHI_SQUARE_CDF_LOG_HPP
 
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_nonnegative.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/err/check_positive_finite.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/fun/gamma_q.hpp>
-#include <stan/math/prim/scal/fun/digamma.hpp>
-#include <stan/math/prim/scal/fun/lgamma.hpp>
-#include <stan/math/prim/scal/fun/square.hpp>
-#include <stan/math/prim/scal/fun/tgamma.hpp>
-#include <stan/math/prim/scal/meta/VectorView.hpp>
-#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
-#include <stan/math/prim/scal/meta/length.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <stan/math/prim/scal/fun/grad_reg_inc_gamma.hpp>
-#include <boost/random/chi_squared_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <limits>
-#include <cmath>
+#include <stan/math/prim/scal/prob/scaled_inv_chi_square_lcdf.hpp>
 
 namespace stan {
   namespace math {
 
+    /**
+     * @deprecated use <code>scaled_inv_chi_square_lcdf</code>
+     */
     template <typename T_y, typename T_dof, typename T_scale>
     typename return_type<T_y, T_dof, T_scale>::type
     scaled_inv_chi_square_cdf_log(const T_y& y, const T_dof& nu,
                                   const T_scale& s) {
-      typedef typename stan::partials_return_type<T_y, T_dof, T_scale>::type
-        T_partials_return;
-
-      if (!(stan::length(y) && stan::length(nu) && stan::length(s)))
-        return 0.0;
-
-      static const char* function("scaled_inv_chi_square_cdf_log");
-
-      using std::exp;
-
-      T_partials_return P(0.0);
-
-      check_not_nan(function, "Random variable", y);
-      check_nonnegative(function, "Random variable", y);
-      check_positive_finite(function, "Degrees of freedom parameter", nu);
-      check_positive_finite(function, "Scale parameter", s);
-      check_consistent_sizes(function,
-                             "Random variable", y,
-                             "Degrees of freedom parameter", nu,
-                             "Scale parameter", s);
-
-      VectorView<const T_y> y_vec(y);
-      VectorView<const T_dof> nu_vec(nu);
-      VectorView<const T_scale> s_vec(s);
-      size_t N = max_size(y, nu, s);
-
-      OperandsAndPartials<T_y, T_dof, T_scale>
-        operands_and_partials(y, nu, s);
-
-      // Explicit return for extreme values
-      // The gradients are technically ill-defined, but treated as zero
-      for (size_t i = 0; i < stan::length(y); i++) {
-        if (value_of(y_vec[i]) == 0)
-          return operands_and_partials.value(negative_infinity());
-      }
-
-      using std::exp;
-      using std::pow;
-      using std::log;
-
-      VectorBuilder<!is_constant_struct<T_dof>::value,
-                    T_partials_return, T_dof> gamma_vec(stan::length(nu));
-      VectorBuilder<!is_constant_struct<T_dof>::value,
-                    T_partials_return, T_dof> digamma_vec(stan::length(nu));
-
-      if (!is_constant_struct<T_dof>::value) {
-        for (size_t i = 0; i < stan::length(nu); i++) {
-          const T_partials_return half_nu_dbl = 0.5 * value_of(nu_vec[i]);
-          gamma_vec[i] = tgamma(half_nu_dbl);
-          digamma_vec[i] = digamma(half_nu_dbl);
-        }
-      }
-
-      for (size_t n = 0; n < N; n++) {
-        // Explicit results for extreme values
-        // The gradients are technically ill-defined, but treated as zero
-        if (value_of(y_vec[n]) == std::numeric_limits<double>::infinity()) {
-          continue;
-        }
-
-        const T_partials_return y_dbl = value_of(y_vec[n]);
-        const T_partials_return y_inv_dbl = 1.0 / y_dbl;
-        const T_partials_return half_nu_dbl = 0.5 * value_of(nu_vec[n]);
-        const T_partials_return s_dbl = value_of(s_vec[n]);
-        const T_partials_return half_s2_overx_dbl = 0.5 * s_dbl * s_dbl
-          * y_inv_dbl;
-        const T_partials_return half_nu_s2_overx_dbl
-          = 2.0 * half_nu_dbl * half_s2_overx_dbl;
-
-        const T_partials_return Pn = gamma_q(half_nu_dbl, half_nu_s2_overx_dbl);
-        const T_partials_return gamma_p_deriv = exp(-half_nu_s2_overx_dbl)
-          * pow(half_nu_s2_overx_dbl, half_nu_dbl-1) / tgamma(half_nu_dbl);
-
-        P += log(Pn);
-
-        if (!is_constant_struct<T_y>::value)
-          operands_and_partials.d_x1[n] += half_nu_s2_overx_dbl * y_inv_dbl
-            * gamma_p_deriv / Pn;
-        if (!is_constant_struct<T_dof>::value)
-          operands_and_partials.d_x2[n]
-            += (0.5 * grad_reg_inc_gamma(half_nu_dbl,
-                                         half_nu_s2_overx_dbl,
-                                         gamma_vec[n],
-                                         digamma_vec[n])
-                - half_s2_overx_dbl * gamma_p_deriv)
-            / Pn;
-        if (!is_constant_struct<T_scale>::value)
-          operands_and_partials.d_x3[n] += - 2.0 * half_nu_dbl * s_dbl
-            * y_inv_dbl * gamma_p_deriv / Pn;
-      }
-      return operands_and_partials.value(P);
+      return scaled_inv_chi_square_lcdf<T_y, T_dof, T_scale>(y, nu, s);
     }
 
   }

--- a/stan/math/prim/scal/prob/scaled_inv_chi_square_log.hpp
+++ b/stan/math/prim/scal/prob/scaled_inv_chi_square_log.hpp
@@ -1,27 +1,7 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_SCALED_INV_CHI_SQUARE_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_SCALED_INV_CHI_SQUARE_LOG_HPP
 
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_nonnegative.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/err/check_positive_finite.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/fun/gamma_q.hpp>
-#include <stan/math/prim/scal/fun/digamma.hpp>
-#include <stan/math/prim/scal/fun/lgamma.hpp>
-#include <stan/math/prim/scal/fun/square.hpp>
-#include <stan/math/prim/scal/meta/VectorView.hpp>
-#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
-#include <stan/math/prim/scal/meta/length.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <stan/math/prim/scal/fun/grad_reg_inc_gamma.hpp>
-#include <boost/random/chi_squared_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <cmath>
+#include <stan/math/prim/scal/prob/scaled_inv_chi_square_lpdf.hpp>
 
 namespace stan {
   namespace math {
@@ -36,6 +16,9 @@ namespace stan {
      &=& \frac{\nu}{2} \log(\frac{\nu}{2}) - \log (\Gamma (\nu / 2)) + \nu \log(s) - (\frac{\nu}{2} + 1) \log(y) - \frac{\nu s^2}{2y} \\
      & & \mathrm{ where } \; y > 0
      \f}
+     *
+     * @deprecated use <code>scaled_inv_chi_square_lpdf</code>
+     *
      * @param y A scalar variable.
      * @param nu Degrees of freedom.
      * @param s Scale parameter.
@@ -49,119 +32,17 @@ namespace stan {
               typename T_y, typename T_dof, typename T_scale>
     typename return_type<T_y, T_dof, T_scale>::type
     scaled_inv_chi_square_log(const T_y& y, const T_dof& nu, const T_scale& s) {
-      static const char* function("scaled_inv_chi_square_log");
-      typedef typename stan::partials_return_type<T_y, T_dof, T_scale>::type
-        T_partials_return;
-
-      if (!(stan::length(y)
-            && stan::length(nu)
-            && stan::length(s)))
-        return 0.0;
-
-      T_partials_return logp(0.0);
-      check_not_nan(function, "Random variable", y);
-      check_positive_finite(function, "Degrees of freedom parameter", nu);
-      check_positive_finite(function, "Scale parameter", s);
-      check_consistent_sizes(function,
-                             "Random variable", y,
-                             "Degrees of freedom parameter", nu,
-                             "Scale parameter", s);
-
-      if (!include_summand<propto, T_y, T_dof, T_scale>::value)
-        return 0.0;
-
-      VectorView<const T_y> y_vec(y);
-      VectorView<const T_dof> nu_vec(nu);
-      VectorView<const T_scale> s_vec(s);
-      size_t N = max_size(y, nu, s);
-
-      for (size_t n = 0; n < N; n++) {
-        if (value_of(y_vec[n]) <= 0)
-          return LOG_ZERO;
-      }
-
-      using std::log;
-
-      VectorBuilder<include_summand<propto, T_dof, T_y, T_scale>::value,
-                    T_partials_return, T_dof> half_nu(length(nu));
-      for (size_t i = 0; i < length(nu); i++)
-        if (include_summand<propto, T_dof, T_y, T_scale>::value)
-          half_nu[i] = 0.5 * value_of(nu_vec[i]);
-
-      VectorBuilder<include_summand<propto, T_dof, T_y>::value,
-                    T_partials_return, T_y> log_y(length(y));
-      for (size_t i = 0; i < length(y); i++)
-        if (include_summand<propto, T_dof, T_y>::value)
-          log_y[i] = log(value_of(y_vec[i]));
-
-      VectorBuilder<include_summand<propto, T_dof, T_y, T_scale>::value,
-                    T_partials_return, T_y> inv_y(length(y));
-      for (size_t i = 0; i < length(y); i++)
-        if (include_summand<propto, T_dof, T_y, T_scale>::value)
-          inv_y[i] = 1.0 / value_of(y_vec[i]);
-
-      VectorBuilder<include_summand<propto, T_dof, T_scale>::value,
-                    T_partials_return, T_scale> log_s(length(s));
-      for (size_t i = 0; i < length(s); i++)
-        if (include_summand<propto, T_dof, T_scale>::value)
-          log_s[i] = log(value_of(s_vec[i]));
-
-      VectorBuilder<include_summand<propto, T_dof>::value,
-                    T_partials_return, T_dof> log_half_nu(length(nu));
-      VectorBuilder<include_summand<propto, T_dof>::value,
-                    T_partials_return, T_dof> lgamma_half_nu(length(nu));
-      VectorBuilder<!is_constant_struct<T_dof>::value,
-                    T_partials_return, T_dof>
-        digamma_half_nu_over_two(length(nu));
-      for (size_t i = 0; i < length(nu); i++) {
-        if (include_summand<propto, T_dof>::value)
-          lgamma_half_nu[i] = lgamma(half_nu[i]);
-        if (include_summand<propto, T_dof>::value)
-          log_half_nu[i] = log(half_nu[i]);
-        if (!is_constant_struct<T_dof>::value)
-          digamma_half_nu_over_two[i] = digamma(half_nu[i]) * 0.5;
-      }
-
-      OperandsAndPartials<T_y, T_dof, T_scale>
-        operands_and_partials(y, nu, s);
-      for (size_t n = 0; n < N; n++) {
-        const T_partials_return s_dbl = value_of(s_vec[n]);
-        const T_partials_return nu_dbl = value_of(nu_vec[n]);
-        if (include_summand<propto, T_dof>::value)
-          logp += half_nu[n] * log_half_nu[n] - lgamma_half_nu[n];
-        if (include_summand<propto, T_dof, T_scale>::value)
-          logp += nu_dbl * log_s[n];
-        if (include_summand<propto, T_dof, T_y>::value)
-          logp -= (half_nu[n]+1.0) * log_y[n];
-        if (include_summand<propto, T_dof, T_y, T_scale>::value)
-          logp -= half_nu[n] * s_dbl*s_dbl * inv_y[n];
-
-        if (!is_constant_struct<T_y>::value) {
-          operands_and_partials.d_x1[n]
-            += -(half_nu[n] + 1.0) * inv_y[n]
-            + half_nu[n] * s_dbl*s_dbl * inv_y[n]*inv_y[n];
-        }
-        if (!is_constant_struct<T_dof>::value) {
-          operands_and_partials.d_x2[n]
-            += 0.5 * log_half_nu[n] + 0.5
-            - digamma_half_nu_over_two[n]
-            + log_s[n]
-            - 0.5 * log_y[n]
-            - 0.5* s_dbl*s_dbl * inv_y[n];
-        }
-        if (!is_constant_struct<T_scale>::value) {
-          operands_and_partials.d_x3[n]
-            += nu_dbl / s_dbl - nu_dbl * inv_y[n] * s_dbl;
-        }
-      }
-      return operands_and_partials.value(logp);
+      return scaled_inv_chi_square_lpdf<propto, T_y, T_dof, T_scale>(y, nu, s);
     }
 
+    /**
+     * @deprecated use <code>scaled_inv_chi_square_lpdf</code>
+     */
     template <typename T_y, typename T_dof, typename T_scale>
     inline
     typename return_type<T_y, T_dof, T_scale>::type
     scaled_inv_chi_square_log(const T_y& y, const T_dof& nu, const T_scale& s) {
-      return scaled_inv_chi_square_log<false>(y, nu, s);
+      return scaled_inv_chi_square_lpdf<T_y, T_dof, T_scale>(y, nu, s);
     }
 
   }

--- a/stan/math/prim/scal/prob/skew_normal_ccdf_log.hpp
+++ b/stan/math/prim/scal/prob/skew_normal_ccdf_log.hpp
@@ -1,105 +1,22 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_SKEW_NORMAL_CCDF_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_SKEW_NORMAL_CCDF_LOG_HPP
 
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_finite.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/err/check_positive.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/fun/owens_t.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
-#include <stan/math/prim/scal/meta/VectorView.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <boost/math/distributions.hpp>
-#include <cmath>
+#include <stan/math/prim/scal/prob/skew_normal_lccdf.hpp>
 
 namespace stan {
   namespace math {
 
+    /**
+     * @deprecated use <code>skew_normal_lccdf</code>
+     */
     template <typename T_y, typename T_loc, typename T_scale, typename T_shape>
     typename return_type<T_y, T_loc, T_scale, T_shape>::type
     skew_normal_ccdf_log(const T_y& y, const T_loc& mu, const T_scale& sigma,
                          const T_shape& alpha) {
-      static const char* function("skew_normal_ccdf_log");
-      typedef typename stan::partials_return_type<T_y, T_loc, T_scale,
-                                                  T_shape>::type
-        T_partials_return;
-
-      T_partials_return ccdf_log(0.0);
-
-      if (!(stan::length(y)
-            && stan::length(mu)
-            && stan::length(sigma)
-            && stan::length(alpha)))
-        return ccdf_log;
-
-      check_not_nan(function, "Random variable", y);
-      check_finite(function, "Location parameter", mu);
-      check_not_nan(function, "Scale parameter", sigma);
-      check_positive(function, "Scale parameter", sigma);
-      check_finite(function, "Shape parameter", alpha);
-      check_not_nan(function, "Shape parameter", alpha);
-      check_consistent_sizes(function,
-                             "Random variable", y,
-                             "Location parameter", mu,
-                             "Scale parameter", sigma,
-                             "Shape paramter", alpha);
-
-      OperandsAndPartials<T_y, T_loc, T_scale, T_shape>
-        operands_and_partials(y, mu, sigma, alpha);
-
-      using std::log;
-      using std::exp;
-
-      VectorView<const T_y> y_vec(y);
-      VectorView<const T_loc> mu_vec(mu);
-      VectorView<const T_scale> sigma_vec(sigma);
-      VectorView<const T_shape> alpha_vec(alpha);
-      size_t N = max_size(y, mu, sigma, alpha);
-      const double SQRT_TWO_OVER_PI = std::sqrt(2.0 / pi());
-
-      for (size_t n = 0; n < N; n++) {
-        const T_partials_return y_dbl = value_of(y_vec[n]);
-        const T_partials_return mu_dbl = value_of(mu_vec[n]);
-        const T_partials_return sigma_dbl = value_of(sigma_vec[n]);
-        const T_partials_return alpha_dbl = value_of(alpha_vec[n]);
-        const T_partials_return alpha_dbl_sq = alpha_dbl * alpha_dbl;
-        const T_partials_return diff = (y_dbl - mu_dbl) / sigma_dbl;
-        const T_partials_return diff_sq = diff * diff;
-        const T_partials_return scaled_diff =  diff / SQRT_2;
-        const T_partials_return scaled_diff_sq =  diff_sq * 0.5;
-        const T_partials_return ccdf_log_ = 1.0 - 0.5 * erfc(-scaled_diff)
-          + 2 * owens_t(diff, alpha_dbl);
-
-        ccdf_log += log(ccdf_log_);
-
-        const T_partials_return deriv_erfc = SQRT_TWO_OVER_PI * 0.5
-          * exp(-scaled_diff_sq) / sigma_dbl;
-        const T_partials_return deriv_owens = erf(alpha_dbl * scaled_diff)
-          * exp(-scaled_diff_sq) / SQRT_TWO_OVER_PI / (-2.0 * pi()) / sigma_dbl;
-        const T_partials_return rep_deriv = (-2.0 * deriv_owens + deriv_erfc)
-          / ccdf_log_;
-
-        if (!is_constant_struct<T_y>::value)
-          operands_and_partials.d_x1[n] -= rep_deriv;
-        if (!is_constant_struct<T_loc>::value)
-          operands_and_partials.d_x2[n] += rep_deriv;
-        if (!is_constant_struct<T_scale>::value)
-          operands_and_partials.d_x3[n] += rep_deriv * diff;
-        if (!is_constant_struct<T_shape>::value)
-          operands_and_partials.d_x4[n] -= -2.0 * exp(-0.5 * diff_sq
-                                                      * (1.0 + alpha_dbl_sq))
-            / ((1 + alpha_dbl_sq) * 2.0 * pi()) / ccdf_log_;
-      }
-      return operands_and_partials.value(ccdf_log);
+      return skew_normal_lccdf<T_y, T_loc,
+                               T_scale, T_shape>(y, mu, sigma, alpha);
     }
 
   }
 }
 #endif
-

--- a/stan/math/prim/scal/prob/skew_normal_cdf_log.hpp
+++ b/stan/math/prim/scal/prob/skew_normal_cdf_log.hpp
@@ -1,105 +1,22 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_SKEW_NORMAL_CDF_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_SKEW_NORMAL_CDF_LOG_HPP
 
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_finite.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/err/check_positive.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/fun/owens_t.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
-#include <stan/math/prim/scal/meta/VectorView.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <boost/math/distributions.hpp>
-#include <cmath>
+#include <stan/math/prim/scal/prob/skew_normal_lcdf.hpp>
 
 namespace stan {
   namespace math {
 
+    /**
+     * @deprecated use <code>skew_normal_lcdf</code>
+     */
     template <typename T_y, typename T_loc, typename T_scale, typename T_shape>
     typename return_type<T_y, T_loc, T_scale, T_shape>::type
     skew_normal_cdf_log(const T_y& y, const T_loc& mu, const T_scale& sigma,
                         const T_shape& alpha) {
-      static const char* function("skew_normal_cdf_log");
-      typedef typename stan::partials_return_type<T_y, T_loc, T_scale,
-                                                  T_shape>::type
-        T_partials_return;
-
-      T_partials_return cdf_log(0.0);
-
-      if (!(stan::length(y)
-            && stan::length(mu)
-            && stan::length(sigma)
-            && stan::length(alpha)))
-        return cdf_log;
-
-      check_not_nan(function, "Random variable", y);
-      check_finite(function, "Location parameter", mu);
-      check_not_nan(function, "Scale parameter", sigma);
-      check_positive(function, "Scale parameter", sigma);
-      check_finite(function, "Shape parameter", alpha);
-      check_not_nan(function, "Shape parameter", alpha);
-      check_consistent_sizes(function,
-                             "Random variable", y,
-                             "Location parameter", mu,
-                             "Scale parameter", sigma,
-                             "Shape paramter", alpha);
-
-      OperandsAndPartials<T_y, T_loc, T_scale, T_shape>
-        operands_and_partials(y, mu, sigma, alpha);
-
-      using std::log;
-      using std::exp;
-
-      VectorView<const T_y> y_vec(y);
-      VectorView<const T_loc> mu_vec(mu);
-      VectorView<const T_scale> sigma_vec(sigma);
-      VectorView<const T_shape> alpha_vec(alpha);
-      size_t N = max_size(y, mu, sigma, alpha);
-      const double SQRT_TWO_OVER_PI = std::sqrt(2.0 / pi());
-
-      for (size_t n = 0; n < N; n++) {
-        const T_partials_return y_dbl = value_of(y_vec[n]);
-        const T_partials_return mu_dbl = value_of(mu_vec[n]);
-        const T_partials_return sigma_dbl = value_of(sigma_vec[n]);
-        const T_partials_return alpha_dbl = value_of(alpha_vec[n]);
-        const T_partials_return alpha_dbl_sq = alpha_dbl * alpha_dbl;
-        const T_partials_return diff = (y_dbl - mu_dbl) / sigma_dbl;
-        const T_partials_return diff_sq = diff * diff;
-        const T_partials_return scaled_diff =  diff / SQRT_2;
-        const T_partials_return scaled_diff_sq =  diff_sq * 0.5;
-        const T_partials_return cdf_log_ = 0.5 * erfc(-scaled_diff) - 2
-          * owens_t(diff, alpha_dbl);
-
-        cdf_log += log(cdf_log_);
-
-        const T_partials_return deriv_erfc = SQRT_TWO_OVER_PI * 0.5
-          * exp(-scaled_diff_sq) / sigma_dbl;
-        const T_partials_return deriv_owens = erf(alpha_dbl * scaled_diff)
-          * exp(-scaled_diff_sq) / SQRT_TWO_OVER_PI / (-2.0 * pi()) / sigma_dbl;
-        const T_partials_return rep_deriv = (-2.0 * deriv_owens + deriv_erfc)
-          / cdf_log_;
-
-        if (!is_constant_struct<T_y>::value)
-          operands_and_partials.d_x1[n] += rep_deriv;
-        if (!is_constant_struct<T_loc>::value)
-          operands_and_partials.d_x2[n] -= rep_deriv;
-        if (!is_constant_struct<T_scale>::value)
-          operands_and_partials.d_x3[n] -= rep_deriv * diff;
-        if (!is_constant_struct<T_shape>::value)
-          operands_and_partials.d_x4[n] += -2.0 * exp(-0.5 * diff_sq
-                                                      * (1.0 + alpha_dbl_sq))
-            / ((1 + alpha_dbl_sq) * 2.0 * pi()) / cdf_log_;
-      }
-      return operands_and_partials.value(cdf_log);
+      return skew_normal_lcdf<T_y, T_loc,
+                              T_scale, T_shape>(y, mu, sigma, alpha);
     }
 
   }
 }
 #endif
-

--- a/stan/math/prim/scal/prob/skew_normal_log.hpp
+++ b/stan/math/prim/scal/prob/skew_normal_log.hpp
@@ -1,139 +1,36 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_SKEW_NORMAL_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_SKEW_NORMAL_LOG_HPP
 
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_finite.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/err/check_positive.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/fun/erf.hpp>
-#include <stan/math/prim/scal/fun/erfc.hpp>
-#include <stan/math/prim/scal/fun/owens_t.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
-#include <stan/math/prim/scal/meta/VectorView.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <boost/math/distributions.hpp>
-#include <cmath>
+#include <stan/math/prim/scal/prob/skew_normal_lpdf.hpp>
 
 namespace stan {
   namespace math {
 
+    /**
+     * @deprecated use <code>skew_normal_lpdf</code>
+     */
     template <bool propto,
               typename T_y, typename T_loc, typename T_scale, typename T_shape>
     typename return_type<T_y, T_loc, T_scale, T_shape>::type
     skew_normal_log(const T_y& y, const T_loc& mu, const T_scale& sigma,
                     const T_shape& alpha) {
-      static const char* function("skew_normal_log");
-      typedef typename stan::partials_return_type<T_y, T_loc,
-                                                  T_scale, T_shape>::type
-        T_partials_return;
-
-      using std::log;
-      using stan::is_constant_struct;
-      using std::exp;
-
-      if (!(stan::length(y)
-            && stan::length(mu)
-            && stan::length(sigma)
-            && stan::length(alpha)))
-        return 0.0;
-
-      T_partials_return logp(0.0);
-
-      check_not_nan(function, "Random variable", y);
-      check_finite(function, "Location parameter", mu);
-      check_finite(function, "Shape parameter", alpha);
-      check_positive(function, "Scale parameter", sigma);
-      check_consistent_sizes(function,
-                             "Random variable", y,
-                             "Location parameter", mu,
-                             "Scale parameter", sigma,
-                             "Shape paramter", alpha);
-
-      if (!include_summand<propto, T_y, T_loc, T_scale, T_shape>::value)
-        return 0.0;
-
-      OperandsAndPartials<T_y, T_loc, T_scale, T_shape>
-        operands_and_partials(y, mu, sigma, alpha);
-
-      using std::log;
-
-      VectorView<const T_y> y_vec(y);
-      VectorView<const T_loc> mu_vec(mu);
-      VectorView<const T_scale> sigma_vec(sigma);
-      VectorView<const T_shape> alpha_vec(alpha);
-      size_t N = max_size(y, mu, sigma, alpha);
-
-      VectorBuilder<true, T_partials_return, T_scale> inv_sigma(length(sigma));
-      VectorBuilder<include_summand<propto, T_scale>::value,
-                    T_partials_return, T_scale> log_sigma(length(sigma));
-      for (size_t i = 0; i < length(sigma); i++) {
-        inv_sigma[i] = 1.0 / value_of(sigma_vec[i]);
-        if (include_summand<propto, T_scale>::value)
-          log_sigma[i] = log(value_of(sigma_vec[i]));
-      }
-
-      for (size_t n = 0; n < N; n++) {
-        const T_partials_return y_dbl = value_of(y_vec[n]);
-        const T_partials_return mu_dbl = value_of(mu_vec[n]);
-        const T_partials_return sigma_dbl = value_of(sigma_vec[n]);
-        const T_partials_return alpha_dbl = value_of(alpha_vec[n]);
-
-        const T_partials_return y_minus_mu_over_sigma
-          = (y_dbl - mu_dbl) * inv_sigma[n];
-        const double pi_dbl = pi();
-
-        if (include_summand<propto>::value)
-          logp -=  0.5 * log(2.0 * pi_dbl);
-        if (include_summand<propto, T_scale>::value)
-          logp -= log(sigma_dbl);
-        if (include_summand<propto, T_y, T_loc, T_scale>::value)
-          logp -= y_minus_mu_over_sigma * y_minus_mu_over_sigma / 2.0;
-        if (include_summand<propto, T_y, T_loc, T_scale, T_shape>::value)
-          logp += log(erfc(-alpha_dbl * y_minus_mu_over_sigma
-                           / std::sqrt(2.0)));
-
-        T_partials_return deriv_logerf
-          = 2.0 / std::sqrt(pi_dbl)
-          * exp(-alpha_dbl * y_minus_mu_over_sigma / std::sqrt(2.0)
-                * alpha_dbl * y_minus_mu_over_sigma / std::sqrt(2.0))
-          / (1 + erf(alpha_dbl * y_minus_mu_over_sigma
-                     / std::sqrt(2.0)));
-        if (!is_constant_struct<T_y>::value)
-          operands_and_partials.d_x1[n]
-            += -y_minus_mu_over_sigma / sigma_dbl
-            + deriv_logerf * alpha_dbl / (sigma_dbl * std::sqrt(2.0));
-        if (!is_constant_struct<T_loc>::value)
-          operands_and_partials.d_x2[n]
-            += y_minus_mu_over_sigma / sigma_dbl
-            + deriv_logerf * -alpha_dbl / (sigma_dbl * std::sqrt(2.0));
-        if (!is_constant_struct<T_scale>::value)
-          operands_and_partials.d_x3[n]
-            += -1.0 / sigma_dbl
-            + y_minus_mu_over_sigma * y_minus_mu_over_sigma / sigma_dbl
-            - deriv_logerf * y_minus_mu_over_sigma * alpha_dbl
-            / (sigma_dbl * std::sqrt(2.0));
-        if (!is_constant_struct<T_shape>::value)
-          operands_and_partials.d_x4[n]
-            += deriv_logerf * y_minus_mu_over_sigma / std::sqrt(2.0);
-      }
-      return operands_and_partials.value(logp);
+      return skew_normal_lpdf<propto, T_y, T_loc,
+                              T_scale, T_shape>(y, mu, sigma, alpha);
     }
 
+    /**
+     * @deprecated use <code>skew_normal_lpdf</code>
+     */
     template <typename T_y, typename T_loc, typename T_scale, typename T_shape>
     inline
     typename return_type<T_y, T_loc, T_scale, T_shape>::type
-    skew_normal_log(const T_y& y, const T_loc& mu, const T_scale& sigma,
+    skew_normal_log(const T_y& y, const T_loc& mu,
+                    const T_scale& sigma,
                     const T_shape& alpha) {
-      return skew_normal_log<false>(y, mu, sigma, alpha);
+      return skew_normal_lpdf<T_y, T_loc,
+                              T_scale, T_shape>(y, mu, sigma, alpha);
     }
 
   }
 }
 #endif
-

--- a/stan/math/prim/scal/prob/student_t_ccdf_log.hpp
+++ b/stan/math/prim/scal/prob/student_t_ccdf_log.hpp
@@ -1,188 +1,19 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_STUDENT_T_CCDF_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_STUDENT_T_CCDF_LOG_HPP
 
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_finite.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/err/check_positive_finite.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/fun/square.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/fun/lbeta.hpp>
-#include <stan/math/prim/scal/fun/lgamma.hpp>
-#include <stan/math/prim/scal/fun/digamma.hpp>
-#include <stan/math/prim/scal/meta/length.hpp>
-#include <stan/math/prim/scal/fun/grad_reg_inc_beta.hpp>
-#include <stan/math/prim/scal/fun/inc_beta.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
-#include <boost/random/student_t_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <limits>
-#include <cmath>
+#include <stan/math/prim/scal/prob/student_t_lccdf.hpp>
 
 namespace stan {
   namespace math {
 
+    /**
+     * @deprecated use <code>student_t_lccdf</code>
+     */
     template <typename T_y, typename T_dof, typename T_loc, typename T_scale>
     typename return_type<T_y, T_dof, T_loc, T_scale>::type
     student_t_ccdf_log(const T_y& y, const T_dof& nu, const T_loc& mu,
                        const T_scale& sigma) {
-      typedef
-        typename stan::partials_return_type<T_y, T_dof, T_loc, T_scale>::type
-        T_partials_return;
-
-      if (!(stan::length(y) && stan::length(nu) && stan::length(mu)
-            && stan::length(sigma)))
-        return 0.0;
-
-      static const char* function("student_t_ccdf_log");
-
-      using std::exp;
-
-      T_partials_return P(0.0);
-
-      check_not_nan(function, "Random variable", y);
-      check_positive_finite(function, "Degrees of freedom parameter", nu);
-      check_finite(function, "Location parameter", mu);
-      check_positive_finite(function, "Scale parameter", sigma);
-
-      VectorView<const T_y> y_vec(y);
-      VectorView<const T_dof> nu_vec(nu);
-      VectorView<const T_loc> mu_vec(mu);
-      VectorView<const T_scale> sigma_vec(sigma);
-      size_t N = max_size(y, nu, mu, sigma);
-
-      OperandsAndPartials<T_y, T_dof, T_loc, T_scale>
-        operands_and_partials(y, nu, mu, sigma);
-
-      // Explicit return for extreme values
-      // The gradients are technically ill-defined, but treated as zero
-      for (size_t i = 0; i < stan::length(y); i++) {
-        if (value_of(y_vec[i]) == -std::numeric_limits<double>::infinity())
-          return operands_and_partials.value(0.0);
-      }
-
-      using std::pow;
-      using std::exp;
-      using std::log;
-
-      T_partials_return digammaHalf = 0;
-
-      VectorBuilder<!is_constant_struct<T_dof>::value,
-                    T_partials_return, T_dof>
-        digamma_vec(stan::length(nu));
-      VectorBuilder<!is_constant_struct<T_dof>::value,
-                    T_partials_return, T_dof>
-        digammaNu_vec(stan::length(nu));
-      VectorBuilder<!is_constant_struct<T_dof>::value,
-                    T_partials_return, T_dof>
-        digammaNuPlusHalf_vec(stan::length(nu));
-
-      if (!is_constant_struct<T_dof>::value) {
-        digammaHalf = digamma(0.5);
-
-        for (size_t i = 0; i < stan::length(nu); i++) {
-          const T_partials_return nu_dbl = value_of(nu_vec[i]);
-
-          digammaNu_vec[i] = digamma(0.5 * nu_dbl);
-          digammaNuPlusHalf_vec[i] = digamma(0.5 + 0.5 * nu_dbl);
-        }
-      }
-
-      for (size_t n = 0; n < N; n++) {
-        // Explicit results for extreme values
-        // The gradients are technically ill-defined, but treated as zero
-        if (value_of(y_vec[n]) == std::numeric_limits<double>::infinity()) {
-          return operands_and_partials.value(negative_infinity());
-        }
-
-        const T_partials_return sigma_inv = 1.0 / value_of(sigma_vec[n]);
-        const T_partials_return t = (value_of(y_vec[n]) - value_of(mu_vec[n]))
-          * sigma_inv;
-        const T_partials_return nu_dbl = value_of(nu_vec[n]);
-        const T_partials_return q = nu_dbl / (t * t);
-        const T_partials_return r = 1.0 / (1.0 + q);
-        const T_partials_return J = 2 * r * r * q / t;
-        const T_partials_return betaNuHalf = exp(lbeta(0.5, 0.5 * nu_dbl));
-        T_partials_return zJacobian = t > 0 ? - 0.5 : 0.5;
-
-        if (q < 2) {
-          T_partials_return z = inc_beta(0.5 * nu_dbl, (T_partials_return)0.5,
-                                         1.0 - r);
-          const T_partials_return Pn = t > 0 ? 0.5 * z : 1.0 - 0.5 * z;
-          const T_partials_return d_ibeta = pow(r, -0.5)
-            * pow(1.0 - r, 0.5*nu_dbl - 1) / betaNuHalf;
-
-          P += log(Pn);
-
-          if (!is_constant_struct<T_y>::value)
-            operands_and_partials.d_x1[n]
-              += zJacobian * d_ibeta * J * sigma_inv / Pn;
-
-          if (!is_constant_struct<T_dof>::value) {
-            T_partials_return g1 = 0;
-            T_partials_return g2 = 0;
-
-            grad_reg_inc_beta(g1, g2, 0.5 * nu_dbl,
-                              (T_partials_return)0.5, 1.0 - r,
-                              digammaNu_vec[n], digammaHalf,
-                              digammaNuPlusHalf_vec[n],
-                              betaNuHalf);
-
-            operands_and_partials.d_x2[n]
-              -= zJacobian * (d_ibeta * (r / t) * (r / t) + 0.5 * g1) / Pn;
-          }
-
-          if (!is_constant_struct<T_loc>::value)
-            operands_and_partials.d_x3[n]
-              -= zJacobian * d_ibeta * J * sigma_inv / Pn;
-          if (!is_constant_struct<T_scale>::value)
-            operands_and_partials.d_x4[n]
-              -= zJacobian * d_ibeta * J * sigma_inv * t / Pn;
-
-        } else {
-          T_partials_return z = 1.0 - inc_beta((T_partials_return)0.5,
-                                               0.5*nu_dbl, r);
-          zJacobian *= -1;
-
-          const T_partials_return Pn = t > 0 ? 0.5 * z : 1.0 - 0.5 * z;
-
-          T_partials_return d_ibeta = pow(1.0-r, 0.5*nu_dbl-1) * pow(r, -0.5)
-            / betaNuHalf;
-
-          P += log(Pn);
-
-          if (!is_constant_struct<T_y>::value)
-            operands_and_partials.d_x1[n]
-              -= zJacobian * d_ibeta * J * sigma_inv / Pn;
-
-          if (!is_constant_struct<T_dof>::value) {
-            T_partials_return g1 = 0;
-            T_partials_return g2 = 0;
-
-            grad_reg_inc_beta(g1, g2, (T_partials_return)0.5,
-                              0.5 * nu_dbl, r,
-                              digammaHalf, digammaNu_vec[n],
-                              digammaNuPlusHalf_vec[n],
-                              betaNuHalf);
-
-            operands_and_partials.d_x2[n]
-              -= zJacobian * (- d_ibeta * (r / t) * (r / t) + 0.5 * g2) / Pn;
-          }
-
-          if (!is_constant_struct<T_loc>::value)
-            operands_and_partials.d_x3[n]
-              += zJacobian * d_ibeta * J * sigma_inv / Pn;
-          if (!is_constant_struct<T_scale>::value)
-            operands_and_partials.d_x4[n]
-              += zJacobian * d_ibeta * J * sigma_inv * t / Pn;
-        }
-      }
-      return operands_and_partials.value(P);
+      return student_t_lccdf<T_y, T_dof, T_loc, T_scale>(y, nu, mu, sigma);
     }
 
   }

--- a/stan/math/prim/scal/prob/student_t_cdf_log.hpp
+++ b/stan/math/prim/scal/prob/student_t_cdf_log.hpp
@@ -1,188 +1,19 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_STUDENT_T_CDF_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_STUDENT_T_CDF_LOG_HPP
 
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_finite.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/err/check_positive_finite.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/fun/square.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/fun/lbeta.hpp>
-#include <stan/math/prim/scal/fun/lgamma.hpp>
-#include <stan/math/prim/scal/fun/digamma.hpp>
-#include <stan/math/prim/scal/meta/length.hpp>
-#include <stan/math/prim/scal/fun/grad_reg_inc_beta.hpp>
-#include <stan/math/prim/scal/fun/inc_beta.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
-#include <boost/random/student_t_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <limits>
-#include <cmath>
+#include <stan/math/prim/scal/prob/student_t_lcdf.hpp>
 
 namespace stan {
   namespace math {
 
+    /**
+     * @deprecated use <code>student_t_lcdf</code>
+     */
     template <typename T_y, typename T_dof, typename T_loc, typename T_scale>
     typename return_type<T_y, T_dof, T_loc, T_scale>::type
     student_t_cdf_log(const T_y& y, const T_dof& nu, const T_loc& mu,
                       const T_scale& sigma) {
-      typedef typename
-        stan::partials_return_type<T_y, T_dof, T_loc, T_scale>::type
-        T_partials_return;
-
-      if (!(stan::length(y) && stan::length(nu) && stan::length(mu)
-            && stan::length(sigma)))
-        return 0.0;
-
-      static const char* function("student_t_cdf_log");
-
-      using std::exp;
-
-      T_partials_return P(0.0);
-
-      check_not_nan(function, "Random variable", y);
-      check_positive_finite(function, "Degrees of freedom parameter", nu);
-      check_finite(function, "Location parameter", mu);
-      check_positive_finite(function, "Scale parameter", sigma);
-
-      VectorView<const T_y> y_vec(y);
-      VectorView<const T_dof> nu_vec(nu);
-      VectorView<const T_loc> mu_vec(mu);
-      VectorView<const T_scale> sigma_vec(sigma);
-      size_t N = max_size(y, nu, mu, sigma);
-
-      OperandsAndPartials<T_y, T_dof, T_loc, T_scale>
-        operands_and_partials(y, nu, mu, sigma);
-
-      // Explicit return for extreme values
-      // The gradients are technically ill-defined, but treated as zero
-      for (size_t i = 0; i < stan::length(y); i++) {
-        if (value_of(y_vec[i]) == -std::numeric_limits<double>::infinity())
-          return operands_and_partials.value(negative_infinity());
-      }
-
-      using std::pow;
-      using std::exp;
-      using std::log;
-
-      T_partials_return digammaHalf = 0;
-
-      VectorBuilder<!is_constant_struct<T_dof>::value,
-                    T_partials_return, T_dof>
-        digamma_vec(stan::length(nu));
-      VectorBuilder<!is_constant_struct<T_dof>::value,
-                    T_partials_return, T_dof>
-        digammaNu_vec(stan::length(nu));
-      VectorBuilder<!is_constant_struct<T_dof>::value,
-                    T_partials_return, T_dof>
-        digammaNuPlusHalf_vec(stan::length(nu));
-
-      if (!is_constant_struct<T_dof>::value) {
-        digammaHalf = digamma(0.5);
-
-        for (size_t i = 0; i < stan::length(nu); i++) {
-          const T_partials_return nu_dbl = value_of(nu_vec[i]);
-
-          digammaNu_vec[i] = digamma(0.5 * nu_dbl);
-          digammaNuPlusHalf_vec[i] = digamma(0.5 + 0.5 * nu_dbl);
-        }
-      }
-
-      for (size_t n = 0; n < N; n++) {
-        // Explicit results for extreme values
-        // The gradients are technically ill-defined, but treated as zero
-        if (value_of(y_vec[n]) == std::numeric_limits<double>::infinity()) {
-          continue;
-        }
-
-        const T_partials_return sigma_inv = 1.0 / value_of(sigma_vec[n]);
-        const T_partials_return t = (value_of(y_vec[n]) - value_of(mu_vec[n]))
-          * sigma_inv;
-        const T_partials_return nu_dbl = value_of(nu_vec[n]);
-        const T_partials_return q = nu_dbl / (t * t);
-        const T_partials_return r = 1.0 / (1.0 + q);
-        const T_partials_return J = 2 * r * r * q / t;
-        const T_partials_return betaNuHalf = exp(lbeta(0.5, 0.5 * nu_dbl));
-        T_partials_return zJacobian = t > 0 ? - 0.5 : 0.5;
-
-        if (q < 2) {
-          T_partials_return z
-            = inc_beta(0.5 * nu_dbl, (T_partials_return)0.5, 1.0 - r);
-          const T_partials_return Pn = t > 0 ? 1.0 - 0.5 * z : 0.5 * z;
-          const T_partials_return d_ibeta = pow(r, -0.5)
-            * pow(1.0 - r, 0.5*nu_dbl - 1) / betaNuHalf;
-
-          P += log(Pn);
-
-          if (!is_constant_struct<T_y>::value)
-            operands_and_partials.d_x1[n]
-              += - zJacobian * d_ibeta * J * sigma_inv / Pn;
-
-          if (!is_constant_struct<T_dof>::value) {
-            T_partials_return g1 = 0;
-            T_partials_return g2 = 0;
-
-            grad_reg_inc_beta(g1, g2, 0.5 * nu_dbl,
-                              (T_partials_return)0.5, 1.0 - r,
-                              digammaNu_vec[n], digammaHalf,
-                              digammaNuPlusHalf_vec[n],
-                              betaNuHalf);
-
-            operands_and_partials.d_x2[n]
-              += zJacobian * (d_ibeta * (r / t) * (r / t) + 0.5 * g1) / Pn;
-          }
-
-          if (!is_constant_struct<T_loc>::value)
-            operands_and_partials.d_x3[n]
-              += zJacobian * d_ibeta * J * sigma_inv / Pn;
-          if (!is_constant_struct<T_scale>::value)
-            operands_and_partials.d_x4[n]
-              += zJacobian * d_ibeta * J * sigma_inv * t / Pn;
-
-        } else {
-          T_partials_return z = 1.0 - inc_beta((T_partials_return)0.5,
-                                               0.5*nu_dbl, r);
-          zJacobian *= -1;
-
-          const T_partials_return Pn = t > 0 ? 1.0 - 0.5 * z : 0.5 * z;
-
-          T_partials_return d_ibeta = pow(1.0-r, 0.5*nu_dbl-1) * pow(r, -0.5)
-            / betaNuHalf;
-
-          P += log(Pn);
-
-          if (!is_constant_struct<T_y>::value)
-            operands_and_partials.d_x1[n]
-              += zJacobian * d_ibeta * J * sigma_inv / Pn;
-
-          if (!is_constant_struct<T_dof>::value) {
-            T_partials_return g1 = 0;
-            T_partials_return g2 = 0;
-
-            grad_reg_inc_beta(g1, g2, (T_partials_return)0.5,
-                              0.5 * nu_dbl, r,
-                              digammaHalf, digammaNu_vec[n],
-                              digammaNuPlusHalf_vec[n],
-                              betaNuHalf);
-
-            operands_and_partials.d_x2[n]
-              += zJacobian * (- d_ibeta * (r / t) * (r / t) + 0.5 * g2) / Pn;
-          }
-
-          if (!is_constant_struct<T_loc>::value)
-            operands_and_partials.d_x3[n]
-              += - zJacobian * d_ibeta * J * sigma_inv / Pn;
-          if (!is_constant_struct<T_scale>::value)
-            operands_and_partials.d_x4[n]
-              += - zJacobian * d_ibeta * J * sigma_inv * t / Pn;
-        }
-      }
-      return operands_and_partials.value(P);
+      return student_t_lcdf<T_y, T_dof, T_loc, T_scale>(y, nu, mu, sigma);
     }
 
   }

--- a/stan/math/prim/scal/prob/student_t_log.hpp
+++ b/stan/math/prim/scal/prob/student_t_log.hpp
@@ -1,27 +1,7 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_STUDENT_T_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_STUDENT_T_LOG_HPP
 
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_finite.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/err/check_positive_finite.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/fun/square.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/fun/lbeta.hpp>
-#include <stan/math/prim/scal/fun/lgamma.hpp>
-#include <stan/math/prim/scal/fun/digamma.hpp>
-#include <stan/math/prim/scal/meta/length.hpp>
-#include <stan/math/prim/scal/fun/grad_reg_inc_beta.hpp>
-#include <stan/math/prim/scal/fun/inc_beta.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
-#include <boost/random/student_t_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <cmath>
+#include <stan/math/prim/scal/prob/student_t_lpdf.hpp>
 
 namespace stan {
   namespace math {
@@ -38,6 +18,8 @@ namespace stan {
      &=& \log( \Gamma( (\nu+1)/2 )) - \log (\Gamma (\nu/2) - \frac{1}{2} \log(\nu \pi) - \log(\sigma)
      -\frac{\nu + 1}{2} \log (1 + \frac{1}{\nu} (\frac{y - \mu}{\sigma})^2)
      \f}
+     *
+     * @deprecated use <code>student_t_lpdf</code>
      *
      * @param y A scalar variable.
      * @param nu Degrees of freedom.
@@ -56,159 +38,19 @@ namespace stan {
     typename return_type<T_y, T_dof, T_loc, T_scale>::type
     student_t_log(const T_y& y, const T_dof& nu, const T_loc& mu,
                   const T_scale& sigma) {
-      static const char* function("student_t_log");
-      typedef typename stan::partials_return_type<T_y, T_dof, T_loc,
-                                                  T_scale>::type
-        T_partials_return;
-
-      if (!(stan::length(y)
-            && stan::length(nu)
-            && stan::length(mu)
-            && stan::length(sigma)))
-        return 0.0;
-
-      T_partials_return logp(0.0);
-
-      check_not_nan(function, "Random variable", y);
-      check_positive_finite(function, "Degrees of freedom parameter", nu);
-      check_finite(function, "Location parameter", mu);
-      check_positive_finite(function, "Scale parameter", sigma);
-      check_consistent_sizes(function,
-                             "Random variable", y,
-                             "Degrees of freedom parameter", nu,
-                             "Location parameter", mu,
-                             "Scale parameter", sigma);
-
-      if (!include_summand<propto, T_y, T_dof, T_loc, T_scale>::value)
-        return 0.0;
-
-      VectorView<const T_y> y_vec(y);
-      VectorView<const T_dof> nu_vec(nu);
-      VectorView<const T_loc> mu_vec(mu);
-      VectorView<const T_scale> sigma_vec(sigma);
-      size_t N = max_size(y, nu, mu, sigma);
-
-      using std::log;
-      using std::log;
-
-      VectorBuilder<include_summand<propto, T_y, T_dof, T_loc, T_scale>::value,
-                    T_partials_return, T_dof> half_nu(length(nu));
-      for (size_t i = 0; i < length(nu); i++)
-        if (include_summand<propto, T_y, T_dof, T_loc, T_scale>::value)
-          half_nu[i] = 0.5 * value_of(nu_vec[i]);
-
-      VectorBuilder<include_summand<propto, T_dof>::value,
-                    T_partials_return, T_dof> lgamma_half_nu(length(nu));
-      VectorBuilder<include_summand<propto, T_dof>::value,
-                    T_partials_return, T_dof>
-        lgamma_half_nu_plus_half(length(nu));
-      if (include_summand<propto, T_dof>::value) {
-        for (size_t i = 0; i < length(nu); i++) {
-          lgamma_half_nu[i] = lgamma(half_nu[i]);
-          lgamma_half_nu_plus_half[i] = lgamma(half_nu[i] + 0.5);
-        }
-      }
-
-      VectorBuilder<!is_constant_struct<T_dof>::value,
-                    T_partials_return, T_dof> digamma_half_nu(length(nu));
-      VectorBuilder<!is_constant_struct<T_dof>::value,
-                    T_partials_return, T_dof>
-        digamma_half_nu_plus_half(length(nu));
-      if (!is_constant_struct<T_dof>::value) {
-        for (size_t i = 0; i < length(nu); i++) {
-          digamma_half_nu[i] = digamma(half_nu[i]);
-          digamma_half_nu_plus_half[i] = digamma(half_nu[i] + 0.5);
-        }
-      }
-
-      VectorBuilder<include_summand<propto, T_dof>::value,
-                    T_partials_return, T_dof> log_nu(length(nu));
-      for (size_t i = 0; i < length(nu); i++)
-        if (include_summand<propto, T_dof>::value)
-          log_nu[i] = log(value_of(nu_vec[i]));
-
-      VectorBuilder<include_summand<propto, T_scale>::value,
-                    T_partials_return, T_scale> log_sigma(length(sigma));
-      for (size_t i = 0; i < length(sigma); i++)
-        if (include_summand<propto, T_scale>::value)
-          log_sigma[i] = log(value_of(sigma_vec[i]));
-
-      VectorBuilder<include_summand<propto, T_y, T_dof, T_loc, T_scale>::value,
-                    T_partials_return, T_y, T_dof, T_loc, T_scale>
-        square_y_minus_mu_over_sigma__over_nu(N);
-
-      VectorBuilder<include_summand<propto, T_y, T_dof, T_loc, T_scale>::value,
-                    T_partials_return, T_y, T_dof, T_loc, T_scale>
-        log1p_exp(N);
-
-      for (size_t i = 0; i < N; i++)
-        if (include_summand<propto, T_y, T_dof, T_loc, T_scale>::value) {
-          const T_partials_return y_dbl = value_of(y_vec[i]);
-          const T_partials_return mu_dbl = value_of(mu_vec[i]);
-          const T_partials_return sigma_dbl = value_of(sigma_vec[i]);
-          const T_partials_return nu_dbl = value_of(nu_vec[i]);
-          square_y_minus_mu_over_sigma__over_nu[i]
-            = square((y_dbl - mu_dbl) / sigma_dbl) / nu_dbl;
-          log1p_exp[i] = log1p(square_y_minus_mu_over_sigma__over_nu[i]);
-        }
-
-      OperandsAndPartials<T_y, T_dof, T_loc, T_scale>
-        operands_and_partials(y, nu, mu, sigma);
-      for (size_t n = 0; n < N; n++) {
-        const T_partials_return y_dbl = value_of(y_vec[n]);
-        const T_partials_return mu_dbl = value_of(mu_vec[n]);
-        const T_partials_return sigma_dbl = value_of(sigma_vec[n]);
-        const T_partials_return nu_dbl = value_of(nu_vec[n]);
-        if (include_summand<propto>::value)
-          logp += NEG_LOG_SQRT_PI;
-        if (include_summand<propto, T_dof>::value)
-          logp += lgamma_half_nu_plus_half[n] - lgamma_half_nu[n]
-            -  0.5 * log_nu[n];
-        if (include_summand<propto, T_scale>::value)
-          logp -= log_sigma[n];
-        if (include_summand<propto, T_y, T_dof, T_loc, T_scale>::value)
-          logp -= (half_nu[n] + 0.5)
-            * log1p_exp[n];
-
-        if (!is_constant_struct<T_y>::value) {
-          operands_and_partials.d_x1[n]
-            += -(half_nu[n]+0.5)
-            * 1.0 / (1.0 + square_y_minus_mu_over_sigma__over_nu[n])
-            * (2.0 * (y_dbl - mu_dbl) / square(sigma_dbl) / nu_dbl);
-        }
-        if (!is_constant_struct<T_dof>::value) {
-          const T_partials_return inv_nu = 1.0 / nu_dbl;
-          operands_and_partials.d_x2[n]
-            += 0.5*digamma_half_nu_plus_half[n] - 0.5*digamma_half_nu[n]
-            - 0.5 * inv_nu
-            - 0.5*log1p_exp[n]
-            + (half_nu[n] + 0.5)
-            * (1.0/(1.0 + square_y_minus_mu_over_sigma__over_nu[n])
-               * square_y_minus_mu_over_sigma__over_nu[n] * inv_nu);
-        }
-        if (!is_constant_struct<T_loc>::value) {
-          operands_and_partials.d_x3[n]
-            -= (half_nu[n] + 0.5)
-            / (1.0 + square_y_minus_mu_over_sigma__over_nu[n])
-            * (2.0 * (mu_dbl - y_dbl) / (sigma_dbl*sigma_dbl*nu_dbl));
-        }
-        if (!is_constant_struct<T_scale>::value) {
-          const T_partials_return inv_sigma = 1.0 / sigma_dbl;
-          operands_and_partials.d_x4[n]
-            += -inv_sigma
-            + (nu_dbl + 1.0) / (1.0 + square_y_minus_mu_over_sigma__over_nu[n])
-            * (square_y_minus_mu_over_sigma__over_nu[n] * inv_sigma);
-        }
-      }
-      return operands_and_partials.value(logp);
+      return student_t_lpdf<propto, T_y, T_dof,
+                            T_loc, T_scale>(y, nu, mu, sigma);
     }
 
+    /**
+     * @deprecated use <code>student_t_lpdf</code>
+     */
     template <typename T_y, typename T_dof, typename T_loc, typename T_scale>
     inline
     typename return_type<T_y, T_dof, T_loc, T_scale>::type
     student_t_log(const T_y& y, const T_dof& nu, const T_loc& mu,
                   const T_scale& sigma) {
-      return student_t_log<false>(y, nu, mu, sigma);
+      return student_t_lpdf<T_y, T_dof, T_loc, T_scale>(y, nu, mu, sigma);
     }
 
   }

--- a/stan/math/prim/scal/prob/uniform_ccdf_log.hpp
+++ b/stan/math/prim/scal/prob/uniform_ccdf_log.hpp
@@ -1,83 +1,18 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_UNIFORM_CCDF_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_UNIFORM_CCDF_LOG_HPP
 
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_finite.hpp>
-#include <stan/math/prim/scal/err/check_greater.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <boost/random/uniform_real_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <cmath>
+#include <stan/math/prim/scal/prob/uniform_lccdf.hpp>
 
 namespace stan {
   namespace math {
 
+    /**
+     * @deprecated use <code>uniform_lccdf</code>
+     */
     template <typename T_y, typename T_low, typename T_high>
     typename return_type<T_y, T_low, T_high>::type
     uniform_ccdf_log(const T_y& y, const T_low& alpha, const T_high& beta) {
-      static const char* function("uniform_ccdf_log");
-      typedef typename stan::partials_return_type<T_y, T_low, T_high>::type
-        T_partials_return;
-
-      using std::log;
-
-      if (!(stan::length(y)
-            && stan::length(alpha)
-            && stan::length(beta)))
-        return 0.0;
-
-      T_partials_return ccdf_log(0.0);
-      check_not_nan(function, "Random variable", y);
-      check_finite(function, "Lower bound parameter", alpha);
-      check_finite(function, "Upper bound parameter", beta);
-      check_greater(function, "Upper bound parameter", beta, alpha);
-      check_consistent_sizes(function,
-                             "Random variable", y,
-                             "Lower bound parameter", alpha,
-                             "Upper bound parameter", beta);
-
-      VectorView<const T_y> y_vec(y);
-      VectorView<const T_low> alpha_vec(alpha);
-      VectorView<const T_high> beta_vec(beta);
-      size_t N = max_size(y, alpha, beta);
-
-      for (size_t n = 0; n < N; n++) {
-        const T_partials_return y_dbl = value_of(y_vec[n]);
-        if (y_dbl < value_of(alpha_vec[n])
-            || y_dbl > value_of(beta_vec[n]))
-          return 0.0;
-        if (y_dbl == value_of(beta_vec[n]))
-          return LOG_ZERO;
-      }
-
-      OperandsAndPartials<T_y, T_low, T_high>
-        operands_and_partials(y, alpha, beta);
-      for (size_t n = 0; n < N; n++) {
-        const T_partials_return y_dbl = value_of(y_vec[n]);
-        const T_partials_return alpha_dbl = value_of(alpha_vec[n]);
-        const T_partials_return beta_dbl = value_of(beta_vec[n]);
-        const T_partials_return b_min_a = beta_dbl - alpha_dbl;
-        const T_partials_return ccdf_log_ = 1.0 - (y_dbl - alpha_dbl) / b_min_a;
-
-        ccdf_log += log(ccdf_log_);
-
-        if (!is_constant_struct<T_y>::value)
-          operands_and_partials.d_x1[n] -= 1.0 / b_min_a / ccdf_log_;
-        if (!is_constant_struct<T_low>::value)
-          operands_and_partials.d_x2[n] -= (y_dbl - beta_dbl) / b_min_a
-            / b_min_a / ccdf_log_;
-        if (!is_constant_struct<T_high>::value)
-          operands_and_partials.d_x3[n] += (y_dbl - alpha_dbl) / b_min_a
-            / b_min_a / ccdf_log_;
-      }
-      return operands_and_partials.value(ccdf_log);
+      return uniform_lccdf<T_y, T_low, T_high>(y, alpha, beta);
     }
 
   }

--- a/stan/math/prim/scal/prob/uniform_cdf_log.hpp
+++ b/stan/math/prim/scal/prob/uniform_cdf_log.hpp
@@ -1,83 +1,18 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_UNIFORM_CDF_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_UNIFORM_CDF_LOG_HPP
 
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_finite.hpp>
-#include <stan/math/prim/scal/err/check_greater.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <boost/random/uniform_real_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <cmath>
+#include <stan/math/prim/scal/prob/uniform_lcdf.hpp>
 
 namespace stan {
   namespace math {
 
+    /**
+     * @deprecated use <code>uniform_lcdf</code>
+     */
     template <typename T_y, typename T_low, typename T_high>
     typename return_type<T_y, T_low, T_high>::type
     uniform_cdf_log(const T_y& y, const T_low& alpha, const T_high& beta) {
-      static const char* function("uniform_cdf_log");
-      typedef typename stan::partials_return_type<T_y, T_low, T_high>::type
-        T_partials_return;
-
-      using std::log;
-
-      if (!(stan::length(y)
-            && stan::length(alpha)
-            && stan::length(beta)))
-        return 0.0;
-
-      T_partials_return cdf_log(0.0);
-      check_not_nan(function, "Random variable", y);
-      check_finite(function, "Lower bound parameter", alpha);
-      check_finite(function, "Upper bound parameter", beta);
-      check_greater(function, "Upper bound parameter", beta, alpha);
-      check_consistent_sizes(function,
-                             "Random variable", y,
-                             "Lower bound parameter", alpha,
-                             "Upper bound parameter", beta);
-
-      VectorView<const T_y> y_vec(y);
-      VectorView<const T_low> alpha_vec(alpha);
-      VectorView<const T_high> beta_vec(beta);
-      size_t N = max_size(y, alpha, beta);
-
-      OperandsAndPartials<T_y, T_low, T_high>
-        operands_and_partials(y, alpha, beta);
-
-      for (size_t n = 0; n < N; n++) {
-        const T_partials_return y_dbl = value_of(y_vec[n]);
-        if (y_dbl < value_of(alpha_vec[n])
-            || y_dbl > value_of(beta_vec[n]))
-          return negative_infinity();
-        if (y_dbl == value_of(beta_vec[n]))
-          return operands_and_partials.value(0.0);
-      }
-
-      for (size_t n = 0; n < N; n++) {
-        const T_partials_return y_dbl = value_of(y_vec[n]);
-        const T_partials_return alpha_dbl = value_of(alpha_vec[n]);
-        const T_partials_return beta_dbl = value_of(beta_vec[n]);
-        const T_partials_return b_min_a = beta_dbl - alpha_dbl;
-        const T_partials_return cdf_log_ = (y_dbl - alpha_dbl) / b_min_a;
-
-        cdf_log += log(cdf_log_);
-
-        if (!is_constant_struct<T_y>::value)
-          operands_and_partials.d_x1[n] += 1.0 / b_min_a / cdf_log_;
-        if (!is_constant_struct<T_low>::value)
-          operands_and_partials.d_x2[n] += (y_dbl - beta_dbl) / b_min_a
-            / b_min_a / cdf_log_;
-        if (!is_constant_struct<T_high>::value)
-          operands_and_partials.d_x3[n] -= 1.0 / b_min_a;
-      }
-      return operands_and_partials.value(cdf_log);
+      return uniform_lcdf<T_y, T_low, T_high>(y, alpha, beta);
     }
 
   }

--- a/stan/math/prim/scal/prob/uniform_log.hpp
+++ b/stan/math/prim/scal/prob/uniform_log.hpp
@@ -1,20 +1,7 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_UNIFORM_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_UNIFORM_LOG_HPP
 
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_finite.hpp>
-#include <stan/math/prim/scal/err/check_greater.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <boost/random/uniform_real_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <cmath>
+#include <stan/math/prim/scal/prob/uniform_lpdf.hpp>
 
 namespace stan {
   namespace math {
@@ -31,6 +18,8 @@ namespace stan {
      & & \mathrm{ where } \; y \in [\alpha, \beta], \log(0) \; \mathrm{otherwise}
      \f}
      *
+     * @deprecated use <code>uniform_lpdf</code>
+     *
      * @param y A scalar variable.
      * @param alpha Lower bound.
      * @param beta Upper bound.
@@ -44,77 +33,17 @@ namespace stan {
               typename T_y, typename T_low, typename T_high>
     typename return_type<T_y, T_low, T_high>::type
     uniform_log(const T_y& y, const T_low& alpha, const T_high& beta) {
-      static const char* function("uniform_log");
-      typedef typename stan::partials_return_type<T_y, T_low, T_high>::type
-        T_partials_return;
-
-      using std::log;
-
-      if (!(stan::length(y)
-            && stan::length(alpha)
-            && stan::length(beta)))
-        return 0.0;
-
-      T_partials_return logp(0.0);
-      check_not_nan(function, "Random variable", y);
-      check_finite(function, "Lower bound parameter", alpha);
-      check_finite(function, "Upper bound parameter", beta);
-      check_greater(function, "Upper bound parameter", beta, alpha);
-      check_consistent_sizes(function,
-                             "Random variable", y,
-                             "Lower bound parameter", alpha,
-                             "Upper bound parameter", beta);
-
-      if (!include_summand<propto, T_y, T_low, T_high>::value)
-        return 0.0;
-
-      VectorView<const T_y> y_vec(y);
-      VectorView<const T_low> alpha_vec(alpha);
-      VectorView<const T_high> beta_vec(beta);
-      size_t N = max_size(y, alpha, beta);
-
-      for (size_t n = 0; n < N; n++) {
-        const T_partials_return y_dbl = value_of(y_vec[n]);
-        if (y_dbl < value_of(alpha_vec[n])
-            || y_dbl > value_of(beta_vec[n]))
-          return LOG_ZERO;
-      }
-
-      VectorBuilder<include_summand<propto, T_low, T_high>::value,
-                    T_partials_return, T_low, T_high>
-        inv_beta_minus_alpha(max_size(alpha, beta));
-      for (size_t i = 0; i < max_size(alpha, beta); i++)
-        if (include_summand<propto, T_low, T_high>::value)
-          inv_beta_minus_alpha[i]
-            = 1.0 / (value_of(beta_vec[i]) - value_of(alpha_vec[i]));
-
-      VectorBuilder<include_summand<propto, T_low, T_high>::value,
-                    T_partials_return, T_low, T_high>
-        log_beta_minus_alpha(max_size(alpha, beta));
-      for (size_t i = 0; i < max_size(alpha, beta); i++)
-        if (include_summand<propto, T_low, T_high>::value)
-          log_beta_minus_alpha[i]
-            = log(value_of(beta_vec[i]) - value_of(alpha_vec[i]));
-
-      OperandsAndPartials<T_y, T_low, T_high>
-        operands_and_partials(y, alpha, beta);
-      for (size_t n = 0; n < N; n++) {
-        if (include_summand<propto, T_low, T_high>::value)
-          logp -= log_beta_minus_alpha[n];
-
-        if (!is_constant_struct<T_low>::value)
-          operands_and_partials.d_x2[n] += inv_beta_minus_alpha[n];
-        if (!is_constant_struct<T_high>::value)
-          operands_and_partials.d_x3[n] -= inv_beta_minus_alpha[n];
-      }
-      return operands_and_partials.value(logp);
+      return uniform_lpdf<propto, T_y, T_low, T_high>(y, alpha, beta);
     }
 
+    /**
+     * @deprecated use <code>uniform_lpdf</code>
+     */
     template <typename T_y, typename T_low, typename T_high>
     inline
     typename return_type<T_y, T_low, T_high>::type
     uniform_log(const T_y& y, const T_low& alpha, const T_high& beta) {
-      return uniform_log<false>(y, alpha, beta);
+      return uniform_lpdf<T_y, T_low, T_high>(y, alpha, beta);
     }
 
   }

--- a/stan/math/prim/scal/prob/von_mises_log.hpp
+++ b/stan/math/prim/scal/prob/von_mises_log.hpp
@@ -1,118 +1,28 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_VON_MISES_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_VON_MISES_LOG_HPP
 
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_finite.hpp>
-#include <stan/math/prim/scal/err/check_greater.hpp>
-#include <stan/math/prim/scal/err/check_nonnegative.hpp>
-#include <stan/math/prim/scal/err/check_positive_finite.hpp>
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/fun/modified_bessel_first_kind.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <stan/math/prim/scal/meta/VectorView.hpp>
-#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <cmath>
+#include <stan/math/prim/scal/prob/von_mises_lpdf.hpp>
 
 namespace stan {
   namespace math {
 
+    /**
+     * @deprecated use <code>von_mises_lpdf</code>
+     */
     template<bool propto,
              typename T_y, typename T_loc, typename T_scale>
     typename return_type<T_y, T_loc, T_scale>::type
     von_mises_log(T_y const& y, T_loc const& mu, T_scale const& kappa) {
-      static char const* const function = "von_mises_log";
-      typedef typename stan::partials_return_type<T_y, T_loc, T_scale>::type
-        T_partials_return;
-
-      if (!(stan::length(y)
-            && stan::length(mu)
-            && stan::length(kappa)))
-        return 0.0;
-
-      using stan::is_constant_struct;
-
-      using std::log;
-
-      T_partials_return logp = 0.0;
-
-      check_finite(function, "Random variable", y);
-      check_finite(function, "Location paramter", mu);
-      check_positive_finite(function, "Scale parameter", kappa);
-      check_consistent_sizes(function,
-                             "Random variable", y,
-                             "Location parameter", mu,
-                             "Scale parameter", kappa);
-
-      if (!include_summand<propto, T_y, T_loc, T_scale>::value)
-        return logp;
-
-      const bool y_const = is_constant_struct<T_y>::value;
-      const bool mu_const = is_constant_struct<T_loc>::value;
-      const bool kappa_const = is_constant_struct<T_scale>::value;
-
-      const bool compute_bessel0 = include_summand<propto, T_scale>::value;
-      const bool compute_bessel1 = !kappa_const;
-      const double TWO_PI = 2.0 * pi();
-
-      VectorView<const T_y> y_vec(y);
-      VectorView<const T_loc> mu_vec(mu);
-      VectorView<const T_scale> kappa_vec(kappa);
-
-      VectorBuilder<true, T_partials_return, T_scale> kappa_dbl(length(kappa));
-      VectorBuilder<include_summand<propto, T_scale>::value,
-                    T_partials_return, T_scale> log_bessel0(length(kappa));
-      for (size_t i = 0; i < length(kappa); i++) {
-        kappa_dbl[i] = value_of(kappa_vec[i]);
-        if (include_summand<propto, T_scale>::value)
-          log_bessel0[i]
-            = log(modified_bessel_first_kind(0, value_of(kappa_vec[i])));
-      }
-
-      OperandsAndPartials<T_y, T_loc, T_scale>
-        operands_and_partials(y, mu, kappa);
-
-      size_t N = max_size(y, mu, kappa);
-
-      for (size_t n = 0; n < N; n++) {
-        const T_partials_return y_ = value_of(y_vec[n]);
-        const T_partials_return y_dbl =  y_ - floor(y_ / TWO_PI) * TWO_PI;
-        const T_partials_return mu_dbl = value_of(mu_vec[n]);
-
-        T_partials_return bessel0 = 0;
-        if (compute_bessel0)
-          bessel0 = modified_bessel_first_kind(0, kappa_dbl[n]);
-        T_partials_return bessel1 = 0;
-        if (compute_bessel1)
-          bessel1 = modified_bessel_first_kind(-1, kappa_dbl[n]);
-        const T_partials_return kappa_sin = kappa_dbl[n] * sin(mu_dbl - y_dbl);
-        const T_partials_return kappa_cos = kappa_dbl[n] * cos(mu_dbl - y_dbl);
-
-        if (include_summand<propto>::value)
-          logp -= LOG_TWO_PI;
-        if (include_summand<propto, T_scale>::value)
-          logp -= log_bessel0[n];
-        if (include_summand<propto, T_y, T_loc, T_scale>::value)
-          logp += kappa_cos;
-
-        if (!y_const)
-          operands_and_partials.d_x1[n] += kappa_sin;
-        if (!mu_const)
-          operands_and_partials.d_x2[n] -= kappa_sin;
-        if (!kappa_const)
-          operands_and_partials.d_x3[n] += kappa_cos / kappa_dbl[n]
-            - bessel1 / bessel0;
-      }
-      return operands_and_partials.value(logp);
+      return von_mises_lpdf<propto, T_y, T_loc, T_scale>(y, mu, kappa);
     }
 
+    /**
+     * @deprecated use <code>von_mises_lpdf</code>
+     */
     template<typename T_y, typename T_loc, typename T_scale>
     inline typename return_type<T_y, T_loc, T_scale>::type
     von_mises_log(T_y const& y, T_loc const& mu, T_scale const& kappa) {
-      return von_mises_log<false>(y, mu, kappa);
+      return von_mises_lpdf<T_y, T_loc, T_scale>(y, mu, kappa);
     }
 
   }

--- a/stan/math/prim/scal/prob/weibull_ccdf_log.hpp
+++ b/stan/math/prim/scal/prob/weibull_ccdf_log.hpp
@@ -1,72 +1,18 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_WEIBULL_CCDF_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_WEIBULL_CCDF_LOG_HPP
 
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_finite.hpp>
-#include <stan/math/prim/scal/err/check_nonnegative.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/err/check_positive_finite.hpp>
-#include <stan/math/prim/scal/fun/multiply_log.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/meta/length.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
-#include <stan/math/prim/scal/meta/VectorView.hpp>
-#include <boost/random/weibull_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <cmath>
+#include <stan/math/prim/scal/prob/weibull_lccdf.hpp>
 
 namespace stan {
   namespace math {
 
+    /**
+     * @deprecated use <code>weibull_lccdf</code>
+     */
     template <typename T_y, typename T_shape, typename T_scale>
     typename return_type<T_y, T_shape, T_scale>::type
     weibull_ccdf_log(const T_y& y, const T_shape& alpha, const T_scale& sigma) {
-      typedef typename stan::partials_return_type<T_y, T_shape, T_scale>::type
-        T_partials_return;
-
-      static const char* function("weibull_ccdf_log");
-
-      using boost::math::tools::promote_args;
-      using std::log;
-
-      if (!(stan::length(y)
-            && stan::length(alpha)
-            && stan::length(sigma)))
-        return 0.0;
-
-      T_partials_return ccdf_log(0.0);
-      check_nonnegative(function, "Random variable", y);
-      check_positive_finite(function, "Shape parameter", alpha);
-      check_positive_finite(function, "Scale parameter", sigma);
-
-      OperandsAndPartials<T_y, T_shape, T_scale>
-        operands_and_partials(y, alpha, sigma);
-
-      VectorView<const T_y> y_vec(y);
-      VectorView<const T_scale> sigma_vec(sigma);
-      VectorView<const T_shape> alpha_vec(alpha);
-      size_t N = max_size(y, sigma, alpha);
-      for (size_t n = 0; n < N; n++) {
-        const T_partials_return y_dbl = value_of(y_vec[n]);
-        const T_partials_return sigma_dbl = value_of(sigma_vec[n]);
-        const T_partials_return alpha_dbl = value_of(alpha_vec[n]);
-        const T_partials_return pow_ = pow(y_dbl / sigma_dbl, alpha_dbl);
-
-        ccdf_log -= pow_;
-
-        if (!is_constant_struct<T_y>::value)
-          operands_and_partials.d_x1[n] -= alpha_dbl / y_dbl * pow_;
-        if (!is_constant_struct<T_shape>::value)
-          operands_and_partials.d_x2[n] -= log(y_dbl / sigma_dbl) * pow_;
-        if (!is_constant_struct<T_scale>::value)
-          operands_and_partials.d_x3[n] += alpha_dbl / sigma_dbl * pow_;
-      }
-      return operands_and_partials.value(ccdf_log);
+      return weibull_lccdf<T_y, T_shape, T_scale>(y, alpha, sigma);
     }
 
   }

--- a/stan/math/prim/scal/prob/weibull_cdf_log.hpp
+++ b/stan/math/prim/scal/prob/weibull_cdf_log.hpp
@@ -1,76 +1,18 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_WEIBULL_CDF_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_WEIBULL_CDF_LOG_HPP
 
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_finite.hpp>
-#include <stan/math/prim/scal/err/check_nonnegative.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/err/check_positive_finite.hpp>
-#include <stan/math/prim/scal/fun/multiply_log.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/meta/length.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
-#include <stan/math/prim/scal/meta/VectorView.hpp>
-#include <boost/random/weibull_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <cmath>
+#include <stan/math/prim/scal/prob/weibull_lcdf.hpp>
 
 namespace stan {
   namespace math {
 
+    /**
+     * @deprecated use <code>weibull_lcdf</code>
+     */
     template <typename T_y, typename T_shape, typename T_scale>
     typename return_type<T_y, T_shape, T_scale>::type
     weibull_cdf_log(const T_y& y, const T_shape& alpha, const T_scale& sigma) {
-      typedef typename stan::partials_return_type<T_y, T_shape, T_scale>::type
-        T_partials_return;
-
-      static const char* function("weibull_cdf_log");
-
-      using boost::math::tools::promote_args;
-      using std::log;
-      using std::exp;
-
-      if (!(stan::length(y)
-            && stan::length(alpha)
-            && stan::length(sigma)))
-        return 0.0;
-
-      T_partials_return cdf_log(0.0);
-      check_nonnegative(function, "Random variable", y);
-      check_positive_finite(function, "Shape parameter", alpha);
-      check_positive_finite(function, "Scale parameter", sigma);
-
-      OperandsAndPartials<T_y, T_shape, T_scale>
-        operands_and_partials(y, alpha, sigma);
-
-      VectorView<const T_y> y_vec(y);
-      VectorView<const T_scale> sigma_vec(sigma);
-      VectorView<const T_shape> alpha_vec(alpha);
-      size_t N = max_size(y, sigma, alpha);
-      for (size_t n = 0; n < N; n++) {
-        const T_partials_return y_dbl = value_of(y_vec[n]);
-        const T_partials_return sigma_dbl = value_of(sigma_vec[n]);
-        const T_partials_return alpha_dbl = value_of(alpha_vec[n]);
-        const T_partials_return pow_ = pow(y_dbl / sigma_dbl, alpha_dbl);
-        const T_partials_return exp_ = exp(-pow_);
-        const T_partials_return cdf_ = 1.0 - exp_;
-
-        cdf_log += log(cdf_);
-
-        const T_partials_return rep_deriv = pow_ / (1.0 / exp_ - 1.0);
-        if (!is_constant_struct<T_y>::value)
-          operands_and_partials.d_x1[n] += rep_deriv * alpha_dbl / y_dbl;
-        if (!is_constant_struct<T_shape>::value)
-          operands_and_partials.d_x2[n] += rep_deriv * log(y_dbl / sigma_dbl);
-        if (!is_constant_struct<T_scale>::value)
-          operands_and_partials.d_x3[n] -= rep_deriv * alpha_dbl / sigma_dbl;
-      }
-      return operands_and_partials.value(cdf_log);
+      return weibull_lcdf<T_y, T_shape, T_scale>(y, alpha, sigma);
     }
 
   }

--- a/stan/math/prim/scal/prob/weibull_log.hpp
+++ b/stan/math/prim/scal/prob/weibull_log.hpp
@@ -1,136 +1,29 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_WEIBULL_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_WEIBULL_LOG_HPP
 
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_finite.hpp>
-#include <stan/math/prim/scal/err/check_nonnegative.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/err/check_positive_finite.hpp>
-#include <stan/math/prim/scal/fun/multiply_log.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/meta/length.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
-#include <stan/math/prim/scal/meta/VectorView.hpp>
-#include <boost/random/weibull_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <cmath>
+#include <stan/math/prim/scal/prob/weibull_lpdf.hpp>
 
 namespace stan {
   namespace math {
 
-    // Weibull(y|alpha, sigma)     [y >= 0;  alpha > 0;  sigma > 0]
+    /**
+     * @deprecated use <code>weibull_lpdf</code>
+     */
     template <bool propto,
               typename T_y, typename T_shape, typename T_scale>
     typename return_type<T_y, T_shape, T_scale>::type
     weibull_log(const T_y& y, const T_shape& alpha, const T_scale& sigma) {
-      static const char* function("weibull_log");
-      typedef typename stan::partials_return_type<T_y, T_shape, T_scale>::type
-        T_partials_return;
-
-      using std::log;
-
-      if (!(stan::length(y)
-            && stan::length(alpha)
-            && stan::length(sigma)))
-        return 0.0;
-
-      T_partials_return logp(0.0);
-      check_finite(function, "Random variable", y);
-      check_positive_finite(function, "Shape parameter", alpha);
-      check_positive_finite(function, "Scale parameter", sigma);
-      check_consistent_sizes(function,
-                             "Random variable", y,
-                             "Shape parameter", alpha,
-                             "Scale parameter", sigma);
-
-      if (!include_summand<propto, T_y, T_shape, T_scale>::value)
-        return 0.0;
-
-      VectorView<const T_y> y_vec(y);
-      VectorView<const T_shape> alpha_vec(alpha);
-      VectorView<const T_scale> sigma_vec(sigma);
-      size_t N = max_size(y, alpha, sigma);
-
-      for (size_t n = 0; n < N; n++) {
-        const T_partials_return y_dbl = value_of(y_vec[n]);
-        if (y_dbl < 0)
-          return LOG_ZERO;
-      }
-
-      VectorBuilder<include_summand<propto, T_shape>::value,
-                    T_partials_return, T_shape> log_alpha(length(alpha));
-      for (size_t i = 0; i < length(alpha); i++)
-        if (include_summand<propto, T_shape>::value)
-          log_alpha[i] = log(value_of(alpha_vec[i]));
-
-      VectorBuilder<include_summand<propto, T_y, T_shape>::value,
-                    T_partials_return, T_y> log_y(length(y));
-      for (size_t i = 0; i < length(y); i++)
-        if (include_summand<propto, T_y, T_shape>::value)
-          log_y[i] = log(value_of(y_vec[i]));
-
-      VectorBuilder<include_summand<propto, T_shape, T_scale>::value,
-                    T_partials_return, T_scale> log_sigma(length(sigma));
-      for (size_t i = 0; i < length(sigma); i++)
-        if (include_summand<propto, T_shape, T_scale>::value)
-          log_sigma[i] = log(value_of(sigma_vec[i]));
-
-      VectorBuilder<include_summand<propto, T_y, T_shape, T_scale>::value,
-                    T_partials_return, T_scale> inv_sigma(length(sigma));
-      for (size_t i = 0; i < length(sigma); i++)
-        if (include_summand<propto, T_y, T_shape, T_scale>::value)
-          inv_sigma[i] = 1.0 / value_of(sigma_vec[i]);
-
-      VectorBuilder<include_summand<propto, T_y, T_shape, T_scale>::value,
-                    T_partials_return, T_y, T_shape, T_scale>
-        y_div_sigma_pow_alpha(N);
-      for (size_t i = 0; i < N; i++)
-        if (include_summand<propto, T_y, T_shape, T_scale>::value) {
-          const T_partials_return y_dbl = value_of(y_vec[i]);
-          const T_partials_return alpha_dbl = value_of(alpha_vec[i]);
-          y_div_sigma_pow_alpha[i] = pow(y_dbl * inv_sigma[i], alpha_dbl);
-        }
-
-      OperandsAndPartials<T_y, T_shape, T_scale>
-        operands_and_partials(y, alpha, sigma);
-      for (size_t n = 0; n < N; n++) {
-        const T_partials_return alpha_dbl = value_of(alpha_vec[n]);
-        if (include_summand<propto, T_shape>::value)
-          logp += log_alpha[n];
-        if (include_summand<propto, T_y, T_shape>::value)
-          logp += (alpha_dbl-1.0)*log_y[n];
-        if (include_summand<propto, T_shape, T_scale>::value)
-          logp -= alpha_dbl*log_sigma[n];
-        if (include_summand<propto, T_y, T_shape, T_scale>::value)
-          logp -= y_div_sigma_pow_alpha[n];
-
-        if (!is_constant_struct<T_y>::value) {
-          const T_partials_return inv_y = 1.0 / value_of(y_vec[n]);
-          operands_and_partials.d_x1[n]
-            += (alpha_dbl-1.0) * inv_y
-            - alpha_dbl * y_div_sigma_pow_alpha[n] * inv_y;
-        }
-        if (!is_constant_struct<T_shape>::value)
-          operands_and_partials.d_x2[n]
-            += 1.0/alpha_dbl
-            + (1.0 - y_div_sigma_pow_alpha[n]) * (log_y[n] - log_sigma[n]);
-        if (!is_constant_struct<T_scale>::value)
-          operands_and_partials.d_x3[n]
-            += alpha_dbl * inv_sigma[n] * (y_div_sigma_pow_alpha[n] - 1.0);
-      }
-      return operands_and_partials.value(logp);
+      return weibull_lpdf<propto, T_y, T_shape, T_scale>(y, alpha, sigma);
     }
 
+    /**
+     * @deprecated use <code>weibull_lpdf</code>
+     */
     template <typename T_y, typename T_shape, typename T_scale>
     inline
     typename return_type<T_y, T_shape, T_scale>::type
     weibull_log(const T_y& y, const T_shape& alpha, const T_scale& sigma) {
-      return weibull_log<false>(y, alpha, sigma);
+      return weibull_lpdf<T_y, T_shape, T_scale>(y, alpha, sigma);
     }
 
   }

--- a/stan/math/prim/scal/prob/wiener_log.hpp
+++ b/stan/math/prim/scal/prob/wiener_log.hpp
@@ -1,49 +1,7 @@
-// Original code from which Stan's code is derived:
-// Copyright (c) 2013, Joachim Vandekerckhove.
-// All rights reserved.
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted
-// provided that the following conditions are met:
-//
-//   * Redistributions of source code must retain the above copyright notice,
-//   * this list of conditions and the following disclaimer.
-//   * Redistributions in binary form must reproduce the above copyright notice,
-//   * this list of conditions and the following disclaimer in the
-//   * documentation and/or other materials provided with the distribution.
-//   * Neither the name of the University of California, Irvine nor the names
-//   * of its contributors may be used to endorse or promote products derived
-//   * from this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
-// THE POSSIBILITY OF SUCH DAMAGE.
-
 #ifndef STAN_MATH_PRIM_MAT_PROB_WIENER_LOG_HPP
 #define STAN_MATH_PRIM_MAT_PROB_WIENER_LOG_HPP
 
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/fun/square.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_bounded.hpp>
-#include <stan/math/prim/scal/err/check_finite.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/err/check_positive.hpp>
-#include <stan/math/prim/scal/meta/return_type.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <boost/math/distributions.hpp>
-#include <algorithm>
-#include <cmath>
-#include <string>
+#include <stan/math/prim/scal/prob/wiener_lpdf.hpp>
 
 namespace stan {
   namespace math {
@@ -57,6 +15,8 @@ namespace stan {
      * \f$\beta\f$ must be between 0 and 1. \f$y\f$ should contain
      * reaction times in seconds (strictly positive) with
      * upper-boundary responses.
+     *
+     * @deprecated use <code>wiener_lpdf</code>
      *
      * @param y A scalar variate.
      * @param alpha The boundary separation.
@@ -72,140 +32,21 @@ namespace stan {
     typename return_type<T_y, T_alpha, T_tau, T_beta, T_delta>::type
     wiener_log(const T_y& y, const T_alpha& alpha, const T_tau& tau,
                const T_beta& beta, const T_delta& delta) {
-      static const char* function("wiener_log(%1%)");
-
-      using std::log;
-      using std::exp;
-      using std::pow;
-
-      static const double WIENER_ERR = 0.000001;
-      static const double PI_TIMES_WIENER_ERR = pi() * WIENER_ERR;
-      static const double LOG_PI_LOG_WIENER_ERR =
-        LOG_PI + log(WIENER_ERR);
-      static const double
-        TWO_TIMES_SQRT_2_TIMES_SQRT_PI_TIMES_WIENER_ERR =
-        2.0 * SQRT_2_TIMES_SQRT_PI * WIENER_ERR;
-      static const double LOG_TWO_OVER_TWO_PLUS_LOG_SQRT_PI =
-        LOG_TWO / 2 + LOG_SQRT_PI;
-      static const double SQUARE_PI_OVER_TWO = square(pi()) * 0.5;
-      static const double TWO_TIMES_LOG_SQRT_PI = 2.0 * LOG_SQRT_PI;
-
-      if (!(stan::length(y)
-            && stan::length(alpha)
-            && stan::length(beta)
-            && stan::length(tau)
-            && stan::length(delta)))
-        return 0.0;
-
-      typedef typename return_type<T_y, T_alpha, T_tau,
-                                   T_beta, T_delta>::type T_return_type;
-      T_return_type lp(0.0);
-
-      check_not_nan(function, "Random variable", y);
-      check_not_nan(function, "Boundary separation", alpha);
-      check_not_nan(function, "A-priori bias", beta);
-      check_not_nan(function, "Nondecision time", tau);
-      check_not_nan(function, "Drift rate", delta);
-      check_finite(function, "Boundary separation", alpha);
-      check_finite(function, "A-priori bias", beta);
-      check_finite(function, "Nondecision time", tau);
-      check_finite(function, "Drift rate", delta);
-      check_positive(function, "Random variable", y);
-      check_positive(function, "Boundary separation", alpha);
-      check_positive(function, "Nondecision time", tau);
-      check_bounded(function, "A-priori bias", beta , 0, 1);
-      check_consistent_sizes(function, "Random variable", y,
-                             "Boundary separation", alpha,
-                             "A-priori bias", beta,
-                             "Nondecision time", tau, "Drift rate", delta);
-
-      size_t N = std::max(max_size(y, alpha, beta), max_size(tau, delta));
-      if (!N) return 0.0;
-
-      VectorView<const T_y> y_vec(y);
-      VectorView<const T_alpha> alpha_vec(alpha);
-      VectorView<const T_beta> beta_vec(beta);
-      VectorView<const T_tau> tau_vec(tau);
-      VectorView<const T_delta> delta_vec(delta);
-
-      size_t N_y_tau = max_size(y, tau);
-      for (size_t i = 0; i < N_y_tau; ++i) {
-        if (y_vec[i] <= tau_vec[i]) {
-          std::stringstream msg;
-          msg << ", but must be greater than nondecision time = " << tau_vec[i];
-          std::string msg_str(msg.str());
-          domain_error(function, "Random variable", y_vec[i], " = ",
-                       msg_str.c_str());
-        }
-      }
-
-      if (!include_summand<propto, T_y, T_alpha, T_tau, T_beta, T_delta>::value)
-        return 0;
-
-      for (size_t i = 0; i < N; i++) {
-        typename scalar_type<T_beta>::type one_minus_beta = 1.0 - beta_vec[i];
-        typename scalar_type<T_alpha>::type alpha2 = square(alpha_vec[i]);
-        T_return_type x = (y_vec[i] - tau_vec[i]) / alpha2;
-        T_return_type kl, ks, tmp = 0;
-        T_return_type k, K;
-        T_return_type sqrt_x = sqrt(x);
-        T_return_type log_x = log(x);
-        T_return_type one_over_pi_times_sqrt_x = 1.0 / pi() * sqrt_x;
-
-        // calculate number of terms needed for large t:
-        // if error threshold is set low enough
-        if (PI_TIMES_WIENER_ERR * x < 1) {
-          // compute bound
-          kl = sqrt(-2.0 * SQRT_PI * (LOG_PI_LOG_WIENER_ERR + log_x)) / sqrt_x;
-          // ensure boundary conditions met
-          kl = (kl > one_over_pi_times_sqrt_x) ? kl : one_over_pi_times_sqrt_x;
-        } else {
-          kl = one_over_pi_times_sqrt_x;  // set to boundary condition
-        }
-        // calculate number of terms needed for small t:
-        // if error threshold is set low enough
-        T_return_type tmp_expr0
-          = TWO_TIMES_SQRT_2_TIMES_SQRT_PI_TIMES_WIENER_ERR * sqrt_x;
-        if (tmp_expr0 < 1) {
-          // compute bound
-          ks = 2.0 +  sqrt_x * sqrt(-2 * log(tmp_expr0));
-          // ensure boundary conditions are met
-          T_return_type sqrt_x_plus_one = sqrt_x + 1.0;
-          ks = (ks > sqrt_x_plus_one) ? ks : sqrt_x_plus_one;
-        } else {  // if error threshold was set too high
-          ks = 2.0;  // minimal kappa for that case
-        }
-        if (ks < kl) {  // small t
-          K = ceil(ks);  // round to smallest integer meeting error
-          T_return_type tmp_expr1 = (K - 1.0) / 2.0;
-          T_return_type tmp_expr2 = ceil(tmp_expr1);
-          for (k = -floor(tmp_expr1); k <= tmp_expr2; k++)
-            tmp += (one_minus_beta + 2.0 * k) *
-              exp(-(square(one_minus_beta + 2.0 * k)) * 0.5 / x);
-          tmp = log(tmp) - LOG_TWO_OVER_TWO_PLUS_LOG_SQRT_PI - 1.5 * log_x;
-        } else {  // if large t is better...
-          K = ceil(kl);  // round to smallest integer meeting error
-          for (k = 1; k <= K; ++k)
-            tmp += k * exp(-(square(k)) * (SQUARE_PI_OVER_TWO * x))
-              * sin(k * pi() * one_minus_beta);
-          tmp = log(tmp) + TWO_TIMES_LOG_SQRT_PI;
-        }
-
-        // convert to f(t|v,a,w) and return result
-        lp += delta_vec[i] * alpha_vec[i] * one_minus_beta
-          - square(delta_vec[i]) * x * alpha2 / 2.0
-          - log(alpha2) + tmp;
-      }
-      return lp;
+      return wiener_lpdf<propto, T_y, T_alpha, T_tau,
+                         T_beta, T_delta>(y, alpha, tau, beta, delta);
     }
 
+    /**
+     * @deprecated use <code>wiener_lpdf</code>
+     */
     template <typename T_y, typename T_alpha, typename T_tau,
               typename T_beta, typename T_delta>
     inline
     typename return_type<T_y, T_alpha, T_tau, T_beta, T_delta>::type
     wiener_log(const T_y& y, const T_alpha& alpha, const T_tau& tau,
                const T_beta& beta, const T_delta& delta) {
-      return wiener_log<false>(y, alpha, tau, beta, delta);
+      return wiener_lpdf<T_y, T_alpha, T_tau,
+                         T_beta, T_delta>(y, alpha, tau, beta, delta);
     }
 
   }


### PR DESCRIPTION
#### Note on the 10 related pull requests
This is staged as follows:
- pull requests 1-7 will be adding new functions that mirror the old `_log` functions without altering the `_log` functions (except in situations where there are multiple definitions)
- pull requests 8-10 will deprecate the old functions and have the old functions call the new functions.
- This should wait on PRs: #441, #442, #443, #444, #445, #446, #447.

#### Submisison Checklist

- [x] Run unit tests: `./runTests.py test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary:
This pull request deprecates the `_log` functions by calling the new `_lpdf` / `_lpmf` / `_lcdf` / `_lccdf` function.

#### How to Verify:
Look at code and run code.

#### Side Effects:
None.

#### Documentation:
Doxygen doc deprecating the `_log` function.

#### Reviewer Suggestions: 
Anyone.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Columbia University.

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
