### PR TITLE
Mark relevant numeric_limits methods constexpr

### DIFF
--- a/stan/math/fwd/core/std_numeric_limits.hpp
+++ b/stan/math/fwd/core/std_numeric_limits.hpp
@@ -9,8 +9,12 @@ namespace std {
 template <typename T>
 struct numeric_limits<stan::math::fvar<T> > {
   static const bool is_specialized;
-  static constexpr stan::math::fvar<T> min() { return numeric_limits<double>::min(); }
-  static constexpr stan::math::fvar<T> max() { return numeric_limits<double>::max(); }
+  static constexpr stan::math::fvar<T> min() {
+    return numeric_limits<double>::min();
+  }
+  static constexpr stan::math::fvar<T> max() {
+    return numeric_limits<double>::max();
+  }
   static const int digits;
   static const int digits10;
   static const bool is_signed;

--- a/stan/math/fwd/core/std_numeric_limits.hpp
+++ b/stan/math/fwd/core/std_numeric_limits.hpp
@@ -9,18 +9,18 @@ namespace std {
 template <typename T>
 struct numeric_limits<stan::math::fvar<T> > {
   static const bool is_specialized;
-  static stan::math::fvar<T> min() { return numeric_limits<double>::min(); }
-  static stan::math::fvar<T> max() { return numeric_limits<double>::max(); }
+  static constexpr stan::math::fvar<T> min() { return numeric_limits<double>::min(); }
+  static constexpr stan::math::fvar<T> max() { return numeric_limits<double>::max(); }
   static const int digits;
   static const int digits10;
   static const bool is_signed;
   static const bool is_integer;
   static const bool is_exact;
   static const int radix;
-  static stan::math::fvar<T> epsilon() {
+  static constexpr stan::math::fvar<T> epsilon() {
     return numeric_limits<double>::epsilon();
   }
-  static stan::math::fvar<T> round_error() {
+  static constexpr stan::math::fvar<T> round_error() {
     return numeric_limits<double>::round_error();
   }
 
@@ -35,16 +35,16 @@ struct numeric_limits<stan::math::fvar<T> > {
 
   static const float_denorm_style has_denorm;
   static const bool has_denorm_loss;
-  static stan::math::fvar<T> infinity() {
+  static constexpr stan::math::fvar<T> infinity() {
     return numeric_limits<double>::infinity();
   }
-  static stan::math::fvar<T> quiet_NaN() {
+  static constexpr stan::math::fvar<T> quiet_NaN() {
     return numeric_limits<double>::quiet_NaN();
   }
-  static stan::math::fvar<T> signaling_NaN() {
+  static constexpr stan::math::fvar<T> signaling_NaN() {
     return numeric_limits<double>::signaling_NaN();
   }
-  static stan::math::fvar<T> denorm_min() {
+  static constexpr stan::math::fvar<T> denorm_min() {
     return numeric_limits<double>::denorm_min();
   }
 


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

Mark relevant numeric_limits methods constexpr. This can be done now that Stan is C++11. Previously, there was no good way to do something equivalent with doubles since C++ only supported compile-time static members for integral and enum types.

This is closely related to the changes in #810, but this changes the code that affected by bug #806. I put this into a separate commit because this is technically not part of the fix for #806, but I don't mind bundling things like this in if the normal style around here is to bundle somewhat related things together. Just let me know.

One note on this is that VC++ was relatively late to get `C++11` and `constexpr`. I believe people will need 2013 (with November 2013 CTP) or VC++ 2015 for `constexpr` support.

#### Intended Effect:

Make intent of code clearer. Should also have a (likely very minor) performance benefit.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Dan Luu

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
