### PR TITLE
Add reverse for vectors.

### DIFF
--- a/stan/math/prim/arr.hpp
+++ b/stan/math/prim/arr.hpp
@@ -23,6 +23,7 @@
 #include <stan/math/prim/arr/fun/promote_scalar.hpp>
 #include <stan/math/prim/arr/fun/promote_scalar_type.hpp>
 #include <stan/math/prim/arr/fun/rep_array.hpp>
+#include <stan/math/prim/arr/fun/reverse.hpp>
 #include <stan/math/prim/arr/fun/scaled_add.hpp>
 #include <stan/math/prim/arr/fun/sort_asc.hpp>
 #include <stan/math/prim/arr/fun/sort_desc.hpp>

--- a/stan/math/prim/arr/fun/reverse.hpp
+++ b/stan/math/prim/arr/fun/reverse.hpp
@@ -8,16 +8,17 @@ namespace stan {
   namespace math {
 
     /**
-     * Return the specified vector in reversed order.
+     * Return a copy of the specified vector in reversed order.
      *
      * @tparam T type of elements in vector
      * @param xs vector to order
      * @return vector in reversed order.
      */
     template <typename T>
-    inline std::vector<T> reverse(std::vector<T>& xs) {
-      std::reverse(xs.begin(), xs.end());
-      return xs;
+    inline std::vector<T> reverse(const std::vector<T>& xs) {
+      std::vector<T> reversed(xs.size());
+      std::reverse_copy(xs.begin(), xs.end(), std::begin(reversed));
+      return reversed;
     }
   }
 }

--- a/stan/math/prim/arr/fun/reverse.hpp
+++ b/stan/math/prim/arr/fun/reverse.hpp
@@ -17,7 +17,7 @@ namespace stan {
     template <typename T>
     inline std::vector<T> reverse(const std::vector<T>& xs) {
       std::vector<T> reversed(xs.size());
-      std::reverse_copy(xs.begin(), xs.end(), std::begin(reversed));
+      std::reverse_copy(xs.begin(), xs.end(), reversed.begin());
       return reversed;
     }
   }

--- a/stan/math/prim/arr/fun/reverse.hpp
+++ b/stan/math/prim/arr/fun/reverse.hpp
@@ -1,0 +1,24 @@
+#ifndef STAN_MATH_PRIM_ARR_FUN_REVERSE_HPP
+#define STAN_MATH_PRIM_ARR_FUN_REVERSE_HPP
+
+#include <algorithm>
+#include <vector>
+
+namespace stan {
+  namespace math {
+
+    /**
+     * Return the specified vector in reversed order.
+     *
+     * @tparam T type of elements in vector
+     * @param xs vector to order
+     * @return vector in reversed order.
+     */
+    template <typename T>
+    inline std::vector<T> reverse(std::vector<T>& xs) {
+      std::reverse(xs.begin(), xs.end());
+      return xs;
+    }
+  }
+}
+#endif

--- a/test/unit/math/prim/arr/fun/reverse_test.cpp
+++ b/test/unit/math/prim/arr/fun/reverse_test.cpp
@@ -1,0 +1,13 @@
+#include <stan/math/prim/arr.hpp>
+#include <gtest/gtest.h>
+
+TEST(MathFunctions, reverse) {
+  std::vector<double> x(3);
+  x[0] = 9;
+  x[1] = 2.2;
+  x[2] = 3.3;
+  std::vector<double> y = stan::math::reverse(x);
+  EXPECT_FLOAT_EQ(y[0], 3.3);
+  EXPECT_FLOAT_EQ(y[1], 2.2);
+  EXPECT_FLOAT_EQ(y[2], 9);
+}


### PR DESCRIPTION
#### Submisison Checklist

- [ ] Run unit tests: `./runTests.py test/unit`
- [ ] Run cpplint: `make cpplint`
- [ ] Declare copyright holder and open-source license: see below

#### Summary:
Just a quick resolution of https://github.com/stan-dev/math/issues/344 adding a reverse utility for std::vectors. Like our sort functions, it mutates its argument. We ok with that?

#### Intended Effect:
Add a missing minor feature.

#### How to Verify:
Code is short and there's a unit test.

#### Side Effects:
None, adds a function.

#### Documentation:
doxygen

#### Reviewer Suggestions: 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
