### PR TITLE
final gp_dot_prod_cov rev and prim

### DIFF
--- a/stan/math/prim/mat.hpp
+++ b/stan/math/prim/mat.hpp
@@ -119,6 +119,7 @@
 #include <stan/math/prim/mat/fun/get_base1.hpp>
 #include <stan/math/prim/mat/fun/get_base1_lhs.hpp>
 #include <stan/math/prim/mat/fun/get_lp.hpp>
+#include <stan/math/prim/mat/fun/gp_dot_prod_cov.hpp>
 #include <stan/math/prim/mat/fun/head.hpp>
 #include <stan/math/prim/mat/fun/initialize.hpp>
 #include <stan/math/prim/mat/fun/inv.hpp>

--- a/stan/math/prim/mat/fun/gp_dot_prod_cov.hpp
+++ b/stan/math/prim/mat/fun/gp_dot_prod_cov.hpp
@@ -14,25 +14,25 @@
 namespace stan {
 namespace math {
 
-   /**
-     * Returns a dot product kernel.
-     *
-     * @tparam T_x type of std::vector of elements
-     * @tparam T_sigma type of sigma
-     *
-     * @param x std::vector of elements that can be used in dot product
-     *    This function assumes each element of x is the same size.
-     * @param sigma
-     * @return dot product kernel
-     * @throw std::domain_error if sigma < 0, nan, inf or
-     *   x is nan or infinite
-     */
+/**
+ * Returns a dot product kernel.
+ *
+ * @tparam T_x type of std::vector of elements
+ * @tparam T_sigma type of sigma
+ *
+ * @param x std::vector of elements that can be used in dot product
+ *    This function assumes each element of x is the same size.
+ * @param sigma
+ * @return dot product kernel
+ * @throw std::domain_error if sigma < 0, nan, inf or
+ *   x is nan or infinite
+ */
 template <typename T_x, typename T_sigma>
 inline typename Eigen::Matrix<typename stan::return_type<T_x, T_sigma>::type,
-                             Eigen::Dynamic, Eigen::Dynamic>
+                              Eigen::Dynamic, Eigen::Dynamic>
 gp_dot_prod_cov(const std::vector<T_x> &x, const T_sigma &sigma) {
-  using stan::math::square;
   using stan::math::dot_product;
+  using stan::math::square;
 
   check_not_nan("gp_dot_prod_cov", "sigma", sigma);
   check_nonnegative("gp_dot_prod_cov", "sigma", sigma);
@@ -59,31 +59,31 @@ gp_dot_prod_cov(const std::vector<T_x> &x, const T_sigma &sigma) {
       cov(j, i) = cov(i, j);
     }
   }
-  cov(x_size - 1, x_size - 1) =
-      sigma_sq + dot_product(x[x_size - 1], x[x_size - 1]);
+  cov(x_size - 1, x_size - 1)
+      = sigma_sq + dot_product(x[x_size - 1], x[x_size - 1]);
   return cov;
 }
 
 /**
-     * Returns a dot product kernel.
-     *
-     * @tparam T_x type of std::vector of double
-     * @tparam T_sigma type of sigma
-     *
-     * @param x std::vector of elements that can be used in transpose
-     *   and multiply
-     *    This function assumes each element of x is the same size.
-     * @param sigma
-     * @return dot product kernel
-     * @throw std::domain_error if sigma < 0, nan, inf or
-     *   x is nan or infinite
-     */
+ * Returns a dot product kernel.
+ *
+ * @tparam T_x type of std::vector of double
+ * @tparam T_sigma type of sigma
+ *
+ * @param x std::vector of elements that can be used in transpose
+ *   and multiply
+ *    This function assumes each element of x is the same size.
+ * @param sigma
+ * @return dot product kernel
+ * @throw std::domain_error if sigma < 0, nan, inf or
+ *   x is nan or infinite
+ */
 template <typename T_sigma>
 inline typename Eigen::Matrix<typename stan::return_type<double, T_sigma>::type,
                               Eigen::Dynamic, Eigen::Dynamic>
 gp_dot_prod_cov(const std::vector<double> &x, const T_sigma &sigma) {
-  using stan::math::square;
   using stan::math::dot_product;
+  using stan::math::square;
 
   check_not_nan("gp_dot_prod_cov", "sigma", sigma);
   check_nonnegative("gp_dot_prod_cov", "sigma", sigma);
@@ -134,8 +134,8 @@ inline typename Eigen::Matrix<
     Eigen::Dynamic>
 gp_dot_prod_cov(const std::vector<T_x1> &x1, const std::vector<T_x2> &x2,
                 const T_sigma &sigma) {
-  using stan::math::square;
   using stan::math::dot_product;
+  using stan::math::square;
 
   check_not_nan("gp_dot_prod_cov", "sigma", sigma);
   check_nonnegative("gp_dot_prod_cov", "sigma", sigma);
@@ -158,11 +158,11 @@ gp_dot_prod_cov(const std::vector<T_x1> &x1, const std::vector<T_x2> &x2,
 
   T_sigma sigma_sq = square(sigma);
 
-    for (size_t i = 0; i < x1.size(); ++i) {
-      for (size_t j = 0; j < x2.size(); ++j) {
-        cov(i, j) = sigma_sq + dot_product(x1[i], x2[j]);
-      }
+  for (size_t i = 0; i < x1.size(); ++i) {
+    for (size_t j = 0; j < x2.size(); ++j) {
+      cov(i, j) = sigma_sq + dot_product(x1[i], x2[j]);
     }
+  }
   return cov;
 }
 
@@ -215,6 +215,6 @@ gp_dot_prod_cov(const std::vector<double> &x1, const std::vector<double> &x2,
   }
   return cov;
 }
-}  // math
-}  // stan
+}  // namespace math
+}  // namespace stan
 #endif

