### PR TITLE
Ode ts parameters

### DIFF
--- a/stan/math/prim/arr/functor/coupled_ode_system.hpp
+++ b/stan/math/prim/arr/functor/coupled_ode_system.hpp
@@ -132,8 +132,31 @@ class coupled_ode_system<F, double, double> {
    * @return the decoupled states
    */
   std::vector<std::vector<double> > decouple_states(
-      const std::vector<std::vector<double> >& y) const {
+      const std::vector<std::vector<double> >& y,
+      const std::vector<double>& time_steps) const {
     return y;
+  }
+
+  std::vector<std::vector<var> > decouple_states(
+      const std::vector<std::vector<double> >& y,
+      const std::vector<var>& time_steps) const {
+    const size_t n = y.size();
+    std::vector<std::vector<var>> y_var(n);
+
+    std::vector<var> temp_vars(N_);
+    std::vector<double> temp_gradients(1);
+    std::vector<var> par(1);
+    std::vector<double> rhs_eval(N_);
+    for (size_t i = 0; i < n; i++) {
+      rhs_eval = f_(value_of(time_steps[i]), y[i], theta_dbl_, x_, x_int_, msgs_);
+      for (size_t j = 0; j < N_; j++) { 
+        temp_gradients[0] = rhs_eval[j];
+        par[0] = time_steps[i];
+        temp_vars[j] = precomputed_gradients(y[i][j], par, temp_gradients);
+      }
+      y_var[i] = temp_vars;
+    }
+    return y_var;
   }
 };
 

--- a/stan/math/prim/arr/functor/coupled_ode_system.hpp
+++ b/stan/math/prim/arr/functor/coupled_ode_system.hpp
@@ -2,6 +2,7 @@
 #define STAN_MATH_PRIM_ARR_FUNCTOR_COUPLED_ODE_SYSTEM_HPP
 
 #include <stan/math/prim/scal/err/check_size_match.hpp>
+#include <stan/math/rev/core.hpp>
 #include <ostream>
 #include <vector>
 
@@ -137,15 +138,15 @@ class coupled_ode_system<F, double, double> {
     return y;
   }
 
