### PR TITLE
Feature/issue matern 3/2 prim

### DIFF
--- a/stan/math/prim/mat.hpp
+++ b/stan/math/prim/mat.hpp
@@ -124,6 +124,7 @@
 #include <stan/math/prim/mat/fun/get_base1_lhs.hpp>
 #include <stan/math/prim/mat/fun/get_lp.hpp>
 #include <stan/math/prim/mat/fun/gp_dot_prod_cov.hpp>
+#include <stan/math/prim/mat/fun/gp_matern_3_2_cov.hpp>
 #include <stan/math/prim/mat/fun/head.hpp>
 #include <stan/math/prim/mat/fun/initialize.hpp>
 #include <stan/math/prim/mat/fun/inv.hpp>

--- a/stan/math/prim/mat.hpp
+++ b/stan/math/prim/mat.hpp
@@ -19,8 +19,8 @@
 #include <stan/math/prim/mat/meta/length.hpp>
 #include <stan/math/prim/mat/meta/length_mvt.hpp>
 #include <stan/math/prim/mat/meta/operands_and_partials.hpp>
-#include <stan/math/prim/mat/meta/seq_view.hpp>
 #include <stan/math/prim/mat/meta/scalar_type.hpp>
+#include <stan/math/prim/mat/meta/seq_view.hpp>
 #include <stan/math/prim/mat/meta/value_type.hpp>
 #include <stan/math/prim/mat/meta/vector_seq_view.hpp>
 
@@ -49,6 +49,10 @@
 #include <stan/math/prim/mat/err/constraint_tolerance.hpp>
 #include <stan/math/prim/mat/err/validate_non_negative_index.hpp>
 
+#include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <stan/math/prim/mat/fun/LDLT_factor.hpp>
+#include <stan/math/prim/mat/fun/Phi.hpp>
+#include <stan/math/prim/mat/fun/Phi_approx.hpp>
 #include <stan/math/prim/mat/fun/accumulator.hpp>
 #include <stan/math/prim/mat/fun/acos.hpp>
 #include <stan/math/prim/mat/fun/acosh.hpp>
@@ -95,17 +99,16 @@
 #include <stan/math/prim/mat/fun/csr_u_to_z.hpp>
 #include <stan/math/prim/mat/fun/cumulative_sum.hpp>
 #include <stan/math/prim/mat/fun/determinant.hpp>
-#include <stan/math/prim/mat/fun/diagonal.hpp>
 #include <stan/math/prim/mat/fun/diag_matrix.hpp>
 #include <stan/math/prim/mat/fun/diag_post_multiply.hpp>
 #include <stan/math/prim/mat/fun/diag_pre_multiply.hpp>
+#include <stan/math/prim/mat/fun/diagonal.hpp>
 #include <stan/math/prim/mat/fun/digamma.hpp>
 #include <stan/math/prim/mat/fun/dims.hpp>
 #include <stan/math/prim/mat/fun/distance.hpp>
 #include <stan/math/prim/mat/fun/divide.hpp>
 #include <stan/math/prim/mat/fun/dot_product.hpp>
 #include <stan/math/prim/mat/fun/dot_self.hpp>
-#include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/mat/fun/eigenvalues_sym.hpp>
 #include <stan/math/prim/mat/fun/eigenvectors_sym.hpp>
 #include <stan/math/prim/mat/fun/elt_divide.hpp>
@@ -116,8 +119,8 @@
 #include <stan/math/prim/mat/fun/exp2.hpp>
 #include <stan/math/prim/mat/fun/expm1.hpp>
 #include <stan/math/prim/mat/fun/fabs.hpp>
-#include <stan/math/prim/mat/fun/factor_cov_matrix.hpp>
 #include <stan/math/prim/mat/fun/factor_U.hpp>
+#include <stan/math/prim/mat/fun/factor_cov_matrix.hpp>
 #include <stan/math/prim/mat/fun/fill.hpp>
 #include <stan/math/prim/mat/fun/floor.hpp>
 #include <stan/math/prim/mat/fun/get_base1.hpp>
@@ -128,14 +131,13 @@
 #include <stan/math/prim/mat/fun/head.hpp>
 #include <stan/math/prim/mat/fun/initialize.hpp>
 #include <stan/math/prim/mat/fun/inv.hpp>
-#include <stan/math/prim/mat/fun/inverse.hpp>
-#include <stan/math/prim/mat/fun/inverse_spd.hpp>
+#include <stan/math/prim/mat/fun/inv_Phi.hpp>
 #include <stan/math/prim/mat/fun/inv_cloglog.hpp>
 #include <stan/math/prim/mat/fun/inv_logit.hpp>
-#include <stan/math/prim/mat/fun/inv_Phi.hpp>
 #include <stan/math/prim/mat/fun/inv_sqrt.hpp>
 #include <stan/math/prim/mat/fun/inv_square.hpp>
-#include <stan/math/prim/mat/fun/LDLT_factor.hpp>
+#include <stan/math/prim/mat/fun/inverse.hpp>
+#include <stan/math/prim/mat/fun/inverse_spd.hpp>
 #include <stan/math/prim/mat/fun/lgamma.hpp>
 #include <stan/math/prim/mat/fun/log.hpp>
 #include <stan/math/prim/mat/fun/log10.hpp>
@@ -174,8 +176,6 @@
 #include <stan/math/prim/mat/fun/num_elements.hpp>
 #include <stan/math/prim/mat/fun/ordered_constrain.hpp>
 #include <stan/math/prim/mat/fun/ordered_free.hpp>
-#include <stan/math/prim/mat/fun/Phi.hpp>
-#include <stan/math/prim/mat/fun/Phi_approx.hpp>
 #include <stan/math/prim/mat/fun/positive_ordered_constrain.hpp>
 #include <stan/math/prim/mat/fun/positive_ordered_free.hpp>
 #include <stan/math/prim/mat/fun/prod.hpp>
@@ -220,9 +220,9 @@
 #include <stan/math/prim/mat/fun/square.hpp>
 #include <stan/math/prim/mat/fun/squared_distance.hpp>
 #include <stan/math/prim/mat/fun/stan_print.hpp>
-#include <stan/math/prim/mat/fun/subtract.hpp>
 #include <stan/math/prim/mat/fun/sub_col.hpp>
 #include <stan/math/prim/mat/fun/sub_row.hpp>
+#include <stan/math/prim/mat/fun/subtract.hpp>
 #include <stan/math/prim/mat/fun/sum.hpp>
 #include <stan/math/prim/mat/fun/tail.hpp>
 #include <stan/math/prim/mat/fun/tan.hpp>
@@ -254,17 +254,17 @@
 #include <stan/math/prim/mat/functor/finite_diff_gradient.hpp>
 #include <stan/math/prim/mat/functor/finite_diff_hessian.hpp>
 #include <stan/math/prim/mat/functor/map_rect.hpp>
+#include <stan/math/prim/mat/functor/map_rect_combine.hpp>
 #include <stan/math/prim/mat/functor/map_rect_concurrent.hpp>
 #include <stan/math/prim/mat/functor/map_rect_reduce.hpp>
-#include <stan/math/prim/mat/functor/map_rect_combine.hpp>
 
 #include <stan/math/prim/mat/prob/bernoulli_logit_glm_lpmf.hpp>
 #include <stan/math/prim/mat/prob/categorical_log.hpp>
-#include <stan/math/prim/mat/prob/categorical_lpmf.hpp>
 #include <stan/math/prim/mat/prob/categorical_logit_log.hpp>
 #include <stan/math/prim/mat/prob/categorical_logit_lpmf.hpp>
-#include <stan/math/prim/mat/prob/categorical_rng.hpp>
 #include <stan/math/prim/mat/prob/categorical_logit_rng.hpp>
+#include <stan/math/prim/mat/prob/categorical_lpmf.hpp>
+#include <stan/math/prim/mat/prob/categorical_rng.hpp>
 #include <stan/math/prim/mat/prob/dirichlet_log.hpp>
 #include <stan/math/prim/mat/prob/dirichlet_lpmf.hpp>
 #include <stan/math/prim/mat/prob/dirichlet_rng.hpp>
@@ -306,10 +306,10 @@
 #include <stan/math/prim/mat/prob/ordered_logistic_log.hpp>
 #include <stan/math/prim/mat/prob/ordered_logistic_lpmf.hpp>
 #include <stan/math/prim/mat/prob/ordered_logistic_rng.hpp>
-#include <stan/math/prim/mat/prob/poisson_log_glm_lpmf.hpp>
 #include <stan/math/prim/mat/prob/ordered_probit_log.hpp>
 #include <stan/math/prim/mat/prob/ordered_probit_lpmf.hpp>
 #include <stan/math/prim/mat/prob/ordered_probit_rng.hpp>
+#include <stan/math/prim/mat/prob/poisson_log_glm_lpmf.hpp>
 #include <stan/math/prim/mat/prob/wishart_log.hpp>
 #include <stan/math/prim/mat/prob/wishart_lpdf.hpp>
 #include <stan/math/prim/mat/prob/wishart_rng.hpp>

