### PR TITLE
Revert the matrix autos from #801.

### DIFF
--- a/stan/math/rev/mat/fun/multiply.hpp
+++ b/stan/math/rev/mat/fun/multiply.hpp
@@ -98,11 +98,13 @@ class multiply_mat_vari : public vari {
     using Eigen::Map;
     using Eigen::MatrixXd;
     MatrixXd adjAB(A_rows_, B_cols_);
+    MatrixXd adjA(A_rows_, A_cols_);
+    MatrixXd adjB(A_cols_, B_cols_);
 
     for (size_type i = 0; i < adjAB.size(); ++i)
       adjAB(i) = variRefAB_[i]->adj_;
-    auto adjA = adjAB * Map<MatrixXd>(Bd_, A_cols_, B_cols_).transpose();
-    auto adjB = Map<MatrixXd>(Ad_, A_rows_, A_cols_).transpose() * adjAB;
+    adjA = adjAB * Map<MatrixXd>(Bd_, A_cols_, B_cols_).transpose();
+    adjB = Map<MatrixXd>(Ad_, A_rows_, A_cols_).transpose() * adjAB;
     for (size_type i = 0; i < A_size_; ++i)
       variRefA_[i]->adj_ += adjA(i);
     for (size_type i = 0; i < B_size_; ++i)
@@ -266,10 +268,11 @@ class multiply_mat_vari<double, Ra, Ca, Tb, Cb> : public vari {
     using Eigen::Map;
     using Eigen::MatrixXd;
     MatrixXd adjAB(A_rows_, B_cols_);
+    MatrixXd adjB(A_cols_, B_cols_);
 
     for (size_type i = 0; i < adjAB.size(); ++i)
       adjAB(i) = variRefAB_[i]->adj_;
-    auto adjB = Map<MatrixXd>(Ad_, A_rows_, A_cols_).transpose() * adjAB;
+    adjB = Map<MatrixXd>(Ad_, A_rows_, A_cols_).transpose() * adjAB;
     for (size_type i = 0; i < B_size_; ++i)
       variRefB_[i]->adj_ += adjB(i);
   }
@@ -426,10 +429,11 @@ class multiply_mat_vari<Ta, Ra, Ca, double, Cb> : public vari {
     using Eigen::Map;
     using Eigen::MatrixXd;
     MatrixXd adjAB(A_rows_, B_cols_);
+    MatrixXd adjA(A_rows_, A_cols_);
 
     for (size_type i = 0; i < adjAB.size(); ++i)
       adjAB(i) = variRefAB_[i]->adj_;
-    auto adjA = adjAB * Map<MatrixXd>(Bd_, A_cols_, B_cols_).transpose();
+    adjA = adjAB * Map<MatrixXd>(Bd_, A_cols_, B_cols_).transpose();
     for (size_type i = 0; i < A_size_; ++i)
       variRefA_[i]->adj_ += adjA(i);
   }


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary:
[After benchmarking](http://discourse.mc-stan.org/t/profiling-c-code/3033/23?u=seantalts), it seems like replacing Matrix declarations with `auto` only performs well if there's 1 row or column, and not by very much. So reverting the changes from #801 to these, but keeping the ones for vectors that gave us a 35% speedup in the logistic regression performance test.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
