### PR TITLE
Cleanup anonymous namespace

### DIFF
--- a/stan/math/memory/stack_alloc.hpp
+++ b/stan/math/memory/stack_alloc.hpp
@@ -30,7 +30,7 @@ bool is_aligned(T* ptr, unsigned int bytes_aligned) {
   return (reinterpret_cast<uintptr_t>(ptr) % bytes_aligned) == 0U;
 }
 
-namespace {
+namespace internal{
 const size_t DEFAULT_INITIAL_NBYTES = 1 << 16;  // 64KB
 
 // FIXME: enforce alignment
@@ -47,7 +47,7 @@ inline char* eight_byte_aligned_malloc(size_t size) {
   }
   return ptr;
 }
-}  // namespace
+}  // namespace internal
 
 /**
  * An instance of this class provides a memory pool through
@@ -102,7 +102,7 @@ class stack_alloc {
       size_t newsize = sizes_.back() * 2;
       if (newsize < len)
         newsize = len;
-      blocks_.push_back(eight_byte_aligned_malloc(newsize));
+      blocks_.push_back(internal::eight_byte_aligned_malloc(newsize));
       if (!blocks_.back())
         throw std::bad_alloc();
       sizes_.push_back(newsize);
@@ -125,7 +125,7 @@ class stack_alloc {
    * aligned.
    */
   explicit stack_alloc(size_t initial_nbytes = DEFAULT_INITIAL_NBYTES)
-      : blocks_(1, eight_byte_aligned_malloc(initial_nbytes)),
+      : blocks_(1, internal::eight_byte_aligned_malloc(initial_nbytes)),
         sizes_(1, initial_nbytes),
         cur_block_(0),
         cur_block_end_(blocks_[0] + initial_nbytes),

