### PR TITLE
issue 892: overload matrix_exp

### DIFF
--- a/stan/math/prim/mat/fun/matrix_exp.hpp
+++ b/stan/math/prim/mat/fun/matrix_exp.hpp
@@ -83,7 +83,8 @@ inline Eigen::Matrix<T, 1, 1> matrix_exp(const Eigen::Matrix<T, 1, 1>& A) {
  */
 template <int N, int Cb>
 inline Eigen::Matrix<double, N, Cb> matrix_exp(
-    const Eigen::Matrix<double, N, N>& A, const Eigen::Matrix<double, N, Cb>& B,
+    const Eigen::Matrix<double, N, N>& A,
+    const Eigen::Matrix<double, N, Cb>& B,
     const double& t = 1.0) {
   return matrix_exp_action(A, B, t);
 }

--- a/stan/math/prim/mat/fun/matrix_exp.hpp
+++ b/stan/math/prim/mat/fun/matrix_exp.hpp
@@ -66,6 +66,29 @@ inline Eigen::Matrix<T, 1, 1> matrix_exp(const Eigen::Matrix<T, 1, 1>& A) {
   res << exp(A(0));
   return res;
 }
+
+  /**
+   * Overload matrix_exp function to perform matrix_exp_action.
+   * This simplifies stan UI: we only expose
+   * matrix_exp_action through the following signatures
+   * - matrix_exp(A, B)
+   * - matrix_exp(A, B, t)
+   *
+   * @tparam N Rows and cols matrix A, also rows of matrix B
+   * @tparam Cb Columns matrix B
+   * @param[in] A Matrix
+   * @param[in] B Matrix
+   * @param[in] t double
+   * @return exponential of At multiplies B
+   */
+  template <int N, int Cb>
+  inline Eigen::Matrix<double, N, Cb>
+  matrix_exp(const Eigen::Matrix<double, N, N>& A,
+             const Eigen::Matrix<double, N, Cb>& B,
+             const double& t = 1.0) {
+    return matrix_exp_action(A, B, t);
+  }
+
 }  // namespace math
 }  // namespace stan
 #endif

