### PR TITLE
issue 1010 - Replacing Boost functions with cmath (Part 2 - error checking)

### DIFF
--- a/stan/math/fwd/scal/fun/gamma_p.hpp
+++ b/stan/math/fwd/scal/fun/gamma_p.hpp
@@ -5,6 +5,7 @@
 #include <stan/math/fwd/scal/fun/value_of_rec.hpp>
 #include <stan/math/prim/scal/err/domain_error.hpp>
 #include <stan/math/prim/scal/fun/gamma_p.hpp>
+#include <stan/math/prim/scal/fun/lgamma.hpp>
 #include <stan/math/prim/scal/fun/grad_reg_lower_inc_gamma.hpp>
 #include <limits>
 
@@ -14,7 +15,6 @@ namespace math {
 template <typename T>
 inline fvar<T> gamma_p(const fvar<T> &x1, const fvar<T> &x2) {
   using boost::math::digamma;
-  using boost::math::lgamma;
   using std::exp;
   using std::fabs;
   using std::log;
@@ -60,7 +60,7 @@ inline fvar<T> gamma_p(double x1, const fvar<T> &x2) {
   if (is_inf(x1))
     return fvar<T>(u, std::numeric_limits<double>::quiet_NaN());
 
-  T der2 = exp(-x2.val_ + (x1 - 1.0) * log(x2.val_) - boost::math::lgamma(x1));
+  T der2 = exp(-x2.val_ + (x1 - 1.0) * log(x2.val_) - stan::math::lgamma(x1));
 
   return fvar<T>(u, x2.d_ * der2);
 }

--- a/stan/math/fwd/scal/fun/gamma_p.hpp
+++ b/stan/math/fwd/scal/fun/gamma_p.hpp
@@ -60,7 +60,7 @@ inline fvar<T> gamma_p(double x1, const fvar<T> &x2) {
   if (is_inf(x1))
     return fvar<T>(u, std::numeric_limits<double>::quiet_NaN());
 
-  T der2 = exp(-x2.val_ + (x1 - 1.0) * log(x2.val_) - stan::math::lgamma(x1));
+  T der2 = exp(-x2.val_ + (x1 - 1.0) * log(x2.val_) - lgamma(x1));
 
   return fvar<T>(u, x2.d_ * der2);
 }

--- a/stan/math/fwd/scal/fun/gamma_q.hpp
+++ b/stan/math/fwd/scal/fun/gamma_q.hpp
@@ -2,7 +2,7 @@
 #define STAN_MATH_FWD_SCAL_FUN_GAMMA_Q_HPP
 
 #include <stan/math/fwd/core.hpp>
-
+#include <stan/math/prim/scal/fun/tgamma.hpp>
 #include <stan/math/prim/scal/fun/gamma_q.hpp>
 
 namespace stan {
@@ -11,7 +11,6 @@ namespace math {
 template <typename T>
 inline fvar<T> gamma_q(const fvar<T>& x1, const fvar<T>& x2) {
   using boost::math::digamma;
-  using boost::math::tgamma;
   using std::exp;
   using std::fabs;
   using std::log;
@@ -44,7 +43,6 @@ inline fvar<T> gamma_q(const fvar<T>& x1, const fvar<T>& x2) {
 template <typename T>
 inline fvar<T> gamma_q(const fvar<T>& x1, double x2) {
   using boost::math::digamma;
-  using boost::math::tgamma;
   using std::exp;
   using std::fabs;
   using std::log;
@@ -80,7 +78,7 @@ inline fvar<T> gamma_q(double x1, const fvar<T>& x2) {
 
   T u = gamma_q(x1, x2.val_);
 
-  double g = boost::math::tgamma(x1);
+  double g = tgamma(x1);
 
   T der2 = -exp(-x2.val_) * pow(x2.val_, x1 - 1.0) / g;
 

--- a/stan/math/prim/mat/fun/log_mix.hpp
+++ b/stan/math/prim/mat/fun/log_mix.hpp
@@ -1,6 +1,8 @@
 #ifndef STAN_MATH_PRIM_MAT_FUN_LOG_MIX_HPP
 #define STAN_MATH_PRIM_MAT_FUN_LOG_MIX_HPP
 
+#include <stan/math/prim/arr/meta/get.hpp>
+#include <stan/math/prim/arr/meta/length.hpp>
 #include <stan/math/prim/mat/meta/is_vector.hpp>
 #include <stan/math/prim/mat/meta/get.hpp>
 #include <stan/math/prim/mat/meta/length.hpp>
@@ -10,8 +12,6 @@
 #include <stan/math/prim/mat/meta/vector_seq_view.hpp>
 #include <stan/math/prim/mat/meta/broadcast_array.hpp>
 #include <stan/math/prim/mat/meta/operands_and_partials.hpp>
-#include <stan/math/prim/arr/meta/get.hpp>
-#include <stan/math/prim/arr/meta/length.hpp>
 #include <stan/math/prim/scal/err/check_bounded.hpp>
 #include <stan/math/prim/scal/err/check_not_nan.hpp>
 #include <stan/math/prim/scal/err/check_consistent_sizes.hpp>

--- a/stan/math/prim/mat/fun/tgamma.hpp
+++ b/stan/math/prim/mat/fun/tgamma.hpp
@@ -2,7 +2,7 @@
 #define STAN_MATH_PRIM_MAT_FUN_TGAMMA_HPP
 
 #include <stan/math/prim/mat/vectorize/apply_scalar_unary.hpp>
-#include <boost/math/special_functions/gamma.hpp>
+#include <stan/math/prim/scal/fun/tgamma.hpp>
 
 namespace stan {
 namespace math {
@@ -17,7 +17,6 @@ namespace math {
 struct tgamma_fun {
   template <typename T>
   static inline T fun(const T& x) {
-    using boost::math::tgamma;
     return tgamma(x);
   }
 };

--- a/stan/math/prim/mat/prob/multi_student_t_lpdf.hpp
+++ b/stan/math/prim/mat/prob/multi_student_t_lpdf.hpp
@@ -15,6 +15,7 @@
 #include <stan/math/prim/scal/fun/constants.hpp>
 #include <stan/math/prim/scal/fun/is_inf.hpp>
 #include <stan/math/prim/scal/fun/log1p.hpp>
+#include <stan/math/prim/scal/fun/lgamma.hpp>
 #include <stan/math/prim/scal/meta/include_summand.hpp>
 #include <boost/math/special_functions/gamma.hpp>
 #include <boost/random/variate_generator.hpp>
@@ -36,7 +37,6 @@ typename return_type<T_y, T_dof, T_loc, T_scale>::type multi_student_t_lpdf(
     const T_y& y, const T_dof& nu, const T_loc& mu, const T_scale& Sigma) {
   static const char* function = "multi_student_t";
 
-  using boost::math::lgamma;
   using std::log;
 
   typedef typename scalar_type<T_scale>::type T_scale_elem;

--- a/stan/math/prim/mat/prob/multinomial_lpmf.hpp
+++ b/stan/math/prim/mat/prob/multinomial_lpmf.hpp
@@ -10,6 +10,7 @@
 #include <stan/math/prim/scal/err/check_positive.hpp>
 #include <stan/math/prim/scal/fun/multiply_log.hpp>
 #include <stan/math/prim/scal/fun/constants.hpp>
+#include <stan/math/prim/scal/fun/lgamma.hpp>
 #include <stan/math/prim/scal/meta/include_summand.hpp>
 #include <vector>
 
@@ -23,7 +24,6 @@ typename boost::math::tools::promote_args<T_prob>::type multinomial_lpmf(
     const Eigen::Matrix<T_prob, Eigen::Dynamic, 1>& theta) {
   static const char* function = "multinomial_lpmf";
 
-  using boost::math::lgamma;
   using boost::math::tools::promote_args;
 
   typename promote_args<T_prob>::type lp(0.0);

--- a/stan/math/prim/scal/fun/acosh.hpp
+++ b/stan/math/prim/scal/fun/acosh.hpp
@@ -1,11 +1,10 @@
 #ifndef STAN_MATH_PRIM_SCAL_FUN_ACOSH_HPP
 #define STAN_MATH_PRIM_SCAL_FUN_ACOSH_HPP
 
-#include <stan/math/prim/scal/fun/constants.hpp>
 #include <stan/math/prim/scal/fun/is_nan.hpp>
-#include <stan/math/prim/scal/meta/likely.hpp>
-#include <stan/math/prim/scal/fun/boost_policy.hpp>
-#include <boost/math/special_functions/acosh.hpp>
+#include <stan/math/prim/scal/fun/is_inf.hpp>
+#include <stan/math/prim/scal/err/check_greater_or_equal.hpp>
+#include <cmath>
 
 namespace stan {
 namespace math {
@@ -19,10 +18,16 @@ namespace math {
  * @throw std::domain_error If argument is less than 1.
  */
 inline double acosh(double x) {
-  if (unlikely(is_nan(x)))
+  if (is_nan(x)) {
     return x;
-  else
-    return boost::math::acosh(x, boost_policy_t());
+  } else {
+    check_greater_or_equal("acosh", "x", x, 1.0);
+    #ifdef _WIN32
+      if (is_inf(x))
+        return x;
+    #endif
+    return std::acosh(x);
+  }
 }
 
 /**
@@ -32,7 +37,18 @@ inline double acosh(double x) {
  * @return Inverse hyperbolic cosine of the argument.
  * @throw std::domain_error If argument is less than 1.
  */
-inline double acosh(int x) { return acosh(static_cast<double>(x)); }
+inline double acosh(int x) {
+  if (is_nan(x)) {
+    return x;
+  } else {
+    check_greater_or_equal("acosh", "x", x, 1);
+    #ifdef _WIN32
+      if (is_inf(x))
+        return x;
+    #endif
+    return std::acosh(x);
+  }
+}
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/prim/scal/fun/atanh.hpp
+++ b/stan/math/prim/scal/fun/atanh.hpp
@@ -1,11 +1,9 @@
 #ifndef STAN_MATH_PRIM_SCAL_FUN_ATANH_HPP
 #define STAN_MATH_PRIM_SCAL_FUN_ATANH_HPP
 
-#include <stan/math/prim/scal/fun/constants.hpp>
 #include <stan/math/prim/scal/fun/is_nan.hpp>
-#include <stan/math/prim/scal/meta/likely.hpp>
-#include <stan/math/prim/scal/fun/boost_policy.hpp>
-#include <boost/math/special_functions/atanh.hpp>
+#include <stan/math/prim/scal/err/check_bounded.hpp>
+#include <cmath>
 
 namespace stan {
 namespace math {
@@ -21,10 +19,12 @@ namespace math {
  * @throw std::domain_error If argument is not in [-1, 1].
  */
 inline double atanh(double x) {
-  if (unlikely(is_nan(x)))
+  if (is_nan(x)) {
     return x;
-  else
-    return boost::math::atanh(x, boost_policy_t());
+  } else {
+    check_bounded("atanh", "x", x, -1.0, 1.0);
+    return std::atanh(x);
+  }
 }
 
 /**
@@ -34,7 +34,14 @@ inline double atanh(double x) {
  * @return Inverse hyperbolic tangent of the argument.
  * @throw std::domain_error If argument is less than 1.
  */
-inline double atanh(int x) { return atanh(static_cast<double>(x)); }
+inline double atanh(int x) {
+  if (is_nan(x)) {
+    return x;
+  } else {
+    check_bounded("atanh", "x", x, -1, 1);
+    return std::atanh(x);
+  }
+}
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/prim/scal/fun/binomial_coefficient_log.hpp
+++ b/stan/math/prim/scal/fun/binomial_coefficient_log.hpp
@@ -1,7 +1,7 @@
 #ifndef STAN_MATH_PRIM_SCAL_FUN_BINOMIAL_COEFFICIENT_LOG_HPP
 #define STAN_MATH_PRIM_SCAL_FUN_BINOMIAL_COEFFICIENT_LOG_HPP
 
-#include <boost/math/special_functions/gamma.hpp>
+#include <stan/math/prim/scal/fun/lgamma.hpp>
 #include <boost/math/tools/promotion.hpp>
 
 namespace stan {
@@ -59,7 +59,6 @@ namespace math {
 template <typename T_N, typename T_n>
 inline typename boost::math::tools::promote_args<T_N, T_n>::type
 binomial_coefficient_log(const T_N N, const T_n n) {
-  using boost::math::lgamma;
   using std::log;
   const double CUTOFF = 1000;
   if (N - n < CUTOFF) {

--- a/stan/math/prim/scal/fun/grad_reg_inc_gamma.hpp
+++ b/stan/math/prim/scal/fun/grad_reg_inc_gamma.hpp
@@ -23,7 +23,7 @@ namespace math {
  *
  * @param a   shape parameter, a > 0
  * @param z   location z >= 0
- * @param g   boost::math::tgamma(a) (precomputed value)
+ * @param g   stan::math::tgamma(a) (precomputed value)
  * @param dig boost::math::digamma(a) (precomputed value)
  * @param precision required precision; applies to series expansion only
  * @param max_steps number of steps to take.

--- a/stan/math/prim/scal/fun/lbeta.hpp
+++ b/stan/math/prim/scal/fun/lbeta.hpp
@@ -2,8 +2,7 @@
 #define STAN_MATH_PRIM_SCAL_FUN_LBETA_HPP
 
 #include <boost/math/tools/promotion.hpp>
-
-#include <boost/math/special_functions/gamma.hpp>
+#include <stan/math/prim/scal/fun/lgamma.hpp>
 
 namespace stan {
 namespace math {
@@ -21,7 +20,7 @@ namespace math {
  * \f$\log \mbox{B}(a, b) = \log \Gamma(a) + \log \Gamma(b) - \log
  \Gamma(a+b)\f$.
  *
- * See boost::math::lgamma() for the double-based and stan::math for the
+ * See stan::math::lgamma() for the double-based and stan::math for the
  * variable-based log Gamma function.
  *
  *
@@ -57,7 +56,6 @@ namespace math {
 template <typename T1, typename T2>
 inline typename boost::math::tools::promote_args<T1, T2>::type lbeta(
     const T1 a, const T2 b) {
-  using boost::math::lgamma;
   return lgamma(a) + lgamma(b) - lgamma(a + b);
 }
 

--- a/stan/math/prim/scal/fun/lgamma.hpp
+++ b/stan/math/prim/scal/fun/lgamma.hpp
@@ -1,8 +1,7 @@
 #ifndef STAN_MATH_PRIM_SCAL_FUN_LGAMMA_HPP
 #define STAN_MATH_PRIM_SCAL_FUN_LGAMMA_HPP
 
-#include <stan/math/prim/scal/fun/boost_policy.hpp>
-#include <boost/math/special_functions/gamma.hpp>
+#include <cmath>
 
 namespace stan {
 namespace math {
@@ -33,9 +32,7 @@ namespace math {
 * @return natural logarithm of the gamma function applied to
 * argument
 */
-inline double lgamma(double x) {
-  return boost::math::lgamma(x, boost_policy_t());
-}
+inline double lgamma(double x) { return std::lgamma(x); }
 
 /**
  * Return the natural logarithm of the gamma function applied
@@ -45,7 +42,7 @@ inline double lgamma(double x) {
  * @return natural logarithm of the gamma function applied to
  * argument
  */
-inline double lgamma(int x) { return boost::math::lgamma(x, boost_policy_t()); }
+inline double lgamma(int x) { return std::lgamma(x); }
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/prim/scal/fun/lmgamma.hpp
+++ b/stan/math/prim/scal/fun/lmgamma.hpp
@@ -3,7 +3,7 @@
 
 #include <boost/math/tools/promotion.hpp>
 #include <stan/math/prim/scal/fun/constants.hpp>
-#include <boost/math/special_functions/gamma.hpp>
+#include <stan/math/prim/scal/fun/lgamma.hpp>
 
 namespace stan {
 namespace math {
@@ -52,7 +52,6 @@ namespace math {
  */
 template <typename T>
 inline typename boost::math::tools::promote_args<T>::type lmgamma(int k, T x) {
-  using boost::math::lgamma;
   typename boost::math::tools::promote_args<T>::type result
       = k * (k - 1) * LOG_PI_OVER_FOUR;
 

--- a/stan/math/prim/scal/fun/log1p.hpp
+++ b/stan/math/prim/scal/fun/log1p.hpp
@@ -1,8 +1,9 @@
 #ifndef STAN_MATH_PRIM_SCAL_FUN_LOG1P_HPP
 #define STAN_MATH_PRIM_SCAL_FUN_LOG1P_HPP
 
-#include <stan/math/prim/scal/fun/boost_policy.hpp>
-#include <boost/math/special_functions/log1p.hpp>
+#include <stan/math/prim/scal/err/check_greater_or_equal.hpp>
+#include <stan/math/prim/scal/fun/is_nan.hpp>
+#include <cmath>
 
 namespace stan {
 namespace math {
@@ -23,7 +24,12 @@ namespace math {
  * @throw std::domain_error If argument is less than -1.
  */
 inline double log1p(double x) {
-  return boost::math::log1p(x, boost_policy_t());
+  if (is_nan(x)) {
+    return x;
+  } else {
+    check_greater_or_equal("log1p", "x", x, -1.0);
+    return std::log1p(x);
+  }
 }
 
 /**
@@ -35,7 +41,14 @@ inline double log1p(double x) {
  * @return Natural logarithm of one plus the argument.
  * @throw std::domain_error If argument is less than -1.
  */
-inline double log1p(int x) { return log1p(static_cast<double>(x)); }
+inline double log1p(int x) {
+  if (is_nan(x)) {
+    return x;
+  } else {
+    check_greater_or_equal("log1p", "x", x, -1);
+    return std::log1p(x);
+  }
+}
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/prim/scal/fun/tgamma.hpp
+++ b/stan/math/prim/scal/fun/tgamma.hpp
@@ -1,7 +1,9 @@
 #ifndef STAN_MATH_PRIM_SCAL_FUN_TGAMMA_HPP
 #define STAN_MATH_PRIM_SCAL_FUN_TGAMMA_HPP
 
-#include <boost/math/special_functions/gamma.hpp>
+#include <stan/math/prim/scal/err/domain_error.hpp>
+#include <stan/math/prim/scal/fun/is_nonpositive_integer.hpp>
+#include <cmath>
 
 namespace stan {
 namespace math {
@@ -12,7 +14,11 @@ namespace math {
  * @param x Argument.
  * @return The gamma function applied to argument.
  */
-inline double tgamma(double x) { return boost::math::tgamma(x); }
+inline double tgamma(double x) {
+  if (x == 0.0 || is_nonpositive_integer(x))
+    domain_error("tgamma", "x", x, "x == 0 or negative integer");
+  return std::tgamma(x);
+}
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/prim/scal/prob/chi_square_cdf.hpp
+++ b/stan/math/prim/scal/prob/chi_square_cdf.hpp
@@ -14,6 +14,7 @@
 #include <stan/math/prim/scal/fun/value_of.hpp>
 #include <stan/math/prim/scal/fun/gamma_p.hpp>
 #include <stan/math/prim/scal/fun/digamma.hpp>
+#include <stan/math/prim/scal/fun/tgamma.hpp>
 #include <stan/math/prim/scal/meta/scalar_seq_view.hpp>
 #include <stan/math/prim/scal/meta/VectorBuilder.hpp>
 #include <stan/math/prim/scal/fun/grad_reg_inc_gamma.hpp>
@@ -70,8 +71,6 @@ typename return_type<T_y, T_dof>::type chi_square_cdf(const T_y& y,
       return ops_partials.build(0.0);
   }
 
-  using boost::math::tgamma;
-  using std::exp;
   using std::exp;
   using std::pow;
 

--- a/stan/math/prim/scal/prob/chi_square_lccdf.hpp
+++ b/stan/math/prim/scal/prob/chi_square_lccdf.hpp
@@ -14,6 +14,7 @@
 #include <stan/math/prim/scal/fun/value_of.hpp>
 #include <stan/math/prim/scal/fun/gamma_q.hpp>
 #include <stan/math/prim/scal/fun/digamma.hpp>
+#include <stan/math/prim/scal/fun/tgamma.hpp>
 #include <stan/math/prim/scal/meta/scalar_seq_view.hpp>
 #include <stan/math/prim/scal/meta/VectorBuilder.hpp>
 #include <stan/math/prim/scal/fun/grad_reg_inc_gamma.hpp>
@@ -70,8 +71,6 @@ typename return_type<T_y, T_dof>::type chi_square_lccdf(const T_y& y,
       return ops_partials.build(0.0);
   }
 
-  using boost::math::tgamma;
-  using std::exp;
   using std::exp;
   using std::log;
   using std::pow;

--- a/stan/math/prim/scal/prob/chi_square_lcdf.hpp
+++ b/stan/math/prim/scal/prob/chi_square_lcdf.hpp
@@ -14,6 +14,7 @@
 #include <stan/math/prim/scal/fun/value_of.hpp>
 #include <stan/math/prim/scal/fun/gamma_p.hpp>
 #include <stan/math/prim/scal/fun/digamma.hpp>
+#include <stan/math/prim/scal/fun/tgamma.hpp>
 #include <stan/math/prim/scal/meta/scalar_seq_view.hpp>
 #include <stan/math/prim/scal/meta/VectorBuilder.hpp>
 #include <stan/math/prim/scal/fun/grad_reg_inc_gamma.hpp>
@@ -70,8 +71,6 @@ typename return_type<T_y, T_dof>::type chi_square_lcdf(const T_y& y,
       return ops_partials.build(negative_infinity());
   }
 
-  using boost::math::tgamma;
-  using std::exp;
   using std::exp;
   using std::log;
   using std::pow;

--- a/stan/math/prim/scal/prob/chi_square_lpdf.hpp
+++ b/stan/math/prim/scal/prob/chi_square_lpdf.hpp
@@ -14,6 +14,7 @@
 #include <stan/math/prim/scal/fun/value_of.hpp>
 #include <stan/math/prim/scal/fun/gamma_p.hpp>
 #include <stan/math/prim/scal/fun/digamma.hpp>
+#include <stan/math/prim/scal/fun/lgamma.hpp>
 #include <stan/math/prim/scal/meta/VectorBuilder.hpp>
 #include <stan/math/prim/scal/fun/grad_reg_inc_gamma.hpp>
 #include <stan/math/prim/scal/meta/include_summand.hpp>
@@ -73,7 +74,6 @@ typename return_type<T_y, T_dof>::type chi_square_lpdf(const T_y& y,
     return 0.0;
 
   using boost::math::digamma;
-  using boost::math::lgamma;
   using std::log;
 
   VectorBuilder<include_summand<propto, T_y, T_dof>::value, T_partials_return,

--- a/stan/math/prim/scal/prob/gamma_cdf.hpp
+++ b/stan/math/prim/scal/prob/gamma_cdf.hpp
@@ -14,6 +14,7 @@
 #include <stan/math/prim/scal/fun/value_of.hpp>
 #include <stan/math/prim/scal/fun/gamma_p.hpp>
 #include <stan/math/prim/scal/fun/digamma.hpp>
+#include <stan/math/prim/scal/fun/tgamma.hpp>
 #include <stan/math/prim/scal/meta/length.hpp>
 #include <stan/math/prim/scal/meta/is_constant_struct.hpp>
 #include <stan/math/prim/scal/meta/scalar_seq_view.hpp>
@@ -80,7 +81,6 @@ typename return_type<T_y, T_shape, T_inv_scale>::type gamma_cdf(
       return ops_partials.build(0.0);
   }
 
-  using boost::math::tgamma;
   using std::exp;
   using std::pow;
 

--- a/stan/math/prim/scal/prob/gamma_lccdf.hpp
+++ b/stan/math/prim/scal/prob/gamma_lccdf.hpp
@@ -14,6 +14,7 @@
 #include <stan/math/prim/scal/fun/value_of.hpp>
 #include <stan/math/prim/scal/fun/gamma_q.hpp>
 #include <stan/math/prim/scal/fun/digamma.hpp>
+#include <stan/math/prim/scal/fun/tgamma.hpp>
 #include <stan/math/prim/scal/meta/length.hpp>
 #include <stan/math/prim/scal/meta/is_constant_struct.hpp>
 #include <stan/math/prim/scal/meta/scalar_seq_view.hpp>
@@ -67,7 +68,6 @@ typename return_type<T_y, T_shape, T_inv_scale>::type gamma_lccdf(
       return ops_partials.build(0.0);
   }
 
-  using boost::math::tgamma;
   using std::exp;
   using std::log;
   using std::pow;

--- a/stan/math/prim/scal/prob/gamma_lcdf.hpp
+++ b/stan/math/prim/scal/prob/gamma_lcdf.hpp
@@ -16,6 +16,7 @@
 #include <stan/math/prim/scal/fun/value_of.hpp>
 #include <stan/math/prim/scal/fun/gamma_p.hpp>
 #include <stan/math/prim/scal/fun/digamma.hpp>
+#include <stan/math/prim/scal/fun/tgamma.hpp>
 #include <stan/math/prim/scal/meta/length.hpp>
 #include <stan/math/prim/scal/meta/is_constant_struct.hpp>
 #include <stan/math/prim/scal/meta/scalar_seq_view.hpp>
@@ -66,7 +67,6 @@ typename return_type<T_y, T_shape, T_inv_scale>::type gamma_lcdf(
       return ops_partials.build(negative_infinity());
   }
 
-  using boost::math::tgamma;
   using std::exp;
   using std::log;
   using std::pow;

--- a/stan/math/prim/scal/prob/gamma_lpdf.hpp
+++ b/stan/math/prim/scal/prob/gamma_lpdf.hpp
@@ -16,6 +16,7 @@
 #include <stan/math/prim/scal/fun/value_of.hpp>
 #include <stan/math/prim/scal/fun/gamma_p.hpp>
 #include <stan/math/prim/scal/fun/digamma.hpp>
+#include <stan/math/prim/scal/fun/lgamma.hpp>
 #include <stan/math/prim/scal/meta/VectorBuilder.hpp>
 #include <stan/math/prim/scal/meta/include_summand.hpp>
 #include <stan/math/prim/scal/meta/scalar_seq_view.hpp>
@@ -86,7 +87,6 @@ typename return_type<T_y, T_shape, T_inv_scale>::type gamma_lpdf(
   operands_and_partials<T_y, T_shape, T_inv_scale> ops_partials(y, alpha, beta);
 
   using boost::math::digamma;
-  using boost::math::lgamma;
   using std::log;
 
   VectorBuilder<include_summand<propto, T_y, T_shape>::value, T_partials_return,

--- a/stan/math/prim/scal/prob/inv_chi_square_cdf.hpp
+++ b/stan/math/prim/scal/prob/inv_chi_square_cdf.hpp
@@ -14,6 +14,7 @@
 #include <stan/math/prim/scal/fun/value_of.hpp>
 #include <stan/math/prim/scal/fun/gamma_q.hpp>
 #include <stan/math/prim/scal/fun/digamma.hpp>
+#include <stan/math/prim/scal/fun/tgamma.hpp>
 #include <stan/math/prim/scal/meta/length.hpp>
 #include <stan/math/prim/scal/meta/is_constant_struct.hpp>
 #include <stan/math/prim/scal/meta/scalar_seq_view.hpp>
@@ -75,7 +76,6 @@ typename return_type<T_y, T_dof>::type inv_chi_square_cdf(const T_y& y,
     if (value_of(y_vec[i]) == 0)
       return ops_partials.build(0.0);
 
-  using boost::math::tgamma;
   using std::exp;
   using std::pow;
 

--- a/stan/math/prim/scal/prob/inv_chi_square_lccdf.hpp
+++ b/stan/math/prim/scal/prob/inv_chi_square_lccdf.hpp
@@ -14,6 +14,7 @@
 #include <stan/math/prim/scal/fun/value_of.hpp>
 #include <stan/math/prim/scal/fun/gamma_p.hpp>
 #include <stan/math/prim/scal/fun/digamma.hpp>
+#include <stan/math/prim/scal/fun/tgamma.hpp>
 #include <stan/math/prim/scal/meta/length.hpp>
 #include <stan/math/prim/scal/meta/is_constant_struct.hpp>
 #include <stan/math/prim/scal/meta/scalar_seq_view.hpp>
@@ -75,7 +76,6 @@ typename return_type<T_y, T_dof>::type inv_chi_square_lccdf(const T_y& y,
     if (value_of(y_vec[i]) == 0)
       return ops_partials.build(0.0);
 
-  using boost::math::tgamma;
   using std::exp;
   using std::log;
   using std::pow;

--- a/stan/math/prim/scal/prob/inv_chi_square_lcdf.hpp
+++ b/stan/math/prim/scal/prob/inv_chi_square_lcdf.hpp
@@ -12,6 +12,7 @@
 #include <stan/math/prim/scal/fun/value_of.hpp>
 #include <stan/math/prim/scal/fun/gamma_q.hpp>
 #include <stan/math/prim/scal/fun/digamma.hpp>
+#include <stan/math/prim/scal/fun/tgamma.hpp>
 #include <stan/math/prim/scal/meta/length.hpp>
 #include <stan/math/prim/scal/meta/is_constant_struct.hpp>
 #include <stan/math/prim/scal/meta/scalar_seq_view.hpp>
@@ -75,7 +76,6 @@ typename return_type<T_y, T_dof>::type inv_chi_square_lcdf(const T_y& y,
     if (value_of(y_vec[i]) == 0)
       return ops_partials.build(negative_infinity());
 
-  using boost::math::tgamma;
   using std::exp;
   using std::log;
   using std::pow;

--- a/stan/math/prim/scal/prob/inv_chi_square_lpdf.hpp
+++ b/stan/math/prim/scal/prob/inv_chi_square_lpdf.hpp
@@ -14,6 +14,7 @@
 #include <stan/math/prim/scal/fun/value_of.hpp>
 #include <stan/math/prim/scal/fun/gamma_q.hpp>
 #include <stan/math/prim/scal/fun/digamma.hpp>
+#include <stan/math/prim/scal/fun/lgamma.hpp>
 #include <stan/math/prim/scal/meta/length.hpp>
 #include <stan/math/prim/scal/meta/is_constant_struct.hpp>
 #include <stan/math/prim/scal/meta/scalar_seq_view.hpp>
@@ -71,7 +72,6 @@ typename return_type<T_y, T_dof>::type inv_chi_square_lpdf(const T_y& y,
       return LOG_ZERO;
 
   using boost::math::digamma;
-  using boost::math::lgamma;
   using std::log;
 
   VectorBuilder<include_summand<propto, T_y, T_dof>::value, T_partials_return,

--- a/stan/math/prim/scal/prob/inv_gamma_lccdf.hpp
+++ b/stan/math/prim/scal/prob/inv_gamma_lccdf.hpp
@@ -14,6 +14,7 @@
 #include <stan/math/prim/scal/fun/constants.hpp>
 #include <stan/math/prim/scal/fun/value_of.hpp>
 #include <stan/math/prim/scal/fun/lgamma.hpp>
+#include <stan/math/prim/scal/fun/tgamma.hpp>
 #include <stan/math/prim/scal/fun/gamma_p.hpp>
 #include <stan/math/prim/scal/fun/digamma.hpp>
 #include <stan/math/prim/scal/meta/length.hpp>
@@ -67,7 +68,6 @@ typename return_type<T_y, T_shape, T_scale>::type inv_gamma_lccdf(
       return ops_partials.build(0.0);
   }
 
-  using boost::math::tgamma;
   using std::exp;
   using std::log;
   using std::pow;

--- a/stan/math/rev/scal/fun/gamma_p.hpp
+++ b/stan/math/rev/scal/fun/gamma_p.hpp
@@ -20,7 +20,6 @@ class gamma_p_vv_vari : public op_vv_vari {
   gamma_p_vv_vari(vari* avi, vari* bvi)
       : op_vv_vari(gamma_p(avi->val_, bvi->val_), avi, bvi) {}
   void chain() {
-    using boost::math::lgamma;
     using std::exp;
     using std::fabs;
     using std::log;

--- a/stan/math/rev/scal/fun/ibeta.hpp
+++ b/stan/math/rev/scal/fun/ibeta.hpp
@@ -94,7 +94,6 @@ class ibeta_vdv_vari : public op_vdv_vari {
     using boost::math::constants::pi;
     using boost::math::digamma;
     using boost::math::ibeta;
-    using boost::math::tgamma;
     using std::log;
     using std::pow;
     using std::sin;
@@ -117,7 +116,6 @@ class ibeta_vdd_vari : public op_vdd_vari {
     using boost::math::constants::pi;
     using boost::math::digamma;
     using boost::math::ibeta;
-    using boost::math::tgamma;
     using std::log;
     using std::pow;
     using std::sin;
@@ -139,7 +137,6 @@ class ibeta_dvv_vari : public op_dvv_vari {
     using boost::math::constants::pi;
     using boost::math::digamma;
     using boost::math::ibeta;
-    using boost::math::tgamma;
     using std::log;
     using std::pow;
     using std::sin;
@@ -164,7 +161,6 @@ class ibeta_dvd_vari : public op_dvd_vari {
     using boost::math::constants::pi;
     using boost::math::digamma;
     using boost::math::ibeta;
-    using boost::math::tgamma;
     using std::log;
     using std::pow;
     using std::sin;

--- a/test/unit/math/fwd/scal/fun/atanh_test.cpp
+++ b/test/unit/math/fwd/scal/fun/atanh_test.cpp
@@ -4,7 +4,7 @@
 #include <test/unit/math/fwd/scal/fun/nan_util.hpp>
 
 TEST(AgradFwdAtanh, Fvar) {
-  using boost::math::atanh;
+  using stan::math::atanh;
   using stan::math::fvar;
 
   fvar<double> x(0.5, 1.0);
@@ -21,7 +21,7 @@ TEST(AgradFwdAtanh, Fvar) {
 }
 
 TEST(AgradFwdAtanh, FvarFvarDouble) {
-  using boost::math::atanh;
+  using stan::math::atanh;
   using stan::math::fvar;
 
   fvar<fvar<double> > x;

--- a/test/unit/math/fwd/scal/fun/lgamma_test.cpp
+++ b/test/unit/math/fwd/scal/fun/lgamma_test.cpp
@@ -6,7 +6,7 @@
 
 TEST(AgradFwdLgamma, Fvar) {
   using boost::math::digamma;
-  using boost::math::lgamma;
+  using stan::math::lgamma;
   using stan::math::fvar;
 
   fvar<double> x(0.5, 1.0);
@@ -18,7 +18,7 @@ TEST(AgradFwdLgamma, Fvar) {
 
 TEST(AgradFwdLgamma, FvarFvarDouble) {
   using boost::math::digamma;
-  using boost::math::lgamma;
+  using stan::math::lgamma;
   using stan::math::fvar;
 
   fvar<fvar<double> > x;

--- a/test/unit/math/fwd/scal/fun/tgamma_test.cpp
+++ b/test/unit/math/fwd/scal/fun/tgamma_test.cpp
@@ -6,7 +6,7 @@
 
 TEST(AgradFwdTgamma, Fvar) {
   using boost::math::digamma;
-  using boost::math::tgamma;
+  using stan::math::tgamma;
   using stan::math::fvar;
 
   fvar<double> x(0.5, 1.0);

--- a/test/unit/math/mix/scal/fun/atanh_test.cpp
+++ b/test/unit/math/mix/scal/fun/atanh_test.cpp
@@ -5,7 +5,7 @@
 #include <test/unit/math/mix/scal/fun/nan_util.hpp>
 
 TEST(AgradFwdAtanh, FvarVar_1stDeriv) {
-  using boost::math::atanh;
+  using stan::math::atanh;
   using stan::math::fvar;
   using stan::math::var;
 
@@ -22,7 +22,7 @@ TEST(AgradFwdAtanh, FvarVar_1stDeriv) {
 }
 
 TEST(AgradFwdAtanh, FvarVar_2ndDeriv) {
-  using boost::math::atanh;
+  using stan::math::atanh;
   using stan::math::fvar;
   using stan::math::var;
 
@@ -36,7 +36,7 @@ TEST(AgradFwdAtanh, FvarVar_2ndDeriv) {
 }
 
 TEST(AgradFwdAtanh, FvarFvarVar_1stDeriv) {
-  using boost::math::atanh;
+  using stan::math::atanh;
   using stan::math::fvar;
   using stan::math::var;
 
@@ -73,7 +73,7 @@ TEST(AgradFwdAtanh, FvarFvarVar_1stDeriv) {
 }
 
 TEST(AgradFwdAtanh, FvarFvarVar_2ndDeriv) {
-  using boost::math::atanh;
+  using stan::math::atanh;
   using stan::math::fvar;
   using stan::math::var;
 
@@ -109,7 +109,7 @@ TEST(AgradFwdAtanh, FvarFvarVar_2ndDeriv) {
   EXPECT_FLOAT_EQ(1.7777778, r[0]);
 }
 TEST(AgradFwdAtanh, FvarFvarVar_3rdDeriv) {
-  using boost::math::atanh;
+  using stan::math::atanh;
   using stan::math::fvar;
   using stan::math::var;
 

--- a/test/unit/math/mix/scal/fun/lgamma_test.cpp
+++ b/test/unit/math/mix/scal/fun/lgamma_test.cpp
@@ -6,7 +6,7 @@
 
 TEST(AgradFwdLgamma, FvarVar_1stDeriv) {
   using boost::math::digamma;
-  using boost::math::lgamma;
+  using stan::math::lgamma;
   using stan::math::fvar;
   using stan::math::var;
 
@@ -23,7 +23,7 @@ TEST(AgradFwdLgamma, FvarVar_1stDeriv) {
 }
 TEST(AgradFwdLgamma, FvarVar_2ndDeriv) {
   using boost::math::digamma;
-  using boost::math::lgamma;
+  using stan::math::lgamma;
   using stan::math::fvar;
   using stan::math::var;
 
@@ -40,7 +40,7 @@ TEST(AgradFwdLgamma, FvarVar_2ndDeriv) {
 }
 TEST(AgradFwdLgamma, FvarFvarVar_1stDeriv) {
   using boost::math::digamma;
-  using boost::math::lgamma;
+  using stan::math::lgamma;
   using stan::math::fvar;
   using stan::math::var;
 
@@ -77,7 +77,7 @@ TEST(AgradFwdLgamma, FvarFvarVar_1stDeriv) {
 }
 TEST(AgradFwdLgamma, FvarFvarVar_2ndDeriv) {
   using boost::math::digamma;
-  using boost::math::lgamma;
+  using stan::math::lgamma;
   using stan::math::fvar;
   using stan::math::var;
 

--- a/test/unit/math/mix/scal/fun/tgamma_test.cpp
+++ b/test/unit/math/mix/scal/fun/tgamma_test.cpp
@@ -6,7 +6,7 @@
 
 TEST(AgradFwdTgamma, FvarVar_1stDeriv) {
   using boost::math::digamma;
-  using boost::math::tgamma;
+  using stan::math::tgamma;
   using stan::math::fvar;
   using stan::math::var;
 
@@ -23,7 +23,7 @@ TEST(AgradFwdTgamma, FvarVar_1stDeriv) {
 }
 TEST(AgradFwdTgamma, FvarVar_2ndDeriv) {
   using boost::math::digamma;
-  using boost::math::tgamma;
+  using stan::math::tgamma;
   using stan::math::fvar;
   using stan::math::var;
 
@@ -38,7 +38,7 @@ TEST(AgradFwdTgamma, FvarVar_2ndDeriv) {
 
 TEST(AgradFwdTgamma, FvarFvarDouble) {
   using boost::math::digamma;
-  using boost::math::tgamma;
+  using stan::math::tgamma;
   using stan::math::fvar;
 
   fvar<fvar<double> > x;
@@ -64,7 +64,7 @@ TEST(AgradFwdTgamma, FvarFvarDouble) {
 }
 TEST(AgradFwdTgamma, FvarFvarVar_1stDeriv) {
   using boost::math::digamma;
-  using boost::math::tgamma;
+  using stan::math::tgamma;
   using stan::math::fvar;
   using stan::math::var;
 
@@ -101,7 +101,7 @@ TEST(AgradFwdTgamma, FvarFvarVar_1stDeriv) {
 }
 TEST(AgradFwdTgamma, FvarFvarVar_2ndDeriv) {
   using boost::math::digamma;
-  using boost::math::tgamma;
+  using stan::math::tgamma;
   using stan::math::fvar;
   using stan::math::var;
 
@@ -129,7 +129,7 @@ TEST(AgradFwdTgamma, FvarFvarVar_2ndDeriv) {
 }
 TEST(AgradFwdTgamma, FvarFvarVar_3rdDeriv) {
   using boost::math::digamma;
-  using boost::math::tgamma;
+  using stan::math::tgamma;
   using stan::math::fvar;
   using stan::math::var;
 

--- a/test/unit/math/prim/scal/fun/grad_reg_inc_gamma_test.cpp
+++ b/test/unit/math/prim/scal/fun/grad_reg_inc_gamma_test.cpp
@@ -1,12 +1,13 @@
 #include <gtest/gtest.h>
 #include <stan/math/prim/scal/fun/digamma.hpp>
+#include <stan/math/prim/scal/fun/tgamma.hpp>
 #include <stan/math/prim/scal/fun/grad_reg_inc_gamma.hpp>
 
 // converge
 TEST(MathPrimScalFun, grad_reg_inc_gamma_1) {
   double alpha = 1.1;
   double z = 0.2;
-  double g = boost::math::tgamma(alpha);
+  double g = stan::math::tgamma(alpha);
   double dig = stan::math::digamma(alpha);
   EXPECT_NEAR(0.31416364892410884,
               stan::math::grad_reg_inc_gamma(alpha, z, g, dig, 1e-10), 1e-8);
@@ -15,7 +16,7 @@ TEST(MathPrimScalFun, grad_reg_inc_gamma_1) {
 TEST(MathPrimScalFun, grad_reg_inc_gamma_2) {
   double alpha = 1.1;
   double z = 2.0;
-  double g = boost::math::tgamma(alpha);
+  double g = stan::math::tgamma(alpha);
   double dig = stan::math::digamma(alpha);
   EXPECT_NEAR(0.2350546737889920,
               stan::math::grad_reg_inc_gamma(alpha, z, g, dig, 1e-10), 1e-8);
@@ -24,7 +25,7 @@ TEST(MathPrimScalFun, grad_reg_inc_gamma_2) {
 TEST(MathPrimScalFun, grad_reg_inc_gamma_3) {
   double alpha = 2.5;
   double z = 1.3;
-  double g = boost::math::tgamma(alpha);
+  double g = stan::math::tgamma(alpha);
   double dig = stan::math::digamma(alpha);
   EXPECT_NEAR(0.22962689833555939,
               stan::math::grad_reg_inc_gamma(alpha, z, g, dig, 1e-10), 1e-8);
@@ -33,7 +34,7 @@ TEST(MathPrimScalFun, grad_reg_inc_gamma_3) {
 TEST(MathPrimScalFun, grad_reg_inc_gamma_4) {
   double alpha = 2.5;
   double z = 30;
-  double g = boost::math::tgamma(alpha);
+  double g = stan::math::tgamma(alpha);
   double dig = stan::math::digamma(alpha);
   EXPECT_NEAR(3.3205e-11,
               stan::math::grad_reg_inc_gamma(alpha, z, g, dig, 1e-10), 1e-8);
@@ -42,7 +43,7 @@ TEST(MathPrimScalFun, grad_reg_inc_gamma_4) {
 TEST(MathPrimScalFun, grad_reg_inc_gamma_5) {
   double alpha = 9;
   double z = 10;
-  double g = boost::math::tgamma(alpha);
+  double g = stan::math::tgamma(alpha);
   double dig = stan::math::digamma(alpha);
   EXPECT_NEAR(0.120855166827777,
               stan::math::grad_reg_inc_gamma(alpha, z, g, dig, 1e-10), 4e-7);
@@ -51,7 +52,7 @@ TEST(MathPrimScalFun, grad_reg_inc_gamma_5) {
 TEST(MathPrimScalFun, grad_reg_inc_gamma_6) {
   double alpha = 10.0;
   double z = 9.0;
-  double g = boost::math::tgamma(alpha);
+  double g = stan::math::tgamma(alpha);
   double dig = stan::math::digamma(alpha);
   EXPECT_NEAR(0.1270365119242684,
               stan::math::grad_reg_inc_gamma(alpha, z, g, dig, 1e-12), 1e-8);

--- a/test/unit/math/prim/scal/fun/lgamma_test.cpp
+++ b/test/unit/math/prim/scal/fun/lgamma_test.cpp
@@ -11,5 +11,5 @@ TEST(MathFunctions, lgammaStanMathUsing) { using stan::math::lgamma; }
 TEST(MathFunctions, lgamma_nan) {
   double nan = std::numeric_limits<double>::quiet_NaN();
   EXPECT_PRED1(boost::math::isnan<double>, stan::math::lgamma(nan));
-  EXPECT_PRED1(boost::math::isnan<double>, stan::math::lgamma(0));
+  EXPECT_PRED1(boost::math::isinf<double>, stan::math::lgamma(0));
 }

--- a/test/unit/math/rev/scal/fun/tgamma_test.cpp
+++ b/test/unit/math/rev/scal/fun/tgamma_test.cpp
@@ -6,12 +6,12 @@
 TEST(AgradRev, tgamma) {
   AVAR a = 3.5;
   AVAR f = stan::math::tgamma(a);
-  EXPECT_FLOAT_EQ(boost::math::tgamma(3.5), f.val());
+  EXPECT_FLOAT_EQ(stan::math::tgamma(3.5), f.val());
 
   AVEC x = createAVEC(a);
   VEC grad_f;
   f.grad(x, grad_f);
-  EXPECT_FLOAT_EQ(boost::math::digamma(3.5) * boost::math::tgamma(3.5),
+  EXPECT_FLOAT_EQ(boost::math::digamma(3.5) * stan::math::tgamma(3.5),
                   grad_f[0]);
 }
 


### PR DESCRIPTION
## Summary

Addresses part 2 of issue #1010, replacing ```boost::math::``` functions that need input checking and platform-specific return handling

The following functions have been replaced:
- acosh
- atanh
- lgamma
- log1p
- tgamma


## Tests
Only major change is that ```lgamma(0)``` now expects an ```inf``` return rather than ```nan```

## Side Effects

N/A

## Checklist

- [x] Math issue #1010 

- [x] Copyright holder: Andrew Johnson

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
