### PR TITLE
Add passing by reference for matrix_exp function.

### DIFF
--- a/stan/math/prim/mat/fun/matrix_exp.hpp
+++ b/stan/math/prim/mat/fun/matrix_exp.hpp
@@ -18,7 +18,7 @@ namespace math {
  */
 template <typename T>
 inline Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> matrix_exp(
-    const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> A) {
+    const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& A) {
   check_nonzero_size("matrix_exp", "input matrix", A);
   check_square("matrix_exp", "input matrix", A);
 


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py test/unit/math/prim/mat/fun/matrix_exp_test.cpp`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary:
Matrix argument gets passed by reference instead of by value.

#### Intended Effect:
Avoids creating a copy of the argument.

#### How to Verify:
Unit tests run (shows changes do not break the code. Not sure how to demonstrate gain in efficiency).


#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Charles Margossian

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
