### PR TITLE
Don't output distribution test logs. Archive them as an artifact if tests fail

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -166,7 +166,7 @@ pipeline {
                     post {
                         always { retry(3) { deleteDir() } }
                         failure {
-                            zip zipFile: "dist.log.zip", archive: true, glob: 'dist.log'
+                            script { zip zipFile: "dist.log.zip", archive: true, glob: 'dist.log' }
                             echo "Distribution tests failed. Check out dist.log artifact for test logs."
                         }
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -161,10 +161,15 @@ pipeline {
                                 sh "echo CXXFLAGS+=-DSTAN_TEST_ROW_VECTORS >> make/local"
                             }
                         }
-                        sh "./runTests.py -j${env.PARALLEL} test/prob"
-
+                        sh "./runTests.py -j${env.PARALLEL} test/prob &> dist.log"
                     }
-                    post { always { retry(3) { deleteDir() } } }
+                    post {
+                        always { retry(3) { deleteDir() } }
+                        failure {
+                            archiveArtifacts 'dist.log'
+                            echo "Distribution tests failed. Check out dist.log artifact for test logs."
+                        }
+                    }
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -166,7 +166,7 @@ pipeline {
                     post {
                         always { retry(3) { deleteDir() } }
                         failure {
-                            archiveArtifacts 'dist.log'
+                            zip zipFile: "dist.log.zip", archive: true, glob: 'dist.log'
                             echo "Distribution tests failed. Check out dist.log artifact for test logs."
                         }
                     }


### PR DESCRIPTION
#### Context
The Distribution test logs take up a lot of space when storing old builds (about 1.5GB each, which gets stored a couple of times by Jenkins). We have limited disk space on master and would like to keep as many historical builds as we can. This PR writes the distribution test stdout and stderr to a file and then archives that file as an artifact if tests fail. I think artifacts are also stored more sensibly (so they will only be stored once, not 2 or more times as with logs) and have a more sensible UI for large files.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
