### PR TITLE
Always zip and archive log file, at least until we trust this step.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -164,10 +164,12 @@ pipeline {
                         sh "./runTests.py -j${env.PARALLEL} test/prob &> dist.log"
                     }
                     post {
-                        always { retry(3) { deleteDir() } }
-                        failure {
+                        always {
                             script { zip zipFile: "dist.log.zip", archive: true, glob: 'dist.log' }
-                            echo "Distribution tests failed. Check out dist.log artifact for test logs."
+                            retry(3) { deleteDir() }
+                        }
+                        failure {
+                            echo "Distribution tests failed. Check out dist.log.zip artifact for test logs."
                         }
                     }
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -161,7 +161,7 @@ pipeline {
                                 sh "echo CXXFLAGS+=-DSTAN_TEST_ROW_VECTORS >> make/local"
                             }
                         }
-                        sh "./runTests.py -j${env.PARALLEL} test/prob &> dist.log"
+                        sh "./runTests.py -j${env.PARALLEL} test/prob > dist.log 2>&1"
                     }
                     post {
                         always {


### PR DESCRIPTION
I'm worried that [this develop build](http://d1m1s1b1.stat.columbia.edu:8080/job/Math%20Pipeline/job/develop/19/) didn't actually execute the distribution tests (they claim to have finished in 3 seconds) but the log file is gone. Probably a good idea to always archive zipped for now.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
