### PR TITLE
fixes #498, mdivide_left_tri_low now calls var overload

### DIFF
--- a/stan/math/prim/mat/fun/mdivide_left_tri_low.hpp
+++ b/stan/math/prim/mat/fun/mdivide_left_tri_low.hpp
@@ -6,9 +6,31 @@
 #include <stan/math/prim/mat/fun/mdivide_left_tri.hpp>
 #include <stan/math/prim/mat/err/check_square.hpp>
 #include <stan/math/prim/mat/err/check_multiplicable.hpp>
+
 namespace stan {
   namespace math {
 
+    /**
+     * Return the result of left dividing the second argument by the
+     * first argument.  Calling <code>mdivide_left_tri_low(A,
+     * b)</code> with divisor <code>A</code> and dividend
+     * <code>b</code> is more arithmetically stable than calling
+     * <code>inv(A) * b</code>.
+     *
+     * @tparam T1 type of divisor matrix
+     * @tparam T2 type of dividend matrix
+     * @tparam R1 rows of divisor matrix
+     * @tparam C1 columns of divisor matrix
+     * @tparam R2 rows of dividen matrix
+     * @tparam C2 rows of divisor matrix
+     * @param A divisor, an invertible square matrix
+     * @param b dividend, a matrix or vector with the same number of
+     *   rows as the divisor has columns
+     * @return left division of b by A
+     * @throws std::invalid_argument if the divisor is not square or
+     *   the dividend does not have the same number of rows as the
+     *   divisor has columns.
+     */
     template <typename T1, typename T2, int R1, int C1, int R2, int C2>
     inline
     Eigen::Matrix<typename boost::math::tools::promote_args<T1, T2>::type,
@@ -17,14 +39,14 @@ namespace stan {
                          const Eigen::Matrix<T2, R2, C2> &b) {
       check_square("mdivide_left_tri_low", "A", A);
       check_multiplicable("mdivide_left_tri_low", "A", A, "b", b);
-      return mdivide_left_tri<Eigen::Lower, T1, T2, R1, C1, R2, C2>(A, b);
+      return mdivide_left_tri<Eigen::Lower>(A, b);
     }
+
     template <typename T, int R1, int C1>
-    inline
-    Eigen::Matrix<T, R1, C1>
+    inline Eigen::Matrix<T, R1, C1>
     mdivide_left_tri_low(const Eigen::Matrix<T, R1, C1> &A) {
       check_square("mdivide_left_tri_low", "A", A);
-      return mdivide_left_tri<Eigen::Lower, T, R1, C1>(A);
+      return mdivide_left_tri<Eigen::Lower>(A);
     }
 
   }

--- a/test/unit/math/rev/mat/fun/mdivide_left_tri_low_test.cpp
+++ b/test/unit/math/rev/mat/fun/mdivide_left_tri_low_test.cpp
@@ -6,7 +6,7 @@
 #include <stdexcept>
 #include <iostream>
 
-TEST(AgradRevMatrix, mdivide_left_tri_low) {
+TEST(AgradRevMatrix, var_var_mdivide_left_tri_low) {
   using stan::math::matrix_d;
   using stan::math::matrix_v;
   using stan::math::vector_v;
@@ -16,6 +16,102 @@ TEST(AgradRevMatrix, mdivide_left_tri_low) {
   // it only uses a triangular view A
 
   matrix_v A(2, 2);
+  matrix_v B(2, 2);
+
+  A << 1, 0.0 / 0.0,
+    -3, 5;
+  B << 2, 5, 12, 109;
+
+  vector_v c(2);
+  c << 3, 5;
+
+  matrix_v A_under_B = mdivide_left_tri_low(A, B);
+  EXPECT_EQ(2, A_under_B.rows());
+  EXPECT_EQ(2, A_under_B.cols());
+  for (int i = 0; i < A_under_B.size(); ++i)
+    EXPECT_FALSE(stan::math::is_nan(A_under_B(i)));
+
+  EXPECT_NO_THROW(mdivide_left_tri_low(A, B));
+  EXPECT_NO_THROW(mdivide_left_tri_low(A, c));
+
+  matrix_v D(3, 2);
+  D << 1, 2, 5, -19, 73, 31;
+  EXPECT_THROW(mdivide_left_tri_low(D, B), std::invalid_argument);
+  EXPECT_THROW(mdivide_left_tri_low(D, c), std::invalid_argument);
+
+  vector_v e(3);
+  e << 1, 2, 9;
+  EXPECT_THROW(mdivide_left_tri_low(A, e), std::invalid_argument);
+
+  matrix_v A2(2, 2);
+  A2 << 1, 0, -3, 5;
+  matrix_v B2(2, 2);
+  B2 << 2, 5, 12, 109;
+  matrix_v A2_under_B2 = A2.inverse() * B2;
+  EXPECT_EQ(2, A2_under_B2.rows());
+  EXPECT_EQ(2, A2_under_B2.cols());
+  for (int i = 0; i < A2_under_B2.size(); ++i)
+    EXPECT_FLOAT_EQ(A2_under_B2(i).val(), A_under_B(i).val());
+}
+
+TEST(AgradRevMatrix, var_double_mdivide_left_tri_low) {
+  using stan::math::matrix_d;
+  using stan::math::matrix_v;
+  using stan::math::vector_v;
+  using stan::math::mdivide_left_tri;
+  using stan::math::mdivide_left_tri_low;
+
+  // it only uses a triangular view A
+
+  matrix_v A(2, 2);
+  matrix_d B(2, 2);
+
+  A << 1, 0.0 / 0.0,
+    -3, 5;
+  B << 2, 5, 12, 109;
+
+  vector_v c(2);
+  c << 3, 5;
+
+  matrix_v A_under_B = mdivide_left_tri_low(A, B);
+  EXPECT_EQ(2, A_under_B.rows());
+  EXPECT_EQ(2, A_under_B.cols());
+  for (int i = 0; i < A_under_B.size(); ++i)
+    EXPECT_FALSE(stan::math::is_nan(A_under_B(i)));
+
+  EXPECT_NO_THROW(mdivide_left_tri_low(A, B));
+  EXPECT_NO_THROW(mdivide_left_tri_low(A, c));
+
+  matrix_v D(3, 2);
+  D << 1, 2, 5, -19, 73, 31;
+  EXPECT_THROW(mdivide_left_tri_low(D, B), std::invalid_argument);
+  EXPECT_THROW(mdivide_left_tri_low(D, c), std::invalid_argument);
+
+  vector_v e(3);
+  e << 1, 2, 9;
+  EXPECT_THROW(mdivide_left_tri_low(A, e), std::invalid_argument);
+
+  matrix_v A2(2, 2);
+  A2 << 1, 0, -3, 5;
+  matrix_v B2(2, 2);
+  B2 << 2, 5, 12, 109;
+  matrix_v A2_under_B2 = A2.inverse() * B2;
+  EXPECT_EQ(2, A2_under_B2.rows());
+  EXPECT_EQ(2, A2_under_B2.cols());
+  for (int i = 0; i < A2_under_B2.size(); ++i)
+    EXPECT_FLOAT_EQ(A2_under_B2(i).val(), A_under_B(i).val());
+}
+
+TEST(AgradRevMatrix, double_var_mdivide_left_tri_low) {
+  using stan::math::matrix_d;
+  using stan::math::matrix_v;
+  using stan::math::vector_v;
+  using stan::math::mdivide_left_tri;
+  using stan::math::mdivide_left_tri_low;
+
+  // it only uses a triangular view A
+
+  matrix_d A(2, 2);
   matrix_v B(2, 2);
 
   A << 1, 0.0 / 0.0,

--- a/test/unit/math/rev/mat/fun/mdivide_left_tri_low_test.cpp
+++ b/test/unit/math/rev/mat/fun/mdivide_left_tri_low_test.cpp
@@ -1,0 +1,55 @@
+#include <stan/math/rev/mat.hpp>
+#include <stan/math/rev/mat/fun/mdivide_left_tri.hpp>
+#include <gtest/gtest.h>
+#include <test/unit/math/rev/mat/fun/util.hpp>
+#include <test/unit/math/rev/mat/util.hpp>
+#include <stdexcept>
+#include <iostream>
+
+TEST(AgradRevMatrix, mdivide_left_tri_low) {
+  using stan::math::matrix_d;
+  using stan::math::matrix_v;
+  using stan::math::vector_v;
+  using stan::math::mdivide_left_tri;
+  using stan::math::mdivide_left_tri_low;
+
+  // it only uses a triangular view A
+
+  matrix_v A(2, 2);
+  matrix_v B(2, 2);
+
+  A << 1, 0.0 / 0.0,
+    -3, 5;
+  B << 2, 5, 12, 109;
+
+  vector_v c(2);
+  c << 3, 5;
+
+  matrix_v A_under_B = mdivide_left_tri_low(A, B);
+  EXPECT_EQ(2, A_under_B.rows());
+  EXPECT_EQ(2, A_under_B.cols());
+  for (int i = 0; i < A_under_B.size(); ++i)
+    EXPECT_FALSE(stan::math::is_nan(A_under_B(i)));
+
+  EXPECT_NO_THROW(mdivide_left_tri_low(A, B));
+  EXPECT_NO_THROW(mdivide_left_tri_low(A, c));
+
+  matrix_v D(3, 2);
+  D << 1, 2, 5, -19, 73, 31;
+  EXPECT_THROW(mdivide_left_tri_low(D, B), std::invalid_argument);
+  EXPECT_THROW(mdivide_left_tri_low(D, c), std::invalid_argument);
+
+  vector_v e(3);
+  e << 1, 2, 9;
+  EXPECT_THROW(mdivide_left_tri_low(A, e), std::invalid_argument);
+
+  matrix_v A2(2, 2);
+  A2 << 1, 0, -3, 5;
+  matrix_v B2(2, 2);
+  B2 << 2, 5, 12, 109;
+  matrix_v A2_under_B2 = A2.inverse() * B2;
+  EXPECT_EQ(2, A2_under_B2.rows());
+  EXPECT_EQ(2, A2_under_B2.cols());
+  for (int i = 0; i < A2_under_B2.size(); ++i)
+    EXPECT_FLOAT_EQ(A2_under_B2(i).val(), A_under_B(i).val());
+}


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

Fix overload logic in `mdivide_left_tri_low` so that it calls the `var` version of `mdivide_left_tri` where appropriate.

#### Intended Effect:

Reduce memory size for matrix division.

#### How to Verify:

Unit tests still pass.

#### Side Effects:

May be a bit slower according to @rtrangucci 

#### Documentation:

I added doc and tests for `mdivide_left_tri_low` showing how it's used as a view and gets the right values.  Other tests for `mdivide_left_tri` remain.

#### Reviewer Suggestions: 

Anyone.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
