### PR TITLE
check consistent size of state and dy_dt in ode_system

### DIFF
--- a/stan/math/rev/mat/functor/cvodes_ode_data.hpp
+++ b/stan/math/rev/mat/functor/cvodes_ode_data.hpp
@@ -90,14 +90,13 @@ namespace stan {
       }
 
     private:
-      void rhs(const double y[], double dy_dt[], double t) const {
+      inline void rhs(const double y[], double dy_dt[], double t) const {
         const std::vector<double> y_vec(y, y + N_);
-        std::vector<double> dy_dt_vec(N_);
-        ode_system_(t, y_vec, dy_dt_vec);
-        std::copy(dy_dt_vec.begin(), dy_dt_vec.end(), dy_dt);
+        Eigen::Map<Eigen::VectorXd> dy_dt_eig(dy_dt, N_);
+        ode_system_(t, y_vec, dy_dt_eig);
       }
 
-      int dense_jacobian(const double* y, DlsMat J, double t) const {
+      inline int dense_jacobian(const double* y, DlsMat J, double t) const {
         const std::vector<double> y_vec(y, y + N_);
         Eigen::VectorXd fy(N_);
         Eigen::Map<Eigen::MatrixXd> Jy_map(J->data, N_, N_);

--- a/stan/math/rev/mat/functor/ode_system.hpp
+++ b/stan/math/rev/mat/functor/ode_system.hpp
@@ -93,10 +93,8 @@ namespace stan {
           start_nested();
           vector<var> y_var(y.begin(), y.end());
           vector<var> dy_dt_var = f_(t, y_var, theta_, x_, x_int_, msgs_);
-          if (unlikely(y.size() != dy_dt_var.size())) {
-            recover_memory_nested();
+          if (unlikely(y.size() != dy_dt_var.size()))
             throw std::runtime_error(error_msg(y.size(), dy_dt_var.size()));
-          }
           for (size_t i = 0; i < dy_dt_var.size(); ++i) {
             dy_dt(i) = dy_dt_var[i].val();
             set_zero_all_adjoints_nested();
@@ -143,10 +141,8 @@ namespace stan {
           z_var.insert(z_var.end(), y_var.begin(), y_var.end());
           z_var.insert(z_var.end(), theta_var.begin(), theta_var.end());
           vector<var> dy_dt_var = f_(t, y_var, theta_var, x_, x_int_, msgs_);
-          if (unlikely(y.size() != dy_dt_var.size())) {
-            recover_memory_nested();
+          if (unlikely(y.size() != dy_dt_var.size()))
             throw std::runtime_error(error_msg(y.size(), dy_dt_var.size()));
-          }
           for (size_t i = 0; i < dy_dt_var.size(); ++i) {
             dy_dt(i) = dy_dt_var[i].val();
             set_zero_all_adjoints_nested();

--- a/stan/math/rev/mat/functor/ode_system.hpp
+++ b/stan/math/rev/mat/functor/ode_system.hpp
@@ -92,8 +92,10 @@ namespace stan {
           start_nested();
           vector<var> y_var(y.begin(), y.end());
           vector<var> dy_dt_var = f_(t, y_var, theta_, x_, x_int_, msgs_);
-          if (unlikely(y.size() != dy_dt_var.size()))
+          if (unlikely(y.size() != dy_dt_var.size())) {
+            recover_memory_nested();
             throw std::runtime_error(error_msg(y.size(), dy_dt_var.size()));
+          }
           for (size_t i = 0; i < dy_dt_var.size(); ++i) {
             dy_dt(i) = dy_dt_var[i].val();
             set_zero_all_adjoints_nested();
@@ -140,8 +142,10 @@ namespace stan {
           z_var.insert(z_var.end(), y_var.begin(), y_var.end());
           z_var.insert(z_var.end(), theta_var.begin(), theta_var.end());
           vector<var> dy_dt_var = f_(t, y_var, theta_var, x_, x_int_, msgs_);
-          if (unlikely(y.size() != dy_dt_var.size()))
+          if (unlikely(y.size() != dy_dt_var.size())) {
+            recover_memory_nested();
             throw std::runtime_error(error_msg(y.size(), dy_dt_var.size()));
+          }
           for (size_t i = 0; i < dy_dt_var.size(); ++i) {
             dy_dt(i) = dy_dt_var[i].val();
             set_zero_all_adjoints_nested();

--- a/stan/math/rev/mat/functor/ode_system.hpp
+++ b/stan/math/rev/mat/functor/ode_system.hpp
@@ -5,6 +5,7 @@
 #include <stan/math/prim/arr/fun/value_of.hpp>
 #include <iostream>
 #include <sstream>
+#include <string>
 #include <vector>
 
 namespace stan {

--- a/test/unit/math/prim/arr/functor/harmonic_oscillator.hpp
+++ b/test/unit/math/prim/arr/functor/harmonic_oscillator.hpp
@@ -6,8 +6,8 @@
 
 struct harm_osc_ode_fun {
   template <typename T0, typename T1, typename T2>
-  inline 
-  std::vector<typename stan::return_type<T1,T2>::type> 
+  inline
+  std::vector<typename stan::return_type<T1,T2>::type>
   operator()(const T0& t_in, // initial time
              const std::vector<T1>& y_in, //initial positions
              const std::vector<T2>& theta, // parameters
@@ -20,15 +20,15 @@ struct harm_osc_ode_fun {
     std::vector<typename stan::return_type<T1,T2>::type> res;
     res.push_back(y_in.at(1));
     res.push_back(-y_in.at(0) - theta.at(0)*y_in.at(1));
-    
+
     return res;
   }
 };
 
 struct harm_osc_ode_data_fun {
   template <typename T0, typename T1, typename T2>
-  inline 
-  std::vector<typename stan::return_type<T1,T2>::type> 
+  inline
+  std::vector<typename stan::return_type<T1,T2>::type>
   operator()(const T0& t_in, // initial time
              const std::vector<T1>& y_in, //initial positions
              const std::vector<T2>& theta, // parameters
@@ -41,9 +41,53 @@ struct harm_osc_ode_data_fun {
     std::vector<typename stan::return_type<T1,T2>::type> res;
     res.push_back(x.at(0) * y_in.at(1) + x_int.at(0));
     res.push_back(-x.at(1) * y_in.at(0) - x.at(2) * theta.at(0) * y_in.at(1) + x_int.at(1));
-    
+
     return res;
   }
 };
+
+
+struct harm_osc_ode_wrong_size_1_fun {
+  template <typename T0, typename T1, typename T2>
+  inline
+  std::vector<typename stan::return_type<T1,T2>::type>
+  operator()(const T0& t_in, // initial time
+             const std::vector<T1>& y_in, //initial positions
+             const std::vector<T2>& theta, // parameters
+             const std::vector<double>& x, // double data
+             const std::vector<int>& x_int,
+             std::ostream* msgs) const { // integer data
+    if (y_in.size() != 2)
+      throw std::domain_error("this function was called with inconsistent state");
+
+    std::vector<typename stan::return_type<T1,T2>::type> res;
+    res.push_back(y_in.at(1));
+    res.push_back(-y_in.at(0) - theta.at(0)*y_in.at(1));
+    res.push_back(0);
+
+    return res;
+  }
+};
+
+struct harm_osc_ode_wrong_size_2_fun {
+  template <typename T0, typename T1, typename T2>
+  inline
+  std::vector<typename stan::return_type<T1,T2>::type>
+  operator()(const T0& t_in, // initial time
+             const std::vector<T1>& y_in, //initial positions
+             const std::vector<T2>& theta, // parameters
+             const std::vector<double>& x, // double data
+             const std::vector<int>& x_int,
+             std::ostream* msgs) const { // integer data
+    if (y_in.size() != 2)
+      throw std::domain_error("this function was called with inconsistent state");
+
+    std::vector<typename stan::return_type<T1,T2>::type> res;
+    res.push_back(0);
+
+    return res;
+  }
+};
+
 
 #endif

--- a/test/unit/math/rev/mat/functor/ode_system_test.cpp
+++ b/test/unit/math/rev/mat/functor/ode_system_test.cpp
@@ -44,7 +44,7 @@ struct StanMathRevOdeSystem : public ::testing::Test {
 TEST_F(StanMathRevOdeSystem, ode_system_rhs) {
   stan::math::ode_system<harm_osc_ode_fun> ode_system(ode_rhs, theta, x, x_int, &msgs);
 
-  std::vector<double> dy_dt;
+  Eigen::VectorXd dy_dt(N);
 
   ode_system(t0, y0, dy_dt);
 

--- a/test/unit/math/rev/mat/functor/ode_system_test.cpp
+++ b/test/unit/math/rev/mat/functor/ode_system_test.cpp
@@ -32,6 +32,8 @@ struct StanMathRevOdeSystem : public ::testing::Test {
   std::vector<double> y0;
   std::vector<double> theta;
   harm_osc_ode_fun ode_rhs;
+  harm_osc_ode_wrong_size_1_fun ode_wrong_size_1_rhs;
+  harm_osc_ode_wrong_size_2_fun ode_wrong_size_2_rhs;
   size_t N;
   size_t M;
   Eigen::MatrixXd Jy_ref;
@@ -50,6 +52,22 @@ TEST_F(StanMathRevOdeSystem, ode_system_rhs) {
 
   EXPECT_FLOAT_EQ( 2.0, dy_dt[0]);
   EXPECT_FLOAT_EQ(-2.0, dy_dt[1]);
+}
+
+TEST_F(StanMathRevOdeSystem, ode_system_rhs_wrong_size) {
+  Eigen::VectorXd dy_dt(N);
+
+  stan::math::ode_system<harm_osc_ode_wrong_size_1_fun>
+    ode_system1(ode_wrong_size_1_rhs, theta, x, x_int, &msgs);
+  EXPECT_THROW_MSG(ode_system1(t0, y0, dy_dt),
+                   std::runtime_error,
+                   "ode_system: size of state vector y (2) and derivative vector dy_dt (3) in the ODE functor do not match in size.");
+
+  stan::math::ode_system<harm_osc_ode_wrong_size_2_fun>
+    ode_system2(ode_wrong_size_2_rhs, theta, x, x_int, &msgs);
+  EXPECT_THROW_MSG(ode_system2(t0, y0, dy_dt),
+                   std::runtime_error,
+                   "ode_system: size of state vector y (2) and derivative vector dy_dt (1) in the ODE functor do not match in size.");
 }
 
 // ************ jacobian wrt to states ************************
@@ -219,4 +237,3 @@ TEST_F(StanMathRevOdeSystem, ode_system_jac_Mv_Mm_Mm) {
     for(size_t j = 0; j < M; j++)
       EXPECT_FLOAT_EQ(Jtheta_ref(i,j), Jtheta(i,j));
 }
-


### PR DESCRIPTION
#### Submission Checklist

- [X] Run unit tests: `./runTests.py test/unit`
- [X] Run cpplint: `make cpplint`
- [X] Declare copyright holder and open-source license: see below

#### Summary:
Programs with inconsistent ODE RHS functors may cause inconsistencies when integrated with `integrate_ode_bdf`. This pull adds extra checks to avoid this. Closes issue #552 

#### Intended Effect:
Bring programs as in issue #552 to an early end. Requires to check consistency of vector sizes of the state vector y and the dy_dt size as the dy_dt size is under the control of the user supplied ODE RHS functor.

#### How to Verify:
Run the program in issue #552 with the bdf integrator. The new output (with stan from the current develop branch) is now:

```
Unrecoverable error evaluating the log probability at the initial value.
Exception thrown at line 34: ode_system: size of state vector y and dy_dt vector from ODE functor do not match in size.
```

Finally, run the tests in `test/unit/math/rev/mat/functor/`

- `cvodes_ode_data_prim_test.cpp`
- `cvodes_ode_data_rev_test.cpp`
- `integrate_ode_bdf_prim_test.cpp`
- `integrate_ode_bdf_rev_test.cpp`
- `ode_system_test.cpp`

#### Side Effects:
Aligned the input type of the dy_dt argument of the () operator to be consistent in ode_system with the jacobian member functions. No user facing changes.

#### Documentation:

#### Reviewer Suggestions: 
@bob-carpenter @syclik @betanalpha 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Sebastian Weber

By submitting this pull request, the copyright holder is requiring to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)