### PR TITLE
Add .*.swp for temp vim files to gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,9 @@
 *~
 \#*#
 
+# temporary vim files
+.*.swp
+
 # depedencies files
 *.d
 *.d.*


### PR DESCRIPTION
[skip-ci]

#### Submisison Checklist

- [x] Run unit tests: `./runTests.py test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary:
Just want to add vim's swap files to the gitignore.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Dual Space LLC

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
