### PR TITLE
Feature/issue 90 poisson logcdf

### DIFF
--- a/stan/math/prim/scal.hpp
+++ b/stan/math/prim/scal.hpp
@@ -352,6 +352,7 @@
 #include <stan/math/prim/scal/prob/poisson_lccdf.hpp>
 #include <stan/math/prim/scal/prob/poisson_lcdf.hpp>
 #include <stan/math/prim/scal/prob/poisson_log.hpp>
+#include <stan/math/prim/scal/prob/poisson_log_cdf.hpp>
 #include <stan/math/prim/scal/prob/poisson_lpmf.hpp>
 #include <stan/math/prim/scal/prob/poisson_rng.hpp>
 #include <stan/math/prim/scal/prob/poisson_log_log.hpp>

--- a/stan/math/prim/scal.hpp
+++ b/stan/math/prim/scal.hpp
@@ -353,6 +353,7 @@
 #include <stan/math/prim/scal/prob/poisson_lcdf.hpp>
 #include <stan/math/prim/scal/prob/poisson_log.hpp>
 #include <stan/math/prim/scal/prob/poisson_log_cdf.hpp>
+#include <stan/math/prim/scal/prob/poisson_log_ccdf_log.hpp>
 #include <stan/math/prim/scal/prob/poisson_log_cdf_log.hpp>
 #include <stan/math/prim/scal/prob/poisson_lpmf.hpp>
 #include <stan/math/prim/scal/prob/poisson_rng.hpp>

--- a/stan/math/prim/scal.hpp
+++ b/stan/math/prim/scal.hpp
@@ -353,6 +353,7 @@
 #include <stan/math/prim/scal/prob/poisson_lcdf.hpp>
 #include <stan/math/prim/scal/prob/poisson_log.hpp>
 #include <stan/math/prim/scal/prob/poisson_log_cdf.hpp>
+#include <stan/math/prim/scal/prob/poisson_log_cdf_log.hpp>
 #include <stan/math/prim/scal/prob/poisson_lpmf.hpp>
 #include <stan/math/prim/scal/prob/poisson_rng.hpp>
 #include <stan/math/prim/scal/prob/poisson_log_log.hpp>

--- a/stan/math/prim/scal/prob/poisson_log_ccdf_log.hpp
+++ b/stan/math/prim/scal/prob/poisson_log_ccdf_log.hpp
@@ -1,0 +1,83 @@
+#ifndef STAN_MATH_PRIM_SCAL_PROB_POISSON_LOG_CCDF_LOG_HPP
+#define STAN_MATH_PRIM_SCAL_PROB_POISSON_LOG_CCDF_LOG_HPP
+
+#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
+#include <stan/math/prim/scal/meta/partials_return_type.hpp>
+#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
+#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
+#include <stan/math/prim/scal/err/check_less.hpp>
+#include <stan/math/prim/scal/err/check_nonnegative.hpp>
+#include <stan/math/prim/scal/err/check_not_nan.hpp>
+#include <stan/math/prim/scal/fun/constants.hpp>
+#include <stan/math/prim/scal/fun/multiply_log.hpp>
+#include <stan/math/prim/scal/fun/gamma_p.hpp>
+#include <stan/math/prim/scal/fun/gamma_q.hpp>
+#include <stan/math/prim/scal/fun/lgamma.hpp>
+#include <stan/math/prim/scal/fun/value_of.hpp>
+#include <boost/random/poisson_distribution.hpp>
+#include <boost/random/variate_generator.hpp>
+#include <cmath>
+#include <limits>
+
+namespace stan {
+  namespace math {
+
+    template <typename T_n, typename T_rate>
+    typename return_type<T_rate>::type
+    poisson_log_ccdf_log(const T_n& n, const T_rate& log_lambda) {
+      static const char* function("poisson_log_ccdf_log");
+      typedef typename stan::partials_return_type<T_n, T_rate>::type
+        T_partials_return;
+
+      if (!(stan::length(n) && stan::length(log_lambda)))
+        return 0.0;
+
+      T_partials_return P(0.0);
+
+      check_not_nan(function, "Log rate parameter", log_lambda);
+      check_consistent_sizes(function,
+                             "Random variable", n,
+                             "Log rate parameter", log_lambda);
+
+      VectorView<const T_n> n_vec(n);
+      VectorView<const T_rate> log_lambda_vec(log_lambda);
+      size_t size = max_size(n, log_lambda);
+
+      using std::log;
+      using std::exp;
+
+      OperandsAndPartials<T_rate> operands_and_partials(log_lambda);
+
+      // Explicit return for extreme values
+      // The gradients are technically ill-defined, but treated as neg infinity
+      for (size_t i = 0; i < stan::length(n); i++) {
+        if (value_of(n_vec[i]) < 0)
+          return operands_and_partials.value(0.0);
+      }
+
+      for (size_t i = 0; i < size; i++) {
+        // Explicit results for extreme values
+        // The gradients are technically ill-defined, but treated as zero
+        if (value_of(n_vec[i]) == std::numeric_limits<int>::max())
+          return operands_and_partials.value(negative_infinity());
+
+        const T_partials_return n_dbl = value_of(n_vec[i]);
+        const T_partials_return log_lambda_dbl = value_of(log_lambda_vec[i]);
+        const T_partials_return lambda_dbl = exp(log_lambda_dbl);
+        const T_partials_return log_Pi = log(gamma_p(n_dbl+1, lambda_dbl));
+
+        P += log_Pi;
+
+        if (!is_constant_struct<T_rate>::value) {
+          operands_and_partials.d_x1[i] += exp(n_dbl * log(lambda_dbl)
+                                               - lambda_dbl - lgamma(n_dbl+1)
+                                               - log_Pi);
+          operands_and_partials.d_x1[i] *= lambda_dbl;
+        }
+      }
+      return operands_and_partials.value(P);
+    }
+
+  }
+}
+#endif

