### PR TITLE
[Jenkins] Unify Windows Headers and Unit tests to cut time required

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -172,19 +172,12 @@ pipeline {
                     }
                     post { always { retry(3) { deleteDir() } } }
                 }
-                stage('Windows Headers') {
+                stage('Windows Headers & Unit') {
                     agent { label 'windows' }
                     steps {
                         deleteDirWin()
                         unstash 'MathSetup'
                         bat "make -j${env.PARALLEL} test-headers"
-                    }
-                }
-                stage('Windows Unit') {
-                    agent { label 'windows' }
-                    steps {
-                        deleteDirWin()
-                        unstash 'MathSetup'
                         runTestsWin("test/unit")
                     }
                 }


### PR DESCRIPTION
On windows, setup and teardown is particularly expensive, taking something like 3 or 4 minutes. This quick PR just does Windows Unit tests immediately after the Windows Header tests in the same directory rather than deleting the whole directory and unstashing in between.

    * Copyright holder: Columbia University