### PR TITLE
Add 'Inverse scale' in gamma error output.

### DIFF
--- a/stan/math/prim/scal/prob/gamma_cdf.hpp
+++ b/stan/math/prim/scal/prob/gamma_cdf.hpp
@@ -60,13 +60,13 @@ namespace stan {
       T_partials_return P(1.0);
 
       check_positive_finite(function, "Shape parameter", alpha);
-      check_positive_finite(function, "Scale parameter", beta);
+      check_positive_finite(function, "Inverse scale parameter", beta);
       check_not_nan(function, "Random variable", y);
       check_nonnegative(function, "Random variable", y);
       check_consistent_sizes(function,
                              "Random variable", y,
                              "Shape parameter", alpha,
-                             "Scale Parameter", beta);
+                             "Inverse scale parameter", beta);
 
       scalar_seq_view<const T_y> y_vec(y);
       scalar_seq_view<const T_shape> alpha_vec(alpha);

--- a/stan/math/prim/scal/prob/gamma_lccdf.hpp
+++ b/stan/math/prim/scal/prob/gamma_lccdf.hpp
@@ -48,13 +48,13 @@ namespace stan {
       T_partials_return P(0.0);
 
       check_positive_finite(function, "Shape parameter", alpha);
-      check_positive_finite(function, "Scale parameter", beta);
+      check_positive_finite(function, "Inverse scale parameter", beta);
       check_not_nan(function, "Random variable", y);
       check_nonnegative(function, "Random variable", y);
       check_consistent_sizes(function,
                              "Random variable", y,
                              "Shape parameter", alpha,
-                             "Scale Parameter", beta);
+                             "Inverse scale parameter", beta);
 
       scalar_seq_view<const T_y> y_vec(y);
       scalar_seq_view<const T_shape> alpha_vec(alpha);

--- a/stan/math/prim/scal/prob/gamma_lcdf.hpp
+++ b/stan/math/prim/scal/prob/gamma_lcdf.hpp
@@ -46,13 +46,13 @@ namespace stan {
       T_partials_return P(0.0);
 
       check_positive_finite(function, "Shape parameter", alpha);
-      check_positive_finite(function, "Scale parameter", beta);
+      check_positive_finite(function, "Inverse scale parameter", beta);
       check_not_nan(function, "Random variable", y);
       check_nonnegative(function, "Random variable", y);
       check_consistent_sizes(function,
                              "Random variable", y,
                              "Shape parameter", alpha,
-                             "Scale Parameter", beta);
+                             "Inverse scale parameter", beta);
 
       scalar_seq_view<const T_y> y_vec(y);
       scalar_seq_view<const T_shape> alpha_vec(alpha);

--- a/stan/math/prim/scal/prob/gamma_rng.hpp
+++ b/stan/math/prim/scal/prob/gamma_rng.hpp
@@ -38,7 +38,7 @@ namespace stan {
       /*
         the boost gamma distribution is defined by
         shape and scale, whereas the stan one is defined
-        by shape and rate
+        by shape and rate (inverse scale)
       */
       variate_generator<RNG&, gamma_distribution<> >
         gamma_rng(rng, gamma_distribution<>(alpha, 1.0 / beta));


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

`gamma_*` functions use **shape** and **rate (inverse scale)** parametrization for Gamma distribution.
Now the doc and the parameters checkers are consistent with the input parameters.

The issue: https://github.com/stan-dev/math/issues/514

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Nikita Doykov

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
