### PR TITLE
Feature/issue 864 matern 5/2 prim

### DIFF
--- a/stan/math/prim/mat.hpp
+++ b/stan/math/prim/mat.hpp
@@ -15,8 +15,8 @@
 #include <stan/math/prim/mat/meta/length.hpp>
 #include <stan/math/prim/mat/meta/length_mvt.hpp>
 #include <stan/math/prim/mat/meta/operands_and_partials.hpp>
-#include <stan/math/prim/mat/meta/seq_view.hpp>
 #include <stan/math/prim/mat/meta/scalar_type.hpp>
+#include <stan/math/prim/mat/meta/seq_view.hpp>
 #include <stan/math/prim/mat/meta/value_type.hpp>
 #include <stan/math/prim/mat/meta/vector_seq_view.hpp>
 
@@ -45,6 +45,10 @@
 #include <stan/math/prim/mat/err/constraint_tolerance.hpp>
 #include <stan/math/prim/mat/err/validate_non_negative_index.hpp>
 
+#include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <stan/math/prim/mat/fun/LDLT_factor.hpp>
+#include <stan/math/prim/mat/fun/Phi.hpp>
+#include <stan/math/prim/mat/fun/Phi_approx.hpp>
 #include <stan/math/prim/mat/fun/accumulator.hpp>
 #include <stan/math/prim/mat/fun/acos.hpp>
 #include <stan/math/prim/mat/fun/acosh.hpp>
@@ -91,17 +95,16 @@
 #include <stan/math/prim/mat/fun/csr_u_to_z.hpp>
 #include <stan/math/prim/mat/fun/cumulative_sum.hpp>
 #include <stan/math/prim/mat/fun/determinant.hpp>
-#include <stan/math/prim/mat/fun/diagonal.hpp>
 #include <stan/math/prim/mat/fun/diag_matrix.hpp>
 #include <stan/math/prim/mat/fun/diag_post_multiply.hpp>
 #include <stan/math/prim/mat/fun/diag_pre_multiply.hpp>
+#include <stan/math/prim/mat/fun/diagonal.hpp>
 #include <stan/math/prim/mat/fun/digamma.hpp>
 #include <stan/math/prim/mat/fun/dims.hpp>
 #include <stan/math/prim/mat/fun/distance.hpp>
 #include <stan/math/prim/mat/fun/divide.hpp>
 #include <stan/math/prim/mat/fun/dot_product.hpp>
 #include <stan/math/prim/mat/fun/dot_self.hpp>
-#include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/mat/fun/eigenvalues_sym.hpp>
 #include <stan/math/prim/mat/fun/eigenvectors_sym.hpp>
 #include <stan/math/prim/mat/fun/elt_divide.hpp>
@@ -112,8 +115,8 @@
 #include <stan/math/prim/mat/fun/exp2.hpp>
 #include <stan/math/prim/mat/fun/expm1.hpp>
 #include <stan/math/prim/mat/fun/fabs.hpp>
-#include <stan/math/prim/mat/fun/factor_cov_matrix.hpp>
 #include <stan/math/prim/mat/fun/factor_U.hpp>
+#include <stan/math/prim/mat/fun/factor_cov_matrix.hpp>
 #include <stan/math/prim/mat/fun/fill.hpp>
 #include <stan/math/prim/mat/fun/floor.hpp>
 #include <stan/math/prim/mat/fun/get_base1.hpp>
@@ -123,14 +126,13 @@
 #include <stan/math/prim/mat/fun/head.hpp>
 #include <stan/math/prim/mat/fun/initialize.hpp>
 #include <stan/math/prim/mat/fun/inv.hpp>
-#include <stan/math/prim/mat/fun/inverse.hpp>
-#include <stan/math/prim/mat/fun/inverse_spd.hpp>
+#include <stan/math/prim/mat/fun/inv_Phi.hpp>
 #include <stan/math/prim/mat/fun/inv_cloglog.hpp>
 #include <stan/math/prim/mat/fun/inv_logit.hpp>
-#include <stan/math/prim/mat/fun/inv_Phi.hpp>
 #include <stan/math/prim/mat/fun/inv_sqrt.hpp>
 #include <stan/math/prim/mat/fun/inv_square.hpp>
-#include <stan/math/prim/mat/fun/LDLT_factor.hpp>
+#include <stan/math/prim/mat/fun/inverse.hpp>
+#include <stan/math/prim/mat/fun/inverse_spd.hpp>
 #include <stan/math/prim/mat/fun/lgamma.hpp>
 #include <stan/math/prim/mat/fun/log.hpp>
 #include <stan/math/prim/mat/fun/log10.hpp>
@@ -169,8 +171,6 @@
 #include <stan/math/prim/mat/fun/num_elements.hpp>
 #include <stan/math/prim/mat/fun/ordered_constrain.hpp>
 #include <stan/math/prim/mat/fun/ordered_free.hpp>
-#include <stan/math/prim/mat/fun/Phi.hpp>
-#include <stan/math/prim/mat/fun/Phi_approx.hpp>
 #include <stan/math/prim/mat/fun/positive_ordered_constrain.hpp>
 #include <stan/math/prim/mat/fun/positive_ordered_free.hpp>
 #include <stan/math/prim/mat/fun/prod.hpp>
@@ -215,9 +215,9 @@
 #include <stan/math/prim/mat/fun/square.hpp>
 #include <stan/math/prim/mat/fun/squared_distance.hpp>
 #include <stan/math/prim/mat/fun/stan_print.hpp>
-#include <stan/math/prim/mat/fun/subtract.hpp>
 #include <stan/math/prim/mat/fun/sub_col.hpp>
 #include <stan/math/prim/mat/fun/sub_row.hpp>
+#include <stan/math/prim/mat/fun/subtract.hpp>
 #include <stan/math/prim/mat/fun/sum.hpp>
 #include <stan/math/prim/mat/fun/tail.hpp>
 #include <stan/math/prim/mat/fun/tan.hpp>
@@ -249,17 +249,17 @@
 #include <stan/math/prim/mat/functor/finite_diff_gradient.hpp>
 #include <stan/math/prim/mat/functor/finite_diff_hessian.hpp>
 #include <stan/math/prim/mat/functor/map_rect.hpp>
-#include <stan/math/prim/mat/functor/map_rect_serial.hpp>
-#include <stan/math/prim/mat/functor/map_rect_reduce.hpp>
 #include <stan/math/prim/mat/functor/map_rect_combine.hpp>
+#include <stan/math/prim/mat/functor/map_rect_reduce.hpp>
+#include <stan/math/prim/mat/functor/map_rect_serial.hpp>
 
 #include <stan/math/prim/mat/prob/bernoulli_logit_glm_lpmf.hpp>
 #include <stan/math/prim/mat/prob/categorical_log.hpp>
-#include <stan/math/prim/mat/prob/categorical_lpmf.hpp>
 #include <stan/math/prim/mat/prob/categorical_logit_log.hpp>
 #include <stan/math/prim/mat/prob/categorical_logit_lpmf.hpp>
-#include <stan/math/prim/mat/prob/categorical_rng.hpp>
 #include <stan/math/prim/mat/prob/categorical_logit_rng.hpp>
+#include <stan/math/prim/mat/prob/categorical_lpmf.hpp>
+#include <stan/math/prim/mat/prob/categorical_rng.hpp>
 #include <stan/math/prim/mat/prob/dirichlet_log.hpp>
 #include <stan/math/prim/mat/prob/dirichlet_lpmf.hpp>
 #include <stan/math/prim/mat/prob/dirichlet_rng.hpp>
@@ -301,10 +301,10 @@
 #include <stan/math/prim/mat/prob/ordered_logistic_log.hpp>
 #include <stan/math/prim/mat/prob/ordered_logistic_lpmf.hpp>
 #include <stan/math/prim/mat/prob/ordered_logistic_rng.hpp>
-#include <stan/math/prim/mat/prob/poisson_log_glm_lpmf.hpp>
 #include <stan/math/prim/mat/prob/ordered_probit_log.hpp>
 #include <stan/math/prim/mat/prob/ordered_probit_lpmf.hpp>
 #include <stan/math/prim/mat/prob/ordered_probit_rng.hpp>
+#include <stan/math/prim/mat/prob/poisson_log_glm_lpmf.hpp>
 #include <stan/math/prim/mat/prob/wishart_log.hpp>
 #include <stan/math/prim/mat/prob/wishart_lpdf.hpp>
 #include <stan/math/prim/mat/prob/wishart_rng.hpp>

--- a/stan/math/prim/mat.hpp
+++ b/stan/math/prim/mat.hpp
@@ -119,6 +119,7 @@
 #include <stan/math/prim/mat/fun/get_base1.hpp>
 #include <stan/math/prim/mat/fun/get_base1_lhs.hpp>
 #include <stan/math/prim/mat/fun/get_lp.hpp>
+#include <stan/math/prim/mat/fun/gp_matern_5_2_cov.hpp>
 #include <stan/math/prim/mat/fun/head.hpp>
 #include <stan/math/prim/mat/fun/initialize.hpp>
 #include <stan/math/prim/mat/fun/inv.hpp>

--- a/stan/math/prim/mat/fun/gp_matern_5_2_cov.hpp
+++ b/stan/math/prim/mat/fun/gp_matern_5_2_cov.hpp
@@ -1,0 +1,216 @@
+#ifndef STAN_MATH_PRIM_MAT_FUN_GP_MATERN_5_2_COV_HPP
+#define STAN_MATH_PRIM_MAT_FUN_GP_MATERN_5_2_COV_HPP
+
+#include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <stan/math/prim/scal/err/check_finite.hpp>
+#include <stan/math/prim/scal/err/check_nonnegative.hpp>
+#include <stan/math/prim/scal/err/check_not_nan.hpp>
+#include <stan/math/prim/scal/fun/square.hpp>
+#include <stan/math/prim/scal/fun/squared_distance.hpp>
+#include <stan/math/prim/scal/meta/return_type.hpp>
+#include <cmath>
+#include <vector>
+
+
+namespace stan {
+namespace math {
+
+template <typename T_x, typename T_s, typename T_l>
+inline typename Eigen::Matrix<typename stan::return_type<T_x, T_s, T_l>::type,
+                              Eigen::Dynamic, Eigen::Dynamic>
+gp_matern_5_2_cov(const std::vector<T_x> &x, const T_s &sigma,
+                  const T_l &length_scale) {
+  using stan::math::square;
+  using stan::math::squared_distance;
+  using std::exp;
+  using std::pow;
+
+  size_t x_size = x.size();
+  for (size_t n = 0; n < x_size; ++n)
+    check_not_nan("gp_matern_5_2_cov", "x", x[n]);
+
+  check_positive("gp_matern_5_2_cov", "marginal variance", sigma);
+  check_not_nan("gp_matern_5_2_cov", "marginal variance", sigma);
+
+  check_positive("gp_matern_5_2_cov", "length-scale", length_scale);
+  check_not_nan("gp_matern_5_2_cov", "length-scale", length_scale);
+
+  Eigen::Matrix<typename stan::return_type<T_x, T_s, T_l>::type, Eigen::Dynamic,
+                Eigen::Dynamic>
+      cov(x_size, x_size);
+
+  if (x_size == 0)
+    return cov;
+
+  T_s sigma_sq = square(sigma);
+  T_l root_5_inv_l = pow(5.0, 0.5) / length_scale;
+  T_l inv_l_sq_5_3 = 5.0 / (3.0 * square(length_scale));
+  T_l neg_root_5_inv_l = -1.0 * pow(5.0, 0.5) / length_scale;
+  
+  for (size_t i = 0; i < (x_size - 1); ++i) {
+    cov(i, i) = sigma_sq;
+    for (size_t j = i + 1; j < x_size; ++j) {
+      cov(i, j) = sigma_sq *
+        (1.0 + root_5_inv_l * squared_distance(x[i], x[j]) +
+         inv_l_sq_5_3 * pow(squared_distance(x[i], x[j]), 2.0)) *
+        exp(neg_root_5_inv_l * squared_distance(x[i], x[j]));
+      cov(j, i) = cov(i, j);
+    }
+  }
+  cov(x_size - 1, x_size - 1) = sigma_sq;
+  return cov;
+}
+
+template <typename T_x, typename T_s, typename T_l>
+inline typename Eigen::Matrix<typename stan::return_type<T_x, T_s, T_l>::type,
+                              Eigen::Dynamic, Eigen::Dynamic>
+gp_matern_5_2_cov(const std::vector<T_x> &x, const T_s &sigma,
+                  const std::vector<T_l> &length_scale) {
+  using stan::math::square;
+  using stan::math::squared_distance;
+  using std::exp;
+  using std::pow;
+
+  size_t x_size = x.size();
+  size_t l_size = length_scale.size();
+  for (size_t n = 0; n < x_size; ++n)
+    check_not_nan("gp_matern_5_2_cov", "x", x[n]);
+
+  check_positive("gp_matern_5_2_cov", "marginal variance", sigma);
+  check_not_nan("gp_matern_5_2_cov", "marginal variance", sigma);
+
+  check_positive("gp_matern_5_2_cov", "length-scale", length_scale);
+  check_not_nan("gp_matern_5_2_cov", "length-scale", length_scale);
+
+  Eigen::Matrix<typename stan::return_type<T_x, T_s, T_l>::type, Eigen::Dynamic,
+                Eigen::Dynamic>
+      cov(x_size, x_size);
+
+  if (x_size == 0)
+    return cov;
+
+  T_s sigma_sq = square(sigma);
+  T_l root_5 = pow(5.0, 0.5);
+  T_l five_thirds = 5.0 / 3.0;
+  T_l neg_root_5 = -1.0 * pow(5.0, 0.5);
+  T_l temp;
+  
+  for (size_t i = 0; i < (x_size - 1); ++i) {
+    cov(i, i) = sigma_sq;
+    for (size_t j = i + 1; j < x_size; ++j) {
+      temp = 0;
+      for (size_t k = 0; k < l_size; ++k)
+        temp += squared_distance(x[i], x[j]) / square(length_scale[k]);
+      cov(i, j) = sigma_sq *
+        (1.0 + root_5 * temp + five_thirds * square(temp)) *
+        exp(neg_root_5 * temp);
+      cov(j, i) = cov(i, j);
+    }
+  }
+  cov(x_size - 1, x_size - 1) = sigma_sq;
+  return cov;
+}
+
+template <typename T_x1, typename T_x2, typename T_s, typename T_l>
+inline typename Eigen::Matrix<typename stan::return_type<T_x1, T_x2,
+                                                         T_s, T_l>::type,
+                              Eigen::Dynamic, Eigen::Dynamic>
+gp_matern_5_2_cov(const std::vector<T_x1> &x1, const std::vector<T_x2> &x2, 
+                  const T_s &sigma, const T_l &length_scale) {
+  using stan::math::square;
+  using stan::math::squared_distance;
+  using std::exp;
+  using std::pow;
+
+  size_t x1_size = x1.size();
+  size_t x2_size = x2.size();
+
+  for (size_t n = 0; n < x1_size; ++n)
+    check_not_nan("gp_matern_5_2_cov", "x1", x1[n]);
+  for (size_t n = 0; n < x2_size; ++n)
+    check_not_nan("gp_matern_5_2_cov", "x1", x2[n]);
+
+  check_positive("gp_matern_5_2_cov", "marginal variance", sigma);
+  check_not_nan("gp_matern_5_2_cov", "marginal variance", sigma);
+
+  check_positive("gp_matern_5_2_cov", "length-scale", length_scale);
+  check_not_nan("gp_matern_5_2_cov", "length-scale", length_scale);
+
+  Eigen::Matrix<typename stan::return_type<T_x1, T_x2, T_s, T_l>::type,
+                Eigen::Dynamic, Eigen::Dynamic>
+      cov(x1_size, x2_size);
+
+  if (x1_size == 0 || x2_size == 0)
+    return cov;
+
+  T_s sigma_sq = square(sigma);
+  T_l root_5_inv_l = pow(5.0, 0.5) / length_scale;
+  T_l inv_l_sq_5_3 = 5.0 / (3.0 * square(length_scale));
+  T_l neg_root_5_inv_l = -1.0 * pow(5.0, 0.5) / length_scale;
+  
+  for (size_t i = 0; i < x1_size; ++i) {
+    for (size_t j = 0; j < x2_size; ++j) {
+      cov(i, j) = sigma_sq *
+        (1.0 + root_5_inv_l * squared_distance(x1[i], x2[j]) +
+         inv_l_sq_5_3 * pow(squared_distance(x1[i], x2[j]), 2.0)) *
+        exp(neg_root_5_inv_l * squared_distance(x1[i], x2[j]));
+    }
+  }
+  return cov;
+}
+
+template <typename T_x1, typename T_x2, typename T_s, typename T_l>
+inline typename Eigen::Matrix<typename stan::return_type<T_x1, T_x2,
+                                                         T_s, T_l>::type,
+                              Eigen::Dynamic, Eigen::Dynamic>
+gp_matern_5_2_cov(const std::vector<T_x1> &x1, const std::vector<T_x2> &x2, 
+                  const T_s &sigma, const std::vector<T_l> &length_scale) {
+  using stan::math::square;
+  using stan::math::squared_distance;
+  using std::exp;
+  using std::pow;
+
+  size_t x1_size = x1.size();
+  size_t x2_size = x2.size();
+  size_t l_size = length_scale.size();
+
+  for (size_t n = 0; n < x1_size; ++n)
+    check_not_nan("gp_matern_5_2_cov", "x1", x1[n]);
+  for (size_t n = 0; n < x2_size; ++n)
+    check_not_nan("gp_matern_5_2_cov", "x1", x2[n]);
+
+  check_positive("gp_matern_5_2_cov", "marginal variance", sigma);
+  check_not_nan("gp_matern_5_2_cov", "marginal variance", sigma);
+
+  check_positive("gp_matern_5_2_cov", "length-scale", length_scale);
+  for (size_t n = 0; n < l_size; ++n)
+    check_not_nan("gp_matern_5_2_cov", "length-scale", length_scale[n]);
+
+  Eigen::Matrix<typename stan::return_type<T_x1, T_x2, T_s, T_l>::type,
+                Eigen::Dynamic, Eigen::Dynamic>
+      cov(x1_size, x2_size);
+
+  if (x1_size == 0 || x2_size == 0)
+    return cov;
+
+  T_s sigma_sq = square(sigma);
+  T_l root_5 = pow(5.0, 0.5);
+  T_l five_thirds = 5.0 / 3.0;
+  T_l neg_root_5 = -1.0 * pow(5.0, 0.5);
+  T_l temp;
+  
+  for (size_t i = 0; i < x1_size; ++i) {
+    for (size_t j = 0; j < x2_size; ++j) {
+      temp = 0;
+      for (size_t k = 0; k < l_size; ++k)
+        temp += squared_distance(x1[i], x2[j]) / square(length_scale[k]);
+      cov(i, j) = sigma_sq *
+        (1.0 + root_5 * temp + five_thirds * square(temp)) *
+        exp(neg_root_5 * temp);
+    }
+  }
+  return cov;
+}
+}  // namespace math
+}  // namespace stan
+#endif

--- a/stan/math/prim/mat/fun/gp_matern_5_2_cov.hpp
+++ b/stan/math/prim/mat/fun/gp_matern_5_2_cov.hpp
@@ -1,6 +1,7 @@
 #ifndef STAN_MATH_PRIM_MAT_FUN_GP_MATERN_5_2_COV_HPP
 #define STAN_MATH_PRIM_MAT_FUN_GP_MATERN_5_2_COV_HPP
 
+#include <cmath>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/scal/err/check_finite.hpp>
 #include <stan/math/prim/scal/err/check_nonnegative.hpp>
@@ -8,9 +9,7 @@
 #include <stan/math/prim/scal/fun/square.hpp>
 #include <stan/math/prim/scal/fun/squared_distance.hpp>
 #include <stan/math/prim/scal/meta/return_type.hpp>
-#include <cmath>
 #include <vector>
