### PR TITLE
WIP Feature/faster ad tls v3B

### DIFF
--- a/stan/math/rev/arr/fun/sum.hpp
+++ b/stan/math/rev/arr/fun/sum.hpp
@@ -29,7 +29,7 @@ class sum_v_vari : public vari {
 
   explicit sum_v_vari(const std::vector<var>& v1)
       : vari(sum_of_val(v1)),
-        v_(reinterpret_cast<vari**>(ChainableStack::instance().memalloc_.alloc(
+        v_(reinterpret_cast<vari**>(ChainableStack::instance_->memalloc_.alloc(
             v1.size() * sizeof(vari*)))),
         length_(v1.size()) {
     for (size_t i = 0; i < length_; i++)

--- a/stan/math/rev/core/autodiffstackstorage.hpp
+++ b/stan/math/rev/core/autodiffstackstorage.hpp
@@ -90,19 +90,6 @@ struct AutodiffStackSingleton {
   explicit AutodiffStackSingleton(AutodiffStackSingleton_t const &) = delete;
   AutodiffStackSingleton &operator=(const AutodiffStackSingleton_t &) = delete;
 
-  static constexpr inline AutodiffStackStorage &instance() {
-    return *instance_;
-  }
-
- private:
-  static bool init() {
-    if (!instance_) {
-      instance_ = new AutodiffStackStorage();
-      return true;
-    }
-    return false;
-  }
-
   static
 #ifdef STAN_THREADS
 #ifdef __GNUC__
@@ -112,6 +99,15 @@ struct AutodiffStackSingleton {
 #endif
 #endif
       AutodiffStackStorage *instance_;
+
+ private:
+  static bool init() {
+    if (!instance_) {
+      instance_ = new AutodiffStackStorage();
+      return true;
+    }
+    return false;
+  }
 
   bool own_instance_;
 };

--- a/stan/math/rev/core/build_vari_array.hpp
+++ b/stan/math/rev/core/build_vari_array.hpp
@@ -20,7 +20,7 @@ namespace math {
 template <int R, int C>
 vari** build_vari_array(const Eigen::Matrix<var, R, C>& x) {
   vari** x_vi_
-      = ChainableStack::instance().memalloc_.alloc_array<vari*>(x.size());
+      = ChainableStack::instance_->memalloc_.alloc_array<vari*>(x.size());
   for (int i = 0; i < x.size(); ++i) {
     x_vi_[i] = x(i).vi_;
   }

--- a/stan/math/rev/core/chainable_alloc.hpp
+++ b/stan/math/rev/core/chainable_alloc.hpp
@@ -16,7 +16,7 @@ namespace math {
 class chainable_alloc {
  public:
   chainable_alloc() {
-    ChainableStack::instance().var_alloc_stack_.push_back(this);
+    ChainableStack::instance_->var_alloc_stack_.push_back(this);
   }
   virtual ~chainable_alloc() {}
 };

--- a/stan/math/rev/core/empty_nested.hpp
+++ b/stan/math/rev/core/empty_nested.hpp
@@ -10,7 +10,7 @@ namespace math {
  * Return true if there is no nested autodiff being executed.
  */
 static inline bool empty_nested() {
-  return ChainableStack::instance().nested_var_stack_sizes_.empty();
+  return ChainableStack::instance_->nested_var_stack_sizes_.empty();
 }
 
 }  // namespace math

--- a/stan/math/rev/core/gevv_vvv_vari.hpp
+++ b/stan/math/rev/core/gevv_vvv_vari.hpp
@@ -32,7 +32,7 @@ class gevv_vvv_vari : public vari {
         length_(length) {
     alpha_ = alpha->vi_;
     // TODO(carpenter): replace this with array alloc fun call
-    v1_ = reinterpret_cast<vari**>(ChainableStack::instance().memalloc_.alloc(
+    v1_ = reinterpret_cast<vari**>(ChainableStack::instance_->memalloc_.alloc(
         2 * length_ * sizeof(vari*)));
     v2_ = v1_ + length_;
     for (size_t i = 0; i < length_; i++)

--- a/stan/math/rev/core/grad.hpp
+++ b/stan/math/rev/core/grad.hpp
@@ -37,8 +37,8 @@ static void grad(vari* vi) {
 
   typedef std::vector<vari*>::reverse_iterator it_t;
   vi->init_dependent();
-  it_t begin = ChainableStack::instance().var_stack_.rbegin();
-  it_t end = empty_nested() ? ChainableStack::instance().var_stack_.rend()
+  it_t begin = ChainableStack::instance_->var_stack_.rbegin();
+  it_t end = empty_nested() ? ChainableStack::instance_->var_stack_.rend()
                             : begin + nested_size();
   for (it_t it = begin; it < end; ++it) {
     (*it)->chain();

--- a/stan/math/rev/core/nested_size.hpp
+++ b/stan/math/rev/core/nested_size.hpp
@@ -8,8 +8,8 @@ namespace stan {
 namespace math {
 
 static inline size_t nested_size() {
-  return ChainableStack::instance().var_stack_.size()
-         - ChainableStack::instance().nested_var_stack_sizes_.back();
+  return ChainableStack::instance_->var_stack_.size()
+         - ChainableStack::instance_->nested_var_stack_sizes_.back();
 }
 
 }  // namespace math

--- a/stan/math/rev/core/precomputed_gradients.hpp
+++ b/stan/math/rev/core/precomputed_gradients.hpp
@@ -52,9 +52,9 @@ class precomputed_gradients_vari : public vari {
                              const std::vector<double>& gradients)
       : vari(val),
         size_(vars.size()),
-        varis_(ChainableStack::instance().memalloc_.alloc_array<vari*>(
+        varis_(ChainableStack::instance_->memalloc_.alloc_array<vari*>(
             vars.size())),
-        gradients_(ChainableStack::instance().memalloc_.alloc_array<double>(
+        gradients_(ChainableStack::instance_->memalloc_.alloc_array<double>(
             vars.size())) {
     check_consistent_sizes("precomputed_gradients_vari", "vars", vars,
                            "gradients", gradients);

--- a/stan/math/rev/core/print_stack.hpp
+++ b/stan/math/rev/core/print_stack.hpp
@@ -18,14 +18,14 @@ namespace math {
  * @param o ostream to modify
  */
 inline void print_stack(std::ostream& o) {
-  o << "STACK, size=" << ChainableStack::instance().var_stack_.size()
+  o << "STACK, size=" << ChainableStack::instance_->var_stack_.size()
     << std::endl;
   // TODO(carpenter): this shouldn't need to be cast any more
-  for (size_t i = 0; i < ChainableStack::instance().var_stack_.size(); ++i)
-    o << i << "  " << ChainableStack::instance().var_stack_[i] << "  "
-      << (static_cast<vari*>(ChainableStack::instance().var_stack_[i]))->val_
+  for (size_t i = 0; i < ChainableStack::instance_->var_stack_.size(); ++i)
+    o << i << "  " << ChainableStack::instance_->var_stack_[i] << "  "
+      << (static_cast<vari*>(ChainableStack::instance_->var_stack_[i]))->val_
       << " : "
-      << (static_cast<vari*>(ChainableStack::instance().var_stack_[i]))->adj_
+      << (static_cast<vari*>(ChainableStack::instance_->var_stack_[i]))->adj_
       << std::endl;
 }
 

--- a/stan/math/rev/core/recover_memory.hpp
+++ b/stan/math/rev/core/recover_memory.hpp
@@ -20,13 +20,13 @@ static inline void recover_memory() {
     throw std::logic_error(
         "empty_nested() must be true"
         " before calling recover_memory()");
-  ChainableStack::instance().var_stack_.clear();
-  ChainableStack::instance().var_nochain_stack_.clear();
-  for (auto &x : ChainableStack::instance().var_alloc_stack_) {
+  ChainableStack::instance_->var_stack_.clear();
+  ChainableStack::instance_->var_nochain_stack_.clear();
+  for (auto &x : ChainableStack::instance_->var_alloc_stack_) {
     delete x;
   }
-  ChainableStack::instance().var_alloc_stack_.clear();
-  ChainableStack::instance().memalloc_.recover_all();
+  ChainableStack::instance_->var_alloc_stack_.clear();
+  ChainableStack::instance_->memalloc_.recover_all();
 }
 
 }  // namespace math

--- a/stan/math/rev/core/recover_memory_nested.hpp
+++ b/stan/math/rev/core/recover_memory_nested.hpp
@@ -23,24 +23,24 @@ static inline void recover_memory_nested() {
         "empty_nested() must be false"
         " before calling recover_memory_nested()");
 
-  ChainableStack::instance().var_stack_.resize(
-      ChainableStack::instance().nested_var_stack_sizes_.back());
-  ChainableStack::instance().nested_var_stack_sizes_.pop_back();
+  ChainableStack::instance_->var_stack_.resize(
+      ChainableStack::instance_->nested_var_stack_sizes_.back());
+  ChainableStack::instance_->nested_var_stack_sizes_.pop_back();
 
-  ChainableStack::instance().var_nochain_stack_.resize(
-      ChainableStack::instance().nested_var_nochain_stack_sizes_.back());
-  ChainableStack::instance().nested_var_nochain_stack_sizes_.pop_back();
+  ChainableStack::instance_->var_nochain_stack_.resize(
+      ChainableStack::instance_->nested_var_nochain_stack_sizes_.back());
+  ChainableStack::instance_->nested_var_nochain_stack_sizes_.pop_back();
 
   for (size_t i
-       = ChainableStack::instance().nested_var_alloc_stack_starts_.back();
-       i < ChainableStack::instance().var_alloc_stack_.size(); ++i) {
-    delete ChainableStack::instance().var_alloc_stack_[i];
+       = ChainableStack::instance_->nested_var_alloc_stack_starts_.back();
+       i < ChainableStack::instance_->var_alloc_stack_.size(); ++i) {
+    delete ChainableStack::instance_->var_alloc_stack_[i];
   }
-  ChainableStack::instance().var_alloc_stack_.resize(
-      ChainableStack::instance().nested_var_alloc_stack_starts_.back());
-  ChainableStack::instance().nested_var_alloc_stack_starts_.pop_back();
+  ChainableStack::instance_->var_alloc_stack_.resize(
+      ChainableStack::instance_->nested_var_alloc_stack_starts_.back());
+  ChainableStack::instance_->nested_var_alloc_stack_starts_.pop_back();
 
-  ChainableStack::instance().memalloc_.recover_nested();
+  ChainableStack::instance_->memalloc_.recover_nested();
 }
 
 }  // namespace math

--- a/stan/math/rev/core/set_zero_all_adjoints.hpp
+++ b/stan/math/rev/core/set_zero_all_adjoints.hpp
@@ -12,9 +12,9 @@ namespace math {
  * Reset all adjoint values in the stack to zero.
  */
 static void set_zero_all_adjoints() {
-  for (auto &x : ChainableStack::instance().var_stack_)
+  for (auto &x : ChainableStack::instance_->var_stack_)
     x->set_zero_adjoint();
-  for (auto &x : ChainableStack::instance().var_nochain_stack_)
+  for (auto &x : ChainableStack::instance_->var_nochain_stack_)
     x->set_zero_adjoint();
 }
 

--- a/stan/math/rev/core/set_zero_all_adjoints_nested.hpp
+++ b/stan/math/rev/core/set_zero_all_adjoints_nested.hpp
@@ -19,17 +19,17 @@ static void set_zero_all_adjoints_nested() {
     throw std::logic_error(
         "empty_nested() must be false before calling"
         " set_zero_all_adjoints_nested()");
-  size_t start1 = ChainableStack::instance().nested_var_stack_sizes_.back();
+  size_t start1 = ChainableStack::instance_->nested_var_stack_sizes_.back();
   // avoid wrap with unsigned when start1 == 0
   for (size_t i = (start1 == 0U) ? 0U : (start1 - 1);
-       i < ChainableStack::instance().var_stack_.size(); ++i)
-    ChainableStack::instance().var_stack_[i]->set_zero_adjoint();
+       i < ChainableStack::instance_->var_stack_.size(); ++i)
+    ChainableStack::instance_->var_stack_[i]->set_zero_adjoint();
 
   size_t start2
-      = ChainableStack::instance().nested_var_nochain_stack_sizes_.back();
+      = ChainableStack::instance_->nested_var_nochain_stack_sizes_.back();
   for (size_t i = (start2 == 0U) ? 0U : (start2 - 1);
-       i < ChainableStack::instance().var_nochain_stack_.size(); ++i) {
-    ChainableStack::instance().var_nochain_stack_[i]->set_zero_adjoint();
+       i < ChainableStack::instance_->var_nochain_stack_.size(); ++i) {
+    ChainableStack::instance_->var_nochain_stack_[i]->set_zero_adjoint();
   }
 }
 

--- a/stan/math/rev/core/start_nested.hpp
+++ b/stan/math/rev/core/start_nested.hpp
@@ -11,13 +11,13 @@ namespace math {
  * can find it.
  */
 static inline void start_nested() {
-  ChainableStack::instance().nested_var_stack_sizes_.push_back(
-      ChainableStack::instance().var_stack_.size());
-  ChainableStack::instance().nested_var_nochain_stack_sizes_.push_back(
-      ChainableStack::instance().var_nochain_stack_.size());
-  ChainableStack::instance().nested_var_alloc_stack_starts_.push_back(
-      ChainableStack::instance().var_alloc_stack_.size());
-  ChainableStack::instance().memalloc_.start_nested();
+  ChainableStack::instance_->nested_var_stack_sizes_.push_back(
+      ChainableStack::instance_->var_stack_.size());
+  ChainableStack::instance_->nested_var_nochain_stack_sizes_.push_back(
+      ChainableStack::instance_->var_nochain_stack_.size());
+  ChainableStack::instance_->nested_var_alloc_stack_starts_.push_back(
+      ChainableStack::instance_->var_alloc_stack_.size());
+  ChainableStack::instance_->memalloc_.start_nested();
 }
 
 }  // namespace math

--- a/stan/math/rev/core/vari.hpp
+++ b/stan/math/rev/core/vari.hpp
@@ -56,14 +56,14 @@ class vari {
    * @param x Value of the constructed variable.
    */
   explicit vari(double x) : val_(x), adj_(0.0) {
-    ChainableStack::instance().var_stack_.push_back(this);
+    ChainableStack::instance_->var_stack_.push_back(this);
   }
 
   vari(double x, bool stacked) : val_(x), adj_(0.0) {
     if (stacked)
-      ChainableStack::instance().var_stack_.push_back(this);
+      ChainableStack::instance_->var_stack_.push_back(this);
     else
-      ChainableStack::instance().var_nochain_stack_.push_back(this);
+      ChainableStack::instance_->var_nochain_stack_.push_back(this);
   }
 
   /**
@@ -123,7 +123,7 @@ class vari {
    * @return Pointer to allocated bytes.
    */
   static inline void* operator new(size_t nbytes) {
-    return ChainableStack::instance().memalloc_.alloc(nbytes);
+    return ChainableStack::instance_->memalloc_.alloc(nbytes);
   }
 
   /**

--- a/stan/math/rev/mat/fun/cholesky_decompose.hpp
+++ b/stan/math/rev/mat/fun/cholesky_decompose.hpp
@@ -79,9 +79,9 @@ class cholesky_block : public vari {
                  const Eigen::Matrix<double, -1, -1>& L_A)
       : vari(0.0),
         M_(A.rows()),
-        vari_ref_A_(ChainableStack::instance().memalloc_.alloc_array<vari*>(
+        vari_ref_A_(ChainableStack::instance_->memalloc_.alloc_array<vari*>(
             A.rows() * (A.rows() + 1) / 2)),
-        vari_ref_L_(ChainableStack::instance().memalloc_.alloc_array<vari*>(
+        vari_ref_L_(ChainableStack::instance_->memalloc_.alloc_array<vari*>(
             A.rows() * (A.rows() + 1) / 2)) {
     size_t pos = 0;
     block_size_ = std::max(M_ / 8, 8);
@@ -191,9 +191,9 @@ class cholesky_scalar : public vari {
                   const Eigen::Matrix<double, -1, -1>& L_A)
       : vari(0.0),
         M_(A.rows()),
-        vari_ref_A_(ChainableStack::instance().memalloc_.alloc_array<vari*>(
+        vari_ref_A_(ChainableStack::instance_->memalloc_.alloc_array<vari*>(
             A.rows() * (A.rows() + 1) / 2)),
-        vari_ref_L_(ChainableStack::instance().memalloc_.alloc_array<vari*>(
+        vari_ref_L_(ChainableStack::instance_->memalloc_.alloc_array<vari*>(
             A.rows() * (A.rows() + 1) / 2)) {
     size_t accum = 0;
     size_t accum_i = accum;
@@ -281,9 +281,9 @@ class cholesky_opencl : public vari {
                   const Eigen::Matrix<double, -1, -1>& L_A)
       : vari(0.0),
         M_(A.rows()),
-        vari_ref_A_(ChainableStack::instance().memalloc_.alloc_array<vari*>(
+        vari_ref_A_(ChainableStack::instance_->memalloc_.alloc_array<vari*>(
             A.rows() * (A.rows() + 1) / 2)),
-        vari_ref_L_(ChainableStack::instance().memalloc_.alloc_array<vari*>(
+        vari_ref_L_(ChainableStack::instance_->memalloc_.alloc_array<vari*>(
             A.rows() * (A.rows() + 1) / 2)) {
     size_t pos = 0;
     for (size_type j = 0; j < M_; ++j) {

--- a/stan/math/rev/mat/fun/cov_exp_quad.hpp
+++ b/stan/math/rev/mat/fun/cov_exp_quad.hpp
@@ -46,14 +46,14 @@ class cov_exp_quad_vari : public vari {
         l_d_(value_of(l)),
         sigma_d_(value_of(sigma)),
         sigma_sq_d_(sigma_d_ * sigma_d_),
-        dist_(ChainableStack::instance().memalloc_.alloc_array<double>(
+        dist_(ChainableStack::instance_->memalloc_.alloc_array<double>(
             size_ltri_)),
         l_vari_(l.vi_),
         sigma_vari_(sigma.vi_),
-        cov_lower_(ChainableStack::instance().memalloc_.alloc_array<vari*>(
+        cov_lower_(ChainableStack::instance_->memalloc_.alloc_array<vari*>(
             size_ltri_)),
         cov_diag_(
-            ChainableStack::instance().memalloc_.alloc_array<vari*>(size_)) {
+            ChainableStack::instance_->memalloc_.alloc_array<vari*>(size_)) {
     double inv_half_sq_l_d = 0.5 / (l_d_ * l_d_);
     size_t pos = 0;
     for (size_t j = 0; j < size_ - 1; ++j) {
@@ -114,13 +114,13 @@ class cov_exp_quad_vari<T_x, double, T_l> : public vari {
         l_d_(value_of(l)),
         sigma_d_(value_of(sigma)),
         sigma_sq_d_(sigma_d_ * sigma_d_),
-        dist_(ChainableStack::instance().memalloc_.alloc_array<double>(
+        dist_(ChainableStack::instance_->memalloc_.alloc_array<double>(
             size_ltri_)),
         l_vari_(l.vi_),
-        cov_lower_(ChainableStack::instance().memalloc_.alloc_array<vari*>(
+        cov_lower_(ChainableStack::instance_->memalloc_.alloc_array<vari*>(
             size_ltri_)),
         cov_diag_(
-            ChainableStack::instance().memalloc_.alloc_array<vari*>(size_)) {
+            ChainableStack::instance_->memalloc_.alloc_array<vari*>(size_)) {
     double inv_half_sq_l_d = 0.5 / (l_d_ * l_d_);
     size_t pos = 0;
     for (size_t j = 0; j < size_ - 1; ++j) {

--- a/stan/math/rev/mat/fun/determinant.hpp
+++ b/stan/math/rev/mat/fun/determinant.hpp
@@ -24,10 +24,10 @@ class determinant_vari : public vari {
       : vari(determinant_vari_calc(A)),
         rows_(A.rows()),
         cols_(A.cols()),
-        A_(reinterpret_cast<double*>(ChainableStack::instance().memalloc_.alloc(
+        A_(reinterpret_cast<double*>(ChainableStack::instance_->memalloc_.alloc(
             sizeof(double) * A.rows() * A.cols()))),
         adjARef_(
-            reinterpret_cast<vari**>(ChainableStack::instance().memalloc_.alloc(
+            reinterpret_cast<vari**>(ChainableStack::instance_->memalloc_.alloc(
                 sizeof(vari*) * A.rows() * A.cols()))) {
     size_t pos = 0;
     for (size_type j = 0; j < cols_; j++) {

--- a/stan/math/rev/mat/fun/dot_product.hpp
+++ b/stan/math/rev/mat/fun/dot_product.hpp
@@ -84,7 +84,7 @@ class dot_product_vari : public vari {
                          vari** shared = nullptr) {
     if (shared == nullptr) {
       mem_v = reinterpret_cast<vari**>(
-          ChainableStack::instance().memalloc_.alloc(length_ * sizeof(vari*)));
+          ChainableStack::instance_->memalloc_.alloc(length_ * sizeof(vari*)));
       for (size_t i = 0; i < length_; i++)
         mem_v[i] = inv[i].vi_;
     } else {
@@ -96,7 +96,7 @@ class dot_product_vari : public vari {
                          vari** shared = nullptr) {
     if (shared == nullptr) {
       mem_v = reinterpret_cast<vari**>(
-          ChainableStack::instance().memalloc_.alloc(length_ * sizeof(vari*)));
+          ChainableStack::instance_->memalloc_.alloc(length_ * sizeof(vari*)));
       for (size_t i = 0; i < length_; i++)
         mem_v[i] = inv(i).vi_;
     } else {
@@ -108,7 +108,7 @@ class dot_product_vari : public vari {
                          double* shared = nullptr) {
     if (shared == nullptr) {
       mem_d = reinterpret_cast<double*>(
-          ChainableStack::instance().memalloc_.alloc(length_ * sizeof(double)));
+          ChainableStack::instance_->memalloc_.alloc(length_ * sizeof(double)));
       for (size_t i = 0; i < length_; i++)
         mem_d[i] = ind[i];
     } else {
@@ -120,7 +120,7 @@ class dot_product_vari : public vari {
                          double* shared = nullptr) {
     if (shared == nullptr) {
       mem_d = reinterpret_cast<double*>(
-          ChainableStack::instance().memalloc_.alloc(length_ * sizeof(double)));
+          ChainableStack::instance_->memalloc_.alloc(length_ * sizeof(double)));
       for (size_t i = 0; i < length_; i++)
         mem_d[i] = ind(i);
     } else {

--- a/stan/math/rev/mat/fun/dot_self.hpp
+++ b/stan/math/rev/mat/fun/dot_self.hpp
@@ -24,7 +24,7 @@ class dot_self_vari : public vari {
   explicit dot_self_vari(const Eigen::DenseBase<Derived>& v)
       : vari(var_dot_self(v)), size_(v.size()) {
     v_ = reinterpret_cast<vari**>(
-        ChainableStack::instance().memalloc_.alloc(size_ * sizeof(vari*)));
+        ChainableStack::instance_->memalloc_.alloc(size_ * sizeof(vari*)));
     for (size_t i = 0; i < size_; i++)
       v_[i] = v[i].vi_;
   }
@@ -32,7 +32,7 @@ class dot_self_vari : public vari {
   explicit dot_self_vari(const Eigen::Matrix<var, R, C>& v)
       : vari(var_dot_self(v)), size_(v.size()) {
     v_ = reinterpret_cast<vari**>(
-        ChainableStack::instance().memalloc_.alloc(size_ * sizeof(vari*)));
+        ChainableStack::instance_->memalloc_.alloc(size_ * sizeof(vari*)));
     for (size_t i = 0; i < size_; ++i)
       v_[i] = v(i).vi_;
   }

--- a/stan/math/rev/mat/fun/gp_exp_quad_cov.hpp
+++ b/stan/math/rev/mat/fun/gp_exp_quad_cov.hpp
@@ -71,14 +71,14 @@ class gp_exp_quad_cov_vari : public vari {
         l_d_(value_of(length_scale)),
         sigma_d_(value_of(sigma)),
         sigma_sq_d_(sigma_d_ * sigma_d_),
-        dist_(ChainableStack::instance().memalloc_.alloc_array<double>(
+        dist_(ChainableStack::instance_->memalloc_.alloc_array<double>(
             size_ltri_)),
         l_vari_(length_scale.vi_),
         sigma_vari_(sigma.vi_),
-        cov_lower_(ChainableStack::instance().memalloc_.alloc_array<vari *>(
+        cov_lower_(ChainableStack::instance_->memalloc_.alloc_array<vari *>(
             size_ltri_)),
         cov_diag_(
-            ChainableStack::instance().memalloc_.alloc_array<vari *>(size_)) {
+            ChainableStack::instance_->memalloc_.alloc_array<vari *>(size_)) {
     double inv_half_sq_l_d = 0.5 / (l_d_ * l_d_);
     size_t pos = 0;
     for (size_t j = 0; j < size_ - 1; ++j) {
@@ -164,13 +164,13 @@ class gp_exp_quad_cov_vari<T_x, double, T_l> : public vari {
         l_d_(value_of(length_scale)),
         sigma_d_(value_of(sigma)),
         sigma_sq_d_(sigma_d_ * sigma_d_),
-        dist_(ChainableStack::instance().memalloc_.alloc_array<double>(
+        dist_(ChainableStack::instance_->memalloc_.alloc_array<double>(
             size_ltri_)),
         l_vari_(length_scale.vi_),
-        cov_lower_(ChainableStack::instance().memalloc_.alloc_array<vari *>(
+        cov_lower_(ChainableStack::instance_->memalloc_.alloc_array<vari *>(
             size_ltri_)),
         cov_diag_(
-            ChainableStack::instance().memalloc_.alloc_array<vari *>(size_)) {
+            ChainableStack::instance_->memalloc_.alloc_array<vari *>(size_)) {
     double inv_half_sq_l_d = 0.5 / (l_d_ * l_d_);
     size_t pos = 0;
     for (size_t j = 0; j < size_ - 1; ++j) {

--- a/stan/math/rev/mat/fun/gp_periodic_cov.hpp
+++ b/stan/math/rev/mat/fun/gp_periodic_cov.hpp
@@ -98,19 +98,19 @@ class gp_periodic_cov_vari : public vari {
         sigma_d_(value_of(sigma)),
         p_d_(value_of(p)),
         sigma_sq_d_(sigma_d_ * sigma_d_),
-        dist_(ChainableStack::instance().memalloc_.alloc_array<double>(
+        dist_(ChainableStack::instance_->memalloc_.alloc_array<double>(
             size_ltri_)),
-        sin_2_dist_(ChainableStack::instance().memalloc_.alloc_array<double>(
+        sin_2_dist_(ChainableStack::instance_->memalloc_.alloc_array<double>(
             size_ltri_)),
-        sin_dist_sq_(ChainableStack::instance().memalloc_.alloc_array<double>(
+        sin_dist_sq_(ChainableStack::instance_->memalloc_.alloc_array<double>(
             size_ltri_)),
         l_vari_(l.vi_),
         sigma_vari_(sigma.vi_),
         p_vari_(p.vi_),
-        cov_lower_(ChainableStack::instance().memalloc_.alloc_array<vari *>(
+        cov_lower_(ChainableStack::instance_->memalloc_.alloc_array<vari *>(
             size_ltri_)),
         cov_diag_(
-            ChainableStack::instance().memalloc_.alloc_array<vari *>(size_)) {
+            ChainableStack::instance_->memalloc_.alloc_array<vari *>(size_)) {
     double neg_two_inv_l_sq = -2.0 / (l_d_ * l_d_);
     double pi_div_p = pi() / p_d_;
 
@@ -231,18 +231,18 @@ class gp_periodic_cov_vari<T_x, double, T_l, T_p> : public vari {
         sigma_d_(sigma),
         p_d_(value_of(p)),
         sigma_sq_d_(sigma_d_ * sigma_d_),
-        dist_(ChainableStack::instance().memalloc_.alloc_array<double>(
+        dist_(ChainableStack::instance_->memalloc_.alloc_array<double>(
             size_ltri_)),
-        sin_2_dist_(ChainableStack::instance().memalloc_.alloc_array<double>(
+        sin_2_dist_(ChainableStack::instance_->memalloc_.alloc_array<double>(
             size_ltri_)),
-        sin_dist_sq_(ChainableStack::instance().memalloc_.alloc_array<double>(
+        sin_dist_sq_(ChainableStack::instance_->memalloc_.alloc_array<double>(
             size_ltri_)),
         l_vari_(l.vi_),
         p_vari_(p.vi_),
-        cov_lower_(ChainableStack::instance().memalloc_.alloc_array<vari *>(
+        cov_lower_(ChainableStack::instance_->memalloc_.alloc_array<vari *>(
             size_ltri_)),
         cov_diag_(
-            ChainableStack::instance().memalloc_.alloc_array<vari *>(size_)) {
+            ChainableStack::instance_->memalloc_.alloc_array<vari *>(size_)) {
     double neg_two_inv_l_sq = -2.0 / (l_d_ * l_d_);
     double pi_div_p = pi() / p_d_;
 

--- a/stan/math/rev/mat/fun/log_determinant.hpp
+++ b/stan/math/rev/mat/fun/log_determinant.hpp
@@ -24,13 +24,13 @@ inline var log_determinant(const Eigen::Matrix<var, R, C>& m) {
   double val = hh.logAbsDeterminant();
 
   vari** varis
-      = ChainableStack::instance().memalloc_.alloc_array<vari*>(m.size());
+      = ChainableStack::instance_->memalloc_.alloc_array<vari*>(m.size());
   for (int i = 0; i < m.size(); ++i)
     varis[i] = m(i).vi_;
 
   Matrix<double, R, C> m_inv_transpose = hh.inverse().transpose();
   double* gradients
-      = ChainableStack::instance().memalloc_.alloc_array<double>(m.size());
+      = ChainableStack::instance_->memalloc_.alloc_array<double>(m.size());
   for (int i = 0; i < m.size(); ++i)
     gradients[i] = m_inv_transpose(i);
 

--- a/stan/math/rev/mat/fun/log_determinant_spd.hpp
+++ b/stan/math/rev/mat/fun/log_determinant_spd.hpp
@@ -43,12 +43,12 @@ inline var log_determinant_spd(const Eigen::Matrix<var, R, C>& m) {
                "log determininant of the matrix argument", val);
 
   vari** operands
-      = ChainableStack::instance().memalloc_.alloc_array<vari*>(m.size());
+      = ChainableStack::instance_->memalloc_.alloc_array<vari*>(m.size());
   for (int i = 0; i < m.size(); ++i)
     operands[i] = m(i).vi_;
 
   double* gradients
-      = ChainableStack::instance().memalloc_.alloc_array<double>(m.size());
+      = ChainableStack::instance_->memalloc_.alloc_array<double>(m.size());
   for (int i = 0; i < m.size(); ++i)
     gradients[i] = m_d(i);
 

--- a/stan/math/rev/mat/fun/mdivide_left.hpp
+++ b/stan/math/rev/mat/fun/mdivide_left.hpp
@@ -30,19 +30,19 @@ class mdivide_left_vv_vari : public vari {
         M_(A.rows()),
         N_(B.cols()),
         A_(reinterpret_cast<double *>(
-            ChainableStack::instance().memalloc_.alloc(sizeof(double) * A.rows()
+            ChainableStack::instance_->memalloc_.alloc(sizeof(double) * A.rows()
                                                        * A.cols()))),
         C_(reinterpret_cast<double *>(
-            ChainableStack::instance().memalloc_.alloc(sizeof(double) * B.rows()
+            ChainableStack::instance_->memalloc_.alloc(sizeof(double) * B.rows()
                                                        * B.cols()))),
         variRefA_(reinterpret_cast<vari **>(
-            ChainableStack::instance().memalloc_.alloc(sizeof(vari *) * A.rows()
+            ChainableStack::instance_->memalloc_.alloc(sizeof(vari *) * A.rows()
                                                        * A.cols()))),
         variRefB_(reinterpret_cast<vari **>(
-            ChainableStack::instance().memalloc_.alloc(sizeof(vari *) * B.rows()
+            ChainableStack::instance_->memalloc_.alloc(sizeof(vari *) * B.rows()
                                                        * B.cols()))),
         variRefC_(reinterpret_cast<vari **>(
-            ChainableStack::instance().memalloc_.alloc(sizeof(vari *) * B.rows()
+            ChainableStack::instance_->memalloc_.alloc(sizeof(vari *) * B.rows()
                                                        * B.cols()))) {
     using Eigen::Map;
     using Eigen::Matrix;
@@ -125,16 +125,16 @@ class mdivide_left_dv_vari : public vari {
         M_(A.rows()),
         N_(B.cols()),
         A_(reinterpret_cast<double *>(
-            ChainableStack::instance().memalloc_.alloc(sizeof(double) * A.rows()
+            ChainableStack::instance_->memalloc_.alloc(sizeof(double) * A.rows()
                                                        * A.cols()))),
         C_(reinterpret_cast<double *>(
-            ChainableStack::instance().memalloc_.alloc(sizeof(double) * B.rows()
+            ChainableStack::instance_->memalloc_.alloc(sizeof(double) * B.rows()
                                                        * B.cols()))),
         variRefB_(reinterpret_cast<vari **>(
-            ChainableStack::instance().memalloc_.alloc(sizeof(vari *) * B.rows()
+            ChainableStack::instance_->memalloc_.alloc(sizeof(vari *) * B.rows()
                                                        * B.cols()))),
         variRefC_(reinterpret_cast<vari **>(
-            ChainableStack::instance().memalloc_.alloc(sizeof(vari *) * B.rows()
+            ChainableStack::instance_->memalloc_.alloc(sizeof(vari *) * B.rows()
                                                        * B.cols()))) {
     using Eigen::Map;
     using Eigen::Matrix;
@@ -208,16 +208,16 @@ class mdivide_left_vd_vari : public vari {
         M_(A.rows()),
         N_(B.cols()),
         A_(reinterpret_cast<double *>(
-            ChainableStack::instance().memalloc_.alloc(sizeof(double) * A.rows()
+            ChainableStack::instance_->memalloc_.alloc(sizeof(double) * A.rows()
                                                        * A.cols()))),
         C_(reinterpret_cast<double *>(
-            ChainableStack::instance().memalloc_.alloc(sizeof(double) * B.rows()
+            ChainableStack::instance_->memalloc_.alloc(sizeof(double) * B.rows()
                                                        * B.cols()))),
         variRefA_(reinterpret_cast<vari **>(
-            ChainableStack::instance().memalloc_.alloc(sizeof(vari *) * A.rows()
+            ChainableStack::instance_->memalloc_.alloc(sizeof(vari *) * A.rows()
                                                        * A.cols()))),
         variRefC_(reinterpret_cast<vari **>(
-            ChainableStack::instance().memalloc_.alloc(sizeof(vari *) * B.rows()
+            ChainableStack::instance_->memalloc_.alloc(sizeof(vari *) * B.rows()
                                                        * B.cols()))) {
     using Eigen::Map;
     using Eigen::Matrix;

--- a/stan/math/rev/mat/fun/mdivide_left_ldlt.hpp
+++ b/stan/math/rev/mat/fun/mdivide_left_ldlt.hpp
@@ -50,10 +50,10 @@ class mdivide_left_ldlt_vv_vari : public vari {
         M_(A.rows()),
         N_(B.cols()),
         variRefB_(reinterpret_cast<vari **>(
-            ChainableStack::instance().memalloc_.alloc(sizeof(vari *) * B.rows()
+            ChainableStack::instance_->memalloc_.alloc(sizeof(vari *) * B.rows()
                                                        * B.cols()))),
         variRefC_(reinterpret_cast<vari **>(
-            ChainableStack::instance().memalloc_.alloc(sizeof(vari *) * B.rows()
+            ChainableStack::instance_->memalloc_.alloc(sizeof(vari *) * B.rows()
                                                        * B.cols()))),
         alloc_(new mdivide_left_ldlt_alloc<R1, C1, R2, C2>()),
         alloc_ldlt_(A.alloc_) {
@@ -126,10 +126,10 @@ class mdivide_left_ldlt_dv_vari : public vari {
         M_(A.rows()),
         N_(B.cols()),
         variRefB_(reinterpret_cast<vari **>(
-            ChainableStack::instance().memalloc_.alloc(sizeof(vari *) * B.rows()
+            ChainableStack::instance_->memalloc_.alloc(sizeof(vari *) * B.rows()
                                                        * B.cols()))),
         variRefC_(reinterpret_cast<vari **>(
-            ChainableStack::instance().memalloc_.alloc(sizeof(vari *) * B.rows()
+            ChainableStack::instance_->memalloc_.alloc(sizeof(vari *) * B.rows()
                                                        * B.cols()))),
         alloc_(new mdivide_left_ldlt_alloc<R1, C1, R2, C2>()) {
     using Eigen::Map;
@@ -199,7 +199,7 @@ class mdivide_left_ldlt_vd_vari : public vari {
         M_(A.rows()),
         N_(B.cols()),
         variRefC_(reinterpret_cast<vari **>(
-            ChainableStack::instance().memalloc_.alloc(sizeof(vari *) * B.rows()
+            ChainableStack::instance_->memalloc_.alloc(sizeof(vari *) * B.rows()
                                                        * B.cols()))),
         alloc_(new mdivide_left_ldlt_alloc<R1, C1, R2, C2>()),
         alloc_ldlt_(A.alloc_) {

--- a/stan/math/rev/mat/fun/mdivide_left_spd.hpp
+++ b/stan/math/rev/mat/fun/mdivide_left_spd.hpp
@@ -38,13 +38,13 @@ class mdivide_left_spd_vv_vari : public vari {
         M_(A.rows()),
         N_(B.cols()),
         variRefA_(reinterpret_cast<vari **>(
-            ChainableStack::instance().memalloc_.alloc(sizeof(vari *) * A.rows()
+            ChainableStack::instance_->memalloc_.alloc(sizeof(vari *) * A.rows()
                                                        * A.cols()))),
         variRefB_(reinterpret_cast<vari **>(
-            ChainableStack::instance().memalloc_.alloc(sizeof(vari *) * B.rows()
+            ChainableStack::instance_->memalloc_.alloc(sizeof(vari *) * B.rows()
                                                        * B.cols()))),
         variRefC_(reinterpret_cast<vari **>(
-            ChainableStack::instance().memalloc_.alloc(sizeof(vari *) * B.rows()
+            ChainableStack::instance_->memalloc_.alloc(sizeof(vari *) * B.rows()
                                                        * B.cols()))),
         alloc_(new mdivide_left_spd_alloc<R1, C1, R2, C2>()) {
     using Eigen::Map;
@@ -124,10 +124,10 @@ class mdivide_left_spd_dv_vari : public vari {
         M_(A.rows()),
         N_(B.cols()),
         variRefB_(reinterpret_cast<vari **>(
-            ChainableStack::instance().memalloc_.alloc(sizeof(vari *) * B.rows()
+            ChainableStack::instance_->memalloc_.alloc(sizeof(vari *) * B.rows()
                                                        * B.cols()))),
         variRefC_(reinterpret_cast<vari **>(
-            ChainableStack::instance().memalloc_.alloc(sizeof(vari *) * B.rows()
+            ChainableStack::instance_->memalloc_.alloc(sizeof(vari *) * B.rows()
                                                        * B.cols()))),
         alloc_(new mdivide_left_spd_alloc<R1, C1, R2, C2>()) {
     using Eigen::Map;
@@ -189,10 +189,10 @@ class mdivide_left_spd_vd_vari : public vari {
         M_(A.rows()),
         N_(B.cols()),
         variRefA_(reinterpret_cast<vari **>(
-            ChainableStack::instance().memalloc_.alloc(sizeof(vari *) * A.rows()
+            ChainableStack::instance_->memalloc_.alloc(sizeof(vari *) * A.rows()
                                                        * A.cols()))),
         variRefC_(reinterpret_cast<vari **>(
-            ChainableStack::instance().memalloc_.alloc(sizeof(vari *) * B.rows()
+            ChainableStack::instance_->memalloc_.alloc(sizeof(vari *) * B.rows()
                                                        * B.cols()))),
         alloc_(new mdivide_left_spd_alloc<R1, C1, R2, C2>()) {
     using Eigen::Map;

--- a/stan/math/rev/mat/fun/mdivide_left_tri.hpp
+++ b/stan/math/rev/mat/fun/mdivide_left_tri.hpp
@@ -30,19 +30,19 @@ class mdivide_left_tri_vv_vari : public vari {
         M_(A.rows()),
         N_(B.cols()),
         A_(reinterpret_cast<double *>(
-            ChainableStack::instance().memalloc_.alloc(sizeof(double) * A.rows()
+            ChainableStack::instance_->memalloc_.alloc(sizeof(double) * A.rows()
                                                        * A.cols()))),
         C_(reinterpret_cast<double *>(
-            ChainableStack::instance().memalloc_.alloc(sizeof(double) * B.rows()
+            ChainableStack::instance_->memalloc_.alloc(sizeof(double) * B.rows()
                                                        * B.cols()))),
         variRefA_(reinterpret_cast<vari **>(
-            ChainableStack::instance().memalloc_.alloc(sizeof(vari *) * A.rows()
+            ChainableStack::instance_->memalloc_.alloc(sizeof(vari *) * A.rows()
                                                        * (A.rows() + 1) / 2))),
         variRefB_(reinterpret_cast<vari **>(
-            ChainableStack::instance().memalloc_.alloc(sizeof(vari *) * B.rows()
+            ChainableStack::instance_->memalloc_.alloc(sizeof(vari *) * B.rows()
                                                        * B.cols()))),
         variRefC_(reinterpret_cast<vari **>(
-            ChainableStack::instance().memalloc_.alloc(sizeof(vari *) * B.rows()
+            ChainableStack::instance_->memalloc_.alloc(sizeof(vari *) * B.rows()
                                                        * B.cols()))) {
     using Eigen::Map;
     using Eigen::Matrix;
@@ -143,16 +143,16 @@ class mdivide_left_tri_dv_vari : public vari {
         M_(A.rows()),
         N_(B.cols()),
         A_(reinterpret_cast<double *>(
-            ChainableStack::instance().memalloc_.alloc(sizeof(double) * A.rows()
+            ChainableStack::instance_->memalloc_.alloc(sizeof(double) * A.rows()
                                                        * A.cols()))),
         C_(reinterpret_cast<double *>(
-            ChainableStack::instance().memalloc_.alloc(sizeof(double) * B.rows()
+            ChainableStack::instance_->memalloc_.alloc(sizeof(double) * B.rows()
                                                        * B.cols()))),
         variRefB_(reinterpret_cast<vari **>(
-            ChainableStack::instance().memalloc_.alloc(sizeof(vari *) * B.rows()
+            ChainableStack::instance_->memalloc_.alloc(sizeof(vari *) * B.rows()
                                                        * B.cols()))),
         variRefC_(reinterpret_cast<vari **>(
-            ChainableStack::instance().memalloc_.alloc(sizeof(vari *) * B.rows()
+            ChainableStack::instance_->memalloc_.alloc(sizeof(vari *) * B.rows()
                                                        * B.cols()))) {
     using Eigen::Map;
     using Eigen::Matrix;
@@ -228,16 +228,16 @@ class mdivide_left_tri_vd_vari : public vari {
         M_(A.rows()),
         N_(B.cols()),
         A_(reinterpret_cast<double *>(
-            ChainableStack::instance().memalloc_.alloc(sizeof(double) * A.rows()
+            ChainableStack::instance_->memalloc_.alloc(sizeof(double) * A.rows()
                                                        * A.cols()))),
         C_(reinterpret_cast<double *>(
-            ChainableStack::instance().memalloc_.alloc(sizeof(double) * B.rows()
+            ChainableStack::instance_->memalloc_.alloc(sizeof(double) * B.rows()
                                                        * B.cols()))),
         variRefA_(reinterpret_cast<vari **>(
-            ChainableStack::instance().memalloc_.alloc(sizeof(vari *) * A.rows()
+            ChainableStack::instance_->memalloc_.alloc(sizeof(vari *) * A.rows()
                                                        * (A.rows() + 1) / 2))),
         variRefC_(reinterpret_cast<vari **>(
-            ChainableStack::instance().memalloc_.alloc(sizeof(vari *) * B.rows()
+            ChainableStack::instance_->memalloc_.alloc(sizeof(vari *) * B.rows()
                                                        * B.cols()))) {
     using Eigen::Map;
     using Eigen::Matrix;

--- a/stan/math/rev/mat/fun/multiply.hpp
+++ b/stan/math/rev/mat/fun/multiply.hpp
@@ -71,13 +71,13 @@ class multiply_mat_vari : public vari {
         B_cols_(B.cols()),
         A_size_(A.size()),
         B_size_(B.size()),
-        Ad_(ChainableStack::instance().memalloc_.alloc_array<double>(A_size_)),
-        Bd_(ChainableStack::instance().memalloc_.alloc_array<double>(B_size_)),
+        Ad_(ChainableStack::instance_->memalloc_.alloc_array<double>(A_size_)),
+        Bd_(ChainableStack::instance_->memalloc_.alloc_array<double>(B_size_)),
         variRefA_(
-            ChainableStack::instance().memalloc_.alloc_array<vari*>(A_size_)),
+            ChainableStack::instance_->memalloc_.alloc_array<vari*>(A_size_)),
         variRefB_(
-            ChainableStack::instance().memalloc_.alloc_array<vari*>(B_size_)),
-        variRefAB_(ChainableStack::instance().memalloc_.alloc_array<vari*>(
+            ChainableStack::instance_->memalloc_.alloc_array<vari*>(B_size_)),
+        variRefAB_(ChainableStack::instance_->memalloc_.alloc_array<vari*>(
             A_rows_ * B_cols_)) {
     using Eigen::Map;
     using Eigen::MatrixXd;
@@ -158,12 +158,12 @@ class multiply_mat_vari<Ta, 1, Ca, Tb, 1> : public vari {
                     const Eigen::Matrix<Tb, Ca, 1>& B)
       : vari(0.0),
         size_(A.cols()),
-        Ad_(ChainableStack::instance().memalloc_.alloc_array<double>(size_)),
-        Bd_(ChainableStack::instance().memalloc_.alloc_array<double>(size_)),
+        Ad_(ChainableStack::instance_->memalloc_.alloc_array<double>(size_)),
+        Bd_(ChainableStack::instance_->memalloc_.alloc_array<double>(size_)),
         variRefA_(
-            ChainableStack::instance().memalloc_.alloc_array<vari*>(size_)),
+            ChainableStack::instance_->memalloc_.alloc_array<vari*>(size_)),
         variRefB_(
-            ChainableStack::instance().memalloc_.alloc_array<vari*>(size_)) {
+            ChainableStack::instance_->memalloc_.alloc_array<vari*>(size_)) {
     using Eigen::Map;
     using Eigen::RowVectorXd;
     using Eigen::VectorXd;
@@ -248,11 +248,11 @@ class multiply_mat_vari<double, Ra, Ca, Tb, Cb> : public vari {
         B_cols_(B.cols()),
         A_size_(A.size()),
         B_size_(B.size()),
-        Ad_(ChainableStack::instance().memalloc_.alloc_array<double>(A_size_)),
-        Bd_(ChainableStack::instance().memalloc_.alloc_array<double>(B_size_)),
+        Ad_(ChainableStack::instance_->memalloc_.alloc_array<double>(A_size_)),
+        Bd_(ChainableStack::instance_->memalloc_.alloc_array<double>(B_size_)),
         variRefB_(
-            ChainableStack::instance().memalloc_.alloc_array<vari*>(B_size_)),
-        variRefAB_(ChainableStack::instance().memalloc_.alloc_array<vari*>(
+            ChainableStack::instance_->memalloc_.alloc_array<vari*>(B_size_)),
+        variRefAB_(ChainableStack::instance_->memalloc_.alloc_array<vari*>(
             A_rows_ * B_cols_)) {
     using Eigen::Map;
     using Eigen::MatrixXd;
@@ -326,10 +326,10 @@ class multiply_mat_vari<double, 1, Ca, Tb, 1> : public vari {
                     const Eigen::Matrix<Tb, Ca, 1>& B)
       : vari(0.0),
         size_(A.cols()),
-        Ad_(ChainableStack::instance().memalloc_.alloc_array<double>(size_)),
-        Bd_(ChainableStack::instance().memalloc_.alloc_array<double>(size_)),
+        Ad_(ChainableStack::instance_->memalloc_.alloc_array<double>(size_)),
+        Bd_(ChainableStack::instance_->memalloc_.alloc_array<double>(size_)),
         variRefB_(
-            ChainableStack::instance().memalloc_.alloc_array<vari*>(size_)) {
+            ChainableStack::instance_->memalloc_.alloc_array<vari*>(size_)) {
     using Eigen::Map;
     using Eigen::RowVectorXd;
     using Eigen::VectorXd;
@@ -410,11 +410,11 @@ class multiply_mat_vari<Ta, Ra, Ca, double, Cb> : public vari {
         B_cols_(B.cols()),
         A_size_(A.size()),
         B_size_(B.size()),
-        Ad_(ChainableStack::instance().memalloc_.alloc_array<double>(A_size_)),
-        Bd_(ChainableStack::instance().memalloc_.alloc_array<double>(B_size_)),
+        Ad_(ChainableStack::instance_->memalloc_.alloc_array<double>(A_size_)),
+        Bd_(ChainableStack::instance_->memalloc_.alloc_array<double>(B_size_)),
         variRefA_(
-            ChainableStack::instance().memalloc_.alloc_array<vari*>(A_size_)),
-        variRefAB_(ChainableStack::instance().memalloc_.alloc_array<vari*>(
+            ChainableStack::instance_->memalloc_.alloc_array<vari*>(A_size_)),
+        variRefAB_(ChainableStack::instance_->memalloc_.alloc_array<vari*>(
             A_rows_ * B_cols_)) {
     using Eigen::Map;
     using Eigen::MatrixXd;
@@ -492,10 +492,10 @@ class multiply_mat_vari<Ta, 1, Ca, double, 1> : public vari {
                     const Eigen::Matrix<double, Ca, 1>& B)
       : vari(0.0),
         size_(A.cols()),
-        Ad_(ChainableStack::instance().memalloc_.alloc_array<double>(size_)),
-        Bd_(ChainableStack::instance().memalloc_.alloc_array<double>(size_)),
+        Ad_(ChainableStack::instance_->memalloc_.alloc_array<double>(size_)),
+        Bd_(ChainableStack::instance_->memalloc_.alloc_array<double>(size_)),
         variRefA_(
-            ChainableStack::instance().memalloc_.alloc_array<vari*>(size_)) {
+            ChainableStack::instance_->memalloc_.alloc_array<vari*>(size_)) {
     using Eigen::Map;
     using Eigen::RowVectorXd;
     using Eigen::VectorXd;

--- a/stan/math/rev/mat/fun/multiply_lower_tri_self_transpose.hpp
+++ b/stan/math/rev/mat/fun/multiply_lower_tri_self_transpose.hpp
@@ -33,7 +33,7 @@ inline matrix_v multiply_lower_tri_self_transpose(const matrix_v& L) {
   else  // if (K < J)
     Knz = (K * (K + 1)) / 2;
   vari** vs = reinterpret_cast<vari**>(
-      ChainableStack::instance().memalloc_.alloc(Knz * sizeof(vari*)));
+      ChainableStack::instance_->memalloc_.alloc(Knz * sizeof(vari*)));
   int pos = 0;
   for (int m = 0; m < K; ++m)
     for (int n = 0; n < ((J < (m + 1)) ? J : (m + 1)); ++n) {

--- a/stan/math/rev/mat/fun/ordered_constrain.hpp
+++ b/stan/math/rev/mat/fun/ordered_constrain.hpp
@@ -36,7 +36,7 @@ class ordered_constrain_op {
     if (N_ == 0)
       return y;
 
-    exp_x_ = ChainableStack::instance().memalloc_.alloc_array<double>(N_ - 1);
+    exp_x_ = ChainableStack::instance_->memalloc_.alloc_array<double>(N_ - 1);
 
     y[0] = x[0];
     for (int n = 1; n < N_; ++n) {

--- a/stan/math/rev/mat/fun/positive_ordered_constrain.hpp
+++ b/stan/math/rev/mat/fun/positive_ordered_constrain.hpp
@@ -36,7 +36,7 @@ class positive_ordered_constrain_op {
     if (N_ == 0)
       return y;
 
-    exp_x_ = ChainableStack::instance().memalloc_.alloc_array<double>(N_);
+    exp_x_ = ChainableStack::instance_->memalloc_.alloc_array<double>(N_);
 
     exp_x_[0] = exp(x[0]);
     y[0] = exp_x_[0];

--- a/stan/math/rev/mat/fun/sd.hpp
+++ b/stan/math/rev/mat/fun/sd.hpp
@@ -20,7 +20,7 @@ namespace internal {
 inline var calc_sd(size_t size, const var* dtrs) {
   using std::sqrt;
   vari** varis = reinterpret_cast<vari**>(
-      ChainableStack::instance().memalloc_.alloc(size * sizeof(vari*)));
+      ChainableStack::instance_->memalloc_.alloc(size * sizeof(vari*)));
   for (size_t i = 0; i < size; ++i)
     varis[i] = dtrs[i].vi_;
   double sum = 0.0;
@@ -35,7 +35,7 @@ inline var calc_sd(size_t size, const var* dtrs) {
   double variance = sum_of_squares / (size - 1);
   double sd = sqrt(variance);
   double* partials = reinterpret_cast<double*>(
-      ChainableStack::instance().memalloc_.alloc(size * sizeof(double)));
+      ChainableStack::instance_->memalloc_.alloc(size * sizeof(double)));
   if (sum_of_squares < 1e-20) {
     double grad_limit = 1 / std::sqrt(static_cast<double>(size));
     for (size_t i = 0; i < size; ++i)

--- a/stan/math/rev/mat/fun/simplex_constrain.hpp
+++ b/stan/math/rev/mat/fun/simplex_constrain.hpp
@@ -36,8 +36,8 @@ class simplex_constrain_op {
   Eigen::VectorXd operator()(const std::array<bool, size>& needs_adj,
                              const Eigen::VectorXd& y) {
     N_ = y.size();
-    diag_ = ChainableStack::instance().memalloc_.alloc_array<double>(N_);
-    z_ = ChainableStack::instance().memalloc_.alloc_array<double>(N_);
+    diag_ = ChainableStack::instance_->memalloc_.alloc_array<double>(N_);
+    z_ = ChainableStack::instance_->memalloc_.alloc_array<double>(N_);
 
     Eigen::Matrix<double, Eigen::Dynamic, 1> x(N_ + 1);
     double stick_len(1.0);

--- a/stan/math/rev/mat/fun/softmax.hpp
+++ b/stan/math/rev/mat/fun/softmax.hpp
@@ -29,7 +29,7 @@ class softmax_op {
   Eigen::VectorXd operator()(const std::array<bool, size>& needs_adj,
                              const Eigen::VectorXd& alpha) {
     N_ = alpha.size();
-    y_ = ChainableStack::instance().memalloc_.alloc_array<double>(N_);
+    y_ = ChainableStack::instance_->memalloc_.alloc_array<double>(N_);
 
     auto y = softmax(alpha);
     for (int n = 0; n < N_; ++n)

--- a/stan/math/rev/mat/fun/squared_distance.hpp
+++ b/stan/math/rev/mat/fun/squared_distance.hpp
@@ -44,12 +44,12 @@ class squared_distance_vv_vari : public vari {
                            const Eigen::Matrix<var, R2, C2>& v2)
       : vari(var_squared_distance(v1, v2)), length_(v1.size()) {
     v1_ = reinterpret_cast<vari**>(
-        ChainableStack::instance().memalloc_.alloc(length_ * sizeof(vari*)));
+        ChainableStack::instance_->memalloc_.alloc(length_ * sizeof(vari*)));
     for (size_t i = 0; i < length_; i++)
       v1_[i] = v1(i).vi_;
 
     v2_ = reinterpret_cast<vari**>(
-        ChainableStack::instance().memalloc_.alloc(length_ * sizeof(vari*)));
+        ChainableStack::instance_->memalloc_.alloc(length_ * sizeof(vari*)));
     for (size_t i = 0; i < length_; i++)
       v2_[i] = v2(i).vi_;
   }
@@ -88,12 +88,12 @@ class squared_distance_vd_vari : public vari {
                            const Eigen::Matrix<double, R2, C2>& v2)
       : vari(var_squared_distance(v1, v2)), length_(v1.size()) {
     v1_ = reinterpret_cast<vari**>(
-        ChainableStack::instance().memalloc_.alloc(length_ * sizeof(vari*)));
+        ChainableStack::instance_->memalloc_.alloc(length_ * sizeof(vari*)));
     for (size_t i = 0; i < length_; i++)
       v1_[i] = v1(i).vi_;
 
     v2_ = reinterpret_cast<double*>(
-        ChainableStack::instance().memalloc_.alloc(length_ * sizeof(double)));
+        ChainableStack::instance_->memalloc_.alloc(length_ * sizeof(double)));
     for (size_t i = 0; i < length_; i++)
       v2_[i] = v2(i);
   }

--- a/stan/math/rev/mat/fun/sum.hpp
+++ b/stan/math/rev/mat/fun/sum.hpp
@@ -29,7 +29,7 @@ class sum_eigen_v_vari : public sum_v_vari {
   explicit sum_eigen_v_vari(const Eigen::Matrix<var, R1, C1>& v1)
       : sum_v_vari(
             sum_of_val(v1),
-            reinterpret_cast<vari**>(ChainableStack::instance().memalloc_.alloc(
+            reinterpret_cast<vari**>(ChainableStack::instance_->memalloc_.alloc(
                 v1.size() * sizeof(vari*))),
             v1.size()) {
     for (size_t i = 0; i < length_; i++)

--- a/stan/math/rev/mat/fun/tcrossprod.hpp
+++ b/stan/math/rev/mat/fun/tcrossprod.hpp
@@ -34,7 +34,7 @@ inline matrix_v tcrossprod(const matrix_v& M) {
   matrix_v MMt(M.rows(), M.rows());
 
   vari** vs
-      = reinterpret_cast<vari**>(ChainableStack::instance().memalloc_.alloc(
+      = reinterpret_cast<vari**>(ChainableStack::instance_->memalloc_.alloc(
           (M.rows() * M.cols()) * sizeof(vari*)));
   int pos = 0;
   for (int m = 0; m < M.rows(); ++m)

--- a/stan/math/rev/mat/fun/unit_vector_constrain.hpp
+++ b/stan/math/rev/mat/fun/unit_vector_constrain.hpp
@@ -58,7 +58,7 @@ Eigen::Matrix<var, R, C> unit_vector_constrain(
   check_nonzero_size("unit_vector", "y", y);
 
   vari** y_vi_array = reinterpret_cast<vari**>(
-      ChainableStack::instance().memalloc_.alloc(sizeof(vari*) * y.size()));
+      ChainableStack::instance_->memalloc_.alloc(sizeof(vari*) * y.size()));
   for (int i = 0; i < y.size(); ++i)
     y_vi_array[i] = y.coeff(i).vi_;
 
@@ -71,7 +71,7 @@ Eigen::Matrix<var, R, C> unit_vector_constrain(
   Eigen::VectorXd unit_vector_d = y_d / norm;
 
   double* unit_vector_y_d_array = reinterpret_cast<double*>(
-      ChainableStack::instance().memalloc_.alloc(sizeof(double) * y_d.size()));
+      ChainableStack::instance_->memalloc_.alloc(sizeof(double) * y_d.size()));
   for (int i = 0; i < y_d.size(); ++i)
     unit_vector_y_d_array[i] = unit_vector_d.coeff(i);
 

--- a/stan/math/rev/mat/fun/variance.hpp
+++ b/stan/math/rev/mat/fun/variance.hpp
@@ -14,7 +14,7 @@ namespace math {
 namespace internal {
 
 inline var calc_variance(size_t size, const var* dtrs) {
-  vari** varis = ChainableStack::instance().memalloc_.alloc_array<vari*>(size);
+  vari** varis = ChainableStack::instance_->memalloc_.alloc_array<vari*>(size);
   for (size_t i = 0; i < size; ++i)
     varis[i] = dtrs[i].vi_;
   double sum = 0.0;
@@ -25,7 +25,7 @@ inline var calc_variance(size_t size, const var* dtrs) {
   double reciprocal_size_m1 = 1.0 / (size - 1);
   double two_over_size_m1 = 2.0 * reciprocal_size_m1;
   double* partials
-      = ChainableStack::instance().memalloc_.alloc_array<double>(size);
+      = ChainableStack::instance_->memalloc_.alloc_array<double>(size);
   for (size_t i = 0; i < size; ++i) {
     double diff = dtrs[i].vi_->val_ - mean;
     sum_of_squares += diff * diff;

--- a/stan/math/rev/mat/functor/adj_jac_apply.hpp
+++ b/stan/math/rev/mat/functor/adj_jac_apply.hpp
@@ -331,7 +331,7 @@ struct adj_jac_vari : public vari {
    * @return var
    */
   var build_return_varis_and_vars(const double& val_y) {
-    y_vi_ = ChainableStack::instance().memalloc_.alloc_array<vari*>(1);
+    y_vi_ = ChainableStack::instance_->memalloc_.alloc_array<vari*>(1);
     y_vi_[0] = new vari(val_y, false);
 
     return y_vi_[0];
@@ -350,7 +350,7 @@ struct adj_jac_vari : public vari {
     std::vector<var> var_y(M_[0]);
 
     y_vi_
-        = ChainableStack::instance().memalloc_.alloc_array<vari*>(var_y.size());
+        = ChainableStack::instance_->memalloc_.alloc_array<vari*>(var_y.size());
     for (size_t m = 0; m < var_y.size(); ++m) {
       y_vi_[m] = new vari(val_y[m], false);
       var_y[m] = y_vi_[m];
@@ -377,7 +377,7 @@ struct adj_jac_vari : public vari {
     Eigen::Matrix<var, R, C> var_y(M_[0], M_[1]);
 
     y_vi_
-        = ChainableStack::instance().memalloc_.alloc_array<vari*>(var_y.size());
+        = ChainableStack::instance_->memalloc_.alloc_array<vari*>(var_y.size());
     for (int m = 0; m < var_y.size(); ++m) {
       y_vi_[m] = new vari(val_y(m), false);
       var_y(m) = y_vi_[m];
@@ -406,7 +406,7 @@ struct adj_jac_vari : public vari {
    * @return Output of f_ as vars
    */
   auto operator()(const Targs&... args) {
-    x_vis_ = ChainableStack::instance().memalloc_.alloc_array<vari*>(
+    x_vis_ = ChainableStack::instance_->memalloc_.alloc_array<vari*>(
         count_memory(0, args...));
 
     prepare_x_vis(args...);

--- a/stan/math/rev/mat/functor/algebra_solver.hpp
+++ b/stan/math/rev/mat/functor/algebra_solver.hpp
@@ -44,12 +44,12 @@ struct algebra_solver_vari : public vari {
                       const Eigen::VectorXd& theta_dbl, Fx& fx,
                       std::ostream* msgs)
       : vari(theta_dbl(0)),
-        y_(ChainableStack::instance().memalloc_.alloc_array<vari*>(y.size())),
+        y_(ChainableStack::instance_->memalloc_.alloc_array<vari*>(y.size())),
         y_size_(y.size()),
         x_size_(x.size()),
         theta_(
-            ChainableStack::instance().memalloc_.alloc_array<vari*>(x_size_)),
-        Jx_y_(ChainableStack::instance().memalloc_.alloc_array<double>(
+            ChainableStack::instance_->memalloc_.alloc_array<vari*>(x_size_)),
+        Jx_y_(ChainableStack::instance_->memalloc_.alloc_array<double>(
             x_size_ * y_size_)) {
     using Eigen::Map;
     using Eigen::MatrixXd;

--- a/stan/math/rev/scal/meta/operands_and_partials.hpp
+++ b/stan/math/rev/scal/meta/operands_and_partials.hpp
@@ -102,9 +102,9 @@ class operands_and_partials<Op1, Op2, Op3, Op4, Op5, var> {
     size_t size = edge1_.size() + edge2_.size() + edge3_.size() + edge4_.size()
                   + edge5_.size();
     vari** varis
-        = ChainableStack::instance().memalloc_.alloc_array<vari*>(size);
+        = ChainableStack::instance_->memalloc_.alloc_array<vari*>(size);
     double* partials
-        = ChainableStack::instance().memalloc_.alloc_array<double>(size);
+        = ChainableStack::instance_->memalloc_.alloc_array<double>(size);
     int idx = 0;
     edge1_.dump_operands(&varis[idx]);
     edge1_.dump_partials(&partials[idx]);

--- a/test/unit/math/rev/arr/err/check_bounded_test.cpp
+++ b/test/unit/math/rev/arr/err/check_bounded_test.cpp
@@ -14,13 +14,13 @@ TEST(AgradRevErrorHandlingScalar, CheckBoundedVarCheckVectorized) {
   for (int i = 0; i < N; ++i)
     a.push_back(var(i));
 
-  size_t stack_size = stan::math::ChainableStack::instance().var_stack_.size();
+  size_t stack_size = stan::math::ChainableStack::instance_->var_stack_.size();
 
   EXPECT_EQ(5U, stack_size);
   EXPECT_NO_THROW(check_bounded(function, "a", a, -1.0, 6.0));
 
   size_t stack_size_after_call
-      = stan::math::ChainableStack::instance().var_stack_.size();
+      = stan::math::ChainableStack::instance_->var_stack_.size();
   EXPECT_EQ(5U, stack_size_after_call);
   stan::math::recover_memory();
 }

--- a/test/unit/math/rev/arr/err/check_consistent_size_test.cpp
+++ b/test/unit/math/rev/arr/err/check_consistent_size_test.cpp
@@ -14,13 +14,13 @@ TEST(AgradRevErrorHandlingScalar, CheckConsistentSizeVarCheckVectorized) {
   for (int i = 0; i < N; ++i)
     a.push_back(var(i));
 
-  size_t stack_size = stan::math::ChainableStack::instance().var_stack_.size();
+  size_t stack_size = stan::math::ChainableStack::instance_->var_stack_.size();
 
   EXPECT_EQ(5U, stack_size);
   EXPECT_NO_THROW(check_consistent_size(function, "a", a, 5U));
 
   size_t stack_size_after_call
-      = stan::math::ChainableStack::instance().var_stack_.size();
+      = stan::math::ChainableStack::instance_->var_stack_.size();
   EXPECT_EQ(5U, stack_size_after_call);
   stan::math::recover_memory();
 }

--- a/test/unit/math/rev/arr/err/check_consistent_sizes_test.cpp
+++ b/test/unit/math/rev/arr/err/check_consistent_sizes_test.cpp
@@ -17,13 +17,13 @@ TEST(AgradRevErrorHandlingScalar, CheckConsistentSizeVarCheckVectorized) {
     a.push_back(var(i));
   }
 
-  size_t stack_size = stan::math::ChainableStack::instance().var_stack_.size();
+  size_t stack_size = stan::math::ChainableStack::instance_->var_stack_.size();
 
   EXPECT_EQ(10U, stack_size);
   EXPECT_NO_THROW(check_consistent_sizes(function, "a", a, "b", b));
 
   size_t stack_size_after_call
-      = stan::math::ChainableStack::instance().var_stack_.size();
+      = stan::math::ChainableStack::instance_->var_stack_.size();
   EXPECT_EQ(10U, stack_size_after_call);
   stan::math::recover_memory();
 }

--- a/test/unit/math/rev/arr/err/check_finite_test.cpp
+++ b/test/unit/math/rev/arr/err/check_finite_test.cpp
@@ -15,19 +15,19 @@ TEST(AgradRevErrorHandlingScalar, CheckFiniteVarCheckVectorized) {
   for (int i = 0; i < N; ++i)
     a.push_back(var(i));
 
-  size_t stack_size = stan::math::ChainableStack::instance().var_stack_.size();
+  size_t stack_size = stan::math::ChainableStack::instance_->var_stack_.size();
 
   EXPECT_EQ(5U, stack_size);
   EXPECT_NO_THROW(check_finite(function, "a", a));
 
   size_t stack_size_after_call
-      = stan::math::ChainableStack::instance().var_stack_.size();
+      = stan::math::ChainableStack::instance_->var_stack_.size();
   EXPECT_EQ(5U, stack_size_after_call);
 
   a[1] = std::numeric_limits<double>::infinity();
   EXPECT_THROW(check_finite(function, "a", a), std::domain_error);
   stack_size_after_call
-      = stan::math::ChainableStack::instance().var_stack_.size();
+      = stan::math::ChainableStack::instance_->var_stack_.size();
   EXPECT_EQ(6U, stack_size_after_call);
 
   stan::math::recover_memory();

--- a/test/unit/math/rev/arr/err/check_greater_or_equal_test.cpp
+++ b/test/unit/math/rev/arr/err/check_greater_or_equal_test.cpp
@@ -17,19 +17,19 @@ TEST(AgradRevErrorHandlingScalar, CheckFiniteVarCheckVectorized) {
   for (int i = 0; i < N; ++i)
     a.push_back(var(i));
 
-  size_t stack_size = stan::math::ChainableStack::instance().var_stack_.size();
+  size_t stack_size = stan::math::ChainableStack::instance_->var_stack_.size();
 
   EXPECT_EQ(5U, stack_size);
   EXPECT_NO_THROW(check_greater_or_equal(function, "a", a, -1.0));
 
   size_t stack_size_after_call
-      = stan::math::ChainableStack::instance().var_stack_.size();
+      = stan::math::ChainableStack::instance_->var_stack_.size();
   EXPECT_EQ(5U, stack_size_after_call);
 
   EXPECT_THROW(check_greater_or_equal(function, "a", a, 2.0),
                std::domain_error);
   stack_size_after_call
-      = stan::math::ChainableStack::instance().var_stack_.size();
+      = stan::math::ChainableStack::instance_->var_stack_.size();
   EXPECT_EQ(5U, stack_size_after_call);
 
   stan::math::recover_memory();

--- a/test/unit/math/rev/arr/err/check_greater_test.cpp
+++ b/test/unit/math/rev/arr/err/check_greater_test.cpp
@@ -17,18 +17,18 @@ TEST(AgradRevErrorHandlingScalar, CheckGreaterVarCheckVectorized) {
   for (int i = 0; i < N; ++i)
     a.push_back(var(i));
 
-  size_t stack_size = stan::math::ChainableStack::instance().var_stack_.size();
+  size_t stack_size = stan::math::ChainableStack::instance_->var_stack_.size();
 
   EXPECT_EQ(5U, stack_size);
   EXPECT_NO_THROW(check_greater(function, "a", a, -1.0));
 
   size_t stack_size_after_call
-      = stan::math::ChainableStack::instance().var_stack_.size();
+      = stan::math::ChainableStack::instance_->var_stack_.size();
   EXPECT_EQ(5U, stack_size_after_call);
 
   EXPECT_THROW(check_greater(function, "a", a, 2.0), std::domain_error);
   stack_size_after_call
-      = stan::math::ChainableStack::instance().var_stack_.size();
+      = stan::math::ChainableStack::instance_->var_stack_.size();
   EXPECT_EQ(5U, stack_size_after_call);
 
   stan::math::recover_memory();

--- a/test/unit/math/rev/arr/err/check_less_or_equal_test.cpp
+++ b/test/unit/math/rev/arr/err/check_less_or_equal_test.cpp
@@ -17,18 +17,18 @@ TEST(AgradRevErrorHandlingScalar, CheckLessOrEqualVarCheckVectorized) {
   for (int i = 0; i < N; ++i)
     a.push_back(var(i));
 
-  size_t stack_size = stan::math::ChainableStack::instance().var_stack_.size();
+  size_t stack_size = stan::math::ChainableStack::instance_->var_stack_.size();
 
   EXPECT_EQ(5U, stack_size);
   EXPECT_NO_THROW(check_less_or_equal(function, "a", a, 10.0));
 
   size_t stack_size_after_call
-      = stan::math::ChainableStack::instance().var_stack_.size();
+      = stan::math::ChainableStack::instance_->var_stack_.size();
   EXPECT_EQ(5U, stack_size_after_call);
 
   EXPECT_THROW(check_less_or_equal(function, "a", a, 2.0), std::domain_error);
   stack_size_after_call
-      = stan::math::ChainableStack::instance().var_stack_.size();
+      = stan::math::ChainableStack::instance_->var_stack_.size();
   EXPECT_EQ(5U, stack_size_after_call);
 
   stan::math::recover_memory();

--- a/test/unit/math/rev/arr/err/check_less_test.cpp
+++ b/test/unit/math/rev/arr/err/check_less_test.cpp
@@ -17,18 +17,18 @@ TEST(AgradRevErrorHandlingScalar, CheckLessVarCheckVectorized) {
   for (int i = 0; i < N; ++i)
     a.push_back(var(i));
 
-  size_t stack_size = stan::math::ChainableStack::instance().var_stack_.size();
+  size_t stack_size = stan::math::ChainableStack::instance_->var_stack_.size();
 
   EXPECT_EQ(5U, stack_size);
   EXPECT_NO_THROW(check_less(function, "a", a, 10.0));
 
   size_t stack_size_after_call
-      = stan::math::ChainableStack::instance().var_stack_.size();
+      = stan::math::ChainableStack::instance_->var_stack_.size();
   EXPECT_EQ(5U, stack_size_after_call);
 
   EXPECT_THROW(check_less(function, "a", a, 2.0), std::domain_error);
   stack_size_after_call
-      = stan::math::ChainableStack::instance().var_stack_.size();
+      = stan::math::ChainableStack::instance_->var_stack_.size();
   EXPECT_EQ(5U, stack_size_after_call);
 
   stan::math::recover_memory();

--- a/test/unit/math/rev/arr/err/check_nonnegative_test.cpp
+++ b/test/unit/math/rev/arr/err/check_nonnegative_test.cpp
@@ -46,31 +46,31 @@ TEST(AgradRevErrorHandlingScalar, CheckNonnegativeVarCheckVectorized) {
   for (int i = 0; i < N; ++i)
     a.push_back(var(i));
 
-  size_t stack_size = stan::math::ChainableStack::instance().var_stack_.size();
+  size_t stack_size = stan::math::ChainableStack::instance_->var_stack_.size();
 
   EXPECT_EQ(5U, stack_size);
   EXPECT_NO_THROW(check_nonnegative(function, "a", a));
 
   size_t stack_size_after_call
-      = stan::math::ChainableStack::instance().var_stack_.size();
+      = stan::math::ChainableStack::instance_->var_stack_.size();
   EXPECT_EQ(5U, stack_size_after_call);
 
   a[1] = std::numeric_limits<double>::infinity();
   EXPECT_NO_THROW(check_nonnegative(function, "a", a));
   stack_size_after_call
-      = stan::math::ChainableStack::instance().var_stack_.size();
+      = stan::math::ChainableStack::instance_->var_stack_.size();
   EXPECT_EQ(6U, stack_size_after_call);
 
   a[1] = -1.0;
   EXPECT_THROW(check_nonnegative(function, "a", a), std::domain_error);
   stack_size_after_call
-      = stan::math::ChainableStack::instance().var_stack_.size();
+      = stan::math::ChainableStack::instance_->var_stack_.size();
   EXPECT_EQ(7U, stack_size_after_call);
 
   a[1] = 0.0;
   EXPECT_NO_THROW(check_nonnegative(function, "a", a));
   stack_size_after_call
-      = stan::math::ChainableStack::instance().var_stack_.size();
+      = stan::math::ChainableStack::instance_->var_stack_.size();
   EXPECT_EQ(8U, stack_size_after_call);
 
   stan::math::recover_memory();

--- a/test/unit/math/rev/arr/err/check_not_nan_test.cpp
+++ b/test/unit/math/rev/arr/err/check_not_nan_test.cpp
@@ -14,13 +14,13 @@ TEST(AgradRevErrorHandlingScalar, CheckNotNanVarCheckVectorized) {
   for (int i = 0; i < N; ++i)
     a.push_back(var(i));
 
-  size_t stack_size = stan::math::ChainableStack::instance().var_stack_.size();
+  size_t stack_size = stan::math::ChainableStack::instance_->var_stack_.size();
 
   EXPECT_EQ(5U, stack_size);
   EXPECT_NO_THROW(check_not_nan(function, "a", a));
 
   size_t stack_size_after_call
-      = stan::math::ChainableStack::instance().var_stack_.size();
+      = stan::math::ChainableStack::instance_->var_stack_.size();
   EXPECT_EQ(5U, stack_size_after_call);
   stan::math::recover_memory();
 }
@@ -37,13 +37,13 @@ TEST(ErrorHandlingScalar, CheckNotNanVarCheckVectorized) {
   for (int i = 0; i < N; ++i)
     a.push_back(var(i));
 
-  size_t stack_size = stan::math::ChainableStack::instance().var_stack_.size();
+  size_t stack_size = stan::math::ChainableStack::instance_->var_stack_.size();
 
   EXPECT_EQ(5U, stack_size);
   EXPECT_NO_THROW(check_not_nan(function, "a", a));
 
   size_t stack_size_after_call
-      = stan::math::ChainableStack::instance().var_stack_.size();
+      = stan::math::ChainableStack::instance_->var_stack_.size();
   EXPECT_EQ(5U, stack_size_after_call);
   stan::math::recover_memory();
 }

--- a/test/unit/math/rev/arr/err/check_positive_finite_test.cpp
+++ b/test/unit/math/rev/arr/err/check_positive_finite_test.cpp
@@ -66,20 +66,20 @@ TEST(AgradRevErrorHandlingScalar, CheckPositiveFiniteVarCheckVectorized) {
   for (int i = 0; i < N; ++i)
     a.push_back(var(i));
 
-  size_t stack_size = stan::math::ChainableStack::instance().var_stack_.size();
+  size_t stack_size = stan::math::ChainableStack::instance_->var_stack_.size();
 
   EXPECT_EQ(5U, stack_size);
   EXPECT_THROW(check_positive_finite(function, "a", a), std::domain_error);
   EXPECT_NO_THROW(check_positive_finite(function, "a", a[2]));
 
   size_t stack_size_after_call
-      = stan::math::ChainableStack::instance().var_stack_.size();
+      = stan::math::ChainableStack::instance_->var_stack_.size();
   EXPECT_EQ(5U, stack_size_after_call);
 
   a[2] = std::numeric_limits<double>::infinity();
   EXPECT_THROW(check_positive_finite(function, "a", a), std::domain_error);
   stack_size_after_call
-      = stan::math::ChainableStack::instance().var_stack_.size();
+      = stan::math::ChainableStack::instance_->var_stack_.size();
   EXPECT_EQ(6U, stack_size_after_call);
   stan::math::recover_memory();
 }

--- a/test/unit/math/rev/arr/util.hpp
+++ b/test/unit/math/rev/arr/util.hpp
@@ -11,7 +11,7 @@ namespace test {
 void check_varis_on_stack(const std::vector<stan::math::var>& x) {
   for (size_t n = 0; n < x.size(); ++n)
     EXPECT_TRUE(
-        stan::math::ChainableStack::instance().memalloc_.in_stack(x[n].vi_))
+        stan::math::ChainableStack::instance_->memalloc_.in_stack(x[n].vi_))
         << n << " is not on the stack";
 }
 

--- a/test/unit/math/rev/core/build_vari_array_test.cpp
+++ b/test/unit/math/rev/core/build_vari_array_test.cpp
@@ -23,29 +23,29 @@ TEST(AgradRev, build_vari_array) {
   vari **vdv = build_vari_array(mdv);
   vari **vvv = build_vari_array(mvv);
 
-  EXPECT_TRUE(stan::math::ChainableStack::instance().memalloc_.in_stack(vdd));
-  EXPECT_TRUE(stan::math::ChainableStack::instance().memalloc_.in_stack(vvd));
-  EXPECT_TRUE(stan::math::ChainableStack::instance().memalloc_.in_stack(vdv));
-  EXPECT_TRUE(stan::math::ChainableStack::instance().memalloc_.in_stack(vvv));
+  EXPECT_TRUE(stan::math::ChainableStack::instance_->memalloc_.in_stack(vdd));
+  EXPECT_TRUE(stan::math::ChainableStack::instance_->memalloc_.in_stack(vvd));
+  EXPECT_TRUE(stan::math::ChainableStack::instance_->memalloc_.in_stack(vdv));
+  EXPECT_TRUE(stan::math::ChainableStack::instance_->memalloc_.in_stack(vvv));
 
   for (int i = 0; i < mdd.size(); ++i) {
     EXPECT_EQ(mdd.data()[i].vi_, vdd[i]);
     EXPECT_TRUE(
-        stan::math::ChainableStack::instance().memalloc_.in_stack(vdd[i]));
+        stan::math::ChainableStack::instance_->memalloc_.in_stack(vdd[i]));
   }
   for (int i = 0; i < mvd.size(); ++i) {
     EXPECT_EQ(mvd.data()[i].vi_, vvd[i]);
     EXPECT_TRUE(
-        stan::math::ChainableStack::instance().memalloc_.in_stack(vvd[i]));
+        stan::math::ChainableStack::instance_->memalloc_.in_stack(vvd[i]));
   }
   for (int i = 0; i < mdv.size(); ++i) {
     EXPECT_EQ(mdv.data()[i].vi_, vdv[i]);
     EXPECT_TRUE(
-        stan::math::ChainableStack::instance().memalloc_.in_stack(vdv[i]));
+        stan::math::ChainableStack::instance_->memalloc_.in_stack(vdv[i]));
   }
   for (int i = 0; i < mvv.size(); ++i) {
     EXPECT_EQ(mvv.data()[i].vi_, vvv[i]);
     EXPECT_TRUE(
-        stan::math::ChainableStack::instance().memalloc_.in_stack(vvv[i]));
+        stan::math::ChainableStack::instance_->memalloc_.in_stack(vvv[i]));
   }
 }

--- a/test/unit/math/rev/core/thread_stack_instance_test.cpp
+++ b/test/unit/math/rev/core/thread_stack_instance_test.cpp
@@ -9,21 +9,21 @@ TEST(thread_stack_instance, initialize) {
   // the main thread must be initialized by the time this code is
   // reached. This will actually segfault if this is not the case.
   // The pointer to the reference returned must evaluate to true.
-  EXPECT_TRUE(&ChainableStack::instance());
+  EXPECT_TRUE(ChainableStack::instance_);
 
-  ChainableStack::AutodiffStackStorage& main_ad_stack
-      = ChainableStack::instance();
+  ChainableStack::AutodiffStackStorage* main_ad_stack
+      = ChainableStack::instance_;
 
   auto thread_tester = [&]() -> void {
     ChainableStack thread_instance;
-    EXPECT_TRUE(&ChainableStack::instance());
-    EXPECT_TRUE(&ChainableStack::instance()
+    EXPECT_TRUE(ChainableStack::instance_);
+    EXPECT_TRUE(ChainableStack::instance_
 #ifdef STAN_THREADS
                 !=
 #else
                 ==
 #endif
-                &main_ad_stack);
+                main_ad_stack);
   };
   std::thread other_work(thread_tester);
 
@@ -37,18 +37,18 @@ TEST(thread_stack_instance, child_instances) {
   // set)
   stan::math::var a = 1;
 
-  ChainableStack::AutodiffStackStorage& main_ad_stack
-      = ChainableStack::instance();
+  ChainableStack::AutodiffStackStorage* main_ad_stack
+      = ChainableStack::instance_;
 
   auto thread_tester = [&]() -> void {
     ChainableStack thread_instance;
-    EXPECT_TRUE(main_ad_stack.var_stack_.size()
+    EXPECT_TRUE(main_ad_stack->var_stack_.size()
 #ifdef STAN_THREADS
                 >
 #else
                 ==
 #endif
-                ChainableStack::instance().var_stack_.size());
+                ChainableStack::instance_->var_stack_.size());
   };
 
   std::thread other_work(thread_tester);
@@ -59,21 +59,21 @@ TEST(thread_stack_instance, child_instances) {
 TEST(thread_stack_instance, persistence) {
   using stan::math::ChainableStack;
 
-  ChainableStack::AutodiffStackStorage& main_ad_stack
-      = ChainableStack::instance();
+  ChainableStack::AutodiffStackStorage* main_ad_stack
+      = ChainableStack::instance_;
 
   {
     // this obviously must be true
-    EXPECT_TRUE(&ChainableStack::instance() == &main_ad_stack);
+    EXPECT_TRUE(ChainableStack::instance_ == main_ad_stack);
 
     // and when constructing a new instance ...
     ChainableStack another_tape;
 
     // ... this must still be true ...
-    EXPECT_TRUE(&ChainableStack::instance() == &main_ad_stack);
+    EXPECT_TRUE(ChainableStack::instance_ == main_ad_stack);
   }
 
   // ... and if we now let another_tape fade away we still expect the
   // main tape to stay around
-  EXPECT_TRUE(&ChainableStack::instance() == &main_ad_stack);
+  EXPECT_TRUE(ChainableStack::instance_ == main_ad_stack);
 }

--- a/test/unit/math/rev/mat/err/check_pos_semidefinite_test.cpp
+++ b/test/unit/math/rev/mat/err/check_pos_semidefinite_test.cpp
@@ -52,12 +52,12 @@ TEST(AgradRevErrorHandlingMatrix, CheckPosDefiniteMatrixVarCheck) {
   y << 2, -1, 0, -1, 2, -1, 0, -1, 2;
 
   size_t stack_before_call
-      = stan::math::ChainableStack::instance().var_stack_.size();
+      = stan::math::ChainableStack::instance_->var_stack_.size();
   EXPECT_EQ(10U, stack_before_call);
 
   EXPECT_NO_THROW(check_pos_semidefinite("checkPosDefiniteMatrix", "y", y));
   size_t stack_after_call
-      = stan::math::ChainableStack::instance().var_stack_.size();
+      = stan::math::ChainableStack::instance_->var_stack_.size();
 
   EXPECT_EQ(10U, stack_after_call);
 }

--- a/test/unit/math/rev/mat/fun/log_softmax_test.cpp
+++ b/test/unit/math/rev/mat/fun/log_softmax_test.cpp
@@ -22,7 +22,7 @@ TEST(AgradRevMatrix, logSoftmaxLeak) {
     }
     Matrix<var, Dynamic, 1> theta = log_softmax(x);
   }
-  EXPECT_GT(stan::math::ChainableStack::instance().memalloc_.bytes_allocated(),
+  EXPECT_GT(stan::math::ChainableStack::instance_->memalloc_.bytes_allocated(),
             4000000);
 }
 

--- a/test/unit/math/rev/mat/fun/stored_gradient_vari_test.cpp
+++ b/test/unit/math/rev/mat/fun/stored_gradient_vari_test.cpp
@@ -7,7 +7,7 @@ TEST(StoredGradientVari, propagate3) {
   using stan::math::var;
   using stan::math::vari;
   vari** xs = reinterpret_cast<vari**>(
-      stan::math::ChainableStack::instance().memalloc_.alloc(3
+      stan::math::ChainableStack::instance_->memalloc_.alloc(3
                                                              * sizeof(vari*)));
   // value not used here
   var xs1 = 1;
@@ -19,7 +19,7 @@ TEST(StoredGradientVari, propagate3) {
   xs[1] = xs2.vi_;
   xs[2] = xs3.vi_;
   double* partials = reinterpret_cast<double*>(
-      stan::math::ChainableStack::instance().memalloc_.alloc(3
+      stan::math::ChainableStack::instance_->memalloc_.alloc(3
                                                              * sizeof(double)));
   partials[0] = 10;
   partials[1] = 100;
@@ -69,7 +69,7 @@ TEST(AgradRevMatrix, check_varis_on_stack) {
   using stan::math::var;
   using stan::math::vari;
   vari** xs = reinterpret_cast<vari**>(
-      stan::math::ChainableStack::instance().memalloc_.alloc(3
+      stan::math::ChainableStack::instance_->memalloc_.alloc(3
                                                              * sizeof(vari*)));
   // value not used here
   var xs1 = 1;
@@ -81,7 +81,7 @@ TEST(AgradRevMatrix, check_varis_on_stack) {
   xs[1] = xs2.vi_;
   xs[2] = xs3.vi_;
   double* partials = reinterpret_cast<double*>(
-      stan::math::ChainableStack::instance().memalloc_.alloc(3
+      stan::math::ChainableStack::instance_->memalloc_.alloc(3
                                                              * sizeof(double)));
   partials[0] = 10;
   partials[1] = 100;

--- a/test/unit/math/rev/mat/functor/adj_jac_apply_test.cpp
+++ b/test/unit/math/rev/mat/functor/adj_jac_apply_test.cpp
@@ -66,7 +66,7 @@ struct StdVectorSinFunctor {
     N_ = x.size();
     std::vector<double> out(N_);
 
-    x_ = stan::math::ChainableStack::instance().memalloc_.alloc_array<double>(
+    x_ = stan::math::ChainableStack::instance_->memalloc_.alloc_array<double>(
         N_);
 
     for (int i = 0; i < N_; ++i) {
@@ -138,7 +138,7 @@ struct SinFunctor {
     N_ = x.size();
     Eigen::VectorXd out(N_);
     x_mem_
-        = stan::math::ChainableStack::instance().memalloc_.alloc_array<double>(
+        = stan::math::ChainableStack::instance_->memalloc_.alloc_array<double>(
             N_);
 
     for (int n = 0; n < N_; ++n) {
@@ -235,7 +235,7 @@ struct RowVectorSinFunctor {
     N_ = x.size();
     Eigen::RowVectorXd out(N_);
     x_mem_
-        = stan::math::ChainableStack::instance().memalloc_.alloc_array<double>(
+        = stan::math::ChainableStack::instance_->memalloc_.alloc_array<double>(
             N_);
 
     for (int n = 0; n < N_; ++n) {
@@ -334,7 +334,7 @@ struct MatrixSinFunctor {
     M_ = x.cols();
     Eigen::MatrixXd out(N_, M_);
     x_mem_
-        = stan::math::ChainableStack::instance().memalloc_.alloc_array<double>(
+        = stan::math::ChainableStack::instance_->memalloc_.alloc_array<double>(
             N_ * M_);
 
     for (int n = 0; n < N_ * M_; ++n) {

--- a/test/unit/math/rev/mat/functor/gradient_test.cpp
+++ b/test/unit/math/rev/mat/functor/gradient_test.cpp
@@ -139,6 +139,6 @@ TEST(AgradAutoDiff, RecoverMemory) {
   }
   // depends on starting allocation of 65K not being exceeded
   // without recovery_memory in autodiff::apply_recover(), takes 67M
-  EXPECT_LT(stan::math::ChainableStack::instance().memalloc_.bytes_allocated(),
+  EXPECT_LT(stan::math::ChainableStack::instance_->memalloc_.bytes_allocated(),
             100000);
 }

--- a/test/unit/math/rev/mat/util.hpp
+++ b/test/unit/math/rev/mat/util.hpp
@@ -11,7 +11,7 @@ template <int R, int C>
 void check_varis_on_stack(const Eigen::Matrix<stan::math::var, R, C>& x) {
   for (int j = 0; j < x.cols(); ++j)
     for (int i = 0; i < x.rows(); ++i)
-      EXPECT_TRUE(stan::math::ChainableStack::instance().memalloc_.in_stack(
+      EXPECT_TRUE(stan::math::ChainableStack::instance_->memalloc_.in_stack(
           x(i, j).vi_))
           << i << ", " << j << " is not on the stack";
 }

--- a/test/unit/math/rev/scal/err/check_bounded_test.cpp
+++ b/test/unit/math/rev/scal/err/check_bounded_test.cpp
@@ -121,13 +121,13 @@ TEST(AgradRevErrorHandlingScalar, CheckBoundedVarCheckUnivariate) {
   const char* function = "check_bounded";
   var a(5.0);
 
-  size_t stack_size = stan::math::ChainableStack::instance().var_stack_.size();
+  size_t stack_size = stan::math::ChainableStack::instance_->var_stack_.size();
 
   EXPECT_EQ(1U, stack_size);
   EXPECT_NO_THROW(check_bounded(function, "a", a, 4.0, 6.0));
 
   size_t stack_size_after_call
-      = stan::math::ChainableStack::instance().var_stack_.size();
+      = stan::math::ChainableStack::instance_->var_stack_.size();
   EXPECT_EQ(1U, stack_size_after_call);
 
   stan::math::recover_memory();

--- a/test/unit/math/rev/scal/err/check_finite_test.cpp
+++ b/test/unit/math/rev/scal/err/check_finite_test.cpp
@@ -34,19 +34,19 @@ TEST(AgradRevErrorHandlingScalar, CheckFiniteVarCheckUnivariate) {
   const char* function = "check_finite";
   var a(5.0);
 
-  size_t stack_size = stan::math::ChainableStack::instance().var_stack_.size();
+  size_t stack_size = stan::math::ChainableStack::instance_->var_stack_.size();
 
   EXPECT_EQ(1U, stack_size);
   EXPECT_NO_THROW(check_finite(function, "a", a));
 
   size_t stack_size_after_call
-      = stan::math::ChainableStack::instance().var_stack_.size();
+      = stan::math::ChainableStack::instance_->var_stack_.size();
   EXPECT_EQ(1U, stack_size_after_call);
 
   a = std::numeric_limits<double>::infinity();
   EXPECT_THROW(check_finite(function, "a", a), std::domain_error);
   stack_size_after_call
-      = stan::math::ChainableStack::instance().var_stack_.size();
+      = stan::math::ChainableStack::instance_->var_stack_.size();
   EXPECT_EQ(2U, stack_size_after_call);
 
   stan::math::recover_memory();

--- a/test/unit/math/rev/scal/err/check_greater_or_equal_test.cpp
+++ b/test/unit/math/rev/scal/err/check_greater_or_equal_test.cpp
@@ -45,19 +45,19 @@ TEST(AgradRevErrorHandlingScalar, CheckGreaterOrEqualVarCheckUnivariate) {
   const char* function = "check_greater_or_equal";
   var a(5.0);
 
-  size_t stack_size = stan::math::ChainableStack::instance().var_stack_.size();
+  size_t stack_size = stan::math::ChainableStack::instance_->var_stack_.size();
 
   EXPECT_EQ(1U, stack_size);
   EXPECT_NO_THROW(check_greater_or_equal(function, "a", a, 2.0));
 
   size_t stack_size_after_call
-      = stan::math::ChainableStack::instance().var_stack_.size();
+      = stan::math::ChainableStack::instance_->var_stack_.size();
   EXPECT_EQ(1U, stack_size_after_call);
 
   EXPECT_THROW(check_greater_or_equal(function, "a", a, 10.0),
                std::domain_error);
   stack_size_after_call
-      = stan::math::ChainableStack::instance().var_stack_.size();
+      = stan::math::ChainableStack::instance_->var_stack_.size();
   EXPECT_EQ(1U, stack_size_after_call);
 
   stan::math::recover_memory();

--- a/test/unit/math/rev/scal/err/check_greater_test.cpp
+++ b/test/unit/math/rev/scal/err/check_greater_test.cpp
@@ -44,18 +44,18 @@ TEST(AgradRevErrorHandlingScalar, CheckGreaterVarCheckUnivariate) {
   const char* function = "check_greater";
   var a(5.0);
 
-  size_t stack_size = stan::math::ChainableStack::instance().var_stack_.size();
+  size_t stack_size = stan::math::ChainableStack::instance_->var_stack_.size();
 
   EXPECT_EQ(1U, stack_size);
   EXPECT_NO_THROW(check_greater(function, "a", a, 2.0));
 
   size_t stack_size_after_call
-      = stan::math::ChainableStack::instance().var_stack_.size();
+      = stan::math::ChainableStack::instance_->var_stack_.size();
   EXPECT_EQ(1U, stack_size_after_call);
 
   EXPECT_THROW(check_greater(function, "a", a, 10.0), std::domain_error);
   stack_size_after_call
-      = stan::math::ChainableStack::instance().var_stack_.size();
+      = stan::math::ChainableStack::instance_->var_stack_.size();
   EXPECT_EQ(1U, stack_size_after_call);
 
   stan::math::recover_memory();

--- a/test/unit/math/rev/scal/err/check_less_or_equal_test.cpp
+++ b/test/unit/math/rev/scal/err/check_less_or_equal_test.cpp
@@ -45,24 +45,24 @@ TEST(AgradRevErrorHandlingScalar, CheckLessOrEqualVarCheckUnivariate) {
   const char* function = "check_less_or_equal";
   var a(5.0);
 
-  size_t stack_size = stan::math::ChainableStack::instance().var_stack_.size();
+  size_t stack_size = stan::math::ChainableStack::instance_->var_stack_.size();
 
   EXPECT_EQ(1U, stack_size);
   EXPECT_THROW(check_less_or_equal(function, "a", a, 2.0), std::domain_error);
 
   size_t stack_size_after_call
-      = stan::math::ChainableStack::instance().var_stack_.size();
+      = stan::math::ChainableStack::instance_->var_stack_.size();
   EXPECT_EQ(1U, stack_size_after_call);
 
   EXPECT_NO_THROW(check_less_or_equal(function, "a", a, 5.0));
 
   stack_size_after_call
-      = stan::math::ChainableStack::instance().var_stack_.size();
+      = stan::math::ChainableStack::instance_->var_stack_.size();
   EXPECT_EQ(1U, stack_size_after_call);
 
   EXPECT_NO_THROW(check_less_or_equal(function, "a", a, 10.0));
   stack_size_after_call
-      = stan::math::ChainableStack::instance().var_stack_.size();
+      = stan::math::ChainableStack::instance_->var_stack_.size();
   EXPECT_EQ(1U, stack_size_after_call);
 
   stan::math::recover_memory();

--- a/test/unit/math/rev/scal/err/check_less_test.cpp
+++ b/test/unit/math/rev/scal/err/check_less_test.cpp
@@ -44,18 +44,18 @@ TEST(AgradRevErrorHandlingScalar, CheckLessVarCheckUnivariate) {
   const char* function = "check_less";
   var a(5.0);
 
-  size_t stack_size = stan::math::ChainableStack::instance().var_stack_.size();
+  size_t stack_size = stan::math::ChainableStack::instance_->var_stack_.size();
 
   EXPECT_EQ(1U, stack_size);
   EXPECT_THROW(check_less(function, "a", a, 2.0), std::domain_error);
 
   size_t stack_size_after_call
-      = stan::math::ChainableStack::instance().var_stack_.size();
+      = stan::math::ChainableStack::instance_->var_stack_.size();
   EXPECT_EQ(1U, stack_size_after_call);
 
   EXPECT_NO_THROW(check_less(function, "a", a, 10.0));
   stack_size_after_call
-      = stan::math::ChainableStack::instance().var_stack_.size();
+      = stan::math::ChainableStack::instance_->var_stack_.size();
   EXPECT_EQ(1U, stack_size_after_call);
 
   stan::math::recover_memory();

--- a/test/unit/math/rev/scal/err/check_nonnegative_test.cpp
+++ b/test/unit/math/rev/scal/err/check_nonnegative_test.cpp
@@ -37,31 +37,31 @@ TEST(AgradRevErrorHandlingScalar, CheckNonnegativeVarCheckUnivariate) {
   const char* function = "check_nonnegative";
   var a(5.0);
 
-  size_t stack_size = stan::math::ChainableStack::instance().var_stack_.size();
+  size_t stack_size = stan::math::ChainableStack::instance_->var_stack_.size();
 
   EXPECT_EQ(1U, stack_size);
   EXPECT_NO_THROW(check_nonnegative(function, "a", a));
 
   size_t stack_size_after_call
-      = stan::math::ChainableStack::instance().var_stack_.size();
+      = stan::math::ChainableStack::instance_->var_stack_.size();
   EXPECT_EQ(1U, stack_size_after_call);
 
   a = std::numeric_limits<double>::infinity();
   EXPECT_NO_THROW(check_nonnegative(function, "a", a));
   stack_size_after_call
-      = stan::math::ChainableStack::instance().var_stack_.size();
+      = stan::math::ChainableStack::instance_->var_stack_.size();
   EXPECT_EQ(2U, stack_size_after_call);
 
   a = 0.0;
   EXPECT_NO_THROW(check_nonnegative(function, "a", a));
   stack_size_after_call
-      = stan::math::ChainableStack::instance().var_stack_.size();
+      = stan::math::ChainableStack::instance_->var_stack_.size();
   EXPECT_EQ(3U, stack_size_after_call);
 
   a = -1.1;
   EXPECT_THROW(check_nonnegative(function, "a", a), std::domain_error);
   stack_size_after_call
-      = stan::math::ChainableStack::instance().var_stack_.size();
+      = stan::math::ChainableStack::instance_->var_stack_.size();
   EXPECT_EQ(4U, stack_size_after_call);
   stan::math::recover_memory();
 }

--- a/test/unit/math/rev/scal/err/check_not_nan_test.cpp
+++ b/test/unit/math/rev/scal/err/check_not_nan_test.cpp
@@ -45,13 +45,13 @@ TEST(AgradRevErrorHandlingScalar, CheckNotNanVarCheckUnivariate) {
   const char* function = "check_not_nan";
   var a(5.0);
 
-  size_t stack_size = stan::math::ChainableStack::instance().var_stack_.size();
+  size_t stack_size = stan::math::ChainableStack::instance_->var_stack_.size();
 
   EXPECT_EQ(1U, stack_size);
   EXPECT_NO_THROW(check_not_nan(function, "a", a));
 
   size_t stack_size_after_call
-      = stan::math::ChainableStack::instance().var_stack_.size();
+      = stan::math::ChainableStack::instance_->var_stack_.size();
   EXPECT_EQ(1U, stack_size_after_call);
 
   stan::math::recover_memory();
@@ -64,13 +64,13 @@ TEST(ErrorHandlingScalar, CheckNotNanVarCheckUnivariate) {
   const char* function = "check_not_nan";
   var a(5.0);
 
-  size_t stack_size = stan::math::ChainableStack::instance().var_stack_.size();
+  size_t stack_size = stan::math::ChainableStack::instance_->var_stack_.size();
 
   EXPECT_EQ(1U, stack_size);
   EXPECT_NO_THROW(check_not_nan(function, "a", a));
 
   size_t stack_size_after_call
-      = stan::math::ChainableStack::instance().var_stack_.size();
+      = stan::math::ChainableStack::instance_->var_stack_.size();
   EXPECT_EQ(1U, stack_size_after_call);
 
   stan::math::recover_memory();

--- a/test/unit/math/rev/scal/err/check_positive_finite_test.cpp
+++ b/test/unit/math/rev/scal/err/check_positive_finite_test.cpp
@@ -37,13 +37,13 @@ TEST(AgradRevErrorHandlingScalar, CheckPositiveFiniteVarCheckUnivariate) {
   const char* function = "check_positive_finite";
   var a(5.0);
 
-  size_t stack_size = stan::math::ChainableStack::instance().var_stack_.size();
+  size_t stack_size = stan::math::ChainableStack::instance_->var_stack_.size();
 
   EXPECT_EQ(1U, stack_size);
   EXPECT_NO_THROW(check_positive_finite(function, "a", a));
 
   size_t stack_size_after_call
-      = stan::math::ChainableStack::instance().var_stack_.size();
+      = stan::math::ChainableStack::instance_->var_stack_.size();
   EXPECT_EQ(1U, stack_size_after_call);
 
   stan::math::recover_memory();

--- a/test/unit/math/rev/scal/err/check_positive_test.cpp
+++ b/test/unit/math/rev/scal/err/check_positive_test.cpp
@@ -22,13 +22,13 @@ TEST(AgradRevErrorHandlingScalar, CheckPositiveVarCheckUnivariate) {
   const char* function = "check_positive";
   var a(5.0);
 
-  size_t stack_size = stan::math::ChainableStack::instance().var_stack_.size();
+  size_t stack_size = stan::math::ChainableStack::instance_->var_stack_.size();
 
   EXPECT_EQ(1U, stack_size);
   EXPECT_NO_THROW(check_positive(function, "a", a));
 
   size_t stack_size_after_call
-      = stan::math::ChainableStack::instance().var_stack_.size();
+      = stan::math::ChainableStack::instance_->var_stack_.size();
   EXPECT_EQ(1U, stack_size_after_call);
 
   stan::math::recover_memory();

--- a/test/unit/math/rev/scal/util.hpp
+++ b/test/unit/math/rev/scal/util.hpp
@@ -7,7 +7,7 @@
 namespace test {
 
 void check_varis_on_stack(const stan::math::var& x) {
-  EXPECT_TRUE(stan::math::ChainableStack::instance().memalloc_.in_stack(x.vi_))
+  EXPECT_TRUE(stan::math::ChainableStack::instance_->memalloc_.in_stack(x.vi_))
       << "not on the stack";
 }
 


### PR DESCRIPTION
This PR is a continuation of the reverted one from this merged PR: https://github.com/stan-dev/math/pull/1135

(I am not sure why git is unhappy and is in a state of not wanting to merge... do I need to rebase?)

**I am still in the process to sort things, but I want to see the tests on Jenkins.**

This PR speeds up the access to the AD tape whenever `thread_local` storage (TLS) is needed for the AD tape. In addition programs with TLS now work on Windows with gcc 4.9.3.

## Summary

This PR has the main goal to reduce the performance penalty implied by turning on thread capability of stan-math. As it turns out, the proposed implementation works out of the box on Windows with the gcc 4.9.3 compiler which is not the case with the current threading implementation in develop. So we fix a bug which affects many users given the popularity of Windows. The Windows bug is tickled in the commit a7bf7782432d57c195cc2fe90e9eb3fe7dffbfe1 on Jenkins and it is fixed in the current form of the PR.

The performance benefits of this PR are documented in the [previous PR](https://github.com/stan-dev/math/pull/1103) which served as a first prototype. In summary, we loose ~20% on develop when turning on threading while with this PR we reduce this to less than 3% on average.

The key change of this PR is to change how the global AD tape instance is declared and accessed. Currently in develop the global AD tape is declared 

- for the non-threading case as a static global instance.
- for the threading case as a TLS which is declared as a static instance of a static function (Meyer singleton design).

**This PR changes this to a global pointer to the AD tape, which is a TLS for threading, and which is initialized to the constant `nullptr` expression at compile-time**. Initialization to a constant expression at compile-time (as opposed to a dynamic expression right now in develop) allows the compiler to use the TLS global pointer more efficiently. Furthermore, the `thread_local` keyword used to declare TLS can be swapped for the compiler-specific `__thread` keyword whenever the expression is constant on gnu extension compatible compilers. The `__thread` keyword has been around much longer than the C++11 `thread_local` keyword and only the `__thread` keyword guarantees to the compiler the the variable is (in fact must be) initialized with a constant expression which allows the use of fast TLS code.

**The runtime initialisation of the AD tape for the main process is automatically achieved through the instantiation of a global object** which manages the life-time of the AD stack (as performed in the new file `math/stan/math/rev/core/init_chainablestack.hpp`).

## Side-effects

There is no change in behavior for programs whenever `STAN_THREADS` is not defined. If `STAN_THREADS` is defined, then any C++ client library which uses the stan-math functions (`map_rect` in particular) will continue to work unchanged. However, C++ clients which use AD in child threads will stop working. The reason is that the AD tape requires initialization in child threads. The initialization of the AD tape can be done by constructing a `ChainableStack` instance which will trigger AD tape initialization for the thread. The first instantiation of `ChainableStack` in a given child thread will take ownership of the AD tape. Thus only the first created instance will free the AD tape resource upon destruction.

## Tests

`test/unit/math/rev/core/thread_stack_instance_test.cpp` is a new test and is written to test matters with and without threading. The test is setup to test different things depending on enabling threading or not.

- STAN_THREADS NOT defined (no threading). In this case we only have a global AD tape. All child-threads created by a given program will see the same AD tape. Thus initializing the AD tape on the main thread implies that it is initialized on the child-thread, etc.

- STAN_THREADS IS defined (threading case). Now all new threads created must see their own TLS of the AD tape pointer which is not initialized at the beginning and is independent of the main thread AD tape when performing AD operations.

In addition I have added to the `map_rect_concurrent` tests code which enforces that these tests are always run with 4 threads regardless of the `STAN_NUM_THREADS` definition (which is often not set and this things do not run threaded during testing).


## Checklist

- [X] Math issue #1102 & #1134 

- [X] Copyright holder: Sebastian Weber

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [X] the new changes are tested

## Remaining TODO

- [x] @seantalts will review the code at the implementation level.
- [ ] We will run these benchmarks after we've caught up to develop (and hopefully after we've made any additional code changes):
    - [ ] microbenchmark for develop vs this branch without any threading. This will be run on Window, Linux, Mac for the compilers we've said we'd support (one per OS).
    - [x] @wds15's non-stiff integrator example for develop vs this branch with threading. This will run on Linux and Mac for the compilers we've said we'd support. (Windows does not work currently on develop.)
- [ ] If all of the benchmarks show no more than 5% speed regression, then it's acceptable performance-wise. (We have every reason to believe that we'll get a large speed benefit for threading.)
- [x] @syclik will run the benchmarks for the non-stiff integrator example by Monday. If he's unable to run the benchmarks by Monday, we will use the microbenchmark results only.


## End-to-end performance results

@syclik ran @wds15's benchmark on Mac with clang++ 6 and Linux with g++ 5 using these scripts: [syclik/benchmark-stan](https://github.com/syclik/benchmark-stan/tree/math/1135-ad). These results were generated on the git hash 95844ac using the all pointer design (with an instance() method abstraction).


### Summary

This PR is definitely faster for threading (compared to develop with threading)!

* Linux, g++ 5:
  * 1 thread: 18% faster
  * 2 threads: 12% faster
  * 4 threads: 13% faster
* Mac, clang++ 6:
  * 1 thread: 27% faster
  * 2 threads: 26% faster
  * 4 threads: 29% faster

### Data (time in seconds per run)

| os | threads | branch	| n | mean | sd	| min |	max |
|----|---------|--------|---|------|----|-----|-----|
| linux | 1 | new | 10 | 204.9988 |  3.7411436 | 201.402 | 215.134 |
| linux | 1 | old | 10 | 250.7093 |  1.0396194 | 249.544 | 252.021 |
| linux | 2 | new | 10 | 228.5871 |  0.5270710 | 228.024 | 229.507 |
| linux | 2 | old | 10 | 259.4587 |  1.7354262 | 257.465 | 262.409 |
| linux | 4 | new | 10 | 156.1332 |  0.1720515 | 155.854 | 156.346 |
| linux | 4 | old | 10 | 180.4681 |  0.2238524 | 180.118 | 180.887 |
|   mac | 1 | new | 10 | 302.0826 | 13.1204998 | 289.895 | 334.361 |
|   mac | 1 | old | 10 | 412.2389 |  7.1865066 | 403.996 | 425.580 |
|   mac | 2 | new | 10 | 167.9633 |  3.5238670 | 161.854 | 173.285 |
|   mac | 2 | old | 10 | 225.8895 |  4.1751089 | 218.869 | 231.755 |
|   mac | 4 | new | 10 |  96.2758 |  1.6974981 |  93.061 |  98.700 |
|   mac | 4 | old | 10 | 134.9916 |  3.3910946 | 129.339 | 141.984 |

(I still wouldn't suggest using this for single-threaded mode. I haven't benchmarked as thoroughly since it's not what this is about, but on Linux, it's about break even, but on Mac, it's about 10% slower.)