### PR TITLE
Feature/issue 947 stan num threds check

### DIFF
--- a/stan/math/prim/mat/functor/map_rect_concurrent.hpp
+++ b/stan/math/prim/mat/functor/map_rect_concurrent.hpp
@@ -5,6 +5,8 @@
 
 #include <stan/math/prim/mat/functor/map_rect_reduce.hpp>
 #include <stan/math/prim/mat/functor/map_rect_combine.hpp>
+#include <boost/lexical_cast.hpp>
+#include <boost/throw_exception.hpp>
 
 #include <vector>
 #include <thread>
@@ -20,30 +22,43 @@ namespace internal {
  * the environment variable STAN_NUM_THREADS and follows these
  * conventions:
  *
- * - STAN_NUM_THREADS is not defined or is not a number => num_threads=1
+ * - STAN_NUM_THREADS is not defined => num_threads=1
  * - STAN_NUM_THREADS is positive => num_threads is set to the
  *   specified number
  * - STAN_NUM_THREADS is set to -1 => num_threads is the number of
  *   available cores on the machine
- * - STAN_NUM_THREADS < -1 => num_threads is 1
+ * - STAN_NUM_THREADS < -1, STAN_NUM_THREADS = 0 or STAN_NUM_THREADS is 
+ *   not numeric => throws an exception
  *
  * Should num_threads exceed the number of jobs, then num_threads will
  * be set equal to the number of jobs.
  *
  * @param num_jobs number of jobs
  * @return number of threads to use
+ * @throws 
  */
 inline int get_num_threads(int num_jobs) {
   int num_threads = 1;
 #ifdef STAN_THREADS
   const char* env_stan_num_threads = std::getenv("STAN_NUM_THREADS");
   if (env_stan_num_threads != nullptr) {
-    const int env_num_threads = std::atoi(env_stan_num_threads);
-    if (env_num_threads > 0)
-      num_threads = env_num_threads;
-    else if (env_num_threads == -1)
-      num_threads = std::thread::hardware_concurrency();
-    // anything else will use 1 thread.
+    try {
+      const int env_num_threads = 
+          boost::lexical_cast<int>(env_stan_num_threads);
+      if (env_num_threads > 0)
+        num_threads = env_num_threads;
+      else if (env_num_threads == -1)
+        num_threads = std::thread::hardware_concurrency();
+      else 
+        boost::throw_exception(std::runtime_error(
+            "The STAN_NUM_THREADS environment variable must be positive or -1")
+            );
+      // anything else will use 1 thread.
+    } catch (boost::bad_lexical_cast) { 
+      boost::throw_exception(std::runtime_error(
+            "The STAN_NUM_THREADS environment variable is not numeric")
+            );
+    }
   }
   if (num_threads > num_jobs)
     num_threads = num_jobs;

--- a/stan/math/prim/mat/functor/map_rect_concurrent.hpp
+++ b/stan/math/prim/mat/functor/map_rect_concurrent.hpp
@@ -43,21 +43,19 @@ inline int get_num_threads(int num_jobs) {
   const char* env_stan_num_threads = std::getenv("STAN_NUM_THREADS");
   if (env_stan_num_threads != nullptr) {
     try {
-      const int env_num_threads = 
+      const int env_num_threads =
           boost::lexical_cast<int>(env_stan_num_threads);
       if (env_num_threads > 0)
         num_threads = env_num_threads;
       else if (env_num_threads == -1)
         num_threads = std::thread::hardware_concurrency();
-      else 
+      else
         boost::throw_exception(std::runtime_error(
-            "The STAN_NUM_THREADS environment variable must be positive or -1")
-            );
+          "The STAN_NUM_THREADS environment variable must be positive or -1"));
       // anything else will use 1 thread.
-    } catch (boost::bad_lexical_cast) { 
+    } catch (boost::bad_lexical_cast) {
       boost::throw_exception(std::runtime_error(
-            "The STAN_NUM_THREADS environment variable is not numeric")
-            );
+          "The STAN_NUM_THREADS environment variable is not numeric"));
     }
   }
   if (num_threads > num_jobs)

--- a/test/unit/math/prim/mat/functor/num_threads_test.cpp
+++ b/test/unit/math/prim/mat/functor/num_threads_test.cpp
@@ -7,35 +7,39 @@
 
 #include <stdlib.h>
 
