### PR TITLE
Fixes doxygen on develop

### DIFF
--- a/doxygen/doxygen.cfg
+++ b/doxygen/doxygen.cfg
@@ -68,7 +68,7 @@ OUTPUT_DIRECTORY       = doc/api
 # performance problems for the file system.
 # The default value is: NO.
 
-CREATE_SUBDIRS         = NO
+CREATE_SUBDIRS         = YES
 
 # # If the ALLOW_UNICODE_NAMES tag is set to YES, doxygen will allow non-ASCII
 # # characters to appear in the names of generated files. If set to NO, non-ASCII
@@ -693,7 +693,7 @@ CITE_BIB_FILES         =
 # messages are off.
 # The default value is: NO.
 
-QUIET                  = NO
+QUIET                  = YES
 
 # The WARNINGS tag can be used to turn on/off the warning messages that are
 # generated to standard error ( stderr) by doxygen. If WARNINGS is set to YES
@@ -726,6 +726,12 @@ WARN_IF_DOC_ERROR      = YES
 # The default value is: NO.
 
 WARN_NO_PARAMDOC       = NO
+
+# If the WARN_AS_ERROR tag is set to YES then doxygen will immediately stop when
+# a warning is encountered.
+# The default value is: NO.
+
+WARN_AS_ERROR          = YES
 
 # The WARN_FORMAT tag determines the format of the warning messages that doxygen
 # can produce. The string should contain the $file, $line, and $text tags, which

--- a/stan/math/prim/mat/fun/matrix_exp_pade.hpp
+++ b/stan/math/prim/mat/fun/matrix_exp_pade.hpp
@@ -6,34 +6,34 @@
 namespace stan {
   namespace math {
 
-        /**
-         * Computes the matrix exponential, using a Pade
-         * approximation, coupled with scaling and
-         * squaring.
-         *
-         * @tparam MatrixType scalar type of the elements
-         * in the input matrix.
-         * @param[in] arg matrix to exponentiate.
-         * @param[out] Matrix exponential of input matrix.
-         */
-        template <typename MatrixType>
-        MatrixType
-        matrix_exp_pade(const MatrixType& arg) {
-          MatrixType result;
-          MatrixType U, V;
-          int squarings;
-          Eigen::matrix_exp_computeUV<MatrixType>::run(
-            arg, U, V, squarings, arg(0, 0));  // Pade approximant is
-                                               // (U+V) / (-U+V)
-          MatrixType numer = U + V;
-          MatrixType denom = -U + V;
-          result = denom.partialPivLu().solve(numer);
-          for (int i = 0; i < squarings; ++i)
-            result *= result;  // undo scaling by repeated squaring
+    /**
+     * Computes the matrix exponential, using a Pade
+     * approximation, coupled with scaling and
+     * squaring.
+     *
+     * @tparam MatrixType scalar type of the elements
+     * in the input matrix.
+     * @param[in] arg matrix to exponentiate.
+     * @return Matrix exponential of input matrix.
+     */
+    template <typename MatrixType>
+    MatrixType
+    matrix_exp_pade(const MatrixType& arg) {
+      MatrixType result;
+      MatrixType U, V;
+      int squarings;
+      Eigen::matrix_exp_computeUV<MatrixType>::run(arg, U, V, squarings,
+                                                   arg(0, 0));
+      // Pade approximant is
+      // (U+V) / (-U+V)
+      MatrixType numer = U + V;
+      MatrixType denom = -U + V;
+      result = denom.partialPivLu().solve(numer);
+      for (int i = 0; i < squarings; ++i)
+        result *= result;  // undo scaling by repeated squaring
 
-          return result;
-        }
+      return result;
     }
+  }
 }
-
 #endif


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary:
Removes warnings for doxygen.
Adds a couple of different options for doxygen. Hopefully having less output will help Jenkins pick out warnings.

#### Intended Effect:
Jenkins should now pick up doxygen warnings.
With an updated doxygen version, doxygen will stop at the first error.

#### How to Verify:
`make doxygen`

#### Side Effects:
None.

#### Documentation:
This fixes documentation.

#### Reviewer Suggestions: 
Anyone.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Columbia University.

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
