### PR TITLE
Bugfix/issue 696 system functor init

### DIFF
--- a/stan/math/rev/mat/functor/algebra_system.hpp
+++ b/stan/math/rev/mat/functor/algebra_system.hpp
@@ -41,7 +41,7 @@ struct system_functor {
                  const Eigen::Matrix<T1, Eigen::Dynamic, 1>& y,
                  const std::vector<double>& dat,
                  const std::vector<int>& dat_int, std::ostream* msgs)
-      : f_(), x_(x), y_(y), dat_(dat), dat_int_(dat_int), msgs_(msgs) {}
+      : f_(f), x_(x), y_(y), dat_(dat), dat_int_(dat_int), msgs_(msgs) {}
 
   /**
    * An operator that takes in an independent variable. The

--- a/test/unit/math/rev/mat/functor/algebra_solver_test.cpp
+++ b/test/unit/math/rev/mat/functor/algebra_solver_test.cpp
@@ -6,6 +6,7 @@
 #include <gtest/gtest.h>
 #include <iostream>
 #include <fstream>
+#include <vector>
 
 // Every test exists in duplicate to test the case
 // where y (the auxiliary parameters) are passed as

--- a/test/unit/math/rev/mat/functor/algebra_solver_test.cpp
+++ b/test/unit/math/rev/mat/functor/algebra_solver_test.cpp
@@ -238,3 +238,22 @@ TEST(MathMatrix, degenerate_dbl) {
   EXPECT_FLOAT_EQ(5, theta(0));
   EXPECT_FLOAT_EQ(5, theta(0));
 }
+
+// unit test to demo issue #696
+// system functor init bug issue #696
+TEST(MathMatrix, system_functor_constructor) {
+  using stan::math::system_functor;
+
+  Eigen::VectorXd y(2);
+  y << 5, 8;
+  Eigen::VectorXd x(2);
+  x << 10, 1;
+  std::vector<double> dat{0.0, 0.0};
+  std::vector<int> dat_int{0, 0};
+  std::ostream* msgs = 0;
+  int f = 99;
+
+  system_functor<int, double, double, true> fs(f, x, y, dat, dat_int, msgs);
+
+  EXPECT_EQ(fs.f_, f);
+}


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary:
Fix empty f_() in system_functor's init list. Add unit test.
#### Intended Effect:

#### How to Verify:
Unit test "MathMatrix.system_functor_constructor".

#### Side Effects:
N/A

#### Documentation:

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
