### PR TITLE
Bugfix/issue 894 mpi make 2

### DIFF
--- a/make/libraries
+++ b/make/libraries
@@ -73,15 +73,15 @@ $(BOOST_LIB)/mpi.so:
 $(BOOST_LIB)/libboost_serialization.so: $(BOOST_LIB)/mpi.so
 
 $(BOOST_LIB)/libboost_serialization.dylib: $(BOOST_LIB)/mpi.so
-	install_name_tool -add_rpath $(BOOST_LIB_ABS) $(BOOST_LIB)/libboost_serialization.dylib
-	install_name_tool -id @rpath/libboost_serialization.dylib $(BOOST_LIB)/libboost_serialization.dylib
+	install_name_tool -add_rpath "$(BOOST_LIB_ABS)" "$(BOOST_LIB)/libboost_serialization.dylib"
+	install_name_tool -id @rpath/libboost_serialization.dylib "$(BOOST_LIB)/libboost_serialization.dylib"
 
 $(BOOST_LIB)/libboost_mpi.so: $(BOOST_LIB)/mpi.so
 
 $(BOOST_LIB)/libboost_mpi.dylib: $(BOOST_LIB)/mpi.so
-	install_name_tool -add_rpath $(BOOST_LIB_ABS) $(BOOST_LIB)/libboost_mpi.dylib
-	install_name_tool -change libboost_serialization.dylib @rpath/libboost_serialization.dylib $(BOOST_LIB)/libboost_mpi.dylib
-	install_name_tool -id @rpath/libboost_mpi.dylib $(BOOST_LIB)/libboost_mpi.dylib
+	install_name_tool -add_rpath "$(BOOST_LIB_ABS)" "$(BOOST_LIB)/libboost_mpi.dylib"
+	install_name_tool -change libboost_serialization.dylib @rpath/libboost_serialization.dylib "$(BOOST_LIB)/libboost_mpi.dylib"
+	install_name_tool -id @rpath/libboost_mpi.dylib "$(BOOST_LIB)/libboost_mpi.dylib"
 
 .PHONY: clean-libraries
 clean-libraries:

--- a/make/os_linux
+++ b/make/os_linux
@@ -32,7 +32,7 @@ endif
 DLL := .so
 
 ifdef STAN_MPI
-  LDFLAGS_MPI = -L$(BOOST_LIB) -lboost_serialization -lboost_mpi -Wl,-rpath,$(BOOST_LIB_ABS)
+  LDFLAGS_MPI = -L"$(BOOST_LIB)" -lboost_serialization -lboost_mpi -Wl,-rpath,"$(BOOST_LIB_ABS)"
   CXXFLAGS_MPI = -DSTAN_MPI
   LIBMPI = $(BOOST_LIB)/libboost_mpi$(DLL) $(BOOST_LIB)/libboost_serialization$(DLL)
 endif

--- a/make/os_mac
+++ b/make/os_mac
@@ -23,7 +23,7 @@ endif
 DLL := .dylib
 
 ifdef STAN_MPI
-  LDFLAGS_MPI = -L$(BOOST_LIB) -lboost_serialization -lboost_mpi -Wl,-rpath,$(BOOST_LIB_ABS)
+  LDFLAGS_MPI = -L"$(BOOST_LIB)" -lboost_serialization -lboost_mpi -Wl,-rpath,"$(BOOST_LIB_ABS)"
   CXXFLAGS_MPI = -DSTAN_MPI
   LIBMPI = $(BOOST_LIB)/libboost_mpi$(DLL) $(BOOST_LIB)/libboost_serialization$(DLL)
 endif

--- a/make/tests
+++ b/make/tests
@@ -13,7 +13,7 @@ $(GTEST)/src/gtest-all.o: CXXFLAGS += $(GTEST_CXXFLAGS)
 
 test/%$(EXE) : CXXFLAGS += $(GTEST_CXXFLAGS)
 test/%$(EXE) : test/%.o $(GTEST_MAIN) $(GTEST)/src/gtest-all.o
-	$(LINK.cpp) -o $@ $^ $(LDFLAGS_OPENCL)
+	$(LINK.cpp) -o $@ $^ $(LDFLAGS_OPENCL) $(LDFLAGS_MPI)
 
 ##
 # Rule for generating dependencies.
@@ -23,7 +23,7 @@ test/%.d : test/%.cpp
 	@mkdir -p $(dir $@)
 	@set -e; \
 	rm -f $@; \
-	$(COMPILE.cpp) -MM $< > $@.$$$$; \
+	$(COMPILE.cpp) $< -MM > $@.$$$$; \
 	sed -e 's,\($(*F)\)\.o[ :]*,$(@D)/\1.o $@ : ,g' < $@.$$$$ > $@; \
 	rm -f $@.$$$$
 


### PR DESCRIPTION
#### Submission Checklist

- [X] Run unit tests: `./runTests.py test/unit` (for the MPI tests)
- [ ] Run cpplint: `make cpplint`
- [X] Declare copyright holder and open-source license: see below

#### Summary:
Fix issues with path's including spaces and fix issues with the linker happening occasionally on Jenkins (this last bit is hard for me to reproduce locally).

#### Intended Effect:
Fix build issues with MPI in some occasions.

#### How to Verify:
Place math in directory with a space `../some space/math`, for example. Then enable MPI by putting into `make/local`
```
STAN_MPI=true
CC=mpicxx
```
then run these tests:
```
test/unit/map_rect_mpi_test.cpp
test/unit/math/rev/mat/functor/map_rect_mpi_test.cpp
test/unit/math/prim/mat/functor/map_rect_mpi_test.cpp
test/unit/math/prim/mat/functor/mpi_parallel_call_test.cpp
test/unit/math/prim/arr/functor/mpi_cluster_test.cpp
```

#### Side Effects:
None

#### Documentation:
None

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Sebastian Weber

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)