### PR TITLE
Add .gitattributes for dealing with line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# These files are text and should be normalized (convert crlf =&gt; lf)
+*.hpp text diff=cpp
+*.cpp text diff=cpp
+*.py text diff=python
+*.tex text diff=tex


### PR DESCRIPTION
#### Summary:
We have contributors using a variety of operating systems and so line-endings can get mangled or changed on a per-user basis. Some of our automatic tools don't deal well with this situation (looking at you, clang-format).

This normalizes all line endings to Unix LF style, as per https://git-scm.com/docs/gitattributes and http://adaptivepatchwork.com/2012/03/01/mind-the-end-of-your-line/

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