--- a/stan/math/memory/stack_alloc.hpp
+++ b/stan/math/memory/stack_alloc.hpp
@@ -124,7 +124,7 @@ class stack_alloc {
    * @throws std::runtime_error if the underlying malloc is not 8-byte
    * aligned.
    */
-  explicit stack_alloc(size_t initial_nbytes = DEFAULT_INITIAL_NBYTES)
+  explicit stack_alloc(size_t initial_nbytes = internal::DEFAULT_INITIAL_NBYTES)
       : blocks_(1, internal::eight_byte_aligned_malloc(initial_nbytes)),
         sizes_(1, initial_nbytes),
         cur_block_(0),

--- a/stan/math/memory/stack_alloc.hpp
+++ b/stan/math/memory/stack_alloc.hpp
@@ -30,7 +30,7 @@ bool is_aligned(T* ptr, unsigned int bytes_aligned) {
   return (reinterpret_cast<uintptr_t>(ptr) % bytes_aligned) == 0U;
 }
 
-namespace internal{
+namespace internal {
 const size_t DEFAULT_INITIAL_NBYTES = 1 << 16;  // 64KB
 
 // FIXME: enforce alignment

--- a/stan/math/prim/mat/err/check_finite.hpp
+++ b/stan/math/prim/mat/err/check_finite.hpp
@@ -9,7 +9,7 @@
 
 namespace stan {
 namespace math {
-namespace {
+namespace internal{
 template <typename T, int R, int C>
 struct finite<Eigen::Matrix<T, R, C>, true> {
   static void check(const char* function, const char* name,
@@ -23,7 +23,7 @@ struct finite<Eigen::Matrix<T, R, C>, true> {
     }
   }
 };
-}  // namespace
+}  // namespace internal
 }  // namespace math
 }  // namespace stan
 

--- a/stan/math/prim/mat/err/check_finite.hpp
+++ b/stan/math/prim/mat/err/check_finite.hpp
@@ -9,7 +9,7 @@
 
 namespace stan {
 namespace math {
-namespace internal{
+namespace internal {
 template <typename T, int R, int C>
 struct finite<Eigen::Matrix<T, R, C>, true> {
   static void check(const char* function, const char* name,

--- a/stan/math/prim/mat/fun/autocorrelation.hpp
+++ b/stan/math/prim/mat/fun/autocorrelation.hpp
@@ -10,7 +10,7 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 /**
  * Find the optimal next size for the FFT so that
  * a minimum number of zeros are padded.
@@ -31,7 +31,7 @@ size_t fft_next_good_size(size_t N) {
     N++;
   }
 }
-}  // namespace
+}  // namespace internal
 
 /**
  * Write autocorrelation estimates for every lag for the specified
@@ -60,7 +60,7 @@ void autocorrelation(const std::vector<T>& y, std::vector<T>& ac,
   using std::vector;
 
   size_t N = y.size();
-  size_t M = fft_next_good_size(N);
+  size_t M = internal::fft_next_good_size(N);
   size_t Mt2 = 2 * M;
 
   vector<complex<T> > freqvec;
@@ -111,7 +111,7 @@ template <typename T, typename DerivedA, typename DerivedB>
 void autocorrelation(const Eigen::MatrixBase<DerivedA>& y,
                      Eigen::MatrixBase<DerivedB>& ac, Eigen::FFT<T>& fft) {
   size_t N = y.size();
-  size_t M = fft_next_good_size(N);
+  size_t M = internal::fft_next_good_size(N);
   size_t Mt2 = 2 * M;
 
   // centered_signal = y-mean(y) followed by N zeros

--- a/stan/math/prim/mat/fun/autocorrelation.hpp
+++ b/stan/math/prim/mat/fun/autocorrelation.hpp
@@ -14,7 +14,7 @@ namespace internal {
  * Find the optimal next size for the FFT so that
  * a minimum number of zeros are padded.
  */
-size_t fft_next_good_size(size_t N) {
+inline size_t fft_next_good_size(size_t N) {
   if (N <= 2)
     return 2;
   while (true) {

--- a/stan/math/prim/mat/fun/autocorrelation.hpp
+++ b/stan/math/prim/mat/fun/autocorrelation.hpp
@@ -9,8 +9,7 @@
 
 namespace stan {
 namespace math {
-
-namespace internal{
+namespace internal {
 /**
  * Find the optimal next size for the FFT so that
  * a minimum number of zeros are padded.

--- a/stan/math/prim/mat/fun/resize.hpp
+++ b/stan/math/prim/mat/fun/resize.hpp
@@ -6,7 +6,7 @@
 
 namespace stan {
 namespace math {
-namespace {
+namespace internal{
 template <typename T, int R, int C>
 void resize(Eigen::Matrix<T, R, C>& x, const std::vector<int>& dims, int pos) {
   x.resize(dims[pos], dims[pos + 1]);
@@ -26,7 +26,7 @@ void resize(std::vector<T>& x, const std::vector<int>& dims, int pos) {
   for (size_t i = 0; i < x.size(); ++i)
     resize(x[i], dims, pos);
 }
-}  // namespace
+}  // namespace internal
 
 /**
  * Recursively resize the specified vector of vectors,
@@ -39,7 +39,7 @@ void resize(std::vector<T>& x, const std::vector<int>& dims, int pos) {
  */
 template <typename T>
 inline void resize(T& x, std::vector<int> dims) {
-  resize(x, dims, 0U);
+  internal::resize(x, dims, 0U);
 }
 
 }  // namespace math

--- a/stan/math/prim/mat/fun/resize.hpp
+++ b/stan/math/prim/mat/fun/resize.hpp
@@ -6,7 +6,7 @@
 
 namespace stan {
 namespace math {
-namespace internal{
+namespace internal {
 template <typename T, int R, int C>
 void resize(Eigen::Matrix<T, R, C>& x, const std::vector<int>& dims, int pos) {
   x.resize(dims[pos], dims[pos + 1]);

--- a/stan/math/prim/mat/fun/sort_indices.hpp
+++ b/stan/math/prim/mat/fun/sort_indices.hpp
@@ -27,7 +27,7 @@ class index_comparator {
    * Construct an index comparator holding a reference
    * to the specified container.
    *
-   * @patam xs Container
+   * @param xs Container
    */
   explicit index_comparator(const C& xs) : xs_(xs) {}
 

--- a/stan/math/prim/mat/fun/sort_indices.hpp
+++ b/stan/math/prim/mat/fun/sort_indices.hpp
@@ -17,7 +17,7 @@ namespace math {
  * @tparam ascending true if sorting in ascending order
  * @tparam C container type
  */
-namespace internal{
+namespace internal {
 template <bool ascending, typename C>
 class index_comparator {
   const C& xs_;

--- a/stan/math/prim/mat/fun/sort_indices.hpp
+++ b/stan/math/prim/mat/fun/sort_indices.hpp
@@ -17,7 +17,7 @@ namespace math {
  * @tparam ascending true if sorting in ascending order
  * @tparam C container type
  */
-namespace {
+namespace internal{
 template <bool ascending, typename C>
 class index_comparator {
   const C& xs_;
@@ -47,6 +47,8 @@ class index_comparator {
   }
 };
 
+}  // namespace internal
+
 /**
  * Return an integer array of indices of the specified container
  * sorting the values in ascending or descending order based on
@@ -69,8 +71,6 @@ std::vector<int> sort_indices(const C& xs) {
   std::sort(idxs.begin(), idxs.end(), comparator);
   return idxs;
 }
-
-}  // namespace
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/prim/mat/fun/sort_indices.hpp
+++ b/stan/math/prim/mat/fun/sort_indices.hpp
@@ -67,7 +67,7 @@ std::vector<int> sort_indices(const C& xs) {
   idxs.resize(size);
   for (idx_t i = 0; i < size; ++i)
     idxs[i] = i + 1;
-  index_comparator<ascending, C> comparator(xs);
+  internal::index_comparator<ascending, C> comparator(xs);
   std::sort(idxs.begin(), idxs.end(), comparator);
   return idxs;
 }

--- a/stan/math/prim/scal/err/check_finite.hpp
+++ b/stan/math/prim/scal/err/check_finite.hpp
@@ -11,7 +11,7 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 template <typename T_y, bool is_vec>
 struct finite {
   static void check(const char* function, const char* name, const T_y& y) {
@@ -30,7 +30,7 @@ struct finite<T_y, true> {
     }
   }
 };
-}  // namespace
+}  // namespace internal
 
 /**
  * Check if <code>y</code> is finite.
@@ -49,7 +49,7 @@ struct finite<T_y, true> {
  */
 template <typename T_y>
 inline void check_finite(const char* function, const char* name, const T_y& y) {
-  finite<T_y, is_vector_like<T_y>::value>::check(function, name, y);
+  internal::finite<T_y, is_vector_like<T_y>::value>::check(function, name, y);
 }
 }  // namespace math
 }  // namespace stan

--- a/stan/math/prim/scal/err/check_finite.hpp
+++ b/stan/math/prim/scal/err/check_finite.hpp
@@ -11,7 +11,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 template <typename T_y, bool is_vec>
 struct finite {
   static void check(const char* function, const char* name, const T_y& y) {

--- a/stan/math/prim/scal/err/check_greater.hpp
+++ b/stan/math/prim/scal/err/check_greater.hpp
@@ -12,7 +12,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 template <typename T_y, typename T_low, bool is_vec>
 struct greater {
   static void check(const char* function, const char* name, const T_y& y,
@@ -71,8 +71,8 @@ struct greater<T_y, T_low, true> {
 template <typename T_y, typename T_low>
 inline void check_greater(const char* function, const char* name, const T_y& y,
                           const T_low& low) {
-  internal::greater<T_y, T_low, is_vector_like<T_y>::value>::check(function, name, y,
-                                                         low);
+  internal::greater<T_y, T_low,
+                    is_vector_like<T_y>::value>::check(function, name, y, low);
 }
 }  // namespace math
 }  // namespace stan

--- a/stan/math/prim/scal/err/check_greater.hpp
+++ b/stan/math/prim/scal/err/check_greater.hpp
@@ -12,7 +12,7 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 template <typename T_y, typename T_low, bool is_vec>
 struct greater {
   static void check(const char* function, const char* name, const T_y& y,
@@ -48,7 +48,7 @@ struct greater<T_y, T_low, true> {
     }
   }
 };
-}  // namespace
+}  // namespace internal
 
 /**
  * Check if <code>y</code> is strictly greater
@@ -71,7 +71,7 @@ struct greater<T_y, T_low, true> {
 template <typename T_y, typename T_low>
 inline void check_greater(const char* function, const char* name, const T_y& y,
                           const T_low& low) {
-  greater<T_y, T_low, is_vector_like<T_y>::value>::check(function, name, y,
+  internal::greater<T_y, T_low, is_vector_like<T_y>::value>::check(function, name, y,
                                                          low);
 }
 }  // namespace math

--- a/stan/math/prim/scal/err/check_greater.hpp
+++ b/stan/math/prim/scal/err/check_greater.hpp
@@ -71,8 +71,8 @@ struct greater<T_y, T_low, true> {
 template <typename T_y, typename T_low>
 inline void check_greater(const char* function, const char* name, const T_y& y,
                           const T_low& low) {
-  internal::greater<T_y, T_low,
-                    is_vector_like<T_y>::value>::check(function, name, y, low);
+  internal::greater<T_y, T_low, is_vector_like<T_y>::value>::check(
+      function, name, y, low);
 }
 }  // namespace math
 }  // namespace stan

--- a/stan/math/prim/scal/err/check_greater_or_equal.hpp
+++ b/stan/math/prim/scal/err/check_greater_or_equal.hpp
@@ -11,7 +11,7 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 template <typename T_y, typename T_low, bool is_vec>
 struct greater_or_equal {
   static void check(const char* function, const char* name, const T_y& y,
@@ -48,7 +48,7 @@ struct greater_or_equal<T_y, T_low, true> {
     }
   }
 };
-}  // namespace
+}  // namespace internal
 
 /**
  * Check if <code>y</code> is greater or equal
@@ -71,7 +71,7 @@ struct greater_or_equal<T_y, T_low, true> {
 template <typename T_y, typename T_low>
 inline void check_greater_or_equal(const char* function, const char* name,
                                    const T_y& y, const T_low& low) {
-  greater_or_equal<T_y, T_low, is_vector_like<T_y>::value>::check(function,
+  internal::greater_or_equal<T_y, T_low, is_vector_like<T_y>::value>::check(function,
                                                                   name, y, low);
 }
 }  // namespace math

--- a/stan/math/prim/scal/err/check_greater_or_equal.hpp
+++ b/stan/math/prim/scal/err/check_greater_or_equal.hpp
@@ -71,8 +71,8 @@ struct greater_or_equal<T_y, T_low, true> {
 template <typename T_y, typename T_low>
 inline void check_greater_or_equal(const char* function, const char* name,
                                    const T_y& y, const T_low& low) {
-  internal::greater_or_equal<T_y, T_low,
-    is_vector_like<T_y>::value>::check(function, name, y, low);
+  internal::greater_or_equal<T_y, T_low, is_vector_like<T_y>::value>::check(
+      function, name, y, low);
 }
 }  // namespace math
 }  // namespace stan

--- a/stan/math/prim/scal/err/check_greater_or_equal.hpp
+++ b/stan/math/prim/scal/err/check_greater_or_equal.hpp
@@ -11,7 +11,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 template <typename T_y, typename T_low, bool is_vec>
 struct greater_or_equal {
   static void check(const char* function, const char* name, const T_y& y,
@@ -71,8 +71,8 @@ struct greater_or_equal<T_y, T_low, true> {
 template <typename T_y, typename T_low>
 inline void check_greater_or_equal(const char* function, const char* name,
                                    const T_y& y, const T_low& low) {
-  internal::greater_or_equal<T_y, T_low, is_vector_like<T_y>::value>::check(function,
-                                                                  name, y, low);
+  internal::greater_or_equal<T_y, T_low,
+    is_vector_like<T_y>::value>::check(function, name, y, low);
 }
 }  // namespace math
 }  // namespace stan

--- a/stan/math/prim/scal/err/check_less.hpp
+++ b/stan/math/prim/scal/err/check_less.hpp
@@ -12,7 +12,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 template <typename T_y, typename T_high, bool is_vec>
 struct less {
   static void check(const char* function, const char* name, const T_y& y,
@@ -71,7 +71,8 @@ struct less<T_y, T_high, true> {
 template <typename T_y, typename T_high>
 inline void check_less(const char* function, const char* name, const T_y& y,
                        const T_high& high) {
-  internal::less<T_y, T_high, is_vector_like<T_y>::value>::check(function, name, y, high);
+  internal::less<T_y, T_high,
+   is_vector_like<T_y>::value>::check(function, name, y, high);
 }
 }  // namespace math
 }  // namespace stan

--- a/stan/math/prim/scal/err/check_less.hpp
+++ b/stan/math/prim/scal/err/check_less.hpp
@@ -12,7 +12,7 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 template <typename T_y, typename T_high, bool is_vec>
 struct less {
   static void check(const char* function, const char* name, const T_y& y,
@@ -48,7 +48,7 @@ struct less<T_y, T_high, true> {
     }
   }
 };
-}  // namespace
+}  // namespace internal
 
 /**
  * Check if <code>y</code> is strictly less
@@ -71,7 +71,7 @@ struct less<T_y, T_high, true> {
 template <typename T_y, typename T_high>
 inline void check_less(const char* function, const char* name, const T_y& y,
                        const T_high& high) {
-  less<T_y, T_high, is_vector_like<T_y>::value>::check(function, name, y, high);
+  internal::less<T_y, T_high, is_vector_like<T_y>::value>::check(function, name, y, high);
 }
 }  // namespace math
 }  // namespace stan

--- a/stan/math/prim/scal/err/check_less.hpp
+++ b/stan/math/prim/scal/err/check_less.hpp
@@ -71,8 +71,8 @@ struct less<T_y, T_high, true> {
 template <typename T_y, typename T_high>
 inline void check_less(const char* function, const char* name, const T_y& y,
                        const T_high& high) {
-  internal::less<T_y, T_high,
-   is_vector_like<T_y>::value>::check(function, name, y, high);
+  internal::less<T_y, T_high, is_vector_like<T_y>::value>::check(function, name,
+                                                                 y, high);
 }
 }  // namespace math
 }  // namespace stan

--- a/stan/math/prim/scal/err/check_less_or_equal.hpp
+++ b/stan/math/prim/scal/err/check_less_or_equal.hpp
@@ -71,8 +71,8 @@ struct less_or_equal<T_y, T_high, true> {
 template <typename T_y, typename T_high>
 inline void check_less_or_equal(const char* function, const char* name,
                                 const T_y& y, const T_high& high) {
-  internal::less_or_equal<T_y, T_high,
-          is_vector_like<T_y>::value>::check(function, name, y, high);
+  internal::less_or_equal<T_y, T_high, is_vector_like<T_y>::value>::check(
+      function, name, y, high);
 }
 }  // namespace math
 }  // namespace stan

--- a/stan/math/prim/scal/err/check_less_or_equal.hpp
+++ b/stan/math/prim/scal/err/check_less_or_equal.hpp
@@ -12,7 +12,7 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 template <typename T_y, typename T_high, bool is_vec>
 struct less_or_equal {
   static void check(const char* function, const char* name, const T_y& y,
@@ -48,7 +48,7 @@ struct less_or_equal<T_y, T_high, true> {
     }
   }
 };
-}  // namespace
+}  // namespace internal
 
 /**
  * Check if <code>y</code> is less or equal to
@@ -71,7 +71,7 @@ struct less_or_equal<T_y, T_high, true> {
 template <typename T_y, typename T_high>
 inline void check_less_or_equal(const char* function, const char* name,
                                 const T_y& y, const T_high& high) {
-  less_or_equal<T_y, T_high, is_vector_like<T_y>::value>::check(function, name,
+  internal::less_or_equal<T_y, T_high, is_vector_like<T_y>::value>::check(function, name,
                                                                 y, high);
 }
 }  // namespace math

--- a/stan/math/prim/scal/err/check_less_or_equal.hpp
+++ b/stan/math/prim/scal/err/check_less_or_equal.hpp
@@ -12,7 +12,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 template <typename T_y, typename T_high, bool is_vec>
 struct less_or_equal {
   static void check(const char* function, const char* name, const T_y& y,
@@ -71,8 +71,8 @@ struct less_or_equal<T_y, T_high, true> {
 template <typename T_y, typename T_high>
 inline void check_less_or_equal(const char* function, const char* name,
                                 const T_y& y, const T_high& high) {
-  internal::less_or_equal<T_y, T_high, is_vector_like<T_y>::value>::check(function, name,
-                                                                y, high);
+  internal::less_or_equal<T_y, T_high,
+          is_vector_like<T_y>::value>::check(function, name, y, high);
 }
 }  // namespace math
 }  // namespace stan

--- a/stan/math/prim/scal/err/check_nonnegative.hpp
+++ b/stan/math/prim/scal/err/check_nonnegative.hpp
@@ -34,7 +34,7 @@ struct nonnegative<T_y, true> {
     }
   }
 };
-}  // namespace
+}  // namespace internal
 
 /**
  * Check if <code>y</code> is non-negative.
@@ -54,8 +54,8 @@ struct nonnegative<T_y, true> {
 template <typename T_y>
 inline void check_nonnegative(const char* function, const char* name,
                               const T_y& y) {
-  internal::nonnegative<T_y,
-   is_vector_like<T_y>::value>::check(function, name, y);
+  internal::nonnegative<T_y, is_vector_like<T_y>::value>::check(function, name,
+                                                                y);
 }
 }  // namespace math
 }  // namespace stan

--- a/stan/math/prim/scal/err/check_nonnegative.hpp
+++ b/stan/math/prim/scal/err/check_nonnegative.hpp
@@ -11,7 +11,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 template <typename T_y, bool is_vec>
 struct nonnegative {
   static void check(const char* function, const char* name, const T_y& y) {
@@ -54,7 +54,8 @@ struct nonnegative<T_y, true> {
 template <typename T_y>
 inline void check_nonnegative(const char* function, const char* name,
                               const T_y& y) {
-  internal::nonnegative<T_y, is_vector_like<T_y>::value>::check(function, name, y);
+  internal::nonnegative<T_y,
+   is_vector_like<T_y>::value>::check(function, name, y);
 }
 }  // namespace math
 }  // namespace stan

--- a/stan/math/prim/scal/err/check_nonnegative.hpp
+++ b/stan/math/prim/scal/err/check_nonnegative.hpp
@@ -11,7 +11,7 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 template <typename T_y, bool is_vec>
 struct nonnegative {
   static void check(const char* function, const char* name, const T_y& y) {
@@ -54,7 +54,7 @@ struct nonnegative<T_y, true> {
 template <typename T_y>
 inline void check_nonnegative(const char* function, const char* name,
                               const T_y& y) {
-  nonnegative<T_y, is_vector_like<T_y>::value>::check(function, name, y);
+  internal::nonnegative<T_y, is_vector_like<T_y>::value>::check(function, name, y);
 }
 }  // namespace math
 }  // namespace stan

--- a/stan/math/prim/scal/err/check_not_nan.hpp
+++ b/stan/math/prim/scal/err/check_not_nan.hpp
@@ -11,7 +11,7 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 template <typename T_y, bool is_vec>
 struct not_nan {
   static void check(const char* function, const char* name, const T_y& y) {
@@ -29,7 +29,7 @@ struct not_nan<T_y, true> {
     }
   }
 };
-}  // namespace
+}  // namespace internal
 
 /**
  * Check if <code>y</code> is not
@@ -50,7 +50,7 @@ struct not_nan<T_y, true> {
 template <typename T_y>
 inline void check_not_nan(const char* function, const char* name,
                           const T_y& y) {
-  not_nan<T_y, is_vector_like<T_y>::value>::check(function, name, y);
+  internal::not_nan<T_y, is_vector_like<T_y>::value>::check(function, name, y);
 }
 
 }  // namespace math

--- a/stan/math/prim/scal/err/check_not_nan.hpp
+++ b/stan/math/prim/scal/err/check_not_nan.hpp
@@ -11,7 +11,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 template <typename T_y, bool is_vec>
 struct not_nan {
   static void check(const char* function, const char* name, const T_y& y) {

--- a/stan/math/prim/scal/err/check_positive.hpp
+++ b/stan/math/prim/scal/err/check_positive.hpp
@@ -12,7 +12,7 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 
 template <typename T_y, bool is_vec>
 struct positive {
@@ -36,7 +36,7 @@ struct positive<T_y, true> {
   }
 };
 
-}  // namespace
+}  // namespace internal
 
 /**
  * Check if <code>y</code> is positive.
@@ -56,7 +56,7 @@ struct positive<T_y, true> {
 template <typename T_y>
 inline void check_positive(const char* function, const char* name,
                            const T_y& y) {
-  positive<T_y, is_vector_like<T_y>::value>::check(function, name, y);
+  internal::positive<T_y, is_vector_like<T_y>::value>::check(function, name, y);
 }
 
 }  // namespace math

--- a/stan/math/prim/scal/err/check_positive.hpp
+++ b/stan/math/prim/scal/err/check_positive.hpp
@@ -12,7 +12,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 
 template <typename T_y, bool is_vec>
 struct positive {

--- a/stan/math/prim/scal/meta/scalar_type_pre.hpp
+++ b/stan/math/prim/scal/meta/scalar_type_pre.hpp
@@ -5,7 +5,7 @@
 #include <stan/math/prim/scal/meta/value_type.hpp>
 
 namespace stan {
-namespace internal{
+namespace internal {
 template <bool is_vec, typename T, typename T_container>
 struct scalar_type_helper_pre {
   typedef T_container type;

--- a/stan/math/prim/scal/meta/scalar_type_pre.hpp
+++ b/stan/math/prim/scal/meta/scalar_type_pre.hpp
@@ -5,7 +5,7 @@
 #include <stan/math/prim/scal/meta/value_type.hpp>
 
 namespace stan {
-namespace {
+namespace internal{
 template <bool is_vec, typename T, typename T_container>
 struct scalar_type_helper_pre {
   typedef T_container type;
@@ -18,7 +18,7 @@ struct scalar_type_helper_pre<true, T, T_container> {
       typename stan::math::value_type<T>::type,
       typename stan::math::value_type<T_container>::type>::type type;
 };
-}  // namespace
+}  // namespace internal
 
 /**
  * Metaprogram structure to determine the type of first container of
@@ -28,7 +28,7 @@ struct scalar_type_helper_pre<true, T, T_container> {
  */
 template <typename T>
 struct scalar_type_pre {
-  typedef typename scalar_type_helper_pre<
+  typedef typename internal::scalar_type_helper_pre<
       is_vector<typename stan::math::value_type<T>::type>::value,
       typename stan::math::value_type<T>::type, T>::type type;
 };

--- a/stan/math/rev/arr/fun/log_sum_exp.hpp
+++ b/stan/math/rev/arr/fun/log_sum_exp.hpp
@@ -10,7 +10,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 double log_sum_exp_as_double(const std::vector<var>& x) {
   using std::exp;
   using std::log;

--- a/stan/math/rev/arr/fun/log_sum_exp.hpp
+++ b/stan/math/rev/arr/fun/log_sum_exp.hpp
@@ -10,7 +10,7 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 double log_sum_exp_as_double(const std::vector<var>& x) {
   using std::exp;
   using std::log;
@@ -36,13 +36,13 @@ class log_sum_exp_vector_vari : public op_vector_vari {
     }
   }
 };
-}  // namespace
+}  // namespace internal
 
 /**
  * Returns the log sum of exponentials.
  */
 inline var log_sum_exp(const std::vector<var>& x) {
-  return var(new log_sum_exp_vector_vari(x));
+  return var(new internal::log_sum_exp_vector_vari(x));
 }
 
 }  // namespace math

--- a/stan/math/rev/arr/fun/log_sum_exp.hpp
+++ b/stan/math/rev/arr/fun/log_sum_exp.hpp
@@ -11,7 +11,7 @@ namespace stan {
 namespace math {
 
 namespace internal {
-double log_sum_exp_as_double(const std::vector<var>& x) {
+inline double log_sum_exp_as_double(const std::vector<var>& x) {
   using std::exp;
   using std::log;
   using std::numeric_limits;

--- a/stan/math/rev/core/operator_addition.hpp
+++ b/stan/math/rev/core/operator_addition.hpp
@@ -10,7 +10,7 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 class add_vv_vari : public op_vv_vari {
  public:
   add_vv_vari(vari* avi, vari* bvi)
@@ -36,7 +36,7 @@ class add_vd_vari : public op_vd_vari {
       avi_->adj_ += adj_;
   }
 };
-}  // namespace
+}  // namespace internal
 
 /**
  * Addition operator for variables (C++).
@@ -77,7 +77,7 @@ class add_vd_vari : public op_vd_vari {
  * @return Variable result of adding two variables.
  */
 inline var operator+(const var& a, const var& b) {
-  return var(new add_vv_vari(a.vi_, b.vi_));
+  return var(new internal::add_vv_vari(a.vi_, b.vi_));
 }
 
 /**
@@ -94,7 +94,7 @@ inline var operator+(const var& a, const var& b) {
 inline var operator+(const var& a, double b) {
   if (b == 0.0)
     return a;
-  return var(new add_vd_vari(a.vi_, b));
+  return var(new internal::add_vd_vari(a.vi_, b));
 }
 
 /**
@@ -111,7 +111,7 @@ inline var operator+(const var& a, double b) {
 inline var operator+(double a, const var& b) {
   if (a == 0.0)
     return b;
-  return var(new add_vd_vari(b.vi_, a));  // by symmetry
+  return var(new internal::add_vd_vari(b.vi_, a));  // by symmetry
 }
 
 }  // namespace math

--- a/stan/math/rev/core/operator_addition.hpp
+++ b/stan/math/rev/core/operator_addition.hpp
@@ -10,7 +10,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 class add_vv_vari : public op_vv_vari {
  public:
   add_vv_vari(vari* avi, vari* bvi)

--- a/stan/math/rev/core/operator_divide_equal.hpp
+++ b/stan/math/rev/core/operator_divide_equal.hpp
@@ -8,14 +8,14 @@ namespace stan {
 namespace math {
 
 inline var& var::operator/=(const var& b) {
-  vi_ = new divide_vv_vari(vi_, b.vi_);
+  vi_ = new internal::divide_vv_vari(vi_, b.vi_);
   return *this;
 }
 
 inline var& var::operator/=(double b) {
   if (b == 1.0)
     return *this;
-  vi_ = new divide_vd_vari(vi_, b);
+  vi_ = new internal::divide_vd_vari(vi_, b);
   return *this;
 }
 

--- a/stan/math/rev/core/operator_division.hpp
+++ b/stan/math/rev/core/operator_division.hpp
@@ -11,7 +11,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 // (a/b)' = a' * (1 / b) - b' * (a / [b * b])
 class divide_vv_vari : public op_vv_vari {
  public:

--- a/stan/math/rev/core/operator_division.hpp
+++ b/stan/math/rev/core/operator_division.hpp
@@ -11,7 +11,7 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 // (a/b)' = a' * (1 / b) - b' * (a / [b * b])
 class divide_vv_vari : public op_vv_vari {
  public:
@@ -44,7 +44,7 @@ class divide_dv_vari : public op_dv_vari {
   divide_dv_vari(double a, vari* bvi) : op_dv_vari(a / bvi->val_, a, bvi) {}
   void chain() { bvi_->adj_ -= adj_ * ad_ / (bvi_->val_ * bvi_->val_); }
 };
-}  // namespace
+}  // namespace internal
 
 /**
  * Division operator for two variables (C++).
@@ -85,7 +85,7 @@ class divide_dv_vari : public op_dv_vari {
  * second.
  */
 inline var operator/(const var& a, const var& b) {
-  return var(new divide_vv_vari(a.vi_, b.vi_));
+  return var(new internal::divide_vv_vari(a.vi_, b.vi_));
 }
 
 /**
@@ -102,7 +102,7 @@ inline var operator/(const var& a, const var& b) {
 inline var operator/(const var& a, double b) {
   if (b == 1.0)
     return a;
-  return var(new divide_vd_vari(a.vi_, b));
+  return var(new internal::divide_vd_vari(a.vi_, b));
 }
 
 /**
@@ -117,7 +117,7 @@ inline var operator/(const var& a, double b) {
  * @return Variable result of dividing the scalar by the variable.
  */
 inline var operator/(double a, const var& b) {
-  return var(new divide_dv_vari(a, b.vi_));
+  return var(new internal::divide_dv_vari(a, b.vi_));
 }
 
 }  // namespace math

--- a/stan/math/rev/core/operator_minus_equal.hpp
+++ b/stan/math/rev/core/operator_minus_equal.hpp
@@ -8,14 +8,14 @@ namespace stan {
 namespace math {
 
 inline var& var::operator-=(const var& b) {
-  vi_ = new subtract_vv_vari(vi_, b.vi_);
+  vi_ = new internal::subtract_vv_vari(vi_, b.vi_);
   return *this;
 }
 
 inline var& var::operator-=(double b) {
   if (b == 0.0)
     return *this;
-  vi_ = new subtract_vd_vari(vi_, b);
+  vi_ = new internal::subtract_vd_vari(vi_, b);
   return *this;
 }
 

--- a/stan/math/rev/core/operator_multiplication.hpp
+++ b/stan/math/rev/core/operator_multiplication.hpp
@@ -10,7 +10,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 class multiply_vv_vari : public op_vv_vari {
  public:
   multiply_vv_vari(vari* avi, vari* bvi)

--- a/stan/math/rev/core/operator_multiplication.hpp
+++ b/stan/math/rev/core/operator_multiplication.hpp
@@ -10,7 +10,7 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 class multiply_vv_vari : public op_vv_vari {
  public:
   multiply_vv_vari(vari* avi, vari* bvi)
@@ -36,7 +36,7 @@ class multiply_vd_vari : public op_vd_vari {
       avi_->adj_ += adj_ * bd_;
   }
 };
-}  // namespace
+}  // namespace internal
 
 /**
  * Multiplication operator for two variables (C++).
@@ -76,7 +76,7 @@ class multiply_vd_vari : public op_vd_vari {
  * @return Variable result of multiplying operands.
  */
 inline var operator*(const var& a, const var& b) {
-  return var(new multiply_vv_vari(a.vi_, b.vi_));
+  return var(new internal::multiply_vv_vari(a.vi_, b.vi_));
 }
 
 /**
@@ -93,7 +93,7 @@ inline var operator*(const var& a, const var& b) {
 inline var operator*(const var& a, double b) {
   if (b == 1.0)
     return a;
-  return var(new multiply_vd_vari(a.vi_, b));
+  return var(new internal::multiply_vd_vari(a.vi_, b));
 }
 
 /**
@@ -110,7 +110,7 @@ inline var operator*(const var& a, double b) {
 inline var operator*(double a, const var& b) {
   if (a == 1.0)
     return b;
-  return var(new multiply_vd_vari(b.vi_, a));  // by symmetry
+  return var(new internal::multiply_vd_vari(b.vi_, a));  // by symmetry
 }
 
 }  // namespace math

--- a/stan/math/rev/core/operator_multiply_equal.hpp
+++ b/stan/math/rev/core/operator_multiply_equal.hpp
@@ -8,14 +8,14 @@ namespace stan {
 namespace math {
 
 inline var& var::operator*=(const var& b) {
-  vi_ = new multiply_vv_vari(vi_, b.vi_);
+  vi_ = new internal::multiply_vv_vari(vi_, b.vi_);
   return *this;
 }
 
 inline var& var::operator*=(double b) {
   if (b == 1.0)
     return *this;
-  vi_ = new multiply_vd_vari(vi_, b);
+  vi_ = new internal::multiply_vd_vari(vi_, b);
   return *this;
 }
 

--- a/stan/math/rev/core/operator_plus_equal.hpp
+++ b/stan/math/rev/core/operator_plus_equal.hpp
@@ -8,14 +8,14 @@ namespace stan {
 namespace math {
 
 inline var& var::operator+=(const var& b) {
-  vi_ = new add_vv_vari(vi_, b.vi_);
+  vi_ = new internal::add_vv_vari(vi_, b.vi_);
   return *this;
 }
 
 inline var& var::operator+=(double b) {
   if (b == 0.0)
     return *this;
-  vi_ = new add_vd_vari(vi_, b);
+  vi_ = new internal::add_vd_vari(vi_, b);
   return *this;
 }
 

--- a/stan/math/rev/core/operator_subtraction.hpp
+++ b/stan/math/rev/core/operator_subtraction.hpp
@@ -11,7 +11,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 class subtract_vv_vari : public op_vv_vari {
  public:
   subtract_vv_vari(vari* avi, vari* bvi)

--- a/stan/math/rev/core/operator_subtraction.hpp
+++ b/stan/math/rev/core/operator_subtraction.hpp
@@ -11,7 +11,7 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 class subtract_vv_vari : public op_vv_vari {
  public:
   subtract_vv_vari(vari* avi, vari* bvi)
@@ -48,7 +48,7 @@ class subtract_dv_vari : public op_dv_vari {
       bvi_->adj_ -= adj_;
   }
 };
-}  // namespace
+}  // namespace internal
 
 /**
  * Subtraction operator for variables (C++).
@@ -89,7 +89,7 @@ class subtract_dv_vari : public op_dv_vari {
  * the first.
  */
 inline var operator-(const var& a, const var& b) {
-  return var(new subtract_vv_vari(a.vi_, b.vi_));
+  return var(new internal::subtract_vv_vari(a.vi_, b.vi_));
 }
 
 /**
@@ -106,7 +106,7 @@ inline var operator-(const var& a, const var& b) {
 inline var operator-(const var& a, double b) {
   if (b == 0.0)
     return a;
-  return var(new subtract_vd_vari(a.vi_, b));
+  return var(new internal::subtract_vd_vari(a.vi_, b));
 }
 
 /**
@@ -121,7 +121,7 @@ inline var operator-(const var& a, double b) {
  * @return Result of sutracting a variable from a scalar.
  */
 inline var operator-(double a, const var& b) {
-  return var(new subtract_dv_vari(a, b.vi_));
+  return var(new internal::subtract_dv_vari(a, b.vi_));
 }
 
 }  // namespace math

--- a/stan/math/rev/core/operator_unary_decrement.hpp
+++ b/stan/math/rev/core/operator_unary_decrement.hpp
@@ -9,7 +9,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 class decrement_vari : public op_v_vari {
  public:
   explicit decrement_vari(vari* avi) : op_v_vari(avi->val_ - 1.0, avi) {}

--- a/stan/math/rev/core/operator_unary_decrement.hpp
+++ b/stan/math/rev/core/operator_unary_decrement.hpp
@@ -9,7 +9,7 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 class decrement_vari : public op_v_vari {
  public:
   explicit decrement_vari(vari* avi) : op_v_vari(avi->val_ - 1.0, avi) {}
@@ -36,7 +36,7 @@ class decrement_vari : public op_v_vari {
  * @return Reference the result of decrementing this input variable.
  */
 inline var& operator--(var& a) {
-  a.vi_ = new decrement_vari(a.vi_);
+  a.vi_ = new internal::decrement_vari(a.vi_);
   return a;
 }
 
@@ -53,7 +53,7 @@ inline var& operator--(var& a) {
  */
 inline var operator--(var& a, int /*dummy*/) {
   var temp(a);
-  a.vi_ = new decrement_vari(a.vi_);
+  a.vi_ = new internal::decrement_vari(a.vi_);
   return temp;
 }
 

--- a/stan/math/rev/core/operator_unary_decrement.hpp
+++ b/stan/math/rev/core/operator_unary_decrement.hpp
@@ -20,7 +20,7 @@ class decrement_vari : public op_v_vari {
       avi_->adj_ += adj_;
   }
 };
-}  // namespace
+}  // namespace internal
 
 /**
  * Prefix decrement operator for variables (C++).

--- a/stan/math/rev/core/operator_unary_increment.hpp
+++ b/stan/math/rev/core/operator_unary_increment.hpp
@@ -9,7 +9,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 class increment_vari : public op_v_vari {
  public:
   explicit increment_vari(vari* avi) : op_v_vari(avi->val_ + 1.0, avi) {}

--- a/stan/math/rev/core/operator_unary_increment.hpp
+++ b/stan/math/rev/core/operator_unary_increment.hpp
@@ -9,7 +9,7 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 class increment_vari : public op_v_vari {
  public:
   explicit increment_vari(vari* avi) : op_v_vari(avi->val_ + 1.0, avi) {}
@@ -20,7 +20,7 @@ class increment_vari : public op_v_vari {
       avi_->adj_ += adj_;
   }
 };
-}  // namespace
+}  // namespace internal
 
 /**
  * Prefix increment operator for variables (C++).  Following C++,
@@ -32,7 +32,7 @@ class increment_vari : public op_v_vari {
  * @return Reference the result of incrementing this input variable.
  */
 inline var& operator++(var& a) {
-  a.vi_ = new increment_vari(a.vi_);
+  a.vi_ = new internal::increment_vari(a.vi_);
   return a;
 }
 
@@ -49,7 +49,7 @@ inline var& operator++(var& a) {
  */
 inline var operator++(var& a, int /*dummy*/) {
   var temp(a);
-  a.vi_ = new increment_vari(a.vi_);
+  a.vi_ = new internal::increment_vari(a.vi_);
   return temp;
 }
 

--- a/stan/math/rev/core/operator_unary_negative.hpp
+++ b/stan/math/rev/core/operator_unary_negative.hpp
@@ -9,7 +9,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 class neg_vari : public op_v_vari {
  public:
   explicit neg_vari(vari* avi) : op_v_vari(-(avi->val_), avi) {}
@@ -46,7 +46,9 @@ class neg_vari : public op_v_vari {
  * @param a Argument variable.
  * @return Negation of variable.
  */
-inline var operator-(const var& a) { return var(new internal::neg_vari(a.vi_)); }
+inline var operator-(const var& a) {
+  return var(new internal::neg_vari(a.vi_));
+}
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/rev/core/operator_unary_negative.hpp
+++ b/stan/math/rev/core/operator_unary_negative.hpp
@@ -9,7 +9,7 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 class neg_vari : public op_v_vari {
  public:
   explicit neg_vari(vari* avi) : op_v_vari(-(avi->val_), avi) {}
@@ -20,7 +20,7 @@ class neg_vari : public op_v_vari {
       avi_->adj_ -= adj_;
   }
 };
-}  // namespace
+}  // namespace internal
 
 /**
  * Unary negation operator for variables (C++).
@@ -46,7 +46,7 @@ class neg_vari : public op_v_vari {
  * @param a Argument variable.
  * @return Negation of variable.
  */
-inline var operator-(const var& a) { return var(new neg_vari(a.vi_)); }
+inline var operator-(const var& a) { return var(new internal::neg_vari(a.vi_)); }
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/rev/mat/fun/columns_dot_product.hpp
+++ b/stan/math/rev/mat/fun/columns_dot_product.hpp
@@ -25,7 +25,7 @@ columns_dot_product(const Eigen::Matrix<T1, R1, C1>& v1,
   check_matching_sizes("dot_product", "v1", v1, "v2", v2);
   Eigen::Matrix<var, 1, C1> ret(1, v1.cols());
   for (size_type j = 0; j < v1.cols(); ++j) {
-    ret(j) = var(new dot_product_vari<T1, T2>(v1.col(j), v2.col(j)));
+    ret(j) = var(new internal::dot_product_vari<T1, T2>(v1.col(j), v2.col(j)));
   }
   return ret;
 }

--- a/stan/math/rev/mat/fun/columns_dot_self.hpp
+++ b/stan/math/rev/mat/fun/columns_dot_self.hpp
@@ -22,7 +22,7 @@ inline Eigen::Matrix<var, 1, C> columns_dot_self(
     const Eigen::Matrix<var, R, C>& x) {
   Eigen::Matrix<var, 1, C> ret(1, x.cols());
   for (size_type i = 0; i < x.cols(); i++) {
-    ret(i) = var(new dot_self_vari(x.col(i)));
+    ret(i) = var(new internal::dot_self_vari(x.col(i)));
   }
   return ret;
 }

--- a/stan/math/rev/mat/fun/determinant.hpp
+++ b/stan/math/rev/mat/fun/determinant.hpp
@@ -11,7 +11,7 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 template <int R, int C>
 class determinant_vari : public vari {
   int rows_;
@@ -58,12 +58,12 @@ class determinant_vari : public vari {
     }
   }
 };
-}  // namespace
+}  // namespace internal
 
 template <int R, int C>
 inline var determinant(const Eigen::Matrix<var, R, C>& m) {
   check_square("determinant", "m", m);
-  return var(new determinant_vari<R, C>(m));
+  return var(new internal::determinant_vari<R, C>(m));
 }
 
 }  // namespace math

--- a/stan/math/rev/mat/fun/determinant.hpp
+++ b/stan/math/rev/mat/fun/determinant.hpp
@@ -11,7 +11,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 template <int R, int C>
 class determinant_vari : public vari {
   int rows_;

--- a/stan/math/rev/mat/fun/dot_product.hpp
+++ b/stan/math/rev/mat/fun/dot_product.hpp
@@ -15,7 +15,7 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 template <typename T>
 struct dot_product_store_type;
 
@@ -184,7 +184,7 @@ class dot_product_vari : public vari {
   }
   virtual void chain() { chain(v1_, v2_); }
 };
-}  // namespace
+}  // namespace internal
 
 /**
  * Returns the dot product.
@@ -202,7 +202,7 @@ dot_product(const Eigen::Matrix<T1, R1, C1>& v1,
   check_vector("dot_product", "v1", v1);
   check_vector("dot_product", "v2", v2);
   check_matching_sizes("dot_product", "v1", v1, "v2", v2);
-  return var(new dot_product_vari<T1, T2>(v1, v2));
+  return var(new internal::dot_product_vari<T1, T2>(v1, v2));
 }
 /**
  * Returns the dot product.
@@ -216,7 +216,7 @@ template <typename T1, typename T2>
 inline typename std::enable_if<
     std::is_same<T1, var>::value || std::is_same<T2, var>::value, var>::type
 dot_product(const T1* v1, const T2* v2, size_t length) {
-  return var(new dot_product_vari<T1, T2>(v1, v2, length));
+  return var(new internal::dot_product_vari<T1, T2>(v1, v2, length));
 }
 
 /**
@@ -232,7 +232,7 @@ inline typename std::enable_if<
     std::is_same<T1, var>::value || std::is_same<T2, var>::value, var>::type
 dot_product(const std::vector<T1>& v1, const std::vector<T2>& v2) {
   check_matching_sizes("dot_product", "v1", v1, "v2", v2);
-  return var(new dot_product_vari<T1, T2>(&v1[0], &v2[0], v1.size()));
+  return var(new internal::dot_product_vari<T1, T2>(&v1[0], &v2[0], v1.size()));
 }
 
 }  // namespace math

--- a/stan/math/rev/mat/fun/dot_product.hpp
+++ b/stan/math/rev/mat/fun/dot_product.hpp
@@ -15,7 +15,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 template <typename T>
 struct dot_product_store_type;
 

--- a/stan/math/rev/mat/fun/dot_self.hpp
+++ b/stan/math/rev/mat/fun/dot_self.hpp
@@ -11,7 +11,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 class dot_self_vari : public vari {
  protected:
   vari** v_;

--- a/stan/math/rev/mat/fun/dot_self.hpp
+++ b/stan/math/rev/mat/fun/dot_self.hpp
@@ -11,7 +11,7 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 class dot_self_vari : public vari {
  protected:
   vari** v_;
@@ -62,7 +62,7 @@ class dot_self_vari : public vari {
       v_[i]->adj_ += adj_ * 2.0 * v_[i]->val_;
   }
 };
-}  // namespace
+}  // namespace internal
 /**
  * Returns the dot product of a vector with itself.
  *
@@ -76,7 +76,7 @@ class dot_self_vari : public vari {
 template <int R, int C>
 inline var dot_self(const Eigen::Matrix<var, R, C>& v) {
   check_vector("dot_self", "v", v);
-  return var(new dot_self_vari(v));
+  return var(new internal::dot_self_vari(v));
 }
 
 }  // namespace math

--- a/stan/math/rev/mat/fun/log_determinant_ldlt.hpp
+++ b/stan/math/rev/mat/fun/log_determinant_ldlt.hpp
@@ -8,7 +8,7 @@
 
 namespace stan {
 namespace math {
-namespace {
+namespace internal{
 
 /**
  * Returns the log det of the matrix whose LDLT factorization is given
@@ -41,11 +41,11 @@ class log_det_ldlt_vari : public vari {
 
   const LDLT_alloc<R, C> *alloc_ldlt_;
 };
-}  // namespace
+}  // namespace internal
 
 template <int R, int C>
 var log_determinant_ldlt(LDLT_factor<var, R, C> &A) {
-  return var(new log_det_ldlt_vari<R, C>(A));
+  return var(new internal::log_det_ldlt_vari<R, C>(A));
 }
 
 }  // namespace math

--- a/stan/math/rev/mat/fun/log_determinant_ldlt.hpp
+++ b/stan/math/rev/mat/fun/log_determinant_ldlt.hpp
@@ -8,7 +8,7 @@
 
 namespace stan {
 namespace math {
-namespace internal{
+namespace internal {
 
 /**
  * Returns the log det of the matrix whose LDLT factorization is given

--- a/stan/math/rev/mat/fun/log_softmax.hpp
+++ b/stan/math/rev/mat/fun/log_softmax.hpp
@@ -12,7 +12,7 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 
 class log_softmax_elt_vari : public vari {
  private:
@@ -39,7 +39,7 @@ class log_softmax_elt_vari : public vari {
   }
 };
 
-}  // namespace
+}  // namespace internal
 
 /**
  * Return the softmax of the specified Eigen vector.  Softmax is
@@ -100,7 +100,7 @@ inline Eigen::Matrix<var, Eigen::Dynamic, 1> log_softmax(
   Matrix<var, Dynamic, 1> log_softmax_alpha(alpha.size());
   for (int k = 0; k < log_softmax_alpha.size(); ++k)
     log_softmax_alpha(k)
-        = var(new log_softmax_elt_vari(log_softmax_alpha_d[k], alpha_vi_array,
+        = var(new internal::log_softmax_elt_vari(log_softmax_alpha_d[k], alpha_vi_array,
                                        softmax_alpha_d_array, alpha.size(), k));
   return log_softmax_alpha;
 }

--- a/stan/math/rev/mat/fun/log_softmax.hpp
+++ b/stan/math/rev/mat/fun/log_softmax.hpp
@@ -99,9 +99,9 @@ inline Eigen::Matrix<var, Eigen::Dynamic, 1> log_softmax(
 
   Matrix<var, Dynamic, 1> log_softmax_alpha(alpha.size());
   for (int k = 0; k < log_softmax_alpha.size(); ++k)
-    log_softmax_alpha(k)
-        = var(new internal::log_softmax_elt_vari(log_softmax_alpha_d[k],
-                   alpha_vi_array, softmax_alpha_d_array, alpha.size(), k));
+    log_softmax_alpha(k) = var(new internal::log_softmax_elt_vari(
+        log_softmax_alpha_d[k], alpha_vi_array, softmax_alpha_d_array,
+        alpha.size(), k));
   return log_softmax_alpha;
 }
 

--- a/stan/math/rev/mat/fun/log_softmax.hpp
+++ b/stan/math/rev/mat/fun/log_softmax.hpp
@@ -12,7 +12,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 
 class log_softmax_elt_vari : public vari {
  private:
@@ -100,8 +100,8 @@ inline Eigen::Matrix<var, Eigen::Dynamic, 1> log_softmax(
   Matrix<var, Dynamic, 1> log_softmax_alpha(alpha.size());
   for (int k = 0; k < log_softmax_alpha.size(); ++k)
     log_softmax_alpha(k)
-        = var(new internal::log_softmax_elt_vari(log_softmax_alpha_d[k], alpha_vi_array,
-                                       softmax_alpha_d_array, alpha.size(), k));
+        = var(new internal::log_softmax_elt_vari(log_softmax_alpha_d[k],
+                   alpha_vi_array, softmax_alpha_d_array, alpha.size(), k));
   return log_softmax_alpha;
 }
 

--- a/stan/math/rev/mat/fun/log_sum_exp.hpp
+++ b/stan/math/rev/mat/fun/log_sum_exp.hpp
@@ -10,7 +10,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 
 // these function and the following class just translate
 // log_sum_exp for std::vector for Eigen::Matrix

--- a/stan/math/rev/mat/fun/log_sum_exp.hpp
+++ b/stan/math/rev/mat/fun/log_sum_exp.hpp
@@ -10,7 +10,7 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 
 // these function and the following class just translate
 // log_sum_exp for std::vector for Eigen::Matrix
@@ -42,7 +42,7 @@ class log_sum_exp_matrix_vari : public op_matrix_vari {
     }
   }
 };
-}  // namespace
+}  // namespace internal
 
 /**
  * Returns the log sum of exponentials.
@@ -51,7 +51,7 @@ class log_sum_exp_matrix_vari : public op_matrix_vari {
  */
 template <int R, int C>
 inline var log_sum_exp(const Eigen::Matrix<var, R, C>& x) {
-  return var(new log_sum_exp_matrix_vari(x));
+  return var(new internal::log_sum_exp_matrix_vari(x));
 }
 
 }  // namespace math

--- a/stan/math/rev/mat/fun/log_sum_exp.hpp
+++ b/stan/math/rev/mat/fun/log_sum_exp.hpp
@@ -16,7 +16,7 @@ namespace internal {
 // log_sum_exp for std::vector for Eigen::Matrix
 
 template <int R, int C>
-double log_sum_exp_as_double(const Eigen::Matrix<var, R, C>& x) {
+inline double log_sum_exp_as_double(const Eigen::Matrix<var, R, C>& x) {
   using std::exp;
   using std::log;
   using std::numeric_limits;

--- a/stan/math/rev/mat/fun/mdivide_left.hpp
+++ b/stan/math/rev/mat/fun/mdivide_left.hpp
@@ -12,7 +12,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 template <int R1, int C1, int R2, int C2>
 class mdivide_left_vv_vari : public vari {
  public:

--- a/stan/math/rev/mat/fun/mdivide_left.hpp
+++ b/stan/math/rev/mat/fun/mdivide_left.hpp
@@ -12,7 +12,7 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 template <int R1, int C1, int R2, int C2>
 class mdivide_left_vv_vari : public vari {
  public:
@@ -267,7 +267,7 @@ class mdivide_left_vd_vari : public vari {
         variRefA_[pos++]->adj_ += adjA(i, j);
   }
 };
-}  // namespace
+}  // namespace internal
 
 template <int R1, int C1, int R2, int C2>
 inline Eigen::Matrix<var, R1, C2> mdivide_left(
@@ -281,8 +281,8 @@ inline Eigen::Matrix<var, R1, C2> mdivide_left(
   // expression graph to evaluate the adjoint, but is not needed
   // for the returned matrix.  Memory will be cleaned up with the
   // arena allocator.
-  mdivide_left_vv_vari<R1, C1, R2, C2> *baseVari
-      = new mdivide_left_vv_vari<R1, C1, R2, C2>(A, b);
+  internal::mdivide_left_vv_vari<R1, C1, R2, C2> *baseVari
+      = new internal::mdivide_left_vv_vari<R1, C1, R2, C2>(A, b);
 
   size_t pos = 0;
   for (size_type j = 0; j < res.cols(); j++)
@@ -305,8 +305,8 @@ inline Eigen::Matrix<var, R1, C2> mdivide_left(
   // expression graph to evaluate the adjoint, but is not needed
   // for the returned matrix.  Memory will be cleaned up with the
   // arena allocator.
-  mdivide_left_vd_vari<R1, C1, R2, C2> *baseVari
-      = new mdivide_left_vd_vari<R1, C1, R2, C2>(A, b);
+  internal::mdivide_left_vd_vari<R1, C1, R2, C2> *baseVari
+      = new internal::mdivide_left_vd_vari<R1, C1, R2, C2>(A, b);
 
   size_t pos = 0;
   for (size_type j = 0; j < res.cols(); j++)
@@ -329,8 +329,8 @@ inline Eigen::Matrix<var, R1, C2> mdivide_left(
   // expression graph to evaluate the adjoint, but is not needed
   // for the returned matrix.  Memory will be cleaned up with the
   // arena allocator.
-  mdivide_left_dv_vari<R1, C1, R2, C2> *baseVari
-      = new mdivide_left_dv_vari<R1, C1, R2, C2>(A, b);
+  internal::mdivide_left_dv_vari<R1, C1, R2, C2> *baseVari
+      = new internal::mdivide_left_dv_vari<R1, C1, R2, C2>(A, b);
 
   size_t pos = 0;
   for (size_type j = 0; j < res.cols(); j++)

--- a/stan/math/rev/mat/fun/mdivide_left_ldlt.hpp
+++ b/stan/math/rev/mat/fun/mdivide_left_ldlt.hpp
@@ -9,7 +9,7 @@
 
 namespace stan {
 namespace math {
-namespace {
+namespace internal{
 template <int R1, int C1, int R2, int C2>
 class mdivide_left_ldlt_alloc : public chainable_alloc {
  public:
@@ -231,7 +231,7 @@ class mdivide_left_ldlt_vd_vari : public vari {
         alloc_ldlt_->variA_(i, j)->adj_ += adjA(i, j);
   }
 };
-}  // namespace
+}  // namespace internal
 
 /**
  * Returns the solution of the system Ax=b given an LDLT_factor of A
@@ -247,8 +247,8 @@ inline Eigen::Matrix<var, R1, C2> mdivide_left_ldlt(
 
   check_multiplicable("mdivide_left_ldlt", "A", A, "b", b);
 
-  mdivide_left_ldlt_vv_vari<R1, C1, R2, C2> *baseVari
-      = new mdivide_left_ldlt_vv_vari<R1, C1, R2, C2>(A, b);
+  internal::mdivide_left_ldlt_vv_vari<R1, C1, R2, C2> *baseVari
+      = new internal::mdivide_left_ldlt_vv_vari<R1, C1, R2, C2>(A, b);
 
   int pos = 0;
   for (int j = 0; j < res.cols(); j++)
@@ -272,8 +272,8 @@ inline Eigen::Matrix<var, R1, C2> mdivide_left_ldlt(
 
   check_multiplicable("mdivide_left_ldlt", "A", A, "b", b);
 
-  mdivide_left_ldlt_vd_vari<R1, C1, R2, C2> *baseVari
-      = new mdivide_left_ldlt_vd_vari<R1, C1, R2, C2>(A, b);
+  internal::mdivide_left_ldlt_vd_vari<R1, C1, R2, C2> *baseVari
+      = new internal::mdivide_left_ldlt_vd_vari<R1, C1, R2, C2>(A, b);
 
   int pos = 0;
   for (int j = 0; j < res.cols(); j++)
@@ -297,8 +297,8 @@ inline Eigen::Matrix<var, R1, C2> mdivide_left_ldlt(
 
   check_multiplicable("mdivide_left_ldlt", "A", A, "b", b);
 
-  mdivide_left_ldlt_dv_vari<R1, C1, R2, C2> *baseVari
-      = new mdivide_left_ldlt_dv_vari<R1, C1, R2, C2>(A, b);
+  internal::mdivide_left_ldlt_dv_vari<R1, C1, R2, C2> *baseVari
+      = new internal::mdivide_left_ldlt_dv_vari<R1, C1, R2, C2>(A, b);
 
   int pos = 0;
   for (int j = 0; j < res.cols(); j++)

--- a/stan/math/rev/mat/fun/mdivide_left_ldlt.hpp
+++ b/stan/math/rev/mat/fun/mdivide_left_ldlt.hpp
@@ -9,7 +9,7 @@
 
 namespace stan {
 namespace math {
-namespace internal{
+namespace internal {
 template <int R1, int C1, int R2, int C2>
 class mdivide_left_ldlt_alloc : public chainable_alloc {
  public:

--- a/stan/math/rev/mat/fun/mdivide_left_spd.hpp
+++ b/stan/math/rev/mat/fun/mdivide_left_spd.hpp
@@ -12,7 +12,7 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 template <int R1, int C1, int R2, int C2>
 class mdivide_left_spd_alloc : public chainable_alloc {
  public:
@@ -240,7 +240,7 @@ class mdivide_left_spd_vd_vari : public vari {
         variRefA_[pos++]->adj_ += adjA(i, j);
   }
 };
-}  // namespace
+}  // namespace internal
 
 template <int R1, int C1, int R2, int C2>
 inline Eigen::Matrix<var, R1, C2> mdivide_left_spd(
@@ -254,8 +254,8 @@ inline Eigen::Matrix<var, R1, C2> mdivide_left_spd(
   // expression graph to evaluate the adjoint, but is not needed
   // for the returned matrix.  Memory will be cleaned up with the
   // arena allocator.
-  mdivide_left_spd_vv_vari<R1, C1, R2, C2> *baseVari
-      = new mdivide_left_spd_vv_vari<R1, C1, R2, C2>(A, b);
+  internal::mdivide_left_spd_vv_vari<R1, C1, R2, C2> *baseVari
+      = new internal::mdivide_left_spd_vv_vari<R1, C1, R2, C2>(A, b);
 
   size_t pos = 0;
   for (size_type j = 0; j < res.cols(); j++)
@@ -278,8 +278,8 @@ inline Eigen::Matrix<var, R1, C2> mdivide_left_spd(
   // expression graph to evaluate the adjoint, but is not needed
   // for the returned matrix.  Memory will be cleaned up with the
   // arena allocator.
-  mdivide_left_spd_vd_vari<R1, C1, R2, C2> *baseVari
-      = new mdivide_left_spd_vd_vari<R1, C1, R2, C2>(A, b);
+  internal::mdivide_left_spd_vd_vari<R1, C1, R2, C2> *baseVari
+      = new internal::mdivide_left_spd_vd_vari<R1, C1, R2, C2>(A, b);
 
   size_t pos = 0;
   for (size_type j = 0; j < res.cols(); j++)
@@ -302,8 +302,8 @@ inline Eigen::Matrix<var, R1, C2> mdivide_left_spd(
   // expression graph to evaluate the adjoint, but is not needed
   // for the returned matrix.  Memory will be cleaned up with the
   // arena allocator.
-  mdivide_left_spd_dv_vari<R1, C1, R2, C2> *baseVari
-      = new mdivide_left_spd_dv_vari<R1, C1, R2, C2>(A, b);
+  internal::mdivide_left_spd_dv_vari<R1, C1, R2, C2> *baseVari
+      = new internal::mdivide_left_spd_dv_vari<R1, C1, R2, C2>(A, b);
 
   size_t pos = 0;
   for (size_type j = 0; j < res.cols(); j++)

--- a/stan/math/rev/mat/fun/mdivide_left_spd.hpp
+++ b/stan/math/rev/mat/fun/mdivide_left_spd.hpp
@@ -12,7 +12,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 template <int R1, int C1, int R2, int C2>
 class mdivide_left_spd_alloc : public chainable_alloc {
  public:

--- a/stan/math/rev/mat/fun/mdivide_left_tri.hpp
+++ b/stan/math/rev/mat/fun/mdivide_left_tri.hpp
@@ -12,7 +12,7 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 template <int TriView, int R1, int C1, int R2, int C2>
 class mdivide_left_tri_vv_vari : public vari {
  public:
@@ -305,7 +305,7 @@ class mdivide_left_tri_vd_vari : public vari {
     }
   }
 };
-}  // namespace
+}  // namespace internal
 
 template <int TriView, int R1, int C1, int R2, int C2>
 inline Eigen::Matrix<var, R1, C2> mdivide_left_tri(
@@ -319,8 +319,8 @@ inline Eigen::Matrix<var, R1, C2> mdivide_left_tri(
   // expression graph to evaluate the adjoint, but is not needed
   // for the returned matrix.  Memory will be cleaned up with the
   // arena allocator.
-  mdivide_left_tri_vv_vari<TriView, R1, C1, R2, C2> *baseVari
-      = new mdivide_left_tri_vv_vari<TriView, R1, C1, R2, C2>(A, b);
+  internal::mdivide_left_tri_vv_vari<TriView, R1, C1, R2, C2> *baseVari
+      = new internal::mdivide_left_tri_vv_vari<TriView, R1, C1, R2, C2>(A, b);
 
   size_t pos = 0;
   for (size_type j = 0; j < res.cols(); j++)
@@ -342,8 +342,8 @@ inline Eigen::Matrix<var, R1, C2> mdivide_left_tri(
   // expression graph to evaluate the adjoint, but is not needed
   // for the returned matrix.  Memory will be cleaned up with the
   // arena allocator.
-  mdivide_left_tri_dv_vari<TriView, R1, C1, R2, C2> *baseVari
-      = new mdivide_left_tri_dv_vari<TriView, R1, C1, R2, C2>(A, b);
+  internal::mdivide_left_tri_dv_vari<TriView, R1, C1, R2, C2> *baseVari
+      = new internal::mdivide_left_tri_dv_vari<TriView, R1, C1, R2, C2>(A, b);
 
   size_t pos = 0;
   for (size_type j = 0; j < res.cols(); j++)
@@ -365,8 +365,8 @@ inline Eigen::Matrix<var, R1, C2> mdivide_left_tri(
   // expression graph to evaluate the adjoint, but is not needed
   // for the returned matrix.  Memory will be cleaned up with the
   // arena allocator.
-  mdivide_left_tri_vd_vari<TriView, R1, C1, R2, C2> *baseVari
-      = new mdivide_left_tri_vd_vari<TriView, R1, C1, R2, C2>(A, b);
+  internal::mdivide_left_tri_vd_vari<TriView, R1, C1, R2, C2> *baseVari
+      = new internal::mdivide_left_tri_vd_vari<TriView, R1, C1, R2, C2>(A, b);
 
   size_t pos = 0;
   for (size_type j = 0; j < res.cols(); j++)

--- a/stan/math/rev/mat/fun/mdivide_left_tri.hpp
+++ b/stan/math/rev/mat/fun/mdivide_left_tri.hpp
@@ -12,7 +12,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 template <int TriView, int R1, int C1, int R2, int C2>
 class mdivide_left_tri_vv_vari : public vari {
  public:

--- a/stan/math/rev/mat/fun/multiply_lower_tri_self_transpose.hpp
+++ b/stan/math/rev/mat/fun/multiply_lower_tri_self_transpose.hpp
@@ -40,9 +40,9 @@ inline matrix_v multiply_lower_tri_self_transpose(const matrix_v& L) {
       vs[pos++] = L(m, n).vi_;
     }
   for (int m = 0, mpos = 0; m < K; ++m, mpos += (J < m) ? J : m) {
-    LLt(m, m) = var(new dot_self_vari(vs + mpos, (J < (m + 1)) ? J : (m + 1)));
+    LLt(m, m) = var(new internal::dot_self_vari(vs + mpos, (J < (m + 1)) ? J : (m + 1)));
     for (int n = 0, npos = 0; n < m; ++n, npos += (J < n) ? J : n) {
-      LLt(m, n) = LLt(n, m) = var(new dot_product_vari<var, var>(
+      LLt(m, n) = LLt(n, m) = var(new internal::dot_product_vari<var, var>(
           vs + mpos, vs + npos, (J < (n + 1)) ? J : (n + 1)));
     }
   }

--- a/stan/math/rev/mat/fun/multiply_lower_tri_self_transpose.hpp
+++ b/stan/math/rev/mat/fun/multiply_lower_tri_self_transpose.hpp
@@ -40,7 +40,8 @@ inline matrix_v multiply_lower_tri_self_transpose(const matrix_v& L) {
       vs[pos++] = L(m, n).vi_;
     }
   for (int m = 0, mpos = 0; m < K; ++m, mpos += (J < m) ? J : m) {
-    LLt(m, m) = var(new internal::dot_self_vari(vs + mpos, (J < (m + 1)) ? J : (m + 1)));
+    LLt(m, m) = var(
+        new internal::dot_self_vari(vs + mpos, (J < (m + 1)) ? J : (m + 1)));
     for (int n = 0, npos = 0; n < m; ++n, npos += (J < n) ? J : n) {
       LLt(m, n) = LLt(n, m) = var(new internal::dot_product_vari<var, var>(
           vs + mpos, vs + npos, (J < (n + 1)) ? J : (n + 1)));

--- a/stan/math/rev/mat/fun/ordered_constrain.hpp
+++ b/stan/math/rev/mat/fun/ordered_constrain.hpp
@@ -10,7 +10,7 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 class ordered_constrain_op {
   int N_;
   double* exp_x_;
@@ -73,7 +73,7 @@ class ordered_constrain_op {
     return std::make_tuple(adj_times_jac);
   }
 };
-}  // namespace
+}  // namespace internal
 
 /**
  * Return an increasing ordered vector derived from the specified
@@ -85,7 +85,7 @@ class ordered_constrain_op {
  */
 inline Eigen::Matrix<var, Eigen::Dynamic, 1> ordered_constrain(
     const Eigen::Matrix<var, Eigen::Dynamic, 1>& x) {
-  return adj_jac_apply<ordered_constrain_op>(x);
+  return adj_jac_apply<internal::ordered_constrain_op>(x);
 }
 
 }  // namespace math

--- a/stan/math/rev/mat/fun/ordered_constrain.hpp
+++ b/stan/math/rev/mat/fun/ordered_constrain.hpp
@@ -10,7 +10,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 class ordered_constrain_op {
   int N_;
   double* exp_x_;

--- a/stan/math/rev/mat/fun/positive_ordered_constrain.hpp
+++ b/stan/math/rev/mat/fun/positive_ordered_constrain.hpp
@@ -10,7 +10,7 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 class positive_ordered_constrain_op {
   int N_;
   double* exp_x_;
@@ -71,7 +71,7 @@ class positive_ordered_constrain_op {
     return std::make_tuple(adj_times_jac);
   }
 };
-}  // namespace
+}  // namespace internal
 
 /**
  * Return an increasing positive ordered vector derived from the specified
@@ -83,7 +83,7 @@ class positive_ordered_constrain_op {
  */
 inline Eigen::Matrix<var, Eigen::Dynamic, 1> positive_ordered_constrain(
     const Eigen::Matrix<var, Eigen::Dynamic, 1>& x) {
-  return adj_jac_apply<positive_ordered_constrain_op>(x);
+  return adj_jac_apply<internal::positive_ordered_constrain_op>(x);
 }
 
 }  // namespace math

--- a/stan/math/rev/mat/fun/positive_ordered_constrain.hpp
+++ b/stan/math/rev/mat/fun/positive_ordered_constrain.hpp
@@ -10,7 +10,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 class positive_ordered_constrain_op {
   int N_;
   double* exp_x_;

--- a/stan/math/rev/mat/fun/quad_form.hpp
+++ b/stan/math/rev/mat/fun/quad_form.hpp
@@ -15,7 +15,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 template <typename Ta, int Ra, int Ca, typename Tb, int Rb, int Cb>
 class quad_form_vari_alloc : public chainable_alloc {
  private:

--- a/stan/math/rev/mat/fun/quad_form.hpp
+++ b/stan/math/rev/mat/fun/quad_form.hpp
@@ -15,7 +15,7 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 template <typename Ta, int Ra, int Ca, typename Tb, int Rb, int Cb>
 class quad_form_vari_alloc : public chainable_alloc {
  private:
@@ -108,7 +108,7 @@ class quad_form_vari : public vari {
 
   quad_form_vari_alloc<Ta, Ra, Ca, Tb, Rb, Cb>* impl_;
 };
-}  // namespace
+}  // namespace internal
 
 template <typename Ta, int Ra, int Ca, typename Tb, int Rb, int Cb>
 inline typename std::enable_if<std::is_same<Ta, var>::value
@@ -119,8 +119,8 @@ quad_form(const Eigen::Matrix<Ta, Ra, Ca>& A,
   check_square("quad_form", "A", A);
   check_multiplicable("quad_form", "A", A, "B", B);
 
-  quad_form_vari<Ta, Ra, Ca, Tb, Rb, Cb>* baseVari
-      = new quad_form_vari<Ta, Ra, Ca, Tb, Rb, Cb>(A, B);
+  internal::quad_form_vari<Ta, Ra, Ca, Tb, Rb, Cb>* baseVari
+      = new internal::quad_form_vari<Ta, Ra, Ca, Tb, Rb, Cb>(A, B);
 
   return baseVari->impl_->C_;
 }
@@ -133,8 +133,8 @@ quad_form(const Eigen::Matrix<Ta, Ra, Ca>& A,
   check_square("quad_form", "A", A);
   check_multiplicable("quad_form", "A", A, "B", B);
 
-  quad_form_vari<Ta, Ra, Ca, Tb, Rb, 1>* baseVari
-      = new quad_form_vari<Ta, Ra, Ca, Tb, Rb, 1>(A, B);
+  internal::quad_form_vari<Ta, Ra, Ca, Tb, Rb, 1>* baseVari
+      = new internal::quad_form_vari<Ta, Ra, Ca, Tb, Rb, 1>(A, B);
 
   return baseVari->impl_->C_(0, 0);
 }

--- a/stan/math/rev/mat/fun/quad_form_sym.hpp
+++ b/stan/math/rev/mat/fun/quad_form_sym.hpp
@@ -26,8 +26,8 @@ quad_form_sym(const Eigen::Matrix<Ta, Ra, Ca>& A,
   check_symmetric("quad_form_sym", "A", A);
   check_multiplicable("quad_form_sym", "A", A, "B", B);
 
-  quad_form_vari<Ta, Ra, Ca, Tb, Rb, Cb>* baseVari
-      = new quad_form_vari<Ta, Ra, Ca, Tb, Rb, Cb>(A, B, true);
+  internal::quad_form_vari<Ta, Ra, Ca, Tb, Rb, Cb>* baseVari
+      = new internal::quad_form_vari<Ta, Ra, Ca, Tb, Rb, Cb>(A, B, true);
 
   return baseVari->impl_->C_;
 }
@@ -41,8 +41,8 @@ quad_form_sym(const Eigen::Matrix<Ta, Ra, Ca>& A,
   check_symmetric("quad_form_sym", "A", A);
   check_multiplicable("quad_form_sym", "A", A, "B", B);
 
-  quad_form_vari<Ta, Ra, Ca, Tb, Rb, 1>* baseVari
-      = new quad_form_vari<Ta, Ra, Ca, Tb, Rb, 1>(A, B, true);
+  internal::quad_form_vari<Ta, Ra, Ca, Tb, Rb, 1>* baseVari
+      = new internal::quad_form_vari<Ta, Ra, Ca, Tb, Rb, 1>(A, B, true);
 
   return baseVari->impl_->C_(0, 0);
 }

--- a/stan/math/rev/mat/fun/rows_dot_product.hpp
+++ b/stan/math/rev/mat/fun/rows_dot_product.hpp
@@ -25,7 +25,7 @@ rows_dot_product(const Eigen::Matrix<T1, R1, C1>& v1,
   check_matching_sizes("dot_product", "v1", v1, "v2", v2);
   Eigen::Matrix<var, R1, 1> ret(v1.rows(), 1);
   for (size_type j = 0; j < v1.rows(); ++j) {
-    ret(j) = var(new dot_product_vari<T1, T2>(v1.row(j), v2.row(j)));
+    ret(j) = var(new internal::dot_product_vari<T1, T2>(v1.row(j), v2.row(j)));
   }
   return ret;
 }

--- a/stan/math/rev/mat/fun/sd.hpp
+++ b/stan/math/rev/mat/fun/sd.hpp
@@ -17,7 +17,7 @@ namespace internal {
 // if x.size() = N, and x[i] = x[j] =
 // then lim sd(x) -> 0 [ d/dx[n] sd(x) ] = sqrt(N) / N
 
-var calc_sd(size_t size, const var* dtrs) {
+inline var calc_sd(size_t size, const var* dtrs) {
   using std::sqrt;
   vari** varis = reinterpret_cast<vari**>(
       ChainableStack::instance().memalloc_.alloc(size * sizeof(vari*)));

--- a/stan/math/rev/mat/fun/sd.hpp
+++ b/stan/math/rev/mat/fun/sd.hpp
@@ -12,7 +12,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 
 // if x.size() = N, and x[i] = x[j] =
 // then lim sd(x) -> 0 [ d/dx[n] sd(x) ] = sqrt(N) / N

--- a/stan/math/rev/mat/fun/sd.hpp
+++ b/stan/math/rev/mat/fun/sd.hpp
@@ -12,7 +12,7 @@
 namespace stan {
 namespace math {
 
-namespace {  // anonymous
+namespace internal{
 
 // if x.size() = N, and x[i] = x[j] =
 // then lim sd(x) -> 0 [ d/dx[n] sd(x) ] = sqrt(N) / N
@@ -48,7 +48,7 @@ var calc_sd(size_t size, const var* dtrs) {
   return var(new stored_gradient_vari(sd, size, varis, partials));
 }
 
-}  // namespace
+}  // namespace internal
 
 /**
  * Return the sample standard deviation of the specified standard
@@ -61,7 +61,7 @@ inline var sd(const std::vector<var>& v) {
   check_nonzero_size("sd", "v", v);
   if (v.size() == 1)
     return 0;
-  return calc_sd(v.size(), &v[0]);
+  return internal::calc_sd(v.size(), &v[0]);
 }
 
 /*
@@ -79,7 +79,7 @@ var sd(const Eigen::Matrix<var, R, C>& m) {
   check_nonzero_size("sd", "m", m);
   if (m.size() == 1)
     return 0;
-  return calc_sd(m.size(), &m(0));
+  return internal::calc_sd(m.size(), &m(0));
 }
 
 }  // namespace math

--- a/stan/math/rev/mat/fun/simplex_constrain.hpp
+++ b/stan/math/rev/mat/fun/simplex_constrain.hpp
@@ -11,7 +11,7 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 class simplex_constrain_op {
   int N_;
   double* diag_;  // diagonal of the Jacobian of the operator
@@ -79,7 +79,7 @@ class simplex_constrain_op {
     return std::make_tuple(adj_times_jac);
   }
 };
-}  // namespace
+}  // namespace internal
 
 /**
  * Return the simplex corresponding to the specified free vector.
@@ -94,7 +94,7 @@ class simplex_constrain_op {
  */
 inline Eigen::Matrix<var, Eigen::Dynamic, 1> simplex_constrain(
     const Eigen::Matrix<var, Eigen::Dynamic, 1>& y) {
-  return adj_jac_apply<simplex_constrain_op>(y);
+  return adj_jac_apply<internal::simplex_constrain_op>(y);
 }
 
 }  // namespace math

--- a/stan/math/rev/mat/fun/simplex_constrain.hpp
+++ b/stan/math/rev/mat/fun/simplex_constrain.hpp
@@ -11,7 +11,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 class simplex_constrain_op {
   int N_;
   double* diag_;  // diagonal of the Jacobian of the operator

--- a/stan/math/rev/mat/fun/softmax.hpp
+++ b/stan/math/rev/mat/fun/softmax.hpp
@@ -11,7 +11,7 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 class softmax_op {
   int N_;
   double* y_;  // Holds the results of the softmax
@@ -61,7 +61,7 @@ class softmax_op {
     return std::make_tuple(adj_times_jac);
   }
 };
-}  // namespace
+}  // namespace internal
 
 /**
  * Return the softmax of the specified Eigen vector.  Softmax is
@@ -75,7 +75,7 @@ inline Eigen::Matrix<var, Eigen::Dynamic, 1> softmax(
     const Eigen::Matrix<var, Eigen::Dynamic, 1>& alpha) {
   check_nonzero_size("softmax", "alpha", alpha);
 
-  return adj_jac_apply<softmax_op>(alpha);
+  return adj_jac_apply<internal::softmax_op>(alpha);
 }
 
 }  // namespace math

--- a/stan/math/rev/mat/fun/softmax.hpp
+++ b/stan/math/rev/mat/fun/softmax.hpp
@@ -11,7 +11,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 class softmax_op {
   int N_;
   double* y_;  // Holds the results of the softmax

--- a/stan/math/rev/mat/fun/squared_distance.hpp
+++ b/stan/math/rev/mat/fun/squared_distance.hpp
@@ -16,7 +16,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 
 class squared_distance_vv_vari : public vari {
  protected:

--- a/stan/math/rev/mat/fun/squared_distance.hpp
+++ b/stan/math/rev/mat/fun/squared_distance.hpp
@@ -16,7 +16,7 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 
 class squared_distance_vv_vari : public vari {
  protected:
@@ -103,7 +103,7 @@ class squared_distance_vd_vari : public vari {
     }
   }
 };
-}  // namespace
+}  // namespace internal
 
 template <int R1, int C1, int R2, int C2>
 inline var squared_distance(const Eigen::Matrix<var, R1, C1>& v1,
@@ -111,7 +111,7 @@ inline var squared_distance(const Eigen::Matrix<var, R1, C1>& v1,
   check_vector("squared_distance", "v1", v1);
   check_vector("squared_distance", "v2", v2);
   check_matching_sizes("squared_distance", "v1", v1, "v2", v2);
-  return var(new squared_distance_vv_vari(v1, v2));
+  return var(new internal::squared_distance_vv_vari(v1, v2));
 }
 template <int R1, int C1, int R2, int C2>
 inline var squared_distance(const Eigen::Matrix<var, R1, C1>& v1,
@@ -119,7 +119,7 @@ inline var squared_distance(const Eigen::Matrix<var, R1, C1>& v1,
   check_vector("squared_distance", "v1", v1);
   check_vector("squared_distance", "v2", v2);
   check_matching_sizes("squared_distance", "v1", v1, "v2", v2);
-  return var(new squared_distance_vd_vari(v1, v2));
+  return var(new internal::squared_distance_vd_vari(v1, v2));
 }
 template <int R1, int C1, int R2, int C2>
 inline var squared_distance(const Eigen::Matrix<double, R1, C1>& v1,
@@ -127,7 +127,7 @@ inline var squared_distance(const Eigen::Matrix<double, R1, C1>& v1,
   check_vector("squared_distance", "v1", v1);
   check_vector("squared_distance", "v2", v2);
   check_matching_sizes("squared_distance", "v1", v1, "v2", v2);
-  return var(new squared_distance_vd_vari(v2, v1));
+  return var(new internal::squared_distance_vd_vari(v2, v1));
 }
 
 }  // namespace math

--- a/stan/math/rev/mat/fun/tcrossprod.hpp
+++ b/stan/math/rev/mat/fun/tcrossprod.hpp
@@ -41,10 +41,10 @@ inline matrix_v tcrossprod(const matrix_v& M) {
     for (int n = 0; n < M.cols(); ++n)
       vs[pos++] = M(m, n).vi_;
   for (int m = 0; m < M.rows(); ++m)
-    MMt(m, m) = var(new dot_self_vari(vs + m * M.cols(), M.cols()));
+    MMt(m, m) = var(new internal::dot_self_vari(vs + m * M.cols(), M.cols()));
   for (int m = 0; m < M.rows(); ++m) {
     for (int n = 0; n < m; ++n) {
-      MMt(m, n) = var(new dot_product_vari<var, var>(
+      MMt(m, n) = var(new internal::dot_product_vari<var, var>(
           vs + m * M.cols(), vs + n * M.cols(), M.cols()));
       MMt(n, m) = MMt(m, n);
     }

--- a/stan/math/rev/mat/fun/trace_gen_inv_quad_form_ldlt.hpp
+++ b/stan/math/rev/mat/fun/trace_gen_inv_quad_form_ldlt.hpp
@@ -31,8 +31,8 @@ inline
   check_multiplicable("trace_gen_inv_quad_form_ldlt", "A", A, "B", B);
   check_multiplicable("trace_gen_inv_quad_form_ldlt", "B", B, "D", D);
 
-  trace_inv_quad_form_ldlt_impl<T2, R2, C2, T3, R3, C3> *_impl
-      = new trace_inv_quad_form_ldlt_impl<T2, R2, C2, T3, R3, C3>(D, A, B);
+  internal::trace_inv_quad_form_ldlt_impl<T2, R2, C2, T3, R3, C3> *_impl
+      = new internal::trace_inv_quad_form_ldlt_impl<T2, R2, C2, T3, R3, C3>(D, A, B);
 
   return var(new trace_inv_quad_form_ldlt_vari<T2, R2, C2, T3, R3, C3>(_impl));
 }

--- a/stan/math/rev/mat/fun/trace_gen_inv_quad_form_ldlt.hpp
+++ b/stan/math/rev/mat/fun/trace_gen_inv_quad_form_ldlt.hpp
@@ -18,8 +18,8 @@ namespace math {
  *       trace(D B^T A^-1 B)
  * where D is a square matrix and the LDLT_factor of A is provided.
  **/
-template <typename T1, int R1, int C1, typename T2, int R2,
-          int C2, typename T3, int R3, int C3>
+template <typename T1, int R1, int C1, typename T2, int R2, int C2, typename T3,
+          int R3, int C3>
 inline
     typename std::enable_if<stan::is_var<T1>::value || stan::is_var<T2>::value
                                 || stan::is_var<T3>::value,

--- a/stan/math/rev/mat/fun/trace_gen_inv_quad_form_ldlt.hpp
+++ b/stan/math/rev/mat/fun/trace_gen_inv_quad_form_ldlt.hpp
@@ -18,8 +18,8 @@ namespace math {
  *       trace(D B^T A^-1 B)
  * where D is a square matrix and the LDLT_factor of A is provided.
  **/
-template <typename T1, int R1, int C1, typename T2, int R2, int C2, typename T3,
-          int R3, int C3>
+template <typename T1, int R1, int C1, typename T2, int R2,
+          int C2, typename T3, int R3, int C3>
 inline
     typename std::enable_if<stan::is_var<T1>::value || stan::is_var<T2>::value
                                 || stan::is_var<T3>::value,

--- a/stan/math/rev/mat/fun/trace_gen_inv_quad_form_ldlt.hpp
+++ b/stan/math/rev/mat/fun/trace_gen_inv_quad_form_ldlt.hpp
@@ -32,9 +32,12 @@ inline
   check_multiplicable("trace_gen_inv_quad_form_ldlt", "B", B, "D", D);
 
   internal::trace_inv_quad_form_ldlt_impl<T2, R2, C2, T3, R3, C3> *_impl
-      = new internal::trace_inv_quad_form_ldlt_impl<T2, R2, C2, T3, R3, C3>(D, A, B);
+      = new internal::trace_inv_quad_form_ldlt_impl<T2, R2, C2, T3, R3, C3>(
+          D, A, B);
 
-  return var(new internal::trace_inv_quad_form_ldlt_vari<T2, R2, C2, T3, R3, C3>(_impl));
+  return var(
+      new internal::trace_inv_quad_form_ldlt_vari<T2, R2, C2, T3, R3, C3>(
+          _impl));
 }
 
 }  // namespace math

--- a/stan/math/rev/mat/fun/trace_gen_inv_quad_form_ldlt.hpp
+++ b/stan/math/rev/mat/fun/trace_gen_inv_quad_form_ldlt.hpp
@@ -34,7 +34,7 @@ inline
   internal::trace_inv_quad_form_ldlt_impl<T2, R2, C2, T3, R3, C3> *_impl
       = new internal::trace_inv_quad_form_ldlt_impl<T2, R2, C2, T3, R3, C3>(D, A, B);
 
-  return var(new trace_inv_quad_form_ldlt_vari<T2, R2, C2, T3, R3, C3>(_impl));
+  return var(new internal::trace_inv_quad_form_ldlt_vari<T2, R2, C2, T3, R3, C3>(_impl));
 }
 
 }  // namespace math

--- a/stan/math/rev/mat/fun/trace_gen_quad_form.hpp
+++ b/stan/math/rev/mat/fun/trace_gen_quad_form.hpp
@@ -14,7 +14,7 @@
 
 namespace stan {
 namespace math {
-namespace internal{
+namespace internal {
 template <typename Td, int Rd, int Cd, typename Ta, int Ra, int Ca, typename Tb,
           int Rb, int Cb>
 class trace_gen_quad_form_vari_alloc : public chainable_alloc {
@@ -105,11 +105,14 @@ trace_gen_quad_form(const Eigen::Matrix<Td, Rd, Cd>& D,
   check_multiplicable("trace_gen_quad_form", "A", A, "B", B);
   check_multiplicable("trace_gen_quad_form", "B", B, "D", D);
 
-  internal::trace_gen_quad_form_vari_alloc<Td, Rd, Cd, Ta, Ra, Ca, Tb, Rb, Cb>* baseVari
-      = new internal::trace_gen_quad_form_vari_alloc<Td, Rd, Cd, Ta, Ra, Ca, Tb, Rb, Cb>(
+  internal::trace_gen_quad_form_vari_alloc<Td, Rd, Cd,
+                                           Ta, Ra, Ca, Tb, Rb, Cb>* baseVari
+      = new internal::trace_gen_quad_form_vari_alloc<Td, Rd, Cd,
+                                                     Ta, Ra, Ca, Tb, Rb, Cb>(
           D, A, B);
 
-  return var(new internal::trace_gen_quad_form_vari<Td, Rd, Cd, Ta, Ra, Ca, Tb, Rb, Cb>(
+  return var(new internal::trace_gen_quad_form_vari<Td, Rd, Cd,
+                                                    Ta, Ra, Ca, Tb, Rb, Cb>(
       baseVari));
 }
 

--- a/stan/math/rev/mat/fun/trace_gen_quad_form.hpp
+++ b/stan/math/rev/mat/fun/trace_gen_quad_form.hpp
@@ -105,15 +105,13 @@ trace_gen_quad_form(const Eigen::Matrix<Td, Rd, Cd>& D,
   check_multiplicable("trace_gen_quad_form", "A", A, "B", B);
   check_multiplicable("trace_gen_quad_form", "B", B, "D", D);
 
-  internal::trace_gen_quad_form_vari_alloc<Td, Rd, Cd,
-                                           Ta, Ra, Ca, Tb, Rb, Cb>* baseVari
-      = new internal::trace_gen_quad_form_vari_alloc<Td, Rd, Cd,
-                                                     Ta, Ra, Ca, Tb, Rb, Cb>(
-          D, A, B);
+  internal::trace_gen_quad_form_vari_alloc<Td, Rd, Cd, Ta, Ra, Ca, Tb, Rb, Cb>*
+      baseVari
+      = new internal::trace_gen_quad_form_vari_alloc<Td, Rd, Cd, Ta, Ra, Ca, Tb,
+                                                     Rb, Cb>(D, A, B);
 
-  return var(new internal::trace_gen_quad_form_vari<Td, Rd, Cd,
-                                                    Ta, Ra, Ca, Tb, Rb, Cb>(
-      baseVari));
+  return var(new internal::trace_gen_quad_form_vari<Td, Rd, Cd, Ta, Ra, Ca, Tb,
+                                                    Rb, Cb>(baseVari));
 }
 
 }  // namespace math

--- a/stan/math/rev/mat/fun/trace_gen_quad_form.hpp
+++ b/stan/math/rev/mat/fun/trace_gen_quad_form.hpp
@@ -14,7 +14,7 @@
 
 namespace stan {
 namespace math {
-namespace {
+namespace internal{
 template <typename Td, int Rd, int Cd, typename Ta, int Ra, int Ca, typename Tb,
           int Rb, int Cb>
 class trace_gen_quad_form_vari_alloc : public chainable_alloc {
@@ -89,7 +89,7 @@ class trace_gen_quad_form_vari : public vari {
 
   trace_gen_quad_form_vari_alloc<Td, Rd, Cd, Ta, Ra, Ca, Tb, Rb, Cb>* impl_;
 };
-}  // namespace
+}  // namespace internal
 
 template <typename Td, int Rd, int Cd, typename Ta, int Ra, int Ca, typename Tb,
           int Rb, int Cb>
@@ -105,11 +105,11 @@ trace_gen_quad_form(const Eigen::Matrix<Td, Rd, Cd>& D,
   check_multiplicable("trace_gen_quad_form", "A", A, "B", B);
   check_multiplicable("trace_gen_quad_form", "B", B, "D", D);
 
-  trace_gen_quad_form_vari_alloc<Td, Rd, Cd, Ta, Ra, Ca, Tb, Rb, Cb>* baseVari
-      = new trace_gen_quad_form_vari_alloc<Td, Rd, Cd, Ta, Ra, Ca, Tb, Rb, Cb>(
+  internal::trace_gen_quad_form_vari_alloc<Td, Rd, Cd, Ta, Ra, Ca, Tb, Rb, Cb>* baseVari
+      = new internal::trace_gen_quad_form_vari_alloc<Td, Rd, Cd, Ta, Ra, Ca, Tb, Rb, Cb>(
           D, A, B);
 
-  return var(new trace_gen_quad_form_vari<Td, Rd, Cd, Ta, Ra, Ca, Tb, Rb, Cb>(
+  return var(new internal::trace_gen_quad_form_vari<Td, Rd, Cd, Ta, Ra, Ca, Tb, Rb, Cb>(
       baseVari));
 }
 

--- a/stan/math/rev/mat/fun/trace_inv_quad_form_ldlt.hpp
+++ b/stan/math/rev/mat/fun/trace_inv_quad_form_ldlt.hpp
@@ -164,11 +164,12 @@ inline
   check_multiplicable("trace_inv_quad_form_ldlt", "A", A, "B", B);
 
   internal::trace_inv_quad_form_ldlt_impl<T2, R2, C2, T3, R3, C3> *impl_
-      = new internal::trace_inv_quad_form_ldlt_impl<T2, R2, C2,
-                                                    T3, R3, C3>(A, B);
+      = new internal::trace_inv_quad_form_ldlt_impl<T2, R2, C2, T3, R3, C3>(A,
+                                                                            B);
 
-  return var(new internal::trace_inv_quad_form_ldlt_vari<T2, R2, C2, T3,
-                                                         R3, C3>(impl_));
+  return var(
+      new internal::trace_inv_quad_form_ldlt_vari<T2, R2, C2, T3, R3, C3>(
+          impl_));
 }
 
 }  // namespace math

--- a/stan/math/rev/mat/fun/trace_inv_quad_form_ldlt.hpp
+++ b/stan/math/rev/mat/fun/trace_inv_quad_form_ldlt.hpp
@@ -12,7 +12,7 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 template <typename T2, int R2, int C2, typename T3, int R3, int C3>
 class trace_inv_quad_form_ldlt_impl : public chainable_alloc {
  protected:
@@ -148,7 +148,7 @@ class trace_inv_quad_form_ldlt_vari : public vari {
   trace_inv_quad_form_ldlt_impl<T2, R2, C2, T3, R3, C3> *impl_;
 };
 
-}  // namespace
+}  // namespace internal
 
 /**
  * Compute the trace of an inverse quadratic form.  I.E., this computes
@@ -163,10 +163,10 @@ inline
                              const Eigen::Matrix<T3, R3, C3> &B) {
   check_multiplicable("trace_inv_quad_form_ldlt", "A", A, "B", B);
 
-  trace_inv_quad_form_ldlt_impl<T2, R2, C2, T3, R3, C3> *impl_
-      = new trace_inv_quad_form_ldlt_impl<T2, R2, C2, T3, R3, C3>(A, B);
+  internal::trace_inv_quad_form_ldlt_impl<T2, R2, C2, T3, R3, C3> *impl_
+      = new internal::trace_inv_quad_form_ldlt_impl<T2, R2, C2, T3, R3, C3>(A, B);
 
-  return var(new trace_inv_quad_form_ldlt_vari<T2, R2, C2, T3, R3, C3>(impl_));
+  return var(new internal::trace_inv_quad_form_ldlt_vari<T2, R2, C2, T3, R3, C3>(impl_));
 }
 
 }  // namespace math

--- a/stan/math/rev/mat/fun/trace_inv_quad_form_ldlt.hpp
+++ b/stan/math/rev/mat/fun/trace_inv_quad_form_ldlt.hpp
@@ -12,7 +12,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 template <typename T2, int R2, int C2, typename T3, int R3, int C3>
 class trace_inv_quad_form_ldlt_impl : public chainable_alloc {
  protected:
@@ -164,9 +164,11 @@ inline
   check_multiplicable("trace_inv_quad_form_ldlt", "A", A, "B", B);
 
   internal::trace_inv_quad_form_ldlt_impl<T2, R2, C2, T3, R3, C3> *impl_
-      = new internal::trace_inv_quad_form_ldlt_impl<T2, R2, C2, T3, R3, C3>(A, B);
+      = new internal::trace_inv_quad_form_ldlt_impl<T2, R2, C2,
+                                                    T3, R3, C3>(A, B);
 
-  return var(new internal::trace_inv_quad_form_ldlt_vari<T2, R2, C2, T3, R3, C3>(impl_));
+  return var(new internal::trace_inv_quad_form_ldlt_vari<T2, R2, C2, T3,
+                                                         R3, C3>(impl_));
 }
 
 }  // namespace math

--- a/stan/math/rev/mat/fun/trace_quad_form.hpp
+++ b/stan/math/rev/mat/fun/trace_quad_form.hpp
@@ -14,7 +14,7 @@
 
 namespace stan {
 namespace math {
-namespace {
+namespace internal{
 template <typename Ta, int Ra, int Ca, typename Tb, int Rb, int Cb>
 class trace_quad_form_vari_alloc : public chainable_alloc {
  public:
@@ -77,7 +77,7 @@ class trace_quad_form_vari : public vari {
 
   trace_quad_form_vari_alloc<Ta, Ra, Ca, Tb, Rb, Cb>* impl_;
 };
-}  // namespace
+}  // namespace internal
 
 template <typename Ta, int Ra, int Ca, typename Tb, int Rb, int Cb>
 inline typename std::enable_if<
@@ -87,10 +87,10 @@ trace_quad_form(const Eigen::Matrix<Ta, Ra, Ca>& A,
   check_square("trace_quad_form", "A", A);
   check_multiplicable("trace_quad_form", "A", A, "B", B);
 
-  trace_quad_form_vari_alloc<Ta, Ra, Ca, Tb, Rb, Cb>* baseVari
-      = new trace_quad_form_vari_alloc<Ta, Ra, Ca, Tb, Rb, Cb>(A, B);
+  internal::trace_quad_form_vari_alloc<Ta, Ra, Ca, Tb, Rb, Cb>* baseVari
+      = new internal::trace_quad_form_vari_alloc<Ta, Ra, Ca, Tb, Rb, Cb>(A, B);
 
-  return var(new trace_quad_form_vari<Ta, Ra, Ca, Tb, Rb, Cb>(baseVari));
+  return var(new internal::trace_quad_form_vari<Ta, Ra, Ca, Tb, Rb, Cb>(baseVari));
 }
 
 }  // namespace math

--- a/stan/math/rev/mat/fun/trace_quad_form.hpp
+++ b/stan/math/rev/mat/fun/trace_quad_form.hpp
@@ -14,7 +14,7 @@
 
 namespace stan {
 namespace math {
-namespace internal{
+namespace internal {
 template <typename Ta, int Ra, int Ca, typename Tb, int Rb, int Cb>
 class trace_quad_form_vari_alloc : public chainable_alloc {
  public:
@@ -90,7 +90,8 @@ trace_quad_form(const Eigen::Matrix<Ta, Ra, Ca>& A,
   internal::trace_quad_form_vari_alloc<Ta, Ra, Ca, Tb, Rb, Cb>* baseVari
       = new internal::trace_quad_form_vari_alloc<Ta, Ra, Ca, Tb, Rb, Cb>(A, B);
 
-  return var(new internal::trace_quad_form_vari<Ta, Ra, Ca, Tb, Rb, Cb>(baseVari));
+  return var(new internal::trace_quad_form_vari<Ta, Ra, Ca,
+                                                Tb, Rb, Cb>(baseVari));
 }
 
 }  // namespace math

--- a/stan/math/rev/mat/fun/trace_quad_form.hpp
+++ b/stan/math/rev/mat/fun/trace_quad_form.hpp
@@ -90,8 +90,8 @@ trace_quad_form(const Eigen::Matrix<Ta, Ra, Ca>& A,
   internal::trace_quad_form_vari_alloc<Ta, Ra, Ca, Tb, Rb, Cb>* baseVari
       = new internal::trace_quad_form_vari_alloc<Ta, Ra, Ca, Tb, Rb, Cb>(A, B);
 
-  return var(new internal::trace_quad_form_vari<Ta, Ra, Ca,
-                                                Tb, Rb, Cb>(baseVari));
+  return var(
+      new internal::trace_quad_form_vari<Ta, Ra, Ca, Tb, Rb, Cb>(baseVari));
 }
 
 }  // namespace math

--- a/stan/math/rev/mat/fun/unit_vector_constrain.hpp
+++ b/stan/math/rev/mat/fun/unit_vector_constrain.hpp
@@ -77,9 +77,9 @@ Eigen::Matrix<var, R, C> unit_vector_constrain(
 
   Eigen::Matrix<var, R, C> unit_vector_y(y.size());
   for (int k = 0; k < y.size(); ++k)
-    unit_vector_y.coeffRef(k) = var(
-        new internal::unit_vector_elt_vari(unit_vector_d[k], y_vi_array,
-                                 unit_vector_y_d_array, y.size(), k, norm));
+    unit_vector_y.coeffRef(k) = var(new internal::unit_vector_elt_vari(
+        unit_vector_d[k], y_vi_array, unit_vector_y_d_array, y.size(), k,
+        norm));
   return unit_vector_y;
 }
 

--- a/stan/math/rev/mat/fun/unit_vector_constrain.hpp
+++ b/stan/math/rev/mat/fun/unit_vector_constrain.hpp
@@ -13,7 +13,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 class unit_vector_elt_vari : public vari {
  private:
   vari** y_;

--- a/stan/math/rev/mat/fun/unit_vector_constrain.hpp
+++ b/stan/math/rev/mat/fun/unit_vector_constrain.hpp
@@ -13,7 +13,7 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 class unit_vector_elt_vari : public vari {
  private:
   vari** y_;
@@ -41,7 +41,7 @@ class unit_vector_elt_vari : public vari {
     }
   }
 };
-}  // namespace
+}  // namespace internal
 
 /**
  * Return the unit length vector corresponding to the free vector y.
@@ -78,7 +78,7 @@ Eigen::Matrix<var, R, C> unit_vector_constrain(
   Eigen::Matrix<var, R, C> unit_vector_y(y.size());
   for (int k = 0; k < y.size(); ++k)
     unit_vector_y.coeffRef(k) = var(
-        new unit_vector_elt_vari(unit_vector_d[k], y_vi_array,
+        new internal::unit_vector_elt_vari(unit_vector_d[k], y_vi_array,
                                  unit_vector_y_d_array, y.size(), k, norm));
   return unit_vector_y;
 }

--- a/stan/math/rev/mat/fun/variance.hpp
+++ b/stan/math/rev/mat/fun/variance.hpp
@@ -11,7 +11,7 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 
 inline var calc_variance(size_t size, const var* dtrs) {
   vari** varis = ChainableStack::instance().memalloc_.alloc_array<vari*>(size);
@@ -35,7 +35,7 @@ inline var calc_variance(size_t size, const var* dtrs) {
   return var(new stored_gradient_vari(variance, size, varis, partials));
 }
 
-}  // namespace
+}  // namespace internal
 
 /**
  * Return the sample variance of the specified standard
@@ -48,7 +48,7 @@ inline var variance(const std::vector<var>& v) {
   check_nonzero_size("variance", "v", v);
   if (v.size() == 1)
     return 0;
-  return calc_variance(v.size(), &v[0]);
+  return internal::calc_variance(v.size(), &v[0]);
 }
 
 /*
@@ -66,7 +66,7 @@ var variance(const Eigen::Matrix<var, R, C>& m) {
   check_nonzero_size("variance", "m", m);
   if (m.size() == 1)
     return 0;
-  return calc_variance(m.size(), &m(0));
+  return internal::calc_variance(m.size(), &m(0));
 }
 
 }  // namespace math

--- a/stan/math/rev/mat/fun/variance.hpp
+++ b/stan/math/rev/mat/fun/variance.hpp
@@ -11,7 +11,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 
 inline var calc_variance(size_t size, const var* dtrs) {
   vari** varis = ChainableStack::instance().memalloc_.alloc_array<vari*>(size);

--- a/stan/math/rev/scal/fun/Phi.hpp
+++ b/stan/math/rev/scal/fun/Phi.hpp
@@ -7,7 +7,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 class Phi_vari : public op_v_vari {
  public:
   explicit Phi_vari(vari* avi) : op_v_vari(Phi(avi->val_), avi) {}

--- a/stan/math/rev/scal/fun/Phi.hpp
+++ b/stan/math/rev/scal/fun/Phi.hpp
@@ -7,7 +7,7 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 class Phi_vari : public op_v_vari {
  public:
   explicit Phi_vari(vari* avi) : op_v_vari(Phi(avi->val_), avi) {}
@@ -17,7 +17,7 @@ class Phi_vari : public op_v_vari {
                   * std::exp(NEG_HALF * avi_->val_ * avi_->val_);
   }
 };
-}  // namespace
+}  // namespace internal
 
 /**
  * The unit normal cumulative density function for variables (stan).
@@ -60,7 +60,7 @@ class Phi_vari : public op_v_vari {
  * @param a Variable argument.
  * @return The unit normal cdf evaluated at the specified argument.
  */
-inline var Phi(const var& a) { return var(new Phi_vari(a.vi_)); }
+inline var Phi(const var& a) { return var(new internal::Phi_vari(a.vi_)); }
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/rev/scal/fun/acos.hpp
+++ b/stan/math/rev/scal/fun/acos.hpp
@@ -8,7 +8,7 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 class acos_vari : public op_v_vari {
  public:
   explicit acos_vari(vari* avi) : op_v_vari(std::acos(avi->val_), avi) {}
@@ -16,7 +16,7 @@ class acos_vari : public op_v_vari {
     avi_->adj_ -= adj_ / std::sqrt(1.0 - (avi_->val_ * avi_->val_));
   }
 };
-}  // namespace
+}  // namespace internal
 
 /**
  * Return the principal value of the arc cosine of a variable,
@@ -54,7 +54,7 @@ class acos_vari : public op_v_vari {
  * @param a Variable in range [-1, 1].
  * @return Arc cosine of variable, in radians.
  */
-inline var acos(const var& a) { return var(new acos_vari(a.vi_)); }
+inline var acos(const var& a) { return var(new internal::acos_vari(a.vi_)); }
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/rev/scal/fun/acos.hpp
+++ b/stan/math/rev/scal/fun/acos.hpp
@@ -8,7 +8,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 class acos_vari : public op_v_vari {
  public:
   explicit acos_vari(vari* avi) : op_v_vari(std::acos(avi->val_), avi) {}

--- a/stan/math/rev/scal/fun/acosh.hpp
+++ b/stan/math/rev/scal/fun/acosh.hpp
@@ -8,7 +8,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 class acosh_vari : public op_v_vari {
  public:
   acosh_vari(double val, vari* avi) : op_v_vari(val, avi) {}

--- a/stan/math/rev/scal/fun/acosh.hpp
+++ b/stan/math/rev/scal/fun/acosh.hpp
@@ -8,7 +8,7 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 class acosh_vari : public op_v_vari {
  public:
   acosh_vari(double val, vari* avi) : op_v_vari(val, avi) {}
@@ -16,7 +16,7 @@ class acosh_vari : public op_v_vari {
     avi_->adj_ += adj_ / std::sqrt(avi_->val_ * avi_->val_ - 1.0);
   }
 };
-}  // namespace
+}  // namespace internal
 
 /**
  * The inverse hyperbolic cosine function for variables (C99).
@@ -58,7 +58,7 @@ class acosh_vari : public op_v_vari {
  * @return Inverse hyperbolic cosine of the variable.
  */
 inline var acosh(const var& a) {
-  return var(new acosh_vari(stan::math::acosh(a.val()), a.vi_));
+  return var(new internal::acosh_vari(stan::math::acosh(a.val()), a.vi_));
 }
 
 }  // namespace math

--- a/stan/math/rev/scal/fun/asin.hpp
+++ b/stan/math/rev/scal/fun/asin.hpp
@@ -7,7 +7,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 class asin_vari : public op_v_vari {
  public:
   explicit asin_vari(vari* avi) : op_v_vari(std::asin(avi->val_), avi) {}

--- a/stan/math/rev/scal/fun/asin.hpp
+++ b/stan/math/rev/scal/fun/asin.hpp
@@ -7,7 +7,7 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 class asin_vari : public op_v_vari {
  public:
   explicit asin_vari(vari* avi) : op_v_vari(std::asin(avi->val_), avi) {}
@@ -15,7 +15,7 @@ class asin_vari : public op_v_vari {
     avi_->adj_ += adj_ / std::sqrt(1.0 - (avi_->val_ * avi_->val_));
   }
 };
-}  // namespace
+}  // namespace internal
 
 /**
  * Return the principal value of the arc sine, in radians, of the
@@ -53,7 +53,7 @@ class asin_vari : public op_v_vari {
  * @param a Variable in range [-1, 1].
  * @return Arc sine of variable, in radians.
  */
-inline var asin(const var& a) { return var(new asin_vari(a.vi_)); }
+inline var asin(const var& a) { return var(new internal::asin_vari(a.vi_)); }
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/rev/scal/fun/asinh.hpp
+++ b/stan/math/rev/scal/fun/asinh.hpp
@@ -8,7 +8,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 class asinh_vari : public op_v_vari {
  public:
   asinh_vari(double val, vari* avi) : op_v_vari(val, avi) {}

--- a/stan/math/rev/scal/fun/asinh.hpp
+++ b/stan/math/rev/scal/fun/asinh.hpp
@@ -8,7 +8,7 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 class asinh_vari : public op_v_vari {
  public:
   asinh_vari(double val, vari* avi) : op_v_vari(val, avi) {}
@@ -16,7 +16,7 @@ class asinh_vari : public op_v_vari {
     avi_->adj_ += adj_ / std::sqrt(avi_->val_ * avi_->val_ + 1.0);
   }
 };
-}  // namespace
+}  // namespace internal
 
 /**
  * The inverse hyperbolic sine function for variables (C99).
@@ -52,7 +52,7 @@ class asinh_vari : public op_v_vari {
  * @return Inverse hyperbolic sine of the variable.
  */
 inline var asinh(const var& a) {
-  return var(new asinh_vari(asinh(a.val()), a.vi_));
+  return var(new internal::asinh_vari(asinh(a.val()), a.vi_));
 }
 
 }  // namespace math

--- a/stan/math/rev/scal/fun/atan.hpp
+++ b/stan/math/rev/scal/fun/atan.hpp
@@ -8,13 +8,13 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 class atan_vari : public op_v_vari {
  public:
   explicit atan_vari(vari* avi) : op_v_vari(std::atan(avi->val_), avi) {}
   void chain() { avi_->adj_ += adj_ / (1.0 + (avi_->val_ * avi_->val_)); }
 };
-}  // namespace
+}  // namespace internal
 
 /**
  * Return the principal value of the arc tangent, in radians, of the
@@ -46,7 +46,7 @@ class atan_vari : public op_v_vari {
  * @param a Variable in range [-1, 1].
  * @return Arc tangent of variable, in radians.
  */
-inline var atan(const var& a) { return var(new atan_vari(a.vi_)); }
+inline var atan(const var& a) { return var(new internal::atan_vari(a.vi_)); }
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/rev/scal/fun/atan.hpp
+++ b/stan/math/rev/scal/fun/atan.hpp
@@ -8,7 +8,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 class atan_vari : public op_v_vari {
  public:
   explicit atan_vari(vari* avi) : op_v_vari(std::atan(avi->val_), avi) {}

--- a/stan/math/rev/scal/fun/atan2.hpp
+++ b/stan/math/rev/scal/fun/atan2.hpp
@@ -8,7 +8,7 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 class atan2_vv_vari : public op_vv_vari {
  public:
   atan2_vv_vari(vari* avi, vari* bvi)
@@ -40,7 +40,7 @@ class atan2_dv_vari : public op_dv_vari {
     bvi_->adj_ -= adj_ * ad_ / a_sq_plus_b_sq;
   }
 };
-}  // namespace
+}  // namespace internal
 
 /**
  * Return the principal value of the arc tangent, in radians, of
@@ -59,7 +59,7 @@ class atan2_dv_vari : public op_dv_vari {
  * @return The arc tangent of the fraction, in radians.
  */
 inline var atan2(const var& a, const var& b) {
-  return var(new atan2_vv_vari(a.vi_, b.vi_));
+  return var(new internal::atan2_vv_vari(a.vi_, b.vi_));
 }
 
 /**
@@ -75,7 +75,7 @@ inline var atan2(const var& a, const var& b) {
  * @return The arc tangent of the fraction, in radians.
  */
 inline var atan2(const var& a, double b) {
-  return var(new atan2_vd_vari(a.vi_, b));
+  return var(new internal::atan2_vd_vari(a.vi_, b));
 }
 
 /**
@@ -115,7 +115,7 @@ inline var atan2(const var& a, double b) {
  * @return The arc tangent of the fraction, in radians.
  */
 inline var atan2(double a, const var& b) {
-  return var(new atan2_dv_vari(a, b.vi_));
+  return var(new internal::atan2_dv_vari(a, b.vi_));
 }
 
 }  // namespace math

--- a/stan/math/rev/scal/fun/atan2.hpp
+++ b/stan/math/rev/scal/fun/atan2.hpp
@@ -8,7 +8,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 class atan2_vv_vari : public op_vv_vari {
  public:
   atan2_vv_vari(vari* avi, vari* bvi)

--- a/stan/math/rev/scal/fun/atanh.hpp
+++ b/stan/math/rev/scal/fun/atanh.hpp
@@ -8,7 +8,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 class atanh_vari : public op_v_vari {
  public:
   atanh_vari(double val, vari* avi) : op_v_vari(val, avi) {}

--- a/stan/math/rev/scal/fun/atanh.hpp
+++ b/stan/math/rev/scal/fun/atanh.hpp
@@ -8,13 +8,13 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 class atanh_vari : public op_v_vari {
  public:
   atanh_vari(double val, vari* avi) : op_v_vari(val, avi) {}
   void chain() { avi_->adj_ += adj_ / (1.0 - avi_->val_ * avi_->val_); }
 };
-}  // namespace
+}  // namespace internal
 
 /**
  * The inverse hyperbolic tangent function for variables (C99).
@@ -56,7 +56,7 @@ class atanh_vari : public op_v_vari {
    * @throw std::domain_error if a < -1 or a > 1
    */
 inline var atanh(const var& a) {
-  return var(new atanh_vari(atanh(a.val()), a.vi_));
+  return var(new internal::atanh_vari(atanh(a.val()), a.vi_));
 }
 
 }  // namespace math

--- a/stan/math/rev/scal/fun/bessel_first_kind.hpp
+++ b/stan/math/rev/scal/fun/bessel_first_kind.hpp
@@ -8,7 +8,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 
 class bessel_first_kind_dv_vari : public op_dv_vari {
  public:

--- a/stan/math/rev/scal/fun/bessel_first_kind.hpp
+++ b/stan/math/rev/scal/fun/bessel_first_kind.hpp
@@ -8,7 +8,7 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 
 class bessel_first_kind_dv_vari : public op_dv_vari {
  public:
@@ -20,10 +20,10 @@ class bessel_first_kind_dv_vari : public op_dv_vari {
                      - bessel_first_kind(ad_ + 1, bvi_->val_));
   }
 };
-}  // namespace
+}  // namespace internal
 
 inline var bessel_first_kind(int v, const var& a) {
-  return var(new bessel_first_kind_dv_vari(v, a.vi_));
+  return var(new internal::bessel_first_kind_dv_vari(v, a.vi_));
 }
 
 }  // namespace math

--- a/stan/math/rev/scal/fun/bessel_second_kind.hpp
+++ b/stan/math/rev/scal/fun/bessel_second_kind.hpp
@@ -8,7 +8,7 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 
 class bessel_second_kind_dv_vari : public op_dv_vari {
  public:
@@ -20,10 +20,10 @@ class bessel_second_kind_dv_vari : public op_dv_vari {
                      - bessel_second_kind(ad_ + 1, bvi_->val_));
   }
 };
-}  // namespace
+}  // namespace internal
 
 inline var bessel_second_kind(int v, const var& a) {
-  return var(new bessel_second_kind_dv_vari(v, a.vi_));
+  return var(new internal::bessel_second_kind_dv_vari(v, a.vi_));
 }
 
 }  // namespace math

--- a/stan/math/rev/scal/fun/bessel_second_kind.hpp
+++ b/stan/math/rev/scal/fun/bessel_second_kind.hpp
@@ -8,7 +8,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 
 class bessel_second_kind_dv_vari : public op_dv_vari {
  public:

--- a/stan/math/rev/scal/fun/binary_log_loss.hpp
+++ b/stan/math/rev/scal/fun/binary_log_loss.hpp
@@ -9,7 +9,7 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 class binary_log_loss_1_vari : public op_v_vari {
  public:
   explicit binary_log_loss_1_vari(vari* avi)
@@ -23,7 +23,7 @@ class binary_log_loss_0_vari : public op_v_vari {
       : op_v_vari(-log1p(-avi->val_), avi) {}
   void chain() { avi_->adj_ += adj_ / (1.0 - avi_->val_); }
 };
-}  // namespace
+}  // namespace internal
 
 /**
  * The log loss function for variables (stan).
@@ -61,9 +61,9 @@ class binary_log_loss_0_vari : public op_v_vari {
  */
 inline var binary_log_loss(int y, const var& y_hat) {
   if (y == 0)
-    return var(new binary_log_loss_0_vari(y_hat.vi_));
+    return var(new internal::binary_log_loss_0_vari(y_hat.vi_));
   else
-    return var(new binary_log_loss_1_vari(y_hat.vi_));
+    return var(new internal::binary_log_loss_1_vari(y_hat.vi_));
 }
 
 }  // namespace math

--- a/stan/math/rev/scal/fun/binary_log_loss.hpp
+++ b/stan/math/rev/scal/fun/binary_log_loss.hpp
@@ -9,7 +9,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 class binary_log_loss_1_vari : public op_v_vari {
  public:
   explicit binary_log_loss_1_vari(vari* avi)

--- a/stan/math/rev/scal/fun/cbrt.hpp
+++ b/stan/math/rev/scal/fun/cbrt.hpp
@@ -7,13 +7,13 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 class cbrt_vari : public op_v_vari {
  public:
   explicit cbrt_vari(vari* avi) : op_v_vari(cbrt(avi->val_), avi) {}
   void chain() { avi_->adj_ += adj_ / (3.0 * val_ * val_); }
 };
-}  // namespace
+}  // namespace internal
 
 /**
  * Returns the cube root of the specified variable (C99).
@@ -41,7 +41,7 @@ class cbrt_vari : public op_v_vari {
  * @param a Specified variable.
  * @return Cube root of the variable.
  */
-inline var cbrt(const var& a) { return var(new cbrt_vari(a.vi_)); }
+inline var cbrt(const var& a) { return var(new internal::cbrt_vari(a.vi_)); }
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/rev/scal/fun/cbrt.hpp
+++ b/stan/math/rev/scal/fun/cbrt.hpp
@@ -7,7 +7,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 class cbrt_vari : public op_v_vari {
  public:
   explicit cbrt_vari(vari* avi) : op_v_vari(cbrt(avi->val_), avi) {}

--- a/stan/math/rev/scal/fun/ceil.hpp
+++ b/stan/math/rev/scal/fun/ceil.hpp
@@ -10,7 +10,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 class ceil_vari : public op_v_vari {
  public:
   explicit ceil_vari(vari* avi) : op_v_vari(std::ceil(avi->val_), avi) {}

--- a/stan/math/rev/scal/fun/ceil.hpp
+++ b/stan/math/rev/scal/fun/ceil.hpp
@@ -55,7 +55,7 @@ class ceil_vari : public op_v_vari {
  * @param a Input variable.
  * @return Ceiling of the variable.
  */
-inline var ceil(const var& a) { return var(new ceil_vari(a.vi_)); }
+inline var ceil(const var& a) { return var(new internal::ceil_vari(a.vi_)); }
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/rev/scal/fun/ceil.hpp
+++ b/stan/math/rev/scal/fun/ceil.hpp
@@ -10,7 +10,7 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 class ceil_vari : public op_v_vari {
  public:
   explicit ceil_vari(vari* avi) : op_v_vari(std::ceil(avi->val_), avi) {}
@@ -19,7 +19,7 @@ class ceil_vari : public op_v_vari {
       avi_->adj_ = std::numeric_limits<double>::quiet_NaN();
   }
 };
-}  // namespace
+}  // namespace internal
 
 /**
  * Return the ceiling of the specified variable (cmath).

--- a/stan/math/rev/scal/fun/cos.hpp
+++ b/stan/math/rev/scal/fun/cos.hpp
@@ -7,13 +7,13 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 class cos_vari : public op_v_vari {
  public:
   explicit cos_vari(vari* avi) : op_v_vari(std::cos(avi->val_), avi) {}
   void chain() { avi_->adj_ -= adj_ * std::sin(avi_->val_); }
 };
-}  // namespace
+}  // namespace internal
 
 /**
  * Return the cosine of a radian-scaled variable (cmath).
@@ -42,7 +42,7 @@ class cos_vari : public op_v_vari {
  * @param a Variable for radians of angle.
  * @return Cosine of variable.
  */
-inline var cos(const var& a) { return var(new cos_vari(a.vi_)); }
+inline var cos(const var& a) { return var(new internal::cos_vari(a.vi_)); }
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/rev/scal/fun/cos.hpp
+++ b/stan/math/rev/scal/fun/cos.hpp
@@ -7,7 +7,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 class cos_vari : public op_v_vari {
  public:
   explicit cos_vari(vari* avi) : op_v_vari(std::cos(avi->val_), avi) {}

--- a/stan/math/rev/scal/fun/cosh.hpp
+++ b/stan/math/rev/scal/fun/cosh.hpp
@@ -8,7 +8,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 class cosh_vari : public op_v_vari {
  public:
   explicit cosh_vari(vari* avi) : op_v_vari(std::cosh(avi->val_), avi) {}

--- a/stan/math/rev/scal/fun/cosh.hpp
+++ b/stan/math/rev/scal/fun/cosh.hpp
@@ -8,13 +8,13 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 class cosh_vari : public op_v_vari {
  public:
   explicit cosh_vari(vari* avi) : op_v_vari(std::cosh(avi->val_), avi) {}
   void chain() { avi_->adj_ += adj_ * std::sinh(avi_->val_); }
 };
-}  // namespace
+}  // namespace internal
 
 /**
  * Return the hyperbolic cosine of the specified variable (cmath).
@@ -43,7 +43,7 @@ class cosh_vari : public op_v_vari {
  * @param a Variable.
  * @return Hyperbolic cosine of variable.
  */
-inline var cosh(const var& a) { return var(new cosh_vari(a.vi_)); }
+inline var cosh(const var& a) { return var(new internal::cosh_vari(a.vi_)); }
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/rev/scal/fun/digamma.hpp
+++ b/stan/math/rev/scal/fun/digamma.hpp
@@ -8,15 +8,15 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 class digamma_vari : public op_v_vari {
  public:
   explicit digamma_vari(vari* avi) : op_v_vari(digamma(avi->val_), avi) {}
   void chain() { avi_->adj_ += adj_ * trigamma(avi_->val_); }
 };
-}  // namespace
+}  // namespace internal
 
-inline var digamma(const var& a) { return var(new digamma_vari(a.vi_)); }
+inline var digamma(const var& a) { return var(new internal::digamma_vari(a.vi_)); }
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/rev/scal/fun/digamma.hpp
+++ b/stan/math/rev/scal/fun/digamma.hpp
@@ -8,7 +8,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 class digamma_vari : public op_v_vari {
  public:
   explicit digamma_vari(vari* avi) : op_v_vari(digamma(avi->val_), avi) {}
@@ -16,7 +16,9 @@ class digamma_vari : public op_v_vari {
 };
 }  // namespace internal
 
-inline var digamma(const var& a) { return var(new internal::digamma_vari(a.vi_)); }
+inline var digamma(const var& a) {
+  return var(new internal::digamma_vari(a.vi_));
+}
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/rev/scal/fun/erf.hpp
+++ b/stan/math/rev/scal/fun/erf.hpp
@@ -9,7 +9,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 class erf_vari : public op_v_vari {
  public:
   explicit erf_vari(vari* avi) : op_v_vari(erf(avi->val_), avi) {}

--- a/stan/math/rev/scal/fun/erf.hpp
+++ b/stan/math/rev/scal/fun/erf.hpp
@@ -9,7 +9,7 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 class erf_vari : public op_v_vari {
  public:
   explicit erf_vari(vari* avi) : op_v_vari(erf(avi->val_), avi) {}
@@ -17,7 +17,7 @@ class erf_vari : public op_v_vari {
     avi_->adj_ += adj_ * TWO_OVER_SQRT_PI * std::exp(-avi_->val_ * avi_->val_);
   }
 };
-}  // namespace
+}  // namespace internal
 
 /**
  * The error function for variables (C99).
@@ -54,7 +54,7 @@ class erf_vari : public op_v_vari {
  * @param a The variable.
  * @return Error function applied to the variable.
  */
-inline var erf(const var& a) { return var(new erf_vari(a.vi_)); }
+inline var erf(const var& a) { return var(new internal::erf_vari(a.vi_)); }
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/rev/scal/fun/erfc.hpp
+++ b/stan/math/rev/scal/fun/erfc.hpp
@@ -9,7 +9,7 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 class erfc_vari : public op_v_vari {
  public:
   explicit erfc_vari(vari* avi) : op_v_vari(erfc(avi->val_), avi) {}
@@ -18,7 +18,7 @@ class erfc_vari : public op_v_vari {
         += adj_ * NEG_TWO_OVER_SQRT_PI * std::exp(-avi_->val_ * avi_->val_);
   }
 };
-}  // namespace
+}  // namespace internal
 
 /**
  * The complementary error function for variables (C99).
@@ -55,7 +55,7 @@ class erfc_vari : public op_v_vari {
  * @param a The variable.
  * @return Complementary error function applied to the variable.
  */
-inline var erfc(const var& a) { return var(new erfc_vari(a.vi_)); }
+inline var erfc(const var& a) { return var(new internal::erfc_vari(a.vi_)); }
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/rev/scal/fun/erfc.hpp
+++ b/stan/math/rev/scal/fun/erfc.hpp
@@ -9,7 +9,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 class erfc_vari : public op_v_vari {
  public:
   explicit erfc_vari(vari* avi) : op_v_vari(erfc(avi->val_), avi) {}

--- a/stan/math/rev/scal/fun/exp.hpp
+++ b/stan/math/rev/scal/fun/exp.hpp
@@ -7,7 +7,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 class exp_vari : public op_v_vari {
  public:
   explicit exp_vari(vari* avi) : op_v_vari(std::exp(avi->val_), avi) {}

--- a/stan/math/rev/scal/fun/exp.hpp
+++ b/stan/math/rev/scal/fun/exp.hpp
@@ -7,13 +7,13 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 class exp_vari : public op_v_vari {
  public:
   explicit exp_vari(vari* avi) : op_v_vari(std::exp(avi->val_), avi) {}
   void chain() { avi_->adj_ += adj_ * val_; }
 };
-}  // namespace
+}  // namespace internal
 
 /**
  * Return the exponentiation of the specified variable (cmath).
@@ -37,7 +37,7 @@ class exp_vari : public op_v_vari {
  * @param a Variable to exponentiate.
  * @return Exponentiated variable.
  */
-inline var exp(const var& a) { return var(new exp_vari(a.vi_)); }
+inline var exp(const var& a) { return var(new internal::exp_vari(a.vi_)); }
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/rev/scal/fun/exp2.hpp
+++ b/stan/math/rev/scal/fun/exp2.hpp
@@ -9,7 +9,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 class exp2_vari : public op_v_vari {
  public:
   explicit exp2_vari(vari* avi) : op_v_vari(std::pow(2.0, avi->val_), avi) {}

--- a/stan/math/rev/scal/fun/exp2.hpp
+++ b/stan/math/rev/scal/fun/exp2.hpp
@@ -15,7 +15,7 @@ class exp2_vari : public op_v_vari {
   explicit exp2_vari(vari* avi) : op_v_vari(std::pow(2.0, avi->val_), avi) {}
   void chain() { avi_->adj_ += adj_ * val_ * LOG_2; }
 };
-}  // namespace
+}  // namespace internal
 
 /**
  * Exponentiation base 2 function for variables (C99).

--- a/stan/math/rev/scal/fun/exp2.hpp
+++ b/stan/math/rev/scal/fun/exp2.hpp
@@ -9,7 +9,7 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 class exp2_vari : public op_v_vari {
  public:
   explicit exp2_vari(vari* avi) : op_v_vari(std::pow(2.0, avi->val_), avi) {}
@@ -43,7 +43,7 @@ class exp2_vari : public op_v_vari {
  * @param a The variable.
  * @return Two to the power of the specified variable.
  */
-inline var exp2(const var& a) { return var(new exp2_vari(a.vi_)); }
+inline var exp2(const var& a) { return var(new internal::exp2_vari(a.vi_)); }
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/rev/scal/fun/expm1.hpp
+++ b/stan/math/rev/scal/fun/expm1.hpp
@@ -7,13 +7,13 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 class expm1_vari : public op_v_vari {
  public:
   explicit expm1_vari(vari* avi) : op_v_vari(expm1(avi->val_), avi) {}
   void chain() { avi_->adj_ += adj_ * (val_ + 1); }
 };
-}  // namespace
+}  // namespace internal
 
 /**
  * The exponentiation of the specified variable minus 1 (C99).
@@ -42,7 +42,7 @@ class expm1_vari : public op_v_vari {
  * @param a The variable.
  * @return Two to the power of the specified variable.
  */
-inline var expm1(const var& a) { return var(new expm1_vari(a.vi_)); }
+inline var expm1(const var& a) { return var(new internal::expm1_vari(a.vi_)); }
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/rev/scal/fun/expm1.hpp
+++ b/stan/math/rev/scal/fun/expm1.hpp
@@ -7,7 +7,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 class expm1_vari : public op_v_vari {
  public:
   explicit expm1_vari(vari* avi) : op_v_vari(expm1(avi->val_), avi) {}

--- a/stan/math/rev/scal/fun/fabs.hpp
+++ b/stan/math/rev/scal/fun/fabs.hpp
@@ -50,7 +50,7 @@ inline var fabs(const var& a) {
   if (a.val() > 0.0)
     return a;
   else if (a.val() < 0.0)
-    return var(new neg_vari(a.vi_));
+    return var(new internal::neg_vari(a.vi_));
   else if (a.val() == 0)
     return var(new vari(0));
   else

--- a/stan/math/rev/scal/fun/fdim.hpp
+++ b/stan/math/rev/scal/fun/fdim.hpp
@@ -9,7 +9,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 class fdim_vv_vari : public op_vv_vari {
  public:
   fdim_vv_vari(vari* avi, vari* bvi)
@@ -89,7 +89,7 @@ class fdim_dv_vari : public op_dv_vari {
 inline var fdim(const var& a, const var& b) {
   // reversed test to get NaN vals automatically in second case
   return (a.vi_->val_ <= b.vi_->val_) ? var(new vari(0.0))
-                                      : var(new internal::fdim_vv_vari(a.vi_, b.vi_));
+                              : var(new internal::fdim_vv_vari(a.vi_, b.vi_));
 }
 
 /**

--- a/stan/math/rev/scal/fun/fdim.hpp
+++ b/stan/math/rev/scal/fun/fdim.hpp
@@ -88,8 +88,9 @@ class fdim_dv_vari : public op_dv_vari {
  */
 inline var fdim(const var& a, const var& b) {
   // reversed test to get NaN vals automatically in second case
-  return (a.vi_->val_ <= b.vi_->val_) ? var(new vari(0.0))
-                              : var(new internal::fdim_vv_vari(a.vi_, b.vi_));
+  return (a.vi_->val_ <= b.vi_->val_)
+             ? var(new vari(0.0))
+             : var(new internal::fdim_vv_vari(a.vi_, b.vi_));
 }
 
 /**

--- a/stan/math/rev/scal/fun/fdim.hpp
+++ b/stan/math/rev/scal/fun/fdim.hpp
@@ -9,7 +9,7 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 class fdim_vv_vari : public op_vv_vari {
  public:
   fdim_vv_vari(vari* avi, vari* bvi)
@@ -46,7 +46,7 @@ class fdim_dv_vari : public op_dv_vari {
       bvi_->adj_ -= adj_;
   }
 };
-}  // namespace
+}  // namespace internal
 
 /**
  * Return the positive difference between the first variable's the value
@@ -89,7 +89,7 @@ class fdim_dv_vari : public op_dv_vari {
 inline var fdim(const var& a, const var& b) {
   // reversed test to get NaN vals automatically in second case
   return (a.vi_->val_ <= b.vi_->val_) ? var(new vari(0.0))
-                                      : var(new fdim_vv_vari(a.vi_, b.vi_));
+                                      : var(new internal::fdim_vv_vari(a.vi_, b.vi_));
 }
 
 /**
@@ -107,7 +107,7 @@ inline var fdim(const var& a, const var& b) {
 inline var fdim(double a, const var& b) {
   // reversed test to get NaN vals automatically in second case
   return a <= b.vi_->val_ ? var(new vari(0.0))
-                          : var(new fdim_dv_vari(a, b.vi_));
+                          : var(new internal::fdim_dv_vari(a, b.vi_));
 }
 
 /**
@@ -124,7 +124,7 @@ inline var fdim(double a, const var& b) {
 inline var fdim(const var& a, double b) {
   // reversed test to get NaN vals automatically in second case
   return a.vi_->val_ <= b ? var(new vari(0.0))
-                          : var(new fdim_vd_vari(a.vi_, b));
+                          : var(new internal::fdim_vd_vari(a.vi_, b));
 }
 
 }  // namespace math

--- a/stan/math/rev/scal/fun/floor.hpp
+++ b/stan/math/rev/scal/fun/floor.hpp
@@ -10,7 +10,7 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal::{
 class floor_vari : public op_v_vari {
  public:
   explicit floor_vari(vari* avi) : op_v_vari(std::floor(avi->val_), avi) {}
@@ -19,7 +19,7 @@ class floor_vari : public op_v_vari {
       avi_->adj_ = std::numeric_limits<double>::quiet_NaN();
   }
 };
-}  // namespace
+}  // namespace internal
 
 /**
  * Return the floor of the specified variable (cmath).
@@ -55,7 +55,7 @@ class floor_vari : public op_v_vari {
  * @param a Input variable.
  * @return Floor of the variable.
  */
-inline var floor(const var& a) { return var(new floor_vari(a.vi_)); }
+inline var floor(const var& a) { return var(new internal::floor_vari(a.vi_)); }
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/rev/scal/fun/floor.hpp
+++ b/stan/math/rev/scal/fun/floor.hpp
@@ -10,7 +10,7 @@
 namespace stan {
 namespace math {
 
-namespace internal::{
+namespace internal{
 class floor_vari : public op_v_vari {
  public:
   explicit floor_vari(vari* avi) : op_v_vari(std::floor(avi->val_), avi) {}

--- a/stan/math/rev/scal/fun/floor.hpp
+++ b/stan/math/rev/scal/fun/floor.hpp
@@ -10,7 +10,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 class floor_vari : public op_v_vari {
  public:
   explicit floor_vari(vari* avi) : op_v_vari(std::floor(avi->val_), avi) {}

--- a/stan/math/rev/scal/fun/fma.hpp
+++ b/stan/math/rev/scal/fun/fma.hpp
@@ -11,7 +11,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 class fma_vvv_vari : public op_vvv_vari {
  public:
   fma_vvv_vari(vari* avi, vari* bvi, vari* cvi)

--- a/stan/math/rev/scal/fun/fma.hpp
+++ b/stan/math/rev/scal/fun/fma.hpp
@@ -11,7 +11,7 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 class fma_vvv_vari : public op_vvv_vari {
  public:
   fma_vvv_vari(vari* avi, vari* bvi, vari* cvi)
@@ -83,7 +83,7 @@ class fma_ddv_vari : public op_ddv_vari {
       cvi_->adj_ += adj_;
   }
 };
-}  // namespace
+}  // namespace internal
 
 /**
  * The fused multiply-add function for three variables (C99).
@@ -104,7 +104,7 @@ class fma_ddv_vari : public op_ddv_vari {
  * @return Product of the multiplicands plus the summand, ($a * $b) + $c.
  */
 inline var fma(const var& a, const var& b, const var& c) {
-  return var(new fma_vvv_vari(a.vi_, b.vi_, c.vi_));
+  return var(new internal::fma_vvv_vari(a.vi_, b.vi_, c.vi_));
 }
 
 /**
@@ -124,7 +124,7 @@ inline var fma(const var& a, const var& b, const var& c) {
  * @return Product of the multiplicands plus the summand, ($a * $b) + $c.
  */
 inline var fma(const var& a, const var& b, double c) {
-  return var(new fma_vvd_vari(a.vi_, b.vi_, c));
+  return var(new internal::fma_vvd_vari(a.vi_, b.vi_, c));
 }
 
 /**
@@ -144,7 +144,7 @@ inline var fma(const var& a, const var& b, double c) {
  * @return Product of the multiplicands plus the summand, ($a * $b) + $c.
  */
 inline var fma(const var& a, double b, const var& c) {
-  return var(new fma_vdv_vari(a.vi_, b, c.vi_));
+  return var(new internal::fma_vdv_vari(a.vi_, b, c.vi_));
 }
 
 /**
@@ -166,7 +166,7 @@ inline var fma(const var& a, double b, const var& c) {
  * @return Product of the multiplicands plus the summand, ($a * $b) + $c.
  */
 inline var fma(const var& a, double b, double c) {
-  return var(new fma_vdd_vari(a.vi_, b, c));
+  return var(new internal::fma_vdd_vari(a.vi_, b, c));
 }
 
 /**
@@ -184,7 +184,7 @@ inline var fma(const var& a, double b, double c) {
  * @return Product of the multiplicands plus the summand, ($a * $b) + $c.
  */
 inline var fma(double a, const var& b, double c) {
-  return var(new fma_vdd_vari(b.vi_, a, c));
+  return var(new internal::fma_vdd_vari(b.vi_, a, c));
 }
 
 /**
@@ -202,7 +202,7 @@ inline var fma(double a, const var& b, double c) {
  * @return Product of the multiplicands plus the summand, ($a * $b) + $c.
  */
 inline var fma(double a, double b, const var& c) {
-  return var(new fma_ddv_vari(a, b, c.vi_));
+  return var(new internal::fma_ddv_vari(a, b, c.vi_));
 }
 
 /**
@@ -222,7 +222,7 @@ inline var fma(double a, double b, const var& c) {
  * @return Product of the multiplicands plus the summand, ($a * $b) + $c.
  */
 inline var fma(double a, const var& b, const var& c) {
-  return var(new fma_vdv_vari(b.vi_, a, c.vi_));  // a-b symmetry
+  return var(new internal::fma_vdv_vari(b.vi_, a, c.vi_));  // a-b symmetry
 }
 
 }  // namespace math

--- a/stan/math/rev/scal/fun/fmod.hpp
+++ b/stan/math/rev/scal/fun/fmod.hpp
@@ -9,7 +9,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 class fmod_vv_vari : public op_vv_vari {
  public:
   fmod_vv_vari(vari* avi, vari* bvi)

--- a/stan/math/rev/scal/fun/fmod.hpp
+++ b/stan/math/rev/scal/fun/fmod.hpp
@@ -9,7 +9,7 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 class fmod_vv_vari : public op_vv_vari {
  public:
   fmod_vv_vari(vari* avi, vari* bvi)
@@ -50,7 +50,7 @@ class fmod_dv_vari : public op_dv_vari {
     }
   }
 };
-}  // namespace
+}  // namespace internal
 
 /**
  * Return the floating point remainder after dividing the
@@ -96,7 +96,7 @@ class fmod_dv_vari : public op_dv_vari {
  * by the second.
  */
 inline var fmod(const var& a, const var& b) {
-  return var(new fmod_vv_vari(a.vi_, b.vi_));
+  return var(new internal::fmod_vv_vari(a.vi_, b.vi_));
 }
 
 /**
@@ -113,7 +113,7 @@ inline var fmod(const var& a, const var& b) {
  * the second scalar.
  */
 inline var fmod(const var& a, double b) {
-  return var(new fmod_vd_vari(a.vi_, b));
+  return var(new internal::fmod_vd_vari(a.vi_, b));
 }
 
 /**
@@ -130,7 +130,7 @@ inline var fmod(const var& a, double b) {
  * the second variable.
  */
 inline var fmod(double a, const var& b) {
-  return var(new fmod_dv_vari(a, b.vi_));
+  return var(new internal::fmod_dv_vari(a, b.vi_));
 }
 
 }  // namespace math

--- a/stan/math/rev/scal/fun/gamma_p.hpp
+++ b/stan/math/rev/scal/fun/gamma_p.hpp
@@ -14,7 +14,7 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 class gamma_p_vv_vari : public op_vv_vari {
  public:
   gamma_p_vv_vari(vari* avi, vari* bvi)
@@ -95,18 +95,18 @@ class gamma_p_dv_vari : public op_dv_vari {
                              - lgamma(ad_));
   }
 };
-}  // namespace
+}  // namespace internal
 
 inline var gamma_p(const var& a, const var& b) {
-  return var(new gamma_p_vv_vari(a.vi_, b.vi_));
+  return var(new internal::gamma_p_vv_vari(a.vi_, b.vi_));
 }
 
 inline var gamma_p(const var& a, double b) {
-  return var(new gamma_p_vd_vari(a.vi_, b));
+  return var(new internal::gamma_p_vd_vari(a.vi_, b));
 }
 
 inline var gamma_p(double a, const var& b) {
-  return var(new gamma_p_dv_vari(a, b.vi_));
+  return var(new internal::gamma_p_dv_vari(a, b.vi_));
 }
 
 }  // namespace math

--- a/stan/math/rev/scal/fun/gamma_p.hpp
+++ b/stan/math/rev/scal/fun/gamma_p.hpp
@@ -14,7 +14,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 class gamma_p_vv_vari : public op_vv_vari {
  public:
   gamma_p_vv_vari(vari* avi, vari* bvi)

--- a/stan/math/rev/scal/fun/gamma_q.hpp
+++ b/stan/math/rev/scal/fun/gamma_q.hpp
@@ -12,7 +12,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 class gamma_q_vv_vari : public op_vv_vari {
  public:
   gamma_q_vv_vari(vari* avi, vari* bvi)

--- a/stan/math/rev/scal/fun/gamma_q.hpp
+++ b/stan/math/rev/scal/fun/gamma_q.hpp
@@ -12,7 +12,7 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 class gamma_q_vv_vari : public op_vv_vari {
  public:
   gamma_q_vv_vari(vari* avi, vari* bvi)
@@ -45,18 +45,18 @@ class gamma_q_dv_vari : public op_dv_vari {
     bvi_->adj_ -= adj_ * boost::math::gamma_p_derivative(ad_, bvi_->val_);
   }
 };
-}  // namespace
+}  // namespace internal
 
 inline var gamma_q(const var& a, const var& b) {
-  return var(new gamma_q_vv_vari(a.vi_, b.vi_));
+  return var(new internal::gamma_q_vv_vari(a.vi_, b.vi_));
 }
 
 inline var gamma_q(const var& a, double b) {
-  return var(new gamma_q_vd_vari(a.vi_, b));
+  return var(new internal::gamma_q_vd_vari(a.vi_, b));
 }
 
 inline var gamma_q(double a, const var& b) {
-  return var(new gamma_q_dv_vari(a, b.vi_));
+  return var(new internal::gamma_q_dv_vari(a, b.vi_));
 }
 
 }  // namespace math

--- a/stan/math/rev/scal/fun/hypot.hpp
+++ b/stan/math/rev/scal/fun/hypot.hpp
@@ -7,7 +7,7 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 class hypot_vv_vari : public op_vv_vari {
  public:
   hypot_vv_vari(vari* avi, vari* bvi)
@@ -23,7 +23,7 @@ class hypot_vd_vari : public op_v_vari {
   hypot_vd_vari(vari* avi, double b) : op_v_vari(hypot(avi->val_, b), avi) {}
   void chain() { avi_->adj_ += adj_ * avi_->val_ / val_; }
 };
-}  // namespace
+}  // namespace internal
 
 /**
  * Returns the length of the hypoteneuse of a right triangle
@@ -42,7 +42,7 @@ class hypot_vd_vari : public op_v_vari {
  * @return Length of hypoteneuse.
  */
 inline var hypot(const var& a, const var& b) {
-  return var(new hypot_vv_vari(a.vi_, b.vi_));
+  return var(new internal::hypot_vv_vari(a.vi_, b.vi_));
 }
 
 /**
@@ -58,7 +58,7 @@ inline var hypot(const var& a, const var& b) {
  * @return Length of hypoteneuse.
  */
 inline var hypot(const var& a, double b) {
-  return var(new hypot_vd_vari(a.vi_, b));
+  return var(new internal::hypot_vd_vari(a.vi_, b));
 }
 
 /**
@@ -101,7 +101,7 @@ inline var hypot(const var& a, double b) {
  * @return Length of hypoteneuse.
  */
 inline var hypot(double a, const var& b) {
-  return var(new hypot_vd_vari(b.vi_, a));
+  return var(new internal::hypot_vd_vari(b.vi_, a));
 }
 
 }  // namespace math

--- a/stan/math/rev/scal/fun/hypot.hpp
+++ b/stan/math/rev/scal/fun/hypot.hpp
@@ -7,7 +7,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 class hypot_vv_vari : public op_vv_vari {
  public:
   hypot_vv_vari(vari* avi, vari* bvi)

--- a/stan/math/rev/scal/fun/ibeta.hpp
+++ b/stan/math/rev/scal/fun/ibeta.hpp
@@ -16,8 +16,8 @@ namespace internal {
  * Handles negative values of b properly.
  */
 inline double ibeta_hypergeometric_helper(double a, double b, double z,
-                                   double precision = 1e-8,
-                                   double max_steps = 1000) {
+                                          double precision = 1e-8,
+                                          double max_steps = 1000) {
   double val = 0;
   double diff = 1;
   double k = 0;

--- a/stan/math/rev/scal/fun/ibeta.hpp
+++ b/stan/math/rev/scal/fun/ibeta.hpp
@@ -9,7 +9,7 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 /**
  * Calculates the generalized hypergeometric 3F2(a, a, b; a + 1, a + 1; z).
  *
@@ -184,7 +184,7 @@ class ibeta_ddv_vari : public op_ddv_vari {
     cvi_->adj_ += adj_ * boost::math::ibeta_derivative(a, b, c);
   }
 };
-}  // namespace
+}  // namespace internal
 
 /**
  * The normalized incomplete beta function of a, b, and x.
@@ -205,7 +205,7 @@ class ibeta_ddv_vari : public op_ddv_vari {
  * @throws if any argument is NaN.
  */
 inline var ibeta(const var& a, const var& b, const var& x) {
-  return var(new ibeta_vvv_vari(a.vi_, b.vi_, x.vi_));
+  return var(new internal::ibeta_vvv_vari(a.vi_, b.vi_, x.vi_));
 }
 
 }  // namespace math

--- a/stan/math/rev/scal/fun/ibeta.hpp
+++ b/stan/math/rev/scal/fun/ibeta.hpp
@@ -15,7 +15,7 @@ namespace internal {
  *
  * Handles negative values of b properly.
  */
-double ibeta_hypergeometric_helper(double a, double b, double z,
+inline double ibeta_hypergeometric_helper(double a, double b, double z,
                                    double precision = 1e-8,
                                    double max_steps = 1000) {
   double val = 0;

--- a/stan/math/rev/scal/fun/ibeta.hpp
+++ b/stan/math/rev/scal/fun/ibeta.hpp
@@ -9,7 +9,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 /**
  * Calculates the generalized hypergeometric 3F2(a, a, b; a + 1, a + 1; z).
  *

--- a/stan/math/rev/scal/fun/inc_beta.hpp
+++ b/stan/math/rev/scal/fun/inc_beta.hpp
@@ -12,7 +12,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 
 class inc_beta_vvv_vari : public op_vvv_vari {
  public:

--- a/stan/math/rev/scal/fun/inc_beta.hpp
+++ b/stan/math/rev/scal/fun/inc_beta.hpp
@@ -12,7 +12,7 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 
 class inc_beta_vvv_vari : public op_vvv_vari {
  public:
@@ -34,10 +34,10 @@ class inc_beta_vvv_vari : public op_vvv_vari {
   }
 };
 
-}  // namespace
+}  // namespace internal
 
 inline var inc_beta(const var& a, const var& b, const var& c) {
-  return var(new inc_beta_vvv_vari(a.vi_, b.vi_, c.vi_));
+  return var(new internal::inc_beta_vvv_vari(a.vi_, b.vi_, c.vi_));
 }
 
 }  // namespace math

--- a/stan/math/rev/scal/fun/inv.hpp
+++ b/stan/math/rev/scal/fun/inv.hpp
@@ -8,13 +8,13 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 class inv_vari : public op_v_vari {
  public:
   explicit inv_vari(vari* avi) : op_v_vari(inv(avi->val_), avi) {}
   void chain() { avi_->adj_ -= adj_ / (avi_->val_ * avi_->val_); }
 };
-}  // namespace
+}  // namespace internal
 
 /**
  *
@@ -35,7 +35,7 @@ class inv_vari : public op_v_vari {
    \f]
  *
  */
-inline var inv(const var& a) { return var(new inv_vari(a.vi_)); }
+inline var inv(const var& a) { return var(new internal::inv_vari(a.vi_)); }
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/rev/scal/fun/inv.hpp
+++ b/stan/math/rev/scal/fun/inv.hpp
@@ -8,7 +8,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 class inv_vari : public op_v_vari {
  public:
   explicit inv_vari(vari* avi) : op_v_vari(inv(avi->val_), avi) {}

--- a/stan/math/rev/scal/fun/inv_Phi.hpp
+++ b/stan/math/rev/scal/fun/inv_Phi.hpp
@@ -9,7 +9,7 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 class inv_Phi_vari : public op_v_vari {
  public:
   explicit inv_Phi_vari(vari* avi) : op_v_vari(inv_Phi(avi->val_), avi) {}
@@ -19,7 +19,7 @@ class inv_Phi_vari : public op_v_vari {
         += adj_ * SQRT_2_TIMES_SQRT_PI / std::exp(NEG_HALF * val_ * val_);
   }
 };
-}  // namespace
+}  // namespace internal
 
 /**
  * The inverse of unit normal cumulative density function.
@@ -31,7 +31,7 @@ class inv_Phi_vari : public op_v_vari {
  * @param p Probability
  * @return The unit normal inverse cdf evaluated at p
  */
-inline var inv_Phi(const var& p) { return var(new inv_Phi_vari(p.vi_)); }
+inline var inv_Phi(const var& p) { return var(new internal::inv_Phi_vari(p.vi_)); }
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/rev/scal/fun/inv_Phi.hpp
+++ b/stan/math/rev/scal/fun/inv_Phi.hpp
@@ -9,7 +9,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 class inv_Phi_vari : public op_v_vari {
  public:
   explicit inv_Phi_vari(vari* avi) : op_v_vari(inv_Phi(avi->val_), avi) {}
@@ -31,7 +31,9 @@ class inv_Phi_vari : public op_v_vari {
  * @param p Probability
  * @return The unit normal inverse cdf evaluated at p
  */
-inline var inv_Phi(const var& p) { return var(new internal::inv_Phi_vari(p.vi_)); }
+inline var inv_Phi(const var& p) {
+  return var(new internal::inv_Phi_vari(p.vi_));
+}
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/rev/scal/fun/inv_cloglog.hpp
+++ b/stan/math/rev/scal/fun/inv_cloglog.hpp
@@ -7,7 +7,7 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 class inv_cloglog_vari : public op_v_vari {
  public:
   explicit inv_cloglog_vari(vari* avi)
@@ -16,7 +16,7 @@ class inv_cloglog_vari : public op_v_vari {
     avi_->adj_ += adj_ * std::exp(avi_->val_ - std::exp(avi_->val_));
   }
 };
-}  // namespace
+}  // namespace internal
 
 /**
  * Return the inverse complementary log-log function applied
@@ -33,7 +33,7 @@ class inv_cloglog_vari : public op_v_vari {
  * argument.
  */
 inline var inv_cloglog(const var& a) {
-  return var(new inv_cloglog_vari(a.vi_));
+  return var(new internal::inv_cloglog_vari(a.vi_));
 }
 
 }  // namespace math

--- a/stan/math/rev/scal/fun/inv_cloglog.hpp
+++ b/stan/math/rev/scal/fun/inv_cloglog.hpp
@@ -7,7 +7,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 class inv_cloglog_vari : public op_v_vari {
  public:
   explicit inv_cloglog_vari(vari* avi)

--- a/stan/math/rev/scal/fun/inv_logit.hpp
+++ b/stan/math/rev/scal/fun/inv_logit.hpp
@@ -7,7 +7,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 class inv_logit_vari : public op_v_vari {
  public:
   explicit inv_logit_vari(vari* avi) : op_v_vari(inv_logit(avi->val_), avi) {}
@@ -28,7 +28,9 @@ class inv_logit_vari : public op_v_vari {
  * @param a Argument variable.
  * @return Inverse logit of argument.
  */
-inline var inv_logit(const var& a) { return var(new internal::inv_logit_vari(a.vi_)); }
+inline var inv_logit(const var& a) {
+  return var(new internal::inv_logit_vari(a.vi_));
+}
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/rev/scal/fun/inv_logit.hpp
+++ b/stan/math/rev/scal/fun/inv_logit.hpp
@@ -7,13 +7,13 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 class inv_logit_vari : public op_v_vari {
  public:
   explicit inv_logit_vari(vari* avi) : op_v_vari(inv_logit(avi->val_), avi) {}
   void chain() { avi_->adj_ += adj_ * val_ * (1.0 - val_); }
 };
-}  // namespace
+}  // namespace internal
 
 /**
  * The inverse logit function for variables (stan).
@@ -28,7 +28,7 @@ class inv_logit_vari : public op_v_vari {
  * @param a Argument variable.
  * @return Inverse logit of argument.
  */
-inline var inv_logit(const var& a) { return var(new inv_logit_vari(a.vi_)); }
+inline var inv_logit(const var& a) { return var(new internal::inv_logit_vari(a.vi_)); }
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/rev/scal/fun/inv_sqrt.hpp
+++ b/stan/math/rev/scal/fun/inv_sqrt.hpp
@@ -8,7 +8,7 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 class inv_sqrt_vari : public op_v_vari {
  public:
   explicit inv_sqrt_vari(vari* avi) : op_v_vari(inv_sqrt(avi->val_), avi) {}
@@ -16,7 +16,7 @@ class inv_sqrt_vari : public op_v_vari {
     avi_->adj_ -= 0.5 * adj_ / (avi_->val_ * std::sqrt(avi_->val_));
   }
 };
-}  // namespace
+}  // namespace internal
 
 /**
  *
@@ -37,7 +37,7 @@ class inv_sqrt_vari : public op_v_vari {
    \f]
  *
  */
-inline var inv_sqrt(const var& a) { return var(new inv_sqrt_vari(a.vi_)); }
+inline var inv_sqrt(const var& a) { return var(new internal::inv_sqrt_vari(a.vi_)); }
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/rev/scal/fun/inv_sqrt.hpp
+++ b/stan/math/rev/scal/fun/inv_sqrt.hpp
@@ -8,7 +8,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 class inv_sqrt_vari : public op_v_vari {
  public:
   explicit inv_sqrt_vari(vari* avi) : op_v_vari(inv_sqrt(avi->val_), avi) {}
@@ -37,7 +37,9 @@ class inv_sqrt_vari : public op_v_vari {
    \f]
  *
  */
-inline var inv_sqrt(const var& a) { return var(new internal::inv_sqrt_vari(a.vi_)); }
+inline var inv_sqrt(const var& a) {
+  return var(new internal::inv_sqrt_vari(a.vi_));
+}
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/rev/scal/fun/inv_square.hpp
+++ b/stan/math/rev/scal/fun/inv_square.hpp
@@ -8,7 +8,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 class inv_square_vari : public op_v_vari {
  public:
   explicit inv_square_vari(vari* avi) : op_v_vari(inv_square(avi->val_), avi) {}
@@ -37,7 +37,9 @@ class inv_square_vari : public op_v_vari {
    \f]
  *
  */
-inline var inv_square(const var& a) { return var(new internal::inv_square_vari(a.vi_)); }
+inline var inv_square(const var& a) {
+  return var(new internal::inv_square_vari(a.vi_));
+}
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/rev/scal/fun/inv_square.hpp
+++ b/stan/math/rev/scal/fun/inv_square.hpp
@@ -8,7 +8,7 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 class inv_square_vari : public op_v_vari {
  public:
   explicit inv_square_vari(vari* avi) : op_v_vari(inv_square(avi->val_), avi) {}
@@ -16,7 +16,7 @@ class inv_square_vari : public op_v_vari {
     avi_->adj_ -= 2 * adj_ / (avi_->val_ * avi_->val_ * avi_->val_);
   }
 };
-}  // namespace
+}  // namespace internal
 
 /**
  *
@@ -37,7 +37,7 @@ class inv_square_vari : public op_v_vari {
    \f]
  *
  */
-inline var inv_square(const var& a) { return var(new inv_square_vari(a.vi_)); }
+inline var inv_square(const var& a) { return var(new internal::inv_square_vari(a.vi_)); }
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/rev/scal/fun/lgamma.hpp
+++ b/stan/math/rev/scal/fun/lgamma.hpp
@@ -9,13 +9,13 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 class lgamma_vari : public op_v_vari {
  public:
   lgamma_vari(double value, vari* avi) : op_v_vari(value, avi) {}
   void chain() { avi_->adj_ += adj_ * digamma(avi_->val_); }
 };
-}  // namespace
+}  // namespace internal
 
 /**
  * The log gamma function for variables (C99).
@@ -28,7 +28,7 @@ class lgamma_vari : public op_v_vari {
  * @return Log gamma of the variable.
  */
 inline var lgamma(const var& a) {
-  return var(new lgamma_vari(lgamma(a.val()), a.vi_));
+  return var(new internal::lgamma_vari(lgamma(a.val()), a.vi_));
 }
 
 }  // namespace math

--- a/stan/math/rev/scal/fun/lgamma.hpp
+++ b/stan/math/rev/scal/fun/lgamma.hpp
@@ -9,7 +9,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 class lgamma_vari : public op_v_vari {
  public:
   lgamma_vari(double value, vari* avi) : op_v_vari(value, avi) {}

--- a/stan/math/rev/scal/fun/lmgamma.hpp
+++ b/stan/math/rev/scal/fun/lmgamma.hpp
@@ -10,7 +10,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 class lmgamma_dv_vari : public op_dv_vari {
  public:
   lmgamma_dv_vari(int a, vari* bvi)

--- a/stan/math/rev/scal/fun/lmgamma.hpp
+++ b/stan/math/rev/scal/fun/lmgamma.hpp
@@ -10,7 +10,7 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 class lmgamma_dv_vari : public op_dv_vari {
  public:
   lmgamma_dv_vari(int a, vari* bvi)
@@ -22,10 +22,10 @@ class lmgamma_dv_vari : public op_dv_vari {
     bvi_->adj_ += adj_ * deriv;
   }
 };
-}  // namespace
+}  // namespace internal
 
 inline var lmgamma(int a, const var& b) {
-  return var(new lmgamma_dv_vari(a, b.vi_));
+  return var(new internal::lmgamma_dv_vari(a, b.vi_));
 }
 
 }  // namespace math

--- a/stan/math/rev/scal/fun/log.hpp
+++ b/stan/math/rev/scal/fun/log.hpp
@@ -7,13 +7,13 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 class log_vari : public op_v_vari {
  public:
   explicit log_vari(vari* avi) : op_v_vari(std::log(avi->val_), avi) {}
   void chain() { avi_->adj_ += adj_ / avi_->val_; }
 };
-}  // namespace
+}  // namespace internal
 
 /**
  * Return the natural log of the specified variable (cmath).
@@ -43,7 +43,7 @@ class log_vari : public op_v_vari {
  * @param a Variable whose log is taken.
  * @return Natural log of variable.
  */
-inline var log(const var& a) { return var(new log_vari(a.vi_)); }
+inline var log(const var& a) { return var(new internal::log_vari(a.vi_)); }
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/rev/scal/fun/log.hpp
+++ b/stan/math/rev/scal/fun/log.hpp
@@ -7,7 +7,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 class log_vari : public op_v_vari {
  public:
   explicit log_vari(vari* avi) : op_v_vari(std::log(avi->val_), avi) {}

--- a/stan/math/rev/scal/fun/log10.hpp
+++ b/stan/math/rev/scal/fun/log10.hpp
@@ -8,7 +8,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 class log10_vari : public op_v_vari {
  public:
   const double exp_val_;

--- a/stan/math/rev/scal/fun/log10.hpp
+++ b/stan/math/rev/scal/fun/log10.hpp
@@ -8,7 +8,7 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 class log10_vari : public op_v_vari {
  public:
   const double exp_val_;
@@ -16,7 +16,7 @@ class log10_vari : public op_v_vari {
       : op_v_vari(std::log10(avi->val_), avi), exp_val_(avi->val_) {}
   void chain() { avi_->adj_ += adj_ / (LOG_10 * exp_val_); }
 };
-}  // namespace
+}  // namespace internal
 
 /**
  * Return the base 10 log of the specified variable (cmath).
@@ -47,7 +47,7 @@ class log10_vari : public op_v_vari {
  * @param a Variable whose log is taken.
  * @return Base 10 log of variable.
  */
-inline var log10(const var& a) { return var(new log10_vari(a.vi_)); }
+inline var log10(const var& a) { return var(new internal::log10_vari(a.vi_)); }
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/rev/scal/fun/log1m.hpp
+++ b/stan/math/rev/scal/fun/log1m.hpp
@@ -7,7 +7,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 class log1m_vari : public op_v_vari {
  public:
   explicit log1m_vari(vari* avi) : op_v_vari(log1m(avi->val_), avi) {}

--- a/stan/math/rev/scal/fun/log1m.hpp
+++ b/stan/math/rev/scal/fun/log1m.hpp
@@ -7,13 +7,13 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 class log1m_vari : public op_v_vari {
  public:
   explicit log1m_vari(vari* avi) : op_v_vari(log1m(avi->val_), avi) {}
   void chain() { avi_->adj_ += adj_ / (avi_->val_ - 1); }
 };
-}  // namespace
+}  // namespace internal
 
 /**
  * The log (1 - x) function for variables.
@@ -25,7 +25,7 @@ class log1m_vari : public op_v_vari {
  * @param a The variable.
  * @return The variable representing log of 1 minus the variable.
  */
-inline var log1m(const var& a) { return var(new log1m_vari(a.vi_)); }
+inline var log1m(const var& a) { return var(new internal::log1m_vari(a.vi_)); }
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/rev/scal/fun/log1m_exp.hpp
+++ b/stan/math/rev/scal/fun/log1m_exp.hpp
@@ -8,14 +8,14 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 class log1m_exp_v_vari : public op_v_vari {
  public:
   explicit log1m_exp_v_vari(vari* avi) : op_v_vari(log1m_exp(avi->val_), avi) {}
 
   void chain() { avi_->adj_ -= adj_ / expm1(-(avi_->val_)); }
 };
-}  // namespace
+}  // namespace internal
 
 /**
  * Return the log of 1 minus the exponential of the specified
@@ -28,7 +28,7 @@ class log1m_exp_v_vari : public op_v_vari {
  * @return Natural logarithm of one minus the exponential of the
  * argument.
  */
-inline var log1m_exp(const var& x) { return var(new log1m_exp_v_vari(x.vi_)); }
+inline var log1m_exp(const var& x) { return var(new internal::log1m_exp_v_vari(x.vi_)); }
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/rev/scal/fun/log1m_exp.hpp
+++ b/stan/math/rev/scal/fun/log1m_exp.hpp
@@ -8,7 +8,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 class log1m_exp_v_vari : public op_v_vari {
  public:
   explicit log1m_exp_v_vari(vari* avi) : op_v_vari(log1m_exp(avi->val_), avi) {}
@@ -28,7 +28,9 @@ class log1m_exp_v_vari : public op_v_vari {
  * @return Natural logarithm of one minus the exponential of the
  * argument.
  */
-inline var log1m_exp(const var& x) { return var(new internal::log1m_exp_v_vari(x.vi_)); }
+inline var log1m_exp(const var& x) {
+  return var(new internal::log1m_exp_v_vari(x.vi_));
+}
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/rev/scal/fun/log1p.hpp
+++ b/stan/math/rev/scal/fun/log1p.hpp
@@ -7,7 +7,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 class log1p_vari : public op_v_vari {
  public:
   explicit log1p_vari(vari* avi) : op_v_vari(log1p(avi->val_), avi) {}

--- a/stan/math/rev/scal/fun/log1p.hpp
+++ b/stan/math/rev/scal/fun/log1p.hpp
@@ -7,13 +7,13 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 class log1p_vari : public op_v_vari {
  public:
   explicit log1p_vari(vari* avi) : op_v_vari(log1p(avi->val_), avi) {}
   void chain() { avi_->adj_ += adj_ / (1 + avi_->val_); }
 };
-}  // namespace
+}  // namespace internal
 
 /**
  * The log (1 + x) function for variables (C99).
@@ -25,7 +25,7 @@ class log1p_vari : public op_v_vari {
  * @param a The variable.
  * @return The log of 1 plus the variable.
  */
-inline var log1p(const var& a) { return var(new log1p_vari(a.vi_)); }
+inline var log1p(const var& a) { return var(new internal::log1p_vari(a.vi_)); }
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/rev/scal/fun/log1p_exp.hpp
+++ b/stan/math/rev/scal/fun/log1p_exp.hpp
@@ -8,7 +8,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 class log1p_exp_v_vari : public op_v_vari {
  public:
   explicit log1p_exp_v_vari(vari* avi) : op_v_vari(log1p_exp(avi->val_), avi) {}
@@ -20,7 +20,9 @@ class log1p_exp_v_vari : public op_v_vari {
  * Return the log of 1 plus the exponential of the specified
  * variable.
  */
-inline var log1p_exp(const var& a) { return var(new internal::log1p_exp_v_vari(a.vi_)); }
+inline var log1p_exp(const var& a) {
+  return var(new internal::log1p_exp_v_vari(a.vi_));
+}
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/rev/scal/fun/log1p_exp.hpp
+++ b/stan/math/rev/scal/fun/log1p_exp.hpp
@@ -8,19 +8,19 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 class log1p_exp_v_vari : public op_v_vari {
  public:
   explicit log1p_exp_v_vari(vari* avi) : op_v_vari(log1p_exp(avi->val_), avi) {}
   void chain() { avi_->adj_ += adj_ * calculate_chain(avi_->val_, val_); }
 };
-}  // namespace
+}  // namespace internal
 
 /**
  * Return the log of 1 plus the exponential of the specified
  * variable.
  */
-inline var log1p_exp(const var& a) { return var(new log1p_exp_v_vari(a.vi_)); }
+inline var log1p_exp(const var& a) { return var(new internal::log1p_exp_v_vari(a.vi_)); }
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/rev/scal/fun/log2.hpp
+++ b/stan/math/rev/scal/fun/log2.hpp
@@ -8,13 +8,13 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 class log2_vari : public op_v_vari {
  public:
   explicit log2_vari(vari* avi) : op_v_vari(log2(avi->val_), avi) {}
   void chain() { avi_->adj_ += adj_ / (LOG_2 * avi_->val_); }
 };
-}  // namespace
+}  // namespace internal
 
 /**
  * Returns the base 2 logarithm of the specified variable (C99).
@@ -46,7 +46,7 @@ class log2_vari : public op_v_vari {
  * @param a Specified variable.
  * @return Base 2 logarithm of the variable.
  */
