### PR TITLE
fixes #346, replace copy args with refs

### DIFF
--- a/stan/math/prim/mat/err/check_ldlt_factor.hpp
+++ b/stan/math/prim/mat/err/check_ldlt_factor.hpp
@@ -21,7 +21,7 @@ namespace stan {
      * @tparam C columns of the matrix
      * @param[in] function function name for error messages
      * @param[in] name variable name for error messages
-     * @param[in] an LDLT factor to check for validity
+     * @param[in] A LDLT factor to check for validity
      * @throws <code>std::domain_error</code> if the LDLT factor is
      *   invalid.
      */

--- a/stan/math/prim/scal/fun/identity_constrain.hpp
+++ b/stan/math/prim/scal/fun/identity_constrain.hpp
@@ -30,7 +30,6 @@ namespace stan {
      *
      * @tparam T type of scalar.
      * @param[in] x scalar
-     * @param[in,out] lp reference to log probability.
      * @return transformed input
      */
     template <typename T>

--- a/stan/math/prim/scal/fun/identity_free.hpp
+++ b/stan/math/prim/scal/fun/identity_free.hpp
@@ -16,7 +16,7 @@ namespace stan {
      * @return value
      */
     template <typename T>
-    inline identity_free(const T& y) {
+    inline T identity_free(const T& y) {
       return y;
     }
 

--- a/stan/math/prim/scal/fun/lub_free.hpp
+++ b/stan/math/prim/scal/fun/lub_free.hpp
@@ -30,24 +30,22 @@ namespace stan {
      * positive infinity and the lower bound negative infinity,
      * this function reduces to <code>identity_free(y)</code>.
      *
-     * @tparam T Type of scalar.
-     * @param y Scalar input.
-     * @param lb Lower bound.
-     * @param ub Upper bound.
-     * @return The free scalar that transforms to the input scalar
-     * given the bounds.
+     * @tparam T type of scalar
+     * @tparam TL type of lower bound
+     * @tparam TU type of upper bound
+     * @param y constrained value
+     * @param lb lower bound
+     * @param ub upper bound
+     * @return the free scalar that transforms to the input scalar
+     *   given the bounds
      * @throw std::invalid_argument if the lower bound is greater than
      *   the upper bound, y is less than the lower bound, or y is
      *   greater than the upper bound
      */
     template <typename T, typename TL, typename TU>
-    inline
-    typename boost::math::tools::promote_args<T, TL, TU>::type
-    lub_free(const T y, TL lb, TU ub) {
-      check_bounded<T, TL, TU>
-        ("lub_free",
-         "Bounded variable",
-         y, lb, ub);
+    inline typename boost::math::tools::promote_args<T, TL, TU>::type
+    lub_free(const T& y, const TL& lb, const TU& ub) {
+      check_bounded<T, TL, TU>("lub_free", "Bounded variable", y, lb, ub);
       if (lb == -std::numeric_limits<double>::infinity())
         return ub_free(y, ub);
       if (ub == std::numeric_limits<double>::infinity())

--- a/stan/math/prim/scal/fun/positive_constrain.hpp
+++ b/stan/math/prim/scal/fun/positive_constrain.hpp
@@ -17,7 +17,7 @@ namespace stan {
      * @return Input transformed to be positive.
      */
     template <typename T>
-    inline T positive_constrain(const T x) {
+    inline T positive_constrain(const T& x) {
       using std::exp;
       return exp(x);
     }
@@ -33,13 +33,13 @@ namespace stan {
      * <p>\f$\log | \frac{d}{dx} \mbox{exp}(x) |
      *    = \log | \mbox{exp}(x) | =  x\f$.
      *
-     * @param x Arbitrary input scalar.
-     * @param lp Log probability reference.
-     * @return Input transformed to be positive.
-     * @tparam T Type of scalar.
+     * @tparam T type of unconstrained value
+     * @param x unconstrained value
+     * @param lp log density reference.
+     * @return positive constrained version of unconstrained value
      */
     template <typename T>
-    inline T positive_constrain(const T x, T& lp) {
+    inline T positive_constrain(const T& x, T& lp) {
       using std::exp;
       lp += x;
       return exp(x);

--- a/stan/math/prim/scal/fun/positive_free.hpp
+++ b/stan/math/prim/scal/fun/positive_free.hpp
@@ -21,14 +21,13 @@ namespace stan {
      * @param y Input scalar.
      * @return Unconstrained value that produces the input when constrained.
      * @tparam T Type of scalar.
-     * @throw std::domain_error if the variable is negative.
+     * @throw std::domain_error if the variable is negative
      */
     template <typename T>
     inline
-    T positive_free(const T y) {
+    T positive_free(const T& y) {
       using std::log;
-      check_positive("positive_free",
-                     "Positive variable", y);
+      check_positive("positive_free", "Positive variable", y);
       return log(y);
     }
 

--- a/stan/math/prim/scal/fun/prob_constrain.hpp
+++ b/stan/math/prim/scal/fun/prob_constrain.hpp
@@ -16,14 +16,12 @@ namespace stan {
      *
      * <p>\f$f(x) = \mbox{logit}^{-1}(x) = \frac{1}{1 + \exp(x)}\f$.
      *
-     * @param x Free scalar.
-     * @return Probability-constrained result of transforming
-     * the free scalar.
-     * @tparam T Type of scalar.
+     * @tparam T type of scalar
+     * @param[in] x unconstrained value
+     * @return result constrained to fall in (0, 1)
      */
     template <typename T>
-    inline
-    T prob_constrain(const T x) {
+    inline T prob_constrain(const T& x) {
       return inv_logit(x);
     }
 
@@ -42,15 +40,13 @@ namespace stan {
      * <p>\f$\log ((\mbox{logit}^{-1}(x)) (1 - \mbox{logit}^{-1}(x))\f$
      * <p>\f$\log (\mbox{logit}^{-1}(x)) + \log (1 - \mbox{logit}^{-1}(x))\f$.
      *
-     * @param x Free scalar.
-     * @param lp Log probability reference.
-     * @return Probability-constrained result of transforming
-     * the free scalar.
-     * @tparam T Type of scalar.
+     * @tparam T type of scalar
+     * @param[in] x unconstrained value
+     * @param[in, out] lp log density
+     * @return result constrained to fall in (0, 1)
      */
     template <typename T>
-    inline
-    T prob_constrain(const T x, T& lp) {
+    inline T prob_constrain(const T& x, T& lp) {
       using std::log;
       T inv_logit_x = inv_logit(x);
       lp += log(inv_logit_x) + log1m(inv_logit_x);

--- a/stan/math/prim/scal/fun/prob_free.hpp
+++ b/stan/math/prim/scal/fun/prob_free.hpp
@@ -17,16 +17,15 @@ namespace stan {
      *
      * <p>\f$f^{-1}(y) = \mbox{logit}(y) = \frac{1 - y}{y}\f$.
      *
-     * @param y Scalar input.
-     * @tparam T Type of scalar.
-     * @throw std::domain_error if y is less than 0 or greater than 1.
+     * @tparam T type of constrained value
+     * @param y constrained value
+     * @return corresponding unconstrained value
+     * @throw std::domain_error if y is not in (0, 1)
      */
     template <typename T>
-    inline
-    T prob_free(const T y) {
-      check_bounded<T, double, double>
-        ("prob_free", "Probability variable",
-         y, 0, 1);
+    inline T prob_free(const T& y) {
+      check_bounded<T, double, double>("prob_free", "Probability variable",
+                                       y, 0, 1);
       return logit(y);
     }
 

--- a/stan/math/prim/scal/fun/step.hpp
+++ b/stan/math/prim/scal/fun/step.hpp
@@ -20,13 +20,12 @@ namespace stan {
        \end{cases}
        \f]
      *
-     * @param y Scalar argument.
-     *
-     * @return 1 if the specified argument is greater than or equal to
-     * 0.0, and 0 otherwise.
+     * @tparam T type of value
+     * @param y value
+     * @return zero if the value is less than zero, and one otherwise
      */
     template <typename T>
-    inline int step(const T y) {
+    inline int step(const T& y) {
       return y < 0.0 ? 0 : 1;
     }
 

--- a/stan/math/prim/scal/fun/ub_constrain.hpp
+++ b/stan/math/prim/scal/fun/ub_constrain.hpp
@@ -22,16 +22,15 @@ namespace stan {
      * If the upper bound is positive infinity, this function
      * reduces to <code>identity_constrain(x)</code>.
      *
-     * @param x Free scalar.
-     * @param ub Upper bound.
-     * @return Transformed scalar with specified upper bound.
-     * @tparam T Type of scalar.
-     * @tparam TU Type of upper bound.
+     * @tparam T type of scalar
+     * @tparam TU type of upper bound
+     * @param[in] x free scalar.
+     * @param[in] ub upper bound
+     * @return scalar constrained to have upper bound
      */
     template <typename T, typename TU>
-    inline
-    typename boost::math::tools::promote_args<T, TU>::type
-    ub_constrain(const T x, const TU ub) {
+    inline typename boost::math::tools::promote_args<T, TU>::type
+    ub_constrain(const T& x, const TU& ub) {
       using std::exp;
       if (ub == std::numeric_limits<double>::infinity())
         return identity_constrain(x);
@@ -54,17 +53,17 @@ namespace stan {
      * If the upper bound is positive infinity, this function
      * reduces to <code>identity_constrain(x, lp)</code>.
      *
-     * @param x Free scalar.
-     * @param ub Upper bound.
-     * @param lp Log probability reference.
-     * @return Transformed scalar with specified upper bound.
-     * @tparam T Type of scalar.
-     * @tparam TU Type of upper bound.
+     * @tparam T type of scalar
+     * @tparam TU type of upper bound
+     * @param[in] x free scalar.
+     * @param[in] ub upper bound
+     * @param[in,out] lp log density
+     * @return scalar constrained to have upper bound
      */
     template <typename T, typename TU>
     inline
     typename boost::math::tools::promote_args<T, TU>::type
-    ub_constrain(const T x, const TU ub, T& lp) {
+    ub_constrain(const T& x, const TU& ub, T& lp) {
       using std::exp;
       if (ub == std::numeric_limits<double>::infinity())
         return identity_constrain(x, lp);

--- a/stan/math/prim/scal/fun/ub_free.hpp
+++ b/stan/math/prim/scal/fun/ub_free.hpp
@@ -24,23 +24,21 @@ namespace stan {
      * If the upper bound is positive infinity, this function
      * reduces to <code>identity_free(y)</code>.
      *
-     * @param y Upper-bounded scalar.
-     * @param ub Upper bound.
-     * @return Free scalar corresponding to upper-bounded scalar.
-     * @tparam T Type of scalar.
-     * @tparam TU Type of upper bound.
-     * @throw std::invalid_argument if y is greater than the upper
-     * bound.
+     * @tparam T type of scalar
+     * @tparam TU type of upper bound
+     * @param y constrained scalar with specified upper bound
+     * @param ub upper bound
+     * @return unconstrained scalar with respect to upper bound
+     * @throw std::invalid_argument if constrained scalar is greater
+     *   than the upper bound.
      */
     template <typename T, typename TU>
-    inline
-    typename boost::math::tools::promote_args<T, TU>::type
-    ub_free(const T y, const TU ub) {
+    inline typename boost::math::tools::promote_args<T, TU>::type
+    ub_free(const T& y, const TU& ub) {
       using std::log;
       if (ub == std::numeric_limits<double>::infinity())
         return identity_free(y);
-      check_less_or_equal("ub_free",
-                          "Upper bounded variable", y, ub);
+      check_less_or_equal("ub_free", "Upper bounded variable", y, ub);
       return log(ub - y);
     }
 

--- a/stan/math/prim/scal/fun/value_of.hpp
+++ b/stan/math/prim/scal/fun/value_of.hpp
@@ -15,9 +15,9 @@ namespace stan {
      * types requiring pass-by-reference, this template function
      * should be specialized.
      *
-     * @tparam T Type of scalar.
-     * @param x Scalar to convert to double.
-     * @return Value of scalar cast to a double.
+     * @tparam T type of scalar.
+     * @param x scalar to convert to double
+     * @return value of scalar cast to double
      */
     template <typename T>
     inline double value_of(const T x) {
@@ -32,8 +32,8 @@ namespace stan {
      *
      * <p>This inline pass-through no-op should be compiled away.
      *
-     * @param x Specified value.
-     * @return Specified value.
+     * @param x value
+     * @return input value
      */
     template <>
     inline double value_of<double>(double x) {


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

Replaced arguments of form `(T x)` with `(const T& x)` to avoid copies.  Also cleaned up a lot of doc.

#### Side Effects:

it should be faster :-)

#### Documentation:

cleaned it up where I saw it

#### Reviewer Suggestions: 

anyone

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
