### PR TITLE
Feature/issue xxx exponential cov prim

### DIFF
--- a/stan/math/prim/mat.hpp
+++ b/stan/math/prim/mat.hpp
@@ -119,6 +119,7 @@
 #include <stan/math/prim/mat/fun/get_base1.hpp>
 #include <stan/math/prim/mat/fun/get_base1_lhs.hpp>
 #include <stan/math/prim/mat/fun/get_lp.hpp>
+#include <stan/math/prim/mat/fun/gp_exponential_cov.hpp>
 #include <stan/math/prim/mat/fun/head.hpp>
 #include <stan/math/prim/mat/fun/initialize.hpp>
 #include <stan/math/prim/mat/fun/inv.hpp>

--- a/stan/math/prim/mat.hpp
+++ b/stan/math/prim/mat.hpp
@@ -15,8 +15,8 @@
 #include <stan/math/prim/mat/meta/length.hpp>
 #include <stan/math/prim/mat/meta/length_mvt.hpp>
 #include <stan/math/prim/mat/meta/operands_and_partials.hpp>
-#include <stan/math/prim/mat/meta/seq_view.hpp>
 #include <stan/math/prim/mat/meta/scalar_type.hpp>
+#include <stan/math/prim/mat/meta/seq_view.hpp>
 #include <stan/math/prim/mat/meta/value_type.hpp>
 #include <stan/math/prim/mat/meta/vector_seq_view.hpp>
 
@@ -45,6 +45,10 @@
 #include <stan/math/prim/mat/err/constraint_tolerance.hpp>
 #include <stan/math/prim/mat/err/validate_non_negative_index.hpp>
 
+#include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <stan/math/prim/mat/fun/LDLT_factor.hpp>
+#include <stan/math/prim/mat/fun/Phi.hpp>
+#include <stan/math/prim/mat/fun/Phi_approx.hpp>
 #include <stan/math/prim/mat/fun/accumulator.hpp>
 #include <stan/math/prim/mat/fun/acos.hpp>
 #include <stan/math/prim/mat/fun/acosh.hpp>
@@ -91,17 +95,16 @@
 #include <stan/math/prim/mat/fun/csr_u_to_z.hpp>
 #include <stan/math/prim/mat/fun/cumulative_sum.hpp>
 #include <stan/math/prim/mat/fun/determinant.hpp>
-#include <stan/math/prim/mat/fun/diagonal.hpp>
 #include <stan/math/prim/mat/fun/diag_matrix.hpp>
 #include <stan/math/prim/mat/fun/diag_post_multiply.hpp>
 #include <stan/math/prim/mat/fun/diag_pre_multiply.hpp>
+#include <stan/math/prim/mat/fun/diagonal.hpp>
 #include <stan/math/prim/mat/fun/digamma.hpp>
 #include <stan/math/prim/mat/fun/dims.hpp>
 #include <stan/math/prim/mat/fun/distance.hpp>
 #include <stan/math/prim/mat/fun/divide.hpp>
 #include <stan/math/prim/mat/fun/dot_product.hpp>
 #include <stan/math/prim/mat/fun/dot_self.hpp>
-#include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/mat/fun/eigenvalues_sym.hpp>
 #include <stan/math/prim/mat/fun/eigenvectors_sym.hpp>
 #include <stan/math/prim/mat/fun/elt_divide.hpp>
@@ -112,8 +115,8 @@
 #include <stan/math/prim/mat/fun/exp2.hpp>
 #include <stan/math/prim/mat/fun/expm1.hpp>
 #include <stan/math/prim/mat/fun/fabs.hpp>
-#include <stan/math/prim/mat/fun/factor_cov_matrix.hpp>
 #include <stan/math/prim/mat/fun/factor_U.hpp>
+#include <stan/math/prim/mat/fun/factor_cov_matrix.hpp>
 #include <stan/math/prim/mat/fun/fill.hpp>
 #include <stan/math/prim/mat/fun/floor.hpp>
 #include <stan/math/prim/mat/fun/get_base1.hpp>
@@ -123,14 +126,13 @@
 #include <stan/math/prim/mat/fun/head.hpp>
 #include <stan/math/prim/mat/fun/initialize.hpp>
 #include <stan/math/prim/mat/fun/inv.hpp>
-#include <stan/math/prim/mat/fun/inverse.hpp>
-#include <stan/math/prim/mat/fun/inverse_spd.hpp>
+#include <stan/math/prim/mat/fun/inv_Phi.hpp>
 #include <stan/math/prim/mat/fun/inv_cloglog.hpp>
 #include <stan/math/prim/mat/fun/inv_logit.hpp>
-#include <stan/math/prim/mat/fun/inv_Phi.hpp>
 #include <stan/math/prim/mat/fun/inv_sqrt.hpp>
 #include <stan/math/prim/mat/fun/inv_square.hpp>
-#include <stan/math/prim/mat/fun/LDLT_factor.hpp>
+#include <stan/math/prim/mat/fun/inverse.hpp>
+#include <stan/math/prim/mat/fun/inverse_spd.hpp>
 #include <stan/math/prim/mat/fun/lgamma.hpp>
 #include <stan/math/prim/mat/fun/log.hpp>
 #include <stan/math/prim/mat/fun/log10.hpp>
@@ -169,8 +171,6 @@
 #include <stan/math/prim/mat/fun/num_elements.hpp>
 #include <stan/math/prim/mat/fun/ordered_constrain.hpp>
 #include <stan/math/prim/mat/fun/ordered_free.hpp>
-#include <stan/math/prim/mat/fun/Phi.hpp>
-#include <stan/math/prim/mat/fun/Phi_approx.hpp>
 #include <stan/math/prim/mat/fun/positive_ordered_constrain.hpp>
 #include <stan/math/prim/mat/fun/positive_ordered_free.hpp>
 #include <stan/math/prim/mat/fun/prod.hpp>
@@ -215,9 +215,9 @@
 #include <stan/math/prim/mat/fun/square.hpp>
 #include <stan/math/prim/mat/fun/squared_distance.hpp>
 #include <stan/math/prim/mat/fun/stan_print.hpp>
-#include <stan/math/prim/mat/fun/subtract.hpp>
 #include <stan/math/prim/mat/fun/sub_col.hpp>
 #include <stan/math/prim/mat/fun/sub_row.hpp>
+#include <stan/math/prim/mat/fun/subtract.hpp>
 #include <stan/math/prim/mat/fun/sum.hpp>
 #include <stan/math/prim/mat/fun/tail.hpp>
 #include <stan/math/prim/mat/fun/tan.hpp>
@@ -249,17 +249,17 @@
 #include <stan/math/prim/mat/functor/finite_diff_gradient.hpp>
 #include <stan/math/prim/mat/functor/finite_diff_hessian.hpp>
 #include <stan/math/prim/mat/functor/map_rect.hpp>
-#include <stan/math/prim/mat/functor/map_rect_serial.hpp>
-#include <stan/math/prim/mat/functor/map_rect_reduce.hpp>
 #include <stan/math/prim/mat/functor/map_rect_combine.hpp>
+#include <stan/math/prim/mat/functor/map_rect_reduce.hpp>
+#include <stan/math/prim/mat/functor/map_rect_serial.hpp>
 
 #include <stan/math/prim/mat/prob/bernoulli_logit_glm_lpmf.hpp>
 #include <stan/math/prim/mat/prob/categorical_log.hpp>
-#include <stan/math/prim/mat/prob/categorical_lpmf.hpp>
 #include <stan/math/prim/mat/prob/categorical_logit_log.hpp>
 #include <stan/math/prim/mat/prob/categorical_logit_lpmf.hpp>
-#include <stan/math/prim/mat/prob/categorical_rng.hpp>
 #include <stan/math/prim/mat/prob/categorical_logit_rng.hpp>
+#include <stan/math/prim/mat/prob/categorical_lpmf.hpp>
+#include <stan/math/prim/mat/prob/categorical_rng.hpp>
 #include <stan/math/prim/mat/prob/dirichlet_log.hpp>
 #include <stan/math/prim/mat/prob/dirichlet_lpmf.hpp>
 #include <stan/math/prim/mat/prob/dirichlet_rng.hpp>
@@ -301,10 +301,10 @@
 #include <stan/math/prim/mat/prob/ordered_logistic_log.hpp>
 #include <stan/math/prim/mat/prob/ordered_logistic_lpmf.hpp>
 #include <stan/math/prim/mat/prob/ordered_logistic_rng.hpp>
-#include <stan/math/prim/mat/prob/poisson_log_glm_lpmf.hpp>
 #include <stan/math/prim/mat/prob/ordered_probit_log.hpp>
 #include <stan/math/prim/mat/prob/ordered_probit_lpmf.hpp>
 #include <stan/math/prim/mat/prob/ordered_probit_rng.hpp>
+#include <stan/math/prim/mat/prob/poisson_log_glm_lpmf.hpp>
 #include <stan/math/prim/mat/prob/wishart_log.hpp>
 #include <stan/math/prim/mat/prob/wishart_lpdf.hpp>
 #include <stan/math/prim/mat/prob/wishart_rng.hpp>

--- a/stan/math/prim/mat/fun/gp_exponential_cov.hpp
+++ b/stan/math/prim/mat/fun/gp_exponential_cov.hpp
@@ -1,0 +1,246 @@
+#ifndef STAN_MATH_PRIM_MAT_FUN_GP_EXPONENTIAL_COV_HPP
+#define STAN_MATH_PRIM_MAT_FUN_GP_EXPONENTIAL_COV_HPP
+
+#include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <stan/math/prim/scal/fun/square.hpp>
+#include <stan/math/prim/scal/fun/squared_distance.hpp>
+#include <stan/math/prim/scal/meta/return_type.hpp>
+#include <cmath>
+#include <vector>
+
+namespace stan {
+namespace math {
+
+/** Returns a Matern exponential covariance matrix with one input vector
+ *
+ * \f[ k(x, x') = \sigma^2 exp(-\frac{\sqrt{(x - x')^2}}{l^2}) \f]
+ *
+ * See Rausmussen & Williams et al 2006 Chapter 4.
+ *
+ * @param x std::vector of elements that can be used in stan::math::distance
+ * @param length_scale length scale
+ * @param sigma standard deviation that can be used in stan::math::square
+ * @throw std::domain error if sigma <= 0, l <= 0, or x is nan or inf
+ *
+ */
+template <typename T_x, typename T_s, typename T_l>
+inline typename Eigen::Matrix<typename stan::return_type<T_x, T_s, T_l>::type,
+                              Eigen::Dynamic, Eigen::Dynamic>
+gp_exponential_cov(const std::vector<T_x>& x, const T_s &sigma,
+                  const T_l &length_scale) {
+  using stan::math::squared_distance;
+  using stan::math::square;
+  using std::exp;
+  using std::pow;
+
+  size_t x_size = x.size();
+  for (size_t n = 0; n < x_size; ++n)
+    check_not_nan("gp_exponential_cov", "x", x[n]);
+
+  check_positive("gp_exponential_cov", "marginal variance", sigma);
+  check_not_nan("gp_exponential_cov", "marginal variance", sigma);
+
+  check_positive("gp_exponential_cov", "length-scale", length_scale);
+  check_not_nan("gp_exponential_cov", "length-scale", length_scale);
+
+  Eigen::Matrix<typename stan::return_type<T_x, T_s, T_l>::type,
+                Eigen::Dynamic, Eigen::Dynamic>
+    cov(x_size, x_size);
+
+  if (x_size == 0)
+    return cov;
+
+  T_s sigma_sq = square(sigma);
+  T_l neg_inv_l_sq = -1.0 / square(length_scale);
+
+  for (size_t i = 0; i < (x_size - 1); ++i) {
+    cov(i, i) = sigma_sq;
+    for (size_t j = i + 1; j < x_size; ++j) {
+      cov(i, j) = sigma_sq * exp(neg_inv_l_sq * squared_distance(x[i], x[j]));
+      cov(j, i) = cov(i, j);
+    }
+  }
+  cov(x_size - 1, x_size - 1) = sigma_sq;
+  return cov;
+}
+
+/** Returns a Matern exponential covariance matrix with one input vector
+ *  with automatic relevance determination (ARD) priors
+ *
+ * \f[ k(x, x') = \sigma^2 exp(-\sum_{k=1}^K\frac{\sqrt{(x - x')^2}}{l_k^2}) \f]
+ *
+ * See Rausmussen & Williams et al 2006 Chapter 4.
+ *
+ * @param x std::vector of elements that can be used in stan::math::distance
+ * @param length_scale length scale
+ * @param sigma standard deviation that can be used in stan::math::square
+ * @throw std::domain error if sigma <= 0, l <= 0, or x is nan or inf
+ *
+ */
+template <typename T_x, typename T_s, typename T_l>
+inline typename Eigen::Matrix<typename stan::return_type<T_x, T_s, T_l>::type,
+                              Eigen::Dynamic, Eigen::Dynamic>
+gp_exponential_cov(const std::vector<T_x>& x, const T_s &sigma,
+                  const std::vector<T_l> &length_scale) {
+  using stan::math::squared_distance;
+  using stan::math::square;
+  using std::exp;
+  using std::pow;
+
+  size_t x_size = x.size();
+  size_t l_size = length_scale.size();
+  for (size_t n = 0; n < x_size; ++n)
+    check_not_nan("gp_exponential_cov", "x", x[n]);
+
+  check_positive("gp_exponential_cov", "marginal variance", sigma);
+  check_not_nan("gp_exponential_cov", "marginal variance", sigma);
+
+  check_positive("gp_exponential_cov", "length-scale", length_scale);
+  check_not_nan("gp_exponential_cov", "length-scale", length_scale);
+
+  Eigen::Matrix<typename stan::return_type<T_x, T_s, T_l>::type,
+                Eigen::Dynamic, Eigen::Dynamic>
+    cov(x_size, x_size);
+
+  if (x_size == 0)
+    return cov;
+
+  T_s sigma_sq = square(sigma);
+  T_l temp;
+
+  for (size_t i = 0; i < (x_size - 1); ++i) {
+    cov(i, i) = sigma_sq;
+    for (size_t j = i + 1; j < x_size; ++j) {
+      temp = 0;
+      for (size_t k = 0; k < l_size; ++k)
+        temp += squared_distance(x[i], x[j]) / square(length_scale[k]);
+      cov(i, j) = sigma_sq * exp(-1.0 * temp);
+      cov(j, i) = cov(i, j);
+    }
+  }
+  cov(x_size - 1, x_size - 1) = sigma_sq;
+  return cov;
+}
+
+/** Returns a Matern exponential covariance matrix with two input vectors
+ *
+ * \f[ k(x, x') = \sigma^2 exp(-\frac{\sqrt{(x - x')^2}}{l^2}) \f]
+ *
+ * See Rausmussen & Williams et al 2006 Chapter 4.
+ *
+ * @param x1 std::vector of elements that can be used in stan::math::distance
+ * @param x2 std::vector of elements that can be used in stan::math::distance
+ * @param length_scale length scale
+ * @param sigma standard deviation that can be used in stan::math::square
+ * @throw std::domain error if sigma <= 0, l <= 0, or x is nan or inf
+ *
+ */
+template <typename T_x1, typename T_x2, typename T_s, typename T_l>
+inline typename Eigen::Matrix<typename stan::return_type<T_x1, T_x2,
+                                                         T_s, T_l>::type,
+                              Eigen::Dynamic, Eigen::Dynamic>
+gp_exponential_cov(const std::vector<T_x1>& x1, const std::vector<T_x2>& x2,
+                  const T_s &sigma, const T_l &length_scale) {
+  using stan::math::squared_distance;
+  using stan::math::square;
+  using std::exp;
+  using std::pow;
+
+  size_t x1_size = x1.size();
+  size_t x2_size = x2.size();
+
+  for (size_t n = 0; n < x1_size; ++n)
+    check_not_nan("gp_exponential_cov", "x1", x1[n]);
+  for (size_t n = 0; n < x2_size; ++n)
+    check_not_nan("gp_exponential_cov", "x2", x2[n]);
+
+  check_positive("gp_exponential_cov", "marginal variance", sigma);
+  check_not_nan("gp_exponential_cov", "marginal variance", sigma);
+
+  check_positive("gp_exponential_cov", "length-scale", length_scale);
+  check_not_nan("gp_exponential_cov", "length-scale", length_scale);
+
+  Eigen::Matrix<typename stan::return_type<T_x1, T_x2, T_s, T_l>::type,
+                Eigen::Dynamic, Eigen::Dynamic>
+    cov(x1_size, x2_size);
+
+  if (x1_size == 0 || x2_size == 0)
+    return cov;
+
+  T_s sigma_sq = square(sigma);
+  T_l neg_inv_l_sq = -1.0 / square(length_scale);
+
+  for (size_t i = 0; i < x1_size; ++i) {
+    for (size_t j = 0; j < x2_size; ++j) {
+      cov(i, j) = sigma_sq * exp(neg_inv_l_sq * squared_distance(x1[i], x2[j]));
+    }
+  }
+  return cov;
+}
+
+/** Returns a Matern exponential covariance matrix with two input vectors
+ *  with automatic relevance determination (ARD) priors
+ *
+ * \f[ k(x, x') = \sigma^2 exp(-\sum_{k=1}^K\frac{\sqrt{(x - x')^2}}{l_k^2}) \f]
+ *
+ * See Rausmussen & Williams et al 2006 Chapter 4.
+ *
+ * @param x1 std::vector of elements that can be used in stan::math::distance
+ * @param x2 std::vector of elements that can be used in stan::math::distance
+ * @param length_scale length scale
+ * @param sigma standard deviation that can be used in stan::math::square
+ * @throw std::domain error if sigma <= 0, l <= 0, or x is nan or inf
+ *
+ */
+template <typename T_x1, typename T_x2, typename T_s, typename T_l>
+inline typename Eigen::Matrix<typename stan::return_type<T_x1, T_x2,
+                                                         T_s, T_l>::type,
+                              Eigen::Dynamic, Eigen::Dynamic>
+gp_exponential_cov(const std::vector<T_x1>& x1, const std::vector<T_x2>& x2,
+                  const T_s &sigma, const std::vector<T_l> &length_scale) {
+  using stan::math::squared_distance;
+  using stan::math::square;
+  using std::exp;
+  using std::pow;
+
+  size_t x1_size = x1.size();
+  size_t x2_size = x2.size();
+
+  for (size_t n = 0; n < x1_size; ++n)
+    check_not_nan("gp_exponential_cov", "x1", x1[n]);
+  for (size_t n = 0; n < x2_size; ++n)
+    check_not_nan("gp_exponential_cov", "x2", x2[n]);
+
+  check_positive("gp_exponential_cov", "marginal variance", sigma);
+  check_not_nan("gp_exponential_cov", "marginal variance", sigma);
+
+  check_positive("gp_exponential_cov", "length-scale", length_scale);
+  size_t l_size = length_scale.size();
+  for (size_t n = 0; n < l_size; ++n)
+    check_not_nan("gp_exponential_cov", "length-scale", length_scale[n]);
+
+  Eigen::Matrix<typename stan::return_type<T_x1, T_x2, T_s, T_l>::type,
+                Eigen::Dynamic, Eigen::Dynamic>
+    cov(x1_size, x2_size);
+
+  if (x1_size == 0 || x2_size == 0)
+    return cov;
+
+  T_s sigma_sq = square(sigma);
+  T_l temp;
+
+  for (size_t i = 0; i < x1_size; ++i) {
+    for (size_t j = 0; j < x2_size; ++j) {
+      temp = 0;
+      for (size_t k = 0; k < l_size; ++k)
+        temp += squared_distance(x1[i], x2[j]) / square(length_scale[k]);
+      cov(i, j) = sigma_sq * exp(-1.0 * temp);
+    }
+  }
+  return cov;
+}
+
+}  // namespace math
+}  // namespace stan
+
+#endif

