### PR TITLE
add map_rect_serial [WIP]

### DIFF
--- a/stan/math/prim/mat.hpp
+++ b/stan/math/prim/mat.hpp
@@ -246,6 +246,10 @@
 
 #include <stan/math/prim/mat/functor/finite_diff_gradient.hpp>
 #include <stan/math/prim/mat/functor/finite_diff_hessian.hpp>
+#include <stan/math/prim/mat/functor/map_rect.hpp>
+#include <stan/math/prim/mat/functor/map_rect_serial.hpp>
+#include <stan/math/prim/mat/functor/map_rect_reduce.hpp>
+#include <stan/math/prim/mat/functor/map_rect_combine.hpp>
 
 #include <stan/math/prim/mat/prob/bernoulli_logit_glm_lpmf.hpp>
 #include <stan/math/prim/mat/prob/categorical_log.hpp>

--- a/stan/math/prim/mat/functor/map_rect.hpp
+++ b/stan/math/prim/mat/functor/map_rect.hpp
@@ -1,0 +1,39 @@
+#ifndef STAN_MATH_PRIM_MAT_FUNCTOR_MAP_RECT_HPP
+#define STAN_MATH_PRIM_MAT_FUNCTOR_MAP_RECT_HPP
+
+#include <stan/math/prim/mat/fun/typedefs.hpp>
+
+#define STAN_REGISTER_MAP_RECT(CALLID, FUNCTOR)
+
+#ifdef STAN_HAS_MPI
+#error "MPI not yet supported"
+#else
+#include <stan/math/prim/mat/functor/map_rect_serial.hpp>
+#endif
+
+#include <vector>
+
+namespace stan {
+namespace math {
+
+template <int call_id, typename F, typename T_shared_param,
+          typename T_job_param>
+Eigen::Matrix<typename stan::return_type<T_shared_param, T_job_param>::type,
+              Eigen::Dynamic, 1>
+map_rect(const Eigen::Matrix<T_shared_param, Eigen::Dynamic, 1>& shared_params,
+         const std::vector<Eigen::Matrix<T_job_param, Eigen::Dynamic, 1>>&
+             job_params,
+         const std::vector<std::vector<double>>& x_r,
+         const std::vector<std::vector<int>>& x_i, std::ostream* msgs = 0) {
+#ifdef STAN_HAS_MPI
+#error "MPI not yet supported"
+#else
+  return map_rect_serial<call_id, F, T_shared_param, T_job_param>(
+      shared_params, job_params, x_r, x_i, msgs);
+#endif
+}
+
+}  // namespace math
+}  // namespace stan
+
+#endif

--- a/stan/math/prim/mat/functor/map_rect_combine.hpp
+++ b/stan/math/prim/mat/functor/map_rect_combine.hpp
@@ -1,0 +1,79 @@
+#ifndef STAN_MATH_PRIM_MAT_FUNCTOR_MAP_RECT_COMBINE_HPP
+#define STAN_MATH_PRIM_MAT_FUNCTOR_MAP_RECT_COMBINE_HPP
+
+#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
+#include <stan/math/prim/scal/meta/operands_and_partials.hpp>
+#include <stan/math/prim/arr/fun/sum.hpp>
+#include <stan/math/prim/mat/fun/typedefs.hpp>
+
+#include <vector>
+
+namespace stan {
+namespace math {
+namespace internal {
+
+template <typename F, typename T_shared_param, typename T_job_param>
+class map_rect_combine {
+  typedef operands_and_partials<
+      Eigen::Matrix<T_shared_param, Eigen::Dynamic, 1>,
+      Eigen::Matrix<T_job_param, Eigen::Dynamic, 1>>
+      ops_partials_t;
+  std::vector<ops_partials_t> ops_partials_;
+
+  const std::size_t num_shared_operands_;
+  const std::size_t num_job_operands_;
+
+ public:
+  typedef Eigen::Matrix<
+      typename stan::return_type<T_shared_param, T_job_param>::type,
+      Eigen::Dynamic, 1>
+      result_type;
+
+  map_rect_combine()
+      : ops_partials_(), num_shared_operands_(0), num_job_operands_(0) {}
+  map_rect_combine(
+      const Eigen::Matrix<T_shared_param, Eigen::Dynamic, 1>& shared_params,
+      const std::vector<Eigen::Matrix<T_job_param, Eigen::Dynamic, 1>>&
+          job_params)
+      : ops_partials_(),
+        num_shared_operands_(shared_params.rows()),
+        num_job_operands_(dims(job_params)[1]) {
+    ops_partials_.reserve(job_params.size());
+    for (std::size_t i = 0; i < job_params.size(); i++) {
+      ops_partials_.push_back(ops_partials_t(shared_params, job_params[i]));
+    }
+  }
+
+  result_type operator()(const matrix_d& world_result,
+                         const std::vector<int>& world_f_out) {
+    const std::size_t num_jobs = world_f_out.size();
+    const std::size_t offset_job_params
+        = is_constant_struct<T_shared_param>::value ? 1
+                                                    : 1 + num_shared_operands_;
+    const std::size_t size_world_f_out = sum(world_f_out);
+
+    result_type out(size_world_f_out);
+
+    for (std::size_t i = 0, ij = 0; i != num_jobs; ++i) {
+      for (int j = 0; j != world_f_out[i]; ++j, ++ij) {
+        if (!is_constant_struct<T_shared_param>::value)
+          ops_partials_[i].edge1_.partials_
+              = world_result.block(1, ij, num_shared_operands_, 1);
+
+        if (!is_constant_struct<T_job_param>::value)
+          ops_partials_[i].edge2_.partials_
+              = world_result.block(offset_job_params, ij, num_job_operands_, 1);
+
+        out(ij) = ops_partials_[i].build(world_result(0, ij));
+      }
+    }
+
+    return out;
+  }
+};
+
+}  // namespace internal
+}  // namespace math
+}  // namespace stan
+
+#endif

