### PR TITLE
ifdef out remaining printf statements

### DIFF
--- a/lib/cvodes_2.9.0/src/nvec_ser/nvector_serial.c
+++ b/lib/cvodes_2.9.0/src/nvec_ser/nvector_serial.c
@@ -270,6 +270,7 @@ void N_VPrint_Serial(N_Vector x)
   long int i, N;
   realtype *xd;
 
+#ifndef NO_FPRINTF_OUTPUT
   xd = NULL;
 
   N  = NV_LENGTH_S(x);
@@ -285,6 +286,7 @@ void N_VPrint_Serial(N_Vector x)
 #endif
   }
   printf("\n");
+#endif
 
   return;
 }

--- a/lib/cvodes_2.9.0/src/nvec_ser/nvector_serial.c
+++ b/lib/cvodes_2.9.0/src/nvec_ser/nvector_serial.c
@@ -267,10 +267,10 @@ long int N_VGetLength_Serial(N_Vector v)
  
 void N_VPrint_Serial(N_Vector x)
 {
+#ifndef NO_FPRINTF_OUTPUT
   long int i, N;
   realtype *xd;
 
-#ifndef NO_FPRINTF_OUTPUT
   xd = NULL;
 
   N  = NV_LENGTH_S(x);

--- a/lib/cvodes_2.9.0/src/sundials/sundials_direct.c
+++ b/lib/cvodes_2.9.0/src/sundials/sundials_direct.c
@@ -306,10 +306,10 @@ void SetToZero(DlsMat A)
 
 void PrintMat(DlsMat A)
 {
+#ifndef NO_FPRINTF_OUTPUT
   long int i, j, start, finish;
   realtype **a;
 
-#ifndef NO_FPRINTF_OUTPUT
   switch (A->type) {
 
   case SUNDIALS_DENSE:

--- a/lib/cvodes_2.9.0/src/sundials/sundials_direct.c
+++ b/lib/cvodes_2.9.0/src/sundials/sundials_direct.c
@@ -309,6 +309,7 @@ void PrintMat(DlsMat A)
   long int i, j, start, finish;
   realtype **a;
 
+#ifndef NO_FPRINTF_OUTPUT
   switch (A->type) {
 
   case SUNDIALS_DENSE:
@@ -354,7 +355,7 @@ void PrintMat(DlsMat A)
     break;
 
   }
-
+#endif
 }
 
 

--- a/lib/cvodes_2.9.0/src/sundials/sundials_sparse.c
+++ b/lib/cvodes_2.9.0/src/sundials/sundials_sparse.c
@@ -736,6 +736,7 @@ void SparsePrintMat(const SlsMat A, FILE* outfile)
   char *matrixtype;
   char *indexname;
 
+#ifndef NO_FPRINTF_OUTPUT
   NNZ = A->NNZ;
 
   switch(A->sparsetype) {
@@ -771,7 +772,7 @@ void SparsePrintMat(const SlsMat A, FILE* outfile)
     fprintf(outfile, "\n");
   }
   fprintf(outfile, "\n");
-    
+#endif   
 }
 
 

--- a/lib/cvodes_2.9.0/src/sundials/sundials_sparse.c
+++ b/lib/cvodes_2.9.0/src/sundials/sundials_sparse.c
@@ -732,11 +732,11 @@ int SparseMatvec(const SlsMat A, const realtype *x, realtype *y)
  */
 void SparsePrintMat(const SlsMat A, FILE* outfile)
 {
+#ifndef NO_FPRINTF_OUTPUT
   int i,j, NNZ;
   char *matrixtype;
   char *indexname;
 
-#ifndef NO_FPRINTF_OUTPUT
   NNZ = A->NNZ;
 
   switch(A->sparsetype) {


### PR DESCRIPTION
#### Submission Checklist

- [X] Run unit tests: `./runTests.py test/unit`
- [X] Run cpplint: `make cpplint`
- [X] Declare copyright holder and open-source license: see below

#### Summary:

disables printf functions from CVODES by wrapping them in ifdef blocks controlled by NO_FPRINTF_OUTPUT

#### Intended Effect:

make CRAN happy which forbids any printf calls in binaries (even if they are not called).

closes #524 

#### How to Verify:

build cvodes and then
```
cd lib/cvodes_2.9.0
grep -R -F -n -w "printf" .
```

this should not show any of the binary files pop up.

#### Side Effects:

#### Documentation:

#### Reviewer Suggestions: 

@bgoodri 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Sebastian Weber

By submitting this pull request, the copyright holder is requiring to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
