### PR TITLE
sqrt(int) resolve ambiguity, fixes #712

### DIFF
--- a/stan/math/prim/scal.hpp
+++ b/stan/math/prim/scal.hpp
@@ -167,6 +167,7 @@
 #include <stan/math/prim/scal/fun/size_zero.hpp>
 #include <stan/math/prim/scal/fun/square.hpp>
 #include <stan/math/prim/scal/fun/squared_distance.hpp>
+#include <stan/math/prim/scal/fun/sqrt.hpp>
 #include <stan/math/prim/scal/fun/step.hpp>
 #include <stan/math/prim/scal/fun/tgamma.hpp>
 #include <stan/math/prim/scal/fun/trigamma.hpp>

--- a/stan/math/prim/scal/fun/sqrt.hpp
+++ b/stan/math/prim/scal/fun/sqrt.hpp
@@ -1,0 +1,20 @@
+#ifndef STAN_MATH_PRIM_SCAL_FUN_SQRT_HPP
+#define STAN_MATH_PRIM_SCAL_FUN_SQRT_HPP
+
+#include <cmath>
+
+namespace stan {
+namespace math {
+
+/**
+ * Return the square root of the specified argument.  This
+ * version is required to disambiguate <code>sqrt(int)</code>.
+ *
+ * @param[in] x Argument.
+ * @return Natural exponential of argument.
+ */
+inline double sqrt(int x) { return std::sqrt(static_cast<double>(x)); }
+
+}  // namespace math
+}  // namespace stan
+#endif

--- a/test/unit/math/prim/scal/fun/sqrt_test.cpp
+++ b/test/unit/math/prim/scal/fun/sqrt_test.cpp
@@ -1,0 +1,10 @@
+#include <stan/math.hpp>
+#include <stan/math/prim/scal/fun/sqrt.hpp>
+#include <gtest/gtest.h>
+
+TEST(MathFunctions, sqrtInt) {
+  using stan::math::sqrt;
+  using std::sqrt;
+  EXPECT_FLOAT_EQ(std::sqrt(3.0), sqrt(3));
+  EXPECT_TRUE(stan::math::is_nan(sqrt(-2)));
+}


### PR DESCRIPTION
## Summary

Add `stan::math::sqrt(int)` signature to resolve ambiguity with template vs. double promotion in C++11. 

## Tests

Add unit test that failed to compile before `sqrt(int)` added and now passes.

## Side Effects

No.

## Checklist

- [x] Math issue #712

- [x] Copyright holder: Columbia University

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
