### PR TITLE
Replace the use of OpenCL kernels with API calls for copies of rectangular buffers

### DIFF
--- a/stan/math/opencl/copy.hpp
+++ b/stan/math/opencl/copy.hpp
@@ -177,14 +177,15 @@ inline void copy(matrix_cl& dst, const matrix_cl& src) {
   if (src.size() == 0) {
     return;
   }
+  cl::CommandQueue queue = opencl_context.queue();
   try {
     /**
      * Copies the contents of the src buffer to the dst buffer
      * see the matrix_cl(matrix_cl&) constructor
      *  for explanation
      */
-    opencl_kernels::copy(cl::NDRange(dst.rows(), dst.cols()), src.buffer(),
-                         dst.buffer(), dst.rows(), dst.cols());
+    queue.enqueueCopyBuffer(src.buffer(), dst.buffer(), 0, 0,
+                            sizeof(double) * src.size());
   } catch (const cl::Error& e) {
     std::cout << e.err() << std::endl;
     check_opencl_error("copy (OpenCL)->(OpenCL)", e);

--- a/stan/math/opencl/matrix_cl.hpp
+++ b/stan/math/opencl/matrix_cl.hpp
@@ -213,27 +213,27 @@ class matrix_cl {
     try {
       if (triangular_view == TriangularViewCL::Entire) {
         cl::size_t<3> src_offset;
-        src_offset[0] = A_i*sizeof(double);
+        src_offset[0] = A_i * sizeof(double);
         src_offset[1] = A_j;
         src_offset[2] = 0;
         cl::size_t<3> dst_offset;
-        dst_offset[0] = this_i*sizeof(double);
+        dst_offset[0] = this_i * sizeof(double);
         dst_offset[1] = this_j;
         dst_offset[2] = 0;
         cl::size_t<3> size;
-        size[0] = nrows*sizeof(double);
+        size[0] = nrows * sizeof(double);
         size[1] = ncols;
         size[2] = 1;
-        cmdQueue.enqueueCopyBufferRect(A.buffer(), this->buffer(),
-              src_offset, dst_offset, size,
-              A.rows()*sizeof(double), A.rows()*A.cols()*sizeof(double),
-              sizeof(double)*this->rows(),
-              this->rows()*this->cols()*sizeof(double));
+        cmdQueue.enqueueCopyBufferRect(
+            A.buffer(), this->buffer(), src_offset, dst_offset, size,
+            A.rows() * sizeof(double), A.rows() * A.cols() * sizeof(double),
+            sizeof(double) * this->rows(),
+            this->rows() * this->cols() * sizeof(double));
       } else {
-              opencl_kernels::sub_block(cl::NDRange(nrows, ncols), A.buffer(),
-                                this->buffer(), A_i, A_j, this_i, this_j, nrows,
-                                ncols, A.rows(), A.cols(), this->rows(),
-                                this->cols(), triangular_view);
+        opencl_kernels::sub_block(cl::NDRange(nrows, ncols), A.buffer(),
+                                  this->buffer(), A_i, A_j, this_i, this_j,
+                                  nrows, ncols, A.rows(), A.cols(),
+                                  this->rows(), this->cols(), triangular_view);
       }
     } catch (const cl::Error& e) {
       check_opencl_error("copy_submatrix", e);

--- a/stan/math/opencl/matrix_cl.hpp
+++ b/stan/math/opencl/matrix_cl.hpp
@@ -200,8 +200,8 @@ class matrix_cl {
    * @param ncols the number of columns in the submatrix
    */
   template <TriangularViewCL triangular_view = TriangularViewCL::Entire>
-  void sub_block(const matrix_cl& A, size_t A_i, size_t A_j, size_t this_i, size_t this_j,
-                 size_t nrows, size_t ncols) {
+  void sub_block(const matrix_cl& A, size_t A_i, size_t A_j, size_t this_i,
+                 size_t this_j, size_t nrows, size_t ncols) {
     if (nrows == 0 || ncols == 0) {
       return;
     }
@@ -212,9 +212,12 @@ class matrix_cl {
     cl::CommandQueue cmdQueue = opencl_context.queue();
     try {
       if (triangular_view == TriangularViewCL::Entire) {
-        cl::size_t<3> src_offset = opencl::to_size_t({A_i * sizeof(double), A_j, 0});
-        cl::size_t<3> dst_offset = opencl::to_size_t({this_i * sizeof(double), this_j, 0});
-        cl::size_t<3> size = opencl::to_size_t({nrows * sizeof(double), ncols, 1});
+        cl::size_t<3> src_offset
+            = opencl::to_size_t({A_i * sizeof(double), A_j, 0});
+        cl::size_t<3> dst_offset
+            = opencl::to_size_t({this_i * sizeof(double), this_j, 0});
+        cl::size_t<3> size
+            = opencl::to_size_t({nrows * sizeof(double), ncols, 1});
         cmdQueue.enqueueCopyBufferRect(
             A.buffer(), this->buffer(), src_offset, dst_offset, size,
             A.rows() * sizeof(double), A.rows() * A.cols() * sizeof(double),

--- a/stan/math/opencl/matrix_cl.hpp
+++ b/stan/math/opencl/matrix_cl.hpp
@@ -200,8 +200,8 @@ class matrix_cl {
    * @param ncols the number of columns in the submatrix
    */
   template <TriangularViewCL triangular_view = TriangularViewCL::Entire>
-  void sub_block(const matrix_cl& A, int A_i, int A_j, int this_i, int this_j,
-                 int nrows, int ncols) {
+  void sub_block(const matrix_cl& A, size_t A_i, size_t A_j, size_t this_i, size_t this_j,
+                 size_t nrows, size_t ncols) {
     if (nrows == 0 || ncols == 0) {
       return;
     }
@@ -212,18 +212,9 @@ class matrix_cl {
     cl::CommandQueue cmdQueue = opencl_context.queue();
     try {
       if (triangular_view == TriangularViewCL::Entire) {
-        cl::size_t<3> src_offset;
-        src_offset[0] = A_i * sizeof(double);
-        src_offset[1] = A_j;
-        src_offset[2] = 0;
-        cl::size_t<3> dst_offset;
-        dst_offset[0] = this_i * sizeof(double);
-        dst_offset[1] = this_j;
-        dst_offset[2] = 0;
-        cl::size_t<3> size;
-        size[0] = nrows * sizeof(double);
-        size[1] = ncols;
-        size[2] = 1;
+        cl::size_t<3> src_offset = opencl::to_size_t({A_i * sizeof(double), A_j, 0});
+        cl::size_t<3> dst_offset = opencl::to_size_t({this_i * sizeof(double), this_j, 0});
+        cl::size_t<3> size = opencl::to_size_t({nrows * sizeof(double), ncols, 1});
         cmdQueue.enqueueCopyBufferRect(
             A.buffer(), this->buffer(), src_offset, dst_offset, size,
             A.rows() * sizeof(double), A.rows() * A.cols() * sizeof(double),

--- a/stan/math/opencl/matrix_cl.hpp
+++ b/stan/math/opencl/matrix_cl.hpp
@@ -211,10 +211,30 @@ class matrix_cl {
     }
     cl::CommandQueue cmdQueue = opencl_context.queue();
     try {
-      opencl_kernels::sub_block(cl::NDRange(nrows, ncols), A.buffer(),
+      if (triangular_view == TriangularViewCL::Entire) {
+        cl::size_t<3> src_offset;
+        src_offset[0] = A_i*sizeof(double);
+        src_offset[1] = A_j;
+        src_offset[2] = 0;
+        cl::size_t<3> dst_offset;
+        dst_offset[0] = this_i*sizeof(double);
+        dst_offset[1] = this_j;
+        dst_offset[2] = 0;
+        cl::size_t<3> size;
+        size[0] = nrows*sizeof(double);
+        size[1] = ncols;
+        size[2] = 1;
+        cmdQueue.enqueueCopyBufferRect(A.buffer(), this->buffer(),
+              src_offset, dst_offset, size,
+              A.rows()*sizeof(double), A.rows()*A.cols()*sizeof(double),
+              sizeof(double)*this->rows(),
+              this->rows()*this->cols()*sizeof(double));
+      } else {
+              opencl_kernels::sub_block(cl::NDRange(nrows, ncols), A.buffer(),
                                 this->buffer(), A_i, A_j, this_i, this_j, nrows,
                                 ncols, A.rows(), A.cols(), this->rows(),
                                 this->cols(), triangular_view);
+      }
     } catch (const cl::Error& e) {
       check_opencl_error("copy_submatrix", e);
     }

--- a/stan/math/opencl/opencl_context.hpp
+++ b/stan/math/opencl/opencl_context.hpp
@@ -33,7 +33,19 @@
  */
 namespace stan {
 namespace math {
-
+namespace opencl {
+/**
+ * A helper function to 
+ */
+template <size_t len=3>
+cl::size_t<len> to_size_t(std::vector<size_t> values) {
+  assert(values.size() ==len);
+  cl::size_t<len> s;
+  for (size_t i = 0; i < len; i++)
+    s[i] = values[i];
+  return s;
+}  
+}
 /**
  * The <code>opencl_context_base</code> class represents an OpenCL context
  * in the standard Meyers singleton design pattern.

--- a/stan/math/opencl/opencl_context.hpp
+++ b/stan/math/opencl/opencl_context.hpp
@@ -38,15 +38,15 @@ namespace opencl {
  * A helper function to convert a std::vector
  * to cl::size_t<3>
  */
-template <size_t len=3>
+template <size_t len = 3>
 cl::size_t<len> to_size_t(std::vector<size_t> values) {
-  assert(values.size() ==len);
+  assert(values.size() == len);
   cl::size_t<len> s;
   for (size_t i = 0; i < len; i++)
     s[i] = values[i];
   return s;
-}  
 }
+}  // namespace opencl
 /**
  * The <code>opencl_context_base</code> class represents an OpenCL context
  * in the standard Meyers singleton design pattern.

--- a/stan/math/opencl/opencl_context.hpp
+++ b/stan/math/opencl/opencl_context.hpp
@@ -35,7 +35,8 @@ namespace stan {
 namespace math {
 namespace opencl {
 /**
- * A helper function to 
+ * A helper function to convert a std::vector
+ * to cl::size_t<3>
  */
 template <size_t len=3>
 cl::size_t<len> to_size_t(std::vector<size_t> values) {


### PR DESCRIPTION
## Summary

This replaces the use of OpenCL kernels with the API calls for rectangular buffers. For triangular copies the kernels are still faster than API+`zeros()` kernel. See #1168 for benchmark results. Will post the benchmarks for triangular copies in a reply below.

## Tests

/

## Side Effects

/

## Checklist

- [x] Math issue #1168 

- [x] Copyright holder: Rok Češnovar, Univ. of Ljubljana
    
- [x] the basic tests are passing

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
