### PR TITLE
Bugfix/issue 2708 map rect fail

### DIFF
--- a/stan/math/prim/mat/functor/map_rect_concurrent.hpp
+++ b/stan/math/prim/mat/functor/map_rect_concurrent.hpp
@@ -103,19 +103,17 @@ map_rect_concurrent(
 #ifdef STAN_THREADS
   if (num_threads > 1) {
     const int big_job_size = small_job_size + 1;
-    const int num_big_threads = num_threads - (num_jobs % num_threads); 
+    const int num_big_threads = num_threads - (num_jobs % num_threads);
     const int num_small_threads = num_threads - 1 - num_big_threads;
     int job_start = small_job_size;
     for (int i = 0; i < num_big_threads; ++i) {
-      futures.emplace_back(
-          std::async(std::launch::async, execute_chunk, job_start,
-	      big_job_size));
+      futures.emplace_back(std::async(std::launch::async, execute_chunk,
+                                      job_start, big_job_size));
       job_start += big_job_size;
     }
     for (int i = 0; i < num_small_threads; ++i) {
-      futures.emplace_back(
-          std::async(std::launch::async, execute_chunk, job_start,
-	      big_job_size));
+      futures.emplace_back(std::async(std::launch::async, execute_chunk,
+                                      job_start, big_job_size));
       job_start += small_job_size;
     }
   }

--- a/test/unit/math/prim/mat/functor/map_rect_concurrent_test.cpp
+++ b/test/unit/math/prim/mat/functor/map_rect_concurrent_test.cpp
@@ -21,7 +21,7 @@ struct map_rect : public ::testing::Test {
   std::vector<Eigen::VectorXd> job_params_d;
   std::vector<std::vector<double> > x_r;
   std::vector<std::vector<int> > x_i;
-  const int N = 10;
+  const int N = 5;
 
   virtual void SetUp() {
     shared_params_d.resize(2);


### PR DESCRIPTION
Proposed fix to map_rect_concurrent.  @wds15 I tried updating the tests to do a range of shard sizes but I'm missing something about the combine step.  Currently I don't feel comfortable saying this is fixed unless we test a range of shard sizes.  It might make more sense to me if you explain the two checks in this test:

```
TEST_F(map_rect, concurrent_ragged_return_size_dd) {
  Eigen::VectorXd res1 = stan::math::map_rect<0, hard_work>(
      shared_params_d, job_params_d, x_r, x_i);

  EXPECT_EQ(res1.size(), 2 * N);

  x_i[1] = std::vector<int>(1, 1);

  Eigen::VectorXd res2 = stan::math::map_rect<1, hard_work>(
      shared_params_d, job_params_d, x_r, x_i);

  EXPECT_EQ(res2.size(), 2 * N + 1);
}
```

## Checklist

- [x] Math issue #1075 

- [x] Copyright holder: Krzysztof Sakrejda

- [X] the basic tests are passing

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [X] the new changes are tested
