### PR TITLE
Fix accidental precision loss (#814)

### DIFF
--- a/stan/math/rev/mat/fun/variance.hpp
+++ b/stan/math/rev/mat/fun/variance.hpp
@@ -23,16 +23,16 @@ inline var calc_variance(size_t size, const var* dtrs) {
     sum += dtrs[i].vi_->val_;
   double mean = sum / size;
   double sum_of_squares = 0;
+  double reciprocal_size_m1 = 1.0 / (size - 1);
+  double two_over_size_m1 = 2.0 * reciprocal_size_m1;
+  double* partials = reinterpret_cast<double*>(
+      ChainableStack::memalloc_.alloc(size * sizeof(double)));
   for (size_t i = 0; i < size; ++i) {
     double diff = dtrs[i].vi_->val_ - mean;
     sum_of_squares += diff * diff;
+    partials[i] = two_over_size_m1 * diff;
   }
-  double variance = sum_of_squares / (size - 1);
-  double* partials = reinterpret_cast<double*>(
-      ChainableStack::memalloc_.alloc(size * sizeof(double)));
-  double two_over_size_m1 = 2 / (size - 1);
-  for (size_t i = 0; i < size; ++i)
-    partials[i] = two_over_size_m1 * (dtrs[i].vi_->val_ - mean);
+  double variance = sum_of_squares * reciprocal_size_m1;
   return var(new stored_gradient_vari(variance, size, varis, partials));
 }
 


### PR DESCRIPTION
#### Submission Checklist

- [ ] Run unit tests: `./runTests.py test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

There's accidental precision loss due to the use of integer instead of floating point divide. The offending function also does redundant loads and possibly a redundant divide, even with optimizations enabled. See #814 for more details and discussion.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Dan Luu

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
