### PR TITLE
Bugfix/issue 1075 map rect fail

### DIFF
--- a/stan/math/prim/mat/functor/map_rect_concurrent.hpp
+++ b/stan/math/prim/mat/functor/map_rect_concurrent.hpp
@@ -102,8 +102,7 @@ map_rect_concurrent(
 
 #ifdef STAN_THREADS
   if (num_threads > 1) {
-    const int num_big_threads
-        = (num_jobs - num_jobs_per_thread) % (num_threads - 1);
+    const int num_big_threads = num_jobs % num_threads;
     const int first_big_thread = num_threads - num_big_threads;
     for (int i = 1, job_start = num_jobs_per_thread, job_size = 0;
          i < num_threads; ++i, job_start += job_size) {

--- a/test/unit/math/prim/mat/functor/map_rect_concurrent_threads_test.cpp
+++ b/test/unit/math/prim/mat/functor/map_rect_concurrent_threads_test.cpp
@@ -1,0 +1,93 @@
+// the tests here check that map_rect_concurrent works correct as such we
+// enforce that STAN_MPI is NOT defined while STAN_THREADS is turned on
+
+#ifdef STAN_MPI
+#undef STAN_MPI
+#endif
+
+#ifndef STAN_THREADS
+#define STAN_THREADS
+#endif
+
+#include <stan/math/prim/mat.hpp>
+#include <gtest/gtest.h>
+
+#include <test/unit/math/prim/mat/functor/hard_work.hpp>
+
+#include <iostream>
+#include <vector>
+#include <string>
+#include <stdlib.h>
+
+// utility to set number of threads to use
+void set_n_threads(std::size_t num_threads) {
+  static char env_string[256];
+  std::string num_threads_str = std::to_string(num_threads);
+  snprintf(env_string, sizeof(env_string), "STAN_NUM_THREADS=%s",
+           num_threads_str.c_str());
+  putenv(env_string);
+}
+
+STAN_REGISTER_MAP_RECT(0, hard_work)
+STAN_REGISTER_MAP_RECT(1, hard_work)
+
+struct map_rect : public ::testing::Test {
+  Eigen::VectorXd shared_params_d;
+  std::vector<Eigen::VectorXd> job_params_d;
+  std::vector<std::vector<double> > x_r;
+  std::vector<std::vector<int> > x_i;
+  const int N = 7;
+
+  virtual void SetUp() {
+    shared_params_d.resize(2);
+    shared_params_d << 2, 0;
+
+    for (int n = 0; n != N; ++n) {
+      Eigen::VectorXd job_d(2);
+      job_d << 0, n * n;
+      job_params_d.push_back(job_d);
+    }
+
+    x_r = std::vector<std::vector<double> >(N, std::vector<double>(1, 1.0));
+    x_i = std::vector<std::vector<int> >(N, std::vector<int>(1, 0));
+  }
+};
+
+TEST_F(map_rect, concurrent_varying_num_threads_ragged_dd) {
+  for (std::size_t i = 1; i < 2 * N + 1; ++i) {
+    set_n_threads(i);
+
+    Eigen::VectorXd res1 = stan::math::map_rect<0, hard_work>(
+        shared_params_d, job_params_d, x_r, x_i);
+
+    EXPECT_EQ(res1.size(), 2 * N);
+  }
+
+  x_i[1] = std::vector<int>(1, 1);
+
+  for (std::size_t i = 1; i < 2 * N + 1; ++i) {
+    set_n_threads(i);
+
+    Eigen::VectorXd res2 = stan::math::map_rect<1, hard_work>(
+        shared_params_d, job_params_d, x_r, x_i);
+
+    EXPECT_EQ(res2.size(), 2 * N + 1);
+  }
+}
+
+TEST_F(map_rect, concurrent_varying_num_threads_eval_ok_dd) {
+  for (std::size_t i = 1; i < 2 * N + 1; ++i) {
+    set_n_threads(i);
+
+    Eigen::VectorXd res1 = stan::math::map_rect<0, hard_work>(
+        shared_params_d, job_params_d, x_r, x_i);
+    for (int i = 0, j = 0; i < N; i++) {
+      j = 2 * i;
+      EXPECT_FLOAT_EQ(res1(j), job_params_d[i](0) * job_params_d[i](0)
+                                   + shared_params_d(0));
+      EXPECT_FLOAT_EQ(res1(j + 1),
+                      x_r[i][0] * job_params_d[i](1) * job_params_d[i](0)
+                          + 2 * shared_params_d(0) + shared_params_d(1));
+    }
+  }
+}

--- a/test/unit/math/prim/mat/functor/map_rect_concurrent_threads_test.cpp
+++ b/test/unit/math/prim/mat/functor/map_rect_concurrent_threads_test.cpp
@@ -9,15 +9,16 @@
 #define STAN_THREADS
 #endif
 
-#include <stan/math/prim/mat.hpp>
+#include <stdlib.h>
+
 #include <gtest/gtest.h>
+#include <stan/math/prim/mat.hpp>
 
 #include <test/unit/math/prim/mat/functor/hard_work.hpp>
 
 #include <iostream>
 #include <vector>
 #include <string>
-#include <stdlib.h>
 
 // utility to set number of threads to use
 void set_n_threads(std::size_t num_threads) {


### PR DESCRIPTION
## Summary

Fixes an issue with `map_rect` whenever threading is used.

## Tests

There is a new test which triggers the issue:

`test/unit/math/prim/mat/functor/map_rect_concurrent_threads_test.cpp`

If you run this test on commit `cb1f5b4` then it will fail as this has the current develop `map_rect_concurrent` with the failing behavior. The next commit then fixes the problem.


## Side Effects

Nope.

## Checklist

- [X] Math issue #1075 

- [X] Copyright holder: Sebastian Weber

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [X] the new changes are tested