### PR TITLE
fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The Stan Math Library is licensed under the [new BSD license](https://raw.github
 
 Required Libraries
 ------------------
-Stan Math depends on two libraries:
+Stan Math depends on three libraries:
 
 - Boost (version 1.62.0): [Boost Home Page](http://www.boost.org)
 - Eigen (version 3.2.9): [Eigen Home Page](http://eigen.tuxfamily.org/index.php?title=Main_Page)


### PR DESCRIPTION
#### Submisison Checklist

- [ ] Run unit tests: `./runTests.py test/unit`
- [ ] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

The only change is "two" to "three" in the README file. The text said "two libraries" but three libraries are listed. 

#### Intended Effect:

Fix the README file.

#### How to Verify:

Look at it.

#### Side Effects:

#### Documentation:

#### Reviewer Suggestions: 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
