### PR TITLE
Cleanup of "using stan::math::x" and "using stan::x" for non-ambiguous functions

### DIFF
--- a/stan/math/prim/mat/fun/gp_dot_prod_cov.hpp
+++ b/stan/math/prim/mat/fun/gp_dot_prod_cov.hpp
@@ -42,9 +42,6 @@ Eigen::Matrix<typename return_type<T_x, T_sigma>::type, Eigen::Dynamic,
               Eigen::Dynamic>
 gp_dot_prod_cov(const std::vector<Eigen::Matrix<T_x, Eigen::Dynamic, 1>> &x,
                 const T_sigma &sigma) {
-  using stan::math::dot_product;
-  using stan::math::square;
-
   check_not_nan("gp_dot_prod_cov", "sigma", sigma);
   check_nonnegative("gp_dot_prod_cov", "sigma", sigma);
   check_finite("gp_dot_prod_cov", "sigma", sigma);
@@ -100,9 +97,6 @@ template <typename T_x, typename T_sigma>
 Eigen::Matrix<typename return_type<T_x, T_sigma>::type, Eigen::Dynamic,
               Eigen::Dynamic>
 gp_dot_prod_cov(const std::vector<T_x> &x, const T_sigma &sigma) {
-  using stan::math::dot_product;
-  using stan::math::square;
-
   check_not_nan("gp_dot_prod_cov", "sigma", sigma);
   check_nonnegative("gp_dot_prod_cov", "sigma", sigma);
   check_finite("gp_dot_prod_cov", "sigma", sigma);
@@ -158,9 +152,6 @@ Eigen::Matrix<typename return_type<T_x1, T_x2, T_sigma>::type, Eigen::Dynamic,
 gp_dot_prod_cov(const std::vector<Eigen::Matrix<T_x1, Eigen::Dynamic, 1>> &x1,
                 const std::vector<Eigen::Matrix<T_x2, Eigen::Dynamic, 1>> &x2,
                 const T_sigma &sigma) {
-  using stan::math::dot_product;
-  using stan::math::square;
-
   check_not_nan("gp_dot_prod_cov", "sigma", sigma);
   check_nonnegative("gp_dot_prod_cov", "sigma", sigma);
   check_finite("gp_dot_prod_cov", "sigma", sigma);
@@ -219,8 +210,6 @@ Eigen::Matrix<typename return_type<T_x1, T_x2, T_sigma>::type, Eigen::Dynamic,
               Eigen::Dynamic>
 gp_dot_prod_cov(const std::vector<T_x1> &x1, const std::vector<T_x2> &x2,
                 const T_sigma &sigma) {
-  using stan::math::square;
-
   check_not_nan("gp_dot_prod_cov", "sigma", sigma);
   check_nonnegative("gp_dot_prod_cov", "sigma", sigma);
   check_finite("gp_dot_prod_cov", "sigma", sigma);

--- a/stan/math/prim/scal/err/check_consistent_sizes.hpp
+++ b/stan/math/prim/scal/err/check_consistent_sizes.hpp
@@ -29,7 +29,6 @@ template <typename T1, typename T2>
 inline void check_consistent_sizes(const char* function, const char* name1,
                                    const T1& x1, const char* name2,
                                    const T2& x2) {
-  using stan::is_vector;
   size_t max_size = std::max(is_vector<T1>::value * size_of(x1),
                              is_vector<T2>::value * size_of(x2));
   check_consistent_size(function, name1, x1, max_size);

--- a/stan/math/prim/scal/fun/choose.hpp
+++ b/stan/math/prim/scal/fun/choose.hpp
@@ -26,8 +26,6 @@ namespace math {
  * result will not fit in an int type
  */
 inline int choose(int n, int k) {
-  using stan::math::check_less_or_equal;
-  using stan::math::check_nonnegative;
   check_nonnegative("choose", "n", n);
   check_nonnegative("choose", "k", k);
   if (k > n)

--- a/stan/math/prim/scal/prob/bernoulli_logit_lpmf.hpp
+++ b/stan/math/prim/scal/prob/bernoulli_logit_lpmf.hpp
@@ -41,7 +41,6 @@ typename return_type<T_prob>::type bernoulli_logit_lpmf(const T_n& n,
   typedef
       typename stan::partials_return_type<T_n, T_prob>::type T_partials_return;
 
-  using stan::is_constant_struct;
   using std::exp;
 
   if (size_zero(n, theta))

--- a/stan/math/prim/scal/prob/bernoulli_logit_rng.hpp
+++ b/stan/math/prim/scal/prob/bernoulli_logit_rng.hpp
@@ -31,7 +31,6 @@ inline typename VectorBuilder<true, int, T_t>::type bernoulli_logit_rng(
     const T_t& t, RNG& rng) {
   using boost::bernoulli_distribution;
   using boost::variate_generator;
-  using stan::math::inv_logit;
 
   check_finite("bernoulli_logit_rng", "Logit transformed probability parameter",
                t);

--- a/stan/math/prim/scal/prob/beta_lpdf.hpp
+++ b/stan/math/prim/scal/prob/beta_lpdf.hpp
@@ -59,8 +59,6 @@ typename return_type<T_y, T_scale_succ, T_scale_fail>::type beta_lpdf(
       typename stan::partials_return_type<T_y, T_scale_succ, T_scale_fail>::type
           T_partials_return;
 
-  using stan::is_constant_struct;
-  using stan::is_vector;
   using std::log;
 
   if (size_zero(y, alpha, beta))

--- a/stan/math/prim/scal/prob/beta_proportion_lpdf.hpp
+++ b/stan/math/prim/scal/prob/beta_proportion_lpdf.hpp
@@ -54,7 +54,6 @@ typename return_type<T_y, T_loc, T_prec>::type beta_proportion_lpdf(
   typedef typename stan::partials_return_type<T_y, T_loc, T_prec>::type
       T_partials_return;
 
-  using stan::is_constant_struct;
   using std::log;
 
   if (size_zero(y, mu, kappa))

--- a/stan/math/prim/scal/prob/cauchy_lpdf.hpp
+++ b/stan/math/prim/scal/prob/cauchy_lpdf.hpp
@@ -47,8 +47,6 @@ typename return_type<T_y, T_loc, T_scale>::type cauchy_lpdf(
   typedef typename stan::partials_return_type<T_y, T_loc, T_scale>::type
       T_partials_return;
 
-  using stan::is_constant_struct;
-
   if (size_zero(y, mu, sigma))
     return 0.0;
 

--- a/stan/math/prim/scal/prob/double_exponential_lpdf.hpp
+++ b/stan/math/prim/scal/prob/double_exponential_lpdf.hpp
@@ -45,7 +45,6 @@ typename return_type<T_y, T_loc, T_scale>::type double_exponential_lpdf(
   typedef typename stan::partials_return_type<T_y, T_loc, T_scale>::type
       T_partials_return;
 
-  using stan::is_constant_struct;
   using std::fabs;
   using std::log;
   using std::log;

--- a/stan/math/prim/scal/prob/exp_mod_normal_lpdf.hpp
+++ b/stan/math/prim/scal/prob/exp_mod_normal_lpdf.hpp
@@ -31,7 +31,6 @@ exp_mod_normal_lpdf(const T_y& y, const T_loc& mu, const T_scale& sigma,
       typename stan::partials_return_type<T_y, T_loc, T_scale,
                                           T_inv_scale>::type T_partials_return;
 
-  using stan::is_constant_struct;
   using std::log;
 
   if (size_zero(y, mu, sigma, lambda))

--- a/stan/math/prim/scal/prob/gamma_lpdf.hpp
+++ b/stan/math/prim/scal/prob/gamma_lpdf.hpp
@@ -57,8 +57,6 @@ typename return_type<T_y, T_shape, T_inv_scale>::type gamma_lpdf(
   typedef typename stan::partials_return_type<T_y, T_shape, T_inv_scale>::type
       T_partials_return;
 
-  using stan::is_constant_struct;
-
   if (size_zero(y, alpha, beta))
     return 0.0;
 

--- a/stan/math/prim/scal/prob/gumbel_lpdf.hpp
+++ b/stan/math/prim/scal/prob/gumbel_lpdf.hpp
@@ -45,7 +45,6 @@ typename return_type<T_y, T_loc, T_scale>::type gumbel_lpdf(
   typedef typename stan::partials_return_type<T_y, T_loc, T_scale>::type
       T_partials_return;
 
-  using stan::is_constant_struct;
   using std::exp;
   using std::log;
 

--- a/stan/math/prim/scal/prob/inv_gamma_lpdf.hpp
+++ b/stan/math/prim/scal/prob/inv_gamma_lpdf.hpp
@@ -53,7 +53,7 @@ typename return_type<T_y, T_shape, T_scale>::type inv_gamma_lpdf(
       T_partials_return;
 
   using boost::math::tools::promote_args;
-  
+
   if (size_zero(y, alpha, beta))
     return 0.0;
 

--- a/stan/math/prim/scal/prob/inv_gamma_lpdf.hpp
+++ b/stan/math/prim/scal/prob/inv_gamma_lpdf.hpp
@@ -53,8 +53,7 @@ typename return_type<T_y, T_shape, T_scale>::type inv_gamma_lpdf(
       T_partials_return;
 
   using boost::math::tools::promote_args;
-  using stan::is_constant_struct;
-
+  
   if (size_zero(y, alpha, beta))
     return 0.0;
 

--- a/stan/math/prim/scal/prob/lognormal_lpdf.hpp
+++ b/stan/math/prim/scal/prob/lognormal_lpdf.hpp
@@ -34,8 +34,6 @@ typename return_type<T_y, T_loc, T_scale>::type lognormal_lpdf(
   typedef typename stan::partials_return_type<T_y, T_loc, T_scale>::type
       T_partials_return;
 
-  using stan::is_constant_struct;
-
   if (size_zero(y, mu, sigma))
     return 0.0;
 

--- a/stan/math/prim/scal/prob/normal_lpdf.hpp
+++ b/stan/math/prim/scal/prob/normal_lpdf.hpp
@@ -48,7 +48,6 @@ typename return_type<T_y, T_loc, T_scale>::type normal_lpdf(
   typedef typename stan::partials_return_type<T_y, T_loc, T_scale>::type
       T_partials_return;
 
-  using stan::is_constant_struct;
   using std::log;
   using std::log;
 

--- a/stan/math/prim/scal/prob/normal_sufficient_lpdf.hpp
+++ b/stan/math/prim/scal/prob/normal_sufficient_lpdf.hpp
@@ -56,13 +56,6 @@ typename return_type<T_y, T_s, T_loc, T_scale>::type normal_sufficient_lpdf(
       typename stan::partials_return_type<T_y, T_s, T_n, T_loc, T_scale>::type
           T_partials_return;
 
-  using stan::is_constant_struct;
-  using stan::math::check_consistent_sizes;
-  using stan::math::check_finite;
-  using stan::math::check_not_nan;
-  using stan::math::check_positive;
-  using stan::math::include_summand;
-  using stan::math::value_of;
   using std::log;
 
   // check if any vectors are zero length

--- a/stan/math/prim/scal/prob/rayleigh_cdf.hpp
+++ b/stan/math/prim/scal/prob/rayleigh_cdf.hpp
@@ -31,7 +31,6 @@ typename return_type<T_y, T_scale>::type rayleigh_cdf(const T_y& y,
   typedef
       typename stan::partials_return_type<T_y, T_scale>::type T_partials_return;
 
-  using stan::is_constant_struct;
   using std::exp;
 
   T_partials_return cdf(1.0);

--- a/stan/math/prim/scal/prob/rayleigh_lccdf.hpp
+++ b/stan/math/prim/scal/prob/rayleigh_lccdf.hpp
@@ -30,8 +30,6 @@ typename return_type<T_y, T_scale>::type rayleigh_lccdf(const T_y& y,
   typedef
       typename stan::partials_return_type<T_y, T_scale>::type T_partials_return;
 
-  using stan::is_constant_struct;
-
   T_partials_return ccdf_log(0.0);
 
   if (size_zero(y, sigma))

--- a/stan/math/prim/scal/prob/rayleigh_lcdf.hpp
+++ b/stan/math/prim/scal/prob/rayleigh_lcdf.hpp
@@ -31,7 +31,6 @@ typename return_type<T_y, T_scale>::type rayleigh_lcdf(const T_y& y,
   typedef
       typename stan::partials_return_type<T_y, T_scale>::type T_partials_return;
 
-  using stan::is_constant_struct;
   using std::exp;
 
   T_partials_return cdf_log(0.0);

--- a/stan/math/prim/scal/prob/rayleigh_lpdf.hpp
+++ b/stan/math/prim/scal/prob/rayleigh_lpdf.hpp
@@ -31,7 +31,6 @@ typename return_type<T_y, T_scale>::type rayleigh_lpdf(const T_y& y,
   typedef
       typename stan::partials_return_type<T_y, T_scale>::type T_partials_return;
 
-  using stan::is_constant_struct;
   using std::log;
   using std::log;
 

--- a/stan/math/prim/scal/prob/skew_normal_lpdf.hpp
+++ b/stan/math/prim/scal/prob/skew_normal_lpdf.hpp
@@ -33,7 +33,6 @@ typename return_type<T_y, T_loc, T_scale, T_shape>::type skew_normal_lpdf(
       typename stan::partials_return_type<T_y, T_loc, T_scale, T_shape>::type
           T_partials_return;
 
-  using stan::is_constant_struct;
   using std::exp;
   using std::log;
 

--- a/stan/math/prim/scal/prob/std_normal_lpdf.hpp
+++ b/stan/math/prim/scal/prob/std_normal_lpdf.hpp
@@ -33,8 +33,6 @@ typename return_type<T_y>::type std_normal_lpdf(const T_y& y) {
   static const char* function = "std_normal_lpdf";
   typedef typename stan::partials_return_type<T_y>::type T_partials_return;
 
-  using stan::is_constant_struct;
-
   if (size_zero(y))
     return 0.0;
 

--- a/stan/math/prim/scal/prob/von_mises_lpdf.hpp
+++ b/stan/math/prim/scal/prob/von_mises_lpdf.hpp
@@ -32,8 +32,6 @@ typename return_type<T_y, T_loc, T_scale>::type von_mises_lpdf(
   if (size_zero(y, mu, kappa))
     return 0.0;
 
-  using stan::is_constant_struct;
-
   using std::log;
 
   T_partials_return logp = 0.0;

--- a/stan/math/rev/mat/functor/idas_system.hpp
+++ b/stan/math/rev/mat/functor/idas_system.hpp
@@ -329,8 +329,6 @@ class idas_system {
   }
 
   void check_ic_consistency(const double& t0, const double& tol) {
-    using stan::math::dot_self;
-    using stan::math::value_of;
     const std::vector<double> theta_d(value_of(theta_));
     const std::vector<double> yy_d(value_of(yy_));
     const std::vector<double> yp_d(value_of(yp_));

--- a/stan/math/rev/scal/fun/log_mix.hpp
+++ b/stan/math/rev/scal/fun/log_mix.hpp
@@ -80,7 +80,6 @@ inline void log_mix_partial_helper(
 template <typename T_theta, typename T_lambda1, typename T_lambda2>
 inline typename return_type<T_theta, T_lambda1, T_lambda2>::type log_mix(
     const T_theta& theta, const T_lambda1& lambda1, const T_lambda2& lambda2) {
-  using stan::is_constant_struct;
   using std::log;
 
   operands_and_partials<T_theta, T_lambda1, T_lambda2> ops_partials(


### PR DESCRIPTION
## Summary

This is another slam-dunkish PR to cleanup some of the old issues. I am running some performance/tuning tests and have some downtime to go through this easy stuff. 

This PR removes the using statements for the following non-ambiguous functions:
```
stan::math::dot_self;
stan::math::include_summand;
stan::math::inv_logit;
stan::math::value_of;
stan::math::check_consistent_sizes;
stan::math::check_finite;
stan::math::check_not_nan;
stan::math::check_positive;
stan::math::check_less_or_equal;
stan::math::check_nonnegative;
stan::math::dot_product;
stan::math::square;

stan::is_constant_struct;
stan::is_vector;
```

The remaining using statements in `stan/math` are either in the `Eigen` namespace or for the following 
```
functions 
max_size
get
length
is_vector
round
lgamma
```


## Tests

/

## Side Effects

/

## Checklist

- [x] Math issue #594 and #426 

- [x] Copyright holder: Rok Češnovar, Univ. of Ljubljana

- [x] the basic tests are passing

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
