### PR TITLE
fixes #534, simplifying fvar ctors

### DIFF
--- a/stan/math/fwd/core/fvar.hpp
+++ b/stan/math/fwd/core/fvar.hpp
@@ -3,7 +3,6 @@
 
 #include <stan/math/prim/scal/meta/likely.hpp>
 #include <stan/math/prim/scal/fun/is_nan.hpp>
-#include <boost/utility/enable_if.hpp>
 #include <ostream>
 
 namespace stan {
@@ -11,141 +10,230 @@ namespace stan {
 
     template <typename T>
     struct fvar {
-      T val_;  // value
-      T d_;    // tangent (aka derivative)
-
-      T val() const { return val_; }
-      T tangent() const { return d_; }
-
-      typedef fvar value_type;
+      // typedef fvar value_type;
 
       /**
-       * Construct a forward variable with zero value and zero
-       * tangent.
+       * The value of this variable.
+       */
+      T val_;
+
+      /**
+       * The tangent (derivative) of this variable.
+       */
+      T d_;
+
+      /**
+       * Return the value of this variable.
+       *
+       * @return value of this variable
+       */
+      T val() const { return val_; }
+
+      /**
+       * Return the tangent (derivative) of this variable.
+       *
+       * @return tangent of this variable
+       */
+      T tangent() const { return d_; }
+
+      /**
+       * Construct a forward variable with zero value and tangent.
        */
       fvar() : val_(0), d_(0) { }
 
       /**
-       * Copy construct a forward variable by copying its value and
-       * tangent.
+       * Construct a forward variable with value and tangent set to
+       * the value and tangent of the specified variable.
        *
-       * @param x forward variable to copy
+       * @param[in] x variable to be copied
        */
-      fvar(const fvar<T>& x) : val_(x.val_), d_(x.d_) {  }
-
-      /**
-       * Construct a forward variable with specified value and zero
-       * tangent.  If the value is not-a-number, tangent will be set to
-       * not-a-number.
-       *
-       * @param v value of constructed forward variable
-       */
-      fvar(double v) : val_(v), d_(0) {  // NOLINT
-        if (unlikely(is_nan(v)))
-          d_ = v;
-      }
+      fvar(const fvar<T>& x) : val_(x.val_), d_(x.d_) { }
 
       /**
        * Construct a forward variable with the specified value and
-       * tangent value.  If the value is not-a-number, tangent will be
-       * set to not-a-number.
+       * zero tangent.
        *
-       * @tparam V type of value, must be assignable to T
-       * @param v value
-       * @param d tangent, defaulting to 0
+       * @tparam V type of value (must be assignable to the value and
+       *   tangent type T)
+       * @param[in] v value
        */
       template <typename V>
-      fvar(const V& v, double d = 0) : val_(v), d_(d) {  // NOLINT
-        if (unlikely(is_nan(v)))
-          d_ = v;
+      fvar(const V& v) : val_(v), d_(0) {  // NOLINT(runtime/explicit)
+        if (is_nan(v)) d_ = v;
       }
 
       /**
        * Construct a forward variable with the specified value and
-       * tangent value.  If the value is not-a-number, tangent will be
-       * set to not-a-number.
+       * tangent.
        *
-       * @tparam TV type of value, must be assignable to T
-       * @tparam TD type of tangent, must be assignable to T, defaults
-       * to 0
-       * @param v value
-       * @param d tangent
+       * @tparam V type of value (must be assignable to the value and
+       *   tangent type T)
+       * @tparam D type of tangent (must be assignable to the value and
+       *   tangent type T)
+       * @param[in] v value
+       * @param[in] d tangent
        */
-      // TV and TD must be assignable to T
-      template <typename TV, typename TD>
-      fvar(const TV& v, const TD& d = 0.0) : val_(v), d_(d) {  // NOLINT
-        if (unlikely(is_nan(v)))
-          d_ = v;
+      template <typename V, typename D>
+      fvar(const V& v, const D& d) : val_(v), d_(d) {
+        if (is_nan(v)) d_ = v;
       }
 
+      /**
+       * Add the specified variable to this variable and return a
+       * reference to this variable.
+       *
+       * @param[in] x2 variable to add
+       * @return reference to this variable after addition
+       */
       inline fvar<T>& operator+=(const fvar<T>& x2) {
         val_ += x2.val_;
         d_ += x2.d_;
         return *this;
       }
 
+      /**
+       * Add the specified value to this variable and return a
+       * reference to this variable.
+       *
+       * @param[in] x2 value to add
+       * @return reference to this variable after addition
+       */
       inline fvar<T>& operator+=(double x2) {
         val_ += x2;
         return *this;
       }
 
+      /**
+       * Subtract the specified variable from this variable and return a
+       * reference to this variable.
+       *
+       * @param[in] x2 variable to subtract
+       * @return reference to this variable after subtraction
+       */
       inline fvar<T>& operator-=(const fvar<T>& x2) {
         val_ -= x2.val_;
         d_ -= x2.d_;
         return *this;
       }
 
+      /**
+       * Subtract the specified value from this variable and return a
+       * reference to this variable.
+       *
+       * @param[in] x2 value to add
+       * @return reference to this variable after subtraction
+       */
       inline fvar<T>& operator-=(double x2) {
         val_ -= x2;
         return *this;
       }
 
+      /**
+       * Multiply this variable by the the specified variable and
+       * return a reference to this variable.
+       *
+       * @param[in] x2 variable to multiply
+       * @return reference to this variable after multiplication
+       */
       inline fvar<T>& operator*=(const fvar<T>& x2) {
         d_ = d_ * x2.val_ + val_ * x2.d_;
         val_ *= x2.val_;
         return *this;
       }
 
+      /**
+       * Multiply this variable by the the specified value and
+       * return a reference to this variable.
+       *
+       * @param[in] x2 value to multiply
+       * @return reference to this variable after multiplication
+       */
       inline fvar<T>& operator*=(double x2) {
         val_ *= x2;
         d_ *= x2;
         return *this;
       }
 
+      /**
+       * Divide this variable by the the specified variable and
+       * return a reference to this variable.
+       *
+       * @param[in] x2 variable to divide this variable by
+       * @return reference to this variable after division
+       */
       inline fvar<T>& operator/=(const fvar<T>& x2) {
         d_ = (d_ * x2.val_ - val_ * x2.d_) / (x2.val_ * x2.val_);
         val_ /= x2.val_;
         return *this;
       }
 
+      /**
+       * Divide this value by the the specified variable and
+       * return a reference to this variable.
+       *
+       * @param[in] x2 value to divide this variable by
+       * @return reference to this variable after division
+       */
       inline fvar<T>& operator/=(double x2) {
         val_ /= x2;
         d_ /= x2;
         return *this;
       }
 
+      /**
+       * Increment this variable by one and return a reference to this
+       * variable after the increment.
+       *
+       * @return reference to this variable after increment
+       */
       inline fvar<T>& operator++() {
         ++val_;
         return *this;
       }
 
+      /**
+       * Increment this variable by one and return a reference to a
+       * copy of this variable before it was incremented.
+       *
+       * @return reference to copy of this variable before increment
+       */
       inline fvar<T> operator++(int /*dummy*/) {
         fvar<T> result(val_, d_);
         ++val_;
         return result;
       }
 
+      /**
+       * Decrement this variable by one and return a reference to this
+       * variable after the decrement.
+       *
+       * @return reference to this variable after decrement
+       */
       inline fvar<T>& operator--() {
         --val_;
         return *this;
       }
 
+      /**
+       * Decrement this variable by one and return a reference to a
+       * copy of this variable before it was decremented.
+       *
+       * @return reference to copy of this variable before decrement
+       */
       inline fvar<T> operator--(int /*dummy*/) {
         fvar<T> result(val_, d_);
         --val_;
         return result;
       }
 
+      /**
+       * Write the value of the specified variable to the specified
+       * output stream, returning a reference to the output stream.
+       *
+       * @param[in,out] os stream for writing value
+       * @param[in] v variable whose value is written
+       * @return reference to the specified output stream
+       */
       friend std::ostream& operator<<(std::ostream& os, const fvar<T>& v) {
         return os << v.val_;
       }

--- a/stan/math/fwd/mat/fun/quad_form_sym.hpp
+++ b/stan/math/fwd/mat/fun/quad_form_sym.hpp
@@ -20,7 +20,7 @@ namespace stan {
       check_symmetric("quad_form_sym", "A", A);
       Eigen::Matrix<fvar<T>, CB, CB>
         ret(multiply(transpose(B), multiply(A, B)));
-      return T(0.5) * (ret + transpose(ret));
+      return 0.5 * (ret + transpose(ret));
     }
 
     template<int RA, int CA, int RB, typename T>
@@ -45,7 +45,7 @@ namespace stan {
       check_symmetric("quad_form_sym", "A", A);
       Eigen::Matrix<fvar<T>, CB, CB>
         ret(multiply(transpose(B), multiply(A, B)));
-      return T(0.5) * (ret + transpose(ret));
+      return 0.5 * (ret + transpose(ret));
     }
 
     template<int RA, int CA, int RB, typename T>

--- a/test/unit/math/fwd/mat/vectorize/build_fwd_vector.hpp
+++ b/test/unit/math/fwd/mat/vectorize/build_fwd_vector.hpp
@@ -6,24 +6,18 @@
 
 template <typename F>
 static inline std::vector<double>
-build_fwd_vector(std::vector<double> double_vector,
-                          int seed_index = -1) { 
+build_fwd_vector(std::vector<double> double_vector, int seed_index = -1) {
   return F::valid_inputs();
 }
 
 template <typename F, typename T>
 static inline std::vector<stan::math::fvar<T> >
 build_fwd_vector(std::vector<stan::math::fvar<T> > fvar_vector,
-                        int seed_index = -1) { 
+                 int seed_index = -1) {
   using std::vector;
   using stan::math::fvar;
-
   vector<T> template_v = build_fwd_vector<F>(vector<T>(), seed_index);
-
   for (size_t i = 0; i < template_v.size(); ++i) {
-  
-    // For fvar<fvar<double> >, this will fill in 
-    // all four components
     if (seed_index == static_cast<int>(i))
       fvar_vector.push_back(fvar<T>(template_v[i], template_v[i]));
     else


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

Simplified `fvar<T>` constructors to allow generic assignable value and tangent.

#### Intended Effect:

Remove all the complicated edge cases, avoid `if_else`, reducing the number of `fvar` constructors and simplifying them.

#### How to Verify:

Unit tests all still work.

#### Side Effects:

No.

#### Documentation:

Added doxygen doc to entire `core/fvar.hpp` file.

#### Reviewer Suggestions: 

anyone

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
