### PR TITLE
Added vectorized version of bernoulli_logit_rng (Issue 45)

### DIFF
--- a/stan/math/prim/scal/prob/bernoulli_logit_rng.hpp
+++ b/stan/math/prim/scal/prob/bernoulli_logit_rng.hpp
@@ -1,32 +1,31 @@
 #ifndef STAN_MATH_PRIM_SCAL_PROB_BERNOULLI_LOGIT_RNG_HPP
 #define STAN_MATH_PRIM_SCAL_PROB_BERNOULLI_LOGIT_RNG_HPP
 
+#include <stan/math/prim/scal/fun/inv_logit.hpp>
+#include <stan/math/prim/scal/err/check_finite.hpp>
+#include <stan/math/prim/scal/meta/length.hpp>
+#include <stan/math/prim/scal/meta/scalar_seq_view.hpp>
+#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
 #include <boost/random/bernoulli_distribution.hpp>
 #include <boost/random/variate_generator.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_bounded.hpp>
-#include <stan/math/prim/scal/err/check_finite.hpp>
-#include <stan/math/prim/scal/err/check_not_nan.hpp>
-#include <stan/math/prim/scal/fun/constants.hpp>
-#include <stan/math/prim/scal/fun/inv_logit.hpp>
-#include <stan/math/prim/scal/fun/log1m.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
 
 namespace stan {
 namespace math {
 
 /**
- * A Bernoulli random number generator which takes as its argument the
- * often more convenient logit-parametrization.
+ * Return a Bernoulli random variate with logit-parameterized chance of success using the specified random number generator.
  *
- * @tparam RNG Random number generator type.
- * @param t logit-transformed probability parameter.
- * @param rng pseudorandom number generator.
- * @return Bernoulli(logit^{-1}(t)) generated random number, either 0 or 1.
+ * t can be a scalar or a one-dimensional container.
+ *
+ * @tparam T_t type of logit-parameterized chance of success parameter
+ * @tparam RNG type of random number generator
+ * @param theta (Sequence of) logit-parameterized chance of success parameter(s)
+ * @param rng random number generator
+ * @return (Sequence of) Bernoulli random variate(s)
+ * @throw std::domain_error if logit-parameterized chance of success parameter is not finite
  */
-template <class RNG>
-inline int bernoulli_logit_rng(double t, RNG& rng) {
+template <typename T_t, class RNG>
+inline typename VectorBuilder<true, int, T_t>::type bernoulli_logit_rng(const T_t& t, RNG& rng) {
   using boost::bernoulli_distribution;
   using boost::variate_generator;
   using stan::math::inv_logit;
@@ -34,9 +33,17 @@ inline int bernoulli_logit_rng(double t, RNG& rng) {
   check_finite("bernoulli_logit_rng", "Logit transformed probability parameter",
                t);
 
-  variate_generator<RNG&, bernoulli_distribution<> > bernoulli_rng(
-      rng, bernoulli_distribution<>(inv_logit(t)));
-  return bernoulli_rng();
+  scalar_seq_view<T_t> t_vec(t);
+  size_t N = length(t);
+  VectorBuilder<true, int, T_t> output(N);
+
+  for (size_t n = 0; n < N; ++n) {
+    variate_generator<RNG&, bernoulli_distribution<> > bernoulli_rng(
+      rng, bernoulli_distribution<>(inv_logit(t_vec[n])));
+    output[n] = bernoulli_rng();
+  }
+
+  return output.data();
 }
 
 }  // namespace math

--- a/stan/math/prim/scal/prob/bernoulli_logit_rng.hpp
+++ b/stan/math/prim/scal/prob/bernoulli_logit_rng.hpp
@@ -19,7 +19,7 @@ namespace math {
  *
  * @tparam T_t type of logit-parameterized chance of success parameter
  * @tparam RNG type of random number generator
- * @param theta (Sequence of) logit-parameterized chance of success parameter(s)
+ * @param t (Sequence of) logit-parameterized chance of success parameter(s)
  * @param rng random number generator
  * @return (Sequence of) Bernoulli random variate(s)
  * @throw std::domain_error if logit-parameterized chance of success parameter is not finite

--- a/test/unit/math/prim/mat/prob/bernoulli_logit_test.cpp
+++ b/test/unit/math/prim/mat/prob/bernoulli_logit_test.cpp
@@ -1,0 +1,34 @@
+#include <gtest/gtest.h>
+#include <boost/math/distributions.hpp>
+#include <boost/random/mersenne_twister.hpp>
+#include <stan/math/prim/mat.hpp>
+#include <test/unit/math/prim/mat/prob/vector_rng_test_helper.hpp>
+#include <test/unit/math/prim/mat/prob/VectorIntRNGTestRig.hpp>
+#include <limits>
+#include <vector>
+
+class BernoulliLogitTestRig : public VectorIntRNGTestRig {
+ public:
+  BernoulliLogitTestRig()
+    : VectorIntRNGTestRig(10000, 10, {0, 1}, {-5.7, -1.0, 0.0, 0.2, 1.0, 10.0},
+                            {-3, -2, 0, 1}, {}, {}) {}
+
+  template <typename T1, typename T2, typename T3, typename T_rng>
+  auto generate_samples(const T1& t, const T2&, const T3&,
+                        T_rng& rng) const {
+    return stan::math::bernoulli_logit_rng(t, rng);
+  }
+
+  template <typename T1>
+  double pmf(int y, T1 t, double, double) const {
+    return std::exp(stan::math::bernoulli_logit_lpmf(y, t));
+  }
+};
+
+TEST(ProbDistributionsBernoulliLogit, errorCheck) {
+  check_dist_throws_all_types(BernoulliLogitTestRig());
+}
+
+TEST(ProbDistributionsBernoulliLogit, distributionCheck) {
+  check_counts_real(BernoulliLogitTestRig());
+}


### PR DESCRIPTION
#### Submission Checklist

- [ ] Run unit tests: `./runTests.py test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

@roualdes discovered bernoulli_logit_rng hadn't been vectorized. We gotta fix that

@mitzimorris can you review this one?

#### Intended Effect:

Vectorized bernoulli_logit_rng

#### How to Verify:

./runTests.py test/unit/math/prim/scal/prob/bernoulli_logit_test
./runTests.py test/unit/math/prim/mat/prob/bernoulli_logit_test

#### Side Effects:

None!

#### Documentation:

In the Doxygen

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
