### PR TITLE
Feature/issue add matern 3/2 prim

### DIFF
--- a/stan/math/prim/mat.hpp
+++ b/stan/math/prim/mat.hpp
@@ -15,8 +15,8 @@
 #include <stan/math/prim/mat/meta/length.hpp>
 #include <stan/math/prim/mat/meta/length_mvt.hpp>
 #include <stan/math/prim/mat/meta/operands_and_partials.hpp>
-#include <stan/math/prim/mat/meta/seq_view.hpp>
 #include <stan/math/prim/mat/meta/scalar_type.hpp>
+#include <stan/math/prim/mat/meta/seq_view.hpp>
 #include <stan/math/prim/mat/meta/value_type.hpp>
 #include <stan/math/prim/mat/meta/vector_seq_view.hpp>
 
@@ -45,6 +45,10 @@
 #include <stan/math/prim/mat/err/constraint_tolerance.hpp>
 #include <stan/math/prim/mat/err/validate_non_negative_index.hpp>
 
+#include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <stan/math/prim/mat/fun/LDLT_factor.hpp>
+#include <stan/math/prim/mat/fun/Phi.hpp>
+#include <stan/math/prim/mat/fun/Phi_approx.hpp>
 #include <stan/math/prim/mat/fun/accumulator.hpp>
 #include <stan/math/prim/mat/fun/acos.hpp>
 #include <stan/math/prim/mat/fun/acosh.hpp>
@@ -91,17 +95,16 @@
 #include <stan/math/prim/mat/fun/csr_u_to_z.hpp>
 #include <stan/math/prim/mat/fun/cumulative_sum.hpp>
 #include <stan/math/prim/mat/fun/determinant.hpp>
-#include <stan/math/prim/mat/fun/diagonal.hpp>
 #include <stan/math/prim/mat/fun/diag_matrix.hpp>
 #include <stan/math/prim/mat/fun/diag_post_multiply.hpp>
 #include <stan/math/prim/mat/fun/diag_pre_multiply.hpp>
+#include <stan/math/prim/mat/fun/diagonal.hpp>
 #include <stan/math/prim/mat/fun/digamma.hpp>
 #include <stan/math/prim/mat/fun/dims.hpp>
 #include <stan/math/prim/mat/fun/distance.hpp>
 #include <stan/math/prim/mat/fun/divide.hpp>
 #include <stan/math/prim/mat/fun/dot_product.hpp>
 #include <stan/math/prim/mat/fun/dot_self.hpp>
-#include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/mat/fun/eigenvalues_sym.hpp>
 #include <stan/math/prim/mat/fun/eigenvectors_sym.hpp>
 #include <stan/math/prim/mat/fun/elt_divide.hpp>
@@ -112,8 +115,8 @@
 #include <stan/math/prim/mat/fun/exp2.hpp>
 #include <stan/math/prim/mat/fun/expm1.hpp>
 #include <stan/math/prim/mat/fun/fabs.hpp>
-#include <stan/math/prim/mat/fun/factor_cov_matrix.hpp>
 #include <stan/math/prim/mat/fun/factor_U.hpp>
+#include <stan/math/prim/mat/fun/factor_cov_matrix.hpp>
 #include <stan/math/prim/mat/fun/fill.hpp>
 #include <stan/math/prim/mat/fun/floor.hpp>
 #include <stan/math/prim/mat/fun/get_base1.hpp>
@@ -123,14 +126,13 @@
 #include <stan/math/prim/mat/fun/head.hpp>
 #include <stan/math/prim/mat/fun/initialize.hpp>
 #include <stan/math/prim/mat/fun/inv.hpp>
-#include <stan/math/prim/mat/fun/inverse.hpp>
-#include <stan/math/prim/mat/fun/inverse_spd.hpp>
+#include <stan/math/prim/mat/fun/inv_Phi.hpp>
 #include <stan/math/prim/mat/fun/inv_cloglog.hpp>
 #include <stan/math/prim/mat/fun/inv_logit.hpp>
-#include <stan/math/prim/mat/fun/inv_Phi.hpp>
 #include <stan/math/prim/mat/fun/inv_sqrt.hpp>
 #include <stan/math/prim/mat/fun/inv_square.hpp>
-#include <stan/math/prim/mat/fun/LDLT_factor.hpp>
+#include <stan/math/prim/mat/fun/inverse.hpp>
+#include <stan/math/prim/mat/fun/inverse_spd.hpp>
 #include <stan/math/prim/mat/fun/lgamma.hpp>
 #include <stan/math/prim/mat/fun/log.hpp>
 #include <stan/math/prim/mat/fun/log10.hpp>
@@ -169,8 +171,6 @@
 #include <stan/math/prim/mat/fun/num_elements.hpp>
 #include <stan/math/prim/mat/fun/ordered_constrain.hpp>
 #include <stan/math/prim/mat/fun/ordered_free.hpp>
-#include <stan/math/prim/mat/fun/Phi.hpp>
-#include <stan/math/prim/mat/fun/Phi_approx.hpp>
 #include <stan/math/prim/mat/fun/positive_ordered_constrain.hpp>
 #include <stan/math/prim/mat/fun/positive_ordered_free.hpp>
 #include <stan/math/prim/mat/fun/prod.hpp>
@@ -215,9 +215,9 @@
 #include <stan/math/prim/mat/fun/square.hpp>
 #include <stan/math/prim/mat/fun/squared_distance.hpp>
 #include <stan/math/prim/mat/fun/stan_print.hpp>
-#include <stan/math/prim/mat/fun/subtract.hpp>
 #include <stan/math/prim/mat/fun/sub_col.hpp>
 #include <stan/math/prim/mat/fun/sub_row.hpp>
+#include <stan/math/prim/mat/fun/subtract.hpp>
 #include <stan/math/prim/mat/fun/sum.hpp>
 #include <stan/math/prim/mat/fun/tail.hpp>
 #include <stan/math/prim/mat/fun/tan.hpp>
@@ -249,17 +249,17 @@
 #include <stan/math/prim/mat/functor/finite_diff_gradient.hpp>
 #include <stan/math/prim/mat/functor/finite_diff_hessian.hpp>
 #include <stan/math/prim/mat/functor/map_rect.hpp>
-#include <stan/math/prim/mat/functor/map_rect_serial.hpp>
-#include <stan/math/prim/mat/functor/map_rect_reduce.hpp>
 #include <stan/math/prim/mat/functor/map_rect_combine.hpp>
+#include <stan/math/prim/mat/functor/map_rect_reduce.hpp>
+#include <stan/math/prim/mat/functor/map_rect_serial.hpp>
 
 #include <stan/math/prim/mat/prob/bernoulli_logit_glm_lpmf.hpp>
 #include <stan/math/prim/mat/prob/categorical_log.hpp>
-#include <stan/math/prim/mat/prob/categorical_lpmf.hpp>
 #include <stan/math/prim/mat/prob/categorical_logit_log.hpp>
 #include <stan/math/prim/mat/prob/categorical_logit_lpmf.hpp>
-#include <stan/math/prim/mat/prob/categorical_rng.hpp>
 #include <stan/math/prim/mat/prob/categorical_logit_rng.hpp>
+#include <stan/math/prim/mat/prob/categorical_lpmf.hpp>
+#include <stan/math/prim/mat/prob/categorical_rng.hpp>
 #include <stan/math/prim/mat/prob/dirichlet_log.hpp>
 #include <stan/math/prim/mat/prob/dirichlet_lpmf.hpp>
 #include <stan/math/prim/mat/prob/dirichlet_rng.hpp>
@@ -301,10 +301,10 @@
 #include <stan/math/prim/mat/prob/ordered_logistic_log.hpp>
 #include <stan/math/prim/mat/prob/ordered_logistic_lpmf.hpp>
 #include <stan/math/prim/mat/prob/ordered_logistic_rng.hpp>
-#include <stan/math/prim/mat/prob/poisson_log_glm_lpmf.hpp>
 #include <stan/math/prim/mat/prob/ordered_probit_log.hpp>
 #include <stan/math/prim/mat/prob/ordered_probit_lpmf.hpp>
 #include <stan/math/prim/mat/prob/ordered_probit_rng.hpp>
+#include <stan/math/prim/mat/prob/poisson_log_glm_lpmf.hpp>
 #include <stan/math/prim/mat/prob/wishart_log.hpp>
 #include <stan/math/prim/mat/prob/wishart_lpdf.hpp>
 #include <stan/math/prim/mat/prob/wishart_rng.hpp>

--- a/stan/math/prim/mat.hpp
+++ b/stan/math/prim/mat.hpp
@@ -119,6 +119,7 @@
 #include <stan/math/prim/mat/fun/get_base1.hpp>
 #include <stan/math/prim/mat/fun/get_base1_lhs.hpp>
 #include <stan/math/prim/mat/fun/get_lp.hpp>
+#include <stan/math/prim/mat/fun/gp_matern_3_2_cov.hpp>
 #include <stan/math/prim/mat/fun/head.hpp>
 #include <stan/math/prim/mat/fun/initialize.hpp>
 #include <stan/math/prim/mat/fun/inv.hpp>

--- a/stan/math/prim/mat.hpp
+++ b/stan/math/prim/mat.hpp
@@ -122,7 +122,6 @@
 #include <stan/math/prim/mat/fun/get_base1.hpp>
 #include <stan/math/prim/mat/fun/get_base1_lhs.hpp>
 #include <stan/math/prim/mat/fun/get_lp.hpp>
-#include <stan/math/prim/mat/fun/gp_matern_3_2_cov.hpp>
 #include <stan/math/prim/mat/fun/gp_dot_prod_cov.hpp>
 #include <stan/math/prim/mat/fun/gp_matern_3_2_cov.hpp>
 #include <stan/math/prim/mat/fun/head.hpp>

--- a/stan/math/prim/mat/fun/gp_matern_3_2_cov.hpp
+++ b/stan/math/prim/mat/fun/gp_matern_3_2_cov.hpp
@@ -1,10 +1,11 @@
 #ifndef STAN_MATH_PRIM_MAT_FUN_GP_MATERN_3_2_COV_HPP
 #define STAN_MATH_PRIM_MAT_FUN_GP_MATERN_3_2_COV_HPP
 
-#include <cmath>
 #include <stan/math/prim/scal/fun/square.hpp>
-#include <stan/math/prim/scal/meta/return_type.hpp>
 #include <stan/math/prim/scal/fun/squared_distance.hpp>