--- a/stan/math/prim/mat/fun/gp_matern_3_2_cov.hpp
+++ b/stan/math/prim/mat/fun/gp_matern_3_2_cov.hpp
@@ -1,0 +1,272 @@
+#ifndef STAN_MATH_PRIM_MAT_FUN_GP_MATERN_3_2_COV_HPP
+#define STAN_MATH_PRIM_MAT_FUN_GP_MATERN_3_2_COV_HPP
+
+#include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <stan/math/prim/scal/err/check_finite.hpp>
+#include <stan/math/prim/scal/err/check_nonnegative.hpp>
+#include <stan/math/prim/scal/err/check_not_nan.hpp>
+#include <stan/math/prim/scal/fun/square.hpp>
+#include <stan/math/prim/scal/fun/squared_distance.hpp>
+#include <stan/math/prim/scal/meta/return_type.hpp>
+#include <cmath>
+#include <vector>
+
+namespace stan {
+namespace math {
+
+/** Returns a Matern 3/2 covariance matrix with one input vector
+ *
+ * \f[ k(x, x') = \sigma^2(1 +
+ *  \frac{\sqrt{3}d(x, x')}{l})exp(-\frac{\sqrt{3}d(x, x')}{l})
+ * \f]
+ *
+ * where \f$ d(x, x') \f$ is the squared distace, or dot product.
+ *
+ * See Rausmussen & Williams et al 2006 Chapter 4.
+ *
+ * @param x std::vector of elements that can be used in stan::math::distance
+ * @param length_scale length scale
+ * @param sigma standard deviation that can be used in stan::math::square
+ * @throw std::domain error if sigma <= 0, l <= 0, or x is nan or inf
+ *
+ */
+template <typename T_x, typename T_s, typename T_l>
+inline typename Eigen::Matrix<typename stan::return_type<T_x, T_s, T_l>::type,
+                              Eigen::Dynamic, Eigen::Dynamic>
+gp_matern_3_2_cov(const std::vector<T_x> &x, const T_s &sigma,
+                  const T_l &length_scale) {
+  using stan::math::square;
+  using stan::math::squared_distance;
+  using std::exp;
+  using std::pow;
+
+  size_t x_size = x.size();
+  for (size_t n = 0; n < x_size; ++n)
+    check_not_nan("gp_matern_3_2_cov", "x", x[n]);
+
+  check_positive("gp_matern_3_2_cov", "marginal variance", sigma);
+  check_not_nan("gp_matern_3_2_cov", "marginal variance", sigma);
+
+  check_positive("gp_matern_3_2_cov", "length-scale", length_scale);
+  check_not_nan("gp_matern_3_2_cov", "length-scale", length_scale);
+
+  Eigen::Matrix<typename stan::return_type<T_x, T_s, T_l>::type, Eigen::Dynamic,
+                Eigen::Dynamic>
+      cov(x_size, x_size);
+
+  if (x_size == 0)
+    return cov;
+
+  T_s sigma_sq = square(sigma);
+  T_l root_3_inv_l = pow(3, 0.5) / length_scale;
+  T_l neg_root_3_inv_l = -1.0 * pow(3, 0.5) / length_scale;
+
+  for (size_t i = 0; i < (x_size - 1); ++i) {
+    cov(i, i) = sigma_sq;
+    for (size_t j = i + 1; j < x_size; ++j) {
+      cov(i, j) = sigma_sq * (1.0 + root_3_inv_l * squared_distance(x[i], x[j]))
+                  * exp(neg_root_3_inv_l * squared_distance(x[i], x[j]));
+      cov(j, i) = cov(i, j);
+    }
+  }
+  cov(x_size - 1, x_size - 1) = sigma_sq;
+  return cov;
+}
+
+/** Returns a Matern 3/2 Kernel with one input vector,
+ * with automatic relevance determination (ARD) priors
+ *
+ * \f[ k(x, x') = \sigma^2(1 + \sqrt{3}
+ *   \sum_{k=1}^{K}\frac{d{(x, x')}}{l_k})
+ *   exp(-\sqrt{3}\sum_{k=1}^{K}\frac{d(x, x')}{l_k}) \f]
+ *
+ * where \f$d(x, x')\f$ is the squared distance, or dot product.
+ * See Rausmussen & Williams et al 2006 Chapter 4.
+ *
+ * @param x std::vector of elements that can be used in stan::math::distance
+ * @param length_scale length scale
+ * @param sigma standard deviation that can be used in stan::math::square
+ * @throw std::domain error if sigma <= 0, l <= 0, or x is nan or inf
+ */
+template <typename T_x, typename T_s, typename T_l>
+inline typename Eigen::Matrix<typename stan::return_type<T_x, T_s, T_l>::type,
+                              Eigen::Dynamic, Eigen::Dynamic>
+gp_matern_3_2_cov(const std::vector<T_x> &x, const T_s &sigma,
+                  const std::vector<T_l> &length_scale) {
+  using stan::math::square;
+  using stan::math::squared_distance;
+  using std::exp;
+  using std::pow;
+
+  size_t x_size = x.size();
+  size_t l_size = length_scale.size();
+  for (size_t n = 0; n < x_size; ++n)
+    check_not_nan("gp_matern_3_2_cov", "x", x[n]);
+
+  check_positive("gp_matern_3_2_cov", "marginal variance", sigma);
+  check_not_nan("gp_matern_3_2_cov", "marginal variance", sigma);
+
+  check_positive("gp_matern_3_2_cov", "length-scale", length_scale);
+
+  for (size_t n = 0; n < x_size; ++n)
+    check_not_nan("gp_matern_3_2_cov", "length-scale", length_scale[n]);
+
+  Eigen::Matrix<typename stan::return_type<T_x, T_s, T_l>::type, Eigen::Dynamic,
+                Eigen::Dynamic>
+      cov(x_size, x_size);
+
+  if (x_size == 0)
+    return cov;
+
+  T_s sigma_sq = square(sigma);
+  T_l root_3 = pow(3.0, 0.5);
+  T_l neg_root_3 = -1.0 * pow(3.0, 0.5);
+  T_l temp;
+
+  for (size_t i = 0; i < x_size; ++i) {
+    for (size_t j = i; j < x_size; ++j) {
+      temp = 0;
+      for (size_t k = 0; k < l_size; ++k) {
+        temp += squared_distance(x[i], x[j]) / length_scale[k];
+      }
+      temp = pow(temp, 0.5);
+      cov(i, j) = sigma_sq * (1.0 + root_3 * temp) * exp(neg_root_3 * temp);
+      cov(j, i) = cov(i, j);
+    }
+  }
+  return cov;
+}
+
+/** Returns a Matern 3/2 covariance matrix with two input vectors
+ *
+ * \f[ k(x, x') = \sigma^2(1 +
+ *  \frac{\sqrt{3}d(x, x')}{l})exp(-\sqrt{3}\frac{d(x, x')}{l})
+ * \f]
+ *
+ * where \f$d(x, x')\f$ is the squared distance, or dot product.
+ * See Rausmussen & Williams et al 2006 Chapter 4.
+ *
+ * @param x1 std::vector of elements that can be used in stan::math::distance
+ * @param x2 std::vector of elements that can be used in stan::math::distance
+ * @param length_scale length scale
+ * @param sigma standard deviation that can be used in stan::math::square
+ * @throw std::domain error if sigma <= 0, l <= 0, or x1, x2 are nan or inf
+ *
+ */
+template <typename T_x1, typename T_x2, typename T_s, typename T_l>
+inline typename Eigen::Matrix<
+    typename stan::return_type<T_x1, T_x2, T_s, T_l>::type, Eigen::Dynamic,
+    Eigen::Dynamic>
+gp_matern_3_2_cov(const std::vector<T_x1> &x1, const std::vector<T_x2> &x2,
+                  const T_s &sigma, const T_l &length_scale) {
+  using stan::math::square;
+  using stan::math::squared_distance;
+  using std::exp;
+  using std::pow;
+
+  size_t x1_size = x1.size();
+  size_t x2_size = x2.size();
+  for (size_t n = 0; n < x1_size; ++n)
+    check_not_nan("gp_matern_3_2_cov", "x1", x1[n]);
+  for (size_t n = 0; n < x2_size; ++n)
+    check_not_nan("gp_matern_3_2_cov", "x2", x2[n]);
+
+  check_positive("gp_matern_3_2_cov", "marginal variance", sigma);
+  check_not_nan("gp_matern_3_2_cov", "marginal variance", sigma);
+
+  check_positive("gp_matern_3_2_cov", "length-scale", length_scale);
+  check_not_nan("gp_matern_3_2_cov", "length-scale", length_scale);
+
+  Eigen::Matrix<typename stan::return_type<T_x1, T_x2, T_s, T_l>::type,
+                Eigen::Dynamic, Eigen::Dynamic>
+      cov(x1_size, x2_size);
+
+  if (x1_size == 0 || x2_size == 0)
+    return cov;
+
+  T_s sigma_sq = square(sigma);
+  T_l root_3_inv_l_sq = pow(3.0, 0.5) / length_scale;
+  T_l neg_root_3_inv_l_sq = -1.0 * pow(3.0, 0.5) / length_scale;
+
+  for (size_t i = 0; i < x1_size; ++i) {
+    for (size_t j = 0; j < x2_size; ++j) {
+      cov(i, j) = sigma_sq
+                  * (1.0 + root_3_inv_l_sq * squared_distance(x1[i], x2[j]))
+                  * exp(neg_root_3_inv_l_sq * squared_distance(x1[i], x2[j]));
+    }
+  }
+  return cov;
+}
+
+/** Returns a Matern 3/2 Kernel with two input vectors with automatic
+ * relevance determination (ARD) priors
+ *
+ * \f[ k(x, x') = \sigma^2(1 + \sqrt{3}
+ *   \sum_{k=1}^{K}\frac{d(x, x')}{l_k})
+ *   exp(-\sqrt{3}\sum_{k=1}^{K}\frac{d(x, x')}{l_k}) \f]
+ *
+ * where \f$d(x, x')\f$ is the squared distance, or dot product.
+ * See Rausmussen & Williams et al 2006 Chapter 4.
+ *
+ * @param x1 std::vector of elements that can be used in stan::math::distance
+ * @param x2 std::vector of elements that can be used in stan::math::distance
+ * @param length_scale length scale
+ * @param sigma standard deviation that can be used in stan::math::square
+ * @throw std::domain error if sigma <= 0, l <= 0, or x1, x2 are nan or inf
+ *
+ */
+template <typename T_x1, typename T_x2, typename T_s, typename T_l>
+inline typename Eigen::Matrix<
+    typename stan::return_type<T_x1, T_x2, T_s, T_l>::type, Eigen::Dynamic,
+    Eigen::Dynamic>
+gp_matern_3_2_cov(const std::vector<T_x1> &x1, const std::vector<T_x2> &x2,
+                  const T_s &sigma, const std::vector<T_l> &length_scale) {
+  using stan::math::square;
+  using stan::math::squared_distance;
+  using std::exp;
+  using std::pow;
+
+  size_t x1_size = x1.size();
+  size_t x2_size = x2.size();
+  size_t l_size = length_scale.size();
+
+  for (size_t n = 0; n < x1_size; ++n)
+    check_not_nan("gp_matern_3_2_cov", "x1", x1[n]);
+  for (size_t n = 0; n < x2_size; ++n)
+    check_not_nan("gp_matern_3_2_cov", "x2", x2[n]);
+
+  check_positive("gp_matern_3_2_cov", "marginal variance", sigma);
+  check_not_nan("gp_matern_3_2_cov", "marginal variance", sigma);
+
+  check_positive("gp_matern_3_2_cov", "length-scale", length_scale);
+
+  for (size_t n = 0; n < l_size; ++n)
+    check_not_nan("gp_matern_3_2_cov", "length-scale", length_scale[n]);
+
+  Eigen::Matrix<typename stan::return_type<T_x1, T_x2, T_s, T_l>::type,
+                Eigen::Dynamic, Eigen::Dynamic>
+      cov(x1_size, x2_size);
+
+  if (x1_size == 0 || x2_size == 0)
+    return cov;
+
+  T_s sigma_sq = square(sigma);
+  T_l root_3 = pow(3.0, 0.5);
+  T_l neg_root_3 = -1.0 * pow(3.0, 0.5);
+  T_l temp;
+
+  for (size_t i = 0; i < x1_size; ++i) {
+    for (size_t j = 0; j < x2_size; ++j) {
+      temp = 0;
+      for (size_t k = 0; k < l_size; ++k) {
+        temp += squared_distance(x1[i], x2[j]) / length_scale[k];
+      }
+      temp = pow(temp, 0.5);
+      cov(i, j) = sigma_sq * (1.0 + root_3 * temp) * exp(neg_root_3 * temp);
+    }
+  }
+  return cov;
+}
+}  // namespace math
+}  // namespace stan
+#endif

--- a/stan/math/prim/mat/fun/gp_matern_3_2_cov.hpp
+++ b/stan/math/prim/mat/fun/gp_matern_3_2_cov.hpp
@@ -64,8 +64,9 @@ gp_matern_3_2_cov(const std::vector<T_x> &x, const T_s &sigma,
   for (size_t i = 0; i < (x_size - 1); ++i) {
     cov(i, i) = sigma_sq;
     for (size_t j = i + 1; j < x_size; ++j) {
-      cov(i, j) = sigma_sq * (1.0 + root_3_inv_l * squared_distance(x[i], x[j]))
-                  * exp(neg_root_3_inv_l * squared_distance(x[i], x[j]));
+      cov(i, j) = sigma_sq *
+                  (1.0 + root_3_inv_l * squared_distance(x[i], x[j])) *
+                  exp(neg_root_3_inv_l * squared_distance(x[i], x[j]));
       cov(j, i) = cov(i, j);
     }
   }
@@ -190,9 +191,9 @@ gp_matern_3_2_cov(const std::vector<T_x1> &x1, const std::vector<T_x2> &x2,
 
   for (size_t i = 0; i < x1_size; ++i) {
     for (size_t j = 0; j < x2_size; ++j) {
-      cov(i, j) = sigma_sq
-                  * (1.0 + root_3_inv_l_sq * squared_distance(x1[i], x2[j]))
-                  * exp(neg_root_3_inv_l_sq * squared_distance(x1[i], x2[j]));
+      cov(i, j) = sigma_sq *
+                  (1.0 + root_3_inv_l_sq * squared_distance(x1[i], x2[j])) *
+                  exp(neg_root_3_inv_l_sq * squared_distance(x1[i], x2[j]));
     }
   }
   return cov;

--- a/stan/math/prim/mat/fun/gp_matern_3_2_cov.hpp
+++ b/stan/math/prim/mat/fun/gp_matern_3_2_cov.hpp
@@ -64,9 +64,8 @@ gp_matern_3_2_cov(const std::vector<T_x> &x, const T_s &sigma,
   for (size_t i = 0; i < (x_size - 1); ++i) {
     cov(i, i) = sigma_sq;
     for (size_t j = i + 1; j < x_size; ++j) {
-      cov(i, j) = sigma_sq *
-                  (1.0 + root_3_inv_l * squared_distance(x[i], x[j])) *
-                  exp(neg_root_3_inv_l * squared_distance(x[i], x[j]));
+      cov(i, j) = sigma_sq * (1.0 + root_3_inv_l * squared_distance(x[i], x[j]))
+                  * exp(neg_root_3_inv_l * squared_distance(x[i], x[j]));
       cov(j, i) = cov(i, j);
     }
   }
@@ -191,9 +190,9 @@ gp_matern_3_2_cov(const std::vector<T_x1> &x1, const std::vector<T_x2> &x2,
 
   for (size_t i = 0; i < x1_size; ++i) {
     for (size_t j = 0; j < x2_size; ++j) {
-      cov(i, j) = sigma_sq *
-                  (1.0 + root_3_inv_l_sq * squared_distance(x1[i], x2[j])) *
-                  exp(neg_root_3_inv_l_sq * squared_distance(x1[i], x2[j]));
+      cov(i, j) = sigma_sq
+                  * (1.0 + root_3_inv_l_sq * squared_distance(x1[i], x2[j]))
+                  * exp(neg_root_3_inv_l_sq * squared_distance(x1[i], x2[j]));
     }
   }
   return cov;

--- a/test/unit/math/prim/mat/fun/gp_matern_3_2_cov_test.cpp
+++ b/test/unit/math/prim/mat/fun/gp_matern_3_2_cov_test.cpp
@@ -47,11 +47,12 @@ TEST(MathPrimMat, vec_double_gp_matern_3_2_cov1) {
   for (int i = 0; i < 3; i++)
     for (int j = 0; j < 3; j++)
       EXPECT_FLOAT_EQ(
-          sigma * sigma *
-              (1.0 +
-               (pow(3.0, 0.5) / l) * stan::math::squared_distance(x[i], x[j])) *
-              std::exp(-1.0 * (pow(3.0, 0.5) / l) *
-                       stan::math::squared_distance(x[i], x[j])),
+          sigma * sigma
+              * (1.0
+                 + (pow(3.0, 0.5) / l)
+                       * stan::math::squared_distance(x[i], x[j]))
+              * std::exp(-1.0 * (pow(3.0, 0.5) / l)
+                         * stan::math::squared_distance(x[i], x[j])),
           cov(i, j))
           << "index: (" << i << ", " << j << ")";
 }
@@ -81,8 +82,8 @@ TEST(MathPrimMat, vec_double_ard_gp_matern_3_2_cov1) {
         temp += stan::math::squared_distance(x[i], x[j]) / l[k];
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp)) *
-                          std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp))
+                          * std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
                       cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -103,13 +104,14 @@ TEST(MathPrimMat, vec_eigen_gp_matern_3_2_cov1) {
   cov = stan::math::gp_matern_3_2_cov(x1, sigma, l);
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
-      EXPECT_FLOAT_EQ(sigma * sigma *
-                          (1.0 +
-                           (pow(3.0, 0.5) / l) *
-                               stan::math::squared_distance(x1[i], x1[j])) *
-                          std::exp(-1.0 * (pow(3.0, 0.5) / l) *
-                                   stan::math::squared_distance(x1[i], x1[j])),
-                      cov(i, j))
+      EXPECT_FLOAT_EQ(
+          sigma * sigma
+              * (1.0
+                 + (pow(3.0, 0.5) / l)
+                       * stan::math::squared_distance(x1[i], x1[j]))
+              * std::exp(-1.0 * (pow(3.0, 0.5) / l)
+                         * stan::math::squared_distance(x1[i], x1[j])),
+          cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -135,13 +137,14 @@ TEST(MathPrimMat, vec_eigen_eigen_gp_matern_3_2_cov1) {
   cov = stan::math::gp_matern_3_2_cov(x1, x2, sigma, l);
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
-      EXPECT_FLOAT_EQ(sigma * sigma *
-                          (1.0 +
-                           (pow(3.0, 0.5) / l) *
-                               stan::math::squared_distance(x1[i], x2[j])) *
-                          std::exp(-1.0 * (pow(3.0, 0.5) / l) *
-                                   stan::math::squared_distance(x1[i], x2[j])),
-                      cov(i, j))
+      EXPECT_FLOAT_EQ(
+          sigma * sigma
+              * (1.0
+                 + (pow(3.0, 0.5) / l)
+                       * stan::math::squared_distance(x1[i], x2[j]))
+              * std::exp(-1.0 * (pow(3.0, 0.5) / l)
+                         * stan::math::squared_distance(x1[i], x2[j])),
+          cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -165,13 +168,14 @@ TEST(MathPrimMat, vec_double_double_gp_matern_3_2_cov1) {
   cov = stan::math::gp_matern_3_2_cov(x1, x2, sigma, l);
   for (int i = 0; i < 3; i++)
     for (int j = 0; j < 3; j++)
-      EXPECT_FLOAT_EQ(sigma * sigma *
-                          (1.0 +
-                           (pow(3.0, 0.5) / l) *
-                               stan::math::squared_distance(x1[i], x2[j])) *
-                          std::exp(-1.0 * (pow(3.0, 0.5) / l) *
-                                   stan::math::squared_distance(x1[i], x2[j])),
-                      cov(i, j))
+      EXPECT_FLOAT_EQ(
+          sigma * sigma
+              * (1.0
+                 + (pow(3.0, 0.5) / l)
+                       * stan::math::squared_distance(x1[i], x2[j]))
+              * std::exp(-1.0 * (pow(3.0, 0.5) / l)
+                         * stan::math::squared_distance(x1[i], x2[j])),
+          cov(i, j))
           << "index: (" << i << ", " << j << ")";
 }
 
@@ -200,8 +204,8 @@ TEST(MathPrimMat, vec_eigen_ard_gp_matern_3_2_cov1) {
       for (int k = 0; k < 5; k++) {
         temp += stan::math::squared_distance(x1[i], x1[j]) / l[k];
       }
-      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp)) *
-                          std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp))
+                          * std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
                       cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -236,8 +240,8 @@ TEST(MathPrimMat, vec_double_double_ard_gp_matern_3_2_cov1) {
       for (int k = 0; k < 4; k++) {
         temp += stan::math::squared_distance(x1[i], x2[j]) / l[k];
       }
-      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * pow(temp, 0.5)) *
-                          std::exp(-1.0 * pow(3.0, 0.5) * pow(temp, 0.5)),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * pow(temp, 0.5))
+                          * std::exp(-1.0 * pow(3.0, 0.5) * pow(temp, 0.5)),
                       cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -274,8 +278,8 @@ TEST(MathPrimMat, vec_eigen_eigen_ard_gp_matern_3_2_cov1) {
       for (int k = 0; k < 4; k++) {
         temp += stan::math::squared_distance(x1[i], x2[j]) / l[k];
       }
-      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * pow(temp, 0.5)) *
-                          std::exp(-1.0 * pow(3.0, 0.5) * pow(temp, 0.5)),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * pow(temp, 0.5))
+                          * std::exp(-1.0 * pow(3.0, 0.5) * pow(temp, 0.5)),
                       cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -296,13 +300,14 @@ TEST(MathPrimMat, rvec_eigen_gp_matern_3_2_cov1) {
   cov = stan::math::gp_matern_3_2_cov(x1, sigma, l);
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
-      EXPECT_FLOAT_EQ(sigma * sigma *
-                          (1.0 +
-                           (pow(3.0, 0.5) / l) *
-                               stan::math::squared_distance(x1[i], x1[j])) *
-                          std::exp(-1.0 * (pow(3.0, 0.5) / l) *
-                                   stan::math::squared_distance(x1[i], x1[j])),
-                      cov(i, j))
+      EXPECT_FLOAT_EQ(
+          sigma * sigma
+              * (1.0
+                 + (pow(3.0, 0.5) / l)
+                       * stan::math::squared_distance(x1[i], x1[j]))
+              * std::exp(-1.0 * (pow(3.0, 0.5) / l)
+                         * stan::math::squared_distance(x1[i], x1[j])),
+          cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -333,8 +338,8 @@ TEST(MathPrimMat, rvec_eigen_ard_gp_matern_3_2_cov1) {
         temp += stan::math::squared_distance(x1[i], x1[j]) / l[k];
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp)) *
-                          std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp))
+                          * std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
                       cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -361,13 +366,14 @@ TEST(MathPrimMat, vec_eigen_rvec_eigen_gp_matern_3_2_cov1) {
   cov = stan::math::gp_matern_3_2_cov(x1, x2, sigma, l);
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
-      EXPECT_FLOAT_EQ(sigma * sigma *
-                          (1.0 +
-                           (pow(3.0, 0.5) / l) *
-                               stan::math::squared_distance(x1[i], x2[j])) *
-                          std::exp(-1.0 * (pow(3.0, 0.5) / l) *
-                                   stan::math::squared_distance(x1[i], x2[j])),
-                      cov(i, j))
+      EXPECT_FLOAT_EQ(
+          sigma * sigma
+              * (1.0
+                 + (pow(3.0, 0.5) / l)
+                       * stan::math::squared_distance(x1[i], x2[j]))
+              * std::exp(-1.0 * (pow(3.0, 0.5) / l)
+                         * stan::math::squared_distance(x1[i], x2[j])),
+          cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -375,13 +381,14 @@ TEST(MathPrimMat, vec_eigen_rvec_eigen_gp_matern_3_2_cov1) {
   cov = stan::math::gp_matern_3_2_cov(x2, x1, sigma, l);
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
-      EXPECT_FLOAT_EQ(sigma * sigma *
-                          (1.0 +
-                           (pow(3.0, 0.5) / l) *
-                               stan::math::squared_distance(x2[i], x1[j])) *
-                          std::exp(-1.0 * (pow(3.0, 0.5) / l) *
-                                   stan::math::squared_distance(x2[i], x1[j])),
-                      cov(i, j))
+      EXPECT_FLOAT_EQ(
+          sigma * sigma
+              * (1.0
+                 + (pow(3.0, 0.5) / l)
+                       * stan::math::squared_distance(x2[i], x1[j]))
+              * std::exp(-1.0 * (pow(3.0, 0.5) / l)
+                         * stan::math::squared_distance(x2[i], x1[j])),
+          cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -416,8 +423,8 @@ TEST(MathPrimMat, vec_eigen_rvec_eigen_ard_gp_matern_3_2_cov1) {
         temp += stan::math::squared_distance(x1[i], x2[j]) / l[k];
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp)) *
-                          std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp))
+                          * std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
                       cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -430,8 +437,8 @@ TEST(MathPrimMat, vec_eigen_rvec_eigen_ard_gp_matern_3_2_cov1) {
         temp += stan::math::squared_distance(x2[i], x1[j]) / l[k];
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp)) *
-                          std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp))
+                          * std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
                       cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -458,13 +465,14 @@ TEST(MathPrimMat, rvec_eigen_rvec_eigen_gp_matern_3_2_cov1) {
   cov = stan::math::gp_matern_3_2_cov(x1, x2, sigma, l);
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
-      EXPECT_FLOAT_EQ(sigma * sigma *
-                          (1.0 +
-                           (pow(3.0, 0.5) / l) *
-                               stan::math::squared_distance(x1[i], x2[j])) *
-                          std::exp(-1.0 * (pow(3.0, 0.5) / l) *
-                                   stan::math::squared_distance(x1[i], x2[j])),
-                      cov(i, j))
+      EXPECT_FLOAT_EQ(
+          sigma * sigma
+              * (1.0
+                 + (pow(3.0, 0.5) / l)
+                       * stan::math::squared_distance(x1[i], x2[j]))
+              * std::exp(-1.0 * (pow(3.0, 0.5) / l)
+                         * stan::math::squared_distance(x1[i], x2[j])),
+          cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -472,13 +480,14 @@ TEST(MathPrimMat, rvec_eigen_rvec_eigen_gp_matern_3_2_cov1) {
   cov = stan::math::gp_matern_3_2_cov(x2, x1, sigma, l);
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
-      EXPECT_FLOAT_EQ(sigma * sigma *
-                          (1.0 +
-                           (pow(3.0, 0.5) / l) *
-                               stan::math::squared_distance(x2[i], x1[j])) *
-                          std::exp(-1.0 * (pow(3.0, 0.5) / l) *
-                                   stan::math::squared_distance(x2[i], x1[j])),
-                      cov(i, j))
+      EXPECT_FLOAT_EQ(
+          sigma * sigma
+              * (1.0
+                 + (pow(3.0, 0.5) / l)
+                       * stan::math::squared_distance(x2[i], x1[j]))
+              * std::exp(-1.0 * (pow(3.0, 0.5) / l)
+                         * stan::math::squared_distance(x2[i], x1[j])),
+          cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -514,8 +523,8 @@ TEST(MathPrimMat, rvec_eigen_rvec_eigen_ard_gp_matern_3_2_cov1) {
         temp += stan::math::squared_distance(x1[i], x2[j]) / l[k];
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp)) *
-                          std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp))
+                          * std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
                       cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -528,8 +537,8 @@ TEST(MathPrimMat, rvec_eigen_rvec_eigen_ard_gp_matern_3_2_cov1) {
         temp += stan::math::squared_distance(x2[i], x1[j]) / l[k];
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp)) *
-                          std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp))
+                          * std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
                       cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -567,144 +576,152 @@ TEST(MathPrimMat, vec_eigen_mixed_gp_matern_3_2_cov2) {
     x2_vec[i] << 2 * i, 3 * i, 4 * i;
   }
   Eigen::MatrixXd cov;
