### PR TITLE
Lots of fixes for integrate_1d

### DIFF
--- a/stan/math/prim/arr/functor/integrate_1d.hpp
+++ b/stan/math/prim/arr/functor/integrate_1d.hpp
@@ -16,10 +16,10 @@ namespace stan {
 namespace math {
 /**
  * Integrate a single variable function f from a to b to within a specified
- * tolerance. This function assumes a is less than b.
+ * relative tolerance. This function assumes a is less than b.
  *
  * The signature for f should be:
- *   double foo(double x, double xc)
+ *   double f(double x, double xc)
  *
  * It should return the value of the function evaluated at x.
  *
@@ -28,7 +28,7 @@ namespace math {
  * the Boost quadrature library is chosen.
  *
  * Integrals that cross zero are broken into two, and the separate integrals are
- * each integrated to the given tolerance.
+ * each integrated to the given relative tolerance.
  *
  * For integrals with finite limits, the xc argument is the distance to the
  * nearest boundary. So for a > 0, b > 0, it will be a - x for x closer to a,
@@ -43,11 +43,11 @@ namespace math {
  * @param f the function to be integrated
  * @param a lower limit of integration
  * @param b upper limit of integration
- * @param tolerance target tolerance passed to Boost quadrature
+ * @param relative_tolerance target relative tolerance passed to Boost quadrature
  * @return numeric integral of function f
  */
 template <typename F>
-inline double integrate(const F& f, double a, double b, double tolerance) {
+inline double integrate(const F& f, double a, double b, double relative_tolerance) {
   double error1 = 0.0;
   double error2 = 0.0;
   double L1 = 0.0;
@@ -60,7 +60,7 @@ inline double integrate(const F& f, double a, double b, double tolerance) {
       return f(x, std::numeric_limits<double>::quiet_NaN());
     };
     boost::math::quadrature::sinh_sinh<double> integrator;
-    Q = integrator.integrate(f_wrap, tolerance, &error1, &L1, &levels);
+    Q = integrator.integrate(f_wrap, relative_tolerance, &error1, &L1, &levels);
   } else if (std::isinf(a)) {
     boost::math::quadrature::exp_sinh<double> integrator;
     /**
@@ -72,14 +72,14 @@ inline double integrate(const F& f, double a, double b, double tolerance) {
       auto f_wrap = [&](double x) {
         return f(-(x + b), std::numeric_limits<double>::quiet_NaN());
       };
-      Q = integrator.integrate(f_wrap, tolerance, &error1, &L1, &levels);
+      Q = integrator.integrate(f_wrap, relative_tolerance, &error1, &L1, &levels);
     } else {
       boost::math::quadrature::tanh_sinh<double> integrator_right;
       auto f_wrap = [&](double x) {
         return f(-x, std::numeric_limits<double>::quiet_NaN());
       };
-      Q = integrator.integrate(f_wrap, tolerance, &error1, &L1, &levels)
-          + integrator_right.integrate(f_wrap, -b, 0, tolerance, &error2, &L2,
+      Q = integrator.integrate(f_wrap, relative_tolerance, &error1, &L1, &levels)
+          + integrator_right.integrate(f_wrap, -b, 0, relative_tolerance, &error2, &L2,
                                        &levels);
       used_two_integrals = true;
     }
@@ -89,14 +89,14 @@ inline double integrate(const F& f, double a, double b, double tolerance) {
       auto f_wrap = [&](double x) {
         return f(x + a, std::numeric_limits<double>::quiet_NaN());
       };
-      Q = integrator.integrate(f_wrap, tolerance, &error1, &L1, &levels);
+      Q = integrator.integrate(f_wrap, relative_tolerance, &error1, &L1, &levels);
     } else {
       boost::math::quadrature::tanh_sinh<double> integrator_right;
       auto f_wrap = [&](double x) {
         return f(x, std::numeric_limits<double>::quiet_NaN());
       };
-      Q = integrator.integrate(f_wrap, tolerance, &error1, &L1, &levels)
-          + integrator_right.integrate(f_wrap, a, 0, tolerance, &error2, &L2,
+      Q = integrator.integrate(f_wrap, relative_tolerance, &error1, &L1, &levels)
+          + integrator_right.integrate(f_wrap, a, 0, relative_tolerance, &error2, &L2,
                                        &levels);
       used_two_integrals = true;
     }
@@ -104,31 +104,31 @@ inline double integrate(const F& f, double a, double b, double tolerance) {
     auto f_wrap = [&](double x, double xc) { return f(x, xc); };
     boost::math::quadrature::tanh_sinh<double> integrator;
     if (a < 0.0 && b > 0.0) {
-      Q = integrator.integrate(f_wrap, a, 0.0, tolerance, &error1, &L1, &levels)
-          + integrator.integrate(f_wrap, 0.0, b, tolerance, &error2, &L2,
+      Q = integrator.integrate(f_wrap, a, 0.0, relative_tolerance, &error1, &L1, &levels)
+          + integrator.integrate(f_wrap, 0.0, b, relative_tolerance, &error2, &L2,
                                  &levels);
       used_two_integrals = true;
     } else {
-      Q = integrator.integrate(f_wrap, a, b, tolerance, &error1, &L1, &levels);
+      Q = integrator.integrate(f_wrap, a, b, relative_tolerance, &error1, &L1, &levels);
     }
   }
 
   static const char* function = "integrate";
   if (used_two_integrals) {
-    if (error1 > tolerance * L1) {
+    if (error1 > relative_tolerance * L1) {
       domain_error(function, "error estimate of integral below zero", error1,
                    "",
-                   " exceeds the given tolerance times integral below zero");
+                   " exceeds the given relative tolerance times norm of integral below zero");
     }
-    if (error2 > tolerance * L2) {
+    if (error2 > relative_tolerance * L2) {
       domain_error(function, "error estimate of integral above zero", error2,
                    "",
-                   " exceeds the given tolerance times integral above zero");
+                   " exceeds the given relative tolerance times norm of integral above zero");
     }
   } else {
-    if (error1 > tolerance * L1) {
+    if (error1 > relative_tolerance * L1) {
       domain_error(function, "error estimate of integral", error1, "",
-                   " exceeds the given tolerance times integral");
+                   " exceeds the given relative tolerance times norm of integral");
     }
   }
   return Q;
@@ -136,17 +136,17 @@ inline double integrate(const F& f, double a, double b, double tolerance) {
 
 /**
  * Compute the integral of the single variable function f from a to b to within
- * a specified tolerance. a and b can be finite or infinite.
+ * a specified relative tolerance. a and b can be finite or infinite.
  *
  * The signature for f should be:
- *   double foo(double x, double xc, std::vector<double> theta,
- * std::vector<double> x_r, std::vector<int> x_i, std::ostream& msgs)
+ *   double f(double x, double xc, const std::vector<double>& theta,
+ *     const std::vector<double>& x_r, const std::vector<int>& x_i, std::ostream* msgs)
  *
  * It should return the value of the function evaluated at x. Any errors
  * should be printed to the msgs stream.
  *
  * Integrals that cross zero are broken into two, and the separate integrals are
- * each integrated to the given tolerance.
+ * each integrated to the given relative tolerance.
  *
  * For integrals with finite limits, the xc argument is the distance to the
  * nearest boundary. So for a > 0, b > 0, it will be a - x for x closer to a,
@@ -157,11 +157,16 @@ inline double integrate(const F& f, double a, double b, double tolerance) {
  *
  * If either limit is infinite, xc is set to NaN
  *
- * Boost decides the integration is converged when subsequent estimates of the
- * integral are less than tolerance * abs(integral). This means the tolerance is
- * relative to the actual scale of the integral. Integrals that cross zero are
+ * The integration algorithm terminates when
+ *   \f[
+ *     \frac{{|I_{n + 1} - I_n|}}{{|I|_{n + 1}}} < \text{relative tolerance}
+ *   \f]
+ * where \f$I_{n}\f$ is the nth estimate of the integral and \f$|I|_{n}\f$ is the
+ * nth estimate of the norm of the integral.
+ *
+ * Integrals that cross zero are
  * split into two. In this case, each integral is separately integrated to the
- * given tolerance.
+ * given relative_tolerance.
  *
  * @tparam T Type of f
  * @param f the function to be integrated
@@ -171,7 +176,7 @@ inline double integrate(const F& f, double a, double b, double tolerance) {
  * @param x_r additional data to be passed to f
  * @param x_i additional integer data to be passed to f
  * @param[in, out] msgs the print stream for warning messages
- * @param tolerance integrator tolerance passed to Boost quadrature
+ * @param relative_tolerance tolerance passed to Boost quadrature
  * @return numeric integral of function f
  */
 template <typename F>
@@ -179,7 +184,7 @@ inline double integrate_1d(
     const F& f, const double a, const double b,
     const std::vector<double>& theta, const std::vector<double>& x_r,
     const std::vector<int>& x_i, std::ostream& msgs,
-    const double tolerance
+    const double relative_tolerance
     = std::sqrt(std::numeric_limits<double>::epsilon())) {
   static const char* function = "integrate_1d";
   check_less_or_equal(function, "lower limit", a, b);
@@ -191,8 +196,8 @@ inline double integrate_1d(
   } else {
     return integrate(
         std::bind<double>(f, std::placeholders::_1, std::placeholders::_2,
-                          theta, x_r, x_i, std::ref(msgs)),
-        a, b, tolerance);
+                          theta, x_r, x_i, &msgs),
+        a, b, relative_tolerance);
   }
 }
 

--- a/stan/math/rev/arr/functor/integrate_1d.hpp
+++ b/stan/math/rev/arr/functor/integrate_1d.hpp
@@ -42,11 +42,11 @@ inline double gradient_of_f(const F &f, const double &x, const double &xc,
     fx.grad();
     gradient = theta_var[n].adj();
     if (is_nan(gradient)) {
-      if (fx.val() == 0)
+      if (fx.val() == 0) {
         gradient = 0;
-      else
-        throw std::domain_error(
-            std::string("derivative of integral is nan for parameter ", n));
+      } else {
+        domain_error("gradient_of_f", "The gradient of f", n, "is nan for parameter ", "");
+      }
     }
   } catch (const std::exception &e) {
     recover_memory_nested();

--- a/stan/math/rev/arr/functor/integrate_1d.hpp
+++ b/stan/math/rev/arr/functor/integrate_1d.hpp
@@ -45,7 +45,8 @@ inline double gradient_of_f(const F &f, const double &x, const double &xc,
       if (fx.val() == 0) {
         gradient = 0;
       } else {
-        domain_error("gradient_of_f", "The gradient of f", n, "is nan for parameter ", "");
+        domain_error("gradient_of_f", "The gradient of f", n,
+                     "is nan for parameter ", "");
       }
     }
   } catch (const std::exception &e) {

--- a/stan/math/rev/arr/functor/integrate_1d.hpp
+++ b/stan/math/rev/arr/functor/integrate_1d.hpp
@@ -23,8 +23,8 @@ namespace math {
  * Calculate first derivative of f(x, param, std::ostream&)
  * with respect to the nth parameter. Uses nested reverse mode autodiff
  *
- * Gradients that evaluate to NaN when the function is zero are set to zero as
- * well
+ * Gradients that evaluate to NaN are set to zero if the function itself
+ * evaluates to zero. If the function is not zero and the gradient evaluates to NaN, a std::domain_error is thrown
  */
 template <typename F>
 inline double gradient_of_f(const F &f, const double &x, const double &xc,

--- a/stan/math/rev/arr/functor/integrate_1d.hpp
+++ b/stan/math/rev/arr/functor/integrate_1d.hpp
@@ -8,6 +8,8 @@
 #include <stan/math/rev/scal/fun/is_nan.hpp>
 #include <stan/math/rev/scal/fun/value_of.hpp>
 #include <stan/math/rev/scal/meta/is_var.hpp>
+#include <boost/utility/enable_if.hpp>
+#include <boost/type_traits.hpp>
 #include <string>
 #include <vector>
 #include <functional>
@@ -20,6 +22,9 @@ namespace math {
 /**
  * Calculate first derivative of f(x, param, std::ostream&)
  * with respect to the nth parameter. Uses nested reverse mode autodiff
+ *
+ * Gradients that evaluate to NaN when the function is zero are set to zero as
+ * well
  */
 template <typename F>
 inline double gradient_of_f(const F &f, const double &x, const double &xc,
@@ -33,7 +38,7 @@ inline double gradient_of_f(const F &f, const double &x, const double &xc,
   try {
     for (size_t i = 0; i < theta_vals.size(); i++)
       theta_var[i] = theta_vals[i];
-    var fx = f(x, xc, theta_var, x_r, x_i, msgs);
+    var fx = f(x, xc, theta_var, x_r, x_i, &msgs);
     fx.grad();
     gradient = theta_var[n].adj();
     if (is_nan(gradient)) {
@@ -54,17 +59,18 @@ inline double gradient_of_f(const F &f, const double &x, const double &xc,
 
 /**
  * Compute the integral of the single variable function f from a to b to within
- * a specified tolerance. a and b can be finite or infinite.
+ * a specified relative tolerance. a and b can be finite or infinite.
  *
  * f should be compatible with reverse mode autodiff and have the signature:
- *   var foo(double x, double xc, std::vector<var> theta, std::vector<double>
- * x_r, std::vector<int> x_i, std::ostream& msgs)
+ *   var f(double x, double xc, const std::vector<var>& theta,
+ *     const std::vector<double>& x_r, const std::vector<int> &x_i,
+ * std::ostream* msgs)
  *
  * It should return the value of the function evaluated at x. Any errors
  * should be printed to the msgs stream.
  *
  * Integrals that cross zero are broken into two, and the separate integrals are
- * each integrated to the given tolerance.
+ * each integrated to the given relative tolerance.
  *
  * For integrals with finite limits, the xc argument is the distance to the
  * nearest boundary. So for a > 0, b > 0, it will be a - x for x closer to a,
@@ -75,11 +81,21 @@ inline double gradient_of_f(const F &f, const double &x, const double &xc,
  *
  * If either limit is infinite, xc is set to NaN
  *
- * Boost decides the integration is converged when subsequent estimates of the
- * integral are less than tolerance * abs(integral). This means the tolerance is
- * relative to the actual scale of the integral. Integrals that cross zero are
+ * The integration algorithm terminates when
+ *   \f[
+ *     \frac{{|I_{n + 1} - I_n|}}{{|I|_{n + 1}}} < \text{relative tolerance}
+ *   \f]
+ * where \f$I_{n}\f$ is the nth estimate of the integral and \f$|I|_{n}\f$ is
+ * the nth estimate of the norm of the integral.
+ *
+ * Integrals that cross zero are
  * split into two. In this case, each integral is separately integrated to the
- * given tolerance.
+ * given relative_tolerance.
+ *
+ * Gradients of f that evaluate to NaN when the function evaluates to zero are
+ * set to zero themselves. This is due to the autodiff easily overflowing to NaN
+ * when evaluating gradients near the maximum and minimum floating point values
+ * (where the function should be zero anyway for the integral to exist)
  *
  * @tparam T_a type of first limit
  * @tparam T_b type of second limit
@@ -92,16 +108,19 @@ inline double gradient_of_f(const F &f, const double &x, const double &xc,
  * @param x_r additional data to be passed to f
  * @param x_i additional integer data to be passed to f
  * @param[in, out] msgs the print stream for warning messages
- * @param tolerance integrator tolerance passed to Boost quadrature
+ * @param relative_tolerance relative tolerance passed to Boost quadrature
  * @return numeric integral of function f
  */
 template <typename F, typename T_a, typename T_b, typename T_theta>
-inline var integrate_1d(const F &f, const T_a &a, const T_b &b,
-                        const std::vector<T_theta> &theta,
-                        const std::vector<double> &x_r,
-                        const std::vector<int> &x_i, std::ostream &msgs,
-                        const double tolerance
-                        = std::sqrt(std::numeric_limits<double>::epsilon())) {
+inline typename boost::enable_if_c<boost::is_same<T_a, var>::value
+                                       || boost::is_same<T_a, var>::value
+                                       || boost::is_same<T_theta, var>::value,
+                                   var>::type
+integrate_1d(const F &f, const T_a &a, const T_b &b,
+             const std::vector<T_theta> &theta, const std::vector<double> &x_r,
+             const std::vector<int> &x_i, std::ostream &msgs,
+             const double relative_tolerance
+             = std::sqrt(std::numeric_limits<double>::epsilon())) {
   static const char *function = "integrate_1d";
   check_less_or_equal(function, "lower limit", a, b);
 
@@ -113,8 +132,8 @@ inline var integrate_1d(const F &f, const T_a &a, const T_b &b,
   } else {
     double integral = integrate(
         std::bind<double>(f, std::placeholders::_1, std::placeholders::_2,
-                          value_of(theta), x_r, x_i, std::ref(msgs)),
-        value_of(a), value_of(b), tolerance);
+                          value_of(theta), x_r, x_i, &msgs),
+        value_of(a), value_of(b), relative_tolerance);
 
     size_t N_theta_vars = is_var<T_theta>::value ? theta.size() : 0;
     std::vector<double> dintegral_dtheta(N_theta_vars);
@@ -128,7 +147,7 @@ inline var integrate_1d(const F &f, const T_a &a, const T_b &b,
             std::bind<double>(gradient_of_f<F>, f, std::placeholders::_1,
                               std::placeholders::_2, theta_vals, x_r, x_i, n,
                               std::ref(msgs)),
-            value_of(a), value_of(b), tolerance);
+            value_of(a), value_of(b), relative_tolerance);
         theta_concat[n] = theta[n];
       }
     }
@@ -136,13 +155,13 @@ inline var integrate_1d(const F &f, const T_a &a, const T_b &b,
     if (!is_inf(a) && is_var<T_a>::value) {
       theta_concat.push_back(a);
       dintegral_dtheta.push_back(
-          -value_of(f(value_of(a), 0.0, theta, x_r, x_i, msgs)));
+          -value_of(f(value_of(a), 0.0, theta, x_r, x_i, &msgs)));
     }
 
     if (!is_inf(b) && is_var<T_b>::value) {
       theta_concat.push_back(b);
       dintegral_dtheta.push_back(
-          value_of(f(value_of(b), 0.0, theta, x_r, x_i, msgs)));
+          value_of(f(value_of(b), 0.0, theta, x_r, x_i, &msgs)));
     }
 
     return precomputed_gradients(integral, theta_concat, dintegral_dtheta);

--- a/test/unit/math/prim/arr/functor/integrate_1d_test.cpp
+++ b/test/unit/math/prim/arr/functor/integrate_1d_test.cpp
@@ -13,7 +13,7 @@ struct f1 {
   inline typename stan::return_type<T1, T2>::type operator()(
       const T1 &x, const T1 &xc, const std::vector<T2> &theta,
       const std::vector<double> &x_r, const std::vector<int> &x_i,
-      std::ostream &msgs) const {
+      std::ostream *msgs) const {
     return exp(-x) / sqrt(x);
   }
 };
@@ -23,7 +23,7 @@ struct f2 {
   inline typename stan::return_type<T1, T2>::type operator()(
       const T1 &x, const T1 &xc, const std::vector<T2> &theta,
       const std::vector<double> &x_r, const std::vector<int> &x_i,
-      std::ostream &msgs) const {
+      std::ostream *msgs) const {
     if (x <= 0.5) {
       return sqrt(x) / sqrt(1 - x * x);
     } else {
@@ -37,7 +37,7 @@ struct f3 {
   inline typename stan::return_type<T1, T2>::type operator()(
       const T1 &x, const T1 &xc, const std::vector<T2> &theta,
       const std::vector<double> &x_r, const std::vector<int> &x_i,
-      std::ostream &msgs) const {
+      std::ostream *msgs) const {
     return exp(-x);
   }
 };
@@ -47,7 +47,7 @@ struct f4 {
   inline typename stan::return_type<T1, T2>::type operator()(
       const T1 &x, const T1 &xc, const std::vector<T2> &theta,
       const std::vector<double> &x_r, const std::vector<int> &x_i,
-      std::ostream &msgs) const {
+      std::ostream *msgs) const {
     return exp(x) + theta[0];
   }
 };
@@ -57,7 +57,7 @@ struct f5 {
   inline typename stan::return_type<T1, T2>::type operator()(
       const T1 &x, const T1 &xc, const std::vector<T2> &theta,
       const std::vector<double> &x_r, const std::vector<int> &x_i,
-      std::ostream &msgs) const {
+      std::ostream *msgs) const {
     return exp(x) + pow(theta[0], 2) + pow(theta[1], 3);
   }
 };
@@ -67,7 +67,7 @@ struct f6 {
   inline typename stan::return_type<T1, T2>::type operator()(
       const T1 &x, const T1 &xc, const std::vector<T2> &theta,
       const std::vector<double> &x_r, const std::vector<int> &x_i,
-      std::ostream &msgs) const {
+      std::ostream *msgs) const {
     return exp(x) + pow(x_i[0], 2) + pow(theta[0], 4) + 3 * theta[1];
   }
 };
@@ -77,7 +77,7 @@ struct f7 {
   inline typename stan::return_type<T1, T2>::type operator()(
       const T1 &x, const T1 &xc, const std::vector<T2> &theta,
       const std::vector<double> &x_r, const std::vector<int> &x_i,
-      std::ostream &msgs) const {
+      std::ostream *msgs) const {
     return exp(x) + pow(x_r[0], 2) + pow(x_r[1], 5) + 3 * x_r[2];
   }
 };
@@ -87,7 +87,7 @@ struct f8 {
   inline typename stan::return_type<T1, T2>::type operator()(
       const T1 &x, const T1 &xc, const std::vector<T2> &theta,
       const std::vector<double> &x_r, const std::vector<int> &x_i,
-      std::ostream &msgs) const {
+      std::ostream *msgs) const {
     return exp(-pow(x - theta[0], x_i[0]) / pow(x_r[0], x_i[0]));
   }
 };
@@ -97,7 +97,7 @@ struct f9 {
   inline typename stan::return_type<T1, T2>::type operator()(
       const T1 &x, const T1 &xc, const std::vector<T2> &theta,
       const std::vector<double> &x_r, const std::vector<int> &x_i,
-      std::ostream &msgs) const {
+      std::ostream *msgs) const {
     return 1.0 / (1.0 + pow(x, x_i[0]) / theta[0]);
   }
 };
@@ -107,7 +107,7 @@ struct f10 {
   inline typename stan::return_type<T1, T2>::type operator()(
       const T1 &x, const T1 &xc, const std::vector<T2> &theta,
       const std::vector<double> &x_r, const std::vector<int> &x_i,
-      std::ostream &msgs) const {
+      std::ostream *msgs) const {
     return pow(x, theta[0] - 1.0)
            * pow((x > 0.5) ? xc : (1 - x), theta[1] - 1.0);
   }
@@ -118,7 +118,7 @@ struct f11 {
   inline typename stan::return_type<T1, T2>::type operator()(
       const T1 &x, const T1 &xc, const std::vector<T2> &theta,
       const std::vector<double> &x_r, const std::vector<int> &x_i,
-      std::ostream &msgs) const {
+      std::ostream *msgs) const {
     return (std::isnan(xc)) ? xc : 0.0;
   }
 };
@@ -128,7 +128,7 @@ struct f12 {
   inline typename stan::return_type<T1, T2>::type operator()(
       const T1 &x, const T1 &xc, const std::vector<T2> &theta,
       const std::vector<double> &x_r, const std::vector<int> &x_i,
-      std::ostream &msgs) const {
+      std::ostream *msgs) const {
     T1 out = stan::math::modified_bessel_second_kind(0, x);
     if (out > 0)
       return 2 * x * out;
@@ -141,7 +141,7 @@ struct f13 {
   inline typename stan::return_type<T1, T2>::type operator()(
       const T1 &x, const T1 &xc, const std::vector<T2> &theta,
       const std::vector<double> &x_r, const std::vector<int> &x_i,
-      std::ostream &msgs) const {
+      std::ostream *msgs) const {
     T1 out = stan::math::modified_bessel_second_kind(0, x);
     if (out > 0)
       return 2 * x * stan::math::square(out);
@@ -154,7 +154,7 @@ struct f14 {
   inline typename stan::return_type<T1, T2>::type operator()(
       const T1 &x, const T1 &xc, const std::vector<T2> &theta,
       const std::vector<double> &x_r, const std::vector<int> &x_i,
-      std::ostream &msgs) const {
+      std::ostream *msgs) const {
     return exp(x) * stan::math::inv_sqrt(x > 0.5 ? xc : 1 - x);
   }
 };
@@ -164,7 +164,7 @@ struct f15 {
   inline typename stan::return_type<T1, T2>::type operator()(
       const T1 &x, const T1 &xc, const std::vector<T2> &theta,
       const std::vector<double> &x_r, const std::vector<int> &x_i,
-      std::ostream &msgs) const {
+      std::ostream *msgs) const {
     T1 x2 = x * x;
     T1 numer = x2 * log(x);
     T1 denom = x < 0.5 ? (x + 1) * (x - 1) : (x + 1) * -xc;
@@ -178,7 +178,7 @@ struct f16 {
   inline typename stan::return_type<T1, T2>::type operator()(
       const T1 &x, const T1 &xc, const std::vector<T2> &theta,
       const std::vector<double> &x_r, const std::vector<int> &x_i,
-      std::ostream &msgs) const {
+      std::ostream *msgs) const {
     return x * sin(x) / (1 + stan::math::square(cos(x)));
   }
 };
@@ -226,7 +226,7 @@ void test_integration(const F &f, double a, double b,
     auto flipped =
         [&](const double &x, const double &xc, const std::vector<double> &theta,
             const std::vector<double> &x_r, const std::vector<int> &x_i,
-            std::ostream &msgs) { return f(-x, -xc, theta, x_r, x_i, msgs); };
+            std::ostream *msgs) { return f(-x, -xc, theta, x_r, x_i, msgs); };
     EXPECT_LE(std::abs(integrate_1d(flipped, -b, -a, thetas, x_r, x_i, msgs,
                                     tolerance)
                        - val),
@@ -284,12 +284,24 @@ TEST(StanMath_integrate_1d, TestThrows) {
       f11{}, 0.0, 1.0, std::vector<double>(), {}, {}, msgs, 1e-6));
 }
 
+TEST(StanMath_integrate_1d, test_integer_arguments) {
+  double v;
+  EXPECT_NO_THROW(v = stan::math::integrate_1d(f2{}, 0, 1, std::vector<double>(),
+					       {}, {}, msgs, 1e-6));
+  EXPECT_NO_THROW(v = stan::math::integrate_1d(f2{}, 0.0, 1, std::vector<double>(),
+					       {}, {}, msgs, 1e-6));
+  EXPECT_NO_THROW(v = stan::math::integrate_1d(f2{}, 0, 1.0, std::vector<double>(),
+					       {}, {}, msgs, 1e-6));
+}
+
 TEST(StanMath_integrate_1d, test1) {
   // Tricky integral from Boost docs + limit at infinity
   test_integration(f1{}, 0.0, std::numeric_limits<double>::infinity(), {}, {},
                    {}, 1.772453850905516);
   // Tricky integral from Boost 1d integration docs
   test_integration(f2{}, 0.0, 1.0, {}, {}, {}, 1.198140234735592);
+  // Tricky integral from Boost 1d integration docs
+  test_integration(f2{}, 0, 1, {}, {}, {}, 1.198140234735592);
   // Zero crossing integral + limit at infinity
   test_integration(f3{}, -2.0, std::numeric_limits<double>::infinity(), {}, {},
                    {}, 7.38905609893065);

--- a/test/unit/math/rev/arr/functor/integrate_1d_test.cpp
+++ b/test/unit/math/rev/arr/functor/integrate_1d_test.cpp
@@ -15,7 +15,7 @@ struct f1 {
   inline typename stan::return_type<T1, T2>::type operator()(
       const T1 &x, const T1 &xc, const std::vector<T2> &theta,
       const std::vector<double> &x_r, const std::vector<int> &x_i,
-      std::ostream &msgs) const {
+      std::ostream *msgs) const {
     return exp(x) + theta[0];
   }
 };
@@ -25,7 +25,7 @@ struct f2 {
   inline typename stan::return_type<T1, T2>::type operator()(
       const T1 &x, const T1 &xc, const std::vector<T2> &theta,
       const std::vector<double> &x_r, const std::vector<int> &x_i,
-      std::ostream &msgs) const {
+      std::ostream *msgs) const {
     return exp(theta[0] * cos(2 * 3.141593 * x)) + theta[0];
   }
 };
@@ -35,7 +35,7 @@ struct f3 {
   inline typename stan::return_type<T1, T2>::type operator()(
       const T1 &x, const T1 &xc, const std::vector<T2> &theta,
       const std::vector<double> &x_r, const std::vector<int> &x_i,
-      std::ostream &msgs) const {
+      std::ostream *msgs) const {
     return exp(x) + pow(theta[0], x_r[0]) + 2 * pow(theta[1], x_r[1])
            + 2 * theta[2];
   }
@@ -46,7 +46,7 @@ struct f4 {
   inline typename stan::return_type<T1, T2>::type operator()(
       const T1 &x, const T1 &xc, const std::vector<T2> &theta,
       const std::vector<double> &x_r, const std::vector<int> &x_i,
-      std::ostream &msgs) const {
+      std::ostream *msgs) const {
     return exp(-x) / sqrt(x);
   }
 };
@@ -56,7 +56,7 @@ struct f5 {
   inline typename stan::return_type<T1, T2>::type operator()(
       const T1 &x, const T1 &xc, const std::vector<T2> &theta,
       const std::vector<double> &x_r, const std::vector<int> &x_i,
-      std::ostream &msgs) const {
+      std::ostream *msgs) const {
     return exp(-theta[0] * x) / sqrt(theta[1] * x);
   }
 };
@@ -66,7 +66,7 @@ struct f6 {
   inline typename stan::return_type<T1, T2>::type operator()(
       const T1 &x, const T1 &xc, const std::vector<T2> &theta,
       const std::vector<double> &x_r, const std::vector<int> &x_i,
-      std::ostream &msgs) const {
+      std::ostream *msgs) const {
     return sqrt(x / (1 - theta[0] * x * x));
   }
 };
@@ -76,7 +76,7 @@ struct f7 {
   inline typename stan::return_type<T1, T2>::type operator()(
       const T1 &x, const T1 &xc, const std::vector<T2> &theta,
       const std::vector<double> &x_r, const std::vector<int> &x_i,
-      std::ostream &msgs) const {
+      std::ostream *msgs) const {
     return exp(-theta[0] * x);
   }
 };
@@ -86,7 +86,7 @@ struct f8 {
   inline typename stan::return_type<T1, T2>::type operator()(
       const T1 &x, const T1 &xc, const std::vector<T2> &theta,
       const std::vector<double> &x_r, const std::vector<int> &x_i,
-      std::ostream &msgs) const {
+      std::ostream *msgs) const {
     return exp(theta[0] * x);
   }
 };
@@ -96,7 +96,7 @@ struct f10 {
   inline typename stan::return_type<T1, T2>::type operator()(
       const T1 &x, const T1 &xc, const std::vector<T2> &theta,
       const std::vector<double> &x_r, const std::vector<int> &x_i,
-      std::ostream &msgs) const {
+      std::ostream *msgs) const {
     return 1 / (1 + pow(x, x_i[0]) / x_r[0]);
   }
 };
@@ -106,7 +106,7 @@ struct f11 {
   inline typename stan::return_type<T1, T2>::type operator()(
       const T1 &x, const T1 &xc, const std::vector<T2> &theta,
       const std::vector<double> &x_r, const std::vector<int> &x_i,
-      std::ostream &msgs) const {
+      std::ostream *msgs) const {
     return pow(x, theta[0] - 1.0)
            * pow((x > 0.5) ? xc : (1 - x), theta[1] - 1.0);
   }
@@ -117,7 +117,7 @@ struct f12 {
   inline typename stan::return_type<T1, T2>::type operator()(
       const T1 &x, const T1 &xc, const std::vector<T2> &theta,
       const std::vector<double> &x_r, const std::vector<int> &x_i,
-      std::ostream &msgs) const {
+      std::ostream *msgs) const {
     T2 mu = theta[0];
     T2 sigma = theta[1];
     return exp(-0.5 * stan::math::square((x - mu) / sigma))
@@ -130,7 +130,7 @@ struct f13 {
   inline typename stan::return_type<T1, T2>::type operator()(
       const T1 &x, const T1 &xc, const std::vector<T2> &theta,
       const std::vector<double> &x_r, const std::vector<int> &x_i,
-      std::ostream &msgs) const {
+      std::ostream *msgs) const {
     return x + theta[0] + theta[1];
   }
 };
@@ -230,6 +230,17 @@ void test_derivatives(const F &f, double a, double b,
     if (stan::is_var<T_b>::value)
       EXPECT_LE(std::abs(d_b - get_adjoint_if_var(b_)), tolerance);
   }
+}
+
+TEST(StanMath_integrate_1d, test_integer_arguments) {
+  stan::math::var v;
+  std::vector<stan::math::var> theta = {0.5};
+  EXPECT_NO_THROW(v = stan::math::integrate_1d(f2{}, 0, 1, theta,
+					       {}, {}, msgs, 1e-6));
+  EXPECT_NO_THROW(v = stan::math::integrate_1d(f2{}, 0.0, 1, theta,
+                                        {}, {}, msgs, 1e-6));
+  EXPECT_NO_THROW(v = stan::math::integrate_1d(f2{}, 0, 1.0, theta,
+                                        {}, {}, msgs, 1e-6));
 }
 
 TEST(StanMath_integrate_1d, TestDerivatives) {
@@ -336,7 +347,7 @@ TEST(StanMath_integrate_1d, TestBeta) {
   var beta = 13.0 / 7;
   AVEC theta = {alpha, beta};
   auto pdf = [](auto x, auto xc, auto theta, auto x_r, auto x_i,
-                std::ostream &msgs) {
+                std::ostream *msgs) {
     return exp(stan::math::beta_lpdf(x, theta[0], theta[1]));
   };
   var I = integrate_1d(pdf, 0.0, 1.0, theta, {}, {}, msgs, 1e-8);
@@ -360,7 +371,7 @@ TEST(StanMath_integrate_1d, TestCauchy) {
   double b = std::numeric_limits<double>::infinity();
   double a = -b;
   auto pdf = [](auto x, auto xc, auto theta, auto x_r, auto x_i,
-                std::ostream &msgs) {
+                std::ostream *msgs) {
     return exp(stan::math::cauchy_lpdf(x, theta[0], theta[1]));
   };
   var I = integrate_1d(pdf, a, b, theta, {}, {}, msgs, 1e-8);
@@ -383,7 +394,7 @@ TEST(StanMath_integrate_1d, TestChiSquare) {
   double b = std::numeric_limits<double>::infinity();
   double a = 0;
   auto pdf = [](auto x, auto xc, auto theta, auto x_r, auto x_i,
-                std::ostream &msgs) {
+                std::ostream *msgs) {
     return exp(stan::math::chi_square_lpdf(x, theta[0]));
   };
   var I = integrate_1d(pdf, a, b, theta, {}, {}, msgs, 1e-8);
@@ -406,7 +417,7 @@ TEST(StanMath_integrate_1d, TestDoubleExponential) {
   double a = -std::numeric_limits<double>::infinity();
   double b = mu.val();
   auto pdf = [](auto x, auto xc, auto theta, auto x_r, auto x_i,
-                std::ostream &msgs) {
+                std::ostream *msgs) {
     return exp(stan::math::double_exponential_lpdf(x, theta[0], theta[1]));
   };
   // requires two subintervals to achieve numerical accuracy
@@ -421,35 +432,6 @@ TEST(StanMath_integrate_1d, TestDoubleExponential) {
   EXPECT_FLOAT_EQ(1, 1 + g[1]);
 }
 
-/*
-TEST(StanMath_integrate_1d, TestExpModNormal) {
-  using stan::math::var;
-  using stan::math::integrate_1d;
-  using stan::math::exp;
-
-  var mu = 9.0 / 5;
-  var sigma = 13.0 / 7;
-  var lambda = 11.0 / 9;
-  AVEC theta = {mu, sigma, lambda};
-  double b = std::numeric_limits<double>::infinity();
-  double a = -b;
-  auto pdf = [](auto x, auto xc, auto theta,
-                auto x_r, auto x_i, std::ostream& msgs) {
-     return exp(stan::math::exp_mod_normal_lpdf(x,
-                  theta[0], theta[1], theta[2]));
-  };
-  var I = integrate_1d(pdf, a, b, theta, {}, {}, msgs, 1e-8);
-  EXPECT_FLOAT_EQ(1, I.val());
-
-  AVEC x = createAVEC(mu, sigma, lambda);
-  VEC g;
-  I.grad(x, g);
-  EXPECT_FLOAT_EQ(1, 1 + g[0]);
-  EXPECT_FLOAT_EQ(1, 1 + g[1]);
-  EXPECT_FLOAT_EQ(1, 1 + g[2]);
-}
-*/
-
 TEST(StanMath_integrate_1d, TestExponential) {
   using stan::math::exp;
   using stan::math::integrate_1d;
@@ -460,7 +442,7 @@ TEST(StanMath_integrate_1d, TestExponential) {
   double b = std::numeric_limits<double>::infinity();
   double a = 0;
   auto pdf = [](auto x, auto xc, auto theta, auto x_r, auto x_i,
-                std::ostream &msgs) {
+                std::ostream *msgs) {
     return exp(stan::math::exponential_lpdf(x, theta[0]));
   };
   var I = integrate_1d(pdf, a, b, theta, {}, {}, msgs, 1e-8);
@@ -483,7 +465,7 @@ TEST(StanMath_integrate_1d, TestFrechet) {
   double b = std::numeric_limits<double>::infinity();
   double a = 0;
   auto pdf = [](auto x, auto xc, auto theta, auto x_r, auto x_i,
-                std::ostream &msgs) {
+                std::ostream *msgs) {
     return exp(stan::math::frechet_lpdf(x, theta[0], theta[1]));
   };
   var I = integrate_1d(pdf, a, b, theta, {}, {}, msgs, 1e-8);
@@ -507,7 +489,7 @@ TEST(StanMath_integrate_1d, TestGamma) {
   double b = std::numeric_limits<double>::infinity();
   double a = 0;
   auto pdf = [](auto x, auto xc, auto theta, auto x_r, auto x_i,
-                std::ostream &msgs) {
+                std::ostream *msgs) {
     return exp(stan::math::gamma_lpdf(x, theta[0], theta[1]));
   };
   var I = integrate_1d(pdf, a, b, theta, {}, {}, msgs, 1e-8);
@@ -531,7 +513,7 @@ TEST(StanMath_integrate_1d, TestGumbel) {
   double b = std::numeric_limits<double>::infinity();
   double a = -b;
   auto pdf = [](auto x, auto xc, auto theta, auto x_r, auto x_i,
-                std::ostream &msgs) {
+                std::ostream *msgs) {
     return exp(stan::math::gumbel_lpdf(x, theta[0], theta[1]));
   };
   var I = integrate_1d(pdf, a, b, theta, {}, {}, msgs, 1e-8);
@@ -554,7 +536,7 @@ TEST(StanMath_integrate_1d, TestInvChiSquared) {
   double b = std::numeric_limits<double>::infinity();
   double a = 0;
   auto pdf = [](auto x, auto xc, auto theta, auto x_r, auto x_i,
-                std::ostream &msgs) {
+                std::ostream *msgs) {
     return exp(stan::math::inv_chi_square_lpdf(x, theta[0]));
   };
   var I = integrate_1d(pdf, a, b, theta, {}, {}, msgs, 1e-8);
@@ -577,7 +559,7 @@ TEST(StanMath_integrate_1d, TestLogistic) {
   double b = std::numeric_limits<double>::infinity();
   double a = -b;
   auto pdf = [](auto x, auto xc, auto theta, auto x_r, auto x_i,
-                std::ostream &msgs) {
+                std::ostream *msgs) {
     return exp(stan::math::logistic_lpdf(x, theta[0], theta[1]));
   };
   var I = integrate_1d(pdf, a, b, theta, {}, {}, msgs, 1e-8);
@@ -601,7 +583,7 @@ TEST(StanMath_integrate_1d, TestLogNormal) {
   double b = std::numeric_limits<double>::infinity();
   double a = 0;
   auto pdf = [](auto x, auto xc, auto theta, auto x_r, auto x_i,
-                std::ostream &msgs) {
+                std::ostream *msgs) {
     return exp(stan::math::lognormal_lpdf(x, theta[0], theta[1]));
   };
   var I = integrate_1d(pdf, a, b, theta, {}, {}, msgs, 1e-8);
@@ -625,7 +607,7 @@ TEST(StanMath_integrate_1d, TestNormal) {
   double b = std::numeric_limits<double>::infinity();
   double a = -b;
   auto pdf = [](auto x, auto xc, auto theta, auto x_r, auto x_i,
-                std::ostream &msgs) {
+                std::ostream *msgs) {
     return exp(stan::math::normal_lpdf(x, theta[0], theta[1]));
   };
   var I = integrate_1d(pdf, a, b, theta, {}, {}, msgs, 1e-8);
@@ -638,38 +620,6 @@ TEST(StanMath_integrate_1d, TestNormal) {
   EXPECT_FLOAT_EQ(1, 1 + g[1]);
 }
 
-/*
-TEST(StanMath_integrate_1d, TestNormalSufficient) {
-  using stan::math::var;
-  using stan::math::integrate_1d;
-  using stan::math::exp;
-
-  var mu = 9.0 / 5;
-  var sigma = 13.0 / 7;
-  AVEC theta = {mu, sigma};
-  double b = std::numeric_limits<double>::infinity();
-  double a = -b;
-  auto pdf = [&](auto x, auto xc, auto theta,
-                 auto x_r, auto x_i, std::ostream& msgs) {
-     return integrate_1d([&x](auto s, auto xc, auto theta,
-                            auto x_r, auto x_i,
-                            std::ostream& msgs) {
-       return exp(stan::math::normal_sufficient_lpdf(x, s, 10,
-                    theta[0], theta[1]));
-       }, 0, std::numeric_limits<double>::infinity(),
-          theta, {}, {}, std::cout, 1e-8);
-  };
-  var I = integrate_1d(pdf, a, b, theta, {}, {}, msgs, 1e-8);
-  EXPECT_FLOAT_EQ(1, I.val());
-
-  AVEC x = createAVEC(mu, sigma);
-  VEC g;
-  I.grad(x, g);
-  EXPECT_FLOAT_EQ(1, 1 + g[0]);
-  EXPECT_FLOAT_EQ(1, 1 + g[1]);
-}
-*/
-
 TEST(StanMath_integrate_1d, TestPareto) {
   using stan::math::exp;
   using stan::math::integrate_1d;
@@ -681,7 +631,7 @@ TEST(StanMath_integrate_1d, TestPareto) {
   double b = std::numeric_limits<double>::infinity();
   var a = m;
   auto pdf = [](auto x, auto xc, auto theta, auto x_r, auto x_i,
-                std::ostream &msgs) {
+                std::ostream *msgs) {
     return exp(stan::math::pareto_lpdf(x, theta[0], theta[1]));
   };
   var I = integrate_1d(pdf, a, b, theta, {}, {}, msgs, 1e-8);
@@ -706,7 +656,7 @@ TEST(StanMath_integrate_1d, TestPareto2) {
   double b = std::numeric_limits<double>::infinity();
   var a = mu;
   auto pdf = [](auto x, auto xc, auto theta, auto x_r, auto x_i,
-                std::ostream &msgs) {
+                std::ostream *msgs) {
     return exp(stan::math::pareto_type_2_lpdf(x, theta[0], theta[1], theta[2]));
   };
   var I = integrate_1d(pdf, a, b, theta, {}, {}, msgs, 1e-8);
@@ -730,7 +680,7 @@ TEST(StanMath_integrate_1d, TestRayleigh) {
   double b = std::numeric_limits<double>::infinity();
   double a = 0;
   auto pdf = [](auto x, auto xc, auto theta, auto x_r, auto x_i,
-                std::ostream &msgs) {
+                std::ostream *msgs) {
     return exp(stan::math::rayleigh_lpdf(x, theta[0]));
   };
   var I = integrate_1d(pdf, a, b, theta, {}, {}, msgs, 1e-8);
@@ -753,7 +703,7 @@ TEST(StanMath_integrate_1d, TestScaledInvChiSquare) {
   double b = std::numeric_limits<double>::infinity();
   double a = 0;
   auto pdf = [](auto x, auto xc, auto theta, auto x_r, auto x_i,
-                std::ostream &msgs) {
+                std::ostream *msgs) {
     return exp(stan::math::scaled_inv_chi_square_lpdf(x, theta[0], theta[1]));
   };
   var I = integrate_1d(pdf, a, b, theta, {}, {}, msgs, 1e-8);
@@ -765,35 +715,6 @@ TEST(StanMath_integrate_1d, TestScaledInvChiSquare) {
   EXPECT_FLOAT_EQ(1, 1 + g[0]);
   EXPECT_FLOAT_EQ(1, 1 + g[1]);
 }
-
-/*
-TEST(StanMath_integrate_1d, TestSkewNormal) {
-  using stan::math::var;
-  using stan::math::integrate_1d;
-  using stan::math::exp;
-
-  var mu = 9.0 / 5;
-  var sigma = 13.0 / 7;
-  var alpha = 11.0 / 3;
-  AVEC theta = {mu, sigma, alpha};
-  double b = std::numeric_limits<double>::infinity();
-  double a = -b;
-  auto pdf = [](auto x, auto xc, auto theta,
-                auto x_r, auto x_i, std::ostream& msgs) {
-     return exp(stan::math::skew_normal_lpdf(x, theta[0],
-                theta[1], theta[2]));
-  };
-  var I = integrate_1d(pdf, a, b, theta, {}, {}, msgs, 1e-8);
-  EXPECT_FLOAT_EQ(1, I.val());
-
-  AVEC x = createAVEC(mu, sigma, alpha);
-  VEC g;
-  I.grad(x, g);
-  EXPECT_FLOAT_EQ(1, 1 + g[0]);
-  EXPECT_FLOAT_EQ(1, 1 + g[1]);
-  EXPECT_FLOAT_EQ(1, 1 + g[2]);
-}
-*/
 
 TEST(StanMath_integrate_1d, TestStudentT) {
   using stan::math::exp;
@@ -807,7 +728,7 @@ TEST(StanMath_integrate_1d, TestStudentT) {
   double b = std::numeric_limits<double>::infinity();
   double a = -b;
   auto pdf = [](auto x, auto xc, auto theta, auto x_r, auto x_i,
-                std::ostream &msgs) {
+                std::ostream *msgs) {
     return exp(stan::math::student_t_lpdf(x, theta[0], theta[1], theta[2]));
   };
   var I = integrate_1d(pdf, a, b, theta, {}, {}, msgs, 1e-8);
@@ -830,7 +751,7 @@ TEST(StanMath_integrate_1d, TestUniform) {
   var b = 13.0 / 7;
   AVEC theta = {a, b};
   auto pdf = [](auto x, auto xc, auto theta, auto x_r, auto x_i,
-                std::ostream &msgs) {
+                std::ostream *msgs) {
     return exp(stan::math::uniform_lpdf(x, theta[0], theta[1]));
   };
   var I = integrate_1d(pdf, a, b, theta, {}, {}, msgs, 1e-8);
@@ -854,7 +775,7 @@ TEST(StanMath_integrate_1d, TestVonMises) {
   double b = stan::math::pi() * 2;
   double a = 0;
   auto pdf = [](auto x, auto xc, auto theta, auto x_r, auto x_i,
-                std::ostream &msgs) {
+                std::ostream *msgs) {
     return exp(stan::math::von_mises_lpdf(x, theta[0], theta[1]));
   };
   var I = integrate_1d(pdf, a, b, theta, {}, {}, msgs, 1e-8);
@@ -878,7 +799,7 @@ TEST(StanMath_integrate_1d, TestWeibull) {
   double b = std::numeric_limits<double>::infinity();
   double a = 0;
   auto pdf = [](auto x, auto xc, auto theta, auto x_r, auto x_i,
-                std::ostream &msgs) {
+                std::ostream *msgs) {
     return exp(stan::math::weibull_lpdf(x, theta[0], theta[1]));
   };
   var I = integrate_1d(pdf, a, b, theta, {}, {}, msgs, 1e-8);


### PR DESCRIPTION
#### Submission Checklist

- [] Run unit tests: `./runTests.py test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary:

Updated docs for 1d integrator (Issue 210)
Fixed issue whereby integer limits of integration would call rev mode integrate_1d even if prim integrate_1d was desired (Issue #935)
Integrate_1d functors now expect std::ostream pointers instead of references to work with stan (Issue #933)

#### Intended Effect:

This should make it easier to understand how relative tolerance works. It should also make it actually compile with real models. 

#### How to Verify:

./runTests test/unit/math/prim/arr/functor/integrate_1d_test.cpp
./runTests test/unit/math/rev/arr/functor/integrate_1d_test.cpp

#### Side Effects:

Bob's integrate_1d stan-dev/stan pull req. gets slowed down.

#### Documentation:

Doxygen!

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
