### PR TITLE
fix vexing parse

### DIFF
--- a/stan/math/prim/mat/meta/broadcast_array.hpp
+++ b/stan/math/prim/mat/meta/broadcast_array.hpp
@@ -9,7 +9,7 @@ namespace stan {
   namespace math {
     namespace internal {
       template <typename ViewElt, typename OpElt, int R, int C>
-      class empty_broadcast_array<ViewElt, Eigen::Matrix<OpElt, R, C>> {
+      class empty_broadcast_array<ViewElt, Eigen::Matrix<OpElt, R, C> > {
       public:
         empty_broadcast_array() {}
        /**

--- a/stan/math/prim/mat/prob/ordered_logistic_lpmf.hpp
+++ b/stan/math/prim/mat/prob/ordered_logistic_lpmf.hpp
@@ -194,7 +194,7 @@ namespace stan {
     ordered_logistic_lpmf(const std::vector<int>& y,
                           const Eigen::Matrix<T_loc, Eigen::Dynamic, 1>& lambda,
                           const std::vector<Eigen::Matrix<
-                                                T_cut, Eigen::Dynamic, 1>>& c) {
+                                            T_cut, Eigen::Dynamic, 1> >& c) {
       typename return_type<T_loc, T_cut>::type logp_n(0.0);
 
       using std::exp;
@@ -237,7 +237,7 @@ namespace stan {
     ordered_logistic_lpmf(const std::vector<int>& y,
                           const Eigen::Matrix<T_loc, Eigen::Dynamic, 1>& lambda,
                           const std::vector<Eigen::Matrix<
-                                                T_cut, Eigen::Dynamic, 1>>& c) {
+                                            T_cut, Eigen::Dynamic, 1> >& c) {
       return ordered_logistic_lpmf<false>(y, lambda, c);
     }
   }

--- a/stan/math/prim/mat/prob/ordered_probit_lpmf.hpp
+++ b/stan/math/prim/mat/prob/ordered_probit_lpmf.hpp
@@ -171,7 +171,7 @@ namespace stan {
     ordered_probit_lpmf(const std::vector<int>& y,
                         const Eigen::Matrix<T_loc, Eigen::Dynamic, 1>& lambda,
                         const std::vector<Eigen::Matrix<
-                                              T_cut, Eigen::Dynamic, 1>>& c) {
+                                          T_cut, Eigen::Dynamic, 1> >& c) {
       using std::exp;
       using std::log;
 
@@ -214,7 +214,7 @@ namespace stan {
     ordered_probit_lpmf(const std::vector<int>& y,
                         const Eigen::Matrix<T_loc, Eigen::Dynamic, 1>& lambda,
                         const std::vector<Eigen::Matrix<
-                                              T_cut, Eigen::Dynamic, 1>>& c) {
+                                          T_cut, Eigen::Dynamic, 1> >& c) {
       return ordered_probit_lpmf<false>(y, lambda, c);
     }
   }


### PR DESCRIPTION
#### Submission Checklist

- [X] Run unit tests: `./runTests.py test/unit`
- [X] Run cpplint: `make cpplint`
- [X] Declare copyright holder and open-source license: see below

#### Summary:

Add space in the arguments of ordered_logistic_lpmf from `>>&` to `> >&`

#### Intended Effect:

Fixes #675 

#### How to Verify:

Run unit test

#### Side Effects:

None

#### Documentation:

None

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Trustees of Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
