### PR TITLE
feature/issue-914 Beta Distribution mean/precision parameterization

### DIFF
--- a/stan/math/prim/scal.hpp
+++ b/stan/math/prim/scal.hpp
@@ -196,6 +196,10 @@
 #include <stan/math/prim/scal/prob/beta_binomial_log.hpp>
 #include <stan/math/prim/scal/prob/beta_binomial_lpmf.hpp>
 #include <stan/math/prim/scal/prob/beta_binomial_rng.hpp>
+#include <stan/math/prim/scal/prob/beta_proportion_lcdf.hpp>
+#include <stan/math/prim/scal/prob/beta_proportion_lccdf.hpp>
+#include <stan/math/prim/scal/prob/beta_proportion_lpdf.hpp>
+#include <stan/math/prim/scal/prob/beta_proportion_rng.hpp>
 #include <stan/math/prim/scal/prob/beta_ccdf_log.hpp>
 #include <stan/math/prim/scal/prob/beta_cdf.hpp>
 #include <stan/math/prim/scal/prob/beta_cdf_log.hpp>

--- a/stan/math/prim/scal/prob/beta_proportion_lccdf.hpp
+++ b/stan/math/prim/scal/prob/beta_proportion_lccdf.hpp
@@ -1,0 +1,142 @@
+#ifndef STAN_MATH_PRIM_SCAL_PROB_BETA_PROPORTION_LCCDF_HPP
+#define STAN_MATH_PRIM_SCAL_PROB_BETA_PROPORTION_LCCDF_HPP
+
+#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
+#include <stan/math/prim/scal/meta/partials_return_type.hpp>
+#include <stan/math/prim/scal/meta/operands_and_partials.hpp>
+#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
+#include <stan/math/prim/scal/err/check_less_or_equal.hpp>
+#include <stan/math/prim/scal/err/check_nonnegative.hpp>
+#include <stan/math/prim/scal/err/check_not_nan.hpp>
+#include <stan/math/prim/scal/err/check_positive_finite.hpp>
+#include <stan/math/prim/scal/fun/size_zero.hpp>
+#include <stan/math/prim/scal/fun/value_of.hpp>
+#include <stan/math/prim/scal/fun/digamma.hpp>
+#include <stan/math/prim/scal/fun/lbeta.hpp>
+#include <stan/math/prim/scal/meta/contains_nonconstant_struct.hpp>
+#include <stan/math/prim/scal/meta/scalar_seq_view.hpp>
+#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
+#include <stan/math/prim/scal/fun/constants.hpp>
+#include <stan/math/prim/scal/meta/include_summand.hpp>
+#include <stan/math/prim/scal/fun/grad_reg_inc_beta.hpp>
+#include <stan/math/prim/scal/fun/inc_beta.hpp>
+#include <cmath>
+
+namespace stan {
+namespace math {
+
+/**
+ * Returns the beta log complementary cumulative distribution function
+ * for the given probability and parameterized with location and
+ * precision parameters. Given matching containers returns the log sum
+ * of probabilities.
+ *
+ * @tparam T_y type of probability parameter
+ * @tparam T_loc type of location parameter
+ * @tparam T_prec type of precision parameter
+ * @param y probability parameter
+ * @param p location parameter
+ * @param c precision parameter
+ * @return log probability or log sum of probabilities
+ * @throw std::domain_error if p is outside (0, 1)
+ * @throw std::domain_error if c is nonpositive
+ * @throw std::domain_error if y is not a valid probability
+ * @throw std::invalid_argument if container sizes mismatch
+ */
+template <typename T_y, typename T_loc, typename T_prec>
+typename return_type<T_y, T_loc, T_prec>::type beta_proportion_lccdf(
+    const T_y& y, const T_loc& p, const T_prec& c) {
+
+  typedef
+    typename stan::partials_return_type<T_y, T_loc, T_prec>::type
+    T_partials_return;
+
+  static const char* function = "beta_proportion_lccdf";
+
+  if (size_zero(y, p, c))
+    return 0.0;
+
+  using boost::math::tools::promote_args;
+
+  T_partials_return ccdf_log(0.0);
+
+  check_positive(function, "Location parameter", p);
+  check_less_or_equal(function, "Location parameter", p, 1.0);
+  check_positive_finite(function, "Precision parameter", c);
+  check_not_nan(function, "Random variable", y);
+  check_nonnegative(function, "Random variable", y);
+  check_less_or_equal(function, "Random variable", y, 1.0);
+  check_consistent_sizes(function, "Random variable", y,
+                         "Location parameter", p,
+                         "Precision parameter", c);
+
+  scalar_seq_view<T_y> y_vec(y);
+  scalar_seq_view<T_loc> p_vec(p);
+  scalar_seq_view<T_prec> c_vec(c);
+  size_t N = max_size(y, p, c);
+
+  operands_and_partials<T_y, T_loc, T_prec> ops_partials(y, p, c);
+
+  using std::exp;
+  using std::exp;
+  using std::log;
+  using std::pow;
+
+  VectorBuilder<contains_nonconstant_struct<T_loc, T_prec>::value,
+                T_partials_return, T_loc, T_prec>
+      digamma_pc(max_size(p, c));
+  VectorBuilder<contains_nonconstant_struct<T_loc, T_prec>::value,
+                T_partials_return, T_loc, T_prec>
+      digamma_c_1m_p(max_size(p, c));
+  VectorBuilder<contains_nonconstant_struct<T_loc, T_prec>::value,
+                T_partials_return, T_loc, T_prec>
+    digamma_c(max_size(p, c));
+
+  if (contains_nonconstant_struct<T_loc, T_prec>::value) {
+    for (size_t i = 0; i < N; i++) {
+      const T_partials_return pc_dbl = value_of(p_vec[i]) * value_of(c_vec[i]);
+      const T_partials_return c_1m_p_dbl
+        = value_of(c_vec[i]) * (1.0 - value_of(p_vec[i]));
+
+      digamma_pc[i] = digamma(pc_dbl);
+      digamma_c_1m_p[i] = digamma(c_1m_p_dbl);
+      digamma_c[i] = digamma(value_of(c_vec[i]));
+    }
+  }
+
+  for (size_t n = 0; n < N; n++) {
+    const T_partials_return y_dbl = value_of(y_vec[n]);
+    const T_partials_return p_dbl = value_of(p_vec[n]);
+    const T_partials_return c_dbl = value_of(c_vec[n]);
+    const T_partials_return pc_dbl = p_dbl * c_dbl;
+    const T_partials_return c_1m_p_dbl = c_dbl * (1.0 - p_dbl);
+    const T_partials_return betafunc_dbl = exp(lbeta(pc_dbl, c_1m_p_dbl));
+    const T_partials_return Pn = 1.0 - inc_beta(pc_dbl, c_1m_p_dbl, y_dbl);
+
+    ccdf_log += log(Pn);
+
+    if (!is_constant_struct<T_y>::value)
+      ops_partials.edge1_.partials_[n] -= pow(1 - y_dbl, c_1m_p_dbl - 1)
+                                          * pow(y_dbl, pc_dbl - 1)
+                                          / betafunc_dbl / Pn;
+
+    T_partials_return g1 = 0;
+    T_partials_return g2 = 0;
+
+    if (contains_nonconstant_struct<T_loc, T_prec>::value) {
+      grad_reg_inc_beta(g1, g2, pc_dbl, c_1m_p_dbl, y_dbl,
+                        digamma_pc[n], digamma_c_1m_p[n],
+                        digamma_c[n], betafunc_dbl);
+    }
+    if (!is_constant_struct<T_loc>::value)
+      ops_partials.edge2_.partials_[n] -= c_dbl * (g1 - g2) / Pn;
+    if (!is_constant_struct<T_prec>::value)
+      ops_partials.edge3_.partials_[n]
+        -= (g1 * p_dbl + g2 * (1.0 - p_dbl)) / Pn;
+  }
+  return ops_partials.build(ccdf_log);
+}
+
+}  // namespace math
+}  // namespace stan
+#endif

