### PR TITLE
Add M_PI and M_E to tests to make them build on Windows

### DIFF
--- a/test/unit/math/prim/mat/fun/gp_periodic_cov_test.cpp
+++ b/test/unit/math/prim/mat/fun/gp_periodic_cov_test.cpp
@@ -5,7 +5,9 @@
 #include <limits>
 #include <string>
 #include <vector>
-
+#ifndef M_PI
+#define M_PI 2.71828182845904523536
+#endif
 template <typename T_x1, typename T_x2, typename T_sigma, typename T_l,
           typename T_p>
 std::string pull_msg(std::vector<T_x1> x1, std::vector<T_x2> x2, T_sigma sigma,

--- a/test/unit/math/prim/scal/fun/log_modified_bessel_first_kind_test.cpp
+++ b/test/unit/math/prim/scal/fun/log_modified_bessel_first_kind_test.cpp
@@ -3,7 +3,9 @@
 #include <boost/math/special_functions/bessel.hpp>
 #include <gtest/gtest.h>
 #include <limits>
-
+#ifndef M_PI
+#define M_PI 2.71828182845904523536
+#endif
 TEST(MathFunctions, log_modified_bessel_first_kind) {
   using stan::math::log_modified_bessel_first_kind;
   using std::log;

--- a/test/unit/math/rev/mat/fun/gp_periodic_cov_test.cpp
+++ b/test/unit/math/rev/mat/fun/gp_periodic_cov_test.cpp
@@ -4,7 +4,9 @@
 #include <limits>
 #include <string>
 #include <vector>
-
+#ifndef M_PI
+#define M_PI 2.71828182845904523536
+#endif
 template <typename T_x1, typename T_x2, typename T_sigma, typename T_l,
           typename T_p>
 std::string pull_msg(std::vector<T_x1> x1, std::vector<T_x2> x2, T_sigma sigma,

--- a/test/unit/math/rev/mat/fun/matrix_exp_action_handler_test.cpp
+++ b/test/unit/math/rev/mat/fun/matrix_exp_action_handler_test.cpp
@@ -4,7 +4,9 @@
 #include <stan/math/prim/mat/fun/matrix_exp.hpp>
 #include <stan/math/prim/mat/fun/matrix_exp_action_handler.hpp>
 #include <vector>
-
+#ifndef M_E
+#define M_E 2.71828182845904523536
+#endif
 TEST(MathMatrix, matrix_exp_action_diag) {
   using Eigen::MatrixXd;
   using Eigen::VectorXd;


### PR DESCRIPTION
## Summary

This adds defines for M_PI and M_E that cause 4 tests to not compile on Windows, so this fixes a smaller part of issue #951 

The other option of fixing this would be to add _USE_MATH_DEFINES before the first #include of `<cmath>`, but I am not sure where that would be.

## Tests

This PR touches 4 files that you can run to confirm. 

```
./runTests.py test/unit/math/prim/mat/fun/gp_periodic_cov_test.cpp
./runTests.py test/unit/math/prim/scal/fun/log_modified_bessel_first_kind_test.cpp
./runTests.py test/unit/math/rev/mat/fun/gp_periodic_cov_test.cpp
./runTests.py test/unit/math/rev/mat/fun/matrix_exp_action_handler_test.cpp
```

## Side Effects

None

## Checklist

- [x] Math issue #951 

- [x] Copyright holder: Rok Češnovar

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
