### PR TITLE
Feature/issue 1049 ode speedup

### DIFF
--- a/stan/math/rev/arr/functor/coupled_ode_system.hpp
+++ b/stan/math/rev/arr/functor/coupled_ode_system.hpp
@@ -101,19 +101,12 @@ struct coupled_ode_system<F, double, var> {
                   double t) const {
     using std::vector;
 
-    vector<double> grad(N_ + M_);
-
     try {
       start_nested();
 
-      vector<var> z_vars;
-      z_vars.reserve(N_ + M_);
-
       vector<var> y_vars(z.begin(), z.begin() + N_);
-      z_vars.insert(z_vars.end(), y_vars.begin(), y_vars.end());
 
       vector<var> theta_vars(theta_dbl_.begin(), theta_dbl_.end());
-      z_vars.insert(z_vars.end(), theta_vars.begin(), theta_vars.end());
 
       vector<var> dy_dt_vars = f_(t, y_vars, theta_vars, x_, x_int_, msgs_);
 
@@ -123,15 +116,15 @@ struct coupled_ode_system<F, double, var> {
       for (size_t i = 0; i < N_; i++) {
         dz_dt[i] = dy_dt_vars[i].val();
         set_zero_all_adjoints_nested();
-        dy_dt_vars[i].grad(z_vars, grad);
+        dy_dt_vars[i].grad();
 
         for (size_t j = 0; j < M_; j++) {
           // orders derivatives by equation (i.e. if there are 2 eqns
           // (y1, y2) and 2 parameters (a, b), dy_dt will be ordered as:
           // dy1_dt, dy2_dt, dy1_da, dy2_da, dy1_db, dy2_db
-          double temp_deriv = grad[N_ + j];
+          double temp_deriv = theta_vars[j].adj();
           for (size_t k = 0; k < N_; k++)
-            temp_deriv += z[N_ + N_ * j + k] * grad[k];
+            temp_deriv += z[N_ + N_ * j + k] * y_vars[k].adj();
 
           dz_dt[N_ + i + j * N_] = temp_deriv;
         }
@@ -284,8 +277,6 @@ struct coupled_ode_system<F, var, double> {
                   double t) const {
     using std::vector;
 
-    std::vector<double> grad(N_);
-
     try {
       start_nested();
 
@@ -299,7 +290,7 @@ struct coupled_ode_system<F, var, double> {
       for (size_t i = 0; i < N_; i++) {
         dz_dt[i] = dy_dt_vars[i].val();
         set_zero_all_adjoints_nested();
-        dy_dt_vars[i].grad(y_vars, grad);
+        dy_dt_vars[i].grad();
 
         for (size_t j = 0; j < N_; j++) {
           // orders derivatives by equation (i.e. if there are 2 eqns
@@ -307,7 +298,7 @@ struct coupled_ode_system<F, var, double> {
           // dy1_dt, dy2_dt, dy1_da, dy2_da, dy1_db, dy2_db
           double temp_deriv = 0;
           for (size_t k = 0; k < N_; k++)
-            temp_deriv += z[N_ + N_ * j + k] * grad[k];
+            temp_deriv += z[N_ + N_ * j + k] * y_vars[k].adj();
 
           dz_dt[N_ + i + j * N_] = temp_deriv;
         }
@@ -478,19 +469,12 @@ struct coupled_ode_system<F, var, var> {
                   double t) const {
     using std::vector;
 
-    vector<double> grad(N_ + M_);
-
     try {
       start_nested();
 
-      vector<var> z_vars;
-      z_vars.reserve(N_ + M_);
-
       vector<var> y_vars(z.begin(), z.begin() + N_);
-      z_vars.insert(z_vars.end(), y_vars.begin(), y_vars.end());
 
       vector<var> theta_vars(theta_dbl_.begin(), theta_dbl_.end());
-      z_vars.insert(z_vars.end(), theta_vars.begin(), theta_vars.end());
 
       vector<var> dy_dt_vars = f_(t, y_vars, theta_vars, x_, x_int_, msgs_);
 
@@ -500,17 +484,25 @@ struct coupled_ode_system<F, var, var> {
       for (size_t i = 0; i < N_; i++) {
         dz_dt[i] = dy_dt_vars[i].val();
         set_zero_all_adjoints_nested();
-        dy_dt_vars[i].grad(z_vars, grad);
+        dy_dt_vars[i].grad();
 
-        for (size_t j = 0; j < N_ + M_; j++) {
+        for (size_t j = 0; j < N_; j++) {
           // orders derivatives by equation (i.e. if there are 2 eqns
           // (y1, y2) and 2 parameters (a, b), dy_dt will be ordered as:
           // dy1_dt, dy2_dt, dy1_da, dy2_da, dy1_db, dy2_db
-          double temp_deriv = j < N_ ? 0 : grad[j];
+          double temp_deriv = 0;
           for (size_t k = 0; k < N_; k++)
-            temp_deriv += z[N_ + N_ * j + k] * grad[k];
+            temp_deriv += z[N_ + N_ * j + k] * y_vars[k].adj();
 
           dz_dt[N_ + i + j * N_] = temp_deriv;
+        }
+
+        for (size_t j = 0; j < M_; j++) {
+          double temp_deriv = theta_vars[j].adj();
+          for (size_t k = 0; k < N_; k++)
+            temp_deriv += z[N_ + N_ * N_ + N_ * j + k] * y_vars[k].adj();
+
+          dz_dt[N_ + N_ * N_ + i + j * N_] = temp_deriv;
         }
       }
     } catch (const std::exception& e) {

--- a/stan/math/rev/arr/functor/coupled_ode_system.hpp
+++ b/stan/math/rev/arr/functor/coupled_ode_system.hpp
@@ -122,10 +122,11 @@ struct coupled_ode_system<F, double, var> {
           // (y1, y2) and 2 parameters (a, b), dy_dt will be ordered as:
           // dy1_dt, dy2_dt, dy1_da, dy2_da, dy1_db, dy2_db
           double temp_deriv = theta_vars[j].adj();
+          const size_t offset = N_ + N_ * j;
           for (size_t k = 0; k < N_; k++)
-            temp_deriv += z[N_ + N_ * j + k] * y_vars[k].adj();
+            temp_deriv += z[offset + k] * y_vars[k].adj();
 
-          dz_dt[N_ + i + j * N_] = temp_deriv;
+          dz_dt[offset + i] = temp_deriv;
         }
 
         set_zero_all_adjoints_nested();
@@ -297,10 +298,11 @@ struct coupled_ode_system<F, var, double> {
           // (y1, y2) and 2 parameters (a, b), dy_dt will be ordered as:
           // dy1_dt, dy2_dt, dy1_da, dy2_da, dy1_db, dy2_db
           double temp_deriv = 0;
+          const size_t offset = N_ + N_ * j;
           for (size_t k = 0; k < N_; k++)
-            temp_deriv += z[N_ + N_ * j + k] * y_vars[k].adj();
+            temp_deriv += z[offset + k] * y_vars[k].adj();
 
-          dz_dt[N_ + i + j * N_] = temp_deriv;
+          dz_dt[offset + i] = temp_deriv;
         }
 
         set_zero_all_adjoints_nested();
@@ -492,18 +494,20 @@ struct coupled_ode_system<F, var, var> {
           // (y1, y2) and 2 parameters (a, b), dy_dt will be ordered as:
           // dy1_dt, dy2_dt, dy1_da, dy2_da, dy1_db, dy2_db
           double temp_deriv = 0;
+          const size_t offset = N_ + N_ * j;
           for (size_t k = 0; k < N_; k++)
-            temp_deriv += z[N_ + N_ * j + k] * y_vars[k].adj();
+            temp_deriv += z[offset + k] * y_vars[k].adj();
 
-          dz_dt[N_ + i + j * N_] = temp_deriv;
+          dz_dt[offset + i] = temp_deriv;
         }
 
         for (size_t j = 0; j < M_; j++) {
           double temp_deriv = theta_vars[j].adj();
+          const size_t offset = N_ + N_ * N_ + N_ * j;
           for (size_t k = 0; k < N_; k++)
-            temp_deriv += z[N_ + N_ * N_ + N_ * j + k] * y_vars[k].adj();
+            temp_deriv += z[offset + k] * y_vars[k].adj();
 
-          dz_dt[N_ + N_ * N_ + i + j * N_] = temp_deriv;
+          dz_dt[offset + i] = temp_deriv;
         }
 
         set_zero_all_adjoints_nested();

--- a/stan/math/rev/arr/functor/coupled_ode_system.hpp
+++ b/stan/math/rev/arr/functor/coupled_ode_system.hpp
@@ -115,7 +115,6 @@ struct coupled_ode_system<F, double, var> {
 
       for (size_t i = 0; i < N_; i++) {
         dz_dt[i] = dy_dt_vars[i].val();
-        set_zero_all_adjoints_nested();
         dy_dt_vars[i].grad();
 
         for (size_t j = 0; j < M_; j++) {
@@ -128,6 +127,8 @@ struct coupled_ode_system<F, double, var> {
 
           dz_dt[N_ + i + j * N_] = temp_deriv;
         }
+
+        set_zero_all_adjoints_nested();
       }
     } catch (const std::exception& e) {
       recover_memory_nested();
@@ -289,7 +290,6 @@ struct coupled_ode_system<F, var, double> {
 
       for (size_t i = 0; i < N_; i++) {
         dz_dt[i] = dy_dt_vars[i].val();
-        set_zero_all_adjoints_nested();
         dy_dt_vars[i].grad();
 
         for (size_t j = 0; j < N_; j++) {
@@ -302,6 +302,8 @@ struct coupled_ode_system<F, var, double> {
 
           dz_dt[N_ + i + j * N_] = temp_deriv;
         }
+
+        set_zero_all_adjoints_nested();
       }
     } catch (const std::exception& e) {
       recover_memory_nested();
@@ -483,7 +485,6 @@ struct coupled_ode_system<F, var, var> {
 
       for (size_t i = 0; i < N_; i++) {
         dz_dt[i] = dy_dt_vars[i].val();
-        set_zero_all_adjoints_nested();
         dy_dt_vars[i].grad();
 
         for (size_t j = 0; j < N_; j++) {
@@ -504,6 +505,8 @@ struct coupled_ode_system<F, var, var> {
 
           dz_dt[N_ + N_ * N_ + i + j * N_] = temp_deriv;
         }
+
+        set_zero_all_adjoints_nested();
       }
     } catch (const std::exception& e) {
       recover_memory_nested();


### PR DESCRIPTION
## Summary

The aim of this PR is to speedup the `coupled_ode_system`. This is achieved by reducing the number of temporaries on the AD stack and saving the `grad` vector which is allocated otherwise. As example I am reporting with the PR the differences before and after this change the evaluation speed of the ODE stress test on this wiki (https://github.com/stan-dev/math/wiki/ODE-stress-test).

On develop I get: 1977ms
On this PR I get: 1754ms

which is >10% speedup. There is some variation in runtimes, but these are considerably smaller than 10%.

As the `coupled_ode_system` is used for the stiff and non-stiff integration this speedup will propagate to all ODE solvers.

## Tests

No new tests as no new behavior is introduced. All existing ODE tests

```
test/unit/math/rev/mat/functor/integrate_ode_adams_prim_test.cpp
test/unit/math/rev/mat/functor/integrate_ode_adams_rev_test.cpp
test/unit/math/rev/mat/functor/integrate_ode_bdf_rev_test.cpp
test/unit/math/rev/mat/functor/integrate_ode_cvodes_grad_rev_test.cpp
test/unit/math/rev/mat/functor/integrate_ode_bdf_prim_test.cpp
test/unit/math/rev/arr/functor/integrate_ode_rk45_grad_test.cpp
test/unit/math/rev/arr/functor/integrate_ode_rk45_tooMuchWork_test.cpp
test/unit/math/rev/arr/functor/integrate_ode_rk45_test.cpp
test/unit/math/prim/arr/functor/integrate_ode_rk45_test.cpp
```

still run OK.

## Side Effects

It's faster.

## Checklist

- [X] Math issue #1049 

- [X] Copyright holder: Sebastian Weber

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [X] the new changes are tested