-inline var log2(const var& a) { return var(new log2_vari(a.vi_)); }
+inline var log2(const var& a) { return var(new internal::log2_vari(a.vi_)); }
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/rev/scal/fun/log2.hpp
+++ b/stan/math/rev/scal/fun/log2.hpp
@@ -8,7 +8,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 class log2_vari : public op_v_vari {
  public:
   explicit log2_vari(vari* avi) : op_v_vari(log2(avi->val_), avi) {}

--- a/stan/math/rev/scal/fun/log_diff_exp.hpp
+++ b/stan/math/rev/scal/fun/log_diff_exp.hpp
@@ -9,7 +9,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 class log_diff_exp_vv_vari : public op_vv_vari {
  public:
   log_diff_exp_vv_vari(vari* avi, vari* bvi)

--- a/stan/math/rev/scal/fun/log_diff_exp.hpp
+++ b/stan/math/rev/scal/fun/log_diff_exp.hpp
@@ -9,7 +9,7 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 class log_diff_exp_vv_vari : public op_vv_vari {
  public:
   log_diff_exp_vv_vari(vari* avi, vari* bvi)
@@ -31,7 +31,7 @@ class log_diff_exp_dv_vari : public op_dv_vari {
       : op_dv_vari(log_diff_exp(a, bvi->val_), a, bvi) {}
   void chain() { bvi_->adj_ -= adj_ / expm1(ad_ - bvi_->val_); }
 };
-}  // namespace
+}  // namespace internal
 
 /**
  * Returns the log difference of the exponentiated arguments.
@@ -41,7 +41,7 @@ class log_diff_exp_dv_vari : public op_dv_vari {
  * @return Log difference of the expnoentiated arguments.
  */
 inline var log_diff_exp(const var& a, const var& b) {
-  return var(new log_diff_exp_vv_vari(a.vi_, b.vi_));
+  return var(new internal::log_diff_exp_vv_vari(a.vi_, b.vi_));
 }
 
 /**
@@ -52,7 +52,7 @@ inline var log_diff_exp(const var& a, const var& b) {
  * @return Log difference of the expnoentiated arguments.
  */
 inline var log_diff_exp(const var& a, double b) {
-  return var(new log_diff_exp_vd_vari(a.vi_, b));
+  return var(new internal::log_diff_exp_vd_vari(a.vi_, b));
 }
 
 /**
@@ -63,7 +63,7 @@ inline var log_diff_exp(const var& a, double b) {
  * @return Log difference of the expnoentiated arguments.
  */
 inline var log_diff_exp(double a, const var& b) {
-  return var(new log_diff_exp_dv_vari(a, b.vi_));
+  return var(new internal::log_diff_exp_dv_vari(a, b.vi_));
 }
 
 }  // namespace math

