### PR TITLE
Added "append_array" function to address Issue 481

### DIFF
--- a/stan/math/prim/arr.hpp
+++ b/stan/math/prim/arr.hpp
@@ -15,6 +15,7 @@
 #include <stan/math/prim/arr/err/check_nonzero_size.hpp>
 #include <stan/math/prim/arr/err/check_ordered.hpp>
 
+#include <stan/math/prim/arr/fun/append_array.hpp>
 #include <stan/math/prim/arr/fun/array_builder.hpp>
 #include <stan/math/prim/arr/fun/common_type.hpp>
 #include <stan/math/prim/arr/fun/dot.hpp>

--- a/stan/math/prim/arr/fun/append_array.hpp
+++ b/stan/math/prim/arr/fun/append_array.hpp
@@ -1,0 +1,31 @@
+#ifndef STAN_MATH_PRIM_ARR_FUN_APPEND_ARRAY_HPP
+#define STAN_MATH_PRIM_ARR_FUN_APPEND_ARRAY_HPP
+
+#include <boost/math/tools/promotion.hpp>
+#include <vector>
+
+namespace stan {
+  namespace math {
+
+    /**
+     * Return the concatenation of two specified vectors in the order of
+     *   the arguments
+     *
+     * @tparam T1 Scalar type of first vector.
+     * @tparam T2 Scalar Type of second vector.
+     * @param x First vector.
+     * @param y Second vector.
+     * @return A vector of x and y concatenated together (in that order).
+     */
+    template <typename T1, typename T2>
+    std::vector<typename boost::math::tools::promote_args<T1, T2>::type>
+    append_array(const std::vector<T1>& x, const std::vector<T2>& y) {
+      std::vector<typename boost::math::tools::promote_args<T1, T2>::type> z;
+      z.reserve(x.size() + y.size());
+      z.insert(z.end(), x.begin(), x.end());
+      z.insert(z.end(), y.begin(), y.end());
+      return z;
+    }
+  }
+}
+#endif

