### PR TITLE
Fixes makefile dependencies on Windows.

### DIFF
--- a/make/tests
+++ b/make/tests
@@ -3,11 +3,12 @@ N_TESTS ?= 100
 # to group the probability tests into
 
 ##
-# Build test executables
+# Anything targets in test/ (.d, .o, executable)
+# needs the GTEST flags
 ##
-test/%$(EXE) : CXXFLAGS += $(CXXFLAGS_GTEST)
-test/%$(EXE) : CPPFLAGS += $(CPPFLAGS_GTEST)
-test/%$(EXE) : INC += $(INC_GTEST)
+test/% : CXXFLAGS += $(CXXFLAGS_GTEST)
+test/% : CPPFLAGS += $(CPPFLAGS_GTEST)
+test/% : INC += $(INC_GTEST)
 
 test/%$(EXE) : test/%.o $(GTEST)/src/gtest_main.cc $(GTEST)/src/gtest-all.o $(MPI_TARGETS)
 	$(LINK.cpp) $^ $(LDLIBS) $(OUTPUT_OPTION)

--- a/make/tests
+++ b/make/tests
@@ -3,8 +3,7 @@ N_TESTS ?= 100
 # to group the probability tests into
 
 ##
-# Anything targets in test/ (.d, .o, executable)
-# needs the GTEST flags
+# Any targets in test/ (.d, .o, executable) needs the GTEST flags
 ##
 test/% : CXXFLAGS += $(CXXFLAGS_GTEST)
 test/% : CPPFLAGS += $(CPPFLAGS_GTEST)


### PR DESCRIPTION
## Summary

The build process on Windows was rebuilding tests unnecessarily. This stops that from happening.

Details: The makefile was only adding the `GTEST` flags to the compiler options for the `.exe` instead of for every artifact inside the `test/` folder. That was masked on Mac and Linux because the make variable `$(EXE)` evaluates to nothing and the targets changed matches a wildcard. In windows, it only matches `.exe` and not things like `.d`. That's been fixed.

## Tests

In Windows run this multiple times:
```
make test/unit/math_c11_test.exe
```

The first time, it should build everything. On subsequent runs, it shouldn't rebuild.

@seantalts: thanks for letting me know this was a problem.

## Side Effects

Should make testing faster on Windows. This was the expected behavior.

## Checklist

- [x] Math issue #1087

- [x] Copyright holder: Generable

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen (N/A)
   The doc in the makefile was made a little more precise.

- [x] the new changes are tested
   These were tested by hand. Using just the direct make invocation as well as using the python script on a single test and on a folder.
