### PR TITLE
Feature/issue 512 speedup ode

### DIFF
--- a/stan/math/prim/arr/functor/coupled_ode_system.hpp
+++ b/stan/math/prim/arr/functor/coupled_ode_system.hpp
@@ -94,7 +94,7 @@ namespace stan {
        */
       void operator()(const std::vector<double>& y,
                       std::vector<double>& dy_dt,
-                      double t) {
+                      double t) const {
         dy_dt = f_(t, y, theta_dbl_, x_, x_int_, msgs_);
         check_size_match("coupled_ode_system",
                          "y", y.size(),
@@ -122,7 +122,7 @@ namespace stan {
        *
        * @return initial state of the coupled system
        */
-      std::vector<double> initial_state() {
+      std::vector<double> initial_state() const {
         std::vector<double> state(size_, 0.0);
         for (size_t n = 0; n < N_; n++)
           state[n] = y0_dbl_[n];
@@ -140,7 +140,7 @@ namespace stan {
        * @return the decoupled states
        */
       std::vector<std::vector<double> >
-      decouple_states(const std::vector<std::vector<double> >& y) {
+      decouple_states(const std::vector<std::vector<double> >& y) const {
         return y;
       }
     };

--- a/stan/math/prim/arr/functor/integrate_ode_rk45.hpp
+++ b/stan/math/prim/arr/functor/integrate_ode_rk45.hpp
@@ -127,7 +127,7 @@ namespace stan {
                                                            double,
                                                            std::vector<double>,
                                                            double>() ),
-                      coupled_system,
+                      boost::ref(coupled_system),
                       initial_coupled_state,
                       boost::begin(ts_vec), boost::end(ts_vec),
                       step_size,

--- a/stan/math/rev/arr/functor/coupled_ode_system.hpp
+++ b/stan/math/rev/arr/functor/coupled_ode_system.hpp
@@ -122,12 +122,6 @@ namespace stan {
                       double t) const {
         using std::vector;
 
-        vector<double> y(z.begin(), z.begin() + N_);
-        dz_dt = f_(t, y, theta_dbl_, x_, x_int_, msgs_);
-        check_size_match("coupled_ode_system", "dz_dt", dz_dt.size(),
-                         "states", N_);
-
-        vector<double> coupled_sys(N_ * M_);
         vector<double> grad(N_ + M_);
 
         try {
@@ -136,7 +130,7 @@ namespace stan {
           vector<var> z_vars;
           z_vars.reserve(N_ + M_);
 
-          vector<var> y_vars(y.begin(), y.end());
+          vector<var> y_vars(z.begin(), z.begin() + N_);
           z_vars.insert(z_vars.end(), y_vars.begin(), y_vars.end());
 
           vector<var> theta_vars(theta_dbl_.begin(), theta_dbl_.end());
@@ -144,7 +138,11 @@ namespace stan {
 
           vector<var> dy_dt_vars = f_(t, y_vars, theta_vars, x_, x_int_, msgs_);
 
+          check_size_match("coupled_ode_system", "dz_dt", dy_dt_vars.size(),
+                           "states", N_);
+
           for (size_t i = 0; i < N_; i++) {
+            dz_dt[i] = dy_dt_vars[i].val();
             set_zero_all_adjoints_nested();
             dy_dt_vars[i].grad(z_vars, grad);
 
@@ -156,7 +154,7 @@ namespace stan {
               for (size_t k = 0; k < N_; k++)
                 temp_deriv += z[N_ + N_ * j + k] * grad[k];
 
-              coupled_sys[i + j * N_] = temp_deriv;
+              dz_dt[N_ + i + j * N_] = temp_deriv;
             }
           }
         } catch (const std::exception& e) {
@@ -164,8 +162,6 @@ namespace stan {
           throw;
         }
         recover_memory_nested();
-
-        dz_dt.insert(dz_dt.end(), coupled_sys.begin(), coupled_sys.end());
       }
 
       /**
@@ -320,11 +316,6 @@ namespace stan {
         for (size_t n = 0; n < N_; n++)
           y[n] += y0_dbl_[n];
 
-        dz_dt = f_(t, y, theta_dbl_, x_, x_int_, msgs_);
-        check_size_match("coupled_ode_system", "dz_dt", dz_dt.size(),
-                         "states", N_);
-
-        std::vector<double> coupled_sys(N_ * N_);
         std::vector<double> grad(N_);
 
         try {
@@ -338,7 +329,11 @@ namespace stan {
 
           vector<var> dy_dt_vars = f_(t, y_vars, theta_dbl_, x_, x_int_, msgs_);
 
+          check_size_match("coupled_ode_system", "dz_dt", dy_dt_vars.size(),
+                           "states", N_);
+
           for (size_t i = 0; i < N_; i++) {
+            dz_dt[i] = dy_dt_vars[i].val();
             set_zero_all_adjoints_nested();
             dy_dt_vars[i].grad(z_vars, grad);
 
@@ -350,7 +345,7 @@ namespace stan {
               for (size_t k = 0; k < N_; k++)
                 temp_deriv += z[N_ + N_ * j + k] * grad[k];
 
-              coupled_sys[i + j * N_] = temp_deriv;
+              dz_dt[N_ + i + j * N_] = temp_deriv;
             }
           }
         } catch (const std::exception& e) {
@@ -358,8 +353,6 @@ namespace stan {
           throw;
         }
         recover_memory_nested();
-
-        dz_dt.insert(dz_dt.end(), coupled_sys.begin(), coupled_sys.end());
       }
 
       /**
@@ -528,11 +521,6 @@ namespace stan {
         for (size_t n = 0; n < N_; n++)
           y[n] += y0_dbl_[n];
 
-        dz_dt = f_(t, y, theta_dbl_, x_, x_int_, msgs_);
-        check_size_match("coupled_ode_system", "dz_dt", dz_dt.size(),
-                         "states", N_);
-
-        vector<double> coupled_sys(N_ * (N_ + M_));
         vector<double> grad(N_ + M_);
 
         try {
@@ -549,7 +537,11 @@ namespace stan {
 
           vector<var> dy_dt_vars = f_(t, y_vars, theta_vars, x_, x_int_, msgs_);
 
+          check_size_match("coupled_ode_system", "dz_dt", dy_dt_vars.size(),
+                           "states", N_);
+
           for (size_t i = 0; i < N_; i++) {
+            dz_dt[i] = dy_dt_vars[i].val();
             set_zero_all_adjoints_nested();
             dy_dt_vars[i].grad(z_vars, grad);
 
@@ -561,7 +553,7 @@ namespace stan {
               for (size_t k = 0; k < N_; k++)
                 temp_deriv += z[N_ + N_ * j + k] * grad[k];
 
-              coupled_sys[i + j * N_] = temp_deriv;
+              dz_dt[N_ + i + j * N_] = temp_deriv;
             }
           }
         } catch (const std::exception& e) {
@@ -569,8 +561,6 @@ namespace stan {
           throw;
         }
         recover_memory_nested();
-
-        dz_dt.insert(dz_dt.end(), coupled_sys.begin(), coupled_sys.end());
       }
 
       /**

--- a/stan/math/rev/arr/functor/coupled_ode_system.hpp
+++ b/stan/math/rev/arr/functor/coupled_ode_system.hpp
@@ -4,9 +4,9 @@
 #include <stan/math/prim/arr/meta/get.hpp>
 #include <stan/math/prim/arr/meta/length.hpp>
 #include <stan/math/prim/arr/functor/coupled_ode_system.hpp>
+#include <stan/math/prim/arr/fun/value_of.hpp>
 #include <stan/math/prim/scal/err/check_size_match.hpp>
 #include <stan/math/rev/scal/fun/value_of_rec.hpp>
-#include <stan/math/rev/scal/fun/value_of.hpp>
 #include <stan/math/rev/core.hpp>
 #include <ostream>
 #include <stdexcept>
@@ -63,7 +63,7 @@ namespace stan {
       const F& f_;
       const std::vector<double>& y0_dbl_;
       const std::vector<var>& theta_;
-      std::vector<double> theta_dbl_;
+      const std::vector<double> theta_dbl_;
       const std::vector<double>& x_;
       const std::vector<int>& x_int_;
       const size_t N_;
@@ -92,16 +92,13 @@ namespace stan {
         : f_(f),
           y0_dbl_(y0),
           theta_(theta),
-          theta_dbl_(theta.size(), 0.0),
+          theta_dbl_(value_of(theta)),
           x_(x),
           x_int_(x_int),
           N_(y0.size()),
           M_(theta.size()),
           size_(N_ + N_ * M_),
-          msgs_(msgs) {
-        for (size_t m = 0; m < M_; m++)
-          theta_dbl_[m] = value_of(theta[m]);
-      }
+          msgs_(msgs) {}
 
       /**
        * Assign the derivative vector with the system derivatives at
@@ -122,7 +119,7 @@ namespace stan {
        */
       void operator()(const std::vector<double>& z,
                       std::vector<double>& dz_dt,
-                      double t) {
+                      double t) const {
         using std::vector;
 
         vector<double> y(z.begin(), z.begin() + N_);
@@ -193,7 +190,7 @@ namespace stan {
        *
        * @return the initial condition of the coupled system.
        */
-      std::vector<double> initial_state() {
+      std::vector<double> initial_state() const {
         std::vector<double> state(size_, 0.0);
         for (size_t n = 0; n < N_; n++)
           state[n] = y0_dbl_[n];
@@ -207,7 +204,7 @@ namespace stan {
        * @param y coupled states after solving the ode
        */
       std::vector<std::vector<var> >
-      decouple_states(const std::vector<std::vector<double> >& y) {
+      decouple_states(const std::vector<std::vector<double> >& y) const {
         std::vector<var> temp_vars(N_);
         std::vector<double> temp_gradients(M_);
         std::vector<std::vector<var> > y_return(y.size());
@@ -259,7 +256,7 @@ namespace stan {
     struct coupled_ode_system <F, var, double> {
       const F& f_;
       const std::vector<var>& y0_;
-      std::vector<double> y0_dbl_;
+      const std::vector<double> y0_dbl_;
       const std::vector<double>& theta_dbl_;
       const std::vector<double>& x_;
       const std::vector<int>& x_int_;
@@ -289,17 +286,14 @@ namespace stan {
                          std::ostream* msgs)
         : f_(f),
           y0_(y0),
-          y0_dbl_(y0.size(), 0.0),
+          y0_dbl_(value_of(y0)),
           theta_dbl_(theta),
           x_(x),
           x_int_(x_int),
           msgs_(msgs),
           N_(y0.size()),
           M_(theta.size()),
-          size_(N_ + N_ * N_) {
-        for (size_t n = 0; n < N_; n++)
-          y0_dbl_[n] = value_of(y0_[n]);
-      }
+          size_(N_ + N_ * N_) {}
 
       /**
        * Calculates the derivative of the coupled ode system
@@ -319,7 +313,7 @@ namespace stan {
        */
       void operator()(const std::vector<double>& z,
                       std::vector<double>& dz_dt,
-                      double t) {
+                      double t) const {
         using std::vector;
 
         std::vector<double> y(z.begin(), z.begin() + N_);
@@ -391,7 +385,7 @@ namespace stan {
        *   This is a vector of length size() where all elements
        *   are 0.
        */
-      std::vector<double> initial_state() {
+      std::vector<double> initial_state() const {
         return std::vector<double>(size_, 0.0);
       }
 
@@ -403,7 +397,7 @@ namespace stan {
        * @param y the vector of the coupled states after solving the ode
        */
       std::vector<std::vector<var> >
-      decouple_states(const std::vector<std::vector<double> >& y) {
+      decouple_states(const std::vector<std::vector<double> >& y) const {
         using std::vector;
 
         vector<var> temp_vars(N_);
@@ -468,9 +462,9 @@ namespace stan {
     struct coupled_ode_system <F, var, stan::math::var> {
       const F& f_;
       const std::vector<var>& y0_;
-      std::vector<double> y0_dbl_;
+      const std::vector<double> y0_dbl_;
       const std::vector<var>& theta_;
-      std::vector<double> theta_dbl_;
+      const std::vector<double> theta_dbl_;
       const std::vector<double>& x_;
       const std::vector<int>& x_int_;
       const size_t N_;
@@ -499,21 +493,15 @@ namespace stan {
                          std::ostream* msgs)
         : f_(f),
           y0_(y0),
-          y0_dbl_(y0.size(), 0.0),
+          y0_dbl_(value_of(y0)),
           theta_(theta),
-          theta_dbl_(theta.size(), 0.0),
+          theta_dbl_(value_of(theta)),
           x_(x),
           x_int_(x_int),
           N_(y0.size()),
           M_(theta.size()),
           size_(N_ + N_ * (N_ + M_)),
-          msgs_(msgs) {
-        for (size_t n = 0; n < N_; n++)
-          y0_dbl_[n] = value_of(y0[n]);
-
-        for (size_t m = 0; m < M_; m++)
-          theta_dbl_[m] = value_of(theta[m]);
-      }
+          msgs_(msgs) {}
 
       /**
        * Populates the derivative vector with derivatives of the
@@ -533,7 +521,7 @@ namespace stan {
        */
       void operator()(const std::vector<double>& z,
                       std::vector<double>& dz_dt,
-                      double t) {
+                      double t) const {
         using std::vector;
 
         vector<double> y(z.begin(), z.begin() + N_);
@@ -605,7 +593,7 @@ namespace stan {
        * @return the initial condition of the coupled system.  This is
        * a vector of length size() where all elements are 0.
        */
-      std::vector<double> initial_state() {
+      std::vector<double> initial_state() const {
         return std::vector<double>(size_, 0.0);
       }
 
@@ -617,7 +605,7 @@ namespace stan {
        * @param y the vector of the coupled states after solving the ode
        */
       std::vector<std::vector<var> >
-      decouple_states(const std::vector<std::vector<double> >& y) {
+      decouple_states(const std::vector<std::vector<double> >& y) const {
         using std::vector;
 
         vector<var> vars = y0_;

--- a/test/unit/math/rev/arr/functor/coupled_ode_system_test.cpp
+++ b/test/unit/math/rev/arr/functor/coupled_ode_system_test.cpp
@@ -25,7 +25,7 @@ TEST_F(StanAgradRevOde, coupled_ode_system_dv) {
   std::vector<double> coupled_y0;
   std::vector<double> y0;
   double t0;
-  std::vector<double> dy_dt;
+  std::vector<double> dy_dt(4, 0);
 
   double gamma(0.15);
   t0 = 0;
@@ -146,7 +146,7 @@ TEST_F(StanAgradRevOde, memory_recovery_dv) {
     coupled_system_dv(base_ode, y0_d, theta_v, x, x_int, &msgs);
 
   std::vector<double> y(3,0);
-  std::vector<double> dy_dt(3,0);
+  std::vector<double> dy_dt(3 + N * M,0);
   double t = 10;
   
   EXPECT_TRUE(stan::math::empty_nested());
@@ -174,7 +174,7 @@ TEST_F(StanAgradRevOde, memory_recovery_exception_dv) {
       coupled_system_dv(throwing_ode, y0_d, theta_v, x, x_int, &msgs);
     
     std::vector<double> y(3,0);
-    std::vector<double> dy_dt(3,0);
+    std::vector<double> dy_dt(3 + N * M,0);
     double t = 10;
     
     EXPECT_TRUE(stan::math::empty_nested());
@@ -197,7 +197,7 @@ TEST_F(StanAgradRevOde, coupled_ode_system_vd) {
   std::vector<stan::math::var> y0_var;
   std::vector<double> y0_adj;
   double t0;
-  std::vector<double> dy_dt;
+  std::vector<double> dy_dt(6, 0);
 
   double gamma(0.15);
   t0 = 0;
@@ -324,7 +324,7 @@ TEST_F(StanAgradRevOde, memory_recovery_vd) {
     coupled_system_vd(base_ode, y0_v, theta_d, x, x_int, &msgs);
 
   std::vector<double> y(3,0);
-  std::vector<double> dy_dt(3,0);
+  std::vector<double> dy_dt(3 + N * N,0);
   double t = 10;
   
   EXPECT_TRUE(stan::math::empty_nested());
@@ -352,7 +352,7 @@ TEST_F(StanAgradRevOde, memory_recovery_exception_vd) {
       coupled_system_vd(throwing_ode, y0_v, theta_d, x, x_int, &msgs);
     
     std::vector<double> y(3,0);
-    std::vector<double> dy_dt(3,0);
+    std::vector<double> dy_dt(3 + N * N,0);
     double t = 10;
     
     EXPECT_TRUE(stan::math::empty_nested());
@@ -385,7 +385,7 @@ TEST_F(StanAgradRevOde, coupled_ode_system_vv) {
   double t0; 
   t0 = 0;
 
-  std::vector<double> dy_dt;
+  std::vector<double> dy_dt(2 + 2 * 2 + 2 * 1);
   system(coupled_y0, dy_dt, t0);
 
   std::vector<double> y0_double(2);
@@ -503,7 +503,7 @@ TEST_F(StanAgradRevOde, memory_recovery_vv) {
     coupled_system_vv(base_ode, y0_v, theta_v, x, x_int, &msgs);
 
   std::vector<double> y(3,0);
-  std::vector<double> dy_dt(3,0);
+  std::vector<double> dy_dt(3 + N * N + N * M,0);
   double t = 10;
   
   EXPECT_TRUE(stan::math::empty_nested());
@@ -531,7 +531,7 @@ TEST_F(StanAgradRevOde, memory_recovery_exception_vv) {
       coupled_system_vv(throwing_ode, y0_v, theta_v, x, x_int, &msgs);
     
     std::vector<double> y(3,0);
-    std::vector<double> dy_dt(3,0);
+    std::vector<double> dy_dt(3 + N * N + N * M,0);
     double t = 10;
     
     EXPECT_TRUE(stan::math::empty_nested());


### PR DESCRIPTION
#### Submission Checklist

- [X] Run unit tests: `./runTests.py test/unit`
- [X] Run cpplint: `make cpplint`
- [X] Declare copyright holder and open-source license: see below

#### Summary:
Internal changes to the non-stiff ODE solver which speedup ODE integration whenever the ODE RHS side is costly to evaluate. This is the case whenever complicated forcing functions are involved. For example, a dosing schedule in PK/PD models.

#### Intended Effect:
Make non-stiff ODE integration faster. This is realized by avoiding duplicate evaluation of the ODE RHS whenever the ODE integrator calls the () operator of the coupled_ode_system.

#### How to Verify:
Look at code changes and run tests
- `test/unit/math/rev/arr/functor/coupled_ode_system_test.cpp`
- `test/unit/math/prim/arr/functor/coupled_ode_system_test.cpp`

To observe the speedup I have run a benchmark which involves a costly ODE RHS and the execution time goes down from 3.51h (2.14.0) to 2.38h (this branch) which is a ~50% speed increase.

The tests required a minor adjustment. The old test code passed a dy_dt into the coupled_ode_system () operator which had the size of the base system. However, odeint will always pass in a vector as dy_dt into the coupled ode system () operator which is as large as the coupled system and expect that this vector is updated. Hence, we can do the update in-place instead of doing a reallocation which was done before. Therefore, tests need to pass a vector into the () operator which corresponds in size to the coupled ode system, i.e. the vector must be as large as the initial_state vector.

#### Side Effects:
None.

#### Documentation:

#### Reviewer Suggestions: 
Anyone.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Sebastian Weber

By submitting this pull request, the copyright holder is requiring to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