--- a/stan/math/prim/scal/prob/beta_proportion_lcdf.hpp
+++ b/stan/math/prim/scal/prob/beta_proportion_lcdf.hpp
@@ -1,0 +1,141 @@
+#ifndef STAN_MATH_PRIM_SCAL_PROB_BETA_PROPORTION_LCDF_HPP
+#define STAN_MATH_PRIM_SCAL_PROB_BETA_PROPORTION_LCDF_HPP
+
+#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
+#include <stan/math/prim/scal/meta/partials_return_type.hpp>
+#include <stan/math/prim/scal/meta/operands_and_partials.hpp>
+#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
+#include <stan/math/prim/scal/err/check_less_or_equal.hpp>
+#include <stan/math/prim/scal/err/check_nonnegative.hpp>
+#include <stan/math/prim/scal/err/check_not_nan.hpp>
+#include <stan/math/prim/scal/err/check_positive_finite.hpp>
+#include <stan/math/prim/scal/fun/size_zero.hpp>
+#include <stan/math/prim/scal/fun/value_of.hpp>
+#include <stan/math/prim/scal/fun/digamma.hpp>
+#include <stan/math/prim/scal/fun/lbeta.hpp>
+#include <stan/math/prim/scal/meta/contains_nonconstant_struct.hpp>
+#include <stan/math/prim/scal/fun/constants.hpp>
+#include <stan/math/prim/scal/meta/include_summand.hpp>
+#include <stan/math/prim/scal/meta/scalar_seq_view.hpp>
+#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
+#include <stan/math/prim/scal/fun/grad_reg_inc_beta.hpp>
+#include <stan/math/prim/scal/fun/inc_beta.hpp>
+#include <cmath>
+
+namespace stan {
+namespace math {
+
+/**
+ * Returns the beta log cumulative distribution function parameterized
+ * for the location and precition. Given matching containers returns
+ * the log sum of probabilities.
+ *
+ * @tparam T_y type of probability parameter
+ * @tparam T_loc type of location parameter
+ * @tparam T_prec_fail type of precision parameter
+ * @param y probability parameter
+ * @param p location parameter
+ * @param c precision parameter
+ * @return log probability or log sum of probabilities
+ * @throw std::domain_error if p is outside of (0, 1)
+ * @throw std::domain_error if c is nonpositive
+ * @throw std::domain_error if y is not a valid probability
+ * @throw std::invalid_argument if container sizes mismatch
+ */
+template <typename T_y, typename T_loc, typename T_prec>
+typename return_type<T_y, T_loc, T_prec>::type beta_proportion_lcdf(
+    const T_y& y, const T_loc& p, const T_prec& c) {
+  typedef
+      typename stan::partials_return_type<T_y, T_loc, T_prec>::type
+          T_partials_return;
+
+  if (size_zero(y, p, c))
+    return 0.0;
+
+  static const char* function = "beta_proportion_lcdf";
+
+  using boost::math::tools::promote_args;
+
+  T_partials_return cdf_log(0.0);
+
+  check_positive(function, "Location parameter", p);
+  check_less_or_equal(function, "Location parameter", p, 1.0);
+  check_positive_finite(function, "Precision parameter", c);
+  check_not_nan(function, "Random variable", y);
+  check_nonnegative(function, "Random variable", y);
+  check_less_or_equal(function, "Random variable", y, 1.0);
+  check_consistent_sizes(function, "Random variable", y,
+                         "Location parameter", p,
+                         "Precision parameter", c);
+
+  scalar_seq_view<T_y> y_vec(y);
+  scalar_seq_view<T_loc> p_vec(p);
+  scalar_seq_view<T_prec> c_vec(c);
+  size_t N = max_size(y, p, c);
+
+  operands_and_partials<T_y, T_loc, T_prec> ops_partials(y, p, c);
+
+  using std::exp;
+  using std::exp;
+  using std::log;
+  using std::pow;
+
+  VectorBuilder<contains_nonconstant_struct<T_loc, T_prec>::value,
+                T_partials_return, T_loc, T_prec>
+    digamma_pc(max_size(p, c));
+  VectorBuilder<contains_nonconstant_struct<T_loc, T_prec>::value,
+                T_partials_return, T_loc, T_prec>
+    digamma_c_1m_p(max_size(p, c));
+  VectorBuilder<contains_nonconstant_struct<T_loc, T_prec>::value,
+                T_partials_return, T_loc, T_prec>
+    digamma_c(max_size(p, c));
+
+  if (contains_nonconstant_struct<T_loc, T_prec>::value) {
+    for (size_t i = 0; i < N; i++) {
+      const T_partials_return pc_dbl = value_of(p_vec[i]) * value_of(c_vec[i]);
+      const T_partials_return c_1m_p_dbl
+        = value_of(c_vec[i]) * (1.0 - value_of(p_vec[i]));
+
+      digamma_pc[i] = digamma(pc_dbl);
+      digamma_c_1m_p[i] = digamma(c_1m_p_dbl);
+      digamma_c[i] = digamma(value_of(c_vec[i]));
+    }
+  }
+
+  for (size_t n = 0; n < N; n++) {
+    const T_partials_return y_dbl = value_of(y_vec[n]);
+    const T_partials_return p_dbl = value_of(p_vec[n]);
+    const T_partials_return c_dbl = value_of(c_vec[n]);
+    const T_partials_return pc_dbl = p_dbl * c_dbl;
+    const T_partials_return c_1m_p_dbl = c_dbl * (1.0 - p_dbl);
+    const T_partials_return betafunc_dbl = exp(lbeta(pc_dbl, c_1m_p_dbl));
+    const T_partials_return Pn = inc_beta(pc_dbl, c_1m_p_dbl, y_dbl);
+
+    cdf_log += log(Pn);
+
+    if (!is_constant_struct<T_y>::value)
+      ops_partials.edge1_.partials_[n] += pow(1.0 - y_dbl, c_1m_p_dbl - 1.0)
+                                          * pow(y_dbl, pc_dbl - 1.0)
+                                          / betafunc_dbl / Pn;
+
+    T_partials_return g1 = 0;
+    T_partials_return g2 = 0;
+
+    if (contains_nonconstant_struct<T_loc, T_prec>::value) {
+      grad_reg_inc_beta(g1, g2, pc_dbl, c_1m_p_dbl, y_dbl,
+                        digamma_pc[n], digamma_c_1m_p[n],
+                        digamma_c[n], betafunc_dbl);
+    }
+    if (!is_constant_struct<T_loc>::value)
+      ops_partials.edge2_.partials_[n] += c_dbl * (g1 - g2) / Pn;
+    if (!is_constant_struct<T_prec>::value)
+      ops_partials.edge3_.partials_[n]
+        += (g1 * p_dbl + g2 * (1.0 - p_dbl)) / Pn;
+  }
+
+  return ops_partials.build(cdf_log);
+}
+
+}  // namespace math
+}  // namespace stan
+#endif

