### PR TITLE
Feature/issue 75 correlation

### DIFF
--- a/stan/math/rev/mat.hpp
+++ b/stan/math/rev/mat.hpp
@@ -18,6 +18,7 @@
 #include <stan/math/rev/mat/fun/cov_exp_quad.hpp>
 #include <stan/math/rev/mat/fun/crossprod.hpp>
 #include <stan/math/rev/mat/fun/covariance.hpp>
+#include <stan/math/rev/mat/fun/correlation.hpp>
 #include <stan/math/rev/mat/fun/determinant.hpp>
 #include <stan/math/rev/mat/fun/divide.hpp>
 #include <stan/math/rev/mat/fun/dot_product.hpp>

--- a/stan/math/rev/mat.hpp
+++ b/stan/math/rev/mat.hpp
@@ -17,6 +17,7 @@
 #include <stan/math/rev/mat/fun/columns_dot_self.hpp>
 #include <stan/math/rev/mat/fun/cov_exp_quad.hpp>
 #include <stan/math/rev/mat/fun/crossprod.hpp>
+#include <stan/math/rev/mat/fun/covariance.hpp>
 #include <stan/math/rev/mat/fun/determinant.hpp>
 #include <stan/math/rev/mat/fun/divide.hpp>
 #include <stan/math/rev/mat/fun/dot_product.hpp>

