### PR TITLE
Use cumulative_sum instead of nested loop in categorical_rng

### DIFF
--- a/stan/math/prim/mat/prob/categorical_rng.hpp
+++ b/stan/math/prim/mat/prob/categorical_rng.hpp
@@ -7,6 +7,7 @@
 #include <stan/math/prim/scal/err/check_bounded.hpp>
 #include <stan/math/prim/scal/fun/value_of.hpp>
 #include <stan/math/prim/mat/fun/sum.hpp>
+#include <stan/math/prim/mat/fun/cumulative_sum.hpp>
 #include <stan/math/prim/mat/meta/index_type.hpp>
 #include <stan/math/prim/scal/fun/constants.hpp>
 #include <stan/math/prim/scal/meta/include_summand.hpp>
@@ -31,10 +32,7 @@ namespace stan {
       Eigen::VectorXd index(theta.rows());
       index.setZero();
 
-      for (int i = 0; i < theta.rows(); i++) {
-        for (int j = i; j < theta.rows(); j++)
-          index(j) += theta(i, 0);
-      }
+      index = cumulative_sum(theta);
 
       double c = uniform01_rng();
       int b = 0;


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

- Header test for [stan/math/prim/arr/fun/promote_elements.hpp](https://github.com/stan-dev/math/blob/f51421b85ece83edca273db623a0659473bac659/stan/math/prim/arr/fun/promote_elements.hpp#L30) fails because `size_t` is not found, but this is independent of the changes in this pull request.

#### Summary:

Fixes #503 by changing a nested loop to a call to `stan::math::cumulative_sum`. This results in a speed-up of `categorical_rng`.

- I believe this reduces the number of operations in calculating the cumulative sum of `theta` approximately from `(N * (N + 1)) / 2` to `2 * N`.

Minor speed improvements might still be gained by changing to a binary search over `index`, or only calculating the cumulative sum up to `c`, but the speed gains would smaller and code changes less transparent.

#### Intended Effect:

- Much faster `categorical_rng` when simplex `theta` is large.

#### How to Verify:

- Unit tests show `categorical_rng` still works correctly.

- To quantify speed gains, compare or profile code using `categorical_rng` with previous version. Absolute runtime and share of time spent in `categorical_rng` will drop steeply as a function of the size of `theta`. Tested for different N in the range 1000 - 15000.

#### Side Effects:

None.

- Performance for small `theta` was not measured, but that too should be faster.

#### Documentation:

No changes to the documentation.

#### Reviewer Suggestions: 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Torsti Schulz

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
