### PR TITLE
Create log version of std_normal

### DIFF
--- a/stan/math/prim/scal.hpp
+++ b/stan/math/prim/scal.hpp
@@ -389,6 +389,7 @@
 #include <stan/math/prim/scal/prob/skew_normal_lpdf.hpp>
 #include <stan/math/prim/scal/prob/skew_normal_rng.hpp>
 #include <stan/math/prim/scal/prob/std_normal_lpdf.hpp>
+#include <stan/math/prim/scal/prob/std_normal_log.hpp>
 #include <stan/math/prim/scal/prob/student_t_ccdf_log.hpp>
 #include <stan/math/prim/scal/prob/student_t_cdf.hpp>
 #include <stan/math/prim/scal/prob/student_t_cdf_log.hpp>

--- a/stan/math/prim/scal/prob/std_normal_log.hpp
+++ b/stan/math/prim/scal/prob/std_normal_log.hpp
@@ -27,7 +27,7 @@ typename return_type<T_y>::type std_normal_log(const T_y& y) {
 }
 
 /**
- * @deprecated use <code>normal_lpdf</code>
+ * @deprecated use <code>std_normal_lpdf</code>
  */
 template <typename T_y>
 inline typename return_type<T_y>::type std_normal_log(const T_y& y) {

--- a/stan/math/prim/scal/prob/std_normal_log.hpp
+++ b/stan/math/prim/scal/prob/std_normal_log.hpp
@@ -1,0 +1,39 @@
+#ifndef STAN_MATH_PRIM_SCAL_PROB_STD_NORMAL_LOG_HPP
+#define STAN_MATH_PRIM_SCAL_PROB_STD_NORMAL_LOG_HPP
+
+#include <stan/math/prim/scal/meta/return_type.hpp>
+#include <stan/math/prim/scal/prob/std_normal_lpdf.hpp>
+
+namespace stan {
+namespace math {
+
+/**
+ * The log of a standard normal density for the specified scalar(s).
+ * y can be either a scalar or a vector.
+ *
+ * <p>The result log probability is defined to be the sum of the
+ * log probabilities for each observation.
+ *
+ * @deprecated use <code>std_normal_lpdf</code>
+ *
+ * @tparam T_y Underlying type of scalar in sequence.
+ * @param y (Sequence of) scalar(s).
+ * @return The log of the product of the densities.
+ * @throw std::domain_error if any scalar is nan.
+ */
+template <bool propto, typename T_y>
+typename return_type<T_y>::type std_normal_log(const T_y& y) {
+  return std_normal_lpdf<propto, T_y>(y);
+}
+
+/**
+ * @deprecated use <code>normal_lpdf</code>
+ */
+template <typename T_y>
+inline typename return_type<T_y>::type std_normal_log(const T_y& y) {
+  return std_normal_lpdf<T_y>(y);
+}
+
+}
+}
+#endif

--- a/test/unit/math/prim/scal/prob/std_normal_log_test.cpp
+++ b/test/unit/math/prim/scal/prob/std_normal_log_test.cpp
@@ -1,0 +1,22 @@
+#include <stan/math/prim/scal.hpp>
+#include <gtest/gtest.h>
+
+TEST(ProbStdNormal, log_matches_lpdf) {
+  double y = 0.8;
+
+  EXPECT_FLOAT_EQ((stan::math::std_normal_lpdf(y)),
+                  (stan::math::std_normal_log(y)));
+  EXPECT_FLOAT_EQ((stan::math::std_normal_lpdf<true>(y)),
+                  (stan::math::std_normal_log<true>(y)));
+  EXPECT_FLOAT_EQ((stan::math::std_normal_lpdf<false>(y)),
+                  (stan::math::std_normal_log<false>(y)));
+  EXPECT_FLOAT_EQ(
+      (stan::math::std_normal_lpdf<true, double>(y)),
+      (stan::math::std_normal_log<true, double>(y)));
+  EXPECT_FLOAT_EQ(
+      (stan::math::std_normal_lpdf<false, double>(y)),
+      (stan::math::std_normal_log<false, double>(y)));
+  EXPECT_FLOAT_EQ(
+      (stan::math::std_normal_lpdf<double>(y)),
+      (stan::math::std_normal_log<double>(y)));
+}


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary:
This adds a log version of the std_normal function.

#### Intended Effect:
This adds a `std_normal_log` function, which is basically a wrapper function for `std_normal_lpdf`. I'm adding this function because Stan currently expects a log version of the function (see Issue stan-dev/stan#2439).

#### How to Verify:
Run `./runTests.py test/unit/math/prim/scal/prob/std_normal_log_test.cpp` to verify that the function works like `std_normal_lpdf`.

#### Side Effects:
N/A

#### Documentation:
N/A

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Rayleigh Lei owns the copyrights to this work.

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
