### PR TITLE
Feature - Vectorised ordered probit distribution

### DIFF
--- a/stan/math/prim/mat.hpp
+++ b/stan/math/prim/mat.hpp
@@ -289,6 +289,8 @@
 #include <stan/math/prim/mat/prob/ordered_logistic_log.hpp>
 #include <stan/math/prim/mat/prob/ordered_logistic_lpmf.hpp>
 #include <stan/math/prim/mat/prob/ordered_logistic_rng.hpp>
+#include <stan/math/prim/mat/prob/ordered_probit_lpmf.hpp>
+#include <stan/math/prim/mat/prob/ordered_probit_rng.hpp>
 #include <stan/math/prim/mat/prob/wishart_log.hpp>
 #include <stan/math/prim/mat/prob/wishart_lpdf.hpp>
 #include <stan/math/prim/mat/prob/wishart_rng.hpp>

--- a/stan/math/prim/mat.hpp
+++ b/stan/math/prim/mat.hpp
@@ -289,6 +289,7 @@
 #include <stan/math/prim/mat/prob/ordered_logistic_log.hpp>
 #include <stan/math/prim/mat/prob/ordered_logistic_lpmf.hpp>
 #include <stan/math/prim/mat/prob/ordered_logistic_rng.hpp>
+#include <stan/math/prim/mat/prob/ordered_probit_log.hpp>
 #include <stan/math/prim/mat/prob/ordered_probit_lpmf.hpp>
 #include <stan/math/prim/mat/prob/ordered_probit_rng.hpp>
 #include <stan/math/prim/mat/prob/wishart_log.hpp>

--- a/stan/math/prim/mat/prob/ordered_probit_log.hpp
+++ b/stan/math/prim/mat/prob/ordered_probit_log.hpp
@@ -7,7 +7,6 @@
 namespace stan {
   namespace math {
 
-
     /**
      * Returns the (natural) log probability of the integer/s 
      * given the vector of continuous location/s and 

--- a/stan/math/prim/mat/prob/ordered_probit_log.hpp
+++ b/stan/math/prim/mat/prob/ordered_probit_log.hpp
@@ -1,0 +1,58 @@
+#ifndef STAN_MATH_PRIM_MAT_PROB_ORDERED_PROBIT_LOG_HPP
+#define STAN_MATH_PRIM_MAT_PROB_ORDERED_PROBIT_LOG_HPP
+
+#include <stan/math/prim/mat/prob/ordered_probit_lpmf.hpp>
+#include <stan/math/prim/scal/meta/return_type.hpp>
+
+namespace stan {
+  namespace math {
+
+
+    /**
+     * Returns the (natural) log probability of the integer/s 
+     * given the vector of continuous location/s and 
+     * specified cutpoints in an ordered probit model.
+     *
+     * <p>Typically the continous location
+     * will be the dot product of a vector of regression coefficients
+     * and a vector of predictors for the outcome.
+     *
+     * @tparam propto True if calculating up to a proportion.
+     * @tparam T_y y variable type (int or array of integers).
+     * @tparam T_loc Location type (double or vector).
+     * @tparam T_cut Cut-point type (vector or array of vectors).
+     * @param y Integers
+     * @param lambda Continuous location variables.
+     * @param c Positive increasing cutpoints.
+     * @return Log probability of outcome given location and
+     * cutpoints.
+     * @throw std::domain_error If the outcome is not between 1 and
+     * the number of cutpoints plus 2; if the cutpoint vector is
+     * empty; if the cutpoint vector contains a non-positive,
+     * non-finite value; or if the cutpoint vector is not sorted in
+     * ascending order.
+     * @throw std::invalid_argument If array y and vector lambda 
+     * are different lengths.
+     * @throw std::invalid_argument if array y and array of vectors
+     * c are different lengths.
+     *
+     * @deprecated use <code>ordered_probit_lpmf</code>
+     */
+    template <bool propto, typename T_y, typename T_loc, typename T_cut>
+    typename return_type<T_loc, T_cut>::type
+    ordered_probit_log(const T_y& y, const T_loc& lambda, const T_cut& c) {
+      return ordered_probit_lpmf<propto>(y, lambda, c);
+    }
+
+    /**
+     * @deprecated use <code>ordered_probit_lpmf</code>
+     */
+    template <typename T_y, typename T_loc, typename T_cut>
+    typename return_type<T_loc, T_cut>::type
+    ordered_probit_log(const T_y& y, const T_loc& lambda, const T_cut& c) {
+      return ordered_probit_lpmf(y, lambda, c);
+    }
+
+  }
+}
+#endif

