### PR TITLE
remove forward decl for LDLT_factor, fixes #476

### DIFF
--- a/stan/math/prim/mat/fun/LDLT_factor.hpp
+++ b/stan/math/prim/mat/fun/LDLT_factor.hpp
@@ -9,13 +9,14 @@
 namespace stan {
   namespace math {
 
-    template <typename T, int R, int C>
-    class LDLT_factor;
-
     /**
      * LDLT_factor is a thin wrapper on Eigen::LDLT to allow for
      * reusing factorizations and efficient autodiff of things like
      * log determinants and solutions to linear systems.
+     *
+     * Memory is allocated in the constructor and stored in a
+     * <code>boost::shared_ptr</code>, which ensures that is freed
+     * when the object is released.
      *
      * After the constructor and/or compute() is called users of
      * LDLT_factor are responsible for calling success() to
@@ -32,13 +33,14 @@ namespace stan {
      * ldlt_A2.compute(A2);
      * ~~~
      *
-     * Now, the caller should check that ldlt_A1.success() and ldlt_A2.success()
+     * The caller should check that ldlt_A1.success() and ldlt_A2.success()
      * are true or abort accordingly.  Alternatively, call check_ldlt_factor().
      *
      * Note that ldlt_A1 and ldlt_A2 are completely equivalent.  They simply
      * demonstrate two different ways to construct the factorization.
      *
-     * Now, the caller can use the LDLT_factor objects as needed.  For instance
+     * The caller can use the LDLT_factor objects as needed.  For
+     * instance
      *
      * ~~~
      * x1 = mdivide_left_ldlt(ldlt_A1, b1);
@@ -48,22 +50,31 @@ namespace stan {
      * d2 = log_determinant_ldlt(ldlt_A2);
      * ~~~
      *
-     * This class is conceptually similar to the corresponding Eigen class
-     * Any spd matrix A can be decomposed as LDL' where L is unit
-     * lower-triangular and D is diagonal with positive diagonal elements
+     * This class is conceptually similar to the corresponding Eigen
+     * class.  Any symmetric, positive-definite matrix A can be
+     * decomposed as LDL' where L is unit lower-triangular and D is
+     * diagonal with positive diagonal elements.
+     *
+     * @tparam T scalare type held in the matrix
+     * @tparam R rows (as in Eigen)
+     * @tparam C columns (as in Eigen)
      */
-    template <int R, int C, typename T>
-    class LDLT_factor<T, R, C> {
+    template <typename T, int R, int C>
+    class LDLT_factor {
     public:
-      LDLT_factor()
-        : N_(0), ldltP_(new Eigen::LDLT<Eigen::Matrix<T, R, C> >()) {}
+      typedef Eigen::Matrix<T, Eigen::Dynamic, 1> vector_t;
+      typedef Eigen::Matrix<T, R, C> matrix_t;
+      typedef Eigen::LDLT<matrix_t> ldlt_t;
+      typedef size_t size_type;
+      typedef double value_type;
 
-      explicit LDLT_factor(const Eigen::Matrix<T, R, C>& A)
-        : N_(0), ldltP_(new Eigen::LDLT<Eigen::Matrix<T, R, C> >()) {
+      LDLT_factor() : N_(0), ldltP_(new ldlt_t()) { }
+
+      explicit LDLT_factor(const matrix_t& A) : N_(0), ldltP_(new ldlt_t()) {
         compute(A);
       }
 
-      inline void compute(const Eigen::Matrix<T, R, C>& A) {
+      inline void compute(const matrix_t& A) {
         check_square("LDLT_factor", "A", A);
         N_ = A.rows();
         ldltP_->compute(A);
@@ -74,7 +85,7 @@ namespace stan {
           return false;
         if (!(ldltP_->isPositive()))
           return false;
-        Eigen::Matrix<T, Eigen::Dynamic, 1> ldltP_diag(ldltP_->vectorD());
+        vector_t ldltP_diag(ldltP_->vectorD());
         for (int i = 0; i < ldltP_diag.size(); ++i)
           if (ldltP_diag(i) <= 0 || is_nan(ldltP_diag(i)))
             return false;
@@ -85,48 +96,43 @@ namespace stan {
         return ldltP_->vectorD().array().log().sum();
       }
 
-      inline void inverse(Eigen::Matrix<T, R, C>& invA) const {
+      inline void inverse(matrix_t& invA) const {
         invA.setIdentity(N_);
         ldltP_->solveInPlace(invA);
       }
 
 #if EIGEN_VERSION_AT_LEAST(3, 3, 0)
       template <typename Rhs>
-      inline const
-      Eigen::Solve<Eigen::LDLT<Eigen::Matrix<T, R, C> >, Rhs>
+      inline const Eigen::Solve<ldlt_t, Rhs>
       solve(const Eigen::MatrixBase<Rhs>& b) const {
         return ldltP_->solve(b);
       }
 #else
       template <typename Rhs>
-      inline const
-      Eigen::internal::solve_retval<Eigen::LDLT< Eigen::Matrix<T, R, C> >, Rhs>
+      inline const Eigen::internal::solve_retval<ldlt_t, Rhs>
       solve(const Eigen::MatrixBase<Rhs>& b) const {
         return ldltP_->solve(b);
       }
 #endif
 
-      inline Eigen::Matrix<T, R, C>
-      solveRight(const Eigen::Matrix<T, R, C>& B) const {
+      inline matrix_t solveRight(const matrix_t& B) const {
         return ldltP_->solve(B.transpose()).transpose();
       }
 
-      inline Eigen::Matrix<T, Eigen::Dynamic, 1> vectorD() const {
+      inline vector_t vectorD() const {
         return ldltP_->vectorD();
       }
 
-      inline Eigen::LDLT<Eigen::Matrix<T, R, C> > matrixLDLT() const {
+      inline ldlt_t matrixLDLT() const {
         return ldltP_->matrixLDLT();
       }
 
       inline size_t rows() const { return N_; }
       inline size_t cols() const { return N_; }
 
-      typedef size_t size_type;
-      typedef double value_type;
 
       size_t N_;
-      boost::shared_ptr<Eigen::LDLT<Eigen::Matrix<T, R, C> > > ldltP_;
+      boost::shared_ptr<ldlt_t> ldltP_;
     };
 
   }


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

Remove buggy forward declaration for `LDLT_factor` class and convert declaration of implementation class to basic definition rather than specialization.

#### Intended Effect:

Make compatible with picky compilers that noticed that the specialization wasn't doing anything.  Also cleaned up some of the code with typedefs.

#### How to Verify:

Unit tests.

#### Side Effects:

No.

#### Documentation:

No.

#### Reviewer Suggestions: 

anyone

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
