### PR TITLE
Feature/issue 1036 add quantile method

### DIFF
--- a/stan/math/prim/arr.hpp
+++ b/stan/math/prim/arr.hpp
@@ -28,6 +28,7 @@
 #include <stan/math/prim/arr/fun/promote_elements.hpp>
 #include <stan/math/prim/arr/fun/promote_scalar.hpp>
 #include <stan/math/prim/arr/fun/promote_scalar_type.hpp>
+#include <stan/math/prim/arr/fun/quantile.hpp>
 #include <stan/math/prim/arr/fun/rep_array.hpp>
 #include <stan/math/prim/arr/fun/scaled_add.hpp>
 #include <stan/math/prim/arr/fun/sort_asc.hpp>

--- a/stan/math/prim/arr/fun/quantile.hpp
+++ b/stan/math/prim/arr/fun/quantile.hpp
@@ -1,0 +1,44 @@
+#ifndef STAN_MATH_PRIM_ARR_FUN_QUANTILE_HPP
+#define STAN_MATH_PRIM_ARR_FUN_QUANTILE_HPP
+
+#include <stan/math/prim/scal/err/check_greater_or_equal.hpp>
+#include <stan/math/prim/scal/err/check_less_or_equal.hpp>
+#include <stan/math/prim/arr/fun/sort_asc.hpp>
+#include <cmath>
+#include <vector>
+
+namespace stan {
+namespace math {
+
+/**
+ * Return the the q-th quantile of the specified sequence of values.
+ *
+ * @param[in] x array of specified values
+ * @param[in] p quantile to calculate, which must be between 0 and 1
+ * @return The p-th quantile of the vector values
+ */
+inline double quantile(const std::vector<double>& x, double p) {
+  using std::ceil;
+  using std::floor;
+
+  check_greater_or_equal("quantile", "p", p, 0.0);
+  check_less_or_equal("quantile", "p", p, 1.0);
+
+  std::vector<double> sorted = sort_asc(x);
+
+  double index = p * (sorted.size() - 1);
+  size_t ceiled = static_cast<size_t>(ceil(index));
+  size_t floored = static_cast<size_t>(floor(index));
+
+  if (ceiled == floored) {
+    return sorted[ceiled];
+  }
+
+  return (ceiled - index) * sorted[floored]
+         + (index - floored) * sorted[ceiled];
+}
+
+}  // namespace math
+}  // namespace stan
+
+#endif

--- a/stan/math/prim/mat.hpp
+++ b/stan/math/prim/mat.hpp
@@ -190,6 +190,7 @@
 #include <stan/math/prim/mat/fun/quad_form.hpp>
 #include <stan/math/prim/mat/fun/quad_form_diag.hpp>
 #include <stan/math/prim/mat/fun/quad_form_sym.hpp>
+#include <stan/math/prim/mat/fun/quantile.hpp>
 #include <stan/math/prim/mat/fun/rank.hpp>
 #include <stan/math/prim/mat/fun/read_corr_L.hpp>
 #include <stan/math/prim/mat/fun/read_corr_matrix.hpp>

--- a/stan/math/prim/mat/fun/quantile.hpp
+++ b/stan/math/prim/mat/fun/quantile.hpp
@@ -1,0 +1,45 @@
+#ifndef STAN_MATH_PRIM_MAT_FUN_QUANTILE_HPP
+#define STAN_MATH_PRIM_MAT_FUN_QUANTILE_HPP
+
+#include <stan/math/prim/scal/err/check_greater_or_equal.hpp>
+#include <stan/math/prim/scal/err/check_less_or_equal.hpp>
+#include <stan/math/prim/mat/fun/sort_asc.hpp>
+#include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <cmath>
+
+namespace stan {
+namespace math {
+
+/**
+ * Return the the q-th quantile of the specified sequence of values.
+ *
+ * @param[in] x matrix of specified values
+ * @param[in] p quantile to calculate, which must be between 0 and 1
+ * @return The p-th quantile of the vector values
+ */
+template <int R, int C>
+double quantile(const Eigen::Matrix<double, R, C>& x, double p) {
+  using std::ceil;
+  using std::floor;
+
+  check_greater_or_equal("quantile", "p", p, 0.0);
+  check_less_or_equal("quantile", "p", p, 1.0);
+
+  Eigen::Matrix<double, R, C> sorted = sort_asc(x);
+
+  double index = p * (sorted.size() - 1);
+  size_t ceiled = static_cast<size_t>(ceil(index));
+  size_t floored = static_cast<size_t>(floor(index));
+
+  if (ceiled == floored) {
+    return sorted(ceiled);
+  }
+
+  return (ceiled - index) * sorted(floored)
+         + (index - floored) * sorted(ceiled);
+}
+
+}  // namespace math
+}  // namespace stan
+
+#endif

--- a/stan/math/prim/scal/err/check_not_nan.hpp
+++ b/stan/math/prim/scal/err/check_not_nan.hpp
@@ -8,6 +8,13 @@
 #include <stan/math/prim/scal/fun/value_of_rec.hpp>
 #include <stan/math/prim/scal/fun/is_nan.hpp>
 