--- a/stan/math/prim/mat/prob/ordered_probit_lpmf.hpp
+++ b/stan/math/prim/mat/prob/ordered_probit_lpmf.hpp
@@ -1,0 +1,226 @@
+#ifndef STAN_MATH_PRIM_MAT_PROB_ORDERED_PROBIT_LPMF_HPP
+#define STAN_MATH_PRIM_MAT_PROB_ORDERED_PROBIT_LPMF_HPP
+
+#include <stan/math/prim/scal/fun/inv_logit.hpp>
+#include <stan/math/prim/scal/fun/log1m.hpp>
+#include <stan/math/prim/scal/err/check_bounded.hpp>
+#include <stan/math/prim/scal/err/check_finite.hpp>
+#include <stan/math/prim/scal/err/check_greater.hpp>
+#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
+#include <stan/math/prim/mat/err/check_ordered.hpp>
+#include <stan/math/prim/scal/fun/constants.hpp>
+#include <stan/math/prim/scal/meta/return_type.hpp>
+#include <Eigen/StdVector>
+#include <string>
+#include <vector>
+
+namespace stan {
+  namespace math {
+
+    /**
+     * Returns the (natural) log probability of the specified integer
+     * outcome given the continuous location and specified cutpoints
+     * in an ordered probit model.
+     *
+     * <p>Typically the continous location
+     * will be the dot product of a vector of regression coefficients
+     * and a vector of predictors for the outcome.
+     *
+     * @tparam propto True if calculating up to a proportion.
+     * @tparam T_loc Location type.
+     * @tparam T_cut Cut-point type.
+     * @param y Outcome.
+     * @param lambda Location.
+     * @param c Positive increasing vector of cutpoints.
+     * @return Log probability of outcome given location and
+     * cutpoints.
+     * @throw std::domain_error If the outcome is not between 1 and
+     * the number of cutpoints plus 2; if the cutpoint vector is
+     * empty; if the cutpoint vector contains a non-positive,
+     * non-finite value; or if the cutpoint vector is not sorted in
+     * ascending order.
+     */
+    template <bool propto, typename T_loc, typename T_cut>
+    typename return_type<T_loc>::type
+    ordered_probit_lpmf(int y, const T_loc& lambda,
+                          const Eigen::Matrix<T_cut, Eigen::Dynamic, 1>& c) {
+      using std::exp;
+      using std::log;
+
+      static const std::string function = "ordered_probit";
+
+      int K = c.size() + 1;
+
+      check_bounded(function, "Random variable", y, 1, K);
+      check_finite(function, "Location parameter", lambda);
+      check_greater(function, "Size of cut points parameter", c.size(), 0);
+      check_ordered(function, "Cut-points", c);
+      check_finite(function, "Final cut-point", c(c.size()-1));
+      check_finite(function, "First cut-point", c(0));
+
+      if (y == 1) {
+        return log1m(Phi(lambda - c[0]));
+      } else if (y == K) {
+        return log(Phi(lambda - c[K-2]));
+      } else {
+        return log(Phi(lambda - c[y-2]) - Phi(lambda - c[y-1]));
+      }
+    }
+
+    template <typename T_loc, typename T_cut>
+    typename return_type<T_loc>::type
+    ordered_probit_lpmf(int y, const T_loc& lambda,
+                          const Eigen::Matrix<T_cut, Eigen::Dynamic, 1>& c)  {
+      return ordered_probit_lpmf<false>(y, lambda, c);
+    }
+
+    /**
+     * Returns the (natural) log probability of the specified array 
+     * of integers given the vector of continuous locations and 
+     * specified cutpoints in an ordered probit model.
+     *
+     * <p>Typically the continous location
+     * will be the dot product of a vector of regression coefficients
+     * and a vector of predictors for the outcome.
+     *
+     * @tparam propto True if calculating up to a proportion.
+     * @tparam T_loc Location type.
+     * @tparam T_cut Cut-point type.
+     * @param y Array of integers
+     * @param lambda Vector of continuous location variables.
+     * @param c Positive increasing vector of cutpoints.
+     * @return Log probability of outcome given location and
+     * cutpoints.
+     * @throw std::domain_error If the outcome is not between 1 and
+     * the number of cutpoints plus 2; if the cutpoint vector is
+     * empty; if the cutpoint vector contains a non-positive,
+     * non-finite value; or if the cutpoint vector is not sorted in
+     * ascending order.
+     * @throw std::invalid_argument If y and lambda are different
+     * lengths.
+     */
+    template <bool propto, typename T_loc, typename T_cut>
+    typename return_type<T_loc>::type
+    ordered_probit_lpmf(const std::vector<int>& y,
+                          const Eigen::Matrix<T_loc, Eigen::Dynamic, 1>& lambda,
+                          const Eigen::Matrix<T_cut, Eigen::Dynamic, 1>& c) {
+      using std::exp;
+      using std::log;
+
+      static const std::string function = "ordered_probit";
+
+      int N = lambda.size();
+      int K = c.size() + 1;
+
+      check_consistent_sizes(function, "Integers", y, "Locations", lambda);
+      check_bounded(function, "Random variable", y, 1, K);
+      check_finite(function, "Location parameter", lambda);
+      check_ordered(function, "Cut-points", c);
+      check_greater(function, "Size of cut points parameter", c.size(), 0);
+      check_finite(function, "Final cut-point", c(c.size()-1));
+      check_finite(function, "First cut-point", c(0));
+
+      typename return_type<T_loc>::type logp_n(0.0);
+
+      for (int i = 0; i < N; ++i) {
+        if (y[i] == 1) {
+          logp_n += log1m(Phi(lambda[i] - c[0]));
+        } else if (y[i] == K) {
+          logp_n += log(Phi(lambda[i] - c[K-2]));
+        } else {
+          logp_n += log(Phi(lambda[i] - c[y[i]-2]) -
+                          Phi(lambda[i] - c[y[i]-1]));
+        }
+      }
+      return logp_n;
+    }
+
+    template <typename T_loc, typename T_cut>
+    typename return_type<T_loc>::type
+    ordered_probit_lpmf(const std::vector<int>& y,
+                          const Eigen::Matrix<T_loc, Eigen::Dynamic, 1>& lambda,
+                          const Eigen::Matrix<T_cut, Eigen::Dynamic, 1>& c) {
+      return ordered_probit_lpmf<false>(y, lambda, c);
+    }
+
+    /**
+     * Returns the (natural) log probability of the specified array 
+     * of integers given the vector of continuous locations and 
+     * array of specified cutpoints in an ordered probit model.
+     *
+     * <p>Typically the continous location
+     * will be the dot product of a vector of regression coefficients
+     * and a vector of predictors for the outcome.
+     *
+     * @tparam propto True if calculating up to a proportion.
+     * @tparam T_y Type of y variable (should be std::vector<int>).
+     * @tparam T_loc Location type.
+     * @tparam T_cut Cut-point type.
+     * @param y Array of integers
+     * @param lambda Vector of continuous location variables.
+     * @param c array of Positive increasing vectors of cutpoints.
+     * @return Log probability of outcome given location and
+     * cutpoints.
+     * @throw std::domain_error If the outcome is not between 1 and
+     * the number of cutpoints plus 2; if the cutpoint vector is
+     * empty; if the cutpoint vector contains a non-positive,
+     * non-finite value; or if the cutpoint vector is not sorted in
+     * ascending order.
+     * @throw std::invalid_argument If y and lambda are different
+     * lengths, or if y and the array of cutpoints are of different
+     * lengths.
+     */
+    template <bool propto, typename T_loc, typename T_cut>
+    typename return_type<T_loc>::type
+    ordered_probit_lpmf(const std::vector<int>& y,
+                          const Eigen::Matrix<T_loc, Eigen::Dynamic, 1>& lambda,
+                          const std::vector<Eigen::Matrix<
+                                                T_cut, Eigen::Dynamic, 1>>& c) {
+      using std::exp;
+      using std::log;
+
+      static const std::string function = "ordered_probit";
+
+      int N = lambda.size();
+
+      check_consistent_sizes(function, "Integers", y, "Locations", lambda);
+      check_consistent_sizes(function, "Integers", y, "Cut-points", c);
+
+      for (int i = 0; i < N; ++i) {
+        int K = c[i].size() + 1;
+
+        check_bounded(function, "Random variable", y[i], 1, K);
+        check_greater(function, "Size of cut points parameter", c[i].size(), 0);
+        check_ordered(function, "Cut-points", c[i]);
+      }
+
+        check_finite(function, "Location parameter", lambda);
+        check_finite(function, "Cut-points", c);
+
+      typename return_type<T_loc>::type logp_n(0.0);
+
+      for (int i = 0; i < N; ++i) {
+        int K = c[i].size() + 1;
+        if (y[i] == 1) {
+          logp_n += log1m(Phi(lambda[i] - c[i][0]));
+        } else if (y[i] == K) {
+          logp_n += log(Phi(lambda[i] - c[i][K-2]));
+        } else {
+          logp_n += log(Phi(lambda[i] - c[i][y[i]-2]) -
+                          Phi(lambda[i] - c[i][y[i]-1]));
+        }
+      }
+      return logp_n;
+    }
+
+    template <typename T_loc, typename T_cut>
+    typename return_type<T_loc>::type
+    ordered_probit_lpmf(const std::vector<int>& y,
+                          const Eigen::Matrix<T_loc, Eigen::Dynamic, 1>& lambda,
+                          const std::vector<Eigen::Matrix<
+                                                T_cut, Eigen::Dynamic, 1>>& c) {
+      return ordered_probit_lpmf<false>(y, lambda, c);
+    }
+  }
+}
+#endif