-  EXPECT_NO_THROW(cov =
-                      stan::math::gp_matern_3_2_cov(x1_rvec, x2_vec, sigma, l));
+  EXPECT_NO_THROW(cov
+                  = stan::math::gp_matern_3_2_cov(x1_rvec, x2_vec, sigma, l));
   EXPECT_EQ(3, cov.rows());
   EXPECT_EQ(4, cov.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-          sigma * sigma * (1.0 +
-                           (pow(3.0, 0.5) / l) * stan::math::squared_distance(
-                                                     x1_rvec[i], x2_vec[j])) *
-              std::exp(-1.0 * (pow(3.0, 0.5) / l) *
-                       stan::math::squared_distance(x1_rvec[i], x2_vec[j])),
+          sigma * sigma
+              * (1.0
+                 + (pow(3.0, 0.5) / l)
+                       * stan::math::squared_distance(x1_rvec[i], x2_vec[j]))
+              * std::exp(-1.0 * (pow(3.0, 0.5) / l)
+                         * stan::math::squared_distance(x1_rvec[i], x2_vec[j])),
           cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov7;
-  EXPECT_NO_THROW(cov7 =
-                      stan::math::gp_matern_3_2_cov(x2_vec, x1_rvec, sigma, l));
+  EXPECT_NO_THROW(cov7
+                  = stan::math::gp_matern_3_2_cov(x2_vec, x1_rvec, sigma, l));
   EXPECT_EQ(4, cov7.rows());
   EXPECT_EQ(3, cov7.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-          sigma * sigma * (1.0 +
-                           (pow(3.0, 0.5) / l) * stan::math::squared_distance(
-                                                     x2_vec[i], x1_rvec[j])) *
-              std::exp(-1.0 * (pow(3.0, 0.5) / l) *
-                       stan::math::squared_distance(x2_vec[i], x1_rvec[j])),
+          sigma * sigma
+              * (1.0
+                 + (pow(3.0, 0.5) / l)
+                       * stan::math::squared_distance(x2_vec[i], x1_rvec[j]))
+              * std::exp(-1.0 * (pow(3.0, 0.5) / l)
+                         * stan::math::squared_distance(x2_vec[i], x1_rvec[j])),
           cov7(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov2;
-  EXPECT_NO_THROW(cov2 =
-                      stan::math::gp_matern_3_2_cov(x1_vec, x2_rvec, sigma, l));
+  EXPECT_NO_THROW(cov2
+                  = stan::math::gp_matern_3_2_cov(x1_vec, x2_rvec, sigma, l));
   EXPECT_EQ(3, cov2.rows());
   EXPECT_EQ(4, cov2.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-          sigma * sigma * (1.0 +
-                           (pow(3.0, 0.5) / l) * stan::math::squared_distance(
-                                                     x1_vec[i], x2_rvec[j])) *
-              std::exp(-1.0 * (pow(3.0, 0.5) / l) *
-                       stan::math::squared_distance(x1_vec[i], x2_rvec[j])),
+          sigma * sigma
+              * (1.0
+                 + (pow(3.0, 0.5) / l)
+                       * stan::math::squared_distance(x1_vec[i], x2_rvec[j]))
+              * std::exp(-1.0 * (pow(3.0, 0.5) / l)
+                         * stan::math::squared_distance(x1_vec[i], x2_rvec[j])),
           cov2(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov8;
-  EXPECT_NO_THROW(cov8 =
-                      stan::math::gp_matern_3_2_cov(x2_rvec, x1_vec, sigma, l));
+  EXPECT_NO_THROW(cov8
+                  = stan::math::gp_matern_3_2_cov(x2_rvec, x1_vec, sigma, l));
   EXPECT_EQ(4, cov8.rows());
   EXPECT_EQ(3, cov8.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-          sigma * sigma * (1.0 +
-                           (pow(3.0, 0.5) / l) * stan::math::squared_distance(
-                                                     x2_rvec[i], x1_vec[j])) *
-              std::exp(-1.0 * (pow(3.0, 0.5) / l) *
-                       stan::math::squared_distance(x2_rvec[i], x1_vec[j])),
+          sigma * sigma
+              * (1.0
+                 + (pow(3.0, 0.5) / l)
+                       * stan::math::squared_distance(x2_rvec[i], x1_vec[j]))
+              * std::exp(-1.0 * (pow(3.0, 0.5) / l)
+                         * stan::math::squared_distance(x2_rvec[i], x1_vec[j])),
           cov8(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov3;
-  EXPECT_NO_THROW(cov3 =
-                      stan::math::gp_matern_3_2_cov(x2_vec, x2_rvec, sigma, l));
+  EXPECT_NO_THROW(cov3
+                  = stan::math::gp_matern_3_2_cov(x2_vec, x2_rvec, sigma, l));
   EXPECT_EQ(4, cov3.rows());
   EXPECT_EQ(4, cov3.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-          sigma * sigma * (1.0 +
-                           (pow(3.0, 0.5) / l) * stan::math::squared_distance(
-                                                     x2_vec[i], x2_rvec[j])) *
-              std::exp(-1.0 * (pow(3.0, 0.5) / l) *
-                       stan::math::squared_distance(x2_vec[i], x2_rvec[j])),
+          sigma * sigma
+              * (1.0
+                 + (pow(3.0, 0.5) / l)
+                       * stan::math::squared_distance(x2_vec[i], x2_rvec[j]))
+              * std::exp(-1.0 * (pow(3.0, 0.5) / l)
+                         * stan::math::squared_distance(x2_vec[i], x2_rvec[j])),
           cov3(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov4;
-  EXPECT_NO_THROW(cov4 =
-                      stan::math::gp_matern_3_2_cov(x2_rvec, x2_vec, sigma, l));
+  EXPECT_NO_THROW(cov4
+                  = stan::math::gp_matern_3_2_cov(x2_rvec, x2_vec, sigma, l));
   EXPECT_EQ(4, cov4.rows());
   EXPECT_EQ(4, cov4.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-          sigma * sigma * (1.0 +
-                           (pow(3.0, 0.5) / l) * stan::math::squared_distance(
-                                                     x2_rvec[i], x2_vec[j])) *
-              std::exp(-1.0 * (pow(3.0, 0.5) / l) *
-                       stan::math::squared_distance(x2_rvec[i], x2_vec[j])),
+          sigma * sigma
+              * (1.0
+                 + (pow(3.0, 0.5) / l)
+                       * stan::math::squared_distance(x2_rvec[i], x2_vec[j]))
+              * std::exp(-1.0 * (pow(3.0, 0.5) / l)
+                         * stan::math::squared_distance(x2_rvec[i], x2_vec[j])),
           cov4(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov5;
-  EXPECT_NO_THROW(cov5 =
-                      stan::math::gp_matern_3_2_cov(x1_rvec, x1_vec, sigma, l));
+  EXPECT_NO_THROW(cov5
+                  = stan::math::gp_matern_3_2_cov(x1_rvec, x1_vec, sigma, l));
   EXPECT_EQ(3, cov5.rows());
   EXPECT_EQ(3, cov5.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-          sigma * sigma * (1.0 +
-                           (pow(3.0, 0.5) / l) * stan::math::squared_distance(
-                                                     x1_rvec[i], x1_vec[j])) *
-              std::exp(-1.0 * (pow(3.0, 0.5) / l) *
-                       stan::math::squared_distance(x1_rvec[i], x1_vec[j])),
+          sigma * sigma
+              * (1.0
+                 + (pow(3.0, 0.5) / l)
+                       * stan::math::squared_distance(x1_rvec[i], x1_vec[j]))
+              * std::exp(-1.0 * (pow(3.0, 0.5) / l)
+                         * stan::math::squared_distance(x1_rvec[i], x1_vec[j])),
           cov5(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov6;
-  EXPECT_NO_THROW(cov6 =
-                      stan::math::gp_matern_3_2_cov(x1_vec, x1_rvec, sigma, l));
+  EXPECT_NO_THROW(cov6
+                  = stan::math::gp_matern_3_2_cov(x1_vec, x1_rvec, sigma, l));
   EXPECT_EQ(3, cov6.rows());
   EXPECT_EQ(3, cov6.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-          sigma * sigma * (1.0 +
-                           (pow(3.0, 0.5) / l) * stan::math::squared_distance(
-                                                     x1_vec[i], x1_rvec[j])) *
-              std::exp(-1.0 * (pow(3.0, 0.5) / l) *
-                       stan::math::squared_distance(x1_vec[i], x1_rvec[j])),
+          sigma * sigma
+              * (1.0
+                 + (pow(3.0, 0.5) / l)
+                       * stan::math::squared_distance(x1_vec[i], x1_rvec[j]))
+              * std::exp(-1.0 * (pow(3.0, 0.5) / l)
+                         * stan::math::squared_distance(x1_vec[i], x1_rvec[j])),
           cov6(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -747,8 +764,8 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_matern_3_2_cov2) {
     x2_vec[i] << 2 * i, 3 * i, 4 * i;
   }
   Eigen::MatrixXd cov;
-  EXPECT_NO_THROW(cov =
-                      stan::math::gp_matern_3_2_cov(x1_rvec, x2_vec, sigma, l));
+  EXPECT_NO_THROW(cov
+                  = stan::math::gp_matern_3_2_cov(x1_rvec, x2_vec, sigma, l));
   EXPECT_EQ(3, cov.rows());
   EXPECT_EQ(4, cov.cols());
   for (int i = 0; i < 3; i++) {
@@ -758,16 +775,16 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_matern_3_2_cov2) {
         temp += stan::math::squared_distance(x1_rvec[i], x2_vec[j]) / l[k];
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp)) *
-                          std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp))
+                          * std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
                       cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov7;
-  EXPECT_NO_THROW(cov7 =
-                      stan::math::gp_matern_3_2_cov(x2_vec, x1_rvec, sigma, l));
+  EXPECT_NO_THROW(cov7
+                  = stan::math::gp_matern_3_2_cov(x2_vec, x1_rvec, sigma, l));
   EXPECT_EQ(4, cov7.rows());
   EXPECT_EQ(3, cov7.cols());
   for (int i = 0; i < 3; i++) {
@@ -777,16 +794,16 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_matern_3_2_cov2) {
         temp += stan::math::squared_distance(x2_vec[i], x1_rvec[j]) / l[k];
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp)) *
-                          std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp))
+                          * std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
                       cov7(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov2;
-  EXPECT_NO_THROW(cov2 =
-                      stan::math::gp_matern_3_2_cov(x1_vec, x2_rvec, sigma, l));
+  EXPECT_NO_THROW(cov2
+                  = stan::math::gp_matern_3_2_cov(x1_vec, x2_rvec, sigma, l));
   EXPECT_EQ(3, cov2.rows());
   EXPECT_EQ(4, cov2.cols());
   for (int i = 0; i < 3; i++) {
@@ -796,16 +813,16 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_matern_3_2_cov2) {
         temp += stan::math::squared_distance(x1_vec[i], x2_rvec[j]) / l[k];
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp)) *
-                          std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp))
+                          * std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
                       cov2(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov8;
-  EXPECT_NO_THROW(cov8 =
-                      stan::math::gp_matern_3_2_cov(x2_rvec, x1_vec, sigma, l));
+  EXPECT_NO_THROW(cov8
+                  = stan::math::gp_matern_3_2_cov(x2_rvec, x1_vec, sigma, l));
   EXPECT_EQ(4, cov8.rows());
   EXPECT_EQ(3, cov8.cols());
   for (int i = 0; i < 3; i++) {
@@ -815,16 +832,16 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_matern_3_2_cov2) {
         temp += stan::math::squared_distance(x2_rvec[i], x1_vec[j]) / l[k];
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp)) *
-                          std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp))
+                          * std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
                       cov8(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov3;
-  EXPECT_NO_THROW(cov3 =
-                      stan::math::gp_matern_3_2_cov(x2_vec, x2_rvec, sigma, l));
+  EXPECT_NO_THROW(cov3
+                  = stan::math::gp_matern_3_2_cov(x2_vec, x2_rvec, sigma, l));
   EXPECT_EQ(4, cov3.rows());
   EXPECT_EQ(4, cov3.cols());
   for (int i = 0; i < 3; i++) {
@@ -834,16 +851,16 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_matern_3_2_cov2) {
         temp += stan::math::squared_distance(x2_vec[i], x2_rvec[j]) / l[k];
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp)) *
-                          std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp))
+                          * std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
                       cov3(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov4;
-  EXPECT_NO_THROW(cov4 =
-                      stan::math::gp_matern_3_2_cov(x2_rvec, x2_vec, sigma, l));
+  EXPECT_NO_THROW(cov4
+                  = stan::math::gp_matern_3_2_cov(x2_rvec, x2_vec, sigma, l));
   EXPECT_EQ(4, cov4.rows());
   EXPECT_EQ(4, cov4.cols());
   for (int i = 0; i < 3; i++) {
@@ -853,16 +870,16 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_matern_3_2_cov2) {
         temp += stan::math::squared_distance(x2_rvec[i], x2_vec[j]) / l[k];
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp)) *
-                          std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp))
+                          * std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
                       cov4(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov5;
-  EXPECT_NO_THROW(cov5 =
-                      stan::math::gp_matern_3_2_cov(x1_rvec, x1_vec, sigma, l));
+  EXPECT_NO_THROW(cov5
+                  = stan::math::gp_matern_3_2_cov(x1_rvec, x1_vec, sigma, l));
   EXPECT_EQ(3, cov5.rows());
   EXPECT_EQ(3, cov5.cols());
   for (int i = 0; i < 3; i++) {
@@ -872,16 +889,16 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_matern_3_2_cov2) {
         temp += stan::math::squared_distance(x1_rvec[i], x1_vec[j]) / l[k];
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp)) *
-                          std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp))
+                          * std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
                       cov5(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov6;
-  EXPECT_NO_THROW(cov6 =
-                      stan::math::gp_matern_3_2_cov(x1_vec, x1_rvec, sigma, l));
+  EXPECT_NO_THROW(cov6
+                  = stan::math::gp_matern_3_2_cov(x1_vec, x1_rvec, sigma, l));
   EXPECT_EQ(3, cov6.rows());
   EXPECT_EQ(3, cov6.cols());
   for (int i = 0; i < 3; i++) {
@@ -891,8 +908,8 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_matern_3_2_cov2) {
         temp += stan::math::squared_distance(x1_vec[i], x1_rvec[j]) / l[k];
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp)) *
-                          std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp))
+                          * std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
                       cov6(i, j))
           << "index: (" << i << ", " << j << ")";
     }