--- a/test/unit/math/fwd/arr/fun/append_array_test.cpp
+++ b/test/unit/math/fwd/arr/fun/append_array_test.cpp
@@ -1,0 +1,322 @@
+#include <stan/math/fwd/arr.hpp>
+#include <gtest/gtest.h>
+
+TEST(AgradFwd, append_array_double_fvar) {
+  std::vector<double> x(3);
+  std::vector<stan::math::fvar<double> > y(2), result;
+
+  x[0] = 1.0;
+  x[1] = 2.0;
+  x[2] = 3.0;
+  y[0] = 0.5;
+  y[0].d_ = 5.0;
+  y[1] = 4.0;
+  y[1].d_ = 6.0;
+
+  EXPECT_NO_THROW(result = stan::math::append_array(x, y));
+  EXPECT_EQ(5, result.size());
+
+  EXPECT_FLOAT_EQ(1.0, result[0].val());
+  EXPECT_FLOAT_EQ(2.0, result[1].val());
+  EXPECT_FLOAT_EQ(3.0, result[2].val());
+  EXPECT_FLOAT_EQ(0.5, result[3].val());
+  EXPECT_FLOAT_EQ(4.0, result[4].val());
+
+  EXPECT_FLOAT_EQ(0.0, result[0].tangent());
+  EXPECT_FLOAT_EQ(0.0, result[1].tangent());
+  EXPECT_FLOAT_EQ(0.0, result[2].tangent());
+  EXPECT_FLOAT_EQ(5.0, result[3].tangent());
+  EXPECT_FLOAT_EQ(6.0, result[4].tangent());
+}
+
+TEST(AgradFwd, append_array_fvar_double) {
+  std::vector<double> x(2);
+  std::vector<stan::math::fvar<double> > y(3), result;
+
+  x[0] = 1.0;
+  x[1] = 2.0;
+  y[0] = 5.0;
+  y[0].d_ = 1.5;
+  y[1] = 6.0;
+  y[1].d_ = 2.5;
+  y[2] = 7.0;
+  y[2].d_ = 3.5;
+
+  EXPECT_NO_THROW(result = stan::math::append_array(y, x));
+  EXPECT_EQ(5, result.size());
+  EXPECT_FLOAT_EQ(5.0, result[0].val());
+  EXPECT_FLOAT_EQ(6.0, result[1].val());
+  EXPECT_FLOAT_EQ(7.0, result[2].val());
+  EXPECT_FLOAT_EQ(1.0, result[3].val());
+  EXPECT_FLOAT_EQ(2.0, result[4].val());
+
+  EXPECT_FLOAT_EQ(1.5, result[0].tangent());
+  EXPECT_FLOAT_EQ(2.5, result[1].tangent());
+  EXPECT_FLOAT_EQ(3.5, result[2].tangent());
+  EXPECT_FLOAT_EQ(0.0, result[3].tangent());
+  EXPECT_FLOAT_EQ(0.0, result[4].tangent());
+}
+
+TEST(AgradFwd, append_array_double_fvar_fvar) {
+  std::vector<double> x(3);
+  std::vector<stan::math::fvar<stan::math::fvar<double> > > y(2), result;
+
+  x[0] = 1.0;
+  x[1] = 2.0;
+  x[2] = 3.0;
+  y[0] = 0.5;
+  y[0].val_.d_ = 1.5;
+  y[0].d_ = 5.0;
+  y[0].d_.d_ = 2.5;
+  y[1] = 4.0;
+  y[1].val_.d_ = 3.5;
+  y[1].d_ = 6.0;
+  y[1].d_.d_ = 4.5;
+
+  EXPECT_NO_THROW(result = stan::math::append_array(x, y));
+  EXPECT_EQ(5, result.size());
+
+  EXPECT_FLOAT_EQ(1.0, result[0].val().val());
+  EXPECT_FLOAT_EQ(2.0, result[1].val().val());
+  EXPECT_FLOAT_EQ(3.0, result[2].val().val());
+  EXPECT_FLOAT_EQ(0.5, result[3].val().val());
+  EXPECT_FLOAT_EQ(4.0, result[4].val().val());
+
+  EXPECT_FLOAT_EQ(0.0, result[0].val().tangent());
+  EXPECT_FLOAT_EQ(0.0, result[1].val().tangent());
+  EXPECT_FLOAT_EQ(0.0, result[2].val().tangent());
+  EXPECT_FLOAT_EQ(1.5, result[3].val().tangent());
+  EXPECT_FLOAT_EQ(3.5, result[4].val().tangent());
+
+  EXPECT_FLOAT_EQ(0.0, result[0].tangent().val());
+  EXPECT_FLOAT_EQ(0.0, result[1].tangent().val());
+  EXPECT_FLOAT_EQ(0.0, result[2].tangent().val());
+  EXPECT_FLOAT_EQ(5.0, result[3].tangent().val());
+  EXPECT_FLOAT_EQ(6.0, result[4].tangent().val());
+
+  EXPECT_FLOAT_EQ(0.0, result[0].tangent().tangent());
+  EXPECT_FLOAT_EQ(0.0, result[1].tangent().tangent());
+  EXPECT_FLOAT_EQ(0.0, result[2].tangent().tangent());
+  EXPECT_FLOAT_EQ(2.5, result[3].tangent().tangent());
+  EXPECT_FLOAT_EQ(4.5, result[4].tangent().tangent());
+}
+
+TEST(AgradFwd, append_array_fvar_fvar_double) {
+  std::vector<double> x(2);
+  std::vector<stan::math::fvar<stan::math::fvar<double> > > y(3), result;
+
+  x[0] = 1.0;
+  x[1] = 2.0;
+  y[0] = 5.0;
+  y[0].val_.d_ = 11.0;
+  y[0].d_ = 1.5;
+  y[0].d_.d_ = 15.0;
+  y[1] = 6.0;
+  y[1].val_.d_ = 12.0;
+  y[1].d_ = 2.5;
+  y[1].d_.d_ = 16.0;
+  y[2] = 7.0;
+  y[2].val_.d_ = 13.0;
+  y[2].d_ = 3.5;
+  y[2].d_.d_ = 17.0;
+
+  EXPECT_NO_THROW(result = stan::math::append_array(y, x));
+  EXPECT_EQ(5, result.size());
+  EXPECT_FLOAT_EQ(5.0, result[0].val().val());
+  EXPECT_FLOAT_EQ(6.0, result[1].val().val());
+  EXPECT_FLOAT_EQ(7.0, result[2].val().val());
+  EXPECT_FLOAT_EQ(1.0, result[3].val().val());
+  EXPECT_FLOAT_EQ(2.0, result[4].val().val());
+
+  EXPECT_FLOAT_EQ(11.0, result[0].val().tangent());
+  EXPECT_FLOAT_EQ(12.0, result[1].val().tangent());
+  EXPECT_FLOAT_EQ(13.0, result[2].val().tangent());
+  EXPECT_FLOAT_EQ(0.0, result[3].val().tangent());
+  EXPECT_FLOAT_EQ(0.0, result[4].val().tangent());
+
+  EXPECT_FLOAT_EQ(1.5, result[0].tangent().val());
+  EXPECT_FLOAT_EQ(2.5, result[1].tangent().val());
+  EXPECT_FLOAT_EQ(3.5, result[2].tangent().val());
+  EXPECT_FLOAT_EQ(0.0, result[3].tangent().val());
+  EXPECT_FLOAT_EQ(0.0, result[4].tangent().val());
+
+  EXPECT_FLOAT_EQ(15.0, result[0].tangent().tangent());
+  EXPECT_FLOAT_EQ(16.0, result[1].tangent().tangent());
+  EXPECT_FLOAT_EQ(17.0, result[2].tangent().tangent());
+  EXPECT_FLOAT_EQ(0.0, result[3].tangent().tangent());
+  EXPECT_FLOAT_EQ(0.0, result[4].tangent().tangent());
+}
+
+TEST(AgradFwd, append_array_fvar_fvar) {
+  std::vector<stan::math::fvar<double> > x(3), y(2), result;
+
+  x[0] = 5.0;
+  x[0].d_ = 1.5;
+  x[1] = 6.0;
+  x[1].d_ = 0.5;
+  x[2] = 7.0;
+  x[2].d_ = -1.5;
+  y[0] = 0.5;
+  y[0].d_ = 2.5;
+  y[1] = 4.0;
+  y[1].d_ = -5.0;
+
+  EXPECT_NO_THROW(result = stan::math::append_array(x, y));
+  EXPECT_EQ(5, result.size());
+  EXPECT_FLOAT_EQ(5.0, result[0].val());
+  EXPECT_FLOAT_EQ(6.0, result[1].val());
+  EXPECT_FLOAT_EQ(7.0, result[2].val());
+  EXPECT_FLOAT_EQ(0.5, result[3].val());
+  EXPECT_FLOAT_EQ(4.0, result[4].val());
+
+  EXPECT_FLOAT_EQ(1.5, result[0].tangent());
+  EXPECT_FLOAT_EQ(0.5, result[1].tangent());
+  EXPECT_FLOAT_EQ(-1.5, result[2].tangent());
+  EXPECT_FLOAT_EQ(2.5, result[3].tangent());
+  EXPECT_FLOAT_EQ(-5.0, result[4].tangent());
+}
+
+TEST(AgradFwd, append_array_fvar_fvar_fvar1) {
+  std::vector<stan::math::fvar<double> > x(3);
+  std::vector<stan::math::fvar<stan::math::fvar<double> > > y(2), result;
+
+  x[0] = 5.0;
+  x[0].d_ = 1.5;
+  x[1] = 6.0;
+  x[1].d_ = 0.5;
+  x[2] = 7.0;
+  x[2].d_ = -1.5;
+  y[0] = 0.5;
+  y[0].val_.d_ = 11.0;
+  y[0].d_ = 2.5;
+  y[0].d_.d_ = 15.0;
+  y[1] = 4.0;
+  y[1].val_.d_ = 12.0;
+  y[1].d_ = -5.0;
+  y[1].d_.d_ = 16.0;
+
+  EXPECT_NO_THROW(result = stan::math::append_array(x, y));
+  EXPECT_EQ(5, result.size());
+  EXPECT_FLOAT_EQ(5.0, result[0].val().val());
+  EXPECT_FLOAT_EQ(6.0, result[1].val().val());
+  EXPECT_FLOAT_EQ(7.0, result[2].val().val());
+  EXPECT_FLOAT_EQ(0.5, result[3].val().val());
+  EXPECT_FLOAT_EQ(4.0, result[4].val().val());
+
+  EXPECT_FLOAT_EQ(1.5, result[0].val().tangent());
+  EXPECT_FLOAT_EQ(0.5, result[1].val().tangent());
+  EXPECT_FLOAT_EQ(-1.5, result[2].val().tangent());
+  EXPECT_FLOAT_EQ(11.0, result[3].val().tangent());
+  EXPECT_FLOAT_EQ(12.0, result[4].val().tangent());
+
+  EXPECT_FLOAT_EQ(0.0, result[0].tangent().val());
+  EXPECT_FLOAT_EQ(0.0, result[1].tangent().val());
+  EXPECT_FLOAT_EQ(0.0, result[2].tangent().val());
+  EXPECT_FLOAT_EQ(2.5, result[3].tangent().val());
+  EXPECT_FLOAT_EQ(-5.0, result[4].tangent().val());
+
+  EXPECT_FLOAT_EQ(0.0, result[0].tangent().tangent());
+  EXPECT_FLOAT_EQ(0.0, result[1].tangent().tangent());
+  EXPECT_FLOAT_EQ(0.0, result[2].tangent().tangent());
+  EXPECT_FLOAT_EQ(15.0, result[3].tangent().tangent());
+  EXPECT_FLOAT_EQ(16.0, result[4].tangent().tangent());
+}
+
+TEST(AgradFwd, append_array_fvar_fvar_fvar2) {
+  std::vector<stan::math::fvar<double> > y(2);
+  std::vector<stan::math::fvar<stan::math::fvar<double> > > x(3), result;
+
+  x[0] = 5.0;
+  x[0].val_.d_ = 11.0;
+  x[0].d_ = 1.5;
+  x[0].d_.d_ = 15.0;
+  x[1] = 6.0;
+  x[1].val_.d_ = 12.0;
+  x[1].d_ = 0.5;
+  x[1].d_.d_ = 16.0;
+  x[2] = 7.0;
+  x[2].val_.d_ = 13.0;
+  x[2].d_ = -1.5;
+  x[2].d_.d_ = 17.0;
+  y[0] = 0.5;
+  y[0].d_ = 2.5;
+  y[1] = 4.0;
+  y[1].d_ = -5.0;
+
+  EXPECT_NO_THROW(result = stan::math::append_array(x, y));
+  EXPECT_EQ(5, result.size());
+  EXPECT_FLOAT_EQ(5.0, result[0].val().val());
+  EXPECT_FLOAT_EQ(6.0, result[1].val().val());
+  EXPECT_FLOAT_EQ(7.0, result[2].val().val());
+  EXPECT_FLOAT_EQ(0.5, result[3].val().val());
+  EXPECT_FLOAT_EQ(4.0, result[4].val().val());
+
+  EXPECT_FLOAT_EQ(11.0, result[0].val().tangent());
+  EXPECT_FLOAT_EQ(12.0, result[1].val().tangent());
+  EXPECT_FLOAT_EQ(13.0, result[2].val().tangent());
+  EXPECT_FLOAT_EQ(2.5, result[3].val().tangent());
+  EXPECT_FLOAT_EQ(-5.0, result[4].val().tangent());
+
+  EXPECT_FLOAT_EQ(1.5, result[0].tangent().val());
+  EXPECT_FLOAT_EQ(0.5, result[1].tangent().val());
+  EXPECT_FLOAT_EQ(-1.5, result[2].tangent().val());
+  EXPECT_FLOAT_EQ(0.0, result[3].tangent().val());
+  EXPECT_FLOAT_EQ(0.0, result[4].tangent().val());
+
+  EXPECT_FLOAT_EQ(15.0, result[0].tangent().tangent());
+  EXPECT_FLOAT_EQ(16.0, result[1].tangent().tangent());
+  EXPECT_FLOAT_EQ(17.0, result[2].tangent().tangent());
+  EXPECT_FLOAT_EQ(0.0, result[3].tangent().tangent());
+  EXPECT_FLOAT_EQ(0.0, result[4].tangent().tangent());
+}
+
+TEST(AgradFwd, append_array_fvar_fvar_fvar_fvar) {
+  std::vector<stan::math::fvar<stan::math::fvar<double> > > x(3), y(2), result;
+
+  x[0] = 5.0;
+  x[0].val_.d_ = 11.0;
+  x[0].d_ = 1.5;
+  x[0].d_.d_ = 16.0;
+  x[1] = 6.0;
+  x[1].val_.d_ = 12.0;
+  x[1].d_ = 0.5;
+  x[1].d_.d_ = 17.0;
+  x[2] = 7.0;
+  x[2].val_.d_ = 13.0;
+  x[2].d_ = -1.5;
+  x[2].d_.d_ = 18.0;
+  y[0] = 0.5;
+  y[0].val_.d_ = 14.0;
+  y[0].d_ = 2.5;
+  y[0].d_.d_ = 19.0;
+  y[1] = 4.0;
+  y[1].val_.d_ = 15.0;
+  y[1].d_ = -5.0;
+  y[1].d_.d_ = 20.0;
+
+  EXPECT_NO_THROW(result = stan::math::append_array(x, y));
+  EXPECT_EQ(5, result.size());
+  EXPECT_FLOAT_EQ(5.0, result[0].val().val());
+  EXPECT_FLOAT_EQ(6.0, result[1].val().val());
+  EXPECT_FLOAT_EQ(7.0, result[2].val().val());
+  EXPECT_FLOAT_EQ(0.5, result[3].val().val());
+  EXPECT_FLOAT_EQ(4.0, result[4].val().val());
+
+  EXPECT_FLOAT_EQ(1.5, result[0].tangent().val());
+  EXPECT_FLOAT_EQ(0.5, result[1].tangent().val());
+  EXPECT_FLOAT_EQ(-1.5, result[2].tangent().val());
+  EXPECT_FLOAT_EQ(2.5, result[3].tangent().val());
+  EXPECT_FLOAT_EQ(-5.0, result[4].tangent().val());
+
+  EXPECT_FLOAT_EQ(11.0, result[0].val().tangent());
+  EXPECT_FLOAT_EQ(12.0, result[1].val().tangent());
+  EXPECT_FLOAT_EQ(13.0, result[2].val().tangent());
+  EXPECT_FLOAT_EQ(14.0, result[3].val().tangent());
+  EXPECT_FLOAT_EQ(15.0, result[4].val().tangent());
+
+  EXPECT_FLOAT_EQ(16.0, result[0].tangent().tangent());
+  EXPECT_FLOAT_EQ(17.0, result[1].tangent().tangent());
+  EXPECT_FLOAT_EQ(18.0, result[2].tangent().tangent());
+  EXPECT_FLOAT_EQ(19.0, result[3].tangent().tangent());
+  EXPECT_FLOAT_EQ(20.0, result[4].tangent().tangent());
+}

