### PR TITLE
Tests corrected now.

### DIFF
--- a/test/unit/math/prim/scal/err/check_positive_test.cpp
+++ b/test/unit/math/prim/scal/err/check_positive_test.cpp
@@ -5,7 +5,7 @@ TEST(ErrorHandlingScalar,CheckPositive) {
   using stan::math::check_positive;
   const std::string function = "check_positive";
 
-  EXPECT_NO_THROW(check_positive(function, "x", nan));
+  EXPECT_NO_THROW(check_positive(function, "x", 3.0));
 }
 
 TEST(ErrorHandlingScalar,CheckPositive_nan) {

--- a/test/unit/math/rev/scal/err/check_positive_test.cpp
+++ b/test/unit/math/rev/scal/err/check_positive_test.cpp
@@ -1,5 +1,6 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
+#include <exception>
 
 using stan::math::var;
 
@@ -7,7 +8,8 @@ TEST(AgradRevErrorHandlingScalar,CheckPositive) {
   using stan::math::check_positive;
   const std::string function = "check_positive";
 
-  EXPECT_NO_THROW(check_positive(function, "x", nan));
+  var x = std::numeric_limits<var>::quiet_NaN();
+  EXPECT_THROW(check_positive(function, "x", x), std::domain_error);
 
   stan::math::recover_memory();
 }


### PR DESCRIPTION
#### Submission Checklist

- [ x] Run unit tests: `./runTests.py test/unit`
- [ x] Run cpplint: `make cpplint`
- [ x] Declare copyright holder and open-source license: see below

#### Summary:
tests previously passed because `nan` was a function in main namespace. Now they
pass/fail as expected.

#### Intended Effect:
Tests pass

#### How to Verify:
Run tests

#### Side Effects:
They used to pass regardless of whether the code worked or not 

#### Documentation:
NA

#### Copyright and Licensing

Krzysztof Sakrejda

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
