### PR TITLE
make MPI build more robust

### DIFF
--- a/make/libraries
+++ b/make/libraries
@@ -68,6 +68,10 @@ $(BOOST)/user-config.jam:
 	echo "# In case of a compiler mismatch used by mpicxx and" >> $(BOOST)/user-config.jam
 	echo "# the compiler used for Stan, consider configuring" >> $(BOOST)/user-config.jam
 	echo "# the boost toolset here" >> $(BOOST)/user-config.jam
+	echo "# Moreover, should your mpicxx command live in a" >> $(BOOST)/user-config.jam
+	echo "# in a non-standard directory, then consider to tell" >> $(BOOST)/user-config.jam
+	echo "# boost mpi using this syntax:" >> $(BOOST)/user-config.jam
+	echo "#using mpi : /path/to/mpicxx ;" >> $(BOOST)/user-config.jam
 	echo "using mpi ;" >> $(BOOST)/user-config.jam
 
 $(BOOST_LIB)/mpi.so: $(BOOST)/user-config.jam

--- a/make/setup_mpi
+++ b/make/setup_mpi
@@ -9,5 +9,5 @@
 ifdef STAN_MPI
   LIBMPI = $(BOOST_LIB)/libboost_serialization$(DLL) $(BOOST_LIB)/libboost_mpi$(DLL) $(MATH)bin/math/prim/arr/functor/mpi_cluster_inst.o
   CXXFLAGS_MPI = -DSTAN_MPI
-  LDFLAGS_MPI ?= -Wl,-lboost_mpi -Wl,-lboost_serialization -Wl,-L,"$(BOOST_LIB_ABS)" -Wl,-rpath,"$(BOOST_LIB_ABS)"
+  LDFLAGS_MPI ?= -Wl,-L,"$(BOOST_LIB_ABS)" -Wl,-rpath,"$(BOOST_LIB_ABS)"
 endif


### PR DESCRIPTION
## Summary

The intend of the PR is make the MPI build more robust. The old MPI makefiles did link against old system installed boost libraries in case those are installed. This change avoids this by not using the `-l` linker flags, but instead give the linker directly the `.so` (Linux) or `.dylib` (MacOS) files to avoid any confusion.

In addition, this PR adds some more information to `lib/boost*/user_config.jam` for non-standard system setups of MPI.

(@syclik It looks like the bigger makefile refactor takes a moment longer, so it will be good to get this in sooner if possible)

## Tests

Sorry, but additional tests are over my head. To trigger the bug, please setup a system with an outdated boost. Only this new PR will manage to link against the stan-mth provided boost and avoid the outdated system boost.

## Side Effects

No

## Checklist

- [X] Math issue #990

- [X] Copyright holder: Sebastian Weber

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [ ] the new changes are tested... I don't see how
