### PR TITLE
implement more special cases for pow(var,double)

### DIFF
--- a/stan/math/rev/scal/fun/pow.hpp
+++ b/stan/math/rev/scal/fun/pow.hpp
@@ -2,7 +2,11 @@
 #define STAN_MATH_REV_SCAL_FUN_POW_HPP
 
 #include <stan/math/rev/core.hpp>
+#include <stan/math/rev/scal/fun/inv.hpp>
+#include <stan/math/rev/scal/fun/inv_sqrt.hpp>
+#include <stan/math/rev/scal/fun/inv_square.hpp>
 #include <stan/math/rev/scal/fun/sqrt.hpp>
+#include <stan/math/rev/scal/fun/square.hpp>
 #include <stan/math/prim/scal/fun/is_nan.hpp>
 #include <cmath>
 #include <limits>
@@ -125,7 +129,13 @@ namespace stan {
       if (exponent == 1.0)
         return base;
       if (exponent == 2.0)
-        return base * base;  // FIXME: use square()
+        return square(base);
+      if (exponent == -2.0)
+        return inv_square(base);
+      if (exponent == -1.0)
+        return inv(base);
+      if (exponent == -0.5)
+        return inv_sqrt(base);
       return var(new pow_vd_vari(base.vi_, exponent));
     }
 

--- a/test/unit/math/rev/scal/fun/pow_test.cpp
+++ b/test/unit/math/rev/scal/fun/pow_test.cpp
@@ -17,15 +17,35 @@ TEST(AgradRev,pow_var_var) {
 }
 
 TEST(AgradRev,pow_var_double) {
-  AVAR a(3.0);
+  AVAR a(4.0);
   double b = 4.0;
   AVAR f = pow(a,b);
-  EXPECT_FLOAT_EQ(81.0,f.val());
+  EXPECT_FLOAT_EQ(256.0,f.val());
 
   AVEC x = createAVEC(a);
   VEC g;
   f.grad(x,g);
-  EXPECT_FLOAT_EQ(4.0 * pow(3.0,4.0-1.0), g[0]);
+  EXPECT_FLOAT_EQ(4.0 * pow(4.0,4.0-1.0), g[0]);
+
+  b = 2.0;
+  f = pow(a,b);
+  EXPECT_FLOAT_EQ(16.0,f.val());
+
+  b = 0.5;
+  f = pow(a,b);
+  EXPECT_FLOAT_EQ(2.0,f.val());
+
+  b = 1.0;
+  f = pow(a,b);
+  EXPECT_FLOAT_EQ(a.val(),f.val());
+
+  b = -0.5;
+  f = pow(a,b);
+  EXPECT_FLOAT_EQ(0.5,f.val());
+
+  b = -2.0;
+  f = pow(a,b);
+  EXPECT_FLOAT_EQ(1/16.0,f.val());
 }
 
 


### PR DESCRIPTION
#### Submission Checklist

- [X] Run unit tests: `./runTests.py test/unit`
- [X] Run cpplint: `make cpplint`
- [X] Declare copyright holder and open-source license: see below

#### Summary:

Specialize `pow` in the case were the base is a `var` and the exponent is a double among -1, -0.5, and -2.

#### Intended Effect:

Avoid unnecessary internal calculations in `pow`.

#### How to Verify:

Run slightly expanded unit tests

#### Side Effects:

None

#### Documentation:

None

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Trustees of Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
