### PR TITLE
mpi_cluster constructor with communicator arguments

### DIFF
--- a/lib/gtest_1.7.0/src/gtest_main.cc
+++ b/lib/gtest_1.7.0/src/gtest_main.cc
@@ -39,6 +39,7 @@ GTEST_API_ int main(int argc, char **argv) {
   // for MPI testing we test with all workers in listen mode. No
   // output is generated from the workers.
   stan::math::mpi_cluster cluster;
+  stan::math::mpi_cluster cluster2(MPI_COMM_WORLD, boost::mpi::comm_attach);
   cluster.listen();
   if (cluster.rank_ != 0)
     return 0;

--- a/stan/math/prim/arr/functor/mpi_cluster.hpp
+++ b/stan/math/prim/arr/functor/mpi_cluster.hpp
@@ -139,9 +139,8 @@ struct mpi_cluster {
    * @param comm MPI communicator
    * @param kind the kind of communicator
    */
-  mpi_cluster(const MPI_Comm & comm, boost::mpi::comm_create_kind kind) :
-    world_(comm, kind)
-  {}
+  mpi_cluster(const MPI_Comm& comm, boost::mpi::comm_create_kind kind)
+      : world_(comm, kind) {}
 
   ~mpi_cluster() {
     // the destructor will ensure that the childs are being

--- a/stan/math/prim/arr/functor/mpi_cluster.hpp
+++ b/stan/math/prim/arr/functor/mpi_cluster.hpp
@@ -130,6 +130,15 @@ struct mpi_cluster {
 
   mpi_cluster() {}
 
+  /*
+   * @c mpi_cluster can also be constructed given a
+   * communicator and its kind, used to in the constructor
+   * of @c boost::mpi::communicator. This allows using @c mpi_cluster
+   * in more complex MPI communication patterns.
+   *
+   * @param comm MPI communicator
+   * @param kind the kind of communicator
+   */
   mpi_cluster(const MPI_Comm & comm, boost::mpi::comm_create_kind kind) :
     world_(comm, kind)
   {}

--- a/stan/math/prim/arr/functor/mpi_cluster.hpp
+++ b/stan/math/prim/arr/functor/mpi_cluster.hpp
@@ -130,6 +130,10 @@ struct mpi_cluster {
 
   mpi_cluster() {}
 
+  mpi_cluster(const MPI_Comm & comm, boost::mpi::comm_create_kind kind) :
+    world_(comm, kind)
+  {}
+
   ~mpi_cluster() {
     // the destructor will ensure that the childs are being
     // shutdown


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary:
Addresses #939 , to allow `mpi_cluster` to be constructed with user-specified `communicator`, by adding constructor
```c++
  mpi_cluster(const MPI_Comm & comm, boost::mpi::comm_create_kind kind) :
    world_(comm, kind)
  {}
```
where `comm` could be a communicator other than `MPI_COMM_WORLD`.


#### Intended Effect:
New constructor of `mpi_cluster`

#### How to Verify:
unit test

#### Side Effects:
n/a

#### Documentation:
doxygen

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Metrum Research Group, LLC
By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