+#include <stan/math/prim/scal/meta/return_type.hpp>
+#include <cmath>
+#include <vector>
 
 namespace stan {
 namespace math {
@@ -12,10 +13,11 @@ namespace math {
 /** Returns a Matern 3/2 covariance matrix with one input vector
  *
  * \f[ k(x, x') = \sigma^2(1 + \gamma \sqrt{3}
- *  \frac{\sqrt{(x - x')^2}}{l}exp(-\gamma\sqrt{3}\frac{\sqrt{(x - x')^2}}{l})  \f]
+ *  \frac{\sqrt{(x - x')^2}}{l}exp(-\gamma\sqrt{3}\frac{\sqrt{(x - x')^2}}{l})
+ * \f]
  *
  * See Rausmussen & Williams et al 2006 Chapter 4.
- * 
+ *
  * @param x std::vector of elements that can be used in stan::math::distance
  * @param length_scale length scale
  * @param sigma standard deviation that can be used in stan::math::square
@@ -42,7 +44,7 @@ inline
   check_not_nan("gp_matern_3_2_cov", "marginal variance", sigma);
 
   check_not_nan("gp_matern_3_2_cov", "gamma", gamma);
-  
+
   for (size_t n = 0; n < x_size; ++n)
     check_not_nan("gp_matern_3_2_cov", "x", x[n]);
 
@@ -60,9 +62,9 @@ inline
   for (size_t i = 0; i < (x_size - 1); ++i) {
     cov(i, i) = sigma_sq;
     for (size_t j = i + 1; j < x_size; ++j) {
-      cov(i, j) = sigma_sq * (1.0 + root_3_inv_l * gamma *
-                              squared_distance(x[i], x[j])) *
-        exp(neg_gamma * root_3_inv_l * squared_distance(x[i], x[j]));
+      cov(i, j) = sigma_sq *
+                  (1.0 + root_3_inv_l * gamma * squared_distance(x[i], x[j])) *
+                  exp(neg_gamma * root_3_inv_l * squared_distance(x[i], x[j]));
       cov(j, i) = cov(i, j);
     }
   }
@@ -73,7 +75,7 @@ inline
 /** Returns a Matern 3/2 Kernel with one input vector,
  * with automatic relevance determination (ARD) priors
  *
- * \f[ k(x, x') = \sigma^2(1 + \gamma \sqrt{3} 
+ * \f[ k(x, x') = \sigma^2(1 + \gamma \sqrt{3}
  *   \frac{\sum_{k=1}^{K}\sqrt{(x - x')^2}}{l_k}
  *   exp(-\gamma\sqrt{3}\sum_{k=1}^{K}\frac{\sqrt{(x - x')^2}}{l_k}) \f]
  *
@@ -95,7 +97,7 @@ inline
   using std::pow;
   using std::abs;
   using std::exp;
-  
+
   size_t x_size = x.size();
   size_t l_size = length_scale.size();
 
@@ -106,7 +108,7 @@ inline
   check_not_nan("gp_matern_3_2_cov", "marginal variance", sigma);
 
   check_not_nan("gp_matern_3_2_cov", "gamma", gamma);
-  
+
   for (size_t n = 0; n < x_size; ++n)
     check_not_nan("gp_matern_3_2_cov", "x", x[n]);
 
@@ -129,7 +131,7 @@ inline
         temp += squared_distance(x[i], x[j]) / length_scale[k];
       }
       cov(i, j) = sigma_sq * (1.0 + root_3 * gamma * pow(temp, 0.5)) *
-        exp(neg_gamma * root_3 * pow(temp, 0.5));
+                  exp(neg_gamma * root_3 * pow(temp, 0.5));
       cov(j, i) = cov(i, j);
     }
   }
@@ -138,8 +140,9 @@ inline
 
 /** Returns a Matern 3/2 covariance matrix with two input vectors
  *
- * \f[ k(x, x') = \sigma^2(1 + \gamma \sqrt{3} 
- *  \frac{\sqrt{(x - x')^2}}{l}exp(-\gamma\sqrt{3}\frac{\sqrt{(x - x')^2}}{l})  \f]
+ * \f[ k(x, x') = \sigma^2(1 + \gamma \sqrt{3}
+ *  \frac{\sqrt{(x - x')^2}}{l}exp(-\gamma\sqrt{3}\frac{\sqrt{(x - x')^2}}{l})
+ * \f]
  *
  * See Rausmussen & Williams et al 2006 Chapter 4.
  *
@@ -163,14 +166,14 @@ gp_matern_3_2_cov(const std::vector<T_x1> &x1, const std::vector<T_x2> &x2,
   using std::abs;
   using std::exp;
   using stan::math::squared_distance;
-  
+
   size_t x1_size = x1.size();
   size_t x2_size = x2.size();
 
   // add check same size
   check_positive("gp_matern_3_2_cov", "length-scale", length_scale);
   check_not_nan("gp_matern_3_2_cov", "length-scale", length_scale);
-  
+
   check_positive("gp_matern_3_2_cov", "marginal variance", sigma);
   check_not_nan("gp_matern_3_2_cov", "marginal variance", sigma);
 
@@ -194,14 +197,16 @@ gp_matern_3_2_cov(const std::vector<T_x1> &x1, const std::vector<T_x2> &x2,
 
   for (size_t i = 0; i < x1_size; ++i) {
     for (size_t j = 0; j < x2_size; ++j) {
-      cov(i, j) = sigma_sq * (1.0 + root_3_inv_l * gamma * squared_distance(x1[i], x2[j])) *
-        exp(neg_gamma * root_3_inv_l * squared_distance(x1[i], x2[j]));
+      cov(i, j) =
+          sigma_sq *
+          (1.0 + root_3_inv_l * gamma * squared_distance(x1[i], x2[j])) *
+          exp(neg_gamma * root_3_inv_l * squared_distance(x1[i], x2[j]));
     }
   }
   return cov;
 }
 
-/** Returns a Matern 3/2 Kernel with two input vectors with automatic 
+/** Returns a Matern 3/2 Kernel with two input vectors with automatic
  * relevance determination (ARD) priors
  *
  * \f[ k(x, x') = \sigma^2(1 + \gamma \sqrt{3}
@@ -230,7 +235,7 @@ gp_matern_3_2_cov(const std::vector<T_x1> &x1, const std::vector<T_x2> &x2,
   using std::abs;
   using std::exp;
   using stan::math::squared_distance;
-  
+
   size_t x1_size = x1.size();
   size_t x2_size = x2.size();
   size_t l_size = length_scale.size();
@@ -238,12 +243,12 @@ gp_matern_3_2_cov(const std::vector<T_x1> &x1, const std::vector<T_x2> &x2,
 
   check_positive("gp_matern_3_2_cov", "length-scale", length_scale);
   check_not_nan("gp_matern_3_2_cov", "length-scale", length_scale);
-  
+
   check_positive("gp_matern_3_2_cov", "marginal variance", sigma);
   check_not_nan("gp_matern_3_2_cov", "marginal variance", sigma);
 
   check_not_nan("gp_matern_3_2_cov", "gamma", gamma);
-  
+
   for (size_t n = 0; n < x1_size; ++n)
     check_not_nan("gp_matern_3_2_cov", "x1", x1[n]);
   for (size_t n = 0; n < x2_size; ++n)
@@ -268,11 +273,11 @@ gp_matern_3_2_cov(const std::vector<T_x1> &x1, const std::vector<T_x2> &x2,
         temp += squared_distance(x1[i], x2[j]) / length_scale[k];
       }
       cov(i, j) = sigma_sq * (1.0 + root_3 * gamma * pow(temp, 0.5)) *
-        exp(neg_gamma * root_3 * pow(temp, 0.5));
+                  exp(neg_gamma * root_3 * pow(temp, 0.5));
     }
   }
   return cov;
 }
-} // namespace math
-} // namespace stan
+}  // namespace math
+}  // namespace stan
 #endif

--- a/stan/math/prim/mat/fun/gp_matern_3_2_cov.hpp
+++ b/stan/math/prim/mat/fun/gp_matern_3_2_cov.hpp
@@ -1,0 +1,175 @@
+#ifndef STAN_MATH_PRIM_MAT_FUN_GP_MATERN_3_2_COV_HPP
+#define STAN_MATH_PRIM_MAT_FUN_GP_MATERN_3_2_COV_HPP
+
+#include <cmath>
+#include <stan/math/prim/scal/meta/return_type.hpp>
+#include <stan/math/prim/scal/fun/square.hpp>
+
+
+namespace stan {
+namespace math {
+
+  /** Returns a Matern 3/2 Kernel with one input vector
+   *  
+   * \f$ k(x, x') = \sigma^2(1 + \gamma \sqrt{3} \\
+   *  \frac{\abs{x - x'}}{l}exp(-\gamma\sqrt{3}\frac{\abs{x - x'}}{l})  \f$
+   * 
+   * @param x std::vector of elements that can be used in stan::math::distance
+   * @param sigma standard deviation that can be used in stan::math::square
+   * @param gamma 
+   * @param length_scale length scale
+   * @param squared distance 
+   * @throw std::domain error if sigma <= 0, l <= l, or x is nan of inf.
+   * 
+   */
+template<typename T_x, typename T_l, typename T_s, typename T_g>
+inline typename
+Eigen::Matrix<typename stan::return_type<T_x, T_l, T_s, T_g>::type,
+              Eigen::Dynamic, Eigen::Dynamic>
+gp_matern_3_2_cov(const std::vector<T_x>& x, const T_l& length_scale,
+                  const T_s& sigma = 1.0, const T_g& gamma = 1.0){
+  using std::pow;
+  using std::abs;
+  using std::exp;
+
+  size_t x_size = x.size();
+  check_positive("gp_matern_3_2_cov", "marginal variance", sigma);
+  check_positive("gp_matern_3_2_cov", "length-scale", length_scale);
+  for (size_t n = 0; n < x_size; ++n)
+    check_not_nan("gp_matern_3_2_cov", "x", x[n]);
+         
+  Eigen::Matrix<typename stan::return_type<T_x, T_s, T_g, T_l>::type,
+                Eigen::Dynamic, Eigen::Dynamic>
+    cov(x_size, x_size);
+
+  if(x_size == 0)
+    return cov;
+
+  T_s sigma_sq = square(sigma);
+  T_l root_3_inv_l = pow(3, 0.5) / length_scale;
+  T_g neg_gamma = -1.0 * gamma;
+  
+  for (size_t i = 0; i < (x_size - 1); ++i) {
+    cov(i, i) = sigma_sq;
+    for(size_t j = i + 1; j < x_size; ++j){
+      cov(i, j) = sigma_sq * (1.0 + root_3_inv_l * gamma *abs(x[i] - x[j])) *
+        exp(neg_gamma *  root_3_inv_l * abs(x[i] - x[j]));
+      cov(j, i) = cov(i, j);
+    }
+  }
+  cov(x_size - 1, x_size - 1) = sigma_sq;
+  return cov;
+}
+
+  /** Returns a Matern 3/2 Kernel with one input vector,
+   * with ARD priors.
+   *  
+   * CHECK THIS FORMULA:
+   * \f$ k(x, x') = \sigma^2(1 + \gamma \sqrt{3} \\
+   *   \frac{\sum_{k=1}^{K}\abs{x - x'}}{l_k}
+   *   exp(-\gamma\sqrt{3}\sum_{k=1}^{K}\frac{\abs{x - x'}}{l}) \f$
+   * 
+   * @param x std::vector of elements that can be used in stan::math::distance
+   * @param sigma standard deviation that can be used in stan::math::square
+   * @param gamma 
+   * @param length_scale length scale
+   * @param squared distance 
+   * @throw std::domain error if sigma <= 0, l <= l, or x is nan of inf.
+   * 
+   */
+template<typename T_x, typename T_l, typename T_s, typename T_g>
+inline typename
+Eigen::Matrix<typename stan::return_type<T_x, T_l, T_s, T_g>::type,
+              Eigen::Dynamic, Eigen::Dynamic>
+gp_matern_3_2_cov(const std::vector<T_x>& x,
+                  const std::vector<T_l>& length_scale,
+                  const T_s& sigma = 1.0, const T_g& gamma = 1.0){
+  using std::pow;
+  using std::abs;
+  using std::exp;
+
+  size_t x_size = x.size();
+  size_t l_size = length_scale.size();
+
+  check_positive("gp_matern_3_2_cov", "marginal variance", sigma);
+  check_positive("gp_matern_3_2_cov", "length-scale", length_scale);
+  for (size_t n = 0; n < x_size; ++n)
+    check_not_nan("gp_matern_3_2_cov", "x", x[n]);
+         
+  Eigen::Matrix<typename stan::return_type<T_x, T_l, T_s, T_g>::type,
+                Eigen::Dynamic, Eigen::Dynamic>
+    cov(x_size, x_size);
+
+  if(x_size == 0)
+    return cov;
+
+  T_s sigma_sq = square(sigma);
+  T_l root_3 = pow(3.0, 0.5);
+  T_g neg_gamma = -1.0 * gamma;
+  T_l temp;
+  
+  for (size_t i = 0; i < x_size; ++i) {
+    for (size_t j = i; j < x_size; ++j) {
+      temp = 0;
+      for (size_t k = 0; k < l_size; ++k) {
+        temp += (1.0 + root_3 * gamma * abs(x[i] - x[j]) / length_scale[k]) *
+          exp(neg_gamma * root_3 * abs(x[i] - x[j]) / length_scale[k]);
+      }
+      cov(i, j) = sigma_sq * temp;
+      cov(j, i) = cov(i, j);
+    }
+  }
+  return cov;
+}
+
+  // TODO add x1, x2 for double... this is for vector of vectors
+  
+template<typename T_x1, typename T_x2, typename T_l, typename T_s, typename T_g>
+inline typename
+Eigen::Matrix<typename stan::return_type<T_x1, T_x2, T_l, T_s, T_g>::type,
+              Eigen::Dynamic, Eigen::Dynamic>
+gp_matern_3_2_cov(const std::vector<T_x1>& x1, const std::vector<T_x2>& x2,
+                  const T_l& length_scale, const T_s& sigma = 1.0,
+                  const T_g& gamma = 1.0){
+  using std::pow;
+  using std::abs;
+  using std::exp;
+
+  size_t x1_size = x1.size();
+  size_t x2_size = x2.size();
+
+  // add check same size
+  
+  check_positive("gp_matern_3_2_cov", "marginal variance", sigma);
+  check_positive("gp_matern_3_2_cov", "length-scale", length_scale);
+  for (size_t n = 0; n < x1_size; ++n)
+    check_not_nan("gp_matern_3_2_cov", "x1", x1[n]);
+  for (size_t n = 0; n < x2_size; ++n)
+    check_not_nan("gp_matern_3_2_cov", "x2", x2[n]);
+         
+  Eigen::Matrix<typename stan::return_type<T_x1, T_x2, T_s, T_g, T_l>::type,
+                Eigen::Dynamic, Eigen::Dynamic>
+    cov(x1_size, x2_size);
+
+  if(x1_size == 0 || x2_size == 0)
+    return cov;
+
+  T_s sigma_sq = square(sigma);
+  T_l root_3_inv_l = pow(3, 0.5) / length_scale;
+  T_g neg_gamma = -1.0 * gamma;
+  T_g distance;
+  
+  for (size_t i = 0; i < x1_size; ++i) {
+    for (size_t j = 0; j < x2_size; ++j){
+      distance = 0.0;
+      for (size_t k = 0; k < x1_size; ++k)
+        distance += abs(x1[i][k] - x2[j][k]);
+      cov(i, j) = sigma_sq * (1.0 + root_3_inv_l * gamma * distance) *
+        exp(neg_gamma *  root_3_inv_l * distance);
+    }
+  }
+  return cov;
+}
+}  // namespace math
+}  // namespace stan
+#endif

--- a/stan/math/prim/mat/fun/gp_matern_3_2_cov.hpp
+++ b/stan/math/prim/mat/fun/gp_matern_3_2_cov.hpp
@@ -14,7 +14,7 @@ namespace math {
 /** Returns a Matern 3/2 covariance matrix with one input vector
  *
  * \f[ k(x, x') = \sigma^2(1 + \gamma \sqrt{3}
- *  \frac{\sqrt{(x - x')^2}}{l}exp(-\gamma\sqrt{3}\frac{\sqrt{(x - x')^2}}{l})
+ *  \frac{\sqrt{(x - x')^2}}{l})exp(-\gamma\sqrt{3}\frac{\sqrt{(x - x')^2}}{l})
  * \f]
  *
  * See Rausmussen & Williams et al 2006 Chapter 4.
@@ -78,7 +78,7 @@ inline
  * with automatic relevance determination (ARD) priors
  *
  * \f[ k(x, x') = \sigma^2(1 + \gamma \sqrt{3}
- *   \frac{\sum_{k=1}^{K}\sqrt{(x - x')^2}}{l_k}
+ *   \frac{\sum_{k=1}^{K}\sqrt{(x - x')^2}}{l_k})
  *   exp(-\gamma\sqrt{3}\sum_{k=1}^{K}\frac{\sqrt{(x - x')^2}}{l_k}) \f]
  *
  * See Rausmussen & Williams et al 2006 Chapter 4.
@@ -143,7 +143,7 @@ inline
 /** Returns a Matern 3/2 covariance matrix with two input vectors
  *
  * \f[ k(x, x') = \sigma^2(1 + \gamma \sqrt{3}
- *  \frac{\sqrt{(x - x')^2}}{l}exp(-\gamma\sqrt{3}\frac{\sqrt{(x - x')^2}}{l})
+ *  \frac{\sqrt{(x - x')^2}}{l})exp(-\gamma\sqrt{3}\frac{\sqrt{(x - x')^2}}{l})
  * \f]
  *
  * See Rausmussen & Williams et al 2006 Chapter 4.
@@ -212,7 +212,7 @@ gp_matern_3_2_cov(const std::vector<T_x1> &x1, const std::vector<T_x2> &x2,
  * relevance determination (ARD) priors
  *
  * \f[ k(x, x') = \sigma^2(1 + \gamma \sqrt{3}
- *   \frac{\sum_{k=1}^{K}\sqrt{(x - x')^2}}{l_k}
+ *   \frac{\sum_{k=1}^{K}\sqrt{(x - x')^2}}{l_k})
  *   exp(-\gamma\sqrt{3}\sum_{k=1}^{K}\frac{\sqrt{(x - x')^2}}{l_k}) \f]
  *
  * See Rausmussen & Williams et al 2006 Chapter 4.

--- a/stan/math/prim/mat/fun/gp_matern_3_2_cov.hpp
+++ b/stan/math/prim/mat/fun/gp_matern_3_2_cov.hpp
@@ -13,7 +13,7 @@ namespace math {
 /** Returns a Matern 3/2 covariance matrix with one input vector
  *
  * \f[ k(x, x') = \sigma^2(1 + \sqrt{3}
- *  \frac{\sqrt{(x - x')^2}}{l}exp(-\sqrt{3}\frac{\sqrt{(x - x')^2}}{l})
+ *  \frac{\sqrt{(x - x')^2}}{l})exp(-\sqrt{3}\frac{\sqrt{(x - x')^2}}{l})
  * \f]
  *
  * See Rausmussen & Williams et al 2006 Chapter 4.
@@ -72,7 +72,7 @@ gp_matern_3_2_cov(const std::vector<T_x> &x, const T_s &sigma,
  * with automatic relevance determination (ARD) priors
  *
  * \f[ k(x, x') = \sigma^2(1 + \sqrt{3}
- *   \frac{\sum_{k=1}^{K}\sqrt{(x - x')^2}}{l_k}
+ *   \frac{\sum_{k=1}^{K}\sqrt{(x - x')^2}}{l_k})
  *   exp(-\sqrt{3}\sum_{k=1}^{K}\frac{\sqrt{(x - x')^2}}{l_k}) \f]
  *
  * See Rausmussen & Williams et al 2006 Chapter 4.
@@ -132,7 +132,7 @@ gp_matern_3_2_cov(const std::vector<T_x> &x, const T_s &sigma,
 /** Returns a Matern 3/2 covariance matrix with two input vectors
  *
  * \f[ k(x, x') = \sigma^2(1 + \sqrt{3}
- *  \frac{\sqrt{(x - x')^2}}{l}exp(-\sqrt{3}\frac{\sqrt{(x - x')^2}}{l})
+ *  \frac{\sqrt{(x - x')^2}}{l})exp(-\sqrt{3}\frac{\sqrt{(x - x')^2}}{l})
  * \f]
  *
  * See Rausmussen & Williams et al 2006 Chapter 4.
@@ -194,7 +194,7 @@ gp_matern_3_2_cov(const std::vector<T_x1> &x1, const std::vector<T_x2> &x2,
  * relevance determination (ARD) priors
  *
  * \f[ k(x, x') = \sigma^2(1 + \sqrt{3}
- *   \frac{\sum_{k=1}^{K}\sqrt{(x - x')^2}}{l_k}
+ *   \frac{\sum_{k=1}^{K}\sqrt{(x - x')^2}}{l_k})
  *   exp(-\sqrt{3}\sum_{k=1}^{K}\frac{\sqrt{(x - x')^2}}{l_k}) \f]
  *
  * See Rausmussen & Williams et al 2006 Chapter 4.

--- a/stan/math/prim/mat/fun/gp_matern_3_2_cov.hpp
+++ b/stan/math/prim/mat/fun/gp_matern_3_2_cov.hpp
@@ -1,6 +1,7 @@
 #ifndef STAN_MATH_PRIM_MAT_FUN_GP_MATERN_3_2_COV_HPP
 #define STAN_MATH_PRIM_MAT_FUN_GP_MATERN_3_2_COV_HPP
 
+#include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/scal/fun/square.hpp>
 #include <stan/math/prim/scal/fun/squared_distance.hpp>
 #include <stan/math/prim/scal/meta/return_type.hpp>

--- a/stan/math/prim/mat/fun/gp_matern_3_2_cov.hpp
+++ b/stan/math/prim/mat/fun/gp_matern_3_2_cov.hpp
@@ -2,58 +2,66 @@
 #define STAN_MATH_PRIM_MAT_FUN_GP_MATERN_3_2_COV_HPP
 
 #include <cmath>
-#include <stan/math/prim/scal/meta/return_type.hpp>
 #include <stan/math/prim/scal/fun/square.hpp>
-
+#include <stan/math/prim/scal/meta/return_type.hpp>
+#include <stan/math/prim/scal/fun/squared_distance.hpp>
 
 namespace stan {
 namespace math {
 
-  /** Returns a Matern 3/2 Kernel with one input vector
-   *  
-   * \f$ k(x, x') = \sigma^2(1 + \gamma \sqrt{3} \\
-   *  \frac{\abs{x - x'}}{l}exp(-\gamma\sqrt{3}\frac{\abs{x - x'}}{l})  \f$
-   * 
-   * @param x std::vector of elements that can be used in stan::math::distance
-   * @param sigma standard deviation that can be used in stan::math::square
-   * @param gamma 
-   * @param length_scale length scale
-   * @param squared distance 
-   * @throw std::domain error if sigma <= 0, l <= l, or x is nan of inf.
-   * 
-   */
-template<typename T_x, typename T_l, typename T_s, typename T_g>
-inline typename
-Eigen::Matrix<typename stan::return_type<T_x, T_l, T_s, T_g>::type,
-              Eigen::Dynamic, Eigen::Dynamic>
-gp_matern_3_2_cov(const std::vector<T_x>& x, const T_l& length_scale,
-                  const T_s& sigma = 1.0, const T_g& gamma = 1.0){
+/** Returns a Matern 3/2 Kernel with one input vector
+ *
+ * \f$ k(x, x') = \sigma^2(1 + \gamma \sqrt{3} \\
+ *  \frac{\abs{x - x'}}{l}exp(-\gamma\sqrt{3}\frac{\sqrt{(x - x')^2}}{l})  \f$
+ *
+ * @param x std::vector of elements that can be used in stan::math::distance
+ * @param sigma standard deviation that can be used in stan::math::square
+ * @param gamma
+ * @param length_scale length scale
+ * @param squared distance
+ * @throw std::domain error if sigma <= 0, l <= l, or x is nan of inf.
+ *
+ */
+template <typename T_x, typename T_l, typename T_s, typename T_g>
+inline
+    typename Eigen::Matrix<typename stan::return_type<T_x, T_l, T_s, T_g>::type,
+                           Eigen::Dynamic, Eigen::Dynamic>
+    gp_matern_3_2_cov(const std::vector<T_x> &x, const T_l &length_scale,
+                      const T_s &sigma = 1.0, const T_g &gamma = 1.0) {
   using std::pow;
   using std::abs;
   using std::exp;
+  using stan::math::squared_distance;
 
   size_t x_size = x.size();
-  check_positive("gp_matern_3_2_cov", "marginal variance", sigma);
   check_positive("gp_matern_3_2_cov", "length-scale", length_scale);
+  check_not_nan("gp_matern_3_2_cov", "length-scale", length_scale);
+
+  check_positive("gp_matern_3_2_cov", "marginal variance", sigma);
+  check_not_nan("gp_matern_3_2_cov", "marginal variance", sigma);
+
+  check_not_nan("gp_matern_3_2_cov", "gamma", gamma);
+  
   for (size_t n = 0; n < x_size; ++n)
     check_not_nan("gp_matern_3_2_cov", "x", x[n]);
-         
+
   Eigen::Matrix<typename stan::return_type<T_x, T_s, T_g, T_l>::type,
                 Eigen::Dynamic, Eigen::Dynamic>
-    cov(x_size, x_size);
+      cov(x_size, x_size);
 
-  if(x_size == 0)
+  if (x_size == 0)
     return cov;
 
   T_s sigma_sq = square(sigma);
   T_l root_3_inv_l = pow(3, 0.5) / length_scale;
   T_g neg_gamma = -1.0 * gamma;
-  
+
   for (size_t i = 0; i < (x_size - 1); ++i) {
     cov(i, i) = sigma_sq;
-    for(size_t j = i + 1; j < x_size; ++j){
-      cov(i, j) = sigma_sq * (1.0 + root_3_inv_l * gamma *abs(x[i] - x[j])) *
-        exp(neg_gamma *  root_3_inv_l * abs(x[i] - x[j]));
+    for (size_t j = i + 1; j < x_size; ++j) {
+      cov(i, j) = sigma_sq * (1.0 + root_3_inv_l * gamma *
+                              squared_distance(x[i], x[j])) *
+        exp(neg_gamma * root_3_inv_l * squared_distance(x[i], x[j]));
       cov(j, i) = cov(i, j);
     }
   }
@@ -61,115 +69,206 @@ gp_matern_3_2_cov(const std::vector<T_x>& x, const T_l& length_scale,
   return cov;
 }
 
-  /** Returns a Matern 3/2 Kernel with one input vector,
-   * with ARD priors.
-   *  
-   * CHECK THIS FORMULA:
-   * \f$ k(x, x') = \sigma^2(1 + \gamma \sqrt{3} \\
-   *   \frac{\sum_{k=1}^{K}\abs{x - x'}}{l_k}
-   *   exp(-\gamma\sqrt{3}\sum_{k=1}^{K}\frac{\abs{x - x'}}{l}) \f$
-   * 
-   * @param x std::vector of elements that can be used in stan::math::distance
-   * @param sigma standard deviation that can be used in stan::math::square
-   * @param gamma 
-   * @param length_scale length scale
-   * @param squared distance 
-   * @throw std::domain error if sigma <= 0, l <= l, or x is nan of inf.
-   * 
-   */
-template<typename T_x, typename T_l, typename T_s, typename T_g>
-inline typename
-Eigen::Matrix<typename stan::return_type<T_x, T_l, T_s, T_g>::type,
-              Eigen::Dynamic, Eigen::Dynamic>
-gp_matern_3_2_cov(const std::vector<T_x>& x,
-                  const std::vector<T_l>& length_scale,
-                  const T_s& sigma = 1.0, const T_g& gamma = 1.0){
+/** Returns a Matern 3/2 Kernel with one input vector,
+ * with ARD priors.
+ *
+ * CHECK THIS FORMULA:
+ * \f$ k(x, x') = \sigma^2(1 + \gamma \sqrt{3} \\
+ *   \frac{\sum_{k=1}^{K}\sqrt{(x - x')^2}}{l_k}
+ *   exp(-\gamma\sqrt{3}\sum_{k=1}^{K}\frac{\abs{x - x'}}{l}) \f$
+ *
+ * @param x std::vector of elements that can be used in stan::math::distance
+ * @param sigma standard deviation that can be used in stan::math::square
+ * @param gamma
+ * @param length_scale length scale
+ * @param squared distance
+ * @throw std::domain error if sigma <= 0, l <= l, or x is nan of inf.
+ *
+ */
+template <typename T_x, typename T_l, typename T_s, typename T_g>
+inline
+    typename Eigen::Matrix<typename stan::return_type<T_x, T_l, T_s, T_g>::type,
+                           Eigen::Dynamic, Eigen::Dynamic>
+    gp_matern_3_2_cov(const std::vector<T_x> &x,
+                      const std::vector<T_l> &length_scale,
+                      const T_s &sigma = 1.0, const T_g &gamma = 1.0) {
   using std::pow;
   using std::abs;
   using std::exp;
-
+  
+  
   size_t x_size = x.size();
   size_t l_size = length_scale.size();
 
-  check_positive("gp_matern_3_2_cov", "marginal variance", sigma);
   check_positive("gp_matern_3_2_cov", "length-scale", length_scale);
+  check_not_nan("gp_matern_3_2_cov", "length-scale", length_scale);
+
+  check_positive("gp_matern_3_2_cov", "marginal variance", sigma);
+  check_not_nan("gp_matern_3_2_cov", "marginal variance", sigma);
+
+  check_not_nan("gp_matern_3_2_cov", "gamma", gamma);
+  
   for (size_t n = 0; n < x_size; ++n)
     check_not_nan("gp_matern_3_2_cov", "x", x[n]);
-         
+
   Eigen::Matrix<typename stan::return_type<T_x, T_l, T_s, T_g>::type,
                 Eigen::Dynamic, Eigen::Dynamic>
-    cov(x_size, x_size);
+      cov(x_size, x_size);
 
-  if(x_size == 0)
+  if (x_size == 0)
     return cov;
 
   T_s sigma_sq = square(sigma);
   T_l root_3 = pow(3.0, 0.5);
   T_g neg_gamma = -1.0 * gamma;
   T_l temp;
-  
+
   for (size_t i = 0; i < x_size; ++i) {
     for (size_t j = i; j < x_size; ++j) {
       temp = 0;
       for (size_t k = 0; k < l_size; ++k) {
-        temp += (1.0 + root_3 * gamma * abs(x[i] - x[j]) / length_scale[k]) *
-          exp(neg_gamma * root_3 * abs(x[i] - x[j]) / length_scale[k]);
+        temp += squared_distance(x[i], x[j]) / length_scale[k];
       }
-      cov(i, j) = sigma_sq * temp;
+      cov(i, j) = sigma_sq * (1.0 + root_3 * gamma * pow(temp, 0.5)) *
+        exp(neg_gamma * root_3 * pow(temp, 0.5));
       cov(j, i) = cov(i, j);
     }
   }
   return cov;
 }
 
-  // TODO add x1, x2 for double... this is for vector of vectors
-  
-template<typename T_x1, typename T_x2, typename T_l, typename T_s, typename T_g>
-inline typename
-Eigen::Matrix<typename stan::return_type<T_x1, T_x2, T_l, T_s, T_g>::type,
-              Eigen::Dynamic, Eigen::Dynamic>
-gp_matern_3_2_cov(const std::vector<T_x1>& x1, const std::vector<T_x2>& x2,
-                  const T_l& length_scale, const T_s& sigma = 1.0,
-                  const T_g& gamma = 1.0){
+/** Returns a Matern 3/2 Kernel with two input vectors
+ *
+ * \f$ k(x, x') = \sigma^2(1 + \gamma \sqrt{3} \\
+ *  \frac{\abs{x - x'}}{l}exp(-\gamma\sqrt{3}\frac{\sqrt{(x - x')^2}}{l})  \f$
+ *
+ * @param x std::vector of elements that can be used in stan::math::distance
+ * @param sigma standard deviation that can be used in stan::math::square
+ * @param gamma
+ * @param length_scale length scale
+ * @param squared distance
+ * @throw std::domain error if sigma <= 0, l <= l, or x is nan of inf.
+ *
+ */
+template <typename T_x1, typename T_x2, typename T_l, typename T_s,
+          typename T_g>
+inline typename Eigen::Matrix<
+    typename stan::return_type<T_x1, T_x2, T_l, T_s, T_g>::type, Eigen::Dynamic,
+    Eigen::Dynamic>
+gp_matern_3_2_cov(const std::vector<T_x1> &x1, const std::vector<T_x2> &x2,
+                  const T_l &length_scale, const T_s &sigma = 1.0,
+                  const T_g &gamma = 1.0) {
   using std::pow;
   using std::abs;
   using std::exp;
-
+  using stan::math::squared_distance;
+  
   size_t x1_size = x1.size();
   size_t x2_size = x2.size();
 
   // add check same size
+  check_positive("gp_matern_3_2_cov", "length-scale", length_scale);
+  check_not_nan("gp_matern_3_2_cov", "length-scale", length_scale);
   
   check_positive("gp_matern_3_2_cov", "marginal variance", sigma);
-  check_positive("gp_matern_3_2_cov", "length-scale", length_scale);
+  check_not_nan("gp_matern_3_2_cov", "marginal variance", sigma);
+
+  check_not_nan("gp_matern_3_2_cov", "gamma", gamma);
+
   for (size_t n = 0; n < x1_size; ++n)
     check_not_nan("gp_matern_3_2_cov", "x1", x1[n]);
   for (size_t n = 0; n < x2_size; ++n)
     check_not_nan("gp_matern_3_2_cov", "x2", x2[n]);
-         
+
   Eigen::Matrix<typename stan::return_type<T_x1, T_x2, T_s, T_g, T_l>::type,
                 Eigen::Dynamic, Eigen::Dynamic>
-    cov(x1_size, x2_size);
+      cov(x1_size, x2_size);
 
-  if(x1_size == 0 || x2_size == 0)
+  if (x1_size == 0 || x2_size == 0)
     return cov;
 
   T_s sigma_sq = square(sigma);
   T_l root_3_inv_l = pow(3, 0.5) / length_scale;
   T_g neg_gamma = -1.0 * gamma;
-  T_g distance;
-  
+
   for (size_t i = 0; i < x1_size; ++i) {
-    for (size_t j = 0; j < x2_size; ++j){
-      distance = 0.0;
-      for (size_t k = 0; k < x1_size; ++k)
-        distance += abs(x1[i][k] - x2[j][k]);
-      cov(i, j) = sigma_sq * (1.0 + root_3_inv_l * gamma * distance) *
-        exp(neg_gamma *  root_3_inv_l * distance);
+    for (size_t j = 0; j < x2_size; ++j) {
+      cov(i, j) = sigma_sq * (1.0 + root_3_inv_l * gamma * squared_distance(x1[i], x2[j])) *
+        exp(neg_gamma * root_3_inv_l * squared_distance(x1[i], x2[j]));
     }
   }
   return cov;
 }
-}  // namespace math
-}  // namespace stan
+
+/** Returns a Matern 3/2 Kernel with two input vectors with ARD priors
+ *
+ * \f$ k(x, x') = \sigma^2(1 + \gamma \sqrt{3} \\
+ *   \frac{\sum_{k=1}^{K}\sqrt{(x - x')^2}}{l_k}
+ *   exp(-\gamma\sqrt{3}\sum_{k=1}^{K}\frac{\abs{x - x'}}{l}) \f$
+ *
+ * @param x std::vector of elements that can be used in stan::math::distance
+ * @param sigma standard deviation that can be used in stan::math::square
+ * @param gamma
+ * @param length_scale length scale
+ * @param squared distance
+ * @throw std::domain error if sigma <= 0, l <= l, or x is nan of inf.
+ *
+ */
+template <typename T_x1, typename T_x2, typename T_l, typename T_s,
+          typename T_g>
+inline typename Eigen::Matrix<
+    typename stan::return_type<T_x1, T_x2, T_l, T_s, T_g>::type, Eigen::Dynamic,
+    Eigen::Dynamic>
+gp_matern_3_2_cov(const std::vector<T_x1> &x1, const std::vector<T_x2> &x2,
+                  const std::vector<T_l> &length_scale, const T_s &sigma = 1.0,
+                  const T_g &gamma = 1.0) {
+  using std::pow;
+  using std::abs;
+  using std::exp;
+  using stan::math::squared_distance;
+  
+  size_t x1_size = x1.size();
+  size_t x2_size = x2.size();
+  size_t l_size = length_scale.size();
+  // add check same size
+
+  check_positive("gp_matern_3_2_cov", "length-scale", length_scale);
+  check_not_nan("gp_matern_3_2_cov", "length-scale", length_scale);
+  
+  check_positive("gp_matern_3_2_cov", "marginal variance", sigma);
+  check_not_nan("gp_matern_3_2_cov", "marginal variance", sigma);
+
+  check_not_nan("gp_matern_3_2_cov", "gamma", gamma);
+  
+  for (size_t n = 0; n < x1_size; ++n)
+    check_not_nan("gp_matern_3_2_cov", "x1", x1[n]);
+  for (size_t n = 0; n < x2_size; ++n)
+    check_not_nan("gp_matern_3_2_cov", "x2", x2[n]);
+
+  Eigen::Matrix<typename stan::return_type<T_x1, T_x2, T_s, T_g, T_l>::type,
+                Eigen::Dynamic, Eigen::Dynamic>
+      cov(x1_size, x2_size);
+
+  if (x1_size == 0 || x2_size == 0)
+    return cov;
+
+  T_s sigma_sq = square(sigma);
+  T_l root_3 = pow(3.0, 0.5);
+  T_g neg_gamma = -1.0 * gamma;
+  T_l temp;
+
+  for (size_t i = 0; i < x1_size; ++i) {
+    for (size_t j = 0; j < x2_size; ++j) {
+      temp = 0;
+      for (size_t k = 0; k < l_size; ++k) {
+        temp += squared_distance(x1[i], x2[j]) / length_scale[k];
+      }
+      cov(i, j) = sigma_sq * (1.0 + root_3 * gamma * pow(temp, 0.5)) *
+        exp(neg_gamma * root_3 * pow(temp, 0.5));
+    }
+  }
+  return cov;
+}
+} // namespace math
+} // namespace stan
 #endif

--- a/stan/math/prim/mat/fun/gp_matern_3_2_cov.hpp
+++ b/stan/math/prim/mat/fun/gp_matern_3_2_cov.hpp
@@ -9,17 +9,18 @@
 namespace stan {
 namespace math {
 
-/** Returns a Matern 3/2 Kernel with one input vector
+/** Returns a Matern 3/2 covariance matrix with one input vector
  *
- * \f$ k(x, x') = \sigma^2(1 + \gamma \sqrt{3} \\
- *  \frac{\abs{x - x'}}{l}exp(-\gamma\sqrt{3}\frac{\sqrt{(x - x')^2}}{l})  \f$
+ * \f[ k(x, x') = \sigma^2(1 + \gamma \sqrt{3}
+ *  \frac{\sqrt{(x - x')^2}}{l}exp(-\gamma\sqrt{3}\frac{\sqrt{(x - x')^2}}{l})  \f]
  *
+ * See Rausmussen & Williams et al 2006 Chapter 4.
+ * 
  * @param x std::vector of elements that can be used in stan::math::distance
+ * @param length_scale length scale
  * @param sigma standard deviation that can be used in stan::math::square
  * @param gamma
- * @param length_scale length scale
- * @param squared distance
- * @throw std::domain error if sigma <= 0, l <= l, or x is nan of inf.
+ * @throw std::domain error if sigma <= 0, l <= 0, or x or gamma are nan of inf
  *
  */
 template <typename T_x, typename T_l, typename T_s, typename T_g>
@@ -70,20 +71,19 @@ inline
 }
 
 /** Returns a Matern 3/2 Kernel with one input vector,
- * with ARD priors.
+ * with automatic relevance determination (ARD) priors
  *
- * CHECK THIS FORMULA:
- * \f$ k(x, x') = \sigma^2(1 + \gamma \sqrt{3} \\
+ * \f[ k(x, x') = \sigma^2(1 + \gamma \sqrt{3} 
  *   \frac{\sum_{k=1}^{K}\sqrt{(x - x')^2}}{l_k}
- *   exp(-\gamma\sqrt{3}\sum_{k=1}^{K}\frac{\abs{x - x'}}{l}) \f$
+ *   exp(-\gamma\sqrt{3}\sum_{k=1}^{K}\frac{\sqrt{(x - x')^2}}{l_k}) \f]
+ *
+ * See Rausmussen & Williams et al 2006 Chapter 4.
  *
  * @param x std::vector of elements that can be used in stan::math::distance
+ * @param length_scale length scale
  * @param sigma standard deviation that can be used in stan::math::square
  * @param gamma
- * @param length_scale length scale
- * @param squared distance
- * @throw std::domain error if sigma <= 0, l <= l, or x is nan of inf.
- *
+ * @throw std::domain error if sigma <= 0, l <= 0, or x or gamma are nan of inf
  */
 template <typename T_x, typename T_l, typename T_s, typename T_g>
 inline
@@ -95,7 +95,6 @@ inline
   using std::pow;
   using std::abs;
   using std::exp;
-  
   
   size_t x_size = x.size();
   size_t l_size = length_scale.size();
@@ -137,17 +136,19 @@ inline
   return cov;
 }
 
-/** Returns a Matern 3/2 Kernel with two input vectors
+/** Returns a Matern 3/2 covariance matrix with two input vectors
  *
- * \f$ k(x, x') = \sigma^2(1 + \gamma \sqrt{3} \\
- *  \frac{\abs{x - x'}}{l}exp(-\gamma\sqrt{3}\frac{\sqrt{(x - x')^2}}{l})  \f$
+ * \f[ k(x, x') = \sigma^2(1 + \gamma \sqrt{3} 
+ *  \frac{\sqrt{(x - x')^2}}{l}exp(-\gamma\sqrt{3}\frac{\sqrt{(x - x')^2}}{l})  \f]
  *
- * @param x std::vector of elements that can be used in stan::math::distance
+ * See Rausmussen & Williams et al 2006 Chapter 4.
+ *
+ * @param x1 std::vector of elements that can be used in stan::math::distance
+ * @param x2 std::vector of elements that can be used in stan::math::distance
+ * @param length_scale length scale
  * @param sigma standard deviation that can be used in stan::math::square
  * @param gamma
- * @param length_scale length scale
- * @param squared distance
- * @throw std::domain error if sigma <= 0, l <= l, or x is nan of inf.
+ * @throw std::domain error if sigma <= 0, l <= 0, or x or gamma are nan of inf
  *
  */
 template <typename T_x1, typename T_x2, typename T_l, typename T_s,
@@ -200,18 +201,21 @@ gp_matern_3_2_cov(const std::vector<T_x1> &x1, const std::vector<T_x2> &x2,
   return cov;
 }
 
-/** Returns a Matern 3/2 Kernel with two input vectors with ARD priors
+/** Returns a Matern 3/2 Kernel with two input vectors with automatic 
+ * relevance determination (ARD) priors
  *
- * \f$ k(x, x') = \sigma^2(1 + \gamma \sqrt{3} \\
+ * \f[ k(x, x') = \sigma^2(1 + \gamma \sqrt{3}
  *   \frac{\sum_{k=1}^{K}\sqrt{(x - x')^2}}{l_k}
- *   exp(-\gamma\sqrt{3}\sum_{k=1}^{K}\frac{\abs{x - x'}}{l}) \f$
+ *   exp(-\gamma\sqrt{3}\sum_{k=1}^{K}\frac{\sqrt{(x - x')^2}}{l_k}) \f]
  *
- * @param x std::vector of elements that can be used in stan::math::distance
+ * See Rausmussen & Williams et al 2006 Chapter 4.
+ *
+ * @param x1 std::vector of elements that can be used in stan::math::distance
+ * @param x2 std::vector of elements that can be used in stan::math::distance
+ * @param length_scale length scale
  * @param sigma standard deviation that can be used in stan::math::square
  * @param gamma
- * @param length_scale length scale
- * @param squared distance
- * @throw std::domain error if sigma <= 0, l <= l, or x is nan of inf.
+ * @throw std::domain error if sigma <= 0, l <= 0, or x or gamma are nan of inf
  *
  */
 template <typename T_x1, typename T_x2, typename T_l, typename T_s,

--- a/stan/math/prim/mat/fun/gp_matern_3_2_cov.hpp
+++ b/stan/math/prim/mat/fun/gp_matern_3_2_cov.hpp
@@ -2,8 +2,12 @@
 #define STAN_MATH_PRIM_MAT_FUN_GP_MATERN_3_2_COV_HPP
 
 #include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <stan/math/prim/scal/err/check_finite.hpp>
+#include <stan/math/prim/scal/err/check_nonnegative.hpp>
+#include <stan/math/prim/scal/err/check_not_nan.hpp>
 #include <stan/math/prim/scal/fun/square.hpp>
 #include <stan/math/prim/scal/fun/squared_distance.hpp>
+#include <stan/math/prim/scal/meta/return_type.hpp>
 #include <cmath>
 #include <vector>
 

--- a/stan/math/prim/mat/fun/gp_matern_3_2_cov.hpp
+++ b/stan/math/prim/mat/fun/gp_matern_3_2_cov.hpp
@@ -1,10 +1,10 @@
 #ifndef STAN_MATH_PRIM_MAT_FUN_GP_MATERN_3_2_COV_HPP
 #define STAN_MATH_PRIM_MAT_FUN_GP_MATERN_3_2_COV_HPP
 
-#include <cmath>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/scal/fun/square.hpp>
 #include <stan/math/prim/scal/fun/squared_distance.hpp>
+#include <cmath>
 #include <vector>
 
 namespace stan {

--- a/stan/math/prim/mat/fun/gp_matern_3_2_cov.hpp
+++ b/stan/math/prim/mat/fun/gp_matern_3_2_cov.hpp
@@ -1,11 +1,10 @@
 #ifndef STAN_MATH_PRIM_MAT_FUN_GP_MATERN_3_2_COV_HPP
 #define STAN_MATH_PRIM_MAT_FUN_GP_MATERN_3_2_COV_HPP
 
+#include <cmath>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/scal/fun/square.hpp>
 #include <stan/math/prim/scal/fun/squared_distance.hpp>
-#include <stan/math/prim/scal/meta/return_type.hpp>
-#include <cmath>
 #include <vector>
 
 namespace stan {
@@ -13,8 +12,8 @@ namespace math {
 
 /** Returns a Matern 3/2 covariance matrix with one input vector
  *
- * \f[ k(x, x') = \sigma^2(1 + \gamma \sqrt{3}
- *  \frac{\sqrt{(x - x')^2}}{l})exp(-\gamma\sqrt{3}\frac{\sqrt{(x - x')^2}}{l})
+ * \f[ k(x, x') = \sigma^2(1 + \sqrt{3}
+ *  \frac{\sqrt{(x - x')^2}}{l}exp(-\sqrt{3}\frac{\sqrt{(x - x')^2}}{l})
  * \f]
  *
  * See Rausmussen & Williams et al 2006 Chapter 4.
@@ -22,35 +21,32 @@ namespace math {
  * @param x std::vector of elements that can be used in stan::math::distance
  * @param length_scale length scale
  * @param sigma standard deviation that can be used in stan::math::square
- * @param gamma
- * @throw std::domain error if sigma <= 0, l <= 0, or x or gamma are nan of inf
+ * @throw std::domain error if sigma <= 0, l <= 0, or x is nan or inf
  *
  */
-template <typename T_x, typename T_l, typename T_s, typename T_g>
-inline
-    typename Eigen::Matrix<typename stan::return_type<T_x, T_l, T_s, T_g>::type,
-                           Eigen::Dynamic, Eigen::Dynamic>
-    gp_matern_3_2_cov(const std::vector<T_x> &x, const T_l &length_scale,
-                      const T_s &sigma = 1.0, const T_g &gamma = 1.0) {
+template <typename T_x, typename T_s, typename T_l>
+inline typename Eigen::Matrix<typename stan::return_type<T_x, T_s, T_l>::type,
+                              Eigen::Dynamic, Eigen::Dynamic>
+gp_matern_3_2_cov(const std::vector<T_x> &x, const T_s &sigma,
+                  const T_l &length_scale) {
   using stan::math::squared_distance;
   using std::abs;
   using std::exp;
   using std::pow;
 
   size_t x_size = x.size();
-  check_positive("gp_matern_3_2_cov", "length-scale", length_scale);
-  check_not_nan("gp_matern_3_2_cov", "length-scale", length_scale);
 
   check_positive("gp_matern_3_2_cov", "marginal variance", sigma);
   check_not_nan("gp_matern_3_2_cov", "marginal variance", sigma);
 
-  check_not_nan("gp_matern_3_2_cov", "gamma", gamma);
+  check_positive("gp_matern_3_2_cov", "length-scale", length_scale);
+  check_not_nan("gp_matern_3_2_cov", "length-scale", length_scale);
 
   for (size_t n = 0; n < x_size; ++n)
     check_not_nan("gp_matern_3_2_cov", "x", x[n]);
 
-  Eigen::Matrix<typename stan::return_type<T_x, T_s, T_g, T_l>::type,
-                Eigen::Dynamic, Eigen::Dynamic>
+  Eigen::Matrix<typename stan::return_type<T_x, T_s, T_l>::type, Eigen::Dynamic,
+                Eigen::Dynamic>
       cov(x_size, x_size);
 
   if (x_size == 0)
@@ -58,15 +54,14 @@ inline
 
   T_s sigma_sq = square(sigma);
   T_l root_3_inv_l = pow(3, 0.5) / length_scale;
-  T_g neg_gamma = -1.0 * gamma;
+  T_l neg_root_3_inv_l = -1.0 * pow(3, 0.5) / length_scale;
 
   for (size_t i = 0; i < (x_size - 1); ++i) {
     cov(i, i) = sigma_sq;
     for (size_t j = i + 1; j < x_size; ++j) {
-      cov(i, j)
-          = sigma_sq
-            * (1.0 + root_3_inv_l * gamma * squared_distance(x[i], x[j]))
-            * exp(neg_gamma * root_3_inv_l * squared_distance(x[i], x[j]));
+      cov(i, j) = sigma_sq *
+                  (1.0 + root_3_inv_l * squared_distance(x[i], x[j])) *
+                  exp(neg_root_3_inv_l * squared_distance(x[i], x[j]));
       cov(j, i) = cov(i, j);
     }
   }
@@ -77,25 +72,22 @@ inline
 /** Returns a Matern 3/2 Kernel with one input vector,
  * with automatic relevance determination (ARD) priors
  *
- * \f[ k(x, x') = \sigma^2(1 + \gamma \sqrt{3}
- *   \frac{\sum_{k=1}^{K}\sqrt{(x - x')^2}}{l_k})
- *   exp(-\gamma\sqrt{3}\sum_{k=1}^{K}\frac{\sqrt{(x - x')^2}}{l_k}) \f]
+ * \f[ k(x, x') = \sigma^2(1 + \sqrt{3}
+ *   \frac{\sum_{k=1}^{K}\sqrt{(x - x')^2}}{l_k}
+ *   exp(-\sqrt{3}\sum_{k=1}^{K}\frac{\sqrt{(x - x')^2}}{l_k}) \f]
  *
  * See Rausmussen & Williams et al 2006 Chapter 4.
  *
  * @param x std::vector of elements that can be used in stan::math::distance
  * @param length_scale length scale
  * @param sigma standard deviation that can be used in stan::math::square
- * @param gamma
- * @throw std::domain error if sigma <= 0, l <= 0, or x or gamma are nan of inf
+ * @throw std::domain error if sigma <= 0, l <= 0, or x is nan or inf
  */
-template <typename T_x, typename T_l, typename T_s, typename T_g>
-inline
-    typename Eigen::Matrix<typename stan::return_type<T_x, T_l, T_s, T_g>::type,
-                           Eigen::Dynamic, Eigen::Dynamic>
-    gp_matern_3_2_cov(const std::vector<T_x> &x,
-                      const std::vector<T_l> &length_scale,
-                      const T_s &sigma = 1.0, const T_g &gamma = 1.0) {
+template <typename T_x, typename T_s, typename T_l>
+inline typename Eigen::Matrix<typename stan::return_type<T_x, T_s, T_l>::type,
+                              Eigen::Dynamic, Eigen::Dynamic>
+gp_matern_3_2_cov(const std::vector<T_x> &x, const T_s &sigma,
+                  const std::vector<T_l> &length_scale) {
   using std::abs;
   using std::exp;
   using std::pow;
@@ -103,19 +95,17 @@ inline
   size_t x_size = x.size();
   size_t l_size = length_scale.size();
 
-  check_positive("gp_matern_3_2_cov", "length-scale", length_scale);
-  check_not_nan("gp_matern_3_2_cov", "length-scale", length_scale);
-
   check_positive("gp_matern_3_2_cov", "marginal variance", sigma);
   check_not_nan("gp_matern_3_2_cov", "marginal variance", sigma);
 
-  check_not_nan("gp_matern_3_2_cov", "gamma", gamma);
+  check_positive("gp_matern_3_2_cov", "length-scale", length_scale);
+  check_not_nan("gp_matern_3_2_cov", "length-scale", length_scale);
 
   for (size_t n = 0; n < x_size; ++n)
     check_not_nan("gp_matern_3_2_cov", "x", x[n]);
 
-  Eigen::Matrix<typename stan::return_type<T_x, T_l, T_s, T_g>::type,
-                Eigen::Dynamic, Eigen::Dynamic>
+  Eigen::Matrix<typename stan::return_type<T_x, T_s, T_l>::type, Eigen::Dynamic,
+                Eigen::Dynamic>
       cov(x_size, x_size);
 
   if (x_size == 0)
@@ -123,7 +113,7 @@ inline
 
   T_s sigma_sq = square(sigma);
   T_l root_3 = pow(3.0, 0.5);
-  T_g neg_gamma = -1.0 * gamma;
+  T_l neg_root_3 = -1.0 * pow(3.0, 0.5);
   T_l temp;
 
   for (size_t i = 0; i < x_size; ++i) {
@@ -132,8 +122,8 @@ inline
       for (size_t k = 0; k < l_size; ++k) {
         temp += squared_distance(x[i], x[j]) / length_scale[k];
       }
-      cov(i, j) = sigma_sq * (1.0 + root_3 * gamma * pow(temp, 0.5))
-                  * exp(neg_gamma * root_3 * pow(temp, 0.5));
+      temp = pow(temp, 0.5);
+      cov(i, j) = sigma_sq * (1.0 + root_3 * temp) * exp(neg_root_3 * temp);
       cov(j, i) = cov(i, j);
     }
   }
@@ -142,8 +132,8 @@ inline
 
 /** Returns a Matern 3/2 covariance matrix with two input vectors
  *
- * \f[ k(x, x') = \sigma^2(1 + \gamma \sqrt{3}
- *  \frac{\sqrt{(x - x')^2}}{l})exp(-\gamma\sqrt{3}\frac{\sqrt{(x - x')^2}}{l})
+ * \f[ k(x, x') = \sigma^2(1 + \sqrt{3}
+ *  \frac{\sqrt{(x - x')^2}}{l}exp(-\sqrt{3}\frac{\sqrt{(x - x')^2}}{l})
  * \f]
  *
  * See Rausmussen & Williams et al 2006 Chapter 4.
@@ -152,18 +142,15 @@ inline
  * @param x2 std::vector of elements that can be used in stan::math::distance
  * @param length_scale length scale
  * @param sigma standard deviation that can be used in stan::math::square
- * @param gamma
- * @throw std::domain error if sigma <= 0, l <= 0, or x or gamma are nan of inf
+ * @throw std::domain error if sigma <= 0, l <= 0, or x1, x2 are nan or inf
  *
  */
-template <typename T_x1, typename T_x2, typename T_l, typename T_s,
-          typename T_g>
+template <typename T_x1, typename T_x2, typename T_s, typename T_l>
 inline typename Eigen::Matrix<
-    typename stan::return_type<T_x1, T_x2, T_l, T_s, T_g>::type, Eigen::Dynamic,
+    typename stan::return_type<T_x1, T_x2, T_s, T_l>::type, Eigen::Dynamic,
     Eigen::Dynamic>
 gp_matern_3_2_cov(const std::vector<T_x1> &x1, const std::vector<T_x2> &x2,
-                  const T_l &length_scale, const T_s &sigma = 1.0,
-                  const T_g &gamma = 1.0) {
+                  const T_s &sigma, const T_l &length_scale) {
   using stan::math::squared_distance;
   using std::abs;
   using std::exp;
@@ -172,21 +159,18 @@ gp_matern_3_2_cov(const std::vector<T_x1> &x1, const std::vector<T_x2> &x2,
   size_t x1_size = x1.size();
   size_t x2_size = x2.size();
 
-  // add check same size
-  check_positive("gp_matern_3_2_cov", "length-scale", length_scale);
-  check_not_nan("gp_matern_3_2_cov", "length-scale", length_scale);
-
   check_positive("gp_matern_3_2_cov", "marginal variance", sigma);
   check_not_nan("gp_matern_3_2_cov", "marginal variance", sigma);
 
-  check_not_nan("gp_matern_3_2_cov", "gamma", gamma);
+  check_positive("gp_matern_3_2_cov", "length-scale", length_scale);
+  check_not_nan("gp_matern_3_2_cov", "length-scale", length_scale);
 
   for (size_t n = 0; n < x1_size; ++n)
     check_not_nan("gp_matern_3_2_cov", "x1", x1[n]);
   for (size_t n = 0; n < x2_size; ++n)
     check_not_nan("gp_matern_3_2_cov", "x2", x2[n]);
 
-  Eigen::Matrix<typename stan::return_type<T_x1, T_x2, T_s, T_g, T_l>::type,
+  Eigen::Matrix<typename stan::return_type<T_x1, T_x2, T_s, T_l>::type,
                 Eigen::Dynamic, Eigen::Dynamic>
       cov(x1_size, x2_size);
 
@@ -194,15 +178,14 @@ gp_matern_3_2_cov(const std::vector<T_x1> &x1, const std::vector<T_x2> &x2,
     return cov;
 
   T_s sigma_sq = square(sigma);
-  T_l root_3_inv_l = pow(3, 0.5) / length_scale;
-  T_g neg_gamma = -1.0 * gamma;
+  T_l root_3_inv_l = pow(3.0, 0.5) / length_scale;
+  T_l neg_root_3_inv_l = -1.0 * pow(3.0, 0.5) / length_scale;
 
   for (size_t i = 0; i < x1_size; ++i) {
     for (size_t j = 0; j < x2_size; ++j) {
-      cov(i, j)
-          = sigma_sq
-            * (1.0 + root_3_inv_l * gamma * squared_distance(x1[i], x2[j]))
-            * exp(neg_gamma * root_3_inv_l * squared_distance(x1[i], x2[j]));
+      cov(i, j) = sigma_sq *
+                  (1.0 + root_3_inv_l * squared_distance(x1[i], x2[j])) *
+                  exp(neg_root_3_inv_l * squared_distance(x1[i], x2[j]));
     }
   }
   return cov;
@@ -211,9 +194,9 @@ gp_matern_3_2_cov(const std::vector<T_x1> &x1, const std::vector<T_x2> &x2,
 /** Returns a Matern 3/2 Kernel with two input vectors with automatic
  * relevance determination (ARD) priors
  *
- * \f[ k(x, x') = \sigma^2(1 + \gamma \sqrt{3}
- *   \frac{\sum_{k=1}^{K}\sqrt{(x - x')^2}}{l_k})
- *   exp(-\gamma\sqrt{3}\sum_{k=1}^{K}\frac{\sqrt{(x - x')^2}}{l_k}) \f]
+ * \f[ k(x, x') = \sigma^2(1 + \sqrt{3}
+ *   \frac{\sum_{k=1}^{K}\sqrt{(x - x')^2}}{l_k}
+ *   exp(-\sqrt{3}\sum_{k=1}^{K}\frac{\sqrt{(x - x')^2}}{l_k}) \f]
  *
  * See Rausmussen & Williams et al 2006 Chapter 4.
  *
@@ -221,18 +204,15 @@ gp_matern_3_2_cov(const std::vector<T_x1> &x1, const std::vector<T_x2> &x2,
  * @param x2 std::vector of elements that can be used in stan::math::distance
  * @param length_scale length scale
  * @param sigma standard deviation that can be used in stan::math::square
- * @param gamma
- * @throw std::domain error if sigma <= 0, l <= 0, or x or gamma are nan of inf
+ * @throw std::domain error if sigma <= 0, l <= 0, or x1, x2 are nan or inf
  *
  */
-template <typename T_x1, typename T_x2, typename T_l, typename T_s,
-          typename T_g>
+template <typename T_x1, typename T_x2, typename T_s, typename T_l>
 inline typename Eigen::Matrix<
-    typename stan::return_type<T_x1, T_x2, T_l, T_s, T_g>::type, Eigen::Dynamic,
+    typename stan::return_type<T_x1, T_x2, T_s, T_l>::type, Eigen::Dynamic,
     Eigen::Dynamic>
 gp_matern_3_2_cov(const std::vector<T_x1> &x1, const std::vector<T_x2> &x2,
-                  const std::vector<T_l> &length_scale, const T_s &sigma = 1.0,
-                  const T_g &gamma = 1.0) {
+                  const T_s &sigma, const std::vector<T_l> &length_scale) {
   using stan::math::squared_distance;
   using std::abs;
   using std::exp;
@@ -241,22 +221,19 @@ gp_matern_3_2_cov(const std::vector<T_x1> &x1, const std::vector<T_x2> &x2,
   size_t x1_size = x1.size();
   size_t x2_size = x2.size();
   size_t l_size = length_scale.size();
-  // add check same size
-
-  check_positive("gp_matern_3_2_cov", "length-scale", length_scale);
-  check_not_nan("gp_matern_3_2_cov", "length-scale", length_scale);
 
   check_positive("gp_matern_3_2_cov", "marginal variance", sigma);
   check_not_nan("gp_matern_3_2_cov", "marginal variance", sigma);
 
-  check_not_nan("gp_matern_3_2_cov", "gamma", gamma);
+  check_positive("gp_matern_3_2_cov", "length-scale", length_scale);
+  check_not_nan("gp_matern_3_2_cov", "length-scale", length_scale);
 
   for (size_t n = 0; n < x1_size; ++n)
     check_not_nan("gp_matern_3_2_cov", "x1", x1[n]);
   for (size_t n = 0; n < x2_size; ++n)
     check_not_nan("gp_matern_3_2_cov", "x2", x2[n]);
 
-  Eigen::Matrix<typename stan::return_type<T_x1, T_x2, T_s, T_g, T_l>::type,
+  Eigen::Matrix<typename stan::return_type<T_x1, T_x2, T_s, T_l>::type,
                 Eigen::Dynamic, Eigen::Dynamic>
       cov(x1_size, x2_size);
 
@@ -265,7 +242,7 @@ gp_matern_3_2_cov(const std::vector<T_x1> &x1, const std::vector<T_x2> &x2,
 
   T_s sigma_sq = square(sigma);
   T_l root_3 = pow(3.0, 0.5);
-  T_g neg_gamma = -1.0 * gamma;
+  T_l neg_root_3 = -1.0 * pow(3.0, 0.5);
   T_l temp;
 
   for (size_t i = 0; i < x1_size; ++i) {
@@ -274,12 +251,12 @@ gp_matern_3_2_cov(const std::vector<T_x1> &x1, const std::vector<T_x2> &x2,
       for (size_t k = 0; k < l_size; ++k) {
         temp += squared_distance(x1[i], x2[j]) / length_scale[k];
       }
-      cov(i, j) = sigma_sq * (1.0 + root_3 * gamma * pow(temp, 0.5))
-                  * exp(neg_gamma * root_3 * pow(temp, 0.5));
+      temp = pow(temp, 0.5);
+      cov(i, j) = sigma_sq * (1.0 + root_3 * temp) * exp(neg_root_3 * temp);
     }
   }
   return cov;
 }
-}  // namespace math
-}  // namespace stan
+} // namespace math
+} // namespace stan
 #endif

--- a/stan/math/prim/mat/fun/gp_matern_3_2_cov.hpp
+++ b/stan/math/prim/mat/fun/gp_matern_3_2_cov.hpp
@@ -59,9 +59,8 @@ gp_matern_3_2_cov(const std::vector<T_x> &x, const T_s &sigma,
   for (size_t i = 0; i < (x_size - 1); ++i) {
     cov(i, i) = sigma_sq;
     for (size_t j = i + 1; j < x_size; ++j) {
-      cov(i, j) = sigma_sq *
-                  (1.0 + root_3_inv_l * squared_distance(x[i], x[j])) *
-                  exp(neg_root_3_inv_l * squared_distance(x[i], x[j]));
+      cov(i, j) = sigma_sq * (1.0 + root_3_inv_l * squared_distance(x[i], x[j]))
+                  * exp(neg_root_3_inv_l * squared_distance(x[i], x[j]));
       cov(j, i) = cov(i, j);
     }
   }
@@ -183,9 +182,9 @@ gp_matern_3_2_cov(const std::vector<T_x1> &x1, const std::vector<T_x2> &x2,
 
   for (size_t i = 0; i < x1_size; ++i) {
     for (size_t j = 0; j < x2_size; ++j) {
-      cov(i, j) = sigma_sq *
-                  (1.0 + root_3_inv_l * squared_distance(x1[i], x2[j])) *
-                  exp(neg_root_3_inv_l * squared_distance(x1[i], x2[j]));
+      cov(i, j) = sigma_sq
+                  * (1.0 + root_3_inv_l * squared_distance(x1[i], x2[j]))
+                  * exp(neg_root_3_inv_l * squared_distance(x1[i], x2[j]));
     }
   }
   return cov;
@@ -257,6 +256,6 @@ gp_matern_3_2_cov(const std::vector<T_x1> &x1, const std::vector<T_x2> &x2,
   }
   return cov;
 }
-} // namespace math
-} // namespace stan
+}  // namespace math
+}  // namespace stan
 #endif

--- a/stan/math/prim/mat/fun/gp_matern_3_2_cov.hpp
+++ b/stan/math/prim/mat/fun/gp_matern_3_2_cov.hpp
@@ -31,10 +31,10 @@ inline
                            Eigen::Dynamic, Eigen::Dynamic>
     gp_matern_3_2_cov(const std::vector<T_x> &x, const T_l &length_scale,
                       const T_s &sigma = 1.0, const T_g &gamma = 1.0) {
-  using std::pow;
+  using stan::math::squared_distance;
   using std::abs;
   using std::exp;
-  using stan::math::squared_distance;
+  using std::pow;
 
   size_t x_size = x.size();
   check_positive("gp_matern_3_2_cov", "length-scale", length_scale);
@@ -62,9 +62,10 @@ inline
   for (size_t i = 0; i < (x_size - 1); ++i) {
     cov(i, i) = sigma_sq;
     for (size_t j = i + 1; j < x_size; ++j) {
-      cov(i, j) = sigma_sq *
-                  (1.0 + root_3_inv_l * gamma * squared_distance(x[i], x[j])) *
-                  exp(neg_gamma * root_3_inv_l * squared_distance(x[i], x[j]));
+      cov(i, j)
+          = sigma_sq
+            * (1.0 + root_3_inv_l * gamma * squared_distance(x[i], x[j]))
+            * exp(neg_gamma * root_3_inv_l * squared_distance(x[i], x[j]));
       cov(j, i) = cov(i, j);
     }
   }
@@ -94,9 +95,9 @@ inline
     gp_matern_3_2_cov(const std::vector<T_x> &x,
                       const std::vector<T_l> &length_scale,
                       const T_s &sigma = 1.0, const T_g &gamma = 1.0) {
-  using std::pow;
   using std::abs;
   using std::exp;
+  using std::pow;
 
   size_t x_size = x.size();
   size_t l_size = length_scale.size();
@@ -130,8 +131,8 @@ inline
       for (size_t k = 0; k < l_size; ++k) {
         temp += squared_distance(x[i], x[j]) / length_scale[k];
       }
-      cov(i, j) = sigma_sq * (1.0 + root_3 * gamma * pow(temp, 0.5)) *
-                  exp(neg_gamma * root_3 * pow(temp, 0.5));
+      cov(i, j) = sigma_sq * (1.0 + root_3 * gamma * pow(temp, 0.5))
+                  * exp(neg_gamma * root_3 * pow(temp, 0.5));
       cov(j, i) = cov(i, j);
     }
   }
@@ -162,10 +163,10 @@ inline typename Eigen::Matrix<
 gp_matern_3_2_cov(const std::vector<T_x1> &x1, const std::vector<T_x2> &x2,
                   const T_l &length_scale, const T_s &sigma = 1.0,
                   const T_g &gamma = 1.0) {
-  using std::pow;
+  using stan::math::squared_distance;
   using std::abs;
   using std::exp;
-  using stan::math::squared_distance;
+  using std::pow;
 
   size_t x1_size = x1.size();
   size_t x2_size = x2.size();
@@ -197,10 +198,10 @@ gp_matern_3_2_cov(const std::vector<T_x1> &x1, const std::vector<T_x2> &x2,
 
   for (size_t i = 0; i < x1_size; ++i) {
     for (size_t j = 0; j < x2_size; ++j) {
-      cov(i, j) =
-          sigma_sq *
-          (1.0 + root_3_inv_l * gamma * squared_distance(x1[i], x2[j])) *
-          exp(neg_gamma * root_3_inv_l * squared_distance(x1[i], x2[j]));
+      cov(i, j)
+          = sigma_sq
+            * (1.0 + root_3_inv_l * gamma * squared_distance(x1[i], x2[j]))
+            * exp(neg_gamma * root_3_inv_l * squared_distance(x1[i], x2[j]));
     }
   }
   return cov;
@@ -231,10 +232,10 @@ inline typename Eigen::Matrix<
 gp_matern_3_2_cov(const std::vector<T_x1> &x1, const std::vector<T_x2> &x2,
                   const std::vector<T_l> &length_scale, const T_s &sigma = 1.0,
                   const T_g &gamma = 1.0) {
-  using std::pow;
+  using stan::math::squared_distance;
   using std::abs;
   using std::exp;
-  using stan::math::squared_distance;
+  using std::pow;
 
   size_t x1_size = x1.size();
   size_t x2_size = x2.size();
@@ -272,8 +273,8 @@ gp_matern_3_2_cov(const std::vector<T_x1> &x1, const std::vector<T_x2> &x2,
       for (size_t k = 0; k < l_size; ++k) {
         temp += squared_distance(x1[i], x2[j]) / length_scale[k];
       }
-      cov(i, j) = sigma_sq * (1.0 + root_3 * gamma * pow(temp, 0.5)) *
-                  exp(neg_gamma * root_3 * pow(temp, 0.5));
+      cov(i, j) = sigma_sq * (1.0 + root_3 * gamma * pow(temp, 0.5))
+                  * exp(neg_gamma * root_3 * pow(temp, 0.5));
     }
   }
   return cov;

--- a/test/unit/math/prim/mat/fun/gp_matern_3_2_cov_test.cpp
+++ b/test/unit/math/prim/mat/fun/gp_matern_3_2_cov_test.cpp
@@ -47,11 +47,12 @@ TEST(MathPrimMat, vec_double_gp_matern_3_2_cov1) {
   for (int i = 0; i < 3; i++)
     for (int j = 0; j < 3; j++)
       EXPECT_FLOAT_EQ(
-          sigma * sigma *
-              (1.0 +
-               (pow(3.0, 0.5) / l) * stan::math::squared_distance(x[i], x[j])) *
-              std::exp(-1.0 * (pow(3.0, 0.5) / l) *
-                       stan::math::squared_distance(x[i], x[j])),
+          sigma * sigma
+              * (1.0
+                 + (pow(3.0, 0.5) / l)
+                       * stan::math::squared_distance(x[i], x[j]))
+              * std::exp(-1.0 * (pow(3.0, 0.5) / l)
+                         * stan::math::squared_distance(x[i], x[j])),
           cov(i, j))
           << "index: (" << i << ", " << j << ")";
 }
@@ -81,8 +82,8 @@ TEST(MathPrimMat, vec_double_ard_gp_matern_3_2_cov1) {
         temp += stan::math::squared_distance(x[i], x[j]) / l[k];
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp)) *
-                          std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp))
+                          * std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
                       cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -103,13 +104,14 @@ TEST(MathPrimMat, vec_eigen_gp_matern_3_2_cov1) {
   cov = stan::math::gp_matern_3_2_cov(x1, sigma, l);
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
-      EXPECT_FLOAT_EQ(sigma * sigma *
-                          (1.0 +
-                           (pow(3.0, 0.5) / l) *
-                               stan::math::squared_distance(x1[i], x1[j])) *
-                          std::exp(-1.0 * (pow(3.0, 0.5) / l) *
-                                   stan::math::squared_distance(x1[i], x1[j])),
-                      cov(i, j))
+      EXPECT_FLOAT_EQ(
+          sigma * sigma
+              * (1.0
+                 + (pow(3.0, 0.5) / l)
+                       * stan::math::squared_distance(x1[i], x1[j]))
+              * std::exp(-1.0 * (pow(3.0, 0.5) / l)
+                         * stan::math::squared_distance(x1[i], x1[j])),
+          cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -135,13 +137,14 @@ TEST(MathPrimMat, vec_eigen_eigen_gp_matern_3_2_cov1) {
   cov = stan::math::gp_matern_3_2_cov(x1, x2, sigma, l);
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
-      EXPECT_FLOAT_EQ(sigma * sigma *
-                          (1.0 +
-                           (pow(3.0, 0.5) / l) *
-                               stan::math::squared_distance(x1[i], x2[j])) *
-                          std::exp(-1.0 * (pow(3.0, 0.5) / l) *
-                                   stan::math::squared_distance(x1[i], x2[j])),
-                      cov(i, j))
+      EXPECT_FLOAT_EQ(
+          sigma * sigma
+              * (1.0
+                 + (pow(3.0, 0.5) / l)
+                       * stan::math::squared_distance(x1[i], x2[j]))
+              * std::exp(-1.0 * (pow(3.0, 0.5) / l)
+                         * stan::math::squared_distance(x1[i], x2[j])),
+          cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -165,13 +168,14 @@ TEST(MathPrimMat, vec_double_double_gp_matern_3_2_cov1) {
   cov = stan::math::gp_matern_3_2_cov(x1, x2, sigma, l);
   for (int i = 0; i < 3; i++)
     for (int j = 0; j < 3; j++)
-      EXPECT_FLOAT_EQ(sigma * sigma *
-                          (1.0 +
-                           (pow(3.0, 0.5) / l) *
-                               stan::math::squared_distance(x1[i], x2[j])) *
-                          std::exp(-1.0 * (pow(3.0, 0.5) / l) *
-                                   stan::math::squared_distance(x1[i], x2[j])),
-                      cov(i, j))
+      EXPECT_FLOAT_EQ(
+          sigma * sigma
+              * (1.0
+                 + (pow(3.0, 0.5) / l)
+                       * stan::math::squared_distance(x1[i], x2[j]))
+              * std::exp(-1.0 * (pow(3.0, 0.5) / l)
+                         * stan::math::squared_distance(x1[i], x2[j])),
+          cov(i, j))
           << "index: (" << i << ", " << j << ")";
 }
 
@@ -201,8 +205,8 @@ TEST(MathPrimMat, vec_eigen_ard_gp_matern_3_2_cov1) {
         temp += stan::math::squared_distance(x1[i], x1[j]) / l[k];
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp)) *
-                          std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp))
+                          * std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
                       cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -237,8 +241,8 @@ TEST(MathPrimMat, vec_double_double_ard_gp_matern_3_2_cov1) {
       for (int k = 0; k < 4; k++) {
         temp += stan::math::squared_distance(x1[i], x2[j]) / l[k];
       }
-      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * pow(temp, 0.5)) *
-                          std::exp(-1.0 * pow(3.0, 0.5) * pow(temp, 0.5)),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * pow(temp, 0.5))
+                          * std::exp(-1.0 * pow(3.0, 0.5) * pow(temp, 0.5)),
                       cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -275,8 +279,8 @@ TEST(MathPrimMat, vec_eigen_eigen_ard_gp_matern_3_2_cov1) {
       for (int k = 0; k < 4; k++) {
         temp += stan::math::squared_distance(x1[i], x2[j]) / l[k];
       }
-      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * pow(temp, 0.5)) *
-                          std::exp(-1.0 * pow(3.0, 0.5) * pow(temp, 0.5)),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * pow(temp, 0.5))
+                          * std::exp(-1.0 * pow(3.0, 0.5) * pow(temp, 0.5)),
                       cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -297,13 +301,14 @@ TEST(MathPrimMat, rvec_eigen_gp_matern_3_2_cov1) {
   cov = stan::math::gp_matern_3_2_cov(x1, sigma, l);
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
-      EXPECT_FLOAT_EQ(sigma * sigma *
-                          (1.0 +
-                           (pow(3.0, 0.5) / l) *
-                               stan::math::squared_distance(x1[i], x1[j])) *
-                          std::exp(-1.0 * (pow(3.0, 0.5) / l) *
-                                   stan::math::squared_distance(x1[i], x1[j])),
-                      cov(i, j))
+      EXPECT_FLOAT_EQ(
+          sigma * sigma
+              * (1.0
+                 + (pow(3.0, 0.5) / l)
+                       * stan::math::squared_distance(x1[i], x1[j]))
+              * std::exp(-1.0 * (pow(3.0, 0.5) / l)
+                         * stan::math::squared_distance(x1[i], x1[j])),
+          cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -334,8 +339,8 @@ TEST(MathPrimMat, rvec_eigen_ard_gp_matern_3_2_cov1) {
         temp += stan::math::squared_distance(x1[i], x1[j]) / l[k];
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp)) *
-                          std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp))
+                          * std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
                       cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -362,13 +367,14 @@ TEST(MathPrimMat, vec_eigen_rvec_eigen_gp_matern_3_2_cov1) {
   cov = stan::math::gp_matern_3_2_cov(x1, x2, sigma, l);
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
-      EXPECT_FLOAT_EQ(sigma * sigma *
-                          (1.0 +
-                           (pow(3.0, 0.5) / l) *
-                               stan::math::squared_distance(x1[i], x2[j])) *
-                          std::exp(-1.0 * (pow(3.0, 0.5) / l) *
-                                   stan::math::squared_distance(x1[i], x2[j])),
-                      cov(i, j))
+      EXPECT_FLOAT_EQ(
+          sigma * sigma
+              * (1.0
+                 + (pow(3.0, 0.5) / l)
+                       * stan::math::squared_distance(x1[i], x2[j]))
+              * std::exp(-1.0 * (pow(3.0, 0.5) / l)
+                         * stan::math::squared_distance(x1[i], x2[j])),
+          cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -376,13 +382,14 @@ TEST(MathPrimMat, vec_eigen_rvec_eigen_gp_matern_3_2_cov1) {
   cov = stan::math::gp_matern_3_2_cov(x2, x1, sigma, l);
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
-      EXPECT_FLOAT_EQ(sigma * sigma *
-                          (1.0 +
-                           (pow(3.0, 0.5) / l) *
-                               stan::math::squared_distance(x2[i], x1[j])) *
-                          std::exp(-1.0 * (pow(3.0, 0.5) / l) *
-                                   stan::math::squared_distance(x2[i], x1[j])),
-                      cov(i, j))
+      EXPECT_FLOAT_EQ(
+          sigma * sigma
+              * (1.0
+                 + (pow(3.0, 0.5) / l)
+                       * stan::math::squared_distance(x2[i], x1[j]))
+              * std::exp(-1.0 * (pow(3.0, 0.5) / l)
+                         * stan::math::squared_distance(x2[i], x1[j])),
+          cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -417,8 +424,8 @@ TEST(MathPrimMat, vec_eigen_rvec_eigen_ard_gp_matern_3_2_cov1) {
         temp += stan::math::squared_distance(x1[i], x2[j]) / l[k];
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp)) *
-                          std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp))
+                          * std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
                       cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -431,8 +438,8 @@ TEST(MathPrimMat, vec_eigen_rvec_eigen_ard_gp_matern_3_2_cov1) {
         temp += stan::math::squared_distance(x2[i], x1[j]) / l[k];
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp)) *
-                          std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp))
+                          * std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
                       cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -459,13 +466,14 @@ TEST(MathPrimMat, rvec_eigen_rvec_eigen_gp_matern_3_2_cov1) {
   cov = stan::math::gp_matern_3_2_cov(x1, x2, sigma, l);
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
-      EXPECT_FLOAT_EQ(sigma * sigma *
-                          (1.0 +
-                           (pow(3.0, 0.5) / l) *
-                               stan::math::squared_distance(x1[i], x2[j])) *
-                          std::exp(-1.0 * (pow(3.0, 0.5) / l) *
-                                   stan::math::squared_distance(x1[i], x2[j])),
-                      cov(i, j))
+      EXPECT_FLOAT_EQ(
+          sigma * sigma
+              * (1.0
+                 + (pow(3.0, 0.5) / l)
+                       * stan::math::squared_distance(x1[i], x2[j]))
+              * std::exp(-1.0 * (pow(3.0, 0.5) / l)
+                         * stan::math::squared_distance(x1[i], x2[j])),
+          cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -473,13 +481,14 @@ TEST(MathPrimMat, rvec_eigen_rvec_eigen_gp_matern_3_2_cov1) {
   cov = stan::math::gp_matern_3_2_cov(x2, x1, sigma, l);
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
-      EXPECT_FLOAT_EQ(sigma * sigma *
-                          (1.0 +
-                           (pow(3.0, 0.5) / l) *
-                               stan::math::squared_distance(x2[i], x1[j])) *
-                          std::exp(-1.0 * (pow(3.0, 0.5) / l) *
-                                   stan::math::squared_distance(x2[i], x1[j])),
-                      cov(i, j))
+      EXPECT_FLOAT_EQ(
+          sigma * sigma
+              * (1.0
+                 + (pow(3.0, 0.5) / l)
+                       * stan::math::squared_distance(x2[i], x1[j]))
+              * std::exp(-1.0 * (pow(3.0, 0.5) / l)
+                         * stan::math::squared_distance(x2[i], x1[j])),
+          cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -515,8 +524,8 @@ TEST(MathPrimMat, rvec_eigen_rvec_eigen_ard_gp_matern_3_2_cov1) {
         temp += stan::math::squared_distance(x1[i], x2[j]) / l[k];
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp)) *
-                          std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp))
+                          * std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
                       cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -529,8 +538,8 @@ TEST(MathPrimMat, rvec_eigen_rvec_eigen_ard_gp_matern_3_2_cov1) {
         temp += stan::math::squared_distance(x2[i], x1[j]) / l[k];
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp)) *
-                          std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp))
+                          * std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
                       cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -568,144 +577,152 @@ TEST(MathPrimMat, vec_eigen_mixed_gp_matern_3_2_cov2) {
     x2_vec[i] << 2 * i, 3 * i, 4 * i;
   }
   Eigen::MatrixXd cov;
-  EXPECT_NO_THROW(cov =
-                      stan::math::gp_matern_3_2_cov(x1_rvec, x2_vec, sigma, l));
+  EXPECT_NO_THROW(cov
+                  = stan::math::gp_matern_3_2_cov(x1_rvec, x2_vec, sigma, l));
   EXPECT_EQ(3, cov.rows());
   EXPECT_EQ(4, cov.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-          sigma * sigma * (1.0 +
-                           (pow(3.0, 0.5) / l) * stan::math::squared_distance(
-                                                     x1_rvec[i], x2_vec[j])) *
-              std::exp(-1.0 * (pow(3.0, 0.5) / l) *
-                       stan::math::squared_distance(x1_rvec[i], x2_vec[j])),
+          sigma * sigma
+              * (1.0
+                 + (pow(3.0, 0.5) / l)
+                       * stan::math::squared_distance(x1_rvec[i], x2_vec[j]))
+              * std::exp(-1.0 * (pow(3.0, 0.5) / l)
+                         * stan::math::squared_distance(x1_rvec[i], x2_vec[j])),
           cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov7;
-  EXPECT_NO_THROW(cov7 =
-                      stan::math::gp_matern_3_2_cov(x2_vec, x1_rvec, sigma, l));
+  EXPECT_NO_THROW(cov7
+                  = stan::math::gp_matern_3_2_cov(x2_vec, x1_rvec, sigma, l));
   EXPECT_EQ(4, cov7.rows());
   EXPECT_EQ(3, cov7.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-          sigma * sigma * (1.0 +
-                           (pow(3.0, 0.5) / l) * stan::math::squared_distance(
-                                                     x2_vec[i], x1_rvec[j])) *
-              std::exp(-1.0 * (pow(3.0, 0.5) / l) *
-                       stan::math::squared_distance(x2_vec[i], x1_rvec[j])),
+          sigma * sigma
+              * (1.0
+                 + (pow(3.0, 0.5) / l)
+                       * stan::math::squared_distance(x2_vec[i], x1_rvec[j]))
+              * std::exp(-1.0 * (pow(3.0, 0.5) / l)
+                         * stan::math::squared_distance(x2_vec[i], x1_rvec[j])),
           cov7(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov2;
-  EXPECT_NO_THROW(cov2 =
-                      stan::math::gp_matern_3_2_cov(x1_vec, x2_rvec, sigma, l));
+  EXPECT_NO_THROW(cov2
+                  = stan::math::gp_matern_3_2_cov(x1_vec, x2_rvec, sigma, l));
   EXPECT_EQ(3, cov2.rows());
   EXPECT_EQ(4, cov2.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-          sigma * sigma * (1.0 +
-                           (pow(3.0, 0.5) / l) * stan::math::squared_distance(
-                                                     x1_vec[i], x2_rvec[j])) *
-              std::exp(-1.0 * (pow(3.0, 0.5) / l) *
-                       stan::math::squared_distance(x1_vec[i], x2_rvec[j])),
+          sigma * sigma
+              * (1.0
+                 + (pow(3.0, 0.5) / l)
+                       * stan::math::squared_distance(x1_vec[i], x2_rvec[j]))
+              * std::exp(-1.0 * (pow(3.0, 0.5) / l)
+                         * stan::math::squared_distance(x1_vec[i], x2_rvec[j])),
           cov2(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov8;
-  EXPECT_NO_THROW(cov8 =
-                      stan::math::gp_matern_3_2_cov(x2_rvec, x1_vec, sigma, l));
+  EXPECT_NO_THROW(cov8
+                  = stan::math::gp_matern_3_2_cov(x2_rvec, x1_vec, sigma, l));
   EXPECT_EQ(4, cov8.rows());
   EXPECT_EQ(3, cov8.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-          sigma * sigma * (1.0 +
-                           (pow(3.0, 0.5) / l) * stan::math::squared_distance(
-                                                     x2_rvec[i], x1_vec[j])) *
-              std::exp(-1.0 * (pow(3.0, 0.5) / l) *
-                       stan::math::squared_distance(x2_rvec[i], x1_vec[j])),
+          sigma * sigma
+              * (1.0
+                 + (pow(3.0, 0.5) / l)
+                       * stan::math::squared_distance(x2_rvec[i], x1_vec[j]))
+              * std::exp(-1.0 * (pow(3.0, 0.5) / l)
+                         * stan::math::squared_distance(x2_rvec[i], x1_vec[j])),
           cov8(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov3;
-  EXPECT_NO_THROW(cov3 =
-                      stan::math::gp_matern_3_2_cov(x2_vec, x2_rvec, sigma, l));
+  EXPECT_NO_THROW(cov3
+                  = stan::math::gp_matern_3_2_cov(x2_vec, x2_rvec, sigma, l));
   EXPECT_EQ(4, cov3.rows());
   EXPECT_EQ(4, cov3.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-          sigma * sigma * (1.0 +
-                           (pow(3.0, 0.5) / l) * stan::math::squared_distance(
-                                                     x2_vec[i], x2_rvec[j])) *
-              std::exp(-1.0 * (pow(3.0, 0.5) / l) *
-                       stan::math::squared_distance(x2_vec[i], x2_rvec[j])),
+          sigma * sigma
+              * (1.0
+                 + (pow(3.0, 0.5) / l)
+                       * stan::math::squared_distance(x2_vec[i], x2_rvec[j]))
+              * std::exp(-1.0 * (pow(3.0, 0.5) / l)
+                         * stan::math::squared_distance(x2_vec[i], x2_rvec[j])),
           cov3(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov4;
-  EXPECT_NO_THROW(cov4 =
-                      stan::math::gp_matern_3_2_cov(x2_rvec, x2_vec, sigma, l));
+  EXPECT_NO_THROW(cov4
+                  = stan::math::gp_matern_3_2_cov(x2_rvec, x2_vec, sigma, l));
   EXPECT_EQ(4, cov4.rows());
   EXPECT_EQ(4, cov4.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-          sigma * sigma * (1.0 +
-                           (pow(3.0, 0.5) / l) * stan::math::squared_distance(
-                                                     x2_rvec[i], x2_vec[j])) *
-              std::exp(-1.0 * (pow(3.0, 0.5) / l) *
-                       stan::math::squared_distance(x2_rvec[i], x2_vec[j])),
+          sigma * sigma
+              * (1.0
+                 + (pow(3.0, 0.5) / l)
+                       * stan::math::squared_distance(x2_rvec[i], x2_vec[j]))
+              * std::exp(-1.0 * (pow(3.0, 0.5) / l)
+                         * stan::math::squared_distance(x2_rvec[i], x2_vec[j])),
           cov4(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov5;
-  EXPECT_NO_THROW(cov5 =
-                      stan::math::gp_matern_3_2_cov(x1_rvec, x1_vec, sigma, l));
+  EXPECT_NO_THROW(cov5
+                  = stan::math::gp_matern_3_2_cov(x1_rvec, x1_vec, sigma, l));
   EXPECT_EQ(3, cov5.rows());
   EXPECT_EQ(3, cov5.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-          sigma * sigma * (1.0 +
-                           (pow(3.0, 0.5) / l) * stan::math::squared_distance(
-                                                     x1_rvec[i], x1_vec[j])) *
-              std::exp(-1.0 * (pow(3.0, 0.5) / l) *
-                       stan::math::squared_distance(x1_rvec[i], x1_vec[j])),
+          sigma * sigma
+              * (1.0
+                 + (pow(3.0, 0.5) / l)
+                       * stan::math::squared_distance(x1_rvec[i], x1_vec[j]))
+              * std::exp(-1.0 * (pow(3.0, 0.5) / l)
+                         * stan::math::squared_distance(x1_rvec[i], x1_vec[j])),
           cov5(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov6;
-  EXPECT_NO_THROW(cov6 =
-                      stan::math::gp_matern_3_2_cov(x1_vec, x1_rvec, sigma, l));
+  EXPECT_NO_THROW(cov6
+                  = stan::math::gp_matern_3_2_cov(x1_vec, x1_rvec, sigma, l));
   EXPECT_EQ(3, cov6.rows());
   EXPECT_EQ(3, cov6.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-          sigma * sigma * (1.0 +
-                           (pow(3.0, 0.5) / l) * stan::math::squared_distance(
-                                                     x1_vec[i], x1_rvec[j])) *
-              std::exp(-1.0 * (pow(3.0, 0.5) / l) *
-                       stan::math::squared_distance(x1_vec[i], x1_rvec[j])),
+          sigma * sigma
+              * (1.0
+                 + (pow(3.0, 0.5) / l)
+                       * stan::math::squared_distance(x1_vec[i], x1_rvec[j]))
+              * std::exp(-1.0 * (pow(3.0, 0.5) / l)
+                         * stan::math::squared_distance(x1_vec[i], x1_rvec[j])),
           cov6(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -748,8 +765,8 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_matern_3_2_cov2) {
     x2_vec[i] << 2 * i, 3 * i, 4 * i;
   }
   Eigen::MatrixXd cov;
-  EXPECT_NO_THROW(cov =
-                      stan::math::gp_matern_3_2_cov(x1_rvec, x2_vec, sigma, l));
+  EXPECT_NO_THROW(cov
+                  = stan::math::gp_matern_3_2_cov(x1_rvec, x2_vec, sigma, l));
   EXPECT_EQ(3, cov.rows());
   EXPECT_EQ(4, cov.cols());
   for (int i = 0; i < 3; i++) {
@@ -759,16 +776,16 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_matern_3_2_cov2) {
         temp += stan::math::squared_distance(x1_rvec[i], x2_vec[j]) / l[k];
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp)) *
-                          std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp))
+                          * std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
                       cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov7;
-  EXPECT_NO_THROW(cov7 =
-                      stan::math::gp_matern_3_2_cov(x2_vec, x1_rvec, sigma, l));
+  EXPECT_NO_THROW(cov7
+                  = stan::math::gp_matern_3_2_cov(x2_vec, x1_rvec, sigma, l));
   EXPECT_EQ(4, cov7.rows());
   EXPECT_EQ(3, cov7.cols());
   for (int i = 0; i < 3; i++) {
@@ -778,16 +795,16 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_matern_3_2_cov2) {
         temp += stan::math::squared_distance(x2_vec[i], x1_rvec[j]) / l[k];
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp)) *
-                          std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp))
+                          * std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
                       cov7(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov2;
-  EXPECT_NO_THROW(cov2 =
-                      stan::math::gp_matern_3_2_cov(x1_vec, x2_rvec, sigma, l));
+  EXPECT_NO_THROW(cov2
+                  = stan::math::gp_matern_3_2_cov(x1_vec, x2_rvec, sigma, l));
   EXPECT_EQ(3, cov2.rows());
   EXPECT_EQ(4, cov2.cols());
   for (int i = 0; i < 3; i++) {
@@ -797,16 +814,16 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_matern_3_2_cov2) {
         temp += stan::math::squared_distance(x1_vec[i], x2_rvec[j]) / l[k];
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp)) *
-                          std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp))
+                          * std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
                       cov2(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov8;
-  EXPECT_NO_THROW(cov8 =
-                      stan::math::gp_matern_3_2_cov(x2_rvec, x1_vec, sigma, l));
+  EXPECT_NO_THROW(cov8
+                  = stan::math::gp_matern_3_2_cov(x2_rvec, x1_vec, sigma, l));
   EXPECT_EQ(4, cov8.rows());
   EXPECT_EQ(3, cov8.cols());
   for (int i = 0; i < 3; i++) {
@@ -816,16 +833,16 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_matern_3_2_cov2) {
         temp += stan::math::squared_distance(x2_rvec[i], x1_vec[j]) / l[k];
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp)) *
-                          std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp))
+                          * std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
                       cov8(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov3;
-  EXPECT_NO_THROW(cov3 =
-                      stan::math::gp_matern_3_2_cov(x2_vec, x2_rvec, sigma, l));
+  EXPECT_NO_THROW(cov3
+                  = stan::math::gp_matern_3_2_cov(x2_vec, x2_rvec, sigma, l));
   EXPECT_EQ(4, cov3.rows());
   EXPECT_EQ(4, cov3.cols());
   for (int i = 0; i < 3; i++) {
@@ -835,16 +852,16 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_matern_3_2_cov2) {
         temp += stan::math::squared_distance(x2_vec[i], x2_rvec[j]) / l[k];
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp)) *
-                          std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp))
+                          * std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
                       cov3(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov4;
-  EXPECT_NO_THROW(cov4 =
-                      stan::math::gp_matern_3_2_cov(x2_rvec, x2_vec, sigma, l));
+  EXPECT_NO_THROW(cov4
+                  = stan::math::gp_matern_3_2_cov(x2_rvec, x2_vec, sigma, l));
   EXPECT_EQ(4, cov4.rows());
   EXPECT_EQ(4, cov4.cols());
   for (int i = 0; i < 3; i++) {
@@ -854,16 +871,16 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_matern_3_2_cov2) {
         temp += stan::math::squared_distance(x2_rvec[i], x2_vec[j]) / l[k];
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp)) *
-                          std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp))
+                          * std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
                       cov4(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov5;
-  EXPECT_NO_THROW(cov5 =
-                      stan::math::gp_matern_3_2_cov(x1_rvec, x1_vec, sigma, l));
+  EXPECT_NO_THROW(cov5
+                  = stan::math::gp_matern_3_2_cov(x1_rvec, x1_vec, sigma, l));
   EXPECT_EQ(3, cov5.rows());
   EXPECT_EQ(3, cov5.cols());
   for (int i = 0; i < 3; i++) {
@@ -873,16 +890,16 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_matern_3_2_cov2) {
         temp += stan::math::squared_distance(x1_rvec[i], x1_vec[j]) / l[k];
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp)) *
-                          std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp))
+                          * std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
                       cov5(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov6;
-  EXPECT_NO_THROW(cov6 =
-                      stan::math::gp_matern_3_2_cov(x1_vec, x1_rvec, sigma, l));
+  EXPECT_NO_THROW(cov6
+                  = stan::math::gp_matern_3_2_cov(x1_vec, x1_rvec, sigma, l));
   EXPECT_EQ(3, cov6.rows());
   EXPECT_EQ(3, cov6.cols());
   for (int i = 0; i < 3; i++) {
@@ -892,8 +909,8 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_matern_3_2_cov2) {
         temp += stan::math::squared_distance(x1_vec[i], x1_rvec[j]) / l[k];
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp)) *
-                          std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp))
+                          * std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
                       cov6(i, j))
           << "index: (" << i << ", " << j << ")";
     }

