### PR TITLE
Added categorical_logit_rng to Stan Math for issue 517

### DIFF
--- a/stan/math/prim/mat.hpp
+++ b/stan/math/prim/mat.hpp
@@ -250,6 +250,7 @@
 #include <stan/math/prim/mat/prob/categorical_logit_log.hpp>
 #include <stan/math/prim/mat/prob/categorical_logit_lpmf.hpp>
 #include <stan/math/prim/mat/prob/categorical_rng.hpp>
+#include <stan/math/prim/mat/prob/categorical_logit_rng.hpp>
 #include <stan/math/prim/mat/prob/dirichlet_log.hpp>
 #include <stan/math/prim/mat/prob/dirichlet_lpmf.hpp>
 #include <stan/math/prim/mat/prob/dirichlet_rng.hpp>

--- a/stan/math/prim/mat/prob/categorical_logit_rng.hpp
+++ b/stan/math/prim/mat/prob/categorical_logit_rng.hpp
@@ -1,0 +1,56 @@
+#ifndef STAN_MATH_PRIM_MAT_PROB_CATEGORICAL_LOGIT_RNG_HPP
+#define STAN_MATH_PRIM_MAT_PROB_CATEGORICAL_LOGIT_RNG_HPP
+
+#include <boost/random/uniform_01.hpp>
+#include <boost/random/variate_generator.hpp>
+#include <stan/math/prim/scal/err/check_finite.hpp>
+#include <stan/math/prim/mat/err/check_simplex.hpp>
+#include <stan/math/prim/mat/fun/cumulative_sum.hpp>
+#include <stan/math/prim/mat/fun/softmax.hpp>
+#include <stan/math/prim/mat/fun/Eigen.hpp>
+
+namespace stan {
+  namespace math {
+
+    /**
+     * Return a draw from a Categorical distribution given a
+     * a vector of unnormalized log probabilities and a psuedo-random
+     * number generator.
+     *
+     * This is a convenience wrapper around
+     * <code>categorical_rng(softmax(beta), rng)</code>.
+     *
+     * @tparam RNG Type of pseudo-random number generator.
+     * @param beta Vector of unnormalized log probabilities.
+     * @param rng Pseudo-random number generator.
+     * @return Categorical random variate
+     */
+    template <class RNG>
+    inline int
+    categorical_logit_rng(const Eigen::Matrix<double, Eigen::Dynamic, 1>& beta,
+                    RNG& rng) {
+      using boost::variate_generator;
+      using boost::uniform_01;
+
+      static const char* function("categorical_logit_rng");
+
+      check_finite(function, "Log odds parameter", beta);
+
+      variate_generator<RNG&, uniform_01<> >
+        uniform01_rng(rng, uniform_01<>());
+
+      Eigen::VectorXd theta = softmax(beta);
+
+      Eigen::VectorXd index(theta.rows());
+
+      index = cumulative_sum(theta);
+
+      double c = uniform01_rng();
+      int b = 0;
+      while (c > index(b))
+        b++;
+      return b + 1;
+    }
+  }
+}
+#endif

