### PR TITLE
Edit cmake build (for Sean)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,13 @@ cmake_minimum_required(VERSION 3.5)
 project(math)
 
 set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_FLAGS "-O3")
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Release)
+endif()
 
+set(CMAKE_CXX_FLAGS "-Wall -Wextra")
+set(CMAKE_CXX_FLAGS_DEBUG "-g")
+set(CMAKE_CXX_FLAGS_RELEASE "-O3")
 
 ### googletest include
 add_subdirectory(lib/gtest_1.7.0)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,10 @@ endif()
 set(CMAKE_CXX_FLAGS "-Wall -Wextra")
 set(CMAKE_CXX_FLAGS_DEBUG "-g")
 set(CMAKE_CXX_FLAGS_RELEASE "-O3")
+# Setting -O3 to work around linking issue which also affects the non-cmake build
+# Dependencies aren't correctly specified, so the build only succeeds if certain
+# symbols are optimized out. See #806.
+
 
 ### googletest include
 add_subdirectory(lib/gtest_1.7.0)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,17 @@ set(CMAKE_CXX_FLAGS_RELEASE "-O3")
 # symbols are optimized out. See #806.
 
 
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER MATCHES "[Cc]lang")
+  # This is a workaround for an old clang bug.
+  # See https://bugs.llvm.org/show_bug.cgi?id=13530 for info on the clang bug.
+  # The non-cmake build works around this by specifying a different libstdc++,
+  # which is incorrect for many configurations, including some configurations
+  # with clang < 3.9.
+  if (CLANG_VERSION_STRING VERSION_LESS 3.9)
+    add_compile_options("-D__STRICT_ANSI__")
+  endif()
+endif()
+
 ### googletest include
 add_subdirectory(lib/gtest_1.7.0)
 


### PR DESCRIPTION
#### Submission Checklist

- [x ] Run unit tests: `./runTests.py test/unit`
- [ x] Run cpplint: `make cpplint`
- [ x] Declare copyright holder and open-source license: see below

#### Summary:

Some minor fixes for the cmake build. Adds a workaround that's equivalent to the clang bug 13530, but does so in a way that doesn't break a stock lubuntu 17 build as well as other builds. Also reduces the scope of the workaround for #806.

#### Intended Effect:

#### How to Verify:

#### Side Effects:

#### Documentation:

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Dan Luu

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