--- a/stan/math/prim/mat/prob/ordered_probit_lpmf.hpp
+++ b/stan/math/prim/mat/prob/ordered_probit_lpmf.hpp
@@ -1,14 +1,13 @@
 #ifndef STAN_MATH_PRIM_MAT_PROB_ORDERED_PROBIT_LPMF_HPP
 #define STAN_MATH_PRIM_MAT_PROB_ORDERED_PROBIT_LPMF_HPP
 
-#include <stan/math/prim/scal/fun/inv_logit.hpp>
+#include <stan/math/prim/scal/fun/Phi.hpp>
 #include <stan/math/prim/scal/fun/log1m.hpp>
 #include <stan/math/prim/scal/err/check_bounded.hpp>
 #include <stan/math/prim/scal/err/check_finite.hpp>
 #include <stan/math/prim/scal/err/check_greater.hpp>
 #include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/mat/err/check_ordered.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
+#include <stan/math/prim/arr/err/check_ordered.hpp>
 #include <stan/math/prim/scal/meta/return_type.hpp>
 #include <Eigen/StdVector>
 #include <string>
@@ -55,8 +54,7 @@ namespace stan {
       check_finite(function, "Location parameter", lambda);
       check_greater(function, "Size of cut points parameter", c.size(), 0);
       check_ordered(function, "Cut-points", c);
-      check_finite(function, "Final cut-point", c(c.size()-1));
-      check_finite(function, "First cut-point", c(0));
+      check_finite(function, "Cut-points", c);
 
       if (y == 1) {
         return log1m(Phi(lambda - c[0]));
@@ -117,8 +115,7 @@ namespace stan {
       check_finite(function, "Location parameter", lambda);
       check_ordered(function, "Cut-points", c);
       check_greater(function, "Size of cut points parameter", c.size(), 0);
-      check_finite(function, "Final cut-point", c(c.size()-1));
-      check_finite(function, "First cut-point", c(0));
+      check_finite(function, "Cut-points", c);
 
       typename return_type<T_loc>::type logp_n(0.0);
 
@@ -188,7 +185,6 @@ namespace stan {
 
       for (int i = 0; i < N; ++i) {
         int K = c[i].size() + 1;
-
         check_bounded(function, "Random variable", y[i], 1, K);
         check_greater(function, "Size of cut points parameter", c[i].size(), 0);
         check_ordered(function, "Cut-points", c[i]);
@@ -201,6 +197,7 @@ namespace stan {
 
       for (int i = 0; i < N; ++i) {
         int K = c[i].size() + 1;
+
         if (y[i] == 1) {
           logp_n += log1m(Phi(lambda[i] - c[i][0]));
         } else if (y[i] == K) {

--- a/stan/math/prim/mat/prob/ordered_probit_lpmf.hpp
+++ b/stan/math/prim/mat/prob/ordered_probit_lpmf.hpp
@@ -9,6 +9,7 @@
 #include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
 #include <stan/math/prim/arr/err/check_ordered.hpp>
 #include <stan/math/prim/scal/meta/return_type.hpp>
+#include <Eigen/Dense>
 #include <string>
 #include <vector>
 

--- a/stan/math/prim/mat/prob/ordered_probit_lpmf.hpp
+++ b/stan/math/prim/mat/prob/ordered_probit_lpmf.hpp
@@ -9,7 +9,6 @@
 #include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
 #include <stan/math/prim/arr/err/check_ordered.hpp>
 #include <stan/math/prim/scal/meta/return_type.hpp>
-#include <Eigen/StdVector>
 #include <string>
 #include <vector>
 
@@ -40,9 +39,9 @@ namespace stan {
      * ascending order.
      */
     template <bool propto, typename T_loc, typename T_cut>
-    typename return_type<T_loc>::type
+    typename return_type<T_loc, T_cut>::type
     ordered_probit_lpmf(int y, const T_loc& lambda,
-                          const Eigen::Matrix<T_cut, Eigen::Dynamic, 1>& c) {
+                        const Eigen::Matrix<T_cut, Eigen::Dynamic, 1>& c) {
       using std::exp;
       using std::log;
 
@@ -66,9 +65,9 @@ namespace stan {
     }
 
     template <typename T_loc, typename T_cut>
-    typename return_type<T_loc>::type
+    typename return_type<T_loc, T_cut>::type
     ordered_probit_lpmf(int y, const T_loc& lambda,
-                          const Eigen::Matrix<T_cut, Eigen::Dynamic, 1>& c)  {
+                        const Eigen::Matrix<T_cut, Eigen::Dynamic, 1>& c)  {
       return ordered_probit_lpmf<false>(y, lambda, c);
     }
 
@@ -98,10 +97,10 @@ namespace stan {
      * lengths.
      */
     template <bool propto, typename T_loc, typename T_cut>
-    typename return_type<T_loc>::type
+    typename return_type<T_loc, T_cut>::type
     ordered_probit_lpmf(const std::vector<int>& y,
-                          const Eigen::Matrix<T_loc, Eigen::Dynamic, 1>& lambda,
-                          const Eigen::Matrix<T_cut, Eigen::Dynamic, 1>& c) {
+                        const Eigen::Matrix<T_loc, Eigen::Dynamic, 1>& lambda,
+                        const Eigen::Matrix<T_cut, Eigen::Dynamic, 1>& c) {
       using std::exp;
       using std::log;
 
@@ -117,7 +116,7 @@ namespace stan {
       check_greater(function, "Size of cut points parameter", c.size(), 0);
       check_finite(function, "Cut-points", c);
 
-      typename return_type<T_loc>::type logp_n(0.0);
+      typename return_type<T_loc, T_cut>::type logp_n(0.0);
 
       for (int i = 0; i < N; ++i) {
         if (y[i] == 1) {
@@ -125,18 +124,18 @@ namespace stan {
         } else if (y[i] == K) {
           logp_n += log(Phi(lambda[i] - c[K-2]));
         } else {
-          logp_n += log(Phi(lambda[i] - c[y[i]-2]) -
-                          Phi(lambda[i] - c[y[i]-1]));
+          logp_n += log(Phi(lambda[i] - c[y[i]-2])
+                          - Phi(lambda[i] - c[y[i]-1]));
         }
       }
       return logp_n;
     }
 
     template <typename T_loc, typename T_cut>
-    typename return_type<T_loc>::type
+    typename return_type<T_loc, T_cut>::type
     ordered_probit_lpmf(const std::vector<int>& y,
-                          const Eigen::Matrix<T_loc, Eigen::Dynamic, 1>& lambda,
-                          const Eigen::Matrix<T_cut, Eigen::Dynamic, 1>& c) {
+                        const Eigen::Matrix<T_loc, Eigen::Dynamic, 1>& lambda,
+                        const Eigen::Matrix<T_cut, Eigen::Dynamic, 1>& c) {
       return ordered_probit_lpmf<false>(y, lambda, c);
     }
 
@@ -168,11 +167,11 @@ namespace stan {
      * lengths.
      */
     template <bool propto, typename T_loc, typename T_cut>
-    typename return_type<T_loc>::type
+    typename return_type<T_loc, T_cut>::type
     ordered_probit_lpmf(const std::vector<int>& y,
-                          const Eigen::Matrix<T_loc, Eigen::Dynamic, 1>& lambda,
-                          const std::vector<Eigen::Matrix<
-                                                T_cut, Eigen::Dynamic, 1>>& c) {
+                        const Eigen::Matrix<T_loc, Eigen::Dynamic, 1>& lambda,
+                        const std::vector<Eigen::Matrix<
+                                              T_cut, Eigen::Dynamic, 1>>& c) {
       using std::exp;
       using std::log;
 
@@ -190,10 +189,10 @@ namespace stan {
         check_ordered(function, "Cut-points", c[i]);
       }
 
-        check_finite(function, "Location parameter", lambda);
-        check_finite(function, "Cut-points", c);
+      check_finite(function, "Location parameter", lambda);
+      check_finite(function, "Cut-points", c);
 
-      typename return_type<T_loc>::type logp_n(0.0);
+      typename return_type<T_loc, T_cut>::type logp_n(0.0);
 
       for (int i = 0; i < N; ++i) {
         int K = c[i].size() + 1;
@@ -203,19 +202,19 @@ namespace stan {
         } else if (y[i] == K) {
           logp_n += log(Phi(lambda[i] - c[i][K-2]));
         } else {
-          logp_n += log(Phi(lambda[i] - c[i][y[i]-2]) -
-                          Phi(lambda[i] - c[i][y[i]-1]));
+          logp_n += log(Phi(lambda[i] - c[i][y[i]-2])
+                          - Phi(lambda[i] - c[i][y[i]-1]));
         }
       }
       return logp_n;
     }
 
     template <typename T_loc, typename T_cut>
-    typename return_type<T_loc>::type
+    typename return_type<T_loc, T_cut>::type
     ordered_probit_lpmf(const std::vector<int>& y,
-                          const Eigen::Matrix<T_loc, Eigen::Dynamic, 1>& lambda,
-                          const std::vector<Eigen::Matrix<
-                                                T_cut, Eigen::Dynamic, 1>>& c) {
+                        const Eigen::Matrix<T_loc, Eigen::Dynamic, 1>& lambda,
+                        const std::vector<Eigen::Matrix<
+                                              T_cut, Eigen::Dynamic, 1>>& c) {
       return ordered_probit_lpmf<false>(y, lambda, c);
     }
   }

--- a/stan/math/prim/mat/prob/ordered_probit_rng.hpp
+++ b/stan/math/prim/mat/prob/ordered_probit_rng.hpp
@@ -1,0 +1,43 @@
+#ifndef STAN_MATH_PRIM_MAT_PROB_ORDERED_PROBIT_RNG_HPP
+#define STAN_MATH_PRIM_MAT_PROB_ORDERED_PROBIT_RNG_HPP
+
+#include <boost/random/uniform_01.hpp>
+#include <boost/random/variate_generator.hpp>
+#include <stan/math/prim/scal/fun/Phi.hpp>
+#include <stan/math/prim/scal/err/check_finite.hpp>
+#include <stan/math/prim/scal/err/check_greater.hpp>
+#include <stan/math/prim/scal/err/check_ordered.hpp>
+#include <stan/math/prim/scal/fun/constants.hpp>
+#include <stan/math/prim/mat/prob/categorical_rng.hpp>
+#include <string>
+
+namespace stan {
+  namespace math {
+
+    template <class RNG>
+    inline int
+    ordered_probit_rng(double eta,
+                         const Eigen::Matrix<double, Eigen::Dynamic, 1>& c,
+                         RNG& rng) {
+      using boost::variate_generator;
+
+      static const std::string function = "ordered_probit";
+
+      check_finite(function, "Location parameter", eta);
+      check_greater(function, "Size of cut points parameter", c.size(), 0);
+      check_ordered(function, "Cut points vector", c);
+      check_finite(function, "Cut points parameter", c(c.size() - 1));
+      check_finite(function, "Cut points parameter", c(0));
+
+      Eigen::VectorXd cut(c.rows() + 1);
+      cut(0) = 1 - Phi(eta - c(0));
+      for (int j = 1; j < c.rows(); j++)
+        cut(j) = Phi(eta - c(j - 1)) - Phi(eta - c(j));
+      cut(c.rows()) = Phi(eta - c(c.rows() - 1));
+
+      return categorical_rng(cut, rng);
+    }
+
+  }
+}
+#endif

--- a/stan/math/prim/mat/prob/ordered_probit_rng.hpp
+++ b/stan/math/prim/mat/prob/ordered_probit_rng.hpp
@@ -14,8 +14,8 @@ namespace stan {
     template <class RNG>
     inline int
     ordered_probit_rng(double eta,
-                         const Eigen::Matrix<double, Eigen::Dynamic, 1>& c,
-                         RNG& rng) {
+                       const Eigen::VectorXd& c,
+                       RNG& rng) {
       static const std::string function = "ordered_probit";
 
       check_finite(function, "Location parameter", eta);

--- a/stan/math/prim/mat/prob/ordered_probit_rng.hpp
+++ b/stan/math/prim/mat/prob/ordered_probit_rng.hpp
@@ -1,13 +1,10 @@
 #ifndef STAN_MATH_PRIM_MAT_PROB_ORDERED_PROBIT_RNG_HPP
 #define STAN_MATH_PRIM_MAT_PROB_ORDERED_PROBIT_RNG_HPP
 
-#include <boost/random/uniform_01.hpp>
-#include <boost/random/variate_generator.hpp>
 #include <stan/math/prim/scal/fun/Phi.hpp>
 #include <stan/math/prim/scal/err/check_finite.hpp>
 #include <stan/math/prim/scal/err/check_greater.hpp>
-#include <stan/math/prim/scal/err/check_ordered.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
+#include <stan/math/prim/mat/err/check_ordered.hpp>
 #include <stan/math/prim/mat/prob/categorical_rng.hpp>
 #include <string>
 
@@ -19,15 +16,12 @@ namespace stan {
     ordered_probit_rng(double eta,
                          const Eigen::Matrix<double, Eigen::Dynamic, 1>& c,
                          RNG& rng) {
-      using boost::variate_generator;
-
       static const std::string function = "ordered_probit";
 
       check_finite(function, "Location parameter", eta);
       check_greater(function, "Size of cut points parameter", c.size(), 0);
       check_ordered(function, "Cut points vector", c);
-      check_finite(function, "Cut points parameter", c(c.size() - 1));
-      check_finite(function, "Cut points parameter", c(0));
+      check_finite(function, "Cut-points", c);
 
       Eigen::VectorXd cut(c.rows() + 1);
       cut(0) = 1 - Phi(eta - c(0));

--- a/test/unit/math/prim/mat/prob/ordered_probit_log_test.cpp
+++ b/test/unit/math/prim/mat/prob/ordered_probit_log_test.cpp
@@ -1,0 +1,23 @@
+#include <stan/math/prim/mat.hpp>
+#include <gtest/gtest.h>
+
+TEST(ProbOrderedProbit, log_matches_lpmf) {
+  int K = 5;
+  Eigen::Matrix<double,Eigen::Dynamic,1> c(K-1);
+  c << -1.7, -0.3, 1.2, 2.6;
+  double lambda = 1.1;
+  
+  EXPECT_FLOAT_EQ((stan::math::ordered_probit_lpmf(3, lambda, c)),
+                  (stan::math::ordered_probit_log(3, lambda, c)));
+  EXPECT_FLOAT_EQ((stan::math::ordered_probit_lpmf<true>(3, lambda, c)),
+                  (stan::math::ordered_probit_log<true>(3, lambda, c)));
+  EXPECT_FLOAT_EQ((stan::math::ordered_probit_lpmf<false>(3, lambda, c)),
+                  (stan::math::ordered_probit_log<false>(3, lambda, c)));
+  EXPECT_FLOAT_EQ((stan::math::ordered_probit_lpmf<true, double, double>(3, lambda, c)),
+                  (stan::math::ordered_probit_log<true, double, double>(3, lambda, c)));
+  EXPECT_FLOAT_EQ((stan::math::ordered_probit_lpmf<false, double, double>(3, lambda, c)),
+                  (stan::math::ordered_probit_log<false, double, double>(3, lambda, c)));
+  EXPECT_FLOAT_EQ((stan::math::ordered_probit_lpmf<double, double>(3, lambda, c)),
+                  (stan::math::ordered_probit_log<double, double>(3, lambda, c)));
+
+}

--- a/test/unit/math/prim/mat/prob/ordered_probit_test.cpp
+++ b/test/unit/math/prim/mat/prob/ordered_probit_test.cpp
@@ -1,0 +1,202 @@
+#include <stan/math/prim/mat.hpp>
+#include <gtest/gtest.h>
+#include <boost/random/mersenne_twister.hpp>
+#include <boost/math/distributions.hpp>
+
+using Eigen::Matrix;
+using Eigen::Dynamic;
+
+typedef Eigen::Matrix<double,Eigen::Dynamic,1> vector_d;
+
+vector_d
+get_simplex(double lambda, 
+           const vector_d& c) {
+  using stan::math::Phi;
+  int K = c.size() + 1;
+  vector_d theta(K);
+  theta(0) = 1.0 - Phi(lambda - c(0));
+  for (int k = 1; k < (K - 1); ++k)
+    theta(k) = Phi(lambda - c(k - 1)) - Phi(lambda - c(k));
+  theta(K-1) = Phi(lambda - c(K-2)); // - 0.0
+  return theta;
+}
+
+TEST(ProbDistributions,ordered_probit_vals) {
+  using Eigen::Matrix;
+  using Eigen::Dynamic;
+
+  using stan::math::ordered_probit_log;
+  using stan::math::Phi;
+
+  int K = 5;
+  Matrix<double,Dynamic,1> c(K-1);
+  c << -1.7, -0.3, 1.2, 2.6;
+  double lambda = 1.1;
+  
+  vector_d theta = get_simplex(lambda,c);
+
+  double sum = 0.0;
+  for (int k = 0; k < theta.size(); ++k)
+    sum += theta(k);
+  EXPECT_FLOAT_EQ(1.0,sum);
+
+
+  for (int k = 0; k < K; ++k) 
+    EXPECT_FLOAT_EQ(log(theta(k)), ordered_probit_log(k+1,lambda,c));
+
+  EXPECT_THROW(ordered_probit_log(0,lambda,c),std::domain_error);
+  EXPECT_THROW(ordered_probit_log(6,lambda,c),std::domain_error);
+}
+
+TEST(ProbDistributions,ordered_probit_vals_2) {
+  using Eigen::Matrix;
+  using Eigen::Dynamic;
+
+  using stan::math::ordered_probit_log;
+  using stan::math::Phi;
+
+  int K = 3;
+  Matrix<double,Dynamic,1> c(K-1);
+  c << -0.2, 4;
+  double lambda = -0.9;
+  
+  vector_d theta = get_simplex(lambda,c);
+
+  double sum = 0.0;
+  for (int k = 0; k < theta.size(); ++k)
+    sum += theta(k);
+  EXPECT_FLOAT_EQ(1.0,sum);
+
+  for (int k = 0; k < K; ++k)
+    EXPECT_FLOAT_EQ(log(theta(k)),ordered_probit_log(k+1,lambda,c));
+
+  EXPECT_THROW(ordered_probit_log(0,lambda,c),std::domain_error);
+  EXPECT_THROW(ordered_probit_log(4,lambda,c),std::domain_error);
+}
+
+TEST(ProbDistributions,ordered_probit) {
+  using stan::math::ordered_probit_log;
+  int K = 4;
+  Eigen::Matrix<double,Eigen::Dynamic,1> c(K-1);
+  c << -0.3, 0.1, 1.2;
+  double lambda = 0.5;
+  EXPECT_THROW(ordered_probit_log(-1,lambda,c),std::domain_error);
+  EXPECT_THROW(ordered_probit_log(0,lambda,c),std::domain_error);
+  EXPECT_THROW(ordered_probit_log(5,lambda,c),std::domain_error);
+  for (int k = 1; k <= K; ++k)
+    EXPECT_NO_THROW(ordered_probit_log(k,lambda,c));
+
+  Eigen::Matrix<double,Eigen::Dynamic,1> c_zero; // init size zero
+  EXPECT_EQ(0,c_zero.size());
+  EXPECT_THROW(ordered_probit_log(1,lambda,c_zero),std::domain_error);
+
+  Eigen::Matrix<double,Eigen::Dynamic,1> c_neg(1);
+  c_neg << -13.7;
+  EXPECT_NO_THROW(ordered_probit_log(1,lambda,c_neg));
+
+  Eigen::Matrix<double,Eigen::Dynamic,1> c_unord(3);
+  c_unord << 1.0, 0.4, 2.0;
+  EXPECT_THROW(ordered_probit_log(1,lambda,c_unord),std::domain_error);
+
+  Eigen::Matrix<double,Eigen::Dynamic,1> c_unord_2(3); 
+  c_unord_2 << 1.0, 2.0, 0.4;
+  EXPECT_THROW(ordered_probit_log(1,lambda,c_unord_2),std::domain_error);
+
+  double nan = std::numeric_limits<double>::quiet_NaN();
+  double inf = std::numeric_limits<double>::infinity();
+
+  EXPECT_THROW(ordered_probit_log(1,nan,c),std::domain_error);
+  EXPECT_THROW(ordered_probit_log(1,inf,c),std::domain_error);
+
+  Eigen::Matrix<double,Eigen::Dynamic,1> cbad(2); 
+  cbad << 0.2, inf;
+  EXPECT_THROW(ordered_probit_log(1,1.0,cbad),std::domain_error);
+  cbad[1] = nan;
+  EXPECT_THROW(ordered_probit_log(1,1.0,cbad),std::domain_error);
+
+  Eigen::Matrix<double,Eigen::Dynamic,1> cbad1(1); 
+  cbad1 <<  inf;
+  EXPECT_THROW(ordered_probit_log(1,1.0,cbad1),std::domain_error);
+  cbad1[0] = nan;
+  EXPECT_THROW(ordered_probit_log(1,1.0,cbad1),std::domain_error);
+
+  Eigen::Matrix<double,Eigen::Dynamic,1> cbad3(3); 
+  cbad3 <<  0.5, inf, 1.0;
+  EXPECT_THROW(ordered_probit_log(1,1.0,cbad3),std::domain_error);
+  cbad3[1] = nan;
+  EXPECT_THROW(ordered_probit_log(1,1.0,cbad3),std::domain_error);
+}
+
+void expect_nan(double x) {
+  EXPECT_TRUE(std::isnan(x));
+}
+
+
+TEST(ProbDistributionOrderedProbit, error_check) {
+  boost::random::mt19937 rng;
+  double inf = std::numeric_limits<double>::infinity();
+  Eigen::VectorXd c(4);
+  c << -2, 
+    2.0,
+    5,
+    10;
+  EXPECT_NO_THROW(stan::math::ordered_probit_rng(4.0, c, rng));
+
+  EXPECT_THROW(stan::math::ordered_probit_rng(stan::math::positive_infinity(), 
+                                                c, rng),
+               std::domain_error);
+  c << -inf, 
+    2.0,
+    -5,
+    inf;
+  EXPECT_THROW(stan::math::ordered_probit_rng(4.0, c, rng),
+               std::domain_error);
+
+}
+
+TEST(ProbDistributionOrderedProbit, chiSquareGoodnessFitTest) {
+  using stan::math::Phi;
+  boost::random::mt19937 rng;
+  int N = 10000;
+  double eta = 1.0;
+  Eigen::VectorXd theta(3);
+  theta << -0.4, 
+    4.0,
+    6.2;
+  Eigen::VectorXd prob(4);
+  prob(0) = 1 - Phi(eta - theta(0));
+  prob(1) = Phi(eta - theta(0)) - Phi(eta - theta(1));
+  prob(2) = Phi(eta - theta(1)) - Phi(eta - theta(2));
+  prob(3) = Phi(eta - theta(2));
+  int K = prob.rows();
+  boost::math::chi_squared mydist(K-1);
+
+  Eigen::VectorXd loc(prob.rows());
+  for(int i = 0; i < prob.rows(); i++)
+    loc(i) = 0;
+
+  for(int i = 0; i < prob.rows(); i++) {
+      for(int j = i; j < prob.rows(); j++)
+  loc(j) += prob(i);
+    }
+
+  int count = 0;
+  int bin [K];
+  double expect [K];
+  for(int i = 0 ; i < K; i++) {
+    bin[i] = 0;
+    expect[i] = N * prob(i);
+  }
+
+  while (count < N) {
+    int a = stan::math::ordered_probit_rng(eta,theta,rng);
+    bin[a - 1]++;
+    count++;
+   }
+
+  double chi = 0;
+
+  for(int j = 0; j < K; j++)
+    chi += ((bin[j] - expect[j]) * (bin[j] - expect[j]) / expect[j]);
+  EXPECT_TRUE(chi < quantile(complement(mydist, 1e-6)));
+}


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

Introduces distribution, and unit tests, for modelling ordered categorical responses with a probit link. Very heavily based on the changes to the ```ordered_logistic()``` distribution introduced in #638.

Takes the following signatures:
```
int ~ ordered_probit(real, vector)
int[] ~ ordered_probit(vector, vector)
int[] ~ ordered_probit(vector, vector[])
```
In rough testing, this is almost 3 times faster than specifying the model in Stan (as on pp.138 of the manual), not to mention much more concise!

#### Intended Effect:
Make ordered probit distributions in Stan more efficient and easier to specify.

#### How to Verify:
```
./runTests.py test/unit/math/prim/mat/prob/ordered_probit_*
```

#### Side Effects:
None.

#### Documentation:
N/A.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Andrew Johnson

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