--- a/stan/math/prim/scal/prob/poisson_log_cdf.hpp
+++ b/stan/math/prim/scal/prob/poisson_log_cdf.hpp
@@ -1,0 +1,88 @@
+#ifndef STAN_MATH_PRIM_SCAL_PROB_POISSON_LOG_CDF_HPP
+#define STAN_MATH_PRIM_SCAL_PROB_POISSON_LOG_CDF_HPP
+
+#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
+#include <stan/math/prim/scal/meta/partials_return_type.hpp>
+#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
+#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
+#include <stan/math/prim/scal/err/check_less.hpp>
+#include <stan/math/prim/scal/err/check_nonnegative.hpp>
+#include <stan/math/prim/scal/err/check_not_nan.hpp>
+#include <stan/math/prim/scal/fun/constants.hpp>
+#include <stan/math/prim/scal/fun/multiply_log.hpp>
+#include <stan/math/prim/scal/fun/gamma_q.hpp>
+#include <stan/math/prim/scal/fun/tgamma.hpp>
+#include <stan/math/prim/scal/fun/value_of.hpp>
+#include <boost/random/poisson_distribution.hpp>
+#include <boost/random/variate_generator.hpp>
+#include <cmath>
+#include <limits>
+
+namespace stan {
+  namespace math {
+
+    // Poisson Log CDF
+    template <typename T_n, typename T_rate>
+    typename return_type<T_rate>::type
+    poisson_log_cdf(const T_n& n, const T_rate& log_lambda) {
+      static const char* function("poisson_log_cdf");
+      typedef typename stan::partials_return_type<T_n, T_rate>::type
+        T_partials_return;
+
+      if (!(stan::length(n) && stan::length(log_lambda)))
+        return 1.0;
+
+      T_partials_return P(1.0);
+
+      check_not_nan(function, "Log rate parameter", log_lambda);
+      check_consistent_sizes(function,
+                             "Random variable", n,
+                             "Log rate parameter", log_lambda);
+
+      VectorView<const T_n> n_vec(n);
+      VectorView<const T_rate> log_lambda_vec(log_lambda);
+      size_t size = max_size(n, log_lambda);
+
+      using std::exp;
+      using std::pow;
+
+      OperandsAndPartials<T_rate> operands_and_partials(log_lambda);
+
+      // Explicit return for extreme values
+      // The gradients are technically ill-defined, but treated as zero
+      for (size_t i = 0; i < stan::length(n); i++) {
+        if (value_of(n_vec[i]) < 0)
+          return operands_and_partials.value(0.0);
+      }
+
+      for (size_t i = 0; i < size; i++) {
+        // Explicit results for extreme values
+        // The gradients are technically ill-defined, but treated as zero
+        if (value_of(n_vec[i]) == std::numeric_limits<int>::max())
+          continue;
+
+        const T_partials_return n_dbl = value_of(n_vec[i]);
+        const T_partials_return log_lambda_dbl = value_of(log_lambda_vec[i]);
+        const T_partials_return lambda_dbl = exp(log_lambda_dbl);
+        const T_partials_return Pi = gamma_q(n_dbl+1, lambda_dbl);
+
+        P *= Pi;
+
+        if (!is_constant_struct<T_rate>::value)
+          operands_and_partials.d_x1[i] -= exp(-lambda_dbl)
+            * pow(lambda_dbl, n_dbl) / tgamma(n_dbl+1) / Pi;
+      }
+
+      if (!is_constant_struct<T_rate>::value) {
+        for (size_t i = 0; i < stan::length(log_lambda); ++i) {
+        const T_partials_return log_lambda_dbl = value_of(log_lambda_vec[i]);
+        const T_partials_return lambda_dbl = exp(log_lambda_dbl);
+          operands_and_partials.d_x1[i] *= P * lambda_dbl;
+        }
+      }
+      return operands_and_partials.value(P);
+    }
+
+  }
+}
+#endif

