### PR TITLE
Fix / change how we run the upstream tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -187,18 +187,12 @@ pipeline {
         }
         stage('Upstream tests') {
             parallel {
-                stage('CmdStan Upstream Tests') {
-                    when { expression { env.BRANCH_NAME ==~ /PR-\d+/ } }
-                    steps {
-                        build(job: "CmdStan/${params.cmdstan_pr}",
-                              parameters: [string(name: 'math_pr', value: env.BRANCH_NAME)])
-                    }
-                }
                 stage('Stan Upstream Tests') {
                     when { expression { env.BRANCH_NAME ==~ /PR-\d+/ } }
                     steps {
                         build(job: "Stan/${params.stan_pr}",
-                              parameters: [string(name: 'math_pr', value: env.BRANCH_NAME)])
+                              parameters: [string(name: 'math_pr', value: env.BRANCH_NAME),
+                                           string(name: 'cmdstan_pr', value: params.cmdstan_pr)])
                     }
                 }
             }


### PR DESCRIPTION
We'll just run the Stan job as our upstream test, pass it the cmdstan PR reference, and let it kick off its own upstream cmdstan tests. This fixes a bug - right now if you need both a cmdstan and a stan PR, this will run the tests correctly but the Stan job will kick off upstream tests that fail because they don't have the cmdstan PR passed to them.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
