### PR TITLE
Use Eigen's allFinite to cut execution time of normal_glm (and others?) by 27%

### DIFF
--- a/stan/math/prim/mat.hpp
+++ b/stan/math/prim/mat.hpp
@@ -25,6 +25,7 @@
 #include <stan/math/prim/mat/err/check_column_index.hpp>
 #include <stan/math/prim/mat/err/check_corr_matrix.hpp>
 #include <stan/math/prim/mat/err/check_cov_matrix.hpp>
+#include <stan/math/prim/mat/err/check_finite.hpp>
 #include <stan/math/prim/mat/err/check_ldlt_factor.hpp>
 #include <stan/math/prim/mat/err/check_lower_triangular.hpp>
 #include <stan/math/prim/mat/err/check_matching_dims.hpp>

--- a/stan/math/prim/mat/err/check_finite.hpp
+++ b/stan/math/prim/mat/err/check_finite.hpp
@@ -1,8 +1,10 @@
 #ifndef STAN_MATH_PRIM_MAT_ERR_CHECK_FINITE_HPP
 #define STAN_MATH_PRIM_MAT_ERR_CHECK_FINITE_HPP
 
-#include <Eigen/Dense>
+#include <stan/math/prim/scal/err/domain_error.hpp>
 #include <stan/math/prim/scal/err/check_finite.hpp>
+#include <Eigen/Dense>
+#include <boost/math/special_functions/fpclassify.hpp>
 
 namespace stan {
 namespace math {
@@ -11,8 +13,13 @@ template <typename T, int R, int C>
 struct finite<Eigen::Matrix<T, R, C>, true> {
   static void check(const char* function, const char* name,
                     const Eigen::Matrix<T, R, C>& y) {
-    if (!y.allFinite())
-      domain_error(function, name, y, "is ", ", but must be finite!");
+    if (!y.allFinite()) {
+      for (int n = 0; n < y.size(); ++n) {
+        if (!(boost::math::isfinite)(y(n)))
+          domain_error_vec(function, name, y, n, "is ",
+                           ", but must be finite!");
+      }
+    }
   }
 };
 }  // namespace

--- a/stan/math/prim/mat/err/check_finite.hpp
+++ b/stan/math/prim/mat/err/check_finite.hpp
@@ -1,0 +1,22 @@
+#ifndef STAN_MATH_PRIM_MAT_ERR_CHECK_FINITE_HPP
+#define STAN_MATH_PRIM_MAT_ERR_CHECK_FINITE_HPP
+
+#include <Eigen/Dense>
+#include <stan/math/prim/scal/err/check_finite.hpp>
+
+namespace stan {
+namespace math {
+namespace {
+template <typename T, int R, int C>
+struct finite<Eigen::Matrix<T, R, C>, true> {
+  static void check(const char* function, const char* name,
+                    const Eigen::Matrix<T, R, C>& y) {
+    if (!y.allFinite())
+      domain_error(function, name, y, "is ", ", but must be finite!");
+  }
+};
+}
+}
+}
+
+#endif

--- a/stan/math/prim/mat/err/check_finite.hpp
+++ b/stan/math/prim/mat/err/check_finite.hpp
@@ -15,8 +15,8 @@ struct finite<Eigen::Matrix<T, R, C>, true> {
       domain_error(function, name, y, "is ", ", but must be finite!");
   }
 };
-}
-}
-}
+}  // namespace
+}  // namespace math
+}  // namespace stan
 
 #endif

--- a/stan/math/prim/mat/err/check_finite.hpp
+++ b/stan/math/prim/mat/err/check_finite.hpp
@@ -3,6 +3,7 @@
 
 #include <stan/math/prim/scal/err/domain_error.hpp>
 #include <stan/math/prim/scal/err/check_finite.hpp>
+#include <stan/math/prim/mat/fun/value_of.hpp>
 #include <Eigen/Dense>
 #include <boost/math/special_functions/fpclassify.hpp>
 
@@ -13,7 +14,7 @@ template <typename T, int R, int C>
 struct finite<Eigen::Matrix<T, R, C>, true> {
   static void check(const char* function, const char* name,
                     const Eigen::Matrix<T, R, C>& y) {
-    if (!y.allFinite()) {
+    if (!value_of(y).allFinite()) {
       for (int n = 0; n < y.size(); ++n) {
         if (!(boost::math::isfinite)(y(n)))
           domain_error_vec(function, name, y, n, "is ",


### PR DESCRIPTION
For background discussion, see [this thread](https://discourse.mc-stan.org/t/potential-slowness-in-operands-and-partials/5343/15)
## Checklist

- [x] Copyright holder: (fill in copyright holder information)

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses: Columbia University
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [ ] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
