### PR TITLE
take parameter y0 by reference

### DIFF
--- a/stan/math/prim/arr/functor/integrate_ode_rk45.hpp
+++ b/stan/math/prim/arr/functor/integrate_ode_rk45.hpp
@@ -67,7 +67,7 @@ namespace math {
  */
 template <typename F, typename T1, typename T2>
 std::vector<std::vector<typename stan::return_type<T1, T2>::type> >
-integrate_ode_rk45(const F& f, const std::vector<T1> y0, double t0,
+integrate_ode_rk45(const F& f, const std::vector<T1>& y0, double t0,
                    const std::vector<double>& ts, const std::vector<T2>& theta,
                    const std::vector<double>& x, const std::vector<int>& x_int,
                    std::ostream* msgs = 0, double relative_tolerance = 1e-6,


### PR DESCRIPTION
#### Submission Checklist

- [ didn't do] Run unit tests: `./runTests.py test/unit`
- [ didn't do] Run cpplint: `make cpplint`
- [ done] Declare copyright holder and open-source license: see below

#### Summary:
Parameter y0 of integrate_ode_rk45 now taken by reference

#### Intended Effect:
Eliminate extra copy

#### How to Verify:
I suppose you could use valgrind or clang's memory auditing tools

#### Side Effects:
None, except possibly faster performance for larger vectors

#### Documentation:
This change does not impact documentation

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Christopher Paul Chiasson

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
