### PR TITLE
Add some tests for return_type

### DIFF
--- a/test/unit/math/prim/mat/meta/return_type_test.cpp
+++ b/test/unit/math/prim/mat/meta/return_type_test.cpp
@@ -1,0 +1,25 @@
+#include <stan/math/prim/mat.hpp>
+#include <gtest/gtest.h>
+#include <test/unit/util.hpp>
+
+using stan::return_type;
+using std::vector;
+using Eigen::MatrixXd;
+using Eigen::VectorXd;
+using Eigen::RowVectorXd;
+
+TEST(MetaTraits, ReturnTypeMatrixXd) {
+  test::expect_same_type<double, return_type<MatrixXd>::type>();
+}
+
+TEST(MetaTraits, ReturnTypeVectorXd) {
+  test::expect_same_type<double, return_type<VectorXd>::type>();
+}
+
+TEST(MetaTraits, ReturnTypeRowVectorXd) {
+  test::expect_same_type<double, return_type<RowVectorXd>::type>();
+}
+
+TEST(MetaTraits, ReturnTypeArray) {
+  test::expect_same_type<double, return_type<vector<int> >::type>();
+}

--- a/test/unit/math/prim/scal/meta/return_type_test.cpp
+++ b/test/unit/math/prim/scal/meta/return_type_test.cpp
@@ -1,0 +1,17 @@
+#include <stan/math/prim/scal.hpp>
+#include <gtest/gtest.h>
+#include <test/unit/util.hpp>
+
+using stan::return_type;
+
+TEST(MetaTraits, ReturnTypeDouble) {
+  test::expect_same_type<double, return_type<double>::type>();
+}
+
+TEST(MetaTraits, ReturnTypeFloat) {
+  test::expect_same_type<double, return_type<float>::type>();
+}
+
+TEST(MetaTraits, ReturnTypeInt) {
+  test::expect_same_type<double, return_type<int>::type>();
+}


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary:
I'm unfamiliar with promote_args from boost and it wasn't immediately clear to me how return_type should behave, so I wrote some tests that explicitly show the behavior. 

#### Reviewer Suggestions: 
I'm not sure if these tests add much value besides potentially helping future newbs, so I'm not sure if we want stuff like this in the codebase or not. Feel free to just close the PR without merging.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Dual Space LLC

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