--- a/stan/math/prim/scal/prob/poisson_log_cdf_log.hpp
+++ b/stan/math/prim/scal/prob/poisson_log_cdf_log.hpp
@@ -1,0 +1,83 @@
+#ifndef STAN_MATH_PRIM_SCAL_PROB_POISSON_LOG_CDF_LOG_HPP
+#define STAN_MATH_PRIM_SCAL_PROB_POISSON_LOG_CDF_LOG_HPP
+
+#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
+#include <stan/math/prim/scal/meta/partials_return_type.hpp>
+#include <stan/math/prim/scal/meta/OperandsAndPartials.hpp>
+#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
+#include <stan/math/prim/scal/err/check_less.hpp>
+#include <stan/math/prim/scal/err/check_nonnegative.hpp>
+#include <stan/math/prim/scal/err/check_not_nan.hpp>
+#include <stan/math/prim/scal/fun/constants.hpp>
+#include <stan/math/prim/scal/fun/multiply_log.hpp>
+#include <stan/math/prim/scal/fun/gamma_q.hpp>
+#include <stan/math/prim/scal/fun/lgamma.hpp>
+#include <stan/math/prim/scal/fun/value_of.hpp>
+#include <boost/random/poisson_distribution.hpp>
+#include <boost/random/variate_generator.hpp>
+#include <cmath>
+#include <limits>
+
+namespace stan {
+  namespace math {
+
+    template <typename T_n, typename T_rate>
+    typename return_type<T_rate>::type
+    poisson_log_cdf_log(const T_n& n, const T_rate& log_lambda) {
+      static const char* function("poisson_log_cdf_log");
+      typedef typename stan::partials_return_type<T_n, T_rate>::type
+        T_partials_return;
+
+      if (!(stan::length(n) && stan::length(log_lambda)))
+        return 0.0;
+
+      T_partials_return P(0.0);
+
+      check_not_nan(function, "Rate parameter", log_lambda);
+      check_nonnegative(function, "Rate parameter", log_lambda);
+      check_consistent_sizes(function,
+                             "Random variable", n,
+                             "Rate parameter", log_lambda);
+
+      VectorView<const T_n> n_vec(n);
+      VectorView<const T_rate> log_lambda_vec(log_lambda);
+      size_t size = max_size(n, log_lambda);
+
+      using std::log;
+      using std::exp;
+
+      OperandsAndPartials<T_rate> operands_and_partials(log_lambda);
+
+      // Explicit return for extreme values
+      // The gradients are technically ill-defined, but treated as neg infinity
+      for (size_t i = 0; i < stan::length(n); i++) {
+        if (value_of(n_vec[i]) < 0)
+          return operands_and_partials.value(negative_infinity());
+      }
+
+      for (size_t i = 0; i < size; i++) {
+        // Explicit results for extreme values
+        // The gradients are technically ill-defined, but treated as zero
+        if (value_of(n_vec[i]) == std::numeric_limits<int>::max())
+          continue;
+
+        const T_partials_return n_dbl = value_of(n_vec[i]);
+        const T_partials_return log_lambda_dbl = value_of(log_lambda_vec[i]);
+        const T_partials_return lambda_dbl = exp(log_lambda_dbl);
+        const T_partials_return log_Pi = log(gamma_q(n_dbl+1, lambda_dbl));
+
+        P += log_Pi;
+
+        if (!is_constant_struct<T_rate>::value) {
+          operands_and_partials.d_x1[i] += - exp(n_dbl * log(lambda_dbl)
+                                                 - lambda_dbl - lgamma(n_dbl+1)
+                                                 - log_Pi);
+          operands_and_partials.d_x1[i] *= lambda_dbl;
+        }
+      }
+      return operands_and_partials.value(P);
+    }
+
+  }
+}
+#endif