--- a/stan/math/prim/mat/fun/gp_exponential_cov.hpp
+++ b/stan/math/prim/mat/fun/gp_exponential_cov.hpp
@@ -1,11 +1,11 @@
 #ifndef STAN_MATH_PRIM_MAT_FUN_GP_EXPONENTIAL_COV_HPP
 #define STAN_MATH_PRIM_MAT_FUN_GP_EXPONENTIAL_COV_HPP
 
-#include <cmath>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/scal/fun/square.hpp>
 #include <stan/math/prim/scal/fun/squared_distance.hpp>
 #include <stan/math/prim/scal/meta/return_type.hpp>
+#include <cmath>
 #include <vector>
 
 namespace stan {
@@ -13,8 +13,10 @@ namespace math {
 
 /** Returns a Matern exponential covariance matrix with one input vector
  *
- * \f[ k(x, x') = \sigma^2 exp(-\frac{\sqrt{(x - x')^2}}{l^2}) \f]
+ * \f[ k(x, x') = \sigma^2 exp(-\frac{d(x, x')}{l}) \f]
  *
+ * where \f$ d(x, x') \f$ is the squared distance, or the dot product.
+ * 
  * See Rausmussen & Williams et al 2006 Chapter 4.
  *
  * @param x std::vector of elements that can be used in stan::math::distance
@@ -51,12 +53,12 @@ gp_exponential_cov(const std::vector<T_x> &x, const T_s &sigma,
     return cov;
 
   T_s sigma_sq = square(sigma);
-  T_l neg_inv_l_sq = -1.0 / square(length_scale);
+  T_l neg_inv_l = -1.0 / length_scale;
 
   for (size_t i = 0; i < (x_size - 1); ++i) {
     cov(i, i) = sigma_sq;
     for (size_t j = i + 1; j < x_size; ++j) {
-      cov(i, j) = sigma_sq * exp(neg_inv_l_sq * squared_distance(x[i], x[j]));
+      cov(i, j) = sigma_sq * exp(neg_inv_l * squared_distance(x[i], x[j]));
       cov(j, i) = cov(i, j);
     }
   }
@@ -67,8 +69,10 @@ gp_exponential_cov(const std::vector<T_x> &x, const T_s &sigma,
 /** Returns a Matern exponential covariance matrix with one input vector
  *  with automatic relevance determination (ARD) priors
  *
- * \f[ k(x, x') = \sigma^2 exp(-\sum_{k=1}^K\frac{\sqrt{(x - x')^2}}{l_k^2}) \f]
+ * \f[ k(x, x') = \sigma^2 exp(-\sum_{k=1}^K\frac{d(x, x')}{l_k}) \f]
  *
+ * where \f$ d(x, x') \f$ is the squared distance, or dot product.
+ * 
  * See Rausmussen & Williams et al 2006 Chapter 4.
  *
  * @param x std::vector of elements that can be used in stan::math::distance
@@ -113,7 +117,7 @@ gp_exponential_cov(const std::vector<T_x> &x, const T_s &sigma,
     for (size_t j = i + 1; j < x_size; ++j) {
       temp = 0;
       for (size_t k = 0; k < l_size; ++k)
-        temp += squared_distance(x[i], x[j]) / square(length_scale[k]);
+        temp += squared_distance(x[i], x[j]) / length_scale[k];
       cov(i, j) = sigma_sq * exp(-1.0 * temp);
       cov(j, i) = cov(i, j);
     }
@@ -124,8 +128,10 @@ gp_exponential_cov(const std::vector<T_x> &x, const T_s &sigma,
 
 /** Returns a Matern exponential covariance matrix with two input vectors
  *
- * \f[ k(x, x') = \sigma^2 exp(-\frac{\sqrt{(x - x')^2}}{l^2}) \f]
+ * \f[ k(x, x') = \sigma^2 exp(-\frac{d(x, x')}{l}) \f]
  *
+ * where \f$ d(x, x') \f$ is the squared distance, or dot product.
+ * 
  * See Rausmussen & Williams et al 2006 Chapter 4.
  *
  * @param x1 std::vector of elements that can be used in stan::math::distance
@@ -168,11 +174,11 @@ gp_exponential_cov(const std::vector<T_x1> &x1, const std::vector<T_x2> &x2,
     return cov;
 
   T_s sigma_sq = square(sigma);
-  T_l neg_inv_l_sq = -1.0 / square(length_scale);
+  T_l neg_inv_l = -1.0 / length_scale;
 
   for (size_t i = 0; i < x1_size; ++i) {
     for (size_t j = 0; j < x2_size; ++j) {
-      cov(i, j) = sigma_sq * exp(neg_inv_l_sq * squared_distance(x1[i], x2[j]));
+      cov(i, j) = sigma_sq * exp(neg_inv_l * squared_distance(x1[i], x2[j]));
     }
   }
   return cov;
@@ -181,8 +187,10 @@ gp_exponential_cov(const std::vector<T_x1> &x1, const std::vector<T_x2> &x2,
 /** Returns a Matern exponential covariance matrix with two input vectors
  *  with automatic relevance determination (ARD) priors
  *
- * \f[ k(x, x') = \sigma^2 exp(-\sum_{k=1}^K\frac{\sqrt{(x - x')^2}}{l_k^2}) \f]
+ * \f[ k(x, x') = \sigma^2 exp(-\sum_{k=1}^K\frac{d(x, x')}{l_k}) \f]
  *
+ * where \f$ d(x, x') \f$ is the squared distance, or dot product.
+ * 
  * See Rausmussen & Williams et al 2006 Chapter 4.
  *
  * @param x1 std::vector of elements that can be used in stan::math::distance
@@ -233,7 +241,7 @@ gp_exponential_cov(const std::vector<T_x1> &x1, const std::vector<T_x2> &x2,
     for (size_t j = 0; j < x2_size; ++j) {
       temp = 0;
       for (size_t k = 0; k < l_size; ++k)
-        temp += squared_distance(x1[i], x2[j]) / square(length_scale[k]);
+        temp += squared_distance(x1[i], x2[j]) / length_scale[k];
       cov(i, j) = sigma_sq * exp(-1.0 * temp);
     }
   }

--- a/stan/math/prim/mat/fun/gp_exponential_cov.hpp
+++ b/stan/math/prim/mat/fun/gp_exponential_cov.hpp
@@ -248,7 +248,7 @@ gp_exponential_cov(const std::vector<T_x1> &x1, const std::vector<T_x2> &x2,
   return cov;
 }
 
-} // namespace math
-} // namespace stan
+}  // namespace math
+}  // namespace stan
 
 #endif

--- a/stan/math/prim/mat/fun/gp_exponential_cov.hpp
+++ b/stan/math/prim/mat/fun/gp_exponential_cov.hpp
@@ -1,11 +1,11 @@
 #ifndef STAN_MATH_PRIM_MAT_FUN_GP_EXPONENTIAL_COV_HPP
 #define STAN_MATH_PRIM_MAT_FUN_GP_EXPONENTIAL_COV_HPP
 
+#include <cmath>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/scal/fun/square.hpp>
 #include <stan/math/prim/scal/fun/squared_distance.hpp>
 #include <stan/math/prim/scal/meta/return_type.hpp>
-#include <cmath>
 #include <vector>
 
 namespace stan {
@@ -16,7 +16,7 @@ namespace math {
  * \f[ k(x, x') = \sigma^2 exp(-\frac{d(x, x')}{l}) \f]
  *
  * where \f$ d(x, x') \f$ is the squared distance, or the dot product.
- * 
+ *
  * See Rausmussen & Williams et al 2006 Chapter 4.
  *
  * @param x std::vector of elements that can be used in stan::math::distance
@@ -72,7 +72,7 @@ gp_exponential_cov(const std::vector<T_x> &x, const T_s &sigma,
  * \f[ k(x, x') = \sigma^2 exp(-\sum_{k=1}^K\frac{d(x, x')}{l_k}) \f]
  *
  * where \f$ d(x, x') \f$ is the squared distance, or dot product.
- * 
+ *
  * See Rausmussen & Williams et al 2006 Chapter 4.
  *
  * @param x std::vector of elements that can be used in stan::math::distance
@@ -131,7 +131,7 @@ gp_exponential_cov(const std::vector<T_x> &x, const T_s &sigma,
  * \f[ k(x, x') = \sigma^2 exp(-\frac{d(x, x')}{l}) \f]
  *
  * where \f$ d(x, x') \f$ is the squared distance, or dot product.
- * 
+ *
  * See Rausmussen & Williams et al 2006 Chapter 4.
  *
  * @param x1 std::vector of elements that can be used in stan::math::distance
@@ -190,7 +190,7 @@ gp_exponential_cov(const std::vector<T_x1> &x1, const std::vector<T_x2> &x2,
  * \f[ k(x, x') = \sigma^2 exp(-\sum_{k=1}^K\frac{d(x, x')}{l_k}) \f]
  *
  * where \f$ d(x, x') \f$ is the squared distance, or dot product.
- * 
+ *
  * See Rausmussen & Williams et al 2006 Chapter 4.
  *
  * @param x1 std::vector of elements that can be used in stan::math::distance

--- a/stan/math/prim/mat/fun/gp_exponential_cov.hpp
+++ b/stan/math/prim/mat/fun/gp_exponential_cov.hpp
@@ -1,11 +1,11 @@
 #ifndef STAN_MATH_PRIM_MAT_FUN_GP_EXPONENTIAL_COV_HPP
 #define STAN_MATH_PRIM_MAT_FUN_GP_EXPONENTIAL_COV_HPP
 
+#include <cmath>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/scal/fun/square.hpp>
 #include <stan/math/prim/scal/fun/squared_distance.hpp>
 #include <stan/math/prim/scal/meta/return_type.hpp>
-#include <cmath>
 #include <vector>
 
 namespace stan {
@@ -26,8 +26,8 @@ namespace math {
 template <typename T_x, typename T_s, typename T_l>
 inline typename Eigen::Matrix<typename stan::return_type<T_x, T_s, T_l>::type,
                               Eigen::Dynamic, Eigen::Dynamic>
-gp_exponential_cov(const std::vector<T_x>& x, const T_s &sigma,
-                  const T_l &length_scale) {
+gp_exponential_cov(const std::vector<T_x> &x, const T_s &sigma,
+                   const T_l &length_scale) {
   using stan::math::squared_distance;
   using stan::math::square;
   using std::exp;
@@ -43,9 +43,9 @@ gp_exponential_cov(const std::vector<T_x>& x, const T_s &sigma,
   check_positive("gp_exponential_cov", "length-scale", length_scale);
   check_not_nan("gp_exponential_cov", "length-scale", length_scale);
 
-  Eigen::Matrix<typename stan::return_type<T_x, T_s, T_l>::type,
-                Eigen::Dynamic, Eigen::Dynamic>
-    cov(x_size, x_size);
+  Eigen::Matrix<typename stan::return_type<T_x, T_s, T_l>::type, Eigen::Dynamic,
+                Eigen::Dynamic>
+      cov(x_size, x_size);
 
   if (x_size == 0)
     return cov;
@@ -80,8 +80,8 @@ gp_exponential_cov(const std::vector<T_x>& x, const T_s &sigma,
 template <typename T_x, typename T_s, typename T_l>
 inline typename Eigen::Matrix<typename stan::return_type<T_x, T_s, T_l>::type,
                               Eigen::Dynamic, Eigen::Dynamic>
-gp_exponential_cov(const std::vector<T_x>& x, const T_s &sigma,
-                  const std::vector<T_l> &length_scale) {
+gp_exponential_cov(const std::vector<T_x> &x, const T_s &sigma,
+                   const std::vector<T_l> &length_scale) {
   using stan::math::squared_distance;
   using stan::math::square;
   using std::exp;
@@ -98,9 +98,9 @@ gp_exponential_cov(const std::vector<T_x>& x, const T_s &sigma,
   check_positive("gp_exponential_cov", "length-scale", length_scale);
   check_not_nan("gp_exponential_cov", "length-scale", length_scale);
 
-  Eigen::Matrix<typename stan::return_type<T_x, T_s, T_l>::type,
-                Eigen::Dynamic, Eigen::Dynamic>
-    cov(x_size, x_size);
+  Eigen::Matrix<typename stan::return_type<T_x, T_s, T_l>::type, Eigen::Dynamic,
+                Eigen::Dynamic>
+      cov(x_size, x_size);
 
   if (x_size == 0)
     return cov;
@@ -136,11 +136,11 @@ gp_exponential_cov(const std::vector<T_x>& x, const T_s &sigma,
  *
  */
 template <typename T_x1, typename T_x2, typename T_s, typename T_l>
-inline typename Eigen::Matrix<typename stan::return_type<T_x1, T_x2,
-                                                         T_s, T_l>::type,
-                              Eigen::Dynamic, Eigen::Dynamic>
-gp_exponential_cov(const std::vector<T_x1>& x1, const std::vector<T_x2>& x2,
-                  const T_s &sigma, const T_l &length_scale) {
+inline typename Eigen::Matrix<
+    typename stan::return_type<T_x1, T_x2, T_s, T_l>::type, Eigen::Dynamic,
+    Eigen::Dynamic>
+gp_exponential_cov(const std::vector<T_x1> &x1, const std::vector<T_x2> &x2,
+                   const T_s &sigma, const T_l &length_scale) {
   using stan::math::squared_distance;
   using stan::math::square;
   using std::exp;
@@ -162,7 +162,7 @@ gp_exponential_cov(const std::vector<T_x1>& x1, const std::vector<T_x2>& x2,
 
   Eigen::Matrix<typename stan::return_type<T_x1, T_x2, T_s, T_l>::type,
                 Eigen::Dynamic, Eigen::Dynamic>
-    cov(x1_size, x2_size);
+      cov(x1_size, x2_size);
 
   if (x1_size == 0 || x2_size == 0)
     return cov;
@@ -193,11 +193,11 @@ gp_exponential_cov(const std::vector<T_x1>& x1, const std::vector<T_x2>& x2,
  *
  */
 template <typename T_x1, typename T_x2, typename T_s, typename T_l>
-inline typename Eigen::Matrix<typename stan::return_type<T_x1, T_x2,
-                                                         T_s, T_l>::type,
-                              Eigen::Dynamic, Eigen::Dynamic>
-gp_exponential_cov(const std::vector<T_x1>& x1, const std::vector<T_x2>& x2,
-                  const T_s &sigma, const std::vector<T_l> &length_scale) {
+inline typename Eigen::Matrix<
+    typename stan::return_type<T_x1, T_x2, T_s, T_l>::type, Eigen::Dynamic,
+    Eigen::Dynamic>
+gp_exponential_cov(const std::vector<T_x1> &x1, const std::vector<T_x2> &x2,
+                   const T_s &sigma, const std::vector<T_l> &length_scale) {
   using stan::math::squared_distance;
   using stan::math::square;
   using std::exp;
@@ -221,7 +221,7 @@ gp_exponential_cov(const std::vector<T_x1>& x1, const std::vector<T_x2>& x2,
 
   Eigen::Matrix<typename stan::return_type<T_x1, T_x2, T_s, T_l>::type,
                 Eigen::Dynamic, Eigen::Dynamic>
-    cov(x1_size, x2_size);
+      cov(x1_size, x2_size);
 
   if (x1_size == 0 || x2_size == 0)
     return cov;
@@ -240,7 +240,7 @@ gp_exponential_cov(const std::vector<T_x1>& x1, const std::vector<T_x2>& x2,
   return cov;
 }
 
-}  // namespace math
-}  // namespace stan
+} // namespace math
+} // namespace stan
 
 #endif

--- a/stan/math/prim/mat/fun/gp_exponential_cov.hpp
+++ b/stan/math/prim/mat/fun/gp_exponential_cov.hpp
@@ -1,11 +1,11 @@
 #ifndef STAN_MATH_PRIM_MAT_FUN_GP_EXPONENTIAL_COV_HPP
 #define STAN_MATH_PRIM_MAT_FUN_GP_EXPONENTIAL_COV_HPP
 
-#include <cmath>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/scal/fun/square.hpp>
 #include <stan/math/prim/scal/fun/squared_distance.hpp>
 #include <stan/math/prim/scal/meta/return_type.hpp>
+#include <cmath>
 #include <vector>
 
 namespace stan {

--- a/test/unit/math/prim/mat/fun/gp_exponential_cov_test.cpp
+++ b/test/unit/math/prim/mat/fun/gp_exponential_cov_test.cpp
@@ -1,0 +1,1142 @@
+#include <gtest/gtest.h>
+#include <stan/math/prim/mat.hpp>
+#include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <cmath>
+#include <limits>
+#include <string>
+#include <vector>
+
+template <typename T_x, typename T_s, typename T_l>
+std::string pull_msg(std::vector<T_x> x, T_s sigma, T_l l) {
+  std::string message;
+  try {
+    stan::math::gp_exponential_cov(x, sigma, l);
+  } catch (std::domain_error &e) {
+    message = e.what();
+  } catch (...) {
+    message = "Threw the wrong exception";
+  }
+  return message;
+}
+
+template <typename T_x1, typename T_x2, typename T_s, typename T_l>
+std::string pull_msg(std::vector<T_x1> x1, std::vector<T_x2> x2, T_s sigma,
+                     T_l l) {
+  std::string message;
+  try {
+    stan::math::gp_exponential_cov(x1, x2, sigma, l);
+  } catch (std::domain_error &e) {
+    message = e.what();
+  } catch (...) {
+    message = "Threw the wrong exception";
+  }
+  return message;
+}
+
+TEST(MathPrimMat, vec_double_gp_exponential_cov1) {
+  double sigma = 0.2;
+  double l = 5.0;
+
+  std::vector<double> x(3);
+  x[0] = -2;
+  x[1] = -1;
+  x[2] = -0.5;
+
+  Eigen::MatrixXd cov;
+  cov = stan::math::gp_exponential_cov(x, sigma, l);
+  for (int i = 0; i < 3; i++)
+    for (int j = 0; j < 3; j++)
+      EXPECT_FLOAT_EQ(sigma * sigma *
+                      std::exp(-1.0 *
+                               stan::math::squared_distance(x[i], x[j]) /
+                               std::pow(l, 2)),
+          cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+}
+
+TEST(MathPrimMat, vec_double_ard_gp_exponential_cov1) {
+  double sigma = 0.2;
+  double temp;
+
+  std::vector<double> x(3);
+  x[0] = -2;
+  x[1] = -1;
+  x[2] = -0.5;
+
+  std::vector<double> l(5);
+  l[0] = 0.1;
+  l[1] = 0.2;
+  l[2] = 0.3;
+  l[3] = 0.4;
+  l[4] = 0.5;
+
+  Eigen::MatrixXd cov;
+  cov = stan::math::gp_exponential_cov(x, sigma, l);
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 5; k++) {
+        temp += stan::math::squared_distance(x[i], x[j])
+                / stan::math::square(l[k]);
+      }
+
+      EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp),
+                      cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+}
+
+TEST(MathPrimMat, vec_eigen_gp_exponential_cov1) {
+  double l = 0.2;
+  double sigma = 0.3;
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x1(3);
+  for (size_t i = 0; i < x1.size(); ++i) {
+    x1[i].resize(1, 3);
+    x1[i] << 1 * i, 2 * i, 3 * i;
+  }
+
+  Eigen::MatrixXd cov;
+  cov = stan::math::gp_exponential_cov(x1, sigma, l);
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      EXPECT_FLOAT_EQ(
+          sigma * sigma * std::exp(-1.0 *
+                               stan::math::squared_distance(x1[i], x1[j]) /
+                               std::pow(l, 2)),
+          cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+}
+
+TEST(MathPrimMat, vec_eigen_eigen_gp_exponential_cov1) {
+  double l = 0.2;
+  double sigma = 0.3;
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x1(3);
+  for (size_t i = 0; i < x1.size(); ++i) {
+    x1[i].resize(1, 3);
+    x1[i] << 1 * i, 2 * i, 3 * i;
+  }
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x2(3);
+  for (size_t i = 0; i < x2.size(); ++i) {
+    x2[i].resize(1, 3);
+    x2[i] << 2 * i, 3 * i, 4 * i;
+  }
+
+  Eigen::MatrixXd cov;
+  cov = stan::math::gp_exponential_cov(x1, x2, sigma, l);
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      EXPECT_FLOAT_EQ(
+          sigma * sigma * std::exp(-1.0 *
+                               stan::math::squared_distance(x1[i], x2[j]) /
+                               std::pow(l, 2)),
+          cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+}
+
+TEST(MathPrimMat, vec_double_double_gp_exponential_cov1) {
+  double sigma = 0.2;
+  double l = 5.0;
+
+  std::vector<double> x1(3);
+  x1[0] = -2;
+  x1[1] = -1;
+  x1[2] = -0.5;
+
+  std::vector<double> x2(3);
+  x2[0] = 3;
+  x2[1] = -4;
+  x2[2] = -0.7;
+
+  Eigen::MatrixXd cov;
+  cov = stan::math::gp_exponential_cov(x1, x2, sigma, l);
+  for (int i = 0; i < 3; i++)
+    for (int j = 0; j < 3; j++)
+      EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 *
+                               stan::math::squared_distance(x1[i], x2[j]) /
+                               std::pow(l, 2)),
+          cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+}
+
+TEST(MathPrimMat, vec_eigen_ard_gp_exponential_cov1) {
+  double sigma = 0.3;
+  double temp;
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x1(3);
+  for (size_t i = 0; i < x1.size(); ++i) {
+    x1[i].resize(1, 3);
+    x1[i] << 1 * i, 2 * i, 3 * i;
+  }
+
+  std::vector<double> l(5);
+  l[0] = 0.1;
+  l[1] = 0.2;
+  l[2] = 0.3;
+  l[3] = 0.4;
+  l[4] = 0.5;
+
+  Eigen::MatrixXd cov;
+  cov = stan::math::gp_exponential_cov(x1, sigma, l);
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 5; k++) {
+        temp += stan::math::squared_distance(x1[i], x1[j])
+                / stan::math::square(l[k]);
+      }
+      EXPECT_FLOAT_EQ(sigma * sigma * exp(-1.0 * temp),
+                      cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+}
+
+TEST(MathPrimMat, vec_double_double_ard_gp_exponential_cov1) {
+  double sigma = 0.2;
+  double temp;
+
+  std::vector<double> x1(3);
+  x1[0] = -2;
+  x1[1] = -1;
+  x1[2] = -0.5;
+
+  std::vector<double> x2(3);
+  x2[0] = 3;
+  x2[1] = -4;
+  x2[2] = -0.7;
+
+  std::vector<double> l(4);
+  l[0] = 1;
+  l[1] = 2;
+  l[2] = 3;
+  l[3] = 4;
+
+  Eigen::MatrixXd cov;
+  cov = stan::math::gp_exponential_cov(x1, x2, sigma, l);
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 4; k++) {
+        temp += stan::math::squared_distance(x1[i], x2[j])
+                / stan::math::square(l[k]);
+      }
+      EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp),
+                      cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+}
+
+TEST(MathPrimMat, vec_eigen_eigen_ard_gp_exponential_cov1) {
+  double sigma = 0.2;
+  double temp;
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x1(3);
+  for (size_t i = 0; i < x1.size(); ++i) {
+    x1[i].resize(1, 3);
+    x1[i] << 1 * i, 2 * i, 3 * i;
+  }
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x2(3);
+  for (size_t i = 0; i < x2.size(); ++i) {
+    x2[i].resize(1, 3);
+    x2[i] << 2 * i, 3 * i, 4 * i;
+  }
+
+  std::vector<double> l(4);
+  l[0] = 1;
+  l[1] = 2;
+  l[2] = 3;
+  l[3] = 4;
+
+  Eigen::MatrixXd cov;
+  cov = stan::math::gp_exponential_cov(x1, x2, sigma, l);
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 4; k++) {
+        temp += stan::math::squared_distance(x1[i], x2[j])
+                / stan::math::square(l[k]);
+      }
+      EXPECT_FLOAT_EQ(sigma * sigma * exp(-1.0 * temp),
+                      cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+}
+
+TEST(MathPrimMat, rvec_eigen_gp_exponential_cov1) {
+  double l = 0.2;
+  double sigma = 0.3;
+
+  std::vector<Eigen::Matrix<double, -1, 1>> x1(3);
+  for (size_t i = 0; i < x1.size(); ++i) {
+    x1[i].resize(3, 1);
+    x1[i] << 1 * i, 2 * i, 3 * i;
+  }
+
+  Eigen::MatrixXd cov;
+  cov = stan::math::gp_exponential_cov(x1, sigma, l);
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      EXPECT_FLOAT_EQ(sigma * sigma *
+                      std::exp(-1.0 * stan::math::squared_distance(x1[i], x1[j])
+                               / stan::math::square(l)),
+                      cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+}
+
+TEST(MathPrimMat, vec_eigen_rvec_eigen_gp_exponential_cov1) {
+  double sigma = 0.3;
+  double l = 2.3;
+
+  std::vector<Eigen::Matrix<double, -1, 1>> x1(3);
+  for (size_t i = 0; i < x1.size(); ++i) {
+    x1[i].resize(3, 1);
+    x1[i] << 1 * i, 2 * i, 3 * i;
+  }
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x2(3);
+  for (size_t i = 0; i < x2.size(); ++i) {
+    x2[i].resize(1, 3);
+    x2[i] << 2 * i, 3 * i, 4 * i;
+  }
+
+  Eigen::MatrixXd cov;
+  cov = stan::math::gp_exponential_cov(x1, x2, sigma, l);
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      EXPECT_FLOAT_EQ(sigma * sigma *
+                      std::exp(-1.0 *
+                               stan::math::squared_distance(x1[i], x2[j])
+                               / std::pow(l, 2)),
+          cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+
+  cov = stan::math::gp_exponential_cov(x2, x1, sigma, l);
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      EXPECT_FLOAT_EQ(sigma * sigma *
+                      std::exp(-1.0 *
+                               stan::math::squared_distance(x2[i], x1[j]) /
+                               std::pow(l, 2)),
+                                               cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+}
+
+TEST(MathPrimMat, vec_eigen_rvec_eigen_ard_gp_exponential_cov1) {
+  double sigma = 0.3;
+  double temp = 0;
+  std::vector<double> l(3);
+  l[0] = 1;
+  l[1] = 2;
+  l[2] = 3;
+
+  std::vector<Eigen::Matrix<double, -1, 1>> x1(3);
+  for (size_t i = 0; i < x1.size(); ++i) {
+    x1[i].resize(3, 1);
+    x1[i] << 1 * i, 2 * i, 3 * i;
+  }
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x2(3);
+  for (size_t i = 0; i < x2.size(); ++i) {
+    x2[i].resize(1, 3);
+    x2[i] << 2 * i, 3 * i, 4 * i;
+  }
+
+  Eigen::MatrixXd cov;
+  cov = stan::math::gp_exponential_cov(x1, x2, sigma, l);
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 3; k++) {
+        temp += stan::math::squared_distance(x1[i], x2[j])
+                / stan::math::square(l[k]);
+      }
+
+      EXPECT_FLOAT_EQ(sigma * sigma *  exp(-1.0 * temp),
+                      cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+  cov = stan::math::gp_exponential_cov(x2, x1, sigma, l);
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 3; k++) {
+        temp += stan::math::squared_distance(x2[i], x1[j])
+                / stan::math::square(l[k]);
+      }
+
+      EXPECT_FLOAT_EQ(sigma * sigma *  exp(-1.0 * temp),
+                      cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+}
+
+TEST(MathPrimMat, rvec_eigen_rvec_eigen_gp_exponential_cov1) {
+  double sigma = 0.3;
+  double l = 2.3;
+
+  std::vector<Eigen::Matrix<double, -1, 1>> x1(3);
+  for (size_t i = 0; i < x1.size(); ++i) {
+    x1[i].resize(3, 1);
+    x1[i] << 1 * i, 2 * i, 3 * i;
+  }
+
+  std::vector<Eigen::Matrix<double, -1, 1>> x2(3);
+  for (size_t i = 0; i < x2.size(); ++i) {
+    x2[i].resize(3, 1);
+    x2[i] << 2 * i, 3 * i, 4 * i;
+  }
+
+  Eigen::MatrixXd cov;
+  cov = stan::math::gp_exponential_cov(x1, x2, sigma, l);
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      EXPECT_FLOAT_EQ(sigma * sigma *
+                      std::exp(-1.0 *
+                               stan::math::squared_distance(x1[i], x2[j])
+                               / std::pow(l, 2)),
+          cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+
+  cov = stan::math::gp_exponential_cov(x2, x1, sigma, l);
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      EXPECT_FLOAT_EQ(sigma * sigma *
+                      std::exp(-1.0 *
+                               stan::math::squared_distance(x2[i], x1[j])
+                               / std::pow(l, 2)),
+          cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+}
+
+TEST(MathPrimMat, rvec_eigen_rvec_eigen_ard_gp_exponential_cov1) {
+  double sigma = 0.3;
+  double temp;
+
+  std::vector<double> l(3);
+  l[0] = 1;
+  l[1] = 2;
+  l[2] = 3;
+
+  std::vector<Eigen::Matrix<double, -1, 1>> x1(3);
+  for (size_t i = 0; i < x1.size(); ++i) {
+    x1[i].resize(3, 1);
+    x1[i] << 1 * i, 2 * i, 3 * i;
+  }
+
+  std::vector<Eigen::Matrix<double, -1, 1>> x2(3);
+  for (size_t i = 0; i < x2.size(); ++i) {
+    x2[i].resize(3, 1);
+    x2[i] << 2 * i, 3 * i, 4 * i;
+  }
+
+  Eigen::MatrixXd cov;
+  cov = stan::math::gp_exponential_cov(x1, x2, sigma, l);
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 3; k++) {
+        temp += stan::math::squared_distance(x1[i], x2[j])
+                / stan::math::square(l[k]);
+      }
+
+      EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp),
+                      cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+  cov = stan::math::gp_exponential_cov(x2, x1, sigma, l);
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 3; k++) {
+        temp += stan::math::squared_distance(x2[i], x1[j])
+                / stan::math::square(l[k]);
+      }
+
+      EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp),
+                      cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+}
+
+TEST(MathPrimMat, vec_eigen_mixed_gp_exponential_cov2) {
+  using stan::math::squared_distance;
+  double sigma = 0.2;
+  double l = 5;
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x1_rvec(3);
+  std::vector<Eigen::Matrix<double, 1, -1>> x2_rvec(4);
+
+  for (size_t i = 0; i < x1_rvec.size(); ++i) {
+    x1_rvec[i].resize(1, 3);
+    x1_rvec[i] << 1 * i, 2 * i, 3 * i;
+  }
+
+  for (size_t i = 0; i < x2_rvec.size(); ++i) {
+    x2_rvec[i].resize(1, 3);
+    x2_rvec[i] << 2 * i, 3 * i, 4 * i;
+  }
+
+  std::vector<Eigen::Matrix<double, -1, 1>> x1_vec(3);
+  std::vector<Eigen::Matrix<double, -1, 1>> x2_vec(4);
+
+  for (size_t i = 0; i < x1_vec.size(); ++i) {
+    x1_vec[i].resize(3, 1);
+    x1_vec[i] << 1 * i, 2 * i, 3 * i;
+  }
+
+  for (size_t i = 0; i < x2_vec.size(); ++i) {
+    x2_vec[i].resize(3, 1);
+    x2_vec[i] << 2 * i, 3 * i, 4 * i;
+  }
+  Eigen::MatrixXd cov;
+  EXPECT_NO_THROW(cov
+                  = stan::math::gp_exponential_cov(x1_rvec, x2_vec, sigma, l));
+  EXPECT_EQ(3, cov.rows());
+  EXPECT_EQ(4, cov.cols());
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      EXPECT_FLOAT_EQ(sigma * sigma *
+                      std::exp(-1.0 *
+                             stan::math::squared_distance(x1_rvec[i], x2_vec[j])
+                               / std::pow(l, 2)),
+          cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+
+  Eigen::MatrixXd cov7;
+  EXPECT_NO_THROW(cov7
+                  = stan::math::gp_exponential_cov(x2_vec, x1_rvec, sigma, l));
+  EXPECT_EQ(4, cov7.rows());
+  EXPECT_EQ(3, cov7.cols());
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      EXPECT_FLOAT_EQ(sigma * sigma *
+                      std::exp(-1.0 *
+                             stan::math::squared_distance(x2_vec[i], x1_rvec[j])
+                               / std::pow(l, 2)),
+          cov7(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+
+  Eigen::MatrixXd cov2;
+  EXPECT_NO_THROW(cov2
+                  = stan::math::gp_exponential_cov(x1_vec, x2_rvec, sigma, l));
+  EXPECT_EQ(3, cov2.rows());
+  EXPECT_EQ(4, cov2.cols());
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      EXPECT_FLOAT_EQ(sigma * sigma *
+                      std::exp(-1.0 *
+                             stan::math::squared_distance(x1_vec[i], x2_rvec[j])
+                               / std::pow(l, 2)),
+          cov2(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+
+  Eigen::MatrixXd cov8;
+  EXPECT_NO_THROW(cov8
+                  = stan::math::gp_exponential_cov(x2_rvec, x1_vec, sigma, l));
+  EXPECT_EQ(4, cov8.rows());
+  EXPECT_EQ(3, cov8.cols());
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      EXPECT_FLOAT_EQ(sigma * sigma *
+                      std::exp(-1.0 *
+                             stan::math::squared_distance(x2_rvec[i], x1_vec[j])
+                               / std::pow(l, 2)),
+          cov8(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+
+  Eigen::MatrixXd cov3;
+  EXPECT_NO_THROW(cov3
+                  = stan::math::gp_exponential_cov(x2_vec, x2_rvec, sigma, l));
+  EXPECT_EQ(4, cov3.rows());
+  EXPECT_EQ(4, cov3.cols());
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      EXPECT_FLOAT_EQ(sigma * sigma *
+                      std::exp(-1.0 *
+                             stan::math::squared_distance(x2_vec[i], x2_rvec[j])
+                               / std::pow(l, 2)),
+          cov3(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+
+  Eigen::MatrixXd cov4;
+  EXPECT_NO_THROW(cov4
+                  = stan::math::gp_exponential_cov(x2_rvec, x2_vec, sigma, l));
+  EXPECT_EQ(4, cov4.rows());
+  EXPECT_EQ(4, cov4.cols());
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      EXPECT_FLOAT_EQ(sigma * sigma *
+                      std::exp(-1.0 *
+                             stan::math::squared_distance(x2_rvec[i], x2_vec[j])
+                               / std::pow(l, 2)),
+          cov4(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+
+  Eigen::MatrixXd cov5;
+  EXPECT_NO_THROW(cov5
+                  = stan::math::gp_exponential_cov(x1_rvec, x1_vec, sigma, l));
+  EXPECT_EQ(3, cov5.rows());
+  EXPECT_EQ(3, cov5.cols());
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      EXPECT_FLOAT_EQ(sigma * sigma *
+                      std::exp(-1.0 *
+                             stan::math::squared_distance(x1_rvec[i], x1_vec[j])
+                               / std::pow(l, 2)),
+          cov5(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+
+  Eigen::MatrixXd cov6;
+  EXPECT_NO_THROW(cov6
+                  = stan::math::gp_exponential_cov(x1_vec, x1_rvec, sigma, l));
+  EXPECT_EQ(3, cov6.rows());
+  EXPECT_EQ(3, cov6.cols());
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      EXPECT_FLOAT_EQ(sigma * sigma *
+                      std::exp(-1.0 *
+                             stan::math::squared_distance(x1_vec[i], x1_rvec[j])
+                               / std::pow(l, 2)),
+          cov6(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+}
+
+TEST(MathPrimMat, vec_eigen_mixed_ard_gp_exponential_cov2) {
+  using stan::math::squared_distance;
+  double sigma = 0.2;
+  double temp;
+
+  std::vector<double> l(3);
+  l[0] = 1;
+  l[1] = 2;
+  l[2] = 3;
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x1_rvec(3);
+  std::vector<Eigen::Matrix<double, 1, -1>> x2_rvec(4);
+
+  for (size_t i = 0; i < x1_rvec.size(); ++i) {
+    x1_rvec[i].resize(1, 3);
+    x1_rvec[i] << 1 * i, 2 * i, 3 * i;
+  }
+
+  for (size_t i = 0; i < x2_rvec.size(); ++i) {
+    x2_rvec[i].resize(1, 3);
+    x2_rvec[i] << 2 * i, 3 * i, 4 * i;
+  }
+
+  std::vector<Eigen::Matrix<double, -1, 1>> x1_vec(3);
+  std::vector<Eigen::Matrix<double, -1, 1>> x2_vec(4);
+
+  for (size_t i = 0; i < x1_vec.size(); ++i) {
+    x1_vec[i].resize(3, 1);
+    x1_vec[i] << 1 * i, 2 * i, 3 * i;
+  }
+
+  for (size_t i = 0; i < x2_vec.size(); ++i) {
+    x2_vec[i].resize(3, 1);
+    x2_vec[i] << 2 * i, 3 * i, 4 * i;
+  }
+  Eigen::MatrixXd cov;
+  EXPECT_NO_THROW(cov
+                  = stan::math::gp_exponential_cov(x1_rvec, x2_vec, sigma, l));
+  EXPECT_EQ(3, cov.rows());
+  EXPECT_EQ(4, cov.cols());
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 3; k++) {
+        temp += stan::math::squared_distance(x1_rvec[i], x2_vec[j])
+                / stan::math::square(l[k]);
+      }
+
+      EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp),
+                      cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+
+  Eigen::MatrixXd cov7;
+  EXPECT_NO_THROW(cov7
+                  = stan::math::gp_exponential_cov(x2_vec, x1_rvec, sigma, l));
+  EXPECT_EQ(4, cov7.rows());
+  EXPECT_EQ(3, cov7.cols());
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 3; k++) {
+        temp += stan::math::squared_distance(x2_vec[i], x1_rvec[j])
+                / stan::math::square(l[k]);
+      }
+
+      EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp),
+                      cov7(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+
+  Eigen::MatrixXd cov2;
+  EXPECT_NO_THROW(cov2
+                  = stan::math::gp_exponential_cov(x1_vec, x2_rvec, sigma, l));
+  EXPECT_EQ(3, cov2.rows());
+  EXPECT_EQ(4, cov2.cols());
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 3; k++) {
+        temp += stan::math::squared_distance(x1_vec[i], x2_rvec[j])
+                / stan::math::square(l[k]);
+      }
+      EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp),
+                      cov2(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+
+  Eigen::MatrixXd cov8;
+  EXPECT_NO_THROW(cov8
+                  = stan::math::gp_exponential_cov(x2_rvec, x1_vec, sigma, l));
+  EXPECT_EQ(4, cov8.rows());
+  EXPECT_EQ(3, cov8.cols());
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 3; k++) {
+        temp += stan::math::squared_distance(x2_rvec[i], x1_vec[j])
+                / stan::math::square(l[k]);
+      }
+
+      EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp),
+                      cov8(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+
+  Eigen::MatrixXd cov3;
+  EXPECT_NO_THROW(cov3
+                  = stan::math::gp_exponential_cov(x2_vec, x2_rvec, sigma, l));
+  EXPECT_EQ(4, cov3.rows());
+  EXPECT_EQ(4, cov3.cols());
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 3; k++) {
+        temp += stan::math::squared_distance(x2_vec[i], x2_rvec[j])
+                / stan::math::square(l[k]);
+      }
+
+      EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp),
+                      cov3(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+
+  Eigen::MatrixXd cov4;
+  EXPECT_NO_THROW(cov4
+                  = stan::math::gp_exponential_cov(x2_rvec, x2_vec, sigma, l));
+  EXPECT_EQ(4, cov4.rows());
+  EXPECT_EQ(4, cov4.cols());
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 3; k++) {
+        temp += stan::math::squared_distance(x2_rvec[i], x2_vec[j])
+                / stan::math::square(l[k]);
+      }
+
+      EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp),
+                      cov4(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+
+  Eigen::MatrixXd cov5;
+  EXPECT_NO_THROW(cov5
+                  = stan::math::gp_exponential_cov(x1_rvec, x1_vec, sigma, l));
+  EXPECT_EQ(3, cov5.rows());
+  EXPECT_EQ(3, cov5.cols());
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 3; k++) {
+        temp += stan::math::squared_distance(x1_rvec[i], x1_vec[j])
+                / stan::math::square(l[k]);
+      }
+
+      EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp),
+                      cov5(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+
+  Eigen::MatrixXd cov6;
+  EXPECT_NO_THROW(cov6
+                  = stan::math::gp_exponential_cov(x1_vec, x1_rvec, sigma, l));
+  EXPECT_EQ(3, cov6.rows());
+  EXPECT_EQ(3, cov6.cols());
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 3; k++) {
+        temp += stan::math::squared_distance(x1_vec[i], x1_rvec[j])
+                / stan::math::square(l[k]);
+      }
+
+      EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp),
+                      cov6(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+}
+
+TEST(MathPrimMat, domain_err_training_sig_l_gamma) {
+  double sigma = .2;
+  double l = 7;
+  double sigma_bad = -1.0;
+  double l_bad = -1.0;
+
+  std::vector<double> l_vec(2);
+  l_vec[0] = 1;
+  l_vec[1] = 2;
+
+  std::vector<double> l_vec_bad(2);
+  l_vec_bad[0] = 1;
+  l_vec_bad[1] = -1;
+
+  std::vector<double> x(3);
+  x[0] = -2;
+  x[1] = -1;
+  x[2] = -0.5;
+
+  std::vector<Eigen::Matrix<double, -1, 1>> x_2(3);
+  for (size_t i = 0; i < x_2.size(); ++i) {
+    x_2[i].resize(3, 1);
+    x_2[i] << 1, 2, 3;
+  }
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x_3(3);
+  for (size_t i = 0; i < x_3.size(); ++i) {
+    x_3[i].resize(1, 3);
+    x_3[i] << 1, 2, 3;
+  }
+
+  std::string msg1, msg2, msg3, msg4;
+  msg1 = pull_msg(x, sigma, l_bad);
+  msg2 = pull_msg(x, sigma_bad, l_bad);
+  msg3 = pull_msg(x, sigma_bad, l_bad);
+  EXPECT_TRUE(std::string::npos != msg1.find(" length-scale")) << msg1;
+  EXPECT_TRUE(std::string::npos != msg2.find(" marginal variance")) << msg2;
+  EXPECT_TRUE(std::string::npos != msg3.find(" marginal variance")) << msg3;
+
+  msg1 = pull_msg(x, sigma, l_bad);
+  msg2 = pull_msg(x, sigma_bad, l_vec);
+  msg3 = pull_msg(x, sigma_bad, l_bad);
+  EXPECT_TRUE(std::string::npos != msg1.find(" length-scale")) << msg1;
+  EXPECT_TRUE(std::string::npos != msg2.find(" marginal variance")) << msg2;
+  EXPECT_TRUE(std::string::npos != msg3.find(" marginal variance")) << msg3;
+
+  msg1 = pull_msg(x, sigma, l_vec_bad);
+  msg2 = pull_msg(x, sigma_bad, l_vec_bad);
+  msg3 = pull_msg(x, sigma_bad, l_vec);
+  EXPECT_TRUE(std::string::npos != msg1.find(" length-scale")) << msg1;
+  EXPECT_TRUE(std::string::npos != msg2.find(" marginal variance")) << msg2;
+  EXPECT_TRUE(std::string::npos != msg3.find(" marginal variance")) << msg3;
+
+  msg1 = pull_msg(x_2, sigma, l_bad);
+  msg2 = pull_msg(x_2, sigma_bad, l);
+  msg3 = pull_msg(x_2, sigma_bad, l_bad);
+  EXPECT_TRUE(std::string::npos != msg1.find(" length-scale")) << msg1;
+  EXPECT_TRUE(std::string::npos != msg2.find(" marginal variance")) << msg2;
+  EXPECT_TRUE(std::string::npos != msg3.find(" marginal variance")) << msg3;
+
+  msg1 = pull_msg(x_2, sigma, l_bad);
+  msg2 = pull_msg(x_2, sigma_bad, l_vec);
+  msg3 = pull_msg(x_2, sigma_bad, l_bad);
+  EXPECT_TRUE(std::string::npos != msg1.find(" length-scale")) << msg1;
+  EXPECT_TRUE(std::string::npos != msg2.find(" marginal variance")) << msg2;
+  EXPECT_TRUE(std::string::npos != msg3.find(" marginal variance")) << msg3;
+
+  msg1 = pull_msg(x_2, sigma, l_vec_bad);
+  msg2 = pull_msg(x_2, sigma_bad, l_vec_bad);
+  msg3 = pull_msg(x_2, sigma_bad, l_vec);
+  EXPECT_TRUE(std::string::npos != msg1.find(" length-scale")) << msg1;
+  EXPECT_TRUE(std::string::npos != msg2.find(" marginal variance")) << msg2;
+  EXPECT_TRUE(std::string::npos != msg3.find(" marginal variance")) << msg3;
+
+  msg1 = pull_msg(x_2, x_3, sigma, l_bad);
+  msg2 = pull_msg(x_2, x_3, sigma_bad, l);
+  msg3 = pull_msg(x_2, x_3, sigma_bad, l_bad);
+  EXPECT_TRUE(std::string::npos != msg1.find(" length-scale")) << msg1;
+  EXPECT_TRUE(std::string::npos != msg2.find(" marginal variance")) << msg2;
+  EXPECT_TRUE(std::string::npos != msg3.find(" marginal variance")) << msg3;
+
+  msg1 = pull_msg(x_2, x_3, sigma, l_bad);
+  msg2 = pull_msg(x_2, x_3, sigma_bad, l_vec);
+  msg3 = pull_msg(x_2, x_3, sigma_bad, l_bad);
+  EXPECT_TRUE(std::string::npos != msg1.find(" length-scale")) << msg1;
+  EXPECT_TRUE(std::string::npos != msg2.find(" marginal variance")) << msg2;
+  EXPECT_TRUE(std::string::npos != msg3.find(" marginal variance")) << msg3;
+
+  msg1 = pull_msg(x_2, x_3, sigma, l_vec_bad);
+  msg2 = pull_msg(x_2, x_3, sigma_bad, l_vec_bad);
+  msg3 = pull_msg(x_2, x_3, sigma_bad, l_vec);
+  EXPECT_TRUE(std::string::npos != msg1.find(" length-scale")) << msg1;
+  EXPECT_TRUE(std::string::npos != msg2.find(" marginal variance")) << msg2;
+  EXPECT_TRUE(std::string::npos != msg3.find(" marginal variance")) << msg3;
+
+  msg1 = pull_msg(x_3, x_3, sigma, l_vec_bad);
+  msg2 = pull_msg(x_3, x_3, sigma_bad, l_vec_bad);
+  msg3 = pull_msg(x_3, x_3, sigma_bad, l_vec);
+  EXPECT_TRUE(std::string::npos != msg1.find(" length-scale")) << msg1;
+  EXPECT_TRUE(std::string::npos != msg2.find(" marginal variance")) << msg2;
+  EXPECT_TRUE(std::string::npos != msg3.find(" marginal variance")) << msg3;
+
+  msg1 = pull_msg(x_2, x_2, sigma, l_vec_bad);
+  msg2 = pull_msg(x_2, x_2, sigma_bad, l_vec_bad);
+  msg3 = pull_msg(x_2, x_2, sigma_bad, l_vec);
+  EXPECT_TRUE(std::string::npos != msg1.find(" length-scale")) << msg1;
+  EXPECT_TRUE(std::string::npos != msg2.find(" marginal variance")) << msg2;
+  EXPECT_TRUE(std::string::npos != msg3.find(" marginal variance")) << msg3;
+}
+
+TEST(MathPrimMat, nan_error_training_sig_l_gamma) {
+  double sigma = 0.2;
+  double l = 5;
+
+  std::vector<double> x(3);
+  x[0] = -2;
+  x[1] = -1;
+  x[2] = -0.5;
+
+  std::vector<Eigen::Matrix<double, -1, 1>> x_2(3);
+  for (size_t i = 0; i < x_2.size(); ++i) {
+    x_2[i].resize(3, 1);
+    x_2[i] << 1, 2, 3;
+  }
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x_3(3);
+  for (size_t i = 0; i < x_3.size(); ++i) {
+    x_3[i].resize(1, 3);
+    x_3[i] << 1, 2, 3;
+  }
+
+  std::vector<double> l_vec(2);
+  l_vec[0] = 1;
+  l_vec[1] = 2;
+
+  std::vector<double> l_vec_bad(2);
+  l_vec_bad[0] = 1;
+  l_vec_bad[1] = -1;
+
+  std::vector<double> x_bad(x);
+  x_bad[1] = std::numeric_limits<double>::quiet_NaN();
+
+  std::vector<Eigen::Matrix<double, -1, 1>> x_bad_2(x_2);
+  x_bad_2[1](1) = std::numeric_limits<double>::quiet_NaN();
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x_bad_3(x_3);
+  x_bad_3[1](1) = std::numeric_limits<double>::quiet_NaN();
+
+  double sigma_bad = std::numeric_limits<double>::quiet_NaN();
+  double l_bad = std::numeric_limits<double>::quiet_NaN();
+
+  std::string msg1, msg2, msg3, msg4;
+  msg1 = pull_msg(x, sigma, l_bad);
+  msg2 = pull_msg(x, sigma_bad, l);
+  msg3 = pull_msg(x, sigma_bad, l_bad);
+  EXPECT_TRUE(std::string::npos != msg1.find(" length-scale")) << msg1;
+  EXPECT_TRUE(std::string::npos != msg2.find(" marginal variance")) << msg2;
+  EXPECT_TRUE(std::string::npos != msg3.find(" marginal variance")) << msg3;
+
+  EXPECT_THROW(stan::math::gp_exponential_cov(x, sigma, l_bad),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_exponential_cov(x, sigma_bad, l),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_exponential_cov(x, sigma_bad, l_bad),
+               std::domain_error);
+
+  EXPECT_THROW(stan::math::gp_exponential_cov(x_bad, l, sigma),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_exponential_cov(x_bad, sigma_bad, l),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_exponential_cov(x_bad, sigma_bad, l_bad),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_exponential_cov(x_bad, sigma, l_bad),
+               std::domain_error);
+
+  EXPECT_THROW(stan::math::gp_exponential_cov(x_2, sigma, l_bad),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_exponential_cov(x_2, sigma_bad, l),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_exponential_cov(x_2, sigma_bad, l_bad),
+               std::domain_error);
+
+  EXPECT_THROW(stan::math::gp_exponential_cov(x_bad_2, sigma, l_bad),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_exponential_cov(x_bad_2, sigma_bad, l),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_exponential_cov(x_bad_2, sigma, l),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_exponential_cov(x_bad_2, sigma_bad, l_bad),
+               std::domain_error);
+
+  EXPECT_THROW(stan::math::gp_exponential_cov(x_3, sigma, l_bad),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_exponential_cov(x_3, sigma_bad, l),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_exponential_cov(x_3, sigma_bad, l_bad),
+               std::domain_error);
+
+  EXPECT_THROW(stan::math::gp_exponential_cov(x_bad_3, sigma, l_bad),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_exponential_cov(x_bad_3, sigma_bad, l),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_exponential_cov(x_bad_3, sigma_bad, l_bad),
+               std::domain_error);
+
+  EXPECT_TRUE(std::string::npos != msg1.find(" length-scale")) << msg1;
+  EXPECT_TRUE(std::string::npos != msg2.find(" marginal variance")) << msg2;
+  EXPECT_TRUE(std::string::npos != msg3.find(" marginal variance")) << msg3;
+
+  EXPECT_THROW(stan::math::gp_exponential_cov(x, sigma, l_vec_bad),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_exponential_cov(x, sigma_bad, l_vec),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_exponential_cov(x, sigma_bad, l_vec_bad),
+               std::domain_error);
+
+  EXPECT_THROW(stan::math::gp_exponential_cov(x_bad, sigma, l_vec),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_exponential_cov(x_bad, sigma_bad, l_vec),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_exponential_cov(x_bad, sigma_bad, l_vec_bad),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_exponential_cov(x_bad, sigma, l_vec_bad),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_exponential_cov(x_bad, sigma_bad, l_vec_bad),
+               std::domain_error);
+
+  EXPECT_THROW(stan::math::gp_exponential_cov(x_2, sigma, l_vec_bad),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_exponential_cov(x_2, sigma_bad, l_vec),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_exponential_cov(x_2, sigma_bad, l_vec_bad),
+               std::domain_error);
+
+  EXPECT_THROW(stan::math::gp_exponential_cov(x_bad_2, sigma, l_vec_bad),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_exponential_cov(x_bad_2, sigma_bad, l_vec),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_exponential_cov(x_bad_2, sigma_bad, l_vec_bad),
+               std::domain_error);
+
+  EXPECT_THROW(stan::math::gp_exponential_cov(x_3, sigma, l_vec_bad),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_exponential_cov(x_3, sigma_bad, l_vec),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_exponential_cov(x_3, sigma_bad, l_vec_bad),
+               std::domain_error);
+
+  EXPECT_THROW(stan::math::gp_exponential_cov(x_bad_3, sigma, l_vec_bad),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_exponential_cov(x_bad_3, sigma_bad, l_vec),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_exponential_cov(x_bad_3, sigma_bad, l_vec_bad),
+               std::domain_error);
+}
+
+TEST(MathPrimMat, dim_mismatch_vec_eigen_rvec_gp_exponential_cov2) {
+  double sigma = 0.2;
+  double l = 5;
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x_vec_1(3);
+  for (size_t i = 0; i < x_vec_1.size(); ++i) {
+    x_vec_1[i].resize(1, 3);
+    x_vec_1[i] << 1, 2, 3;
+  }
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x_vec_2(4);
+  for (size_t i = 0; i < x_vec_2.size(); ++i) {
+    x_vec_2[i].resize(1, 4);
+    x_vec_2[i] << 4, 1, 3, 1;
+  }
+  EXPECT_THROW(stan::math::gp_exponential_cov(x_vec_1, x_vec_2, sigma, l),
+               std::invalid_argument);
+}
+
+TEST(MathPrimMat, dim_mismatch_vec_eigen_mixed_gp_exponential_cov) {
+  double sigma = 0.2;
+  double l = 5;
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x_rvec_1(3);
+  for (size_t i = 0; i < x_rvec_1.size(); ++i) {
+    x_rvec_1[i].resize(1, 3);
+    x_rvec_1[i] << 1, 2, 3;
+  }
+
+  std::vector<Eigen::Matrix<double, -1, 1>> x_vec_1(4);
+  for (size_t i = 0; i < x_vec_1.size(); ++i) {
+    x_vec_1[i].resize(4, 1);
+    x_vec_1[i] << 4, 1, 3, 1;
+  }
+
+  std::vector<Eigen::Matrix<double, -1, 1>> x_vec_2(3);
+  for (size_t i = 0; i < x_vec_2.size(); ++i) {
+    x_vec_2[i].resize(3, 1);
+    x_vec_2[i] << 1, 2, 3;
+  }
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x_rvec_2(4);
+  for (size_t i = 0; i < x_rvec_2.size(); ++i) {
+    x_rvec_2[i].resize(1, 4);
+    x_rvec_2[i] << 1, 2, 3, 4;
+  }
+  EXPECT_THROW(stan::math::gp_exponential_cov(x_rvec_1, x_vec_1, sigma, l),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::gp_exponential_cov(x_vec_1, x_rvec_1, sigma, l),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::gp_exponential_cov(x_rvec_2, x_vec_2, sigma, l),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::gp_exponential_cov(x_vec_2, x_rvec_2, sigma, l),
+               std::invalid_argument);
+}

--- a/test/unit/math/prim/mat/fun/gp_exponential_cov_test.cpp
+++ b/test/unit/math/prim/mat/fun/gp_exponential_cov_test.cpp
@@ -1,8 +1,8 @@
+#include <cmath>
 #include <gtest/gtest.h>
+#include <limits>
 #include <stan/math/prim/mat.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
-#include <cmath>
-#include <limits>
 #include <string>
 #include <vector>
 
@@ -47,10 +47,10 @@ TEST(MathPrimMat, vec_double_gp_exponential_cov1) {
   for (int i = 0; i < 3; i++)
     for (int j = 0; j < 3; j++)
       EXPECT_FLOAT_EQ(sigma * sigma *
-                      std::exp(-1.0 *
-                               stan::math::squared_distance(x[i], x[j]) /
-                               std::pow(l, 2)),
-          cov(i, j))
+                          std::exp(-1.0 *
+                                   stan::math::squared_distance(x[i], x[j]) /
+                                   std::pow(l, 2)),
+                      cov(i, j))
           << "index: (" << i << ", " << j << ")";
 }
 
@@ -76,12 +76,11 @@ TEST(MathPrimMat, vec_double_ard_gp_exponential_cov1) {
     for (int j = 0; j < 3; j++) {
       temp = 0;
       for (int k = 0; k < 5; k++) {
-        temp += stan::math::squared_distance(x[i], x[j])
-                / stan::math::square(l[k]);
+        temp +=
+            stan::math::squared_distance(x[i], x[j]) / stan::math::square(l[k]);
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp),
-                      cov(i, j))
+      EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp), cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -101,11 +100,11 @@ TEST(MathPrimMat, vec_eigen_gp_exponential_cov1) {
   cov = stan::math::gp_exponential_cov(x1, sigma, l);
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
-      EXPECT_FLOAT_EQ(
-          sigma * sigma * std::exp(-1.0 *
-                               stan::math::squared_distance(x1[i], x1[j]) /
-                               std::pow(l, 2)),
-          cov(i, j))
+      EXPECT_FLOAT_EQ(sigma * sigma *
+                          std::exp(-1.0 *
+                                   stan::math::squared_distance(x1[i], x1[j]) /
+                                   std::pow(l, 2)),
+                      cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -131,11 +130,11 @@ TEST(MathPrimMat, vec_eigen_eigen_gp_exponential_cov1) {
   cov = stan::math::gp_exponential_cov(x1, x2, sigma, l);
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
-      EXPECT_FLOAT_EQ(
-          sigma * sigma * std::exp(-1.0 *
-                               stan::math::squared_distance(x1[i], x2[j]) /
-                               std::pow(l, 2)),
-          cov(i, j))
+      EXPECT_FLOAT_EQ(sigma * sigma *
+                          std::exp(-1.0 *
+                                   stan::math::squared_distance(x1[i], x2[j]) /
+                                   std::pow(l, 2)),
+                      cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -159,10 +158,11 @@ TEST(MathPrimMat, vec_double_double_gp_exponential_cov1) {
   cov = stan::math::gp_exponential_cov(x1, x2, sigma, l);
   for (int i = 0; i < 3; i++)
     for (int j = 0; j < 3; j++)
-      EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 *
-                               stan::math::squared_distance(x1[i], x2[j]) /
-                               std::pow(l, 2)),
-          cov(i, j))
+      EXPECT_FLOAT_EQ(sigma * sigma *
+                          std::exp(-1.0 *
+                                   stan::math::squared_distance(x1[i], x2[j]) /
+                                   std::pow(l, 2)),
+                      cov(i, j))
           << "index: (" << i << ", " << j << ")";
 }
 
@@ -189,11 +189,10 @@ TEST(MathPrimMat, vec_eigen_ard_gp_exponential_cov1) {
     for (int j = 0; j < 3; j++) {
       temp = 0;
       for (int k = 0; k < 5; k++) {
-        temp += stan::math::squared_distance(x1[i], x1[j])
-                / stan::math::square(l[k]);
+        temp += stan::math::squared_distance(x1[i], x1[j]) /
+                stan::math::square(l[k]);
       }
-      EXPECT_FLOAT_EQ(sigma * sigma * exp(-1.0 * temp),
-                      cov(i, j))
+      EXPECT_FLOAT_EQ(sigma * sigma * exp(-1.0 * temp), cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -225,11 +224,10 @@ TEST(MathPrimMat, vec_double_double_ard_gp_exponential_cov1) {
     for (int j = 0; j < 3; j++) {
       temp = 0;
       for (int k = 0; k < 4; k++) {
-        temp += stan::math::squared_distance(x1[i], x2[j])
-                / stan::math::square(l[k]);
+        temp += stan::math::squared_distance(x1[i], x2[j]) /
+                stan::math::square(l[k]);
       }
-      EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp),
-                      cov(i, j))
+      EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp), cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -263,11 +261,10 @@ TEST(MathPrimMat, vec_eigen_eigen_ard_gp_exponential_cov1) {
     for (int j = 0; j < 3; j++) {
       temp = 0;
       for (int k = 0; k < 4; k++) {
-        temp += stan::math::squared_distance(x1[i], x2[j])
-                / stan::math::square(l[k]);
+        temp += stan::math::squared_distance(x1[i], x2[j]) /
+                stan::math::square(l[k]);
       }
-      EXPECT_FLOAT_EQ(sigma * sigma * exp(-1.0 * temp),
-                      cov(i, j))
+      EXPECT_FLOAT_EQ(sigma * sigma * exp(-1.0 * temp), cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -288,8 +285,9 @@ TEST(MathPrimMat, rvec_eigen_gp_exponential_cov1) {
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(sigma * sigma *
-                      std::exp(-1.0 * stan::math::squared_distance(x1[i], x1[j])
-                               / stan::math::square(l)),
+                          std::exp(-1.0 *
+                                   stan::math::squared_distance(x1[i], x1[j]) /
+                                   stan::math::square(l)),
                       cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -317,10 +315,10 @@ TEST(MathPrimMat, vec_eigen_rvec_eigen_gp_exponential_cov1) {
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(sigma * sigma *
-                      std::exp(-1.0 *
-                               stan::math::squared_distance(x1[i], x2[j])
-                               / std::pow(l, 2)),
-          cov(i, j))
+                          std::exp(-1.0 *
+                                   stan::math::squared_distance(x1[i], x2[j]) /
+                                   std::pow(l, 2)),
+                      cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -329,10 +327,10 @@ TEST(MathPrimMat, vec_eigen_rvec_eigen_gp_exponential_cov1) {
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(sigma * sigma *
-                      std::exp(-1.0 *
-                               stan::math::squared_distance(x2[i], x1[j]) /
-                               std::pow(l, 2)),
-                                               cov(i, j))
+                          std::exp(-1.0 *
+                                   stan::math::squared_distance(x2[i], x1[j]) /
+                                   std::pow(l, 2)),
+                      cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -364,12 +362,11 @@ TEST(MathPrimMat, vec_eigen_rvec_eigen_ard_gp_exponential_cov1) {
     for (int j = 0; j < 3; j++) {
       temp = 0;
       for (int k = 0; k < 3; k++) {
-        temp += stan::math::squared_distance(x1[i], x2[j])
-                / stan::math::square(l[k]);
+        temp += stan::math::squared_distance(x1[i], x2[j]) /
+                stan::math::square(l[k]);
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma *  exp(-1.0 * temp),
-                      cov(i, j))
+      EXPECT_FLOAT_EQ(sigma * sigma * exp(-1.0 * temp), cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -378,12 +375,11 @@ TEST(MathPrimMat, vec_eigen_rvec_eigen_ard_gp_exponential_cov1) {
     for (int j = 0; j < 3; j++) {
       temp = 0;
       for (int k = 0; k < 3; k++) {
-        temp += stan::math::squared_distance(x2[i], x1[j])
-                / stan::math::square(l[k]);
+        temp += stan::math::squared_distance(x2[i], x1[j]) /
+                stan::math::square(l[k]);
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma *  exp(-1.0 * temp),
-                      cov(i, j))
+      EXPECT_FLOAT_EQ(sigma * sigma * exp(-1.0 * temp), cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -410,10 +406,10 @@ TEST(MathPrimMat, rvec_eigen_rvec_eigen_gp_exponential_cov1) {
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(sigma * sigma *
-                      std::exp(-1.0 *
-                               stan::math::squared_distance(x1[i], x2[j])
-                               / std::pow(l, 2)),
-          cov(i, j))
+                          std::exp(-1.0 *
+                                   stan::math::squared_distance(x1[i], x2[j]) /
+                                   std::pow(l, 2)),
+                      cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -422,10 +418,10 @@ TEST(MathPrimMat, rvec_eigen_rvec_eigen_gp_exponential_cov1) {
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(sigma * sigma *
-                      std::exp(-1.0 *
-                               stan::math::squared_distance(x2[i], x1[j])
-                               / std::pow(l, 2)),
-          cov(i, j))
+                          std::exp(-1.0 *
+                                   stan::math::squared_distance(x2[i], x1[j]) /
+                                   std::pow(l, 2)),
+                      cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -458,12 +454,11 @@ TEST(MathPrimMat, rvec_eigen_rvec_eigen_ard_gp_exponential_cov1) {
     for (int j = 0; j < 3; j++) {
       temp = 0;
       for (int k = 0; k < 3; k++) {
-        temp += stan::math::squared_distance(x1[i], x2[j])
-                / stan::math::square(l[k]);
+        temp += stan::math::squared_distance(x1[i], x2[j]) /
+                stan::math::square(l[k]);
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp),
-                      cov(i, j))
+      EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp), cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -472,12 +467,11 @@ TEST(MathPrimMat, rvec_eigen_rvec_eigen_ard_gp_exponential_cov1) {
     for (int j = 0; j < 3; j++) {
       temp = 0;
       for (int k = 0; k < 3; k++) {
-        temp += stan::math::squared_distance(x2[i], x1[j])
-                / stan::math::square(l[k]);
+        temp += stan::math::squared_distance(x2[i], x1[j]) /
+                stan::math::square(l[k]);
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp),
-                      cov(i, j))
+      EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp), cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -514,129 +508,129 @@ TEST(MathPrimMat, vec_eigen_mixed_gp_exponential_cov2) {
     x2_vec[i] << 2 * i, 3 * i, 4 * i;
   }
   Eigen::MatrixXd cov;
-  EXPECT_NO_THROW(cov
-                  = stan::math::gp_exponential_cov(x1_rvec, x2_vec, sigma, l));
+  EXPECT_NO_THROW(
+      cov = stan::math::gp_exponential_cov(x1_rvec, x2_vec, sigma, l));
   EXPECT_EQ(3, cov.rows());
   EXPECT_EQ(4, cov.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(sigma * sigma *
-                      std::exp(-1.0 *
-                             stan::math::squared_distance(x1_rvec[i], x2_vec[j])
-                               / std::pow(l, 2)),
-          cov(i, j))
+                          std::exp(-1.0 * stan::math::squared_distance(
+                                              x1_rvec[i], x2_vec[j]) /
+                                   std::pow(l, 2)),
+                      cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov7;
-  EXPECT_NO_THROW(cov7
-                  = stan::math::gp_exponential_cov(x2_vec, x1_rvec, sigma, l));
+  EXPECT_NO_THROW(
+      cov7 = stan::math::gp_exponential_cov(x2_vec, x1_rvec, sigma, l));
   EXPECT_EQ(4, cov7.rows());
   EXPECT_EQ(3, cov7.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(sigma * sigma *
-                      std::exp(-1.0 *
-                             stan::math::squared_distance(x2_vec[i], x1_rvec[j])
-                               / std::pow(l, 2)),
-          cov7(i, j))
+                          std::exp(-1.0 * stan::math::squared_distance(
+                                              x2_vec[i], x1_rvec[j]) /
+                                   std::pow(l, 2)),
+                      cov7(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov2;
-  EXPECT_NO_THROW(cov2
-                  = stan::math::gp_exponential_cov(x1_vec, x2_rvec, sigma, l));
+  EXPECT_NO_THROW(
+      cov2 = stan::math::gp_exponential_cov(x1_vec, x2_rvec, sigma, l));
   EXPECT_EQ(3, cov2.rows());
   EXPECT_EQ(4, cov2.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(sigma * sigma *
-                      std::exp(-1.0 *
-                             stan::math::squared_distance(x1_vec[i], x2_rvec[j])
-                               / std::pow(l, 2)),
-          cov2(i, j))
+                          std::exp(-1.0 * stan::math::squared_distance(
+                                              x1_vec[i], x2_rvec[j]) /
+                                   std::pow(l, 2)),
+                      cov2(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov8;
-  EXPECT_NO_THROW(cov8
-                  = stan::math::gp_exponential_cov(x2_rvec, x1_vec, sigma, l));
+  EXPECT_NO_THROW(
+      cov8 = stan::math::gp_exponential_cov(x2_rvec, x1_vec, sigma, l));
   EXPECT_EQ(4, cov8.rows());
   EXPECT_EQ(3, cov8.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(sigma * sigma *
-                      std::exp(-1.0 *
-                             stan::math::squared_distance(x2_rvec[i], x1_vec[j])
-                               / std::pow(l, 2)),
-          cov8(i, j))
+                          std::exp(-1.0 * stan::math::squared_distance(
+                                              x2_rvec[i], x1_vec[j]) /
+                                   std::pow(l, 2)),
+                      cov8(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov3;
-  EXPECT_NO_THROW(cov3
-                  = stan::math::gp_exponential_cov(x2_vec, x2_rvec, sigma, l));
+  EXPECT_NO_THROW(
+      cov3 = stan::math::gp_exponential_cov(x2_vec, x2_rvec, sigma, l));
   EXPECT_EQ(4, cov3.rows());
   EXPECT_EQ(4, cov3.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(sigma * sigma *
-                      std::exp(-1.0 *
-                             stan::math::squared_distance(x2_vec[i], x2_rvec[j])
-                               / std::pow(l, 2)),
-          cov3(i, j))
+                          std::exp(-1.0 * stan::math::squared_distance(
+                                              x2_vec[i], x2_rvec[j]) /
+                                   std::pow(l, 2)),
+                      cov3(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov4;
-  EXPECT_NO_THROW(cov4
-                  = stan::math::gp_exponential_cov(x2_rvec, x2_vec, sigma, l));
+  EXPECT_NO_THROW(
+      cov4 = stan::math::gp_exponential_cov(x2_rvec, x2_vec, sigma, l));
   EXPECT_EQ(4, cov4.rows());
   EXPECT_EQ(4, cov4.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(sigma * sigma *
-                      std::exp(-1.0 *
-                             stan::math::squared_distance(x2_rvec[i], x2_vec[j])
-                               / std::pow(l, 2)),
-          cov4(i, j))
+                          std::exp(-1.0 * stan::math::squared_distance(
+                                              x2_rvec[i], x2_vec[j]) /
+                                   std::pow(l, 2)),
+                      cov4(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov5;
-  EXPECT_NO_THROW(cov5
-                  = stan::math::gp_exponential_cov(x1_rvec, x1_vec, sigma, l));
+  EXPECT_NO_THROW(
+      cov5 = stan::math::gp_exponential_cov(x1_rvec, x1_vec, sigma, l));
   EXPECT_EQ(3, cov5.rows());
   EXPECT_EQ(3, cov5.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(sigma * sigma *
-                      std::exp(-1.0 *
-                             stan::math::squared_distance(x1_rvec[i], x1_vec[j])
-                               / std::pow(l, 2)),
-          cov5(i, j))
+                          std::exp(-1.0 * stan::math::squared_distance(
+                                              x1_rvec[i], x1_vec[j]) /
+                                   std::pow(l, 2)),
+                      cov5(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov6;
-  EXPECT_NO_THROW(cov6
-                  = stan::math::gp_exponential_cov(x1_vec, x1_rvec, sigma, l));
+  EXPECT_NO_THROW(
+      cov6 = stan::math::gp_exponential_cov(x1_vec, x1_rvec, sigma, l));
   EXPECT_EQ(3, cov6.rows());
   EXPECT_EQ(3, cov6.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(sigma * sigma *
-                      std::exp(-1.0 *
-                             stan::math::squared_distance(x1_vec[i], x1_rvec[j])
-                               / std::pow(l, 2)),
-          cov6(i, j))
+                          std::exp(-1.0 * stan::math::squared_distance(
+                                              x1_vec[i], x1_rvec[j]) /
+                                   std::pow(l, 2)),
+                      cov6(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -678,152 +672,144 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_exponential_cov2) {
     x2_vec[i] << 2 * i, 3 * i, 4 * i;
   }
   Eigen::MatrixXd cov;
-  EXPECT_NO_THROW(cov
-                  = stan::math::gp_exponential_cov(x1_rvec, x2_vec, sigma, l));
+  EXPECT_NO_THROW(
+      cov = stan::math::gp_exponential_cov(x1_rvec, x2_vec, sigma, l));
   EXPECT_EQ(3, cov.rows());
   EXPECT_EQ(4, cov.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       temp = 0;
       for (int k = 0; k < 3; k++) {
-        temp += stan::math::squared_distance(x1_rvec[i], x2_vec[j])
-                / stan::math::square(l[k]);
+        temp += stan::math::squared_distance(x1_rvec[i], x2_vec[j]) /
+                stan::math::square(l[k]);
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp),
-                      cov(i, j))
+      EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp), cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov7;
-  EXPECT_NO_THROW(cov7
-                  = stan::math::gp_exponential_cov(x2_vec, x1_rvec, sigma, l));
+  EXPECT_NO_THROW(
+      cov7 = stan::math::gp_exponential_cov(x2_vec, x1_rvec, sigma, l));
   EXPECT_EQ(4, cov7.rows());
   EXPECT_EQ(3, cov7.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       temp = 0;
       for (int k = 0; k < 3; k++) {
-        temp += stan::math::squared_distance(x2_vec[i], x1_rvec[j])
-                / stan::math::square(l[k]);
+        temp += stan::math::squared_distance(x2_vec[i], x1_rvec[j]) /
+                stan::math::square(l[k]);
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp),
-                      cov7(i, j))
+      EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp), cov7(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov2;
-  EXPECT_NO_THROW(cov2
-                  = stan::math::gp_exponential_cov(x1_vec, x2_rvec, sigma, l));
+  EXPECT_NO_THROW(
+      cov2 = stan::math::gp_exponential_cov(x1_vec, x2_rvec, sigma, l));
   EXPECT_EQ(3, cov2.rows());
   EXPECT_EQ(4, cov2.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       temp = 0;
       for (int k = 0; k < 3; k++) {
-        temp += stan::math::squared_distance(x1_vec[i], x2_rvec[j])
-                / stan::math::square(l[k]);
+        temp += stan::math::squared_distance(x1_vec[i], x2_rvec[j]) /
+                stan::math::square(l[k]);
       }
-      EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp),
-                      cov2(i, j))
+      EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp), cov2(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov8;
-  EXPECT_NO_THROW(cov8
-                  = stan::math::gp_exponential_cov(x2_rvec, x1_vec, sigma, l));
+  EXPECT_NO_THROW(
+      cov8 = stan::math::gp_exponential_cov(x2_rvec, x1_vec, sigma, l));
   EXPECT_EQ(4, cov8.rows());
   EXPECT_EQ(3, cov8.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       temp = 0;
       for (int k = 0; k < 3; k++) {
-        temp += stan::math::squared_distance(x2_rvec[i], x1_vec[j])
-                / stan::math::square(l[k]);
+        temp += stan::math::squared_distance(x2_rvec[i], x1_vec[j]) /
+                stan::math::square(l[k]);
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp),
-                      cov8(i, j))
+      EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp), cov8(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov3;
-  EXPECT_NO_THROW(cov3
-                  = stan::math::gp_exponential_cov(x2_vec, x2_rvec, sigma, l));
+  EXPECT_NO_THROW(
+      cov3 = stan::math::gp_exponential_cov(x2_vec, x2_rvec, sigma, l));
   EXPECT_EQ(4, cov3.rows());
   EXPECT_EQ(4, cov3.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       temp = 0;
       for (int k = 0; k < 3; k++) {
-        temp += stan::math::squared_distance(x2_vec[i], x2_rvec[j])
-                / stan::math::square(l[k]);
+        temp += stan::math::squared_distance(x2_vec[i], x2_rvec[j]) /
+                stan::math::square(l[k]);
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp),
-                      cov3(i, j))
+      EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp), cov3(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov4;
-  EXPECT_NO_THROW(cov4
-                  = stan::math::gp_exponential_cov(x2_rvec, x2_vec, sigma, l));
+  EXPECT_NO_THROW(
+      cov4 = stan::math::gp_exponential_cov(x2_rvec, x2_vec, sigma, l));
   EXPECT_EQ(4, cov4.rows());
   EXPECT_EQ(4, cov4.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       temp = 0;
       for (int k = 0; k < 3; k++) {
-        temp += stan::math::squared_distance(x2_rvec[i], x2_vec[j])
-                / stan::math::square(l[k]);
+        temp += stan::math::squared_distance(x2_rvec[i], x2_vec[j]) /
+                stan::math::square(l[k]);
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp),
-                      cov4(i, j))
+      EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp), cov4(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov5;
-  EXPECT_NO_THROW(cov5
-                  = stan::math::gp_exponential_cov(x1_rvec, x1_vec, sigma, l));
+  EXPECT_NO_THROW(
+      cov5 = stan::math::gp_exponential_cov(x1_rvec, x1_vec, sigma, l));
   EXPECT_EQ(3, cov5.rows());
   EXPECT_EQ(3, cov5.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       temp = 0;
       for (int k = 0; k < 3; k++) {
-        temp += stan::math::squared_distance(x1_rvec[i], x1_vec[j])
-                / stan::math::square(l[k]);
+        temp += stan::math::squared_distance(x1_rvec[i], x1_vec[j]) /
+                stan::math::square(l[k]);
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp),
-                      cov5(i, j))
+      EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp), cov5(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov6;
-  EXPECT_NO_THROW(cov6
-                  = stan::math::gp_exponential_cov(x1_vec, x1_rvec, sigma, l));
+  EXPECT_NO_THROW(
+      cov6 = stan::math::gp_exponential_cov(x1_vec, x1_rvec, sigma, l));
   EXPECT_EQ(3, cov6.rows());
   EXPECT_EQ(3, cov6.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       temp = 0;
       for (int k = 0; k < 3; k++) {
-        temp += stan::math::squared_distance(x1_vec[i], x1_rvec[j])
-                / stan::math::square(l[k]);
+        temp += stan::math::squared_distance(x1_vec[i], x1_rvec[j]) /
+                stan::math::square(l[k]);
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp),
-                      cov6(i, j))
+      EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp), cov6(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }

--- a/test/unit/math/prim/mat/fun/gp_exponential_cov_test.cpp
+++ b/test/unit/math/prim/mat/fun/gp_exponential_cov_test.cpp
@@ -47,8 +47,8 @@ TEST(MathPrimMat, vec_double_gp_exponential_cov1) {
   for (int i = 0; i < 3; i++)
     for (int j = 0; j < 3; j++)
       EXPECT_FLOAT_EQ(
-          sigma * sigma *
-              std::exp(-1.0 * stan::math::squared_distance(x[i], x[j]) / l),
+          sigma * sigma
+              * std::exp(-1.0 * stan::math::squared_distance(x[i], x[j]) / l),
           cov(i, j))
           << "index: (" << i << ", " << j << ")";
 }
@@ -99,8 +99,8 @@ TEST(MathPrimMat, vec_eigen_gp_exponential_cov1) {
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-          sigma * sigma *
-              std::exp(-1.0 * stan::math::squared_distance(x1[i], x1[j]) / l),
+          sigma * sigma
+              * std::exp(-1.0 * stan::math::squared_distance(x1[i], x1[j]) / l),
           cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -128,8 +128,8 @@ TEST(MathPrimMat, vec_eigen_eigen_gp_exponential_cov1) {
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-          sigma * sigma *
-              std::exp(-1.0 * stan::math::squared_distance(x1[i], x2[j]) / l),
+          sigma * sigma
+              * std::exp(-1.0 * stan::math::squared_distance(x1[i], x2[j]) / l),
           cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -155,8 +155,8 @@ TEST(MathPrimMat, vec_double_double_gp_exponential_cov1) {
   for (int i = 0; i < 3; i++)
     for (int j = 0; j < 3; j++)
       EXPECT_FLOAT_EQ(
-          sigma * sigma *
-              std::exp(-1.0 * stan::math::squared_distance(x1[i], x2[j]) / l),
+          sigma * sigma
+              * std::exp(-1.0 * stan::math::squared_distance(x1[i], x2[j]) / l),
           cov(i, j))
           << "index: (" << i << ", " << j << ")";
 }
@@ -277,8 +277,8 @@ TEST(MathPrimMat, rvec_eigen_gp_exponential_cov1) {
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-          sigma * sigma *
-              std::exp(-1.0 * stan::math::squared_distance(x1[i], x1[j]) / l),
+          sigma * sigma
+              * std::exp(-1.0 * stan::math::squared_distance(x1[i], x1[j]) / l),
           cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -306,8 +306,8 @@ TEST(MathPrimMat, vec_eigen_rvec_eigen_gp_exponential_cov1) {
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-          sigma * sigma *
-              std::exp(-1.0 * stan::math::squared_distance(x1[i], x2[j]) / l),
+          sigma * sigma
+              * std::exp(-1.0 * stan::math::squared_distance(x1[i], x2[j]) / l),
           cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -317,8 +317,8 @@ TEST(MathPrimMat, vec_eigen_rvec_eigen_gp_exponential_cov1) {
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-          sigma * sigma *
-              std::exp(-1.0 * stan::math::squared_distance(x2[i], x1[j]) / l),
+          sigma * sigma
+              * std::exp(-1.0 * stan::math::squared_distance(x2[i], x1[j]) / l),
           cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -393,8 +393,8 @@ TEST(MathPrimMat, rvec_eigen_rvec_eigen_gp_exponential_cov1) {
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-          sigma * sigma *
-              std::exp(-1.0 * stan::math::squared_distance(x1[i], x2[j]) / l),
+          sigma * sigma
+              * std::exp(-1.0 * stan::math::squared_distance(x1[i], x2[j]) / l),
           cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -404,8 +404,8 @@ TEST(MathPrimMat, rvec_eigen_rvec_eigen_gp_exponential_cov1) {
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-          sigma * sigma *
-              std::exp(-1.0 * stan::math::squared_distance(x2[i], x1[j]) / l),
+          sigma * sigma
+              * std::exp(-1.0 * stan::math::squared_distance(x2[i], x1[j]) / l),
           cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -491,128 +491,136 @@ TEST(MathPrimMat, vec_eigen_mixed_gp_exponential_cov2) {
     x2_vec[i] << 2 * i, 3 * i, 4 * i;
   }
   Eigen::MatrixXd cov;
-  EXPECT_NO_THROW(
-      cov = stan::math::gp_exponential_cov(x1_rvec, x2_vec, sigma, l));
+  EXPECT_NO_THROW(cov
+                  = stan::math::gp_exponential_cov(x1_rvec, x2_vec, sigma, l));
   EXPECT_EQ(3, cov.rows());
   EXPECT_EQ(4, cov.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-          sigma * sigma *
-              std::exp(-1.0 *
-                       stan::math::squared_distance(x1_rvec[i], x2_vec[j]) / l),
+          sigma * sigma
+              * std::exp(-1.0
+                         * stan::math::squared_distance(x1_rvec[i], x2_vec[j])
+                         / l),
           cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov7;
-  EXPECT_NO_THROW(
-      cov7 = stan::math::gp_exponential_cov(x2_vec, x1_rvec, sigma, l));
+  EXPECT_NO_THROW(cov7
+                  = stan::math::gp_exponential_cov(x2_vec, x1_rvec, sigma, l));
   EXPECT_EQ(4, cov7.rows());
   EXPECT_EQ(3, cov7.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-          sigma * sigma *
-              std::exp(-1.0 *
-                       stan::math::squared_distance(x2_vec[i], x1_rvec[j]) / l),
+          sigma * sigma
+              * std::exp(-1.0
+                         * stan::math::squared_distance(x2_vec[i], x1_rvec[j])
+                         / l),
           cov7(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov2;
-  EXPECT_NO_THROW(
-      cov2 = stan::math::gp_exponential_cov(x1_vec, x2_rvec, sigma, l));
+  EXPECT_NO_THROW(cov2
+                  = stan::math::gp_exponential_cov(x1_vec, x2_rvec, sigma, l));
   EXPECT_EQ(3, cov2.rows());
   EXPECT_EQ(4, cov2.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-          sigma * sigma *
-              std::exp(-1.0 *
-                       stan::math::squared_distance(x1_vec[i], x2_rvec[j]) / l),
+          sigma * sigma
+              * std::exp(-1.0
+                         * stan::math::squared_distance(x1_vec[i], x2_rvec[j])
+                         / l),
           cov2(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov8;
-  EXPECT_NO_THROW(
-      cov8 = stan::math::gp_exponential_cov(x2_rvec, x1_vec, sigma, l));
+  EXPECT_NO_THROW(cov8
+                  = stan::math::gp_exponential_cov(x2_rvec, x1_vec, sigma, l));
   EXPECT_EQ(4, cov8.rows());
   EXPECT_EQ(3, cov8.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-          sigma * sigma *
-              std::exp(-1.0 *
-                       stan::math::squared_distance(x2_rvec[i], x1_vec[j]) / l),
+          sigma * sigma
+              * std::exp(-1.0
+                         * stan::math::squared_distance(x2_rvec[i], x1_vec[j])
+                         / l),
           cov8(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov3;
-  EXPECT_NO_THROW(
-      cov3 = stan::math::gp_exponential_cov(x2_vec, x2_rvec, sigma, l));
+  EXPECT_NO_THROW(cov3
+                  = stan::math::gp_exponential_cov(x2_vec, x2_rvec, sigma, l));
   EXPECT_EQ(4, cov3.rows());
   EXPECT_EQ(4, cov3.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-          sigma * sigma *
-              std::exp(-1.0 *
-                       stan::math::squared_distance(x2_vec[i], x2_rvec[j]) / l),
+          sigma * sigma
+              * std::exp(-1.0
+                         * stan::math::squared_distance(x2_vec[i], x2_rvec[j])
+                         / l),
           cov3(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov4;
-  EXPECT_NO_THROW(
-      cov4 = stan::math::gp_exponential_cov(x2_rvec, x2_vec, sigma, l));
+  EXPECT_NO_THROW(cov4
+                  = stan::math::gp_exponential_cov(x2_rvec, x2_vec, sigma, l));
   EXPECT_EQ(4, cov4.rows());
   EXPECT_EQ(4, cov4.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-          sigma * sigma *
-              std::exp(-1.0 *
-                       stan::math::squared_distance(x2_rvec[i], x2_vec[j]) / l),
+          sigma * sigma
+              * std::exp(-1.0
+                         * stan::math::squared_distance(x2_rvec[i], x2_vec[j])
+                         / l),
           cov4(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov5;
-  EXPECT_NO_THROW(
-      cov5 = stan::math::gp_exponential_cov(x1_rvec, x1_vec, sigma, l));
+  EXPECT_NO_THROW(cov5
+                  = stan::math::gp_exponential_cov(x1_rvec, x1_vec, sigma, l));
   EXPECT_EQ(3, cov5.rows());
   EXPECT_EQ(3, cov5.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-          sigma * sigma *
-              std::exp(-1.0 *
-                       stan::math::squared_distance(x1_rvec[i], x1_vec[j]) / l),
+          sigma * sigma
+              * std::exp(-1.0
+                         * stan::math::squared_distance(x1_rvec[i], x1_vec[j])
+                         / l),
           cov5(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov6;
-  EXPECT_NO_THROW(
-      cov6 = stan::math::gp_exponential_cov(x1_vec, x1_rvec, sigma, l));
+  EXPECT_NO_THROW(cov6
+                  = stan::math::gp_exponential_cov(x1_vec, x1_rvec, sigma, l));
   EXPECT_EQ(3, cov6.rows());
   EXPECT_EQ(3, cov6.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-          sigma * sigma *
-              std::exp(-1.0 *
-                       stan::math::squared_distance(x1_vec[i], x1_rvec[j]) / l),
+          sigma * sigma
+              * std::exp(-1.0
+                         * stan::math::squared_distance(x1_vec[i], x1_rvec[j])
+                         / l),
           cov6(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -655,8 +663,8 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_exponential_cov2) {
     x2_vec[i] << 2 * i, 3 * i, 4 * i;
   }
   Eigen::MatrixXd cov;
-  EXPECT_NO_THROW(
-      cov = stan::math::gp_exponential_cov(x1_rvec, x2_vec, sigma, l));
+  EXPECT_NO_THROW(cov
+                  = stan::math::gp_exponential_cov(x1_rvec, x2_vec, sigma, l));
   EXPECT_EQ(3, cov.rows());
   EXPECT_EQ(4, cov.cols());
   for (int i = 0; i < 3; i++) {
@@ -672,8 +680,8 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_exponential_cov2) {
   }
 
   Eigen::MatrixXd cov7;
-  EXPECT_NO_THROW(
-      cov7 = stan::math::gp_exponential_cov(x2_vec, x1_rvec, sigma, l));
+  EXPECT_NO_THROW(cov7
+                  = stan::math::gp_exponential_cov(x2_vec, x1_rvec, sigma, l));
   EXPECT_EQ(4, cov7.rows());
   EXPECT_EQ(3, cov7.cols());
   for (int i = 0; i < 3; i++) {
@@ -689,8 +697,8 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_exponential_cov2) {
   }
 
   Eigen::MatrixXd cov2;
-  EXPECT_NO_THROW(
-      cov2 = stan::math::gp_exponential_cov(x1_vec, x2_rvec, sigma, l));
+  EXPECT_NO_THROW(cov2
+                  = stan::math::gp_exponential_cov(x1_vec, x2_rvec, sigma, l));
   EXPECT_EQ(3, cov2.rows());
   EXPECT_EQ(4, cov2.cols());
   for (int i = 0; i < 3; i++) {
@@ -705,8 +713,8 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_exponential_cov2) {
   }
 
   Eigen::MatrixXd cov8;
-  EXPECT_NO_THROW(
-      cov8 = stan::math::gp_exponential_cov(x2_rvec, x1_vec, sigma, l));
+  EXPECT_NO_THROW(cov8
+                  = stan::math::gp_exponential_cov(x2_rvec, x1_vec, sigma, l));
   EXPECT_EQ(4, cov8.rows());
   EXPECT_EQ(3, cov8.cols());
   for (int i = 0; i < 3; i++) {
@@ -722,8 +730,8 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_exponential_cov2) {
   }
 
   Eigen::MatrixXd cov3;
-  EXPECT_NO_THROW(
-      cov3 = stan::math::gp_exponential_cov(x2_vec, x2_rvec, sigma, l));
+  EXPECT_NO_THROW(cov3
+                  = stan::math::gp_exponential_cov(x2_vec, x2_rvec, sigma, l));
   EXPECT_EQ(4, cov3.rows());
   EXPECT_EQ(4, cov3.cols());
   for (int i = 0; i < 3; i++) {
@@ -739,8 +747,8 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_exponential_cov2) {
   }
 
   Eigen::MatrixXd cov4;
-  EXPECT_NO_THROW(
-      cov4 = stan::math::gp_exponential_cov(x2_rvec, x2_vec, sigma, l));
+  EXPECT_NO_THROW(cov4
+                  = stan::math::gp_exponential_cov(x2_rvec, x2_vec, sigma, l));
   EXPECT_EQ(4, cov4.rows());
   EXPECT_EQ(4, cov4.cols());
   for (int i = 0; i < 3; i++) {
@@ -756,8 +764,8 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_exponential_cov2) {
   }
 
   Eigen::MatrixXd cov5;
-  EXPECT_NO_THROW(
-      cov5 = stan::math::gp_exponential_cov(x1_rvec, x1_vec, sigma, l));
+  EXPECT_NO_THROW(cov5
+                  = stan::math::gp_exponential_cov(x1_rvec, x1_vec, sigma, l));
   EXPECT_EQ(3, cov5.rows());
   EXPECT_EQ(3, cov5.cols());
   for (int i = 0; i < 3; i++) {
@@ -773,8 +781,8 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_exponential_cov2) {
   }
 
   Eigen::MatrixXd cov6;
-  EXPECT_NO_THROW(
-      cov6 = stan::math::gp_exponential_cov(x1_vec, x1_rvec, sigma, l));
+  EXPECT_NO_THROW(cov6
+                  = stan::math::gp_exponential_cov(x1_vec, x1_rvec, sigma, l));
   EXPECT_EQ(3, cov6.rows());
   EXPECT_EQ(3, cov6.cols());
   for (int i = 0; i < 3; i++) {

--- a/test/unit/math/prim/mat/fun/gp_exponential_cov_test.cpp
+++ b/test/unit/math/prim/mat/fun/gp_exponential_cov_test.cpp
@@ -49,7 +49,7 @@ TEST(MathPrimMat, vec_double_gp_exponential_cov1) {
       EXPECT_FLOAT_EQ(sigma * sigma *
                           std::exp(-1.0 *
                                    stan::math::squared_distance(x[i], x[j]) /
-                                   std::pow(l, 2)),
+                                   l),
                       cov(i, j))
           << "index: (" << i << ", " << j << ")";
 }
@@ -77,7 +77,7 @@ TEST(MathPrimMat, vec_double_ard_gp_exponential_cov1) {
       temp = 0;
       for (int k = 0; k < 5; k++) {
         temp +=
-            stan::math::squared_distance(x[i], x[j]) / stan::math::square(l[k]);
+            stan::math::squared_distance(x[i], x[j]) / l[k];
       }
 
       EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp), cov(i, j))
@@ -103,7 +103,7 @@ TEST(MathPrimMat, vec_eigen_gp_exponential_cov1) {
       EXPECT_FLOAT_EQ(sigma * sigma *
                           std::exp(-1.0 *
                                    stan::math::squared_distance(x1[i], x1[j]) /
-                                   std::pow(l, 2)),
+                                   l),
                       cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -133,7 +133,7 @@ TEST(MathPrimMat, vec_eigen_eigen_gp_exponential_cov1) {
       EXPECT_FLOAT_EQ(sigma * sigma *
                           std::exp(-1.0 *
                                    stan::math::squared_distance(x1[i], x2[j]) /
-                                   std::pow(l, 2)),
+                                   l),
                       cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -161,7 +161,7 @@ TEST(MathPrimMat, vec_double_double_gp_exponential_cov1) {
       EXPECT_FLOAT_EQ(sigma * sigma *
                           std::exp(-1.0 *
                                    stan::math::squared_distance(x1[i], x2[j]) /
-                                   std::pow(l, 2)),
+                                   l),
                       cov(i, j))
           << "index: (" << i << ", " << j << ")";
 }
@@ -190,7 +190,7 @@ TEST(MathPrimMat, vec_eigen_ard_gp_exponential_cov1) {
       temp = 0;
       for (int k = 0; k < 5; k++) {
         temp += stan::math::squared_distance(x1[i], x1[j]) /
-                stan::math::square(l[k]);
+                l[k];
       }
       EXPECT_FLOAT_EQ(sigma * sigma * exp(-1.0 * temp), cov(i, j))
           << "index: (" << i << ", " << j << ")";
@@ -225,7 +225,7 @@ TEST(MathPrimMat, vec_double_double_ard_gp_exponential_cov1) {
       temp = 0;
       for (int k = 0; k < 4; k++) {
         temp += stan::math::squared_distance(x1[i], x2[j]) /
-                stan::math::square(l[k]);
+                l[k];
       }
       EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp), cov(i, j))
           << "index: (" << i << ", " << j << ")";
@@ -262,7 +262,7 @@ TEST(MathPrimMat, vec_eigen_eigen_ard_gp_exponential_cov1) {
       temp = 0;
       for (int k = 0; k < 4; k++) {
         temp += stan::math::squared_distance(x1[i], x2[j]) /
-                stan::math::square(l[k]);
+                l[k];
       }
       EXPECT_FLOAT_EQ(sigma * sigma * exp(-1.0 * temp), cov(i, j))
           << "index: (" << i << ", " << j << ")";
@@ -287,7 +287,7 @@ TEST(MathPrimMat, rvec_eigen_gp_exponential_cov1) {
       EXPECT_FLOAT_EQ(sigma * sigma *
                           std::exp(-1.0 *
                                    stan::math::squared_distance(x1[i], x1[j]) /
-                                   stan::math::square(l)),
+                                   l),
                       cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -317,7 +317,7 @@ TEST(MathPrimMat, vec_eigen_rvec_eigen_gp_exponential_cov1) {
       EXPECT_FLOAT_EQ(sigma * sigma *
                           std::exp(-1.0 *
                                    stan::math::squared_distance(x1[i], x2[j]) /
-                                   std::pow(l, 2)),
+                                   l),
                       cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -329,7 +329,7 @@ TEST(MathPrimMat, vec_eigen_rvec_eigen_gp_exponential_cov1) {
       EXPECT_FLOAT_EQ(sigma * sigma *
                           std::exp(-1.0 *
                                    stan::math::squared_distance(x2[i], x1[j]) /
-                                   std::pow(l, 2)),
+                                   l),
                       cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -363,7 +363,7 @@ TEST(MathPrimMat, vec_eigen_rvec_eigen_ard_gp_exponential_cov1) {
       temp = 0;
       for (int k = 0; k < 3; k++) {
         temp += stan::math::squared_distance(x1[i], x2[j]) /
-                stan::math::square(l[k]);
+                l[k];
       }
 
       EXPECT_FLOAT_EQ(sigma * sigma * exp(-1.0 * temp), cov(i, j))
@@ -376,7 +376,7 @@ TEST(MathPrimMat, vec_eigen_rvec_eigen_ard_gp_exponential_cov1) {
       temp = 0;
       for (int k = 0; k < 3; k++) {
         temp += stan::math::squared_distance(x2[i], x1[j]) /
-                stan::math::square(l[k]);
+                l[k];
       }
 
       EXPECT_FLOAT_EQ(sigma * sigma * exp(-1.0 * temp), cov(i, j))
@@ -408,7 +408,7 @@ TEST(MathPrimMat, rvec_eigen_rvec_eigen_gp_exponential_cov1) {
       EXPECT_FLOAT_EQ(sigma * sigma *
                           std::exp(-1.0 *
                                    stan::math::squared_distance(x1[i], x2[j]) /
-                                   std::pow(l, 2)),
+                                   l),
                       cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -420,7 +420,7 @@ TEST(MathPrimMat, rvec_eigen_rvec_eigen_gp_exponential_cov1) {
       EXPECT_FLOAT_EQ(sigma * sigma *
                           std::exp(-1.0 *
                                    stan::math::squared_distance(x2[i], x1[j]) /
-                                   std::pow(l, 2)),
+                                   l),
                       cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -455,7 +455,7 @@ TEST(MathPrimMat, rvec_eigen_rvec_eigen_ard_gp_exponential_cov1) {
       temp = 0;
       for (int k = 0; k < 3; k++) {
         temp += stan::math::squared_distance(x1[i], x2[j]) /
-                stan::math::square(l[k]);
+                l[k];
       }
 
       EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp), cov(i, j))
@@ -468,7 +468,7 @@ TEST(MathPrimMat, rvec_eigen_rvec_eigen_ard_gp_exponential_cov1) {
       temp = 0;
       for (int k = 0; k < 3; k++) {
         temp += stan::math::squared_distance(x2[i], x1[j]) /
-                stan::math::square(l[k]);
+                l[k];
       }
 
       EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp), cov(i, j))
@@ -517,7 +517,7 @@ TEST(MathPrimMat, vec_eigen_mixed_gp_exponential_cov2) {
       EXPECT_FLOAT_EQ(sigma * sigma *
                           std::exp(-1.0 * stan::math::squared_distance(
                                               x1_rvec[i], x2_vec[j]) /
-                                   std::pow(l, 2)),
+                                   l),
                       cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -533,7 +533,7 @@ TEST(MathPrimMat, vec_eigen_mixed_gp_exponential_cov2) {
       EXPECT_FLOAT_EQ(sigma * sigma *
                           std::exp(-1.0 * stan::math::squared_distance(
                                               x2_vec[i], x1_rvec[j]) /
-                                   std::pow(l, 2)),
+                                   l),
                       cov7(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -549,7 +549,7 @@ TEST(MathPrimMat, vec_eigen_mixed_gp_exponential_cov2) {
       EXPECT_FLOAT_EQ(sigma * sigma *
                           std::exp(-1.0 * stan::math::squared_distance(
                                               x1_vec[i], x2_rvec[j]) /
-                                   std::pow(l, 2)),
+                                   l),
                       cov2(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -565,7 +565,7 @@ TEST(MathPrimMat, vec_eigen_mixed_gp_exponential_cov2) {
       EXPECT_FLOAT_EQ(sigma * sigma *
                           std::exp(-1.0 * stan::math::squared_distance(
                                               x2_rvec[i], x1_vec[j]) /
-                                   std::pow(l, 2)),
+                                   l),
                       cov8(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -581,7 +581,7 @@ TEST(MathPrimMat, vec_eigen_mixed_gp_exponential_cov2) {
       EXPECT_FLOAT_EQ(sigma * sigma *
                           std::exp(-1.0 * stan::math::squared_distance(
                                               x2_vec[i], x2_rvec[j]) /
-                                   std::pow(l, 2)),
+                                   l),
                       cov3(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -597,7 +597,7 @@ TEST(MathPrimMat, vec_eigen_mixed_gp_exponential_cov2) {
       EXPECT_FLOAT_EQ(sigma * sigma *
                           std::exp(-1.0 * stan::math::squared_distance(
                                               x2_rvec[i], x2_vec[j]) /
-                                   std::pow(l, 2)),
+                                   l),
                       cov4(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -613,7 +613,7 @@ TEST(MathPrimMat, vec_eigen_mixed_gp_exponential_cov2) {
       EXPECT_FLOAT_EQ(sigma * sigma *
                           std::exp(-1.0 * stan::math::squared_distance(
                                               x1_rvec[i], x1_vec[j]) /
-                                   std::pow(l, 2)),
+                                   l),
                       cov5(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -629,7 +629,7 @@ TEST(MathPrimMat, vec_eigen_mixed_gp_exponential_cov2) {
       EXPECT_FLOAT_EQ(sigma * sigma *
                           std::exp(-1.0 * stan::math::squared_distance(
                                               x1_vec[i], x1_rvec[j]) /
-                                   std::pow(l, 2)),
+                                   l),
                       cov6(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -681,7 +681,7 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_exponential_cov2) {
       temp = 0;
       for (int k = 0; k < 3; k++) {
         temp += stan::math::squared_distance(x1_rvec[i], x2_vec[j]) /
-                stan::math::square(l[k]);
+                l[k];
       }
 
       EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp), cov(i, j))
@@ -699,7 +699,7 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_exponential_cov2) {
       temp = 0;
       for (int k = 0; k < 3; k++) {
         temp += stan::math::squared_distance(x2_vec[i], x1_rvec[j]) /
-                stan::math::square(l[k]);
+                l[k];
       }
 
       EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp), cov7(i, j))
@@ -717,7 +717,7 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_exponential_cov2) {
       temp = 0;
       for (int k = 0; k < 3; k++) {
         temp += stan::math::squared_distance(x1_vec[i], x2_rvec[j]) /
-                stan::math::square(l[k]);
+                l[k];
       }
       EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp), cov2(i, j))
           << "index: (" << i << ", " << j << ")";
@@ -734,7 +734,7 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_exponential_cov2) {
       temp = 0;
       for (int k = 0; k < 3; k++) {
         temp += stan::math::squared_distance(x2_rvec[i], x1_vec[j]) /
-                stan::math::square(l[k]);
+                l[k];
       }
 
       EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp), cov8(i, j))
@@ -752,7 +752,7 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_exponential_cov2) {
       temp = 0;
       for (int k = 0; k < 3; k++) {
         temp += stan::math::squared_distance(x2_vec[i], x2_rvec[j]) /
-                stan::math::square(l[k]);
+                l[k];
       }
 
       EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp), cov3(i, j))
@@ -770,7 +770,7 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_exponential_cov2) {
       temp = 0;
       for (int k = 0; k < 3; k++) {
         temp += stan::math::squared_distance(x2_rvec[i], x2_vec[j]) /
-                stan::math::square(l[k]);
+                l[k];
       }
 
       EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp), cov4(i, j))
@@ -788,7 +788,7 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_exponential_cov2) {
       temp = 0;
       for (int k = 0; k < 3; k++) {
         temp += stan::math::squared_distance(x1_rvec[i], x1_vec[j]) /
-                stan::math::square(l[k]);
+                l[k];
       }
 
       EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp), cov5(i, j))
@@ -806,7 +806,7 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_exponential_cov2) {
       temp = 0;
       for (int k = 0; k < 3; k++) {
         temp += stan::math::squared_distance(x1_vec[i], x1_rvec[j]) /
-                stan::math::square(l[k]);
+                l[k];
       }
 
       EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp), cov6(i, j))

--- a/test/unit/math/prim/mat/fun/gp_exponential_cov_test.cpp
+++ b/test/unit/math/prim/mat/fun/gp_exponential_cov_test.cpp
@@ -1,8 +1,8 @@
-#include <cmath>
 #include <gtest/gtest.h>
-#include <limits>
 #include <stan/math/prim/mat.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <cmath>
+#include <limits>
 #include <string>
 #include <vector>
 

--- a/test/unit/math/prim/mat/fun/gp_exponential_cov_test.cpp
+++ b/test/unit/math/prim/mat/fun/gp_exponential_cov_test.cpp
@@ -46,11 +46,10 @@ TEST(MathPrimMat, vec_double_gp_exponential_cov1) {
   cov = stan::math::gp_exponential_cov(x, sigma, l);
   for (int i = 0; i < 3; i++)
     for (int j = 0; j < 3; j++)
-      EXPECT_FLOAT_EQ(sigma * sigma *
-                          std::exp(-1.0 *
-                                   stan::math::squared_distance(x[i], x[j]) /
-                                   l),
-                      cov(i, j))
+      EXPECT_FLOAT_EQ(
+          sigma * sigma *
+              std::exp(-1.0 * stan::math::squared_distance(x[i], x[j]) / l),
+          cov(i, j))
           << "index: (" << i << ", " << j << ")";
 }
 
@@ -76,8 +75,7 @@ TEST(MathPrimMat, vec_double_ard_gp_exponential_cov1) {
     for (int j = 0; j < 3; j++) {
       temp = 0;
       for (int k = 0; k < 5; k++) {
-        temp +=
-            stan::math::squared_distance(x[i], x[j]) / l[k];
+        temp += stan::math::squared_distance(x[i], x[j]) / l[k];
       }
 
       EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp), cov(i, j))
@@ -100,11 +98,10 @@ TEST(MathPrimMat, vec_eigen_gp_exponential_cov1) {
   cov = stan::math::gp_exponential_cov(x1, sigma, l);
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
-      EXPECT_FLOAT_EQ(sigma * sigma *
-                          std::exp(-1.0 *
-                                   stan::math::squared_distance(x1[i], x1[j]) /
-                                   l),
-                      cov(i, j))
+      EXPECT_FLOAT_EQ(
+          sigma * sigma *
+              std::exp(-1.0 * stan::math::squared_distance(x1[i], x1[j]) / l),
+          cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -130,11 +127,10 @@ TEST(MathPrimMat, vec_eigen_eigen_gp_exponential_cov1) {
   cov = stan::math::gp_exponential_cov(x1, x2, sigma, l);
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
-      EXPECT_FLOAT_EQ(sigma * sigma *
-                          std::exp(-1.0 *
-                                   stan::math::squared_distance(x1[i], x2[j]) /
-                                   l),
-                      cov(i, j))
+      EXPECT_FLOAT_EQ(
+          sigma * sigma *
+              std::exp(-1.0 * stan::math::squared_distance(x1[i], x2[j]) / l),
+          cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -158,11 +154,10 @@ TEST(MathPrimMat, vec_double_double_gp_exponential_cov1) {
   cov = stan::math::gp_exponential_cov(x1, x2, sigma, l);
   for (int i = 0; i < 3; i++)
     for (int j = 0; j < 3; j++)
-      EXPECT_FLOAT_EQ(sigma * sigma *
-                          std::exp(-1.0 *
-                                   stan::math::squared_distance(x1[i], x2[j]) /
-                                   l),
-                      cov(i, j))
+      EXPECT_FLOAT_EQ(
+          sigma * sigma *
+              std::exp(-1.0 * stan::math::squared_distance(x1[i], x2[j]) / l),
+          cov(i, j))
           << "index: (" << i << ", " << j << ")";
 }
 
@@ -189,8 +184,7 @@ TEST(MathPrimMat, vec_eigen_ard_gp_exponential_cov1) {
     for (int j = 0; j < 3; j++) {
       temp = 0;
       for (int k = 0; k < 5; k++) {
-        temp += stan::math::squared_distance(x1[i], x1[j]) /
-                l[k];
+        temp += stan::math::squared_distance(x1[i], x1[j]) / l[k];
       }
       EXPECT_FLOAT_EQ(sigma * sigma * exp(-1.0 * temp), cov(i, j))
           << "index: (" << i << ", " << j << ")";
@@ -224,8 +218,7 @@ TEST(MathPrimMat, vec_double_double_ard_gp_exponential_cov1) {
     for (int j = 0; j < 3; j++) {
       temp = 0;
       for (int k = 0; k < 4; k++) {
-        temp += stan::math::squared_distance(x1[i], x2[j]) /
-                l[k];
+        temp += stan::math::squared_distance(x1[i], x2[j]) / l[k];
       }
       EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp), cov(i, j))
           << "index: (" << i << ", " << j << ")";
@@ -261,8 +254,7 @@ TEST(MathPrimMat, vec_eigen_eigen_ard_gp_exponential_cov1) {
     for (int j = 0; j < 3; j++) {
       temp = 0;
       for (int k = 0; k < 4; k++) {
-        temp += stan::math::squared_distance(x1[i], x2[j]) /
-                l[k];
+        temp += stan::math::squared_distance(x1[i], x2[j]) / l[k];
       }
       EXPECT_FLOAT_EQ(sigma * sigma * exp(-1.0 * temp), cov(i, j))
           << "index: (" << i << ", " << j << ")";
@@ -284,11 +276,10 @@ TEST(MathPrimMat, rvec_eigen_gp_exponential_cov1) {
   cov = stan::math::gp_exponential_cov(x1, sigma, l);
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
-      EXPECT_FLOAT_EQ(sigma * sigma *
-                          std::exp(-1.0 *
-                                   stan::math::squared_distance(x1[i], x1[j]) /
-                                   l),
-                      cov(i, j))
+      EXPECT_FLOAT_EQ(
+          sigma * sigma *
+              std::exp(-1.0 * stan::math::squared_distance(x1[i], x1[j]) / l),
+          cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -314,11 +305,10 @@ TEST(MathPrimMat, vec_eigen_rvec_eigen_gp_exponential_cov1) {
   cov = stan::math::gp_exponential_cov(x1, x2, sigma, l);
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
-      EXPECT_FLOAT_EQ(sigma * sigma *
-                          std::exp(-1.0 *
-                                   stan::math::squared_distance(x1[i], x2[j]) /
-                                   l),
-                      cov(i, j))
+      EXPECT_FLOAT_EQ(
+          sigma * sigma *
+              std::exp(-1.0 * stan::math::squared_distance(x1[i], x2[j]) / l),
+          cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -326,11 +316,10 @@ TEST(MathPrimMat, vec_eigen_rvec_eigen_gp_exponential_cov1) {
   cov = stan::math::gp_exponential_cov(x2, x1, sigma, l);
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
-      EXPECT_FLOAT_EQ(sigma * sigma *
-                          std::exp(-1.0 *
-                                   stan::math::squared_distance(x2[i], x1[j]) /
-                                   l),
-                      cov(i, j))
+      EXPECT_FLOAT_EQ(
+          sigma * sigma *
+              std::exp(-1.0 * stan::math::squared_distance(x2[i], x1[j]) / l),
+          cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -362,8 +351,7 @@ TEST(MathPrimMat, vec_eigen_rvec_eigen_ard_gp_exponential_cov1) {
     for (int j = 0; j < 3; j++) {
       temp = 0;
       for (int k = 0; k < 3; k++) {
-        temp += stan::math::squared_distance(x1[i], x2[j]) /
-                l[k];
+        temp += stan::math::squared_distance(x1[i], x2[j]) / l[k];
       }
 
       EXPECT_FLOAT_EQ(sigma * sigma * exp(-1.0 * temp), cov(i, j))
@@ -375,8 +363,7 @@ TEST(MathPrimMat, vec_eigen_rvec_eigen_ard_gp_exponential_cov1) {
     for (int j = 0; j < 3; j++) {
       temp = 0;
       for (int k = 0; k < 3; k++) {
-        temp += stan::math::squared_distance(x2[i], x1[j]) /
-                l[k];
+        temp += stan::math::squared_distance(x2[i], x1[j]) / l[k];
       }
 
       EXPECT_FLOAT_EQ(sigma * sigma * exp(-1.0 * temp), cov(i, j))
@@ -405,11 +392,10 @@ TEST(MathPrimMat, rvec_eigen_rvec_eigen_gp_exponential_cov1) {
   cov = stan::math::gp_exponential_cov(x1, x2, sigma, l);
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
-      EXPECT_FLOAT_EQ(sigma * sigma *
-                          std::exp(-1.0 *
-                                   stan::math::squared_distance(x1[i], x2[j]) /
-                                   l),
-                      cov(i, j))
+      EXPECT_FLOAT_EQ(
+          sigma * sigma *
+              std::exp(-1.0 * stan::math::squared_distance(x1[i], x2[j]) / l),
+          cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -417,11 +403,10 @@ TEST(MathPrimMat, rvec_eigen_rvec_eigen_gp_exponential_cov1) {
   cov = stan::math::gp_exponential_cov(x2, x1, sigma, l);
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
-      EXPECT_FLOAT_EQ(sigma * sigma *
-                          std::exp(-1.0 *
-                                   stan::math::squared_distance(x2[i], x1[j]) /
-                                   l),
-                      cov(i, j))
+      EXPECT_FLOAT_EQ(
+          sigma * sigma *
+              std::exp(-1.0 * stan::math::squared_distance(x2[i], x1[j]) / l),
+          cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -454,8 +439,7 @@ TEST(MathPrimMat, rvec_eigen_rvec_eigen_ard_gp_exponential_cov1) {
     for (int j = 0; j < 3; j++) {
       temp = 0;
       for (int k = 0; k < 3; k++) {
-        temp += stan::math::squared_distance(x1[i], x2[j]) /
-                l[k];
+        temp += stan::math::squared_distance(x1[i], x2[j]) / l[k];
       }
 
       EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp), cov(i, j))
@@ -467,8 +451,7 @@ TEST(MathPrimMat, rvec_eigen_rvec_eigen_ard_gp_exponential_cov1) {
     for (int j = 0; j < 3; j++) {
       temp = 0;
       for (int k = 0; k < 3; k++) {
-        temp += stan::math::squared_distance(x2[i], x1[j]) /
-                l[k];
+        temp += stan::math::squared_distance(x2[i], x1[j]) / l[k];
       }
 
       EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp), cov(i, j))
@@ -514,11 +497,11 @@ TEST(MathPrimMat, vec_eigen_mixed_gp_exponential_cov2) {
   EXPECT_EQ(4, cov.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
-      EXPECT_FLOAT_EQ(sigma * sigma *
-                          std::exp(-1.0 * stan::math::squared_distance(
-                                              x1_rvec[i], x2_vec[j]) /
-                                   l),
-                      cov(i, j))
+      EXPECT_FLOAT_EQ(
+          sigma * sigma *
+              std::exp(-1.0 *
+                       stan::math::squared_distance(x1_rvec[i], x2_vec[j]) / l),
+          cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -530,11 +513,11 @@ TEST(MathPrimMat, vec_eigen_mixed_gp_exponential_cov2) {
   EXPECT_EQ(3, cov7.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
-      EXPECT_FLOAT_EQ(sigma * sigma *
-                          std::exp(-1.0 * stan::math::squared_distance(
-                                              x2_vec[i], x1_rvec[j]) /
-                                   l),
-                      cov7(i, j))
+      EXPECT_FLOAT_EQ(
+          sigma * sigma *
+              std::exp(-1.0 *
+                       stan::math::squared_distance(x2_vec[i], x1_rvec[j]) / l),
+          cov7(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -546,11 +529,11 @@ TEST(MathPrimMat, vec_eigen_mixed_gp_exponential_cov2) {
   EXPECT_EQ(4, cov2.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
-      EXPECT_FLOAT_EQ(sigma * sigma *
-                          std::exp(-1.0 * stan::math::squared_distance(
-                                              x1_vec[i], x2_rvec[j]) /
-                                   l),
-                      cov2(i, j))
+      EXPECT_FLOAT_EQ(
+          sigma * sigma *
+              std::exp(-1.0 *
+                       stan::math::squared_distance(x1_vec[i], x2_rvec[j]) / l),
+          cov2(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -562,11 +545,11 @@ TEST(MathPrimMat, vec_eigen_mixed_gp_exponential_cov2) {
   EXPECT_EQ(3, cov8.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
-      EXPECT_FLOAT_EQ(sigma * sigma *
-                          std::exp(-1.0 * stan::math::squared_distance(
-                                              x2_rvec[i], x1_vec[j]) /
-                                   l),
-                      cov8(i, j))
+      EXPECT_FLOAT_EQ(
+          sigma * sigma *
+              std::exp(-1.0 *
+                       stan::math::squared_distance(x2_rvec[i], x1_vec[j]) / l),
+          cov8(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -578,11 +561,11 @@ TEST(MathPrimMat, vec_eigen_mixed_gp_exponential_cov2) {
   EXPECT_EQ(4, cov3.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
-      EXPECT_FLOAT_EQ(sigma * sigma *
-                          std::exp(-1.0 * stan::math::squared_distance(
-                                              x2_vec[i], x2_rvec[j]) /
-                                   l),
-                      cov3(i, j))
+      EXPECT_FLOAT_EQ(
+          sigma * sigma *
+              std::exp(-1.0 *
+                       stan::math::squared_distance(x2_vec[i], x2_rvec[j]) / l),
+          cov3(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -594,11 +577,11 @@ TEST(MathPrimMat, vec_eigen_mixed_gp_exponential_cov2) {
   EXPECT_EQ(4, cov4.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
-      EXPECT_FLOAT_EQ(sigma * sigma *
-                          std::exp(-1.0 * stan::math::squared_distance(
-                                              x2_rvec[i], x2_vec[j]) /
-                                   l),
-                      cov4(i, j))
+      EXPECT_FLOAT_EQ(
+          sigma * sigma *
+              std::exp(-1.0 *
+                       stan::math::squared_distance(x2_rvec[i], x2_vec[j]) / l),
+          cov4(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -610,11 +593,11 @@ TEST(MathPrimMat, vec_eigen_mixed_gp_exponential_cov2) {
   EXPECT_EQ(3, cov5.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
-      EXPECT_FLOAT_EQ(sigma * sigma *
-                          std::exp(-1.0 * stan::math::squared_distance(
-                                              x1_rvec[i], x1_vec[j]) /
-                                   l),
-                      cov5(i, j))
+      EXPECT_FLOAT_EQ(
+          sigma * sigma *
+              std::exp(-1.0 *
+                       stan::math::squared_distance(x1_rvec[i], x1_vec[j]) / l),
+          cov5(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -626,11 +609,11 @@ TEST(MathPrimMat, vec_eigen_mixed_gp_exponential_cov2) {
   EXPECT_EQ(3, cov6.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
-      EXPECT_FLOAT_EQ(sigma * sigma *
-                          std::exp(-1.0 * stan::math::squared_distance(
-                                              x1_vec[i], x1_rvec[j]) /
-                                   l),
-                      cov6(i, j))
+      EXPECT_FLOAT_EQ(
+          sigma * sigma *
+              std::exp(-1.0 *
+                       stan::math::squared_distance(x1_vec[i], x1_rvec[j]) / l),
+          cov6(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -680,8 +663,7 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_exponential_cov2) {
     for (int j = 0; j < 3; j++) {
       temp = 0;
       for (int k = 0; k < 3; k++) {
-        temp += stan::math::squared_distance(x1_rvec[i], x2_vec[j]) /
-                l[k];
+        temp += stan::math::squared_distance(x1_rvec[i], x2_vec[j]) / l[k];
       }
 
       EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp), cov(i, j))
@@ -698,8 +680,7 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_exponential_cov2) {
     for (int j = 0; j < 3; j++) {
       temp = 0;
       for (int k = 0; k < 3; k++) {
-        temp += stan::math::squared_distance(x2_vec[i], x1_rvec[j]) /
-                l[k];
+        temp += stan::math::squared_distance(x2_vec[i], x1_rvec[j]) / l[k];
       }
 
       EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp), cov7(i, j))
@@ -716,8 +697,7 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_exponential_cov2) {
     for (int j = 0; j < 3; j++) {
       temp = 0;
       for (int k = 0; k < 3; k++) {
-        temp += stan::math::squared_distance(x1_vec[i], x2_rvec[j]) /
-                l[k];
+        temp += stan::math::squared_distance(x1_vec[i], x2_rvec[j]) / l[k];
       }
       EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp), cov2(i, j))
           << "index: (" << i << ", " << j << ")";
@@ -733,8 +713,7 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_exponential_cov2) {
     for (int j = 0; j < 3; j++) {
       temp = 0;
       for (int k = 0; k < 3; k++) {
-        temp += stan::math::squared_distance(x2_rvec[i], x1_vec[j]) /
-                l[k];
+        temp += stan::math::squared_distance(x2_rvec[i], x1_vec[j]) / l[k];
       }
 
       EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp), cov8(i, j))
@@ -751,8 +730,7 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_exponential_cov2) {
     for (int j = 0; j < 3; j++) {
       temp = 0;
       for (int k = 0; k < 3; k++) {
-        temp += stan::math::squared_distance(x2_vec[i], x2_rvec[j]) /
-                l[k];
+        temp += stan::math::squared_distance(x2_vec[i], x2_rvec[j]) / l[k];
       }
 
       EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp), cov3(i, j))
@@ -769,8 +747,7 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_exponential_cov2) {
     for (int j = 0; j < 3; j++) {
       temp = 0;
       for (int k = 0; k < 3; k++) {
-        temp += stan::math::squared_distance(x2_rvec[i], x2_vec[j]) /
-                l[k];
+        temp += stan::math::squared_distance(x2_rvec[i], x2_vec[j]) / l[k];
       }
 
       EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp), cov4(i, j))
@@ -787,8 +764,7 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_exponential_cov2) {
     for (int j = 0; j < 3; j++) {
       temp = 0;
       for (int k = 0; k < 3; k++) {
-        temp += stan::math::squared_distance(x1_rvec[i], x1_vec[j]) /
-                l[k];
+        temp += stan::math::squared_distance(x1_rvec[i], x1_vec[j]) / l[k];
       }
 
       EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp), cov5(i, j))
@@ -805,8 +781,7 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_exponential_cov2) {
     for (int j = 0; j < 3; j++) {
       temp = 0;
       for (int k = 0; k < 3; k++) {
-        temp += stan::math::squared_distance(x1_vec[i], x1_rvec[j]) /
-                l[k];
+        temp += stan::math::squared_distance(x1_vec[i], x1_rvec[j]) / l[k];
       }
 
       EXPECT_FLOAT_EQ(sigma * sigma * std::exp(-1.0 * temp), cov6(i, j))


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary:
Add exponential covariance function to prim with ARD support. This is consistent with with both GMPL (Rasmussen & Williams) and our current quadratic exponential covariance function. Users will be able to switch back and forth between covariance functions easily, per Mike's suggestion on discourse. Please see the latex documentation for description of how I calculate the function and ARD.

#### How to Verify:
Here are the different data types and error message calls I tested:
vec double
vec double double
vec double ARD
vec eigen
vec eigen eigen
vec eigen ARD
vec double double ARD
rvec eigen
rvec eigen ARD
vec eigen rvec eigen
vec eigen rvec eigen ARD
rvec eigen rvec eigen
rvec eigen rvec eigen ARD
eigen mixed
eigen mixed ARD
double domain err training
nan error training
differing x lengths

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Copywrite<2018><Andre Zapico>

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