--- a/stan/math/prim/mat/functor/map_rect_reduce.hpp
+++ b/stan/math/prim/mat/functor/map_rect_reduce.hpp
@@ -1,0 +1,34 @@
+#ifndef STAN_MATH_PRIM_MAT_FUNCTOR_MAP_RECT_REDUCE_HPP
+#define STAN_MATH_PRIM_MAT_FUNCTOR_MAP_RECT_REDUCE_HPP
+
+#include <stan/math/prim/mat/fun/typedefs.hpp>
+
+#include <vector>
+
+namespace stan {
+namespace math {
+namespace internal {
+
+template <typename F, typename T_shared_param, typename T_job_param>
+class map_rect_reduce {};
+
+template <typename F>
+class map_rect_reduce<F, double, double> {
+ public:
+  matrix_d operator()(const vector_d& shared_params,
+                      const vector_d& job_specific_params,
+                      const std::vector<double>& x_r,
+                      const std::vector<int>& x_i,
+                      std::ostream* msgs = 0) const {
+    const F f;
+    const matrix_d out
+        = f(shared_params, job_specific_params, x_r, x_i, msgs).transpose();
+    return out;
+  }
+};
+
+}  // namespace internal
+}  // namespace math
+}  // namespace stan
+
+#endif

--- a/stan/math/prim/mat/functor/map_rect_serial.hpp
+++ b/stan/math/prim/mat/functor/map_rect_serial.hpp
@@ -1,0 +1,65 @@
+#ifndef STAN_MATH_PRIM_MAT_FUNCTOR_MAP_RECT_SERIAL_HPP
+#define STAN_MATH_PRIM_MAT_FUNCTOR_MAP_RECT_SERIAL_HPP
+
+#include <stan/math/prim/mat/fun/typedefs.hpp>
+
+#include <stan/math/prim/mat/functor/map_rect_reduce.hpp>
+#include <stan/math/prim/mat/functor/map_rect_combine.hpp>
+
+#include <vector>
+
+namespace stan {
+namespace math {
+
+template <int call_id, typename F, typename T_shared_param,
+          typename T_job_param>
+Eigen::Matrix<typename stan::return_type<T_shared_param, T_job_param>::type,
+              Eigen::Dynamic, 1>
+map_rect_serial(
+    const Eigen::Matrix<T_shared_param, Eigen::Dynamic, 1>& shared_params,
+    const std::vector<Eigen::Matrix<T_job_param, Eigen::Dynamic, 1>>&
+        job_params,
+    const std::vector<std::vector<double>>& x_r,
+    const std::vector<std::vector<int>>& x_i, std::ostream* msgs = 0) {
+  check_nonzero_size("map_rect_serial", "job parameters", job_params);
+  check_matching_sizes("map_rect_serial", "job parameters", job_params,
+                       "continuous data", x_r);
+  check_matching_sizes("map_rect_serial", "job parameters", job_params,
+                       "integer data", x_i);
+
+  typedef internal::map_rect_reduce<F, T_shared_param, T_job_param> ReduceF;
+  typedef internal::map_rect_combine<F, T_shared_param, T_job_param> CombineF;
+
+  const int num_jobs = job_params.size();
+  const vector_d shared_params_dbl = value_of(shared_params);
+
+  matrix_d world_output(0, 0);
+  std::vector<int> world_f_out(num_jobs, -1);
+
+  int offset = 0;
+  for (int i = 0; i < num_jobs; ++i) {
+    const matrix_d job_output = ReduceF()(
+        shared_params_dbl, value_of(job_params[i]), x_r[i], x_i[i], msgs);
+    world_f_out[i] = job_output.cols();
+
+    if (i == 0)
+      world_output.resize(job_output.rows(), num_jobs * world_f_out[i]);
+
+    if (world_output.cols() < offset + world_f_out[i])
+      world_output.conservativeResize(Eigen::NoChange,
+                                      2 * (offset + world_f_out[i]));
+
+    world_output.block(0, offset, world_output.rows(), world_f_out[i])
+        = job_output;
+
+    offset += world_f_out[i];
+  }
+
+  CombineF combine(shared_params, job_params);
+  return combine(world_output, world_f_out);
+}
+
+}  // namespace math
+}  // namespace stan
+
+#endif

