### PR TITLE
Change from c++11 to c++14 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ If this is in the file `/path/to/foo/foo.cpp`, then you can compile and run this
 
 ```
 > cd /path/to/foo
-> clang++ -std=c++11 -I /path/to/stan-math -I /path/to/Eigen -I /path/to/boost -I /path/to/sundials foo.cpp
+> clang++ -std=c++14 -I /path/to/stan-math -I /path/to/Eigen -I /path/to/boost -I /path/to/sundials foo.cpp
 > ./a.out
 log normal(1 | 2, 3)=-2.07311
 ```
@@ -54,7 +54,7 @@ The `-I` includes provide paths pointing to the four necessary includes:
 Note that the paths should *not* include the final directories `stan`, `Eigen`, or `boost` on the paths.  An example of a real instantiation:
 
 ```
-clang++ -std=c++11 -I ~/stan-dev/math -I ~/stan-dev/math/lib/eigen_3.3.3/ -I ~/stan-dev/math/lib/boost_1.66.0/ -I ~/stan-dev/math/lib/sundials_3.1.0/include foo.cpp
+clang++ -std=c++14 -I ~/stan-dev/math -I ~/stan-dev/math/lib/eigen_3.3.3/ -I ~/stan-dev/math/lib/boost_1.66.0/ -I ~/stan-dev/math/lib/sundials_3.1.0/include foo.cpp
 ```
 
 The following directories all exist below the links given to `-I`: `~/stan-dev/math/stan` and `~/stan-dev/math/lib/eigen_3.3.3/Eigen` and `~stan-dev/math/lib/boost_1.66.0/boost` and `~stan-dev/math/lib/sundials_3.1.0/include`.


### PR DESCRIPTION
I tried to compile the simple example cpp script presented in README and got an error that `std::index_sequence` couldn't be found. The fix was to use `-std=c++14` instead of `-std=c++11`.

Thanks for submitting a pull request! Please remove this text when submitting.

Start by filling in the Summary, Tests, and Side Effects sections of this pull request and then work through the handy checklist at the bottom. If anything significant is missing, the pull request may be closed until it's ready. The full guidebook on how pull requests are reviewed is here: [Code Review Guidelines](https://github.com/stan-dev/math/wiki/Developer-Doc#code-review-guidelines).

## Summary

Describe the contents of the pull request. The issue describes the problem that needs to be fixed, whereas the text here should help the reviewer figure out to what extent this pull request solves the issue.

Describe implementation details and any relevant information that would help the code reviewer understand this pull request. If there is anything special you need to draw someone's attention to, do it here. Link to any related pull requests or Discourse threads.

## Tests

Describe the new tests with the pull request.

For bug fixes there should be a new test that would fail if the patch weren't in place (so that the bug could be caught if it comes up again).

For new features there should be at least one test showing the expected behavior and one test that demonstrates error handling. Be aware the reviewer will very likely ask for more tests than this, but it's a start.

## Side Effects

Are there any side effects that we should be aware of?

## Checklist

- [ ] Math issue #(issue number)

- [ ] Copyright holder: (fill in copyright holder information)

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [ ] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [ ] the code is written in idiomatic C++ and changes are documented in the doxygen

- [ ] the new changes are tested
