### PR TITLE
Doxygen: fixes Jenkins so it fails on errors and fixes the current errors

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -123,7 +123,7 @@ pipeline {
                         Dependencies: { sh """#!/bin/bash
                             set -o pipefail
                             make test-math-dependencies 2>&1 | tee dependencies.log""" } ,
-                        Documentation: { sh 'make doxygen' },
+                        Documentation: { sh "make doxygen" },
                     )
                 }
             }


### PR DESCRIPTION
## Summary

When this PR is complete, develop should have no more doxygen errors.

Here are things that are being fixed:

- Jenkins fails on doxygen errors
- ...


## Tests

This PR should show that the PR fails to build. Please provide a link to a failed build when this is available.

## Side Effects

None

## Checklist

- [x] Math issue #1139

- [x] Copyright holder: Generable

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [ ] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [ ] the code is written in idiomatic C++ and changes are documented in the doxygen

- [ ] the new changes are tested