--- a/stan/math/prim/mat/prob/categorical_logit_rng.hpp
+++ b/stan/math/prim/mat/prob/categorical_logit_rng.hpp
@@ -11,7 +11,6 @@
 
 namespace stan {
   namespace math {
-
     /**
      * Return a draw from a Categorical distribution given a
      * a vector of unnormalized log probabilities and a psuedo-random
@@ -27,8 +26,8 @@ namespace stan {
      */
     template <class RNG>
     inline int
-    categorical_logit_rng(const Eigen::Matrix<double, Eigen::Dynamic, 1>& beta,
-                    RNG& rng) {
+    categorical_logit_rng(const Eigen::VectorXd& beta,
+                          RNG& rng) {
       using boost::variate_generator;
       using boost::uniform_01;
 
@@ -38,12 +37,8 @@ namespace stan {
 
       variate_generator<RNG&, uniform_01<> >
         uniform01_rng(rng, uniform_01<>());
-
       Eigen::VectorXd theta = softmax(beta);
-
-      Eigen::VectorXd index(theta.rows());
-
-      index = cumulative_sum(theta);
+      Eigen::VectorXd index = cumulative_sum(theta);
 
       double c = uniform01_rng();
       int b = 0;

--- a/test/unit/math/prim/mat/prob/categorical_logit_rng_test.cpp
+++ b/test/unit/math/prim/mat/prob/categorical_logit_rng_test.cpp
@@ -1,0 +1,59 @@
+#include <stan/math/prim/mat.hpp>
+#include <gtest/gtest.h>
+#include <limits>
+#include <boost/random/mersenne_twister.hpp>
+#include <boost/math/distributions.hpp>
+
+using Eigen::VectorXd;
+using stan::math::softmax;
+
+TEST(ProbDistributionsCategoricalLogit, error_check) {
+  using stan::math::categorical_logit_rng;
+  boost::random::mt19937 rng;
+
+  VectorXd beta(3);
+
+  beta << 1.0, 10.0, -10.0;
+  EXPECT_NO_THROW(categorical_logit_rng(beta, rng));
+
+  beta << -1e3, 1.1e3, 1e5;
+  EXPECT_NO_THROW(categorical_logit_rng(beta, rng));
+
+  beta(1) = std::numeric_limits<double>::quiet_NaN();
+  EXPECT_THROW(categorical_logit_rng(beta, rng), std::domain_error);
+
+  beta(1) = std::numeric_limits<double>::infinity();
+  EXPECT_THROW(categorical_logit_rng(beta, rng), std::domain_error);
+}
+
+TEST(ProbDistributionsCategoricalLogit, chiSquareGoodnessFitTest) {
+  boost::random::mt19937 rng;
+  int N = 10000;
+  int K = 3;
+  VectorXd beta(K);
+
+  beta << -0.5,
+    0.1,
+    0.3;
+
+  VectorXd theta = softmax(beta);
+  boost::math::chi_squared mydist(K - 1);
+
+  int bin [K];
+  double expect [K];
+  for(int i = 0; i < K; i++) {
+    bin[i] = 0;
+    expect[i] = N * theta(i);
+  }
+
+  for(int i = 0;  i < N; i++) {
+    int a = stan::math::categorical_logit_rng(beta, rng);
+    bin[a - 1]++;
+  }
+
+  double chi = 0;
+  for(int j = 0; j < K; j++)
+    chi += ((bin[j] - expect[j]) * (bin[j] - expect[j]) / expect[j]);
+
+  EXPECT_TRUE(chi < quantile(complement(mydist, 1e-6)));
+}

--- a/test/unit/math/prim/mat/prob/categorical_logit_test.cpp
+++ b/test/unit/math/prim/mat/prob/categorical_logit_test.cpp
@@ -1,11 +1,13 @@
 #include <stan/math/prim/mat.hpp>
 #include <gtest/gtest.h>
 #include <limits>
+#include <boost/random/mersenne_twister.hpp>
+#include <boost/math/distributions.hpp>
 
 using Eigen::Dynamic;
 using Eigen::Matrix;
 using stan::math::log_softmax;
-using stan::math::log_softmax;
+using stan::math::softmax;
 
 TEST(ProbDistributionsCategoricalLogit,Categorical) {
   Matrix<double,Dynamic,1> theta(3,1);
@@ -78,4 +80,59 @@ TEST(ProbDistributionsCategoricalLogit, error) {
   ns[0] = 1;
   ns[1] = 12;
   EXPECT_THROW(categorical_logit_log(ns, theta), std::domain_error);
+}
+
+TEST(ProbDistributionsCategoricalLogit, error_check) {
+  using stan::math::categorical_logit_rng;
+  boost::random::mt19937 rng;
+
+  Matrix<double, Dynamic, 1> beta(3);
+
+  beta << 1.0, 10.0, -10.0;
+
+  EXPECT_NO_THROW(categorical_logit_rng(beta, rng));
+
+  beta << -1e3, 1.1e3, 1e5;
+
+  EXPECT_NO_THROW(categorical_logit_rng(beta, rng));
+
+  beta(1) = std::numeric_limits<double>::quiet_NaN();
+  EXPECT_THROW(categorical_logit_rng(beta, rng), std::domain_error);
+
+  beta(1) = std::numeric_limits<double>::infinity();
+  EXPECT_THROW(categorical_logit_rng(beta, rng), std::domain_error);
+}
+
+TEST(ProbDistributionsCategoricalLogit, chiSquareGoodnessFitTest) {
+  boost::random::mt19937 rng;
+
+  int N = 10000;
+  Matrix<double, Dynamic, 1> beta(3);
+  beta << -0.5,
+    0.1,
+    0.3;
+
+  Matrix<double, Dynamic, 1> theta = softmax(beta);
+
+  int K = theta.rows();
+  boost::math::chi_squared mydist(K - 1);
+
+  int bin [K];
+  double expect [K];
+  for(int i = 0 ; i < K; i++) {
+    bin[i] = 0;
+    expect[i] = N * theta(i);
+  }
+
+  for(int i = 0;  i < N; i++) {
+    int a = stan::math::categorical_logit_rng(beta, rng);
+    bin[a - 1]++;
+  }
+
+  double chi = 0;
+
+  for(int j = 0; j < K; j++)
+    chi += ((bin[j] - expect[j]) * (bin[j] - expect[j]) / expect[j]);
+
+  EXPECT_TRUE(chi < quantile(complement(mydist, 1e-6)));
 }


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

Added categorical_logit_rng function to address part of this issue https://github.com/stan-dev/math/issues/517

I've got a couple questions for the tests. I just copied the structure of things from categorical_rng.

Is it okay for me to use softmax in the test function (line 115 categorical_logit_test.cpp)? Or should I manually compute the theta simplex and plug the values in (so if softmax is wrong for some reason it doesn't allow the categorical_logit_rng tests silently succeed)?

Do the categorical distributions need somehow added to the automatically generated test distribution tests in test/prob? I see a bunch of stuff in there for other distributions but not for the categorial ones. The tests I added in test/unit/math/prim/mat/prob seem pretty coarse (copying what was there for categorial_rng).

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): University of California, Santa Barbara

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
