### PR TITLE
fix memory issues in set_n_threads_var

### DIFF
--- a/test/unit/math/prim/mat/functor/num_threads_test.cpp
+++ b/test/unit/math/prim/mat/functor/num_threads_test.cpp
@@ -10,7 +10,7 @@
 
 // Can't easily use std::string as putenv require non-const char*
 void set_n_threads_var(const char* value) {
-  char env_string[256];
+  static char env_string[256];
   snprintf(env_string, sizeof(env_string), "STAN_NUM_THREADS=%s", value);
   putenv(env_string);
 }


### PR DESCRIPTION

## Summary

Issue #1068 describes a failure of the `test/unit/math/prim/mat/functor/num_threads_test` test when using a g++ compiler and `O=0` in `make/local`. The test works just fine with `O=3` and clang does not bother with the optimization flag.

This page here:

https://www.codecogs.com/library/computing/c/stdlib.h/getenv.php?alias=putenv

made me think that the local memory in the `set_n_threads_var` function is not properly dealt with given how `putenv` works (see the bugs section above). All I did is to declare that char buffer to be a static member of the function to make the memory for this variable persistent. This seems to do the trick as now things work fine.

## Tests

The test now works even when using `O=0` with g++ compilers (I tested version 6 + 7).

## Side Effects



## Checklist

- [X] Math issue #1068 

- [X] Copyright holder: Sebastian Weber

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [ ] the new changes are tested; nope... this is the test