### PR TITLE
Feature/issue 651 algebra solver

### DIFF
--- a/stan/math/rev/mat/functor/algebra_solver.hpp
+++ b/stan/math/rev/mat/functor/algebra_solver.hpp
@@ -177,7 +177,7 @@ Eigen::VectorXd algebra_solver(
     message2 << "algebra_solver: the norm of the algebraic function is: "
              << system_norm << " but should be lower than the function "
              << "tolerance: " << function_tolerance << ". Consider "
-             << "increasing the relative tolerance and the "
+             << "decreasing the relative tolerance and increasing the "
              << "max_num_steps.";
     throw boost::math::evaluation_error(message2.str());
   }

--- a/stan/math/rev/mat/functor/algebra_solver.hpp
+++ b/stan/math/rev/mat/functor/algebra_solver.hpp
@@ -102,7 +102,6 @@ struct algebra_solver_vari : public vari {
  * @param[in] max_num_steps  maximum number of function evaluations.
  * @return theta Vector of solutions to the system of equations.
  * @throw <code>std::invalid_argument</code> if x has size zero.
- * @throw <code>std::invalid_argument</code> if y has size zero.
  * @throw <code>std::invalid_argument</code> if x has non-finite elements.
  * @throw <code>std::invalid_argument</code> if y has non-finite elements.
  * @throw <code>std::invalid_argument</code> if dat has non-finite elements.
@@ -126,7 +125,6 @@ Eigen::VectorXd algebra_solver(
     double function_tolerance = 1e-6,
     long int max_num_steps = 1e+3) {  // NOLINT(runtime/int)
   check_nonzero_size("algebra_solver", "initial guess", x);
-  check_nonzero_size("algebra_solver", "parameter vector", y);
   for (int i = 0; i < x.size(); i++)
     check_finite("algebra_solver", "initial guess", x(i));
   for (int i = 0; i < y.size(); i++)
@@ -214,7 +212,6 @@ Eigen::VectorXd algebra_solver(
  * @param[in] max_num_steps  maximum number of function evaluations.
  * @return theta Vector of solutions to the system of equations.
  * @throw <code>std::invalid_argument</code> if x has size zero.
- * @throw <code>std::invalid_argument</code> if y has size zero.
  * @throw <code>std::invalid_argument</code> if x has non-finite elements.
  * @throw <code>std::invalid_argument</code> if y has non-finite elements.
  * @throw <code>std::invalid_argument</code> if dat has non-finite elements.

--- a/stan/math/rev/mat/functor/algebra_solver.hpp
+++ b/stan/math/rev/mat/functor/algebra_solver.hpp
@@ -5,6 +5,7 @@
 #include <stan/math/prim/mat/fun/mdivide_left.hpp>
 #include <stan/math/rev/core.hpp>
 #include <stan/math/rev/scal/meta/is_var.hpp>
+#include <stan/math/prim/mat/fun/value_of.hpp>
 #include <stan/math/prim/scal/err/check_finite.hpp>
 #include <stan/math/prim/scal/err/check_consistent_size.hpp>
 #include <stan/math/prim/arr/err/check_matching_sizes.hpp>
@@ -88,6 +89,7 @@ struct algebra_solver_vari : public vari {
  * norm as a metric to measure how far we are from the origin (0).
  *
  * @tparam F type of equation system function.
+ * @tparam T type of initial guess vector.
  * @param[in] f Functor that evaluates the system of equations.
  * @param[in] x Vector of starting values.
  * @param[in] y parameter vector for the equation system. The function
@@ -117,12 +119,12 @@ struct algebra_solver_vari : public vari {
  * <code>std::runtime_error</code>) if the norm of the solution exceeds the
  * function tolerance.
  */
-template <typename F>
+template <typename F, typename T>
 Eigen::VectorXd algebra_solver(
-    const F& f, const Eigen::VectorXd& x, const Eigen::VectorXd& y,
-    const std::vector<double>& dat, const std::vector<int>& dat_int,
-    std::ostream* msgs = 0, double relative_tolerance = 1e-10,
-    double function_tolerance = 1e-6,
+    const F& f, const Eigen::Matrix<T, Eigen::Dynamic, 1>& x, 
+    const Eigen::VectorXd& y, const std::vector<double>& dat,
+    const std::vector<int>& dat_int, std::ostream* msgs = 0, 
+    double relative_tolerance = 1e-10, double function_tolerance = 1e-6,
     long int max_num_steps = 1e+3) {  // NOLINT(runtime/int)
   check_nonzero_size("algebra_solver", "initial guess", x);
   for (int i = 0; i < x.size(); i++)
@@ -149,15 +151,16 @@ Eigen::VectorXd algebra_solver(
   // Create functor for algebraic system
   typedef system_functor<F, double, double, true> FS;
   typedef hybrj_functor_solver<FS, F, double, double> FX;
-  FX fx(FS(), f, x, y, dat, dat_int, msgs);
+  FX fx(FS(), f, value_of(x), y, dat, dat_int, msgs);
   Eigen::HybridNonLinearSolver<FX> solver(fx);
 
   // Check dimension unknowns equals dimension of system output
   check_matching_sizes("algebra_solver", "the algebraic system's output",
-                       fx.get_value(x), "the vector of unknowns, x,", x);
+                       fx.get_value(value_of(x)), "the vector of unknowns, x,", 
+                       x);
 
   // Compute theta_dbl
-  Eigen::VectorXd theta_dbl = x;
+  Eigen::VectorXd theta_dbl = value_of(x);
   solver.parameters.xtol = relative_tolerance;
   solver.parameters.maxfev = max_num_steps;
   solver.solve(theta_dbl);
@@ -199,9 +202,10 @@ Eigen::VectorXd algebra_solver(
  * top, using the algebra_solver_vari class.
  *
  * @tparam F type of equation system function.
- * @tparam T  Type of elements in y vectors.
+ * @tparam T1  Type of elements in x vector.
+ * @tparam T2  Type of elements in y vector.
  * @param[in] f Functor that evaluates the system of equations.
- * @param[in] x Vector of starting values.
+ * @param[in] x Vector of starting values (initial guess).
  * @param[in] y parameter vector for the equation system.
  * @param[in] dat continuous data vector for the equation system.
  * @param[in] dat_int integer data vector for the equation system.
@@ -227,17 +231,18 @@ Eigen::VectorXd algebra_solver(
  * <code>std::runtime_error</code>) if the norm of the solution exceeds the
  * function tolerance.
  */
-template <typename F, typename T>
-Eigen::Matrix<T, Eigen::Dynamic, 1> algebra_solver(
-    const F& f, const Eigen::VectorXd& x,
-    const Eigen::Matrix<T, Eigen::Dynamic, 1>& y,
+template <typename F, typename T1, typename T2>
+Eigen::Matrix<T2, Eigen::Dynamic, 1> algebra_solver(
+    const F& f, 
+    const Eigen::Matrix<T1, Eigen::Dynamic, 1>& x,
+    const Eigen::Matrix<T2, Eigen::Dynamic, 1>& y,
     const std::vector<double>& dat, const std::vector<int>& dat_int,
     std::ostream* msgs = 0, double relative_tolerance = 1e-10,
     double function_tolerance = 1e-6,
     long int max_num_steps = 1e+3) {  // NOLINT(runtime/int)
   Eigen::VectorXd theta_dbl
-      = algebra_solver(f, x, value_of(y), dat, dat_int, 0, relative_tolerance,
-                       function_tolerance, max_num_steps);
+      = algebra_solver(f, x, value_of(y), dat, dat_int, 0,
+                       relative_tolerance, function_tolerance, max_num_steps);
 
   typedef system_functor<F, double, double, false> FY;
 
@@ -246,12 +251,12 @@ Eigen::Matrix<T, Eigen::Dynamic, 1> algebra_solver(
   // and use it here (if possible).
   typedef system_functor<F, double, double, true> FS;
   typedef hybrj_functor_solver<FS, F, double, double> FX;
-  FX fx(FS(), f, x, value_of(y), dat, dat_int, msgs);
+  FX fx(FS(), f, value_of(x), value_of(y), dat, dat_int, msgs);
 
   // Construct vari
-  algebra_solver_vari<FY, F, T, FX>* vi0
-      = new algebra_solver_vari<FY, F, T, FX>(FY(), f, x, y, dat, dat_int,
-                                              theta_dbl, fx, msgs);
+  algebra_solver_vari<FY, F, T2, FX>* vi0
+      = new algebra_solver_vari<FY, F, T2, FX>(FY(), f, value_of(x), y, dat,
+                                               dat_int, theta_dbl, fx, msgs);
   Eigen::Matrix<var, Eigen::Dynamic, 1> theta(x.size());
   theta(0) = var(vi0->theta_[0]);
   for (int i = 1; i < x.size(); ++i)

--- a/stan/math/rev/mat/functor/algebra_solver.hpp
+++ b/stan/math/rev/mat/functor/algebra_solver.hpp
@@ -121,9 +121,9 @@ struct algebra_solver_vari : public vari {
  */
 template <typename F, typename T>
 Eigen::VectorXd algebra_solver(
-    const F& f, const Eigen::Matrix<T, Eigen::Dynamic, 1>& x, 
+    const F& f, const Eigen::Matrix<T, Eigen::Dynamic, 1>& x,
     const Eigen::VectorXd& y, const std::vector<double>& dat,
-    const std::vector<int>& dat_int, std::ostream* msgs = 0, 
+    const std::vector<int>& dat_int, std::ostream* msgs = 0,
     double relative_tolerance = 1e-10, double function_tolerance = 1e-6,
     long int max_num_steps = 1e+3) {  // NOLINT(runtime/int)
   check_nonzero_size("algebra_solver", "initial guess", x);
@@ -156,7 +156,7 @@ Eigen::VectorXd algebra_solver(
 
   // Check dimension unknowns equals dimension of system output
   check_matching_sizes("algebra_solver", "the algebraic system's output",
-                       fx.get_value(value_of(x)), "the vector of unknowns, x,", 
+                       fx.get_value(value_of(x)), "the vector of unknowns, x,",
                        x);
 
   // Compute theta_dbl
@@ -233,7 +233,7 @@ Eigen::VectorXd algebra_solver(
  */
 template <typename F, typename T1, typename T2>
 Eigen::Matrix<T2, Eigen::Dynamic, 1> algebra_solver(
-    const F& f, 
+    const F& f,
     const Eigen::Matrix<T1, Eigen::Dynamic, 1>& x,
     const Eigen::Matrix<T2, Eigen::Dynamic, 1>& y,
     const std::vector<double>& dat, const std::vector<int>& dat_int,

--- a/test/unit/math/rev/mat/functor/algebra_solver_test.cpp
+++ b/test/unit/math/rev/mat/functor/algebra_solver_test.cpp
@@ -82,16 +82,16 @@ TEST(MathMatrix, simple_Eq_nopara) {
   dat[0] = 5;
   dat[1] = 4;
   dat[2] = 2;
-  
+
   int n_x = 2;
   Eigen::VectorXd x(n_x);
   x << 1, 1;  // initial guess
   Eigen::VectorXd y_dummy;
   std::vector<int> dummy_dat_int;
-  
+
   Eigen::Matrix<double, Eigen::Dynamic, 1> theta;
-  
-  theta = stan::math::algebra_solver(simple_eq_functor_nopara(), 
+
+  theta = stan::math::algebra_solver(simple_eq_functor_nopara(),
                                      x, y_dummy, dat, dummy_dat_int);
 
   EXPECT_EQ(20, theta(0));
@@ -110,9 +110,9 @@ TEST(MathMatrix, simple_Eq_init_is_para) {
   std::vector<double> dat;
   std::vector<int> dat_int;
 
-  Eigen::VectorXd theta = stan::math::algebra_solver(simple_eq_functor(), 
+  Eigen::VectorXd theta = stan::math::algebra_solver(simple_eq_functor(),
                                                      x, y, dat, dat_int);
-  
+
   EXPECT_EQ(20, theta(0));
   EXPECT_EQ(2, theta(1));
 }
@@ -278,7 +278,20 @@ TEST(MathMatrix, degenerate_dbl) {
   x << 1, 1;  // Initial Guess
   theta = degenerate_test(y, x);
   EXPECT_FLOAT_EQ(5, theta(0));
+  EXPECT_FLOAT_EQ(5, theta(1));
+
+  // See if the initial guess determines neighborhood of the
+  // solution, when solutions have different scales.
+  y << 5, 100;
+  x << 1, 1;  // initial guess
+  theta = degenerate_test(y, x);
   EXPECT_FLOAT_EQ(5, theta(0));
+  EXPECT_FLOAT_EQ(5, theta(1));
+
+  x << 120, 120;  // Initial guess
+  theta = degenerate_test(y, x);
+  EXPECT_FLOAT_EQ(100, theta(0));
+  EXPECT_FLOAT_EQ(100, theta(1));
 }
 
 // unit test to demo issue #696

--- a/test/unit/math/rev/mat/functor/algebra_solver_test.cpp
+++ b/test/unit/math/rev/mat/functor/algebra_solver_test.cpp
@@ -76,6 +76,28 @@ TEST(MathMatrix, simple_Eq_tuned_dbl) {
       = simple_eq_test(simple_eq_functor(), y, true, xtol, ftol, maxfev);
 }
 
+TEST(MathMatrix, simple_Eq_nopara) {
+  std::vector<double> dat(3);
+  dat[0] = 5;
+  dat[1] = 4;
+  dat[2] = 2;
+  
+  int n_x = 2;
+  Eigen::VectorXd x(n_x);
+  x << 1, 1;  // initial guess
+  Eigen::VectorXd y_dummy;
+  std::vector<int> dummy_dat_int;
+  
+  Eigen::Matrix<double, Eigen::Dynamic, 1> theta;
+  
+  theta = stan::math::algebra_solver(simple_eq_functor_nopara(), 
+                                     x, y_dummy, dat, dummy_dat_int);
+
+  EXPECT_EQ(20, theta(0));
+  EXPECT_EQ(2, theta(1));
+}
+
+
 TEST(MathMatrix, non_linear_eq) {
   using stan::math::var;
 

--- a/test/unit/math/rev/mat/functor/algebra_solver_test.cpp
+++ b/test/unit/math/rev/mat/functor/algebra_solver_test.cpp
@@ -11,6 +11,7 @@
 // Every test exists in duplicate to test the case
 // where y (the auxiliary parameters) are passed as
 // data (double type) or parameters (var types).
+
 TEST(MathMatrix, simple_Eq) {
   using stan::math::var;
 
@@ -97,6 +98,24 @@ TEST(MathMatrix, simple_Eq_nopara) {
   EXPECT_EQ(2, theta(1));
 }
 
+TEST(MathMatrix, simple_Eq_init_is_para) {
+  using stan::math::var;
+  Eigen::VectorXd y(3);
+  y << 5, 4, 2;
+
+  int n_x = 2;
+  Eigen::Matrix<var, Eigen::Dynamic, 1> x(n_x);
+  x << 1, 1;
+
+  std::vector<double> dat;
+  std::vector<int> dat_int;
+
+  Eigen::VectorXd theta = stan::math::algebra_solver(simple_eq_functor(), 
+                                                     x, y, dat, dat_int);
+  
+  EXPECT_EQ(20, theta(0));
+  EXPECT_EQ(2, theta(1));
+}
 
 TEST(MathMatrix, non_linear_eq) {
   using stan::math::var;

--- a/test/unit/math/rev/mat/functor/util_algebra_solver.hpp
+++ b/test/unit/math/rev/mat/functor/util_algebra_solver.hpp
@@ -230,8 +230,8 @@ void inline unsolvable_test(Eigen::Matrix<T, Eigen::Dynamic, 1>& y) {
           << 1.41421  // sqrt(2)
           << " but should be lower than the function tolerance: "
           << function_tolerance
-          << ". Consider increasing the relative tolerance and the"
-          << " max_num_steps.";
+          << ". Consider decreasing the relative tolerance and increasing"
+          << " the max_num_steps.";
   std::string msg = err_msg.str();
   EXPECT_THROW_MSG(
       algebra_solver(unsolvable_eq_functor(), x, y, dat, dat_int, 0,

--- a/test/unit/math/rev/mat/functor/util_algebra_solver.hpp
+++ b/test/unit/math/rev/mat/functor/util_algebra_solver.hpp
@@ -24,6 +24,22 @@ struct simple_eq_functor {
   }
 };
 
+struct simple_eq_functor_nopara {
+  template <typename T0, typename T1>
+  inline Eigen::Matrix<typename boost::math::tools::promote_args<T0, T1>::type,
+                       Eigen::Dynamic, 1>
+  operator()(const Eigen::Matrix<T0, Eigen::Dynamic, 1>& x,
+           const Eigen::Matrix<T1, Eigen::Dynamic, 1>& y,
+           const std::vector<double>& dat, const std::vector<int>& dat_int,
+           std::ostream* pstream__) const {
+    typedef typename boost::math::tools::promote_args<T0, T1>::type scalar;
+    Eigen::Matrix<scalar, Eigen::Dynamic, 1> z(2);
+    z(0) = x(0) - dat[0] * dat[1];
+    z(1) = x(1) - dat[2];
+    return z;
+  }
+};
+
 struct non_linear_eq_functor {
   template <typename T0, typename T1>
   inline Eigen::Matrix<typename boost::math::tools::promote_args<T0, T1>::type,
@@ -165,15 +181,6 @@ inline void error_conditions_test(
   EXPECT_THROW_MSG(algebra_solver(f, x_bad, y, dat, dat_int),
                    std::invalid_argument, msg2);
 
-  typedef Eigen::Matrix<T, Eigen::Dynamic, 1> matrix;
-  matrix y_bad(static_cast<typename matrix::Index>(0));
-  std::stringstream err_msg3;
-  err_msg3 << "algebra_solver: parameter vector has size 0, but "
-           << "must have a non-zero size";
-  std::string msg3 = err_msg3.str();
-  EXPECT_THROW_MSG(algebra_solver(f, x, y_bad, dat, dat_int),
-                   std::invalid_argument, msg3);
-
   double inf = std::numeric_limits<double>::infinity();
   Eigen::VectorXd x_bad_inf(n_x);
   x_bad_inf << inf, 1, 1;
@@ -182,6 +189,7 @@ inline void error_conditions_test(
                    "algebra_solver: initial guess is inf, but must "
                    "be finite!");
 
+  typedef Eigen::Matrix<T, Eigen::Dynamic, 1> matrix;
   matrix y_bad_inf(3);
   y_bad_inf << inf, 1, 1;
   EXPECT_THROW_MSG(algebra_solver(f, x, y_bad_inf, dat, dat_int),


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py test/unit/math/rev/mat/functor/algebra_solver_test.cpp`
- [ ] Run cpplint: `make cpplint` (hmm... got an error when trying to run cpplint)
- [x] Declare copyright holder and open-source license: see below

#### Summary:
Solves issue #651:

- Vector of auxiliary parameters can now have size 0. 
- Initial guess can be a vector of parameters.
- Fixed an error message.

#### Intended Effect:
Makes the algebra solver easier to use. In particular, allows for better initial guesses (since these can now vary with parameters).

#### How to Verify:
Added unit tests.

#### Documentation:
Will update the user manual with the Stan pull request.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Charles Margossian, Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
