### PR TITLE
Feature/issue 1018 beta proportion log functions

### DIFF
--- a/stan/math/prim/scal.hpp
+++ b/stan/math/prim/scal.hpp
@@ -195,10 +195,6 @@
 #include <stan/math/prim/scal/prob/beta_binomial_log.hpp>
 #include <stan/math/prim/scal/prob/beta_binomial_lpmf.hpp>
 #include <stan/math/prim/scal/prob/beta_binomial_rng.hpp>
-#include <stan/math/prim/scal/prob/beta_proportion_lccdf.hpp>
-#include <stan/math/prim/scal/prob/beta_proportion_lcdf.hpp>
-#include <stan/math/prim/scal/prob/beta_proportion_lpdf.hpp>
-#include <stan/math/prim/scal/prob/beta_proportion_rng.hpp>
 #include <stan/math/prim/scal/prob/beta_ccdf_log.hpp>
 #include <stan/math/prim/scal/prob/beta_cdf.hpp>
 #include <stan/math/prim/scal/prob/beta_cdf_log.hpp>
@@ -207,6 +203,13 @@
 #include <stan/math/prim/scal/prob/beta_log.hpp>
 #include <stan/math/prim/scal/prob/beta_lpdf.hpp>
 #include <stan/math/prim/scal/prob/beta_rng.hpp>
+#include <stan/math/prim/scal/prob/beta_proportion_ccdf_log.hpp>
+#include <stan/math/prim/scal/prob/beta_proportion_cdf_log.hpp>
+#include <stan/math/prim/scal/prob/beta_proportion_lccdf.hpp>
+#include <stan/math/prim/scal/prob/beta_proportion_lcdf.hpp>
+#include <stan/math/prim/scal/prob/beta_proportion_log.hpp>
+#include <stan/math/prim/scal/prob/beta_proportion_lpdf.hpp>
+#include <stan/math/prim/scal/prob/beta_proportion_rng.hpp>
 #include <stan/math/prim/scal/prob/binomial_ccdf_log.hpp>
 #include <stan/math/prim/scal/prob/binomial_cdf.hpp>
 #include <stan/math/prim/scal/prob/binomial_cdf_log.hpp>

