### PR TITLE
Replace regular multiply with triangular multiply in cholesky_decompose prim&rev

### DIFF
--- a/stan/math/opencl/cholesky_decompose.hpp
+++ b/stan/math/opencl/cholesky_decompose.hpp
@@ -80,8 +80,9 @@ inline matrix_cl cholesky_decompose(matrix_cl& A) {
   A_21.sub_block(A, block, 0, 0, 0, block_subset, block);
   // computes A_21*((L_11^-1)^T)
   // and copies the resulting submatrix to the lower left hand corner of A
-  matrix_cl L_21 = opencl::multiply<TriangularViewCL::Entire,
-      TriangularViewCL::Upper>(A_21, transpose(lower_triangular_inverse(L_11)));
+  matrix_cl L_21
+      = opencl::multiply<TriangularViewCL::Entire, TriangularViewCL::Upper>(
+          A_21, transpose(lower_triangular_inverse(L_11)));
   A.sub_block(L_21, 0, 0, block, 0, block_subset, block);
   matrix_cl A_22(block_subset, block_subset);
   A_22.sub_block(A, block, block, 0, 0, block_subset, block_subset);

--- a/stan/math/opencl/cholesky_decompose.hpp
+++ b/stan/math/opencl/cholesky_decompose.hpp
@@ -71,7 +71,7 @@ inline matrix_cl cholesky_decompose(matrix_cl& A) {
   // The following function either calls the
   // blocked cholesky recursively for the submatrix A_11
   // or calls the kernel  directly if the size of the block is small enough
-  matrix_cl L_11 = stan::math::cholesky_decompose(A_11);
+  matrix_cl L_11 = cholesky_decompose(A_11);
   // Copies L_11 back to the input matrix
   A.sub_block(L_11, 0, 0, 0, 0, block, block);
 
@@ -80,14 +80,14 @@ inline matrix_cl cholesky_decompose(matrix_cl& A) {
   A_21.sub_block(A, block, 0, 0, 0, block_subset, block);
   // computes A_21*((L_11^-1)^T)
   // and copies the resulting submatrix to the lower left hand corner of A
-  matrix_cl L_21 = A_21 * transpose(lower_triangular_inverse(L_11));
+  matrix_cl L_21 = opencl::multiply<TriangularViewCL::Entire, TriangularViewCL::Upper>(A_21, transpose(lower_triangular_inverse(L_11)));
   A.sub_block(L_21, 0, 0, block, 0, block_subset, block);
   matrix_cl A_22(block_subset, block_subset);
   A_22.sub_block(A, block, block, 0, 0, block_subset, block_subset);
   // computes A_22 - L_21*(L_21^T)
   matrix_cl L_22 = A_22 - multiply_transpose(L_21);
   // copy L_22 into A's lower left hand corner
-  matrix_cl L_rem_11 = stan::math::cholesky_decompose(L_22);
+  matrix_cl L_rem_11 = cholesky_decompose(L_22);
   A.sub_block(L_rem_11, 0, 0, block, block, block_subset, block_subset);
   check_nan("cholesky_decompose (OpenCL)", "Matrix m", A);
   check_diagonal_zeros("cholesky_decompose (OpenCL)", "Matrix m", A);

--- a/stan/math/opencl/cholesky_decompose.hpp
+++ b/stan/math/opencl/cholesky_decompose.hpp
@@ -80,7 +80,8 @@ inline matrix_cl cholesky_decompose(matrix_cl& A) {
   A_21.sub_block(A, block, 0, 0, 0, block_subset, block);
   // computes A_21*((L_11^-1)^T)
   // and copies the resulting submatrix to the lower left hand corner of A
-  matrix_cl L_21 = opencl::multiply<TriangularViewCL::Entire, TriangularViewCL::Upper>(A_21, transpose(lower_triangular_inverse(L_11)));
+  matrix_cl L_21 = opencl::multiply<TriangularViewCL::Entire,
+      TriangularViewCL::Upper>(A_21, transpose(lower_triangular_inverse(L_11)));
   A.sub_block(L_21, 0, 0, block, 0, block_subset, block);
   matrix_cl A_22(block_subset, block_subset);
   A_22.sub_block(A, block, block, 0, 0, block_subset, block_subset);

--- a/stan/math/rev/mat/fun/cholesky_decompose.hpp
+++ b/stan/math/rev/mat/fun/cholesky_decompose.hpp
@@ -127,7 +127,6 @@ class cholesky_block : public vari {
     using Eigen::Upper;
     auto L_adj = Eigen::MatrixXd::Zero(M_, M_).eval();
     auto L = Eigen::MatrixXd::Zero(M_, M_).eval();
-
     size_t pos = 0;
     for (size_type j = 0; j < M_; ++j) {
       for (size_type i = j; i < M_; ++i) {
@@ -303,10 +302,10 @@ class cholesky_opencl : public vari {
    * @param L_adj matrix of adjoints of L
    */
   inline void symbolic_rev(matrix_cl& L, matrix_cl& L_adj) {
-    L_adj = transpose(L) * L_adj;
+    L_adj = opencl::multiply<TriangularViewCL::Upper, TriangularViewCL::Entire>(transpose(L), L_adj);
     L_adj.triangular_transpose<TriangularMapCL::LowerToUpper>();
     L = transpose(lower_triangular_inverse(L));
-    L_adj = L * transpose(opencl::multiply<TriangularViewCL::Entire, TriangularViewCL::Upper>(L, L_adj));
+    L_adj = L * transpose(opencl::multiply<TriangularViewCL::Upper, TriangularViewCL::Entire>(L, L_adj));
     L_adj.triangular_transpose<TriangularMapCL::LowerToUpper>();
   }
 
@@ -330,7 +329,6 @@ class cholesky_opencl : public vari {
         ++pos;
       }
     }
-
     matrix_cl L(L_cpu);
     matrix_cl L_adj(L_adj_cpu);
     int block_size
@@ -366,7 +364,8 @@ class cholesky_opencl : public vari {
       B_adj.sub_block(L_adj, k, 0, 0, 0, m_k_ind, j);
       C_adj.sub_block(L_adj, k, j, 0, 0, m_k_ind, k_j_ind);
 
-      C_adj = opencl::multiply<TriangularViewCL::Entire, TriangularViewCL::Lower>(C_adj * lower_triangular_inverse(D));
+      C_adj = opencl::multiply<TriangularViewCL::Entire, TriangularViewCL::Lower>(C_adj, lower_triangular_inverse(D));
+      //C_adj = C_adj * lower_triangular_inverse(D);
       B_adj = B_adj - C_adj * R;
       D_adj = D_adj - transpose(C_adj) * C;
 
@@ -374,7 +373,7 @@ class cholesky_opencl : public vari {
 
       R_adj = R_adj - transpose(C_adj) * B - D_adj * R;
       D_adj = diagonal_multiply(D_adj, 0.5);
-      D_adj.zeros<stan::math::TriangularViewCL::Upper>();
+      D_adj.zeros<TriangularViewCL::Upper>();
 
       L_adj.sub_block(R_adj, 0, 0, j, 0, k_j_ind, j);
       L_adj.sub_block(D_adj, 0, 0, j, j, k_j_ind, k_j_ind);

--- a/stan/math/rev/mat/fun/cholesky_decompose.hpp
+++ b/stan/math/rev/mat/fun/cholesky_decompose.hpp
@@ -306,7 +306,7 @@ class cholesky_opencl : public vari {
     L_adj = transpose(L) * L_adj;
     L_adj.triangular_transpose<TriangularMapCL::LowerToUpper>();
     L = transpose(lower_triangular_inverse(L));
-    L_adj = L * transpose(L * L_adj);
+    L_adj = L * transpose(opencl::multiply<TriangularViewCL::Entire, TriangularViewCL::Upper>(L, L_adj));
     L_adj.triangular_transpose<TriangularMapCL::LowerToUpper>();
   }
 
@@ -366,7 +366,7 @@ class cholesky_opencl : public vari {
       B_adj.sub_block(L_adj, k, 0, 0, 0, m_k_ind, j);
       C_adj.sub_block(L_adj, k, j, 0, 0, m_k_ind, k_j_ind);
 
-      C_adj = C_adj * lower_triangular_inverse(D);
+      C_adj = opencl::multiply<TriangularViewCL::Entire, TriangularViewCL::Lower>(C_adj * lower_triangular_inverse(D));
       B_adj = B_adj - C_adj * R;
       D_adj = D_adj - transpose(C_adj) * C;
 

--- a/stan/math/rev/mat/fun/cholesky_decompose.hpp
+++ b/stan/math/rev/mat/fun/cholesky_decompose.hpp
@@ -302,12 +302,13 @@ class cholesky_opencl : public vari {
    * @param L_adj matrix of adjoints of L
    */
   inline void symbolic_rev(matrix_cl& L, matrix_cl& L_adj) {
-    L_adj = opencl::multiply<TriangularViewCL::Upper,
-                                TriangularViewCL::Entire>(transpose(L), L_adj);
+    L_adj = opencl::multiply<TriangularViewCL::Upper, TriangularViewCL::Entire>(
+        transpose(L), L_adj);
     L_adj.triangular_transpose<TriangularMapCL::LowerToUpper>();
     L = transpose(lower_triangular_inverse(L));
-    L_adj = L * transpose(opencl::multiply<TriangularViewCL::Upper,
-                                          TriangularViewCL::Entire>(L, L_adj));
+    L_adj = L
+            * transpose(opencl::multiply<TriangularViewCL::Upper,
+                                         TriangularViewCL::Entire>(L, L_adj));
     L_adj.triangular_transpose<TriangularMapCL::LowerToUpper>();
   }
 
@@ -366,8 +367,9 @@ class cholesky_opencl : public vari {
       B_adj.sub_block(L_adj, k, 0, 0, 0, m_k_ind, j);
       C_adj.sub_block(L_adj, k, j, 0, 0, m_k_ind, k_j_ind);
 
-      C_adj = opencl::multiply<TriangularViewCL::Entire,
-                  TriangularViewCL::Lower>(C_adj, lower_triangular_inverse(D));
+      C_adj
+          = opencl::multiply<TriangularViewCL::Entire, TriangularViewCL::Lower>(
+              C_adj, lower_triangular_inverse(D));
       B_adj = B_adj - C_adj * R;
       D_adj = D_adj - transpose(C_adj) * C;
 

--- a/stan/math/rev/mat/fun/cholesky_decompose.hpp
+++ b/stan/math/rev/mat/fun/cholesky_decompose.hpp
@@ -302,10 +302,12 @@ class cholesky_opencl : public vari {
    * @param L_adj matrix of adjoints of L
    */
   inline void symbolic_rev(matrix_cl& L, matrix_cl& L_adj) {
-    L_adj = opencl::multiply<TriangularViewCL::Upper, TriangularViewCL::Entire>(transpose(L), L_adj);
+    L_adj = opencl::multiply<TriangularViewCL::Upper,
+                                TriangularViewCL::Entire>(transpose(L), L_adj);
     L_adj.triangular_transpose<TriangularMapCL::LowerToUpper>();
     L = transpose(lower_triangular_inverse(L));
-    L_adj = L * transpose(opencl::multiply<TriangularViewCL::Upper, TriangularViewCL::Entire>(L, L_adj));
+    L_adj = L * transpose(opencl::multiply<TriangularViewCL::Upper,
+                                          TriangularViewCL::Entire>(L, L_adj));
     L_adj.triangular_transpose<TriangularMapCL::LowerToUpper>();
   }
 
@@ -364,8 +366,8 @@ class cholesky_opencl : public vari {
       B_adj.sub_block(L_adj, k, 0, 0, 0, m_k_ind, j);
       C_adj.sub_block(L_adj, k, j, 0, 0, m_k_ind, k_j_ind);
 
-      C_adj = opencl::multiply<TriangularViewCL::Entire, TriangularViewCL::Lower>(C_adj, lower_triangular_inverse(D));
-      //C_adj = C_adj * lower_triangular_inverse(D);
+      C_adj = opencl::multiply<TriangularViewCL::Entire,
+                  TriangularViewCL::Lower>(C_adj, lower_triangular_inverse(D));
       B_adj = B_adj - C_adj * R;
       D_adj = D_adj - transpose(C_adj) * C;
 


### PR DESCRIPTION
## Summary

This PR replaces the regular multiply with triangular multiply specialization in Cholesky prim/rev. It does not provide any breathtaking speedups due to the blocked nature of both algorithms that limit the sizes of these multiplies. Will post the expected speedups for both below.

Minor: removes two uses of stan::math:: in cholesky_decompose code.

## Tests

Re-run `./runTests.py test/unit -f cholesky_decompose`

## Side Effects

/

## Checklist

- [x] Math issue #1142 

- [x] Copyright holder: Rok Češnovar, Univ. of Ljubljana

- [x] the basic tests are passing

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
