### PR TITLE
Updated Github templates with stuff from the Stan Math meeting today

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,8 +1,7 @@
 ## Description
-Describe the issue as clearly as possible. Issues are meant for bug reports and feature requests. The issue should contain enough information for a developer to create a pull request.
+Describe the issue as clearly as possible. Issues are meant for bug reports and feature requests. The issue should contain enough information for a developer to put together a solution.
 
 If this is a general question, please post to the [forums](http://discourse.mc-stan.org).
-
 
 ## Example
 For **bug reports**:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,24 @@
-Thanks for submitting a pull request! Please remove this text when submitting. We expect everything in the checklist to be completed before the pull request is merged. If anything significant is missing, the pull request may be closed until it's ready.
+Thanks for submitting a pull request! Please remove this text when submitting.
 
-Please help guide the reviewer through your code (see [Code Review Guidelines](https://github.com/stan-dev/math/wiki/Developer-Doc#code-review-guidelines)).
+Start by filling in the Summary, Tests, and Side Effects sections of this pull request and then work through the handy checklist at the bottom. If anything significant is missing, the pull request may be closed until it's ready. The full guidebook on how pull requests are reviewed is here: [Code Review Guidelines](https://github.com/stan-dev/math/wiki/Developer-Doc#code-review-guidelines).
+
+## Summary
+
+Describe the contents of the pull request. The issue describes the problem that needs to be fixed, whereas the text here should help the reviewer figure out to what extent this pull request solves the issue.
+
+Describe implementation details and any relevant information that would help the code reviewer understand this pull request. If there is anything special you need to draw someone's attention to, do it here. Link to any related pull requests or Discourse threads.
+
+## Tests
+
+Describe the new tests with the pull request.
+
+For bug fixes there should be a new test that would fail if the patch weren't in place (so that the bug could be caught if it comes up again).
+
+For new features there should be at least one test showing the expected behavior and one test that demonstrates error handling. Be aware the reviewer will very likely ask for more tests than this, but it's a start.
+
+## Side Effects
+
+Are there any side effects that we should be aware of?
 
 ## Checklist
 
@@ -22,21 +40,3 @@ Please help guide the reviewer through your code (see [Code Review Guidelines](h
 - [ ] the code is written in idiomatic C++ and changes are documented in the doxygen
 
 - [ ] the new changes are tested
-
-## Summary
-
-Describe the contents of the pull request. The issue describes the problem that needs to be fixed, whereas the text here should help the reviewer figure out to what extent this pull request solves the issue.
-
-Describe implementation details and any relevant information that would help the code reviewer understand this pull request. If there is anything special you need to draw someone's attention to, do it here. Link to any related pull requests or Discourse threads.
-
-## Tests
-
-Describe the new tests with the pull request.
-
-For bug fixes, there should be a new test that would fail if the patch weren't in place (so that the bug could be caught if it comes up again).
-
-For new features, there should be at least one test showing the expected behavior and one test that demonstrates error handling. The reviewer will very likely ask for more tests.
-
-## Side Effects
-
-Are there any side effects that we should be aware of?

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,6 @@
-Thanks for submitting a pull request! Please remove this text when submitting. We expect everything in the checklist to be completed before the pull request is merged. If any is missing, the pull request may be closed until it's ready. Please help guide the reviewer through your code (see [Code Review Guidelines](https://github.com/stan-dev/math/wiki/Developer-Doc#code-review-guidelines)).
+Thanks for submitting a pull request! Please remove this text when submitting. We expect everything in the checklist to be completed before the pull request is merged. If anything significant is missing, the pull request may be closed until it's ready.
+
+Please help guide the reviewer through your code (see [Code Review Guidelines](https://github.com/stan-dev/math/wiki/Developer-Doc#code-review-guidelines)).
 
 ## Checklist
 
@@ -10,47 +12,31 @@ Thanks for submitting a pull request! Please remove this text when submitting. W
       - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
       - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
 
-- [ ] the code base is stable
+- [ ] the basic tests are passing
 
-    - all unit tests pass
-    - continuous integration passes
+    - unit tests pass (to run, use: `./runTests.py test/unit`)
+    - header checks pass, (`make test-headers`)
+    - docs build, (`make doxygen`)
+    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)
 
-- [ ] the changes are maintainable
+- [ ] the code is written in idiomatic C++ and changes are documented in the doxygen
 
-    - the code design is idiomatic C++ or there's a good reason it's not
-    - please include appropriate documentation
-
-- [ ] the changes are tested
-
-    - there's at least one new test
-    - for bugs: at least one test that fails before the patch
-    - for features: at least one test that shows expected behavior
-    - for features: at least one test that shows error handling
-
-- [ ] the changes adhere to the Math library's [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality)
-
-    - CppLint passes: `make cpplint`
-
-
-Additional:
-- Link to discourse thread: ()
-
+- [ ] the new changes are tested
 
 ## Summary
-Describe the contents of the pull request. The issue describes what should happen. This pull request should show how that happens.
 
-Describe implementation details and any relevant information that would help the code reviewer understand this pull request.
+Describe the contents of the pull request. The issue describes the problem that needs to be fixed, whereas the text here should help the reviewer figure out to what extent this pull request solves the issue.
 
-
+Describe implementation details and any relevant information that would help the code reviewer understand this pull request. If there is anything special you need to draw someone's attention to, do it here. Link to any related pull requests or Discourse threads.
 
 ## Tests
-Describe (in words) the new tests with the pull request. Explain what you're testing. There should be at least one test that shows how the new code works. There should also be a test to show what happens when there's a failure.
 
+Describe the new tests with the pull request.
 
+For bug fixes, there should be a new test that would fail if the patch weren't in place (so that the bug could be caught if it comes up again).
+
+For new features, there should be at least one test showing the expected behavior and one test that demonstrates error handling. The reviewer will very likely ask for more tests.
 
 ## Side Effects
+
 Are there any side effects that we should be aware of?
-
-
-## Additional Notes
-Leave additional notes for the code reviewer here.


### PR DESCRIPTION
It's somehow appropriate that this pull request governing what is a good pull request doesn't satisfy its own requirements. No Math issue, no tests, and I didn't check the tests in place pass either hahaha.

@roualdes if I messed up what you suggested for the Summary section, go ahead and add it. There's a way you can edit these files inline with Github which might be easier than a full clone pull/push.

I shortened and rearranged things quite aggressively. Hopefully it's okay. Can we move the checklist to the bottom though? And just say you need to fill it out? I think the pulls would look nicer if they started with a description of what was being fixed, rather than a checklist that's basically meant as a way to remind people to run all the tests and write docs. I felt like that was too big a change to make without asking though.