--- a/stan/math/prim/scal/prob/beta_proportion_lpdf.hpp
+++ b/stan/math/prim/scal/prob/beta_proportion_lpdf.hpp
@@ -1,0 +1,188 @@
+#ifndef STAN_MATH_PRIM_SCAL_PROB_BETA_PROPORTION_LPDF_HPP
+#define STAN_MATH_PRIM_SCAL_PROB_BETA_PROPORTION_LPDF_HPP
+
+#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
+#include <stan/math/prim/scal/meta/partials_return_type.hpp>
+#include <stan/math/prim/scal/meta/operands_and_partials.hpp>
+#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
+#include <stan/math/prim/scal/err/check_less_or_equal.hpp>
+#include <stan/math/prim/scal/err/check_nonnegative.hpp>
+#include <stan/math/prim/scal/err/check_not_nan.hpp>
+#include <stan/math/prim/scal/err/check_positive_finite.hpp>
+#include <stan/math/prim/scal/fun/size_zero.hpp>
+#include <stan/math/prim/scal/fun/log1m.hpp>
+#include <stan/math/prim/scal/fun/constants.hpp>
+#include <stan/math/prim/scal/fun/value_of.hpp>
+#include <stan/math/prim/scal/fun/digamma.hpp>
+#include <stan/math/prim/scal/fun/lgamma.hpp>
+#include <stan/math/prim/scal/meta/contains_nonconstant_struct.hpp>
+#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
+#include <stan/math/prim/scal/meta/include_summand.hpp>
+#include <stan/math/prim/scal/meta/scalar_seq_view.hpp>
+#include <cmath>
+
+namespace stan {
+namespace math {
+
+/**
+ * The log of the beta density parameterized for the location and
+ * precision. y, p (location), or c (precision) can each either be
+ * scalar or a vector.  Any vector inputs must be the same length.
+ *
+ * <p> The result log probability is defined to be the sum of
+ * the log probabilities for each observation/p/c triple.
+ *
+ * Prior location, p, must be contained in (0, 1).  Prior precision
+ * must be positive.
+ *
+ * @param y (Sequence of) scalar(s).
+ * @param p (Sequence of) prior location(s).
+ * @param c (Sequence of) prior precision(s).
+ * @return The log of the product of densities.
+ * @tparam T_y Type of scalar outcome.
+ * @tparam T_loc Type of prior location.
+ * @tparam T_prec Type of prior precision.
+ */
+template <bool propto, typename T_y, typename T_loc,
+          typename T_prec>
+typename return_type<T_y, T_loc, T_prec>::type beta_proportion_lpdf(
+    const T_y& y, const T_loc& p, const T_prec& c) {
+  static const char* function = "beta_proportion_lpdf";
+
+  typedef
+    typename stan::partials_return_type<T_y, T_loc, T_prec>::type
+    T_partials_return;
+
+  using stan::is_constant_struct;
+  using std::log;
+
+  if (size_zero(y, p, c))
+    return 0.0;
+
+  T_partials_return logp(0.0);
+
+  check_positive(function, "Location parameter", p);
+  check_less_or_equal(function, "Location parameter", p, 1.0);
+  check_positive_finite(function, "Precision parameter", c);
+  check_not_nan(function, "Random variable", y);
+  check_nonnegative(function, "Random variable", y);
+  check_less_or_equal(function, "Random variable", y, 1.0);
+  check_consistent_sizes(function, "Random variable", y,
+                         "Location parameter", p,
+                         "Precision parameter", c);
+
+  if (!include_summand<propto, T_y, T_loc, T_prec>::value)
+    return 0.0;
+
+  scalar_seq_view<T_y> y_vec(y);
+  scalar_seq_view<T_loc> p_vec(p);
+  scalar_seq_view<T_prec> c_vec(c);
+  size_t N = max_size(y, p, c);
+
+  for (size_t n = 0; n < N; n++) {
+    const T_partials_return y_dbl = value_of(y_vec[n]);
+    if (y_dbl < 0 || y_dbl > 1)
+      return LOG_ZERO;
+  }
+
+  operands_and_partials<T_y, T_loc, T_prec> ops_partials(y, p, c);
+
+  VectorBuilder<include_summand<propto, T_y, T_loc, T_prec>::value,
+                T_partials_return, T_y>
+      log_y(length(y));
+  VectorBuilder<include_summand<propto, T_y, T_loc, T_prec>::value,
+                T_partials_return, T_y>
+      log1m_y(length(y));
+
+  for (size_t n = 0; n < length(y); n++) {
+    if (include_summand<propto, T_y, T_loc, T_prec>::value) {
+      log_y[n] = log(value_of(y_vec[n]));
+      log1m_y[n] = log1m(value_of(y_vec[n]));
+    }
+  }
+
+  VectorBuilder<include_summand<propto, T_loc, T_prec>::value,
+                T_partials_return, T_loc, T_prec>
+    lgamma_pc(max_size(p, c));
+  VectorBuilder<contains_nonconstant_struct<T_loc, T_prec>::value,
+                T_partials_return, T_loc, T_prec>
+    digamma_pc(max_size(p, c));
+
+  for (size_t n = 0; n < max_size(p, c); n++) {
+    const T_partials_return pc
+      = value_of(p_vec[n]) * value_of(c_vec[n]);
+    if (include_summand<propto, T_loc, T_prec>::value)
+      lgamma_pc[n] = lgamma(pc);
+    if (contains_nonconstant_struct<T_loc, T_prec>::value)
+      digamma_pc[n] = digamma(pc);
+  }
+
+  VectorBuilder<include_summand<propto, T_loc, T_prec>::value,
+                T_partials_return, T_loc, T_prec>
+    lgamma_c_1m_p(max_size(p, c));
+  VectorBuilder<contains_nonconstant_struct<T_loc, T_prec>::value,
+                T_partials_return, T_loc, T_prec>
+    digamma_c_1m_p(max_size(p, c));
+
+  for (size_t n = 0; n < max_size(p, c); n++) {
+    const T_partials_return c_1m_p
+      = value_of(c_vec[n]) * (1.0 - value_of(p_vec[n]));
+    if (include_summand<propto, T_loc, T_prec>::value)
+      lgamma_c_1m_p[n] = lgamma(c_1m_p);
+    if (contains_nonconstant_struct<T_loc, T_prec>::value)
+      digamma_c_1m_p[n] = digamma(c_1m_p);
+  }
+
+  VectorBuilder<include_summand<propto, T_prec>::value,
+                T_partials_return, T_prec>
+    lgamma_c(length(c));
+  VectorBuilder<!is_constant_struct<T_prec>::value,
+                T_partials_return, T_prec>
+    digamma_c(length(c));
+
+  for (size_t n = 0; n < length(c); n++) {
+    if (include_summand<propto, T_prec>::value)
+      lgamma_c[n] = lgamma(value_of(c_vec[n]));
+    if (!is_constant_struct<T_prec>::value)
+      digamma_c[n] = digamma(value_of(c_vec[n]));
+  }
+
+  for (size_t n = 0; n < N; n++) {
+    const T_partials_return y_dbl = value_of(y_vec[n]);
+    const T_partials_return p_dbl = value_of(p_vec[n]);
+    const T_partials_return c_dbl = value_of(c_vec[n]);
+
+    if (include_summand<propto, T_prec>::value)
+      logp += lgamma_c[n];
+    if (include_summand<propto, T_loc, T_prec>::value)
+      logp -= lgamma_pc[n] + lgamma_c_1m_p[n];
+    if (include_summand<propto, T_y, T_loc, T_prec>::value) {
+      const T_partials_return pc_dbl = p_dbl * c_dbl;
+      logp += (pc_dbl - 1.0) * log_y[n] + (c_dbl - pc_dbl - 1.0) * log1m_y[n];
+    }
+
+    if (!is_constant_struct<T_y>::value) {
+      const T_partials_return pc_dbl = p_dbl * c_dbl;
+      ops_partials.edge1_.partials_[n]
+          += (pc_dbl - 1.0) / y_dbl + (c_dbl - pc_dbl - 1.0) / (y_dbl - 1.0);
+    }
+    if (!is_constant_struct<T_loc>::value)
+      ops_partials.edge2_.partials_[n]
+        += c_dbl * (digamma_c_1m_p[n] - digamma_pc[n] + log_y[n] - log1m_y[n]);
+    if (!is_constant_struct<T_prec>::value)
+      ops_partials.edge3_.partials_[n]
+        += digamma_c[n] + p_dbl * (log_y[n] - digamma_pc[n])
+        + (1.0 - p_dbl) * (log1m_y[n] - digamma_c_1m_p[n]);
+  }
+  return ops_partials.build(logp);
+}
+
+template <typename T_y, typename T_loc, typename T_prec>
+inline typename return_type<T_y, T_loc, T_prec>::type beta_proportion_lpdf(
+    const T_y& y, const T_loc& p, const T_prec& c) {
+  return beta_proportion_lpdf<false>(y, p, c);
+}
+
+}  // namespace math
+}  // namespace stan
+#endif

--- a/stan/math/prim/scal/prob/beta_proportion_rng.hpp
+++ b/stan/math/prim/scal/prob/beta_proportion_rng.hpp
@@ -1,0 +1,64 @@
+#ifndef STAN_MATH_PRIM_SCAL_PROB_BETA_PROPORTION_RNG_HPP
+#define STAN_MATH_PRIM_SCAL_PROB_BETA_PROPORTION_RNG_HPP
+
+#include <boost/random/gamma_distribution.hpp>
+#include <boost/random/uniform_real_distribution.hpp>
+#include <boost/random/variate_generator.hpp>
+#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
+#include <stan/math/prim/scal/err/check_positive_finite.hpp>
+#include <stan/math/prim/scal/err/check_positive.hpp>
+#include <stan/math/prim/scal/fun/log_sum_exp.hpp>
+#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
+#include <stan/math/prim/scal/meta/max_size.hpp>
+#include <stan/math/prim/scal/meta/scalar_seq_view.hpp>
+
+namespace stan {
+namespace math {
+
+/**
+ * Return a Beta random variate parameterized with location and
+ * precision parameters using the given random number generator.
+ *
+ * p and c can each be a scalar or a one-dimensional container. Any
+ * non-scalar inputs must be the same size.
+ *
+ * @tparam T_loc Type of location parameter
+ * @tparam T_prec Type of precision parameter
+ * @tparam RNG type of random number generator
+ * @param p (Sequence of) location parameter(s) in (0, 1)
+ * @param c (Sequence of) positive finite precision parameter(s)
+ * @param rng random number generator
+ * @return (Sequence of) beta random variate(s)
+ * @throw std::domain_error if p is outside of (0, 1)
+ * @throw std::domain_error if c is nonpositive
+ * @throw std::invalid_argument if non-scalar arguments are of different
+ * sizes
+ */
+template <typename T_loc, typename T_prec, class RNG>
+inline typename VectorBuilder<true, double, T_loc, T_prec>::type
+beta_proportion_rng(const T_loc &p, const T_prec &c, RNG &rng) {
+  static const char *function = "beta_proportion_rng";
+
+  check_positive(function, "Location parameter", p);
+  check_less_or_equal(function, "Location parameter", p, 1.0);
+  check_positive_finite(function, "Precision parameter", c);
+  check_consistent_sizes(function, "Location parameter", p,
+                         "Precision parameter", c);
+
+  scalar_seq_view<T_loc> p_vec(p);
+  scalar_seq_view<T_prec> c_vec(c);
+  size_t N = max_size(p, c);
+  VectorBuilder<true, double, T_loc, T_prec> output(N);
+
+  for (size_t n = 0; n < N; ++n) {
+    double alpha = p_vec[n] * c_vec[n];
+    double beta = (1.0 - p_vec[n]) * c_vec[n];
+    output[n] = beta_rng(alpha, beta, rng);
+  }
+
+  return output.data();
+}
+
+}  // namespace math
+}  // namespace stan
+#endif

--- a/test/prob/beta_proportion/beta_proportion_ccdf_log_test.hpp
+++ b/test/prob/beta_proportion/beta_proportion_ccdf_log_test.hpp
@@ -1,0 +1,79 @@
+// Arguments: Doubles, Doubles, Doubles
+#include <stan/math/prim/scal.hpp>
+
+using stan::math::var;
+using std::numeric_limits;
+using std::vector;
+
+class AgradCcdfLogBetaProportion : public AgradCcdfLogTest {
+ public:
+  void valid_values(vector<vector<double> >& parameters,
+                    vector<double>& log_ccdf) {
+    vector<double> param(3);
+
+    param[0] = 0.5;  // y
+    param[1] = 0.4;  // p (location)
+    param[2] = 5.0;  // c (precision)
+    parameters.push_back(param);
+    log_ccdf.push_back(std::log(1.0 - 0.6875));  // expected Log_CDF
+
+    param[0] = 0.25;  // y
+    param[1] = 0.75;  // p (location)
+    param[2] = 1.4;   // c (precision)
+    parameters.push_back(param);
+    log_ccdf.push_back(std::log(1.0 - 0.08724396598527127));  // expected Log_CDF
+  }
+
+  void invalid_values(vector<size_t>& index, vector<double>& value) {
+    // y
+    index.push_back(0U);
+    value.push_back(-1.0);
+
+    index.push_back(0U);
+    value.push_back(2.0);
+
+    // alpha
+    index.push_back(1U);
+    value.push_back(-1.0);
+
+    index.push_back(1U);
+    value.push_back(0.0);
+
+    index.push_back(1U);
+    value.push_back(numeric_limits<double>::infinity());
+
+    // beta
+    index.push_back(2U);
+    value.push_back(-1.0);
+
+    index.push_back(2U);
+    value.push_back(0.0);
+
+    index.push_back(2U);
+    value.push_back(numeric_limits<double>::infinity());
+  }
+
+  bool has_lower_bound() { return true; }
+
+  double lower_bound() { return 0.0; }
+
+  bool has_upper_bound() { return true; }
+
+  double upper_bound() { return 1.0; }
+
+  template <typename T_y, typename T_loc, typename T_prec,
+            typename T3, typename T4, typename T5>
+  typename stan::return_type<T_y, T_loc, T_prec>::type ccdf_log(
+      const T_y& y, const T_loc& p, const T_prec& c,
+      const T3&, const T4&, const T5&) {
+    return stan::math::beta_proportion_lccdf(y, p, c);
+  }
+
+  template <typename T_y, typename T_loc, typename T_prec,
+            typename T3, typename T4, typename T5>
+  typename stan::return_type<T_y, T_loc, T_prec>::type
+  ccdf_log_function(const T_y& y, const T_loc& p,
+                    const T_prec& c, const T3&, const T4&, const T5&) {
+    return stan::math::beta_proportion_lccdf(y, p, c);
+  }
+};

