### PR TITLE
add more output to runTests.py and reformat to pep styles

### DIFF
--- a/runTests.py
+++ b/runTests.py
@@ -1,161 +1,193 @@
 #!/usr/bin/python
 
 """
-replacement for runtest target in Makefile
-arg 1:  test dir or test file
+Replacement for runtest target in Makefile.
+
+Call script with '-h' as an option to see a helpful message.
 """
 
+from __future__ import print_function
+from argparse import ArgumentParser, RawTextHelpFormatter
 import os
 import os.path
 import platform
-import sys
 import subprocess
+import sys
 import time
-import re
 
 winsfx = ".exe"
 testsfx = "_test.cpp"
-debug = False
 batchSize = 25
 
-def usage():
-    sys.stdout.write('usage: %s <path/test/dir(/files)>\n' % sys.argv[0])
-    sys.stdout.write('or\n')
-    sys.stdout.write('       %s -j<#cores> <path/test/dir(/files)>\n' % sys.argv[0])
-    sys.exit(0)
+
+def processCLIArgs():
+    """
+    Define and process the command line interface to the runTests.py script.
+    """
+    cli_description = "Generate and run stan math library tests."
+    cli_epilog = "See more information at: https://github.com/stan-dev/math"
+
+    parser = ArgumentParser(description=cli_description,
+                            epilog=cli_epilog,
+                            formatter_class=RawTextHelpFormatter)
+
+    # Now define all the rules of the command line args and opts
+    parser.add_argument("-j", metavar="N", type=int, default=1,
+                        help="number of cores for make to use")
+
+    tests_help_msg = "The path(s) to the test case(s) to run.\n"
+    tests_help_msg += "Example: 'test/unit', 'test/prob', and/or\n"
+    tests_help_msg += "         'test/unit/math/prim/scal/fun/abs_test.cpp'"
+    parser.add_argument("tests", nargs="+", type=str,
+                        help=tests_help_msg)
+
+    parser.add_argument("-d", "--debug", dest="debug", action="store_true",
+                        help="request additional script debugging output.")
+
+    # And parse the command line against those rules
+    return parser.parse_args()
+
 
 def stopErr(msg, returncode):
+    """Report an error message to stderr and exit with a given code."""
     sys.stderr.write('%s\n' % msg)
     sys.stderr.write('exit now (%s)\n' % time.strftime('%x %X %Z'))
     sys.exit(returncode)
 
+
 def isWin():
     if (platform.system().lower().startswith("windows")
-        or os.name.lower().startswith("windows")):
+            or os.name.lower().startswith("windows")):
         return True
     return False
 
-# set up good makefile target name
+
 def mungeName(name):
+    """Set up the makefile target name"""
     if (name.endswith(testsfx)):
-        name = name.replace(testsfx,"_test")
+        name = name.replace(testsfx, "_test")
+
         if (isWin()):
             name += winsfx
-            name = name.replace("\\","/")
+            name = name.replace("\\", "/")
+
     return name
 
+
 def doCommand(command):
+    """Run command as a shell command and report/exit on errors."""
     print("------------------------------------------------------------")
     print("%s" % command)
-    p1 = subprocess.Popen(command,shell=True)
+    p1 = subprocess.Popen(command, shell=True)
     p1.wait()
-    if (not(p1.returncode == None) and not(p1.returncode == 0)):
+    if (not(p1.returncode is None) and not(p1.returncode == 0)):
         stopErr('%s failed' % command, p1.returncode)
 
+
 def generateTests(j):
-    if (j == None):
+    """Generate all tests and pass along the j parameter to make."""
+    if j is None:
         command = 'make generate-tests -s'
     else:
         command = 'make -j%d generate-tests -s' % j
     doCommand(command)
 
+
 def makeTest(name, j):
+    """Run the make command for a given single test."""
     target = mungeName(name)
-    if (j == None):
+    if j is None:
         command = 'make %s' % target
     else:
-        command = 'make -j%d %s' % (j,target)
+        command = 'make -j%d %s' % (j, target)
     doCommand(command)
 
-def makeTests(dirname, filenames, j):
+
+def makeTests(dirname, filenames, j, debug):
     targets = list()
     for name in filenames:
         if (not name.endswith(testsfx)):
             continue
-        target = "/".join([dirname,name])
+
+        target = "/".join([dirname, name])
         target = mungeName(target)
         targets.append(target)
+
     if (len(targets) > 0):
         if (debug):
             print('# targets: %d' % len(targets))
         startIdx = 0
         endIdx = batchSize
+
         while (startIdx < len(targets)):
-            if (j == None):
+            if j is None:
                 command = 'make %s' % ' '.join(targets[startIdx:endIdx])
             else:
-                command = 'make -j%d %s' % (j,' '.join(targets[startIdx:endIdx]))
+                command = 'make -j%d %s' % (j, ' '.join(targets[startIdx:endIdx]))
+
             if (debug):
