### PR TITLE
Replace boost::enable_if_c, boost::enable_if and boost:disable_if with std::enable_if

### DIFF
--- a/make/test-math-dependencies
+++ b/make/test-math-dependencies
@@ -1,3 +1,27 @@
+## 
+#  Function to search code for warnings.
+#
+#  After all the warnings are found, use
+#  print_math_warnings to print the warnings.
+#
+#  The output of the warnings look like cpplint warnings.
+#  It displays the filename, the line number, the message,
+#  and the type of error message.
+#
+#  Example:
+#  stan/math/fwd/core/fvar.hpp(105): File uses boost::enable_if_c instead of std::enable_if. [C++14]
+#
+#  Arguments (in order):
+#    type: The type of error message. Example: 'C++14'
+#    folder: The folders to search for this type of error. Example: 'stan/math/*/scal'
+#    pattern: The pattern to find. This pattern is searched for in non-comment lines.
+#      Example: 'boost::enable_if<'
+#    message: The descriptive error message to pass to the user. For some reason, this
+#      message has to escape '<' and '>', so use '\<' and '\>. If you see a message like
+#      "/bin/sh: boost/utility/enable_if.hpp: No such file or directory", the message
+#      needs to be escaped.
+#      Example: 'Replace \<boost/utility/enable_if.hpp\> with \<type_traits\>.'
+##
 define math_warnings
 $(eval type:= $1)
 $(eval all_headers := $(shell find $2 -name '*.hpp' -o -name '*.cpp'))