--- a/stan/math/rev/mat.hpp
+++ b/stan/math/rev/mat.hpp
@@ -59,5 +59,6 @@
 #include <stan/math/rev/mat/functor/cvodes_utils.hpp>
 #include <stan/math/rev/mat/functor/cvodes_ode_data.hpp>
 #include <stan/math/rev/mat/functor/integrate_ode_bdf.hpp>
+#include <stan/math/rev/mat/functor/map_rect_reduce.hpp>
 
 #endif

--- a/stan/math/rev/mat/functor/map_rect_reduce.hpp
+++ b/stan/math/rev/mat/functor/map_rect_reduce.hpp
@@ -1,0 +1,163 @@
+#ifndef STAN_MATH_REV_MAT_FUNCTOR_MAP_RECT_REDUCE_HPP
+#define STAN_MATH_REV_MAT_FUNCTOR_MAP_RECT_REDUCE_HPP
+
+#include <stan/math/prim/mat/functor/map_rect_reduce.hpp>
+#include <stan/math/prim/mat/fun/typedefs.hpp>
+#include <stan/math/rev/core/var.hpp>
+#include <stan/math/rev/mat/fun/typedefs.hpp>
+
+#include <vector>
+
+namespace stan {
+namespace math {
+namespace internal {
+
+template <typename F>
+struct map_rect_reduce<F, var, var> {
+  matrix_d operator()(const vector_d& shared_params,
+                      const vector_d& job_specific_params,
+                      const std::vector<double>& x_r,
+                      const std::vector<int>& x_i,
+                      std::ostream* msgs = 0) const {
+    const size_type num_shared_params = shared_params.rows();
+    const size_type num_job_specific_params = job_specific_params.rows();
+    const size_type num_params = num_shared_params + num_job_specific_params;
+    matrix_d out(1 + num_params, 0);
+
+    try {
+      start_nested();
+      vector_v shared_params_v(num_shared_params);
+      vector_v job_specific_params_v(num_job_specific_params);
+
+      for (size_type i = 0; i < num_shared_params; ++i)
+        shared_params_v(i) = shared_params(i);
+      for (size_type i = 0; i < num_job_specific_params; ++i)
+        job_specific_params_v(i) = job_specific_params(i);
+
+      std::vector<var> z_vars(num_params);
+
+      for (size_type i = 0; i < num_shared_params; ++i)
+        z_vars[i] = shared_params_v(i);
+      for (size_type i = 0; i < num_job_specific_params; ++i)
+        z_vars[num_shared_params + i] = job_specific_params_v(i);
+
+      const F f;
+      vector_v fx_v = f(shared_params_v, job_specific_params_v, x_r, x_i, msgs);
+
+      const size_type size_f = fx_v.rows();
+
+      out.resize(Eigen::NoChange, size_f);
+
+      for (size_type i = 0; i < size_f; ++i) {
+        out(0, i) = fx_v(i).val();
+        set_zero_all_adjoints_nested();
+        fx_v(i).grad();
+        for (size_type j = 0; j < num_params; ++j)
+          out(1 + j, i) = z_vars[j].vi_->adj_;
+      }
+      recover_memory_nested();
+    } catch (const std::exception& e) {
+      recover_memory_nested();
+      throw;
+    }
+    return out;
+  }
+};
+
+template <typename F>
+struct map_rect_reduce<F, double, var> {
+  matrix_d operator()(const vector_d& shared_params,
+                      const vector_d& job_specific_params,
+                      const std::vector<double>& x_r,
+                      const std::vector<int>& x_i,
+                      std::ostream* msgs = 0) const {
+    const size_type num_job_specific_params = job_specific_params.rows();
+    matrix_d out(1 + num_job_specific_params, 0);
+
+    try {
+      start_nested();
+      vector_v job_specific_params_v(num_job_specific_params);
+
+      for (size_type i = 0; i < num_job_specific_params; ++i)
+        job_specific_params_v(i) = job_specific_params(i);
+
+      const F f;
+      vector_v fx_v = f(shared_params, job_specific_params_v, x_r, x_i, msgs);
+
+      const size_type size_f = fx_v.rows();
+
+      out.resize(Eigen::NoChange, size_f);
+
+      for (size_type i = 0; i < size_f; ++i) {
+        out(0, i) = fx_v(i).val();
+        set_zero_all_adjoints_nested();
+        fx_v(i).grad();
+        for (size_type j = 0; j < num_job_specific_params; ++j)
+          out(1 + j, i) = job_specific_params_v(j).vi_->adj_;
+      }
+      recover_memory_nested();
+    } catch (const std::exception& e) {
+      recover_memory_nested();
+      throw;
+    }
+    return out;
+  }
+};
+
+template <typename F>
+struct map_rect_reduce<F, var, double> {
+  matrix_d operator()(const vector_d& shared_params,
+                      const vector_d& job_specific_params,
+                      const std::vector<double>& x_r,
+                      const std::vector<int>& x_i,
+                      std::ostream* msgs = 0) const {
+    const size_type num_shared_params = shared_params.rows();
+    matrix_d out(1 + num_shared_params, 0);
+
+    try {
+      start_nested();
+      vector_v shared_params_v(num_shared_params);
+
+      for (size_type i = 0; i < num_shared_params; ++i)
+        shared_params_v(i) = shared_params(i);
+
+      const F f;
+      vector_v fx_v = f(shared_params_v, job_specific_params, x_r, x_i, 0);
+
+      const size_type size_f = fx_v.rows();
+
+      out.resize(Eigen::NoChange, size_f);
+
+      for (size_type i = 0; i < size_f; ++i) {
+        out(0, i) = fx_v(i).val();
+        set_zero_all_adjoints_nested();
+        fx_v(i).grad();
+        for (size_type j = 0; j < num_shared_params; ++j)
+          out(1 + j, i) = shared_params_v(j).vi_->adj_;
+      }
+      recover_memory_nested();
+    } catch (const std::exception& e) {
+      recover_memory_nested();
+      throw;
+    }
+    return out;
+  }
+};
+
+}  // namespace internal
+}  // namespace math
+}  // namespace stan
+
+#ifdef STAN_REGISTER_MPI_MAP_RECT_ALL
+
+#undef STAN_REGISTER_MPI_MAP_RECT_ALL
+
+#define STAN_REGISTER_MPI_MAP_RECT_ALL(CALLID, FUNCTOR)       \
+  STAN_REGISTER_MPI_MAP_RECT(CALLID, FUNCTOR, double, double) \
+  STAN_REGISTER_MPI_MAP_RECT(CALLID, FUNCTOR, double, var)    \
+  STAN_REGISTER_MPI_MAP_RECT(CALLID, FUNCTOR, var, double)    \
+  STAN_REGISTER_MPI_MAP_RECT(CALLID, FUNCTOR, var, var)
+
+#endif
+
+#endif

