### PR TITLE
replace boost lgamma with std, fixes #1063

### DIFF
--- a/stan/math/prim/scal/fun/lgamma.hpp
+++ b/stan/math/prim/scal/fun/lgamma.hpp
@@ -1,41 +1,22 @@
 #ifndef STAN_MATH_PRIM_SCAL_FUN_LGAMMA_HPP
 #define STAN_MATH_PRIM_SCAL_FUN_LGAMMA_HPP
 
-#include <stan/math/prim/scal/fun/boost_policy.hpp>
-#include <boost/math/special_functions/gamma.hpp>
+#include <cmath>
 
 namespace stan {
 namespace math {
 
 /**
- * Return the natural logarithm of the gamma function applied to
- * the specified argument.
+ * Return the natural logarithm of the gamma function applied to the
+ * specified argument.  If the input is a non-positive integer, the
+ * result is positive infinity.  If the input is not-a-number, the
+ * result and gradient are not-a-number.
  *
-   \f[
-   \mbox{lgamma}(x) =
-   \begin{cases}
-     \textrm{error} & \mbox{if } x\in \{\dots, -3, -2, -1, 0\}\\
-     \ln\Gamma(x) & \mbox{if } x\not\in \{\dots, -3, -2, -1, 0\}\\[6pt]
-     \textrm{NaN} & \mbox{if } x = \textrm{NaN}
-   \end{cases}
-   \f]
-
-   \f[
-   \frac{\partial\, \mbox{lgamma}(x)}{\partial x} =
-   \begin{cases}
-     \textrm{error} & \mbox{if } x\in \{\dots, -3, -2, -1, 0\}\\
-     \Psi(x) & \mbox{if } x\not\in \{\dots, -3, -2, -1, 0\}\\[6pt]
-     \textrm{NaN} & \mbox{if } x = \textrm{NaN}
-   \end{cases}
-\f]
-*
-* @param x argument
-* @return natural logarithm of the gamma function applied to
-* argument
-*/
-inline double lgamma(double x) {
-  return boost::math::lgamma(x, boost_policy_t());
-}
+ * @param x argument
+ * @return natural logarithm of the gamma function applied to
+ * argument
+ */
+inline double lgamma(double x) { return std::lgamma(x); }
 
 /**
  * Return the natural logarithm of the gamma function applied
@@ -45,7 +26,7 @@ inline double lgamma(double x) {
  * @return natural logarithm of the gamma function applied to
  * argument
  */
-inline double lgamma(int x) { return boost::math::lgamma(x, boost_policy_t()); }
+inline double lgamma(int x) { return std::lgamma(x); }
 
 }  // namespace math
 }  // namespace stan

--- a/test/unit/math/prim/scal/fun/lgamma_test.cpp
+++ b/test/unit/math/prim/scal/fun/lgamma_test.cpp
@@ -4,12 +4,24 @@
 #include <gtest/gtest.h>
 #include <limits>
 
-TEST(MathFunctions, lgamma) { EXPECT_TRUE(boost::math::isinf(lgamma(0.0))); }
+#include <iostream>
+
+// as it just delegates
+
+TEST(MathFunctions, lgamma_finite) {
+  EXPECT_FLOAT_EQ(-0.0853740900033158, stan::math::lgamma(1.2));
+  EXPECT_FLOAT_EQ(1.57917603403998, stan::math::lgamma(-1.2));
+}
+TEST(MathFunctions, lgamma_non_pos_int) {
+  EXPECT_PRED1(boost::math::isinf<double>, stan::math::lgamma(0));
+  EXPECT_PRED1(boost::math::isinf<double>, stan::math::lgamma(0.0));
+  EXPECT_PRED1(boost::math::isinf<double>, stan::math::lgamma(-2));
+  EXPECT_PRED1(boost::math::isinf<double>, stan::math::lgamma(-2.0));
+}
 
 TEST(MathFunctions, lgammaStanMathUsing) { using stan::math::lgamma; }
 
 TEST(MathFunctions, lgamma_nan) {
   double nan = std::numeric_limits<double>::quiet_NaN();
   EXPECT_PRED1(boost::math::isnan<double>, stan::math::lgamma(nan));
-  EXPECT_PRED1(boost::math::isnan<double>, stan::math::lgamma(0));
 }


### PR DESCRIPTION
##  Summary

Replace Boost implementation of `lgamma` in `prim/scal/fun` with standard library version.

The goal is to solve #1063 so this works with g++ 7.3.  

## Tests

The makefiles are currently broken;  see #1068.   I don't believe our CI tests 7.3 and I can't test it without resolving #1068, so I'm tossing it up in a PR.
