### PR TITLE
Bugfix/issue 824 speed 2

### DIFF
--- a/stan/math/rev/core/autodiffstackstorage.hpp
+++ b/stan/math/rev/core/autodiffstackstorage.hpp
@@ -12,7 +12,7 @@ struct AutodiffStackStorage {
   typedef AutodiffStackStorage<ChainableT, ChainableAllocT>
       AutodiffStackStorage_t;
 
-  static AutodiffStackStorage_t& context() {
+  static inline AutodiffStackStorage_t& context() {
 #ifndef STAN_THREADS
     static AutodiffStackStorage_t ad_stack;
 #else

--- a/stan/math/rev/core/autodiffstackstorage.hpp
+++ b/stan/math/rev/core/autodiffstackstorage.hpp
@@ -14,10 +14,9 @@ struct AutodiffStackStorage {
 
   static AutodiffStackStorage_t& context() {
 #ifndef STAN_THREADS
-    static AutodiffStackStorage_t ad_stack = AutodiffStackStorage_t();
+    static AutodiffStackStorage_t ad_stack;
 #else
-    static thread_local AutodiffStackStorage_t ad_stack
-        = AutodiffStackStorage_t();
+    static thread_local AutodiffStackStorage_t ad_stack;
 #endif
     return ad_stack;
   }

--- a/stan/math/rev/core/vari.hpp
+++ b/stan/math/rev/core/vari.hpp
@@ -37,7 +37,7 @@ class vari {
 #else
   thread_local static ChainableStack& ad_stack_;
 #endif
-  
+
  public:
   /**
    * The value of this variable.


### PR DESCRIPTION
#### Submission Checklist

- [ ] Run unit tests: `./runTests.py test/unit`
- [X] Run cpplint: `make cpplint`
- [X] Declare copyright holder and open-source license: see below

#### Summary:
Adresses performance regression bug introduced with threaded AD stack change.

It turns out that using a `static` variables declared as member of a `static` function is causing problems for the compiler to optimize. This PR adds to `vari` a reference to the ad_stack such that no function call is needed after the first evaluation of the `context()` function. Whenever threads are to be used, the `thread_local` keyword is used.

This change did solve the performance regression problems:

- performance prior to the threaded AD pull (cmdstan hash `8f218b6c0584af995ed7e48faa8408d03cb040ee`:
```
stat_comp_benchmarks/benchmarks/arK/arK.stan,2.10290490389
```

- performance after this change:
```
stat_comp_benchmarks/benchmarks/arK/arK.stan,2.09031249285
```

- for reference, performance with the threaded AD changes which caused the slow down:
```
stat_comp_benchmarks/benchmarks/arK/arK.stan,2.34019263983
```

all of the above are with threading turned off. When the `thread_local` keyword is used, the timings are
```
stat_comp_benchmarks/benchmarks/arK/arK.stan,3.27428181171
```
...so there is quite some penalty for using threads (which is not the concern of this PR).

#### Intended Effect:
Recover speed.

#### How to Verify:
Follow instructions [on discourse](http://discourse.mc-stan.org/t/15-20-ish-performance-regression/3812).

#### Side Effects:

#### Documentation:

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Sebastian Weber

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)