### PR TITLE
In matrix_exp_pade, rename return variable pade_approximation, and de…

### DIFF
--- a/stan/math/prim/mat/fun/matrix_exp_pade.hpp
+++ b/stan/math/prim/mat/fun/matrix_exp_pade.hpp
@@ -19,7 +19,6 @@ namespace stan {
     template <typename MatrixType>
     MatrixType
     matrix_exp_pade(const MatrixType& arg) {
-      MatrixType result;
       MatrixType U, V;
       int squarings;
       Eigen::matrix_exp_computeUV<MatrixType>::run(arg, U, V, squarings,
@@ -28,11 +27,11 @@ namespace stan {
       // (U+V) / (-U+V)
       MatrixType numer = U + V;
       MatrixType denom = -U + V;
-      result = denom.partialPivLu().solve(numer);
+      MatrixType pade_approximation = denom.partialPivLu().solve(numer);
       for (int i = 0; i < squarings; ++i)
-        result *= result;  // undo scaling by repeated squaring
-
-      return result;
+        pade_approximation *= pade_approximation;  // undo scaling by
+                                                   // repeated squaring
+      return pade_approximation;
     }
   }
 }


### PR DESCRIPTION
#### Submisison Checklist

- [ ] Run unit tests: `./runTests.py test/unit` (Ran 9 tests for matrix exponential).
- [X] Run cpplint: `make cpplint`
- [X] Declare copyright holder and open-source license: see below

#### Summary:
In `stan/math/prim/mat/fun/matrix_exp_pade.hpp`, rename return variable pade_approximation, and declare variable right before it gets used, as oppose to at the top of the function.

See issue #456 

#### Intended Effect:
- Code readability
- Memory isn't allocated for a variable that only get's used later
- Aesthetics

#### How to Verify:
The first two intended effects are trivial. Code doesn't break.
The question of aesthetics is considerably more complicated and profound. What is beauty, and more importantly what is it in the framework of Stan, where only computer scientists seem to grasp it?

#### Side Effects:
None.

#### Documentation:
None.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Metrum Research Group LLC

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)