### PR TITLE
Bugfix/issue 1100 missing bounds

### DIFF
--- a/stan/math/prim/mat.hpp
+++ b/stan/math/prim/mat.hpp
@@ -24,6 +24,7 @@
 #include <stan/math/prim/mat/err/check_cholesky_factor_corr.hpp>
 #include <stan/math/prim/mat/err/check_column_index.hpp>
 #include <stan/math/prim/mat/err/check_consistent_size_mvt.hpp>
+#include <stan/math/prim/mat/err/check_consistent_sizes_mvt.hpp>
 #include <stan/math/prim/mat/err/check_corr_matrix.hpp>
 #include <stan/math/prim/mat/err/check_cov_matrix.hpp>
 #include <stan/math/prim/mat/err/check_finite.hpp>

--- a/stan/math/prim/mat.hpp
+++ b/stan/math/prim/mat.hpp
@@ -23,6 +23,7 @@
 #include <stan/math/prim/mat/err/check_cholesky_factor.hpp>
 #include <stan/math/prim/mat/err/check_cholesky_factor_corr.hpp>
 #include <stan/math/prim/mat/err/check_column_index.hpp>
+#include <stan/math/prim/mat/err/check_consistent_size_mvt.hpp>
 #include <stan/math/prim/mat/err/check_corr_matrix.hpp>
 #include <stan/math/prim/mat/err/check_cov_matrix.hpp>
 #include <stan/math/prim/mat/err/check_finite.hpp>

--- a/stan/math/prim/mat/err/check_consistent_size_mvt.hpp
+++ b/stan/math/prim/mat/err/check_consistent_size_mvt.hpp
@@ -1,7 +1,9 @@
 #ifndef STAN_MATH_PRIM_SCAL_ERR_CHECK_CONSISTENT_SIZE_MVT_HPP
 #define STAN_MATH_PRIM_SCAL_ERR_CHECK_CONSISTENT_SIZE_MVT_HPP
 
+#include <stan/math/prim/mat/meta/length.hpp>
 #include <stan/math/prim/mat/meta/length_mvt.hpp>
+#include <stan/math/prim/mat/meta/is_vector.hpp>
 #include <stan/math/prim/scal/err/invalid_argument.hpp>
 #include <sstream>
 #include <string>