--- a/stan/math/prim/mat/fun/gp_dot_prod_cov.hpp
+++ b/stan/math/prim/mat/fun/gp_dot_prod_cov.hpp
@@ -1,0 +1,220 @@
+#ifndef STAN_MATH_PRIM_MAT_FUN_COV_DOT_PROD_HPP
+#define STAN_MATH_PRIM_MAT_FUN_COV_DOT_PROD_HPP
+
+#include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <stan/math/prim/mat/fun/value_of.hpp>
+#include <stan/math/prim/scal/err/check_nonnegative.hpp>
+#include <stan/math/prim/scal/err/check_not_nan.hpp>
+#include <stan/math/prim/scal/err/check_size_match.hpp>
+#include <stan/math/prim/scal/fun/square.hpp>
+#include <stan/math/prim/scal/meta/return_type.hpp>
+#include <stan/math/rev/mat/fun/dot_product.hpp>
+#include <vector>
+
+namespace stan {
+namespace math {
+
+   /**
+     * Returns a dot product kernel.
+     *
+     * @tparam T_x type of std::vector of elements
+     * @tparam T_sigma type of sigma
+     *
+     * @param x std::vector of elements that can be used in dot product
+     *    This function assumes each element of x is the same size.
+     * @param sigma
+     * @return dot product kernel
+     * @throw std::domain_error if sigma < 0, nan, inf or
+     *   x is nan or infinite
+     */
+template <typename T_x, typename T_sigma>
+inline typename Eigen::Matrix<typename stan::return_type<T_x, T_sigma>::type,
+                             Eigen::Dynamic, Eigen::Dynamic>
+gp_dot_prod_cov(const std::vector<T_x> &x, const T_sigma &sigma) {
+  using stan::math::square;
+  using stan::math::dot_product;
+
+  check_not_nan("gp_dot_prod_cov", "sigma", sigma);
+  check_nonnegative("gp_dot_prod_cov", "sigma", sigma);
+  check_finite("gp_dot_prod_cov", "sigma", sigma);
+
+  for (size_t n = 0; n < x.size(); ++n) {
+    check_not_nan("gp_dot_prod_cov", "x", x[n]);
+    check_finite("gp_dot_prod_cov", "x", x[n]);
+  }
+
+  Eigen::Matrix<typename stan::return_type<T_x, T_sigma>::type, Eigen::Dynamic,
+                Eigen::Dynamic>
+      cov(x.size(), x.size());
+  int x_size = x.size();
+  if (x_size == 0)
+    return cov;
+
+  T_sigma sigma_sq = square(sigma);
+
+  for (int i = 0; i < (x_size - 1); ++i) {
+    cov(i, i) = sigma_sq + dot_product(x[i], x[i]);
+    for (int j = i + 1; j < x_size; ++j) {
+      cov(i, j) = sigma_sq + dot_product(x[i], x[j]);
+      cov(j, i) = cov(i, j);
+    }
+  }
+  cov(x_size - 1, x_size - 1) =
+      sigma_sq + dot_product(x[x_size - 1], x[x_size - 1]);
+  return cov;
+}
+
+/**
+     * Returns a dot product kernel.
+     *
+     * @tparam T_x type of std::vector of double
+     * @tparam T_sigma type of sigma
+     *
+     * @param x std::vector of elements that can be used in transpose
+     *   and multiply
+     *    This function assumes each element of x is the same size.
+     * @param sigma
+     * @return dot product kernel
+     * @throw std::domain_error if sigma < 0, nan, inf or
+     *   x is nan or infinite
+     */
+template <typename T_sigma>
+inline typename Eigen::Matrix<typename stan::return_type<double, T_sigma>::type,
+                              Eigen::Dynamic, Eigen::Dynamic>
+gp_dot_prod_cov(const std::vector<double> &x, const T_sigma &sigma) {
+  using stan::math::square;
+  using stan::math::dot_product;
+
+  check_not_nan("gp_dot_prod_cov", "sigma", sigma);
+  check_nonnegative("gp_dot_prod_cov", "sigma", sigma);
+  check_finite("gp_dot_prod_cov", "sigma", sigma);
+
+  for (size_t n = 0; n < x.size(); ++n) {
+    check_not_nan("gp_dot_prod_cov", "x", x[n]);
+    check_finite("gp_dot_prod_cov", "x", x[n]);
+  }
+
+  Eigen::Matrix<typename stan::return_type<double, T_sigma>::type,
+                Eigen::Dynamic, Eigen::Dynamic>
+      cov(x.size(), x.size());
+  int x_size = x.size();
+  if (x_size == 0)
+    return cov;
+
+  T_sigma sigma_sq = square(sigma);
+
+  for (int i = 0; i < (x_size - 1); ++i) {
+    cov(i, i) = sigma_sq + x[i] * x[i];
+    for (int j = i + 1; j < x_size; ++j) {
+      cov(i, j) = sigma_sq + x[i] * x[j];
+      cov(j, i) = cov(i, j);
+    }
+  }
+  cov(x_size - 1, x_size - 1) = sigma_sq + x[x_size - 1] * x[x_size - 1];
+  return cov;
+}
+
+/**
+ * Returns a dot product kernel.
+ *
+ * @tparam T_x1 type of first std::vector of elements
+ * @tparam T_x2 type of second std::vector of elements
+ * @tparam T_sigma type of sigma
+ *
+ * @param x1 std::vector of elements that can be used in dot_product
+ * @param x2 std::vector of elements that can be used in dot_product
+ * @param sigma
+ * @return dot product kernel
+ * @throw std::domain_error if sigma < 0, nan or inf
+ *   or if x1 or x2 are nan or inf
+ */
+template <typename T_x1, typename T_x2, typename T_sigma>
+inline typename Eigen::Matrix<
+    typename stan::return_type<T_x1, T_x2, T_sigma>::type, Eigen::Dynamic,
+    Eigen::Dynamic>
+gp_dot_prod_cov(const std::vector<T_x1> &x1, const std::vector<T_x2> &x2,
+                const T_sigma &sigma) {
+  using stan::math::square;
+  using stan::math::dot_product;
+
+  check_not_nan("gp_dot_prod_cov", "sigma", sigma);
+  check_nonnegative("gp_dot_prod_cov", "sigma", sigma);
+  check_finite("gp_dot_prod_cov", "sigma", sigma);
+
+  for (size_t n = 0; n < x1.size(); ++n) {
+    check_not_nan("gp_dot_prod_cov", "x1", x1[n]);
+    check_finite("gp_dot_prod_cov", "x1", x1[n]);
+  }
+  for (size_t n = 0; n < x2.size(); ++n) {
+    check_not_nan("gp_dot_prod_cov", "x2", x2[n]);
+    check_finite("gp_dot_prod_cov", "x2", x2[n]);
+  }
+  Eigen::Matrix<typename stan::return_type<T_x1, T_x2, T_sigma>::type,
+                Eigen::Dynamic, Eigen::Dynamic>
+      cov(x1.size(), x2.size());
+
+  if (x1.size() == 0 || x2.size() == 0)
+    return cov;
+
+  T_sigma sigma_sq = square(sigma);
+
+    for (size_t i = 0; i < x1.size(); ++i) {
+      for (size_t j = 0; j < x2.size(); ++j) {
+        cov(i, j) = sigma_sq + dot_product(x1[i], x2[j]);
+      }
+    }
+  return cov;
+}
+
+/**
+ * Returns a dot product kernel.
+ *
+ * @tparam T_x1 type of first std::vector of double
+ * @tparam T_x2 type of second std::vector of double
+ * @tparam T_sigma type of sigma
+ *
+ * @param x1 std::vector of elements that can be used in dot_product
+ * @param x2 std::vector of elements that can be used in dot_product
+ * @param sigma
+ * @return dot product kernel
+ * @throw std::domain_error if sigma < 0, nan or inf
+ *   or if x1 or x2 are nan or inf
+ */
+template <typename T_sigma>
+inline typename Eigen::Matrix<typename stan::return_type<double, T_sigma>::type,
+                              Eigen::Dynamic, Eigen::Dynamic>
+gp_dot_prod_cov(const std::vector<double> &x1, const std::vector<double> &x2,
+                const T_sigma &sigma) {
+  using stan::math::square;
+
+  check_not_nan("gp_dot_prod_cov", "sigma", sigma);
+  check_nonnegative("gp_dot_prod_cov", "sigma", sigma);
+  check_finite("gp_dot_prod_cov", "sigma", sigma);
+
+  for (size_t n = 0; n < x1.size(); ++n) {
+    check_not_nan("gp_dot_prod_cov", "x1", x1[n]);
+    check_finite("gp_dot_prod_cov", "x1", x1[n]);
+  }
+  for (size_t n = 0; n < x2.size(); ++n) {
+    check_not_nan("gp_dot_prod_cov", "x2", x2[n]);
+    check_finite("gp_dot_prod_cov", "x2", x2[n]);
+  }
+  Eigen::Matrix<typename stan::return_type<double, T_sigma>::type,
+                Eigen::Dynamic, Eigen::Dynamic>
+      cov(x1.size(), x2.size());
+
+  if (x1.size() == 0 || x2.size() == 0)
+    return cov;
+
+  T_sigma sigma_sq = square(sigma);
+
+  for (size_t i = 0; i < x1.size(); ++i) {
+    for (size_t j = 0; j < x2.size(); ++j) {
+      cov(i, j) = sigma_sq + x1[i] * x2[j];
+    }
+  }
+  return cov;
+}
+}  // math
+}  // stan
+#endif

--- a/stan/math/rev/mat.hpp
+++ b/stan/math/rev/mat.hpp
@@ -22,6 +22,7 @@
 #include <stan/math/rev/mat/fun/dot_product.hpp>
 #include <stan/math/rev/mat/fun/dot_self.hpp>
 #include <stan/math/rev/mat/fun/grad.hpp>
+#include <stan/math/rev/mat/fun/gp_dot_prod_cov.hpp>
 #include <stan/math/rev/mat/fun/initialize_variable.hpp>
 #include <stan/math/rev/mat/fun/LDLT_alloc.hpp>
 #include <stan/math/rev/mat/fun/LDLT_factor.hpp>

