### PR TITLE
Updated to check compile-time dims

### DIFF
--- a/stan/math/prim/mat/err/check_matching_dims.hpp
+++ b/stan/math/prim/mat/err/check_matching_dims.hpp
@@ -4,6 +4,7 @@
 #include <stan/math/prim/scal/err/domain_error.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/scal/err/check_size_match.hpp>
+#include <stan/math/prim/scal/err/invalid_argument.hpp>
 #include <sstream>
 #include <string>
 
@@ -13,9 +14,7 @@ namespace stan {
     /**
      * Check if the two matrices are of the same size.
      *
-     * This function checks not only the runtime sizes, but the static
-     * sizes as well. For example, a 4x1 matrix is not the same as a vector
-     * with 4 elements.
+     * This function checks the runtime sizes only. 
      *
      * @tparam T1 Scalar type of the first matrix
      * @tparam T2 Scalar type of the second matrix
@@ -47,6 +46,49 @@ namespace stan {
                        "columns of ", name2, y2.cols());
     }
 
+    /**
+     * Check if the two matrices are of the same size.
+     *
+     * This function checks the runtime sizes and can also check the static
+     * sizes as well. For example, a 4x1 matrix is not the same as a vector
+     * with 4 elements.
+     *
+     * @tparam check_compile Whether to check the static sizes 
+     * @tparam T1 Scalar type of the first matrix
+     * @tparam T2 Scalar type of the second matrix
+     * @tparam R1 Rows specified at compile time of the first matrix
+     * @tparam C1 Columns specified at compile time of the first matrix
+     * @tparam R2 Rows specified at compile time of the second matrix
+     * @tparam C2 Columns specified at compile time of the second matrix
+     *
+     * @param function Function name (for error messages)
+     * @param name1 Variable name for the first matrix (for error messages)
+     * @param y1 First matrix
+     * @param name2 Variable name for the second matrix (for error messages)
+     * @param y2 Second matrix
+     *
+     * @throw <code>std::invalid_argument</code> if the 
+     * dimensions of the matrices do not match
+     */
+    template <bool check_compile, typename T1, typename T2,
+              int R1, int C1, int R2, int C2>
+    inline void check_matching_dims(const std::string& function,
+                                    const std::string& name1,
+                                    const Eigen::Matrix<T1, R1, C1>& y1,
+                                    const std::string& name2,
+                                    const Eigen::Matrix<T2, R2, C2>& y2) {
+      if (check_compile) {
+        if (R1 != R2 || C1 != C2) {
+          std::ostringstream msg;
+          msg << "Static rows and cols of "
+              << name1 << " and " << name2
+              << " must match in size.";
+          std::string msg_str(msg.str());
+          invalid_argument(function, msg_str.c_str(), "", "");
+        }
+      }
+      check_matching_dims(function, name1, y1, name2, y2);
+    }
   }
 }
 #endif