--- a/test/unit/math/prim/mat/functor/faulty_functor.hpp
+++ b/test/unit/math/prim/mat/functor/faulty_functor.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <stdexcept>
+#include <vector>
+
+struct faulty_functor {
+  template <typename T1, typename T2>
+  Eigen::Matrix<typename stan::return_type<T1, T2>::type, Eigen::Dynamic, 1>
+  operator()(const Eigen::Matrix<T1, Eigen::Dynamic, 1>& eta,
+             const Eigen::Matrix<T2, Eigen::Dynamic, 1>& theta,
+             const std::vector<double>& x_r, const std::vector<int>& x_i,
+             std::ostream* msgs = 0) const {
+    typedef typename stan::return_type<T1, T2>::type result_type;
+    Eigen::Matrix<result_type, Eigen::Dynamic, 1> res;
+    res.resize(2);
+    res(0) = theta(0) * theta(0);
+    res(1) = x_r[0] * theta(1) * theta(0);
+    // std::cout << "theta(0) = " << theta(0) << std::endl;
+    if (stan::math::abs(theta(0) + 1.0) < 1E-7) {  // check for param being 1.0
+      // std::cout << "THROWING! DEAL WITH IT!" << std::endl;
+      throw std::domain_error("Illegal parameter!");
+    }
+    return (res);
+  }
+};

