### PR TITLE
use std::round in choose

### DIFF
--- a/stan/math/prim/scal/fun/choose.hpp
+++ b/stan/math/prim/scal/fun/choose.hpp
@@ -5,6 +5,7 @@
 #include <stan/math/prim/scal/err/check_less_or_equal.hpp>
 #include <boost/math/special_functions/binomial.hpp>
 #include <limits>
+#include <cmath>
 
 namespace stan {
   namespace math {
@@ -34,8 +35,7 @@ namespace stan {
       const double choices = boost::math::binomial_coefficient<double>(n, k);
       check_less_or_equal("choose", "n choose k", choices,
                           std::numeric_limits<int>::max());
-      // won't get proper round until C++11
-      return static_cast<int>(choices < 0 ? choices - 0.5 : choices + 0.5);
+      return static_cast<int>(std::round(choices));
     }
 
   }


### PR DESCRIPTION
#### Submission Checklist

- [X] Run unit tests: `./runTests.py test/unit`
- [X] Run cpplint: `make cpplint`
- [X] Declare copyright holder and open-source license: see below

#### Summary:

Use `std:round` in `choose` rather than the pre-C++11 rounding

#### Intended Effect:

Possibly prevent incorrect rounding. Fixes #652 

#### How to Verify:

There is no verifiably wrong behavior currently, but the unit test continues to pass. 

#### Side Effects:

None

#### Documentation:

None

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Trustees of Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
