### PR TITLE
Adding doc for many functions in prim/scal/prob

### DIFF
--- a/stan/math/prim/scal/prob/bernoulli_cdf.hpp
+++ b/stan/math/prim/scal/prob/bernoulli_cdf.hpp
@@ -20,19 +20,16 @@ namespace stan {
   namespace math {
 
     /**
-     * CDF of the Bernoulli distribution. If vectors of matching lengths
-     * are supplied, returns the product of the probabilities.
+     * Returns the CDF of the Bernoulli distribution. If containers are 
+     * supplied, returns the product of the probabilities.
      *
-     * @param n (sequence of) integers, must be 0 or 1
-     * @param theta (sequence of) probability parameters
-     *
-     * @tparam T_n type of integers
-     * @tparam T_prob type of probability parameters
-     *
-     * @return product of the probabilities
-     *
-     * @throw std::domain_error if probability parameters fall outside of [0,1].
-     * @throw std::invalid_argument if vector parameters have non-matching sizes.
+     * @tparam T_n type of integer parameter
+     * @tparam T_prob type of chance of success parameter
+     * @param n integer parameter
+     * @param theta chance of success parameter
+     * @return probability or product of probabilities
+     * @throw std::domain_error if theta is not a valid probability
+     * @throw std::invalid_argument if container sizes mismatch.
      */
     template <typename T_n, typename T_prob>
     typename return_type<T_prob>::type

--- a/stan/math/prim/scal/prob/bernoulli_cdf.hpp
+++ b/stan/math/prim/scal/prob/bernoulli_cdf.hpp
@@ -19,7 +19,21 @@
 namespace stan {
   namespace math {
 
-    // Bernoulli CDF
+    /**
+     * CDF of the Bernoulli distribution. If vectors of matching lengths
+     * are supplied, returns the product of the probabilities.
+     *
+     * @param n (sequence of) integers, must be 0 or 1
+     * @param theta (sequence of) probability parameters
+     *
+     * @tparam T_n type of integers
+     * @tparam T_prob type of probability parameters
+     *
+     * @return product of the probabilities
+     *
+     * @throw std::domain_error if probability parameters fall outside of [0,1].
+     * @throw std::invalid_argument if vector parameters have non-matching sizes.
+     */
     template <typename T_n, typename T_prob>
     typename return_type<T_prob>::type
     bernoulli_cdf(const T_n& n, const T_prob& theta) {

--- a/stan/math/prim/scal/prob/bernoulli_lccdf.hpp
+++ b/stan/math/prim/scal/prob/bernoulli_lccdf.hpp
@@ -21,19 +21,16 @@ namespace stan {
   namespace math {
 
     /**
-     * Log complementary CDF of the Bernoulli distribution. If vectors of matching lengths
-     * are supplied, returns the log sum of the probabilities.
+     * Returns the log CCDF of the Bernoulli distribution. If containers are 
+     * supplied, returns the log sum of the probabilities.
      *
-     * @param n (sequence of) integers, must be 0 or 1
-     * @param theta (sequence of) probability parameters
-     *
-     * @tparam T_n type of integers
-     * @tparam T_prob type of probability parameters
-     *
-     * @return sum of the log probabilities
-     *
-     * @throw std::domain_error if probability parameters fall outside of [0,1].
-     * @throw std::invalid_argument if vector parameters have non-matching sizes.
+     * @tparam T_n type of integer parameter
+     * @tparam T_prob type of chance of success parameter
+     * @param n integer parameter
+     * @param theta chance of success parameter
+     * @return log probability or log sum of probabilities
+     * @throw std::domain_error if theta is not a valid probability
+     * @throw std::invalid_argument if container sizes mismatch.
      */
     template <typename T_n, typename T_prob>
     typename return_type<T_prob>::type

--- a/stan/math/prim/scal/prob/bernoulli_lccdf.hpp
+++ b/stan/math/prim/scal/prob/bernoulli_lccdf.hpp
@@ -20,6 +20,21 @@
 namespace stan {
   namespace math {
 
+    /**
+     * Log complementary CDF of the Bernoulli distribution. If vectors of matching lengths
+     * are supplied, returns the log sum of the probabilities.
+     *
+     * @param n (sequence of) integers, must be 0 or 1
+     * @param theta (sequence of) probability parameters
+     *
+     * @tparam T_n type of integers
+     * @tparam T_prob type of probability parameters
+     *
+     * @return sum of the log probabilities
+     *
+     * @throw std::domain_error if probability parameters fall outside of [0,1].
+     * @throw std::invalid_argument if vector parameters have non-matching sizes.
+     */
     template <typename T_n, typename T_prob>
     typename return_type<T_prob>::type
     bernoulli_lccdf(const T_n& n, const T_prob& theta) {

--- a/stan/math/prim/scal/prob/bernoulli_lcdf.hpp
+++ b/stan/math/prim/scal/prob/bernoulli_lcdf.hpp
@@ -21,19 +21,16 @@ namespace stan {
   namespace math {
 
     /**
-     * Log CDF of the Bernoulli distribution. If vectors of matching lengths
-     * are supplied, returns the log sum of the probabilities.
+     * Returns the log CDF of the Bernoulli distribution. If containers are 
+     * supplied, returns the log sum of the probabilities.
      *
-     * @param n (sequence of) integers, must be 0 or 1
-     * @param theta (sequence of) probability parameters
-     *
-     * @tparam T_n type of integers
-     * @tparam T_prob type of probability parameters
-     *
-     * @return log sum of the probabilities
-     *
-     * @throw std::domain_error if probability parameters fall outside of [0,1].
-     * @throw std::invalid_argument if vector parameters have non-matching sizes.
+     * @tparam T_n type of integer parameter
+     * @tparam T_prob type of chance of success parameter
+     * @param n integer parameter
+     * @param theta chance of success parameter
+     * @return log probability or log sum of probabilities
+     * @throw std::domain_error if theta is not a valid probability
+     * @throw std::invalid_argument if container sizes mismatch.
      */
     template <typename T_n, typename T_prob>
     typename return_type<T_prob>::type

--- a/stan/math/prim/scal/prob/bernoulli_lcdf.hpp
+++ b/stan/math/prim/scal/prob/bernoulli_lcdf.hpp
@@ -20,6 +20,21 @@
 namespace stan {
   namespace math {
 
+    /**
+     * Log CDF of the Bernoulli distribution. If vectors of matching lengths
+     * are supplied, returns the log sum of the probabilities.
+     *
+     * @param n (sequence of) integers, must be 0 or 1
+     * @param theta (sequence of) probability parameters
+     *
+     * @tparam T_n type of integers
+     * @tparam T_prob type of probability parameters
+     *
+     * @return log sum of the probabilities
+     *
+     * @throw std::domain_error if probability parameters fall outside of [0,1].
+     * @throw std::invalid_argument if vector parameters have non-matching sizes.
+     */
     template <typename T_n, typename T_prob>
     typename return_type<T_prob>::type
     bernoulli_lcdf(const T_n& n, const T_prob& theta) {

--- a/stan/math/prim/scal/prob/bernoulli_logit_lpmf.hpp
+++ b/stan/math/prim/scal/prob/bernoulli_logit_lpmf.hpp
@@ -20,8 +20,21 @@
 namespace stan {
   namespace math {
 
-    // Bernoulli(n|inv_logit(theta))   [0 <= n <= 1;   -inf <= theta <= inf]
-    // FIXME: documentation
+    /**
+     * Log PMF of the Logit-parametrized Bernoulli distribution. If vectors of matching lengths
+     * are supplied, returns the log sum of the probabilities.
+     *
+     * @param n (sequence of) integers, must be 0 or 1
+     * @param theta (sequence of) logit transformed probability parameters
+     *
+     * @tparam T_n type of integers
+     * @tparam T_prob type of probability parameters
+     *
+     * @return log sum of the probabilities
+     *
+     * @throw std::domain_error if logit-transformed probability parameters are not fine
+     * @throw std::invalid_argument if vector parameters have non-matching sizes.
+     */
     template <bool propto, typename T_n, typename T_prob>
     typename return_type<T_prob>::type
     bernoulli_logit_lpmf(const T_n& n, const T_prob& theta) {

--- a/stan/math/prim/scal/prob/bernoulli_logit_lpmf.hpp
+++ b/stan/math/prim/scal/prob/bernoulli_logit_lpmf.hpp
@@ -21,19 +21,16 @@ namespace stan {
   namespace math {
 
     /**
-     * Log PMF of the Logit-parametrized Bernoulli distribution. If vectors of matching lengths
-     * are supplied, returns the log sum of the probabilities.
+     * Returns the log PMF of the logit-parametrized Bernoulli distribution. If 
+     * containers are supplied, returns the log sum of the probabilities.
      *
-     * @param n (sequence of) integers, must be 0 or 1
-     * @param theta (sequence of) logit transformed probability parameters
-     *
-     * @tparam T_n type of integers
-     * @tparam T_prob type of probability parameters
-     *
-     * @return log sum of the probabilities
-     *
-     * @throw std::domain_error if logit-transformed probability parameters are not fine
-     * @throw std::invalid_argument if vector parameters have non-matching sizes.
+     * @tparam T_n type of integer parameter
+     * @tparam T_prob type of chance of success parameter
+     * @param n integer parameter
+     * @param theta logit-transformed chance of success parameter
+     * @return log probability or log sum of probabilities
+     * @throw std::domain_error if theta is infinite.
+     * @throw std::invalid_argument if container sizes mismatch.
      */
     template <bool propto, typename T_n, typename T_prob>
     typename return_type<T_prob>::type

--- a/stan/math/prim/scal/prob/bernoulli_lpmf.hpp
+++ b/stan/math/prim/scal/prob/bernoulli_lpmf.hpp
@@ -21,19 +21,16 @@ namespace stan {
   namespace math {
 
     /**
-     * Log PMF of the Bernoulli distribution. If vectors of matching lengths
-     * are supplied, returns the log sum of the probabilities.
+     * Returns the log PMF of the Bernoulli distribution. If containers are 
+     * supplied, returns the log sum of the probabilities.
      *
-     * @param n (sequence of) integers, must be 0 or 1
-     * @param theta (sequence of) probability parameters
-     *
-     * @tparam T_n type of integers
-     * @tparam T_prob type of probability parameters
-     *
-     * @return log sum of the probabilities
-     *
-     * @throw std::domain_error if probability parameters fall outside of [0,1].
-     * @throw std::invalid_argument if vector parameters have non-matching sizes.
+     * @tparam T_n type of integer parameters
+     * @tparam T_prob type of chance of success parameters
+     * @param n integer parameter
+     * @param theta chance of success parameter
+     * @return log probability or log sum of probabilities
+     * @throw std::domain_error if theta is not a valid probability
+     * @throw std::invalid_argument if container sizes mismatch.
      */
     template <bool propto, typename T_n, typename T_prob>
     typename return_type<T_prob>::type

--- a/stan/math/prim/scal/prob/bernoulli_lpmf.hpp
+++ b/stan/math/prim/scal/prob/bernoulli_lpmf.hpp
@@ -20,8 +20,21 @@
 namespace stan {
   namespace math {
 
-    // Bernoulli(n|theta)   [0 <= n <= 1;   0 <= theta <= 1]
-    // FIXME: documentation
+    /**
+     * Log PMF of the Bernoulli distribution. If vectors of matching lengths
+     * are supplied, returns the log sum of the probabilities.
+     *
+     * @param n (sequence of) integers, must be 0 or 1
+     * @param theta (sequence of) probability parameters
+     *
+     * @tparam T_n type of integers
+     * @tparam T_prob type of probability parameters
+     *
+     * @return log sum of the probabilities
+     *
+     * @throw std::domain_error if probability parameters fall outside of [0,1].
+     * @throw std::invalid_argument if vector parameters have non-matching sizes.
+     */
     template <bool propto, typename T_n, typename T_prob>
     typename return_type<T_prob>::type
     bernoulli_lpmf(const T_n& n,

--- a/stan/math/prim/scal/prob/bernoulli_rng.hpp
+++ b/stan/math/prim/scal/prob/bernoulli_rng.hpp
@@ -16,6 +16,14 @@
 namespace stan {
   namespace math {
 
+    /**
+     * Bernoulli random number generator (biased coin).
+     *
+     * @param theta probability parameter
+     * @tparam RNG type of random number generator
+     * @return 0 or 1.
+     * @throw std::domain_error if probability parameter is invalid.
+     */
     template <class RNG>
     inline int
     bernoulli_rng(double theta,

--- a/stan/math/prim/scal/prob/bernoulli_rng.hpp
+++ b/stan/math/prim/scal/prob/bernoulli_rng.hpp
@@ -20,6 +20,7 @@ namespace stan {
      * Bernoulli random number generator (biased coin).
      *
      * @param theta probability parameter
+     * @param rng random number generator
      * @tparam RNG type of random number generator
      * @return 0 or 1.
      * @throw std::domain_error if probability parameter is invalid.

--- a/stan/math/prim/scal/prob/bernoulli_rng.hpp
+++ b/stan/math/prim/scal/prob/bernoulli_rng.hpp
@@ -17,12 +17,13 @@ namespace stan {
   namespace math {
 
     /**
-     * Bernoulli random number generator (biased coin).
+     * Return pseudorandom Bernoulli draw with specified chance of success 
+     * using the specified random number generator.
      *
-     * @param theta probability parameter
-     * @param rng random number generator
      * @tparam RNG type of random number generator
-     * @return 0 or 1.
+     * @param theta chance of success parameter
+     * @param rng random number generator
+     * @return Bernoulli random variate 
      * @throw std::domain_error if probability parameter is invalid.
      */
     template <class RNG>

--- a/stan/math/prim/scal/prob/beta_binomial_cdf.hpp
+++ b/stan/math/prim/scal/prob/beta_binomial_cdf.hpp
@@ -24,21 +24,21 @@ namespace stan {
   namespace math {
 
     /**
-     * CDF for Beta-Binomial distribution.
+     * Returns the CDF of the Beta-Binomial distribution with given population 
+     * size, prior success, and prior failure parameters. Given containers of 
+     * matching sizes, returns the product of probabilities.
      *
-     * <p>Equivalent to a Binomial(N,p) with a Beta(alpha, beta)
-     * prior on p. If given vector parameters of matching size, will return the product of
-     * probabilities.</p>
-     *
-     * @param n (vector of) non-negative integer successes variable count(s)
-     * @param N (vector of) positive integer size parameter(s)
-     * @param alpha (vector of) prior success parameter(s)
-     * @param beta (vector of) prior failure parameter(s)
-     *
-     * @return product of probabilities.
-     *
-     * @throw std::domain_error if N, alpha, or beta fails to be positive.
-     * @throw std::invalid_argument if vector parameters have non-matching sizes.
+     * @tparam T_n type of success parameter
+     * @tparam T_N type of population size parameter
+     * @tparam T_size1 type of prior success parameter
+     * @tparam T_size2 type of prior failure parameter
+     * @param n success parameter
+     * @param N population size parameter
+     * @param alpha prior success parameter
+     * @param beta prior failure parameter
+     * @return probability or product of probabilities
+     * @throw std::domain_error if N, alpha, or beta fails to be positive
+     * @throw std::invalid_argument if container sizes mismatch
      */
     template <typename T_n, typename T_N,
               typename T_size1, typename T_size2>

--- a/stan/math/prim/scal/prob/beta_binomial_cdf.hpp
+++ b/stan/math/prim/scal/prob/beta_binomial_cdf.hpp
@@ -23,7 +23,23 @@
 namespace stan {
   namespace math {
 
-    // Beta-Binomial CDF
+    /**
+     * CDF for Beta-Binomial distribution.
+     *
+     * <p>Equivalent to a Binomial(N,p) with a Beta(alpha, beta)
+     * prior on p. If given vector parameters of matching size, will return the product of
+     * probabilities.</p>
+     *
+     * @param n (vector of) non-negative integer successes variable count(s)
+     * @param N (vector of) positive integer size parameter(s)
+     * @param alpha (vector of) prior success parameter(s)
+     * @param beta (vector of) prior failure parameter(s)
+     *
+     * @return product of probabilities.
+     *
+     * @throw std::domain_error if N, alpha, or beta fails to be positive.
+     * @throw std::invalid_argument if vector parameters have non-matching sizes.
+     */
     template <typename T_n, typename T_N,
               typename T_size1, typename T_size2>
     typename return_type<T_size1, T_size2>::type

--- a/stan/math/prim/scal/prob/beta_binomial_lccdf.hpp
+++ b/stan/math/prim/scal/prob/beta_binomial_lccdf.hpp
@@ -23,6 +23,23 @@
 namespace stan {
   namespace math {
 
+    /**
+     * Log complementary CDF for Beta-Binomial distribution.
+     *
+     * <p>Equivalent to a Binomial(N,p) with a Beta(alpha, beta)
+     * prior on p. If given vector parameters of matching size, will return the log sum of
+     * probabilities.</p>
+     *
+     * @param n (vector of) non-negative integer successes variable count(s)
+     * @param N (vector of) positive integer size parameter(s)
+     * @param alpha (vector of) prior success parameter(s)
+     * @param beta (vector of) prior failure parameter(s)
+     *
+     * @return log sum of probabilities.
+     *
+     * @throw std::domain_error if N, alpha, or beta fails to be positive.
+     * @throw std::invalid_argument if vector parameters have non-matching sizes.
+     */
     template <typename T_n, typename T_N,
               typename T_size1, typename T_size2>
     typename return_type<T_size1, T_size2>::type

--- a/stan/math/prim/scal/prob/beta_binomial_lccdf.hpp
+++ b/stan/math/prim/scal/prob/beta_binomial_lccdf.hpp
@@ -24,21 +24,21 @@ namespace stan {
   namespace math {
 
     /**
-     * Log complementary CDF for Beta-Binomial distribution.
+     * Returns the log CCDF of the Beta-Binomial distribution with given population 
+     * size, prior success, and prior failure parameters. Given containers of 
+     * matching sizes, returns the log sum of probabilities.
      *
-     * <p>Equivalent to a Binomial(N,p) with a Beta(alpha, beta)
-     * prior on p. If given vector parameters of matching size, will return the log sum of
-     * probabilities.</p>
-     *
-     * @param n (vector of) non-negative integer successes variable count(s)
-     * @param N (vector of) positive integer size parameter(s)
-     * @param alpha (vector of) prior success parameter(s)
-     * @param beta (vector of) prior failure parameter(s)
-     *
-     * @return log sum of probabilities.
-     *
-     * @throw std::domain_error if N, alpha, or beta fails to be positive.
-     * @throw std::invalid_argument if vector parameters have non-matching sizes.
+     * @tparam T_n type of success parameter
+     * @tparam T_N type of population size parameter
+     * @tparam T_size1 type of prior success parameter
+     * @tparam T_size2 type of prior failure parameter
+     * @param n success parameter
+     * @param N population size parameter
+     * @param alpha prior success parameter
+     * @param beta prior failure parameter
+     * @return log probability or log sum of probabilities
+     * @throw std::domain_error if N, alpha, or beta fails to be positive
+     * @throw std::invalid_argument if container sizes mismatch
      */
     template <typename T_n, typename T_N,
               typename T_size1, typename T_size2>

--- a/stan/math/prim/scal/prob/beta_binomial_lcdf.hpp
+++ b/stan/math/prim/scal/prob/beta_binomial_lcdf.hpp
@@ -24,21 +24,21 @@ namespace stan {
   namespace math {
 
     /**
-     * Log CDF for Beta-Binomial distribution.
+     * Returns the log CDF of the Beta-Binomial distribution with given population 
+     * size, prior success, and prior failure parameters. Given containers of 
+     * matching sizes, returns the log sum of probabilities.
      *
-     * <p>Equivalent to a Binomial(N,p) with a Beta(alpha, beta)
-     * prior on p. If given vector parameters of matching size, will return the log sum of
-     * probabilities.</p>
-     *
-     * @param n (vector of) non-negative integer successes variable count(s)
-     * @param N (vector of) positive integer size parameter(s)
-     * @param alpha (vector of) prior success parameter(s)
-     * @param beta (vector of) prior failure parameter(s)
-     *
-     * @return log sum of probabilities.
-     *
-     * @throw std::domain_error if N, alpha, or beta fails to be positive.
-     * @throw std::invalid_argument if vector parameters have non-matching sizes.
+     * @tparam T_n type of success parameter
+     * @tparam T_N type of population size parameter
+     * @tparam T_size1 type of prior success parameter
+     * @tparam T_size2 type of prior failure parameter
+     * @param n success parameter
+     * @param N population size parameter
+     * @param alpha prior success parameter
+     * @param beta prior failure parameter
+     * @return log probability or log sum of probabilities
+     * @throw std::domain_error if N, alpha, or beta fails to be positive
+     * @throw std::invalid_argument if container sizes mismatch
      */
     template <typename T_n, typename T_N,
               typename T_size1, typename T_size2>

--- a/stan/math/prim/scal/prob/beta_binomial_lcdf.hpp
+++ b/stan/math/prim/scal/prob/beta_binomial_lcdf.hpp
@@ -23,6 +23,23 @@
 namespace stan {
   namespace math {
 
+    /**
+     * Log CDF for Beta-Binomial distribution.
+     *
+     * <p>Equivalent to a Binomial(N,p) with a Beta(alpha, beta)
+     * prior on p. If given vector parameters of matching size, will return the log sum of
+     * probabilities.</p>
+     *
+     * @param n (vector of) non-negative integer successes variable count(s)
+     * @param N (vector of) positive integer size parameter(s)
+     * @param alpha (vector of) prior success parameter(s)
+     * @param beta (vector of) prior failure parameter(s)
+     *
+     * @return log sum of probabilities.
+     *
+     * @throw std::domain_error if N, alpha, or beta fails to be positive.
+     * @throw std::invalid_argument if vector parameters have non-matching sizes.
+     */
     template <typename T_n, typename T_N,
               typename T_size1, typename T_size2>
     typename return_type<T_size1, T_size2>::type

--- a/stan/math/prim/scal/prob/beta_binomial_lpmf.hpp
+++ b/stan/math/prim/scal/prob/beta_binomial_lpmf.hpp
@@ -23,7 +23,23 @@
 namespace stan {
   namespace math {
 
-    // BetaBinomial(n|alpha, beta) [alpha > 0;  beta > 0;  n >= 0]
+    /**
+     * Log probability mass function for Beta-Binomial distribution.
+     *
+     * <p>Equivalent to a Binomial(N,p) with a Beta(alpha, beta)
+     * prior on p. If given vector parameters of matching size, will return the log sum of
+     * probabilities.</p>
+     *
+     * @param n (vector of) non-negative integer successes variable count(s)
+     * @param N (vector of) positive integer size parameter(s)
+     * @param alpha (vector of) prior success parameter(s)
+     * @param beta (vector of) prior failure parameter(s)
+     *
+     * @return log sum of probabilities.
+     *
+     * @throw std::domain_error if N, alpha, or beta fails to be positive.
+     * @throw std::invalid_argument if vector parameters have non-matching sizes.
+     */
     template <bool propto,
               typename T_n, typename T_N,
               typename T_size1, typename T_size2>

--- a/stan/math/prim/scal/prob/beta_binomial_lpmf.hpp
+++ b/stan/math/prim/scal/prob/beta_binomial_lpmf.hpp
@@ -24,21 +24,21 @@ namespace stan {
   namespace math {
 
     /**
-     * Log probability mass function for Beta-Binomial distribution.
+     * Returns the log PMF of the Beta-Binomial distribution with given population 
+     * size, prior success, and prior failure parameters. Given containers of 
+     * matching sizes, returns the log sum of probabilities.
      *
-     * <p>Equivalent to a Binomial(N,p) with a Beta(alpha, beta)
-     * prior on p. If given vector parameters of matching size, will return the log sum of
-     * probabilities.</p>
-     *
-     * @param n (vector of) non-negative integer successes variable count(s)
-     * @param N (vector of) positive integer size parameter(s)
-     * @param alpha (vector of) prior success parameter(s)
-     * @param beta (vector of) prior failure parameter(s)
-     *
-     * @return log sum of probabilities.
-     *
-     * @throw std::domain_error if N, alpha, or beta fails to be positive.
-     * @throw std::invalid_argument if vector parameters have non-matching sizes.
+     * @tparam T_n type of success parameter
+     * @tparam T_N type of population size parameter
+     * @tparam T_size1 type of prior success parameter
+     * @tparam T_size2 type of prior failure parameter
+     * @param n success parameter
+     * @param N population size parameter
+     * @param alpha prior success parameter
+     * @param beta prior failure parameter
+     * @return log probability or log sum of probabilities
+     * @throw std::domain_error if N, alpha, or beta fails to be positive
+     * @throw std::invalid_argument if container sizes mismatch
      */
     template <bool propto,
               typename T_n, typename T_N,

--- a/stan/math/prim/scal/prob/beta_binomial_rng.hpp
+++ b/stan/math/prim/scal/prob/beta_binomial_rng.hpp
@@ -28,6 +28,7 @@ namespace stan {
      * @param N population size parameter
      * @param alpha success parameter
      * @param beta failure parameter
+     * @param rng random number generator
      * @return Beta-Binomial random variate
      * @throw std::domain_error if N, alpha, or beta is negative.
      */

--- a/stan/math/prim/scal/prob/beta_binomial_rng.hpp
+++ b/stan/math/prim/scal/prob/beta_binomial_rng.hpp
@@ -20,37 +20,15 @@ namespace stan {
   namespace math {
 
     /**
-     * Paranoid wrapper for beta_rng which enforces good output at the cost
-     * of introducing an infinite loop.
+     * Return a pseudorandom Beta-Binomial draw with specified population size,
+     * prior success, and prior failure parameter using the specified random
+     * number generator.
      *
+     * @tparam RNG type of random number generator
+     * @param N population size parameter
      * @param alpha success parameter
      * @param beta failure parameter
-     * @param rng random number generator
-     * @tparam RNG class of random number generator
-     * @return sample from beta distribution
-     */
-    template <class RNG>
-    inline double safe_beta_rng(double alpha, double beta, RNG& rng) {
-      double p = beta_rng(alpha, beta, rng);
-      while (p < 0 || p > 1) {
-        p = beta_rng(alpha, beta, rng);
-      }
-      return p;
-    }
-
-    /**
-     * Beta-Binomial random number generator. Equivalent to drawing p from Beta(alpha,beta)
-     * and then drawing from a Binomial(N,p) distribution.
-     *
-     * @param N nonnegative population size.
-     * @param alpha nonnegative sucess parameter.
-     * @param beta nonnegative failure parameter.
-     * @param rng random number generator.
-     *
-     * @tparam RNG type of rng.
-     *
-     * @return draw from beta-binomial distribution with specified parameters.
-     *
+     * @return Beta-Binomial random variate
      * @throw std::domain_error if N, alpha, or beta is negative.
      */
     template <class RNG>
@@ -67,7 +45,7 @@ namespace stan {
       check_positive_finite(function,
                             "Second prior sample size parameter", beta);
 
-      double p = safe_beta_rng(alpha, beta, rng);
+      double p = beta_rng(alpha, beta, rng);
       return binomial_rng(N, p, rng);
     }
 

--- a/stan/math/prim/scal/prob/beta_binomial_rng.hpp
+++ b/stan/math/prim/scal/prob/beta_binomial_rng.hpp
@@ -33,7 +33,7 @@ namespace stan {
     inline double safe_beta_rng(double alpha, double beta, RNG& rng) {
       double p = beta_rng(alpha, beta, rng);
       while (p < 0 || p > 1) {
-        p = beta_rng(alpha, beta, rng)
+        p = beta_rng(alpha, beta, rng);
       }
       return p;
     }

--- a/stan/math/prim/scal/prob/beta_lccdf.hpp
+++ b/stan/math/prim/scal/prob/beta_lccdf.hpp
@@ -30,6 +30,18 @@
 namespace stan {
   namespace math {
 
+    /**
+     * Calculates the beta log complementary cumulative distribution function 
+     * for the given variate and scale variables.
+     *
+     * @param y A scalar variate.
+     * @param alpha Prior sample size.
+     * @param beta Prior sample size.
+     * @return The beta log cumulative cdf evaluated at the specified arguments.
+     * @tparam T_y Type of y.
+     * @tparam T_scale_succ Type of alpha.
+     * @tparam T_scale_fail Type of beta.
+     */
     template <typename T_y, typename T_scale_succ, typename T_scale_fail>
     typename return_type<T_y, T_scale_succ, T_scale_fail>::type
     beta_lccdf(const T_y& y, const T_scale_succ& alpha,

--- a/stan/math/prim/scal/prob/beta_lccdf.hpp
+++ b/stan/math/prim/scal/prob/beta_lccdf.hpp
@@ -31,16 +31,20 @@ namespace stan {
   namespace math {
 
     /**
-     * Calculates the beta log complementary cumulative distribution function 
-     * for the given variate and scale variables.
+     * Returns the beta log complementary cumulative distribution function for 
+     * the given probability, success, and failure parameters. Given matching 
+     * containers returns the log sum of probabilities.
      *
-     * @param y A scalar variate.
-     * @param alpha Prior sample size.
-     * @param beta Prior sample size.
-     * @return The beta log cumulative cdf evaluated at the specified arguments.
-     * @tparam T_y Type of y.
-     * @tparam T_scale_succ Type of alpha.
-     * @tparam T_scale_fail Type of beta.
+     * @tparam T_y type of probability parameter
+     * @tparam T_scale_succ type of success parameter
+     * @tparam T_scale_fail type of failure parameter
+     * @param y probability parameter
+     * @param alpha success parameter
+     * @param beta failure parameter
+     * @return log probability or log sum of proabbilities
+     * @throw std::domain_error if alpha or beta is negative
+     * @throw std::domain_error if y is not a valid probability
+     * @throw std::invalid_argument if container sizes mismatch
      */
     template <typename T_y, typename T_scale_succ, typename T_scale_fail>
     typename return_type<T_y, T_scale_succ, T_scale_fail>::type

--- a/stan/math/prim/scal/prob/beta_lcdf.hpp
+++ b/stan/math/prim/scal/prob/beta_lcdf.hpp
@@ -30,16 +30,20 @@ namespace stan {
   namespace math {
 
     /**
-     * Calculates the beta log cumulative distribution function for the given
-     * variate and scale variables.
+     * Returns the beta log cumulative distribution function for the given
+     * probability, success, and failure parameters. Given matching containers
+     * returns the log sum of probabilities.
      *
-     * @param y A scalar variate.
-     * @param alpha Prior sample size.
-     * @param beta Prior sample size.
-     * @return The beta log cdf evaluated at the specified arguments.
-     * @tparam T_y Type of y.
-     * @tparam T_scale_succ Type of alpha.
-     * @tparam T_scale_fail Type of beta.
+     * @tparam T_y type of probability parameter
+     * @tparam T_scale_succ type of success parameter
+     * @tparam T_scale_fail type of failure parameter
+     * @param y probability parameter
+     * @param alpha success parameter
+     * @param beta failure parameter
+     * @return log probability or log sum of probabilities
+     * @throw std::domain_error if alpha or beta is negative
+     * @throw std::domain_error if y is not a valid probability
+     * @throw std::invalid_argument if container sizes mismatch
      */
     template <typename T_y, typename T_scale_succ, typename T_scale_fail>
     typename return_type<T_y, T_scale_succ, T_scale_fail>::type

--- a/stan/math/prim/scal/prob/beta_lcdf.hpp
+++ b/stan/math/prim/scal/prob/beta_lcdf.hpp
@@ -29,6 +29,18 @@
 namespace stan {
   namespace math {
 
+    /**
+     * Calculates the beta log cumulative distribution function for the given
+     * variate and scale variables.
+     *
+     * @param y A scalar variate.
+     * @param alpha Prior sample size.
+     * @param beta Prior sample size.
+     * @return The beta log cdf evaluated at the specified arguments.
+     * @tparam T_y Type of y.
+     * @tparam T_scale_succ Type of alpha.
+     * @tparam T_scale_fail Type of beta.
+     */
     template <typename T_y, typename T_scale_succ, typename T_scale_fail>
     typename return_type<T_y, T_scale_succ, T_scale_fail>::type
     beta_lcdf(const T_y& y, const T_scale_succ& alpha,

--- a/stan/math/prim/scal/prob/beta_rng.hpp
+++ b/stan/math/prim/scal/prob/beta_rng.hpp
@@ -26,14 +26,15 @@ namespace stan {
   namespace math {
 
     /**
-     * Beta distribution random number generator with parameters alpha, beta.
+     * Return a pseudorandom Beta variate with the supplied success and failure
+     * parameters and specified random number generator.
      *
-     * @param alpha positive finite success parameter.
-     * @param beta positive finite failure parameter.
-     * @param rng random number generator.
-     * @tparam RNG class of random number generator.
-     * @return sample from Beta(alpha,beta) distribution.
-     * @throw std::domain_error if alpha or beta is nonpositive.
+     * @tparam RNG class of random number generator
+     * @param alpha positive finite success parameter
+     * @param beta positive finite failure parameter
+     * @param rng random number generator
+     * @return Beta random variate
+     * @throw std::domain_error if alpha or beta is nonpositive
      */
     template <class RNG>
     inline double

--- a/stan/math/prim/scal/prob/beta_rng.hpp
+++ b/stan/math/prim/scal/prob/beta_rng.hpp
@@ -25,6 +25,16 @@
 namespace stan {
   namespace math {
 
+    /**
+     * Beta distribution random number generator with parameters alpha, beta.
+     *
+     * @param alpha positive finite success parameter.
+     * @param beta positive finite failure parameter.
+     * @param rng random number generator.
+     * @tparam RNG class of random number generator.
+     * @return sample from Beta(alpha,beta) distribution.
+     * @throw std::domain_error if alpha or beta is nonpositive.
+     */
     template <class RNG>
     inline double
     beta_rng(double alpha,

--- a/stan/math/prim/scal/prob/binomial_cdf.hpp
+++ b/stan/math/prim/scal/prob/binomial_cdf.hpp
@@ -28,17 +28,20 @@ namespace stan {
   namespace math {
 
     /**
-     * Binomial CDF. If given vectors of matching lengths, returns
-     * the product of probabilities.
+     * Returns the CDF for the binomial distribution evaluated at the specified
+     * success, population size, and chance of success. If given containers of
+     * matching lengths, returns the product of probabilities.
      *
-     * @param n successes variable
+     * @tparam T_n type of successes parameter
+     * @tparam T_N type of population size parameter
+     * @tparam theta type of chance of success parameter
+     * @param n successes parameter
      * @param N population size parameter
-     * @param theta probability parameter
-     *
+     * @param theta chance of success parameter
      * @return probability or product of probabilities
-     *
-     * @throw std::domain_error if N is negative or probability parameter is invalid
-     * @throw std::invalid_argument if vector sizes do not match
+     * @throw std::domain_error if N is negative
+     * @throw std::domain_error if theta is not a valid probability
+     * @throw std::invalid_argument if container sizes mismatch
      */
     template <typename T_n, typename T_N, typename T_prob>
     typename return_type<T_prob>::type

--- a/stan/math/prim/scal/prob/binomial_cdf.hpp
+++ b/stan/math/prim/scal/prob/binomial_cdf.hpp
@@ -27,6 +27,19 @@
 namespace stan {
   namespace math {
 
+    /**
+     * Binomial CDF. If given vectors of matching lengths, returns
+     * the product of probabilities.
+     *
+     * @param n successes variable
+     * @param N population size parameter
+     * @param theta probability parameter
+     *
+     * @return probability or product of probabilities
+     *
+     * @throw std::domain_error if N is negative or probability parameter is invalid
+     * @throw std::invalid_argument if vector sizes do not match
+     */
     template <typename T_n, typename T_N, typename T_prob>
     typename return_type<T_prob>::type
     binomial_cdf(const T_n& n, const T_N& N, const T_prob& theta) {

--- a/stan/math/prim/scal/prob/binomial_lccdf.hpp
+++ b/stan/math/prim/scal/prob/binomial_lccdf.hpp
@@ -28,17 +28,20 @@ namespace stan {
   namespace math {
 
     /**
-     * Binomial log complementary CDF. If given vectors of matching lengths, returns
-     * the log sum of probabilities.
+     * Returns the log CCDF for the binomial distribution evaluated at the 
+     * specified success, population size, and chance of success. If given 
+     * containers of matching lengths, returns the log sum of probabilities.
      *
-     * @param n successes variable
+     * @tparam T_n type of successes parameter
+     * @tparam T_N type of population size parameter
+     * @tparam theta type of chance of success parameter
+     * @param n successes parameter
      * @param N population size parameter
-     * @param theta probability parameter
-     *
+     * @param theta chance of success parameter
      * @return log probability or log sum of probabilities
-     *
-     * @throw std::domain_error if N is negative or probability parameter is invalid
-     * @throw std::invalid_argument if vector sizes do not match
+     * @throw std::domain_error if N is negative
+     * @throw std::domain_error if theta is not a valid probability
+     * @throw std::invalid_argument if container sizes mismatch
      */
     template <typename T_n, typename T_N, typename T_prob>
     typename return_type<T_prob>::type

--- a/stan/math/prim/scal/prob/binomial_lccdf.hpp
+++ b/stan/math/prim/scal/prob/binomial_lccdf.hpp
@@ -27,6 +27,19 @@
 namespace stan {
   namespace math {
 
+    /**
+     * Binomial log complementary CDF. If given vectors of matching lengths, returns
+     * the log sum of probabilities.
+     *
+     * @param n successes variable
+     * @param N population size parameter
+     * @param theta probability parameter
+     *
+     * @return log probability or log sum of probabilities
+     *
+     * @throw std::domain_error if N is negative or probability parameter is invalid
+     * @throw std::invalid_argument if vector sizes do not match
+     */
     template <typename T_n, typename T_N, typename T_prob>
     typename return_type<T_prob>::type
     binomial_lccdf(const T_n& n, const T_N& N, const T_prob& theta) {

--- a/stan/math/prim/scal/prob/binomial_lcdf.hpp
+++ b/stan/math/prim/scal/prob/binomial_lcdf.hpp
@@ -27,6 +27,19 @@
 namespace stan {
   namespace math {
 
+    /**
+     * Binomial log CDF. If given vectors of matching lengths, returns
+     * the log sum of probabilities.
+     *
+     * @param n successes variable
+     * @param N population size parameter
+     * @param theta probability parameter
+     *
+     * @return log probability or log sum of probabilities
+     *
+     * @throw std::domain_error if N is negative or probability parameter is invalid
+     * @throw std::invalid_argument if vector sizes do not match
+     */
     template <typename T_n, typename T_N, typename T_prob>
     typename return_type<T_prob>::type
     binomial_lcdf(const T_n& n, const T_N& N, const T_prob& theta) {

--- a/stan/math/prim/scal/prob/binomial_lcdf.hpp
+++ b/stan/math/prim/scal/prob/binomial_lcdf.hpp
@@ -28,17 +28,20 @@ namespace stan {
   namespace math {
 
     /**
-     * Binomial log CDF. If given vectors of matching lengths, returns
-     * the log sum of probabilities.
+     * Returns the log CDF for the binomial distribution evaluated at the 
+     * specified success, population size, and chance of success. If given 
+     * containers of matching lengths, returns the log sum of probabilities.
      *
-     * @param n successes variable
+     * @tparam T_n type of successes parameter
+     * @tparam T_N type of population size parameter
+     * @tparam theta type of chance of success parameter
+     * @param n successes parameter
      * @param N population size parameter
-     * @param theta probability parameter
-     *
+     * @param theta chance of success parameter
      * @return log probability or log sum of probabilities
-     *
-     * @throw std::domain_error if N is negative or probability parameter is invalid
-     * @throw std::invalid_argument if vector sizes do not match
+     * @throw std::domain_error if N is negative
+     * @throw std::domain_error if theta is not a valid probability
+     * @throw std::invalid_argument if container sizes mismatch
      */
     template <typename T_n, typename T_N, typename T_prob>
     typename return_type<T_prob>::type

--- a/stan/math/prim/scal/prob/binomial_logit_lpmf.hpp
+++ b/stan/math/prim/scal/prob/binomial_logit_lpmf.hpp
@@ -27,8 +27,21 @@
 namespace stan {
   namespace math {
 
-    // BinomialLogit(n|N, alpha)  [N >= 0;  0 <= n <= N]
-    // BinomialLogit(n|N, alpha) = Binomial(n|N, inv_logit(alpha))
+    /**
+     * Binomial log PMF in logit parametrization. Binomial(n|n, inv_logit(alpha)) 
+     *
+     * If given vectors of matching lengths, returns
+     * the log sum of probabilities.
+     *
+     * @param n successes variable
+     * @param N population size parameter
+     * @param alpha logit transformed probability parameter
+     *
+     * @return log probability or log sum of probabilities
+     *
+     * @throw std::domain_error if N is negative or probability parameter is invalid
+     * @throw std::invalid_argument if vector sizes do not match
+     */
     template <bool propto,
               typename T_n,
               typename T_N,

--- a/stan/math/prim/scal/prob/binomial_lpmf.hpp
+++ b/stan/math/prim/scal/prob/binomial_lpmf.hpp
@@ -27,7 +27,19 @@
 namespace stan {
   namespace math {
 
-    // Binomial(n|N, theta)  [N >= 0;  0 <= n <= N;  0 <= theta <= 1]
+    /**
+     * Binomial log PMF. If given vectors of matching lengths, returns
+     * the log sum of probabilities.
+     *
+     * @param n successes variable
+     * @param N population size parameter
+     * @param theta probability parameter
+     *
+     * @return log probability or log sum of probabilities
+     *
+     * @throw std::domain_error if N is negative or probability parameter is invalid
+     * @throw std::invalid_argument if vector sizes do not match
+     */
     template <bool propto,
               typename T_n,
               typename T_N,

--- a/stan/math/prim/scal/prob/binomial_lpmf.hpp
+++ b/stan/math/prim/scal/prob/binomial_lpmf.hpp
@@ -28,17 +28,21 @@ namespace stan {
   namespace math {
 
     /**
-     * Binomial log PMF. If given vectors of matching lengths, returns
-     * the log sum of probabilities.
+     * Returns the log PMF for the binomial distribution evaluated at the 
+     * specified success, population size, and chance of success. If given 
+     * containers of matching lengths, returns the log sum of probabilities.
      *
-     * @param n successes variable
+     * @tparam T_n type of successes parameter
+     * @tparam T_N type of population size parameter
+     * @tparam theta type of chance of success parameter
+     * @param n successes parameter
      * @param N population size parameter
-     * @param theta probability parameter
-     *
+     * @param theta chance of success parameter
      * @return log probability or log sum of probabilities
-     *
-     * @throw std::domain_error if N is negative or probability parameter is invalid
-     * @throw std::invalid_argument if vector sizes do not match
+     * @throw std::domain_error if n is negative or greater than N
+     * @throw std::domain_error if N is negative
+     * @throw std::domain_error if theta is not a valid probability
+     * @throw std::invalid_argument if container sizes mismatch
      */
     template <bool propto,
               typename T_n,

--- a/stan/math/prim/scal/prob/binomial_rng.hpp
+++ b/stan/math/prim/scal/prob/binomial_rng.hpp
@@ -23,6 +23,16 @@
 namespace stan {
   namespace math {
 
+    /**
+     * Binomial random number generator.
+     *
+     * @param N population size parameter
+     * @param theta probability parameter
+     * @param rng random number generator
+     * @tparam RNG class of rng
+     * @return sample from Binomial(N,theta)
+     * @throw std::domain_error if N is negative or theta is outside [0,1]
+     */
     template <class RNG>
     inline int
     binomial_rng(int N,

--- a/stan/math/prim/scal/prob/binomial_rng.hpp
+++ b/stan/math/prim/scal/prob/binomial_rng.hpp
@@ -24,14 +24,17 @@ namespace stan {
   namespace math {
 
     /**
-     * Binomial random number generator.
+     * Return a pseudorandom Binomial random variable for the given population
+     * size and chance of success parameters using the specified random number
+     * generator.
      *
-     * @param N population size parameter
-     * @param theta probability parameter
-     * @param rng random number generator
      * @tparam RNG class of rng
-     * @return sample from Binomial(N,theta)
-     * @throw std::domain_error if N is negative or theta is outside [0,1]
+     * @param N population size parameter
+     * @param theta chance of success parameter
+     * @param rng random number generator
+     * @return Binomial random variate
+     * @throw std::domain_error if N is negative
+     * @throw std::domain_error if theta is not a valid probability
      */
     template <class RNG>
     inline int

--- a/stan/math/prim/scal/prob/cauchy_cdf.hpp
+++ b/stan/math/prim/scal/prob/cauchy_cdf.hpp
@@ -21,21 +21,19 @@ namespace stan {
   namespace math {
 
     /**
-     * Calculates the cauchy cumulative distribution function for
-     * the given variate, location, and scale.
+     * Returns the cauchy cumulative distribution function for the given 
+     * location, and scale. If given containers of matching sizes
+     * returns the product of probabilities.
      *
-     * \f$\frac{1}{\pi}\arctan\left(\frac{y-\mu}{\sigma}\right) + \frac{1}{2}\f$
-     *
-     * @param y A scalar variate.
-     * @param mu The location parameter.
-     * @param sigma The scale parameter.
-     * @tparam T_y type of variable, y
-     * @tparam T_loc type of location parameter, mu
-     * @tparam T_scale type of scale parameter, sigma
-     *
+     * @tparam T_y type of real parameter
+     * @tparam T_loc type of location parameter
+     * @tparam T_scale type of scale parameter
+     * @param y real parameter
+     * @param mu location parameter
+     * @param sigma scale parameter
      * @return probability or product of probabilities
      * @throw std::domain_error if sigma is nonpositive or y, mu are nan
-     * @throw std::invalid_argument if given vectors of mismatched sizes.
+     * @throw std::invalid_argument if container sizes mismatch
      */
     template <typename T_y, typename T_loc, typename T_scale>
     typename return_type<T_y, T_loc, T_scale>::type

--- a/stan/math/prim/scal/prob/cauchy_cdf.hpp
+++ b/stan/math/prim/scal/prob/cauchy_cdf.hpp
@@ -29,8 +29,13 @@ namespace stan {
      * @param y A scalar variate.
      * @param mu The location parameter.
      * @param sigma The scale parameter.
+     * @tparam T_y type of variable, y
+     * @tparam T_loc type of location parameter, mu
+     * @tparam T_scale type of scale parameter, sigma
      *
-     * @return
+     * @return probability or product of probabilities
+     * @throw std::domain_error if sigma is nonpositive or y, mu are nan
+     * @throw std::invalid_argument if given vectors of mismatched sizes.
      */
     template <typename T_y, typename T_loc, typename T_scale>
     typename return_type<T_y, T_loc, T_scale>::type

--- a/stan/math/prim/scal/prob/cauchy_lccdf.hpp
+++ b/stan/math/prim/scal/prob/cauchy_lccdf.hpp
@@ -19,23 +19,21 @@
 
 namespace stan {
   namespace math {
-
+    
     /**
-     * Calculates the cauchy log complementary cumulative distribution function for
-     * the given variate, location, and scale.
+     * Returns the cauchy log complementary cumulative distribution function 
+     * for the given location, and scale. If given containers of matching sizes
+     * returns the log sum of probabilities.
      *
-     * \f$\frac{1}{\pi}\arctan\left(\frac{y-\mu}{\sigma}\right) + \frac{1}{2}\f$
-     *
-     * @param y A scalar variate.
-     * @param mu The location parameter.
-     * @param sigma The scale parameter.
-     * @tparam T_y type of variable, y
-     * @tparam T_loc type of location parameter, mu
-     * @tparam T_scale type of scale parameter, sigma
-     *
+     * @tparam T_y type of real parameter
+     * @tparam T_loc type of location parameter
+     * @tparam T_scale type of scale parameter
+     * @param y real parameter
+     * @param mu location parameter
+     * @param sigma scale parameter
      * @return log probability or log sum of probabilities
      * @throw std::domain_error if sigma is nonpositive or y, mu are nan
-     * @throw std::invalid_argument if given vectors of mismatched sizes.
+     * @throw std::invalid_argument if container sizes mismatch
      */
     template <typename T_y, typename T_loc, typename T_scale>
     typename return_type<T_y, T_loc, T_scale>::type

--- a/stan/math/prim/scal/prob/cauchy_lccdf.hpp
+++ b/stan/math/prim/scal/prob/cauchy_lccdf.hpp
@@ -19,7 +19,7 @@
 
 namespace stan {
   namespace math {
-    
+
     /**
      * Returns the cauchy log complementary cumulative distribution function
      * for the given location, and scale. If given containers of matching sizes

--- a/stan/math/prim/scal/prob/cauchy_lccdf.hpp
+++ b/stan/math/prim/scal/prob/cauchy_lccdf.hpp
@@ -20,6 +20,23 @@
 namespace stan {
   namespace math {
 
+    /**
+     * Calculates the cauchy log complementary cumulative distribution function for
+     * the given variate, location, and scale.
+     *
+     * \f$\frac{1}{\pi}\arctan\left(\frac{y-\mu}{\sigma}\right) + \frac{1}{2}\f$
+     *
+     * @param y A scalar variate.
+     * @param mu The location parameter.
+     * @param sigma The scale parameter.
+     * @tparam T_y type of variable, y
+     * @tparam T_loc type of location parameter, mu
+     * @tparam T_scale type of scale parameter, sigma
+     *
+     * @return log probability or log sum of probabilities
+     * @throw std::domain_error if sigma is nonpositive or y, mu are nan
+     * @throw std::invalid_argument if given vectors of mismatched sizes.
+     */
     template <typename T_y, typename T_loc, typename T_scale>
     typename return_type<T_y, T_loc, T_scale>::type
     cauchy_lccdf(const T_y& y, const T_loc& mu, const T_scale& sigma) {

--- a/stan/math/prim/scal/prob/cauchy_lccdf.hpp
+++ b/stan/math/prim/scal/prob/cauchy_lccdf.hpp
@@ -21,7 +21,7 @@ namespace stan {
   namespace math {
     
     /**
-     * Returns the cauchy log complementary cumulative distribution function 
+     * Returns the cauchy log complementary cumulative distribution function
      * for the given location, and scale. If given containers of matching sizes
      * returns the log sum of probabilities.
      *

--- a/stan/math/prim/scal/prob/cauchy_lcdf.hpp
+++ b/stan/math/prim/scal/prob/cauchy_lcdf.hpp
@@ -21,21 +21,19 @@ namespace stan {
   namespace math {
 
     /**
-     * Calculates the cauchy log cumulative distribution function for
-     * the given variate, location, and scale.
+     * Returns the cauchy log cumulative distribution function for the given 
+     * location, and scale. If given containers of matching sizes
+     * returns the log sum of probabilities.
      *
-     * \f$\frac{1}{\pi}\arctan\left(\frac{y-\mu}{\sigma}\right) + \frac{1}{2}\f$
-     *
-     * @param y A scalar variate.
-     * @param mu The location parameter.
-     * @param sigma The scale parameter.
-     * @tparam T_y type of variable, y
-     * @tparam T_loc type of location parameter, mu
-     * @tparam T_scale type of scale parameter, sigma
-     *
+     * @tparam T_y type of real parameter
+     * @tparam T_loc type of location parameter
+     * @tparam T_scale type of scale parameter
+     * @param y real parameter
+     * @param mu location parameter
+     * @param sigma scale parameter
      * @return log probability or log sum of probabilities
      * @throw std::domain_error if sigma is nonpositive or y, mu are nan
-     * @throw std::invalid_argument if given vectors of mismatched sizes.
+     * @throw std::invalid_argument if container sizes mismatch
      */
     template <typename T_y, typename T_loc, typename T_scale>
     typename return_type<T_y, T_loc, T_scale>::type

--- a/stan/math/prim/scal/prob/cauchy_lcdf.hpp
+++ b/stan/math/prim/scal/prob/cauchy_lcdf.hpp
@@ -20,6 +20,23 @@
 namespace stan {
   namespace math {
 
+    /**
+     * Calculates the cauchy log cumulative distribution function for
+     * the given variate, location, and scale.
+     *
+     * \f$\frac{1}{\pi}\arctan\left(\frac{y-\mu}{\sigma}\right) + \frac{1}{2}\f$
+     *
+     * @param y A scalar variate.
+     * @param mu The location parameter.
+     * @param sigma The scale parameter.
+     * @tparam T_y type of variable, y
+     * @tparam T_loc type of location parameter, mu
+     * @tparam T_scale type of scale parameter, sigma
+     *
+     * @return log probability or log sum of probabilities
+     * @throw std::domain_error if sigma is nonpositive or y, mu are nan
+     * @throw std::invalid_argument if given vectors of mismatched sizes.
+     */
     template <typename T_y, typename T_loc, typename T_scale>
     typename return_type<T_y, T_loc, T_scale>::type
     cauchy_lcdf(const T_y& y, const T_loc& mu, const T_scale& sigma) {

--- a/stan/math/prim/scal/prob/cauchy_rng.hpp
+++ b/stan/math/prim/scal/prob/cauchy_rng.hpp
@@ -17,14 +17,15 @@ namespace stan {
   namespace math {
 
     /**
-     * Cauchy random number generator.
+     * Return a pseudorandom Cauchy variate for the given location and scale
+     * using the specified random number generator.
      *
+     * @tparam RNG type of random number generator
      * @param mu location parameter
      * @param sigma positive scale parameter
      * @param rng random number generator
-     * @tparam RNG type of random number generator
-     * @return sample from Cauchy(mu, sigma)
-     * @throw std::domain_error if mu is infinite or sigma is nonpositive.
+     * @return Cauchy random variate
+     * @throw std::domain_error if mu is infinite or sigma is nonpositive
      */
     template <class RNG>
     inline double

--- a/stan/math/prim/scal/prob/cauchy_rng.hpp
+++ b/stan/math/prim/scal/prob/cauchy_rng.hpp
@@ -16,6 +16,16 @@
 namespace stan {
   namespace math {
 
+    /**
+     * Cauchy random number generator.
+     *
+     * @param mu location parameter
+     * @param sigma positive scale parameter
+     * @param rng random number generator
+     * @tparam RNG type of random number generator
+     * @return sample from Cauchy(mu, sigma)
+     * @throw std::domain_error if mu is infinite or sigma is nonpositive.
+     */
     template <class RNG>
     inline double
     cauchy_rng(double mu,

--- a/stan/math/prim/scal/prob/chi_square_cdf.hpp
+++ b/stan/math/prim/scal/prob/chi_square_cdf.hpp
@@ -26,12 +26,17 @@ namespace stan {
 
     /**
      * Calculates the chi square cumulative distribution function for the given
-     * variate and degrees of freedom.
+     * variate and degrees of freedom. If given vectors of matching sizes, returns
+     * the product of probabilities.
      *
-     * y A scalar variate.
-     * nu Degrees of freedom.
+     * @param y A scalar variate.
+     * @param nu Degrees of freedom.
+     * @tparam T_y type of scalar variate, y.
+     * @tparam T_dof type of degrees of freedom parameter
      *
-     * @return The cdf of the chi square distribution
+     * @return probability or product of probabilities
+     * @throw std::domain_error if y is negative or nu is nonpositive
+     * @throw std::invalid_argument if given vectors of mismatched size
      */
     template <typename T_y, typename T_dof>
     typename return_type<T_y, T_dof>::type

--- a/stan/math/prim/scal/prob/chi_square_cdf.hpp
+++ b/stan/math/prim/scal/prob/chi_square_cdf.hpp
@@ -25,18 +25,17 @@ namespace stan {
   namespace math {
 
     /**
-     * Calculates the chi square cumulative distribution function for the given
-     * variate and degrees of freedom. If given vectors of matching sizes, returns
-     * the product of probabilities.
+     * Returns the chi square cumulative distribution function for the given
+     * variate and degrees of freedom. If given containers of matching sizes, 
+     * returns the product of probabilities.
      *
-     * @param y A scalar variate.
-     * @param nu Degrees of freedom.
-     * @tparam T_y type of scalar variate, y.
+     * @tparam T_y type of scalar parameter
      * @tparam T_dof type of degrees of freedom parameter
-     *
+     * @param y scalar parameter
+     * @param nu degrees of freedom parameter
      * @return probability or product of probabilities
      * @throw std::domain_error if y is negative or nu is nonpositive
-     * @throw std::invalid_argument if given vectors of mismatched size
+     * @throw std::invalid_argument if container sizes mismatch
      */
     template <typename T_y, typename T_dof>
     typename return_type<T_y, T_dof>::type

--- a/stan/math/prim/scal/prob/chi_square_lccdf.hpp
+++ b/stan/math/prim/scal/prob/chi_square_lccdf.hpp
@@ -25,18 +25,17 @@ namespace stan {
   namespace math {
 
     /**
-     * Calculates the chi square log complementary cumulative distribution function for 
-     * the given variate and degrees of freedom. If given vectors of matching sizes, 
-     * returns the log sum of probabilities.
+     * Returns the chi square log complementary cumulative distribution 
+     * function for the given variate and degrees of freedom. If given 
+     * containers of matching sizes, returns the log sum of probabilities.
      *
-     * @param y A scalar variate.
-     * @param nu Degrees of freedom.
-     * @tparam T_y type of scalar variate, y.
+     * @tparam T_y type of scalar parameter
      * @tparam T_dof type of degrees of freedom parameter
-     *
+     * @param y scalar parameter
+     * @param nu degrees of freedom parameter
      * @return log probability or log sum of probabilities
      * @throw std::domain_error if y is negative or nu is nonpositive
-     * @throw std::invalid_argument if given vectors of mismatched size
+     * @throw std::invalid_argument if container sizes mismatch
      */
     template <typename T_y, typename T_dof>
     typename return_type<T_y, T_dof>::type

--- a/stan/math/prim/scal/prob/chi_square_lccdf.hpp
+++ b/stan/math/prim/scal/prob/chi_square_lccdf.hpp
@@ -24,6 +24,20 @@
 namespace stan {
   namespace math {
 
+    /**
+     * Calculates the chi square log complementary cumulative distribution function for 
+     * the given variate and degrees of freedom. If given vectors of matching sizes, 
+     * returns the log sum of probabilities.
+     *
+     * @param y A scalar variate.
+     * @param nu Degrees of freedom.
+     * @tparam T_y type of scalar variate, y.
+     * @tparam T_dof type of degrees of freedom parameter
+     *
+     * @return log probability or log sum of probabilities
+     * @throw std::domain_error if y is negative or nu is nonpositive
+     * @throw std::invalid_argument if given vectors of mismatched size
+     */
     template <typename T_y, typename T_dof>
     typename return_type<T_y, T_dof>::type
     chi_square_lccdf(const T_y& y, const T_dof& nu) {

--- a/stan/math/prim/scal/prob/chi_square_lcdf.hpp
+++ b/stan/math/prim/scal/prob/chi_square_lcdf.hpp
@@ -24,6 +24,20 @@
 namespace stan {
   namespace math {
 
+    /**
+     * Calculates the chi square log cumulative distribution function for the given
+     * variate and degrees of freedom. If given vectors of matching sizes, returns
+     * the log sum of probabilities.
+     *
+     * @param y A scalar variate.
+     * @param nu Degrees of freedom.
+     * @tparam T_y type of scalar variate, y.
+     * @tparam T_dof type of degrees of freedom parameter
+     *
+     * @return log probability or log sum of probabilities
+     * @throw std::domain_error if y is negative or nu is nonpositive
+     * @throw std::invalid_argument if given vectors of mismatched size
+     */
     template <typename T_y, typename T_dof>
     typename return_type<T_y, T_dof>::type
     chi_square_lcdf(const T_y& y, const T_dof& nu) {

--- a/stan/math/prim/scal/prob/chi_square_lcdf.hpp
+++ b/stan/math/prim/scal/prob/chi_square_lcdf.hpp
@@ -25,18 +25,17 @@ namespace stan {
   namespace math {
 
     /**
-     * Calculates the chi square log cumulative distribution function for the given
-     * variate and degrees of freedom. If given vectors of matching sizes, returns
-     * the log sum of probabilities.
+     * Returns the chi square log cumulative distribution function for the given
+     * variate and degrees of freedom. If given containers of matching sizes, 
+     * returns the log sum of probabilities.
      *
-     * @param y A scalar variate.
-     * @param nu Degrees of freedom.
-     * @tparam T_y type of scalar variate, y.
+     * @tparam T_y type of scalar parameter
      * @tparam T_dof type of degrees of freedom parameter
-     *
+     * @param y scalar parameter
+     * @param nu degrees of freedom parameter
      * @return log probability or log sum of probabilities
      * @throw std::domain_error if y is negative or nu is nonpositive
-     * @throw std::invalid_argument if given vectors of mismatched size
+     * @throw std::invalid_argument if container sizes mismatch
      */
     template <typename T_y, typename T_dof>
     typename return_type<T_y, T_dof>::type

--- a/stan/math/prim/scal/prob/chi_square_rng.hpp
+++ b/stan/math/prim/scal/prob/chi_square_rng.hpp
@@ -19,13 +19,14 @@ namespace stan {
   namespace math {
 
     /**
-     * Chi squared distribution random number generator with nu degrees of freedom.
+     * Return a pseudorandom chi squared variate with the nu degrees of freedom
+     * using the specified random number generator.
      *
-     * @param nu positive degrees of freedom parameter.
-     * @param rng random number generator.
-     * @tparam RNG class of random number generator.
-     * @return sample from chi_squared(nu) distribution.
-     * @throw std::domain_error if nu is nonpositive.
+     * @tparam RNG class of random number generator
+     * @param nu positive degrees of freedom parameter
+     * @param rng random number generator
+     * @return chi squared random variate
+     * @throw std::domain_error if nu is nonpositive
      */
     template <class RNG>
     inline double

--- a/stan/math/prim/scal/prob/chi_square_rng.hpp
+++ b/stan/math/prim/scal/prob/chi_square_rng.hpp
@@ -18,6 +18,15 @@
 namespace stan {
   namespace math {
 
+    /**
+     * Chi squared distribution random number generator with nu degrees of freedom.
+     *
+     * @param nu positive degrees of freedom parameter.
+     * @param rng random number generator.
+     * @tparam RNG class of random number generator.
+     * @return sample from chi_squared(nu) distribution.
+     * @throw std::domain_error if nu is nonpositive.
+     */
     template <class RNG>
     inline double
     chi_square_rng(double nu,

--- a/stan/math/prim/scal/prob/double_exponential_cdf.hpp
+++ b/stan/math/prim/scal/prob/double_exponential_cdf.hpp
@@ -21,22 +21,16 @@ namespace stan {
   namespace math {
 
     /**
-     * Calculates the double exponential cumulative density function.
+     * Returns the double exponential cumulative density function. Given
+     * containers of matching sizes, returns the product of probabilities.
      *
-     * \f$ f(y|\mu, \sigma) = \begin{cases} \
-     \frac{1}{2} \exp\left(\frac{y-\mu}{\sigma}\right), \mbox{if } y < \mu \\
-     1 - \frac{1}{2} \exp\left(-\frac{y-\mu}{\sigma}\right), \mbox{if } y \ge \mu \
-     \end{cases}\f$
-     *
-     * @param y A scalar variate.
-     * @param mu The location parameter.
-     * @param sigma The scale parameter.
-     * @tparam T_y type of scalar parameter.
+     * @tparam T_y type of real parameter.
      * @tparam T_loc type of location parameter.
      * @tparam T_scale type of scale parameter.
-     *
-     * @return The cumulative density function.
-     *
+     * @param y real parameter
+     * @param mu location parameter
+     * @param sigma scale parameter
+     * @return probability or product of probabilities
      * @throw std::domain_error if y is nan, mu is infinite, or sigma is nonpositive
      */
     template <typename T_y, typename T_loc, typename T_scale>

--- a/stan/math/prim/scal/prob/double_exponential_cdf.hpp
+++ b/stan/math/prim/scal/prob/double_exponential_cdf.hpp
@@ -31,8 +31,13 @@ namespace stan {
      * @param y A scalar variate.
      * @param mu The location parameter.
      * @param sigma The scale parameter.
+     * @tparam T_y type of scalar parameter.
+     * @tparam T_loc type of location parameter.
+     * @tparam T_scale type of scale parameter.
      *
      * @return The cumulative density function.
+     *
+     * @throw std::domain_error if y is nan, mu is infinite, or sigma is nonpositive
      */
     template <typename T_y, typename T_loc, typename T_scale>
     typename return_type<T_y, T_loc, T_scale>::type

--- a/stan/math/prim/scal/prob/double_exponential_lccdf.hpp
+++ b/stan/math/prim/scal/prob/double_exponential_lccdf.hpp
@@ -20,6 +20,22 @@
 namespace stan {
   namespace math {
 
+    /**
+     * Calculates the double exponential log complementary CDF for the given
+     * variable, location, and scale. If given vectors of matching sizes, returns
+     * the log sum of probabilities.
+     *
+     * @param y A scalar variate.
+     * @param mu Location parameter.
+     * @param sigma Scale parameter.
+     * @tparam T_y type of scalar variate, y.
+     * @tparam T_loc type of location parameter.
+     * @tparam T_scale type of scale parameter.
+     *
+     * @return log probability or log sum of probabilities
+     * @throw std::domain_error if y is nan, mu is infinite, or sigma is nonpositive.
+     * @throw std::invalid_argument if given vectors of mismatched size
+     */
     template <typename T_y, typename T_loc, typename T_scale>
     typename return_type<T_y, T_loc, T_scale>::type
     double_exponential_lccdf(const T_y& y, const T_loc& mu,

--- a/stan/math/prim/scal/prob/double_exponential_lccdf.hpp
+++ b/stan/math/prim/scal/prob/double_exponential_lccdf.hpp
@@ -21,20 +21,19 @@ namespace stan {
   namespace math {
 
     /**
-     * Calculates the double exponential log complementary CDF for the given
-     * variable, location, and scale. If given vectors of matching sizes, returns
-     * the log sum of probabilities.
+     * Returns the double exponential log complementary cumulative density 
+     * function. Given containers of matching sizes, returns the log sum of 
+     * probabilities.
      *
-     * @param y A scalar variate.
-     * @param mu Location parameter.
-     * @param sigma Scale parameter.
-     * @tparam T_y type of scalar variate, y.
+     * @tparam T_y type of real parameter.
      * @tparam T_loc type of location parameter.
      * @tparam T_scale type of scale parameter.
-     *
+     * @param y real parameter
+     * @param mu location parameter
+     * @param sigma scale parameter
      * @return log probability or log sum of probabilities
-     * @throw std::domain_error if y is nan, mu is infinite, or sigma is nonpositive.
-     * @throw std::invalid_argument if given vectors of mismatched size
+     * @throw std::domain_error if y is nan, mu is infinite, or sigma is nonpositive
+     * @throw std::invalid_argument if container sizes mismatch
      */
     template <typename T_y, typename T_loc, typename T_scale>
     typename return_type<T_y, T_loc, T_scale>::type

--- a/stan/math/prim/scal/prob/double_exponential_lcdf.hpp
+++ b/stan/math/prim/scal/prob/double_exponential_lcdf.hpp
@@ -21,20 +21,18 @@ namespace stan {
   namespace math {
 
     /**
-     * Calculates the double exponential log cumulative distribution function for the given
-     * variable, location, and scale. If given vectors of matching sizes, returns
-     * the log sum of probabilities.
+     * Returns the double exponential log cumulative density function. Given
+     * containers of matching sizes, returns the log sum of probabilities.
      *
-     * @param y A scalar variate.
-     * @param mu Location parameter.
-     * @param sigma Scale parameter.
-     * @tparam T_y type of scalar variate, y.
+     * @tparam T_y type of real parameter.
      * @tparam T_loc type of location parameter.
      * @tparam T_scale type of scale parameter.
-     *
+     * @param y real parameter
+     * @param mu location parameter
+     * @param sigma scale parameter
      * @return log probability or log sum of probabilities
-     * @throw std::domain_error if y is nan, mu is infinite, or sigma is nonpositive.
-     * @throw std::invalid_argument if given vectors of mismatched size
+     * @throw std::domain_error if y is nan, mu is infinite, or sigma is nonpositive
+     * @throw std::invalid_argument if container sizes mismatch
      */
     template <typename T_y, typename T_loc, typename T_scale>
     typename return_type<T_y, T_loc, T_scale>::type

--- a/stan/math/prim/scal/prob/double_exponential_lcdf.hpp
+++ b/stan/math/prim/scal/prob/double_exponential_lcdf.hpp
@@ -20,6 +20,22 @@
 namespace stan {
   namespace math {
 
+    /**
+     * Calculates the double exponential log cumulative distribution function for the given
+     * variable, location, and scale. If given vectors of matching sizes, returns
+     * the log sum of probabilities.
+     *
+     * @param y A scalar variate.
+     * @param mu Location parameter.
+     * @param sigma Scale parameter.
+     * @tparam T_y type of scalar variate, y.
+     * @tparam T_loc type of location parameter.
+     * @tparam T_scale type of scale parameter.
+     *
+     * @return log probability or log sum of probabilities
+     * @throw std::domain_error if y is nan, mu is infinite, or sigma is nonpositive.
+     * @throw std::invalid_argument if given vectors of mismatched size
+     */
     template <typename T_y, typename T_loc, typename T_scale>
     typename return_type<T_y, T_loc, T_scale>::type
     double_exponential_lcdf(const T_y& y, const T_loc& mu,

--- a/stan/math/prim/scal/prob/double_exponential_lpdf.hpp
+++ b/stan/math/prim/scal/prob/double_exponential_lpdf.hpp
@@ -22,8 +22,22 @@
 namespace stan {
   namespace math {
 
-    // DoubleExponential(y|mu, sigma)  [sigma > 0]
-    // FIXME: add documentation
+    /**
+     * Calculates the double exponential log PDF function for the given
+     * variable, location, and scale. If given vectors of matching sizes, returns
+     * the log sum of probabilities.
+     *
+     * @param y A scalar variate.
+     * @param mu Location parameter.
+     * @param sigma Scale parameter.
+     * @tparam T_y type of scalar variate, y.
+     * @tparam T_loc type of location parameter.
+     * @tparam T_scale type of scale parameter.
+     *
+     * @return log probability or log sum of probabilities
+     * @throw std::domain_error if y is nan, mu is infinite, or sigma is nonpositive.
+     * @throw std::invalid_argument if given vectors of mismatched size
+     */
     template <bool propto,
               typename T_y, typename T_loc, typename T_scale>
     typename return_type<T_y, T_loc, T_scale>::type

--- a/stan/math/prim/scal/prob/double_exponential_lpdf.hpp
+++ b/stan/math/prim/scal/prob/double_exponential_lpdf.hpp
@@ -23,20 +23,18 @@ namespace stan {
   namespace math {
 
     /**
-     * Calculates the double exponential log PDF function for the given
-     * variable, location, and scale. If given vectors of matching sizes, returns
-     * the log sum of probabilities.
+     * Returns the double exponential log probability density function. Given
+     * containers of matching sizes, returns the log sum of densities.
      *
-     * @param y A scalar variate.
-     * @param mu Location parameter.
-     * @param sigma Scale parameter.
-     * @tparam T_y type of scalar variate, y.
+     * @tparam T_y type of real parameter.
      * @tparam T_loc type of location parameter.
      * @tparam T_scale type of scale parameter.
-     *
-     * @return log probability or log sum of probabilities
-     * @throw std::domain_error if y is nan, mu is infinite, or sigma is nonpositive.
-     * @throw std::invalid_argument if given vectors of mismatched size
+     * @param y real parameter
+     * @param mu location parameter
+     * @param sigma scale parameter
+     * @return log probability density or log sum of probability densities
+     * @throw std::domain_error if y is nan, mu is infinite, or sigma is nonpositive
+     * @throw std::invalid_argument if container sizes mismatch
      */
     template <bool propto,
               typename T_y, typename T_loc, typename T_scale>

--- a/stan/math/prim/scal/prob/double_exponential_rng.hpp
+++ b/stan/math/prim/scal/prob/double_exponential_rng.hpp
@@ -18,15 +18,15 @@ namespace stan {
   namespace math {
 
     /**
-     * Double exponential distribution random number generator with 
-     * location and scale parameters mu, sigma. 
+     * Return a pseudorandom double exponential variate with the given location
+     * and scale using the specified random number generator.
      *
-     * @param mu location parameter.
-     * @param sigma positive scale parameter.
-     * @param rng random number generator.
-     * @tparam RNG class of random number generator.
-     * @return sample from DoubleExponential(mu, sigma) distribution.
-     * @throw std::domain_error if mu is infinite or sigma is nonpositive.
+     * @tparam RNG class of random number generator
+     * @param mu location parameter
+     * @param sigma positive scale parameter
+     * @param rng random number generator
+     * @return double exponential random variate
+     * @throw std::domain_error if mu is infinite or sigma is nonpositive
      */
     template <class RNG>
     inline double

--- a/stan/math/prim/scal/prob/double_exponential_rng.hpp
+++ b/stan/math/prim/scal/prob/double_exponential_rng.hpp
@@ -17,6 +17,17 @@
 namespace stan {
   namespace math {
 
+    /**
+     * Double exponential distribution random number generator with 
+     * location and scale parameters mu, sigma. 
+     *
+     * @param mu location parameter.
+     * @param sigma positive scale parameter.
+     * @param rng random number generator.
+     * @tparam RNG class of random number generator.
+     * @return sample from DoubleExponential(mu, sigma) distribution.
+     * @throw std::domain_error if mu is infinite or sigma is nonpositive.
+     */
     template <class RNG>
     inline double
     double_exponential_rng(double mu,

--- a/stan/math/prim/scal/prob/gumbel_cdf.hpp
+++ b/stan/math/prim/scal/prob/gumbel_cdf.hpp
@@ -22,6 +22,23 @@
 namespace stan {
   namespace math {
 
+    /**
+     * Gumbel(mu, beta) cumulative density function.
+     * Given vector parameters of matching sizes,
+     * returns the product of probabilities.
+     *
+     * @param y A scalar variate.
+     * @param mu location parameter.
+     * @param beta scale parameter.
+     * @tparam T_y type of scalar parameter.
+     * @tparam T_loc type of location parameter.
+     * @tparam T_scale type of scale parameter.
+     *
+     * @return The cumulative density function.
+     *
+     * @throw std::domain_error if y is nan, mu is infinite, or beta is nonpositive
+     * @throw std::invalid_argument if vector sizes mismatch.
+     */
     template <typename T_y, typename T_loc, typename T_scale>
     typename return_type<T_y, T_loc, T_scale>::type
     gumbel_cdf(const T_y& y, const T_loc& mu, const T_scale& beta) {

--- a/stan/math/prim/scal/prob/gumbel_cdf.hpp
+++ b/stan/math/prim/scal/prob/gumbel_cdf.hpp
@@ -23,21 +23,19 @@ namespace stan {
   namespace math {
 
     /**
-     * Gumbel(mu, beta) cumulative density function.
-     * Given vector parameters of matching sizes,
-     * returns the product of probabilities.
+     * Returns the Gumbel distribution cumulative distribution for the given 
+     * location and scale. Given containers of matching sizes, returns the 
+     * product of probabilities.
      *
-     * @param y A scalar variate.
-     * @param mu location parameter.
-     * @param beta scale parameter.
-     * @tparam T_y type of scalar parameter.
-     * @tparam T_loc type of location parameter.
-     * @tparam T_scale type of scale parameter.
-     *
-     * @return The cumulative density function.
-     *
+     * @tparam T_y type of real parameter
+     * @tparam T_loc type of location parameter
+     * @tparam T_scale type of scale parameter
+     * @param y real parameter
+     * @param mu location parameter
+     * @param beta scale parameter
+     * @return probability or product of probabilities
      * @throw std::domain_error if y is nan, mu is infinite, or beta is nonpositive
-     * @throw std::invalid_argument if vector sizes mismatch.
+     * @throw std::invalid_argument if container sizes mismatch
      */
     template <typename T_y, typename T_loc, typename T_scale>
     typename return_type<T_y, T_loc, T_scale>::type

--- a/stan/math/prim/scal/prob/gumbel_lccdf.hpp
+++ b/stan/math/prim/scal/prob/gumbel_lccdf.hpp
@@ -23,21 +23,19 @@ namespace stan {
   namespace math {
 
     /**
-     * Gumbel(mu, beta) log complementary cumulative density function.
-     * Given vector parameters of matching sizes,
-     * returns the product of probabilities.
+     * Returns the Gumbel log complementary cumulative distribution for the 
+     * given location and scale. Given containers of matching sizes, returns 
+     * the log sum of probabilities.
      *
-     * @param y A scalar variate.
-     * @param mu location parameter.
-     * @param beta scale parameter.
-     * @tparam T_y type of scalar parameter.
-     * @tparam T_loc type of location parameter.
-     * @tparam T_scale type of scale parameter.
-     *
-     * @return The log complementary cumulative density function.
-     *
+     * @tparam T_y type of real parameter
+     * @tparam T_loc type of location parameter
+     * @tparam T_scale type of scale parameter
+     * @param y real parameter
+     * @param mu location parameter
+     * @param beta scale parameter
+     * @return log probability or log sum of probabilities
      * @throw std::domain_error if y is nan, mu is infinite, or beta is nonpositive
-     * @throw std::invalid_argument if vector sizes mismatch.
+     * @throw std::invalid_argument if container sizes mismatch
      */
     template <typename T_y, typename T_loc, typename T_scale>
     typename return_type<T_y, T_loc, T_scale>::type

--- a/stan/math/prim/scal/prob/gumbel_lccdf.hpp
+++ b/stan/math/prim/scal/prob/gumbel_lccdf.hpp
@@ -22,6 +22,23 @@
 namespace stan {
   namespace math {
 
+    /**
+     * Gumbel(mu, beta) log complementary cumulative density function.
+     * Given vector parameters of matching sizes,
+     * returns the product of probabilities.
+     *
+     * @param y A scalar variate.
+     * @param mu location parameter.
+     * @param beta scale parameter.
+     * @tparam T_y type of scalar parameter.
+     * @tparam T_loc type of location parameter.
+     * @tparam T_scale type of scale parameter.
+     *
+     * @return The log complementary cumulative density function.
+     *
+     * @throw std::domain_error if y is nan, mu is infinite, or beta is nonpositive
+     * @throw std::invalid_argument if vector sizes mismatch.
+     */
     template <typename T_y, typename T_loc, typename T_scale>
     typename return_type<T_y, T_loc, T_scale>::type
     gumbel_lccdf(const T_y& y, const T_loc& mu, const T_scale& beta) {

--- a/stan/math/prim/scal/prob/gumbel_lcdf.hpp
+++ b/stan/math/prim/scal/prob/gumbel_lcdf.hpp
@@ -22,6 +22,23 @@
 namespace stan {
   namespace math {
 
+    /**
+     * Gumbel(mu, beta) log cumulative density function.
+     * Given vector parameters of matching sizes,
+     * returns the product of probabilities.
+     *
+     * @param y A scalar variate.
+     * @param mu location parameter.
+     * @param beta scale parameter.
+     * @tparam T_y type of scalar parameter.
+     * @tparam T_loc type of location parameter.
+     * @tparam T_scale type of scale parameter.
+     *
+     * @return The log cumulative density function.
+     *
+     * @throw std::domain_error if y is nan, mu is infinite, or beta is nonpositive
+     * @throw std::invalid_argument if vector sizes mismatch.
+     */
     template <typename T_y, typename T_loc, typename T_scale>
     typename return_type<T_y, T_loc, T_scale>::type
     gumbel_lcdf(const T_y& y, const T_loc& mu, const T_scale& beta) {

--- a/stan/math/prim/scal/prob/gumbel_lcdf.hpp
+++ b/stan/math/prim/scal/prob/gumbel_lcdf.hpp
@@ -23,21 +23,19 @@ namespace stan {
   namespace math {
 
     /**
-     * Gumbel(mu, beta) log cumulative density function.
-     * Given vector parameters of matching sizes,
-     * returns the product of probabilities.
+     * Returns the Gumbel log cumulative distribution for the given 
+     * location and scale. Given containers of matching sizes, returns the 
+     * log sum of probabilities.
      *
-     * @param y A scalar variate.
-     * @param mu location parameter.
-     * @param beta scale parameter.
-     * @tparam T_y type of scalar parameter.
-     * @tparam T_loc type of location parameter.
-     * @tparam T_scale type of scale parameter.
-     *
-     * @return The log cumulative density function.
-     *
+     * @tparam T_y type of real parameter
+     * @tparam T_loc type of location parameter
+     * @tparam T_scale type of scale parameter
+     * @param y real parameter
+     * @param mu location parameter
+     * @param beta scale parameter
+     * @return log probability or log sum of probabilities
      * @throw std::domain_error if y is nan, mu is infinite, or beta is nonpositive
-     * @throw std::invalid_argument if vector sizes mismatch.
+     * @throw std::invalid_argument if container sizes mismatch
      */
     template <typename T_y, typename T_loc, typename T_scale>
     typename return_type<T_y, T_loc, T_scale>::type

--- a/stan/math/prim/scal/prob/gumbel_lpdf.hpp
+++ b/stan/math/prim/scal/prob/gumbel_lpdf.hpp
@@ -22,6 +22,23 @@
 namespace stan {
   namespace math {
 
+    /**
+     * Gumbel(mu, beta) log probability density function.
+     * Given vector parameters of matching sizes,
+     * returns the product of probabilities.
+     *
+     * @param y A scalar variate.
+     * @param mu location parameter.
+     * @param beta scale parameter.
+     * @tparam T_y type of scalar parameter.
+     * @tparam T_loc type of location parameter.
+     * @tparam T_scale type of scale parameter.
+     *
+     * @return The log probability density function.
+     *
+     * @throw std::domain_error if y is nan, mu is infinite, or beta is nonpositive
+     * @throw std::invalid_argument if vector sizes mismatch.
+     */
     template <bool propto, typename T_y, typename T_loc, typename T_scale>
     typename return_type<T_y, T_loc, T_scale>::type
     gumbel_lpdf(const T_y& y, const T_loc& mu, const T_scale& beta) {

--- a/stan/math/prim/scal/prob/gumbel_lpdf.hpp
+++ b/stan/math/prim/scal/prob/gumbel_lpdf.hpp
@@ -23,21 +23,19 @@ namespace stan {
   namespace math {
 
     /**
-     * Gumbel(mu, beta) log probability density function.
-     * Given vector parameters of matching sizes,
-     * returns the product of probabilities.
+     * Returns the Gumbel log probability density for the given 
+     * location and scale. Given containers of matching sizes, returns the 
+     * log sum of densities.
      *
-     * @param y A scalar variate.
-     * @param mu location parameter.
-     * @param beta scale parameter.
-     * @tparam T_y type of scalar parameter.
-     * @tparam T_loc type of location parameter.
-     * @tparam T_scale type of scale parameter.
-     *
-     * @return The log probability density function.
-     *
+     * @tparam T_y type of real parameter
+     * @tparam T_loc type of location parameter
+     * @tparam T_scale type of scale parameter
+     * @param y real parameter
+     * @param mu location parameter
+     * @param beta scale parameter
+     * @return log probability density or log sum of probability densities
      * @throw std::domain_error if y is nan, mu is infinite, or beta is nonpositive
-     * @throw std::invalid_argument if vector sizes mismatch.
+     * @throw std::invalid_argument if container sizes mismatch
      */
     template <bool propto, typename T_y, typename T_loc, typename T_scale>
     typename return_type<T_y, T_loc, T_scale>::type

--- a/stan/math/prim/scal/prob/gumbel_rng.hpp
+++ b/stan/math/prim/scal/prob/gumbel_rng.hpp
@@ -18,6 +18,16 @@
 namespace stan {
   namespace math {
 
+    /**
+     * Gumbel(mu, beta) random number generator.
+     *
+     * @param mu location parameter
+     * @param beta positive scale parameter
+     * @param rng random number generator
+     * @tparam RNG type of random number generator
+     * @return sample from Gumbel(mu, beta)
+     * @throw std::domain_error if mu is infinite or beta is nonpositive.
+     */
     template <class RNG>
     inline double
     gumbel_rng(double mu,

--- a/stan/math/prim/scal/prob/gumbel_rng.hpp
+++ b/stan/math/prim/scal/prob/gumbel_rng.hpp
@@ -19,13 +19,14 @@ namespace stan {
   namespace math {
 
     /**
-     * Gumbel(mu, beta) random number generator.
+     * Return a pseudorandom Gumbel variate with the given location and scale
+     * using the specified random number generator.
      *
+     * @tparam RNG type of random number generator
      * @param mu location parameter
      * @param beta positive scale parameter
      * @param rng random number generator
-     * @tparam RNG type of random number generator
-     * @return sample from Gumbel(mu, beta)
+     * @return Gumbel random variate
      * @throw std::domain_error if mu is infinite or beta is nonpositive.
      */
     template <class RNG>

--- a/stan/math/prim/scal/prob/inv_chi_square_cdf.hpp
+++ b/stan/math/prim/scal/prob/inv_chi_square_cdf.hpp
@@ -27,6 +27,20 @@
 namespace stan {
   namespace math {
 
+    /**
+     * Calculates the inverse chi square cumulative distribution function for the given
+     * variate and degrees of freedom. If given vectors of matching sizes, returns
+     * the product of probabilities.
+     *
+     * @param y A scalar variate.
+     * @param nu Degrees of freedom.
+     * @tparam T_y type of scalar variate, y.
+     * @tparam T_dof type of degrees of freedom parameter
+     *
+     * @return probability or product of probabilities
+     * @throw std::domain_error if y is negative or nu is nonpositive
+     * @throw std::invalid_argument if given vectors of mismatched size
+     */
     template <typename T_y, typename T_dof>
     typename return_type<T_y, T_dof>::type
     inv_chi_square_cdf(const T_y& y, const T_dof& nu) {

--- a/stan/math/prim/scal/prob/inv_chi_square_cdf.hpp
+++ b/stan/math/prim/scal/prob/inv_chi_square_cdf.hpp
@@ -28,18 +28,17 @@ namespace stan {
   namespace math {
 
     /**
-     * Calculates the inverse chi square cumulative distribution function for the given
-     * variate and degrees of freedom. If given vectors of matching sizes, returns
-     * the product of probabilities.
+     * Returns the inverse chi square cumulative distribution function for the
+     * given variate and degrees of freedom. If given containers of matching 
+     * sizes, returns the product of probabilities.
      *
-     * @param y A scalar variate.
-     * @param nu Degrees of freedom.
-     * @tparam T_y type of scalar variate, y.
+     * @tparam T_y type of scalar parameter
      * @tparam T_dof type of degrees of freedom parameter
-     *
+     * @param y scalar parameter
+     * @param nu degrees of freedom parameter
      * @return probability or product of probabilities
      * @throw std::domain_error if y is negative or nu is nonpositive
-     * @throw std::invalid_argument if given vectors of mismatched size
+     * @throw std::invalid_argument if container sizes mismatch
      */
     template <typename T_y, typename T_dof>
     typename return_type<T_y, T_dof>::type

--- a/stan/math/prim/scal/prob/inv_chi_square_lccdf.hpp
+++ b/stan/math/prim/scal/prob/inv_chi_square_lccdf.hpp
@@ -27,6 +27,20 @@
 namespace stan {
   namespace math {
 
+    /**
+     * Calculates the inverse chi square log complementary cumulative distribution function 
+     * for the given variate and degrees of freedom. If given vectors of matching sizes, 
+     * returns the log sum of probabilities.
+     *
+     * @param y A scalar variate.
+     * @param nu Degrees of freedom.
+     * @tparam T_y type of scalar variate, y.
+     * @tparam T_dof type of degrees of freedom parameter
+     *
+     * @return log probability or log sum of probabilities
+     * @throw std::domain_error if y is negative or nu is nonpositive
+     * @throw std::invalid_argument if given vectors of mismatched size
+     */
     template <typename T_y, typename T_dof>
     typename return_type<T_y, T_dof>::type
     inv_chi_square_lccdf(const T_y& y, const T_dof& nu) {

--- a/stan/math/prim/scal/prob/inv_chi_square_lccdf.hpp
+++ b/stan/math/prim/scal/prob/inv_chi_square_lccdf.hpp
@@ -28,18 +28,17 @@ namespace stan {
   namespace math {
 
     /**
-     * Calculates the inverse chi square log complementary cumulative distribution function 
-     * for the given variate and degrees of freedom. If given vectors of matching sizes, 
-     * returns the log sum of probabilities.
+     * Returns the inverse chi square log complementary cumulative distribution 
+     * function for the given variate and degrees of freedom. If given 
+     * containers of matching sizes, returns the log sum of probabilities.
      *
-     * @param y A scalar variate.
-     * @param nu Degrees of freedom.
-     * @tparam T_y type of scalar variate, y.
+     * @tparam T_y type of scalar parameter
      * @tparam T_dof type of degrees of freedom parameter
-     *
+     * @param y scalar parameter
+     * @param nu degrees of freedom parameter
      * @return log probability or log sum of probabilities
      * @throw std::domain_error if y is negative or nu is nonpositive
-     * @throw std::invalid_argument if given vectors of mismatched size
+     * @throw std::invalid_argument if container sizes mismatch
      */
     template <typename T_y, typename T_dof>
     typename return_type<T_y, T_dof>::type

--- a/stan/math/prim/scal/prob/inv_chi_square_lcdf.hpp
+++ b/stan/math/prim/scal/prob/inv_chi_square_lcdf.hpp
@@ -27,6 +27,20 @@
 namespace stan {
   namespace math {
 
+    /**
+     * Calculates the inverse chi square log cumulative distribution function for the given
+     * variate and degrees of freedom. If given vectors of matching sizes, returns
+     * the log sum of probabilities.
+     *
+     * @param y A scalar variate.
+     * @param nu Degrees of freedom.
+     * @tparam T_y type of scalar variate, y.
+     * @tparam T_dof type of degrees of freedom parameter
+     *
+     * @return log probability or log sum of probabilities
+     * @throw std::domain_error if y is negative or nu is nonpositive
+     * @throw std::invalid_argument if given vectors of mismatched size
+     */
     template <typename T_y, typename T_dof>
     typename return_type<T_y, T_dof>::type
     inv_chi_square_lcdf(const T_y& y, const T_dof& nu) {

--- a/stan/math/prim/scal/prob/inv_chi_square_lcdf.hpp
+++ b/stan/math/prim/scal/prob/inv_chi_square_lcdf.hpp
@@ -28,18 +28,17 @@ namespace stan {
   namespace math {
 
     /**
-     * Calculates the inverse chi square log cumulative distribution function for the given
-     * variate and degrees of freedom. If given vectors of matching sizes, returns
-     * the log sum of probabilities.
+     * Returns the inverse chi square log cumulative distribution function for
+     * the given variate and degrees of freedom. If given containers of 
+     * matching sizes, returns the log sum of probabilities.
      *
-     * @param y A scalar variate.
-     * @param nu Degrees of freedom.
-     * @tparam T_y type of scalar variate, y.
+     * @tparam T_y type of scalar parameter
      * @tparam T_dof type of degrees of freedom parameter
-     *
+     * @param y scalar parameter
+     * @param nu degrees of freedom parameter
      * @return log probability or log sum of probabilities
      * @throw std::domain_error if y is negative or nu is nonpositive
-     * @throw std::invalid_argument if given vectors of mismatched size
+     * @throw std::invalid_argument if container sizes mismatch
      */
     template <typename T_y, typename T_dof>
     typename return_type<T_y, T_dof>::type

--- a/stan/math/prim/scal/prob/inv_chi_square_rng.hpp
+++ b/stan/math/prim/scal/prob/inv_chi_square_rng.hpp
@@ -22,6 +22,15 @@
 namespace stan {
   namespace math {
 
+    /**
+     * Inverse chi squared distribution random number generator with nu degrees of freedom.
+     *
+     * @param nu positive degrees of freedom parameter.
+     * @param rng random number generator.
+     * @tparam RNG class of random number generator.
+     * @return sample from chi_squared(nu) distribution.
+     * @throw std::domain_error if nu is nonpositive.
+     */
     template <class RNG>
     inline double
     inv_chi_square_rng(double nu,

--- a/stan/math/prim/scal/prob/inv_chi_square_rng.hpp
+++ b/stan/math/prim/scal/prob/inv_chi_square_rng.hpp
@@ -23,13 +23,14 @@ namespace stan {
   namespace math {
 
     /**
-     * Inverse chi squared distribution random number generator with nu degrees of freedom.
+     * Return a pseudorandom Inverse chi squared variate with the nu degrees of
+     * freedom using the specified random number generator.
      *
-     * @param nu positive degrees of freedom parameter.
-     * @param rng random number generator.
-     * @tparam RNG class of random number generator.
-     * @return sample from chi_squared(nu) distribution.
-     * @throw std::domain_error if nu is nonpositive.
+     * @tparam RNG class of random number generator
+     * @param nu positive degrees of freedom parameter
+     * @param rng random number generator
+     * @return inverse chi squared random variate
+     * @throw std::domain_error if nu is nonpositive
      */
     template <class RNG>
     inline double

--- a/stan/math/prim/scal/prob/weibull_cdf.hpp
+++ b/stan/math/prim/scal/prob/weibull_cdf.hpp
@@ -24,17 +24,18 @@ namespace stan {
   namespace math {
 
     /**
-     * Calculates the Weibull cumulative distribution function 
-     * for the given variate, location, and scale.
+     * Returns the Weibull cumulative distribution function for the given 
+     * location and scale. Given containers of matching sizes, returns the
+     * product of probabilities.
      *
-     * @param y A scalar variate.
-     * @param alpha shape parameter.
-     * @param sigma scale parameter.
-     * @return Weibull cdf evaluated at the specified arguments.
-     * @tparam T_y Type of y.
-     * @tparam T_shape Type of shape parameter.
-     * @tparam T_scale Type of scale paramater.
-     * @throw std::domain_error if y is negative, alpha sigma is nonpositive. 
+     * @tparam T_y type of real parameter
+     * @tparam T_shape type of shape parameter
+     * @tparam T_scale type of scale paramater
+     * @param y real parameter
+     * @param alpha shape parameter
+     * @param sigma scale parameter
+     * @return probability or product of probabilities
+     * @throw std::domain_error if y is negative, alpha sigma is nonpositive 
      */
     template <typename T_y, typename T_shape, typename T_scale>
     typename return_type<T_y, T_shape, T_scale>::type

--- a/stan/math/prim/scal/prob/weibull_cdf.hpp
+++ b/stan/math/prim/scal/prob/weibull_cdf.hpp
@@ -23,6 +23,19 @@
 namespace stan {
   namespace math {
 
+    /**
+     * Calculates the Weibull cumulative distribution function 
+     * for the given variate, location, and scale.
+     *
+     * @param y A scalar variate.
+     * @param alpha shape parameter.
+     * @param sigma scale parameter.
+     * @return Weibull cdf evaluated at the specified arguments.
+     * @tparam T_y Type of y.
+     * @tparam T_shape Type of shape parameter.
+     * @tparam T_scale Type of scale paramater.
+     * @throw std::domain_error if y is negative, alpha sigma is nonpositive. 
+     */
     template <typename T_y, typename T_shape, typename T_scale>
     typename return_type<T_y, T_shape, T_scale>::type
     weibull_cdf(const T_y& y, const T_shape& alpha, const T_scale& sigma) {

--- a/stan/math/prim/scal/prob/weibull_lccdf.hpp
+++ b/stan/math/prim/scal/prob/weibull_lccdf.hpp
@@ -24,17 +24,18 @@ namespace stan {
   namespace math {
 
     /**
-     * Calculates the Weibull log complementary cumulative distribution function 
-     * for the given variate, location, and scale.
+     * Returns the Weibull log complementary cumulative distribution function
+     * for the given location and scale. Given containers of matching sizes, 
+     * returns the log sum of probabilities.
      *
-     * @param y A scalar variate.
-     * @param alpha shape parameter.
-     * @param sigma scale parameter.
-     * @return Weibull log complementary cdf evaluated at the specified arguments.
-     * @tparam T_y Type of y.
-     * @tparam T_shape Type of shape parameter.
-     * @tparam T_scale Type of scale paramater.
-     * @throw std::domain_error if y is negative, alpha sigma is nonpositive. 
+     * @tparam T_y type of real parameter
+     * @tparam T_shape type of shape parameter
+     * @tparam T_scale type of scale paramater
+     * @param y real parameter
+     * @param alpha shape parameter
+     * @param sigma scale parameter
+     * @return log probability or log sum of probabilities
+     * @throw std::domain_error if y is negative, alpha sigma is nonpositive 
      */
     template <typename T_y, typename T_shape, typename T_scale>
     typename return_type<T_y, T_shape, T_scale>::type

--- a/stan/math/prim/scal/prob/weibull_lccdf.hpp
+++ b/stan/math/prim/scal/prob/weibull_lccdf.hpp
@@ -23,6 +23,19 @@
 namespace stan {
   namespace math {
 
+    /**
+     * Calculates the Weibull log complementary cumulative distribution function 
+     * for the given variate, location, and scale.
+     *
+     * @param y A scalar variate.
+     * @param alpha shape parameter.
+     * @param sigma scale parameter.
+     * @return Weibull log complementary cdf evaluated at the specified arguments.
+     * @tparam T_y Type of y.
+     * @tparam T_shape Type of shape parameter.
+     * @tparam T_scale Type of scale paramater.
+     * @throw std::domain_error if y is negative, alpha sigma is nonpositive. 
+     */
     template <typename T_y, typename T_shape, typename T_scale>
     typename return_type<T_y, T_shape, T_scale>::type
     weibull_lccdf(const T_y& y, const T_shape& alpha, const T_scale& sigma) {

--- a/stan/math/prim/scal/prob/weibull_lcdf.hpp
+++ b/stan/math/prim/scal/prob/weibull_lcdf.hpp
@@ -23,6 +23,19 @@
 namespace stan {
   namespace math {
 
+    /**
+     * Calculates the Weibull log cumulative distribution function 
+     * for the given variate, location, and scale.
+     *
+     * @param y A scalar variate.
+     * @param alpha shape parameter.
+     * @param sigma scale parameter.
+     * @return Weibull log cdf evaluated at the specified arguments.
+     * @tparam T_y Type of y.
+     * @tparam T_shape Type of shape parameter.
+     * @tparam T_scale Type of scale paramater.
+     * @throw std::domain_error if y is negative, alpha sigma is nonpositive. 
+     */
     template <typename T_y, typename T_shape, typename T_scale>
     typename return_type<T_y, T_shape, T_scale>::type
     weibull_lcdf(const T_y& y, const T_shape& alpha, const T_scale& sigma) {

--- a/stan/math/prim/scal/prob/weibull_lcdf.hpp
+++ b/stan/math/prim/scal/prob/weibull_lcdf.hpp
@@ -24,17 +24,18 @@ namespace stan {
   namespace math {
 
     /**
-     * Calculates the Weibull log cumulative distribution function 
-     * for the given variate, location, and scale.
+     * Returns the Weibull log cumulative distribution function for the given 
+     * location and scale. Given containers of matching sizes, returns the
+     * log sum of probabilities.
      *
-     * @param y A scalar variate.
-     * @param alpha shape parameter.
-     * @param sigma scale parameter.
-     * @return Weibull log cdf evaluated at the specified arguments.
-     * @tparam T_y Type of y.
-     * @tparam T_shape Type of shape parameter.
-     * @tparam T_scale Type of scale paramater.
-     * @throw std::domain_error if y is negative, alpha sigma is nonpositive. 
+     * @tparam T_y type of real parameter
+     * @tparam T_shape type of shape parameter
+     * @tparam T_scale type of scale paramater
+     * @param y real parameter
+     * @param alpha shape parameter
+     * @param sigma scale parameter
+     * @return log probability or log sum of probabilities
+     * @throw std::domain_error if y is negative, alpha sigma is nonpositive 
      */
     template <typename T_y, typename T_shape, typename T_scale>
     typename return_type<T_y, T_shape, T_scale>::type

--- a/stan/math/prim/scal/prob/weibull_lpdf.hpp
+++ b/stan/math/prim/scal/prob/weibull_lpdf.hpp
@@ -23,7 +23,18 @@
 namespace stan {
   namespace math {
 
-    // Weibull(y|alpha, sigma)     [y >= 0;  alpha > 0;  sigma > 0]
+    /**
+     * Calculates the Weibull log probability density function 
+     *
+     * @param y A scalar variate.
+     * @param alpha shape parameter.
+     * @param sigma scale parameter.
+     * @return Weibull log pdf evaluated at the specified arguments.
+     * @tparam T_y Type of y.
+     * @tparam T_shape Type of shape parameter.
+     * @tparam T_scale Type of scale paramater.
+     * @throw std::domain_error if y is negative, alpha sigma is nonpositive. 
+     */
     template <bool propto,
               typename T_y, typename T_shape, typename T_scale>
     typename return_type<T_y, T_shape, T_scale>::type

--- a/stan/math/prim/scal/prob/weibull_lpdf.hpp
+++ b/stan/math/prim/scal/prob/weibull_lpdf.hpp
@@ -24,16 +24,18 @@ namespace stan {
   namespace math {
 
     /**
-     * Calculates the Weibull log probability density function 
+     * Returns the Weibull log probability density for the given 
+     * location and scale. Given containers of matching sizes, returns the
+     * log sum of probability densities.
      *
-     * @param y A scalar variate.
-     * @param alpha shape parameter.
-     * @param sigma scale parameter.
-     * @return Weibull log pdf evaluated at the specified arguments.
-     * @tparam T_y Type of y.
-     * @tparam T_shape Type of shape parameter.
-     * @tparam T_scale Type of scale paramater.
-     * @throw std::domain_error if y is negative, alpha sigma is nonpositive. 
+     * @tparam T_y type of real parameter
+     * @tparam T_shape type of shape parameter
+     * @tparam T_scale type of scale paramater
+     * @param y real parameter
+     * @param alpha shape parameter
+     * @param sigma scale parameter
+     * @return log probability density or log sum of probability densities
+     * @throw std::domain_error if y is negative, alpha sigma is nonpositive 
      */
     template <bool propto,
               typename T_y, typename T_shape, typename T_scale>

--- a/stan/math/prim/scal/prob/weibull_rng.hpp
+++ b/stan/math/prim/scal/prob/weibull_rng.hpp
@@ -18,14 +18,15 @@ namespace stan {
   namespace math {
 
     /**
-     * Weibull distribution random number generator with parameters alpha, sigma.
+     * Return a pseudorandom Weibull variate with given shape and scale using
+     * the specified random number generator.
      *
-     * @param alpha positive finite shape parameter.
-     * @param sigma positive finite scale parameter.
-     * @param rng random number generator.
-     * @tparam RNG class of random number generator.
-     * @return sample from Weibull(alpha, sigma)  distribution.
-     * @throw std::domain_error if alpha or sigma is nonpositive.
+     * @tparam RNG class of random number generator
+     * @param alpha shape parameter
+     * @param sigma scale parameter
+     * @param rng random number generator
+     * @return Weibull random variate
+     * @throw std::domain_error if alpha or sigma is nonpositive
      */
     template <class RNG>
     inline double

--- a/stan/math/prim/scal/prob/weibull_rng.hpp
+++ b/stan/math/prim/scal/prob/weibull_rng.hpp
@@ -17,6 +17,16 @@
 namespace stan {
   namespace math {
 
+    /**
+     * Weibull distribution random number generator with parameters alpha, sigma.
+     *
+     * @param alpha positive finite shape parameter.
+     * @param sigma positive finite scale parameter.
+     * @param rng random number generator.
+     * @tparam RNG class of random number generator.
+     * @return sample from Weibull(alpha, sigma)  distribution.
+     * @throw std::domain_error if alpha or sigma is nonpositive.
+     */
     template <class RNG>
     inline double
     weibull_rng(double alpha,


### PR DESCRIPTION
#### Submisison Checklist

- [ ] Run unit tests: `./runTests.py test/unit`
- [ ] Run cpplint: `make cpplint`
- [ ] Declare copyright holder and open-source license: see below

#### Summary:
This doesn't finish adding doxygen doc to the distributions in prim/scal/prob but tips the balance in our favor and seems like a small enough stack to review. Begins to address issues in https://github.com/stan-dev/math/issues/475

#### Intended Effect:
No effect on code except for one function that was re-organized

#### How to Verify:
Check for errors in doc, allow CI to run tests. I'll check too.

#### Side Effects:
Should be none.

#### Documentation:

#### Reviewer Suggestions: 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