-
 
 namespace stan {
 namespace math {
@@ -46,14 +45,14 @@ gp_matern_5_2_cov(const std::vector<T_x> &x, const T_s &sigma,
   T_l root_5_inv_l = pow(5.0, 0.5) / length_scale;
   T_l inv_l_sq_5_3 = 5.0 / (3.0 * square(length_scale));
   T_l neg_root_5_inv_l = -1.0 * pow(5.0, 0.5) / length_scale;
-  
+
   for (size_t i = 0; i < (x_size - 1); ++i) {
     cov(i, i) = sigma_sq;
     for (size_t j = i + 1; j < x_size; ++j) {
       cov(i, j) = sigma_sq *
-        (1.0 + root_5_inv_l * squared_distance(x[i], x[j]) +
-         inv_l_sq_5_3 * pow(squared_distance(x[i], x[j]), 2.0)) *
-        exp(neg_root_5_inv_l * squared_distance(x[i], x[j]));
+                  (1.0 + root_5_inv_l * squared_distance(x[i], x[j]) +
+                   inv_l_sq_5_3 * pow(squared_distance(x[i], x[j]), 2.0)) *
+                  exp(neg_root_5_inv_l * squared_distance(x[i], x[j]));
       cov(j, i) = cov(i, j);
     }
   }
@@ -94,7 +93,7 @@ gp_matern_5_2_cov(const std::vector<T_x> &x, const T_s &sigma,
   T_l five_thirds = 5.0 / 3.0;
   T_l neg_root_5 = -1.0 * pow(5.0, 0.5);
   T_l temp;
-  
+
   for (size_t i = 0; i < (x_size - 1); ++i) {
     cov(i, i) = sigma_sq;
     for (size_t j = i + 1; j < x_size; ++j) {
@@ -102,8 +101,8 @@ gp_matern_5_2_cov(const std::vector<T_x> &x, const T_s &sigma,
       for (size_t k = 0; k < l_size; ++k)
         temp += squared_distance(x[i], x[j]) / square(length_scale[k]);
       cov(i, j) = sigma_sq *
-        (1.0 + root_5 * temp + five_thirds * square(temp)) *
-        exp(neg_root_5 * temp);
+                  (1.0 + root_5 * temp + five_thirds * square(temp)) *
+                  exp(neg_root_5 * temp);
       cov(j, i) = cov(i, j);
     }
   }
@@ -112,10 +111,10 @@ gp_matern_5_2_cov(const std::vector<T_x> &x, const T_s &sigma,
 }
 
 template <typename T_x1, typename T_x2, typename T_s, typename T_l>
-inline typename Eigen::Matrix<typename stan::return_type<T_x1, T_x2,
-                                                         T_s, T_l>::type,
-                              Eigen::Dynamic, Eigen::Dynamic>
-gp_matern_5_2_cov(const std::vector<T_x1> &x1, const std::vector<T_x2> &x2, 
+inline typename Eigen::Matrix<
+    typename stan::return_type<T_x1, T_x2, T_s, T_l>::type, Eigen::Dynamic,
+    Eigen::Dynamic>
+gp_matern_5_2_cov(const std::vector<T_x1> &x1, const std::vector<T_x2> &x2,
                   const T_s &sigma, const T_l &length_scale) {
   using stan::math::square;
   using stan::math::squared_distance;
@@ -147,23 +146,23 @@ gp_matern_5_2_cov(const std::vector<T_x1> &x1, const std::vector<T_x2> &x2,
   T_l root_5_inv_l = pow(5.0, 0.5) / length_scale;
   T_l inv_l_sq_5_3 = 5.0 / (3.0 * square(length_scale));
   T_l neg_root_5_inv_l = -1.0 * pow(5.0, 0.5) / length_scale;
-  
+
   for (size_t i = 0; i < x1_size; ++i) {
     for (size_t j = 0; j < x2_size; ++j) {
       cov(i, j) = sigma_sq *
-        (1.0 + root_5_inv_l * squared_distance(x1[i], x2[j]) +
-         inv_l_sq_5_3 * pow(squared_distance(x1[i], x2[j]), 2.0)) *
-        exp(neg_root_5_inv_l * squared_distance(x1[i], x2[j]));
+                  (1.0 + root_5_inv_l * squared_distance(x1[i], x2[j]) +
+                   inv_l_sq_5_3 * pow(squared_distance(x1[i], x2[j]), 2.0)) *
+                  exp(neg_root_5_inv_l * squared_distance(x1[i], x2[j]));
     }
   }
   return cov;
 }
 
 template <typename T_x1, typename T_x2, typename T_s, typename T_l>
-inline typename Eigen::Matrix<typename stan::return_type<T_x1, T_x2,
-                                                         T_s, T_l>::type,
-                              Eigen::Dynamic, Eigen::Dynamic>
-gp_matern_5_2_cov(const std::vector<T_x1> &x1, const std::vector<T_x2> &x2, 
+inline typename Eigen::Matrix<
+    typename stan::return_type<T_x1, T_x2, T_s, T_l>::type, Eigen::Dynamic,
+    Eigen::Dynamic>
+gp_matern_5_2_cov(const std::vector<T_x1> &x1, const std::vector<T_x2> &x2,
                   const T_s &sigma, const std::vector<T_l> &length_scale) {
   using stan::math::square;
   using stan::math::squared_distance;
@@ -198,19 +197,19 @@ gp_matern_5_2_cov(const std::vector<T_x1> &x1, const std::vector<T_x2> &x2,
   T_l five_thirds = 5.0 / 3.0;
   T_l neg_root_5 = -1.0 * pow(5.0, 0.5);
   T_l temp;
-  
+
   for (size_t i = 0; i < x1_size; ++i) {
     for (size_t j = 0; j < x2_size; ++j) {
       temp = 0;
       for (size_t k = 0; k < l_size; ++k)
         temp += squared_distance(x1[i], x2[j]) / square(length_scale[k]);
       cov(i, j) = sigma_sq *
-        (1.0 + root_5 * temp + five_thirds * square(temp)) *
-        exp(neg_root_5 * temp);
+                  (1.0 + root_5 * temp + five_thirds * square(temp)) *
+                  exp(neg_root_5 * temp);
     }
   }
   return cov;
 }
-}  // namespace math
-}  // namespace stan
+} // namespace math
+} // namespace stan
 #endif

--- a/stan/math/prim/mat/fun/gp_matern_5_2_cov.hpp
+++ b/stan/math/prim/mat/fun/gp_matern_5_2_cov.hpp
@@ -64,10 +64,10 @@ gp_matern_5_2_cov(const std::vector<T_x> &x, const T_s &sigma,
   for (size_t i = 0; i < (x_size - 1); ++i) {
     cov(i, i) = sigma_sq;
     for (size_t j = i + 1; j < x_size; ++j) {
-      cov(i, j) = sigma_sq *
-                  (1.0 + root_5_inv_l * squared_distance(x[i], x[j]) +
-                   inv_l_sq_5_3 * pow(squared_distance(x[i], x[j]), 2.0)) *
-                  exp(neg_root_5_inv_l * squared_distance(x[i], x[j]));
+      cov(i, j) = sigma_sq
+                  * (1.0 + root_5_inv_l * squared_distance(x[i], x[j])
+                     + inv_l_sq_5_3 * pow(squared_distance(x[i], x[j]), 2.0))
+                  * exp(neg_root_5_inv_l * squared_distance(x[i], x[j]));
       cov(j, i) = cov(i, j);
     }
   }
@@ -132,9 +132,8 @@ gp_matern_5_2_cov(const std::vector<T_x> &x, const T_s &sigma,
       temp = 0;
       for (size_t k = 0; k < l_size; ++k)
         temp += squared_distance(x[i], x[j]) / length_scale[k];
-      cov(i, j) = sigma_sq *
-                  (1.0 + root_5 * temp + five_thirds * square(temp)) *
-                  exp(neg_root_5 * temp);
+      cov(i, j) = sigma_sq * (1.0 + root_5 * temp + five_thirds * square(temp))
+                  * exp(neg_root_5 * temp);
       cov(j, i) = cov(i, j);
     }
   }
@@ -197,10 +196,10 @@ gp_matern_5_2_cov(const std::vector<T_x1> &x1, const std::vector<T_x2> &x2,
 
   for (size_t i = 0; i < x1_size; ++i) {
     for (size_t j = 0; j < x2_size; ++j) {
-      cov(i, j) = sigma_sq *
-                  (1.0 + root_5_inv_l * squared_distance(x1[i], x2[j]) +
-                   inv_l_sq_5_3 * pow(squared_distance(x1[i], x2[j]), 2.0)) *
-                  exp(neg_root_5_inv_l * squared_distance(x1[i], x2[j]));
+      cov(i, j) = sigma_sq
+                  * (1.0 + root_5_inv_l * squared_distance(x1[i], x2[j])
+                     + inv_l_sq_5_3 * pow(squared_distance(x1[i], x2[j]), 2.0))
+                  * exp(neg_root_5_inv_l * squared_distance(x1[i], x2[j]));
     }
   }
   return cov;
@@ -269,9 +268,8 @@ gp_matern_5_2_cov(const std::vector<T_x1> &x1, const std::vector<T_x2> &x2,
       temp = 0;
       for (size_t k = 0; k < l_size; ++k)
         temp += squared_distance(x1[i], x2[j]) / length_scale[k];
-      cov(i, j) = sigma_sq *
-                  (1.0 + root_5 * temp + five_thirds * square(temp)) *
-                  exp(neg_root_5 * temp);
+      cov(i, j) = sigma_sq * (1.0 + root_5 * temp + five_thirds * square(temp))
+                  * exp(neg_root_5 * temp);
     }
   }
   return cov;

--- a/test/unit/math/prim/mat/fun/gp_matern_5_2_cov_test.cpp
+++ b/test/unit/math/prim/mat/fun/gp_matern_5_2_cov_test.cpp
@@ -1,11 +1,10 @@
+#include <cmath>
 #include <gtest/gtest.h>
+#include <limits>
 #include <stan/math/prim/mat.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
-#include <cmath>
-#include <limits>
 #include <string>
 #include <vector>
-
 
 template <typename T_x, typename T_s, typename T_l>
 std::string pull_msg(std::vector<T_x> x, T_s sigma, T_l l) {
@@ -47,16 +46,18 @@ TEST(MathPrimMat, vec_double_gp_matern_5_2_cov1) {
   cov = stan::math::gp_matern_5_2_cov(x, sigma, l);
   for (int i = 0; i < 3; i++)
     for (int j = 0; j < 3; j++)
-      EXPECT_FLOAT_EQ(sigma * sigma *
-        (1 + std::pow(5, 0.5) / l * stan::math::squared_distance(x[i], x[j]) +
-         (5.0 / 3.0) * std::pow(stan::math::squared_distance(x[i], x[j]), 2) /
-         std::pow(l, 2)) * std::exp(-1.0 * pow(5.0, 0.5) *
-                                    stan::math::squared_distance(x[i], x[j])
-                                    / l),
+      EXPECT_FLOAT_EQ(
+          sigma * sigma *
+              (1 +
+               std::pow(5, 0.5) / l * stan::math::squared_distance(x[i], x[j]) +
+               (5.0 / 3.0) *
+                   std::pow(stan::math::squared_distance(x[i], x[j]), 2) /
+                   std::pow(l, 2)) *
+              std::exp(-1.0 * pow(5.0, 0.5) *
+                       stan::math::squared_distance(x[i], x[j]) / l),
           cov(i, j))
           << "index: (" << i << ", " << j << ")";
 }
-
 
 TEST(MathPrimMat, vec_double_ard_gp_matern_5_2_cov1) {
   double sigma = 0.2;
@@ -80,14 +81,13 @@ TEST(MathPrimMat, vec_double_ard_gp_matern_5_2_cov1) {
     for (int j = 0; j < 3; j++) {
       temp = 0;
       for (int k = 0; k < 5; k++) {
-        temp += stan::math::squared_distance(x[i], x[j])
-                / stan::math::square(l[k]);
+        temp +=
+            stan::math::squared_distance(x[i], x[j]) / stan::math::square(l[k]);
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma *
-        (1 + std::pow(5.0, 0.5) * temp +
-         (5.0 / 3.0) * std::pow(temp, 2.0)) *
-                      std::exp(-1.0 * pow(5.0, 0.5) * temp),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1 + std::pow(5.0, 0.5) * temp +
+                                       (5.0 / 3.0) * std::pow(temp, 2.0)) *
+                          std::exp(-1.0 * pow(5.0, 0.5) * temp),
                       cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -108,12 +108,16 @@ TEST(MathPrimMat, vec_eigen_gp_matern_5_2_cov1) {
   cov = stan::math::gp_matern_5_2_cov(x1, sigma, l);
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
-      EXPECT_FLOAT_EQ(sigma * sigma *
-        (1 + std::pow(5, 0.5) / l * stan::math::squared_distance(x1[i], x1[j]) +
-         (5.0 / 3.0) * std::pow(stan::math::squared_distance(x1[i], x1[j]), 2) /
-         std::pow(l, 2)) * std::exp(-1.0 * pow(5.0, 0.5) *
-                                    stan::math::squared_distance(x1[i], x1[j])
-                                    / l),
+      EXPECT_FLOAT_EQ(
+          sigma * sigma *
+              (1 +
+               std::pow(5, 0.5) / l *
+                   stan::math::squared_distance(x1[i], x1[j]) +
+               (5.0 / 3.0) *
+                   std::pow(stan::math::squared_distance(x1[i], x1[j]), 2) /
+                   std::pow(l, 2)) *
+              std::exp(-1.0 * pow(5.0, 0.5) *
+                       stan::math::squared_distance(x1[i], x1[j]) / l),
           cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -141,12 +145,15 @@ TEST(MathPrimMat, vec_eigen_eigen_gp_matern_5_2_cov1) {
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-          sigma * sigma * 
-        (1 + std::pow(5, 0.5) / l * stan::math::squared_distance(x1[i], x2[j]) +
-        (5.0 / 3.0) * std::pow(stan::math::squared_distance(x1[i], x2[j]), 2) /
-         std::pow(l, 2)) * std::exp(-1.0 * pow(5.0, 0.5) *
-                                    stan::math::squared_distance(x1[i], x2[j])
-                                    / l),
+          sigma * sigma *
+              (1 +
+               std::pow(5, 0.5) / l *
+                   stan::math::squared_distance(x1[i], x2[j]) +
+               (5.0 / 3.0) *
+                   std::pow(stan::math::squared_distance(x1[i], x2[j]), 2) /
+                   std::pow(l, 2)) *
+              std::exp(-1.0 * pow(5.0, 0.5) *
+                       stan::math::squared_distance(x1[i], x2[j]) / l),
           cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -173,11 +180,14 @@ TEST(MathPrimMat, vec_double_double_gp_matern_5_2_cov1) {
     for (int j = 0; j < 3; j++)
       EXPECT_FLOAT_EQ(
           sigma * sigma *
-        (1 + std::pow(5, 0.5) / l * stan::math::squared_distance(x1[i], x2[j]) +
-        (5.0 / 3.0) * std::pow(stan::math::squared_distance(x1[i], x2[j]), 2) /
-         std::pow(l, 2)) * std::exp(-1.0 * pow(5.0, 0.5) *
-                                    stan::math::squared_distance(x1[i], x2[j])
-                                    / l),
+              (1 +
+               std::pow(5, 0.5) / l *
+                   stan::math::squared_distance(x1[i], x2[j]) +
+               (5.0 / 3.0) *
+                   std::pow(stan::math::squared_distance(x1[i], x2[j]), 2) /
+                   std::pow(l, 2)) *
+              std::exp(-1.0 * pow(5.0, 0.5) *
+                       stan::math::squared_distance(x1[i], x2[j]) / l),
           cov(i, j))
           << "index: (" << i << ", " << j << ")";
 }
@@ -205,13 +215,12 @@ TEST(MathPrimMat, vec_eigen_ard_gp_matern_5_2_cov1) {
     for (int j = 0; j < 3; j++) {
       temp = 0;
       for (int k = 0; k < 5; k++) {
-        temp += stan::math::squared_distance(x1[i], x1[j])
-                / stan::math::square(l[k]);
+        temp += stan::math::squared_distance(x1[i], x1[j]) /
+                stan::math::square(l[k]);
       }
-      EXPECT_FLOAT_EQ(sigma * sigma *
-         (1 + std::pow(5.0, 0.5) * temp +
-         (5.0 / 3.0) * std::pow(temp, 2.0)) *
-                      std::exp(-1.0 * pow(5.0, 0.5) * temp),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1 + std::pow(5.0, 0.5) * temp +
+                                       (5.0 / 3.0) * std::pow(temp, 2.0)) *
+                          std::exp(-1.0 * pow(5.0, 0.5) * temp),
                       cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -244,13 +253,12 @@ TEST(MathPrimMat, vec_double_double_ard_gp_matern_5_2_cov1) {
     for (int j = 0; j < 3; j++) {
       temp = 0;
       for (int k = 0; k < 4; k++) {
-        temp += stan::math::squared_distance(x1[i], x2[j])
-                / stan::math::square(l[k]);
+        temp += stan::math::squared_distance(x1[i], x2[j]) /
+                stan::math::square(l[k]);
       }
-      EXPECT_FLOAT_EQ(sigma * sigma *
-         (1 + std::pow(5.0, 0.5) * temp +
-         (5.0 / 3.0) * std::pow(temp, 2.0)) *
-                      std::exp(-1.0 * pow(5.0, 0.5) * temp),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1 + std::pow(5.0, 0.5) * temp +
+                                       (5.0 / 3.0) * std::pow(temp, 2.0)) *
+                          std::exp(-1.0 * pow(5.0, 0.5) * temp),
                       cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -285,13 +293,12 @@ TEST(MathPrimMat, vec_eigen_eigen_ard_gp_matern_5_2_cov1) {
     for (int j = 0; j < 3; j++) {
       temp = 0;
       for (int k = 0; k < 4; k++) {
-        temp += stan::math::squared_distance(x1[i], x2[j])
-                / stan::math::square(l[k]);
+        temp += stan::math::squared_distance(x1[i], x2[j]) /
+                stan::math::square(l[k]);
       }
-      EXPECT_FLOAT_EQ(sigma * sigma *
-         (1 + std::pow(5.0, 0.5) * temp +
-         (5.0 / 3.0) * std::pow(temp, 2.0)) *
-                      std::exp(-1.0 * pow(5.0, 0.5) * temp),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1 + std::pow(5.0, 0.5) * temp +
+                                       (5.0 / 3.0) * std::pow(temp, 2.0)) *
+                          std::exp(-1.0 * pow(5.0, 0.5) * temp),
                       cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -313,12 +320,15 @@ TEST(MathPrimMat, rvec_eigen_gp_matern_5_2_cov1) {
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-        sigma * sigma * 
-        (1 + std::pow(5, 0.5) / l * stan::math::squared_distance(x1[i], x1[j]) +
-        (5.0 / 3.0) * std::pow(stan::math::squared_distance(x1[i], x1[j]), 2) /
-         std::pow(l, 2)) * std::exp(-1.0 * pow(5.0, 0.5) *
-                                    stan::math::squared_distance(x1[i], x1[j])
-                                    / l),
+          sigma * sigma *
+              (1 +
+               std::pow(5, 0.5) / l *
+                   stan::math::squared_distance(x1[i], x1[j]) +
+               (5.0 / 3.0) *
+                   std::pow(stan::math::squared_distance(x1[i], x1[j]), 2) /
+                   std::pow(l, 2)) *
+              std::exp(-1.0 * pow(5.0, 0.5) *
+                       stan::math::squared_distance(x1[i], x1[j]) / l),
           cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -347,14 +357,13 @@ TEST(MathPrimMat, rvec_eigen_ard_gp_matern_5_2_cov1) {
     for (int j = 0; j < 3; j++) {
       temp = 0;
       for (int k = 0; k < 4; k++) {
-        temp += stan::math::squared_distance(x1[i], x1[j])
-                / stan::math::square(l[k]);
+        temp += stan::math::squared_distance(x1[i], x1[j]) /
+                stan::math::square(l[k]);
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma *
-         (1 + std::pow(5.0, 0.5) * temp +
-         (5.0 / 3.0) * std::pow(temp, 2.0)) *
-                      std::exp(-1.0 * pow(5.0, 0.5) * temp),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1 + std::pow(5.0, 0.5) * temp +
+                                       (5.0 / 3.0) * std::pow(temp, 2.0)) *
+                          std::exp(-1.0 * pow(5.0, 0.5) * temp),
                       cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -382,12 +391,15 @@ TEST(MathPrimMat, vec_eigen_rvec_eigen_gp_matern_5_2_cov1) {
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-        sigma * sigma * 
-        (1 + std::pow(5, 0.5) / l * stan::math::squared_distance(x1[i], x2[j]) +
-        (5.0 / 3.0) * std::pow(stan::math::squared_distance(x1[i], x2[j]), 2) /
-         std::pow(l, 2)) * std::exp(-1.0 * pow(5.0, 0.5) *
-                                    stan::math::squared_distance(x1[i], x2[j])
-                                    / l),
+          sigma * sigma *
+              (1 +
+               std::pow(5, 0.5) / l *
+                   stan::math::squared_distance(x1[i], x2[j]) +
+               (5.0 / 3.0) *
+                   std::pow(stan::math::squared_distance(x1[i], x2[j]), 2) /
+                   std::pow(l, 2)) *
+              std::exp(-1.0 * pow(5.0, 0.5) *
+                       stan::math::squared_distance(x1[i], x2[j]) / l),
           cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -397,12 +409,15 @@ TEST(MathPrimMat, vec_eigen_rvec_eigen_gp_matern_5_2_cov1) {
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-        sigma * sigma * 
-        (1 + std::pow(5, 0.5) / l * stan::math::squared_distance(x2[i], x1[j]) +
-        (5.0 / 3.0) * std::pow(stan::math::squared_distance(x2[i], x1[j]), 2) /
-         std::pow(l, 2)) * std::exp(-1.0 * pow(5.0, 0.5) *
-                                    stan::math::squared_distance(x2[i], x1[j])
-                                    / l),
+          sigma * sigma *
+              (1 +
+               std::pow(5, 0.5) / l *
+                   stan::math::squared_distance(x2[i], x1[j]) +
+               (5.0 / 3.0) *
+                   std::pow(stan::math::squared_distance(x2[i], x1[j]), 2) /
+                   std::pow(l, 2)) *
+              std::exp(-1.0 * pow(5.0, 0.5) *
+                       stan::math::squared_distance(x2[i], x1[j]) / l),
           cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -435,14 +450,13 @@ TEST(MathPrimMat, vec_eigen_rvec_eigen_ard_gp_matern_5_2_cov1) {
     for (int j = 0; j < 3; j++) {
       temp = 0;
       for (int k = 0; k < 3; k++) {
-        temp += stan::math::squared_distance(x1[i], x2[j])
-                / stan::math::square(l[k]);
+        temp += stan::math::squared_distance(x1[i], x2[j]) /
+                stan::math::square(l[k]);
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma *
-         (1 + std::pow(5.0, 0.5) * temp +
-         (5.0 / 3.0) * std::pow(temp, 2.0)) *
-                      std::exp(-1.0 * pow(5.0, 0.5) * temp),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1 + std::pow(5.0, 0.5) * temp +
+                                       (5.0 / 3.0) * std::pow(temp, 2.0)) *
+                          std::exp(-1.0 * pow(5.0, 0.5) * temp),
                       cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -452,14 +466,13 @@ TEST(MathPrimMat, vec_eigen_rvec_eigen_ard_gp_matern_5_2_cov1) {
     for (int j = 0; j < 3; j++) {
       temp = 0;
       for (int k = 0; k < 3; k++) {
-        temp += stan::math::squared_distance(x2[i], x1[j])
-                / stan::math::square(l[k]);
+        temp += stan::math::squared_distance(x2[i], x1[j]) /
+                stan::math::square(l[k]);
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma *
-         (1 + std::pow(5.0, 0.5) * temp +
-         (5.0 / 3.0) * std::pow(temp, 2.0)) *
-                      std::exp(-1.0 * pow(5.0, 0.5) * temp),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1 + std::pow(5.0, 0.5) * temp +
+                                       (5.0 / 3.0) * std::pow(temp, 2.0)) *
+                          std::exp(-1.0 * pow(5.0, 0.5) * temp),
                       cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -487,12 +500,15 @@ TEST(MathPrimMat, rvec_eigen_rvec_eigen_gp_matern_5_2_cov1) {
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-        sigma * sigma * 
-        (1 + std::pow(5, 0.5) / l * stan::math::squared_distance(x1[i], x2[j]) +
-        (5.0 / 3.0) * std::pow(stan::math::squared_distance(x1[i], x2[j]), 2) /
-         std::pow(l, 2)) * std::exp(-1.0 * pow(5.0, 0.5) *
-                                    stan::math::squared_distance(x1[i], x2[j])
-                                    / l),
+          sigma * sigma *
+              (1 +
+               std::pow(5, 0.5) / l *
+                   stan::math::squared_distance(x1[i], x2[j]) +
+               (5.0 / 3.0) *
+                   std::pow(stan::math::squared_distance(x1[i], x2[j]), 2) /
+                   std::pow(l, 2)) *
+              std::exp(-1.0 * pow(5.0, 0.5) *
+                       stan::math::squared_distance(x1[i], x2[j]) / l),
           cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -502,12 +518,15 @@ TEST(MathPrimMat, rvec_eigen_rvec_eigen_gp_matern_5_2_cov1) {
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-        sigma * sigma * 
-        (1 + std::pow(5, 0.5) / l * stan::math::squared_distance(x2[i], x1[j]) +
-        (5.0 / 3.0) * std::pow(stan::math::squared_distance(x2[i], x1[j]), 2) /
-         std::pow(l, 2)) * std::exp(-1.0 * pow(5.0, 0.5) *
-                                    stan::math::squared_distance(x2[i], x1[j])
-                                    / l),
+          sigma * sigma *
+              (1 +
+               std::pow(5, 0.5) / l *
+                   stan::math::squared_distance(x2[i], x1[j]) +
+               (5.0 / 3.0) *
+                   std::pow(stan::math::squared_distance(x2[i], x1[j]), 2) /
+                   std::pow(l, 2)) *
+              std::exp(-1.0 * pow(5.0, 0.5) *
+                       stan::math::squared_distance(x2[i], x1[j]) / l),
           cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -541,13 +560,12 @@ TEST(MathPrimMat, rvec_eigen_rvec_eigen_ard_gp_matern_5_2_cov1) {
     for (int j = 0; j < 3; j++) {
       temp = 0;
       for (int k = 0; k < 3; k++) {
-        temp += stan::math::squared_distance(x1[i], x2[j])
-                / stan::math::square(l[k]);
+        temp += stan::math::squared_distance(x1[i], x2[j]) /
+                stan::math::square(l[k]);
       }
-      EXPECT_FLOAT_EQ(sigma * sigma *
-         (1 + std::pow(5.0, 0.5) * temp +
-         (5.0 / 3.0) * std::pow(temp, 2.0)) *
-                      std::exp(-1.0 * pow(5.0, 0.5) * temp),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1 + std::pow(5.0, 0.5) * temp +
+                                       (5.0 / 3.0) * std::pow(temp, 2.0)) *
+                          std::exp(-1.0 * pow(5.0, 0.5) * temp),
                       cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -557,13 +575,12 @@ TEST(MathPrimMat, rvec_eigen_rvec_eigen_ard_gp_matern_5_2_cov1) {
     for (int j = 0; j < 3; j++) {
       temp = 0;
       for (int k = 0; k < 3; k++) {
-        temp += stan::math::squared_distance(x2[i], x1[j])
-                / stan::math::square(l[k]);
+        temp += stan::math::squared_distance(x2[i], x1[j]) /
+                stan::math::square(l[k]);
       }
-      EXPECT_FLOAT_EQ(sigma * sigma *
-         (1 + std::pow(5.0, 0.5) * temp +
-         (5.0 / 3.0) * std::pow(temp, 2.0)) *
-                      std::exp(-1.0 * pow(5.0, 0.5) * temp),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1 + std::pow(5.0, 0.5) * temp +
+                                       (5.0 / 3.0) * std::pow(temp, 2.0)) *
+                          std::exp(-1.0 * pow(5.0, 0.5) * temp),
                       cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -601,176 +618,184 @@ TEST(MathPrimMat, vec_eigen_mixed_gp_matern_5_2_cov2) {
     x2_vec[i] << 2 * i, 3 * i, 4 * i;
   }
   Eigen::MatrixXd cov;
-  EXPECT_NO_THROW(cov
-                  = stan::math::gp_matern_5_2_cov(x1_rvec, x2_vec, sigma, l));
+  EXPECT_NO_THROW(cov =
+                      stan::math::gp_matern_5_2_cov(x1_rvec, x2_vec, sigma, l));
   EXPECT_EQ(3, cov.rows());
   EXPECT_EQ(4, cov.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-        sigma * sigma * 
-        (1 + std::pow(5, 0.5) / l * stan::math::squared_distance(x1_rvec[i],
-                                                                 x2_vec[j]) +
-        (5.0 / 3.0) * std::pow(stan::math::squared_distance(x1_rvec[i],
-                                                            x2_vec[j]), 2) /
-         std::pow(l, 2)) * std::exp(-1.0 * pow(5.0, 0.5) *
-                                    stan::math::squared_distance(x1_rvec[i],
-                                                                 x2_vec[j])
-                                    / l),
+          sigma * sigma *
+              (1 +
+               std::pow(5, 0.5) / l *
+                   stan::math::squared_distance(x1_rvec[i], x2_vec[j]) +
+               (5.0 / 3.0) *
+                   std::pow(stan::math::squared_distance(x1_rvec[i], x2_vec[j]),
+                            2) /
+                   std::pow(l, 2)) *
+              std::exp(-1.0 * pow(5.0, 0.5) *
+                       stan::math::squared_distance(x1_rvec[i], x2_vec[j]) / l),
           cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov7;
-  EXPECT_NO_THROW(cov7
-                  = stan::math::gp_matern_5_2_cov(x2_vec, x1_rvec, sigma, l));
+  EXPECT_NO_THROW(cov7 =
+                      stan::math::gp_matern_5_2_cov(x2_vec, x1_rvec, sigma, l));
   EXPECT_EQ(4, cov7.rows());
   EXPECT_EQ(3, cov7.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-        sigma * sigma * 
-        (1 + std::pow(5, 0.5) / l * stan::math::squared_distance(x2_vec[i],
-                                                                 x1_rvec[j]) +
-         (5.0 / 3.0) * std::pow(stan::math::squared_distance(x2_vec[i],
-                                                             x1_rvec[j]), 2) /
-         std::pow(l, 2)) * std::exp(-1.0 * pow(5.0, 0.5) *
-                                    stan::math::squared_distance(x2_vec[i],
-                                                                 x1_rvec[j])
-                                    / l),
+          sigma * sigma *
+              (1 +
+               std::pow(5, 0.5) / l *
+                   stan::math::squared_distance(x2_vec[i], x1_rvec[j]) +
+               (5.0 / 3.0) *
+                   std::pow(stan::math::squared_distance(x2_vec[i], x1_rvec[j]),
+                            2) /
+                   std::pow(l, 2)) *
+              std::exp(-1.0 * pow(5.0, 0.5) *
+                       stan::math::squared_distance(x2_vec[i], x1_rvec[j]) / l),
           cov7(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov2;
-  EXPECT_NO_THROW(cov2
-                  = stan::math::gp_matern_5_2_cov(x1_vec, x2_rvec, sigma, l));
+  EXPECT_NO_THROW(cov2 =
+                      stan::math::gp_matern_5_2_cov(x1_vec, x2_rvec, sigma, l));
   EXPECT_EQ(3, cov2.rows());
   EXPECT_EQ(4, cov2.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-        sigma * sigma * 
-        (1 + std::pow(5, 0.5) / l * stan::math::squared_distance(x1_vec[i],
-                                                                 x2_rvec[j]) +
-        (5.0 / 3.0) * std::pow(stan::math::squared_distance(x1_vec[i],
-                                                            x2_rvec[j]), 2) /
-         std::pow(l, 2)) * std::exp(-1.0 * pow(5.0, 0.5) *
-                                    stan::math::squared_distance(x1_vec[i],
-                                                                 x2_rvec[j])
-                                    / l),
+          sigma * sigma *
+              (1 +
+               std::pow(5, 0.5) / l *
+                   stan::math::squared_distance(x1_vec[i], x2_rvec[j]) +
+               (5.0 / 3.0) *
+                   std::pow(stan::math::squared_distance(x1_vec[i], x2_rvec[j]),
+                            2) /
+                   std::pow(l, 2)) *
+              std::exp(-1.0 * pow(5.0, 0.5) *
+                       stan::math::squared_distance(x1_vec[i], x2_rvec[j]) / l),
           cov2(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov8;
-  EXPECT_NO_THROW(cov8
-                  = stan::math::gp_matern_5_2_cov(x2_rvec, x1_vec, sigma, l));
+  EXPECT_NO_THROW(cov8 =
+                      stan::math::gp_matern_5_2_cov(x2_rvec, x1_vec, sigma, l));
   EXPECT_EQ(4, cov8.rows());
   EXPECT_EQ(3, cov8.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-        sigma * sigma * 
-        (1 + std::pow(5, 0.5) / l * stan::math::squared_distance(x2_rvec[i],
-                                                                 x1_vec[j]) +
-        (5.0 / 3.0) * std::pow(stan::math::squared_distance(x2_rvec[i],
-                                                            x1_vec[j]), 2) /
-         std::pow(l, 2)) * std::exp(-1.0 * pow(5.0, 0.5) *
-                                    stan::math::squared_distance(x2_rvec[i],
-                                                                 x1_vec[j])
-                                    / l),
+          sigma * sigma *
+              (1 +
+               std::pow(5, 0.5) / l *
+                   stan::math::squared_distance(x2_rvec[i], x1_vec[j]) +
+               (5.0 / 3.0) *
+                   std::pow(stan::math::squared_distance(x2_rvec[i], x1_vec[j]),
+                            2) /
+                   std::pow(l, 2)) *
+              std::exp(-1.0 * pow(5.0, 0.5) *
+                       stan::math::squared_distance(x2_rvec[i], x1_vec[j]) / l),
           cov8(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov3;
-  EXPECT_NO_THROW(cov3
-                  = stan::math::gp_matern_5_2_cov(x2_vec, x2_rvec, sigma, l));
+  EXPECT_NO_THROW(cov3 =
+                      stan::math::gp_matern_5_2_cov(x2_vec, x2_rvec, sigma, l));
   EXPECT_EQ(4, cov3.rows());
   EXPECT_EQ(4, cov3.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-        sigma * sigma * 
-        (1 + std::pow(5, 0.5) / l * stan::math::squared_distance(x2_vec[i],
-                                                                 x2_rvec[j]) +
-        (5.0 / 3.0) * std::pow(stan::math::squared_distance(x2_vec[i],
-                                                            x2_rvec[j]), 2) /
-         std::pow(l, 2)) * std::exp(-1.0 * pow(5.0, 0.5) *
-                                    stan::math::squared_distance(x2_vec[i],
-                                                                 x2_rvec[j])
-                                    / l),
+          sigma * sigma *
+              (1 +
+               std::pow(5, 0.5) / l *
+                   stan::math::squared_distance(x2_vec[i], x2_rvec[j]) +
+               (5.0 / 3.0) *
+                   std::pow(stan::math::squared_distance(x2_vec[i], x2_rvec[j]),
+                            2) /
+                   std::pow(l, 2)) *
+              std::exp(-1.0 * pow(5.0, 0.5) *
+                       stan::math::squared_distance(x2_vec[i], x2_rvec[j]) / l),
           cov3(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov4;
-  EXPECT_NO_THROW(cov4
-                  = stan::math::gp_matern_5_2_cov(x2_rvec, x2_vec, sigma, l));
+  EXPECT_NO_THROW(cov4 =
+                      stan::math::gp_matern_5_2_cov(x2_rvec, x2_vec, sigma, l));
   EXPECT_EQ(4, cov4.rows());
   EXPECT_EQ(4, cov4.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-        sigma * sigma * 
-        (1 + std::pow(5, 0.5) / l * stan::math::squared_distance(x2_rvec[i],
-                                                                 x2_vec[j]) +
-        (5.0 / 3.0) * std::pow(stan::math::squared_distance(x2_rvec[i],
-                                                            x2_vec[j]), 2) /
-         std::pow(l, 2)) * std::exp(-1.0 * pow(5.0, 0.5) *
-                                    stan::math::squared_distance(x2_rvec[i],
-                                                                 x2_vec[j])
-                                    / l),
+          sigma * sigma *
+              (1 +
+               std::pow(5, 0.5) / l *
+                   stan::math::squared_distance(x2_rvec[i], x2_vec[j]) +
+               (5.0 / 3.0) *
+                   std::pow(stan::math::squared_distance(x2_rvec[i], x2_vec[j]),
+                            2) /
+                   std::pow(l, 2)) *
+              std::exp(-1.0 * pow(5.0, 0.5) *
+                       stan::math::squared_distance(x2_rvec[i], x2_vec[j]) / l),
           cov4(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov5;
-  EXPECT_NO_THROW(cov5
-                  = stan::math::gp_matern_5_2_cov(x1_rvec, x1_vec, sigma, l));
+  EXPECT_NO_THROW(cov5 =
+                      stan::math::gp_matern_5_2_cov(x1_rvec, x1_vec, sigma, l));
   EXPECT_EQ(3, cov5.rows());
   EXPECT_EQ(3, cov5.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-        sigma * sigma * 
-        (1 + std::pow(5, 0.5) / l * stan::math::squared_distance(x1_rvec[i],
-                                                                 x1_vec[j]) +
-        (5.0 / 3.0) * std::pow(stan::math::squared_distance(x1_rvec[i],
-                                                            x1_vec[j]), 2) /
-         std::pow(l, 2)) * std::exp(-1.0 * pow(5.0, 0.5) *
-                                    stan::math::squared_distance(x1_rvec[i],
-                                                                 x1_vec[j])
-                                    / l),
+          sigma * sigma *
+              (1 +
+               std::pow(5, 0.5) / l *
+                   stan::math::squared_distance(x1_rvec[i], x1_vec[j]) +
+               (5.0 / 3.0) *
+                   std::pow(stan::math::squared_distance(x1_rvec[i], x1_vec[j]),
+                            2) /
+                   std::pow(l, 2)) *
+              std::exp(-1.0 * pow(5.0, 0.5) *
+                       stan::math::squared_distance(x1_rvec[i], x1_vec[j]) / l),
           cov5(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov6;
-  EXPECT_NO_THROW(cov6
-                  = stan::math::gp_matern_5_2_cov(x1_vec, x1_rvec, sigma, l));
+  EXPECT_NO_THROW(cov6 =
+                      stan::math::gp_matern_5_2_cov(x1_vec, x1_rvec, sigma, l));
   EXPECT_EQ(3, cov6.rows());
   EXPECT_EQ(3, cov6.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-        sigma * sigma * 
-        (1 + std::pow(5, 0.5) / l * stan::math::squared_distance(x1_vec[i],
-                                                                 x1_rvec[j]) +
-        (5.0 / 3.0) * std::pow(stan::math::squared_distance(x1_vec[i],
-                                                            x1_rvec[j]), 2) /
-         std::pow(l, 2)) * std::exp(-1.0 * pow(5.0, 0.5) *
-                                    stan::math::squared_distance(x1_vec[i],
-                                                                 x1_rvec[j])
-                                    / l),
+          sigma * sigma *
+              (1 +
+               std::pow(5, 0.5) / l *
+                   stan::math::squared_distance(x1_vec[i], x1_rvec[j]) +
+               (5.0 / 3.0) *
+                   std::pow(stan::math::squared_distance(x1_vec[i], x1_rvec[j]),
+                            2) /
+                   std::pow(l, 2)) *
+              std::exp(-1.0 * pow(5.0, 0.5) *
+                       stan::math::squared_distance(x1_vec[i], x1_rvec[j]) / l),
           cov6(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -813,176 +838,168 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_matern_5_2_cov2) {
     x2_vec[i] << 2 * i, 3 * i, 4 * i;
   }
   Eigen::MatrixXd cov;
-  EXPECT_NO_THROW(cov
-                  = stan::math::gp_matern_5_2_cov(x1_rvec, x2_vec, sigma, l));
+  EXPECT_NO_THROW(cov =
+                      stan::math::gp_matern_5_2_cov(x1_rvec, x2_vec, sigma, l));
   EXPECT_EQ(3, cov.rows());
   EXPECT_EQ(4, cov.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       temp = 0;
       for (int k = 0; k < 3; k++) {
-        temp += stan::math::squared_distance(x1_rvec[i], x2_vec[j])
-                / stan::math::square(l[k]);
+        temp += stan::math::squared_distance(x1_rvec[i], x2_vec[j]) /
+                stan::math::square(l[k]);
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma *
-         (1 + std::pow(5.0, 0.5) * temp +
-         (5.0 / 3.0) * std::pow(temp, 2.0)) *
-                      std::exp(-1.0 * pow(5.0, 0.5) * temp),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1 + std::pow(5.0, 0.5) * temp +
+                                       (5.0 / 3.0) * std::pow(temp, 2.0)) *
+                          std::exp(-1.0 * pow(5.0, 0.5) * temp),
                       cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov7;
-  EXPECT_NO_THROW(cov7
-                  = stan::math::gp_matern_5_2_cov(x2_vec, x1_rvec, sigma, l));
+  EXPECT_NO_THROW(cov7 =
+                      stan::math::gp_matern_5_2_cov(x2_vec, x1_rvec, sigma, l));
   EXPECT_EQ(4, cov7.rows());
   EXPECT_EQ(3, cov7.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       temp = 0;
       for (int k = 0; k < 3; k++) {
-        temp += stan::math::squared_distance(x2_vec[i], x1_rvec[j])
-                / stan::math::square(l[k]);
+        temp += stan::math::squared_distance(x2_vec[i], x1_rvec[j]) /
+                stan::math::square(l[k]);
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma *
-         (1 + std::pow(5.0, 0.5) * temp +
-         (5.0 / 3.0) * std::pow(temp, 2.0)) *
-                      std::exp(-1.0 * pow(5.0, 0.5) * temp),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1 + std::pow(5.0, 0.5) * temp +
+                                       (5.0 / 3.0) * std::pow(temp, 2.0)) *
+                          std::exp(-1.0 * pow(5.0, 0.5) * temp),
                       cov7(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov2;
-  EXPECT_NO_THROW(cov2
-                  = stan::math::gp_matern_5_2_cov(x1_vec, x2_rvec, sigma, l));
+  EXPECT_NO_THROW(cov2 =
+                      stan::math::gp_matern_5_2_cov(x1_vec, x2_rvec, sigma, l));
   EXPECT_EQ(3, cov2.rows());
   EXPECT_EQ(4, cov2.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       temp = 0;
       for (int k = 0; k < 3; k++) {
-        temp += stan::math::squared_distance(x1_vec[i], x2_rvec[j])
-                / stan::math::square(l[k]);
+        temp += stan::math::squared_distance(x1_vec[i], x2_rvec[j]) /
+                stan::math::square(l[k]);
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma *
-         (1 + std::pow(5.0, 0.5) * temp +
-         (5.0 / 3.0) * std::pow(temp, 2.0)) *
-                      std::exp(-1.0 * pow(5.0, 0.5) * temp),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1 + std::pow(5.0, 0.5) * temp +
+                                       (5.0 / 3.0) * std::pow(temp, 2.0)) *
+                          std::exp(-1.0 * pow(5.0, 0.5) * temp),
                       cov2(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov8;
-  EXPECT_NO_THROW(cov8
-                  = stan::math::gp_matern_5_2_cov(x2_rvec, x1_vec, sigma, l));
+  EXPECT_NO_THROW(cov8 =
+                      stan::math::gp_matern_5_2_cov(x2_rvec, x1_vec, sigma, l));
   EXPECT_EQ(4, cov8.rows());
   EXPECT_EQ(3, cov8.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       temp = 0;
       for (int k = 0; k < 3; k++) {
-        temp += stan::math::squared_distance(x2_rvec[i], x1_vec[j])
-                / stan::math::square(l[k]);
+        temp += stan::math::squared_distance(x2_rvec[i], x1_vec[j]) /
+                stan::math::square(l[k]);
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma *
-         (1 + std::pow(5.0, 0.5) * temp +
-         (5.0 / 3.0) * std::pow(temp, 2.0)) *
-                      std::exp(-1.0 * pow(5.0, 0.5) * temp),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1 + std::pow(5.0, 0.5) * temp +
+                                       (5.0 / 3.0) * std::pow(temp, 2.0)) *
+                          std::exp(-1.0 * pow(5.0, 0.5) * temp),
                       cov8(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov3;
-  EXPECT_NO_THROW(cov3
-                  = stan::math::gp_matern_5_2_cov(x2_vec, x2_rvec, sigma, l));
+  EXPECT_NO_THROW(cov3 =
+                      stan::math::gp_matern_5_2_cov(x2_vec, x2_rvec, sigma, l));
   EXPECT_EQ(4, cov3.rows());
   EXPECT_EQ(4, cov3.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       temp = 0;
       for (int k = 0; k < 3; k++) {
-        temp += stan::math::squared_distance(x2_vec[i], x2_rvec[j])
-                / stan::math::square(l[k]);
+        temp += stan::math::squared_distance(x2_vec[i], x2_rvec[j]) /
+                stan::math::square(l[k]);
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma *
-         (1 + std::pow(5.0, 0.5) * temp +
-         (5.0 / 3.0) * std::pow(temp, 2.0)) *
-                      std::exp(-1.0 * pow(5.0, 0.5) * temp),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1 + std::pow(5.0, 0.5) * temp +
+                                       (5.0 / 3.0) * std::pow(temp, 2.0)) *
+                          std::exp(-1.0 * pow(5.0, 0.5) * temp),
                       cov3(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov4;
-  EXPECT_NO_THROW(cov4
-                  = stan::math::gp_matern_5_2_cov(x2_rvec, x2_vec, sigma, l));
+  EXPECT_NO_THROW(cov4 =
+                      stan::math::gp_matern_5_2_cov(x2_rvec, x2_vec, sigma, l));
   EXPECT_EQ(4, cov4.rows());
   EXPECT_EQ(4, cov4.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       temp = 0;
       for (int k = 0; k < 3; k++) {
-        temp += stan::math::squared_distance(x2_rvec[i], x2_vec[j])
-                / stan::math::square(l[k]);
+        temp += stan::math::squared_distance(x2_rvec[i], x2_vec[j]) /
+                stan::math::square(l[k]);
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma *
-         (1 + std::pow(5.0, 0.5) * temp +
-         (5.0 / 3.0) * std::pow(temp, 2.0)) *
-                      std::exp(-1.0 * pow(5.0, 0.5) * temp),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1 + std::pow(5.0, 0.5) * temp +
+                                       (5.0 / 3.0) * std::pow(temp, 2.0)) *
+                          std::exp(-1.0 * pow(5.0, 0.5) * temp),
                       cov4(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov5;
-  EXPECT_NO_THROW(cov5
-                  = stan::math::gp_matern_5_2_cov(x1_rvec, x1_vec, sigma, l));
+  EXPECT_NO_THROW(cov5 =
+                      stan::math::gp_matern_5_2_cov(x1_rvec, x1_vec, sigma, l));
   EXPECT_EQ(3, cov5.rows());
   EXPECT_EQ(3, cov5.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       temp = 0;
       for (int k = 0; k < 3; k++) {
-        temp += stan::math::squared_distance(x1_rvec[i], x1_vec[j])
-                / stan::math::square(l[k]);
+        temp += stan::math::squared_distance(x1_rvec[i], x1_vec[j]) /
+                stan::math::square(l[k]);
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma *
-         (1 + std::pow(5.0, 0.5) * temp +
-         (5.0 / 3.0) * std::pow(temp, 2.0)) *
-                      std::exp(-1.0 * pow(5.0, 0.5) * temp),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1 + std::pow(5.0, 0.5) * temp +
+                                       (5.0 / 3.0) * std::pow(temp, 2.0)) *
+                          std::exp(-1.0 * pow(5.0, 0.5) * temp),
                       cov5(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov6;
-  EXPECT_NO_THROW(cov6
-                  = stan::math::gp_matern_5_2_cov(x1_vec, x1_rvec, sigma, l));
+  EXPECT_NO_THROW(cov6 =
+                      stan::math::gp_matern_5_2_cov(x1_vec, x1_rvec, sigma, l));
   EXPECT_EQ(3, cov6.rows());
   EXPECT_EQ(3, cov6.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       temp = 0;
       for (int k = 0; k < 3; k++) {
-        temp += stan::math::squared_distance(x1_vec[i], x1_rvec[j])
-                / stan::math::square(l[k]);
+        temp += stan::math::squared_distance(x1_vec[i], x1_rvec[j]) /
+                stan::math::square(l[k]);
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma *
-         (1 + std::pow(5.0, 0.5) * temp +
-         (5.0 / 3.0) * std::pow(temp, 2.0)) *
-                      std::exp(-1.0 * pow(5.0, 0.5) * temp),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1 + std::pow(5.0, 0.5) * temp +
+                                       (5.0 / 3.0) * std::pow(temp, 2.0)) *
+                          std::exp(-1.0 * pow(5.0, 0.5) * temp),
                       cov6(i, j))
           << "index: (" << i << ", " << j << ")";
     }

--- a/test/unit/math/prim/mat/fun/gp_matern_5_2_cov_test.cpp
+++ b/test/unit/math/prim/mat/fun/gp_matern_5_2_cov_test.cpp
@@ -1,0 +1,1302 @@
+#include <gtest/gtest.h>
+#include <stan/math/prim/mat.hpp>
+#include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <cmath>
+#include <limits>
+#include <string>
+#include <vector>
+
+
+template <typename T_x, typename T_s, typename T_l>
+std::string pull_msg(std::vector<T_x> x, T_s sigma, T_l l) {
+  std::string message;
+  try {
+    stan::math::gp_matern_5_2_cov(x, sigma, l);
+  } catch (std::domain_error &e) {
+    message = e.what();
+  } catch (...) {
+    message = "Threw the wrong exception";
+  }
+  return message;
+}
+
+template <typename T_x1, typename T_x2, typename T_s, typename T_l>
+std::string pull_msg(std::vector<T_x1> x1, std::vector<T_x2> x2, T_s sigma,
+                     T_l l) {
+  std::string message;
+  try {
+    stan::math::gp_matern_5_2_cov(x1, x2, sigma, l);
+  } catch (std::domain_error &e) {
+    message = e.what();
+  } catch (...) {
+    message = "Threw the wrong exception";
+  }
+  return message;
+}
+
+TEST(MathPrimMat, vec_double_gp_matern_5_2_cov1) {
+  double sigma = 0.2;
+  double l = 5.0;
+
+  std::vector<double> x(3);
+  x[0] = -2;
+  x[1] = -1;
+  x[2] = -0.5;
+
+  Eigen::MatrixXd cov;
+  cov = stan::math::gp_matern_5_2_cov(x, sigma, l);
+  for (int i = 0; i < 3; i++)
+    for (int j = 0; j < 3; j++)
+      EXPECT_FLOAT_EQ(sigma * sigma *
+        (1 + std::pow(5, 0.5) / l * stan::math::squared_distance(x[i], x[j]) +
+         (5.0 / 3.0) * std::pow(stan::math::squared_distance(x[i], x[j]), 2) /
+         std::pow(l, 2)) * std::exp(-1.0 * pow(5.0, 0.5) *
+                                    stan::math::squared_distance(x[i], x[j])
+                                    / l),
+          cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+}
+
+
+TEST(MathPrimMat, vec_double_ard_gp_matern_5_2_cov1) {
+  double sigma = 0.2;
+  double temp;
+
+  std::vector<double> x(3);
+  x[0] = -2;
+  x[1] = -1;
+  x[2] = -0.5;
+
+  std::vector<double> l(5);
+  l[0] = 0.1;
+  l[1] = 0.2;
+  l[2] = 0.3;
+  l[3] = 0.4;
+  l[4] = 0.5;
+
+  Eigen::MatrixXd cov;
+  cov = stan::math::gp_matern_5_2_cov(x, sigma, l);
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 5; k++) {
+        temp += stan::math::squared_distance(x[i], x[j])
+                / stan::math::square(l[k]);
+      }
+
+      EXPECT_FLOAT_EQ(sigma * sigma *
+        (1 + std::pow(5.0, 0.5) * temp +
+         (5.0 / 3.0) * std::pow(temp, 2.0)) *
+                      std::exp(-1.0 * pow(5.0, 0.5) * temp),
+                      cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+}
+
+TEST(MathPrimMat, vec_eigen_gp_matern_5_2_cov1) {
+  double l = 0.2;
+  double sigma = 0.3;
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x1(3);
+  for (size_t i = 0; i < x1.size(); ++i) {
+    x1[i].resize(1, 3);
+    x1[i] << 1 * i, 2 * i, 3 * i;
+  }
+
+  Eigen::MatrixXd cov;
+  cov = stan::math::gp_matern_5_2_cov(x1, sigma, l);
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      EXPECT_FLOAT_EQ(sigma * sigma *
+        (1 + std::pow(5, 0.5) / l * stan::math::squared_distance(x1[i], x1[j]) +
+         (5.0 / 3.0) * std::pow(stan::math::squared_distance(x1[i], x1[j]), 2) /
+         std::pow(l, 2)) * std::exp(-1.0 * pow(5.0, 0.5) *
+                                    stan::math::squared_distance(x1[i], x1[j])
+                                    / l),
+          cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+}
+
+TEST(MathPrimMat, vec_eigen_eigen_gp_matern_5_2_cov1) {
+  double l = 0.2;
+  double sigma = 0.3;
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x1(3);
+  for (size_t i = 0; i < x1.size(); ++i) {
+    x1[i].resize(1, 3);
+    x1[i] << 1 * i, 2 * i, 3 * i;
+  }
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x2(3);
+  for (size_t i = 0; i < x2.size(); ++i) {
+    x2[i].resize(1, 3);
+    x2[i] << 2 * i, 3 * i, 4 * i;
+  }
+
+  Eigen::MatrixXd cov;
+  cov = stan::math::gp_matern_5_2_cov(x1, x2, sigma, l);
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      EXPECT_FLOAT_EQ(
+          sigma * sigma * 
+        (1 + std::pow(5, 0.5) / l * stan::math::squared_distance(x1[i], x2[j]) +
+        (5.0 / 3.0) * std::pow(stan::math::squared_distance(x1[i], x2[j]), 2) /
+         std::pow(l, 2)) * std::exp(-1.0 * pow(5.0, 0.5) *
+                                    stan::math::squared_distance(x1[i], x2[j])
+                                    / l),
+          cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+}
+
+TEST(MathPrimMat, vec_double_double_gp_matern_5_2_cov1) {
+  double sigma = 0.2;
+  double l = 5.0;
+
+  std::vector<double> x1(3);
+  x1[0] = -2;
+  x1[1] = -1;
+  x1[2] = -0.5;
+
+  std::vector<double> x2(3);
+  x2[0] = 3;
+  x2[1] = -4;
+  x2[2] = -0.7;
+
+  Eigen::MatrixXd cov;
+  cov = stan::math::gp_matern_5_2_cov(x1, x2, sigma, l);
+  for (int i = 0; i < 3; i++)
+    for (int j = 0; j < 3; j++)
+      EXPECT_FLOAT_EQ(
+          sigma * sigma *
+        (1 + std::pow(5, 0.5) / l * stan::math::squared_distance(x1[i], x2[j]) +
+        (5.0 / 3.0) * std::pow(stan::math::squared_distance(x1[i], x2[j]), 2) /
+         std::pow(l, 2)) * std::exp(-1.0 * pow(5.0, 0.5) *
+                                    stan::math::squared_distance(x1[i], x2[j])
+                                    / l),
+          cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+}
+
+TEST(MathPrimMat, vec_eigen_ard_gp_matern_5_2_cov1) {
+  double sigma = 0.3;
+  double temp;
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x1(3);
+  for (size_t i = 0; i < x1.size(); ++i) {
+    x1[i].resize(1, 3);
+    x1[i] << 1 * i, 2 * i, 3 * i;
+  }
+
+  std::vector<double> l(5);
+  l[0] = 0.1;
+  l[1] = 0.2;
+  l[2] = 0.3;
+  l[3] = 0.4;
+  l[4] = 0.5;
+
+  Eigen::MatrixXd cov;
+  cov = stan::math::gp_matern_5_2_cov(x1, sigma, l);
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 5; k++) {
+        temp += stan::math::squared_distance(x1[i], x1[j])
+                / stan::math::square(l[k]);
+      }
+      EXPECT_FLOAT_EQ(sigma * sigma *
+         (1 + std::pow(5.0, 0.5) * temp +
+         (5.0 / 3.0) * std::pow(temp, 2.0)) *
+                      std::exp(-1.0 * pow(5.0, 0.5) * temp),
+                      cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+}
+
+TEST(MathPrimMat, vec_double_double_ard_gp_matern_5_2_cov1) {
+  double sigma = 0.2;
+  double temp;
+
+  std::vector<double> x1(3);
+  x1[0] = -2;
+  x1[1] = -1;
+  x1[2] = -0.5;
+
+  std::vector<double> x2(3);
+  x2[0] = 3;
+  x2[1] = -4;
+  x2[2] = -0.7;
+
+  std::vector<double> l(4);
+  l[0] = 1;
+  l[1] = 2;
+  l[2] = 3;
+  l[3] = 4;
+
+  Eigen::MatrixXd cov;
+  cov = stan::math::gp_matern_5_2_cov(x1, x2, sigma, l);
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 4; k++) {
+        temp += stan::math::squared_distance(x1[i], x2[j])
+                / stan::math::square(l[k]);
+      }
+      EXPECT_FLOAT_EQ(sigma * sigma *
+         (1 + std::pow(5.0, 0.5) * temp +
+         (5.0 / 3.0) * std::pow(temp, 2.0)) *
+                      std::exp(-1.0 * pow(5.0, 0.5) * temp),
+                      cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+}
+
+TEST(MathPrimMat, vec_eigen_eigen_ard_gp_matern_5_2_cov1) {
+  double sigma = 0.2;
+  double temp;
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x1(3);
+  for (size_t i = 0; i < x1.size(); ++i) {
+    x1[i].resize(1, 3);
+    x1[i] << 1 * i, 2 * i, 3 * i;
+  }
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x2(3);
+  for (size_t i = 0; i < x2.size(); ++i) {
+    x2[i].resize(1, 3);
+    x2[i] << 2 * i, 3 * i, 4 * i;
+  }
+
+  std::vector<double> l(4);
+  l[0] = 1;
+  l[1] = 2;
+  l[2] = 3;
+  l[3] = 4;
+
+  Eigen::MatrixXd cov;
+  cov = stan::math::gp_matern_5_2_cov(x1, x2, sigma, l);
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 4; k++) {
+        temp += stan::math::squared_distance(x1[i], x2[j])
+                / stan::math::square(l[k]);
+      }
+      EXPECT_FLOAT_EQ(sigma * sigma *
+         (1 + std::pow(5.0, 0.5) * temp +
+         (5.0 / 3.0) * std::pow(temp, 2.0)) *
+                      std::exp(-1.0 * pow(5.0, 0.5) * temp),
+                      cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+}
+
+TEST(MathPrimMat, rvec_eigen_gp_matern_5_2_cov1) {
+  double l = 0.2;
+  double sigma = 0.3;
+
+  std::vector<Eigen::Matrix<double, -1, 1>> x1(3);
+  for (size_t i = 0; i < x1.size(); ++i) {
+    x1[i].resize(3, 1);
+    x1[i] << 1 * i, 2 * i, 3 * i;
+  }
+
+  Eigen::MatrixXd cov;
+  cov = stan::math::gp_matern_5_2_cov(x1, sigma, l);
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      EXPECT_FLOAT_EQ(
+        sigma * sigma * 
+        (1 + std::pow(5, 0.5) / l * stan::math::squared_distance(x1[i], x1[j]) +
+        (5.0 / 3.0) * std::pow(stan::math::squared_distance(x1[i], x1[j]), 2) /
+         std::pow(l, 2)) * std::exp(-1.0 * pow(5.0, 0.5) *
+                                    stan::math::squared_distance(x1[i], x1[j])
+                                    / l),
+          cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+}
+
+TEST(MathPrimMat, rvec_eigen_ard_gp_matern_5_2_cov1) {
+  double sigma = 0.3;
+  double temp;
+
+  std::vector<Eigen::Matrix<double, -1, 1>> x1(3);
+  for (size_t i = 0; i < x1.size(); ++i) {
+    x1[i].resize(3, 1);
+    x1[i] << 1 * i, 2 * i, 3 * i;
+  }
+
+  std::vector<double> l(4);
+  l[0] = 1;
+  l[1] = 2;
+  l[2] = 3;
+  l[3] = 4;
+
+  Eigen::MatrixXd cov;
+  cov = stan::math::gp_matern_5_2_cov(x1, sigma, l);
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 4; k++) {
+        temp += stan::math::squared_distance(x1[i], x1[j])
+                / stan::math::square(l[k]);
+      }
+
+      EXPECT_FLOAT_EQ(sigma * sigma *
+         (1 + std::pow(5.0, 0.5) * temp +
+         (5.0 / 3.0) * std::pow(temp, 2.0)) *
+                      std::exp(-1.0 * pow(5.0, 0.5) * temp),
+                      cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+}
+
+TEST(MathPrimMat, vec_eigen_rvec_eigen_gp_matern_5_2_cov1) {
+  double sigma = 0.3;
+  double l = 2.3;
+
+  std::vector<Eigen::Matrix<double, -1, 1>> x1(3);
+  for (size_t i = 0; i < x1.size(); ++i) {
+    x1[i].resize(3, 1);
+    x1[i] << 1 * i, 2 * i, 3 * i;
+  }
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x2(3);
+  for (size_t i = 0; i < x2.size(); ++i) {
+    x2[i].resize(1, 3);
+    x2[i] << 2 * i, 3 * i, 4 * i;
+  }
+
+  Eigen::MatrixXd cov;
+  cov = stan::math::gp_matern_5_2_cov(x1, x2, sigma, l);
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      EXPECT_FLOAT_EQ(
+        sigma * sigma * 
+        (1 + std::pow(5, 0.5) / l * stan::math::squared_distance(x1[i], x2[j]) +
+        (5.0 / 3.0) * std::pow(stan::math::squared_distance(x1[i], x2[j]), 2) /
+         std::pow(l, 2)) * std::exp(-1.0 * pow(5.0, 0.5) *
+                                    stan::math::squared_distance(x1[i], x2[j])
+                                    / l),
+          cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+
+  cov = stan::math::gp_matern_5_2_cov(x2, x1, sigma, l);
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      EXPECT_FLOAT_EQ(
+        sigma * sigma * 
+        (1 + std::pow(5, 0.5) / l * stan::math::squared_distance(x2[i], x1[j]) +
+        (5.0 / 3.0) * std::pow(stan::math::squared_distance(x2[i], x1[j]), 2) /
+         std::pow(l, 2)) * std::exp(-1.0 * pow(5.0, 0.5) *
+                                    stan::math::squared_distance(x2[i], x1[j])
+                                    / l),
+          cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+}
+
+TEST(MathPrimMat, vec_eigen_rvec_eigen_ard_gp_matern_5_2_cov1) {
+  double sigma = 0.3;
+  double temp = 0;
+  std::vector<double> l(3);
+  l[0] = 1;
+  l[1] = 2;
+  l[2] = 3;
+
+  std::vector<Eigen::Matrix<double, -1, 1>> x1(3);
+  for (size_t i = 0; i < x1.size(); ++i) {
+    x1[i].resize(3, 1);
+    x1[i] << 1 * i, 2 * i, 3 * i;
+  }
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x2(3);
+  for (size_t i = 0; i < x2.size(); ++i) {
+    x2[i].resize(1, 3);
+    x2[i] << 2 * i, 3 * i, 4 * i;
+  }
+
+  Eigen::MatrixXd cov;
+  cov = stan::math::gp_matern_5_2_cov(x1, x2, sigma, l);
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 3; k++) {
+        temp += stan::math::squared_distance(x1[i], x2[j])
+                / stan::math::square(l[k]);
+      }
+
+      EXPECT_FLOAT_EQ(sigma * sigma *
+         (1 + std::pow(5.0, 0.5) * temp +
+         (5.0 / 3.0) * std::pow(temp, 2.0)) *
+                      std::exp(-1.0 * pow(5.0, 0.5) * temp),
+                      cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+  cov = stan::math::gp_matern_5_2_cov(x2, x1, sigma, l);
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 3; k++) {
+        temp += stan::math::squared_distance(x2[i], x1[j])
+                / stan::math::square(l[k]);
+      }
+
+      EXPECT_FLOAT_EQ(sigma * sigma *
+         (1 + std::pow(5.0, 0.5) * temp +
+         (5.0 / 3.0) * std::pow(temp, 2.0)) *
+                      std::exp(-1.0 * pow(5.0, 0.5) * temp),
+                      cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+}
+
+TEST(MathPrimMat, rvec_eigen_rvec_eigen_gp_matern_5_2_cov1) {
+  double sigma = 0.3;
+  double l = 2.3;
+
+  std::vector<Eigen::Matrix<double, -1, 1>> x1(3);
+  for (size_t i = 0; i < x1.size(); ++i) {
+    x1[i].resize(3, 1);
+    x1[i] << 1 * i, 2 * i, 3 * i;
+  }
+
+  std::vector<Eigen::Matrix<double, -1, 1>> x2(3);
+  for (size_t i = 0; i < x2.size(); ++i) {
+    x2[i].resize(3, 1);
+    x2[i] << 2 * i, 3 * i, 4 * i;
+  }
+
+  Eigen::MatrixXd cov;
+  cov = stan::math::gp_matern_5_2_cov(x1, x2, sigma, l);
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      EXPECT_FLOAT_EQ(
+        sigma * sigma * 
+        (1 + std::pow(5, 0.5) / l * stan::math::squared_distance(x1[i], x2[j]) +
+        (5.0 / 3.0) * std::pow(stan::math::squared_distance(x1[i], x2[j]), 2) /
+         std::pow(l, 2)) * std::exp(-1.0 * pow(5.0, 0.5) *
+                                    stan::math::squared_distance(x1[i], x2[j])
+                                    / l),
+          cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+
+  cov = stan::math::gp_matern_5_2_cov(x2, x1, sigma, l);
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      EXPECT_FLOAT_EQ(
+        sigma * sigma * 
+        (1 + std::pow(5, 0.5) / l * stan::math::squared_distance(x2[i], x1[j]) +
+        (5.0 / 3.0) * std::pow(stan::math::squared_distance(x2[i], x1[j]), 2) /
+         std::pow(l, 2)) * std::exp(-1.0 * pow(5.0, 0.5) *
+                                    stan::math::squared_distance(x2[i], x1[j])
+                                    / l),
+          cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+}
+
+TEST(MathPrimMat, rvec_eigen_rvec_eigen_ard_gp_matern_5_2_cov1) {
+  double sigma = 0.3;
+  double temp;
+
+  std::vector<double> l(3);
+  l[0] = 1;
+  l[1] = 2;
+  l[2] = 3;
+
+  std::vector<Eigen::Matrix<double, -1, 1>> x1(3);
+  for (size_t i = 0; i < x1.size(); ++i) {
+    x1[i].resize(3, 1);
+    x1[i] << 1 * i, 2 * i, 3 * i;
+  }
+
+  std::vector<Eigen::Matrix<double, -1, 1>> x2(3);
+  for (size_t i = 0; i < x2.size(); ++i) {
+    x2[i].resize(3, 1);
+    x2[i] << 2 * i, 3 * i, 4 * i;
+  }
+
+  Eigen::MatrixXd cov;
+  cov = stan::math::gp_matern_5_2_cov(x1, x2, sigma, l);
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 3; k++) {
+        temp += stan::math::squared_distance(x1[i], x2[j])
+                / stan::math::square(l[k]);
+      }
+      EXPECT_FLOAT_EQ(sigma * sigma *
+         (1 + std::pow(5.0, 0.5) * temp +
+         (5.0 / 3.0) * std::pow(temp, 2.0)) *
+                      std::exp(-1.0 * pow(5.0, 0.5) * temp),
+                      cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+  cov = stan::math::gp_matern_5_2_cov(x2, x1, sigma, l);
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 3; k++) {
+        temp += stan::math::squared_distance(x2[i], x1[j])
+                / stan::math::square(l[k]);
+      }
+      EXPECT_FLOAT_EQ(sigma * sigma *
+         (1 + std::pow(5.0, 0.5) * temp +
+         (5.0 / 3.0) * std::pow(temp, 2.0)) *
+                      std::exp(-1.0 * pow(5.0, 0.5) * temp),
+                      cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+}
+
+TEST(MathPrimMat, vec_eigen_mixed_gp_matern_5_2_cov2) {
+  using stan::math::squared_distance;
+  double sigma = 0.2;
+  double l = 5;
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x1_rvec(3);
+  std::vector<Eigen::Matrix<double, 1, -1>> x2_rvec(4);
+
+  for (size_t i = 0; i < x1_rvec.size(); ++i) {
+    x1_rvec[i].resize(1, 3);
+    x1_rvec[i] << 1 * i, 2 * i, 3 * i;
+  }
+
+  for (size_t i = 0; i < x2_rvec.size(); ++i) {
+    x2_rvec[i].resize(1, 3);
+    x2_rvec[i] << 2 * i, 3 * i, 4 * i;
+  }
+
+  std::vector<Eigen::Matrix<double, -1, 1>> x1_vec(3);
+  std::vector<Eigen::Matrix<double, -1, 1>> x2_vec(4);
+
+  for (size_t i = 0; i < x1_vec.size(); ++i) {
+    x1_vec[i].resize(3, 1);
+    x1_vec[i] << 1 * i, 2 * i, 3 * i;
+  }
+
+  for (size_t i = 0; i < x2_vec.size(); ++i) {
+    x2_vec[i].resize(3, 1);
+    x2_vec[i] << 2 * i, 3 * i, 4 * i;
+  }
+  Eigen::MatrixXd cov;
+  EXPECT_NO_THROW(cov
+                  = stan::math::gp_matern_5_2_cov(x1_rvec, x2_vec, sigma, l));
+  EXPECT_EQ(3, cov.rows());
+  EXPECT_EQ(4, cov.cols());
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      EXPECT_FLOAT_EQ(
+        sigma * sigma * 
+        (1 + std::pow(5, 0.5) / l * stan::math::squared_distance(x1_rvec[i],
+                                                                 x2_vec[j]) +
+        (5.0 / 3.0) * std::pow(stan::math::squared_distance(x1_rvec[i],
+                                                            x2_vec[j]), 2) /
+         std::pow(l, 2)) * std::exp(-1.0 * pow(5.0, 0.5) *
+                                    stan::math::squared_distance(x1_rvec[i],
+                                                                 x2_vec[j])
+                                    / l),
+          cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+
+  Eigen::MatrixXd cov7;
+  EXPECT_NO_THROW(cov7
+                  = stan::math::gp_matern_5_2_cov(x2_vec, x1_rvec, sigma, l));
+  EXPECT_EQ(4, cov7.rows());
+  EXPECT_EQ(3, cov7.cols());
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      EXPECT_FLOAT_EQ(
+        sigma * sigma * 
+        (1 + std::pow(5, 0.5) / l * stan::math::squared_distance(x2_vec[i],
+                                                                 x1_rvec[j]) +
+         (5.0 / 3.0) * std::pow(stan::math::squared_distance(x2_vec[i],
+                                                             x1_rvec[j]), 2) /
+         std::pow(l, 2)) * std::exp(-1.0 * pow(5.0, 0.5) *
+                                    stan::math::squared_distance(x2_vec[i],
+                                                                 x1_rvec[j])
+                                    / l),
+          cov7(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+
+  Eigen::MatrixXd cov2;
+  EXPECT_NO_THROW(cov2
+                  = stan::math::gp_matern_5_2_cov(x1_vec, x2_rvec, sigma, l));
+  EXPECT_EQ(3, cov2.rows());
+  EXPECT_EQ(4, cov2.cols());
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      EXPECT_FLOAT_EQ(
+        sigma * sigma * 
+        (1 + std::pow(5, 0.5) / l * stan::math::squared_distance(x1_vec[i],
+                                                                 x2_rvec[j]) +
+        (5.0 / 3.0) * std::pow(stan::math::squared_distance(x1_vec[i],
+                                                            x2_rvec[j]), 2) /
+         std::pow(l, 2)) * std::exp(-1.0 * pow(5.0, 0.5) *
+                                    stan::math::squared_distance(x1_vec[i],
+                                                                 x2_rvec[j])
+                                    / l),
+          cov2(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+
+  Eigen::MatrixXd cov8;
+  EXPECT_NO_THROW(cov8
+                  = stan::math::gp_matern_5_2_cov(x2_rvec, x1_vec, sigma, l));
+  EXPECT_EQ(4, cov8.rows());
+  EXPECT_EQ(3, cov8.cols());
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      EXPECT_FLOAT_EQ(
+        sigma * sigma * 
+        (1 + std::pow(5, 0.5) / l * stan::math::squared_distance(x2_rvec[i],
+                                                                 x1_vec[j]) +
+        (5.0 / 3.0) * std::pow(stan::math::squared_distance(x2_rvec[i],
+                                                            x1_vec[j]), 2) /
+         std::pow(l, 2)) * std::exp(-1.0 * pow(5.0, 0.5) *
+                                    stan::math::squared_distance(x2_rvec[i],
+                                                                 x1_vec[j])
+                                    / l),
+          cov8(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+
+  Eigen::MatrixXd cov3;
+  EXPECT_NO_THROW(cov3
+                  = stan::math::gp_matern_5_2_cov(x2_vec, x2_rvec, sigma, l));
+  EXPECT_EQ(4, cov3.rows());
+  EXPECT_EQ(4, cov3.cols());
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      EXPECT_FLOAT_EQ(
+        sigma * sigma * 
+        (1 + std::pow(5, 0.5) / l * stan::math::squared_distance(x2_vec[i],
+                                                                 x2_rvec[j]) +
+        (5.0 / 3.0) * std::pow(stan::math::squared_distance(x2_vec[i],
+                                                            x2_rvec[j]), 2) /
+         std::pow(l, 2)) * std::exp(-1.0 * pow(5.0, 0.5) *
+                                    stan::math::squared_distance(x2_vec[i],
+                                                                 x2_rvec[j])
+                                    / l),
+          cov3(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+
+  Eigen::MatrixXd cov4;
+  EXPECT_NO_THROW(cov4
+                  = stan::math::gp_matern_5_2_cov(x2_rvec, x2_vec, sigma, l));
+  EXPECT_EQ(4, cov4.rows());
+  EXPECT_EQ(4, cov4.cols());
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      EXPECT_FLOAT_EQ(
+        sigma * sigma * 
+        (1 + std::pow(5, 0.5) / l * stan::math::squared_distance(x2_rvec[i],
+                                                                 x2_vec[j]) +
+        (5.0 / 3.0) * std::pow(stan::math::squared_distance(x2_rvec[i],
+                                                            x2_vec[j]), 2) /
+         std::pow(l, 2)) * std::exp(-1.0 * pow(5.0, 0.5) *
+                                    stan::math::squared_distance(x2_rvec[i],
+                                                                 x2_vec[j])
+                                    / l),
+          cov4(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+
+  Eigen::MatrixXd cov5;
+  EXPECT_NO_THROW(cov5
+                  = stan::math::gp_matern_5_2_cov(x1_rvec, x1_vec, sigma, l));
+  EXPECT_EQ(3, cov5.rows());
+  EXPECT_EQ(3, cov5.cols());
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      EXPECT_FLOAT_EQ(
+        sigma * sigma * 
+        (1 + std::pow(5, 0.5) / l * stan::math::squared_distance(x1_rvec[i],
+                                                                 x1_vec[j]) +
+        (5.0 / 3.0) * std::pow(stan::math::squared_distance(x1_rvec[i],
+                                                            x1_vec[j]), 2) /
+         std::pow(l, 2)) * std::exp(-1.0 * pow(5.0, 0.5) *
+                                    stan::math::squared_distance(x1_rvec[i],
+                                                                 x1_vec[j])
+                                    / l),
+          cov5(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+
+  Eigen::MatrixXd cov6;
+  EXPECT_NO_THROW(cov6
+                  = stan::math::gp_matern_5_2_cov(x1_vec, x1_rvec, sigma, l));
+  EXPECT_EQ(3, cov6.rows());
+  EXPECT_EQ(3, cov6.cols());
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      EXPECT_FLOAT_EQ(
+        sigma * sigma * 
+        (1 + std::pow(5, 0.5) / l * stan::math::squared_distance(x1_vec[i],
+                                                                 x1_rvec[j]) +
+        (5.0 / 3.0) * std::pow(stan::math::squared_distance(x1_vec[i],
+                                                            x1_rvec[j]), 2) /
+         std::pow(l, 2)) * std::exp(-1.0 * pow(5.0, 0.5) *
+                                    stan::math::squared_distance(x1_vec[i],
+                                                                 x1_rvec[j])
+                                    / l),
+          cov6(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+}
+
+TEST(MathPrimMat, vec_eigen_mixed_ard_gp_matern_5_2_cov2) {
+  using stan::math::squared_distance;
+  double sigma = 0.2;
+  double temp;
+
+  std::vector<double> l(3);
+  l[0] = 1;
+  l[1] = 2;
+  l[2] = 3;
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x1_rvec(3);
+  std::vector<Eigen::Matrix<double, 1, -1>> x2_rvec(4);
+
+  for (size_t i = 0; i < x1_rvec.size(); ++i) {
+    x1_rvec[i].resize(1, 3);
+    x1_rvec[i] << 1 * i, 2 * i, 3 * i;
+  }
+
+  for (size_t i = 0; i < x2_rvec.size(); ++i) {
+    x2_rvec[i].resize(1, 3);
+    x2_rvec[i] << 2 * i, 3 * i, 4 * i;
+  }
+
+  std::vector<Eigen::Matrix<double, -1, 1>> x1_vec(3);
+  std::vector<Eigen::Matrix<double, -1, 1>> x2_vec(4);
+
+  for (size_t i = 0; i < x1_vec.size(); ++i) {
+    x1_vec[i].resize(3, 1);
+    x1_vec[i] << 1 * i, 2 * i, 3 * i;
+  }
+
+  for (size_t i = 0; i < x2_vec.size(); ++i) {
+    x2_vec[i].resize(3, 1);
+    x2_vec[i] << 2 * i, 3 * i, 4 * i;
+  }
+  Eigen::MatrixXd cov;
+  EXPECT_NO_THROW(cov
+                  = stan::math::gp_matern_5_2_cov(x1_rvec, x2_vec, sigma, l));
+  EXPECT_EQ(3, cov.rows());
+  EXPECT_EQ(4, cov.cols());
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 3; k++) {
+        temp += stan::math::squared_distance(x1_rvec[i], x2_vec[j])
+                / stan::math::square(l[k]);
+      }
+
+      EXPECT_FLOAT_EQ(sigma * sigma *
+         (1 + std::pow(5.0, 0.5) * temp +
+         (5.0 / 3.0) * std::pow(temp, 2.0)) *
+                      std::exp(-1.0 * pow(5.0, 0.5) * temp),
+                      cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+
+  Eigen::MatrixXd cov7;
+  EXPECT_NO_THROW(cov7
+                  = stan::math::gp_matern_5_2_cov(x2_vec, x1_rvec, sigma, l));
+  EXPECT_EQ(4, cov7.rows());
+  EXPECT_EQ(3, cov7.cols());
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 3; k++) {
+        temp += stan::math::squared_distance(x2_vec[i], x1_rvec[j])
+                / stan::math::square(l[k]);
+      }
+
+      EXPECT_FLOAT_EQ(sigma * sigma *
+         (1 + std::pow(5.0, 0.5) * temp +
+         (5.0 / 3.0) * std::pow(temp, 2.0)) *
+                      std::exp(-1.0 * pow(5.0, 0.5) * temp),
+                      cov7(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+
+  Eigen::MatrixXd cov2;
+  EXPECT_NO_THROW(cov2
+                  = stan::math::gp_matern_5_2_cov(x1_vec, x2_rvec, sigma, l));
+  EXPECT_EQ(3, cov2.rows());
+  EXPECT_EQ(4, cov2.cols());
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 3; k++) {
+        temp += stan::math::squared_distance(x1_vec[i], x2_rvec[j])
+                / stan::math::square(l[k]);
+      }
+
+      EXPECT_FLOAT_EQ(sigma * sigma *
+         (1 + std::pow(5.0, 0.5) * temp +
+         (5.0 / 3.0) * std::pow(temp, 2.0)) *
+                      std::exp(-1.0 * pow(5.0, 0.5) * temp),
+                      cov2(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+
+  Eigen::MatrixXd cov8;
+  EXPECT_NO_THROW(cov8
+                  = stan::math::gp_matern_5_2_cov(x2_rvec, x1_vec, sigma, l));
+  EXPECT_EQ(4, cov8.rows());
+  EXPECT_EQ(3, cov8.cols());
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 3; k++) {
+        temp += stan::math::squared_distance(x2_rvec[i], x1_vec[j])
+                / stan::math::square(l[k]);
+      }
+
+      EXPECT_FLOAT_EQ(sigma * sigma *
+         (1 + std::pow(5.0, 0.5) * temp +
+         (5.0 / 3.0) * std::pow(temp, 2.0)) *
+                      std::exp(-1.0 * pow(5.0, 0.5) * temp),
+                      cov8(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+
+  Eigen::MatrixXd cov3;
+  EXPECT_NO_THROW(cov3
+                  = stan::math::gp_matern_5_2_cov(x2_vec, x2_rvec, sigma, l));
+  EXPECT_EQ(4, cov3.rows());
+  EXPECT_EQ(4, cov3.cols());
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 3; k++) {
+        temp += stan::math::squared_distance(x2_vec[i], x2_rvec[j])
+                / stan::math::square(l[k]);
+      }
+
+      EXPECT_FLOAT_EQ(sigma * sigma *
+         (1 + std::pow(5.0, 0.5) * temp +
+         (5.0 / 3.0) * std::pow(temp, 2.0)) *
+                      std::exp(-1.0 * pow(5.0, 0.5) * temp),
+                      cov3(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+
+  Eigen::MatrixXd cov4;
+  EXPECT_NO_THROW(cov4
+                  = stan::math::gp_matern_5_2_cov(x2_rvec, x2_vec, sigma, l));
+  EXPECT_EQ(4, cov4.rows());
+  EXPECT_EQ(4, cov4.cols());
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 3; k++) {
+        temp += stan::math::squared_distance(x2_rvec[i], x2_vec[j])
+                / stan::math::square(l[k]);
+      }
+
+      EXPECT_FLOAT_EQ(sigma * sigma *
+         (1 + std::pow(5.0, 0.5) * temp +
+         (5.0 / 3.0) * std::pow(temp, 2.0)) *
+                      std::exp(-1.0 * pow(5.0, 0.5) * temp),
+                      cov4(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+
+  Eigen::MatrixXd cov5;
+  EXPECT_NO_THROW(cov5
+                  = stan::math::gp_matern_5_2_cov(x1_rvec, x1_vec, sigma, l));
+  EXPECT_EQ(3, cov5.rows());
+  EXPECT_EQ(3, cov5.cols());
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 3; k++) {
+        temp += stan::math::squared_distance(x1_rvec[i], x1_vec[j])
+                / stan::math::square(l[k]);
+      }
+
+      EXPECT_FLOAT_EQ(sigma * sigma *
+         (1 + std::pow(5.0, 0.5) * temp +
+         (5.0 / 3.0) * std::pow(temp, 2.0)) *
+                      std::exp(-1.0 * pow(5.0, 0.5) * temp),
+                      cov5(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+
+  Eigen::MatrixXd cov6;
+  EXPECT_NO_THROW(cov6
+                  = stan::math::gp_matern_5_2_cov(x1_vec, x1_rvec, sigma, l));
+  EXPECT_EQ(3, cov6.rows());
+  EXPECT_EQ(3, cov6.cols());
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 3; k++) {
+        temp += stan::math::squared_distance(x1_vec[i], x1_rvec[j])
+                / stan::math::square(l[k]);
+      }
+
+      EXPECT_FLOAT_EQ(sigma * sigma *
+         (1 + std::pow(5.0, 0.5) * temp +
+         (5.0 / 3.0) * std::pow(temp, 2.0)) *
+                      std::exp(-1.0 * pow(5.0, 0.5) * temp),
+                      cov6(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+}
+
+TEST(MathPrimMat, domain_err_training_sig_l_gamma) {
+  double sigma = .2;
+  double l = 7;
+  double sigma_bad = -1.0;
+  double l_bad = -1.0;
+
+  std::vector<double> l_vec(2);
+  l_vec[0] = 1;
+  l_vec[1] = 2;
+
+  std::vector<double> l_vec_bad(2);
+  l_vec_bad[0] = 1;
+  l_vec_bad[1] = -1;
+
+  std::vector<double> x(3);
+  x[0] = -2;
+  x[1] = -1;
+  x[2] = -0.5;
+
+  std::vector<Eigen::Matrix<double, -1, 1>> x_2(3);
+  for (size_t i = 0; i < x_2.size(); ++i) {
+    x_2[i].resize(3, 1);
+    x_2[i] << 1, 2, 3;
+  }
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x_3(3);
+  for (size_t i = 0; i < x_3.size(); ++i) {
+    x_3[i].resize(1, 3);
+    x_3[i] << 1, 2, 3;
+  }
+
+  std::string msg1, msg2, msg3, msg4;
+  msg1 = pull_msg(x, sigma, l_bad);
+  msg2 = pull_msg(x, sigma_bad, l_bad);
+  msg3 = pull_msg(x, sigma_bad, l_bad);
+  EXPECT_TRUE(std::string::npos != msg1.find(" length-scale")) << msg1;
+  EXPECT_TRUE(std::string::npos != msg2.find(" marginal variance")) << msg2;
+  EXPECT_TRUE(std::string::npos != msg3.find(" marginal variance")) << msg3;
+
+  msg1 = pull_msg(x, sigma, l_bad);
+  msg2 = pull_msg(x, sigma_bad, l_vec);
+  msg3 = pull_msg(x, sigma_bad, l_bad);
+  EXPECT_TRUE(std::string::npos != msg1.find(" length-scale")) << msg1;
+  EXPECT_TRUE(std::string::npos != msg2.find(" marginal variance")) << msg2;
+  EXPECT_TRUE(std::string::npos != msg3.find(" marginal variance")) << msg3;
+
+  msg1 = pull_msg(x, sigma, l_vec_bad);
+  msg2 = pull_msg(x, sigma_bad, l_vec_bad);
+  msg3 = pull_msg(x, sigma_bad, l_vec);
+  EXPECT_TRUE(std::string::npos != msg1.find(" length-scale")) << msg1;
+  EXPECT_TRUE(std::string::npos != msg2.find(" marginal variance")) << msg2;
+  EXPECT_TRUE(std::string::npos != msg3.find(" marginal variance")) << msg3;
+
+  msg1 = pull_msg(x_2, sigma, l_bad);
+  msg2 = pull_msg(x_2, sigma_bad, l);
+  msg3 = pull_msg(x_2, sigma_bad, l_bad);
+  EXPECT_TRUE(std::string::npos != msg1.find(" length-scale")) << msg1;
+  EXPECT_TRUE(std::string::npos != msg2.find(" marginal variance")) << msg2;
+  EXPECT_TRUE(std::string::npos != msg3.find(" marginal variance")) << msg3;
+
+  msg1 = pull_msg(x_2, sigma, l_bad);
+  msg2 = pull_msg(x_2, sigma_bad, l_vec);
+  msg3 = pull_msg(x_2, sigma_bad, l_bad);
+  EXPECT_TRUE(std::string::npos != msg1.find(" length-scale")) << msg1;
+  EXPECT_TRUE(std::string::npos != msg2.find(" marginal variance")) << msg2;
+  EXPECT_TRUE(std::string::npos != msg3.find(" marginal variance")) << msg3;
+
+  msg1 = pull_msg(x_2, sigma, l_vec_bad);
+  msg2 = pull_msg(x_2, sigma_bad, l_vec_bad);
+  msg3 = pull_msg(x_2, sigma_bad, l_vec);
+  EXPECT_TRUE(std::string::npos != msg1.find(" length-scale")) << msg1;
+  EXPECT_TRUE(std::string::npos != msg2.find(" marginal variance")) << msg2;
+  EXPECT_TRUE(std::string::npos != msg3.find(" marginal variance")) << msg3;
+
+  msg1 = pull_msg(x_2, x_3, sigma, l_bad);
+  msg2 = pull_msg(x_2, x_3, sigma_bad, l);
+  msg3 = pull_msg(x_2, x_3, sigma_bad, l_bad);
+  EXPECT_TRUE(std::string::npos != msg1.find(" length-scale")) << msg1;
+  EXPECT_TRUE(std::string::npos != msg2.find(" marginal variance")) << msg2;
+  EXPECT_TRUE(std::string::npos != msg3.find(" marginal variance")) << msg3;
+
+  msg1 = pull_msg(x_2, x_3, sigma, l_bad);
+  msg2 = pull_msg(x_2, x_3, sigma_bad, l_vec);
+  msg3 = pull_msg(x_2, x_3, sigma_bad, l_bad);
+  EXPECT_TRUE(std::string::npos != msg1.find(" length-scale")) << msg1;
+  EXPECT_TRUE(std::string::npos != msg2.find(" marginal variance")) << msg2;
+  EXPECT_TRUE(std::string::npos != msg3.find(" marginal variance")) << msg3;
+
+  msg1 = pull_msg(x_2, x_3, sigma, l_vec_bad);
+  msg2 = pull_msg(x_2, x_3, sigma_bad, l_vec_bad);
+  msg3 = pull_msg(x_2, x_3, sigma_bad, l_vec);
+  EXPECT_TRUE(std::string::npos != msg1.find(" length-scale")) << msg1;
+  EXPECT_TRUE(std::string::npos != msg2.find(" marginal variance")) << msg2;
+  EXPECT_TRUE(std::string::npos != msg3.find(" marginal variance")) << msg3;
+
+  msg1 = pull_msg(x_3, x_3, sigma, l_vec_bad);
+  msg2 = pull_msg(x_3, x_3, sigma_bad, l_vec_bad);
+  msg3 = pull_msg(x_3, x_3, sigma_bad, l_vec);
+  EXPECT_TRUE(std::string::npos != msg1.find(" length-scale")) << msg1;
+  EXPECT_TRUE(std::string::npos != msg2.find(" marginal variance")) << msg2;
+  EXPECT_TRUE(std::string::npos != msg3.find(" marginal variance")) << msg3;
+
+  msg1 = pull_msg(x_2, x_2, sigma, l_vec_bad);
+  msg2 = pull_msg(x_2, x_2, sigma_bad, l_vec_bad);
+  msg3 = pull_msg(x_2, x_2, sigma_bad, l_vec);
+  EXPECT_TRUE(std::string::npos != msg1.find(" length-scale")) << msg1;
+  EXPECT_TRUE(std::string::npos != msg2.find(" marginal variance")) << msg2;
+  EXPECT_TRUE(std::string::npos != msg3.find(" marginal variance")) << msg3;
+}
+
+TEST(MathPrimMat, nan_error_training_sig_l_gamma) {
+  double sigma = 0.2;
+  double l = 5;
+
+  std::vector<double> x(3);
+  x[0] = -2;
+  x[1] = -1;
+  x[2] = -0.5;
+
+  std::vector<Eigen::Matrix<double, -1, 1>> x_2(3);
+  for (size_t i = 0; i < x_2.size(); ++i) {
+    x_2[i].resize(3, 1);
+    x_2[i] << 1, 2, 3;
+  }
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x_3(3);
+  for (size_t i = 0; i < x_3.size(); ++i) {
+    x_3[i].resize(1, 3);
+    x_3[i] << 1, 2, 3;
+  }
+
+  std::vector<double> l_vec(2);
+  l_vec[0] = 1;
+  l_vec[1] = 2;
+
+  std::vector<double> l_vec_bad(2);
+  l_vec_bad[0] = 1;
+  l_vec_bad[1] = -1;
+
+  std::vector<double> x_bad(x);
+  x_bad[1] = std::numeric_limits<double>::quiet_NaN();
+
+  std::vector<Eigen::Matrix<double, -1, 1>> x_bad_2(x_2);
+  x_bad_2[1](1) = std::numeric_limits<double>::quiet_NaN();
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x_bad_3(x_3);
+  x_bad_3[1](1) = std::numeric_limits<double>::quiet_NaN();
+
+  double sigma_bad = std::numeric_limits<double>::quiet_NaN();
+  double l_bad = std::numeric_limits<double>::quiet_NaN();
+
+  std::string msg1, msg2, msg3, msg4;
+  msg1 = pull_msg(x, sigma, l_bad);
+  msg2 = pull_msg(x, sigma_bad, l);
+  msg3 = pull_msg(x, sigma_bad, l_bad);
+  EXPECT_TRUE(std::string::npos != msg1.find(" length-scale")) << msg1;
+  EXPECT_TRUE(std::string::npos != msg2.find(" marginal variance")) << msg2;
+  EXPECT_TRUE(std::string::npos != msg3.find(" marginal variance")) << msg3;
+
+  EXPECT_THROW(stan::math::gp_matern_5_2_cov(x, sigma, l_bad),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_5_2_cov(x, sigma_bad, l),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_5_2_cov(x, sigma_bad, l_bad),
+               std::domain_error);
+
+  EXPECT_THROW(stan::math::gp_matern_5_2_cov(x_bad, l, sigma),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_5_2_cov(x_bad, sigma_bad, l),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_5_2_cov(x_bad, sigma_bad, l_bad),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_5_2_cov(x_bad, sigma, l_bad),
+               std::domain_error);
+
+  EXPECT_THROW(stan::math::gp_matern_5_2_cov(x_2, sigma, l_bad),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_5_2_cov(x_2, sigma_bad, l),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_5_2_cov(x_2, sigma_bad, l_bad),
+               std::domain_error);
+
+  EXPECT_THROW(stan::math::gp_matern_5_2_cov(x_bad_2, sigma, l_bad),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_5_2_cov(x_bad_2, sigma_bad, l),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_5_2_cov(x_bad_2, sigma, l),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_5_2_cov(x_bad_2, sigma_bad, l_bad),
+               std::domain_error);
+
+  EXPECT_THROW(stan::math::gp_matern_5_2_cov(x_3, sigma, l_bad),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_5_2_cov(x_3, sigma_bad, l),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_5_2_cov(x_3, sigma_bad, l_bad),
+               std::domain_error);
+
+  EXPECT_THROW(stan::math::gp_matern_5_2_cov(x_bad_3, sigma, l_bad),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_5_2_cov(x_bad_3, sigma_bad, l),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_5_2_cov(x_bad_3, sigma_bad, l_bad),
+               std::domain_error);
+
+  EXPECT_TRUE(std::string::npos != msg1.find(" length-scale")) << msg1;
+  EXPECT_TRUE(std::string::npos != msg2.find(" marginal variance")) << msg2;
+  EXPECT_TRUE(std::string::npos != msg3.find(" marginal variance")) << msg3;
+
+  EXPECT_THROW(stan::math::gp_matern_5_2_cov(x, sigma, l_vec_bad),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_5_2_cov(x, sigma_bad, l_vec),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_5_2_cov(x, sigma_bad, l_vec_bad),
+               std::domain_error);
+
+  EXPECT_THROW(stan::math::gp_matern_5_2_cov(x_bad, sigma, l_vec),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_5_2_cov(x_bad, sigma_bad, l_vec),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_5_2_cov(x_bad, sigma_bad, l_vec_bad),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_5_2_cov(x_bad, sigma, l_vec_bad),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_5_2_cov(x_bad, sigma_bad, l_vec_bad),
+               std::domain_error);
+
+  EXPECT_THROW(stan::math::gp_matern_5_2_cov(x_2, sigma, l_vec_bad),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_5_2_cov(x_2, sigma_bad, l_vec),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_5_2_cov(x_2, sigma_bad, l_vec_bad),
+               std::domain_error);
+
+  EXPECT_THROW(stan::math::gp_matern_5_2_cov(x_bad_2, sigma, l_vec_bad),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_5_2_cov(x_bad_2, sigma_bad, l_vec),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_5_2_cov(x_bad_2, sigma_bad, l_vec_bad),
+               std::domain_error);
+
+  EXPECT_THROW(stan::math::gp_matern_5_2_cov(x_3, sigma, l_vec_bad),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_5_2_cov(x_3, sigma_bad, l_vec),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_5_2_cov(x_3, sigma_bad, l_vec_bad),
+               std::domain_error);
+
+  EXPECT_THROW(stan::math::gp_matern_5_2_cov(x_bad_3, sigma, l_vec_bad),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_5_2_cov(x_bad_3, sigma_bad, l_vec),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_5_2_cov(x_bad_3, sigma_bad, l_vec_bad),
+               std::domain_error);
+}
+
+TEST(MathPrimMat, dim_mismatch_vec_eigen_rvec_gp_matern_5_2_cov2) {
+  double sigma = 0.2;
+  double l = 5;
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x_vec_1(3);
+  for (size_t i = 0; i < x_vec_1.size(); ++i) {
+    x_vec_1[i].resize(1, 3);
+    x_vec_1[i] << 1, 2, 3;
+  }
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x_vec_2(4);
+  for (size_t i = 0; i < x_vec_2.size(); ++i) {
+    x_vec_2[i].resize(1, 4);
+    x_vec_2[i] << 4, 1, 3, 1;
+  }
+  EXPECT_THROW(stan::math::gp_matern_5_2_cov(x_vec_1, x_vec_2, sigma, l),
+               std::invalid_argument);
+}
+
+TEST(MathPrimMat, dim_mismatch_vec_eigen_mixed_gp_matern_5_2_cov) {
+  double sigma = 0.2;
+  double l = 5;
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x_rvec_1(3);
+  for (size_t i = 0; i < x_rvec_1.size(); ++i) {
+    x_rvec_1[i].resize(1, 3);
+    x_rvec_1[i] << 1, 2, 3;
+  }
+
+  std::vector<Eigen::Matrix<double, -1, 1>> x_vec_1(4);
+  for (size_t i = 0; i < x_vec_1.size(); ++i) {
+    x_vec_1[i].resize(4, 1);
+    x_vec_1[i] << 4, 1, 3, 1;
+  }
+
+  std::vector<Eigen::Matrix<double, -1, 1>> x_vec_2(3);
+  for (size_t i = 0; i < x_vec_2.size(); ++i) {
+    x_vec_2[i].resize(3, 1);
+    x_vec_2[i] << 1, 2, 3;
+  }
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x_rvec_2(4);
+  for (size_t i = 0; i < x_rvec_2.size(); ++i) {
+    x_rvec_2[i].resize(1, 4);
+    x_rvec_2[i] << 1, 2, 3, 4;
+  }
+  EXPECT_THROW(stan::math::gp_matern_5_2_cov(x_rvec_1, x_vec_1, sigma, l),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::gp_matern_5_2_cov(x_vec_1, x_rvec_1, sigma, l),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::gp_matern_5_2_cov(x_rvec_2, x_vec_2, sigma, l),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::gp_matern_5_2_cov(x_vec_2, x_rvec_2, sigma, l),
+               std::invalid_argument);
+}

--- a/test/unit/math/prim/mat/fun/gp_matern_5_2_cov_test.cpp
+++ b/test/unit/math/prim/mat/fun/gp_matern_5_2_cov_test.cpp
@@ -47,14 +47,15 @@ TEST(MathPrimMat, vec_double_gp_matern_5_2_cov1) {
   for (int i = 0; i < 3; i++)
     for (int j = 0; j < 3; j++)
       EXPECT_FLOAT_EQ(
-          sigma * sigma *
-              (1 +
-               std::pow(5, 0.5) / l * stan::math::squared_distance(x[i], x[j]) +
-               (5.0 / 3.0) *
-                   std::pow(stan::math::squared_distance(x[i], x[j]), 2) /
-                   std::pow(l, 2)) *
-              std::exp(-1.0 * pow(5.0, 0.5) *
-                       stan::math::squared_distance(x[i], x[j]) / l),
+          sigma * sigma
+              * (1
+                 + std::pow(5, 0.5) / l
+                       * stan::math::squared_distance(x[i], x[j])
+                 + (5.0 / 3.0)
+                       * std::pow(stan::math::squared_distance(x[i], x[j]), 2)
+                       / std::pow(l, 2))
+              * std::exp(-1.0 * pow(5.0, 0.5)
+                         * stan::math::squared_distance(x[i], x[j]) / l),
           cov(i, j))
           << "index: (" << i << ", " << j << ")";
 }
@@ -81,13 +82,13 @@ TEST(MathPrimMat, vec_double_ard_gp_matern_5_2_cov1) {
     for (int j = 0; j < 3; j++) {
       temp = 0;
       for (int k = 0; k < 5; k++) {
-        temp +=
-            stan::math::squared_distance(x[i], x[j]) / l[k];
+        temp += stan::math::squared_distance(x[i], x[j]) / l[k];
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma * (1 + std::pow(5.0, 0.5) * temp +
-                                       (5.0 / 3.0) * std::pow(temp, 2.0)) *
-                          std::exp(-1.0 * pow(5.0, 0.5) * temp),
+      EXPECT_FLOAT_EQ(sigma * sigma
+                          * (1 + std::pow(5.0, 0.5) * temp
+                             + (5.0 / 3.0) * std::pow(temp, 2.0))
+                          * std::exp(-1.0 * pow(5.0, 0.5) * temp),
                       cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -109,15 +110,15 @@ TEST(MathPrimMat, vec_eigen_gp_matern_5_2_cov1) {
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-          sigma * sigma *
-              (1 +
-               std::pow(5, 0.5) / l *
-                   stan::math::squared_distance(x1[i], x1[j]) +
-               (5.0 / 3.0) *
-                   std::pow(stan::math::squared_distance(x1[i], x1[j]), 2) /
-                   std::pow(l, 2)) *
-              std::exp(-1.0 * pow(5.0, 0.5) *
-                       stan::math::squared_distance(x1[i], x1[j]) / l),
+          sigma * sigma
+              * (1
+                 + std::pow(5, 0.5) / l
+                       * stan::math::squared_distance(x1[i], x1[j])
+                 + (5.0 / 3.0)
+                       * std::pow(stan::math::squared_distance(x1[i], x1[j]), 2)
+                       / std::pow(l, 2))
+              * std::exp(-1.0 * pow(5.0, 0.5)
+                         * stan::math::squared_distance(x1[i], x1[j]) / l),
           cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -145,15 +146,15 @@ TEST(MathPrimMat, vec_eigen_eigen_gp_matern_5_2_cov1) {
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-          sigma * sigma *
-              (1 +
-               std::pow(5, 0.5) / l *
-                   stan::math::squared_distance(x1[i], x2[j]) +
-               (5.0 / 3.0) *
-                   std::pow(stan::math::squared_distance(x1[i], x2[j]), 2) /
-                   std::pow(l, 2)) *
-              std::exp(-1.0 * pow(5.0, 0.5) *
-                       stan::math::squared_distance(x1[i], x2[j]) / l),
+          sigma * sigma
+              * (1
+                 + std::pow(5, 0.5) / l
+                       * stan::math::squared_distance(x1[i], x2[j])
+                 + (5.0 / 3.0)
+                       * std::pow(stan::math::squared_distance(x1[i], x2[j]), 2)
+                       / std::pow(l, 2))
+              * std::exp(-1.0 * pow(5.0, 0.5)
+                         * stan::math::squared_distance(x1[i], x2[j]) / l),
           cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -179,15 +180,15 @@ TEST(MathPrimMat, vec_double_double_gp_matern_5_2_cov1) {
   for (int i = 0; i < 3; i++)
     for (int j = 0; j < 3; j++)
       EXPECT_FLOAT_EQ(
-          sigma * sigma *
-              (1 +
-               std::pow(5, 0.5) / l *
-                   stan::math::squared_distance(x1[i], x2[j]) +
-               (5.0 / 3.0) *
-                   std::pow(stan::math::squared_distance(x1[i], x2[j]), 2) /
-                   std::pow(l, 2)) *
-              std::exp(-1.0 * pow(5.0, 0.5) *
-                       stan::math::squared_distance(x1[i], x2[j]) / l),
+          sigma * sigma
+              * (1
+                 + std::pow(5, 0.5) / l
+                       * stan::math::squared_distance(x1[i], x2[j])
+                 + (5.0 / 3.0)
+                       * std::pow(stan::math::squared_distance(x1[i], x2[j]), 2)
+                       / std::pow(l, 2))
+              * std::exp(-1.0 * pow(5.0, 0.5)
+                         * stan::math::squared_distance(x1[i], x2[j]) / l),
           cov(i, j))
           << "index: (" << i << ", " << j << ")";
 }
@@ -215,12 +216,12 @@ TEST(MathPrimMat, vec_eigen_ard_gp_matern_5_2_cov1) {
     for (int j = 0; j < 3; j++) {
       temp = 0;
       for (int k = 0; k < 5; k++) {
-        temp += stan::math::squared_distance(x1[i], x1[j]) /
-                l[k];
+        temp += stan::math::squared_distance(x1[i], x1[j]) / l[k];
       }
-      EXPECT_FLOAT_EQ(sigma * sigma * (1 + std::pow(5.0, 0.5) * temp +
-                                       (5.0 / 3.0) * std::pow(temp, 2.0)) *
-                          std::exp(-1.0 * pow(5.0, 0.5) * temp),
+      EXPECT_FLOAT_EQ(sigma * sigma
+                          * (1 + std::pow(5.0, 0.5) * temp
+                             + (5.0 / 3.0) * std::pow(temp, 2.0))
+                          * std::exp(-1.0 * pow(5.0, 0.5) * temp),
                       cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -253,12 +254,12 @@ TEST(MathPrimMat, vec_double_double_ard_gp_matern_5_2_cov1) {
     for (int j = 0; j < 3; j++) {
       temp = 0;
       for (int k = 0; k < 4; k++) {
-        temp += stan::math::squared_distance(x1[i], x2[j]) /
-                l[k];
+        temp += stan::math::squared_distance(x1[i], x2[j]) / l[k];
       }
-      EXPECT_FLOAT_EQ(sigma * sigma * (1 + std::pow(5.0, 0.5) * temp +
-                                       (5.0 / 3.0) * std::pow(temp, 2.0)) *
-                          std::exp(-1.0 * pow(5.0, 0.5) * temp),
+      EXPECT_FLOAT_EQ(sigma * sigma
+                          * (1 + std::pow(5.0, 0.5) * temp
+                             + (5.0 / 3.0) * std::pow(temp, 2.0))
+                          * std::exp(-1.0 * pow(5.0, 0.5) * temp),
                       cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -293,12 +294,12 @@ TEST(MathPrimMat, vec_eigen_eigen_ard_gp_matern_5_2_cov1) {
     for (int j = 0; j < 3; j++) {
       temp = 0;
       for (int k = 0; k < 4; k++) {
-        temp += stan::math::squared_distance(x1[i], x2[j]) /
-                l[k];
+        temp += stan::math::squared_distance(x1[i], x2[j]) / l[k];
       }
-      EXPECT_FLOAT_EQ(sigma * sigma * (1 + std::pow(5.0, 0.5) * temp +
-                                       (5.0 / 3.0) * std::pow(temp, 2.0)) *
-                          std::exp(-1.0 * pow(5.0, 0.5) * temp),
+      EXPECT_FLOAT_EQ(sigma * sigma
+                          * (1 + std::pow(5.0, 0.5) * temp
+                             + (5.0 / 3.0) * std::pow(temp, 2.0))
+                          * std::exp(-1.0 * pow(5.0, 0.5) * temp),
                       cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -320,15 +321,15 @@ TEST(MathPrimMat, rvec_eigen_gp_matern_5_2_cov1) {
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-          sigma * sigma *
-              (1 +
-               std::pow(5, 0.5) / l *
-                   stan::math::squared_distance(x1[i], x1[j]) +
-               (5.0 / 3.0) *
-                   std::pow(stan::math::squared_distance(x1[i], x1[j]), 2) /
-                   std::pow(l, 2)) *
-              std::exp(-1.0 * pow(5.0, 0.5) *
-                       stan::math::squared_distance(x1[i], x1[j]) / l),
+          sigma * sigma
+              * (1
+                 + std::pow(5, 0.5) / l
+                       * stan::math::squared_distance(x1[i], x1[j])
+                 + (5.0 / 3.0)
+                       * std::pow(stan::math::squared_distance(x1[i], x1[j]), 2)
+                       / std::pow(l, 2))
+              * std::exp(-1.0 * pow(5.0, 0.5)
+                         * stan::math::squared_distance(x1[i], x1[j]) / l),
           cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -357,13 +358,13 @@ TEST(MathPrimMat, rvec_eigen_ard_gp_matern_5_2_cov1) {
     for (int j = 0; j < 3; j++) {
       temp = 0;
       for (int k = 0; k < 4; k++) {
-        temp += stan::math::squared_distance(x1[i], x1[j]) /
-                l[k];
+        temp += stan::math::squared_distance(x1[i], x1[j]) / l[k];
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma * (1 + std::pow(5.0, 0.5) * temp +
-                                       (5.0 / 3.0) * std::pow(temp, 2.0)) *
-                          std::exp(-1.0 * pow(5.0, 0.5) * temp),
+      EXPECT_FLOAT_EQ(sigma * sigma
+                          * (1 + std::pow(5.0, 0.5) * temp
+                             + (5.0 / 3.0) * std::pow(temp, 2.0))
+                          * std::exp(-1.0 * pow(5.0, 0.5) * temp),
                       cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -391,15 +392,15 @@ TEST(MathPrimMat, vec_eigen_rvec_eigen_gp_matern_5_2_cov1) {
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-          sigma * sigma *
-              (1 +
-               std::pow(5, 0.5) / l *
-                   stan::math::squared_distance(x1[i], x2[j]) +
-               (5.0 / 3.0) *
-                   std::pow(stan::math::squared_distance(x1[i], x2[j]), 2) /
-                   std::pow(l, 2)) *
-              std::exp(-1.0 * pow(5.0, 0.5) *
-                       stan::math::squared_distance(x1[i], x2[j]) / l),
+          sigma * sigma
+              * (1
+                 + std::pow(5, 0.5) / l
+                       * stan::math::squared_distance(x1[i], x2[j])
+                 + (5.0 / 3.0)
+                       * std::pow(stan::math::squared_distance(x1[i], x2[j]), 2)
+                       / std::pow(l, 2))
+              * std::exp(-1.0 * pow(5.0, 0.5)
+                         * stan::math::squared_distance(x1[i], x2[j]) / l),
           cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -409,15 +410,15 @@ TEST(MathPrimMat, vec_eigen_rvec_eigen_gp_matern_5_2_cov1) {
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-          sigma * sigma *
-              (1 +
-               std::pow(5, 0.5) / l *
-                   stan::math::squared_distance(x2[i], x1[j]) +
-               (5.0 / 3.0) *
-                   std::pow(stan::math::squared_distance(x2[i], x1[j]), 2) /
-                   std::pow(l, 2)) *
-              std::exp(-1.0 * pow(5.0, 0.5) *
-                       stan::math::squared_distance(x2[i], x1[j]) / l),
+          sigma * sigma
+              * (1
+                 + std::pow(5, 0.5) / l
+                       * stan::math::squared_distance(x2[i], x1[j])
+                 + (5.0 / 3.0)
+                       * std::pow(stan::math::squared_distance(x2[i], x1[j]), 2)
+                       / std::pow(l, 2))
+              * std::exp(-1.0 * pow(5.0, 0.5)
+                         * stan::math::squared_distance(x2[i], x1[j]) / l),
           cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -450,13 +451,13 @@ TEST(MathPrimMat, vec_eigen_rvec_eigen_ard_gp_matern_5_2_cov1) {
     for (int j = 0; j < 3; j++) {
       temp = 0;
       for (int k = 0; k < 3; k++) {
-        temp += stan::math::squared_distance(x1[i], x2[j]) /
-                l[k];
+        temp += stan::math::squared_distance(x1[i], x2[j]) / l[k];
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma * (1 + std::pow(5.0, 0.5) * temp +
-                                       (5.0 / 3.0) * std::pow(temp, 2.0)) *
-                          std::exp(-1.0 * pow(5.0, 0.5) * temp),
+      EXPECT_FLOAT_EQ(sigma * sigma
+                          * (1 + std::pow(5.0, 0.5) * temp
+                             + (5.0 / 3.0) * std::pow(temp, 2.0))
+                          * std::exp(-1.0 * pow(5.0, 0.5) * temp),
                       cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -466,13 +467,13 @@ TEST(MathPrimMat, vec_eigen_rvec_eigen_ard_gp_matern_5_2_cov1) {
     for (int j = 0; j < 3; j++) {
       temp = 0;
       for (int k = 0; k < 3; k++) {
-        temp += stan::math::squared_distance(x2[i], x1[j]) /
-                l[k];
+        temp += stan::math::squared_distance(x2[i], x1[j]) / l[k];
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma * (1 + std::pow(5.0, 0.5) * temp +
-                                       (5.0 / 3.0) * std::pow(temp, 2.0)) *
-                          std::exp(-1.0 * pow(5.0, 0.5) * temp),
+      EXPECT_FLOAT_EQ(sigma * sigma
+                          * (1 + std::pow(5.0, 0.5) * temp
+                             + (5.0 / 3.0) * std::pow(temp, 2.0))
+                          * std::exp(-1.0 * pow(5.0, 0.5) * temp),
                       cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -500,15 +501,15 @@ TEST(MathPrimMat, rvec_eigen_rvec_eigen_gp_matern_5_2_cov1) {
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-          sigma * sigma *
-              (1 +
-               std::pow(5, 0.5) / l *
-                   stan::math::squared_distance(x1[i], x2[j]) +
-               (5.0 / 3.0) *
-                   std::pow(stan::math::squared_distance(x1[i], x2[j]), 2) /
-                   std::pow(l, 2)) *
-              std::exp(-1.0 * pow(5.0, 0.5) *
-                       stan::math::squared_distance(x1[i], x2[j]) / l),
+          sigma * sigma
+              * (1
+                 + std::pow(5, 0.5) / l
+                       * stan::math::squared_distance(x1[i], x2[j])
+                 + (5.0 / 3.0)
+                       * std::pow(stan::math::squared_distance(x1[i], x2[j]), 2)
+                       / std::pow(l, 2))
+              * std::exp(-1.0 * pow(5.0, 0.5)
+                         * stan::math::squared_distance(x1[i], x2[j]) / l),
           cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -518,15 +519,15 @@ TEST(MathPrimMat, rvec_eigen_rvec_eigen_gp_matern_5_2_cov1) {
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-          sigma * sigma *
-              (1 +
-               std::pow(5, 0.5) / l *
-                   stan::math::squared_distance(x2[i], x1[j]) +
-               (5.0 / 3.0) *
-                   std::pow(stan::math::squared_distance(x2[i], x1[j]), 2) /
-                   std::pow(l, 2)) *
-              std::exp(-1.0 * pow(5.0, 0.5) *
-                       stan::math::squared_distance(x2[i], x1[j]) / l),
+          sigma * sigma
+              * (1
+                 + std::pow(5, 0.5) / l
+                       * stan::math::squared_distance(x2[i], x1[j])
+                 + (5.0 / 3.0)
+                       * std::pow(stan::math::squared_distance(x2[i], x1[j]), 2)
+                       / std::pow(l, 2))
+              * std::exp(-1.0 * pow(5.0, 0.5)
+                         * stan::math::squared_distance(x2[i], x1[j]) / l),
           cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -560,12 +561,12 @@ TEST(MathPrimMat, rvec_eigen_rvec_eigen_ard_gp_matern_5_2_cov1) {
     for (int j = 0; j < 3; j++) {
       temp = 0;
       for (int k = 0; k < 3; k++) {
-        temp += stan::math::squared_distance(x1[i], x2[j]) /
-                l[k];
+        temp += stan::math::squared_distance(x1[i], x2[j]) / l[k];
       }
-      EXPECT_FLOAT_EQ(sigma * sigma * (1 + std::pow(5.0, 0.5) * temp +
-                                       (5.0 / 3.0) * std::pow(temp, 2.0)) *
-                          std::exp(-1.0 * pow(5.0, 0.5) * temp),
+      EXPECT_FLOAT_EQ(sigma * sigma
+                          * (1 + std::pow(5.0, 0.5) * temp
+                             + (5.0 / 3.0) * std::pow(temp, 2.0))
+                          * std::exp(-1.0 * pow(5.0, 0.5) * temp),
                       cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -575,12 +576,12 @@ TEST(MathPrimMat, rvec_eigen_rvec_eigen_ard_gp_matern_5_2_cov1) {
     for (int j = 0; j < 3; j++) {
       temp = 0;
       for (int k = 0; k < 3; k++) {
-        temp += stan::math::squared_distance(x2[i], x1[j]) /
-                l[k];
+        temp += stan::math::squared_distance(x2[i], x1[j]) / l[k];
       }
-      EXPECT_FLOAT_EQ(sigma * sigma * (1 + std::pow(5.0, 0.5) * temp +
-                                       (5.0 / 3.0) * std::pow(temp, 2.0)) *
-                          std::exp(-1.0 * pow(5.0, 0.5) * temp),
+      EXPECT_FLOAT_EQ(sigma * sigma
+                          * (1 + std::pow(5.0, 0.5) * temp
+                             + (5.0 / 3.0) * std::pow(temp, 2.0))
+                          * std::exp(-1.0 * pow(5.0, 0.5) * temp),
                       cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -618,184 +619,200 @@ TEST(MathPrimMat, vec_eigen_mixed_gp_matern_5_2_cov2) {
     x2_vec[i] << 2 * i, 3 * i, 4 * i;
   }
   Eigen::MatrixXd cov;
-  EXPECT_NO_THROW(cov =
-                      stan::math::gp_matern_5_2_cov(x1_rvec, x2_vec, sigma, l));
+  EXPECT_NO_THROW(cov
+                  = stan::math::gp_matern_5_2_cov(x1_rvec, x2_vec, sigma, l));
   EXPECT_EQ(3, cov.rows());
   EXPECT_EQ(4, cov.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-          sigma * sigma *
-              (1 +
-               std::pow(5, 0.5) / l *
-                   stan::math::squared_distance(x1_rvec[i], x2_vec[j]) +
-               (5.0 / 3.0) *
-                   std::pow(stan::math::squared_distance(x1_rvec[i], x2_vec[j]),
-                            2) /
-                   std::pow(l, 2)) *
-              std::exp(-1.0 * pow(5.0, 0.5) *
-                       stan::math::squared_distance(x1_rvec[i], x2_vec[j]) / l),
+          sigma * sigma
+              * (1
+                 + std::pow(5, 0.5) / l
+                       * stan::math::squared_distance(x1_rvec[i], x2_vec[j])
+                 + (5.0 / 3.0)
+                       * std::pow(stan::math::squared_distance(x1_rvec[i],
+                                                               x2_vec[j]),
+                                  2)
+                       / std::pow(l, 2))
+              * std::exp(-1.0 * pow(5.0, 0.5)
+                         * stan::math::squared_distance(x1_rvec[i], x2_vec[j])
+                         / l),
           cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov7;
-  EXPECT_NO_THROW(cov7 =
-                      stan::math::gp_matern_5_2_cov(x2_vec, x1_rvec, sigma, l));
+  EXPECT_NO_THROW(cov7
+                  = stan::math::gp_matern_5_2_cov(x2_vec, x1_rvec, sigma, l));
   EXPECT_EQ(4, cov7.rows());
   EXPECT_EQ(3, cov7.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-          sigma * sigma *
-              (1 +
-               std::pow(5, 0.5) / l *
-                   stan::math::squared_distance(x2_vec[i], x1_rvec[j]) +
-               (5.0 / 3.0) *
-                   std::pow(stan::math::squared_distance(x2_vec[i], x1_rvec[j]),
-                            2) /
-                   std::pow(l, 2)) *
-              std::exp(-1.0 * pow(5.0, 0.5) *
-                       stan::math::squared_distance(x2_vec[i], x1_rvec[j]) / l),
+          sigma * sigma
+              * (1
+                 + std::pow(5, 0.5) / l
+                       * stan::math::squared_distance(x2_vec[i], x1_rvec[j])
+                 + (5.0 / 3.0)
+                       * std::pow(stan::math::squared_distance(x2_vec[i],
+                                                               x1_rvec[j]),
+                                  2)
+                       / std::pow(l, 2))
+              * std::exp(-1.0 * pow(5.0, 0.5)
+                         * stan::math::squared_distance(x2_vec[i], x1_rvec[j])
+                         / l),
           cov7(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov2;
-  EXPECT_NO_THROW(cov2 =
-                      stan::math::gp_matern_5_2_cov(x1_vec, x2_rvec, sigma, l));
+  EXPECT_NO_THROW(cov2
+                  = stan::math::gp_matern_5_2_cov(x1_vec, x2_rvec, sigma, l));
   EXPECT_EQ(3, cov2.rows());
   EXPECT_EQ(4, cov2.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-          sigma * sigma *
-              (1 +
-               std::pow(5, 0.5) / l *
-                   stan::math::squared_distance(x1_vec[i], x2_rvec[j]) +
-               (5.0 / 3.0) *
-                   std::pow(stan::math::squared_distance(x1_vec[i], x2_rvec[j]),
-                            2) /
-                   std::pow(l, 2)) *
-              std::exp(-1.0 * pow(5.0, 0.5) *
-                       stan::math::squared_distance(x1_vec[i], x2_rvec[j]) / l),
+          sigma * sigma
+              * (1
+                 + std::pow(5, 0.5) / l
+                       * stan::math::squared_distance(x1_vec[i], x2_rvec[j])
+                 + (5.0 / 3.0)
+                       * std::pow(stan::math::squared_distance(x1_vec[i],
+                                                               x2_rvec[j]),
+                                  2)
+                       / std::pow(l, 2))
+              * std::exp(-1.0 * pow(5.0, 0.5)
+                         * stan::math::squared_distance(x1_vec[i], x2_rvec[j])
+                         / l),
           cov2(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov8;
-  EXPECT_NO_THROW(cov8 =
-                      stan::math::gp_matern_5_2_cov(x2_rvec, x1_vec, sigma, l));
+  EXPECT_NO_THROW(cov8
+                  = stan::math::gp_matern_5_2_cov(x2_rvec, x1_vec, sigma, l));
   EXPECT_EQ(4, cov8.rows());
   EXPECT_EQ(3, cov8.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-          sigma * sigma *
-              (1 +
-               std::pow(5, 0.5) / l *
-                   stan::math::squared_distance(x2_rvec[i], x1_vec[j]) +
-               (5.0 / 3.0) *
-                   std::pow(stan::math::squared_distance(x2_rvec[i], x1_vec[j]),
-                            2) /
-                   std::pow(l, 2)) *
-              std::exp(-1.0 * pow(5.0, 0.5) *
-                       stan::math::squared_distance(x2_rvec[i], x1_vec[j]) / l),
+          sigma * sigma
+              * (1
+                 + std::pow(5, 0.5) / l
+                       * stan::math::squared_distance(x2_rvec[i], x1_vec[j])
+                 + (5.0 / 3.0)
+                       * std::pow(stan::math::squared_distance(x2_rvec[i],
+                                                               x1_vec[j]),
+                                  2)
+                       / std::pow(l, 2))
+              * std::exp(-1.0 * pow(5.0, 0.5)
+                         * stan::math::squared_distance(x2_rvec[i], x1_vec[j])
+                         / l),
           cov8(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov3;
-  EXPECT_NO_THROW(cov3 =
-                      stan::math::gp_matern_5_2_cov(x2_vec, x2_rvec, sigma, l));
+  EXPECT_NO_THROW(cov3
+                  = stan::math::gp_matern_5_2_cov(x2_vec, x2_rvec, sigma, l));
   EXPECT_EQ(4, cov3.rows());
   EXPECT_EQ(4, cov3.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-          sigma * sigma *
-              (1 +
-               std::pow(5, 0.5) / l *
-                   stan::math::squared_distance(x2_vec[i], x2_rvec[j]) +
-               (5.0 / 3.0) *
-                   std::pow(stan::math::squared_distance(x2_vec[i], x2_rvec[j]),
-                            2) /
-                   std::pow(l, 2)) *
-              std::exp(-1.0 * pow(5.0, 0.5) *
-                       stan::math::squared_distance(x2_vec[i], x2_rvec[j]) / l),
+          sigma * sigma
+              * (1
+                 + std::pow(5, 0.5) / l
+                       * stan::math::squared_distance(x2_vec[i], x2_rvec[j])
+                 + (5.0 / 3.0)
+                       * std::pow(stan::math::squared_distance(x2_vec[i],
+                                                               x2_rvec[j]),
+                                  2)
+                       / std::pow(l, 2))
+              * std::exp(-1.0 * pow(5.0, 0.5)
+                         * stan::math::squared_distance(x2_vec[i], x2_rvec[j])
+                         / l),
           cov3(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov4;
-  EXPECT_NO_THROW(cov4 =
-                      stan::math::gp_matern_5_2_cov(x2_rvec, x2_vec, sigma, l));
+  EXPECT_NO_THROW(cov4
+                  = stan::math::gp_matern_5_2_cov(x2_rvec, x2_vec, sigma, l));
   EXPECT_EQ(4, cov4.rows());
   EXPECT_EQ(4, cov4.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-          sigma * sigma *
-              (1 +
-               std::pow(5, 0.5) / l *
-                   stan::math::squared_distance(x2_rvec[i], x2_vec[j]) +
-               (5.0 / 3.0) *
-                   std::pow(stan::math::squared_distance(x2_rvec[i], x2_vec[j]),
-                            2) /
-                   std::pow(l, 2)) *
-              std::exp(-1.0 * pow(5.0, 0.5) *
-                       stan::math::squared_distance(x2_rvec[i], x2_vec[j]) / l),
+          sigma * sigma
+              * (1
+                 + std::pow(5, 0.5) / l
+                       * stan::math::squared_distance(x2_rvec[i], x2_vec[j])
+                 + (5.0 / 3.0)
+                       * std::pow(stan::math::squared_distance(x2_rvec[i],
+                                                               x2_vec[j]),
+                                  2)
+                       / std::pow(l, 2))
+              * std::exp(-1.0 * pow(5.0, 0.5)
+                         * stan::math::squared_distance(x2_rvec[i], x2_vec[j])
+                         / l),
           cov4(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov5;
-  EXPECT_NO_THROW(cov5 =
-                      stan::math::gp_matern_5_2_cov(x1_rvec, x1_vec, sigma, l));
+  EXPECT_NO_THROW(cov5
+                  = stan::math::gp_matern_5_2_cov(x1_rvec, x1_vec, sigma, l));
   EXPECT_EQ(3, cov5.rows());
   EXPECT_EQ(3, cov5.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-          sigma * sigma *
-              (1 +
-               std::pow(5, 0.5) / l *
-                   stan::math::squared_distance(x1_rvec[i], x1_vec[j]) +
-               (5.0 / 3.0) *
-                   std::pow(stan::math::squared_distance(x1_rvec[i], x1_vec[j]),
-                            2) /
-                   std::pow(l, 2)) *
-              std::exp(-1.0 * pow(5.0, 0.5) *
-                       stan::math::squared_distance(x1_rvec[i], x1_vec[j]) / l),
+          sigma * sigma
+              * (1
+                 + std::pow(5, 0.5) / l
+                       * stan::math::squared_distance(x1_rvec[i], x1_vec[j])
+                 + (5.0 / 3.0)
+                       * std::pow(stan::math::squared_distance(x1_rvec[i],
+                                                               x1_vec[j]),
+                                  2)
+                       / std::pow(l, 2))
+              * std::exp(-1.0 * pow(5.0, 0.5)
+                         * stan::math::squared_distance(x1_rvec[i], x1_vec[j])
+                         / l),
           cov5(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov6;
-  EXPECT_NO_THROW(cov6 =
-                      stan::math::gp_matern_5_2_cov(x1_vec, x1_rvec, sigma, l));
+  EXPECT_NO_THROW(cov6
+                  = stan::math::gp_matern_5_2_cov(x1_vec, x1_rvec, sigma, l));
   EXPECT_EQ(3, cov6.rows());
   EXPECT_EQ(3, cov6.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-          sigma * sigma *
-              (1 +
-               std::pow(5, 0.5) / l *
-                   stan::math::squared_distance(x1_vec[i], x1_rvec[j]) +
-               (5.0 / 3.0) *
-                   std::pow(stan::math::squared_distance(x1_vec[i], x1_rvec[j]),
-                            2) /
-                   std::pow(l, 2)) *
-              std::exp(-1.0 * pow(5.0, 0.5) *
-                       stan::math::squared_distance(x1_vec[i], x1_rvec[j]) / l),
+          sigma * sigma
+              * (1
+                 + std::pow(5, 0.5) / l
+                       * stan::math::squared_distance(x1_vec[i], x1_rvec[j])
+                 + (5.0 / 3.0)
+                       * std::pow(stan::math::squared_distance(x1_vec[i],
+                                                               x1_rvec[j]),
+                                  2)
+                       / std::pow(l, 2))
+              * std::exp(-1.0 * pow(5.0, 0.5)
+                         * stan::math::squared_distance(x1_vec[i], x1_rvec[j])
+                         / l),
           cov6(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -838,168 +855,168 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_matern_5_2_cov2) {
     x2_vec[i] << 2 * i, 3 * i, 4 * i;
   }
   Eigen::MatrixXd cov;
-  EXPECT_NO_THROW(cov =
-                      stan::math::gp_matern_5_2_cov(x1_rvec, x2_vec, sigma, l));
+  EXPECT_NO_THROW(cov
+                  = stan::math::gp_matern_5_2_cov(x1_rvec, x2_vec, sigma, l));
   EXPECT_EQ(3, cov.rows());
   EXPECT_EQ(4, cov.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       temp = 0;
       for (int k = 0; k < 3; k++) {
-        temp += stan::math::squared_distance(x1_rvec[i], x2_vec[j]) /
-                l[k];
+        temp += stan::math::squared_distance(x1_rvec[i], x2_vec[j]) / l[k];
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma * (1 + std::pow(5.0, 0.5) * temp +
-                                       (5.0 / 3.0) * std::pow(temp, 2.0)) *
-                          std::exp(-1.0 * pow(5.0, 0.5) * temp),
+      EXPECT_FLOAT_EQ(sigma * sigma
+                          * (1 + std::pow(5.0, 0.5) * temp
+                             + (5.0 / 3.0) * std::pow(temp, 2.0))
+                          * std::exp(-1.0 * pow(5.0, 0.5) * temp),
                       cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov7;
-  EXPECT_NO_THROW(cov7 =
-                      stan::math::gp_matern_5_2_cov(x2_vec, x1_rvec, sigma, l));
+  EXPECT_NO_THROW(cov7
+                  = stan::math::gp_matern_5_2_cov(x2_vec, x1_rvec, sigma, l));
   EXPECT_EQ(4, cov7.rows());
   EXPECT_EQ(3, cov7.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       temp = 0;
       for (int k = 0; k < 3; k++) {
-        temp += stan::math::squared_distance(x2_vec[i], x1_rvec[j]) /
-                l[k];
+        temp += stan::math::squared_distance(x2_vec[i], x1_rvec[j]) / l[k];
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma * (1 + std::pow(5.0, 0.5) * temp +
-                                       (5.0 / 3.0) * std::pow(temp, 2.0)) *
-                          std::exp(-1.0 * pow(5.0, 0.5) * temp),
+      EXPECT_FLOAT_EQ(sigma * sigma
+                          * (1 + std::pow(5.0, 0.5) * temp
+                             + (5.0 / 3.0) * std::pow(temp, 2.0))
+                          * std::exp(-1.0 * pow(5.0, 0.5) * temp),
                       cov7(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov2;
-  EXPECT_NO_THROW(cov2 =
-                      stan::math::gp_matern_5_2_cov(x1_vec, x2_rvec, sigma, l));
+  EXPECT_NO_THROW(cov2
+                  = stan::math::gp_matern_5_2_cov(x1_vec, x2_rvec, sigma, l));
   EXPECT_EQ(3, cov2.rows());
   EXPECT_EQ(4, cov2.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       temp = 0;
       for (int k = 0; k < 3; k++) {
-        temp += stan::math::squared_distance(x1_vec[i], x2_rvec[j]) /
-                l[k];
+        temp += stan::math::squared_distance(x1_vec[i], x2_rvec[j]) / l[k];
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma * (1 + std::pow(5.0, 0.5) * temp +
-                                       (5.0 / 3.0) * std::pow(temp, 2.0)) *
-                          std::exp(-1.0 * pow(5.0, 0.5) * temp),
+      EXPECT_FLOAT_EQ(sigma * sigma
+                          * (1 + std::pow(5.0, 0.5) * temp
+                             + (5.0 / 3.0) * std::pow(temp, 2.0))
+                          * std::exp(-1.0 * pow(5.0, 0.5) * temp),
                       cov2(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov8;
-  EXPECT_NO_THROW(cov8 =
-                      stan::math::gp_matern_5_2_cov(x2_rvec, x1_vec, sigma, l));
+  EXPECT_NO_THROW(cov8
+                  = stan::math::gp_matern_5_2_cov(x2_rvec, x1_vec, sigma, l));
   EXPECT_EQ(4, cov8.rows());
   EXPECT_EQ(3, cov8.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       temp = 0;
       for (int k = 0; k < 3; k++) {
-        temp += stan::math::squared_distance(x2_rvec[i], x1_vec[j]) /
-                l[k];
+        temp += stan::math::squared_distance(x2_rvec[i], x1_vec[j]) / l[k];
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma * (1 + std::pow(5.0, 0.5) * temp +
-                                       (5.0 / 3.0) * std::pow(temp, 2.0)) *
-                          std::exp(-1.0 * pow(5.0, 0.5) * temp),
+      EXPECT_FLOAT_EQ(sigma * sigma
+                          * (1 + std::pow(5.0, 0.5) * temp
+                             + (5.0 / 3.0) * std::pow(temp, 2.0))
+                          * std::exp(-1.0 * pow(5.0, 0.5) * temp),
                       cov8(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov3;
-  EXPECT_NO_THROW(cov3 =
-                      stan::math::gp_matern_5_2_cov(x2_vec, x2_rvec, sigma, l));
+  EXPECT_NO_THROW(cov3
+                  = stan::math::gp_matern_5_2_cov(x2_vec, x2_rvec, sigma, l));
   EXPECT_EQ(4, cov3.rows());
   EXPECT_EQ(4, cov3.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       temp = 0;
       for (int k = 0; k < 3; k++) {
-        temp += stan::math::squared_distance(x2_vec[i], x2_rvec[j]) /
-                l[k];
+        temp += stan::math::squared_distance(x2_vec[i], x2_rvec[j]) / l[k];
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma * (1 + std::pow(5.0, 0.5) * temp +
-                                       (5.0 / 3.0) * std::pow(temp, 2.0)) *
-                          std::exp(-1.0 * pow(5.0, 0.5) * temp),
+      EXPECT_FLOAT_EQ(sigma * sigma
+                          * (1 + std::pow(5.0, 0.5) * temp
+                             + (5.0 / 3.0) * std::pow(temp, 2.0))
+                          * std::exp(-1.0 * pow(5.0, 0.5) * temp),
                       cov3(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov4;
-  EXPECT_NO_THROW(cov4 =
-                      stan::math::gp_matern_5_2_cov(x2_rvec, x2_vec, sigma, l));
+  EXPECT_NO_THROW(cov4
+                  = stan::math::gp_matern_5_2_cov(x2_rvec, x2_vec, sigma, l));
   EXPECT_EQ(4, cov4.rows());
   EXPECT_EQ(4, cov4.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       temp = 0;
       for (int k = 0; k < 3; k++) {
-        temp += stan::math::squared_distance(x2_rvec[i], x2_vec[j]) /
-                l[k];
+        temp += stan::math::squared_distance(x2_rvec[i], x2_vec[j]) / l[k];
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma * (1 + std::pow(5.0, 0.5) * temp +
-                                       (5.0 / 3.0) * std::pow(temp, 2.0)) *
-                          std::exp(-1.0 * pow(5.0, 0.5) * temp),
+      EXPECT_FLOAT_EQ(sigma * sigma
+                          * (1 + std::pow(5.0, 0.5) * temp
+                             + (5.0 / 3.0) * std::pow(temp, 2.0))
+                          * std::exp(-1.0 * pow(5.0, 0.5) * temp),
                       cov4(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov5;
-  EXPECT_NO_THROW(cov5 =
-                      stan::math::gp_matern_5_2_cov(x1_rvec, x1_vec, sigma, l));
+  EXPECT_NO_THROW(cov5
+                  = stan::math::gp_matern_5_2_cov(x1_rvec, x1_vec, sigma, l));
   EXPECT_EQ(3, cov5.rows());
   EXPECT_EQ(3, cov5.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       temp = 0;
       for (int k = 0; k < 3; k++) {
-        temp += stan::math::squared_distance(x1_rvec[i], x1_vec[j]) /
-                l[k];
+        temp += stan::math::squared_distance(x1_rvec[i], x1_vec[j]) / l[k];
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma * (1 + std::pow(5.0, 0.5) * temp +
-                                       (5.0 / 3.0) * std::pow(temp, 2.0)) *
-                          std::exp(-1.0 * pow(5.0, 0.5) * temp),
+      EXPECT_FLOAT_EQ(sigma * sigma
+                          * (1 + std::pow(5.0, 0.5) * temp
+                             + (5.0 / 3.0) * std::pow(temp, 2.0))
+                          * std::exp(-1.0 * pow(5.0, 0.5) * temp),
                       cov5(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov6;
-  EXPECT_NO_THROW(cov6 =
-                      stan::math::gp_matern_5_2_cov(x1_vec, x1_rvec, sigma, l));
+  EXPECT_NO_THROW(cov6
+                  = stan::math::gp_matern_5_2_cov(x1_vec, x1_rvec, sigma, l));
   EXPECT_EQ(3, cov6.rows());
   EXPECT_EQ(3, cov6.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       temp = 0;
       for (int k = 0; k < 3; k++) {
-        temp += stan::math::squared_distance(x1_vec[i], x1_rvec[j]) /
-                l[k];
+        temp += stan::math::squared_distance(x1_vec[i], x1_rvec[j]) / l[k];
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma * (1 + std::pow(5.0, 0.5) * temp +
-                                       (5.0 / 3.0) * std::pow(temp, 2.0)) *
-                          std::exp(-1.0 * pow(5.0, 0.5) * temp),
+      EXPECT_FLOAT_EQ(sigma * sigma
+                          * (1 + std::pow(5.0, 0.5) * temp
+                             + (5.0 / 3.0) * std::pow(temp, 2.0))
+                          * std::exp(-1.0 * pow(5.0, 0.5) * temp),
                       cov6(i, j))
           << "index: (" << i << ", " << j << ")";
     }

--- a/test/unit/math/prim/mat/fun/gp_matern_5_2_cov_test.cpp
+++ b/test/unit/math/prim/mat/fun/gp_matern_5_2_cov_test.cpp
@@ -1,8 +1,8 @@
-#include <cmath>
 #include <gtest/gtest.h>
-#include <limits>
 #include <stan/math/prim/mat.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <cmath>
+#include <limits>
 #include <string>
 #include <vector>
 
@@ -82,7 +82,7 @@ TEST(MathPrimMat, vec_double_ard_gp_matern_5_2_cov1) {
       temp = 0;
       for (int k = 0; k < 5; k++) {
         temp +=
-            stan::math::squared_distance(x[i], x[j]) / stan::math::square(l[k]);
+            stan::math::squared_distance(x[i], x[j]) / l[k];
       }
 
       EXPECT_FLOAT_EQ(sigma * sigma * (1 + std::pow(5.0, 0.5) * temp +
@@ -216,7 +216,7 @@ TEST(MathPrimMat, vec_eigen_ard_gp_matern_5_2_cov1) {
       temp = 0;
       for (int k = 0; k < 5; k++) {
         temp += stan::math::squared_distance(x1[i], x1[j]) /
-                stan::math::square(l[k]);
+                l[k];
       }
       EXPECT_FLOAT_EQ(sigma * sigma * (1 + std::pow(5.0, 0.5) * temp +
                                        (5.0 / 3.0) * std::pow(temp, 2.0)) *
@@ -254,7 +254,7 @@ TEST(MathPrimMat, vec_double_double_ard_gp_matern_5_2_cov1) {
       temp = 0;
       for (int k = 0; k < 4; k++) {
         temp += stan::math::squared_distance(x1[i], x2[j]) /
-                stan::math::square(l[k]);
+                l[k];
       }
       EXPECT_FLOAT_EQ(sigma * sigma * (1 + std::pow(5.0, 0.5) * temp +
                                        (5.0 / 3.0) * std::pow(temp, 2.0)) *
@@ -294,7 +294,7 @@ TEST(MathPrimMat, vec_eigen_eigen_ard_gp_matern_5_2_cov1) {
       temp = 0;
       for (int k = 0; k < 4; k++) {
         temp += stan::math::squared_distance(x1[i], x2[j]) /
-                stan::math::square(l[k]);
+                l[k];
       }
       EXPECT_FLOAT_EQ(sigma * sigma * (1 + std::pow(5.0, 0.5) * temp +
                                        (5.0 / 3.0) * std::pow(temp, 2.0)) *
@@ -358,7 +358,7 @@ TEST(MathPrimMat, rvec_eigen_ard_gp_matern_5_2_cov1) {
       temp = 0;
       for (int k = 0; k < 4; k++) {
         temp += stan::math::squared_distance(x1[i], x1[j]) /
-                stan::math::square(l[k]);
+                l[k];
       }
 
       EXPECT_FLOAT_EQ(sigma * sigma * (1 + std::pow(5.0, 0.5) * temp +
@@ -451,7 +451,7 @@ TEST(MathPrimMat, vec_eigen_rvec_eigen_ard_gp_matern_5_2_cov1) {
       temp = 0;
       for (int k = 0; k < 3; k++) {
         temp += stan::math::squared_distance(x1[i], x2[j]) /
-                stan::math::square(l[k]);
+                l[k];
       }
 
       EXPECT_FLOAT_EQ(sigma * sigma * (1 + std::pow(5.0, 0.5) * temp +
@@ -467,7 +467,7 @@ TEST(MathPrimMat, vec_eigen_rvec_eigen_ard_gp_matern_5_2_cov1) {
       temp = 0;
       for (int k = 0; k < 3; k++) {
         temp += stan::math::squared_distance(x2[i], x1[j]) /
-                stan::math::square(l[k]);
+                l[k];
       }
 
       EXPECT_FLOAT_EQ(sigma * sigma * (1 + std::pow(5.0, 0.5) * temp +
@@ -561,7 +561,7 @@ TEST(MathPrimMat, rvec_eigen_rvec_eigen_ard_gp_matern_5_2_cov1) {
       temp = 0;
       for (int k = 0; k < 3; k++) {
         temp += stan::math::squared_distance(x1[i], x2[j]) /
-                stan::math::square(l[k]);
+                l[k];
       }
       EXPECT_FLOAT_EQ(sigma * sigma * (1 + std::pow(5.0, 0.5) * temp +
                                        (5.0 / 3.0) * std::pow(temp, 2.0)) *
@@ -576,7 +576,7 @@ TEST(MathPrimMat, rvec_eigen_rvec_eigen_ard_gp_matern_5_2_cov1) {
       temp = 0;
       for (int k = 0; k < 3; k++) {
         temp += stan::math::squared_distance(x2[i], x1[j]) /
-                stan::math::square(l[k]);
+                l[k];
       }
       EXPECT_FLOAT_EQ(sigma * sigma * (1 + std::pow(5.0, 0.5) * temp +
                                        (5.0 / 3.0) * std::pow(temp, 2.0)) *
@@ -847,7 +847,7 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_matern_5_2_cov2) {
       temp = 0;
       for (int k = 0; k < 3; k++) {
         temp += stan::math::squared_distance(x1_rvec[i], x2_vec[j]) /
-                stan::math::square(l[k]);
+                l[k];
       }
 
       EXPECT_FLOAT_EQ(sigma * sigma * (1 + std::pow(5.0, 0.5) * temp +
@@ -868,7 +868,7 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_matern_5_2_cov2) {
       temp = 0;
       for (int k = 0; k < 3; k++) {
         temp += stan::math::squared_distance(x2_vec[i], x1_rvec[j]) /
-                stan::math::square(l[k]);
+                l[k];
       }
 
       EXPECT_FLOAT_EQ(sigma * sigma * (1 + std::pow(5.0, 0.5) * temp +
@@ -889,7 +889,7 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_matern_5_2_cov2) {
       temp = 0;
       for (int k = 0; k < 3; k++) {
         temp += stan::math::squared_distance(x1_vec[i], x2_rvec[j]) /
-                stan::math::square(l[k]);
+                l[k];
       }
 
       EXPECT_FLOAT_EQ(sigma * sigma * (1 + std::pow(5.0, 0.5) * temp +
@@ -910,7 +910,7 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_matern_5_2_cov2) {
       temp = 0;
       for (int k = 0; k < 3; k++) {
         temp += stan::math::squared_distance(x2_rvec[i], x1_vec[j]) /
-                stan::math::square(l[k]);
+                l[k];
       }
 
       EXPECT_FLOAT_EQ(sigma * sigma * (1 + std::pow(5.0, 0.5) * temp +
@@ -931,7 +931,7 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_matern_5_2_cov2) {
       temp = 0;
       for (int k = 0; k < 3; k++) {
         temp += stan::math::squared_distance(x2_vec[i], x2_rvec[j]) /
-                stan::math::square(l[k]);
+                l[k];
       }
 
       EXPECT_FLOAT_EQ(sigma * sigma * (1 + std::pow(5.0, 0.5) * temp +
@@ -952,7 +952,7 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_matern_5_2_cov2) {
       temp = 0;
       for (int k = 0; k < 3; k++) {
         temp += stan::math::squared_distance(x2_rvec[i], x2_vec[j]) /
-                stan::math::square(l[k]);
+                l[k];
       }
 
       EXPECT_FLOAT_EQ(sigma * sigma * (1 + std::pow(5.0, 0.5) * temp +
@@ -973,7 +973,7 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_matern_5_2_cov2) {
       temp = 0;
       for (int k = 0; k < 3; k++) {
         temp += stan::math::squared_distance(x1_rvec[i], x1_vec[j]) /
-                stan::math::square(l[k]);
+                l[k];
       }
 
       EXPECT_FLOAT_EQ(sigma * sigma * (1 + std::pow(5.0, 0.5) * temp +
@@ -994,7 +994,7 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_matern_5_2_cov2) {
       temp = 0;
       for (int k = 0; k < 3; k++) {
         temp += stan::math::squared_distance(x1_vec[i], x1_rvec[j]) /
-                stan::math::square(l[k]);
+                l[k];
       }
 
       EXPECT_FLOAT_EQ(sigma * sigma * (1 + std::pow(5.0, 0.5) * temp +


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary:
Add matern 5/2 kernel to prim.

This is consistent with with both GMPL (Rasmussen & Williams) and our current quadratic exponential covariance function. Users will be able to switch back and forth between covariance functions easily, per Mike's suggestion on discourse. Please see the latex documentation for description of how I calculate the function and ARD.

#### How to Verify:
testing:
vec double
vec double double
vec double ARD
vec eigen
vec eigen eigen
vec eigen ARD
vec double double ARD
rvec eigen
rvec eigen ARD
vec eigen rvec eigen
vec eigen rvec eigen ARD
rvec eigen rvec eigen
rvec eigen rvec eigen ARD
eigen mixed
eigen mixed ARD
double domain err training
nan error training
differing x lengths

#### Copyright and Licensing
Copywrite<2018><Andre Zapico>

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
