### PR TITLE
Feature/issue 905 make mpi 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -138,7 +138,7 @@ matrix:
 
  # - TESTFOLDER=test/unit/math/mix # times out on travis
 
-script: ./runTests.py -j2 $TESTFOLDER
+script: PARALLEL=2 ./runTests.py -j2 $TESTFOLDER
 
 sudo: false
 dist: trusty

--- a/make/libraries
+++ b/make/libraries
@@ -7,8 +7,8 @@ BOOST_LIB ?= $(MATH)lib/boost_1.66.0/stage/lib
 GTEST ?= $(MATH)lib/gtest_1.7.0
 CPPLINT ?= $(MATH)lib/cpplint_4.45
 OPENCL ?= $(MATH)lib/opencl_1.2.8
-IDAS ?= $(MATH)lib/idas-2.1.0
 SUNDIALS ?= $(MATH)lib/sundials_3.1.0
+BOOST_PARALLEL_BUILD ?= $(PARALLEL)
 
 ##
 # Build rules for cvodes
@@ -68,7 +68,7 @@ $(BOOST_LIB)/mpi.so:
 	@mkdir -p $(dir $@)
 	cd $(BOOST); ./bootstrap.sh
 	cd $(BOOST); echo "using mpi ;" >> user-config.jam
-	cd $(BOOST); ./b2 --user-config=user-config.jam --with-mpi --with-serialization
+	cd $(BOOST); ./b2 --user-config=user-config.jam --layout=system --with-mpi --with-serialization -j$(or $(BOOST_PARALLEL_BUILD),1) variant=release link=shared threading=multi runtime-link=shared
 
 $(BOOST_LIB)/libboost_serialization.so: $(BOOST_LIB)/mpi.so
 
@@ -85,6 +85,6 @@ $(BOOST_LIB)/libboost_mpi.dylib: $(BOOST_LIB)/mpi.so
 
 .PHONY: clean-libraries
 clean-libraries:
-	$(RM) $(sort $(SUNDIALS_CVODES) $(SUNDIALS_IDAS) $(SUNDIALS_NVECSERIAL) $(LIBSUNDIALS))
-	$(RM) -rf $(BOOST_LIB)/*  
-	$(RM) -rf $(BOOST)/bin.v2  
+	$(RM) $(sort $(SUNDIALS_CVODES) $(SUNDIALS_IDAS) $(SUNDIALS_NVECSERIAL) $(LIBSUNDIALS) $(LIBMPI))
+	$(RM) -rf $(BOOST_LIB)/*
+	$(RM) -rf $(BOOST)/bin.v2 $(BOOST)/tools/build/src/engine/bootstrap/ $(BOOST)/tools/build/src/engine/bin.* $(BOOST)/project-config.jam* $(BOOST)/b2 $(BOOST)/bjam $(BOOST)/bootstrap.log

--- a/make/os_linux
+++ b/make/os_linux
@@ -30,7 +30,3 @@ ifdef STAN_OPENCL
 endif
 
 DLL := .so
-
-ifdef STAN_MPI
-  LDFLAGS_MPI ?= -L"$(BOOST_LIB)" -lboost_serialization -lboost_mpi -Wl,-rpath,"$(BOOST_LIB_ABS)"
-endif

--- a/make/os_mac
+++ b/make/os_mac
@@ -21,7 +21,3 @@ ifdef STAN_OPENCL
 endif
 
 DLL := .dylib
-
-ifdef STAN_MPI
-  LDFLAGS_MPI ?= -L"$(BOOST_LIB)" -lboost_serialization -lboost_mpi -Wl,-rpath,"$(BOOST_LIB_ABS)"
-endif

--- a/make/setup_mpi
+++ b/make/setup_mpi
@@ -6,7 +6,7 @@
 # Defines
 #  STAN_MPI
 ifdef STAN_MPI
-  CXXFLAGS += -DSTAN_MPI
-  LDFLAGS += $(LDFLAGS_MPI)
+  CXXFLAGS_MPI = -DSTAN_MPI
+  LDFLAGS_MPI ?= -L"$(BOOST_LIB)" -lboost_serialization -lboost_mpi -Wl,-rpath,"$(BOOST_LIB_ABS)"
   LIBMPI = $(BOOST_LIB)/libboost_mpi$(DLL) $(BOOST_LIB)/libboost_serialization$(DLL) $(MATH)src/math/prim/arr/mpi_cluster.o
 endif

--- a/make/tests
+++ b/make/tests
@@ -69,17 +69,14 @@ $(OPENCL_TESTS) : LDFLAGS += $(LDFLAGS_OPENCL)
 #
 # MPI tests
 #
-# note: Since gtest main must manage the MPI ressource, currently all tests
-# are linked against MPI
+# note: Since gtest main must manage the MPI ressource, we include in all tests
+# MPI
 ##
 
-#ifdef STAN_MPI
+ifdef STAN_MPI
 #  MPI_TESTS := $(subst .cpp,$(EXE),$(shell find test -name *mpi_*test.cpp))
-#  $(MPI_TESTS): LDFLAGS += $(LDFLAGS_MPI)
-#  $(MPI_TESTS): CXXFLAGS += $(CXXFLAGS_MPI)
-#  $(MPI_TESTS): $(LIBMPI)
-#  GTEST_CXXFLAGS += $(CXXFLAGS_MPI)
-#endif
+  GTEST_CXXFLAGS += $(CXXFLAGS_MPI)
+endif
 
 ############################################################
 #


### PR DESCRIPTION
#### Submission Checklist

- [X] Run unit tests: `./runTests.py test/unit`
- [X] Run cpplint: `make cpplint`
- [X] Declare copyright holder and open-source license: see below

#### Summary:
Speed up boost build, do a more through clean-up of boost left-overs & take MPI out of the global CXXFLAGS & LDFLAGS if enabled

#### Intended Effect:
Faster build (and tests), better integration with cmdstan makefile logic (and specialities).

#### How to Verify:
Run the tests
```
test/unit/math/rev/mat/functor/map_rect_mpi_test.cpp
test/unit/math/prim/mat/functor/map_rect_mpi_test.cpp
test/unit/math/prim/mat/functor/mpi_parallel_call_test.cpp
test/unit/math/prim/arr/functor/mpi_cluster_test.cpp
```

#### Side Effects:
None

#### Documentation:

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Sebastian Weber

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)