--- a/test/prob/beta_proportion/beta_proportion_cdf_log_test.hpp
+++ b/test/prob/beta_proportion/beta_proportion_cdf_log_test.hpp
@@ -1,0 +1,79 @@
+// Arguments: Doubles, Doubles, Doubles
+#include <stan/math/prim/scal.hpp>
+
+using stan::math::var;
+using std::numeric_limits;
+using std::vector;
+
+class AgradCdfLogBetaProportion : public AgradCdfLogTest {
+ public:
+  void valid_values(vector<vector<double> >& parameters,
+                    vector<double>& log_cdf) {
+    vector<double> param(3);
+
+    param[0] = 0.5;  // y
+    param[1] = 0.4;  // p (location)
+    param[2] = 5.0;  // c (precision)
+    parameters.push_back(param);
+    log_cdf.push_back(std::log(0.6875));  // expected Log_CDF
+
+    param[0] = 0.25;  // y
+    param[1] = 0.75;  // p (location)
+    param[2] = 1.4;   // c (precision)
+    parameters.push_back(param);
+    log_cdf.push_back(std::log(0.08724396598527127));  // expected Log_CDF
+  }
+
+  void invalid_values(vector<size_t>& index, vector<double>& value) {
+    // y
+    index.push_back(0U);
+    value.push_back(-1.0);
+
+    index.push_back(0U);
+    value.push_back(2.0);
+
+    // p
+    index.push_back(1U);
+    value.push_back(-1.0);
+
+    index.push_back(1U);
+    value.push_back(0.0);
+
+    index.push_back(1U);
+    value.push_back(numeric_limits<double>::infinity());
+
+    // c
+    index.push_back(2U);
+    value.push_back(-1.0);
+
+    index.push_back(2U);
+    value.push_back(0.0);
+
+    index.push_back(2U);
+    value.push_back(numeric_limits<double>::infinity());
+  }
+
+  bool has_lower_bound() { return true; }
+
+  double lower_bound() { return 0.0; }
+
+  bool has_upper_bound() { return true; }
+
+  double upper_bound() { return 1.0; }
+
+  template <typename T_y, typename T_loc, typename T_prec,
+            typename T3, typename T4, typename T5>
+  typename stan::return_type<T_y, T_loc, T_prec>::type cdf_log(
+      const T_y& y, const T_loc& p, const T_prec& c,
+      const T3&, const T4&, const T5&) {
+    return stan::math::beta_proportion_lcdf(y, p, c);
+  }
+
+  template <typename T_y, typename T_loc, typename T_prec,
+            typename T3, typename T4, typename T5>
+  typename stan::return_type<T_y, T_loc, T_prec>::type
+  cdf_log_function(const T_y& y, const T_loc& p,
+                   const T_prec& c, const T3&, const T4&, const T5&) {
+    return stan::math::beta_proportion_lcdf(y, p, c);
+  }
+};

--- a/test/prob/beta_proportion/beta_proportion_test.hpp
+++ b/test/prob/beta_proportion/beta_proportion_test.hpp
@@ -1,0 +1,96 @@
+// Arguments: Doubles, Doubles, Doubles
+#include <stan/math/prim/scal.hpp>
+#include <boost/utility/enable_if.hpp>
+
+using stan::math::var;
+using std::numeric_limits;
+using std::vector;
+
+class AgradDistributionsBetaProportion : public AgradDistributionTest {
+ public:
+  void valid_values(vector<vector<double> >& parameters,
+                    vector<double>& log_prob) {
+    vector<double> param(3);
+
+    param[0] = 0.4;  // y
+    param[1] = 0.5;  // p (location)
+    param[2] = 0.5;  // c (precision)
+    parameters.push_back(param);
+    log_prob.push_back(-0.9333428397413457);  // expected log_prob
+
+    param[0] = 0.5;  // y
+    param[1] = 0.2;  // p (location)
+    param[2] = 0.4;  // c (precision)
+    parameters.push_back(param);
+    log_prob.push_back(-1.6070080920051264);  // expected log_prob
+
+    param[0] = 0.85; // y
+    param[1] = 0.15; // p (location)
+    param[2] = 4.5;  // c (precision)
+    parameters.push_back(param);
+    log_prob.push_back(-4.7214376176246775); // expected log_prob
+  }
+
+  void invalid_values(vector<size_t>& index, vector<double>& value) {
+    // y
+    index.push_back(0U);
+    value.push_back(-1.0);
+
+    index.push_back(0U);
+    value.push_back(2.0);
+
+    // p
+    index.push_back(1U);
+    value.push_back(0.0);
+
+    index.push_back(1U);
+    value.push_back(-1.0);
+
+    index.push_back(1U);
+    value.push_back(numeric_limits<double>::infinity());
+
+    index.push_back(1U);
+    value.push_back(-numeric_limits<double>::infinity());
+
+    // c
+    index.push_back(2U);
+    value.push_back(0.0);
+
+    index.push_back(2U);
+    value.push_back(-1.0);
+
+    index.push_back(2U);
+    value.push_back(numeric_limits<double>::infinity());
+
+    index.push_back(2U);
+    value.push_back(-numeric_limits<double>::infinity());
+  }
+
+  template <typename T_y, typename T_loc, typename T_prec, typename T3,
+            typename T4, typename T5>
+  typename stan::return_type<T_y, T_loc, T_prec>::type log_prob(
+      const T_y& y, const T_loc& p, const T_prec& c, const T3&,
+      const T4&, const T5&) {
+    return stan::math::beta_proportion_lpdf(y, p, c);
+  }
+
+  template <bool propto, typename T_y, typename T_loc, typename T_prec,
+            typename T3, typename T4, typename T5>
+  typename stan::return_type<T_y, T_loc, T_prec>::type log_prob(
+      const T_y& y, const T_loc& p, const T_prec& c, const T3&,
+      const T4&, const T5&) {
+    return stan::math::beta_proportion_lpdf<propto>(y, p, c);
+  }
+
+  template <typename T_y, typename T_loc, typename T_prec, typename T3,
+            typename T4, typename T5>
+  typename stan::return_type<T_y, T_loc, T_prec, T3, T4, T5>::type
+  log_prob_function(const T_y& y, const T_loc& p, const T_prec& c,
+                    const T3&, const T4&, const T5&) {
+    using stan::math::log1m;
+    using std::log;
+
+    return (p*c - 1.0) * log(y) + ((1.0 - p) * c - 1.0) * log1m(y)
+      + lgamma(c) - lgamma(p * c) - lgamma((1.0 - p) * c);
+  }
+};