--- a/test/unit/math/prim/mat/fun/gp_matern_3_2_cov_test.cpp
+++ b/test/unit/math/prim/mat/fun/gp_matern_3_2_cov_test.cpp
@@ -1,11 +1,9 @@
 #include <gtest/gtest.h>
-#include <limits>
 #include <stan/math/prim/mat.hpp>
+#include <cmath>
+#include <limits>
 #include <string>
 #include <vector>
-
-// temp:
-#include <cmath>
 
 template <typename T_x, typename T_l, typename T_s, typename T_g>
 std::string pull_msg(std::vector<T_x> x, T_l l, T_s sigma, T_g gamma) {
@@ -49,13 +47,13 @@ TEST(MathPrimMat, vec_double_gp_matern_3_2_cov1) {
   cov = stan::math::gp_matern_3_2_cov(x, l, sigma, gamma);
   for (int i = 0; i < 3; i++)
     for (int j = 0; j < 3; j++)
-      EXPECT_FLOAT_EQ(
-          sigma * sigma *
-          (1.0 + (pow(3.0, 0.5) / l) * gamma *
-           stan::math::squared_distance(x[i], x[j])) *
-          std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l) *
-                   stan::math::squared_distance(x[i], x[j])),
-          cov(i, j))
+      EXPECT_FLOAT_EQ(sigma * sigma *
+                          (1.0 +
+                           (pow(3.0, 0.5) / l) * gamma *
+                               stan::math::squared_distance(x[i], x[j])) *
+                          std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l) *
+                                   stan::math::squared_distance(x[i], x[j])),
+                      cov(i, j))
           << "index: (" << i << ", " << j << ")";
 }
 