--- a/test/unit/math/mix/arr/fun/append_array_test.cpp
+++ b/test/unit/math/mix/arr/fun/append_array_test.cpp
@@ -1,0 +1,580 @@
+#include <stan/math/mix/arr.hpp>
+#include <gtest/gtest.h>
+
+TEST(AgradMix, append_array_fvar_fvar_var_fvar_var) {
+  std::vector<stan::math::fvar<stan::math::var> > x(2);
+  std::vector<stan::math::fvar<stan::math::fvar<stan::math::var> > > y(3), result;
+
+  x[0] = 1.0;
+  x[0].d_ = 2.5;
+  x[1] = 2.0;
+  x[1].d_ = 3.5;
+  y[0] = 5.0;
+  y[0].d_ = 1.5;
+  y[1] = 6.0;
+  y[1].d_ = -2.5;
+  y[2] = 7.0;
+  y[2].d_ = -3.5;
+
+  EXPECT_NO_THROW(result = stan::math::append_array(y, x));
+  EXPECT_EQ(5, result.size());
+  EXPECT_FLOAT_EQ(5.0, result[0].val().val().val());
+  EXPECT_FLOAT_EQ(6.0, result[1].val().val().val());
+  EXPECT_FLOAT_EQ(7.0, result[2].val().val().val());
+  EXPECT_FLOAT_EQ(1.0, result[3].val().val().val());
+  EXPECT_FLOAT_EQ(2.0, result[4].val().val().val());
+
+  EXPECT_FLOAT_EQ(1.5, result[0].tangent().val().val());
+  EXPECT_FLOAT_EQ(-2.5, result[1].tangent().val().val());
+  EXPECT_FLOAT_EQ(-3.5, result[2].tangent().val().val());
+  EXPECT_FLOAT_EQ(0.0, result[3].tangent().val().val());
+  EXPECT_FLOAT_EQ(0.0, result[4].tangent().val().val());
+
+  EXPECT_FLOAT_EQ(0.0, result[0].val().tangent().val());
+  EXPECT_FLOAT_EQ(0.0, result[1].val().tangent().val());
+  EXPECT_FLOAT_EQ(0.0, result[2].val().tangent().val());
+  EXPECT_FLOAT_EQ(2.5, result[3].val().tangent().val());
+  EXPECT_FLOAT_EQ(3.5, result[4].val().tangent().val());
+
+  for(unsigned int i = 0; i < result.size(); i++) {
+    EXPECT_FLOAT_EQ(0.0, result[i].tangent().tangent().val());
+  }
+
+  for(unsigned int i = 0; i < result.size(); i++) {
+    stan::math::set_zero_all_adjoints();
+
+    result[i].val().val().grad();
+
+    for(unsigned int j = 0; j < y.size(); j++) {
+      EXPECT_FLOAT_EQ(0.0, y[j].tangent().val().adj());
+      EXPECT_FLOAT_EQ(0.0, y[j].val().tangent().adj());
+      EXPECT_FLOAT_EQ(0.0, y[j].tangent().tangent().adj());
+    }
+
+    for(unsigned int j = 0; j < x.size(); j++) {
+      EXPECT_FLOAT_EQ(0.0, x[j].tangent().adj());
+    }
+
+    if(i == 0)
+      EXPECT_FLOAT_EQ(1.0, y[0].val().val().adj());
+    else
+      EXPECT_FLOAT_EQ(0.0, y[0].val().val().adj());
+
+    if(i == 1)
+      EXPECT_FLOAT_EQ(1.0, y[1].val().val().adj());
+    else
+      EXPECT_FLOAT_EQ(0.0, y[1].val().val().adj());
+
+    if(i == 2)
+      EXPECT_FLOAT_EQ(1.0, y[2].val().val().adj());
+    else
+      EXPECT_FLOAT_EQ(0.0, y[2].val().val().adj());
+
+    if(i == 3)
+      EXPECT_FLOAT_EQ(1.0, x[0].val().adj());
+    else
+      EXPECT_FLOAT_EQ(0.0, x[0].val().adj());
+
+    if(i == 4)
+      EXPECT_FLOAT_EQ(1.0, x[1].val().adj());
+    else
+      EXPECT_FLOAT_EQ(0.0, x[1].val().adj());
+  }
+
+  for(unsigned int i = 0; i < result.size(); i++) {
+    stan::math::set_zero_all_adjoints();
+
+    result[i].val().tangent().grad();
+
+    for(unsigned int j = 0; j < y.size(); j++) {
+      EXPECT_FLOAT_EQ(0.0, y[j].val().val().adj());
+      EXPECT_FLOAT_EQ(0.0, y[j].tangent().val().adj());
+      EXPECT_FLOAT_EQ(0.0, y[j].tangent().tangent().adj());
+    }
+
+    for(unsigned int j = 0; j < x.size(); j++) {
+      EXPECT_FLOAT_EQ(0.0, x[j].val().adj());
+    }
+
+    if(i == 0)
+      EXPECT_FLOAT_EQ(1.0, y[0].val().tangent().adj());
+    else
+      EXPECT_FLOAT_EQ(0.0, y[0].val().tangent().adj());
+
+    if(i == 1)
+      EXPECT_FLOAT_EQ(1.0, y[1].val().tangent().adj());
+    else
+      EXPECT_FLOAT_EQ(0.0, y[1].val().tangent().adj());
+
+    if(i == 2)
+      EXPECT_FLOAT_EQ(1.0, y[2].val().tangent().adj());
+    else
+      EXPECT_FLOAT_EQ(0.0, y[2].val().tangent().adj());
+
+    if(i == 3)
+      EXPECT_FLOAT_EQ(1.0, x[0].tangent().adj());
+    else
+      EXPECT_FLOAT_EQ(0.0, x[0].tangent().adj());
+
+    if(i == 4)
+      EXPECT_FLOAT_EQ(1.0, x[1].tangent().adj());
+    else
+      EXPECT_FLOAT_EQ(0.0, x[1].tangent().adj());
+  }
+
+  for(unsigned int i = 0; i < result.size(); i++) {
+    stan::math::set_zero_all_adjoints();
+
+    result[i].tangent().val().grad();
+
+    for(unsigned int j = 0; j < y.size(); j++) {
+      EXPECT_FLOAT_EQ(0.0, y[j].val().val().adj());
+      EXPECT_FLOAT_EQ(0.0, y[j].val().tangent().adj());
+      EXPECT_FLOAT_EQ(0.0, y[j].tangent().tangent().adj());
+    }
+
+    for(unsigned int j = 0; j < x.size(); j++) {
+      EXPECT_FLOAT_EQ(0.0, x[j].val().adj());
+      EXPECT_FLOAT_EQ(0.0, x[j].tangent().adj());
+    }
+
+    if(i == 0)
+      EXPECT_FLOAT_EQ(1.0, y[0].tangent().val().adj());
+    else
+      EXPECT_FLOAT_EQ(0.0, y[0].tangent().val().adj());
+
+    if(i == 1)
+      EXPECT_FLOAT_EQ(1.0, y[1].tangent().val().adj());
+    else
+      EXPECT_FLOAT_EQ(0.0, y[1].tangent().val().adj());
+
+    if(i == 2)
+      EXPECT_FLOAT_EQ(1.0, y[2].tangent().val().adj());
+    else
+      EXPECT_FLOAT_EQ(0.0, y[2].tangent().val().adj());
+  }
+
+  for(unsigned int i = 0; i < result.size(); i++) {
+    stan::math::set_zero_all_adjoints();
+
+    result[i].tangent().tangent().grad();
+
+    for(unsigned int j = 0; j < y.size(); j++) {
+      EXPECT_FLOAT_EQ(0.0, y[j].val().val().adj());
+      EXPECT_FLOAT_EQ(0.0, y[j].tangent().val().adj());
+      EXPECT_FLOAT_EQ(0.0, y[j].val().tangent().adj());
+    }
+
+    for(unsigned int j = 0; j < x.size(); j++) {
+      EXPECT_FLOAT_EQ(0.0, x[j].val().adj());
+      EXPECT_FLOAT_EQ(0.0, x[j].tangent().adj());
+    }
+
+    if(i == 0)
+      EXPECT_FLOAT_EQ(1.0, y[0].tangent().tangent().adj());
+    else
+      EXPECT_FLOAT_EQ(0.0, y[0].tangent().tangent().adj());
+
+    if(i == 1)
+      EXPECT_FLOAT_EQ(1.0, y[1].tangent().tangent().adj());
+    else
+      EXPECT_FLOAT_EQ(0.0, y[1].tangent().tangent().adj());
+
+    if(i == 2)
+      EXPECT_FLOAT_EQ(1.0, y[2].tangent().tangent().adj());
+    else
+      EXPECT_FLOAT_EQ(0.0, y[2].tangent().tangent().adj());
+  }
+}
+
+TEST(AgradMix, append_array_fvar_var_fvar_fvar_var) {
+  std::vector<stan::math::fvar<stan::math::var> > x(2);
+  std::vector<stan::math::fvar<stan::math::fvar<stan::math::var> > > y(3), result;
+
+  x[0] = 1.0;
+  x[0].d_ = 2.5;
+  x[1] = 2.0;
+  x[1].d_ = 3.5;
+  y[0] = 5.0;
+  y[0].d_ = 1.5;
+  y[1] = 6.0;
+  y[1].d_ = -2.5;
+  y[2] = 7.0;
+  y[2].d_ = -3.5;
+
+  EXPECT_NO_THROW(result = stan::math::append_array(x, y));
+  EXPECT_EQ(5, result.size());
+  EXPECT_FLOAT_EQ(1.0, result[0].val().val().val());
+  EXPECT_FLOAT_EQ(2.0, result[1].val().val().val());
+  EXPECT_FLOAT_EQ(5.0, result[2].val().val().val());
+  EXPECT_FLOAT_EQ(6.0, result[3].val().val().val());
+  EXPECT_FLOAT_EQ(7.0, result[4].val().val().val());
+
+  EXPECT_FLOAT_EQ(0.0, result[0].tangent().val().val());
+  EXPECT_FLOAT_EQ(0.0, result[1].tangent().val().val());
+  EXPECT_FLOAT_EQ(1.5, result[2].tangent().val().val());
+  EXPECT_FLOAT_EQ(-2.5, result[3].tangent().val().val());
+  EXPECT_FLOAT_EQ(-3.5, result[4].tangent().val().val());
+
+  EXPECT_FLOAT_EQ(2.5, result[0].val().tangent().val());
+  EXPECT_FLOAT_EQ(3.5, result[1].val().tangent().val());
+  EXPECT_FLOAT_EQ(0.0, result[2].val().tangent().val());
+  EXPECT_FLOAT_EQ(0.0, result[3].val().tangent().val());
+  EXPECT_FLOAT_EQ(0.0, result[4].val().tangent().val());
+
+  for(unsigned int i = 0; i < result.size(); i++) {
+    EXPECT_FLOAT_EQ(0.0, result[i].tangent().tangent().val());
+  }
+
+  for(unsigned int i = 0; i < result.size(); i++) {
+    stan::math::set_zero_all_adjoints();
+
+    result[i].val().val().grad();
+
+    for(unsigned int j = 0; j < y.size(); j++) {
+      EXPECT_FLOAT_EQ(0.0, y[j].tangent().val().adj());
+      EXPECT_FLOAT_EQ(0.0, y[j].val().tangent().adj());
+      EXPECT_FLOAT_EQ(0.0, y[j].tangent().tangent().adj());
+    }
+
+    for(unsigned int j = 0; j < x.size(); j++) {
+      EXPECT_FLOAT_EQ(0.0, x[j].tangent().adj());
+    }
+
+    if(i == 0)
+      EXPECT_FLOAT_EQ(1.0, x[0].val().adj());
+    else
+      EXPECT_FLOAT_EQ(0.0, x[0].val().adj());
+
+    if(i == 1)
+      EXPECT_FLOAT_EQ(1.0, x[1].val().adj());
+    else
+      EXPECT_FLOAT_EQ(0.0, x[1].val().adj());
+
+    if(i == 2)
+      EXPECT_FLOAT_EQ(1.0, y[0].val().val().adj());
+    else
+      EXPECT_FLOAT_EQ(0.0, y[0].val().val().adj());
+
+    if(i == 3)
+      EXPECT_FLOAT_EQ(1.0, y[1].val().val().adj());
+    else
+      EXPECT_FLOAT_EQ(0.0, y[1].val().val().adj());
+
+    if(i == 4)
+      EXPECT_FLOAT_EQ(1.0, y[2].val().val().adj());
+    else
+      EXPECT_FLOAT_EQ(0.0, y[2].val().val().adj());
+  }
+
+  for(unsigned int i = 0; i < result.size(); i++) {
+    stan::math::set_zero_all_adjoints();
+
+    result[i].tangent().val().grad();
+
+    for(unsigned int j = 0; j < y.size(); j++) {
+      EXPECT_FLOAT_EQ(0.0, y[j].val().val().adj());
+      EXPECT_FLOAT_EQ(0.0, y[j].val().tangent().adj());
+      EXPECT_FLOAT_EQ(0.0, y[j].tangent().tangent().adj());
+    }
+
+    for(unsigned int j = 0; j < x.size(); j++) {
+      EXPECT_FLOAT_EQ(0.0, x[j].val().adj());
+      EXPECT_FLOAT_EQ(0.0, x[j].tangent().adj());
+    }
+
+    if(i == 2)
+      EXPECT_FLOAT_EQ(1.0, y[0].tangent().val().adj());
+    else
+      EXPECT_FLOAT_EQ(0.0, y[0].tangent().val().adj());
+
+    if(i == 3)
+      EXPECT_FLOAT_EQ(1.0, y[1].tangent().val().adj());
+    else
+      EXPECT_FLOAT_EQ(0.0, y[1].tangent().val().adj());
+
+    if(i == 4)
+      EXPECT_FLOAT_EQ(1.0, y[2].tangent().val().adj());
+    else
+      EXPECT_FLOAT_EQ(0.0, y[2].tangent().val().adj());
+  }
+
+  for(unsigned int i = 0; i < result.size(); i++) {
+    stan::math::set_zero_all_adjoints();
+
+    result[i].val().tangent().grad();
+
+    for(unsigned int j = 0; j < y.size(); j++) {
+      EXPECT_FLOAT_EQ(0.0, y[j].val().val().adj());
+      EXPECT_FLOAT_EQ(0.0, y[j].tangent().val().adj());
+      EXPECT_FLOAT_EQ(0.0, y[j].tangent().tangent().adj());
+    }
+
+    for(unsigned int j = 0; j < x.size(); j++) {
+      EXPECT_FLOAT_EQ(0.0, x[j].val().adj());
+    }
+
+    if(i == 0)
+      EXPECT_FLOAT_EQ(1.0, x[0].tangent().adj());
+    else
+      EXPECT_FLOAT_EQ(0.0, x[0].tangent().adj());
+
+    if(i == 1)
+      EXPECT_FLOAT_EQ(1.0, x[1].tangent().adj());
+    else
+      EXPECT_FLOAT_EQ(0.0, x[1].tangent().adj());
+
+    if(i == 2)
+      EXPECT_FLOAT_EQ(1.0, y[0].val().tangent().adj());
+    else
+      EXPECT_FLOAT_EQ(0.0, y[0].val().tangent().adj());
+
+    if(i == 3)
+      EXPECT_FLOAT_EQ(1.0, y[1].val().tangent().adj());
+    else
+      EXPECT_FLOAT_EQ(0.0, y[1].val().tangent().adj());
+
+    if(i == 4)
+      EXPECT_FLOAT_EQ(1.0, y[2].val().tangent().adj());
+    else
+      EXPECT_FLOAT_EQ(0.0, y[2].val().tangent().adj());
+  }
+
+  for(unsigned int i = 0; i < result.size(); i++) {
+    stan::math::set_zero_all_adjoints();
+
+    result[i].tangent().tangent().grad();
+
+    for(unsigned int j = 0; j < y.size(); j++) {
+      EXPECT_FLOAT_EQ(0.0, y[j].val().val().adj());
+      EXPECT_FLOAT_EQ(0.0, y[j].tangent().val().adj());
+      EXPECT_FLOAT_EQ(0.0, y[j].val().tangent().adj());
+    }
+
+    for(unsigned int j = 0; j < x.size(); j++) {
+      EXPECT_FLOAT_EQ(0.0, x[j].val().adj());
+      EXPECT_FLOAT_EQ(0.0, x[j].tangent().adj());
+    }
+
+    if(i == 2)
+      EXPECT_FLOAT_EQ(1.0, y[0].tangent().tangent().adj());
+    else
+      EXPECT_FLOAT_EQ(0.0, y[0].tangent().tangent().adj());
+
+    if(i == 3)
+      EXPECT_FLOAT_EQ(1.0, y[1].tangent().tangent().adj());
+    else
+      EXPECT_FLOAT_EQ(0.0, y[1].tangent().tangent().adj());
+
+    if(i == 4)
+      EXPECT_FLOAT_EQ(1.0, y[2].tangent().tangent().adj());
+    else
+      EXPECT_FLOAT_EQ(0.0, y[2].tangent().tangent().adj());
+  }
+}
+
+TEST(AgradMix, append_array_fvar_fvar_var_fvar_fvar_var) {
+  std::vector<stan::math::fvar<stan::math::fvar<stan::math::var> > > x(2), y(3), result;
+
+  x[0] = 1.0;
+  x[0].d_ = 2.5;
+  x[1] = 2.0;
+  x[1].d_ = 3.5;
+  y[0] = 5.0;
+  y[0].d_ = 1.5;
+  y[1] = 6.0;
+  y[1].d_ = -2.5;
+  y[2] = 7.0;
+  y[2].d_ = -3.5;
+
+  EXPECT_NO_THROW(result = stan::math::append_array(x, y));
+  EXPECT_EQ(5, result.size());
+  EXPECT_FLOAT_EQ(1.0, result[0].val().val().val());
+  EXPECT_FLOAT_EQ(2.0, result[1].val().val().val());
+  EXPECT_FLOAT_EQ(5.0, result[2].val().val().val());
+  EXPECT_FLOAT_EQ(6.0, result[3].val().val().val());
+  EXPECT_FLOAT_EQ(7.0, result[4].val().val().val());
+
+  EXPECT_FLOAT_EQ(2.5, result[0].tangent().val().val());
+  EXPECT_FLOAT_EQ(3.5, result[1].tangent().val().val());
+  EXPECT_FLOAT_EQ(1.5, result[2].tangent().val().val());
+  EXPECT_FLOAT_EQ(-2.5, result[3].tangent().val().val());
+  EXPECT_FLOAT_EQ(-3.5, result[4].tangent().val().val());
+
+  for(unsigned int i = 0; i < result.size(); i++) {
+    EXPECT_FLOAT_EQ(0.0, result[i].tangent().tangent().val());
+    EXPECT_FLOAT_EQ(0.0, result[i].val().tangent().val());
+  }
+
+  for(unsigned int i = 0; i < result.size(); i++) {
+    stan::math::set_zero_all_adjoints();
+
+    result[i].val().val().grad();
+
+    for(unsigned int j = 0; j < y.size(); j++) {
+      EXPECT_FLOAT_EQ(0.0, y[j].tangent().val().adj());
+      EXPECT_FLOAT_EQ(0.0, y[j].val().tangent().adj());
+      EXPECT_FLOAT_EQ(0.0, y[j].tangent().tangent().adj());
+    }
+
+    for(unsigned int j = 0; j < x.size(); j++) {
+      EXPECT_FLOAT_EQ(0.0, x[j].tangent().val().adj());
+      EXPECT_FLOAT_EQ(0.0, x[j].val().tangent().adj());
+      EXPECT_FLOAT_EQ(0.0, x[j].tangent().tangent().adj());
+    }
+
+    if(i == 0)
+      EXPECT_FLOAT_EQ(1.0, x[0].val().val().adj());
+    else
+      EXPECT_FLOAT_EQ(0.0, x[0].val().val().adj());
+
+    if(i == 1)
+      EXPECT_FLOAT_EQ(1.0, x[1].val().val().adj());
+    else
+      EXPECT_FLOAT_EQ(0.0, x[1].val().val().adj());
+
+    if(i == 2)
+      EXPECT_FLOAT_EQ(1.0, y[0].val().val().adj());
+    else
+      EXPECT_FLOAT_EQ(0.0, y[0].val().val().adj());
+
+    if(i == 3)
+      EXPECT_FLOAT_EQ(1.0, y[1].val().val().adj());
+    else
+      EXPECT_FLOAT_EQ(0.0, y[1].val().val().adj());
+
+    if(i == 4)
+      EXPECT_FLOAT_EQ(1.0, y[2].val().val().adj());
+    else
+      EXPECT_FLOAT_EQ(0.0, y[2].val().val().adj());
+  }
+
+  for(unsigned int i = 0; i < result.size(); i++) {
+    stan::math::set_zero_all_adjoints();
+
+    result[i].val().tangent().grad();
+
+    for(unsigned int j = 0; j < y.size(); j++) {
+      EXPECT_FLOAT_EQ(0.0, y[j].val().val().adj());
+      EXPECT_FLOAT_EQ(0.0, y[j].tangent().val().adj());
+      EXPECT_FLOAT_EQ(0.0, y[j].tangent().tangent().adj());
+    }
+
+    for(unsigned int j = 0; j < x.size(); j++) {
+      EXPECT_FLOAT_EQ(0.0, x[j].val().val().adj());
+      EXPECT_FLOAT_EQ(0.0, x[j].tangent().val().adj());
+      EXPECT_FLOAT_EQ(0.0, x[j].tangent().tangent().adj());
+    }
+
+    if(i == 0)
+      EXPECT_FLOAT_EQ(1.0, x[0].val().tangent().adj());
+    else
+      EXPECT_FLOAT_EQ(0.0, x[0].val().tangent().adj());
+
+    if(i == 1)
+      EXPECT_FLOAT_EQ(1.0, x[1].val().tangent().adj());
+    else
+      EXPECT_FLOAT_EQ(0.0, x[1].val().tangent().adj());
+
+    if(i == 2)
+      EXPECT_FLOAT_EQ(1.0, y[0].val().tangent().adj());
+    else
+      EXPECT_FLOAT_EQ(0.0, y[0].val().tangent().adj());
+
+    if(i == 3)
+      EXPECT_FLOAT_EQ(1.0, y[1].val().tangent().adj());
+    else
+      EXPECT_FLOAT_EQ(0.0, y[1].val().tangent().adj());
+
+    if(i == 4)
+      EXPECT_FLOAT_EQ(1.0, y[2].val().tangent().adj());
+    else          
+      EXPECT_FLOAT_EQ(0.0, y[2].val().tangent().adj());
+  }
+
+  for(unsigned int i = 0; i < result.size(); i++) {
+    stan::math::set_zero_all_adjoints();
+
+    result[i].tangent().val().grad();
+
+    for(unsigned int j = 0; j < y.size(); j++) {
+      EXPECT_FLOAT_EQ(0.0, y[j].val().val().adj());
+      EXPECT_FLOAT_EQ(0.0, y[j].val().tangent().adj());
+      EXPECT_FLOAT_EQ(0.0, y[j].tangent().tangent().adj());
+    }
+
+    for(unsigned int j = 0; j < x.size(); j++) {
+      EXPECT_FLOAT_EQ(0.0, x[j].val().val().adj());
+      EXPECT_FLOAT_EQ(0.0, x[j].val().tangent().adj());
+      EXPECT_FLOAT_EQ(0.0, x[j].tangent().tangent().adj());
+    }
+
+    if(i == 0)
+      EXPECT_FLOAT_EQ(1.0, x[0].tangent().val().adj());
+    else
+      EXPECT_FLOAT_EQ(0.0, x[0].tangent().val().adj());
+
+    if(i == 1)
+      EXPECT_FLOAT_EQ(1.0, x[1].tangent().val().adj());
+    else
+      EXPECT_FLOAT_EQ(0.0, x[1].tangent().val().adj());
+
+    if(i == 2)
+      EXPECT_FLOAT_EQ(1.0, y[0].tangent().val().adj());
+    else
+      EXPECT_FLOAT_EQ(0.0, y[0].tangent().val().adj());
+
+    if(i == 3)
+      EXPECT_FLOAT_EQ(1.0, y[1].tangent().val().adj());
+    else
+      EXPECT_FLOAT_EQ(0.0, y[1].tangent().val().adj());
+
+    if(i == 4)
+      EXPECT_FLOAT_EQ(1.0, y[2].tangent().val().adj());
+    else
+      EXPECT_FLOAT_EQ(0.0, y[2].tangent().val().adj());
+  }
+
+  for(unsigned int i = 0; i < result.size(); i++) {
+    stan::math::set_zero_all_adjoints();
+
+    result[i].tangent().tangent().grad();
+
+    for(unsigned int j = 0; j < y.size(); j++) {
+      EXPECT_FLOAT_EQ(0.0, y[j].val().val().adj());
+      EXPECT_FLOAT_EQ(0.0, y[j].val().tangent().adj());
+      EXPECT_FLOAT_EQ(0.0, y[j].tangent().val().adj());
+    }
+
+    for(unsigned int j = 0; j < x.size(); j++) {
+      EXPECT_FLOAT_EQ(0.0, x[j].val().val().adj());
+      EXPECT_FLOAT_EQ(0.0, x[j].val().tangent().adj());
+      EXPECT_FLOAT_EQ(0.0, x[j].tangent().val().adj());
+    }
+
+    if(i == 0)
+      EXPECT_FLOAT_EQ(1.0, x[0].tangent().tangent().adj());
+    else
+      EXPECT_FLOAT_EQ(0.0, x[0].tangent().tangent().adj());
+
+    if(i == 1)
+      EXPECT_FLOAT_EQ(1.0, x[1].tangent().tangent().adj());
+    else
+      EXPECT_FLOAT_EQ(0.0, x[1].tangent().tangent().adj());
+
+    if(i == 2)
+      EXPECT_FLOAT_EQ(1.0, y[0].tangent().tangent().adj());
+    else
+      EXPECT_FLOAT_EQ(0.0, y[0].tangent().tangent().adj());
+
+    if(i == 3)
+      EXPECT_FLOAT_EQ(1.0, y[1].tangent().tangent().adj());
+    else
+      EXPECT_FLOAT_EQ(0.0, y[1].tangent().tangent().adj());
+
+    if(i == 4)
+      EXPECT_FLOAT_EQ(1.0, y[2].tangent().tangent().adj());
+    else
+      EXPECT_FLOAT_EQ(0.0, y[2].tangent().tangent().adj());
+  }
+}