+#include <stan/math/prim/arr/meta/get.hpp>
+#include <stan/math/prim/arr/meta/length.hpp>
+
+#include <stan/math/prim/mat/meta/get.hpp>
+#include <stan/math/prim/mat/meta/is_vector_like.hpp>
+#include <stan/math/prim/mat/meta/length.hpp>
+
 namespace stan {
 namespace math {
 

--- a/stan/math/prim/scal/err/domain_error_vec.hpp
+++ b/stan/math/prim/scal/err/domain_error_vec.hpp
@@ -5,6 +5,8 @@
 #include <stan/math/prim/scal/meta/value_type.hpp>
 #include <stan/math/prim/scal/meta/error_index.hpp>
 #include <stan/math/prim/scal/meta/get.hpp>
+#include <stan/math/prim/arr/meta/get.hpp>
+#include <stan/math/prim/mat/meta/get.hpp>
 #include <sstream>
 #include <string>
 

--- a/stan/math/prim/scal/meta/is_vector_like.hpp
+++ b/stan/math/prim/scal/meta/is_vector_like.hpp
@@ -2,6 +2,8 @@
 #define STAN_MATH_PRIM_SCAL_META_IS_VECTOR_LIKE_HPP
 
 #include <stan/math/prim/scal/meta/is_vector.hpp>
+#include <stan/math/prim/arr/meta/is_vector.hpp>
+#include <stan/math/prim/mat/meta/is_vector.hpp>
 
 namespace stan {
 

--- a/test/unit/math/prim/arr/fun/quantile_test.cpp
+++ b/test/unit/math/prim/arr/fun/quantile_test.cpp
@@ -1,0 +1,28 @@
+#include <stan/math/prim/arr.hpp>
+#include <gtest/gtest.h>
+#include <vector>
+
+TEST(MathFunctions, quantile) {
+  using stan::math::quantile;
+
+  std::vector<double> v0(3);
+  v0[0] = 4;
+  v0[1] = 1;
+  v0[2] = 2;
+  EXPECT_FLOAT_EQ(1.0, quantile(v0, 0.00));
+  EXPECT_FLOAT_EQ(1.5, quantile(v0, 0.25));
+  EXPECT_FLOAT_EQ(2.0, quantile(v0, 0.50));
+  EXPECT_FLOAT_EQ(3.0, quantile(v0, 0.75));
+  EXPECT_FLOAT_EQ(4.0, quantile(v0, 1.00));
+
+  std::vector<double> v1(4);
+  v1[0] = 7;
+  v1[1] = 1;
+  v1[2] = 4;
+  v1[3] = 2;
+  EXPECT_FLOAT_EQ(1.00, quantile(v1, 0.00));
+  EXPECT_FLOAT_EQ(1.75, quantile(v1, 0.25));
+  EXPECT_FLOAT_EQ(3.00, quantile(v1, 0.50));
+  EXPECT_FLOAT_EQ(4.75, quantile(v1, 0.75));
+  EXPECT_FLOAT_EQ(7.00, quantile(v1, 1.00));
+}

--- a/test/unit/math/prim/mat/fun/quantile_test.cpp
+++ b/test/unit/math/prim/mat/fun/quantile_test.cpp
@@ -1,0 +1,30 @@
+#include <stan/math/prim/mat.hpp>
+#include <gtest/gtest.h>
+
+TEST(MathFunctions, quantile) {
+  using Eigen::Dynamic;
+  using Eigen::Matrix;
+  using stan::math::quantile;
+
+  Matrix<double, Dynamic, Dynamic> m(3, 2);
+  m << 1, 2, 3, 4, 5, 6;
+  EXPECT_FLOAT_EQ(1.0, quantile(m, 0.0));
+  EXPECT_FLOAT_EQ(3.5, quantile(m, 0.5));
+  EXPECT_FLOAT_EQ(6.0, quantile(m, 1.0));
+
+  Matrix<double, Dynamic, 1> v0(3);
+  v0 << 4, 1, 2;
+  EXPECT_FLOAT_EQ(1.0, quantile(v0, 0.00));
+  EXPECT_FLOAT_EQ(1.5, quantile(v0, 0.25));
+  EXPECT_FLOAT_EQ(2.0, quantile(v0, 0.50));
+  EXPECT_FLOAT_EQ(3.0, quantile(v0, 0.75));
+  EXPECT_FLOAT_EQ(4.0, quantile(v0, 1.00));
+
+  Matrix<double, Dynamic, 1> v1(4);
+  v1 << 7, 1, 4, 2;
+  EXPECT_FLOAT_EQ(1.00, quantile(v1, 0.00));
+  EXPECT_FLOAT_EQ(1.75, quantile(v1, 0.25));
+  EXPECT_FLOAT_EQ(3.00, quantile(v1, 0.50));
+  EXPECT_FLOAT_EQ(4.75, quantile(v1, 0.75));
+  EXPECT_FLOAT_EQ(7.00, quantile(v1, 1.00));
+}


### PR DESCRIPTION
## Summary

This implements the method for evaluating the `q`-th quantile of the specified data.

## Tests

- `test/unit/math/prim/arr/fun/quantile_test.cpp`
- `test/unit/math/prim/mat/fun/quantile_test.cpp`

## Side Effects

No.

## Checklist

- [x] Math issue #1036, and also related to #1106

- [X] Copyright holder: Licht Takeuchi
    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