--- a/stan/math/rev/scal/fun/log_falling_factorial.hpp
+++ b/stan/math/rev/scal/fun/log_falling_factorial.hpp
@@ -10,7 +10,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 
 class log_falling_factorial_vv_vari : public op_vv_vari {
  public:

--- a/stan/math/rev/scal/fun/log_falling_factorial.hpp
+++ b/stan/math/rev/scal/fun/log_falling_factorial.hpp
@@ -10,7 +10,7 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 
 class log_falling_factorial_vv_vari : public op_vv_vari {
  public:
@@ -53,18 +53,18 @@ class log_falling_factorial_dv_vari : public op_dv_vari {
       bvi_->adj_ += adj_ * digamma(ad_ - bvi_->val_ + 1);
   }
 };
-}  // namespace
+}  // namespace internal
 
 inline var log_falling_factorial(const var& a, double b) {
-  return var(new log_falling_factorial_vd_vari(a.vi_, b));
+  return var(new internal::log_falling_factorial_vd_vari(a.vi_, b));
 }
 
 inline var log_falling_factorial(const var& a, const var& b) {
-  return var(new log_falling_factorial_vv_vari(a.vi_, b.vi_));
+  return var(new internal::log_falling_factorial_vv_vari(a.vi_, b.vi_));
 }
 
 inline var log_falling_factorial(double a, const var& b) {
-  return var(new log_falling_factorial_dv_vari(a, b.vi_));
+  return var(new internal::log_falling_factorial_dv_vari(a, b.vi_));
 }
 
 }  // namespace math