--- a/stan/math/rev/mat/fun/correlation.hpp
+++ b/stan/math/rev/mat/fun/correlation.hpp
@@ -60,10 +60,10 @@ namespace stan {
 
       //Ensure there are enough observations
       if(nrows <= 1)
-	invalid_argument<Matrix<T,Dynamic,Dynamic> >
+	invalid_argument<int>
 	    ("corr"
 	     , "x"
-	     , x
+	     , nrows
 	     , "Too few observations to compute correlation"
 	     );	
       
@@ -72,10 +72,10 @@ namespace stan {
       //Append columns provided they have the right dimensionality
       for(int i = 0; i < x.size(); ++i){
 	if(x[i].rows() != nrows)
-	  invalid_argument<Matrix<T,Dynamic,1> >
+	  invalid_argument<unsigned int>
 	    ("corr"
 	     , "x"
-	     , x
+	     , x[i].rows()
 	     , "Column vectors not all of same length"
 	     );
 	
@@ -92,10 +92,10 @@ namespace stan {
 
       //Ensure there are enough observations to compute covariance
       if(x.size() <= 1)
-	invalid_argument<Matrix<T,Dynamic,Dynamic> >
+	invalid_argument<unsigned int>
 	    ("corr"
 	     , "x"
-	     , x
+	     , x.size()
 	     , "Too few observations to compute correlation"
 	     );
       
@@ -104,10 +104,10 @@ namespace stan {
       //Append rows provided they have the right dimensionality
       for(int i = 0; i < x.size(); ++i){
 	if(x[i].cols() != ncols)
-	  invalid_argument<Matrix<T,Dynamic,1> >
+	  invalid_argument<unsigned int>
 	    ("corr"
 	     , "x"
-	     , x
+	     , x[i].cols()
 	     , "Column vectors not all of same length"
 	     );
 	    

--- a/stan/math/rev/mat/fun/correlation.hpp
+++ b/stan/math/rev/mat/fun/correlation.hpp
@@ -1,0 +1,123 @@
+#ifndef STAN_MATH_REV_MAT_FUN_CORRELATION_HPP
+#define STAN_MATH_REV_MAT_FUN_CORRELATION_HPP
+
+#include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <stan/math/rev/core.hpp>
+#include <stan/math/prim/scal/err/invalid_argument.hpp>
+
+
+using namespace Eigen;
+
+namespace stan {
+  namespace math {
+      
+      template <typename T>
+      Matrix<T,Dynamic,Dynamic> corr(const Matrix<T,Dynamic,Dynamic>& x){
+
+	// Ensure there are enough observations
+	if(x.rows() <= 1)
+	  invalid_argument<Matrix<T,Dynamic,Dynamic> >
+	    ("corr"
+	     , "x"
+	     , x
+	     , "Too few observations to compute correlation"
+	     );
+
+	//Center The matrix
+	Matrix<T,Dynamic,Dynamic>
+	  centered = x.rowwise() - x.colwise().mean();
+
+	//Create an empty matrix to be viewed
+	SelfAdjointView<Matrix<T,Dynamic,Dynamic>, Lower> cmat =
+	  Matrix<T,Dynamic,Dynamic>(x.cols(),x.cols()). //initialize matrix
+	  setZero().                                    //zero it
+          template selfadjointView<Lower>().            //operate only on lower tri
+	  rankUpdate(centered.adjoint(), 1 / double(x.rows() - 1)); //compute XTX/(n-1)
+	
+	
+	std::vector<T> column_variances(x.cols());
+	for(int j = 0; j < x.cols(); ++j){
+	  Matrix<T,Dynamic,1> curr_col(centered.col(j));
+	  column_variances[j] = (curr_col.adjoint() * curr_col)(0) / double(x.rows() - 1);
+	}
+
+	for(int j = 0; j < x.cols(); ++j)
+	  for(int i = j; i < x.cols(); ++i){
+	    if(i == j){
+	      cmat(i,j) = column_variances[j];
+	    } else {
+	      cmat(i,j) /= (sqrt(column_variances[i]) * sqrt(column_variances[j]));
+	    }
+	  }
+	    
+	return( Matrix<T,Dynamic,Dynamic>(cmat) );
+			  
+    }
+
+    template <typename T>
+    Matrix<T,Dynamic,Dynamic> corr(const std::vector<Matrix<T,Dynamic,1> >& x){
+      int nrows = x[0].rows();
+
+      //Ensure there are enough observations
+      if(nrows <= 1)
+	invalid_argument<Matrix<T,Dynamic,Dynamic> >
+	    ("corr"
+	     , "x"
+	     , x
+	     , "Too few observations to compute correlation"
+	     );	
+      
+      Matrix<T,Dynamic,Dynamic> mat(nrows, x.size());
+
+      //Append columns provided they have the right dimensionality
+      for(int i = 0; i < x.size(); ++i){
+	if(x[i].rows() != nrows)
+	  invalid_argument<Matrix<T,Dynamic,1> >
+	    ("corr"
+	     , "x"
+	     , x
+	     , "Column vectors not all of same length"
+	     );
+	
+	mat.col(i) = x[i].col(0); 
+      }
+
+      //Finish the job with the general matrix covariance
+      return( corr(mat) );
+    }
+
+    template <typename T>
+    Matrix<T,Dynamic,Dynamic> corr(const std::vector<Matrix<T,1,Dynamic> >& x){
+      int ncols = x[0].cols();
+
+      //Ensure there are enough observations to compute covariance
+      if(x.size() <= 1)
+	invalid_argument<Matrix<T,Dynamic,Dynamic> >
+	    ("corr"
+	     , "x"
+	     , x
+	     , "Too few observations to compute correlation"
+	     );
+      
+      Matrix<T,Dynamic,Dynamic> mat(x.size(), ncols);
+
+      //Append rows provided they have the right dimensionality
+      for(int i = 0; i < x.size(); ++i){
+	if(x[i].cols() != ncols)
+	  invalid_argument<Matrix<T,Dynamic,1> >
+	    ("corr"
+	     , "x"
+	     , x
+	     , "Column vectors not all of same length"
+	     );
+	    
+	mat.row(i) = x[i].row(0); 
+      }
+
+      //Finish the job with the general matrix covariance	
+      return( corr(mat) );
+    }
+
+  }
+}
+#endif

--- a/stan/math/rev/mat/fun/covariance.hpp
+++ b/stan/math/rev/mat/fun/covariance.hpp
@@ -1,0 +1,108 @@
+#ifndef STAN_MATH_REV_MAT_FUN_COVARIANCE_HPP
+#define STAN_MATH_REV_MAT_FUN_COVARIANCE_HPP
+
+#include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <stan/math/rev/core.hpp>
+#include <stan/math/prim/scal/err/invalid_argument.hpp>
+
+
+using namespace Eigen;
+
+namespace stan {
+  namespace math {
+      
+      template <typename T>
+      Matrix<T,Dynamic,Dynamic> cov(const Matrix<T,Dynamic,Dynamic>& x){
+
+	// Ensure there are enough observations
+	if(x.rows() <= 1)
+	  invalid_argument<Matrix<T,Dynamic,Dynamic> >
+	    ("cov"
+	     , "x"
+	     , x
+	     , "Too few observations to compute covariance"
+	     );
+
+	//Center The matrix
+	Matrix<T,Dynamic,Dynamic>
+	  centered = x.rowwise() - x.colwise().mean();
+
+	//Create an empty matrix to be viewed
+	Matrix<T,Dynamic,Dynamic>
+	  cmat(Matrix<T,Dynamic,Dynamic>(x.cols(),x.cols()). //initialize matrix
+	       setZero().                                    //zero it
+	       template selfadjointView<Lower>().            //operate only on lower tri
+	       rankUpdate(centered.adjoint(), 1 / double(x.rows() - 1)) //compute XTX/(n-1)
+	       );                                                       //copy up to full size
+
+	return( cmat );
+			  
+    }
+
+    template <typename T>
+    Matrix<T,Dynamic,Dynamic> cov(const std::vector<Matrix<T,Dynamic,1> >& x){
+      int nrows = x[0].rows();
+
+      //Ensure there are enough observations
+      if(nrows <= 1)
+	invalid_argument<Matrix<T,Dynamic,Dynamic> >
+	    ("cov"
+	     , "x"
+	     , x
+	     , "Too few observations to compute covariance"
+	     );	
+      
+      Matrix<T,Dynamic,Dynamic> mat(nrows, x.size());
+
+      //Append columns provided they have the right dimensionality
+      for(int i = 0; i < x.size(); ++i){
+	if(x[i].rows() != nrows)
+	  invalid_argument<Matrix<T,Dynamic,1> >
+	    ("cov"
+	     , "x"
+	     , x
+	     , "Column vectors not all of same length"
+	     );
+	
+	mat.col(i) = x[i].col(0); 
+      }
+
+      //Finish the job with the general matrix covariance
+      return( cov(mat) );
+    }
+
+    template <typename T>
+    Matrix<T,Dynamic,Dynamic> cov(const std::vector<Matrix<T,1,Dynamic> >& x){
+      int ncols = x[0].cols();
+
+      //Ensure there are enough observations to compute covariance
+      if(x.size() <= 1)
+	invalid_argument<Matrix<T,Dynamic,Dynamic> >
+	    ("cov"
+	     , "x"
+	     , x
+	     , "Too few observations to compute covariance"
+	     );
+      
+      Matrix<T,Dynamic,Dynamic> mat(x.size(), ncols);
+
+      //Append rows provided they have the right dimensionality
+      for(int i = 0; i < x.size(); ++i){
+	if(x[i].cols() != ncols)
+	  invalid_argument<Matrix<T,Dynamic,1> >
+	    ("cov"
+	     , "x"
+	     , x
+	     , "Column vectors not all of same length"
+	     );
+	    
+	mat.row(i) = x[i].row(0); 
+      }
+
+      //Finish the job with the general matrix covariance	
+      return( cov(mat) );
+    }
+
+  }
+}
+#endif

--- a/stan/math/rev/mat/fun/covariance.hpp
+++ b/stan/math/rev/mat/fun/covariance.hpp
@@ -45,22 +45,22 @@ namespace stan {
 
       //Ensure there are enough observations
       if(nrows <= 1)
-	invalid_argument<Matrix<T,Dynamic,Dynamic> >
-	    ("cov"
-	     , "x"
-	     , x
-	     , "Too few observations to compute covariance"
-	     );	
+	invalid_argument<unsigned int>
+	  ("cov"
+	   , "x"
+	   , nrows
+	   , "Too few observations to compute covariance"
+	   );	
       
       Matrix<T,Dynamic,Dynamic> mat(nrows, x.size());
 
       //Append columns provided they have the right dimensionality
-      for(int i = 0; i < x.size(); ++i){
+      for(unsigned int i = 0; i < x.size(); ++i){
 	if(x[i].rows() != nrows)
-	  invalid_argument<Matrix<T,Dynamic,1> >
+	  invalid_argument<unsigned int>
 	    ("cov"
 	     , "x"
-	     , x
+	     , x[i].rows()
 	     , "Column vectors not all of same length"
 	     );
 	
@@ -77,23 +77,23 @@ namespace stan {
 
       //Ensure there are enough observations to compute covariance
       if(x.size() <= 1)
-	invalid_argument<Matrix<T,Dynamic,Dynamic> >
-	    ("cov"
-	     , "x"
-	     , x
-	     , "Too few observations to compute covariance"
-	     );
+	invalid_argument<unsigned int>
+	  ("cov"
+	   ,"x"
+	   , x.size()
+	   , "Too few observations to compute covariance"
+	   );
       
       Matrix<T,Dynamic,Dynamic> mat(x.size(), ncols);
 
       //Append rows provided they have the right dimensionality
-      for(int i = 0; i < x.size(); ++i){
+      for(unsigned int i = 0; i < x.size(); ++i){
 	if(x[i].cols() != ncols)
-	  invalid_argument<Matrix<T,Dynamic,1> >
+	  invalid_argument<unsigned int>
 	    ("cov"
 	     , "x"
-	     , x
-	     , "Column vectors not all of same length"
+	     , x[i].cols()
+	     , "Row vectors not all of same length"
 	     );
 	    
 	mat.row(i) = x[i].row(0); 

--- a/test/unit/math/rev/mat/fun/correlation_test.cpp
+++ b/test/unit/math/rev/mat/fun/correlation_test.cpp
@@ -1,0 +1,24 @@
+#include <stan/math/rev/mat.hpp>
+#include <gtest/gtest.h>
+#include <test/unit/math/rev/mat/fun/util.hpp>
+#include <test/unit/math/rev/mat/util.hpp>
+
+TEST(AgradRevMatrix, cov_eq) {
+  using stan::math::corr;
+  using namespace Eigen;
+    
+  Matrix<double, Dynamic, Dynamic> x(3,3);
+  x <<
+    1, 5, 9,
+    2, 4, 6,
+    3, 6, 7;
+
+  Matrix<double, Dynamic, Dynamic> cmat =
+    corr(x);
+
+  EXPECT_FLOAT_EQ(cmat(0,0), 1.0);
+  EXPECT_FLOAT_EQ(cmat(0,2), -1.0 / sqrt(7.0 / 3.0 ));
+  EXPECT_FLOAT_EQ(cmat(1,2), 0.5 / sqrt(7.0 / 3.0 ));
+  
+}
+

--- a/test/unit/math/rev/mat/fun/correlation_test.cpp
+++ b/test/unit/math/rev/mat/fun/correlation_test.cpp
@@ -22,3 +22,44 @@ TEST(AgradRevMatrix, cov_eq) {
   
 }
 
+TEST(AgradRevMatrix, corr_colvec_eq) {
+  using stan::math::corr;
+  using namespace Eigen;  
+  
+  std::vector<Matrix<double, Dynamic,1> > mat_vec(3);
+  for(int i = 0; i < 3; ++i)
+    mat_vec[i] = Matrix<double, Dynamic, 1>(3);
+
+  mat_vec[0] << 1, 2 ,3;
+  mat_vec[1] << 5, 4, 6;
+  mat_vec[2] << 9, 6, 7;
+  
+  Matrix<double, Dynamic, Dynamic> cmat =
+    corr(mat_vec);
+
+  EXPECT_FLOAT_EQ(cmat(0,0), 1.0);
+  EXPECT_FLOAT_EQ(cmat(0,2), -1.0 / sqrt(7.0 / 3.0 ));
+  EXPECT_FLOAT_EQ(cmat(1,2), 0.5 / sqrt(7.0 / 3.0 ));
+}
+
+
+TEST(AgradRevMatrix, corr_rowvec_eq) {
+  using stan::math::corr;
+  using namespace Eigen;
+    
+  std::vector<Matrix<double, 1, Dynamic> > mat_vec(3);
+  for(int i = 0; i < 3; ++i)
+    mat_vec[i] = Matrix<double,1,Dynamic>(3);
+
+  mat_vec[0] << 1, 5 ,9;
+  mat_vec[1] << 2, 4, 6;
+  mat_vec[2] << 3, 6, 7;
+
+
+  Matrix<double, Dynamic, Dynamic> cmat =
+    corr(mat_vec);
+
+  EXPECT_FLOAT_EQ(cmat(0,0), 1.0);
+  EXPECT_FLOAT_EQ(cmat(0,2), -1.0 / sqrt(7.0 / 3.0 ));
+  EXPECT_FLOAT_EQ(cmat(1,2), 0.5 / sqrt(7.0 / 3.0 ));
+}

--- a/test/unit/math/rev/mat/fun/covariance_test.cpp
+++ b/test/unit/math/rev/mat/fun/covariance_test.cpp
@@ -16,10 +16,50 @@ TEST(AgradRevMatrix, cov_eq) {
   Matrix<double, Dynamic, Dynamic> cmat =
     cov(x);
 
-  //std::cout << cmat;
+  EXPECT_FLOAT_EQ(cmat(0,0), 1.0);
+  EXPECT_FLOAT_EQ(cmat(0,2), -1.0);
+  EXPECT_FLOAT_EQ(cmat(2,2), 7.0/3.0);
+}
+
+
+TEST(AgradRevMatrix, cov_colvec_eq) {
+  using stan::math::cov;
+  using namespace Eigen;  
+  
+  std::vector<Matrix<double, Dynamic,1> > mat_vec(3);
+  for(int i = 0; i < 3; ++i)
+    mat_vec[i] = Matrix<double, Dynamic, 1>(3);
+
+  mat_vec[0] << 1, 2 ,3;
+  mat_vec[1] << 5, 4, 6;
+  mat_vec[2] << 9, 6, 7;
+  
+  Matrix<double, Dynamic, Dynamic> cmat =
+    cov(mat_vec);
 
   EXPECT_FLOAT_EQ(cmat(0,0), 1.0);
   EXPECT_FLOAT_EQ(cmat(0,2), -1.0);
   EXPECT_FLOAT_EQ(cmat(2,2), 7.0/3.0);
 }
 
+
+TEST(AgradRevMatrix, cov_rowvec_eq) {
+  using stan::math::cov;
+  using namespace Eigen;
+    
+  std::vector<Matrix<double, 1, Dynamic> > mat_vec(3);
+  for(int i = 0; i < 3; ++i)
+    mat_vec[i] = Matrix<double,1,Dynamic>(3);
+
+  mat_vec[0] << 1, 5 ,9;
+  mat_vec[1] << 2, 4, 6;
+  mat_vec[2] << 3, 6, 7;
+
+
+  Matrix<double, Dynamic, Dynamic> cmat =
+    cov(mat_vec);
+
+  EXPECT_FLOAT_EQ(cmat(0,0), 1.0);
+  EXPECT_FLOAT_EQ(cmat(0,2), -1.0);
+  EXPECT_FLOAT_EQ(cmat(2,2), 7.0/3.0);
+}

--- a/test/unit/math/rev/mat/fun/covariance_test.cpp
+++ b/test/unit/math/rev/mat/fun/covariance_test.cpp
@@ -1,0 +1,25 @@
+#include <stan/math/rev/mat.hpp>
+#include <gtest/gtest.h>
+#include <test/unit/math/rev/mat/fun/util.hpp>
+#include <test/unit/math/rev/mat/util.hpp>
+
+TEST(AgradRevMatrix, cov_eq) {
+  using stan::math::cov;
+  using namespace Eigen;
+    
+  Matrix<double, Dynamic, Dynamic> x(3,3);
+  x <<
+    1, 5, 9,
+    2, 4, 6,
+    3, 6, 7;
+
+  Matrix<double, Dynamic, Dynamic> cmat =
+    cov(x);
+
+  //std::cout << cmat;
+
+  EXPECT_FLOAT_EQ(cmat(0,0), 1.0);
+  EXPECT_FLOAT_EQ(cmat(0,2), -1.0);
+  EXPECT_FLOAT_EQ(cmat(2,2), 7.0/3.0);
+}
+


### PR DESCRIPTION
#### Submission Checklist

- [ ] Run unit tests: `./runTests.py test/unit`
- [ ] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

Add correlation and covariance functions to rev/mat/fun, this is in order to address issue #75. 

#### Intended Effect:

Implement the naive pure eigen approach to computing these sample statistics as suggested by Bob in the original stan issue. Unsure how to make this compatible with autodiff, but hopefully more seasoned devs can help me with this. Additionally unsure if dividing by a double in the code will be compatible with the autodiff types.

#### How to Verify:

Run a model that requires sample correlations or covariance.

#### Side Effects:

None

#### Documentation:

Presently none

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): 

- Chris Hammill

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