--- a/stan/math/prim/scal/prob/beta_proportion_ccdf_log.hpp
+++ b/stan/math/prim/scal/prob/beta_proportion_ccdf_log.hpp
@@ -17,13 +17,13 @@ namespace math {
  *
  * @deprecated use <code>beta_proportion_lccdf</code>
  *
- * @tparam T_y type of probability parameter
+ * @tparam T_y type of y
  * @tparam T_loc type of location parameter
  * @tparam T_prec type of precision parameter
- * @param y type of probability parameter
- * @param mu location parameter
- * @param kappa precision parameter
- * @return log probability or log sum of probabilities
+ * @param y (Sequence of) scalar(s) between zero and one
+ * @param mu (Sequence of) location parameter(s)
+ * @param kappa (Sequence of) precision parameter(s)
+ * @return log probability or sum of log of probabilities
  * @throw std::domain_error if mu is outside (0, 1)
  * @throw std::domain_error if kappa is nonpositive
  * @throw std::domain_error if 1 - y is not a valid probability

--- a/stan/math/prim/scal/prob/beta_proportion_ccdf_log.hpp
+++ b/stan/math/prim/scal/prob/beta_proportion_ccdf_log.hpp
@@ -1,0 +1,40 @@
+#ifndef STAN_MATH_PRIM_SCAL_PROB_BETA_CCDF_LOG_HPP
+#define STAN_MATH_PRIM_SCAL_PROB_BETA_CCDF_LOG_HPP
+
+#include <stan/math/prim/scal/meta/return_type.hpp>
+#include <stan/math/prim/scal/prob/beta_proportion_lccdf.hpp>
+
+namespace stan {
+namespace math {
+
+/**
+ * Returns the beta log complementary cumulative distribution function
+ * for specified probability, location, and precision parameters:
+ * beta_proportion_lccdf(y | mu, kappa) = beta_lccdf(y | mu * kappa, (1 -
+ * mu) * kappa).  Any arguments other than scalars must be containers of
+ * the same size.  With non-scalar arguments, the return is the sum of
+ * the log ccdfs with scalars broadcast as necessary.
+ *
+ * @deprecated use <code>beta_proportion_lccdf</code>
+ *
+ * @tparam T_y type of probability parameter
+ * @tparam T_loc type of location parameter
+ * @tparam T_prec type of precision parameter
+ * @param y type of probability parameter
+ * @param mu location parameter
+ * @param kappa precision parameter
+ * @return log probability or log sum of probabilities
+ * @throw std::domain_error if mu is outside (0, 1)
+ * @throw std::domain_error if kappa is nonpositive
+ * @throw std::domain_error if 1 - y is not a valid probability
+ * @throw std::invalid_argument if container sizes mismatch
+ */
+template <typename T_y, typename T_loc, typename T_prec>
+typename return_type<T_y, T_loc, T_prec>::type beta_proportion_ccdf_log(
+    const T_y& y, const T_loc& mu, const T_prec& kappa) {
+  return beta_proportion_lccdf<T_y, T_loc, T_prec>(y, mu, kappa);
+}
+
+}  // namespace math
+}  // namespace stan
+#endif

--- a/stan/math/prim/scal/prob/beta_proportion_ccdf_log.hpp
+++ b/stan/math/prim/scal/prob/beta_proportion_ccdf_log.hpp
@@ -1,5 +1,5 @@
-#ifndef STAN_MATH_PRIM_SCAL_PROB_BETA_CCDF_LOG_HPP
-#define STAN_MATH_PRIM_SCAL_PROB_BETA_CCDF_LOG_HPP
+#ifndef STAN_MATH_PRIM_SCAL_PROB_BETA_PROPORTION_CCDF_LOG_HPP
+#define STAN_MATH_PRIM_SCAL_PROB_BETA_PROPORTION_CCDF_LOG_HPP
 
 #include <stan/math/prim/scal/meta/return_type.hpp>
 #include <stan/math/prim/scal/prob/beta_proportion_lccdf.hpp>

--- a/stan/math/prim/scal/prob/beta_proportion_cdf_log.hpp
+++ b/stan/math/prim/scal/prob/beta_proportion_cdf_log.hpp
@@ -1,0 +1,40 @@
+#ifndef STAN_MATH_PRIM_SCAL_PROB_BETA_CDF_LOG_HPP
+#define STAN_MATH_PRIM_SCAL_PROB_BETA_CDF_LOG_HPP
+
+#include <stan/math/prim/scal/meta/return_type.hpp>
+#include <stan/math/prim/scal/prob/beta_proportion_lcdf.hpp>
+
+namespace stan {
+namespace math {
+
+/**
+ * Returns the beta log cumulative distribution function
+ * for specified probability, location, and precision parameters:
+ * beta_proportion_lcdf(y | mu, kappa) = beta_lcdf(y | mu * kappa, (1 -
+ * mu) * kappa).  Any arguments other than scalars must be containers of
+ * the same size.  With non-scalar arguments, the return is the sum of
+ * the log cdfs with scalars broadcast as necessary.
+ *
+ * @deprecated use <code>beta_proportion_lcdf</code>
+ *
+ * @tparam T_y type of probability parameter
+ * @tparam T_loc type of location parameter
+ * @tparam T_prec type of precision parameter
+ * @param y probability parameter
+ * @param mu location parameter
+ * @param kappa precision parameter
+ * @return log probability or log sum of probabilities
+ * @throw std::domain_error if mu is outside of (0, 1)
+ * @throw std::domain_error if kappa is nonpositive
+ * @throw std::domain_error if y is not a valid probability
+ * @throw std::invalid_argument if container sizes mismatch
+ */
+template <typename T_y, typename T_loc, typename T_prec>
+typename return_type<T_y, T_loc, T_prec>::type beta_proportion_cdf_log(
+    const T_y& y, const T_loc& mu, const T_prec& kappa) {
+  return beta_proportion_lcdf<T_y, T_loc, T_prec>(y, mu, kappa);
+}
+
+}  // namespace math
+}  // namespace stan
+#endif

--- a/stan/math/prim/scal/prob/beta_proportion_cdf_log.hpp
+++ b/stan/math/prim/scal/prob/beta_proportion_cdf_log.hpp
@@ -1,5 +1,5 @@
-#ifndef STAN_MATH_PRIM_SCAL_PROB_BETA_CDF_LOG_HPP
-#define STAN_MATH_PRIM_SCAL_PROB_BETA_CDF_LOG_HPP
+#ifndef STAN_MATH_PRIM_SCAL_PROB_BETA_PROPORTION_CDF_LOG_HPP
+#define STAN_MATH_PRIM_SCAL_PROB_BETA_PROPORTION_CDF_LOG_HPP
 
 #include <stan/math/prim/scal/meta/return_type.hpp>
 #include <stan/math/prim/scal/prob/beta_proportion_lcdf.hpp>

--- a/stan/math/prim/scal/prob/beta_proportion_cdf_log.hpp
+++ b/stan/math/prim/scal/prob/beta_proportion_cdf_log.hpp
@@ -17,13 +17,13 @@ namespace math {
  *
  * @deprecated use <code>beta_proportion_lcdf</code>
  *
- * @tparam T_y type of probability parameter
+ * @tparam T_y type of y
  * @tparam T_loc type of location parameter
  * @tparam T_prec type of precision parameter
- * @param y probability parameter
- * @param mu location parameter
- * @param kappa precision parameter
- * @return log probability or log sum of probabilities
+ * @param y (Sequence of) scalar(s) between zero and one
+ * @param mu (Sequence of) location parameter(s)
+ * @param kappa (Sequence of) precision parameter(s)
+ * @return log probability or sum of log of probabilities
  * @throw std::domain_error if mu is outside of (0, 1)
  * @throw std::domain_error if kappa is nonpositive
  * @throw std::domain_error if y is not a valid probability

--- a/stan/math/prim/scal/prob/beta_proportion_lccdf.hpp
+++ b/stan/math/prim/scal/prob/beta_proportion_lccdf.hpp
@@ -34,13 +34,13 @@ namespace math {
  * the same size.  With non-scalar arguments, the return is the sum of
  * the log ccdfs with scalars broadcast as necessary.
  *
- * @tparam T_y type of probability parameter
+ * @tparam T_y type of y
  * @tparam T_loc type of location parameter
  * @tparam T_prec type of precision parameter
- * @param y type of probability parameter
- * @param mu location parameter
- * @param kappa precision parameter
- * @return log probability or log sum of probabilities
+ * @param y (Sequence of) scalar(s) between zero and one
+ * @param mu (Sequence of) location parameter(s)
+ * @param kappa (Sequence of) precision parameter(s)
+ * @return log probability or sum of log of probabilities
  * @throw std::domain_error if mu is outside (0, 1)
  * @throw std::domain_error if kappa is nonpositive
  * @throw std::domain_error if 1 - y is not a valid probability

--- a/stan/math/prim/scal/prob/beta_proportion_lcdf.hpp
+++ b/stan/math/prim/scal/prob/beta_proportion_lcdf.hpp
@@ -34,13 +34,13 @@ namespace math {
  * the same size.  With non-scalar arguments, the return is the sum of
  * the log cdfs with scalars broadcast as necessary.
  *
- * @tparam T_y type of probability parameter
+ * @tparam T_y type of y
  * @tparam T_loc type of location parameter
  * @tparam T_prec type of precision parameter
- * @param y probability parameter
- * @param mu location parameter
- * @param kappa precision parameter
- * @return log probability or log sum of probabilities
+ * @param y (Sequence of) scalar(s) between zero and one
+ * @param mu (Sequence of) location parameter(s)
+ * @param kappa (Sequence of) precision parameter(s)
+ * @return log probability or sum of log of probabilities
  * @throw std::domain_error if mu is outside of (0, 1)
  * @throw std::domain_error if kappa is nonpositive
  * @throw std::domain_error if y is not a valid probability

--- a/stan/math/prim/scal/prob/beta_proportion_log.hpp
+++ b/stan/math/prim/scal/prob/beta_proportion_log.hpp
@@ -1,0 +1,51 @@
+#ifndef STAN_MATH_PRIM_SCAL_PROB_BETA_LOG_HPP
+#define STAN_MATH_PRIM_SCAL_PROB_BETA_LOG_HPP
+
+#include <stan/math/prim/scal/meta/return_type.hpp>
+#include <stan/math/prim/scal/prob/beta_proportion_lpdf.hpp>
+
+namespace stan {
+namespace math {
+
+/**
+ * The log of the beta density for specified y, location, and
+ * precision: beta_proportion_lpdf(y | mu, kappa) = beta_lpdf(y | mu *
+ * kappa, (1 - mu) * kappa).  Any arguments other than scalars must be
+ * containers of the same size.  With non-scalar arguments, the return
+ * is the sum of the log pdfs with scalars broadcast as necessary.
+ *
+ * <p> The result log probability is defined to be the sum of
+ * the log probabilities for each observation/mu/kappa triple.
+ *
+ * Prior location, mu, must be contained in (0, 1).  Prior precision
+ * must be positive.
+ *
+ * @deprecated use <code>beta_proportion_lpdf</code>
+ *
+ * @param y (Sequence of) scalar(s).
+ * @param mu (Sequence of) prior location(s).
+ * @param kappa (Sequence of) prior precision(s).
+ * @return The log of the product of densities.
+ * @tparam T_y Type of scalar outcome.
+ * @tparam T_loc Type of prior location.
+ * @tparam T_prec Type of prior precision.
+ */
+template <bool propto, typename T_y, typename T_loc,
+          typename T_prec>
+typename return_type<T_y, T_loc, T_prec>::type beta_proportion_log(
+    const T_y& y, const T_loc& mu, const T_prec& kappa) {
+  return beta_proportion_lpdf<propto, T_y, T_loc, T_prec>(y, mu, kappa);
+}
+
+/**
+ * @deprecated use <code>beta_proportion_lpdf</code>
+ */
+template <typename T_y, typename T_loc, typename T_prec>
+inline typename return_type<T_y, T_loc, T_prec>::type beta_proportion_log(
+    const T_y& y, const T_loc& mu, const T_prec& kappa) {
+  return beta_proportion_lpdf<T_y, T_loc, T_prec>(y, mu, kappa);
+}
+
+}  // namespace math
+}  // namespace stan
+#endif

--- a/stan/math/prim/scal/prob/beta_proportion_log.hpp
+++ b/stan/math/prim/scal/prob/beta_proportion_log.hpp
@@ -1,5 +1,5 @@
-#ifndef STAN_MATH_PRIM_SCAL_PROB_BETA_LOG_HPP
-#define STAN_MATH_PRIM_SCAL_PROB_BETA_LOG_HPP
+#ifndef STAN_MATH_PRIM_SCAL_PROB_BETA_PROPORTION_LOG_HPP
+#define STAN_MATH_PRIM_SCAL_PROB_BETA_PROPORTION_LOG_HPP
 
 #include <stan/math/prim/scal/meta/return_type.hpp>
 #include <stan/math/prim/scal/prob/beta_proportion_lpdf.hpp>

--- a/stan/math/prim/scal/prob/beta_proportion_log.hpp
+++ b/stan/math/prim/scal/prob/beta_proportion_log.hpp
@@ -22,9 +22,9 @@ namespace math {
  *
  * @deprecated use <code>beta_proportion_lpdf</code>
  *
- * @param y (Sequence of) scalar(s).
- * @param mu (Sequence of) prior location(s).
- * @param kappa (Sequence of) prior precision(s).
+ * @param y (Sequence of) scalar(s) between zero and one
+ * @param mu (Sequence of) location parameter(s)
+ * @param kappa (Sequence of) precision parameter(s)
  * @return The log of the product of densities.
  * @tparam T_y Type of scalar outcome.
  * @tparam T_loc Type of prior location.

--- a/stan/math/prim/scal/prob/beta_proportion_lpdf.hpp
+++ b/stan/math/prim/scal/prob/beta_proportion_lpdf.hpp
@@ -38,9 +38,9 @@ namespace math {
  * Prior location, mu, must be contained in (0, 1).  Prior precision
  * must be positive.
  *
- * @param y (Sequence of) scalar(s).
- * @param mu (Sequence of) prior location(s).
- * @param kappa (Sequence of) prior precision(s).
+ * @param y (Sequence of) scalar(s) between zero and one
+ * @param mu (Sequence of) location parameter(s)
+ * @param kappa (Sequence of) precision parameter(s)
  * @return The log of the product of densities.
  * @tparam T_y Type of scalar outcome.
  * @tparam T_loc Type of prior location.

--- a/test/unit/math/prim/scal/prob/beta_proportion_ccdf_log_test.cpp
+++ b/test/unit/math/prim/scal/prob/beta_proportion_ccdf_log_test.cpp
@@ -1,0 +1,15 @@
+#include <stan/math/prim/scal.hpp>
+#include <gtest/gtest.h>
+
+TEST(ProbBetaProportion, ccdf_log_matches_lccdf) {
+  double y = 0.8;
+  double mu = 0.51;
+  double kappa = 2.3;
+
+  EXPECT_FLOAT_EQ((stan::math::beta_proportion_lccdf(y, mu, kappa)),
+                  (stan::math::beta_proportion_ccdf_log(y, mu, kappa)));
+  EXPECT_FLOAT_EQ((stan::math::beta_proportion_lccdf
+                   <double, double, double>(y, mu, kappa)),
+                  (stan::math::beta_proportion_ccdf_log
+                   <double, double, double>(y, mu, kappa)));
+}

--- a/test/unit/math/prim/scal/prob/beta_proportion_cdf_log_test.cpp
+++ b/test/unit/math/prim/scal/prob/beta_proportion_cdf_log_test.cpp
@@ -1,0 +1,15 @@
+#include <stan/math/prim/scal.hpp>
+#include <gtest/gtest.h>
+
+TEST(ProbBetaProportion, cdf_log_matches_lcdf) {
+  double y = 0.8;
+  double mu = .51;
+  double kappa = 2.3;
+
+  EXPECT_FLOAT_EQ((stan::math::beta_proportion_lcdf(y, mu, kappa)),
+                  (stan::math::beta_proportion_cdf_log(y, mu, kappa)));
+  EXPECT_FLOAT_EQ((stan::math::beta_proportion_lcdf
+                   <double, double, double>(y, mu, kappa)),
+                  (stan::math::beta_proportion_cdf_log
+                   <double, double, double>(y, mu, kappa)));
+}

--- a/test/unit/math/prim/scal/prob/beta_proportion_log_test.cpp
+++ b/test/unit/math/prim/scal/prob/beta_proportion_log_test.cpp
@@ -1,0 +1,27 @@
+#include <stan/math/prim/scal.hpp>
+#include <gtest/gtest.h>
+
+TEST(ProbBetaProportion, log_matches_lpdf) {
+  double y = 0.8;
+  double mu = .51;
+  double kappa = 2.3;
+
+  EXPECT_FLOAT_EQ((stan::math::beta_proportion_lpdf(y, mu, kappa)),
+                  (stan::math::beta_proportion_log(y, mu, kappa)));
+  EXPECT_FLOAT_EQ((stan::math::beta_proportion_lpdf<true>(y, mu, kappa)),
+                  (stan::math::beta_proportion_log<true>(y, mu, kappa)));
+  EXPECT_FLOAT_EQ((stan::math::beta_proportion_lpdf<false>(y, mu, kappa)),
+                  (stan::math::beta_proportion_log<false>(y, mu, kappa)));
+  EXPECT_FLOAT_EQ((stan::math::beta_proportion_lpdf
+                   <true, double, double, double>(y, mu, kappa)),
+                  (stan::math::beta_proportion_log
+                   <true, double, double, double>(y, mu, kappa)));
+  EXPECT_FLOAT_EQ((stan::math::beta_proportion_lpdf
+                   <false, double, double, double>(y, mu, kappa)),
+                  (stan::math::beta_proportion_log
+                   <false, double, double, double>(y, mu, kappa)));
+  EXPECT_FLOAT_EQ((stan::math::beta_proportion_lpdf
+                   <double, double, double>(y, mu, kappa)),
+                  (stan::math::beta_proportion_log
+                   <double, double, double>(y, mu, kappa)));
+}


### PR DESCRIPTION
## Summary

Add
`stan/math/prim/scal/prob/beta_proportion_ccdf_log.hpp`,
`stan/math/prim/scal/prob/beta_proportion_cdf_log.hpp`, and
`stan/math/prim/scal/prob/beta_proportion_log.hpp`.

These should have been added to the now merged https://github.com/stan-dev/math/pull/975.  However, I've just learned that Stan is not ready to add new distribution functions without these; RE https://github.com/stan-dev/stan/issues/2623.  

## Tests
Add
`test/unit/math/prim/scal/prob/beta_proportion_ccdf_log_test.cpp`,
`test/unit/math/prim/scal/prob/beta_proportion_cdf_log_test.cpp`, and 
`test/unit/math/prim/scal/prob/beta_proportion_log_test.cpp`.

## Side Effects

None

## Checklist

- [x] Math issue https://github.com/stan-dev/math/issues/1018

- [x] Copyright holder: California State University, Chico

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - [x] header checks pass, (`make test-headers`)
    - [x] docs build, (`make doxygen`)
    - [x] code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
