### PR TITLE
fix performance regression bug, fixes #824

### DIFF
--- a/stan/math/rev/arr/fun/sum.hpp
+++ b/stan/math/rev/arr/fun/sum.hpp
@@ -29,8 +29,8 @@ class sum_v_vari : public vari {
 
   explicit sum_v_vari(const std::vector<var>& v1)
       : vari(sum_of_val(v1)),
-        v_(reinterpret_cast<vari**>(ChainableStack.memalloc_.alloc(
-            v1.size() * sizeof(vari*)))),
+        v_(reinterpret_cast<vari**>(
+            ChainableStack.memalloc_.alloc(v1.size() * sizeof(vari*)))),
         length_(v1.size()) {
     for (size_t i = 0; i < length_; i++)
       v_[i] = v1[i].vi_;

--- a/stan/math/rev/arr/fun/sum.hpp
+++ b/stan/math/rev/arr/fun/sum.hpp
@@ -29,7 +29,7 @@ class sum_v_vari : public vari {
 
   explicit sum_v_vari(const std::vector<var>& v1)
       : vari(sum_of_val(v1)),
-        v_(reinterpret_cast<vari**>(ChainableStack::context().memalloc_.alloc(
+        v_(reinterpret_cast<vari**>(ChainableStack.memalloc_.alloc(
             v1.size() * sizeof(vari*)))),
         length_(v1.size()) {
     for (size_t i = 0; i < length_; i++)

--- a/stan/math/rev/core/autodiffstackstorage.hpp
+++ b/stan/math/rev/core/autodiffstackstorage.hpp
@@ -9,7 +9,6 @@ namespace math {
 
 template <typename ChainableT, typename ChainableAllocT>
 struct AutodiffStackStorage {
-
   std::vector<ChainableT*> var_stack_;
   std::vector<ChainableT*> var_nochain_stack_;
   std::vector<ChainableAllocT*> var_alloc_stack_;

--- a/stan/math/rev/core/autodiffstackstorage.hpp
+++ b/stan/math/rev/core/autodiffstackstorage.hpp
@@ -9,18 +9,6 @@ namespace math {
 
 template <typename ChainableT, typename ChainableAllocT>
 struct AutodiffStackStorage {
-  typedef AutodiffStackStorage<ChainableT, ChainableAllocT>
-      AutodiffStackStorage_t;
-
-  static AutodiffStackStorage_t& context() {
-#ifndef STAN_THREADS
-    static AutodiffStackStorage_t ad_stack = AutodiffStackStorage_t();
-#else
-    static thread_local AutodiffStackStorage_t ad_stack
-        = AutodiffStackStorage_t();
-#endif
-    return ad_stack;
-  }
 
   std::vector<ChainableT*> var_stack_;
   std::vector<ChainableT*> var_nochain_stack_;

--- a/stan/math/rev/core/chainable_alloc.hpp
+++ b/stan/math/rev/core/chainable_alloc.hpp
@@ -15,9 +15,7 @@ namespace math {
  */
 class chainable_alloc {
  public:
-  chainable_alloc() {
-    ChainableStack.var_alloc_stack_.push_back(this);
-  }
+  chainable_alloc() { ChainableStack.var_alloc_stack_.push_back(this); }
   virtual ~chainable_alloc() {}
 };
 

--- a/stan/math/rev/core/chainable_alloc.hpp
+++ b/stan/math/rev/core/chainable_alloc.hpp
@@ -16,7 +16,7 @@ namespace math {
 class chainable_alloc {
  public:
   chainable_alloc() {
-    ChainableStack::context().var_alloc_stack_.push_back(this);
+    ChainableStack.var_alloc_stack_.push_back(this);
   }
   virtual ~chainable_alloc() {}
 };

--- a/stan/math/rev/core/chainablestack.hpp
+++ b/stan/math/rev/core/chainablestack.hpp
@@ -9,7 +9,13 @@ namespace math {
 class vari;
 class chainable_alloc;
 
-typedef AutodiffStackStorage<vari, chainable_alloc> ChainableStack;
+typedef AutodiffStackStorage<vari, chainable_alloc> ChainableStack_t;
+
+#ifndef STAN_THREADS
+static ChainableStack_t ChainableStack;
+#else
+static thread_local ChainableStack_t ChainableStack;
+#endif
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/rev/core/empty_nested.hpp
+++ b/stan/math/rev/core/empty_nested.hpp
@@ -10,7 +10,7 @@ namespace math {
  * Return true if there is no nested autodiff being executed.
  */
 static inline bool empty_nested() {
-  return ChainableStack::context().nested_var_stack_sizes_.empty();
+  return ChainableStack.nested_var_stack_sizes_.empty();
 }
 
 }  // namespace math

--- a/stan/math/rev/core/gevv_vvv_vari.hpp
+++ b/stan/math/rev/core/gevv_vvv_vari.hpp
@@ -33,7 +33,7 @@ class gevv_vvv_vari : public vari {
     alpha_ = alpha->vi_;
     // TODO(carpenter): replace this with array alloc fun call
     v1_ = reinterpret_cast<vari**>(
-        ChainableStack::context().memalloc_.alloc(2 * length_ * sizeof(vari*)));
+        ChainableStack.memalloc_.alloc(2 * length_ * sizeof(vari*)));
     v2_ = v1_ + length_;
     for (size_t i = 0; i < length_; i++)
       v1_[i] = v1[i * stride1].vi_;

--- a/stan/math/rev/core/grad.hpp
+++ b/stan/math/rev/core/grad.hpp
@@ -37,8 +37,8 @@ static void grad(vari* vi) {
 
   typedef std::vector<vari*>::reverse_iterator it_t;
   vi->init_dependent();
-  it_t begin = ChainableStack::context().var_stack_.rbegin();
-  it_t end = empty_nested() ? ChainableStack::context().var_stack_.rend()
+  it_t begin = ChainableStack.var_stack_.rbegin();
+  it_t end = empty_nested() ? ChainableStack.var_stack_.rend()
                             : begin + nested_size();
   for (it_t it = begin; it < end; ++it) {
     (*it)->chain();

--- a/stan/math/rev/core/nested_size.hpp
+++ b/stan/math/rev/core/nested_size.hpp
@@ -8,8 +8,8 @@ namespace stan {
 namespace math {
 
 static inline size_t nested_size() {
-  return ChainableStack::context().var_stack_.size()
-         - ChainableStack::context().nested_var_stack_sizes_.back();
+  return ChainableStack.var_stack_.size()
+         - ChainableStack.nested_var_stack_sizes_.back();
 }
 
 }  // namespace math

--- a/stan/math/rev/core/precomputed_gradients.hpp
+++ b/stan/math/rev/core/precomputed_gradients.hpp
@@ -52,9 +52,9 @@ class precomputed_gradients_vari : public vari {
                              const std::vector<double>& gradients)
       : vari(val),
         size_(vars.size()),
-        varis_(ChainableStack::context().memalloc_.alloc_array<vari*>(
+        varis_(ChainableStack.memalloc_.alloc_array<vari*>(
             vars.size())),
-        gradients_(ChainableStack::context().memalloc_.alloc_array<double>(
+        gradients_(ChainableStack.memalloc_.alloc_array<double>(
             vars.size())) {
     check_consistent_sizes("precomputed_gradients_vari", "vars", vars,
                            "gradients", gradients);

--- a/stan/math/rev/core/precomputed_gradients.hpp
+++ b/stan/math/rev/core/precomputed_gradients.hpp
@@ -52,10 +52,8 @@ class precomputed_gradients_vari : public vari {
                              const std::vector<double>& gradients)
       : vari(val),
         size_(vars.size()),
-        varis_(ChainableStack.memalloc_.alloc_array<vari*>(
-            vars.size())),
-        gradients_(ChainableStack.memalloc_.alloc_array<double>(
-            vars.size())) {
+        varis_(ChainableStack.memalloc_.alloc_array<vari*>(vars.size())),
+        gradients_(ChainableStack.memalloc_.alloc_array<double>(vars.size())) {
     check_consistent_sizes("precomputed_gradients_vari", "vars", vars,
                            "gradients", gradients);
     for (size_t i = 0; i < vars.size(); ++i)

--- a/stan/math/rev/core/print_stack.hpp
+++ b/stan/math/rev/core/print_stack.hpp
@@ -18,15 +18,12 @@ namespace math {
  * @param o ostream to modify
  */
 inline void print_stack(std::ostream& o) {
-  o << "STACK, size=" << ChainableStack.var_stack_.size()
-    << std::endl;
+  o << "STACK, size=" << ChainableStack.var_stack_.size() << std::endl;
   // TODO(carpenter): this shouldn't need to be cast any more
   for (size_t i = 0; i < ChainableStack.var_stack_.size(); ++i)
     o << i << "  " << ChainableStack.var_stack_[i] << "  "
-      << (static_cast<vari*>(ChainableStack.var_stack_[i]))->val_
-      << " : "
-      << (static_cast<vari*>(ChainableStack.var_stack_[i]))->adj_
-      << std::endl;
+      << (static_cast<vari*>(ChainableStack.var_stack_[i]))->val_ << " : "
+      << (static_cast<vari*>(ChainableStack.var_stack_[i]))->adj_ << std::endl;
 }
 
 }  // namespace math

--- a/stan/math/rev/core/print_stack.hpp
+++ b/stan/math/rev/core/print_stack.hpp
@@ -18,14 +18,14 @@ namespace math {
  * @param o ostream to modify
  */
 inline void print_stack(std::ostream& o) {
-  o << "STACK, size=" << ChainableStack::context().var_stack_.size()
+  o << "STACK, size=" << ChainableStack.var_stack_.size()
     << std::endl;
   // TODO(carpenter): this shouldn't need to be cast any more
-  for (size_t i = 0; i < ChainableStack::context().var_stack_.size(); ++i)
-    o << i << "  " << ChainableStack::context().var_stack_[i] << "  "
-      << (static_cast<vari*>(ChainableStack::context().var_stack_[i]))->val_
+  for (size_t i = 0; i < ChainableStack.var_stack_.size(); ++i)
+    o << i << "  " << ChainableStack.var_stack_[i] << "  "
+      << (static_cast<vari*>(ChainableStack.var_stack_[i]))->val_
       << " : "
-      << (static_cast<vari*>(ChainableStack::context().var_stack_[i]))->adj_
+      << (static_cast<vari*>(ChainableStack.var_stack_[i]))->adj_
       << std::endl;
 }
 

--- a/stan/math/rev/core/recover_memory.hpp
+++ b/stan/math/rev/core/recover_memory.hpp
@@ -20,13 +20,13 @@ static inline void recover_memory() {
     throw std::logic_error(
         "empty_nested() must be true"
         " before calling recover_memory()");
-  ChainableStack::context().var_stack_.clear();
-  ChainableStack::context().var_nochain_stack_.clear();
-  for (auto &x : ChainableStack::context().var_alloc_stack_) {
+  ChainableStack.var_stack_.clear();
+  ChainableStack.var_nochain_stack_.clear();
+  for (auto &x : ChainableStack.var_alloc_stack_) {
     delete x;
   }
-  ChainableStack::context().var_alloc_stack_.clear();
-  ChainableStack::context().memalloc_.recover_all();
+  ChainableStack.var_alloc_stack_.clear();
+  ChainableStack.memalloc_.recover_all();
 }
 
 }  // namespace math

--- a/stan/math/rev/core/recover_memory_nested.hpp
+++ b/stan/math/rev/core/recover_memory_nested.hpp
@@ -23,24 +23,24 @@ static inline void recover_memory_nested() {
         "empty_nested() must be false"
         " before calling recover_memory_nested()");
 
-  ChainableStack::context().var_stack_.resize(
-      ChainableStack::context().nested_var_stack_sizes_.back());
-  ChainableStack::context().nested_var_stack_sizes_.pop_back();
+  ChainableStack.var_stack_.resize(
+      ChainableStack.nested_var_stack_sizes_.back());
+  ChainableStack.nested_var_stack_sizes_.pop_back();
 
-  ChainableStack::context().var_nochain_stack_.resize(
-      ChainableStack::context().nested_var_nochain_stack_sizes_.back());
-  ChainableStack::context().nested_var_nochain_stack_sizes_.pop_back();
+  ChainableStack.var_nochain_stack_.resize(
+      ChainableStack.nested_var_nochain_stack_sizes_.back());
+  ChainableStack.nested_var_nochain_stack_sizes_.pop_back();
 
   for (size_t i
-       = ChainableStack::context().nested_var_alloc_stack_starts_.back();
-       i < ChainableStack::context().var_alloc_stack_.size(); ++i) {
-    delete ChainableStack::context().var_alloc_stack_[i];
+       = ChainableStack.nested_var_alloc_stack_starts_.back();
+       i < ChainableStack.var_alloc_stack_.size(); ++i) {
+    delete ChainableStack.var_alloc_stack_[i];
   }
-  ChainableStack::context().var_alloc_stack_.resize(
-      ChainableStack::context().nested_var_alloc_stack_starts_.back());
-  ChainableStack::context().nested_var_alloc_stack_starts_.pop_back();
+  ChainableStack.var_alloc_stack_.resize(
+      ChainableStack.nested_var_alloc_stack_starts_.back());
+  ChainableStack.nested_var_alloc_stack_starts_.pop_back();
 
-  ChainableStack::context().memalloc_.recover_nested();
+  ChainableStack.memalloc_.recover_nested();
 }
 
 }  // namespace math

--- a/stan/math/rev/core/recover_memory_nested.hpp
+++ b/stan/math/rev/core/recover_memory_nested.hpp
@@ -31,8 +31,7 @@ static inline void recover_memory_nested() {
       ChainableStack.nested_var_nochain_stack_sizes_.back());
   ChainableStack.nested_var_nochain_stack_sizes_.pop_back();
 
-  for (size_t i
-       = ChainableStack.nested_var_alloc_stack_starts_.back();
+  for (size_t i = ChainableStack.nested_var_alloc_stack_starts_.back();
        i < ChainableStack.var_alloc_stack_.size(); ++i) {
     delete ChainableStack.var_alloc_stack_[i];
   }

--- a/stan/math/rev/core/set_zero_all_adjoints.hpp
+++ b/stan/math/rev/core/set_zero_all_adjoints.hpp
@@ -12,9 +12,9 @@ namespace math {
  * Reset all adjoint values in the stack to zero.
  */
 static void set_zero_all_adjoints() {
-  for (auto &x : ChainableStack::context().var_stack_)
+  for (auto &x : ChainableStack.var_stack_)
     x->set_zero_adjoint();
-  for (auto &x : ChainableStack::context().var_nochain_stack_)
+  for (auto &x : ChainableStack.var_nochain_stack_)
     x->set_zero_adjoint();
 }
 

--- a/stan/math/rev/core/set_zero_all_adjoints_nested.hpp
+++ b/stan/math/rev/core/set_zero_all_adjoints_nested.hpp
@@ -19,17 +19,17 @@ static void set_zero_all_adjoints_nested() {
     throw std::logic_error(
         "empty_nested() must be false before calling"
         " set_zero_all_adjoints_nested()");
-  size_t start1 = ChainableStack::context().nested_var_stack_sizes_.back();
+  size_t start1 = ChainableStack.nested_var_stack_sizes_.back();
   // avoid wrap with unsigned when start1 == 0
   for (size_t i = (start1 == 0U) ? 0U : (start1 - 1);
-       i < ChainableStack::context().var_stack_.size(); ++i)
-    ChainableStack::context().var_stack_[i]->set_zero_adjoint();
+       i < ChainableStack.var_stack_.size(); ++i)
+    ChainableStack.var_stack_[i]->set_zero_adjoint();
 
   size_t start2
-      = ChainableStack::context().nested_var_nochain_stack_sizes_.back();
+      = ChainableStack.nested_var_nochain_stack_sizes_.back();
   for (size_t i = (start2 == 0U) ? 0U : (start2 - 1);
-       i < ChainableStack::context().var_nochain_stack_.size(); ++i) {
-    ChainableStack::context().var_nochain_stack_[i]->set_zero_adjoint();
+       i < ChainableStack.var_nochain_stack_.size(); ++i) {
+    ChainableStack.var_nochain_stack_[i]->set_zero_adjoint();
   }
 }
 

--- a/stan/math/rev/core/set_zero_all_adjoints_nested.hpp
+++ b/stan/math/rev/core/set_zero_all_adjoints_nested.hpp
@@ -25,8 +25,7 @@ static void set_zero_all_adjoints_nested() {
        i < ChainableStack.var_stack_.size(); ++i)
     ChainableStack.var_stack_[i]->set_zero_adjoint();
 
-  size_t start2
-      = ChainableStack.nested_var_nochain_stack_sizes_.back();
+  size_t start2 = ChainableStack.nested_var_nochain_stack_sizes_.back();
   for (size_t i = (start2 == 0U) ? 0U : (start2 - 1);
        i < ChainableStack.var_nochain_stack_.size(); ++i) {
     ChainableStack.var_nochain_stack_[i]->set_zero_adjoint();

--- a/stan/math/rev/core/start_nested.hpp
+++ b/stan/math/rev/core/start_nested.hpp
@@ -11,13 +11,13 @@ namespace math {
  * can find it.
  */
 static inline void start_nested() {
-  ChainableStack::context().nested_var_stack_sizes_.push_back(
-      ChainableStack::context().var_stack_.size());
-  ChainableStack::context().nested_var_nochain_stack_sizes_.push_back(
-      ChainableStack::context().var_nochain_stack_.size());
-  ChainableStack::context().nested_var_alloc_stack_starts_.push_back(
-      ChainableStack::context().var_alloc_stack_.size());
-  ChainableStack::context().memalloc_.start_nested();
+  ChainableStack.nested_var_stack_sizes_.push_back(
+      ChainableStack.var_stack_.size());
+  ChainableStack.nested_var_nochain_stack_sizes_.push_back(
+      ChainableStack.var_nochain_stack_.size());
+  ChainableStack.nested_var_alloc_stack_starts_.push_back(
+      ChainableStack.var_alloc_stack_.size());
+  ChainableStack.memalloc_.start_nested();
 }
 
 }  // namespace math

--- a/stan/math/rev/core/vari.hpp
+++ b/stan/math/rev/core/vari.hpp
@@ -56,14 +56,14 @@ class vari {
    * @param x Value of the constructed variable.
    */
   explicit vari(double x) : val_(x), adj_(0.0) {
-    ChainableStack::context().var_stack_.push_back(this);
+    ChainableStack.var_stack_.push_back(this);
   }
 
   vari(double x, bool stacked) : val_(x), adj_(0.0) {
     if (stacked)
-      ChainableStack::context().var_stack_.push_back(this);
+      ChainableStack.var_stack_.push_back(this);
     else
-      ChainableStack::context().var_nochain_stack_.push_back(this);
+      ChainableStack.var_nochain_stack_.push_back(this);
   }
 
   /**
@@ -123,7 +123,7 @@ class vari {
    * @return Pointer to allocated bytes.
    */
   static inline void* operator new(size_t nbytes) {
-    return ChainableStack::context().memalloc_.alloc(nbytes);
+    return ChainableStack.memalloc_.alloc(nbytes);
   }
 
   /**

--- a/stan/math/rev/mat/fun/cholesky_decompose.hpp
+++ b/stan/math/rev/mat/fun/cholesky_decompose.hpp
@@ -44,9 +44,9 @@ class cholesky_block : public vari {
                  const Eigen::Matrix<double, -1, -1>& L_A)
       : vari(0.0),
         M_(A.rows()),
-        variRefA_(ChainableStack::context().memalloc_.alloc_array<vari*>(
+        variRefA_(ChainableStack.memalloc_.alloc_array<vari*>(
             A.rows() * (A.rows() + 1) / 2)),
-        variRefL_(ChainableStack::context().memalloc_.alloc_array<vari*>(
+        variRefL_(ChainableStack.memalloc_.alloc_array<vari*>(
             A.rows() * (A.rows() + 1) / 2)) {
     size_t pos = 0;
     block_size_ = std::max((M_ / 8 / 16) * 16, 8);
@@ -159,9 +159,9 @@ class cholesky_scalar : public vari {
                   const Eigen::Matrix<double, -1, -1>& L_A)
       : vari(0.0),
         M_(A.rows()),
-        variRefA_(ChainableStack::context().memalloc_.alloc_array<vari*>(
+        variRefA_(ChainableStack.memalloc_.alloc_array<vari*>(
             A.rows() * (A.rows() + 1) / 2)),
-        variRefL_(ChainableStack::context().memalloc_.alloc_array<vari*>(
+        variRefL_(ChainableStack.memalloc_.alloc_array<vari*>(
             A.rows() * (A.rows() + 1) / 2)) {
     size_t accum = 0;
     size_t accum_i = accum;

--- a/stan/math/rev/mat/fun/cov_exp_quad.hpp
+++ b/stan/math/rev/mat/fun/cov_exp_quad.hpp
@@ -72,14 +72,11 @@ class cov_exp_quad_vari : public vari {
         l_d_(value_of(l)),
         sigma_d_(value_of(sigma)),
         sigma_sq_d_(sigma_d_ * sigma_d_),
-        dist_(ChainableStack.memalloc_.alloc_array<double>(
-            size_ltri_)),
+        dist_(ChainableStack.memalloc_.alloc_array<double>(size_ltri_)),
         l_vari_(l.vi_),
         sigma_vari_(sigma.vi_),
-        cov_lower_(
-            ChainableStack.memalloc_.alloc_array<vari*>(size_ltri_)),
-        cov_diag_(
-            ChainableStack.memalloc_.alloc_array<vari*>(size_)) {
+        cov_lower_(ChainableStack.memalloc_.alloc_array<vari*>(size_ltri_)),
+        cov_diag_(ChainableStack.memalloc_.alloc_array<vari*>(size_)) {
     double inv_half_sq_l_d = 0.5 / (l_d_ * l_d_);
     size_t pos = 0;
     for (size_t j = 0; j < size_ - 1; ++j) {
@@ -164,13 +161,10 @@ class cov_exp_quad_vari<T_x, double, T_l> : public vari {
         l_d_(value_of(l)),
         sigma_d_(value_of(sigma)),
         sigma_sq_d_(sigma_d_ * sigma_d_),
-        dist_(ChainableStack.memalloc_.alloc_array<double>(
-            size_ltri_)),
+        dist_(ChainableStack.memalloc_.alloc_array<double>(size_ltri_)),
         l_vari_(l.vi_),
-        cov_lower_(
-            ChainableStack.memalloc_.alloc_array<vari*>(size_ltri_)),
-        cov_diag_(
-            ChainableStack.memalloc_.alloc_array<vari*>(size_)) {
+        cov_lower_(ChainableStack.memalloc_.alloc_array<vari*>(size_ltri_)),
+        cov_diag_(ChainableStack.memalloc_.alloc_array<vari*>(size_)) {
     double inv_half_sq_l_d = 0.5 / (l_d_ * l_d_);
     size_t pos = 0;
     for (size_t j = 0; j < size_ - 1; ++j) {

--- a/stan/math/rev/mat/fun/cov_exp_quad.hpp
+++ b/stan/math/rev/mat/fun/cov_exp_quad.hpp
@@ -72,14 +72,14 @@ class cov_exp_quad_vari : public vari {
         l_d_(value_of(l)),
         sigma_d_(value_of(sigma)),
         sigma_sq_d_(sigma_d_ * sigma_d_),
-        dist_(ChainableStack::context().memalloc_.alloc_array<double>(
+        dist_(ChainableStack.memalloc_.alloc_array<double>(
             size_ltri_)),
         l_vari_(l.vi_),
         sigma_vari_(sigma.vi_),
         cov_lower_(
-            ChainableStack::context().memalloc_.alloc_array<vari*>(size_ltri_)),
+            ChainableStack.memalloc_.alloc_array<vari*>(size_ltri_)),
         cov_diag_(
-            ChainableStack::context().memalloc_.alloc_array<vari*>(size_)) {
+            ChainableStack.memalloc_.alloc_array<vari*>(size_)) {
     double inv_half_sq_l_d = 0.5 / (l_d_ * l_d_);
     size_t pos = 0;
     for (size_t j = 0; j < size_ - 1; ++j) {
@@ -164,13 +164,13 @@ class cov_exp_quad_vari<T_x, double, T_l> : public vari {
         l_d_(value_of(l)),
         sigma_d_(value_of(sigma)),
         sigma_sq_d_(sigma_d_ * sigma_d_),
-        dist_(ChainableStack::context().memalloc_.alloc_array<double>(
+        dist_(ChainableStack.memalloc_.alloc_array<double>(
             size_ltri_)),
         l_vari_(l.vi_),
         cov_lower_(
-            ChainableStack::context().memalloc_.alloc_array<vari*>(size_ltri_)),
+            ChainableStack.memalloc_.alloc_array<vari*>(size_ltri_)),
         cov_diag_(
-            ChainableStack::context().memalloc_.alloc_array<vari*>(size_)) {
+            ChainableStack.memalloc_.alloc_array<vari*>(size_)) {
     double inv_half_sq_l_d = 0.5 / (l_d_ * l_d_);
     size_t pos = 0;
     for (size_t j = 0; j < size_ - 1; ++j) {

--- a/stan/math/rev/mat/fun/determinant.hpp
+++ b/stan/math/rev/mat/fun/determinant.hpp
@@ -26,9 +26,8 @@ class determinant_vari : public vari {
         cols_(A.cols()),
         A_(reinterpret_cast<double*>(ChainableStack.memalloc_.alloc(
             sizeof(double) * A.rows() * A.cols()))),
-        adjARef_(
-            reinterpret_cast<vari**>(ChainableStack.memalloc_.alloc(
-                sizeof(vari*) * A.rows() * A.cols()))) {
+        adjARef_(reinterpret_cast<vari**>(ChainableStack.memalloc_.alloc(
+            sizeof(vari*) * A.rows() * A.cols()))) {
     size_t pos = 0;
     for (size_type j = 0; j < cols_; j++) {
       for (size_type i = 0; i < rows_; i++) {

--- a/stan/math/rev/mat/fun/determinant.hpp
+++ b/stan/math/rev/mat/fun/determinant.hpp
@@ -24,10 +24,10 @@ class determinant_vari : public vari {
       : vari(determinant_vari_calc(A)),
         rows_(A.rows()),
         cols_(A.cols()),
-        A_(reinterpret_cast<double*>(ChainableStack::context().memalloc_.alloc(
+        A_(reinterpret_cast<double*>(ChainableStack.memalloc_.alloc(
             sizeof(double) * A.rows() * A.cols()))),
         adjARef_(
-            reinterpret_cast<vari**>(ChainableStack::context().memalloc_.alloc(
+            reinterpret_cast<vari**>(ChainableStack.memalloc_.alloc(
                 sizeof(vari*) * A.rows() * A.cols()))) {
     size_t pos = 0;
     for (size_type j = 0; j < cols_; j++) {

--- a/stan/math/rev/mat/fun/dot_product.hpp
+++ b/stan/math/rev/mat/fun/dot_product.hpp
@@ -85,7 +85,7 @@ class dot_product_vari : public vari {
                          vari** shared = nullptr) {
     if (shared == nullptr) {
       mem_v = reinterpret_cast<vari**>(
-          ChainableStack::context().memalloc_.alloc(length_ * sizeof(vari*)));
+          ChainableStack.memalloc_.alloc(length_ * sizeof(vari*)));
       for (size_t i = 0; i < length_; i++)
         mem_v[i] = inv[i].vi_;
     } else {
@@ -97,7 +97,7 @@ class dot_product_vari : public vari {
                          vari** shared = nullptr) {
     if (shared == nullptr) {
       mem_v = reinterpret_cast<vari**>(
-          ChainableStack::context().memalloc_.alloc(length_ * sizeof(vari*)));
+          ChainableStack.memalloc_.alloc(length_ * sizeof(vari*)));
       for (size_t i = 0; i < length_; i++)
         mem_v[i] = inv(i).vi_;
     } else {
@@ -109,7 +109,7 @@ class dot_product_vari : public vari {
                          double* shared = nullptr) {
     if (shared == nullptr) {
       mem_d = reinterpret_cast<double*>(
-          ChainableStack::context().memalloc_.alloc(length_ * sizeof(double)));
+          ChainableStack.memalloc_.alloc(length_ * sizeof(double)));
       for (size_t i = 0; i < length_; i++)
         mem_d[i] = ind[i];
     } else {
@@ -121,7 +121,7 @@ class dot_product_vari : public vari {
                          double* shared = nullptr) {
     if (shared == nullptr) {
       mem_d = reinterpret_cast<double*>(
-          ChainableStack::context().memalloc_.alloc(length_ * sizeof(double)));
+          ChainableStack.memalloc_.alloc(length_ * sizeof(double)));
       for (size_t i = 0; i < length_; i++)
         mem_d[i] = ind(i);
     } else {

--- a/stan/math/rev/mat/fun/dot_self.hpp
+++ b/stan/math/rev/mat/fun/dot_self.hpp
@@ -24,7 +24,7 @@ class dot_self_vari : public vari {
   explicit dot_self_vari(const Eigen::DenseBase<Derived>& v)
       : vari(var_dot_self(v)), size_(v.size()) {
     v_ = reinterpret_cast<vari**>(
-        ChainableStack::context().memalloc_.alloc(size_ * sizeof(vari*)));
+        ChainableStack.memalloc_.alloc(size_ * sizeof(vari*)));
     for (size_t i = 0; i < size_; i++)
       v_[i] = v[i].vi_;
   }
@@ -32,7 +32,7 @@ class dot_self_vari : public vari {
   explicit dot_self_vari(const Eigen::Matrix<var, R, C>& v)
       : vari(var_dot_self(v)), size_(v.size()) {
     v_ = reinterpret_cast<vari**>(
-        ChainableStack::context().memalloc_.alloc(size_ * sizeof(vari*)));
+        ChainableStack.memalloc_.alloc(size_ * sizeof(vari*)));
     for (size_t i = 0; i < size_; ++i)
       v_[i] = v(i).vi_;
   }

--- a/stan/math/rev/mat/fun/log_determinant.hpp
+++ b/stan/math/rev/mat/fun/log_determinant.hpp
@@ -23,14 +23,12 @@ inline var log_determinant(const Eigen::Matrix<var, R, C>& m) {
 
   double val = hh.logAbsDeterminant();
 
-  vari** varis
-      = ChainableStack.memalloc_.alloc_array<vari*>(m.size());
+  vari** varis = ChainableStack.memalloc_.alloc_array<vari*>(m.size());
   for (int i = 0; i < m.size(); ++i)
     varis[i] = m(i).vi_;
 
   Matrix<double, R, C> m_inv_transpose = hh.inverse().transpose();
-  double* gradients
-      = ChainableStack.memalloc_.alloc_array<double>(m.size());
+  double* gradients = ChainableStack.memalloc_.alloc_array<double>(m.size());
   for (int i = 0; i < m.size(); ++i)
     gradients[i] = m_inv_transpose(i);
 

--- a/stan/math/rev/mat/fun/log_determinant.hpp
+++ b/stan/math/rev/mat/fun/log_determinant.hpp
@@ -24,13 +24,13 @@ inline var log_determinant(const Eigen::Matrix<var, R, C>& m) {
   double val = hh.logAbsDeterminant();
 
   vari** varis
-      = ChainableStack::context().memalloc_.alloc_array<vari*>(m.size());
+      = ChainableStack.memalloc_.alloc_array<vari*>(m.size());
   for (int i = 0; i < m.size(); ++i)
     varis[i] = m(i).vi_;
 
   Matrix<double, R, C> m_inv_transpose = hh.inverse().transpose();
   double* gradients
-      = ChainableStack::context().memalloc_.alloc_array<double>(m.size());
+      = ChainableStack.memalloc_.alloc_array<double>(m.size());
   for (int i = 0; i < m.size(); ++i)
     gradients[i] = m_inv_transpose(i);
 

--- a/stan/math/rev/mat/fun/log_determinant_spd.hpp
+++ b/stan/math/rev/mat/fun/log_determinant_spd.hpp
@@ -42,13 +42,11 @@ inline var log_determinant_spd(const Eigen::Matrix<var, R, C>& m) {
   check_finite("log_determinant_spd",
                "log determininant of the matrix argument", val);
 
-  vari** operands
-      = ChainableStack.memalloc_.alloc_array<vari*>(m.size());
+  vari** operands = ChainableStack.memalloc_.alloc_array<vari*>(m.size());
   for (int i = 0; i < m.size(); ++i)
     operands[i] = m(i).vi_;
 
-  double* gradients
-      = ChainableStack.memalloc_.alloc_array<double>(m.size());
+  double* gradients = ChainableStack.memalloc_.alloc_array<double>(m.size());
   for (int i = 0; i < m.size(); ++i)
     gradients[i] = m_d(i);
 

--- a/stan/math/rev/mat/fun/log_determinant_spd.hpp
+++ b/stan/math/rev/mat/fun/log_determinant_spd.hpp
@@ -43,12 +43,12 @@ inline var log_determinant_spd(const Eigen::Matrix<var, R, C>& m) {
                "log determininant of the matrix argument", val);
 
   vari** operands
-      = ChainableStack::context().memalloc_.alloc_array<vari*>(m.size());
+      = ChainableStack.memalloc_.alloc_array<vari*>(m.size());
   for (int i = 0; i < m.size(); ++i)
     operands[i] = m(i).vi_;
 
   double* gradients
-      = ChainableStack::context().memalloc_.alloc_array<double>(m.size());
+      = ChainableStack.memalloc_.alloc_array<double>(m.size());
   for (int i = 0; i < m.size(); ++i)
     gradients[i] = m_d(i);
 

--- a/stan/math/rev/mat/fun/mdivide_left.hpp
+++ b/stan/math/rev/mat/fun/mdivide_left.hpp
@@ -33,15 +33,12 @@ class mdivide_left_vv_vari : public vari {
             sizeof(double) * A.rows() * A.cols()))),
         C_(reinterpret_cast<double *>(ChainableStack.memalloc_.alloc(
             sizeof(double) * B.rows() * B.cols()))),
-        variRefA_(
-            reinterpret_cast<vari **>(ChainableStack.memalloc_.alloc(
-                sizeof(vari *) * A.rows() * A.cols()))),
-        variRefB_(
-            reinterpret_cast<vari **>(ChainableStack.memalloc_.alloc(
-                sizeof(vari *) * B.rows() * B.cols()))),
-        variRefC_(
-            reinterpret_cast<vari **>(ChainableStack.memalloc_.alloc(
-                sizeof(vari *) * B.rows() * B.cols()))) {
+        variRefA_(reinterpret_cast<vari **>(ChainableStack.memalloc_.alloc(
+            sizeof(vari *) * A.rows() * A.cols()))),
+        variRefB_(reinterpret_cast<vari **>(ChainableStack.memalloc_.alloc(
+            sizeof(vari *) * B.rows() * B.cols()))),
+        variRefC_(reinterpret_cast<vari **>(ChainableStack.memalloc_.alloc(
+            sizeof(vari *) * B.rows() * B.cols()))) {
     using Eigen::Map;
     using Eigen::Matrix;
 
@@ -126,12 +123,10 @@ class mdivide_left_dv_vari : public vari {
             sizeof(double) * A.rows() * A.cols()))),
         C_(reinterpret_cast<double *>(ChainableStack.memalloc_.alloc(
             sizeof(double) * B.rows() * B.cols()))),
-        variRefB_(
-            reinterpret_cast<vari **>(ChainableStack.memalloc_.alloc(
-                sizeof(vari *) * B.rows() * B.cols()))),
-        variRefC_(
-            reinterpret_cast<vari **>(ChainableStack.memalloc_.alloc(
-                sizeof(vari *) * B.rows() * B.cols()))) {
+        variRefB_(reinterpret_cast<vari **>(ChainableStack.memalloc_.alloc(
+            sizeof(vari *) * B.rows() * B.cols()))),
+        variRefC_(reinterpret_cast<vari **>(ChainableStack.memalloc_.alloc(
+            sizeof(vari *) * B.rows() * B.cols()))) {
     using Eigen::Map;
     using Eigen::Matrix;
 
@@ -207,12 +202,10 @@ class mdivide_left_vd_vari : public vari {
             sizeof(double) * A.rows() * A.cols()))),
         C_(reinterpret_cast<double *>(ChainableStack.memalloc_.alloc(
             sizeof(double) * B.rows() * B.cols()))),
-        variRefA_(
-            reinterpret_cast<vari **>(ChainableStack.memalloc_.alloc(
-                sizeof(vari *) * A.rows() * A.cols()))),
-        variRefC_(
-            reinterpret_cast<vari **>(ChainableStack.memalloc_.alloc(
-                sizeof(vari *) * B.rows() * B.cols()))) {
+        variRefA_(reinterpret_cast<vari **>(ChainableStack.memalloc_.alloc(
+            sizeof(vari *) * A.rows() * A.cols()))),
+        variRefC_(reinterpret_cast<vari **>(ChainableStack.memalloc_.alloc(
+            sizeof(vari *) * B.rows() * B.cols()))) {
     using Eigen::Map;
     using Eigen::Matrix;
 

--- a/stan/math/rev/mat/fun/mdivide_left.hpp
+++ b/stan/math/rev/mat/fun/mdivide_left.hpp
@@ -29,18 +29,18 @@ class mdivide_left_vv_vari : public vari {
       : vari(0.0),
         M_(A.rows()),
         N_(B.cols()),
-        A_(reinterpret_cast<double *>(ChainableStack::context().memalloc_.alloc(
+        A_(reinterpret_cast<double *>(ChainableStack.memalloc_.alloc(
             sizeof(double) * A.rows() * A.cols()))),
-        C_(reinterpret_cast<double *>(ChainableStack::context().memalloc_.alloc(
+        C_(reinterpret_cast<double *>(ChainableStack.memalloc_.alloc(
             sizeof(double) * B.rows() * B.cols()))),
         variRefA_(
-            reinterpret_cast<vari **>(ChainableStack::context().memalloc_.alloc(
+            reinterpret_cast<vari **>(ChainableStack.memalloc_.alloc(
                 sizeof(vari *) * A.rows() * A.cols()))),
         variRefB_(
-            reinterpret_cast<vari **>(ChainableStack::context().memalloc_.alloc(
+            reinterpret_cast<vari **>(ChainableStack.memalloc_.alloc(
                 sizeof(vari *) * B.rows() * B.cols()))),
         variRefC_(
-            reinterpret_cast<vari **>(ChainableStack::context().memalloc_.alloc(
+            reinterpret_cast<vari **>(ChainableStack.memalloc_.alloc(
                 sizeof(vari *) * B.rows() * B.cols()))) {
     using Eigen::Map;
     using Eigen::Matrix;
@@ -122,15 +122,15 @@ class mdivide_left_dv_vari : public vari {
       : vari(0.0),
         M_(A.rows()),
         N_(B.cols()),
-        A_(reinterpret_cast<double *>(ChainableStack::context().memalloc_.alloc(
+        A_(reinterpret_cast<double *>(ChainableStack.memalloc_.alloc(
             sizeof(double) * A.rows() * A.cols()))),
-        C_(reinterpret_cast<double *>(ChainableStack::context().memalloc_.alloc(
+        C_(reinterpret_cast<double *>(ChainableStack.memalloc_.alloc(
             sizeof(double) * B.rows() * B.cols()))),
         variRefB_(
-            reinterpret_cast<vari **>(ChainableStack::context().memalloc_.alloc(
+            reinterpret_cast<vari **>(ChainableStack.memalloc_.alloc(
                 sizeof(vari *) * B.rows() * B.cols()))),
         variRefC_(
-            reinterpret_cast<vari **>(ChainableStack::context().memalloc_.alloc(
+            reinterpret_cast<vari **>(ChainableStack.memalloc_.alloc(
                 sizeof(vari *) * B.rows() * B.cols()))) {
     using Eigen::Map;
     using Eigen::Matrix;
@@ -203,15 +203,15 @@ class mdivide_left_vd_vari : public vari {
       : vari(0.0),
         M_(A.rows()),
         N_(B.cols()),
-        A_(reinterpret_cast<double *>(ChainableStack::context().memalloc_.alloc(
+        A_(reinterpret_cast<double *>(ChainableStack.memalloc_.alloc(
             sizeof(double) * A.rows() * A.cols()))),
-        C_(reinterpret_cast<double *>(ChainableStack::context().memalloc_.alloc(
+        C_(reinterpret_cast<double *>(ChainableStack.memalloc_.alloc(
             sizeof(double) * B.rows() * B.cols()))),
         variRefA_(
-            reinterpret_cast<vari **>(ChainableStack::context().memalloc_.alloc(
+            reinterpret_cast<vari **>(ChainableStack.memalloc_.alloc(
                 sizeof(vari *) * A.rows() * A.cols()))),
         variRefC_(
-            reinterpret_cast<vari **>(ChainableStack::context().memalloc_.alloc(
+            reinterpret_cast<vari **>(ChainableStack.memalloc_.alloc(
                 sizeof(vari *) * B.rows() * B.cols()))) {
     using Eigen::Map;
     using Eigen::Matrix;

--- a/stan/math/rev/mat/fun/mdivide_left_ldlt.hpp
+++ b/stan/math/rev/mat/fun/mdivide_left_ldlt.hpp
@@ -50,10 +50,10 @@ class mdivide_left_ldlt_vv_vari : public vari {
         M_(A.rows()),
         N_(B.cols()),
         variRefB_(
-            reinterpret_cast<vari **>(ChainableStack::context().memalloc_.alloc(
+            reinterpret_cast<vari **>(ChainableStack.memalloc_.alloc(
                 sizeof(vari *) * B.rows() * B.cols()))),
         variRefC_(
-            reinterpret_cast<vari **>(ChainableStack::context().memalloc_.alloc(
+            reinterpret_cast<vari **>(ChainableStack.memalloc_.alloc(
                 sizeof(vari *) * B.rows() * B.cols()))),
         alloc_(new mdivide_left_ldlt_alloc<R1, C1, R2, C2>()),
         alloc_ldlt_(A.alloc_) {
@@ -126,10 +126,10 @@ class mdivide_left_ldlt_dv_vari : public vari {
         M_(A.rows()),
         N_(B.cols()),
         variRefB_(
-            reinterpret_cast<vari **>(ChainableStack::context().memalloc_.alloc(
+            reinterpret_cast<vari **>(ChainableStack.memalloc_.alloc(
                 sizeof(vari *) * B.rows() * B.cols()))),
         variRefC_(
-            reinterpret_cast<vari **>(ChainableStack::context().memalloc_.alloc(
+            reinterpret_cast<vari **>(ChainableStack.memalloc_.alloc(
                 sizeof(vari *) * B.rows() * B.cols()))),
         alloc_(new mdivide_left_ldlt_alloc<R1, C1, R2, C2>()) {
     using Eigen::Map;
@@ -199,7 +199,7 @@ class mdivide_left_ldlt_vd_vari : public vari {
         M_(A.rows()),
         N_(B.cols()),
         variRefC_(
-            reinterpret_cast<vari **>(ChainableStack::context().memalloc_.alloc(
+            reinterpret_cast<vari **>(ChainableStack.memalloc_.alloc(
                 sizeof(vari *) * B.rows() * B.cols()))),
         alloc_(new mdivide_left_ldlt_alloc<R1, C1, R2, C2>()),
         alloc_ldlt_(A.alloc_) {

--- a/stan/math/rev/mat/fun/mdivide_left_ldlt.hpp
+++ b/stan/math/rev/mat/fun/mdivide_left_ldlt.hpp
@@ -49,12 +49,10 @@ class mdivide_left_ldlt_vv_vari : public vari {
       : vari(0.0),
         M_(A.rows()),
         N_(B.cols()),
-        variRefB_(
-            reinterpret_cast<vari **>(ChainableStack.memalloc_.alloc(
-                sizeof(vari *) * B.rows() * B.cols()))),
-        variRefC_(
-            reinterpret_cast<vari **>(ChainableStack.memalloc_.alloc(
-                sizeof(vari *) * B.rows() * B.cols()))),
+        variRefB_(reinterpret_cast<vari **>(ChainableStack.memalloc_.alloc(
+            sizeof(vari *) * B.rows() * B.cols()))),
+        variRefC_(reinterpret_cast<vari **>(ChainableStack.memalloc_.alloc(
+            sizeof(vari *) * B.rows() * B.cols()))),
         alloc_(new mdivide_left_ldlt_alloc<R1, C1, R2, C2>()),
         alloc_ldlt_(A.alloc_) {
     int pos = 0;
@@ -125,12 +123,10 @@ class mdivide_left_ldlt_dv_vari : public vari {
       : vari(0.0),
         M_(A.rows()),
         N_(B.cols()),
-        variRefB_(
-            reinterpret_cast<vari **>(ChainableStack.memalloc_.alloc(
-                sizeof(vari *) * B.rows() * B.cols()))),
-        variRefC_(
-            reinterpret_cast<vari **>(ChainableStack.memalloc_.alloc(
-                sizeof(vari *) * B.rows() * B.cols()))),
+        variRefB_(reinterpret_cast<vari **>(ChainableStack.memalloc_.alloc(
+            sizeof(vari *) * B.rows() * B.cols()))),
+        variRefC_(reinterpret_cast<vari **>(ChainableStack.memalloc_.alloc(
+            sizeof(vari *) * B.rows() * B.cols()))),
         alloc_(new mdivide_left_ldlt_alloc<R1, C1, R2, C2>()) {
     using Eigen::Map;
     using Eigen::Matrix;
@@ -198,9 +194,8 @@ class mdivide_left_ldlt_vd_vari : public vari {
       : vari(0.0),
         M_(A.rows()),
         N_(B.cols()),
-        variRefC_(
-            reinterpret_cast<vari **>(ChainableStack.memalloc_.alloc(
-                sizeof(vari *) * B.rows() * B.cols()))),
+        variRefC_(reinterpret_cast<vari **>(ChainableStack.memalloc_.alloc(
+            sizeof(vari *) * B.rows() * B.cols()))),
         alloc_(new mdivide_left_ldlt_alloc<R1, C1, R2, C2>()),
         alloc_ldlt_(A.alloc_) {
     alloc_->C_ = B;

--- a/stan/math/rev/mat/fun/mdivide_left_spd.hpp
+++ b/stan/math/rev/mat/fun/mdivide_left_spd.hpp
@@ -37,15 +37,12 @@ class mdivide_left_spd_vv_vari : public vari {
       : vari(0.0),
         M_(A.rows()),
         N_(B.cols()),
-        variRefA_(
-            reinterpret_cast<vari **>(ChainableStack.memalloc_.alloc(
-                sizeof(vari *) * A.rows() * A.cols()))),
-        variRefB_(
-            reinterpret_cast<vari **>(ChainableStack.memalloc_.alloc(
-                sizeof(vari *) * B.rows() * B.cols()))),
-        variRefC_(
-            reinterpret_cast<vari **>(ChainableStack.memalloc_.alloc(
-                sizeof(vari *) * B.rows() * B.cols()))),
+        variRefA_(reinterpret_cast<vari **>(ChainableStack.memalloc_.alloc(
+            sizeof(vari *) * A.rows() * A.cols()))),
+        variRefB_(reinterpret_cast<vari **>(ChainableStack.memalloc_.alloc(
+            sizeof(vari *) * B.rows() * B.cols()))),
+        variRefC_(reinterpret_cast<vari **>(ChainableStack.memalloc_.alloc(
+            sizeof(vari *) * B.rows() * B.cols()))),
         alloc_(new mdivide_left_spd_alloc<R1, C1, R2, C2>()) {
     using Eigen::Map;
     using Eigen::Matrix;
@@ -123,12 +120,10 @@ class mdivide_left_spd_dv_vari : public vari {
       : vari(0.0),
         M_(A.rows()),
         N_(B.cols()),
-        variRefB_(
-            reinterpret_cast<vari **>(ChainableStack.memalloc_.alloc(
-                sizeof(vari *) * B.rows() * B.cols()))),
-        variRefC_(
-            reinterpret_cast<vari **>(ChainableStack.memalloc_.alloc(
-                sizeof(vari *) * B.rows() * B.cols()))),
+        variRefB_(reinterpret_cast<vari **>(ChainableStack.memalloc_.alloc(
+            sizeof(vari *) * B.rows() * B.cols()))),
+        variRefC_(reinterpret_cast<vari **>(ChainableStack.memalloc_.alloc(
+            sizeof(vari *) * B.rows() * B.cols()))),
         alloc_(new mdivide_left_spd_alloc<R1, C1, R2, C2>()) {
     using Eigen::Map;
     using Eigen::Matrix;
@@ -188,12 +183,10 @@ class mdivide_left_spd_vd_vari : public vari {
       : vari(0.0),
         M_(A.rows()),
         N_(B.cols()),
-        variRefA_(
-            reinterpret_cast<vari **>(ChainableStack.memalloc_.alloc(
-                sizeof(vari *) * A.rows() * A.cols()))),
-        variRefC_(
-            reinterpret_cast<vari **>(ChainableStack.memalloc_.alloc(
-                sizeof(vari *) * B.rows() * B.cols()))),
+        variRefA_(reinterpret_cast<vari **>(ChainableStack.memalloc_.alloc(
+            sizeof(vari *) * A.rows() * A.cols()))),
+        variRefC_(reinterpret_cast<vari **>(ChainableStack.memalloc_.alloc(
+            sizeof(vari *) * B.rows() * B.cols()))),
         alloc_(new mdivide_left_spd_alloc<R1, C1, R2, C2>()) {
     using Eigen::Map;
     using Eigen::Matrix;

--- a/stan/math/rev/mat/fun/mdivide_left_spd.hpp
+++ b/stan/math/rev/mat/fun/mdivide_left_spd.hpp
@@ -38,13 +38,13 @@ class mdivide_left_spd_vv_vari : public vari {
         M_(A.rows()),
         N_(B.cols()),
         variRefA_(
-            reinterpret_cast<vari **>(ChainableStack::context().memalloc_.alloc(
+            reinterpret_cast<vari **>(ChainableStack.memalloc_.alloc(
                 sizeof(vari *) * A.rows() * A.cols()))),
         variRefB_(
-            reinterpret_cast<vari **>(ChainableStack::context().memalloc_.alloc(
+            reinterpret_cast<vari **>(ChainableStack.memalloc_.alloc(
                 sizeof(vari *) * B.rows() * B.cols()))),
         variRefC_(
-            reinterpret_cast<vari **>(ChainableStack::context().memalloc_.alloc(
+            reinterpret_cast<vari **>(ChainableStack.memalloc_.alloc(
                 sizeof(vari *) * B.rows() * B.cols()))),
         alloc_(new mdivide_left_spd_alloc<R1, C1, R2, C2>()) {
     using Eigen::Map;
@@ -124,10 +124,10 @@ class mdivide_left_spd_dv_vari : public vari {
         M_(A.rows()),
         N_(B.cols()),
         variRefB_(
-            reinterpret_cast<vari **>(ChainableStack::context().memalloc_.alloc(
+            reinterpret_cast<vari **>(ChainableStack.memalloc_.alloc(
                 sizeof(vari *) * B.rows() * B.cols()))),
         variRefC_(
-            reinterpret_cast<vari **>(ChainableStack::context().memalloc_.alloc(
+            reinterpret_cast<vari **>(ChainableStack.memalloc_.alloc(
                 sizeof(vari *) * B.rows() * B.cols()))),
         alloc_(new mdivide_left_spd_alloc<R1, C1, R2, C2>()) {
     using Eigen::Map;
@@ -189,10 +189,10 @@ class mdivide_left_spd_vd_vari : public vari {
         M_(A.rows()),
         N_(B.cols()),
         variRefA_(
-            reinterpret_cast<vari **>(ChainableStack::context().memalloc_.alloc(
+            reinterpret_cast<vari **>(ChainableStack.memalloc_.alloc(
                 sizeof(vari *) * A.rows() * A.cols()))),
         variRefC_(
-            reinterpret_cast<vari **>(ChainableStack::context().memalloc_.alloc(
+            reinterpret_cast<vari **>(ChainableStack.memalloc_.alloc(
                 sizeof(vari *) * B.rows() * B.cols()))),
         alloc_(new mdivide_left_spd_alloc<R1, C1, R2, C2>()) {
     using Eigen::Map;

--- a/stan/math/rev/mat/fun/mdivide_left_tri.hpp
+++ b/stan/math/rev/mat/fun/mdivide_left_tri.hpp
@@ -29,18 +29,18 @@ class mdivide_left_tri_vv_vari : public vari {
       : vari(0.0),
         M_(A.rows()),
         N_(B.cols()),
-        A_(reinterpret_cast<double *>(ChainableStack::context().memalloc_.alloc(
+        A_(reinterpret_cast<double *>(ChainableStack.memalloc_.alloc(
             sizeof(double) * A.rows() * A.cols()))),
-        C_(reinterpret_cast<double *>(ChainableStack::context().memalloc_.alloc(
+        C_(reinterpret_cast<double *>(ChainableStack.memalloc_.alloc(
             sizeof(double) * B.rows() * B.cols()))),
         variRefA_(
-            reinterpret_cast<vari **>(ChainableStack::context().memalloc_.alloc(
+            reinterpret_cast<vari **>(ChainableStack.memalloc_.alloc(
                 sizeof(vari *) * A.rows() * (A.rows() + 1) / 2))),
         variRefB_(
-            reinterpret_cast<vari **>(ChainableStack::context().memalloc_.alloc(
+            reinterpret_cast<vari **>(ChainableStack.memalloc_.alloc(
                 sizeof(vari *) * B.rows() * B.cols()))),
         variRefC_(
-            reinterpret_cast<vari **>(ChainableStack::context().memalloc_.alloc(
+            reinterpret_cast<vari **>(ChainableStack.memalloc_.alloc(
                 sizeof(vari *) * B.rows() * B.cols()))) {
     using Eigen::Map;
     using Eigen::Matrix;
@@ -140,15 +140,15 @@ class mdivide_left_tri_dv_vari : public vari {
       : vari(0.0),
         M_(A.rows()),
         N_(B.cols()),
-        A_(reinterpret_cast<double *>(ChainableStack::context().memalloc_.alloc(
+        A_(reinterpret_cast<double *>(ChainableStack.memalloc_.alloc(
             sizeof(double) * A.rows() * A.cols()))),
-        C_(reinterpret_cast<double *>(ChainableStack::context().memalloc_.alloc(
+        C_(reinterpret_cast<double *>(ChainableStack.memalloc_.alloc(
             sizeof(double) * B.rows() * B.cols()))),
         variRefB_(
-            reinterpret_cast<vari **>(ChainableStack::context().memalloc_.alloc(
+            reinterpret_cast<vari **>(ChainableStack.memalloc_.alloc(
                 sizeof(vari *) * B.rows() * B.cols()))),
         variRefC_(
-            reinterpret_cast<vari **>(ChainableStack::context().memalloc_.alloc(
+            reinterpret_cast<vari **>(ChainableStack.memalloc_.alloc(
                 sizeof(vari *) * B.rows() * B.cols()))) {
     using Eigen::Map;
     using Eigen::Matrix;
@@ -223,15 +223,15 @@ class mdivide_left_tri_vd_vari : public vari {
       : vari(0.0),
         M_(A.rows()),
         N_(B.cols()),
-        A_(reinterpret_cast<double *>(ChainableStack::context().memalloc_.alloc(
+        A_(reinterpret_cast<double *>(ChainableStack.memalloc_.alloc(
             sizeof(double) * A.rows() * A.cols()))),
-        C_(reinterpret_cast<double *>(ChainableStack::context().memalloc_.alloc(
+        C_(reinterpret_cast<double *>(ChainableStack.memalloc_.alloc(
             sizeof(double) * B.rows() * B.cols()))),
         variRefA_(
-            reinterpret_cast<vari **>(ChainableStack::context().memalloc_.alloc(
+            reinterpret_cast<vari **>(ChainableStack.memalloc_.alloc(
                 sizeof(vari *) * A.rows() * (A.rows() + 1) / 2))),
         variRefC_(
-            reinterpret_cast<vari **>(ChainableStack::context().memalloc_.alloc(
+            reinterpret_cast<vari **>(ChainableStack.memalloc_.alloc(
                 sizeof(vari *) * B.rows() * B.cols()))) {
     using Eigen::Map;
     using Eigen::Matrix;

--- a/stan/math/rev/mat/fun/mdivide_left_tri.hpp
+++ b/stan/math/rev/mat/fun/mdivide_left_tri.hpp
@@ -33,15 +33,12 @@ class mdivide_left_tri_vv_vari : public vari {
             sizeof(double) * A.rows() * A.cols()))),
         C_(reinterpret_cast<double *>(ChainableStack.memalloc_.alloc(
             sizeof(double) * B.rows() * B.cols()))),
-        variRefA_(
-            reinterpret_cast<vari **>(ChainableStack.memalloc_.alloc(
-                sizeof(vari *) * A.rows() * (A.rows() + 1) / 2))),
-        variRefB_(
-            reinterpret_cast<vari **>(ChainableStack.memalloc_.alloc(
-                sizeof(vari *) * B.rows() * B.cols()))),
-        variRefC_(
-            reinterpret_cast<vari **>(ChainableStack.memalloc_.alloc(
-                sizeof(vari *) * B.rows() * B.cols()))) {
+        variRefA_(reinterpret_cast<vari **>(ChainableStack.memalloc_.alloc(
+            sizeof(vari *) * A.rows() * (A.rows() + 1) / 2))),
+        variRefB_(reinterpret_cast<vari **>(ChainableStack.memalloc_.alloc(
+            sizeof(vari *) * B.rows() * B.cols()))),
+        variRefC_(reinterpret_cast<vari **>(ChainableStack.memalloc_.alloc(
+            sizeof(vari *) * B.rows() * B.cols()))) {
     using Eigen::Map;
     using Eigen::Matrix;
 
@@ -144,12 +141,10 @@ class mdivide_left_tri_dv_vari : public vari {
             sizeof(double) * A.rows() * A.cols()))),
         C_(reinterpret_cast<double *>(ChainableStack.memalloc_.alloc(
             sizeof(double) * B.rows() * B.cols()))),
-        variRefB_(
-            reinterpret_cast<vari **>(ChainableStack.memalloc_.alloc(
-                sizeof(vari *) * B.rows() * B.cols()))),
-        variRefC_(
-            reinterpret_cast<vari **>(ChainableStack.memalloc_.alloc(
-                sizeof(vari *) * B.rows() * B.cols()))) {
+        variRefB_(reinterpret_cast<vari **>(ChainableStack.memalloc_.alloc(
+            sizeof(vari *) * B.rows() * B.cols()))),
+        variRefC_(reinterpret_cast<vari **>(ChainableStack.memalloc_.alloc(
+            sizeof(vari *) * B.rows() * B.cols()))) {
     using Eigen::Map;
     using Eigen::Matrix;
 
@@ -227,12 +222,10 @@ class mdivide_left_tri_vd_vari : public vari {
             sizeof(double) * A.rows() * A.cols()))),
         C_(reinterpret_cast<double *>(ChainableStack.memalloc_.alloc(
             sizeof(double) * B.rows() * B.cols()))),
-        variRefA_(
-            reinterpret_cast<vari **>(ChainableStack.memalloc_.alloc(
-                sizeof(vari *) * A.rows() * (A.rows() + 1) / 2))),
-        variRefC_(
-            reinterpret_cast<vari **>(ChainableStack.memalloc_.alloc(
-                sizeof(vari *) * B.rows() * B.cols()))) {
+        variRefA_(reinterpret_cast<vari **>(ChainableStack.memalloc_.alloc(
+            sizeof(vari *) * A.rows() * (A.rows() + 1) / 2))),
+        variRefC_(reinterpret_cast<vari **>(ChainableStack.memalloc_.alloc(
+            sizeof(vari *) * B.rows() * B.cols()))) {
     using Eigen::Map;
     using Eigen::Matrix;
 

--- a/stan/math/rev/mat/fun/multiply.hpp
+++ b/stan/math/rev/mat/fun/multiply.hpp
@@ -74,12 +74,10 @@ class multiply_mat_vari : public vari {
         B_size_(B.size()),
         Ad_(ChainableStack.memalloc_.alloc_array<double>(A_size_)),
         Bd_(ChainableStack.memalloc_.alloc_array<double>(B_size_)),
-        variRefA_(
-            ChainableStack.memalloc_.alloc_array<vari*>(A_size_)),
-        variRefB_(
-            ChainableStack.memalloc_.alloc_array<vari*>(B_size_)),
-        variRefAB_(ChainableStack.memalloc_.alloc_array<vari*>(
-            A_rows_ * B_cols_)) {
+        variRefA_(ChainableStack.memalloc_.alloc_array<vari*>(A_size_)),
+        variRefB_(ChainableStack.memalloc_.alloc_array<vari*>(B_size_)),
+        variRefAB_(
+            ChainableStack.memalloc_.alloc_array<vari*>(A_rows_ * B_cols_)) {
     using Eigen::Map;
     using Eigen::MatrixXd;
     for (size_type i = 0; i < A.size(); ++i) {
@@ -161,10 +159,8 @@ class multiply_mat_vari<Ta, 1, Ca, Tb, 1> : public vari {
         size_(A.cols()),
         Ad_(ChainableStack.memalloc_.alloc_array<double>(size_)),
         Bd_(ChainableStack.memalloc_.alloc_array<double>(size_)),
-        variRefA_(
-            ChainableStack.memalloc_.alloc_array<vari*>(size_)),
-        variRefB_(
-            ChainableStack.memalloc_.alloc_array<vari*>(size_)) {
+        variRefA_(ChainableStack.memalloc_.alloc_array<vari*>(size_)),
+        variRefB_(ChainableStack.memalloc_.alloc_array<vari*>(size_)) {
     using Eigen::Map;
     using Eigen::RowVectorXd;
     using Eigen::VectorXd;
@@ -251,10 +247,9 @@ class multiply_mat_vari<double, Ra, Ca, Tb, Cb> : public vari {
         B_size_(B.size()),
         Ad_(ChainableStack.memalloc_.alloc_array<double>(A_size_)),
         Bd_(ChainableStack.memalloc_.alloc_array<double>(B_size_)),
-        variRefB_(
-            ChainableStack.memalloc_.alloc_array<vari*>(B_size_)),
-        variRefAB_(ChainableStack.memalloc_.alloc_array<vari*>(
-            A_rows_ * B_cols_)) {
+        variRefB_(ChainableStack.memalloc_.alloc_array<vari*>(B_size_)),
+        variRefAB_(
+            ChainableStack.memalloc_.alloc_array<vari*>(A_rows_ * B_cols_)) {
     using Eigen::Map;
     using Eigen::MatrixXd;
     for (size_type i = 0; i < A.size(); ++i)
@@ -329,8 +324,7 @@ class multiply_mat_vari<double, 1, Ca, Tb, 1> : public vari {
         size_(A.cols()),
         Ad_(ChainableStack.memalloc_.alloc_array<double>(size_)),
         Bd_(ChainableStack.memalloc_.alloc_array<double>(size_)),
-        variRefB_(
-            ChainableStack.memalloc_.alloc_array<vari*>(size_)) {
+        variRefB_(ChainableStack.memalloc_.alloc_array<vari*>(size_)) {
     using Eigen::Map;
     using Eigen::RowVectorXd;
     using Eigen::VectorXd;
@@ -413,10 +407,9 @@ class multiply_mat_vari<Ta, Ra, Ca, double, Cb> : public vari {
         B_size_(B.size()),
         Ad_(ChainableStack.memalloc_.alloc_array<double>(A_size_)),
         Bd_(ChainableStack.memalloc_.alloc_array<double>(B_size_)),
-        variRefA_(
-            ChainableStack.memalloc_.alloc_array<vari*>(A_size_)),
-        variRefAB_(ChainableStack.memalloc_.alloc_array<vari*>(
-            A_rows_ * B_cols_)) {
+        variRefA_(ChainableStack.memalloc_.alloc_array<vari*>(A_size_)),
+        variRefAB_(
+            ChainableStack.memalloc_.alloc_array<vari*>(A_rows_ * B_cols_)) {
     using Eigen::Map;
     using Eigen::MatrixXd;
     for (size_type i = 0; i < A_size_; ++i) {
@@ -495,8 +488,7 @@ class multiply_mat_vari<Ta, 1, Ca, double, 1> : public vari {
         size_(A.cols()),
         Ad_(ChainableStack.memalloc_.alloc_array<double>(size_)),
         Bd_(ChainableStack.memalloc_.alloc_array<double>(size_)),
-        variRefA_(
-            ChainableStack.memalloc_.alloc_array<vari*>(size_)) {
+        variRefA_(ChainableStack.memalloc_.alloc_array<vari*>(size_)) {
     using Eigen::Map;
     using Eigen::RowVectorXd;
     using Eigen::VectorXd;

--- a/stan/math/rev/mat/fun/multiply.hpp
+++ b/stan/math/rev/mat/fun/multiply.hpp
@@ -72,13 +72,13 @@ class multiply_mat_vari : public vari {
         B_cols_(B.cols()),
         A_size_(A.size()),
         B_size_(B.size()),
-        Ad_(ChainableStack::context().memalloc_.alloc_array<double>(A_size_)),
-        Bd_(ChainableStack::context().memalloc_.alloc_array<double>(B_size_)),
+        Ad_(ChainableStack.memalloc_.alloc_array<double>(A_size_)),
+        Bd_(ChainableStack.memalloc_.alloc_array<double>(B_size_)),
         variRefA_(
-            ChainableStack::context().memalloc_.alloc_array<vari*>(A_size_)),
+            ChainableStack.memalloc_.alloc_array<vari*>(A_size_)),
         variRefB_(
-            ChainableStack::context().memalloc_.alloc_array<vari*>(B_size_)),
-        variRefAB_(ChainableStack::context().memalloc_.alloc_array<vari*>(
+            ChainableStack.memalloc_.alloc_array<vari*>(B_size_)),
+        variRefAB_(ChainableStack.memalloc_.alloc_array<vari*>(
             A_rows_ * B_cols_)) {
     using Eigen::Map;
     using Eigen::MatrixXd;
@@ -159,12 +159,12 @@ class multiply_mat_vari<Ta, 1, Ca, Tb, 1> : public vari {
                     const Eigen::Matrix<Tb, Ca, 1>& B)
       : vari(0.0),
         size_(A.cols()),
-        Ad_(ChainableStack::context().memalloc_.alloc_array<double>(size_)),
-        Bd_(ChainableStack::context().memalloc_.alloc_array<double>(size_)),
+        Ad_(ChainableStack.memalloc_.alloc_array<double>(size_)),
+        Bd_(ChainableStack.memalloc_.alloc_array<double>(size_)),
         variRefA_(
-            ChainableStack::context().memalloc_.alloc_array<vari*>(size_)),
+            ChainableStack.memalloc_.alloc_array<vari*>(size_)),
         variRefB_(
-            ChainableStack::context().memalloc_.alloc_array<vari*>(size_)) {
+            ChainableStack.memalloc_.alloc_array<vari*>(size_)) {
     using Eigen::Map;
     using Eigen::RowVectorXd;
     using Eigen::VectorXd;
@@ -249,11 +249,11 @@ class multiply_mat_vari<double, Ra, Ca, Tb, Cb> : public vari {
         B_cols_(B.cols()),
         A_size_(A.size()),
         B_size_(B.size()),
-        Ad_(ChainableStack::context().memalloc_.alloc_array<double>(A_size_)),
-        Bd_(ChainableStack::context().memalloc_.alloc_array<double>(B_size_)),
+        Ad_(ChainableStack.memalloc_.alloc_array<double>(A_size_)),
+        Bd_(ChainableStack.memalloc_.alloc_array<double>(B_size_)),
         variRefB_(
-            ChainableStack::context().memalloc_.alloc_array<vari*>(B_size_)),
-        variRefAB_(ChainableStack::context().memalloc_.alloc_array<vari*>(
+            ChainableStack.memalloc_.alloc_array<vari*>(B_size_)),
+        variRefAB_(ChainableStack.memalloc_.alloc_array<vari*>(
             A_rows_ * B_cols_)) {
     using Eigen::Map;
     using Eigen::MatrixXd;
@@ -327,10 +327,10 @@ class multiply_mat_vari<double, 1, Ca, Tb, 1> : public vari {
                     const Eigen::Matrix<Tb, Ca, 1>& B)
       : vari(0.0),
         size_(A.cols()),
-        Ad_(ChainableStack::context().memalloc_.alloc_array<double>(size_)),
-        Bd_(ChainableStack::context().memalloc_.alloc_array<double>(size_)),
+        Ad_(ChainableStack.memalloc_.alloc_array<double>(size_)),
+        Bd_(ChainableStack.memalloc_.alloc_array<double>(size_)),
         variRefB_(
-            ChainableStack::context().memalloc_.alloc_array<vari*>(size_)) {
+            ChainableStack.memalloc_.alloc_array<vari*>(size_)) {
     using Eigen::Map;
     using Eigen::RowVectorXd;
     using Eigen::VectorXd;
@@ -411,11 +411,11 @@ class multiply_mat_vari<Ta, Ra, Ca, double, Cb> : public vari {
         B_cols_(B.cols()),
         A_size_(A.size()),
         B_size_(B.size()),
-        Ad_(ChainableStack::context().memalloc_.alloc_array<double>(A_size_)),
-        Bd_(ChainableStack::context().memalloc_.alloc_array<double>(B_size_)),
+        Ad_(ChainableStack.memalloc_.alloc_array<double>(A_size_)),
+        Bd_(ChainableStack.memalloc_.alloc_array<double>(B_size_)),
         variRefA_(
-            ChainableStack::context().memalloc_.alloc_array<vari*>(A_size_)),
-        variRefAB_(ChainableStack::context().memalloc_.alloc_array<vari*>(
+            ChainableStack.memalloc_.alloc_array<vari*>(A_size_)),
+        variRefAB_(ChainableStack.memalloc_.alloc_array<vari*>(
             A_rows_ * B_cols_)) {
     using Eigen::Map;
     using Eigen::MatrixXd;
@@ -493,10 +493,10 @@ class multiply_mat_vari<Ta, 1, Ca, double, 1> : public vari {
                     const Eigen::Matrix<double, Ca, 1>& B)
       : vari(0.0),
         size_(A.cols()),
-        Ad_(ChainableStack::context().memalloc_.alloc_array<double>(size_)),
-        Bd_(ChainableStack::context().memalloc_.alloc_array<double>(size_)),
+        Ad_(ChainableStack.memalloc_.alloc_array<double>(size_)),
+        Bd_(ChainableStack.memalloc_.alloc_array<double>(size_)),
         variRefA_(
-            ChainableStack::context().memalloc_.alloc_array<vari*>(size_)) {
+            ChainableStack.memalloc_.alloc_array<vari*>(size_)) {
     using Eigen::Map;
     using Eigen::RowVectorXd;
     using Eigen::VectorXd;

--- a/stan/math/rev/mat/fun/multiply_lower_tri_self_transpose.hpp
+++ b/stan/math/rev/mat/fun/multiply_lower_tri_self_transpose.hpp
@@ -33,7 +33,7 @@ inline matrix_v multiply_lower_tri_self_transpose(const matrix_v& L) {
   else  // if (K < J)
     Knz = (K * (K + 1)) / 2;
   vari** vs = reinterpret_cast<vari**>(
-      ChainableStack::context().memalloc_.alloc(Knz * sizeof(vari*)));
+      ChainableStack.memalloc_.alloc(Knz * sizeof(vari*)));
   int pos = 0;
   for (int m = 0; m < K; ++m)
     for (int n = 0; n < ((J < (m + 1)) ? J : (m + 1)); ++n) {

--- a/stan/math/rev/mat/fun/sd.hpp
+++ b/stan/math/rev/mat/fun/sd.hpp
@@ -20,7 +20,7 @@ namespace {  // anonymous
 var calc_sd(size_t size, const var* dtrs) {
   using std::sqrt;
   vari** varis = reinterpret_cast<vari**>(
-      ChainableStack::context().memalloc_.alloc(size * sizeof(vari*)));
+      ChainableStack.memalloc_.alloc(size * sizeof(vari*)));
   for (size_t i = 0; i < size; ++i)
     varis[i] = dtrs[i].vi_;
   double sum = 0.0;
@@ -35,7 +35,7 @@ var calc_sd(size_t size, const var* dtrs) {
   double variance = sum_of_squares / (size - 1);
   double sd = sqrt(variance);
   double* partials = reinterpret_cast<double*>(
-      ChainableStack::context().memalloc_.alloc(size * sizeof(double)));
+      ChainableStack.memalloc_.alloc(size * sizeof(double)));
   if (sum_of_squares < 1e-20) {
     double grad_limit = 1 / std::sqrt(static_cast<double>(size));
     for (size_t i = 0; i < size; ++i)

--- a/stan/math/rev/mat/fun/softmax.hpp
+++ b/stan/math/rev/mat/fun/softmax.hpp
@@ -57,7 +57,7 @@ inline Eigen::Matrix<var, Eigen::Dynamic, 1> softmax(
   check_nonzero_size("softmax", "alpha", alpha);
 
   vari** alpha_vi_array = reinterpret_cast<vari**>(
-      ChainableStack::context().memalloc_.alloc(sizeof(vari*) * alpha.size()));
+      ChainableStack.memalloc_.alloc(sizeof(vari*) * alpha.size()));
   for (int i = 0; i < alpha.size(); ++i)
     alpha_vi_array[i] = alpha(i).vi_;
 
@@ -68,7 +68,7 @@ inline Eigen::Matrix<var, Eigen::Dynamic, 1> softmax(
   Matrix<double, Dynamic, 1> softmax_alpha_d = softmax(alpha_d);
 
   double* softmax_alpha_d_array
-      = reinterpret_cast<double*>(ChainableStack::context().memalloc_.alloc(
+      = reinterpret_cast<double*>(ChainableStack.memalloc_.alloc(
           sizeof(double) * alpha_d.size()));
   for (int i = 0; i < alpha_d.size(); ++i)
     softmax_alpha_d_array[i] = softmax_alpha_d(i);

--- a/stan/math/rev/mat/fun/softmax.hpp
+++ b/stan/math/rev/mat/fun/softmax.hpp
@@ -67,9 +67,8 @@ inline Eigen::Matrix<var, Eigen::Dynamic, 1> softmax(
 
   Matrix<double, Dynamic, 1> softmax_alpha_d = softmax(alpha_d);
 
-  double* softmax_alpha_d_array
-      = reinterpret_cast<double*>(ChainableStack.memalloc_.alloc(
-          sizeof(double) * alpha_d.size()));
+  double* softmax_alpha_d_array = reinterpret_cast<double*>(
+      ChainableStack.memalloc_.alloc(sizeof(double) * alpha_d.size()));
   for (int i = 0; i < alpha_d.size(); ++i)
     softmax_alpha_d_array[i] = softmax_alpha_d(i);
 

--- a/stan/math/rev/mat/fun/squared_distance.hpp
+++ b/stan/math/rev/mat/fun/squared_distance.hpp
@@ -44,12 +44,12 @@ class squared_distance_vv_vari : public vari {
                            const Eigen::Matrix<var, R2, C2>& v2)
       : vari(var_squared_distance(v1, v2)), length_(v1.size()) {
     v1_ = reinterpret_cast<vari**>(
-        ChainableStack::context().memalloc_.alloc(length_ * sizeof(vari*)));
+        ChainableStack.memalloc_.alloc(length_ * sizeof(vari*)));
     for (size_t i = 0; i < length_; i++)
       v1_[i] = v1(i).vi_;
 
     v2_ = reinterpret_cast<vari**>(
-        ChainableStack::context().memalloc_.alloc(length_ * sizeof(vari*)));
+        ChainableStack.memalloc_.alloc(length_ * sizeof(vari*)));
     for (size_t i = 0; i < length_; i++)
       v2_[i] = v2(i).vi_;
   }
@@ -88,12 +88,12 @@ class squared_distance_vd_vari : public vari {
                            const Eigen::Matrix<double, R2, C2>& v2)
       : vari(var_squared_distance(v1, v2)), length_(v1.size()) {
     v1_ = reinterpret_cast<vari**>(
-        ChainableStack::context().memalloc_.alloc(length_ * sizeof(vari*)));
+        ChainableStack.memalloc_.alloc(length_ * sizeof(vari*)));
     for (size_t i = 0; i < length_; i++)
       v1_[i] = v1(i).vi_;
 
     v2_ = reinterpret_cast<double*>(
-        ChainableStack::context().memalloc_.alloc(length_ * sizeof(double)));
+        ChainableStack.memalloc_.alloc(length_ * sizeof(double)));
     for (size_t i = 0; i < length_; i++)
       v2_[i] = v2(i);
   }

--- a/stan/math/rev/mat/fun/sum.hpp
+++ b/stan/math/rev/mat/fun/sum.hpp
@@ -27,11 +27,10 @@ class sum_eigen_v_vari : public sum_v_vari {
  public:
   template <int R1, int C1>
   explicit sum_eigen_v_vari(const Eigen::Matrix<var, R1, C1>& v1)
-      : sum_v_vari(
-            sum_of_val(v1),
-            reinterpret_cast<vari**>(ChainableStack.memalloc_.alloc(
-                v1.size() * sizeof(vari*))),
-            v1.size()) {
+      : sum_v_vari(sum_of_val(v1),
+                   reinterpret_cast<vari**>(ChainableStack.memalloc_.alloc(
+                       v1.size() * sizeof(vari*))),
+                   v1.size()) {
     for (size_t i = 0; i < length_; i++)
       v_[i] = v1(i).vi_;
   }

--- a/stan/math/rev/mat/fun/sum.hpp
+++ b/stan/math/rev/mat/fun/sum.hpp
@@ -29,7 +29,7 @@ class sum_eigen_v_vari : public sum_v_vari {
   explicit sum_eigen_v_vari(const Eigen::Matrix<var, R1, C1>& v1)
       : sum_v_vari(
             sum_of_val(v1),
-            reinterpret_cast<vari**>(ChainableStack::context().memalloc_.alloc(
+            reinterpret_cast<vari**>(ChainableStack.memalloc_.alloc(
                 v1.size() * sizeof(vari*))),
             v1.size()) {
     for (size_t i = 0; i < length_; i++)

--- a/stan/math/rev/mat/fun/tcrossprod.hpp
+++ b/stan/math/rev/mat/fun/tcrossprod.hpp
@@ -34,7 +34,7 @@ inline matrix_v tcrossprod(const matrix_v& M) {
   matrix_v MMt(M.rows(), M.rows());
 
   vari** vs
-      = reinterpret_cast<vari**>(ChainableStack::context().memalloc_.alloc(
+      = reinterpret_cast<vari**>(ChainableStack.memalloc_.alloc(
           (M.rows() * M.cols()) * sizeof(vari*)));
   int pos = 0;
   for (int m = 0; m < M.rows(); ++m)

--- a/stan/math/rev/mat/fun/tcrossprod.hpp
+++ b/stan/math/rev/mat/fun/tcrossprod.hpp
@@ -33,9 +33,8 @@ inline matrix_v tcrossprod(const matrix_v& M) {
 
   matrix_v MMt(M.rows(), M.rows());
 
-  vari** vs
-      = reinterpret_cast<vari**>(ChainableStack.memalloc_.alloc(
-          (M.rows() * M.cols()) * sizeof(vari*)));
+  vari** vs = reinterpret_cast<vari**>(
+      ChainableStack.memalloc_.alloc((M.rows() * M.cols()) * sizeof(vari*)));
   int pos = 0;
   for (int m = 0; m < M.rows(); ++m)
     for (int n = 0; n < M.cols(); ++n)

--- a/stan/math/rev/mat/fun/unit_vector_constrain.hpp
+++ b/stan/math/rev/mat/fun/unit_vector_constrain.hpp
@@ -58,7 +58,7 @@ Eigen::Matrix<var, R, C> unit_vector_constrain(
   check_nonzero_size("unit_vector", "y", y);
 
   vari** y_vi_array = reinterpret_cast<vari**>(
-      ChainableStack::context().memalloc_.alloc(sizeof(vari*) * y.size()));
+      ChainableStack.memalloc_.alloc(sizeof(vari*) * y.size()));
   for (int i = 0; i < y.size(); ++i)
     y_vi_array[i] = y.coeff(i).vi_;
 
@@ -71,7 +71,7 @@ Eigen::Matrix<var, R, C> unit_vector_constrain(
   Eigen::VectorXd unit_vector_d = y_d / norm;
 
   double* unit_vector_y_d_array = reinterpret_cast<double*>(
-      ChainableStack::context().memalloc_.alloc(sizeof(double) * y_d.size()));
+      ChainableStack.memalloc_.alloc(sizeof(double) * y_d.size()));
   for (int i = 0; i < y_d.size(); ++i)
     unit_vector_y_d_array[i] = unit_vector_d.coeff(i);
 

--- a/stan/math/rev/mat/fun/variance.hpp
+++ b/stan/math/rev/mat/fun/variance.hpp
@@ -15,7 +15,7 @@ namespace {
 
 inline var calc_variance(size_t size, const var* dtrs) {
   vari** varis = reinterpret_cast<vari**>(
-      ChainableStack::context().memalloc_.alloc(size * sizeof(vari*)));
+      ChainableStack.memalloc_.alloc(size * sizeof(vari*)));
   for (size_t i = 0; i < size; ++i)
     varis[i] = dtrs[i].vi_;
   double sum = 0.0;
@@ -29,7 +29,7 @@ inline var calc_variance(size_t size, const var* dtrs) {
   }
   double variance = sum_of_squares / (size - 1);
   double* partials = reinterpret_cast<double*>(
-      ChainableStack::context().memalloc_.alloc(size * sizeof(double)));
+      ChainableStack.memalloc_.alloc(size * sizeof(double)));
   double two_over_size_m1 = 2 / (size - 1);
   for (size_t i = 0; i < size; ++i)
     partials[i] = two_over_size_m1 * (dtrs[i].vi_->val_ - mean);

--- a/stan/math/rev/mat/functor/algebra_solver.hpp
+++ b/stan/math/rev/mat/functor/algebra_solver.hpp
@@ -48,8 +48,7 @@ struct algebra_solver_vari : public vari {
         y_size_(y.size()),
         x_size_(x.size()),
         theta_(ChainableStack.memalloc_.alloc_array<vari*>(x_size_)),
-        Jx_y_(ChainableStack.memalloc_.alloc_array<double>(
-            x_size_ * y_size_)) {
+        Jx_y_(ChainableStack.memalloc_.alloc_array<double>(x_size_ * y_size_)) {
     using Eigen::Map;
     using Eigen::MatrixXd;
     for (int i = 0; i < y.size(); ++i)

--- a/stan/math/rev/mat/functor/algebra_solver.hpp
+++ b/stan/math/rev/mat/functor/algebra_solver.hpp
@@ -44,11 +44,11 @@ struct algebra_solver_vari : public vari {
                       const Eigen::VectorXd& theta_dbl, Fx& fx,
                       std::ostream* msgs)
       : vari(theta_dbl(0)),
-        y_(ChainableStack::context().memalloc_.alloc_array<vari*>(y.size())),
+        y_(ChainableStack.memalloc_.alloc_array<vari*>(y.size())),
         y_size_(y.size()),
         x_size_(x.size()),
-        theta_(ChainableStack::context().memalloc_.alloc_array<vari*>(x_size_)),
-        Jx_y_(ChainableStack::context().memalloc_.alloc_array<double>(
+        theta_(ChainableStack.memalloc_.alloc_array<vari*>(x_size_)),
+        Jx_y_(ChainableStack.memalloc_.alloc_array<double>(
             x_size_ * y_size_)) {
     using Eigen::Map;
     using Eigen::MatrixXd;

--- a/stan/math/rev/scal/meta/operands_and_partials.hpp
+++ b/stan/math/rev/scal/meta/operands_and_partials.hpp
@@ -94,9 +94,9 @@ class operands_and_partials<Op1, Op2, Op3, Op4, Op5, var> {
   var build(double value) {
     size_t size = edge1_.size() + edge2_.size() + edge3_.size() + edge4_.size()
                   + edge5_.size();
-    vari** varis = ChainableStack::context().memalloc_.alloc_array<vari*>(size);
+    vari** varis = ChainableStack.memalloc_.alloc_array<vari*>(size);
     double* partials
-        = ChainableStack::context().memalloc_.alloc_array<double>(size);
+        = ChainableStack.memalloc_.alloc_array<double>(size);
     int idx = 0;
     edge1_.dump_operands(&varis[idx]);
     edge1_.dump_partials(&partials[idx]);

--- a/stan/math/rev/scal/meta/operands_and_partials.hpp
+++ b/stan/math/rev/scal/meta/operands_and_partials.hpp
@@ -95,8 +95,7 @@ class operands_and_partials<Op1, Op2, Op3, Op4, Op5, var> {
     size_t size = edge1_.size() + edge2_.size() + edge3_.size() + edge4_.size()
                   + edge5_.size();
     vari** varis = ChainableStack.memalloc_.alloc_array<vari*>(size);
-    double* partials
-        = ChainableStack.memalloc_.alloc_array<double>(size);
+    double* partials = ChainableStack.memalloc_.alloc_array<double>(size);
     int idx = 0;
     edge1_.dump_operands(&varis[idx]);
     edge1_.dump_partials(&partials[idx]);

--- a/test/unit/math/rev/arr/err/check_bounded_test.cpp
+++ b/test/unit/math/rev/arr/err/check_bounded_test.cpp
@@ -14,13 +14,13 @@ TEST(AgradRevErrorHandlingScalar, CheckBoundedVarCheckVectorized) {
   for (int i = 0; i < N; ++i)
     a.push_back(var(i));
 
-  size_t stack_size = stan::math::ChainableStack::context().var_stack_.size();
+  size_t stack_size = stan::math::ChainableStack.var_stack_.size();
 
   EXPECT_EQ(5U, stack_size);
   EXPECT_NO_THROW(check_bounded(function, "a", a, -1.0, 6.0));
 
   size_t stack_size_after_call
-      = stan::math::ChainableStack::context().var_stack_.size();
+      = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(5U, stack_size_after_call);
   stan::math::recover_memory();
 }

--- a/test/unit/math/rev/arr/err/check_bounded_test.cpp
+++ b/test/unit/math/rev/arr/err/check_bounded_test.cpp
@@ -19,8 +19,7 @@ TEST(AgradRevErrorHandlingScalar, CheckBoundedVarCheckVectorized) {
   EXPECT_EQ(5U, stack_size);
   EXPECT_NO_THROW(check_bounded(function, "a", a, -1.0, 6.0));
 
-  size_t stack_size_after_call
-      = stan::math::ChainableStack.var_stack_.size();
+  size_t stack_size_after_call = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(5U, stack_size_after_call);
   stan::math::recover_memory();
 }

--- a/test/unit/math/rev/arr/err/check_consistent_size_test.cpp
+++ b/test/unit/math/rev/arr/err/check_consistent_size_test.cpp
@@ -14,13 +14,13 @@ TEST(AgradRevErrorHandlingScalar, CheckConsistentSizeVarCheckVectorized) {
   for (int i = 0; i < N; ++i)
     a.push_back(var(i));
 
-  size_t stack_size = stan::math::ChainableStack::context().var_stack_.size();
+  size_t stack_size = stan::math::ChainableStack.var_stack_.size();
 
   EXPECT_EQ(5U, stack_size);
   EXPECT_NO_THROW(check_consistent_size(function, "a", a, 5U));
 
   size_t stack_size_after_call
-      = stan::math::ChainableStack::context().var_stack_.size();
+      = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(5U, stack_size_after_call);
   stan::math::recover_memory();
 }

--- a/test/unit/math/rev/arr/err/check_consistent_size_test.cpp
+++ b/test/unit/math/rev/arr/err/check_consistent_size_test.cpp
@@ -19,8 +19,7 @@ TEST(AgradRevErrorHandlingScalar, CheckConsistentSizeVarCheckVectorized) {
   EXPECT_EQ(5U, stack_size);
   EXPECT_NO_THROW(check_consistent_size(function, "a", a, 5U));
 
-  size_t stack_size_after_call
-      = stan::math::ChainableStack.var_stack_.size();
+  size_t stack_size_after_call = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(5U, stack_size_after_call);
   stan::math::recover_memory();
 }

--- a/test/unit/math/rev/arr/err/check_consistent_sizes_test.cpp
+++ b/test/unit/math/rev/arr/err/check_consistent_sizes_test.cpp
@@ -22,8 +22,7 @@ TEST(AgradRevErrorHandlingScalar, CheckConsistentSizeVarCheckVectorized) {
   EXPECT_EQ(10U, stack_size);
   EXPECT_NO_THROW(check_consistent_sizes(function, "a", a, "b", b));
 
-  size_t stack_size_after_call
-      = stan::math::ChainableStack.var_stack_.size();
+  size_t stack_size_after_call = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(10U, stack_size_after_call);
   stan::math::recover_memory();
 }

--- a/test/unit/math/rev/arr/err/check_consistent_sizes_test.cpp
+++ b/test/unit/math/rev/arr/err/check_consistent_sizes_test.cpp
@@ -17,13 +17,13 @@ TEST(AgradRevErrorHandlingScalar, CheckConsistentSizeVarCheckVectorized) {
     a.push_back(var(i));
   }
 
-  size_t stack_size = stan::math::ChainableStack::context().var_stack_.size();
+  size_t stack_size = stan::math::ChainableStack.var_stack_.size();
 
   EXPECT_EQ(10U, stack_size);
   EXPECT_NO_THROW(check_consistent_sizes(function, "a", a, "b", b));
 
   size_t stack_size_after_call
-      = stan::math::ChainableStack::context().var_stack_.size();
+      = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(10U, stack_size_after_call);
   stan::math::recover_memory();
 }

--- a/test/unit/math/rev/arr/err/check_finite_test.cpp
+++ b/test/unit/math/rev/arr/err/check_finite_test.cpp
@@ -20,14 +20,12 @@ TEST(AgradRevErrorHandlingScalar, CheckFiniteVarCheckVectorized) {
   EXPECT_EQ(5U, stack_size);
   EXPECT_NO_THROW(check_finite(function, "a", a));
 
-  size_t stack_size_after_call
-      = stan::math::ChainableStack.var_stack_.size();
+  size_t stack_size_after_call = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(5U, stack_size_after_call);
 
   a[1] = std::numeric_limits<double>::infinity();
   EXPECT_THROW(check_finite(function, "a", a), std::domain_error);
-  stack_size_after_call
-      = stan::math::ChainableStack.var_stack_.size();
+  stack_size_after_call = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(6U, stack_size_after_call);
 
   stan::math::recover_memory();

--- a/test/unit/math/rev/arr/err/check_finite_test.cpp
+++ b/test/unit/math/rev/arr/err/check_finite_test.cpp
@@ -15,19 +15,19 @@ TEST(AgradRevErrorHandlingScalar, CheckFiniteVarCheckVectorized) {
   for (int i = 0; i < N; ++i)
     a.push_back(var(i));
 
-  size_t stack_size = stan::math::ChainableStack::context().var_stack_.size();
+  size_t stack_size = stan::math::ChainableStack.var_stack_.size();
 
   EXPECT_EQ(5U, stack_size);
   EXPECT_NO_THROW(check_finite(function, "a", a));
 
   size_t stack_size_after_call
-      = stan::math::ChainableStack::context().var_stack_.size();
+      = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(5U, stack_size_after_call);
 
   a[1] = std::numeric_limits<double>::infinity();
   EXPECT_THROW(check_finite(function, "a", a), std::domain_error);
   stack_size_after_call
-      = stan::math::ChainableStack::context().var_stack_.size();
+      = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(6U, stack_size_after_call);
 
   stan::math::recover_memory();

--- a/test/unit/math/rev/arr/err/check_greater_or_equal_test.cpp
+++ b/test/unit/math/rev/arr/err/check_greater_or_equal_test.cpp
@@ -22,14 +22,12 @@ TEST(AgradRevErrorHandlingScalar, CheckFiniteVarCheckVectorized) {
   EXPECT_EQ(5U, stack_size);
   EXPECT_NO_THROW(check_greater_or_equal(function, "a", a, -1.0));
 
-  size_t stack_size_after_call
-      = stan::math::ChainableStack.var_stack_.size();
+  size_t stack_size_after_call = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(5U, stack_size_after_call);
 
   EXPECT_THROW(check_greater_or_equal(function, "a", a, 2.0),
                std::domain_error);
-  stack_size_after_call
-      = stan::math::ChainableStack.var_stack_.size();
+  stack_size_after_call = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(5U, stack_size_after_call);
 
   stan::math::recover_memory();

--- a/test/unit/math/rev/arr/err/check_greater_or_equal_test.cpp
+++ b/test/unit/math/rev/arr/err/check_greater_or_equal_test.cpp
@@ -17,19 +17,19 @@ TEST(AgradRevErrorHandlingScalar, CheckFiniteVarCheckVectorized) {
   for (int i = 0; i < N; ++i)
     a.push_back(var(i));
 
-  size_t stack_size = stan::math::ChainableStack::context().var_stack_.size();
+  size_t stack_size = stan::math::ChainableStack.var_stack_.size();
 
   EXPECT_EQ(5U, stack_size);
   EXPECT_NO_THROW(check_greater_or_equal(function, "a", a, -1.0));
 
   size_t stack_size_after_call
-      = stan::math::ChainableStack::context().var_stack_.size();
+      = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(5U, stack_size_after_call);
 
   EXPECT_THROW(check_greater_or_equal(function, "a", a, 2.0),
                std::domain_error);
   stack_size_after_call
-      = stan::math::ChainableStack::context().var_stack_.size();
+      = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(5U, stack_size_after_call);
 
   stan::math::recover_memory();

--- a/test/unit/math/rev/arr/err/check_greater_test.cpp
+++ b/test/unit/math/rev/arr/err/check_greater_test.cpp
@@ -17,18 +17,18 @@ TEST(AgradRevErrorHandlingScalar, CheckGreaterVarCheckVectorized) {
   for (int i = 0; i < N; ++i)
     a.push_back(var(i));
 
-  size_t stack_size = stan::math::ChainableStack::context().var_stack_.size();
+  size_t stack_size = stan::math::ChainableStack.var_stack_.size();
 
   EXPECT_EQ(5U, stack_size);
   EXPECT_NO_THROW(check_greater(function, "a", a, -1.0));
 
   size_t stack_size_after_call
-      = stan::math::ChainableStack::context().var_stack_.size();
+      = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(5U, stack_size_after_call);
 
   EXPECT_THROW(check_greater(function, "a", a, 2.0), std::domain_error);
   stack_size_after_call
-      = stan::math::ChainableStack::context().var_stack_.size();
+      = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(5U, stack_size_after_call);
 
   stan::math::recover_memory();

--- a/test/unit/math/rev/arr/err/check_greater_test.cpp
+++ b/test/unit/math/rev/arr/err/check_greater_test.cpp
@@ -22,13 +22,11 @@ TEST(AgradRevErrorHandlingScalar, CheckGreaterVarCheckVectorized) {
   EXPECT_EQ(5U, stack_size);
   EXPECT_NO_THROW(check_greater(function, "a", a, -1.0));
 
-  size_t stack_size_after_call
-      = stan::math::ChainableStack.var_stack_.size();
+  size_t stack_size_after_call = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(5U, stack_size_after_call);
 
   EXPECT_THROW(check_greater(function, "a", a, 2.0), std::domain_error);
-  stack_size_after_call
-      = stan::math::ChainableStack.var_stack_.size();
+  stack_size_after_call = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(5U, stack_size_after_call);
 
   stan::math::recover_memory();

--- a/test/unit/math/rev/arr/err/check_less_or_equal_test.cpp
+++ b/test/unit/math/rev/arr/err/check_less_or_equal_test.cpp
@@ -17,18 +17,18 @@ TEST(AgradRevErrorHandlingScalar, CheckLessOrEqualVarCheckVectorized) {
   for (int i = 0; i < N; ++i)
     a.push_back(var(i));
 
-  size_t stack_size = stan::math::ChainableStack::context().var_stack_.size();
+  size_t stack_size = stan::math::ChainableStack.var_stack_.size();
 
   EXPECT_EQ(5U, stack_size);
   EXPECT_NO_THROW(check_less_or_equal(function, "a", a, 10.0));
 
   size_t stack_size_after_call
-      = stan::math::ChainableStack::context().var_stack_.size();
+      = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(5U, stack_size_after_call);
 
   EXPECT_THROW(check_less_or_equal(function, "a", a, 2.0), std::domain_error);
   stack_size_after_call
-      = stan::math::ChainableStack::context().var_stack_.size();
+      = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(5U, stack_size_after_call);
 
   stan::math::recover_memory();

--- a/test/unit/math/rev/arr/err/check_less_or_equal_test.cpp
+++ b/test/unit/math/rev/arr/err/check_less_or_equal_test.cpp
@@ -22,13 +22,11 @@ TEST(AgradRevErrorHandlingScalar, CheckLessOrEqualVarCheckVectorized) {
   EXPECT_EQ(5U, stack_size);
   EXPECT_NO_THROW(check_less_or_equal(function, "a", a, 10.0));
 
-  size_t stack_size_after_call
-      = stan::math::ChainableStack.var_stack_.size();
+  size_t stack_size_after_call = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(5U, stack_size_after_call);
 
   EXPECT_THROW(check_less_or_equal(function, "a", a, 2.0), std::domain_error);
-  stack_size_after_call
-      = stan::math::ChainableStack.var_stack_.size();
+  stack_size_after_call = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(5U, stack_size_after_call);
 
   stan::math::recover_memory();

--- a/test/unit/math/rev/arr/err/check_less_test.cpp
+++ b/test/unit/math/rev/arr/err/check_less_test.cpp
@@ -17,18 +17,18 @@ TEST(AgradRevErrorHandlingScalar, CheckLessVarCheckVectorized) {
   for (int i = 0; i < N; ++i)
     a.push_back(var(i));
 
-  size_t stack_size = stan::math::ChainableStack::context().var_stack_.size();
+  size_t stack_size = stan::math::ChainableStack.var_stack_.size();
 
   EXPECT_EQ(5U, stack_size);
   EXPECT_NO_THROW(check_less(function, "a", a, 10.0));
 
   size_t stack_size_after_call
-      = stan::math::ChainableStack::context().var_stack_.size();
+      = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(5U, stack_size_after_call);
 
   EXPECT_THROW(check_less(function, "a", a, 2.0), std::domain_error);
   stack_size_after_call
-      = stan::math::ChainableStack::context().var_stack_.size();
+      = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(5U, stack_size_after_call);
 
   stan::math::recover_memory();

--- a/test/unit/math/rev/arr/err/check_less_test.cpp
+++ b/test/unit/math/rev/arr/err/check_less_test.cpp
@@ -22,13 +22,11 @@ TEST(AgradRevErrorHandlingScalar, CheckLessVarCheckVectorized) {
   EXPECT_EQ(5U, stack_size);
   EXPECT_NO_THROW(check_less(function, "a", a, 10.0));
 
-  size_t stack_size_after_call
-      = stan::math::ChainableStack.var_stack_.size();
+  size_t stack_size_after_call = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(5U, stack_size_after_call);
 
   EXPECT_THROW(check_less(function, "a", a, 2.0), std::domain_error);
-  stack_size_after_call
-      = stan::math::ChainableStack.var_stack_.size();
+  stack_size_after_call = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(5U, stack_size_after_call);
 
   stan::math::recover_memory();

--- a/test/unit/math/rev/arr/err/check_nonnegative_test.cpp
+++ b/test/unit/math/rev/arr/err/check_nonnegative_test.cpp
@@ -51,26 +51,22 @@ TEST(AgradRevErrorHandlingScalar, CheckNonnegativeVarCheckVectorized) {
   EXPECT_EQ(5U, stack_size);
   EXPECT_NO_THROW(check_nonnegative(function, "a", a));
 
-  size_t stack_size_after_call
-      = stan::math::ChainableStack.var_stack_.size();
+  size_t stack_size_after_call = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(5U, stack_size_after_call);
 
   a[1] = std::numeric_limits<double>::infinity();
   EXPECT_NO_THROW(check_nonnegative(function, "a", a));
-  stack_size_after_call
-      = stan::math::ChainableStack.var_stack_.size();
+  stack_size_after_call = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(6U, stack_size_after_call);
 
   a[1] = -1.0;
   EXPECT_THROW(check_nonnegative(function, "a", a), std::domain_error);
-  stack_size_after_call
-      = stan::math::ChainableStack.var_stack_.size();
+  stack_size_after_call = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(7U, stack_size_after_call);
 
   a[1] = 0.0;
   EXPECT_NO_THROW(check_nonnegative(function, "a", a));
-  stack_size_after_call
-      = stan::math::ChainableStack.var_stack_.size();
+  stack_size_after_call = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(8U, stack_size_after_call);
 
   stan::math::recover_memory();

--- a/test/unit/math/rev/arr/err/check_nonnegative_test.cpp
+++ b/test/unit/math/rev/arr/err/check_nonnegative_test.cpp
@@ -46,31 +46,31 @@ TEST(AgradRevErrorHandlingScalar, CheckNonnegativeVarCheckVectorized) {
   for (int i = 0; i < N; ++i)
     a.push_back(var(i));
 
-  size_t stack_size = stan::math::ChainableStack::context().var_stack_.size();
+  size_t stack_size = stan::math::ChainableStack.var_stack_.size();
 
   EXPECT_EQ(5U, stack_size);
   EXPECT_NO_THROW(check_nonnegative(function, "a", a));
 
   size_t stack_size_after_call
-      = stan::math::ChainableStack::context().var_stack_.size();
+      = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(5U, stack_size_after_call);
 
   a[1] = std::numeric_limits<double>::infinity();
   EXPECT_NO_THROW(check_nonnegative(function, "a", a));
   stack_size_after_call
-      = stan::math::ChainableStack::context().var_stack_.size();
+      = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(6U, stack_size_after_call);
 
   a[1] = -1.0;
   EXPECT_THROW(check_nonnegative(function, "a", a), std::domain_error);
   stack_size_after_call
-      = stan::math::ChainableStack::context().var_stack_.size();
+      = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(7U, stack_size_after_call);
 
   a[1] = 0.0;
   EXPECT_NO_THROW(check_nonnegative(function, "a", a));
   stack_size_after_call
-      = stan::math::ChainableStack::context().var_stack_.size();
+      = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(8U, stack_size_after_call);
 
   stan::math::recover_memory();

--- a/test/unit/math/rev/arr/err/check_not_nan_test.cpp
+++ b/test/unit/math/rev/arr/err/check_not_nan_test.cpp
@@ -19,8 +19,7 @@ TEST(AgradRevErrorHandlingScalar, CheckNotNanVarCheckVectorized) {
   EXPECT_EQ(5U, stack_size);
   EXPECT_NO_THROW(check_not_nan(function, "a", a));
 
-  size_t stack_size_after_call
-      = stan::math::ChainableStack.var_stack_.size();
+  size_t stack_size_after_call = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(5U, stack_size_after_call);
   stan::math::recover_memory();
 }
@@ -42,8 +41,7 @@ TEST(ErrorHandlingScalar, CheckNotNanVarCheckVectorized) {
   EXPECT_EQ(5U, stack_size);
   EXPECT_NO_THROW(check_not_nan(function, "a", a));
 
-  size_t stack_size_after_call
-      = stan::math::ChainableStack.var_stack_.size();
+  size_t stack_size_after_call = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(5U, stack_size_after_call);
   stan::math::recover_memory();
 }

--- a/test/unit/math/rev/arr/err/check_not_nan_test.cpp
+++ b/test/unit/math/rev/arr/err/check_not_nan_test.cpp
@@ -14,13 +14,13 @@ TEST(AgradRevErrorHandlingScalar, CheckNotNanVarCheckVectorized) {
   for (int i = 0; i < N; ++i)
     a.push_back(var(i));
 
-  size_t stack_size = stan::math::ChainableStack::context().var_stack_.size();
+  size_t stack_size = stan::math::ChainableStack.var_stack_.size();
 
   EXPECT_EQ(5U, stack_size);
   EXPECT_NO_THROW(check_not_nan(function, "a", a));
 
   size_t stack_size_after_call
-      = stan::math::ChainableStack::context().var_stack_.size();
+      = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(5U, stack_size_after_call);
   stan::math::recover_memory();
 }
@@ -37,13 +37,13 @@ TEST(ErrorHandlingScalar, CheckNotNanVarCheckVectorized) {
   for (int i = 0; i < N; ++i)
     a.push_back(var(i));
 
-  size_t stack_size = stan::math::ChainableStack::context().var_stack_.size();
+  size_t stack_size = stan::math::ChainableStack.var_stack_.size();
 
   EXPECT_EQ(5U, stack_size);
   EXPECT_NO_THROW(check_not_nan(function, "a", a));
 
   size_t stack_size_after_call
-      = stan::math::ChainableStack::context().var_stack_.size();
+      = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(5U, stack_size_after_call);
   stan::math::recover_memory();
 }

--- a/test/unit/math/rev/arr/err/check_positive_finite_test.cpp
+++ b/test/unit/math/rev/arr/err/check_positive_finite_test.cpp
@@ -66,20 +66,20 @@ TEST(AgradRevErrorHandlingScalar, CheckPositiveFiniteVarCheckVectorized) {
   for (int i = 0; i < N; ++i)
     a.push_back(var(i));
 
-  size_t stack_size = stan::math::ChainableStack::context().var_stack_.size();
+  size_t stack_size = stan::math::ChainableStack.var_stack_.size();
 
   EXPECT_EQ(5U, stack_size);
   EXPECT_THROW(check_positive_finite(function, "a", a), std::domain_error);
   EXPECT_NO_THROW(check_positive_finite(function, "a", a[2]));
 
   size_t stack_size_after_call
-      = stan::math::ChainableStack::context().var_stack_.size();
+      = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(5U, stack_size_after_call);
 
   a[2] = std::numeric_limits<double>::infinity();
   EXPECT_THROW(check_positive_finite(function, "a", a), std::domain_error);
   stack_size_after_call
-      = stan::math::ChainableStack::context().var_stack_.size();
+      = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(6U, stack_size_after_call);
   stan::math::recover_memory();
 }

--- a/test/unit/math/rev/arr/err/check_positive_finite_test.cpp
+++ b/test/unit/math/rev/arr/err/check_positive_finite_test.cpp
@@ -72,14 +72,12 @@ TEST(AgradRevErrorHandlingScalar, CheckPositiveFiniteVarCheckVectorized) {
   EXPECT_THROW(check_positive_finite(function, "a", a), std::domain_error);
   EXPECT_NO_THROW(check_positive_finite(function, "a", a[2]));
 
-  size_t stack_size_after_call
-      = stan::math::ChainableStack.var_stack_.size();
+  size_t stack_size_after_call = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(5U, stack_size_after_call);
 
   a[2] = std::numeric_limits<double>::infinity();
   EXPECT_THROW(check_positive_finite(function, "a", a), std::domain_error);
-  stack_size_after_call
-      = stan::math::ChainableStack.var_stack_.size();
+  stack_size_after_call = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(6U, stack_size_after_call);
   stan::math::recover_memory();
 }

--- a/test/unit/math/rev/arr/util.hpp
+++ b/test/unit/math/rev/arr/util.hpp
@@ -11,7 +11,7 @@ namespace test {
 void check_varis_on_stack(const std::vector<stan::math::var>& x) {
   for (size_t n = 0; n < x.size(); ++n)
     EXPECT_TRUE(
-        stan::math::ChainableStack::context().memalloc_.in_stack(x[n].vi_))
+        stan::math::ChainableStack.memalloc_.in_stack(x[n].vi_))
         << n << " is not on the stack";
 }
 

--- a/test/unit/math/rev/arr/util.hpp
+++ b/test/unit/math/rev/arr/util.hpp
@@ -10,8 +10,7 @@ namespace test {
 
 void check_varis_on_stack(const std::vector<stan::math::var>& x) {
   for (size_t n = 0; n < x.size(); ++n)
-    EXPECT_TRUE(
-        stan::math::ChainableStack.memalloc_.in_stack(x[n].vi_))
+    EXPECT_TRUE(stan::math::ChainableStack.memalloc_.in_stack(x[n].vi_))
         << n << " is not on the stack";
 }
 

--- a/test/unit/math/rev/mat/err/check_pos_semidefinite_test.cpp
+++ b/test/unit/math/rev/mat/err/check_pos_semidefinite_test.cpp
@@ -51,13 +51,11 @@ TEST(AgradRevErrorHandlingMatrix, CheckPosDefiniteMatrixVarCheck) {
   y.resize(3, 3);
   y << 2, -1, 0, -1, 2, -1, 0, -1, 2;
 
-  size_t stack_before_call
-      = stan::math::ChainableStack.var_stack_.size();
+  size_t stack_before_call = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(10U, stack_before_call);
 
   EXPECT_NO_THROW(check_pos_semidefinite("checkPosDefiniteMatrix", "y", y));
-  size_t stack_after_call
-      = stan::math::ChainableStack.var_stack_.size();
+  size_t stack_after_call = stan::math::ChainableStack.var_stack_.size();
 
   EXPECT_EQ(10U, stack_after_call);
 }

--- a/test/unit/math/rev/mat/err/check_pos_semidefinite_test.cpp
+++ b/test/unit/math/rev/mat/err/check_pos_semidefinite_test.cpp
@@ -52,12 +52,12 @@ TEST(AgradRevErrorHandlingMatrix, CheckPosDefiniteMatrixVarCheck) {
   y << 2, -1, 0, -1, 2, -1, 0, -1, 2;
 
   size_t stack_before_call
-      = stan::math::ChainableStack::context().var_stack_.size();
+      = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(10U, stack_before_call);
 
   EXPECT_NO_THROW(check_pos_semidefinite("checkPosDefiniteMatrix", "y", y));
   size_t stack_after_call
-      = stan::math::ChainableStack::context().var_stack_.size();
+      = stan::math::ChainableStack.var_stack_.size();
 
   EXPECT_EQ(10U, stack_after_call);
 }

--- a/test/unit/math/rev/mat/fun/log_softmax_test.cpp
+++ b/test/unit/math/rev/mat/fun/log_softmax_test.cpp
@@ -23,8 +23,7 @@ TEST(AgradRevMatrix, logSoftmaxLeak) {
     }
     Matrix<var, Dynamic, 1> theta = log_softmax(x);
   }
-  EXPECT_GT(stan::math::ChainableStack.memalloc_.bytes_allocated(),
-            4000000);
+  EXPECT_GT(stan::math::ChainableStack.memalloc_.bytes_allocated(), 4000000);
 }
 
 TEST(AgradRevMatrix, log_softmax) {

--- a/test/unit/math/rev/mat/fun/log_softmax_test.cpp
+++ b/test/unit/math/rev/mat/fun/log_softmax_test.cpp
@@ -23,7 +23,7 @@ TEST(AgradRevMatrix, logSoftmaxLeak) {
     }
     Matrix<var, Dynamic, 1> theta = log_softmax(x);
   }
-  EXPECT_GT(stan::math::ChainableStack::context().memalloc_.bytes_allocated(),
+  EXPECT_GT(stan::math::ChainableStack.memalloc_.bytes_allocated(),
             4000000);
 }
 

--- a/test/unit/math/rev/mat/fun/softmax_test.cpp
+++ b/test/unit/math/rev/mat/fun/softmax_test.cpp
@@ -24,8 +24,7 @@ TEST(AgradRevMatrix, softmaxLeak) {
     Matrix<var, Dynamic, 1> theta = softmax(x);
   }
   // test is greater than because leak is on heap, not stack
-  EXPECT_GT(stan::math::ChainableStack.memalloc_.bytes_allocated(),
-            200000);
+  EXPECT_GT(stan::math::ChainableStack.memalloc_.bytes_allocated(), 200000);
 }
 
 TEST(AgradRevMatrix, softmax) {

--- a/test/unit/math/rev/mat/fun/softmax_test.cpp
+++ b/test/unit/math/rev/mat/fun/softmax_test.cpp
@@ -24,7 +24,7 @@ TEST(AgradRevMatrix, softmaxLeak) {
     Matrix<var, Dynamic, 1> theta = softmax(x);
   }
   // test is greater than because leak is on heap, not stack
-  EXPECT_GT(stan::math::ChainableStack::context().memalloc_.bytes_allocated(),
+  EXPECT_GT(stan::math::ChainableStack.memalloc_.bytes_allocated(),
             200000);
 }
 

--- a/test/unit/math/rev/mat/fun/stored_gradient_vari_test.cpp
+++ b/test/unit/math/rev/mat/fun/stored_gradient_vari_test.cpp
@@ -18,8 +18,7 @@ TEST(StoredGradientVari, propagate3) {
   xs[1] = xs2.vi_;
   xs[2] = xs3.vi_;
   double* partials = reinterpret_cast<double*>(
-      stan::math::ChainableStack.memalloc_.alloc(3
-                                                            * sizeof(double)));
+      stan::math::ChainableStack.memalloc_.alloc(3 * sizeof(double)));
   partials[0] = 10;
   partials[1] = 100;
   partials[2] = 1000;
@@ -79,8 +78,7 @@ TEST(AgradRevMatrix, check_varis_on_stack) {
   xs[1] = xs2.vi_;
   xs[2] = xs3.vi_;
   double* partials = reinterpret_cast<double*>(
-      stan::math::ChainableStack.memalloc_.alloc(3
-                                                            * sizeof(double)));
+      stan::math::ChainableStack.memalloc_.alloc(3 * sizeof(double)));
   partials[0] = 10;
   partials[1] = 100;
   partials[2] = 1000;

--- a/test/unit/math/rev/mat/fun/stored_gradient_vari_test.cpp
+++ b/test/unit/math/rev/mat/fun/stored_gradient_vari_test.cpp
@@ -7,7 +7,7 @@ TEST(StoredGradientVari, propagate3) {
   using stan::math::var;
   using stan::math::vari;
   vari** xs = reinterpret_cast<vari**>(
-      stan::math::ChainableStack::context().memalloc_.alloc(3 * sizeof(vari*)));
+      stan::math::ChainableStack.memalloc_.alloc(3 * sizeof(vari*)));
   // value not used here
   var xs1 = 1;
   // value not used here
@@ -18,7 +18,7 @@ TEST(StoredGradientVari, propagate3) {
   xs[1] = xs2.vi_;
   xs[2] = xs3.vi_;
   double* partials = reinterpret_cast<double*>(
-      stan::math::ChainableStack::context().memalloc_.alloc(3
+      stan::math::ChainableStack.memalloc_.alloc(3
                                                             * sizeof(double)));
   partials[0] = 10;
   partials[1] = 100;
@@ -68,7 +68,7 @@ TEST(AgradRevMatrix, check_varis_on_stack) {
   using stan::math::var;
   using stan::math::vari;
   vari** xs = reinterpret_cast<vari**>(
-      stan::math::ChainableStack::context().memalloc_.alloc(3 * sizeof(vari*)));
+      stan::math::ChainableStack.memalloc_.alloc(3 * sizeof(vari*)));
   // value not used here
   var xs1 = 1;
   // value not used here
@@ -79,7 +79,7 @@ TEST(AgradRevMatrix, check_varis_on_stack) {
   xs[1] = xs2.vi_;
   xs[2] = xs3.vi_;
   double* partials = reinterpret_cast<double*>(
-      stan::math::ChainableStack::context().memalloc_.alloc(3
+      stan::math::ChainableStack.memalloc_.alloc(3
                                                             * sizeof(double)));
   partials[0] = 10;
   partials[1] = 100;

--- a/test/unit/math/rev/mat/functor/gradient_test.cpp
+++ b/test/unit/math/rev/mat/functor/gradient_test.cpp
@@ -138,6 +138,5 @@ TEST(AgradAutoDiff, RecoverMemory) {
   }
   // depends on starting allocation of 65K not being exceeded
   // without recovery_memory in autodiff::apply_recover(), takes 67M
-  EXPECT_LT(stan::math::ChainableStack.memalloc_.bytes_allocated(),
-            100000);
+  EXPECT_LT(stan::math::ChainableStack.memalloc_.bytes_allocated(), 100000);
 }

--- a/test/unit/math/rev/mat/functor/gradient_test.cpp
+++ b/test/unit/math/rev/mat/functor/gradient_test.cpp
@@ -138,6 +138,6 @@ TEST(AgradAutoDiff, RecoverMemory) {
   }
   // depends on starting allocation of 65K not being exceeded
   // without recovery_memory in autodiff::apply_recover(), takes 67M
-  EXPECT_LT(stan::math::ChainableStack::context().memalloc_.bytes_allocated(),
+  EXPECT_LT(stan::math::ChainableStack.memalloc_.bytes_allocated(),
             100000);
 }

--- a/test/unit/math/rev/mat/util.hpp
+++ b/test/unit/math/rev/mat/util.hpp
@@ -11,8 +11,7 @@ template <int R, int C>
 void check_varis_on_stack(const Eigen::Matrix<stan::math::var, R, C>& x) {
   for (int j = 0; j < x.cols(); ++j)
     for (int i = 0; i < x.rows(); ++i)
-      EXPECT_TRUE(
-          stan::math::ChainableStack.memalloc_.in_stack(x(i, j).vi_))
+      EXPECT_TRUE(stan::math::ChainableStack.memalloc_.in_stack(x(i, j).vi_))
           << i << ", " << j << " is not on the stack";
 }
 

--- a/test/unit/math/rev/mat/util.hpp
+++ b/test/unit/math/rev/mat/util.hpp
@@ -12,7 +12,7 @@ void check_varis_on_stack(const Eigen::Matrix<stan::math::var, R, C>& x) {
   for (int j = 0; j < x.cols(); ++j)
     for (int i = 0; i < x.rows(); ++i)
       EXPECT_TRUE(
-          stan::math::ChainableStack::context().memalloc_.in_stack(x(i, j).vi_))
+          stan::math::ChainableStack.memalloc_.in_stack(x(i, j).vi_))
           << i << ", " << j << " is not on the stack";
 }
 

--- a/test/unit/math/rev/scal/err/check_bounded_test.cpp
+++ b/test/unit/math/rev/scal/err/check_bounded_test.cpp
@@ -126,8 +126,7 @@ TEST(AgradRevErrorHandlingScalar, CheckBoundedVarCheckUnivariate) {
   EXPECT_EQ(1U, stack_size);
   EXPECT_NO_THROW(check_bounded(function, "a", a, 4.0, 6.0));
 
-  size_t stack_size_after_call
-      = stan::math::ChainableStack.var_stack_.size();
+  size_t stack_size_after_call = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(1U, stack_size_after_call);
 
   stan::math::recover_memory();

--- a/test/unit/math/rev/scal/err/check_bounded_test.cpp
+++ b/test/unit/math/rev/scal/err/check_bounded_test.cpp
@@ -121,13 +121,13 @@ TEST(AgradRevErrorHandlingScalar, CheckBoundedVarCheckUnivariate) {
   const char* function = "check_bounded";
   var a(5.0);
 
-  size_t stack_size = stan::math::ChainableStack::context().var_stack_.size();
+  size_t stack_size = stan::math::ChainableStack.var_stack_.size();
 
   EXPECT_EQ(1U, stack_size);
   EXPECT_NO_THROW(check_bounded(function, "a", a, 4.0, 6.0));
 
   size_t stack_size_after_call
-      = stan::math::ChainableStack::context().var_stack_.size();
+      = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(1U, stack_size_after_call);
 
   stan::math::recover_memory();

--- a/test/unit/math/rev/scal/err/check_finite_test.cpp
+++ b/test/unit/math/rev/scal/err/check_finite_test.cpp
@@ -39,14 +39,12 @@ TEST(AgradRevErrorHandlingScalar, CheckFiniteVarCheckUnivariate) {
   EXPECT_EQ(1U, stack_size);
   EXPECT_NO_THROW(check_finite(function, "a", a));
 
-  size_t stack_size_after_call
-      = stan::math::ChainableStack.var_stack_.size();
+  size_t stack_size_after_call = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(1U, stack_size_after_call);
 
   a = std::numeric_limits<double>::infinity();
   EXPECT_THROW(check_finite(function, "a", a), std::domain_error);
-  stack_size_after_call
-      = stan::math::ChainableStack.var_stack_.size();
+  stack_size_after_call = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(2U, stack_size_after_call);
 
   stan::math::recover_memory();

--- a/test/unit/math/rev/scal/err/check_finite_test.cpp
+++ b/test/unit/math/rev/scal/err/check_finite_test.cpp
@@ -34,19 +34,19 @@ TEST(AgradRevErrorHandlingScalar, CheckFiniteVarCheckUnivariate) {
   const char* function = "check_finite";
   var a(5.0);
 
-  size_t stack_size = stan::math::ChainableStack::context().var_stack_.size();
+  size_t stack_size = stan::math::ChainableStack.var_stack_.size();
 
   EXPECT_EQ(1U, stack_size);
   EXPECT_NO_THROW(check_finite(function, "a", a));
 
   size_t stack_size_after_call
-      = stan::math::ChainableStack::context().var_stack_.size();
+      = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(1U, stack_size_after_call);
 
   a = std::numeric_limits<double>::infinity();
   EXPECT_THROW(check_finite(function, "a", a), std::domain_error);
   stack_size_after_call
-      = stan::math::ChainableStack::context().var_stack_.size();
+      = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(2U, stack_size_after_call);
 
   stan::math::recover_memory();

--- a/test/unit/math/rev/scal/err/check_greater_or_equal_test.cpp
+++ b/test/unit/math/rev/scal/err/check_greater_or_equal_test.cpp
@@ -45,19 +45,19 @@ TEST(AgradRevErrorHandlingScalar, CheckGreaterOrEqualVarCheckUnivariate) {
   const char* function = "check_greater_or_equal";
   var a(5.0);
 
-  size_t stack_size = stan::math::ChainableStack::context().var_stack_.size();
+  size_t stack_size = stan::math::ChainableStack.var_stack_.size();
 
   EXPECT_EQ(1U, stack_size);
   EXPECT_NO_THROW(check_greater_or_equal(function, "a", a, 2.0));
 
   size_t stack_size_after_call
-      = stan::math::ChainableStack::context().var_stack_.size();
+      = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(1U, stack_size_after_call);
 
   EXPECT_THROW(check_greater_or_equal(function, "a", a, 10.0),
                std::domain_error);
   stack_size_after_call
-      = stan::math::ChainableStack::context().var_stack_.size();
+      = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(1U, stack_size_after_call);
 
   stan::math::recover_memory();

--- a/test/unit/math/rev/scal/err/check_greater_or_equal_test.cpp
+++ b/test/unit/math/rev/scal/err/check_greater_or_equal_test.cpp
@@ -50,14 +50,12 @@ TEST(AgradRevErrorHandlingScalar, CheckGreaterOrEqualVarCheckUnivariate) {
   EXPECT_EQ(1U, stack_size);
   EXPECT_NO_THROW(check_greater_or_equal(function, "a", a, 2.0));
 
-  size_t stack_size_after_call
-      = stan::math::ChainableStack.var_stack_.size();
+  size_t stack_size_after_call = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(1U, stack_size_after_call);
 
   EXPECT_THROW(check_greater_or_equal(function, "a", a, 10.0),
                std::domain_error);
-  stack_size_after_call
-      = stan::math::ChainableStack.var_stack_.size();
+  stack_size_after_call = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(1U, stack_size_after_call);
 
   stan::math::recover_memory();

--- a/test/unit/math/rev/scal/err/check_greater_test.cpp
+++ b/test/unit/math/rev/scal/err/check_greater_test.cpp
@@ -44,18 +44,18 @@ TEST(AgradRevErrorHandlingScalar, CheckGreaterVarCheckUnivariate) {
   const char* function = "check_greater";
   var a(5.0);
 
-  size_t stack_size = stan::math::ChainableStack::context().var_stack_.size();
+  size_t stack_size = stan::math::ChainableStack.var_stack_.size();
 
   EXPECT_EQ(1U, stack_size);
   EXPECT_NO_THROW(check_greater(function, "a", a, 2.0));
 
   size_t stack_size_after_call
-      = stan::math::ChainableStack::context().var_stack_.size();
+      = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(1U, stack_size_after_call);
 
   EXPECT_THROW(check_greater(function, "a", a, 10.0), std::domain_error);
   stack_size_after_call
-      = stan::math::ChainableStack::context().var_stack_.size();
+      = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(1U, stack_size_after_call);
 
   stan::math::recover_memory();

--- a/test/unit/math/rev/scal/err/check_greater_test.cpp
+++ b/test/unit/math/rev/scal/err/check_greater_test.cpp
@@ -49,13 +49,11 @@ TEST(AgradRevErrorHandlingScalar, CheckGreaterVarCheckUnivariate) {
   EXPECT_EQ(1U, stack_size);
   EXPECT_NO_THROW(check_greater(function, "a", a, 2.0));
 
-  size_t stack_size_after_call
-      = stan::math::ChainableStack.var_stack_.size();
+  size_t stack_size_after_call = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(1U, stack_size_after_call);
 
   EXPECT_THROW(check_greater(function, "a", a, 10.0), std::domain_error);
-  stack_size_after_call
-      = stan::math::ChainableStack.var_stack_.size();
+  stack_size_after_call = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(1U, stack_size_after_call);
 
   stan::math::recover_memory();

--- a/test/unit/math/rev/scal/err/check_less_or_equal_test.cpp
+++ b/test/unit/math/rev/scal/err/check_less_or_equal_test.cpp
@@ -50,19 +50,16 @@ TEST(AgradRevErrorHandlingScalar, CheckLessOrEqualVarCheckUnivariate) {
   EXPECT_EQ(1U, stack_size);
   EXPECT_THROW(check_less_or_equal(function, "a", a, 2.0), std::domain_error);
 
-  size_t stack_size_after_call
-      = stan::math::ChainableStack.var_stack_.size();
+  size_t stack_size_after_call = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(1U, stack_size_after_call);
 
   EXPECT_NO_THROW(check_less_or_equal(function, "a", a, 5.0));
 
-  stack_size_after_call
-      = stan::math::ChainableStack.var_stack_.size();
+  stack_size_after_call = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(1U, stack_size_after_call);
 
   EXPECT_NO_THROW(check_less_or_equal(function, "a", a, 10.0));
-  stack_size_after_call
-      = stan::math::ChainableStack.var_stack_.size();
+  stack_size_after_call = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(1U, stack_size_after_call);
 
   stan::math::recover_memory();

--- a/test/unit/math/rev/scal/err/check_less_or_equal_test.cpp
+++ b/test/unit/math/rev/scal/err/check_less_or_equal_test.cpp
@@ -45,24 +45,24 @@ TEST(AgradRevErrorHandlingScalar, CheckLessOrEqualVarCheckUnivariate) {
   const char* function = "check_less_or_equal";
   var a(5.0);
 
-  size_t stack_size = stan::math::ChainableStack::context().var_stack_.size();
+  size_t stack_size = stan::math::ChainableStack.var_stack_.size();
 
   EXPECT_EQ(1U, stack_size);
   EXPECT_THROW(check_less_or_equal(function, "a", a, 2.0), std::domain_error);
 
   size_t stack_size_after_call
-      = stan::math::ChainableStack::context().var_stack_.size();
+      = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(1U, stack_size_after_call);
 
   EXPECT_NO_THROW(check_less_or_equal(function, "a", a, 5.0));
 
   stack_size_after_call
-      = stan::math::ChainableStack::context().var_stack_.size();
+      = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(1U, stack_size_after_call);
 
   EXPECT_NO_THROW(check_less_or_equal(function, "a", a, 10.0));
   stack_size_after_call
-      = stan::math::ChainableStack::context().var_stack_.size();
+      = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(1U, stack_size_after_call);
 
   stan::math::recover_memory();

--- a/test/unit/math/rev/scal/err/check_less_test.cpp
+++ b/test/unit/math/rev/scal/err/check_less_test.cpp
@@ -49,13 +49,11 @@ TEST(AgradRevErrorHandlingScalar, CheckLessVarCheckUnivariate) {
   EXPECT_EQ(1U, stack_size);
   EXPECT_THROW(check_less(function, "a", a, 2.0), std::domain_error);
 
-  size_t stack_size_after_call
-      = stan::math::ChainableStack.var_stack_.size();
+  size_t stack_size_after_call = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(1U, stack_size_after_call);
 
   EXPECT_NO_THROW(check_less(function, "a", a, 10.0));
-  stack_size_after_call
-      = stan::math::ChainableStack.var_stack_.size();
+  stack_size_after_call = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(1U, stack_size_after_call);
 
   stan::math::recover_memory();

--- a/test/unit/math/rev/scal/err/check_less_test.cpp
+++ b/test/unit/math/rev/scal/err/check_less_test.cpp
@@ -44,18 +44,18 @@ TEST(AgradRevErrorHandlingScalar, CheckLessVarCheckUnivariate) {
   const char* function = "check_less";
   var a(5.0);
 
-  size_t stack_size = stan::math::ChainableStack::context().var_stack_.size();
+  size_t stack_size = stan::math::ChainableStack.var_stack_.size();
 
   EXPECT_EQ(1U, stack_size);
   EXPECT_THROW(check_less(function, "a", a, 2.0), std::domain_error);
 
   size_t stack_size_after_call
-      = stan::math::ChainableStack::context().var_stack_.size();
+      = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(1U, stack_size_after_call);
 
   EXPECT_NO_THROW(check_less(function, "a", a, 10.0));
   stack_size_after_call
-      = stan::math::ChainableStack::context().var_stack_.size();
+      = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(1U, stack_size_after_call);
 
   stan::math::recover_memory();

--- a/test/unit/math/rev/scal/err/check_nonnegative_test.cpp
+++ b/test/unit/math/rev/scal/err/check_nonnegative_test.cpp
@@ -42,26 +42,22 @@ TEST(AgradRevErrorHandlingScalar, CheckNonnegativeVarCheckUnivariate) {
   EXPECT_EQ(1U, stack_size);
   EXPECT_NO_THROW(check_nonnegative(function, "a", a));
 
-  size_t stack_size_after_call
-      = stan::math::ChainableStack.var_stack_.size();
+  size_t stack_size_after_call = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(1U, stack_size_after_call);
 
   a = std::numeric_limits<double>::infinity();
   EXPECT_NO_THROW(check_nonnegative(function, "a", a));
-  stack_size_after_call
-      = stan::math::ChainableStack.var_stack_.size();
+  stack_size_after_call = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(2U, stack_size_after_call);
 
   a = 0.0;
   EXPECT_NO_THROW(check_nonnegative(function, "a", a));
-  stack_size_after_call
-      = stan::math::ChainableStack.var_stack_.size();
+  stack_size_after_call = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(3U, stack_size_after_call);
 
   a = -1.1;
   EXPECT_THROW(check_nonnegative(function, "a", a), std::domain_error);
-  stack_size_after_call
-      = stan::math::ChainableStack.var_stack_.size();
+  stack_size_after_call = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(4U, stack_size_after_call);
   stan::math::recover_memory();
 }

--- a/test/unit/math/rev/scal/err/check_nonnegative_test.cpp
+++ b/test/unit/math/rev/scal/err/check_nonnegative_test.cpp
@@ -37,31 +37,31 @@ TEST(AgradRevErrorHandlingScalar, CheckNonnegativeVarCheckUnivariate) {
   const char* function = "check_nonnegative";
   var a(5.0);
 
-  size_t stack_size = stan::math::ChainableStack::context().var_stack_.size();
+  size_t stack_size = stan::math::ChainableStack.var_stack_.size();
 
   EXPECT_EQ(1U, stack_size);
   EXPECT_NO_THROW(check_nonnegative(function, "a", a));
 
   size_t stack_size_after_call
-      = stan::math::ChainableStack::context().var_stack_.size();
+      = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(1U, stack_size_after_call);
 
   a = std::numeric_limits<double>::infinity();
   EXPECT_NO_THROW(check_nonnegative(function, "a", a));
   stack_size_after_call
-      = stan::math::ChainableStack::context().var_stack_.size();
+      = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(2U, stack_size_after_call);
 
   a = 0.0;
   EXPECT_NO_THROW(check_nonnegative(function, "a", a));
   stack_size_after_call
-      = stan::math::ChainableStack::context().var_stack_.size();
+      = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(3U, stack_size_after_call);
 
   a = -1.1;
   EXPECT_THROW(check_nonnegative(function, "a", a), std::domain_error);
   stack_size_after_call
-      = stan::math::ChainableStack::context().var_stack_.size();
+      = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(4U, stack_size_after_call);
   stan::math::recover_memory();
 }

--- a/test/unit/math/rev/scal/err/check_not_nan_test.cpp
+++ b/test/unit/math/rev/scal/err/check_not_nan_test.cpp
@@ -50,8 +50,7 @@ TEST(AgradRevErrorHandlingScalar, CheckNotNanVarCheckUnivariate) {
   EXPECT_EQ(1U, stack_size);
   EXPECT_NO_THROW(check_not_nan(function, "a", a));
 
-  size_t stack_size_after_call
-      = stan::math::ChainableStack.var_stack_.size();
+  size_t stack_size_after_call = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(1U, stack_size_after_call);
 
   stan::math::recover_memory();
@@ -69,8 +68,7 @@ TEST(ErrorHandlingScalar, CheckNotNanVarCheckUnivariate) {
   EXPECT_EQ(1U, stack_size);
   EXPECT_NO_THROW(check_not_nan(function, "a", a));
 
-  size_t stack_size_after_call
-      = stan::math::ChainableStack.var_stack_.size();
+  size_t stack_size_after_call = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(1U, stack_size_after_call);
 
   stan::math::recover_memory();

--- a/test/unit/math/rev/scal/err/check_not_nan_test.cpp
+++ b/test/unit/math/rev/scal/err/check_not_nan_test.cpp
@@ -45,13 +45,13 @@ TEST(AgradRevErrorHandlingScalar, CheckNotNanVarCheckUnivariate) {
   const char* function = "check_not_nan";
   var a(5.0);
 
-  size_t stack_size = stan::math::ChainableStack::context().var_stack_.size();
+  size_t stack_size = stan::math::ChainableStack.var_stack_.size();
 
   EXPECT_EQ(1U, stack_size);
   EXPECT_NO_THROW(check_not_nan(function, "a", a));
 
   size_t stack_size_after_call
-      = stan::math::ChainableStack::context().var_stack_.size();
+      = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(1U, stack_size_after_call);
 
   stan::math::recover_memory();
@@ -64,13 +64,13 @@ TEST(ErrorHandlingScalar, CheckNotNanVarCheckUnivariate) {
   const char* function = "check_not_nan";
   var a(5.0);
 
-  size_t stack_size = stan::math::ChainableStack::context().var_stack_.size();
+  size_t stack_size = stan::math::ChainableStack.var_stack_.size();
 
   EXPECT_EQ(1U, stack_size);
   EXPECT_NO_THROW(check_not_nan(function, "a", a));
 
   size_t stack_size_after_call
-      = stan::math::ChainableStack::context().var_stack_.size();
+      = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(1U, stack_size_after_call);
 
   stan::math::recover_memory();

--- a/test/unit/math/rev/scal/err/check_positive_finite_test.cpp
+++ b/test/unit/math/rev/scal/err/check_positive_finite_test.cpp
@@ -37,13 +37,13 @@ TEST(AgradRevErrorHandlingScalar, CheckPositiveFiniteVarCheckUnivariate) {
   const char* function = "check_positive_finite";
   var a(5.0);
 
-  size_t stack_size = stan::math::ChainableStack::context().var_stack_.size();
+  size_t stack_size = stan::math::ChainableStack.var_stack_.size();
 
   EXPECT_EQ(1U, stack_size);
   EXPECT_NO_THROW(check_positive_finite(function, "a", a));
 
   size_t stack_size_after_call
-      = stan::math::ChainableStack::context().var_stack_.size();
+      = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(1U, stack_size_after_call);
 
   stan::math::recover_memory();

--- a/test/unit/math/rev/scal/err/check_positive_finite_test.cpp
+++ b/test/unit/math/rev/scal/err/check_positive_finite_test.cpp
@@ -42,8 +42,7 @@ TEST(AgradRevErrorHandlingScalar, CheckPositiveFiniteVarCheckUnivariate) {
   EXPECT_EQ(1U, stack_size);
   EXPECT_NO_THROW(check_positive_finite(function, "a", a));
 
-  size_t stack_size_after_call
-      = stan::math::ChainableStack.var_stack_.size();
+  size_t stack_size_after_call = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(1U, stack_size_after_call);
 
   stan::math::recover_memory();

--- a/test/unit/math/rev/scal/err/check_positive_test.cpp
+++ b/test/unit/math/rev/scal/err/check_positive_test.cpp
@@ -22,13 +22,13 @@ TEST(AgradRevErrorHandlingScalar, CheckPositiveVarCheckUnivariate) {
   const char* function = "check_positive";
   var a(5.0);
 
-  size_t stack_size = stan::math::ChainableStack::context().var_stack_.size();
+  size_t stack_size = stan::math::ChainableStack.var_stack_.size();
 
   EXPECT_EQ(1U, stack_size);
   EXPECT_NO_THROW(check_positive(function, "a", a));
 
   size_t stack_size_after_call
-      = stan::math::ChainableStack::context().var_stack_.size();
+      = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(1U, stack_size_after_call);
 
   stan::math::recover_memory();

--- a/test/unit/math/rev/scal/err/check_positive_test.cpp
+++ b/test/unit/math/rev/scal/err/check_positive_test.cpp
@@ -27,8 +27,7 @@ TEST(AgradRevErrorHandlingScalar, CheckPositiveVarCheckUnivariate) {
   EXPECT_EQ(1U, stack_size);
   EXPECT_NO_THROW(check_positive(function, "a", a));
 
-  size_t stack_size_after_call
-      = stan::math::ChainableStack.var_stack_.size();
+  size_t stack_size_after_call = stan::math::ChainableStack.var_stack_.size();
   EXPECT_EQ(1U, stack_size_after_call);
 
   stan::math::recover_memory();

--- a/test/unit/math/rev/scal/util.hpp
+++ b/test/unit/math/rev/scal/util.hpp
@@ -7,7 +7,7 @@
 namespace test {
 
 void check_varis_on_stack(const stan::math::var& x) {
-  EXPECT_TRUE(stan::math::ChainableStack::context().memalloc_.in_stack(x.vi_))
+  EXPECT_TRUE(stan::math::ChainableStack.memalloc_.in_stack(x.vi_))
       << "not on the stack";
 }
 


### PR DESCRIPTION
#### Submission Checklist

- [ ] Run unit tests: `./runTests.py test/unit`
- [ ] Run cpplint: `make cpplint`
- [X] Declare copyright holder and open-source license: see below

#### Summary:
Adresses performance regression bug introduced with threaded AD stack change.

It turns out that using a `static` variables declared as member of a `static` function is causing problems for the compiler to optimize. This PR changes this such that directly a global instance of `ChainableStack` is declared. Whenever threads are to be used, the `thread_local` keyword is used.

This change did solve the performance regression problems:

- performance prior to the threaded AD pull (cmdstan hash `8f218b6c0584af995ed7e48faa8408d03cb040ee`:
```
stat_comp_benchmarks/benchmarks/arK/arK.stan,2.10290490389
```

- performance after this change:
```
stat_comp_benchmarks/benchmarks/arK/arK.stan,1.90999811888
```

- for reference, performance with the threaded AD changes which caused the slow down:
```
stat_comp_benchmarks/benchmarks/arK/arK.stan,2.34019263983
```

all of the above are without threading enabled.

#### Intended Effect:
recover speed.

#### How to Verify:
Run the performance regression framework. Please use as reference for the cmdstan hash `8f218b6c0584af995ed7e48faa8408d03cb040ee`.

#### Side Effects:
Looks like that things get faster.

#### Documentation:

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Sebastian Weber

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)