### PR TITLE
bugfix/issue-stan-2433: change step to match int_step

### DIFF
--- a/stan/math/prim/scal/fun/step.hpp
+++ b/stan/math/prim/scal/fun/step.hpp
@@ -7,26 +7,28 @@ namespace math {
 /**
  * The step, or Heaviside, function.
  *
- * The function is defined by
+ * For double NaN input, step(NaN) returns 0.
  *
- * <code>step(y) = (y < 0.0) ? 0 : 1</code>.
+ * Note: behavior changed from
+ * <code>step(y) = (y < 0.0) ? 0 : 1</code>
+ * to
  *
    \f[
-   \mbox{step}(x) =
+   \mbox{step}(y) =
    \begin{cases}
-     0 & \mbox{if } x \leq 0 \\
-     1 & \mbox{if } x > 0  \\[6pt]
-     0 & \mbox{if } x = \textrm{NaN}
+     0 & \mbox{if } y \leq 0 \\
+     1 & \mbox{if } y > 0  \\[6pt]
+     0 & \mbox{if } y = \textrm{NaN}
    \end{cases}
    \f]
  *
- * @tparam T type of value
- * @param y value
- * @return zero if the value is less than zero, and one otherwise
+ * @tparam T value type
+ * @param[in] y value
+ * @return 1 if value is greater than 0 and 0 otherwise
  */
 template <typename T>
 inline double step(const T& y) {
-  return y < 0.0 ? 0 : 1;
+  return y > 0.0;
 }
 
 }  // namespace math

--- a/stan/math/rev/scal/fun/step.hpp
+++ b/stan/math/rev/scal/fun/step.hpp
@@ -23,7 +23,7 @@ namespace math {
  * value is greater than or equal to 0.0, and value 0.0 otherwise.
  */
 inline var step(const var& a) {
-  return var(new vari(a.vi_->val_ < 0.0 ? 0.0 : 1.0));
+  return var(new vari(a.vi_->val_ > 0.0));
 }
 
 }  // namespace math

--- a/stan/math/rev/scal/fun/step.hpp
+++ b/stan/math/rev/scal/fun/step.hpp
@@ -22,9 +22,7 @@ namespace math {
  * @return The constant variable with value 1.0 if the argument's
  * value is greater than or equal to 0.0, and value 0.0 otherwise.
  */
-inline var step(const var& a) {
-  return var(new vari(a.vi_->val_ > 0.0));
-}
+inline var step(const var& a) { return var(new vari(a.vi_->val_ > 0.0)); }
 
 }  // namespace math
 }  // namespace stan

--- a/test/unit/math/prim/scal/fun/step_test.cpp
+++ b/test/unit/math/prim/scal/fun/step_test.cpp
@@ -5,19 +5,26 @@
 
 TEST(MathFunctions, step_double) {
   using stan::math::step;
-  EXPECT_EQ(1.0, step(3.7));
-  EXPECT_EQ(1.0, step(0.0));
-  EXPECT_EQ(0.0, step(-2.93));
+  EXPECT_EQ(0.0, step(-1.0));
+  EXPECT_EQ(0.0, step(0.0));
+  EXPECT_EQ(1.0, step(0.00000000001));
+  EXPECT_EQ(1.0, step(100.0));
 }
 
 TEST(MathFunctions, step_int) {
   using stan::math::step;
-  EXPECT_EQ(1.0, step(static_cast<int>(4)));
-  EXPECT_EQ(1.0, step(static_cast<int>(0)));
-  EXPECT_EQ(0.0, step(static_cast<int>(-3)));
+  EXPECT_EQ(0.0, step(static_cast<int>(-1)));
+  EXPECT_EQ(0.0, step(static_cast<int>(0)));
+  EXPECT_EQ(1.0, step(static_cast<int>(100)));
+}
+
+TEST(MathFunctions, step_inf) {
+  using stan::math::step;
+  EXPECT_EQ(1.0, step(std::numeric_limits<double>::infinity()));
+  EXPECT_EQ(0.0, step(-std::numeric_limits<double>::infinity()));
 }
 
 TEST(MathFunctions, step_nan) {
   double nan = std::numeric_limits<double>::quiet_NaN();
-  EXPECT_EQ(1.0, stan::math::step(nan));
+  EXPECT_EQ(0.0, stan::math::step(nan));
 }

--- a/test/unit/math/rev/scal/fun/step_test.cpp
+++ b/test/unit/math/rev/scal/fun/step_test.cpp
@@ -18,7 +18,7 @@ TEST(AgradRev, step) {
 TEST(AgradRev, step_2) {
   AVAR a = 0.0;
   AVAR f = stan::math::step(a);
-  EXPECT_FLOAT_EQ(1.0, f.val());
+  EXPECT_FLOAT_EQ(0.0, f.val());
 
   AVEC x = createAVEC(a);
   VEC grad_f;
@@ -39,7 +39,7 @@ TEST(AgradRev, step_3) {
 TEST(AgradRev, step_nan) {
   stan::math::var nan = std::numeric_limits<double>::quiet_NaN();
 
-  EXPECT_EQ(1U, stan::math::step(nan).val());
+  EXPECT_EQ(0.0, stan::math::step(nan).val());
 }
 
 TEST(AgradRev, check_varis_on_stack) {


### PR DESCRIPTION
#### Submission Checklist

- [ ] Run unit tests: `./runTests.py test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

Change `stan::math::step` to match `stan::math::int_step` as requested in stan-dev/stan issue 2433.

#### Intended Effect:

Consistency between step functions.

#### How to Verify:

./runTests.py -j3 test/unit/math/prim/scal/
 
and

./runTests.py -j3 test/unit/math/rev/scal/

I ran the above commands without error.

#### Side Effects:

Change is step function behavior.

#### Documentation:

Made a note about this change just above step function definition.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): California State University, Chico

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
