### PR TITLE
Add tests for VectorViewMvt; they pass but test buggy behavior.

### DIFF
--- a/test/unit/math/prim/mat/meta/VectorViewMvt_test.cpp
+++ b/test/unit/math/prim/mat/meta/VectorViewMvt_test.cpp
@@ -1,0 +1,193 @@
+#include <stan/math/prim/mat.hpp>
+#include <gtest/gtest.h>
+#include <iostream>
+#include <stdexcept>
+#include <vector>
+
+TEST(MetaTraits, VectorViewMvt_matrix_double) {
+  using stan::VectorViewMvt;
+  using Eigen::Matrix;
+  using Eigen::Dynamic;
+
+  Matrix<double,Dynamic,1> a(10);
+  for (size_t n = 0; n < 10; ++n)
+    a[n] = n;
+  VectorViewMvt<Matrix<double,Dynamic,1> > av(a);
+  for (size_t n = 0; n < 10; ++n)
+    EXPECT_FLOAT_EQ(a[n], av[n][n]);
+  for (size_t n = 0; n < 10; ++n)
+    av[120*n][n] = n+10;
+  for (size_t n = 0; n < 10; ++n) {
+    EXPECT_FLOAT_EQ(10+n, av[n][n]);
+    EXPECT_FLOAT_EQ(10+n, a[n]);
+  }
+
+  const Matrix<double,Dynamic,1> b(a);
+  VectorViewMvt<const Matrix<double,Dynamic,1> > bv(b);
+  for (size_t n = 0; n < 10; ++n)
+    EXPECT_FLOAT_EQ(b[n], bv[n][n]);
+
+  Matrix<double,1,Dynamic> c(10);
+  for (size_t n = 0; n < 10; ++n)
+    c[n] = n;
+  VectorViewMvt<Matrix<double,1,Dynamic> > cv(c);
+  for (size_t n = 0; n < 10; ++n)
+    EXPECT_FLOAT_EQ(c[n], cv[n][n]);
+  for (size_t n = 0; n < 10; ++n)
+    cv[n][n] = n+10;
+  for (size_t n = 0; n < 10; ++n) {
+    EXPECT_FLOAT_EQ(10+n, cv[n][n]);
+    EXPECT_FLOAT_EQ(10+n, c[n]);
+  }
+
+  const Matrix<double,1,Dynamic> d(c);
+  VectorViewMvt<const Matrix<double,1,Dynamic>,
+          stan::is_vector<Matrix<double,1,Dynamic> >::value > dv(d);
+  for (size_t n = 0; n < 10; ++n)
+    EXPECT_FLOAT_EQ(d[n], dv[n][n]);
+
+}
+// XXX Need to test both const and regular for everything!
+
+TEST(MetaTraits,VectorViewMvt_multivariate_const) {
+  using stan::VectorViewMvt;
+  using Eigen::Matrix;
+  using Eigen::Dynamic;
+
+  //Test std::vector of column vectors
+  Matrix<double,Dynamic,1> x(3);
+  x << 1.0, 4.0, 9.0;
+  Matrix<double,Dynamic,1> y(3);
+  y << 2.0, 5.0, 10.0;
+  std::vector<Matrix<double,Dynamic,1> > xy_vecs;
+  xy_vecs.push_back(x);
+  xy_vecs.push_back(y);
+
+  VectorViewMvt<const Matrix<double,Dynamic,1> > xy_view(xy_vecs);
+  EXPECT_FLOAT_EQ(1.0,xy_view[0][0]);
+  EXPECT_FLOAT_EQ(4.0,xy_view[0][1]);
+  EXPECT_FLOAT_EQ(9.0,xy_view[0][2]);
+  // Should be:
+  //EXPECT_FLOAT_EQ(2.0,xy_view[1][0]);
+  //EXPECT_FLOAT_EQ(5.0,xy_view[1][1]);
+  //EXPECT_FLOAT_EQ(10.0,xy_view[1][2]);
+  // Currently this case is buggy as is_array is not set correctly so it just
+  // gives the 1st matrix back again.
+  EXPECT_FLOAT_EQ(1.0,xy_view[1][0]);
+  EXPECT_FLOAT_EQ(4.0,xy_view[1][1]);
+  EXPECT_FLOAT_EQ(9.0,xy_view[1][2]);
+
+  //Test std::vector of row vectors
+  Matrix<double,1,Dynamic> a(3);
+  a << 1.0, 4.0, 9.0;
+  Matrix<double,1,Dynamic> b(3);
+  b << 2.0, 5.0, 10.0;
+  std::vector<Matrix<double,1,Dynamic> > ab_vecs;
+  ab_vecs.push_back(a);
+  ab_vecs.push_back(b);
+
+  VectorViewMvt<const Matrix<double,1,Dynamic> > ab_view(ab_vecs);
+  EXPECT_FLOAT_EQ(1.0,ab_view[0][0]);
+  EXPECT_FLOAT_EQ(4.0,ab_view[0][1]);
+  EXPECT_FLOAT_EQ(9.0,ab_view[0][2]);
+  // Should be:
+  //EXPECT_FLOAT_EQ(2.0,ab_view[1][0]);
+  //EXPECT_FLOAT_EQ(5.0,ab_view[1][1]);
+  //EXPECT_FLOAT_EQ(10.0,ab_view[1][2]);
+  // Currently this case is buggy as is_array is not set correctly so it just
+  // gives the 1st matrix back again.
+  EXPECT_FLOAT_EQ(1.0,ab_view[1][0]);
+  EXPECT_FLOAT_EQ(4.0,ab_view[1][1]);
+  EXPECT_FLOAT_EQ(9.0,ab_view[1][2]);
+
+  //This tests a std::vector of matrices
+  Matrix<double,Dynamic,Dynamic> m(2,3);
+  m << 1.0, 2.0, 3.0, -100.0, -200.0, -300.0;
+  Matrix<double,Dynamic,Dynamic> n(2,3);
+  n << 4.0, 5.0, 6.0, -400.0, -500.0, -600.0;
+  std::vector<Matrix<double,Dynamic,Dynamic> > mn_matrices;
+  mn_matrices.push_back(m);
+  mn_matrices.push_back(n);
+  VectorViewMvt<const Matrix<double,Dynamic,Dynamic> > mn_view(mn_matrices);
+  for (int k = 0; k < 2; ++k) {
+    for (int j = 0; j < 3; ++j) {
+      for (int i = 0; i < 2; ++i) {
+        // Should be:
+        //EXPECT_FLOAT_EQ(mn_matrices[k](i,j),mn_view[k](i,j));
+        // Bug in is_array leads to:
+        EXPECT_FLOAT_EQ(mn_matrices[0](i,j),mn_view[k](i,j));
+      }
+    }
+  }
+}
+TEST(MetaTraits,VectorViewMvt_multivariate) {
+  using stan::VectorViewMvt;
+  using Eigen::Matrix;
+  using Eigen::Dynamic;
+
+  //Test std::vector of column vectors
+  Matrix<double,Dynamic,1> x(3);
+  x << 1.0, 4.0, 9.0;
+  Matrix<double,Dynamic,1> y(3);
+  y << 2.0, 5.0, 10.0;
+  std::vector<Matrix<double,Dynamic,1> > xy_vecs;
+  xy_vecs.push_back(x);
+  xy_vecs.push_back(y);
+
+  VectorViewMvt<Matrix<double,Dynamic,1> > xy_view(xy_vecs);
+  EXPECT_FLOAT_EQ(1.0,xy_view[0][0]);
+  EXPECT_FLOAT_EQ(4.0,xy_view[0][1]);
+  EXPECT_FLOAT_EQ(9.0,xy_view[0][2]);
+  // Should be:
+  //EXPECT_FLOAT_EQ(2.0,xy_view[1][0]);
+  //EXPECT_FLOAT_EQ(5.0,xy_view[1][1]);
+  //EXPECT_FLOAT_EQ(10.0,xy_view[1][2]);
+  // Currently this case is buggy as is_array is not set correctly so it just
+  // gives the 1st matrix back again.
+  EXPECT_FLOAT_EQ(1.0,xy_view[1][0]);
+  EXPECT_FLOAT_EQ(4.0,xy_view[1][1]);
+  EXPECT_FLOAT_EQ(9.0,xy_view[1][2]);
+
+  //Test std::vector of row vectors
+  Matrix<double,1,Dynamic> a(3);
+  a << 1.0, 4.0, 9.0;
+  Matrix<double,1,Dynamic> b(3);
+  b << 2.0, 5.0, 10.0;
+  std::vector<Matrix<double,1,Dynamic> > ab_vecs;
+  ab_vecs.push_back(a);
+  ab_vecs.push_back(b);
+
+  VectorViewMvt<Matrix<double,1,Dynamic> > ab_view(ab_vecs);
+  EXPECT_FLOAT_EQ(1.0,ab_view[0][0]);
+  EXPECT_FLOAT_EQ(4.0,ab_view[0][1]);
+  EXPECT_FLOAT_EQ(9.0,ab_view[0][2]);
+  // Should be:
+  //EXPECT_FLOAT_EQ(2.0,ab_view[1][0]);
+  //EXPECT_FLOAT_EQ(5.0,ab_view[1][1]);
+  //EXPECT_FLOAT_EQ(10.0,ab_view[1][2]);
+  // Currently this case is buggy as is_array is not set correctly so it just
+  // gives the 1st matrix back again.
+  EXPECT_FLOAT_EQ(1.0,ab_view[1][0]);
+  EXPECT_FLOAT_EQ(4.0,ab_view[1][1]);
+  EXPECT_FLOAT_EQ(9.0,ab_view[1][2]);
+
+  //This tests a std::vector of matrices
+  Matrix<double,Dynamic,Dynamic> m(2,3);
+  m << 1.0, 2.0, 3.0, -100.0, -200.0, -300.0;
+  Matrix<double,Dynamic,Dynamic> n(2,3);
+  n << 4.0, 5.0, 6.0, -400.0, -500.0, -600.0;
+  std::vector<Matrix<double,Dynamic,Dynamic> > mn_matrices;
+  mn_matrices.push_back(m);
+  mn_matrices.push_back(n);
+  VectorViewMvt<Matrix<double,Dynamic,Dynamic> > mn_view(mn_matrices);
+  for (int k = 0; k < 2; ++k) {
+    for (int j = 0; j < 3; ++j) {
+      for (int i = 0; i < 2; ++i) {
+        // Should be:
+        //EXPECT_FLOAT_EQ(mn_matrices[k](i,j),mn_view[k](i,j));
+        // Bug in is_array leads to:
+        EXPECT_FLOAT_EQ(mn_matrices[0](i,j),mn_view[k](i,j));
+      }
+    }
+  }
+}