@@ -84,10 +82,11 @@ TEST(MathPrimMat, vec_double_ard_gp_matern_3_2_cov1) {
       for (int k = 0; k < 5; k++) {
         temp += stan::math::squared_distance(x[i], x[j]) / l[k];
       }
-      
-      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + gamma * pow(3.0, 0.5) * sqrt(temp))
-                      * std::exp(-1.0 * gamma * pow(3.0, 0.5) * sqrt(temp))
-                      , cov(i, j))
+
+      EXPECT_FLOAT_EQ(sigma * sigma *
+                          (1.0 + gamma * pow(3.0, 0.5) * sqrt(temp)) *
+                          std::exp(-1.0 * gamma * pow(3.0, 0.5) * sqrt(temp)),
+                      cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -108,13 +107,13 @@ TEST(MathPrimMat, vec_eigen_gp_matern_3_2_cov1) {
   cov = stan::math::gp_matern_3_2_cov(x1, l, sigma, gamma);
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
-      EXPECT_FLOAT_EQ(
-                      sigma * sigma * (1.0 + (pow(3.0, 0.5) / l) * gamma *
-                                       stan::math::squared_distance(x1[i],
-                                                                    x1[j])) *
-              std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l) *
-                       stan::math::squared_distance(x1[i], x1[j])),
-          cov(i, j))
+      EXPECT_FLOAT_EQ(sigma * sigma *
+                          (1.0 +
+                           (pow(3.0, 0.5) / l) * gamma *
+                               stan::math::squared_distance(x1[i], x1[j])) *
+                          std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l) *
+                                   stan::math::squared_distance(x1[i], x1[j])),
+                      cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -136,18 +135,18 @@ TEST(MathPrimMat, vec_eigen_eigen_gp_matern_3_2_cov1) {
     x2[i].resize(1, 3);
     x2[i] << 2 * i, 3 * i, 4 * i;
   }
-  
+
   Eigen::MatrixXd cov;
   cov = stan::math::gp_matern_3_2_cov(x1, x2, l, sigma, gamma);
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
-      EXPECT_FLOAT_EQ(
-                      sigma * sigma * (1.0 + (pow(3.0, 0.5) / l) * gamma *
-                                       stan::math::squared_distance(x1[i],
-                                                                    x2[j])) *
-              std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l) *
-                       stan::math::squared_distance(x1[i], x2[j])),
-          cov(i, j))
+      EXPECT_FLOAT_EQ(sigma * sigma *
+                          (1.0 +
+                           (pow(3.0, 0.5) / l) * gamma *
+                               stan::math::squared_distance(x1[i], x2[j])) *
+                          std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l) *
+                                   stan::math::squared_distance(x1[i], x2[j])),
+                      cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -167,18 +166,18 @@ TEST(MathPrimMat, vec_double_double_gp_matern_3_2_cov1) {
   x2[0] = 3;
   x2[1] = -4;
   x2[2] = -0.7;
-  
+
   Eigen::MatrixXd cov;
   cov = stan::math::gp_matern_3_2_cov(x1, x2, l, sigma, gamma);
   for (int i = 0; i < 3; i++)
     for (int j = 0; j < 3; j++)
-      EXPECT_FLOAT_EQ(
-          sigma * sigma *
-          (1.0 + (pow(3.0, 0.5) / l) * gamma *
-           stan::math::squared_distance(x1[i], x2[j])) *
-          std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l) *
-                   stan::math::squared_distance(x1[i], x2[j])),
-          cov(i, j))
+      EXPECT_FLOAT_EQ(sigma * sigma *
+                          (1.0 +
+                           (pow(3.0, 0.5) / l) * gamma *
+                               stan::math::squared_distance(x1[i], x2[j])) *
+                          std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l) *
+                                   stan::math::squared_distance(x1[i], x2[j])),
+                      cov(i, j))
           << "index: (" << i << ", " << j << ")";
 }
 