--- a/test/unit/math/prim/mat/functor/faulty_functor.hpp
+++ b/test/unit/math/prim/mat/functor/faulty_functor.hpp
@@ -4,6 +4,7 @@
 #include <vector>
 
 struct faulty_functor {
+  faulty_functor() {}
   template <typename T1, typename T2>
   Eigen::Matrix<typename stan::return_type<T1, T2>::type, Eigen::Dynamic, 1>
   operator()(const Eigen::Matrix<T1, Eigen::Dynamic, 1>& eta,

--- a/test/unit/math/prim/mat/functor/hard_work.hpp
+++ b/test/unit/math/prim/mat/functor/hard_work.hpp
@@ -3,6 +3,7 @@
 #include <vector>
 
 struct hard_work {
+  hard_work() {}
   template <typename T1, typename T2>
   Eigen::Matrix<typename stan::return_type<T1, T2>::type, Eigen::Dynamic, 1>
   operator()(const Eigen::Matrix<T1, Eigen::Dynamic, 1>& eta,

--- a/test/unit/math/prim/mat/functor/hard_work.hpp
+++ b/test/unit/math/prim/mat/functor/hard_work.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <vector>
+
+struct hard_work {
+  template <typename T1, typename T2>
+  Eigen::Matrix<typename stan::return_type<T1, T2>::type, Eigen::Dynamic, 1>
+  operator()(const Eigen::Matrix<T1, Eigen::Dynamic, 1>& eta,
+             const Eigen::Matrix<T2, Eigen::Dynamic, 1>& theta,
+             const std::vector<double>& x_r, const std::vector<int>& x_i,
+             std::ostream* msgs = 0) const {
+    typedef typename stan::return_type<T1, T2>::type result_type;
+    Eigen::Matrix<result_type, Eigen::Dynamic, 1> res;
+    res.resize(2);
+    res(0) = theta(0) * theta(0) + eta(0);
+    res(1) = x_r[0] * theta(1) * theta(0) + 2 * eta(0) + eta(1);
+    return (res);
+  }
+};

--- a/test/unit/math/prim/mat/functor/map_rect_test.cpp
+++ b/test/unit/math/prim/mat/functor/map_rect_test.cpp
@@ -1,0 +1,27 @@
+#include <stan/math/prim/mat.hpp>
+#include <gtest/gtest.h>
+
+#include <test/unit/math/prim/mat/functor/hard_work.hpp>
+
+#include <iostream>
+#include <vector>
+
+TEST(map_rect_serial, hard_work_dd) {
+  Eigen::VectorXd shared_params_d(2);
+  shared_params_d << 2, 0;
+  std::vector<Eigen::VectorXd> job_params_d;
+
+  const std::size_t N = 10;
+
+  for (std::size_t n = 0; n != N; ++n) {
+    Eigen::VectorXd job_d(2);
+    job_d << 0, n * n;
+    job_params_d.push_back(job_d);
+  }
+
+  std::vector<std::vector<double> > x_r(N, std::vector<double>(1, 1.0));
+  std::vector<std::vector<int> > x_i(N, std::vector<int>(0));
+
+  Eigen::VectorXd result = stan::math::map_rect_serial<0, hard_work>(
+      shared_params_d, job_params_d, x_r, x_i);
+}

--- a/test/unit/math/rev/mat/functor/map_rect_test.cpp
+++ b/test/unit/math/rev/mat/functor/map_rect_test.cpp
@@ -1,0 +1,64 @@
+#include <stan/math.hpp>
+#include <gtest/gtest.h>
+
+#include <test/unit/math/prim/mat/functor/hard_work.hpp>
+#include <test/unit/math/prim/mat/functor/faulty_functor.hpp>
+
+#include <iostream>
+#include <vector>
+
+struct MapRectJob : public ::testing::Test {
+  stan::math::vector_v shared_params_v;
+  std::vector<stan::math::vector_v> job_params_v;
+  stan::math::vector_v shared_params_v2;
+  std::vector<stan::math::vector_v> job_params_v2;
+  const std::size_t N = 10;
+  std::vector<std::vector<double>> x_r
+      = std::vector<std::vector<double>>(N, std::vector<double>(1, 1.0));
+  std::vector<std::vector<int>> x_i
+      = std::vector<std::vector<int>>(N, std::vector<int>(1, 0));
+
+  virtual void SetUp() {
+    shared_params_v.resize(2);
+    shared_params_v << 2, 0;
+    shared_params_v2.resize(2);
+    shared_params_v2 << 2, 0;
+
+    for (std::size_t n = 0; n != N; ++n) {
+      x_i[n][0] = n;
+      stan::math::vector_v job_v(2);
+      job_v << n + 1.0, n * n;
+      job_params_v.push_back(job_v);
+
+      stan::math::vector_v job_v2(2);
+      job_v2 << n + 1.0, n * n;
+      job_params_v2.push_back(job_v2);
+    }
+  }
+};
+
+TEST_F(MapRectJob, hard_work_vv) {
+  stan::math::vector_v result_serial
+      = stan::math::map_rect_serial<0, hard_work>(shared_params_v, job_params_v,
+                                                  x_r, x_i, 0);
+}
+
+TEST_F(MapRectJob, always_faulty_functor_vv) {
+  stan::math::vector_v result;
+
+  EXPECT_NO_THROW((result = stan::math::map_rect<1, faulty_functor>(
+                       shared_params_v, job_params_v, x_r, x_i)));
+
+  // faulty functor throws on theta(0) being -1.0
+  // throwing during the first evaluation is quite severe and will
+  // lead to a respective runtime error
+  job_params_v[0](0) = -1;
+
+  // upon the second evaluation throwing is handled internally different
+  EXPECT_ANY_THROW((result = stan::math::map_rect<1, faulty_functor>(
+                        shared_params_v, job_params_v, x_r, x_i)));
+
+  // throwing on the very first evaluation
+  EXPECT_ANY_THROW((result = stan::math::map_rect<2, faulty_functor>(
+                        shared_params_v, job_params_v, x_r, x_i)));
+}


### PR DESCRIPTION
#### Submission Checklist

- [ ] Run unit tests: `./runTests.py test/unit`
- [X] Run cpplint: `make cpplint`
- [X] Declare copyright holder and open-source license: see below

#### Summary:
add serial version of map_rect

#### Intended Effect:
this version of map_rect has the exact same interface as the mpi version which is to follow. Currently there are bare minimum tests which show how the code runs. Help in adding tests is much appreciated. Note that for MPI the function has two special properties:

1. template argument `call_id` which serves to enumerate the data passed into the function. This is used in the MPI code to take advantage of a static data concept
2. the user functor is passed into the function as type only. For MPI we will never transmit any function object and hence the design enforces that all what is transmitted is type information.

Both of the above points will require special handling the stan parser.

Also note, that the serial version of `map_rect` computes all derivatives on the spot and stores these as precomputed_gradients in the AD tree. This is in line with what the MPI code will be doing and this strategy showed considerable speedups for large-scale models (close to 1.8x performance).

#### How to Verify:

Right now the two tests

- `test/unit/math/prim/mat/functor/map_rect_test.cpp`
- `test/unit/math/rev/mat/functor/map_rect_test.cpp`

show how to call the functions.

#### Side Effects:

#### Documentation:

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Sebastian Weber

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)