### PR TITLE
Fixed initialization and test naming for bernoulli_logit_glm_lpmf 

### DIFF
--- a/test/unit/math/rev/mat/prob/bernoulli_logit_glm_lpmf_test.cpp
+++ b/test/unit/math/rev/mat/prob/bernoulli_logit_glm_lpmf_test.cpp
@@ -316,7 +316,8 @@ TEST(ProbDistributionsBernoulliLogitGLM,
 }
 
 //  We check that the right errors are thrown.
-TEST(ProbDistributionsPoissonLogGLM, glm_matches_poisson_log_error_checking) {
+TEST(ProbDistributionsPoissonLogGLM,
+     glm_matches_bernoulli_logit_error_checking) {
   int N = 3;
   int M = 2;
   int W = 4;
@@ -335,7 +336,7 @@ TEST(ProbDistributionsPoissonLogGLM, glm_matches_poisson_log_error_checking) {
   }
   Eigen::Matrix<int, -1, 1> yw3(N, 1);
   for (int n = 0; n < N; n++) {
-    yw2[n] = 42 + (Eigen::Matrix<uint, -1, 1>::Random(1, 1)[0] % 2);
+    yw3[n] = 42 + (Eigen::Matrix<uint, -1, 1>::Random(1, 1)[0] % 2);
   }
   Eigen::Matrix<double, -1, -1> x = Eigen::Matrix<double, -1, -1>::Random(N, M);
   Eigen::Matrix<double, -1, -1> xw1


### PR DESCRIPTION
This should fix #995. Since that is a randomly occurring variable then I guess if this passes we don't really know if it was fixed. But it definitely fixes something in the right place!

## Checklist

- [x] Math issue #995

- [x] Copyright holder: Columbia University

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [ ] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [ ] the new changes are tested
