### PR TITLE
Replace 1/x with inv(x) - issue #595

### DIFF
--- a/stan/math/prim/scal/prob/bernoulli_cdf.hpp
+++ b/stan/math/prim/scal/prob/bernoulli_cdf.hpp
@@ -75,7 +75,7 @@ namespace stan {
         P *= Pi;
 
         if (!is_constant_struct<T_prob>::value)
-          ops_partials.edge1_.partials_[i] += - 1 / Pi;
+          ops_partials.edge1_.partials_[i] += - inv(Pi);
       }
 
       if (!is_constant_struct<T_prob>::value) {

--- a/stan/math/prim/scal/prob/bernoulli_lccdf.hpp
+++ b/stan/math/prim/scal/prob/bernoulli_lccdf.hpp
@@ -77,7 +77,7 @@ namespace stan {
           P += log(Pi);
 
           if (!is_constant_struct<T_prob>::value)
-            ops_partials.edge1_.partials_[i] += 1 / Pi;
+            ops_partials.edge1_.partials_[i] += inv(Pi);
         }
       }
 

--- a/stan/math/prim/scal/prob/bernoulli_lcdf.hpp
+++ b/stan/math/prim/scal/prob/bernoulli_lcdf.hpp
@@ -77,7 +77,7 @@ namespace stan {
         P += log(Pi);
 
         if (!is_constant_struct<T_prob>::value)
-          ops_partials.edge1_.partials_[i] -= 1 / Pi;
+          ops_partials.edge1_.partials_[i] -= inv(Pi);
       }
 
       return ops_partials.build(P);

--- a/stan/math/prim/scal/prob/bernoulli_lpmf.hpp
+++ b/stan/math/prim/scal/prob/bernoulli_lpmf.hpp
@@ -103,9 +103,9 @@ namespace stan {
 
           if (!is_constant_struct<T_prob>::value) {
             if (n_int == 1)
-              ops_partials.edge1_.partials_[n] += 1.0 / theta_dbl;
+              ops_partials.edge1_.partials_[n] += inv(theta_dbl);
             else
-              ops_partials.edge1_.partials_[n] += 1.0 / (theta_dbl - 1);
+              ops_partials.edge1_.partials_[n] += inv(theta_dbl - 1);
           }
         }
       }

