### PR TITLE
Feature/issue 977 some variadic templating

### DIFF
--- a/stan/math/prim/scal/meta/include_summand.hpp
+++ b/stan/math/prim/scal/meta/include_summand.hpp
@@ -26,16 +26,35 @@ namespace math {
  * proportionality constant.
  * @tparam T1 First
  */
+template <bool propto, typename T=double, typename... T_pack>
+struct include_summand {
+  enum {
+    value = (!stan::is_constant<typename scalar_type<T>::type>::value
+      || include_summand<propto,T_pack...>::value
+    )
+  };
+};
+
+// T defaults to double (specializations inherrit defaults)
+template <bool propto, typename T>
+struct include_summand<propto,T> {
+  enum {
+    value = (!propto || !stan::is_constant<typename scalar_type<T>::type>::value)
+  };
+};
+   /**
+    * <code>true</code> if a term with the specified propto
+    * value and subterm types should be included in a proportionality
+    * calculation.
+    */
+
+ /*
 template <bool propto, typename T1 = double, typename T2 = double,
           typename T3 = double, typename T4 = double, typename T5 = double,
           typename T6 = double, typename T7 = double, typename T8 = double,
           typename T9 = double, typename T10 = double>
-struct include_summand {
-  /**
-   * <code>true</code> if a term with the specified propto
-   * value and subterm types should be included in a proportionality
-   * calculation.
-   */
+          struct include_summand {
+
   enum {
     value
     = (!propto || !stan::is_constant<typename scalar_type<T1>::type>::value
@@ -49,7 +68,9 @@ struct include_summand {
        || !stan::is_constant<typename scalar_type<T9>::type>::value
        || !stan::is_constant<typename scalar_type<T10>::type>::value)
   };
+
 };
+*/
 
 }  // namespace math
 

--- a/stan/math/prim/scal/meta/include_summand.hpp
+++ b/stan/math/prim/scal/meta/include_summand.hpp
@@ -17,16 +17,23 @@ namespace math {
  * should be included for all of the types of variables
  * in a term.
  *
+ * The metaprogram can take an arbitrary number of types.
+ *
  * The <code>value</code> enum will be <code>true</code> if the
  * <code>propto</code> parameter is <code>false</code> or if any
  * of the other template arguments are not constants as defined by
  * <code>stan::is_constant<T></code>.
-
+ *
+ * Example use: <code>include_summand<false, double, var, double, double></code>
+ *
  * @tparam propto <code>true</code> if calculating up to a
  * proportionality constant.
- * @tparam T1 First
+ * @tparam T (optional). A type
+ * @tparam T_pack (optional). A parameter pack of types. This is used to
+ * extend the applicabiity of the function to an arbitrary number of types.
  */
-template <bool propto, typename T=double, typename... T_pack>
+
+template <bool propto, typename T = double, typename... T_pack>
 struct include_summand {
   enum {
     value = (!stan::is_constant<typename scalar_type<T>::type>::value
@@ -35,7 +42,6 @@ struct include_summand {
   };
 };
 
-// T defaults to double (specializations inherrit defaults)
 template <bool propto, typename T>
 struct include_summand<propto,T> {
   /**

--- a/stan/math/prim/scal/meta/include_summand.hpp
+++ b/stan/math/prim/scal/meta/include_summand.hpp
@@ -38,39 +38,15 @@ struct include_summand {
 // T defaults to double (specializations inherrit defaults)
 template <bool propto, typename T>
 struct include_summand<propto,T> {
+  /**
+   * <code>true</code> if a term with the specified propto
+   * value and subterm types should be included in a proportionality
+   * calculation.
+   */
   enum {
     value = (!propto || !stan::is_constant<typename scalar_type<T>::type>::value)
   };
 };
-   /**
-    * <code>true</code> if a term with the specified propto
-    * value and subterm types should be included in a proportionality
-    * calculation.
-    */
-
- /*
-template <bool propto, typename T1 = double, typename T2 = double,
-          typename T3 = double, typename T4 = double, typename T5 = double,
-          typename T6 = double, typename T7 = double, typename T8 = double,
-          typename T9 = double, typename T10 = double>
-          struct include_summand {
-
-  enum {
-    value
-    = (!propto || !stan::is_constant<typename scalar_type<T1>::type>::value
-       || !stan::is_constant<typename scalar_type<T2>::type>::value
-       || !stan::is_constant<typename scalar_type<T3>::type>::value
-       || !stan::is_constant<typename scalar_type<T4>::type>::value
-       || !stan::is_constant<typename scalar_type<T5>::type>::value
-       || !stan::is_constant<typename scalar_type<T6>::type>::value
-       || !stan::is_constant<typename scalar_type<T7>::type>::value
-       || !stan::is_constant<typename scalar_type<T8>::type>::value
-       || !stan::is_constant<typename scalar_type<T9>::type>::value
-       || !stan::is_constant<typename scalar_type<T10>::type>::value)
-  };
-
-};
-*/
 
 }  // namespace math
 

--- a/stan/math/prim/scal/meta/partials_return_type.hpp
+++ b/stan/math/prim/scal/meta/partials_return_type.hpp
@@ -2,33 +2,36 @@
 #define STAN_MATH_PRIM_SCAL_META_PARTIALS_RETURN_TYPE_HPP
 
 #include <stan/math/prim/scal/meta/partials_type.hpp>
+#include <stan/math/rev/core/var.hpp>
+#include <stan/math/rev/scal/meta/partials_type.hpp>
+#include <stan/math/fwd/core/fvar.hpp>
+#include <stan/math/fwd/scal/meta/partials_type.hpp>
 #include <stan/math/prim/scal/meta/scalar_type.hpp>
 #include <boost/math/tools/promotion.hpp>
 
 namespace stan {
 
-/**
- * Template metaprogram to calculate the base scalar return type for partial
- * derivatives. The metaprogram can take an arbitrary number of template
- * parameters.
- *
- * All C++ primitive types (except <code>long double</code>) are automatically
- * promoted to <code>double</code>.
- *
- * <code>partials_return_type<...></code> is a class defining a single public
- * typedef <code>type</code> that is <code>double</code> for containers
- * of base C++ types (except for <code>long double</code>) as well as
- * containers of <code>var</code>s.
- *
- * <code>partials_type<fvar<var> >::type</code> is not <code>var</code>.
- *
- * Example usage:
- *  - <code>return_type<int,double,float>::type</code> is <code>double</code>
- *  - <code>return_type<double,var>::type</code> is <code>double</code>
- *
- * @tparam T (required) A type
- * @tparam T_pack (optional) A parameter pack containing further types.
- */
+  /**
+   * Template metaprogram to calculate the base scalar return type resulting
+   * from promoting all the scalar types of the template parameters. The
+   * metaprogram can take an arbitrary number of template parameters.
+   *
+   * All C++ primitive types (except <code>long double</code>) are automatically
+   * promoted to <code>double</code>.
+   *
+   * <code>partials_return_type<...></code> is a class defining a single public
+   * typedef <code>type</code> that is <code>var</code> if there is a forward
+   * mode variable type and is <code>double</code> otherwise (this is the most
+   * common case).
+   * Example usage:
+   *
+   *  - <code>return_type<int,double,var>::type</code> is <code>double</code>
+   *  - The same thing with <code>var</code> replaced with a forward mode type
+   *  like <code>fvar<T></code> will return <code>T</code>.
+   *
+   * @tparam T (required) A type
+   * @tparam T_pack (optional) A parameter pack containing further types.
+   */
 
 template <typename T, typename... T_pack>
 struct partials_return_type {

--- a/stan/math/prim/scal/meta/partials_return_type.hpp
+++ b/stan/math/prim/scal/meta/partials_return_type.hpp
@@ -11,27 +11,27 @@
 
 namespace stan {
 
-  /**
-   * Template metaprogram to calculate the base scalar return type resulting
-   * from promoting all the scalar types of the template parameters. The
-   * metaprogram can take an arbitrary number of template parameters.
-   *
-   * All C++ primitive types (except <code>long double</code>) are automatically
-   * promoted to <code>double</code>.
-   *
-   * <code>partials_return_type<...></code> is a class defining a single public
-   * typedef <code>type</code> that is <code>var</code> if there is a forward
-   * mode variable type and is <code>double</code> otherwise (this is the most
-   * common case).
-   * Example usage:
-   *
-   *  - <code>return_type<int,double,var>::type</code> is <code>double</code>
-   *  - The same thing with <code>var</code> replaced with a forward mode type
-   *  like <code>fvar<T></code> will return <code>T</code>.
-   *
-   * @tparam T (required) A type
-   * @tparam T_pack (optional) A parameter pack containing further types.
-   */
+/**
+ * Template metaprogram to calculate the base scalar return type resulting
+ * from promoting all the scalar types of the template parameters. The
+ * metaprogram can take an arbitrary number of template parameters.
+ *
+ * All C++ primitive types (except <code>long double</code>) are automatically
+ * promoted to <code>double</code>.
+ *
+ * <code>partials_return_type<...></code> is a class defining a single public
+ * typedef <code>type</code> that is <code>var</code> if there is a forward
+ * mode variable type and is <code>double</code> otherwise (this is the most
+ * common case).
+ * Example usage:
+ *
+ *  - <code>return_type<int,double,var>::type</code> is <code>double</code>
+ *  - The same thing with <code>var</code> replaced with a forward mode type
+ *  like <code>fvar<T></code> will return <code>T</code>.
+ *
+ * @tparam T (required) A type
+ * @tparam T_pack (optional) A parameter pack containing further types.
+ */
 
 template <typename T, typename... T_pack>
 struct partials_return_type {

--- a/stan/math/prim/scal/meta/partials_return_type.hpp
+++ b/stan/math/prim/scal/meta/partials_return_type.hpp
@@ -7,6 +7,21 @@
 
 namespace stan {
 
+template <typename T, typename... T_pack>
+struct partials_return_type {
+  typedef typename boost::math::tools::promote_args<double,
+      typename partials_type<typename scalar_type<T>::type>::type,
+      typename partials_return_type<T_pack...>::type >::type type;
+};
+
+template <typename T>
+struct partials_return_type<T> {
+  typedef typename boost::math::tools::promote_args<double,
+      typename partials_type<typename scalar_type<T>::type>::type >::type type;
+};
+
+
+/*
 template <typename T1, typename T2 = double, typename T3 = double,
           typename T4 = double, typename T5 = double, typename T6 = double>
 struct partials_return_type {
@@ -18,5 +33,6 @@ struct partials_return_type {
       typename partials_type<typename scalar_type<T5>::type>::type,
       typename partials_type<typename scalar_type<T6>::type>::type>::type type;
 };
+*/
 }  // namespace stan
 #endif

--- a/stan/math/prim/scal/meta/partials_return_type.hpp
+++ b/stan/math/prim/scal/meta/partials_return_type.hpp
@@ -2,17 +2,18 @@
 #define STAN_MATH_PRIM_SCAL_META_PARTIALS_RETURN_TYPE_HPP
 
 #include <stan/math/prim/scal/meta/partials_type.hpp>
-#include <stan/math/rev/core/var.hpp>
+/*#include <stan/math/rev/core/var.hpp>
 #include <stan/math/rev/scal/meta/partials_type.hpp>
 #include <stan/math/fwd/core/fvar.hpp>
 #include <stan/math/fwd/scal/meta/partials_type.hpp>
+*/
 #include <stan/math/prim/scal/meta/scalar_type.hpp>
 #include <boost/math/tools/promotion.hpp>
 
 namespace stan {
 
 /**
- * Template metaprogram to calculate the base scalar return type resulting
+ * Template metaprogram to calculate the partial derivative type resulting
  * from promoting all the scalar types of the template parameters. The
  * metaprogram can take an arbitrary number of template parameters.
  *

--- a/stan/math/prim/scal/meta/partials_return_type.hpp
+++ b/stan/math/prim/scal/meta/partials_return_type.hpp
@@ -2,11 +2,6 @@
 #define STAN_MATH_PRIM_SCAL_META_PARTIALS_RETURN_TYPE_HPP
 
 #include <stan/math/prim/scal/meta/partials_type.hpp>
-/*#include <stan/math/rev/core/var.hpp>
-#include <stan/math/rev/scal/meta/partials_type.hpp>
-#include <stan/math/fwd/core/fvar.hpp>
-#include <stan/math/fwd/scal/meta/partials_type.hpp>
-*/
 #include <stan/math/prim/scal/meta/scalar_type.hpp>
 #include <boost/math/tools/promotion.hpp>
 

--- a/stan/math/prim/scal/meta/partials_return_type.hpp
+++ b/stan/math/prim/scal/meta/partials_return_type.hpp
@@ -7,6 +7,29 @@
 
 namespace stan {
 
+  /**
+   * Template metaprogram to calculate the base scalar return type for partial
+   * derivatives. The metaprogram can take an arbitrary number of template
+   * parameters.
+   *
+   * All C++ primitive types (except <code>long double</code>) are automatically
+   * promoted to <code>double</code>.
+   *
+   * <code>partials_return_type<...></code> is a class defining a single public
+   * typedef <code>type</code> that is <code>double</code> for containers
+   * of base C++ types (except for <code>long double</code>) as well as
+   * containers of <code>var</code> types.
+   *
+   * <code>partials_type<fvar<var> >::type</code> is not <code>var</code>.
+   *
+   * Example usage:
+   *  - <code>return_type<int,double,float>::type</code> is <code>double</code>
+   *  - <code>return_type<double,var>::type</code> is <code>double</code>
+   *
+   * @tparam T (required) A type
+   * @tparam T_pack (optional) A parameter pack containing further types.
+   */
+
 template <typename T, typename... T_pack>
 struct partials_return_type {
   typedef typename boost::math::tools::promote_args<double,

--- a/stan/math/prim/scal/meta/partials_return_type.hpp
+++ b/stan/math/prim/scal/meta/partials_return_type.hpp
@@ -20,19 +20,5 @@ struct partials_return_type<T> {
       typename partials_type<typename scalar_type<T>::type>::type >::type type;
 };
 
-
-/*
-template <typename T1, typename T2 = double, typename T3 = double,
-          typename T4 = double, typename T5 = double, typename T6 = double>
-struct partials_return_type {
-  typedef typename boost::math::tools::promote_args<
-      typename partials_type<typename scalar_type<T1>::type>::type,
-      typename partials_type<typename scalar_type<T2>::type>::type,
-      typename partials_type<typename scalar_type<T3>::type>::type,
-      typename partials_type<typename scalar_type<T4>::type>::type,
-      typename partials_type<typename scalar_type<T5>::type>::type,
-      typename partials_type<typename scalar_type<T6>::type>::type>::type type;
-};
-*/
 }  // namespace stan
 #endif

--- a/stan/math/prim/scal/meta/return_type.hpp
+++ b/stan/math/prim/scal/meta/return_type.hpp
@@ -42,6 +42,5 @@ struct return_type<T> {
       double, typename scalar_type<T>::type>::type type;
 };
 
-
 }  // namespace stan
 #endif

--- a/stan/math/prim/scal/meta/return_type.hpp
+++ b/stan/math/prim/scal/meta/return_type.hpp
@@ -9,16 +9,23 @@ namespace stan {
 /**
  * Metaprogram to calculate the base scalar return type resulting
  * from promoting all the scalar types of the template parameters.
+ * Note: Sub-double types are promoted to double.
  */
-template <typename T1, typename T2 = double, typename T3 = double,
-          typename T4 = double, typename T5 = double, typename T6 = double>
-struct return_type {
-  typedef typename boost::math::tools::promote_args<
-      typename scalar_type<T1>::type, typename scalar_type<T2>::type,
-      typename scalar_type<T3>::type, typename scalar_type<T4>::type,
-      typename scalar_type<T5>::type, typename scalar_type<T6>::type>::type
+
+
+ template <typename T, typename... Types_pack>
+ struct return_type {
+   typedef typename boost::math::tools::promote_args<double,
+      typename scalar_type<T>::type,
+      typename return_type<Types_pack...>::type>::type
       type;
-};
+ };
+
+ template <typename T>
+ struct return_type<T> {
+   typedef typename boost::math::tools::promote_args<double,
+       typename scalar_type<T>::type>::type type;
+ };
 
 }  // namespace stan
 #endif

--- a/stan/math/prim/scal/meta/return_type.hpp
+++ b/stan/math/prim/scal/meta/return_type.hpp
@@ -7,11 +7,27 @@
 namespace stan {
 
 /**
- * Metaprogram to calculate the base scalar return type resulting
- * from promoting all the scalar types of the template parameters.
- * Note: Sub-double types are promoted to double.
+ * Template metaprogram to calculate the base scalar return type resulting
+ * from promoting all the scalar types of the template parameters. The metaprogram
+ * can take an arbitrary number of template parameters.
+ *
+ * All C++ primitive types (except <code>long double</code>) are automatically
+ * promoted to <code>double</code>.
+ *
+ * <code>return_type<...></code> is a class defining a single public
+ * typedef <code>type</code> that is <code>var</code> if there is a non-constant
+ * template argument and is <code>double</code> otherwise. This is consistent
+ * with the Stan logic that if code receives <code>var</code> as an input type,
+ * then the return type is <code>var</code>. All other functions return
+ * <code>double</code>.
+ *
+ * Example usage:
+ *  - <code>return_type<int,double,float>::type</code> is <code>double</code>
+ *  - <code>return_type<double,var>::type</code> is <code>var</code>
+ *
+ * @tparam T (required) A type
+ * @tparam Types_pack (optional) A parameter pack containing further types.
  */
-
 
  template <typename T, typename... Types_pack>
  struct return_type {

--- a/stan/math/prim/scal/meta/return_type.hpp
+++ b/stan/math/prim/scal/meta/return_type.hpp
@@ -39,7 +39,7 @@ struct return_type {
 template <typename T>
 struct return_type<T> {
   typedef typename boost::math::tools::promote_args<
-      double, typename scalar_type<T>::type>::type type;
+       double, typename scalar_type<T>::type>::type type;
 };
 
 }  // namespace stan

--- a/stan/math/prim/scal/meta/return_type.hpp
+++ b/stan/math/prim/scal/meta/return_type.hpp
@@ -29,21 +29,6 @@ namespace stan {
  * @tparam Types_pack (optional) A parameter pack containing further types.
  */
 
-<<<<<<< HEAD
- template <typename T, typename... Types_pack>
- struct return_type {
-   typedef typename boost::math::tools::promote_args<double,
-      typename scalar_type<T>::type,
-      typename return_type<Types_pack...>::type>::type
-      type;
- };
-
- template <typename T>
- struct return_type<T> {
-   typedef typename boost::math::tools::promote_args<double,
-       typename scalar_type<T>::type>::type type;
- };
-=======
 template <typename T, typename... Types_pack>
 struct return_type {
   typedef typename boost::math::tools::promote_args<
@@ -56,7 +41,7 @@ struct return_type<T> {
   typedef typename boost::math::tools::promote_args<
       double, typename scalar_type<T>::type>::type type;
 };
->>>>>>> 2505cdf20df15712c027eecb0b55fbb76ed98738
+
 
 }  // namespace stan
 #endif

--- a/stan/math/prim/scal/meta/return_type.hpp
+++ b/stan/math/prim/scal/meta/return_type.hpp
@@ -39,7 +39,7 @@ struct return_type {
 template <typename T>
 struct return_type<T> {
   typedef typename boost::math::tools::promote_args<
-       double, typename scalar_type<T>::type>::type type;
+      double, typename scalar_type<T>::type>::type type;
 };
 
 }  // namespace stan

--- a/stan/math/rev/arr/functor/integrate_1d.hpp
+++ b/stan/math/rev/arr/functor/integrate_1d.hpp
@@ -24,7 +24,8 @@ namespace math {
  * with respect to the nth parameter. Uses nested reverse mode autodiff
  *
  * Gradients that evaluate to NaN are set to zero if the function itself
- * evaluates to zero. If the function is not zero and the gradient evaluates to NaN, a std::domain_error is thrown
+ * evaluates to zero. If the function is not zero and the gradient evaluates to
+ * NaN, a std::domain_error is thrown
  */
 template <typename F>
 inline double gradient_of_f(const F &f, const double &x, const double &xc,

--- a/test/unit/math/fwd/scal/meta/include_summand_test.cpp
+++ b/test/unit/math/fwd/scal/meta/include_summand_test.cpp
@@ -1,0 +1,26 @@
+#include <stan/math/fwd/scal.hpp>
+#include <gtest/gtest.h>
+#include <test/unit/util.hpp>
+
+using stan::math::include_summand;
+using stan::math::fvar;
+
+TEST(MetaTraits, IncludeSummandProptoTrueFvarDouble) {
+  EXPECT_TRUE((include_summand<true,fvar<double> >::value));
+}
+
+TEST(MetaTraits, IncludeSummandProptoTrueFvarFvarDouble) {
+  EXPECT_TRUE((include_summand<true,fvar<fvar<double> > >::value));
+}
+
+
+TEST(MetaTraits, IncludeSummandProtoTrueFvarDoubleTen) {
+  EXPECT_TRUE((include_summand<true,double,fvar<double>,int,fvar<double>,double,
+                                double, int, int, fvar<double>, int>::value));
+}
+
+TEST(MetaTraits, IncludeSummandProtoTrueFvarFvarDoubleTen) {
+  EXPECT_TRUE((include_summand<true,double,fvar<fvar<double> >,int,
+                                fvar<fvar<double> >,double,double, int,int,
+                                fvar<fvar<double> >, int>::value));
+}

--- a/test/unit/math/fwd/scal/meta/include_summand_test.cpp
+++ b/test/unit/math/fwd/scal/meta/include_summand_test.cpp
@@ -2,25 +2,25 @@
 #include <gtest/gtest.h>
 #include <test/unit/util.hpp>
 
-using stan::math::include_summand;
 using stan::math::fvar;
+using stan::math::include_summand;
 
 TEST(MetaTraits, IncludeSummandProptoTrueFvarDouble) {
-  EXPECT_TRUE((include_summand<true,fvar<double> >::value));
+  EXPECT_TRUE((include_summand<true, fvar<double> >::value));
 }
 
 TEST(MetaTraits, IncludeSummandProptoTrueFvarFvarDouble) {
-  EXPECT_TRUE((include_summand<true,fvar<fvar<double> > >::value));
+  EXPECT_TRUE((include_summand<true, fvar<fvar<double> > >::value));
 }
 
-
 TEST(MetaTraits, IncludeSummandProtoTrueFvarDoubleTen) {
-  EXPECT_TRUE((include_summand<true,double,fvar<double>,int,fvar<double>,double,
-                                double, int, int, fvar<double>, int>::value));
+  EXPECT_TRUE(
+      (include_summand<true, double, fvar<double>, int, fvar<double>, double,
+                       double, int, int, fvar<double>, int>::value));
 }
 
 TEST(MetaTraits, IncludeSummandProtoTrueFvarFvarDoubleTen) {
-  EXPECT_TRUE((include_summand<true,double,fvar<fvar<double> >,int,
-                                fvar<fvar<double> >,double,double, int,int,
-                                fvar<fvar<double> >, int>::value));
+  EXPECT_TRUE((include_summand<true, double, fvar<fvar<double> >, int,
+                               fvar<fvar<double> >, double, double, int, int,
+                               fvar<fvar<double> >, int>::value));
 }

--- a/test/unit/math/fwd/scal/meta/partials_return_type_test.cpp
+++ b/test/unit/math/fwd/scal/meta/partials_return_type_test.cpp
@@ -1,16 +1,33 @@
 #include <stan/math/fwd/scal.hpp>
+
 #include <gtest/gtest.h>
+#include <test/unit/util.hpp>
 
-TEST(MetaTraits, partials_return_type) {
-  using stan::math::fvar;
-  using stan::partials_return_type;
+using stan::partials_return_type;
+using stan::math::fvar;
 
-  partials_return_type<double, fvar<fvar<double> > >::type b(3.0, 2.0);
-  EXPECT_EQ(3.0, b.val_);
-  EXPECT_EQ(2.0, b.d_);
+TEST(MetaTraits, PartialsReturnTypeFvarDouble) {
+  test::expect_same_type<double, partials_return_type<fvar<double>
+                         >::type>();
+}
 
-  partials_return_type<double, double, fvar<fvar<double> >,
-                       fvar<fvar<double> > >::type e(3.0, 2.0);
-  EXPECT_EQ(3.0, e.val_);
-  EXPECT_EQ(2.0, e.d_);
+TEST(MetaTraits, PartialsReturnTypeFvarFvarDouble) {
+  test::expect_same_type<fvar<double>,
+                         partials_return_type<fvar<fvar<double> > >::type>();
+}
+
+TEST(MetaTraits, PartialsReturnTypeFvarDoubleTenParams) {
+  test::expect_same_type<
+      double, partials_return_type<double, fvar<double>, double, int,
+                                         double, float, float, float,
+                                         fvar<double>, int>::type>();
+}
+
+TEST(MetaTraits, PartialsReturnTypeFvarFvarDoubleTenParams) {
+  test::expect_same_type<
+      fvar<double>, partials_return_type<double, fvar<fvar<double> >,
+                                                double, int, double, float,
+                                                float, float,
+                                                fvar<fvar<double> >,
+                                                int>::type>();
 }

--- a/test/unit/math/fwd/scal/meta/partials_return_type_test.cpp
+++ b/test/unit/math/fwd/scal/meta/partials_return_type_test.cpp
@@ -3,12 +3,11 @@
 #include <gtest/gtest.h>
 #include <test/unit/util.hpp>
 
-using stan::partials_return_type;
 using stan::math::fvar;
+using stan::partials_return_type;
 
 TEST(MetaTraits, PartialsReturnTypeFvarDouble) {
-  test::expect_same_type<double, partials_return_type<fvar<double>
-                         >::type>();
+  test::expect_same_type<double, partials_return_type<fvar<double> >::type>();
 }
 
 TEST(MetaTraits, PartialsReturnTypeFvarFvarDouble) {
@@ -18,16 +17,14 @@ TEST(MetaTraits, PartialsReturnTypeFvarFvarDouble) {
 
 TEST(MetaTraits, PartialsReturnTypeFvarDoubleTenParams) {
   test::expect_same_type<
-      double, partials_return_type<double, fvar<double>, double, int,
-                                         double, float, float, float,
-                                         fvar<double>, int>::type>();
+      double,
+      partials_return_type<double, fvar<double>, double, int, double, float,
+                           float, float, fvar<double>, int>::type>();
 }
 
 TEST(MetaTraits, PartialsReturnTypeFvarFvarDoubleTenParams) {
   test::expect_same_type<
-      fvar<double>, partials_return_type<double, fvar<fvar<double> >,
-                                                double, int, double, float,
-                                                float, float,
-                                                fvar<fvar<double> >,
-                                                int>::type>();
+      fvar<double>, partials_return_type<double, fvar<fvar<double> >, double,
+                                         int, double, float, float, float,
+                                         fvar<fvar<double> >, int>::type>();
 }

--- a/test/unit/math/fwd/scal/meta/return_type_test.cpp
+++ b/test/unit/math/fwd/scal/meta/return_type_test.cpp
@@ -5,23 +5,25 @@
 using stan::math::fvar;
 using stan::return_type;
 
-TEST(MetaTraits, ReturnTypeFvar) {
+TEST(MetaTraits, ReturnTypeFvarDouble) {
   test::expect_same_type<fvar<double>, return_type<fvar<double> >::type>();
-  test::expect_same_type<fvar<double>,
-                         return_type<fvar<double>, fvar<double> >::type>();
-  test::expect_same_type<fvar<double>, return_type<fvar<double>, fvar<double>,
-                                                   fvar<double> >::type>();
-  test::expect_same_type<
-      fvar<double>, return_type<fvar<double>, fvar<double>, double>::type>();
+}
+
+TEST(MetaTraits, ReturnTypeFvarFvarDouble) {
   test::expect_same_type<fvar<fvar<double> >,
                          return_type<fvar<fvar<double> > >::type>();
+}
+
+TEST(MetaTraits, ReturnTypeFvarDoubleTenParams) {
+  test::expect_same_type<
+      fvar<double>,
+      return_type<double, fvar<double>, double, int, double, float, float,
+                  float, fvar<double>, int>::type>();
+}
+
+TEST(MetaTraits, ReturnTypeFvarFvarDoubleTenParams) {
   test::expect_same_type<
       fvar<fvar<double> >,
-      return_type<fvar<fvar<double> >, fvar<fvar<double> > >::type>();
-  test::expect_same_type<fvar<fvar<double> >,
-                         return_type<fvar<fvar<double> >, fvar<fvar<double> >,
-                                     fvar<fvar<double> > >::type>();
-  test::expect_same_type<
-      fvar<fvar<double> >,
-      return_type<fvar<fvar<double> >, fvar<fvar<double> >, double>::type>();
+      return_type<double, fvar<fvar<double> >, double, int, double, float,
+                  float, float, fvar<fvar<double> >, int>::type>();
 }

--- a/test/unit/math/mix/scal/meta/include_summand_test.cpp
+++ b/test/unit/math/mix/scal/meta/include_summand_test.cpp
@@ -2,25 +2,25 @@
 #include <gtest/gtest.h>
 #include <test/unit/util.hpp>
 
+using stan::math::fvar;
 using stan::math::include_summand;
 using stan::math::var;
-using stan::math::fvar;
 
 TEST(MetaTraits, IncludeSummandProptoTrueFvarVar) {
-  EXPECT_TRUE((include_summand<true,fvar<var> >::value));
+  EXPECT_TRUE((include_summand<true, fvar<var> >::value));
 }
 
 TEST(MetaTraits, IncludeSummandProptoTrueFvarFvarVar) {
-  EXPECT_TRUE((include_summand<true,fvar<fvar<var> > >::value));
+  EXPECT_TRUE((include_summand<true, fvar<fvar<var> > >::value));
 }
 
 TEST(MetaTraits, IncludeSummandProtoTrueFvarVarTen) {
-  EXPECT_TRUE((include_summand<true,double,fvar<var>,int,fvar<var>,double,
-                                double, int, int, fvar<var>, int>::value));
+  EXPECT_TRUE((include_summand<true, double, fvar<var>, int, fvar<var>, double,
+                               double, int, int, fvar<var>, int>::value));
 }
 
 TEST(MetaTraits, IncludeSummandProtoTrueFvarFvarVarTen) {
-  EXPECT_TRUE((include_summand<true,double,fvar<fvar<var> >,int,
-                                fvar<fvar<var> >,double,double, int,int,
-                                fvar<fvar<var> >, int>::value));
+  EXPECT_TRUE((
+      include_summand<true, double, fvar<fvar<var> >, int, fvar<fvar<var> >,
+                      double, double, int, int, fvar<fvar<var> >, int>::value));
 }

--- a/test/unit/math/mix/scal/meta/include_summand_test.cpp
+++ b/test/unit/math/mix/scal/meta/include_summand_test.cpp
@@ -1,0 +1,26 @@
+#include <stan/math/mix/scal.hpp>
+#include <gtest/gtest.h>
+#include <test/unit/util.hpp>
+
+using stan::math::include_summand;
+using stan::math::var;
+using stan::math::fvar;
+
+TEST(MetaTraits, IncludeSummandProptoTrueFvarVar) {
+  EXPECT_TRUE((include_summand<true,fvar<var> >::value));
+}
+
+TEST(MetaTraits, IncludeSummandProptoTrueFvarFvarVar) {
+  EXPECT_TRUE((include_summand<true,fvar<fvar<var> > >::value));
+}
+
+TEST(MetaTraits, IncludeSummandProtoTrueFvarVarTen) {
+  EXPECT_TRUE((include_summand<true,double,fvar<var>,int,fvar<var>,double,
+                                double, int, int, fvar<var>, int>::value));
+}
+
+TEST(MetaTraits, IncludeSummandProtoTrueFvarFvarVarTen) {
+  EXPECT_TRUE((include_summand<true,double,fvar<fvar<var> >,int,
+                                fvar<fvar<var> >,double,double, int,int,
+                                fvar<fvar<var> >, int>::value));
+}

--- a/test/unit/math/mix/scal/meta/partials_return_type_test.cpp
+++ b/test/unit/math/mix/scal/meta/partials_return_type_test.cpp
@@ -1,20 +1,31 @@
 #include <stan/math/mix/scal.hpp>
+
 #include <gtest/gtest.h>
+#include <test/unit/util.hpp>
 
-TEST(MetaTraits, partials_return_type) {
-  using stan::math::fvar;
-  using stan::math::var;
-  using stan::partials_return_type;
+using stan::partials_return_type;
+using stan::math::var;
+using stan::math::fvar;
 
-  partials_return_type<double, fvar<fvar<var> > >::type c(3.0, 2.0);
-  EXPECT_EQ(3.0, c.val_.val());
-  EXPECT_EQ(2.0, c.d_.val());
+TEST(MetaTraits, PartialsReturnTypeFvarVar) {
+  test::expect_same_type<var, partials_return_type<fvar<var> >::type>();
+}
 
-  partials_return_type<double, double, var, fvar<fvar<var> > >::type d(3.0,
-                                                                       2.0);
-  EXPECT_EQ(3.0, d.val_.val());
-  EXPECT_EQ(2.0, d.d_.val());
+TEST(MetaTraits, PartialsReturnTypeFvarFvarVar) {
+  test::expect_same_type<fvar<var>, partials_return_type<fvar<fvar<var> >
+                                                          >::type>();
+}
 
-  partials_return_type<double, double, var, fvar<var> >::type e(3.0);
-  EXPECT_EQ(3.0, e.val());
+TEST(MetaTraits, PartialsReturnTypeFvarVarTenParams) {
+  test::expect_same_type<
+      var, partials_return_type<double, fvar<var>, double, int, double,
+                                      float, float, float, fvar<var>,
+                                      int>::type>();
+}
+
+TEST(MetaTraits, PartialsReturnTypeFvarFvarVarTenParams) {
+  test::expect_same_type<
+      fvar<var>, partials_return_type<double, fvar<fvar<var> >, double,
+                                             int, double, float, float, float,
+                                             fvar<fvar<var> >, int>::type>();
 }

--- a/test/unit/math/mix/scal/meta/partials_return_type_test.cpp
+++ b/test/unit/math/mix/scal/meta/partials_return_type_test.cpp
@@ -3,29 +3,28 @@
 #include <gtest/gtest.h>
 #include <test/unit/util.hpp>
 
-using stan::partials_return_type;
-using stan::math::var;
 using stan::math::fvar;
+using stan::math::var;
+using stan::partials_return_type;
 
 TEST(MetaTraits, PartialsReturnTypeFvarVar) {
   test::expect_same_type<var, partials_return_type<fvar<var> >::type>();
 }
 
 TEST(MetaTraits, PartialsReturnTypeFvarFvarVar) {
-  test::expect_same_type<fvar<var>, partials_return_type<fvar<fvar<var> >
-                                                          >::type>();
+  test::expect_same_type<fvar<var>,
+                         partials_return_type<fvar<fvar<var> > >::type>();
 }
 
 TEST(MetaTraits, PartialsReturnTypeFvarVarTenParams) {
   test::expect_same_type<
-      var, partials_return_type<double, fvar<var>, double, int, double,
-                                      float, float, float, fvar<var>,
-                                      int>::type>();
+      var, partials_return_type<double, fvar<var>, double, int, double, float,
+                                float, float, fvar<var>, int>::type>();
 }
 
 TEST(MetaTraits, PartialsReturnTypeFvarFvarVarTenParams) {
   test::expect_same_type<
-      fvar<var>, partials_return_type<double, fvar<fvar<var> >, double,
-                                             int, double, float, float, float,
-                                             fvar<fvar<var> >, int>::type>();
+      fvar<var>,
+      partials_return_type<double, fvar<fvar<var> >, double, int, double, float,
+                           float, float, fvar<fvar<var> >, int>::type>();
 }

--- a/test/unit/math/mix/scal/meta/return_type_test.cpp
+++ b/test/unit/math/mix/scal/meta/return_type_test.cpp
@@ -6,7 +6,6 @@ using stan::math::fvar;
 using stan::math::var;
 using stan::return_type;
 
-
 TEST(MetaTraits, ReturnTypeFvarVar) {
   test::expect_same_type<fvar<var>, return_type<fvar<var> >::type>();
 }

--- a/test/unit/math/mix/scal/meta/return_type_test.cpp
+++ b/test/unit/math/mix/scal/meta/return_type_test.cpp
@@ -2,27 +2,29 @@
 #include <gtest/gtest.h>
 #include <test/unit/util.hpp>
 
-TEST(MetaTraits, ReturnTypeMix) {
-  using stan::math::fvar;
-  using stan::math::var;
-  using stan::return_type;
+using stan::math::fvar;
+using stan::math::var;
+using stan::return_type;
 
+
+TEST(MetaTraits, ReturnTypeFvarVar) {
   test::expect_same_type<fvar<var>, return_type<fvar<var> >::type>();
-  test::expect_same_type<fvar<var>, return_type<fvar<var>, fvar<var> >::type>();
-  test::expect_same_type<fvar<var>,
-                         return_type<fvar<var>, fvar<var>, fvar<var> >::type>();
-  test::expect_same_type<fvar<var>,
-                         return_type<fvar<var>, fvar<var>, var>::type>();
+}
 
+TEST(MetaTraits, ReturnTypeFvarFvarVar) {
   test::expect_same_type<fvar<fvar<var> >,
                          return_type<fvar<fvar<var> > >::type>();
+}
+
+TEST(MetaTraits, ReturnTypeFvarVarTenParams) {
+  test::expect_same_type<
+      fvar<var>, return_type<double, fvar<var>, double, int, double, float,
+                             float, float, fvar<var>, int>::type>();
+}
+
+TEST(MetaTraits, ReturnTypeFvarFvarVarTenParams) {
   test::expect_same_type<
       fvar<fvar<var> >,
-      return_type<fvar<fvar<var> >, fvar<fvar<var> > >::type>();
-  test::expect_same_type<fvar<fvar<var> >,
-                         return_type<fvar<fvar<var> >, fvar<fvar<var> >,
-                                     fvar<fvar<var> > >::type>();
-  test::expect_same_type<
-      fvar<fvar<var> >,
-      return_type<fvar<fvar<var> >, fvar<fvar<var> >, var>::type>();
+      return_type<double, fvar<fvar<var> >, double, int, double, float, float,
+                  float, fvar<fvar<var> >, int>::type>();
 }

--- a/test/unit/math/prim/scal/meta/include_summand_test.cpp
+++ b/test/unit/math/prim/scal/meta/include_summand_test.cpp
@@ -9,19 +9,19 @@ TEST(MetaTraits, IncludeSummandProptoFalse) {
 }
 
 TEST(MetaTraits, IncludeSummandProptoTrueInt) {
-  EXPECT_FALSE((include_summand<true,int>::value));
+  EXPECT_FALSE((include_summand<true, int>::value));
 }
 
 TEST(MetaTraits, IncludeSummandProptoTrueDouble) {
-  EXPECT_FALSE((include_summand<true,double>::value));
+  EXPECT_FALSE((include_summand<true, double>::value));
 }
 
 TEST(MetaTraits, IncludeSummandConstantPropToTrueTen) {
-  EXPECT_FALSE((include_summand<true,double,double,int,int,double,double,
+  EXPECT_FALSE((include_summand<true, double, double, int, int, double, double,
                                 int, int, double, int>::value));
 }
 
 TEST(MetaTraits, IncludeSummandConstantProptoFalseTen) {
-  EXPECT_TRUE((include_summand<false,double,double,int,int,double,double,
-                                int, int, double, int>::value));
+  EXPECT_TRUE((include_summand<false, double, double, int, int, double, double,
+                               int, int, double, int>::value));
 }

--- a/test/unit/math/prim/scal/meta/include_summand_test.cpp
+++ b/test/unit/math/prim/scal/meta/include_summand_test.cpp
@@ -1,0 +1,27 @@
+#include <stan/math/prim/scal.hpp>
+#include <gtest/gtest.h>
+#include <test/unit/util.hpp>
+
+using stan::math::include_summand;
+
+TEST(MetaTraits, IncludeSummandProptoFalse) {
+  EXPECT_TRUE(include_summand<false>::value);
+}
+
+TEST(MetaTraits, IncludeSummandProptoTrueInt) {
+  EXPECT_FALSE((include_summand<true,int>::value));
+}
+
+TEST(MetaTraits, IncludeSummandProptoTrueDouble) {
+  EXPECT_FALSE((include_summand<true,double>::value));
+}
+
+TEST(MetaTraits, IncludeSummandConstantPropToTrueTen) {
+  EXPECT_FALSE((include_summand<true,double,double,int,int,double,double,
+                                int, int, double, int>::value));
+}
+
+TEST(MetaTraits, IncludeSummandConstantProptoFalseTen) {
+  EXPECT_TRUE((include_summand<false,double,double,int,int,double,double,
+                                int, int, double, int>::value));
+}

--- a/test/unit/math/prim/scal/meta/partials_return_type_test.cpp
+++ b/test/unit/math/prim/scal/meta/partials_return_type_test.cpp
@@ -7,9 +7,9 @@
 #include <gtest/gtest.h>
 #include <test/unit/util.hpp>
 
-using stan::partials_return_type;
-using stan::math::var;
 using stan::math::fvar;
+using stan::math::var;
+using stan::partials_return_type;
 
 TEST(MetaTraits, PartialsReturnTypeDouble) {
   test::expect_same_type<double, partials_return_type<double>::type>();
@@ -24,8 +24,7 @@ TEST(MetaTraits, PartialsReturnTypeInt) {
 }
 
 TEST(MetaTraits, PartialsReturnTypeScalarTenParams) {
-  test::expect_same_type<double,
-                         partials_return_type<double, int, double, float, float,
-                                              double, float, int, double,
-                                              double>::type>();
+  test::expect_same_type<
+      double, partials_return_type<double, int, double, float, float, double,
+                                   float, int, double, double>::type>();
 }

--- a/test/unit/math/prim/scal/meta/partials_return_type_test.cpp
+++ b/test/unit/math/prim/scal/meta/partials_return_type_test.cpp
@@ -1,0 +1,31 @@
+#include <stan/math/prim/scal.hpp>
+#include <stan/math/rev/scal.hpp>
+#include <stan/math/rev/core.hpp>
+#include <stan/math/fwd/core.hpp>
+#include <stan/math/fwd/scal.hpp>
+
+#include <gtest/gtest.h>
+#include <test/unit/util.hpp>
+
+using stan::partials_return_type;
+using stan::math::var;
+using stan::math::fvar;
+
+TEST(MetaTraits, PartialsReturnTypeDouble) {
+  test::expect_same_type<double, partials_return_type<double>::type>();
+}
+
+TEST(MetaTraits, PartialsReturnTypeFloat) {
+  test::expect_same_type<double, partials_return_type<float>::type>();
+}
+
+TEST(MetaTraits, PartialsReturnTypeInt) {
+  test::expect_same_type<double, partials_return_type<int>::type>();
+}
+
+TEST(MetaTraits, PartialsReturnTypeScalarTenParams) {
+  test::expect_same_type<double,
+                         partials_return_type<double, int, double, float, float,
+                                              double, float, int, double,
+                                              double>::type>();
+}

--- a/test/unit/math/prim/scal/meta/return_type_test.cpp
+++ b/test/unit/math/prim/scal/meta/return_type_test.cpp
@@ -1,9 +1,12 @@
 #include <stan/math/prim/scal.hpp>
+#include <stan/math/rev/scal.hpp>
 #include <stan/math/rev/core.hpp>
+#include <stan/math/fwd/core.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/util.hpp>
 
 using stan::math::var;
+using stan::math::fvar;
 using stan::return_type;
 
 TEST(MetaTraits, ReturnTypeDouble) {
@@ -18,24 +21,62 @@ TEST(MetaTraits, ReturnTypeInt) {
   test::expect_same_type<double, return_type<int>::type>();
 }
 
-TEST(MetaTraits, ReturnTypeDoubleMany) {
-  test::expect_same_type<double,
-                         return_type<double, int, double, float, float, double,
-                                     float, int, double>::type>();
+TEST(MetaTraits, ReturnTypeVar) {
+  test::expect_same_type<var, return_type<var>::type>();
 }
 
-TEST(MetaTraits, ReturnTypeTwentyOneParams) {
+TEST(MetaTraits, ReturnTypeFvarDouble) {
+  test::expect_same_type<fvar<double>, return_type<fvar<double> >::type>();
+}
+
+TEST(MetaTraits, ReturnTypeFvarFvarDouble) {
+  test::expect_same_type<fvar<fvar<double> >, return_type<fvar<fvar<double> >
+                                                          >::type>();
+}
+
+TEST(MetaTraits, ReturnTypeFvarVar) {
+  test::expect_same_type<fvar<var>, return_type<fvar<var> >::type>();
+}
+
+TEST(MetaTraits, ReturnTypeFvarFvarVar) {
+  test::expect_same_type<fvar<fvar<var> >, return_type<fvar<fvar<var> >
+                                                          >::type>();
+}
+
+TEST(MetaTraits, ReturnTypeScalarTenParams) {
+  test::expect_same_type<double,
+                         return_type<double, int, double, float, float, double,
+                                     float, int, double, double>::type>();
+}
+
+TEST(MetaTraits, ReturnTypeVarTenParams) {
   test::expect_same_type<
       var, return_type<double, var, double, int, double, float, float, float,
-                       var, int, double, int, double, float, float, double, var,
-                       double, int, double, float>::type>();
+                       var, int>::type>();
+}
 
-  TEST(MetaTraits, ReturnTypeVarMany) {
-    test::expect_same_type<var,
-                           return_type<double, var, float, var, int, double,
-                                       int, double, float, float>::type>();
-  }
+TEST(MetaTraits, ReturnTypeFvarDoubleTenParams) {
+  test::expect_same_type<
+      fvar<double>, return_type<double, fvar<double>, double, int, double,
+                                float, float, float, fvar<double>, int>::type>();
+}
 
-  TEST(MetaTraits, ReturnTypeVarLast) {
-    test::expect_same_type<var, return_type<double, double, var>::type>();
-  }
+TEST(MetaTraits, ReturnTypeFvarFvarDoubleTenParams) {
+  test::expect_same_type<
+      fvar<fvar<double> >, return_type<double, fvar<fvar<double> >, double, int,
+                                       double, float, float, float,
+                                       fvar<fvar<double> >, int>::type>();
+}
+
+TEST(MetaTraits, ReturnTypeFvarVarTenParams) {
+  test::expect_same_type<
+      fvar<var>, return_type<double, fvar<var>, double, int, double, float,
+                             float, float, fvar<var>, int>::type>();
+}
+
+TEST(MetaTraits, ReturnTypeFvarFvarVarTenParams) {
+  test::expect_same_type<
+      fvar<fvar<var> >, return_type<double, fvar<fvar<var> >, double, int,
+                                    double, float, float, float,
+                                    fvar<fvar<var> >, int>::type>();
+}

--- a/test/unit/math/prim/scal/meta/return_type_test.cpp
+++ b/test/unit/math/prim/scal/meta/return_type_test.cpp
@@ -26,16 +26,17 @@ TEST(MetaTraits, ReturnTypeDoubleMany) {
 }
 
 TEST(MetaTraits, ReturnTypeTwentyOneParams) {
-  test::expect_same_type<var,
-       return_type<double, var, double, int, double, float, float, float,
+  test::expect_same_type<
+      var, return_type<double, var, double, int, double, float, float, float,
                        var, int, double, int, double, float, float, double, var,
                        double, int, double, float>::type>();
 
-TEST(MetaTraits, ReturnTypeVarMany) {
-  test::expect_same_type<var, return_type<double, var, float, var, int, double,
-                                          int, double, float, float>::type>();
-}
+  TEST(MetaTraits, ReturnTypeVarMany) {
+    test::expect_same_type<var,
+                           return_type<double, var, float, var, int, double,
+                                       int, double, float, float>::type>();
+  }
 
-TEST(MetaTraits, ReturnTypeVarLast) {
-  test::expect_same_type<var, return_type<double, double, var>::type>();
-}
+  TEST(MetaTraits, ReturnTypeVarLast) {
+    test::expect_same_type<var, return_type<double, double, var>::type>();
+  }

--- a/test/unit/math/prim/scal/meta/return_type_test.cpp
+++ b/test/unit/math/prim/scal/meta/return_type_test.cpp
@@ -1,8 +1,10 @@
 #include <stan/math/prim/scal.hpp>
+#include <stan/math/rev/core.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/util.hpp>
 
 using stan::return_type;
+using stan::math::var;
 
 TEST(MetaTraits, ReturnTypeDouble) {
   test::expect_same_type<double, return_type<double>::type>();
@@ -14,4 +16,17 @@ TEST(MetaTraits, ReturnTypeFloat) {
 
 TEST(MetaTraits, ReturnTypeInt) {
   test::expect_same_type<double, return_type<int>::type>();
+}
+
+TEST(MetaTraits, ReturnTypeDoubleMany) {
+  test::expect_same_type<double, return_type<double,int,double,float,float,double,float,int,double>::type>();
+}
+
+TEST(MetaTraits, ReturnTypeVarMany) {
+  test::expect_same_type<var, return_type<double,var,float,var,int,double,int,double,float,float>::type>();
+}
+
+
+TEST(MetaTraits, ReturnTypeVarLast) {
+  test::expect_same_type<var, return_type<double,double,var>::type>();
 }

--- a/test/unit/math/prim/scal/meta/return_type_test.cpp
+++ b/test/unit/math/prim/scal/meta/return_type_test.cpp
@@ -19,13 +19,15 @@ TEST(MetaTraits, ReturnTypeInt) {
 }
 
 TEST(MetaTraits, ReturnTypeDoubleMany) {
-  test::expect_same_type<double, return_type<double,int,double,float,float,double,float,int,double>::type>();
+  test::expect_same_type<double, return_type<double,int,double,float,float,
+    double,float,int,double>::type>();
 }
 
-TEST(MetaTraits, ReturnTypeVarMany) {
-  test::expect_same_type<var, return_type<double,var,float,var,int,double,int,double,float,float>::type>();
+TEST(MetaTraits, ReturnTypeTwentyOneParams) {
+  test::expect_same_type<var, return_type<double,var,double,int,double,float,
+     float,float,var,int,double,int,double,float,float,
+     double,var,double,int,double,float>::type>();
 }
-
 
 TEST(MetaTraits, ReturnTypeVarLast) {
   test::expect_same_type<var, return_type<double,double,var>::type>();

--- a/test/unit/math/prim/scal/meta/return_type_test.cpp
+++ b/test/unit/math/prim/scal/meta/return_type_test.cpp
@@ -1,12 +1,7 @@
 #include <stan/math/prim/scal.hpp>
-#include <stan/math/rev/scal.hpp>
-#include <stan/math/rev/core.hpp>
-#include <stan/math/fwd/core.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/util.hpp>
 
-using stan::math::fvar;
-using stan::math::var;
 using stan::return_type;
 
 TEST(MetaTraits, ReturnTypeDouble) {
@@ -21,63 +16,8 @@ TEST(MetaTraits, ReturnTypeInt) {
   test::expect_same_type<double, return_type<int>::type>();
 }
 
-TEST(MetaTraits, ReturnTypeVar) {
-  test::expect_same_type<var, return_type<var>::type>();
-}
-
-TEST(MetaTraits, ReturnTypeFvarDouble) {
-  test::expect_same_type<fvar<double>, return_type<fvar<double> >::type>();
-}
-
-TEST(MetaTraits, ReturnTypeFvarFvarDouble) {
-  test::expect_same_type<fvar<fvar<double> >,
-                         return_type<fvar<fvar<double> > >::type>();
-}
-
-TEST(MetaTraits, ReturnTypeFvarVar) {
-  test::expect_same_type<fvar<var>, return_type<fvar<var> >::type>();
-}
-
-TEST(MetaTraits, ReturnTypeFvarFvarVar) {
-  test::expect_same_type<fvar<fvar<var> >,
-                         return_type<fvar<fvar<var> > >::type>();
-}
-
 TEST(MetaTraits, ReturnTypeScalarTenParams) {
   test::expect_same_type<double,
                          return_type<double, int, double, float, float, double,
                                      float, int, double, double>::type>();
-}
-
-TEST(MetaTraits, ReturnTypeVarTenParams) {
-  test::expect_same_type<var,
-                         return_type<double, var, double, int, double, float,
-                                     float, float, var, int>::type>();
-}
-
-TEST(MetaTraits, ReturnTypeFvarDoubleTenParams) {
-  test::expect_same_type<
-      fvar<double>,
-      return_type<double, fvar<double>, double, int, double, float, float,
-                  float, fvar<double>, int>::type>();
-}
-
-TEST(MetaTraits, ReturnTypeFvarFvarDoubleTenParams) {
-  test::expect_same_type<
-      fvar<fvar<double> >,
-      return_type<double, fvar<fvar<double> >, double, int, double, float,
-                  float, float, fvar<fvar<double> >, int>::type>();
-}
-
-TEST(MetaTraits, ReturnTypeFvarVarTenParams) {
-  test::expect_same_type<
-      fvar<var>, return_type<double, fvar<var>, double, int, double, float,
-                             float, float, fvar<var>, int>::type>();
-}
-
-TEST(MetaTraits, ReturnTypeFvarFvarVarTenParams) {
-  test::expect_same_type<
-      fvar<fvar<var> >,
-      return_type<double, fvar<fvar<var> >, double, int, double, float, float,
-                  float, fvar<fvar<var> >, int>::type>();
 }

--- a/test/unit/math/prim/scal/meta/return_type_test.cpp
+++ b/test/unit/math/prim/scal/meta/return_type_test.cpp
@@ -19,7 +19,6 @@ TEST(MetaTraits, ReturnTypeInt) {
 }
 
 TEST(MetaTraits, ReturnTypeDoubleMany) {
-<<<<<<< HEAD
   test::expect_same_type<double,
                          return_type<double, int, double, float, float, double,
                                      float, int, double>::type>();

--- a/test/unit/math/prim/scal/meta/return_type_test.cpp
+++ b/test/unit/math/prim/scal/meta/return_type_test.cpp
@@ -5,8 +5,8 @@
 #include <gtest/gtest.h>
 #include <test/unit/util.hpp>
 
-using stan::math::var;
 using stan::math::fvar;
+using stan::math::var;
 using stan::return_type;
 
 TEST(MetaTraits, ReturnTypeDouble) {
@@ -30,8 +30,8 @@ TEST(MetaTraits, ReturnTypeFvarDouble) {
 }
 
 TEST(MetaTraits, ReturnTypeFvarFvarDouble) {
-  test::expect_same_type<fvar<fvar<double> >, return_type<fvar<fvar<double> >
-                                                          >::type>();
+  test::expect_same_type<fvar<fvar<double> >,
+                         return_type<fvar<fvar<double> > >::type>();
 }
 
 TEST(MetaTraits, ReturnTypeFvarVar) {
@@ -39,8 +39,8 @@ TEST(MetaTraits, ReturnTypeFvarVar) {
 }
 
 TEST(MetaTraits, ReturnTypeFvarFvarVar) {
-  test::expect_same_type<fvar<fvar<var> >, return_type<fvar<fvar<var> >
-                                                          >::type>();
+  test::expect_same_type<fvar<fvar<var> >,
+                         return_type<fvar<fvar<var> > >::type>();
 }
 
 TEST(MetaTraits, ReturnTypeScalarTenParams) {
@@ -50,22 +50,23 @@ TEST(MetaTraits, ReturnTypeScalarTenParams) {
 }
 
 TEST(MetaTraits, ReturnTypeVarTenParams) {
-  test::expect_same_type<
-      var, return_type<double, var, double, int, double, float, float, float,
-                       var, int>::type>();
+  test::expect_same_type<var,
+                         return_type<double, var, double, int, double, float,
+                                     float, float, var, int>::type>();
 }
 
 TEST(MetaTraits, ReturnTypeFvarDoubleTenParams) {
   test::expect_same_type<
-      fvar<double>, return_type<double, fvar<double>, double, int, double,
-                                float, float, float, fvar<double>, int>::type>();
+      fvar<double>,
+      return_type<double, fvar<double>, double, int, double, float, float,
+                  float, fvar<double>, int>::type>();
 }
 
 TEST(MetaTraits, ReturnTypeFvarFvarDoubleTenParams) {
   test::expect_same_type<
-      fvar<fvar<double> >, return_type<double, fvar<fvar<double> >, double, int,
-                                       double, float, float, float,
-                                       fvar<fvar<double> >, int>::type>();
+      fvar<fvar<double> >,
+      return_type<double, fvar<fvar<double> >, double, int, double, float,
+                  float, float, fvar<fvar<double> >, int>::type>();
 }
 
 TEST(MetaTraits, ReturnTypeFvarVarTenParams) {
@@ -76,7 +77,7 @@ TEST(MetaTraits, ReturnTypeFvarVarTenParams) {
 
 TEST(MetaTraits, ReturnTypeFvarFvarVarTenParams) {
   test::expect_same_type<
-      fvar<fvar<var> >, return_type<double, fvar<fvar<var> >, double, int,
-                                    double, float, float, float,
-                                    fvar<fvar<var> >, int>::type>();
+      fvar<fvar<var> >,
+      return_type<double, fvar<fvar<var> >, double, int, double, float, float,
+                  float, fvar<fvar<var> >, int>::type>();
 }

--- a/test/unit/math/rev/scal/meta/include_summand_test.cpp
+++ b/test/unit/math/rev/scal/meta/include_summand_test.cpp
@@ -1,0 +1,15 @@
+#include <stan/math/rev/scal.hpp>
+#include <gtest/gtest.h>
+#include <test/unit/util.hpp>
+
+using stan::math::include_summand;
+using stan::math::var;
+
+TEST(MetaTraits, IncludeSummandProptoTrueVar) {
+  EXPECT_TRUE((include_summand<true,var>::value));
+}
+
+TEST(MetaTraits, IncludeSummandProtoTrueVarTen) {
+  EXPECT_TRUE((include_summand<true,double,var,int,var,double,double,
+                                int, int, var, int>::value));
+}

--- a/test/unit/math/rev/scal/meta/include_summand_test.cpp
+++ b/test/unit/math/rev/scal/meta/include_summand_test.cpp
@@ -6,10 +6,10 @@ using stan::math::include_summand;
 using stan::math::var;
 
 TEST(MetaTraits, IncludeSummandProptoTrueVar) {
-  EXPECT_TRUE((include_summand<true,var>::value));
+  EXPECT_TRUE((include_summand<true, var>::value));
 }
 
 TEST(MetaTraits, IncludeSummandProtoTrueVarTen) {
-  EXPECT_TRUE((include_summand<true,double,var,int,var,double,double,
-                                int, int, var, int>::value));
+  EXPECT_TRUE((include_summand<true, double, var, int, var, double, double, int,
+                               int, var, int>::value));
 }

--- a/test/unit/math/rev/scal/meta/partials_return_type_test.cpp
+++ b/test/unit/math/rev/scal/meta/partials_return_type_test.cpp
@@ -3,8 +3,8 @@
 #include <gtest/gtest.h>
 #include <test/unit/util.hpp>
 
-using stan::partials_return_type;
 using stan::math::var;
+using stan::partials_return_type;
 
 TEST(MetaTraits, PartialsReturnTypeVar) {
   test::expect_same_type<double, partials_return_type<var>::type>();

--- a/test/unit/math/rev/scal/meta/partials_return_type_test.cpp
+++ b/test/unit/math/rev/scal/meta/partials_return_type_test.cpp
@@ -1,10 +1,17 @@
 #include <stan/math/rev/scal.hpp>
+
 #include <gtest/gtest.h>
+#include <test/unit/util.hpp>
 
-TEST(MetaTraits, partials_return_type) {
-  using stan::math::var;
-  using stan::partials_return_type;
+using stan::partials_return_type;
+using stan::math::var;
 
-  partials_return_type<double, stan::math::var>::type f(5.0);
-  EXPECT_EQ(5.0, f);
+TEST(MetaTraits, PartialsReturnTypeVar) {
+  test::expect_same_type<double, partials_return_type<var>::type>();
+}
+
+TEST(MetaTraits, PartialsReturnTypeVarTenParams) {
+  test::expect_same_type<
+      double, partials_return_type<double, var, double, int, double, float,
+                                   float, float, var, int>::type>();
 }

--- a/test/unit/math/rev/scal/meta/return_type_test.cpp
+++ b/test/unit/math/rev/scal/meta/return_type_test.cpp
@@ -5,7 +5,6 @@
 using stan::math::var;
 using stan::return_type;
 
-
 TEST(MetaTraits, ReturnTypeVar) {
   test::expect_same_type<var, return_type<var>::type>();
 }

--- a/test/unit/math/rev/scal/meta/return_type_test.cpp
+++ b/test/unit/math/rev/scal/meta/return_type_test.cpp
@@ -1,0 +1,17 @@
+#include <stan/math/rev/scal.hpp>
+#include <gtest/gtest.h>
+#include <test/unit/util.hpp>
+
+using stan::math::var;
+using stan::return_type;
+
+
+TEST(MetaTraits, ReturnTypeVar) {
+  test::expect_same_type<var, return_type<var>::type>();
+}
+
+TEST(MetaTraits, ReturnTypeVarTenParams) {
+  test::expect_same_type<var,
+                         return_type<double, var, double, int, double, float,
+                                     float, float, var, int>::type>();
+}


### PR DESCRIPTION
## Summary

I replace the code in `return_type`, `partials_return_type` and `include_summand` to use variadic template parameters. This should make it unnecessary to keep expanding the code every time we need a function that takes more arguments.

I'm not 100% happy with the base case in `include_summand`, I feel like it should be `include_summand<bool propto>` but I couldn't make partial specialization work with a non-type template parameter. I imagine that it's something dumb I did.

The two return_type programs promote everything lower in precedence to `double`, which is consistent with the existing behaviour. 

## Tests

I wrote new tests for `partials_return_type` and `include_summand`.  I expanded the test for `return_type`.
- All the tests have multiple types (including `var`)
- All the `*return_type` tests test `int` and `float` (consistent with existing tests) and put `var`s in various places in the template arguments.
- The `include_summand` tests cover no types + `propto=false`, `propto=true` + `double` types, `propto = true` + a mixture of `double` and `var`

This is a kinda important piece of code, so let me know if I missed any tests

## Side Effects

None. 

## Checklist

- [x] Math issue #977 

- [ ] Copyright holder: Daniel Simpson 


    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [ ] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`) (Passes)
    - docs build, (`make doxygen`) (Error)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`) (Passes)

- [ ] the code is written in idiomatic C++ and changes are documented in the doxygen

- [ ]the new changes are tested
