### PR TITLE
Issue 597 - Fix order of return for normal_cdf

### DIFF
--- a/stan/math/prim/scal/prob/normal_cdf.hpp
+++ b/stan/math/prim/scal/prob/normal_cdf.hpp
@@ -44,10 +44,10 @@ namespace stan {
 
       using std::exp;
 
-      T_partials_return cdf(1.0);
-
       if (!(stan::length(y) && stan::length(mu) && stan::length(sigma)))
-        return cdf;
+        return 0.0;
+
+      T_partials_return cdf(1.0);
 
       check_not_nan(function, "Random variable", y);
       check_finite(function, "Location parameter", mu);

--- a/stan/math/prim/scal/prob/normal_lccdf.hpp
+++ b/stan/math/prim/scal/prob/normal_lccdf.hpp
@@ -32,9 +32,10 @@ namespace stan {
       using std::log;
       using std::exp;
 
-      T_partials_return ccdf_log(0.0);
       if (!(stan::length(y) && stan::length(mu) && stan::length(sigma)))
-        return ccdf_log;
+        return 0.0;
+
+      T_partials_return ccdf_log(0.0);
 
       check_not_nan(function, "Random variable", y);
       check_finite(function, "Location parameter", mu);

--- a/stan/math/prim/scal/prob/normal_lcdf.hpp
+++ b/stan/math/prim/scal/prob/normal_lcdf.hpp
@@ -34,7 +34,7 @@ namespace stan {
 
       if (!(stan::length(y) && stan::length(mu) && stan::length(sigma)))
         return 0.0;
-      
+
       T_partials_return cdf_log(0.0);
 
       check_not_nan(function, "Random variable", y);

--- a/stan/math/prim/scal/prob/normal_lcdf.hpp
+++ b/stan/math/prim/scal/prob/normal_lcdf.hpp
@@ -32,9 +32,10 @@ namespace stan {
       using std::log;
       using std::exp;
 
-      T_partials_return cdf_log(0.0);
       if (!(stan::length(y) && stan::length(mu) && stan::length(sigma)))
-        return cdf_log;
+        return 0.0;
+      
+      T_partials_return cdf_log(0.0);
 
       check_not_nan(function, "Random variable", y);
       check_finite(function, "Location parameter", mu);


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary:
Addresses issue #597, making the order of return in normal_cdf/lcdf/lccdf consistent with rest of prob. functions.

#### Intended Effect:
Make code more consistent.

#### How to Verify:
Visually inspect.

#### Side Effects:
None.

#### Documentation:
N/A

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Andrew Johnson

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
