### PR TITLE
Adds stage to generate docs in gh-pages branch for Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -66,6 +66,36 @@ pipeline {
                 }
             }
         }
+        stage("Make-doxygen") {
+            when {
+                 branch 'test_jenkins_docs'
+            }
+            agent any
+            steps {
+              script {
+                  retry(3) { checkout scm }
+                  withCredentials([usernamePassword(credentialsId: 'a630aebc-6861-4e69-b497-fd7f496ec46b',
+                      usernameVariable: 'GIT_USERNAME', passwordVariable: 'GIT_PASSWORD')]) {
+                      sh """#!/bin/bash
+                          set -x
+                          make doxygen
+                          git config --global user.email "mc.stanislaw@gmail.com"
+                          git config --global user.name "Stan Jenkins"
+                          git checkout --detach
+                          git branch -D gh-pages
+                          git checkout --orphan gh-pages
+                          git rm --cached stan test lib make
+                          git add -f doc
+                          git commit -m "auto generated docs from Jenkins"
+                          git push https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/${fork()}/math.git +gh-pages:gh-pages
+                          git checkout -f test_jenkins_docs
+                          exit 1
+                          """
+                  }
+               }
+            }
+            post { always { deleteDir() } }
+        }
         stage("Clang-format") {
             agent any
             steps {
@@ -191,33 +221,6 @@ pipeline {
                                     parameters: [string(name: 'math_pr', value: env.BRANCH_NAME)])
                     }
                 }