--- a/test/unit/math/prim/mat/fun/gp_matern_3_2_cov_test.cpp
+++ b/test/unit/math/prim/mat/fun/gp_matern_3_2_cov_test.cpp
@@ -47,12 +47,11 @@ TEST(MathPrimMat, vec_double_gp_matern_3_2_cov1) {
   for (int i = 0; i < 3; i++)
     for (int j = 0; j < 3; j++)
       EXPECT_FLOAT_EQ(
-          sigma * sigma
-              * (1.0
-                 + (pow(3.0, 0.5) / l)
-                       * stan::math::squared_distance(x[i], x[j]))
-              * std::exp(-1.0 * (pow(3.0, 0.5) / l)
-                         * stan::math::squared_distance(x[i], x[j])),
+          sigma * sigma *
+              (1.0 +
+               (pow(3.0, 0.5) / l) * stan::math::squared_distance(x[i], x[j])) *
+              std::exp(-1.0 * (pow(3.0, 0.5) / l) *
+                       stan::math::squared_distance(x[i], x[j])),
           cov(i, j))
           << "index: (" << i << ", " << j << ")";
 }
@@ -82,8 +81,8 @@ TEST(MathPrimMat, vec_double_ard_gp_matern_3_2_cov1) {
         temp += stan::math::squared_distance(x[i], x[j]) / l[k];
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp))
-                          * std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp)) *
+                          std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
                       cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -104,14 +103,13 @@ TEST(MathPrimMat, vec_eigen_gp_matern_3_2_cov1) {
   cov = stan::math::gp_matern_3_2_cov(x1, sigma, l);
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
-      EXPECT_FLOAT_EQ(
-          sigma * sigma
-              * (1.0
-                 + (pow(3.0, 0.5) / l)
-                       * stan::math::squared_distance(x1[i], x1[j]))
-              * std::exp(-1.0 * (pow(3.0, 0.5) / l)
-                         * stan::math::squared_distance(x1[i], x1[j])),
-          cov(i, j))
+      EXPECT_FLOAT_EQ(sigma * sigma *
+                          (1.0 +
+                           (pow(3.0, 0.5) / l) *
+                               stan::math::squared_distance(x1[i], x1[j])) *
+                          std::exp(-1.0 * (pow(3.0, 0.5) / l) *
+                                   stan::math::squared_distance(x1[i], x1[j])),
+                      cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -137,14 +135,13 @@ TEST(MathPrimMat, vec_eigen_eigen_gp_matern_3_2_cov1) {
   cov = stan::math::gp_matern_3_2_cov(x1, x2, sigma, l);
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
-      EXPECT_FLOAT_EQ(
-          sigma * sigma
-              * (1.0
-                 + (pow(3.0, 0.5) / l)
-                       * stan::math::squared_distance(x1[i], x2[j]))
-              * std::exp(-1.0 * (pow(3.0, 0.5) / l)
-                         * stan::math::squared_distance(x1[i], x2[j])),
-          cov(i, j))
+      EXPECT_FLOAT_EQ(sigma * sigma *
+                          (1.0 +
+                           (pow(3.0, 0.5) / l) *
+                               stan::math::squared_distance(x1[i], x2[j])) *
+                          std::exp(-1.0 * (pow(3.0, 0.5) / l) *
+                                   stan::math::squared_distance(x1[i], x2[j])),
+                      cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -168,14 +165,13 @@ TEST(MathPrimMat, vec_double_double_gp_matern_3_2_cov1) {
   cov = stan::math::gp_matern_3_2_cov(x1, x2, sigma, l);
   for (int i = 0; i < 3; i++)
     for (int j = 0; j < 3; j++)
-      EXPECT_FLOAT_EQ(
-          sigma * sigma
-              * (1.0
-                 + (pow(3.0, 0.5) / l)
-                       * stan::math::squared_distance(x1[i], x2[j]))
-              * std::exp(-1.0 * (pow(3.0, 0.5) / l)
-                         * stan::math::squared_distance(x1[i], x2[j])),
-          cov(i, j))
+      EXPECT_FLOAT_EQ(sigma * sigma *
+                          (1.0 +
+                           (pow(3.0, 0.5) / l) *
+                               stan::math::squared_distance(x1[i], x2[j])) *
+                          std::exp(-1.0 * (pow(3.0, 0.5) / l) *
+                                   stan::math::squared_distance(x1[i], x2[j])),
+                      cov(i, j))
           << "index: (" << i << ", " << j << ")";
 }
 
@@ -204,8 +200,8 @@ TEST(MathPrimMat, vec_eigen_ard_gp_matern_3_2_cov1) {
       for (int k = 0; k < 5; k++) {
         temp += stan::math::squared_distance(x1[i], x1[j]) / l[k];
       }
-      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp))
-                          * std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp)) *
+                          std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
                       cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -240,8 +236,8 @@ TEST(MathPrimMat, vec_double_double_ard_gp_matern_3_2_cov1) {
       for (int k = 0; k < 4; k++) {
         temp += stan::math::squared_distance(x1[i], x2[j]) / l[k];
       }
-      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * pow(temp, 0.5))
-                          * std::exp(-1.0 * pow(3.0, 0.5) * pow(temp, 0.5)),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * pow(temp, 0.5)) *
+                          std::exp(-1.0 * pow(3.0, 0.5) * pow(temp, 0.5)),
                       cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -278,8 +274,8 @@ TEST(MathPrimMat, vec_eigen_eigen_ard_gp_matern_3_2_cov1) {
       for (int k = 0; k < 4; k++) {
         temp += stan::math::squared_distance(x1[i], x2[j]) / l[k];
       }
-      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * pow(temp, 0.5))
-                          * std::exp(-1.0 * pow(3.0, 0.5) * pow(temp, 0.5)),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * pow(temp, 0.5)) *
+                          std::exp(-1.0 * pow(3.0, 0.5) * pow(temp, 0.5)),
                       cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -300,14 +296,13 @@ TEST(MathPrimMat, rvec_eigen_gp_matern_3_2_cov1) {
   cov = stan::math::gp_matern_3_2_cov(x1, sigma, l);
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
-      EXPECT_FLOAT_EQ(
-          sigma * sigma
-              * (1.0
-                 + (pow(3.0, 0.5) / l)
-                       * stan::math::squared_distance(x1[i], x1[j]))
-              * std::exp(-1.0 * (pow(3.0, 0.5) / l)
-                         * stan::math::squared_distance(x1[i], x1[j])),
-          cov(i, j))
+      EXPECT_FLOAT_EQ(sigma * sigma *
+                          (1.0 +
+                           (pow(3.0, 0.5) / l) *
+                               stan::math::squared_distance(x1[i], x1[j])) *
+                          std::exp(-1.0 * (pow(3.0, 0.5) / l) *
+                                   stan::math::squared_distance(x1[i], x1[j])),
+                      cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -338,8 +333,8 @@ TEST(MathPrimMat, rvec_eigen_ard_gp_matern_3_2_cov1) {
         temp += stan::math::squared_distance(x1[i], x1[j]) / l[k];
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp))
-                          * std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp)) *
+                          std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
                       cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -366,14 +361,13 @@ TEST(MathPrimMat, vec_eigen_rvec_eigen_gp_matern_3_2_cov1) {
   cov = stan::math::gp_matern_3_2_cov(x1, x2, sigma, l);
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
-      EXPECT_FLOAT_EQ(
-          sigma * sigma
-              * (1.0
-                 + (pow(3.0, 0.5) / l)
-                       * stan::math::squared_distance(x1[i], x2[j]))
-              * std::exp(-1.0 * (pow(3.0, 0.5) / l)
-                         * stan::math::squared_distance(x1[i], x2[j])),
-          cov(i, j))
+      EXPECT_FLOAT_EQ(sigma * sigma *
+                          (1.0 +
+                           (pow(3.0, 0.5) / l) *
+                               stan::math::squared_distance(x1[i], x2[j])) *
+                          std::exp(-1.0 * (pow(3.0, 0.5) / l) *
+                                   stan::math::squared_distance(x1[i], x2[j])),
+                      cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -381,14 +375,13 @@ TEST(MathPrimMat, vec_eigen_rvec_eigen_gp_matern_3_2_cov1) {
   cov = stan::math::gp_matern_3_2_cov(x2, x1, sigma, l);
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
-      EXPECT_FLOAT_EQ(
-          sigma * sigma
-              * (1.0
-                 + (pow(3.0, 0.5) / l)
-                       * stan::math::squared_distance(x2[i], x1[j]))
-              * std::exp(-1.0 * (pow(3.0, 0.5) / l)
-                         * stan::math::squared_distance(x2[i], x1[j])),
-          cov(i, j))
+      EXPECT_FLOAT_EQ(sigma * sigma *
+                          (1.0 +
+                           (pow(3.0, 0.5) / l) *
+                               stan::math::squared_distance(x2[i], x1[j])) *
+                          std::exp(-1.0 * (pow(3.0, 0.5) / l) *
+                                   stan::math::squared_distance(x2[i], x1[j])),
+                      cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -423,8 +416,8 @@ TEST(MathPrimMat, vec_eigen_rvec_eigen_ard_gp_matern_3_2_cov1) {
         temp += stan::math::squared_distance(x1[i], x2[j]) / l[k];
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp))
-                          * std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp)) *
+                          std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
                       cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -437,8 +430,8 @@ TEST(MathPrimMat, vec_eigen_rvec_eigen_ard_gp_matern_3_2_cov1) {
         temp += stan::math::squared_distance(x2[i], x1[j]) / l[k];
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp))
-                          * std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp)) *
+                          std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
                       cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -465,14 +458,13 @@ TEST(MathPrimMat, rvec_eigen_rvec_eigen_gp_matern_3_2_cov1) {
   cov = stan::math::gp_matern_3_2_cov(x1, x2, sigma, l);
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
-      EXPECT_FLOAT_EQ(
-          sigma * sigma
-              * (1.0
-                 + (pow(3.0, 0.5) / l)
-                       * stan::math::squared_distance(x1[i], x2[j]))
-              * std::exp(-1.0 * (pow(3.0, 0.5) / l)
-                         * stan::math::squared_distance(x1[i], x2[j])),
-          cov(i, j))
+      EXPECT_FLOAT_EQ(sigma * sigma *
+                          (1.0 +
+                           (pow(3.0, 0.5) / l) *
+                               stan::math::squared_distance(x1[i], x2[j])) *
+                          std::exp(-1.0 * (pow(3.0, 0.5) / l) *
+                                   stan::math::squared_distance(x1[i], x2[j])),
+                      cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -480,14 +472,13 @@ TEST(MathPrimMat, rvec_eigen_rvec_eigen_gp_matern_3_2_cov1) {
   cov = stan::math::gp_matern_3_2_cov(x2, x1, sigma, l);
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
-      EXPECT_FLOAT_EQ(
-          sigma * sigma
-              * (1.0
-                 + (pow(3.0, 0.5) / l)
-                       * stan::math::squared_distance(x2[i], x1[j]))
-              * std::exp(-1.0 * (pow(3.0, 0.5) / l)
-                         * stan::math::squared_distance(x2[i], x1[j])),
-          cov(i, j))
+      EXPECT_FLOAT_EQ(sigma * sigma *
+                          (1.0 +
+                           (pow(3.0, 0.5) / l) *
+                               stan::math::squared_distance(x2[i], x1[j])) *
+                          std::exp(-1.0 * (pow(3.0, 0.5) / l) *
+                                   stan::math::squared_distance(x2[i], x1[j])),
+                      cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
@@ -523,8 +514,8 @@ TEST(MathPrimMat, rvec_eigen_rvec_eigen_ard_gp_matern_3_2_cov1) {
         temp += stan::math::squared_distance(x1[i], x2[j]) / l[k];
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp))
-                          * std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp)) *
+                          std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
                       cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -537,8 +528,8 @@ TEST(MathPrimMat, rvec_eigen_rvec_eigen_ard_gp_matern_3_2_cov1) {
         temp += stan::math::squared_distance(x2[i], x1[j]) / l[k];
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp))
-                          * std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp)) *
+                          std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
                       cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -576,152 +567,144 @@ TEST(MathPrimMat, vec_eigen_mixed_gp_matern_3_2_cov2) {
     x2_vec[i] << 2 * i, 3 * i, 4 * i;
   }
   Eigen::MatrixXd cov;