@@ -186,7 +185,7 @@ TEST(MathPrimMat, vec_eigen_ard_gp_matern_3_2_cov1) {
   double sigma = 0.3;
   double gamma = 0.5;
   double temp;
-  
+
   std::vector<Eigen::Matrix<double, 1, -1>> x1(3);
   for (size_t i = 0; i < x1.size(); ++i) {
     x1[i].resize(1, 3);
@@ -199,7 +198,7 @@ TEST(MathPrimMat, vec_eigen_ard_gp_matern_3_2_cov1) {
   l[2] = 0.3;
   l[3] = 0.4;
   l[4] = 0.5;
-  
+
   Eigen::MatrixXd cov;
   cov = stan::math::gp_matern_3_2_cov(x1, l, sigma, gamma);
   for (int i = 0; i < 3; i++) {
@@ -208,10 +207,11 @@ TEST(MathPrimMat, vec_eigen_ard_gp_matern_3_2_cov1) {
       for (int k = 0; k < 5; k++) {
         temp += stan::math::squared_distance(x1[i], x1[j]) / l[k];
       }
-      
-      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + gamma * pow(3.0, 0.5) * sqrt(temp))
-                      * std::exp(-1.0 * gamma * pow(3.0, 0.5) * sqrt(temp))
-                      , cov(i, j))
+
+      EXPECT_FLOAT_EQ(sigma * sigma *
+                          (1.0 + gamma * pow(3.0, 0.5) * sqrt(temp)) *
+                          std::exp(-1.0 * gamma * pow(3.0, 0.5) * sqrt(temp)),
+                      cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -221,7 +221,7 @@ TEST(MathPrimMat, vec_double_double_ard_gp_matern_3_2_cov1) {
   double sigma = 0.2;
   double gamma = 1.2;
   double temp;
-  
+
   std::vector<double> x1(3);
   x1[0] = -2;
   x1[1] = -1;
@@ -237,7 +237,7 @@ TEST(MathPrimMat, vec_double_double_ard_gp_matern_3_2_cov1) {
   l[1] = 2;
   l[2] = 3;
   l[3] = 4;
-  
+
   Eigen::MatrixXd cov;
   cov = stan::math::gp_matern_3_2_cov(x1, x2, l, sigma, gamma);
   for (int i = 0; i < 3; i++) {
@@ -246,9 +246,10 @@ TEST(MathPrimMat, vec_double_double_ard_gp_matern_3_2_cov1) {
       for (int k = 0; k < 4; k++) {
         temp += stan::math::squared_distance(x1[i], x2[j]) / l[k];
       }
-      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + gamma * pow(3.0, 0.5) * pow(temp, 0.5))
-                      * std::exp(-1.0 * gamma * pow(3.0, 0.5) * pow(temp, 0.5))
-                      , cov(i, j))
+      EXPECT_FLOAT_EQ(
+          sigma * sigma * (1.0 + gamma * pow(3.0, 0.5) * pow(temp, 0.5)) *
+              std::exp(-1.0 * gamma * pow(3.0, 0.5) * pow(temp, 0.5)),
+          cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -258,7 +259,7 @@ TEST(MathPrimMat, vec_eigen_eigen_ard_gp_matern_3_2_cov1) {
   double sigma = 0.2;
   double gamma = 1.2;
   double temp;
-  
+
   std::vector<Eigen::Matrix<double, 1, -1>> x1(3);
   for (size_t i = 0; i < x1.size(); ++i) {
     x1[i].resize(1, 3);
@@ -276,7 +277,7 @@ TEST(MathPrimMat, vec_eigen_eigen_ard_gp_matern_3_2_cov1) {
   l[1] = 2;
   l[2] = 3;
   l[3] = 4;
-  
+
   Eigen::MatrixXd cov;
   cov = stan::math::gp_matern_3_2_cov(x1, x2, l, sigma, gamma);
   for (int i = 0; i < 3; i++) {
@@ -285,9 +286,10 @@ TEST(MathPrimMat, vec_eigen_eigen_ard_gp_matern_3_2_cov1) {
       for (int k = 0; k < 4; k++) {
         temp += stan::math::squared_distance(x1[i], x2[j]) / l[k];
       }
-      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + gamma * pow(3.0, 0.5) * pow(temp, 0.5))
-                      * std::exp(-1.0 * gamma * pow(3.0, 0.5) * pow(temp, 0.5))
-                      , cov(i, j))
+      EXPECT_FLOAT_EQ(
+          sigma * sigma * (1.0 + gamma * pow(3.0, 0.5) * pow(temp, 0.5)) *
+              std::exp(-1.0 * gamma * pow(3.0, 0.5) * pow(temp, 0.5)),
+          cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -308,13 +310,13 @@ TEST(MathPrimMat, rvec_eigen_gp_matern_3_2_cov1) {
   cov = stan::math::gp_matern_3_2_cov(x1, l, sigma, gamma);
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
-      EXPECT_FLOAT_EQ(
-                      sigma * sigma * (1.0 + (pow(3.0, 0.5) / l) * gamma *
-                                       stan::math::squared_distance(x1[i],
-                                                                    x1[j])) *
-              std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l) *
-                       stan::math::squared_distance(x1[i], x1[j])),
-          cov(i, j))
+      EXPECT_FLOAT_EQ(sigma * sigma *
+                          (1.0 +
+                           (pow(3.0, 0.5) / l) * gamma *
+                               stan::math::squared_distance(x1[i], x1[j])) *
+                          std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l) *
+                                   stan::math::squared_distance(x1[i], x1[j])),
+                      cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -336,7 +338,7 @@ TEST(MathPrimMat, rvec_eigen_ard_gp_matern_3_2_cov1) {
   l[1] = 2;
   l[2] = 3;
   l[3] = 4;
-  
+
   Eigen::MatrixXd cov;
   cov = stan::math::gp_matern_3_2_cov(x1, l, sigma, gamma);
   for (int i = 0; i < 3; i++) {
@@ -345,10 +347,11 @@ TEST(MathPrimMat, rvec_eigen_ard_gp_matern_3_2_cov1) {
       for (int k = 0; k < 4; k++) {
         temp += stan::math::squared_distance(x1[i], x1[j]) / l[k];
       }
-      
-      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + gamma * pow(3.0, 0.5) * sqrt(temp))
-                      * std::exp(-1.0 * gamma * pow(3.0, 0.5) * sqrt(temp))
-                      , cov(i, j))
+
+      EXPECT_FLOAT_EQ(sigma * sigma *
+                          (1.0 + gamma * pow(3.0, 0.5) * sqrt(temp)) *
+                          std::exp(-1.0 * gamma * pow(3.0, 0.5) * sqrt(temp)),
+                      cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -358,7 +361,7 @@ TEST(MathPrimMat, vec_eigen_rvec_eigen_gp_matern_3_2_cov1) {
   double sigma = 0.3;
   double gamma = 0.5;
   double l = 2.3;
-  
+
   std::vector<Eigen::Matrix<double, -1, 1>> x1(3);
   for (size_t i = 0; i < x1.size(); ++i) {
     x1[i].resize(3, 1);
@@ -372,30 +375,30 @@ TEST(MathPrimMat, vec_eigen_rvec_eigen_gp_matern_3_2_cov1) {
   }
 
   Eigen::MatrixXd cov;
-  cov = stan::math::gp_matern_3_2_cov(x1, x2, l, sigma, gamma); 
+  cov = stan::math::gp_matern_3_2_cov(x1, x2, l, sigma, gamma);
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
-      EXPECT_FLOAT_EQ(
-                      sigma * sigma * (1.0 + (pow(3.0, 0.5) / l) * gamma *
-                                       stan::math::squared_distance(x1[i],
-                                                                    x2[j])) *
-              std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l) *
-                       stan::math::squared_distance(x1[i], x2[j])),
-          cov(i, j))
+      EXPECT_FLOAT_EQ(sigma * sigma *
+                          (1.0 +
+                           (pow(3.0, 0.5) / l) * gamma *
+                               stan::math::squared_distance(x1[i], x2[j])) *
+                          std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l) *
+                                   stan::math::squared_distance(x1[i], x2[j])),
+                      cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
-  cov = stan::math::gp_matern_3_2_cov(x2, x1, l, sigma, gamma); 
+  cov = stan::math::gp_matern_3_2_cov(x2, x1, l, sigma, gamma);
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
-      EXPECT_FLOAT_EQ(
-                      sigma * sigma * (1.0 + (pow(3.0, 0.5) / l) * gamma *
-                                       stan::math::squared_distance(x2[i],
-                                                                    x1[j])) *
-              std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l) *
-                       stan::math::squared_distance(x2[i], x1[j])),
-          cov(i, j))
+      EXPECT_FLOAT_EQ(sigma * sigma *
+                          (1.0 +
+                           (pow(3.0, 0.5) / l) * gamma *
+                               stan::math::squared_distance(x2[i], x1[j])) *
+                          std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l) *
+                                   stan::math::squared_distance(x2[i], x1[j])),
+                      cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -409,7 +412,7 @@ TEST(MathPrimMat, vec_eigen_rvec_eigen_ard_gp_matern_3_2_cov1) {
   l[0] = 1;
   l[1] = 2;
   l[2] = 3;
-  
+
   std::vector<Eigen::Matrix<double, -1, 1>> x1(3);
   for (size_t i = 0; i < x1.size(); ++i) {
     x1[i].resize(3, 1);
@@ -423,31 +426,33 @@ TEST(MathPrimMat, vec_eigen_rvec_eigen_ard_gp_matern_3_2_cov1) {
   }
 
   Eigen::MatrixXd cov;
-  cov = stan::math::gp_matern_3_2_cov(x1, x2, l, sigma, gamma); 
+  cov = stan::math::gp_matern_3_2_cov(x1, x2, l, sigma, gamma);
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       temp = 0;
       for (int k = 0; k < 3; k++) {
         temp += stan::math::squared_distance(x1[i], x2[j]) / l[k];
       }
-      
-      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + gamma * pow(3.0, 0.5) * sqrt(temp))
-                      * std::exp(-1.0 * gamma * pow(3.0, 0.5) * sqrt(temp))
-                      , cov(i, j))
+
+      EXPECT_FLOAT_EQ(sigma * sigma *
+                          (1.0 + gamma * pow(3.0, 0.5) * sqrt(temp)) *
+                          std::exp(-1.0 * gamma * pow(3.0, 0.5) * sqrt(temp)),
+                      cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
-  cov = stan::math::gp_matern_3_2_cov(x2, x1, l, sigma, gamma); 
+  cov = stan::math::gp_matern_3_2_cov(x2, x1, l, sigma, gamma);
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       temp = 0;
       for (int k = 0; k < 3; k++) {
         temp += stan::math::squared_distance(x2[i], x1[j]) / l[k];
       }
-      
-      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + gamma * pow(3.0, 0.5) * sqrt(temp))
-                      * std::exp(-1.0 * gamma * pow(3.0, 0.5) * sqrt(temp))
-                      , cov(i, j))
+
+      EXPECT_FLOAT_EQ(sigma * sigma *
+                          (1.0 + gamma * pow(3.0, 0.5) * sqrt(temp)) *
+                          std::exp(-1.0 * gamma * pow(3.0, 0.5) * sqrt(temp)),
+                      cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -457,7 +462,7 @@ TEST(MathPrimMat, rvec_eigen_rvec_eigen_gp_matern_3_2_cov1) {
   double sigma = 0.3;
   double gamma = 0.5;
   double l = 2.3;
-  
+
   std::vector<Eigen::Matrix<double, -1, 1>> x1(3);
   for (size_t i = 0; i < x1.size(); ++i) {
     x1[i].resize(3, 1);
@@ -471,30 +476,30 @@ TEST(MathPrimMat, rvec_eigen_rvec_eigen_gp_matern_3_2_cov1) {
   }
 
   Eigen::MatrixXd cov;
-  cov = stan::math::gp_matern_3_2_cov(x1, x2, l, sigma, gamma); 
+  cov = stan::math::gp_matern_3_2_cov(x1, x2, l, sigma, gamma);
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
-      EXPECT_FLOAT_EQ(
-                      sigma * sigma * (1.0 + (pow(3.0, 0.5) / l) * gamma *
-                                       stan::math::squared_distance(x1[i],
-                                                                    x2[j])) *
-              std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l) *
-                       stan::math::squared_distance(x1[i], x2[j])),
-          cov(i, j))
+      EXPECT_FLOAT_EQ(sigma * sigma *
+                          (1.0 +
+                           (pow(3.0, 0.5) / l) * gamma *
+                               stan::math::squared_distance(x1[i], x2[j])) *
+                          std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l) *
+                                   stan::math::squared_distance(x1[i], x2[j])),
+                      cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
-  cov = stan::math::gp_matern_3_2_cov(x2, x1, l, sigma, gamma); 
+  cov = stan::math::gp_matern_3_2_cov(x2, x1, l, sigma, gamma);
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
-      EXPECT_FLOAT_EQ(
-                      sigma * sigma * (1.0 + (pow(3.0, 0.5) / l) * gamma *
-                                       stan::math::squared_distance(x2[i],
-                                                                    x1[j])) *
-              std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l) *
-                       stan::math::squared_distance(x2[i], x1[j])),
-          cov(i, j))
+      EXPECT_FLOAT_EQ(sigma * sigma *
+                          (1.0 +
+                           (pow(3.0, 0.5) / l) * gamma *
+                               stan::math::squared_distance(x2[i], x1[j])) *
+                          std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l) *
+                                   stan::math::squared_distance(x2[i], x1[j])),
+                      cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -509,7 +514,7 @@ TEST(MathPrimMat, rvec_eigen_rvec_eigen_ard_gp_matern_3_2_cov1) {
   l[0] = 1;
   l[1] = 2;
   l[2] = 3;
-  
+
   std::vector<Eigen::Matrix<double, -1, 1>> x1(3);
   for (size_t i = 0; i < x1.size(); ++i) {
     x1[i].resize(3, 1);
@@ -523,31 +528,33 @@ TEST(MathPrimMat, rvec_eigen_rvec_eigen_ard_gp_matern_3_2_cov1) {
   }
 
   Eigen::MatrixXd cov;
-  cov = stan::math::gp_matern_3_2_cov(x1, x2, l, sigma, gamma); 
+  cov = stan::math::gp_matern_3_2_cov(x1, x2, l, sigma, gamma);
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       temp = 0;
       for (int k = 0; k < 3; k++) {
         temp += stan::math::squared_distance(x1[i], x2[j]) / l[k];
       }
-      
-      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + gamma * pow(3.0, 0.5) * sqrt(temp))
-                      * std::exp(-1.0 * gamma * pow(3.0, 0.5) * sqrt(temp))
-                      , cov(i, j))
+
+      EXPECT_FLOAT_EQ(sigma * sigma *
+                          (1.0 + gamma * pow(3.0, 0.5) * sqrt(temp)) *
+                          std::exp(-1.0 * gamma * pow(3.0, 0.5) * sqrt(temp)),
+                      cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
-  cov = stan::math::gp_matern_3_2_cov(x2, x1, l, sigma, gamma); 
+  cov = stan::math::gp_matern_3_2_cov(x2, x1, l, sigma, gamma);
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       temp = 0;
       for (int k = 0; k < 3; k++) {
         temp += stan::math::squared_distance(x2[i], x1[j]) / l[k];
       }
-      
-      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + gamma * pow(3.0, 0.5) * sqrt(temp))
-                      * std::exp(-1.0 * gamma * pow(3.0, 0.5) * sqrt(temp))
-                      , cov(i, j))
+
+      EXPECT_FLOAT_EQ(sigma * sigma *
+                          (1.0 + gamma * pow(3.0, 0.5) * sqrt(temp)) *
+                          std::exp(-1.0 * gamma * pow(3.0, 0.5) * sqrt(temp)),
+                      cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -559,8 +566,8 @@ TEST(MathPrimMat, vec_eigen_mixed_gp_matern_3_2_cov2) {
   double gamma = 0.5;
   double l = 5;
 
-  std::vector<Eigen::Matrix<double, 1, -1> > x1_rvec(3);
-  std::vector<Eigen::Matrix<double, 1, -1> > x2_rvec(4);
+  std::vector<Eigen::Matrix<double, 1, -1>> x1_rvec(3);
+  std::vector<Eigen::Matrix<double, 1, -1>> x2_rvec(4);
 
   for (size_t i = 0; i < x1_rvec.size(); ++i) {
     x1_rvec[i].resize(1, 3);
@@ -572,8 +579,8 @@ TEST(MathPrimMat, vec_eigen_mixed_gp_matern_3_2_cov2) {
     x2_rvec[i] << 2 * i, 3 * i, 4 * i;
   }
 
-  std::vector<Eigen::Matrix<double, -1, 1> > x1_vec(3);
-  std::vector<Eigen::Matrix<double, -1, 1> > x2_vec(4);
+  std::vector<Eigen::Matrix<double, -1, 1>> x1_vec(3);
+  std::vector<Eigen::Matrix<double, -1, 1>> x2_vec(4);
 
   for (size_t i = 0; i < x1_vec.size(); ++i) {
     x1_vec[i].resize(3, 1);
@@ -585,16 +592,17 @@ TEST(MathPrimMat, vec_eigen_mixed_gp_matern_3_2_cov2) {
     x2_vec[i] << 2 * i, 3 * i, 4 * i;
   }
   Eigen::MatrixXd cov;
-  EXPECT_NO_THROW(cov = stan::math::gp_matern_3_2_cov(x1_rvec, x2_vec, l, sigma,
-                                                      gamma));
+  EXPECT_NO_THROW(
+      cov = stan::math::gp_matern_3_2_cov(x1_rvec, x2_vec, l, sigma, gamma));
   EXPECT_EQ(3, cov.rows());
   EXPECT_EQ(4, cov.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-                      sigma * sigma * (1.0 + (pow(3.0, 0.5) / l) * gamma *
-                                       stan::math::squared_distance(x1_rvec[i],
-                                                                    x2_vec[j])) *
+          sigma * sigma *
+              (1.0 +
+               (pow(3.0, 0.5) / l) * gamma *
+                   stan::math::squared_distance(x1_rvec[i], x2_vec[j])) *
               std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l) *
                        stan::math::squared_distance(x1_rvec[i], x2_vec[j])),
           cov(i, j))
@@ -603,16 +611,17 @@ TEST(MathPrimMat, vec_eigen_mixed_gp_matern_3_2_cov2) {
   }
 
   Eigen::MatrixXd cov7;
-  EXPECT_NO_THROW(cov7 = stan::math::gp_matern_3_2_cov(x2_vec, x1_rvec, l,
-                                                       sigma, gamma));
+  EXPECT_NO_THROW(
+      cov7 = stan::math::gp_matern_3_2_cov(x2_vec, x1_rvec, l, sigma, gamma));
   EXPECT_EQ(4, cov7.rows());
   EXPECT_EQ(3, cov7.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-                      sigma * sigma * (1.0 + (pow(3.0, 0.5) / l) * gamma *
-                                       stan::math::squared_distance(x2_vec[i],
-                                                                    x1_rvec[j])) *
+          sigma * sigma *
+              (1.0 +
+               (pow(3.0, 0.5) / l) * gamma *
+                   stan::math::squared_distance(x2_vec[i], x1_rvec[j])) *
               std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l) *
                        stan::math::squared_distance(x2_vec[i], x1_rvec[j])),
           cov7(i, j))
@@ -620,16 +629,17 @@ TEST(MathPrimMat, vec_eigen_mixed_gp_matern_3_2_cov2) {
     }
   }
   Eigen::MatrixXd cov2;
-  EXPECT_NO_THROW(cov2 = stan::math::gp_matern_3_2_cov(x1_vec, x2_rvec, l,
-                                                       sigma, gamma));
+  EXPECT_NO_THROW(
+      cov2 = stan::math::gp_matern_3_2_cov(x1_vec, x2_rvec, l, sigma, gamma));
   EXPECT_EQ(3, cov2.rows());
   EXPECT_EQ(4, cov2.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-                      sigma * sigma * (1.0 + (pow(3.0, 0.5) / l) * gamma *
-                                       stan::math::squared_distance(x1_vec[i],
-                                                                    x2_rvec[j])) *
+          sigma * sigma *
+              (1.0 +
+               (pow(3.0, 0.5) / l) * gamma *
+                   stan::math::squared_distance(x1_vec[i], x2_rvec[j])) *
               std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l) *
                        stan::math::squared_distance(x1_vec[i], x2_rvec[j])),
           cov2(i, j))
@@ -638,16 +648,17 @@ TEST(MathPrimMat, vec_eigen_mixed_gp_matern_3_2_cov2) {
   }
 
   Eigen::MatrixXd cov8;
-  EXPECT_NO_THROW(cov8 = stan::math::gp_matern_3_2_cov(x2_rvec, x1_vec, l,
-                                                       sigma, gamma));
+  EXPECT_NO_THROW(
+      cov8 = stan::math::gp_matern_3_2_cov(x2_rvec, x1_vec, l, sigma, gamma));
   EXPECT_EQ(4, cov8.rows());
   EXPECT_EQ(3, cov8.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-                      sigma * sigma * (1.0 + (pow(3.0, 0.5) / l) * gamma *
-                                       stan::math::squared_distance(x2_rvec[i],
-                                                                    x1_vec[j])) *
+          sigma * sigma *
+              (1.0 +
+               (pow(3.0, 0.5) / l) * gamma *
+                   stan::math::squared_distance(x2_rvec[i], x1_vec[j])) *
               std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l) *
                        stan::math::squared_distance(x2_rvec[i], x1_vec[j])),
           cov8(i, j))
@@ -656,16 +667,17 @@ TEST(MathPrimMat, vec_eigen_mixed_gp_matern_3_2_cov2) {
   }
 
   Eigen::MatrixXd cov3;
-  EXPECT_NO_THROW(cov3 = stan::math::gp_matern_3_2_cov(x2_vec, x2_rvec, l,
-                                                       sigma, gamma));
+  EXPECT_NO_THROW(
+      cov3 = stan::math::gp_matern_3_2_cov(x2_vec, x2_rvec, l, sigma, gamma));
   EXPECT_EQ(4, cov3.rows());
   EXPECT_EQ(4, cov3.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-                      sigma * sigma * (1.0 + (pow(3.0, 0.5) / l) * gamma *
-                                       stan::math::squared_distance(x2_vec[i],
-                                                                    x2_rvec[j])) *
+          sigma * sigma *
+              (1.0 +
+               (pow(3.0, 0.5) / l) * gamma *
+                   stan::math::squared_distance(x2_vec[i], x2_rvec[j])) *
               std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l) *
                        stan::math::squared_distance(x2_vec[i], x2_rvec[j])),
           cov3(i, j))
@@ -674,16 +686,17 @@ TEST(MathPrimMat, vec_eigen_mixed_gp_matern_3_2_cov2) {
   }
 
   Eigen::MatrixXd cov4;
-  EXPECT_NO_THROW(cov4 = stan::math::gp_matern_3_2_cov(x2_rvec, x2_vec, l,
-                                                       sigma, gamma));
+  EXPECT_NO_THROW(
+      cov4 = stan::math::gp_matern_3_2_cov(x2_rvec, x2_vec, l, sigma, gamma));
   EXPECT_EQ(4, cov4.rows());
   EXPECT_EQ(4, cov4.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-                      sigma * sigma * (1.0 + (pow(3.0, 0.5) / l) * gamma *
-                                       stan::math::squared_distance(x2_rvec[i],
-                                                                    x2_vec[j])) *
+          sigma * sigma *
+              (1.0 +
+               (pow(3.0, 0.5) / l) * gamma *
+                   stan::math::squared_distance(x2_rvec[i], x2_vec[j])) *
               std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l) *
                        stan::math::squared_distance(x2_rvec[i], x2_vec[j])),
           cov4(i, j))
@@ -692,16 +705,17 @@ TEST(MathPrimMat, vec_eigen_mixed_gp_matern_3_2_cov2) {
   }
 
   Eigen::MatrixXd cov5;
-  EXPECT_NO_THROW(cov5 = stan::math::gp_matern_3_2_cov(x1_rvec, x1_vec, l,
-                                                       sigma, gamma));
+  EXPECT_NO_THROW(
+      cov5 = stan::math::gp_matern_3_2_cov(x1_rvec, x1_vec, l, sigma, gamma));
   EXPECT_EQ(3, cov5.rows());
   EXPECT_EQ(3, cov5.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-                      sigma * sigma * (1.0 + (pow(3.0, 0.5) / l) * gamma *
-                                       stan::math::squared_distance(x1_rvec[i],
-                                                                    x1_vec[j])) *
+          sigma * sigma *
+              (1.0 +
+               (pow(3.0, 0.5) / l) * gamma *
+                   stan::math::squared_distance(x1_rvec[i], x1_vec[j])) *
               std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l) *
                        stan::math::squared_distance(x1_rvec[i], x1_vec[j])),
           cov5(i, j))
@@ -710,17 +724,17 @@ TEST(MathPrimMat, vec_eigen_mixed_gp_matern_3_2_cov2) {
   }
 
   Eigen::MatrixXd cov6;
-  EXPECT_NO_THROW(cov6 = stan::math::gp_matern_3_2_cov(x1_vec, x1_rvec, l,
-                                                       sigma, gamma));
+  EXPECT_NO_THROW(
+      cov6 = stan::math::gp_matern_3_2_cov(x1_vec, x1_rvec, l, sigma, gamma));
   EXPECT_EQ(3, cov6.rows());
   EXPECT_EQ(3, cov6.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-                      sigma * sigma * (1.0 + (pow(3.0, 0.5) / l) * gamma *
-                                       stan::math::squared_distance(x1_vec[i],
-                                                                    x1_rvec[j]))
-                      *
+          sigma * sigma *
+              (1.0 +
+               (pow(3.0, 0.5) / l) * gamma *
+                   stan::math::squared_distance(x1_vec[i], x1_rvec[j])) *
               std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l) *
                        stan::math::squared_distance(x1_vec[i], x1_rvec[j])),
           cov6(i, j))
@@ -739,10 +753,9 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_matern_3_2_cov2) {
   l[0] = 1;
   l[1] = 2;
   l[2] = 3;
-  
 
-  std::vector<Eigen::Matrix<double, 1, -1> > x1_rvec(3);
-  std::vector<Eigen::Matrix<double, 1, -1> > x2_rvec(4);
+  std::vector<Eigen::Matrix<double, 1, -1>> x1_rvec(3);
+  std::vector<Eigen::Matrix<double, 1, -1>> x2_rvec(4);
 
   for (size_t i = 0; i < x1_rvec.size(); ++i) {
     x1_rvec[i].resize(1, 3);
@@ -754,8 +767,8 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_matern_3_2_cov2) {
     x2_rvec[i] << 2 * i, 3 * i, 4 * i;
   }
 
-  std::vector<Eigen::Matrix<double, -1, 1> > x1_vec(3);
-  std::vector<Eigen::Matrix<double, -1, 1> > x2_vec(4);
+  std::vector<Eigen::Matrix<double, -1, 1>> x1_vec(3);
+  std::vector<Eigen::Matrix<double, -1, 1>> x2_vec(4);
 
   for (size_t i = 0; i < x1_vec.size(); ++i) {
     x1_vec[i].resize(3, 1);
@@ -767,8 +780,8 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_matern_3_2_cov2) {
     x2_vec[i] << 2 * i, 3 * i, 4 * i;
   }
   Eigen::MatrixXd cov;
-  EXPECT_NO_THROW(cov = stan::math::gp_matern_3_2_cov(x1_rvec, x2_vec, l, sigma,
-                                                      gamma));
+  EXPECT_NO_THROW(
+      cov = stan::math::gp_matern_3_2_cov(x1_rvec, x2_vec, l, sigma, gamma));
   EXPECT_EQ(3, cov.rows());
   EXPECT_EQ(4, cov.cols());
   for (int i = 0; i < 3; i++) {
@@ -777,18 +790,18 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_matern_3_2_cov2) {
       for (int k = 0; k < 3; k++) {
         temp += stan::math::squared_distance(x1_rvec[i], x2_vec[j]) / l[k];
       }
-      
-      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + gamma * pow(3.0, 0.5) * sqrt(temp))
-                      * std::exp(-1.0 * gamma * pow(3.0, 0.5) * sqrt(temp))
-                      , cov(i, j))
-          << "index: (" << i << ", " << j << ")";
 
+      EXPECT_FLOAT_EQ(sigma * sigma *
+                          (1.0 + gamma * pow(3.0, 0.5) * sqrt(temp)) *
+                          std::exp(-1.0 * gamma * pow(3.0, 0.5) * sqrt(temp)),
+                      cov(i, j))
+          << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov7;
-  EXPECT_NO_THROW(cov7 = stan::math::gp_matern_3_2_cov(x2_vec, x1_rvec, l,
-                                                       sigma, gamma));
+  EXPECT_NO_THROW(
+      cov7 = stan::math::gp_matern_3_2_cov(x2_vec, x1_rvec, l, sigma, gamma));
   EXPECT_EQ(4, cov7.rows());
   EXPECT_EQ(3, cov7.cols());
   for (int i = 0; i < 3; i++) {
@@ -797,17 +810,18 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_matern_3_2_cov2) {
       for (int k = 0; k < 3; k++) {
         temp += stan::math::squared_distance(x2_vec[i], x1_rvec[j]) / l[k];
       }
-      
-      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + gamma * pow(3.0, 0.5) * sqrt(temp))
-                      * std::exp(-1.0 * gamma * pow(3.0, 0.5) * sqrt(temp))
-                      , cov7(i, j))
+
+      EXPECT_FLOAT_EQ(sigma * sigma *
+                          (1.0 + gamma * pow(3.0, 0.5) * sqrt(temp)) *
+                          std::exp(-1.0 * gamma * pow(3.0, 0.5) * sqrt(temp)),
+                      cov7(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov2;
-  EXPECT_NO_THROW(cov2 = stan::math::gp_matern_3_2_cov(x1_vec, x2_rvec, l,
-                                                       sigma, gamma));
+  EXPECT_NO_THROW(
+      cov2 = stan::math::gp_matern_3_2_cov(x1_vec, x2_rvec, l, sigma, gamma));
   EXPECT_EQ(3, cov2.rows());
   EXPECT_EQ(4, cov2.cols());
   for (int i = 0; i < 3; i++) {
@@ -816,17 +830,18 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_matern_3_2_cov2) {
       for (int k = 0; k < 3; k++) {
         temp += stan::math::squared_distance(x1_vec[i], x2_rvec[j]) / l[k];
       }
-      
-      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + gamma * pow(3.0, 0.5) * sqrt(temp))
-                      * std::exp(-1.0 * gamma * pow(3.0, 0.5) * sqrt(temp))
-                      , cov2(i, j))
+
+      EXPECT_FLOAT_EQ(sigma * sigma *
+                          (1.0 + gamma * pow(3.0, 0.5) * sqrt(temp)) *
+                          std::exp(-1.0 * gamma * pow(3.0, 0.5) * sqrt(temp)),
+                      cov2(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov8;
-  EXPECT_NO_THROW(cov8 = stan::math::gp_matern_3_2_cov(x2_rvec, x1_vec, l,
-                                                       sigma, gamma));
+  EXPECT_NO_THROW(
+      cov8 = stan::math::gp_matern_3_2_cov(x2_rvec, x1_vec, l, sigma, gamma));
   EXPECT_EQ(4, cov8.rows());
   EXPECT_EQ(3, cov8.cols());
   for (int i = 0; i < 3; i++) {
@@ -835,17 +850,18 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_matern_3_2_cov2) {
       for (int k = 0; k < 3; k++) {
         temp += stan::math::squared_distance(x2_rvec[i], x1_vec[j]) / l[k];
       }
-      
-      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + gamma * pow(3.0, 0.5) * sqrt(temp))
-                      * std::exp(-1.0 * gamma * pow(3.0, 0.5) * sqrt(temp))
-                      , cov8(i, j))
+
+      EXPECT_FLOAT_EQ(sigma * sigma *
+                          (1.0 + gamma * pow(3.0, 0.5) * sqrt(temp)) *
+                          std::exp(-1.0 * gamma * pow(3.0, 0.5) * sqrt(temp)),
+                      cov8(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov3;
-  EXPECT_NO_THROW(cov3 = stan::math::gp_matern_3_2_cov(x2_vec, x2_rvec, l,
-                                                       sigma, gamma));
+  EXPECT_NO_THROW(
+      cov3 = stan::math::gp_matern_3_2_cov(x2_vec, x2_rvec, l, sigma, gamma));
   EXPECT_EQ(4, cov3.rows());
   EXPECT_EQ(4, cov3.cols());
   for (int i = 0; i < 3; i++) {
@@ -854,17 +870,18 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_matern_3_2_cov2) {
       for (int k = 0; k < 3; k++) {
         temp += stan::math::squared_distance(x2_vec[i], x2_rvec[j]) / l[k];
       }
-      
-      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + gamma * pow(3.0, 0.5) * sqrt(temp))
-                      * std::exp(-1.0 * gamma * pow(3.0, 0.5) * sqrt(temp))
-                      , cov3(i, j))
+
+      EXPECT_FLOAT_EQ(sigma * sigma *
+                          (1.0 + gamma * pow(3.0, 0.5) * sqrt(temp)) *
+                          std::exp(-1.0 * gamma * pow(3.0, 0.5) * sqrt(temp)),
+                      cov3(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov4;
-  EXPECT_NO_THROW(cov4 = stan::math::gp_matern_3_2_cov(x2_rvec, x2_vec, l,
-                                                       sigma, gamma));
+  EXPECT_NO_THROW(
+      cov4 = stan::math::gp_matern_3_2_cov(x2_rvec, x2_vec, l, sigma, gamma));
   EXPECT_EQ(4, cov4.rows());
   EXPECT_EQ(4, cov4.cols());
   for (int i = 0; i < 3; i++) {
@@ -873,17 +890,18 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_matern_3_2_cov2) {
       for (int k = 0; k < 3; k++) {
         temp += stan::math::squared_distance(x2_rvec[i], x2_vec[j]) / l[k];
       }
-      
-      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + gamma * pow(3.0, 0.5) * sqrt(temp))
-                      * std::exp(-1.0 * gamma * pow(3.0, 0.5) * sqrt(temp))
-                      , cov4(i, j))
+
+      EXPECT_FLOAT_EQ(sigma * sigma *
+                          (1.0 + gamma * pow(3.0, 0.5) * sqrt(temp)) *
+                          std::exp(-1.0 * gamma * pow(3.0, 0.5) * sqrt(temp)),
+                      cov4(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov5;
-  EXPECT_NO_THROW(cov5 = stan::math::gp_matern_3_2_cov(x1_rvec, x1_vec, l,
-                                                       sigma, gamma));
+  EXPECT_NO_THROW(
+      cov5 = stan::math::gp_matern_3_2_cov(x1_rvec, x1_vec, l, sigma, gamma));
   EXPECT_EQ(3, cov5.rows());
   EXPECT_EQ(3, cov5.cols());
   for (int i = 0; i < 3; i++) {
@@ -892,17 +910,18 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_matern_3_2_cov2) {
       for (int k = 0; k < 3; k++) {
         temp += stan::math::squared_distance(x1_rvec[i], x1_vec[j]) / l[k];
       }
-      
-      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + gamma * pow(3.0, 0.5) * sqrt(temp))
-                      * std::exp(-1.0 * gamma * pow(3.0, 0.5) * sqrt(temp))
-                      , cov5(i, j))
+
+      EXPECT_FLOAT_EQ(sigma * sigma *
+                          (1.0 + gamma * pow(3.0, 0.5) * sqrt(temp)) *
+                          std::exp(-1.0 * gamma * pow(3.0, 0.5) * sqrt(temp)),
+                      cov5(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov6;
-  EXPECT_NO_THROW(cov6 = stan::math::gp_matern_3_2_cov(x1_vec, x1_rvec, l,
-                                                       sigma, gamma));
+  EXPECT_NO_THROW(
+      cov6 = stan::math::gp_matern_3_2_cov(x1_vec, x1_rvec, l, sigma, gamma));
   EXPECT_EQ(3, cov6.rows());
   EXPECT_EQ(3, cov6.cols());
   for (int i = 0; i < 3; i++) {
@@ -911,17 +930,17 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_matern_3_2_cov2) {
       for (int k = 0; k < 3; k++) {
         temp += stan::math::squared_distance(x1_vec[i], x1_rvec[j]) / l[k];
       }
-      
-      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + gamma * pow(3.0, 0.5) * sqrt(temp))
-                      * std::exp(-1.0 * gamma * pow(3.0, 0.5) * sqrt(temp))
-                      , cov6(i, j))
+
+      EXPECT_FLOAT_EQ(sigma * sigma *
+                          (1.0 + gamma * pow(3.0, 0.5) * sqrt(temp)) *
+                          std::exp(-1.0 * gamma * pow(3.0, 0.5) * sqrt(temp)),
+                      cov6(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 }
 
 TEST(MathPrimMat, domain_err_training_sig_l_gamma) {
-
   double sigma = .2;
   double l = 7;
   double gamma = .8;
@@ -935,19 +954,19 @@ TEST(MathPrimMat, domain_err_training_sig_l_gamma) {
   std::vector<double> l_vec_bad(2);
   l_vec_bad[0] = 1;
   l_vec_bad[1] = -1;
-  
+
   std::vector<double> x(3);
   x[0] = -2;
   x[1] = -1;
   x[2] = -0.5;
 
-  std::vector<Eigen::Matrix<double, -1, 1> > x_2(3);
+  std::vector<Eigen::Matrix<double, -1, 1>> x_2(3);
   for (size_t i = 0; i < x_2.size(); ++i) {
     x_2[i].resize(3, 1);
     x_2[i] << 1, 2, 3;
   }
 
-  std::vector<Eigen::Matrix<double, 1, -1> > x_3(3);
+  std::vector<Eigen::Matrix<double, 1, -1>> x_3(3);
   for (size_t i = 0; i < x_3.size(); ++i) {
     x_3[i].resize(1, 3);
     x_3[i] << 1, 2, 3;
@@ -1029,10 +1048,8 @@ TEST(MathPrimMat, domain_err_training_sig_l_gamma) {
   msg3 = pull_msg(x_2, x_2, l_vec, sigma_bad, gamma);
   EXPECT_TRUE(std::string::npos != msg1.find(" length-scale")) << msg1;
   EXPECT_TRUE(std::string::npos != msg2.find(" length-scale")) << msg2;
-  EXPECT_TRUE(std::string::npos != msg3.find(" marginal variance")) << msg3; 
-  
+  EXPECT_TRUE(std::string::npos != msg3.find(" marginal variance")) << msg3;
 }
-
 
 TEST(MathPrimMat, nan_error_training_sig_l_gamma) {
   double sigma = 0.2;
@@ -1044,13 +1061,13 @@ TEST(MathPrimMat, nan_error_training_sig_l_gamma) {
   x[1] = -1;
   x[2] = -0.5;
 
-  std::vector<Eigen::Matrix<double, -1, 1> > x_2(3);
+  std::vector<Eigen::Matrix<double, -1, 1>> x_2(3);
   for (size_t i = 0; i < x_2.size(); ++i) {
     x_2[i].resize(3, 1);
     x_2[i] << 1, 2, 3;
   }
 
-  std::vector<Eigen::Matrix<double, 1, -1> > x_3(3);
+  std::vector<Eigen::Matrix<double, 1, -1>> x_3(3);
   for (size_t i = 0; i < x_3.size(); ++i) {
     x_3[i].resize(1, 3);
     x_3[i] << 1, 2, 3;
@@ -1063,20 +1080,20 @@ TEST(MathPrimMat, nan_error_training_sig_l_gamma) {
   std::vector<double> l_vec_bad(2);
   l_vec_bad[0] = 1;
   l_vec_bad[1] = -1;
-  
+
   std::vector<double> x_bad(x);
   x_bad[1] = std::numeric_limits<double>::quiet_NaN();
 
-  std::vector<Eigen::Matrix<double, -1, 1> > x_bad_2(x_2);
+  std::vector<Eigen::Matrix<double, -1, 1>> x_bad_2(x_2);
   x_bad_2[1](1) = std::numeric_limits<double>::quiet_NaN();
 
-  std::vector<Eigen::Matrix<double, 1, -1> > x_bad_3(x_3);
+  std::vector<Eigen::Matrix<double, 1, -1>> x_bad_3(x_3);
   x_bad_3[1](1) = std::numeric_limits<double>::quiet_NaN();
 
   double sigma_bad = std::numeric_limits<double>::quiet_NaN();
   double l_bad = std::numeric_limits<double>::quiet_NaN();
   double gamma_bad = std::numeric_limits<double>::quiet_NaN();
-  
+
   std::string msg1, msg2, msg3, msg4;
   msg1 = pull_msg(x, l_bad, sigma, gamma);
   msg2 = pull_msg(x, l, sigma_bad, gamma);
@@ -1086,7 +1103,7 @@ TEST(MathPrimMat, nan_error_training_sig_l_gamma) {
   EXPECT_TRUE(std::string::npos != msg2.find(" marginal variance")) << msg2;
   EXPECT_TRUE(std::string::npos != msg3.find(" gamma")) << msg3;
   EXPECT_TRUE(std::string::npos != msg4.find(" length-scale")) << msg4;
-  
+
   EXPECT_THROW(stan::math::gp_matern_3_2_cov(x, l_bad, sigma, gamma),
                std::domain_error);
   EXPECT_THROW(stan::math::gp_matern_3_2_cov(x, l, sigma_bad, gamma),
@@ -1106,9 +1123,9 @@ TEST(MathPrimMat, nan_error_training_sig_l_gamma) {
                std::domain_error);
   EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_bad, l, sigma, gamma_bad),
                std::domain_error);
-  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_bad, l_bad, sigma_bad,
-                                             gamma_bad),
-               std::domain_error);
+  EXPECT_THROW(
+      stan::math::gp_matern_3_2_cov(x_bad, l_bad, sigma_bad, gamma_bad),
+      std::domain_error);
 
   EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_2, l_bad, sigma, gamma),
                std::domain_error);
@@ -1118,16 +1135,16 @@ TEST(MathPrimMat, nan_error_training_sig_l_gamma) {
                std::domain_error);
   EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_2, l_bad, sigma_bad, gamma_bad),
                std::domain_error);
-  
+
   EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_bad_2, l_bad, sigma, gamma),
                std::domain_error);
   EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_bad_2, l, sigma_bad, gamma),
                std::domain_error);
   EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_bad_2, l, sigma, gamma_bad),
                std::domain_error);
-  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_bad_2, l_bad, sigma_bad,
-                                             gamma_bad),
-               std::domain_error);
+  EXPECT_THROW(
+      stan::math::gp_matern_3_2_cov(x_bad_2, l_bad, sigma_bad, gamma_bad),
+      std::domain_error);
 
   EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_3, l_bad, sigma, gamma),
                std::domain_error);