-void set_n_threads_var(const std::string& value) {
-  std::string env_string = "STAN_NUM_THREADS=" + value;
-  putenv(env_string.c_str());
+// Can't easily use std::string as putenv require non-const char*
+void set_n_threads_var(const char* value) {
+  char env_string[256];
+  snprintf(env_string, sizeof(env_string), "STAN_NUM_THREADS=%s", value);
+  putenv(env_string);
 }
 
 TEST(num_threads, correct_values) {
   set_n_threads_var("10");
   EXPECT_EQ(stan::math::internal::get_num_threads(100), 10);
-  EXPECT_EQ(stan::math::internal::get_num_threads(5), 5);
+
+  set_n_threads_var("4");
+  EXPECT_EQ(stan::math::internal::get_num_threads(3), 3);
 
   set_n_threads_var("-1");
-  EXPECT_TRUE(stan::math::internal::get_num_threads(5) >= 1);
+  EXPECT_GE(stan::math::internal::get_num_threads(5), 1);
 }
 
 TEST(num_threads, incorrect_values) {
   set_n_threads_var("abc");
-  EXPECT_THROW_MSG(stan::math::internal::get_num_threads(5), 
+  EXPECT_THROW_MSG(stan::math::internal::get_num_threads(5),
       std::runtime_error, "is not numeric");
 
   set_n_threads_var("1c");
-  EXPECT_THROW_MSG(stan::math::internal::get_num_threads(5), 
+  EXPECT_THROW_MSG(stan::math::internal::get_num_threads(5),
       std::runtime_error, "is not numeric");
 
   set_n_threads_var("-2");
-  EXPECT_THROW_MSG(stan::math::internal::get_num_threads(5), 
+  EXPECT_THROW_MSG(stan::math::internal::get_num_threads(5),
       std::runtime_error, "must be positive or -1");
 
   set_n_threads_var("0");
-  EXPECT_THROW_MSG(stan::math::internal::get_num_threads(5), 
+  EXPECT_THROW_MSG(stan::math::internal::get_num_threads(5),
       std::runtime_error, "must be positive or -1");
-
 }
+

--- a/test/unit/math/prim/mat/functor/num_threads_test.cpp
+++ b/test/unit/math/prim/mat/functor/num_threads_test.cpp
@@ -1,0 +1,41 @@
+#define STAN_THREADS
+
+#include <stan/math/prim/mat/functor/map_rect_concurrent.hpp>
+#include <gtest/gtest.h>
+#include <test/unit/util.hpp>
+
+
+#include <stdlib.h>
+
+void set_n_threads_var(const std::string& value) {
+  std::string env_string = "STAN_NUM_THREADS=" + value;
+  putenv(env_string.c_str());
+}
+
+TEST(num_threads, correct_values) {
+  set_n_threads_var("10");
+  EXPECT_EQ(stan::math::internal::get_num_threads(100), 10);
+  EXPECT_EQ(stan::math::internal::get_num_threads(5), 5);
+
+  set_n_threads_var("-1");
+  EXPECT_TRUE(stan::math::internal::get_num_threads(5) >= 1);
+}
+
+TEST(num_threads, incorrect_values) {
+  set_n_threads_var("abc");
+  EXPECT_THROW_MSG(stan::math::internal::get_num_threads(5), 
+      std::runtime_error, "is not numeric");
+
+  set_n_threads_var("1c");
+  EXPECT_THROW_MSG(stan::math::internal::get_num_threads(5), 
+      std::runtime_error, "is not numeric");
+
+  set_n_threads_var("-2");
+  EXPECT_THROW_MSG(stan::math::internal::get_num_threads(5), 
+      std::runtime_error, "must be positive or -1");
+
+  set_n_threads_var("0");
+  EXPECT_THROW_MSG(stan::math::internal::get_num_threads(5), 
+      std::runtime_error, "must be positive or -1");
+
+}


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests: `./runTests.py test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary:
Resolves #947, setting the STAN_NUM_THREADS variable to non-numeric and other illegal values throws an exception.

#### Intended Effect:
Throw an exception When invalid values are encountered

#### How to Verify:
Unit test in `test/unit/math/prim/mat/functor/num_threads_test.cpp`

#### Side Effects:
Changes previously documented behavior.

#### Documentation:
Updated https://github.com/stan-dev/math/wiki/Threading-Support ([diff](https://github.com/stan-dev/math/wiki/Threading-Support/_compare/d59c1747a2377b2c6133010a33fab278de2972a9...703a3396e860870c3d275630a8d428e83da8f7a1) )

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Martin Modrák

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