--- a/stan/math/rev/scal/fun/log_inv_logit_diff.hpp
+++ b/stan/math/rev/scal/fun/log_inv_logit_diff.hpp
@@ -34,7 +34,7 @@ namespace math {
  * @return Result of log difference of inverse logits of arguments
  *          and gradients.
  */
-namespace internal{
+namespace internal {
 class log_inv_logit_diff_vv_vari : public op_vv_vari {
  public:
   log_inv_logit_diff_vv_vari(vari* avi, vari* bvi)

--- a/stan/math/rev/scal/fun/log_inv_logit_diff.hpp
+++ b/stan/math/rev/scal/fun/log_inv_logit_diff.hpp
@@ -34,7 +34,7 @@ namespace math {
  * @return Result of log difference of inverse logits of arguments
  *          and gradients.
  */
-namespace {
+namespace internal{
 class log_inv_logit_diff_vv_vari : public op_vv_vari {
  public:
   log_inv_logit_diff_vv_vari(vari* avi, vari* bvi)
@@ -65,18 +65,18 @@ class log_inv_logit_diff_dv_vari : public op_dv_vari {
     bvi_->adj_ -= adj_ * (inv(expm1(ad_ - bvi_->val_)) + inv_logit(bvi_->val_));
   }
 };
-}  // namespace
+}  // namespace internal
 
 inline var log_inv_logit_diff(const var& a, double b) {
-  return var(new log_inv_logit_diff_vd_vari(a.vi_, b));
+  return var(new internal::log_inv_logit_diff_vd_vari(a.vi_, b));
 }
 
 inline var log_inv_logit_diff(const var& a, const var& b) {
-  return var(new log_inv_logit_diff_vv_vari(a.vi_, b.vi_));
+  return var(new internal::log_inv_logit_diff_vv_vari(a.vi_, b.vi_));
 }
 
 inline var log_inv_logit_diff(double a, const var& b) {
-  return var(new log_inv_logit_diff_dv_vari(a, b.vi_));
+  return var(new internal::log_inv_logit_diff_dv_vari(a, b.vi_));
 }
 
 }  // namespace math

--- a/stan/math/rev/scal/fun/log_rising_factorial.hpp
+++ b/stan/math/rev/scal/fun/log_rising_factorial.hpp
@@ -9,7 +9,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 
 class log_rising_factorial_vv_vari : public op_vv_vari {
  public:

--- a/stan/math/rev/scal/fun/log_rising_factorial.hpp
+++ b/stan/math/rev/scal/fun/log_rising_factorial.hpp
@@ -9,7 +9,7 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 
 class log_rising_factorial_vv_vari : public op_vv_vari {
  public:
@@ -37,18 +37,18 @@ class log_rising_factorial_dv_vari : public op_dv_vari {
       : op_dv_vari(log_rising_factorial(a, bvi->val_), a, bvi) {}
   void chain() { bvi_->adj_ += adj_ * digamma(bvi_->val_ + ad_); }
 };
-}  // namespace
+}  // namespace internal
 
 inline var log_rising_factorial(const var& a, double b) {
-  return var(new log_rising_factorial_vd_vari(a.vi_, b));
+  return var(new internal::log_rising_factorial_vd_vari(a.vi_, b));
 }
 
 inline var log_rising_factorial(const var& a, const var& b) {
-  return var(new log_rising_factorial_vv_vari(a.vi_, b.vi_));
+  return var(new internal::log_rising_factorial_vv_vari(a.vi_, b.vi_));
 }
 
 inline var log_rising_factorial(double a, const var& b) {
-  return var(new log_rising_factorial_dv_vari(a, b.vi_));
+  return var(new internal::log_rising_factorial_dv_vari(a, b.vi_));
 }
 
 }  // namespace math

--- a/stan/math/rev/scal/fun/log_sum_exp.hpp
+++ b/stan/math/rev/scal/fun/log_sum_exp.hpp
@@ -8,7 +8,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 
 class log_sum_exp_vv_vari : public op_vv_vari {
  public:

--- a/stan/math/rev/scal/fun/log_sum_exp.hpp
+++ b/stan/math/rev/scal/fun/log_sum_exp.hpp
@@ -8,7 +8,7 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 
 class log_sum_exp_vv_vari : public op_vv_vari {
  public:
@@ -32,25 +32,25 @@ class log_sum_exp_dv_vari : public op_dv_vari {
   void chain() { bvi_->adj_ += adj_ * calculate_chain(bvi_->val_, val_); }
 };
 
-}  // namespace
+}  // namespace internal
 
 /**
  * Returns the log sum of exponentials.
  */
 inline var log_sum_exp(const var& a, const var& b) {
-  return var(new log_sum_exp_vv_vari(a.vi_, b.vi_));
+  return var(new internal::log_sum_exp_vv_vari(a.vi_, b.vi_));
 }
 /**
  * Returns the log sum of exponentials.
  */
 inline var log_sum_exp(const var& a, double b) {
-  return var(new log_sum_exp_vd_vari(a.vi_, b));
+  return var(new internal::log_sum_exp_vd_vari(a.vi_, b));
 }
 /**
  * Returns the log sum of exponentials.
  */
 inline var log_sum_exp(double a, const var& b) {
-  return var(new log_sum_exp_dv_vari(a, b.vi_));
+  return var(new internal::log_sum_exp_dv_vari(a, b.vi_));
 }
 
 }  // namespace math

--- a/stan/math/rev/scal/fun/modified_bessel_first_kind.hpp
+++ b/stan/math/rev/scal/fun/modified_bessel_first_kind.hpp
@@ -7,7 +7,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 
 class modified_bessel_first_kind_dv_vari : public op_dv_vari {
  public:

--- a/stan/math/rev/scal/fun/modified_bessel_first_kind.hpp
+++ b/stan/math/rev/scal/fun/modified_bessel_first_kind.hpp
@@ -7,7 +7,7 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 
 class modified_bessel_first_kind_dv_vari : public op_dv_vari {
  public:
@@ -20,10 +20,10 @@ class modified_bessel_first_kind_dv_vari : public op_dv_vari {
               + modified_bessel_first_kind(ad_ - 1, bvi_->val_));
   }
 };
-}  // namespace
+}  // namespace internal
 
 inline var modified_bessel_first_kind(int v, const var& a) {
-  return var(new modified_bessel_first_kind_dv_vari(v, a.vi_));
+  return var(new internal::modified_bessel_first_kind_dv_vari(v, a.vi_));
 }
 
 }  // namespace math