@@ -66,4 +90,36 @@ test-math-dependencies:
              '<Eigen', 'File includes an Eigen header.')
 	@$(call math_warnings, 'arr', stan/math/*/arr,\
              'Eigen::', 'File uses Eigen.')
+## Check to make sure we use C++14 constructs
+##    stan/math
+	@$(call math_warnings, 'C++14', 'stan/math',\
+             'boost::is_unsigned<', 'File uses boost::is_unsigned instead of std::is_unsigned.')
+	@$(call math_warnings, 'C++14', 'stan/math',\
+             '<boost/type_traits/is_unsigned>',\
+             'File includes <boost/type_traits/is_unsigned.hpp> instead of <type_traits>.')
+	@$(call math_warnings, 'C++14', 'stan/math',\
+             'boost::is_arithmetic<', 'File uses boost::is_arithmetic instead of std::is_arithmetic.')
+	@$(call math_warnings, 'C++14', 'stan/math',\
+             '<boost/type_traits/is_arithmetic.hpp>',\
+             'File includes <boost/type_traits/is_unsigned.hpp> instead of <type_traits>.')
+	@$(call math_warnings, 'C++14', 'stan/math',\
+             'boost::is_convertible<', 'File uses boost::is_convertible instead of std::is_convertible.')
+	@$(call math_warnings, 'C++14', 'stan/math',\
+             '<boost/type_traits/is_convertible.hpp>',\
+             'File includes <boost/type_traits/is_convertible.hpp> instead of <type_traits>.')
+	@$(call math_warnings, 'C++14', 'stan/math',\
+             'boost::is_same<', 'File uses boost::is_same instead of std::is_same.')
+	@$(call math_warnings, 'C++14', 'stan/math',\
+             '<boost/type_traits/is_same.hpp>',\
+             'File includes <boost/type_traits/is_same.hpp> instead of <type_traits>.')
+	@$(call math_warnings, 'C++14', 'stan/math',\
+             'boost::enable_if_c<', 'File uses boost::enable_if_c instead of std::enable_if.')
+	@$(call math_warnings, 'C++14', 'stan/math',\
+             'boost::enable_if<', 'File uses boost::enable_if instead of std::enable_if.')
+	@$(call math_warnings, 'C++14', 'stan/math',\
+             'boost::disable_if<', 'File uses boost::disable_if instead of std::enable_if.')
+	@$(call math_warnings, 'C++14', 'stan/math',\
+             '<boost/utility/enable_if.hpp>',\
+             'Replace \<boost/utility/enable_if.hpp\> with \<type_traits\>.')
+## Print all warnings
 	@$(call print_math_warnings)

--- a/stan/math/fwd/core/fvar.hpp
+++ b/stan/math/fwd/core/fvar.hpp
@@ -4,7 +4,6 @@
 #include <stan/math/prim/scal/meta/likely.hpp>
 #include <stan/math/prim/scal/fun/is_nan.hpp>
 #include <stan/math/fwd/scal/meta/ad_promotable.hpp>
-#include <boost/utility/enable_if.hpp>
 #include <ostream>
 
 namespace stan {
@@ -102,7 +101,7 @@ struct fvar {
    */
   template <typename V>
   fvar(const V& v,
-       typename boost::enable_if_c<ad_promotable<V, T>::value>::type* dummy = 0)
+       typename std::enable_if<ad_promotable<V, T>::value>::type* dummy = 0)
       : val_(v), d_(0.0) {
     if (unlikely(is_nan(v)))
       d_ = v;

--- a/stan/math/prim/mat/fun/accumulator.hpp
+++ b/stan/math/prim/mat/fun/accumulator.hpp
@@ -3,7 +3,6 @@
 
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/mat/fun/sum.hpp>
-#include <boost/utility/enable_if.hpp>
 #include <vector>
 #include <type_traits>
 
@@ -47,7 +46,7 @@ class accumulator {
    * @param x Value to add
    */
   template <typename S>
-  typename boost::enable_if<std::is_arithmetic<S>, void>::type add(S x) {
+  typename std::enable_if<std::is_arithmetic<S>::value, void>::type add(S x) {
     buf_.push_back(static_cast<T>(x));
   }
 
@@ -64,9 +63,9 @@ class accumulator {
    * @param x Value to add
    */
   template <typename S>
-  typename boost::disable_if<
-      std::is_arithmetic<S>,
-      typename boost::enable_if<std::is_same<S, T>, void>::type>::type
+  typename std::enable_if<
+      !std::is_arithmetic<S>::value,
+      typename std::enable_if<std::is_same<S, T>::value, void>::type>::type
   add(const S& x) {
     buf_.push_back(x);
   }

--- a/stan/math/prim/mat/fun/divide.hpp
+++ b/stan/math/prim/mat/fun/divide.hpp
@@ -17,7 +17,7 @@ namespace math {
  */
 template <int R, int C, typename T>
 inline typename std::enable_if<std::is_arithmetic<T>::value,
-                                   Eigen::Matrix<double, R, C> >::type
+                               Eigen::Matrix<double, R, C> >::type
 divide(const Eigen::Matrix<double, R, C>& m, T c) {
   return m / c;
 }

--- a/stan/math/prim/mat/fun/divide.hpp
+++ b/stan/math/prim/mat/fun/divide.hpp
@@ -1,7 +1,6 @@
 #ifndef STAN_MATH_PRIM_MAT_FUN_DIVIDE_HPP
 #define STAN_MATH_PRIM_MAT_FUN_DIVIDE_HPP
 
-#include <boost/utility/enable_if.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <type_traits>
 
@@ -17,7 +16,7 @@ namespace math {
  * @return Matrix divided by scalar.
  */
 template <int R, int C, typename T>
-inline typename boost::enable_if_c<std::is_arithmetic<T>::value,
+inline typename std::enable_if<std::is_arithmetic<T>::value,
                                    Eigen::Matrix<double, R, C> >::type
 divide(const Eigen::Matrix<double, R, C>& m, T c) {
   return m / c;

--- a/stan/math/prim/mat/fun/initialize.hpp
+++ b/stan/math/prim/mat/fun/initialize.hpp
@@ -2,7 +2,6 @@
 #define STAN_MATH_PRIM_MAT_FUN_INITIALIZE_HPP
 
 #include <stan/math/prim/mat/fun/Eigen.hpp>
-#include <boost/utility/enable_if.hpp>
 #include <vector>
 #include <type_traits>
 
@@ -17,7 +16,7 @@ inline void initialize(T& x, const T& v) {
   x = v;
 }
 template <typename T, typename V>
-inline typename boost::enable_if_c<std::is_arithmetic<V>::value, void>::type
+inline typename std::enable_if<std::is_arithmetic<V>::value, void>::type
 initialize(T& x, V v) {
   x = v;
 }

--- a/stan/math/prim/mat/fun/multiply.hpp
+++ b/stan/math/prim/mat/fun/multiply.hpp
@@ -4,7 +4,6 @@
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/arr/err/check_matching_sizes.hpp>
 #include <stan/math/prim/mat/err/check_multiplicable.hpp>
-#include <boost/utility/enable_if.hpp>
 #include <type_traits>
 
 namespace stan {
@@ -19,7 +18,7 @@ namespace math {
  * @return Product of matrix and scalar.
  */
 template <int R, int C, typename T>
-inline typename boost::enable_if_c<std::is_arithmetic<T>::value,
+inline typename std::enable_if<std::is_arithmetic<T>::value,
                                    Eigen::Matrix<double, R, C> >::type
 multiply(const Eigen::Matrix<double, R, C>& m, T c) {
   return c * m;
@@ -34,7 +33,7 @@ multiply(const Eigen::Matrix<double, R, C>& m, T c) {
  * @return Product of scalar and matrix.
  */
 template <int R, int C, typename T>
-inline typename boost::enable_if_c<std::is_arithmetic<T>::value,
+inline typename std::enable_if<std::is_arithmetic<T>::value,
                                    Eigen::Matrix<double, R, C> >::type
 multiply(T c, const Eigen::Matrix<double, R, C>& m) {
   return c * m;

--- a/stan/math/prim/mat/fun/multiply.hpp
+++ b/stan/math/prim/mat/fun/multiply.hpp
@@ -19,7 +19,7 @@ namespace math {
  */
 template <int R, int C, typename T>
 inline typename std::enable_if<std::is_arithmetic<T>::value,
-                                   Eigen::Matrix<double, R, C> >::type
+                               Eigen::Matrix<double, R, C> >::type
 multiply(const Eigen::Matrix<double, R, C>& m, T c) {
   return c * m;
 }
@@ -34,7 +34,7 @@ multiply(const Eigen::Matrix<double, R, C>& m, T c) {
  */
 template <int R, int C, typename T>
 inline typename std::enable_if<std::is_arithmetic<T>::value,
-                                   Eigen::Matrix<double, R, C> >::type
+                               Eigen::Matrix<double, R, C> >::type
 multiply(T c, const Eigen::Matrix<double, R, C>& m) {
   return c * m;
 }

--- a/stan/math/prim/mat/fun/trace_gen_inv_quad_form_ldlt.hpp
+++ b/stan/math/prim/mat/fun/trace_gen_inv_quad_form_ldlt.hpp
@@ -21,7 +21,7 @@ namespace math {
  */
 template <typename T1, typename T2, typename T3, int R1, int C1, int R2, int C2,
           int R3, int C3>
-inline typename boost::enable_if_c<
+inline typename std::enable_if<
     !stan::is_var<T1>::value && !stan::is_var<T2>::value
         && !stan::is_var<T3>::value,
     typename boost::math::tools::promote_args<T1, T2, T3>::type>::type

--- a/stan/math/prim/mat/fun/trace_gen_quad_form.hpp
+++ b/stan/math/prim/mat/fun/trace_gen_quad_form.hpp
@@ -1,7 +1,6 @@
 #ifndef STAN_MATH_PRIM_MAT_FUN_TRACE_GEN_QUAD_FORM_HPP
 #define STAN_MATH_PRIM_MAT_FUN_TRACE_GEN_QUAD_FORM_HPP
 
-#include <boost/utility/enable_if.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/mat/err/check_multiplicable.hpp>
 #include <stan/math/prim/mat/err/check_square.hpp>

--- a/stan/math/prim/mat/fun/trace_inv_quad_form_ldlt.hpp
+++ b/stan/math/prim/mat/fun/trace_inv_quad_form_ldlt.hpp
@@ -19,7 +19,7 @@ namespace math {
  * where the LDLT_factor of A is provided.
  */
 template <typename T1, typename T2, int R2, int C2, int R3, int C3>
-inline typename boost::enable_if_c<
+inline typename std::enable_if<
     !stan::is_var<T1>::value && !stan::is_var<T2>::value,
     typename boost::math::tools::promote_args<T1, T2>::type>::type
 trace_inv_quad_form_ldlt(const LDLT_factor<T1, R2, C2> &A,

--- a/stan/math/prim/scal/fun/primitive_value.hpp
+++ b/stan/math/prim/scal/fun/primitive_value.hpp
@@ -1,7 +1,6 @@
 #ifndef STAN_MATH_PRIM_SCAL_FUN_PRIMITIVE_VALUE_HPP
 #define STAN_MATH_PRIM_SCAL_FUN_PRIMITIVE_VALUE_HPP
 
-#include <boost/utility/enable_if.hpp>
 #include <stan/math/prim/scal/fun/value_of.hpp>
 #include <type_traits>
 
@@ -24,7 +23,7 @@ namespace math {
  * @return input unmodified.
  */
 template <typename T>
-inline typename boost::enable_if<std::is_arithmetic<T>, T>::type
+inline typename std::enable_if<std::is_arithmetic<T>::value, T>::type
 primitive_value(T x) {
   return x;
 }
@@ -40,7 +39,7 @@ primitive_value(T x) {
  * @return value of input.
  */
 template <typename T>
-inline typename boost::disable_if<std::is_arithmetic<T>, double>::type
+inline typename std::enable_if<!std::is_arithmetic<T>::value, double>::type
 primitive_value(const T& x) {
   return value_of(x);
 }

--- a/stan/math/prim/scal/meta/ad_promotable.hpp
+++ b/stan/math/prim/scal/meta/ad_promotable.hpp
@@ -29,8 +29,8 @@ struct ad_promotable {
  * @tparam T promoted and target type
  */
 template <typename T>
-struct ad_promotable<typename std::enable_if<std::is_arithmetic<T>::value, T>::type,
-                     T> {
+struct ad_promotable<
+    typename std::enable_if<std::is_arithmetic<T>::value, T>::type, T> {
   enum { value = true };
 };
 

--- a/stan/math/prim/scal/meta/ad_promotable.hpp
+++ b/stan/math/prim/scal/meta/ad_promotable.hpp
@@ -1,7 +1,6 @@
 #ifndef STAN_MATH_PRIM_SCAL_META_AD_PROMOTABLE_HPP
 #define STAN_MATH_PRIM_SCAL_META_AD_PROMOTABLE_HPP
 
-#include <boost/utility/enable_if.hpp>
 #include <type_traits>
 
 namespace stan {
@@ -30,7 +29,7 @@ struct ad_promotable {
  * @tparam T promoted and target type
  */
 template <typename T>
-struct ad_promotable<typename boost::enable_if<std::is_arithmetic<T>, T>::type,
+struct ad_promotable<typename std::enable_if<std::is_arithmetic<T>::value, T>::type,
                      T> {
   enum { value = true };
 };

--- a/stan/math/rev/arr/functor/integrate_1d.hpp
+++ b/stan/math/rev/arr/functor/integrate_1d.hpp
@@ -114,9 +114,9 @@ inline double gradient_of_f(const F &f, const double &x, const double &xc,
  */
 template <typename F, typename T_a, typename T_b, typename T_theta>
 inline typename std::enable_if<std::is_same<T_a, var>::value
-                                       || std::is_same<T_b, var>::value
-                                       || std::is_same<T_theta, var>::value,
-                                   var>::type
+                                   || std::is_same<T_b, var>::value
+                                   || std::is_same<T_theta, var>::value,
+                               var>::type
 integrate_1d(const F &f, const T_a &a, const T_b &b,
              const std::vector<T_theta> &theta, const std::vector<double> &x_r,
              const std::vector<int> &x_i, std::ostream &msgs,

--- a/stan/math/rev/arr/functor/integrate_1d.hpp
+++ b/stan/math/rev/arr/functor/integrate_1d.hpp
@@ -8,7 +8,6 @@
 #include <stan/math/rev/scal/fun/is_nan.hpp>
 #include <stan/math/rev/scal/fun/value_of.hpp>
 #include <stan/math/rev/scal/meta/is_var.hpp>
-#include <boost/utility/enable_if.hpp>
 #include <type_traits>
 #include <string>
 #include <vector>
@@ -114,7 +113,7 @@ inline double gradient_of_f(const F &f, const double &x, const double &xc,
  * @return numeric integral of function f
  */
 template <typename F, typename T_a, typename T_b, typename T_theta>
-inline typename boost::enable_if_c<std::is_same<T_a, var>::value
+inline typename std::enable_if<std::is_same<T_a, var>::value
                                        || std::is_same<T_b, var>::value
                                        || std::is_same<T_theta, var>::value,
                                    var>::type

--- a/stan/math/rev/mat/fun/columns_dot_product.hpp
+++ b/stan/math/rev/mat/fun/columns_dot_product.hpp
@@ -18,8 +18,8 @@ namespace math {
 
 template <typename T1, int R1, int C1, typename T2, int R2, int C2>
 inline typename std::enable_if<std::is_same<T1, var>::value
-                                       || std::is_same<T2, var>::value,
-                                   Eigen::Matrix<var, 1, C1> >::type
+                                   || std::is_same<T2, var>::value,
+                               Eigen::Matrix<var, 1, C1> >::type
 columns_dot_product(const Eigen::Matrix<T1, R1, C1>& v1,
                     const Eigen::Matrix<T2, R2, C2>& v2) {
   check_matching_sizes("dot_product", "v1", v1, "v2", v2);

--- a/stan/math/rev/mat/fun/columns_dot_product.hpp
+++ b/stan/math/rev/mat/fun/columns_dot_product.hpp
@@ -10,7 +10,6 @@
 #include <stan/math/rev/mat/fun/typedefs.hpp>
 #include <stan/math/rev/scal/fun/value_of.hpp>
 #include <stan/math/rev/mat/fun/dot_product.hpp>
-#include <boost/utility/enable_if.hpp>
 #include <vector>
 #include <type_traits>
 
@@ -18,7 +17,7 @@ namespace stan {
 namespace math {
 
 template <typename T1, int R1, int C1, typename T2, int R2, int C2>
-inline typename boost::enable_if_c<std::is_same<T1, var>::value
+inline typename std::enable_if<std::is_same<T1, var>::value
                                        || std::is_same<T2, var>::value,
                                    Eigen::Matrix<var, 1, C1> >::type
 columns_dot_product(const Eigen::Matrix<T1, R1, C1>& v1,

--- a/stan/math/rev/mat/fun/cov_exp_quad.hpp
+++ b/stan/math/rev/mat/fun/cov_exp_quad.hpp
@@ -11,7 +11,6 @@
 #include <stan/math/prim/scal/fun/exp.hpp>
 #include <stan/math/prim/scal/meta/scalar_type.hpp>
 #include <boost/math/tools/promotion.hpp>
-#include <boost/utility/enable_if.hpp>
 #include <type_traits>
 #include <vector>
 #include <cmath>
@@ -152,7 +151,7 @@ class cov_exp_quad_vari<T_x, double, T_l> : public vari {
  * @deprecated use <code>gp_exp_quad_cov_vari</code>
  */
 template <typename T_x>
-inline typename boost::enable_if_c<
+inline typename std::enable_if<
     std::is_same<typename scalar_type<T_x>::type, double>::value,
     Eigen::Matrix<var, -1, -1> >::type
 cov_exp_quad(const std::vector<T_x>& x, const var& sigma, const var& l) {
@@ -163,7 +162,7 @@ cov_exp_quad(const std::vector<T_x>& x, const var& sigma, const var& l) {
  * @deprecated use <code>gp_exp_quad_cov_vari</code>
  */
 template <typename T_x>
-inline typename boost::enable_if_c<
+inline typename std::enable_if<
     std::is_same<typename scalar_type<T_x>::type, double>::value,
     Eigen::Matrix<var, -1, -1> >::type
 cov_exp_quad(const std::vector<T_x>& x, double sigma, const var& l) {

--- a/stan/math/rev/mat/fun/dot_product.hpp
+++ b/stan/math/rev/mat/fun/dot_product.hpp
@@ -9,7 +9,6 @@
 #include <stan/math/rev/core.hpp>
 #include <stan/math/rev/mat/fun/typedefs.hpp>
 #include <stan/math/rev/scal/fun/value_of.hpp>
-#include <boost/utility/enable_if.hpp>
 #include <type_traits>
 #include <vector>
 
@@ -196,7 +195,7 @@ class dot_product_vari : public vari {
  * @throw std::domain_error if length of v1 is not equal to length of v2.
  */
 template <typename T1, int R1, int C1, typename T2, int R2, int C2>
-inline typename boost::enable_if_c<
+inline typename std::enable_if<
     std::is_same<T1, var>::value || std::is_same<T2, var>::value, var>::type
 dot_product(const Eigen::Matrix<T1, R1, C1>& v1,
             const Eigen::Matrix<T2, R2, C2>& v2) {
@@ -214,7 +213,7 @@ dot_product(const Eigen::Matrix<T1, R1, C1>& v1,
  * @return Dot product of the arrays.
  */
 template <typename T1, typename T2>
-inline typename boost::enable_if_c<
+inline typename std::enable_if<
     std::is_same<T1, var>::value || std::is_same<T2, var>::value, var>::type
 dot_product(const T1* v1, const T2* v2, size_t length) {
   return var(new dot_product_vari<T1, T2>(v1, v2, length));
@@ -229,7 +228,7 @@ dot_product(const T1* v1, const T2* v2, size_t length) {
  * @throw std::domain_error if sizes of v1 and v2 do not match.
  */
 template <typename T1, typename T2>
-inline typename boost::enable_if_c<
+inline typename std::enable_if<
     std::is_same<T1, var>::value || std::is_same<T2, var>::value, var>::type
 dot_product(const std::vector<T1>& v1, const std::vector<T2>& v2) {
   check_matching_sizes("dot_product", "v1", v1, "v2", v2);

--- a/stan/math/rev/mat/fun/gp_exp_quad_cov.hpp
+++ b/stan/math/rev/mat/fun/gp_exp_quad_cov.hpp
@@ -2,7 +2,6 @@
 #define STAN_MATH_REV_MAT_FUN_GP_EXP_QUAD_COV_HPP
 
 #include <boost/math/tools/promotion.hpp>
-#include <boost/utility/enable_if.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/scal/err/check_not_nan.hpp>
 #include <stan/math/prim/scal/err/check_positive.hpp>
@@ -210,7 +209,7 @@ class gp_exp_quad_cov_vari<T_x, double, T_l> : public vari {
  *   x is nan or infinite
  */
 template <typename T_x>
-inline typename boost::enable_if_c<
+inline typename std::enable_if<
     std::is_same<typename scalar_type<T_x>::type, double>::value,
     Eigen::Matrix<var, -1, -1>>::type
 gp_exp_quad_cov(const std::vector<T_x> &x, const var &sigma,
@@ -253,7 +252,7 @@ gp_exp_quad_cov(const std::vector<T_x> &x, const var &sigma,
  *   x is nan or infinite
  */
 template <typename T_x>
-inline typename boost::enable_if_c<
+inline typename std::enable_if<
     std::is_same<typename scalar_type<T_x>::type, double>::value,
     Eigen::Matrix<var, -1, -1>>::type
 gp_exp_quad_cov(const std::vector<T_x> &x, double sigma,

--- a/stan/math/rev/mat/fun/gp_periodic_cov.hpp
+++ b/stan/math/rev/mat/fun/gp_periodic_cov.hpp
@@ -2,7 +2,6 @@
 #define STAN_MATH_REV_MAT_FUN_GP_PERIODIC_COV_HPP
 
 #include <boost/math/tools/promotion.hpp>
-#include <boost/utility/enable_if.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/scal/err/check_not_nan.hpp>
 #include <stan/math/prim/scal/err/check_positive.hpp>
@@ -300,7 +299,7 @@ class gp_periodic_cov_vari<T_x, double, T_l, T_p> : public vari {
  *   x is nan or infinite
  */
 template <typename T_x>
-inline typename boost::enable_if_c<
+inline typename std::enable_if<
     std::is_same<typename scalar_type<T_x>::type, double>::value,
     Eigen::Matrix<var, Eigen::Dynamic, Eigen::Dynamic>>::type
 gp_periodic_cov(const std::vector<T_x> &x, const var &sigma, const var &l,
@@ -352,7 +351,7 @@ gp_periodic_cov(const std::vector<T_x> &x, const var &sigma, const var &l,
  *   x is nan or infinite
  */
 template <typename T_x>
-inline typename boost::enable_if_c<
+inline typename std::enable_if<
     std::is_same<typename scalar_type<T_x>::type, double>::value,
     Eigen::Matrix<var, Eigen::Dynamic, Eigen::Dynamic>>::type
 gp_periodic_cov(const std::vector<T_x> &x, double sigma, const var &l,

--- a/stan/math/rev/mat/fun/multiply.hpp
+++ b/stan/math/rev/mat/fun/multiply.hpp
@@ -589,8 +589,8 @@ inline Eigen::Matrix<var, R1, C1> multiply(const Eigen::Matrix<T1, R1, C1>& m,
  */
 template <typename Ta, int Ra, int Ca, typename Tb, int Cb>
 inline typename std::enable_if<std::is_same<Ta, var>::value
-                                       || std::is_same<Tb, var>::value,
-                                   Eigen::Matrix<var, Ra, Cb> >::type
+                                   || std::is_same<Tb, var>::value,
+                               Eigen::Matrix<var, Ra, Cb> >::type
 multiply(const Eigen::Matrix<Ta, Ra, Ca>& A,
          const Eigen::Matrix<Tb, Ca, Cb>& B) {
   check_multiplicable("multiply", "A", A, "B", B);

--- a/stan/math/rev/mat/fun/multiply.hpp
+++ b/stan/math/rev/mat/fun/multiply.hpp
@@ -11,7 +11,6 @@
 #include <stan/math/prim/mat/err/check_multiplicable.hpp>
 #include <stan/math/prim/scal/err/check_not_nan.hpp>
 #include <boost/math/tools/promotion.hpp>
-#include <boost/utility/enable_if.hpp>
 #include <type_traits>
 
 namespace stan {
@@ -532,7 +531,7 @@ class multiply_mat_vari<Ta, 1, Ca, double, 1> : public vari {
  * @return Product of scalars
  */
 template <typename T1, typename T2>
-inline typename boost::enable_if_c<
+inline typename std::enable_if<
     (boost::is_scalar<T1>::value || std::is_same<T1, var>::value)
         && (boost::is_scalar<T2>::value || std::is_same<T2, var>::value),
     typename boost::math::tools::promote_args<T1, T2>::type>::type
@@ -589,7 +588,7 @@ inline Eigen::Matrix<var, R1, C1> multiply(const Eigen::Matrix<T1, R1, C1>& m,
  * @return Product of scalar and matrix.
  */
 template <typename Ta, int Ra, int Ca, typename Tb, int Cb>
-inline typename boost::enable_if_c<std::is_same<Ta, var>::value
+inline typename std::enable_if<std::is_same<Ta, var>::value
                                        || std::is_same<Tb, var>::value,
                                    Eigen::Matrix<var, Ra, Cb> >::type
 multiply(const Eigen::Matrix<Ta, Ra, Ca>& A,
@@ -619,7 +618,7 @@ multiply(const Eigen::Matrix<Ta, Ra, Ca>& A,
  * @return Scalar product of row vector and vector
  */
 template <typename Ta, int Ca, typename Tb>
-inline typename boost::enable_if_c<
+inline typename std::enable_if<
     std::is_same<Ta, var>::value || std::is_same<Tb, var>::value, var>::type
 multiply(const Eigen::Matrix<Ta, 1, Ca>& A, const Eigen::Matrix<Tb, Ca, 1>& B) {
   check_multiplicable("multiply", "A", A, "B", B);

--- a/stan/math/rev/mat/fun/quad_form.hpp
+++ b/stan/math/rev/mat/fun/quad_form.hpp
@@ -112,8 +112,8 @@ class quad_form_vari : public vari {
 
 template <typename Ta, int Ra, int Ca, typename Tb, int Rb, int Cb>
 inline typename std::enable_if<std::is_same<Ta, var>::value
-                                       || std::is_same<Tb, var>::value,
-                                   Eigen::Matrix<var, Cb, Cb> >::type
+                                   || std::is_same<Tb, var>::value,
+                               Eigen::Matrix<var, Cb, Cb> >::type
 quad_form(const Eigen::Matrix<Ta, Ra, Ca>& A,
           const Eigen::Matrix<Tb, Rb, Cb>& B) {
   check_square("quad_form", "A", A);

--- a/stan/math/rev/mat/fun/quad_form.hpp
+++ b/stan/math/rev/mat/fun/quad_form.hpp
@@ -1,7 +1,6 @@
 #ifndef STAN_MATH_REV_MAT_FUN_QUAD_FORM_HPP
 #define STAN_MATH_REV_MAT_FUN_QUAD_FORM_HPP
 
-#include <boost/utility/enable_if.hpp>
 #include <stan/math/rev/core.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/mat/fun/typedefs.hpp>
@@ -112,7 +111,7 @@ class quad_form_vari : public vari {
 }  // namespace
 
 template <typename Ta, int Ra, int Ca, typename Tb, int Rb, int Cb>
-inline typename boost::enable_if_c<std::is_same<Ta, var>::value
+inline typename std::enable_if<std::is_same<Ta, var>::value
                                        || std::is_same<Tb, var>::value,
                                    Eigen::Matrix<var, Cb, Cb> >::type
 quad_form(const Eigen::Matrix<Ta, Ra, Ca>& A,
@@ -127,7 +126,7 @@ quad_form(const Eigen::Matrix<Ta, Ra, Ca>& A,
 }
 
 template <typename Ta, int Ra, int Ca, typename Tb, int Rb>
-inline typename boost::enable_if_c<
+inline typename std::enable_if<
     std::is_same<Ta, var>::value || std::is_same<Tb, var>::value, var>::type
 quad_form(const Eigen::Matrix<Ta, Ra, Ca>& A,
           const Eigen::Matrix<Tb, Rb, 1>& B) {

--- a/stan/math/rev/mat/fun/quad_form_sym.hpp
+++ b/stan/math/rev/mat/fun/quad_form_sym.hpp
@@ -1,7 +1,6 @@
 #ifndef STAN_MATH_REV_MAT_FUN_QUAD_FORM_SYM_HPP
 #define STAN_MATH_REV_MAT_FUN_QUAD_FORM_SYM_HPP
 
-#include <boost/utility/enable_if.hpp>
 #include <stan/math/rev/core.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/mat/fun/typedefs.hpp>
@@ -18,7 +17,7 @@ namespace stan {
 namespace math {
 
 template <typename Ta, int Ra, int Ca, typename Tb, int Rb, int Cb>
-inline typename boost::enable_if_c<std::is_same<Ta, var>::value
+inline typename std::enable_if<std::is_same<Ta, var>::value
                                        || std::is_same<Tb, var>::value,
                                    Eigen::Matrix<var, Cb, Cb> >::type
 quad_form_sym(const Eigen::Matrix<Ta, Ra, Ca>& A,
@@ -34,7 +33,7 @@ quad_form_sym(const Eigen::Matrix<Ta, Ra, Ca>& A,
 }
 
 template <typename Ta, int Ra, int Ca, typename Tb, int Rb>
-inline typename boost::enable_if_c<
+inline typename std::enable_if<
     std::is_same<Ta, var>::value || std::is_same<Tb, var>::value, var>::type
 quad_form_sym(const Eigen::Matrix<Ta, Ra, Ca>& A,
               const Eigen::Matrix<Tb, Rb, 1>& B) {

--- a/stan/math/rev/mat/fun/quad_form_sym.hpp
+++ b/stan/math/rev/mat/fun/quad_form_sym.hpp
@@ -18,8 +18,8 @@ namespace math {
 
 template <typename Ta, int Ra, int Ca, typename Tb, int Rb, int Cb>
 inline typename std::enable_if<std::is_same<Ta, var>::value
-                                       || std::is_same<Tb, var>::value,
-                                   Eigen::Matrix<var, Cb, Cb> >::type
+                                   || std::is_same<Tb, var>::value,
+                               Eigen::Matrix<var, Cb, Cb> >::type
 quad_form_sym(const Eigen::Matrix<Ta, Ra, Ca>& A,
               const Eigen::Matrix<Tb, Rb, Cb>& B) {
   check_square("quad_form", "A", A);

--- a/stan/math/rev/mat/fun/rows_dot_product.hpp
+++ b/stan/math/rev/mat/fun/rows_dot_product.hpp
@@ -18,8 +18,8 @@ namespace math {
 
 template <typename T1, int R1, int C1, typename T2, int R2, int C2>
 inline typename std::enable_if<std::is_same<T1, var>::value
-                                       || std::is_same<T2, var>::value,
-                                   Eigen::Matrix<var, R1, 1> >::type
+                                   || std::is_same<T2, var>::value,
+                               Eigen::Matrix<var, R1, 1> >::type
 rows_dot_product(const Eigen::Matrix<T1, R1, C1>& v1,
                  const Eigen::Matrix<T2, R2, C2>& v2) {
   check_matching_sizes("dot_product", "v1", v1, "v2", v2);

--- a/stan/math/rev/mat/fun/rows_dot_product.hpp
+++ b/stan/math/rev/mat/fun/rows_dot_product.hpp
@@ -10,7 +10,6 @@
 #include <stan/math/rev/mat/fun/typedefs.hpp>
 #include <stan/math/rev/scal/fun/value_of.hpp>
 #include <stan/math/rev/mat/fun/dot_product.hpp>
-#include <boost/utility/enable_if.hpp>
 #include <type_traits>
 #include <vector>
 
@@ -18,7 +17,7 @@ namespace stan {
 namespace math {
 
 template <typename T1, int R1, int C1, typename T2, int R2, int C2>
-inline typename boost::enable_if_c<std::is_same<T1, var>::value
+inline typename std::enable_if<std::is_same<T1, var>::value
                                        || std::is_same<T2, var>::value,
                                    Eigen::Matrix<var, R1, 1> >::type
 rows_dot_product(const Eigen::Matrix<T1, R1, C1>& v1,

--- a/stan/math/rev/mat/fun/trace_gen_inv_quad_form_ldlt.hpp
+++ b/stan/math/rev/mat/fun/trace_gen_inv_quad_form_ldlt.hpp
@@ -20,13 +20,13 @@ namespace math {
  **/
 template <typename T1, int R1, int C1, typename T2, int R2, int C2, typename T3,
           int R3, int C3>
-inline typename std::enable_if<stan::is_var<T1>::value
-                                       || stan::is_var<T2>::value
-                                       || stan::is_var<T3>::value,
-                                   var>::type
-trace_gen_inv_quad_form_ldlt(const Eigen::Matrix<T1, R1, C1> &D,
-                             const LDLT_factor<T2, R2, C2> &A,
-                             const Eigen::Matrix<T3, R3, C3> &B) {
+inline
+    typename std::enable_if<stan::is_var<T1>::value || stan::is_var<T2>::value
+                                || stan::is_var<T3>::value,
+                            var>::type
+    trace_gen_inv_quad_form_ldlt(const Eigen::Matrix<T1, R1, C1> &D,
+                                 const LDLT_factor<T2, R2, C2> &A,
+                                 const Eigen::Matrix<T3, R3, C3> &B) {
   check_square("trace_gen_inv_quad_form_ldlt", "D", D);
   check_multiplicable("trace_gen_inv_quad_form_ldlt", "A", A, "B", B);
   check_multiplicable("trace_gen_inv_quad_form_ldlt", "B", B, "D", D);

--- a/stan/math/rev/mat/fun/trace_gen_inv_quad_form_ldlt.hpp
+++ b/stan/math/rev/mat/fun/trace_gen_inv_quad_form_ldlt.hpp
@@ -5,10 +5,10 @@
 #include <stan/math/rev/core.hpp>
 #include <stan/math/prim/scal/meta/is_var.hpp>
 #include <stan/math/rev/scal/meta/is_var.hpp>
-#include <boost/utility/enable_if.hpp>
 #include <stan/math/prim/mat/err/check_multiplicable.hpp>
 #include <stan/math/prim/mat/err/check_square.hpp>
 #include <stan/math/rev/mat/fun/trace_inv_quad_form_ldlt.hpp>
+#include <type_traits>
 
 namespace stan {
 namespace math {
@@ -20,7 +20,7 @@ namespace math {
  **/
 template <typename T1, int R1, int C1, typename T2, int R2, int C2, typename T3,
           int R3, int C3>
-inline typename boost::enable_if_c<stan::is_var<T1>::value
+inline typename std::enable_if<stan::is_var<T1>::value
                                        || stan::is_var<T2>::value
                                        || stan::is_var<T3>::value,
                                    var>::type

--- a/stan/math/rev/mat/fun/trace_gen_quad_form.hpp
+++ b/stan/math/rev/mat/fun/trace_gen_quad_form.hpp
@@ -94,9 +94,9 @@ class trace_gen_quad_form_vari : public vari {
 template <typename Td, int Rd, int Cd, typename Ta, int Ra, int Ca, typename Tb,
           int Rb, int Cb>
 inline typename std::enable_if<std::is_same<Td, var>::value
-                                       || std::is_same<Ta, var>::value
-                                       || std::is_same<Tb, var>::value,
-                                   var>::type
+                                   || std::is_same<Ta, var>::value
+                                   || std::is_same<Tb, var>::value,
+                               var>::type
 trace_gen_quad_form(const Eigen::Matrix<Td, Rd, Cd>& D,
                     const Eigen::Matrix<Ta, Ra, Ca>& A,
                     const Eigen::Matrix<Tb, Rb, Cb>& B) {

--- a/stan/math/rev/mat/fun/trace_gen_quad_form.hpp
+++ b/stan/math/rev/mat/fun/trace_gen_quad_form.hpp
@@ -1,7 +1,6 @@
 #ifndef STAN_MATH_REV_MAT_FUN_TRACE_GEN_QUAD_FORM_HPP
 #define STAN_MATH_REV_MAT_FUN_TRACE_GEN_QUAD_FORM_HPP
 
-#include <boost/utility/enable_if.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/mat/fun/typedefs.hpp>
 #include <stan/math/rev/core.hpp>
@@ -94,7 +93,7 @@ class trace_gen_quad_form_vari : public vari {
 
 template <typename Td, int Rd, int Cd, typename Ta, int Ra, int Ca, typename Tb,
           int Rb, int Cb>
-inline typename boost::enable_if_c<std::is_same<Td, var>::value
+inline typename std::enable_if<std::is_same<Td, var>::value
                                        || std::is_same<Ta, var>::value
                                        || std::is_same<Tb, var>::value,
                                    var>::type

--- a/stan/math/rev/mat/fun/trace_inv_quad_form_ldlt.hpp
+++ b/stan/math/rev/mat/fun/trace_inv_quad_form_ldlt.hpp
@@ -156,10 +156,11 @@ class trace_inv_quad_form_ldlt_vari : public vari {
  * where the LDLT_factor of A is provided.
  **/
 template <typename T2, int R2, int C2, typename T3, int R3, int C3>
-inline typename std::enable_if<
-    stan::is_var<T2>::value || stan::is_var<T3>::value, var>::type
-trace_inv_quad_form_ldlt(const LDLT_factor<T2, R2, C2> &A,
-                         const Eigen::Matrix<T3, R3, C3> &B) {
+inline
+    typename std::enable_if<stan::is_var<T2>::value || stan::is_var<T3>::value,
+                            var>::type
+    trace_inv_quad_form_ldlt(const LDLT_factor<T2, R2, C2> &A,
+                             const Eigen::Matrix<T3, R3, C3> &B) {
   check_multiplicable("trace_inv_quad_form_ldlt", "A", A, "B", B);
 
   trace_inv_quad_form_ldlt_impl<T2, R2, C2, T3, R3, C3> *impl_

--- a/stan/math/rev/mat/fun/trace_inv_quad_form_ldlt.hpp
+++ b/stan/math/rev/mat/fun/trace_inv_quad_form_ldlt.hpp
@@ -5,9 +5,9 @@
 #include <stan/math/rev/core.hpp>
 #include <stan/math/rev/mat/fun/LDLT_alloc.hpp>
 #include <stan/math/rev/mat/fun/LDLT_factor.hpp>
-#include <boost/utility/enable_if.hpp>
 #include <stan/math/prim/mat/err/check_multiplicable.hpp>
 #include <stan/math/rev/scal/meta/is_var.hpp>
+#include <type_traits>
 
 namespace stan {
 namespace math {
@@ -156,7 +156,7 @@ class trace_inv_quad_form_ldlt_vari : public vari {
  * where the LDLT_factor of A is provided.
  **/
 template <typename T2, int R2, int C2, typename T3, int R3, int C3>
-inline typename boost::enable_if_c<
+inline typename std::enable_if<
     stan::is_var<T2>::value || stan::is_var<T3>::value, var>::type
 trace_inv_quad_form_ldlt(const LDLT_factor<T2, R2, C2> &A,
                          const Eigen::Matrix<T3, R3, C3> &B) {

--- a/stan/math/rev/mat/fun/trace_quad_form.hpp
+++ b/stan/math/rev/mat/fun/trace_quad_form.hpp
@@ -1,7 +1,6 @@
 #ifndef STAN_MATH_REV_MAT_FUN_TRACE_QUAD_FORM_HPP
 #define STAN_MATH_REV_MAT_FUN_TRACE_QUAD_FORM_HPP
 
-#include <boost/utility/enable_if.hpp>
 #include <stan/math/rev/core.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/mat/fun/typedefs.hpp>
@@ -81,7 +80,7 @@ class trace_quad_form_vari : public vari {
 }  // namespace
 
 template <typename Ta, int Ra, int Ca, typename Tb, int Rb, int Cb>
-inline typename boost::enable_if_c<
+inline typename std::enable_if<
     std::is_same<Ta, var>::value || std::is_same<Tb, var>::value, var>::type
 trace_quad_form(const Eigen::Matrix<Ta, Ra, Ca>& A,
                 const Eigen::Matrix<Tb, Rb, Cb>& B) {

--- a/test/prob/beta/beta_test.hpp
+++ b/test/prob/beta/beta_test.hpp
@@ -1,6 +1,5 @@
 // Arguments: Doubles, Doubles, Doubles
 #include <stan/math/prim/scal.hpp>
-#include <boost/utility/enable_if.hpp>
 
 using stan::math::var;
 using std::numeric_limits;

--- a/test/prob/beta_proportion/beta_proportion_test.hpp
+++ b/test/prob/beta_proportion/beta_proportion_test.hpp
@@ -1,6 +1,5 @@
 // Arguments: Doubles, Doubles, Doubles
 #include <stan/math/prim/scal.hpp>
-#include <boost/utility/enable_if.hpp>
 
 using stan::math::var;
 using std::numeric_limits;

--- a/test/prob/normal/normal_cdf_test.hpp
+++ b/test/prob/normal/normal_cdf_test.hpp
@@ -1,6 +1,5 @@
 // Arguments: Doubles, Doubles, Doubles
 #include <stan/math/prim/scal.hpp>
-#include <boost/utility/enable_if.hpp>
 
 using stan::math::var;
 using std::numeric_limits;


### PR DESCRIPTION
## Summary

This PR is the final sequel of my boost cleanup trilogy. The changes are simple, there are 3 different cases: 

- replace `boost::enable_if_c` directly with  [std::enable_if](https://en.cppreference.com/w/cpp/types/enable_if). 

- replace `boost::enable_if` with `std::enable_if` and add an additional `::value` to the first parameter of the type trait

- replace `boost::disable_if` with `std::enable_if`, add an additional `::value` to the first parameter of the type trait and a negation

## Tests

There are no new tests added.

## Side Effects

/

## Checklist

- [x] Math issue #1126 

- [x] Copyright holder: Rok Češnovar, Univ. of Ljubljana

- [x] the basic tests are passing

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
