### PR TITLE
Made value_of handle const references correctly (Issue #968)

### DIFF
--- a/stan/math/prim/arr/fun/value_of.hpp
+++ b/stan/math/prim/arr/fun/value_of.hpp
@@ -38,7 +38,6 @@ inline std::vector<typename child_type<T>::type> value_of(
  * @param x Specified std::vector.
  * @return Specified std::vector.
  */
-template <>
 inline const std::vector<double>& value_of(const std::vector<double>& x) {
   return x;
 }

--- a/stan/math/prim/arr/fun/value_of.hpp
+++ b/stan/math/prim/arr/fun/value_of.hpp
@@ -39,7 +39,7 @@ inline std::vector<typename child_type<T>::type> value_of(
  * @return Specified std::vector.
  */
 template <>
-inline std::vector<double> value_of(const std::vector<double>& x) {
+inline const std::vector<double>& value_of(const std::vector<double>& x) {
   return x;
 }
 

--- a/stan/math/prim/mat/fun/value_of.hpp
+++ b/stan/math/prim/mat/fun/value_of.hpp
@@ -42,7 +42,7 @@ inline Eigen::Matrix<typename child_type<T>::type, R, C> value_of(
  * @return Specified matrix.
  */
 template <int R, int C>
-inline typename Eigen::Matrix<double, R, C> value_of(
+inline const Eigen::Matrix<double, R, C>& value_of(
     const Eigen::Matrix<double, R, C>& x) {
   return x;
 }

--- a/test/unit/math/prim/arr/fun/value_of_test.cpp
+++ b/test/unit/math/prim/arr/fun/value_of_test.cpp
@@ -27,16 +27,12 @@ TEST(MathMatrix, value_of) {
 
 TEST(MathFunctions, value_of_return_type_short_circuit) {
   std::vector<double> a(5, 0);
-  bool r1 = std::is_same<decltype(stan::math::value_of(a)),
-                         std::vector<double>>::value;
-  EXPECT_FALSE(r1);
-  bool r2 = std::is_same<decltype(stan::math::value_of(a)),
-                         std::vector<double>&>::value;
-  EXPECT_FALSE(r2);
-  bool r3 = std::is_same<decltype(stan::math::value_of(a)),
-                         const std::vector<double>>::value;
-  EXPECT_FALSE(r3);
-  bool r4 = std::is_same<decltype(stan::math::value_of(a)),
-                         const std::vector<double>&>::value;
-  EXPECT_TRUE(r4);
+  EXPECT_FALSE((std::is_same<decltype(stan::math::value_of(a)),
+                             std::vector<double>>::value));
+  EXPECT_FALSE((std::is_same<decltype(stan::math::value_of(a)),
+                             std::vector<double>&>::value));
+  EXPECT_FALSE((std::is_same<decltype(stan::math::value_of(a)),
+                             const std::vector<double>>::value));
+  EXPECT_TRUE((std::is_same<decltype(stan::math::value_of(a)),
+                            const std::vector<double>&>::value));
 }

--- a/test/unit/math/prim/arr/fun/value_of_test.cpp
+++ b/test/unit/math/prim/arr/fun/value_of_test.cpp
@@ -1,6 +1,7 @@
 #include <stan/math/prim/arr.hpp>
 #include <gtest/gtest.h>
 #include <vector>
+#include <type_traits>
 
 TEST(MathMatrix, value_of) {
   using stan::math::value_of;
@@ -22,4 +23,20 @@ TEST(MathMatrix, value_of) {
 
   for (int i = 0; i < 10; ++i)
     EXPECT_FLOAT_EQ(a[i], d_a[i]);
+}
+
+TEST(MathFunctions, value_of_return_type_short_circuit) {
+  std::vector<double> a(5, 0);
+  bool r1 = std::is_same<decltype(stan::math::value_of(a)),
+                         std::vector<double>>::value;
+  EXPECT_FALSE(r1);
+  bool r2 = std::is_same<decltype(stan::math::value_of(a)),
+                         std::vector<double>&>::value;
+  EXPECT_FALSE(r2);
+  bool r3 = std::is_same<decltype(stan::math::value_of(a)),
+                         const std::vector<double>>::value;
+  EXPECT_FALSE(r3);
+  bool r4 = std::is_same<decltype(stan::math::value_of(a)),
+                         const std::vector<double>&>::value;
+  EXPECT_TRUE(r4);
 }

--- a/test/unit/math/prim/mat/fun/value_of_test.cpp
+++ b/test/unit/math/prim/mat/fun/value_of_test.cpp
@@ -27,70 +27,60 @@ TEST(MathMatrix, value_of) {
 
 TEST(MathFunctions, value_of_return_type_short_circuit_vector_xd) {
   Eigen::Matrix<double, Eigen::Dynamic, 1> a(5);
-  bool r1 = std::is_same<decltype(stan::math::value_of(a)),
-                         Eigen::Matrix<double, Eigen::Dynamic, 1>>::value;
-  EXPECT_FALSE(r1);
-  bool r2 = std::is_same<decltype(stan::math::value_of(a)),
-                         Eigen::Matrix<double, Eigen::Dynamic, 1>&>::value;
-  EXPECT_FALSE(r2);
-  bool r3 = std::is_same<decltype(stan::math::value_of(a)),
-                         const Eigen::Matrix<double, Eigen::Dynamic, 1>>::value;
-  EXPECT_FALSE(r3);
-  bool r4
-      = std::is_same<decltype(stan::math::value_of(a)),
-                     const Eigen::Matrix<double, Eigen::Dynamic, 1>&>::value;
-  EXPECT_TRUE(r4);
+  EXPECT_FALSE((std::is_same<decltype(stan::math::value_of(a)),
+                             Eigen::Matrix<double, Eigen::Dynamic, 1>>::value));
+  EXPECT_FALSE(
+      (std::is_same<decltype(stan::math::value_of(a)),
+                    Eigen::Matrix<double, Eigen::Dynamic, 1>&>::value));
+  EXPECT_FALSE(
+      (std::is_same<decltype(stan::math::value_of(a)),
+                    const Eigen::Matrix<double, Eigen::Dynamic, 1>>::value));
+  EXPECT_TRUE(
+      (std::is_same<decltype(stan::math::value_of(a)),
+                    const Eigen::Matrix<double, Eigen::Dynamic, 1>&>::value));
 }
 
 TEST(MathFunctions, value_of_return_type_short_circuit_row_vector_xd) {
   Eigen::Matrix<double, 1, Eigen::Dynamic> a(5);
-  bool r1 = std::is_same<decltype(stan::math::value_of(a)),
-                         Eigen::Matrix<double, 1, Eigen::Dynamic>>::value;
-  EXPECT_FALSE(r1);
-  bool r2 = std::is_same<decltype(stan::math::value_of(a)),
-                         Eigen::Matrix<double, 1, Eigen::Dynamic>&>::value;
-  EXPECT_FALSE(r2);
-  bool r3 = std::is_same<decltype(stan::math::value_of(a)),
-                         const Eigen::Matrix<double, 1, Eigen::Dynamic>>::value;
-  EXPECT_FALSE(r3);
-  bool r4
-      = std::is_same<decltype(stan::math::value_of(a)),
-                     const Eigen::Matrix<double, 1, Eigen::Dynamic>&>::value;
-  EXPECT_TRUE(r4);
+  EXPECT_FALSE((std::is_same<decltype(stan::math::value_of(a)),
+                             Eigen::Matrix<double, 1, Eigen::Dynamic>>::value));
+  EXPECT_FALSE(
+      (std::is_same<decltype(stan::math::value_of(a)),
+                    Eigen::Matrix<double, 1, Eigen::Dynamic>&>::value));
+  EXPECT_FALSE(
+      (std::is_same<decltype(stan::math::value_of(a)),
+                    const Eigen::Matrix<double, 1, Eigen::Dynamic>>::value));
+  EXPECT_TRUE(
+      (std::is_same<decltype(stan::math::value_of(a)),
+                    const Eigen::Matrix<double, 1, Eigen::Dynamic>&>::value));
 }
 
 TEST(MathFunctions, value_of_return_type_short_circuit_matrix_xd) {
   Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> a(5, 4);
-  bool r1 = std::is_same<
-      decltype(stan::math::value_of(a)),
-      Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>>::value;
-  EXPECT_FALSE(r1);
-  bool r2 = std::is_same<
-      decltype(stan::math::value_of(a)),
-      Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>&>::value;
-  EXPECT_FALSE(r2);
-  bool r3 = std::is_same<
-      decltype(stan::math::value_of(a)),
-      const Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>>::value;
-  EXPECT_FALSE(r3);
-  bool r4 = std::is_same<
-      decltype(stan::math::value_of(a)),
-      const Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>&>::value;
-  EXPECT_TRUE(r4);
+  EXPECT_FALSE((std::is_same<
+                decltype(stan::math::value_of(a)),
+                Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>>::value));
+  EXPECT_FALSE(
+      (std::is_same<
+          decltype(stan::math::value_of(a)),
+          Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>&>::value));
+  EXPECT_FALSE(
+      (std::is_same<
+          decltype(stan::math::value_of(a)),
+          const Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>>::value));
+  EXPECT_TRUE((std::is_same<decltype(stan::math::value_of(a)),
+                            const Eigen::Matrix<double, Eigen::Dynamic,
+                                                Eigen::Dynamic>&>::value));
 }
 
 TEST(MathFunctions, value_of_return_type_short_circuit_static_sized_matrix) {
   Eigen::Matrix<double, 5, 4> a;
-  bool r1 = std::is_same<decltype(stan::math::value_of(a)),
-                         Eigen::Matrix<double, 5, 4>>::value;
-  EXPECT_FALSE(r1);
-  bool r2 = std::is_same<decltype(stan::math::value_of(a)),
-                         Eigen::Matrix<double, 5, 4>&>::value;
-  EXPECT_FALSE(r2);
-  bool r3 = std::is_same<decltype(stan::math::value_of(a)),
-                         const Eigen::Matrix<double, 5, 4>>::value;
-  EXPECT_FALSE(r3);
-  bool r4 = std::is_same<decltype(stan::math::value_of(a)),
-                         const Eigen::Matrix<double, 5, 4>&>::value;
-  EXPECT_TRUE(r4);
+  EXPECT_FALSE((std::is_same<decltype(stan::math::value_of(a)),
+                             Eigen::Matrix<double, 5, 4>>::value));
+  EXPECT_FALSE((std::is_same<decltype(stan::math::value_of(a)),
+                             Eigen::Matrix<double, 5, 4>&>::value));
+  EXPECT_FALSE((std::is_same<decltype(stan::math::value_of(a)),
+                             const Eigen::Matrix<double, 5, 4>>::value));
+  EXPECT_TRUE((std::is_same<decltype(stan::math::value_of(a)),
+                            const Eigen::Matrix<double, 5, 4>&>::value));
 }

--- a/test/unit/math/prim/mat/fun/value_of_test.cpp
+++ b/test/unit/math/prim/mat/fun/value_of_test.cpp
@@ -1,5 +1,6 @@
 #include <stan/math/prim/mat.hpp>
 #include <gtest/gtest.h>
+#include <type_traits>
 
 TEST(MathMatrix, value_of) {
   using stan::math::value_of;
@@ -22,4 +23,74 @@ TEST(MathMatrix, value_of) {
   for (int i = 0; i < 2; ++i)
     for (int j = 0; j < 5; ++j)
       EXPECT_FLOAT_EQ(a(i, j), d_a(i, j));
+}
+
+TEST(MathFunctions, value_of_return_type_short_circuit_vector_xd) {
+  Eigen::Matrix<double, Eigen::Dynamic, 1> a(5);
+  bool r1 = std::is_same<decltype(stan::math::value_of(a)),
+                         Eigen::Matrix<double, Eigen::Dynamic, 1>>::value;
+  EXPECT_FALSE(r1);
+  bool r2 = std::is_same<decltype(stan::math::value_of(a)),
+                         Eigen::Matrix<double, Eigen::Dynamic, 1>&>::value;
+  EXPECT_FALSE(r2);
+  bool r3 = std::is_same<decltype(stan::math::value_of(a)),
+                         const Eigen::Matrix<double, Eigen::Dynamic, 1>>::value;
+  EXPECT_FALSE(r3);
+  bool r4
+      = std::is_same<decltype(stan::math::value_of(a)),
+                     const Eigen::Matrix<double, Eigen::Dynamic, 1>&>::value;
+  EXPECT_TRUE(r4);
+}
+
+TEST(MathFunctions, value_of_return_type_short_circuit_row_vector_xd) {
+  Eigen::Matrix<double, 1, Eigen::Dynamic> a(5);
+  bool r1 = std::is_same<decltype(stan::math::value_of(a)),
+                         Eigen::Matrix<double, 1, Eigen::Dynamic>>::value;
+  EXPECT_FALSE(r1);
+  bool r2 = std::is_same<decltype(stan::math::value_of(a)),
+                         Eigen::Matrix<double, 1, Eigen::Dynamic>&>::value;
+  EXPECT_FALSE(r2);
+  bool r3 = std::is_same<decltype(stan::math::value_of(a)),
+                         const Eigen::Matrix<double, 1, Eigen::Dynamic>>::value;
+  EXPECT_FALSE(r3);
+  bool r4
+      = std::is_same<decltype(stan::math::value_of(a)),
+                     const Eigen::Matrix<double, 1, Eigen::Dynamic>&>::value;
+  EXPECT_TRUE(r4);
+}
+
+TEST(MathFunctions, value_of_return_type_short_circuit_matrix_xd) {
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> a(5, 4);
+  bool r1 = std::is_same<
+      decltype(stan::math::value_of(a)),
+      Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>>::value;
+  EXPECT_FALSE(r1);
+  bool r2 = std::is_same<
+      decltype(stan::math::value_of(a)),
+      Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>&>::value;
+  EXPECT_FALSE(r2);
+  bool r3 = std::is_same<
+      decltype(stan::math::value_of(a)),
+      const Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>>::value;
+  EXPECT_FALSE(r3);
+  bool r4 = std::is_same<
+      decltype(stan::math::value_of(a)),
+      const Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>&>::value;
+  EXPECT_TRUE(r4);
+}
+
+TEST(MathFunctions, value_of_return_type_short_circuit_static_sized_matrix) {
+  Eigen::Matrix<double, 5, 4> a;
+  bool r1 = std::is_same<decltype(stan::math::value_of(a)),
+                         Eigen::Matrix<double, 5, 4>>::value;
+  EXPECT_FALSE(r1);
+  bool r2 = std::is_same<decltype(stan::math::value_of(a)),
+                         Eigen::Matrix<double, 5, 4>&>::value;
+  EXPECT_FALSE(r2);
+  bool r3 = std::is_same<decltype(stan::math::value_of(a)),
+                         const Eigen::Matrix<double, 5, 4>>::value;
+  EXPECT_FALSE(r3);
+  bool r4 = std::is_same<decltype(stan::math::value_of(a)),
+                         const Eigen::Matrix<double, 5, 4>&>::value;
+  EXPECT_TRUE(r4);
 }


### PR DESCRIPTION
## Summary

Fixes the bug here: https://github.com/stan-dev/math/issues/968

And discussed here: http://discourse.mc-stan.org/t/value-of/5091

## Tests

If the current CI passes, then I propose the new implementation is Good Enough (TM)

## Side Effects

Should make things faster. Hopefully nothing blows up.

## Checklist

- [x] Math issue #968 

- [x] Copyright holder: Columbia University

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [I'd like to think so] the new changes are tested
