### PR TITLE
avoid shifting of ode states whenever initials vary

### DIFF
--- a/test/unit/math/rev/arr/functor/coupled_ode_system_test.cpp
+++ b/test/unit/math/rev/arr/functor/coupled_ode_system_test.cpp
@@ -204,9 +204,9 @@ TEST_F(StanAgradRevOde, coupled_ode_system_vd) {
   coupled_y0.push_back(1.0);
   coupled_y0.push_back(0.5);
   coupled_y0.push_back(1.0);
-  coupled_y0.push_back(3.0);
-  coupled_y0.push_back(2.0);
-  coupled_y0.push_back(5.0);
+  coupled_y0.push_back(0.0);
+  coupled_y0.push_back(0.0);
+  coupled_y0.push_back(1.0);
 
   y0_var.push_back(1.0);
   y0_var.push_back(0.5);
@@ -216,12 +216,12 @@ TEST_F(StanAgradRevOde, coupled_ode_system_vd) {
 
   system(coupled_y0, dy_dt, t0);
 
-  EXPECT_FLOAT_EQ(1.0, dy_dt[0]);
-  EXPECT_FLOAT_EQ(-2.0 - 0.15 * 1.0, dy_dt[1]);
-  EXPECT_FLOAT_EQ(0 + 1.0 * 0 + 3.0 * 1 + 0, dy_dt[2]);
-  EXPECT_FLOAT_EQ(-1.0 - 1.0 * 1.0 - 0.15 * 3.0, dy_dt[3]);
-  EXPECT_FLOAT_EQ(1.0 + 2.0 * 0 + 5.0 * 1.0, dy_dt[4]);
-  EXPECT_FLOAT_EQ(-0.15 - 1.0 * 2.0 - 0.15 * 5.0, dy_dt[5]);
+  EXPECT_FLOAT_EQ(0.5, dy_dt[0]);
+  EXPECT_FLOAT_EQ(-1.0 - 0.15 * 0.5, dy_dt[1]);
+  EXPECT_FLOAT_EQ(0.0 * 1.0 + 1.0 * 0.0, dy_dt[2]);
+  EXPECT_FLOAT_EQ(-1.0 * 1.0 - 0.15 * 0.0, dy_dt[3]);
+  EXPECT_FLOAT_EQ(0.0 * 0.0 + 1.0 * 1.0, dy_dt[4]);
+  EXPECT_FLOAT_EQ(-1.0 * 0.0 - 0.15 * 1.0, dy_dt[5]);
 }
 TEST_F(StanAgradRevOde, decouple_states_vd) {
   using stan::math::coupled_ode_system;
@@ -258,7 +258,7 @@ TEST_F(StanAgradRevOde, decouple_states_vd) {
 
   for (size_t t = 0; t < T; t++)
     for (size_t n = 0; n < 2; n++)
-      EXPECT_FLOAT_EQ(ys_coupled[t][n] + y0[n].val(), ys[t][n].val());
+      EXPECT_FLOAT_EQ(ys_coupled[t][n], ys[t][n].val());
 }
 TEST_F(StanAgradRevOde, initial_state_vd) {
   using stan::math::coupled_ode_system;
@@ -283,10 +283,10 @@ TEST_F(StanAgradRevOde, initial_state_vd) {
 
   state = coupled_system_vd.initial_state();
   for (size_t n = 0; n < N; n++)
-    EXPECT_FLOAT_EQ(0.0, state[n])
-        << "we need derivatives of y0; initial state gets set to 0";
-  for (size_t n = N; n < state.size(); n++)
-    EXPECT_FLOAT_EQ(0.0, state[n]);
+    EXPECT_FLOAT_EQ(n + 1, state[n]);
+  for (size_t i = 0; i < N; i++)
+    for (size_t j = 0; j < N; j++)
+      EXPECT_FLOAT_EQ(i == j ? 1.0 : 0.0, state[N + i + j * N]);
 }
 TEST_F(StanAgradRevOde, size_vd) {
   using stan::math::coupled_ode_system;
@@ -374,6 +374,10 @@ TEST_F(StanAgradRevOde, coupled_ode_system_vv) {
       harm_osc, y0_var, theta_var, x, x_int, &msgs);
 
   std::vector<double> coupled_y0(8, 0);
+  coupled_y0[0] = 1.0;
+  coupled_y0[1] = 0.5;
+  coupled_y0[2] = 1.0;
+  coupled_y0[5] = 1.0;
 
   double t0;
   t0 = 0;
@@ -435,7 +439,7 @@ TEST_F(StanAgradRevOde, decouple_states_vv) {
 
   for (size_t t = 0; t < T; t++)
     for (size_t n = 0; n < 2; n++)
-      EXPECT_FLOAT_EQ(ys_coupled[t][n] + y0[n].val(), ys[t][n].val());
+      EXPECT_FLOAT_EQ(ys_coupled[t][n], ys[t][n].val());
 }
 TEST_F(StanAgradRevOde, initial_state_vv) {
   using stan::math::coupled_ode_system;
@@ -458,9 +462,11 @@ TEST_F(StanAgradRevOde, initial_state_vv) {
 
   std::vector<double> state = coupled_system_vv.initial_state();
   for (size_t n = 0; n < N; n++)
-    EXPECT_FLOAT_EQ(0.0, state[n])
-        << "we need derivatives of y0; initial state gets set to 0";
-  for (size_t n = N; n < state.size(); n++)
+    EXPECT_FLOAT_EQ(n + 1, state[n]);
+  for (size_t i = 0; i < N; i++)
+    for (size_t j = 0; j < N; j++)
+      EXPECT_FLOAT_EQ(i == j ? 1.0 : 0.0, state[N + i + j * N]);
+  for (size_t n = N + N * N; n < N + N * N + N * M; n++)
     EXPECT_FLOAT_EQ(0.0, state[n]);
 }
 TEST_F(StanAgradRevOde, size_vv) {


### PR DESCRIPTION
#### Submission Checklist

- [ ] Run unit tests: `./runTests.py test/unit`
- [X] Run cpplint: `make cpplint`
- [X] Declare copyright holder and open-source license: see below

#### Summary:
avoids shifting of the ode system for the non-stiff integrator

#### Intended Effect:
speed things up (avoid an extra copy of all states as var on AD stack) and make given tolerances apply to what we actually integrate.

#### How to Verify:
Tests in `test/unit/math/rev/arr/functor/`. In particular the `integrate_ode_rk45_grad_test.cpp` and `coupled_ode_system_test.cpp`.

#### Side Effects:
ODE system is not any more shifted. When there are N states and O outputs we will avoid N*O extra vars on the AD stack whenever initials vary.

#### Documentation:
In the code.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Sebastian Weber

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)