### PR TITLE
Fix gcc compiler warnings for cvodes_util and suppress warnings gcc now has with 4.9.3

### DIFF
--- a/make/default_compiler_options
+++ b/make/default_compiler_options
@@ -12,7 +12,7 @@ AR = ar
 # CPPFLAGS are used for both C and C++ compilation
 CPPFLAGS = -DNO_FPRINTF_OUTPUT -pipe
 # CXXFLAGS are just used for C++
-CXXFLAGS = -Wall -I . -isystem $(EIGEN) -isystem $(BOOST) -isystem $(CVODES)/include -std=c++1y -DBOOST_RESULT_OF_USE_TR1 -DBOOST_NO_DECLTYPE -DBOOST_DISABLE_ASSERTS -DBOOST_PHOENIX_NO_VARIADIC_EXPRESSION
+CXXFLAGS = -Wall -I . -isystem $(EIGEN) -isystem $(BOOST) -isystem $(CVODES)/include -std=c++1y -DBOOST_RESULT_OF_USE_TR1 -DBOOST_NO_DECLTYPE -DBOOST_DISABLE_ASSERTS -DBOOST_PHOENIX_NO_VARIADIC_EXPRESSION -Wno-unused-function -Wno-uninitialized
 GTEST_CXXFLAGS = -DGTEST_USE_OWN_TR1_TUPLE
 LDLIBS =
 EXE =

--- a/make/os_linux
+++ b/make/os_linux
@@ -20,7 +20,5 @@ ifeq (mingw32-g++,$(CC_TYPE))
 endif
 ifeq (clang++,$(CC_TYPE))
   GTEST_CXXFLAGS += -DGTEST_HAS_PTHREAD=0
-  CXXFLAGS += -Wno-unused-function
-  CXXFLAGS += -Wno-uninitialized
 endif
 

--- a/make/os_mac
+++ b/make/os_mac
@@ -11,7 +11,6 @@ endif
 
 ifeq (clang++,$(CC_TYPE))
   CXXFLAGS += -Wno-unknown-warning-option
-  CXXFLAGS += -Wno-unused-function
   CXXFLAGS += -Wno-tautological-compare
   CXXFLAGS += -Wsign-compare
 endif

--- a/make/os_win
+++ b/make/os_win
@@ -26,15 +26,11 @@ else
 endif
 ifeq (g++,$(CC_TYPE))
   CXXFLAGS += -m$(BIT)
-  CXXFLAGS += -Wno-unused-function
-  CXXFLAGS += -Wno-uninitialized
   CXXFLAGS += -Wno-unused-but-set-variable
   LDLIBS += -static-libgcc
   LDLIBS += -static-libstdc++
 endif
 ifeq (mingw32-g++,$(CC_TYPE))
-  CXXFLAGS += -Wno-unused-function
-  CXXFLAGS += -Wno-uninitialized
   LDLIBS += -static-libgcc
 #  LDLIBS += -static-libstdc++
 endif

--- a/stan/math/rev/mat/functor/cvodes_utils.hpp
+++ b/stan/math/rev/mat/functor/cvodes_utils.hpp
@@ -6,6 +6,7 @@
 #include <cvodes/cvodes_dense.h>
 #include <nvector/nvector_serial.h>
 #include <sstream>
+#include <stdexcept>
 #include <string>
 
 namespace stan {


### PR DESCRIPTION
re: http://discourse.mc-stan.org/t/help-with-jenkins/1984/21

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
