### PR TITLE
Replace boost::is_unsigned, boost::is_arithmetic and boost::is_convertible wtih std library equivalents

### DIFF
--- a/stan/math/prim/mat/fun/accumulator.hpp
+++ b/stan/math/prim/mat/fun/accumulator.hpp
@@ -6,6 +6,7 @@
 #include <boost/utility/enable_if.hpp>
 #include <boost/type_traits/is_same.hpp>
 #include <vector>
+#include <type_traits>
 
 namespace stan {
 namespace math {

--- a/stan/math/prim/mat/fun/accumulator.hpp
+++ b/stan/math/prim/mat/fun/accumulator.hpp
@@ -4,7 +4,6 @@
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/mat/fun/sum.hpp>
 #include <boost/utility/enable_if.hpp>
-#include <boost/type_traits/is_arithmetic.hpp>
 #include <boost/type_traits/is_same.hpp>
 #include <vector>
 
@@ -41,14 +40,14 @@ class accumulator {
    * Add the specified arithmetic type value to the buffer after
    * static casting it to the class type <code>T</code>.
    *
-   * <p>See the Boost doc for <code>boost::is_arithmetic</code>
+   * <p>See the std library doc for <code>std::is_arithmetic</code>
    * for information on what counts as an arithmetic type.
    *
    * @tparam S Type of argument
    * @param x Value to add
    */
   template <typename S>
-  typename boost::enable_if<boost::is_arithmetic<S>, void>::type add(S x) {
+  typename boost::enable_if<std::is_arithmetic<S>, void>::type add(S x) {
     buf_.push_back(static_cast<T>(x));
   }
 
@@ -58,7 +57,7 @@ class accumulator {
    * <p>This function is disabled if the type <code>S</code> is
    * arithmetic or if it's not the same as <code>T</code>.
    *
-   * <p>See the Boost doc for <code>boost::is_arithmetic</code>
+   * <p>See the std library doc for <code>std::is_arithmetic</code>
    * for information on what counts as an arithmetic type.
    *
    * @tparam S Type of argument
@@ -66,7 +65,7 @@ class accumulator {
    */
   template <typename S>
   typename boost::disable_if<
-      boost::is_arithmetic<S>,
+      std::is_arithmetic<S>,
       typename boost::enable_if<boost::is_same<S, T>, void>::type>::type
   add(const S& x) {
     buf_.push_back(x);

--- a/stan/math/prim/mat/fun/divide.hpp
+++ b/stan/math/prim/mat/fun/divide.hpp
@@ -3,6 +3,7 @@
 
 #include <boost/utility/enable_if.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <type_traits>
 
 namespace stan {
 namespace math {

--- a/stan/math/prim/mat/fun/divide.hpp
+++ b/stan/math/prim/mat/fun/divide.hpp
@@ -1,7 +1,6 @@
 #ifndef STAN_MATH_PRIM_MAT_FUN_DIVIDE_HPP
 #define STAN_MATH_PRIM_MAT_FUN_DIVIDE_HPP
 
-#include <boost/type_traits/is_arithmetic.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 
@@ -17,7 +16,7 @@ namespace math {
  * @return Matrix divided by scalar.
  */
 template <int R, int C, typename T>
-inline typename boost::enable_if_c<boost::is_arithmetic<T>::value,
+inline typename boost::enable_if_c<std::is_arithmetic<T>::value,
                                    Eigen::Matrix<double, R, C> >::type
 divide(const Eigen::Matrix<double, R, C>& m, T c) {
   return m / c;

--- a/stan/math/prim/scal/err/check_nonnegative.hpp
+++ b/stan/math/prim/scal/err/check_nonnegative.hpp
@@ -6,6 +6,7 @@
 #include <stan/math/prim/scal/meta/length.hpp>
 #include <stan/math/prim/scal/meta/value_type.hpp>
 #include <stan/math/prim/scal/meta/is_vector_like.hpp>
+#include <type_traits>
 
 namespace stan {
 namespace math {

--- a/stan/math/prim/scal/err/check_nonnegative.hpp
+++ b/stan/math/prim/scal/err/check_nonnegative.hpp
@@ -6,7 +6,6 @@
 #include <stan/math/prim/scal/meta/length.hpp>
 #include <stan/math/prim/scal/meta/value_type.hpp>
 #include <stan/math/prim/scal/meta/is_vector_like.hpp>
-#include <boost/type_traits/is_unsigned.hpp>
 
 namespace stan {
 namespace math {
@@ -17,7 +16,7 @@ struct nonnegative {
   static void check(const char* function, const char* name, const T_y& y) {
     // have to use not is_unsigned. is_signed will be false
     // floating point types that have no unsigned versions.
-    if (!boost::is_unsigned<T_y>::value && !(y >= 0))
+    if (!std::is_unsigned<T_y>::value && !(y >= 0))
       domain_error(function, name, y, "is ", ", but must be >= 0!");
   }
 };
@@ -28,7 +27,7 @@ struct nonnegative<T_y, true> {
     using stan::length;
 
     for (size_t n = 0; n < length(y); n++) {
-      if (!boost::is_unsigned<typename value_type<T_y>::type>::value
+      if (!std::is_unsigned<typename value_type<T_y>::type>::value
           && !(stan::get(y, n) >= 0))
         domain_error_vec(function, name, y, n, "is ", ", but must be >= 0!");
     }

--- a/stan/math/prim/scal/err/check_positive.hpp
+++ b/stan/math/prim/scal/err/check_positive.hpp
@@ -19,7 +19,7 @@ struct positive {
   static void check(const char* function, const char* name, const T_y& y) {
     // have to use not is_unsigned. is_signed will be false
     // floating point types that have no unsigned versions.
-    if (std::is_signed<T_y>::value && !(y > 0))
+    if (!std::is_unsigned<T_y>::value && !(y > 0))
       domain_error(function, name, y, "is ", ", but must be > 0!");
   }
 };
@@ -29,7 +29,7 @@ struct positive<T_y, true> {
   static void check(const char* function, const char* name, const T_y& y) {
     using stan::length;
     for (size_t n = 0; n < length(y); n++) {
-      if (std::is_signed<typename value_type<T_y>::type>::value
+      if (!std::is_unsigned<typename value_type<T_y>::type>::value
           && !(stan::get(y, n) > 0))
         domain_error_vec(function, name, y, n, "is ", ", but must be > 0!");
     }

--- a/stan/math/prim/scal/err/check_positive.hpp
+++ b/stan/math/prim/scal/err/check_positive.hpp
@@ -18,7 +18,7 @@ struct positive {
   static void check(const char* function, const char* name, const T_y& y) {
     // have to use not is_unsigned. is_signed will be false
     // floating point types that have no unsigned versions.
-    if (!std::is_unsigned<T_y>::value && !(y > 0))
+    if (std::is_signed<T_y>::value && !(y > 0))
       domain_error(function, name, y, "is ", ", but must be > 0!");
   }
 };
@@ -28,7 +28,7 @@ struct positive<T_y, true> {
   static void check(const char* function, const char* name, const T_y& y) {
     using stan::length;
     for (size_t n = 0; n < length(y); n++) {
-      if (!std::is_unsigned<typename value_type<T_y>::type>::value
+      if (std::is_signed<typename value_type<T_y>::type>::value
           && !(stan::get(y, n) > 0))
         domain_error_vec(function, name, y, n, "is ", ", but must be > 0!");
     }

--- a/stan/math/prim/scal/err/check_positive.hpp
+++ b/stan/math/prim/scal/err/check_positive.hpp
@@ -7,6 +7,7 @@
 #include <stan/math/prim/scal/meta/length.hpp>
 #include <stan/math/prim/scal/meta/get.hpp>
 #include <stan/math/prim/scal/meta/is_vector_like.hpp>
+#include <type_traits>
 
 namespace stan {
 namespace math {

--- a/stan/math/prim/scal/err/check_positive.hpp
+++ b/stan/math/prim/scal/err/check_positive.hpp
@@ -7,7 +7,6 @@
 #include <stan/math/prim/scal/meta/length.hpp>
 #include <stan/math/prim/scal/meta/get.hpp>
 #include <stan/math/prim/scal/meta/is_vector_like.hpp>
-#include <boost/type_traits/is_unsigned.hpp>
 
 namespace stan {
 namespace math {
@@ -19,7 +18,7 @@ struct positive {
   static void check(const char* function, const char* name, const T_y& y) {
     // have to use not is_unsigned. is_signed will be false
     // floating point types that have no unsigned versions.
-    if (!boost::is_unsigned<T_y>::value && !(y > 0))
+    if (!std::is_unsigned<T_y>::value && !(y > 0))
       domain_error(function, name, y, "is ", ", but must be > 0!");
   }
 };
@@ -29,7 +28,7 @@ struct positive<T_y, true> {
   static void check(const char* function, const char* name, const T_y& y) {
     using stan::length;
     for (size_t n = 0; n < length(y); n++) {
-      if (!boost::is_unsigned<typename value_type<T_y>::type>::value
+      if (!std::is_unsigned<typename value_type<T_y>::type>::value
           && !(stan::get(y, n) > 0))
         domain_error_vec(function, name, y, n, "is ", ", but must be > 0!");
     }

--- a/stan/math/prim/scal/fun/primitive_value.hpp
+++ b/stan/math/prim/scal/fun/primitive_value.hpp
@@ -3,6 +3,7 @@
 
 #include <boost/utility/enable_if.hpp>
 #include <stan/math/prim/scal/fun/value_of.hpp>
+#include <type_traits>
 
 namespace stan {
 namespace math {

--- a/stan/math/prim/scal/fun/primitive_value.hpp
+++ b/stan/math/prim/scal/fun/primitive_value.hpp
@@ -2,7 +2,6 @@
 #define STAN_MATH_PRIM_SCAL_FUN_PRIMITIVE_VALUE_HPP
 
 #include <boost/utility/enable_if.hpp>
-#include <boost/type_traits/is_arithmetic.hpp>
 #include <stan/math/prim/scal/fun/value_of.hpp>
 
 namespace stan {
@@ -13,7 +12,7 @@ namespace math {
  * unmodified with its own declared type.
  *
  * <p>This template function can only be instantiated with
- * arithmetic types as defined by Boost's
+ * arithmetic types as defined by std library's
  * <code>is_arithmetic</code> trait metaprogram.
  *
  * <p>This function differs from <code>value_of</code> in that it
@@ -24,7 +23,7 @@ namespace math {
  * @return input unmodified.
  */
 template <typename T>
-inline typename boost::enable_if<boost::is_arithmetic<T>, T>::type
+inline typename boost::enable_if<std::is_arithmetic<T>, T>::type
 primitive_value(T x) {
   return x;
 }
@@ -33,14 +32,14 @@ primitive_value(T x) {
  * Return the primitive value of the specified argument.
  *
  * <p>This implementation only applies to non-arithmetic types as
- * defined by Boost's <code>is_arithmetic</code> trait metaprogram.
+ * defined by std libray's <code>is_arithmetic</code> trait metaprogram.
  *
  * @tparam T type of non-arithmetic input.
  * @param x input.
  * @return value of input.
  */
 template <typename T>
-inline typename boost::disable_if<boost::is_arithmetic<T>, double>::type
+inline typename boost::disable_if<std::is_arithmetic<T>, double>::type
 primitive_value(const T& x) {
   return value_of(x);
 }

--- a/stan/math/prim/scal/meta/is_constant.hpp
+++ b/stan/math/prim/scal/meta/is_constant.hpp
@@ -1,8 +1,6 @@
 #ifndef STAN_MATH_PRIM_SCAL_META_IS_CONSTANT_HPP
 #define STAN_MATH_PRIM_SCAL_META_IS_CONSTANT_HPP
 
-#include <boost/type_traits/is_convertible.hpp>
-
 namespace stan {
 
 /**
@@ -24,7 +22,7 @@ struct is_constant {
    * A boolean constant with equal to <code>true</code> if the
    * type parameter <code>T</code> is a mathematical constant.
    */
-  enum { value = boost::is_convertible<T, double>::value };
+  enum { value = std::is_convertible<T, double>::value };
 };
 
 }  // namespace stan

--- a/stan/math/prim/scal/meta/is_constant.hpp
+++ b/stan/math/prim/scal/meta/is_constant.hpp
@@ -1,6 +1,8 @@
 #ifndef STAN_MATH_PRIM_SCAL_META_IS_CONSTANT_HPP
 #define STAN_MATH_PRIM_SCAL_META_IS_CONSTANT_HPP
 
+#include <type_traits>
+
 namespace stan {
 
 /**

--- a/stan/math/prim/scal/meta/is_var_or_arithmetic.hpp
+++ b/stan/math/prim/scal/meta/is_var_or_arithmetic.hpp
@@ -3,7 +3,6 @@
 
 #include <stan/math/prim/scal/meta/is_var.hpp>
 #include <stan/math/prim/scal/meta/scalar_type.hpp>
-#include <boost/type_traits/is_arithmetic.hpp>
 
 namespace stan {
 
@@ -12,17 +11,17 @@ template <typename T1, typename T2 = double, typename T3 = double,
 struct is_var_or_arithmetic {
   enum {
     value = (is_var<typename scalar_type<T1>::type>::value
-             || boost::is_arithmetic<typename scalar_type<T1>::type>::value)
+             || std::is_arithmetic<typename scalar_type<T1>::type>::value)
             && (is_var<typename scalar_type<T2>::type>::value
-                || boost::is_arithmetic<typename scalar_type<T2>::type>::value)
+                || std::is_arithmetic<typename scalar_type<T2>::type>::value)
             && (is_var<typename scalar_type<T3>::type>::value
-                || boost::is_arithmetic<typename scalar_type<T3>::type>::value)
+                || std::is_arithmetic<typename scalar_type<T3>::type>::value)
             && (is_var<typename scalar_type<T4>::type>::value
-                || boost::is_arithmetic<typename scalar_type<T4>::type>::value)
+                || std::is_arithmetic<typename scalar_type<T4>::type>::value)
             && (is_var<typename scalar_type<T5>::type>::value
-                || boost::is_arithmetic<typename scalar_type<T5>::type>::value)
+                || std::is_arithmetic<typename scalar_type<T5>::type>::value)
             && (is_var<typename scalar_type<T6>::type>::value
-                || boost::is_arithmetic<typename scalar_type<T6>::type>::value)
+                || std::is_arithmetic<typename scalar_type<T6>::type>::value)
   };
 };
 

--- a/stan/math/prim/scal/meta/is_var_or_arithmetic.hpp
+++ b/stan/math/prim/scal/meta/is_var_or_arithmetic.hpp
@@ -3,6 +3,7 @@
 
 #include <stan/math/prim/scal/meta/is_var.hpp>
 #include <stan/math/prim/scal/meta/scalar_type.hpp>
+#include <type_traits>
 
 namespace stan {
 


### PR DESCRIPTION
## Summary

This is a simple PR that replaces boost::is_arithmetic with [std::is_arithmetic](https://en.cppreference.com/w/cpp/types/is_arithmetic), boost:is_convertible with [std::is_convertible](https://en.cppreference.com/w/cpp/types/is_convertible). The use of !boost::is_unsigned is replaced with [std::is_signed](https://en.cppreference.com/w/cpp/types/is_signed) as std libraries version supports floating points unlike Boost.

Replacing is_same and enable_if are going to be separate PRs as they require more changes.

## Tests

There are no new tests added.

## Side Effects

/

## Checklist

- [x] Math issue #1126 

- [x] Copyright holder: Rok Češnovar

- [ ] the basic tests are passing

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