--- a/test/unit/math/prim/mat/prob/beta_proportion_test.cpp
+++ b/test/unit/math/prim/mat/prob/beta_proportion_test.cpp
@@ -1,0 +1,49 @@
+#include <gtest/gtest.h>
+#include <boost/math/distributions.hpp>
+#include <boost/random/mersenne_twister.hpp>
+#include <stan/math/prim/mat.hpp>
+#include <test/unit/math/prim/mat/prob/vector_rng_test_helper.hpp>
+#include <limits>
+#include <vector>
+
+class BetaProportionTestRig : public VectorRealRNGTestRig {
+ public:
+  BetaProportionTestRig()
+    : VectorRealRNGTestRig(10000, 10, {0.3, 0.4, 0.5, 0.6, 0.7}, {1, 2, 3},
+                             {-2.5, -1.7, -0.1, 0.0}, {-3, -2, -1, 0},
+                             {0.35, 0.5, 0.9, 1.7, 2.1, 4.1}, {1, 2, 3, 4},
+                             {-2.7, -1.5, -0.5, 0.0}, {-3, -2, -1, 0}) {}
+
+  template <typename T1, typename T2, typename T3, typename T_rng>
+  auto generate_samples(const T1& p, const T2& c, const T3&,
+                        T_rng& rng) const {
+    return stan::math::beta_proportion_rng(p, c, rng);
+  }
+
+  std::vector<double> generate_quantiles(double p, double c,
+                                         double) const {
+    // transform from location and precision parameterization
+    // into shape1 (alpha) and shape2 (beta) parameterization
+    double alpha = p * c;
+    double beta = (1.0 - p) * c;
+    std::vector<double> quantiles;
+    double K = boost::math::round(2 * std::pow(N_, 0.4));
+    boost::math::beta_distribution<> dist(alpha, beta);
+
+    for (int i = 1; i < K; ++i) {
+      double frac = i / K;
+      quantiles.push_back(quantile(dist, frac));
+    }
+    quantiles.push_back(std::numeric_limits<double>::max());
+
+    return quantiles;
+  }
+};
+
+TEST(ProbDistributionsBetaProportion, errorCheck) {
+  check_dist_throws_real_first_argument(BetaProportionTestRig());
+}
+
+TEST(ProbDistributionsBetaProportion, distributionTest) {
+  check_quantiles_real_first_argument(BetaProportionTestRig());
+}

--- a/test/unit/math/prim/mat/prob/vector_rng_test_helper.hpp
+++ b/test/unit/math/prim/mat/prob/vector_rng_test_helper.hpp
@@ -301,6 +301,23 @@ void check_dist_throws_int_first_argument(const T_rig& rig) {
 }
 
 /*
+ * This function calls check_dist_throws with the given test_rig where
+ * the first argument can only be a double or a std::vector<double>
+ * and the other arguments can be any combination of int,
+ * std::vector<int>, double, std::vector<double>, Eigen::VectorXd, or
+ * Eigen::RowVectorXd
+ *
+ * @tparam T_rig Test rig type for random number generator
+ * @param T_rig Test rig for random number generator
+ */
+template <typename T_rig>
+void check_dist_throws_real_first_argument(const T_rig& rig) {
+  apply_template_permutations<std::tuple<double, std::vector<double> >,
+                              ArgumentTypes,
+                              ArgumentTypes>(check_dist_throws{}, rig);
+}
+
+/*
  * Convert a scalar to a length one vector
  *
  * @tparam T Scalar type
@@ -413,6 +430,23 @@ void check_quantiles_real(const T_rig& rig) {
 template <typename T_rig>
 void check_quantiles_real_real(const T_rig& rig) {
   apply_template_permutations<ArgumentTypes, ArgumentTypes,
+                              std::tuple<double> >(check_quantiles{}, rig);
+}
+
+/*
+ * Call check_quantiles on the given test rig for a continuous
+ * distribution that has two parameters where the first can only be a
+ * double or a std::vector<double> and the other argument can be int,
+ * std::vector<int>, double, std::vector<double>, Eigen::VectorXd, or
+ * an Eigen::RowVectorXd
+ *
+ * @tparam T_rig Type of test rig for random number generator
+ * @param T_rig Test rig for random number generator
+ */
+template <typename T_rig>
+void check_quantiles_real_first_argument(const T_rig& rig) {
+  apply_template_permutations<std::tuple<double, std::vector<double> >,
+                              ArgumentTypes,
                               std::tuple<double> >(check_quantiles{}, rig);
 }
 

