### PR TITLE
Fixes #693. Updating README.md to include C++11 flag for compiling.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ If this is in the file `/path/to/foo/foo.cpp`, then you can compile and run this
 
 ```
 > cd /path/to/foo
-> clang++ -I /path/to/stan-math -I /path/to/Eigen -I /path/to/boost foo.cpp  -I /path/to/cvodes
+> clang++ -I /path/to/stan-math -I /path/to/Eigen -I /path/to/boost -I /path/to/cvodes -std=c++11 foo.cpp
 > ./a.out
 log normal(1 | 2, 3)=-2.07311
 ```
@@ -52,7 +52,7 @@ The `-I` includes provide paths pointing to the four necessary includes:
 Note that the paths should *not* include the final directories `stan`, `Eigen`, or `boost` on the paths.  An example of a real instantiation:
 
 ```
-clang++ -I ~/stan-dev/math -I ~/stan-dev/math/lib/eigen_3.3.3/ -I ~/stan-dev/math/lib/boost_1.64.0/ -I ~/stan-dev/math/lib/cvodes_2.9.0/include foo.cpp
+clang++ -I ~/stan-dev/math -I ~/stan-dev/math/lib/eigen_3.3.3/ -I ~/stan-dev/math/lib/boost_1.64.0/ -I ~/stan-dev/math/lib/cvodes_2.9.0/include -std=c++11 foo.cpp
 ```
 
 The following directories all exist below the links given to `-I`: `~/stan-dev/math/stan` and `~/stan-dev/math/lib/eigen_3.3.3/Eigen` and `~stan-dev/math/lib/boost_1.64.0/boost` and `~stan-dev/math/lib/cvodes_2.9.0/include`.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ If this is in the file `/path/to/foo/foo.cpp`, then you can compile and run this
 
 ```
 > cd /path/to/foo
-> clang++ -I /path/to/stan-math -I /path/to/Eigen -I /path/to/boost -I /path/to/cvodes -std=c++11 foo.cpp
+> clang++ -std=c++11 -I /path/to/stan-math -I /path/to/Eigen -I /path/to/boost -I /path/to/cvodes foo.cpp
 > ./a.out
 log normal(1 | 2, 3)=-2.07311
 ```
@@ -52,7 +52,7 @@ The `-I` includes provide paths pointing to the four necessary includes:
 Note that the paths should *not* include the final directories `stan`, `Eigen`, or `boost` on the paths.  An example of a real instantiation:
 
 ```
-clang++ -I ~/stan-dev/math -I ~/stan-dev/math/lib/eigen_3.3.3/ -I ~/stan-dev/math/lib/boost_1.64.0/ -I ~/stan-dev/math/lib/cvodes_2.9.0/include -std=c++11 foo.cpp
+clang++ -std=c++11 -I ~/stan-dev/math -I ~/stan-dev/math/lib/eigen_3.3.3/ -I ~/stan-dev/math/lib/boost_1.64.0/ -I ~/stan-dev/math/lib/cvodes_2.9.0/include foo.cpp
 ```
 
 The following directories all exist below the links given to `-I`: `~/stan-dev/math/stan` and `~/stan-dev/math/lib/eigen_3.3.3/Eigen` and `~stan-dev/math/lib/boost_1.64.0/boost` and `~stan-dev/math/lib/cvodes_2.9.0/include`.


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

Update README.md to include `-std=c++11` flag for compiling.

#### How to Verify:

Try following instructions in README.md.

#### Side Effects:

None.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Generable.

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
