### PR TITLE
add gp exponential cov prim

### DIFF
--- a/stan/math/prim/mat.hpp
+++ b/stan/math/prim/mat.hpp
@@ -119,6 +119,7 @@
 #include <stan/math/prim/mat/fun/get_base1.hpp>
 #include <stan/math/prim/mat/fun/get_base1_lhs.hpp>
 #include <stan/math/prim/mat/fun/get_lp.hpp>
+#include <stan/math/prim/mat/fun/gp_exponential_cov.hpp>
 #include <stan/math/prim/mat/fun/head.hpp>
 #include <stan/math/prim/mat/fun/initialize.hpp>
 #include <stan/math/prim/mat/fun/inv.hpp>

--- a/stan/math/prim/mat/fun/gp_exponential_cov.hpp
+++ b/stan/math/prim/mat/fun/gp_exponential_cov.hpp
@@ -1,0 +1,246 @@
+#ifndef STAN_MATH_PRIM_MAT_FUN_GP_EXPONENTIAL_COV_HPP
+#define STAN_MATH_PRIM_MAT_FUN_GP_EXPONENTIAL_COV_HPP
+
+#include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <stan/math/prim/scal/fun/square.hpp>
+#include <stan/math/prim/scal/fun/squared_distance.hpp>
+#include <stan/math/prim/scal/meta/return_type.hpp>
+#include <cmath>
+#include <vector>
+
+namespace stan {
+namespace math {
+
+/** Returns a Matern exponential covariance matrix with one input vector
+ *
+ * \f[ k(x, x') = \sigma^2 exp(-\frac{\sqrt{(x - x')^2}}{l^2}) \f]
+ *
+ * See Rausmussen & Williams et al 2006 Chapter 4.
+ *
+ * @param x std::vector of elements that can be used in stan::math::distance
+ * @param length_scale length scale
+ * @param sigma standard deviation that can be used in stan::math::square
+ * @throw std::domain error if sigma <= 0, l <= 0, or x is nan or inf
+ *
+ */
+template <typename T_x, typename T_s, typename T_l>
+inline typename Eigen::Matrix<typename stan::return_type<T_x, T_s, T_l>::type,
+                              Eigen::Dynamic, Eigen::Dynamic>
+gp_exponential_cov(const std::vector<T_x>& x, const T_s &sigma,
+                  const T_l &length_scale) {
+  using stan::math::squared_distance;
+  using stan::math::square;
+  using std::exp;
+  using std::pow;
+
+  size_t x_size = x.size();
+  for (size_t n = 0; n < x_size; ++n)
+    check_not_nan("gp_exponential_cov", "x", x[n]);
+
+  check_positive("gp_exponential_cov", "marginal variance", sigma);
+  check_not_nan("gp_exponential_cov", "marginal variance", sigma);
+
+  check_positive("gp_exponential_cov", "length-scale", length_scale);
+  check_not_nan("gp_exponential_cov", "length-scale", length_scale);
+
+  Eigen::Matrix<typename stan::return_type<T_x, T_s, T_l>::type,
+                Eigen::Dynamic, Eigen::Dynamic>
+    cov(x_size, x_size);
+
+  if (x_size == 0)
+    return cov;
+
+  T_s sigma_sq = square(sigma);
+  T_l neg_inv_l_sq = -1.0 / square(length_scale);
+
+  for (size_t i = 0; i < (x_size - 1); ++i) {
+    cov(i, i) = sigma_sq;
+    for (size_t j = i + 1; j < x_size; ++j) {
+      cov(i, j) = sigma_sq * exp(neg_inv_l_sq * squared_distance(x[i], x[j]));
+      cov(j, i) = cov(i, j);
+    }
+  }
+  cov(x_size - 1, x_size - 1) = sigma_sq;
+  return cov;
+}
+
+/** Returns a Matern exponential covariance matrix with one input vector
+ *  with automatic relevance determination (ARD) priors
+ *
+ * \f[ k(x, x') = \sigma^2 exp(-\sum_{k=1}^K\frac{\sqrt{(x - x')^2}}{l_k^2}) \f]
+ *
+ * See Rausmussen & Williams et al 2006 Chapter 4.
+ *
+ * @param x std::vector of elements that can be used in stan::math::distance
+ * @param length_scale length scale
+ * @param sigma standard deviation that can be used in stan::math::square
+ * @throw std::domain error if sigma <= 0, l <= 0, or x is nan or inf
+ *
+ */
+template <typename T_x, typename T_s, typename T_l>
+inline typename Eigen::Matrix<typename stan::return_type<T_x, T_s, T_l>::type,
+                              Eigen::Dynamic, Eigen::Dynamic>
+gp_exponential_cov(const std::vector<T_x>& x, const T_s &sigma,
+                  const std::vector<T_l> &length_scale) {
+  using stan::math::squared_distance;
+  using stan::math::square;
+  using std::exp;
+  using std::pow;
+
+  size_t x_size = x.size();
+  size_t l_size = length_scale.size();
+  for (size_t n = 0; n < x_size; ++n)
+    check_not_nan("gp_exponential_cov", "x", x[n]);
+
+  check_positive("gp_exponential_cov", "marginal variance", sigma);
+  check_not_nan("gp_exponential_cov", "marginal variance", sigma);
+
+  check_positive("gp_exponential_cov", "length-scale", length_scale);
+  check_not_nan("gp_exponential_cov", "length-scale", length_scale);
+
+  Eigen::Matrix<typename stan::return_type<T_x, T_s, T_l>::type,
+                Eigen::Dynamic, Eigen::Dynamic>
+    cov(x_size, x_size);
+
+  if (x_size == 0)
+    return cov;
+
+  T_s sigma_sq = square(sigma);
+  T_l temp;
+
+  for (size_t i = 0; i < (x_size - 1); ++i) {
+    cov(i, i) = sigma_sq;
+    for (size_t j = i + 1; j < x_size; ++j) {
+      temp = 0;
+      for (size_t k = 0; k < l_size; ++k)
+        temp += squared_distance(x[i], x[j]) / square(length_scale[k]);
+      cov(i, j) = sigma_sq * exp(-1.0 * temp);
+      cov(j, i) = cov(i, j);
+    }
+  }
+  cov(x_size - 1, x_size - 1) = sigma_sq;
+  return cov;
+}
+
+/** Returns a Matern exponential covariance matrix with two input vectors
+ *
+ * \f[ k(x, x') = \sigma^2 exp(-\frac{\sqrt{(x - x')^2}}{l^2}) \f]
+ *
+ * See Rausmussen & Williams et al 2006 Chapter 4.
+ *
+ * @param x1 std::vector of elements that can be used in stan::math::distance
+ * @param x2 std::vector of elements that can be used in stan::math::distance
+ * @param length_scale length scale
+ * @param sigma standard deviation that can be used in stan::math::square
+ * @throw std::domain error if sigma <= 0, l <= 0, or x is nan or inf
+ *
+ */
+template <typename T_x1, typename T_x2, typename T_s, typename T_l>
+inline typename Eigen::Matrix<typename stan::return_type<T_x1, T_x2,
+                                                         T_s, T_l>::type,
+                              Eigen::Dynamic, Eigen::Dynamic>
+gp_exponential_cov(const std::vector<T_x1>& x1, const std::vector<T_x2>& x2,
+                  const T_s &sigma, const T_l &length_scale) {
+  using stan::math::squared_distance;
+  using stan::math::square;
+  using std::exp;
+  using std::pow;
+
+  size_t x1_size = x1.size();
+  size_t x2_size = x2.size();
+
+  for (size_t n = 0; n < x1_size; ++n)
+    check_not_nan("gp_exponential_cov", "x1", x1[n]);
+  for (size_t n = 0; n < x2_size; ++n)
+    check_not_nan("gp_exponential_cov", "x2", x2[n]);
+
+  check_positive("gp_exponential_cov", "marginal variance", sigma);
+  check_not_nan("gp_exponential_cov", "marginal variance", sigma);
+
+  check_positive("gp_exponential_cov", "length-scale", length_scale);
+  check_not_nan("gp_exponential_cov", "length-scale", length_scale);
+
+  Eigen::Matrix<typename stan::return_type<T_x1, T_x2, T_s, T_l>::type,
+                Eigen::Dynamic, Eigen::Dynamic>
+    cov(x1_size, x2_size);
+
+  if (x1_size == 0 || x2_size == 0)
+    return cov;
+
+  T_s sigma_sq = square(sigma);
+  T_l neg_inv_l_sq = -1.0 / square(length_scale);
+
+  for (size_t i = 0; i < x1_size; ++i) {
+    for (size_t j = 0; j < x2_size; ++j) {
+      cov(i, j) = sigma_sq * exp(neg_inv_l_sq * squared_distance(x1[i], x2[j]));
+    }
+  }
+  return cov;
+}
+
+/** Returns a Matern exponential covariance matrix with two input vectors
+ *  with automatic relevance determination (ARD) priors
+ *
+ * \f[ k(x, x') = \sigma^2 exp(-\sum_{k=1}^K\frac{\sqrt{(x - x')^2}}{l_k^2}) \f]
+ *
+ * See Rausmussen & Williams et al 2006 Chapter 4.
+ *
+ * @param x1 std::vector of elements that can be used in stan::math::distance
+ * @param x2 std::vector of elements that can be used in stan::math::distance
+ * @param length_scale length scale
+ * @param sigma standard deviation that can be used in stan::math::square
+ * @throw std::domain error if sigma <= 0, l <= 0, or x is nan or inf
+ *
+ */
+template <typename T_x1, typename T_x2, typename T_s, typename T_l>
+inline typename Eigen::Matrix<typename stan::return_type<T_x1, T_x2,
+                                                         T_s, T_l>::type,
+                              Eigen::Dynamic, Eigen::Dynamic>
+gp_exponential_cov(const std::vector<T_x1>& x1, const std::vector<T_x2>& x2,
+                  const T_s &sigma, const std::vector<T_l> &length_scale) {
+  using stan::math::squared_distance;
+  using stan::math::square;
+  using std::exp;
+  using std::pow;
+
+  size_t x1_size = x1.size();
+  size_t x2_size = x2.size();
+
+  for (size_t n = 0; n < x1_size; ++n)
+    check_not_nan("gp_exponential_cov", "x1", x1[n]);
+  for (size_t n = 0; n < x2_size; ++n)
+    check_not_nan("gp_exponential_cov", "x2", x2[n]);
+
+  check_positive("gp_exponential_cov", "marginal variance", sigma);
+  check_not_nan("gp_exponential_cov", "marginal variance", sigma);
+
+  check_positive("gp_exponential_cov", "length-scale", length_scale);
+  size_t l_size = length_scale.size();
+  for (size_t n = 0; n < l_size; ++n)
+    check_not_nan("gp_exponential_cov", "length-scale", length_scale[n]);
+
+  Eigen::Matrix<typename stan::return_type<T_x1, T_x2, T_s, T_l>::type,
+                Eigen::Dynamic, Eigen::Dynamic>
+    cov(x1_size, x2_size);
+
+  if (x1_size == 0 || x2_size == 0)
+    return cov;
+
+  T_s sigma_sq = square(sigma);
+  T_l temp;
+
+  for (size_t i = 0; i < x1_size; ++i) {
+    for (size_t j = 0; j < x2_size; ++j) {
+      temp = 0;
+      for (size_t k = 0; k < l_size; ++k)
+        temp += squared_distance(x1[i], x2[j]) / square(length_scale[k]);
+      cov(i, j) = sigma_sq * exp(-1.0 * temp);
+    }
+  }
+  return cov;
+}
+
+}  // namespace math
+}  // namespace stan
+
+#endif

