### PR TITLE
Template prim sum's return type on eigen matrices (code cleanup #987)

### DIFF
--- a/stan/math/prim/arr/fun/sum.hpp
+++ b/stan/math/prim/arr/fun/sum.hpp
@@ -3,6 +3,7 @@
 
 #include <cstddef>
 #include <vector>
+#include <numeric>
 
 namespace stan {
 namespace math {
@@ -16,12 +17,7 @@ namespace math {
  */
 template <typename T>
 inline T sum(const std::vector<T>& xs) {
-  if (xs.size() == 0)
-    return 0;
-  T sum(xs[0]);
-  for (size_t i = 1; i < xs.size(); ++i)
-    sum += xs[i];
-  return sum;
+  return std::accumulate(xs.begin(), xs.end(), T{0});
 }
 
 }  // namespace math

--- a/stan/math/prim/mat/fun/sum.hpp
+++ b/stan/math/prim/mat/fun/sum.hpp
@@ -19,7 +19,7 @@ namespace math {
  * @return Sum of coefficients of vector.
  */
 template <typename T, int R, int C>
-inline double sum(const Eigen::Matrix<T, R, C>& v) {
+inline T sum(const Eigen::Matrix<T, R, C>& v) {
   return v.sum();
 }
 

--- a/test/unit/math/prim/mat/fun/sum_test.cpp
+++ b/test/unit/math/prim/mat/fun/sum_test.cpp
@@ -2,6 +2,7 @@
 #include <gtest/gtest.h>
 #include <test/unit/util.hpp>
 #include <type_traits>
+#include <vector>
 
 TEST(MathMatrix, sumVector) {
   using Eigen::Dynamic;

--- a/test/unit/math/prim/mat/fun/sum_test.cpp
+++ b/test/unit/math/prim/mat/fun/sum_test.cpp
@@ -3,8 +3,6 @@
 #include <test/unit/util.hpp>
 #include <type_traits>
 
-
-
 TEST(MathMatrix, sumVector) {
   using Eigen::Dynamic;
   using Eigen::Matrix;

--- a/test/unit/math/prim/mat/fun/sum_test.cpp
+++ b/test/unit/math/prim/mat/fun/sum_test.cpp
@@ -1,5 +1,9 @@
 #include <stan/math/prim/mat.hpp>
 #include <gtest/gtest.h>
+#include <test/unit/util.hpp>
+#include <type_traits>
+
+
 
 TEST(MathMatrix, sumVector) {
   using Eigen::Dynamic;
@@ -53,4 +57,14 @@ TEST(MathMatrix, sumMatrix) {
   m = stan::math::matrix_d(3, 2);
   m << 1, 2, 3, 4, 5, 6;
   EXPECT_FLOAT_EQ(21.0, sum(m));
+}
+
+template <typename T>
+using sum_return_t = decltype(stan::math::sum(std::declval<T>()));
+
+TEST(MathMatrix, sumIsTemplated) {
+  using Eigen::Matrix;
+  test::expect_same_type<int, sum_return_t<Matrix<int, 2, 3>>>();
+  test::expect_same_type<double, sum_return_t<Matrix<double, 4, 2>>>();
+  test::expect_same_type<float, sum_return_t<std::vector<float>>>();
 }


### PR DESCRIPTION
## Summary

This fixes a little bug that @bbbales2 noted in #987: prim's implementation of `sum` for Eigen::Matrix was always returning `double`, rather than its argument's (templated) element type. Per our discussion in the issue, I've also replaced `sum`'s implementation for `std::vector` with the standard library algorithm `std::accumulate`.

## Tests

One new test that makes sure that `sum` has the right return type for various argument types. Any other return cases I should check?

## Side Effects

None.

## Checklist

- [x] #987 

- [ ] Copyright holder: (fill in copyright holder information)

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [ ] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
