### PR TITLE
issue-785 Removes C++14 auto parameter from lambda function

### DIFF
--- a/test/unit/math_c11_test.cpp
+++ b/test/unit/math_c11_test.cpp
@@ -2,6 +2,6 @@
 
 TEST(MathMeta, ensure_c11_features_present) {
   int s[] = {2, 4};
-  auto f = [&s](auto i) { return i + s[0]; };
+  auto f = [&s](int i) { return i + s[0]; };
   EXPECT_EQ(4, f(2));
 }


### PR DESCRIPTION
This is a C++11 test, so I am updating it to use only C++11 features

#### Submission Checklist

- [ ] Run unit tests: `./runTests.py test/unit`
- [ ] Run cpplint: `make cpplint`
- [ X] Declare copyright holder and open-source license: see below

#### Summary:
Updates math_c11_test.cpp to only use C++11 features

#### Intended Effect:
Aligns feature check with feature set of C++11

#### How to Verify:
Compile in C++11 standards mode

#### Side Effects:
Won't test C++14 compliance anymore

#### Documentation:
None require

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Oil States

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
