### PR TITLE
do not pass uninitialized symbols

### DIFF
--- a/test/unit/math/mix/mat/util/autodiff_tester.hpp
+++ b/test/unit/math/mix/mat/util/autodiff_tester.hpp
@@ -116,7 +116,7 @@ template <typename F>
 void test_gradient(const F& f, const Eigen::VectorXd& x, double fx,
                    bool test_derivs) {
   Eigen::VectorXd grad_ad;
-  double fx_ad;
+  double fx_ad = fx;
   gradient<F>(f, x, fx_ad, grad_ad);
   expect_near("test_gradient fx = fx_ad", fx, fx_ad);
   if (!test_derivs || !is_finite(x) || !is_finite(fx))
@@ -137,7 +137,7 @@ template <typename F>
 void test_gradient_fvar(const F& f, const Eigen::VectorXd& x, double fx,
                         bool test_derivs) {
   Eigen::VectorXd grad_ad;
-  double fx_ad;
+  double fx_ad = fx;
   gradient<double, F>(f, x, fx_ad, grad_ad);
   expect_near("gradient_fvar fx == fx_ad", fx, fx_ad);
   if (!test_derivs || !is_finite(x) || !is_finite(fx))


### PR DESCRIPTION
## Summary

We were using values without initializing them and this was causing failures on GCC 7. Fixing this will enable us to run tests on gcc 7 and use Ben's Linux node for MPI tests.

## Checklist

- [x] Copyright holder: (fill in copyright holder information)

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses: Columbia University
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
