### PR TITLE
Feature/issue 1452 new to matrix signatures

### DIFF
--- a/stan/math/prim/arr/fun/promote_elements.hpp
+++ b/stan/math/prim/arr/fun/promote_elements.hpp
@@ -3,6 +3,7 @@
 
 #include <stan/math/prim/scal/fun/promote_elements.hpp>
 #include <vector>
+#include <cstddef>
 
 namespace stan {
   namespace math {

--- a/stan/math/prim/mat/fun/to_matrix.hpp
+++ b/stan/math/prim/mat/fun/to_matrix.hpp
@@ -101,7 +101,7 @@ namespace stan {
                              Eigen::Dynamic> (0, 0);
       }
     }
-    
+
     /**
      * Returns a matrix representation of the vector in column-major
      * order with the specified number of rows and columns.
@@ -147,7 +147,7 @@ namespace stan {
                         Eigen::Matrix<T, Eigen::Dynamic,
                                       Eigen::Dynamic> >(&x[0], m, n);
     }
-   
+
     /**
      * Returns a matrix representation of the vector in column-major
      * order with the specified number of rows and columns.
@@ -192,9 +192,9 @@ namespace stan {
     template <typename T, int R, int C>
     inline Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>
     to_matrix(const Eigen::Matrix<T, R, C>& x, int m, int n, int cm) {
-      if (cm == 1)
+      if (cm == 1) {
         return to_matrix(x, m, n);
-      else if (cm == 0) {
+      } else if (cm == 0) {
         check_size_match("to_matrix", "rows * columns", m * n,
                          "matrix size", x.size());
         Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>
@@ -203,8 +203,7 @@ namespace stan {
           for (size_t j=0; j < n; j++, ij++)
             result(i, j) = x(ij);
         return result;
-      }
-      else {
+      } else {
         invalid_argument("to_matrix", "cm", cm,
                          "column-major indicator",
                          "must equal 0 or 1");
@@ -230,13 +229,13 @@ namespace stan {
      */
     template <typename T>
     inline
-    Eigen::Matrix<typename 
+    Eigen::Matrix<typename
       boost::math::tools::promote_args<T, double>::type,
       Eigen::Dynamic, Eigen::Dynamic>
     to_matrix(const std::vector<T>& x, int m, int n, int cm) {
-      if (cm == 1)
+      if (cm == 1) {
         return to_matrix(x, m, n);
-      else if (cm == 0) {
+      } else if (cm == 0) {
         check_size_match("to_matrix", "rows * columns", m * n,
                          "matrix size", x.size());
         Eigen::Matrix<typename
@@ -247,8 +246,7 @@ namespace stan {
           for (size_t j=0; j < n; j++, ij++)
             result(i, j) = x[ij];
         return result;
-      }
-      else {
+      } else {
         invalid_argument("to_matrix", "cm", cm,
                          "column-major indicator",
                          "must equal 0 or 1");

--- a/stan/math/prim/mat/fun/to_matrix.hpp
+++ b/stan/math/prim/mat/fun/to_matrix.hpp
@@ -135,6 +135,28 @@ namespace stan {
       return Eigen::Map<const Eigen::Matrix<T, Eigen::Dynamic,
                                             Eigen::Dynamic> >(&x[0], m, n);
     }
+    
+    /**
+     * Returns a matrix representation of the vector in column-major order
+     * with the specified number of rows and columns.
+     *
+     * @param x vector of values
+     * @param m rows
+     * @param n columns
+     * @return the matrix representation of the input
+     * @throw <code>std::invalid_argument</code> if the sizes do not match
+     */
+    inline Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>
+    to_matrix(const std::vector<int>& x, int m, int n) {
+      static const char* fun = "to_matrix(array)";
+      int size = x.size();
+      check_size_match(fun, "rows * columns", m * n, "vector size", size);
+      Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> result(m, n);
+      double* datap = result.data();
+      for (int i=0; i < size; i++)
+        datap[i] = x[i];
+      return result;
+    }
 
   }
 }

--- a/stan/math/prim/mat/fun/to_matrix.hpp
+++ b/stan/math/prim/mat/fun/to_matrix.hpp
@@ -2,6 +2,7 @@
 #define STAN_MATH_PRIM_MAT_FUN_TO_MATRIX_HPP
 
 #include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <Eigen/Dense>
 #include <vector>
 
 namespace stan {
@@ -24,36 +25,16 @@ namespace stan {
     }
 
     /**
-     * Returns a matrix representation of the vector in column-major order
-     * with the specified number of rows and columns.
-     *
-     * @tparam T type of the scalar
-     * @param x vector of values
-     * @param m rows
-     * @param n columns
-     * @return the matrix representation of the input
-     * @throw <code>std::invalid_argument</code> if the sizes do not match
-     */
-    template <typename T>
-    inline Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>
-    to_matrix(const std::vector<T>& x, int m, int n) {
-      static const char* fun = "to_matrix(array)";
-      check_size_match(fun, "rows * columns", m * n, "vector size", x.size());
-      return Eigen::Map<const Eigen::Matrix<T, Eigen::Dynamic,
-                                            Eigen::Dynamic> >(&x[0], m, n);
-    }
-
-    /**
-     * Returns a matrix representation of the standard vector of standard vectors
+     * Returns a matrix representation of a standard vector of Eigen row vectors
      * with the same dimensions and indexing order.
      *
      * @tparam T type of the scalar
-     * @param x vector of vectors of scalar values
+     * @param x Eigen vector of vectors of scalar values
      * @return the matrix representation of the input
      */
     template <typename T>
     inline Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>
-    to_matrix(const std::vector< std::vector<T> >& x) {
+    to_matrix(const std::vector<Eigen::Matrix<T, 1, Eigen::Dynamic> >& x) {
       size_t rows = x.size();
       if (rows != 0) {
         size_t cols = x[0].size();
@@ -67,18 +48,17 @@ namespace stan {
       }
     }
 
-
     /**
-     * Returns a matrix representation of a standard vector of Eigen row vectors
+     * Returns a matrix representation of the standard vector of standard vectors
      * with the same dimensions and indexing order.
      *
      * @tparam T type of the scalar
-     * @param x Eigen vector of vectors of scalar values
+     * @param x vector of vectors of scalar values
      * @return the matrix representation of the input
      */
     template <typename T>
     inline Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>
-    to_matrix(const std::vector<Eigen::Matrix<T, 1, Eigen::Dynamic> >& x) {
+    to_matrix(const std::vector< std::vector<T> >& x) {
       size_t rows = x.size();
       if (rows != 0) {
         size_t cols = x[0].size();
@@ -113,6 +93,47 @@ namespace stan {
       } else {
         return Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> (0, 0);
       }
+    }
+    
+    /**
+     * Returns a matrix representation of the vector in column-major order
+     * with the specified number of rows and columns.
+     *
+     * @tparam T type of the scalar
+     * @param x matrix
+     * @param m rows
+     * @param n columns
+     * @return Reshaped inputted matrix
+     * @throw <code>std::invalid_argument</code> if the sizes do not match
+     */
+    template <typename T, int R, int C>
+    inline Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>
+    to_matrix(const Eigen::Matrix<T, R, C>& x, int m, int n) {
+      static const char* fun = "to_matrix(matrix)";
+      check_size_match(fun, "rows * columns", m * n, "vector size", x.size());
+      Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> y = x;
+      y.resize(m, n);
+      return y;
+    }
+
+    /**
+     * Returns a matrix representation of the vector in column-major order
+     * with the specified number of rows and columns.
+     *
+     * @tparam T type of the scalar
+     * @param x vector of values
+     * @param m rows
+     * @param n columns
+     * @return the matrix representation of the input
+     * @throw <code>std::invalid_argument</code> if the sizes do not match
+     */
+    template <typename T>
+    inline Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>
+    to_matrix(const std::vector<T>& x, int m, int n) {
+      static const char* fun = "to_matrix(array)";
+      check_size_match(fun, "rows * columns", m * n, "vector size", x.size());
+      return Eigen::Map<const Eigen::Matrix<T, Eigen::Dynamic,
+                                            Eigen::Dynamic> >(&x[0], m, n);
     }
 
   }

--- a/stan/math/prim/mat/fun/to_matrix.hpp
+++ b/stan/math/prim/mat/fun/to_matrix.hpp
@@ -9,7 +9,8 @@ namespace stan {
   namespace math {
     /**
      * Returns a matrix with dynamic dimensions constructed from
-     * an Eigen matrix which is either a row vector, column vector, or matrix.
+     * an Eigen matrix which is either
+     * a row vector, column vector, or matrix.
      * The runtime dimensions will be the same as the input.
      *
      * @tparam T type of the scalar
@@ -25,8 +26,8 @@ namespace stan {
     }
 
     /**
-     * Returns a matrix representation of a standard vector of Eigen row vectors
-     * with the same dimensions and indexing order.
+     * Returns a matrix representation of a standard vector of Eigen
+     * row vectors with the same dimensions and indexing order.
      *
      * @tparam T type of the scalar
      * @param x Eigen vector of vectors of scalar values
@@ -34,11 +35,13 @@ namespace stan {
      */
     template <typename T>
     inline Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>
-    to_matrix(const std::vector<Eigen::Matrix<T, 1, Eigen::Dynamic> >& x) {
+    to_matrix(const
+              std::vector<Eigen::Matrix<T, 1, Eigen::Dynamic> >& x) {
       size_t rows = x.size();
       if (rows != 0) {
         size_t cols = x[0].size();
-        Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> result(rows, cols);
+        Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>
+          result(rows, cols);
         for (size_t i=0, ij=0; i < cols; i++)
           for (size_t j=0; j < rows; j++, ij++)
             result(ij) = x[j][i];
@@ -49,8 +52,8 @@ namespace stan {
     }
 
     /**
-     * Returns a matrix representation of the standard vector of standard vectors
-     * with the same dimensions and indexing order.
+     * Returns a matrix representation of the standard vector of
+     * standard vectors with the same dimensions and indexing order.
      *
      * @tparam T type of the scalar
      * @param x vector of vectors of scalar values
@@ -62,7 +65,8 @@ namespace stan {
       size_t rows = x.size();
       if (rows != 0) {
         size_t cols = x[0].size();
-        Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> result(rows, cols);
+        Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>
+          result(rows, cols);
         for (size_t i=0, ij=0; i < cols; i++)
           for (size_t j=0; j < rows; j++, ij++)
             result(ij) = x[j][i];
@@ -73,11 +77,13 @@ namespace stan {
     }
 
     /**
-     * Returns a matrix representation of a standard vector of standard vectors
-     * of integers with the same dimensions and indexing order.
+     * Returns a matrix representation of a standard vector of
+     * standard vectors of integers with the same dimensions and
+     * indexing order.
      *
      * @param x vector of vectors of integer values
-     * @return the matrix representation of the input, ints promoted to doubles
+     * @return the matrix representation of the input,
+     * ints promoted to doubles
      */
     inline Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>
     to_matrix(const std::vector< std::vector<int> >& x) {
@@ -91,72 +97,118 @@ namespace stan {
             result(ij) = x[j][i];
         return result;
       } else {
-        return Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> (0, 0);
+        return Eigen::Matrix<double, Eigen::Dynamic,
+                             Eigen::Dynamic> (0, 0);
       }
     }
     
     /**
-     * Returns a matrix representation of the vector in column-major order
-     * with the specified number of rows and columns.
+     * Returns a matrix representation of the vector in column-major
+     * order with the specified number of rows and columns.
      *
      * @tparam T type of the scalar
      * @param x matrix
      * @param m rows
      * @param n columns
      * @return Reshaped inputted matrix
-     * @throw <code>std::invalid_argument</code> if the sizes do not match
+     * @throw <code>std::invalid_argument</code> if the sizes
+     * do not match
      */
     template <typename T, int R, int C>
     inline Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>
     to_matrix(const Eigen::Matrix<T, R, C>& x, int m, int n) {
       static const char* fun = "to_matrix(matrix)";
-      check_size_match(fun, "rows * columns", m * n, "vector size", x.size());
+      check_size_match(fun, "rows * columns", m * n, "vector size",
+                       x.size());
       Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> y = x;
       y.resize(m, n);
       return y;
     }
+    
+    /**
+     * Returns a matrix representation of the vector in column-major
+     * order with the specified number of rows and columns.
+     *
+     * @tparam T type of the scalar
+     * @param x matrix
+     * @param m rows
+     * @param n columns
+     * @return Reshaped inputted matrix
+     * @throw <code>std::invalid_argument</code>
+     * if the sizes do not match
+     */
+    template <typename T, int R, int C>
+    inline Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>
+    to_matrix(const Eigen::Matrix<T, R, C>& x, int m, int n, int cm) {
+      if (cm == 1)
+        return to_matrix(x, m, n);
+      else if (cm == 0) {
+        check_size_match("to_matrix", "rows * columns", m * n,
+                         "matrix size", x.size());
+        Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>
+          result(m, n);
+        for (size_t i=0, ij=0; i < m; i++)
+          for (size_t j=0; j < n; j++, ij++)
+            result(i, j) = x(ij);
+        return result;
+      }
+      else {
+        invalid_argument("to_matrix", "cm", cm,
+                         "column-major indicator",
+                         "must equal 0 or 1");
+        return Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> (0, 0);
+      }
+    }
 
     /**
-     * Returns a matrix representation of the vector in column-major order
-     * with the specified number of rows and columns.
+     * Returns a matrix representation of the vector in column-major
+     * order with the specified number of rows and columns.
      *
      * @tparam T type of the scalar
      * @param x vector of values
      * @param m rows
      * @param n columns
      * @return the matrix representation of the input
-     * @throw <code>std::invalid_argument</code> if the sizes do not match
+     * @throw <code>std::invalid_argument</code>
+     * if the sizes do not match
      */
     template <typename T>
     inline Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>
     to_matrix(const std::vector<T>& x, int m, int n) {
       static const char* fun = "to_matrix(array)";
-      check_size_match(fun, "rows * columns", m * n, "vector size", x.size());
-      return Eigen::Map<const Eigen::Matrix<T, Eigen::Dynamic,
-                                            Eigen::Dynamic> >(&x[0], m, n);
+      check_size_match(fun, "rows * columns", m * n, "vector size",
+                       x.size());
+      return Eigen::Map<const
+                        Eigen::Matrix<T, Eigen::Dynamic,
+                                      Eigen::Dynamic> >(&x[0], m, n);
     }
     
     /**
-     * Returns a matrix representation of the vector in column-major order
-     * with the specified number of rows and columns.
+     * Returns a matrix representation of the vector in column-major
+     * order with the specified number of rows and columns.
      *
      * @param x vector of values
      * @param m rows
      * @param n columns
      * @return the matrix representation of the input
-     * @throw <code>std::invalid_argument</code> if the sizes do not match
+     * @throw <code>std::invalid_argument</code>
+     * if the sizes do not match
      */
     inline Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>
     to_matrix(const std::vector<int>& x, int m, int n) {
       static const char* fun = "to_matrix(array)";
       int size = x.size();
-      check_size_match(fun, "rows * columns", m * n, "vector size", size);
-      Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> result(m, n);
+      check_size_match(fun, "rows * columns", m * n,
+                       "vector size", size);
+      Eigen::Matrix<double,
+                    Eigen::Dynamic, Eigen::Dynamic> result(m, n);
       double* datap = result.data();
       for (int i=0; i < size; i++)
         datap[i] = x[i];
       return result;
     }
+    
+
 
   }
 }

--- a/stan/math/prim/mat/fun/to_matrix.hpp
+++ b/stan/math/prim/mat/fun/to_matrix.hpp
@@ -124,7 +124,55 @@ namespace stan {
       y.resize(m, n);
       return y;
     }
-    
+
+    /**
+     * Returns a matrix representation of the vector in column-major
+     * order with the specified number of rows and columns.
+     *
+     * @tparam T type of the scalar
+     * @param x vector of values
+     * @param m rows
+     * @param n columns
+     * @return the matrix representation of the input
+     * @throw <code>std::invalid_argument</code>
+     * if the sizes do not match
+     */
+    template <typename T>
+    inline Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>
+    to_matrix(const std::vector<T>& x, int m, int n) {
+      static const char* fun = "to_matrix(array)";
+      check_size_match(fun, "rows * columns", m * n, "vector size",
+                       x.size());
+      return Eigen::Map<const
+                        Eigen::Matrix<T, Eigen::Dynamic,
+                                      Eigen::Dynamic> >(&x[0], m, n);
+    }
+   
+    /**
+     * Returns a matrix representation of the vector in column-major
+     * order with the specified number of rows and columns.
+     *
+     * @param x vector of values
+     * @param m rows
+     * @param n columns
+     * @return the matrix representation of the input
+     * @throw <code>std::invalid_argument</code>
+     * if the sizes do not match
+     */
+    inline Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>
+    to_matrix(const std::vector<int>& x, int m, int n) {
+      static const char* fun = "to_matrix(array)";
+      int size = x.size();
+      check_size_match(fun, "rows * columns", m * n,
+                       "vector size", size);
+      Eigen::Matrix<double,
+                    Eigen::Dynamic, Eigen::Dynamic> result(m, n);
+      double* datap = result.data();
+      for (int i=0; i < size; i++)
+        datap[i] = x[i];
+      return result;
+    }
+
     /**
      * Returns a matrix representation of the vector in column-major
      * order with the specified number of rows and columns.
@@ -133,6 +181,10 @@ namespace stan {
      * @param x matrix
      * @param m rows
      * @param n columns
+     * @param cm column-major indicator:
+     * if 1, output matrix is transversed in column-major order,
+     * if 0, output matrix is transversed in row-major order,
+     * otherwise function throws std::invalid_argument
      * @return Reshaped inputted matrix
      * @throw <code>std::invalid_argument</code>
      * if the sizes do not match
@@ -168,47 +220,43 @@ namespace stan {
      * @param x vector of values
      * @param m rows
      * @param n columns
+     * @param cm column-major indicator:
+     * if 1, output matrix is transversed in column-major order,
+     * if 0, output matrix is transversed in row-major order,
+     * otherwise function throws std::invalid_argument
      * @return the matrix representation of the input
      * @throw <code>std::invalid_argument</code>
      * if the sizes do not match
      */
     template <typename T>
-    inline Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>
-    to_matrix(const std::vector<T>& x, int m, int n) {
-      static const char* fun = "to_matrix(array)";
-      check_size_match(fun, "rows * columns", m * n, "vector size",
-                       x.size());
-      return Eigen::Map<const
-                        Eigen::Matrix<T, Eigen::Dynamic,
-                                      Eigen::Dynamic> >(&x[0], m, n);
+    inline
+    Eigen::Matrix<typename 
+      boost::math::tools::promote_args<T, double>::type,
+      Eigen::Dynamic, Eigen::Dynamic>
+    to_matrix(const std::vector<T>& x, int m, int n, int cm) {
+      if (cm == 1)
+        return to_matrix(x, m, n);
+      else if (cm == 0) {
+        check_size_match("to_matrix", "rows * columns", m * n,
+                         "matrix size", x.size());
+        Eigen::Matrix<typename
+          boost::math::tools::promote_args<T, double>::type,
+          Eigen::Dynamic, Eigen::Dynamic>
+          result(m, n);
+        for (size_t i=0, ij=0; i < m; i++)
+          for (size_t j=0; j < n; j++, ij++)
+            result(i, j) = x[ij];
+        return result;
+      }
+      else {
+        invalid_argument("to_matrix", "cm", cm,
+                         "column-major indicator",
+                         "must equal 0 or 1");
+        return Eigen::Matrix<typename
+                boost::math::tools::promote_args<T, double>::type,
+                Eigen::Dynamic, Eigen::Dynamic> (0, 0);
+      }
     }
-    
-    /**
-     * Returns a matrix representation of the vector in column-major
-     * order with the specified number of rows and columns.
-     *
-     * @param x vector of values
-     * @param m rows
-     * @param n columns
-     * @return the matrix representation of the input
-     * @throw <code>std::invalid_argument</code>
-     * if the sizes do not match
-     */
-    inline Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>
-    to_matrix(const std::vector<int>& x, int m, int n) {
-      static const char* fun = "to_matrix(array)";
-      int size = x.size();
-      check_size_match(fun, "rows * columns", m * n,
-                       "vector size", size);
-      Eigen::Matrix<double,
-                    Eigen::Dynamic, Eigen::Dynamic> result(m, n);
-      double* datap = result.data();
-      for (int i=0; i < size; i++)
-        datap[i] = x[i];
-      return result;
-    }
-    
-
 
   }
 }

--- a/stan/math/prim/mat/fun/to_matrix.hpp
+++ b/stan/math/prim/mat/fun/to_matrix.hpp
@@ -1,6 +1,9 @@
 #ifndef STAN_MATH_PRIM_MAT_FUN_TO_MATRIX_HPP
 #define STAN_MATH_PRIM_MAT_FUN_TO_MATRIX_HPP
 
+#include <boost/math/tools/promotion.hpp>
+#include <stan/math/prim/scal/err/check_size_match.hpp>
+#include <stan/math/prim/scal/err/invalid_argument.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <Eigen/Dense>
 #include <vector>
@@ -37,13 +40,13 @@ namespace stan {
     inline Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>
     to_matrix(const
               std::vector<Eigen::Matrix<T, 1, Eigen::Dynamic> >& x) {
-      size_t rows = x.size();
+      int rows = x.size();
       if (rows != 0) {
-        size_t cols = x[0].size();
+        int cols = x[0].size();
         Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>
           result(rows, cols);
-        for (size_t i=0, ij=0; i < cols; i++)
-          for (size_t j=0; j < rows; j++, ij++)
+        for (int i=0, ij=0; i < cols; i++)
+          for (int j=0; j < rows; j++, ij++)
             result(ij) = x[j][i];
         return result;
       } else {
@@ -199,8 +202,8 @@ namespace stan {
                          "matrix size", x.size());
         Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>
           result(m, n);
-        for (size_t i=0, ij=0; i < m; i++)
-          for (size_t j=0; j < n; j++, ij++)
+        for (int i=0, ij=0; i < m; i++)
+          for (int j=0; j < n; j++, ij++)
             result(i, j) = x(ij);
         return result;
       } else {
@@ -242,8 +245,8 @@ namespace stan {
           boost::math::tools::promote_args<T, double>::type,
           Eigen::Dynamic, Eigen::Dynamic>
           result(m, n);
-        for (size_t i=0, ij=0; i < m; i++)
-          for (size_t j=0; j < n; j++, ij++)
+        for (int i=0, ij=0; i < m; i++)
+          for (int j=0; j < n; j++, ij++)
             result(i, j) = x[ij];
         return result;
       } else {

--- a/stan/math/prim/mat/fun/to_matrix.hpp
+++ b/stan/math/prim/mat/fun/to_matrix.hpp
@@ -60,38 +60,18 @@ namespace stan {
      * @return the matrix representation of the input
      */
     template <typename T>
-    inline Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>
+    inline Eigen::Matrix<typename
+      boost::math::tools::promote_args<T, double>::type,
+      Eigen::Dynamic, Eigen::Dynamic>
     to_matrix(const std::vector< std::vector<T> >& x) {
+      using boost::math::tools::promote_args;
       size_t rows = x.size();
       if (rows == 0)
-        return Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> (0, 0);
+        return Eigen::Matrix<typename promote_args<T, double>::type,
+                             Eigen::Dynamic, Eigen::Dynamic> (0, 0);
       size_t cols = x[0].size();
-      Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>
-        result(rows, cols);
-      for (size_t i = 0, ij = 0; i < cols; i++)
-        for (size_t j = 0; j < rows; j++, ij++)
-          result(ij) = x[j][i];
-      return result;
-    }
-
-    /**
-     * Returns a matrix representation of a standard vector of
-     * standard vectors of integers with the same dimensions and
-     * indexing order.
-     *
-     * @param x vector of vectors of integer values
-     * @return the matrix representation of the input,
-     * ints promoted to doubles
-     */
-    inline Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>
-    to_matrix(const std::vector< std::vector<int> >& x) {
-      size_t rows = x.size();
-      if (rows == 0)
-        return Eigen::Matrix<double, Eigen::Dynamic,
-                             Eigen::Dynamic> (0, 0);
-      size_t cols = x[0].size();
-      Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>
-        result(rows, cols);
+      Eigen::Matrix<typename promote_args<T, double>::type,
+                    Eigen::Dynamic, Eigen::Dynamic> result(rows, cols);
       for (size_t i = 0, ij = 0; i < cols; i++)
         for (size_t j = 0; j < rows; j++, ij++)
           result(ij) = x[j][i];

--- a/stan/math/prim/mat/fun/to_matrix.hpp
+++ b/stan/math/prim/mat/fun/to_matrix.hpp
@@ -5,15 +5,14 @@
 #include <stan/math/prim/scal/err/check_size_match.hpp>
 #include <stan/math/prim/scal/err/invalid_argument.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
-#include <Eigen/Dense>
 #include <vector>
 
 namespace stan {
   namespace math {
     /**
-     * Returns a matrix with dynamic dimensions constructed from
-     * an Eigen matrix which is either
-     * a row vector, column vector, or matrix.
+     * Returns a matrix with dynamic dimensions constructed from an
+     * Eigen matrix which is either a row vector, column vector,
+     * or matrix.
      * The runtime dimensions will be the same as the input.
      *
      * @tparam T type of the scalar
@@ -41,17 +40,15 @@ namespace stan {
     to_matrix(const
               std::vector<Eigen::Matrix<T, 1, Eigen::Dynamic> >& x) {
       int rows = x.size();
-      if (rows != 0) {
-        int cols = x[0].size();
-        Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>
-          result(rows, cols);
-        for (int i=0, ij=0; i < cols; i++)
-          for (int j=0; j < rows; j++, ij++)
-            result(ij) = x[j][i];
-        return result;
-      } else {
+      if (rows == 0)
         return Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> (0, 0);
-      }
+      int cols = x[0].size();
+      Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>
+        result(rows, cols);
+      for (int i = 0, ij = 0; i < cols; i++)
+        for (int j = 0; j < rows; j++, ij++)
+          result(ij) = x[j][i];
+      return result;
     }
 
     /**
@@ -66,17 +63,15 @@ namespace stan {
     inline Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>
     to_matrix(const std::vector< std::vector<T> >& x) {
       size_t rows = x.size();
-      if (rows != 0) {
-        size_t cols = x[0].size();
-        Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>
-          result(rows, cols);
-        for (size_t i=0, ij=0; i < cols; i++)
-          for (size_t j=0; j < rows; j++, ij++)
-            result(ij) = x[j][i];
-        return result;
-      } else {
+      if (rows == 0)
         return Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> (0, 0);
-      }
+      size_t cols = x[0].size();
+      Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>
+        result(rows, cols);
+      for (size_t i = 0, ij = 0; i < cols; i++)
+        for (size_t j = 0; j < rows; j++, ij++)
+          result(ij) = x[j][i];
+      return result;
     }
 
     /**
@@ -91,18 +86,16 @@ namespace stan {
     inline Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>
     to_matrix(const std::vector< std::vector<int> >& x) {
       size_t rows = x.size();
-      if (rows != 0) {
-        size_t cols = x[0].size();
-        Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>
-          result(rows, cols);
-        for (size_t i=0, ij=0; i < cols; i++)
-          for (size_t j=0; j < rows; j++, ij++)
-            result(ij) = x[j][i];
-        return result;
-      } else {
+      if (rows == 0)
         return Eigen::Matrix<double, Eigen::Dynamic,
                              Eigen::Dynamic> (0, 0);
-      }
+      size_t cols = x[0].size();
+      Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>
+        result(rows, cols);
+      for (size_t i = 0, ij = 0; i < cols; i++)
+        for (size_t j = 0; j < rows; j++, ij++)
+          result(ij) = x[j][i];
+      return result;
     }
 
     /**
@@ -170,9 +163,8 @@ namespace stan {
                        "vector size", size);
       Eigen::Matrix<double,
                     Eigen::Dynamic, Eigen::Dynamic> result(m, n);
-      double* datap = result.data();
-      for (int i=0; i < size; i++)
-        datap[i] = x[i];
+      for (int i = 0; i < size; i++)
+        result(i) = x[i];
       return result;
     }
 
@@ -184,7 +176,7 @@ namespace stan {
      * @param x matrix
      * @param m rows
      * @param n columns
-     * @param cm column-major indicator:
+     * @param col_major column-major indicator:
      * if 1, output matrix is transversed in column-major order,
      * if 0, output matrix is transversed in row-major order,
      * otherwise function throws std::invalid_argument
@@ -194,24 +186,18 @@ namespace stan {
      */
     template <typename T, int R, int C>
     inline Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>
-    to_matrix(const Eigen::Matrix<T, R, C>& x, int m, int n, int cm) {
-      if (cm == 1) {
+    to_matrix(const Eigen::Matrix<T, R, C>& x, int m, int n,
+              bool col_major) {
+      if (col_major)
         return to_matrix(x, m, n);
-      } else if (cm == 0) {
-        check_size_match("to_matrix", "rows * columns", m * n,
-                         "matrix size", x.size());
-        Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>
-          result(m, n);
-        for (int i=0, ij=0; i < m; i++)
-          for (int j=0; j < n; j++, ij++)
-            result(i, j) = x(ij);
-        return result;
-      } else {
-        invalid_argument("to_matrix", "cm", cm,
-                         "column-major indicator",
-                         "must equal 0 or 1");
-        return Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> (0, 0);
-      }
+      check_size_match("to_matrix", "rows * columns", m * n,
+                       "matrix size", x.size());
+      Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>
+        result(m, n);
+      for (int i = 0, ij = 0; i < m; i++)
+        for (int j = 0; j < n; j++, ij++)
+          result(i, j) = x(ij);
+      return result;
     }
 
     /**
@@ -222,7 +208,7 @@ namespace stan {
      * @param x vector of values
      * @param m rows
      * @param n columns
-     * @param cm column-major indicator:
+     * @param col_major column-major indicator:
      * if 1, output matrix is transversed in column-major order,
      * if 0, output matrix is transversed in row-major order,
      * otherwise function throws std::invalid_argument
@@ -235,28 +221,19 @@ namespace stan {
     Eigen::Matrix<typename
       boost::math::tools::promote_args<T, double>::type,
       Eigen::Dynamic, Eigen::Dynamic>
-    to_matrix(const std::vector<T>& x, int m, int n, int cm) {
-      if (cm == 1) {
+    to_matrix(const std::vector<T>& x, int m, int n, bool col_major) {
+      if (col_major)
         return to_matrix(x, m, n);
-      } else if (cm == 0) {
-        check_size_match("to_matrix", "rows * columns", m * n,
-                         "matrix size", x.size());
-        Eigen::Matrix<typename
-          boost::math::tools::promote_args<T, double>::type,
-          Eigen::Dynamic, Eigen::Dynamic>
-          result(m, n);
-        for (int i=0, ij=0; i < m; i++)
-          for (int j=0; j < n; j++, ij++)
-            result(i, j) = x[ij];
-        return result;
-      } else {
-        invalid_argument("to_matrix", "cm", cm,
-                         "column-major indicator",
-                         "must equal 0 or 1");
-        return Eigen::Matrix<typename
-                boost::math::tools::promote_args<T, double>::type,
-                Eigen::Dynamic, Eigen::Dynamic> (0, 0);
-      }
+      check_size_match("to_matrix", "rows * columns", m * n,
+                       "matrix size", x.size());
+      Eigen::Matrix<typename
+        boost::math::tools::promote_args<T, double>::type,
+        Eigen::Dynamic, Eigen::Dynamic>
+        result(m, n);
+      for (int i = 0, ij = 0; i < m; i++)
+        for (int j = 0; j < n; j++, ij++)
+          result(i, j) = x[ij];
+      return result;
     }
 
   }

--- a/stan/math/prim/mat/fun/to_row_vector.hpp
+++ b/stan/math/prim/mat/fun/to_row_vector.hpp
@@ -30,9 +30,8 @@ namespace stan {
     to_row_vector(const std::vector<int> & vec) {
       int C = vec.size();
       Eigen::Matrix<double, 1, Eigen::Dynamic> result(C);
-      double* datap = result.data();
       for (int i=0; i < C; i++)
-        datap[i] = vec[i];
+        result(i) = vec[i];
       return result;
     }
 

--- a/stan/math/prim/mat/fun/to_vector.hpp
+++ b/stan/math/prim/mat/fun/to_vector.hpp
@@ -30,9 +30,8 @@ namespace stan {
     to_vector(const std::vector<int> & vec) {
       int R = vec.size();
       Eigen::Matrix<double, Eigen::Dynamic, 1> result(R);
-      double* datap = result.data();
       for (int i=0; i < R; i++)
-        datap[i] = vec[i];
+        result(i) = vec[i];
       return result;
     }
 

--- a/test/unit/math/prim/mat/fun/to_matrix_test.cpp
+++ b/test/unit/math/prim/mat/fun/to_matrix_test.cpp
@@ -32,7 +32,13 @@ void test_to_matrix_array_answers(int m, int n) {
   for (int i = 0; i < m * n; ++i)
     a(i) = i;
   expect_matrix_eq(a, to_matrix(vec, m, n));
+  expect_matrix_eq(a, to_matrix(vec, m, n, 1));
+  expect_matrix_eq(a, row_major_to_column_major(to_matrix(vec,
+                                                          m, n, 0)));
   expect_matrix_eq(a, to_matrix(vec_int, m, n));
+  expect_matrix_eq(a, to_matrix(vec_int, m, n, 1));
+  expect_matrix_eq(a, row_major_to_column_major(to_matrix(vec_int,
+                                                          m, n, 0)));
 }
 
 TEST(ToMatrixArray, answers) {

--- a/test/unit/math/prim/mat/fun/to_matrix_test.cpp
+++ b/test/unit/math/prim/mat/fun/to_matrix_test.cpp
@@ -11,7 +11,7 @@ void test_to_matrix_array_answers(int m, int n) {
   std::vector<double> vec(m * n);
   for (int i = 0; i < m * n; ++i)
     vec[i] = i;
-  Eigen::MatrixXd a(m, n);
+  Eigen::MatrixXd a(m, n); 
   for (int i = 0; i < m * n; ++i)
     a(i) = i;
   expect_matrix_eq(a, to_matrix(vec, m, n));
@@ -44,6 +44,93 @@ TEST(ToMatrixMatrix, answers) {
   test_to_matrix_matrix_answers(3, 2);
   test_to_matrix_matrix_answers(3, 0);
   test_to_matrix_matrix_answers(0, 3);
+}
+
+// Matrix -> Matrix (with reshape)
+void test_to_matrix_matrix_reshape_answers(int m1, int n1,
+                                           int m2, int n2) {
+  Eigen::MatrixXd a(m1, n1);
+  Eigen::MatrixXd b(m2, n2);
+  for (int i = 0; i < m1 * n1; ++i) {
+    a(i) = static_cast<double>(i)/1.26;
+    b(i) = static_cast<double>(i)/1.26;
+  }
+  expect_matrix_eq(a, to_matrix(b, m1, n1));
+  expect_matrix_eq(b, to_matrix(a, m2, n2));
+  if (n1 != 0)
+    EXPECT_THROW(to_matrix(a, m1+1, n1), std::invalid_argument);
+  if (m1 !=0)
+    EXPECT_THROW(to_matrix(a, m1, n1+1), std::invalid_argument);
+  if (n2 != 0)
+    EXPECT_THROW(to_matrix(a, m2+1, n2), std::invalid_argument);
+  if (m2 !=0)
+    EXPECT_THROW(to_matrix(a, m2, n2+1), std::invalid_argument);
+}
+
+TEST(ToMatrixMatrixReshape, answers) {
+  test_to_matrix_matrix_reshape_answers(0, 0, 0, 0);
+  test_to_matrix_matrix_reshape_answers(3, 2, 2, 3);
+  test_to_matrix_matrix_reshape_answers(3, 2, 6, 1);
+  test_to_matrix_matrix_reshape_answers(3, 0, 0, 3);
+  test_to_matrix_matrix_reshape_answers(8, 2, 4, 4);
+}
+
+// Vector -> Matrix
+void test_to_vector_matrix_answers(int m, int m2, int n2) {
+  Eigen::VectorXd a(m);
+  Eigen::MatrixXd b(m2, n2);
+  Eigen::MatrixXd c(m, 1);
+  for (int i = 0; i < m2 * n2; ++i) {
+    a(i) = static_cast<double>(i)/1.26;
+    b(i) = static_cast<double>(i)/1.26;
+    c(i) = static_cast<double>(i)/1.26;
+  }
+  //without reshape
+  expect_matrix_eq(c, to_matrix(a));
+  
+  //with reshape
+  expect_matrix_eq(b, to_matrix(a, m2, n2));
+  if (n2 != 0)
+    EXPECT_THROW(to_matrix(a, m2+1, n2), std::invalid_argument);
+  if (m2 !=0)
+    EXPECT_THROW(to_matrix(a, m2, n2+1), std::invalid_argument);
+}
+
+TEST(ToMatrixVector, answers) {
+  test_to_vector_matrix_answers(0, 0, 0);
+  test_to_vector_matrix_answers(6, 2, 3);
+  test_to_vector_matrix_answers(18, 6, 3);
+  test_to_vector_matrix_answers(0, 0, 3);
+  test_to_vector_matrix_answers(8, 1, 8);
+}
+
+// RowVector -> Matrix
+void test_to_row_vector_matrix_answers(int n, int m2, int n2) {
+  Eigen::RowVectorXd a(n);
+  Eigen::MatrixXd b(m2, n2);
+  Eigen::MatrixXd c(1, n);
+  for (int i = 0; i < m2 * n2; ++i) {
+    a(i) = static_cast<double>(i)/1.26;
+    b(i) = static_cast<double>(i)/1.26;
+    c(i) = static_cast<double>(i)/1.26;
+  }
+  //without reshape
+  expect_matrix_eq(c, to_matrix(a));
+  
+  //with reshape
+  expect_matrix_eq(b, to_matrix(a, m2, n2));
+  if (n2 != 0)
+    EXPECT_THROW(to_matrix(a, m2+1, n2), std::invalid_argument);
+  if (m2 !=0)
+    EXPECT_THROW(to_matrix(a, m2, n2+1), std::invalid_argument);
+}
+
+TEST(ToMatrixRowVector, answers) {
+  test_to_row_vector_matrix_answers(0, 0, 0);
+  test_to_row_vector_matrix_answers(6, 2, 3);
+  test_to_row_vector_matrix_answers(18, 6, 3);
+  test_to_row_vector_matrix_answers(0, 3, 0);
+  test_to_row_vector_matrix_answers(8, 1, 8);
 }
 
 // [[T]] -> Matrix

--- a/test/unit/math/prim/mat/fun/to_matrix_test.cpp
+++ b/test/unit/math/prim/mat/fun/to_matrix_test.cpp
@@ -33,6 +33,8 @@ void test_to_matrix_array_answers(int m, int n) {
     a(i) = i;
   expect_matrix_eq(a, to_matrix(vec, m, n));
   expect_matrix_eq(a, to_matrix(vec, m, n, 1));
+  expect_matrix_eq(a, to_matrix(vec, m, n, -1));
+  expect_matrix_eq(a, to_matrix(vec, m, n, 2));
   expect_matrix_eq(a, row_major_to_column_major(to_matrix(vec,
                                                           m, n, 0)));
   expect_matrix_eq(a, to_matrix(vec_int, m, n));
@@ -81,6 +83,8 @@ void test_to_matrix_matrix_reshape_answers(int m1, int n1,
   }
   expect_matrix_eq(a, to_matrix(b, m1, n1));
   expect_matrix_eq(a, to_matrix(b, m1, n1, 1));
+  expect_matrix_eq(a, to_matrix(b, m1, n1, -1));
+  expect_matrix_eq(a, to_matrix(b, m1, n1, 2));
   expect_matrix_eq(a,
                    row_major_to_column_major(to_matrix(b, m1, n1, 0)));
   
@@ -88,10 +92,7 @@ void test_to_matrix_matrix_reshape_answers(int m1, int n1,
   expect_matrix_eq(b, to_matrix(a, m2, n2, 1));
   expect_matrix_eq(b,
                    row_major_to_column_major(to_matrix(a, m2, n2, 0)));
-  
-  EXPECT_THROW(to_matrix(a, m1, n1, 2), std::invalid_argument);
-  EXPECT_THROW(to_matrix(a, m1, n1, -1), std::invalid_argument);
-  
+    
   if (n1 != 0) {
     EXPECT_THROW(to_matrix(a, m1+1, n1), std::invalid_argument);
     EXPECT_THROW(to_matrix(a, m1+1, n1, 1), std::invalid_argument);
@@ -138,11 +139,10 @@ void test_to_vector_matrix_answers(int m, int m2, int n2) {
   //with reshape
   expect_matrix_eq(b, to_matrix(a, m2, n2));
   expect_matrix_eq(b, to_matrix(a, m2, n2, 1));
+  expect_matrix_eq(b, to_matrix(a, m2, n2, -1));
+  expect_matrix_eq(b, to_matrix(a, m2, n2, 2));
   expect_matrix_eq(b,
                    row_major_to_column_major(to_matrix(a, m2, n2, 0)));
-
-  EXPECT_THROW(to_matrix(a, m2, n2, 2), std::invalid_argument);
-  EXPECT_THROW(to_matrix(a, m2, n2, -1), std::invalid_argument);
 
   if (n2 != 0) {
     EXPECT_THROW(to_matrix(a, m2+1, n2), std::invalid_argument);
@@ -180,11 +180,10 @@ void test_to_row_vector_matrix_answers(int n, int m2, int n2) {
   //with reshape
   expect_matrix_eq(b, to_matrix(a, m2, n2));
   expect_matrix_eq(b, to_matrix(a, m2, n2, 1));
+  expect_matrix_eq(b, to_matrix(a, m2, n2, -1));
+  expect_matrix_eq(b, to_matrix(a, m2, n2, 2));
   expect_matrix_eq(b,
                    row_major_to_column_major(to_matrix(a, m2, n2, 0)));
-
-  EXPECT_THROW(to_matrix(a, m2, n2, 2), std::invalid_argument);
-  EXPECT_THROW(to_matrix(a, m2, n2, -1), std::invalid_argument);
 
   if (n2 != 0) {
     EXPECT_THROW(to_matrix(a, m2+1, n2), std::invalid_argument);

--- a/test/unit/math/prim/mat/fun/to_matrix_test.cpp
+++ b/test/unit/math/prim/mat/fun/to_matrix_test.cpp
@@ -208,16 +208,19 @@ TEST(ToMatrixRowVector, answers) {
 // [[T]] -> Matrix
 void test_to_matrix_2darray_answers(int m, int n) {
   std::vector<std::vector<double> > vec(m, std::vector<double>(n));
+  std::vector<std::vector<int> > vec_int(m, std::vector<int>(n));
   if (m == 0) n = 0; // Any vec (0, C) will become (0, 0)
   Eigen::MatrixXd a(m, n);
 
   for (int i = 0; i < m; ++i) {
     for (int j = 0; j < n; ++j) {
       vec[i][j] = i * j;
+      vec_int[i][j] = i * j;
       a(i, j) = i * j;
     }
   }
   expect_matrix_eq(a, to_matrix(vec));
+  expect_matrix_eq(a, to_matrix(vec_int));
 }
 
 TEST(ToMatrix2dArray, answers) {
@@ -225,26 +228,4 @@ TEST(ToMatrix2dArray, answers) {
   test_to_matrix_2darray_answers(3, 2);
   test_to_matrix_2darray_answers(3, 0);
   test_to_matrix_2darray_answers(0, 3);
-}
-
-// [[int]] -> Matrix
-void test_to_matrix_2d_int_array_answers(int m, int n) {
-  std::vector<std::vector<int> > vec(m, std::vector<int>(n));
-  if (m == 0) n = 0; // Any vec (0, C) will become (0, 0)
-  Eigen::MatrixXd a(m, n);
-
-  for (int i = 0; i < m; ++i) {
-    for (int j = 0; j < n; ++j) {
-      vec[i][j] = i * j;
-      a(i, j) = i * j;
-    }
-  }
-  expect_matrix_eq(a, to_matrix(vec));
-}
-
-TEST(ToMatrix2dIntArray, answers) {
-  test_to_matrix_2d_int_array_answers(0, 0);
-  test_to_matrix_2d_int_array_answers(3, 2);
-  test_to_matrix_2d_int_array_answers(3, 0);
-  test_to_matrix_2d_int_array_answers(0, 3);
 }

--- a/test/unit/math/prim/mat/fun/to_matrix_test.cpp
+++ b/test/unit/math/prim/mat/fun/to_matrix_test.cpp
@@ -6,6 +6,20 @@
 
 using stan::math::to_matrix;
 
+template <typename T, int R, int C>
+inline Eigen::Matrix<T, R, C>
+row_major_to_column_major(const Eigen::Matrix<T, R, C>& x) {
+  int rows = x.rows();
+  int cols = x.cols();
+  Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>
+    result(rows, cols);
+  for (int i=0, ij=0; i < rows; i++)
+    for (int j=0; j < cols; j++, ij++)
+      result(ij) = x(i, j);
+  return result;
+}
+
+
 // [T] -> Matrix
 void test_to_matrix_array_answers(int m, int n) {
   std::vector<double> vec(m * n);
@@ -60,15 +74,38 @@ void test_to_matrix_matrix_reshape_answers(int m1, int n1,
     b(i) = static_cast<double>(i)/1.26;
   }
   expect_matrix_eq(a, to_matrix(b, m1, n1));
+  expect_matrix_eq(a, to_matrix(b, m1, n1, 1));
+  expect_matrix_eq(a,
+                   row_major_to_column_major(to_matrix(b, m1, n1, 0)));
+  
   expect_matrix_eq(b, to_matrix(a, m2, n2));
-  if (n1 != 0)
+  expect_matrix_eq(b, to_matrix(a, m2, n2, 1));
+  expect_matrix_eq(b,
+                   row_major_to_column_major(to_matrix(a, m2, n2, 0)));
+  
+  EXPECT_THROW(to_matrix(a, m1, n1, 2), std::invalid_argument);
+  EXPECT_THROW(to_matrix(a, m1, n1, -1), std::invalid_argument);
+  
+  if (n1 != 0) {
     EXPECT_THROW(to_matrix(a, m1+1, n1), std::invalid_argument);
-  if (m1 !=0)
+    EXPECT_THROW(to_matrix(a, m1+1, n1, 1), std::invalid_argument);
+    EXPECT_THROW(to_matrix(a, m1+1, n1, 0), std::invalid_argument);
+  }
+  if (m1 !=0) {
     EXPECT_THROW(to_matrix(a, m1, n1+1), std::invalid_argument);
-  if (n2 != 0)
+    EXPECT_THROW(to_matrix(a, m1, n1+1, 1), std::invalid_argument);
+    EXPECT_THROW(to_matrix(a, m1, n1+1, 0), std::invalid_argument);
+  }
+  if (n2 != 0) {
     EXPECT_THROW(to_matrix(a, m2+1, n2), std::invalid_argument);
-  if (m2 !=0)
+    EXPECT_THROW(to_matrix(a, m2+1, n2, 1), std::invalid_argument);
+    EXPECT_THROW(to_matrix(a, m2+1, n2, 0), std::invalid_argument);
+  }
+  if (m2 !=0) {
     EXPECT_THROW(to_matrix(a, m2, n2+1), std::invalid_argument);
+    EXPECT_THROW(to_matrix(a, m2, n2+1, 1), std::invalid_argument);
+    EXPECT_THROW(to_matrix(a, m2, n2+1, 0), std::invalid_argument);
+  }
 }
 
 TEST(ToMatrixMatrixReshape, answers) {
@@ -94,10 +131,23 @@ void test_to_vector_matrix_answers(int m, int m2, int n2) {
   
   //with reshape
   expect_matrix_eq(b, to_matrix(a, m2, n2));
-  if (n2 != 0)
+  expect_matrix_eq(b, to_matrix(a, m2, n2, 1));
+  expect_matrix_eq(b,
+                   row_major_to_column_major(to_matrix(a, m2, n2, 0)));
+
+  EXPECT_THROW(to_matrix(a, m2, n2, 2), std::invalid_argument);
+  EXPECT_THROW(to_matrix(a, m2, n2, -1), std::invalid_argument);
+
+  if (n2 != 0) {
     EXPECT_THROW(to_matrix(a, m2+1, n2), std::invalid_argument);
-  if (m2 !=0)
+    EXPECT_THROW(to_matrix(a, m2+1, n2, 1), std::invalid_argument);
+    EXPECT_THROW(to_matrix(a, m2+1, n2, 0), std::invalid_argument);
+  }
+  if (m2 !=0) {
     EXPECT_THROW(to_matrix(a, m2, n2+1), std::invalid_argument);
+    EXPECT_THROW(to_matrix(a, m2, n2+1, 1), std::invalid_argument);
+    EXPECT_THROW(to_matrix(a, m2, n2+1, 0), std::invalid_argument);
+  }
 }
 
 TEST(ToMatrixVector, answers) {
@@ -123,10 +173,23 @@ void test_to_row_vector_matrix_answers(int n, int m2, int n2) {
   
   //with reshape
   expect_matrix_eq(b, to_matrix(a, m2, n2));
-  if (n2 != 0)
+  expect_matrix_eq(b, to_matrix(a, m2, n2, 1));
+  expect_matrix_eq(b,
+                   row_major_to_column_major(to_matrix(a, m2, n2, 0)));
+
+  EXPECT_THROW(to_matrix(a, m2, n2, 2), std::invalid_argument);
+  EXPECT_THROW(to_matrix(a, m2, n2, -1), std::invalid_argument);
+
+  if (n2 != 0) {
     EXPECT_THROW(to_matrix(a, m2+1, n2), std::invalid_argument);
-  if (m2 !=0)
+    EXPECT_THROW(to_matrix(a, m2+1, n2, 1), std::invalid_argument);
+    EXPECT_THROW(to_matrix(a, m2+1, n2, 0), std::invalid_argument);
+  }
+  if (m2 !=0) {
     EXPECT_THROW(to_matrix(a, m2, n2+1), std::invalid_argument);
+    EXPECT_THROW(to_matrix(a, m2, n2+1, 1), std::invalid_argument);
+    EXPECT_THROW(to_matrix(a, m2, n2+1, 0), std::invalid_argument);
+  }
 }
 
 TEST(ToMatrixRowVector, answers) {

--- a/test/unit/math/prim/mat/fun/to_matrix_test.cpp
+++ b/test/unit/math/prim/mat/fun/to_matrix_test.cpp
@@ -9,12 +9,16 @@ using stan::math::to_matrix;
 // [T] -> Matrix
 void test_to_matrix_array_answers(int m, int n) {
   std::vector<double> vec(m * n);
-  for (int i = 0; i < m * n; ++i)
+  std::vector<int> vec_int(m * n);
+  for (int i = 0; i < m * n; ++i) {
     vec[i] = i;
+    vec_int[i] = i;
+  }
   Eigen::MatrixXd a(m, n); 
   for (int i = 0; i < m * n; ++i)
     a(i) = i;
   expect_matrix_eq(a, to_matrix(vec, m, n));
+  expect_matrix_eq(a, to_matrix(vec_int, m, n));
 }
 
 TEST(ToMatrixArray, answers) {

--- a/test/unit/math/prim/mat/fun/to_matrix_test.cpp
+++ b/test/unit/math/prim/mat/fun/to_matrix_test.cpp
@@ -13,8 +13,8 @@ row_major_to_column_major(const Eigen::Matrix<T, R, C>& x) {
   int cols = x.cols();
   Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>
     result(rows, cols);
-  for (int i=0, ij=0; i < rows; i++)
-    for (int j=0; j < cols; j++, ij++)
+  for (int i = 0, ij = 0; i < rows; i++)
+    for (int j = 0; j < cols; j++, ij++)
       result(ij) = x(i, j);
   return result;
 }
@@ -94,24 +94,24 @@ void test_to_matrix_matrix_reshape_answers(int m1, int n1,
                    row_major_to_column_major(to_matrix(a, m2, n2, 0)));
     
   if (n1 != 0) {
-    EXPECT_THROW(to_matrix(a, m1+1, n1), std::invalid_argument);
-    EXPECT_THROW(to_matrix(a, m1+1, n1, 1), std::invalid_argument);
-    EXPECT_THROW(to_matrix(a, m1+1, n1, 0), std::invalid_argument);
+    EXPECT_THROW(to_matrix(a, m1 + 1, n1), std::invalid_argument);
+    EXPECT_THROW(to_matrix(a, m1 + 1, n1, 1), std::invalid_argument);
+    EXPECT_THROW(to_matrix(a, m1 + 1, n1, 0), std::invalid_argument);
   }
-  if (m1 !=0) {
-    EXPECT_THROW(to_matrix(a, m1, n1+1), std::invalid_argument);
-    EXPECT_THROW(to_matrix(a, m1, n1+1, 1), std::invalid_argument);
-    EXPECT_THROW(to_matrix(a, m1, n1+1, 0), std::invalid_argument);
+  if (m1 != 0) {
+    EXPECT_THROW(to_matrix(a, m1, n1 + 1), std::invalid_argument);
+    EXPECT_THROW(to_matrix(a, m1, n1 + 1, 1), std::invalid_argument);
+    EXPECT_THROW(to_matrix(a, m1, n1 + 1, 0), std::invalid_argument);
   }
   if (n2 != 0) {
-    EXPECT_THROW(to_matrix(a, m2+1, n2), std::invalid_argument);
-    EXPECT_THROW(to_matrix(a, m2+1, n2, 1), std::invalid_argument);
-    EXPECT_THROW(to_matrix(a, m2+1, n2, 0), std::invalid_argument);
+    EXPECT_THROW(to_matrix(a, m2 + 1, n2), std::invalid_argument);
+    EXPECT_THROW(to_matrix(a, m2 + 1, n2, 1), std::invalid_argument);
+    EXPECT_THROW(to_matrix(a, m2 + 1, n2, 0), std::invalid_argument);
   }
-  if (m2 !=0) {
-    EXPECT_THROW(to_matrix(a, m2, n2+1), std::invalid_argument);
-    EXPECT_THROW(to_matrix(a, m2, n2+1, 1), std::invalid_argument);
-    EXPECT_THROW(to_matrix(a, m2, n2+1, 0), std::invalid_argument);
+  if (m2 != 0) {
+    EXPECT_THROW(to_matrix(a, m2, n2 + 1), std::invalid_argument);
+    EXPECT_THROW(to_matrix(a, m2, n2 + 1, 1), std::invalid_argument);
+    EXPECT_THROW(to_matrix(a, m2, n2 + 1, 0), std::invalid_argument);
   }
 }
 
@@ -145,14 +145,14 @@ void test_to_vector_matrix_answers(int m, int m2, int n2) {
                    row_major_to_column_major(to_matrix(a, m2, n2, 0)));
 
   if (n2 != 0) {
-    EXPECT_THROW(to_matrix(a, m2+1, n2), std::invalid_argument);
-    EXPECT_THROW(to_matrix(a, m2+1, n2, 1), std::invalid_argument);
-    EXPECT_THROW(to_matrix(a, m2+1, n2, 0), std::invalid_argument);
+    EXPECT_THROW(to_matrix(a, m2 + 1, n2), std::invalid_argument);
+    EXPECT_THROW(to_matrix(a, m2 + 1, n2, 1), std::invalid_argument);
+    EXPECT_THROW(to_matrix(a, m2 + 1, n2, 0), std::invalid_argument);
   }
   if (m2 !=0) {
-    EXPECT_THROW(to_matrix(a, m2, n2+1), std::invalid_argument);
-    EXPECT_THROW(to_matrix(a, m2, n2+1, 1), std::invalid_argument);
-    EXPECT_THROW(to_matrix(a, m2, n2+1, 0), std::invalid_argument);
+    EXPECT_THROW(to_matrix(a, m2, n2 + 1), std::invalid_argument);
+    EXPECT_THROW(to_matrix(a, m2, n2 + 1, 1), std::invalid_argument);
+    EXPECT_THROW(to_matrix(a, m2, n2 + 1, 0), std::invalid_argument);
   }
 }
 
@@ -186,14 +186,14 @@ void test_to_row_vector_matrix_answers(int n, int m2, int n2) {
                    row_major_to_column_major(to_matrix(a, m2, n2, 0)));
 
   if (n2 != 0) {
-    EXPECT_THROW(to_matrix(a, m2+1, n2), std::invalid_argument);
-    EXPECT_THROW(to_matrix(a, m2+1, n2, 1), std::invalid_argument);
-    EXPECT_THROW(to_matrix(a, m2+1, n2, 0), std::invalid_argument);
+    EXPECT_THROW(to_matrix(a, m2 + 1, n2), std::invalid_argument);
+    EXPECT_THROW(to_matrix(a, m2 + 1, n2, 1), std::invalid_argument);
+    EXPECT_THROW(to_matrix(a, m2 + 1, n2, 0), std::invalid_argument);
   }
   if (m2 !=0) {
-    EXPECT_THROW(to_matrix(a, m2, n2+1), std::invalid_argument);
-    EXPECT_THROW(to_matrix(a, m2, n2+1, 1), std::invalid_argument);
-    EXPECT_THROW(to_matrix(a, m2, n2+1, 0), std::invalid_argument);
+    EXPECT_THROW(to_matrix(a, m2, n2 + 1), std::invalid_argument);
+    EXPECT_THROW(to_matrix(a, m2, n2 + 1, 1), std::invalid_argument);
+    EXPECT_THROW(to_matrix(a, m2, n2 + 1, 0), std::invalid_argument);
   }
 }
 


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py test/unit/math/prim/mat/fun/to_matrix_test.cpp` (hope it suffices)
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary:
Fix issue #507

Implemented a bunch of new to_matrix functions

- `to_matrix(matrix, int, int)`
- `to_matrix(vector, int, int)`
- `to_matrix(row_vector, int, int)`
- `to_matrix(int[], int, int)`
- `to_matrix(matrix, int, int, int)`
- `to_matrix(vector, int, int, int)`
- `to_matrix(row_vector, int, int, int)`
- `to_matrix(real[], int, int, int)`
- `to_matrix(int[], int, int, int)`

#### Intended Effect:
Make users life easier.

#### How to Verify:
Unit tests included.

#### Side Effects:
Almost none other than users (and me) starting to get confused with this bunch of function signatures.

#### Documentation:
Included.

#### Reviewer Suggestions: 
Anyone

#### Copyright and Licensing
Marco Inacio

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
