### PR TITLE
Bugfix/issue 883 mpi make

### DIFF
--- a/make/libraries
+++ b/make/libraries
@@ -3,6 +3,7 @@
 ##
 EIGEN ?= $(MATH)lib/eigen_3.3.3
 BOOST ?= $(MATH)lib/boost_1.66.0
+BOOST_LIB ?= $(MATH)lib/boost_1.66.0/stage/lib
 GTEST ?= $(MATH)lib/gtest_1.7.0
 CPPLINT ?= $(MATH)lib/cpplint_4.45
 OPENCL ?= $(MATH)lib/opencl_1.2.8
@@ -60,28 +61,31 @@ $(STAN_IDAS_HEADERS) : $(LIBSUNDIALS)
 # Build rules for MPI
 ##
 
-$(BOOST)/stage/lib/mpi.so:
+# turn BOOST_LIB into absolute path
+BOOST_LIB_ABS := $(shell cd -- "${BOOST_LIB}" && pwd)
+
+$(BOOST_LIB)/mpi.so:
 	@mkdir -p $(dir $@)
 	cd $(BOOST); ./bootstrap.sh
 	cd $(BOOST); echo "using mpi ;" >> user-config.jam
 	cd $(BOOST); ./b2 --user-config=user-config.jam --with-mpi --with-serialization
 
-$(BOOST)/stage/lib/libboost_serialization.so: $(BOOST)/stage/lib/mpi.so
+$(BOOST_LIB)/libboost_serialization.so: $(BOOST_LIB)/mpi.so
 
-$(BOOST)/stage/lib/libboost_serialization.dylib: $(BOOST)/stage/lib/mpi.so
-	install_name_tool -add_rpath $(BOOST)/stage/lib/ $(BOOST)/stage/lib/libboost_serialization.dylib
-	install_name_tool -id @rpath/libboost_serialization.dylib $(BOOST)/stage/lib/libboost_serialization.dylib
+$(BOOST_LIB)/libboost_serialization.dylib: $(BOOST_LIB)/mpi.so
+	install_name_tool -add_rpath $(BOOST_LIB_ABS) $(BOOST_LIB)/libboost_serialization.dylib
+	install_name_tool -id @rpath/libboost_serialization.dylib $(BOOST_LIB)/libboost_serialization.dylib
 
-$(BOOST)/stage/lib/libboost_mpi.so: $(BOOST)/stage/lib/mpi.so
+$(BOOST_LIB)/libboost_mpi.so: $(BOOST_LIB)/mpi.so
 
-$(BOOST)/stage/lib/libboost_mpi.dylib: $(BOOST)/stage/lib/mpi.so
-	install_name_tool -add_rpath $(BOOST)/stage/lib/ $(BOOST)/stage/lib/libboost_mpi.dylib
-	install_name_tool -change libboost_serialization.dylib @rpath/libboost_serialization.dylib $(BOOST)/stage/lib/libboost_mpi.dylib
-	install_name_tool -id @rpath/libboost_mpi.dylib $(BOOST)/stage/lib/libboost_mpi.dylib
+$(BOOST_LIB)/libboost_mpi.dylib: $(BOOST_LIB)/mpi.so
+	install_name_tool -add_rpath $(BOOST_LIB_ABS) $(BOOST_LIB)/libboost_mpi.dylib
+	install_name_tool -change libboost_serialization.dylib @rpath/libboost_serialization.dylib $(BOOST_LIB)/libboost_mpi.dylib
+	install_name_tool -id @rpath/libboost_mpi.dylib $(BOOST_LIB)/libboost_mpi.dylib
 
 .PHONY: clean-libraries
 clean-libraries:
 	$(RM) $(sort $(SUNDIALS_CVODES) $(SUNDIALS_IDAS) $(SUNDIALS_NVECSERIAL) $(LIBSUNDIALS))