-  EXPECT_NO_THROW(cov
-                  = stan::math::gp_matern_3_2_cov(x1_rvec, x2_vec, sigma, l));
+  EXPECT_NO_THROW(cov =
+                      stan::math::gp_matern_3_2_cov(x1_rvec, x2_vec, sigma, l));
   EXPECT_EQ(3, cov.rows());
   EXPECT_EQ(4, cov.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-          sigma * sigma
-              * (1.0
-                 + (pow(3.0, 0.5) / l)
-                       * stan::math::squared_distance(x1_rvec[i], x2_vec[j]))
-              * std::exp(-1.0 * (pow(3.0, 0.5) / l)
-                         * stan::math::squared_distance(x1_rvec[i], x2_vec[j])),
+          sigma * sigma * (1.0 +
+                           (pow(3.0, 0.5) / l) * stan::math::squared_distance(
+                                                     x1_rvec[i], x2_vec[j])) *
+              std::exp(-1.0 * (pow(3.0, 0.5) / l) *
+                       stan::math::squared_distance(x1_rvec[i], x2_vec[j])),
           cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov7;
-  EXPECT_NO_THROW(cov7
-                  = stan::math::gp_matern_3_2_cov(x2_vec, x1_rvec, sigma, l));
+  EXPECT_NO_THROW(cov7 =
+                      stan::math::gp_matern_3_2_cov(x2_vec, x1_rvec, sigma, l));
   EXPECT_EQ(4, cov7.rows());
   EXPECT_EQ(3, cov7.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-          sigma * sigma
-              * (1.0
-                 + (pow(3.0, 0.5) / l)
-                       * stan::math::squared_distance(x2_vec[i], x1_rvec[j]))
-              * std::exp(-1.0 * (pow(3.0, 0.5) / l)
-                         * stan::math::squared_distance(x2_vec[i], x1_rvec[j])),
+          sigma * sigma * (1.0 +
+                           (pow(3.0, 0.5) / l) * stan::math::squared_distance(
+                                                     x2_vec[i], x1_rvec[j])) *
+              std::exp(-1.0 * (pow(3.0, 0.5) / l) *
+                       stan::math::squared_distance(x2_vec[i], x1_rvec[j])),
           cov7(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov2;
-  EXPECT_NO_THROW(cov2
-                  = stan::math::gp_matern_3_2_cov(x1_vec, x2_rvec, sigma, l));
+  EXPECT_NO_THROW(cov2 =
+                      stan::math::gp_matern_3_2_cov(x1_vec, x2_rvec, sigma, l));
   EXPECT_EQ(3, cov2.rows());
   EXPECT_EQ(4, cov2.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-          sigma * sigma
-              * (1.0
-                 + (pow(3.0, 0.5) / l)
-                       * stan::math::squared_distance(x1_vec[i], x2_rvec[j]))
-              * std::exp(-1.0 * (pow(3.0, 0.5) / l)
-                         * stan::math::squared_distance(x1_vec[i], x2_rvec[j])),
+          sigma * sigma * (1.0 +
+                           (pow(3.0, 0.5) / l) * stan::math::squared_distance(
+                                                     x1_vec[i], x2_rvec[j])) *
+              std::exp(-1.0 * (pow(3.0, 0.5) / l) *
+                       stan::math::squared_distance(x1_vec[i], x2_rvec[j])),
           cov2(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov8;
-  EXPECT_NO_THROW(cov8
-                  = stan::math::gp_matern_3_2_cov(x2_rvec, x1_vec, sigma, l));
+  EXPECT_NO_THROW(cov8 =
+                      stan::math::gp_matern_3_2_cov(x2_rvec, x1_vec, sigma, l));
   EXPECT_EQ(4, cov8.rows());
   EXPECT_EQ(3, cov8.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-          sigma * sigma
-              * (1.0
-                 + (pow(3.0, 0.5) / l)
-                       * stan::math::squared_distance(x2_rvec[i], x1_vec[j]))
-              * std::exp(-1.0 * (pow(3.0, 0.5) / l)
-                         * stan::math::squared_distance(x2_rvec[i], x1_vec[j])),
+          sigma * sigma * (1.0 +
+                           (pow(3.0, 0.5) / l) * stan::math::squared_distance(
+                                                     x2_rvec[i], x1_vec[j])) *
+              std::exp(-1.0 * (pow(3.0, 0.5) / l) *
+                       stan::math::squared_distance(x2_rvec[i], x1_vec[j])),
           cov8(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov3;
-  EXPECT_NO_THROW(cov3
-                  = stan::math::gp_matern_3_2_cov(x2_vec, x2_rvec, sigma, l));
+  EXPECT_NO_THROW(cov3 =
+                      stan::math::gp_matern_3_2_cov(x2_vec, x2_rvec, sigma, l));
   EXPECT_EQ(4, cov3.rows());
   EXPECT_EQ(4, cov3.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-          sigma * sigma
-              * (1.0
-                 + (pow(3.0, 0.5) / l)
-                       * stan::math::squared_distance(x2_vec[i], x2_rvec[j]))
-              * std::exp(-1.0 * (pow(3.0, 0.5) / l)
-                         * stan::math::squared_distance(x2_vec[i], x2_rvec[j])),
+          sigma * sigma * (1.0 +
+                           (pow(3.0, 0.5) / l) * stan::math::squared_distance(
+                                                     x2_vec[i], x2_rvec[j])) *
+              std::exp(-1.0 * (pow(3.0, 0.5) / l) *
+                       stan::math::squared_distance(x2_vec[i], x2_rvec[j])),
           cov3(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov4;
-  EXPECT_NO_THROW(cov4
-                  = stan::math::gp_matern_3_2_cov(x2_rvec, x2_vec, sigma, l));
+  EXPECT_NO_THROW(cov4 =
+                      stan::math::gp_matern_3_2_cov(x2_rvec, x2_vec, sigma, l));
   EXPECT_EQ(4, cov4.rows());
   EXPECT_EQ(4, cov4.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-          sigma * sigma
-              * (1.0
-                 + (pow(3.0, 0.5) / l)
-                       * stan::math::squared_distance(x2_rvec[i], x2_vec[j]))
-              * std::exp(-1.0 * (pow(3.0, 0.5) / l)
-                         * stan::math::squared_distance(x2_rvec[i], x2_vec[j])),
+          sigma * sigma * (1.0 +
+                           (pow(3.0, 0.5) / l) * stan::math::squared_distance(
+                                                     x2_rvec[i], x2_vec[j])) *
+              std::exp(-1.0 * (pow(3.0, 0.5) / l) *
+                       stan::math::squared_distance(x2_rvec[i], x2_vec[j])),
           cov4(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov5;
-  EXPECT_NO_THROW(cov5
-                  = stan::math::gp_matern_3_2_cov(x1_rvec, x1_vec, sigma, l));
+  EXPECT_NO_THROW(cov5 =
+                      stan::math::gp_matern_3_2_cov(x1_rvec, x1_vec, sigma, l));
   EXPECT_EQ(3, cov5.rows());
   EXPECT_EQ(3, cov5.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-          sigma * sigma
-              * (1.0
-                 + (pow(3.0, 0.5) / l)
-                       * stan::math::squared_distance(x1_rvec[i], x1_vec[j]))
-              * std::exp(-1.0 * (pow(3.0, 0.5) / l)
-                         * stan::math::squared_distance(x1_rvec[i], x1_vec[j])),
+          sigma * sigma * (1.0 +
+                           (pow(3.0, 0.5) / l) * stan::math::squared_distance(
+                                                     x1_rvec[i], x1_vec[j])) *
+              std::exp(-1.0 * (pow(3.0, 0.5) / l) *
+                       stan::math::squared_distance(x1_rvec[i], x1_vec[j])),
           cov5(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov6;
-  EXPECT_NO_THROW(cov6
-                  = stan::math::gp_matern_3_2_cov(x1_vec, x1_rvec, sigma, l));
+  EXPECT_NO_THROW(cov6 =
+                      stan::math::gp_matern_3_2_cov(x1_vec, x1_rvec, sigma, l));
   EXPECT_EQ(3, cov6.rows());
   EXPECT_EQ(3, cov6.cols());
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       EXPECT_FLOAT_EQ(
-          sigma * sigma
-              * (1.0
-                 + (pow(3.0, 0.5) / l)
-                       * stan::math::squared_distance(x1_vec[i], x1_rvec[j]))
-              * std::exp(-1.0 * (pow(3.0, 0.5) / l)
-                         * stan::math::squared_distance(x1_vec[i], x1_rvec[j])),
+          sigma * sigma * (1.0 +
+                           (pow(3.0, 0.5) / l) * stan::math::squared_distance(
+                                                     x1_vec[i], x1_rvec[j])) *
+              std::exp(-1.0 * (pow(3.0, 0.5) / l) *
+                       stan::math::squared_distance(x1_vec[i], x1_rvec[j])),
           cov6(i, j))
           << "index: (" << i << ", " << j << ")";
     }
@@ -764,8 +747,8 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_matern_3_2_cov2) {
     x2_vec[i] << 2 * i, 3 * i, 4 * i;
   }
   Eigen::MatrixXd cov;
-  EXPECT_NO_THROW(cov
-                  = stan::math::gp_matern_3_2_cov(x1_rvec, x2_vec, sigma, l));
+  EXPECT_NO_THROW(cov =
+                      stan::math::gp_matern_3_2_cov(x1_rvec, x2_vec, sigma, l));
   EXPECT_EQ(3, cov.rows());
   EXPECT_EQ(4, cov.cols());
   for (int i = 0; i < 3; i++) {
@@ -775,16 +758,16 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_matern_3_2_cov2) {
         temp += stan::math::squared_distance(x1_rvec[i], x2_vec[j]) / l[k];
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp))
-                          * std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp)) *
+                          std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
                       cov(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov7;
-  EXPECT_NO_THROW(cov7
-                  = stan::math::gp_matern_3_2_cov(x2_vec, x1_rvec, sigma, l));
+  EXPECT_NO_THROW(cov7 =
+                      stan::math::gp_matern_3_2_cov(x2_vec, x1_rvec, sigma, l));
   EXPECT_EQ(4, cov7.rows());
   EXPECT_EQ(3, cov7.cols());
   for (int i = 0; i < 3; i++) {
@@ -794,16 +777,16 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_matern_3_2_cov2) {
         temp += stan::math::squared_distance(x2_vec[i], x1_rvec[j]) / l[k];
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp))
-                          * std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp)) *
+                          std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
                       cov7(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov2;
-  EXPECT_NO_THROW(cov2
-                  = stan::math::gp_matern_3_2_cov(x1_vec, x2_rvec, sigma, l));
+  EXPECT_NO_THROW(cov2 =
+                      stan::math::gp_matern_3_2_cov(x1_vec, x2_rvec, sigma, l));
   EXPECT_EQ(3, cov2.rows());
   EXPECT_EQ(4, cov2.cols());
   for (int i = 0; i < 3; i++) {
@@ -813,16 +796,16 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_matern_3_2_cov2) {
         temp += stan::math::squared_distance(x1_vec[i], x2_rvec[j]) / l[k];
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp))
-                          * std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp)) *
+                          std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
                       cov2(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov8;
-  EXPECT_NO_THROW(cov8
-                  = stan::math::gp_matern_3_2_cov(x2_rvec, x1_vec, sigma, l));
+  EXPECT_NO_THROW(cov8 =
+                      stan::math::gp_matern_3_2_cov(x2_rvec, x1_vec, sigma, l));
   EXPECT_EQ(4, cov8.rows());
   EXPECT_EQ(3, cov8.cols());
   for (int i = 0; i < 3; i++) {
@@ -832,16 +815,16 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_matern_3_2_cov2) {
         temp += stan::math::squared_distance(x2_rvec[i], x1_vec[j]) / l[k];
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp))
-                          * std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp)) *
+                          std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
                       cov8(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov3;
-  EXPECT_NO_THROW(cov3
-                  = stan::math::gp_matern_3_2_cov(x2_vec, x2_rvec, sigma, l));
+  EXPECT_NO_THROW(cov3 =
+                      stan::math::gp_matern_3_2_cov(x2_vec, x2_rvec, sigma, l));
   EXPECT_EQ(4, cov3.rows());
   EXPECT_EQ(4, cov3.cols());
   for (int i = 0; i < 3; i++) {
@@ -851,16 +834,16 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_matern_3_2_cov2) {
         temp += stan::math::squared_distance(x2_vec[i], x2_rvec[j]) / l[k];
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp))
-                          * std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp)) *
+                          std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
                       cov3(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov4;
-  EXPECT_NO_THROW(cov4
-                  = stan::math::gp_matern_3_2_cov(x2_rvec, x2_vec, sigma, l));
+  EXPECT_NO_THROW(cov4 =
+                      stan::math::gp_matern_3_2_cov(x2_rvec, x2_vec, sigma, l));
   EXPECT_EQ(4, cov4.rows());
   EXPECT_EQ(4, cov4.cols());
   for (int i = 0; i < 3; i++) {
@@ -870,16 +853,16 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_matern_3_2_cov2) {
         temp += stan::math::squared_distance(x2_rvec[i], x2_vec[j]) / l[k];
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp))
-                          * std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp)) *
+                          std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
                       cov4(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov5;
-  EXPECT_NO_THROW(cov5
-                  = stan::math::gp_matern_3_2_cov(x1_rvec, x1_vec, sigma, l));
+  EXPECT_NO_THROW(cov5 =
+                      stan::math::gp_matern_3_2_cov(x1_rvec, x1_vec, sigma, l));
   EXPECT_EQ(3, cov5.rows());
   EXPECT_EQ(3, cov5.cols());
   for (int i = 0; i < 3; i++) {
@@ -889,16 +872,16 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_matern_3_2_cov2) {
         temp += stan::math::squared_distance(x1_rvec[i], x1_vec[j]) / l[k];
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp))
-                          * std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp)) *
+                          std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
                       cov5(i, j))
           << "index: (" << i << ", " << j << ")";
     }
   }
 
   Eigen::MatrixXd cov6;