@@ -27,14 +29,22 @@ namespace math {
 template <typename T>
 inline void check_consistent_size_mvt(const char* function, const char* name,
                                       const T& x, size_t expected_size) {
-  bool x_contains_vectors
-      = is_vector<typename std::remove_reference<decltype(x[0])>::type>::value;
-  size_t size_x = stan::length_mvt(x);
+  size_t size_x = 0;
 
-  if (!x_contains_vectors)
-    return;
-  else if (expected_size == size_x)
-    return;
+  if (length(x) == 0) {
+    size_x = 0;
+    if (expected_size == 0)
+      return;
+  } else {
+    size_t size_x = stan::length_mvt(x);
+    bool x_contains_vectors = is_vector<
+        typename std::remove_reference<decltype(x[0])>::type>::value;
+
+    if (!x_contains_vectors)
+      return;
+    else if (expected_size == size_x)
+      return;
+  }
 
   std::stringstream msg;
   msg << ", expecting dimension = " << expected_size

--- a/stan/math/prim/mat/err/check_consistent_size_mvt.hpp
+++ b/stan/math/prim/mat/err/check_consistent_size_mvt.hpp
@@ -1,0 +1,52 @@
+#ifndef STAN_MATH_PRIM_SCAL_ERR_CHECK_CONSISTENT_SIZE_MVT_HPP
+#define STAN_MATH_PRIM_SCAL_ERR_CHECK_CONSISTENT_SIZE_MVT_HPP
+
+#include <stan/math/prim/mat/meta/length_mvt.hpp>
+#include <stan/math/prim/scal/err/invalid_argument.hpp>
+#include <sstream>
+#include <string>
+#include <type_traits>
+
+namespace stan {
+namespace math {
+
+/**
+ * Check if the dimension of x is consistent, which is defined to be
+ * <code>expected_size</code> if x is a vector of vectors or 1 if x is
+ * a single vector.
+ *
+ * @tparam T Type of value
+ *
+ * @param function Function name (for error messages)
+ * @param name Variable name (for error messages)
+ * @param x Variable to check for consistent size
+ * @param expected_size Expected size if x is a vector
+ *
+ * @throw <code>invalid_argument</code> if the size is inconsistent
+ */
+template <typename T>
+inline void check_consistent_size_mvt(const char* function, const char* name,
+                                      const T& x, size_t expected_size) {
+  bool x_contains_vectors
+      = is_vector<typename std::remove_reference<decltype(x[0])>::type>::value;
+  size_t size_x = stan::length_mvt(x);
+
+  if (!x_contains_vectors)
+    return;
+  else if (expected_size == size_x)
+    return;
+
+  std::stringstream msg;
+  msg << ", expecting dimension = " << expected_size
+      << "; a function was called with arguments of different "
+      << "scalar, array, vector, or matrix types, and they were not "
+      << "consistently sized;  all arguments must be scalars or "
+      << "multidimensional values of the same shape.";
+  std::string msg_str(msg.str());
+
+  invalid_argument(function, name, size_x, "has dimension = ", msg_str.c_str());
+}
+
+}  // namespace math
+}  // namespace stan
+#endif

--- a/stan/math/prim/mat/err/check_consistent_sizes_mvt.hpp
+++ b/stan/math/prim/mat/err/check_consistent_sizes_mvt.hpp
@@ -1,0 +1,41 @@
+#ifndef STAN_MATH_PRIM_MAT_ERR_CHECK_CONSISTENT_SIZES_MVT_HPP
+#define STAN_MATH_PRIM_MAT_ERR_CHECK_CONSISTENT_SIZES_MVT_HPP
+
+#include <stan/math/prim/mat/err/check_consistent_size_mvt.hpp>
+#include <stan/math/prim/mat/meta/length_mvt.hpp>
+#include <algorithm>
+
+namespace stan {
+namespace math {
+
+/**
+ * Check if the dimension of x1 is consistent
+ * with x2.
+ *
+ * Consistent size is defined as having the same size if vector of
+ * vectors or being a single vector.
+ *
+ * @tparam T1 Type of x1
+ * @tparam T2 Type of x2
+ *
+ * @param function Function name (for error messages)
+ * @param name1 Variable name (for error messages)
+ * @param x1 Variable to check for consistent size
+ * @param name2 Variable name (for error messages)
+ * @param x2 Variable to check for consistent size
+ *
+ * @throw <code>invalid_argument</code> if sizes are inconsistent
+ */
+template <typename T1, typename T2>
+inline void check_consistent_sizes_mvt(const char* function, const char* name1,
+                                       const T1& x1, const char* name2,
+                                       const T2& x2) {
+  using stan::length_mvt;
+  size_t max_size = std::max(length_mvt(x1), length_mvt(x2));
+  check_consistent_size_mvt(function, name1, x1, max_size);
+  check_consistent_size_mvt(function, name2, x2, max_size);
+}
+
+}  // namespace math
+}  // namespace stan
+#endif

--- a/stan/math/prim/mat/prob/multi_normal_cholesky_lpdf.hpp
+++ b/stan/math/prim/mat/prob/multi_normal_cholesky_lpdf.hpp
@@ -13,6 +13,7 @@
 #include <stan/math/prim/scal/err/check_finite.hpp>
 #include <stan/math/prim/scal/err/check_not_nan.hpp>
 #include <stan/math/prim/scal/fun/constants.hpp>
+#include <stan/math/prim/scal/meta/length_mvt.hpp>
 #include <stan/math/prim/scal/meta/max_size_mvt.hpp>
 #include <stan/math/prim/scal/meta/include_summand.hpp>
 #include <stan/math/prim/scal/meta/return_type.hpp>
@@ -57,6 +58,15 @@ typename return_type<T_y, T_loc, T_covar>::type multi_normal_cholesky_lpdf(
   typedef Eigen::Matrix<T_partials_return, Eigen::Dynamic, 1> vector_partials_t;
   typedef Eigen::Matrix<T_partials_return, 1, Eigen::Dynamic>
       row_vector_partials_t;
+
+  size_t number_of_y = length_mvt(y);
+  size_t number_of_mu = length_mvt(mu);
+  if (number_of_y == 0 || number_of_mu == 0)
+    return 0.0;
+  if (number_of_y > 1 && number_of_mu > 1)
+    check_size_match(function, "Number of vectors of the random variable",
+                     number_of_y, "Number of vectors of the mean",
+                     number_of_mu);
 
   vector_seq_view<T_y> y_vec(y);
   vector_seq_view<T_loc> mu_vec(mu);

--- a/stan/math/prim/mat/prob/multi_normal_cholesky_lpdf.hpp
+++ b/stan/math/prim/mat/prob/multi_normal_cholesky_lpdf.hpp
@@ -4,6 +4,7 @@
 #include <stan/math/prim/scal/meta/is_constant_struct.hpp>
 #include <stan/math/prim/scal/meta/partials_return_type.hpp>
 #include <stan/math/prim/mat/meta/operands_and_partials.hpp>
+#include <stan/math/prim/mat/err/check_consistent_sizes_mvt.hpp>
 #include <stan/math/prim/mat/fun/dot_self.hpp>
 #include <stan/math/prim/mat/fun/log.hpp>
 #include <stan/math/prim/mat/fun/mdivide_left_tri.hpp>
@@ -19,7 +20,6 @@
 #include <stan/math/prim/scal/meta/return_type.hpp>
 #include <boost/random/normal_distribution.hpp>
 #include <boost/random/variate_generator.hpp>
-#include <type_traits>
 
 namespace stan {
 namespace math {
@@ -64,14 +64,7 @@ typename return_type<T_y, T_loc, T_covar>::type multi_normal_cholesky_lpdf(
   size_t number_of_mu = length_mvt(mu);
   if (number_of_y == 0 || number_of_mu == 0)
     return 0.0;
-  bool y_contains_vectors
-      = is_vector<typename std::remove_reference<decltype(y[0])>::type>::value;
-  bool mu_contains_vectors
-      = is_vector<typename std::remove_reference<decltype(mu[0])>::type>::value;
-  if (y_contains_vectors && mu_contains_vectors)
-    check_size_match(function, "Number of vectors of the random variable",
-                     number_of_y, "Number of vectors of the mean",
-                     number_of_mu);
+  check_consistent_sizes_mvt(function, "y", y, "mu", mu);
 
   vector_seq_view<T_y> y_vec(y);
   vector_seq_view<T_loc> mu_vec(mu);

--- a/stan/math/prim/mat/prob/multi_normal_cholesky_lpdf.hpp
+++ b/stan/math/prim/mat/prob/multi_normal_cholesky_lpdf.hpp
@@ -19,6 +19,7 @@
 #include <stan/math/prim/scal/meta/return_type.hpp>
 #include <boost/random/normal_distribution.hpp>
 #include <boost/random/variate_generator.hpp>
+#include <type_traits>
 
 namespace stan {
 namespace math {
@@ -63,7 +64,11 @@ typename return_type<T_y, T_loc, T_covar>::type multi_normal_cholesky_lpdf(
   size_t number_of_mu = length_mvt(mu);
   if (number_of_y == 0 || number_of_mu == 0)
     return 0.0;
-  if (number_of_y > 1 && number_of_mu > 1)
+  bool y_contains_vectors
+      = is_vector<typename std::remove_reference<decltype(y[0])>::type>::value;
+  bool mu_contains_vectors
+      = is_vector<typename std::remove_reference<decltype(mu[0])>::type>::value;
+  if (y_contains_vectors && mu_contains_vectors)
     check_size_match(function, "Number of vectors of the random variable",
                      number_of_y, "Number of vectors of the mean",
                      number_of_mu);

--- a/stan/math/prim/mat/prob/multi_normal_lpdf.hpp
+++ b/stan/math/prim/mat/prob/multi_normal_lpdf.hpp
@@ -11,6 +11,7 @@
 #include <stan/math/prim/scal/err/check_not_nan.hpp>
 #include <stan/math/prim/scal/err/check_positive.hpp>
 #include <stan/math/prim/scal/fun/constants.hpp>
+#include <stan/math/prim/scal/meta/length_mvt.hpp>
 #include <stan/math/prim/scal/meta/return_type.hpp>
 #include <stan/math/prim/scal/meta/max_size_mvt.hpp>
 #include <stan/math/prim/scal/meta/include_summand.hpp>
@@ -36,6 +37,15 @@ typename return_type<T_y, T_loc, T_covar>::type multi_normal_lpdf(
   LDLT_factor<T_covar_elem, Dynamic, Dynamic> ldlt_Sigma(Sigma);
   check_ldlt_factor(function, "LDLT_Factor of covariance parameter",
                     ldlt_Sigma);
+
+  size_t number_of_y = length_mvt(y);
+  size_t number_of_mu = length_mvt(mu);
+  if (number_of_y == 0 || number_of_mu == 0)
+    return 0.0;
+  if (number_of_y > 1 && number_of_mu > 1)
+    check_size_match(function, "Number of vectors of the random variable",
+                     number_of_y, "Number of vectors of the mean",
+                     number_of_mu);
 
   vector_seq_view<T_y> y_vec(y);
   vector_seq_view<T_loc> mu_vec(mu);

--- a/stan/math/prim/mat/prob/multi_normal_lpdf.hpp
+++ b/stan/math/prim/mat/prob/multi_normal_lpdf.hpp
@@ -1,6 +1,7 @@
 #ifndef STAN_MATH_PRIM_MAT_PROB_MULTI_NORMAL_LPDF_HPP
 #define STAN_MATH_PRIM_MAT_PROB_MULTI_NORMAL_LPDF_HPP
 
+#include <stan/math/prim/mat/err/check_consistent_sizes_mvt.hpp>
 #include <stan/math/prim/mat/err/check_ldlt_factor.hpp>
 #include <stan/math/prim/mat/err/check_symmetric.hpp>
 #include <stan/math/prim/mat/fun/trace_inv_quad_form_ldlt.hpp>
@@ -17,7 +18,6 @@
 #include <stan/math/prim/scal/meta/include_summand.hpp>
 #include <boost/random/normal_distribution.hpp>
 #include <boost/random/variate_generator.hpp>
-#include <type_traits>
 
 namespace stan {
 namespace math {
@@ -43,14 +43,7 @@ typename return_type<T_y, T_loc, T_covar>::type multi_normal_lpdf(
   size_t number_of_mu = length_mvt(mu);
   if (number_of_y == 0 || number_of_mu == 0)
     return 0.0;
-  bool y_contains_vectors
-      = is_vector<typename std::remove_reference<decltype(y[0])>::type>::value;
-  bool mu_contains_vectors
-      = is_vector<typename std::remove_reference<decltype(mu[0])>::type>::value;
-  if (y_contains_vectors && mu_contains_vectors)
-    check_size_match(function, "Number of vectors of the random variable",
-                     number_of_y, "Number of vectors of the mean",
-                     number_of_mu);
+  check_consistent_sizes_mvt(function, "y", y, "mu", mu);
 
   vector_seq_view<T_y> y_vec(y);
   vector_seq_view<T_loc> mu_vec(mu);

--- a/stan/math/prim/mat/prob/multi_normal_lpdf.hpp
+++ b/stan/math/prim/mat/prob/multi_normal_lpdf.hpp
@@ -17,6 +17,7 @@
 #include <stan/math/prim/scal/meta/include_summand.hpp>
 #include <boost/random/normal_distribution.hpp>
 #include <boost/random/variate_generator.hpp>
+#include <type_traits>
 
 namespace stan {
 namespace math {
@@ -42,7 +43,11 @@ typename return_type<T_y, T_loc, T_covar>::type multi_normal_lpdf(
   size_t number_of_mu = length_mvt(mu);
   if (number_of_y == 0 || number_of_mu == 0)
     return 0.0;
-  if (number_of_y > 1 && number_of_mu > 1)
+  bool y_contains_vectors
+      = is_vector<typename std::remove_reference<decltype(y[0])>::type>::value;
+  bool mu_contains_vectors
+      = is_vector<typename std::remove_reference<decltype(mu[0])>::type>::value;
+  if (y_contains_vectors && mu_contains_vectors)
     check_size_match(function, "Number of vectors of the random variable",
                      number_of_y, "Number of vectors of the mean",
                      number_of_mu);

--- a/stan/math/prim/mat/prob/multi_normal_prec_lpdf.hpp
+++ b/stan/math/prim/mat/prob/multi_normal_prec_lpdf.hpp
@@ -26,6 +26,7 @@
 #include <stan/math/prim/scal/meta/max_size_mvt.hpp>
 #include <stan/math/prim/scal/meta/include_summand.hpp>
 #include <stan/math/prim/scal/meta/return_type.hpp>
+#include <type_traits>
 
 namespace stan {
 namespace math {
@@ -51,7 +52,11 @@ typename return_type<T_y, T_loc, T_covar>::type multi_normal_prec_lpdf(
   size_t number_of_mu = length_mvt(mu);
   if (number_of_y == 0 || number_of_mu == 0)
     return 0.0;
-  if (number_of_y > 1 && number_of_mu > 1)
+  bool y_contains_vectors
+      = is_vector<typename std::remove_reference<decltype(y[0])>::type>::value;
+  bool mu_contains_vectors
+      = is_vector<typename std::remove_reference<decltype(mu[0])>::type>::value;
+  if (y_contains_vectors && mu_contains_vectors)
     check_size_match(function, "Number of vectors of the random variable",
                      number_of_y, "Number of vectors of the mean",
                      number_of_mu);

--- a/stan/math/prim/mat/prob/multi_normal_prec_lpdf.hpp
+++ b/stan/math/prim/mat/prob/multi_normal_prec_lpdf.hpp
@@ -22,6 +22,7 @@
 #include <stan/math/prim/scal/err/check_not_nan.hpp>
 #include <stan/math/prim/scal/err/check_positive.hpp>
 #include <stan/math/prim/scal/fun/constants.hpp>
+#include <stan/math/prim/scal/meta/length_mvt.hpp>
 #include <stan/math/prim/scal/meta/max_size_mvt.hpp>
 #include <stan/math/prim/scal/meta/include_summand.hpp>
 #include <stan/math/prim/scal/meta/return_type.hpp>
@@ -45,6 +46,16 @@ typename return_type<T_y, T_loc, T_covar>::type multi_normal_prec_lpdf(
 
   using Eigen::Matrix;
   using std::vector;
+
+  size_t number_of_y = length_mvt(y);
+  size_t number_of_mu = length_mvt(mu);
+  if (number_of_y == 0 || number_of_mu == 0)
+    return 0.0;
+  if (number_of_y > 1 && number_of_mu > 1)
+    check_size_match(function, "Number of vectors of the random variable",
+                     number_of_y, "Number of vectors of the mean",
+                     number_of_mu);
+
   vector_seq_view<T_y> y_vec(y);
   vector_seq_view<T_loc> mu_vec(mu);
   size_t size_vec = max_size_mvt(y, mu);

--- a/stan/math/prim/mat/prob/multi_normal_prec_lpdf.hpp
+++ b/stan/math/prim/mat/prob/multi_normal_prec_lpdf.hpp
@@ -1,6 +1,7 @@
 #ifndef STAN_MATH_PRIM_MAT_PROB_MULTI_NORMAL_PREC_LPDF_HPP
 #define STAN_MATH_PRIM_MAT_PROB_MULTI_NORMAL_PREC_LPDF_HPP
 
+#include <stan/math/prim/mat/err/check_consistent_sizes_mvt.hpp>
 #include <stan/math/prim/mat/err/check_ldlt_factor.hpp>
 #include <stan/math/prim/mat/err/check_symmetric.hpp>
 #include <stan/math/prim/mat/fun/columns_dot_product.hpp>
@@ -26,7 +27,6 @@
 #include <stan/math/prim/scal/meta/max_size_mvt.hpp>
 #include <stan/math/prim/scal/meta/include_summand.hpp>
 #include <stan/math/prim/scal/meta/return_type.hpp>
-#include <type_traits>
 
 namespace stan {
 namespace math {
@@ -52,14 +52,7 @@ typename return_type<T_y, T_loc, T_covar>::type multi_normal_prec_lpdf(
   size_t number_of_mu = length_mvt(mu);
   if (number_of_y == 0 || number_of_mu == 0)
     return 0.0;
-  bool y_contains_vectors
-      = is_vector<typename std::remove_reference<decltype(y[0])>::type>::value;
-  bool mu_contains_vectors
-      = is_vector<typename std::remove_reference<decltype(mu[0])>::type>::value;
-  if (y_contains_vectors && mu_contains_vectors)
-    check_size_match(function, "Number of vectors of the random variable",
-                     number_of_y, "Number of vectors of the mean",
-                     number_of_mu);
+  check_consistent_sizes_mvt(function, "y", y, "mu", mu);
 
   vector_seq_view<T_y> y_vec(y);
   vector_seq_view<T_loc> mu_vec(mu);

--- a/stan/math/prim/mat/prob/multi_student_t_lpdf.hpp
+++ b/stan/math/prim/mat/prob/multi_student_t_lpdf.hpp
@@ -16,6 +16,7 @@
 #include <stan/math/prim/scal/fun/is_inf.hpp>
 #include <stan/math/prim/scal/fun/log1p.hpp>
 #include <stan/math/prim/scal/fun/lgamma.hpp>
+#include <stan/math/prim/scal/meta/length_mvt.hpp>
 #include <stan/math/prim/scal/meta/include_summand.hpp>
 #include <boost/math/special_functions/gamma.hpp>
 #include <boost/random/variate_generator.hpp>
@@ -51,6 +52,16 @@ typename return_type<T_y, T_dof, T_loc, T_scale>::type multi_student_t_lpdf(
 
   using Eigen::Matrix;
   using std::vector;
+
+  size_t number_of_y = length_mvt(y);
+  size_t number_of_mu = length_mvt(mu);
+  if (number_of_y == 0 || number_of_mu == 0)
+    return 0.0;
+  if (number_of_y > 1 && number_of_mu > 1)
+    check_size_match(function, "Number of vectors of the random variable",
+                     number_of_y, "Number of vectors of the mean",
+                     number_of_mu);
+
   vector_seq_view<T_y> y_vec(y);
   vector_seq_view<T_loc> mu_vec(mu);
   size_t size_vec = max_size_mvt(y, mu);

--- a/stan/math/prim/mat/prob/multi_student_t_lpdf.hpp
+++ b/stan/math/prim/mat/prob/multi_student_t_lpdf.hpp
@@ -22,6 +22,7 @@
 #include <boost/random/variate_generator.hpp>
 #include <cmath>
 #include <cstdlib>
+#include <type_traits>
 
 namespace stan {
 namespace math {
@@ -57,7 +58,11 @@ typename return_type<T_y, T_dof, T_loc, T_scale>::type multi_student_t_lpdf(
   size_t number_of_mu = length_mvt(mu);
   if (number_of_y == 0 || number_of_mu == 0)
     return 0.0;
-  if (number_of_y > 1 && number_of_mu > 1)
+  bool y_contains_vectors
+      = is_vector<typename std::remove_reference<decltype(y[0])>::type>::value;
+  bool mu_contains_vectors
+      = is_vector<typename std::remove_reference<decltype(mu[0])>::type>::value;
+  if (y_contains_vectors && mu_contains_vectors)
     check_size_match(function, "Number of vectors of the random variable",
                      number_of_y, "Number of vectors of the mean",
                      number_of_mu);

--- a/stan/math/prim/mat/prob/multi_student_t_lpdf.hpp
+++ b/stan/math/prim/mat/prob/multi_student_t_lpdf.hpp
@@ -1,6 +1,7 @@
 #ifndef STAN_MATH_PRIM_MAT_PROB_MULTI_STUDENT_T_LPDF_HPP
 #define STAN_MATH_PRIM_MAT_PROB_MULTI_STUDENT_T_LPDF_HPP
 
+#include <stan/math/prim/mat/err/check_consistent_sizes_mvt.hpp>
 #include <stan/math/prim/mat/err/check_ldlt_factor.hpp>
 #include <stan/math/prim/mat/err/check_symmetric.hpp>
 #include <stan/math/prim/mat/fun/multiply.hpp>
@@ -22,7 +23,6 @@
 #include <boost/random/variate_generator.hpp>
 #include <cmath>
 #include <cstdlib>
-#include <type_traits>
 
 namespace stan {
 namespace math {
@@ -58,14 +58,7 @@ typename return_type<T_y, T_dof, T_loc, T_scale>::type multi_student_t_lpdf(
   size_t number_of_mu = length_mvt(mu);
   if (number_of_y == 0 || number_of_mu == 0)
     return 0.0;
-  bool y_contains_vectors
-      = is_vector<typename std::remove_reference<decltype(y[0])>::type>::value;
-  bool mu_contains_vectors
-      = is_vector<typename std::remove_reference<decltype(mu[0])>::type>::value;
-  if (y_contains_vectors && mu_contains_vectors)
-    check_size_match(function, "Number of vectors of the random variable",
-                     number_of_y, "Number of vectors of the mean",
-                     number_of_mu);
+  check_consistent_sizes_mvt(function, "y", y, "mu", mu);
 
   vector_seq_view<T_y> y_vec(y);
   vector_seq_view<T_loc> mu_vec(mu);

--- a/test/unit/math/prim/mat/err/check_consistent_size_mvt_test.cpp
+++ b/test/unit/math/prim/mat/err/check_consistent_size_mvt_test.cpp
@@ -1,0 +1,36 @@
+#include <stan/math/prim/mat.hpp>
+#include <gtest/gtest.h>
+#include <test/unit/util.hpp>
+#include <vector>
+
+TEST(checkConsistentSizeMvt, checkConsistentSizeMvt) {
+  using stan::math::check_consistent_size_mvt;
+
+  size_t expected_size = 3;
+
+  std::vector<Eigen::VectorXd> good(3);
+  Eigen::VectorXd good_single(4);
+  good_single << 1.0, 2.0, 3.0, 4.0;
+  good[0] = good_single;
+  good[1] = good_single;
+  good[2] = good_single;
+  std::vector<Eigen::VectorXd> bad_only_2(2);
+  bad_only_2[0] = good_single;
+  bad_only_2[1] = good_single;
+  std::vector<Eigen::VectorXd> bad_only_1(1);
+  bad_only_1[0] = good_single;
+
+  static const char* function
+      = "TESTcheckConsistentSizeMvtcheckConsistentSizeMvt";
+
+  EXPECT_NO_THROW(
+      check_consistent_size_mvt(function, "good", good, expected_size));
+  EXPECT_NO_THROW(check_consistent_size_mvt(function, "good_single",
+                                            good_single, expected_size));
+  EXPECT_THROW(check_consistent_size_mvt(function, "bad_only_2", bad_only_2,
+                                         expected_size),
+               std::invalid_argument);
+  EXPECT_THROW(check_consistent_size_mvt(function, "bad_only_1", bad_only_1,
+                                         expected_size),
+               std::invalid_argument);
+}

--- a/test/unit/math/prim/mat/err/check_consistent_size_mvt_test.cpp
+++ b/test/unit/math/prim/mat/err/check_consistent_size_mvt_test.cpp
@@ -19,6 +19,7 @@ TEST(checkConsistentSizeMvt, checkConsistentSizeMvt) {
   bad_only_2[1] = good_single;
   std::vector<Eigen::VectorXd> bad_only_1(1);
   bad_only_1[0] = good_single;
+  std::vector<Eigen::VectorXd> empty;
 
   static const char* function
       = "TESTcheckConsistentSizeMvtcheckConsistentSizeMvt";
@@ -27,10 +28,14 @@ TEST(checkConsistentSizeMvt, checkConsistentSizeMvt) {
       check_consistent_size_mvt(function, "good", good, expected_size));
   EXPECT_NO_THROW(check_consistent_size_mvt(function, "good_single",
                                             good_single, expected_size));
+  EXPECT_NO_THROW(check_consistent_size_mvt(function, "empty", empty, 0));
   EXPECT_THROW(check_consistent_size_mvt(function, "bad_only_2", bad_only_2,
                                          expected_size),
                std::invalid_argument);
   EXPECT_THROW(check_consistent_size_mvt(function, "bad_only_1", bad_only_1,
                                          expected_size),
                std::invalid_argument);
+  EXPECT_THROW(
+      check_consistent_size_mvt(function, "empty", empty, expected_size),
+      std::invalid_argument);
 }

--- a/test/unit/math/prim/mat/err/check_consistent_sizes_mvt_test.cpp
+++ b/test/unit/math/prim/mat/err/check_consistent_sizes_mvt_test.cpp
@@ -1,0 +1,49 @@
+#include <stan/math/prim/mat.hpp>
+#include <gtest/gtest.h>
+#include <test/unit/util.hpp>
+#include <vector>
+
+TEST(checkConsistentSizesMvt, checkConsistentSizesMvt) {
+  using stan::math::check_consistent_sizes_mvt;
+
+  size_t expected_size = 3;
+
+  std::vector<Eigen::VectorXd> good(3);
+  Eigen::VectorXd good_single(4);
+  good_single << 1.0, 2.0, 3.0, 4.0;
+  good[0] = good_single;
+  good[1] = good_single;
+  good[2] = good_single;
+  std::vector<Eigen::VectorXd> bad_only_2(2);
+  bad_only_2[0] = good_single;
+  bad_only_2[1] = good_single;
+  std::vector<Eigen::VectorXd> bad_only_1(1);
+  bad_only_1[0] = good_single;
+
+  static const char* function
+      = "TESTcheckConsistentSizesMvtcheckConsistentSizesMvt";
+
+  EXPECT_NO_THROW(check_consistent_sizes_mvt(function, "x1", good, "x2", good));
+  EXPECT_NO_THROW(
+      check_consistent_sizes_mvt(function, "x1", good, "x2", good_single));
+  EXPECT_NO_THROW(
+      check_consistent_sizes_mvt(function, "x1", good_single, "x2", good));
+  EXPECT_NO_THROW(check_consistent_sizes_mvt(function, "x1", good_single, "x2",
+                                             good_single));
+  EXPECT_NO_THROW(check_consistent_sizes_mvt(function, "x1", good_single, "x2",
+                                             bad_only_1));
+  EXPECT_NO_THROW(check_consistent_sizes_mvt(function, "x1", good_single, "x2",
+                                             bad_only_2));
+  EXPECT_THROW(
+      check_consistent_sizes_mvt(function, "x1", good, "x2", bad_only_2),
+      std::invalid_argument);
+  EXPECT_THROW(
+      check_consistent_sizes_mvt(function, "x1", good, "x2", bad_only_1),
+      std::invalid_argument);
+  EXPECT_THROW(
+      check_consistent_sizes_mvt(function, "x1", bad_only_2, "x2", good),
+      std::invalid_argument);
+  EXPECT_THROW(
+      check_consistent_sizes_mvt(function, "x1", bad_only_1, "x2", good),
+      std::invalid_argument);
+}

--- a/test/unit/math/prim/mat/prob/multi_normal_cholesky_test.cpp
+++ b/test/unit/math/prim/mat/prob/multi_normal_cholesky_test.cpp
@@ -245,32 +245,50 @@ TEST(ProbDistributionsMultiNormalCholesky,
 }
 
 TEST(ProbDistributionsMultiNormalCholesky, WrongSize) {
-  vector<Matrix<double, Dynamic, 1> > vec_y_2(2);
-  vector<Matrix<double, Dynamic, 1> > vec_y_3(3);
-  Matrix<double, Dynamic, 1> y(3);
-  y << 2.0, -2.0, 11.0;
-  vec_y_2[0] = y;
-  vec_y_3[0] = y;
-  y << 4.0, -2.0, 1.0;
-  vec_y_2[1] = y;
-  vec_y_3[1] = y;
-  y << 2.0, -1.0, 1.0;
-  vec_y_3[2] = y;
+  vector<Matrix<double, Dynamic, 1> > y_3_3(3);
+  vector<Matrix<double, Dynamic, 1> > y_3_1(3);
+  vector<Matrix<double, Dynamic, 1> > y_3_2(3);
+  vector<Matrix<double, Dynamic, 1> > y_1_3(1);
+  vector<Matrix<double, Dynamic, 1> > y_2_3(2);
+  Matrix<double, Dynamic, 1> y_3(3);
+  Matrix<double, Dynamic, 1> y_2(2);
+  Matrix<double, Dynamic, 1> y_1(1);
+  y_3 << 2.0, -2.0, 11.0;
+  y_2 << 2.0, -2.0;
+  y_1 << 2.0;
+  y_3_3[0] = y_3;
+  y_3_3[1] = y_3;
+  y_3_3[2] = y_3;
+  y_3_1[0] = y_1;
+  y_3_1[1] = y_1;
+  y_3_1[2] = y_1;
+  y_3_2[0] = y_2;
+  y_3_2[1] = y_2;
+  y_3_2[2] = y_2;
+  y_1_3[0] = y_3;
+  y_2_3[0] = y_3;
+  y_2_3[1] = y_3;
 
-  vector<Matrix<double, Dynamic, 1> > vec_mu(3);
-  Matrix<double, Dynamic, 1> mu(3);
-  mu << 1.0, -1.0, 3.0;
-  vec_mu[0] = mu;
-  mu << 2.0, -1.0, 4.0;
-  vec_mu[1] = mu;
-  mu << 3.0, -2.0, 1.0;
-  vec_mu[2] = mu;
+  vector<Matrix<double, Dynamic, 1> > mu_3_3(3);
+  Matrix<double, Dynamic, 1> mu_3(3);
+  mu_3 << 2.0, -2.0, 11.0;
+  mu_3_3[0] = mu_3;
+  mu_3_3[1] = mu_3;
+  mu_3_3[2] = mu_3;
 
   Matrix<double, Dynamic, Dynamic> Sigma(3, 3);
   Sigma << 10.0, -3.0, 0.0, -3.0, 5.0, 0.0, 0.0, 0.0, 5.0;
   Matrix<double, Dynamic, Dynamic> L = Sigma.llt().matrixL();
 
-  EXPECT_NO_THROW(stan::math::multi_normal_cholesky_lpdf(vec_y_3, vec_mu, L));
-  EXPECT_THROW(stan::math::multi_normal_cholesky_lpdf(vec_y_2, vec_mu, L),
+  EXPECT_NO_THROW(stan::math::multi_normal_cholesky_lpdf(y_3_3, mu_3_3, L));
+  EXPECT_NO_THROW(stan::math::multi_normal_cholesky_lpdf(y_3, mu_3_3, L));
+
+  EXPECT_THROW(stan::math::multi_normal_cholesky_lpdf(y_1_3, mu_3_3, L),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::multi_normal_cholesky_lpdf(y_2_3, mu_3_3, L),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::multi_normal_cholesky_lpdf(y_3_1, mu_3_3, L),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::multi_normal_cholesky_lpdf(y_3_2, mu_3_3, L),
                std::invalid_argument);
 }

--- a/test/unit/math/prim/mat/prob/multi_normal_cholesky_test.cpp
+++ b/test/unit/math/prim/mat/prob/multi_normal_cholesky_test.cpp
@@ -243,3 +243,34 @@ TEST(ProbDistributionsMultiNormalCholesky,
 
   EXPECT_TRUE(chi < quantile(complement(mydist, 1e-6)));
 }
+
+TEST(ProbDistributionsMultiNormalCholesky, WrongSize) {
+  vector<Matrix<double, Dynamic, 1> > vec_y_2(2);
+  vector<Matrix<double, Dynamic, 1> > vec_y_3(3);
+  Matrix<double, Dynamic, 1> y(3);
+  y << 2.0, -2.0, 11.0;
+  vec_y_2[0] = y;
+  vec_y_3[0] = y;
+  y << 4.0, -2.0, 1.0;
+  vec_y_2[1] = y;
+  vec_y_3[1] = y;
+  y << 2.0, -1.0, 1.0;
+  vec_y_3[2] = y;
+
+  vector<Matrix<double, Dynamic, 1> > vec_mu(3);
+  Matrix<double, Dynamic, 1> mu(3);
+  mu << 1.0, -1.0, 3.0;
+  vec_mu[0] = mu;
+  mu << 2.0, -1.0, 4.0;
+  vec_mu[1] = mu;
+  mu << 3.0, -2.0, 1.0;
+  vec_mu[2] = mu;
+
+  Matrix<double, Dynamic, Dynamic> Sigma(3, 3);
+  Sigma << 10.0, -3.0, 0.0, -3.0, 5.0, 0.0, 0.0, 0.0, 5.0;
+  Matrix<double, Dynamic, Dynamic> L = Sigma.llt().matrixL();
+
+  EXPECT_NO_THROW(stan::math::multi_normal_cholesky_lpdf(vec_y_3, vec_mu, L));
+  EXPECT_THROW(stan::math::multi_normal_cholesky_lpdf(vec_y_2, vec_mu, L),
+               std::invalid_argument);
+}

--- a/test/unit/math/prim/mat/prob/multi_normal_prec_test.cpp
+++ b/test/unit/math/prim/mat/prob/multi_normal_prec_test.cpp
@@ -104,3 +104,33 @@ TEST(ProbDistributionsMultiNormalPrec, MultiNormalMultiRow) {
   EXPECT_FLOAT_EQ(-54.2152, stan::math::multi_normal_prec_log(y, mu, L));
 }
 */
+
+TEST(ProbDistributionsMultiNormalPrec, WrongSize) {
+  vector<Matrix<double, Dynamic, 1> > vec_y_2(2);
+  vector<Matrix<double, Dynamic, 1> > vec_y_3(3);
+  Matrix<double, Dynamic, 1> y(3);
+  y << 2.0, -2.0, 11.0;
+  vec_y_2[0] = y;
+  vec_y_3[0] = y;
+  y << 4.0, -2.0, 1.0;
+  vec_y_2[1] = y;
+  vec_y_3[1] = y;
+  y << 2.0, -1.0, 1.0;
+  vec_y_3[2] = y;
+
+  vector<Matrix<double, Dynamic, 1> > vec_mu(3);
+  Matrix<double, Dynamic, 1> mu(3);
+  mu << 1.0, -1.0, 3.0;
+  vec_mu[0] = mu;
+  mu << 2.0, -1.0, 4.0;
+  vec_mu[1] = mu;
+  mu << 3.0, -2.0, 1.0;
+  vec_mu[2] = mu;
+
+  Matrix<double, Dynamic, Dynamic> Sigma(3, 3);
+  Sigma << 10.0, -3.0, 0.0, -3.0, 5.0, 0.0, 0.0, 0.0, 5.0;
+
+  EXPECT_NO_THROW(stan::math::multi_normal_prec_lpdf(vec_y_3, vec_mu, Sigma));
+  EXPECT_THROW(stan::math::multi_normal_prec_lpdf(vec_y_2, vec_mu, Sigma),
+               std::invalid_argument);
+}

--- a/test/unit/math/prim/mat/prob/multi_normal_prec_test.cpp
+++ b/test/unit/math/prim/mat/prob/multi_normal_prec_test.cpp
@@ -106,31 +106,50 @@ TEST(ProbDistributionsMultiNormalPrec, MultiNormalMultiRow) {
 */
 
 TEST(ProbDistributionsMultiNormalPrec, WrongSize) {
-  vector<Matrix<double, Dynamic, 1> > vec_y_2(2);
-  vector<Matrix<double, Dynamic, 1> > vec_y_3(3);
-  Matrix<double, Dynamic, 1> y(3);
-  y << 2.0, -2.0, 11.0;
-  vec_y_2[0] = y;
-  vec_y_3[0] = y;
-  y << 4.0, -2.0, 1.0;
-  vec_y_2[1] = y;
-  vec_y_3[1] = y;
-  y << 2.0, -1.0, 1.0;
-  vec_y_3[2] = y;
+  vector<Matrix<double, Dynamic, 1> > y_3_3(3);
+  vector<Matrix<double, Dynamic, 1> > y_3_1(3);
+  vector<Matrix<double, Dynamic, 1> > y_3_2(3);
+  vector<Matrix<double, Dynamic, 1> > y_1_3(1);
+  vector<Matrix<double, Dynamic, 1> > y_2_3(2);
+  Matrix<double, Dynamic, 1> y_3(3);
+  Matrix<double, Dynamic, 1> y_2(2);
+  Matrix<double, Dynamic, 1> y_1(1);
+  y_3 << 2.0, -2.0, 11.0;
+  y_2 << 2.0, -2.0;
+  y_1 << 2.0;
+  y_3_3[0] = y_3;
+  y_3_3[1] = y_3;
+  y_3_3[2] = y_3;
+  y_3_1[0] = y_1;
+  y_3_1[1] = y_1;
+  y_3_1[2] = y_1;
+  y_3_2[0] = y_2;
+  y_3_2[1] = y_2;
+  y_3_2[2] = y_2;
+  y_1_3[0] = y_3;
+  y_2_3[0] = y_3;
+  y_2_3[1] = y_3;
 
-  vector<Matrix<double, Dynamic, 1> > vec_mu(3);
-  Matrix<double, Dynamic, 1> mu(3);
-  mu << 1.0, -1.0, 3.0;
-  vec_mu[0] = mu;
-  mu << 2.0, -1.0, 4.0;
-  vec_mu[1] = mu;
-  mu << 3.0, -2.0, 1.0;
-  vec_mu[2] = mu;
+  vector<Matrix<double, Dynamic, 1> > mu_3_3(3);
+  Matrix<double, Dynamic, 1> mu_3(3);
+  mu_3 << 2.0, -2.0, 11.0;
+  mu_3_3[0] = mu_3;
+  mu_3_3[1] = mu_3;
+  mu_3_3[2] = mu_3;
 
   Matrix<double, Dynamic, Dynamic> Sigma(3, 3);
   Sigma << 10.0, -3.0, 0.0, -3.0, 5.0, 0.0, 0.0, 0.0, 5.0;
+  Sigma = Sigma.inverse();
 
-  EXPECT_NO_THROW(stan::math::multi_normal_prec_lpdf(vec_y_3, vec_mu, Sigma));
-  EXPECT_THROW(stan::math::multi_normal_prec_lpdf(vec_y_2, vec_mu, Sigma),
+  EXPECT_NO_THROW(stan::math::multi_normal_prec_lpdf(y_3_3, mu_3_3, Sigma));
+  EXPECT_NO_THROW(stan::math::multi_normal_prec_lpdf(y_3, mu_3_3, Sigma));
+
+  EXPECT_THROW(stan::math::multi_normal_prec_lpdf(y_1_3, mu_3_3, Sigma),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::multi_normal_prec_lpdf(y_2_3, mu_3_3, Sigma),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::multi_normal_prec_lpdf(y_3_1, mu_3_3, Sigma),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::multi_normal_prec_lpdf(y_3_2, mu_3_3, Sigma),
                std::invalid_argument);
 }

--- a/test/unit/math/prim/mat/prob/multi_normal_test.cpp
+++ b/test/unit/math/prim/mat/prob/multi_normal_test.cpp
@@ -324,3 +324,33 @@ TEST(multiNormalRng, nonPosDefErrorTest) {
   boost::random::mt19937 rng;
   EXPECT_THROW(multi_normal_rng(mu, S, rng), std::domain_error);
 }
+
+TEST(ProbDistributionsMultiNormal, WrongSize) {
+  vector<Matrix<double, Dynamic, 1> > vec_y_2(2);
+  vector<Matrix<double, Dynamic, 1> > vec_y_3(3);
+  Matrix<double, Dynamic, 1> y(3);
+  y << 2.0, -2.0, 11.0;
+  vec_y_2[0] = y;
+  vec_y_3[0] = y;
+  y << 4.0, -2.0, 1.0;
+  vec_y_2[1] = y;
+  vec_y_3[1] = y;
+  y << 2.0, -1.0, 1.0;
+  vec_y_3[2] = y;
+
+  vector<Matrix<double, Dynamic, 1> > vec_mu(3);
+  Matrix<double, Dynamic, 1> mu(3);
+  mu << 1.0, -1.0, 3.0;
+  vec_mu[0] = mu;
+  mu << 2.0, -1.0, 4.0;
+  vec_mu[1] = mu;
+  mu << 3.0, -2.0, 1.0;
+  vec_mu[2] = mu;
+
+  Matrix<double, Dynamic, Dynamic> Sigma(3, 3);
+  Sigma << 10.0, -3.0, 0.0, -3.0, 5.0, 0.0, 0.0, 0.0, 5.0;
+
+  EXPECT_NO_THROW(stan::math::multi_normal_log(vec_y_3, vec_mu, Sigma));
+  EXPECT_THROW(stan::math::multi_normal_log(vec_y_2, vec_mu, Sigma),
+               std::invalid_argument);
+}

--- a/test/unit/math/prim/mat/prob/multi_normal_test.cpp
+++ b/test/unit/math/prim/mat/prob/multi_normal_test.cpp
@@ -326,31 +326,49 @@ TEST(multiNormalRng, nonPosDefErrorTest) {
 }
 
 TEST(ProbDistributionsMultiNormal, WrongSize) {
-  vector<Matrix<double, Dynamic, 1> > vec_y_2(2);
-  vector<Matrix<double, Dynamic, 1> > vec_y_3(3);
-  Matrix<double, Dynamic, 1> y(3);
-  y << 2.0, -2.0, 11.0;
-  vec_y_2[0] = y;
-  vec_y_3[0] = y;
-  y << 4.0, -2.0, 1.0;
-  vec_y_2[1] = y;
-  vec_y_3[1] = y;
-  y << 2.0, -1.0, 1.0;
-  vec_y_3[2] = y;
+  vector<Matrix<double, Dynamic, 1> > y_3_3(3);
+  vector<Matrix<double, Dynamic, 1> > y_3_1(3);
+  vector<Matrix<double, Dynamic, 1> > y_3_2(3);
+  vector<Matrix<double, Dynamic, 1> > y_1_3(1);
+  vector<Matrix<double, Dynamic, 1> > y_2_3(2);
+  Matrix<double, Dynamic, 1> y_3(3);
+  Matrix<double, Dynamic, 1> y_2(2);
+  Matrix<double, Dynamic, 1> y_1(1);
+  y_3 << 2.0, -2.0, 11.0;
+  y_2 << 2.0, -2.0;
+  y_1 << 2.0;
+  y_3_3[0] = y_3;
+  y_3_3[1] = y_3;
+  y_3_3[2] = y_3;
+  y_3_1[0] = y_1;
+  y_3_1[1] = y_1;
+  y_3_1[2] = y_1;
+  y_3_2[0] = y_2;
+  y_3_2[1] = y_2;
+  y_3_2[2] = y_2;
+  y_1_3[0] = y_3;
+  y_2_3[0] = y_3;
+  y_2_3[1] = y_3;
 
-  vector<Matrix<double, Dynamic, 1> > vec_mu(3);
-  Matrix<double, Dynamic, 1> mu(3);
-  mu << 1.0, -1.0, 3.0;
-  vec_mu[0] = mu;
-  mu << 2.0, -1.0, 4.0;
-  vec_mu[1] = mu;
-  mu << 3.0, -2.0, 1.0;
-  vec_mu[2] = mu;
+  vector<Matrix<double, Dynamic, 1> > mu_3_3(3);
+  Matrix<double, Dynamic, 1> mu_3(3);
+  mu_3 << 2.0, -2.0, 11.0;
+  mu_3_3[0] = mu_3;
+  mu_3_3[1] = mu_3;
+  mu_3_3[2] = mu_3;
 
   Matrix<double, Dynamic, Dynamic> Sigma(3, 3);
   Sigma << 10.0, -3.0, 0.0, -3.0, 5.0, 0.0, 0.0, 0.0, 5.0;
 
-  EXPECT_NO_THROW(stan::math::multi_normal_log(vec_y_3, vec_mu, Sigma));
-  EXPECT_THROW(stan::math::multi_normal_log(vec_y_2, vec_mu, Sigma),
+  EXPECT_NO_THROW(stan::math::multi_normal_lpdf(y_3_3, mu_3_3, Sigma));
+  EXPECT_NO_THROW(stan::math::multi_normal_lpdf(y_3, mu_3_3, Sigma));
+
+  EXPECT_THROW(stan::math::multi_normal_lpdf(y_1_3, mu_3_3, Sigma),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::multi_normal_lpdf(y_2_3, mu_3_3, Sigma),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::multi_normal_lpdf(y_3_1, mu_3_3, Sigma),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::multi_normal_lpdf(y_3_2, mu_3_3, Sigma),
                std::invalid_argument);
 }

--- a/test/unit/math/prim/mat/prob/multi_student_t_test.cpp
+++ b/test/unit/math/prim/mat/prob/multi_student_t_test.cpp
@@ -320,3 +320,35 @@ TEST(ProbDistributionsMultiStudentT, marginalTwoChiSquareGoodnessFitTest) {
 
   EXPECT_TRUE(chi < quantile(complement(mydist, 1e-6)));
 }
+
+TEST(ProbDistributionsMultiStudentT, WrongSize) {
+  vector<Matrix<double, Dynamic, 1> > vec_y_2(2);
+  vector<Matrix<double, Dynamic, 1> > vec_y_3(3);
+  Matrix<double, Dynamic, 1> y(3);
+  y << 2.0, -2.0, 11.0;
+  vec_y_2[0] = y;
+  vec_y_3[0] = y;
+  y << 4.0, -2.0, 1.0;
+  vec_y_2[1] = y;
+  vec_y_3[1] = y;
+  y << 2.0, -1.0, 1.0;
+  vec_y_3[2] = y;
+
+  vector<Matrix<double, Dynamic, 1> > vec_mu(3);
+  Matrix<double, Dynamic, 1> mu(3);
+  mu << 1.0, -1.0, 3.0;
+  vec_mu[0] = mu;
+  mu << 2.0, -1.0, 4.0;
+  vec_mu[1] = mu;
+  mu << 3.0, -2.0, 1.0;
+  vec_mu[2] = mu;
+
+  Matrix<double, Dynamic, Dynamic> Sigma(3, 3);
+  Sigma << 10.0, -3.0, 0.0, -3.0, 5.0, 0.0, 0.0, 0.0, 5.0;
+
+  double nu = 4.0;
+
+  EXPECT_NO_THROW(stan::math::multi_student_t_log(vec_y_3, nu, vec_mu, Sigma));
+  EXPECT_THROW(stan::math::multi_student_t_log(vec_y_2, nu, vec_mu, Sigma),
+               std::invalid_argument);
+}

--- a/test/unit/math/prim/mat/prob/multi_student_t_test.cpp
+++ b/test/unit/math/prim/mat/prob/multi_student_t_test.cpp
@@ -322,33 +322,51 @@ TEST(ProbDistributionsMultiStudentT, marginalTwoChiSquareGoodnessFitTest) {
 }
 
 TEST(ProbDistributionsMultiStudentT, WrongSize) {
-  vector<Matrix<double, Dynamic, 1> > vec_y_2(2);
-  vector<Matrix<double, Dynamic, 1> > vec_y_3(3);
-  Matrix<double, Dynamic, 1> y(3);
-  y << 2.0, -2.0, 11.0;
-  vec_y_2[0] = y;
-  vec_y_3[0] = y;
-  y << 4.0, -2.0, 1.0;
-  vec_y_2[1] = y;
-  vec_y_3[1] = y;
-  y << 2.0, -1.0, 1.0;
-  vec_y_3[2] = y;
+  vector<Matrix<double, Dynamic, 1> > y_3_3(3);
+  vector<Matrix<double, Dynamic, 1> > y_3_1(3);
+  vector<Matrix<double, Dynamic, 1> > y_3_2(3);
+  vector<Matrix<double, Dynamic, 1> > y_1_3(1);
+  vector<Matrix<double, Dynamic, 1> > y_2_3(2);
+  Matrix<double, Dynamic, 1> y_3(3);
+  Matrix<double, Dynamic, 1> y_2(2);
+  Matrix<double, Dynamic, 1> y_1(1);
+  y_3 << 2.0, -2.0, 11.0;
+  y_2 << 2.0, -2.0;
+  y_1 << 2.0;
+  y_3_3[0] = y_3;
+  y_3_3[1] = y_3;
+  y_3_3[2] = y_3;
+  y_3_1[0] = y_1;
+  y_3_1[1] = y_1;
+  y_3_1[2] = y_1;
+  y_3_2[0] = y_2;
+  y_3_2[1] = y_2;
+  y_3_2[2] = y_2;
+  y_1_3[0] = y_3;
+  y_2_3[0] = y_3;
+  y_2_3[1] = y_3;
 
-  vector<Matrix<double, Dynamic, 1> > vec_mu(3);
-  Matrix<double, Dynamic, 1> mu(3);
-  mu << 1.0, -1.0, 3.0;
-  vec_mu[0] = mu;
-  mu << 2.0, -1.0, 4.0;
-  vec_mu[1] = mu;
-  mu << 3.0, -2.0, 1.0;
-  vec_mu[2] = mu;
+  vector<Matrix<double, Dynamic, 1> > mu_3_3(3);
+  Matrix<double, Dynamic, 1> mu_3(3);
+  mu_3 << 2.0, -2.0, 11.0;
+  mu_3_3[0] = mu_3;
+  mu_3_3[1] = mu_3;
+  mu_3_3[2] = mu_3;
 
   Matrix<double, Dynamic, Dynamic> Sigma(3, 3);
   Sigma << 10.0, -3.0, 0.0, -3.0, 5.0, 0.0, 0.0, 0.0, 5.0;
 
   double nu = 4.0;
 
-  EXPECT_NO_THROW(stan::math::multi_student_t_log(vec_y_3, nu, vec_mu, Sigma));
-  EXPECT_THROW(stan::math::multi_student_t_log(vec_y_2, nu, vec_mu, Sigma),
+  EXPECT_NO_THROW(stan::math::multi_student_t_lpdf(y_3_3, nu, mu_3_3, Sigma));
+  EXPECT_NO_THROW(stan::math::multi_student_t_lpdf(y_3, nu, mu_3_3, Sigma));
+
+  EXPECT_THROW(stan::math::multi_student_t_lpdf(y_1_3, nu, mu_3_3, Sigma),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::multi_student_t_lpdf(y_2_3, nu, mu_3_3, Sigma),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::multi_student_t_lpdf(y_3_1, nu, mu_3_3, Sigma),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::multi_student_t_lpdf(y_3_2, nu, mu_3_3, Sigma),
                std::invalid_argument);
 }


### PR DESCRIPTION
## Summary

Add tests and fix lpdfs to close #1100.

## Tests

test/unit/math/prim/mat/prob/multi_normal_test.cpp
test/unit/math/prim/mat/prob/multi_normal_cholesky_test.cpp
test/unit/math/prim/mat/prob/multi_normal_prec_test.cpp
test/unit/math/prim/mat/prob/multi_student_t.cpp

## Side Effects

None.

## Checklist

- [X] Math issue #1100
- [X] Copyright holder: Peter Wicks Stringfield
    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
- [X] the basic tests are passing
- [X the code is written in idiomatic C++ and changes are documented in the doxygen
- [X] the new changes are tested