--- a/stan/math/rev/mat/fun/gp_dot_prod_cov.hpp
+++ b/stan/math/rev/mat/fun/gp_dot_prod_cov.hpp
@@ -1,0 +1,178 @@
+#ifndef STAN_MATH_REV_MAT_FUN_GP_DOT_PROD_COV_HPP
+#define STAN_MATH_REV_MAT_FUN_GP_DOT_PROD_COV_HPP
+
+#include <boost/math/tools/promotion.hpp>
+#include <stan/math/rev/mat/fun/dot_product.hpp>
+#include <stan/math/rev/scal/err/check_nonnegative.hpp>
+#include <stan/math/rev/scal/err/check_not_nan.hpp>
+#include <stan/math/rev/scal/err/check_size_match.hpp>
+#include <boost/type_traits.hpp>
+#include <vector>
+
+namespace stan {
+namespace math {
+
+  /**
+   * This is a subclass of the vari class for precomputed
+   * gradients of gp_dot_prod_cov.
+   * 
+   * The class stores the double values for the stiance
+   * matrix, pointers to the varis  for the covariance 
+   * matrix, along with a pointer to the vari for sigma,
+   * and the vari for length scale.
+   *
+   * @tparam T_x type of std::vector of elements
+   * @tparam T_sigma type of sigma
+   */
+template <typename T_x, typename T_sigma>
+inline typename boost::enable_if_c<
+    boost::is_same<typename scalar_type<T_x>::type, double>::value,
+  std::vector<double>>::type
+class gp_dot_prod_cov_vari : public vari {
+public:
+  const size_t size_;
+  const size_t size_ltri;
+  const double sigma_d_;
+  const double sigma_sq_d_;
+  double *dist_;
+  vari *l_vari_;
+  vari *sigma_vari_;
+  vari **cov_lower_;
+  vari **cov_diag_;
+  gp_dot_prod_cov_vari(const std::vector<stan::math::var> &x,
+                       const T_sigma &sigma)
+    : vari(0.0), size_x(x.size()), size_ltri_(size_ * (size_ - 1) / 2),
+      sigma_d_(value_of(sigma)), sigma_sq_d_(sigma_d_ * sigma_d_),
+      dist_(ChainableStack::memalloc_.alloc_array<double>(size_ltri_)),
+      sigma_vari_(sigma.vi_),
+      cov_lower_(ChainableStack::memalloc_.alloc_array<vari *>(size_ltri_)),
+      cov_diag_(ChainableStack::memalloc_.alloc_array<vari *> size_)) {
+  size_t pos = 0;
+  for (size_t j = 0; j < size_ - 1; ++j) {
+    cov_diag_[j] = new vari(sigma_sq_d_ + x[j] * x[j]);
+    for (size_t i = j + 1; i < size_; ++i) {
+      cov_lower_[pos] =
+        new vari(sigma_sq_d_ + x[j] * x[i]);
+      ++pos;
+    }
+  }
+
+  virtual void chain() {
+    double adjsigma = 0;
+
+    for (size_t i = 0; i < size_ltri_; ++i) {
+      vari *el_low = cov_lower_[i];
+      adjsigma += el_low->adj_ * el_low->val_;
+    }
+    for (size_t i = 0; i < size_; ++i) {
+      vari *el = cov_diag_[i];
+      adjsigma += el->adj_ * el->val_;
+    }
+    sigma_vari_->adj_ += adjsigma * 2 / sigma_d_;
+  }
+}
+
+  /**
+   * This is a subclass of the vari class for precomputed
+   * gradients of gp_dot_prod_cov.
+   * 
+   * The class stores the double values for the stiance
+   * matrix, pointers to the varis  for the covariance 
+   * matrix, along with a pointer to the vari for sigma,
+   * and the vari for length scale.
+   *
+   * @tparam T_x type of std::vector of elements
+   * @tparam T_sigma type of sigma
+   */
+template <typename T_x, typename T_sigma>
+inline typename boost::enable_if_c<
+    boost::is_same<typename scalar_type<T_x>::type, double>::value,
+  Eigen::Matrix<var, -1, -1>>::type
+class gp_dot_prod_cov_vari : public vari {
+public:
+  const size_t size_;
+  const size_t size_ltri;
+  const double sigma_d_;
+  const double sigma_sq_d_;
+  double *dist_;
+  vari *l_vari_;
+  vari *sigma_vari_;
+  vari **cov_lower_;
+  vari **cov_diag_;
+  gp_dot_prod_cov_vari(const std::vector<T_x> &x, const T_sigma &sigma)
+    : vari(0.0), size_x(x.size()), size_ltri_(size_ * (size_ - 1) / 2),
+      sigma_d_(value_of(sigma)), sigma_sq_d_(sigma_d_ * sigma_d_),
+      dot_prod_(ChainableStack::memalloc_.alloc_array<double>(size_ltri_)),
+      sigma_vari_(sigma.vi_),
+      cov_lower_(ChainableStack::memalloc_.alloc_array<vari *>(size_ltri_)),
+      cov_diag_(ChainableStack::memalloc_.alloc_array<vari *> size_)) {
+  size_t pos = 0;
+  for (size_t j = 0; j < size_ - 1; ++j) {
+    for (size_t i = j + 1; i < size_; ++i) {
+      cov_lower_[pos] =
+        new vari(sigma_sq_d_ + stan::math::dot_product(x[j], x[i]));
+      ++pos;
+    }
+  }
+  for (size_t i = 0; i < size_; ++i)
+    cov_diag_[i] = sigma_sq_d_ + stan::math::dot_product(x[i], x[i]);
+  virtual void chain() {
+    double adjsigma = 0;
+
+    for (size_t i = 0; i < size_ltri_; ++i) {
+      vari *el_low = cov_lower_[i];
+      adjsigma += el_low->adj_ * el_low->val_;
+    }
+    for (size_t i = 0; i < size_; ++i) {
+      vari *el = cov_diag_[i];
+      adjsigma += el->adj_ * el->val_;
+    }
+    sigma_vari_->adj_ += adjsigma * 2 * sigma_d_;
+  }
+}
+
+  /**
+   * Returns a dot product kernel.
+   * 
+   * @param x std::vector input that can be used in dot product
+   *    Assumes each element of x is the same size
+   * @param sigma 
+   * @throw std::domain_error if sigma < 0, nan, inf or
+   *   x is nan or infinite
+   */
+  template <typename T_x, typename T_sigma>
+  inline typename boost::enable_if_c<
+    boost::is_same<typename scalar_type<T_x>::type, typename<double>>::value>
+  gp_dot_prod_cov(const std::vector<T_x> &x, T_sigma sigma) {
+    size_t x_size = x.size();
+
+    check_not_nan("gp_dot_prod_cov", "sigma", sigma);
+    check_nonnegative("gp_dot_prod_cov", "sigma", sigma);
+    check_finite("gp_dot_prod_cov", "sigma", sigma);
+
+    for (size_t n = 0; n < x.size(); ++n) {
+      check_not_nan("gp_dot_prod_cov", "x", x[n]);
+      check_finite("gp_dot_prod_cov", "x", x[n]);
+    }
+
+    Eigen::Matrix<var, -1, -1> cov(x_size, x_size);
+    if (x_size == 0)
+      return cov;
+
+    gp_dot_prod_cov_vari<T_x, double, var> *baseVari =
+      new gp_dot_prod_cov_vari<T_x, double, var>(x, sigma);
+
+    size_t pos = 0;
+    for (size_t j = 0; j < x_size - 1; ++j) {
+      for (size_t i = (j + 1); i < x_size; ++i) {
+        cov.coeffRef(i, j).vi_ = baseVari->cov_lower_[pos];
+        cov.coeffRef(j, i).vi_ = cov.coefRef(i, j).vi_;
+        ++pos;
+      }
+      cov.coeffRef(j, j).vi_ = baseVari->cov_diag_[j];
+    }
+    cov.coeffRef(x_size - 1, x_size - 1).vi_ = baseVar->cov_diag_[x_size - 1];
+    return cov;
+  }
+}  // namespace math
+}  // namespace stan