--- a/stan/math/prim/mat/fun/gp_exponential_cov.hpp
+++ b/stan/math/prim/mat/fun/gp_exponential_cov.hpp
@@ -26,10 +26,10 @@ namespace math {
 template <typename T_x, typename T_s, typename T_l>
 inline typename Eigen::Matrix<typename stan::return_type<T_x, T_s, T_l>::type,
                               Eigen::Dynamic, Eigen::Dynamic>
-gp_exponential_cov(const std::vector<T_x>& x, const T_s &sigma,
-                  const T_l &length_scale) {
-  using stan::math::squared_distance;
+gp_exponential_cov(const std::vector<T_x> &x, const T_s &sigma,
+                   const T_l &length_scale) {
   using stan::math::square;
+  using stan::math::squared_distance;
   using std::exp;
   using std::pow;
 
@@ -43,9 +43,9 @@ gp_exponential_cov(const std::vector<T_x>& x, const T_s &sigma,
   check_positive("gp_exponential_cov", "length-scale", length_scale);
   check_not_nan("gp_exponential_cov", "length-scale", length_scale);
 
-  Eigen::Matrix<typename stan::return_type<T_x, T_s, T_l>::type,
-                Eigen::Dynamic, Eigen::Dynamic>
-    cov(x_size, x_size);
+  Eigen::Matrix<typename stan::return_type<T_x, T_s, T_l>::type, Eigen::Dynamic,
+                Eigen::Dynamic>
+      cov(x_size, x_size);
 
   if (x_size == 0)
     return cov;
@@ -80,10 +80,10 @@ gp_exponential_cov(const std::vector<T_x>& x, const T_s &sigma,
 template <typename T_x, typename T_s, typename T_l>
 inline typename Eigen::Matrix<typename stan::return_type<T_x, T_s, T_l>::type,
                               Eigen::Dynamic, Eigen::Dynamic>
-gp_exponential_cov(const std::vector<T_x>& x, const T_s &sigma,
-                  const std::vector<T_l> &length_scale) {
-  using stan::math::squared_distance;
+gp_exponential_cov(const std::vector<T_x> &x, const T_s &sigma,
+                   const std::vector<T_l> &length_scale) {
   using stan::math::square;
+  using stan::math::squared_distance;
   using std::exp;
   using std::pow;
 
@@ -98,9 +98,9 @@ gp_exponential_cov(const std::vector<T_x>& x, const T_s &sigma,
   check_positive("gp_exponential_cov", "length-scale", length_scale);
   check_not_nan("gp_exponential_cov", "length-scale", length_scale);
 
-  Eigen::Matrix<typename stan::return_type<T_x, T_s, T_l>::type,
-                Eigen::Dynamic, Eigen::Dynamic>
-    cov(x_size, x_size);
+  Eigen::Matrix<typename stan::return_type<T_x, T_s, T_l>::type, Eigen::Dynamic,
+                Eigen::Dynamic>
+      cov(x_size, x_size);
 
   if (x_size == 0)
     return cov;
@@ -136,13 +136,13 @@ gp_exponential_cov(const std::vector<T_x>& x, const T_s &sigma,
  *
  */
 template <typename T_x1, typename T_x2, typename T_s, typename T_l>
-inline typename Eigen::Matrix<typename stan::return_type<T_x1, T_x2,
-                                                         T_s, T_l>::type,
-                              Eigen::Dynamic, Eigen::Dynamic>
-gp_exponential_cov(const std::vector<T_x1>& x1, const std::vector<T_x2>& x2,
-                  const T_s &sigma, const T_l &length_scale) {
-  using stan::math::squared_distance;
+inline typename Eigen::Matrix<
+    typename stan::return_type<T_x1, T_x2, T_s, T_l>::type, Eigen::Dynamic,
+    Eigen::Dynamic>
+gp_exponential_cov(const std::vector<T_x1> &x1, const std::vector<T_x2> &x2,
+                   const T_s &sigma, const T_l &length_scale) {
   using stan::math::square;
+  using stan::math::squared_distance;
   using std::exp;
   using std::pow;
 
@@ -162,7 +162,7 @@ gp_exponential_cov(const std::vector<T_x1>& x1, const std::vector<T_x2>& x2,
 
   Eigen::Matrix<typename stan::return_type<T_x1, T_x2, T_s, T_l>::type,
                 Eigen::Dynamic, Eigen::Dynamic>
-    cov(x1_size, x2_size);
+      cov(x1_size, x2_size);
 
   if (x1_size == 0 || x2_size == 0)
     return cov;
@@ -193,13 +193,13 @@ gp_exponential_cov(const std::vector<T_x1>& x1, const std::vector<T_x2>& x2,
  *
  */
 template <typename T_x1, typename T_x2, typename T_s, typename T_l>
-inline typename Eigen::Matrix<typename stan::return_type<T_x1, T_x2,
-                                                         T_s, T_l>::type,
-                              Eigen::Dynamic, Eigen::Dynamic>
-gp_exponential_cov(const std::vector<T_x1>& x1, const std::vector<T_x2>& x2,
-                  const T_s &sigma, const std::vector<T_l> &length_scale) {
-  using stan::math::squared_distance;
+inline typename Eigen::Matrix<
+    typename stan::return_type<T_x1, T_x2, T_s, T_l>::type, Eigen::Dynamic,
+    Eigen::Dynamic>
+gp_exponential_cov(const std::vector<T_x1> &x1, const std::vector<T_x2> &x2,
+                   const T_s &sigma, const std::vector<T_l> &length_scale) {
   using stan::math::square;
+  using stan::math::squared_distance;
   using std::exp;
   using std::pow;
 
@@ -221,7 +221,7 @@ gp_exponential_cov(const std::vector<T_x1>& x1, const std::vector<T_x2>& x2,
 
   Eigen::Matrix<typename stan::return_type<T_x1, T_x2, T_s, T_l>::type,
                 Eigen::Dynamic, Eigen::Dynamic>
-    cov(x1_size, x2_size);
+      cov(x1_size, x2_size);
 
   if (x1_size == 0 || x2_size == 0)
     return cov;

--- a/test/unit/math/prim/mat/fun/gp_exponential_cov_test.cpp
+++ b/test/unit/math/prim/mat/fun/gp_exponential_cov_test.cpp
@@ -1,0 +1,1142 @@
+#include <gtest/gtest.h>
+#include <stan/math/prim/mat.hpp>
+#include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <cmath>
+#include <limits>
+#include <string>
+#include <vector>
+
+template <typename T_x, typename T_s, typename T_l>
+std::string pull_msg(std::vector<T_x> x, T_s sigma, T_l l) {
+  std::string message;
+  try {
+    stan::math::gp_exponential_cov(x, sigma, l);
+  } catch (std::domain_error &e) {
+    message = e.what();
+  } catch (...) {
+    message = "Threw the wrong exception";
+  }
+  return message;
+}
+
+template <typename T_x1, typename T_x2, typename T_s, typename T_l>
+std::string pull_msg(std::vector<T_x1> x1, std::vector<T_x2> x2, T_s sigma,
+                     T_l l) {
+  std::string message;
+  try {
+    stan::math::gp_exponential_cov(x1, x2, sigma, l);
+  } catch (std::domain_error &e) {
+    message = e.what();
+  } catch (...) {
+    message = "Threw the wrong exception";
+  }
+  return message;
+}
+
+TEST(MathPrimMat, vec_double_gp_exponential_cov1) {
+  double sigma = 0.2;
+  double l = 5.0;
+
+  std::vector<double> x(3);
+  x[0] = -2;
+  x[1] = -1;
+  x[2] = -0.5;
+
+  Eigen::MatrixXd cov;
+  cov = stan::math::gp_exponential_cov(x, sigma, l);
+  for (int i = 0; i < 3; i++)
+    for (int j = 0; j < 3; j++)
+      EXPECT_FLOAT_EQ(sigma * sigma *
+                      std::exp(-1.0 *
+                               stan::math::squared_distance(x[i], x[j]) /
+                               std::pow(l, 2)),
+          cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+}
+
+TEST(MathPrimMat, vec_double_ard_gp_exponential_cov1) {
+  double sigma = 0.2;
+  double temp;
+
+  std::vector<double> x(3);
+  x[0] = -2;
+  x[1] = -1;
+  x[2] = -0.5;
+
+  std::vector<double> l(5);
+  l[0] = 0.1;
+  l[1] = 0.2;
+  l[2] = 0.3;
+  l[3] = 0.4;
+  l[4] = 0.5;
+
+  Eigen::MatrixXd cov;
+  cov = stan::math::gp_exponential_cov(x, sigma, l);
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 5; k++) {
+        temp += stan::math::squared_distance(x[i], x[j])
+                / stan::math::square(l[k]);
+      }
+
+      EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp),
+                      cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+}
+
+TEST(MathPrimMat, vec_eigen_gp_exponential_cov1) {
+  double l = 0.2;
+  double sigma = 0.3;
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x1(3);
+  for (size_t i = 0; i < x1.size(); ++i) {
+    x1[i].resize(1, 3);
+    x1[i] << 1 * i, 2 * i, 3 * i;
+  }
+
+  Eigen::MatrixXd cov;
+  cov = stan::math::gp_exponential_cov(x1, sigma, l);
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      EXPECT_FLOAT_EQ(
+          sigma * sigma * std::exp(-1.0 *
+                               stan::math::squared_distance(x1[i], x1[j]) /
+                               std::pow(l, 2)),
+          cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+}
+
+TEST(MathPrimMat, vec_eigen_eigen_gp_exponential_cov1) {
+  double l = 0.2;
+  double sigma = 0.3;
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x1(3);
+  for (size_t i = 0; i < x1.size(); ++i) {
+    x1[i].resize(1, 3);
+    x1[i] << 1 * i, 2 * i, 3 * i;
+  }
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x2(3);
+  for (size_t i = 0; i < x2.size(); ++i) {
+    x2[i].resize(1, 3);
+    x2[i] << 2 * i, 3 * i, 4 * i;
+  }
+
+  Eigen::MatrixXd cov;
+  cov = stan::math::gp_exponential_cov(x1, x2, sigma, l);
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      EXPECT_FLOAT_EQ(
+          sigma * sigma * std::exp(-1.0 *
+                               stan::math::squared_distance(x1[i], x2[j]) /
+                               std::pow(l, 2)),
+          cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+}
+
+TEST(MathPrimMat, vec_double_double_gp_exponential_cov1) {
+  double sigma = 0.2;
+  double l = 5.0;
+
+  std::vector<double> x1(3);
+  x1[0] = -2;
+  x1[1] = -1;
+  x1[2] = -0.5;
+
+  std::vector<double> x2(3);
+  x2[0] = 3;
+  x2[1] = -4;
+  x2[2] = -0.7;
+
+  Eigen::MatrixXd cov;
+  cov = stan::math::gp_exponential_cov(x1, x2, sigma, l);
+  for (int i = 0; i < 3; i++)
+    for (int j = 0; j < 3; j++)
+      EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 *
+                               stan::math::squared_distance(x1[i], x2[j]) /
+                               std::pow(l, 2)),
+          cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+}
+
+TEST(MathPrimMat, vec_eigen_ard_gp_exponential_cov1) {
+  double sigma = 0.3;
+  double temp;
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x1(3);
+  for (size_t i = 0; i < x1.size(); ++i) {
+    x1[i].resize(1, 3);
+    x1[i] << 1 * i, 2 * i, 3 * i;
+  }
+
+  std::vector<double> l(5);
+  l[0] = 0.1;
+  l[1] = 0.2;
+  l[2] = 0.3;
+  l[3] = 0.4;
+  l[4] = 0.5;
+
+  Eigen::MatrixXd cov;
+  cov = stan::math::gp_exponential_cov(x1, sigma, l);
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 5; k++) {
+        temp += stan::math::squared_distance(x1[i], x1[j])
+                / stan::math::square(l[k]);
+      }
+      EXPECT_FLOAT_EQ(sigma * sigma * exp(-1.0 * temp),
+                      cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+}
+
+TEST(MathPrimMat, vec_double_double_ard_gp_exponential_cov1) {
+  double sigma = 0.2;
+  double temp;
+
+  std::vector<double> x1(3);
+  x1[0] = -2;
+  x1[1] = -1;
+  x1[2] = -0.5;
+
+  std::vector<double> x2(3);
+  x2[0] = 3;
+  x2[1] = -4;
+  x2[2] = -0.7;
+
+  std::vector<double> l(4);
+  l[0] = 1;
+  l[1] = 2;
+  l[2] = 3;
+  l[3] = 4;
+
+  Eigen::MatrixXd cov;
+  cov = stan::math::gp_exponential_cov(x1, x2, sigma, l);
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 4; k++) {
+        temp += stan::math::squared_distance(x1[i], x2[j])
+                / stan::math::square(l[k]);
+      }
+      EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp),
+                      cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+}
+
+TEST(MathPrimMat, vec_eigen_eigen_ard_gp_exponential_cov1) {
+  double sigma = 0.2;
+  double temp;
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x1(3);
+  for (size_t i = 0; i < x1.size(); ++i) {
+    x1[i].resize(1, 3);
+    x1[i] << 1 * i, 2 * i, 3 * i;
+  }
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x2(3);
+  for (size_t i = 0; i < x2.size(); ++i) {
+    x2[i].resize(1, 3);
+    x2[i] << 2 * i, 3 * i, 4 * i;
+  }
+
+  std::vector<double> l(4);
+  l[0] = 1;
+  l[1] = 2;
+  l[2] = 3;
+  l[3] = 4;
+
+  Eigen::MatrixXd cov;
+  cov = stan::math::gp_exponential_cov(x1, x2, sigma, l);
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 4; k++) {
+        temp += stan::math::squared_distance(x1[i], x2[j])
+                / stan::math::square(l[k]);
+      }
+      EXPECT_FLOAT_EQ(sigma * sigma * exp(-1.0 * temp),
+                      cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+}
+
+TEST(MathPrimMat, rvec_eigen_gp_exponential_cov1) {
+  double l = 0.2;
+  double sigma = 0.3;
+
+  std::vector<Eigen::Matrix<double, -1, 1>> x1(3);
+  for (size_t i = 0; i < x1.size(); ++i) {
+    x1[i].resize(3, 1);
+    x1[i] << 1 * i, 2 * i, 3 * i;
+  }
+
+  Eigen::MatrixXd cov;
+  cov = stan::math::gp_exponential_cov(x1, sigma, l);
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      EXPECT_FLOAT_EQ(sigma * sigma *
+                      std::exp(-1.0 * stan::math::squared_distance(x1[i], x1[j])
+                               / stan::math::square(l)),
+                      cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+}
+
+TEST(MathPrimMat, vec_eigen_rvec_eigen_gp_exponential_cov1) {
+  double sigma = 0.3;
+  double l = 2.3;
+
+  std::vector<Eigen::Matrix<double, -1, 1>> x1(3);
+  for (size_t i = 0; i < x1.size(); ++i) {
+    x1[i].resize(3, 1);
+    x1[i] << 1 * i, 2 * i, 3 * i;
+  }
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x2(3);
+  for (size_t i = 0; i < x2.size(); ++i) {
+    x2[i].resize(1, 3);
+    x2[i] << 2 * i, 3 * i, 4 * i;
+  }
+
+  Eigen::MatrixXd cov;
+  cov = stan::math::gp_exponential_cov(x1, x2, sigma, l);
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      EXPECT_FLOAT_EQ(sigma * sigma *
+                      std::exp(-1.0 *
+                               stan::math::squared_distance(x1[i], x2[j])
+                               / std::pow(l, 2)),
+          cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+
+  cov = stan::math::gp_exponential_cov(x2, x1, sigma, l);
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      EXPECT_FLOAT_EQ(sigma * sigma *
+                      std::exp(-1.0 *
+                               stan::math::squared_distance(x2[i], x1[j]) /
+                               std::pow(l, 2)),
+                                               cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+}
+
+TEST(MathPrimMat, vec_eigen_rvec_eigen_ard_gp_exponential_cov1) {
+  double sigma = 0.3;
+  double temp = 0;
+  std::vector<double> l(3);
+  l[0] = 1;
+  l[1] = 2;
+  l[2] = 3;
+
+  std::vector<Eigen::Matrix<double, -1, 1>> x1(3);
+  for (size_t i = 0; i < x1.size(); ++i) {
+    x1[i].resize(3, 1);
+    x1[i] << 1 * i, 2 * i, 3 * i;
+  }
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x2(3);
+  for (size_t i = 0; i < x2.size(); ++i) {
+    x2[i].resize(1, 3);
+    x2[i] << 2 * i, 3 * i, 4 * i;
+  }
+
+  Eigen::MatrixXd cov;
+  cov = stan::math::gp_exponential_cov(x1, x2, sigma, l);
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 3; k++) {
+        temp += stan::math::squared_distance(x1[i], x2[j])
+                / stan::math::square(l[k]);
+      }
+
+      EXPECT_FLOAT_EQ(sigma * sigma *  exp(-1.0 * temp),
+                      cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+  cov = stan::math::gp_exponential_cov(x2, x1, sigma, l);
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 3; k++) {
+        temp += stan::math::squared_distance(x2[i], x1[j])
+                / stan::math::square(l[k]);
+      }
+
+      EXPECT_FLOAT_EQ(sigma * sigma *  exp(-1.0 * temp),
+                      cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+}
+
+TEST(MathPrimMat, rvec_eigen_rvec_eigen_gp_exponential_cov1) {
+  double sigma = 0.3;
+  double l = 2.3;
+
+  std::vector<Eigen::Matrix<double, -1, 1>> x1(3);
+  for (size_t i = 0; i < x1.size(); ++i) {
+    x1[i].resize(3, 1);
+    x1[i] << 1 * i, 2 * i, 3 * i;
+  }
+
+  std::vector<Eigen::Matrix<double, -1, 1>> x2(3);
+  for (size_t i = 0; i < x2.size(); ++i) {
+    x2[i].resize(3, 1);
+    x2[i] << 2 * i, 3 * i, 4 * i;
+  }
+
+  Eigen::MatrixXd cov;
+  cov = stan::math::gp_exponential_cov(x1, x2, sigma, l);
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      EXPECT_FLOAT_EQ(sigma * sigma *
+                      std::exp(-1.0 *
+                               stan::math::squared_distance(x1[i], x2[j])
+                               / std::pow(l, 2)),
+          cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+
+  cov = stan::math::gp_exponential_cov(x2, x1, sigma, l);
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      EXPECT_FLOAT_EQ(sigma * sigma *
+                      std::exp(-1.0 *
+                               stan::math::squared_distance(x2[i], x1[j])
+                               / std::pow(l, 2)),
+          cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+}
+
+TEST(MathPrimMat, rvec_eigen_rvec_eigen_ard_gp_exponential_cov1) {
+  double sigma = 0.3;
+  double temp;
+
+  std::vector<double> l(3);
+  l[0] = 1;
+  l[1] = 2;
+  l[2] = 3;
+
+  std::vector<Eigen::Matrix<double, -1, 1>> x1(3);
+  for (size_t i = 0; i < x1.size(); ++i) {
+    x1[i].resize(3, 1);
+    x1[i] << 1 * i, 2 * i, 3 * i;
+  }
+
+  std::vector<Eigen::Matrix<double, -1, 1>> x2(3);
+  for (size_t i = 0; i < x2.size(); ++i) {
+    x2[i].resize(3, 1);
+    x2[i] << 2 * i, 3 * i, 4 * i;
+  }
+
+  Eigen::MatrixXd cov;
+  cov = stan::math::gp_exponential_cov(x1, x2, sigma, l);
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 3; k++) {
+        temp += stan::math::squared_distance(x1[i], x2[j])
+                / stan::math::square(l[k]);
+      }
+
+      EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp),
+                      cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+  cov = stan::math::gp_exponential_cov(x2, x1, sigma, l);
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 3; k++) {
+        temp += stan::math::squared_distance(x2[i], x1[j])
+                / stan::math::square(l[k]);
+      }
+
+      EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp),
+                      cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+}
+
+TEST(MathPrimMat, vec_eigen_mixed_gp_exponential_cov2) {
+  using stan::math::squared_distance;
+  double sigma = 0.2;
+  double l = 5;
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x1_rvec(3);
+  std::vector<Eigen::Matrix<double, 1, -1>> x2_rvec(4);
+
+  for (size_t i = 0; i < x1_rvec.size(); ++i) {
+    x1_rvec[i].resize(1, 3);
+    x1_rvec[i] << 1 * i, 2 * i, 3 * i;
+  }
+
+  for (size_t i = 0; i < x2_rvec.size(); ++i) {
+    x2_rvec[i].resize(1, 3);
+    x2_rvec[i] << 2 * i, 3 * i, 4 * i;
+  }
+
+  std::vector<Eigen::Matrix<double, -1, 1>> x1_vec(3);
+  std::vector<Eigen::Matrix<double, -1, 1>> x2_vec(4);
+
+  for (size_t i = 0; i < x1_vec.size(); ++i) {
+    x1_vec[i].resize(3, 1);
+    x1_vec[i] << 1 * i, 2 * i, 3 * i;
+  }
+
+  for (size_t i = 0; i < x2_vec.size(); ++i) {
+    x2_vec[i].resize(3, 1);
+    x2_vec[i] << 2 * i, 3 * i, 4 * i;
+  }
+  Eigen::MatrixXd cov;
+  EXPECT_NO_THROW(cov
+                  = stan::math::gp_exponential_cov(x1_rvec, x2_vec, sigma, l));
+  EXPECT_EQ(3, cov.rows());
+  EXPECT_EQ(4, cov.cols());
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      EXPECT_FLOAT_EQ(sigma * sigma *
+                      std::exp(-1.0 *
+                             stan::math::squared_distance(x1_rvec[i], x2_vec[j])
+                               / std::pow(l, 2)),
+          cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+
+  Eigen::MatrixXd cov7;
+  EXPECT_NO_THROW(cov7
+                  = stan::math::gp_exponential_cov(x2_vec, x1_rvec, sigma, l));
+  EXPECT_EQ(4, cov7.rows());
+  EXPECT_EQ(3, cov7.cols());
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      EXPECT_FLOAT_EQ(sigma * sigma *
+                      std::exp(-1.0 *
+                             stan::math::squared_distance(x2_vec[i], x1_rvec[j])
+                               / std::pow(l, 2)),
+          cov7(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+
+  Eigen::MatrixXd cov2;
+  EXPECT_NO_THROW(cov2
+                  = stan::math::gp_exponential_cov(x1_vec, x2_rvec, sigma, l));
+  EXPECT_EQ(3, cov2.rows());
+  EXPECT_EQ(4, cov2.cols());
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      EXPECT_FLOAT_EQ(sigma * sigma *
+                      std::exp(-1.0 *
+                             stan::math::squared_distance(x1_vec[i], x2_rvec[j])
+                               / std::pow(l, 2)),
+          cov2(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+
+  Eigen::MatrixXd cov8;
+  EXPECT_NO_THROW(cov8
+                  = stan::math::gp_exponential_cov(x2_rvec, x1_vec, sigma, l));
+  EXPECT_EQ(4, cov8.rows());
+  EXPECT_EQ(3, cov8.cols());
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      EXPECT_FLOAT_EQ(sigma * sigma *
+                      std::exp(-1.0 *
+                             stan::math::squared_distance(x2_rvec[i], x1_vec[j])
+                               / std::pow(l, 2)),
+          cov8(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+
+  Eigen::MatrixXd cov3;
+  EXPECT_NO_THROW(cov3
+                  = stan::math::gp_exponential_cov(x2_vec, x2_rvec, sigma, l));
+  EXPECT_EQ(4, cov3.rows());
+  EXPECT_EQ(4, cov3.cols());
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      EXPECT_FLOAT_EQ(sigma * sigma *
+                      std::exp(-1.0 *
+                             stan::math::squared_distance(x2_vec[i], x2_rvec[j])
+                               / std::pow(l, 2)),
+          cov3(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+
+  Eigen::MatrixXd cov4;
+  EXPECT_NO_THROW(cov4
+                  = stan::math::gp_exponential_cov(x2_rvec, x2_vec, sigma, l));
+  EXPECT_EQ(4, cov4.rows());
+  EXPECT_EQ(4, cov4.cols());
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      EXPECT_FLOAT_EQ(sigma * sigma *
+                      std::exp(-1.0 *
+                             stan::math::squared_distance(x2_rvec[i], x2_vec[j])
+                               / std::pow(l, 2)),
+          cov4(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+
+  Eigen::MatrixXd cov5;
+  EXPECT_NO_THROW(cov5
+                  = stan::math::gp_exponential_cov(x1_rvec, x1_vec, sigma, l));
+  EXPECT_EQ(3, cov5.rows());
+  EXPECT_EQ(3, cov5.cols());
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      EXPECT_FLOAT_EQ(sigma * sigma *
+                      std::exp(-1.0 *
+                             stan::math::squared_distance(x1_rvec[i], x1_vec[j])
+                               / std::pow(l, 2)),
+          cov5(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+
+  Eigen::MatrixXd cov6;
+  EXPECT_NO_THROW(cov6
+                  = stan::math::gp_exponential_cov(x1_vec, x1_rvec, sigma, l));
+  EXPECT_EQ(3, cov6.rows());
+  EXPECT_EQ(3, cov6.cols());
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      EXPECT_FLOAT_EQ(sigma * sigma *
+                      std::exp(-1.0 *
+                             stan::math::squared_distance(x1_vec[i], x1_rvec[j])
+                               / std::pow(l, 2)),
+          cov6(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+}
+
+TEST(MathPrimMat, vec_eigen_mixed_ard_gp_exponential_cov2) {
+  using stan::math::squared_distance;
+  double sigma = 0.2;
+  double temp;
+
+  std::vector<double> l(3);
+  l[0] = 1;
+  l[1] = 2;
+  l[2] = 3;
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x1_rvec(3);
+  std::vector<Eigen::Matrix<double, 1, -1>> x2_rvec(4);
+
+  for (size_t i = 0; i < x1_rvec.size(); ++i) {
+    x1_rvec[i].resize(1, 3);
+    x1_rvec[i] << 1 * i, 2 * i, 3 * i;
+  }
+
+  for (size_t i = 0; i < x2_rvec.size(); ++i) {
+    x2_rvec[i].resize(1, 3);
+    x2_rvec[i] << 2 * i, 3 * i, 4 * i;
+  }
+
+  std::vector<Eigen::Matrix<double, -1, 1>> x1_vec(3);
+  std::vector<Eigen::Matrix<double, -1, 1>> x2_vec(4);
+
+  for (size_t i = 0; i < x1_vec.size(); ++i) {
+    x1_vec[i].resize(3, 1);
+    x1_vec[i] << 1 * i, 2 * i, 3 * i;
+  }
+
+  for (size_t i = 0; i < x2_vec.size(); ++i) {
+    x2_vec[i].resize(3, 1);
+    x2_vec[i] << 2 * i, 3 * i, 4 * i;
+  }
+  Eigen::MatrixXd cov;
+  EXPECT_NO_THROW(cov
+                  = stan::math::gp_exponential_cov(x1_rvec, x2_vec, sigma, l));
+  EXPECT_EQ(3, cov.rows());
+  EXPECT_EQ(4, cov.cols());
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 3; k++) {
+        temp += stan::math::squared_distance(x1_rvec[i], x2_vec[j])
+                / stan::math::square(l[k]);
+      }
+
+      EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp),
+                      cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+
+  Eigen::MatrixXd cov7;
+  EXPECT_NO_THROW(cov7
+                  = stan::math::gp_exponential_cov(x2_vec, x1_rvec, sigma, l));
+  EXPECT_EQ(4, cov7.rows());
+  EXPECT_EQ(3, cov7.cols());
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 3; k++) {
+        temp += stan::math::squared_distance(x2_vec[i], x1_rvec[j])
+                / stan::math::square(l[k]);
+      }
+
+      EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp),
+                      cov7(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+
+  Eigen::MatrixXd cov2;
+  EXPECT_NO_THROW(cov2
+                  = stan::math::gp_exponential_cov(x1_vec, x2_rvec, sigma, l));
+  EXPECT_EQ(3, cov2.rows());
+  EXPECT_EQ(4, cov2.cols());
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 3; k++) {
+        temp += stan::math::squared_distance(x1_vec[i], x2_rvec[j])
+                / stan::math::square(l[k]);
+      }
+      EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp),
+                      cov2(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+
+  Eigen::MatrixXd cov8;
+  EXPECT_NO_THROW(cov8
+                  = stan::math::gp_exponential_cov(x2_rvec, x1_vec, sigma, l));
+  EXPECT_EQ(4, cov8.rows());
+  EXPECT_EQ(3, cov8.cols());
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 3; k++) {
+        temp += stan::math::squared_distance(x2_rvec[i], x1_vec[j])
+                / stan::math::square(l[k]);
+      }
+
+      EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp),
+                      cov8(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+
+  Eigen::MatrixXd cov3;
+  EXPECT_NO_THROW(cov3
+                  = stan::math::gp_exponential_cov(x2_vec, x2_rvec, sigma, l));
+  EXPECT_EQ(4, cov3.rows());
+  EXPECT_EQ(4, cov3.cols());
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 3; k++) {
+        temp += stan::math::squared_distance(x2_vec[i], x2_rvec[j])
+                / stan::math::square(l[k]);
+      }
+
+      EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp),
+                      cov3(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+
+  Eigen::MatrixXd cov4;
+  EXPECT_NO_THROW(cov4
+                  = stan::math::gp_exponential_cov(x2_rvec, x2_vec, sigma, l));
+  EXPECT_EQ(4, cov4.rows());
+  EXPECT_EQ(4, cov4.cols());
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 3; k++) {
+        temp += stan::math::squared_distance(x2_rvec[i], x2_vec[j])
+                / stan::math::square(l[k]);
+      }
+
+      EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp),
+                      cov4(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+
+  Eigen::MatrixXd cov5;
+  EXPECT_NO_THROW(cov5
+                  = stan::math::gp_exponential_cov(x1_rvec, x1_vec, sigma, l));
+  EXPECT_EQ(3, cov5.rows());
+  EXPECT_EQ(3, cov5.cols());
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 3; k++) {
+        temp += stan::math::squared_distance(x1_rvec[i], x1_vec[j])
+                / stan::math::square(l[k]);
+      }
+
+      EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp),
+                      cov5(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+
+  Eigen::MatrixXd cov6;
+  EXPECT_NO_THROW(cov6
+                  = stan::math::gp_exponential_cov(x1_vec, x1_rvec, sigma, l));
+  EXPECT_EQ(3, cov6.rows());
+  EXPECT_EQ(3, cov6.cols());
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 3; k++) {
+        temp += stan::math::squared_distance(x1_vec[i], x1_rvec[j])
+                / stan::math::square(l[k]);
+      }
+
+      EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp),
+                      cov6(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+}
+
+TEST(MathPrimMat, domain_err_training_sig_l_gamma) {
+  double sigma = .2;
+  double l = 7;
+  double sigma_bad = -1.0;
+  double l_bad = -1.0;
+
+  std::vector<double> l_vec(2);
+  l_vec[0] = 1;
+  l_vec[1] = 2;
+
+  std::vector<double> l_vec_bad(2);
+  l_vec_bad[0] = 1;
+  l_vec_bad[1] = -1;
+
+  std::vector<double> x(3);
+  x[0] = -2;
+  x[1] = -1;
+  x[2] = -0.5;
+
+  std::vector<Eigen::Matrix<double, -1, 1>> x_2(3);
+  for (size_t i = 0; i < x_2.size(); ++i) {
+    x_2[i].resize(3, 1);
+    x_2[i] << 1, 2, 3;
+  }
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x_3(3);
+  for (size_t i = 0; i < x_3.size(); ++i) {
+    x_3[i].resize(1, 3);
+    x_3[i] << 1, 2, 3;
+  }
+
+  std::string msg1, msg2, msg3, msg4;
+  msg1 = pull_msg(x, sigma, l_bad);
+  msg2 = pull_msg(x, sigma_bad, l_bad);
+  msg3 = pull_msg(x, sigma_bad, l_bad);
+  EXPECT_TRUE(std::string::npos != msg1.find(" length-scale")) << msg1;
+  EXPECT_TRUE(std::string::npos != msg2.find(" marginal variance")) << msg2;
+  EXPECT_TRUE(std::string::npos != msg3.find(" marginal variance")) << msg3;
+
+  msg1 = pull_msg(x, sigma, l_bad);
+  msg2 = pull_msg(x, sigma_bad, l_vec);
+  msg3 = pull_msg(x, sigma_bad, l_bad);
+  EXPECT_TRUE(std::string::npos != msg1.find(" length-scale")) << msg1;
+  EXPECT_TRUE(std::string::npos != msg2.find(" marginal variance")) << msg2;
+  EXPECT_TRUE(std::string::npos != msg3.find(" marginal variance")) << msg3;
+
+  msg1 = pull_msg(x, sigma, l_vec_bad);
+  msg2 = pull_msg(x, sigma_bad, l_vec_bad);
+  msg3 = pull_msg(x, sigma_bad, l_vec);
+  EXPECT_TRUE(std::string::npos != msg1.find(" length-scale")) << msg1;
+  EXPECT_TRUE(std::string::npos != msg2.find(" marginal variance")) << msg2;
+  EXPECT_TRUE(std::string::npos != msg3.find(" marginal variance")) << msg3;
+
+  msg1 = pull_msg(x_2, sigma, l_bad);
+  msg2 = pull_msg(x_2, sigma_bad, l);
+  msg3 = pull_msg(x_2, sigma_bad, l_bad);
+  EXPECT_TRUE(std::string::npos != msg1.find(" length-scale")) << msg1;
+  EXPECT_TRUE(std::string::npos != msg2.find(" marginal variance")) << msg2;
+  EXPECT_TRUE(std::string::npos != msg3.find(" marginal variance")) << msg3;
+
+  msg1 = pull_msg(x_2, sigma, l_bad);
+  msg2 = pull_msg(x_2, sigma_bad, l_vec);
+  msg3 = pull_msg(x_2, sigma_bad, l_bad);
+  EXPECT_TRUE(std::string::npos != msg1.find(" length-scale")) << msg1;
+  EXPECT_TRUE(std::string::npos != msg2.find(" marginal variance")) << msg2;
+  EXPECT_TRUE(std::string::npos != msg3.find(" marginal variance")) << msg3;
+
+  msg1 = pull_msg(x_2, sigma, l_vec_bad);
+  msg2 = pull_msg(x_2, sigma_bad, l_vec_bad);
+  msg3 = pull_msg(x_2, sigma_bad, l_vec);
+  EXPECT_TRUE(std::string::npos != msg1.find(" length-scale")) << msg1;
+  EXPECT_TRUE(std::string::npos != msg2.find(" marginal variance")) << msg2;
+  EXPECT_TRUE(std::string::npos != msg3.find(" marginal variance")) << msg3;
+
+  msg1 = pull_msg(x_2, x_3, sigma, l_bad);
+  msg2 = pull_msg(x_2, x_3, sigma_bad, l);
+  msg3 = pull_msg(x_2, x_3, sigma_bad, l_bad);
+  EXPECT_TRUE(std::string::npos != msg1.find(" length-scale")) << msg1;
+  EXPECT_TRUE(std::string::npos != msg2.find(" marginal variance")) << msg2;
+  EXPECT_TRUE(std::string::npos != msg3.find(" marginal variance")) << msg3;
+
+  msg1 = pull_msg(x_2, x_3, sigma, l_bad);
+  msg2 = pull_msg(x_2, x_3, sigma_bad, l_vec);
+  msg3 = pull_msg(x_2, x_3, sigma_bad, l_bad);
+  EXPECT_TRUE(std::string::npos != msg1.find(" length-scale")) << msg1;
+  EXPECT_TRUE(std::string::npos != msg2.find(" marginal variance")) << msg2;
+  EXPECT_TRUE(std::string::npos != msg3.find(" marginal variance")) << msg3;
+
+  msg1 = pull_msg(x_2, x_3, sigma, l_vec_bad);
+  msg2 = pull_msg(x_2, x_3, sigma_bad, l_vec_bad);
+  msg3 = pull_msg(x_2, x_3, sigma_bad, l_vec);
+  EXPECT_TRUE(std::string::npos != msg1.find(" length-scale")) << msg1;
+  EXPECT_TRUE(std::string::npos != msg2.find(" marginal variance")) << msg2;
+  EXPECT_TRUE(std::string::npos != msg3.find(" marginal variance")) << msg3;
+
+  msg1 = pull_msg(x_3, x_3, sigma, l_vec_bad);
+  msg2 = pull_msg(x_3, x_3, sigma_bad, l_vec_bad);
+  msg3 = pull_msg(x_3, x_3, sigma_bad, l_vec);
+  EXPECT_TRUE(std::string::npos != msg1.find(" length-scale")) << msg1;
+  EXPECT_TRUE(std::string::npos != msg2.find(" marginal variance")) << msg2;
+  EXPECT_TRUE(std::string::npos != msg3.find(" marginal variance")) << msg3;
+
+  msg1 = pull_msg(x_2, x_2, sigma, l_vec_bad);
+  msg2 = pull_msg(x_2, x_2, sigma_bad, l_vec_bad);
+  msg3 = pull_msg(x_2, x_2, sigma_bad, l_vec);
+  EXPECT_TRUE(std::string::npos != msg1.find(" length-scale")) << msg1;
+  EXPECT_TRUE(std::string::npos != msg2.find(" marginal variance")) << msg2;
+  EXPECT_TRUE(std::string::npos != msg3.find(" marginal variance")) << msg3;
+}
+
+TEST(MathPrimMat, nan_error_training_sig_l_gamma) {
+  double sigma = 0.2;
+  double l = 5;
+
+  std::vector<double> x(3);
+  x[0] = -2;
+  x[1] = -1;
+  x[2] = -0.5;
+
+  std::vector<Eigen::Matrix<double, -1, 1>> x_2(3);
+  for (size_t i = 0; i < x_2.size(); ++i) {
+    x_2[i].resize(3, 1);
+    x_2[i] << 1, 2, 3;
+  }
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x_3(3);
+  for (size_t i = 0; i < x_3.size(); ++i) {
+    x_3[i].resize(1, 3);
+    x_3[i] << 1, 2, 3;
+  }
+
+  std::vector<double> l_vec(2);
+  l_vec[0] = 1;
+  l_vec[1] = 2;
+
+  std::vector<double> l_vec_bad(2);
+  l_vec_bad[0] = 1;
+  l_vec_bad[1] = -1;
+
+  std::vector<double> x_bad(x);
+  x_bad[1] = std::numeric_limits<double>::quiet_NaN();
+
+  std::vector<Eigen::Matrix<double, -1, 1>> x_bad_2(x_2);
+  x_bad_2[1](1) = std::numeric_limits<double>::quiet_NaN();
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x_bad_3(x_3);
+  x_bad_3[1](1) = std::numeric_limits<double>::quiet_NaN();
+
+  double sigma_bad = std::numeric_limits<double>::quiet_NaN();
+  double l_bad = std::numeric_limits<double>::quiet_NaN();
+
+  std::string msg1, msg2, msg3, msg4;
+  msg1 = pull_msg(x, sigma, l_bad);
+  msg2 = pull_msg(x, sigma_bad, l);
+  msg3 = pull_msg(x, sigma_bad, l_bad);
+  EXPECT_TRUE(std::string::npos != msg1.find(" length-scale")) << msg1;
+  EXPECT_TRUE(std::string::npos != msg2.find(" marginal variance")) << msg2;
+  EXPECT_TRUE(std::string::npos != msg3.find(" marginal variance")) << msg3;
+
+  EXPECT_THROW(stan::math::gp_exponential_cov(x, sigma, l_bad),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_exponential_cov(x, sigma_bad, l),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_exponential_cov(x, sigma_bad, l_bad),
+               std::domain_error);
+
+  EXPECT_THROW(stan::math::gp_exponential_cov(x_bad, l, sigma),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_exponential_cov(x_bad, sigma_bad, l),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_exponential_cov(x_bad, sigma_bad, l_bad),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_exponential_cov(x_bad, sigma, l_bad),
+               std::domain_error);
+
+  EXPECT_THROW(stan::math::gp_exponential_cov(x_2, sigma, l_bad),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_exponential_cov(x_2, sigma_bad, l),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_exponential_cov(x_2, sigma_bad, l_bad),
+               std::domain_error);
+
+  EXPECT_THROW(stan::math::gp_exponential_cov(x_bad_2, sigma, l_bad),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_exponential_cov(x_bad_2, sigma_bad, l),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_exponential_cov(x_bad_2, sigma, l),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_exponential_cov(x_bad_2, sigma_bad, l_bad),
+               std::domain_error);
+
+  EXPECT_THROW(stan::math::gp_exponential_cov(x_3, sigma, l_bad),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_exponential_cov(x_3, sigma_bad, l),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_exponential_cov(x_3, sigma_bad, l_bad),
+               std::domain_error);
+
+  EXPECT_THROW(stan::math::gp_exponential_cov(x_bad_3, sigma, l_bad),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_exponential_cov(x_bad_3, sigma_bad, l),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_exponential_cov(x_bad_3, sigma_bad, l_bad),
+               std::domain_error);
+
+  EXPECT_TRUE(std::string::npos != msg1.find(" length-scale")) << msg1;
+  EXPECT_TRUE(std::string::npos != msg2.find(" marginal variance")) << msg2;
+  EXPECT_TRUE(std::string::npos != msg3.find(" marginal variance")) << msg3;
+
+  EXPECT_THROW(stan::math::gp_exponential_cov(x, sigma, l_vec_bad),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_exponential_cov(x, sigma_bad, l_vec),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_exponential_cov(x, sigma_bad, l_vec_bad),
+               std::domain_error);
+
+  EXPECT_THROW(stan::math::gp_exponential_cov(x_bad, sigma, l_vec),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_exponential_cov(x_bad, sigma_bad, l_vec),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_exponential_cov(x_bad, sigma_bad, l_vec_bad),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_exponential_cov(x_bad, sigma, l_vec_bad),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_exponential_cov(x_bad, sigma_bad, l_vec_bad),
+               std::domain_error);
+
+  EXPECT_THROW(stan::math::gp_exponential_cov(x_2, sigma, l_vec_bad),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_exponential_cov(x_2, sigma_bad, l_vec),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_exponential_cov(x_2, sigma_bad, l_vec_bad),
+               std::domain_error);
+
+  EXPECT_THROW(stan::math::gp_exponential_cov(x_bad_2, sigma, l_vec_bad),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_exponential_cov(x_bad_2, sigma_bad, l_vec),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_exponential_cov(x_bad_2, sigma_bad, l_vec_bad),
+               std::domain_error);
+
+  EXPECT_THROW(stan::math::gp_exponential_cov(x_3, sigma, l_vec_bad),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_exponential_cov(x_3, sigma_bad, l_vec),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_exponential_cov(x_3, sigma_bad, l_vec_bad),
+               std::domain_error);
+
+  EXPECT_THROW(stan::math::gp_exponential_cov(x_bad_3, sigma, l_vec_bad),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_exponential_cov(x_bad_3, sigma_bad, l_vec),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_exponential_cov(x_bad_3, sigma_bad, l_vec_bad),
+               std::domain_error);
+}
+
+TEST(MathPrimMat, dim_mismatch_vec_eigen_rvec_gp_exponential_cov2) {
+  double sigma = 0.2;
+  double l = 5;
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x_vec_1(3);
+  for (size_t i = 0; i < x_vec_1.size(); ++i) {
+    x_vec_1[i].resize(1, 3);
+    x_vec_1[i] << 1, 2, 3;
+  }
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x_vec_2(4);
+  for (size_t i = 0; i < x_vec_2.size(); ++i) {
+    x_vec_2[i].resize(1, 4);
+    x_vec_2[i] << 4, 1, 3, 1;
+  }
+  EXPECT_THROW(stan::math::gp_exponential_cov(x_vec_1, x_vec_2, sigma, l),
+               std::invalid_argument);
+}
+
+TEST(MathPrimMat, dim_mismatch_vec_eigen_mixed_gp_exponential_cov) {
+  double sigma = 0.2;
+  double l = 5;
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x_rvec_1(3);
+  for (size_t i = 0; i < x_rvec_1.size(); ++i) {
+    x_rvec_1[i].resize(1, 3);
+    x_rvec_1[i] << 1, 2, 3;
+  }
+
+  std::vector<Eigen::Matrix<double, -1, 1>> x_vec_1(4);
+  for (size_t i = 0; i < x_vec_1.size(); ++i) {
+    x_vec_1[i].resize(4, 1);
+    x_vec_1[i] << 4, 1, 3, 1;
+  }
+
+  std::vector<Eigen::Matrix<double, -1, 1>> x_vec_2(3);
+  for (size_t i = 0; i < x_vec_2.size(); ++i) {
+    x_vec_2[i].resize(3, 1);
+    x_vec_2[i] << 1, 2, 3;
+  }
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x_rvec_2(4);
+  for (size_t i = 0; i < x_rvec_2.size(); ++i) {
+    x_rvec_2[i].resize(1, 4);
+    x_rvec_2[i] << 1, 2, 3, 4;
+  }
+  EXPECT_THROW(stan::math::gp_exponential_cov(x_rvec_1, x_vec_1, sigma, l),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::gp_exponential_cov(x_vec_1, x_rvec_1, sigma, l),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::gp_exponential_cov(x_rvec_2, x_vec_2, sigma, l),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::gp_exponential_cov(x_vec_2, x_rvec_2, sigma, l),
+               std::invalid_argument);
+}

--- a/test/unit/math/prim/mat/fun/gp_exponential_cov_test.cpp
+++ b/test/unit/math/prim/mat/fun/gp_exponential_cov_test.cpp
@@ -46,10 +46,10 @@ TEST(MathPrimMat, vec_double_gp_exponential_cov1) {
   cov = stan::math::gp_exponential_cov(x, sigma, l);
   for (int i = 0; i < 3; i++)
     for (int j = 0; j < 3; j++)
-      EXPECT_FLOAT_EQ(sigma * sigma *
-                      std::exp(-1.0 *
-                               stan::math::squared_distance(x[i], x[j]) /
-                               std::pow(l, 2)),
+      EXPECT_FLOAT_EQ(
+          sigma * sigma
+              * std::exp(-1.0 * stan::math::squared_distance(x[i], x[j])
+                         / std::pow(l, 2)),
           cov(i, j))
           << "index: (" << i << ", " << j << ")";
 }
@@ -80,8 +80,7 @@ TEST(MathPrimMat, vec_double_ard_gp_exponential_cov1) {
                 / stan::math::square(l[k]);
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp),
-                      cov(i, j))
+      EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp), cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -102,9 +101,9 @@ TEST(MathPrimMat, vec_eigen_gp_exponential_cov1) {
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-          sigma * sigma * std::exp(-1.0 *
-                               stan::math::squared_distance(x1[i], x1[j]) /
-                               std::pow(l, 2)),
+          sigma * sigma
+              * std::exp(-1.0 * stan::math::squared_distance(x1[i], x1[j])
+                         / std::pow(l, 2)),
           cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -132,9 +131,9 @@ TEST(MathPrimMat, vec_eigen_eigen_gp_exponential_cov1) {
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-          sigma * sigma * std::exp(-1.0 *
-                               stan::math::squared_distance(x1[i], x2[j]) /
-                               std::pow(l, 2)),
+          sigma * sigma
+              * std::exp(-1.0 * stan::math::squared_distance(x1[i], x2[j])
+                         / std::pow(l, 2)),
           cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -159,9 +158,10 @@ TEST(MathPrimMat, vec_double_double_gp_exponential_cov1) {
   cov = stan::math::gp_exponential_cov(x1, x2, sigma, l);
   for (int i = 0; i < 3; i++)
     for (int j = 0; j < 3; j++)
-      EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 *
-                               stan::math::squared_distance(x1[i], x2[j]) /
-                               std::pow(l, 2)),
+      EXPECT_FLOAT_EQ(
+          sigma * sigma
+              * std::exp(-1.0 * stan::math::squared_distance(x1[i], x2[j])
+                         / std::pow(l, 2)),
           cov(i, j))
           << "index: (" << i << ", " << j << ")";
 }
@@ -192,8 +192,7 @@ TEST(MathPrimMat, vec_eigen_ard_gp_exponential_cov1) {
         temp += stan::math::squared_distance(x1[i], x1[j])
                 / stan::math::square(l[k]);
       }
-      EXPECT_FLOAT_EQ(sigma * sigma * exp(-1.0 * temp),
-                      cov(i, j))
+      EXPECT_FLOAT_EQ(sigma * sigma * exp(-1.0 * temp), cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -228,8 +227,7 @@ TEST(MathPrimMat, vec_double_double_ard_gp_exponential_cov1) {
         temp += stan::math::squared_distance(x1[i], x2[j])
                 / stan::math::square(l[k]);
       }
-      EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp),
-                      cov(i, j))
+      EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp), cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -266,8 +264,7 @@ TEST(MathPrimMat, vec_eigen_eigen_ard_gp_exponential_cov1) {
         temp += stan::math::squared_distance(x1[i], x2[j])
                 / stan::math::square(l[k]);
       }
-      EXPECT_FLOAT_EQ(sigma * sigma * exp(-1.0 * temp),
-                      cov(i, j))
+      EXPECT_FLOAT_EQ(sigma * sigma * exp(-1.0 * temp), cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -287,10 +284,11 @@ TEST(MathPrimMat, rvec_eigen_gp_exponential_cov1) {
   cov = stan::math::gp_exponential_cov(x1, sigma, l);
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
-      EXPECT_FLOAT_EQ(sigma * sigma *
-                      std::exp(-1.0 * stan::math::squared_distance(x1[i], x1[j])
-                               / stan::math::square(l)),
-                      cov(i, j))
+      EXPECT_FLOAT_EQ(
+          sigma * sigma
+              * std::exp(-1.0 * stan::math::squared_distance(x1[i], x1[j])
+                         / stan::math::square(l)),
+          cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -316,10 +314,10 @@ TEST(MathPrimMat, vec_eigen_rvec_eigen_gp_exponential_cov1) {
   cov = stan::math::gp_exponential_cov(x1, x2, sigma, l);
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
-      EXPECT_FLOAT_EQ(sigma * sigma *
-                      std::exp(-1.0 *
-                               stan::math::squared_distance(x1[i], x2[j])
-                               / std::pow(l, 2)),
+      EXPECT_FLOAT_EQ(
+          sigma * sigma
+              * std::exp(-1.0 * stan::math::squared_distance(x1[i], x2[j])
+                         / std::pow(l, 2)),
           cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -328,11 +326,11 @@ TEST(MathPrimMat, vec_eigen_rvec_eigen_gp_exponential_cov1) {
   cov = stan::math::gp_exponential_cov(x2, x1, sigma, l);
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
-      EXPECT_FLOAT_EQ(sigma * sigma *
-                      std::exp(-1.0 *
-                               stan::math::squared_distance(x2[i], x1[j]) /
-                               std::pow(l, 2)),
-                                               cov(i, j))
+      EXPECT_FLOAT_EQ(
+          sigma * sigma
+              * std::exp(-1.0 * stan::math::squared_distance(x2[i], x1[j])
+                         / std::pow(l, 2)),
+          cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -368,8 +366,7 @@ TEST(MathPrimMat, vec_eigen_rvec_eigen_ard_gp_exponential_cov1) {
                 / stan::math::square(l[k]);
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma *  exp(-1.0 * temp),
-                      cov(i, j))
+      EXPECT_FLOAT_EQ(sigma * sigma * exp(-1.0 * temp), cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -382,8 +379,7 @@ TEST(MathPrimMat, vec_eigen_rvec_eigen_ard_gp_exponential_cov1) {
                 / stan::math::square(l[k]);
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma *  exp(-1.0 * temp),
-                      cov(i, j))
+      EXPECT_FLOAT_EQ(sigma * sigma * exp(-1.0 * temp), cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -409,10 +405,10 @@ TEST(MathPrimMat, rvec_eigen_rvec_eigen_gp_exponential_cov1) {
   cov = stan::math::gp_exponential_cov(x1, x2, sigma, l);
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
-      EXPECT_FLOAT_EQ(sigma * sigma *
-                      std::exp(-1.0 *
-                               stan::math::squared_distance(x1[i], x2[j])
-                               / std::pow(l, 2)),
+      EXPECT_FLOAT_EQ(
+          sigma * sigma
+              * std::exp(-1.0 * stan::math::squared_distance(x1[i], x2[j])
+                         / std::pow(l, 2)),
           cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -421,10 +417,10 @@ TEST(MathPrimMat, rvec_eigen_rvec_eigen_gp_exponential_cov1) {
   cov = stan::math::gp_exponential_cov(x2, x1, sigma, l);
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
-      EXPECT_FLOAT_EQ(sigma * sigma *
-                      std::exp(-1.0 *
-                               stan::math::squared_distance(x2[i], x1[j])
-                               / std::pow(l, 2)),
+      EXPECT_FLOAT_EQ(
+          sigma * sigma
+              * std::exp(-1.0 * stan::math::squared_distance(x2[i], x1[j])
+                         / std::pow(l, 2)),
           cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -462,8 +458,7 @@ TEST(MathPrimMat, rvec_eigen_rvec_eigen_ard_gp_exponential_cov1) {
                 / stan::math::square(l[k]);
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp),
-                      cov(i, j))
+      EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp), cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -476,8 +471,7 @@ TEST(MathPrimMat, rvec_eigen_rvec_eigen_ard_gp_exponential_cov1) {
                 / stan::math::square(l[k]);
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp),
-                      cov(i, j))
+      EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp), cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -520,10 +514,11 @@ TEST(MathPrimMat, vec_eigen_mixed_gp_exponential_cov2) {
   EXPECT_EQ(4, cov.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
-      EXPECT_FLOAT_EQ(sigma * sigma *
-                      std::exp(-1.0 *
-                             stan::math::squared_distance(x1_rvec[i], x2_vec[j])
-                               / std::pow(l, 2)),
+      EXPECT_FLOAT_EQ(
+          sigma * sigma
+              * std::exp(-1.0
+                         * stan::math::squared_distance(x1_rvec[i], x2_vec[j])
+                         / std::pow(l, 2)),
           cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -536,10 +531,11 @@ TEST(MathPrimMat, vec_eigen_mixed_gp_exponential_cov2) {
   EXPECT_EQ(3, cov7.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
-      EXPECT_FLOAT_EQ(sigma * sigma *
-                      std::exp(-1.0 *
-                             stan::math::squared_distance(x2_vec[i], x1_rvec[j])
-                               / std::pow(l, 2)),
+      EXPECT_FLOAT_EQ(
+          sigma * sigma
+              * std::exp(-1.0
+                         * stan::math::squared_distance(x2_vec[i], x1_rvec[j])
+                         / std::pow(l, 2)),
           cov7(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -552,10 +548,11 @@ TEST(MathPrimMat, vec_eigen_mixed_gp_exponential_cov2) {
   EXPECT_EQ(4, cov2.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
-      EXPECT_FLOAT_EQ(sigma * sigma *
-                      std::exp(-1.0 *
-                             stan::math::squared_distance(x1_vec[i], x2_rvec[j])
-                               / std::pow(l, 2)),
+      EXPECT_FLOAT_EQ(
+          sigma * sigma
+              * std::exp(-1.0
+                         * stan::math::squared_distance(x1_vec[i], x2_rvec[j])
+                         / std::pow(l, 2)),
           cov2(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -568,10 +565,11 @@ TEST(MathPrimMat, vec_eigen_mixed_gp_exponential_cov2) {
   EXPECT_EQ(3, cov8.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
-      EXPECT_FLOAT_EQ(sigma * sigma *
-                      std::exp(-1.0 *
-                             stan::math::squared_distance(x2_rvec[i], x1_vec[j])
-                               / std::pow(l, 2)),
+      EXPECT_FLOAT_EQ(
+          sigma * sigma
+              * std::exp(-1.0
+                         * stan::math::squared_distance(x2_rvec[i], x1_vec[j])
+                         / std::pow(l, 2)),
           cov8(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -584,10 +582,11 @@ TEST(MathPrimMat, vec_eigen_mixed_gp_exponential_cov2) {
   EXPECT_EQ(4, cov3.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
-      EXPECT_FLOAT_EQ(sigma * sigma *
-                      std::exp(-1.0 *
-                             stan::math::squared_distance(x2_vec[i], x2_rvec[j])
-                               / std::pow(l, 2)),
+      EXPECT_FLOAT_EQ(
+          sigma * sigma
+              * std::exp(-1.0
+                         * stan::math::squared_distance(x2_vec[i], x2_rvec[j])
+                         / std::pow(l, 2)),
           cov3(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -600,10 +599,11 @@ TEST(MathPrimMat, vec_eigen_mixed_gp_exponential_cov2) {
   EXPECT_EQ(4, cov4.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
-      EXPECT_FLOAT_EQ(sigma * sigma *
-                      std::exp(-1.0 *
-                             stan::math::squared_distance(x2_rvec[i], x2_vec[j])
-                               / std::pow(l, 2)),
+      EXPECT_FLOAT_EQ(
+          sigma * sigma
+              * std::exp(-1.0
+                         * stan::math::squared_distance(x2_rvec[i], x2_vec[j])
+                         / std::pow(l, 2)),
           cov4(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -616,10 +616,11 @@ TEST(MathPrimMat, vec_eigen_mixed_gp_exponential_cov2) {
   EXPECT_EQ(3, cov5.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
-      EXPECT_FLOAT_EQ(sigma * sigma *
-                      std::exp(-1.0 *
-                             stan::math::squared_distance(x1_rvec[i], x1_vec[j])
-                               / std::pow(l, 2)),
+      EXPECT_FLOAT_EQ(
+          sigma * sigma
+              * std::exp(-1.0
+                         * stan::math::squared_distance(x1_rvec[i], x1_vec[j])
+                         / std::pow(l, 2)),
           cov5(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -632,10 +633,11 @@ TEST(MathPrimMat, vec_eigen_mixed_gp_exponential_cov2) {
   EXPECT_EQ(3, cov6.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
-      EXPECT_FLOAT_EQ(sigma * sigma *
-                      std::exp(-1.0 *
-                             stan::math::squared_distance(x1_vec[i], x1_rvec[j])
-                               / std::pow(l, 2)),
+      EXPECT_FLOAT_EQ(
+          sigma * sigma
+              * std::exp(-1.0
+                         * stan::math::squared_distance(x1_vec[i], x1_rvec[j])
+                         / std::pow(l, 2)),
           cov6(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -690,8 +692,7 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_exponential_cov2) {
                 / stan::math::square(l[k]);
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp),
-                      cov(i, j))
+      EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp), cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -709,8 +710,7 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_exponential_cov2) {
                 / stan::math::square(l[k]);
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp),
-                      cov7(i, j))
+      EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp), cov7(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -727,8 +727,7 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_exponential_cov2) {
         temp += stan::math::squared_distance(x1_vec[i], x2_rvec[j])
                 / stan::math::square(l[k]);
       }
-      EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp),
-                      cov2(i, j))
+      EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp), cov2(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -746,8 +745,7 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_exponential_cov2) {
                 / stan::math::square(l[k]);
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp),
-                      cov8(i, j))
+      EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp), cov8(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -765,8 +763,7 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_exponential_cov2) {
                 / stan::math::square(l[k]);
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp),
-                      cov3(i, j))
+      EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp), cov3(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -784,8 +781,7 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_exponential_cov2) {
                 / stan::math::square(l[k]);
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp),
-                      cov4(i, j))
+      EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp), cov4(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -803,8 +799,7 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_exponential_cov2) {
                 / stan::math::square(l[k]);
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp),
-                      cov5(i, j))
+      EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp), cov5(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -822,8 +817,7 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_exponential_cov2) {
                 / stan::math::square(l[k]);
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp),
-                      cov6(i, j))
+      EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp), cov6(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary:
Add exponential kernel for GP library, with ARD support to prim

#### How to Verify:
Tests include:
vec double
vec double double
vec double ARD
vec eigen
vec eigen eigen
vec eigen ARD
vec double double ARD
rvec eigen
rvec eigen ARD
vec eigen rvec eigen
vec eigen rvec eigen ARD
rvec eigen rvec eigen
rvec eigen rvec eigen ARD
eigen mixed
eigen mixed ARD
double domain err training
nan error training
differing x lengths
#### Documentation:
doxygen

#### Copyright and Licensing
Copywrite<2018><Andre Zapico>

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
