### PR TITLE
make/debug

### DIFF
--- a/make/debug
+++ b/make/debug
@@ -1,0 +1,7 @@
+DEBUG ?= 0
+ifeq ($(DEBUG), 1)
+	CXXFLAGS:=$(filter-out -O${O},$(CXXFLAGS))
+	GTEST_CXXFLAGS:=$(filter-out -O${O},$(GTEST_CXXFLAGS))
+	CXXFLAGS +=-DDEBUG -g -O0
+	CFLAGS +=-DDEBUG -g -O0
+endif

--- a/make/debug
+++ b/make/debug
@@ -1,7 +1,7 @@
 DEBUG ?= 0
 ifeq ($(DEBUG), 1)
-	CXXFLAGS:=$(filter-out -O${O},$(CXXFLAGS))
-	GTEST_CXXFLAGS:=$(filter-out -O${O},$(GTEST_CXXFLAGS))
+	CXXFLAGS := $(filter-out -O${O}, $(CXXFLAGS))
+	GTEST_CXXFLAGS :=$(filter-out -O${O}, $(GTEST_CXXFLAGS))
 	CXXFLAGS +=-DDEBUG -g -O0
 	CFLAGS +=-DDEBUG -g -O0
 endif

--- a/make/debug
+++ b/make/debug
@@ -1,3 +1,5 @@
+# Add DEBUG = 1 in make/local for debug build. Note the
+# 3rd-party libraries will not be compiled with debug flags.
 DEBUG ?= 0
 ifeq ($(DEBUG), 1)
 	CXXFLAGS := $(filter-out -O${O}, $(CXXFLAGS))

--- a/make/tests
+++ b/make/tests
@@ -40,14 +40,6 @@ test/unit/libmultiple.so : test/unit/multiple_translation_units1.o test/unit/mul
 
 test/unit/multiple_translation_units_test.cpp : test/unit/libmultiple.so
 
-
-DEBUG_TESTS := $(subst .cpp,$(EXE),$(shell find test -name *debug_*test.cpp))
-ifeq ($(DEBUG), 1)
-  $(DEBUG_TESTS): CXXFLAGS += $(GTEST_CXXFLAGS)
-  $(DEBUG_TESTS): CXXFLAGS := $(filter-out -O${O}, $(CXXFLAGS))
-  $(DEBUG_TESTS): CXXFLAGS +=-DDEBUG -g -O0
-endif
-
 ############################################################
 #
 # CVODES tests

--- a/make/tests
+++ b/make/tests
@@ -44,7 +44,7 @@ test/unit/multiple_translation_units_test.cpp : test/unit/libmultiple.so
 DEBUG_TESTS := $(subst .cpp,$(EXE),$(shell find test -name *debug_*test.cpp))
 ifeq ($(DEBUG), 1)
   $(DEBUG_TESTS): CXXFLAGS += $(GTEST_CXXFLAGS)
-  $(DEBUG_TESTS): CXXFLAGS:=$(filter-out -O${O},$(CXXFLAGS))
+  $(DEBUG_TESTS): CXXFLAGS := $(filter-out -O${O}, $(CXXFLAGS))
   $(DEBUG_TESTS): CXXFLAGS +=-DDEBUG -g -O0
 endif
 

--- a/make/tests
+++ b/make/tests
@@ -40,6 +40,14 @@ test/unit/libmultiple.so : test/unit/multiple_translation_units1.o test/unit/mul
 
 test/unit/multiple_translation_units_test.cpp : test/unit/libmultiple.so
 
+
+DEBUG_TESTS := $(subst .cpp,$(EXE),$(shell find test -name *debug_*test.cpp))
+ifeq ($(DEBUG), 1)
+  $(DEBUG_TESTS): CXXFLAGS += $(GTEST_CXXFLAGS)
+  $(DEBUG_TESTS): CXXFLAGS:=$(filter-out -O${O},$(CXXFLAGS))
+  $(DEBUG_TESTS): CXXFLAGS +=-DDEBUG -g -O0
+endif
+
 ############################################################
 #
 # CVODES tests

--- a/makefile
+++ b/makefile
@@ -51,6 +51,7 @@ CXX = $(CC)
 
 include make/tests    # tests
 include make/cpplint  # cpplint
+include make/debug    # debug
 
 ##
 # Dependencies


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary:
Add `DEBUG=1` option to `make` to allow debug build with `CXXFLAGS +=-DDEBUG -g -O0`

#### Intended Effect:
This has been sitting in my `local` but I guess it helps that developers use consistent flags to share debug results. 

As to using `-O0` vs `-Og`, see
https://stackoverflow.com/questions/12970596/gcc-4-8-does-og-imply-g/27076307#27076307

We can propagate the setup to downstream repos later on.
#### How to Verify:
use `#ifdef DEBUG` to insert debug codes, and make with
```sh
make DEBUG=1 foo
```

Maybe we also want to also unit test with debug build. I'll leave it to general discussion.

#### Side Effects:
N/A

#### Documentation:
N/A

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Metrum Research Group, LLC

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