-	$(RM) $(BOOST)/stage/lib/*  
+	$(RM) -rf $(BOOST_LIB)/*  
 	$(RM) -rf $(BOOST)/bin.v2  
 

--- a/make/libraries
+++ b/make/libraries
@@ -62,7 +62,7 @@ $(STAN_IDAS_HEADERS) : $(LIBSUNDIALS)
 ##
 
 # turn BOOST_LIB into absolute path
-BOOST_LIB_ABS := $(shell cd -- "${BOOST_LIB}" && pwd)
+BOOST_LIB_ABS := $(shell cd -- "${BOOST_LIB}" && echo $(PWD))
 
 $(BOOST_LIB)/mpi.so:
 	@mkdir -p $(dir $@)

--- a/make/libraries
+++ b/make/libraries
@@ -88,4 +88,3 @@ clean-libraries:
 	$(RM) $(sort $(SUNDIALS_CVODES) $(SUNDIALS_IDAS) $(SUNDIALS_NVECSERIAL) $(LIBSUNDIALS))
 	$(RM) -rf $(BOOST_LIB)/*  
 	$(RM) -rf $(BOOST)/bin.v2  
-

--- a/make/os_linux
+++ b/make/os_linux
@@ -29,9 +29,10 @@ ifdef STAN_OPENCL
   OPENCL_PLATFORM_ID ?= 0
 endif
 
-DLL = .so
+DLL := .so
 
 ifdef STAN_MPI
   LDFLAGS_MPI := -L$(BOOST)/stage/lib -lboost_serialization -lboost_mpi -Wl,-rpath,$(BOOST)/stage/lib
   CXXFLAGS_MPI := -DSTAN_MPI
+  LIBMPI := $(BOOST_LIB_ABS)/libboost_mpi$(DLL) $(BOOST_LIB_ABS)/libboost_serialization$(DLL)
 endif

--- a/make/os_linux
+++ b/make/os_linux
@@ -32,7 +32,7 @@ endif
 DLL := .so
 
 ifdef STAN_MPI
-  LDFLAGS_MPI := -L$(BOOST)/stage/lib -lboost_serialization -lboost_mpi -Wl,-rpath,$(BOOST)/stage/lib
-  CXXFLAGS_MPI := -DSTAN_MPI
-  LIBMPI := $(BOOST_LIB_ABS)/libboost_mpi$(DLL) $(BOOST_LIB_ABS)/libboost_serialization$(DLL)
+  LDFLAGS_MPI = -L$(BOOST_LIB) -lboost_serialization -lboost_mpi -Wl,-rpath,$(BOOST_LIB_ABS)
+  CXXFLAGS_MPI = -DSTAN_MPI
+  LIBMPI = $(BOOST_LIB)/libboost_mpi$(DLL) $(BOOST_LIB)/libboost_serialization$(DLL)
 endif

--- a/make/os_mac
+++ b/make/os_mac
@@ -23,7 +23,7 @@ endif
 DLL := .dylib
 
 ifdef STAN_MPI
-  LDFLAGS_MPI := -L$(BOOST)/stage/lib -lboost_serialization -lboost_mpi -Wl,-rpath,$(BOOST)/stage/lib
-  CXXFLAGS_MPI := -DSTAN_MPI
-  LIBMPI = $(BOOST_LIB_ABS)/libboost_mpi$(DLL) $(BOOST_LIB_ABS)/libboost_serialization$(DLL)
+  LDFLAGS_MPI = -L$(BOOST_LIB) -lboost_serialization -lboost_mpi -Wl,-rpath,$(BOOST_LIB_ABS)
+  CXXFLAGS_MPI = -DSTAN_MPI
+  LIBMPI = $(BOOST_LIB)/libboost_mpi$(DLL) $(BOOST_LIB)/libboost_serialization$(DLL)
 endif

--- a/make/os_mac
+++ b/make/os_mac
@@ -20,9 +20,10 @@ ifdef STAN_OPENCL
   OPENCL_PLATFORM_ID ?= 0
 endif
 
-DLL = .dylib
+DLL := .dylib
 
 ifdef STAN_MPI
   LDFLAGS_MPI := -L$(BOOST)/stage/lib -lboost_serialization -lboost_mpi -Wl,-rpath,$(BOOST)/stage/lib
   CXXFLAGS_MPI := -DSTAN_MPI
+  LIBMPI = $(BOOST_LIB_ABS)/libboost_mpi$(DLL) $(BOOST_LIB_ABS)/libboost_serialization$(DLL)
 endif

--- a/make/tests
+++ b/make/tests
@@ -74,7 +74,7 @@ ifdef STAN_MPI
   MPI_TESTS := $(subst .cpp,$(EXE),$(shell find test -name *mpi_*test.cpp))
   $(MPI_TESTS): LDFLAGS += $(LDFLAGS_MPI)
   $(MPI_TESTS): CXXFLAGS += $(CXXFLAGS_MPI)
-  $(MPI_TESTS): $(BOOST)/stage/lib/libboost_mpi$(DLL) $(BOOST)/stage/lib/libboost_serialization$(DLL)
+  $(MPI_TESTS): $(LIBMPI)
 endif
 
 ############################################################

--- a/makefile
+++ b/makefile
@@ -154,3 +154,5 @@ clean-all: clean clean-doxygen clean-deps clean-libraries
 	@echo '  removing generated test files'
 	$(shell find test/prob -name '*_generated_*_test.cpp' -type f -exec rm {} +)
 	$(RM) $(wildcard test/prob/generate_tests$(EXE))
+
+print-%  : ; @echo $* = $($*)

--- a/makefile
+++ b/makefile
@@ -156,3 +156,4 @@ clean-all: clean clean-doxygen clean-deps clean-libraries
 	$(RM) $(wildcard test/prob/generate_tests$(EXE))
 
 print-%  : ; @echo $* = $($*)
+


### PR DESCRIPTION
#### Submission Checklist

- [ ] Run unit tests: `./runTests.py test/unit`
- [ ] Run cpplint: `make cpplint`
- [X] Declare copyright holder and open-source license: see below

#### Summary:
Changes the rpath facility used to link against the shared libraries of boost from using relative to absolute path's. This makes the resulting more robust in terms of finding the needed dynamic libraries on the system where this is deployed.

#### Intended Effect:
Make MPI dynamic linking more stable.

#### How to Verify:
Follow the compilation of the MPI tests
```
test/unit/math/rev/mat/functor/map_rect_mpi_test.cpp
test/unit/math/prim/mat/functor/map_rect_mpi_test.cpp
test/unit/math/prim/mat/functor/mpi_parallel_call_test.cpp
test/unit/math/prim/arr/functor/mpi_cluster_test.cpp
```
which now use an absolute path for the rpath argument of the compiler.

#### Side Effects:
I have added to the main makefile a print target which allows easy debugging of makefile matters. A

make print-BOOST

shows what make thinks is assigned to BOOST. I can't live without it, but if the reviewer disagrees then I am happy to take it out again.

#### Documentation:

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Sebastian Weber

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