--- a/stan/math/prim/mat/err/check_matching_dims.hpp
+++ b/stan/math/prim/mat/err/check_matching_dims.hpp
@@ -14,7 +14,7 @@ namespace stan {
     /**
      * Check if the two matrices are of the same size.
      *
-     * This function checks the runtime sizes only. 
+     * This function checks the runtime sizes only.
      *
      * @tparam T1 Scalar type of the first matrix
      * @tparam T2 Scalar type of the second matrix
@@ -29,8 +29,8 @@ namespace stan {
      * @param name2 Variable name for the second matrix (for error messages)
      * @param y2 Second matrix
      *
-     * @throw <code>std::invalid_argument</code> if the dimensions of the matrices
-     *   do not match
+     * @throw <code>std::invalid_argument</code>
+     * if the dimensions of the matrices do not match
      */
     template <typename T1, typename T2, int R1, int C1, int R2, int C2>
     inline void check_matching_dims(const std::string& function,
@@ -53,7 +53,7 @@ namespace stan {
      * sizes as well. For example, a 4x1 matrix is not the same as a vector
      * with 4 elements.
      *
-     * @tparam check_compile Whether to check the static sizes 
+     * @tparam check_compile Whether to check the static sizes
      * @tparam T1 Scalar type of the first matrix
      * @tparam T2 Scalar type of the second matrix
      * @tparam R1 Rows specified at compile time of the first matrix
@@ -67,7 +67,7 @@ namespace stan {
      * @param name2 Variable name for the second matrix (for error messages)
      * @param y2 Second matrix
      *
-     * @throw <code>std::invalid_argument</code> if the 
+     * @throw <code>std::invalid_argument</code> if the
      * dimensions of the matrices do not match
      */
     template <bool check_compile, typename T1, typename T2,
@@ -77,15 +77,13 @@ namespace stan {
                                     const Eigen::Matrix<T1, R1, C1>& y1,
                                     const std::string& name2,
                                     const Eigen::Matrix<T2, R2, C2>& y2) {
-      if (check_compile) {
-        if (R1 != R2 || C1 != C2) {
-          std::ostringstream msg;
-          msg << "Static rows and cols of "
-              << name1 << " and " << name2
-              << " must match in size.";
-          std::string msg_str(msg.str());
-          invalid_argument(function, msg_str.c_str(), "", "");
-        }
+      if (check_compile && (R1 != R2 || C1 != C2)) {
+        std::ostringstream msg;
+        msg << "Static rows and cols of "
+            << name1 << " and " << name2
+            << " must match in size.";
+        std::string msg_str(msg.str());
+        invalid_argument(function, msg_str.c_str(), "", "");
       }
       check_matching_dims(function, name1, y1, name2, y2);
     }

--- a/test/unit/math/prim/mat/err/check_matching_dims_test.cpp
+++ b/test/unit/math/prim/mat/err/check_matching_dims_test.cpp
@@ -68,6 +68,11 @@ TEST(ErrorHandlingMatrix, checkMatchingDims_compile_time_sizes) {
   EXPECT_NO_THROW(check_matching_dims("check_matching_dims", "dynamic", m_dynamic,
                                       "2x2", m_2x2));
 
+  EXPECT_THROW_MSG(check_matching_dims<true>("check_matching_dims",
+                                             "dynamic", m_dynamic,
+                                             "2x2", m_2x2),
+                   std::invalid_argument,
+                   "check_matching_dims: Static rows and cols of dynamic and 2x2 must match in size");
   m_dynamic.resize(3,3);
   EXPECT_THROW_MSG(check_matching_dims("check_matching_dims", "dynamic", m_dynamic,
                                        "2x2", m_2x2),
@@ -78,6 +83,11 @@ TEST(ErrorHandlingMatrix, checkMatchingDims_compile_time_sizes) {
   EXPECT_NO_THROW(check_matching_dims("check_matching_dims", "dynamic", m_dynamic,
                                       "vector", vector));
 
+  EXPECT_THROW_MSG(check_matching_dims<true>("check_matching_dims",
+                                             "dynamic", m_dynamic,
+                                             "vector", vector),
+                   std::invalid_argument,
+                   "check_matching_dims: Static rows and cols of dynamic and vector must match in size");
   m_dynamic.resize(3,1);  
   EXPECT_THROW_MSG(check_matching_dims("check_matching_dims", "dynamic", m_dynamic,
                                        "vector", vector),
@@ -88,6 +98,11 @@ TEST(ErrorHandlingMatrix, checkMatchingDims_compile_time_sizes) {
   m_dynamic.resize(1,4);  
   EXPECT_NO_THROW(check_matching_dims("check_matching_dims", "dynamic", m_dynamic,
                                       "rowvector", rowvector));
+  EXPECT_THROW_MSG(check_matching_dims<true>("check_matching_dims",
+                                             "dynamic", m_dynamic,
+                                             "rowvector", rowvector),
+                   std::invalid_argument,
+                   "check_matching_dims: Static rows and cols of dynamic and rowvector must match in size");
 
   m_dynamic.resize(1,3);  
   EXPECT_THROW_MSG(check_matching_dims("check_matching_dims", "dynamic", m_dynamic,


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary:
This updates `check_matching_dim` so it can also check compile-time rows and cols.

#### Intended Effect:
This adds a separate function with the same name that uses an extra template parameter to determine whether to check compile-time rows and cols.

#### How to Verify:
Run `test/unit/math/prim/mat/err/check_matching_dims_test.cpp`.

#### Side Effects:
None. This was written so that the original function still behaves as it did beforehand and that the compile time check only happens when an extra template parameter is set to true. No current function sets this parameter to true.

#### Documentation:
New function is documented.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Rayleigh Lei holds the copyright to this work. 

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
