### PR TITLE
Hotfix/issue 1075 map rect fail

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,15 +32,15 @@ String alsoNotify() {
 Boolean isPR() { env.CHANGE_URL != null }
 String fork() { env.CHANGE_FORK ?: "stan-dev" }
 String branchName() { isPR() ? env.CHANGE_BRANCH :env.BRANCH_NAME }
-String cmdstan_pr() { params.cmdstan_pr ?: "downstream_tests" }
-String stan_pr() { params.stan_pr ?: "downstream_tests" }
+String cmdstan_pr() { params.cmdstan_pr ?: ( env.CHANGE_TARGET == "master" ? "downstream_hotfix" : "downstream_tests" ) }
+String stan_pr() { params.stan_pr ?: ( env.CHANGE_TARGET == "master" ? "downstream_hotfix" : "downstream_tests" ) }
 
 pipeline {
     agent none
     parameters {
-        string(defaultValue: 'downstream_tests', name: 'cmdstan_pr',
+        string(defaultValue: '', name: 'cmdstan_pr',
           description: 'PR to test CmdStan upstream against e.g. PR-630')
-        string(defaultValue: 'downstream_tests', name: 'stan_pr',
+        string(defaultValue: '', name: 'stan_pr',
           description: 'PR to test Stan upstream against e.g. PR-630')
         booleanParam(defaultValue: false, description:
         'Run additional distribution tests on RowVectors (takes 5x as long)',

--- a/stan/math/prim/mat/functor/map_rect_concurrent.hpp
+++ b/stan/math/prim/mat/functor/map_rect_concurrent.hpp
@@ -5,6 +5,8 @@
 
 #include <stan/math/prim/mat/functor/map_rect_reduce.hpp>
 #include <stan/math/prim/mat/functor/map_rect_combine.hpp>
+#include <stan/math/prim/scal/err/invalid_argument.hpp>
+#include <boost/lexical_cast.hpp>
 
 #include <vector>
 #include <thread>
@@ -20,30 +22,45 @@ namespace internal {
  * the environment variable STAN_NUM_THREADS and follows these
  * conventions:
  *
- * - STAN_NUM_THREADS is not defined or is not a number => num_threads=1
+ * - STAN_NUM_THREADS is not defined => num_threads=1
  * - STAN_NUM_THREADS is positive => num_threads is set to the
  *   specified number
  * - STAN_NUM_THREADS is set to -1 => num_threads is the number of
  *   available cores on the machine
- * - STAN_NUM_THREADS < -1 => num_threads is 1
+ * - STAN_NUM_THREADS < -1, STAN_NUM_THREADS = 0 or STAN_NUM_THREADS is
+ *   not numeric => throws an exception
  *
  * Should num_threads exceed the number of jobs, then num_threads will
  * be set equal to the number of jobs.
  *
  * @param num_jobs number of jobs
  * @return number of threads to use
+ * @throws std::runtime_error if the value of STAN_NUM_THREADS env. variable
+ * is invalid
  */
 inline int get_num_threads(int num_jobs) {
   int num_threads = 1;
 #ifdef STAN_THREADS
   const char* env_stan_num_threads = std::getenv("STAN_NUM_THREADS");
   if (env_stan_num_threads != nullptr) {
-    const int env_num_threads = std::atoi(env_stan_num_threads);
-    if (env_num_threads > 0)
-      num_threads = env_num_threads;
-    else if (env_num_threads == -1)
-      num_threads = std::thread::hardware_concurrency();
-    // anything else will use 1 thread.
+    try {
+      const int env_num_threads
+          = boost::lexical_cast<int>(env_stan_num_threads);
+      if (env_num_threads > 0)
+        num_threads = env_num_threads;
+      else if (env_num_threads == -1)
+        num_threads = std::thread::hardware_concurrency();
+      else
+        invalid_argument("get_num_threads(int)", "STAN_NUM_THREADS",
+                         env_stan_num_threads,
+                         "The STAN_NUM_THREADS environment variable is '",
+                         "' but it must be positive or -1");
+    } catch (boost::bad_lexical_cast) {
+      invalid_argument("get_num_threads(int)", "STAN_NUM_THREADS",
+                       env_stan_num_threads,
+                       "The STAN_NUM_THREADS environment variable is '",
+                       "' but it must be a positive number or -1");
+    }
   }
   if (num_threads > num_jobs)
     num_threads = num_jobs;
@@ -85,8 +102,7 @@ map_rect_concurrent(
 
 #ifdef STAN_THREADS
   if (num_threads > 1) {
-    const int num_big_threads
-        = (num_jobs - num_jobs_per_thread) % (num_threads - 1);
+    const int num_big_threads = num_jobs % num_threads;
     const int first_big_thread = num_threads - num_big_threads;
     for (int i = 1, job_start = num_jobs_per_thread, job_size = 0;
          i < num_threads; ++i, job_start += job_size) {

--- a/stan/math/prim/mat/functor/map_rect_concurrent.hpp
+++ b/stan/math/prim/mat/functor/map_rect_concurrent.hpp
@@ -5,8 +5,6 @@
 
 #include <stan/math/prim/mat/functor/map_rect_reduce.hpp>
 #include <stan/math/prim/mat/functor/map_rect_combine.hpp>
-#include <stan/math/prim/scal/err/invalid_argument.hpp>
-#include <boost/lexical_cast.hpp>
 
 #include <vector>
 #include <thread>
@@ -22,45 +20,30 @@ namespace internal {
  * the environment variable STAN_NUM_THREADS and follows these
  * conventions:
  *
- * - STAN_NUM_THREADS is not defined => num_threads=1
+ * - STAN_NUM_THREADS is not defined or is not a number => num_threads=1
  * - STAN_NUM_THREADS is positive => num_threads is set to the
  *   specified number
  * - STAN_NUM_THREADS is set to -1 => num_threads is the number of
  *   available cores on the machine
- * - STAN_NUM_THREADS < -1, STAN_NUM_THREADS = 0 or STAN_NUM_THREADS is
- *   not numeric => throws an exception
+ * - STAN_NUM_THREADS < -1 => num_threads is 1
  *
  * Should num_threads exceed the number of jobs, then num_threads will
  * be set equal to the number of jobs.
  *
  * @param num_jobs number of jobs
  * @return number of threads to use
- * @throws std::runtime_error if the value of STAN_NUM_THREADS env. variable
- * is invalid
  */
 inline int get_num_threads(int num_jobs) {
   int num_threads = 1;
 #ifdef STAN_THREADS
   const char* env_stan_num_threads = std::getenv("STAN_NUM_THREADS");
   if (env_stan_num_threads != nullptr) {
-    try {
-      const int env_num_threads
-          = boost::lexical_cast<int>(env_stan_num_threads);
-      if (env_num_threads > 0)
-        num_threads = env_num_threads;
-      else if (env_num_threads == -1)
-        num_threads = std::thread::hardware_concurrency();
-      else
-        invalid_argument("get_num_threads(int)", "STAN_NUM_THREADS",
-                         env_stan_num_threads,
-                         "The STAN_NUM_THREADS environment variable is '",
-                         "' but it must be positive or -1");
-    } catch (boost::bad_lexical_cast) {
-      invalid_argument("get_num_threads(int)", "STAN_NUM_THREADS",
-                       env_stan_num_threads,
-                       "The STAN_NUM_THREADS environment variable is '",
-                       "' but it must be a positive number or -1");
-    }
+    const int env_num_threads = std::atoi(env_stan_num_threads);
+    if (env_num_threads > 0)
+      num_threads = env_num_threads;
+    else if (env_num_threads == -1)
+      num_threads = std::thread::hardware_concurrency();
+    // anything else will use 1 thread.
   }
   if (num_threads > num_jobs)
     num_threads = num_jobs;

--- a/test/unit/math/prim/mat/functor/map_rect_concurrent_threads_test.cpp
+++ b/test/unit/math/prim/mat/functor/map_rect_concurrent_threads_test.cpp
@@ -1,0 +1,122 @@
+// the tests here check that map_rect_concurrent works correct as such we
+// enforce that STAN_MPI is NOT defined and these tests only run if
+// STAN_THREADS is defined
+
+#ifdef STAN_THREADS
+
+#ifdef STAN_MPI
+#undef STAN_MPI
+#endif
+
+#include <stdlib.h>
+
+#include <gtest/gtest.h>
+#include <stan/math/prim/mat.hpp>
+
+#include <test/unit/math/prim/mat/functor/hard_work.hpp>
+
+#include <iostream>
+#include <vector>
+#include <string>
+
+// utility to set number of threads to use
+void set_n_threads(int num_threads) {
+  static char env_string[256];
+  std::string num_threads_str = std::to_string(num_threads);
+  snprintf(env_string, sizeof(env_string), "STAN_NUM_THREADS=%s",
+           num_threads_str.c_str());
+  putenv(env_string);
+}
+
+STAN_REGISTER_MAP_RECT(0, hard_work)
+STAN_REGISTER_MAP_RECT(1, hard_work)
+
+void setup_job(int N, Eigen::VectorXd& shared_params_d,
+               std::vector<Eigen::VectorXd>& job_params_d,
+               std::vector<std::vector<double> >& x_r,
+               std::vector<std::vector<int> >& x_i) {
+  shared_params_d.resize(2);
+  shared_params_d << 2, 0;
+
+  job_params_d.clear();
+  for (int n = 0; n != N; ++n) {
+    Eigen::VectorXd job_d(2);
+    job_d << 0, n * n;
+    job_params_d.push_back(job_d);
+  }
+
+  x_r.clear();
+  x_i.clear();
+
+  if (N > 0) {
+    x_r = std::vector<std::vector<double> >(N, std::vector<double>(1, 1.0));
+    x_i = std::vector<std::vector<int> >(N, std::vector<int>(1, 0));
+  }
+}
+
+struct map_rect : public ::testing::Test {
+  Eigen::VectorXd shared_params_d;
+  std::vector<Eigen::VectorXd> job_params_d;
+  std::vector<std::vector<double> > x_r;
+  std::vector<std::vector<int> > x_i;
+  std::vector<int> N_test{0, 1, 2, 7, 10, 13, 67, 100};
+
+  virtual void SetUp() {}
+};
+
+TEST_F(map_rect, concurrent_varying_num_threads_ragged_dd) {
+  set_n_threads(-1);
+
+  for (std::size_t i = 1; i < 20; ++i) {
+    for (std::size_t n = 0; n < N_test.size(); ++n) {
+      const int N = N_test[n];
+      setup_job(N, shared_params_d, job_params_d, x_r, x_i);
+
+      Eigen::VectorXd res1 = stan::math::map_rect<0, hard_work>(
+          shared_params_d, job_params_d, x_r, x_i);
+
+      EXPECT_EQ(res1.size(), 2 * N);
+    }
+    set_n_threads(i);
+  }
+
+  set_n_threads(-1);
+  for (std::size_t i = 1; i < 20; ++i) {
+    for (std::size_t n = 1; n < N_test.size(); ++n) {
+      const int N = N_test[n];
+      setup_job(N, shared_params_d, job_params_d, x_r, x_i);
+
+      x_i[0] = std::vector<int>(1, 1);
+
+      Eigen::VectorXd res2 = stan::math::map_rect<0, hard_work>(
+          shared_params_d, job_params_d, x_r, x_i);
+
+      EXPECT_EQ(res2.size(), 2 * N + 1);
+    }
+    set_n_threads(i);
+  }
+}
+
+TEST_F(map_rect, concurrent_varying_num_threads_eval_ok_dd) {
+  set_n_threads(-1);
+  for (std::size_t i = 1; i < 20; ++i) {
+    for (std::size_t n = 0; n < N_test.size(); ++n) {
+      const int N = N_test[n];
+      setup_job(N, shared_params_d, job_params_d, x_r, x_i);
+
+      Eigen::VectorXd res1 = stan::math::map_rect<0, hard_work>(
+          shared_params_d, job_params_d, x_r, x_i);
+      for (int i = 0, j = 0; i < N; i++) {
+        j = 2 * i;
+        EXPECT_FLOAT_EQ(res1(j), job_params_d[i](0) * job_params_d[i](0)
+                                     + shared_params_d(0));
+        EXPECT_FLOAT_EQ(res1(j + 1),
+                        x_r[i][0] * job_params_d[i](1) * job_params_d[i](0)
+                            + 2 * shared_params_d(0) + shared_params_d(1));
+      }
+    }
+    set_n_threads(i);
+  }
+}
+
+#endif


### PR DESCRIPTION
Fixes an issue with `map_rect` whenever threading is used. This PR is a hotfix and the merge request is wrt to MASTER !!! Please correct if that is not what we want here.

## Summary

There is a new test which triggers the issue:

`test/unit/math/prim/mat/functor/map_rect_concurrent_threads_test.cpp`

If you run this test on the current master then it will fail while on this PR it works fine for a range of thread / job combinations.

## Tests

Tests a range of thread / number of job combinations:

`test/unit/math/prim/mat/functor/map_rect_concurrent_threads_test.cpp`


## Side Effects

None I am aware of.

## Checklist

- [X] Math issue #1075 

- [X] Copyright holder: Sebastian Weber

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [X] the new changes are tested
