### PR TITLE
Feature/thin qr

### DIFF
--- a/stan/math/prim/mat.hpp
+++ b/stan/math/prim/mat.hpp
@@ -186,6 +186,8 @@
 #include <stan/math/prim/mat/fun/promote_scalar_type.hpp>
 #include <stan/math/prim/mat/fun/qr_Q.hpp>
 #include <stan/math/prim/mat/fun/qr_R.hpp>
+#include <stan/math/prim/mat/fun/qr_thin_Q.hpp>
+#include <stan/math/prim/mat/fun/qr_thin_R.hpp>
 #include <stan/math/prim/mat/fun/quad_form.hpp>
 #include <stan/math/prim/mat/fun/quad_form_diag.hpp>
 #include <stan/math/prim/mat/fun/quad_form_sym.hpp>

--- a/stan/math/prim/mat/fun/qr_Q.hpp
+++ b/stan/math/prim/mat/fun/qr_Q.hpp
@@ -10,6 +10,12 @@
 namespace stan {
 namespace math {
 
+/**
+ * Returns the orthogonal factor of the fat QR decomposition
+ * @param m Matrix.
+ * @tparam T scalar type
+ * @return Orthogonal matrix with maximal columns
+ */
 template <typename T>
 Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> qr_Q(
     const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& m) {

--- a/stan/math/prim/mat/fun/qr_Q.hpp
+++ b/stan/math/prim/mat/fun/qr_Q.hpp
@@ -5,6 +5,7 @@
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/scal/err/check_greater_or_equal.hpp>
 #include <Eigen/QR>
+#include <algorithm>
 
 namespace stan {
 namespace math {
@@ -14,13 +15,11 @@ Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> qr_Q(
     const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& m) {
   typedef Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> matrix_t;
   check_nonzero_size("qr_Q", "m", m);
-  check_greater_or_equal("qr_Q", "m.rows()", static_cast<size_t>(m.rows()),
-                         static_cast<size_t>(m.cols()));
-
   Eigen::HouseholderQR<matrix_t> qr(m.rows(), m.cols());
   qr.compute(m);
   matrix_t Q = qr.householderQ();
-  for (int i = 0; i < m.cols(); i++)
+  const int min_size = std::min(m.rows(), m.cols());
+  for (int i = 0; i < min_size; i++)
     if (qr.matrixQR().coeff(i, i) < 0)
       Q.col(i) *= -1.0;
   return Q;

--- a/stan/math/prim/mat/fun/qr_R.hpp
+++ b/stan/math/prim/mat/fun/qr_R.hpp
@@ -5,6 +5,7 @@
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/scal/err/check_greater_or_equal.hpp>
 #include <Eigen/QR>
+#include <algorithm>
 
 namespace stan {
 namespace math {
@@ -14,14 +15,13 @@ Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> qr_R(
     const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& m) {
   typedef Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> matrix_t;
   check_nonzero_size("qr_R", "m", m);
-  check_greater_or_equal("qr_R", "m.rows()", static_cast<size_t>(m.rows()),
-                         static_cast<size_t>(m.cols()));
   Eigen::HouseholderQR<matrix_t> qr(m.rows(), m.cols());
   qr.compute(m);
   matrix_t R = qr.matrixQR();
   if (m.rows() > m.cols())
     R.bottomRows(m.rows() - m.cols()).setZero();
-  for (int i = 0; i < R.cols(); i++) {
+  const int min_size = std::min(m.rows(), m.cols());
+  for (int i = 0; i < min_size; i++) {
     for (int j = 0; j < i; j++)
       R.coeffRef(i, j) = 0.0;
     if (R(i, i) < 0)

--- a/stan/math/prim/mat/fun/qr_R.hpp
+++ b/stan/math/prim/mat/fun/qr_R.hpp
@@ -10,6 +10,12 @@
 namespace stan {
 namespace math {
 
+/**
+ * Returns the upper triangular factor of the fat QR decomposition
+ * @param m Matrix.
+ * @tparam T scalar type
+ * @return Upper triangular matrix with maximal rows
+ */
 template <typename T>
 Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> qr_R(
     const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& m) {

--- a/stan/math/prim/mat/fun/qr_thin_Q.hpp
+++ b/stan/math/prim/mat/fun/qr_thin_Q.hpp
@@ -10,11 +10,17 @@
 namespace stan {
 namespace math {
 
+/**
+ * Returns the orthogonal factor of the thin QR decomposition
+ * @param m Matrix.
+ * @tparam T scalar type
+ * @return Orthogonal matrix with minimal columns
+ */
 template <typename T>
 Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> qr_thin_Q(
     const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& m) {
   typedef Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> matrix_t;
-  check_nonzero_size("qr_Q", "m", m);
+  check_nonzero_size("qr_thin_Q", "m", m);
   Eigen::HouseholderQR<matrix_t> qr(m.rows(), m.cols());
   qr.compute(m);
   const int min_size = std::min(m.rows(), m.cols());

--- a/stan/math/prim/mat/fun/qr_thin_Q.hpp
+++ b/stan/math/prim/mat/fun/qr_thin_Q.hpp
@@ -1,0 +1,30 @@
+#ifndef STAN_MATH_PRIM_MAT_FUN_QR_THIN_Q_HPP
+#define STAN_MATH_PRIM_MAT_FUN_QR_THIN_Q_HPP
+
+#include <stan/math/prim/arr/err/check_nonzero_size.hpp>
+#include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <stan/math/prim/scal/err/check_greater_or_equal.hpp>
+#include <Eigen/QR>
+#include <algorithm>
+
+namespace stan {
+namespace math {
+
+template <typename T>
+Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> qr_thin_Q(
+    const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& m) {
+  typedef Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> matrix_t;
+  check_nonzero_size("qr_Q", "m", m);
+  Eigen::HouseholderQR<matrix_t> qr(m.rows(), m.cols());
+  qr.compute(m);
+  const int min_size = std::min(m.rows(), m.cols());
+  matrix_t Q = qr.householderQ() * matrix_t::Identity(m.rows(), min_size);
+  for (int i = 0; i < min_size; i++)
+    if (qr.matrixQR().coeff(i, i) < 0)
+      Q.col(i) *= -1.0;
+  return Q;
+}
+
+}  // namespace math
+}  // namespace stan
+#endif

--- a/stan/math/prim/mat/fun/qr_thin_R.hpp
+++ b/stan/math/prim/mat/fun/qr_thin_R.hpp
@@ -10,11 +10,17 @@
 namespace stan {
 namespace math {
 
+/**
+ * Returns the upper triangular factor of the thin QR decomposition
+ * @param m Matrix.
+ * @tparam T scalar type
+ * @return Upper triangular matrix with minimal rows
+ */
 template <typename T>
 Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> qr_thin_R(
     const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& m) {
   typedef Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> matrix_t;
-  check_nonzero_size("qr_R", "m", m);
+  check_nonzero_size("qr_thin_R", "m", m);
   Eigen::HouseholderQR<matrix_t> qr(m.rows(), m.cols());
   qr.compute(m);
   const int min_size = std::min(m.rows(), m.cols());

--- a/stan/math/prim/mat/fun/qr_thin_R.hpp
+++ b/stan/math/prim/mat/fun/qr_thin_R.hpp
@@ -1,0 +1,33 @@
+#ifndef STAN_MATH_PRIM_MAT_FUN_QR_THIN_R_HPP
+#define STAN_MATH_PRIM_MAT_FUN_QR_THIN_R_HPP
+
+#include <stan/math/prim/arr/err/check_nonzero_size.hpp>
+#include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <stan/math/prim/scal/err/check_greater_or_equal.hpp>
+#include <Eigen/QR>
+#include <algorithm>
+
+namespace stan {
+namespace math {
+
+template <typename T>
+Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> qr_thin_R(
+    const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& m) {
+  typedef Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> matrix_t;
+  check_nonzero_size("qr_R", "m", m);
+  Eigen::HouseholderQR<matrix_t> qr(m.rows(), m.cols());
+  qr.compute(m);
+  const int min_size = std::min(m.rows(), m.cols());
+  matrix_t R = qr.matrixQR().topLeftCorner(min_size, m.cols());
+  for (int i = 0; i < min_size; i++) {
+    for (int j = 0; j < i; j++)
+      R.coeffRef(i, j) = 0.0;
+    if (R(i, i) < 0)
+      R.row(i) *= -1.0;
+  }
+  return R;
+}
+
+}  // namespace math
+}  // namespace stan
+#endif

--- a/test/unit/math/fwd/mat/fun/qr_thin_Q_test.cpp
+++ b/test/unit/math/fwd/mat/fun/qr_thin_Q_test.cpp
@@ -1,0 +1,75 @@
+#include <stan/math/fwd/mat.hpp>
+#include <gtest/gtest.h>
+
+TEST(AgradFwdMatrixQrQ, fd) {
+  using stan::math::matrix_d;
+  using stan::math::matrix_fd;
+  matrix_fd m0(0, 0);
+  matrix_d m2(3, 2);
+  matrix_fd m1(3, 2);
+  m1 << 1, 2, 3, 4, 5, 6;
+  m2 << 1, 2, 3, 4, 5, 6;
+  m1(0, 0).d_ = 1.0;
+  m1(0, 1).d_ = 1.0;
+  m1(1, 0).d_ = 1.0;
+  m1(1, 1).d_ = 1.0;
+  m1(2, 0).d_ = 1.0;
+  m1(2, 1).d_ = 1.0;
+
+  using stan::math::qr_thin_Q;
+  using stan::math::transpose;
+  EXPECT_THROW(qr_thin_Q(m0), std::invalid_argument);
+  EXPECT_NO_THROW(qr_thin_Q(m1));
+
+  matrix_fd res = qr_thin_Q(m1);
+  matrix_d res2 = qr_thin_Q(m2);
+
+  for (int i = 0; i < res2.rows(); i++)
+    for (int j = 0; j < res2.cols(); j++)
+      EXPECT_FLOAT_EQ(res2(i, j), res(i, j).val_);
+
+  EXPECT_FLOAT_EQ(0.12556578, res(0, 0).d_);
+  EXPECT_FLOAT_EQ(-0.023659391, res(0, 1).d_);
+  // EXPECT_NEAR(0, res(0, 2).d_, 1.0E-12);
+  EXPECT_FLOAT_EQ(0.038635623, res(1, 0).d_);
+  EXPECT_FLOAT_EQ(-0.070978172, res(1, 1).d_);
+  // EXPECT_NEAR(0, res(1, 2).d_, 1.0E-12);
+  EXPECT_FLOAT_EQ(-0.048294529, res(2, 0).d_);
+  EXPECT_FLOAT_EQ(-0.11829695, res(2, 1).d_);
+  // EXPECT_NEAR(0, res(2, 2).d_, 1.0E-12);
+}
+
+TEST(AgradFwdMatrixQrQ, ffd) {
+  using stan::math::matrix_d;
+  using stan::math::matrix_ffd;
+  matrix_ffd m0(0, 0);
+  matrix_d m2(3, 2);
+  matrix_ffd m1(3, 2);
+  m1 << 1, 2, 3, 4, 5, 6;
+  m2 << 1, 2, 3, 4, 5, 6;
+  m1(0, 0).d_ = 1.0;
+  m1(0, 1).d_ = 1.0;
+  m1(1, 0).d_ = 1.0;
+  m1(1, 1).d_ = 1.0;
+  m1(2, 0).d_ = 1.0;
+  m1(2, 1).d_ = 1.0;
+
+  using stan::math::qr_thin_Q;
+  using stan::math::transpose;
+  EXPECT_THROW(qr_thin_Q(m0), std::invalid_argument);
+  EXPECT_NO_THROW(qr_thin_Q(m1));
+
+  matrix_ffd res = qr_thin_Q(m1);
+  matrix_d res2 = qr_thin_Q(m2);
+
+  for (int i = 0; i < res2.rows(); i++)
+    for (int j = 0; j < res2.cols(); j++)
+      EXPECT_FLOAT_EQ(res2(i, j), res(i, j).val_.val_);
+
+  EXPECT_FLOAT_EQ(0.12556578, res(0, 0).d_.val_);
+  EXPECT_FLOAT_EQ(-0.023659391, res(0, 1).d_.val_);
+  EXPECT_FLOAT_EQ(0.038635623, res(1, 0).d_.val_);
+  EXPECT_FLOAT_EQ(-0.070978172, res(1, 1).d_.val_);
+  EXPECT_FLOAT_EQ(-0.048294529, res(2, 0).d_.val_);
+  EXPECT_FLOAT_EQ(-0.11829695, res(2, 1).d_.val_);
+}

--- a/test/unit/math/fwd/mat/fun/qr_thin_R_test.cpp
+++ b/test/unit/math/fwd/mat/fun/qr_thin_R_test.cpp
@@ -1,0 +1,72 @@
+#include <stan/math/fwd/mat.hpp>
+#include <gtest/gtest.h>
+
+TEST(AgradFwdMatrixQrR, fd) {
+  using stan::math::matrix_d;
+  using stan::math::matrix_fd;
+  matrix_fd m0(0, 0);
+  matrix_d m2(3, 2);
+  matrix_fd m1(3, 2);
+  m1 << 1, 2, 3, 4, 5, 6;
+  m2 << 1, 2, 3, 4, 5, 6;
+  m1(0, 0).d_ = 1.0;
+  m1(0, 1).d_ = 1.0;
+  m1(1, 0).d_ = 1.0;
+  m1(1, 1).d_ = 1.0;
+  m1(2, 0).d_ = 1.0;
+  m1(2, 1).d_ = 1.0;
+
+  using stan::math::qr_thin_R;
+  using stan::math::transpose;
+  EXPECT_THROW(qr_thin_R(m0), std::invalid_argument);
+  EXPECT_NO_THROW(qr_thin_R(m1));
+
+  matrix_fd res = qr_thin_R(m1);
+  matrix_d res2 = qr_thin_R(m2);
+
+  for (int i = 0; i < res2.rows(); i++)
+    for (int j = 0; j < res2.cols(); j++)
+      EXPECT_FLOAT_EQ(res2(i, j), res(i, j).val_);
+
+  EXPECT_FLOAT_EQ(1.5212777, res(0, 0).d_);
+  EXPECT_FLOAT_EQ(1.6371845, res(0, 1).d_);
+  EXPECT_FLOAT_EQ(0, res(1, 0).d_);
+  EXPECT_FLOAT_EQ(-0.21293451, res(1, 1).d_);
+  // EXPECT_FLOAT_EQ(0, res(2, 0).d_);
+  // EXPECT_FLOAT_EQ(0, res(2, 1).d_);
+}
+
+TEST(AgradFwdMatrixQrR, ffd) {
+  using stan::math::matrix_d;
+  using stan::math::matrix_ffd;
+  matrix_ffd m0(0, 0);
+  matrix_d m2(3, 2);
+  matrix_ffd m1(3, 2);
+  m1 << 1, 2, 3, 4, 5, 6;
+  m2 << 1, 2, 3, 4, 5, 6;
+  m1(0, 0).d_ = 1.0;
+  m1(0, 1).d_ = 1.0;
+  m1(1, 0).d_ = 1.0;
+  m1(1, 1).d_ = 1.0;
+  m1(2, 0).d_ = 1.0;
+  m1(2, 1).d_ = 1.0;
+
+  using stan::math::qr_thin_R;
+  using stan::math::transpose;
+  EXPECT_THROW(qr_thin_R(m0), std::invalid_argument);
+  EXPECT_NO_THROW(qr_thin_R(m1));
+
+  matrix_ffd res = qr_thin_R(m1);
+  matrix_d res2 = qr_thin_R(m2);
+
+  for (int i = 0; i < res2.rows(); i++)
+    for (int j = 0; j < res2.cols(); j++)
+      EXPECT_FLOAT_EQ(res2(i, j), res(i, j).val_.val_);
+
+  EXPECT_FLOAT_EQ(1.5212777, res(0, 0).d_.val_);
+  EXPECT_FLOAT_EQ(1.6371845, res(0, 1).d_.val_);
+  EXPECT_FLOAT_EQ(0, res(1, 0).d_.val_);
+  EXPECT_FLOAT_EQ(-0.21293451, res(1, 1).d_.val_);
+  // EXPECT_FLOAT_EQ(0, res(2, 0).d_.val_);
+  // EXPECT_FLOAT_EQ(0, res(2, 1).d_.val_);
+}

--- a/test/unit/math/prim/mat/fun/qr_Q_test.cpp
+++ b/test/unit/math/prim/mat/fun/qr_Q_test.cpp
@@ -10,5 +10,5 @@ TEST(MathMatrix, qr_Q) {
   using stan::math::transpose;
   EXPECT_THROW(qr_Q(m0), std::invalid_argument);
   EXPECT_NO_THROW(qr_Q(m1));
-  EXPECT_THROW(qr_Q(transpose(m1)), std::domain_error);
+  EXPECT_NO_THROW(qr_Q(transpose(m1)));
 }

--- a/test/unit/math/prim/mat/fun/qr_R_test.cpp
+++ b/test/unit/math/prim/mat/fun/qr_R_test.cpp
@@ -23,5 +23,13 @@ TEST(MathMatrix, qr_R) {
       EXPECT_NEAR(m1(i, j), m2(i, j), 1e-12);
     }
   }
-  EXPECT_THROW(qr_R(transpose(m1)), std::domain_error);
+  for (unsigned int j = 0; j < m1.cols(); j++)
+    EXPECT_TRUE(R(j, j) >= 0.0);
+  stan::math::matrix_d m3(2, 4);
+  m3 = qr_Q(transpose(m1)) * qr_R(transpose(m1));
+  for (unsigned int i = 0; i < m1.rows(); i++) {
+    for (unsigned int j = 0; j < m1.cols(); j++) {
+      EXPECT_NEAR(m1(i, j), m3(j, i), 1e-12);
+    }
+  }
 }

--- a/test/unit/math/prim/mat/fun/qr_thin_Q_test.cpp
+++ b/test/unit/math/prim/mat/fun/qr_thin_Q_test.cpp
@@ -1,0 +1,14 @@
+#include <stan/math/prim/mat.hpp>
+#include <gtest/gtest.h>
+
+TEST(MathMatrix, qr_thin_Q) {
+  stan::math::matrix_d m0(0, 0);
+  stan::math::matrix_d m1(3, 2);
+  m1 << 1, 2, 3, 4, 5, 6;
+
+  using stan::math::qr_thin_Q;
+  using stan::math::transpose;
+  EXPECT_THROW(qr_thin_Q(m0), std::invalid_argument);
+  EXPECT_NO_THROW(qr_thin_Q(m1));
+  EXPECT_NO_THROW(qr_thin_Q(transpose(m1)));
+}

--- a/test/unit/math/prim/mat/fun/qr_thin_R_test.cpp
+++ b/test/unit/math/prim/mat/fun/qr_thin_R_test.cpp
@@ -33,4 +33,14 @@ TEST(MathMatrix, qr_thin_R) {
       EXPECT_NEAR(m1(i, j), m3(j, i), 1e-12);
     }
   }
+
+  stan::math::matrix_d m4(3, 3);
+  m4 << -1, -2, -3, -4, -5, -6, -7, -8, -9;
+  stan::math::matrix_d m5(3, 3);
+  m5 = qr_thin_Q(m4) * qr_thin_R(m4);
+  for (unsigned int i = 0; i < m4.rows(); i++) {
+    for (unsigned int j = 0; j < m4.cols(); j++) {
+      EXPECT_NEAR(m4(i, j), m5(i, j), 1e-12);
+    }
+  }
 }

--- a/test/unit/math/prim/mat/fun/qr_thin_R_test.cpp
+++ b/test/unit/math/prim/mat/fun/qr_thin_R_test.cpp
@@ -1,0 +1,36 @@
+#include <stan/math/prim/mat.hpp>
+#include <gtest/gtest.h>
+
+TEST(MathMatrix, qr_thin_R) {
+  stan::math::matrix_d m0(0, 0);
+  stan::math::matrix_d m1(4, 2);
+  m1 << 1, 2, 3, 4, 5, 6, 7, 8;
+
+  using stan::math::qr_thin_Q;
+  using stan::math::qr_thin_R;
+  using stan::math::transpose;
+  EXPECT_THROW(qr_thin_R(m0), std::invalid_argument);
+  EXPECT_NO_THROW(qr_thin_R(m1));
+
+  stan::math::matrix_d m2(4, 2);
+  stan::math::matrix_d Q(4, 2);
+  stan::math::matrix_d R(2, 2);
+  Q = qr_thin_Q(m1);
+  R = qr_thin_R(m1);
+  m2 = Q * R;
+  for (unsigned int i = 0; i < m1.rows(); i++) {
+    for (unsigned int j = 0; j < m1.cols(); j++) {
+      EXPECT_NEAR(m1(i, j), m2(i, j), 1e-12);
+    }
+  }
+  for (unsigned int j = 0; j < m1.cols(); j++)
+    EXPECT_TRUE(R(j, j) >= 0.0);
+
+  stan::math::matrix_d m3(2, 4);
+  m3 = qr_thin_Q(transpose(m1)) * qr_thin_R(transpose(m1));
+  for (unsigned int i = 0; i < m1.rows(); i++) {
+    for (unsigned int j = 0; j < m1.cols(); j++) {
+      EXPECT_NEAR(m1(i, j), m3(j, i), 1e-12);
+    }
+  }
+}

--- a/test/unit/math/rev/mat/fun/qr_Q_test.cpp
+++ b/test/unit/math/rev/mat/fun/qr_Q_test.cpp
@@ -12,7 +12,6 @@ TEST(MathMatrix, qr_Q) {
   using stan::math::transpose;
   EXPECT_THROW(qr_Q(m0), std::invalid_argument);
   EXPECT_NO_THROW(qr_Q(m1));
-  EXPECT_THROW(qr_Q(transpose(m1)), std::domain_error);
 }
 TEST(AgradRevMatrix, check_varis_on_stack) {
   stan::math::matrix_v m1(3, 2);

--- a/test/unit/math/rev/mat/fun/qr_R_test.cpp
+++ b/test/unit/math/rev/mat/fun/qr_R_test.cpp
@@ -21,7 +21,6 @@ TEST(MathMatrix, qr_R) {
       EXPECT_NEAR(m1(i, j).val(), m2(i, j).val(), 1e-8);
     }
   }
-  EXPECT_THROW(qr_R(transpose(m1)), std::domain_error);
 }
 TEST(AgradRevMatrix, check_varis_on_stack) {
   stan::math::matrix_v m1(3, 2);

--- a/test/unit/math/rev/mat/fun/qr_thin_Q_test.cpp
+++ b/test/unit/math/rev/mat/fun/qr_thin_Q_test.cpp
@@ -1,0 +1,20 @@
+#include <stan/math/rev/mat.hpp>
+#include <gtest/gtest.h>
+#include <test/unit/math/rev/mat/fun/util.hpp>
+#include <test/unit/math/rev/mat/util.hpp>
+
+TEST(MathMatrix, qr_Q) {
+  stan::math::matrix_v m0(0, 0);
+  stan::math::matrix_v m1(3, 2);
+  m1 << 1, 2, 3, 4, 5, 6;
+
+  using stan::math::qr_thin_Q;
+  using stan::math::transpose;
+  EXPECT_THROW(qr_thin_Q(m0), std::invalid_argument);
+  EXPECT_NO_THROW(qr_Q(m1));
+}
+TEST(AgradRevMatrix, check_varis_on_stack) {
+  stan::math::matrix_v m1(3, 2);
+  m1 << 1, 2, 3, 4, 5, 6;
+  test::check_varis_on_stack(stan::math::qr_thin_Q(m1));
+}

--- a/test/unit/math/rev/mat/fun/qr_thin_R_test.cpp
+++ b/test/unit/math/rev/mat/fun/qr_thin_R_test.cpp
@@ -1,0 +1,29 @@
+#include <stan/math/rev/mat.hpp>
+#include <gtest/gtest.h>
+#include <test/unit/math/rev/mat/fun/util.hpp>
+#include <test/unit/math/rev/mat/util.hpp>
+
+TEST(MathMatrix, qr_R) {
+  stan::math::matrix_v m0(0, 0);
+  stan::math::matrix_v m1(3, 2);
+  m1 << 1, 2, 3, 4, 5, 6;
+
+  using stan::math::qr_thin_Q;
+  using stan::math::qr_thin_R;
+  using stan::math::transpose;
+  EXPECT_THROW(qr_thin_R(m0), std::invalid_argument);
+  EXPECT_NO_THROW(qr_thin_R(m1));
+
+  stan::math::matrix_v m2(3, 2);
+  m2 = qr_thin_Q(m1) * qr_thin_R(m1);
+  for (unsigned int i = 0; i < m1.rows(); i++) {
+    for (unsigned int j = 0; j < m1.cols(); j++) {
+      EXPECT_NEAR(m1(i, j).val(), m2(i, j).val(), 1e-8);
+    }
+  }
+}
+TEST(AgradRevMatrix, check_varis_on_stack) {
+  stan::math::matrix_v m1(3, 2);
+  m1 << 1, 2, 3, 4, 5, 6;
+  test::check_varis_on_stack(stan::math::qr_thin_R(m1));
+}


### PR DESCRIPTION
#### Submission Checklist

- [X] Run unit tests: `./runTests.py test/unit`
- [X] Run cpplint: `make cpplint`
- [X] Declare copyright holder and open-source license: see below

#### Summary:

Implement the thin QR decomposition (fixes #899)

Also, relax restriction in fat QR decomposition that the input matrix has at least as many rows as columns

#### Intended Effect:

Not run out of RAM

#### How to Verify:

Run the tests

#### Side Effects:

Stan does not crash on big input matrices

#### Documentation:

None. Documentation in the user manual will have to get updated

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Trustees of Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
