### PR TITLE
loosen tolerances of matrix_exp tests to avoid random failure

### DIFF
--- a/test/unit/math/fwd/mat/fun/matrix_exp_pade_test.cpp
+++ b/test/unit/math/fwd/mat/fun/matrix_exp_pade_test.cpp
@@ -143,10 +143,10 @@ TEST(MathMatrix, matrix_exp_100x100) {
   // Note: because of the way of matrix was constructed,
   // derivative should be the same as value (same case
   // as in the previous test).
-  double rel_err = 1e-10
+  double rel_err = 1e-6
                    * std::max(exp_A.cwiseAbs().maxCoeff(),
                               expm_A.cwiseAbs().maxCoeff().val_),
-         rel_err_d = 1e-10
+         rel_err_d = 1e-6
                      * std::max(exp_A.cwiseAbs().maxCoeff(),
                                 expm_A.cwiseAbs().maxCoeff().d_);
 

--- a/test/unit/math/fwd/mat/fun/matrix_exp_test.cpp
+++ b/test/unit/math/fwd/mat/fun/matrix_exp_test.cpp
@@ -170,10 +170,10 @@ TEST(MathMatrix, matrix_exp_100x100) {
   // Note: because of the way of matrix was constructed,
   // derivative should be the same as value (same case
   // as in the previous test).
-  double rel_err = 1e-10
+  double rel_err = 1e-6
                    * std::max(exp_A.cwiseAbs().maxCoeff(),
                               expm_A.cwiseAbs().maxCoeff().val_),
-         rel_err_d = 1e-10
+         rel_err_d = 1e-6
                      * std::max(exp_A.cwiseAbs().maxCoeff(),
                                 expm_A.cwiseAbs().maxCoeff().d_);
 

--- a/test/unit/math/prim/mat/fun/matrix_exp_pade_test.cpp
+++ b/test/unit/math/prim/mat/fun/matrix_exp_pade_test.cpp
@@ -71,7 +71,7 @@ TEST(MathMatrix, matrix_exp_100x100) {
   expm_A = stan::math::matrix_exp_pade(A);
 
   double rel_err
-      = 1e-10
+      = 1e-6
         * std::max(exp_A.cwiseAbs().maxCoeff(), expm_A.cwiseAbs().maxCoeff());
 
   for (int i = 0; i < size; i++)

--- a/test/unit/math/prim/mat/fun/matrix_exp_test.cpp
+++ b/test/unit/math/prim/mat/fun/matrix_exp_test.cpp
@@ -82,7 +82,7 @@ TEST(MathMatrix, matrix_exp_100x100) {
       expm_A = stan::math::matrix_exp(A);
 
   double rel_err
-      = 1e-10
+      = 1e-6
         * std::max(exp_A.cwiseAbs().maxCoeff(), expm_A.cwiseAbs().maxCoeff());
 
   for (int i = 0; i < size; i++)

--- a/test/unit/math/rev/mat/fun/matrix_exp_test.cpp
+++ b/test/unit/math/rev/mat/fun/matrix_exp_test.cpp
@@ -153,7 +153,7 @@ TEST(MathMatrix, matrix_exp_25x25) {
   Matrix<double, Dynamic, Dynamic> exp_A
       = S * exp_diag_elements.asDiagonal() * S_inv;
 
-  double rel_err = 1e-10
+  double rel_err = 1e-6
                    * std::max(exp_A.cwiseAbs().maxCoeff(),
                               expm_A.cwiseAbs().maxCoeff().val());
 
@@ -177,7 +177,7 @@ TEST(MathMatrix, matrix_exp_25x25) {
         dA(k, k) = exp(diag_elements(k));
         dA_exp = S * dA * S_inv;
         rel_err = std::max(dA_exp.cwiseAbs().maxCoeff(), stan::math::max(g_abs))
-                  * 1e-10;
+                  * 1e-6;
         EXPECT_NEAR(dA_exp(i, j), diag_elements_var(k).adj(), rel_err);
       }
     }


### PR DESCRIPTION
#### Submission Checklist

- [X] Run unit tests: `./runTests.py test/unit`
- [X] Run cpplint: `make cpplint`
- [X] Declare copyright holder and open-source license: see below

#### Summary:
This fixes issue #890 which reports that some matrix exponential tests fail occasionally due to the use of truly random numbers (some random draws apparently create numerically too challenging cases).

This PR adresses the matter by loosening the tolerances used for testing correctness in the tests involving true randomness of the matrix exponential. This PR is an alternative to https://github.com/stan-dev/math/pull/898 ... so we merge this one or the other one.

I think this is urgent as this causes hickups for our test pipeline. As such this PR is rather pragmatic and we probably need to revisit (@charlesm93 or @yizhang-cae may take a look?).

EDIT: The issue for revising this is here: https://github.com/stan-dev/math/issues/902

#### Intended Effect:
Make unit tests again stable.

#### How to Verify:
Look at and run the tests
```
test/unit/math/fwd/mat/fun/matrix_exp_test.cpp
test/unit/math/fwd/mat/fun/matrix_exp_pade_test.cpp
test/unit/math/rev/mat/fun/matrix_exp_test.cpp
test/unit/math/prim/mat/fun/matrix_exp_test.cpp
test/unit/math/prim/mat/fun/matrix_exp_pade_test.cpp
```

#### Side Effects:
Tolerances of the matrix exponential tests are loosened to 10^-6. 

#### Documentation:

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Sebastian Weber

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
