### PR TITLE
fix normalizing constant for LKJ

### DIFF
--- a/stan/math/prim/mat/prob/lkj_corr_lpdf.hpp
+++ b/stan/math/prim/mat/prob/lkj_corr_lpdf.hpp
@@ -50,9 +50,10 @@ namespace stan {
   namespace math {
 
     template <typename T_shape>
-    T_shape do_lkj_constant(const T_shape& eta, const unsigned int& K) {
+    typename boost::math::tools::promote_args<double, T_shape>::type
+    do_lkj_constant(const T_shape& eta, const unsigned int& K) {
       // Lewandowski, Kurowicka, and Joe (2009) theorem 5
-      T_shape constant;
+      typename boost::math::tools::promote_args<double, T_shape>::type constant;
       const int Km1 = K - 1;
       using stan::math::lgamma;
       if (eta == 1.0) {

--- a/stan/math/prim/mat/prob/lkj_corr_lpdf.hpp
+++ b/stan/math/prim/mat/prob/lkj_corr_lpdf.hpp
@@ -44,7 +44,6 @@
 #include <stan/math/prim/mat/fun/cov_matrix_free.hpp>
 #include <stan/math/prim/mat/fun/cov_matrix_constrain_lkj.hpp>
 #include <stan/math/prim/mat/fun/cov_matrix_free_lkj.hpp>
-#include <stan/math/prim/mat/fun/sum.hpp>
 #include <string>
 
 namespace stan {
@@ -55,23 +54,24 @@ namespace stan {
       // Lewandowski, Kurowicka, and Joe (2009) theorem 5
       T_shape constant;
       const int Km1 = K - 1;
+      using stan::math::lgamma;
       if (eta == 1.0) {
         // C++ integer division is appropriate in this block
-        Eigen::VectorXd numerator(Km1 / 2);
-        for (int k = 1; k <= numerator.rows(); k++)
-          numerator(k - 1) = lgamma(2.0 * k);
-        constant = sum(numerator);
+        Eigen::VectorXd denominator(Km1 / 2);
+        for (int k = 1; k <= denominator.rows(); k++)
+          denominator(k - 1) = lgamma(2.0 * k);
+        constant = -denominator.sum();
         if ((K % 2) == 1)
-          constant += 0.25 * (K * K - 1) * LOG_PI
+          constant -= 0.25 * (K * K - 1) * LOG_PI
             - 0.25 * (Km1 * Km1) * LOG_TWO - Km1 * lgamma(0.5 * (K + 1));
         else
-          constant += 0.25 * K * (K - 2) * LOG_PI
+          constant -= 0.25 * K * (K - 2) * LOG_PI
             + 0.25 * (3 * K * K - 4 * K) * LOG_TWO
             + K * lgamma(0.5 * K) - Km1 * lgamma(static_cast<double>(K));
       } else {
-        constant = -Km1 * lgamma(eta + 0.5 * Km1);
+        constant = Km1 * lgamma(eta + 0.5 * Km1);
         for (int k = 1; k <= Km1; k++)
-          constant += 0.5 * k * LOG_PI + lgamma(eta + 0.5 * (Km1 - k));
+          constant -= 0.5 * k * LOG_PI + lgamma(eta + 0.5 * (Km1 - k));
       }
       return constant;
     }

--- a/test/unit/math/prim/mat/prob/lkj_corr_test.cpp
+++ b/test/unit/math/prim/mat/prob/lkj_corr_test.cpp
@@ -1,4 +1,5 @@
 #include <stan/math/prim/mat.hpp>
+#include <stan/math/prim/scal.hpp>
 #include <gtest/gtest.h>
 #include <boost/random/mersenne_twister.hpp>
 #include <boost/math/distributions.hpp>
@@ -130,3 +131,33 @@ TEST(ProbDistributionsLkjCorrCholesky,testHalf) {
                   stan::math::lkj_corr_cholesky_log(L, eta));
 }
 
+TEST(ProbDistributionsLkjCorrCholesky,testConstant) {
+  boost::random::mt19937 rng;
+  unsigned int K = 4;
+  double eta = stan::math::uniform_rng(0,2,rng);
+  double f = stan::math::do_lkj_constant(eta, K);
+  double s = 0;
+  double g = 0;
+  for (unsigned int k = 1; k < K; k++) {
+    s += (2 * eta - 2 + K - k) * (K - k);
+    g += (K - k) * stan::math::lbeta(eta + 0.5 * (K - k - 1),
+                                     eta + 0.5 * (K - k - 1));
+  }
+  g += s * stan::math::log(2.0); // equation 16 in LKJ article
+  EXPECT_FLOAT_EQ(f, -g);
+}
+
+TEST(ProbDistributionsLkjCorrCholesky,testVolume) {
+  unsigned int K = 4;
+  double eta = 1;
+  double f = stan::math::do_lkj_constant(eta, K);
+  double s = 0;
+  double g = 0;
+  for (unsigned int k = 1; k < K; k++) {
+    s += (2 * eta - 2 + K - k) * (K - k);
+    g += (K - k) * stan::math::lbeta(eta + 0.5 * (K - k - 1),
+                                     eta + 0.5 * (K - k - 1));
+  }
+  g += s * stan::math::log(2.0); // equation 16 in LKJ article
+  EXPECT_FLOAT_EQ(f, -g);
+}

--- a/test/unit/math/prim/mat/prob/lkj_corr_test.cpp
+++ b/test/unit/math/prim/mat/prob/lkj_corr_test.cpp
@@ -151,6 +151,7 @@ TEST(ProbDistributionsLkjCorrCholesky,testVolume) {
   unsigned int K = 4;
   double eta = 1;
   double f = stan::math::do_lkj_constant(eta, K);
+  EXPECT_FLOAT_EQ(f, stan::math::do_lkj_constant(1, K));
   double s = 0;
   double g = 0;
   for (unsigned int k = 1; k < K; k++) {


### PR DESCRIPTION
#### Submission Checklist

- [ X] Run unit tests: `./runTests.py test/unit`
- [ X] Run cpplint: `make cpplint`
- [ X] Declare copyright holder and open-source license: see below

#### Summary:

Changes the sign of the log normalizing constant for the LKJ distribution

#### Intended Effect:

Have the PDF integrate to 1.

#### How to Verify:

It is difficult to verify except in the two-dimensional case, which has been verified to be log(0.5).

#### Side Effects:

None

#### Documentation:

None

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Trustees of Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
