### PR TITLE
Fixes #671. Return log(0) at the end of neg_binomial_test.hpp to squash warning.

### DIFF
--- a/test/prob/neg_binomial/neg_binomial_test.hpp
+++ b/test/prob/neg_binomial/neg_binomial_test.hpp
@@ -1,5 +1,6 @@
 // Arguments: Ints, Doubles, Doubles
 #include <stan/math/prim/scal.hpp>
+#include <stdexcept>
 
 using std::vector;
 using std::numeric_limits;
@@ -76,5 +77,6 @@ class AgradDistributionsNegBinomial : public AgradDistributionTest {
       return binomial_coefficient_log<
                  typename stan::scalar_type<T_shape>::type>(n + alpha - 1.0, n)
              - n * log1p(beta) + alpha * log(beta / (1 + beta));
+    return log(0.0);
   }
 };


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

Removes warning neg\_binomial\_test.

#### How to Verify:

Run 
```
./runTests.py test/prob/neg_binomial/neg_binomial_00000_generated_v_test.cpp
```

This should not have any warnings.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Generable

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
