### PR TITLE
Feature/issue 1022 integrate 1d templating

### DIFF
--- a/stan/math/rev/arr/functor/integrate_1d.hpp
+++ b/stan/math/rev/arr/functor/integrate_1d.hpp
@@ -115,7 +115,7 @@ inline double gradient_of_f(const F &f, const double &x, const double &xc,
  */
 template <typename F, typename T_a, typename T_b, typename T_theta>
 inline typename boost::enable_if_c<boost::is_same<T_a, var>::value
-                                       || boost::is_same<T_a, var>::value
+                                       || boost::is_same<T_b, var>::value
                                        || boost::is_same<T_theta, var>::value,
                                    var>::type
 integrate_1d(const F &f, const T_a &a, const T_b &b,

--- a/test/unit/math/rev/arr/functor/integrate_1d_test.cpp
+++ b/test/unit/math/rev/arr/functor/integrate_1d_test.cpp
@@ -274,6 +274,26 @@ TEST(StanMath_integrate_1d, TestDerivatives_zero_crossing) {
                                   -19.06340613646808, 21.41380852375568);
 }
 
+TEST(StanMath_integrate_1d, TestDerivatives_var_right_endpoint_var_params) {
+  // Zero crossing integral + test x_r + vars at right endpoint
+  using stan::math::var;
+  test_derivatives<double, var, var>(
+      f3{}, -1.0, 1.0, {0.5, 1.75, 3.9}, {2.5, 3.0}, {},
+      2.350402387287579 + 2.0 * pow(0.5, 2.5) + 4.0 * pow(1.75, 3.0)
+          + 4.0 * 3.9,
+      {5 * pow(0.5, 1.5), 12 * 1.75 * 1.75, 4.0}, 0.0, 21.41380852375568);
+}
+
+TEST(StanMath_integrate_1d, TestDerivatives_var_left_endpoint_var_params) {
+  // Zero crossing integral + test x_r + var at left endpoint
+  using stan::math::var;
+  test_derivatives<var, double, var>(
+      f3{}, -1.0, 1.0, {0.5, 1.75, 3.9}, {2.5, 3.0}, {},
+      2.350402387287579 + 2.0 * pow(0.5, 2.5) + 4.0 * pow(1.75, 3.0)
+          + 4.0 * 3.9,
+      {5 * pow(0.5, 1.5), 12 * 1.75 * 1.75, 4.0}, -19.06340613646808, 0.0);
+}
+
 TEST(StanMath_integrate_1d, TestDerivatives_no_param_vars) {
   // No param vars
   using stan::math::var;

--- a/test/unit/math/rev/arr/functor/integrate_1d_test.cpp
+++ b/test/unit/math/rev/arr/functor/integrate_1d_test.cpp
@@ -246,9 +246,9 @@ TEST(StanMath_integrate_1d, test_integer_arguments) {
       v = stan::math::integrate_1d(f2{}, 0, 1.0, theta, {}, {}, msgs, 1e-6));
 }
 
-TEST(StanMath_integrate_1d, TestDerivatives) {
-  using stan::math::var;
+TEST(StanMath_integrate_1d, TestDerivatives_easy) {
   // Easy integrals
+  using stan::math::var;
   test_derivatives<double, double, var>(f1{}, 0.2, 0.7, {0.75}, {}, {},
                                         0.7923499493102901 + 0.5 * 0.75, {0.5});
   test_derivatives<var, var, var>(f2{}, 0.0, 1.0, {0.5}, {}, {},
@@ -261,48 +261,104 @@ TEST(StanMath_integrate_1d, TestDerivatives) {
                                         {0.0});
   test_derivatives<double, double, var>(f2{}, 1.0, 1.0, {0.5}, {}, {}, 0.0,
                                         {0.0});
+}
+
+TEST(StanMath_integrate_1d, TestDerivatives_zero_crossing) {
   // Zero crossing integral + test x_r + vars at endpoints
+  using stan::math::var;
   test_derivatives<var, var, var>(f3{}, -1.0, 1.0, {0.5, 1.75, 3.9}, {2.5, 3.0},
                                   {},
                                   2.350402387287579 + 2.0 * pow(0.5, 2.5)
                                       + 4.0 * pow(1.75, 3.0) + 4.0 * 3.9,
                                   {5 * pow(0.5, 1.5), 12 * 1.75 * 1.75, 4.0},
                                   -19.06340613646808, 21.41380852375568);
+}
+
+TEST(StanMath_integrate_1d, TestDerivatives_no_param_vars) {
   // No param vars
+  using stan::math::var;
   test_derivatives<var, var, double>(f3{}, -1.0, 1.0, {0.5, 1.75, 3.9},
                                      {2.5, 3.0}, {},
                                      2.350402387287579 + 2.0 * pow(0.5, 2.5)
                                          + 4.0 * pow(1.75, 3.0) + 4.0 * 3.9,
                                      {}, -19.06340613646808, 21.41380852375568);
+}
+
+TEST(StanMath_integrate_1d, TestDerivatives_left_limit_var) {
+  // No param vars, only left limit var
+  using stan::math::var;
+  test_derivatives<var, double, double>(f3{}, -1.0, 1.0, {0.5, 1.75, 3.9},
+                                        {2.5, 3.0}, {},
+                                        2.350402387287579 + 2.0 * pow(0.5, 2.5)
+                                            + 4.0 * pow(1.75, 3.0) + 4.0 * 3.9,
+                                        {}, -19.06340613646808, 0.0);
+}
+
+TEST(StanMath_integrate_1d, TestDerivatives_right_limit_var) {
+  // No param vars, only right limit var
+  using stan::math::var;
+  test_derivatives<double, var, double>(f3{}, -1.0, 1.0, {0.5, 1.75, 3.9},
+                                        {2.5, 3.0}, {},
+                                        2.350402387287579 + 2.0 * pow(0.5, 2.5)
+                                            + 4.0 * pow(1.75, 3.0) + 4.0 * 3.9,
+                                        {}, 0.0, 21.41380852375568);
+}
+
+TEST(StanMath_integrate_1d, TestDerivatives_tricky1) {
   // Tricky integral from Boost docs + limit at infinity + no gradients
+  using stan::math::var;
   test_derivatives<double, double, var>(f4{}, 0.0,
                                         std::numeric_limits<double>::infinity(),
                                         {}, {}, {}, 1.772453850905516, {});
+}
+
+TEST(StanMath_integrate_1d, TestDerivatives_tricky2) {
   // Tricky integral from Boost docs + limit at infinity with gradients
+  using stan::math::var;
   test_derivatives<double, double, var>(
       f5{}, 0.0, std::numeric_limits<double>::infinity(), {0.5, 3.0}, {}, {},
       1.772453850905516 / sqrt(0.5 * 3.0),
       {-1.772453850905516 * 3.0 / (2 * pow(0.5 * 3.0, 1.5)),
        -1.772453850905516 * 0.5 / (2 * pow(0.5 * 3.0, 1.5))});
+}
+
+TEST(StanMath_integrate_1d, TestDerivatives_tricky3) {
   // Tricky integral from Boost docs
+  using stan::math::var;
   test_derivatives<double, double, var>(
       f6{}, 0.0, 1.0, {0.75}, {}, {}, 0.851926727945904, {0.4814066053874294});
+}
+
+TEST(StanMath_integrate_1d, TestDerivatives_zero_crossing2) {
   // Zero crossing integral + limit at infinity + var at left limit
+  using stan::math::var;
   test_derivatives<var, double, var>(
       f7{}, -5.0, std::numeric_limits<double>::infinity(), {1.5}, {}, {},
       1205.361609637375, {5223.23364176196}, -1808.042414456063,
       std::numeric_limits<double>::quiet_NaN());
+}
+
+TEST(StanMath_integrate_1d, TestDerivatives_zero_crossing3) {
   // Zero crossing integral + limit at negative infinity + var at right limit
+  using stan::math::var;
   test_derivatives<double, var, var>(
       f8{}, -std::numeric_limits<double>::infinity(), 5.0, {1.5}, {}, {},
       1205.361609637375, {5223.23364176196},
       std::numeric_limits<double>::quiet_NaN(), 1808.042414456063);
+}
+
+TEST(StanMath_integrate_1d, TestDerivatives_indefinite) {
   // Both limits at infinity + test x_r/x_i + no gradients
+  using stan::math::var;
   test_derivatives<double, double, var>(
       f10{}, -std::numeric_limits<double>::infinity(),
       std::numeric_limits<double>::infinity(), {}, {1.7}, {4},
       2.536571480364399, {});
+}
+
+TEST(StanMath_integrate_1d, TestDerivatives_endpoint_precision) {
   // Various integrals of beta function
+  using stan::math::var;
   test_derivatives<double, double, var>(f11{}, 0.0, 1.0, {0.1, 0.1}, {}, {},
                                         19.71463948905016,
                                         {-101.229055967892, -101.229055967892});
@@ -318,7 +374,11 @@ TEST(StanMath_integrate_1d, TestDerivatives) {
   test_derivatives<double, double, var>(
       f11{}, 0.0, 1.0, {3.0, 5.0}, {}, {}, 0.00952380952380952,
       {-0.01040816326530613, -0.004852607709750566});
+}
+
+TEST(StanMath_integrate_1d, TestDerivatives_gaussian) {
   // Check Gaussian integrates to 1.0 always
+  using stan::math::var;
   test_derivatives<double, double, var>(
       f12{}, -std::numeric_limits<double>::infinity(),
       std::numeric_limits<double>::infinity(), {5.7, 1}, {}, {}, 1.0,


### PR DESCRIPTION
## Summary

This fixes the problem with the integrate_1d templating described in issue #1022 and adds tests to prevent reintroduction of the bug.

## Tests

This adds two new tests that specifically check that instantiating the function with only the left or right limits as vars works: https://github.com/stan-dev/math/compare/feature/issue-1022-integrate-1d-templating?expand=1#diff-266a0f8b41777de89aa4195b334bf3bbR307 and https://github.com/stan-dev/math/compare/feature/issue-1022-integrate-1d-templating?expand=1#diff-266a0f8b41777de89aa4195b334bf3bbR317

There are also a couple new tests that test the function if either the left or right limits are vars as well as the parameters are vars (the last untested configuration): https://github.com/stan-dev/math/compare/feature/issue-1022-integrate-1d-templating?expand=1#diff-266a0f8b41777de89aa4195b334bf3bbR277 and https://github.com/stan-dev/math/compare/feature/issue-1022-integrate-1d-templating?expand=1#diff-266a0f8b41777de89aa4195b334bf3bbR287

I also broke up the integrate_1d tests so it'll be easier to diagnose what cause a failure.

```
./runTests.py test/unit/math/rev/arr/functor/integrate_1d_test.cpp
```

Describe the new tests with the pull request.

For bug fixes there should be a new test that would fail if the patch weren't in place (so that the bug could be caught if it comes up again).

For new features there should be at least one test showing the expected behavior and one test that demonstrates error handling. Be aware the reviewer will very likely ask for more tests than this, but it's a start.

## Checklist

- [x] Math issue #1022 

- [x] Copyright holder: Columbia University

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