-  EXPECT_NO_THROW(cov6
-                  = stan::math::gp_matern_3_2_cov(x1_vec, x1_rvec, sigma, l));
+  EXPECT_NO_THROW(cov6 =
+                      stan::math::gp_matern_3_2_cov(x1_vec, x1_rvec, sigma, l));
   EXPECT_EQ(3, cov6.rows());
   EXPECT_EQ(3, cov6.cols());
   for (int i = 0; i < 3; i++) {
@@ -908,8 +891,8 @@ TEST(MathPrimMat, vec_eigen_mixed_ard_gp_matern_3_2_cov2) {
         temp += stan::math::squared_distance(x1_vec[i], x1_rvec[j]) / l[k];
       }
 
-      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp))
-                          * std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp)) *
+                          std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
                       cov6(i, j))
           << "index: (" << i << ", " << j << ")";
     }

--- a/test/unit/math/prim/mat/fun/gp_matern_3_2_cov_test.cpp
+++ b/test/unit/math/prim/mat/fun/gp_matern_3_2_cov_test.cpp
@@ -1,0 +1,1229 @@
+#include <gtest/gtest.h>
+#include <stan/math/prim/mat.hpp>
+#include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <cmath>
+#include <limits>
+#include <string>
+#include <vector>
+
+template <typename T_x, typename T_s, typename T_l>
+std::string pull_msg(std::vector<T_x> x, T_s sigma, T_l l) {
+  std::string message;
+  try {
+    stan::math::gp_matern_3_2_cov(x, sigma, l);
+  } catch (std::domain_error &e) {
+    message = e.what();
+  } catch (...) {
+    message = "Threw the wrong exception";
+  }
+  return message;
+}
+
+template <typename T_x1, typename T_x2, typename T_s, typename T_l>
+std::string pull_msg(std::vector<T_x1> x1, std::vector<T_x2> x2, T_s sigma,
+                     T_l l) {
+  std::string message;
+  try {
+    stan::math::gp_matern_3_2_cov(x1, x2, sigma, l);
+  } catch (std::domain_error &e) {
+    message = e.what();
+  } catch (...) {
+    message = "Threw the wrong exception";
+  }
+  return message;
+}
+
+TEST(MathPrimMat, vec_double_gp_matern_3_2_cov1) {
+  double sigma = 0.2;
+  double l = 5.0;
+
+  std::vector<double> x(3);
+  x[0] = -2;
+  x[1] = -1;
+  x[2] = -0.5;
+
+  Eigen::MatrixXd cov;
+  cov = stan::math::gp_matern_3_2_cov(x, sigma, l);
+  for (int i = 0; i < 3; i++)
+    for (int j = 0; j < 3; j++)
+      EXPECT_FLOAT_EQ(
+          sigma * sigma
+              * (1.0
+                 + (pow(3.0, 0.5) / l)
+                       * stan::math::squared_distance(x[i], x[j]))
+              * std::exp(-1.0 * (pow(3.0, 0.5) / l)
+                         * stan::math::squared_distance(x[i], x[j])),
+          cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+}
+
+TEST(MathPrimMat, vec_double_ard_gp_matern_3_2_cov1) {
+  double sigma = 0.2;
+  double temp;
+
+  std::vector<double> x(3);
+  x[0] = -2;
+  x[1] = -1;
+  x[2] = -0.5;
+
+  std::vector<double> l(5);
+  l[0] = 0.1;
+  l[1] = 0.2;
+  l[2] = 0.3;
+  l[3] = 0.4;
+  l[4] = 0.5;
+
+  Eigen::MatrixXd cov;
+  cov = stan::math::gp_matern_3_2_cov(x, sigma, l);
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 5; k++) {
+        temp += stan::math::squared_distance(x[i], x[j]) / l[k];
+      }
+
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp))
+                          * std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
+                      cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+}
+
+TEST(MathPrimMat, vec_eigen_gp_matern_3_2_cov1) {
+  double l = 0.2;
+  double sigma = 0.3;
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x1(3);
+  for (size_t i = 0; i < x1.size(); ++i) {
+    x1[i].resize(1, 3);
+    x1[i] << 1 * i, 2 * i, 3 * i;
+  }
+
+  Eigen::MatrixXd cov;
+  cov = stan::math::gp_matern_3_2_cov(x1, sigma, l);
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      EXPECT_FLOAT_EQ(
+          sigma * sigma
+              * (1.0
+                 + (pow(3.0, 0.5) / l)
+                       * stan::math::squared_distance(x1[i], x1[j]))
+              * std::exp(-1.0 * (pow(3.0, 0.5) / l)
+                         * stan::math::squared_distance(x1[i], x1[j])),
+          cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+}
+
+TEST(MathPrimMat, vec_eigen_eigen_gp_matern_3_2_cov1) {
+  double l = 0.2;
+  double sigma = 0.3;
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x1(3);
+  for (size_t i = 0; i < x1.size(); ++i) {
+    x1[i].resize(1, 3);
+    x1[i] << 1 * i, 2 * i, 3 * i;
+  }
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x2(3);
+  for (size_t i = 0; i < x2.size(); ++i) {
+    x2[i].resize(1, 3);
+    x2[i] << 2 * i, 3 * i, 4 * i;
+  }
+
+  Eigen::MatrixXd cov;
+  cov = stan::math::gp_matern_3_2_cov(x1, x2, sigma, l);
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      EXPECT_FLOAT_EQ(
+          sigma * sigma
+              * (1.0
+                 + (pow(3.0, 0.5) / l)
+                       * stan::math::squared_distance(x1[i], x2[j]))
+              * std::exp(-1.0 * (pow(3.0, 0.5) / l)
+                         * stan::math::squared_distance(x1[i], x2[j])),
+          cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+}
+
+TEST(MathPrimMat, vec_double_double_gp_matern_3_2_cov1) {
+  double sigma = 0.2;
+  double l = 5.0;
+
+  std::vector<double> x1(3);
+  x1[0] = -2;
+  x1[1] = -1;
+  x1[2] = -0.5;
+
+  std::vector<double> x2(3);
+  x2[0] = 3;
+  x2[1] = -4;
+  x2[2] = -0.7;
+
+  Eigen::MatrixXd cov;
+  cov = stan::math::gp_matern_3_2_cov(x1, x2, sigma, l);
+  for (int i = 0; i < 3; i++)
+    for (int j = 0; j < 3; j++)
+      EXPECT_FLOAT_EQ(
+          sigma * sigma
+              * (1.0
+                 + (pow(3.0, 0.5) / l)
+                       * stan::math::squared_distance(x1[i], x2[j]))
+              * std::exp(-1.0 * (pow(3.0, 0.5) / l)
+                         * stan::math::squared_distance(x1[i], x2[j])),
+          cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+}
+
+TEST(MathPrimMat, vec_eigen_ard_gp_matern_3_2_cov1) {
+  double sigma = 0.3;
+  double temp;
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x1(3);
+  for (size_t i = 0; i < x1.size(); ++i) {
+    x1[i].resize(1, 3);
+    x1[i] << 1 * i, 2 * i, 3 * i;
+  }
+
+  std::vector<double> l(5);
+  l[0] = 0.1;
+  l[1] = 0.2;
+  l[2] = 0.3;
+  l[3] = 0.4;
+  l[4] = 0.5;
+
+  Eigen::MatrixXd cov;
+  cov = stan::math::gp_matern_3_2_cov(x1, sigma, l);
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 5; k++) {
+        temp += stan::math::squared_distance(x1[i], x1[j]) / l[k];
+      }
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp))
+                          * std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
+                      cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+}
+
+TEST(MathPrimMat, vec_double_double_ard_gp_matern_3_2_cov1) {
+  double sigma = 0.2;
+  double temp;
+
+  std::vector<double> x1(3);
+  x1[0] = -2;
+  x1[1] = -1;
+  x1[2] = -0.5;
+
+  std::vector<double> x2(3);
+  x2[0] = 3;
+  x2[1] = -4;
+  x2[2] = -0.7;
+
+  std::vector<double> l(4);
+  l[0] = 1;
+  l[1] = 2;
+  l[2] = 3;
+  l[3] = 4;
+
+  Eigen::MatrixXd cov;
+  cov = stan::math::gp_matern_3_2_cov(x1, x2, sigma, l);
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 4; k++) {
+        temp += stan::math::squared_distance(x1[i], x2[j]) / l[k];
+      }
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * pow(temp, 0.5))
+                          * std::exp(-1.0 * pow(3.0, 0.5) * pow(temp, 0.5)),
+                      cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+}
+
+TEST(MathPrimMat, vec_eigen_eigen_ard_gp_matern_3_2_cov1) {
+  double sigma = 0.2;
+  double temp;
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x1(3);
+  for (size_t i = 0; i < x1.size(); ++i) {
+    x1[i].resize(1, 3);
+    x1[i] << 1 * i, 2 * i, 3 * i;
+  }
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x2(3);
+  for (size_t i = 0; i < x2.size(); ++i) {
+    x2[i].resize(1, 3);
+    x2[i] << 2 * i, 3 * i, 4 * i;
+  }
+
+  std::vector<double> l(4);
+  l[0] = 1;
+  l[1] = 2;
+  l[2] = 3;
+  l[3] = 4;
+
+  Eigen::MatrixXd cov;
+  cov = stan::math::gp_matern_3_2_cov(x1, x2, sigma, l);
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 4; k++) {
+        temp += stan::math::squared_distance(x1[i], x2[j]) / l[k];
+      }
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * pow(temp, 0.5))
+                          * std::exp(-1.0 * pow(3.0, 0.5) * pow(temp, 0.5)),
+                      cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+}
+
+TEST(MathPrimMat, rvec_eigen_gp_matern_3_2_cov1) {
+  double l = 0.2;
+  double sigma = 0.3;
+
+  std::vector<Eigen::Matrix<double, -1, 1>> x1(3);
+  for (size_t i = 0; i < x1.size(); ++i) {
+    x1[i].resize(3, 1);
+    x1[i] << 1 * i, 2 * i, 3 * i;
+  }
+
+  Eigen::MatrixXd cov;
+  cov = stan::math::gp_matern_3_2_cov(x1, sigma, l);
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      EXPECT_FLOAT_EQ(
+          sigma * sigma
+              * (1.0
+                 + (pow(3.0, 0.5) / l)
+                       * stan::math::squared_distance(x1[i], x1[j]))
+              * std::exp(-1.0 * (pow(3.0, 0.5) / l)
+                         * stan::math::squared_distance(x1[i], x1[j])),
+          cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+}
+
+TEST(MathPrimMat, rvec_eigen_ard_gp_matern_3_2_cov1) {
+  double sigma = 0.3;
+  double temp;
+
+  std::vector<Eigen::Matrix<double, -1, 1>> x1(3);
+  for (size_t i = 0; i < x1.size(); ++i) {
+    x1[i].resize(3, 1);
+    x1[i] << 1 * i, 2 * i, 3 * i;
+  }
+
+  std::vector<double> l(4);
+  l[0] = 1;
+  l[1] = 2;
+  l[2] = 3;
+  l[3] = 4;
+
+  Eigen::MatrixXd cov;
+  cov = stan::math::gp_matern_3_2_cov(x1, sigma, l);
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 4; k++) {
+        temp += stan::math::squared_distance(x1[i], x1[j]) / l[k];
+      }
+
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp))
+                          * std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
+                      cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+}
+
+TEST(MathPrimMat, vec_eigen_rvec_eigen_gp_matern_3_2_cov1) {
+  double sigma = 0.3;
+  double l = 2.3;
+
+  std::vector<Eigen::Matrix<double, -1, 1>> x1(3);
+  for (size_t i = 0; i < x1.size(); ++i) {
+    x1[i].resize(3, 1);
+    x1[i] << 1 * i, 2 * i, 3 * i;
+  }
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x2(3);
+  for (size_t i = 0; i < x2.size(); ++i) {
+    x2[i].resize(1, 3);
+    x2[i] << 2 * i, 3 * i, 4 * i;
+  }
+
+  Eigen::MatrixXd cov;
+  cov = stan::math::gp_matern_3_2_cov(x1, x2, sigma, l);
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      EXPECT_FLOAT_EQ(
+          sigma * sigma
+              * (1.0
+                 + (pow(3.0, 0.5) / l)
+                       * stan::math::squared_distance(x1[i], x2[j]))
+              * std::exp(-1.0 * (pow(3.0, 0.5) / l)
+                         * stan::math::squared_distance(x1[i], x2[j])),
+          cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+
+  cov = stan::math::gp_matern_3_2_cov(x2, x1, sigma, l);
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      EXPECT_FLOAT_EQ(
+          sigma * sigma
+              * (1.0
+                 + (pow(3.0, 0.5) / l)
+                       * stan::math::squared_distance(x2[i], x1[j]))
+              * std::exp(-1.0 * (pow(3.0, 0.5) / l)
+                         * stan::math::squared_distance(x2[i], x1[j])),
+          cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+}
+
+TEST(MathPrimMat, vec_eigen_rvec_eigen_ard_gp_matern_3_2_cov1) {
+  double sigma = 0.3;
+  double temp = 0;
+  std::vector<double> l(3);
+  l[0] = 1;
+  l[1] = 2;
+  l[2] = 3;
+
+  std::vector<Eigen::Matrix<double, -1, 1>> x1(3);
+  for (size_t i = 0; i < x1.size(); ++i) {
+    x1[i].resize(3, 1);
+    x1[i] << 1 * i, 2 * i, 3 * i;
+  }
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x2(3);
+  for (size_t i = 0; i < x2.size(); ++i) {
+    x2[i].resize(1, 3);
+    x2[i] << 2 * i, 3 * i, 4 * i;
+  }
+
+  Eigen::MatrixXd cov;
+  cov = stan::math::gp_matern_3_2_cov(x1, x2, sigma, l);
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 3; k++) {
+        temp += stan::math::squared_distance(x1[i], x2[j]) / l[k];
+      }
+
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp))
+                          * std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
+                      cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+  cov = stan::math::gp_matern_3_2_cov(x2, x1, sigma, l);
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 3; k++) {
+        temp += stan::math::squared_distance(x2[i], x1[j]) / l[k];
+      }
+
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp))
+                          * std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
+                      cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+}
+
+TEST(MathPrimMat, rvec_eigen_rvec_eigen_gp_matern_3_2_cov1) {
+  double sigma = 0.3;
+  double l = 2.3;
+
+  std::vector<Eigen::Matrix<double, -1, 1>> x1(3);
+  for (size_t i = 0; i < x1.size(); ++i) {
+    x1[i].resize(3, 1);
+    x1[i] << 1 * i, 2 * i, 3 * i;
+  }
+
+  std::vector<Eigen::Matrix<double, -1, 1>> x2(3);
+  for (size_t i = 0; i < x2.size(); ++i) {
+    x2[i].resize(3, 1);
+    x2[i] << 2 * i, 3 * i, 4 * i;
+  }
+
+  Eigen::MatrixXd cov;
+  cov = stan::math::gp_matern_3_2_cov(x1, x2, sigma, l);
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      EXPECT_FLOAT_EQ(
+          sigma * sigma
+              * (1.0
+                 + (pow(3.0, 0.5) / l)
+                       * stan::math::squared_distance(x1[i], x2[j]))
+              * std::exp(-1.0 * (pow(3.0, 0.5) / l)
+                         * stan::math::squared_distance(x1[i], x2[j])),
+          cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+
+  cov = stan::math::gp_matern_3_2_cov(x2, x1, sigma, l);
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      EXPECT_FLOAT_EQ(
+          sigma * sigma
+              * (1.0
+                 + (pow(3.0, 0.5) / l)
+                       * stan::math::squared_distance(x2[i], x1[j]))
+              * std::exp(-1.0 * (pow(3.0, 0.5) / l)
+                         * stan::math::squared_distance(x2[i], x1[j])),
+          cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+}
+
+TEST(MathPrimMat, rvec_eigen_rvec_eigen_ard_gp_matern_3_2_cov1) {
+  double sigma = 0.3;
+  double temp;
+
+  std::vector<double> l(3);
+  l[0] = 1;
+  l[1] = 2;
+  l[2] = 3;
+
+  std::vector<Eigen::Matrix<double, -1, 1>> x1(3);
+  for (size_t i = 0; i < x1.size(); ++i) {
+    x1[i].resize(3, 1);
+    x1[i] << 1 * i, 2 * i, 3 * i;
+  }
+
+  std::vector<Eigen::Matrix<double, -1, 1>> x2(3);
+  for (size_t i = 0; i < x2.size(); ++i) {
+    x2[i].resize(3, 1);
+    x2[i] << 2 * i, 3 * i, 4 * i;
+  }
+
+  Eigen::MatrixXd cov;
+  cov = stan::math::gp_matern_3_2_cov(x1, x2, sigma, l);
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 3; k++) {
+        temp += stan::math::squared_distance(x1[i], x2[j]) / l[k];
+      }
+
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp))
+                          * std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
+                      cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+  cov = stan::math::gp_matern_3_2_cov(x2, x1, sigma, l);
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 3; k++) {
+        temp += stan::math::squared_distance(x2[i], x1[j]) / l[k];
+      }
+
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp))
+                          * std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
+                      cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+}
+
+TEST(MathPrimMat, vec_eigen_mixed_gp_matern_3_2_cov2) {
+  using stan::math::squared_distance;
+  double sigma = 0.2;
+  double l = 5;
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x1_rvec(3);
+  std::vector<Eigen::Matrix<double, 1, -1>> x2_rvec(4);
+
+  for (size_t i = 0; i < x1_rvec.size(); ++i) {
+    x1_rvec[i].resize(1, 3);
+    x1_rvec[i] << 1 * i, 2 * i, 3 * i;
+  }
+
+  for (size_t i = 0; i < x2_rvec.size(); ++i) {
+    x2_rvec[i].resize(1, 3);
+    x2_rvec[i] << 2 * i, 3 * i, 4 * i;
+  }
+
+  std::vector<Eigen::Matrix<double, -1, 1>> x1_vec(3);
+  std::vector<Eigen::Matrix<double, -1, 1>> x2_vec(4);
+
+  for (size_t i = 0; i < x1_vec.size(); ++i) {
+    x1_vec[i].resize(3, 1);
+    x1_vec[i] << 1 * i, 2 * i, 3 * i;
+  }
+
+  for (size_t i = 0; i < x2_vec.size(); ++i) {
+    x2_vec[i].resize(3, 1);
+    x2_vec[i] << 2 * i, 3 * i, 4 * i;
+  }
+  Eigen::MatrixXd cov;
+  EXPECT_NO_THROW(cov
+                  = stan::math::gp_matern_3_2_cov(x1_rvec, x2_vec, sigma, l));
+  EXPECT_EQ(3, cov.rows());
+  EXPECT_EQ(4, cov.cols());
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      EXPECT_FLOAT_EQ(
+          sigma * sigma
+              * (1.0
+                 + (pow(3.0, 0.5) / l)
+                       * stan::math::squared_distance(x1_rvec[i], x2_vec[j]))
+              * std::exp(-1.0 * (pow(3.0, 0.5) / l)
+                         * stan::math::squared_distance(x1_rvec[i], x2_vec[j])),
+          cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+
+  Eigen::MatrixXd cov7;
+  EXPECT_NO_THROW(cov7
+                  = stan::math::gp_matern_3_2_cov(x2_vec, x1_rvec, sigma, l));
+  EXPECT_EQ(4, cov7.rows());
+  EXPECT_EQ(3, cov7.cols());
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      EXPECT_FLOAT_EQ(
+          sigma * sigma
+              * (1.0
+                 + (pow(3.0, 0.5) / l)
+                       * stan::math::squared_distance(x2_vec[i], x1_rvec[j]))
+              * std::exp(-1.0 * (pow(3.0, 0.5) / l)
+                         * stan::math::squared_distance(x2_vec[i], x1_rvec[j])),
+          cov7(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+
+  Eigen::MatrixXd cov2;
+  EXPECT_NO_THROW(cov2
+                  = stan::math::gp_matern_3_2_cov(x1_vec, x2_rvec, sigma, l));
+  EXPECT_EQ(3, cov2.rows());
+  EXPECT_EQ(4, cov2.cols());
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      EXPECT_FLOAT_EQ(
+          sigma * sigma
+              * (1.0
+                 + (pow(3.0, 0.5) / l)
+                       * stan::math::squared_distance(x1_vec[i], x2_rvec[j]))
+              * std::exp(-1.0 * (pow(3.0, 0.5) / l)
+                         * stan::math::squared_distance(x1_vec[i], x2_rvec[j])),
+          cov2(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+
+  Eigen::MatrixXd cov8;
+  EXPECT_NO_THROW(cov8
+                  = stan::math::gp_matern_3_2_cov(x2_rvec, x1_vec, sigma, l));
+  EXPECT_EQ(4, cov8.rows());
+  EXPECT_EQ(3, cov8.cols());
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      EXPECT_FLOAT_EQ(
+          sigma * sigma
+              * (1.0
+                 + (pow(3.0, 0.5) / l)
+                       * stan::math::squared_distance(x2_rvec[i], x1_vec[j]))
+              * std::exp(-1.0 * (pow(3.0, 0.5) / l)
+                         * stan::math::squared_distance(x2_rvec[i], x1_vec[j])),
+          cov8(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+
+  Eigen::MatrixXd cov3;
+  EXPECT_NO_THROW(cov3
+                  = stan::math::gp_matern_3_2_cov(x2_vec, x2_rvec, sigma, l));
+  EXPECT_EQ(4, cov3.rows());
+  EXPECT_EQ(4, cov3.cols());
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      EXPECT_FLOAT_EQ(
+          sigma * sigma
+              * (1.0
+                 + (pow(3.0, 0.5) / l)
+                       * stan::math::squared_distance(x2_vec[i], x2_rvec[j]))
+              * std::exp(-1.0 * (pow(3.0, 0.5) / l)
+                         * stan::math::squared_distance(x2_vec[i], x2_rvec[j])),
+          cov3(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+
+  Eigen::MatrixXd cov4;
+  EXPECT_NO_THROW(cov4
+                  = stan::math::gp_matern_3_2_cov(x2_rvec, x2_vec, sigma, l));
+  EXPECT_EQ(4, cov4.rows());
+  EXPECT_EQ(4, cov4.cols());
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      EXPECT_FLOAT_EQ(
+          sigma * sigma
+              * (1.0
+                 + (pow(3.0, 0.5) / l)
+                       * stan::math::squared_distance(x2_rvec[i], x2_vec[j]))
+              * std::exp(-1.0 * (pow(3.0, 0.5) / l)
+                         * stan::math::squared_distance(x2_rvec[i], x2_vec[j])),
+          cov4(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+
+  Eigen::MatrixXd cov5;
+  EXPECT_NO_THROW(cov5
+                  = stan::math::gp_matern_3_2_cov(x1_rvec, x1_vec, sigma, l));
+  EXPECT_EQ(3, cov5.rows());
+  EXPECT_EQ(3, cov5.cols());
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      EXPECT_FLOAT_EQ(
+          sigma * sigma
+              * (1.0
+                 + (pow(3.0, 0.5) / l)
+                       * stan::math::squared_distance(x1_rvec[i], x1_vec[j]))
+              * std::exp(-1.0 * (pow(3.0, 0.5) / l)
+                         * stan::math::squared_distance(x1_rvec[i], x1_vec[j])),
+          cov5(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+
+  Eigen::MatrixXd cov6;
+  EXPECT_NO_THROW(cov6
+                  = stan::math::gp_matern_3_2_cov(x1_vec, x1_rvec, sigma, l));
+  EXPECT_EQ(3, cov6.rows());
+  EXPECT_EQ(3, cov6.cols());
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      EXPECT_FLOAT_EQ(
+          sigma * sigma
+              * (1.0
+                 + (pow(3.0, 0.5) / l)
+                       * stan::math::squared_distance(x1_vec[i], x1_rvec[j]))
+              * std::exp(-1.0 * (pow(3.0, 0.5) / l)
+                         * stan::math::squared_distance(x1_vec[i], x1_rvec[j])),
+          cov6(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+}
+
+TEST(MathPrimMat, vec_eigen_mixed_ard_gp_matern_3_2_cov2) {
+  using stan::math::squared_distance;
+  double sigma = 0.2;
+  double temp;
+
+  std::vector<double> l(3);
+  l[0] = 1;
+  l[1] = 2;
+  l[2] = 3;
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x1_rvec(3);
+  std::vector<Eigen::Matrix<double, 1, -1>> x2_rvec(4);
+
+  for (size_t i = 0; i < x1_rvec.size(); ++i) {
+    x1_rvec[i].resize(1, 3);
+    x1_rvec[i] << 1 * i, 2 * i, 3 * i;
+  }
+
+  for (size_t i = 0; i < x2_rvec.size(); ++i) {
+    x2_rvec[i].resize(1, 3);
+    x2_rvec[i] << 2 * i, 3 * i, 4 * i;
+  }
+
+  std::vector<Eigen::Matrix<double, -1, 1>> x1_vec(3);
+  std::vector<Eigen::Matrix<double, -1, 1>> x2_vec(4);
+
+  for (size_t i = 0; i < x1_vec.size(); ++i) {
+    x1_vec[i].resize(3, 1);
+    x1_vec[i] << 1 * i, 2 * i, 3 * i;
+  }
+
+  for (size_t i = 0; i < x2_vec.size(); ++i) {
+    x2_vec[i].resize(3, 1);
+    x2_vec[i] << 2 * i, 3 * i, 4 * i;
+  }
+  Eigen::MatrixXd cov;
+  EXPECT_NO_THROW(cov
+                  = stan::math::gp_matern_3_2_cov(x1_rvec, x2_vec, sigma, l));
+  EXPECT_EQ(3, cov.rows());
+  EXPECT_EQ(4, cov.cols());
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 3; k++) {
+        temp += stan::math::squared_distance(x1_rvec[i], x2_vec[j]) / l[k];
+      }
+
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp))
+                          * std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
+                      cov(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+
+  Eigen::MatrixXd cov7;
+  EXPECT_NO_THROW(cov7
+                  = stan::math::gp_matern_3_2_cov(x2_vec, x1_rvec, sigma, l));
+  EXPECT_EQ(4, cov7.rows());
+  EXPECT_EQ(3, cov7.cols());
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 3; k++) {
+        temp += stan::math::squared_distance(x2_vec[i], x1_rvec[j]) / l[k];
+      }
+
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp))
+                          * std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
+                      cov7(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+
+  Eigen::MatrixXd cov2;
+  EXPECT_NO_THROW(cov2
+                  = stan::math::gp_matern_3_2_cov(x1_vec, x2_rvec, sigma, l));
+  EXPECT_EQ(3, cov2.rows());
+  EXPECT_EQ(4, cov2.cols());
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 3; k++) {
+        temp += stan::math::squared_distance(x1_vec[i], x2_rvec[j]) / l[k];
+      }
+
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp))
+                          * std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
+                      cov2(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+
+  Eigen::MatrixXd cov8;
+  EXPECT_NO_THROW(cov8
+                  = stan::math::gp_matern_3_2_cov(x2_rvec, x1_vec, sigma, l));
+  EXPECT_EQ(4, cov8.rows());
+  EXPECT_EQ(3, cov8.cols());
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 3; k++) {
+        temp += stan::math::squared_distance(x2_rvec[i], x1_vec[j]) / l[k];
+      }
+
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp))
+                          * std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
+                      cov8(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+
+  Eigen::MatrixXd cov3;
+  EXPECT_NO_THROW(cov3
+                  = stan::math::gp_matern_3_2_cov(x2_vec, x2_rvec, sigma, l));
+  EXPECT_EQ(4, cov3.rows());
+  EXPECT_EQ(4, cov3.cols());
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 3; k++) {
+        temp += stan::math::squared_distance(x2_vec[i], x2_rvec[j]) / l[k];
+      }
+
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp))
+                          * std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
+                      cov3(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+
+  Eigen::MatrixXd cov4;
+  EXPECT_NO_THROW(cov4
+                  = stan::math::gp_matern_3_2_cov(x2_rvec, x2_vec, sigma, l));
+  EXPECT_EQ(4, cov4.rows());
+  EXPECT_EQ(4, cov4.cols());
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 3; k++) {
+        temp += stan::math::squared_distance(x2_rvec[i], x2_vec[j]) / l[k];
+      }
+
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp))
+                          * std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
+                      cov4(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+
+  Eigen::MatrixXd cov5;
+  EXPECT_NO_THROW(cov5
+                  = stan::math::gp_matern_3_2_cov(x1_rvec, x1_vec, sigma, l));
+  EXPECT_EQ(3, cov5.rows());
+  EXPECT_EQ(3, cov5.cols());
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 3; k++) {
+        temp += stan::math::squared_distance(x1_rvec[i], x1_vec[j]) / l[k];
+      }
+
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp))
+                          * std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
+                      cov5(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+
+  Eigen::MatrixXd cov6;
+  EXPECT_NO_THROW(cov6
+                  = stan::math::gp_matern_3_2_cov(x1_vec, x1_rvec, sigma, l));
+  EXPECT_EQ(3, cov6.rows());
+  EXPECT_EQ(3, cov6.cols());
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      temp = 0;
+      for (int k = 0; k < 3; k++) {
+        temp += stan::math::squared_distance(x1_vec[i], x1_rvec[j]) / l[k];
+      }
+
+      EXPECT_FLOAT_EQ(sigma * sigma * (1.0 + pow(3.0, 0.5) * sqrt(temp))
+                          * std::exp(-1.0 * pow(3.0, 0.5) * sqrt(temp)),
+                      cov6(i, j))
+          << "index: (" << i << ", " << j << ")";
+    }
+  }
+}
+
+TEST(MathPrimMat, domain_err_training_sig_l_gamma) {
+  double sigma = .2;
+  double l = 7;
+  double sigma_bad = -1.0;
+  double l_bad = -1.0;
+
+  std::vector<double> l_vec(2);
+  l_vec[0] = 1;
+  l_vec[1] = 2;
+
+  std::vector<double> l_vec_bad(2);
+  l_vec_bad[0] = 1;
+  l_vec_bad[1] = -1;
+
+  std::vector<double> x(3);
+  x[0] = -2;
+  x[1] = -1;
+  x[2] = -0.5;
+
+  std::vector<Eigen::Matrix<double, -1, 1>> x_2(3);
+  for (size_t i = 0; i < x_2.size(); ++i) {
+    x_2[i].resize(3, 1);
+    x_2[i] << 1, 2, 3;
+  }
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x_3(3);
+  for (size_t i = 0; i < x_3.size(); ++i) {
+    x_3[i].resize(1, 3);
+    x_3[i] << 1, 2, 3;
+  }
+
+  std::string msg1, msg2, msg3, msg4;
+  msg1 = pull_msg(x, sigma, l_bad);
+  msg2 = pull_msg(x, sigma_bad, l_bad);
+  msg3 = pull_msg(x, sigma_bad, l_bad);
+  EXPECT_TRUE(std::string::npos != msg1.find(" length-scale")) << msg1;
+  EXPECT_TRUE(std::string::npos != msg2.find(" marginal variance")) << msg2;
+  EXPECT_TRUE(std::string::npos != msg3.find(" marginal variance")) << msg3;
+
+  msg1 = pull_msg(x, sigma, l_bad);
+  msg2 = pull_msg(x, sigma_bad, l_vec);
+  msg3 = pull_msg(x, sigma_bad, l_bad);
+  EXPECT_TRUE(std::string::npos != msg1.find(" length-scale")) << msg1;
+  EXPECT_TRUE(std::string::npos != msg2.find(" marginal variance")) << msg2;
+  EXPECT_TRUE(std::string::npos != msg3.find(" marginal variance")) << msg3;
+
+  msg1 = pull_msg(x, sigma, l_vec_bad);
+  msg2 = pull_msg(x, sigma_bad, l_vec_bad);
+  msg3 = pull_msg(x, sigma_bad, l_vec);
+  EXPECT_TRUE(std::string::npos != msg1.find(" length-scale")) << msg1;
+  EXPECT_TRUE(std::string::npos != msg2.find(" marginal variance")) << msg2;
+  EXPECT_TRUE(std::string::npos != msg3.find(" marginal variance")) << msg3;
+
+  msg1 = pull_msg(x_2, sigma, l_bad);
+  msg2 = pull_msg(x_2, sigma_bad, l);
+  msg3 = pull_msg(x_2, sigma_bad, l_bad);
+  EXPECT_TRUE(std::string::npos != msg1.find(" length-scale")) << msg1;
+  EXPECT_TRUE(std::string::npos != msg2.find(" marginal variance")) << msg2;
+  EXPECT_TRUE(std::string::npos != msg3.find(" marginal variance")) << msg3;
+
+  msg1 = pull_msg(x_2, sigma, l_bad);
+  msg2 = pull_msg(x_2, sigma_bad, l_vec);
+  msg3 = pull_msg(x_2, sigma_bad, l_bad);
+  EXPECT_TRUE(std::string::npos != msg1.find(" length-scale")) << msg1;
+  EXPECT_TRUE(std::string::npos != msg2.find(" marginal variance")) << msg2;
+  EXPECT_TRUE(std::string::npos != msg3.find(" marginal variance")) << msg3;
+
+  msg1 = pull_msg(x_2, sigma, l_vec_bad);
+  msg2 = pull_msg(x_2, sigma_bad, l_vec_bad);
+  msg3 = pull_msg(x_2, sigma_bad, l_vec);
+  EXPECT_TRUE(std::string::npos != msg1.find(" length-scale")) << msg1;
+  EXPECT_TRUE(std::string::npos != msg2.find(" marginal variance")) << msg2;
+  EXPECT_TRUE(std::string::npos != msg3.find(" marginal variance")) << msg3;
+
+  msg1 = pull_msg(x_2, x_3, sigma, l_bad);
+  msg2 = pull_msg(x_2, x_3, sigma_bad, l);
+  msg3 = pull_msg(x_2, x_3, sigma_bad, l_bad);
+  EXPECT_TRUE(std::string::npos != msg1.find(" length-scale")) << msg1;
+  EXPECT_TRUE(std::string::npos != msg2.find(" marginal variance")) << msg2;
+  EXPECT_TRUE(std::string::npos != msg3.find(" marginal variance")) << msg3;
+
+  msg1 = pull_msg(x_2, x_3, sigma, l_bad);
+  msg2 = pull_msg(x_2, x_3, sigma_bad, l_vec);
+  msg3 = pull_msg(x_2, x_3, sigma_bad, l_bad);
+  EXPECT_TRUE(std::string::npos != msg1.find(" length-scale")) << msg1;
+  EXPECT_TRUE(std::string::npos != msg2.find(" marginal variance")) << msg2;
+  EXPECT_TRUE(std::string::npos != msg3.find(" marginal variance")) << msg3;
+
+  msg1 = pull_msg(x_2, x_3, sigma, l_vec_bad);
+  msg2 = pull_msg(x_2, x_3, sigma_bad, l_vec_bad);
+  msg3 = pull_msg(x_2, x_3, sigma_bad, l_vec);
+  EXPECT_TRUE(std::string::npos != msg1.find(" length-scale")) << msg1;
+  EXPECT_TRUE(std::string::npos != msg2.find(" marginal variance")) << msg2;
+  EXPECT_TRUE(std::string::npos != msg3.find(" marginal variance")) << msg3;
+
+  msg1 = pull_msg(x_3, x_3, sigma, l_vec_bad);
+  msg2 = pull_msg(x_3, x_3, sigma_bad, l_vec_bad);
+  msg3 = pull_msg(x_3, x_3, sigma_bad, l_vec);
+  EXPECT_TRUE(std::string::npos != msg1.find(" length-scale")) << msg1;
+  EXPECT_TRUE(std::string::npos != msg2.find(" marginal variance")) << msg2;
+  EXPECT_TRUE(std::string::npos != msg3.find(" marginal variance")) << msg3;
+
+  msg1 = pull_msg(x_2, x_2, sigma, l_vec_bad);
+  msg2 = pull_msg(x_2, x_2, sigma_bad, l_vec_bad);
+  msg3 = pull_msg(x_2, x_2, sigma_bad, l_vec);
+  EXPECT_TRUE(std::string::npos != msg1.find(" length-scale")) << msg1;
+  EXPECT_TRUE(std::string::npos != msg2.find(" marginal variance")) << msg2;
+  EXPECT_TRUE(std::string::npos != msg3.find(" marginal variance")) << msg3;
+}
+
+TEST(MathPrimMat, nan_error_training_sig_l_gamma) {
+  double sigma = 0.2;
+  double l = 5;
+
+  std::vector<double> x(3);
+  x[0] = -2;
+  x[1] = -1;
+  x[2] = -0.5;
+
+  std::vector<Eigen::Matrix<double, -1, 1>> x_2(3);
+  for (size_t i = 0; i < x_2.size(); ++i) {
+    x_2[i].resize(3, 1);
+    x_2[i] << 1, 2, 3;
+  }
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x_3(3);
+  for (size_t i = 0; i < x_3.size(); ++i) {
+    x_3[i].resize(1, 3);
+    x_3[i] << 1, 2, 3;
+  }
+
+  std::vector<double> l_vec(2);
+  l_vec[0] = 1;
+  l_vec[1] = 2;
+
+  std::vector<double> l_vec_bad(2);
+  l_vec_bad[0] = 1;
+  l_vec_bad[1] = -1;
+
+  std::vector<double> x_bad(x);
+  x_bad[1] = std::numeric_limits<double>::quiet_NaN();
+
+  std::vector<Eigen::Matrix<double, -1, 1>> x_bad_2(x_2);
+  x_bad_2[1](1) = std::numeric_limits<double>::quiet_NaN();
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x_bad_3(x_3);
+  x_bad_3[1](1) = std::numeric_limits<double>::quiet_NaN();
+
+  double sigma_bad = std::numeric_limits<double>::quiet_NaN();
+  double l_bad = std::numeric_limits<double>::quiet_NaN();
+
+  std::string msg1, msg2, msg3, msg4;
+  msg1 = pull_msg(x, sigma, l_bad);
+  msg2 = pull_msg(x, sigma_bad, l);
+  msg3 = pull_msg(x, sigma_bad, l_bad);
+  EXPECT_TRUE(std::string::npos != msg1.find(" length-scale")) << msg1;
+  EXPECT_TRUE(std::string::npos != msg2.find(" marginal variance")) << msg2;
+  EXPECT_TRUE(std::string::npos != msg3.find(" marginal variance")) << msg3;
+
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x, sigma, l_bad),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x, sigma_bad, l),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x, sigma_bad, l_bad),
+               std::domain_error);
+
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_bad, l, sigma),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_bad, sigma_bad, l),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_bad, sigma_bad, l_bad),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_bad, sigma, l_bad),
+               std::domain_error);
+
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_2, sigma, l_bad),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_2, sigma_bad, l),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_2, sigma_bad, l_bad),
+               std::domain_error);
+
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_bad_2, sigma, l_bad),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_bad_2, sigma_bad, l),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_bad_2, sigma, l),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_bad_2, sigma_bad, l_bad),
+               std::domain_error);
+
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_3, sigma, l_bad),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_3, sigma_bad, l),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_3, sigma_bad, l_bad),
+               std::domain_error);
+
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_bad_3, sigma, l_bad),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_bad_3, sigma_bad, l),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_bad_3, sigma_bad, l_bad),
+               std::domain_error);
+
+  EXPECT_TRUE(std::string::npos != msg1.find(" length-scale")) << msg1;
+  EXPECT_TRUE(std::string::npos != msg2.find(" marginal variance")) << msg2;
+  EXPECT_TRUE(std::string::npos != msg3.find(" marginal variance")) << msg3;
+
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x, sigma, l_vec_bad),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x, sigma_bad, l_vec),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x, sigma_bad, l_vec_bad),
+               std::domain_error);
+
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_bad, sigma, l_vec),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_bad, sigma_bad, l_vec),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_bad, sigma_bad, l_vec_bad),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_bad, sigma, l_vec_bad),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_bad, sigma_bad, l_vec_bad),
+               std::domain_error);
+
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_2, sigma, l_vec_bad),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_2, sigma_bad, l_vec),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_2, sigma_bad, l_vec_bad),
+               std::domain_error);
+
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_bad_2, sigma, l_vec_bad),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_bad_2, sigma_bad, l_vec),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_bad_2, sigma_bad, l_vec_bad),
+               std::domain_error);
+
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_3, sigma, l_vec_bad),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_3, sigma_bad, l_vec),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_3, sigma_bad, l_vec_bad),
+               std::domain_error);
+
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_bad_3, sigma, l_vec_bad),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_bad_3, sigma_bad, l_vec),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_bad_3, sigma_bad, l_vec_bad),
+               std::domain_error);
+}
+
+TEST(MathPrimMat, dim_mismatch_vec_eigen_rvec_gp_matern_3_2_cov2) {
+  double sigma = 0.2;
+  double l = 5;
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x_vec_1(3);
+  for (size_t i = 0; i < x_vec_1.size(); ++i) {
+    x_vec_1[i].resize(1, 3);
+    x_vec_1[i] << 1, 2, 3;
+  }
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x_vec_2(4);
+  for (size_t i = 0; i < x_vec_2.size(); ++i) {
+    x_vec_2[i].resize(1, 4);
+    x_vec_2[i] << 4, 1, 3, 1;
+  }
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_vec_1, x_vec_2, sigma, l),
+               std::invalid_argument);
+}
+
+TEST(MathPrimMat, dim_mismatch_vec_eigen_mixed_gp_matern_3_2_cov) {
+  double sigma = 0.2;
+  double l = 5;
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x_rvec_1(3);
+  for (size_t i = 0; i < x_rvec_1.size(); ++i) {
+    x_rvec_1[i].resize(1, 3);
+    x_rvec_1[i] << 1, 2, 3;
+  }
+
+  std::vector<Eigen::Matrix<double, -1, 1>> x_vec_1(4);
+  for (size_t i = 0; i < x_vec_1.size(); ++i) {
+    x_vec_1[i].resize(4, 1);
+    x_vec_1[i] << 4, 1, 3, 1;
+  }
+
+  std::vector<Eigen::Matrix<double, -1, 1>> x_vec_2(3);
+  for (size_t i = 0; i < x_vec_2.size(); ++i) {
+    x_vec_2[i].resize(3, 1);
+    x_vec_2[i] << 1, 2, 3;
+  }
+
+  std::vector<Eigen::Matrix<double, 1, -1>> x_rvec_2(4);
+  for (size_t i = 0; i < x_rvec_2.size(); ++i) {
+    x_rvec_2[i].resize(1, 4);
+    x_rvec_2[i] << 1, 2, 3, 4;
+  }
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_rvec_1, x_vec_1, sigma, l),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_vec_1, x_rvec_1, sigma, l),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_rvec_2, x_vec_2, sigma, l),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::gp_matern_3_2_cov(x_vec_2, x_rvec_2, sigma, l),
+               std::invalid_argument);
+}


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary:
Add matern 3/2 kernel to prim, ARD support.

#### How to Verify:
tested error throws, `std::vector<double>` and all combinations of vec/rvec, etc.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Copywrite<2018><Andre Zapico>

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