@@ -1137,45 +1154,46 @@ TEST(MathPrimMat, nan_error_training_sig_l_gamma) {
                std::domain_error);
   EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_3, l_bad, sigma_bad, gamma_bad),
                std::domain_error);
-  
+
   EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_bad_3, l_bad, sigma, gamma),
                std::domain_error);
   EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_bad_3, l, sigma_bad, gamma),
                std::domain_error);
   EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_bad_3, l, sigma, gamma_bad),
                std::domain_error);
-  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_bad_3, l_bad, sigma_bad,
-                                             gamma_bad),
-               std::domain_error);
-
+  EXPECT_THROW(
+      stan::math::gp_matern_3_2_cov(x_bad_3, l_bad, sigma_bad, gamma_bad),
+      std::domain_error);
 
   EXPECT_TRUE(std::string::npos != msg1.find(" length-scale")) << msg1;
   EXPECT_TRUE(std::string::npos != msg2.find(" marginal variance")) << msg2;
   EXPECT_TRUE(std::string::npos != msg3.find(" gamma")) << msg3;
   EXPECT_TRUE(std::string::npos != msg4.find(" length-scale")) << msg4;
-  
+
   EXPECT_THROW(stan::math::gp_matern_3_2_cov(x, l_vec_bad, sigma, gamma),
                std::domain_error);
   EXPECT_THROW(stan::math::gp_matern_3_2_cov(x, l_vec, sigma_bad, gamma),
                std::domain_error);
   EXPECT_THROW(stan::math::gp_matern_3_2_cov(x, l_vec, sigma, gamma_bad),
                std::domain_error);
-  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x, l_vec_bad, sigma_bad, gamma_bad),
-               std::domain_error);
+  EXPECT_THROW(
+      stan::math::gp_matern_3_2_cov(x, l_vec_bad, sigma_bad, gamma_bad),
+      std::domain_error);
 
   EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_bad, l_vec, sigma, gamma),
                std::domain_error);
   EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_bad, l_vec, sigma_bad, gamma),
                std::domain_error);
-  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_bad, l_vec_bad, sigma_bad, gamma),
-               std::domain_error);
+  EXPECT_THROW(
+      stan::math::gp_matern_3_2_cov(x_bad, l_vec_bad, sigma_bad, gamma),
+      std::domain_error);
   EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_bad, l_vec_bad, sigma, gamma),
                std::domain_error);
   EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_bad, l_vec, sigma, gamma_bad),
                std::domain_error);
-  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_bad, l_vec_bad, sigma_bad,
-                                             gamma_bad),
-               std::domain_error);
+  EXPECT_THROW(
+      stan::math::gp_matern_3_2_cov(x_bad, l_vec_bad, sigma_bad, gamma_bad),
+      std::domain_error);
 
   EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_2, l_vec_bad, sigma, gamma),
                std::domain_error);
@@ -1183,18 +1201,19 @@ TEST(MathPrimMat, nan_error_training_sig_l_gamma) {
                std::domain_error);
   EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_2, l_vec, sigma, gamma_bad),
                std::domain_error);
-  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_2, l_vec_bad, sigma_bad, gamma_bad),
-               std::domain_error);
-  
+  EXPECT_THROW(
+      stan::math::gp_matern_3_2_cov(x_2, l_vec_bad, sigma_bad, gamma_bad),
+      std::domain_error);
+
   EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_bad_2, l_vec_bad, sigma, gamma),
                std::domain_error);
   EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_bad_2, l_vec, sigma_bad, gamma),
                std::domain_error);
   EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_bad_2, l_vec, sigma, gamma_bad),
                std::domain_error);
-  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_bad_2, l_vec_bad, sigma_bad,
-                                             gamma_bad),
-               std::domain_error);
+  EXPECT_THROW(
+      stan::math::gp_matern_3_2_cov(x_bad_2, l_vec_bad, sigma_bad, gamma_bad),
+      std::domain_error);
 
   EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_3, l_vec_bad, sigma, gamma),
                std::domain_error);
@@ -1202,32 +1221,33 @@ TEST(MathPrimMat, nan_error_training_sig_l_gamma) {
                std::domain_error);
   EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_3, l_vec, sigma, gamma_bad),
                std::domain_error);
-  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_3, l_vec_bad, sigma_bad, gamma_bad),
-               std::domain_error);
-  
+  EXPECT_THROW(
+      stan::math::gp_matern_3_2_cov(x_3, l_vec_bad, sigma_bad, gamma_bad),
+      std::domain_error);
+
   EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_bad_3, l_vec_bad, sigma, gamma),
                std::domain_error);
   EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_bad_3, l_vec, sigma_bad, gamma),
                std::domain_error);
   EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_bad_3, l_vec, sigma, gamma_bad),
                std::domain_error);
-  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_bad_3, l_vec_bad, sigma_bad,
-                                             gamma_bad),
-               std::domain_error);
+  EXPECT_THROW(
+      stan::math::gp_matern_3_2_cov(x_bad_3, l_vec_bad, sigma_bad, gamma_bad),
+      std::domain_error);
 }
 
 TEST(MathPrimMat, dim_mismatch_vec_eigen_rvec_gp_matern_3_2_cov2) {
   double sigma = 0.2;
   double l = 5;
   double gamma = -11;
-  
-  std::vector<Eigen::Matrix<double, 1, -1> > x_vec_1(3);
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x_vec_1(3);
   for (size_t i = 0; i < x_vec_1.size(); ++i) {
     x_vec_1[i].resize(1, 3);
     x_vec_1[i] << 1, 2, 3;
   }
 
-  std::vector<Eigen::Matrix<double, 1, -1> > x_vec_2(4);
+  std::vector<Eigen::Matrix<double, 1, -1>> x_vec_2(4);
   for (size_t i = 0; i < x_vec_2.size(); ++i) {
     x_vec_2[i].resize(1, 4);
     x_vec_2[i] << 4, 1, 3, 1;
@@ -1241,35 +1261,39 @@ TEST(MathPrimMat, dim_mismatch_vec_eigen_mixed_gp_matern_3_2_cov) {
   double l = 5;
   double gamma = -11;
 
-  std::vector<Eigen::Matrix<double, 1, -1> > x_rvec_1(3);
+  std::vector<Eigen::Matrix<double, 1, -1>> x_rvec_1(3);
   for (size_t i = 0; i < x_rvec_1.size(); ++i) {
     x_rvec_1[i].resize(1, 3);
     x_rvec_1[i] << 1, 2, 3;
   }
 
-  std::vector<Eigen::Matrix<double, -1, 1> > x_vec_1(4);
+  std::vector<Eigen::Matrix<double, -1, 1>> x_vec_1(4);
   for (size_t i = 0; i < x_vec_1.size(); ++i) {
     x_vec_1[i].resize(4, 1);
     x_vec_1[i] << 4, 1, 3, 1;
   }
 
-  std::vector<Eigen::Matrix<double, -1, 1> > x_vec_2(3);
+  std::vector<Eigen::Matrix<double, -1, 1>> x_vec_2(3);
   for (size_t i = 0; i < x_vec_2.size(); ++i) {
     x_vec_2[i].resize(3, 1);
     x_vec_2[i] << 1, 2, 3;
   }
 
-  std::vector<Eigen::Matrix<double, 1, -1> > x_rvec_2(4);
+  std::vector<Eigen::Matrix<double, 1, -1>> x_rvec_2(4);
   for (size_t i = 0; i < x_rvec_2.size(); ++i) {
     x_rvec_2[i].resize(1, 4);
     x_rvec_2[i] << 1, 2, 3, 4;
   }
-  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_rvec_1, x_vec_1, l, sigma, gamma),
-               std::invalid_argument);
-  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_vec_1, x_rvec_1, l, sigma, gamma),
-               std::invalid_argument);
-  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_rvec_2, x_vec_2, l, sigma, gamma),
-               std::invalid_argument);
-  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_vec_2, x_rvec_2, l, sigma, gamma),
-               std::invalid_argument);
+  EXPECT_THROW(
+      stan::math::gp_matern_3_2_cov(x_rvec_1, x_vec_1, l, sigma, gamma),
+      std::invalid_argument);
+  EXPECT_THROW(
+      stan::math::gp_matern_3_2_cov(x_vec_1, x_rvec_1, l, sigma, gamma),
+      std::invalid_argument);
+  EXPECT_THROW(
+      stan::math::gp_matern_3_2_cov(x_rvec_2, x_vec_2, l, sigma, gamma),
+      std::invalid_argument);
+  EXPECT_THROW(
+      stan::math::gp_matern_3_2_cov(x_vec_2, x_rvec_2, l, sigma, gamma),
+      std::invalid_argument);
 }

--- a/test/unit/math/prim/mat/fun/gp_matern_3_2_cov_test.cpp
+++ b/test/unit/math/prim/mat/fun/gp_matern_3_2_cov_test.cpp
@@ -1,6 +1,6 @@
-#include <stan/math/prim/mat.hpp>
 #include <gtest/gtest.h>
 #include <limits>
+#include <stan/math/prim/mat.hpp>
 #include <string>
 #include <vector>
 
@@ -12,7 +12,7 @@ std::string pull_msg(std::vector<T_x> x, T_l l, T_s sigma, T_g gamma) {
   std::string message;
   try {
     stan::math::gp_matern_3_2_cov(x, l, sigma, gamma);
-  } catch (std::domain_error& e) {
+  } catch (std::domain_error &e) {
     message = e.what();
   } catch (...) {
     message = "Threw the wrong exception";
@@ -20,7 +20,22 @@ std::string pull_msg(std::vector<T_x> x, T_l l, T_s sigma, T_g gamma) {
   return message;
 }
 
-TEST(MathPrimMat, vec_double_gp_matern_3_2_cov1){
+template <typename T_x1, typename T_x2, typename T_l, typename T_s,
+          typename T_g>
+std::string pull_msg(std::vector<T_x1> x1, std::vector<T_x2> x2, T_l l,
+                     T_s sigma, T_g gamma) {
+  std::string message;
+  try {
+    stan::math::gp_matern_3_2_cov(x1, x2, l, sigma, gamma);
+  } catch (std::domain_error &e) {
+    message = e.what();
+  } catch (...) {
+    message = "Threw the wrong exception";
+  }
+  return message;
+}
+
+TEST(MathPrimMat, vec_double_gp_matern_3_2_cov1) {
   double sigma = 0.2;
   double gamma = 1.2;
   double l = 5.0;
@@ -34,19 +49,21 @@ TEST(MathPrimMat, vec_double_gp_matern_3_2_cov1){
   cov = stan::math::gp_matern_3_2_cov(x, l, sigma, gamma);
   for (int i = 0; i < 3; i++)
     for (int j = 0; j < 3; j++)
-      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + (pow(3.0, 0.5) / l) * gamma *
-                                       abs(x[i] - x[j])) *
-                      std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l) *
-                               abs(x[i] - x[j])),
-                      cov(i, j))
-        << "index: (" << i << ", " << j << ")";
+      EXPECT_FLOAT_EQ(
+          sigma * sigma *
+          (1.0 + (pow(3.0, 0.5) / l) * gamma *
+           stan::math::squared_distance(x[i], x[j])) *
+          std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l) *
+                   stan::math::squared_distance(x[i], x[j])),
+          cov(i, j))
+          << "index: (" << i << ", " << j << ")";
 }
 
 TEST(MathPrimMat, vec_double_ard_gp_matern_3_2_cov1) {
   double sigma = 0.2;
   double gamma = 1.2;
-  double temp; 
-  
+  double temp;
+
   std::vector<double> x(3);
   x[0] = -2;
   x[1] = -1;
@@ -58,19 +75,20 @@ TEST(MathPrimMat, vec_double_ard_gp_matern_3_2_cov1) {
   l[2] = 0.3;
   l[3] = 0.4;
   l[4] = 0.5;
-  
+
   Eigen::MatrixXd cov;
   cov = stan::math::gp_matern_3_2_cov(x, l, sigma, gamma);
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       temp = 0;
       for (int k = 0; k < 5; k++) {
-        temp += (1.0 + gamma * pow(3.0, 0.5) * abs(x[i] - x[j]) / l[k]) *
-          exp(-1.0 * gamma * pow(3.0, 0.5) * abs(x[i] - x[j]) / l[k]);
+        temp += stan::math::squared_distance(x[i], x[j]) / l[k];
       }
-      EXPECT_FLOAT_EQ(sigma * sigma * temp,
-                      cov(i, j))
-        << "index: (" << i << ", " << j << ")";
+      
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + gamma * pow(3.0, 0.5) * sqrt(temp))
+                      * std::exp(-1.0 * gamma * pow(3.0, 0.5) * sqrt(temp))
+                      , cov(i, j))
+          << "index: (" << i << ", " << j << ")";
     }
   }
 }
@@ -79,15 +97,41 @@ TEST(MathPrimMat, vec_eigen_gp_matern_3_2_cov1) {
   double l = 0.2;
   double sigma = 0.3;
   double gamma = 0.5;
-  double distance = 0;
 
-  std::vector<Eigen::Matrix<double, 1, -1> > x1(3);
-  std::vector<Eigen::Matrix<double, 1, -1> > x2(4);
+  std::vector<Eigen::Matrix<double, 1, -1>> x1(3);
   for (size_t i = 0; i < x1.size(); ++i) {
     x1[i].resize(1, 3);
     x1[i] << 1 * i, 2 * i, 3 * i;
   }
 
+  Eigen::MatrixXd cov;
+  cov = stan::math::gp_matern_3_2_cov(x1, l, sigma, gamma);
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      EXPECT_FLOAT_EQ(
+                      sigma * sigma * (1.0 + (pow(3.0, 0.5) / l) * gamma *
+                                       stan::math::squared_distance(x1[i],
+                                                                    x1[j])) *
+              std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l) *
+                       stan::math::squared_distance(x1[i], x1[j])),
+          cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+}
+
+TEST(MathPrimMat, vec_eigen_eigen_gp_matern_3_2_cov1) {
+  double l = 0.2;
+  double sigma = 0.3;
+  double gamma = 0.5;
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x1(3);
+  for (size_t i = 0; i < x1.size(); ++i) {
+    x1[i].resize(1, 3);
+    x1[i] << 1 * i, 2 * i, 3 * i;
+  }
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x2(3);
   for (size_t i = 0; i < x2.size(); ++i) {
     x2[i].resize(1, 3);
     x2[i] << 2 * i, 3 * i, 4 * i;
@@ -97,15 +141,1135 @@ TEST(MathPrimMat, vec_eigen_gp_matern_3_2_cov1) {
   cov = stan::math::gp_matern_3_2_cov(x1, x2, l, sigma, gamma);
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
-      distance = 0;
-      for (int k = 0; k < 3; k++)
-        distance += abs(x1[i][k] - x2[j][k]);
-      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + (pow(3.0, 0.5) / l) * gamma *
-                                       distance) *
-                      std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l) *
-                               distance),
-                      cov(i, j))
-        << "index: (" << i << ", " << j << ")";
+      EXPECT_FLOAT_EQ(
+                      sigma * sigma * (1.0 + (pow(3.0, 0.5) / l) * gamma *
+                                       stan::math::squared_distance(x1[i],
+                                                                    x2[j])) *
+              std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l) *
+                       stan::math::squared_distance(x1[i], x2[j])),
+          cov(i, j))
+          << "index: (" << i << ", " << j << ")";
     }
   }