-            }
-        }
-        stage("Make-doxygen") {
-            agent any
-            steps {
-              script {
-                if (isBranch('master')) {
-                  withCredentials([usernamePassword(credentialsId: 'a630aebc-6861-4e69-b497-fd7f496ec46b',
-                      usernameVariable: 'GIT_USERNAME', passwordVariable: 'GIT_PASSWORD')]) {
-                      sh """#!/bin/bash
-                          set -x
-                          make doxygen
-                          git config --global user.email "mc.stanislaw@gmail.com"
-                          git config --global user.name "Stan Jenkins"
-                          git checkout --detach
-                          git branch -D gh-pages
-                          git checkout --orphan gh-pages
-                          git rm --cached stan test lib make
-                          git add -f doc
-                          git commit -m "auto generated docs from Jenkins"
-                          git push https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/${fork()}/math.git +gh-pages:gh-pages
-                          git checkout -f master
-                          exit 1
-                          """
-                      }
-                  }
-               }
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -76,11 +76,12 @@ pipeline {
                         usernameVariable: 'GIT_USERNAME', passwordVariable: 'GIT_PASSWORD')]) {
                         sh """#!/bin/bash
                             set -x
+                            set -e
                             make doxygen
                             git config --global user.email "mc.stanislaw@gmail.com"
                             git config --global user.name "Stan Jenkins"
                             git checkout --detach
-                            git branch -D gh-pages
+                            git branch -D gh-pages || true
                             git checkout --orphan gh-pages
                             git rm --cached stan test lib make
                             git add -f doc

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -67,31 +67,30 @@ pipeline {
             }
         }
         stage("Make-doxygen") {
-            when {
-                 branch 'test_jenkins_docs'
-            }
             agent any
             steps {
               script {
-                  retry(3) { checkout scm }
-                  withCredentials([usernamePassword(credentialsId: 'a630aebc-6861-4e69-b497-fd7f496ec46b',
-                      usernameVariable: 'GIT_USERNAME', passwordVariable: 'GIT_PASSWORD')]) {
-                      sh """#!/bin/bash
-                          set -x
-                          make doxygen
-                          git config --global user.email "mc.stanislaw@gmail.com"
-                          git config --global user.name "Stan Jenkins"
-                          git checkout --detach
-                          git branch -D gh-pages
-                          git checkout --orphan gh-pages
-                          git rm --cached stan test lib make
-                          git add -f doc
-                          git commit -m "auto generated docs from Jenkins"
-                          git push https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/${fork()}/math.git +gh-pages:gh-pages
-                          git checkout -f test_jenkins_docs
-                          exit 1
-                          """
-                  }
+                  if (isBranch('master')) {
+                    retry(3) { checkout scm }
+                    withCredentials([usernamePassword(credentialsId: 'a630aebc-6861-4e69-b497-fd7f496ec46b',
+                        usernameVariable: 'GIT_USERNAME', passwordVariable: 'GIT_PASSWORD')]) {
+                        sh """#!/bin/bash
+                            set -x
+                            make doxygen
+                            git config --global user.email "mc.stanislaw@gmail.com"
+                            git config --global user.name "Stan Jenkins"
+                            git checkout --detach
+                            git branch -D gh-pages
+                            git checkout --orphan gh-pages
+                            git rm --cached stan test lib make
+                            git add -f doc
+                            git commit -m "auto generated docs from Jenkins"
+                            git push https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/${fork()}/math.git +gh-pages:gh-pages
+                            git checkout -f test_jenkins_docs
+                            exit 1
+                            """
+                    }
+                 }
                }
             }
             post { always { deleteDir() } }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -60,7 +60,7 @@ pipeline {
                 not { branch 'develop' }
                 not { branch 'master' }
             }
-            steps { 
+            steps {
                 script {
                     utils.killOldBuilds()
                 }
@@ -149,7 +149,7 @@ pipeline {
                 }
                 stage('Distribution tests') {
                     agent { label "distribution-tests" }
-                    steps { 
+                    steps {
                         unstash 'MathSetup'
                         sh """
                             ${setupCC(false)}
@@ -189,6 +189,29 @@ pipeline {
                     steps {
                         build(job: "Stan/${params.stan_pr}",
                                     parameters: [string(name: 'math_pr', value: env.BRANCH_NAME)])
+                    }
+                }
+            }
+        }
+        stage("Make-doxygen") {
+            agent any
+            steps {
+              if (isBranch('master')) {
+                withCredentials([usernamePassword(credentialsId: 'a630aebc-6861-4e69-b497-fd7f496ec46b',
+                    usernameVariable: 'GIT_USERNAME', passwordVariable: 'GIT_PASSWORD')]) {
+                    sh """#!/bin/bash
+                        set -x
+                        make doxygen
+                        git config --global user.email "mc.stanislaw@gmail.com"
+                        git config --global user.name "Stan Jenkins"
+                        git checkout --detach
+                        git branch -D gh-pages
+                        git checkout --orphan gh-pages
+                        git add -f ./doc/
+                        git commit -m "auto generated docs from Jenkins"
+                        git push https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/${fork()}/math.git +gh-pages:gh-pages
+                        exit 1
+                        """
                     }
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -84,7 +84,7 @@ pipeline {
                             git rm --cached -r stan test lib make
                             git add -f doc
                             git commit -m "auto generated docs from Jenkins"
-                            git push origin +gh-pages:gh-pages
+                            git push https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/${fork()}/math.git +gh-pages:gh-pages
                             git checkout -f test_jenkins_docs
                             exit 1
                             """

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -81,10 +81,10 @@ pipeline {
                             git checkout --detach
                             git branch -D gh-pages || true
                             git checkout --orphan gh-pages
-                            git rm --cached stan test lib make
+                            git rm --cached -r stan test lib make
                             git add -f doc
                             git commit -m "auto generated docs from Jenkins"
-                            git push https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/${fork()}/math.git +gh-pages:gh-pages
+                            git push origin +gh-pages:gh-pages
                             git checkout -f test_jenkins_docs
                             exit 1
                             """

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -60,7 +60,7 @@ pipeline {
                 not { branch 'develop' }
                 not { branch 'master' }
             }
-            steps { 
+            steps {
                 script {
                     utils.killOldBuilds()
                 }
@@ -149,7 +149,7 @@ pipeline {
                 }
                 stage('Distribution tests') {
                     agent { label "distribution-tests" }
-                    steps { 
+                    steps {
                         unstash 'MathSetup'
                         sh """
                             ${setupCC(false)}
@@ -207,9 +207,11 @@ pipeline {
                         git checkout --detach
                         git branch -D gh-pages
                         git checkout --orphan gh-pages
-                        git add -f ./doc/
+                        git rm --cached stan test lib make
+                        git add -f doc
                         git commit -m "auto generated docs from Jenkins"
                         git push https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/${fork()}/math.git +gh-pages:gh-pages
+                        git checkout -f master
                         exit 1
                         """
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -196,26 +196,28 @@ pipeline {
         stage("Make-doxygen") {
             agent any
             steps {
-              if (isBranch('master')) {
-                withCredentials([usernamePassword(credentialsId: 'a630aebc-6861-4e69-b497-fd7f496ec46b',
-                    usernameVariable: 'GIT_USERNAME', passwordVariable: 'GIT_PASSWORD')]) {
-                    sh """#!/bin/bash
-                        set -x
-                        make doxygen
-                        git config --global user.email "mc.stanislaw@gmail.com"
-                        git config --global user.name "Stan Jenkins"
-                        git checkout --detach
-                        git branch -D gh-pages
-                        git checkout --orphan gh-pages
-                        git rm --cached stan test lib make
-                        git add -f doc
-                        git commit -m "auto generated docs from Jenkins"
-                        git push https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/${fork()}/math.git +gh-pages:gh-pages
-                        git checkout -f master
-                        exit 1
-                        """
-                    }
-                }
+              script {
+                if (isBranch('master')) {
+                  withCredentials([usernamePassword(credentialsId: 'a630aebc-6861-4e69-b497-fd7f496ec46b',
+                      usernameVariable: 'GIT_USERNAME', passwordVariable: 'GIT_PASSWORD')]) {
+                      sh """#!/bin/bash
+                          set -x
+                          make doxygen
+                          git config --global user.email "mc.stanislaw@gmail.com"
+                          git config --global user.name "Stan Jenkins"
+                          git checkout --detach
+                          git branch -D gh-pages
+                          git checkout --orphan gh-pages
+                          git rm --cached stan test lib make
+                          git add -f doc
+                          git commit -m "auto generated docs from Jenkins"
+                          git push https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/${fork()}/math.git +gh-pages:gh-pages
+                          git checkout -f master
+                          exit 1
+                          """
+                      }
+                  }
+               }
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -69,8 +69,6 @@ pipeline {
         stage("Make-doxygen") {
             agent any
             steps {
-              script {
-                  if (isBranch('test_jenkins_docs')) {
                     retry(3) { checkout scm }
                     withCredentials([usernamePassword(credentialsId: 'a630aebc-6861-4e69-b497-fd7f496ec46b',
                         usernameVariable: 'GIT_USERNAME', passwordVariable: 'GIT_PASSWORD')]) {
@@ -90,8 +88,6 @@ pipeline {
                             git checkout -f test_jenkins_docs
                             exit 1
                             """
-                    }
-                 }
                }
             }
             post { always { deleteDir() } }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -60,7 +60,7 @@ pipeline {
                 not { branch 'develop' }
                 not { branch 'master' }
             }
-            steps {
+            steps { 
                 script {
                     utils.killOldBuilds()
                 }
@@ -149,7 +149,7 @@ pipeline {
                 }
                 stage('Distribution tests') {
                     agent { label "distribution-tests" }
-                    steps {
+                    steps { 
                         unstash 'MathSetup'
                         sh """
                             ${setupCC(false)}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -70,7 +70,7 @@ pipeline {
             agent any
             steps {
               script {
-                  if (isBranch('master')) {
+                  if (isBranch('test_jenkins_docs')) {
                     retry(3) { checkout scm }
                     withCredentials([usernamePassword(credentialsId: 'a630aebc-6861-4e69-b497-fd7f496ec46b',
                         usernameVariable: 'GIT_USERNAME', passwordVariable: 'GIT_PASSWORD')]) {


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary:
Adds a stage to Jenkins so that the doxygen is made and pushed to the `gh-pages` branch

#### Intended Effect:
Users will be able to go the the doxygen generated website to view documentation for the math library

#### How to Verify:
I'm now sure how we verify this works on Jenkins without running it? Should I change `isBranch('master')` to this branch?

#### Side Effects:
The creation of the gh-pages branch with doxygen website
#### Documentation:
How should we document this?
#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Stephen Bronder
By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