--- a/stan/math/rev/scal/fun/modified_bessel_second_kind.hpp
+++ b/stan/math/rev/scal/fun/modified_bessel_second_kind.hpp
@@ -7,7 +7,7 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 
 class modified_bessel_second_kind_dv_vari : public op_dv_vari {
  public:
@@ -20,10 +20,10 @@ class modified_bessel_second_kind_dv_vari : public op_dv_vari {
               + modified_bessel_second_kind(ad_ - 1, bvi_->val_));
   }
 };
-}  // namespace
+}  // namespace internal
 
 inline var modified_bessel_second_kind(int v, const var& a) {
-  return var(new modified_bessel_second_kind_dv_vari(v, a.vi_));
+  return var(new internal::modified_bessel_second_kind_dv_vari(v, a.vi_));
 }
 
 }  // namespace math

--- a/stan/math/rev/scal/fun/modified_bessel_second_kind.hpp
+++ b/stan/math/rev/scal/fun/modified_bessel_second_kind.hpp
@@ -7,7 +7,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 
 class modified_bessel_second_kind_dv_vari : public op_dv_vari {
  public:

--- a/stan/math/rev/scal/fun/multiply_log.hpp
+++ b/stan/math/rev/scal/fun/multiply_log.hpp
@@ -9,7 +9,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 class multiply_log_vv_vari : public op_vv_vari {
  public:
   multiply_log_vv_vari(vari* avi, vari* bvi)

--- a/stan/math/rev/scal/fun/multiply_log.hpp
+++ b/stan/math/rev/scal/fun/multiply_log.hpp
@@ -9,7 +9,7 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 class multiply_log_vv_vari : public op_vv_vari {
  public:
   multiply_log_vv_vari(vari* avi, vari* bvi)
@@ -51,7 +51,7 @@ class multiply_log_dv_vari : public op_dv_vari {
       bvi_->adj_ += adj_ * ad_ / bvi_->val_;
   }
 };
-}  // namespace
+}  // namespace internal
 
 /**
  * Return the value of a*log(b).
@@ -66,7 +66,7 @@ class multiply_log_dv_vari : public op_dv_vari {
  * @return Value of a*log(b)
  */
 inline var multiply_log(const var& a, const var& b) {
-  return var(new multiply_log_vv_vari(a.vi_, b.vi_));
+  return var(new internal::multiply_log_vv_vari(a.vi_, b.vi_));
 }
 /**
  * Return the value of a*log(b).
@@ -79,7 +79,7 @@ inline var multiply_log(const var& a, const var& b) {
  * @return Value of a*log(b)
  */
 inline var multiply_log(const var& a, double b) {
-  return var(new multiply_log_vd_vari(a.vi_, b));
+  return var(new internal::multiply_log_vd_vari(a.vi_, b));
 }
 /**
  * Return the value of a*log(b).
@@ -95,7 +95,7 @@ inline var multiply_log(const var& a, double b) {
 inline var multiply_log(double a, const var& b) {
   if (a == 1.0)
     return log(b);
-  return var(new multiply_log_dv_vari(a, b.vi_));
+  return var(new internal::multiply_log_dv_vari(a, b.vi_));
 }
 
 }  // namespace math

--- a/stan/math/rev/scal/fun/owens_t.hpp
+++ b/stan/math/rev/scal/fun/owens_t.hpp
@@ -11,7 +11,7 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 class owens_t_vv_vari : public op_vv_vari {
  public:
   owens_t_vv_vari(vari* avi, vari* bvi)
@@ -48,7 +48,7 @@ class owens_t_dv_vari : public op_dv_vari {
                   / (one_p_bvi_sq * 2.0 * pi());
   }
 };
-}  // namespace
+}  // namespace internal
 
 /**
  * The Owen's T function of h and a.
@@ -61,7 +61,7 @@ class owens_t_dv_vari : public op_dv_vari {
  * @return The Owen's T function.
  */
 inline var owens_t(const var& h, const var& a) {
-  return var(new owens_t_vv_vari(h.vi_, a.vi_));
+  return var(new internal::owens_t_vv_vari(h.vi_, a.vi_));
 }
 
 /**
@@ -75,7 +75,7 @@ inline var owens_t(const var& h, const var& a) {
  * @return The Owen's T function.
  */
 inline var owens_t(const var& h, double a) {
-  return var(new owens_t_vd_vari(h.vi_, a));
+  return var(new internal::owens_t_vd_vari(h.vi_, a));
 }
 
 /**
@@ -89,7 +89,7 @@ inline var owens_t(const var& h, double a) {
  * @return The Owen's T function.
  */
 inline var owens_t(double h, const var& a) {
-  return var(new owens_t_dv_vari(h, a.vi_));
+  return var(new internal::owens_t_dv_vari(h, a.vi_));
 }
 
 }  // namespace math

