### PR TITLE
Fixes #667 - Change string back to char*

### DIFF
--- a/stan/math/prim/arr/err/check_matching_sizes.hpp
+++ b/stan/math/prim/arr/err/check_matching_sizes.hpp
@@ -3,7 +3,6 @@
 
 #include <stan/math/prim/scal/err/domain_error.hpp>
 #include <stan/math/prim/scal/err/check_size_match.hpp>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -26,10 +25,10 @@ namespace stan {
      * @throw <code>std::invalid_argument</code> if the sizes do not match
      */
     template <typename T_y1, typename T_y2>
-    inline void check_matching_sizes(const std::string& function,
-                                     const std::string& name1,
+    inline void check_matching_sizes(const char* function,
+                                     const char* name1,
                                      const T_y1& y1,
-                                     const std::string& name2,
+                                     const char* name2,
                                      const T_y2& y2) {
       check_size_match(function,
                        "size of ", name1, y1.size(),

--- a/stan/math/prim/arr/err/check_nonzero_size.hpp
+++ b/stan/math/prim/arr/err/check_nonzero_size.hpp
@@ -2,7 +2,6 @@
 #define STAN_MATH_PRIM_SCAL_ERR_CHECK_NONZERO_SIZE_HPP
 
 #include <stan/math/prim/scal/err/invalid_argument.hpp>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -24,8 +23,8 @@ namespace stan {
      *   has zero size
      */
     template <typename T_y>
-    inline void check_nonzero_size(const std::string& function,
-                                   const std::string& name,
+    inline void check_nonzero_size(const char* function,
+                                   const char* name,
                                    const T_y& y) {
       if (y.size() > 0)
         return;

--- a/stan/math/prim/arr/err/check_ordered.hpp
+++ b/stan/math/prim/arr/err/check_ordered.hpp
@@ -5,8 +5,8 @@
 #include <stan/math/prim/scal/err/domain_error.hpp>
 #include <stan/math/prim/scal/meta/error_index.hpp>
 #include <sstream>
-#include <string>
 #include <vector>
+#include <string>
 
 namespace stan {
   namespace math {
@@ -26,8 +26,8 @@ namespace stan {
      *   values, or if any element is <code>NaN</code>.
      */
     template <typename T_y>
-    void check_ordered(const std::string& function,
-                       const std::string& name,
+    void check_ordered(const char* function,
+                       const char* name,
                        const std::vector<T_y>& y) {
       for (size_t n = 1; n < y.size(); n++) {
         if (!(y[n] > y[n - 1])) {

--- a/stan/math/prim/mat/err/check_cholesky_factor.hpp
+++ b/stan/math/prim/mat/err/check_cholesky_factor.hpp
@@ -5,7 +5,6 @@
 #include <stan/math/prim/scal/err/check_positive.hpp>
 #include <stan/math/prim/scal/err/check_less_or_equal.hpp>
 #include <stan/math/prim/mat/err/check_lower_triangular.hpp>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -30,8 +29,8 @@ namespace stan {
      */
     template <typename T_y>
     inline void
-    check_cholesky_factor(const std::string& function,
-                          const std::string& name,
+    check_cholesky_factor(const char* function,
+                          const char* name,
                   const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>& y) {
       check_less_or_equal(function, "columns and rows of Cholesky factor",
                           y.cols(), y.rows());

--- a/stan/math/prim/mat/err/check_cholesky_factor_corr.hpp
+++ b/stan/math/prim/mat/err/check_cholesky_factor_corr.hpp
@@ -7,7 +7,6 @@
 #include <stan/math/prim/mat/err/check_square.hpp>
 #include <stan/math/prim/mat/err/constraint_tolerance.hpp>
 #include <stan/math/prim/mat/err/check_unit_vector.hpp>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -33,8 +32,8 @@ namespace stan {
      */
     template <typename T_y>
     void
-    check_cholesky_factor_corr(const std::string& function,
-                               const std::string& name,
+    check_cholesky_factor_corr(const char* function,
+                               const char* name,
                   const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>& y) {
       using Eigen::Dynamic;
       check_square(function, name, y);

--- a/stan/math/prim/mat/err/check_column_index.hpp
+++ b/stan/math/prim/mat/err/check_column_index.hpp
@@ -32,8 +32,8 @@ namespace stan {
      * @throw std::out_of_range if index is an invalid column index
      */
     template <typename T_y, int R, int C>
-    inline void check_column_index(const std::string& function,
-                                   const std::string& name,
+    inline void check_column_index(const char* function,
+                                   const char* name,
                                    const Eigen::Matrix<T_y, R, C>& y,
                                    size_t i) {
       if (i >= stan::error_index::value

--- a/stan/math/prim/mat/err/check_corr_matrix.hpp
+++ b/stan/math/prim/mat/err/check_corr_matrix.hpp
@@ -41,8 +41,8 @@ namespace stan {
      */
     template <typename T_y>
     inline void
-    check_corr_matrix(const std::string& function,
-                      const std::string& name,
+    check_corr_matrix(const char* function,
+                      const char* name,
         const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>& y) {
       using Eigen::Matrix;
 

--- a/stan/math/prim/mat/err/check_cov_matrix.hpp
+++ b/stan/math/prim/mat/err/check_cov_matrix.hpp
@@ -3,7 +3,6 @@
 
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/mat/err/check_pos_definite.hpp>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -28,8 +27,8 @@ namespace stan {
      */
     template <typename T_y>
     inline void
-    check_cov_matrix(const std::string& function,
-                     const std::string& name,
+    check_cov_matrix(const char* function,
+                     const char* name,
                   const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>& y) {
       check_pos_definite(function, name, y);
     }

--- a/stan/math/prim/mat/err/check_ldlt_factor.hpp
+++ b/stan/math/prim/mat/err/check_ldlt_factor.hpp
@@ -26,8 +26,8 @@ namespace stan {
      *   invalid.
      */
     template <typename T, int R, int C>
-    inline void check_ldlt_factor(const std::string& function,
-                                  const std::string& name,
+    inline void check_ldlt_factor(const char* function,
+                                  const char* name,
                                   LDLT_factor<T, R, C>& A) {
       if (!A.success()) {
         std::ostringstream msg;

--- a/stan/math/prim/mat/err/check_lower_triangular.hpp
+++ b/stan/math/prim/mat/err/check_lower_triangular.hpp
@@ -29,8 +29,8 @@ namespace stan {
      */
     template <typename T_y>
     inline void
-    check_lower_triangular(const std::string& function,
-                           const std::string& name,
+    check_lower_triangular(const char* function,
+                           const char* name,
                   const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>& y) {
       for (int n = 1; n < y.cols(); ++n) {
         for (int m = 0; m < n && m < y.rows(); ++m) {

--- a/stan/math/prim/mat/err/check_matching_dims.hpp
+++ b/stan/math/prim/mat/err/check_matching_dims.hpp
@@ -33,10 +33,10 @@ namespace stan {
      * if the dimensions of the matrices do not match
      */
     template <typename T1, typename T2, int R1, int C1, int R2, int C2>
-    inline void check_matching_dims(const std::string& function,
-                                    const std::string& name1,
+    inline void check_matching_dims(const char* function,
+                                    const char* name1,
                                     const Eigen::Matrix<T1, R1, C1>& y1,
-                                    const std::string& name2,
+                                    const char* name2,
                                     const Eigen::Matrix<T2, R2, C2>& y2) {
       check_size_match(function,
                        "Rows of ", name1, y1.rows(),
@@ -72,10 +72,10 @@ namespace stan {
      */
     template <bool check_compile, typename T1, typename T2,
               int R1, int C1, int R2, int C2>
-    inline void check_matching_dims(const std::string& function,
-                                    const std::string& name1,
+    inline void check_matching_dims(const char* function,
+                                    const char* name1,
                                     const Eigen::Matrix<T1, R1, C1>& y1,
-                                    const std::string& name2,
+                                    const char* name2,
                                     const Eigen::Matrix<T2, R2, C2>& y2) {
       if (check_compile && (R1 != R2 || C1 != C2)) {
         std::ostringstream msg;

--- a/stan/math/prim/mat/err/check_multiplicable.hpp
+++ b/stan/math/prim/mat/err/check_multiplicable.hpp
@@ -4,7 +4,6 @@
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/scal/err/check_size_match.hpp>
 #include <stan/math/prim/scal/err/check_positive_size.hpp>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -29,10 +28,10 @@ namespace stan {
      *   multiplicable or if either matrix is size 0 for either rows or columns
      */
     template <typename T1, typename T2>
-    inline void check_multiplicable(const std::string& function,
-                                    const std::string& name1,
+    inline void check_multiplicable(const char* function,
+                                    const char* name1,
                                     const T1& y1,
-                                    const std::string& name2,
+                                    const char* name2,
                                     const T2& y2) {
       check_positive_size(function, name1, "rows()", y1.rows());
       check_positive_size(function, name2, "cols()", y2.cols());

--- a/stan/math/prim/mat/err/check_ordered.hpp
+++ b/stan/math/prim/mat/err/check_ordered.hpp
@@ -6,8 +6,8 @@
 #include <stan/math/prim/scal/err/domain_error.hpp>
 #include <stan/math/prim/scal/meta/error_index.hpp>
 #include <sstream>
-#include <string>
 #include <vector>
+#include <string>
 
 namespace stan {
   namespace math {
@@ -27,8 +27,8 @@ namespace stan {
      *   values, or if any element is <code>NaN</code>.
      */
     template <typename T_y>
-    void check_ordered(const std::string& function,
-                       const std::string& name,
+    void check_ordered(const char* function,
+                       const char* name,
                        const Eigen::Matrix<T_y, Eigen::Dynamic, 1>& y) {
       using Eigen::Dynamic;
       using Eigen::Matrix;

--- a/stan/math/prim/mat/err/check_pos_definite.hpp
+++ b/stan/math/prim/mat/err/check_pos_definite.hpp
@@ -12,7 +12,6 @@
 #include <stan/math/prim/scal/err/check_positive_size.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/mat/fun/value_of_rec.hpp>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -31,8 +30,8 @@ namespace stan {
      * if it is not positive definite, or if any element is <code>NaN</code>.
      */
     template <typename T_y>
-    inline void check_pos_definite(const std::string& function,
-                                   const std::string& name,
+    inline void check_pos_definite(const char* function,
+                                   const char* name,
                                    const Eigen::Matrix<T_y, -1, -1>& y) {
       check_symmetric(function, name, y);
       check_positive_size(function, name, "rows", y.rows());
@@ -60,8 +59,8 @@ namespace stan {
      * positive definite.
      */
     template <typename Derived>
-    inline void check_pos_definite(const std::string& function,
-                                   const std::string& name,
+    inline void check_pos_definite(const char* function,
+                                   const char* name,
                                    const Eigen::LDLT<Derived>& cholesky) {
       if (cholesky.info() != Eigen::Success
           || !cholesky.isPositive()
@@ -84,8 +83,8 @@ namespace stan {
      * L matrix is not positive.
      */
     template <typename Derived>
-    inline void check_pos_definite(const std::string& function,
-                                   const std::string& name,
+    inline void check_pos_definite(const char* function,
+                                   const char* name,
                                    const Eigen::LLT<Derived>& cholesky) {
       if (cholesky.info() != Eigen::Success
           || !(cholesky.matrixLLT().diagonal().array() > 0.0).all())

--- a/stan/math/prim/mat/err/check_pos_semidefinite.hpp
+++ b/stan/math/prim/mat/err/check_pos_semidefinite.hpp
@@ -10,7 +10,6 @@
 #include <stan/math/prim/mat/meta/index_type.hpp>
 #include <stan/math/prim/mat/fun/value_of_rec.hpp>
 #include <sstream>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -32,8 +31,8 @@ namespace stan {
      */
     template <typename T_y>
     inline void
-    check_pos_semidefinite(const std::string& function,
-                           const std::string& name,
+    check_pos_semidefinite(const char* function,
+                           const char* name,
                   const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>& y) {
       check_symmetric(function, name, y);
       check_positive_size(function, name, "rows", y.rows());

--- a/stan/math/prim/mat/err/check_positive_ordered.hpp
+++ b/stan/math/prim/mat/err/check_positive_ordered.hpp
@@ -26,8 +26,8 @@ namespace stan {
      */
     template <typename T_y>
     void
-    check_positive_ordered(const std::string& function,
-                           const std::string& name,
+    check_positive_ordered(const char* function,
+                           const char* name,
                            const Eigen::Matrix<T_y, Eigen::Dynamic, 1>& y) {
       using Eigen::Dynamic;
       using Eigen::Matrix;

--- a/stan/math/prim/mat/err/check_range.hpp
+++ b/stan/math/prim/mat/err/check_range.hpp
@@ -25,12 +25,12 @@ namespace stan {
      *
      * @throw <code>std::out_of_range</code> if the index is not in range
      */
-    inline void check_range(const std::string& function,
-                            const std::string& name,
+    inline void check_range(const char* function,
+                            const char* name,
                             int max,
                             int index,
                             int nested_level,
-                            const std::string& error_msg) {
+                            const char* error_msg) {
       if ((index >= stan::error_index::value)
           && (index < max + stan::error_index::value))
         return;
@@ -56,11 +56,11 @@ namespace stan {
      *
      * @throw <code>std::out_of_range</code> if the index is not in range
      */
-    inline void check_range(const std::string& function,
-                            const std::string& name,
+    inline void check_range(const char* function,
+                            const char* name,
                             int max,
                             int index,
-                            const std::string& error_msg) {
+                            const char* error_msg) {
       if ((index >= stan::error_index::value)
           && (index < max + stan::error_index::value))
         return;
@@ -81,8 +81,8 @@ namespace stan {
      *
      * @throw <code>std::out_of_range</code> if the index is not in range
      */
-    inline void check_range(const std::string& function,
-                            const std::string& name,
+    inline void check_range(const char* function,
+                            const char* name,
                             int max,
                             int index) {
       if ((index >= stan::error_index::value)

--- a/stan/math/prim/mat/err/check_row_index.hpp
+++ b/stan/math/prim/mat/err/check_row_index.hpp
@@ -27,8 +27,8 @@ namespace stan {
      * @throw <code>std::out_of_range</code> if the index is out of range.
      */
     template <typename T_y, int R, int C>
-    inline void check_row_index(const std::string& function,
-                                const std::string& name,
+    inline void check_row_index(const char* function,
+                                const char* name,
                                 const Eigen::Matrix<T_y, R, C>& y,
                                 size_t i) {
       if (i >= stan::error_index::value

--- a/stan/math/prim/mat/err/check_simplex.hpp
+++ b/stan/math/prim/mat/err/check_simplex.hpp
@@ -36,8 +36,8 @@ namespace stan {
      *   simplex or if any element is <code>NaN</code>.
      */
     template <typename T_prob>
-    void check_simplex(const std::string& function,
-                       const std::string& name,
+    void check_simplex(const char* function,
+                       const char* name,
                        const Eigen::Matrix<T_prob, Eigen::Dynamic, 1>& theta) {
       using Eigen::Dynamic;
       using Eigen::Matrix;

--- a/stan/math/prim/mat/err/check_spsd_matrix.hpp
+++ b/stan/math/prim/mat/err/check_spsd_matrix.hpp
@@ -6,7 +6,6 @@
 #include <stan/math/prim/mat/err/check_pos_semidefinite.hpp>
 #include <stan/math/prim/mat/err/check_symmetric.hpp>
 #include <stan/math/prim/mat/err/check_square.hpp>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -27,8 +26,8 @@ namespace stan {
      */
     template <typename T_y>
     inline void
-    check_spsd_matrix(const std::string& function,
-                      const std::string& name,
+    check_spsd_matrix(const char* function,
+                      const char* name,
                   const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>& y) {
       check_square(function, name, y);
       check_positive_size(function, name, "rows()", y.rows());

--- a/stan/math/prim/mat/err/check_square.hpp
+++ b/stan/math/prim/mat/err/check_square.hpp
@@ -4,7 +4,6 @@
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/scal/err/check_size_match.hpp>
 #include <sstream>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -25,8 +24,8 @@ namespace stan {
      */
     template <typename T_y>
     inline void
-    check_square(const std::string& function,
-                 const std::string& name,
+    check_square(const char* function,
+                 const char* name,
                  const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>& y) {
       check_size_match(function,
                        "Expecting a square matrix; rows of ", name, y.rows(),

--- a/stan/math/prim/mat/err/check_std_vector_index.hpp
+++ b/stan/math/prim/mat/err/check_std_vector_index.hpp
@@ -26,8 +26,8 @@ namespace stan {
      * @throw <code>std::out_of_range</code> if the index is out of range.
      */
     template <typename T>
-    inline void check_std_vector_index(const std::string& function,
-                                       const std::string& name,
+    inline void check_std_vector_index(const char* function,
+                                       const char* name,
                                        const std::vector<T>& y,
                                        int i) {
       if (i >= static_cast<int>(stan::error_index::value)

--- a/stan/math/prim/mat/err/check_symmetric.hpp
+++ b/stan/math/prim/mat/err/check_symmetric.hpp
@@ -32,8 +32,8 @@ namespace stan {
      */
     template <typename T_y>
     inline void
-    check_symmetric(const std::string& function,
-                    const std::string& name,
+    check_symmetric(const char* function,
+                    const char* name,
                   const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>& y) {
       check_square(function, name, y);
 

--- a/stan/math/prim/mat/err/check_unit_vector.hpp
+++ b/stan/math/prim/mat/err/check_unit_vector.hpp
@@ -31,8 +31,8 @@ namespace stan {
      *   vector or if any element is <code>NaN</code>.
      */
     template <typename T_prob>
-    void check_unit_vector(const std::string& function,
-                           const std::string& name,
+    void check_unit_vector(const char* function,
+                           const char* name,
                            const Eigen::Matrix<T_prob,
                              Eigen::Dynamic, 1>& theta) {
       check_nonzero_size(function, name, theta);

--- a/stan/math/prim/mat/err/check_vector.hpp
+++ b/stan/math/prim/mat/err/check_vector.hpp
@@ -29,8 +29,8 @@ namespace stan {
      *   vector.
      */
     template <typename T, int R, int C>
-    inline void check_vector(const std::string& function,
-                             const std::string& name,
+    inline void check_vector(const char* function,
+                             const char* name,
                              const Eigen::Matrix<T, R, C>& x) {
       if (R == 1)
         return;

--- a/stan/math/prim/mat/err/validate_non_negative_index.hpp
+++ b/stan/math/prim/mat/err/validate_non_negative_index.hpp
@@ -9,8 +9,8 @@ namespace stan {
   namespace math {
 
     inline void
-    validate_non_negative_index(const std::string& var_name,
-                                const std::string& expr,
+    validate_non_negative_index(const char* var_name,
+                                const char* expr,
                                 int val) {
       if (val < 0) {
         std::stringstream msg;

--- a/stan/math/prim/mat/fun/get_base1.hpp
+++ b/stan/math/prim/mat/fun/get_base1.hpp
@@ -3,7 +3,6 @@
 
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/mat/err/check_range.hpp>
-#include <string>
 #include <vector>
 
 namespace stan {
@@ -28,7 +27,7 @@ namespace stan {
     inline const T&
     get_base1(const std::vector<T>& x,
               size_t i,
-              const std::string& error_msg,
+              const char* error_msg,
               size_t idx) {
       check_range("[]", "x", x.size(), i, idx, error_msg);
       return x[i - 1];
@@ -55,7 +54,7 @@ namespace stan {
     get_base1(const std::vector<std::vector<T> >& x,
               size_t i1,
               size_t i2,
-              const std::string& error_msg,
+              const char* error_msg,
               size_t idx) {
       check_range("[]", "x", x.size(), i1, idx, error_msg);
       return get_base1(x[i1 - 1], i2, error_msg, idx + 1);
@@ -84,7 +83,7 @@ namespace stan {
               size_t i1,
               size_t i2,
               size_t i3,
-              const std::string& error_msg,
+              const char* error_msg,
               size_t idx) {
       check_range("[]", "x", x.size(), i1, idx, error_msg);
       return get_base1(x[i1 - 1], i2, i3, error_msg, idx + 1);
@@ -115,7 +114,7 @@ namespace stan {
               size_t i2,
               size_t i3,
               size_t i4,
-              const std::string& error_msg,
+              const char* error_msg,
               size_t idx) {
       check_range("[]", "x", x.size(), i1, idx, error_msg);
       return get_base1(x[i1 - 1], i2, i3, i4, error_msg, idx + 1);
@@ -149,7 +148,7 @@ namespace stan {
               size_t i3,
               size_t i4,
               size_t i5,
-              const std::string& error_msg,
+              const char* error_msg,
               size_t idx) {
       check_range("[]", "x", x.size(), i1, idx, error_msg);
       return get_base1(x[i1 - 1], i2, i3, i4, i5, error_msg, idx + 1);
@@ -185,7 +184,7 @@ namespace stan {
               size_t i4,
               size_t i5,
               size_t i6,
-              const std::string& error_msg,
+              const char* error_msg,
               size_t idx) {
       check_range("[]", "x", x.size(), i1, idx, error_msg);
       return get_base1(x[i1 - 1], i2, i3, i4, i5, i6, error_msg, idx + 1);
@@ -223,7 +222,7 @@ namespace stan {
               size_t i5,
               size_t i6,
               size_t i7,
-              const std::string& error_msg,
+              const char* error_msg,
               size_t idx) {
       check_range("[]", "x", x.size(), i1, idx, error_msg);
       return get_base1(x[i1 - 1], i2, i3, i4, i5, i6, i7, error_msg, idx + 1);
@@ -264,7 +263,7 @@ namespace stan {
               size_t i6,
               size_t i7,
               size_t i8,
-              const std::string& error_msg,
+              const char* error_msg,
               size_t idx) {
       check_range("[]", "x", x.size(), i1, idx, error_msg);
       return get_base1(x[i1 - 1], i2, i3, i4, i5, i6, i7, i8, error_msg,
@@ -295,7 +294,7 @@ namespace stan {
     inline Eigen::Matrix<T, 1, Eigen::Dynamic>
     get_base1(const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& x,
               size_t m,
-              const std::string& error_msg,
+              const char* error_msg,
               size_t idx) {
       check_range("[]", "rows of x", x.rows(), m, idx, error_msg);
       return x.block(m - 1, 0, 1, x.cols());
@@ -323,7 +322,7 @@ namespace stan {
     get_base1(const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& x,
               size_t m,
               size_t n,
-              const std::string& error_msg,
+              const char* error_msg,
               size_t idx) {
       check_range("[]", "rows of x", x.rows(), m, idx, error_msg);
       check_range("[]", "cols of x", x.cols(), n, idx + 1, error_msg);
@@ -349,7 +348,7 @@ namespace stan {
     inline
     const T& get_base1(const Eigen::Matrix<T, Eigen::Dynamic, 1>& x,
                        size_t m,
-                       const std::string& error_msg,
+                       const char* error_msg,
                        size_t idx) {
       check_range("[]", "x", x.size(), m, idx, error_msg);
       return x(m - 1);
@@ -374,7 +373,7 @@ namespace stan {
     inline const T&
     get_base1(const Eigen::Matrix<T, 1, Eigen::Dynamic>& x,
               size_t n,
-              const std::string& error_msg,
+              const char* error_msg,
               size_t idx) {
       check_range("[]", "x", x.size(), n, idx, error_msg);
       return x(n - 1);

--- a/stan/math/prim/mat/fun/get_base1_lhs.hpp
+++ b/stan/math/prim/mat/fun/get_base1_lhs.hpp
@@ -3,7 +3,6 @@
 
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/mat/err/check_range.hpp>
-#include <string>
 #include <vector>
 
 namespace stan {
@@ -28,7 +27,7 @@ namespace stan {
     inline
     T& get_base1_lhs(std::vector<T>& x,
                      size_t i,
-                     const std::string& error_msg,
+                     const char* error_msg,
                      size_t idx) {
       check_range("[]", "x", x.size(), i, idx, error_msg);
       return x[i - 1];
@@ -55,7 +54,7 @@ namespace stan {
     T& get_base1_lhs(std::vector<std::vector<T> >& x,
                      size_t i1,
                      size_t i2,
-                     const std::string& error_msg,
+                     const char* error_msg,
                      size_t idx) {
       check_range("[]", "x", x.size(), i1, idx, error_msg);
       return get_base1_lhs(x[i1 - 1], i2, error_msg, idx+1);
@@ -84,7 +83,7 @@ namespace stan {
                      size_t i1,
                      size_t i2,
                      size_t i3,
-                     const std::string& error_msg,
+                     const char* error_msg,
                      size_t idx) {
       check_range("[]", "x", x.size(), i1, idx, error_msg);
       return get_base1_lhs(x[i1 - 1], i2, i3, error_msg, idx + 1);
@@ -116,7 +115,7 @@ namespace stan {
                      size_t i2,
                      size_t i3,
                      size_t i4,
-                     const std::string& error_msg,
+                     const char* error_msg,
                      size_t idx) {
       check_range("[]", "x", x.size(), i1, idx, error_msg);
       return get_base1_lhs(x[i1 - 1], i2, i3, i4, error_msg, idx + 1);
@@ -150,7 +149,7 @@ namespace stan {
                      size_t i3,
                      size_t i4,
                      size_t i5,
-                     const std::string& error_msg,
+                     const char* error_msg,
                      size_t idx) {
       check_range("[]", "x", x.size(), i1, idx, error_msg);
       return get_base1_lhs(x[i1 - 1], i2, i3, i4, i5, error_msg, idx + 1);
@@ -186,7 +185,7 @@ namespace stan {
                      size_t i4,
                      size_t i5,
                      size_t i6,
-                     const std::string& error_msg,
+                     const char* error_msg,
                      size_t idx) {
       check_range("[]", "x", x.size(), i1, idx, error_msg);
       return get_base1_lhs(x[i1 - 1], i2, i3, i4, i5, i6, error_msg, idx + 1);
@@ -225,7 +224,7 @@ namespace stan {
                      size_t i5,
                      size_t i6,
                      size_t i7,
-                     const std::string& error_msg,
+                     const char* error_msg,
                      size_t idx) {
       check_range("[]", "x", x.size(), i1, idx, error_msg);
       return get_base1_lhs(x[i1 - 1], i2, i3, i4, i5, i6, i7, error_msg,
@@ -267,7 +266,7 @@ namespace stan {
                      size_t i6,
                      size_t i7,
                      size_t i8,
-                     const std::string& error_msg,
+                     const char* error_msg,
                      size_t idx) {
       check_range("[]", "x", x.size(), i1, idx, error_msg);
       return get_base1_lhs(x[i1 - 1], i2, i3, i4, i5, i6, i7, i8,
@@ -299,7 +298,7 @@ namespace stan {
     Eigen::Block<Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> >
     get_base1_lhs(Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& x,
                   size_t m,
-                  const std::string& error_msg,
+                  const char* error_msg,
                   size_t idx) {
       check_range("[]", "rows of x", x.rows(), m, idx, error_msg);
       return x.block(m - 1, 0, 1, x.cols());
@@ -327,7 +326,7 @@ namespace stan {
     T& get_base1_lhs(Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& x,
                      size_t m,
                      size_t n,
-                     const std::string& error_msg,
+                     const char* error_msg,
                      size_t idx) {
       check_range("[]", "rows of x", x.rows(), m, idx, error_msg);
       check_range("[]", "cols of x", x.cols(), n, idx + 1, error_msg);
@@ -353,7 +352,7 @@ namespace stan {
     inline
     T& get_base1_lhs(Eigen::Matrix<T, Eigen::Dynamic, 1>& x,
                      size_t m,
-                     const std::string& error_msg,
+                     const char* error_msg,
                      size_t idx) {
       check_range("[]", "x", x.size(), m, idx, error_msg);
       return x(m - 1);
@@ -378,7 +377,7 @@ namespace stan {
     inline
     T& get_base1_lhs(Eigen::Matrix<T, 1, Eigen::Dynamic>& x,
                      size_t n,
-                     const std::string& error_msg,
+                     const char* error_msg,
                      size_t idx) {
       check_range("[]", "x", x.size(), n, idx, error_msg);
       return x(n - 1);

--- a/stan/math/prim/mat/fun/to_matrix.hpp
+++ b/stan/math/prim/mat/fun/to_matrix.hpp
@@ -5,7 +5,6 @@
 #include <stan/math/prim/scal/err/check_size_match.hpp>
 #include <stan/math/prim/scal/err/invalid_argument.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
-#include <string>
 #include <vector>
 
 namespace stan {
@@ -94,7 +93,7 @@ namespace stan {
     template <typename T, int R, int C>
     inline Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>
     to_matrix(const Eigen::Matrix<T, R, C>& x, int m, int n) {
-      static const std::string function = "to_matrix(matrix)";
+      static const char* function = "to_matrix(matrix)";
       check_size_match(function, "rows * columns", m * n, "vector size",
                        x.size());
       Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> y = x;
@@ -117,7 +116,7 @@ namespace stan {
     template <typename T>
     inline Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>
     to_matrix(const std::vector<T>& x, int m, int n) {
-      static const std::string function = "to_matrix(array)";
+      static const char* function = "to_matrix(array)";
       check_size_match(function, "rows * columns", m * n, "vector size",
                        x.size());
       return Eigen::Map<const
@@ -138,7 +137,7 @@ namespace stan {
      */
     inline Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>
     to_matrix(const std::vector<int>& x, int m, int n) {
-      static const std::string function = "to_matrix(array)";
+      static const char* function = "to_matrix(array)";
       int size = x.size();
       check_size_match(function, "rows * columns", m * n,
                        "vector size", size);

--- a/stan/math/prim/mat/prob/bernoulli_logit_glm_lpmf.hpp
+++ b/stan/math/prim/mat/prob/bernoulli_logit_glm_lpmf.hpp
@@ -17,7 +17,6 @@
 #include <boost/random/bernoulli_distribution.hpp>
 #include <boost/random/variate_generator.hpp>
 #include <cmath>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -48,7 +47,7 @@ namespace stan {
     typename return_type<T_x, T_beta, T_alpha>::type
     bernoulli_logit_glm_lpmf(const T_n &n, const T_x &x, const T_beta &beta,
                              const T_alpha &alpha) {
-      static const std::string function = "bernoulli_logit_glm_lpmf";
+      static const char* function = "bernoulli_logit_glm_lpmf";
       typedef typename stan::partials_return_type<T_n, T_x, T_beta,
                                                   T_alpha>::type
         T_partials_return;

--- a/stan/math/prim/mat/prob/categorical_logit_lpmf.hpp
+++ b/stan/math/prim/mat/prob/categorical_logit_lpmf.hpp
@@ -9,7 +9,6 @@
 #include <stan/math/prim/mat/fun/sum.hpp>
 #include <stan/math/prim/scal/meta/include_summand.hpp>
 #include <boost/math/tools/promotion.hpp>
-#include <string>
 #include <vector>
 
 namespace stan {
@@ -22,7 +21,7 @@ namespace stan {
     categorical_logit_lpmf(int n,
                           const Eigen::Matrix<T_prob, Eigen::Dynamic, 1>&
                           beta) {
-      static const std::string function = "categorical_logit_lpmf";
+      static const char* function = "categorical_logit_lpmf";
 
       check_bounded(function, "categorical outcome out of support", n,
                     1, beta.size());
@@ -50,7 +49,7 @@ namespace stan {
     categorical_logit_lpmf(const std::vector<int>& ns,
                           const Eigen::Matrix<T_prob, Eigen::Dynamic, 1>&
                           beta) {
-      static const std::string function = "categorical_logit_lpmf";
+      static const char* function = "categorical_logit_lpmf";
 
       for (size_t k = 0; k < ns.size(); ++k)
         check_bounded(function, "categorical outcome out of support",

--- a/stan/math/prim/mat/prob/categorical_logit_rng.hpp
+++ b/stan/math/prim/mat/prob/categorical_logit_rng.hpp
@@ -8,7 +8,6 @@
 #include <stan/math/prim/mat/fun/cumulative_sum.hpp>
 #include <stan/math/prim/mat/fun/softmax.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -32,7 +31,7 @@ namespace stan {
       using boost::variate_generator;
       using boost::uniform_01;
 
-      static const std::string function = "categorical_logit_rng";
+      static const char* function = "categorical_logit_rng";
 
       check_finite(function, "Log odds parameter", beta);
 

--- a/stan/math/prim/mat/prob/categorical_lpmf.hpp
+++ b/stan/math/prim/mat/prob/categorical_lpmf.hpp
@@ -12,7 +12,6 @@
 #include <boost/random/uniform_01.hpp>
 #include <boost/random/variate_generator.hpp>
 #include <cmath>
-#include <string>
 #include <vector>
 
 namespace stan {
@@ -24,7 +23,7 @@ namespace stan {
     typename boost::math::tools::promote_args<T_prob>::type
     categorical_lpmf(int n,
                     const Eigen::Matrix<T_prob, Eigen::Dynamic, 1>& theta) {
-      static const std::string function = "categorical_lpmf";
+      static const char* function = "categorical_lpmf";
 
       using boost::math::tools::promote_args;
       using std::log;
@@ -54,7 +53,7 @@ namespace stan {
     typename boost::math::tools::promote_args<T_prob>::type
     categorical_lpmf(const std::vector<int>& ns,
                     const Eigen::Matrix<T_prob, Eigen::Dynamic, 1>& theta) {
-      static const std::string function = "categorical_lpmf";
+      static const char* function = "categorical_lpmf";
 
       using boost::math::tools::promote_args;
       using std::log;

--- a/stan/math/prim/mat/prob/categorical_rng.hpp
+++ b/stan/math/prim/mat/prob/categorical_rng.hpp
@@ -11,7 +11,6 @@
 #include <stan/math/prim/mat/meta/index_type.hpp>
 #include <stan/math/prim/scal/fun/constants.hpp>
 #include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -23,7 +22,7 @@ namespace stan {
       using boost::variate_generator;
       using boost::uniform_01;
 
-      static const std::string function = "categorical_rng";
+      static const char* function = "categorical_rng";
 
       check_simplex(function, "Probabilities parameter", theta);
 

--- a/stan/math/prim/mat/prob/dirichlet_lpmf.hpp
+++ b/stan/math/prim/mat/prob/dirichlet_lpmf.hpp
@@ -10,7 +10,6 @@
 #include <stan/math/prim/scal/fun/multiply_log.hpp>
 #include <stan/math/prim/scal/fun/constants.hpp>
 #include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -46,7 +45,7 @@ namespace stan {
     dirichlet_lpmf(const Eigen::Matrix<T_prob, Eigen::Dynamic, 1>& theta,
                   const Eigen::Matrix
                   <T_prior_sample_size, Eigen::Dynamic, 1>& alpha) {
-      static const std::string function = "dirichlet_lpmf";
+      static const char* function = "dirichlet_lpmf";
       using boost::math::lgamma;
       using boost::math::tools::promote_args;
 

--- a/stan/math/prim/mat/prob/gaussian_dlm_obs_lpdf.hpp
+++ b/stan/math/prim/mat/prob/gaussian_dlm_obs_lpdf.hpp
@@ -24,7 +24,6 @@
 #include <stan/math/prim/scal/fun/constants.hpp>
 #include <stan/math/prim/scal/meta/include_summand.hpp>
 #include <stan/math/prim/scal/meta/return_type.hpp>
-#include <string>
 
 /*
   TODO: time-varying system matrices
@@ -89,7 +88,7 @@ namespace stan {
                          const Eigen::Matrix<T_m0, Eigen::Dynamic, 1>& m0,
                          const Eigen::Matrix
                          <T_C0, Eigen::Dynamic, Eigen::Dynamic>& C0) {
-      static const std::string function = "gaussian_dlm_obs_lpdf";
+      static const char* function = "gaussian_dlm_obs_lpdf";
       typedef typename return_type<
         T_y,
         typename return_type<T_F, T_G, T_V, T_W, T_m0, T_C0>::type>::type T_lp;
@@ -272,7 +271,7 @@ namespace stan {
                          const Eigen::Matrix<T_m0, Eigen::Dynamic, 1>& m0,
                          const Eigen::Matrix
                          <T_C0, Eigen::Dynamic, Eigen::Dynamic>& C0) {
-      static const std::string function = "gaussian_dlm_obs_lpdf";
+      static const char* function = "gaussian_dlm_obs_lpdf";
       typedef
         typename return_type
         <T_y, typename return_type<T_F, T_G, T_V, T_W, T_m0, T_C0>::type>::type

--- a/stan/math/prim/mat/prob/inv_wishart_lpdf.hpp
+++ b/stan/math/prim/mat/prob/inv_wishart_lpdf.hpp
@@ -12,7 +12,6 @@
 #include <stan/math/prim/scal/meta/include_summand.hpp>
 #include <stan/math/prim/scal/fun/lmgamma.hpp>
 #include <stan/math/prim/mat/fun/trace.hpp>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -51,7 +50,7 @@ namespace stan {
                      const T_dof& nu,
                      const Eigen::Matrix
                      <T_scale, Eigen::Dynamic, Eigen::Dynamic>& S) {
-      static const std::string function = "inv_wishart_lpdf";
+      static const char* function = "inv_wishart_lpdf";
 
       using boost::math::tools::promote_args;
       using Eigen::Dynamic;

--- a/stan/math/prim/mat/prob/inv_wishart_rng.hpp
+++ b/stan/math/prim/mat/prob/inv_wishart_rng.hpp
@@ -6,7 +6,6 @@
 #include <stan/math/prim/mat/meta/index_type.hpp>
 #include <stan/math/prim/mat/prob/wishart_rng.hpp>
 #include <stan/math/prim/scal/err/check_greater.hpp>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -14,7 +13,7 @@ namespace stan {
     template <class RNG>
     inline Eigen::MatrixXd
     inv_wishart_rng(double nu, const Eigen::MatrixXd& S, RNG& rng) {
-      static const std::string function = "inv_wishart_rng";
+      static const char* function = "inv_wishart_rng";
 
       using Eigen::MatrixXd;
       typename index_type<MatrixXd>::type k = S.rows();

--- a/stan/math/prim/mat/prob/lkj_corr_cholesky_lpdf.hpp
+++ b/stan/math/prim/mat/prob/lkj_corr_cholesky_lpdf.hpp
@@ -44,7 +44,6 @@
 #include <stan/math/prim/mat/fun/cov_matrix_free_lkj.hpp>
 #include <stan/math/prim/mat/prob/lkj_corr_log.hpp>
 #include <stan/math/prim/mat/fun/multiply.hpp>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -57,7 +56,7 @@ namespace stan {
     lkj_corr_cholesky_lpdf(const Eigen::Matrix
                           <T_covar, Eigen::Dynamic, Eigen::Dynamic>& L,
                           const T_shape& eta) {
-      static const std::string function = "lkj_corr_cholesky_lpdf";
+      static const char* function = "lkj_corr_cholesky_lpdf";
 
       using boost::math::tools::promote_args;
 

--- a/stan/math/prim/mat/prob/lkj_corr_cholesky_rng.hpp
+++ b/stan/math/prim/mat/prob/lkj_corr_cholesky_rng.hpp
@@ -43,7 +43,6 @@
 #include <stan/math/prim/mat/fun/cov_matrix_free.hpp>
 #include <stan/math/prim/mat/fun/cov_matrix_constrain_lkj.hpp>
 #include <stan/math/prim/mat/fun/cov_matrix_free_lkj.hpp>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -53,7 +52,7 @@ namespace stan {
     lkj_corr_cholesky_rng(size_t K,
                           double eta,
                           RNG& rng) {
-      static const std::string function = "lkj_corr_cholesky_rng";
+      static const char* function = "lkj_corr_cholesky_rng";
 
       check_positive(function, "Shape parameter", eta);
 

--- a/stan/math/prim/mat/prob/lkj_corr_lpdf.hpp
+++ b/stan/math/prim/mat/prob/lkj_corr_lpdf.hpp
@@ -44,7 +44,6 @@
 #include <stan/math/prim/mat/fun/cov_matrix_free.hpp>
 #include <stan/math/prim/mat/fun/cov_matrix_constrain_lkj.hpp>
 #include <stan/math/prim/mat/fun/cov_matrix_free_lkj.hpp>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -84,7 +83,7 @@ namespace stan {
     typename boost::math::tools::promote_args<T_y, T_shape>::type
     lkj_corr_lpdf(const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>& y,
                  const T_shape& eta) {
-      static const std::string function = "lkj_corr_lpdf";
+      static const char* function = "lkj_corr_lpdf";
 
       using boost::math::tools::promote_args;
 

--- a/stan/math/prim/mat/prob/lkj_corr_rng.hpp
+++ b/stan/math/prim/mat/prob/lkj_corr_rng.hpp
@@ -4,7 +4,6 @@
 #include <stan/math/prim/mat/fun/multiply_lower_tri_self_transpose.hpp>
 #include <stan/math/prim/mat/prob/lkj_corr_cholesky_rng.hpp>
 #include <stan/math/prim/scal/err/check_positive.hpp>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -25,7 +24,7 @@ namespace stan {
     template <class RNG>
     inline
     Eigen::MatrixXd lkj_corr_rng(size_t K, double eta, RNG& rng) {
-      static const std::string function = "lkj_corr_rng";
+      static const char* function = "lkj_corr_rng";
       check_positive(function, "Shape parameter", eta);
       return multiply_lower_tri_self_transpose(lkj_corr_cholesky_rng(K, eta,
                                                                      rng));

--- a/stan/math/prim/mat/prob/lkj_cov_lpdf.hpp
+++ b/stan/math/prim/mat/prob/lkj_cov_lpdf.hpp
@@ -9,7 +9,6 @@
 #include <stan/math/prim/scal/prob/lognormal_lpdf.hpp>
 #include <stan/math/prim/mat/prob/lkj_corr_lpdf.hpp>
 #include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -24,7 +23,7 @@ namespace stan {
                 const Eigen::Matrix<T_loc, Eigen::Dynamic, 1>& mu,
                 const Eigen::Matrix<T_scale, Eigen::Dynamic, 1>& sigma,
                 const T_shape& eta) {
-      static const std::string function = "lkj_cov_lpdf";
+      static const char* function = "lkj_cov_lpdf";
 
       using boost::math::tools::promote_args;
 
@@ -82,7 +81,7 @@ namespace stan {
                 const T_loc& mu,
                 const T_scale& sigma,
                 const T_shape& eta) {
-      static const std::string function = "lkj_cov_lpdf";
+      static const char* function = "lkj_cov_lpdf";
 
       using boost::math::tools::promote_args;
 

--- a/stan/math/prim/mat/prob/matrix_normal_prec_lpdf.hpp
+++ b/stan/math/prim/mat/prob/matrix_normal_prec_lpdf.hpp
@@ -15,7 +15,6 @@
 #include <stan/math/prim/mat/fun/trace_gen_quad_form.hpp>
 #include <stan/math/prim/scal/fun/constants.hpp>
 #include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -48,7 +47,7 @@ namespace stan {
                            <T_Sigma, Eigen::Dynamic, Eigen::Dynamic>& Sigma,
                            const Eigen::Matrix
                            <T_D, Eigen::Dynamic, Eigen::Dynamic>& D) {
-      static const std::string function = "matrix_normal_prec_lpdf";
+      static const char* function = "matrix_normal_prec_lpdf";
       typename
         boost::math::tools::promote_args<T_y, T_Mu, T_Sigma, T_D>::type lp(0.0);
 

--- a/stan/math/prim/mat/prob/multi_gp_cholesky_lpdf.hpp
+++ b/stan/math/prim/mat/prob/multi_gp_cholesky_lpdf.hpp
@@ -12,7 +12,6 @@
 #include <stan/math/prim/mat/fun/multiply.hpp>
 #include <stan/math/prim/mat/fun/row.hpp>
 #include <stan/math/prim/mat/fun/sum.hpp>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -44,7 +43,7 @@ namespace stan {
                           const Eigen::Matrix
                           <T_covar, Eigen::Dynamic, Eigen::Dynamic>& L,
                           const Eigen::Matrix<T_w, Eigen::Dynamic, 1>& w) {
-      static const std::string function = "multi_gp_cholesky_lpdf";
+      static const char* function = "multi_gp_cholesky_lpdf";
       typedef
         typename boost::math::tools::promote_args<T_y, T_covar, T_w>::type T_lp;
       T_lp lp(0.0);

--- a/stan/math/prim/mat/prob/multi_gp_lpdf.hpp
+++ b/stan/math/prim/mat/prob/multi_gp_lpdf.hpp
@@ -15,7 +15,6 @@
 #include <stan/math/prim/mat/fun/trace_gen_inv_quad_form_ldlt.hpp>
 #include <stan/math/prim/scal/fun/constants.hpp>
 #include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -44,7 +43,7 @@ namespace stan {
                  const Eigen::Matrix
                  <T_covar, Eigen::Dynamic, Eigen::Dynamic>& Sigma,
                  const Eigen::Matrix<T_w, Eigen::Dynamic, 1>& w) {
-      static const std::string function = "multi_gp_lpdf";
+      static const char* function = "multi_gp_lpdf";
       typedef typename boost::math::tools::promote_args<T_y, T_covar, T_w>::type
         T_lp;
       T_lp lp(0.0);

--- a/stan/math/prim/mat/prob/multi_normal_cholesky_lpdf.hpp
+++ b/stan/math/prim/mat/prob/multi_normal_cholesky_lpdf.hpp
@@ -22,7 +22,6 @@
 #include <stan/math/prim/scal/meta/return_type.hpp>
 #include <boost/random/normal_distribution.hpp>
 #include <boost/random/variate_generator.hpp>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -49,7 +48,7 @@ namespace stan {
     multi_normal_cholesky_lpdf(const T_y& y,
                               const T_loc& mu,
                               const T_covar& L) {
-      static const std::string function = "multi_normal_cholesky_lpdf";
+      static const char* function = "multi_normal_cholesky_lpdf";
       typedef typename scalar_type<T_covar>::type T_covar_elem;
       typedef typename return_type<T_y, T_loc, T_covar>::type lp_type;
       lp_type lp(0.0);

--- a/stan/math/prim/mat/prob/multi_normal_cholesky_rng.hpp
+++ b/stan/math/prim/mat/prob/multi_normal_cholesky_rng.hpp
@@ -20,7 +20,6 @@
 
 #include <stan/math/prim/scal/fun/constants.hpp>
 #include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -33,7 +32,7 @@ namespace stan {
       using boost::variate_generator;
       using boost::normal_distribution;
 
-      static const std::string function = "multi_normal_cholesky_rng";
+      static const char* function = "multi_normal_cholesky_rng";
       check_finite(function, "Location parameter", mu);
 
       variate_generator<RNG&, normal_distribution<> >

--- a/stan/math/prim/mat/prob/multi_normal_lpdf.hpp
+++ b/stan/math/prim/mat/prob/multi_normal_lpdf.hpp
@@ -16,7 +16,6 @@
 #include <stan/math/prim/scal/meta/include_summand.hpp>
 #include <boost/random/normal_distribution.hpp>
 #include <boost/random/variate_generator.hpp>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -27,7 +26,7 @@ namespace stan {
     multi_normal_lpdf(const T_y& y,
                      const T_loc& mu,
                      const T_covar& Sigma) {
-      static const std::string function = "multi_normal_lpdf";
+      static const char* function = "multi_normal_lpdf";
       typedef typename scalar_type<T_covar>::type T_covar_elem;
       typedef typename return_type<T_y, T_loc, T_covar>::type lp_type;
       lp_type lp(0.0);

--- a/stan/math/prim/mat/prob/multi_normal_prec_lpdf.hpp
+++ b/stan/math/prim/mat/prob/multi_normal_prec_lpdf.hpp
@@ -25,7 +25,6 @@
 #include <stan/math/prim/scal/meta/max_size_mvt.hpp>
 #include <stan/math/prim/scal/meta/include_summand.hpp>
 #include <stan/math/prim/scal/meta/return_type.hpp>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -36,7 +35,7 @@ namespace stan {
     multi_normal_prec_lpdf(const T_y& y,
                           const T_loc& mu,
                           const T_covar& Sigma) {
-      static const std::string function = "multi_normal_prec_lpdf";
+      static const char* function = "multi_normal_prec_lpdf";
       typedef typename scalar_type<T_covar>::type T_covar_elem;
       typedef typename return_type<T_y, T_loc, T_covar>::type lp_type;
       lp_type lp(0.0);

--- a/stan/math/prim/mat/prob/multi_normal_rng.hpp
+++ b/stan/math/prim/mat/prob/multi_normal_rng.hpp
@@ -11,7 +11,6 @@
 #include <stan/math/prim/mat/fun/log_determinant_ldlt.hpp>
 #include <boost/random/normal_distribution.hpp>
 #include <boost/random/variate_generator.hpp>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -38,7 +37,7 @@ namespace stan {
       using boost::variate_generator;
       using boost::normal_distribution;
 
-      static const std::string function = "multi_normal_rng";
+      static const char* function = "multi_normal_rng";
 
       check_positive(function, "Covariance matrix rows", S.rows());
       check_symmetric(function, "Covariance matrix", S);

--- a/stan/math/prim/mat/prob/multi_student_t_lpdf.hpp
+++ b/stan/math/prim/mat/prob/multi_student_t_lpdf.hpp
@@ -20,7 +20,6 @@
 #include <boost/random/variate_generator.hpp>
 #include <cmath>
 #include <cstdlib>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -38,7 +37,7 @@ namespace stan {
                         const T_dof& nu,
                         const T_loc& mu,
                         const T_scale& Sigma) {
-      static const std::string function = "multi_student_t";
+      static const char* function = "multi_student_t";
 
       using boost::math::lgamma;
       using std::log;

--- a/stan/math/prim/mat/prob/multi_student_t_rng.hpp
+++ b/stan/math/prim/mat/prob/multi_student_t_rng.hpp
@@ -18,7 +18,6 @@
 #include <stan/math/prim/scal/prob/inv_gamma_rng.hpp>
 #include <stan/math/prim/scal/meta/include_summand.hpp>
 #include <cstdlib>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -29,7 +28,7 @@ namespace stan {
           const Eigen::Matrix<double, Eigen::Dynamic, 1>& mu,
           const Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>& s,
           RNG& rng) {
-      static const std::string function = "multi_student_t_rng";
+      static const char* function = "multi_student_t_rng";
 
       check_finite(function, "Location parameter", mu);
       check_symmetric(function, "Scale parameter", s);

--- a/stan/math/prim/mat/prob/multinomial_lpmf.hpp
+++ b/stan/math/prim/mat/prob/multinomial_lpmf.hpp
@@ -12,7 +12,6 @@
 #include <stan/math/prim/scal/fun/constants.hpp>
 #include <stan/math/prim/scal/meta/include_summand.hpp>
 #include <vector>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -23,7 +22,7 @@ namespace stan {
     typename boost::math::tools::promote_args<T_prob>::type
     multinomial_lpmf(const std::vector<int>& ns,
                     const Eigen::Matrix<T_prob, Eigen::Dynamic, 1>& theta) {
-      static const std::string function = "multinomial_lpmf";
+      static const char* function = "multinomial_lpmf";
 
       using boost::math::tools::promote_args;
       using boost::math::lgamma;

--- a/stan/math/prim/mat/prob/multinomial_rng.hpp
+++ b/stan/math/prim/mat/prob/multinomial_rng.hpp
@@ -13,7 +13,6 @@
 #include <boost/random/uniform_01.hpp>
 #include <boost/random/variate_generator.hpp>
 #include <vector>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -23,7 +22,7 @@ namespace stan {
     multinomial_rng(const Eigen::Matrix<double, Eigen::Dynamic, 1>& theta,
                     int N,
                     RNG& rng) {
-      static const std::string function = "multinomial_rng";
+      static const char* function = "multinomial_rng";
 
       check_simplex(function, "Probabilites parameter", theta);
       check_positive(function, "number of trials variables", N);

--- a/stan/math/prim/mat/prob/ordered_logistic_lpmf.hpp
+++ b/stan/math/prim/mat/prob/ordered_logistic_lpmf.hpp
@@ -21,7 +21,6 @@
 #include <stan/math/prim/scal/meta/include_summand.hpp>
 #include <stan/math/prim/scal/meta/return_type.hpp>
 #include <Eigen/StdVector>
-#include <string>
 #include <vector>
 
 namespace stan {
@@ -66,7 +65,7 @@ namespace stan {
       using std::exp;
       using std::log;
 
-      static const std::string function = "ordered_logistic";
+      static const char* function = "ordered_logistic";
 
       int K = c.size() + 1;
 
@@ -129,7 +128,7 @@ namespace stan {
       using std::exp;
       using std::log;
 
-      static const std::string function = "ordered_logistic";
+      static const char* function = "ordered_logistic";
 
       int N = lambda.size();
       int K = c.size() + 1;
@@ -201,7 +200,7 @@ namespace stan {
       using std::exp;
       using std::log;
 
-      static const std::string function = "ordered_logistic";
+      static const char* function = "ordered_logistic";
 
       int N = lambda.size();
 

--- a/stan/math/prim/mat/prob/ordered_logistic_rng.hpp
+++ b/stan/math/prim/mat/prob/ordered_logistic_rng.hpp
@@ -14,7 +14,6 @@
 #include <stan/math/prim/scal/err/check_positive.hpp>
 #include <stan/math/prim/scal/fun/constants.hpp>
 #include <stan/math/prim/mat/prob/categorical_rng.hpp>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -26,7 +25,7 @@ namespace stan {
                          RNG& rng) {
       using boost::variate_generator;
 
-      static const std::string function = "ordered_logistic";
+      static const char* function = "ordered_logistic";
 
       check_finite(function, "Location parameter", eta);
       check_greater(function, "Size of cut points parameter", c.size(), 0);

--- a/stan/math/prim/mat/prob/ordered_probit_lpmf.hpp
+++ b/stan/math/prim/mat/prob/ordered_probit_lpmf.hpp
@@ -10,7 +10,6 @@
 #include <stan/math/prim/arr/err/check_ordered.hpp>
 #include <stan/math/prim/scal/meta/return_type.hpp>
 #include <Eigen/Dense>
-#include <string>
 #include <vector>
 
 namespace stan {
@@ -46,7 +45,7 @@ namespace stan {
       using std::exp;
       using std::log;
 
-      static const std::string function = "ordered_probit";
+      static const char* function = "ordered_probit";
 
       int K = c.size() + 1;
 
@@ -105,7 +104,7 @@ namespace stan {
       using std::exp;
       using std::log;
 
-      static const std::string function = "ordered_probit";
+      static const char* function = "ordered_probit";
 
       int N = lambda.size();
       int K = c.size() + 1;
@@ -176,7 +175,7 @@ namespace stan {
       using std::exp;
       using std::log;
 
-      static const std::string function = "ordered_probit";
+      static const char* function = "ordered_probit";
 
       int N = lambda.size();
 

--- a/stan/math/prim/mat/prob/ordered_probit_rng.hpp
+++ b/stan/math/prim/mat/prob/ordered_probit_rng.hpp
@@ -6,7 +6,6 @@
 #include <stan/math/prim/scal/err/check_greater.hpp>
 #include <stan/math/prim/mat/err/check_ordered.hpp>
 #include <stan/math/prim/mat/prob/categorical_rng.hpp>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -16,7 +15,7 @@ namespace stan {
     ordered_probit_rng(double eta,
                        const Eigen::VectorXd& c,
                        RNG& rng) {
-      static const std::string function = "ordered_probit";
+      static const char* function = "ordered_probit";
 
       check_finite(function, "Location parameter", eta);
       check_greater(function, "Size of cut points parameter", c.size(), 0);

--- a/stan/math/prim/mat/prob/wishart_lpdf.hpp
+++ b/stan/math/prim/mat/prob/wishart_lpdf.hpp
@@ -17,7 +17,6 @@
 #include <stan/math/prim/mat/meta/index_type.hpp>
 #include <stan/math/prim/scal/fun/constants.hpp>
 #include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -56,7 +55,7 @@ namespace stan {
                 const T_dof& nu,
                 const Eigen::Matrix<T_scale, Eigen::Dynamic, Eigen::Dynamic>&
                 S) {
-      static const std::string function = "wishart_lpdf";
+      static const char* function = "wishart_lpdf";
 
       using boost::math::tools::promote_args;
       using Eigen::Dynamic;

--- a/stan/math/prim/mat/prob/wishart_rng.hpp
+++ b/stan/math/prim/mat/prob/wishart_rng.hpp
@@ -8,7 +8,6 @@
 #include <stan/math/prim/scal/err/check_greater.hpp>
 #include <stan/math/prim/scal/prob/chi_square_rng.hpp>
 #include <stan/math/prim/scal/prob/normal_rng.hpp>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -16,7 +15,7 @@ namespace stan {
     template <class RNG>
     inline Eigen::MatrixXd
     wishart_rng(double nu, const Eigen::MatrixXd& S, RNG& rng) {
-      static const std::string function = "wishart_rng";
+      static const char* function = "wishart_rng";
 
       using Eigen::MatrixXd;
       typename index_type<MatrixXd>::type k = S.rows();

--- a/stan/math/prim/scal/err/check_2F1_converges.hpp
+++ b/stan/math/prim/scal/err/check_2F1_converges.hpp
@@ -8,7 +8,6 @@
 #include <limits>
 #include <sstream>
 #include <stdexcept>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -34,7 +33,7 @@ namespace stan {
      *   does not meet convergence conditions, or if any coefficient is NaN.
      */
     template <typename T_a1, typename T_a2, typename T_b1, typename T_z>
-    inline void check_2F1_converges(const std::string& function,
+    inline void check_2F1_converges(const char* function,
                                     const T_a1& a1, const T_a2& a2,
                                     const T_b1& b1, const T_z& z) {
       using std::floor;

--- a/stan/math/prim/scal/err/check_3F2_converges.hpp
+++ b/stan/math/prim/scal/err/check_3F2_converges.hpp
@@ -8,7 +8,6 @@
 #include <limits>
 #include <sstream>
 #include <stdexcept>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -39,7 +38,7 @@ namespace stan {
      */
     template <typename T_a1, typename T_a2, typename T_a3, typename T_b1,
               typename T_b2, typename T_z>
-    inline void check_3F2_converges(const std::string& function,
+    inline void check_3F2_converges(const char* function,
                                     const T_a1& a1, const T_a2& a2,
                                     const T_a3& a3, const T_b1& b1,
                                     const T_b2& b2, const T_z& z) {

--- a/stan/math/prim/scal/err/check_bounded.hpp
+++ b/stan/math/prim/scal/err/check_bounded.hpp
@@ -22,8 +22,8 @@ namespace stan {
       // throws if y, low, or high is nan
       template <typename T_y, typename T_low, typename T_high, bool y_is_vec>
       struct bounded {
-        static void check(const std::string& function,
-                          const std::string& name,
+        static void check(const char* function,
+                          const char* name,
                           const T_y& y,
                           const T_low& low,
                           const T_high& high) {
@@ -46,8 +46,8 @@ namespace stan {
 
       template <typename T_y, typename T_low, typename T_high>
       struct bounded<T_y, T_low, T_high, true> {
-        static void check(const std::string& function,
-                          const std::string& name,
+        static void check(const char* function,
+                          const char* name,
                           const T_y& y,
                           const T_low& low,
                           const T_high& high) {
@@ -88,8 +88,8 @@ namespace stan {
      *   if any of the arguments are NaN.
      */
     template <typename T_y, typename T_low, typename T_high>
-    inline void check_bounded(const std::string& function,
-                              const std::string& name,
+    inline void check_bounded(const char* function,
+                              const char* name,
                               const T_y& y,
                               const T_low& low,
                               const T_high& high) {

--- a/stan/math/prim/scal/err/check_consistent_size.hpp
+++ b/stan/math/prim/scal/err/check_consistent_size.hpp
@@ -24,8 +24,8 @@ namespace stan {
      * @throw <code>invalid_argument</code> if the size is inconsistent
      */
     template <typename T>
-    inline void check_consistent_size(const std::string& function,
-                                      const std::string& name,
+    inline void check_consistent_size(const char* function,
+                                      const char* name,
                                       const T& x,
                                       size_t expected_size) {
       if (!is_vector<T>::value)

--- a/stan/math/prim/scal/err/check_consistent_sizes.hpp
+++ b/stan/math/prim/scal/err/check_consistent_sizes.hpp
@@ -3,7 +3,6 @@
 
 #include <stan/math/prim/scal/err/check_consistent_size.hpp>
 #include <algorithm>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -27,10 +26,10 @@ namespace stan {
      * @throw <code>invalid_argument</code> if sizes are inconsistent
      */
     template <typename T1, typename T2>
-    inline void check_consistent_sizes(const std::string& function,
-                                       const std::string& name1,
+    inline void check_consistent_sizes(const char* function,
+                                       const char* name1,
                                        const T1& x1,
-                                       const std::string& name2,
+                                       const char* name2,
                                        const T2& x2) {
       using stan::is_vector;
       size_t max_size = std::max(is_vector<T1>::value * size_of(x1),
@@ -61,12 +60,12 @@ namespace stan {
      * @throw <code>invalid_argument</code> if sizes are inconsistent
      */
     template <typename T1, typename T2, typename T3>
-    inline void check_consistent_sizes(const std::string& function,
-                                       const std::string& name1,
+    inline void check_consistent_sizes(const char* function,
+                                       const char* name1,
                                        const T1& x1,
-                                       const std::string& name2,
+                                       const char* name2,
                                        const T2& x2,
-                                       const std::string& name3,
+                                       const char* name3,
                                        const T3& x3) {
       size_t max_size = std::max(is_vector<T1>::value * size_of(x1),
                                  std::max(is_vector<T2>::value * size_of(x2),
@@ -101,14 +100,14 @@ namespace stan {
      * @throw <code>invalid_argument</code> if sizes are inconsistent
      */
     template <typename T1, typename T2, typename T3, typename T4>
-    inline void check_consistent_sizes(const std::string& function,
-                                       const std::string& name1,
+    inline void check_consistent_sizes(const char* function,
+                                       const char* name1,
                                        const T1& x1,
-                                       const std::string& name2,
+                                       const char* name2,
                                        const T2& x2,
-                                       const std::string& name3,
+                                       const char* name3,
                                        const T3& x3,
-                                       const std::string& name4,
+                                       const char* name4,
                                        const T4& x4) {
       size_t max_size
         = std::max(is_vector<T1>::value * size_of(x1),
@@ -122,16 +121,16 @@ namespace stan {
     }
     template <typename T1, typename T2, typename T3, typename T4,
               typename T5>
-    inline void check_consistent_sizes(const std::string& function,
-                                       const std::string& name1,
+    inline void check_consistent_sizes(const char* function,
+                                       const char* name1,
                                        const T1& x1,
-                                       const std::string& name2,
+                                       const char* name2,
                                        const T2& x2,
-                                       const std::string& name3,
+                                       const char* name3,
                                        const T3& x3,
-                                       const std::string& name4,
+                                       const char* name4,
                                        const T4& x4,
-                                       const std::string& name5,
+                                       const char* name5,
                                        const T5& x5) {
       size_t max_size = std::max(size_of(x1),
                                  std::max(size_of(x2),

--- a/stan/math/prim/scal/err/check_finite.hpp
+++ b/stan/math/prim/scal/err/check_finite.hpp
@@ -7,7 +7,6 @@
 #include <stan/math/prim/scal/meta/is_vector_like.hpp>
 #include <stan/math/prim/scal/fun/value_of_rec.hpp>
 #include <boost/math/special_functions/fpclassify.hpp>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -15,8 +14,8 @@ namespace stan {
     namespace {
       template <typename T_y, bool is_vec>
       struct finite {
-        static void check(const std::string& function,
-                          const std::string& name,
+        static void check(const char* function,
+                          const char* name,
                           const T_y& y) {
           if (!(boost::math::isfinite)(value_of_rec(y)))
             domain_error(function, name, y,
@@ -26,8 +25,8 @@ namespace stan {
 
       template <typename T_y>
       struct finite<T_y, true> {
-        static void check(const std::string& function,
-                          const std::string& name,
+        static void check(const char* function,
+                          const char* name,
                           const T_y& y) {
           using stan::length;
           for (size_t n = 0; n < length(y); n++) {
@@ -55,8 +54,8 @@ namespace stan {
      *   NaN.
      */
     template <typename T_y>
-    inline void check_finite(const std::string& function,
-                             const std::string& name,
+    inline void check_finite(const char* function,
+                             const char* name,
                              const T_y& y) {
       finite<T_y, is_vector_like<T_y>::value>
         ::check(function, name, y);

--- a/stan/math/prim/scal/err/check_greater.hpp
+++ b/stan/math/prim/scal/err/check_greater.hpp
@@ -15,8 +15,8 @@ namespace stan {
     namespace {
       template <typename T_y, typename T_low, bool is_vec>
       struct greater {
-        static void check(const std::string& function,
-                          const std::string& name,
+        static void check(const char* function,
+                          const char* name,
                           const T_y& y,
                           const T_low& low) {
           using stan::length;
@@ -36,8 +36,8 @@ namespace stan {
 
       template <typename T_y, typename T_low>
       struct greater<T_y, T_low, true> {
-        static void check(const std::string& function,
-                          const std::string& name,
+        static void check(const char* function,
+                          const char* name,
                           const T_y& y,
                           const T_low& low) {
           using stan::length;
@@ -75,8 +75,8 @@ namespace stan {
      *   if any element of y or low is NaN.
      */
     template <typename T_y, typename T_low>
-    inline void check_greater(const std::string& function,
-                              const std::string& name,
+    inline void check_greater(const char* function,
+                              const char* name,
                               const T_y& y,
                               const T_low& low) {
       greater<T_y, T_low, is_vector_like<T_y>::value>

--- a/stan/math/prim/scal/err/check_greater_or_equal.hpp
+++ b/stan/math/prim/scal/err/check_greater_or_equal.hpp
@@ -14,8 +14,8 @@ namespace stan {
     namespace {
       template <typename T_y, typename T_low, bool is_vec>
       struct greater_or_equal {
-        static void check(const std::string& function,
-                          const std::string& name,
+        static void check(const char* function,
+                          const char* name,
                           const T_y& y,
                           const T_low& low) {
           using stan::length;
@@ -35,8 +35,8 @@ namespace stan {
 
       template <typename T_y, typename T_low>
       struct greater_or_equal<T_y, T_low, true> {
-        static void check(const std::string& function,
-                          const std::string& name,
+        static void check(const char* function,
+                          const char* name,
                           const T_y& y,
                           const T_low& low) {
           using stan::length;
@@ -75,8 +75,8 @@ namespace stan {
      *   if any element of y or low is NaN.
      */
     template <typename T_y, typename T_low>
-    inline void check_greater_or_equal(const std::string& function,
-                                       const std::string& name,
+    inline void check_greater_or_equal(const char* function,
+                                       const char* name,
                                        const T_y& y,
                                        const T_low& low) {
       greater_or_equal<T_y, T_low, is_vector_like<T_y>::value>

--- a/stan/math/prim/scal/err/check_less.hpp
+++ b/stan/math/prim/scal/err/check_less.hpp
@@ -15,8 +15,8 @@ namespace stan {
     namespace {
       template <typename T_y, typename T_high, bool is_vec>
       struct less {
-        static void check(const std::string& function,
-                          const std::string& name,
+        static void check(const char* function,
+                          const char* name,
                           const T_y& y,
                           const T_high& high) {
           using stan::length;
@@ -36,8 +36,8 @@ namespace stan {
 
       template <typename T_y, typename T_high>
       struct less<T_y, T_high, true> {
-        static void check(const std::string& function,
-                          const std::string& name,
+        static void check(const char* function,
+                          const char* name,
                           const T_y& y,
                           const T_high& high) {
           using stan::length;
@@ -75,8 +75,8 @@ namespace stan {
      *   or if any element of y or high is NaN.
      */
     template <typename T_y, typename T_high>
-    inline void check_less(const std::string& function,
-                           const std::string& name,
+    inline void check_less(const char* function,
+                           const char* name,
                            const T_y& y,
                            const T_high& high) {
       less<T_y, T_high, is_vector_like<T_y>::value>

--- a/stan/math/prim/scal/err/check_less_or_equal.hpp
+++ b/stan/math/prim/scal/err/check_less_or_equal.hpp
@@ -15,8 +15,8 @@ namespace stan {
     namespace {
       template <typename T_y, typename T_high, bool is_vec>
       struct less_or_equal {
-        static void check(const std::string& function,
-                          const std::string& name,
+        static void check(const char* function,
+                          const char* name,
                           const T_y& y,
                           const T_high& high) {
           using stan::length;
@@ -36,8 +36,8 @@ namespace stan {
 
       template <typename T_y, typename T_high>
       struct less_or_equal<T_y, T_high, true> {
-        static void check(const std::string& function,
-                          const std::string& name,
+        static void check(const char* function,
+                          const char* name,
                           const T_y& y,
                           const T_high& high) {
           using stan::length;
@@ -75,8 +75,8 @@ namespace stan {
      *   to low or if any element of y or high is NaN.
      */
     template <typename T_y, typename T_high>
-    inline void check_less_or_equal(const std::string& function,
-                                    const std::string& name,
+    inline void check_less_or_equal(const char* function,
+                                    const char* name,
                                     const T_y& y,
                                     const T_high& high) {
       less_or_equal<T_y, T_high, is_vector_like<T_y>::value>

--- a/stan/math/prim/scal/err/check_nonnegative.hpp
+++ b/stan/math/prim/scal/err/check_nonnegative.hpp
@@ -7,7 +7,6 @@
 #include <stan/math/prim/scal/meta/value_type.hpp>
 #include <stan/math/prim/scal/meta/is_vector_like.hpp>
 #include <boost/type_traits/is_unsigned.hpp>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -15,8 +14,8 @@ namespace stan {
     namespace {
       template <typename T_y, bool is_vec>
       struct nonnegative {
-        static void check(const std::string& function,
-                          const std::string& name,
+        static void check(const char* function,
+                          const char* name,
                           const T_y& y) {
           // have to use not is_unsigned. is_signed will be false
           // floating point types that have no unsigned versions.
@@ -28,8 +27,8 @@ namespace stan {
 
       template <typename T_y>
       struct nonnegative<T_y, true> {
-        static void check(const std::string& function,
-                          const std::string& name,
+        static void check(const char* function,
+                          const char* name,
                           const T_y& y) {
           using stan::length;
 
@@ -59,8 +58,8 @@ namespace stan {
      *   if any element of y is NaN.
      */
     template <typename T_y>
-    inline void check_nonnegative(const std::string& function,
-                                  const std::string& name,
+    inline void check_nonnegative(const char* function,
+                                  const char* name,
                                   const T_y& y) {
       nonnegative<T_y, is_vector_like<T_y>::value>::check(function, name, y);
     }

--- a/stan/math/prim/scal/err/check_not_nan.hpp
+++ b/stan/math/prim/scal/err/check_not_nan.hpp
@@ -7,7 +7,6 @@
 #include <stan/math/prim/scal/err/domain_error_vec.hpp>
 #include <stan/math/prim/scal/fun/value_of_rec.hpp>
 #include <stan/math/prim/scal/fun/is_nan.hpp>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -15,8 +14,8 @@ namespace stan {
     namespace {
       template <typename T_y, bool is_vec>
       struct not_nan {
-        static void check(const std::string& function,
-                          const std::string& name,
+        static void check(const char* function,
+                          const char* name,
                           const T_y& y) {
           if (is_nan(value_of_rec(y)))
             domain_error(function, name, y,
@@ -26,8 +25,8 @@ namespace stan {
 
       template <typename T_y>
       struct not_nan<T_y, true> {
-        static void check(const std::string& function,
-                          const std::string& name,
+        static void check(const char* function,
+                          const char* name,
                           const T_y& y) {
           for (size_t n = 0; n < stan::length(y); n++) {
             if (is_nan(value_of_rec(stan::get(y, n))))
@@ -55,8 +54,8 @@ namespace stan {
      * @throw <code>domain_error</code> if any element of y is NaN.
      */
     template <typename T_y>
-    inline void check_not_nan(const std::string& function,
-                              const std::string& name,
+    inline void check_not_nan(const char* function,
+                              const char* name,
                               const T_y& y) {
       not_nan<T_y, is_vector_like<T_y>::value>::check(function, name, y);
     }

--- a/stan/math/prim/scal/err/check_positive.hpp
+++ b/stan/math/prim/scal/err/check_positive.hpp
@@ -8,7 +8,6 @@
 #include <stan/math/prim/scal/meta/get.hpp>
 #include <stan/math/prim/scal/meta/is_vector_like.hpp>
 #include <boost/type_traits/is_unsigned.hpp>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -17,8 +16,8 @@ namespace stan {
 
       template <typename T_y, bool is_vec>
       struct positive {
-        static void check(const std::string& function,
-                          const std::string& name,
+        static void check(const char* function,
+                          const char* name,
                           const T_y& y) {
           // have to use not is_unsigned. is_signed will be false
           // floating point types that have no unsigned versions.
@@ -30,8 +29,8 @@ namespace stan {
 
       template <typename T_y>
       struct positive<T_y, true> {
-        static void check(const std::string& function,
-                          const std::string& name,
+        static void check(const char* function,
+                          const char* name,
                           const T_y& y) {
           using stan::length;
           for (size_t n = 0; n < length(y); n++) {
@@ -61,8 +60,8 @@ namespace stan {
      *   if any element of y is NaN.
      */
     template <typename T_y>
-    inline void check_positive(const std::string& function,
-                               const std::string& name,
+    inline void check_positive(const char* function,
+                               const char* name,
                                const T_y& y) {
       positive<T_y, is_vector_like<T_y>::value>::check(function, name, y);
     }

--- a/stan/math/prim/scal/err/check_positive_finite.hpp
+++ b/stan/math/prim/scal/err/check_positive_finite.hpp
@@ -3,7 +3,6 @@
 
 #include <stan/math/prim/scal/err/check_positive.hpp>
 #include <stan/math/prim/scal/err/check_finite.hpp>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -24,8 +23,8 @@ namespace stan {
      *   if any element of y is NaN.
      */
     template <typename T_y>
-    inline void check_positive_finite(const std::string& function,
-                                      const std::string& name,
+    inline void check_positive_finite(const char* function,
+                                      const char* name,
                                       const T_y& y) {
       check_positive(function, name, y);
       check_finite(function, name, y);

--- a/stan/math/prim/scal/err/check_positive_size.hpp
+++ b/stan/math/prim/scal/err/check_positive_size.hpp
@@ -19,9 +19,9 @@ namespace stan {
      * @throw <code>std::invalid_argument</code> if <code>size</code> is
      *   zero or negative.
      */
-    inline void check_positive_size(const std::string& function,
-                                    const std::string& name,
-                                    const std::string& expr,
+    inline void check_positive_size(const char* function,
+                                    const char* name,
+                                    const char* expr,
                                     int size) {
       if (size <= 0) {
         std::stringstream msg;

--- a/stan/math/prim/scal/err/check_size_match.hpp
+++ b/stan/math/prim/scal/err/check_size_match.hpp
@@ -26,10 +26,10 @@ namespace stan {
      *   do not match
      */
     template <typename T_size1, typename T_size2>
-    inline void check_size_match(const std::string& function,
-                                 const std::string& name_i,
+    inline void check_size_match(const char* function,
+                                 const char* name_i,
                                  T_size1 i,
-                                 const std::string& name_j,
+                                 const char* name_j,
                                  T_size2 j) {
       if (likely(i == static_cast<T_size1>(j)))
         return;
@@ -60,12 +60,12 @@ namespace stan {
      *   do not match
      */
     template <typename T_size1, typename T_size2>
-    inline void check_size_match(const std::string& function,
-                                 const std::string& expr_i,
-                                 const std::string& name_i,
+    inline void check_size_match(const char* function,
+                                 const char* expr_i,
+                                 const char* name_i,
                                  T_size1 i,
-                                 const std::string& expr_j,
-                                 const std::string& name_j,
+                                 const char* expr_j,
+                                 const char* name_j,
                                  T_size2 j) {
       if (likely(i == static_cast<T_size1>(j)))
         return;

--- a/stan/math/prim/scal/err/domain_error.hpp
+++ b/stan/math/prim/scal/err/domain_error.hpp
@@ -2,7 +2,6 @@
 #define STAN_MATH_PRIM_SCAL_ERR_DOMAIN_ERROR_HPP
 
 #include <typeinfo>
-#include <string>
 #include <sstream>
 #include <stdexcept>
 
@@ -27,10 +26,10 @@ namespace stan {
      * @throw std::domain_error Always.
      */
     template <typename T>
-    inline void domain_error(const std::string& function,
-                             const std::string& name,
+    inline void domain_error(const char* function,
+                             const char* name,
                              const T& y,
-                             const std::string& msg1, const std::string& msg2) {
+                             const char* msg1, const char* msg2) {
       std::ostringstream message;
       // hack to remove -Waddress, -Wnonnull-compare warnings from GCC 6
       const T* y_ptr = &y;
@@ -55,9 +54,9 @@ namespace stan {
      * @throw std::domain_error Always.
      */
     template <typename T>
-    inline void domain_error(const std::string& function,
-                             const std::string& name,
-                             const T& y, const std::string& msg1) {
+    inline void domain_error(const char* function,
+                             const char* name,
+                             const T& y, const char* msg1) {
       domain_error(function, name, y, msg1, "");
     }
 

--- a/stan/math/prim/scal/err/domain_error_vec.hpp
+++ b/stan/math/prim/scal/err/domain_error_vec.hpp
@@ -34,12 +34,12 @@ namespace stan {
      * @throw std::domain_error
      */
     template <typename T>
-    inline void domain_error_vec(const std::string& function,
-                                 const std::string& name,
+    inline void domain_error_vec(const char* function,
+                                 const char* name,
                                  const T& y,
                                  size_t i,
-                                 const std::string& msg1,
-                                 const std::string& msg2) {
+                                 const char* msg1,
+                                 const char* msg2) {
       std::ostringstream vec_name_stream;
       vec_name_stream << name
                       << "[" << stan::error_index::value + i << "]";
@@ -69,11 +69,11 @@ namespace stan {
      * @throw std::domain_error
      */
     template <typename T>
-    inline void domain_error_vec(const std::string& function,
-                                 const std::string& name,
+    inline void domain_error_vec(const char* function,
+                                 const char* name,
                                  const T& y,
                                  size_t i,
-                                 const std::string& msg) {
+                                 const char* msg) {
       domain_error_vec(function, name, y, i, msg, "");
     }
 

--- a/stan/math/prim/scal/err/invalid_argument.hpp
+++ b/stan/math/prim/scal/err/invalid_argument.hpp
@@ -2,7 +2,6 @@
 #define STAN_MATH_PRIM_SCAL_ERR_INVALID_ARGUMENT_HPP
 
 #include <typeinfo>
-#include <string>
 #include <sstream>
 #include <stdexcept>
 
@@ -28,11 +27,11 @@ namespace stan {
      * @throw std::invalid_argument
      */
     template <typename T>
-    inline void invalid_argument(const std::string& function,
-                                 const std::string& name,
+    inline void invalid_argument(const char* function,
+                                 const char* name,
                                  const T& y,
-                                 const std::string& msg1,
-                                 const std::string& msg2) {
+                                 const char* msg1,
+                                 const char* msg2) {
       std::ostringstream message;
 
       message << function << ": "
@@ -63,10 +62,10 @@ namespace stan {
      * @throw std::invalid_argument
      */
     template <typename T>
-    inline void invalid_argument(const std::string& function,
-                                 const std::string& name,
+    inline void invalid_argument(const char* function,
+                                 const char* name,
                                  const T& y,
-                                 const std::string& msg1) {
+                                 const char* msg1) {
       invalid_argument(function, name, y, msg1, "");
     }
 

--- a/stan/math/prim/scal/err/invalid_argument_vec.hpp
+++ b/stan/math/prim/scal/err/invalid_argument_vec.hpp
@@ -34,12 +34,12 @@ namespace stan {
      * @throw std::invalid_argument
      */
     template <typename T>
-    inline void invalid_argument_vec(const std::string& function,
-                                     const std::string& name,
+    inline void invalid_argument_vec(const char* function,
+                                     const char* name,
                                      const T& y,
                                      size_t i,
-                                     const std::string& msg1,
-                                     const std::string& msg2) {
+                                     const char* msg1,
+                                     const char* msg2) {
       std::ostringstream vec_name_stream;
       vec_name_stream << name
                       << "[" << stan::error_index::value + i << "]";
@@ -70,11 +70,11 @@ namespace stan {
      * @throw std::invalid_argument
      */
     template <typename T>
-    inline void invalid_argument_vec(const std::string& function,
-                                     const std::string& name,
+    inline void invalid_argument_vec(const char* function,
+                                     const char* name,
                                      const T& y,
                                      size_t i,
-                                     const std::string& msg) {
+                                     const char* msg) {
       invalid_argument_vec(function, name, y, i, msg, "");
     }
 

--- a/stan/math/prim/scal/err/out_of_range.hpp
+++ b/stan/math/prim/scal/err/out_of_range.hpp
@@ -3,7 +3,6 @@
 
 #include <stan/math/prim/scal/meta/error_index.hpp>
 #include <typeinfo>
-#include <string>
 #include <sstream>
 #include <stdexcept>
 
@@ -28,11 +27,11 @@ namespace stan {
      * @param msg2 Message to print. Default is "".
      * @throw std::out_of_range with message.
      */
-    inline void out_of_range(const std::string& function,
+    inline void out_of_range(const char* function,
                              int max,
                              int index,
-                             const std::string& msg1 = "",
-                             const std::string& msg2 = "") {
+                             const char* msg1 = "",
+                             const char* msg2 = "") {
       std::ostringstream message;
 
       message << function << ": accessing element out of range. "

--- a/stan/math/prim/scal/fun/falling_factorial.hpp
+++ b/stan/math/prim/scal/fun/falling_factorial.hpp
@@ -6,7 +6,6 @@
 #include <stan/math/prim/scal/err/check_not_nan.hpp>
 #include <stan/math/prim/scal/err/check_nonnegative.hpp>
 #include <limits>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -66,7 +65,7 @@ namespace stan {
     template<typename T>
     inline typename boost::math::tools::promote_args<T>::type
     falling_factorial(const T& x, int n) {
-      static const std::string function = "falling_factorial";
+      static const char* function = "falling_factorial";
       check_not_nan(function, "first argument", x);
       check_nonnegative(function, "second argument", n);
       return boost::math::falling_factorial(x, n, boost_policy_t());

--- a/stan/math/prim/scal/fun/log_falling_factorial.hpp
+++ b/stan/math/prim/scal/fun/log_falling_factorial.hpp
@@ -5,7 +5,6 @@
 #include <stan/math/prim/scal/fun/is_nan.hpp>
 #include <stan/math/prim/scal/fun/lgamma.hpp>
 #include <limits>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -56,7 +55,7 @@ namespace stan {
     log_falling_factorial(const T1 x, const T2 n) {
       if (is_nan(x) || is_nan(n))
         return std::numeric_limits<double>::quiet_NaN();
-      static const std::string function = "log_falling_factorial";
+      static const char* function = "log_falling_factorial";
       check_positive(function, "first argument", x);
       return lgamma(x + 1) - lgamma(x - n + 1);
     }

--- a/stan/math/prim/scal/fun/log_rising_factorial.hpp
+++ b/stan/math/prim/scal/fun/log_rising_factorial.hpp
@@ -5,7 +5,6 @@
 #include <stan/math/prim/scal/fun/is_nan.hpp>
 #include <stan/math/prim/scal/fun/lgamma.hpp>
 #include <limits>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -53,7 +52,7 @@ namespace stan {
     log_rising_factorial(const T1& x, const T2& n) {
       if (is_nan(x) || is_nan(n))
         return std::numeric_limits<double>::quiet_NaN();
-      static const std::string function = "log_rising_factorial";
+      static const char* function = "log_rising_factorial";
       check_positive(function, "first argument", x);
       return lgamma(x + n) - lgamma(x);
     }

--- a/stan/math/prim/scal/fun/rising_factorial.hpp
+++ b/stan/math/prim/scal/fun/rising_factorial.hpp
@@ -6,7 +6,6 @@
 #include <stan/math/prim/scal/err/check_not_nan.hpp>
 #include <stan/math/prim/scal/err/check_nonnegative.hpp>
 #include <limits>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -66,7 +65,7 @@ namespace stan {
     template<typename T>
     inline typename boost::math::tools::promote_args<T>::type
     rising_factorial(const T& x, int n) {
-      static const std::string function = "rising_factorial";
+      static const char* function = "rising_factorial";
       check_not_nan(function, "first argument", x);
       check_nonnegative(function, "second argument", n);
       return boost::math::rising_factorial(x, n, boost_policy_t());

--- a/stan/math/prim/scal/prob/bernoulli_cdf.hpp
+++ b/stan/math/prim/scal/prob/bernoulli_cdf.hpp
@@ -16,7 +16,6 @@
 #include <stan/math/prim/scal/meta/scalar_seq_view.hpp>
 #include <boost/random/bernoulli_distribution.hpp>
 #include <boost/random/variate_generator.hpp>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -36,7 +35,7 @@ namespace stan {
     template <typename T_n, typename T_prob>
     typename return_type<T_prob>::type
     bernoulli_cdf(const T_n& n, const T_prob& theta) {
-      static const std::string function = "bernoulli_cdf";
+      static const char* function = "bernoulli_cdf";
       typedef typename stan::partials_return_type<T_n, T_prob>::type
         T_partials_return;
 

--- a/stan/math/prim/scal/prob/bernoulli_lccdf.hpp
+++ b/stan/math/prim/scal/prob/bernoulli_lccdf.hpp
@@ -17,7 +17,6 @@
 #include <boost/random/bernoulli_distribution.hpp>
 #include <boost/random/variate_generator.hpp>
 #include <cmath>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -37,7 +36,7 @@ namespace stan {
     template <typename T_n, typename T_prob>
     typename return_type<T_prob>::type
     bernoulli_lccdf(const T_n& n, const T_prob& theta) {
-      static const std::string function = "bernoulli_lccdf";
+      static const char* function = "bernoulli_lccdf";
       typedef typename stan::partials_return_type<T_n, T_prob>::type
         T_partials_return;
 

--- a/stan/math/prim/scal/prob/bernoulli_lcdf.hpp
+++ b/stan/math/prim/scal/prob/bernoulli_lcdf.hpp
@@ -17,7 +17,6 @@
 #include <boost/random/bernoulli_distribution.hpp>
 #include <boost/random/variate_generator.hpp>
 #include <cmath>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -37,7 +36,7 @@ namespace stan {
     template <typename T_n, typename T_prob>
     typename return_type<T_prob>::type
     bernoulli_lcdf(const T_n& n, const T_prob& theta) {
-      static const std::string function = "bernoulli_lcdf";
+      static const char* function = "bernoulli_lcdf";
       typedef typename stan::partials_return_type<T_n, T_prob>::type
         T_partials_return;
 

--- a/stan/math/prim/scal/prob/bernoulli_logit_lpmf.hpp
+++ b/stan/math/prim/scal/prob/bernoulli_logit_lpmf.hpp
@@ -17,7 +17,6 @@
 #include <boost/random/bernoulli_distribution.hpp>
 #include <boost/random/variate_generator.hpp>
 #include <cmath>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -37,7 +36,7 @@ namespace stan {
     template <bool propto, typename T_n, typename T_prob>
     typename return_type<T_prob>::type
     bernoulli_logit_lpmf(const T_n& n, const T_prob& theta) {
-      static const std::string function = "bernoulli_logit_lpmf";
+      static const char* function = "bernoulli_logit_lpmf";
       typedef typename stan::partials_return_type<T_n, T_prob>::type
         T_partials_return;
 

--- a/stan/math/prim/scal/prob/bernoulli_lpmf.hpp
+++ b/stan/math/prim/scal/prob/bernoulli_lpmf.hpp
@@ -17,7 +17,6 @@
 #include <boost/random/bernoulli_distribution.hpp>
 #include <boost/random/variate_generator.hpp>
 #include <cmath>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -38,7 +37,7 @@ namespace stan {
     typename return_type<T_prob>::type
     bernoulli_lpmf(const T_n& n,
                   const T_prob& theta) {
-      static const std::string function = "bernoulli_lpmf";
+      static const char* function = "bernoulli_lpmf";
       typedef typename stan::partials_return_type<T_n, T_prob>::type
         T_partials_return;
 

--- a/stan/math/prim/scal/prob/bernoulli_rng.hpp
+++ b/stan/math/prim/scal/prob/bernoulli_rng.hpp
@@ -12,7 +12,6 @@
 #include <stan/math/prim/scal/fun/log1m.hpp>
 #include <stan/math/prim/scal/fun/value_of.hpp>
 #include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -34,7 +33,7 @@ namespace stan {
       using boost::variate_generator;
       using boost::bernoulli_distribution;
 
-      static const std::string function = "bernoulli_rng";
+      static const char* function = "bernoulli_rng";
 
       check_finite(function, "Probability parameter", theta);
       check_bounded(function, "Probability parameter", theta, 0, 1);

--- a/stan/math/prim/scal/prob/beta_binomial_cdf.hpp
+++ b/stan/math/prim/scal/prob/beta_binomial_cdf.hpp
@@ -20,7 +20,6 @@
 #include <stan/math/prim/scal/fun/F32.hpp>
 #include <stan/math/prim/scal/fun/grad_F32.hpp>
 #include <cmath>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -47,7 +46,7 @@ namespace stan {
     typename return_type<T_size1, T_size2>::type
     beta_binomial_cdf(const T_n& n, const T_N& N, const T_size1& alpha,
                       const T_size2& beta) {
-      static const std::string function = "beta_binomial_cdf";
+      static const char* function = "beta_binomial_cdf";
       typedef typename stan::partials_return_type<T_n, T_N, T_size1,
                                                   T_size2>::type
         T_partials_return;

--- a/stan/math/prim/scal/prob/beta_binomial_lccdf.hpp
+++ b/stan/math/prim/scal/prob/beta_binomial_lccdf.hpp
@@ -20,7 +20,6 @@
 #include <stan/math/prim/scal/fun/F32.hpp>
 #include <stan/math/prim/scal/fun/grad_F32.hpp>
 #include <cmath>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -47,7 +46,7 @@ namespace stan {
     typename return_type<T_size1, T_size2>::type
     beta_binomial_lccdf(const T_n& n, const T_N& N, const T_size1& alpha,
                            const T_size2& beta) {
-      static const std::string function = "beta_binomial_lccdf";
+      static const char* function = "beta_binomial_lccdf";
       typedef typename stan::partials_return_type<T_n, T_N, T_size1,
                                                   T_size2>::type
         T_partials_return;

--- a/stan/math/prim/scal/prob/beta_binomial_lcdf.hpp
+++ b/stan/math/prim/scal/prob/beta_binomial_lcdf.hpp
@@ -20,7 +20,6 @@
 #include <stan/math/prim/scal/fun/F32.hpp>
 #include <stan/math/prim/scal/fun/grad_F32.hpp>
 #include <cmath>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -47,7 +46,7 @@ namespace stan {
     typename return_type<T_size1, T_size2>::type
     beta_binomial_lcdf(const T_n& n, const T_N& N, const T_size1& alpha,
                           const T_size2& beta) {
-      static const std::string function = "beta_binomial_lcdf";
+      static const char* function = "beta_binomial_lcdf";
       typedef typename stan::partials_return_type<T_n, T_N, T_size1,
                                                   T_size2>::type
         T_partials_return;

--- a/stan/math/prim/scal/prob/beta_binomial_lpmf.hpp
+++ b/stan/math/prim/scal/prob/beta_binomial_lpmf.hpp
@@ -20,7 +20,6 @@
 #include <stan/math/prim/scal/prob/beta_rng.hpp>
 #include <stan/math/prim/scal/fun/F32.hpp>
 #include <stan/math/prim/scal/fun/grad_F32.hpp>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -50,7 +49,7 @@ namespace stan {
                       const T_N& N,
                       const T_size1& alpha,
                       const T_size2& beta) {
-      static const std::string function = "beta_binomial_lpmf";
+      static const char* function = "beta_binomial_lpmf";
       typedef typename stan::partials_return_type<T_size1, T_size2>::type
         T_partials_return;
 

--- a/stan/math/prim/scal/prob/beta_binomial_rng.hpp
+++ b/stan/math/prim/scal/prob/beta_binomial_rng.hpp
@@ -13,7 +13,6 @@
 #include <stan/math/prim/scal/meta/include_summand.hpp>
 #include <stan/math/prim/scal/prob/binomial_rng.hpp>
 #include <stan/math/prim/scal/prob/beta_rng.hpp>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -37,7 +36,7 @@ namespace stan {
                       double alpha,
                       double beta,
                       RNG& rng) {
-      static const std::string function = "beta_binomial_rng";
+      static const char* function = "beta_binomial_rng";
 
       check_nonnegative(function, "Population size parameter", N);
       check_positive_finite(function,

--- a/stan/math/prim/scal/prob/beta_cdf.hpp
+++ b/stan/math/prim/scal/prob/beta_cdf.hpp
@@ -28,7 +28,6 @@
 #include <boost/random/gamma_distribution.hpp>
 #include <boost/random/variate_generator.hpp>
 #include <cmath>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -56,7 +55,7 @@ namespace stan {
       if (!(stan::length(y) && stan::length(alpha) && stan::length(beta)))
         return 1.0;
 
-      static const std::string function = "beta_cdf";
+      static const char* function = "beta_cdf";
       using boost::math::tools::promote_args;
 
       T_partials_return P(1.0);

--- a/stan/math/prim/scal/prob/beta_lccdf.hpp
+++ b/stan/math/prim/scal/prob/beta_lccdf.hpp
@@ -26,7 +26,6 @@
 #include <boost/random/gamma_distribution.hpp>
 #include <boost/random/variate_generator.hpp>
 #include <cmath>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -58,7 +57,7 @@ namespace stan {
       if (!(stan::length(y) && stan::length(alpha) && stan::length(beta)))
         return 0.0;
 
-      static const std::string function = "beta_lccdf";
+      static const char* function = "beta_lccdf";
 
       using boost::math::tools::promote_args;
 

--- a/stan/math/prim/scal/prob/beta_lcdf.hpp
+++ b/stan/math/prim/scal/prob/beta_lcdf.hpp
@@ -26,7 +26,6 @@
 #include <boost/random/gamma_distribution.hpp>
 #include <boost/random/variate_generator.hpp>
 #include <cmath>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -58,7 +57,7 @@ namespace stan {
       if (!(stan::length(y) && stan::length(alpha) && stan::length(beta)))
         return 0.0;
 
-      static const std::string function = "beta_lcdf";
+      static const char* function = "beta_lcdf";
 
       using boost::math::tools::promote_args;
 

--- a/stan/math/prim/scal/prob/beta_lpdf.hpp
+++ b/stan/math/prim/scal/prob/beta_lpdf.hpp
@@ -26,7 +26,6 @@
 #include <boost/random/gamma_distribution.hpp>
 #include <boost/random/variate_generator.hpp>
 #include <cmath>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -54,7 +53,7 @@ namespace stan {
     typename return_type<T_y, T_scale_succ, T_scale_fail>::type
     beta_lpdf(const T_y& y,
              const T_scale_succ& alpha, const T_scale_fail& beta) {
-      static const std::string function = "beta_lpdf";
+      static const char* function = "beta_lpdf";
 
       typedef typename stan::partials_return_type<T_y,
                                                   T_scale_succ,

--- a/stan/math/prim/scal/prob/beta_rng.hpp
+++ b/stan/math/prim/scal/prob/beta_rng.hpp
@@ -21,7 +21,6 @@
 #include <stan/math/prim/scal/meta/include_summand.hpp>
 #include <stan/math/prim/scal/fun/grad_reg_inc_beta.hpp>
 #include <stan/math/prim/scal/fun/inc_beta.hpp>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -47,7 +46,7 @@ namespace stan {
       using boost::random::uniform_real_distribution;
       using std::log;
       using std::exp;
-      static const std::string function = "beta_rng";
+      static const char* function = "beta_rng";
       check_positive_finite(function, "First shape parameter", alpha);
       check_positive_finite(function, "Second shape parameter", beta);
 

--- a/stan/math/prim/scal/prob/binomial_cdf.hpp
+++ b/stan/math/prim/scal/prob/binomial_cdf.hpp
@@ -24,7 +24,6 @@
 #include <boost/random/binomial_distribution.hpp>
 #include <boost/random/variate_generator.hpp>
 #include <cmath>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -48,7 +47,7 @@ namespace stan {
     template <typename T_n, typename T_N, typename T_prob>
     typename return_type<T_prob>::type
     binomial_cdf(const T_n& n, const T_N& N, const T_prob& theta) {
-      static const std::string function = "binomial_cdf";
+      static const char* function = "binomial_cdf";
       typedef typename stan::partials_return_type<T_n, T_N, T_prob>::type
         T_partials_return;
 

--- a/stan/math/prim/scal/prob/binomial_lccdf.hpp
+++ b/stan/math/prim/scal/prob/binomial_lccdf.hpp
@@ -24,7 +24,6 @@
 #include <boost/random/binomial_distribution.hpp>
 #include <boost/random/variate_generator.hpp>
 #include <cmath>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -48,7 +47,7 @@ namespace stan {
     template <typename T_n, typename T_N, typename T_prob>
     typename return_type<T_prob>::type
     binomial_lccdf(const T_n& n, const T_N& N, const T_prob& theta) {
-      static const std::string function = "binomial_lccdf";
+      static const char* function = "binomial_lccdf";
       typedef typename stan::partials_return_type<T_n, T_N, T_prob>::type
         T_partials_return;
 

--- a/stan/math/prim/scal/prob/binomial_lcdf.hpp
+++ b/stan/math/prim/scal/prob/binomial_lcdf.hpp
@@ -24,7 +24,6 @@
 #include <boost/random/binomial_distribution.hpp>
 #include <boost/random/variate_generator.hpp>
 #include <cmath>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -48,7 +47,7 @@ namespace stan {
     template <typename T_n, typename T_N, typename T_prob>
     typename return_type<T_prob>::type
     binomial_lcdf(const T_n& n, const T_N& N, const T_prob& theta) {
-      static const std::string function = "binomial_lcdf";
+      static const char* function = "binomial_lcdf";
       typedef typename stan::partials_return_type<T_n, T_N, T_prob>::type
         T_partials_return;
 

--- a/stan/math/prim/scal/prob/binomial_logit_lpmf.hpp
+++ b/stan/math/prim/scal/prob/binomial_logit_lpmf.hpp
@@ -24,7 +24,6 @@
 #include <stan/math/prim/scal/fun/inc_beta.hpp>
 #include <boost/random/binomial_distribution.hpp>
 #include <boost/random/variate_generator.hpp>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -55,7 +54,7 @@ namespace stan {
       typedef typename stan::partials_return_type<T_n, T_N, T_prob>::type
         T_partials_return;
 
-      static const std::string function = "binomial_logit_lpmf";
+      static const char* function = "binomial_logit_lpmf";
 
       if (!(stan::length(n) && stan::length(N) && stan::length(alpha)))
         return 0.0;

--- a/stan/math/prim/scal/prob/binomial_lpmf.hpp
+++ b/stan/math/prim/scal/prob/binomial_lpmf.hpp
@@ -24,7 +24,6 @@
 #include <stan/math/prim/scal/fun/inc_beta.hpp>
 #include <boost/random/binomial_distribution.hpp>
 #include <boost/random/variate_generator.hpp>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -57,7 +56,7 @@ namespace stan {
       typedef typename stan::partials_return_type<T_n, T_N, T_prob>::type
         T_partials_return;
 
-      static const std::string function = "binomial_lpmf";
+      static const char* function = "binomial_lpmf";
 
       if (!(stan::length(n) && stan::length(N) && stan::length(theta)))
         return 0.0;

--- a/stan/math/prim/scal/prob/binomial_rng.hpp
+++ b/stan/math/prim/scal/prob/binomial_rng.hpp
@@ -19,7 +19,6 @@
 #include <stan/math/prim/scal/fun/lbeta.hpp>
 #include <stan/math/prim/scal/meta/include_summand.hpp>
 #include <stan/math/prim/scal/fun/inc_beta.hpp>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -45,7 +44,7 @@ namespace stan {
       using boost::variate_generator;
       using boost::binomial_distribution;
 
-      static const std::string function = "binomial_rng";
+      static const char* function = "binomial_rng";
 
       check_nonnegative(function, "Population size parameter", N);
       check_finite(function, "Probability parameter", theta);

--- a/stan/math/prim/scal/prob/cauchy_cdf.hpp
+++ b/stan/math/prim/scal/prob/cauchy_cdf.hpp
@@ -17,7 +17,6 @@
 #include <boost/random/cauchy_distribution.hpp>
 #include <boost/random/variate_generator.hpp>
 #include <limits>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -46,7 +45,7 @@ namespace stan {
       if (!(stan::length(y) && stan::length(mu) && stan::length(sigma)))
         return 1.0;
 
-      static const std::string function = "cauchy_cdf";
+      static const char* function = "cauchy_cdf";
 
       using boost::math::tools::promote_args;
 

--- a/stan/math/prim/scal/prob/cauchy_lccdf.hpp
+++ b/stan/math/prim/scal/prob/cauchy_lccdf.hpp
@@ -17,7 +17,6 @@
 #include <boost/random/cauchy_distribution.hpp>
 #include <boost/random/variate_generator.hpp>
 #include <cmath>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -46,7 +45,7 @@ namespace stan {
       if (!(stan::length(y) && stan::length(mu) && stan::length(sigma)))
         return 0.0;
 
-      static const std::string function = "cauchy_lccdf";
+      static const char* function = "cauchy_lccdf";
 
       using boost::math::tools::promote_args;
 

--- a/stan/math/prim/scal/prob/cauchy_lcdf.hpp
+++ b/stan/math/prim/scal/prob/cauchy_lcdf.hpp
@@ -17,7 +17,6 @@
 #include <boost/random/cauchy_distribution.hpp>
 #include <boost/random/variate_generator.hpp>
 #include <cmath>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -46,7 +45,7 @@ namespace stan {
       if (!(stan::length(y) && stan::length(mu) && stan::length(sigma)))
         return 0.0;
 
-      static const std::string function = "cauchy_lcdf";
+      static const char* function = "cauchy_lcdf";
 
       using boost::math::tools::promote_args;
 

--- a/stan/math/prim/scal/prob/cauchy_lpdf.hpp
+++ b/stan/math/prim/scal/prob/cauchy_lpdf.hpp
@@ -18,7 +18,6 @@
 #include <boost/random/cauchy_distribution.hpp>
 #include <boost/random/variate_generator.hpp>
 #include <cmath>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -44,7 +43,7 @@ namespace stan {
               typename T_y, typename T_loc, typename T_scale>
     typename return_type<T_y, T_loc, T_scale>::type
     cauchy_lpdf(const T_y& y, const T_loc& mu, const T_scale& sigma) {
-      static const std::string function = "cauchy_lpdf";
+      static const char* function = "cauchy_lpdf";
       typedef typename stan::partials_return_type<T_y, T_loc, T_scale>::type
         T_partials_return;
 

--- a/stan/math/prim/scal/prob/cauchy_rng.hpp
+++ b/stan/math/prim/scal/prob/cauchy_rng.hpp
@@ -12,7 +12,6 @@
 #include <stan/math/prim/scal/fun/square.hpp>
 #include <stan/math/prim/scal/fun/value_of.hpp>
 #include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -36,7 +35,7 @@ namespace stan {
       using boost::variate_generator;
       using boost::random::cauchy_distribution;
 
-      static const std::string function = "cauchy_rng";
+      static const char* function = "cauchy_rng";
 
       check_finite(function, "Location parameter", mu);
       check_positive_finite(function, "Scale parameter", sigma);

--- a/stan/math/prim/scal/prob/chi_square_cdf.hpp
+++ b/stan/math/prim/scal/prob/chi_square_cdf.hpp
@@ -21,7 +21,6 @@
 #include <boost/random/variate_generator.hpp>
 #include <cmath>
 #include <limits>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -42,7 +41,7 @@ namespace stan {
     template <typename T_y, typename T_dof>
     typename return_type<T_y, T_dof>::type
     chi_square_cdf(const T_y& y, const T_dof& nu) {
-      static const std::string function = "chi_square_cdf";
+      static const char* function = "chi_square_cdf";
       typedef typename stan::partials_return_type<T_y, T_dof>::type
         T_partials_return;
 

--- a/stan/math/prim/scal/prob/chi_square_lccdf.hpp
+++ b/stan/math/prim/scal/prob/chi_square_lccdf.hpp
@@ -21,7 +21,6 @@
 #include <boost/random/variate_generator.hpp>
 #include <cmath>
 #include <limits>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -42,7 +41,7 @@ namespace stan {
     template <typename T_y, typename T_dof>
     typename return_type<T_y, T_dof>::type
     chi_square_lccdf(const T_y& y, const T_dof& nu) {
-      static const std::string function = "chi_square_lccdf";
+      static const char* function = "chi_square_lccdf";
       typedef typename stan::partials_return_type<T_y, T_dof>::type
         T_partials_return;
 

--- a/stan/math/prim/scal/prob/chi_square_lcdf.hpp
+++ b/stan/math/prim/scal/prob/chi_square_lcdf.hpp
@@ -21,7 +21,6 @@
 #include <boost/random/variate_generator.hpp>
 #include <cmath>
 #include <limits>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -42,7 +41,7 @@ namespace stan {
     template <typename T_y, typename T_dof>
     typename return_type<T_y, T_dof>::type
     chi_square_lcdf(const T_y& y, const T_dof& nu) {
-      static const std::string function = "chi_square_lcdf";
+      static const char* function = "chi_square_lcdf";
       typedef typename stan::partials_return_type<T_y, T_dof>::type
         T_partials_return;
 

--- a/stan/math/prim/scal/prob/chi_square_lpdf.hpp
+++ b/stan/math/prim/scal/prob/chi_square_lpdf.hpp
@@ -20,7 +20,6 @@
 #include <boost/random/chi_squared_distribution.hpp>
 #include <boost/random/variate_generator.hpp>
 #include <cmath>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -48,7 +47,7 @@ namespace stan {
               typename T_y, typename T_dof>
     typename return_type<T_y, T_dof>::type
     chi_square_lpdf(const T_y& y, const T_dof& nu) {
-      static const std::string function = "chi_square_lpdf";
+      static const char* function = "chi_square_lpdf";
       typedef typename stan::partials_return_type<T_y, T_dof>::type
         T_partials_return;
 

--- a/stan/math/prim/scal/prob/chi_square_rng.hpp
+++ b/stan/math/prim/scal/prob/chi_square_rng.hpp
@@ -14,7 +14,6 @@
 #include <stan/math/prim/scal/fun/digamma.hpp>
 #include <stan/math/prim/scal/fun/grad_reg_inc_gamma.hpp>
 #include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -36,7 +35,7 @@ namespace stan {
       using boost::variate_generator;
       using boost::random::chi_squared_distribution;
 
-      static const std::string function = "chi_square_rng";
+      static const char* function = "chi_square_rng";
 
       check_positive_finite(function, "Degrees of freedom parameter", nu);
 

--- a/stan/math/prim/scal/prob/double_exponential_cdf.hpp
+++ b/stan/math/prim/scal/prob/double_exponential_cdf.hpp
@@ -17,7 +17,6 @@
 #include <boost/random/uniform_01.hpp>
 #include <boost/random/variate_generator.hpp>
 #include <cmath>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -40,7 +39,7 @@ namespace stan {
     typename return_type<T_y, T_loc, T_scale>::type
     double_exponential_cdf(const T_y& y,
                            const T_loc& mu, const T_scale& sigma) {
-      static const std::string function = "double_exponential_cdf";
+      static const char* function = "double_exponential_cdf";
       typedef typename stan::partials_return_type<T_y, T_loc, T_scale>::type
         T_partials_return;
 

--- a/stan/math/prim/scal/prob/double_exponential_lccdf.hpp
+++ b/stan/math/prim/scal/prob/double_exponential_lccdf.hpp
@@ -17,7 +17,6 @@
 #include <boost/random/uniform_01.hpp>
 #include <boost/random/variate_generator.hpp>
 #include <cmath>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -41,7 +40,7 @@ namespace stan {
     typename return_type<T_y, T_loc, T_scale>::type
     double_exponential_lccdf(const T_y& y, const T_loc& mu,
                                 const T_scale& sigma) {
-      static const std::string function = "double_exponential_lccdf";
+      static const char* function = "double_exponential_lccdf";
       typedef typename stan::partials_return_type<T_y, T_loc, T_scale>::type
         T_partials_return;
 

--- a/stan/math/prim/scal/prob/double_exponential_lcdf.hpp
+++ b/stan/math/prim/scal/prob/double_exponential_lcdf.hpp
@@ -17,7 +17,6 @@
 #include <boost/random/uniform_01.hpp>
 #include <boost/random/variate_generator.hpp>
 #include <cmath>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -40,7 +39,7 @@ namespace stan {
     typename return_type<T_y, T_loc, T_scale>::type
     double_exponential_lcdf(const T_y& y, const T_loc& mu,
                                const T_scale& sigma) {
-      static const std::string function = "double_exponential_lcdf";
+      static const char* function = "double_exponential_lcdf";
       typedef typename stan::partials_return_type<T_y, T_loc, T_scale>::type
         T_partials_return;
 

--- a/stan/math/prim/scal/prob/double_exponential_lpdf.hpp
+++ b/stan/math/prim/scal/prob/double_exponential_lpdf.hpp
@@ -19,7 +19,6 @@
 #include <boost/random/uniform_01.hpp>
 #include <boost/random/variate_generator.hpp>
 #include <cmath>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -43,7 +42,7 @@ namespace stan {
     typename return_type<T_y, T_loc, T_scale>::type
     double_exponential_lpdf(const T_y& y,
                            const T_loc& mu, const T_scale& sigma) {
-      static const std::string function = "double_exponential_lpdf";
+      static const char* function = "double_exponential_lpdf";
       typedef typename stan::partials_return_type<T_y, T_loc, T_scale>::type
         T_partials_return;
 

--- a/stan/math/prim/scal/prob/double_exponential_rng.hpp
+++ b/stan/math/prim/scal/prob/double_exponential_rng.hpp
@@ -13,7 +13,6 @@
 #include <stan/math/prim/scal/fun/constants.hpp>
 #include <stan/math/prim/scal/meta/include_summand.hpp>
 #include <stan/math/prim/scal/fun/sign.hpp>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -34,7 +33,7 @@ namespace stan {
     double_exponential_rng(double mu,
                            double sigma,
                            RNG& rng) {
-      static const std::string function = "double_exponential_rng";
+      static const char* function = "double_exponential_rng";
 
       using boost::variate_generator;
       using boost::random::uniform_01;

--- a/stan/math/prim/scal/prob/exp_mod_normal_cdf.hpp
+++ b/stan/math/prim/scal/prob/exp_mod_normal_cdf.hpp
@@ -16,7 +16,6 @@
 #include <boost/random/normal_distribution.hpp>
 #include <boost/random/variate_generator.hpp>
 #include <cmath>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -26,7 +25,7 @@ namespace stan {
     typename return_type<T_y, T_loc, T_scale, T_inv_scale>::type
     exp_mod_normal_cdf(const T_y& y, const T_loc& mu, const T_scale& sigma,
                        const T_inv_scale& lambda) {
-      static const std::string function = "exp_mod_normal_cdf";
+      static const char* function = "exp_mod_normal_cdf";
       typedef typename stan::partials_return_type<T_y, T_loc, T_scale,
                                                   T_inv_scale>::type
         T_partials_return;

--- a/stan/math/prim/scal/prob/exp_mod_normal_lccdf.hpp
+++ b/stan/math/prim/scal/prob/exp_mod_normal_lccdf.hpp
@@ -16,7 +16,6 @@
 #include <boost/random/normal_distribution.hpp>
 #include <boost/random/variate_generator.hpp>
 #include <cmath>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -26,7 +25,7 @@ namespace stan {
     typename return_type<T_y, T_loc, T_scale, T_inv_scale>::type
     exp_mod_normal_lccdf(const T_y& y, const T_loc& mu, const T_scale& sigma,
                             const T_inv_scale& lambda) {
-      static const std::string function = "exp_mod_normal_lccdf";
+      static const char* function = "exp_mod_normal_lccdf";
       typedef typename stan::partials_return_type<T_y, T_loc, T_scale,
                                                   T_inv_scale>::type
         T_partials_return;

--- a/stan/math/prim/scal/prob/exp_mod_normal_lcdf.hpp
+++ b/stan/math/prim/scal/prob/exp_mod_normal_lcdf.hpp
@@ -16,7 +16,6 @@
 #include <boost/random/normal_distribution.hpp>
 #include <boost/random/variate_generator.hpp>
 #include <cmath>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -26,7 +25,7 @@ namespace stan {
     typename return_type<T_y, T_loc, T_scale, T_inv_scale>::type
     exp_mod_normal_lcdf(const T_y& y, const T_loc& mu, const T_scale& sigma,
                            const T_inv_scale& lambda) {
-      static const std::string function = "exp_mod_normal_lcdf";
+      static const char* function = "exp_mod_normal_lcdf";
       typedef typename stan::partials_return_type<T_y, T_loc, T_scale,
                                                   T_inv_scale>::type
         T_partials_return;

--- a/stan/math/prim/scal/prob/exp_mod_normal_lpdf.hpp
+++ b/stan/math/prim/scal/prob/exp_mod_normal_lpdf.hpp
@@ -15,7 +15,6 @@
 #include <boost/random/normal_distribution.hpp>
 #include <boost/random/variate_generator.hpp>
 #include <cmath>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -26,7 +25,7 @@ namespace stan {
     typename return_type<T_y, T_loc, T_scale, T_inv_scale>::type
     exp_mod_normal_lpdf(const T_y& y, const T_loc& mu, const T_scale& sigma,
                        const T_inv_scale& lambda) {
-      static const std::string function = "exp_mod_normal_lpdf";
+      static const char* function = "exp_mod_normal_lpdf";
       typedef typename stan::partials_return_type<T_y, T_loc, T_scale,
                                                   T_inv_scale>::type
         T_partials_return;

--- a/stan/math/prim/scal/prob/exp_mod_normal_rng.hpp
+++ b/stan/math/prim/scal/prob/exp_mod_normal_rng.hpp
@@ -14,7 +14,6 @@
 #include <stan/math/prim/scal/fun/value_of.hpp>
 #include <boost/random/normal_distribution.hpp>
 #include <boost/random/variate_generator.hpp>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -25,7 +24,7 @@ namespace stan {
                        double sigma,
                        double lambda,
                        RNG& rng) {
-      static const std::string function = "exp_mod_normal_rng";
+      static const char* function = "exp_mod_normal_rng";
 
       check_finite(function, "Location parameter", mu);
       check_positive_finite(function, "Inv_scale parameter", lambda);

--- a/stan/math/prim/scal/prob/exponential_cdf.hpp
+++ b/stan/math/prim/scal/prob/exponential_cdf.hpp
@@ -18,7 +18,6 @@
 #include <stan/math/prim/scal/fun/constants.hpp>
 #include <stan/math/prim/scal/meta/include_summand.hpp>
 #include <cmath>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -41,7 +40,7 @@ namespace stan {
       typedef typename stan::partials_return_type<T_y, T_inv_scale>::type
         T_partials_return;
 
-      static const std::string function = "exponential_cdf";
+      static const char* function = "exponential_cdf";
 
       using boost::math::tools::promote_args;
       using std::exp;

--- a/stan/math/prim/scal/prob/exponential_lccdf.hpp
+++ b/stan/math/prim/scal/prob/exponential_lccdf.hpp
@@ -17,7 +17,6 @@
 #include <stan/math/prim/scal/meta/return_type.hpp>
 #include <stan/math/prim/scal/fun/constants.hpp>
 #include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -28,7 +27,7 @@ namespace stan {
       typedef typename stan::partials_return_type<T_y, T_inv_scale>::type
         T_partials_return;
 
-      static const std::string function = "exponential_lccdf";
+      static const char* function = "exponential_lccdf";
 
       using boost::math::tools::promote_args;
 

--- a/stan/math/prim/scal/prob/exponential_lcdf.hpp
+++ b/stan/math/prim/scal/prob/exponential_lcdf.hpp
@@ -18,7 +18,6 @@
 #include <stan/math/prim/scal/fun/constants.hpp>
 #include <stan/math/prim/scal/meta/include_summand.hpp>
 #include <cmath>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -30,7 +29,7 @@ namespace stan {
         typename stan::partials_return_type<T_y, T_inv_scale>::type
         T_partials_return;
 
-      static const std::string function = "exponential_lcdf";
+      static const char* function = "exponential_lcdf";
 
       using boost::math::tools::promote_args;
       using std::log;

--- a/stan/math/prim/scal/prob/exponential_lpdf.hpp
+++ b/stan/math/prim/scal/prob/exponential_lpdf.hpp
@@ -18,7 +18,6 @@
 #include <boost/random/exponential_distribution.hpp>
 #include <boost/random/variate_generator.hpp>
 #include <cmath>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -52,7 +51,7 @@ namespace stan {
     template <bool propto, typename T_y, typename T_inv_scale>
     typename return_type<T_y, T_inv_scale>::type
     exponential_lpdf(const T_y& y, const T_inv_scale& beta) {
-      static const std::string function = "exponential_lpdf";
+      static const char* function = "exponential_lpdf";
       typedef typename stan::partials_return_type<T_y, T_inv_scale>::type
         T_partials_return;
 

--- a/stan/math/prim/scal/prob/exponential_rng.hpp
+++ b/stan/math/prim/scal/prob/exponential_rng.hpp
@@ -13,7 +13,6 @@
 #include <stan/math/prim/scal/meta/include_summand.hpp>
 #include <boost/random/exponential_distribution.hpp>
 #include <boost/random/variate_generator.hpp>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -25,7 +24,7 @@ namespace stan {
       using boost::variate_generator;
       using boost::exponential_distribution;
 
-      static const std::string function = "exponential_rng";
+      static const char* function = "exponential_rng";
 
       check_positive_finite(function, "Inverse scale parameter", beta);
 

--- a/stan/math/prim/scal/prob/frechet_cdf.hpp
+++ b/stan/math/prim/scal/prob/frechet_cdf.hpp
@@ -21,7 +21,6 @@
 #include <stan/math/prim/scal/fun/constants.hpp>
 #include <stan/math/prim/scal/meta/include_summand.hpp>
 #include <cmath>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -32,7 +31,7 @@ namespace stan {
       typedef typename stan::partials_return_type<T_y, T_shape, T_scale>::type
         T_partials_return;
 
-      static const std::string function = "frechet_cdf";
+      static const char* function = "frechet_cdf";
 
       using boost::math::tools::promote_args;
       using std::log;

--- a/stan/math/prim/scal/prob/frechet_lccdf.hpp
+++ b/stan/math/prim/scal/prob/frechet_lccdf.hpp
@@ -21,7 +21,6 @@
 #include <stan/math/prim/scal/fun/constants.hpp>
 #include <stan/math/prim/scal/meta/include_summand.hpp>
 #include <cmath>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -32,7 +31,7 @@ namespace stan {
       typedef typename stan::partials_return_type<T_y, T_shape, T_scale>::type
         T_partials_return;
 
-      static const std::string function = "frechet_lccdf";
+      static const char* function = "frechet_lccdf";
 
       using boost::math::tools::promote_args;
 

--- a/stan/math/prim/scal/prob/frechet_lcdf.hpp
+++ b/stan/math/prim/scal/prob/frechet_lcdf.hpp
@@ -21,7 +21,6 @@
 #include <stan/math/prim/scal/fun/constants.hpp>
 #include <stan/math/prim/scal/meta/include_summand.hpp>
 #include <cmath>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -32,7 +31,7 @@ namespace stan {
       typedef typename stan::partials_return_type<T_y, T_shape, T_scale>::type
         T_partials_return;
 
-      static const std::string function = "frechet_lcdf";
+      static const char* function = "frechet_lcdf";
 
       using boost::math::tools::promote_args;
       using std::log;

--- a/stan/math/prim/scal/prob/frechet_lpdf.hpp
+++ b/stan/math/prim/scal/prob/frechet_lpdf.hpp
@@ -21,7 +21,6 @@
 #include <stan/math/prim/scal/fun/constants.hpp>
 #include <stan/math/prim/scal/meta/include_summand.hpp>
 #include <cmath>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -32,7 +31,7 @@ namespace stan {
               typename T_y, typename T_shape, typename T_scale>
     typename return_type<T_y, T_shape, T_scale>::type
     frechet_lpdf(const T_y& y, const T_shape& alpha, const T_scale& sigma) {
-      static const std::string function = "frechet_lpdf";
+      static const char* function = "frechet_lpdf";
       typedef typename stan::partials_return_type<T_y, T_shape, T_scale>::type
         T_partials_return;
 

--- a/stan/math/prim/scal/prob/frechet_rng.hpp
+++ b/stan/math/prim/scal/prob/frechet_rng.hpp
@@ -16,7 +16,6 @@
 #include <stan/math/prim/scal/meta/include_summand.hpp>
 #include <boost/random/weibull_distribution.hpp>
 #include <boost/random/variate_generator.hpp>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -29,7 +28,7 @@ namespace stan {
       using boost::variate_generator;
       using boost::random::weibull_distribution;
 
-      static const std::string function = "frechet_rng";
+      static const char* function = "frechet_rng";
 
       check_finite(function, "Shape parameter", alpha);
       check_positive(function, "Shape parameter", alpha);

--- a/stan/math/prim/scal/prob/gamma_cdf.hpp
+++ b/stan/math/prim/scal/prob/gamma_cdf.hpp
@@ -25,7 +25,6 @@
 #include <boost/random/variate_generator.hpp>
 #include <cmath>
 #include <limits>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -53,7 +52,7 @@ namespace stan {
                                                   T_inv_scale>::type
         T_partials_return;
 
-      static const std::string function = "gamma_cdf";
+      static const char* function = "gamma_cdf";
 
       using boost::math::tools::promote_args;
       using std::exp;

--- a/stan/math/prim/scal/prob/gamma_lccdf.hpp
+++ b/stan/math/prim/scal/prob/gamma_lccdf.hpp
@@ -25,7 +25,6 @@
 #include <boost/random/variate_generator.hpp>
 #include <cmath>
 #include <limits>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -41,7 +40,7 @@ namespace stan {
                                                   T_inv_scale>::type
         T_partials_return;
 
-      static const std::string function = "gamma_lccdf";
+      static const char* function = "gamma_lccdf";
 
       using boost::math::tools::promote_args;
       using std::exp;

--- a/stan/math/prim/scal/prob/gamma_lcdf.hpp
+++ b/stan/math/prim/scal/prob/gamma_lcdf.hpp
@@ -25,7 +25,6 @@
 #include <stan/math/prim/scal/fun/grad_reg_inc_gamma.hpp>
 #include <cmath>
 #include <limits>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -39,7 +38,7 @@ namespace stan {
                                                   T_inv_scale>::type
         T_partials_return;
 
-      static const std::string function = "gamma_lcdf";
+      static const char* function = "gamma_lcdf";
 
       using boost::math::tools::promote_args;
       using std::exp;

--- a/stan/math/prim/scal/prob/gamma_lpdf.hpp
+++ b/stan/math/prim/scal/prob/gamma_lpdf.hpp
@@ -22,7 +22,6 @@
 #include <boost/random/gamma_distribution.hpp>
 #include <boost/random/variate_generator.hpp>
 #include <cmath>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -53,7 +52,7 @@ namespace stan {
               typename T_y, typename T_shape, typename T_inv_scale>
     typename return_type<T_y, T_shape, T_inv_scale>::type
     gamma_lpdf(const T_y& y, const T_shape& alpha, const T_inv_scale& beta) {
-      static const std::string function = "gamma_lpdf";
+      static const char* function = "gamma_lpdf";
       typedef typename stan::partials_return_type<T_y, T_shape,
                                                   T_inv_scale>::type
         T_partials_return;

--- a/stan/math/prim/scal/prob/gamma_rng.hpp
+++ b/stan/math/prim/scal/prob/gamma_rng.hpp
@@ -19,7 +19,6 @@
 #include <stan/math/prim/scal/meta/return_type.hpp>
 #include <stan/math/prim/scal/meta/include_summand.hpp>
 #include <stan/math/prim/scal/fun/grad_reg_inc_gamma.hpp>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -32,7 +31,7 @@ namespace stan {
       using boost::variate_generator;
       using boost::gamma_distribution;
 
-      static const std::string function = "gamma_rng";
+      static const char* function = "gamma_rng";
       check_positive_finite(function, "Shape parameter", alpha);
       check_positive_finite(function, "Inverse scale parameter", beta);
 

--- a/stan/math/prim/scal/prob/gumbel_cdf.hpp
+++ b/stan/math/prim/scal/prob/gumbel_cdf.hpp
@@ -18,7 +18,6 @@
 #include <stan/math/prim/scal/meta/include_summand.hpp>
 #include <stan/math/prim/scal/fun/value_of.hpp>
 #include <cmath>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -41,7 +40,7 @@ namespace stan {
     template <typename T_y, typename T_loc, typename T_scale>
     typename return_type<T_y, T_loc, T_scale>::type
     gumbel_cdf(const T_y& y, const T_loc& mu, const T_scale& beta) {
-      static const std::string function = "gumbel_cdf";
+      static const char* function = "gumbel_cdf";
       typedef typename stan::partials_return_type<T_y, T_loc, T_scale>::type
         T_partials_return;
 

--- a/stan/math/prim/scal/prob/gumbel_lccdf.hpp
+++ b/stan/math/prim/scal/prob/gumbel_lccdf.hpp
@@ -18,7 +18,6 @@
 #include <stan/math/prim/scal/meta/include_summand.hpp>
 #include <stan/math/prim/scal/fun/value_of.hpp>
 #include <cmath>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -41,7 +40,7 @@ namespace stan {
     template <typename T_y, typename T_loc, typename T_scale>
     typename return_type<T_y, T_loc, T_scale>::type
     gumbel_lccdf(const T_y& y, const T_loc& mu, const T_scale& beta) {
-      static const std::string function = "gumbel_lccdf";
+      static const char* function = "gumbel_lccdf";
       typedef typename stan::partials_return_type<T_y, T_loc, T_scale>::type
         T_partials_return;
 

--- a/stan/math/prim/scal/prob/gumbel_lcdf.hpp
+++ b/stan/math/prim/scal/prob/gumbel_lcdf.hpp
@@ -18,7 +18,6 @@
 #include <stan/math/prim/scal/meta/include_summand.hpp>
 #include <stan/math/prim/scal/fun/value_of.hpp>
 #include <cmath>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -41,7 +40,7 @@ namespace stan {
     template <typename T_y, typename T_loc, typename T_scale>
     typename return_type<T_y, T_loc, T_scale>::type
     gumbel_lcdf(const T_y& y, const T_loc& mu, const T_scale& beta) {
-      static const std::string function = "gumbel_lcdf";
+      static const char* function = "gumbel_lcdf";
       typedef typename stan::partials_return_type<T_y, T_loc, T_scale>::type
         T_partials_return;
 

--- a/stan/math/prim/scal/prob/gumbel_lpdf.hpp
+++ b/stan/math/prim/scal/prob/gumbel_lpdf.hpp
@@ -18,7 +18,6 @@
 #include <stan/math/prim/scal/meta/include_summand.hpp>
 #include <stan/math/prim/scal/fun/value_of.hpp>
 #include <cmath>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -41,7 +40,7 @@ namespace stan {
     template <bool propto, typename T_y, typename T_loc, typename T_scale>
     typename return_type<T_y, T_loc, T_scale>::type
     gumbel_lpdf(const T_y& y, const T_loc& mu, const T_scale& beta) {
-      static const std::string function = "gumbel_lpdf";
+      static const char* function = "gumbel_lpdf";
       typedef typename stan::partials_return_type<T_y, T_loc, T_scale>::type
         T_partials_return;
 

--- a/stan/math/prim/scal/prob/gumbel_rng.hpp
+++ b/stan/math/prim/scal/prob/gumbel_rng.hpp
@@ -13,7 +13,6 @@
 #include <stan/math/prim/scal/fun/value_of.hpp>
 #include <boost/random/uniform_01.hpp>
 #include <boost/random/variate_generator.hpp>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -37,7 +36,7 @@ namespace stan {
       using boost::variate_generator;
       using boost::uniform_01;
 
-      static const std::string function = "gumbel_rng";
+      static const char* function = "gumbel_rng";
 
       check_finite(function, "Location parameter", mu);
       check_positive(function, "Scale parameter", beta);

--- a/stan/math/prim/scal/prob/hypergeometric_lpmf.hpp
+++ b/stan/math/prim/scal/prob/hypergeometric_lpmf.hpp
@@ -14,7 +14,6 @@
 #include <stan/math/prim/scal/meta/include_summand.hpp>
 #include <stan/math/prim/scal/fun/constants.hpp>
 #include <boost/math/distributions.hpp>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -28,7 +27,7 @@ namespace stan {
     double
     hypergeometric_lpmf(const T_n& n, const T_N& N,
                        const T_a& a, const T_b& b) {
-      static const std::string function = "hypergeometric_lpmf";
+      static const char* function = "hypergeometric_lpmf";
 
       if (!(stan::length(n) && stan::length(N) && stan::length(a)
             && stan::length(b)))

--- a/stan/math/prim/scal/prob/hypergeometric_rng.hpp
+++ b/stan/math/prim/scal/prob/hypergeometric_rng.hpp
@@ -6,7 +6,6 @@
 #include <stan/math/prim/scal/err/check_bounded.hpp>
 #include <stan/math/prim/scal/err/check_positive.hpp>
 #include <stan/math/prim/scal/prob/uniform_rng.hpp>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -17,7 +16,7 @@ namespace stan {
       using boost::variate_generator;
       using boost::math::hypergeometric_distribution;
 
-      static const std::string function = "hypergeometric_rng";
+      static const char* function = "hypergeometric_rng";
 
       check_bounded(function, "Draws parameter", N, 0, a+b);
       check_positive(function, "Draws parameter", N);

--- a/stan/math/prim/scal/prob/inv_chi_square_cdf.hpp
+++ b/stan/math/prim/scal/prob/inv_chi_square_cdf.hpp
@@ -23,7 +23,6 @@
 #include <stan/math/prim/scal/meta/include_summand.hpp>
 #include <cmath>
 #include <limits>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -50,7 +49,7 @@ namespace stan {
       if (!(stan::length(y) && stan::length(nu)))
         return 1.0;
 
-      static const std::string function = "inv_chi_square_cdf";
+      static const char* function = "inv_chi_square_cdf";
 
       using boost::math::tools::promote_args;
       using std::exp;

--- a/stan/math/prim/scal/prob/inv_chi_square_lccdf.hpp
+++ b/stan/math/prim/scal/prob/inv_chi_square_lccdf.hpp
@@ -23,7 +23,6 @@
 #include <stan/math/prim/scal/meta/include_summand.hpp>
 #include <cmath>
 #include <limits>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -50,7 +49,7 @@ namespace stan {
       if (!(stan::length(y) && stan::length(nu)))
         return 0.0;
 
-      static const std::string function = "inv_chi_square_lccdf";
+      static const char* function = "inv_chi_square_lccdf";
 
       using boost::math::tools::promote_args;
       using std::exp;

--- a/stan/math/prim/scal/prob/inv_chi_square_lcdf.hpp
+++ b/stan/math/prim/scal/prob/inv_chi_square_lcdf.hpp
@@ -23,7 +23,6 @@
 #include <boost/random/variate_generator.hpp>
 #include <cmath>
 #include <limits>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -50,7 +49,7 @@ namespace stan {
       if (!(stan::length(y) && stan::length(nu)))
         return 0.0;
 
-      static const std::string function = "inv_chi_square_lcdf";
+      static const char* function = "inv_chi_square_lcdf";
 
       using boost::math::tools::promote_args;
       using std::exp;

--- a/stan/math/prim/scal/prob/inv_chi_square_lpdf.hpp
+++ b/stan/math/prim/scal/prob/inv_chi_square_lpdf.hpp
@@ -22,7 +22,6 @@
 #include <stan/math/prim/scal/fun/grad_reg_inc_gamma.hpp>
 #include <stan/math/prim/scal/meta/include_summand.hpp>
 #include <cmath>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -50,7 +49,7 @@ namespace stan {
               typename T_y, typename T_dof>
     typename return_type<T_y, T_dof>::type
     inv_chi_square_lpdf(const T_y& y, const T_dof& nu) {
-      static const std::string function = "inv_chi_square_lpdf";
+      static const char* function = "inv_chi_square_lpdf";
       typedef typename stan::partials_return_type<T_y, T_dof>::type
         T_partials_return;
 

--- a/stan/math/prim/scal/prob/inv_chi_square_rng.hpp
+++ b/stan/math/prim/scal/prob/inv_chi_square_rng.hpp
@@ -17,7 +17,6 @@
 #include <stan/math/prim/scal/meta/include_summand.hpp>
 #include <boost/random/chi_squared_distribution.hpp>
 #include <boost/random/variate_generator.hpp>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -39,7 +38,7 @@ namespace stan {
       using boost::variate_generator;
       using boost::random::chi_squared_distribution;
 
-      static const std::string function = "inv_chi_square_rng";
+      static const char* function = "inv_chi_square_rng";
 
       check_positive_finite(function, "Degrees of freedom parameter", nu);
 

--- a/stan/math/prim/scal/prob/inv_gamma_cdf.hpp
+++ b/stan/math/prim/scal/prob/inv_gamma_cdf.hpp
@@ -26,7 +26,6 @@
 #include <stan/math/prim/scal/meta/include_summand.hpp>
 #include <cmath>
 #include <limits>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -56,7 +55,7 @@ namespace stan {
       if (!(stan::length(y) && stan::length(alpha) && stan::length(beta)))
         return 1.0;
 
-      static const std::string function = "inv_gamma_cdf";
+      static const char* function = "inv_gamma_cdf";
 
       using boost::math::tools::promote_args;
       using std::exp;

--- a/stan/math/prim/scal/prob/inv_gamma_lccdf.hpp
+++ b/stan/math/prim/scal/prob/inv_gamma_lccdf.hpp
@@ -25,7 +25,6 @@
 #include <stan/math/prim/scal/meta/include_summand.hpp>
 #include <cmath>
 #include <limits>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -40,7 +39,7 @@ namespace stan {
       if (!(stan::length(y) && stan::length(alpha) && stan::length(beta)))
         return 0.0;
 
-      static const std::string function = "inv_gamma_lccdf";
+      static const char* function = "inv_gamma_lccdf";
 
       using boost::math::tools::promote_args;
       using std::exp;

--- a/stan/math/prim/scal/prob/inv_gamma_lcdf.hpp
+++ b/stan/math/prim/scal/prob/inv_gamma_lcdf.hpp
@@ -26,7 +26,6 @@
 #include <stan/math/prim/scal/meta/include_summand.hpp>
 #include <cmath>
 #include <limits>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -41,7 +40,7 @@ namespace stan {
       if (!(stan::length(y) && stan::length(alpha) && stan::length(beta)))
         return 0.0;
 
-      static const std::string function = "inv_gamma_lcdf";
+      static const char* function = "inv_gamma_lcdf";
 
       using boost::math::tools::promote_args;
       using std::exp;

--- a/stan/math/prim/scal/prob/inv_gamma_lpdf.hpp
+++ b/stan/math/prim/scal/prob/inv_gamma_lpdf.hpp
@@ -24,7 +24,6 @@
 #include <stan/math/prim/scal/fun/grad_reg_inc_gamma.hpp>
 #include <stan/math/prim/scal/meta/include_summand.hpp>
 #include <cmath>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -49,7 +48,7 @@ namespace stan {
               typename T_y, typename T_shape, typename T_scale>
     typename return_type<T_y, T_shape, T_scale>::type
     inv_gamma_lpdf(const T_y& y, const T_shape& alpha, const T_scale& beta) {
-      static const std::string function = "inv_gamma_lpdf";
+      static const char* function = "inv_gamma_lpdf";
       typedef typename stan::partials_return_type<T_y, T_shape, T_scale>::type
         T_partials_return;
 

--- a/stan/math/prim/scal/prob/inv_gamma_rng.hpp
+++ b/stan/math/prim/scal/prob/inv_gamma_rng.hpp
@@ -19,7 +19,6 @@
 #include <stan/math/prim/scal/meta/include_summand.hpp>
 #include <boost/random/gamma_distribution.hpp>
 #include <boost/random/variate_generator.hpp>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -32,7 +31,7 @@ namespace stan {
       using boost::variate_generator;
       using boost::random::gamma_distribution;
 
-      static const std::string function = "inv_gamma_rng";
+      static const char* function = "inv_gamma_rng";
 
       check_positive_finite(function, "Shape parameter", alpha);
       check_positive_finite(function, "Scale parameter", beta);

--- a/stan/math/prim/scal/prob/logistic_cdf.hpp
+++ b/stan/math/prim/scal/prob/logistic_cdf.hpp
@@ -21,7 +21,6 @@
 #include <stan/math/prim/scal/meta/include_summand.hpp>
 #include <cmath>
 #include <limits>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -36,7 +35,7 @@ namespace stan {
       if (!(stan::length(y) && stan::length(mu) && stan::length(sigma)))
         return 1.0;
 
-      static const std::string function = "logistic_cdf";
+      static const char* function = "logistic_cdf";
 
       using boost::math::tools::promote_args;
       using std::exp;

--- a/stan/math/prim/scal/prob/logistic_lccdf.hpp
+++ b/stan/math/prim/scal/prob/logistic_lccdf.hpp
@@ -22,7 +22,6 @@
 #include <stan/math/prim/scal/meta/include_summand.hpp>
 #include <cmath>
 #include <limits>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -36,7 +35,7 @@ namespace stan {
       if (!(stan::length(y) && stan::length(mu) && stan::length(sigma)))
         return 0.0;
 
-      static const std::string function = "logistic_lccdf";
+      static const char* function = "logistic_lccdf";
 
       using boost::math::tools::promote_args;
       using std::log;

--- a/stan/math/prim/scal/prob/logistic_lcdf.hpp
+++ b/stan/math/prim/scal/prob/logistic_lcdf.hpp
@@ -21,7 +21,6 @@
 #include <stan/math/prim/scal/meta/include_summand.hpp>
 #include <cmath>
 #include <limits>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -35,7 +34,7 @@ namespace stan {
       if (!(stan::length(y) && stan::length(mu) && stan::length(sigma)))
         return 0.0;
 
-      static const std::string function = "logistic_lcdf";
+      static const char* function = "logistic_lcdf";
 
       using boost::math::tools::promote_args;
       using std::log;

--- a/stan/math/prim/scal/prob/logistic_lpdf.hpp
+++ b/stan/math/prim/scal/prob/logistic_lpdf.hpp
@@ -20,7 +20,6 @@
 #include <stan/math/prim/scal/meta/return_type.hpp>
 #include <stan/math/prim/scal/meta/include_summand.hpp>
 #include <cmath>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -30,7 +29,7 @@ namespace stan {
               typename T_y, typename T_loc, typename T_scale>
     typename return_type<T_y, T_loc, T_scale>::type
     logistic_lpdf(const T_y& y, const T_loc& mu, const T_scale& sigma) {
-      static const std::string function = "logistic_lpdf";
+      static const char* function = "logistic_lpdf";
       typedef typename stan::partials_return_type<T_y, T_loc, T_scale>::type
         T_partials_return;
 

--- a/stan/math/prim/scal/prob/logistic_rng.hpp
+++ b/stan/math/prim/scal/prob/logistic_rng.hpp
@@ -14,7 +14,6 @@
 #include <stan/math/prim/scal/meta/include_summand.hpp>
 #include <boost/random/exponential_distribution.hpp>
 #include <boost/random/variate_generator.hpp>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -27,7 +26,7 @@ namespace stan {
       using boost::variate_generator;
       using boost::random::exponential_distribution;
 
-      static const std::string function = "logistic_rng";
+      static const char* function = "logistic_rng";
 
       check_finite(function, "Location parameter", mu);
       check_positive_finite(function, "Scale parameter", sigma);

--- a/stan/math/prim/scal/prob/lognormal_cdf.hpp
+++ b/stan/math/prim/scal/prob/lognormal_cdf.hpp
@@ -17,7 +17,6 @@
 #include <boost/random/lognormal_distribution.hpp>
 #include <boost/random/variate_generator.hpp>
 #include <cmath>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -25,7 +24,7 @@ namespace stan {
     template <typename T_y, typename T_loc, typename T_scale>
     typename return_type<T_y, T_loc, T_scale>::type
     lognormal_cdf(const T_y& y, const T_loc& mu, const T_scale& sigma) {
-      static const std::string function = "lognormal_cdf";
+      static const char* function = "lognormal_cdf";
 
       typedef typename stan::partials_return_type<T_y, T_loc, T_scale>::type
         T_partials_return;

--- a/stan/math/prim/scal/prob/lognormal_lccdf.hpp
+++ b/stan/math/prim/scal/prob/lognormal_lccdf.hpp
@@ -17,7 +17,6 @@
 #include <boost/random/lognormal_distribution.hpp>
 #include <boost/random/variate_generator.hpp>
 #include <cmath>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -25,7 +24,7 @@ namespace stan {
     template <typename T_y, typename T_loc, typename T_scale>
     typename return_type<T_y, T_loc, T_scale>::type
     lognormal_lccdf(const T_y& y, const T_loc& mu, const T_scale& sigma) {
-      static const std::string function = "lognormal_lccdf";
+      static const char* function = "lognormal_lccdf";
       typedef typename stan::partials_return_type<T_y, T_loc, T_scale>::type
         T_partials_return;
 

--- a/stan/math/prim/scal/prob/lognormal_lcdf.hpp
+++ b/stan/math/prim/scal/prob/lognormal_lcdf.hpp
@@ -17,7 +17,6 @@
 #include <boost/random/lognormal_distribution.hpp>
 #include <boost/random/variate_generator.hpp>
 #include <cmath>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -25,7 +24,7 @@ namespace stan {
     template <typename T_y, typename T_loc, typename T_scale>
     typename return_type<T_y, T_loc, T_scale>::type
     lognormal_lcdf(const T_y& y, const T_loc& mu, const T_scale& sigma) {
-      static const std::string function = "lognormal_lcdf";
+      static const char* function = "lognormal_lcdf";
       typedef typename stan::partials_return_type<T_y, T_loc, T_scale>::type
         T_partials_return;
 

--- a/stan/math/prim/scal/prob/lognormal_lpdf.hpp
+++ b/stan/math/prim/scal/prob/lognormal_lpdf.hpp
@@ -21,7 +21,6 @@
 #include <stan/math/prim/scal/meta/return_type.hpp>
 #include <stan/math/prim/scal/meta/include_summand.hpp>
 #include <cmath>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -31,7 +30,7 @@ namespace stan {
               typename T_y, typename T_loc, typename T_scale>
     typename return_type<T_y, T_loc, T_scale>::type
     lognormal_lpdf(const T_y& y, const T_loc& mu, const T_scale& sigma) {
-      static const std::string function = "lognormal_lpdf";
+      static const char* function = "lognormal_lpdf";
       typedef typename stan::partials_return_type<T_y, T_loc, T_scale>::type
         T_partials_return;
 

--- a/stan/math/prim/scal/prob/lognormal_rng.hpp
+++ b/stan/math/prim/scal/prob/lognormal_rng.hpp
@@ -12,7 +12,6 @@
 #include <stan/math/prim/scal/fun/value_of.hpp>
 #include <stan/math/prim/scal/fun/square.hpp>
 #include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -25,7 +24,7 @@ namespace stan {
       using boost::variate_generator;
       using boost::random::lognormal_distribution;
 
-      static const std::string function = "lognormal_rng";
+      static const char* function = "lognormal_rng";
 
       check_finite(function, "Location parameter", mu);
       check_positive_finite(function, "Scale parameter", sigma);

--- a/stan/math/prim/scal/prob/neg_binomial_2_cdf.hpp
+++ b/stan/math/prim/scal/prob/neg_binomial_2_cdf.hpp
@@ -17,7 +17,6 @@
 #include <stan/math/prim/scal/meta/scalar_seq_view.hpp>
 #include <stan/math/prim/scal/meta/VectorBuilder.hpp>
 #include <limits>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -28,7 +27,7 @@ namespace stan {
     neg_binomial_2_cdf(const T_n& n,
                        const T_location& mu,
                        const T_precision& phi) {
-      static const std::string function = "neg_binomial_2_cdf";
+      static const char* function = "neg_binomial_2_cdf";
       typedef typename stan::partials_return_type<T_n, T_location,
                                                   T_precision>::type
         T_partials_return;

--- a/stan/math/prim/scal/prob/neg_binomial_2_lccdf.hpp
+++ b/stan/math/prim/scal/prob/neg_binomial_2_lccdf.hpp
@@ -8,7 +8,6 @@
 #include <stan/math/prim/scal/meta/length.hpp>
 #include <stan/math/prim/scal/meta/scalar_seq_view.hpp>
 #include <stan/math/prim/scal/prob/neg_binomial_ccdf_log.hpp>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -23,7 +22,7 @@ namespace stan {
       if (!(stan::length(n) && stan::length(mu) && stan::length(phi)))
         return 0.0;
 
-      static const std::string function = "neg_binomial_2_lccdf";
+      static const char* function = "neg_binomial_2_lccdf";
       check_positive_finite(function, "Location parameter", mu);
       check_positive_finite(function, "Precision parameter", phi);
       check_not_nan(function, "Random variable", n);

--- a/stan/math/prim/scal/prob/neg_binomial_2_lcdf.hpp
+++ b/stan/math/prim/scal/prob/neg_binomial_2_lcdf.hpp
@@ -9,7 +9,6 @@
 #include <stan/math/prim/scal/meta/scalar_seq_view.hpp>
 #include <stan/math/prim/scal/prob/beta_cdf_log.hpp>
 #include <cmath>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -25,7 +24,7 @@ namespace stan {
       if (!(stan::length(n) && stan::length(mu) && stan::length(phi)))
         return 0.0;
 
-      static const std::string function = "neg_binomial_2_lcdf";
+      static const char* function = "neg_binomial_2_lcdf";
       check_positive_finite(function, "Location parameter", mu);
       check_positive_finite(function, "Precision parameter", phi);
       check_not_nan(function, "Random variable", n);

--- a/stan/math/prim/scal/prob/neg_binomial_2_log_lpmf.hpp
+++ b/stan/math/prim/scal/prob/neg_binomial_2_log_lpmf.hpp
@@ -23,7 +23,6 @@
 #include <boost/random/negative_binomial_distribution.hpp>
 #include <boost/random/variate_generator.hpp>
 #include <cmath>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -40,7 +39,7 @@ namespace stan {
                                                   T_precision>::type
         T_partials_return;
 
-      static const std::string function = "neg_binomial_2_log_lpmf";
+      static const char* function = "neg_binomial_2_log_lpmf";
 
       if (!(stan::length(n) && stan::length(eta) && stan::length(phi)))
         return 0.0;

--- a/stan/math/prim/scal/prob/neg_binomial_2_log_rng.hpp
+++ b/stan/math/prim/scal/prob/neg_binomial_2_log_rng.hpp
@@ -18,7 +18,6 @@
 #include <stan/math/prim/scal/prob/gamma_rng.hpp>
 #include <stan/math/prim/scal/prob/poisson_rng.hpp>
 #include <stan/math/prim/scal/fun/grad_reg_inc_beta.hpp>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -33,7 +32,7 @@ namespace stan {
       using boost::random::poisson_distribution;
       using boost::gamma_distribution;
 
-      static const std::string function = "neg_binomial_2_log_rng";
+      static const char* function = "neg_binomial_2_log_rng";
 
       check_finite(function, "Log-location parameter", eta);
       check_positive_finite(function, "Precision parameter", phi);

--- a/stan/math/prim/scal/prob/neg_binomial_2_lpmf.hpp
+++ b/stan/math/prim/scal/prob/neg_binomial_2_lpmf.hpp
@@ -25,7 +25,6 @@
 #include <boost/random/negative_binomial_distribution.hpp>
 #include <boost/random/variate_generator.hpp>
 #include <cmath>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -42,7 +41,7 @@ namespace stan {
                                                   T_precision>::type
         T_partials_return;
 
-      static const std::string function = "neg_binomial_2_lpmf";
+      static const char* function = "neg_binomial_2_lpmf";
 
       if (!(stan::length(n) && stan::length(mu) && stan::length(phi)))
         return 0.0;

--- a/stan/math/prim/scal/prob/neg_binomial_2_rng.hpp
+++ b/stan/math/prim/scal/prob/neg_binomial_2_rng.hpp
@@ -18,7 +18,6 @@
 #include <stan/math/prim/scal/prob/gamma_rng.hpp>
 #include <stan/math/prim/scal/prob/poisson_rng.hpp>
 #include <stan/math/prim/scal/fun/grad_reg_inc_beta.hpp>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -33,7 +32,7 @@ namespace stan {
       using boost::random::poisson_distribution;
       using boost::gamma_distribution;
 
-      static const std::string function = "neg_binomial_2_rng";
+      static const char* function = "neg_binomial_2_rng";
 
       check_positive_finite(function, "Location parameter", mu);
       check_positive_finite(function, "Precision parameter", phi);

--- a/stan/math/prim/scal/prob/neg_binomial_cdf.hpp
+++ b/stan/math/prim/scal/prob/neg_binomial_cdf.hpp
@@ -19,7 +19,6 @@
 #include <stan/math/prim/scal/fun/inc_beta_ddz.hpp>
 #include <cmath>
 #include <limits>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -29,7 +28,7 @@ namespace stan {
     typename return_type<T_shape, T_inv_scale>::type
     neg_binomial_cdf(const T_n& n, const T_shape& alpha,
                      const T_inv_scale& beta) {
-      static const std::string function = "neg_binomial_cdf";
+      static const char* function = "neg_binomial_cdf";
       typedef typename stan::partials_return_type<T_n, T_shape,
                                                   T_inv_scale>::type
         T_partials_return;

--- a/stan/math/prim/scal/prob/neg_binomial_lccdf.hpp
+++ b/stan/math/prim/scal/prob/neg_binomial_lccdf.hpp
@@ -24,7 +24,6 @@
 #include <boost/random/variate_generator.hpp>
 #include <cmath>
 #include <limits>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -34,7 +33,7 @@ namespace stan {
     typename return_type<T_shape, T_inv_scale>::type
     neg_binomial_lccdf(const T_n& n, const T_shape& alpha,
                           const T_inv_scale& beta) {
-      static const std::string function = "neg_binomial_lccdf";
+      static const char* function = "neg_binomial_lccdf";
       typedef typename stan::partials_return_type<T_n, T_shape,
                                                   T_inv_scale>::type
         T_partials_return;

--- a/stan/math/prim/scal/prob/neg_binomial_lcdf.hpp
+++ b/stan/math/prim/scal/prob/neg_binomial_lcdf.hpp
@@ -24,7 +24,6 @@
 #include <boost/random/variate_generator.hpp>
 #include <cmath>
 #include <limits>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -34,7 +33,7 @@ namespace stan {
     typename return_type<T_shape, T_inv_scale>::type
     neg_binomial_lcdf(const T_n& n, const T_shape& alpha,
                          const T_inv_scale& beta) {
-      static const std::string function = "neg_binomial_lcdf";
+      static const char* function = "neg_binomial_lcdf";
       typedef typename stan::partials_return_type<T_n, T_shape,
                                                   T_inv_scale>::type
         T_partials_return;

--- a/stan/math/prim/scal/prob/neg_binomial_lpmf.hpp
+++ b/stan/math/prim/scal/prob/neg_binomial_lpmf.hpp
@@ -26,7 +26,6 @@
 #include <boost/random/negative_binomial_distribution.hpp>
 #include <boost/random/variate_generator.hpp>
 #include <cmath>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -43,7 +42,7 @@ namespace stan {
                                                   T_inv_scale>::type
         T_partials_return;
 
-      static const std::string function = "neg_binomial_lpmf";
+      static const char* function = "neg_binomial_lpmf";
 
       if (!(stan::length(n) && stan::length(alpha) && stan::length(beta)))
         return 0.0;

--- a/stan/math/prim/scal/prob/neg_binomial_rng.hpp
+++ b/stan/math/prim/scal/prob/neg_binomial_rng.hpp
@@ -19,7 +19,6 @@
 #include <stan/math/prim/scal/prob/poisson_rng.hpp>
 #include <stan/math/prim/scal/fun/grad_reg_inc_beta.hpp>
 #include <stan/math/prim/scal/fun/inc_beta.hpp>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -34,7 +33,7 @@ namespace stan {
       using boost::random::poisson_distribution;
       using boost::gamma_distribution;
 
-      static const std::string function = "neg_binomial_rng";
+      static const char* function = "neg_binomial_rng";
 
       // gamma_rng params must be positive and finite
       check_positive_finite(function, "Shape parameter", alpha);

--- a/stan/math/prim/scal/prob/normal_cdf.hpp
+++ b/stan/math/prim/scal/prob/normal_cdf.hpp
@@ -16,7 +16,6 @@
 #include <boost/random/normal_distribution.hpp>
 #include <boost/random/variate_generator.hpp>
 #include <cmath>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -38,7 +37,7 @@ namespace stan {
     template <typename T_y, typename T_loc, typename T_scale>
     typename return_type<T_y, T_loc, T_scale>::type
     normal_cdf(const T_y& y, const T_loc& mu, const T_scale& sigma) {
-      static const std::string function = "normal_cdf";
+      static const char* function = "normal_cdf";
       typedef typename stan::partials_return_type<T_y, T_loc, T_scale>::type
         T_partials_return;
 

--- a/stan/math/prim/scal/prob/normal_lccdf.hpp
+++ b/stan/math/prim/scal/prob/normal_lccdf.hpp
@@ -17,7 +17,6 @@
 #include <boost/random/variate_generator.hpp>
 #include <cmath>
 #include <limits>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -25,7 +24,7 @@ namespace stan {
     template <typename T_y, typename T_loc, typename T_scale>
     typename return_type<T_y, T_loc, T_scale>::type
     normal_lccdf(const T_y& y, const T_loc& mu, const T_scale& sigma) {
-      static const std::string function = "normal_lccdf";
+      static const char* function = "normal_lccdf";
       typedef typename stan::partials_return_type<T_y, T_loc, T_scale>::type
         T_partials_return;
 

--- a/stan/math/prim/scal/prob/normal_lcdf.hpp
+++ b/stan/math/prim/scal/prob/normal_lcdf.hpp
@@ -17,7 +17,6 @@
 #include <boost/random/variate_generator.hpp>
 #include <cmath>
 #include <limits>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -25,7 +24,7 @@ namespace stan {
     template <typename T_y, typename T_loc, typename T_scale>
     typename return_type<T_y, T_loc, T_scale>::type
     normal_lcdf(const T_y& y, const T_loc& mu, const T_scale& sigma) {
-      static const std::string function = "normal_lcdf";
+      static const char* function = "normal_lcdf";
       typedef typename stan::partials_return_type<T_y, T_loc, T_scale>::type
         T_partials_return;
 

--- a/stan/math/prim/scal/prob/normal_lpdf.hpp
+++ b/stan/math/prim/scal/prob/normal_lpdf.hpp
@@ -17,7 +17,6 @@
 #include <boost/random/normal_distribution.hpp>
 #include <boost/random/variate_generator.hpp>
 #include <cmath>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -45,7 +44,7 @@ namespace stan {
               typename T_y, typename T_loc, typename T_scale>
     typename return_type<T_y, T_loc, T_scale>::type
     normal_lpdf(const T_y& y, const T_loc& mu, const T_scale& sigma) {
-      static const std::string function = "normal_lpdf";
+      static const char* function = "normal_lpdf";
       typedef typename stan::partials_return_type<T_y, T_loc, T_scale>::type
         T_partials_return;
 

--- a/stan/math/prim/scal/prob/normal_rng.hpp
+++ b/stan/math/prim/scal/prob/normal_rng.hpp
@@ -9,7 +9,6 @@
 #include <stan/math/prim/scal/meta/max_size.hpp>
 #include <boost/random/normal_distribution.hpp>
 #include <boost/random/variate_generator.hpp>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -38,7 +37,7 @@ namespace stan {
       using boost::variate_generator;
       using boost::normal_distribution;
 
-      static const std::string function = "normal_rng";
+      static const char* function = "normal_rng";
 
       check_finite(function, "Location parameter", mu);
       check_positive_finite(function, "Scale parameter", sigma);

--- a/stan/math/prim/scal/prob/normal_sufficient_lpdf.hpp
+++ b/stan/math/prim/scal/prob/normal_sufficient_lpdf.hpp
@@ -14,7 +14,6 @@
 #include <stan/math/prim/scal/meta/include_summand.hpp>
 #include <stan/math/prim/scal/meta/VectorBuilder.hpp>
 #include <stan/math/prim/scal/meta/max_size.hpp>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -53,7 +52,7 @@ namespace stan {
     normal_sufficient_lpdf(const T_y& y_bar, const T_s& s_squared,
                            const T_n& n_obs, const T_loc& mu,
                            const T_scale& sigma) {
-      static const std::string function = "normal_sufficient_lpdf";
+      static const char* function = "normal_sufficient_lpdf";
       typedef typename
         stan::partials_return_type<T_y, T_s, T_n, T_loc, T_scale>::type
         T_partials_return;

--- a/stan/math/prim/scal/prob/pareto_cdf.hpp
+++ b/stan/math/prim/scal/prob/pareto_cdf.hpp
@@ -17,7 +17,6 @@
 #include <boost/random/variate_generator.hpp>
 #include <cmath>
 #include <limits>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -31,7 +30,7 @@ namespace stan {
       if (!(stan::length(y) && stan::length(y_min) && stan::length(alpha)))
         return 1.0;
 
-      static const std::string function = "pareto_cdf";
+      static const char* function = "pareto_cdf";
 
       using std::log;
       using std::exp;

--- a/stan/math/prim/scal/prob/pareto_lccdf.hpp
+++ b/stan/math/prim/scal/prob/pareto_lccdf.hpp
@@ -17,7 +17,6 @@
 #include <boost/random/variate_generator.hpp>
 #include <cmath>
 #include <limits>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -32,7 +31,7 @@ namespace stan {
       if (!(stan::length(y) && stan::length(y_min) && stan::length(alpha)))
         return 0.0;
 
-      static const std::string function = "pareto_lccdf";
+      static const char* function = "pareto_lccdf";
 
       using std::log;
       using std::exp;

--- a/stan/math/prim/scal/prob/pareto_lcdf.hpp
+++ b/stan/math/prim/scal/prob/pareto_lcdf.hpp
@@ -17,7 +17,6 @@
 #include <boost/random/variate_generator.hpp>
 #include <cmath>
 #include <limits>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -31,7 +30,7 @@ namespace stan {
       if (!(stan::length(y) && stan::length(y_min) && stan::length(alpha)))
         return 0.0;
 
-      static const std::string function = "pareto_lcdf";
+      static const char* function = "pareto_lcdf";
 
       using std::log;
       using std::exp;

--- a/stan/math/prim/scal/prob/pareto_lpdf.hpp
+++ b/stan/math/prim/scal/prob/pareto_lpdf.hpp
@@ -19,7 +19,6 @@
 #include <boost/random/exponential_distribution.hpp>
 #include <boost/random/variate_generator.hpp>
 #include <cmath>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -29,7 +28,7 @@ namespace stan {
               typename T_y, typename T_scale, typename T_shape>
     typename return_type<T_y, T_scale, T_shape>::type
     pareto_lpdf(const T_y& y, const T_scale& y_min, const T_shape& alpha) {
-      static const std::string function = "pareto_lpdf";
+      static const char* function = "pareto_lpdf";
       typedef typename stan::partials_return_type<T_y, T_scale, T_shape>::type
         T_partials_return;
 

--- a/stan/math/prim/scal/prob/pareto_rng.hpp
+++ b/stan/math/prim/scal/prob/pareto_rng.hpp
@@ -11,7 +11,6 @@
 #include <stan/math/prim/scal/fun/constants.hpp>
 #include <stan/math/prim/scal/fun/multiply_log.hpp>
 #include <stan/math/prim/scal/fun/value_of.hpp>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -24,7 +23,7 @@ namespace stan {
       using boost::variate_generator;
       using boost::exponential_distribution;
 
-      static const std::string function = "pareto_rng";
+      static const char* function = "pareto_rng";
 
       check_positive_finite(function, "Scale parameter", y_min);
       check_positive_finite(function, "Shape parameter", alpha);

--- a/stan/math/prim/scal/prob/pareto_type_2_cdf.hpp
+++ b/stan/math/prim/scal/prob/pareto_type_2_cdf.hpp
@@ -18,7 +18,6 @@
 #include <stan/math/prim/scal/meta/VectorBuilder.hpp>
 #include <boost/random/variate_generator.hpp>
 #include <cmath>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -35,7 +34,7 @@ namespace stan {
             && stan::length(alpha)))
         return 1.0;
 
-      static const std::string function = "pareto_type_2_cdf";
+      static const char* function = "pareto_type_2_cdf";
 
       using std::log;
 

--- a/stan/math/prim/scal/prob/pareto_type_2_lccdf.hpp
+++ b/stan/math/prim/scal/prob/pareto_type_2_lccdf.hpp
@@ -17,7 +17,6 @@
 #include <stan/math/prim/scal/meta/VectorBuilder.hpp>
 #include <boost/random/variate_generator.hpp>
 #include <cmath>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -34,7 +33,7 @@ namespace stan {
             && stan::length(alpha)))
         return 0.0;
 
-      static const std::string function = "pareto_type_2_lccdf";
+      static const char* function = "pareto_type_2_lccdf";
 
       using std::log;
 

--- a/stan/math/prim/scal/prob/pareto_type_2_lcdf.hpp
+++ b/stan/math/prim/scal/prob/pareto_type_2_lcdf.hpp
@@ -17,7 +17,6 @@
 #include <stan/math/prim/scal/meta/VectorBuilder.hpp>
 #include <boost/random/variate_generator.hpp>
 #include <cmath>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -34,7 +33,7 @@ namespace stan {
             && stan::length(alpha)))
         return 0.0;
 
-      static const std::string function = "pareto_type_2_lcdf";
+      static const char* function = "pareto_type_2_lcdf";
 
       using std::log;
 

--- a/stan/math/prim/scal/prob/pareto_type_2_lpdf.hpp
+++ b/stan/math/prim/scal/prob/pareto_type_2_lpdf.hpp
@@ -18,7 +18,6 @@
 #include <stan/math/prim/scal/meta/include_summand.hpp>
 #include <boost/random/variate_generator.hpp>
 #include <cmath>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -29,7 +28,7 @@ namespace stan {
     typename return_type<T_y, T_loc, T_scale, T_shape>::type
     pareto_type_2_lpdf(const T_y& y, const T_loc& mu, const T_scale& lambda,
                       const T_shape& alpha) {
-      static const std::string function = "pareto_type_2_lpdf";
+      static const char* function = "pareto_type_2_lpdf";
       typedef
         typename stan::partials_return_type<T_y, T_loc, T_scale, T_shape>::type
         T_partials_return;

--- a/stan/math/prim/scal/prob/pareto_type_2_rng.hpp
+++ b/stan/math/prim/scal/prob/pareto_type_2_rng.hpp
@@ -12,7 +12,6 @@
 #include <stan/math/prim/scal/fun/value_of.hpp>
 #include <stan/math/prim/scal/fun/log1m.hpp>
 #include <stan/math/prim/scal/prob/uniform_rng.hpp>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -23,7 +22,7 @@ namespace stan {
                       double lambda,
                       double alpha,
                       RNG& rng) {
-      static const std::string function = "pareto_type_2_rng";
+      static const char* function = "pareto_type_2_rng";
 
       check_positive(function, "scale parameter", lambda);
       double uniform_01 = uniform_rng(0.0, 1.0, rng);

--- a/stan/math/prim/scal/prob/poisson_cdf.hpp
+++ b/stan/math/prim/scal/prob/poisson_cdf.hpp
@@ -18,7 +18,6 @@
 #include <boost/random/variate_generator.hpp>
 #include <cmath>
 #include <limits>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -27,7 +26,7 @@ namespace stan {
     template <typename T_n, typename T_rate>
     typename return_type<T_rate>::type
     poisson_cdf(const T_n& n, const T_rate& lambda) {
-      static const std::string function = "poisson_cdf";
+      static const char* function = "poisson_cdf";
       typedef typename stan::partials_return_type<T_n, T_rate>::type
         T_partials_return;
 

--- a/stan/math/prim/scal/prob/poisson_lccdf.hpp
+++ b/stan/math/prim/scal/prob/poisson_lccdf.hpp
@@ -19,7 +19,6 @@
 #include <boost/random/variate_generator.hpp>
 #include <cmath>
 #include <limits>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -27,7 +26,7 @@ namespace stan {
     template <typename T_n, typename T_rate>
     typename return_type<T_rate>::type
     poisson_lccdf(const T_n& n, const T_rate& lambda) {
-      static const std::string function = "poisson_lccdf";
+      static const char* function = "poisson_lccdf";
       typedef typename stan::partials_return_type<T_n, T_rate>::type
         T_partials_return;
 

--- a/stan/math/prim/scal/prob/poisson_lcdf.hpp
+++ b/stan/math/prim/scal/prob/poisson_lcdf.hpp
@@ -18,7 +18,6 @@
 #include <boost/random/variate_generator.hpp>
 #include <cmath>
 #include <limits>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -26,7 +25,7 @@ namespace stan {
     template <typename T_n, typename T_rate>
     typename return_type<T_rate>::type
     poisson_lcdf(const T_n& n, const T_rate& lambda) {
-      static const std::string function = "poisson_lcdf";
+      static const char* function = "poisson_lcdf";
       typedef typename stan::partials_return_type<T_n, T_rate>::type
         T_partials_return;
 

--- a/stan/math/prim/scal/prob/poisson_log_lpmf.hpp
+++ b/stan/math/prim/scal/prob/poisson_log_lpmf.hpp
@@ -20,7 +20,6 @@
 #include <boost/random/variate_generator.hpp>
 #include <cmath>
 #include <limits>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -33,7 +32,7 @@ namespace stan {
       typedef typename stan::partials_return_type<T_n, T_log_rate>::type
         T_partials_return;
 
-      static const std::string function = "poisson_log_lpmf";
+      static const char* function = "poisson_log_lpmf";
 
       using std::exp;
 

--- a/stan/math/prim/scal/prob/poisson_log_rng.hpp
+++ b/stan/math/prim/scal/prob/poisson_log_rng.hpp
@@ -12,7 +12,6 @@
 #include <boost/random/poisson_distribution.hpp>
 #include <boost/random/variate_generator.hpp>
 #include <limits>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -24,7 +23,7 @@ namespace stan {
       using boost::variate_generator;
       using boost::random::poisson_distribution;
 
-      static const std::string function = "poisson_log_rng";
+      static const char* function = "poisson_log_rng";
       static const double POISSON_MAX_LOG_RATE = 30 * std::log(2);
 
       using std::exp;

--- a/stan/math/prim/scal/prob/poisson_lpmf.hpp
+++ b/stan/math/prim/scal/prob/poisson_lpmf.hpp
@@ -19,7 +19,6 @@
 #include <boost/random/poisson_distribution.hpp>
 #include <boost/random/variate_generator.hpp>
 #include <limits>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -31,7 +30,7 @@ namespace stan {
       typedef typename stan::partials_return_type<T_n, T_rate>::type
         T_partials_return;
 
-      static const std::string function = "poisson_lpmf";
+      static const char* function = "poisson_lpmf";
 
       if (!(stan::length(n) && stan::length(lambda)))
         return 0.0;

--- a/stan/math/prim/scal/prob/poisson_rng.hpp
+++ b/stan/math/prim/scal/prob/poisson_rng.hpp
@@ -13,7 +13,6 @@
 #include <boost/random/variate_generator.hpp>
 #include <cmath>
 #include <limits>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -25,7 +24,7 @@ namespace stan {
       using boost::variate_generator;
       using boost::random::poisson_distribution;
 
-      static const std::string function = "poisson_rng";
+      static const char* function = "poisson_rng";
 
       check_not_nan(function, "Rate parameter", lambda);
       check_nonnegative(function, "Rate parameter", lambda);

--- a/stan/math/prim/scal/prob/rayleigh_cdf.hpp
+++ b/stan/math/prim/scal/prob/rayleigh_cdf.hpp
@@ -19,7 +19,6 @@
 #include <stan/math/prim/scal/meta/scalar_seq_view.hpp>
 #include <stan/math/prim/scal/meta/VectorBuilder.hpp>
 #include <cmath>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -27,7 +26,7 @@ namespace stan {
     template <typename T_y, typename T_scale>
     typename return_type<T_y, T_scale>::type
     rayleigh_cdf(const T_y& y, const T_scale& sigma) {
-      static const std::string function = "rayleigh_cdf";
+      static const char* function = "rayleigh_cdf";
       typedef typename stan::partials_return_type<T_y, T_scale>::type
         T_partials_return;
 

--- a/stan/math/prim/scal/prob/rayleigh_lccdf.hpp
+++ b/stan/math/prim/scal/prob/rayleigh_lccdf.hpp
@@ -18,7 +18,6 @@
 #include <stan/math/prim/scal/meta/VectorBuilder.hpp>
 #include <boost/random/uniform_real_distribution.hpp>
 #include <boost/random/variate_generator.hpp>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -26,7 +25,7 @@ namespace stan {
     template <typename T_y, typename T_scale>
     typename return_type<T_y, T_scale>::type
     rayleigh_lccdf(const T_y& y, const T_scale& sigma) {
-      static const std::string function = "rayleigh_lccdf";
+      static const char* function = "rayleigh_lccdf";
       typedef typename stan::partials_return_type<T_y, T_scale>::type
         T_partials_return;
 

--- a/stan/math/prim/scal/prob/rayleigh_lcdf.hpp
+++ b/stan/math/prim/scal/prob/rayleigh_lcdf.hpp
@@ -19,7 +19,6 @@
 #include <stan/math/prim/scal/meta/scalar_seq_view.hpp>
 #include <stan/math/prim/scal/meta/VectorBuilder.hpp>
 #include <cmath>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -27,7 +26,7 @@ namespace stan {
     template <typename T_y, typename T_scale>
     typename return_type<T_y, T_scale>::type
     rayleigh_lcdf(const T_y& y, const T_scale& sigma) {
-      static const std::string function = "rayleigh_lcdf";
+      static const char* function = "rayleigh_lcdf";
       typedef typename stan::partials_return_type<T_y, T_scale>::type
         T_partials_return;
 

--- a/stan/math/prim/scal/prob/rayleigh_lpdf.hpp
+++ b/stan/math/prim/scal/prob/rayleigh_lpdf.hpp
@@ -19,7 +19,6 @@
 #include <stan/math/prim/scal/meta/scalar_seq_view.hpp>
 #include <stan/math/prim/scal/meta/VectorBuilder.hpp>
 #include <cmath>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -28,7 +27,7 @@ namespace stan {
               typename T_y, typename T_scale>
     typename return_type<T_y, T_scale>::type
     rayleigh_lpdf(const T_y& y, const T_scale& sigma) {
-      static const std::string function = "rayleigh_lpdf";
+      static const char* function = "rayleigh_lpdf";
       typedef typename stan::partials_return_type<T_y, T_scale>::type
         T_partials_return;
 

--- a/stan/math/prim/scal/prob/rayleigh_rng.hpp
+++ b/stan/math/prim/scal/prob/rayleigh_rng.hpp
@@ -14,7 +14,6 @@
 #include <stan/math/prim/scal/meta/VectorBuilder.hpp>
 #include <boost/random/uniform_real_distribution.hpp>
 #include <boost/random/variate_generator.hpp>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -26,7 +25,7 @@ namespace stan {
       using boost::variate_generator;
       using boost::random::uniform_real_distribution;
 
-      static const std::string function = "rayleigh_rng";
+      static const char* function = "rayleigh_rng";
 
       check_positive(function, "Scale parameter", sigma);
 

--- a/stan/math/prim/scal/prob/scaled_inv_chi_square_cdf.hpp
+++ b/stan/math/prim/scal/prob/scaled_inv_chi_square_cdf.hpp
@@ -24,7 +24,6 @@
 #include <boost/random/variate_generator.hpp>
 #include <limits>
 #include <cmath>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -52,7 +51,7 @@ namespace stan {
       if (!(stan::length(y) && stan::length(nu) && stan::length(s)))
         return 1.0;
 
-      static const std::string function = "scaled_inv_chi_square_cdf";
+      static const char* function = "scaled_inv_chi_square_cdf";
 
       using std::exp;
 

--- a/stan/math/prim/scal/prob/scaled_inv_chi_square_lccdf.hpp
+++ b/stan/math/prim/scal/prob/scaled_inv_chi_square_lccdf.hpp
@@ -24,7 +24,6 @@
 #include <boost/random/variate_generator.hpp>
 #include <limits>
 #include <cmath>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -39,7 +38,7 @@ namespace stan {
       if (!(stan::length(y) && stan::length(nu) && stan::length(s)))
         return 0.0;
 
-      static const std::string function = "scaled_inv_chi_square_lccdf";
+      static const char* function = "scaled_inv_chi_square_lccdf";
 
       using std::exp;
 

--- a/stan/math/prim/scal/prob/scaled_inv_chi_square_lcdf.hpp
+++ b/stan/math/prim/scal/prob/scaled_inv_chi_square_lcdf.hpp
@@ -24,7 +24,6 @@
 #include <boost/random/variate_generator.hpp>
 #include <limits>
 #include <cmath>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -39,7 +38,7 @@ namespace stan {
       if (!(stan::length(y) && stan::length(nu) && stan::length(s)))
         return 0.0;
 
-      static const std::string function = "scaled_inv_chi_square_lcdf";
+      static const char* function = "scaled_inv_chi_square_lcdf";
 
       using std::exp;
 

--- a/stan/math/prim/scal/prob/scaled_inv_chi_square_lpdf.hpp
+++ b/stan/math/prim/scal/prob/scaled_inv_chi_square_lpdf.hpp
@@ -22,7 +22,6 @@
 #include <boost/random/chi_squared_distribution.hpp>
 #include <boost/random/variate_generator.hpp>
 #include <cmath>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -51,7 +50,7 @@ namespace stan {
     typename return_type<T_y, T_dof, T_scale>::type
     scaled_inv_chi_square_lpdf(const T_y& y,
                                const T_dof& nu, const T_scale& s) {
-      static const std::string function = "scaled_inv_chi_square_lpdf";
+      static const char* function = "scaled_inv_chi_square_lpdf";
       typedef typename stan::partials_return_type<T_y, T_dof, T_scale>::type
         T_partials_return;
 

--- a/stan/math/prim/scal/prob/scaled_inv_chi_square_rng.hpp
+++ b/stan/math/prim/scal/prob/scaled_inv_chi_square_rng.hpp
@@ -17,7 +17,6 @@
 #include <stan/math/prim/scal/meta/length.hpp>
 #include <stan/math/prim/scal/meta/include_summand.hpp>
 #include <stan/math/prim/scal/fun/grad_reg_inc_gamma.hpp>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -30,7 +29,7 @@ namespace stan {
       using boost::variate_generator;
       using boost::random::chi_squared_distribution;
 
-      static const std::string function = "scaled_inv_chi_square_rng";
+      static const char* function = "scaled_inv_chi_square_rng";
 
       check_positive_finite(function, "Degrees of freedom parameter", nu);
       check_positive_finite(function, "Scale parameter", s);

--- a/stan/math/prim/scal/prob/skew_normal_cdf.hpp
+++ b/stan/math/prim/scal/prob/skew_normal_cdf.hpp
@@ -17,7 +17,6 @@
 #include <boost/random/variate_generator.hpp>
 #include <boost/math/distributions.hpp>
 #include <cmath>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -26,7 +25,7 @@ namespace stan {
     typename return_type<T_y, T_loc, T_scale, T_shape>::type
     skew_normal_cdf(const T_y& y, const T_loc& mu, const T_scale& sigma,
                     const T_shape& alpha) {
-      static const std::string function = "skew_normal_cdf";
+      static const char* function = "skew_normal_cdf";
       typedef typename stan::partials_return_type<T_y, T_loc, T_scale,
                                                   T_shape>::type
         T_partials_return;

--- a/stan/math/prim/scal/prob/skew_normal_lccdf.hpp
+++ b/stan/math/prim/scal/prob/skew_normal_lccdf.hpp
@@ -17,7 +17,6 @@
 #include <boost/random/variate_generator.hpp>
 #include <boost/math/distributions.hpp>
 #include <cmath>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -26,7 +25,7 @@ namespace stan {
     typename return_type<T_y, T_loc, T_scale, T_shape>::type
     skew_normal_lccdf(const T_y& y, const T_loc& mu, const T_scale& sigma,
                          const T_shape& alpha) {
-      static const std::string function = "skew_normal_lccdf";
+      static const char* function = "skew_normal_lccdf";
       typedef typename stan::partials_return_type<T_y, T_loc, T_scale,
                                                   T_shape>::type
         T_partials_return;

--- a/stan/math/prim/scal/prob/skew_normal_lcdf.hpp
+++ b/stan/math/prim/scal/prob/skew_normal_lcdf.hpp
@@ -17,7 +17,6 @@
 #include <boost/random/variate_generator.hpp>
 #include <boost/math/distributions.hpp>
 #include <cmath>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -26,7 +25,7 @@ namespace stan {
     typename return_type<T_y, T_loc, T_scale, T_shape>::type
     skew_normal_lcdf(const T_y& y, const T_loc& mu, const T_scale& sigma,
                         const T_shape& alpha) {
-      static const std::string function = "skew_normal_lcdf";
+      static const char* function = "skew_normal_lcdf";
       typedef typename stan::partials_return_type<T_y, T_loc, T_scale,
                                                   T_shape>::type
         T_partials_return;

--- a/stan/math/prim/scal/prob/skew_normal_lpdf.hpp
+++ b/stan/math/prim/scal/prob/skew_normal_lpdf.hpp
@@ -19,7 +19,6 @@
 #include <boost/random/variate_generator.hpp>
 #include <boost/math/distributions.hpp>
 #include <cmath>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -29,7 +28,7 @@ namespace stan {
     typename return_type<T_y, T_loc, T_scale, T_shape>::type
     skew_normal_lpdf(const T_y& y, const T_loc& mu, const T_scale& sigma,
                     const T_shape& alpha) {
-      static const std::string function = "skew_normal_lpdf";
+      static const char* function = "skew_normal_lpdf";
       typedef typename stan::partials_return_type<T_y, T_loc,
                                                   T_scale, T_shape>::type
         T_partials_return;

--- a/stan/math/prim/scal/prob/skew_normal_rng.hpp
+++ b/stan/math/prim/scal/prob/skew_normal_rng.hpp
@@ -12,7 +12,6 @@
 #include <stan/math/prim/scal/fun/constants.hpp>
 #include <stan/math/prim/scal/prob/uniform_rng.hpp>
 #include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -25,7 +24,7 @@ namespace stan {
                     RNG& rng) {
       boost::math::skew_normal_distribution<> dist(mu, sigma, alpha);
 
-      static const std::string function = "skew_normal_rng";
+      static const char* function = "skew_normal_rng";
 
       check_finite(function, "Location parameter", mu);
       check_finite(function, "Shape parameter", alpha);

--- a/stan/math/prim/scal/prob/std_normal_lpdf.hpp
+++ b/stan/math/prim/scal/prob/std_normal_lpdf.hpp
@@ -11,7 +11,6 @@
 #include <stan/math/prim/scal/meta/include_summand.hpp>
 #include <boost/random/normal_distribution.hpp>
 #include <boost/random/variate_generator.hpp>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -30,7 +29,7 @@ namespace stan {
      */
     template <bool propto, typename T_y>
     typename return_type<T_y>::type std_normal_lpdf(const T_y& y) {
-      static const std::string function = "std_normal_lpdf";
+      static const char* function = "std_normal_lpdf";
       typedef typename stan::partials_return_type<T_y>::type
         T_partials_return;
 

--- a/stan/math/prim/scal/prob/student_t_cdf.hpp
+++ b/stan/math/prim/scal/prob/student_t_cdf.hpp
@@ -24,7 +24,6 @@
 #include <boost/random/variate_generator.hpp>
 #include <limits>
 #include <cmath>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -41,7 +40,7 @@ namespace stan {
             && stan::length(sigma)))
         return 1.0;
 
-      static const std::string function = "student_t_cdf";
+      static const char* function = "student_t_cdf";
 
       using std::exp;
 

--- a/stan/math/prim/scal/prob/student_t_lccdf.hpp
+++ b/stan/math/prim/scal/prob/student_t_lccdf.hpp
@@ -24,7 +24,6 @@
 #include <boost/random/variate_generator.hpp>
 #include <cmath>
 #include <limits>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -41,7 +40,7 @@ namespace stan {
             && stan::length(sigma)))
         return 0.0;
 
-      static const std::string function = "student_t_lccdf";
+      static const char* function = "student_t_lccdf";
 
       using std::exp;
 

--- a/stan/math/prim/scal/prob/student_t_lcdf.hpp
+++ b/stan/math/prim/scal/prob/student_t_lcdf.hpp
@@ -24,7 +24,6 @@
 #include <boost/random/variate_generator.hpp>
 #include <cmath>
 #include <limits>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -41,7 +40,7 @@ namespace stan {
             && stan::length(sigma)))
         return 0.0;
 
-      static const std::string function = "student_t_lcdf";
+      static const char* function = "student_t_lcdf";
 
       using std::exp;
 

--- a/stan/math/prim/scal/prob/student_t_lpdf.hpp
+++ b/stan/math/prim/scal/prob/student_t_lpdf.hpp
@@ -23,7 +23,6 @@
 #include <boost/random/student_t_distribution.hpp>
 #include <boost/random/variate_generator.hpp>
 #include <cmath>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -58,7 +57,7 @@ namespace stan {
     typename return_type<T_y, T_dof, T_loc, T_scale>::type
     student_t_lpdf(const T_y& y, const T_dof& nu, const T_loc& mu,
                   const T_scale& sigma) {
-      static const std::string function = "student_t_lpdf";
+      static const char* function = "student_t_lpdf";
       typedef typename stan::partials_return_type<T_y, T_dof, T_loc,
                                                   T_scale>::type
         T_partials_return;

--- a/stan/math/prim/scal/prob/student_t_rng.hpp
+++ b/stan/math/prim/scal/prob/student_t_rng.hpp
@@ -18,7 +18,6 @@
 #include <stan/math/prim/scal/fun/inc_beta.hpp>
 #include <stan/math/prim/scal/meta/include_summand.hpp>
 #include <stan/math/prim/scal/meta/VectorBuilder.hpp>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -32,7 +31,7 @@ namespace stan {
       using boost::variate_generator;
       using boost::random::student_t_distribution;
 
-      static const std::string function = "student_t_rng";
+      static const char* function = "student_t_rng";
 
       check_positive_finite(function, "Degrees of freedom parameter", nu);
       check_finite(function, "Location parameter", mu);

--- a/stan/math/prim/scal/prob/uniform_cdf.hpp
+++ b/stan/math/prim/scal/prob/uniform_cdf.hpp
@@ -15,7 +15,6 @@
 #include <stan/math/prim/scal/meta/scalar_seq_view.hpp>
 #include <boost/random/uniform_real_distribution.hpp>
 #include <boost/random/variate_generator.hpp>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -23,7 +22,7 @@ namespace stan {
     template <typename T_y, typename T_low, typename T_high>
     typename return_type<T_y, T_low, T_high>::type
     uniform_cdf(const T_y& y, const T_low& alpha, const T_high& beta) {
-      static const std::string function = "uniform_cdf";
+      static const char* function = "uniform_cdf";
       typedef typename stan::partials_return_type<T_y, T_low, T_high>::type
         T_partials_return;
 

--- a/stan/math/prim/scal/prob/uniform_lccdf.hpp
+++ b/stan/math/prim/scal/prob/uniform_lccdf.hpp
@@ -16,7 +16,6 @@
 #include <boost/random/uniform_real_distribution.hpp>
 #include <boost/random/variate_generator.hpp>
 #include <cmath>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -24,7 +23,7 @@ namespace stan {
     template <typename T_y, typename T_low, typename T_high>
     typename return_type<T_y, T_low, T_high>::type
     uniform_lccdf(const T_y& y, const T_low& alpha, const T_high& beta) {
-      static const std::string function = "uniform_lccdf";
+      static const char* function = "uniform_lccdf";
       typedef typename stan::partials_return_type<T_y, T_low, T_high>::type
         T_partials_return;
 

--- a/stan/math/prim/scal/prob/uniform_lcdf.hpp
+++ b/stan/math/prim/scal/prob/uniform_lcdf.hpp
@@ -16,7 +16,6 @@
 #include <boost/random/uniform_real_distribution.hpp>
 #include <boost/random/variate_generator.hpp>
 #include <cmath>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -24,7 +23,7 @@ namespace stan {
     template <typename T_y, typename T_low, typename T_high>
     typename return_type<T_y, T_low, T_high>::type
     uniform_lcdf(const T_y& y, const T_low& alpha, const T_high& beta) {
-      static const std::string function = "uniform_lcdf";
+      static const char* function = "uniform_lcdf";
       typedef typename stan::partials_return_type<T_y, T_low, T_high>::type
         T_partials_return;
 

--- a/stan/math/prim/scal/prob/uniform_lpdf.hpp
+++ b/stan/math/prim/scal/prob/uniform_lpdf.hpp
@@ -16,7 +16,6 @@
 #include <boost/random/uniform_real_distribution.hpp>
 #include <boost/random/variate_generator.hpp>
 #include <cmath>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -46,7 +45,7 @@ namespace stan {
               typename T_y, typename T_low, typename T_high>
     typename return_type<T_y, T_low, T_high>::type
     uniform_lpdf(const T_y& y, const T_low& alpha, const T_high& beta) {
-      static const std::string function = "uniform_lpdf";
+      static const char* function = "uniform_lpdf";
       typedef typename stan::partials_return_type<T_y, T_low, T_high>::type
         T_partials_return;
 

--- a/stan/math/prim/scal/prob/uniform_rng.hpp
+++ b/stan/math/prim/scal/prob/uniform_rng.hpp
@@ -11,7 +11,6 @@
 #include <stan/math/prim/scal/fun/value_of.hpp>
 #include <stan/math/prim/scal/meta/VectorBuilder.hpp>
 #include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -24,7 +23,7 @@ namespace stan {
       using boost::variate_generator;
       using boost::random::uniform_real_distribution;
 
-      static const std::string function = "uniform_rng";
+      static const char* function = "uniform_rng";
 
       check_finite(function, "Lower bound parameter", alpha);
       check_finite(function, "Upper bound parameter", beta);

--- a/stan/math/prim/scal/prob/von_mises_rng.hpp
+++ b/stan/math/prim/scal/prob/von_mises_rng.hpp
@@ -10,7 +10,6 @@
 #include <stan/math/prim/scal/prob/uniform_rng.hpp>
 #include <stan/math/prim/scal/meta/include_summand.hpp>
 #include <cmath>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -35,7 +34,7 @@ namespace stan {
       using std::log;
       using std::pow;
 
-      static const std::string function = "von_mises_rng";
+      static const char* function = "von_mises_rng";
 
       check_finite(function, "mean", mu);
       check_positive_finite(function, "inverse of variance", kappa);

--- a/stan/math/prim/scal/prob/weibull_cdf.hpp
+++ b/stan/math/prim/scal/prob/weibull_cdf.hpp
@@ -19,7 +19,6 @@
 #include <boost/random/weibull_distribution.hpp>
 #include <boost/random/variate_generator.hpp>
 #include <cmath>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -44,7 +43,7 @@ namespace stan {
       typedef typename stan::partials_return_type<T_y, T_shape, T_scale>::type
         T_partials_return;
 
-      static const std::string function = "weibull_cdf";
+      static const char* function = "weibull_cdf";
 
       using boost::math::tools::promote_args;
       using std::log;

--- a/stan/math/prim/scal/prob/weibull_lccdf.hpp
+++ b/stan/math/prim/scal/prob/weibull_lccdf.hpp
@@ -19,7 +19,6 @@
 #include <boost/random/weibull_distribution.hpp>
 #include <boost/random/variate_generator.hpp>
 #include <cmath>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -44,7 +43,7 @@ namespace stan {
       typedef typename stan::partials_return_type<T_y, T_shape, T_scale>::type
         T_partials_return;
 
-      static const std::string function = "weibull_lccdf";
+      static const char* function = "weibull_lccdf";
 
       using boost::math::tools::promote_args;
       using std::log;

--- a/stan/math/prim/scal/prob/weibull_lcdf.hpp
+++ b/stan/math/prim/scal/prob/weibull_lcdf.hpp
@@ -19,7 +19,6 @@
 #include <boost/random/weibull_distribution.hpp>
 #include <boost/random/variate_generator.hpp>
 #include <cmath>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -44,7 +43,7 @@ namespace stan {
       typedef typename stan::partials_return_type<T_y, T_shape, T_scale>::type
         T_partials_return;
 
-      static const std::string function = "weibull_lcdf";
+      static const char* function = "weibull_lcdf";
 
       using boost::math::tools::promote_args;
       using std::log;

--- a/stan/math/prim/scal/prob/weibull_lpdf.hpp
+++ b/stan/math/prim/scal/prob/weibull_lpdf.hpp
@@ -19,7 +19,6 @@
 #include <boost/random/weibull_distribution.hpp>
 #include <boost/random/variate_generator.hpp>
 #include <cmath>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -42,7 +41,7 @@ namespace stan {
               typename T_y, typename T_shape, typename T_scale>
     typename return_type<T_y, T_shape, T_scale>::type
     weibull_lpdf(const T_y& y, const T_shape& alpha, const T_scale& sigma) {
-      static const std::string function = "weibull_lpdf";
+      static const char* function = "weibull_lpdf";
       typedef typename stan::partials_return_type<T_y, T_shape, T_scale>::type
         T_partials_return;
 

--- a/stan/math/prim/scal/prob/weibull_rng.hpp
+++ b/stan/math/prim/scal/prob/weibull_rng.hpp
@@ -13,7 +13,6 @@
 #include <stan/math/prim/scal/meta/length.hpp>
 #include <stan/math/prim/scal/fun/constants.hpp>
 #include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -37,7 +36,7 @@ namespace stan {
       using boost::variate_generator;
       using boost::random::weibull_distribution;
 
-      static const std::string function = "weibull_rng";
+      static const char* function = "weibull_rng";
 
       check_positive_finite(function, "Shape parameter", alpha);
       check_positive_finite(function, "Scale parameter", sigma);

--- a/stan/math/prim/scal/prob/wiener_lpdf.hpp
+++ b/stan/math/prim/scal/prob/wiener_lpdf.hpp
@@ -73,7 +73,7 @@ namespace stan {
     typename return_type<T_y, T_alpha, T_tau, T_beta, T_delta>::type
     wiener_lpdf(const T_y& y, const T_alpha& alpha, const T_tau& tau,
                const T_beta& beta, const T_delta& delta) {
-      static const std::string function = "wiener_lpdf";
+      static const char* function = "wiener_lpdf";
 
       using std::log;
       using std::exp;

--- a/stan/math/rev/mat/functor/cvodes_utils.hpp
+++ b/stan/math/rev/mat/functor/cvodes_utils.hpp
@@ -7,7 +7,6 @@
 #include <nvector/nvector_serial.h>
 #include <sstream>
 #include <stdexcept>
-#include <string>
 
 namespace stan {
   namespace math {
@@ -20,7 +19,7 @@ namespace stan {
                                           void *eh_data) {
     }
 
-    inline void cvodes_check_flag(int flag, const std::string& func_name) {
+    inline void cvodes_check_flag(int flag, const char* func_name) {
       if (flag < 0) {
         std::ostringstream ss;
         ss << func_name << " failed with error flag " << flag;

--- a/test/unit/math/prim/arr/err/check_finite_test.cpp
+++ b/test/unit/math/prim/arr/err/check_finite_test.cpp
@@ -1,7 +1,6 @@
 #include <stan/math/prim/arr.hpp>
 #include <gtest/gtest.h>
 #include <limits>
-#include <string>
 #include <vector>
 
 using stan::math::check_finite;
@@ -9,7 +8,7 @@ using stan::math::check_finite;
 
 // ---------- check_finite: vector tests ----------
 TEST(ErrorHandlingScalar, CheckFinite_Vector) {
-  const std::string function = "check_finite";
+  const char* function = "check_finite";
   std::vector<double> x;
 
   x.clear();
@@ -42,7 +41,7 @@ TEST(ErrorHandlingScalar, CheckFinite_Vector) {
 }
 
 TEST(ErrorHandlingScalar, CheckFinite_nan) {
-  const std::string function = "check_finite";
+  const char* function = "check_finite";
   double nan = std::numeric_limits<double>::quiet_NaN();
 
   std::vector<double> x;

--- a/test/unit/math/prim/arr/err/check_nonnegative_test.cpp
+++ b/test/unit/math/prim/arr/err/check_nonnegative_test.cpp
@@ -1,14 +1,14 @@
 #include <stan/math/prim/arr.hpp>
 #include <gtest/gtest.h>
 #include <vector>
-#include <string>
 #include <limits>
+#include <string>
 
 using stan::math::check_nonnegative;
 
 TEST(ErrorHandlingScalar, CheckNonnegativeVectorized) {
   int N = 5;
-  const std::string function = "check_nonnegative";
+  const char* function = "check_nonnegative";
   std::vector<double> x(N);
 
   x.assign(N, 0);
@@ -35,7 +35,7 @@ TEST(ErrorHandlingScalar, CheckNonnegativeVectorized) {
 
 TEST(ErrorHandlingScalar, CheckNonnegativeVectorized_one_indexed_message) {
   int N = 5;
-  const std::string function = "check_nonnegative";
+  const char* function = "check_nonnegative";
   std::vector<double> x(N);
   std::string message;
 
@@ -54,7 +54,7 @@ TEST(ErrorHandlingScalar, CheckNonnegativeVectorized_one_indexed_message) {
 }
 
 TEST(ErrorHandlingScalar, CheckNonnegative_nan) {
-  const std::string function = "check_nonnegative";
+  const char* function = "check_nonnegative";
   double nan = std::numeric_limits<double>::quiet_NaN();
 
   std::vector<double> x;

--- a/test/unit/math/prim/arr/err/check_not_nan_test.cpp
+++ b/test/unit/math/prim/arr/err/check_not_nan_test.cpp
@@ -1,15 +1,15 @@
 #include <stan/math/prim/arr.hpp>
 #include <gtest/gtest.h>
 #include <limits>
-#include <string>
 #include <vector>
+#include <string>
 
 
 using stan::math::check_not_nan;
 
 TEST(ErrorHandlingScalar, CheckNotNanVectorized) {
   int N = 5;
-  const std::string function = "check_not_nan";
+  const char* function = "check_not_nan";
   std::vector<double> x(N);
 
   x.assign(N, 0);
@@ -31,7 +31,7 @@ TEST(ErrorHandlingScalar, CheckNotNanVectorized) {
 
 TEST(ErrorHandlingScalar, CheckNotNanVectorized_one_indexed_message) {
   int N = 5;
-  const std::string function = "check_not_nan";
+  const char* function = "check_not_nan";
   std::vector<double> x(N);
   std::string message;
 

--- a/test/unit/math/prim/arr/err/check_positive_finite_test.cpp
+++ b/test/unit/math/prim/arr/err/check_positive_finite_test.cpp
@@ -1,13 +1,12 @@
 #include <stan/math/prim/arr.hpp>
 #include <gtest/gtest.h>
 #include <vector>
-#include <string>
 #include <limits>
 
 using stan::math::check_positive_finite;
 
 TEST(ErrorHandlingScalar, CheckPositiveFinite_Vector) {
-  const std::string function = "check_positive_finite";
+  const char* function = "check_positive_finite";
   std::vector<double> x;
 
   x.clear();
@@ -54,7 +53,7 @@ TEST(ErrorHandlingScalar, CheckPositiveFinite_Vector) {
 }
 
 TEST(ErrorHandlingScalar, CheckPositiveFinite_nan) {
-  const std::string function = "check_positive_finite";
+  const char* function = "check_positive_finite";
   double nan = std::numeric_limits<double>::quiet_NaN();
 
   std::vector<double> x;

--- a/test/unit/math/prim/arr/err/check_positive_test.cpp
+++ b/test/unit/math/prim/arr/err/check_positive_test.cpp
@@ -1,12 +1,11 @@
 #include <stan/math/prim/arr.hpp>
 #include <gtest/gtest.h>
 #include <limits>
-#include <string>
 #include <vector>
 
 TEST(ErrorHandlingScalar, CheckPositive) {
   using stan::math::check_positive;
-  const std::string function = "check_positive";
+  const char* function = "check_positive";
 
   std::vector<double> x;
   x.push_back(1.0);
@@ -20,7 +19,7 @@ TEST(ErrorHandlingScalar, CheckPositive) {
 
 TEST(ErrorHandlingScalar, CheckPositive_nan) {
   using stan::math::check_positive;
-  const std::string function = "check_positive";
+  const char* function = "check_positive";
 
   double nan = std::numeric_limits<double>::quiet_NaN();
 

--- a/test/unit/math/prim/arr/err/out_of_range_test.cpp
+++ b/test/unit/math/prim/arr/err/out_of_range_test.cpp
@@ -1,12 +1,12 @@
 #include <stan/math/prim/arr.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/util.hpp>
-#include <string>
 #include <vector>
+#include <string>
 
-const std::string function_ = "function";
-const std::string msg1_ = "error_message1 ";
-const std::string msg2_ = "error_message2 ";
+const char* function_ = "function";
+const char* msg1_ = "error_message1 ";
+const char* msg2_ = "error_message2 ";
 
 class ErrorHandlingScalar_out_of_range : public ::testing::Test {
 public:

--- a/test/unit/math/prim/mat/err/check_finite_test.cpp
+++ b/test/unit/math/prim/mat/err/check_finite_test.cpp
@@ -7,7 +7,7 @@ using stan::math::check_finite;
 
 // ---------- check_finite: matrix tests ----------
 TEST(ErrorHandlingScalar, CheckFinite_Matrix) {
-  const std::string function = "check_finite";
+  const char* function = "check_finite";
   Eigen::Matrix<double, Eigen::Dynamic, 1> x;
 
   x.resize(3);
@@ -33,7 +33,7 @@ TEST(ErrorHandlingScalar, CheckFinite_Matrix) {
 
 
 TEST(ErrorHandlingScalar, CheckFinite_Matrix_one_indexed_message) {
-  const std::string function = "check_finite";
+  const char* function = "check_finite";
   Eigen::Matrix<double, Eigen::Dynamic, 1> x;
   std::string message;
 
@@ -53,7 +53,7 @@ TEST(ErrorHandlingScalar, CheckFinite_Matrix_one_indexed_message) {
 }
 
 TEST(ErrorHandlingScalar, CheckFinite_nan) {
-  const std::string function = "check_finite";
+  const char* function = "check_finite";
   double nan = std::numeric_limits<double>::quiet_NaN();
 
   Eigen::Matrix<double, Eigen::Dynamic, 1> x_mat(3);

--- a/test/unit/math/prim/mat/err/check_greater_or_equal_test.cpp
+++ b/test/unit/math/prim/mat/err/check_greater_or_equal_test.cpp
@@ -6,7 +6,7 @@
 using stan::math::check_greater_or_equal;
 
 TEST(ErrorHandlingScalar, CheckGreaterOrEqualMatrix) {
-  const std::string function = "check_greater_or_equal";
+  const char* function = "check_greater_or_equal";
   double x;
   double low;
   Eigen::Matrix<double, Eigen::Dynamic, 1> x_vec;
@@ -122,7 +122,7 @@ TEST(ErrorHandlingScalar, CheckGreaterOrEqualMatrix) {
 
 
 TEST(ErrorHandlingScalar, CheckGreaterOrEqual_Matrix_one_indexed_message) {
-  const std::string function = "check_greater_or_equal";
+  const char* function = "check_greater_or_equal";
   double x;
   double low;
   Eigen::Matrix<double, Eigen::Dynamic, 1> x_vec;
@@ -182,7 +182,7 @@ TEST(ErrorHandlingScalar, CheckGreaterOrEqual_Matrix_one_indexed_message) {
 }
 
 TEST(ErrorHandlingScalar, CheckGreaterOrEqual_nan) {
-  const std::string function = "check_greater_or_equal";
+  const char* function = "check_greater_or_equal";
   double nan = std::numeric_limits<double>::quiet_NaN();
 
   Eigen::Matrix<double, Eigen::Dynamic, 1> x_vec(3);

--- a/test/unit/math/prim/mat/err/check_greater_test.cpp
+++ b/test/unit/math/prim/mat/err/check_greater_test.cpp
@@ -5,7 +5,7 @@
 
 using stan::math::check_greater;
 TEST(ErrorHandlingScalar, CheckGreater_Matrix) {
-  const std::string function = "check_greater";
+  const char* function = "check_greater";
   double x;
   double low;
   Eigen::Matrix<double, Eigen::Dynamic, 1> x_vec;
@@ -109,7 +109,7 @@ TEST(ErrorHandlingScalar, CheckGreater_Matrix) {
 }
 
 TEST(ErrorHandlingScalar, CheckGreater_Matrix_one_indexed_message) {
-  const std::string function = "check_greater";
+  const char* function = "check_greater";
   double x;
   double low;
   Eigen::Matrix<double, Eigen::Dynamic, 1> x_vec;
@@ -169,7 +169,7 @@ TEST(ErrorHandlingScalar, CheckGreater_Matrix_one_indexed_message) {
 }
 
 TEST(ErrorHandlingScalar, CheckGreater_nan) {
-  const std::string function = "check_greater";
+  const char* function = "check_greater";
   double x = 10.0;
   double lb = 0.0;
   double nan = std::numeric_limits<double>::quiet_NaN();

--- a/test/unit/math/prim/mat/err/check_less_or_equal_test.cpp
+++ b/test/unit/math/prim/mat/err/check_less_or_equal_test.cpp
@@ -6,7 +6,7 @@
 using stan::math::check_less_or_equal;
 
 TEST(ErrorHandlingScalar, CheckLessOrEqual_Matrix) {
-  const std::string function = "check_less_or_equal";
+  const char* function = "check_less_or_equal";
   double x;
   double high;
   Eigen::Matrix<double, Eigen::Dynamic, 1> x_vec;
@@ -86,7 +86,7 @@ TEST(ErrorHandlingScalar, CheckLessOrEqual_Matrix) {
 }
 
 TEST(ErrorHandlingScalar, CheckLessOrEqual_Matrix_one_indexed_message) {
-  const std::string function = "check_less";
+  const char* function = "check_less";
   double x;
   double high;
   Eigen::Matrix<double, Eigen::Dynamic, 1> x_vec;
@@ -147,7 +147,7 @@ TEST(ErrorHandlingScalar, CheckLessOrEqual_Matrix_one_indexed_message) {
 }
 
 TEST(ErrorHandlingScalar, CheckLessOrEqual_nan) {
-  const std::string function = "check_less_or_equal";
+  const char* function = "check_less_or_equal";
   double nan = std::numeric_limits<double>::quiet_NaN();
   Eigen::Matrix<double, Eigen::Dynamic, 1> x_vec(3);
   Eigen::Matrix<double, Eigen::Dynamic, 1> low_vec(3);

--- a/test/unit/math/prim/mat/err/check_less_test.cpp
+++ b/test/unit/math/prim/mat/err/check_less_test.cpp
@@ -6,7 +6,7 @@
 using stan::math::check_less;
 
 TEST(ErrorHandlingScalar, CheckLess_Matrix) {
-  const std::string function = "check_less";
+  const char* function = "check_less";
   double x;
   double high;
   Eigen::Matrix<double, Eigen::Dynamic, 1> x_vec;
@@ -93,7 +93,7 @@ TEST(ErrorHandlingScalar, CheckLess_Matrix) {
 
 
 TEST(ErrorHandlingScalar, CheckLess_Matrix_one_indexed_message) {
-  const std::string function = "check_less";
+  const char* function = "check_less";
   double x;
   double high;
   Eigen::Matrix<double, Eigen::Dynamic, 1> x_vec;
@@ -154,7 +154,7 @@ TEST(ErrorHandlingScalar, CheckLess_Matrix_one_indexed_message) {
 }
 
 TEST(ErrorHandlingScalar, CheckGreaterOrEqual_nan) {
-  const std::string function = "check_less";
+  const char* function = "check_less";
   double nan = std::numeric_limits<double>::quiet_NaN();
 
   Eigen::Matrix<double, Eigen::Dynamic, 1> x_vec(3);

--- a/test/unit/math/prim/mat/err/check_pos_definite_test.cpp
+++ b/test/unit/math/prim/mat/err/check_pos_definite_test.cpp
@@ -5,7 +5,7 @@
 #include <string>
 
 
-const std::string function = "function";
+const char* function = "function";
 class ErrorHandlingMatrix : public ::testing::Test {
 public:
   void SetUp() {

--- a/test/unit/math/prim/mat/err/check_pos_semidefinite_test.cpp
+++ b/test/unit/math/prim/mat/err/check_pos_semidefinite_test.cpp
@@ -2,9 +2,8 @@
 #include <gtest/gtest.h>
 #include <test/unit/util.hpp>
 #include <limits>
-#include <string>
 
-const std::string function = "function";
+const char* function = "function";
 class ErrorHandlingMatrix : public ::testing::Test {
 public:
   void SetUp() {

--- a/test/unit/math/prim/mat/err/check_positive_finite_test.cpp
+++ b/test/unit/math/prim/mat/err/check_positive_finite_test.cpp
@@ -6,7 +6,7 @@
 using stan::math::check_positive_finite;
 
 TEST(ErrorHandlingScalar, CheckPositiveFinite_Matrix) {
-  const std::string function = "check_positive_finite";
+  const char* function = "check_positive_finite";
   Eigen::Matrix<double, Eigen::Dynamic, 1> x;
 
   x.resize(3);
@@ -42,7 +42,7 @@ TEST(ErrorHandlingScalar, CheckPositiveFinite_Matrix) {
 
 
 TEST(ErrorHandlingScalar, CheckPositiveFinite_Matrix_one_indexed_message) {
-  const std::string function = "check_positive_finite";
+  const char* function = "check_positive_finite";
   Eigen::Matrix<double, Eigen::Dynamic, 1> x;
   std::string message;
 
@@ -61,7 +61,7 @@ TEST(ErrorHandlingScalar, CheckPositiveFinite_Matrix_one_indexed_message) {
     << message;
 }
 TEST(ErrorHandlingScalar, CheckPositiveFinite_Matrix_one_indexed_message_2) {
-  const std::string function = "check_positive_finite";
+  const char* function = "check_positive_finite";
   Eigen::Matrix<double, Eigen::Dynamic, 1> x;
   std::string message;
 
@@ -81,7 +81,7 @@ TEST(ErrorHandlingScalar, CheckPositiveFinite_Matrix_one_indexed_message_2) {
 }
 
 TEST(ErrorHandlingScalar, CheckPositiveFinite_Matrix_one_indexed_message_3) {
-  const std::string function = "check_positive_finite";
+  const char* function = "check_positive_finite";
   Eigen::Matrix<double, Eigen::Dynamic, 1> x;
   std::string message;
 
@@ -101,7 +101,7 @@ TEST(ErrorHandlingScalar, CheckPositiveFinite_Matrix_one_indexed_message_3) {
 }
 
 TEST(ErrorHandlingScalar, CheckPositiveFinite_nan) {
-  const std::string function = "check_positive_finite";
+  const char* function = "check_positive_finite";
   double nan = std::numeric_limits<double>::quiet_NaN();
 
   Eigen::Matrix<double, Eigen::Dynamic, 1> x_mat(3);

--- a/test/unit/math/prim/mat/err/check_positive_test.cpp
+++ b/test/unit/math/prim/mat/err/check_positive_test.cpp
@@ -1,11 +1,10 @@
 #include <stan/math/prim/mat.hpp>
 #include <gtest/gtest.h>
 #include <limits>
-#include <string>
 
 TEST(ErrorHandlingScalar, CheckPositive) {
   using stan::math::check_positive;
-  const std::string function = "check_positive";
+  const char* function = "check_positive";
 
   Eigen::Matrix<double, Eigen::Dynamic, 1> x_mat(3);
   x_mat << 1, 2, 3;
@@ -20,7 +19,7 @@ TEST(ErrorHandlingScalar, CheckPositive) {
 
 TEST(ErrorHandlingScalar, CheckPositive_nan) {
   using stan::math::check_positive;
-  const std::string function = "check_positive";
+  const char* function = "check_positive";
 
   double nan = std::numeric_limits<double>::quiet_NaN();
 

--- a/test/unit/math/prim/mat/err/domain_error_vec_test.cpp
+++ b/test/unit/math/prim/mat/err/domain_error_vec_test.cpp
@@ -3,10 +3,10 @@
 #include <vector>
 #include <string>
 
-const std::string function_ = "function";
-const std::string y_name_ = "y";
-const std::string msg1_ = "error_message ";
-const std::string msg2_ = " second message";
+const char* function_ = "function";
+const char* y_name_ = "y";
+const char* msg1_ = "error_message ";
+const char* msg2_ = " second message";
 
 class ErrorHandlingScalar_domain_error_vec : public ::testing::Test {
 public:

--- a/test/unit/math/prim/mat/err/invalid_argument_vec_test.cpp
+++ b/test/unit/math/prim/mat/err/invalid_argument_vec_test.cpp
@@ -3,10 +3,10 @@
 #include <vector>
 #include <string>
 
-const std::string function_ = "function";
-const std::string y_name_ = "y";
-const std::string msg1_ = "error_message ";
-const std::string msg2_ = " second message";
+const char* function_ = "function";
+const char* y_name_ = "y";
+const char* msg1_ = "error_message ";
+const char* msg2_ = " second message";
 
 class ErrorHandlingScalar_invalid_argument_vec : public ::testing::Test {
 public:

--- a/test/unit/math/prim/mat/fun/multiply_lower_tri_self_transpose_test.cpp
+++ b/test/unit/math/prim/mat/fun/multiply_lower_tri_self_transpose_test.cpp
@@ -1,6 +1,5 @@
 #include <stan/math/prim/mat.hpp>
 #include <gtest/gtest.h>
-#include <string>
 
 using stan::math::matrix_d;
 
@@ -37,7 +36,7 @@ void test_multiply_lower_tri_self_transpose(const matrix_d& x) {
 TEST(MathMatrix, multiply_lower_tri_self_transpose) {
   using stan::math::check_symmetric;
   using stan::math::multiply_lower_tri_self_transpose;
-  static const std::string function
+  static const char* function
     = "stan::math::multiply_lower_tri_self_transpose(%1%)";
   matrix_d x;
   test_multiply_lower_tri_self_transpose(x);

--- a/test/unit/math/prim/scal/err/check_2F1_converges_test.cpp
+++ b/test/unit/math/prim/scal/err/check_2F1_converges_test.cpp
@@ -1,12 +1,11 @@
 #include <stan/math/prim/scal.hpp>
 #include <gtest/gtest.h>
 #include <limits>
-#include <string>
 
 using stan::math::check_2F1_converges;
 
 TEST(passesOnConvergentArgs, Check2F1Converges) {
-  const std::string function = "check_2F1_converges";
+  const char* function = "check_2F1_converges";
   double a1 = 1.0;
   double a2 = 1.0;
   double b1 = 5.0;

--- a/test/unit/math/prim/scal/err/check_3F2_converges_test.cpp
+++ b/test/unit/math/prim/scal/err/check_3F2_converges_test.cpp
@@ -1,12 +1,11 @@
 #include <stan/math/prim/scal.hpp>
 #include <gtest/gtest.h>
 #include <limits>
-#include <string>
 
 using stan::math::check_3F2_converges;
 
 TEST(passesOnConvergentArgs, Check3F2Converges) {
-  const std::string function = "check_3F2_converges";
+  const char* function = "check_3F2_converges";
   double a1 = 1.0;
   double a2 = 1.0;
   double a3 = 1.0;

--- a/test/unit/math/prim/scal/err/check_bounded_test.cpp
+++ b/test/unit/math/prim/scal/err/check_bounded_test.cpp
@@ -1,13 +1,12 @@
 #include <stan/math/prim/scal.hpp>
 #include <gtest/gtest.h>
 #include <limits>
-#include <string>
 
 using stan::math::check_bounded;
 
 TEST(ErrorHandlingScalar, CheckBounded_x) {
-  const std::string function = "check_bounded";
-  const std::string name = "x";
+  const char* function = "check_bounded";
+  const char* name = "x";
   double x = 0;
   double low = -1;
   double high = 1;
@@ -53,8 +52,8 @@ TEST(ErrorHandlingScalar, CheckBounded_x) {
     << " and bounds: " << high << ", " << low;
 }
 TEST(ErrorHandlingScalar, CheckBounded_Low) {
-  const std::string function = "check_bounded";
-  const std::string name = "x";
+  const char* function = "check_bounded";
+  const char* name = "x";
   double x = 0;
   double low = -1;
   double high = 1;
@@ -80,8 +79,8 @@ TEST(ErrorHandlingScalar, CheckBounded_Low) {
     << low << ", " << high;
 }
 TEST(ErrorHandlingScalar, CheckBounded_High) {
-  const std::string function = "check_bounded";
-  const std::string name = "x";
+  const char* function = "check_bounded";
+  const char* name = "x";
   double x = 0;
   double low = -1;
   double high = 1;
@@ -108,8 +107,8 @@ TEST(ErrorHandlingScalar, CheckBounded_High) {
 TEST(ErrorHandlingScalar, CheckBounded_nan) {
   double nan = std::numeric_limits<double>::quiet_NaN();
 
-  const std::string function = "check_bounded";
-  const std::string name = "x";
+  const char* function = "check_bounded";
+  const char* name = "x";
   double x = 0;
   double low = -1;
   double high = 1;

--- a/test/unit/math/prim/scal/err/check_finite_test.cpp
+++ b/test/unit/math/prim/scal/err/check_finite_test.cpp
@@ -1,12 +1,11 @@
 #include <stan/math/prim/scal.hpp>
 #include <gtest/gtest.h>
 #include <limits>
-#include <string>
 
 using stan::math::check_finite;
 
 TEST(ErrorHandlingScalar, CheckFinite) {
-  const std::string function = "check_finite";
+  const char* function = "check_finite";
   double x = 0;
 
   EXPECT_NO_THROW(check_finite(function, "x", x))
@@ -24,7 +23,7 @@ TEST(ErrorHandlingScalar, CheckFinite) {
 }
 
 TEST(ErrorHandlingScalar, CheckFinite_nan) {
-  const std::string function = "check_finite";
+  const char* function = "check_finite";
   double nan = std::numeric_limits<double>::quiet_NaN();
 
   EXPECT_THROW(check_finite(function, "x", nan), std::domain_error);

--- a/test/unit/math/prim/scal/err/check_greater_or_equal_test.cpp
+++ b/test/unit/math/prim/scal/err/check_greater_or_equal_test.cpp
@@ -1,12 +1,11 @@
 #include <stan/math/prim/scal.hpp>
 #include <gtest/gtest.h>
 #include <limits>
-#include <string>
 
 using stan::math::check_greater_or_equal;
 
 TEST(ErrorHandlingScalar, CheckGreaterOrEqual) {
-  const std::string function = "check_greater_or_equal";
+  const char* function = "check_greater_or_equal";
   double x = 10.0;
   double lb = 0.0;
 
@@ -40,7 +39,7 @@ TEST(ErrorHandlingScalar, CheckGreaterOrEqual) {
 }
 
 TEST(ErrorHandlingScalar, CheckGreaterOrEqual_nan) {
-  const std::string function = "check_greater_or_equal";
+  const char* function = "check_greater_or_equal";
   double x = 10.0;
   double lb = 0.0;
   double nan = std::numeric_limits<double>::quiet_NaN();

--- a/test/unit/math/prim/scal/err/check_greater_test.cpp
+++ b/test/unit/math/prim/scal/err/check_greater_test.cpp
@@ -1,12 +1,11 @@
 #include <stan/math/prim/scal.hpp>
 #include <gtest/gtest.h>
 #include <limits>
-#include <string>
 
 using stan::math::check_greater;
 
 TEST(ErrorHandlingScalar, CheckGreater) {
-  const std::string function = "check_greater";
+  const char* function = "check_greater";
   double x = 10.0;
   double lb = 0.0;
 
@@ -37,7 +36,7 @@ TEST(ErrorHandlingScalar, CheckGreater) {
 }
 
 TEST(ErrorHandlingScalar, CheckGreater_nan) {
-  const std::string function = "check_greater";
+  const char* function = "check_greater";
   double x = 10.0;
   double lb = 0.0;
   double nan = std::numeric_limits<double>::quiet_NaN();

--- a/test/unit/math/prim/scal/err/check_less_or_equal_test.cpp
+++ b/test/unit/math/prim/scal/err/check_less_or_equal_test.cpp
@@ -1,12 +1,11 @@
 #include <stan/math/prim/scal.hpp>
 #include <gtest/gtest.h>
 #include <limits>
-#include <string>
 
 using stan::math::check_less_or_equal;
 
 TEST(ErrorHandlingScalar, CheckLessOrEqual) {
-  const std::string function = "check_less_or_equal";
+  const char* function = "check_less_or_equal";
   double x = -10.0;
   double lb = 0.0;
 
@@ -40,7 +39,7 @@ TEST(ErrorHandlingScalar, CheckLessOrEqual) {
 }
 
 TEST(ErrorHandlingScalar, CheckLessOrEqual_nan) {
-  const std::string function = "check_less_or_equal";
+  const char* function = "check_less_or_equal";
   double x = 10.0;
   double lb = 0.0;
   double nan = std::numeric_limits<double>::quiet_NaN();

--- a/test/unit/math/prim/scal/err/check_less_test.cpp
+++ b/test/unit/math/prim/scal/err/check_less_test.cpp
@@ -1,12 +1,11 @@
 #include <stan/math/prim/scal.hpp>
 #include <gtest/gtest.h>
 #include <limits>
-#include <string>
 
 using stan::math::check_less;
 
 TEST(ErrorHandlingScalar, CheckLess) {
-  const std::string function = "check_less";
+  const char* function = "check_less";
   double x = -10.0;
   double lb = 0.0;
 
@@ -37,7 +36,7 @@ TEST(ErrorHandlingScalar, CheckLess) {
 }
 
 TEST(ErrorHandlingScalar, CheckGreaterOrEqual_nan) {
-  const std::string function = "check_less";
+  const char* function = "check_less";
   double x = 10.0;
   double lb = 0.0;
   double nan = std::numeric_limits<double>::quiet_NaN();

--- a/test/unit/math/prim/scal/err/check_nonnegative_test.cpp
+++ b/test/unit/math/prim/scal/err/check_nonnegative_test.cpp
@@ -1,12 +1,11 @@
 #include <stan/math/prim/scal.hpp>
 #include <gtest/gtest.h>
 #include <limits>
-#include <string>
 
 using stan::math::check_nonnegative;
 
 TEST(ErrorHandlingScalar, CheckNonnegative) {
-  const std::string function = "check_nonnegative";
+  const char* function = "check_nonnegative";
   double x = 0;
 
   EXPECT_NO_THROW(check_nonnegative(function, "x", x))
@@ -30,7 +29,7 @@ TEST(ErrorHandlingScalar, CheckNonnegative) {
 }
 
 TEST(ErrorHandlingScalar, CheckNonnegative_nan) {
-  const std::string function = "check_nonnegative";
+  const char* function = "check_nonnegative";
   double nan = std::numeric_limits<double>::quiet_NaN();
 
   EXPECT_THROW(check_nonnegative(function, "x", nan),

--- a/test/unit/math/prim/scal/err/check_not_nan_test.cpp
+++ b/test/unit/math/prim/scal/err/check_not_nan_test.cpp
@@ -1,12 +1,11 @@
 #include <stan/math/prim/scal.hpp>
 #include <gtest/gtest.h>
 #include <limits>
-#include <string>
 
 using stan::math::check_not_nan;
 
 TEST(ErrorHandlingScalar, CheckNotNan) {
-  const std::string function = "check_not_nan";
+  const char* function = "check_not_nan";
   double x = 0;
 
   EXPECT_NO_THROW(check_not_nan(function, "x", x))

--- a/test/unit/math/prim/scal/err/check_positive_finite_test.cpp
+++ b/test/unit/math/prim/scal/err/check_positive_finite_test.cpp
@@ -1,12 +1,11 @@
 #include <stan/math/prim/scal.hpp>
 #include <gtest/gtest.h>
 #include <limits>
-#include <string>
 
 using stan::math::check_positive_finite;
 
 TEST(ErrorHandlingScalar, CheckPositiveFinite) {
-  const std::string function = "check_positive_finite";
+  const char* function = "check_positive_finite";
   double x = 1;
 
   EXPECT_NO_THROW(check_positive_finite(function, "x", x))
@@ -30,7 +29,7 @@ TEST(ErrorHandlingScalar, CheckPositiveFinite) {
 }
 
 TEST(ErrorHandlingScalar, CheckPositiveFinite_nan) {
-  const std::string function = "check_positive_finite";
+  const char* function = "check_positive_finite";
   double nan = std::numeric_limits<double>::quiet_NaN();
 
   EXPECT_THROW(check_positive_finite(function, "x", nan),

--- a/test/unit/math/prim/scal/err/check_positive_size_test.cpp
+++ b/test/unit/math/prim/scal/err/check_positive_size_test.cpp
@@ -5,9 +5,9 @@
 
 TEST(ErrorHandlingScalar, CheckPositiveSize) {
   using stan::math::check_positive_size;
-  const std::string function = "function";
-  const std::string name = "name";
-  const std::string expr = "expr";
+  const char* function = "function";
+  const char* name = "name";
+  const char* expr = "expr";
   std::string expected_msg;
 
 

--- a/test/unit/math/prim/scal/err/check_positive_test.cpp
+++ b/test/unit/math/prim/scal/err/check_positive_test.cpp
@@ -1,18 +1,17 @@
 #include <stan/math/prim/scal.hpp>
 #include <gtest/gtest.h>
 #include <limits>
-#include <string>
 
 TEST(ErrorHandlingScalar, CheckPositive) {
   using stan::math::check_positive;
-  const std::string function = "check_positive";
+  const char* function = "check_positive";
 
   EXPECT_NO_THROW(check_positive(function, "x", 3.0));
 }
 
 TEST(ErrorHandlingScalar, CheckPositive_nan) {
   using stan::math::check_positive;
-  const std::string function = "check_positive";
+  const char* function = "check_positive";
 
   double nan = std::numeric_limits<double>::quiet_NaN();
 

--- a/test/unit/math/prim/scal/err/domain_error_test.cpp
+++ b/test/unit/math/prim/scal/err/domain_error_test.cpp
@@ -1,12 +1,12 @@
 #include <stan/math/prim/scal.hpp>
 #include <gtest/gtest.h>
-#include <string>
 #include <sstream>
+#include <string>
 
-const std::string function_ = "function";
-const std::string y_name_ = "y";
-const std::string msg1_ = "error_message ";
-const std::string msg2_ = " after y";
+const char* function_ = "function";
+const char* y_name_ = "y";
+const char* msg1_ = "error_message ";
+const char* msg2_ = " after y";
 
 class ErrorHandlingScalar_domain_error : public ::testing::Test {
 public:

--- a/test/unit/math/prim/scal/err/invalid_argument_test.cpp
+++ b/test/unit/math/prim/scal/err/invalid_argument_test.cpp
@@ -2,10 +2,10 @@
 #include <gtest/gtest.h>
 #include <string>
 
-const std::string function_ = "function";
-const std::string y_name_ = "y";
-const std::string msg1_ = "error_message ";
-const std::string msg2_ = " after y";
+const char* function_ = "function";
+const char* y_name_ = "y";
+const char* msg1_ = "error_message ";
+const char* msg2_ = " after y";
 
 class ErrorHandlingScalar_invalid_argument : public ::testing::Test {
 public:

--- a/test/unit/math/prim/scal/err/out_of_range_test.cpp
+++ b/test/unit/math/prim/scal/err/out_of_range_test.cpp
@@ -1,12 +1,12 @@
 #include <stan/math/prim/scal.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/util.hpp>
-#include <string>
 #include <vector>
+#include <string>
 
-const std::string function_ = "function";
-const std::string msg1_ = "error_message1 ";
-const std::string msg2_ = "error_message2 ";
+const char* function_ = "function";
+const char* msg1_ = "error_message1 ";
+const char* msg2_ = "error_message2 ";
 
 class ErrorHandlingScalar_out_of_range : public ::testing::Test {
 public:

--- a/test/unit/math/rev/arr/err/check_bounded_test.cpp
+++ b/test/unit/math/rev/arr/err/check_bounded_test.cpp
@@ -1,6 +1,5 @@
 #include <stan/math/rev/arr.hpp>
 #include <gtest/gtest.h>
-#include <string>
 #include <vector>
 
 TEST(AgradRevErrorHandlingScalar, CheckBoundedVarCheckVectorized) {
@@ -9,7 +8,7 @@ TEST(AgradRevErrorHandlingScalar, CheckBoundedVarCheckVectorized) {
   using stan::math::check_bounded;
 
   int N = 5;
-  const std::string function = "check_bounded";
+  const char* function = "check_bounded";
   vector<var> a;
 
   for (int i = 0; i < N; ++i)

--- a/test/unit/math/rev/arr/err/check_consistent_size_test.cpp
+++ b/test/unit/math/rev/arr/err/check_consistent_size_test.cpp
@@ -1,6 +1,5 @@
 #include <stan/math/rev/arr.hpp>
 #include <gtest/gtest.h>
-#include <string>
 #include <vector>
 
 TEST(AgradRevErrorHandlingScalar, CheckConsistentSizeVarCheckVectorized) {
@@ -9,7 +8,7 @@ TEST(AgradRevErrorHandlingScalar, CheckConsistentSizeVarCheckVectorized) {
   using stan::math::check_consistent_size;
 
   int N = 5;
-  const std::string function = "check_consistent_size";
+  const char* function = "check_consistent_size";
   vector<var> a;
 
   for (int i = 0; i < N; ++i)

--- a/test/unit/math/rev/arr/err/check_consistent_sizes_test.cpp
+++ b/test/unit/math/rev/arr/err/check_consistent_sizes_test.cpp
@@ -1,6 +1,5 @@
 #include <stan/math/rev/arr.hpp>
 #include <gtest/gtest.h>
-#include <string>
 #include <vector>
 
 TEST(AgradRevErrorHandlingScalar, CheckConsistentSizeVarCheckVectorized) {
@@ -9,7 +8,7 @@ TEST(AgradRevErrorHandlingScalar, CheckConsistentSizeVarCheckVectorized) {
   using stan::math::check_consistent_sizes;
 
   int N = 5;
-  const std::string function = "check_consistent_size";
+  const char* function = "check_consistent_size";
   vector<var> a;
   vector<var> b;
 

--- a/test/unit/math/rev/arr/err/check_finite_test.cpp
+++ b/test/unit/math/rev/arr/err/check_finite_test.cpp
@@ -1,6 +1,5 @@
 #include <stan/math/rev/arr.hpp>
 #include <gtest/gtest.h>
-#include <string>
 #include <vector>
 #include <limits>
 
@@ -10,7 +9,7 @@ TEST(AgradRevErrorHandlingScalar, CheckFiniteVarCheckVectorized) {
   using stan::math::check_finite;
 
   int N = 5;
-  const std::string function = "check_finite";
+  const char* function = "check_finite";
   vector<var> a;
 
   for (int i = 0; i < N; ++i)

--- a/test/unit/math/rev/arr/err/check_greater_or_equal_test.cpp
+++ b/test/unit/math/rev/arr/err/check_greater_or_equal_test.cpp
@@ -1,6 +1,5 @@
 #include <stan/math/rev/arr.hpp>
 #include <gtest/gtest.h>
-#include <string>
 #include <vector>
 
 using stan::math::var;
@@ -12,7 +11,7 @@ TEST(AgradRevErrorHandlingScalar, CheckFiniteVarCheckVectorized) {
   using stan::math::check_greater_or_equal;
 
   int N = 5;
-  const std::string function = "check_greater_or_equal";
+  const char* function = "check_greater_or_equal";
   vector<var> a;
 
   for (int i = 0; i < N; ++i)

--- a/test/unit/math/rev/arr/err/check_greater_test.cpp
+++ b/test/unit/math/rev/arr/err/check_greater_test.cpp
@@ -1,6 +1,5 @@
 #include <stan/math/rev/arr.hpp>
 #include <gtest/gtest.h>
-#include <string>
 #include <vector>
 
 using stan::math::check_greater;
@@ -12,7 +11,7 @@ TEST(AgradRevErrorHandlingScalar, CheckGreaterVarCheckVectorized) {
   using stan::math::check_greater;
 
   int N = 5;
-  const std::string function = "check_greater";
+  const char* function = "check_greater";
   vector<var> a;
 
   for (int i = 0; i < N; ++i)

--- a/test/unit/math/rev/arr/err/check_less_or_equal_test.cpp
+++ b/test/unit/math/rev/arr/err/check_less_or_equal_test.cpp
@@ -1,6 +1,5 @@
 #include <stan/math/rev/arr.hpp>
 #include <gtest/gtest.h>
-#include <string>
 #include <vector>
 
 using stan::math::check_less_or_equal;
@@ -12,7 +11,7 @@ TEST(AgradRevErrorHandlingScalar, CheckLessOrEqualVarCheckVectorized) {
   using stan::math::check_less_or_equal;
 
   int N = 5;
-  const std::string function = "check_less_or_equal";
+  const char* function = "check_less_or_equal";
   vector<var> a;
 
   for (int i = 0; i < N; ++i)

--- a/test/unit/math/rev/arr/err/check_less_test.cpp
+++ b/test/unit/math/rev/arr/err/check_less_test.cpp
@@ -1,6 +1,5 @@
 #include <stan/math/rev/arr.hpp>
 #include <gtest/gtest.h>
-#include <string>
 #include <vector>
 
 using stan::math::check_less;
@@ -12,7 +11,7 @@ TEST(AgradRevErrorHandlingScalar, CheckLessVarCheckVectorized) {
   using stan::math::check_less;
 
   int N = 5;
-  const std::string function = "check_less";
+  const char* function = "check_less";
   vector<var> a;
 
   for (int i = 0; i < N; ++i)

--- a/test/unit/math/rev/arr/err/check_nonnegative_test.cpp
+++ b/test/unit/math/rev/arr/err/check_nonnegative_test.cpp
@@ -1,7 +1,6 @@
 #include <stan/math/rev/arr.hpp>
 #include <gtest/gtest.h>
 #include <limits>
-#include <string>
 #include <vector>
 
 using stan::math::var;
@@ -9,7 +8,7 @@ using stan::math::check_nonnegative;
 
 TEST(AgradRevErrorHandlingScalar, CheckNonnegativeVectorized) {
   int N = 5;
-  const std::string function = "check_nonnegative";
+  const char* function = "check_nonnegative";
   std::vector<var> x(N);
 
   x.assign(N, 0);
@@ -42,7 +41,7 @@ TEST(AgradRevErrorHandlingScalar, CheckNonnegativeVarCheckVectorized) {
   using stan::math::check_nonnegative;
 
   int N = 5;
-  const std::string function = "check_nonnegative";
+  const char* function = "check_nonnegative";
   vector<var> a;
 
   for (int i = 0; i < N; ++i)

--- a/test/unit/math/rev/arr/err/check_not_nan_test.cpp
+++ b/test/unit/math/rev/arr/err/check_not_nan_test.cpp
@@ -1,6 +1,5 @@
 #include <stan/math/rev/arr.hpp>
 #include <gtest/gtest.h>
-#include <string>
 #include <vector>
 
 TEST(AgradRevErrorHandlingScalar, CheckNotNanVarCheckVectorized) {
@@ -9,7 +8,7 @@ TEST(AgradRevErrorHandlingScalar, CheckNotNanVarCheckVectorized) {
   using stan::math::check_not_nan;
 
   int N = 5;
-  const std::string function = "check_not_nan";
+  const char* function = "check_not_nan";
   vector<var> a;
 
   for (int i = 0; i < N; ++i)
@@ -31,7 +30,7 @@ TEST(ErrorHandlingScalar, CheckNotNanVarCheckVectorized) {
   using stan::math::check_not_nan;
 
   int N = 5;
-  const std::string function = "check_not_nan";
+  const char* function = "check_not_nan";
   vector<var> a;
 
   for (int i = 0; i < N; ++i)

--- a/test/unit/math/rev/arr/err/check_positive_finite_test.cpp
+++ b/test/unit/math/rev/arr/err/check_positive_finite_test.cpp
@@ -2,13 +2,12 @@
 #include <gtest/gtest.h>
 #include <limits>
 #include <vector>
-#include <string>
 
 using stan::math::var;
 using stan::math::check_positive_finite;
 
 TEST(AgradRevErrorHandlingScalar, CheckPositiveFinite_Vector) {
-  const std::string function = "check_positive_finite";
+  const char* function = "check_positive_finite";
   std::vector<var> x;
 
   x.clear();
@@ -61,7 +60,7 @@ TEST(AgradRevErrorHandlingScalar, CheckPositiveFiniteVarCheckVectorized) {
   using stan::math::check_positive_finite;
 
   int N = 5;
-  const std::string function = "check_positive_finite";
+  const char* function = "check_positive_finite";
   vector<var> a;
 
   for (int i = 0; i < N; ++i)

--- a/test/unit/math/rev/arr/err/check_positive_test.cpp
+++ b/test/unit/math/rev/arr/err/check_positive_test.cpp
@@ -1,13 +1,12 @@
 #include <stan/math/rev/arr.hpp>
 #include <gtest/gtest.h>
-#include <string>
 #include <vector>
 
 using stan::math::var;
 
 TEST(AgradRevErrorHandlingScalar, CheckPositive) {
   using stan::math::check_positive;
-  const std::string function = "check_positive";
+  const char* function = "check_positive";
 
   std::vector<var> x;
   x.push_back(var(1.0));

--- a/test/unit/math/rev/arr/err/domain_error_vec_test.cpp
+++ b/test/unit/math/rev/arr/err/domain_error_vec_test.cpp
@@ -3,10 +3,10 @@
 #include <vector>
 #include <string>
 
-const std::string function_ = "function";
-const std::string y_name_ = "y";
-const std::string msg1_ = "error_message ";
-const std::string msg2_ = " second message";
+const char* function_ = "function";
+const char* y_name_ = "y";
+const char* msg1_ = "error_message ";
+const char* msg2_ = " second message";
 
 class ErrorHandlingScalar_domain_error_vec : public ::testing::Test {
 public:

--- a/test/unit/math/rev/arr/err/invalid_argument_vec_test.cpp
+++ b/test/unit/math/rev/arr/err/invalid_argument_vec_test.cpp
@@ -3,10 +3,10 @@
 #include <vector>
 #include <string>
 
-const std::string function_ = "function";
-const std::string y_name_ = "y";
-const std::string msg1_ = "error_message ";
-const std::string msg2_ = " second message";
+const char* function_ = "function";
+const char* y_name_ = "y";
+const char* msg1_ = "error_message ";
+const char* msg2_ = " second message";
 
 class ErrorHandlingScalar_invalid_argument_vec : public ::testing::Test {
 public:

--- a/test/unit/math/rev/arr/err/out_of_range_test.cpp
+++ b/test/unit/math/rev/arr/err/out_of_range_test.cpp
@@ -1,12 +1,12 @@
 #include <stan/math/rev/arr.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/util.hpp>
-#include <string>
 #include <vector>
+#include <string>
 
-const std::string function_ = "function";
-const std::string msg1_ = "error_message1 ";
-const std::string msg2_ = "error_message2 ";
+const char* function_ = "function";
+const char* msg1_ = "error_message1 ";
+const char* msg2_ = "error_message2 ";
 
 class ErrorHandlingScalar_out_of_range : public ::testing::Test {
 public:

--- a/test/unit/math/rev/mat/err/check_consistent_size_test.cpp
+++ b/test/unit/math/rev/mat/err/check_consistent_size_test.cpp
@@ -1,7 +1,6 @@
 #include <stan/math/rev/mat.hpp>
 #include <gtest/gtest.h>
 #include <limits>
-#include <string>
 
 TEST(AgradRevErrorHandlingScalar, checkConsistentSize) {
   using Eigen::Matrix;
@@ -10,8 +9,8 @@ TEST(AgradRevErrorHandlingScalar, checkConsistentSize) {
   using stan::size_of;
   using stan::math::var;
 
-  const std::string function = "check_consistent_size";
-  const std::string name1 = "name1";
+  const char* function = "check_consistent_size";
+  const char* name1 = "name1";
 
 
   Matrix<var, Dynamic, 1> v1(4);
@@ -30,8 +29,8 @@ TEST(AgradRevErrorHandlingScalar, checkConsistentSize_nan) {
   using stan::size_of;
   using stan::math::var;
 
-  const std::string function = "check_consistent_size";
-  const std::string name1 = "name1";
+  const char* function = "check_consistent_size";
+  const char* name1 = "name1";
 
   double nan = std::numeric_limits<double>::quiet_NaN();
 

--- a/test/unit/math/rev/mat/err/check_consistent_sizes_test.cpp
+++ b/test/unit/math/rev/mat/err/check_consistent_sizes_test.cpp
@@ -1,7 +1,6 @@
 #include <stan/math/rev/mat.hpp>
 #include <gtest/gtest.h>
 #include <vector>
-#include <string>
 
 TEST(AgradRevErrorHandlingScalar, checkConsistentSizes) {
   using Eigen::Matrix;
@@ -10,11 +9,11 @@ TEST(AgradRevErrorHandlingScalar, checkConsistentSizes) {
   using stan::size_of;
   using stan::math::var;
 
-  const std::string function = "testConsSizes";
-  const std::string name1 = "name1";
-  const std::string name2 = "name2";
-  const std::string name3 = "name3";
-  const std::string name4 = "name4";
+  const char* function = "testConsSizes";
+  const char* name1 = "name1";
+  const char* name2 = "name2";
+  const char* name3 = "name3";
+  const char* name4 = "name4";
 
 
   Matrix<var, Dynamic, 1> v1(4);
@@ -35,7 +34,7 @@ TEST(AgradRevErrorHandlingScalar, checkConsistentSizes) {
   Matrix<var, Dynamic, 1> v(3);
 
   ASSERT_EQ(3U, size_of(v));
-  const std::string name = "inconsistent";
+  const char* name = "inconsistent";
   EXPECT_THROW(check_consistent_sizes(function, name, v, name2, v2),
                std::invalid_argument);
   EXPECT_THROW(check_consistent_sizes(function, name1, v1, name, v),

--- a/test/unit/math/rev/mat/err/check_cov_matrix_test.cpp
+++ b/test/unit/math/rev/mat/err/check_cov_matrix_test.cpp
@@ -1,6 +1,5 @@
 #include <stan/math/rev/mat.hpp>
 #include <gtest/gtest.h>
-#include <string>
 
 TEST(AgradRevErrorHandlingMatrix, CheckCovMatrix) {
   using stan::math::var;
@@ -9,7 +8,7 @@ TEST(AgradRevErrorHandlingMatrix, CheckCovMatrix) {
 
   using stan::math::check_cov_matrix;
 
-  const std::string function = "check_cov_matrix";
+  const char* function = "check_cov_matrix";
   Matrix<var, Dynamic, Dynamic> Sigma;
   Sigma.resize(1, 1);
   Sigma << 1;

--- a/test/unit/math/rev/mat/err/check_greater_or_equal_test.cpp
+++ b/test/unit/math/rev/mat/err/check_greater_or_equal_test.cpp
@@ -1,13 +1,12 @@
 #include <stan/math/rev/mat.hpp>
 #include <gtest/gtest.h>
 #include <limits>
-#include <string>
 
 using stan::math::var;
 using stan::math::check_greater_or_equal;
 
 TEST(AgradRevErrorHandlingScalar, CheckGreaterOrEqualMatrix) {
-  const std::string function = "check_greater_or_equal";
+  const char* function = "check_greater_or_equal";
   var x;
   var low;
   Eigen::Matrix<var, Eigen::Dynamic, 1> x_vec;

--- a/test/unit/math/rev/mat/err/check_greater_test.cpp
+++ b/test/unit/math/rev/mat/err/check_greater_test.cpp
@@ -1,13 +1,12 @@
 #include <stan/math/rev/mat.hpp>
 #include <gtest/gtest.h>
 #include <limits>
-#include <string>
 
 using stan::math::check_greater;
 using stan::math::var;
 
 TEST(AgradRevErrorHandlingScalar, CheckGreaterMatrix) {
-  const std::string function = "check_greater";
+  const char* function = "check_greater";
   var x;
   var low;
   Eigen::Matrix<var, Eigen::Dynamic, 1> x_vec;

--- a/test/unit/math/rev/mat/err/check_less_or_equal_test.cpp
+++ b/test/unit/math/rev/mat/err/check_less_or_equal_test.cpp
@@ -1,13 +1,12 @@
 #include <stan/math/rev/mat.hpp>
 #include <gtest/gtest.h>
 #include <limits>
-#include <string>
 
 using stan::math::check_less_or_equal;
 using stan::math::var;
 
 TEST(AgradRevErrorHandlingScalar, CheckLessOrEqual_Matrix) {
-  const std::string function = "check_less_or_equal";
+  const char* function = "check_less_or_equal";
   var x;
   var high;
   Eigen::Matrix<var, Eigen::Dynamic, 1> x_vec;

--- a/test/unit/math/rev/mat/err/check_less_test.cpp
+++ b/test/unit/math/rev/mat/err/check_less_test.cpp
@@ -1,13 +1,12 @@
 #include <stan/math/rev/mat.hpp>
 #include <gtest/gtest.h>
 #include <limits>
-#include <string>
 
 using stan::math::check_less;
 using stan::math::var;
 
 TEST(AgradRevErrorHandlingScalar, CheckLess_Matrix) {
-  const std::string function = "check_less";
+  const char* function = "check_less";
   var x;
   var high;
   Eigen::Matrix<var, Eigen::Dynamic, 1> x_vec;

--- a/test/unit/math/rev/mat/err/check_positive_finite_test.cpp
+++ b/test/unit/math/rev/mat/err/check_positive_finite_test.cpp
@@ -1,13 +1,12 @@
 #include <stan/math/rev/mat.hpp>
 #include <gtest/gtest.h>
 #include <limits>
-#include <string>
 
 using stan::math::var;
 using stan::math::check_positive_finite;
 
 TEST(AgradRevErrorHandlingScalar, CheckPositiveFinite_Matrix) {
-  const std::string function = "check_positive_finite";
+  const char* function = "check_positive_finite";
   Eigen::Matrix<var, Eigen::Dynamic, 1> x;
 
   x.resize(3);

--- a/test/unit/math/rev/mat/err/check_positive_test.cpp
+++ b/test/unit/math/rev/mat/err/check_positive_test.cpp
@@ -1,12 +1,11 @@
 #include <stan/math/rev/mat.hpp>
 #include <gtest/gtest.h>
-#include <string>
 
 using stan::math::var;
 
 TEST(AgradRevErrorHandlingScalar, CheckPositive) {
   using stan::math::check_positive;
-  const std::string function = "check_positive";
+  const char* function = "check_positive";
 
   Eigen::Matrix<var, Eigen::Dynamic, 1> x_mat(3);
   x_mat   << 1, 2, 3;

--- a/test/unit/math/rev/scal/err/check_bounded_test.cpp
+++ b/test/unit/math/rev/scal/err/check_bounded_test.cpp
@@ -1,14 +1,13 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
 #include <limits>
-#include <string>
 
 TEST(AgradRevErrorHandlingScalar, CheckBounded_X) {
   using stan::math::var;
   using stan::math::check_bounded;
 
-  const std::string function = "check_bounded";
-  const std::string name = "x";
+  const char* function = "check_bounded";
+  const char* name = "x";
   var x = 0;
   var low = -1;
   var high = 1;
@@ -60,8 +59,8 @@ TEST(AgradRevErrorHandlingScalar, CheckBounded_Low) {
   using stan::math::var;
   using stan::math::check_bounded;
 
-  const std::string function = "check_bounded";
-  const std::string name = "x";
+  const char* function = "check_bounded";
+  const char* name = "x";
   var x = 0;
   var low = -1;
   var high = 1;
@@ -90,8 +89,8 @@ TEST(AgradRevErrorHandlingScalar, CheckBounded_High) {
   using stan::math::var;
   using stan::math::check_bounded;
 
-  const std::string function = "check_bounded";
-  const std::string name = "x";
+  const char* function = "check_bounded";
+  const char* name = "x";
   var x = 0;
   var low = -1;
   var high = 1;
@@ -121,7 +120,7 @@ TEST(AgradRevErrorHandlingScalar, CheckBoundedVarCheckUnivariate) {
   using stan::math::var;
   using stan::math::check_bounded;
 
-  const std::string function = "check_bounded";
+  const char* function = "check_bounded";
   var a(5.0);
 
   size_t stack_size = stan::math::ChainableStack::var_stack_.size();

--- a/test/unit/math/rev/scal/err/check_finite_test.cpp
+++ b/test/unit/math/rev/scal/err/check_finite_test.cpp
@@ -1,14 +1,13 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
 #include <limits>
-#include <string>
 
 TEST(AgradRevErrorHandlingScalar, CheckFinite) {
   using stan::math::var;
   using stan::math::check_finite;
 
-  const std::string function = "check_bounded";
-  const std::string name = "x";
+  const char* function = "check_bounded";
+  const char* name = "x";
   var x = 0;
 
   EXPECT_NO_THROW(check_finite(function, name, x))
@@ -32,7 +31,7 @@ TEST(AgradRevErrorHandlingScalar, CheckFiniteVarCheckUnivariate) {
   using stan::math::var;
   using stan::math::check_finite;
 
-  const std::string function = "check_finite";
+  const char* function = "check_finite";
   var a(5.0);
 
   size_t stack_size = stan::math::ChainableStack::var_stack_.size();

--- a/test/unit/math/rev/scal/err/check_greater_or_equal_test.cpp
+++ b/test/unit/math/rev/scal/err/check_greater_or_equal_test.cpp
@@ -1,13 +1,12 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
 #include <limits>
-#include <string>
 
 using stan::math::var;
 using stan::math::check_greater_or_equal;
 
 TEST(AgradRevErrorHandlingScalar, CheckGreaterOrEqual) {
-  const std::string function = "check_greater_or_equal";
+  const char* function = "check_greater_or_equal";
   var x = 10.0;
   var lb = 0.0;
 
@@ -46,7 +45,7 @@ TEST(AgradRevErrorHandlingScalar, CheckGreaterOrEqualVarCheckUnivariate) {
   using stan::math::var;
   using stan::math::check_greater_or_equal;
 
-  const std::string function = "check_greater_or_equal";
+  const char* function = "check_greater_or_equal";
   var a(5.0);
 
   size_t stack_size = stan::math::ChainableStack::var_stack_.size();

--- a/test/unit/math/rev/scal/err/check_greater_test.cpp
+++ b/test/unit/math/rev/scal/err/check_greater_test.cpp
@@ -1,13 +1,12 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
 #include <limits>
-#include <string>
 
 using stan::math::check_greater;
 using stan::math::var;
 
 TEST(AgradRevErrorHandlingScalar, CheckGreater) {
-  const std::string function = "check_greater";
+  const char* function = "check_greater";
   var x = 10.0;
   var lb = 0.0;
 
@@ -44,7 +43,7 @@ TEST(AgradRevErrorHandlingScalar, CheckGreaterVarCheckUnivariate) {
   using stan::math::var;
   using stan::math::check_greater;
 
-  const std::string function = "check_greater";
+  const char* function = "check_greater";
   var a(5.0);
 
   size_t stack_size = stan::math::ChainableStack::var_stack_.size();

--- a/test/unit/math/rev/scal/err/check_less_or_equal_test.cpp
+++ b/test/unit/math/rev/scal/err/check_less_or_equal_test.cpp
@@ -1,13 +1,12 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
 #include <limits>
-#include <string>
 
 using stan::math::check_less_or_equal;
 using stan::math::var;
 
 TEST(AgradRevErrorHandlingScalar, CheckLessOrEqual) {
-  const std::string function = "check_less_or_equal";
+  const char* function = "check_less_or_equal";
   var x = -10.0;
   var lb = 0.0;
 
@@ -44,7 +43,7 @@ TEST(AgradRevErrorHandlingScalar, CheckLessOrEqualVarCheckUnivariate) {
   using stan::math::var;
   using stan::math::check_less_or_equal;
 
-  const std::string function = "check_less_or_equal";
+  const char* function = "check_less_or_equal";
   var a(5.0);
 
   size_t stack_size = stan::math::ChainableStack::var_stack_.size();

--- a/test/unit/math/rev/scal/err/check_less_test.cpp
+++ b/test/unit/math/rev/scal/err/check_less_test.cpp
@@ -1,13 +1,12 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
 #include <limits>
-#include <string>
 
 using stan::math::check_less;
 using stan::math::var;
 
 TEST(AgradRevErrorHandlingScalar, CheckLess) {
-  const std::string function = "check_less";
+  const char* function = "check_less";
   var x = -10.0;
   var lb = 0.0;
 
@@ -42,7 +41,7 @@ TEST(AgradRevErrorHandlingScalar, CheckLessVarCheckUnivariate) {
   using stan::math::var;
   using stan::math::check_less;
 
-  const std::string function = "check_less";
+  const char* function = "check_less";
   var a(5.0);
 
   size_t stack_size = stan::math::ChainableStack::var_stack_.size();

--- a/test/unit/math/rev/scal/err/check_nonnegative_test.cpp
+++ b/test/unit/math/rev/scal/err/check_nonnegative_test.cpp
@@ -1,13 +1,12 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
 #include <limits>
-#include <string>
 
 using stan::math::var;
 using stan::math::check_nonnegative;
 
 TEST(AgradRevErrorHandlingScalar, CheckNonnegative) {
-  const std::string function = "check_nonnegative";
+  const char* function = "check_nonnegative";
   var x = 0;
 
   EXPECT_NO_THROW(check_nonnegative(function, "x", x))
@@ -35,7 +34,7 @@ TEST(AgradRevErrorHandlingScalar, CheckNonnegativeVarCheckUnivariate) {
   using stan::math::var;
   using stan::math::check_nonnegative;
 
-  const std::string function = "check_nonnegative";
+  const char* function = "check_nonnegative";
   var a(5.0);
 
   size_t stack_size = stan::math::ChainableStack::var_stack_.size();

--- a/test/unit/math/rev/scal/err/check_not_nan_test.cpp
+++ b/test/unit/math/rev/scal/err/check_not_nan_test.cpp
@@ -1,12 +1,11 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
 #include <limits>
-#include <string>
 
 TEST(AgradRevErrorHandlingScalar, CheckNotNan) {
   using stan::math::var;
   using stan::math::check_not_nan;
-  const std::string function = "check_not_nan";
+  const char* function = "check_not_nan";
 
   var x = 0;
   double x_d = 0;
@@ -43,7 +42,7 @@ TEST(AgradRevErrorHandlingScalar, CheckNotNanVarCheckUnivariate) {
   using stan::math::var;
   using stan::math::check_not_nan;
 
-  const std::string function = "check_not_nan";
+  const char* function = "check_not_nan";
   var a(5.0);
 
   size_t stack_size = stan::math::ChainableStack::var_stack_.size();
@@ -61,7 +60,7 @@ TEST(ErrorHandlingScalar, CheckNotNanVarCheckUnivariate) {
   using stan::math::var;
   using stan::math::check_not_nan;
 
-  const std::string function = "check_not_nan";
+  const char* function = "check_not_nan";
   var a(5.0);
 
   size_t stack_size = stan::math::ChainableStack::var_stack_.size();

--- a/test/unit/math/rev/scal/err/check_positive_finite_test.cpp
+++ b/test/unit/math/rev/scal/err/check_positive_finite_test.cpp
@@ -1,13 +1,12 @@
 #include <stan/math/rev/scal.hpp>
 #include <gtest/gtest.h>
 #include <limits>
-#include <string>
 
 using stan::math::var;
 using stan::math::check_positive_finite;
 
 TEST(AgradRevErrorHandlingScalar, CheckPositiveFinite) {
-  const std::string function = "check_positive_finite";
+  const char* function = "check_positive_finite";
   var x = 1;
 
   EXPECT_NO_THROW(check_positive_finite(function, "x", x))
@@ -36,7 +35,7 @@ TEST(AgradRevErrorHandlingScalar, CheckPositiveFiniteVarCheckUnivariate) {
   using stan::math::var;
   using stan::math::check_positive_finite;
 
-  const std::string function = "check_positive_finite";
+  const char* function = "check_positive_finite";
   var a(5.0);
 
   size_t stack_size = stan::math::ChainableStack::var_stack_.size();

--- a/test/unit/math/rev/scal/err/check_positive_test.cpp
+++ b/test/unit/math/rev/scal/err/check_positive_test.cpp
@@ -2,13 +2,12 @@
 #include <gtest/gtest.h>
 #include <exception>
 #include <limits>
-#include <string>
 
 using stan::math::var;
 
 TEST(AgradRevErrorHandlingScalar, CheckPositive) {
   using stan::math::check_positive;
-  const std::string function = "check_positive";
+  const char* function = "check_positive";
 
   var x = std::numeric_limits<var>::quiet_NaN();
   EXPECT_THROW(check_positive(function, "x", x), std::domain_error);
@@ -20,7 +19,7 @@ TEST(AgradRevErrorHandlingScalar, CheckPositiveVarCheckUnivariate) {
   using stan::math::var;
   using stan::math::check_positive;
 
-  const std::string function = "check_positive";
+  const char* function = "check_positive";
   var a(5.0);
 
   size_t stack_size = stan::math::ChainableStack::var_stack_.size();

--- a/test/unit/math/rev/scal/err/domain_error_test.cpp
+++ b/test/unit/math/rev/scal/err/domain_error_test.cpp
@@ -2,10 +2,10 @@
 #include <gtest/gtest.h>
 #include <string>
 
-const std::string function_ = "function";
-const std::string y_name_ = "y";
-const std::string msg1_ = "error_message ";
-const std::string msg2_ = " after y";
+const char* function_ = "function";
+const char* y_name_ = "y";
+const char* msg1_ = "error_message ";
+const char* msg2_ = " after y";
 
 class ErrorHandlingScalar_domain_error : public ::testing::Test {
 public:

--- a/test/unit/math/rev/scal/err/invalid_argument_test.cpp
+++ b/test/unit/math/rev/scal/err/invalid_argument_test.cpp
@@ -2,10 +2,10 @@
 #include <gtest/gtest.h>
 #include <string>
 
-const std::string function_ = "function";
-const std::string y_name_ = "y";
-const std::string msg1_ = "error_message ";
-const std::string msg2_ = " after y";
+const char* function_ = "function";
+const char* y_name_ = "y";
+const char* msg1_ = "error_message ";
+const char* msg2_ = " after y";
 
 class ErrorHandlingScalar_invalid_argument : public ::testing::Test {
 public:


### PR DESCRIPTION
Automating it was easier than dealing with the merge conflicts. Need to check I did it correctly. Here's my automation code:

```
find stan test -name *.hpp -or -name *.cpp | xargs  sed -i '' -e '/#include <string>/d' # assumes nothing else uses strings
find stan test -name *.cpp -or -name *.hpp | xargs  sed -i '' -e 's/const std::string&/const char*/g'
find stan test -name *.cpp -or -name *.hpp | xargs  sed -i '' -e 's/const std::string /const char* /g'
git checkout test/unit/util.hpp stan/math/version.hpp
```

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Columbia University 

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