-                print('start %d, end %d' % (startIdx,endIdx))
+                print('start %d, end %d' % (startIdx, endIdx))
                 print(command)
+
             doCommand(command)
             startIdx = endIdx
             endIdx = startIdx + batchSize
+
             if (endIdx > len(targets)):
                 endIdx = len(targets)
 
 
 def runTest(name):
-    executable = mungeName(name).replace("/",os.sep)
+    executable = mungeName(name).replace("/", os.sep)
     xml = mungeName(name).replace(winsfx, "")
     command = '%s --gtest_output="xml:%s.xml"' % (executable, xml)
     doCommand(command)
 
-def main():
-    if (len(sys.argv) < 2):
-        usage()
 
-    argsIdx = 1
-    j = None
-    if (sys.argv[1].startswith("-j")):
-        argsIdx = 2
-        if (len(sys.argv) < 3):
-            usage()
-        else:
-            j = sys.argv[1].replace("-j","")
-            try:
-                jprime = int(j)
-                if (jprime < 1 or jprime > 16):
-                    stopErr("bad value for -j flag",-1)
-                j = jprime
-            except ValueError:
-                stopErr("bad value for -j flag",-1)
+def main():
+    inputs = processCLIArgs()
 
     # pass 0: generate all auto-generated tests
-    tests = sys.argv[argsIdx:]
-    prob_args = ['test/prob' in arg for arg in tests]
-    if any(prob_args):
-        generateTests(j)
+    if any(['test/prob' in arg for arg in inputs.tests]):
+        generateTests(inputs.j)
 
-    # pass 1:  call make to compile test targets
-    for testname in tests:
+    # pass 1: call make to compile test targets
+    for testname in inputs.tests:
+        # Ensure that the test actually exists at all
         if (not(os.path.exists(testname))):
-            stopErr('%s: no such file or directory' % testname,-1)
+            stopErr('%s: no such file or directory' % testname, -1)
+
+        # If it exists and is a not a directory, run that one test
         if (not(os.path.isdir(testname))):
             if (not(testname.endswith(testsfx))):
-                stopErr('%s: not a testfile' % testname,-1)
-            if (debug):
+                stopErr('%s: not a testfile' % testname, -1)
+
+            if (inputs.debug):
                 print("make single test: %s" % testname)
-            makeTest(testname,j)
+
+            makeTest(testname, inputs.j)
+
+        # If it exists and is a directory, run all tests inside
         else:
             for root, dirs, files in os.walk(testname):
-                if (debug):
+                if (inputs.debug):
                     print("make root: %s" % root)
-                makeTests(root,files,j)
 
-    # pass 2:  run test targets
-    for testname in tests:
+                makeTests(root, files, inputs.j, inputs.debug)
+
+    # pass 2: run test targets
+    for testname in inputs.tests:
         if (not(os.path.isdir(testname))):
-            if (debug):
+            if (inputs.debug):
                 print("run single test: %s" % testname)
             runTest(testname)
         else:
             for root, dirs, files in os.walk(testname):
                 for name in files:
                     if (name.endswith(testsfx)):
-                        if (debug):
-                            print("run dir,test: %s,%s" % (root,name))
-                        runTest(os.sep.join([root,name]))
+                        if (inputs.debug):
+                            print("run dir,test: %s,%s" % (root, name))
+                        runTest(os.sep.join([root, name]))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

Adds more robust argument parsing to the runTests.py script using python's standard argparse module
instead of manually parsing inputs. Also makes the debug variable inside available to toggle as an option
and adds an `-h` option to see a more verbose help message.

Also does some reformatting in alignment with PEP suggestions; spaces around commas, etc.

#### Intended Effect:

No behavior changes - all previous inputs should function the same as before.

The script now outputs a more verbose help message. When passing inputs that are not valid should give a more specific error message as well such as 'too few arguments' or 'unrecognized option'.

Here is the new help message which is open for any changes:
```
usage: runTests.py [-h] [-j N] [-d] tests [tests ...] 

Generate and run stan math library tests.

positional arguments:
    tests            The path(s) to the test case(s) to run.
                     Example: 'test/unit', 'test/prob', and/or
                              'test/unit/math/prim/scal/fun/abs_test.cpp' 
optional arguments:
   -h, --help    show this help message and exit
   -j N          number of cores for make to use
   -d, --debug   request additional script debugging output.

See more information at: https://github.com/stan-dev/math
```
#### How to Verify:
The same commands you have used with the script should still all work. You can view the new help
message by passing `-h` as an option.

#### Side Effects:

This script goes out of alignment with the near identical one in the main `stan` repository. Though if this gets accepted, I'll go over there and change that too.

#### Documentation:

There may be some minor wiki entries that still need to be changed. If I change this same script on the main `stan` repository, then the wiki there definitely needs some changes, because it explicitly prints the help output and that's been updated.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): 

Lucas Kolstad
University of Washington

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
