### PR TITLE
Clean up lint warnings from CLion (clang-tidy, etc.)

### DIFF
--- a/stan/math/memory/stack_alloc.hpp
+++ b/stan/math/memory/stack_alloc.hpp
@@ -142,7 +142,7 @@ class stack_alloc {
    */
   ~stack_alloc() {
     // free ALL blocks
-    for (auto &block : blocks_)
+    for (auto& block : blocks_)
       if (block)
         free(block);
   }

--- a/stan/math/memory/stack_alloc.hpp
+++ b/stan/math/memory/stack_alloc.hpp
@@ -142,9 +142,9 @@ class stack_alloc {
    */
   ~stack_alloc() {
     // free ALL blocks
-    for (size_t i = 0; i < blocks_.size(); ++i)
-      if (blocks_[i])
-        free(blocks_[i]);
+    for (auto &block : blocks_)
+      if (block)
+        free(block);
   }
 
   /**

--- a/stan/math/prim/arr/fun/dot_self.hpp
+++ b/stan/math/prim/arr/fun/dot_self.hpp
@@ -9,8 +9,8 @@ namespace math {
 
 inline double dot_self(const std::vector<double>& x) {
   double sum = 0.0;
-  for (size_t i = 0; i < x.size(); ++i)
-    sum += x[i] * x[i];
+  for (double i : x)
+    sum += i * i;
   return sum;
 }
 

--- a/stan/math/prim/arr/fun/log_sum_exp.hpp
+++ b/stan/math/prim/arr/fun/log_sum_exp.hpp
@@ -27,9 +27,9 @@ inline double log_sum_exp(const std::vector<double>& x) {
   using std::log;
   using std::numeric_limits;
   double max = -numeric_limits<double>::infinity();
-  for (size_t ii = 0; ii < x.size(); ii++)
-    if (x[ii] > max)
-      max = x[ii];
+  for (double xx : x)
+    if (xx > max)
+      max = xx;
 
   double sum = 0.0;
   for (size_t ii = 0; ii < x.size(); ii++)

--- a/stan/math/prim/arr/functor/integrate_ode_rk45.hpp
+++ b/stan/math/prim/arr/functor/integrate_ode_rk45.hpp
@@ -70,7 +70,7 @@ std::vector<std::vector<typename stan::return_type<T1, T2>::type> >
 integrate_ode_rk45(const F& f, const std::vector<T1>& y0, double t0,
                    const std::vector<double>& ts, const std::vector<T2>& theta,
                    const std::vector<double>& x, const std::vector<int>& x_int,
-                   std::ostream* msgs = 0, double relative_tolerance = 1e-6,
+                   std::ostream* msgs = nullptr, double relative_tolerance = 1e-6,
                    double absolute_tolerance = 1e-6, int max_num_steps = 1E6) {
   using boost::numeric::odeint::integrate_times;
   using boost::numeric::odeint::make_dense_output;

--- a/stan/math/prim/arr/functor/integrate_ode_rk45.hpp
+++ b/stan/math/prim/arr/functor/integrate_ode_rk45.hpp
@@ -70,7 +70,8 @@ std::vector<std::vector<typename stan::return_type<T1, T2>::type> >
 integrate_ode_rk45(const F& f, const std::vector<T1>& y0, double t0,
                    const std::vector<double>& ts, const std::vector<T2>& theta,
                    const std::vector<double>& x, const std::vector<int>& x_int,
-                   std::ostream* msgs = nullptr, double relative_tolerance = 1e-6,
+                   std::ostream* msgs = nullptr,
+                   double relative_tolerance = 1e-6,
                    double absolute_tolerance = 1e-6, int max_num_steps = 1E6) {
   using boost::numeric::odeint::integrate_times;
   using boost::numeric::odeint::make_dense_output;

--- a/stan/math/prim/mat/fun/csr_matrix_times_vector.hpp
+++ b/stan/math/prim/mat/fun/csr_matrix_times_vector.hpp
@@ -88,8 +88,8 @@ csr_matrix_times_vector(int m, int n,
   check_size_match("csr_matrix_times_vector", "w", w.size(), "v", v.size());
   check_size_match("csr_matrix_times_vector", "u/z",
                    u[m - 1] + csr_u_to_z(u, m - 1) - 1, "v", v.size());
-  for (unsigned int i = 0; i < v.size(); ++i)
-    check_range("csr_matrix_times_vector", "v[]", n, v[i]);
+  for (int i : v)
+    check_range("csr_matrix_times_vector", "v[]", n, i);
 
   Eigen::Matrix<result_t, Eigen::Dynamic, 1> result(m);
   result.setZero();

--- a/stan/math/prim/mat/fun/csr_to_dense_matrix.hpp
+++ b/stan/math/prim/mat/fun/csr_to_dense_matrix.hpp
@@ -45,8 +45,8 @@ inline Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> csr_to_dense_matrix(
   check_size_match("csr_to_dense_matrix", "w", w.size(), "v", v.size());
   check_size_match("csr_to_dense_matrix", "u/z",
                    u[m - 1] + csr_u_to_z(u, m - 1) - 1, "v", v.size());
-  for (size_t i = 0; i < v.size(); ++i)
-    check_range("csr_to_dense_matrix", "v[]", n, v[i]);
+  for (int i : v)
+    check_range("csr_to_dense_matrix", "v[]", n, i);
 
   Matrix<T, Dynamic, Dynamic> result(m, n);
   result.setZero();

--- a/stan/math/prim/mat/functor/map_rect.hpp
+++ b/stan/math/prim/mat/functor/map_rect.hpp
@@ -109,7 +109,8 @@ map_rect(const Eigen::Matrix<T_shared_param, Eigen::Dynamic, 1>& shared_params,
          const std::vector<Eigen::Matrix<T_job_param, Eigen::Dynamic, 1>>&
              job_params,
          const std::vector<std::vector<double>>& x_r,
-         const std::vector<std::vector<int>>& x_i, std::ostream* msgs = nullptr) {
+         const std::vector<std::vector<int>>& x_i,
+         std::ostream* msgs = nullptr) {
   static const char* function = "map_rect";
   typedef Eigen::Matrix<
       typename stan::return_type<T_shared_param, T_job_param>::type,

--- a/stan/math/prim/mat/functor/map_rect.hpp
+++ b/stan/math/prim/mat/functor/map_rect.hpp
@@ -109,7 +109,7 @@ map_rect(const Eigen::Matrix<T_shared_param, Eigen::Dynamic, 1>& shared_params,
          const std::vector<Eigen::Matrix<T_job_param, Eigen::Dynamic, 1>>&
              job_params,
          const std::vector<std::vector<double>>& x_r,
-         const std::vector<std::vector<int>>& x_i, std::ostream* msgs = 0) {
+         const std::vector<std::vector<int>>& x_i, std::ostream* msgs = nullptr) {
   static const char* function = "map_rect";
   typedef Eigen::Matrix<
       typename stan::return_type<T_shared_param, T_job_param>::type,

--- a/stan/math/prim/mat/functor/map_rect_reduce.hpp
+++ b/stan/math/prim/mat/functor/map_rect_reduce.hpp
@@ -42,7 +42,7 @@ class map_rect_reduce<F, double, double> {
                       const vector_d& job_specific_params,
                       const std::vector<double>& x_r,
                       const std::vector<int>& x_i,
-                      std::ostream* msgs = 0) const {
+                      std::ostream* msgs = nullptr) const {
     return F()(shared_params, job_specific_params, x_r, x_i, msgs).transpose();
   }
 };

--- a/stan/math/prim/mat/functor/map_rect_serial.hpp
+++ b/stan/math/prim/mat/functor/map_rect_serial.hpp
@@ -21,7 +21,7 @@ map_rect_serial(
     const std::vector<Eigen::Matrix<T_job_param, Eigen::Dynamic, 1>>&
         job_params,
     const std::vector<std::vector<double>>& x_r,
-    const std::vector<std::vector<int>>& x_i, std::ostream* msgs = 0) {
+    const std::vector<std::vector<int>>& x_i, std::ostream* msgs = nullptr) {
   typedef map_rect_reduce<F, T_shared_param, T_job_param> ReduceF;
   typedef map_rect_combine<F, T_shared_param, T_job_param> CombineF;
 

--- a/stan/math/prim/mat/prob/categorical_logit_lpmf.hpp
+++ b/stan/math/prim/mat/prob/categorical_logit_lpmf.hpp
@@ -44,7 +44,7 @@ typename boost::math::tools::promote_args<T_prob>::type categorical_logit_lpmf(
     const Eigen::Matrix<T_prob, Eigen::Dynamic, 1>& beta) {
   static const char* function = "categorical_logit_lpmf";
 
-  for (const auto & x : ns)
+  for (const auto& x : ns)
     check_bounded(function, "categorical outcome out of support", x, 1,
                   beta.size());
   check_finite(function, "log odds parameter", beta);

--- a/stan/math/prim/mat/prob/categorical_logit_lpmf.hpp
+++ b/stan/math/prim/mat/prob/categorical_logit_lpmf.hpp
@@ -44,15 +44,15 @@ typename boost::math::tools::promote_args<T_prob>::type categorical_logit_lpmf(
     const Eigen::Matrix<T_prob, Eigen::Dynamic, 1>& beta) {
   static const char* function = "categorical_logit_lpmf";
 
-  for (size_t k = 0; k < ns.size(); ++k)
-    check_bounded(function, "categorical outcome out of support", ns[k], 1,
+  for (const auto & x : ns)
+    check_bounded(function, "categorical outcome out of support", x, 1,
                   beta.size());
   check_finite(function, "log odds parameter", beta);
 
   if (!include_summand<propto, T_prob>::value)
     return 0.0;
 
-  if (ns.size() == 0)
+  if (ns.empty())
     return 0.0;
 
   Eigen::Matrix<T_prob, Eigen::Dynamic, 1> log_softmax_beta = log_softmax(beta);

--- a/stan/math/prim/mat/prob/multinomial_lpmf.hpp
+++ b/stan/math/prim/mat/prob/multinomial_lpmf.hpp
@@ -34,11 +34,11 @@ typename boost::math::tools::promote_args<T_prob>::type multinomial_lpmf(
 
   if (include_summand<propto>::value) {
     double sum = 1.0;
-    for (unsigned int i = 0; i < ns.size(); ++i)
-      sum += ns[i];
+    for (int n : ns)
+      sum += n;
     lp += lgamma(sum);
-    for (unsigned int i = 0; i < ns.size(); ++i)
-      lp -= lgamma(ns[i] + 1.0);
+    for (int n : ns)
+      lp -= lgamma(n + 1.0);
   }
   if (include_summand<propto, T_prob>::value) {
     for (unsigned int i = 0; i < ns.size(); ++i)

--- a/stan/math/prim/scal/fun/grad_2F1.hpp
+++ b/stan/math/prim/scal/fun/grad_2F1.hpp
@@ -44,8 +44,8 @@ void grad_2F1(T& g_a1, T& g_b1, const T& a1, const T& a2, const T& b1,
   g_b1 = 0.0;
 
   T log_g_old[2];
-  for (int i = 0; i < 2; ++i)
-    log_g_old[i] = -std::numeric_limits<T>::infinity();
+  for (auto &i : log_g_old)
+    i = -std::numeric_limits<T>::infinity();
 
   T log_t_old = 0.0;
   T log_t_new = 0.0;
@@ -55,8 +55,8 @@ void grad_2F1(T& g_a1, T& g_b1, const T& a1, const T& a2, const T& b1,
   double log_t_new_sign = 1.0;
   double log_t_old_sign = 1.0;
   double log_g_old_sign[2];
-  for (int i = 0; i < 2; ++i)
-    log_g_old_sign[i] = 1.0;
+  for (double &x : log_g_old_sign)
+    x = 1.0;
 
   for (int k = 0; k <= max_steps; ++k) {
     T p = (a1 + k) * (a2 + k) / ((b1 + k) * (1 + k));

--- a/stan/math/prim/scal/fun/grad_2F1.hpp
+++ b/stan/math/prim/scal/fun/grad_2F1.hpp
@@ -44,7 +44,7 @@ void grad_2F1(T& g_a1, T& g_b1, const T& a1, const T& a2, const T& b1,
   g_b1 = 0.0;
 
   T log_g_old[2];
-  for (auto &i : log_g_old)
+  for (auto& i : log_g_old)
     i = -std::numeric_limits<T>::infinity();
 
   T log_t_old = 0.0;
@@ -55,7 +55,7 @@ void grad_2F1(T& g_a1, T& g_b1, const T& a1, const T& a2, const T& b1,
   double log_t_new_sign = 1.0;
   double log_t_old_sign = 1.0;
   double log_g_old_sign[2];
-  for (double &x : log_g_old_sign)
+  for (double& x : log_g_old_sign)
     x = 1.0;
 
   for (int k = 0; k <= max_steps; ++k) {

--- a/stan/math/prim/scal/fun/grad_F32.hpp
+++ b/stan/math/prim/scal/fun/grad_F32.hpp
@@ -46,8 +46,8 @@ void grad_F32(T* g, const T& a1, const T& a2, const T& a3, const T& b1,
     g[i] = 0.0;
 
   T log_g_old[6];
-  for (int i = 0; i < 6; ++i)
-    log_g_old[i] = -std::numeric_limits<double>::infinity();
+  for (auto &x : log_g_old)
+    x = -std::numeric_limits<double>::infinity();
 
   T log_t_old = 0.0;
   T log_t_new = 0.0;

--- a/stan/math/prim/scal/fun/grad_F32.hpp
+++ b/stan/math/prim/scal/fun/grad_F32.hpp
@@ -46,7 +46,7 @@ void grad_F32(T* g, const T& a1, const T& a2, const T& a3, const T& b1,
     g[i] = 0.0;
 
   T log_g_old[6];
-  for (auto &x : log_g_old)
+  for (auto& x : log_g_old)
     x = -std::numeric_limits<double>::infinity();
 
   T log_t_old = 0.0;

--- a/stan/math/prim/scal/fun/inc_beta_dda.hpp
+++ b/stan/math/prim/scal/fun/inc_beta_dda.hpp
@@ -9,8 +9,6 @@
 namespace stan {
 namespace math {
 
-template <typename T>
-T inc_beta_ddb(T a, T b, T z, T digamma_b, T digamma_ab);
 
 /**
  * Returns the partial derivative of the regularized

--- a/stan/math/prim/scal/fun/inc_beta_dda.hpp
+++ b/stan/math/prim/scal/fun/inc_beta_dda.hpp
@@ -9,7 +9,6 @@
 namespace stan {
 namespace math {
 
-
 /**
  * Returns the partial derivative of the regularized
  * incomplete beta function, I_{z}(a, b) with respect to a.

--- a/stan/math/prim/scal/prob/von_mises_rng.hpp
+++ b/stan/math/prim/scal/prob/von_mises_rng.hpp
@@ -40,7 +40,7 @@ inline double von_mises_rng(double mu, double kappa, RNG& rng) {
   double rho = 0.5 * (r - pow(2 * r, 0.5)) / kappa;
   double s = 0.5 * (1 + rho * rho) / rho;
 
-  bool done = 0;
+  bool done = false;
   double W;
   while (!done) {
     double Z = std::cos(pi() * uniform_rng(0.0, 1.0, rng));

--- a/stan/math/rev/arr/fun/sum.hpp
+++ b/stan/math/rev/arr/fun/sum.hpp
@@ -18,8 +18,8 @@ class sum_v_vari : public vari {
 
   inline static double sum_of_val(const std::vector<var>& v) {
     double result = 0;
-    for (size_t i = 0; i < v.size(); i++)
-      result += v[i].val();
+    for (auto x : v)
+        result += x.val();
     return result;
   }
 
@@ -50,7 +50,7 @@ class sum_v_vari : public vari {
  * @return Sum of vector entries.
  */
 inline var sum(const std::vector<var>& m) {
-  if (m.size() == 0)
+  if (m.empty())
     return 0.0;
   return var(new sum_v_vari(m));
 }

--- a/stan/math/rev/arr/fun/sum.hpp
+++ b/stan/math/rev/arr/fun/sum.hpp
@@ -19,7 +19,7 @@ class sum_v_vari : public vari {
   inline static double sum_of_val(const std::vector<var>& v) {
     double result = 0;
     for (auto x : v)
-        result += x.val();
+      result += x.val();
     return result;
   }
 

--- a/stan/math/rev/core/recover_memory.hpp
+++ b/stan/math/rev/core/recover_memory.hpp
@@ -22,8 +22,8 @@ static inline void recover_memory() {
         " before calling recover_memory()");
   ChainableStack::var_stack_.clear();
   ChainableStack::var_nochain_stack_.clear();
-  for (size_t i = 0; i < ChainableStack::var_alloc_stack_.size(); ++i) {
-    delete ChainableStack::var_alloc_stack_[i];
+  for (auto &x : ChainableStack::var_alloc_stack_) {
+    delete x;
   }
   ChainableStack::var_alloc_stack_.clear();
   ChainableStack::memalloc_.recover_all();

--- a/stan/math/rev/core/set_zero_all_adjoints.hpp
+++ b/stan/math/rev/core/set_zero_all_adjoints.hpp
@@ -12,10 +12,10 @@ namespace math {
  * Reset all adjoint values in the stack to zero.
  */
 static void set_zero_all_adjoints() {
-  for (size_t i = 0; i < ChainableStack::var_stack_.size(); ++i)
-    ChainableStack::var_stack_[i]->set_zero_adjoint();
-  for (size_t i = 0; i < ChainableStack::var_nochain_stack_.size(); ++i)
-    ChainableStack::var_nochain_stack_[i]->set_zero_adjoint();
+  for (auto &x : ChainableStack::var_stack_)
+    x->set_zero_adjoint();
+  for (auto &x : ChainableStack::var_nochain_stack_)
+    x->set_zero_adjoint();
 }
 
 }  // namespace math

--- a/stan/math/rev/core/var.hpp
+++ b/stan/math/rev/core/var.hpp
@@ -53,7 +53,7 @@ class var {
    * @return <code>true</code> if this variable does not yet have
    * a defined variable.
    */
-  bool is_uninitialized() { return (vi_ == static_cast<vari*>(0U)); }
+  bool is_uninitialized() { return (vi_ == static_cast<vari*>(nullptr)); }
 
   /**
    * Construct a variable for later assignment.
@@ -470,7 +470,7 @@ class var {
    * @return Reference to the specified output stream.
    */
   friend std::ostream& operator<<(std::ostream& os, const var& v) {
-    if (v.vi_ == 0)
+    if (v.vi_ == nullptr)
       return os << "uninitialized";
     return os << v.val();
   }

--- a/stan/math/rev/mat/fun/dot_product.hpp
+++ b/stan/math/rev/mat/fun/dot_product.hpp
@@ -81,7 +81,8 @@ class dot_product_vari : public vari {
       v1[i]->adj_ += adj_ * v2_[i];
     }
   }
-  inline void initialize(vari**& mem_v, const var* inv, vari** shared = nullptr) {
+  inline void initialize(vari**& mem_v, const var* inv,
+                         vari** shared = nullptr) {
     if (shared == nullptr) {
       mem_v = reinterpret_cast<vari**>(
           ChainableStack::memalloc_.alloc(length_ * sizeof(vari*)));

--- a/stan/math/rev/mat/fun/dot_product.hpp
+++ b/stan/math/rev/mat/fun/dot_product.hpp
@@ -81,8 +81,8 @@ class dot_product_vari : public vari {
       v1[i]->adj_ += adj_ * v2_[i];
     }
   }
-  inline void initialize(vari**& mem_v, const var* inv, vari** shared = NULL) {
-    if (shared == NULL) {
+  inline void initialize(vari**& mem_v, const var* inv, vari** shared = nullptr) {
+    if (shared == nullptr) {
       mem_v = reinterpret_cast<vari**>(
           ChainableStack::memalloc_.alloc(length_ * sizeof(vari*)));
       for (size_t i = 0; i < length_; i++)
@@ -93,8 +93,8 @@ class dot_product_vari : public vari {
   }
   template <typename Derived>
   inline void initialize(vari**& mem_v, const Eigen::DenseBase<Derived>& inv,
-                         vari** shared = NULL) {
-    if (shared == NULL) {
+                         vari** shared = nullptr) {
+    if (shared == nullptr) {
       mem_v = reinterpret_cast<vari**>(
           ChainableStack::memalloc_.alloc(length_ * sizeof(vari*)));
       for (size_t i = 0; i < length_; i++)
@@ -105,8 +105,8 @@ class dot_product_vari : public vari {
   }
 
   inline void initialize(double*& mem_d, const double* ind,
-                         double* shared = NULL) {
-    if (shared == NULL) {
+                         double* shared = nullptr) {
+    if (shared == nullptr) {
       mem_d = reinterpret_cast<double*>(
           ChainableStack::memalloc_.alloc(length_ * sizeof(double)));
       for (size_t i = 0; i < length_; i++)
@@ -117,8 +117,8 @@ class dot_product_vari : public vari {
   }
   template <typename Derived>
   inline void initialize(double*& mem_d, const Eigen::DenseBase<Derived>& ind,
-                         double* shared = NULL) {
-    if (shared == NULL) {
+                         double* shared = nullptr) {
+    if (shared == nullptr) {
       mem_d = reinterpret_cast<double*>(
           ChainableStack::memalloc_.alloc(length_ * sizeof(double)));
       for (size_t i = 0; i < length_; i++)

--- a/stan/math/rev/mat/functor/algebra_solver.hpp
+++ b/stan/math/rev/mat/functor/algebra_solver.hpp
@@ -123,7 +123,7 @@ template <typename F, typename T>
 Eigen::VectorXd algebra_solver(
     const F& f, const Eigen::Matrix<T, Eigen::Dynamic, 1>& x,
     const Eigen::VectorXd& y, const std::vector<double>& dat,
-    const std::vector<int>& dat_int, std::ostream* msgs = 0,
+    const std::vector<int>& dat_int, std::ostream* msgs = nullptr,
     double relative_tolerance = 1e-10, double function_tolerance = 1e-6,
     long int max_num_steps = 1e+3) {  // NOLINT(runtime/int)
   check_nonzero_size("algebra_solver", "initial guess", x);
@@ -131,10 +131,10 @@ Eigen::VectorXd algebra_solver(
     check_finite("algebra_solver", "initial guess", x(i));
   for (int i = 0; i < y.size(); i++)
     check_finite("algebra_solver", "parameter vector", y(i));
-  for (size_t i = 0; i < dat.size(); i++)
-    check_finite("algebra_solver", "continuous data", dat[i]);
-  for (size_t i = 0; i < dat_int.size(); i++)
-    check_finite("algebra_solver", "integer data", dat_int[i]);
+  for (double i : dat)
+    check_finite("algebra_solver", "continuous data", i);
+  for (const auto & x: dat_int)
+    check_finite("algebra_solver", "integer data", x);
 
   if (relative_tolerance < 0)
     invalid_argument("algebra_solver", "relative_tolerance,",
@@ -236,7 +236,7 @@ Eigen::Matrix<T2, Eigen::Dynamic, 1> algebra_solver(
     const F& f, const Eigen::Matrix<T1, Eigen::Dynamic, 1>& x,
     const Eigen::Matrix<T2, Eigen::Dynamic, 1>& y,
     const std::vector<double>& dat, const std::vector<int>& dat_int,
-    std::ostream* msgs = 0, double relative_tolerance = 1e-10,
+    std::ostream* msgs = nullptr, double relative_tolerance = 1e-10,
     double function_tolerance = 1e-6,
     long int max_num_steps = 1e+3) {  // NOLINT(runtime/int)
   Eigen::VectorXd theta_dbl

--- a/stan/math/rev/mat/functor/algebra_solver.hpp
+++ b/stan/math/rev/mat/functor/algebra_solver.hpp
@@ -133,7 +133,7 @@ Eigen::VectorXd algebra_solver(
     check_finite("algebra_solver", "parameter vector", y(i));
   for (double i : dat)
     check_finite("algebra_solver", "continuous data", i);
-  for (const auto & x: dat_int)
+  for (int x : dat_int)
     check_finite("algebra_solver", "integer data", x);
 
   if (relative_tolerance < 0)

--- a/stan/math/rev/mat/functor/cvodes_utils.hpp
+++ b/stan/math/rev/mat/functor/cvodes_utils.hpp
@@ -30,7 +30,7 @@ inline void cvodes_set_options(void* cvodes_mem, double rel_tol, double abs_tol,
                                // NOLINTNEXTLINE(runtime/int)
                                long int max_num_steps) {
   // forward CVode errors to noop error handler
-  CVodeSetErrHandlerFn(cvodes_mem, cvodes_silent_err_handler, 0);
+  CVodeSetErrHandlerFn(cvodes_mem, cvodes_silent_err_handler, nullptr);
 
   // Initialize solver parameters
   cvodes_check_flag(CVodeSStolerances(cvodes_mem, rel_tol, abs_tol),

--- a/stan/math/rev/mat/functor/integrate_ode_adams.hpp
+++ b/stan/math/rev/mat/functor/integrate_ode_adams.hpp
@@ -14,7 +14,8 @@ integrate_ode_adams(const F& f, const std::vector<T_initial>& y0, double t0,
                     const std::vector<double>& ts,
                     const std::vector<T_param>& theta,
                     const std::vector<double>& x, const std::vector<int>& x_int,
-                    std::ostream* msgs = nullptr, double relative_tolerance = 1e-10,
+                    std::ostream* msgs = nullptr,
+                    double relative_tolerance = 1e-10,
                     double absolute_tolerance = 1e-10,
                     long int max_num_steps = 1e8) {  // NOLINT(runtime/int)
   stan::math::cvodes_integrator<CV_ADAMS> integrator;

--- a/stan/math/rev/mat/functor/integrate_ode_adams.hpp
+++ b/stan/math/rev/mat/functor/integrate_ode_adams.hpp
@@ -14,7 +14,7 @@ integrate_ode_adams(const F& f, const std::vector<T_initial>& y0, double t0,
                     const std::vector<double>& ts,
                     const std::vector<T_param>& theta,
                     const std::vector<double>& x, const std::vector<int>& x_int,
-                    std::ostream* msgs = 0, double relative_tolerance = 1e-10,
+                    std::ostream* msgs = nullptr, double relative_tolerance = 1e-10,
                     double absolute_tolerance = 1e-10,
                     long int max_num_steps = 1e8) {  // NOLINT(runtime/int)
   stan::math::cvodes_integrator<CV_ADAMS> integrator;

--- a/stan/math/rev/mat/functor/integrate_ode_bdf.hpp
+++ b/stan/math/rev/mat/functor/integrate_ode_bdf.hpp
@@ -14,7 +14,7 @@ integrate_ode_bdf(const F& f, const std::vector<T_initial>& y0, double t0,
                   const std::vector<double>& ts,
                   const std::vector<T_param>& theta,
                   const std::vector<double>& x, const std::vector<int>& x_int,
-                  std::ostream* msgs = 0, double relative_tolerance = 1e-10,
+                  std::ostream* msgs = nullptr, double relative_tolerance = 1e-10,
                   double absolute_tolerance = 1e-10,
                   long int max_num_steps = 1e8) {  // NOLINT(runtime/int)
   stan::math::cvodes_integrator<CV_BDF> integrator;

--- a/stan/math/rev/mat/functor/integrate_ode_bdf.hpp
+++ b/stan/math/rev/mat/functor/integrate_ode_bdf.hpp
@@ -14,7 +14,8 @@ integrate_ode_bdf(const F& f, const std::vector<T_initial>& y0, double t0,
                   const std::vector<double>& ts,
                   const std::vector<T_param>& theta,
                   const std::vector<double>& x, const std::vector<int>& x_int,
-                  std::ostream* msgs = nullptr, double relative_tolerance = 1e-10,
+                  std::ostream* msgs = nullptr,
+                  double relative_tolerance = 1e-10,
                   double absolute_tolerance = 1e-10,
                   long int max_num_steps = 1e8) {  // NOLINT(runtime/int)
   stan::math::cvodes_integrator<CV_BDF> integrator;

--- a/stan/math/rev/mat/functor/map_rect_reduce.hpp
+++ b/stan/math/rev/mat/functor/map_rect_reduce.hpp
@@ -19,7 +19,7 @@ struct map_rect_reduce<F, var, var> {
                       const vector_d& job_specific_params,
                       const std::vector<double>& x_r,
                       const std::vector<int>& x_i,
-                      std::ostream* msgs = 0) const {
+                      std::ostream* msgs = nullptr) const {
     const size_type num_shared_params = shared_params.rows();
     const size_type num_job_specific_params = job_specific_params.rows();
     matrix_d out(1 + num_shared_params + num_job_specific_params, 0);
@@ -61,7 +61,7 @@ struct map_rect_reduce<F, double, var> {
                       const vector_d& job_specific_params,
                       const std::vector<double>& x_r,
                       const std::vector<int>& x_i,
-                      std::ostream* msgs = 0) const {
+                      std::ostream* msgs = nullptr) const {
     const size_type num_job_specific_params = job_specific_params.rows();
     matrix_d out(1 + num_job_specific_params, 0);
 
@@ -97,7 +97,7 @@ struct map_rect_reduce<F, var, double> {
                       const vector_d& job_specific_params,
                       const std::vector<double>& x_r,
                       const std::vector<int>& x_i,
-                      std::ostream* msgs = 0) const {
+                      std::ostream* msgs = nullptr) const {
     const size_type num_shared_params = shared_params.rows();
     matrix_d out(1 + num_shared_params, 0);
 


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

Fix some lint warnings from CLion (which applies clang-tidy and other checkers to the code). This is < 1% of all warnings. If people think this kind of thing is useful, I can do more of these.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Dan Luu

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