+}
+
+TEST(MathPrimMat, vec_double_double_gp_matern_3_2_cov1) {
+  double sigma = 0.2;
+  double gamma = 1.2;
+  double l = 5.0;
+
+  std::vector<double> x1(3);
+  x1[0] = -2;
+  x1[1] = -1;
+  x1[2] = -0.5;
+
+  std::vector<double> x2(3);
+  x2[0] = 3;
+  x2[1] = -4;
+  x2[2] = -0.7;
+  
+  Eigen::MatrixXd cov;
+  cov = stan::math::gp_matern_3_2_cov(x1, x2, l, sigma, gamma);
+  for (int i = 0; i < 3; i++)
+    for (int j = 0; j < 3; j++)
+      EXPECT_FLOAT_EQ(
+          sigma * sigma *
+          (1.0 + (pow(3.0, 0.5) / l) * gamma *
+           stan::math::squared_distance(x1[i], x2[j])) *
+          std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l) *
+                   stan::math::squared_distance(x1[i], x2[j])),
+          cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+}
+
+TEST(MathPrimMat, vec_eigen_ard_gp_matern_3_2_cov1) {
+  double sigma = 0.3;
+  double gamma = 0.5;
+  double temp;
+  
+  std::vector<Eigen::Matrix<double, 1, -1>> x1(3);
+  for (size_t i = 0; i < x1.size(); ++i) {
+    x1[i].resize(1, 3);
+    x1[i] << 1 * i, 2 * i, 3 * i;
+  }
+
+  std::vector<double> l(5);
+  l[0] = 0.1;
+  l[1] = 0.2;
+  l[2] = 0.3;
+  l[3] = 0.4;
+  l[4] = 0.5;
+  
+  Eigen::MatrixXd cov;
+  cov = stan::math::gp_matern_3_2_cov(x1, l, sigma, gamma);
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 5; k++) {
+        temp += stan::math::squared_distance(x1[i], x1[j]) / l[k];
+      }
+      
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + gamma * pow(3.0, 0.5) * sqrt(temp))
+                      * std::exp(-1.0 * gamma * pow(3.0, 0.5) * sqrt(temp))
+                      , cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+}
+
+TEST(MathPrimMat, vec_double_double_ard_gp_matern_3_2_cov1) {
+  double sigma = 0.2;
+  double gamma = 1.2;
+  double temp;
+  
+  std::vector<double> x1(3);
+  x1[0] = -2;
+  x1[1] = -1;
+  x1[2] = -0.5;
+
+  std::vector<double> x2(3);
+  x2[0] = 3;
+  x2[1] = -4;
+  x2[2] = -0.7;
+
+  std::vector<double> l(4);
+  l[0] = 1;
+  l[1] = 2;
+  l[2] = 3;
+  l[3] = 4;
+  
+  Eigen::MatrixXd cov;
+  cov = stan::math::gp_matern_3_2_cov(x1, x2, l, sigma, gamma);
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 4; k++) {
+        temp += stan::math::squared_distance(x1[i], x2[j]) / l[k];
+      }
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + gamma * pow(3.0, 0.5) * pow(temp, 0.5))
+                      * std::exp(-1.0 * gamma * pow(3.0, 0.5) * pow(temp, 0.5))
+                      , cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+}
+
+TEST(MathPrimMat, vec_eigen_eigen_ard_gp_matern_3_2_cov1) {
+  double sigma = 0.2;
+  double gamma = 1.2;
+  double temp;
+  
+  std::vector<Eigen::Matrix<double, 1, -1>> x1(3);
+  for (size_t i = 0; i < x1.size(); ++i) {
+    x1[i].resize(1, 3);
+    x1[i] << 1 * i, 2 * i, 3 * i;
+  }
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x2(3);
+  for (size_t i = 0; i < x2.size(); ++i) {
+    x2[i].resize(1, 3);
+    x2[i] << 2 * i, 3 * i, 4 * i;
+  }
+
+  std::vector<double> l(4);
+  l[0] = 1;
+  l[1] = 2;
+  l[2] = 3;
+  l[3] = 4;
+  
+  Eigen::MatrixXd cov;
+  cov = stan::math::gp_matern_3_2_cov(x1, x2, l, sigma, gamma);
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 4; k++) {
+        temp += stan::math::squared_distance(x1[i], x2[j]) / l[k];
+      }
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + gamma * pow(3.0, 0.5) * pow(temp, 0.5))
+                      * std::exp(-1.0 * gamma * pow(3.0, 0.5) * pow(temp, 0.5))
+                      , cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+}
+
+TEST(MathPrimMat, rvec_eigen_gp_matern_3_2_cov1) {
+  double l = 0.2;
+  double sigma = 0.3;
+  double gamma = 0.5;
+
+  std::vector<Eigen::Matrix<double, -1, 1>> x1(3);
+  for (size_t i = 0; i < x1.size(); ++i) {
+    x1[i].resize(3, 1);
+    x1[i] << 1 * i, 2 * i, 3 * i;
+  }
+
+  Eigen::MatrixXd cov;
+  cov = stan::math::gp_matern_3_2_cov(x1, l, sigma, gamma);
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      EXPECT_FLOAT_EQ(
+                      sigma * sigma * (1.0 + (pow(3.0, 0.5) / l) * gamma *
+                                       stan::math::squared_distance(x1[i],
+                                                                    x1[j])) *
+              std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l) *
+                       stan::math::squared_distance(x1[i], x1[j])),
+          cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+}
+
+TEST(MathPrimMat, rvec_eigen_ard_gp_matern_3_2_cov1) {
+  double sigma = 0.3;
+  double gamma = 0.5;
+  double temp;
+
+  std::vector<Eigen::Matrix<double, -1, 1>> x1(3);
+  for (size_t i = 0; i < x1.size(); ++i) {
+    x1[i].resize(3, 1);
+    x1[i] << 1 * i, 2 * i, 3 * i;
+  }
+
+  std::vector<double> l(4);
+  l[0] = 1;
+  l[1] = 2;
+  l[2] = 3;
+  l[3] = 4;
+  
+  Eigen::MatrixXd cov;
+  cov = stan::math::gp_matern_3_2_cov(x1, l, sigma, gamma);
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 4; k++) {
+        temp += stan::math::squared_distance(x1[i], x1[j]) / l[k];
+      }
+      
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + gamma * pow(3.0, 0.5) * sqrt(temp))
+                      * std::exp(-1.0 * gamma * pow(3.0, 0.5) * sqrt(temp))
+                      , cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+}
+
+TEST(MathPrimMat, vec_eigen_rvec_eigen_gp_matern_3_2_cov1) {
+  double sigma = 0.3;
+  double gamma = 0.5;
+  double l = 2.3;
+  
+  std::vector<Eigen::Matrix<double, -1, 1>> x1(3);
+  for (size_t i = 0; i < x1.size(); ++i) {
+    x1[i].resize(3, 1);
+    x1[i] << 1 * i, 2 * i, 3 * i;
+  }
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x2(3);
+  for (size_t i = 0; i < x2.size(); ++i) {
+    x2[i].resize(1, 3);
+    x2[i] << 2 * i, 3 * i, 4 * i;
+  }
+
+  Eigen::MatrixXd cov;
+  cov = stan::math::gp_matern_3_2_cov(x1, x2, l, sigma, gamma); 
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      EXPECT_FLOAT_EQ(
+                      sigma * sigma * (1.0 + (pow(3.0, 0.5) / l) * gamma *
+                                       stan::math::squared_distance(x1[i],
+                                                                    x2[j])) *
+              std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l) *
+                       stan::math::squared_distance(x1[i], x2[j])),
+          cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+
+  cov = stan::math::gp_matern_3_2_cov(x2, x1, l, sigma, gamma); 
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      EXPECT_FLOAT_EQ(
+                      sigma * sigma * (1.0 + (pow(3.0, 0.5) / l) * gamma *
+                                       stan::math::squared_distance(x2[i],
+                                                                    x1[j])) *
+              std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l) *
+                       stan::math::squared_distance(x2[i], x1[j])),
+          cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+}
+
+TEST(MathPrimMat, vec_eigen_rvec_eigen_ard_gp_matern_3_2_cov1) {
+  double sigma = 0.3;
+  double gamma = 0.5;
+  double temp = 0;
+  std::vector<double> l(3);
+  l[0] = 1;
+  l[1] = 2;
+  l[2] = 3;
+  
+  std::vector<Eigen::Matrix<double, -1, 1>> x1(3);
+  for (size_t i = 0; i < x1.size(); ++i) {
+    x1[i].resize(3, 1);
+    x1[i] << 1 * i, 2 * i, 3 * i;
+  }
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x2(3);
+  for (size_t i = 0; i < x2.size(); ++i) {
+    x2[i].resize(1, 3);
+    x2[i] << 2 * i, 3 * i, 4 * i;
+  }
+
+  Eigen::MatrixXd cov;
+  cov = stan::math::gp_matern_3_2_cov(x1, x2, l, sigma, gamma); 
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 3; k++) {
+        temp += stan::math::squared_distance(x1[i], x2[j]) / l[k];
+      }
+      
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + gamma * pow(3.0, 0.5) * sqrt(temp))
+                      * std::exp(-1.0 * gamma * pow(3.0, 0.5) * sqrt(temp))
+                      , cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+  cov = stan::math::gp_matern_3_2_cov(x2, x1, l, sigma, gamma); 
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 3; k++) {
+        temp += stan::math::squared_distance(x2[i], x1[j]) / l[k];
+      }
+      
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + gamma * pow(3.0, 0.5) * sqrt(temp))
+                      * std::exp(-1.0 * gamma * pow(3.0, 0.5) * sqrt(temp))
+                      , cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+}
+
+TEST(MathPrimMat, rvec_eigen_rvec_eigen_gp_matern_3_2_cov1) {
+  double sigma = 0.3;
+  double gamma = 0.5;
+  double l = 2.3;
+  
+  std::vector<Eigen::Matrix<double, -1, 1>> x1(3);
+  for (size_t i = 0; i < x1.size(); ++i) {
+    x1[i].resize(3, 1);
+    x1[i] << 1 * i, 2 * i, 3 * i;
+  }
+
+  std::vector<Eigen::Matrix<double, -1, 1>> x2(3);
+  for (size_t i = 0; i < x2.size(); ++i) {
+    x2[i].resize(3, 1);
+    x2[i] << 2 * i, 3 * i, 4 * i;
+  }
+
+  Eigen::MatrixXd cov;
+  cov = stan::math::gp_matern_3_2_cov(x1, x2, l, sigma, gamma); 
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      EXPECT_FLOAT_EQ(
+                      sigma * sigma * (1.0 + (pow(3.0, 0.5) / l) * gamma *
+                                       stan::math::squared_distance(x1[i],
+                                                                    x2[j])) *
+              std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l) *
+                       stan::math::squared_distance(x1[i], x2[j])),
+          cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+
+  cov = stan::math::gp_matern_3_2_cov(x2, x1, l, sigma, gamma); 
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      EXPECT_FLOAT_EQ(
+                      sigma * sigma * (1.0 + (pow(3.0, 0.5) / l) * gamma *
+                                       stan::math::squared_distance(x2[i],
+                                                                    x1[j])) *
+              std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l) *
+                       stan::math::squared_distance(x2[i], x1[j])),
+          cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+}
+
+TEST(MathPrimMat, rvec_eigen_rvec_eigen_ard_gp_matern_3_2_cov1) {
+  double sigma = 0.3;
+  double gamma = 0.5;
+  double temp;
+
+  std::vector<double> l(3);
+  l[0] = 1;
+  l[1] = 2;
+  l[2] = 3;
+  
+  std::vector<Eigen::Matrix<double, -1, 1>> x1(3);
+  for (size_t i = 0; i < x1.size(); ++i) {
+    x1[i].resize(3, 1);
+    x1[i] << 1 * i, 2 * i, 3 * i;
+  }
+
+  std::vector<Eigen::Matrix<double, -1, 1>> x2(3);
+  for (size_t i = 0; i < x2.size(); ++i) {
+    x2[i].resize(3, 1);
+    x2[i] << 2 * i, 3 * i, 4 * i;
+  }
+
+  Eigen::MatrixXd cov;
+  cov = stan::math::gp_matern_3_2_cov(x1, x2, l, sigma, gamma); 
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 3; k++) {
+        temp += stan::math::squared_distance(x1[i], x2[j]) / l[k];
+      }
+      
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + gamma * pow(3.0, 0.5) * sqrt(temp))
+                      * std::exp(-1.0 * gamma * pow(3.0, 0.5) * sqrt(temp))
+                      , cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+  cov = stan::math::gp_matern_3_2_cov(x2, x1, l, sigma, gamma); 
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 3; k++) {
+        temp += stan::math::squared_distance(x2[i], x1[j]) / l[k];
+      }
+      
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + gamma * pow(3.0, 0.5) * sqrt(temp))
+                      * std::exp(-1.0 * gamma * pow(3.0, 0.5) * sqrt(temp))
+                      , cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+}
+
+TEST(MathPrimMat, vec_eigen_mixed_gp_matern_3_2_cov2) {
+  using stan::math::squared_distance;
+  double sigma = 0.2;
+  double gamma = 0.5;
+  double l = 5;
+
+  std::vector<Eigen::Matrix<double, 1, -1> > x1_rvec(3);
+  std::vector<Eigen::Matrix<double, 1, -1> > x2_rvec(4);
+
+  for (size_t i = 0; i < x1_rvec.size(); ++i) {
+    x1_rvec[i].resize(1, 3);
+    x1_rvec[i] << 1 * i, 2 * i, 3 * i;
+  }
+
+  for (size_t i = 0; i < x2_rvec.size(); ++i) {
+    x2_rvec[i].resize(1, 3);
+    x2_rvec[i] << 2 * i, 3 * i, 4 * i;
+  }
+
+  std::vector<Eigen::Matrix<double, -1, 1> > x1_vec(3);
+  std::vector<Eigen::Matrix<double, -1, 1> > x2_vec(4);
+
+  for (size_t i = 0; i < x1_vec.size(); ++i) {
+    x1_vec[i].resize(3, 1);
+    x1_vec[i] << 1 * i, 2 * i, 3 * i;
+  }
+
+  for (size_t i = 0; i < x2_vec.size(); ++i) {
+    x2_vec[i].resize(3, 1);
+    x2_vec[i] << 2 * i, 3 * i, 4 * i;
+  }
+  Eigen::MatrixXd cov;
+  EXPECT_NO_THROW(cov = stan::math::gp_matern_3_2_cov(x1_rvec, x2_vec, l, sigma,
+                                                      gamma));
+  EXPECT_EQ(3, cov.rows());
+  EXPECT_EQ(4, cov.cols());
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      EXPECT_FLOAT_EQ(
+                      sigma * sigma * (1.0 + (pow(3.0, 0.5) / l) * gamma *
+                                       stan::math::squared_distance(x1_rvec[i],
+                                                                    x2_vec[j])) *
+              std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l) *
+                       stan::math::squared_distance(x1_rvec[i], x2_vec[j])),
+          cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+
+  Eigen::MatrixXd cov7;
+  EXPECT_NO_THROW(cov7 = stan::math::gp_matern_3_2_cov(x2_vec, x1_rvec, l,
+                                                       sigma, gamma));
+  EXPECT_EQ(4, cov7.rows());
+  EXPECT_EQ(3, cov7.cols());
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      EXPECT_FLOAT_EQ(
+                      sigma * sigma * (1.0 + (pow(3.0, 0.5) / l) * gamma *
+                                       stan::math::squared_distance(x2_vec[i],
+                                                                    x1_rvec[j])) *
+              std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l) *
+                       stan::math::squared_distance(x2_vec[i], x1_rvec[j])),
+          cov7(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+  Eigen::MatrixXd cov2;
+  EXPECT_NO_THROW(cov2 = stan::math::gp_matern_3_2_cov(x1_vec, x2_rvec, l,
+                                                       sigma, gamma));
+  EXPECT_EQ(3, cov2.rows());
+  EXPECT_EQ(4, cov2.cols());
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      EXPECT_FLOAT_EQ(
+                      sigma * sigma * (1.0 + (pow(3.0, 0.5) / l) * gamma *
+                                       stan::math::squared_distance(x1_vec[i],
+                                                                    x2_rvec[j])) *
+              std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l) *
+                       stan::math::squared_distance(x1_vec[i], x2_rvec[j])),
+          cov2(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+
+  Eigen::MatrixXd cov8;
+  EXPECT_NO_THROW(cov8 = stan::math::gp_matern_3_2_cov(x2_rvec, x1_vec, l,
+                                                       sigma, gamma));
+  EXPECT_EQ(4, cov8.rows());
+  EXPECT_EQ(3, cov8.cols());
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      EXPECT_FLOAT_EQ(
+                      sigma * sigma * (1.0 + (pow(3.0, 0.5) / l) * gamma *
+                                       stan::math::squared_distance(x2_rvec[i],
+                                                                    x1_vec[j])) *
+              std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l) *
+                       stan::math::squared_distance(x2_rvec[i], x1_vec[j])),
+          cov8(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+
+  Eigen::MatrixXd cov3;
+  EXPECT_NO_THROW(cov3 = stan::math::gp_matern_3_2_cov(x2_vec, x2_rvec, l,
+                                                       sigma, gamma));
+  EXPECT_EQ(4, cov3.rows());
+  EXPECT_EQ(4, cov3.cols());
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      EXPECT_FLOAT_EQ(
+                      sigma * sigma * (1.0 + (pow(3.0, 0.5) / l) * gamma *
+                                       stan::math::squared_distance(x2_vec[i],
+                                                                    x2_rvec[j])) *
+              std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l) *
+                       stan::math::squared_distance(x2_vec[i], x2_rvec[j])),
+          cov3(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+
+  Eigen::MatrixXd cov4;
+  EXPECT_NO_THROW(cov4 = stan::math::gp_matern_3_2_cov(x2_rvec, x2_vec, l,
+                                                       sigma, gamma));
+  EXPECT_EQ(4, cov4.rows());
+  EXPECT_EQ(4, cov4.cols());
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      EXPECT_FLOAT_EQ(
+                      sigma * sigma * (1.0 + (pow(3.0, 0.5) / l) * gamma *
+                                       stan::math::squared_distance(x2_rvec[i],
+                                                                    x2_vec[j])) *
+              std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l) *
+                       stan::math::squared_distance(x2_rvec[i], x2_vec[j])),
+          cov4(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+
+  Eigen::MatrixXd cov5;
+  EXPECT_NO_THROW(cov5 = stan::math::gp_matern_3_2_cov(x1_rvec, x1_vec, l,
+                                                       sigma, gamma));
+  EXPECT_EQ(3, cov5.rows());
+  EXPECT_EQ(3, cov5.cols());
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      EXPECT_FLOAT_EQ(
+                      sigma * sigma * (1.0 + (pow(3.0, 0.5) / l) * gamma *
+                                       stan::math::squared_distance(x1_rvec[i],
+                                                                    x1_vec[j])) *
+              std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l) *
+                       stan::math::squared_distance(x1_rvec[i], x1_vec[j])),
+          cov5(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+
+  Eigen::MatrixXd cov6;
+  EXPECT_NO_THROW(cov6 = stan::math::gp_matern_3_2_cov(x1_vec, x1_rvec, l,
+                                                       sigma, gamma));
+  EXPECT_EQ(3, cov6.rows());
+  EXPECT_EQ(3, cov6.cols());
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      EXPECT_FLOAT_EQ(
+                      sigma * sigma * (1.0 + (pow(3.0, 0.5) / l) * gamma *
+                                       stan::math::squared_distance(x1_vec[i],
+                                                                    x1_rvec[j]))
+                      *
+              std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l) *
+                       stan::math::squared_distance(x1_vec[i], x1_rvec[j])),
+          cov6(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+}
+
+TEST(MathPrimMat, vec_eigen_mixed_ard_gp_matern_3_2_cov2) {
+  using stan::math::squared_distance;
+  double sigma = 0.2;
+  double gamma = 0.5;
+  double temp;
+
+  std::vector<double> l(3);
+  l[0] = 1;
+  l[1] = 2;
+  l[2] = 3;
+  
+
+  std::vector<Eigen::Matrix<double, 1, -1> > x1_rvec(3);
+  std::vector<Eigen::Matrix<double, 1, -1> > x2_rvec(4);
+
+  for (size_t i = 0; i < x1_rvec.size(); ++i) {
+    x1_rvec[i].resize(1, 3);
+    x1_rvec[i] << 1 * i, 2 * i, 3 * i;
+  }
+
+  for (size_t i = 0; i < x2_rvec.size(); ++i) {
+    x2_rvec[i].resize(1, 3);
+    x2_rvec[i] << 2 * i, 3 * i, 4 * i;
+  }
+
+  std::vector<Eigen::Matrix<double, -1, 1> > x1_vec(3);
+  std::vector<Eigen::Matrix<double, -1, 1> > x2_vec(4);
+
+  for (size_t i = 0; i < x1_vec.size(); ++i) {
+    x1_vec[i].resize(3, 1);
+    x1_vec[i] << 1 * i, 2 * i, 3 * i;
+  }
+
+  for (size_t i = 0; i < x2_vec.size(); ++i) {
+    x2_vec[i].resize(3, 1);
+    x2_vec[i] << 2 * i, 3 * i, 4 * i;
+  }
+  Eigen::MatrixXd cov;
+  EXPECT_NO_THROW(cov = stan::math::gp_matern_3_2_cov(x1_rvec, x2_vec, l, sigma,
+                                                      gamma));
+  EXPECT_EQ(3, cov.rows());
+  EXPECT_EQ(4, cov.cols());
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 3; k++) {
+        temp += stan::math::squared_distance(x1_rvec[i], x2_vec[j]) / l[k];
+      }
+      
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + gamma * pow(3.0, 0.5) * sqrt(temp))
+                      * std::exp(-1.0 * gamma * pow(3.0, 0.5) * sqrt(temp))
+                      , cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+
+    }
+  }
+
+  Eigen::MatrixXd cov7;
+  EXPECT_NO_THROW(cov7 = stan::math::gp_matern_3_2_cov(x2_vec, x1_rvec, l,
+                                                       sigma, gamma));
+  EXPECT_EQ(4, cov7.rows());
+  EXPECT_EQ(3, cov7.cols());
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 3; k++) {
+        temp += stan::math::squared_distance(x2_vec[i], x1_rvec[j]) / l[k];
+      }
+      
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + gamma * pow(3.0, 0.5) * sqrt(temp))
+                      * std::exp(-1.0 * gamma * pow(3.0, 0.5) * sqrt(temp))
+                      , cov7(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+
+  Eigen::MatrixXd cov2;
+  EXPECT_NO_THROW(cov2 = stan::math::gp_matern_3_2_cov(x1_vec, x2_rvec, l,
+                                                       sigma, gamma));
+  EXPECT_EQ(3, cov2.rows());
+  EXPECT_EQ(4, cov2.cols());
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 3; k++) {
+        temp += stan::math::squared_distance(x1_vec[i], x2_rvec[j]) / l[k];
+      }
+      
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + gamma * pow(3.0, 0.5) * sqrt(temp))
+                      * std::exp(-1.0 * gamma * pow(3.0, 0.5) * sqrt(temp))
+                      , cov2(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+
+  Eigen::MatrixXd cov8;
+  EXPECT_NO_THROW(cov8 = stan::math::gp_matern_3_2_cov(x2_rvec, x1_vec, l,
+                                                       sigma, gamma));
+  EXPECT_EQ(4, cov8.rows());
+  EXPECT_EQ(3, cov8.cols());
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 3; k++) {
+        temp += stan::math::squared_distance(x2_rvec[i], x1_vec[j]) / l[k];
+      }
+      
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + gamma * pow(3.0, 0.5) * sqrt(temp))
+                      * std::exp(-1.0 * gamma * pow(3.0, 0.5) * sqrt(temp))
+                      , cov8(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+
+  Eigen::MatrixXd cov3;
+  EXPECT_NO_THROW(cov3 = stan::math::gp_matern_3_2_cov(x2_vec, x2_rvec, l,
+                                                       sigma, gamma));
+  EXPECT_EQ(4, cov3.rows());
+  EXPECT_EQ(4, cov3.cols());
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 3; k++) {
+        temp += stan::math::squared_distance(x2_vec[i], x2_rvec[j]) / l[k];
+      }
+      
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + gamma * pow(3.0, 0.5) * sqrt(temp))
+                      * std::exp(-1.0 * gamma * pow(3.0, 0.5) * sqrt(temp))
+                      , cov3(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+
+  Eigen::MatrixXd cov4;
+  EXPECT_NO_THROW(cov4 = stan::math::gp_matern_3_2_cov(x2_rvec, x2_vec, l,
+                                                       sigma, gamma));
+  EXPECT_EQ(4, cov4.rows());
+  EXPECT_EQ(4, cov4.cols());
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 3; k++) {
+        temp += stan::math::squared_distance(x2_rvec[i], x2_vec[j]) / l[k];
+      }
+      
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + gamma * pow(3.0, 0.5) * sqrt(temp))
+                      * std::exp(-1.0 * gamma * pow(3.0, 0.5) * sqrt(temp))
+                      , cov4(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+
+  Eigen::MatrixXd cov5;
+  EXPECT_NO_THROW(cov5 = stan::math::gp_matern_3_2_cov(x1_rvec, x1_vec, l,
+                                                       sigma, gamma));
+  EXPECT_EQ(3, cov5.rows());
+  EXPECT_EQ(3, cov5.cols());
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 3; k++) {
+        temp += stan::math::squared_distance(x1_rvec[i], x1_vec[j]) / l[k];
+      }
+      
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + gamma * pow(3.0, 0.5) * sqrt(temp))
+                      * std::exp(-1.0 * gamma * pow(3.0, 0.5) * sqrt(temp))
+                      , cov5(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+
+  Eigen::MatrixXd cov6;
+  EXPECT_NO_THROW(cov6 = stan::math::gp_matern_3_2_cov(x1_vec, x1_rvec, l,
+                                                       sigma, gamma));
+  EXPECT_EQ(3, cov6.rows());
+  EXPECT_EQ(3, cov6.cols());
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 3; k++) {
+        temp += stan::math::squared_distance(x1_vec[i], x1_rvec[j]) / l[k];
+      }
+      
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + gamma * pow(3.0, 0.5) * sqrt(temp))
+                      * std::exp(-1.0 * gamma * pow(3.0, 0.5) * sqrt(temp))
+                      , cov6(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+}
+
+TEST(MathPrimMat, domain_err_training_sig_l_gamma) {
+
+  double sigma = .2;
+  double l = 7;
+  double gamma = .8;
+  double sigma_bad = -1.0;
+  double l_bad = -1.0;
+
+  std::vector<double> l_vec(2);
+  l_vec[0] = 1;
+  l_vec[1] = 2;
+
+  std::vector<double> l_vec_bad(2);
+  l_vec_bad[0] = 1;
+  l_vec_bad[1] = -1;
+  
+  std::vector<double> x(3);
+  x[0] = -2;
+  x[1] = -1;
+  x[2] = -0.5;
+
+  std::vector<Eigen::Matrix<double, -1, 1> > x_2(3);
+  for (size_t i = 0; i < x_2.size(); ++i) {
+    x_2[i].resize(3, 1);
+    x_2[i] << 1, 2, 3;
+  }
+
+  std::vector<Eigen::Matrix<double, 1, -1> > x_3(3);
+  for (size_t i = 0; i < x_3.size(); ++i) {
+    x_3[i].resize(1, 3);
+    x_3[i] << 1, 2, 3;
+  }
+
+  std::string msg1, msg2, msg3, msg4;
+  msg1 = pull_msg(x, l_bad, sigma, gamma);
+  msg2 = pull_msg(x, l, sigma_bad, gamma);
+  msg3 = pull_msg(x, l_bad, sigma_bad, gamma);
+  EXPECT_TRUE(std::string::npos != msg1.find(" length-scale")) << msg1;
+  EXPECT_TRUE(std::string::npos != msg2.find(" marginal variance")) << msg2;
+  EXPECT_TRUE(std::string::npos != msg3.find(" length-scale")) << msg3;
+
+  msg1 = pull_msg(x, l_bad, sigma, gamma);
+  msg2 = pull_msg(x, l_vec, sigma_bad, gamma);
+  msg3 = pull_msg(x, l_bad, sigma_bad, gamma);
+  EXPECT_TRUE(std::string::npos != msg1.find(" length-scale")) << msg1;
+  EXPECT_TRUE(std::string::npos != msg2.find(" marginal variance")) << msg2;
+  EXPECT_TRUE(std::string::npos != msg3.find(" length-scale")) << msg3;
+
+  msg1 = pull_msg(x, l_vec_bad, sigma, gamma);
+  msg2 = pull_msg(x, l_vec_bad, sigma_bad, gamma);
+  msg3 = pull_msg(x, l_vec, sigma_bad, gamma);
+  EXPECT_TRUE(std::string::npos != msg1.find(" length-scale")) << msg1;
+  EXPECT_TRUE(std::string::npos != msg2.find(" length-scale")) << msg2;
+  EXPECT_TRUE(std::string::npos != msg3.find(" marginal variance")) << msg3;
+
+  msg1 = pull_msg(x_2, l_bad, sigma, gamma);
+  msg2 = pull_msg(x_2, l, sigma_bad, gamma);
+  msg3 = pull_msg(x_2, l_bad, sigma_bad, gamma);
+  EXPECT_TRUE(std::string::npos != msg1.find(" length-scale")) << msg1;
+  EXPECT_TRUE(std::string::npos != msg2.find(" marginal variance")) << msg2;
+  EXPECT_TRUE(std::string::npos != msg3.find(" length-scale")) << msg3;
+
+  msg1 = pull_msg(x_2, l_bad, sigma, gamma);
+  msg2 = pull_msg(x_2, l_vec, sigma_bad, gamma);
+  msg3 = pull_msg(x_2, l_bad, sigma_bad, gamma);
+  EXPECT_TRUE(std::string::npos != msg1.find(" length-scale")) << msg1;
+  EXPECT_TRUE(std::string::npos != msg2.find(" marginal variance")) << msg2;
+  EXPECT_TRUE(std::string::npos != msg3.find(" length-scale")) << msg3;
+
+  msg1 = pull_msg(x_2, l_vec_bad, sigma, gamma);
+  msg2 = pull_msg(x_2, l_vec_bad, sigma_bad, gamma);
+  msg3 = pull_msg(x_2, l_vec, sigma_bad, gamma);
+  EXPECT_TRUE(std::string::npos != msg1.find(" length-scale")) << msg1;
+  EXPECT_TRUE(std::string::npos != msg2.find(" length-scale")) << msg2;
+  EXPECT_TRUE(std::string::npos != msg3.find(" marginal variance")) << msg3;
+
+  msg1 = pull_msg(x_2, x_3, l_bad, sigma, gamma);
+  msg2 = pull_msg(x_2, x_3, l, sigma_bad, gamma);
+  msg3 = pull_msg(x_2, x_3, l_bad, sigma_bad, gamma);
+  EXPECT_TRUE(std::string::npos != msg1.find(" length-scale")) << msg1;
+  EXPECT_TRUE(std::string::npos != msg2.find(" marginal variance")) << msg2;
+  EXPECT_TRUE(std::string::npos != msg3.find(" length-scale")) << msg3;
+
+  msg1 = pull_msg(x_2, x_3, l_bad, sigma, gamma);
+  msg2 = pull_msg(x_2, x_3, l_vec, sigma_bad, gamma);
+  msg3 = pull_msg(x_2, x_3, l_bad, sigma_bad, gamma);
+  EXPECT_TRUE(std::string::npos != msg1.find(" length-scale")) << msg1;
+  EXPECT_TRUE(std::string::npos != msg2.find(" marginal variance")) << msg2;
+  EXPECT_TRUE(std::string::npos != msg3.find(" length-scale")) << msg3;
+
+  msg1 = pull_msg(x_2, x_3, l_vec_bad, sigma, gamma);
+  msg2 = pull_msg(x_2, x_3, l_vec_bad, sigma_bad, gamma);
+  msg3 = pull_msg(x_2, x_3, l_vec, sigma_bad, gamma);
+  EXPECT_TRUE(std::string::npos != msg1.find(" length-scale")) << msg1;
+  EXPECT_TRUE(std::string::npos != msg2.find(" length-scale")) << msg2;
+  EXPECT_TRUE(std::string::npos != msg3.find(" marginal variance")) << msg3;
+
+  msg1 = pull_msg(x_3, x_3, l_vec_bad, sigma, gamma);
+  msg2 = pull_msg(x_3, x_3, l_vec_bad, sigma_bad, gamma);
+  msg3 = pull_msg(x_3, x_3, l_vec, sigma_bad, gamma);
+  EXPECT_TRUE(std::string::npos != msg1.find(" length-scale")) << msg1;
+  EXPECT_TRUE(std::string::npos != msg2.find(" length-scale")) << msg2;
+  EXPECT_TRUE(std::string::npos != msg3.find(" marginal variance")) << msg3;
+
+  msg1 = pull_msg(x_2, x_2, l_vec_bad, sigma, gamma);
+  msg2 = pull_msg(x_2, x_2, l_vec_bad, sigma_bad, gamma);
+  msg3 = pull_msg(x_2, x_2, l_vec, sigma_bad, gamma);
+  EXPECT_TRUE(std::string::npos != msg1.find(" length-scale")) << msg1;
+  EXPECT_TRUE(std::string::npos != msg2.find(" length-scale")) << msg2;
+  EXPECT_TRUE(std::string::npos != msg3.find(" marginal variance")) << msg3; 
+  
+}
+
+
+TEST(MathPrimMat, nan_error_training_sig_l_gamma) {
+  double sigma = 0.2;
+  double l = 5;
+  double gamma = 1.0;
+
+  std::vector<double> x(3);
+  x[0] = -2;
+  x[1] = -1;
+  x[2] = -0.5;
+
+  std::vector<Eigen::Matrix<double, -1, 1> > x_2(3);
+  for (size_t i = 0; i < x_2.size(); ++i) {
+    x_2[i].resize(3, 1);
+    x_2[i] << 1, 2, 3;
+  }
+
+  std::vector<Eigen::Matrix<double, 1, -1> > x_3(3);
+  for (size_t i = 0; i < x_3.size(); ++i) {
+    x_3[i].resize(1, 3);
+    x_3[i] << 1, 2, 3;
+  }
+
+  std::vector<double> l_vec(2);
+  l_vec[0] = 1;
+  l_vec[1] = 2;
+
+  std::vector<double> l_vec_bad(2);
+  l_vec_bad[0] = 1;
+  l_vec_bad[1] = -1;
+  
+  std::vector<double> x_bad(x);
+  x_bad[1] = std::numeric_limits<double>::quiet_NaN();
+
+  std::vector<Eigen::Matrix<double, -1, 1> > x_bad_2(x_2);
+  x_bad_2[1](1) = std::numeric_limits<double>::quiet_NaN();
+
+  std::vector<Eigen::Matrix<double, 1, -1> > x_bad_3(x_3);
+  x_bad_3[1](1) = std::numeric_limits<double>::quiet_NaN();
+
+  double sigma_bad = std::numeric_limits<double>::quiet_NaN();
+  double l_bad = std::numeric_limits<double>::quiet_NaN();
+  double gamma_bad = std::numeric_limits<double>::quiet_NaN();
+  
+  std::string msg1, msg2, msg3, msg4;
+  msg1 = pull_msg(x, l_bad, sigma, gamma);
+  msg2 = pull_msg(x, l, sigma_bad, gamma);
+  msg3 = pull_msg(x, l, sigma, gamma_bad);
+  msg4 = pull_msg(x, l_bad, sigma_bad, gamma_bad);
+  EXPECT_TRUE(std::string::npos != msg1.find(" length-scale")) << msg1;
+  EXPECT_TRUE(std::string::npos != msg2.find(" marginal variance")) << msg2;
+  EXPECT_TRUE(std::string::npos != msg3.find(" gamma")) << msg3;
+  EXPECT_TRUE(std::string::npos != msg4.find(" length-scale")) << msg4;
+  
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x, l_bad, sigma, gamma),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x, l, sigma_bad, gamma),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x, l, sigma, gamma_bad),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x, l_bad, sigma_bad, gamma_bad),
+               std::domain_error);
+
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_bad, l, sigma, gamma),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_bad, l, sigma_bad, gamma),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_bad, l_bad, sigma_bad, gamma),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_bad, l_bad, sigma, gamma),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_bad, l, sigma, gamma_bad),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_bad, l_bad, sigma_bad,
+                                             gamma_bad),
+               std::domain_error);
+
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_2, l_bad, sigma, gamma),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_2, l, sigma_bad, gamma),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_2, l, sigma, gamma_bad),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_2, l_bad, sigma_bad, gamma_bad),
+               std::domain_error);
+  
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_bad_2, l_bad, sigma, gamma),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_bad_2, l, sigma_bad, gamma),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_bad_2, l, sigma, gamma_bad),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_bad_2, l_bad, sigma_bad,
+                                             gamma_bad),
+               std::domain_error);
+
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_3, l_bad, sigma, gamma),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_3, l, sigma_bad, gamma),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_3, l, sigma, gamma_bad),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_3, l_bad, sigma_bad, gamma_bad),
+               std::domain_error);
+  
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_bad_3, l_bad, sigma, gamma),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_bad_3, l, sigma_bad, gamma),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_bad_3, l, sigma, gamma_bad),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_bad_3, l_bad, sigma_bad,
+                                             gamma_bad),
+               std::domain_error);
+
+
+  EXPECT_TRUE(std::string::npos != msg1.find(" length-scale")) << msg1;
+  EXPECT_TRUE(std::string::npos != msg2.find(" marginal variance")) << msg2;
+  EXPECT_TRUE(std::string::npos != msg3.find(" gamma")) << msg3;
+  EXPECT_TRUE(std::string::npos != msg4.find(" length-scale")) << msg4;
+  
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x, l_vec_bad, sigma, gamma),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x, l_vec, sigma_bad, gamma),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x, l_vec, sigma, gamma_bad),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x, l_vec_bad, sigma_bad, gamma_bad),
+               std::domain_error);
+
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_bad, l_vec, sigma, gamma),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_bad, l_vec, sigma_bad, gamma),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_bad, l_vec_bad, sigma_bad, gamma),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_bad, l_vec_bad, sigma, gamma),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_bad, l_vec, sigma, gamma_bad),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_bad, l_vec_bad, sigma_bad,
+                                             gamma_bad),
+               std::domain_error);
+
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_2, l_vec_bad, sigma, gamma),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_2, l_vec, sigma_bad, gamma),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_2, l_vec, sigma, gamma_bad),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_2, l_vec_bad, sigma_bad, gamma_bad),
+               std::domain_error);
+  
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_bad_2, l_vec_bad, sigma, gamma),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_bad_2, l_vec, sigma_bad, gamma),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_bad_2, l_vec, sigma, gamma_bad),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_bad_2, l_vec_bad, sigma_bad,
+                                             gamma_bad),
+               std::domain_error);
+
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_3, l_vec_bad, sigma, gamma),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_3, l_vec, sigma_bad, gamma),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_3, l_vec, sigma, gamma_bad),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_3, l_vec_bad, sigma_bad, gamma_bad),
+               std::domain_error);
+  
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_bad_3, l_vec_bad, sigma, gamma),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_bad_3, l_vec, sigma_bad, gamma),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_bad_3, l_vec, sigma, gamma_bad),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_bad_3, l_vec_bad, sigma_bad,
+                                             gamma_bad),
+               std::domain_error);
+}
+
+TEST(MathPrimMat, dim_mismatch_vec_eigen_rvec_gp_matern_3_2_cov2) {
+  double sigma = 0.2;
+  double l = 5;
+  double gamma = -11;
+  
+  std::vector<Eigen::Matrix<double, 1, -1> > x_vec_1(3);
+  for (size_t i = 0; i < x_vec_1.size(); ++i) {
+    x_vec_1[i].resize(1, 3);
+    x_vec_1[i] << 1, 2, 3;
+  }
+
+  std::vector<Eigen::Matrix<double, 1, -1> > x_vec_2(4);
+  for (size_t i = 0; i < x_vec_2.size(); ++i) {
+    x_vec_2[i].resize(1, 4);
+    x_vec_2[i] << 4, 1, 3, 1;
+  }
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_vec_1, x_vec_2, l, sigma, gamma),
+               std::invalid_argument);
+}
+
+TEST(MathPrimMat, dim_mismatch_vec_eigen_mixed_gp_matern_3_2_cov) {
+  double sigma = 0.2;
+  double l = 5;
+  double gamma = -11;
+
+  std::vector<Eigen::Matrix<double, 1, -1> > x_rvec_1(3);
+  for (size_t i = 0; i < x_rvec_1.size(); ++i) {
+    x_rvec_1[i].resize(1, 3);
+    x_rvec_1[i] << 1, 2, 3;
+  }
+
+  std::vector<Eigen::Matrix<double, -1, 1> > x_vec_1(4);
+  for (size_t i = 0; i < x_vec_1.size(); ++i) {
+    x_vec_1[i].resize(4, 1);
+    x_vec_1[i] << 4, 1, 3, 1;
+  }
+
+  std::vector<Eigen::Matrix<double, -1, 1> > x_vec_2(3);
+  for (size_t i = 0; i < x_vec_2.size(); ++i) {
+    x_vec_2[i].resize(3, 1);
+    x_vec_2[i] << 1, 2, 3;
+  }
+
+  std::vector<Eigen::Matrix<double, 1, -1> > x_rvec_2(4);
+  for (size_t i = 0; i < x_rvec_2.size(); ++i) {
+    x_rvec_2[i].resize(1, 4);
+    x_rvec_2[i] << 1, 2, 3, 4;
+  }
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_rvec_1, x_vec_1, l, sigma, gamma),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_vec_1, x_rvec_1, l, sigma, gamma),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_rvec_2, x_vec_2, l, sigma, gamma),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_vec_2, x_rvec_2, l, sigma, gamma),
+               std::invalid_argument);
 }