-  std::vector<std::vector<var> > decouple_states(
+  std::vector<std::vector<stan::math::var> > decouple_states(
       const std::vector<std::vector<double> >& y,
-      const std::vector<var>& time_steps) const {
+      const std::vector<stan::math::var>& time_steps) const {
     const size_t n = y.size();
-    std::vector<std::vector<var>> y_var(n);
+    std::vector<std::vector<stan::math::var> > y_var(n);
 
-    std::vector<var> temp_vars(N_);
+    std::vector<stan::math::var> temp_vars(N_);
     std::vector<double> temp_gradients(1);
-    std::vector<var> par(1);
+    std::vector<stan::math::var> par(1);
     std::vector<double> rhs_eval(N_);
     for (size_t i = 0; i < n; i++) {
       rhs_eval = f_(value_of(time_steps[i]), y[i], theta_dbl_, x_, x_int_, msgs_);

--- a/stan/math/prim/arr/functor/coupled_ode_system.hpp
+++ b/stan/math/prim/arr/functor/coupled_ode_system.hpp
@@ -166,8 +166,8 @@ class coupled_ode_system<F, double, double> {
     std::vector<stan::math::var> par(1);
     std::vector<double> rhs_eval(N_);
     for (size_t i = 0; i < n; i++) {
-      rhs_eval = f_(stan::math::value_of(time_steps[i]), y[i],
-                    theta_dbl_, x_, x_int_, msgs_);
+      rhs_eval = f_(stan::math::value_of(time_steps[i]), y[i], theta_dbl_, x_,
+                    x_int_, msgs_);
       for (size_t j = 0; j < N_; j++) {
         temp_gradients[0] = rhs_eval[j];
         // only integration ends can be parameters

--- a/stan/math/prim/arr/functor/coupled_ode_system.hpp
+++ b/stan/math/prim/arr/functor/coupled_ode_system.hpp
@@ -3,7 +3,6 @@
 
 #include <stan/math/rev/scal/fun/value_of.hpp>
 #include <stan/math/prim/scal/err/check_size_match.hpp>
-#include <stan/math/rev/core.hpp>
 #include <ostream>
 #include <vector>
 

--- a/stan/math/prim/arr/functor/coupled_ode_system.hpp
+++ b/stan/math/prim/arr/functor/coupled_ode_system.hpp
@@ -144,7 +144,7 @@ class coupled_ode_system<F, double, double> {
   /**
    * Returns the base portion of the coupled state.
    *
-   * <p>In In this class, when time steps are parameters,
+   * <p>In this class, when time steps are parameters,
    * The function returns vars with gradients being the RHS
    * of the ODE system. So that for ODE system
    * du/dt = f(u, t)
@@ -170,7 +170,13 @@ class coupled_ode_system<F, double, double> {
                     x_int_, msgs_);
       for (size_t j = 0; j < N_; j++) {
         temp_gradients[0] = rhs_eval[j];
-        // only integration ends can be parameters
+
+        // only integration ends can be parameters. In other
+        // words, numerical solution at step i is only
+        // dependent on the init time point of that step. It
+        // does not explicitly dependent on other time step
+        // points. In particular, it does not deppend on
+        // future steps.
         par[0] = time_steps[i];
         temp_vars[j] = precomputed_gradients(y[i][j], par, temp_gradients);
       }

--- a/stan/math/prim/arr/functor/coupled_ode_system.hpp
+++ b/stan/math/prim/arr/functor/coupled_ode_system.hpp
@@ -1,6 +1,7 @@
 #ifndef STAN_MATH_PRIM_ARR_FUNCTOR_COUPLED_ODE_SYSTEM_HPP
 #define STAN_MATH_PRIM_ARR_FUNCTOR_COUPLED_ODE_SYSTEM_HPP
 
+#include <stan/math/rev/scal/fun/value_of.hpp>
 #include <stan/math/prim/scal/err/check_size_match.hpp>
 #include <stan/math/rev/core.hpp>
 #include <ostream>
@@ -165,7 +166,7 @@ class coupled_ode_system<F, double, double> {
     std::vector<stan::math::var> par(1);
     std::vector<double> rhs_eval(N_);
     for (size_t i = 0; i < n; i++) {
-      rhs_eval = f_(value_of(time_steps[i]), y[i],
+      rhs_eval = f_(stan::math::value_of(time_steps[i]), y[i],
                     theta_dbl_, x_, x_int_, msgs_);
       for (size_t j = 0; j < N_; j++) {
         temp_gradients[0] = rhs_eval[j];

--- a/stan/math/prim/arr/functor/integrate_ode_rk45.hpp
+++ b/stan/math/prim/arr/functor/integrate_ode_rk45.hpp
@@ -66,13 +66,12 @@ namespace math {
  * @return a vector of states, each state being a vector of the
  * same size as the state variable, corresponding to a time in ts.
  */
-  template <typename F, typename T1, typename T2, typename T_ts>
+template <typename F, typename T1, typename T2, typename T_ts>
 std::vector<std::vector<typename stan::return_type<T1, T2, T_ts>::type> >
 integrate_ode_rk45(const F& f, const std::vector<T1>& y0, double t0,
                    const std::vector<T_ts>& time_steps,
-                   const std::vector<T2>& theta,
-                   const std::vector<double>& x, const std::vector<int>& x_int,
-                   std::ostream* msgs = nullptr,
+                   const std::vector<T2>& theta, const std::vector<double>& x,
+                   const std::vector<int>& x_int, std::ostream* msgs = nullptr,
                    double relative_tolerance = 1e-6,
                    double absolute_tolerance = 1e-6, int max_num_steps = 1E6) {
   using boost::numeric::odeint::integrate_times;

--- a/stan/math/prim/arr/functor/integrate_ode_rk45.hpp
+++ b/stan/math/prim/arr/functor/integrate_ode_rk45.hpp
@@ -66,7 +66,7 @@ namespace math {
  * same size as the state variable, corresponding to a time in ts.
  */
   template <typename F, typename T1, typename T2, typename T_ts>
-std::vector<std::vector<typename stan::return_type<T1, T2>::type> >
+std::vector<std::vector<typename stan::return_type<T1, T2, T_ts>::type> >
 integrate_ode_rk45(const F& f, const std::vector<T1>& y0, double t0,
                    const std::vector<T_ts>& time_steps,
                    const std::vector<T2>& theta,

--- a/stan/math/prim/arr/functor/integrate_ode_rk45.hpp
+++ b/stan/math/prim/arr/functor/integrate_ode_rk45.hpp
@@ -47,10 +47,11 @@ namespace math {
  * @tparam F type of ODE system function.
  * @tparam T1 type of scalars for initial values.
  * @tparam T2 type of scalars for parameters.
+ * @tparam T_ts type of scalars for time steps.
  * @param[in] f functor for the base ordinary differential equation.
  * @param[in] y0 initial state.
  * @param[in] t0 initial time.
- * @param[in] ts times of the desired solutions, in strictly
+ * @param[in] time_steps times of the desired solutions, in strictly
  * increasing order, all greater than the initial time.
  * @param[in] theta parameter vector for the ODE.
  * @param[in] x continuous data vector for the ODE.

--- a/stan/math/prim/arr/functor/integrate_ode_rk45.hpp
+++ b/stan/math/prim/arr/functor/integrate_ode_rk45.hpp
@@ -65,10 +65,11 @@ namespace math {
  * @return a vector of states, each state being a vector of the
  * same size as the state variable, corresponding to a time in ts.
  */
-template <typename F, typename T1, typename T2>
+  template <typename F, typename T1, typename T2, typename T_ts>
 std::vector<std::vector<typename stan::return_type<T1, T2>::type> >
 integrate_ode_rk45(const F& f, const std::vector<T1>& y0, double t0,
-                   const std::vector<double>& ts, const std::vector<T2>& theta,
+                   const std::vector<T_ts>& time_steps,
+                   const std::vector<T2>& theta,
                    const std::vector<double>& x, const std::vector<int>& x_int,
                    std::ostream* msgs = nullptr,
                    double relative_tolerance = 1e-6,
@@ -77,6 +78,8 @@ integrate_ode_rk45(const F& f, const std::vector<T1>& y0, double t0,
   using boost::numeric::odeint::make_dense_output;
   using boost::numeric::odeint::max_step_checker;
   using boost::numeric::odeint::runge_kutta_dopri5;
+
+  const std::vector<double> ts = value_of(time_steps);
 
   check_finite("integrate_ode_rk45", "initial state", y0);
   check_finite("integrate_ode_rk45", "initial time", t0);
@@ -126,7 +129,7 @@ integrate_ode_rk45(const F& f, const std::vector<T1>& y0, double t0,
   y_coupled.erase(y_coupled.begin());
 
   // the coupled system also encapsulates the decoupling operation
-  return coupled_system.decouple_states(y_coupled);
+  return coupled_system.decouple_states(y_coupled, time_steps);
 }
 
 }  // namespace math

--- a/stan/math/rev/arr/functor/coupled_ode_system.hpp
+++ b/stan/math/rev/arr/functor/coupled_ode_system.hpp
@@ -219,8 +219,8 @@ struct coupled_ode_system<F, double, var> {
 
     for (size_t i = 0; i < y.size(); i++) {
       std::vector<double> y0_temp(y[i].begin(), y[i].begin() + N_);
-      rhs_eval = f_(value_of(time_steps[i]),
-                    y0_temp, theta_dbl_, x_, x_int_, msgs_);
+      rhs_eval
+          = f_(value_of(time_steps[i]), y0_temp, theta_dbl_, x_, x_int_, msgs_);
       theta_aug[M_] = time_steps[i];
       // iterate over number of equations
       for (size_t j = 0; j < N_; j++) {
@@ -229,8 +229,8 @@ struct coupled_ode_system<F, double, var> {
           temp_gradients[k] = y[i][y0_dbl_.size() + y0_dbl_.size() * k + j];
 
         temp_gradients[M_] = rhs_eval[j];
-        temp_vars[j] = precomputed_gradients(y[i][j],
-                                             theta_aug, temp_gradients);
+        temp_vars[j]
+            = precomputed_gradients(y[i][j], theta_aug, temp_gradients);
       }
       y_return[i] = temp_vars;
     }
@@ -434,7 +434,7 @@ struct coupled_ode_system<F, var, double> {
     using std::vector;
 
     vector<var> temp_vars(N_);
-    vector<double> temp_gradients(N_+1);
+    vector<double> temp_gradients(N_ + 1);
     vector<vector<var> > y_return(y.size());
     std::vector<stan::math::var> theta_aug;
     theta_aug.reserve(N_ + 1);
@@ -444,8 +444,8 @@ struct coupled_ode_system<F, var, double> {
 
     for (size_t i = 0; i < y.size(); i++) {
       std::vector<double> y0_temp(y[i].begin(), y[i].begin() + N_);
-      rhs_eval = f_(value_of(time_steps[i]),
-                    y0_temp, theta_dbl_, x_, x_int_, msgs_);
+      rhs_eval
+          = f_(value_of(time_steps[i]), y0_temp, theta_dbl_, x_, x_int_, msgs_);
       theta_aug[N_] = time_steps[i];
       // iterate over number of equations
       for (size_t j = 0; j < N_; j++) {
@@ -454,8 +454,8 @@ struct coupled_ode_system<F, var, double> {
           temp_gradients[k] = y[i][y0_.size() + y0_.size() * k + j];
 
         temp_gradients[N_] = rhs_eval[j];
-        temp_vars[j] = precomputed_gradients(y[i][j],
-                                             theta_aug, temp_gradients);
+        temp_vars[j]
+            = precomputed_gradients(y[i][j], theta_aug, temp_gradients);
       }
       y_return[i] = temp_vars;
     }
@@ -691,8 +691,8 @@ struct coupled_ode_system<F, var, var> {
 
     for (size_t i = 0; i < y.size(); i++) {
       std::vector<double> y0_temp(y[i].begin(), y[i].begin() + N_);
-      rhs_eval = f_(value_of(time_steps[i]), y0_temp,
-                    theta_dbl_, x_, x_int_, msgs_);
+      rhs_eval
+          = f_(value_of(time_steps[i]), y0_temp, theta_dbl_, x_, x_int_, msgs_);
       theta_aug[N_ + M_] = time_steps[i];
       // iterate over number of equations
       for (size_t j = 0; j < N_; j++) {
@@ -701,8 +701,8 @@ struct coupled_ode_system<F, var, var> {
           temp_gradients[k] = y[i][N_ + N_ * k + j];
 
         temp_gradients[N_ + M_] = rhs_eval[j];
-        temp_vars[j] = precomputed_gradients(y[i][j],
-                                             theta_aug, temp_gradients);
+        temp_vars[j]
+            = precomputed_gradients(y[i][j], theta_aug, temp_gradients);
       }
       y_return[i] = temp_vars;
     }

--- a/stan/math/rev/arr/functor/coupled_ode_system.hpp
+++ b/stan/math/rev/arr/functor/coupled_ode_system.hpp
@@ -175,6 +175,7 @@ struct coupled_ode_system<F, double, var> {
    * specified coupled system state.
    *
    * @param y coupled states after solving the ode
+   * @param time_steps the vector of the observation times
    */
   std::vector<std::vector<var> > decouple_states(
       const std::vector<std::vector<double> >& y,
@@ -197,6 +198,13 @@ struct coupled_ode_system<F, double, var> {
     return y_return;
   }
 
+  /**
+   * Returns the base ODE system state corresponding to the
+   * specified coupled system state.
+   *
+   * @param y coupled states after solving the ode
+   * @param time_steps the vector of the observation times
+   */
   std::vector<std::vector<var> > decouple_states(
       const std::vector<std::vector<double> >& y,
       const std::vector<var>& time_steps) const {
@@ -210,16 +218,18 @@ struct coupled_ode_system<F, double, var> {
     std::vector<double> rhs_eval(N_);
 
     for (size_t i = 0; i < y.size(); i++) {
-      rhs_eval = f_(value_of(time_steps[i]), y[i], theta_dbl_, x_, x_int_, msgs_);
+      rhs_eval = f_(value_of(time_steps[i]),
+                    y[i], theta_dbl_, x_, x_int_, msgs_);
       theta_aug[M_] = time_steps[i];
       // iterate over number of equations
-      for (size_t j = 0; j < N_; j++) { 
+      for (size_t j = 0; j < N_; j++) {
         // iterate over parameters for each equation
         for (size_t k = 0; k < M_; k++)
           temp_gradients[k] = y[i][y0_dbl_.size() + y0_dbl_.size() * k + j];
 
         temp_gradients[M_] = rhs_eval[j];
-        temp_vars[j] = precomputed_gradients(y[i][j], theta_aug, temp_gradients);
+        temp_vars[j] = precomputed_gradients(y[i][j],
+                                             theta_aug, temp_gradients);
       }
       y_return[i] = temp_vars;
     }
@@ -380,11 +390,11 @@ struct coupled_ode_system<F, var, double> {
   }
 
   /**
-   * Return the solutions to the basic ODE system, including
-   * appropriate autodiff partial derivatives, given the specified
-   * coupled system solution.
+   * Returns the base ODE system state corresponding to the
+   * specified coupled system state.
    *
-   * @param y the vector of the coupled states after solving the ode
+   * @param y coupled states after solving the ode
+   * @param time_steps the vector of the observation times
    */
   std::vector<std::vector<var> > decouple_states(
       const std::vector<std::vector<double> >& y,
@@ -410,6 +420,13 @@ struct coupled_ode_system<F, var, double> {
     return y_return;
   }
 
+  /**
+   * Returns the base ODE system state corresponding to the
+   * specified coupled system state.
+   *
+   * @param y coupled states after solving the ode
+   * @param time_steps the vector of the observation times
+   */
   std::vector<std::vector<var> > decouple_states(
       const std::vector<std::vector<double> >& y,
       const std::vector<var>& time_steps) const {
@@ -425,7 +442,8 @@ struct coupled_ode_system<F, var, double> {
     std::vector<double> rhs_eval(N_);
 
     for (size_t i = 0; i < y.size(); i++) {
-      rhs_eval = f_(value_of(time_steps[i]), y[i], theta_dbl_, x_, x_int_, msgs_);
+      rhs_eval = f_(value_of(time_steps[i]),
+                    y[i], theta_dbl_, x_, x_int_, msgs_);
       theta_aug[N_] = time_steps[i];
       // iterate over number of equations
       for (size_t j = 0; j < N_; j++) {
@@ -434,14 +452,14 @@ struct coupled_ode_system<F, var, double> {
           temp_gradients[k] = y[i][y0_.size() + y0_.size() * k + j];
 
         temp_gradients[N_] = rhs_eval[j];
-        temp_vars[j] = precomputed_gradients(y[i][j], theta_aug, temp_gradients);
+        temp_vars[j] = precomputed_gradients(y[i][j],
+                                             theta_aug, temp_gradients);
       }
       y_return[i] = temp_vars;
     }
 
     return y_return;
   }
-
 };
 
 /**
@@ -612,11 +630,11 @@ struct coupled_ode_system<F, var, var> {
   }
 
   /**
-   * Return the basic ODE solutions given the specified coupled
-   * system solutions, including the partials versus the
-   * parameters encoded in the autodiff results.
+   * Returns the base ODE system state corresponding to the
+   * specified coupled system state.
    *
-   * @param y the vector of the coupled states after solving the ode
+   * @param y coupled states after solving the ode
+   * @param time_steps the vector of the observation times
    */
   std::vector<std::vector<var> > decouple_states(
       const std::vector<std::vector<double> >& y,
@@ -645,6 +663,13 @@ struct coupled_ode_system<F, var, var> {
     return y_return;
   }
 
+  /**
+   * Returns the base ODE system state corresponding to the
+   * specified coupled system state.
+   *
+   * @param y coupled states after solving the ode
+   * @param time_steps the vector of the observation times
+   */
   std::vector<std::vector<var> > decouple_states(
       const std::vector<std::vector<double> >& y,
       const std::vector<var>& time_steps) const {
@@ -663,7 +688,8 @@ struct coupled_ode_system<F, var, var> {
     std::vector<double> rhs_eval(N_);
 
     for (size_t i = 0; i < y.size(); i++) {
-      rhs_eval = f_(value_of(time_steps[i]), y[i], theta_dbl_, x_, x_int_, msgs_);
+      rhs_eval = f_(value_of(time_steps[i]), y[i],
+                    theta_dbl_, x_, x_int_, msgs_);
       theta_aug[N_ + M_] = time_steps[i];
       // iterate over number of equations
       for (size_t j = 0; j < N_; j++) {
@@ -672,7 +698,8 @@ struct coupled_ode_system<F, var, var> {
           temp_gradients[k] = y[i][N_ + N_ * k + j];
 
         temp_gradients[N_ + M_] = rhs_eval[j];
-        temp_vars[j] = precomputed_gradients(y[i][j], theta_aug, temp_gradients);
+        temp_vars[j] = precomputed_gradients(y[i][j],
+                                             theta_aug, temp_gradients);
       }
       y_return[i] = temp_vars;
     }

--- a/stan/math/rev/arr/functor/coupled_ode_system.hpp
+++ b/stan/math/rev/arr/functor/coupled_ode_system.hpp
@@ -218,8 +218,9 @@ struct coupled_ode_system<F, double, var> {
     std::vector<double> rhs_eval(N_);
 
     for (size_t i = 0; i < y.size(); i++) {
+      std::vector<double> y0_temp(y[i].begin(), y[i].begin() + N_);
       rhs_eval = f_(value_of(time_steps[i]),
-                    y[i], theta_dbl_, x_, x_int_, msgs_);
+                    y0_temp, theta_dbl_, x_, x_int_, msgs_);
       theta_aug[M_] = time_steps[i];
       // iterate over number of equations
       for (size_t j = 0; j < N_; j++) {
@@ -442,8 +443,9 @@ struct coupled_ode_system<F, var, double> {
     std::vector<double> rhs_eval(N_);
 
     for (size_t i = 0; i < y.size(); i++) {
+      std::vector<double> y0_temp(y[i].begin(), y[i].begin() + N_);
       rhs_eval = f_(value_of(time_steps[i]),
-                    y[i], theta_dbl_, x_, x_int_, msgs_);
+                    y0_temp, theta_dbl_, x_, x_int_, msgs_);
       theta_aug[N_] = time_steps[i];
       // iterate over number of equations
       for (size_t j = 0; j < N_; j++) {
@@ -688,7 +690,8 @@ struct coupled_ode_system<F, var, var> {
     std::vector<double> rhs_eval(N_);
 
     for (size_t i = 0; i < y.size(); i++) {
-      rhs_eval = f_(value_of(time_steps[i]), y[i],
+      std::vector<double> y0_temp(y[i].begin(), y[i].begin() + N_);
+      rhs_eval = f_(value_of(time_steps[i]), y0_temp,
                     theta_dbl_, x_, x_int_, msgs_);
       theta_aug[N_ + M_] = time_steps[i];
       // iterate over number of equations

--- a/stan/math/rev/mat/functor/cvodes_integrator.hpp
+++ b/stan/math/rev/mat/functor/cvodes_integrator.hpp
@@ -52,10 +52,11 @@ class cvodes_integrator {
    * @tparam F type of ODE system function.
    * @tparam T_initial type of scalars for initial values.
    * @tparam T_param type of scalars for parameters.
+   * @tparam T_ts type of scalars for time steps.
    * @param[in] f functor for the base ordinary differential equation.
    * @param[in] y0 initial state.
    * @param[in] t0 initial time.
-   * @param[in] ts times of the desired solutions, in strictly
+   * @param[in] time_steps times of the desired solutions, in strictly
    * increasing order, all greater than the initial time.
    * @param[in] theta parameter vector for the ODE.
    * @param[in] x continuous data vector for the ODE.

--- a/stan/math/rev/mat/functor/cvodes_integrator.hpp
+++ b/stan/math/rev/mat/functor/cvodes_integrator.hpp
@@ -68,17 +68,20 @@ class cvodes_integrator {
    * @return a vector of states, each state being a vector of the
    * same size as the state variable, corresponding to a time in ts.
    */
-  template <typename F, typename T_initial, typename T_param>
+  template <typename F, typename T_initial, typename T_param, typename T_ts>
   std::vector<
       std::vector<typename stan::return_type<T_initial, T_param>::type> >
   integrate(const F& f, const std::vector<T_initial>& y0, double t0,
-            const std::vector<double>& ts, const std::vector<T_param>& theta,
+            const std::vector<T_ts>& time_steps,
+            const std::vector<T_param>& theta,
             const std::vector<double>& x, const std::vector<int>& x_int,
             std::ostream* msgs, double relative_tolerance,
             double absolute_tolerance,
             long int max_num_steps) {  // NOLINT(runtime/int)
     typedef stan::is_var<T_initial> initial_var;
     typedef stan::is_var<T_param> param_var;
+
+    const std::vector<double> ts = value_of(time_steps);
 
     const char* fun = "integrate_ode_cvodes";
 
@@ -175,7 +178,7 @@ class cvodes_integrator {
 
     CVodeFree(&cvodes_mem);
 
-    return cvodes_data.coupled_ode_.decouple_states(y_coupled);
+    return cvodes_data.coupled_ode_.decouple_states(y_coupled, time_steps);
   }
 };  // cvodes integrator
 }  // namespace math

--- a/stan/math/rev/mat/functor/cvodes_integrator.hpp
+++ b/stan/math/rev/mat/functor/cvodes_integrator.hpp
@@ -70,7 +70,7 @@ class cvodes_integrator {
    */
   template <typename F, typename T_initial, typename T_param, typename T_ts>
   std::vector<
-      std::vector<typename stan::return_type<T_initial, T_param>::type> >
+      std::vector<typename stan::return_type<T_initial, T_param, T_ts>::type> >
   integrate(const F& f, const std::vector<T_initial>& y0, double t0,
             const std::vector<T_ts>& time_steps,
             const std::vector<T_param>& theta,

--- a/stan/math/rev/mat/functor/cvodes_integrator.hpp
+++ b/stan/math/rev/mat/functor/cvodes_integrator.hpp
@@ -74,10 +74,9 @@ class cvodes_integrator {
       std::vector<typename stan::return_type<T_initial, T_param, T_ts>::type> >
   integrate(const F& f, const std::vector<T_initial>& y0, double t0,
             const std::vector<T_ts>& time_steps,
-            const std::vector<T_param>& theta,
-            const std::vector<double>& x, const std::vector<int>& x_int,
-            std::ostream* msgs, double relative_tolerance,
-            double absolute_tolerance,
+            const std::vector<T_param>& theta, const std::vector<double>& x,
+            const std::vector<int>& x_int, std::ostream* msgs,
+            double relative_tolerance, double absolute_tolerance,
             long int max_num_steps) {  // NOLINT(runtime/int)
     typedef stan::is_var<T_initial> initial_var;
     typedef stan::is_var<T_param> param_var;

--- a/stan/math/rev/mat/functor/integrate_ode_adams.hpp
+++ b/stan/math/rev/mat/functor/integrate_ode_adams.hpp
@@ -9,8 +9,8 @@ namespace stan {
 namespace math {
 
 template <typename F, typename T_initial, typename T_param, typename T_ts>
-std::vector<std::vector<typename
-                        stan::return_type<T_initial, T_param, T_ts>::type> >
+std::vector<
+    std::vector<typename stan::return_type<T_initial, T_param, T_ts>::type> >
 integrate_ode_adams(const F& f, const std::vector<T_initial>& y0, double t0,
                     const std::vector<T_ts>& ts,
                     const std::vector<T_param>& theta,

--- a/stan/math/rev/mat/functor/integrate_ode_adams.hpp
+++ b/stan/math/rev/mat/functor/integrate_ode_adams.hpp
@@ -8,10 +8,10 @@
 namespace stan {
 namespace math {
 
-template <typename F, typename T_initial, typename T_param>
+template <typename F, typename T_initial, typename T_param, typename T_ts>
 std::vector<std::vector<typename stan::return_type<T_initial, T_param>::type> >
 integrate_ode_adams(const F& f, const std::vector<T_initial>& y0, double t0,
-                    const std::vector<double>& ts,
+                    const std::vector<T_ts>& ts,
                     const std::vector<T_param>& theta,
                     const std::vector<double>& x, const std::vector<int>& x_int,
                     std::ostream* msgs = nullptr,

--- a/stan/math/rev/mat/functor/integrate_ode_adams.hpp
+++ b/stan/math/rev/mat/functor/integrate_ode_adams.hpp
@@ -9,7 +9,8 @@ namespace stan {
 namespace math {
 
 template <typename F, typename T_initial, typename T_param, typename T_ts>
-std::vector<std::vector<typename stan::return_type<T_initial, T_param, T_ts>::type> >
+std::vector<std::vector<typename
+                        stan::return_type<T_initial, T_param, T_ts>::type> >
 integrate_ode_adams(const F& f, const std::vector<T_initial>& y0, double t0,
                     const std::vector<T_ts>& ts,
                     const std::vector<T_param>& theta,

--- a/stan/math/rev/mat/functor/integrate_ode_adams.hpp
+++ b/stan/math/rev/mat/functor/integrate_ode_adams.hpp
@@ -9,7 +9,7 @@ namespace stan {
 namespace math {
 
 template <typename F, typename T_initial, typename T_param, typename T_ts>
-std::vector<std::vector<typename stan::return_type<T_initial, T_param>::type> >
+std::vector<std::vector<typename stan::return_type<T_initial, T_param, T_ts>::type> >
 integrate_ode_adams(const F& f, const std::vector<T_initial>& y0, double t0,
                     const std::vector<T_ts>& ts,
                     const std::vector<T_param>& theta,

--- a/stan/math/rev/mat/functor/integrate_ode_bdf.hpp
+++ b/stan/math/rev/mat/functor/integrate_ode_bdf.hpp
@@ -9,7 +9,8 @@ namespace stan {
 namespace math {
 
 template <typename F, typename T_initial, typename T_param, typename T_ts>
-std::vector<std::vector<typename stan::return_type<T_initial, T_param, T_ts>::type> >
+std::vector<std::vector<typename
+                        stan::return_type<T_initial, T_param, T_ts>::type> >
 integrate_ode_bdf(const F& f, const std::vector<T_initial>& y0, double t0,
                   const std::vector<T_ts>& ts,
                   const std::vector<T_param>& theta,

--- a/stan/math/rev/mat/functor/integrate_ode_bdf.hpp
+++ b/stan/math/rev/mat/functor/integrate_ode_bdf.hpp
@@ -9,7 +9,7 @@ namespace stan {
 namespace math {
 
 template <typename F, typename T_initial, typename T_param, typename T_ts>
-std::vector<std::vector<typename stan::return_type<T_initial, T_param>::type> >
+std::vector<std::vector<typename stan::return_type<T_initial, T_param, T_ts>::type> >
 integrate_ode_bdf(const F& f, const std::vector<T_initial>& y0, double t0,
                   const std::vector<T_ts>& ts,
                   const std::vector<T_param>& theta,

--- a/stan/math/rev/mat/functor/integrate_ode_bdf.hpp
+++ b/stan/math/rev/mat/functor/integrate_ode_bdf.hpp
@@ -9,8 +9,8 @@ namespace stan {
 namespace math {
 
 template <typename F, typename T_initial, typename T_param, typename T_ts>
-std::vector<std::vector<typename
-                        stan::return_type<T_initial, T_param, T_ts>::type> >
+std::vector<
+    std::vector<typename stan::return_type<T_initial, T_param, T_ts>::type> >
 integrate_ode_bdf(const F& f, const std::vector<T_initial>& y0, double t0,
                   const std::vector<T_ts>& ts,
                   const std::vector<T_param>& theta,

--- a/stan/math/rev/mat/functor/integrate_ode_bdf.hpp
+++ b/stan/math/rev/mat/functor/integrate_ode_bdf.hpp
@@ -8,10 +8,10 @@
 namespace stan {
 namespace math {
 
-template <typename F, typename T_initial, typename T_param>
+template <typename F, typename T_initial, typename T_param, typename T_ts>
 std::vector<std::vector<typename stan::return_type<T_initial, T_param>::type> >
 integrate_ode_bdf(const F& f, const std::vector<T_initial>& y0, double t0,
-                  const std::vector<double>& ts,
+                  const std::vector<T_ts>& ts,
                   const std::vector<T_param>& theta,
                   const std::vector<double>& x, const std::vector<int>& x_int,
                   std::ostream* msgs = nullptr,

--- a/test/unit/math/prim/arr/functor/coupled_ode_system_test.cpp
+++ b/test/unit/math/prim/arr/functor/coupled_ode_system_test.cpp
@@ -39,7 +39,8 @@ TEST_F(StanMathOde, decouple_states_dd) {
   }
 
   std::vector<std::vector<double> > ys;
-  ys = coupled_system.decouple_states(ys_coupled);
+  std::vector<double> ts_dummy;
+  ys = coupled_system.decouple_states(ys_coupled, ts_dummy);
 
   ASSERT_EQ(T, ys.size());
   for (int t = 0; t < T; t++)

--- a/test/unit/math/rev/arr/functor/coupled_ode_system_test.cpp
+++ b/test/unit/math/rev/arr/functor/coupled_ode_system_test.cpp
@@ -76,7 +76,8 @@ TEST_F(StanAgradRevOde, decouple_states_dv) {
   }
 
   std::vector<std::vector<var> > ys;
-  ys = coupled_system.decouple_states(ys_coupled);
+  std::vector<double> ts_dummy;
+  ys = coupled_system.decouple_states(ys_coupled, ts_dummy);
 
   ASSERT_EQ(T, ys.size());
   for (size_t t = 0; t < T; t++)
@@ -250,7 +251,8 @@ TEST_F(StanAgradRevOde, decouple_states_vd) {
   }
 
   std::vector<std::vector<var> > ys;
-  ys = coupled_system.decouple_states(ys_coupled);
+  std::vector<double> ts_dummy;
+  ys = coupled_system.decouple_states(ys_coupled, ts_dummy);
 
   ASSERT_EQ(T, ys.size());
   for (size_t t = 0; t < T; t++)
@@ -431,7 +433,8 @@ TEST_F(StanAgradRevOde, decouple_states_vv) {
   }
 
   std::vector<std::vector<var> > ys;
-  ys = coupled_system.decouple_states(ys_coupled);
+  std::vector<double> ts_dummy;
+  ys = coupled_system.decouple_states(ys_coupled, ts_dummy);
 
   ASSERT_EQ(T, ys.size());
   for (size_t t = 0; t < T; t++)

--- a/test/unit/math/rev/arr/functor/integrate_ode_rk45_test.cpp
+++ b/test/unit/math/rev/arr/functor/integrate_ode_rk45_test.cpp
@@ -117,7 +117,7 @@ TEST(StanAgradRevOde_integrate_ode_rk45, lorenz_finite_diff) {
   test_ode(lorenz, t0, ts, y0, theta, x, x_int, 1e-8, 1e-1);
 }
 
-TEST(StanAgradRevOde_integrate_ode_rk45, rate_as_param) {
+TEST(StanAgradRevOde_integrate_ode_rk45, time_steps_as_param) {
   using stan::math::integrate_ode_rk45;
   using stan::math::to_var;
 
@@ -134,6 +134,10 @@ TEST(StanAgradRevOde_integrate_ode_rk45, rate_as_param) {
   std::vector<stan::math::var> thetav = to_var(theta);
 
   std::vector<std::vector<stan::math::var> > res;
+
+  // here we only test first & last steps, and reply on the
+  // fact that results in-between affect the initial
+  // condition of the last step to check their validity.
   auto test_val = [&res]() {
     EXPECT_NEAR(0.995029, res[0][0].val(), 1e-5);
     EXPECT_NEAR(-0.0990884, res[0][1].val(), 1e-5);
@@ -150,7 +154,7 @@ TEST(StanAgradRevOde_integrate_ode_rk45, rate_as_param) {
   test_val();
 }
 
-TEST(StanAgradRevOde_integrate_ode_rk45, rate_as_param_AD) {
+TEST(StanAgradRevOde_integrate_ode_rk45, time_steps_as_param_AD) {
   using stan::math::integrate_ode_rk45;
   using stan::math::to_var;
   using stan::math::value_of;

--- a/test/unit/math/rev/arr/functor/integrate_ode_rk45_test.cpp
+++ b/test/unit/math/rev/arr/functor/integrate_ode_rk45_test.cpp
@@ -123,10 +123,11 @@ TEST(StanAgradRevOde_integrate_ode_rk45, rate_as_param) {
 
   const double t0 = 0.0;
   harm_osc_ode_fun ode;
-  std::vector<double> theta {0.15};
-  std::vector<double> y0 {1.0, 0.0};
+  std::vector<double> theta{0.15};
+  std::vector<double> y0{1.0, 0.0};
   std::vector<stan::math::var> ts;
-  for (int i = 0; i < 100; i++) ts.push_back(t0 + 0.1 * (i + 1));
+  for (int i = 0; i < 100; i++)
+    ts.push_back(t0 + 0.1 * (i + 1));
   std::vector<double> x;
   std::vector<int> x_int;
   std::vector<stan::math::var> y0v = to_var(y0);
@@ -134,31 +135,35 @@ TEST(StanAgradRevOde_integrate_ode_rk45, rate_as_param) {
 
   std::vector<std::vector<stan::math::var> > res;
   auto test_val = [&res]() {
-    EXPECT_NEAR(0.995029   , res[0][0].val(), 1e-5);
-    EXPECT_NEAR(-0.0990884 , res[0][1].val(), 1e-5);
-    EXPECT_NEAR(-0.421907  , res[99][0].val(), 1e-5);
-    EXPECT_NEAR(0.246407   , res[99][1].val(), 1e-5);
+    EXPECT_NEAR(0.995029, res[0][0].val(), 1e-5);
+    EXPECT_NEAR(-0.0990884, res[0][1].val(), 1e-5);
+    EXPECT_NEAR(-0.421907, res[99][0].val(), 1e-5);
+    EXPECT_NEAR(0.246407, res[99][1].val(), 1e-5);
   };
-  res = integrate_ode_rk45(ode, y0, t0, ts, theta, x, x_int)   ; test_val();
-  res = integrate_ode_rk45(ode, y0v, t0, ts, theta, x, x_int)  ; test_val();
-  res = integrate_ode_rk45(ode, y0, t0, ts, thetav, x, x_int)  ; test_val();
-  res = integrate_ode_rk45(ode, y0v, t0, ts, thetav, x, x_int) ; test_val();
+  res = integrate_ode_rk45(ode, y0, t0, ts, theta, x, x_int);
+  test_val();
+  res = integrate_ode_rk45(ode, y0v, t0, ts, theta, x, x_int);
+  test_val();
+  res = integrate_ode_rk45(ode, y0, t0, ts, thetav, x, x_int);
+  test_val();
+  res = integrate_ode_rk45(ode, y0v, t0, ts, thetav, x, x_int);
+  test_val();
 }
 
 TEST(StanAgradRevOde_integrate_ode_rk45, rate_as_param_AD) {
-  using stan::math::var;
   using stan::math::integrate_ode_rk45;
   using stan::math::to_var;
   using stan::math::value_of;
+  using stan::math::var;
   const double t0 = 0.0;
-  const int nt = 100;           // nb. of time steps
-  const int ns = 2;             // nb. of states
+  const int nt = 100;  // nb. of time steps
+  const int ns = 2;    // nb. of states
   std::ostream* msgs = NULL;
 
   harm_osc_ode_fun ode;
 
-  std::vector<double> theta {0.15};
-  std::vector<double> y0 {1.0, 0.0};
+  std::vector<double> theta{0.15};
+  std::vector<double> y0{1.0, 0.0};
   std::vector<stan::math::var> ts;
   for (int i = 0; i < nt; i++)
     ts.push_back(t0 + 0.1 * (i + 1));
@@ -189,8 +194,12 @@ TEST(StanAgradRevOde_integrate_ode_rk45, rate_as_param_AD) {
       }
     }
   };
-  res = integrate_ode_rk45(ode, y0, t0, ts, theta, x, x_int)   ; test_ad();
-  res = integrate_ode_rk45(ode, y0v, t0, ts, theta, x, x_int)  ; test_ad();
-  res = integrate_ode_rk45(ode, y0, t0, ts, thetav, x, x_int)  ; test_ad();
-  res = integrate_ode_rk45(ode, y0v, t0, ts, thetav, x, x_int) ; test_ad();
+  res = integrate_ode_rk45(ode, y0, t0, ts, theta, x, x_int);
+  test_ad();
+  res = integrate_ode_rk45(ode, y0v, t0, ts, theta, x, x_int);
+  test_ad();
+  res = integrate_ode_rk45(ode, y0, t0, ts, thetav, x, x_int);
+  test_ad();
+  res = integrate_ode_rk45(ode, y0v, t0, ts, thetav, x, x_int);
+  test_ad();
 }

--- a/test/unit/math/rev/arr/functor/integrate_ode_rk45_test.cpp
+++ b/test/unit/math/rev/arr/functor/integrate_ode_rk45_test.cpp
@@ -116,3 +116,81 @@ TEST(StanAgradRevOde_integrate_ode_rk45, lorenz_finite_diff) {
 
   test_ode(lorenz, t0, ts, y0, theta, x, x_int, 1e-8, 1e-1);
 }
+
+TEST(StanAgradRevOde_integrate_ode_rk45, rate_as_param) {
+  using stan::math::integrate_ode_rk45;
+  using stan::math::to_var;
+
+  const double t0 = 0.0;
+  harm_osc_ode_fun ode;
+  std::vector<double> theta {0.15};
+  std::vector<double> y0 {1.0, 0.0};
+  std::vector<stan::math::var> ts;
+  for (int i = 0; i < 100; i++) ts.push_back(t0 + 0.1 * (i + 1));
+  std::vector<double> x;
+  std::vector<int> x_int;
+  std::vector<stan::math::var> y0v = to_var(y0);
+  std::vector<stan::math::var> thetav = to_var(theta);
+
+  std::vector<std::vector<stan::math::var> > res;
+  auto test_val = [&res]() {
+    EXPECT_NEAR(0.995029   , res[0][0].val(), 1e-5);
+    EXPECT_NEAR(-0.0990884 , res[0][1].val(), 1e-5);
+    EXPECT_NEAR(-0.421907  , res[99][0].val(), 1e-5);
+    EXPECT_NEAR(0.246407   , res[99][1].val(), 1e-5);
+  };
+  res = integrate_ode_rk45(ode, y0, t0, ts, theta, x, x_int)   ; test_val();
+  res = integrate_ode_rk45(ode, y0v, t0, ts, theta, x, x_int)  ; test_val();
+  res = integrate_ode_rk45(ode, y0, t0, ts, thetav, x, x_int)  ; test_val();
+  res = integrate_ode_rk45(ode, y0v, t0, ts, thetav, x, x_int) ; test_val();
+}
+
+TEST(StanAgradRevOde_integrate_ode_rk45, rate_as_param_AD) {
+  using stan::math::var;
+  using stan::math::integrate_ode_rk45;
+  using stan::math::to_var;
+  using stan::math::value_of;
+  const double t0 = 0.0;
+  const int nt = 100;           // nb. of time steps
+  const int ns = 2;             // nb. of states
+  std::ostream* msgs = NULL;
+
+  harm_osc_ode_fun ode;
+
+  std::vector<double> theta {0.15};
+  std::vector<double> y0 {1.0, 0.0};
+  std::vector<stan::math::var> ts;
+  for (int i = 0; i < nt; i++)
+    ts.push_back(t0 + 0.1 * (i + 1));
+
+  std::vector<double> x;
+  std::vector<int> x_int;
+  std::vector<stan::math::var> y0v = to_var(y0);
+  std::vector<stan::math::var> thetav = to_var(theta);
+
+  std::vector<std::vector<stan::math::var> > res;
+  std::vector<double> g;
+  auto test_ad = [&res, &g, &ts, &ode, &nt, &ns, &theta, &x, &x_int, &msgs]() {
+    for (auto i = 0; i < nt; ++i) {
+      std::vector<double> res_d = value_of(res[i]);
+      for (auto j = 0; j < ns; ++j) {
+        g.clear();
+        res[i][j].grad(ts, g);
+        for (auto k = 0; k < nt; ++k) {
+          if (k != i) {
+            EXPECT_FLOAT_EQ(g[k], 0.0);
+          } else {
+            std::vector<double> y0(res_d.begin(), res_d.begin() + ns);
+            EXPECT_FLOAT_EQ(g[k],
+                            ode(ts[i].val(), y0, theta, x, x_int, msgs)[j]);
+          }
+        }
+        stan::math::set_zero_all_adjoints();
+      }
+    }
+  };
+  res = integrate_ode_rk45(ode, y0, t0, ts, theta, x, x_int)   ; test_ad();
+  res = integrate_ode_rk45(ode, y0v, t0, ts, theta, x, x_int)  ; test_ad();
+  res = integrate_ode_rk45(ode, y0, t0, ts, thetav, x, x_int)  ; test_ad();
+  res = integrate_ode_rk45(ode, y0v, t0, ts, thetav, x, x_int) ; test_ad();
+}

--- a/test/unit/math/rev/mat/functor/integrate_ode_adams_rev_test.cpp
+++ b/test/unit/math/rev/mat/functor/integrate_ode_adams_rev_test.cpp
@@ -222,30 +222,3 @@ TEST(StanAgradRevOde_integrate_ode_adams, time_steps_as_param_AD) {
   res = integrate_ode_adams(ode, y0v, t0, ts, thetav, x, x_int);
   test_ad();
 }
-
-// TODO(Yi Zhang): failure
-// TEST(StanAgradRevOde_integrate_ode, lorenz_finite_diff) {
-//   lorenz_ode_fun lorenz;
-
-//   std::vector<double> y0;
-//   std::vector<double> theta;
-//   double t0;
-//   std::vector<double> ts;
-
-//   t0 = 0;
-
-//   theta.push_back(10.0);
-//   theta.push_back(28.0);
-//   theta.push_back(8.0 / 3.0);
-//   y0.push_back(10.0);
-//   y0.push_back(1.0);
-//   y0.push_back(1.0);
-
-//   std::vector<double> x;
-//   std::vector<int> x_int;
-
-//   for (int i = 0; i < 100; i++)
-//     ts.push_back(0.1 * (i + 1));
-
-//   test_ode_cvode(lorenz, t0, ts, y0, theta, x, x_int, 1e-8, 1e-1);
-// }

--- a/test/unit/math/rev/mat/functor/integrate_ode_adams_rev_test.cpp
+++ b/test/unit/math/rev/mat/functor/integrate_ode_adams_rev_test.cpp
@@ -142,10 +142,11 @@ TEST(StanAgradRevOde_integrate_ode_adams, rate_as_param) {
 
   const double t0 = 0.0;
   harm_osc_ode_fun ode;
-  std::vector<double> theta {0.15};
-  std::vector<double> y0 {1.0, 0.0};
+  std::vector<double> theta{0.15};
+  std::vector<double> y0{1.0, 0.0};
   std::vector<stan::math::var> ts;
-  for (int i = 0; i < 100; i++) ts.push_back(t0 + 0.1 * (i + 1));
+  for (int i = 0; i < 100; i++)
+    ts.push_back(t0 + 0.1 * (i + 1));
   std::vector<double> x;
   std::vector<int> x_int;
   std::vector<stan::math::var> y0v = to_var(y0);
@@ -153,31 +154,35 @@ TEST(StanAgradRevOde_integrate_ode_adams, rate_as_param) {
 
   std::vector<std::vector<stan::math::var> > res;
   auto test_val = [&res]() {
-    EXPECT_NEAR(0.995029   , res[0][0].val(), 1e-5);
-    EXPECT_NEAR(-0.0990884 , res[0][1].val(), 1e-5);
-    EXPECT_NEAR(-0.421907  , res[99][0].val(), 1e-5);
-    EXPECT_NEAR(0.246407   , res[99][1].val(), 1e-5);
+    EXPECT_NEAR(0.995029, res[0][0].val(), 1e-5);
+    EXPECT_NEAR(-0.0990884, res[0][1].val(), 1e-5);
+    EXPECT_NEAR(-0.421907, res[99][0].val(), 1e-5);
+    EXPECT_NEAR(0.246407, res[99][1].val(), 1e-5);
   };
-  res = integrate_ode_adams(ode, y0, t0, ts, theta, x, x_int)   ; test_val();
-  res = integrate_ode_adams(ode, y0v, t0, ts, theta, x, x_int)  ; test_val();
-  res = integrate_ode_adams(ode, y0, t0, ts, thetav, x, x_int)  ; test_val();
-  res = integrate_ode_adams(ode, y0v, t0, ts, thetav, x, x_int) ; test_val();
+  res = integrate_ode_adams(ode, y0, t0, ts, theta, x, x_int);
+  test_val();
+  res = integrate_ode_adams(ode, y0v, t0, ts, theta, x, x_int);
+  test_val();
+  res = integrate_ode_adams(ode, y0, t0, ts, thetav, x, x_int);
+  test_val();
+  res = integrate_ode_adams(ode, y0v, t0, ts, thetav, x, x_int);
+  test_val();
 }
 
 TEST(StanAgradRevOde_integrate_ode_adams, rate_as_param_AD) {
-  using stan::math::var;
   using stan::math::integrate_ode_adams;
   using stan::math::to_var;
   using stan::math::value_of;
+  using stan::math::var;
   const double t0 = 0.0;
-  const int nt = 100;           // nb. of time steps
-  const int ns = 2;             // nb. of states
+  const int nt = 100;  // nb. of time steps
+  const int ns = 2;    // nb. of states
   std::ostream* msgs = NULL;
 
   harm_osc_ode_fun ode;
 
-  std::vector<double> theta {0.15};
-  std::vector<double> y0 {1.0, 0.0};
+  std::vector<double> theta{0.15};
+  std::vector<double> y0{1.0, 0.0};
   std::vector<stan::math::var> ts;
   for (int i = 0; i < nt; i++)
     ts.push_back(t0 + 0.1 * (i + 1));
@@ -208,12 +213,15 @@ TEST(StanAgradRevOde_integrate_ode_adams, rate_as_param_AD) {
       }
     }
   };
-  res = integrate_ode_adams(ode, y0, t0, ts, theta, x, x_int)   ; test_ad();
-  res = integrate_ode_adams(ode, y0v, t0, ts, theta, x, x_int)  ; test_ad();
-  res = integrate_ode_adams(ode, y0, t0, ts, thetav, x, x_int)  ; test_ad();
-  res = integrate_ode_adams(ode, y0v, t0, ts, thetav, x, x_int) ; test_ad();
+  res = integrate_ode_adams(ode, y0, t0, ts, theta, x, x_int);
+  test_ad();
+  res = integrate_ode_adams(ode, y0v, t0, ts, theta, x, x_int);
+  test_ad();
+  res = integrate_ode_adams(ode, y0, t0, ts, thetav, x, x_int);
+  test_ad();
+  res = integrate_ode_adams(ode, y0v, t0, ts, thetav, x, x_int);
+  test_ad();
 }
-
 
 // TODO(Yi Zhang): failure
 // TEST(StanAgradRevOde_integrate_ode, lorenz_finite_diff) {

--- a/test/unit/math/rev/mat/functor/integrate_ode_adams_rev_test.cpp
+++ b/test/unit/math/rev/mat/functor/integrate_ode_adams_rev_test.cpp
@@ -136,7 +136,7 @@ TEST(StanAgradRevOde_integrate_ode, harmonic_oscillator_error) {
   sho_error_test<var, var>(harm_osc, y0, t0, ts, theta, x, x_int, error_msg);
 }
 
-TEST(StanAgradRevOde_integrate_ode_adams, rate_as_param) {
+TEST(StanAgradRevOde_integrate_ode_adams, time_steps_as_param) {
   using stan::math::integrate_ode_adams;
   using stan::math::to_var;
 
@@ -169,7 +169,7 @@ TEST(StanAgradRevOde_integrate_ode_adams, rate_as_param) {
   test_val();
 }
 
-TEST(StanAgradRevOde_integrate_ode_adams, rate_as_param_AD) {
+TEST(StanAgradRevOde_integrate_ode_adams, time_steps_as_param_AD) {
   using stan::math::integrate_ode_adams;
   using stan::math::to_var;
   using stan::math::value_of;

--- a/test/unit/math/rev/mat/functor/integrate_ode_adams_rev_test.cpp
+++ b/test/unit/math/rev/mat/functor/integrate_ode_adams_rev_test.cpp
@@ -136,6 +136,85 @@ TEST(StanAgradRevOde_integrate_ode, harmonic_oscillator_error) {
   sho_error_test<var, var>(harm_osc, y0, t0, ts, theta, x, x_int, error_msg);
 }
 
+TEST(StanAgradRevOde_integrate_ode_adams, rate_as_param) {
+  using stan::math::integrate_ode_adams;
+  using stan::math::to_var;
+
+  const double t0 = 0.0;
+  harm_osc_ode_fun ode;
+  std::vector<double> theta {0.15};
+  std::vector<double> y0 {1.0, 0.0};
+  std::vector<stan::math::var> ts;
+  for (int i = 0; i < 100; i++) ts.push_back(t0 + 0.1 * (i + 1));
+  std::vector<double> x;
+  std::vector<int> x_int;
+  std::vector<stan::math::var> y0v = to_var(y0);
+  std::vector<stan::math::var> thetav = to_var(theta);
+
+  std::vector<std::vector<stan::math::var> > res;
+  auto test_val = [&res]() {
+    EXPECT_NEAR(0.995029   , res[0][0].val(), 1e-5);
+    EXPECT_NEAR(-0.0990884 , res[0][1].val(), 1e-5);
+    EXPECT_NEAR(-0.421907  , res[99][0].val(), 1e-5);
+    EXPECT_NEAR(0.246407   , res[99][1].val(), 1e-5);
+  };
+  res = integrate_ode_adams(ode, y0, t0, ts, theta, x, x_int)   ; test_val();
+  res = integrate_ode_adams(ode, y0v, t0, ts, theta, x, x_int)  ; test_val();
+  res = integrate_ode_adams(ode, y0, t0, ts, thetav, x, x_int)  ; test_val();
+  res = integrate_ode_adams(ode, y0v, t0, ts, thetav, x, x_int) ; test_val();
+}
+
+TEST(StanAgradRevOde_integrate_ode_adams, rate_as_param_AD) {
+  using stan::math::var;
+  using stan::math::integrate_ode_adams;
+  using stan::math::to_var;
+  using stan::math::value_of;
+  const double t0 = 0.0;
+  const int nt = 100;           // nb. of time steps
+  const int ns = 2;             // nb. of states
+  std::ostream* msgs = NULL;
+
+  harm_osc_ode_fun ode;
+
+  std::vector<double> theta {0.15};
+  std::vector<double> y0 {1.0, 0.0};
+  std::vector<stan::math::var> ts;
+  for (int i = 0; i < nt; i++)
+    ts.push_back(t0 + 0.1 * (i + 1));
+
+  std::vector<double> x;
+  std::vector<int> x_int;
+  std::vector<stan::math::var> y0v = to_var(y0);
+  std::vector<stan::math::var> thetav = to_var(theta);
+
+  std::vector<std::vector<stan::math::var> > res;
+  std::vector<double> g;
+  auto test_ad = [&res, &g, &ts, &ode, &nt, &ns, &theta, &x, &x_int, &msgs]() {
+    for (auto i = 0; i < nt; ++i) {
+      std::vector<double> res_d = value_of(res[i]);
+      for (auto j = 0; j < ns; ++j) {
+        g.clear();
+        res[i][j].grad(ts, g);
+        for (auto k = 0; k < nt; ++k) {
+          if (k != i) {
+            EXPECT_FLOAT_EQ(g[k], 0.0);
+          } else {
+            std::vector<double> y0(res_d.begin(), res_d.begin() + ns);
+            EXPECT_FLOAT_EQ(g[k],
+                            ode(ts[i].val(), y0, theta, x, x_int, msgs)[j]);
+          }
+        }
+        stan::math::set_zero_all_adjoints();
+      }
+    }
+  };
+  res = integrate_ode_adams(ode, y0, t0, ts, theta, x, x_int)   ; test_ad();
+  res = integrate_ode_adams(ode, y0v, t0, ts, theta, x, x_int)  ; test_ad();
+  res = integrate_ode_adams(ode, y0, t0, ts, thetav, x, x_int)  ; test_ad();
+  res = integrate_ode_adams(ode, y0v, t0, ts, thetav, x, x_int) ; test_ad();
+}
+
+
 // TODO(Yi Zhang): failure
 // TEST(StanAgradRevOde_integrate_ode, lorenz_finite_diff) {
 //   lorenz_ode_fun lorenz;

--- a/test/unit/math/rev/mat/functor/integrate_ode_bdf_rev_test.cpp
+++ b/test/unit/math/rev/mat/functor/integrate_ode_bdf_rev_test.cpp
@@ -169,10 +169,11 @@ TEST(StanAgradRevOde_integrate_ode_bdf, rate_as_param) {
 
   const double t0 = 0.0;
   harm_osc_ode_fun ode;
-  std::vector<double> theta {0.15};
-  std::vector<double> y0 {1.0, 0.0};
+  std::vector<double> theta{0.15};
+  std::vector<double> y0{1.0, 0.0};
   std::vector<stan::math::var> ts;
-  for (int i = 0; i < 100; i++) ts.push_back(t0 + 0.1 * (i + 1));
+  for (int i = 0; i < 100; i++)
+    ts.push_back(t0 + 0.1 * (i + 1));
   std::vector<double> x;
   std::vector<int> x_int;
   std::vector<stan::math::var> y0v = to_var(y0);
@@ -180,31 +181,35 @@ TEST(StanAgradRevOde_integrate_ode_bdf, rate_as_param) {
 
   std::vector<std::vector<stan::math::var> > res;
   auto test_val = [&res]() {
-    EXPECT_NEAR(0.995029   , res[0][0].val(), 1e-5);
-    EXPECT_NEAR(-0.0990884 , res[0][1].val(), 1e-5);
-    EXPECT_NEAR(-0.421907  , res[99][0].val(), 1e-5);
-    EXPECT_NEAR(0.246407   , res[99][1].val(), 1e-5);
+    EXPECT_NEAR(0.995029, res[0][0].val(), 1e-5);
+    EXPECT_NEAR(-0.0990884, res[0][1].val(), 1e-5);
+    EXPECT_NEAR(-0.421907, res[99][0].val(), 1e-5);
+    EXPECT_NEAR(0.246407, res[99][1].val(), 1e-5);
   };
-  res = integrate_ode_bdf(ode, y0, t0, ts, theta, x, x_int)   ; test_val();
-  res = integrate_ode_bdf(ode, y0v, t0, ts, theta, x, x_int)  ; test_val();
-  res = integrate_ode_bdf(ode, y0, t0, ts, thetav, x, x_int)  ; test_val();
-  res = integrate_ode_bdf(ode, y0v, t0, ts, thetav, x, x_int) ; test_val();
+  res = integrate_ode_bdf(ode, y0, t0, ts, theta, x, x_int);
+  test_val();
+  res = integrate_ode_bdf(ode, y0v, t0, ts, theta, x, x_int);
+  test_val();
+  res = integrate_ode_bdf(ode, y0, t0, ts, thetav, x, x_int);
+  test_val();
+  res = integrate_ode_bdf(ode, y0v, t0, ts, thetav, x, x_int);
+  test_val();
 }
 
 TEST(StanAgradRevOde_integrate_ode_bdf, rate_as_param_AD) {
-  using stan::math::var;
   using stan::math::integrate_ode_bdf;
   using stan::math::to_var;
   using stan::math::value_of;
+  using stan::math::var;
   const double t0 = 0.0;
-  const int nt = 100;           // nb. of time steps
-  const int ns = 2;             // nb. of states
+  const int nt = 100;  // nb. of time steps
+  const int ns = 2;    // nb. of states
   std::ostream* msgs = NULL;
 
   harm_osc_ode_fun ode;
 
-  std::vector<double> theta {0.15};
-  std::vector<double> y0 {1.0, 0.0};
+  std::vector<double> theta{0.15};
+  std::vector<double> y0{1.0, 0.0};
   std::vector<stan::math::var> ts;
   for (int i = 0; i < nt; i++)
     ts.push_back(t0 + 0.1 * (i + 1));
@@ -235,8 +240,12 @@ TEST(StanAgradRevOde_integrate_ode_bdf, rate_as_param_AD) {
       }
     }
   };
-  res = integrate_ode_bdf(ode, y0, t0, ts, theta, x, x_int)   ; test_ad();
-  res = integrate_ode_bdf(ode, y0v, t0, ts, theta, x, x_int)  ; test_ad();
-  res = integrate_ode_bdf(ode, y0, t0, ts, thetav, x, x_int)  ; test_ad();
-  res = integrate_ode_bdf(ode, y0v, t0, ts, thetav, x, x_int) ; test_ad();
+  res = integrate_ode_bdf(ode, y0, t0, ts, theta, x, x_int);
+  test_ad();
+  res = integrate_ode_bdf(ode, y0v, t0, ts, theta, x, x_int);
+  test_ad();
+  res = integrate_ode_bdf(ode, y0, t0, ts, thetav, x, x_int);
+  test_ad();
+  res = integrate_ode_bdf(ode, y0v, t0, ts, thetav, x, x_int);
+  test_ad();
 }

--- a/test/unit/math/rev/mat/functor/integrate_ode_bdf_rev_test.cpp
+++ b/test/unit/math/rev/mat/functor/integrate_ode_bdf_rev_test.cpp
@@ -162,3 +162,81 @@ TEST(StanAgradRevOde_integrate_ode, lorenz_finite_diff) {
 
   test_ode_cvode(lorenz, t0, ts, y0, theta, x, x_int, 1e-8, 1e-1);
 }
+
+TEST(StanAgradRevOde_integrate_ode_bdf, rate_as_param) {
+  using stan::math::integrate_ode_bdf;
+  using stan::math::to_var;
+
+  const double t0 = 0.0;
+  harm_osc_ode_fun ode;
+  std::vector<double> theta {0.15};
+  std::vector<double> y0 {1.0, 0.0};
+  std::vector<stan::math::var> ts;
+  for (int i = 0; i < 100; i++) ts.push_back(t0 + 0.1 * (i + 1));
+  std::vector<double> x;
+  std::vector<int> x_int;
+  std::vector<stan::math::var> y0v = to_var(y0);
+  std::vector<stan::math::var> thetav = to_var(theta);
+
+  std::vector<std::vector<stan::math::var> > res;
+  auto test_val = [&res]() {
+    EXPECT_NEAR(0.995029   , res[0][0].val(), 1e-5);
+    EXPECT_NEAR(-0.0990884 , res[0][1].val(), 1e-5);
+    EXPECT_NEAR(-0.421907  , res[99][0].val(), 1e-5);
+    EXPECT_NEAR(0.246407   , res[99][1].val(), 1e-5);
+  };
+  res = integrate_ode_bdf(ode, y0, t0, ts, theta, x, x_int)   ; test_val();
+  res = integrate_ode_bdf(ode, y0v, t0, ts, theta, x, x_int)  ; test_val();
+  res = integrate_ode_bdf(ode, y0, t0, ts, thetav, x, x_int)  ; test_val();
+  res = integrate_ode_bdf(ode, y0v, t0, ts, thetav, x, x_int) ; test_val();
+}
+
+TEST(StanAgradRevOde_integrate_ode_bdf, rate_as_param_AD) {
+  using stan::math::var;
+  using stan::math::integrate_ode_bdf;
+  using stan::math::to_var;
+  using stan::math::value_of;
+  const double t0 = 0.0;
+  const int nt = 100;           // nb. of time steps
+  const int ns = 2;             // nb. of states
+  std::ostream* msgs = NULL;
+
+  harm_osc_ode_fun ode;
+
+  std::vector<double> theta {0.15};
+  std::vector<double> y0 {1.0, 0.0};
+  std::vector<stan::math::var> ts;
+  for (int i = 0; i < nt; i++)
+    ts.push_back(t0 + 0.1 * (i + 1));
+
+  std::vector<double> x;
+  std::vector<int> x_int;
+  std::vector<stan::math::var> y0v = to_var(y0);
+  std::vector<stan::math::var> thetav = to_var(theta);
+
+  std::vector<std::vector<stan::math::var> > res;
+  std::vector<double> g;
+  auto test_ad = [&res, &g, &ts, &ode, &nt, &ns, &theta, &x, &x_int, &msgs]() {
+    for (auto i = 0; i < nt; ++i) {
+      std::vector<double> res_d = value_of(res[i]);
+      for (auto j = 0; j < ns; ++j) {
+        g.clear();
+        res[i][j].grad(ts, g);
+        for (auto k = 0; k < nt; ++k) {
+          if (k != i) {
+            EXPECT_FLOAT_EQ(g[k], 0.0);
+          } else {
+            std::vector<double> y0(res_d.begin(), res_d.begin() + ns);
+            EXPECT_FLOAT_EQ(g[k],
+                            ode(ts[i].val(), y0, theta, x, x_int, msgs)[j]);
+          }
+        }
+        stan::math::set_zero_all_adjoints();
+      }
+    }
+  };
+  res = integrate_ode_bdf(ode, y0, t0, ts, theta, x, x_int)   ; test_ad();
+  res = integrate_ode_bdf(ode, y0v, t0, ts, theta, x, x_int)  ; test_ad();
+  res = integrate_ode_bdf(ode, y0, t0, ts, thetav, x, x_int)  ; test_ad();
+  res = integrate_ode_bdf(ode, y0v, t0, ts, thetav, x, x_int) ; test_ad();
+}

--- a/test/unit/math/rev/mat/functor/integrate_ode_bdf_rev_test.cpp
+++ b/test/unit/math/rev/mat/functor/integrate_ode_bdf_rev_test.cpp
@@ -163,7 +163,7 @@ TEST(StanAgradRevOde_integrate_ode, lorenz_finite_diff) {
   test_ode_cvode(lorenz, t0, ts, y0, theta, x, x_int, 1e-8, 1e-1);
 }
 
-TEST(StanAgradRevOde_integrate_ode_bdf, rate_as_param) {
+TEST(StanAgradRevOde_integrate_ode_bdf, time_steps_as_param) {
   using stan::math::integrate_ode_bdf;
   using stan::math::to_var;
 
@@ -196,7 +196,7 @@ TEST(StanAgradRevOde_integrate_ode_bdf, rate_as_param) {
   test_val();
 }
 
-TEST(StanAgradRevOde_integrate_ode_bdf, rate_as_param_AD) {
+TEST(StanAgradRevOde_integrate_ode_bdf, time_steps_as_param_AD) {
   using stan::math::integrate_ode_bdf;
   using stan::math::to_var;
   using stan::math::value_of;


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary:
Allow `ts` of ODE integration functions to be `var`. This can be used to make inference on observation time in models involving ODEs.

The sensitivity with respect to `ts[i]` is zero unless at the `i`th observation results, in which case the sensitivity is the RHS of the ODEs.

#### Intended Effect:
Allow `ts` in ODE solvers to be parameters.

#### How to Verify:
unit tests.

#### Side Effects:
N/A

#### Documentation:
In src.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Metrum Research Group, LLC.

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