--- a/test/unit/math/prim/scal/prob/poisson_log_ccdf_log_test.cpp
+++ b/test/unit/math/prim/scal/prob/poisson_log_ccdf_log_test.cpp
@@ -1,0 +1,28 @@
+#include <stan/math/prim/scal.hpp>
+#include <gtest/gtest.h>
+
+void check_values(int count, double log_rate) {
+  using std::exp;
+  using stan::math::is_nan;
+  using stan::math::poisson_log_ccdf_log;
+  using stan::math::poisson_ccdf_log;
+
+  double rate = exp(log_rate);
+
+  double val1 = poisson_log_ccdf_log(count, log_rate);
+  double val2 = poisson_ccdf_log(count, rate);
+
+  EXPECT_FALSE(is_nan(val1));
+  EXPECT_FALSE(val1 > 0.0);
+  EXPECT_FLOAT_EQ(val1, val2);
+}
+
+TEST(ProbPoisson, log_ccdf_log_values) {
+  int count = 2;
+  for (int i = 0; i < 6; ++i) {
+    double log_rate = 0.3;
+    for (int j = 0; j < 5; ++j) {
+      check_values(count, log_rate);
+    }
+  }
+}

--- a/test/unit/math/prim/scal/prob/poisson_log_cdf_log_test.cpp
+++ b/test/unit/math/prim/scal/prob/poisson_log_cdf_log_test.cpp
@@ -1,0 +1,28 @@
+#include <stan/math/prim/scal.hpp>
+#include <gtest/gtest.h>
+
+void check_values(int count, double log_rate) {
+  using std::exp;
+  using stan::math::is_nan;
+  using stan::math::poisson_log_cdf_log;
+  using stan::math::poisson_cdf_log;
+
+  double rate = exp(log_rate);
+
+  double val1 = poisson_log_cdf_log(count, log_rate);
+  double val2 = poisson_cdf_log(count, rate);
+
+  EXPECT_FALSE(is_nan(val1));
+  EXPECT_FALSE(val1 > 0.0);
+  EXPECT_FLOAT_EQ(val1, val2);
+}
+
+TEST(ProbPoisson, log_cdf_log_values) {
+  int count = 2;
+  for (int i = 0; i < 6; ++i) {
+    double log_rate = 0.3;
+    for (int j = 0; j < 5; ++j) {
+      check_values(count, log_rate);
+    }
+  }
+}

--- a/test/unit/math/prim/scal/prob/poisson_log_cdf_test.cpp
+++ b/test/unit/math/prim/scal/prob/poisson_log_cdf_test.cpp
@@ -1,0 +1,29 @@
+#include <stan/math/prim/scal.hpp>
+#include <gtest/gtest.h>
+
+void check_values(int count, double log_rate) {
+  using std::exp;
+  using stan::math::is_nan;
+  using stan::math::poisson_log_cdf;
+  using stan::math::poisson_cdf;
+
+  double rate = exp(log_rate);
+
+  double val1 = poisson_log_cdf(count, log_rate);
+  double val2 = poisson_cdf(count, rate);
+
+  EXPECT_FALSE(is_nan(val1));
+  EXPECT_FALSE(val1 < 0.0);
+  EXPECT_FALSE(val1 > 1.0);
+  EXPECT_FLOAT_EQ(val1, val2);
+}
+
+TEST(ProbPoisson, log_cdf_values) {
+  int count = 2;
+  for (int i = 0; i < 6; ++i) {
+    double log_rate = 0.3;
+    for (int j = 0; j < 5; ++j) {
+      check_values(count, log_rate);
+    }
+  }
+}

--- a/test/unit/math/rev/scal/prob/poisson_log_ccdf_log_test.cpp
+++ b/test/unit/math/rev/scal/prob/poisson_log_ccdf_log_test.cpp
@@ -1,0 +1,39 @@
+#include <stan/math/rev/scal.hpp>
+#include <gtest/gtest.h>
+#include <vector>
+
+TEST(ProbPoisson, log_ccdf_log_chain_rule) {
+  using std::exp;
+
+  using stan::math::is_nan;
+  using stan::math::var;
+
+  using stan::math::poisson_log_ccdf_log;
+  using stan::math::poisson_ccdf_log;
+
+  int count = 20;
+  double log_rate_dbl = 2.1;
+  double rate_dbl = exp(log_rate_dbl);
+  
+  var log_rate(log_rate_dbl);
+  var rate(rate_dbl);
+
+  var val1 = poisson_log_ccdf_log(count, log_rate);
+  var val2 = poisson_ccdf_log(count, rate);
+  
+  std::vector<var> x1;
+  x1.push_back(log_rate);
+
+  std::vector<var> x2;
+  x2.push_back(rate);
+
+  std::vector<double> gradients1;
+  std::vector<double> gradients2;
+
+  val1.grad(x1, gradients1);
+  val2.grad(x2, gradients2);
+
+  EXPECT_FALSE(is_nan(gradients1[0]));
+  EXPECT_FALSE(is_nan(gradients2[0]));
+  EXPECT_NEAR(gradients1[0], gradients2[0] * rate_dbl, 0.01);
+}