--- a/test/unit/math/prim/mat/fun/gp_matern_3_2_cov_test.cpp
+++ b/test/unit/math/prim/mat/fun/gp_matern_3_2_cov_test.cpp
@@ -47,13 +47,14 @@ TEST(MathPrimMat, vec_double_gp_matern_3_2_cov1) {
   cov = stan::math::gp_matern_3_2_cov(x, l, sigma, gamma);
   for (int i = 0; i < 3; i++)
     for (int j = 0; j < 3; j++)
-      EXPECT_FLOAT_EQ(sigma * sigma *
-                          (1.0 +
-                           (pow(3.0, 0.5) / l) * gamma *
-                               stan::math::squared_distance(x[i], x[j])) *
-                          std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l) *
-                                   stan::math::squared_distance(x[i], x[j])),
-                      cov(i, j))
+      EXPECT_FLOAT_EQ(
+          sigma * sigma
+              * (1.0
+                 + (pow(3.0, 0.5) / l) * gamma
+                       * stan::math::squared_distance(x[i], x[j]))
+              * std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l)
+                         * stan::math::squared_distance(x[i], x[j])),
+          cov(i, j))
           << "index: (" << i << ", " << j << ")";
 }
 
@@ -83,9 +84,8 @@ TEST(MathPrimMat, vec_double_ard_gp_matern_3_2_cov1) {
         temp += stan::math::squared_distance(x[i], x[j]) / l[k];
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma *
-                          (1.0 + gamma * pow(3.0, 0.5) * sqrt(temp)) *
-                          std::exp(-1.0 * gamma * pow(3.0, 0.5) * sqrt(temp)),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + gamma * pow(3.0, 0.5) * sqrt(temp))
+                          * std::exp(-1.0 * gamma * pow(3.0, 0.5) * sqrt(temp)),
                       cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -107,13 +107,14 @@ TEST(MathPrimMat, vec_eigen_gp_matern_3_2_cov1) {
   cov = stan::math::gp_matern_3_2_cov(x1, l, sigma, gamma);
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
-      EXPECT_FLOAT_EQ(sigma * sigma *
-                          (1.0 +
-                           (pow(3.0, 0.5) / l) * gamma *
-                               stan::math::squared_distance(x1[i], x1[j])) *
-                          std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l) *
-                                   stan::math::squared_distance(x1[i], x1[j])),
-                      cov(i, j))
+      EXPECT_FLOAT_EQ(
+          sigma * sigma
+              * (1.0
+                 + (pow(3.0, 0.5) / l) * gamma
+                       * stan::math::squared_distance(x1[i], x1[j]))
+              * std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l)
+                         * stan::math::squared_distance(x1[i], x1[j])),
+          cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -140,13 +141,14 @@ TEST(MathPrimMat, vec_eigen_eigen_gp_matern_3_2_cov1) {
   cov = stan::math::gp_matern_3_2_cov(x1, x2, l, sigma, gamma);
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
-      EXPECT_FLOAT_EQ(sigma * sigma *
-                          (1.0 +
-                           (pow(3.0, 0.5) / l) * gamma *
-                               stan::math::squared_distance(x1[i], x2[j])) *
-                          std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l) *
-                                   stan::math::squared_distance(x1[i], x2[j])),
-                      cov(i, j))
+      EXPECT_FLOAT_EQ(
+          sigma * sigma
+              * (1.0
+                 + (pow(3.0, 0.5) / l) * gamma
+                       * stan::math::squared_distance(x1[i], x2[j]))
+              * std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l)
+                         * stan::math::squared_distance(x1[i], x2[j])),
+          cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -171,13 +173,14 @@ TEST(MathPrimMat, vec_double_double_gp_matern_3_2_cov1) {
   cov = stan::math::gp_matern_3_2_cov(x1, x2, l, sigma, gamma);
   for (int i = 0; i < 3; i++)
     for (int j = 0; j < 3; j++)
-      EXPECT_FLOAT_EQ(sigma * sigma *
-                          (1.0 +
-                           (pow(3.0, 0.5) / l) * gamma *
-                               stan::math::squared_distance(x1[i], x2[j])) *
-                          std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l) *
-                                   stan::math::squared_distance(x1[i], x2[j])),
-                      cov(i, j))
+      EXPECT_FLOAT_EQ(
+          sigma * sigma
+              * (1.0
+                 + (pow(3.0, 0.5) / l) * gamma
+                       * stan::math::squared_distance(x1[i], x2[j]))
+              * std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l)
+                         * stan::math::squared_distance(x1[i], x2[j])),
+          cov(i, j))
           << "index: (" << i << ", " << j << ")";
 }
 
@@ -208,9 +211,8 @@ TEST(MathPrimMat, vec_eigen_ard_gp_matern_3_2_cov1) {
         temp += stan::math::squared_distance(x1[i], x1[j]) / l[k];
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma *
-                          (1.0 + gamma * pow(3.0, 0.5) * sqrt(temp)) *
-                          std::exp(-1.0 * gamma * pow(3.0, 0.5) * sqrt(temp)),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + gamma * pow(3.0, 0.5) * sqrt(temp))
+                          * std::exp(-1.0 * gamma * pow(3.0, 0.5) * sqrt(temp)),
                       cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -247,8 +249,8 @@ TEST(MathPrimMat, vec_double_double_ard_gp_matern_3_2_cov1) {
         temp += stan::math::squared_distance(x1[i], x2[j]) / l[k];
       }
       EXPECT_FLOAT_EQ(
-          sigma * sigma * (1.0 + gamma * pow(3.0, 0.5) * pow(temp, 0.5)) *
-              std::exp(-1.0 * gamma * pow(3.0, 0.5) * pow(temp, 0.5)),
+          sigma * sigma * (1.0 + gamma * pow(3.0, 0.5) * pow(temp, 0.5))
+              * std::exp(-1.0 * gamma * pow(3.0, 0.5) * pow(temp, 0.5)),
           cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -287,8 +289,8 @@ TEST(MathPrimMat, vec_eigen_eigen_ard_gp_matern_3_2_cov1) {
         temp += stan::math::squared_distance(x1[i], x2[j]) / l[k];
       }
       EXPECT_FLOAT_EQ(
-          sigma * sigma * (1.0 + gamma * pow(3.0, 0.5) * pow(temp, 0.5)) *
-              std::exp(-1.0 * gamma * pow(3.0, 0.5) * pow(temp, 0.5)),
+          sigma * sigma * (1.0 + gamma * pow(3.0, 0.5) * pow(temp, 0.5))
+              * std::exp(-1.0 * gamma * pow(3.0, 0.5) * pow(temp, 0.5)),
           cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -310,13 +312,14 @@ TEST(MathPrimMat, rvec_eigen_gp_matern_3_2_cov1) {
   cov = stan::math::gp_matern_3_2_cov(x1, l, sigma, gamma);
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
-      EXPECT_FLOAT_EQ(sigma * sigma *
-                          (1.0 +
-                           (pow(3.0, 0.5) / l) * gamma *
-                               stan::math::squared_distance(x1[i], x1[j])) *
-                          std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l) *
-                                   stan::math::squared_distance(x1[i], x1[j])),
-                      cov(i, j))
+      EXPECT_FLOAT_EQ(
+          sigma * sigma
+              * (1.0
+                 + (pow(3.0, 0.5) / l) * gamma
+                       * stan::math::squared_distance(x1[i], x1[j]))
+              * std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l)
+                         * stan::math::squared_distance(x1[i], x1[j])),
+          cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -348,9 +351,8 @@ TEST(MathPrimMat, rvec_eigen_ard_gp_matern_3_2_cov1) {
         temp += stan::math::squared_distance(x1[i], x1[j]) / l[k];
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma *
-                          (1.0 + gamma * pow(3.0, 0.5) * sqrt(temp)) *
-                          std::exp(-1.0 * gamma * pow(3.0, 0.5) * sqrt(temp)),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + gamma * pow(3.0, 0.5) * sqrt(temp))
+                          * std::exp(-1.0 * gamma * pow(3.0, 0.5) * sqrt(temp)),
                       cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -378,13 +380,14 @@ TEST(MathPrimMat, vec_eigen_rvec_eigen_gp_matern_3_2_cov1) {
   cov = stan::math::gp_matern_3_2_cov(x1, x2, l, sigma, gamma);
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
-      EXPECT_FLOAT_EQ(sigma * sigma *
-                          (1.0 +
-                           (pow(3.0, 0.5) / l) * gamma *
-                               stan::math::squared_distance(x1[i], x2[j])) *
-                          std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l) *
-                                   stan::math::squared_distance(x1[i], x2[j])),
-                      cov(i, j))
+      EXPECT_FLOAT_EQ(
+          sigma * sigma
+              * (1.0
+                 + (pow(3.0, 0.5) / l) * gamma
+                       * stan::math::squared_distance(x1[i], x2[j]))
+              * std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l)
+                         * stan::math::squared_distance(x1[i], x2[j])),
+          cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -392,13 +395,14 @@ TEST(MathPrimMat, vec_eigen_rvec_eigen_gp_matern_3_2_cov1) {
   cov = stan::math::gp_matern_3_2_cov(x2, x1, l, sigma, gamma);
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
-      EXPECT_FLOAT_EQ(sigma * sigma *
-                          (1.0 +
-                           (pow(3.0, 0.5) / l) * gamma *
-                               stan::math::squared_distance(x2[i], x1[j])) *
-                          std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l) *
-                                   stan::math::squared_distance(x2[i], x1[j])),
-                      cov(i, j))
+      EXPECT_FLOAT_EQ(
+          sigma * sigma
+              * (1.0
+                 + (pow(3.0, 0.5) / l) * gamma
+                       * stan::math::squared_distance(x2[i], x1[j]))
+              * std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l)
+                         * stan::math::squared_distance(x2[i], x1[j])),
+          cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -434,9 +438,8 @@ TEST(MathPrimMat, vec_eigen_rvec_eigen_ard_gp_matern_3_2_cov1) {
         temp += stan::math::squared_distance(x1[i], x2[j]) / l[k];
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma *
-                          (1.0 + gamma * pow(3.0, 0.5) * sqrt(temp)) *
-                          std::exp(-1.0 * gamma * pow(3.0, 0.5) * sqrt(temp)),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + gamma * pow(3.0, 0.5) * sqrt(temp))
+                          * std::exp(-1.0 * gamma * pow(3.0, 0.5) * sqrt(temp)),
                       cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -449,9 +452,8 @@ TEST(MathPrimMat, vec_eigen_rvec_eigen_ard_gp_matern_3_2_cov1) {
         temp += stan::math::squared_distance(x2[i], x1[j]) / l[k];
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma *
-                          (1.0 + gamma * pow(3.0, 0.5) * sqrt(temp)) *
-                          std::exp(-1.0 * gamma * pow(3.0, 0.5) * sqrt(temp)),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + gamma * pow(3.0, 0.5) * sqrt(temp))
+                          * std::exp(-1.0 * gamma * pow(3.0, 0.5) * sqrt(temp)),
                       cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -479,13 +481,14 @@ TEST(MathPrimMat, rvec_eigen_rvec_eigen_gp_matern_3_2_cov1) {
   cov = stan::math::gp_matern_3_2_cov(x1, x2, l, sigma, gamma);
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
-      EXPECT_FLOAT_EQ(sigma * sigma *
-                          (1.0 +
-                           (pow(3.0, 0.5) / l) * gamma *
-                               stan::math::squared_distance(x1[i], x2[j])) *
-                          std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l) *
-                                   stan::math::squared_distance(x1[i], x2[j])),
-                      cov(i, j))
+      EXPECT_FLOAT_EQ(
+          sigma * sigma
+              * (1.0
+                 + (pow(3.0, 0.5) / l) * gamma
+                       * stan::math::squared_distance(x1[i], x2[j]))
+              * std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l)
+                         * stan::math::squared_distance(x1[i], x2[j])),
+          cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -493,13 +496,14 @@ TEST(MathPrimMat, rvec_eigen_rvec_eigen_gp_matern_3_2_cov1) {
   cov = stan::math::gp_matern_3_2_cov(x2, x1, l, sigma, gamma);
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
-      EXPECT_FLOAT_EQ(sigma * sigma *
-                          (1.0 +
-                           (pow(3.0, 0.5) / l) * gamma *
-                               stan::math::squared_distance(x2[i], x1[j])) *
-                          std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l) *
-                                   stan::math::squared_distance(x2[i], x1[j])),
-                      cov(i, j))
+      EXPECT_FLOAT_EQ(
+          sigma * sigma
+              * (1.0
+                 + (pow(3.0, 0.5) / l) * gamma
+                       * stan::math::squared_distance(x2[i], x1[j]))
+              * std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l)
+                         * stan::math::squared_distance(x2[i], x1[j])),
+          cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -536,9 +540,8 @@ TEST(MathPrimMat, rvec_eigen_rvec_eigen_ard_gp_matern_3_2_cov1) {
         temp += stan::math::squared_distance(x1[i], x2[j]) / l[k];
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma *
-                          (1.0 + gamma * pow(3.0, 0.5) * sqrt(temp)) *
-                          std::exp(-1.0 * gamma * pow(3.0, 0.5) * sqrt(temp)),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + gamma * pow(3.0, 0.5) * sqrt(temp))
+                          * std::exp(-1.0 * gamma * pow(3.0, 0.5) * sqrt(temp)),
                       cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -551,9 +554,8 @@ TEST(MathPrimMat, rvec_eigen_rvec_eigen_ard_gp_matern_3_2_cov1) {
         temp += stan::math::squared_distance(x2[i], x1[j]) / l[k];
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma *
-                          (1.0 + gamma * pow(3.0, 0.5) * sqrt(temp)) *
-                          std::exp(-1.0 * gamma * pow(3.0, 0.5) * sqrt(temp)),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + gamma * pow(3.0, 0.5) * sqrt(temp))
+                          * std::exp(-1.0 * gamma * pow(3.0, 0.5) * sqrt(temp)),
                       cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -599,12 +601,12 @@ TEST(MathPrimMat, vec_eigen_mixed_gp_matern_3_2_cov2) {
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-          sigma * sigma *
-              (1.0 +
-               (pow(3.0, 0.5) / l) * gamma *
-                   stan::math::squared_distance(x1_rvec[i], x2_vec[j])) *
-              std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l) *
-                       stan::math::squared_distance(x1_rvec[i], x2_vec[j])),
+          sigma * sigma
+              * (1.0
+                 + (pow(3.0, 0.5) / l) * gamma
+                       * stan::math::squared_distance(x1_rvec[i], x2_vec[j]))
+              * std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l)
+                         * stan::math::squared_distance(x1_rvec[i], x2_vec[j])),
           cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -618,12 +620,12 @@ TEST(MathPrimMat, vec_eigen_mixed_gp_matern_3_2_cov2) {
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-          sigma * sigma *
-              (1.0 +
-               (pow(3.0, 0.5) / l) * gamma *
-                   stan::math::squared_distance(x2_vec[i], x1_rvec[j])) *
-              std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l) *
-                       stan::math::squared_distance(x2_vec[i], x1_rvec[j])),
+          sigma * sigma
+              * (1.0
+                 + (pow(3.0, 0.5) / l) * gamma
+                       * stan::math::squared_distance(x2_vec[i], x1_rvec[j]))
+              * std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l)
+                         * stan::math::squared_distance(x2_vec[i], x1_rvec[j])),
           cov7(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -636,12 +638,12 @@ TEST(MathPrimMat, vec_eigen_mixed_gp_matern_3_2_cov2) {
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-          sigma * sigma *
-              (1.0 +
-               (pow(3.0, 0.5) / l) * gamma *
-                   stan::math::squared_distance(x1_vec[i], x2_rvec[j])) *
-              std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l) *
-                       stan::math::squared_distance(x1_vec[i], x2_rvec[j])),
+          sigma * sigma
+              * (1.0
+                 + (pow(3.0, 0.5) / l) * gamma
+                       * stan::math::squared_distance(x1_vec[i], x2_rvec[j]))
+              * std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l)
+                         * stan::math::squared_distance(x1_vec[i], x2_rvec[j])),
           cov2(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -655,12 +657,12 @@ TEST(MathPrimMat, vec_eigen_mixed_gp_matern_3_2_cov2) {
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-          sigma * sigma *
-              (1.0 +
-               (pow(3.0, 0.5) / l) * gamma *
-                   stan::math::squared_distance(x2_rvec[i], x1_vec[j])) *
-              std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l) *
-                       stan::math::squared_distance(x2_rvec[i], x1_vec[j])),
+          sigma * sigma
+              * (1.0
+                 + (pow(3.0, 0.5) / l) * gamma
+                       * stan::math::squared_distance(x2_rvec[i], x1_vec[j]))
+              * std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l)
+                         * stan::math::squared_distance(x2_rvec[i], x1_vec[j])),
           cov8(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -674,12 +676,12 @@ TEST(MathPrimMat, vec_eigen_mixed_gp_matern_3_2_cov2) {
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-          sigma * sigma *
-              (1.0 +
-               (pow(3.0, 0.5) / l) * gamma *
-                   stan::math::squared_distance(x2_vec[i], x2_rvec[j])) *
-              std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l) *
-                       stan::math::squared_distance(x2_vec[i], x2_rvec[j])),
+          sigma * sigma
+              * (1.0
+                 + (pow(3.0, 0.5) / l) * gamma
+                       * stan::math::squared_distance(x2_vec[i], x2_rvec[j]))
+              * std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l)
+                         * stan::math::squared_distance(x2_vec[i], x2_rvec[j])),
           cov3(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -693,12 +695,12 @@ TEST(MathPrimMat, vec_eigen_mixed_gp_matern_3_2_cov2) {
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-          sigma * sigma *
-              (1.0 +
-               (pow(3.0, 0.5) / l) * gamma *
-                   stan::math::squared_distance(x2_rvec[i], x2_vec[j])) *
-              std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l) *
-                       stan::math::squared_distance(x2_rvec[i], x2_vec[j])),
+          sigma * sigma
+              * (1.0
+                 + (pow(3.0, 0.5) / l) * gamma
+                       * stan::math::squared_distance(x2_rvec[i], x2_vec[j]))
+              * std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l)
+                         * stan::math::squared_distance(x2_rvec[i], x2_vec[j])),
           cov4(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -712,12 +714,12 @@ TEST(MathPrimMat, vec_eigen_mixed_gp_matern_3_2_cov2) {
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-          sigma * sigma *
-              (1.0 +
-               (pow(3.0, 0.5) / l) * gamma *
-                   stan::math::squared_distance(x1_rvec[i], x1_vec[j])) *
-              std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l) *
-                       stan::math::squared_distance(x1_rvec[i], x1_vec[j])),
+          sigma * sigma
+              * (1.0
+                 + (pow(3.0, 0.5) / l) * gamma
+                       * stan::math::squared_distance(x1_rvec[i], x1_vec[j]))
+              * std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l)
+                         * stan::math::squared_distance(x1_rvec[i], x1_vec[j])),
           cov5(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -731,12 +733,12 @@ TEST(MathPrimMat, vec_eigen_mixed_gp_matern_3_2_cov2) {
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-          sigma * sigma *
-              (1.0 +
-               (pow(3.0, 0.5) / l) * gamma *
-                   stan::math::squared_distance(x1_vec[i], x1_rvec[j])) *
-              std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l) *
-                       stan::math::squared_distance(x1_vec[i], x1_rvec[j])),
+          sigma * sigma
+              * (1.0
+                 + (pow(3.0, 0.5) / l) * gamma
+                       * stan::math::squared_distance(x1_vec[i], x1_rvec[j]))
+              * std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l)
+                         * stan::math::squared_distance(x1_vec[i], x1_rvec[j])),
           cov6(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -791,9 +793,8 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_matern_3_2_cov2) {
         temp += stan::math::squared_distance(x1_rvec[i], x2_vec[j]) / l[k];
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma *
-                          (1.0 + gamma * pow(3.0, 0.5) * sqrt(temp)) *
-                          std::exp(-1.0 * gamma * pow(3.0, 0.5) * sqrt(temp)),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + gamma * pow(3.0, 0.5) * sqrt(temp))
+                          * std::exp(-1.0 * gamma * pow(3.0, 0.5) * sqrt(temp)),
                       cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -811,9 +812,8 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_matern_3_2_cov2) {
         temp += stan::math::squared_distance(x2_vec[i], x1_rvec[j]) / l[k];
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma *
-                          (1.0 + gamma * pow(3.0, 0.5) * sqrt(temp)) *
-                          std::exp(-1.0 * gamma * pow(3.0, 0.5) * sqrt(temp)),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + gamma * pow(3.0, 0.5) * sqrt(temp))
+                          * std::exp(-1.0 * gamma * pow(3.0, 0.5) * sqrt(temp)),
                       cov7(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -831,9 +831,8 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_matern_3_2_cov2) {
         temp += stan::math::squared_distance(x1_vec[i], x2_rvec[j]) / l[k];
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma *
-                          (1.0 + gamma * pow(3.0, 0.5) * sqrt(temp)) *
-                          std::exp(-1.0 * gamma * pow(3.0, 0.5) * sqrt(temp)),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + gamma * pow(3.0, 0.5) * sqrt(temp))
+                          * std::exp(-1.0 * gamma * pow(3.0, 0.5) * sqrt(temp)),
                       cov2(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -851,9 +850,8 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_matern_3_2_cov2) {
         temp += stan::math::squared_distance(x2_rvec[i], x1_vec[j]) / l[k];
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma *
-                          (1.0 + gamma * pow(3.0, 0.5) * sqrt(temp)) *
-                          std::exp(-1.0 * gamma * pow(3.0, 0.5) * sqrt(temp)),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + gamma * pow(3.0, 0.5) * sqrt(temp))
+                          * std::exp(-1.0 * gamma * pow(3.0, 0.5) * sqrt(temp)),
                       cov8(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -871,9 +869,8 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_matern_3_2_cov2) {
         temp += stan::math::squared_distance(x2_vec[i], x2_rvec[j]) / l[k];
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma *
-                          (1.0 + gamma * pow(3.0, 0.5) * sqrt(temp)) *
-                          std::exp(-1.0 * gamma * pow(3.0, 0.5) * sqrt(temp)),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + gamma * pow(3.0, 0.5) * sqrt(temp))
+                          * std::exp(-1.0 * gamma * pow(3.0, 0.5) * sqrt(temp)),
                       cov3(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -891,9 +888,8 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_matern_3_2_cov2) {
         temp += stan::math::squared_distance(x2_rvec[i], x2_vec[j]) / l[k];
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma *
-                          (1.0 + gamma * pow(3.0, 0.5) * sqrt(temp)) *
-                          std::exp(-1.0 * gamma * pow(3.0, 0.5) * sqrt(temp)),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + gamma * pow(3.0, 0.5) * sqrt(temp))
+                          * std::exp(-1.0 * gamma * pow(3.0, 0.5) * sqrt(temp)),
                       cov4(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -911,9 +907,8 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_matern_3_2_cov2) {
         temp += stan::math::squared_distance(x1_rvec[i], x1_vec[j]) / l[k];
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma *
-                          (1.0 + gamma * pow(3.0, 0.5) * sqrt(temp)) *
-                          std::exp(-1.0 * gamma * pow(3.0, 0.5) * sqrt(temp)),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + gamma * pow(3.0, 0.5) * sqrt(temp))
+                          * std::exp(-1.0 * gamma * pow(3.0, 0.5) * sqrt(temp)),
                       cov5(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -931,9 +926,8 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_matern_3_2_cov2) {
         temp += stan::math::squared_distance(x1_vec[i], x1_rvec[j]) / l[k];
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma *
-                          (1.0 + gamma * pow(3.0, 0.5) * sqrt(temp)) *
-                          std::exp(-1.0 * gamma * pow(3.0, 0.5) * sqrt(temp)),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + gamma * pow(3.0, 0.5) * sqrt(temp))
+                          * std::exp(-1.0 * gamma * pow(3.0, 0.5) * sqrt(temp)),
                       cov6(i, j))
           << "index: (" << i << ", " << j << ")";
     }

--- a/test/unit/math/prim/mat/fun/gp_matern_3_2_cov_test.cpp
+++ b/test/unit/math/prim/mat/fun/gp_matern_3_2_cov_test.cpp
@@ -1,0 +1,111 @@
+#include <stan/math/prim/mat.hpp>
+#include <gtest/gtest.h>
+#include <limits>
+#include <string>
+#include <vector>
+
+// temp:
+#include <cmath>
+
+template <typename T_x, typename T_l, typename T_s, typename T_g>
+std::string pull_msg(std::vector<T_x> x, T_l l, T_s sigma, T_g gamma) {
+  std::string message;
+  try {
+    stan::math::gp_matern_3_2_cov(x, l, sigma, gamma);
+  } catch (std::domain_error& e) {
+    message = e.what();
+  } catch (...) {
+    message = "Threw the wrong exception";
+  }
+  return message;
+}
+
+TEST(MathPrimMat, vec_double_gp_matern_3_2_cov1){
+  double sigma = 0.2;
+  double gamma = 1.2;
+  double l = 5.0;
+
+  std::vector<double> x(3);
+  x[0] = -2;
+  x[1] = -1;
+  x[2] = -0.5;
+
+  Eigen::MatrixXd cov;
+  cov = stan::math::gp_matern_3_2_cov(x, l, sigma, gamma);
+  for (int i = 0; i < 3; i++)
+    for (int j = 0; j < 3; j++)
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + (pow(3.0, 0.5) / l) * gamma *
+                                       abs(x[i] - x[j])) *
+                      std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l) *
+                               abs(x[i] - x[j])),
+                      cov(i, j))
+        << "index: (" << i << ", " << j << ")";
+}
+
+TEST(MathPrimMat, vec_double_ard_gp_matern_3_2_cov1) {
+  double sigma = 0.2;
+  double gamma = 1.2;
+  double temp; 
+  
+  std::vector<double> x(3);
+  x[0] = -2;
+  x[1] = -1;
+  x[2] = -0.5;
+
+  std::vector<double> l(5);
+  l[0] = 0.1;
+  l[1] = 0.2;
+  l[2] = 0.3;
+  l[3] = 0.4;
+  l[4] = 0.5;
+  
+  Eigen::MatrixXd cov;
+  cov = stan::math::gp_matern_3_2_cov(x, l, sigma, gamma);
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 5; k++) {
+        temp += (1.0 + gamma * pow(3.0, 0.5) * abs(x[i] - x[j]) / l[k]) *
+          exp(-1.0 * gamma * pow(3.0, 0.5) * abs(x[i] - x[j]) / l[k]);
+      }
+      EXPECT_FLOAT_EQ(sigma * sigma * temp,
+                      cov(i, j))
+        << "index: (" << i << ", " << j << ")";
+    }
+  }
+}
+
+TEST(MathPrimMat, vec_eigen_gp_matern_3_2_cov1) {
+  double l = 0.2;
+  double sigma = 0.3;
+  double gamma = 0.5;
+  double distance = 0;
+
+  std::vector<Eigen::Matrix<double, 1, -1> > x1(3);
+  std::vector<Eigen::Matrix<double, 1, -1> > x2(4);
+  for (size_t i = 0; i < x1.size(); ++i) {
+    x1[i].resize(1, 3);
+    x1[i] << 1 * i, 2 * i, 3 * i;
+  }
+
+  for (size_t i = 0; i < x2.size(); ++i) {
+    x2[i].resize(1, 3);
+    x2[i] << 2 * i, 3 * i, 4 * i;
+  }
+  
+  Eigen::MatrixXd cov;
+  cov = stan::math::gp_matern_3_2_cov(x1, x2, l, sigma, gamma);
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      distance = 0;
+      for (int k = 0; k < 3; k++)
+        distance += abs(x1[i][k] - x2[j][k]);
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + (pow(3.0, 0.5) / l) * gamma *
+                                       distance) *
+                      std::exp(-1.0 * gamma * (pow(3.0, 0.5) / l) *
+                               distance),
+                      cov(i, j))
+        << "index: (" << i << ", " << j << ")";
+    }
+  }
+}

--- a/test/unit/math/prim/mat/fun/gp_matern_3_2_cov_test.cpp
+++ b/test/unit/math/prim/mat/fun/gp_matern_3_2_cov_test.cpp
@@ -1,8 +1,8 @@
-#include <cmath>
 #include <gtest/gtest.h>
-#include <limits>
 #include <stan/math/prim/mat.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <cmath>
+#include <limits>
 #include <string>
 #include <vector>
 

--- a/test/unit/math/prim/mat/fun/gp_matern_3_2_cov_test.cpp
+++ b/test/unit/math/prim/mat/fun/gp_matern_3_2_cov_test.cpp
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+#include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/mat.hpp>
 #include <cmath>
 #include <limits>


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary:
Add a Matern 3/2 Kernel (Covariance Function) to Prim library, with ARD prior support.

#### How to Verify:
Tests include, but are not limited to:
      vec double
      vec double double
      vec double ARD
      vec eigen
      vec eigen eigen
      vec eigen ARD
      vec double double ARD
      rvec eigen
      rvec eigen ARD
      vec eigne rvec eigen
      vec eigen rvec eigen ARD
      rvec eigen rvec eigen
      rvec eigen rvec eigen ARD
      eigen mixed
      eigen mixed ARD
      double domain err training
      nan error training
      differing x lengths
#### Documentation:
doxygen

#### Copyright and Licensing

Copyright <2018> <Andre Zapico>
Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
