### PR TITLE
Add missing tests

### DIFF
--- a/test/unit/math/prim/mat/fun/LDLT_factor_test.cpp
+++ b/test/unit/math/prim/mat/fun/LDLT_factor_test.cpp
@@ -33,8 +33,8 @@ TEST(MathMatrix, LDLTfactor_InvalidValues) {
 
   Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> non_spd(3, 3);
   non_spd << 2.0, 0.0, 0.0,
-        -1.0, 0.0, -1.0,
-         0.0, -1.0, 2.0;
+            -1.0, 0.0, -1.0,
+             0.0, -1.0, 2.0;
 
   Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> spd_nan(3, 3);
   spd_nan << 2.0, -1.0, nan,

--- a/test/unit/math/prim/mat/fun/LDLT_factor_test.cpp
+++ b/test/unit/math/prim/mat/fun/LDLT_factor_test.cpp
@@ -1,3 +1,76 @@
+#include <stan/math/prim/mat/fun/LDLT_factor.hpp>
+#include <stan/math/prim/mat/fun/log_determinant_ldlt.hpp>
 #include <stan/math/prim/mat.hpp>
 #include <gtest/gtest.h>
+#include <limits>
 
+TEST(MathMatrix, LDLTfactor_Values) {
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> spd(3, 3);
+  spd << 2.0, -1.0, 0.0,
+        -1.0, 2.0, -1.0,
+         0.0, -1.0, 2.0;
+
+  stan::math::LDLT_factor<double,
+                          Eigen::Dynamic, Eigen::Dynamic> stan_ldlt_1(spd);
+  stan::math::LDLT_factor<double, Eigen::Dynamic, Eigen::Dynamic> stan_ldlt_2;
+  stan_ldlt_2.compute(spd);
+
+  Eigen::LDLT<Eigen::Matrix<double,
+                            Eigen::Dynamic, Eigen::Dynamic>> eigen_ldlt(spd);
+
+  double stan_ldlt_1_logdet = stan_ldlt_1.log_abs_det();
+  double stan_ldlt_2_logdet = stan_ldlt_2.log_abs_det();
+  double eigen_ldlt_logdet = eigen_ldlt.vectorD().array().log().sum();
+
+  EXPECT_EQ(stan_ldlt_1_logdet, eigen_ldlt_logdet);
+  EXPECT_EQ(stan_ldlt_1_logdet, stan_ldlt_2_logdet);
+}
+
+TEST(MathMatrix, LDLTfactor_InvalidValues) {
+  double nan = std::numeric_limits<double>::quiet_NaN();
+  double infty = std::numeric_limits<double>::infinity();
+  double neg_infty = -std::numeric_limits<double>::infinity();
+
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> non_spd(3, 3);
+  non_spd << 2.0, 0.0, 0.0,
+        -1.0, 0.0, -1.0,
+         0.0, -1.0, 2.0;
+
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> spd_nan(3, 3);
+  spd_nan << 2.0, -1.0, nan,
+            -1.0, 2.0, -1.0,
+             nan, -1.0, 2.0;
+
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> spd_infty(3, 3);
+  spd_infty << 2.0, -1.0, infty,
+              -1.0, 2.0, -1.0,
+               infty, -1.0, 2.0;
+
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> spd_neg_infty(3, 3);
+  spd_neg_infty << 2.0, -1.0, neg_infty,
+                  -1.0, 2.0, -1.0,
+                   neg_infty, -1.0, 2.0;
+
+  stan::math::LDLT_factor<double,
+                          Eigen::Dynamic,
+                          Eigen::Dynamic> non_spd_ldlt(non_spd);
+  stan::math::LDLT_factor<double,
+                          Eigen::Dynamic,
+                          Eigen::Dynamic> nan_ldlt(spd_nan);
+  stan::math::LDLT_factor<double,
+                          Eigen::Dynamic,
+                          Eigen::Dynamic> infty_ldlt(spd_infty);
+  stan::math::LDLT_factor<double,
+                          Eigen::Dynamic,
+                          Eigen::Dynamic> neg_infty_ldlt(spd_neg_infty);
+
+  double non_spd_ldlt_logdet = non_spd_ldlt.log_abs_det();
+  double nan_ldlt_logdet = nan_ldlt.log_abs_det();
+  double infty_ldlt_logdet = infty_ldlt.log_abs_det();
+  double neg_infty_ldlt_logdet = neg_infty_ldlt.log_abs_det();
+
+  EXPECT_TRUE(isnan(non_spd_ldlt_logdet));
+  EXPECT_TRUE(isnan(nan_ldlt_logdet));
+  EXPECT_TRUE(isnan(infty_ldlt_logdet));
+  EXPECT_TRUE(isnan(neg_infty_ldlt_logdet));
+}

--- a/test/unit/math/prim/mat/fun/columns_dot_product_test.cpp
+++ b/test/unit/math/prim/mat/fun/columns_dot_product_test.cpp
@@ -1,2 +1,90 @@
+#include <stan/math/prim/mat/fun/columns_dot_product.hpp>
+#include <stan/math/prim/mat/fun/dot_product.hpp>
 #include <stan/math/prim/mat.hpp>
 #include <gtest/gtest.h>
+#include <limits>
+
+TEST(MathMatrix, ColumnsDotProduct_Values) {
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> a(3, 3);
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> b(3, 3);
+  Eigen::Matrix<double, Eigen::Dynamic, 1> a1(3, 1);
+  Eigen::Matrix<double, Eigen::Dynamic, 1> a2(3, 1);
+  Eigen::Matrix<double, Eigen::Dynamic, 1> a3(3, 1);
+  Eigen::Matrix<double, Eigen::Dynamic, 1> b1(3, 1);
+  Eigen::Matrix<double, Eigen::Dynamic, 1> b2(3, 1);
+  Eigen::Matrix<double, Eigen::Dynamic, 1> b3(3, 1);
+
+  a << 13.5, 3.67, 8.98,
+       12.5, 3.65, 1.69,
+       1.52, 15.35, 5.69;
+
+  a1 << 13.5, 12.5, 1.52;
+  a2 << 3.67, 3.65, 15.35;
+  a3 << 8.98, 1.69, 5.69;
+
+  b << 5.56, 2.68, 11.96,
+       11.63, 7.52, 1.96,
+       6.35, 5.24, 8.65;
+
+  b1 << 5.56, 11.63, 6.35;
+  b2 << 2.68, 7.52, 5.24;
+  b3 << 11.96, 1.96, 8.65;
+
+  Eigen::Matrix<double, 1, Eigen::Dynamic> dot_manual(1, 3);
+  dot_manual << (13.5 * 5.56) + (12.5 * 11.63) + (1.52 * 6.35),
+                (3.67 * 2.68) + (3.65 * 7.52) + (15.35 * 5.24),
+                (8.98 * 11.96) + (1.69 * 1.96) + (5.69 * 8.65);
+
+  Eigen::Matrix<double, 1, Eigen::Dynamic> dot_stan(1, 3);
+  dot_stan << stan::math::dot_product(a1, b1),
+              stan::math::dot_product(a2, b2),
+              stan::math::dot_product(a3, b3);
+
+  Eigen::Matrix<double, 1, Eigen::Dynamic> dot_eigen(1, 3);
+  dot_eigen << a.col(0).dot(b.col(0)),
+               a.col(1).dot(b.col(1)),
+               a.col(2).dot(b.col(2));
+
+  EXPECT_EQ(stan::math::columns_dot_product(a, b), dot_manual);
+  EXPECT_EQ(stan::math::columns_dot_product(a, b), dot_stan);
+  EXPECT_EQ(stan::math::columns_dot_product(a, b), dot_eigen);
+}
+
+TEST(MathMatrix, ColumnsDotProduct_Throws) {
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> a(3, 3);
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> b_cols_large(3, 6);
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> b_cols_zero(3, 0);
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> b_rows_large(6, 3);
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> b_rows_zero(0, 3);
+
+  double nan = std::numeric_limits<double>::quiet_NaN();
+  double infty = std::numeric_limits<double>::infinity();
+  double neg_infty = -std::numeric_limits<double>::infinity();
+
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> b_nan(3, 3);
+  b_nan << nan, 2.68, 11.96,
+           11.63, 7.52, 1.96,
+           6.35, 5.24, 8.65;
+
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> b_infty(3, 3);
+  b_infty << infty, 2.68, 11.96,
+             11.63, 7.52, 1.96,
+             6.35, 5.24, 8.65;
+
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> b_neg_infty(3, 3);
+  b_neg_infty << neg_infty, 2.68, 11.96,
+                 11.63, 7.52, 1.96,
+                 6.35, 5.24, 8.65;
+
+  EXPECT_THROW(stan::math::columns_dot_product(a, b_cols_large),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::columns_dot_product(a, b_cols_zero),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::columns_dot_product(a, b_rows_large),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::columns_dot_product(a, b_rows_zero),
+               std::invalid_argument);
+  EXPECT_NO_THROW(stan::math::columns_dot_product(a, b_nan));
+  EXPECT_NO_THROW(stan::math::columns_dot_product(a, b_infty));
+  EXPECT_NO_THROW(stan::math::columns_dot_product(a, b_neg_infty));
+}

--- a/test/unit/math/prim/mat/fun/dot_product_test.cpp
+++ b/test/unit/math/prim/mat/fun/dot_product_test.cpp
@@ -1,3 +1,72 @@
+#include <stan/math/prim/mat/fun/dot_product.hpp>
 #include <stan/math/prim/mat.hpp>
 #include <gtest/gtest.h>
+#include <limits>
 
+TEST(MathMatrix, DotProduct_Values) {
+  Eigen::Matrix<double, 1, Eigen::Dynamic> r1(1, 3);
+  Eigen::Matrix<double, 1, Eigen::Dynamic> r2(1, 3);
+  Eigen::Matrix<double, Eigen::Dynamic, 1> c1(3, 1);
+  Eigen::Matrix<double, Eigen::Dynamic, 1> c2(3, 1);
+
+
+  r1 << 13.5, 3.67, 8.98;
+  r2 << 12.5, 3.65, 1.69;
+
+  c1 << 5.56, 2.68, 11.96;
+  c2 << 11.63, 7.52, 1.96;
+
+  double row_dot_manual = (13.5 * 12.5) + (3.67 * 3.65) + (8.98 * 1.69);
+  double col_dot_manual = (5.56 * 11.63) + (2.68 * 7.52) + (11.96 * 1.96);
+
+  double row_dot_eigen = r1.dot(r2);
+  double col_dot_eigen = c1.dot(c2);
+
+  EXPECT_EQ(stan::math::dot_product(r1, r2), row_dot_manual);
+  EXPECT_EQ(stan::math::dot_product(r1, r2), row_dot_eigen);
+  EXPECT_EQ(stan::math::dot_product(c1, c2), col_dot_manual);
+  EXPECT_EQ(stan::math::dot_product(c1, c2), col_dot_eigen);
+}
+
+TEST(MathMatrix, DotProduct_Throws) {
+  Eigen::Matrix<double, Eigen::Dynamic, 1> col_normal(3, 1);
+  Eigen::Matrix<double, 1, Eigen::Dynamic> row_normal(1, 3);
+  Eigen::Matrix<double, Eigen::Dynamic, 1> col_large(6, 1);
+  Eigen::Matrix<double, 1, Eigen::Dynamic> row_large(1, 6);
+  Eigen::Matrix<double, Eigen::Dynamic, 1> col_zero(0, 1);
+  Eigen::Matrix<double, 1, Eigen::Dynamic> row_zero(1, 0);
+
+  double nan = std::numeric_limits<double>::quiet_NaN();
+  double infty = std::numeric_limits<double>::infinity();
+  double neg_infty = -std::numeric_limits<double>::infinity();
+
+  Eigen::Matrix<double, Eigen::Dynamic, 1> col_nan(3, 1);
+  Eigen::Matrix<double, 1, Eigen::Dynamic> row_nan(1, 3);
+  col_nan << nan, 2.68, 11.96;
+  row_nan << nan, 2.68, 11.96;
+
+  Eigen::Matrix<double, Eigen::Dynamic, 1> col_infty(3, 1);
+  Eigen::Matrix<double, 1, Eigen::Dynamic> row_infty(1, 3);
+  col_infty << infty, 2.68, 11.96;
+  row_infty << infty, 2.68, 11.96;
+
+  Eigen::Matrix<double, Eigen::Dynamic, 1> col_neg_infty(3, 1);
+  Eigen::Matrix<double, 1, Eigen::Dynamic> row_neg_infty(1, 3);
+  col_neg_infty << neg_infty, 2.68, 11.96;
+  row_neg_infty << neg_infty, 2.68, 11.96;
+
+  EXPECT_THROW(stan::math::dot_product(col_normal, col_large),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::dot_product(row_normal, row_large),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::dot_product(col_normal, col_zero),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::dot_product(row_normal, row_zero),
+               std::invalid_argument);
+  EXPECT_NO_THROW(stan::math::dot_product(col_normal, col_nan));
+  EXPECT_NO_THROW(stan::math::dot_product(row_normal, row_nan));
+  EXPECT_NO_THROW(stan::math::dot_product(col_normal, col_infty));
+  EXPECT_NO_THROW(stan::math::dot_product(row_normal, row_infty));
+  EXPECT_NO_THROW(stan::math::dot_product(col_normal, col_neg_infty));
+  EXPECT_NO_THROW(stan::math::dot_product(row_normal, row_neg_infty));
+}

--- a/test/unit/math/prim/mat/fun/log_determinant_test.cpp
+++ b/test/unit/math/prim/mat/fun/log_determinant_test.cpp
@@ -1,2 +1,60 @@
+#include <stan/math/prim/mat/fun/log_determinant.hpp>
 #include <stan/math/prim/mat.hpp>
 #include <gtest/gtest.h>
+#include <limits>
+
+TEST(MathMatrix, LogDeterminant_Values) {
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> a(3, 3);
+  a << 1.52, 1.69, 11.98,
+       12.56, 37.56, 31.69,
+       15.42, 43.31, 5.69;
+
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> b(3, 3);
+  b << 5.56, 2.68, 11.96,
+       11.63, 7.52, 1.96,
+       6.35, 5.24, 8.65;
+
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> a_times_b(3, 3);
+  a_times_b << a * b;
+
+  double det_manual = (1.52 * 37.56 * 5.69) + (1.69 * 31.69 * 15.42)
+                       + (11.98 * 12.56 * 43.31) - (11.98 * 37.56 * 15.42)
+                       - (1.69 * 12.56 * 5.69)  - (1.52 * 31.69 * 43.31);
+  double sum_logdet = stan::math::log_determinant(a)
+                      + stan::math::log_determinant(b);
+
+  EXPECT_FLOAT_EQ(stan::math::log_determinant(a), log(abs(det_manual)));
+  EXPECT_FLOAT_EQ(stan::math::log_determinant(a_times_b), sum_logdet);
+}
+
+TEST(MathMatrix, LogDeterminant_Throws) {
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> a_cols_large(3, 6);
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> a_cols_zero(3, 0);
+
+  double nan = std::numeric_limits<double>::quiet_NaN();
+  double infty = std::numeric_limits<double>::infinity();
+  double neg_infty = -std::numeric_limits<double>::infinity();
+
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> a_nan(3, 3);
+  a_nan << nan, 2.68, 11.96,
+           11.63, 7.52, 1.96,
+           6.35, 5.24, 8.65;
+
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> a_infty(3, 3);
+  a_infty << infty, 2.68, 11.96,
+             11.63, 7.52, 1.96,
+             6.35, 5.24, 8.65;
+
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> a_neg_infty(3, 3);
+  a_neg_infty << neg_infty, 2.68, 11.96,
+                 11.63, 7.52, 1.96,
+                 6.35, 5.24, 8.65;
+
+  EXPECT_THROW(stan::math::log_determinant(a_cols_large),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::log_determinant(a_cols_zero),
+               std::invalid_argument);
+  EXPECT_NO_THROW(stan::math::log_determinant(a_nan));
+  EXPECT_NO_THROW(stan::math::log_determinant(a_infty));
+  EXPECT_NO_THROW(stan::math::log_determinant(a_neg_infty));
+}

--- a/test/unit/math/prim/mat/fun/mdivide_left_tri_low_test.cpp
+++ b/test/unit/math/prim/mat/fun/mdivide_left_tri_low_test.cpp
@@ -1,2 +1,68 @@
+#include <stan/math/prim/mat/fun/mdivide_left_tri_low.hpp>
+#include <stan/math/prim/mat/fun/inverse.hpp>
+#include <test/unit/math/prim/mat/fun/expect_matrix_eq.hpp>
 #include <stan/math/prim/mat.hpp>
 #include <gtest/gtest.h>
+#include <limits>
+
+TEST(MathMatrix, MDivide_LeftTriLow_Values) {
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> a(3, 3);
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> b(3, 3);
+  Eigen::Matrix<double, Eigen::Dynamic, 1> b_vec(3, 1);
+
+  a << 13.5, 0, 0,
+       12.5, 3.65, 0,
+       1.52, 15.35, 5.69;
+
+  b << 5.56, 2.68, 11.96,
+       11.63, 7.52, 1.96,
+       6.35, 5.24, 8.65;
+
+  b_vec << 5.56, 11.63, 6.35;
+
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> div_manual(3, 3);
+  div_manual << stan::math::inverse(a) * b;
+
+  Eigen::Matrix<double, Eigen::Dynamic, 1> div_vec_manual(3, 1);
+  div_vec_manual << stan::math::inverse(a) * b_vec;
+
+  expect_matrix_eq(stan::math::mdivide_left_tri_low(a, b), div_manual);
+  expect_matrix_eq(stan::math::mdivide_left_tri_low(a, b_vec), div_vec_manual);
+}
+
+TEST(MathMatrix, MDivide_LeftTriLow_Throws) {
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> b_rows_large(6, 3);
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> b_rows_zero(0, 3);
+
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> a(3, 3);
+  a << 13.5, 0, 0,
+       12.5, 3.65, 0,
+       1.52, 15.35, 5.69;
+
+  double nan = std::numeric_limits<double>::quiet_NaN();
+  double infty = std::numeric_limits<double>::infinity();
+  double neg_infty = -std::numeric_limits<double>::infinity();
+
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> b_nan(3, 3);
+  b_nan << nan, 2.68, 11.96,
+           11.63, 7.52, 1.96,
+           6.35, 5.24, 8.65;
+
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> b_infty(3, 3);
+  b_infty << infty, 2.68, 11.96,
+             11.63, 7.52, 1.96,
+             6.35, 5.24, 8.65;
+
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> b_neg_infty(3, 3);
+  b_neg_infty << neg_infty, 2.68, 11.96,
+                 11.63, 7.52, 1.96,
+                 6.35, 5.24, 8.65;
+
+  EXPECT_THROW(stan::math::mdivide_left_tri_low(a, b_rows_large),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::mdivide_left_tri_low(a, b_rows_zero),
+               std::invalid_argument);
+  EXPECT_NO_THROW(stan::math::mdivide_left_tri_low(a, b_nan));
+  EXPECT_NO_THROW(stan::math::mdivide_left_tri_low(a, b_infty));
+  EXPECT_NO_THROW(stan::math::mdivide_left_tri_low(a, b_neg_infty));
+}

--- a/test/unit/math/prim/mat/fun/mdivide_right_tri_low_test.cpp
+++ b/test/unit/math/prim/mat/fun/mdivide_right_tri_low_test.cpp
@@ -1,2 +1,68 @@
+#include <stan/math/prim/mat/fun/mdivide_right_tri_low.hpp>
+#include <stan/math/prim/mat/fun/inverse.hpp>
 #include <stan/math/prim/mat.hpp>
+#include <test/unit/math/prim/mat/fun/expect_matrix_eq.hpp>
 #include <gtest/gtest.h>
+#include <limits>
+
+TEST(MathMatrix, MDivide_RightTriLow_Values) {
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> a(3, 3);
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> b(3, 3);
+  Eigen::Matrix<double, 1, Eigen::Dynamic> b_vec(1, 3);
+
+  a << 13.5, 0, 0,
+       12.5, 3.65, 0,
+       1.52, 15.35, 5.69;
+
+  b << 5.56, 2.68, 11.96,
+       11.63, 7.52, 1.96,
+       6.35, 5.24, 8.65;
+
+  b_vec << 5.56, 11.63, 6.35;
+
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> div_manual(3, 3);
+  div_manual << b * stan::math::inverse(a);
+
+  Eigen::Matrix<double, 1, Eigen::Dynamic> div_vec_manual(1, 3);
+  div_vec_manual << b_vec * stan::math::inverse(a);
+
+  expect_matrix_eq(stan::math::mdivide_right_tri_low(b, a), div_manual);
+  expect_matrix_eq(stan::math::mdivide_right_tri_low(b_vec, a), div_vec_manual);
+}
+
+TEST(MathMatrix, MDivide_RightTriLow_Throws) {
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> b_rows_large(3, 6);
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> b_rows_zero(3, 0);
+
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> a(3, 3);
+  a << 13.5, 0, 0,
+       12.5, 3.65, 0,
+       1.52, 15.35, 5.69;
+
+  double nan = std::numeric_limits<double>::quiet_NaN();
+  double infty = std::numeric_limits<double>::infinity();
+  double neg_infty = -std::numeric_limits<double>::infinity();
+
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> b_nan(3, 3);
+  b_nan << nan, 2.68, 11.96,
+           11.63, 7.52, 1.96,
+           6.35, 5.24, 8.65;
+
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> b_infty(3, 3);
+  b_infty << infty, 2.68, 11.96,
+             11.63, 7.52, 1.96,
+             6.35, 5.24, 8.65;
+
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> b_neg_infty(3, 3);
+  b_neg_infty << neg_infty, 2.68, 11.96,
+                 11.63, 7.52, 1.96,
+                 6.35, 5.24, 8.65;
+
+  EXPECT_THROW(stan::math::mdivide_right_tri_low(b_rows_large, a),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::mdivide_right_tri_low(b_rows_zero, a),
+               std::invalid_argument);
+  EXPECT_NO_THROW(stan::math::mdivide_right_tri_low(b_nan, a));
+  EXPECT_NO_THROW(stan::math::mdivide_right_tri_low(b_infty, a));
+  EXPECT_NO_THROW(stan::math::mdivide_right_tri_low(b_neg_infty, a));
+}

--- a/test/unit/math/prim/mat/fun/rows_dot_product_test.cpp
+++ b/test/unit/math/prim/mat/fun/rows_dot_product_test.cpp
@@ -1,2 +1,90 @@
+#include <stan/math/prim/mat/fun/rows_dot_product.hpp>
+#include <stan/math/prim/mat/fun/dot_product.hpp>
 #include <stan/math/prim/mat.hpp>
 #include <gtest/gtest.h>
+#include <limits>
+
+TEST(MathMatrix, RowsDotProduct_Values) {
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> a(3, 3);
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> b(3, 3);
+  Eigen::Matrix<double, 1, Eigen::Dynamic> a1(1, 3);
+  Eigen::Matrix<double, 1, Eigen::Dynamic> a2(1, 3);
+  Eigen::Matrix<double, 1, Eigen::Dynamic> a3(1, 3);
+  Eigen::Matrix<double, 1, Eigen::Dynamic> b1(1, 3);
+  Eigen::Matrix<double, 1, Eigen::Dynamic> b2(1, 3);
+  Eigen::Matrix<double, 1, Eigen::Dynamic> b3(1, 3);
+
+  a << 13.5, 3.67, 8.98,
+       12.5, 3.65, 1.69,
+       1.52, 15.35, 5.69;
+
+  a1 << 13.5, 3.67, 8.98;
+  a2 << 12.5, 3.65, 1.69;
+  a3 << 1.52, 15.35, 5.69;
+
+  b << 5.56, 2.68, 11.96,
+       11.63, 7.52, 1.96,
+       6.35, 5.24, 8.65;
+
+  b1 << 5.56, 2.68, 11.96;
+  b2 << 11.63, 7.52, 1.96;
+  b3 << 6.35, 5.24, 8.65;
+
+  Eigen::Matrix<double, Eigen::Dynamic,  1> dot_manual(3, 1);
+  dot_manual << (13.5 * 5.56) + (3.67 * 2.68) + (8.98 * 11.96),
+                (12.5 * 11.63) + (3.65 * 7.52) + (1.69 * 1.96),
+                (1.52 * 6.35) + (15.35 * 5.24) + (5.69 * 8.65);
+
+  Eigen::Matrix<double, Eigen::Dynamic, 1> dot_stan(3, 1);
+  dot_stan << stan::math::dot_product(a1, b1),
+              stan::math::dot_product(a2, b2),
+              stan::math::dot_product(a3, b3);
+
+  Eigen::Matrix<double, Eigen::Dynamic, 1> dot_eigen(3, 1);
+  dot_eigen << a.row(0).dot(b.row(0)),
+               a.row(1).dot(b.row(1)),
+               a.row(2).dot(b.row(2));
+
+  EXPECT_EQ(stan::math::rows_dot_product(a, b), dot_manual);
+  EXPECT_EQ(stan::math::rows_dot_product(a, b), dot_stan);
+  EXPECT_EQ(stan::math::rows_dot_product(a, b), dot_eigen);
+}
+
+TEST(MathMatrix, RowsDotProduct_Throws) {
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> a(3, 3);
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> b_cols_large(3, 6);
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> b_cols_zero(3, 0);
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> b_rows_large(6, 3);
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> b_rows_zero(0, 3);
+
+  double nan = std::numeric_limits<double>::quiet_NaN();
+  double infty = std::numeric_limits<double>::infinity();
+  double neg_infty = -std::numeric_limits<double>::infinity();
+
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> b_nan(3, 3);
+  b_nan << nan, 2.68, 11.96,
+           11.63, 7.52, 1.96,
+           6.35, 5.24, 8.65;
+
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> b_infty(3, 3);
+  b_infty << infty, 2.68, 11.96,
+             11.63, 7.52, 1.96,
+             6.35, 5.24, 8.65;
+
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> b_neg_infty(3, 3);
+  b_neg_infty << neg_infty, 2.68, 11.96,
+                 11.63, 7.52, 1.96,
+                 6.35, 5.24, 8.65;
+
+  EXPECT_THROW(stan::math::rows_dot_product(a, b_cols_large),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::rows_dot_product(a, b_cols_zero),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::rows_dot_product(a, b_rows_large),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::rows_dot_product(a, b_rows_zero),
+               std::invalid_argument);
+  EXPECT_NO_THROW(stan::math::rows_dot_product(a, b_nan));
+  EXPECT_NO_THROW(stan::math::rows_dot_product(a, b_infty));
+  EXPECT_NO_THROW(stan::math::rows_dot_product(a, b_neg_infty));
+}

--- a/test/unit/math/prim/mat/fun/typedefs_test.cpp
+++ b/test/unit/math/prim/mat/fun/typedefs_test.cpp
@@ -1,3 +1,30 @@
+#include <stan/math/prim/mat/fun/typedefs.hpp>
+#include <stan/math/prim/mat/meta/index_type.hpp>
 #include <stan/math/prim/mat.hpp>
 #include <gtest/gtest.h>
+#include <typeinfo>
+#include <vector>
 
+TEST(MathMatrix, Typedefs) {
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> eigen_matrix(3, 3);
+  Eigen::Matrix<double, Eigen::Dynamic, 1> eigen_vector(3, 1);
+  Eigen::Matrix<double, 1, Eigen::Dynamic> eigen_row_vector(1, 3);
+  stan::math::index_type<Eigen::Matrix<double,
+                                       Eigen::Dynamic,
+                                       Eigen::Dynamic> >::type eigen_index;
+
+  stan::math::matrix_d stan_matrix(3, 3);
+  stan::math::vector_d stan_vector(3, 1);
+  stan::math::row_vector_d stan_row_vector(1, 3);
+  stan::math::size_type stan_index;
+
+  std::vector<double> cpp_vector(3);
+
+
+  EXPECT_EQ(typeid(eigen_index), typeid(stan_index));
+  EXPECT_EQ(typeid(eigen_matrix), typeid(stan_matrix));
+  EXPECT_EQ(typeid(eigen_vector), typeid(stan_vector));
+  EXPECT_EQ(typeid(eigen_row_vector), typeid(stan_row_vector));
+
+  EXPECT_NE(typeid(stan_vector), typeid(cpp_vector));
+}


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary:
As mentioned on discourse, a number of test files for prim/mat functions are empty:
- LDLT_factor
- dot_product
- columns_dot_product
- rows_dot_product
- typedefs
- log_determinant
- mdivide_left_tri_low
- mdivide_right_tri_low

This PR adds tests for those functions.

Original discussion here: http://discourse.mc-stan.org/t/why-are-some-test-files-2-or-3-lines-long/2314/3

#### Intended Effect:
Make testing more comprehensive

#### How to Verify:

#### Side Effects:
None.

#### Documentation:
N/A

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Andrew Johnson

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