--- a/test/unit/math/prim/scal/prob/beta_proportion_test.cpp
+++ b/test/unit/math/prim/scal/prob/beta_proportion_test.cpp
@@ -1,0 +1,87 @@
+#include <stan/math/prim/scal.hpp>
+#include <gtest/gtest.h>
+#include <boost/random/mersenne_twister.hpp>
+#include <boost/math/distributions.hpp>
+#include <test/unit/math/prim/scal/prob/util.hpp>
+#include <limits>
+#include <vector>
+
+TEST(ProbDistributionsBetaProportion, error_check) {
+  boost::random::mt19937 rng;
+  EXPECT_NO_THROW(stan::math::beta_proportion_rng(0.5, 3.0, rng));
+  EXPECT_NO_THROW(stan::math::beta_proportion_rng(1e-10, 1e-10, rng));
+  EXPECT_THROW(stan::math::beta_proportion_rng(2.0, -1.0, rng),
+               std::domain_error);
+  EXPECT_THROW(stan::math::beta_proportion_rng(-2.0, 1.0, rng),
+               std::domain_error);
+  EXPECT_THROW(stan::math::beta_proportion_rng(-2.0, -1.0, rng),
+               std::domain_error);
+  EXPECT_THROW(stan::math::beta_proportion_rng(stan::math::positive_infinity(),
+                                               1.0, rng), std::domain_error);
+  EXPECT_THROW(stan::math::beta_proportion_rng(2,
+                                               stan::math::positive_infinity(),
+                                               rng),
+               std::domain_error);
+}
+
+TEST(ProbDistributionsBetaProportion, chiSquareGoodnessFitTest) {
+  boost::random::mt19937 rng;
+  int N = 10000;
+  int K = boost::math::round(2 * std::pow(N, 0.4));
+
+  double p = 0.5;  // location
+  double c = 3.0;  // precision
+
+  std::vector<double> samples;
+  for (int i = 0; i < N; ++i) {
+    samples.push_back(stan::math::beta_proportion_rng(p, c, rng));
+  }
+
+  // transform from location and precision parameterization
+  // into shape1 (alpha) and shape2 (beta) parameterization
+  double alpha = p * c;
+  double beta = (1.0 - p) * c;
+
+  // Generate quantiles from boost's beta distribution
+  boost::math::beta_distribution<> dist(alpha, beta);
+  std::vector<double> quantiles;
+  for (int i = 1; i < K; ++i) {
+    double frac = static_cast<double>(i) / K;
+    quantiles.push_back(quantile(dist, frac));
+  }
+  quantiles.push_back(std::numeric_limits<double>::max());
+
+  // Assert that they match
+  assert_matches_quantiles(samples, quantiles, 1e-6);
+}
+
+TEST(ProbDistributionsBetaProportion, chiSquareGoodnessFitTest2) {
+  boost::random::mt19937 rng;
+  int N = 10000;
+  int K = boost::math::round(2 * std::pow(N, 0.4));
+
+  double p = 0.3;  // location
+  double c = 0.5;  // precision
+
+  std::vector<double> samples;
+  for (int i = 0; i < N; ++i) {
+    samples.push_back(stan::math::beta_proportion_rng(p, c, rng));
+  }
+
+  // transform from location and precision parameterization
+  // into shape1 (alpha) and shape2 (beta) parameterization
+  double alpha = p * c;
+  double beta = (1.0 - p) * c;
+
+  // Generate quantiles from boost's beta distribution
+  boost::math::beta_distribution<> dist(alpha, beta);
+  std::vector<double> quantiles;
+  for (int i = 1; i < K; ++i) {
+    double frac = static_cast<double>(i) / K;
+    quantiles.push_back(quantile(dist, frac));
+  }
+  quantiles.push_back(std::numeric_limits<double>::max());
+
+  // Assert that they match
+  assert_matches_quantiles(samples, quantiles, 1e-6);
+}


### PR DESCRIPTION
## Summary

Address issue https://github.com/stan-dev/math/issues/914 by adding beta distribution functions with mean/precision parameterization, which previously did not exist: 

```
stan/math/prim/scal/prob/beta_proportion_lccdf.hpp
stan/math/prim/scal/prob/beta_proportion_lcdf.hpp
stan/math/prim/scal/prob/beta_proportion_lpdf.hpp
stan/math/prim/scal/prob/beta_proportion_rng.hpp
```

The issue suggests that "Any or all of these beta_proportion_X functions may be implemented in prim by delegating to the equivalent beta_X function," but honestly I couldn't figure this out for `beta_proportion_lccdf` nor `beta_proportion_lcdf` -- maintaining templated types, while mathematically manipulating them and passing them to `beta_X` was not obvious, to me.  

Instead, I just did the math and wrote the code for `lpdf`, `lccdf`, and `lcdf`.  Do we trust the the finite difference tests safely check my math, here?

On the other hand, `beta_proportion_rng` does delegate to `beta_rng`.  It was pretty easy to find a parameterization of `beta_proportion` that made `beta_rng` unhappy.  For this PR, I chose proportions `p` not too close to the boundaries `0` and `1`, and didn't choose too small values of the precision parameter `c`, since we seem to have been content with `beta_rng` thus far.  Should I file a separate issue about the apparent fragility of `beta_rng`?  

Please note that `beta_proportion_lpdf(y, p, c)` can not accept integer parameters for `y` since ` y \in (0, 1)`.  Thus, I added two functions to `test/unit/math/prim/mat/prob/vector_rng_test_helper.hpp` to account for this within the `test_rig`s.  I'd appreciate someone double checking these.

Are the tests below sufficient for adding a new distribution function?

## Tests

Tests for `beta_proportion_lccdf` live in `test/prob/beta_proportio/beta_proportion_ccdf_log_test.hpp`

Tests for `beta_proportion_lcdf` live in`test/prob/beta_proportion/beta_proportion_cdf_log_test.hpp` 

Tests for `beta_proportion_lpdf` live in`test/prob/beta_proportion/beta_proportion_test.hpp`

Tests for `beta_proportion_rng` live in `test/unit/math/prim/mat/prob/beta_proportion_test.cpp` and `test/unit/math/prim/scal/prob/beta_proportion_test.cpp`


## Side Effects

No side effects intended.

## Checklist

- [x] Math issue https://github.com/stan-dev/math/issues/914

- [x] Copyright holder: California State University, Chico

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses: 
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing
    - ~~unit tests pass (to run, use: `./runTests.py test/unit`)~~ instead I ran `./runTests.py` on  `test/unit/math/prim/scal/prob/beta_proportion_test.cpp`, `test/unit/math/prim/mat/prob/beta_proportion_test.cpp`, and`test/prob/beta_proportion/`
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

To my best abilities.

- [x] the new changes are tested
