### PR TITLE
adjoint-vector product, #876

### DIFF
--- a/stan/math/prim/mat/fun/softmax.hpp
+++ b/stan/math/prim/mat/fun/softmax.hpp
@@ -27,10 +27,10 @@ namespace math {
  * \displaystyle
  * \mbox{ } \ \ \ = \left\{
  * \begin{array}{ll}
- * \mbox{softmax}(y)[k] - \mbox{softmax}(y)[k] \times \mbox{softmax}(y)[m]
+ * \mbox{softmax}(y)[k] \times (1 - \mbox{softmax}(y)[m])
  * & \mbox{ if } m = k, \mbox{ and}
  * \\[6pt]
- * \mbox{softmax}(y)[k] * \mbox{softmax}(y)[m]
+ * -\mbox{softmax}(y)[k] \times \mbox{softmax}(y)[m]
  * & \mbox{ if } m \neq k.
  * \end{array}
  * \right.

--- a/stan/math/rev/core.hpp
+++ b/stan/math/rev/core.hpp
@@ -2,6 +2,7 @@
 #define STAN_MATH_REV_CORE_HPP
 
 #include <stan/math/rev/core/autodiffstackstorage.hpp>
+#include <stan/math/rev/core/build_vari_array.hpp>
 #include <stan/math/rev/core/chainable_alloc.hpp>
 #include <stan/math/rev/core/chainablestack.hpp>
 #include <stan/math/rev/core/ddv_vari.hpp>

--- a/stan/math/rev/core/build_vari_array.hpp
+++ b/stan/math/rev/core/build_vari_array.hpp
@@ -22,7 +22,7 @@ vari** build_vari_array(const Eigen::Matrix<var, R, C>& x) {
   vari** x_vi_
       = ChainableStack::instance().memalloc_.alloc_array<vari*>(x.size());
   for (int i = 0; i < x.size(); ++i) {
-    x_vi_[i] = x.data()[i].vi_;
+    x_vi_[i] = x(i).vi_;
   }
   return x_vi_;
 }

--- a/stan/math/rev/core/build_vari_array.hpp
+++ b/stan/math/rev/core/build_vari_array.hpp
@@ -8,6 +8,15 @@
 namespace stan {
 namespace math {
 
+/**
+ * Allocates and populates a flat array of vari pointers in the autodiff arena
+ * with the varis pointed to by the vars in the input Eigen matrix
+ *
+ * @tparam R Eigen row type of x
+ * @tparam C Eigen column type of x
+ * @param x Input
+ * @return Flat array of vari pointers
+ */
 template <int R, int C>
 vari** build_vari_array(const Eigen::Matrix<var, R, C>& x) {
   vari** x_vi_

--- a/stan/math/rev/core/build_vari_array.hpp
+++ b/stan/math/rev/core/build_vari_array.hpp
@@ -1,0 +1,22 @@
+#ifndef STAN_MATH_REV_CORE_BUILD_VARI_ARRAY_HPP
+#define STAN_MATH_REV_CORE_BUILD_VARI_ARRAY_HPP
+
+#include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <stan/math/rev/core/var.hpp>
+#include <stan/math/rev/core/vari.hpp>
+
+namespace stan {
+namespace math {
+
+template <int R, int C>
+vari** build_vari_array(const Eigen::Matrix<var, R, C>& x) {
+  vari** x_vi_ = ChainableStack::instance().memalloc_.alloc_array<vari*>(x.size());
+  for (int i = 0; i < x.size(); ++i) {
+    x_vi_[i] = x.data()[i].vi_;
+  }
+  return x_vi_;
+}
+
+}  // namespace math
+}  // namespace stan
+#endif

--- a/stan/math/rev/core/build_vari_array.hpp
+++ b/stan/math/rev/core/build_vari_array.hpp
@@ -10,7 +10,8 @@ namespace math {
 
 template <int R, int C>
 vari** build_vari_array(const Eigen::Matrix<var, R, C>& x) {
-  vari** x_vi_ = ChainableStack::instance().memalloc_.alloc_array<vari*>(x.size());
+  vari** x_vi_
+      = ChainableStack::instance().memalloc_.alloc_array<vari*>(x.size());
   for (int i = 0; i < x.size(); ++i) {
     x_vi_[i] = x.data()[i].vi_;
   }

--- a/stan/math/rev/mat.hpp
+++ b/stan/math/rev/mat.hpp
@@ -12,7 +12,7 @@
 #include <stan/math/prim/mat.hpp>
 #include <stan/math/rev/arr.hpp>
 
-#include <stan/math/rev/mat/fun/adj_jac.hpp>
+#include <stan/math/rev/mat/fun/adj_jac_apply.hpp>
 #include <stan/math/rev/mat/fun/cholesky_decompose.hpp>
 #include <stan/math/rev/mat/fun/columns_dot_product.hpp>
 #include <stan/math/rev/mat/fun/columns_dot_self.hpp>

--- a/stan/math/rev/mat.hpp
+++ b/stan/math/rev/mat.hpp
@@ -12,6 +12,7 @@
 #include <stan/math/prim/mat.hpp>
 #include <stan/math/rev/arr.hpp>
 
+#include <stan/math/rev/mat/fun/adj_jac.hpp>
 #include <stan/math/rev/mat/fun/cholesky_decompose.hpp>
 #include <stan/math/rev/mat/fun/columns_dot_product.hpp>
 #include <stan/math/rev/mat/fun/columns_dot_self.hpp>

--- a/stan/math/rev/mat/fun/adj_jac.hpp
+++ b/stan/math/rev/mat/fun/adj_jac.hpp
@@ -1,0 +1,91 @@
+#ifndef STAN_MATH_REV_MAT_FUN_ADJ_JAC_HPP
+#define STAN_MATH_REV_MAT_FUN_ADJ_JAC_HPP
+
+#include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <stan/math/rev/core.hpp>
+#include <vector>
+
+namespace stan {
+namespace math {
+
+/*
+ * The adjoint Jacobian vari is a special vari for wrapping up user defined ops that supply an apply operation (that performs an operation on some input) and a multiply_adjoint_jacobian call (that computes the result of the product of the transpose of the adjoint times the Jacobian of the operator).
+ *
+ * The adjoint Jacobian vari itself does nothing other than connect the supplied operation to the autodiff stack and coordinate movement of data between all the involved varis so that someone can implement autodiff functions without ever having to deal with autodiff types.
+ */
+template <typename F>
+struct adj_jac_vari : public vari {
+  F* f_;
+  int N_;
+  vari** x_vi_;
+  int M_;
+  vari** y_vi_;
+
+  adj_jac_vari(F* f, const Eigen::Matrix<var, Eigen::Dynamic, 1>& x, int M, vari** y_vi)
+    : vari(0.0), f_(f),
+        N_(x.size()), x_vi_(ChainableStack::instance().memalloc_.alloc_array<vari*>(N_)),
+	M_(M), y_vi_(y_vi) {
+    for (int n = 0; n < N_; ++n)
+      x_vi_[n] = x(n).vi_;
+  }
+
+  void chain() {
+    Eigen::Matrix<double, Eigen::Dynamic, 1> y_adj(M_);
+    for (int m = 0; m < M_; ++m)
+      y_adj(m) = y_vi_[m] -> adj_;
+    Eigen::Matrix<double, Eigen::Dynamic, 1> y_adj_jac = f_ -> multiply_adjoint_jacobian(y_adj);
+    for (int n = 0; n < N_; ++n)
+      x_vi_[n] -> adj_ += y_adj_jac(n);
+  }
+};
+
+/*
+ * adj_jac_apply makes it possible to write reasonably efficient reverse-mode autodiff code without ever touching Stan's autodiff internals
+ *
+ * Mathematically, to use a function in reverse mode autodiff, you need to be able to evaluate the function (y = f(x)) and the Jacobian of that function (df(x)/dx).
+ *
+ * Pretend there exists some large, complicated function, L(x), which contains our smaller function f(x). The goal of autodiff is to compute dL/dx. If we break the large function into pieces:
+ *
+ * y = f(x)
+ * L = g(y)
+ *
+ * Then if we were given dL/dy, then we could compute dL/dx by the product dL/dy * dy/dx
+ *
+ * Because y = f(x), dy/dx is just df(x)/dx, the Jacobian of the function we're trying to define. In vector form,
+ *
+ * dL/dx = (dL/dy)' * df(x)/dx
+ *
+ * So implementing f(x) and the product above is all that is required mathematically to implement reverse-mode autodiff for a function.
+ *
+ * adj_jac_apply takes as a template argument a functor that supplies:
+ *   Eigen::VectorXd apply(const Eigen::VectorXd& x) and,
+ *   Eigen::VectorXd multiply_adjoint_jacobian(const Eigen::VectorXd& adj)
+ *
+ *  apply is f(x) and multiply_adjoint_jacobian is responsible for computing the adjoint transpose Jacobian product (which frequently does not require the calculation of the full Jacobian).
+ *
+ * The functor supplied to adj_jac_apply must be careful to allocate itself as well as any other variables it defines on the autodiff memory stack because its destructor will never be called! (and so memory will leak if allocated anywhere else)
+ *
+ * @tparam F functor to be connected to the autodiff stack
+ * @param x input to the functor
+ * @return the result of the specified operation wrapped up in vars
+ */
+template <class F>
+Eigen::Matrix<var, Eigen::Dynamic, 1> adj_jac_apply(const Eigen::Matrix<var, Eigen::Dynamic, 1>& x) {
+  F *f = new F();
+  Eigen::Matrix<double, Eigen::Dynamic, 1> val_y = f -> apply(value_of(x));
+
+  int M = val_y.size();
+  vari** y_vi = ChainableStack::instance().memalloc_.alloc_array<vari*>(M);
+  Eigen::Matrix<var, Eigen::Dynamic, 1> y(M);
+  for (int m = 0; m < M; ++m) {
+    y_vi[m] = new vari(val_y(m), false);
+    y(m) = var(y_vi[m]);
+  }
+
+  new adj_jac_vari<F>(f, x, M, y_vi);
+  return y;
+}
+
+}  // namespace math
+}  // namespace stan
+#endif

--- a/stan/math/rev/mat/fun/adj_jac.hpp
+++ b/stan/math/rev/mat/fun/adj_jac.hpp
@@ -9,9 +9,15 @@ namespace stan {
 namespace math {
 
 /*
- * The adjoint Jacobian vari is a special vari for wrapping up user defined ops that supply an apply operation (that performs an operation on some input) and a multiply_adjoint_jacobian call (that computes the result of the product of the transpose of the adjoint times the Jacobian of the operator).
+ * The adjoint Jacobian vari is a special vari for wrapping up user defined ops
+ * that supply an apply operation (that performs an operation on some input) and
+ * a multiply_adjoint_jacobian call (that computes the result of the product of
+ * the transpose of the adjoint times the Jacobian of the operator).
  *
- * The adjoint Jacobian vari itself does nothing other than connect the supplied operation to the autodiff stack and coordinate movement of data between all the involved varis so that someone can implement autodiff functions without ever having to deal with autodiff types.
+ * The adjoint Jacobian vari itself does nothing other than connect the supplied
+ * operation to the autodiff stack and coordinate movement of data between all
+ * the involved varis so that someone can implement autodiff functions without
+ * ever having to deal with autodiff types.
  */
 template <typename F>
 struct adj_jac_vari : public vari {
@@ -21,10 +27,14 @@ struct adj_jac_vari : public vari {
   int M_;
   vari** y_vi_;
 
-  adj_jac_vari(F* f, const Eigen::Matrix<var, Eigen::Dynamic, 1>& x, int M, vari** y_vi)
-    : vari(0.0), f_(f),
-        N_(x.size()), x_vi_(ChainableStack::instance().memalloc_.alloc_array<vari*>(N_)),
-	M_(M), y_vi_(y_vi) {
+  adj_jac_vari(F* f, const Eigen::Matrix<var, Eigen::Dynamic, 1>& x, int M,
+               vari** y_vi)
+      : vari(0.0),
+        f_(f),
+        N_(x.size()),
+        x_vi_(ChainableStack::instance().memalloc_.alloc_array<vari*>(N_)),
+        M_(M),
+        y_vi_(y_vi) {
     for (int n = 0; n < N_; ++n)
       x_vi_[n] = x(n).vi_;
   }
@@ -32,47 +42,62 @@ struct adj_jac_vari : public vari {
   void chain() {
     Eigen::Matrix<double, Eigen::Dynamic, 1> y_adj(M_);
     for (int m = 0; m < M_; ++m)
-      y_adj(m) = y_vi_[m] -> adj_;
-    Eigen::Matrix<double, Eigen::Dynamic, 1> y_adj_jac = f_ -> multiply_adjoint_jacobian(y_adj);
+      y_adj(m) = y_vi_[m]->adj_;
+    Eigen::Matrix<double, Eigen::Dynamic, 1> y_adj_jac
+        = f_->multiply_adjoint_jacobian(y_adj);
     for (int n = 0; n < N_; ++n)
-      x_vi_[n] -> adj_ += y_adj_jac(n);
+      x_vi_[n]->adj_ += y_adj_jac(n);
   }
 };
 
 /*
- * adj_jac_apply makes it possible to write reasonably efficient reverse-mode autodiff code without ever touching Stan's autodiff internals
+ * adj_jac_apply makes it possible to write reasonably efficient reverse-mode
+ * autodiff code without ever touching Stan's autodiff internals
  *
- * Mathematically, to use a function in reverse mode autodiff, you need to be able to evaluate the function (y = f(x)) and the Jacobian of that function (df(x)/dx).
+ * Mathematically, to use a function in reverse mode autodiff, you need to be
+ * able to evaluate the function (y = f(x)) and the Jacobian of that function
+ * (df(x)/dx).
  *
- * Pretend there exists some large, complicated function, L(x), which contains our smaller function f(x). The goal of autodiff is to compute dL/dx. If we break the large function into pieces:
+ * Pretend there exists some large, complicated function, L(x), which contains
+ * our smaller function f(x). The goal of autodiff is to compute dL/dx. If we
+ * break the large function into pieces:
  *
  * y = f(x)
  * L = g(y)
  *
- * Then if we were given dL/dy, then we could compute dL/dx by the product dL/dy * dy/dx
+ * Then if we were given dL/dy, then we could compute dL/dx by the product dL/dy
+ * * dy/dx
  *
- * Because y = f(x), dy/dx is just df(x)/dx, the Jacobian of the function we're trying to define. In vector form,
+ * Because y = f(x), dy/dx is just df(x)/dx, the Jacobian of the function we're
+ * trying to define. In vector form,
  *
  * dL/dx = (dL/dy)' * df(x)/dx
  *
- * So implementing f(x) and the product above is all that is required mathematically to implement reverse-mode autodiff for a function.
+ * So implementing f(x) and the product above is all that is required
+ * mathematically to implement reverse-mode autodiff for a function.
  *
  * adj_jac_apply takes as a template argument a functor that supplies:
  *   Eigen::VectorXd apply(const Eigen::VectorXd& x) and,
  *   Eigen::VectorXd multiply_adjoint_jacobian(const Eigen::VectorXd& adj)
  *
- *  apply is f(x) and multiply_adjoint_jacobian is responsible for computing the adjoint transpose Jacobian product (which frequently does not require the calculation of the full Jacobian).
+ *  apply is f(x) and multiply_adjoint_jacobian is responsible for computing the
+ * adjoint transpose Jacobian product (which frequently does not require the
+ * calculation of the full Jacobian).
  *
- * The functor supplied to adj_jac_apply must be careful to allocate itself as well as any other variables it defines on the autodiff memory stack because its destructor will never be called! (and so memory will leak if allocated anywhere else)
+ * The functor supplied to adj_jac_apply must be careful to allocate itself as
+ * well as any other variables it defines on the autodiff memory stack because
+ * its destructor will never be called! (and so memory will leak if allocated
+ * anywhere else)
  *
  * @tparam F functor to be connected to the autodiff stack
  * @param x input to the functor
  * @return the result of the specified operation wrapped up in vars
  */
 template <class F>
-Eigen::Matrix<var, Eigen::Dynamic, 1> adj_jac_apply(const Eigen::Matrix<var, Eigen::Dynamic, 1>& x) {
-  F *f = new F();
-  Eigen::Matrix<double, Eigen::Dynamic, 1> val_y = f -> apply(value_of(x));
+Eigen::Matrix<var, Eigen::Dynamic, 1> adj_jac_apply(
+    const Eigen::Matrix<var, Eigen::Dynamic, 1>& x) {
+  F* f = new F();
+  Eigen::Matrix<double, Eigen::Dynamic, 1> val_y = f->apply(value_of(x));
 
   int M = val_y.size();
   vari** y_vi = ChainableStack::instance().memalloc_.alloc_array<vari*>(M);

--- a/stan/math/rev/mat/fun/adj_jac_apply.hpp
+++ b/stan/math/rev/mat/fun/adj_jac_apply.hpp
@@ -39,11 +39,10 @@ struct adj_jac_vari : public vari {
    * @param x Input as vars
    */
   explicit adj_jac_vari(const Eigen::Matrix<var, Eigen::Dynamic, 1>& x)
-      : vari(0),  // The val_ in this vari is unused
+      : vari(std::numeric_limits<double>::quiet_NaN()),  // The val_ in this
+                                                         // vari is unused
         N_(x.size()),
-        x_vi_(build_vari_array(x)),
-        M_(0),
-        y_vi_(NULL) {
+        x_vi_(build_vari_array(x)) {
     Eigen::Matrix<double, Eigen::Dynamic, 1> val_y = f_(value_of(x));
 
     M_ = val_y.size();

--- a/stan/math/rev/mat/fun/adj_jac_apply.hpp
+++ b/stan/math/rev/mat/fun/adj_jac_apply.hpp
@@ -44,7 +44,8 @@ struct adj_jac_vari : public vari {
                                                          // vari is unused
         N_(x.size()),
         x_vi_(build_vari_array(x)) {
-    Eigen::Matrix<double, Eigen::Dynamic, 1> val_y = f_(value_of(x));
+    Eigen::Matrix<double, Eigen::Dynamic, 1> val_x = value_of(x);
+    Eigen::Matrix<double, Eigen::Dynamic, 1> val_y = f_(val_x);
 
     M_ = val_y.size();
     y_vi_ = ChainableStack::instance().memalloc_.alloc_array<vari*>(M_);

--- a/stan/math/rev/mat/fun/adj_jac_apply.hpp
+++ b/stan/math/rev/mat/fun/adj_jac_apply.hpp
@@ -4,6 +4,7 @@
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/mat.hpp>
 #include <stan/math/rev/core.hpp>
+#include <limits>
 #include <vector>
 
 namespace stan {

--- a/stan/math/rev/mat/fun/adj_jac_apply.hpp
+++ b/stan/math/rev/mat/fun/adj_jac_apply.hpp
@@ -27,12 +27,12 @@ struct adj_jac_vari : public vari {
   int M_;
   vari** y_vi_;
 
-  adj_jac_vari(const Eigen::Matrix<var, Eigen::Dynamic, 1>& x)
-    : vari(0),  // The val_ in this vari is unused
-      N_(x.size()),
-      x_vi_(build_vari_array(x)),
-      M_(0),
-      y_vi_(NULL) {
+  explicit adj_jac_vari(const Eigen::Matrix<var, Eigen::Dynamic, 1>& x)
+      : vari(0),  // The val_ in this vari is unused
+        N_(x.size()),
+        x_vi_(build_vari_array(x)),
+        M_(0),
+        y_vi_(NULL) {
     Eigen::Matrix<double, Eigen::Dynamic, 1> val_y = f_(value_of(x));
 
     M_ = val_y.size();
@@ -54,7 +54,8 @@ struct adj_jac_vari : public vari {
 };
 
 /*
- * Return the result of applying the function defined by a nullary construction of F to the specified input argument
+ * Return the result of applying the function defined by a nullary construction
+ * of F to the specified input argument
  *
  * adj_jac_apply makes it possible to write efficient reverse-mode
  * autodiff code without ever touching Stan's autodiff internals
@@ -63,9 +64,9 @@ struct adj_jac_vari : public vari {
  * able to evaluate the function (y = f(x)) and the Jacobian of that function
  * (df(x)/dx) times a vector.
  *
- * As an example, pretend there exists some large, complicated function, L(x), which contains
- * our smaller function f(x). The goal of autodiff is to compute dL/dx. If we
- * break the large function into pieces:
+ * As an example, pretend there exists some large, complicated function, L(x),
+ * which contains our smaller function f(x). The goal of autodiff is to compute
+ * dL/dx. If we break the large function into pieces:
  *
  * y = f(x)
  * L = g(y)
@@ -80,21 +81,24 @@ struct adj_jac_vari : public vari {
  * So implementing f(x) and the product above is all that is required
  * mathematically to implement reverse-mode autodiff for a function.
  *
- * adj_jac_apply takes as a template argument a functor F that supplies the non-static member functions:
- *   (required) Eigen::VectorXd operator()(const Eigen::VectorXd& x),
- *   (required) Eigen::VectorXd multiply_adjoint_jacobian(const Eigen::VectorXd& adj) and,
- *   (optional) a nullary constructor
+ * adj_jac_apply takes as a template argument a functor F that supplies the
+ * non-static member functions: (required) Eigen::VectorXd operator()(const
+ * Eigen::VectorXd& x), (required) Eigen::VectorXd
+ * multiply_adjoint_jacobian(const Eigen::VectorXd& adj) and, (optional) a
+ * nullary constructor
  *
- * operator() is responsible for computing f(x) and multiply_adjoint_jacobian is responsible for computing the
- * adjoint transpose Jacobian product (which frequently does not require the
- * calculation of the full Jacobian).
+ * operator() is responsible for computing f(x) and multiply_adjoint_jacobian is
+ * responsible for computing the adjoint transpose Jacobian product (which
+ * frequently does not require the calculation of the full Jacobian).
  *
- * operator() will be called before multiply_adjoint_jacobian is called, and is only called once in the lifetime of the functor
- * multiply_adjoint_jacobian is called after operator() and may be called multiple times for any single functor
+ * operator() will be called before multiply_adjoint_jacobian is called, and is
+ * only called once in the lifetime of the functor multiply_adjoint_jacobian is
+ * called after operator() and may be called multiple times for any single
+ * functor
  *
- * The functor supplied to adj_jac_apply must be careful to allocate any variables it defines on the autodiff memory stack because
- * its destructor will never be called! (and so memory will leak if allocated
- * anywhere else)
+ * The functor supplied to adj_jac_apply must be careful to allocate any
+ * variables it defines on the autodiff memory stack because its destructor will
+ * never be called! (and so memory will leak if allocated anywhere else)
  *
  * @tparam F functor to be connected to the autodiff stack
  * @param x input to the functor
@@ -103,7 +107,7 @@ struct adj_jac_vari : public vari {
 template <class F>
 Eigen::Matrix<var, Eigen::Dynamic, 1> adj_jac_apply(
     const Eigen::Matrix<var, Eigen::Dynamic, 1>& x) {
-  adj_jac_vari<F> *vi = new adj_jac_vari<F>(x);
+  adj_jac_vari<F>* vi = new adj_jac_vari<F>(x);
   Eigen::Matrix<var, Eigen::Dynamic, 1> y(vi->M_);
 
   for (int m = 0; m < vi->M_; ++m)

--- a/stan/math/rev/mat/fun/adj_jac_apply.hpp
+++ b/stan/math/rev/mat/fun/adj_jac_apply.hpp
@@ -2,7 +2,8 @@
 #define STAN_MATH_REV_MAT_FUN_ADJ_JAC_APPLY_HPP
 
 #include <stan/math/prim/mat/fun/Eigen.hpp>
-#include <stan/math/rev/mat.hpp>
+#include <stan/math/prim/mat.hpp>
+#include <stan/math/rev/core.hpp>
 #include <vector>
 
 namespace stan {

--- a/stan/math/rev/mat/fun/adj_jac_apply.hpp
+++ b/stan/math/rev/mat/fun/adj_jac_apply.hpp
@@ -10,24 +10,12 @@ namespace stan {
 namespace math {
 
 /*
- * adj_jac_vari interfaces a user supplied functor with the reverse mode
- * autodiff.
- *
- * The functor must supply:
- *  1. Eigen::VectorXd operator()(const Eigen::VectorXd& x) -- which evaluates
- * the function
- *  2. Eigen::VectorXd multiply_adjoint_jacobian(const Eigen::VectorXd& adj) --
- * which computes the result of the product of the transpose of the adjoint
- * times the Jacobian of the function
- *
- * multiply_adjoint_jacobian may be called multiple times during the life of an
- * adj_jac_vari, but operator() will only be called once.
- *
- * The functor may allocate memory in the autodiff arena, but its destructor
- * will not be called
- *
- * adj_jac_vari allows someone to implement functions with custom reverse mode
+ * adj_jac_vari interfaces a user supplied functor  with the reverse mode
+ * autodiff. It allows someone to implement functions with custom reverse mode
  * autodiff without having to deal with autodiff types.
+ *
+ * The requirements on the functor F are described in the documentation for
+ * adj_jac_apply
  *
  * @tparam F class of functor
  */
@@ -66,12 +54,12 @@ struct adj_jac_vari : public vari {
   }
 
   /**
-   * chain propagates the adjoints at the output varis back to the input varis
-   * by calling the multiply_adjoint_jacobian function of the user defined
-   * functor
+   * chain propagates the adjoints at the output varis (y_vi_) back to the input
+   * varis (x_vi_) by using the multiply_adjoint_jacobian function of the user
+   * defined functor
    *
    * Unlike the constructor, this operation may be called multiple times during
-   * the life of the vari.
+   * the life of the vari
    */
   void chain() {
     Eigen::Matrix<double, Eigen::Dynamic, 1> y_adj(M_);
@@ -92,8 +80,8 @@ struct adj_jac_vari : public vari {
  * autodiff code without ever touching Stan's autodiff internals
  *
  * Mathematically, to use a function in reverse mode autodiff, you need to be
- * able to evaluate the function (y = f(x)) and the Jacobian of that function
- * (df(x)/dx) times a vector.
+ * able to evaluate the function (y = f(x)) and multiply the Jacobian of that
+ * function (df(x)/dx) by a vector.
  *
  * As an example, pretend there exists some large, complicated function, L(x),
  * which contains our smaller function f(x). The goal of autodiff is to compute

--- a/stan/math/rev/mat/fun/softmax.hpp
+++ b/stan/math/rev/mat/fun/softmax.hpp
@@ -13,10 +13,10 @@ namespace math {
 namespace {
 class SoftmaxOp {
   int N_;
-  double* y_mem_;  // Holds the results of the softmax
+  double* y_;  // Holds the results of the softmax
 
  public:
-  SoftmaxOp() : N_(0), y_mem_(NULL) {}
+  SoftmaxOp() : N_(0), y_(NULL) {}
 
   /*
    * Compute the softmax of the unconstrained input vector
@@ -26,11 +26,11 @@ class SoftmaxOp {
    */
   Eigen::VectorXd operator()(const Eigen::VectorXd& alpha) {
     N_ = alpha.size();
-    y_mem_ = ChainableStack::instance().memalloc_.alloc_array<double>(N_);
+    y_ = ChainableStack::instance().memalloc_.alloc_array<double>(N_);
 
     auto y = softmax(alpha);
     for (int n = 0; n < N_; ++n)
-      y_mem_[n] = y(n);
+      y_[n] = y(n);
     return y;
   }
 
@@ -45,7 +45,7 @@ class SoftmaxOp {
    */
   Eigen::VectorXd multiply_adjoint_jacobian(const Eigen::VectorXd& adj) const {
     Eigen::VectorXd adj_times_jac(N_);
-    Eigen::Map<Eigen::Matrix<double, Eigen::Dynamic, 1> > y(y_mem_, N_);
+    Eigen::Map<Eigen::Matrix<double, Eigen::Dynamic, 1> > y(y_, N_);
 
     double adj_dot_y = adj.dot(y);
     for (int n = 0; n < N_; ++n) {

--- a/stan/math/rev/mat/fun/softmax.hpp
+++ b/stan/math/rev/mat/fun/softmax.hpp
@@ -4,7 +4,7 @@
 #include <stan/math/prim/arr/err/check_nonzero_size.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/mat/fun/softmax.hpp>
-#include <stan/math/rev/mat.hpp>
+#include <stan/math/rev/mat/fun/adj_jac_apply.hpp>
 #include <vector>
 
 namespace stan {

--- a/stan/math/rev/mat/fun/softmax.hpp
+++ b/stan/math/rev/mat/fun/softmax.hpp
@@ -16,7 +16,7 @@ class SoftmaxOp {
   double* y_mem_;  // Holds the results of the softmax
  public:
   SoftmaxOp() : N_(0), y_mem_(NULL) {}
-  
+
   /*
    * Compute the softmax of the unconstrained input vector
    *

--- a/stan/math/rev/mat/fun/softmax.hpp
+++ b/stan/math/rev/mat/fun/softmax.hpp
@@ -4,81 +4,74 @@
 #include <stan/math/prim/arr/err/check_nonzero_size.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/mat/fun/softmax.hpp>
-#include <stan/math/rev/core.hpp>
+#include <stan/math/rev/mat.hpp>
 #include <vector>
 
 namespace stan {
 namespace math {
 
 namespace {
-class softmax_elt_vari : public vari {
- private:
-  vari** alpha_;
-  const double* softmax_alpha_;
-  const int size_;  // array sizes
-  const int idx_;   // in in softmax output
+  class softmax_op {
+    int N;
+    double *y_mem_; // Holds the results of the softmax
+  public:
+    /*
+     * Compute the softmax of the unconstrained input vector
+     *
+     * @param alpha Unconstrained input vector.
+     * @return Softmax of the input.
+     */
+    Eigen::VectorXd apply(const Eigen::VectorXd& alpha) {
+      N = alpha.size();
+      y_mem_ = ChainableStack::instance().memalloc_.alloc_array<double>(N);
 
- public:
-  softmax_elt_vari(double val, vari** alpha, const double* softmax_alpha,
-                   int size, int idx)
-      : vari(val),
-        alpha_(alpha),
-        softmax_alpha_(softmax_alpha),
-        size_(size),
-        idx_(idx) {}
-  void chain() {
-    for (int m = 0; m < size_; ++m) {
-      if (m == idx_) {
-        alpha_[m]->adj_
-            += adj_ * softmax_alpha_[idx_] * (1 - softmax_alpha_[m]);
-      } else {
-        alpha_[m]->adj_ -= adj_ * softmax_alpha_[idx_] * softmax_alpha_[m];
-      }
+      auto y = softmax(alpha);
+      for (int n = 0; n < N; ++n)
+	y_mem_[n] = y(n);
+      return y;
     }
-  }
-};
+
+    /*
+     * Compute the result of multiply the transpose of the adjoint vector times the Jacobian of the softmax operator. It is more efficient to do this without actually computing the Jacobian and doing the vector-matrix product.
+     *
+     * @param adj Eigen::VectorXd of adjoints at the output of the softmax
+     * @return Eigen::VectorXd of adjoints propagated through softmax operation
+     */
+    Eigen::VectorXd multiply_adjoint_jacobian(const Eigen::VectorXd& adj) const {
+      Eigen::VectorXd adj_times_jac(N);
+
+      Eigen::Map<Eigen::Matrix<double, Eigen::Dynamic, 1> > y(y_mem_, N);
+
+      double adj_dot_y = adj.dot(y);
+      for (int n = 0; n < N; ++n) {
+	adj_times_jac(n) = -y(n) * adj_dot_y + y(n) * adj(n);
+      }
+
+      return adj_times_jac;
+    }
+
+    //  Allocate on the autodiff stack
+    static inline void* operator new(size_t nbytes) {
+      return ChainableStack::instance().memalloc_.alloc(nbytes);
+    }
+
+    //  No need to call the destructor, that'll get handled elsewhere
+    static inline void operator delete(void* ) {}
+  };
 }  // namespace
 
 /**
  * Return the softmax of the specified Eigen vector.  Softmax is
  * guaranteed to return a simplex.
  *
- * The gradient calculations are unfolded.
- *
  * @param alpha Unconstrained input vector.
  * @return Softmax of the input.
  * @throw std::domain_error If the input vector is size 0.
  */
-inline Eigen::Matrix<var, Eigen::Dynamic, 1> softmax(
-    const Eigen::Matrix<var, Eigen::Dynamic, 1>& alpha) {
-  using Eigen::Dynamic;
-  using Eigen::Matrix;
-
+Eigen::Matrix<var, Eigen::Dynamic, 1> softmax(const Eigen::Matrix<var, Eigen::Dynamic, 1>& alpha) {
   check_nonzero_size("softmax", "alpha", alpha);
 
-  vari** alpha_vi_array = reinterpret_cast<vari**>(
-      ChainableStack::instance().memalloc_.alloc(sizeof(vari*) * alpha.size()));
-  for (int i = 0; i < alpha.size(); ++i)
-    alpha_vi_array[i] = alpha(i).vi_;
-
-  Matrix<double, Dynamic, 1> alpha_d(alpha.size());
-  for (int i = 0; i < alpha_d.size(); ++i)
-    alpha_d(i) = alpha(i).val();
-
-  Matrix<double, Dynamic, 1> softmax_alpha_d = softmax(alpha_d);
-
-  double* softmax_alpha_d_array
-      = reinterpret_cast<double*>(ChainableStack::instance().memalloc_.alloc(
-          sizeof(double) * alpha_d.size()));
-  for (int i = 0; i < alpha_d.size(); ++i)
-    softmax_alpha_d_array[i] = softmax_alpha_d(i);
-
-  Matrix<var, Dynamic, 1> softmax_alpha(alpha.size());
-  for (int k = 0; k < softmax_alpha.size(); ++k)
-    softmax_alpha(k)
-        = var(new softmax_elt_vari(softmax_alpha_d[k], alpha_vi_array,
-                                   softmax_alpha_d_array, alpha.size(), k));
-  return softmax_alpha;
+  return adj_jac_apply<softmax_op>(alpha);
 }
 
 }  // namespace math

--- a/stan/math/rev/mat/fun/softmax.hpp
+++ b/stan/math/rev/mat/fun/softmax.hpp
@@ -65,7 +65,7 @@ class SoftmaxOp {
  * @return Softmax of the input.
  * @throw std::domain_error If the input vector is size 0.
  */
-Eigen::Matrix<var, Eigen::Dynamic, 1> softmax(
+inline Eigen::Matrix<var, Eigen::Dynamic, 1> softmax(
     const Eigen::Matrix<var, Eigen::Dynamic, 1>& alpha) {
   check_nonzero_size("softmax", "alpha", alpha);
 

--- a/stan/math/rev/mat/fun/softmax.hpp
+++ b/stan/math/rev/mat/fun/softmax.hpp
@@ -14,6 +14,7 @@ namespace {
 class SoftmaxOp {
   int N_;
   double* y_mem_;  // Holds the results of the softmax
+
  public:
   SoftmaxOp() : N_(0), y_mem_(NULL) {}
 

--- a/stan/math/rev/mat/fun/softmax.hpp
+++ b/stan/math/rev/mat/fun/softmax.hpp
@@ -11,12 +11,12 @@ namespace stan {
 namespace math {
 
 namespace {
-class SoftmaxOp {
+class softmax_op {
   int N_;
   double* y_;  // Holds the results of the softmax
 
  public:
-  SoftmaxOp() : N_(0), y_(NULL) {}
+  softmax_op() : N_(0), y_(NULL) {}
 
   /*
    * Compute the softmax of the unconstrained input vector
@@ -69,7 +69,7 @@ inline Eigen::Matrix<var, Eigen::Dynamic, 1> softmax(
     const Eigen::Matrix<var, Eigen::Dynamic, 1>& alpha) {
   check_nonzero_size("softmax", "alpha", alpha);
 
-  return adj_jac_apply<SoftmaxOp>(alpha);
+  return adj_jac_apply<softmax_op>(alpha);
 }
 
 }  // namespace math

--- a/test/unit/math/rev/core/build_vari_array_test.cpp
+++ b/test/unit/math/rev/core/build_vari_array_test.cpp
@@ -3,10 +3,10 @@
 #include <sstream>
 
 TEST(AgradRev, build_vari_array) {
+  using Eigen::Dynamic;
+  using Eigen::Matrix;
   using stan::math::var;
   using stan::math::vari;
-  using Eigen::Matrix;
-  using Eigen::Dynamic;
 
   Matrix<var, Dynamic, Dynamic> mdd(3, 2);
   Matrix<var, 1, Dynamic> mvd(5);
@@ -30,18 +30,22 @@ TEST(AgradRev, build_vari_array) {
 
   for (int i = 0; i < mdd.size(); ++i) {
     EXPECT_EQ(mdd.data()[i].vi_, vdd[i]);
-    EXPECT_TRUE(stan::math::ChainableStack::instance().memalloc_.in_stack(vdd[i]));
+    EXPECT_TRUE(
+        stan::math::ChainableStack::instance().memalloc_.in_stack(vdd[i]));
   }
   for (int i = 0; i < mvd.size(); ++i) {
     EXPECT_EQ(mvd.data()[i].vi_, vvd[i]);
-    EXPECT_TRUE(stan::math::ChainableStack::instance().memalloc_.in_stack(vvd[i]));
+    EXPECT_TRUE(
+        stan::math::ChainableStack::instance().memalloc_.in_stack(vvd[i]));
   }
   for (int i = 0; i < mdv.size(); ++i) {
     EXPECT_EQ(mdv.data()[i].vi_, vdv[i]);
-    EXPECT_TRUE(stan::math::ChainableStack::instance().memalloc_.in_stack(vdv[i]));
+    EXPECT_TRUE(
+        stan::math::ChainableStack::instance().memalloc_.in_stack(vdv[i]));
   }
   for (int i = 0; i < mvv.size(); ++i) {
     EXPECT_EQ(mvv.data()[i].vi_, vvv[i]);
-    EXPECT_TRUE(stan::math::ChainableStack::instance().memalloc_.in_stack(vvv[i]));
+    EXPECT_TRUE(
+        stan::math::ChainableStack::instance().memalloc_.in_stack(vvv[i]));
   }
 }

--- a/test/unit/math/rev/core/build_vari_array_test.cpp
+++ b/test/unit/math/rev/core/build_vari_array_test.cpp
@@ -1,0 +1,47 @@
+#include <stan/math/rev/core.hpp>
+#include <gtest/gtest.h>
+#include <sstream>
+
+TEST(AgradRev, build_vari_array) {
+  using stan::math::var;
+  using stan::math::vari;
+  using Eigen::Matrix;
+  using Eigen::Dynamic;
+
+  Matrix<var, Dynamic, Dynamic> mdd(3, 2);
+  Matrix<var, 1, Dynamic> mvd(5);
+  Matrix<var, Dynamic, 1> mdv(3);
+  Matrix<var, 2, 3> mvv;
+
+  mdd << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0;
+  mvd << 1.0, 2.0, 3.0, 4.0, 5.0;
+  mdv << 1.0, 2.0, 3.0;
+  mvv << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0;
+
+  vari **vdd = build_vari_array(mdd);
+  vari **vvd = build_vari_array(mvd);
+  vari **vdv = build_vari_array(mdv);
+  vari **vvv = build_vari_array(mvv);
+
+  EXPECT_TRUE(stan::math::ChainableStack::instance().memalloc_.in_stack(vdd));
+  EXPECT_TRUE(stan::math::ChainableStack::instance().memalloc_.in_stack(vvd));
+  EXPECT_TRUE(stan::math::ChainableStack::instance().memalloc_.in_stack(vdv));
+  EXPECT_TRUE(stan::math::ChainableStack::instance().memalloc_.in_stack(vvv));
+
+  for (int i = 0; i < mdd.size(); ++i) {
+    EXPECT_EQ(mdd.data()[i].vi_, vdd[i]);
+    EXPECT_TRUE(stan::math::ChainableStack::instance().memalloc_.in_stack(vdd[i]));
+  }
+  for (int i = 0; i < mvd.size(); ++i) {
+    EXPECT_EQ(mvd.data()[i].vi_, vvd[i]);
+    EXPECT_TRUE(stan::math::ChainableStack::instance().memalloc_.in_stack(vvd[i]));
+  }
+  for (int i = 0; i < mdv.size(); ++i) {
+    EXPECT_EQ(mdv.data()[i].vi_, vdv[i]);
+    EXPECT_TRUE(stan::math::ChainableStack::instance().memalloc_.in_stack(vdv[i]));
+  }
+  for (int i = 0; i < mvv.size(); ++i) {
+    EXPECT_EQ(mvv.data()[i].vi_, vvv[i]);
+    EXPECT_TRUE(stan::math::ChainableStack::instance().memalloc_.in_stack(vvv[i]));
+  }
+}

--- a/test/unit/math/rev/mat/fun/adj_jac_apply_test.cpp
+++ b/test/unit/math/rev/mat/fun/adj_jac_apply_test.cpp
@@ -1,15 +1,17 @@
 #include <stan/math/rev/core.hpp>
+#include <test/unit/math/rev/mat/util.hpp>
 #include <gtest/gtest.h>
 #include <sstream>
-#include <test/unit/math/rev/mat/util.hpp>
 
 struct SinFunctor {
   int N_;
-  double* x_mem_;
+  double *x_mem_;
   Eigen::VectorXd operator()(const Eigen::VectorXd &x) {
     N_ = x.size();
     Eigen::VectorXd out(N_);
-    x_mem_ = stan::math::ChainableStack::instance().memalloc_.alloc_array<double>(N_);
+    x_mem_
+        = stan::math::ChainableStack::instance().memalloc_.alloc_array<double>(
+            N_);
 
     for (int n = 0; n < N_; ++n) {
       x_mem_[n] = x(n);
@@ -88,5 +90,5 @@ TEST(AgradRev, test_multiple_jac) {
   sum_y2.grad();
   EXPECT_NEAR(x1(0).adj(), 0.0, 1e-10);
   EXPECT_NEAR(x2(0).adj(), 1.73 * -0.4161468365471424, 1e-10);
-  EXPECT_NEAR(x2(1).adj(), 1.57 * 0.5403023058681398, 1e-10);  
+  EXPECT_NEAR(x2(1).adj(), 1.57 * 0.5403023058681398, 1e-10);
 }

--- a/test/unit/math/rev/mat/fun/adj_jac_apply_test.cpp
+++ b/test/unit/math/rev/mat/fun/adj_jac_apply_test.cpp
@@ -1,0 +1,92 @@
+#include <stan/math/rev/core.hpp>
+#include <gtest/gtest.h>
+#include <sstream>
+#include <test/unit/math/rev/mat/util.hpp>
+
+struct SinFunctor {
+  int N_;
+  double* x_mem_;
+  Eigen::VectorXd operator()(const Eigen::VectorXd &x) {
+    N_ = x.size();
+    Eigen::VectorXd out(N_);
+    x_mem_ = stan::math::ChainableStack::instance().memalloc_.alloc_array<double>(N_);
+
+    for (int n = 0; n < N_; ++n) {
+      x_mem_[n] = x(n);
+      out(n) = sin(x(n));
+    }
+
+    return out;
+  }
+
+  Eigen::VectorXd multiply_adjoint_jacobian(const Eigen::VectorXd &adj) {
+    Eigen::VectorXd out(N_);
+
+    for (int n = 0; n < N_; ++n) {
+      out(n) = cos(x_mem_[n]) * adj(n);
+    }
+
+    return out;
+  }
+};
+
+TEST(AgradRev, test_stack) {
+  Eigen::Matrix<stan::math::var, Eigen::Dynamic, 1> x1(1), x2(2), y1(1), y2(2);
+  x1 << 1.0;
+  x2 << 2.0, 1.0;
+
+  y1 = stan::math::adj_jac_apply<SinFunctor>(x1);
+  y2 = stan::math::adj_jac_apply<SinFunctor>(x2);
+
+  test::check_varis_on_stack(y1);
+  test::check_varis_on_stack(y2);
+}
+
+TEST(AgradRev, test_values) {
+  Eigen::Matrix<stan::math::var, Eigen::Dynamic, 1> x1(1), x2(2), y1(1), y2(2);
+  x1 << 1.0;
+  x2 << 2.0, 1.0;
+
+  y1 = stan::math::adj_jac_apply<SinFunctor>(x1);
+  y2 = stan::math::adj_jac_apply<SinFunctor>(x2);
+
+  EXPECT_NEAR(y1(0).val(), 0.841470984807897, 1e-10);
+  EXPECT_NEAR(y2(0).val(), 0.909297426825682, 1e-10);
+  EXPECT_NEAR(y2(1).val(), 0.841470984807897, 1e-10);
+}
+
+TEST(AgradRev, test_multiple_jac) {
+  Eigen::Matrix<stan::math::var, Eigen::Dynamic, 1> x1(1), x2(2), y1(1), y2(2);
+  x1 << 1.0;
+  x2 << 2.0, 1.0;
+
+  y1 = stan::math::adj_jac_apply<SinFunctor>(x1);
+  y2 = stan::math::adj_jac_apply<SinFunctor>(x2);
+
+  y1(0).grad();
+  EXPECT_NEAR(x1(0).adj(), 0.5403023058681398, 1e-10);
+  EXPECT_NEAR(x2(0).adj(), 0.0, 1e-10);
+  EXPECT_NEAR(x2(1).adj(), 0.0, 1e-10);
+
+  stan::math::set_zero_all_adjoints();
+
+  y2(0).grad();
+  EXPECT_NEAR(x1(0).adj(), 0.0, 1e-10);
+  EXPECT_NEAR(x2(0).adj(), -0.4161468365471424, 1e-10);
+  EXPECT_NEAR(x2(1).adj(), 0.0, 1e-10);
+
+  stan::math::set_zero_all_adjoints();
+
+  y2(1).grad();
+  EXPECT_NEAR(x1(0).adj(), 0.0, 1e-10);
+  EXPECT_NEAR(x2(0).adj(), 0.0, 1e-10);
+  EXPECT_NEAR(x2(1).adj(), 0.5403023058681398, 1e-10);
+
+  stan::math::set_zero_all_adjoints();
+
+  stan::math::var sum_y2 = (1.73 * y2(0) + 1.57 * y2(1));
+  sum_y2.grad();
+  EXPECT_NEAR(x1(0).adj(), 0.0, 1e-10);
+  EXPECT_NEAR(x2(0).adj(), 1.73 * -0.4161468365471424, 1e-10);
+  EXPECT_NEAR(x2(1).adj(), 1.57 * 0.5403023058681398, 1e-10);  
+}

--- a/test/unit/math/rev/mat/fun/softmax_test.cpp
+++ b/test/unit/math/rev/mat/fun/softmax_test.cpp
@@ -58,51 +58,32 @@ TEST(AgradRevMatrix, softmax) {
   EXPECT_FLOAT_EQ(exp(10) / (exp(-1) + exp(1) + exp(10.0)), theta3[2].val());
 }
 
-// compute grad using templated definition in math
-// to check custom derivatives
-std::vector<double> softmax_grad(
-    Eigen::Matrix<double, Eigen::Dynamic, 1>& alpha_dbl, int k) {
-  using Eigen::Dynamic;
-  using Eigen::Matrix;
-  using stan::math::var;
-  Matrix<var, Dynamic, 1> alpha(alpha_dbl.size());
-  for (int i = 0; i < alpha.size(); ++i)
-    alpha(i) = alpha_dbl(i);
-
-  std::vector<var> x(alpha.size());
-  for (size_t i = 0; i < x.size(); ++i)
-    x[i] = alpha(i);
-
-  var fx_k = stan::math::softmax(alpha)[k];
-  std::vector<double> grad(alpha.size());
-  fx_k.grad(x, grad);
-  return grad;
-}
-TEST(AgradRevSoftmax, Grad) {
+TEST(AgradRevSoftmax, gradient_check) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using stan::math::softmax;
   using stan::math::var;
-  for (int k = 0; k < 3; ++k) {
-    Matrix<AVAR, Dynamic, 1> alpha(3);
-    alpha << 0.0, 3.0, -1.0;
-    Matrix<double, Dynamic, 1> alpha_dbl(3);
-    alpha_dbl << 0.0, 3.0, -1.0;
-
-    AVEC x(3);
-    for (int i = 0; i < 3; ++i)
-      x[i] = alpha(i);
-    Matrix<AVAR, Dynamic, 1> theta = softmax(alpha);
-    AVAR fx_k = theta(k);
-    std::vector<double> grad;
-    fx_k.grad(x, grad);
-
-    std::vector<double> grad_expected = softmax_grad(alpha_dbl, k);
-    EXPECT_EQ(grad_expected.size(), grad.size());
-    for (size_t i = 0; i < grad_expected.size(); ++i)
-      EXPECT_FLOAT_EQ(grad_expected[i], grad[i]);
+  std::vector<std::vector<double> > inputs = { { 0.5, -1.0, 3.0 }, {4.0, 3.0, -2.0 } };
+  std::vector<double> vals = { 0.07459555713221443, 0.729736214118415 };
+  std::vector<std::vector<double> > grads = { { 0.06903105998834897, -0.001241607138856182, -0.06778945284949277 }, { 0.1972212719225377, -0.1959012993504623, -0.001319972572075391 } };
+  for (size_t i = 0; i < inputs.size(); ++i) {
+    for (int j = 0; j < 3; ++j) {
+      stan::math::set_zero_all_adjoints();
+      
+      Matrix<AVAR, Dynamic, 1> alpha(3);
+      for(int k = 0; k < 3; ++k)
+	alpha((j + k) % 3) = inputs[i][k];
+      
+      Matrix<AVAR, Dynamic, 1> theta = softmax(alpha);
+      theta(j).grad();
+      
+      EXPECT_NEAR(vals[i], theta(j).val(), 1e-10);
+      for (size_t k = 0; k < 3; ++k)
+	EXPECT_NEAR(grads[i][k], alpha((j + k) % 3).adj(), 1e-10);
+    }
   }
 }
+
 TEST(AgradRevMatrix, check_varis_on_stack) {
   Eigen::Matrix<stan::math::var, Eigen::Dynamic, 1> alpha(3);
   alpha << 0.0, 3.0, -1.0;

--- a/test/unit/math/rev/mat/fun/softmax_test.cpp
+++ b/test/unit/math/rev/mat/fun/softmax_test.cpp
@@ -4,29 +4,6 @@
 #include <test/unit/math/rev/mat/util.hpp>
 #include <vector>
 
-TEST(AgradRevMatrix, softmaxLeak) {
-  // FIXME: very brittle test depending on unrelated constants of
-  //        block sizes/growth in stan::math::stack_alloc
-  using Eigen::Dynamic;
-  using Eigen::Matrix;
-  using stan::math::softmax;
-  using stan::math::var;
-  using stan::math::vector_v;
-
-  int SIZE = 20;
-  int NUM = 112;  // alloc on stack: 458752; bug fix used: = 196608
-  Matrix<var, Dynamic, 1> x(SIZE);
-  for (int i = 0; i < NUM; ++i) {
-    for (int n = 0; n < x.size(); ++n) {
-      x(n) = 0.1 * n;
-    }
-    Matrix<var, Dynamic, 1> theta = softmax(x);
-  }
-  // test is greater than because leak is on heap, not stack
-  EXPECT_GT(stan::math::ChainableStack::instance().memalloc_.bytes_allocated(),
-            200000);
-}
-
 TEST(AgradRevMatrix, softmax) {
   using Eigen::Dynamic;
   using Eigen::Matrix;


### PR DESCRIPTION
#### Submission Checklist

- [ ] Run unit tests: `./runTests.py test/unit`
- [ ] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

This is my initial attempt at getting https://github.com/stan-dev/math/issues/876 coded up. ~~No tests yet. Work in progress, don't merge.~~ Tests are here!

#### Intended Effect:

Use the new features to make softmax better

The goal of issue 876 is to allow people to add functions that are compatible with reverse mode autodiff without actually having to dig into the Stan implementation of reverse mode autodiff

#### How to Verify:

./runTests.py test/unit/math/rev/mat/fun/softmax_test

#### Side Effects:

~~This weird test breaks: https://github.com/stan-dev/math/blob/e7c695c8e085c0c5d2bfc0cf2983dc62bb2cf398/test/unit/math/rev/mat/fun/softmax_test.cpp#L8, but it's a self-proclaimed weird and brittle test. Still makes me nervous.~~ We're getting rid of this test (https://github.com/stan-dev/math/pull/924#issuecomment-402292761)

#### Documentation:

Doxygen!

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