--- a/test/unit/math/rev/scal/prob/poisson_log_cdf_log_test.cpp
+++ b/test/unit/math/rev/scal/prob/poisson_log_cdf_log_test.cpp
@@ -1,0 +1,39 @@
+#include <stan/math/rev/scal.hpp>
+#include <gtest/gtest.h>
+#include <vector>
+
+TEST(ProbPoisson, log_cdf_log_chain_rule) {
+  using std::exp;
+
+  using stan::math::is_nan;
+  using stan::math::var;
+
+  using stan::math::poisson_log_cdf_log;
+  using stan::math::poisson_cdf_log;
+
+  int count = 20;
+  double log_rate_dbl = 2.1;
+  double rate_dbl = exp(log_rate_dbl);
+  
+  var log_rate(log_rate_dbl);
+  var rate(rate_dbl);
+
+  var val1 = poisson_log_cdf_log(count, log_rate);
+  var val2 = poisson_cdf_log(count, rate);
+  
+  std::vector<var> x1;
+  x1.push_back(log_rate);
+
+  std::vector<var> x2;
+  x2.push_back(rate);
+
+  std::vector<double> gradients1;
+  std::vector<double> gradients2;
+
+  val1.grad(x1, gradients1);
+  val2.grad(x2, gradients2);
+
+  EXPECT_FALSE(is_nan(gradients1[0]));
+  EXPECT_FALSE(is_nan(gradients2[0]));
+  EXPECT_NEAR(gradients1[0], gradients2[0] * rate_dbl, 0.01);
+}

--- a/test/unit/math/rev/scal/prob/poisson_log_cdf_test.cpp
+++ b/test/unit/math/rev/scal/prob/poisson_log_cdf_test.cpp
@@ -1,0 +1,39 @@
+#include <stan/math/rev/scal.hpp>
+#include <gtest/gtest.h>
+#include <vector>
+
+TEST(ProbPoisson, log_cdf_chain_rule) {
+  using std::exp;
+
+  using stan::math::is_nan;
+  using stan::math::var;
+
+  using stan::math::poisson_log_cdf;
+  using stan::math::poisson_cdf;
+
+  int count = 20;
+  double log_rate_dbl = 2.1;
+  double rate_dbl = exp(log_rate_dbl);
+  
+  var log_rate(log_rate_dbl);
+  var rate(rate_dbl);
+
+  var val1 = poisson_log_cdf(count, log_rate);
+  var val2 = poisson_cdf(count, rate);
+  
+  std::vector<var> x1;
+  x1.push_back(log_rate);
+
+  std::vector<var> x2;
+  x2.push_back(rate);
+
+  std::vector<double> gradients1;
+  std::vector<double> gradients2;
+
+  val1.grad(x1, gradients1);
+  val2.grad(x2, gradients2);
+
+  EXPECT_FALSE(is_nan(gradients1[0]));
+  EXPECT_FALSE(is_nan(gradients2[0]));
+  EXPECT_NEAR(gradients1[0], gradients2[0] * rate_dbl, 0.01);
+}


### PR DESCRIPTION
#### Submisison Checklist

- [ ] Run unit tests: `./runTests.py test/unit`
- [ ] Run cpplint: `make cpplint`
- [ ] Declare copyright holder and open-source license: see below

#### Summary:
adds `poisson_log_cdf`, `poisson_log_cdf_log`, and `poisson_log_ccdf_log` and adds tests for correct values and partial derivatives with respect to the log rate parameter. this is computed in the silly way you'd expect, `poisson_log_cdf(n, t) = poisson_cdf(n, exp(t))` and the derivatives get a corresponding correction from the chain rule applied to the second argument.

resolves https://github.com/stan-dev/math/issues/90

#### Intended Effect:

#### How to Verify:
Besides running the six tests, it may be helpful to look at the adjacent files `poisson_cdf.hpp,` `poisson_cdf_log.hpp`, and `poisson_ccdf_log.hpp` of which these files are a minor variation. 

#### Side Effects:
None, adds three functions to the math library.

#### Documentation:
Will follow up with a PR adding these to the stan language and add doc in the manual at that time

#### Reviewer Suggestions: 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
