### PR TITLE
avoid random random numbers by avoiding the use of std::random_device

### DIFF
--- a/test/unit/math/fwd/mat/fun/matrix_exp_test.cpp
+++ b/test/unit/math/fwd/mat/fun/matrix_exp_test.cpp
@@ -140,7 +140,7 @@ TEST(MathMatrix, matrix_exp_100x100) {
   using stan::math::matrix_fd;
 
   int size = 100;
-  std::random_device rd;
+  std::mt19937 rd(1);
   std::mt19937 mt(rd());
   Matrix<double, Dynamic, Dynamic> S = Eigen::MatrixXd::Identity(size, size),
                                    I = Eigen::MatrixXd::Identity(size, size);

--- a/test/unit/math/mix/mat/fun/append_array_test.cpp
+++ b/test/unit/math/mix/mat/fun/append_array_test.cpp
@@ -48,7 +48,7 @@ typedef Eigen::Matrix<ffv, Eigen::Dynamic, Eigen::Dynamic> Mffv;
  */
 template <typename T1>
 void build(int n1, int n0, T1& z) {
-  std::random_device rd;
+  std::mt19937 rd(1);
   std::mt19937 mt(rd());
   z = T1(rd());
 }
@@ -230,7 +230,7 @@ void checkv() {
   std::vector<T2> y;
   std::vector<T3> result;
 
-  std::random_device rd;
+  std::mt19937 rd(1);
   std::mt19937 mt(rd());
 
   int r1 = rd() % 5, r2 = rd() % 5 + 1, r3 = rd() % 5 + 1, r4 = rd() % 5;
@@ -260,7 +260,7 @@ void checkvv() {
   std::vector<std::vector<T2> > y;
   std::vector<std::vector<T3> > result;
 
-  std::random_device rd;
+  std::mt19937 rd(1);
   std::mt19937 mt(rd());
 
   int r1 = rd() % 5, r2 = rd() % 5 + 1, r3 = rd() % 5 + 1, r4 = rd() % 5 + 1,

--- a/test/unit/math/prim/mat/fun/matrix_exp_pade_test.cpp
+++ b/test/unit/math/prim/mat/fun/matrix_exp_pade_test.cpp
@@ -49,7 +49,7 @@ TEST(MathMatrix, matrix_exp_100x100) {
   Matrix<double, Dynamic, Dynamic> S = Eigen::MatrixXd::Identity(size, size),
                                    I = Eigen::MatrixXd::Identity(size, size);
   int col1, col2;
-  std::random_device rd;
+  std::mt19937 rd(1);
   std::mt19937 mt(rd());
   for (int i = 0; i < 5 * size; i++) {
     col1 = rd() % size;

--- a/test/unit/math/prim/mat/fun/matrix_exp_test.cpp
+++ b/test/unit/math/prim/mat/fun/matrix_exp_test.cpp
@@ -59,7 +59,7 @@ TEST(MathMatrix, matrix_exp_100x100) {
   Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> S
       = Eigen::MatrixXd::Identity(size, size),
       I = Eigen::MatrixXd::Identity(size, size);
-  std::random_device rd;
+  std::mt19937 rd(1);
   std::mt19937 mt(rd());
   int col1, col2;
   for (int i = 0; i < 5 * size; i++) {

--- a/test/unit/math/prim/mat/prob/lkj_cov_test.cpp
+++ b/test/unit/math/prim/mat/prob/lkj_cov_test.cpp
@@ -3,7 +3,7 @@
 #include <random>
 
 TEST(ProbDistributionsLkjCorr, testIdentity) {
-  std::random_device rd;
+  std::mt19937 rd(1);
   std::mt19937 mt(rd());
   unsigned int K = 4;
   Eigen::MatrixXd Sigma(K, K);
@@ -18,7 +18,7 @@ TEST(ProbDistributionsLkjCorr, testIdentity) {
 }
 
 TEST(ProbDistributionsLkjCorr, testHalf) {
-  std::random_device rd;
+  std::mt19937 rd(1);
   std::mt19937 mt(rd());
   unsigned int K = 4;
   Eigen::MatrixXd Sigma(K, K);
@@ -34,7 +34,7 @@ TEST(ProbDistributionsLkjCorr, testHalf) {
 }
 
 TEST(ProbDistributionsLkjCorr, Sigma) {
-  std::random_device rd;
+  std::mt19937 rd(1);
   std::mt19937 mt(rd());
   unsigned int K = 4;
   Eigen::MatrixXd Sigma(K, K);

--- a/test/unit/math/rev/mat/fun/matrix_exp_pade_test.cpp
+++ b/test/unit/math/rev/mat/fun/matrix_exp_pade_test.cpp
@@ -100,7 +100,7 @@ TEST(MathMatrix, matrix_exp_25x25) {
 
   int size = 25;
 
-  std::random_device rd;
+  std::mt19937 rd(1);
   std::mt19937 mt(rd());
 
   // Randomly construct input matrix

--- a/test/unit/math/rev/mat/fun/matrix_exp_test.cpp
+++ b/test/unit/math/rev/mat/fun/matrix_exp_test.cpp
@@ -124,7 +124,7 @@ TEST(MathMatrix, matrix_exp_25x25) {
 
   int size = 25;
 
-  std::random_device rd;
+  std::mt19937 rd(1);
   std::mt19937 mt(rd());
 
   // Randomly construct input matrix


### PR DESCRIPTION
#### Submission Checklist

- [X] Run unit tests: `./runTests.py test/unit`
- [ ] Run cpplint: `make cpplint`
- [X] Declare copyright holder and open-source license: see below

#### Summary:
This fixes issue #890 which reports that some tests fail occasionally. It turns out that we use random random numbers ... that is the random seed of used for the random generator in some tests were derived using the `stan::random_device` facility such that the random number generator stream changed from test to test. This happens to trigger once in a while test failures.

This PR now replaces the `std::random_device` generator with a mersenne twister seeded with seed 1. Thus we will get always the same tests whenever things are sufficiently stable. This should avoid occasionally breaking tests while we still use random numbers as needed.

#### Intended Effect:
Make tests reliable.

#### How to Verify:
Run the tests
```
test/unit/math/fwd/mat/fun/matrix_exp_test.cpp
test/unit/math/fwd/mat/fun/matrix_exp_pade_test.cpp
test/unit/math/mix/mat/fun/append_array_test.cpp
test/unit/math/rev/mat/fun/matrix_exp_test.cpp
test/unit/math/prim/mat/prob/lkj_cov_test.cpp
test/unit/math/prim/mat/fun/matrix_exp_test.cpp
test/unit/math/prim/mat/fun/matrix_exp_pade_test.cpp
```

#### Side Effects:
None.

#### Documentation:
NA

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Sebastian Weber

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)