--- a/stan/math/rev/scal/fun/owens_t.hpp
+++ b/stan/math/rev/scal/fun/owens_t.hpp
@@ -11,7 +11,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 class owens_t_vv_vari : public op_vv_vari {
  public:
   owens_t_vv_vari(vari* avi, vari* bvi)

--- a/stan/math/rev/scal/fun/pow.hpp
+++ b/stan/math/rev/scal/fun/pow.hpp
@@ -130,7 +130,7 @@ inline var pow(const var& base, double exponent) {
     return inv(base);
   if (exponent == -0.5)
     return inv_sqrt(base);
-  return var(new pow_vd_vari(base.vi_, exponent));
+  return var(new internal::pow_vd_vari(base.vi_, exponent));
 }
 
 /**
@@ -146,7 +146,7 @@ inline var pow(const var& base, double exponent) {
  * @return Base raised to the exponent.
  */
 inline var pow(double base, const var& exponent) {
-  return var(new pow_dv_vari(base, exponent.vi_));
+  return var(new internal::pow_dv_vari(base, exponent.vi_));
 }
 
 }  // namespace math

--- a/stan/math/rev/scal/fun/pow.hpp
+++ b/stan/math/rev/scal/fun/pow.hpp
@@ -14,7 +14,7 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 class pow_vv_vari : public op_vv_vari {
  public:
   pow_vv_vari(vari* avi, vari* bvi)
@@ -61,7 +61,7 @@ class pow_dv_vari : public op_dv_vari {
     }
   }
 };