--- a/test/unit/math/prim/mat/meta/VectorViewMvt_test.cpp
+++ b/test/unit/math/prim/mat/meta/VectorViewMvt_test.cpp
@@ -5,47 +5,87 @@
 #include <vector>
 
 // Just test the use case where a single matrix is passed in to VectorViewMvt.
-// The case where a std::vector of matrices is passed in is broken and will be refactored.
+// The case where a std::vector of matrices is passed in is broken and will be
+// refactored.
 
-TEST(MetaTraits, VectorViewMvt_matrix_double) {
+TEST(MetaTraits, VectorViewMvt_vector_double) {
   using stan::VectorViewMvt;
-  using Eigen::Matrix;
+  using Eigen::VectorXd;
+  using Eigen::RowVectorXd;
   using Eigen::Dynamic;
 
-  Matrix<double,Dynamic,1> a(10);
+  VectorXd a(10);
   for (size_t n = 0; n < 10; ++n)
     a[n] = n;
-  VectorViewMvt<Matrix<double,Dynamic,1> > av(a);
+  VectorViewMvt<VectorXd> av(a);
   for (size_t n = 0; n < 10; ++n)
     EXPECT_FLOAT_EQ(a[n], av[0][n]);
   for (size_t n = 0; n < 10; ++n)
-    av[120*n][n] = n+10;
+    av[120*n][n] = n + 10;
   for (size_t n = 0; n < 10; ++n) {
-    EXPECT_FLOAT_EQ(10+n, av[0][n]);
-    EXPECT_FLOAT_EQ(10+n, a[n]);
+    EXPECT_FLOAT_EQ(10 + n, av[0][n]);
+    EXPECT_FLOAT_EQ(10 + n, a[n]);
   }
 
-  const Matrix<double,Dynamic,1> b(a);
-  VectorViewMvt<const Matrix<double,Dynamic,1> > bv(b);
+  const VectorXd b(a);
+  VectorViewMvt<const VectorXd> bv(b);
   for (size_t n = 0; n < 10; ++n)
     EXPECT_FLOAT_EQ(b[n], bv[0][n]);
 
-  Matrix<double,1,Dynamic> c(10);
+  RowVectorXd c(10);
   for (size_t n = 0; n < 10; ++n)
     c[n] = n;
-  VectorViewMvt<Matrix<double,1,Dynamic> > cv(c);
+  VectorViewMvt<RowVectorXd> cv(c);
   for (size_t n = 0; n < 10; ++n)
     EXPECT_FLOAT_EQ(c[n], cv[0][n]);
   for (size_t n = 0; n < 10; ++n)
-    cv[0][n] = n+10;
+    cv[0][n] = n + 10;
   for (size_t n = 0; n < 10; ++n) {
-    EXPECT_FLOAT_EQ(10+n, cv[0][n]);
-    EXPECT_FLOAT_EQ(10+n, c[n]);
+    EXPECT_FLOAT_EQ(10 + n, cv[0][n]);
+    EXPECT_FLOAT_EQ(10 + n, c[n]);
   }
 
-  const Matrix<double,1,Dynamic> d(c);
-  VectorViewMvt<const Matrix<double,1,Dynamic>,
-          stan::is_vector<Matrix<double,1,Dynamic> >::value > dv(d);
+  const RowVectorXd d(c);
+  VectorViewMvt<const RowVectorXd, stan::is_vector<RowVectorXd>::value > dv(d);
   for (size_t n = 0; n < 10; ++n)
     EXPECT_FLOAT_EQ(d[n], dv[0][n]);
+}
+
+TEST(MetaTraits, VectorViewMvt_matrix_double) {
+  using stan::VectorViewMvt;
+  using Eigen::MatrixXd;
+  using Eigen::Dynamic;
+
+  MatrixXd a(10, 10);
+  for (size_t i = 0; i < 10; ++i) {
+    for (size_t j = 0; j < 10; ++j) {
+      a(i, j) = 100 * i + j;
+    }
+  }
+  VectorViewMvt<MatrixXd> av(a);
+  for (size_t i = 0; i < 10; ++i) {
+    for (size_t j = 0; j < 10; ++j) {
+      EXPECT_FLOAT_EQ(av[0](i, j), a(i, j));
+    }
+  }
+
+  //Test mutation passes thru to original matrix
+  for (size_t i = 0; i < 10; ++i) {
+    for (size_t j = 0; j < 10; ++j) {
+      av[0](i, j) = a(i, j) + 10;
+    }
+  }
+  for (size_t i = 0; i < 10; ++i) {
+    for (size_t j = 0; j < 10; ++j) {
+      EXPECT_FLOAT_EQ(av[0](i, j), a(i, j));
+    }
+  }
+
+  const MatrixXd b(a);
+  VectorViewMvt<const MatrixXd> bv(b);
+  for (size_t i = 0; i < 10; ++i) {
+    for (size_t j = 0; j < 10; ++j) {
+      EXPECT_FLOAT_EQ(bv[0](i, j), b(i, j));
+    }
+  }
 }

--- a/test/unit/math/prim/mat/meta/VectorViewMvt_test.cpp
+++ b/test/unit/math/prim/mat/meta/VectorViewMvt_test.cpp
@@ -4,6 +4,9 @@
 #include <stdexcept>
 #include <vector>
 
+// Just test the use case where a single matrix is passed in to VectorViewMvt.
+// The case where a std::vector of matrices is passed in is broken and will be refactored.
+
 TEST(MetaTraits, VectorViewMvt_matrix_double) {
   using stan::VectorViewMvt;
   using Eigen::Matrix;
@@ -14,29 +17,29 @@ TEST(MetaTraits, VectorViewMvt_matrix_double) {
     a[n] = n;
   VectorViewMvt<Matrix<double,Dynamic,1> > av(a);
   for (size_t n = 0; n < 10; ++n)
-    EXPECT_FLOAT_EQ(a[n], av[n][n]);
+    EXPECT_FLOAT_EQ(a[n], av[0][n]);
   for (size_t n = 0; n < 10; ++n)
     av[120*n][n] = n+10;
   for (size_t n = 0; n < 10; ++n) {
-    EXPECT_FLOAT_EQ(10+n, av[n][n]);
+    EXPECT_FLOAT_EQ(10+n, av[0][n]);
     EXPECT_FLOAT_EQ(10+n, a[n]);
   }
 
   const Matrix<double,Dynamic,1> b(a);
   VectorViewMvt<const Matrix<double,Dynamic,1> > bv(b);
   for (size_t n = 0; n < 10; ++n)
-    EXPECT_FLOAT_EQ(b[n], bv[n][n]);
+    EXPECT_FLOAT_EQ(b[n], bv[0][n]);
 
   Matrix<double,1,Dynamic> c(10);
   for (size_t n = 0; n < 10; ++n)
     c[n] = n;
   VectorViewMvt<Matrix<double,1,Dynamic> > cv(c);
   for (size_t n = 0; n < 10; ++n)
-    EXPECT_FLOAT_EQ(c[n], cv[n][n]);
+    EXPECT_FLOAT_EQ(c[n], cv[0][n]);
   for (size_t n = 0; n < 10; ++n)
-    cv[n][n] = n+10;
+    cv[0][n] = n+10;
   for (size_t n = 0; n < 10; ++n) {
-    EXPECT_FLOAT_EQ(10+n, cv[n][n]);
+    EXPECT_FLOAT_EQ(10+n, cv[0][n]);
     EXPECT_FLOAT_EQ(10+n, c[n]);
   }
 
@@ -44,150 +47,5 @@ TEST(MetaTraits, VectorViewMvt_matrix_double) {
   VectorViewMvt<const Matrix<double,1,Dynamic>,
           stan::is_vector<Matrix<double,1,Dynamic> >::value > dv(d);
   for (size_t n = 0; n < 10; ++n)
-    EXPECT_FLOAT_EQ(d[n], dv[n][n]);
-
-}
-// XXX Need to test both const and regular for everything!
-
-TEST(MetaTraits,VectorViewMvt_multivariate_const) {
-  using stan::VectorViewMvt;
-  using Eigen::Matrix;
-  using Eigen::Dynamic;
-
-  //Test std::vector of column vectors
-  Matrix<double,Dynamic,1> x(3);
-  x << 1.0, 4.0, 9.0;
-  Matrix<double,Dynamic,1> y(3);
-  y << 2.0, 5.0, 10.0;
-  std::vector<Matrix<double,Dynamic,1> > xy_vecs;
-  xy_vecs.push_back(x);
-  xy_vecs.push_back(y);
-
-  VectorViewMvt<const Matrix<double,Dynamic,1> > xy_view(xy_vecs);
-  EXPECT_FLOAT_EQ(1.0,xy_view[0][0]);
-  EXPECT_FLOAT_EQ(4.0,xy_view[0][1]);
-  EXPECT_FLOAT_EQ(9.0,xy_view[0][2]);
-  // Should be:
-  //EXPECT_FLOAT_EQ(2.0,xy_view[1][0]);
-  //EXPECT_FLOAT_EQ(5.0,xy_view[1][1]);
-  //EXPECT_FLOAT_EQ(10.0,xy_view[1][2]);
-  // Currently this case is buggy as is_array is not set correctly so it just
-  // gives the 1st matrix back again.
-  EXPECT_FLOAT_EQ(1.0,xy_view[1][0]);
-  EXPECT_FLOAT_EQ(4.0,xy_view[1][1]);
-  EXPECT_FLOAT_EQ(9.0,xy_view[1][2]);
-
-  //Test std::vector of row vectors
-  Matrix<double,1,Dynamic> a(3);
-  a << 1.0, 4.0, 9.0;
-  Matrix<double,1,Dynamic> b(3);
-  b << 2.0, 5.0, 10.0;
-  std::vector<Matrix<double,1,Dynamic> > ab_vecs;
-  ab_vecs.push_back(a);
-  ab_vecs.push_back(b);
-
-  VectorViewMvt<const Matrix<double,1,Dynamic> > ab_view(ab_vecs);
-  EXPECT_FLOAT_EQ(1.0,ab_view[0][0]);
-  EXPECT_FLOAT_EQ(4.0,ab_view[0][1]);
-  EXPECT_FLOAT_EQ(9.0,ab_view[0][2]);
-  // Should be:
-  //EXPECT_FLOAT_EQ(2.0,ab_view[1][0]);
-  //EXPECT_FLOAT_EQ(5.0,ab_view[1][1]);
-  //EXPECT_FLOAT_EQ(10.0,ab_view[1][2]);
-  // Currently this case is buggy as is_array is not set correctly so it just
-  // gives the 1st matrix back again.
-  EXPECT_FLOAT_EQ(1.0,ab_view[1][0]);
-  EXPECT_FLOAT_EQ(4.0,ab_view[1][1]);
-  EXPECT_FLOAT_EQ(9.0,ab_view[1][2]);
-
-  //This tests a std::vector of matrices
-  Matrix<double,Dynamic,Dynamic> m(2,3);
-  m << 1.0, 2.0, 3.0, -100.0, -200.0, -300.0;
-  Matrix<double,Dynamic,Dynamic> n(2,3);
-  n << 4.0, 5.0, 6.0, -400.0, -500.0, -600.0;
-  std::vector<Matrix<double,Dynamic,Dynamic> > mn_matrices;
-  mn_matrices.push_back(m);
-  mn_matrices.push_back(n);
-  VectorViewMvt<const Matrix<double,Dynamic,Dynamic> > mn_view(mn_matrices);
-  for (int k = 0; k < 2; ++k) {
-    for (int j = 0; j < 3; ++j) {
-      for (int i = 0; i < 2; ++i) {
-        // Should be:
-        //EXPECT_FLOAT_EQ(mn_matrices[k](i,j),mn_view[k](i,j));
-        // Bug in is_array leads to:
-        EXPECT_FLOAT_EQ(mn_matrices[0](i,j),mn_view[k](i,j));
-      }
-    }
-  }
-}
-TEST(MetaTraits,VectorViewMvt_multivariate) {
-  using stan::VectorViewMvt;
-  using Eigen::Matrix;
-  using Eigen::Dynamic;
-
-  //Test std::vector of column vectors
-  Matrix<double,Dynamic,1> x(3);
-  x << 1.0, 4.0, 9.0;
-  Matrix<double,Dynamic,1> y(3);
-  y << 2.0, 5.0, 10.0;
-  std::vector<Matrix<double,Dynamic,1> > xy_vecs;
-  xy_vecs.push_back(x);
-  xy_vecs.push_back(y);
-
-  VectorViewMvt<Matrix<double,Dynamic,1> > xy_view(xy_vecs);
-  EXPECT_FLOAT_EQ(1.0,xy_view[0][0]);
-  EXPECT_FLOAT_EQ(4.0,xy_view[0][1]);
-  EXPECT_FLOAT_EQ(9.0,xy_view[0][2]);
-  // Should be:
-  //EXPECT_FLOAT_EQ(2.0,xy_view[1][0]);
-  //EXPECT_FLOAT_EQ(5.0,xy_view[1][1]);
-  //EXPECT_FLOAT_EQ(10.0,xy_view[1][2]);
-  // Currently this case is buggy as is_array is not set correctly so it just
-  // gives the 1st matrix back again.
-  EXPECT_FLOAT_EQ(1.0,xy_view[1][0]);
-  EXPECT_FLOAT_EQ(4.0,xy_view[1][1]);
-  EXPECT_FLOAT_EQ(9.0,xy_view[1][2]);
-
-  //Test std::vector of row vectors
-  Matrix<double,1,Dynamic> a(3);
-  a << 1.0, 4.0, 9.0;
-  Matrix<double,1,Dynamic> b(3);
-  b << 2.0, 5.0, 10.0;
-  std::vector<Matrix<double,1,Dynamic> > ab_vecs;
-  ab_vecs.push_back(a);
-  ab_vecs.push_back(b);
-
-  VectorViewMvt<Matrix<double,1,Dynamic> > ab_view(ab_vecs);
-  EXPECT_FLOAT_EQ(1.0,ab_view[0][0]);
-  EXPECT_FLOAT_EQ(4.0,ab_view[0][1]);
-  EXPECT_FLOAT_EQ(9.0,ab_view[0][2]);
-  // Should be:
-  //EXPECT_FLOAT_EQ(2.0,ab_view[1][0]);
-  //EXPECT_FLOAT_EQ(5.0,ab_view[1][1]);
-  //EXPECT_FLOAT_EQ(10.0,ab_view[1][2]);
-  // Currently this case is buggy as is_array is not set correctly so it just
-  // gives the 1st matrix back again.
-  EXPECT_FLOAT_EQ(1.0,ab_view[1][0]);
-  EXPECT_FLOAT_EQ(4.0,ab_view[1][1]);
-  EXPECT_FLOAT_EQ(9.0,ab_view[1][2]);
-
-  //This tests a std::vector of matrices
-  Matrix<double,Dynamic,Dynamic> m(2,3);
-  m << 1.0, 2.0, 3.0, -100.0, -200.0, -300.0;
-  Matrix<double,Dynamic,Dynamic> n(2,3);
-  n << 4.0, 5.0, 6.0, -400.0, -500.0, -600.0;
-  std::vector<Matrix<double,Dynamic,Dynamic> > mn_matrices;
-  mn_matrices.push_back(m);
-  mn_matrices.push_back(n);
-  VectorViewMvt<Matrix<double,Dynamic,Dynamic> > mn_view(mn_matrices);
-  for (int k = 0; k < 2; ++k) {
-    for (int j = 0; j < 3; ++j) {
-      for (int i = 0; i < 2; ++i) {
-        // Should be:
-        //EXPECT_FLOAT_EQ(mn_matrices[k](i,j),mn_view[k](i,j));
-        // Bug in is_array leads to:
-        EXPECT_FLOAT_EQ(mn_matrices[0](i,j),mn_view[k](i,j));
-      }
-    }
-  }
+    EXPECT_FLOAT_EQ(d[n], dv[0][n]);
 }


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary:
Add tests for VectorViewMvt a la #93 

To close this issue, still need to add tests for `scalar_type_pre`.

Contains some tests that pass with currently buggy behavior described on [the Discourse thread](http://discourse.mc-stan.org/t/vectorviewmvt-broadcasting-logic-question). Will work out how to fix those before closing #93 as well.
#### Intended Effect:

#### How to Verify:

#### Side Effects:

#### Documentation:

#### Reviewer Suggestions: 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Sean Talts

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
