### PR TITLE
align MPI code instantiation with stan conventions as good as possible

### DIFF
--- a/make/libraries
+++ b/make/libraries
@@ -78,7 +78,7 @@ $(BOOST_LIB)/libboost_serialization.dylib: $(BOOST_LIB)/mpi.so
 
 $(BOOST_LIB)/libboost_mpi.so: $(BOOST_LIB)/mpi.so
 
-$(BOOST_LIB)/libboost_mpi.dylib: $(BOOST_LIB)/mpi.so
+$(BOOST_LIB)/libboost_mpi.dylib: $(BOOST_LIB)/mpi.so $(BOOST_LIB)/libboost_serialization.dylib
 	install_name_tool -add_rpath "$(BOOST_LIB_ABS)" "$(BOOST_LIB)/libboost_mpi.dylib"
 	install_name_tool -change libboost_serialization.dylib @rpath/libboost_serialization.dylib "$(BOOST_LIB)/libboost_mpi.dylib"
 	install_name_tool -id @rpath/libboost_mpi.dylib "$(BOOST_LIB)/libboost_mpi.dylib"
@@ -88,3 +88,4 @@ clean-libraries:
 	$(RM) $(sort $(SUNDIALS_CVODES) $(SUNDIALS_IDAS) $(SUNDIALS_NVECSERIAL) $(LIBSUNDIALS) $(LIBMPI))
 	$(RM) -rf $(BOOST_LIB)/*
 	$(RM) -rf $(BOOST)/bin.v2 $(BOOST)/tools/build/src/engine/bootstrap/ $(BOOST)/tools/build/src/engine/bin.* $(BOOST)/project-config.jam* $(BOOST)/b2 $(BOOST)/bjam $(BOOST)/bootstrap.log
+	$(RM) -rf bin

--- a/make/libstanmath_mpi
+++ b/make/libstanmath_mpi
@@ -1,0 +1,12 @@
+MPI_TEMPLATE_INSTANTIATION_CPP := $(shell find stan -type f -name 'mpi_*_inst.cpp') $(shell find stan -type f -name 'mpi_*_def.cpp')
+MPI_TEMPLATE_INSTANTIATION := $(MPI_TEMPLATE_INSTANTIATION_CPP:stan/%.cpp=bin/%.o)
+
+# linking in MPI definitions via a static library does not work
+#bin/libstanmath_mpi.a : $(MPI_TEMPLATE_INSTANTIATION)
+#	@mkdir -p $(dir $@)
+#	$(AR) -rs bin/libstanmath_mpi.a $(MPI_TEMPLATE_INSTANTIATION)
+
+$(MPI_TEMPLATE_INSTANTIATION) : bin/%.o : stan/%.cpp
+	@mkdir -p $(dir $@)
+	$(COMPILE.cc) -c -O$(O_STANC) $(OUTPUT_OPTION) $(CXXFLAGS_MPI) $<
+

--- a/make/setup_mpi
+++ b/make/setup_mpi
@@ -5,8 +5,9 @@
 # link to MPI
 # Defines
 #  STAN_MPI
+# 
 ifdef STAN_MPI
-  LIBMPI = $(MATH)src/math/prim/arr/mpi_cluster.o $(BOOST_LIB)/libboost_mpi$(DLL) $(BOOST_LIB)/libboost_serialization$(DLL)
+  LIBMPI = $(BOOST_LIB)/libboost_serialization$(DLL) $(BOOST_LIB)/libboost_mpi$(DLL) bin/math/prim/arr/functor/mpi_cluster_inst.o
   CXXFLAGS_MPI = -DSTAN_MPI
   LDFLAGS_MPI ?= -Wl,-lboost_mpi -Wl,-lboost_serialization -Wl,-L,"$(BOOST_LIB_ABS)" -Wl,-rpath,"$(BOOST_LIB_ABS)"
 endif

--- a/makefile
+++ b/makefile
@@ -58,6 +58,8 @@ CXX = $(CC)
 #  STAN_MPI
 -include make/setup_mpi
 
+include make/libstanmath_mpi # bin/libstanmath_mpi.a
+
 include make/tests    # tests
 include make/cpplint  # cpplint
 

--- a/stan/math/prim/arr/functor/mpi_cluster_inst.cpp
+++ b/stan/math/prim/arr/functor/mpi_cluster_inst.cpp
@@ -2,7 +2,8 @@
 
 #include <stan/math/prim/arr/functor/mpi_cluster.hpp>
 
-// register stop worker command
+// register stop worker command (instantiates boost serialization
+// templates)
 STAN_REGISTER_MPI_COMMAND(stan::math::mpi_stop_worker)
 
 #endif


### PR DESCRIPTION
#### Submission Checklist

- [ ] Run unit tests: `./runTests.py test/unit`
- [X] Run cpplint: `make cpplint`
- [X] Declare copyright holder and open-source license: see below

#### Summary:
Places code which has to be instantiated once for MPI into stan-standards compliant locations.

#### Intended Effect:
MPI code needs instantiated code which is now handled following the conventions in `stan` as good as possible. That is, the `cpp` file is not inside `stan/...` and called `*_inst.cpp`. This is the same logic as done for `libstanc`, for example. However, there is one notable difference: While in `stan` the `bin/libstanc.a` static library is formed and then linked during compilation, this does not work for the MPI code (for reasons not clear to me). However, what does work is to directly link in the object file. This is likely due to how references to shared libraries are handled. The proposed change works and is reasonable as there is no gain at the moment to link either the static library or directly the object file.

#### How to Verify:
Run the MPI tests:

```
test/unit/math/rev/mat/functor/map_rect_mpi_test.cpp
test/unit/math/prim/mat/functor/map_rect_mpi_test.cpp
test/unit/math/prim/mat/functor/mpi_parallel_call_test.cpp
test/unit/math/prim/arr/functor/mpi_cluster_test.cpp
```

#### Side Effects:

#### Documentation:

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Sebastian Weber

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)