### PR TITLE
Feature/issue 752 mvn speedup 2

### DIFF
--- a/stan/math/prim/mat/prob/multi_normal_cholesky_lpdf.hpp
+++ b/stan/math/prim/mat/prob/multi_normal_cholesky_lpdf.hpp
@@ -55,7 +55,8 @@ typename return_type<T_y, T_loc, T_covar>::type multi_normal_cholesky_lpdf(
   typedef Eigen::Matrix<T_partials_return, Eigen::Dynamic, Eigen::Dynamic>
       matrix_partials_t;
   typedef Eigen::Matrix<T_partials_return, Eigen::Dynamic, 1> vector_partials_t;
-  typedef Eigen::Matrix<T_partials_return, 1, Eigen::Dynamic> row_vector_partials_t;
+  typedef Eigen::Matrix<T_partials_return, 1, Eigen::Dynamic>
+      row_vector_partials_t;
 
   vector_seq_view<T_y> y_vec(y);
   vector_seq_view<T_loc> mu_vec(mu);
@@ -122,8 +123,12 @@ typename return_type<T_y, T_loc, T_covar>::type multi_normal_cholesky_lpdf(
       for (int j = 0; j < size_y; j++)
         y_minus_mu_dbl(j) = value_of(y_vec[i](j)) - value_of(mu_vec[i](j));
 
-      const row_vector_partials_t half = (inv_L_dbl.template triangularView<Eigen::Lower>() * y_minus_mu_dbl).transpose();
-      const vector_partials_t scaled_diff = (half * inv_L_dbl.template triangularView<Eigen::Lower>()).transpose();
+      const row_vector_partials_t half
+          = (inv_L_dbl.template triangularView<Eigen::Lower>() * y_minus_mu_dbl)
+                .transpose();
+      const vector_partials_t scaled_diff
+          = (half * inv_L_dbl.template triangularView<Eigen::Lower>())
+                .transpose();
 
       logp -= 0.5 * dot_self(half);
 

--- a/stan/math/rev/scal/fun/log_sum_exp.hpp
+++ b/stan/math/rev/scal/fun/log_sum_exp.hpp
@@ -15,9 +15,8 @@ class log_sum_exp_vv_vari : public op_vv_vari {
   log_sum_exp_vv_vari(vari* avi, vari* bvi)
       : op_vv_vari(log_sum_exp(avi->val_, bvi->val_), avi, bvi) {}
   void chain() {
-    const double df_da = calculate_chain(avi_->val_, val_);
-    avi_->adj_ += adj_ * df_da;
-    bvi_->adj_ += adj_ * (1.0 - df_da);
+    avi_->adj_ += adj_ * calculate_chain(avi_->val_, val_);
+    bvi_->adj_ += adj_ * calculate_chain(bvi_->val_, val_);
   }
 };
 class log_sum_exp_vd_vari : public op_vd_vari {

--- a/stan/math/rev/scal/fun/log_sum_exp.hpp
+++ b/stan/math/rev/scal/fun/log_sum_exp.hpp
@@ -15,8 +15,9 @@ class log_sum_exp_vv_vari : public op_vv_vari {
   log_sum_exp_vv_vari(vari* avi, vari* bvi)
       : op_vv_vari(log_sum_exp(avi->val_, bvi->val_), avi, bvi) {}
   void chain() {
-    avi_->adj_ += adj_ * calculate_chain(avi_->val_, val_);
-    bvi_->adj_ += adj_ * calculate_chain(bvi_->val_, val_);
+    const double df_da = calculate_chain(avi_->val_, val_);
+    avi_->adj_ += adj_ * df_da;
+    bvi_->adj_ += adj_ * (1.0 - df_da);
   }
 };
 class log_sum_exp_vd_vari : public op_vd_vari {


### PR DESCRIPTION
#### Submission Checklist

- [ ] Run unit tests: `./runTests.py test/unit`
- [X] Run cpplint: `make cpplint`
- [X] Declare copyright holder and open-source license: see below

#### Summary:
Speedup multi_normal_cholesky by using the inverted cholesky factor more efficiently.

#### Intended Effect:
Make the code faster.

For a d=500 dimensionality problem the current code is ~2.3x faster when comparing the gradient evaluation time against vanilla 2.17.1. This new version is 3.2x faster in comparison to vanilla 2.17.1.

#### How to Verify:
Run the tests

```
test/unit/math/fwd/mat/prob/multi_normal_cholesky_test.cpp
test/unit/math/mix/mat/prob/multi_normal_cholesky_test.cpp
test/unit/math/rev/mat/prob/multi_normal_cholesky2_test.cpp
test/unit/math/rev/mat/prob/multi_normal_cholesky_test.cpp
test/unit/math/prim/mat/prob/multi_normal_cholesky_test.cpp
test/unit/math/prim/mat/prob/multi_normal_cholesky_log_test.cpp
```

#### Side Effects:
None.

#### Documentation:
NA

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Sebastian Weber

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