-}  // namespace
+}  // namespace internal
 
 /**
  * Return the base raised to the power of the exponent (cmath).
@@ -102,7 +102,7 @@ class pow_dv_vari : public op_dv_vari {
  * @return Base raised to the exponent.
  */
 inline var pow(const var& base, const var& exponent) {
-  return var(new pow_vv_vari(base.vi_, exponent.vi_));
+  return var(new internal::pow_vv_vari(base.vi_, exponent.vi_));
 }
 
 /**

--- a/stan/math/rev/scal/fun/pow.hpp
+++ b/stan/math/rev/scal/fun/pow.hpp
@@ -14,7 +14,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 class pow_vv_vari : public op_vv_vari {
  public:
   pow_vv_vari(vari* avi, vari* bvi)

--- a/stan/math/rev/scal/fun/round.hpp
+++ b/stan/math/rev/scal/fun/round.hpp
@@ -9,7 +9,7 @@
 namespace stan {
 namespace math {
 
-namespace internal::{
+namespace internal{
 class round_vari : public op_v_vari {
  public:
   explicit round_vari(vari* avi) : op_v_vari(round(avi->val_), avi) {}

--- a/stan/math/rev/scal/fun/round.hpp
+++ b/stan/math/rev/scal/fun/round.hpp
@@ -18,7 +18,7 @@ class round_vari : public op_v_vari {
       avi_->adj_ = std::numeric_limits<double>::quiet_NaN();
   }
 };
-}  // namespace
+}  // namespace internal
 
 /**
  * Returns the rounded form of the specified variable (C99).

--- a/stan/math/rev/scal/fun/round.hpp
+++ b/stan/math/rev/scal/fun/round.hpp
@@ -9,7 +9,7 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal::{
 class round_vari : public op_v_vari {
  public:
   explicit round_vari(vari* avi) : op_v_vari(round(avi->val_), avi) {}
@@ -50,7 +50,7 @@ class round_vari : public op_v_vari {
  * @param a Specified variable.
  * @return Rounded variable.
  */
-inline var round(const var& a) { return var(new round_vari(a.vi_)); }
+inline var round(const var& a) { return var(new internal::round_vari(a.vi_)); }
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/rev/scal/fun/round.hpp
+++ b/stan/math/rev/scal/fun/round.hpp
@@ -9,7 +9,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 class round_vari : public op_v_vari {
  public:
   explicit round_vari(vari* avi) : op_v_vari(round(avi->val_), avi) {}

--- a/stan/math/rev/scal/fun/sin.hpp
+++ b/stan/math/rev/scal/fun/sin.hpp
@@ -7,13 +7,13 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 class sin_vari : public op_v_vari {
  public:
   explicit sin_vari(vari* avi) : op_v_vari(std::sin(avi->val_), avi) {}
   void chain() { avi_->adj_ += adj_ * std::cos(avi_->val_); }
 };
-}  // namespace
+}  // namespace internal
 
 /**
  * Return the sine of a radian-scaled variable (cmath).
@@ -42,7 +42,7 @@ class sin_vari : public op_v_vari {
  * @param a Variable for radians of angle.
  * @return Sine of variable.
  */
-inline var sin(const var& a) { return var(new sin_vari(a.vi_)); }
+inline var sin(const var& a) { return var(new internal::sin_vari(a.vi_)); }
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/rev/scal/fun/sin.hpp
+++ b/stan/math/rev/scal/fun/sin.hpp
@@ -7,7 +7,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 class sin_vari : public op_v_vari {
  public:
   explicit sin_vari(vari* avi) : op_v_vari(std::sin(avi->val_), avi) {}

--- a/stan/math/rev/scal/fun/sinh.hpp
+++ b/stan/math/rev/scal/fun/sinh.hpp
@@ -7,7 +7,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 class sinh_vari : public op_v_vari {
  public:
   explicit sinh_vari(vari* avi) : op_v_vari(std::sinh(avi->val_), avi) {}

--- a/stan/math/rev/scal/fun/sinh.hpp
+++ b/stan/math/rev/scal/fun/sinh.hpp
@@ -7,13 +7,13 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 class sinh_vari : public op_v_vari {
  public:
   explicit sinh_vari(vari* avi) : op_v_vari(std::sinh(avi->val_), avi) {}
   void chain() { avi_->adj_ += adj_ * std::cosh(avi_->val_); }
 };
-}  // namespace
+}  // namespace internal
 
 /**
  * Return the hyperbolic sine of the specified variable (cmath).
@@ -42,7 +42,7 @@ class sinh_vari : public op_v_vari {
  * @param a Variable.
  * @return Hyperbolic sine of variable.
  */
-inline var sinh(const var& a) { return var(new sinh_vari(a.vi_)); }
+inline var sinh(const var& a) { return var(new internal::sinh_vari(a.vi_)); }
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/rev/scal/fun/sqrt.hpp
+++ b/stan/math/rev/scal/fun/sqrt.hpp
@@ -7,7 +7,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 class sqrt_vari : public op_v_vari {
  public:
   explicit sqrt_vari(vari* avi) : op_v_vari(std::sqrt(avi->val_), avi) {}

--- a/stan/math/rev/scal/fun/sqrt.hpp
+++ b/stan/math/rev/scal/fun/sqrt.hpp
@@ -7,13 +7,13 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 class sqrt_vari : public op_v_vari {
  public:
   explicit sqrt_vari(vari* avi) : op_v_vari(std::sqrt(avi->val_), avi) {}
   void chain() { avi_->adj_ += adj_ / (2.0 * val_); }
 };
-}  // namespace
+}  // namespace internal
 
 /**
  * Return the square root of the specified variable (cmath).
@@ -43,7 +43,7 @@ class sqrt_vari : public op_v_vari {
  * @param a Variable whose square root is taken.
  * @return Square root of variable.
  */
-inline var sqrt(const var& a) { return var(new sqrt_vari(a.vi_)); }
+inline var sqrt(const var& a) { return var(new internal::sqrt_vari(a.vi_)); }
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/rev/scal/fun/square.hpp
+++ b/stan/math/rev/scal/fun/square.hpp
@@ -6,7 +6,7 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 class square_vari : public op_v_vari {
  public:
   explicit square_vari(vari* avi) : op_v_vari(avi->val_ * avi->val_, avi) {}

--- a/stan/math/rev/scal/fun/square.hpp
+++ b/stan/math/rev/scal/fun/square.hpp
@@ -6,7 +6,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 class square_vari : public op_v_vari {
  public:
   explicit square_vari(vari* avi) : op_v_vari(avi->val_ * avi->val_, avi) {}
@@ -39,7 +39,9 @@ class square_vari : public op_v_vari {
  * @param x Variable to square.
  * @return Square of variable.
  */
-inline var square(const var& x) { return var(new internal::square_vari(x.vi_)); }
+inline var square(const var& x) {
+  return var(new internal::square_vari(x.vi_));
+}
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/rev/scal/fun/square.hpp
+++ b/stan/math/rev/scal/fun/square.hpp
@@ -39,7 +39,7 @@ class square_vari : public op_v_vari {
  * @param x Variable to square.
  * @return Square of variable.
  */
-inline var square(const var& x) { return var(new square_vari(x.vi_)); }
+inline var square(const var& x) { return var(new internal::square_vari(x.vi_)); }
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/rev/scal/fun/square.hpp
+++ b/stan/math/rev/scal/fun/square.hpp
@@ -12,7 +12,7 @@ class square_vari : public op_v_vari {
   explicit square_vari(vari* avi) : op_v_vari(avi->val_ * avi->val_, avi) {}
   void chain() { avi_->adj_ += adj_ * 2.0 * avi_->val_; }
 };
-}  // namespace
+}  // namespace internal
 
 /**
  * Return the square of the input variable.

--- a/stan/math/rev/scal/fun/tan.hpp
+++ b/stan/math/rev/scal/fun/tan.hpp
@@ -7,13 +7,13 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 class tan_vari : public op_v_vari {
  public:
   explicit tan_vari(vari* avi) : op_v_vari(std::tan(avi->val_), avi) {}
   void chain() { avi_->adj_ += adj_ * (1.0 + val_ * val_); }
 };
-}  // namespace
+}  // namespace internal
 
 /**
  * Return the tangent of a radian-scaled variable (cmath).
@@ -42,7 +42,7 @@ class tan_vari : public op_v_vari {
  * @param a Variable for radians of angle.
  * @return Tangent of variable.
  */
-inline var tan(const var& a) { return var(new tan_vari(a.vi_)); }
+inline var tan(const var& a) { return var(new internal::tan_vari(a.vi_)); }
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/rev/scal/fun/tan.hpp
+++ b/stan/math/rev/scal/fun/tan.hpp
@@ -7,7 +7,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 class tan_vari : public op_v_vari {
  public:
   explicit tan_vari(vari* avi) : op_v_vari(std::tan(avi->val_), avi) {}

--- a/stan/math/rev/scal/fun/tanh.hpp
+++ b/stan/math/rev/scal/fun/tanh.hpp
@@ -7,7 +7,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 class tanh_vari : public op_v_vari {
  public:
   explicit tanh_vari(vari* avi) : op_v_vari(std::tanh(avi->val_), avi) {}

--- a/stan/math/rev/scal/fun/tanh.hpp
+++ b/stan/math/rev/scal/fun/tanh.hpp
@@ -7,7 +7,7 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 class tanh_vari : public op_v_vari {
  public:
   explicit tanh_vari(vari* avi) : op_v_vari(std::tanh(avi->val_), avi) {}
@@ -16,7 +16,7 @@ class tanh_vari : public op_v_vari {
     avi_->adj_ += adj_ / (cosh * cosh);
   }
 };
-}  // namespace
+}  // namespace internal
 
 /**
  * Return the hyperbolic tangent of the specified variable (cmath).
@@ -45,7 +45,7 @@ class tanh_vari : public op_v_vari {
  * @param a Variable.
  * @return Hyperbolic tangent of variable.
  */
-inline var tanh(const var& a) { return var(new tanh_vari(a.vi_)); }
+inline var tanh(const var& a) { return var(new internal::tanh_vari(a.vi_)); }
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/rev/scal/fun/tgamma.hpp
+++ b/stan/math/rev/scal/fun/tgamma.hpp
@@ -8,7 +8,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 class tgamma_vari : public op_v_vari {
  public:
   explicit tgamma_vari(vari* avi) : op_v_vari(tgamma(avi->val_), avi) {}
@@ -52,7 +52,9 @@ class tgamma_vari : public op_v_vari {
  * @param a Argument to function.
  * @return The Gamma function applied to the specified argument.
  */
-inline var tgamma(const var& a) { return var(new internal::tgamma_vari(a.vi_)); }
+inline var tgamma(const var& a) {
+  return var(new internal::tgamma_vari(a.vi_));
+}
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/rev/scal/fun/tgamma.hpp
+++ b/stan/math/rev/scal/fun/tgamma.hpp
@@ -8,13 +8,13 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 class tgamma_vari : public op_v_vari {
  public:
   explicit tgamma_vari(vari* avi) : op_v_vari(tgamma(avi->val_), avi) {}
   void chain() { avi_->adj_ += adj_ * val_ * digamma(avi_->val_); }
 };
-}  // namespace
+}  // namespace internal
 
 /**
  * Return the Gamma function applied to the specified variable (C99).
@@ -52,7 +52,7 @@ class tgamma_vari : public op_v_vari {
  * @param a Argument to function.
  * @return The Gamma function applied to the specified argument.
  */
-inline var tgamma(const var& a) { return var(new tgamma_vari(a.vi_)); }
+inline var tgamma(const var& a) { return var(new internal::tgamma_vari(a.vi_)); }
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/rev/scal/fun/trunc.hpp
+++ b/stan/math/rev/scal/fun/trunc.hpp
@@ -9,7 +9,7 @@
 namespace stan {
 namespace math {
 
-namespace internal{
+namespace internal {
 class trunc_vari : public op_v_vari {
  public:
   explicit trunc_vari(vari* avi) : op_v_vari(trunc(avi->val_), avi) {}

--- a/stan/math/rev/scal/fun/trunc.hpp
+++ b/stan/math/rev/scal/fun/trunc.hpp
@@ -9,7 +9,7 @@
 namespace stan {
 namespace math {
 
-namespace {
+namespace internal{
 class trunc_vari : public op_v_vari {
  public:
   explicit trunc_vari(vari* avi) : op_v_vari(trunc(avi->val_), avi) {}
@@ -18,7 +18,7 @@ class trunc_vari : public op_v_vari {
       avi_->adj_ = std::numeric_limits<double>::quiet_NaN();
   }
 };
-}  // namespace
+}  // namespace internal
 
 /**
  * Returns the truncatation of the specified variable (C99).
@@ -50,7 +50,7 @@ class trunc_vari : public op_v_vari {
  * @param a Specified variable.
  * @return Truncation of the variable.
  */
-inline var trunc(const var& a) { return var(new trunc_vari(a.vi_)); }
+inline var trunc(const var& a) { return var(new internal::trunc_vari(a.vi_)); }
 
 }  // namespace math
 }  // namespace stan

--- a/test/unit/math/memory/stack_alloc_test.cpp
+++ b/test/unit/math/memory/stack_alloc_test.cpp
@@ -104,9 +104,11 @@ TEST(stack_alloc, in_stack) {
 TEST(stack_alloc, in_stack_second_block) {
   stan::math::stack_alloc allocator;
 
-  char* x = allocator.alloc_array<char>(stan::math::internal::DEFAULT_INITIAL_NBYTES);
+  char* x = allocator.alloc_array<char>(
+      stan::math::internal::DEFAULT_INITIAL_NBYTES);
   EXPECT_TRUE(allocator.in_stack(x));
-  EXPECT_FALSE(allocator.in_stack(x + stan::math::internal::DEFAULT_INITIAL_NBYTES));
+  EXPECT_FALSE(
+      allocator.in_stack(x + stan::math::internal::DEFAULT_INITIAL_NBYTES));
 
   char* y = allocator.alloc_array<char>(1);
   EXPECT_TRUE(allocator.in_stack(x));

--- a/test/unit/math/memory/stack_alloc_test.cpp
+++ b/test/unit/math/memory/stack_alloc_test.cpp
@@ -104,9 +104,9 @@ TEST(stack_alloc, in_stack) {
 TEST(stack_alloc, in_stack_second_block) {
   stan::math::stack_alloc allocator;
 
-  char* x = allocator.alloc_array<char>(stan::math::DEFAULT_INITIAL_NBYTES);
+  char* x = allocator.alloc_array<char>(stan::math::internal::DEFAULT_INITIAL_NBYTES);
   EXPECT_TRUE(allocator.in_stack(x));
-  EXPECT_FALSE(allocator.in_stack(x + stan::math::DEFAULT_INITIAL_NBYTES));
+  EXPECT_FALSE(allocator.in_stack(x + stan::math::internal::DEFAULT_INITIAL_NBYTES));
 
   char* y = allocator.alloc_array<char>(1);
   EXPECT_TRUE(allocator.in_stack(x));

--- a/test/unit/math/prim/mat/fun/autocorrelation_test.cpp
+++ b/test/unit/math/prim/mat/fun/autocorrelation_test.cpp
@@ -59,7 +59,7 @@ TEST(ProbAutocorrelation, test2) {
   EXPECT_NEAR(0.33, ac(5), 0.01);
 }
 
-TEST(ProbAutocorrelation, fft_next_good_size) {
+TEST(ProbAutocorrelation, fft_next_good_size_test) {
   EXPECT_EQ(2U, stan::math::internal::fft_next_good_size(0));
   EXPECT_EQ(2U, stan::math::internal::fft_next_good_size(1));
   EXPECT_EQ(2U, stan::math::internal::fft_next_good_size(2));

--- a/test/unit/math/prim/mat/fun/autocorrelation_test.cpp
+++ b/test/unit/math/prim/mat/fun/autocorrelation_test.cpp
@@ -60,12 +60,12 @@ TEST(ProbAutocorrelation, test2) {
 }
 
 TEST(ProbAutocorrelation, fft_next_good_size) {
-  EXPECT_EQ(2U, stan::math::fft_next_good_size(0));
-  EXPECT_EQ(2U, stan::math::fft_next_good_size(1));
-  EXPECT_EQ(2U, stan::math::fft_next_good_size(2));
-  EXPECT_EQ(3U, stan::math::fft_next_good_size(3));
+  EXPECT_EQ(2U, stan::math::internal::fft_next_good_size(0));
+  EXPECT_EQ(2U, stan::math::internal::fft_next_good_size(1));
+  EXPECT_EQ(2U, stan::math::internal::fft_next_good_size(2));
+  EXPECT_EQ(3U, stan::math::internal::fft_next_good_size(3));
 
-  EXPECT_EQ(4U, stan::math::fft_next_good_size(4));
-  EXPECT_EQ(128U, stan::math::fft_next_good_size(128));
-  EXPECT_EQ(135U, stan::math::fft_next_good_size(129));
+  EXPECT_EQ(4U, stan::math::internal::fft_next_good_size(4));
+  EXPECT_EQ(128U, stan::math::internal::fft_next_good_size(128));
+  EXPECT_EQ(135U, stan::math::internal::fft_next_good_size(129));
 }


### PR DESCRIPTION
## Summary

This PR cleans up the use of `namespace {` with the use of `namespace internal{`. This PR touches a lot of files but the changes are trivial.

`sort_indices` was moved outside of the anonymous namespace to the `stan::math` namespace as its used in some other files.

## Tests

/

## Side Effects

/

## Checklist

- [x] Math issue #1006 

- [x] Copyright holder: Rok Češnovar

- [x] the basic tests are passing

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
