### PR TITLE
add --use-config flag to ./b2 to build mpi

### DIFF
--- a/make/libraries
+++ b/make/libraries
@@ -39,7 +39,7 @@ $(STAN_CVODES_HEADERS) : $(LIBCVODES)
 $(BOOST)/stage/lib/mpi.so :
 	cd $(BOOST); ./bootstrap.sh
 	cd $(BOOST); echo "using mpi ;" >> user-config.jam
-	cd $(BOOST); ./b2 --with-mpi --with-serialization
+	cd $(BOOST); ./b2 --user-config=user-config.jam --with-mpi --with-serialization
 
 stan-mpi : $(BOOST)/stage/lib/mpi.so
 	@echo "Please add \"include make/mpi\" to make/local"


### PR DESCRIPTION
bjam may not read correct user-config.jam unless given --user-config option. See
https://stackoverflow.com/questions/2892582/trying-to-build-boost-mpi-but-the-lib-files-are-not-created-whats-going-on

#### Submission Checklist

- [x] Run unit tests: `./runTests.py test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