--- a/stan/math/prim/scal/prob/cauchy_cdf.hpp
+++ b/stan/math/prim/scal/prob/cauchy_cdf.hpp
@@ -86,7 +86,7 @@ namespace stan {
 
         const T_partials_return y_dbl = value_of(y_vec[n]);
         const T_partials_return mu_dbl = value_of(mu_vec[n]);
-        const T_partials_return sigma_inv_dbl = 1.0 / value_of(sigma_vec[n]);
+        const T_partials_return sigma_inv_dbl = inv(value_of(sigma_vec[n]));
 
         const T_partials_return z = (y_dbl - mu_dbl) * sigma_inv_dbl;
 

--- a/stan/math/prim/scal/prob/cauchy_lccdf.hpp
+++ b/stan/math/prim/scal/prob/cauchy_lccdf.hpp
@@ -74,14 +74,14 @@ namespace stan {
       for (size_t n = 0; n < N; n++) {
         const T_partials_return y_dbl = value_of(y_vec[n]);
         const T_partials_return mu_dbl = value_of(mu_vec[n]);
-        const T_partials_return sigma_inv_dbl = 1.0 / value_of(sigma_vec[n]);
+        const T_partials_return sigma_inv_dbl = inv(value_of(sigma_vec[n]));
         const T_partials_return sigma_dbl = value_of(sigma_vec[n]);
         const T_partials_return z = (y_dbl - mu_dbl) * sigma_inv_dbl;
 
         const T_partials_return Pn = 0.5 - atan(z) / pi();
         ccdf_log += log(Pn);
 
-        const T_partials_return rep_deriv = 1.0 / (Pn * pi()
+        const T_partials_return rep_deriv = inv(Pn * pi()
                                                    * (z * z * sigma_dbl
                                                       + sigma_dbl));
         if (!is_constant_struct<T_y>::value)

--- a/stan/math/prim/scal/prob/cauchy_lcdf.hpp
+++ b/stan/math/prim/scal/prob/cauchy_lcdf.hpp
@@ -74,7 +74,7 @@ namespace stan {
       for (size_t n = 0; n < N; n++) {
         const T_partials_return y_dbl = value_of(y_vec[n]);
         const T_partials_return mu_dbl = value_of(mu_vec[n]);
-        const T_partials_return sigma_inv_dbl = 1.0 / value_of(sigma_vec[n]);
+        const T_partials_return sigma_inv_dbl = inv(value_of(sigma_vec[n]));
         const T_partials_return sigma_dbl = value_of(sigma_vec[n]);
 
         const T_partials_return z = (y_dbl - mu_dbl) * sigma_inv_dbl;
@@ -83,7 +83,7 @@ namespace stan {
         cdf_log += log(Pn);
 
         const T_partials_return rep_deriv
-          = 1.0 / (pi() * Pn * (z * z * sigma_dbl + sigma_dbl));
+          = inv(pi() * Pn * (z * z * sigma_dbl + sigma_dbl));
         if (!is_constant_struct<T_y>::value)
           ops_partials.edge1_.partials_[n] += rep_deriv;
         if (!is_constant_struct<T_loc>::value)

--- a/stan/math/prim/scal/prob/cauchy_lpdf.hpp
+++ b/stan/math/prim/scal/prob/cauchy_lpdf.hpp
@@ -80,7 +80,7 @@ namespace stan {
                     T_partials_return, T_scale> log_sigma(length(sigma));
       for (size_t i = 0; i < length(sigma); i++) {
         const T_partials_return sigma_dbl = value_of(sigma_vec[i]);
-        inv_sigma[i] = 1.0 / sigma_dbl;
+        inv_sigma[i] = inv(sigma_dbl);
         sigma_squared[i] = sigma_dbl * sigma_dbl;
         if (include_summand<propto, T_scale>::value) {
           log_sigma[i] = log(sigma_dbl);

--- a/stan/math/prim/scal/prob/chi_square_lpdf.hpp
+++ b/stan/math/prim/scal/prob/chi_square_lpdf.hpp
@@ -88,7 +88,7 @@ namespace stan {
                     T_partials_return, T_y> inv_y(length(y));
       for (size_t i = 0; i < length(y); i++)
         if (include_summand<propto, T_y>::value)
-          inv_y[i] = 1.0 / value_of(y_vec[i]);
+          inv_y[i] = inv(value_of(y_vec[i]));
 
       VectorBuilder<include_summand<propto, T_dof>::value,
                     T_partials_return, T_dof> lgamma_half_nu(length(nu));

--- a/stan/math/prim/scal/prob/double_exponential_cdf.hpp
+++ b/stan/math/prim/scal/prob/double_exponential_cdf.hpp
@@ -83,7 +83,7 @@ namespace stan {
         const T_partials_return sigma_dbl = value_of(sigma_vec[n]);
         const T_partials_return scaled_diff = (y_dbl - mu_dbl) / sigma_dbl;
         const T_partials_return exp_scaled_diff = exp(scaled_diff);
-        const T_partials_return inv_sigma = 1.0 / sigma_dbl;
+        const T_partials_return inv_sigma = inv(sigma_dbl);
 
         if (y_dbl < mu_dbl) {
           if (!is_constant_struct<T_y>::value)

--- a/stan/math/prim/scal/prob/double_exponential_lccdf.hpp
+++ b/stan/math/prim/scal/prob/double_exponential_lccdf.hpp
@@ -76,12 +76,11 @@ namespace stan {
         const T_partials_return mu_dbl = value_of(mu_vec[n]);
         const T_partials_return sigma_dbl = value_of(sigma_vec[n]);
         const T_partials_return scaled_diff = (y_dbl - mu_dbl) / sigma_dbl;
-        const T_partials_return inv_sigma = 1.0 / sigma_dbl;
+        const T_partials_return inv_sigma = inv(sigma_dbl);
         if (y_dbl < mu_dbl) {
           ccdf_log += log1m(0.5 * exp(scaled_diff));
 
-          const T_partials_return rep_deriv = 1.0
-            / (2.0 * exp(-scaled_diff) - 1.0);
+          const T_partials_return rep_deriv = inv(2.0 * exp(-scaled_diff) - 1.0);
           if (!is_constant_struct<T_y>::value)
             ops_partials.edge1_.partials_[n] -= rep_deriv * inv_sigma;
           if (!is_constant_struct<T_loc>::value)

--- a/stan/math/prim/scal/prob/double_exponential_lccdf.hpp
+++ b/stan/math/prim/scal/prob/double_exponential_lccdf.hpp
@@ -80,7 +80,8 @@ namespace stan {
         if (y_dbl < mu_dbl) {
           ccdf_log += log1m(0.5 * exp(scaled_diff));
 
-          const T_partials_return rep_deriv = inv(2.0 * exp(-scaled_diff) - 1.0);
+          const T_partials_return rep_deriv = inv(2.0
+                                                    * exp(-scaled_diff) - 1.0);
           if (!is_constant_struct<T_y>::value)
             ops_partials.edge1_.partials_[n] -= rep_deriv * inv_sigma;
           if (!is_constant_struct<T_loc>::value)

--- a/stan/math/prim/scal/prob/double_exponential_lcdf.hpp
+++ b/stan/math/prim/scal/prob/double_exponential_lcdf.hpp
@@ -88,7 +88,8 @@ namespace stan {
         } else {
           cdf_log += log1m(0.5 * exp(-scaled_diff));
 
-          const T_partials_return rep_deriv = inv(2.0 * exp(scaled_diff) - 1.0);
+          const T_partials_return rep_deriv = inv(2.0
+                                                    * exp(scaled_diff) - 1.0);
           if (!is_constant_struct<T_y>::value)
             ops_partials.edge1_.partials_[n] += rep_deriv * inv_sigma;
           if (!is_constant_struct<T_loc>::value)

--- a/stan/math/prim/scal/prob/double_exponential_lcdf.hpp
+++ b/stan/math/prim/scal/prob/double_exponential_lcdf.hpp
@@ -75,7 +75,7 @@ namespace stan {
         const T_partials_return mu_dbl = value_of(mu_vec[n]);
         const T_partials_return sigma_dbl = value_of(sigma_vec[n]);
         const T_partials_return scaled_diff = (y_dbl - mu_dbl) / sigma_dbl;
-        const T_partials_return inv_sigma = 1.0 / sigma_dbl;
+        const T_partials_return inv_sigma = inv(sigma_dbl);
         if (y_dbl < mu_dbl) {
           cdf_log += log_half + scaled_diff;
 
@@ -88,8 +88,7 @@ namespace stan {
         } else {
           cdf_log += log1m(0.5 * exp(-scaled_diff));
 
-          const T_partials_return rep_deriv = 1.0
-            / (2.0 * exp(scaled_diff) - 1.0);
+          const T_partials_return rep_deriv = inv(2.0 * exp(scaled_diff) - 1.0);
           if (!is_constant_struct<T_y>::value)
             ops_partials.edge1_.partials_[n] += rep_deriv * inv_sigma;
           if (!is_constant_struct<T_loc>::value)

--- a/stan/math/prim/scal/prob/double_exponential_lpdf.hpp
+++ b/stan/math/prim/scal/prob/double_exponential_lpdf.hpp
@@ -84,7 +84,7 @@ namespace stan {
       for (size_t i = 0; i < length(sigma); i++) {
         const T_partials_return sigma_dbl = value_of(sigma_vec[i]);
         if (include_summand<propto, T_y, T_loc, T_scale>::value)
-          inv_sigma[i] = 1.0 / sigma_dbl;
+          inv_sigma[i] = inv(sigma_dbl);
         if (include_summand<propto, T_scale>::value)
           log_sigma[i] = log(value_of(sigma_vec[i]));
         if (!is_constant_struct<T_scale>::value)

--- a/stan/math/prim/scal/prob/exp_mod_normal_lpdf.hpp
+++ b/stan/math/prim/scal/prob/exp_mod_normal_lpdf.hpp
@@ -98,7 +98,7 @@ namespace stan {
         if (!is_constant_struct<T_y>::value)
           ops_partials.edge1_.partials_[n]
             += -lambda_dbl
-            + deriv_logerfc * -1.0 / (sigma_dbl * std::sqrt(2.0));
+            + deriv_logerfc * -inv(sigma_dbl * std::sqrt(2.0));
         if (!is_constant_struct<T_loc>::value)
           ops_partials.edge2_.partials_[n]
             += lambda_dbl
@@ -112,7 +112,7 @@ namespace stan {
                + y_dbl / (sigma_dbl * sigma_dbl * std::sqrt(2.0)));
         if (!is_constant_struct<T_inv_scale>::value)
           ops_partials.edge4_.partials_[n]
-            += 1 / lambda_dbl + lambda_dbl * sigma_dbl * sigma_dbl
+            += inv(lambda_dbl) + lambda_dbl * sigma_dbl * sigma_dbl
             + mu_dbl - y_dbl + deriv_logerfc * sigma_dbl / std::sqrt(2.0);
       }
       return ops_partials.build(logp);

--- a/stan/math/prim/scal/prob/exponential_lpdf.hpp
+++ b/stan/math/prim/scal/prob/exponential_lpdf.hpp
@@ -92,7 +92,7 @@ namespace stan {
         if (!is_constant_struct<T_y>::value)
           ops_partials.edge1_.partials_[n] -= beta_dbl;
         if (!is_constant_struct<T_inv_scale>::value)
-          ops_partials.edge2_.partials_[n] += 1 / beta_dbl - y_dbl;
+          ops_partials.edge2_.partials_[n] += inv(beta_dbl) - y_dbl;
       }
       return ops_partials.build(logp);
     }

--- a/stan/math/prim/scal/prob/frechet_lccdf.hpp
+++ b/stan/math/prim/scal/prob/frechet_lccdf.hpp
@@ -63,7 +63,7 @@ namespace stan {
 
         ccdf_log += log1m(exp_);
 
-        const T_partials_return rep_deriv_ = pow_ / (1.0 / exp_ - 1);
+        const T_partials_return rep_deriv_ = pow_ / (inv(exp_) - 1);
         if (!is_constant_struct<T_y>::value)
           ops_partials.edge1_.partials_[n] -= alpha_dbl / y_dbl * rep_deriv_;
         if (!is_constant_struct<T_shape>::value)

--- a/stan/math/prim/scal/prob/frechet_lpdf.hpp
+++ b/stan/math/prim/scal/prob/frechet_lpdf.hpp
@@ -80,7 +80,7 @@ namespace stan {
                     T_partials_return, T_y> inv_y(length(y));
       for (size_t i = 0; i < length(y); i++)
         if (include_summand<propto, T_y, T_shape, T_scale>::value)
-          inv_y[i] = 1.0 / value_of(y_vec[i]);
+          inv_y[i] = inv(value_of(y_vec[i]));
 
       VectorBuilder<include_summand<propto, T_y, T_shape, T_scale>::value,
                     T_partials_return, T_y, T_shape, T_scale>
@@ -113,7 +113,7 @@ namespace stan {
         }
         if (!is_constant_struct<T_shape>::value)
           ops_partials.edge2_.partials_[n]
-            += 1.0/alpha_dbl
+            += inv(alpha_dbl)
             + (1.0 - sigma_div_y_pow_alpha[n]) * (log_sigma[n] - log_y[n]);
         if (!is_constant_struct<T_scale>::value)
           ops_partials.edge3_.partials_[n]

--- a/stan/math/prim/scal/prob/frechet_rng.hpp
+++ b/stan/math/prim/scal/prob/frechet_rng.hpp
@@ -37,8 +37,8 @@ namespace stan {
       check_positive(function, "Scale parameter", sigma);
 
       variate_generator<RNG&, weibull_distribution<> >
-        weibull_rng(rng, weibull_distribution<>(alpha, 1.0/sigma));
-      return 1.0 / weibull_rng();
+        weibull_rng(rng, weibull_distribution<>(alpha, inv(sigma)));
+      return inv(weibull_rng());
     }
 
   }

--- a/stan/math/prim/scal/prob/gamma_rng.hpp
+++ b/stan/math/prim/scal/prob/gamma_rng.hpp
@@ -42,7 +42,7 @@ namespace stan {
         by shape and rate (inverse scale)
       */
       variate_generator<RNG&, gamma_distribution<> >
-        gamma_rng(rng, gamma_distribution<>(alpha, 1.0 / beta));
+        gamma_rng(rng, gamma_distribution<>(alpha, inv(beta)));
       return gamma_rng();
     }
 

--- a/stan/math/prim/scal/prob/gumbel_lpdf.hpp
+++ b/stan/math/prim/scal/prob/gumbel_lpdf.hpp
@@ -77,7 +77,7 @@ namespace stan {
       VectorBuilder<include_summand<propto, T_scale>::value,
                     T_partials_return, T_scale> log_beta(length(beta));
       for (size_t i = 0; i < length(beta); i++) {
-        inv_beta[i] = 1.0 / value_of(beta_vec[i]);
+        inv_beta[i] = inv(value_of(beta_vec[i]));
         if (include_summand<propto, T_scale>::value)
           log_beta[i] = log(value_of(beta_vec[i]));
       }

--- a/stan/math/prim/scal/prob/inv_chi_square_cdf.hpp
+++ b/stan/math/prim/scal/prob/inv_chi_square_cdf.hpp
@@ -101,7 +101,7 @@ namespace stan {
         }
 
         const T_partials_return y_dbl = value_of(y_vec[n]);
-        const T_partials_return y_inv_dbl = 1.0 / y_dbl;
+        const T_partials_return y_inv_dbl = inv(y_dbl);
         const T_partials_return nu_dbl = value_of(nu_vec[n]);
 
         const T_partials_return Pn = gamma_q(0.5 * nu_dbl, 0.5 * y_inv_dbl);

--- a/stan/math/prim/scal/prob/inv_chi_square_lccdf.hpp
+++ b/stan/math/prim/scal/prob/inv_chi_square_lccdf.hpp
@@ -102,7 +102,7 @@ namespace stan {
         }
 
         const T_partials_return y_dbl = value_of(y_vec[n]);
-        const T_partials_return y_inv_dbl = 1.0 / y_dbl;
+        const T_partials_return y_inv_dbl = inv(y_dbl);
         const T_partials_return nu_dbl = value_of(nu_vec[n]);
 
         const T_partials_return Pn = gamma_p(0.5 * nu_dbl, 0.5

--- a/stan/math/prim/scal/prob/inv_chi_square_lcdf.hpp
+++ b/stan/math/prim/scal/prob/inv_chi_square_lcdf.hpp
@@ -102,7 +102,7 @@ namespace stan {
         }
 
         const T_partials_return y_dbl = value_of(y_vec[n]);
-        const T_partials_return y_inv_dbl = 1.0 / y_dbl;
+        const T_partials_return y_inv_dbl = inv(y_dbl);
         const T_partials_return nu_dbl = value_of(nu_vec[n]);
 
         const T_partials_return Pn = gamma_q(0.5 * nu_dbl, 0.5 * y_inv_dbl);

--- a/stan/math/prim/scal/prob/inv_chi_square_lpdf.hpp
+++ b/stan/math/prim/scal/prob/inv_chi_square_lpdf.hpp
@@ -86,7 +86,7 @@ namespace stan {
                     T_partials_return, T_y> inv_y(length(y));
       for (size_t i = 0; i < length(y); i++)
         if (include_summand<propto, T_y>::value)
-          inv_y[i] = 1.0 / value_of(y_vec[i]);
+          inv_y[i] = inv(value_of(y_vec[i]));
 
       VectorBuilder<include_summand<propto, T_dof>::value,
                     T_partials_return, T_dof> lgamma_half_nu(length(nu));

--- a/stan/math/prim/scal/prob/inv_chi_square_rng.hpp
+++ b/stan/math/prim/scal/prob/inv_chi_square_rng.hpp
@@ -45,7 +45,7 @@ namespace stan {
 
       variate_generator<RNG&, chi_squared_distribution<> >
         chi_square_rng(rng, chi_squared_distribution<>(nu));
-      return 1 / chi_square_rng();
+      return inv(chi_square_rng());
     }
 
   }

--- a/stan/math/prim/scal/prob/inv_gamma_cdf.hpp
+++ b/stan/math/prim/scal/prob/inv_gamma_cdf.hpp
@@ -112,7 +112,7 @@ namespace stan {
           continue;
 
         const T_partials_return y_dbl = value_of(y_vec[n]);
-        const T_partials_return y_inv_dbl = 1.0 / y_dbl;
+        const T_partials_return y_inv_dbl = inv(y_dbl);
         const T_partials_return alpha_dbl = value_of(alpha_vec[n]);
         const T_partials_return beta_dbl = value_of(beta_vec[n]);
 

--- a/stan/math/prim/scal/prob/inv_gamma_lccdf.hpp
+++ b/stan/math/prim/scal/prob/inv_gamma_lccdf.hpp
@@ -97,7 +97,7 @@ namespace stan {
           return ops_partials.build(negative_infinity());
 
         const T_partials_return y_dbl = value_of(y_vec[n]);
-        const T_partials_return y_inv_dbl = 1.0 / y_dbl;
+        const T_partials_return y_inv_dbl = inv(y_dbl);
         const T_partials_return alpha_dbl = value_of(alpha_vec[n]);
         const T_partials_return beta_dbl = value_of(beta_vec[n]);
 

--- a/stan/math/prim/scal/prob/inv_gamma_lcdf.hpp
+++ b/stan/math/prim/scal/prob/inv_gamma_lcdf.hpp
@@ -97,7 +97,7 @@ namespace stan {
           continue;
 
         const T_partials_return y_dbl = value_of(y_vec[n]);
-        const T_partials_return y_inv_dbl = 1.0 / y_dbl;
+        const T_partials_return y_inv_dbl = inv(y_dbl);
         const T_partials_return alpha_dbl = value_of(alpha_vec[n]);
         const T_partials_return beta_dbl = value_of(beta_vec[n]);
 

--- a/stan/math/prim/scal/prob/inv_gamma_lpdf.hpp
+++ b/stan/math/prim/scal/prob/inv_gamma_lpdf.hpp
@@ -97,7 +97,7 @@ namespace stan {
           if (value_of(y_vec[n]) > 0)
             log_y[n] = log(value_of(y_vec[n]));
         if (include_summand<propto, T_y, T_scale>::value)
-          inv_y[n] = 1.0 / value_of(y_vec[n]);
+          inv_y[n] = inv(value_of(y_vec[n]));
       }
 
       VectorBuilder<include_summand<propto, T_shape>::value,

--- a/stan/math/prim/scal/prob/inv_gamma_rng.hpp
+++ b/stan/math/prim/scal/prob/inv_gamma_rng.hpp
@@ -38,8 +38,8 @@ namespace stan {
       check_positive_finite(function, "Scale parameter", beta);
 
       variate_generator<RNG&, gamma_distribution<> >
-        gamma_rng(rng, gamma_distribution<>(alpha, 1 / beta));
-      return 1 / gamma_rng();
+        gamma_rng(rng, gamma_distribution<>(alpha, inv(beta)));
+      return inv(gamma_rng());
     }
 
   }

--- a/stan/math/prim/scal/prob/logistic_cdf.hpp
+++ b/stan/math/prim/scal/prob/logistic_cdf.hpp
@@ -76,9 +76,9 @@ namespace stan {
         const T_partials_return y_dbl = value_of(y_vec[n]);
         const T_partials_return mu_dbl = value_of(mu_vec[n]);
         const T_partials_return sigma_dbl = value_of(sigma_vec[n]);
-        const T_partials_return sigma_inv_vec = 1.0 / value_of(sigma_vec[n]);
+        const T_partials_return sigma_inv_vec = inv(value_of(sigma_vec[n]));
 
-        const T_partials_return Pn = 1.0 / (1.0 + exp(-(y_dbl - mu_dbl)
+        const T_partials_return Pn = inv(1.0 + exp(-(y_dbl - mu_dbl)
                                                       * sigma_inv_vec));
 
         P *= Pn;

--- a/stan/math/prim/scal/prob/logistic_lccdf.hpp
+++ b/stan/math/prim/scal/prob/logistic_lccdf.hpp
@@ -77,9 +77,9 @@ namespace stan {
         const T_partials_return y_dbl = value_of(y_vec[n]);
         const T_partials_return mu_dbl = value_of(mu_vec[n]);
         const T_partials_return sigma_dbl = value_of(sigma_vec[n]);
-        const T_partials_return sigma_inv_vec = 1.0 / value_of(sigma_vec[n]);
+        const T_partials_return sigma_inv_vec = inv(value_of(sigma_vec[n]));
 
-        const T_partials_return Pn = 1.0 - 1.0 / (1.0 + exp(-(y_dbl - mu_dbl)
+        const T_partials_return Pn = 1.0 - inv(1.0 + exp(-(y_dbl - mu_dbl)
                                                             * sigma_inv_vec));
         P += log(Pn);
 

--- a/stan/math/prim/scal/prob/logistic_lcdf.hpp
+++ b/stan/math/prim/scal/prob/logistic_lcdf.hpp
@@ -77,9 +77,9 @@ namespace stan {
         const T_partials_return y_dbl = value_of(y_vec[n]);
         const T_partials_return mu_dbl = value_of(mu_vec[n]);
         const T_partials_return sigma_dbl = value_of(sigma_vec[n]);
-        const T_partials_return sigma_inv_vec = 1.0 / value_of(sigma_vec[n]);
+        const T_partials_return sigma_inv_vec = inv(value_of(sigma_vec[n]));
 
-        const T_partials_return Pn = 1.0 / (1.0 + exp(-(y_dbl - mu_dbl)
+        const T_partials_return Pn = inv(1.0 + exp(-(y_dbl - mu_dbl)
                                                       *sigma_inv_vec));
         P += log(Pn);
 

--- a/stan/math/prim/scal/prob/logistic_lpdf.hpp
+++ b/stan/math/prim/scal/prob/logistic_lpdf.hpp
@@ -65,7 +65,7 @@ namespace stan {
       VectorBuilder<include_summand<propto, T_scale>::value,
                     T_partials_return, T_scale> log_sigma(length(sigma));
       for (size_t i = 0; i < length(sigma); i++) {
-        inv_sigma[i] = 1.0 / value_of(sigma_vec[i]);
+        inv_sigma[i] = inv(value_of(sigma_vec[i]));
         if (include_summand<propto, T_scale>::value)
           log_sigma[i] = log(value_of(sigma_vec[i]));
       }
@@ -97,7 +97,7 @@ namespace stan {
           exp_m_y_minus_mu_div_sigma = exp(-y_minus_mu_div_sigma);
         T_partials_return inv_1p_exp_y_minus_mu_div_sigma(0);
         if (contains_nonconstant_struct<T_y, T_scale>::value)
-          inv_1p_exp_y_minus_mu_div_sigma = 1 / (1 + exp(y_minus_mu_div_sigma));
+          inv_1p_exp_y_minus_mu_div_sigma = inv(1 + exp(y_minus_mu_div_sigma));
 
         if (include_summand<propto, T_y, T_loc, T_scale>::value)
           logp -= y_minus_mu_div_sigma;

--- a/stan/math/prim/scal/prob/lognormal_lpdf.hpp
+++ b/stan/math/prim/scal/prob/lognormal_lpdf.hpp
@@ -79,7 +79,7 @@ namespace stan {
                     T_partials_return, T_scale> inv_sigma_sq(length(sigma));
       if (include_summand<propto, T_y, T_loc, T_scale>::value) {
         for (size_t n = 0; n < length(sigma); n++)
-          inv_sigma[n] = 1 / value_of(sigma_vec[n]);
+          inv_sigma[n] = inv(value_of(sigma_vec[n]));
       }
       if (include_summand<propto, T_y, T_loc, T_scale>::value) {
         for (size_t n = 0; n < length(sigma); n++)
@@ -97,7 +97,7 @@ namespace stan {
                     T_partials_return, T_y> inv_y(length(y));
       if (!is_constant_struct<T_y>::value) {
         for (size_t n = 0; n < length(y); n++)
-          inv_y[n] = 1 / value_of(y_vec[n]);
+          inv_y[n] = inv(value_of(y_vec[n]));
       }
 
       if (include_summand<propto>::value)

--- a/stan/math/prim/scal/prob/neg_binomial_2_cdf.hpp
+++ b/stan/math/prim/scal/prob/neg_binomial_2_cdf.hpp
@@ -89,7 +89,7 @@ namespace stan {
         const T_partials_return phi_dbl = value_of(phi_vec[i]);
 
         const T_partials_return p_dbl = phi_dbl / (mu_dbl + phi_dbl);
-        const T_partials_return d_dbl = 1.0 / ((mu_dbl + phi_dbl)
+        const T_partials_return d_dbl = inv((mu_dbl + phi_dbl)
                                                * (mu_dbl + phi_dbl));
 
         const T_partials_return P_i =

--- a/stan/math/prim/scal/prob/neg_binomial_cdf.hpp
+++ b/stan/math/prim/scal/prob/neg_binomial_cdf.hpp
@@ -90,7 +90,7 @@ namespace stan {
         const T_partials_return beta_dbl = value_of(beta_vec[i]);
 
         const T_partials_return p_dbl = beta_dbl / (1.0 + beta_dbl);
-        const T_partials_return d_dbl = 1.0 / ((1.0 + beta_dbl)
+        const T_partials_return d_dbl = inv((1.0 + beta_dbl)
                                                * (1.0 + beta_dbl));
 
         const T_partials_return P_i =

--- a/stan/math/prim/scal/prob/neg_binomial_lccdf.hpp
+++ b/stan/math/prim/scal/prob/neg_binomial_lccdf.hpp
@@ -102,7 +102,7 @@ namespace stan {
         const T_partials_return alpha_dbl = value_of(alpha_vec[i]);
         const T_partials_return beta_dbl = value_of(beta_vec[i]);
         const T_partials_return p_dbl = beta_dbl / (1.0 + beta_dbl);
-        const T_partials_return d_dbl = 1.0 / ((1.0 + beta_dbl)
+        const T_partials_return d_dbl = inv((1.0 + beta_dbl)
                                                * (1.0 + beta_dbl));
         const T_partials_return Pi = 1.0 - inc_beta(alpha_dbl, n_dbl + 1.0,
                                                     p_dbl);

--- a/stan/math/prim/scal/prob/neg_binomial_lcdf.hpp
+++ b/stan/math/prim/scal/prob/neg_binomial_lcdf.hpp
@@ -102,7 +102,7 @@ namespace stan {
         const T_partials_return alpha_dbl = value_of(alpha_vec[i]);
         const T_partials_return beta_dbl = value_of(beta_vec[i]);
         const T_partials_return p_dbl = beta_dbl / (1.0 + beta_dbl);
-        const T_partials_return d_dbl = 1.0 / ((1.0 + beta_dbl)
+        const T_partials_return d_dbl = inv((1.0 + beta_dbl)
                                                * (1.0 + beta_dbl));
         const T_partials_return Pi = inc_beta(alpha_dbl, n_dbl + 1.0, p_dbl);
         const T_partials_return beta_func = exp(lbeta(n_dbl + 1, alpha_dbl));

--- a/stan/math/prim/scal/prob/neg_binomial_lpmf.hpp
+++ b/stan/math/prim/scal/prob/neg_binomial_lpmf.hpp
@@ -131,7 +131,7 @@ namespace stan {
           if (!is_constant_struct<T_shape>::value)
             ops_partials.edge1_.partials_[i]
               += n_vec[i] / value_of(alpha_vec[i])
-              - 1.0 / value_of(beta_vec[i]);
+              - inv(value_of(beta_vec[i]));
           if (!is_constant_struct<T_inv_scale>::value)
             ops_partials.edge2_.partials_[i]
               += (lambda[i] - n_vec[i]) / value_of(beta_vec[i]);

--- a/stan/math/prim/scal/prob/neg_binomial_rng.hpp
+++ b/stan/math/prim/scal/prob/neg_binomial_rng.hpp
@@ -42,7 +42,7 @@ namespace stan {
 
       double rng_from_gamma =
         variate_generator<RNG&, gamma_distribution<> >
-        (rng, gamma_distribution<>(alpha, 1.0 / beta))();
+        (rng, gamma_distribution<>(alpha, inv(beta)))();
 
       // same as the constraints for poisson_rng
       check_less(function,

--- a/stan/math/prim/scal/prob/normal_lpdf.hpp
+++ b/stan/math/prim/scal/prob/normal_lpdf.hpp
@@ -80,7 +80,7 @@ namespace stan {
       VectorBuilder<include_summand<propto, T_scale>::value,
                     T_partials_return, T_scale> log_sigma(length(sigma));
       for (size_t i = 0; i < length(sigma); i++) {
-        inv_sigma[i] = 1.0 / value_of(sigma_vec[i]);
+        inv_sigma[i] = inv(value_of(sigma_vec[i]));
         if (include_summand<propto, T_scale>::value)
           log_sigma[i] = log(value_of(sigma_vec[i]));
       }

--- a/stan/math/prim/scal/prob/pareto_cdf.hpp
+++ b/stan/math/prim/scal/prob/pareto_cdf.hpp
@@ -72,7 +72,7 @@ namespace stan {
 
         const T_partials_return log_dbl = log(value_of(y_min_vec[n])
                                               / value_of(y_vec[n]));
-        const T_partials_return y_min_inv_dbl = 1.0 / value_of(y_min_vec[n]);
+        const T_partials_return y_min_inv_dbl = inv(value_of(y_min_vec[n]));
         const T_partials_return alpha_dbl = value_of(alpha_vec[n]);
 
         const T_partials_return Pn = 1.0 - exp(alpha_dbl * log_dbl);

--- a/stan/math/prim/scal/prob/pareto_lccdf.hpp
+++ b/stan/math/prim/scal/prob/pareto_lccdf.hpp
@@ -72,7 +72,7 @@ namespace stan {
 
         const T_partials_return log_dbl = log(value_of(y_min_vec[n])
                                               / value_of(y_vec[n]));
-        const T_partials_return y_min_inv_dbl = 1.0 / value_of(y_min_vec[n]);
+        const T_partials_return y_min_inv_dbl = inv(value_of(y_min_vec[n]));
         const T_partials_return alpha_dbl = value_of(alpha_vec[n]);
 
         P += alpha_dbl * log_dbl;

--- a/stan/math/prim/scal/prob/pareto_lcdf.hpp
+++ b/stan/math/prim/scal/prob/pareto_lcdf.hpp
@@ -71,7 +71,7 @@ namespace stan {
 
         const T_partials_return log_dbl = log(value_of(y_min_vec[n])
                                               / value_of(y_vec[n]));
-        const T_partials_return y_min_inv_dbl = 1.0 / value_of(y_min_vec[n]);
+        const T_partials_return y_min_inv_dbl = inv(value_of(y_min_vec[n]));
         const T_partials_return alpha_dbl = value_of(alpha_vec[n]);
 
         const T_partials_return Pn = 1.0 - exp(alpha_dbl * log_dbl);

--- a/stan/math/prim/scal/prob/pareto_lpdf.hpp
+++ b/stan/math/prim/scal/prob/pareto_lpdf.hpp
@@ -75,7 +75,7 @@ namespace stan {
                     T_partials_return, T_y> inv_y(length(y));
       if (contains_nonconstant_struct<T_y, T_shape>::value) {
         for (size_t n = 0; n < length(y); n++)
-          inv_y[n] = 1 / value_of(y_vec[n]);
+          inv_y[n] = inv(value_of(y_vec[n]));
       }
 
       VectorBuilder<include_summand<propto, T_scale, T_shape>::value,
@@ -109,7 +109,7 @@ namespace stan {
             += alpha_dbl / value_of(y_min_vec[n]);
         if (!is_constant_struct<T_shape>::value)
           ops_partials.edge3_.partials_[n]
-            += 1 / alpha_dbl + log_y_min[n] - log_y[n];
+            += inv(alpha_dbl) + log_y_min[n] - log_y[n];
       }
       return ops_partials.build(logp);
     }

--- a/stan/math/prim/scal/prob/pareto_type_2_lcdf.hpp
+++ b/stan/math/prim/scal/prob/pareto_type_2_lcdf.hpp
@@ -77,9 +77,9 @@ namespace stan {
           / value_of(lambda_vec[i]);
         const T_partials_return p1_pow_alpha
           = pow(temp, value_of(alpha_vec[i]));
-        cdf_log[i] = log1m(1.0 / p1_pow_alpha);
+        cdf_log[i] = log1m(inv(p1_pow_alpha));
 
-        inv_p1_pow_alpha_minus_one[i] = 1.0 / (p1_pow_alpha - 1.0);
+        inv_p1_pow_alpha_minus_one[i] = inv(p1_pow_alpha - 1.0);
 
         if (!is_constant_struct<T_shape>::value)
           log_1p_y_over_lambda[i] = log(temp);

--- a/stan/math/prim/scal/prob/pareto_type_2_lpdf.hpp
+++ b/stan/math/prim/scal/prob/pareto_type_2_lpdf.hpp
@@ -93,7 +93,7 @@ namespace stan {
                     T_partials_return, T_shape> inv_alpha(length(alpha));
       if (!is_constant_struct<T_shape>::value) {
         for (size_t n = 0; n < length(alpha); n++)
-          inv_alpha[n] = 1 / value_of(alpha_vec[n]);
+          inv_alpha[n] = inv(value_of(alpha_vec[n]));
       }
 
       for (size_t n = 0; n < N; n++) {
@@ -102,7 +102,7 @@ namespace stan {
         const T_partials_return lambda_dbl = value_of(lambda_vec[n]);
         const T_partials_return alpha_dbl = value_of(alpha_vec[n]);
         const T_partials_return sum_dbl = lambda_dbl + y_dbl - mu_dbl;
-        const T_partials_return inv_sum = 1.0 / sum_dbl;
+        const T_partials_return inv_sum = inv(sum_dbl);
         const T_partials_return alpha_div_sum = alpha_dbl / sum_dbl;
         const T_partials_return deriv_1_2 = inv_sum + alpha_div_sum;
 

--- a/stan/math/prim/scal/prob/pareto_type_2_rng.hpp
+++ b/stan/math/prim/scal/prob/pareto_type_2_rng.hpp
@@ -27,7 +27,7 @@ namespace stan {
 
       check_positive(function, "scale parameter", lambda);
       double uniform_01 = uniform_rng(0.0, 1.0, rng);
-      return (std::pow(1.0 - uniform_01, -1.0 / alpha) - 1.0) * lambda + mu;
+      return (std::pow(1.0 - uniform_01, -inv(alpha)) - 1.0) * lambda + mu;
     }
 
   }

--- a/stan/math/prim/scal/prob/rayleigh_cdf.hpp
+++ b/stan/math/prim/scal/prob/rayleigh_cdf.hpp
@@ -55,7 +55,7 @@ namespace stan {
 
       VectorBuilder<true, T_partials_return, T_scale> inv_sigma(length(sigma));
       for (size_t i = 0; i < length(sigma); i++) {
-        inv_sigma[i] = 1.0 / value_of(sigma_vec[i]);
+        inv_sigma[i] = inv(value_of(sigma_vec[i]));
       }
 
       for (size_t n = 0; n < N; n++) {

--- a/stan/math/prim/scal/prob/rayleigh_lccdf.hpp
+++ b/stan/math/prim/scal/prob/rayleigh_lccdf.hpp
@@ -53,7 +53,7 @@ namespace stan {
 
       VectorBuilder<true, T_partials_return, T_scale> inv_sigma(length(sigma));
       for (size_t i = 0; i < length(sigma); i++) {
-        inv_sigma[i] = 1.0 / value_of(sigma_vec[i]);
+        inv_sigma[i] = inv(value_of(sigma_vec[i]));
       }
 
       for (size_t n = 0; n < N; n++) {

--- a/stan/math/prim/scal/prob/rayleigh_lcdf.hpp
+++ b/stan/math/prim/scal/prob/rayleigh_lcdf.hpp
@@ -55,7 +55,7 @@ namespace stan {
 
       VectorBuilder<true, T_partials_return, T_scale> inv_sigma(length(sigma));
       for (size_t i = 0; i < length(sigma); i++) {
-        inv_sigma[i] = 1.0 / value_of(sigma_vec[i]);
+        inv_sigma[i] = inv(value_of(sigma_vec[i]));
       }
 
       for (size_t n = 0; n < N; n++) {

--- a/stan/math/prim/scal/prob/rayleigh_lpdf.hpp
+++ b/stan/math/prim/scal/prob/rayleigh_lpdf.hpp
@@ -61,7 +61,7 @@ namespace stan {
       VectorBuilder<include_summand<propto, T_scale>::value,
                     T_partials_return, T_scale> log_sigma(length(sigma));
       for (size_t i = 0; i < length(sigma); i++) {
-        inv_sigma[i] = 1.0 / value_of(sigma_vec[i]);
+        inv_sigma[i] = inv(value_of(sigma_vec[i]));
         if (include_summand<propto, T_scale>::value)
           log_sigma[i] = log(value_of(sigma_vec[i]));
       }
@@ -79,7 +79,7 @@ namespace stan {
 
         T_partials_return scaled_diff = inv_sigma[n] * y_over_sigma;
         if (!is_constant_struct<T_y>::value)
-          ops_partials.edge1_.partials_[n] += 1.0 / y_dbl - scaled_diff;
+          ops_partials.edge1_.partials_[n] += inv(y_dbl) - scaled_diff;
         if (!is_constant_struct<T_scale>::value)
           ops_partials.edge2_.partials_[n]
             += y_over_sigma * scaled_diff - 2.0 * inv_sigma[n];

--- a/stan/math/prim/scal/prob/scaled_inv_chi_square_cdf.hpp
+++ b/stan/math/prim/scal/prob/scaled_inv_chi_square_cdf.hpp
@@ -106,7 +106,7 @@ namespace stan {
         }
 
         const T_partials_return y_dbl = value_of(y_vec[n]);
-        const T_partials_return y_inv_dbl = 1.0 / y_dbl;
+        const T_partials_return y_inv_dbl = inv(y_dbl);
         const T_partials_return half_nu_dbl = 0.5 * value_of(nu_vec[n]);
         const T_partials_return s_dbl = value_of(s_vec[n]);
         const T_partials_return half_s2_overx_dbl = 0.5 * s_dbl * s_dbl

--- a/stan/math/prim/scal/prob/scaled_inv_chi_square_lccdf.hpp
+++ b/stan/math/prim/scal/prob/scaled_inv_chi_square_lccdf.hpp
@@ -94,7 +94,7 @@ namespace stan {
         }
 
         const T_partials_return y_dbl = value_of(y_vec[n]);
-        const T_partials_return y_inv_dbl = 1.0 / y_dbl;
+        const T_partials_return y_inv_dbl = inv(y_dbl);
         const T_partials_return half_nu_dbl = 0.5 * value_of(nu_vec[n]);
         const T_partials_return s_dbl = value_of(s_vec[n]);
         const T_partials_return half_s2_overx_dbl = 0.5 * s_dbl * s_dbl

--- a/stan/math/prim/scal/prob/scaled_inv_chi_square_lcdf.hpp
+++ b/stan/math/prim/scal/prob/scaled_inv_chi_square_lcdf.hpp
@@ -94,7 +94,7 @@ namespace stan {
         }
 
         const T_partials_return y_dbl = value_of(y_vec[n]);
-        const T_partials_return y_inv_dbl = 1.0 / y_dbl;
+        const T_partials_return y_inv_dbl = inv(y_dbl);
         const T_partials_return half_nu_dbl = 0.5 * value_of(nu_vec[n]);
         const T_partials_return s_dbl = value_of(s_vec[n]);
         const T_partials_return half_s2_overx_dbl = 0.5 * s_dbl * s_dbl

--- a/stan/math/prim/scal/prob/scaled_inv_chi_square_lpdf.hpp
+++ b/stan/math/prim/scal/prob/scaled_inv_chi_square_lpdf.hpp
@@ -98,7 +98,7 @@ namespace stan {
                     T_partials_return, T_y> inv_y(length(y));
       for (size_t i = 0; i < length(y); i++)
         if (include_summand<propto, T_dof, T_y, T_scale>::value)
-          inv_y[i] = 1.0 / value_of(y_vec[i]);
+          inv_y[i] = inv(value_of(y_vec[i]));
 
       VectorBuilder<include_summand<propto, T_dof, T_scale>::value,
                     T_partials_return, T_scale> log_s(length(s));

--- a/stan/math/prim/scal/prob/skew_normal_lpdf.hpp
+++ b/stan/math/prim/scal/prob/skew_normal_lpdf.hpp
@@ -72,7 +72,7 @@ namespace stan {
       VectorBuilder<include_summand<propto, T_scale>::value,
                     T_partials_return, T_scale> log_sigma(length(sigma));
       for (size_t i = 0; i < length(sigma); i++) {
-        inv_sigma[i] = 1.0 / value_of(sigma_vec[i]);
+        inv_sigma[i] = inv(value_of(sigma_vec[i]));
         if (include_summand<propto, T_scale>::value)
           log_sigma[i] = log(value_of(sigma_vec[i]));
       }
@@ -113,7 +113,7 @@ namespace stan {
             + deriv_logerf * -alpha_dbl / (sigma_dbl * std::sqrt(2.0));
         if (!is_constant_struct<T_scale>::value)
           ops_partials.edge3_.partials_[n]
-            += -1.0 / sigma_dbl
+            += -inv(sigma_dbl)
             + y_minus_mu_over_sigma * y_minus_mu_over_sigma / sigma_dbl
             - deriv_logerf * y_minus_mu_over_sigma * alpha_dbl
             / (sigma_dbl * std::sqrt(2.0));

--- a/stan/math/prim/scal/prob/student_t_cdf.hpp
+++ b/stan/math/prim/scal/prob/student_t_cdf.hpp
@@ -101,12 +101,12 @@ namespace stan {
           continue;
         }
 
-        const T_partials_return sigma_inv = 1.0 / value_of(sigma_vec[n]);
+        const T_partials_return sigma_inv = inv(value_of(sigma_vec[n]));
         const T_partials_return t = (value_of(y_vec[n]) - value_of(mu_vec[n]))
           * sigma_inv;
         const T_partials_return nu_dbl = value_of(nu_vec[n]);
         const T_partials_return q = nu_dbl / (t * t);
-        const T_partials_return r = 1.0 / (1.0 + q);
+        const T_partials_return r = inv(1.0 + q);
         const T_partials_return J = 2 * r * r * q / t;
         const T_partials_return betaNuHalf = exp(lbeta(0.5, 0.5*nu_dbl));
         double zJacobian = t > 0 ? - 0.5 : 0.5;

--- a/stan/math/prim/scal/prob/student_t_lccdf.hpp
+++ b/stan/math/prim/scal/prob/student_t_lccdf.hpp
@@ -102,12 +102,12 @@ namespace stan {
           return ops_partials.build(negative_infinity());
         }
 
-        const T_partials_return sigma_inv = 1.0 / value_of(sigma_vec[n]);
+        const T_partials_return sigma_inv = inv(value_of(sigma_vec[n]));
         const T_partials_return t = (value_of(y_vec[n]) - value_of(mu_vec[n]))
           * sigma_inv;
         const T_partials_return nu_dbl = value_of(nu_vec[n]);
         const T_partials_return q = nu_dbl / (t * t);
-        const T_partials_return r = 1.0 / (1.0 + q);
+        const T_partials_return r = inv(1.0 + q);
         const T_partials_return J = 2 * r * r * q / t;
         const T_partials_return betaNuHalf = exp(lbeta(0.5, 0.5 * nu_dbl));
         T_partials_return zJacobian = t > 0 ? - 0.5 : 0.5;

--- a/stan/math/prim/scal/prob/student_t_lcdf.hpp
+++ b/stan/math/prim/scal/prob/student_t_lcdf.hpp
@@ -102,12 +102,12 @@ namespace stan {
           continue;
         }
 
-        const T_partials_return sigma_inv = 1.0 / value_of(sigma_vec[n]);
+        const T_partials_return sigma_inv = inv(value_of(sigma_vec[n]));
         const T_partials_return t = (value_of(y_vec[n]) - value_of(mu_vec[n]))
           * sigma_inv;
         const T_partials_return nu_dbl = value_of(nu_vec[n]);
         const T_partials_return q = nu_dbl / (t * t);
-        const T_partials_return r = 1.0 / (1.0 + q);
+        const T_partials_return r = inv(1.0 + q);
         const T_partials_return J = 2 * r * r * q / t;
         const T_partials_return betaNuHalf = exp(lbeta(0.5, 0.5 * nu_dbl));
         T_partials_return zJacobian = t > 0 ? - 0.5 : 0.5;

--- a/stan/math/prim/scal/prob/student_t_lpdf.hpp
+++ b/stan/math/prim/scal/prob/student_t_lpdf.hpp
@@ -173,17 +173,17 @@ namespace stan {
         if (!is_constant_struct<T_y>::value) {
           ops_partials.edge1_.partials_[n]
             += -(half_nu[n]+0.5)
-            * 1.0 / (1.0 + square_y_minus_mu_over_sigma__over_nu[n])
+            * inv(1.0 + square_y_minus_mu_over_sigma__over_nu[n])
             * (2.0 * (y_dbl - mu_dbl) / square(sigma_dbl) / nu_dbl);
         }
         if (!is_constant_struct<T_dof>::value) {
-          const T_partials_return inv_nu = 1.0 / nu_dbl;
+          const T_partials_return inv_nu = inv(nu_dbl);
           ops_partials.edge2_.partials_[n]
             += 0.5*digamma_half_nu_plus_half[n] - 0.5*digamma_half_nu[n]
             - 0.5 * inv_nu
             - 0.5*log1p_exp[n]
             + (half_nu[n] + 0.5)
-            * (1.0/(1.0 + square_y_minus_mu_over_sigma__over_nu[n])
+            * (inv(1.0 + square_y_minus_mu_over_sigma__over_nu[n])
                * square_y_minus_mu_over_sigma__over_nu[n] * inv_nu);
         }
         if (!is_constant_struct<T_loc>::value) {
@@ -193,7 +193,7 @@ namespace stan {
             * (2.0 * (mu_dbl - y_dbl) / (sigma_dbl*sigma_dbl*nu_dbl));
         }
         if (!is_constant_struct<T_scale>::value) {
-          const T_partials_return inv_sigma = 1.0 / sigma_dbl;
+          const T_partials_return inv_sigma = inv(sigma_dbl);
           ops_partials.edge4_.partials_[n]
             += -inv_sigma
             + (nu_dbl + 1.0) / (1.0 + square_y_minus_mu_over_sigma__over_nu[n])

--- a/stan/math/prim/scal/prob/uniform_cdf.hpp
+++ b/stan/math/prim/scal/prob/uniform_cdf.hpp
@@ -64,12 +64,12 @@ namespace stan {
         cdf *= cdf_;
 
         if (!is_constant_struct<T_y>::value)
-          ops_partials.edge1_.partials_[n] += 1.0 / b_min_a / cdf_;
+          ops_partials.edge1_.partials_[n] += inv(b_min_a) / cdf_;
         if (!is_constant_struct<T_low>::value)
           ops_partials.edge2_.partials_[n] += (y_dbl - beta_dbl) / b_min_a
             / b_min_a / cdf_;
         if (!is_constant_struct<T_high>::value)
-          ops_partials.edge3_.partials_[n] -= 1.0 / b_min_a;
+          ops_partials.edge3_.partials_[n] -= inv(b_min_a);
       }
 
       if (!is_constant_struct<T_y>::value) {

--- a/stan/math/prim/scal/prob/uniform_lccdf.hpp
+++ b/stan/math/prim/scal/prob/uniform_lccdf.hpp
@@ -69,7 +69,7 @@ namespace stan {
         ccdf_log += log(ccdf_log_);
 
         if (!is_constant_struct<T_y>::value)
-          ops_partials.edge1_.partials_[n] -= 1.0 / b_min_a / ccdf_log_;
+          ops_partials.edge1_.partials_[n] -= inv(b_min_a) / ccdf_log_;
         if (!is_constant_struct<T_low>::value)
           ops_partials.edge2_.partials_[n] -= (y_dbl - beta_dbl) / b_min_a
             / b_min_a / ccdf_log_;

--- a/stan/math/prim/scal/prob/uniform_lcdf.hpp
+++ b/stan/math/prim/scal/prob/uniform_lcdf.hpp
@@ -70,12 +70,12 @@ namespace stan {
         cdf_log += log(cdf_log_);
 
         if (!is_constant_struct<T_y>::value)
-          ops_partials.edge1_.partials_[n] += 1.0 / b_min_a / cdf_log_;
+          ops_partials.edge1_.partials_[n] += inv(b_min_a) / cdf_log_;
         if (!is_constant_struct<T_low>::value)
           ops_partials.edge2_.partials_[n] += (y_dbl - beta_dbl) / b_min_a
             / b_min_a / cdf_log_;
         if (!is_constant_struct<T_high>::value)
-          ops_partials.edge3_.partials_[n] -= 1.0 / b_min_a;
+          ops_partials.edge3_.partials_[n] -= inv(b_min_a);
       }
       return ops_partials.build(cdf_log);
     }

--- a/stan/math/prim/scal/prob/uniform_lpdf.hpp
+++ b/stan/math/prim/scal/prob/uniform_lpdf.hpp
@@ -86,7 +86,7 @@ namespace stan {
       for (size_t i = 0; i < max_size(alpha, beta); i++)
         if (include_summand<propto, T_low, T_high>::value)
           inv_beta_minus_alpha[i]
-            = 1.0 / (value_of(beta_vec[i]) - value_of(alpha_vec[i]));
+            = inv(value_of(beta_vec[i]) - value_of(alpha_vec[i]));
 
       VectorBuilder<include_summand<propto, T_low, T_high>::value,
                     T_partials_return, T_low, T_high>

--- a/stan/math/prim/scal/prob/weibull_lcdf.hpp
+++ b/stan/math/prim/scal/prob/weibull_lcdf.hpp
@@ -75,7 +75,7 @@ namespace stan {
 
         cdf_log += log(cdf_);
 
-        const T_partials_return rep_deriv = pow_ / (1.0 / exp_ - 1.0);
+        const T_partials_return rep_deriv = pow_ / (inv(exp_) - 1.0);
         if (!is_constant_struct<T_y>::value)
           ops_partials.edge1_.partials_[n] += rep_deriv * alpha_dbl / y_dbl;
         if (!is_constant_struct<T_shape>::value)

--- a/stan/math/prim/scal/prob/weibull_lpdf.hpp
+++ b/stan/math/prim/scal/prob/weibull_lpdf.hpp
@@ -96,7 +96,7 @@ namespace stan {
                     T_partials_return, T_scale> inv_sigma(length(sigma));
       for (size_t i = 0; i < length(sigma); i++)
         if (include_summand<propto, T_y, T_shape, T_scale>::value)
-          inv_sigma[i] = 1.0 / value_of(sigma_vec[i]);
+          inv_sigma[i] = inv(value_of(sigma_vec[i]));
 
       VectorBuilder<include_summand<propto, T_y, T_shape, T_scale>::value,
                     T_partials_return, T_y, T_shape, T_scale>
@@ -122,14 +122,14 @@ namespace stan {
           logp -= y_div_sigma_pow_alpha[n];
 
         if (!is_constant_struct<T_y>::value) {
-          const T_partials_return inv_y = 1.0 / value_of(y_vec[n]);
+          const T_partials_return inv_y = inv(value_of(y_vec[n]));
           ops_partials.edge1_.partials_[n]
             += (alpha_dbl - 1.0) * inv_y
             - alpha_dbl * y_div_sigma_pow_alpha[n] * inv_y;
         }
         if (!is_constant_struct<T_shape>::value)
           ops_partials.edge2_.partials_[n]
-            += 1.0/alpha_dbl
+            += inv(alpha_dbl)
             + (1.0 - y_div_sigma_pow_alpha[n]) * (log_y[n] - log_sigma[n]);
         if (!is_constant_struct<T_scale>::value)
           ops_partials.edge3_.partials_[n]

--- a/stan/math/prim/scal/prob/wiener_lpdf.hpp
+++ b/stan/math/prim/scal/prob/wiener_lpdf.hpp
@@ -33,6 +33,7 @@
 #include <stan/math/prim/scal/fun/constants.hpp>
 #include <stan/math/prim/scal/fun/square.hpp>
 #include <stan/math/prim/scal/fun/value_of.hpp>
+#include <stan/math/prim/scal/fun/inv.hpp>
 #include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
 #include <stan/math/prim/scal/err/check_bounded.hpp>
 #include <stan/math/prim/scal/err/check_finite.hpp>
@@ -149,7 +150,7 @@ namespace stan {
         T_return_type k, K;
         T_return_type sqrt_x = sqrt(x);
         T_return_type log_x = log(x);
-        T_return_type one_over_pi_times_sqrt_x = 1.0 / pi() * sqrt_x;
+        T_return_type one_over_pi_times_sqrt_x = inv(pi()) * sqrt_x;
 
         // calculate number of terms needed for large t:
         // if error threshold is set low enough


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary:
Replace all instances of 1/x with inv(x). See #595 

#### Intended Effect:
Make code more efficient/consistent.

#### How to Verify:

#### Side Effects:
None (hopefully).

#### Documentation:
None.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Andrew Johnson
By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
