### PR TITLE
Fix typing mistakes in prim/scal operands_and_partials for more performance

### DIFF
--- a/stan/math/prim/mat/meta/operands_and_partials.hpp
+++ b/stan/math/prim/mat/meta/operands_and_partials.hpp
@@ -22,7 +22,7 @@ class ops_partials_edge<ViewElt, Eigen::Matrix<Op, R, C>> {
   partials_t partials_;
   empty_broadcast_array<partials_t, Eigen::Matrix<Op, R, C>> partials_vec_;
   ops_partials_edge() {}
-  explicit ops_partials_edge(const Eigen::Matrix<Op, R, C> ops) {}
+  explicit ops_partials_edge(const Eigen::Matrix<Op, R, C>& /* ops */) {}
 
  private:
   template <typename, typename, typename, typename, typename, typename>
@@ -40,7 +40,8 @@ class ops_partials_edge<ViewElt, std::vector<Eigen::Matrix<Op, R, C>>> {
   typedef empty_broadcast_array<ViewElt, Eigen::Matrix<Op, R, C>> partials_t;
   empty_broadcast_array<partials_t, Eigen::Matrix<Op, R, C>> partials_vec_;
   ops_partials_edge() {}
-  explicit ops_partials_edge(const std::vector<Eigen::Matrix<Op, R, C>> ops) {}
+  explicit ops_partials_edge(
+      const std::vector<Eigen::Matrix<Op, R, C>>& /* ops */) {}
 
  private:
   template <typename, typename, typename, typename, typename, typename>
@@ -60,7 +61,7 @@ class ops_partials_edge<ViewElt, std::vector<std::vector<Op>>> {
   partials_t partials_;
   empty_broadcast_array<partials_t, std::vector<std::vector<Op>>> partials_vec_;
   ops_partials_edge() {}
-  explicit ops_partials_edge(const std::vector<std::vector<Op>> ops) {}
+  explicit ops_partials_edge(const std::vector<std::vector<Op>>& /* ops */) {}
 
  private:
   template <typename, typename, typename, typename, typename, typename>

--- a/stan/math/prim/scal/meta/operands_and_partials.hpp
+++ b/stan/math/prim/scal/meta/operands_and_partials.hpp
@@ -89,13 +89,15 @@ template <typename Op1, typename Op2, typename Op3, typename Op4, typename Op5,
           typename T_return_type>
 class operands_and_partials {
  public:
-  explicit operands_and_partials(const Op1& op1) {}
-  operands_and_partials(const Op1& op1, const Op2& op2) {}
-  operands_and_partials(const Op1& op1, const Op2& op2, const Op3& op3) {}
-  operands_and_partials(const Op1& op1, const Op2& op2, const Op3& op3,
-                        const Op4& op4) {}
-  operands_and_partials(const Op1& op1, const Op2& op2, const Op3& op3,
-                        const Op4& op4, const Op5& op5) {}
+  explicit operands_and_partials(const Op1& /* op1 */) {}
+  operands_and_partials(const Op1& /* op1 */, const Op2& /* op2 */) {}
+  operands_and_partials(const Op1& /* op1 */, const Op2& /* op2 */,
+                        const Op3& /* op3 */) {}
+  operands_and_partials(const Op1& /* op1 */, const Op2& /* op2 */,
+                        const Op3& /* op3 */, const Op4& /* op4 */) {}
+  operands_and_partials(const Op1& /* op1 */, const Op2& /* op2 */,
+                        const Op3& /* op3 */, const Op4& /* op4 */,
+                        const Op5& /* op5 */) {}
 
   /**
    * Build the node to be stored on the autodiff graph.


### PR DESCRIPTION
Check the diff to see what I mean. Turns out there were a lot of extraneous copies due to the missing `&` that caused a lot of consternation in [this thread](https://discourse.mc-stan.org/t/potential-slowness-in-operands-and-partials/5343/20) (not required reading).

## Checklist
- [x] Copyright holder: (fill in copyright holder information)

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses: Columbia University
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
