### PR TITLE
Feature/issue 707 ops partials mv

### DIFF
--- a/stan/math/prim/mat/meta/broadcast_array.hpp
+++ b/stan/math/prim/mat/meta/broadcast_array.hpp
@@ -19,7 +19,53 @@ class empty_broadcast_array<ViewElt, Eigen::Matrix<OpElt, R, C> > {
   /**
    * Not implemented so cannot be called.
    */
+  ViewElt& operator()(int /*i*/);
+  /**
+   * Not implemented so cannot be called.
+   */
   void operator=(Eigen::Matrix<ViewElt, R, C> /*A*/);
+  /**
+   * Not implemented so cannot be called.
+   */
+  void operator+=(Eigen::Matrix<ViewElt, R, C> /*A*/);
+  /**
+   * Not implemented so cannot be called.
+   */
+  void operator-=(Eigen::Matrix<ViewElt, R, C> /*A*/);
+  /**
+   * Not implemented so cannot be called.
+   */
+  Eigen::Matrix<ViewElt, 1, C>& row(int /*i*/);
+  /**
+   * Not implemented so cannot be called.
+   */
+  Eigen::Matrix<ViewElt, R, 1>& col(int /*i*/);
+};
+template <typename ViewElt, typename OpElt, int R, int C>
+class empty_broadcast_array<ViewElt,
+                            std::vector<Eigen::Matrix<OpElt, R, C> > > {
+ public:
+  empty_broadcast_array() {}
+  /**
+   * Not implemented so cannot be called.
+   */
+  ViewElt& operator[](int /*i*/);
+  /**
+   * Not implemented so cannot be called.
+   */
+  ViewElt& operator()(int /*i*/);
+  /**
+   * Not implemented so cannot be called.
+   */
+  void operator=(Eigen::Matrix<ViewElt, R, C> /*A*/);
+  /**
+   * Not implemented so cannot be called.
+   */
+  void operator+=(Eigen::Matrix<ViewElt, R, C> /*A*/);
+  /**
+   * Not implemented so cannot be called.
+   */
+  void operator-=(Eigen::Matrix<ViewElt, R, C> /*A*/);
   /**
    * Not implemented so cannot be called.
    */

--- a/stan/math/prim/mat/meta/broadcast_array.hpp
+++ b/stan/math/prim/mat/meta/broadcast_array.hpp
@@ -1,6 +1,7 @@
 #include <stan/math/prim/scal/meta/broadcast_array.hpp>
 #include <Eigen/Dense>
 #include <stdexcept>
+#include <vector>
 
 #ifndef STAN_MATH_PRIM_MAT_META_BROADCAST_ARRAY_HPP
 #define STAN_MATH_PRIM_MAT_META_BROADCAST_ARRAY_HPP

--- a/stan/math/prim/scal/meta/broadcast_array.hpp
+++ b/stan/math/prim/scal/meta/broadcast_array.hpp
@@ -26,6 +26,20 @@ class empty_broadcast_array {
    */
   T& operator[](int /*i*/);
 };
+
+template <typename T, typename S>
+class empty_nested_broadcast_array {
+  typedef empty_broadcast_array<T, S> empty_broadcast_array_t;
+
+ public:
+  empty_nested_broadcast_array() {}
+  /**
+   * Not implemented so cannot be called.
+   */
+  empty_broadcast_array_t operator[](int /*i*/) {
+    return empty_broadcast_array_t();
+  }
+};
 }  // namespace internal
 }  // namespace math
 }  // namespace stan

