### PR TITLE
[WIP] Implement std::complex<stan::math::var>

### DIFF
--- a/stan/math/rev/core/std_complex.hpp
+++ b/stan/math/rev/core/std_complex.hpp
@@ -3,6 +3,7 @@
 
 #include <stan/math/rev/core/var.hpp>
 #include <stan/math/rev/core/std_numeric_limits.hpp>
+#include <stan/math/rev/core/std_isnan.hpp>
 #include <complex>
 
 namespace std {
@@ -45,6 +46,18 @@ complex<stan::math::var>& complex<stan::math::var>::operator=(
   real(c);
   imag(0.0);
   return *this;
+}
+
+template <>
+complex<stan::math::var> operator/(const complex<stan::math::var>& z,
+                                   const complex<stan::math::var>& w) {
+  return complex<stan::math::var>{z.real() / w.real(), z.imag() / w.imag()};
+}
+
+template <>
+complex<stan::math::var> operator*(const complex<stan::math::var>& z,
+                                   const complex<stan::math::var>& w) {
+  return complex<stan::math::var>{z.real() * w.real(), z.imag() * w.imag()};
 }
 
 }  // namespace std

--- a/stan/math/rev/core/std_complex.hpp
+++ b/stan/math/rev/core/std_complex.hpp
@@ -104,5 +104,23 @@ inline int isnan(const std::complex<stan::math::var>& a) {
   return stan::math::is_nan(a.real().val());
 }
 
+template <>
+inline stan::math::var norm(const complex<stan::math::var>& c) {
+  return stan::math::square(c.real()) + stan::math::square(c.imag());
+}
+
+template <>
+inline complex<stan::math::var> conj(const complex<stan::math::var>& c) {
+  return complex<stan::math::var>(c.real(), -c.imag());
+}
+
+template <>
+inline complex<stan::math::var> proj(const complex<stan::math::var>& c) {
+  if (isinf(c.real()) || isinf(c.imag()))
+    return std::complex<stan::math::var>(stan::math::positive_infinity(),
+                                         copysign(0.0, c.imag().val()));
+  return c;
+}
+
 }  // namespace std
 #endif

--- a/stan/math/rev/core/std_complex.hpp
+++ b/stan/math/rev/core/std_complex.hpp
@@ -70,6 +70,22 @@ complex<stan::math::var> operator*(const complex<stan::math::var>& z,
 }
 
 template <>
+template <>
+complex<stan::math::var>& complex<stan::math::var>::operator/=(
+    const complex<stan::math::var>& y) {
+  *this = *this / y;
+  return *this;
+}
+
+template <>
+template <>
+complex<stan::math::var>& complex<stan::math::var>::operator*=(
+    const complex<stan::math::var>& y) {
+  *this = *this * y;
+  return *this;
+}
+
+template <>
 inline bool operator==(const complex<stan::math::var>& x,
                        const complex<stan::math::var>& y) {
   return x.real() == y.real() && x.imag() == y.imag();

--- a/stan/math/rev/core/std_complex.hpp
+++ b/stan/math/rev/core/std_complex.hpp
@@ -60,5 +60,40 @@ complex<stan::math::var> operator*(const complex<stan::math::var>& z,
   return complex<stan::math::var>{z.real() * w.real(), z.imag() * w.imag()};
 }
 
+template <>
+inline bool operator==(const complex<stan::math::var>& x,
+                       const complex<stan::math::var>& y) {
+  return x.real() == y.real() && x.imag() == y.imag();
+  ;
+}
+
+template <>
+inline bool operator==(const complex<stan::math::var>& x,
+                       const stan::math::var& y) {
+  return x.real() == y && x.imag() == 0;
+}
+
+template <>
+inline bool operator==(const stan::math::var& x,
+                       const complex<stan::math::var>& y) {
+  return y == x;
+}
+
+inline bool operator==(const complex<stan::math::var>& x, double y) {
+  return x.real() == y && x.imag() == 0;
+}
+
+inline bool operator==(double x, const complex<stan::math::var>& y) {
+  return y == x;
+}
+
+inline bool operator!=(const complex<stan::math::var>& x, double y) {
+  return !(x == y);
+}
+
+inline bool operator!=(double x, const complex<stan::math::var>& y) {
+  return !(x == y);
+}
+
 }  // namespace std
 #endif

--- a/stan/math/rev/core/std_complex.hpp
+++ b/stan/math/rev/core/std_complex.hpp
@@ -1,0 +1,23 @@
+#ifndef STAN_MATH_REV_CORE_STD_COMPLEX_HPP
+#define STAN_MATH_REV_CORE_STD_COMPLEX_HPP
+
+#include <stan/math/rev/core/var.hpp>
+#include <stan/math/rev/core/std_numeric_limits.hpp>
+#include <complex>
+
+namespace std {
+
+/**
+ * Specialization of complex for var objects.
+ *
+ * This implementation of std::numeric_limits<stan::math::var>
+ * is used to treat var objects like doubles.
+ */
+/*
+template <>
+struct complex<stan::math::var> {
+
+};*/
+
+}  // namespace std
+#endif

--- a/stan/math/rev/core/std_complex.hpp
+++ b/stan/math/rev/core/std_complex.hpp
@@ -10,14 +10,19 @@ namespace std {
 /**
  * Specialization of complex for var objects.
  *
- * This implementation of std::numeric_limits<stan::math::var>
- * is used to treat var objects like doubles.
  */
-/*
 template <>
-struct complex<stan::math::var> {
+constexpr complex<stan::math::var>::complex(const stan::math::var& re,
+                                            const stan::math::var& im) {
+  real(stan::math::is_uninitialized(re) ? stan::math::var{0.0} : re);
+  imag(stan::math::is_uninitialized(im) ? stan::math::var{0.0} : im);
+}
 
-};*/
+// struct complex<stan::math::var> {
+//   complex()
+//       : _M_real(0), _M_imag(0) {
+//   }
+// };
 
 }  // namespace std
 #endif