--- a/test/unit/math/prim/arr/fun/append_array_test.cpp
+++ b/test/unit/math/prim/arr/fun/append_array_test.cpp
@@ -1,0 +1,76 @@
+#include <stan/math/prim/arr.hpp>
+#include <gtest/gtest.h>
+
+TEST(MathFunctions, append_array) {
+  std::vector<double> x(3), y(2), z, result;
+
+  x[0] = 1.0;
+  x[1] = 2.0;
+  x[2] = 3.0;
+  y[0] = 0.5;
+  y[1] = 4.0;
+
+  EXPECT_NO_THROW(result = stan::math::append_array(x, y));
+  EXPECT_EQ(5, result.size());
+  EXPECT_FLOAT_EQ(1.0, result[0]);
+  EXPECT_FLOAT_EQ(2.0, result[1]);
+  EXPECT_FLOAT_EQ(3.0, result[2]);
+  EXPECT_FLOAT_EQ(0.5, result[3]);
+  EXPECT_FLOAT_EQ(4.0, result[4]);
+
+  EXPECT_NO_THROW(result = stan::math::append_array(x, z));
+  EXPECT_EQ(3, result.size());
+  EXPECT_FLOAT_EQ(1.0, result[0]);
+  EXPECT_FLOAT_EQ(2.0, result[1]);
+  EXPECT_FLOAT_EQ(3.0, result[2]);
+
+  EXPECT_NO_THROW(result = stan::math::append_array(z, z));
+  EXPECT_EQ(0, result.size());
+}
+
+TEST(MathFunctions, append_array_int) {
+  std::vector<double> x(3), result;
+  std::vector<int> y(2), z(3);
+
+  x[0] = 1.0;
+  x[1] = 2.0;
+  x[2] = 3.0;
+  y[0] = 5;
+  y[1] = 4;
+  z[0] = 6;
+  z[1] = 7;
+  z[2] = 8;
+
+  EXPECT_NO_THROW(result = stan::math::append_array(x, y));
+  EXPECT_EQ(5, result.size());
+  EXPECT_FLOAT_EQ(1.0, result[0]);
+  EXPECT_FLOAT_EQ(2.0, result[1]);
+  EXPECT_FLOAT_EQ(3.0, result[2]);
+  EXPECT_FLOAT_EQ(5.0, result[3]);
+  EXPECT_FLOAT_EQ(4.0, result[4]);
+
+  EXPECT_NO_THROW(result = stan::math::append_array(y, z));
+  EXPECT_EQ(5, result.size());
+  EXPECT_FLOAT_EQ(5.0, result[0]);
+  EXPECT_FLOAT_EQ(4.0, result[1]);
+  EXPECT_FLOAT_EQ(6.0, result[2]);
+  EXPECT_FLOAT_EQ(7.0, result[3]);
+  EXPECT_FLOAT_EQ(8.0, result[4]);
+}
+
+TEST(MathFunctions, append_array_nan) {
+  double nan = std::numeric_limits<double>::quiet_NaN();
+  std::vector<double> x(3), y(2), result;
+
+  x[0] = 1.0;
+  x[1] = 2.0;
+  x[2] = nan;
+  y[0] = 0.5;
+  y[1] = 1.0;
+
+  EXPECT_NO_THROW(result = stan::math::append_array(x, y));
+  EXPECT_PRED1(boost::math::isnan<double>, result[2]);
+
+  EXPECT_NO_THROW(result = stan::math::append_array(y, x));
+  EXPECT_PRED1(boost::math::isnan<double>, result[4]);
+}