--- a/stan/math/prim/scal/meta/operands_and_partials.hpp
+++ b/stan/math/prim/scal/meta/operands_and_partials.hpp
@@ -34,14 +34,6 @@ class ops_partials_edge {
   ops_partials_edge() {}
   explicit ops_partials_edge(const Op&) {}
 
-  // typedef empty_broadcast_array<ViewElt, Op> partials_t;
-  // partials_t partials_;
-  // broadcast_array<partials_t> partials_vec_;
-  // broadcast_array<partials_t> partials_vec_;
-
-  // ops_partials_edge() : partials_vec_(partials_) {}
-  // explicit ops_partials_edge(const Op&) : partials_vec_(partials_) {}
-
  private:
   template <typename, typename, typename, typename, typename, typename>
   friend class stan::math::operands_and_partials;

--- a/stan/math/prim/scal/meta/operands_and_partials.hpp
+++ b/stan/math/prim/scal/meta/operands_and_partials.hpp
@@ -28,10 +28,12 @@ namespace internal {
 template <typename ViewElt, typename Op>
 class ops_partials_edge {
  public:
-  empty_broadcast_array<ViewElt, Op> partials_;
+  typedef empty_broadcast_array<ViewElt, Op> partials_t;
+  partials_t partials_;
+  broadcast_array<partials_t> partials_vec_;
 
-  ops_partials_edge() {}
-  explicit ops_partials_edge(const Op& /* op */) {}
+  ops_partials_edge() : partials_vec_(partials_) {}
+  explicit ops_partials_edge(const Op&) : partials_vec_(partials_) {}
 
  private:
   template <typename, typename, typename, typename, typename, typename>

--- a/stan/math/prim/scal/meta/operands_and_partials.hpp
+++ b/stan/math/prim/scal/meta/operands_and_partials.hpp
@@ -28,12 +28,19 @@ namespace internal {
 template <typename ViewElt, typename Op>
 class ops_partials_edge {
  public:
-  typedef empty_broadcast_array<ViewElt, Op> partials_t;
-  partials_t partials_;
-  broadcast_array<partials_t> partials_vec_;
+  empty_broadcast_array<ViewElt, Op> partials_;
+  empty_nested_broadcast_array<ViewElt, Op> partials_vec_;
 
-  ops_partials_edge() : partials_vec_(partials_) {}
-  explicit ops_partials_edge(const Op&) : partials_vec_(partials_) {}
+  ops_partials_edge() {}
+  explicit ops_partials_edge(const Op&) {}
+
+  // typedef empty_broadcast_array<ViewElt, Op> partials_t;
+  // partials_t partials_;
+  // broadcast_array<partials_t> partials_vec_;
+  // broadcast_array<partials_t> partials_vec_;
+
+  // ops_partials_edge() : partials_vec_(partials_) {}
+  // explicit ops_partials_edge(const Op&) : partials_vec_(partials_) {}
 
  private:
   template <typename, typename, typename, typename, typename, typename>

--- a/test/unit/math/rev/mat/meta/operands_and_partials_test.cpp
+++ b/test/unit/math/rev/mat/meta/operands_and_partials_test.cpp
@@ -11,8 +11,7 @@ TEST(AgradPartialsVari, OperandsAndPartialsVec) {
 
   vector_d d_vec(4);
   operands_and_partials<vector_d> o3(d_vec);
-  // IS NOW 80!!
-  // EXPECT_EQ(5, sizeof(o3));
+  EXPECT_EQ(2 * 5, sizeof(o3));
 
   vector_v v_vec(4);
   var v1 = var(0.0);
@@ -49,8 +48,7 @@ TEST(AgradPartialsVari, OperandsAndPartialsStdVec) {
 
   std::vector<double> d_vec(4);
   operands_and_partials<std::vector<double> > o3(d_vec);
-  // IS NOW 80!!
-  // EXPECT_EQ(5, sizeof(o3));
+  EXPECT_EQ(2 * 5, sizeof(o3));
 
   std::vector<var> v_vec;
   var v1 = var(0.0);
@@ -88,8 +86,7 @@ TEST(AgradPartialsVari, OperandsAndPartialsMat) {
   d_mat << 10.0, 20.0, 30.0, 40.0;
   operands_and_partials<matrix_d> o3(d_mat);
 
-  // IS NOW 80!!
-  // EXPECT_EQ(5, sizeof(o3));
+  EXPECT_EQ(2 * 5, sizeof(o3));
 
   matrix_v v_mat(2, 2);
   var v1 = var(0.0);
@@ -132,8 +129,7 @@ TEST(AgradPartialsVari, OperandsAndPartialsMatMultivar) {
   d_mat_vec.push_back(d_mat);
   operands_and_partials<std::vector<matrix_d> > o3(d_mat_vec);
 
-  // IS NOW 80!!
-  // EXPECT_EQ(5, sizeof(o3));
+  EXPECT_EQ(2 * 5, sizeof(o3));
 
   matrix_v v_mat1(2, 2);
   var v1 = var(0.0);
@@ -198,8 +194,7 @@ TEST(AgradPartialsVari, OperandsAndPartialsMultivar) {
   d_vec_vec.push_back(d_vec2);
   operands_and_partials<std::vector<vector_d> > o3(d_vec_vec);
 
-  // IS NOW 80!!
-  // EXPECT_EQ(5, sizeof(o3));
+  EXPECT_EQ(2 * 5, sizeof(o3));
 
   vector_v v_vec1(2);
   var v1 = var(0.0);
@@ -274,8 +269,7 @@ TEST(AgradPartialsVari, OperandsAndPartialsMultivarMixed) {
 
   // 2 partials stdvecs, 4 pointers to edges, 2 pointers to operands
   // vecs
-  // IS NOW 112!!
-  // EXPECT_EQ(2 * sizeof(d_vec1) + 6 * sizeof(&v_vec), sizeof(o4));
+  EXPECT_EQ(2 * sizeof(d_vec1) + 6 * sizeof(&v_vec), sizeof(o4));
 
   std::vector<double> grad;
   var v = o4.build(10.0);

--- a/test/unit/math/rev/mat/meta/operands_and_partials_test.cpp
+++ b/test/unit/math/rev/mat/meta/operands_and_partials_test.cpp
@@ -6,12 +6,13 @@
 TEST(AgradPartialsVari, OperandsAndPartialsVec) {
   using stan::math::operands_and_partials;
   using stan::math::var;
-  using stan::math::vector_v;
   using stan::math::vector_d;
+  using stan::math::vector_v;
 
   vector_d d_vec(4);
   operands_and_partials<vector_d> o3(d_vec);
-  EXPECT_EQ(5, sizeof(o3));
+  // IS NOW 80!!
+  // EXPECT_EQ(5, sizeof(o3));
 
   vector_v v_vec(4);
   var v1 = var(0.0);
@@ -48,7 +49,8 @@ TEST(AgradPartialsVari, OperandsAndPartialsStdVec) {
 
   std::vector<double> d_vec(4);
   operands_and_partials<std::vector<double> > o3(d_vec);
-  EXPECT_EQ(5, sizeof(o3));
+  // IS NOW 80!!
+  // EXPECT_EQ(5, sizeof(o3));
 
   std::vector<var> v_vec;
   var v1 = var(0.0);
@@ -77,16 +79,17 @@ TEST(AgradPartialsVari, OperandsAndPartialsStdVec) {
 }
 
 TEST(AgradPartialsVari, OperandsAndPartialsMat) {
+  using stan::math::matrix_d;
+  using stan::math::matrix_v;
   using stan::math::operands_and_partials;
   using stan::math::var;
-  using stan::math::matrix_v;
-  using stan::math::matrix_d;
 
   matrix_d d_mat(2, 2);
   d_mat << 10.0, 20.0, 30.0, 40.0;
   operands_and_partials<matrix_d> o3(d_mat);
 
-  EXPECT_EQ(5, sizeof(o3));
+  // IS NOW 80!!
+  // EXPECT_EQ(5, sizeof(o3));
 
   matrix_v v_mat(2, 2);
   var v1 = var(0.0);
@@ -118,10 +121,10 @@ TEST(AgradPartialsVari, OperandsAndPartialsMat) {
 }
 
 TEST(AgradPartialsVari, OperandsAndPartialsMatMultivar) {
+  using stan::math::matrix_d;
+  using stan::math::matrix_v;
   using stan::math::operands_and_partials;
   using stan::math::var;
-  using stan::math::matrix_v;
-  using stan::math::matrix_d;
 
   matrix_d d_mat(2, 2);
   d_mat << 10.0, 20.0, 30.0, 40.0;
@@ -129,7 +132,8 @@ TEST(AgradPartialsVari, OperandsAndPartialsMatMultivar) {
   d_mat_vec.push_back(d_mat);
   operands_and_partials<std::vector<matrix_d> > o3(d_mat_vec);
 
-  EXPECT_EQ(5, sizeof(o3));
+  // IS NOW 80!!
+  // EXPECT_EQ(5, sizeof(o3));
 
   matrix_v v_mat1(2, 2);
   var v1 = var(0.0);
@@ -182,8 +186,8 @@ TEST(AgradPartialsVari, OperandsAndPartialsMatMultivar) {
 TEST(AgradPartialsVari, OperandsAndPartialsMultivar) {
   using stan::math::operands_and_partials;
   using stan::math::var;
-  using stan::math::vector_v;
   using stan::math::vector_d;
+  using stan::math::vector_v;
 
   std::vector<vector_d> d_vec_vec(2);
   vector_d d_vec1(2);
@@ -194,7 +198,8 @@ TEST(AgradPartialsVari, OperandsAndPartialsMultivar) {
   d_vec_vec.push_back(d_vec2);
   operands_and_partials<std::vector<vector_d> > o3(d_vec_vec);
 
-  EXPECT_EQ(5, sizeof(o3));
+  // IS NOW 80!!
+  // EXPECT_EQ(5, sizeof(o3));
 
   vector_v v_vec1(2);
   var v1 = var(0.0);
@@ -231,11 +236,11 @@ TEST(AgradPartialsVari, OperandsAndPartialsMultivar) {
 // XXX Test mixed - operands_and_partials<std::vector<matrix_v>,
 //                                        vector_d, vector_v>
 TEST(AgradPartialsVari, OperandsAndPartialsMultivarMixed) {
+  using stan::math::matrix_v;
   using stan::math::operands_and_partials;
   using stan::math::var;
-  using stan::math::vector_v;
   using stan::math::vector_d;
-  using stan::math::matrix_v;
+  using stan::math::vector_v;
 
   std::vector<vector_d> d_vec_vec(2);
   vector_d d_vec1(2);
@@ -267,8 +272,10 @@ TEST(AgradPartialsVari, OperandsAndPartialsMultivarMixed) {
   o4.edge1_.partials_vec_[0] += d_vec1;
   o4.edge3_.partials_vec_[0] += d_vec2;
 
-  // 2 partials stdvecs, 4 pointers to edges, 2 pointers to operands vecs
-  EXPECT_EQ(2 * sizeof(d_vec1) + 6 * sizeof(&v_vec), sizeof(o4));
+  // 2 partials stdvecs, 4 pointers to edges, 2 pointers to operands
+  // vecs
+  // IS NOW 112!!
+  // EXPECT_EQ(2 * sizeof(d_vec1) + 6 * sizeof(&v_vec), sizeof(o4));
 
   std::vector<double> grad;
   var v = o4.build(10.0);
@@ -278,4 +285,27 @@ TEST(AgradPartialsVari, OperandsAndPartialsMultivarMixed) {
   EXPECT_FLOAT_EQ(20.0, grad[1]);
   EXPECT_FLOAT_EQ(30.0, grad[2]);
   EXPECT_FLOAT_EQ(40.0, grad[3]);
+
+  // when given vector_d in place of vector_v all expressions must
+  // still compile
+  operands_and_partials<std::vector<vector_v>, std::vector<vector_d>, vector_d>
+      o5(v_vec, d_vec_vec, d_vec2);
+  o5.edge1_.partials_vec_[0] += d_vec1;
+  if (false) {
+    // the test here is to make things compile as this pattern to
+    // if-out things when terms are const is used in our functions
+    o5.edge3_.partials_vec_[0] += vector_d();
+    o5.edge3_.partials_vec_[0] -= vector_d();
+    o5.edge3_.partials_vec_[0](0) = 0;
+  }
+
+  // the same needs to work for the nested case
+  operands_and_partials<std::vector<vector_d>, std::vector<vector_d>, vector_v>
+      o6(d_vec_vec, d_vec_vec, v_vec2);
+  if (false) {
+    // the test here is to make things compile as this pattern to
+    // if-out things when terms are const is used in our functions
+    o6.edge1_.partials_vec_[0] += d_vec1;
+  }
+  o6.edge3_.partials_vec_[0] += d_vec2;
 }


### PR DESCRIPTION
#### Submission Checklist

- [X] Run unit tests: `./runTests.py test/unit`
- [X] Run cpplint: `make cpplint`
- [X] Declare copyright holder and open-source license: see below

#### Summary:
Correct `operands_and_partials` to work for nested containers as designed. This is needed for multi-variate use of `operands_and_partials`.

#### Intended Effect:
Enable use of `operands_and_partials` with multi-variate distributions which rely on the definition of `partials_vec_` as being part of the edges. The current implementation did not have a `partials_vec_` if an edge was given as `double` such that the usual code pattern would not compile.

#### How to Verify:
A test at the end of `./test/unit/math/rev/mat/meta/operands_and_partials_test.cpp` was added. The test is essentially fulfilled if the test compiles. On current develop the test will fail to compile even though this is the intended use case of the `operands_and_partials`

#### Side Effects:
When an edge is `double` only the size of the overall object increases from 5 to 10.

#### Documentation:

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Sebastian Weber

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)