--- a/stan/math/rev/core/std_complex.hpp
+++ b/stan/math/rev/core/std_complex.hpp
@@ -52,13 +52,16 @@ complex<stan::math::var>& complex<stan::math::var>::operator=(
 template <>
 complex<stan::math::var> operator/(const complex<stan::math::var>& z,
                                    const complex<stan::math::var>& w) {
-  return complex<stan::math::var>{z.real() / w.real(), z.imag() / w.imag()};
+  return complex<stan::math::var>{z.real() * w.real() + z.imag() * w.imag(),
+                                  z.imag() * w.real() - z.real() * w.imag()}
+         / (square(w.real()) + square(w.imag()));
 }
 
 template <>
 complex<stan::math::var> operator*(const complex<stan::math::var>& z,
                                    const complex<stan::math::var>& w) {
-  return complex<stan::math::var>{z.real() * w.real(), z.imag() * w.imag()};
+  return complex<stan::math::var>{z.real() * w.real() - z.imag() * w.imag(),
+                                  z.real() * w.imag() + z.imag() * w.real()};
 }
 
 template <>

--- a/stan/math/rev/core/std_complex.hpp
+++ b/stan/math/rev/core/std_complex.hpp
@@ -8,8 +8,19 @@
 namespace std {
 
 /**
- * Specialization of complex for var objects.
+ * Specialization of the std::complex<stan::math::var>
+ * constructor.
  *
+ * The base template implementation will create uninitialized
+ * stan::math::vars for the default arguments by calling the empty
+ * constructor. This needs to be specialized because uninitialized
+ * vars can cause seg faults.
+ *
+ * Promotion from primitives to stan::math::var applies and this
+ * constructor will handle the primitivies.
+ *
+ * @param re real component
+ * @param im imaginary component
  */
 template <>
 constexpr complex<stan::math::var>::complex(const stan::math::var& re,
@@ -18,11 +29,23 @@ constexpr complex<stan::math::var>::complex(const stan::math::var& re,
   imag(stan::math::is_uninitialized(im) ? stan::math::var{0.0} : im);
 }
 
-// struct complex<stan::math::var> {
-//   complex()
-//       : _M_real(0), _M_imag(0) {
-//   }
-// };
+/**
+ * Specialization of operator= for stan::math::var.
+ *
+ * The base template implementation will leave the imaginary component
+ * as an uninitialized stan::math::var, which can cause seg faults.
+ * This implementation fixes that problem by forcing the imaginary
+ * component to be initialized to 0.0.
+ *
+ *
+ */
+template <>
+complex<stan::math::var>& complex<stan::math::var>::operator=(
+    const stan::math::var& c) {
+  real(c);
+  imag(0.0);
+  return *this;
+}
 
 }  // namespace std
 #endif

--- a/stan/math/rev/core/std_complex.hpp
+++ b/stan/math/rev/core/std_complex.hpp
@@ -1,9 +1,10 @@
 #ifndef STAN_MATH_REV_CORE_STD_COMPLEX_HPP
 #define STAN_MATH_REV_CORE_STD_COMPLEX_HPP
 
-#include <stan/math/rev/core/var.hpp>
+#include <stan/math/rev/core.hpp>
 #include <stan/math/rev/core/std_numeric_limits.hpp>
 #include <stan/math/rev/core/std_isnan.hpp>
+#include <stan/math/rev/core/std_isinf.hpp>
 #include <complex>
 
 namespace std {
@@ -93,6 +94,14 @@ inline bool operator!=(const complex<stan::math::var>& x, double y) {
 
 inline bool operator!=(double x, const complex<stan::math::var>& y) {
   return !(x == y);
+}
+
+inline int isinf(const std::complex<stan::math::var>& a) {
+  return stan::math::is_inf(a.real().val());
+}
+
+inline int isnan(const std::complex<stan::math::var>& a) {
+  return stan::math::is_nan(a.real().val());
 }
 
 }  // namespace std

--- a/stan/math/rev/core/std_complex.hpp
+++ b/stan/math/rev/core/std_complex.hpp
@@ -50,11 +50,16 @@ complex<stan::math::var>& complex<stan::math::var>::operator=(
 }
 
 template <>
+inline stan::math::var norm(const complex<stan::math::var>& c) {
+  return stan::math::square(c.real()) + stan::math::square(c.imag());
+}
+
+template <>
 complex<stan::math::var> operator/(const complex<stan::math::var>& z,
                                    const complex<stan::math::var>& w) {
   return complex<stan::math::var>{z.real() * w.real() + z.imag() * w.imag(),
                                   z.imag() * w.real() - z.real() * w.imag()}
-         / (square(w.real()) + square(w.imag()));
+         / norm(w);
 }
 
 template <>
@@ -91,12 +96,29 @@ inline bool operator==(double x, const complex<stan::math::var>& y) {
   return y == x;
 }
 
+template <>
+inline bool operator!=(const complex<stan::math::var>& x,
+                       const complex<stan::math::var>& y) {
+  return x.real() != y.real() || x.imag() != y.imag();
+}
+
+inline bool operator!=(const complex<stan::math::var>& x,
+                       const stan::math::var& y) {
+  return (x.real() != y || x.imag() != 0);
+}
+
+inline bool operator!=(const stan::math::var& x,
+                       const complex<stan::math::var>& y) {
+  return y != x;
+}
+
 inline bool operator!=(const complex<stan::math::var>& x, double y) {
-  return !(x == y);
+  return (x.real() != y || x.imag() != 0);
+  ;
 }
 
 inline bool operator!=(double x, const complex<stan::math::var>& y) {
-  return !(x == y);
+  return y != x;
 }
 
 inline int isinf(const std::complex<stan::math::var>& a) {
@@ -108,8 +130,8 @@ inline int isnan(const std::complex<stan::math::var>& a) {
 }
 
 template <>
-inline stan::math::var norm(const complex<stan::math::var>& c) {
-  return stan::math::square(c.real()) + stan::math::square(c.imag());
+inline stan::math::var abs(const complex<stan::math::var>& c) {
+  return stan::math::sqrt(norm(c));
 }
 
 template <>

--- a/stan/math/rev/core/var.hpp
+++ b/stan/math/rev/core/var.hpp
@@ -62,7 +62,7 @@ class var {
    * dangling.  Before an assignment, the behavior is thus undefined just
    * as for a basic double.
    */
-  var() : vi_(static_cast<vari*>(0U)) {}
+  constexpr var() : vi_(static_cast<vari*>(0U)) {}
 
   /**
    * Construct a variable from a pointer to a variable implementation.

--- a/stan/math/rev/core/var.hpp
+++ b/stan/math/rev/core/var.hpp
@@ -462,8 +462,7 @@ class var {
   inline var& operator/=(double b);
 
   /**
-   * Write the value of this auto-dif variable and its adjoint to
-   * the specified output stream.
+   * Write the value of this auto-diff variable and to the output stream.
    *
    * @param os Output stream to which to write.
    * @param v Variable to write.
@@ -473,6 +472,21 @@ class var {
     if (v.vi_ == nullptr)
       return os << "uninitialized";
     return os << v.val();
+  }
+
+  /**
+   * Read the value of this auto-diff variable from
+   * the specified input stream.
+   *
+   * @param[in] is Input stream to read
+   * @param v Variable to write.
+   * @return Reference to the specified input stream.
+   */
+  friend std::istream& operator>>(std::istream& is, var& v) {
+    double x;
+    is >> x;
+    v = x;
+    return is;
   }
 };
 

--- a/stan/math/rev/core/var.hpp
+++ b/stan/math/rev/core/var.hpp
@@ -462,7 +462,7 @@ class var {
   inline var& operator/=(double b);
 
   /**
-   * Write the value of this auto-diff variable and to the output stream.
+   * Write the value of this auto-diff variable to the output stream.
    *
    * @param os Output stream to which to write.
    * @param v Variable to write.

--- a/stan/math/rev/scal.hpp
+++ b/stan/math/rev/scal.hpp
@@ -92,6 +92,7 @@
 #include <stan/math/rev/scal/fun/sqrt.hpp>
 #include <stan/math/rev/scal/fun/square.hpp>
 #include <stan/math/rev/scal/fun/squared_distance.hpp>
+#include <stan/math/rev/scal/fun/std_complex.hpp>
 #include <stan/math/rev/scal/fun/step.hpp>
 #include <stan/math/rev/scal/fun/tan.hpp>
 #include <stan/math/rev/scal/fun/tanh.hpp>

--- a/stan/math/rev/scal/fun/std_complex.hpp
+++ b/stan/math/rev/scal/fun/std_complex.hpp
@@ -157,7 +157,7 @@ inline stan::math::var abs(const complex<stan::math::var>& c) {
   return stan::math::sqrt(norm(c));
 }
 
-template<>
+template <>
 inline complex<stan::math::var> exp(const complex<stan::math::var>& z) {
   stan::math::var exp_x = exp(z.real());
   return complex<stan::math::var>(exp_x * cos(z.imag()), exp_x * sin(z.imag()));

--- a/stan/math/rev/scal/fun/std_complex.hpp
+++ b/stan/math/rev/scal/fun/std_complex.hpp
@@ -80,16 +80,13 @@ complex<stan::math::var> operator*(const complex<stan::math::var>& z,
 
 complex<stan::math::var> operator*(const complex<stan::math::var>& z,
                                    double w) {
-  return complex<stan::math::var>{z.real() * w,
-                                  z.imag() * w};
+  return complex<stan::math::var>{z.real() * w, z.imag() * w};
 }
 
 complex<stan::math::var> operator*(double z,
                                    const complex<stan::math::var>& w) {
-  return complex<stan::math::var>{z * w.real(),
-                                  z * w.imag()};
+  return complex<stan::math::var>{z * w.real(), z * w.imag()};
 }
-
 
 template <>
 template <>

--- a/stan/math/rev/scal/fun/std_complex.hpp
+++ b/stan/math/rev/scal/fun/std_complex.hpp
@@ -78,6 +78,19 @@ complex<stan::math::var> operator*(const complex<stan::math::var>& z,
                                   z.real() * w.imag() + z.imag() * w.real()};
 }
 
+complex<stan::math::var> operator*(const complex<stan::math::var>& z,
+                                   double w) {
+  return complex<stan::math::var>{z.real() * w,
+                                  z.imag() * w};
+}
+
+complex<stan::math::var> operator*(double z,
+                                   const complex<stan::math::var>& w) {
+  return complex<stan::math::var>{z * w.real(),
+                                  z * w.imag()};
+}
+
+
 template <>
 template <>
 complex<stan::math::var>& complex<stan::math::var>::operator/=(
@@ -166,7 +179,19 @@ inline complex<stan::math::var> exp(const complex<stan::math::var>& z) {
 template <>
 inline complex<stan::math::var> pow(const complex<stan::math::var>& x,
                                     const complex<stan::math::var>& y) {
-  return (x == 0.0) ? complex<stan::math::var>(0.0, 0.0)
+  return (x == 0.0) ? complex<stan::math::var>(1.0, 0.0)
+                    : std::exp(y * std::log(x));
+}
+
+inline complex<stan::math::var> pow(const complex<stan::math::var>& x,
+                                    double y) {
+  return (x == 0.0) ? complex<stan::math::var>(1.0, 0.0)
+                    : std::exp(y * std::log(x));
+}
+
+inline complex<stan::math::var> pow(double x,
+                                    const complex<stan::math::var>& y) {
+  return (x == 0.0) ? complex<stan::math::var>(1.0, 0.0)
                     : std::exp(y * std::log(x));
 }
 

--- a/stan/math/rev/scal/fun/std_complex.hpp
+++ b/stan/math/rev/scal/fun/std_complex.hpp
@@ -7,6 +7,7 @@
 #include <stan/math/rev/core/std_isinf.hpp>
 #include <stan/math/rev/scal/fun/is_uninitialized.hpp>
 #include <complex>
+#include <iostream>
 
 namespace std {
 
@@ -154,6 +155,30 @@ inline int isnan(const complex<stan::math::var>& a) {
 template <>
 inline stan::math::var abs(const complex<stan::math::var>& c) {
   return stan::math::sqrt(norm(c));
+}
+
+template <>
+inline complex<stan::math::var> pow(const complex<stan::math::var>& x,
+                                    const complex<stan::math::var>& y) {
+  return (x == 0.0) ? complex<stan::math::var>(0.0, 0.0)
+                    : std::exp(y * std::log(x));
+}
+
+template <>
+inline complex<stan::math::var> sqrt(const complex<stan::math::var>& c) {
+  if (c.real() == 0.0) {
+    stan::math::var t = sqrt(abs(c.imag()) / 2.0);
+    return complex<stan::math::var>(t,
+                                    ((c.imag() > 0.0) - (c.imag() < 0.0)) * t);
+  } else {
+    stan::math::var t = sqrt(2.0 * (abs(c) + abs(c.real())));
+    if (c.real() > 0.0) {
+      return complex<stan::math::var>(t / 2.0, (c.imag() / t));
+    } else {
+      return complex<stan::math::var>(
+          abs(c.imag()) / t, ((c.imag() > 0) - (c.imag() < 0)) * t / 2.0);
+    }
+  }
 }
 
 template <>

--- a/stan/math/rev/scal/fun/std_complex.hpp
+++ b/stan/math/rev/scal/fun/std_complex.hpp
@@ -143,11 +143,11 @@ inline bool operator!=(double x, const complex<stan::math::var>& y) {
   return y != x;
 }
 
-inline int isinf(const std::complex<stan::math::var>& a) {
+inline int isinf(const complex<stan::math::var>& a) {
   return stan::math::is_inf(a.real().val());
 }
 
-inline int isnan(const std::complex<stan::math::var>& a) {
+inline int isnan(const complex<stan::math::var>& a) {
   return stan::math::is_nan(a.real().val());
 }
 
@@ -164,8 +164,8 @@ inline complex<stan::math::var> conj(const complex<stan::math::var>& c) {
 template <>
 inline complex<stan::math::var> proj(const complex<stan::math::var>& c) {
   if (isinf(c.real()) || isinf(c.imag()))
-    return std::complex<stan::math::var>(stan::math::positive_infinity(),
-                                         copysign(0.0, c.imag().val()));
+    return complex<stan::math::var>(stan::math::positive_infinity(),
+                                    copysign(0.0, c.imag().val()));
   return c;
 }
 

--- a/stan/math/rev/scal/fun/std_complex.hpp
+++ b/stan/math/rev/scal/fun/std_complex.hpp
@@ -1,10 +1,11 @@
-#ifndef STAN_MATH_REV_CORE_STD_COMPLEX_HPP
-#define STAN_MATH_REV_CORE_STD_COMPLEX_HPP
+#ifndef STAN_MATH_REV_SCAL_FUN_STD_COMPLEX_HPP
+#define STAN_MATH_REV_SCAL_FUN_STD_COMPLEX_HPP
 
 #include <stan/math/rev/core.hpp>
 #include <stan/math/rev/core/std_numeric_limits.hpp>
 #include <stan/math/rev/core/std_isnan.hpp>
 #include <stan/math/rev/core/std_isinf.hpp>
+#include <stan/math/rev/scal/fun/is_uninitialized.hpp>
 #include <complex>
 
 namespace std {
@@ -20,6 +21,13 @@ namespace std {
  *
  * Promotion from primitives to stan::math::var applies and this
  * constructor will handle the primitivies.
+ *
+ * This file is located in the stan/math/rev/scal/fun folder
+ * intentionally.  The implementation depends on templated functions
+ * being template instantiated in the correct order. Although the rest
+ * of the std implementations are in stan/math/rev/core, this one is
+ * different because it requires functions defined for
+ * stan::math::var.
  *
  * @param re real component
  * @param im imaginary component

--- a/stan/math/rev/scal/fun/std_complex.hpp
+++ b/stan/math/rev/scal/fun/std_complex.hpp
@@ -97,7 +97,6 @@ template <>
 inline bool operator==(const complex<stan::math::var>& x,
                        const complex<stan::math::var>& y) {
   return x.real() == y.real() && x.imag() == y.imag();
-  ;
 }
 
 template <>
@@ -138,7 +137,6 @@ inline bool operator!=(const stan::math::var& x,
 
 inline bool operator!=(const complex<stan::math::var>& x, double y) {
   return (x.real() != y || x.imag() != 0);
-  ;
 }
 
 inline bool operator!=(double x, const complex<stan::math::var>& y) {

--- a/stan/math/rev/scal/fun/std_complex.hpp
+++ b/stan/math/rev/scal/fun/std_complex.hpp
@@ -157,6 +157,12 @@ inline stan::math::var abs(const complex<stan::math::var>& c) {
   return stan::math::sqrt(norm(c));
 }
 
+template<>
+inline complex<stan::math::var> exp(const complex<stan::math::var>& z) {
+  stan::math::var exp_x = exp(z.real());
+  return complex<stan::math::var>(exp_x * cos(z.imag()), exp_x * sin(z.imag()));
+}
+
 template <>
 inline complex<stan::math::var> pow(const complex<stan::math::var>& x,
                                     const complex<stan::math::var>& y) {

--- a/test/unit/math/rev/core/std_complex_test.cpp
+++ b/test/unit/math/rev/core/std_complex_test.cpp
@@ -311,23 +311,66 @@ TEST_F(MathRev, comparison) {
   EXPECT_EQ(stack_size,
             stan::math::ChainableStack::instance().var_stack_.size());
 }
-/*
+
 TEST_F(MathRev, serialize_deserialize) {
+  std::stringstream msg;
+
+  std::complex<stan::math::var> x{1, 2};
+  int stack_size = stan::math::ChainableStack::instance().var_stack_.size();
+
   // operator<<
+  msg << x;
+  EXPECT_EQ("(1,2)", msg.str());
+  EXPECT_EQ(stack_size,
+            stan::math::ChainableStack::instance().var_stack_.size());
+
   // operator>>
-  ADD_FAILURE() << "not yet implemented";
+  std::complex<stan::math::var> y;
+  stack_size = stan::math::ChainableStack::instance().var_stack_.size();
+  msg >> y;
+  EXPECT_EQ(1, y.real().val());
+  EXPECT_EQ(2, y.imag().val());
+  EXPECT_EQ(stack_size + 2,
+            stan::math::ChainableStack::instance().var_stack_.size());
 }
 
 TEST_F(MathRev, real) {
-  // real
-  ADD_FAILURE() << "not yet implemented";
+  std::complex<stan::math::var> x{1, 2};
+
+  EXPECT_EQ(2, stan::math::ChainableStack::instance().var_stack_.size());
+
+  EXPECT_EQ(1, x.real().val());
+  EXPECT_EQ(2, stan::math::ChainableStack::instance().var_stack_.size());
+
+  EXPECT_NO_THROW(x.real(2));
+  EXPECT_EQ(2, x.real().val());
+  EXPECT_EQ(3, stan::math::ChainableStack::instance().var_stack_.size());
+
+  stan::math::var y = 3;
+  EXPECT_NO_THROW(x.real(y));
+  EXPECT_EQ(y, x.real().val());
+  EXPECT_EQ(4, stan::math::ChainableStack::instance().var_stack_.size());
 }
 
 TEST_F(MathRev, imag) {
-  // imag
-  ADD_FAILURE() << "not yet implemented";
+  std::complex<stan::math::var> x{1, 2};
+
+  EXPECT_EQ(2, stan::math::ChainableStack::instance().var_stack_.size());
+
+  EXPECT_EQ(2, x.imag().val());
+  EXPECT_EQ(2, stan::math::ChainableStack::instance().var_stack_.size());
+
+  EXPECT_NO_THROW(x.imag(-1));
+  EXPECT_EQ(-1, x.imag().val());
+  EXPECT_EQ(3, stan::math::ChainableStack::instance().var_stack_.size());
+
+  stan::math::var y = 3;
+  EXPECT_NO_THROW(x.imag(y));
+  EXPECT_EQ(y, x.imag().val());
+  EXPECT_EQ(4, stan::math::ChainableStack::instance().var_stack_.size());
 }
 
+/*
 TEST_F(MathRev, abs) {
   // abs
   ADD_FAILURE() << "not yet implemented";

--- a/test/unit/math/rev/core/std_complex_test.cpp
+++ b/test/unit/math/rev/core/std_complex_test.cpp
@@ -112,23 +112,23 @@ TEST_F(MathRev, member_operators) {
   y = std::complex<stan::math::var>{3, 4};
   EXPECT_EQ(4, stan::math::ChainableStack::instance().var_stack_.size());
   x /= y;
-  EXPECT_FLOAT_EQ(1.0 / 3.0, x.real().val());
-  EXPECT_FLOAT_EQ(0.5, x.imag().val());
+  EXPECT_FLOAT_EQ(11.0 / 25.0, x.real().val());
+  EXPECT_FLOAT_EQ(2.0 / 25.0, x.imag().val());
   EXPECT_FLOAT_EQ(3, y.real().val());
   EXPECT_FLOAT_EQ(4, y.imag().val());
-  EXPECT_EQ(6, stan::math::ChainableStack::instance().var_stack_.size());
+  EXPECT_EQ(15, stan::math::ChainableStack::instance().var_stack_.size());
   stan::math::recover_memory();
 
-  // operator*=
+  // operator*
   x = std::complex<stan::math::var>{1, 2};
   y = std::complex<stan::math::var>{3, 4};
   EXPECT_EQ(4, stan::math::ChainableStack::instance().var_stack_.size());
   x *= y;
-  EXPECT_FLOAT_EQ(3, x.real().val());
-  EXPECT_FLOAT_EQ(8, x.imag().val());
+  EXPECT_FLOAT_EQ(-5, x.real().val());
+  EXPECT_FLOAT_EQ(10.0, x.imag().val());
   EXPECT_FLOAT_EQ(3, y.real().val());
   EXPECT_FLOAT_EQ(4, y.imag().val());
-  EXPECT_EQ(6, stan::math::ChainableStack::instance().var_stack_.size());
+  EXPECT_EQ(10, stan::math::ChainableStack::instance().var_stack_.size());
   stan::math::recover_memory();
 }
 
@@ -191,9 +191,9 @@ TEST_F(MathRev, arithmetic) {
   y = std::complex<stan::math::var>{3, 4};
   z = x * y;
 
-  EXPECT_EQ(6, stan::math::ChainableStack::instance().var_stack_.size());
-  EXPECT_FLOAT_EQ(3, z.real().val());
-  EXPECT_FLOAT_EQ(8, z.imag().val());
+  EXPECT_EQ(10, stan::math::ChainableStack::instance().var_stack_.size());
+  EXPECT_FLOAT_EQ(-5, z.real().val());
+  EXPECT_FLOAT_EQ(10, z.imag().val());
   EXPECT_FLOAT_EQ(1, x.real().val());
   EXPECT_FLOAT_EQ(2, x.imag().val());
   EXPECT_FLOAT_EQ(3, y.real().val());
@@ -205,9 +205,9 @@ TEST_F(MathRev, arithmetic) {
   y = std::complex<stan::math::var>{3, 4};
   z = x / y;
 
-  EXPECT_EQ(6, stan::math::ChainableStack::instance().var_stack_.size());
-  EXPECT_FLOAT_EQ(1.0 / 3.0, z.real().val());
-  EXPECT_FLOAT_EQ(0.5, z.imag().val());
+  EXPECT_EQ(15, stan::math::ChainableStack::instance().var_stack_.size());
+  EXPECT_FLOAT_EQ(11.0 / 25.0, z.real().val());
+  EXPECT_FLOAT_EQ(2.0 / 25.0, z.imag().val());
   EXPECT_FLOAT_EQ(1, x.real().val());
   EXPECT_FLOAT_EQ(2, x.imag().val());
   EXPECT_FLOAT_EQ(3, y.real().val());

--- a/test/unit/math/rev/core/std_complex_test.cpp
+++ b/test/unit/math/rev/core/std_complex_test.cpp
@@ -71,33 +71,152 @@ TEST_F(MathRev, assignment_complex) {
   EXPECT_EQ(rhs.imag().vi_, lhs.imag().vi_);
 }
 
-/*
-TEST_F(MathRev, real_component) { ADD_FAILURE() << "not yet implemented"; }
+TEST_F(MathRev, real_component) {
+  std::complex<stan::math::var> c{1, 2};
 
-TEST_F(MathRev, imag_component) { ADD_FAILURE() << "not yet implemented"; }
+  EXPECT_EQ(1, c.real().val());
+}
+
+TEST_F(MathRev, imag_component) {
+  std::complex<stan::math::var> c{1, 2};
+
+  EXPECT_EQ(2, c.imag().val());
+}
 
 TEST_F(MathRev, member_operators) {
+  std::complex<stan::math::var> x{1, 2}, y{3, 4};
+
   // operator+=
+  EXPECT_EQ(4, stan::math::ChainableStack::instance().var_stack_.size());
+  x += y;
+  EXPECT_FLOAT_EQ(4, x.real().val());
+  EXPECT_FLOAT_EQ(6, x.imag().val());
+  EXPECT_FLOAT_EQ(3, y.real().val());
+  EXPECT_FLOAT_EQ(4, y.imag().val());
+  EXPECT_EQ(6, stan::math::ChainableStack::instance().var_stack_.size());
+  stan::math::recover_memory();
+
   // operator-=
+  x = std::complex<stan::math::var>{1, 2};
+  y = std::complex<stan::math::var>{3, 4};
+  EXPECT_EQ(4, stan::math::ChainableStack::instance().var_stack_.size());
+  x -= y;
+  EXPECT_FLOAT_EQ(-2, x.real().val());
+  EXPECT_FLOAT_EQ(-2, x.imag().val());
+  EXPECT_FLOAT_EQ(3, y.real().val());
+  EXPECT_FLOAT_EQ(4, y.imag().val());
+  EXPECT_EQ(6, stan::math::ChainableStack::instance().var_stack_.size());
+  stan::math::recover_memory();
+
   // operator/=
+  x = std::complex<stan::math::var>{1, 2};
+  y = std::complex<stan::math::var>{3, 4};
+  EXPECT_EQ(4, stan::math::ChainableStack::instance().var_stack_.size());
+  x /= y;
+  EXPECT_FLOAT_EQ(1.0 / 3.0, x.real().val());
+  EXPECT_FLOAT_EQ(0.5, x.imag().val());
+  EXPECT_FLOAT_EQ(3, y.real().val());
+  EXPECT_FLOAT_EQ(4, y.imag().val());
+  EXPECT_EQ(6, stan::math::ChainableStack::instance().var_stack_.size());
+  stan::math::recover_memory();
+
   // operator*=
-  ADD_FAILURE() << "not yet implemented";
+  x = std::complex<stan::math::var>{1, 2};
+  y = std::complex<stan::math::var>{3, 4};
+  EXPECT_EQ(4, stan::math::ChainableStack::instance().var_stack_.size());
+  x *= y;
+  EXPECT_FLOAT_EQ(3, x.real().val());
+  EXPECT_FLOAT_EQ(8, x.imag().val());
+  EXPECT_FLOAT_EQ(3, y.real().val());
+  EXPECT_FLOAT_EQ(4, y.imag().val());
+  EXPECT_EQ(6, stan::math::ChainableStack::instance().var_stack_.size());
+  stan::math::recover_memory();
 }
 
 TEST_F(MathRev, unary_operators) {
+  std::complex<stan::math::var> x{1, 2};
+  EXPECT_EQ(2, stan::math::ChainableStack::instance().var_stack_.size());
+
   // operator+
+  std::complex<stan::math::var> z = +x;
+  EXPECT_EQ(2, stan::math::ChainableStack::instance().var_stack_.size());
+  EXPECT_FLOAT_EQ(1, z.real().val());
+  EXPECT_FLOAT_EQ(2, z.imag().val());
+  EXPECT_FLOAT_EQ(1, x.real().val());
+  EXPECT_FLOAT_EQ(2, x.imag().val());
+  stan::math::recover_memory();
+
   // operator-
-  ADD_FAILURE() << "not yet implemented";
+  x = std::complex<stan::math::var>{1, 2};
+  z = -x;
+
+  EXPECT_EQ(4, stan::math::ChainableStack::instance().var_stack_.size());
+  EXPECT_FLOAT_EQ(-1, z.real().val());
+  EXPECT_FLOAT_EQ(-2, z.imag().val());
+  EXPECT_FLOAT_EQ(1, x.real().val());
+  EXPECT_FLOAT_EQ(2, x.imag().val());
+  stan::math::recover_memory();
 }
 
 TEST_F(MathRev, arithmetic) {
+  std::complex<stan::math::var> x{1, 2}, y{3, 4};
+  EXPECT_EQ(4, stan::math::ChainableStack::instance().var_stack_.size());
+
   // operator+
+  std::complex<stan::math::var> z = x - y;
+  EXPECT_EQ(6, stan::math::ChainableStack::instance().var_stack_.size());
+  EXPECT_FLOAT_EQ(-2, z.real().val());
+  EXPECT_FLOAT_EQ(-2, z.imag().val());
+  EXPECT_FLOAT_EQ(1, x.real().val());
+  EXPECT_FLOAT_EQ(2, x.imag().val());
+  EXPECT_FLOAT_EQ(3, y.real().val());
+  EXPECT_FLOAT_EQ(4, y.imag().val());
+  stan::math::recover_memory();
+
   // operator-
+  x = std::complex<stan::math::var>{1, 2};
+  y = std::complex<stan::math::var>{3, 4};
+  z = x + y;
+
+  EXPECT_EQ(6, stan::math::ChainableStack::instance().var_stack_.size());
+  EXPECT_FLOAT_EQ(4, z.real().val());
+  EXPECT_FLOAT_EQ(6, z.imag().val());
+  EXPECT_FLOAT_EQ(1, x.real().val());
+  EXPECT_FLOAT_EQ(2, x.imag().val());
+  EXPECT_FLOAT_EQ(3, y.real().val());
+  EXPECT_FLOAT_EQ(4, y.imag().val());
+  stan::math::recover_memory();
+
   // operator*
+  x = std::complex<stan::math::var>{1, 2};
+  y = std::complex<stan::math::var>{3, 4};
+  z = x * y;
+
+  EXPECT_EQ(6, stan::math::ChainableStack::instance().var_stack_.size());
+  EXPECT_FLOAT_EQ(3, z.real().val());
+  EXPECT_FLOAT_EQ(8, z.imag().val());
+  EXPECT_FLOAT_EQ(1, x.real().val());
+  EXPECT_FLOAT_EQ(2, x.imag().val());
+  EXPECT_FLOAT_EQ(3, y.real().val());
+  EXPECT_FLOAT_EQ(4, y.imag().val());
+  stan::math::recover_memory();
+
   // operator/
-  ADD_FAILURE() << "not yet implemented";
+  x = std::complex<stan::math::var>{1, 2};
+  y = std::complex<stan::math::var>{3, 4};
+  z = x / y;
+
+  EXPECT_EQ(6, stan::math::ChainableStack::instance().var_stack_.size());
+  EXPECT_FLOAT_EQ(1.0 / 3.0, z.real().val());
+  EXPECT_FLOAT_EQ(0.5, z.imag().val());
+  EXPECT_FLOAT_EQ(1, x.real().val());
+  EXPECT_FLOAT_EQ(2, x.imag().val());
+  EXPECT_FLOAT_EQ(3, y.real().val());
+  EXPECT_FLOAT_EQ(4, y.imag().val());
+  stan::math::recover_memory();
 }
 
+/*
 TEST_F(MathRev, comparison) {
   // complex and scalar; assume var and double as scalar?
   // operator==

--- a/test/unit/math/rev/core/std_complex_test.cpp
+++ b/test/unit/math/rev/core/std_complex_test.cpp
@@ -216,13 +216,102 @@ TEST_F(MathRev, arithmetic) {
   stan::math::recover_memory();
 }
 
-/*
 TEST_F(MathRev, comparison) {
   // complex and scalar; assume var and double as scalar?
   // operator==
-  // operator!=
-}
+  std::complex<stan::math::var> x1{1, 2}, y1{3, 4};
+  std::complex<stan::math::var> x2{1, 0}, y2{3, 0};
+  double x_d = 1, y_d = 3;
+  stan::math::var x_v = 1, y_v = 3;
 
+  const int stack_size
+      = stan::math::ChainableStack::instance().var_stack_.size();
+  EXPECT_TRUE(x1 == x1);
+  EXPECT_EQ(stack_size,
+            stan::math::ChainableStack::instance().var_stack_.size());
+  EXPECT_FALSE(x1 == x2);
+  EXPECT_EQ(stack_size,
+            stan::math::ChainableStack::instance().var_stack_.size());
+  EXPECT_FALSE(x1 == y1);
+  EXPECT_EQ(stack_size,
+            stan::math::ChainableStack::instance().var_stack_.size());
+
+  EXPECT_FALSE(x1 == x_d);
+  EXPECT_EQ(stack_size,
+            stan::math::ChainableStack::instance().var_stack_.size());
+  EXPECT_FALSE(x_d == x1);
+  EXPECT_EQ(stack_size,
+            stan::math::ChainableStack::instance().var_stack_.size());
+  EXPECT_TRUE(x2 == x_d);
+  EXPECT_EQ(stack_size,
+            stan::math::ChainableStack::instance().var_stack_.size());
+  EXPECT_TRUE(x_d == x2);
+  EXPECT_EQ(stack_size,
+            stan::math::ChainableStack::instance().var_stack_.size());
+  EXPECT_FALSE(x1 == y_d);
+  EXPECT_EQ(stack_size,
+            stan::math::ChainableStack::instance().var_stack_.size());
+
+  EXPECT_FALSE(x1 == x_v);
+  EXPECT_EQ(stack_size,
+            stan::math::ChainableStack::instance().var_stack_.size());
+  EXPECT_FALSE(x_v == x1);
+  EXPECT_EQ(stack_size,
+            stan::math::ChainableStack::instance().var_stack_.size());
+  EXPECT_TRUE(x2 == x_v);
+  EXPECT_EQ(stack_size,
+            stan::math::ChainableStack::instance().var_stack_.size());
+  EXPECT_TRUE(x_v == x2);
+  EXPECT_EQ(stack_size,
+            stan::math::ChainableStack::instance().var_stack_.size());
+  EXPECT_FALSE(x1 == y_v);
+  EXPECT_EQ(stack_size,
+            stan::math::ChainableStack::instance().var_stack_.size());
+
+  // operator!=
+  EXPECT_FALSE(x1 != x1);
+  EXPECT_EQ(stack_size,
+            stan::math::ChainableStack::instance().var_stack_.size());
+  EXPECT_TRUE(x1 != x2);
+  EXPECT_EQ(stack_size,
+            stan::math::ChainableStack::instance().var_stack_.size());
+  EXPECT_TRUE(x1 != y1);
+  EXPECT_EQ(stack_size,
+            stan::math::ChainableStack::instance().var_stack_.size());
+
+  EXPECT_TRUE(x1 != x_d);
+  EXPECT_EQ(stack_size,
+            stan::math::ChainableStack::instance().var_stack_.size());
+  EXPECT_TRUE(x_d != x1);
+  EXPECT_EQ(stack_size,
+            stan::math::ChainableStack::instance().var_stack_.size());
+  EXPECT_FALSE(x2 != x_d);
+  EXPECT_EQ(stack_size,
+            stan::math::ChainableStack::instance().var_stack_.size());
+  EXPECT_FALSE(x_d != x2);
+  EXPECT_EQ(stack_size,
+            stan::math::ChainableStack::instance().var_stack_.size());
+  EXPECT_TRUE(x1 != y_d);
+  EXPECT_EQ(stack_size,
+            stan::math::ChainableStack::instance().var_stack_.size());
+
+  EXPECT_TRUE(x1 != x_v);
+  EXPECT_EQ(stack_size,
+            stan::math::ChainableStack::instance().var_stack_.size());
+  EXPECT_TRUE(x_v != x1);
+  EXPECT_EQ(stack_size,
+            stan::math::ChainableStack::instance().var_stack_.size());
+  EXPECT_FALSE(x2 != x_v);
+  EXPECT_EQ(stack_size,
+            stan::math::ChainableStack::instance().var_stack_.size());
+  EXPECT_FALSE(x_v != x2);
+  EXPECT_EQ(stack_size,
+            stan::math::ChainableStack::instance().var_stack_.size());
+  EXPECT_TRUE(x1 != y_v);
+  EXPECT_EQ(stack_size,
+            stan::math::ChainableStack::instance().var_stack_.size());
+}
+/*
 TEST_F(MathRev, serialize_deserialize) {
   // operator<<
   // operator>>

--- a/test/unit/math/rev/core/std_complex_test.cpp
+++ b/test/unit/math/rev/core/std_complex_test.cpp
@@ -9,6 +9,7 @@ class MathRev : public testing::Test {
   void SetUp() { stan::math::recover_memory(); }
 };
 
+/*
 TEST_F(MathRev, complex_constructor) {
   std::complex<stan::math::var> x;
   EXPECT_EQ(2, stan::math::ChainableStack::instance().var_stack_.size());
@@ -24,13 +25,9 @@ TEST_F(MathRev, complex_constructor) {
   EXPECT_EQ(2, stan::math::ChainableStack::instance().var_stack_.size());
   stan::math::recover_memory();
 }
-
-/*
+*/
 TEST_F(MathRev, assignment_double) {
   double rhs = 1;
-  // stan::math::var rhs_v = 2;
-  // std::complex<stan::math::var> rhs_c1{3};
-  // std::complex<stan::math::var> rhs_c2{4, 5};
 
   std::complex<stan::math::var> lhs;
   lhs = rhs;
@@ -38,21 +35,17 @@ TEST_F(MathRev, assignment_double) {
   EXPECT_FLOAT_EQ(0, lhs.imag().val());
   EXPECT_EQ(4, stan::math::ChainableStack::instance().var_stack_.size());
 }
-*/
 
-/*
 TEST_F(MathRev, assignment_var) {
   stan::math::var rhs = 2;
-  // std::complex<stan::math::var> rhs_c1{3};
-  // std::complex<stan::math::var> rhs_c2{4, 5};
 
   std::complex<stan::math::var> lhs;
   lhs = rhs;
   EXPECT_FLOAT_EQ(2, lhs.real().val());
   EXPECT_FLOAT_EQ(0, lhs.imag().val());
-  EXPECT_EQ(3, stan::math::ChainableStack::instance().var_stack_.size());
+  EXPECT_EQ(4, stan::math::ChainableStack::instance().var_stack_.size());
+  EXPECT_EQ(rhs.vi_, lhs.real().vi_);
 }
-*/
 
 TEST_F(MathRev, assignment_complex_real_only) {
   std::complex<stan::math::var> rhs{3};
@@ -63,6 +56,7 @@ TEST_F(MathRev, assignment_complex_real_only) {
   EXPECT_FLOAT_EQ(0, lhs.imag().val());
   EXPECT_EQ(4, stan::math::ChainableStack::instance().var_stack_.size());
   EXPECT_EQ(rhs.real().vi_, lhs.real().vi_);
+  EXPECT_EQ(rhs.imag().vi_, lhs.imag().vi_);
 }
 
 TEST_F(MathRev, assignment_complex) {

--- a/test/unit/math/rev/core/std_complex_test.cpp
+++ b/test/unit/math/rev/core/std_complex_test.cpp
@@ -1,0 +1,106 @@
+#include <stan/math/rev/scal.hpp>
+#include <stan/math/rev/core/std_complex.hpp>
+#include <gtest/gtest.h>
+
+// For a definition of the spec:
+// https://en.cppreference.com/w/cpp/numeric/complex
+class MathRev : public testing::Test {
+ public:
+  void SetUp() { stan::math::recover_memory(); }
+};
+
+TEST_F(MathRev, complex_constructor) {
+  std::complex<stan::math::var> x;
+  EXPECT_EQ(0, stan::math::ChainableStack::instance().var_stack_.size());
+  stan::math::recover_memory();
+
+  std::complex<stan::math::var> y{0};
+  EXPECT_EQ(1, stan::math::ChainableStack::instance().var_stack_.size());
+  stan::math::recover_memory();
+
+  std::complex<stan::math::var> z{0, 0};
+  EXPECT_EQ(2, stan::math::ChainableStack::instance().var_stack_.size());
+  stan::math::recover_memory();
+}
+
+TEST_F(MathRev, assignment) {  // operator=
+  ADD_FAILURE() << "not yet implemented";
+}
+
+TEST_F(MathRev, real_component) { ADD_FAILURE() << "not yet implemented"; }
+
+TEST_F(MathRev, imag_component) { ADD_FAILURE() << "not yet implemented"; }
+
+TEST_F(MathRev, member_operators) {
+  // operator+=
+  // operator-=
+  // operator/=
+  // operator*=
+  ADD_FAILURE() << "not yet implemented";
+}
+
+TEST_F(MathRev, unary_operators) {
+  // operator+
+  // operator-
+  ADD_FAILURE() << "not yet implemented";
+}
+
+TEST_F(MathRev, arithmetic) {
+  // operator+
+  // operator-
+  // operator*
+  // operator/
+  ADD_FAILURE() << "not yet implemented";
+}
+
+TEST_F(MathRev, comparison) {
+  // complex and scalar; assume var and double as scalar?
+  // operator==
+  // operator!=
+}
+
+TEST_F(MathRev, serialize_deserialize) {
+  // operator<<
+  // operator>>
+  ADD_FAILURE() << "not yet implemented";
+}
+
+TEST_F(MathRev, real) {
+  // real
+  ADD_FAILURE() << "not yet implemented";
+}
+
+TEST_F(MathRev, imag) {
+  // imag
+  ADD_FAILURE() << "not yet implemented";
+}
+
+TEST_F(MathRev, abs) {
+  // abs
+  ADD_FAILURE() << "not yet implemented";
+}
+
+TEST_F(MathRev, arg) {
+  // arg
+  ADD_FAILURE() << "not yet implemented";
+}
+
+TEST_F(MathRev, norm) {
+  // norm
+  ADD_FAILURE() << "not yet implemented";
+}
+
+TEST_F(MathRev, conj) {
+  // conj
+  ADD_FAILURE() << "not yet implemented";
+}
+
+TEST_F(MathRev, proj) {
+  // projg
+  ADD_FAILURE() << "not yet implemented";
+}
+
+TEST_F(MathRev, polar) {
+  // polar
+  ADD_FAILURE() << "not yet implemented";
+}

--- a/test/unit/math/rev/core/std_complex_test.cpp
+++ b/test/unit/math/rev/core/std_complex_test.cpp
@@ -11,11 +11,13 @@ class MathRev : public testing::Test {
 
 TEST_F(MathRev, complex_constructor) {
   std::complex<stan::math::var> x;
-  EXPECT_EQ(0, stan::math::ChainableStack::instance().var_stack_.size());
+  EXPECT_EQ(2, stan::math::ChainableStack::instance().var_stack_.size());
+  EXPECT_FLOAT_EQ(0, x.real().val());
+  EXPECT_FLOAT_EQ(0, x.imag().val());
   stan::math::recover_memory();
 
   std::complex<stan::math::var> y{0};
-  EXPECT_EQ(1, stan::math::ChainableStack::instance().var_stack_.size());
+  EXPECT_EQ(2, stan::math::ChainableStack::instance().var_stack_.size());
   stan::math::recover_memory();
 
   std::complex<stan::math::var> z{0, 0};
@@ -23,10 +25,59 @@ TEST_F(MathRev, complex_constructor) {
   stan::math::recover_memory();
 }
 
-TEST_F(MathRev, assignment) {  // operator=
-  ADD_FAILURE() << "not yet implemented";
+/*
+TEST_F(MathRev, assignment_double) {
+  double rhs = 1;
+  // stan::math::var rhs_v = 2;
+  // std::complex<stan::math::var> rhs_c1{3};
+  // std::complex<stan::math::var> rhs_c2{4, 5};
+
+  std::complex<stan::math::var> lhs;
+  lhs = rhs;
+  EXPECT_FLOAT_EQ(1, lhs.real().val());
+  EXPECT_FLOAT_EQ(0, lhs.imag().val());
+  EXPECT_EQ(4, stan::math::ChainableStack::instance().var_stack_.size());
+}
+*/
+
+/*
+TEST_F(MathRev, assignment_var) {
+  stan::math::var rhs = 2;
+  // std::complex<stan::math::var> rhs_c1{3};
+  // std::complex<stan::math::var> rhs_c2{4, 5};
+
+  std::complex<stan::math::var> lhs;
+  lhs = rhs;
+  EXPECT_FLOAT_EQ(2, lhs.real().val());
+  EXPECT_FLOAT_EQ(0, lhs.imag().val());
+  EXPECT_EQ(3, stan::math::ChainableStack::instance().var_stack_.size());
+}
+*/
+
+TEST_F(MathRev, assignment_complex_real_only) {
+  std::complex<stan::math::var> rhs{3};
+
+  std::complex<stan::math::var> lhs;
+  lhs = rhs;
+  EXPECT_FLOAT_EQ(3, lhs.real().val());
+  EXPECT_FLOAT_EQ(0, lhs.imag().val());
+  EXPECT_EQ(4, stan::math::ChainableStack::instance().var_stack_.size());
+  EXPECT_EQ(rhs.real().vi_, lhs.real().vi_);
 }
 
+TEST_F(MathRev, assignment_complex) {
+  std::complex<stan::math::var> rhs{4, 5};
+
+  std::complex<stan::math::var> lhs;
+  lhs = rhs;
+  EXPECT_FLOAT_EQ(4, lhs.real().val());
+  EXPECT_FLOAT_EQ(5, lhs.imag().val());
+  EXPECT_EQ(4, stan::math::ChainableStack::instance().var_stack_.size());
+  EXPECT_EQ(rhs.real().vi_, lhs.real().vi_);
+  EXPECT_EQ(rhs.imag().vi_, lhs.imag().vi_);
+}
+
+/*
 TEST_F(MathRev, real_component) { ADD_FAILURE() << "not yet implemented"; }
 
 TEST_F(MathRev, imag_component) { ADD_FAILURE() << "not yet implemented"; }
@@ -104,3 +155,4 @@ TEST_F(MathRev, polar) {
   // polar
   ADD_FAILURE() << "not yet implemented";
 }
+*/

--- a/test/unit/math/rev/core/std_complex_test.cpp
+++ b/test/unit/math/rev/core/std_complex_test.cpp
@@ -370,25 +370,84 @@ TEST_F(MathRev, imag) {
   EXPECT_EQ(4, stan::math::ChainableStack::instance().var_stack_.size());
 }
 
-/*
 TEST_F(MathRev, abs) {
-  // abs
-  ADD_FAILURE() << "not yet implemented";
+  std::complex<stan::math::var> z{3, 4};
+  stan::math::var f = abs(z);
+  EXPECT_EQ(5, f.val());
+  std::vector<stan::math::var> x{real(z)};
+  std::vector<double> g;
+  f.grad(x, g);
+  EXPECT_FLOAT_EQ(0.6, g[0]);
 }
 
 TEST_F(MathRev, arg) {
-  // arg
-  ADD_FAILURE() << "not yet implemented";
+  std::complex<stan::math::var> z{1, stan::math::pi()};
+  stan::math::var f = arg(z);
+  EXPECT_EQ(f.val(), stan::math::atan2(std::imag(z), std::real(z)));
 }
 
-TEST_F(MathRev, norm) {
-  // norm
-  ADD_FAILURE() << "not yet implemented";
+TEST_F(MathRev, isinf) {
+  std::complex<stan::math::var> a{0, 0};
+  std::complex<double> b{0, 0};
+  EXPECT_EQ(std::isinf(b), std::isinf(a));
+  EXPECT_FALSE(std::isinf(a));
+
+  a.real(std::numeric_limits<double>::infinity());
+  a.imag(0);
+  b.real(std::numeric_limits<double>::infinity());
+  b.imag(0);
+  EXPECT_EQ(std::isinf(b), std::isinf(a));
+  EXPECT_TRUE(std::isinf(a));
+
+  a.real(0);
+  a.imag(std::numeric_limits<double>::infinity());
+  b.real(0);
+  b.imag(std::numeric_limits<double>::infinity());
+  EXPECT_EQ(std::isinf(b), std::isinf(a));
+  EXPECT_FALSE(std::isinf(a));
 }
+
+TEST_F(MathRev, isnan) {
+  std::complex<stan::math::var> a{0, 0};
+  std::complex<double> b{0, 0};
+  EXPECT_EQ(std::isnan(b), std::isnan(a));
+  EXPECT_FALSE(std::isnan(a));
+
+  a.real(std::numeric_limits<double>::quiet_NaN());
+  a.imag(0);
+  b.real(std::numeric_limits<double>::quiet_NaN());
+  b.imag(0);
+  EXPECT_EQ(std::isnan(b), std::isnan(a));
+  EXPECT_TRUE(std::isnan(a));
+
+  a.real(0);
+  a.imag(std::numeric_limits<double>::quiet_NaN());
+  b.real(0);
+  b.imag(std::numeric_limits<double>::quiet_NaN());
+  EXPECT_EQ(std::isnan(b), std::isnan(a));
+  EXPECT_FALSE(std::isnan(a));
+}
+
+/*
+TEST_F(MathRev, norm) {
+  std::complex<stan::math::var> z{3, 4};
+  stan::math::var f = norm(z);
+  EXPECT_EQ(f.val(), 25);
+
+  std::vector<stan::math::var> x{imag(z)};
+  std::vector<double> g;
+  f.grad(x, g);
+  EXPECT_FLOAT_EQ(g[0], 8);
+}
+*/
+
+/*
 
 TEST_F(MathRev, conj) {
-  // conj
-  ADD_FAILURE() << "not yet implemented";
+  std::complex<stan::math::var> z(1, 2);
+  stan::math::var f = conj(z);
+  EXPECT_EQ(real(f).val(), 1);
+  EXPECT_EQ(imag(f).val(), -2);
 }
 
 TEST_F(MathRev, proj) {

--- a/test/unit/math/rev/core/std_complex_test.cpp
+++ b/test/unit/math/rev/core/std_complex_test.cpp
@@ -9,7 +9,6 @@ class MathRev : public testing::Test {
   void SetUp() { stan::math::recover_memory(); }
 };
 
-/*
 TEST_F(MathRev, complex_constructor) {
   std::complex<stan::math::var> x;
   EXPECT_EQ(2, stan::math::ChainableStack::instance().var_stack_.size());
@@ -25,7 +24,7 @@ TEST_F(MathRev, complex_constructor) {
   EXPECT_EQ(2, stan::math::ChainableStack::instance().var_stack_.size());
   stan::math::recover_memory();
 }
-*/
+
 TEST_F(MathRev, assignment_double) {
   double rhs = 1;
 
@@ -428,7 +427,6 @@ TEST_F(MathRev, isnan) {
   EXPECT_FALSE(std::isnan(a));
 }
 
-/*
 TEST_F(MathRev, norm) {
   std::complex<stan::math::var> z{3, 4};
   stan::math::var f = norm(z);
@@ -439,24 +437,40 @@ TEST_F(MathRev, norm) {
   f.grad(x, g);
   EXPECT_FLOAT_EQ(g[0], 8);
 }
-*/
-
-/*
 
 TEST_F(MathRev, conj) {
   std::complex<stan::math::var> z(1, 2);
-  stan::math::var f = conj(z);
+  std::complex<stan::math::var> f = conj(z);
   EXPECT_EQ(real(f).val(), 1);
   EXPECT_EQ(imag(f).val(), -2);
 }
 
 TEST_F(MathRev, proj) {
-  // projg
-  ADD_FAILURE() << "not yet implemented";
+  std::complex<stan::math::var> z1(1, 2);
+  std::complex<stan::math::var> f = proj(z1);
+  EXPECT_TRUE(f == z1) << f << std::endl;
+
+  using stan::math::positive_infinity;
+  std::complex<stan::math::var> z2(positive_infinity(), -1);
+  f = proj(z2);
+  EXPECT_TRUE(f == std::complex<stan::math::var>(positive_infinity(), -0))
+      << f << std::endl;
+
+  using stan::math::negative_infinity;
+  std::complex<stan::math::var> z3(0, negative_infinity());
+  f = proj(z3);
+  EXPECT_TRUE(f == std::complex<stan::math::var>(positive_infinity(), -0))
+      << f << std::endl;
+
+  std::complex<stan::math::var> z4(std::numeric_limits<double>::quiet_NaN(),
+                                   -2.0);
+  f = proj(z4);
+  EXPECT_TRUE(stan::math::is_nan(f.real()));
+  EXPECT_FLOAT_EQ(-2.0, f.imag().val());
 }
 
 TEST_F(MathRev, polar) {
-  // polar
-  ADD_FAILURE() << "not yet implemented";
+  std::complex<stan::math::var> z = std::polar(1, 0);
+  stan::math::var f = arg(z);
+  EXPECT_EQ(f.val(), 0.0);
 }
-*/

--- a/test/unit/math/rev/scal/fun/abs_test.cpp
+++ b/test/unit/math/rev/scal/fun/abs_test.cpp
@@ -78,3 +78,13 @@ TEST(AgradRev, check_varis_on_stack) {
   AVAR a = 0.68;
   test::check_varis_on_stack(stan::math::abs(a));
 }
+
+TEST(AgradRev, abs_complex) {
+  std::complex<stan::math::var> z = std::complex<stan::math::var>(3, 4);
+  auto f = abs(z);
+  EXPECT_EQ(5, f.val());
+  AVEC x = createAVEC(real(z));
+  VEC g;
+  f.grad(x, g);
+  EXPECT_FLOAT_EQ(0.6, g[0]);
+}

--- a/test/unit/math/rev/scal/fun/acos_test.cpp
+++ b/test/unit/math/rev/scal/fun/acos_test.cpp
@@ -74,3 +74,14 @@ TEST(AgradRev, check_varis_on_stack) {
   AVAR a = 0.68;
   test::check_varis_on_stack(stan::math::acos(a));
 }
+
+TEST(AgradRev, complex) {
+  stan::math::var x = 2.0 / 3;
+  double h = 1e-8;
+  std::complex<stan::math::var> z(x, h);
+  auto f = acos(z);
+  AVEC v = createAVEC(real(z));
+  VEC g;
+  real(f).grad(v, g);
+  EXPECT_FLOAT_EQ(g[0], imag(f).val() / h);
+}

--- a/test/unit/math/rev/scal/fun/acosh_test.cpp
+++ b/test/unit/math/rev/scal/fun/acosh_test.cpp
@@ -61,3 +61,14 @@ TEST(AgradRev, check_varis_on_stack) {
   AVAR a = 1.3;
   test::check_varis_on_stack(stan::math::acosh(a));
 }
+
+TEST(AgradRev, complex) {
+  stan::math::var x = 3.0 / 2;
+  double h = 1e-8;
+  std::complex<stan::math::var> z(x, h);
+  auto f = acosh(z);
+  AVEC v = createAVEC(real(z));
+  VEC g;
+  real(f).grad(v, g);
+  EXPECT_FLOAT_EQ(g[0], imag(f).val() / h);
+}

--- a/test/unit/math/rev/scal/fun/arg_test.cpp
+++ b/test/unit/math/rev/scal/fun/arg_test.cpp
@@ -1,0 +1,10 @@
+#include <stan/math/rev/scal.hpp>
+#include <gtest/gtest.h>
+
+TEST(AgradRev, arg_test) {
+  std::complex<stan::math::var> z
+      = std::complex<stan::math::var>(1, stan::math::pi());
+  auto f = arg(z);
+  using stan::math::atan2;
+  EXPECT_EQ(f.val(), atan2(std::imag(z), std::real(z)));
+}

--- a/test/unit/math/rev/scal/fun/asin_test.cpp
+++ b/test/unit/math/rev/scal/fun/asin_test.cpp
@@ -74,3 +74,14 @@ TEST(AgradRev, check_varis_on_stack) {
   AVAR a = 0.68;
   test::check_varis_on_stack(stan::math::asin(a));
 }
+
+TEST(AgradRev, complex) {
+  stan::math::var x = 2.0 / 3;
+  double h = 1e-8;
+  std::complex<stan::math::var> z(x, h);
+  auto f = asin(z);
+  AVEC v = createAVEC(real(z));
+  VEC g;
+  real(f).grad(v, g);
+  EXPECT_FLOAT_EQ(g[0], imag(f).val() / h);
+}

--- a/test/unit/math/rev/scal/fun/asinh_test.cpp
+++ b/test/unit/math/rev/scal/fun/asinh_test.cpp
@@ -61,3 +61,14 @@ TEST(AgradRev, check_varis_on_stack) {
   AVAR a = 0.2;
   test::check_varis_on_stack(stan::math::asinh(a));
 }
+
+TEST(AgradRev, complex) {
+  stan::math::var x = 2.0 / 3;
+  double h = 1e-8;
+  std::complex<stan::math::var> z(x, h);
+  auto f = asinh(z);
+  AVEC v = createAVEC(real(z));
+  VEC g;
+  real(f).grad(v, g);
+  EXPECT_FLOAT_EQ(g[0], imag(f).val() / h);
+}

--- a/test/unit/math/rev/scal/fun/atan_test.cpp
+++ b/test/unit/math/rev/scal/fun/atan_test.cpp
@@ -62,3 +62,14 @@ TEST(AgradRev, check_varis_on_stack) {
   AVAR a = 1;
   test::check_varis_on_stack(stan::math::atan(a));
 }
+
+TEST(AgradRev, complex) {
+  stan::math::var x = 2.0 / 3;
+  double h = 1e-8;
+  std::complex<stan::math::var> z(x, h);
+  auto f = atan(z);
+  AVEC v = createAVEC(real(z));
+  VEC g;
+  real(f).grad(v, g);
+  EXPECT_FLOAT_EQ(g[0], imag(f).val() / h);
+}

--- a/test/unit/math/rev/scal/fun/atanh_test.cpp
+++ b/test/unit/math/rev/scal/fun/atanh_test.cpp
@@ -61,3 +61,14 @@ TEST(AgradRev, check_varis_on_stack) {
   AVAR a = 0.3;
   test::check_varis_on_stack(stan::math::atanh(a));
 }
+
+TEST(AgradRev, complex) {
+  stan::math::var x = 2.0 / 3;
+  double h = 1e-8;
+  std::complex<stan::math::var> z(x, h);
+  auto f = atanh(z);
+  AVEC v = createAVEC(real(z));
+  VEC g;
+  real(f).grad(v, g);
+  EXPECT_FLOAT_EQ(g[0], imag(f).val() / h);
+}

--- a/test/unit/math/rev/scal/fun/cos_test.cpp
+++ b/test/unit/math/rev/scal/fun/cos_test.cpp
@@ -51,3 +51,14 @@ TEST(AgradRev, check_varis_on_stack) {
   AVAR a = 0.49;
   test::check_varis_on_stack(stan::math::cos(a));
 }
+
+TEST(AgradRev, complex) {
+  stan::math::var x = 2.0 / 3;
+  double h = 1e-8;
+  std::complex<stan::math::var> z(x, h);
+  auto f = cos(z);
+  AVEC v = createAVEC(real(z));
+  VEC g;
+  real(f).grad(v, g);
+  EXPECT_FLOAT_EQ(g[0], imag(f).val() / h);
+}

--- a/test/unit/math/rev/scal/fun/cosh_test.cpp
+++ b/test/unit/math/rev/scal/fun/cosh_test.cpp
@@ -67,3 +67,14 @@ TEST(AgradRev, check_varis_on_stack) {
   AVAR a = 0.68;
   test::check_varis_on_stack(stan::math::cosh(a));
 }
+
+TEST(AgradRev, complex) {
+  stan::math::var x = 2.0 / 3;
+  double h = 1e-8;
+  std::complex<stan::math::var> z(x, h);
+  auto f = cosh(z);
+  AVEC v = createAVEC(real(z));
+  VEC g;
+  real(f).grad(v, g);
+  EXPECT_FLOAT_EQ(g[0], imag(f).val() / h);
+}

--- a/test/unit/math/rev/scal/fun/exp_test.cpp
+++ b/test/unit/math/rev/scal/fun/exp_test.cpp
@@ -30,3 +30,15 @@ TEST(AgradRev, check_varis_on_stack) {
   AVAR a(6.0);
   test::check_varis_on_stack(stan::math::exp(a));
 }
+
+TEST(AgradRev, euler) {
+  std::complex<stan::math::var> z
+      = std::complex<stan::math::var>(0.0, stan::math::pi());
+  std::complex<stan::math::var> f = exp(z);
+  EXPECT_FLOAT_EQ(-1, real(f).val());
+  EXPECT_FLOAT_EQ(1, 1 + imag(f).val());
+  AVEC x = createAVEC(imag(z));
+  VEC g;
+  real(f).grad(x, g);
+  EXPECT_FLOAT_EQ(1 + g[0], 1);
+}

--- a/test/unit/math/rev/scal/fun/log10_test.cpp
+++ b/test/unit/math/rev/scal/fun/log10_test.cpp
@@ -29,3 +29,14 @@ TEST(AgradRev, check_varis_on_stack) {
   stan::math::var x = 4.0;
   test::check_varis_on_stack(stan::math::log10(x));
 }
+
+TEST(AgradRev, complex) {
+  stan::math::var x = stan::math::pi();
+  double h = 1e-8;
+  std::complex<stan::math::var> z(x, h);
+  auto f = log10(z);
+  AVEC v = createAVEC(real(z));
+  VEC g;
+  real(f).grad(v, g);
+  EXPECT_FLOAT_EQ(g[0], imag(f).val() / h);
+}

--- a/test/unit/math/rev/scal/fun/log_test.cpp
+++ b/test/unit/math/rev/scal/fun/log_test.cpp
@@ -46,3 +46,16 @@ TEST(AgradRev, check_varis_on_stack) {
   AVAR a(5.0);
   test::check_varis_on_stack(stan::math::log(a));
 }
+
+TEST(AgradRev, complex) {
+  stan::math::var x = stan::math::pi();
+  std::complex<stan::math::var> z(x, 2.0 / 3);
+  EXPECT_TRUE(log(conj(z)) == conj(log(z)));
+  double h = 1e-8;
+  z = std::complex<stan::math::var>(x, h);
+  auto f = log(z);
+  AVEC v = createAVEC(real(z));
+  VEC g;
+  real(f).grad(v, g);
+  EXPECT_FLOAT_EQ(g[0], imag(f).val() / h);
+}

--- a/test/unit/math/rev/scal/fun/sin_test.cpp
+++ b/test/unit/math/rev/scal/fun/sin_test.cpp
@@ -51,3 +51,14 @@ TEST(AgradRev, check_varis_on_stack) {
   AVAR a = 0.49;
   test::check_varis_on_stack(stan::math::sin(a));
 }
+
+TEST(AgradRev, complex) {
+  stan::math::var x = 2.0 / 3;
+  double h = 1e-8;
+  std::complex<stan::math::var> z(x, h);
+  auto f = sin(z);
+  AVEC v = createAVEC(real(z));
+  VEC g;
+  real(f).grad(v, g);
+  EXPECT_FLOAT_EQ(g[0], imag(f).val() / h);
+}

--- a/test/unit/math/rev/scal/fun/sinh_test.cpp
+++ b/test/unit/math/rev/scal/fun/sinh_test.cpp
@@ -66,3 +66,14 @@ TEST(AgradRev, check_varis_on_stack) {
   AVAR a = 0.68;
   test::check_varis_on_stack(stan::math::sinh(a));
 }
+
+TEST(AgradRev, complex) {
+  stan::math::var x = 2.0 / 3;
+  double h = 1e-8;
+  std::complex<stan::math::var> z(x, h);
+  auto f = sinh(z);
+  AVEC v = createAVEC(real(z));
+  VEC g;
+  real(f).grad(v, g);
+  EXPECT_FLOAT_EQ(g[0], imag(f).val() / h);
+}

--- a/test/unit/math/rev/scal/fun/std_complex_test.cpp
+++ b/test/unit/math/rev/scal/fun/std_complex_test.cpp
@@ -1,5 +1,5 @@
 #include <stan/math/rev/scal.hpp>
-#include <stan/math/rev/core/std_complex.hpp>
+#include <stan/math/rev/scal/fun/std_complex.hpp>
 #include <gtest/gtest.h>
 
 // For a definition of the spec:

--- a/test/unit/math/rev/scal/fun/std_complex_test.cpp
+++ b/test/unit/math/rev/scal/fun/std_complex_test.cpp
@@ -476,3 +476,42 @@ TEST_F(MathRev, polar) {
   stan::math::var f = arg(z);
   EXPECT_EQ(f.val(), 0.0);
 }
+
+TEST_F(MathRev, sqrt_conj) {
+  std::complex<stan::math::var> z(-5, 12);
+  EXPECT_TRUE(std::sqrt(std::conj(z)) == std::conj(std::sqrt(z)));
+}
+
+TEST_F(MathRev, sqrt_negative_real) {
+  std::complex<stan::math::var> z(-5, 12);
+  std::complex<stan::math::var> zsqrt = sqrt(z);
+  EXPECT_FLOAT_EQ(2, zsqrt.real().val());
+  EXPECT_FLOAT_EQ(3, zsqrt.imag().val());
+}
+
+TEST_F(MathRev, sqrt_positive_real) {
+  std::complex<stan::math::var> z(9, 40);
+  std::complex<stan::math::var> zsqrt = sqrt(z);
+  EXPECT_FLOAT_EQ(5, zsqrt.real().val());
+  EXPECT_FLOAT_EQ(4, zsqrt.imag().val());
+}
+
+TEST_F(MathRev, sqrt_zero_real) {
+  std::complex<stan::math::var> z(0, 8);
+  std::complex<stan::math::var> zsqrt = sqrt(z);
+  EXPECT_FLOAT_EQ(2, zsqrt.real().val());
+  EXPECT_FLOAT_EQ(2, zsqrt.imag().val());
+}
+
+TEST_F(MathRev, pow) {
+  std::complex<stan::math::var> i(0, 1);
+  auto f = pow(i, i);
+  EXPECT_EQ(real(f).val(), exp(-stan::math::pi() / 2));
+}
+
+TEST_F(MathRev, pow_zero) {
+  std::complex<stan::math::var> i(0, 0);
+  auto f = pow(i, i);
+  EXPECT_EQ(0, real(f).val());
+  EXPECT_EQ(0, imag(f).val());
+}

--- a/test/unit/math/rev/scal/fun/std_complex_test.cpp
+++ b/test/unit/math/rev/scal/fun/std_complex_test.cpp
@@ -505,13 +505,13 @@ TEST_F(MathRev, sqrt_zero_real) {
 
 TEST_F(MathRev, pow) {
   std::complex<stan::math::var> i(0, 1);
-  auto f = pow(i, i);
+  std::complex<stan::math::var> f = pow(i, i);
   EXPECT_EQ(real(f).val(), exp(-stan::math::pi() / 2));
 }
 
 TEST_F(MathRev, pow_zero) {
   std::complex<stan::math::var> i(0, 0);
-  auto f = pow(i, i);
-  EXPECT_EQ(0, real(f).val());
+  std::complex<stan::math::var> f = pow(i, i);
+  EXPECT_EQ(1, real(f).val());
   EXPECT_EQ(0, imag(f).val());
 }

--- a/test/unit/math/rev/scal/fun/std_complex_test.cpp
+++ b/test/unit/math/rev/scal/fun/std_complex_test.cpp
@@ -1,6 +1,8 @@
 #include <stan/math/rev/scal.hpp>
 #include <stan/math/rev/scal/fun/std_complex.hpp>
 #include <gtest/gtest.h>
+#include <limits>
+#include <vector>
 
 // For a definition of the spec:
 // https://en.cppreference.com/w/cpp/numeric/complex

--- a/test/unit/math/rev/scal/fun/tan_test.cpp
+++ b/test/unit/math/rev/scal/fun/tan_test.cpp
@@ -53,3 +53,14 @@ TEST(AgradRev, check_varis_on_stack) {
   AVAR a = 0.68;
   test::check_varis_on_stack(stan::math::tan(a));
 }
+
+TEST(AgradRev, complex) {
+  stan::math::var x = 2.0 / 3;
+  double h = 1e-8;
+  std::complex<stan::math::var> z(x, h);
+  auto f = tan(z);
+  AVEC v = createAVEC(real(z));
+  VEC g;
+  real(f).grad(v, g);
+  EXPECT_FLOAT_EQ(g[0], imag(f).val() / h);
+}

--- a/test/unit/math/rev/scal/fun/tanh_test.cpp
+++ b/test/unit/math/rev/scal/fun/tanh_test.cpp
@@ -66,3 +66,14 @@ TEST(AgradRev, check_varis_on_stack) {
   AVAR a = 0.68;
   test::check_varis_on_stack(stan::math::tanh(a));
 }
+
+TEST(AgradRev, complex) {
+  stan::math::var x = 2.0 / 3;
+  double h = 1e-8;
+  std::complex<stan::math::var> z(x, h);
+  auto f = tanh(z);
+  AVEC v = createAVEC(real(z));
+  VEC g;
+  real(f).grad(v, g);
+  EXPECT_FLOAT_EQ(g[0], imag(f).val() / h);
+}


### PR DESCRIPTION
## Summary

This implements `std::complex<stan::math::var>`. We accomplished this by template specialization for enough of the implementation where it'll work.

`std::complex<T>` for non primitive types is explicitly in unspecified. We implemented as much as was necessary for the basic functions to pass. This may have to be revisited as different standard template library implementations may trigger seg faults. For more background information beyond this, see #123.

Note: the implementation is intentionally at `stan/math/rev/scal/fun/std_complex.hpp` even though the rest of the `std` overloads are in `stan/math/rev/core`. This uses functions that need to be instantiated first, so it made sense that it wasn't in the `core` directory.

Here's what we implemented:

1. [constructor](https://github.com/stan-dev/math/pull/1031/files#diff-c23185ef659cb1e552857a9e24497710R13)
2. [operator=](https://github.com/stan-dev/math/pull/1031/files#diff-c23185ef659cb1e552857a9e24497710R42)
3. [`var norm(complex<var>)`](https://github.com/stan-dev/math/pull/1031/files#diff-c23185ef659cb1e552857a9e24497710R60)
4. [operator/](https://github.com/stan-dev/math/pull/1031/files#diff-c23185ef659cb1e552857a9e24497710R65)
5. [operator*](https://github.com/stan-dev/math/pull/1031/files#diff-c23185ef659cb1e552857a9e24497710R73)
6. [operator/=](https://github.com/stan-dev/math/pull/1031/files#diff-c23185ef659cb1e552857a9e24497710R80)
7. [operator*=](https://github.com/stan-dev/math/pull/1031/files#diff-c23185ef659cb1e552857a9e24497710R88)
8. [operator==](https://github.com/stan-dev/math/pull/1031/files#diff-c23185ef659cb1e552857a9e24497710R96)
9. [operator!=](https://github.com/stan-dev/math/pull/1031/files#diff-c23185ef659cb1e552857a9e24497710R122)
10. [`int isinf(complex<var>)`](https://github.com/stan-dev/math/pull/1031/files#diff-c23185ef659cb1e552857a9e24497710R146)
11. [`int isnan(complex<var>)`](https://github.com/stan-dev/math/pull/1031/files#diff-c23185ef659cb1e552857a9e24497710R150)
12. [`var abs(complex<var>)`](https://github.com/stan-dev/math/pull/1031/files#diff-c23185ef659cb1e552857a9e24497710R154)
13. [`complex<var> conj(complex<var>)`](https://github.com/stan-dev/math/pull/1031/files#diff-c23185ef659cb1e552857a9e24497710R159)
15. [`complex<var> proj(complex<var>)`](https://github.com/stan-dev/math/pull/1031/files#diff-c23185ef659cb1e552857a9e24497710R164)

## Tests

There are unit tests for all the operators for `std::complex` and tests for a lot of the functions. We test that the right number of `stan::math::var`s are on the stack after the different operations.

The tests are located in: `test/unit/math/rev/scal/fun/std_complex_test.cpp` and can be run:

```
./runTests.py test/unit/math/rev/scal/fun/std_complex_test.cpp
```

For tests, we tested everything in the spec: https://en.cppreference.com/w/cpp/numeric/complex
That's every member function and non-member function

@bgoodri: your original example compiles and runs!

## Side Effects

I had to add the `constexpr` specifier to the constructor for `stan::math::var` to make it compile. For details, see: [constexpr specifier](https://en.cppreference.com/w/cpp/language/constexpr). @bob-carpenter, that should be fine, right?

## Checklist

- [x] Math issue #123.

- [ ] Copyright holder: 
    - Generable (@syclik's code)
    - Trustees of Columbia University (@bbbales2's code)
   - Trustees of Columbia University (@bgoodri's code)

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [ ] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
