### PR TITLE
Add Stage in Jenkins to make gh-pages with doxygen

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,6 +42,11 @@ def isPR() { env.CHANGE_URL != null }
 def fork() { env.CHANGE_FORK ?: "stan-dev" }
 def branchName() { isPR() ? env.CHANGE_BRANCH :env.BRANCH_NAME }
 
+def writeIndexHTML() {
+  "echo '<head>' >> index.html"
+  "echo '<meta http-equiv=&quot;refresh&quot; content=&quot;0; url=https://github.com/stan-dev/math/tree/gh-pages/doc/api/html&quot; />' >> index.html"
+  "echo '</head>' >> index.html"
+}
 pipeline {
     agent none
     parameters {
@@ -60,11 +65,36 @@ pipeline {
                 not { branch 'develop' }
                 not { branch 'master' }
             }
-            steps { 
+            steps {
                 script {
                     utils.killOldBuilds()
                 }
             }
+        }
+        stage("Make-doxygen") {
+            agent any
+            when { branch 'PR-795'}
+            steps {
+                    retry(3) { checkout scm }
+                    withCredentials([usernamePassword(credentialsId: 'a630aebc-6861-4e69-b497-fd7f496ec46b',
+                        usernameVariable: 'GIT_USERNAME', passwordVariable: 'GIT_PASSWORD')]) {
+                        sh """#!/bin/bash
+                            set -x
+                            make doxygen
+                            git config --global user.email "mc.stanislaw@gmail.com"
+                            git config --global user.name "Stan Jenkins"
+                            git checkout --detach
+                            git branch -D gh-pages
+                            git push https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/${fork()}/math.git :gh-pages
+                            git checkout --orphan gh-pages
+                            git rm --cached -r stan test lib make
+                            git add -f doc
+                            git commit -m "auto generated docs from Jenkins"
+                            git subtree push --prefix doc/api/html https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/${fork()}/math.git gh-pages
+                            """
+               }
+            }
+            post { always { deleteDir() } }
         }
         stage("Clang-format") {
             agent any
@@ -149,7 +179,7 @@ pipeline {
                 }
                 stage('Distribution tests') {
                     agent { label "distribution-tests" }
-                    steps { 
+                    steps {
                         unstash 'MathSetup'
                         sh """
                             ${setupCC(false)}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -66,31 +66,6 @@ pipeline {
                 }
             }
         }
-        stage("Make-doxygen") {
-            agent any
-            when { branch 'PR-795'}
-            steps {
-                    retry(3) { checkout scm }
-                    withCredentials([usernamePassword(credentialsId: 'a630aebc-6861-4e69-b497-fd7f496ec46b',
-                        usernameVariable: 'GIT_USERNAME', passwordVariable: 'GIT_PASSWORD')]) {
-                        sh """#!/bin/bash
-                            set -x
-                            make doxygen
-                            git config --global user.email "mc.stanislaw@gmail.com"
-                            git config --global user.name "Stan Jenkins"
-                            git checkout --detach
-                            git branch -D gh-pages
-                            git push https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/stan-dev/math.git :gh-pages
-                            git checkout --orphan gh-pages
-                            git rm --cached -r stan test lib make
-                            git add -f doc
-                            git commit -m "auto generated docs from Jenkins"
-                            git subtree push --prefix doc/api/html https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/stan-dev/math.git gh-pages
-                            """
-               }
-            }
-            post { always { deleteDir() } }
-        }
         stage("Clang-format") {
             agent any
             steps {
@@ -217,6 +192,31 @@ pipeline {
                     }
                 }
             }
+        }
+        stage("Make-doxygen") {
+            agent any
+            when { branch 'PR-795'}
+            steps {
+                    retry(3) { checkout scm }
+                    withCredentials([usernamePassword(credentialsId: 'a630aebc-6861-4e69-b497-fd7f496ec46b',
+                        usernameVariable: 'GIT_USERNAME', passwordVariable: 'GIT_PASSWORD')]) {
+                        sh """#!/bin/bash
+                            set -x
+                            make doxygen
+                            git config --global user.email "mc.stanislaw@gmail.com"
+                            git config --global user.name "Stan Jenkins"
+                            git checkout --detach
+                            git branch -D gh-pages
+                            git push https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/stan-dev/math.git :gh-pages
+                            git checkout --orphan gh-pages
+                            git rm --cached -r stan test lib make
+                            git add -f doc
+                            git commit -m "auto generated docs from Jenkins"
+                            git subtree push --prefix doc/api/html https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/stan-dev/math.git gh-pages
+                            """
+               }
+            }
+            post { always { deleteDir() } }
         }
     }
     post {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,11 +42,6 @@ def isPR() { env.CHANGE_URL != null }
 def fork() { env.CHANGE_FORK ?: "stan-dev" }
 def branchName() { isPR() ? env.CHANGE_BRANCH :env.BRANCH_NAME }
 
-def writeIndexHTML() {
-  "echo '<head>' >> index.html"
-  "echo '<meta http-equiv=&quot;refresh&quot; content=&quot;0; url=https://github.com/stan-dev/math/tree/gh-pages/doc/api/html&quot; />' >> index.html"
-  "echo '</head>' >> index.html"
-}
 pipeline {
     agent none
     parameters {
@@ -85,12 +80,12 @@ pipeline {
                             git config --global user.name "Stan Jenkins"
                             git checkout --detach
                             git branch -D gh-pages
-                            git push https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/${fork()}/math.git :gh-pages
+                            git push https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/stan-dev/math.git :gh-pages
                             git checkout --orphan gh-pages
                             git rm --cached -r stan test lib make
                             git add -f doc
                             git commit -m "auto generated docs from Jenkins"
-                            git subtree push --prefix doc/api/html https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/${fork()}/math.git gh-pages
+                            git subtree push --prefix doc/api/html https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/stan-dev/math.git gh-pages
                             """
                }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -193,7 +193,7 @@ pipeline {
                 }
             }
         }
-        stage("Make-doxygen") {
+        stage('master') {
             agent any
             when { branch 'PR-795'}
             steps {
@@ -209,7 +209,6 @@ pipeline {
                             git branch -D gh-pages
                             git push https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/stan-dev/math.git :gh-pages
                             git checkout --orphan gh-pages
-                            git rm --cached -r stan test lib make
                             git add -f doc
                             git commit -m "auto generated docs from Jenkins"
                             git subtree push --prefix doc/api/html https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/stan-dev/math.git gh-pages

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -181,39 +181,39 @@ pipeline {
                     when { expression { env.BRANCH_NAME ==~ /PR-\d+/ } }
                     steps {
                         build(job: "CmdStan/${params.cmdstan_pr}",
-                                    parameters: [string(name: 'math_pr', value: env.BRANCH_NAME)])
+                              parameters: [string(name: 'math_pr', value: env.BRANCH_NAME)])
                     }
                 }
                 stage('Stan Upstream Tests') {
                     when { expression { env.BRANCH_NAME ==~ /PR-\d+/ } }
                     steps {
                         build(job: "Stan/${params.stan_pr}",
-                                    parameters: [string(name: 'math_pr', value: env.BRANCH_NAME)])
+                              parameters: [string(name: 'math_pr', value: env.BRANCH_NAME)])
                     }
                 }
             }
         }
-        stage('master') {
+        stage('Upload doxygen') {
             agent any
-            when { branch 'PR-795'}
+            when { branch 'master'}
             steps {
-                    retry(3) { checkout scm }
-                    withCredentials([usernamePassword(credentialsId: 'a630aebc-6861-4e69-b497-fd7f496ec46b',
-                        usernameVariable: 'GIT_USERNAME', passwordVariable: 'GIT_PASSWORD')]) {
-                        sh """#!/bin/bash
-                            set -x
-                            make doxygen
-                            git config --global user.email "mc.stanislaw@gmail.com"
-                            git config --global user.name "Stan Jenkins"
-                            git checkout --detach
-                            git branch -D gh-pages
-                            git push https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/stan-dev/math.git :gh-pages
-                            git checkout --orphan gh-pages
-                            git add -f doc
-                            git commit -m "auto generated docs from Jenkins"
-                            git subtree push --prefix doc/api/html https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/stan-dev/math.git gh-pages
-                            """
-               }
+                retry(3) { checkout scm }
+                withCredentials([usernamePassword(credentialsId: 'a630aebc-6861-4e69-b497-fd7f496ec46b',
+                                                  usernameVariable: 'GIT_USERNAME', passwordVariable: 'GIT_PASSWORD')]) {
+                    sh """#!/bin/bash
+                        set -x
+                        make doxygen
+                        git config --global user.email "mc.stanislaw@gmail.com"
+                        git config --global user.name "Stan Jenkins"
+                        git checkout --detach
+                        git branch -D gh-pages
+                        git push https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/stan-dev/math.git :gh-pages
+                        git checkout --orphan gh-pages
+                        git add -f doc
+                        git commit -m "auto generated docs from Jenkins"
+                        git subtree push --prefix doc/api/html https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/stan-dev/math.git gh-pages
+                        """
+                }
             }
             post { always { deleteDir() } }
         }


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary:
Address https://github.com/stan-dev/math/issues/781. Adds a stage to Jenkins so that the doxygen is made and pushed to the `gh-pages` branch. Was previously https://github.com/stan-dev/math/pull/794

This creates a new stage called 'Make-doxygen' containing commands to

1. make the doxygen
2. detach from head and delete the local and remote version of gh-pages
3. Remove the history by creating an orphaned gh-pages
4. remove unneccessary folders
5. force an add and commit of the docs folder
6. Use subtree to push the html folder of docs to the the github gh-pages root

Now we can access the docs at [mc-stan.org/math](http://mc-stan.org/math/)

#### Intended Effect:
Users will be able to go the the doxygen generated website to view documentation for the math library

#### How to Verify:
I'm now sure how we verify this works on Jenkins without running it? Should I change `isBranch('master')` to this branch?

#### Side Effects:
The creation of the gh-pages branch with doxygen website
#### Documentation:
How should we document this?
#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Stephen Bronder
By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