--- a/stan/math/rev/mat/fun/gp_dot_prod_cov.hpp
+++ b/stan/math/rev/mat/fun/gp_dot_prod_cov.hpp
@@ -12,24 +12,23 @@
 namespace stan {
 namespace math {
 
-  /**
-   * This is a subclass of the vari class for precomputed
-   * gradients of gp_dot_prod_cov.
-   * 
-   * The class stores the double values for the stiance
-   * matrix, pointers to the varis  for the covariance 
-   * matrix, along with a pointer to the vari for sigma,
-   * and the vari for length scale.
-   *
-   * @tparam T_x type of std::vector of elements
-   * @tparam T_sigma type of sigma
-   */
+/**
+ * This is a subclass of the vari class for precomputed
+ * gradients of gp_dot_prod_cov.
+ *
+ * The class stores the double values for the stiance
+ * matrix, pointers to the varis  for the covariance
+ * matrix, along with a pointer to the vari for sigma,
+ * and the vari for length scale.
+ *
+ * @tparam T_x type of std::vector of elements
+ * @tparam T_sigma type of sigma
+ */
 template <typename T_x, typename T_sigma>
 inline typename boost::enable_if_c<
     boost::is_same<typename scalar_type<T_x>::type, double>::value,
-  std::vector<double>>::type
-class gp_dot_prod_cov_vari : public vari {
-public:
+    std::vector<double>>::type class gp_dot_prod_cov_vari : public vari {
+ public:
   const size_t size_;
   const size_t size_ltri;
   const double sigma_d_;
@@ -47,58 +46,57 @@ public:
       sigma_vari_(sigma.vi_),
       cov_lower_(ChainableStack::memalloc_.alloc_array<vari *>(size_ltri_)),
       cov_diag_(ChainableStack::memalloc_.alloc_array<vari *> size_)) {
-  size_t pos = 0;
-  for (size_t j = 0; j < size_ - 1; ++j) {
-    cov_diag_[j] = new vari(sigma_sq_d_ + x[j] * x[j]);
-    for (size_t i = j + 1; i < size_; ++i) {
-      cov_lower_[pos] =
-        new vari(sigma_sq_d_ + x[j] * x[i]);
-      ++pos;
+    size_t pos = 0;
+    for (size_t j = 0; j < size_ - 1; ++j) {
+      cov_diag_[j] = new vari(sigma_sq_d_ + x[j] * x[j]);
+      for (size_t i = j + 1; i < size_; ++i) {
+        cov_lower_[pos] = new vari(sigma_sq_d_ + x[j] * x[i]);
+        ++pos;
+      }
+    }
+
+    virtual void chain() {
+      double adjsigma = 0;
+
+      for (size_t i = 0; i < size_ltri_; ++i) {
+        vari *el_low = cov_lower_[i];
+        adjsigma += el_low->adj_ * el_low->val_;
+      }
+      for (size_t i = 0; i < size_; ++i) {
+        vari *el = cov_diag_[i];
+        adjsigma += el->adj_ * el->val_;
+      }
+      sigma_vari_->adj_ += adjsigma * 2 / sigma_d_;
     }
   }
-
-  virtual void chain() {
-    double adjsigma = 0;
-
-    for (size_t i = 0; i < size_ltri_; ++i) {
-      vari *el_low = cov_lower_[i];
-      adjsigma += el_low->adj_ * el_low->val_;
-    }
-    for (size_t i = 0; i < size_; ++i) {
-      vari *el = cov_diag_[i];
-      adjsigma += el->adj_ * el->val_;
-    }
-    sigma_vari_->adj_ += adjsigma * 2 / sigma_d_;
-  }
-}
 
   /**
    * This is a subclass of the vari class for precomputed
    * gradients of gp_dot_prod_cov.
-   * 
+   *
    * The class stores the double values for the stiance
-   * matrix, pointers to the varis  for the covariance 
+   * matrix, pointers to the varis  for the covariance
    * matrix, along with a pointer to the vari for sigma,
    * and the vari for length scale.
    *
    * @tparam T_x type of std::vector of elements
    * @tparam T_sigma type of sigma
    */
-template <typename T_x, typename T_sigma>
-inline typename boost::enable_if_c<
-    boost::is_same<typename scalar_type<T_x>::type, double>::value,
-  Eigen::Matrix<var, -1, -1>>::type
-class gp_dot_prod_cov_vari : public vari {
-public:
-  const size_t size_;
-  const size_t size_ltri;
-  const double sigma_d_;
-  const double sigma_sq_d_;
-  double *dist_;
-  vari *l_vari_;
-  vari *sigma_vari_;
-  vari **cov_lower_;
-  vari **cov_diag_;
+  template <typename T_x, typename T_sigma>
+  inline typename boost::enable_if_c<
+      boost::is_same<typename scalar_type<T_x>::type, double>::value,
+      Eigen::Matrix<var, -1, -1>>::type class gp_dot_prod_cov_vari
+      : public vari {
+   public:
+    const size_t size_;
+    const size_t size_ltri;
+    const double sigma_d_;
+    const double sigma_sq_d_;
+    double *dist_;
+    vari *l_vari_;
+    vari *sigma_vari_;
+    vari **cov_lower_;
+    vari **cov_diag_;
   gp_dot_prod_cov_vari(const std::vector<T_x> &x, const T_sigma &sigma)
     : vari(0.0), size_x(x.size()), size_ltri_(size_ * (size_ - 1) / 2),
       sigma_d_(value_of(sigma)), sigma_sq_d_(sigma_d_ * sigma_d_),
@@ -106,43 +104,43 @@ public:
       sigma_vari_(sigma.vi_),
       cov_lower_(ChainableStack::memalloc_.alloc_array<vari *>(size_ltri_)),
       cov_diag_(ChainableStack::memalloc_.alloc_array<vari *> size_)) {
-  size_t pos = 0;
-  for (size_t j = 0; j < size_ - 1; ++j) {
-    for (size_t i = j + 1; i < size_; ++i) {
-      cov_lower_[pos] =
-        new vari(sigma_sq_d_ + stan::math::dot_product(x[j], x[i]));
-      ++pos;
+    size_t pos = 0;
+    for (size_t j = 0; j < size_ - 1; ++j) {
+      for (size_t i = j + 1; i < size_; ++i) {
+        cov_lower_[pos]
+            = new vari(sigma_sq_d_ + stan::math::dot_product(x[j], x[i]));
+        ++pos;
+      }
     }
-  }
-  for (size_t i = 0; i < size_; ++i)
-    cov_diag_[i] = sigma_sq_d_ + stan::math::dot_product(x[i], x[i]);
-  virtual void chain() {
-    double adjsigma = 0;
+    for (size_t i = 0; i < size_; ++i)
+      cov_diag_[i] = sigma_sq_d_ + stan::math::dot_product(x[i], x[i]);
+    virtual void chain() {
+      double adjsigma = 0;
 
-    for (size_t i = 0; i < size_ltri_; ++i) {
-      vari *el_low = cov_lower_[i];
-      adjsigma += el_low->adj_ * el_low->val_;
+      for (size_t i = 0; i < size_ltri_; ++i) {
+        vari *el_low = cov_lower_[i];
+        adjsigma += el_low->adj_ * el_low->val_;
+      }
+      for (size_t i = 0; i < size_; ++i) {
+        vari *el = cov_diag_[i];
+        adjsigma += el->adj_ * el->val_;
+      }
+      sigma_vari_->adj_ += adjsigma * 2 * sigma_d_;
     }
-    for (size_t i = 0; i < size_; ++i) {
-      vari *el = cov_diag_[i];
-      adjsigma += el->adj_ * el->val_;
-    }
-    sigma_vari_->adj_ += adjsigma * 2 * sigma_d_;
   }
-}
 
   /**
    * Returns a dot product kernel.
-   * 
+   *
    * @param x std::vector input that can be used in dot product
    *    Assumes each element of x is the same size
-   * @param sigma 
+   * @param sigma
    * @throw std::domain_error if sigma < 0, nan, inf or
    *   x is nan or infinite
    */
   template <typename T_x, typename T_sigma>
   inline typename boost::enable_if_c<
-    boost::is_same<typename scalar_type<T_x>::type, typename<double>>::value>
+      boost::is_same<typename scalar_type<T_x>::type, typename<double>>::value>
   gp_dot_prod_cov(const std::vector<T_x> &x, T_sigma sigma) {
     size_t x_size = x.size();
 
@@ -159,8 +157,8 @@ public:
     if (x_size == 0)
       return cov;
 
-    gp_dot_prod_cov_vari<T_x, double, var> *baseVari =
-      new gp_dot_prod_cov_vari<T_x, double, var>(x, sigma);
+    gp_dot_prod_cov_vari<T_x, double, var> *baseVari
+        = new gp_dot_prod_cov_vari<T_x, double, var>(x, sigma);
 
     size_t pos = 0;
     for (size_t j = 0; j < x_size - 1; ++j) {
@@ -174,5 +172,5 @@ public:
     cov.coeffRef(x_size - 1, x_size - 1).vi_ = baseVar->cov_diag_[x_size - 1];
     return cov;
   }
-}  // namespace math
+  }  // namespace math
 }  // namespace stan

--- a/test/unit/math/prim/mat/fun/gp_dot_prod_cov_test.cpp
+++ b/test/unit/math/prim/mat/fun/gp_dot_prod_cov_test.cpp
@@ -350,9 +350,9 @@ TEST(MathPrimMat, vec_rvec_x1_x2_gp_dot_prod_cov0) {
   EXPECT_EQ(3, cov.cols());
   for (int i = 0; i < 3; ++i) {
     for (int j = 0; j < 3; ++j) {
-      EXPECT_FLOAT_EQ(sigma * sigma +
-                          stan::math::dot_product(x1_vec[i], x1_rvec[j]),
-                      cov(i, j))
+      EXPECT_FLOAT_EQ(
+          sigma * sigma + stan::math::dot_product(x1_vec[i], x1_rvec[j]),
+          cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -378,9 +378,9 @@ TEST(MathPrimMat, rvec_rvec_x1_x2_gp_dot_prod_cov0) {
   EXPECT_NO_THROW(cov = stan::math::gp_dot_prod_cov(x1_rvec, x2_rvec, sigma));
   for (int i = 0; i < 3; ++i) {
     for (int j = 0; j < 3; ++j) {
-      EXPECT_FLOAT_EQ(sigma * sigma +
-                          stan::math::dot_product(x1_rvec[i], x2_rvec[j]),
-                      cov(i, j))
+      EXPECT_FLOAT_EQ(
+          sigma * sigma + stan::math::dot_product(x1_rvec[i], x2_rvec[j]),
+          cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }

--- a/test/unit/math/prim/mat/fun/gp_dot_prod_cov_test.cpp
+++ b/test/unit/math/prim/mat/fun/gp_dot_prod_cov_test.cpp
@@ -1,0 +1,387 @@
+#include <gtest/gtest.h>
+#include <stan/math/prim/mat.hpp>
+#include <limits>
+#include <string>
+#include <vector>
+
+template <typename T_x, typename T_sigma>
+std::string pull_msg(std::vector<T_x> x, T_sigma sigma) {
+  std::string message;
+  try {
+    stan::math::gp_dot_prod_cov(x, sigma);
+  } catch (std::domain_error &e) {
+    message = e.what();
+  } catch (...) {
+    message = "Threw the wrong exection";
+  }
+  return message;
+}
+
+template <typename T_x1, typename T_x2, typename T_sigma>
+std::string pull_msg(std::vector<T_x1> x1, std::vector<T_x2> x2,
+                     T_sigma sigma) {
+  std::string message;
+  try {
+    stan::math::gp_dot_prod_cov(x1, x2, sigma);
+  } catch (std::domain_error &e) {
+    message = e.what();
+  } catch (...) {
+    message = "Threw the wrong exection";
+  }
+  return message;
+}
+
+TEST(MathPrimMat, dummy_function) {
+  // just testing templates here
+
+  std::vector<double> x_0(2);
+  x_0[0] = 1;
+  x_0[1] = 2;
+
+  std::vector<Eigen::Matrix<double, -1, 1>> x_1(2);
+  for (size_t i = 0; i < x_1.size(); ++i) {
+    x_1[i].resize(3, 1);
+    x_1[i] << 2 * i, 3 * i, 4 * i;
+  }
+
+  // stan::math::dummy_fun(x_0);
+  // stan::math::dummy_fun(x_1);
+}
+
+TEST(MathPrimMat, vec_double_gp_dot_prod_cov0) {
+  double sigma = 0.5;
+  double sigma_sq = pow(sigma, 2);
+
+  std::vector<double> x(3);
+  x[0] = -2;
+  x[1] = -1;
+  x[2] = -0.5;
+
+  Eigen::MatrixXd cov;
+  cov = stan::math::gp_dot_prod_cov(x, sigma);
+  EXPECT_NO_THROW(cov = stan::math::gp_dot_prod_cov(x, sigma));
+
+  for (int i = 0; i < 3; i++)
+    for (int j = 0; j < 3; j++)
+      EXPECT_FLOAT_EQ(sigma_sq + x[i] * x[j], cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+}
+
+TEST(MathPrimMat, vec_x_gp_dot_prod_cov0) {
+  double sigma = 0.5;
+
+  std::vector<Eigen::Matrix<double, -1, 1>> x(3);
+  for (size_t i = 0; i < x.size(); ++i) {
+    x[i].resize(3, 1);
+    x[i] << 2 * i, 3 * i, 4 * i;
+  }
+
+  Eigen::MatrixXd cov;
+  EXPECT_NO_THROW(cov = stan::math::gp_dot_prod_cov(x, sigma));
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      EXPECT_FLOAT_EQ(sigma * sigma + stan::math::dot_product(x[i], x[j]),
+                      cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+}
+
+TEST(MathPrimMat, vec_NaN_x_gp_dot_prod_cov_cov0) {
+  double sigma = 1;
+  std::vector<double> x(2);
+  x[0] = 1;
+  x[1] = std::numeric_limits<double>::quiet_NaN();
+
+  EXPECT_THROW(stan::math::gp_dot_prod_cov(x, sigma), std::domain_error);
+  std::string msg;
+  msg = pull_msg(x, sigma);
+  EXPECT_TRUE(std::string::npos != msg.find(" x")) << msg;
+}
+
+TEST(MathPrimMat, vec_NaN_sigma_gp_dot_prod_cov_cov0) {
+  double sigma = std::numeric_limits<double>::quiet_NaN();
+  std::vector<double> x(2);
+  x[0] = 1;
+  x[1] = 2;
+
+  EXPECT_THROW(stan::math::gp_dot_prod_cov(x, sigma), std::domain_error);
+  std::string msg;
+  msg = pull_msg(x, sigma);
+  EXPECT_TRUE(std::string::npos != msg.find(" sigma")) << msg;
+}
+
+TEST(MathPrimMat, vec_NaN_x1_gp_dot_prod_cov_cov0) {
+  double sigma = 2;
+
+  std::vector<double> x1(2);
+  x1[0] = std::numeric_limits<double>::quiet_NaN();
+  x1[1] = 2;
+
+  std::vector<double> x2(2);
+  x2[0] = 1;
+  x2[1] = 2;
+
+  EXPECT_THROW(stan::math::gp_dot_prod_cov(x1, x2, sigma), std::domain_error);
+  std::string msg;
+  msg = pull_msg(x1, x2, sigma);
+  EXPECT_TRUE(std::string::npos != msg.find(" x1")) << msg;
+}
+
+TEST(MathPrimMat, vec_NaN_x2_gp_dot_prod_cov_cov0) {
+  double sigma = 2;
+
+  std::vector<double> x1(2);
+  x1[0] = 1;
+  x1[1] = 2;
+
+  std::vector<double> x2(2);
+  x2[0] = 1;
+  x2[1] = std::numeric_limits<double>::quiet_NaN();
+
+  EXPECT_THROW(stan::math::gp_dot_prod_cov(x1, x2, sigma), std::domain_error);
+  std::string msg;
+  msg = pull_msg(x1, x2, sigma);
+  EXPECT_TRUE(std::string::npos != msg.find(" x2")) << msg;
+}
+
+TEST(MathPrimMat, vec_NaN_x1_x2_sigma_gp_dot_prod_cov_cov0) {
+  double sigma = std::numeric_limits<double>::quiet_NaN();
+
+  std::vector<double> x1(2);
+  x1[0] = 1;
+  x1[1] = 2;
+
+  std::vector<double> x2(2);
+  x2[0] = 1;
+  x2[1] = 3;
+
+  EXPECT_THROW(stan::math::gp_dot_prod_cov(x1, x2, sigma), std::domain_error);
+  std::string msg;
+  msg = pull_msg(x1, x2, sigma);
+  EXPECT_TRUE(std::string::npos != msg.find(" sigma")) << msg;
+}
+
+TEST(MathPrimMat, vec_inf_x_gp_dot_prod_cov_cov0) {
+  double sigma = 1;
+  std::vector<double> x(2);
+  x[0] = 1;
+  x[1] = std::numeric_limits<double>::infinity();
+
+  EXPECT_THROW(stan::math::gp_dot_prod_cov(x, sigma), std::domain_error);
+  std::string msg;
+  msg = pull_msg(x, sigma);
+  EXPECT_TRUE(std::string::npos != msg.find(" x")) << msg;
+}
+
+TEST(MathPrimMat, vec_inf_sigma_gp_dot_prod_cov_cov0) {
+  double sigma = std::numeric_limits<double>::infinity();
+  std::vector<double> x(2);
+  x[0] = 1;
+  x[1] = 2;
+
+  EXPECT_THROW(stan::math::gp_dot_prod_cov(x, sigma), std::domain_error);
+  std::string msg;
+  msg = pull_msg(x, sigma);
+  EXPECT_TRUE(std::string::npos != msg.find(" sigma")) << msg;
+}
+
+TEST(MathPrimMat, vec_inf_x1_gp_dot_prod_cov_cov0) {
+  double sigma = 2;
+
+  std::vector<double> x1(2);
+  x1[0] = std::numeric_limits<double>::infinity();
+  x1[1] = 2;
+
+  std::vector<double> x2(2);
+  x2[0] = 1;
+  x2[1] = 2;
+
+  EXPECT_THROW(stan::math::gp_dot_prod_cov(x1, x2, sigma), std::domain_error);
+  std::string msg;
+  msg = pull_msg(x1, x2, sigma);
+  EXPECT_TRUE(std::string::npos != msg.find(" x1")) << msg;
+}
+
+TEST(MathPrimMat, vec_inf_x2_gp_dot_prod_cov_cov0) {
+  double sigma = 2;
+
+  std::vector<double> x1(2);
+  x1[0] = 1;
+  x1[1] = 2;
+
+  std::vector<double> x2(2);
+  x2[0] = 1;
+  x2[1] = std::numeric_limits<double>::infinity();
+
+  EXPECT_THROW(stan::math::gp_dot_prod_cov(x1, x2, sigma), std::domain_error);
+  std::string msg;
+  msg = pull_msg(x1, x2, sigma);
+  EXPECT_TRUE(std::string::npos != msg.find(" x2")) << msg;
+}
+
+TEST(MathPrimMat, vec_inf_x1_x2_sigma_gp_dot_prod_cov_cov0) {
+  double sigma = std::numeric_limits<double>::infinity();
+
+  std::vector<double> x1(2);
+  x1[0] = 1;
+  x1[1] = 2;
+
+  std::vector<double> x2(2);
+  x2[0] = 1;
+  x2[1] = 3;
+
+  EXPECT_THROW(stan::math::gp_dot_prod_cov(x1, x2, sigma), std::domain_error);
+
+  std::string msg;
+  msg = pull_msg(x1, x2, sigma);
+  EXPECT_TRUE(std::string::npos != msg.find(" sigma")) << msg;
+}
+
+TEST(MathPrimMat, rvec_x_gp_dot_prod_cov0) {
+  double sigma = 0.5;
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x(3);
+  for (size_t i = 0; i < x.size(); ++i) {
+    x[i].resize(1, 3);
+    x[i] << 1 * i, 2 * i, 3 * i;
+  }
+
+  Eigen::MatrixXd cov;
+  EXPECT_NO_THROW(cov = stan::math::gp_dot_prod_cov(x, sigma));
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      EXPECT_FLOAT_EQ(sigma * sigma + stan::math::dot_product(x[i], x[j]),
+                      cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+}
+
+TEST(MathPrimMat, vec_vec_x1_x2_gp_dot_prod_cov0) {
+  double sigma = 0.5;
+
+  std::vector<Eigen::Matrix<double, -1, 1>> x1(3);
+  for (size_t i = 0; i < x1.size(); ++i) {
+    x1[i].resize(3, 1);
+    x1[i] << 2 * i, 3 * i, 4 * i;
+  }
+
+  std::vector<Eigen::Matrix<double, -1, 1>> x2(4);
+  for (size_t i = 0; i < x2.size(); ++i) {
+    x2[i].resize(3, 1);
+    x2[i] << 1 * i, 2 * i, 3 * i;
+  }
+
+  Eigen::MatrixXd cov;
+  EXPECT_NO_THROW(cov = stan::math::gp_dot_prod_cov(x1, x2, sigma));
+  EXPECT_EQ(3, cov.rows());
+  EXPECT_EQ(4, cov.cols());
+  for (int i = 0; i < 3; ++i) {
+    for (int j = 0; j < 4; ++j) {
+      EXPECT_FLOAT_EQ(sigma * sigma + stan::math::dot_product(x1[i], x2[j]),
+                      cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+}
+
+TEST(MathPrimMat, rvec_vec_x1_x2_gp_dot_prod_cov0) {
+  double sigma = 0.5;
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x1(3);
+  std::vector<Eigen::Matrix<double, 1, -1>> x2(4);
+
+  for (size_t i = 0; i < x1.size(); ++i) {
+    x1[i].resize(1, 3);
+    x1[i] << 1 * i, 2 * i, 3 * i;
+  }
+
+  for (size_t i = 0; i < x2.size(); ++i) {
+    x2[i].resize(1, 3);
+    x2[i] << 2 * i, 3 * i, 4 * i;
+  }
+
+  Eigen::MatrixXd cov;
+  EXPECT_NO_THROW(cov = stan::math::gp_dot_prod_cov(x1, x2, sigma));
+  EXPECT_EQ(3, cov.rows());
+  EXPECT_EQ(4, cov.cols());
+  for (int i = 0; i < 3; ++i) {
+    for (int j = 0; j < 4; ++j) {
+      EXPECT_FLOAT_EQ(sigma * sigma + stan::math::dot_product(x1[i], x2[j]),
+                      cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+
+  Eigen::MatrixXd cov2;
+  EXPECT_NO_THROW(cov2 = stan::math::gp_dot_prod_cov(x1, x2, sigma));
+  EXPECT_EQ(3, cov2.rows());
+  EXPECT_EQ(4, cov2.cols());
+  for (int i = 0; i < 3; ++i) {
+    for (int j = 0; j < 4; ++j) {
+      EXPECT_FLOAT_EQ(sigma * sigma + stan::math::dot_product(x1[i], x2[j]),
+                      cov2(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+}
+
+TEST(MathPrimMat, vec_rvec_x1_x2_gp_dot_prod_cov0) {
+  double sigma = 0.7;
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x1_rvec(3);
+
+  for (size_t i = 0; i < x1_rvec.size(); ++i) {
+    x1_rvec[i].resize(1, 3);
+    x1_rvec[i] << 1 * i, 2 * i, 3 * i;
+  }
+
+  std::vector<Eigen::Matrix<double, -1, 1>> x1_vec(3);
+
+  for (size_t i = 0; i < x1_vec.size(); ++i) {
+    x1_vec[i].resize(3, 1);
+    x1_vec[i] << 1 * i, 2 * i, 3 * i;
+  }
+
+  Eigen::MatrixXd cov;
+  EXPECT_NO_THROW(cov = stan::math::gp_dot_prod_cov(x1_vec, x1_rvec, sigma));
+  EXPECT_EQ(3, cov.rows());
+  EXPECT_EQ(3, cov.cols());
+  for (int i = 0; i < 3; ++i) {
+    for (int j = 0; j < 3; ++j) {
+      EXPECT_FLOAT_EQ(sigma * sigma +
+                          stan::math::dot_product(x1_vec[i], x1_rvec[j]),
+                      cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+}
+
+TEST(MathPrimMat, rvec_rvec_x1_x2_gp_dot_prod_cov0) {
+  double sigma = 0.8;
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x1_rvec(3);
+  std::vector<Eigen::Matrix<double, 1, -1>> x2_rvec(4);
+
+  for (size_t i = 0; i < x1_rvec.size(); ++i) {
+    x1_rvec[i].resize(1, 3);
+    x1_rvec[i] << 1 * i, 2 * i, 3 * i;
+  }
+
+  for (size_t i = 0; i < x2_rvec.size(); ++i) {
+    x2_rvec[i].resize(1, 3);
+    x2_rvec[i] << 2 * i, 3 * i, 4 * i;
+  }
+
+  Eigen::MatrixXd cov;
+  EXPECT_NO_THROW(cov = stan::math::gp_dot_prod_cov(x1_rvec, x2_rvec, sigma));
+  for (int i = 0; i < 3; ++i) {
+    for (int j = 0; j < 3; ++j) {
+      EXPECT_FLOAT_EQ(sigma * sigma +
+                          stan::math::dot_product(x1_rvec[i], x2_rvec[j]),
+                      cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+}

--- a/test/unit/math/rev/mat/fun/gp_dot_prod_cov_test.cpp
+++ b/test/unit/math/rev/mat/fun/gp_dot_prod_cov_test.cpp
@@ -1,0 +1,370 @@
+#include <gtest/gtest.h>
+#include <stan/math/prim/mat.hpp>
+#include <limits>
+#include <string>
+#include <vector>
+
+template <typename T_x, typename T_sigma>
+std::string pull_msg(std::vector<T_x> x, T_sigma sigma) {
+  std::string message;
+  try {
+    stan::math::gp_dot_prod_cov(x, sigma);
+  } catch (std::domain_error &e) {
+    message = e.what();
+  } catch (...) {
+    message = "Threw the wrong exection";
+  }
+  return message;
+}
+
+template <typename T_x1, typename T_x2, typename T_sigma>
+std::string pull_msg(std::vector<T_x1> x1, std::vector<T_x2> x2,
+                     T_sigma sigma) {
+  std::string message;
+  try {
+    stan::math::gp_dot_prod_cov(x1, x2, sigma);
+  } catch (std::domain_error &e) {
+    message = e.what();
+  } catch (...) {
+    message = "Threw the wrong exection";
+  }
+  return message;
+}
+
+TEST(MathPrimMat, vec_double_gp_dot_prod_cov0) {
+  double sigma = 0.5;
+  double sigma_sq = pow(sigma, 2);
+
+  std::vector<double> x(3);
+  x[0] = -2;
+  x[1] = -1;
+  x[2] = -0.5;
+
+  Eigen::MatrixXd cov;
+  cov = stan::math::gp_dot_prod_cov(x, sigma);
+  EXPECT_NO_THROW(cov = stan::math::gp_dot_prod_cov(x, sigma));
+
+  for (int i = 0; i < 3; i++)
+    for (int j = 0; j < 3; j++)
+      EXPECT_FLOAT_EQ(sigma_sq + x[i] * x[j], cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+}
+
+TEST(MathPrimMat, vec_x_gp_dot_prod_cov0) {
+  double sigma = 0.5;
+
+  std::vector<Eigen::Matrix<double, -1, 1>> x(3);
+  for (size_t i = 0; i < x.size(); ++i) {
+    x[i].resize(3, 1);
+    x[i] << 2 * i, 3 * i, 4 * i;
+  }
+
+  Eigen::MatrixXd cov;
+  EXPECT_NO_THROW(cov = stan::math::gp_dot_prod_cov(x, sigma));
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      EXPECT_FLOAT_EQ(sigma * sigma + stan::math::dot_product(x[i], x[j]),
+                      cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+}
+
+TEST(MathPrimMat, vec_NaN_x_gp_dot_prod_cov_cov0) {
+  double sigma = 1;
+  std::vector<double> x(2);
+  x[0] = 1;
+  x[1] = std::numeric_limits<double>::quiet_NaN();
+
+  EXPECT_THROW(stan::math::gp_dot_prod_cov(x, sigma), std::domain_error);
+  std::string msg;
+  msg = pull_msg(x, sigma);
+  EXPECT_TRUE(std::string::npos != msg.find(" x")) << msg;
+}
+
+TEST(MathPrimMat, vec_NaN_sigma_gp_dot_prod_cov_cov0) {
+  double sigma = std::numeric_limits<double>::quiet_NaN();
+  std::vector<double> x(2);
+  x[0] = 1;
+  x[1] = 2;
+
+  EXPECT_THROW(stan::math::gp_dot_prod_cov(x, sigma), std::domain_error);
+  std::string msg;
+  msg = pull_msg(x, sigma);
+  EXPECT_TRUE(std::string::npos != msg.find(" sigma")) << msg;
+}
+
+TEST(MathPrimMat, vec_NaN_x1_gp_dot_prod_cov_cov0) {
+  double sigma = 2;
+
+  std::vector<double> x1(2);
+  x1[0] = std::numeric_limits<double>::quiet_NaN();
+  x1[1] = 2;
+
+  std::vector<double> x2(2);
+  x2[0] = 1;
+  x2[1] = 2;
+
+  EXPECT_THROW(stan::math::gp_dot_prod_cov(x1, x2, sigma), std::domain_error);
+  std::string msg;
+  msg = pull_msg(x1, x2, sigma);
+  EXPECT_TRUE(std::string::npos != msg.find(" x1")) << msg;
+}
+
+TEST(MathPrimMat, vec_NaN_x2_gp_dot_prod_cov_cov0) {
+  double sigma = 2;
+
+  std::vector<double> x1(2);
+  x1[0] = 1;
+  x1[1] = 2;
+
+  std::vector<double> x2(2);
+  x2[0] = 1;
+  x2[1] = std::numeric_limits<double>::quiet_NaN();
+
+  EXPECT_THROW(stan::math::gp_dot_prod_cov(x1, x2, sigma), std::domain_error);
+  std::string msg;
+  msg = pull_msg(x1, x2, sigma);
+  EXPECT_TRUE(std::string::npos != msg.find(" x2")) << msg;
+}
+
+TEST(MathPrimMat, vec_NaN_x1_x2_sigma_gp_dot_prod_cov_cov0) {
+  double sigma = std::numeric_limits<double>::quiet_NaN();
+
+  std::vector<double> x1(2);
+  x1[0] = 1;
+  x1[1] = 2;
+
+  std::vector<double> x2(2);
+  x2[0] = 1;
+  x2[1] = 3;
+
+  EXPECT_THROW(stan::math::gp_dot_prod_cov(x1, x2, sigma), std::domain_error);
+  std::string msg;
+  msg = pull_msg(x1, x2, sigma);
+  EXPECT_TRUE(std::string::npos != msg.find(" sigma")) << msg;
+}
+
+TEST(MathPrimMat, vec_inf_x_gp_dot_prod_cov_cov0) {
+  double sigma = 1;
+  std::vector<double> x(2);
+  x[0] = 1;
+  x[1] = std::numeric_limits<double>::infinity();
+
+  EXPECT_THROW(stan::math::gp_dot_prod_cov(x, sigma), std::domain_error);
+  std::string msg;
+  msg = pull_msg(x, sigma);
+  EXPECT_TRUE(std::string::npos != msg.find(" x")) << msg;
+}
+
+TEST(MathPrimMat, vec_inf_sigma_gp_dot_prod_cov_cov0) {
+  double sigma = std::numeric_limits<double>::infinity();
+  std::vector<double> x(2);
+  x[0] = 1;
+  x[1] = 2;
+
+  EXPECT_THROW(stan::math::gp_dot_prod_cov(x, sigma), std::domain_error);
+  std::string msg;
+  msg = pull_msg(x, sigma);
+  EXPECT_TRUE(std::string::npos != msg.find(" sigma")) << msg;
+}
+
+TEST(MathPrimMat, vec_inf_x1_gp_dot_prod_cov_cov0) {
+  double sigma = 2;
+
+  std::vector<double> x1(2);
+  x1[0] = std::numeric_limits<double>::infinity();
+  x1[1] = 2;
+
+  std::vector<double> x2(2);
+  x2[0] = 1;
+  x2[1] = 2;
+
+  EXPECT_THROW(stan::math::gp_dot_prod_cov(x1, x2, sigma), std::domain_error);
+  std::string msg;
+  msg = pull_msg(x1, x2, sigma);
+  EXPECT_TRUE(std::string::npos != msg.find(" x1")) << msg;
+}
+
+TEST(MathPrimMat, vec_inf_x2_gp_dot_prod_cov_cov0) {
+  double sigma = 2;
+
+  std::vector<double> x1(2);
+  x1[0] = 1;
+  x1[1] = 2;
+
+  std::vector<double> x2(2);
+  x2[0] = 1;
+  x2[1] = std::numeric_limits<double>::infinity();
+
+  EXPECT_THROW(stan::math::gp_dot_prod_cov(x1, x2, sigma), std::domain_error);
+  std::string msg;
+  msg = pull_msg(x1, x2, sigma);
+  EXPECT_TRUE(std::string::npos != msg.find(" x2")) << msg;
+}
+
+TEST(MathPrimMat, vec_inf_x1_x2_sigma_gp_dot_prod_cov_cov0) {
+  double sigma = std::numeric_limits<double>::infinity();
+
+  std::vector<double> x1(2);
+  x1[0] = 1;
+  x1[1] = 2;
+
+  std::vector<double> x2(2);
+  x2[0] = 1;
+  x2[1] = 3;
+
+  EXPECT_THROW(stan::math::gp_dot_prod_cov(x1, x2, sigma), std::domain_error);
+
+  std::string msg;
+  msg = pull_msg(x1, x2, sigma);
+  EXPECT_TRUE(std::string::npos != msg.find(" sigma")) << msg;
+}
+
+TEST(MathPrimMat, rvec_x_gp_dot_prod_cov0) {
+  double sigma = 0.5;
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x(3);
+  for (size_t i = 0; i < x.size(); ++i) {
+    x[i].resize(1, 3);
+    x[i] << 1 * i, 2 * i, 3 * i;
+  }
+
+  Eigen::MatrixXd cov;
+  EXPECT_NO_THROW(cov = stan::math::gp_dot_prod_cov(x, sigma));
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      EXPECT_FLOAT_EQ(sigma * sigma + stan::math::dot_product(x[i], x[j]),
+                      cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+}
+
+TEST(MathPrimMat, vec_vec_x1_x2_gp_dot_prod_cov0) {
+  double sigma = 0.5;
+
+  std::vector<Eigen::Matrix<double, -1, 1>> x1(3);
+  for (size_t i = 0; i < x1.size(); ++i) {
+    x1[i].resize(3, 1);
+    x1[i] << 2 * i, 3 * i, 4 * i;
+  }
+
+  std::vector<Eigen::Matrix<double, -1, 1>> x2(4);
+  for (size_t i = 0; i < x2.size(); ++i) {
+    x2[i].resize(3, 1);
+    x2[i] << 1 * i, 2 * i, 3 * i;
+  }
+
+  Eigen::MatrixXd cov;
+  EXPECT_NO_THROW(cov = stan::math::gp_dot_prod_cov(x1, x2, sigma));
+  EXPECT_EQ(3, cov.rows());
+  EXPECT_EQ(4, cov.cols());
+  for (int i = 0; i < 3; ++i) {
+    for (int j = 0; j < 4; ++j) {
+      EXPECT_FLOAT_EQ(sigma * sigma + stan::math::dot_product(x1[i], x2[j]),
+                      cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+}
+
+TEST(MathPrimMat, rvec_vec_x1_x2_gp_dot_prod_cov0) {
+  double sigma = 0.5;
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x1(3);
+  std::vector<Eigen::Matrix<double, 1, -1>> x2(4);
+
+  for (size_t i = 0; i < x1.size(); ++i) {
+    x1[i].resize(1, 3);
+    x1[i] << 1 * i, 2 * i, 3 * i;
+  }
+
+  for (size_t i = 0; i < x2.size(); ++i) {
+    x2[i].resize(1, 3);
+    x2[i] << 2 * i, 3 * i, 4 * i;
+  }
+
+  Eigen::MatrixXd cov;
+  EXPECT_NO_THROW(cov = stan::math::gp_dot_prod_cov(x1, x2, sigma));
+  EXPECT_EQ(3, cov.rows());
+  EXPECT_EQ(4, cov.cols());
+  for (int i = 0; i < 3; ++i) {
+    for (int j = 0; j < 4; ++j) {
+      EXPECT_FLOAT_EQ(sigma * sigma + stan::math::dot_product(x1[i], x2[j]),
+                      cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+
+  Eigen::MatrixXd cov2;
+  EXPECT_NO_THROW(cov2 = stan::math::gp_dot_prod_cov(x1, x2, sigma));
+  EXPECT_EQ(3, cov2.rows());
+  EXPECT_EQ(4, cov2.cols());
+  for (int i = 0; i < 3; ++i) {
+    for (int j = 0; j < 4; ++j) {
+      EXPECT_FLOAT_EQ(sigma * sigma + stan::math::dot_product(x1[i], x2[j]),
+                      cov2(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+}
+
+TEST(MathPrimMat, vec_rvec_x1_x2_gp_dot_prod_cov0) {
+  double sigma = 0.7;
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x1_rvec(3);
+
+  for (size_t i = 0; i < x1_rvec.size(); ++i) {
+    x1_rvec[i].resize(1, 3);
+    x1_rvec[i] << 1 * i, 2 * i, 3 * i;
+  }
+
+  std::vector<Eigen::Matrix<double, -1, 1>> x1_vec(3);
+
+  for (size_t i = 0; i < x1_vec.size(); ++i) {
+    x1_vec[i].resize(3, 1);
+    x1_vec[i] << 1 * i, 2 * i, 3 * i;
+  }
+
+  Eigen::MatrixXd cov;
+  EXPECT_NO_THROW(cov = stan::math::gp_dot_prod_cov(x1_vec, x1_rvec, sigma));
+  EXPECT_EQ(3, cov.rows());
+  EXPECT_EQ(3, cov.cols());
+  for (int i = 0; i < 3; ++i) {
+    for (int j = 0; j < 3; ++j) {
+      EXPECT_FLOAT_EQ(sigma * sigma +
+                          stan::math::dot_product(x1_vec[i], x1_rvec[j]),
+                      cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+}
+
+TEST(MathPrimMat, rvec_rvec_x1_x2_gp_dot_prod_cov0) {
+  double sigma = 0.8;
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x1_rvec(3);
+  std::vector<Eigen::Matrix<double, 1, -1>> x2_rvec(4);
+
+  for (size_t i = 0; i < x1_rvec.size(); ++i) {
+    x1_rvec[i].resize(1, 3);
+    x1_rvec[i] << 1 * i, 2 * i, 3 * i;
+  }
+
+  for (size_t i = 0; i < x2_rvec.size(); ++i) {
+    x2_rvec[i].resize(1, 3);
+    x2_rvec[i] << 2 * i, 3 * i, 4 * i;
+  }
+
+  Eigen::MatrixXd cov;
+  EXPECT_NO_THROW(cov = stan::math::gp_dot_prod_cov(x1_rvec, x2_rvec, sigma));
+  for (int i = 0; i < 3; ++i) {
+    for (int j = 0; j < 3; ++j) {
+      EXPECT_FLOAT_EQ(sigma * sigma +
+                          stan::math::dot_product(x1_rvec[i], x2_rvec[j]),
+                      cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+}

--- a/test/unit/math/rev/mat/fun/gp_dot_prod_cov_test.cpp
+++ b/test/unit/math/rev/mat/fun/gp_dot_prod_cov_test.cpp
@@ -333,9 +333,9 @@ TEST(MathPrimMat, vec_rvec_x1_x2_gp_dot_prod_cov0) {
   EXPECT_EQ(3, cov.cols());
   for (int i = 0; i < 3; ++i) {
     for (int j = 0; j < 3; ++j) {
-      EXPECT_FLOAT_EQ(sigma * sigma +
-                          stan::math::dot_product(x1_vec[i], x1_rvec[j]),
-                      cov(i, j))
+      EXPECT_FLOAT_EQ(
+          sigma * sigma + stan::math::dot_product(x1_vec[i], x1_rvec[j]),
+          cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -361,9 +361,9 @@ TEST(MathPrimMat, rvec_rvec_x1_x2_gp_dot_prod_cov0) {
   EXPECT_NO_THROW(cov = stan::math::gp_dot_prod_cov(x1_rvec, x2_rvec, sigma));
   for (int i = 0; i < 3; ++i) {
     for (int j = 0; j < 3; ++j) {
-      EXPECT_FLOAT_EQ(sigma * sigma +
-                          stan::math::dot_product(x1_rvec[i], x2_rvec[j]),
-                      cov(i, j))
+      EXPECT_FLOAT_EQ(
+          sigma * sigma + stan::math::dot_product(x1_rvec[i], x2_rvec[j]),
+          cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary:
Add a dot product kernel to Stan's Gaussian Process Library. A dot product kernel is equivalent to Bayesian regression with N(0, 1) priors on regression coefficients, and a N(0, \sigma_0^2) prior on the bias. See Rausmussen & Williams, Gaussian Processes for Machine Learning Chapter 4, section 4.2.2 for more details.

#### Intended Effect:
This pull request adds the following: Catch all support for the following stan datatypes: `vector [N] x`, `row_vector[N] x`, `real y[N]`, `real x`, `vector [N] y[K]`, and autodiff (AD) support for all of the above _except_ `real y[N]`


#### How to Verify:
Test cases that test: error messages, vector and non vector arguments, combinations of `double` and `var`, `rvec` and `vec`, and gradients for different parameterizations.

#### Side Effects:
None. 

#### Documentation:
Doxygen. I can add additional documentation in the Stan user manual later in time if needed.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Copyright <2018><Andre Zapico>

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)