--- a/test/unit/math/rev/arr/fun/append_array_test.cpp
+++ b/test/unit/math/rev/arr/fun/append_array_test.cpp
@@ -1,0 +1,126 @@
+#include <stan/math/rev/arr.hpp>
+#include <gtest/gtest.h>
+
+TEST(AgradRev, append_array_double_var) {
+  std::vector<double> x(3);
+  std::vector<stan::math::var> y(2), result;
+
+  x[0] = 1.0;
+  x[1] = 2.0;
+  x[2] = 3.0;
+  y[0] = 0.5;
+  y[1] = 4.0;
+
+  EXPECT_NO_THROW(result = stan::math::append_array(x, y));
+  EXPECT_EQ(5, result.size());
+  EXPECT_FLOAT_EQ(1.0, result[0].val());
+  EXPECT_FLOAT_EQ(2.0, result[1].val());
+  EXPECT_FLOAT_EQ(3.0, result[2].val());
+  EXPECT_FLOAT_EQ(0.5, result[3].val());
+  EXPECT_FLOAT_EQ(4.0, result[4].val());
+
+  for(unsigned int i = 0; i < result.size(); i++) {
+    stan::math::set_zero_all_adjoints();
+
+    result[i].grad();
+
+    if(i == 3)
+      EXPECT_FLOAT_EQ(1.0, y[0].adj());
+    else
+      EXPECT_FLOAT_EQ(0.0, y[0].adj());
+
+    if(i == 4)
+      EXPECT_FLOAT_EQ(1.0, y[1].adj());
+    else
+      EXPECT_FLOAT_EQ(0.0, y[1].adj());
+  }
+}
+
+TEST(AgradRev, append_array_var_double) {
+  std::vector<double> x(2);
+  std::vector<stan::math::var> y(3), result;
+
+  x[0] = 1.0;
+  x[1] = 2.0;
+  y[0] = 5.0;
+  y[1] = 6.0;
+  y[2] = 7.0;
+
+  EXPECT_NO_THROW(result = stan::math::append_array(y, x));
+  EXPECT_EQ(5, result.size());
+  EXPECT_FLOAT_EQ(5.0, result[0].val());
+  EXPECT_FLOAT_EQ(6.0, result[1].val());
+  EXPECT_FLOAT_EQ(7.0, result[2].val());
+  EXPECT_FLOAT_EQ(1.0, result[3].val());
+  EXPECT_FLOAT_EQ(2.0, result[4].val());
+
+  for(unsigned int i = 0; i < result.size(); i++) {
+    stan::math::set_zero_all_adjoints();
+
+    result[i].grad();
+
+    if(i == 0)
+      EXPECT_FLOAT_EQ(1.0, y[0].adj());
+    else
+      EXPECT_FLOAT_EQ(0.0, y[0].adj());
+
+    if(i == 1)
+      EXPECT_FLOAT_EQ(1.0, y[1].adj());
+    else
+      EXPECT_FLOAT_EQ(0.0, y[1].adj());
+
+    if(i == 2)
+      EXPECT_FLOAT_EQ(1.0, y[2].adj());
+    else
+      EXPECT_FLOAT_EQ(0.0, y[2].adj());
+  }
+}
+
+TEST(AgradRev, append_array_var_var) {
+  std::vector<stan::math::var> x(3), y(2), result;
+
+  x[0] = 5.0;
+  x[1] = 6.0;
+  x[2] = 7.0;
+  y[0] = 0.5;
+  y[1] = 4.0;
+
+  EXPECT_NO_THROW(result = stan::math::append_array(x, y));
+  EXPECT_EQ(5, result.size());
+  EXPECT_FLOAT_EQ(5.0, result[0].val());
+  EXPECT_FLOAT_EQ(6.0, result[1].val());
+  EXPECT_FLOAT_EQ(7.0, result[2].val());
+  EXPECT_FLOAT_EQ(0.5, result[3].val());
+  EXPECT_FLOAT_EQ(4.0, result[4].val());
+
+  for(unsigned int i = 0; i < result.size(); i++) {
+    stan::math::set_zero_all_adjoints();
+
+    result[i].grad();
+
+    if(i == 0)
+      EXPECT_FLOAT_EQ(1.0, x[0].adj());
+    else
+      EXPECT_FLOAT_EQ(0.0, x[0].adj());
+
+    if(i == 1)
+      EXPECT_FLOAT_EQ(1.0, x[1].adj());
+    else
+      EXPECT_FLOAT_EQ(0.0, x[1].adj());
+
+    if(i == 2)
+      EXPECT_FLOAT_EQ(1.0, x[2].adj());
+    else
+      EXPECT_FLOAT_EQ(0.0, x[2].adj());
+
+    if(i == 3)
+      EXPECT_FLOAT_EQ(1.0, y[0].adj());
+    else
+      EXPECT_FLOAT_EQ(0.0, y[0].adj());
+
+    if(i == 4)
+      EXPECT_FLOAT_EQ(1.0, y[1].adj());
+    else
+      EXPECT_FLOAT_EQ(0.0, y[1].adj());
+  }
+}


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

Addresses: https://github.com/stan-dev/math/issues/481

This replaces pull request: https://github.com/stan-dev/math/pull/531

Sorry for axing the old pull req, but the outdated fvar stuff was causing issues and I thought it would be better to rebase onto the updated Stan than try to figure it out. I've checked the `fvar<fvar<var>>/fvar<fvar<double>>` behavior and I think these tests make sense (though they are kinda verbose).

#### Side effects

Hopefully none

#### How to Verify:

./runTests.py test/unit/math/prim/arr/fun/append_array_test
./runTests.py test/unit/math/rev/arr/fun/append_array_test
./runTests.py test/unit/math/fwd/arr/fun/append_array_test
./runTests.py test/unit/math/mix/arr/fun/append_array_test

#### Reviewer Suggestions

Anyone

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): University of California, Santa Barbara

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
