### PR TITLE
updating make test-math-dependencies; fixing warnings

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -128,6 +128,7 @@ pipeline {
             post {
                 always {
                     recordIssues enabledForFailure: true, tool: cppLint()
+                    recordIssues enabledForFailure: true, tool: cppLint()
                     deleteDir()
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -120,7 +120,9 @@ pipeline {
                     sh "echo BOOST_PARALLEL_JOBS=${env.PARALLEL} >> make/local"
                     parallel(
                         CppLint: { sh "make cpplint" },
-                        Dependencies: { sh 'make test-math-dependencies 2>&1 > dependencies.log' } ,
+                        Dependencies: { sh """#!/bin/bash
+                            set -o pipefail
+                            make test-math-dependencies 2>&1 | tee dependencies.log""" } ,
                         Documentation: { sh 'make doxygen' },
                     )
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -120,15 +120,16 @@ pipeline {
                     sh "echo BOOST_PARALLEL_JOBS=${env.PARALLEL} >> make/local"
                     parallel(
                         CppLint: { sh "make cpplint" },
-                        Dependencies: { sh 'make test-math-dependencies' } ,
+                        Dependencies: { sh 'make test-math-dependencies 2>&1 > dependencies.log' } ,
                         Documentation: { sh 'make doxygen' },
                     )
                 }
             }
             post {
                 always {
-                    recordIssues enabledForFailure: true, tool: cppLint()
-		    warnings consoleParsers: [[parserName: 'math-dependencies']], canRunOnFailed: true
+                    recordIssues enabledForFailure: true, tools:
+                        [cppLint(),
+                         groovyScript(parserId: 'mathDependencies', pattern: '**/dependencies.log')]
                     deleteDir()
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -127,8 +127,7 @@ pipeline {
             }
             post {
                 always {
-                    warnings consoleParsers: [[parserName: 'CppLint']], canRunOnFailed: true
-                    warnings consoleParsers: [[parserName: 'math-dependencies']], canRunOnFailed: true
+                    recordIssues enabledForFailure: true, tool: cppLint()
                     deleteDir()
                 }
             }
@@ -308,7 +307,7 @@ pipeline {
     post {
         always {
             node("osx || linux") {
-                warnings canRunOnFailed: true, consoleParsers: [[parserName: 'Clang (LLVM based)']]
+                recordIssues enabledForFailure: false, tool: clang()
             }
         }
         success {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -272,6 +272,7 @@ pipeline {
             }
         }
         stage('Upstream tests') {
+            when { expression { env.BRANCH_NAME ==~ /PR-\d+/ } }
             steps {
                 build(job: "Stan/${stan_pr()}",
                         parameters: [string(name: 'math_pr', value: env.BRANCH_NAME),

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -128,6 +128,7 @@ pipeline {
             post {
                 always {
                     recordIssues enabledForFailure: true, tool: cppLint()
+		    warnings consoleParsers: [[parserName: 'math-dependencies']], canRunOnFailed: true
                     deleteDir()
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -128,7 +128,6 @@ pipeline {
             post {
                 always {
                     recordIssues enabledForFailure: true, tool: cppLint()
-                    recordIssues enabledForFailure: true, tool: cppLint()
                     deleteDir()
                 }
             }

--- a/make/test-math-dependencies
+++ b/make/test-math-dependencies
@@ -10,7 +10,7 @@ $(eval _math_warnings_str+=$(_new_math_warnings_str))
 endef
 
 define print_math_warnings
-@echo $(_math_warnings_str)
+@$(_math_warnings_str)
 @exit $(if $(strip $(_math_warnings_str)),1,0)
 endef
 

--- a/make/test-math-dependencies
+++ b/make/test-math-dependencies
@@ -4,7 +4,7 @@ $(eval all_headers := $(shell find $2 -name '*.hpp' -o -name '*.cpp'))
 $(eval pattern := $3)
 $(eval msg := $4)
 $(eval _new_math_warnings_str:=$(foreach file,\
-  $(shell grep -r -n -e $(pattern) $(all_headers) | sed 's|\([^:]*\):\([0-9]*\):.*|\1(\2)|g'),\
+  $(shell grep -r -n -e $(pattern) $(all_headers) | grep -v ": \* " | sed 's|\([^:]*\):\([0-9]*\):.*|\1(\2)|g'),\
   echo '$(file): $(msg) [$(type)]';))
 $(eval _math_warnings_str+=$(_new_math_warnings_str))
 endef

--- a/make/test-math-dependencies
+++ b/make/test-math-dependencies
@@ -3,9 +3,15 @@ $(eval type:= $1)
 $(eval all_headers := $(shell find $2 -name '*.hpp' -o -name '*.cpp'))
 $(eval pattern := $3)
 $(eval msg := $4)
-$(foreach file,\
-   $(shell grep -r -n -e $(pattern) $(all_headers) | sed 's|\([^:]*\):\([0-9]*\):.*|\1(\2)|g'),\
-   echo '$(file): $(msg) [$(type)]';)
+$(eval _new_math_warnings_str:=$(foreach file,\
+  $(shell grep -r -n -e $(pattern) $(all_headers) | sed 's|\([^:]*\):\([0-9]*\):.*|\1(\2)|g'),\
+  echo '$(file): $(msg) [$(type)]';))
+$(eval _math_warnings_str+=$(_new_math_warnings_str))
+endef
+
+define print_math_warnings
+@echo $(_math_warnings_str)
+@exit $(if $(strip $(_math_warnings_str)),1,0)
 endef
 
 .PHONY: test-math-dependencies
@@ -60,3 +66,4 @@ test-math-dependencies:
              '<Eigen', 'File includes an Eigen header.')
 	@$(call math_warnings, 'arr', stan/math/*/arr,\
              'Eigen::', 'File uses Eigen.')
+	@$(call print_math_warnings)

--- a/stan/math/prim/arr/meta/contains_std_vector.hpp
+++ b/stan/math/prim/arr/meta/contains_std_vector.hpp
@@ -3,11 +3,9 @@
 
 #include <type_traits>
 #include <vector>
+#include <stan/math/prim/scal/meta/contains_std_vector.hpp>
 
 namespace stan {
-
-template <typename... Ts>
-struct contains_std_vector : std::false_type {};
 
 template <typename T, typename... Ts>
 struct contains_std_vector<std::vector<T>, Ts...> : std::true_type {};

--- a/stan/math/prim/arr/meta/contains_std_vector.hpp
+++ b/stan/math/prim/arr/meta/contains_std_vector.hpp
@@ -1,9 +1,9 @@
 #ifndef STAN_MATH_PRIM_ARR_META_CONTAINS_STD_VECTOR_HPP
 #define STAN_MATH_PRIM_ARR_META_CONTAINS_STD_VECTOR_HPP
 
+#include <stan/math/prim/scal/meta/contains_std_vector.hpp>
 #include <type_traits>
 #include <vector>
-#include <stan/math/prim/scal/meta/contains_std_vector.hpp>
 
 namespace stan {
 

--- a/stan/math/prim/scal.hpp
+++ b/stan/math/prim/scal.hpp
@@ -3,6 +3,7 @@
 
 #include <stan/math/version.hpp>
 
+#include <stan/math/rev/scal/meta/ad_promotable.hpp>
 #include <stan/math/prim/scal/meta/ad_promotable.hpp>
 #include <stan/math/prim/scal/meta/child_type.hpp>
 #include <stan/math/prim/scal/meta/contains_fvar.hpp>

--- a/stan/math/prim/scal.hpp
+++ b/stan/math/prim/scal.hpp
@@ -7,6 +7,7 @@
 #include <stan/math/prim/scal/meta/child_type.hpp>
 #include <stan/math/prim/scal/meta/contains_fvar.hpp>
 #include <stan/math/prim/scal/meta/contains_nonconstant_struct.hpp>
+#include <stan/math/prim/scal/meta/contains_std_vector.hpp>
 #include <stan/math/prim/scal/meta/contains_vector.hpp>
 #include <stan/math/prim/scal/meta/error_index.hpp>
 #include <stan/math/prim/scal/meta/get.hpp>

--- a/stan/math/prim/scal.hpp
+++ b/stan/math/prim/scal.hpp
@@ -3,7 +3,6 @@
 
 #include <stan/math/version.hpp>
 
-#include <stan/math/rev/scal/meta/ad_promotable.hpp>
 #include <stan/math/prim/scal/meta/ad_promotable.hpp>
 #include <stan/math/prim/scal/meta/child_type.hpp>
 #include <stan/math/prim/scal/meta/contains_fvar.hpp>

--- a/stan/math/prim/scal/meta/StdVectorBuilder.hpp
+++ b/stan/math/prim/scal/meta/StdVectorBuilder.hpp
@@ -2,7 +2,7 @@
 #define STAN_MATH_PRIM_SCAL_META_STDVECTORBUILDER_HPP
 
 #include <stan/math/prim/scal/meta/VectorBuilderHelper.hpp>
-#include <stan/math/prim/arr/meta/contains_std_vector.hpp>
+#include <stan/math/prim/scal/meta/contains_std_vector.hpp>
 
 namespace stan {
 

--- a/stan/math/prim/scal/meta/StdVectorBuilder.hpp
+++ b/stan/math/prim/scal/meta/StdVectorBuilder.hpp
@@ -29,7 +29,6 @@ namespace stan {
  *      and operator[] throws a std::logic_error.
  *  @tparam T1 Type of vector to build
  */
-
 template <bool used, typename T1, typename T2, typename T3 = double,
           typename T4 = double, typename T5 = double, typename T6 = double,
           typename T7 = double>

--- a/stan/math/prim/scal/meta/contains_std_vector.hpp
+++ b/stan/math/prim/scal/meta/contains_std_vector.hpp
@@ -1,0 +1,12 @@
+#ifndef STAN_MATH_PRIM_SCAL_META_CONTAINS_STD_VECTOR_HPP
+#define STAN_MATH_PRIM_SCAL_META_CONTAINS_STD_VECTOR_HPP
+
+#include <stan/math/prim/scal/meta/contains_std_vector.hpp>
+#include <type_traits>
+
+namespace stan {
+  template <typename... Ts>
+  struct contains_std_vector : std::false_type {};
+}
+
+#endif

--- a/test/unit/math/prim/scal/meta/contains_std_vector_test.cpp
+++ b/test/unit/math/prim/scal/meta/contains_std_vector_test.cpp
@@ -1,0 +1,12 @@
+#include <stan/math/prim/scal.hpp>
+#include <gtest/gtest.h>
+#include <vector>
+
+TEST(MetaTraits, contains_std_vector_false) {
+  using stan::contains_std_vector;
+
+  EXPECT_FALSE(contains_std_vector<double>::value);
+  EXPECT_FALSE(contains_std_vector<int>::value);
+  EXPECT_FALSE(contains_std_vector<const double>::value);
+  EXPECT_FALSE(contains_std_vector<const int>::value);
+}


### PR DESCRIPTION
## Summary

This PR does 3 things.

1. It fixes the math dependencies errors that are currently in `develop`. These errors are in `stan/math/prim/scal/meta/StdVectorBuilder.hpp` where it pulls an `arr` header into `scal`. This was fixed by splitting the template metaprogram's base class into `prim` (and adding a test for that).
2. Updating the `make test-math-dependencies` so that it:
    1. returns a non-zero exit code if there are warnings
    2. ignores references to `std::vector` and `Eigen::Matrix` within comments.
3. Updates the Jenkinsfile so that it uses the new warnings next generation plugin for parsing some of the warnings. The parser for `math-dependencies` is still using the old warnings plugin (that's been deprecated) because the mechanism for adding groovy scripts to parse is no longer supported except through the web interface. I figured it's just as well that we leave it as-is.

## Tests

The code for `contains_std_vector.hpp` has been tested with a new unit test in prim. It just makes sure the base case is correct.

For the makefile, I've been running it by hand. When there are no errors, it exits with code 0, if there are errors, it exits with a non-zero return code. I've observed the Jenkins build failing due to warnings and that's our intended effect.

## Side Effects

None.

## Checklist

- [x] Math issue #1078

- [x] Copyright holder:

Generable

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested