### PR TITLE
feature/issue-428 defer to poisson for bad parameters in the negative binomial

### DIFF
--- a/stan/math/prim/scal/prob/neg_binomial_2_log.hpp
+++ b/stan/math/prim/scal/prob/neg_binomial_2_log.hpp
@@ -110,7 +110,7 @@ namespace stan {
           logp += lgamma(n_plus_phi[i]);
 
         // if phi is large we probably overflow, defer to Poisson:
-        if (phi__[i] > 1e12) {
+        if (phi__[i] > 1e5) {
           logp = poisson_log(n_vec[i], mu__[i]);
         }
 

--- a/test/unit/math/prim/scal/prob/neg_binomial_2_test.cpp
+++ b/test/unit/math/prim/scal/prob/neg_binomial_2_test.cpp
@@ -202,3 +202,14 @@ TEST(ProbDistributionsNegBinomial, chiSquareGoodnessFitTest4) {
 
   EXPECT_TRUE(chi < quantile(complement(mydist, 1e-6)));
 }
+
+TEST(ProbDistributionsNegBinomial, extreme_values) {
+  int N = 100;
+  double mu = 8;
+  double phi = 1e12;
+  for (int n = 0; n < 10; ++n) {
+    phi *= 10;
+    double logp = stan::math::neg_binomial_2_log<false>(N, mu, phi);
+    EXPECT_TRUE(logp < 0);
+  }
+}

--- a/test/unit/math/rev/scal/prob/neg_binomial_2_test.cpp
+++ b/test/unit/math/rev/scal/prob/neg_binomial_2_test.cpp
@@ -1,0 +1,103 @@
+#include <stan/math/rev/scal.hpp>
+#include <gtest/gtest.h>
+#include <vector>
+
+TEST(ProbDistributionsNegBinomial, derivatives_not_nan) {
+  using stan::math::is_nan;
+  using stan::math::var;
+  using stan::math::neg_binomial_2_log;
+
+  int N = 100;
+  double mu_dbl = 8;
+  double phi_dbl = 1;
+  
+  var mu(mu_dbl);
+  var phi(phi_dbl);
+
+  for (int k = 0; k < 20; ++k) {
+    var val = neg_binomial_2_log(N, mu, phi);
+
+    std::vector<var> x;
+    x.push_back(mu);
+    x.push_back(phi);
+    
+    std::vector<double> gradients;
+    val.grad(x, gradients);
+
+    EXPECT_FALSE(is_nan(gradients[0]));
+    EXPECT_FALSE(is_nan(gradients[1]));
+
+    phi *= 10;
+  }
+
+}
+
+void test_value_and_derivatives(double expected_val,
+                                double y_dbl, double mu_dbl, double sigma_dbl) {
+  using stan::math::is_nan;
+  using stan::math::var;  
+  using stan::math::normal_cdf;
+  std::stringstream msg_ss;
+  msg_ss << "parameters: (" << y_dbl << ", " << mu_dbl << ", " << sigma_dbl << ")";
+  std::string msg = msg_ss.str();
+
+  SCOPED_TRACE(msg);
+  
+  var y(y_dbl);
+  var mu(mu_dbl);
+  var sigma(sigma_dbl);
+
+  std::vector<double> gradients;
+  var val = normal_cdf(y, mu, sigma);
+  std::vector<var> x;
+  x.push_back(y);
+  x.push_back(mu);
+  x.push_back(sigma);
+  gradients.clear();
+  val.grad(x, gradients);
+
+  double e = 1e-10;
+  double inv2e = 0.5 / e;
+  std::vector<double> finite_diffs;
+  finite_diffs.resize(3);
+  finite_diffs[0] = (normal_cdf(y_dbl + e, mu_dbl, sigma_dbl)
+                     - normal_cdf(y_dbl - e, mu_dbl, sigma_dbl)) * inv2e;
+  finite_diffs[1] = (normal_cdf(y_dbl, mu_dbl + e, sigma_dbl)
+                     - normal_cdf(y_dbl, mu_dbl - e, sigma_dbl)) * inv2e;
+  finite_diffs[2] = (normal_cdf(y_dbl, mu_dbl, sigma_dbl + e)
+                     - normal_cdf(y_dbl, mu_dbl, sigma_dbl - e)) * inv2e;
+
+  
+  EXPECT_FLOAT_EQ(expected_val, val.val());
+  EXPECT_FALSE(is_nan(gradients[0]));
+  EXPECT_FALSE(is_nan(gradients[1]));
+  EXPECT_FALSE(is_nan(gradients[2]));
+  if (!is_nan(gradients[0])) {
+    if (!is_nan(finite_diffs[0]))
+      EXPECT_NEAR(finite_diffs[0], gradients[0], 1e-2);
+    else
+      EXPECT_FLOAT_EQ(0.0, gradients[0]);
+  }
+  if (!is_nan(gradients[1])) {
+    if (!is_nan(finite_diffs[1]))
+      EXPECT_NEAR(finite_diffs[1], gradients[1], 1e-2);
+    else
+      EXPECT_FLOAT_EQ(0.0, gradients[1]);
+  }
+  if (!is_nan(gradients[2])) {
+    if (!is_nan(finite_diffs[2]))
+      EXPECT_NEAR(finite_diffs[2], gradients[2], 1e-2);
+    else
+      EXPECT_FLOAT_EQ(0.0, gradients[2]);
+  }
+}
+
+
+// TEST(normal_cdf, derivatives) {
+//   test_value_and_derivatives(0.5, 10.0, 10.0, 0.5);
+//   test_value_and_derivatives(0.0, -20.0, 10.0, 0.5);
+//   test_value_and_derivatives(0.0, -30.0, 10.0, 0.5);
+//   test_value_and_derivatives(0.0, -50.0, 10.0, 1.0);
+// 
+//   test_value_and_derivatives(1.0, 30.0, 10.0, 0.5);
+// }

--- a/test/unit/math/rev/scal/prob/neg_binomial_2_test.cpp
+++ b/test/unit/math/rev/scal/prob/neg_binomial_2_test.cpp
@@ -2,19 +2,19 @@
 #include <gtest/gtest.h>
 #include <vector>
 
-TEST(ProbDistributionsNegBinomial, derivatives_not_nan) {
+TEST(ProbDistributionsNegBinomial, derivatives) {
   using stan::math::is_nan;
   using stan::math::var;
   using stan::math::neg_binomial_2_log;
 
   int N = 100;
   double mu_dbl = 8;
-  double phi_dbl = 1;
+  double phi_dbl = 1.5;
   
-  var mu(mu_dbl);
-  var phi(phi_dbl);
 
   for (int k = 0; k < 20; ++k) {
+    var mu(mu_dbl);
+    var phi(phi_dbl);
     var val = neg_binomial_2_log(N, mu, phi);
 
     std::vector<var> x;
@@ -24,80 +24,24 @@ TEST(ProbDistributionsNegBinomial, derivatives_not_nan) {
     std::vector<double> gradients;
     val.grad(x, gradients);
 
-    EXPECT_FALSE(is_nan(gradients[0]));
-    EXPECT_FALSE(is_nan(gradients[1]));
+    for (int i = 0; i < 2; ++i) {
+      EXPECT_FALSE(is_nan(gradients[i]));
+    }
 
-    phi *= 10;
-  }
+    std::vector<double> finite_diffs;
+    double eps = 1e-10;
+    double inv2e = 0.5 / eps;
+    double dmu = neg_binomial_2_log(N, mu_dbl + eps, phi_dbl) 
+      - neg_binomial_2_log(N, mu_dbl - eps, phi_dbl);
+    double dphi = neg_binomial_2_log(N, mu_dbl, phi_dbl + eps) 
+      - neg_binomial_2_log(N, mu_dbl, phi_dbl - eps);
+    finite_diffs.push_back(dmu * inv2e);
+    finite_diffs.push_back(dphi * inv2e);
 
-}
+    for (int i = 0; i < 2; ++i) {
+      EXPECT_NEAR(gradients[i], finite_diffs[i], 1.0);
+    }
 
-void test_value_and_derivatives(double expected_val,
-                                double y_dbl, double mu_dbl, double sigma_dbl) {
-  using stan::math::is_nan;
-  using stan::math::var;  
-  using stan::math::normal_cdf;
-  std::stringstream msg_ss;
-  msg_ss << "parameters: (" << y_dbl << ", " << mu_dbl << ", " << sigma_dbl << ")";
-  std::string msg = msg_ss.str();
-
-  SCOPED_TRACE(msg);
-  
-  var y(y_dbl);
-  var mu(mu_dbl);
-  var sigma(sigma_dbl);
-
-  std::vector<double> gradients;
-  var val = normal_cdf(y, mu, sigma);
-  std::vector<var> x;
-  x.push_back(y);
-  x.push_back(mu);
-  x.push_back(sigma);
-  gradients.clear();
-  val.grad(x, gradients);
-
-  double e = 1e-10;
-  double inv2e = 0.5 / e;
-  std::vector<double> finite_diffs;
-  finite_diffs.resize(3);
-  finite_diffs[0] = (normal_cdf(y_dbl + e, mu_dbl, sigma_dbl)
-                     - normal_cdf(y_dbl - e, mu_dbl, sigma_dbl)) * inv2e;
-  finite_diffs[1] = (normal_cdf(y_dbl, mu_dbl + e, sigma_dbl)
-                     - normal_cdf(y_dbl, mu_dbl - e, sigma_dbl)) * inv2e;
-  finite_diffs[2] = (normal_cdf(y_dbl, mu_dbl, sigma_dbl + e)
-                     - normal_cdf(y_dbl, mu_dbl, sigma_dbl - e)) * inv2e;
-
-  
-  EXPECT_FLOAT_EQ(expected_val, val.val());
-  EXPECT_FALSE(is_nan(gradients[0]));
-  EXPECT_FALSE(is_nan(gradients[1]));
-  EXPECT_FALSE(is_nan(gradients[2]));
-  if (!is_nan(gradients[0])) {
-    if (!is_nan(finite_diffs[0]))
-      EXPECT_NEAR(finite_diffs[0], gradients[0], 1e-2);
-    else
-      EXPECT_FLOAT_EQ(0.0, gradients[0]);
-  }
-  if (!is_nan(gradients[1])) {
-    if (!is_nan(finite_diffs[1]))
-      EXPECT_NEAR(finite_diffs[1], gradients[1], 1e-2);
-    else
-      EXPECT_FLOAT_EQ(0.0, gradients[1]);
-  }
-  if (!is_nan(gradients[2])) {
-    if (!is_nan(finite_diffs[2]))
-      EXPECT_NEAR(finite_diffs[2], gradients[2], 1e-2);
-    else
-      EXPECT_FLOAT_EQ(0.0, gradients[2]);
+    phi_dbl *= 10;
   }
 }
-
-
-// TEST(normal_cdf, derivatives) {
-//   test_value_and_derivatives(0.5, 10.0, 10.0, 0.5);
-//   test_value_and_derivatives(0.0, -20.0, 10.0, 0.5);
-//   test_value_and_derivatives(0.0, -30.0, 10.0, 0.5);
-//   test_value_and_derivatives(0.0, -50.0, 10.0, 1.0);
-// 
-//   test_value_and_derivatives(1.0, 30.0, 10.0, 0.5);
-// }


### PR DESCRIPTION
#### Submisison Checklist

- [ ] Run unit tests: `./runTests.py test/unit`
- [ ] Run cpplint: `make cpplint`
- [ ] Declare copyright holder and open-source license: see below

#### Summary:

In the mean/inverse-overdispersion parametrization of the negative binomial distribution we get overflows for ultra-large values of the inverse over-dispersion. This results in counter-intuitive or extremely wrong behavior (positive values for log probability) due to cancellation between extremely large values. We add a test for large values to catch that particular overflow and defer to poisson_log when the over-dispersion is near zero.

Ideally we would never use the inverse-overdispersion-tending-to-infinity area of the negative binomial parameters since, but since this value can be sampled or bizarrely initialized we can't quite avoid dealing with this.

#### Intended Effect:
Fix the bug here: https://github.com/stan-dev/math/issues/428
also relevant is this closed issue which duplicates it https://github.com/stan-dev/math/issues/463

#### How to Verify:
can run the test here `(ProbDistributionsNegBinomial, extreme_values)`: `./runTests.py ./test/unit/math/prim/scal/prob/neg_binomial_2_test.cpp`

decide whether this is a reasonable fallback.

#### Side Effects:
Changes values which were almost certainly nonsense before.

#### Documentation:

#### Reviewer Suggestions: 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
