### PR TITLE
ensure that boost hard-codes dll paths

### DIFF
--- a/make/libraries
+++ b/make/libraries
@@ -77,7 +77,7 @@ $(BOOST)/user-config.jam:
 $(BOOST_LIB)/mpi.so: $(BOOST)/user-config.jam
 	@mkdir -p $(dir $@)
 	cd $(BOOST); ./bootstrap.sh
-	cd $(BOOST); ./b2 --user-config=user-config.jam --layout=system --with-mpi --with-serialization -j$(BOOST_PARALLEL_BUILD) variant=release link=shared threading=multi runtime-link=shared
+	cd $(BOOST); ./b2 --user-config=user-config.jam --layout=system --with-mpi --with-serialization -j$(BOOST_PARALLEL_BUILD) variant=release link=shared threading=multi runtime-link=shared hardcode-dll-paths=true dll-path="$(BOOST_LIB_ABS)"
 
 $(BOOST_LIB)/libboost_serialization.so: $(BOOST_LIB)/mpi.so
 


### PR DESCRIPTION
## Summary

This fixes issue #1002 . The boost build system is instructed to include the absolute path to the dynamic libraries which we build. This ensures a safe use of the shared libraries on Linux.

## Tests

None.

## Side Effects

No. This should make the use of the build dynamic libraries more robust.

## Checklist

- [X] Math issue #1002 

- [X] Copyright holder: Sebastian Weber

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [ ] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [ ] the code is written in idiomatic C++ and changes are documented in the doxygen

- [ ] the new changes are tested
