### PR TITLE
Add filter argument to ./runTests.py

### DIFF
--- a/runTests.py
+++ b/runTests.py
@@ -40,9 +40,10 @@ def processCLIArgs():
     tests_help_msg += "         'test/unit/math/prim/scal/fun/abs_test.cpp'"
     parser.add_argument("tests", nargs="+", type=str,
                         help=tests_help_msg)
-    filter_help_msg = "Tests with file names matching this will be executed"
+    f_help_msg = "Only tests with file names matching these will be executed.\n"
+    f_help_msg += "Example: '-f chol', '-f gpu', '-f prim mat'"
     parser.add_argument("-f", nargs="+", type=str, default = "",
-                        help=filter_help_msg)
+                        help=f_help_msg)
 
     parser.add_argument("-d", "--debug", dest="debug", action="store_true",
                         help="request additional script debugging output.")

--- a/runTests.py
+++ b/runTests.py
@@ -40,6 +40,9 @@ def processCLIArgs():
     tests_help_msg += "         'test/unit/math/prim/scal/fun/abs_test.cpp'"
     parser.add_argument("tests", nargs="+", type=str,
                         help=tests_help_msg)
+    filter_help_msg = "Tests with file names matching this will be executed"
+    parser.add_argument("-f", nargs="+", type=str, default = "",
+                        help=filter_help_msg)
 
     parser.add_argument("-d", "--debug", dest="debug", action="store_true",
                         help="request additional script debugging output.")
@@ -97,15 +100,20 @@ def runTest(name):
     command = '%s --gtest_output="xml:%s.xml"' % (executable, xml)
     doCommand(command)
 
-def findTests(args):
-    folders = filter(os.path.isdir, args)
-    nonfolders = list(set(args) - set(folders))
+def findTests(base_path, filter_names):
+    folders = filter(os.path.isdir, base_path)
+    nonfolders = list(set(base_path) - set(folders))
     tests = nonfolders + [os.path.join(root, n)
             for f in folders
             for root, _, names in os.walk(f)
             for n in names
             if n.endswith(testsfx)]
-    return map(mungeName, tests)
+    tests = map(mungeName, tests)
+    tests = [test
+            for test in tests
+            if all(filter_name in test
+                   for filter_name in filter_names)]
+    return tests
 
 def batched(tests):
     return [tests[i:i + batchSize] for i in range(0, len(tests), batchSize)]
@@ -118,7 +126,7 @@ def main():
     if any(['test/prob' in arg for arg in inputs.tests]):
         generateTests(inputs.j)
 
-    tests = findTests(inputs.tests)
+    tests = findTests(inputs.tests, inputs.f)
     if not tests:
         stopErr("No matching tests found.", -1)
 


### PR DESCRIPTION
#### Submission Checklist

- [ ] Run unit tests: `./runTests.py test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

This add a `-f` option to `./runTests.py` that allows you to filter the tests based on names. For example running
```bash
./runTests.py tests/unit -f chol prim
```
Will run all the tests in `tests/unit` whose path contains both `chol` and `prim`. No one asked for this, but I thought it might be nice. Just throwin' it out there

#### Intended Effect:

Allow for users to filter the specific tests they run

#### How to Verify:

Try it out!

#### Side Effects:
?
#### Documentation:
Added to help file from `-h` for ./runTests.py

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Stephen Bronder

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