--- a/stan/math/prim/mat/fun/matrix_exp.hpp
+++ b/stan/math/prim/mat/fun/matrix_exp.hpp
@@ -83,8 +83,7 @@ inline Eigen::Matrix<T, 1, 1> matrix_exp(const Eigen::Matrix<T, 1, 1>& A) {
  */
 template <int N, int Cb>
 inline Eigen::Matrix<double, N, Cb> matrix_exp(
-    const Eigen::Matrix<double, N, N>& A,
-    const Eigen::Matrix<double, N, Cb>& B,
+    const Eigen::Matrix<double, N, N>& A, const Eigen::Matrix<double, N, Cb>& B,
     const double& t = 1.0) {
   return matrix_exp_action(A, B, t);
 }

--- a/stan/math/prim/mat/fun/matrix_exp.hpp
+++ b/stan/math/prim/mat/fun/matrix_exp.hpp
@@ -67,27 +67,26 @@ inline Eigen::Matrix<T, 1, 1> matrix_exp(const Eigen::Matrix<T, 1, 1>& A) {
   return res;
 }
 
-  /**
-   * Overload matrix_exp function to perform matrix_exp_action.
-   * This simplifies stan UI: we only expose
-   * matrix_exp_action through the following signatures
-   * - matrix_exp(A, B)
-   * - matrix_exp(A, B, t)
-   *
-   * @tparam N Rows and cols matrix A, also rows of matrix B
-   * @tparam Cb Columns matrix B
-   * @param[in] A Matrix
-   * @param[in] B Matrix
-   * @param[in] t double
-   * @return exponential of At multiplies B
-   */
-  template <int N, int Cb>
-  inline Eigen::Matrix<double, N, Cb>
-  matrix_exp(const Eigen::Matrix<double, N, N>& A,
-             const Eigen::Matrix<double, N, Cb>& B,
-             const double& t = 1.0) {
-    return matrix_exp_action(A, B, t);
-  }
+/**
+ * Overload matrix_exp function to perform matrix_exp_action.
+ * This simplifies stan UI: we only expose
+ * matrix_exp_action through the following signatures
+ * - matrix_exp(A, B)
+ * - matrix_exp(A, B, t)
+ *
+ * @tparam N Rows and cols matrix A, also rows of matrix B
+ * @tparam Cb Columns matrix B
+ * @param[in] A Matrix
+ * @param[in] B Matrix
+ * @param[in] t double
+ * @return exponential of At multiplies B
+ */
+template <int N, int Cb>
+inline Eigen::Matrix<double, N, Cb> matrix_exp(
+    const Eigen::Matrix<double, N, N>& A, const Eigen::Matrix<double, N, Cb>& B,
+    const double& t = 1.0) {
+  return matrix_exp_action(A, B, t);
+}
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/rev/mat.hpp
+++ b/stan/math/rev/mat.hpp
@@ -30,6 +30,7 @@
 #include <stan/math/rev/mat/fun/log_determinant_spd.hpp>
 #include <stan/math/rev/mat/fun/log_softmax.hpp>
 #include <stan/math/rev/mat/fun/log_sum_exp.hpp>
+#include <stan/math/rev/mat/fun/matrix_exp.hpp>
 #include <stan/math/rev/mat/fun/mdivide_left.hpp>
 #include <stan/math/rev/mat/fun/mdivide_left_ldlt.hpp>
 #include <stan/math/rev/mat/fun/mdivide_left_spd.hpp>

--- a/stan/math/rev/mat/fun/matrix_exp.hpp
+++ b/stan/math/rev/mat/fun/matrix_exp.hpp
@@ -35,10 +35,10 @@ namespace math {
 template <typename Ta, int N, typename Tb, int Cb>
 inline typename boost::enable_if_c<boost::is_same<Ta, var>::value
                                        || boost::is_same<Tb, var>::value,
-                                   Eigen::Matrix<var, N, Cb> >::type
-inline matrix_exp(const Eigen::Matrix<Ta, N, N>& A,
-                  const Eigen::Matrix<Tb, N, Cb>& B,
-                  const double& t = 1.0) {
+                                   Eigen::Matrix<var, N, Cb> >::
+    type inline matrix_exp(const Eigen::Matrix<Ta, N, N>& A,
+                           const Eigen::Matrix<Tb, N, Cb>& B,
+                           const double& t = 1.0) {
   return matrix_exp_action(A, B, t);
 }
 

--- a/stan/math/rev/mat/fun/matrix_exp.hpp
+++ b/stan/math/rev/mat/fun/matrix_exp.hpp
@@ -1,0 +1,48 @@
+#ifndef STAN_MATH_REV_MAT_FUN_MATRIX_EXP_HPP
+#define STAN_MATH_REV_MAT_FUN_MATRIX_EXP_HPP
+
+#include <stan/math/rev/core.hpp>
+#include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <stan/math/rev/mat/fun/to_var.hpp>
+#include <stan/math/prim/mat/fun/matrix_exp.hpp>
+#include <stan/math/prim/mat/err/check_multiplicable.hpp>
+#include <stan/math/prim/scal/err/check_not_nan.hpp>
+#include <stan/math/rev/mat/fun/matrix_exp_action.hpp>
+#include <boost/math/tools/promotion.hpp>
+#include <boost/utility/enable_if.hpp>
+#include <boost/type_traits.hpp>
+#include <vector>
+
+namespace stan {
+namespace math {
+
+  /**
+   * Overload matrix_exp function to perform matrix_exp_action.
+   * This simplifies stan UI: we only expose
+   * matrix_exp_action through the following signatures
+   * - matrix_exp(A, B)
+   * - matrix_exp(A, B, t)
+   *
+   * @tparam Ta scalar type matrix A
+   * @tparam N Rows and cols matrix A, also rows of matrix B
+   * @tparam Tb scalar type matrix B
+   * @tparam Cb Columns matrix B
+   * @param[in] A Matrix
+   * @param[in] B Matrix
+   * @param[in] t double
+   * @return exponential of At multiplies B
+   */
+  template <typename Ta, int N, typename Tb, int Cb>
+  inline typename boost::enable_if_c<boost::is_same<Ta, var>::value
+                                     || boost::is_same<Tb, var>::value,
+                                     Eigen::Matrix<var, N, Cb> >::type
+  matrix_exp(const Eigen::Matrix<Ta, N, N>& A,
+             const Eigen::Matrix<Tb, N, Cb>& B,
+             const double& t = 1.0) {
+    return matrix_exp_action(A, B, t);
+  }
+
+}  // namespace math
+}  // namespace stan
+
+#endif

--- a/stan/math/rev/mat/fun/matrix_exp.hpp
+++ b/stan/math/rev/mat/fun/matrix_exp.hpp
@@ -36,8 +36,9 @@ template <typename Ta, int N, typename Tb, int Cb>
 inline typename boost::enable_if_c<boost::is_same<Ta, var>::value
                                        || boost::is_same<Tb, var>::value,
                                    Eigen::Matrix<var, N, Cb> >::type
-matrix_exp(const Eigen::Matrix<Ta, N, N>& A, const Eigen::Matrix<Tb, N, Cb>& B,
-           const double& t = 1.0) {
+inline matrix_exp(const Eigen::Matrix<Ta, N, N>& A,
+                  const Eigen::Matrix<Tb, N, Cb>& B,
+                  const double& t = 1.0) {
   return matrix_exp_action(A, B, t);
 }
 

--- a/stan/math/rev/mat/fun/matrix_exp.hpp
+++ b/stan/math/rev/mat/fun/matrix_exp.hpp
@@ -36,7 +36,7 @@ template <typename Ta, int N, typename Tb, int Cb>
 inline typename boost::enable_if_c<boost::is_same<Ta, var>::value
                                        || boost::is_same<Tb, var>::value,
                                    Eigen::Matrix<var, N, Cb> >::
-    type inline matrix_exp(const Eigen::Matrix<Ta, N, N>& A,
+    type matrix_exp(const Eigen::Matrix<Ta, N, N>& A,
                            const Eigen::Matrix<Tb, N, Cb>& B,
                            const double& t = 1.0) {
   return matrix_exp_action(A, B, t);

--- a/stan/math/rev/mat/fun/matrix_exp.hpp
+++ b/stan/math/rev/mat/fun/matrix_exp.hpp
@@ -35,10 +35,9 @@ namespace math {
 template <typename Ta, int N, typename Tb, int Cb>
 inline typename boost::enable_if_c<boost::is_same<Ta, var>::value
                                        || boost::is_same<Tb, var>::value,
-                                   Eigen::Matrix<var, N, Cb> >::
-    type matrix_exp(const Eigen::Matrix<Ta, N, N>& A,
-                           const Eigen::Matrix<Tb, N, Cb>& B,
-                           const double& t = 1.0) {
+                                   Eigen::Matrix<var, N, Cb> >::type
+matrix_exp(const Eigen::Matrix<Ta, N, N>& A, const Eigen::Matrix<Tb, N, Cb>& B,
+           const double& t = 1.0) {
   return matrix_exp_action(A, B, t);
 }
 

--- a/stan/math/rev/mat/fun/matrix_exp.hpp
+++ b/stan/math/rev/mat/fun/matrix_exp.hpp
@@ -16,31 +16,30 @@
 namespace stan {
 namespace math {
 
-  /**
-   * Overload matrix_exp function to perform matrix_exp_action.
-   * This simplifies stan UI: we only expose
-   * matrix_exp_action through the following signatures
-   * - matrix_exp(A, B)
-   * - matrix_exp(A, B, t)
-   *
-   * @tparam Ta scalar type matrix A
-   * @tparam N Rows and cols matrix A, also rows of matrix B
-   * @tparam Tb scalar type matrix B
-   * @tparam Cb Columns matrix B
-   * @param[in] A Matrix
-   * @param[in] B Matrix
-   * @param[in] t double
-   * @return exponential of At multiplies B
-   */
-  template <typename Ta, int N, typename Tb, int Cb>
-  inline typename boost::enable_if_c<boost::is_same<Ta, var>::value
-                                     || boost::is_same<Tb, var>::value,
-                                     Eigen::Matrix<var, N, Cb> >::type
-  matrix_exp(const Eigen::Matrix<Ta, N, N>& A,
-             const Eigen::Matrix<Tb, N, Cb>& B,
-             const double& t = 1.0) {
-    return matrix_exp_action(A, B, t);
-  }
+/**
+ * Overload matrix_exp function to perform matrix_exp_action.
+ * This simplifies stan UI: we only expose
+ * matrix_exp_action through the following signatures
+ * - matrix_exp(A, B)
+ * - matrix_exp(A, B, t)
+ *
+ * @tparam Ta scalar type matrix A
+ * @tparam N Rows and cols matrix A, also rows of matrix B
+ * @tparam Tb scalar type matrix B
+ * @tparam Cb Columns matrix B
+ * @param[in] A Matrix
+ * @param[in] B Matrix
+ * @param[in] t double
+ * @return exponential of At multiplies B
+ */
+template <typename Ta, int N, typename Tb, int Cb>
+inline typename boost::enable_if_c<boost::is_same<Ta, var>::value
+                                       || boost::is_same<Tb, var>::value,
+                                   Eigen::Matrix<var, N, Cb> >::type
+matrix_exp(const Eigen::Matrix<Ta, N, N>& A, const Eigen::Matrix<Tb, N, Cb>& B,
+           const double& t = 1.0) {
+  return matrix_exp_action(A, B, t);
+}
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/rev/mat/fun/matrix_exp_action_handler.hpp
+++ b/stan/math/rev/mat/fun/matrix_exp_action_handler.hpp
@@ -25,8 +25,14 @@ class matrix_exp_action_handler {
   static constexpr int p_max = 8;
   static constexpr int m_max = 55;
   static constexpr double tol = 1.1e-16;
-  static const std::vector<double> theta_m_single_precision;
-  static const std::vector<double> theta_m_double_precision;
+
+// table 3.1 in the reference
+  const std::vector<double>
+  theta_m_single_precision {1.3e-1, 1.0e0, 2.2e0, 3.6e0, 4.9e0, 6.3e0,
+      7.7e0,  9.1e0, 1.1e1, 1.2e1, 1.3e1 };
+  const std::vector<double>
+  theta_m_double_precision {2.4e-3, 1.4e-1, 6.4e-1, 1.4e0, 2.4e0, 3.5e0,
+      4.7e0,  6.0e0,  7.2e0,  8.5e0, 9.9e0 };
 
  public:
   /* Constructor
@@ -115,15 +121,6 @@ class matrix_exp_action_handler {
     }
   }
 };
-
-// table 3.1 in the reference
-const std::vector<double> matrix_exp_action_handler::theta_m_single_precision{
-    1.3e-1, 1.0e0, 2.2e0, 3.6e0, 4.9e0, 6.3e0,
-    7.7e0,  9.1e0, 1.1e1, 1.2e1, 1.3e1};
-
-const std::vector<double> matrix_exp_action_handler::theta_m_double_precision{
-    2.4e-3, 1.4e-1, 6.4e-1, 1.4e0, 2.4e0, 3.5e0,
-    4.7e0,  6.0e0,  7.2e0,  8.5e0, 9.9e0};
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/rev/mat/fun/matrix_exp_action_handler.hpp
+++ b/stan/math/rev/mat/fun/matrix_exp_action_handler.hpp
@@ -26,13 +26,13 @@ class matrix_exp_action_handler {
   static constexpr int m_max = 55;
   static constexpr double tol = 1.1e-16;
 
-// table 3.1 in the reference
-  const std::vector<double>
-  theta_m_single_precision {1.3e-1, 1.0e0, 2.2e0, 3.6e0, 4.9e0, 6.3e0,
-      7.7e0,  9.1e0, 1.1e1, 1.2e1, 1.3e1 };
-  const std::vector<double>
-  theta_m_double_precision {2.4e-3, 1.4e-1, 6.4e-1, 1.4e0, 2.4e0, 3.5e0,
-      4.7e0,  6.0e0,  7.2e0,  8.5e0, 9.9e0 };
+  // table 3.1 in the reference
+  const std::vector<double> theta_m_single_precision{
+      1.3e-1, 1.0e0, 2.2e0, 3.6e0, 4.9e0, 6.3e0,
+      7.7e0,  9.1e0, 1.1e1, 1.2e1, 1.3e1};
+  const std::vector<double> theta_m_double_precision{
+      2.4e-3, 1.4e-1, 6.4e-1, 1.4e0, 2.4e0, 3.5e0,
+      4.7e0,  6.0e0,  7.2e0,  8.5e0, 9.9e0};
 
  public:
   /* Constructor

--- a/stan/math/rev/mat/fun/matrix_exp_action_handler.hpp
+++ b/stan/math/rev/mat/fun/matrix_exp_action_handler.hpp
@@ -5,10 +5,6 @@
 #include <stan/math/rev/core.hpp>
 #include <vector>
 
-double l1norm(const Eigen::MatrixXd& m) {
-  return m.colwise().lpNorm<1>().maxCoeff();
-}
-
 namespace stan {
 namespace math {
 
@@ -33,6 +29,10 @@ class matrix_exp_action_handler {
   const std::vector<double> theta_m_double_precision{
       2.4e-3, 1.4e-1, 6.4e-1, 1.4e0, 2.4e0, 3.5e0,
       4.7e0,  6.0e0,  7.2e0,  8.5e0, 9.9e0};
+
+  double l1norm(const Eigen::MatrixXd& m) {
+    return m.colwise().lpNorm<1>().maxCoeff();
+  }
 
  public:
   /* Constructor

--- a/test/unit/math/rev/mat/fun/matrix_exp_test.cpp
+++ b/test/unit/math/rev/mat/fun/matrix_exp_test.cpp
@@ -191,3 +191,193 @@ TEST(MathMatrix, matrix_exp_exceptions) {
   EXPECT_THROW(matrix_exp(m1), std::invalid_argument);
   EXPECT_THROW(matrix_exp(m2), std::invalid_argument);
 }
+
+////////////////////////////////////////////////////////////////
+// Overload matrix_exp_action.
+////////////////////////////////////////////////////////////////
+template <int N, int M>
+inline void test_matrix_exp_overload_dv() {
+  using stan::math::value_of;
+  using stan::math::var;
+  std::srand(1999);
+
+  Eigen::Matrix<var, N, N> Av = Eigen::Matrix<var, N, N>::Random();
+  Eigen::Matrix<var, N, M> Bv = Eigen::Matrix<var, N, M>::Random();
+  std::vector<stan::math::var> Bvec(Bv.data(), Bv.data() + Bv.size());
+  std::vector<stan::math::var> Avec(Av.data(), Av.data() + Av.size());
+  Eigen::Matrix<double, N, N> A = value_of(Av);
+
+  // brute force
+  Eigen::Matrix<double, N, N> expA = stan::math::matrix_exp(A);
+  Eigen::Matrix<var, N, M> expAB;
+  for (int i = 0; i < N; ++i) {
+    for (int j = 0; j < M; ++j) {
+      expAB(i, j) = 0.0;
+      for (int k = 0; k < N; ++k) {
+        expAB(i, j) += expA(i, k) * Bv(k, j);
+      }
+    }
+  }
+
+  // matrix_exp_action
+  Eigen::Matrix<var, N, M> res_dv = stan::math::matrix_exp(A, Bv);
+  for (int l = 0; l < res_dv.size(); ++l) {
+    EXPECT_FLOAT_EQ(res_dv(l).val(), expAB(l).val());
+  }
+  // compare adjoints
+  std::vector<double> g, g0;
+  for (int l = 0; l < M; ++l) {
+    for (int k = 0; k < N; ++k) {
+      stan::math::set_zero_all_adjoints();
+      res_dv(k, l).grad(Bvec, g);
+      stan::math::set_zero_all_adjoints();
+      expAB(k, l).grad(Bvec, g0);
+      for (size_t j = 0; j < g.size(); ++j) {
+        EXPECT_FLOAT_EQ(g[j], g0[j]);
+      }
+    }
+  }
+
+  // test a single function of expA*B
+  var f = sum(res_dv);
+  var f0 = sum(expAB);
+  stan::math::set_zero_all_adjoints();
+  f.grad(Bvec, g);
+  stan::math::set_zero_all_adjoints();
+  f0.grad(Bvec, g0);
+  for (size_t j = 0; j < g.size(); ++j) {
+    EXPECT_FLOAT_EQ(g[j], g0[j]);
+  }
+}
+
+TEST(MathMatrix, matrix_exp_overload_dv) {
+  test_matrix_exp_overload_dv<1, 1>();
+  test_matrix_exp_overload_dv<1, 5>();
+  test_matrix_exp_overload_dv<5, 1>();
+  test_matrix_exp_overload_dv<5, 5>();
+}
+
+template <int N, int M>
+inline void test_matrix_exp_overload_vd() {
+  using stan::math::value_of;
+  using stan::math::var;
+  std::srand(1999);
+
+  Eigen::Matrix<var, N, N> Av = Eigen::Matrix<var, N, N>::Random();
+  Eigen::Matrix<var, N, M> Bv = Eigen::Matrix<var, N, M>::Random();
+  std::vector<stan::math::var> Bvec(Bv.data(), Bv.data() + Bv.size());
+  std::vector<stan::math::var> Avec(Av.data(), Av.data() + Av.size());
+  Eigen::Matrix<double, N, M> B = value_of(Bv);
+
+  // brute force
+  Eigen::Matrix<var, N, N> expA = stan::math::matrix_exp(Av);
+  Eigen::Matrix<var, N, M> expAB;
+  for (int i = 0; i < N; ++i) {
+    for (int j = 0; j < M; ++j) {
+      expAB(i, j) = 0.0;
+      for (int k = 0; k < N; ++k) {
+        expAB(i, j) += expA(i, k) * B(k, j);
+      }
+    }
+  }
+  // matrix_exp_action
+  Eigen::Matrix<var, N, M> res_vd = stan::math::matrix_exp(Av, B);
+  for (int l = 0; l < res_vd.size(); ++l) {
+    EXPECT_FLOAT_EQ(res_vd(l).val(), expAB(l).val());
+  }
+
+  // compare adjoints
+  std::vector<double> g, g0;
+  for (int l = 0; l < M; ++l) {
+    for (int k = 0; k < N; ++k) {
+      stan::math::set_zero_all_adjoints();
+      res_vd(k, l).grad(Avec, g);
+      stan::math::set_zero_all_adjoints();
+      expAB(k, l).grad(Avec, g0);
+      for (size_t j = 0; j < g.size(); ++j) {
+        EXPECT_FLOAT_EQ(g[j], g0[j]);
+      }
+    }
+  }
+
+  // test a single function of expA*B
+  var f = sum(res_vd);
+  var f0 = sum(expAB);
+  stan::math::set_zero_all_adjoints();
+  f.grad(Avec, g);
+  stan::math::set_zero_all_adjoints();
+  f0.grad(Avec, g0);
+  for (size_t j = 0; j < g.size(); ++j) {
+    EXPECT_FLOAT_EQ(g[j], g0[j]);
+  }
+}
+
+TEST(MathMatrix, matrix_exp_overload_vd) {
+  test_matrix_exp_overload_vd<1, 1>();
+  test_matrix_exp_overload_vd<1, 5>();
+  test_matrix_exp_overload_vd<5, 1>();
+  test_matrix_exp_overload_vd<5, 5>();
+}
+
+template <int N, int M>
+inline void test_matrix_exp_overload_vv() {
+  using stan::math::value_of;
+  using stan::math::var;
+  std::srand(2999);
+
+  Eigen::Matrix<var, N, N> Av = Eigen::Matrix<var, N, N>::Random();
+  Eigen::Matrix<var, N, M> Bv = Eigen::Matrix<var, N, M>::Random();
+  std::vector<stan::math::var> Bvec(Bv.data(), Bv.data() + Bv.size());
+  std::vector<stan::math::var> Avec(Av.data(), Av.data() + Av.size());
+
+  // brute force
+  Eigen::Matrix<var, N, N> expA = stan::math::matrix_exp(Av);
+  Eigen::Matrix<var, N, M> expAB;
+  for (int i = 0; i < N; ++i) {
+    for (int j = 0; j < M; ++j) {
+      expAB(i, j) = 0.0;
+      for (int k = 0; k < N; ++k) {
+        expAB(i, j) += expA(i, k) * Bv(k, j);
+      }
+    }
+  }
+
+  // matrix_exp_action
+  Eigen::Matrix<var, N, M> res_vv = stan::math::matrix_exp(Av, Bv);
+  for (int l = 0; l < res_vv.size(); ++l) {
+    EXPECT_FLOAT_EQ(res_vv(l).val(), expAB(l).val());
+  }
+  Avec.insert(Avec.end(), Bvec.begin(), Bvec.end());
+  // compare adjoints
+  std::vector<double> g, g0;
+  for (int l = 0; l < M; ++l) {
+    for (int k = 0; k < N; ++k) {
+      stan::math::set_zero_all_adjoints();
+      res_vv(k, l).grad(Avec, g);
+      stan::math::set_zero_all_adjoints();
+      expAB(k, l).grad(Avec, g0);
+      for (size_t j = 0; j < g.size(); ++j) {
+        EXPECT_FLOAT_EQ(g[j], g0[j]);
+      }
+    }
+  }
+
+  // test a single function of expA*B
+  var f = sum(res_vv);
+  var f0 = sum(expAB);
+  stan::math::set_zero_all_adjoints();
+  f.grad(Avec, g);
+  stan::math::set_zero_all_adjoints();
+  f0.grad(Avec, g0);
+  for (size_t j = 0; j < g.size(); ++j) {
+    EXPECT_FLOAT_EQ(g[j], g0[j]);
+  }
+}
+
+TEST(MathMatrix, matrix_exp_overload_vv) {
+  test_matrix_exp_overload_vv<1, 1>();
+  test_matrix_exp_overload_vv<1, 5>();
+  test_matrix_exp_overload_vv<5, 1>();
+  test_matrix_exp_overload_vv<5, 5>();
+  test_matrix_exp_overload_vv<10, 2>();
+}


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary:
This PR addresses #892 .

As mentioned at https://github.com/stan-dev/math/issues/771#issuecomment-367142161,
instead of exposing `matrix_exp_action` to Stan language, we can overload the interface of `matrix_exp`, so that 
```Stan
matrix_exp(matrix A, matrix B);
matrix_exp(matrix A, matrix B, real t);
```
calls `matrix_exp_action(A, B)` and `matrix_exp_action(A, B, t)`, respectively.

This is similar to the Mathematica function [`MatrixExp`](http://reference.wolfram.com/language/ref/MatrixExp.html).

#### Intended Effect:
see above
#### How to Verify:
More tests in unit test of `matrix_exp` to test the overloaded function.

#### Side Effects:
n/a

#### Copyright and Licensing
Metrum Research Group, LLC

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
