### PR TITLE
Issue #50: boolean functions - 2 

### DIFF
--- a/stan/math/prim/arr/err/check_opencl.hpp
+++ b/stan/math/prim/arr/err/check_opencl.hpp
@@ -21,7 +21,7 @@ namespace math {
  * occured. It outputs the OpenCL errors that are specified
  * in OpenCL 2.0. If no matching error number is found,
  * it throws the error with the number.
- * @param function the name of the function where the error occured
+ * @param function the name of the function where the error occurred
  * @param e The error number
  */
 inline void check_opencl_error(const char *function, const cl::Error &e) {
@@ -36,32 +36,27 @@ inline void check_opencl_error(const char *function, const cl::Error &e) {
     case -3:
       system_error(function, e.what(), e.err(), "CL_COMPILER_NOT_AVAILABLE");
     case -4:
-      system_error(function, e.what(), e.err(),
-                   "CL_MEM_OBJECT_ALLOCATION_FAILURE");
+      system_error(function, e.what(), e.err(), "CL_MEM_OBJECT_ALLOCATION_FAILURE");
     case -5:
       system_error(function, e.what(), e.err(), "CL_OUT_OF_RESOURCES");
     case -6:
       system_error(function, e.what(), e.err(), "CL_OUT_OF_HOST_MEMORY");
     case -7:
-      system_error(function, e.what(), e.err(),
-                   "CL_PROFILING_INFO_NOT_AVAILABLE");
+      system_error(function, e.what(), e.err(), "CL_PROFILING_INFO_NOT_AVAILABLE");
     case -8:
       system_error(function, e.what(), e.err(), "CL_MEM_COPY_OVERLAP");
     case -9:
       system_error(function, e.what(), e.err(), "CL_IMAGE_FORMAT_MISMATCH");
     case -10:
-      system_error(function, e.what(), e.err(),
-                   "CL_IMAGE_FORMAT_NOT_SUPPORTED");
+      system_error(function, e.what(), e.err(), "CL_IMAGE_FORMAT_NOT_SUPPORTED");
     case -11:
       system_error(function, e.what(), e.err(), "CL_BUILD_PROGRAM_FAILURE");
     case -12:
       system_error(function, e.what(), e.err(), "CL_MAP_FAILURE");
     case -13:
-      system_error(function, e.what(), e.err(),
-                   "CL_MISALIGNED_SUB_BUFFER_OFFSET");
+      system_error(function, e.what(), e.err(), "CL_MISALIGNED_SUB_BUFFER_OFFSET");
     case -14:
-      system_error(function, e.what(), e.err(),
-                   "CL_EXEC_STATUS_ERROR_FOR_EVENTS_IN_WAIT_LIST");
+      system_error(function, e.what(), e.err(), "CL_EXEC_STATUS_ERROR_FOR_EVENTS_IN_WAIT_LIST");
     case -15:
       system_error(function, e.what(), e.err(), "CL_COMPILE_PROGRAM_FAILURE");
     case -16:
@@ -71,8 +66,7 @@ inline void check_opencl_error(const char *function, const cl::Error &e) {
     case -18:
       system_error(function, e.what(), e.err(), "CL_DEVICE_PARTITION_FAILED");
     case -19:
-      system_error(function, e.what(), e.err(),
-                   "CL_KERNEL_ARG_INFO_NOT_AVAILABLE");
+      system_error(function, e.what(), e.err(), "CL_KERNEL_ARG_INFO_NOT_AVAILABLE");
     case -30:
       system_error(function, e.what(), e.err(), "CL_INVALID_VALUE");
     case -31:
@@ -92,8 +86,7 @@ inline void check_opencl_error(const char *function, const cl::Error &e) {
     case -38:
       system_error(function, e.what(), e.err(), "CL_INVALID_MEM_OBJECT");
     case -39:
-      system_error(function, e.what(), e.err(),
-                   "CL_INVALID_IMAGE_FORMAT_DESCRIPTOR");
+      system_error(function, e.what(), e.err(), "CL_INVALID_IMAGE_FORMAT_DESCRIPTOR");
     case -40:
       system_error(function, e.what(), e.err(), "CL_INVALID_IMAGE_SIZE");
     case -41:
@@ -105,8 +98,7 @@ inline void check_opencl_error(const char *function, const cl::Error &e) {
     case -44:
       system_error(function, e.what(), e.err(), "CL_INVALID_PROGRAM");
     case -45:
-      system_error(function, e.what(), e.err(),
-                   "CL_INVALID_PROGRAM_EXECUTABLE");
+      system_error(function, e.what(), e.err(), "CL_INVALID_PROGRAM_EXECUTABLE");
     case -46:
       system_error(function, e.what(), e.err(), "CL_INVALID_KERNEL_NAME");
     case -47:
@@ -152,79 +144,61 @@ inline void check_opencl_error(const char *function, const cl::Error &e) {
     case -67:
       system_error(function, e.what(), e.err(), "CL_INVALID_LINKER_OPTIONS");
     case -68:
-      system_error(function, e.what(), e.err(),
-                   "CL_INVALID_DEVICE_PARTITION_COUNT");
+      system_error(function, e.what(), e.err(), "CL_INVALID_DEVICE_PARTITION_COUNT");
     case -69:
       system_error(function, e.what(), e.err(), "CL_INVALID_PIPE_SIZE");
     case -70:
       system_error(function, e.what(), e.err(), "CL_INVALID_DEVICE_QUEUE");
     case -1000:
-      system_error(function, e.what(), e.err(),
-                   "CL_INVALID_GL_SHAREGROUP_REFERENCE_KHR");
+      system_error(function, e.what(), e.err(), "CL_INVALID_GL_SHAREGROUP_REFERENCE_KHR");
     case -1001:
       system_error(function, e.what(), e.err(), "CL_PLATFORM_NOT_FOUND_KHR");
     case -1002:
       system_error(function, e.what(), e.err(), "CL_INVALID_D3D10_DEVICE_KHR");
     case -1003:
-      system_error(function, e.what(), e.err(),
-                   "CL_INVALID_D3D10_RESOURCE_KHR");
+      system_error(function, e.what(), e.err(), "CL_INVALID_D3D10_RESOURCE_KHR");
     case -1004:
-      system_error(function, e.what(), e.err(),
-                   "CL_D3D10_RESOURCE_ALREADY_ACQUIRED_KHR");
+      system_error(function, e.what(), e.err(), "CL_D3D10_RESOURCE_ALREADY_ACQUIRED_KHR");
     case -1005:
-      system_error(function, e.what(), e.err(),
-                   "CL_D3D10_RESOURCE_NOT_ACQUIRED_KHR");
+      system_error(function, e.what(), e.err(), "CL_D3D10_RESOURCE_NOT_ACQUIRED_KHR");
     case -1006:
       system_error(function, e.what(), e.err(), "CL_INVALID_D3D11_DEVICE_KHR");
     case -1007:
-      system_error(function, e.what(), e.err(),
-                   "CL_INVALID_D3D11_RESOURCE_KHR");
+      system_error(function, e.what(), e.err(), "CL_INVALID_D3D11_RESOURCE_KHR");
     case -1008:
-      system_error(function, e.what(), e.err(),
-                   "CL_D3D11_RESOURCE_ALREADY_ACQUIRED_KHR");
+      system_error(function, e.what(), e.err(), "CL_D3D11_RESOURCE_ALREADY_ACQUIRED_KHR");
     case -1009:
-      system_error(function, e.what(), e.err(),
-                   "CL_D3D11_RESOURCE_NOT_ACQUIRED_KHR");
+      system_error(function, e.what(), e.err(), "CL_D3D11_RESOURCE_NOT_ACQUIRED_KHR");
     case -101:
       system_error(function, e.what(), e.err(), "CL_INVALID_D3D9_DEVICE_NV ");
     case -1011:
       system_error(function, e.what(), e.err(), "CL_INVALID_D3D9_RESOURCE_NV ");
     case -1012:
-      system_error(function, e.what(), e.err(),
-                   "CL_D3D9_RESOURCE_ALREADY_ACQUIRED_NV "
-                   "CL_DX9_RESOURCE_ALREADY_ACQUIRED_INTEL");
+      system_error(function, e.what(), e.err(), "CL_D3D9_RESOURCE_ALREADY_ACQUIRED_NV "
+                                                "CL_DX9_RESOURCE_ALREADY_ACQUIRED_INTEL");
     case -1013:
-      system_error(function, e.what(), e.err(),
-                   "CL_D3D9_RESOURCE_NOT_ACQUIRED_NV "
-                   "CL_DX9_RESOURCE_NOT_ACQUIRED_INTEL");
+      system_error(function, e.what(), e.err(), "CL_D3D9_RESOURCE_NOT_ACQUIRED_NV "
+                                                "CL_DX9_RESOURCE_NOT_ACQUIRED_INTEL");
     case -1092:
-      system_error(function, e.what(), e.err(),
-                   "CL_EGL_RESOURCE_NOT_ACQUIRED_KHR");
+      system_error(function, e.what(), e.err(), "CL_EGL_RESOURCE_NOT_ACQUIRED_KHR");
     case -1093:
       system_error(function, e.what(), e.err(), "CL_INVALID_EGL_OBJECT_KHR");
     case -1094:
       system_error(function, e.what(), e.err(), "CL_INVALID_ACCELERATOR_INTEL");
     case -1095:
-      system_error(function, e.what(), e.err(),
-                   "CL_INVALID_ACCELERATOR_TYPE_INTEL");
+      system_error(function, e.what(), e.err(), "CL_INVALID_ACCELERATOR_TYPE_INTEL");
     case -1096:
-      system_error(function, e.what(), e.err(),
-                   "CL_INVALID_ACCELERATOR_DESCRIPTOR_INTEL");
+      system_error(function, e.what(), e.err(), "CL_INVALID_ACCELERATOR_DESCRIPTOR_INTEL");
     case -1097:
-      system_error(function, e.what(), e.err(),
-                   "CL_ACCELERATOR_TYPE_NOT_SUPPORTED_INTEL");
+      system_error(function, e.what(), e.err(), "CL_ACCELERATOR_TYPE_NOT_SUPPORTED_INTEL");
     case -1098:
-      system_error(function, e.what(), e.err(),
-                   "CL_INVALID_VA_API_MEDIA_ADAPTER_INTEL");
+      system_error(function, e.what(), e.err(), "CL_INVALID_VA_API_MEDIA_ADAPTER_INTEL");
     case -1099:
-      system_error(function, e.what(), e.err(),
-                   "CL_INVALID_VA_API_MEDIA_SURFACE_INTEL");
+      system_error(function, e.what(), e.err(), "CL_INVALID_VA_API_MEDIA_SURFACE_INTEL");
     case -1100:
-      system_error(function, e.what(), e.err(),
-                   "CL_VA_API_MEDIA_SURFACE_ALREADY_ACQUIRED_INTEL");
+      system_error(function, e.what(), e.err(), "CL_VA_API_MEDIA_SURFACE_ALREADY_ACQUIRED_INTEL");
     case -1101:
-      system_error(function, e.what(), e.err(),
-                   "CL_VA_API_MEDIA_SURFACE_NOT_ACQUIRED_INTEL");
+      system_error(function, e.what(), e.err(), "CL_VA_API_MEDIA_SURFACE_NOT_ACQUIRED_INTEL");
     case -9999:
       system_error(function, e.what(), e.err(), "ILLEGAL_READ_OR_WRITE_NVIDIA");
     default:

--- a/stan/math/prim/arr/err/check_opencl.hpp
+++ b/stan/math/prim/arr/err/check_opencl.hpp
@@ -36,27 +36,32 @@ inline void check_opencl_error(const char *function, const cl::Error &e) {
     case -3:
       system_error(function, e.what(), e.err(), "CL_COMPILER_NOT_AVAILABLE");
     case -4:
-      system_error(function, e.what(), e.err(), "CL_MEM_OBJECT_ALLOCATION_FAILURE");
+      system_error(function, e.what(), e.err(),
+                   "CL_MEM_OBJECT_ALLOCATION_FAILURE");
     case -5:
       system_error(function, e.what(), e.err(), "CL_OUT_OF_RESOURCES");
     case -6:
       system_error(function, e.what(), e.err(), "CL_OUT_OF_HOST_MEMORY");
     case -7:
-      system_error(function, e.what(), e.err(), "CL_PROFILING_INFO_NOT_AVAILABLE");
+      system_error(function, e.what(), e.err(),
+                   "CL_PROFILING_INFO_NOT_AVAILABLE");
     case -8:
       system_error(function, e.what(), e.err(), "CL_MEM_COPY_OVERLAP");
     case -9:
       system_error(function, e.what(), e.err(), "CL_IMAGE_FORMAT_MISMATCH");
     case -10:
-      system_error(function, e.what(), e.err(), "CL_IMAGE_FORMAT_NOT_SUPPORTED");
+      system_error(function, e.what(), e.err(),
+                   "CL_IMAGE_FORMAT_NOT_SUPPORTED");
     case -11:
       system_error(function, e.what(), e.err(), "CL_BUILD_PROGRAM_FAILURE");
     case -12:
       system_error(function, e.what(), e.err(), "CL_MAP_FAILURE");
     case -13:
-      system_error(function, e.what(), e.err(), "CL_MISALIGNED_SUB_BUFFER_OFFSET");
+      system_error(function, e.what(), e.err(),
+                   "CL_MISALIGNED_SUB_BUFFER_OFFSET");
     case -14:
-      system_error(function, e.what(), e.err(), "CL_EXEC_STATUS_ERROR_FOR_EVENTS_IN_WAIT_LIST");
+      system_error(function, e.what(), e.err(),
+                   "CL_EXEC_STATUS_ERROR_FOR_EVENTS_IN_WAIT_LIST");
     case -15:
       system_error(function, e.what(), e.err(), "CL_COMPILE_PROGRAM_FAILURE");
     case -16:
@@ -66,7 +71,8 @@ inline void check_opencl_error(const char *function, const cl::Error &e) {
     case -18:
       system_error(function, e.what(), e.err(), "CL_DEVICE_PARTITION_FAILED");
     case -19:
-      system_error(function, e.what(), e.err(), "CL_KERNEL_ARG_INFO_NOT_AVAILABLE");
+      system_error(function, e.what(), e.err(),
+                   "CL_KERNEL_ARG_INFO_NOT_AVAILABLE");
     case -30:
       system_error(function, e.what(), e.err(), "CL_INVALID_VALUE");
     case -31:
@@ -86,7 +92,8 @@ inline void check_opencl_error(const char *function, const cl::Error &e) {
     case -38:
       system_error(function, e.what(), e.err(), "CL_INVALID_MEM_OBJECT");
     case -39:
-      system_error(function, e.what(), e.err(), "CL_INVALID_IMAGE_FORMAT_DESCRIPTOR");
+      system_error(function, e.what(), e.err(),
+                   "CL_INVALID_IMAGE_FORMAT_DESCRIPTOR");
     case -40:
       system_error(function, e.what(), e.err(), "CL_INVALID_IMAGE_SIZE");
     case -41:
@@ -98,7 +105,8 @@ inline void check_opencl_error(const char *function, const cl::Error &e) {
     case -44:
       system_error(function, e.what(), e.err(), "CL_INVALID_PROGRAM");
     case -45:
-      system_error(function, e.what(), e.err(), "CL_INVALID_PROGRAM_EXECUTABLE");
+      system_error(function, e.what(), e.err(),
+                   "CL_INVALID_PROGRAM_EXECUTABLE");
     case -46:
       system_error(function, e.what(), e.err(), "CL_INVALID_KERNEL_NAME");
     case -47:
@@ -144,61 +152,79 @@ inline void check_opencl_error(const char *function, const cl::Error &e) {
     case -67:
       system_error(function, e.what(), e.err(), "CL_INVALID_LINKER_OPTIONS");
     case -68:
-      system_error(function, e.what(), e.err(), "CL_INVALID_DEVICE_PARTITION_COUNT");
+      system_error(function, e.what(), e.err(),
+                   "CL_INVALID_DEVICE_PARTITION_COUNT");
     case -69:
       system_error(function, e.what(), e.err(), "CL_INVALID_PIPE_SIZE");
     case -70:
       system_error(function, e.what(), e.err(), "CL_INVALID_DEVICE_QUEUE");
     case -1000:
-      system_error(function, e.what(), e.err(), "CL_INVALID_GL_SHAREGROUP_REFERENCE_KHR");
+      system_error(function, e.what(), e.err(),
+                   "CL_INVALID_GL_SHAREGROUP_REFERENCE_KHR");
     case -1001:
       system_error(function, e.what(), e.err(), "CL_PLATFORM_NOT_FOUND_KHR");
     case -1002:
       system_error(function, e.what(), e.err(), "CL_INVALID_D3D10_DEVICE_KHR");
     case -1003:
-      system_error(function, e.what(), e.err(), "CL_INVALID_D3D10_RESOURCE_KHR");
+      system_error(function, e.what(), e.err(),
+                   "CL_INVALID_D3D10_RESOURCE_KHR");
     case -1004:
-      system_error(function, e.what(), e.err(), "CL_D3D10_RESOURCE_ALREADY_ACQUIRED_KHR");
+      system_error(function, e.what(), e.err(),
+                   "CL_D3D10_RESOURCE_ALREADY_ACQUIRED_KHR");
     case -1005:
-      system_error(function, e.what(), e.err(), "CL_D3D10_RESOURCE_NOT_ACQUIRED_KHR");
+      system_error(function, e.what(), e.err(),
+                   "CL_D3D10_RESOURCE_NOT_ACQUIRED_KHR");
     case -1006:
       system_error(function, e.what(), e.err(), "CL_INVALID_D3D11_DEVICE_KHR");
     case -1007:
-      system_error(function, e.what(), e.err(), "CL_INVALID_D3D11_RESOURCE_KHR");
+      system_error(function, e.what(), e.err(),
+                   "CL_INVALID_D3D11_RESOURCE_KHR");
     case -1008:
-      system_error(function, e.what(), e.err(), "CL_D3D11_RESOURCE_ALREADY_ACQUIRED_KHR");
+      system_error(function, e.what(), e.err(),
+                   "CL_D3D11_RESOURCE_ALREADY_ACQUIRED_KHR");
     case -1009:
-      system_error(function, e.what(), e.err(), "CL_D3D11_RESOURCE_NOT_ACQUIRED_KHR");
+      system_error(function, e.what(), e.err(),
+                   "CL_D3D11_RESOURCE_NOT_ACQUIRED_KHR");
     case -101:
       system_error(function, e.what(), e.err(), "CL_INVALID_D3D9_DEVICE_NV ");
     case -1011:
       system_error(function, e.what(), e.err(), "CL_INVALID_D3D9_RESOURCE_NV ");
     case -1012:
-      system_error(function, e.what(), e.err(), "CL_D3D9_RESOURCE_ALREADY_ACQUIRED_NV "
-                                                "CL_DX9_RESOURCE_ALREADY_ACQUIRED_INTEL");
+      system_error(function, e.what(), e.err(),
+                   "CL_D3D9_RESOURCE_ALREADY_ACQUIRED_NV "
+                   "CL_DX9_RESOURCE_ALREADY_ACQUIRED_INTEL");
     case -1013:
-      system_error(function, e.what(), e.err(), "CL_D3D9_RESOURCE_NOT_ACQUIRED_NV "
-                                                "CL_DX9_RESOURCE_NOT_ACQUIRED_INTEL");
+      system_error(function, e.what(), e.err(),
+                   "CL_D3D9_RESOURCE_NOT_ACQUIRED_NV "
+                   "CL_DX9_RESOURCE_NOT_ACQUIRED_INTEL");
     case -1092:
-      system_error(function, e.what(), e.err(), "CL_EGL_RESOURCE_NOT_ACQUIRED_KHR");
+      system_error(function, e.what(), e.err(),
+                   "CL_EGL_RESOURCE_NOT_ACQUIRED_KHR");
     case -1093:
       system_error(function, e.what(), e.err(), "CL_INVALID_EGL_OBJECT_KHR");
     case -1094:
       system_error(function, e.what(), e.err(), "CL_INVALID_ACCELERATOR_INTEL");
     case -1095:
-      system_error(function, e.what(), e.err(), "CL_INVALID_ACCELERATOR_TYPE_INTEL");
+      system_error(function, e.what(), e.err(),
+                   "CL_INVALID_ACCELERATOR_TYPE_INTEL");
     case -1096:
-      system_error(function, e.what(), e.err(), "CL_INVALID_ACCELERATOR_DESCRIPTOR_INTEL");
+      system_error(function, e.what(), e.err(),
+                   "CL_INVALID_ACCELERATOR_DESCRIPTOR_INTEL");
     case -1097:
-      system_error(function, e.what(), e.err(), "CL_ACCELERATOR_TYPE_NOT_SUPPORTED_INTEL");
+      system_error(function, e.what(), e.err(),
+                   "CL_ACCELERATOR_TYPE_NOT_SUPPORTED_INTEL");
     case -1098:
-      system_error(function, e.what(), e.err(), "CL_INVALID_VA_API_MEDIA_ADAPTER_INTEL");
+      system_error(function, e.what(), e.err(),
+                   "CL_INVALID_VA_API_MEDIA_ADAPTER_INTEL");
     case -1099:
-      system_error(function, e.what(), e.err(), "CL_INVALID_VA_API_MEDIA_SURFACE_INTEL");
+      system_error(function, e.what(), e.err(),
+                   "CL_INVALID_VA_API_MEDIA_SURFACE_INTEL");
     case -1100:
-      system_error(function, e.what(), e.err(), "CL_VA_API_MEDIA_SURFACE_ALREADY_ACQUIRED_INTEL");
+      system_error(function, e.what(), e.err(),
+                   "CL_VA_API_MEDIA_SURFACE_ALREADY_ACQUIRED_INTEL");
     case -1101:
-      system_error(function, e.what(), e.err(), "CL_VA_API_MEDIA_SURFACE_NOT_ACQUIRED_INTEL");
+      system_error(function, e.what(), e.err(),
+                   "CL_VA_API_MEDIA_SURFACE_NOT_ACQUIRED_INTEL");
     case -9999:
       system_error(function, e.what(), e.err(), "ILLEGAL_READ_OR_WRITE_NVIDIA");
     default:

--- a/stan/math/prim/mat.hpp
+++ b/stan/math/prim/mat.hpp
@@ -44,6 +44,19 @@
 #include <stan/math/prim/mat/err/check_unit_vector.hpp>
 #include <stan/math/prim/mat/err/check_vector.hpp>
 #include <stan/math/prim/mat/err/constraint_tolerance.hpp>
+#include <stan/math/prim/mat/err/is_cholesky_factor_corr.hpp>
+#include <stan/math/prim/mat/err/is_cholesky_factor.hpp>
+#include <stan/math/prim/mat/err/is_column_index.hpp>
+#include <stan/math/prim/mat/err/is_corr_matrix.hpp>
+#include <stan/math/prim/mat/err/is_cov_matrix.hpp>
+#include <stan/math/prim/mat/err/is_ldlt_factor.hpp>
+#include <stan/math/prim/mat/err/is_lower_triangular.hpp>
+#include <stan/math/prim/mat/err/is_mat_finite.hpp>
+#include <stan/math/prim/mat/err/is_matching_dims.hpp>
+#include <stan/math/prim/mat/err/is_pos_definite.hpp>
+#include <stan/math/prim/mat/err/is_square.hpp>
+#include <stan/math/prim/mat/err/is_symmetric.hpp>
+#include <stan/math/prim/mat/err/is_unit_vector.hpp>
 #include <stan/math/prim/mat/err/validate_non_negative_index.hpp>
 
 #include <stan/math/prim/mat/fun/Eigen.hpp>

--- a/stan/math/prim/mat/err/check_cholesky_factor.hpp
+++ b/stan/math/prim/mat/err/check_cholesky_factor.hpp
@@ -9,20 +9,15 @@
 namespace stan {
 namespace math {
 /**
- * Check if the specified matrix is a valid
- * Cholesky factor.
- *
+ * Check if the specified matrix is a valid Cholesky factor.
  * A Cholesky factor is a lower triangular matrix whose diagonal
  * elements are all positive.  Note that Cholesky factors need not
  * be square, but require at least as many rows M as columns N
  * (i.e., M &gt;= N).
- *
  * @tparam T_y Type of elements of Cholesky factor
- *
  * @param function Function name (for error messages)
  * @param name Variable name (for error messages)
  * @param y Matrix to test
- *
  * @throw <code>std::domain_error</code> if y is not a valid Choleksy
  *   factor, if number of rows is less than the number of columns,
  *   if there are 0 columns, or if any element in matrix is NaN

--- a/stan/math/prim/mat/err/check_cholesky_factor_corr.hpp
+++ b/stan/math/prim/mat/err/check_cholesky_factor_corr.hpp
@@ -11,18 +11,14 @@
 namespace stan {
 namespace math {
 /**
- * Check if the specified matrix is a valid
- * Cholesky factor of a correlation matrix.
- *
+ * Check if the specified matrix is a valid Cholesky factor of a
+ * correlation matrix.
  * A Cholesky factor is a lower triangular matrix whose diagonal
  * elements are all positive.  Note that Cholesky factors need not
- * be square, but require at least as many rows M as columns N
+ * be square, but requires at least as many rows M as columns N
  * (i.e., M &gt;= N).
- *
  * Tolerance is specified by <code>math::CONSTRAINT_TOLERANCE</code>.
- *
  * @tparam T_y Type of elements of Cholesky factor
- *
  * @param function Function name (for error messages)
  * @param name Variable name (for error messages)
  * @param y Matrix to test
@@ -34,13 +30,12 @@ template <typename T_y>
 void check_cholesky_factor_corr(
     const char* function, const char* name,
     const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>& y) {
-  using Eigen::Dynamic;
   check_square(function, name, y);
   check_lower_triangular(function, name, y);
   for (int i = 0; i < y.rows(); ++i)
     check_positive(function, name, y(i, i));
   for (int i = 0; i < y.rows(); ++i) {
-    Eigen::Matrix<T_y, Dynamic, 1> y_i = y.row(i).transpose();
+    Eigen::Matrix<T_y, Eigen::Dynamic, 1> y_i = y.row(i).transpose();
     check_unit_vector(function, name, y_i);
   }
 }

--- a/stan/math/prim/mat/err/check_column_index.hpp
+++ b/stan/math/prim/mat/err/check_column_index.hpp
@@ -11,25 +11,20 @@ namespace stan {
 namespace math {
 
 /**
- * Check if the specified index is a valid
- * column of the matrix.
- *
- * By default, this is a 1-indexed check (as opposed to
+ * Check if the specified index is a valid column of the matrix.
+ * By default this is a 1-indexed check (as opposed to
  * 0-indexed). Behavior can be changed by setting
  * <code>stan::error_index::value</code>. This function will
  * throw an <code>std::out_of_range</code> exception if
  * the index is out of bounds.
- *
- * @tparam T_y Type of scalar.
+ * @tparam T_y Type of scalar
  * @tparam R Number of rows of the matrix
  * @tparam C Number of columns of the matrix
- *
  * @param function Function name (for error messages)
  * @param name Variable name (for error messages)
- * @param y Matrix
+ * @param y Matrix to test
  * @param i Index to check
- *
- * @throw std::out_of_range if index is an invalid column index
+ * @throw <code>std::out_of_range</code> if index is an invalid column
  */
 template <typename T_y, int R, int C>
 inline void check_column_index(const char* function, const char* name,

--- a/stan/math/prim/mat/err/check_corr_matrix.hpp
+++ b/stan/math/prim/mat/err/check_corr_matrix.hpp
@@ -37,9 +37,8 @@ template <typename T_y>
 inline void check_corr_matrix(
     const char* function, const char* name,
     const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>& y) {
-
-  typedef typename 
-    index_type<Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic> >::type size_t;
+  typedef typename index_type<
+      Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic> >::type size_t;
 
   check_size_match(function, "Rows of correlation matrix", y.rows(),
                    "columns of correlation matrix", y.cols());

--- a/stan/math/prim/mat/err/check_corr_matrix.hpp
+++ b/stan/math/prim/mat/err/check_corr_matrix.hpp
@@ -17,37 +17,29 @@ namespace stan {
 namespace math {
 
 /**
- * Check if the specified matrix is a valid
- * correlation matrix.
- *
+ * Check if the specified matrix is a valid correlation matrix.
  * A valid correlation matrix is symmetric, has a unit diagonal
  * (all 1 values), and has all values between -1 and 1
  * (inclusive).
- *
  * This function throws exceptions if the variable is not a valid
  * correlation matrix.
- *
  * @tparam T_y Type of scalar
- *
  * @param function Name of the function this was called from
  * @param name Name of the variable
  * @param y Matrix to test
- *
  * @throw <code>std::invalid_argument</code> if the matrix is not square
  *   or if the matrix is 0x0
  * @throw <code>std::domain_error</code> if the matrix is non-symmetric,
  *   diagonals not near 1, not positive definite, or any of the
- *   elements nan.
+ *   elements nan
  */
 template <typename T_y>
 inline void check_corr_matrix(
     const char* function, const char* name,
     const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>& y) {
-  using Eigen::Matrix;
 
-  typedef
-      typename index_type<Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic> >::type
-          size_t;
+  typedef typename 
+    index_type<Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic> >::type size_t;
 
   check_size_match(function, "Rows of correlation matrix", y.rows(),
                    "columns of correlation matrix", y.cols());

--- a/stan/math/prim/mat/err/check_cov_matrix.hpp
+++ b/stan/math/prim/mat/err/check_cov_matrix.hpp
@@ -7,23 +7,18 @@
 namespace stan {
 namespace math {
 /**
- * Check if the specified matrix is a valid
- * covariance matrix.
- *
+ * Check if the specified matrix is a valid covariance matrix.
  * A valid covariance matrix is a square, symmetric matrix that is
  * positive definite.
- *
- * @tparam T Type of scalar.
- *
+ * @tparam T Type of scalar
  * @param function Function name (for error messages)
  * @param name Variable name (for error messages)
  * @param y Matrix to test
- *
  * @throw <code>std::invalid_argument</code> if the matrix is not square
  *   or if the matrix is 0x0
  * @throw <code>std::domain_error</code> if the matrix is not symmetric,
- *   if the matrix is not positive definite,
- *   or if any element of the matrix is nan
+ *   if the matrix is not positive definite, or if any element of the matrix
+ *   is nan
  */
 template <typename T_y>
 inline void check_cov_matrix(

--- a/stan/math/prim/mat/err/check_finite.hpp
+++ b/stan/math/prim/mat/err/check_finite.hpp
@@ -9,6 +9,18 @@
 
 namespace stan {
 namespace math {
+
+/**
+ * Return <code>true</code> is the specified matrix is finite.
+ * @tparams T Scalar type of the matrix, requires class method
+ *   <code>.size()</code>
+ * @tparams R Compile time rows of the matrix
+ * @tparams C Compile time columns of the matrix
+ * @param function Function name (for error messages)
+ * @param name Variable name (for error messages)
+ * @param y Matrix to test
+ * @return <code>true</code> if the matrix is finite
+ **/
 namespace internal {
 template <typename T, int R, int C>
 struct finite<Eigen::Matrix<T, R, C>, true> {

--- a/stan/math/prim/mat/err/check_finite.hpp
+++ b/stan/math/prim/mat/err/check_finite.hpp
@@ -10,7 +10,7 @@
 namespace stan {
 namespace math {
 
-/**
+/*
  * Return <code>true</code> is the specified matrix is finite.
  * @tparams T Scalar type of the matrix, requires class method
  *   <code>.size()</code>

--- a/stan/math/prim/mat/err/check_ldlt_factor.hpp
+++ b/stan/math/prim/mat/err/check_ldlt_factor.hpp
@@ -15,15 +15,13 @@ namespace math {
  * <code>LDLT_factor</code> is invalid if it was constructed from
  * a matrix that is not positive definite.  The check is that the
  * <code>success()</code> method returns <code>true</code>.
- *
- * @tparam T type of scalar
- * @tparam R rows of the matrix
- * @tparam C columns of the matrix
- * @param[in] function function name for error messages
- * @param[in] name variable name for error messages
- * @param[in] A LDLT factor to check for validity
- * @throws <code>std::domain_error</code> if the LDLT factor is
- *   invalid.
+ * @tparam T Type of scalar
+ * @tparam R Rows of the matrix
+ * @tparam C Columns of the matrix
+ * @param[in] function Function name for error messages
+ * @param[in] name Variable name for error messages
+ * @param[in] A The LDLT factor to check for validity
+ * @throws <code>std::domain_error</code> if the LDLT factor is invalid
  */
 template <typename T, int R, int C>
 inline void check_ldlt_factor(const char* function, const char* name,

--- a/stan/math/prim/mat/err/check_lower_triangular.hpp
+++ b/stan/math/prim/mat/err/check_lower_triangular.hpp
@@ -10,19 +10,14 @@
 namespace stan {
 namespace math {
 /**
- * Check if the specified matrix is lower
- * triangular.
- *
+ * Check if the specified matrix is lower triangular.
  * A matrix x is not lower triangular if there is a non-zero entry
  * x[m, n] with m &lt; n. This function only inspects the upper
  * triangular portion of the matrix, not including the diagonal.
- *
  * @tparam T Type of scalar of the matrix
- *
  * @param function Function name (for error messages)
  * @param name Variable name (for error messages)
  * @param y Matrix to test
- *
  * @throw <code>std::domain_error</code> if the matrix is not
  *   lower triangular or if any element in the upper triangular
  *   portion is NaN

--- a/stan/math/prim/mat/err/check_matching_dims.hpp
+++ b/stan/math/prim/mat/err/check_matching_dims.hpp
@@ -13,24 +13,20 @@ namespace math {
 
 /**
  * Check if the two matrices are of the same size.
- *
  * This function checks the runtime sizes only.
- *
  * @tparam T1 Scalar type of the first matrix
  * @tparam T2 Scalar type of the second matrix
  * @tparam R1 Rows specified at compile time of the first matrix
  * @tparam C1 Columns specified at compile time of the first matrix
  * @tparam R2 Rows specified at compile time of the second matrix
  * @tparam C2 Columns specified at compile time of the second matrix
- *
  * @param function Function name (for error messages)
  * @param name1 Variable name for the first matrix (for error messages)
- * @param y1 First matrix
+ * @param y1 First matrix to test
  * @param name2 Variable name for the second matrix (for error messages)
- * @param y2 Second matrix
- *
- * @throw <code>std::invalid_argument</code>
- * if the dimensions of the matrices do not match
+ * @param y2 Second matrix to test
+ * @throw <code>std::invalid_argument</code> if the dimensions of the
+ *    matrices do not match
  */
 template <typename T1, typename T2, int R1, int C1, int R2, int C2>
 inline void check_matching_dims(const char* function, const char* name1,
@@ -45,11 +41,9 @@ inline void check_matching_dims(const char* function, const char* name1,
 
 /**
  * Check if the two matrices are of the same size.
- *
  * This function checks the runtime sizes and can also check the static
  * sizes as well. For example, a 4x1 matrix is not the same as a vector
  * with 4 elements.
- *
  * @tparam check_compile Whether to check the static sizes
  * @tparam T1 Scalar type of the first matrix
  * @tparam T2 Scalar type of the second matrix
@@ -57,15 +51,13 @@ inline void check_matching_dims(const char* function, const char* name1,
  * @tparam C1 Columns specified at compile time of the first matrix
  * @tparam R2 Rows specified at compile time of the second matrix
  * @tparam C2 Columns specified at compile time of the second matrix
- *
  * @param function Function name (for error messages)
  * @param name1 Variable name for the first matrix (for error messages)
- * @param y1 First matrix
+ * @param y1 First matrix to test
  * @param name2 Variable name for the second matrix (for error messages)
- * @param y2 Second matrix
- *
- * @throw <code>std::invalid_argument</code> if the
- * dimensions of the matrices do not match
+ * @param y2 Second matrix to test
+ * @throw <code>std::invalid_argument</code> if the dimensions of the matrices
+ *    do not match
  */
 template <bool check_compile, typename T1, typename T2, int R1, int C1, int R2,
           int C2>
@@ -82,6 +74,7 @@ inline void check_matching_dims(const char* function, const char* name1,
   }
   check_matching_dims(function, name1, y1, name2, y2);
 }
+
 }  // namespace math
 }  // namespace stan
 #endif

--- a/stan/math/prim/mat/err/check_ordered.hpp
+++ b/stan/math/prim/mat/err/check_ordered.hpp
@@ -29,10 +29,8 @@ namespace math {
 template <typename T_y>
 void check_ordered(const char* function, const char* name,
                    const Eigen::Matrix<T_y, Eigen::Dynamic, 1>& y) {
-  using Eigen::Dynamic;
-  using Eigen::Matrix;
 
-  typedef typename index_type<Matrix<T_y, Dynamic, 1> >::type size_t;
+  typedef typename index_type<Eigen::Matrix<T_y, Eigen::Dynamic, 1> >::type size_t;
 
   for (size_t n = 1; n < y.size(); n++) {
     if (!(y[n] > y[n - 1])) {

--- a/stan/math/prim/mat/err/check_ordered.hpp
+++ b/stan/math/prim/mat/err/check_ordered.hpp
@@ -29,8 +29,8 @@ namespace math {
 template <typename T_y>
 void check_ordered(const char* function, const char* name,
                    const Eigen::Matrix<T_y, Eigen::Dynamic, 1>& y) {
-
-  typedef typename index_type<Eigen::Matrix<T_y, Eigen::Dynamic, 1> >::type size_t;
+  typedef
+      typename index_type<Eigen::Matrix<T_y, Eigen::Dynamic, 1> >::type size_t;
 
   for (size_t n = 1; n < y.size(); n++) {
     if (!(y[n] > y[n - 1])) {

--- a/stan/math/prim/mat/err/check_pos_definite.hpp
+++ b/stan/math/prim/mat/err/check_pos_definite.hpp
@@ -17,9 +17,7 @@ namespace stan {
 namespace math {
 
 /**
- * Check if the specified square, symmetric
- * matrix is positive definite.
- *
+ * Check if the specified square, symmetric matrix is positive definite.
  * @tparam T_y Type of scalar of the matrix
  * @param function Function name (for error messages)
  * @param name Variable name (for error messages)
@@ -27,7 +25,7 @@ namespace math {
  * @throw <code>std::invalid_argument</code> if the matrix is not square
  * or if the matrix has 0 size.
  * @throw <code>std::domain_error</code> if the matrix is not symmetric,
- * if it is not positive definite, or if any element is <code>NaN</code>.
+ * if it is not positive definite, or if any element is <code>NaN</code>
  */
 template <typename T_y>
 inline void check_pos_definite(const char* function, const char* name,
@@ -45,16 +43,14 @@ inline void check_pos_definite(const char* function, const char* name,
 }
 
 /**
- * Check if the specified LDLT transform of a matrix
- * is positive definite.
- *
+ * Check if the specified LDLT transform of a matrix is positive definite.
  * @tparam Derived Derived type of the Eigen::LDLT transform.
  * @param function Function name (for error messages)
  * @param name Variable name (for error messages)
  * @param cholesky Eigen::LDLT to test, whose progenitor
  * must not have any NaN elements
  * @throw <code>std::domain_error</code> if the matrix is not
- * positive definite.
+ * positive definite
  */
 template <typename Derived>
 inline void check_pos_definite(const char* function, const char* name,
@@ -65,18 +61,15 @@ inline void check_pos_definite(const char* function, const char* name,
 }
 
 /**
- * Check if the specified LLT decomposition
- * transform resulted in <code>Eigen::Success</code>
- *
+ * Check if the specified LLT decomposition transform resulted in
+ * <code>Eigen::Success</code>
  * @tparam Derived Derived type of the Eigen::LLT transform.
- *
  * @param function Function name (for error messages)
  * @param name Variable name (for error messages)
  * @param cholesky Eigen::LLT to test, whose progenitor
  * must not have any NaN elements
- *
  * @throw <code>std::domain_error</code> if the diagonal of the
- * L matrix is not positive.
+ * L matrix is not positive
  */
 template <typename Derived>
 inline void check_pos_definite(const char* function, const char* name,

--- a/stan/math/prim/mat/err/check_simplex.hpp
+++ b/stan/math/prim/mat/err/check_simplex.hpp
@@ -38,10 +38,9 @@ namespace math {
 template <typename T_prob>
 void check_simplex(const char* function, const char* name,
                    const Eigen::Matrix<T_prob, Eigen::Dynamic, 1>& theta) {
-  using Eigen::Dynamic;
-  using Eigen::Matrix;
 
-  typedef typename index_type<Matrix<T_prob, Dynamic, 1> >::type size_t;
+  typedef typename 
+    index_type<Eigen::Matrix<T_prob, Eigen::Dynamic, 1> >::type size_t;
 
   check_nonzero_size(function, name, theta);
   if (!(fabs(1.0 - theta.sum()) <= CONSTRAINT_TOLERANCE)) {

--- a/stan/math/prim/mat/err/check_simplex.hpp
+++ b/stan/math/prim/mat/err/check_simplex.hpp
@@ -38,9 +38,8 @@ namespace math {
 template <typename T_prob>
 void check_simplex(const char* function, const char* name,
                    const Eigen::Matrix<T_prob, Eigen::Dynamic, 1>& theta) {
-
-  typedef typename 
-    index_type<Eigen::Matrix<T_prob, Eigen::Dynamic, 1> >::type size_t;
+  typedef typename index_type<Eigen::Matrix<T_prob, Eigen::Dynamic, 1> >::type
+      size_t;
 
   check_nonzero_size(function, name, theta);
   if (!(fabs(1.0 - theta.sum()) <= CONSTRAINT_TOLERANCE)) {

--- a/stan/math/prim/mat/err/check_square.hpp
+++ b/stan/math/prim/mat/err/check_square.hpp
@@ -10,17 +10,12 @@ namespace math {
 
 /**
  * Check if the specified matrix is square.
- *
  * This check allows 0x0 matrices.
- *
- * @tparam T Type of scalar.
- *
+ * @tparam T Type of scalar
  * @param function Function name (for error messages)
  * @param name Variable name (for error messages)
  * @param y Matrix to test
- *
- * @throw <code>std::invalid_argument</code> if the matrix
- *    is not square
+ * @throw <code>std::invalid_argument</code> if the matrix is not square
  */
 template <typename T_y>
 inline void check_square(

--- a/stan/math/prim/mat/err/check_symmetric.hpp
+++ b/stan/math/prim/mat/err/check_symmetric.hpp
@@ -32,8 +32,8 @@ inline void check_symmetric(
     const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>& y) {
   check_square(function, name, y);
 
-  typedef typename 
-    index_type<Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic> >::type size_type;
+  typedef typename index_type<
+      Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic> >::type size_type;
 
   size_type k = y.rows();
   if (k == 1)

--- a/stan/math/prim/mat/err/check_symmetric.hpp
+++ b/stan/math/prim/mat/err/check_symmetric.hpp
@@ -16,16 +16,12 @@ namespace math {
 
 /**
  * Check if the specified matrix is symmetric.
- *
  * The error message is either 0 or 1 indexed, specified by
  * <code>stan::error_index::value</code>.
- *
- * @tparam T_y Type of scalar.
- *
+ * @tparam T_y Type of scalar
  * @param function Function name (for error messages)
  * @param name Variable name (for error messages)
  * @param y Matrix to test
- *
  * @throw <code>std::invalid_argument</code> if the matrix is not square.
  * @throw <code>std::domain_error</code> if any element not on the
  *   main diagonal is <code>NaN</code>
@@ -36,11 +32,8 @@ inline void check_symmetric(
     const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>& y) {
   check_square(function, name, y);
 
-  using Eigen::Dynamic;
-  using Eigen::Matrix;
-  using std::fabs;
-
-  typedef typename index_type<Matrix<T_y, Dynamic, Dynamic> >::type size_type;
+  typedef typename 
+    index_type<Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic> >::type size_type;
 
   size_type k = y.rows();
   if (k == 1)

--- a/stan/math/prim/mat/err/check_unit_vector.hpp
+++ b/stan/math/prim/mat/err/check_unit_vector.hpp
@@ -12,23 +12,19 @@ namespace stan {
 namespace math {
 /**
  * Check if the specified vector is unit vector.
- *
  * A valid unit vector is one where the square of the elements
  * summed is equal to 1. This function tests that the sum is within the
- * tolerance specified by <code>CONSTRAINT_TOLERANCE</code>.  This
+ * tolerance specified by <code>CONSTRAINT_TOLERANCE</code>. This
  * function only accepts Eigen vectors, statically typed vectors,
  * not general matrices with 1 column.
- *
  * @tparam T_prob Scalar type of the vector
- *
  * @param function Function name (for error messages)
  * @param name Variable name (for error messages)
- * @param theta Vector to test.
- *
+ * @param theta Vector to test
  * @throw <code>std::invalid_argument</code> if <code>theta</code>
- *   is a 0-vector.
+ *   is a 0-vector
  * @throw <code>std::domain_error</code> if the vector is not a unit
- *   vector or if any element is <code>NaN</code>.
+ *   vector or if any element is <code>NaN</code>
  */
 template <typename T_prob>
 void check_unit_vector(const char* function, const char* name,

--- a/stan/math/prim/mat/err/is_cholesky_factor.hpp
+++ b/stan/math/prim/mat/err/is_cholesky_factor.hpp
@@ -1,0 +1,41 @@
+#ifndef STAN_MATH_PRIM_MAT_ERR_IS_CHOLESKY_FACTOR_HPP
+#define STAN_MATH_PRIM_MAT_ERR_IS_CHOLESKY_FACTOR_HPP
+
+#include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <stan/math/prim/scal/err/is_positive.hpp>
+#include <stan/math/prim/mat/err/is_lower_triangular.hpp>
+#include <stan/math/prim/scal/err/is_less_or_equal.hpp>
+
+namespace stan {
+namespace math {
+/**
+ * Return <code>true</code> if y is a valid Choleksy factor, if
+ * number of rows is not less than the number of columns, if there
+ * are no 0 columns, and no element in matrix is <code>NaN</code>.
+ * A Cholesky factor is a lower triangular matrix whose diagonal
+ * elements are all positive.  Note that Cholesky factors need not
+ * be square, but requires at least as many rows M as columns N
+ * (i.e., M &gt;= N).
+ * @tparam T_y Type of elements of Cholesky factor, requires class method
+ *   <code>.rows()</code> and <code>.cols()</code>
+ * @param y Matrix to test
+ * @return <code>true</code> if y is a valid Choleksy factor, if
+ *   number of rows is not less than the number of columns,
+ *   if there are no 0 columns, and no element in matrix is <code>NaN</code>
+ */
+template <typename T_y>
+inline bool is_cholesky_factor(
+    const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>& y) {
+  if (!is_less_or_equal(y.cols(), y.rows()) || !is_positive(y.cols())
+      || !is_lower_triangular(y))
+    return false;
+  for (int i = 0; i < y.cols(); ++i) {
+    if (!is_positive(y(i, i)))
+      return false;
+  }
+  return true;
+}
+
+}  // namespace math
+}  // namespace stan
+#endif

--- a/stan/math/prim/mat/err/is_cholesky_factor_corr.hpp
+++ b/stan/math/prim/mat/err/is_cholesky_factor_corr.hpp
@@ -1,0 +1,51 @@
+#ifndef STAN_MATH_PRIM_MAT_ERR_IS_CHOLESKY_FACTOR_CORR_HPP
+#define STAN_MATH_PRIM_MAT_ERR_IS_CHOLESKY_FACTOR_CORR_HPP
+
+#include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <stan/math/prim/scal/err/is_positive.hpp>
+#include <stan/math/prim/mat/err/is_lower_triangular.hpp>
+#include <stan/math/prim/mat/err/is_square.hpp>
+#include <stan/math/prim/mat/err/constraint_tolerance.hpp>
+#include <stan/math/prim/mat/err/is_unit_vector.hpp>
+
+namespace stan {
+namespace math {
+/**
+ * Return <code>true</code> if y is a valid Cholesky factor, if
+ * the number of rows is not less than the number of columns, if there
+ * are no zero columns, and no element in matrix is <code>NaN</code>.
+ * A Cholesky factor is a lower triangular matrix whose diagonal
+ * elements are all positive. This definition does not require a
+ * square matrix just that M &gt;= N, for M rows and N columns.
+ * Tolerance is specified by <code>math::CONSTRAINT_TOLERANCE</code>
+ * as 1E-8.
+ * @tparam T_y Type of elements of Cholesky factor, requires class method
+ *   <code>.rows()</code>
+ * @param y Matrix to test
+ * @return <code>true</code> if y is a valid Cholesky factor, if
+ *    the number of rows is not less than the number of columns,
+ *    if there are no 0 columns, and no element in matrix is <code>NaN</code>
+ */
+template <typename T_y>
+inline bool is_cholesky_factor_corr(
+    const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>& y) {
+  if (is_square(y)) {
+    if (is_lower_triangular(y)) {
+      for (int i = 0; i < y.rows(); ++i) {
+        if (!is_positive(y(i, i)))
+          return false;
+      }
+      for (int i = 0; i < y.rows(); ++i) {
+        Eigen::Matrix<T_y, Eigen::Dynamic, 1> y_i = y.row(i).transpose();
+        if (!is_unit_vector(y_i))
+          return false;
+      }
+      return true;
+    }
+  }
+  return false;
+}
+
+}  // namespace math
+}  // namespace stan
+#endif

--- a/stan/math/prim/mat/err/is_column_index.hpp
+++ b/stan/math/prim/mat/err/is_column_index.hpp
@@ -1,0 +1,29 @@
+#ifndef STAN_MATH_PRIM_MAT_ERR_IS_COLUMN_INDEX_HPP
+#define STAN_MATH_PRIM_MAT_ERR_IS_COLUMN_INDEX_HPP
+
+#include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <stan/math/prim/scal/meta/error_index.hpp>
+
+namespace stan {
+namespace math {
+
+/**
+ * Return <code>true</code> no index is invalid column.
+ * By default this is a 1-indexed check (as opposed to zero-indexed).
+ * Behavior can be changed by setting <code>stan::error_index::value</code>.
+ * @tparam T_y Type of scalar, requires class method <code>.cols()</code>
+ * @tparam R Number of rows of the matrix
+ * @tparam C Number of columns of the matrix
+ * @param y Matrix to test
+ * @param i Index to check
+ * @return <code>true</code> no index is invalid column
+ */
+template <typename T_y, int R, int C>
+inline bool is_column_index(const Eigen::Matrix<T_y, R, C>& y, size_t i) {
+  return i >= stan::error_index::value
+         && i < static_cast<size_t>(y.cols()) + stan::error_index::value;
+}
+
+}  // namespace math
+}  // namespace stan
+#endif

--- a/stan/math/prim/mat/err/is_corr_matrix.hpp
+++ b/stan/math/prim/mat/err/is_corr_matrix.hpp
@@ -1,0 +1,51 @@
+#ifndef STAN_MATH_PRIM_MAT_ERR_IS_CORR_MATRIX_HPP
+#define STAN_MATH_PRIM_MAT_ERR_IS_CORR_MATRIX_HPP
+
+#include <stan/math/prim/scal/err/is_positive_size.hpp>
+#include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <stan/math/prim/mat/meta/index_type.hpp>
+#include <stan/math/prim/scal/meta/error_index.hpp>
+#include <stan/math/prim/mat/err/is_pos_definite.hpp>
+#include <stan/math/prim/mat/err/is_symmetric.hpp>
+#include <stan/math/prim/scal/err/is_size_match.hpp>
+#include <stan/math/prim/mat/err/constraint_tolerance.hpp>
+
+namespace stan {
+namespace math {
+
+/**
+ * Return <code>true</code> if the matrix is square and not 0x0,
+ * if the matrix is symmetric, diagonals are near 1, positive definite,
+ * and no elements are <code>NaN</code>
+ * A valid correlation matrix is symmetric, has a unit diagonal
+ * (all 1 values), and has all values between -1 and 1 (inclusive).
+ * @tparam T_y Type of scalar, requires class method <code>.rows()</code>
+ *   and <code>.cols()</code>
+ * @param y Matrix to test
+ * @return <code>true</code> if the matrix is square and not 0x0,
+ *   if the matrix is symmetric, diagonals are near 1, positive definite,
+ *   and no elements are <code>NaN</code>
+ */
+template <typename T_y>
+inline bool is_corr_matrix(
+    const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>& y) {
+
+  typedef typename 
+    index_type<Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic> >::type size_t;
+
+  if (is_size_match(y.rows(), y.cols())) {
+    if (is_positive_size(y.rows())) {
+      if (is_symmetric(y)) {
+        for (size_t k = 0; k < y.rows(); ++k) {
+          if (!(fabs(y(k, k) - 1.0) <= CONSTRAINT_TOLERANCE))
+            return false;
+        }
+      }
+    }
+  }
+  return is_pos_definite(y);
+}
+
+}  // namespace math
+}  // namespace stan
+#endif

--- a/stan/math/prim/mat/err/is_corr_matrix.hpp
+++ b/stan/math/prim/mat/err/is_corr_matrix.hpp
@@ -29,9 +29,8 @@ namespace math {
 template <typename T_y>
 inline bool is_corr_matrix(
     const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>& y) {
-
-  typedef typename 
-    index_type<Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic> >::type size_t;
+  typedef typename index_type<
+      Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic> >::type size_t;
 
   if (is_size_match(y.rows(), y.cols())) {
     if (is_positive_size(y.rows())) {

--- a/stan/math/prim/mat/err/is_cov_matrix.hpp
+++ b/stan/math/prim/mat/err/is_cov_matrix.hpp
@@ -1,0 +1,29 @@
+#ifndef STAN_MATH_PRIM_MAT_ERR_IS_COV_MATRIX_HPP
+#define STAN_MATH_PRIM_MAT_ERR_IS_COV_MATRIX_HPP
+
+#include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <stan/math/prim/mat/err/is_pos_definite.hpp>
+
+namespace stan {
+namespace math {
+/**
+ * Return <code>true</code> if the matrix is square or if the matrix
+ * is 0x0, if the matrix is symmetric, if the matrix is positive
+ * definite, or if no element of the matrix is <code>NaN</code>.
+ * A valid covariance matrix is a square, symmetric matrix that is
+ * positive definite.
+ * @tparam T_y Type of scalar
+ * @param y Matrix to test
+ * @return <code>true</code> if the matrix is square or if the matrix
+ *   is 0x0, if the matrix is symmetric, if the matrix is positive
+ *   definite, or if no element of the matrix is <code>NaN</code>
+ */
+template <typename T_y>
+inline bool is_cov_matrix(
+    const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>& y) {
+  return is_pos_definite(y);
+}
+
+}  // namespace math
+}  // namespace stan
+#endif

--- a/stan/math/prim/mat/err/is_ldlt_factor.hpp
+++ b/stan/math/prim/mat/err/is_ldlt_factor.hpp
@@ -1,0 +1,30 @@
+#ifndef STAN_MATH_PRIM_MAT_ERR_IS_LDLT_FACTOR_HPP
+#define STAN_MATH_PRIM_MAT_ERR_IS_LDLT_FACTOR_HPP
+
+#include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <stan/math/prim/mat/fun/LDLT_factor.hpp>
+
+namespace stan {
+namespace math {
+
+/**
+ * Return <code>true</code> if the specified LDLT factor is invalid.
+ * An <code>LDLT_factor</code> is invalid if it was constructed from
+ * a matrix that is not positive definite.  The check is that the
+ * <code>.success()</code> method returns <code>true</code>.
+ * @tparam T Type of scalar
+ * @tparam R Rows of the matrix
+ * @tparam C Columns of the matrix
+ * @param A The LDLT factor to check for validity
+ * @return <code>true</code> if the LDLT factor is valid
+ */
+template <typename T, int R, int C>
+inline bool is_ldlt_factor(LDLT_factor<T, R, C>& A) {
+  if (!A.success())
+    return false;
+  return true;
+}
+
+}  // namespace math
+}  // namespace stan
+#endif

--- a/stan/math/prim/mat/err/is_lower_triangular.hpp
+++ b/stan/math/prim/mat/err/is_lower_triangular.hpp
@@ -1,0 +1,33 @@
+#ifndef STAN_MATH_PRIM_MAT_ERR_IS_LOWER_TRIANGULAR_HPP
+#define STAN_MATH_PRIM_MAT_ERR_IS_LOWER_TRIANGULAR_HPP
+
+#include <stan/math/prim/mat/fun/Eigen.hpp>
+
+namespace stan {
+namespace math {
+
+/**
+ * Return <code>true</code> is matrix is lower triangular.
+ * A matrix x is not lower triangular if there is a non-zero entry
+ * x[m, n] with m &lt; n. This function only inspect the upper and
+ * triangular portion of the matrix, not including the diagonal.
+ * @tparam T Type of scalar of the matrix, requires class method
+ *   <code>.rows()</code> and <code>.cols()</code>
+ * @param y Matrix to test
+ * @return <code>true</code> is matrix is lower triangular
+ */
+template <typename T_y>
+inline bool is_lower_triangular(
+    const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>& y) {
+  for (int n = 1; n < y.cols(); ++n) {
+    for (int m = 0; m < n && m < y.rows(); ++m) {
+      if (y(m, n) != 0)
+        return false;
+    }
+  }
+  return true;
+}
+
+}  // namespace math
+}  // namespace stan
+#endif

--- a/stan/math/prim/mat/err/is_mat_finite.hpp
+++ b/stan/math/prim/mat/err/is_mat_finite.hpp
@@ -1,0 +1,33 @@
+#ifndef STAN_MATH_PRIM_MAT_ERR_IS_MAT_FINITE_HPP
+#define STAN_MATH_PRIM_MAT_ERR_IS_MAT_FINITE_HPP
+
+#include <stan/math/prim/mat/fun/value_of.hpp>
+#include <Eigen/Dense>
+#include <boost/math/special_functions/fpclassify.hpp>
+
+namespace stan {
+namespace math {
+
+/**
+ * Return <code>true</code> is the specified matrix is finite.
+ * @tparam T Scalar type of the matrix, requires class method
+ *   <code>.size()</code>
+ * @tparam R Compile time rows of the matrix
+ * @tparam C Compile time columns of the matrix
+ * @param y Matrix to test
+ * @return <code>true</code> if the matrix is finite
+ **/
+template <typename T, int R, int C>
+inline bool is_mat_finite(const Eigen::Matrix<T, R, C>& y) {
+  if (!value_of(y).allFinite()) {
+    for (int n = 0; n < y.size(); ++n) {
+      if (!(boost::math::isfinite)(y(n)))
+        return false;
+    }
+  }
+  return true;
+}
+
+}  // namespace math
+}  // namespace stan
+#endif

--- a/stan/math/prim/mat/err/is_matching_dims.hpp
+++ b/stan/math/prim/mat/err/is_matching_dims.hpp
@@ -1,0 +1,59 @@
+#ifndef STAN_MATH_PRIM_MAT_ERR_IS_MATCHING_DIMS_HPP
+#define STAN_MATH_PRIM_MAT_ERR_IS_MATCHING_DIMS_HPP
+
+#include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <stan/math/prim/scal/err/is_size_match.hpp>
+
+namespace stan {
+namespace math {
+
+/**
+ * Return <code>true</code> if the two matrices are of the same size.
+ * This function checks the runtime sizes only.
+ * @tparam T1 Scalar type of the first matrix, requires class method
+ *   <code>.size()</code>
+ * @tparam T2 Scalar type of the second matrix, requires class method
+ *   <code>.size()</code>
+ * @tparam R1 Rows specified at compile time of the first matrix
+ * @tparam C1 Columns specified at compile time of the first matrix
+ * @tparam R2 Rows specified at compile time of the second matrix
+ * @tparam C2 Columns specified at compile time of the second matrix
+ * @param y1 First matrix to test
+ * @param y2 Second matrix to test
+ * @return <code>true</code> if the dimensions of the matrices match
+ */
+template <typename T1, typename T2, int R1, int C1, int R2, int C2>
+inline bool is_matching_dims(const Eigen::Matrix<T1, R1, C1>& y1,
+                             const Eigen::Matrix<T2, R2, C2>& y2) {
+  return is_size_match(y1.rows(), y2.rows())
+         && is_size_match(y1.cols(), y2.cols());
+}
+
+/**
+ * Return <code>true</code> if the two matrices are of the same size.
+ * This function checks the runtime sizes and can also check the static
+ * sizes as well. For example, a 4x1 matrix is not the same as a vector
+ * with 4 elements.
+ * @tparam check_compile Whether to check the static sizes
+ * @tparam T1 Scalar type of the first matrix
+ * @tparam T2 Scalar type of the second matrix
+ * @tparam R1 Rows specified at compile time of the first matrix
+ * @tparam C1 Columns specified at compile time of the first matrix
+ * @tparam R2 Rows specified at compile time of the second matrix
+ * @tparam C2 Columns specified at compile time of the second matrix
+ * @param y1 First matrix to test
+ * @param y2 Second matrix to test
+ * @return <code>true</code> if the dimensions of the matrices match
+ */
+template <bool check_compile, typename T1, typename T2, int R1, int C1, int R2,
+          int C2>
+inline bool is_matching_dims(const Eigen::Matrix<T1, R1, C1>& y1,
+                             const Eigen::Matrix<T2, R2, C2>& y2) {
+  if (check_compile && (R1 != R2 || C1 != C2))
+    return false;
+  return is_matching_dims(y1, y2);
+}
+
+}  // namespace math
+}  // namespace stan
+#endif

--- a/stan/math/prim/mat/err/is_pos_definite.hpp
+++ b/stan/math/prim/mat/err/is_pos_definite.hpp
@@ -1,0 +1,77 @@
+#ifndef STAN_MATH_PRIM_MAT_ERR_IS_POS_DEFINITE_HPP
+#define STAN_MATH_PRIM_MAT_ERR_IS_POS_DEFINITE_HPP
+
+#include <stan/math/prim/mat/meta/get.hpp>
+#include <stan/math/prim/mat/meta/length.hpp>
+#include <stan/math/prim/mat/meta/is_vector.hpp>
+#include <stan/math/prim/mat/meta/is_vector_like.hpp>
+#include <stan/math/prim/scal/err/is_positive_size.hpp>
+#include <stan/math/prim/scal/err/is_not_nan.hpp>
+#include <stan/math/prim/mat/err/is_symmetric.hpp>
+#include <stan/math/prim/mat/err/constraint_tolerance.hpp>
+#include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <stan/math/prim/mat/fun/value_of_rec.hpp>
+
+namespace stan {
+namespace math {
+
+/**
+ * Return <code>true</code> if the matrix is square or if the matrix has
+ * non-zero size, or if the matrix is symmetric, or if it is positive
+ * definite, or if no element is <code>NaN</code>.
+ * @tparam T_y Type of scalar of the matrix, requires class method
+ *   <code>.rows()</code>
+ * @param y Matrix to test
+ * @return <code>true</code> if the matrix is square or if the matrix has non-0
+ *   size, or if the matrix is symmetric, or if it is positive definite, or if
+ *   no element is <code>NaN</code>
+ */
+template <typename T_y>
+inline bool is_pos_definite(const Eigen::Matrix<T_y, -1, -1>& y) {
+  if (is_symmetric(y)) {
+    if (is_positive_size(y.rows())) {
+      if (y.rows() == 1 && !(y(0, 0) > CONSTRAINT_TOLERANCE))
+        return false;
+      Eigen::LDLT<Eigen::MatrixXd> cholesky = value_of_rec(y).ldlt();
+      if (cholesky.info() != Eigen::Success || !cholesky.isPositive()
+          || (cholesky.vectorD().array() <= 0.0).any())
+        return false;
+      return is_not_nan(y);
+    }
+  }
+  return false;
+}
+
+/**
+ * Return <code>true</code> if the matrix is positive definite.
+ * @tparam Derived Derived type of the Eigen::LDLT transform, requires
+ *   class method <code>.info()</code> and <code>.isPositive()</code>
+ *   and <code>.vectorD().array()</code>
+ * @param cholesky Eigen::LDLT to test, whose progenitor
+ * must not have any NaN elements
+ * @return <code>true</code> if the matrix is positive definite
+ */
+template <typename Derived>
+inline bool is_pos_definite(const Eigen::LDLT<Derived>& cholesky) {
+  return !(cholesky.info() != Eigen::Success || !cholesky.isPositive()
+           || !(cholesky.vectorD().array() > 0.0).all());
+}
+
+/**
+ * Return <code>true</code> if diagonal of the L matrix is positive.
+ * @tparam Derived Derived type of the Eigen::LLT transform, requires
+ *   class method <code>.info()</code> and
+ * <code>.matrixLLT().diagonal().array()</code>
+ * @param cholesky Eigen::LLT to test, whose progenitor
+ * must not have any NaN elements
+ * @return <code>true</code> if diagonal of the L matrix is positive
+ */
+template <typename Derived>
+inline bool is_pos_definite(const Eigen::LLT<Derived>& cholesky) {
+  return !(cholesky.info() != Eigen::Success
+           || !(cholesky.matrixLLT().diagonal().array() > 0.0).all());
+}
+
+}  // namespace math
+}  // namespace stan
+#endif

--- a/stan/math/prim/mat/err/is_square.hpp
+++ b/stan/math/prim/mat/err/is_square.hpp
@@ -1,0 +1,26 @@
+#ifndef STAN_MATH_PRIM_MAT_ERR_IS_SQUARE_HPP
+#define STAN_MATH_PRIM_MAT_ERR_IS_SQUARE_HPP
+
+#include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <stan/math/prim/scal/err/is_size_match.hpp>
+
+namespace stan {
+namespace math {
+
+/**
+ * Return <code>true</code> if the matrix is square. This check allows 0x0
+ * matrices.
+ * @tparam T Type of scalar, requires class method <code>.rows()</code>
+ *    and <code>.cols()</code>
+ * @param y Matrix to test
+ * @return <code>true</code> if matrix is square
+ */
+template <typename T_y>
+inline bool is_square(
+    const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>& y) {
+  return is_size_match(y.rows(), y.cols());
+}
+
+}  // namespace math
+}  // namespace stan
+#endif

--- a/stan/math/prim/mat/err/is_symmetric.hpp
+++ b/stan/math/prim/mat/err/is_symmetric.hpp
@@ -22,9 +22,8 @@ template <typename T_y>
 inline bool is_symmetric(
     const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>& y) {
   if (is_square(y)) {
-
-    typedef typename 
-      index_type<Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>>::type size_type;
+    typedef typename index_type<
+        Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>>::type size_type;
 
     size_type k = y.rows();
     if (k == 1)

--- a/stan/math/prim/mat/err/is_symmetric.hpp
+++ b/stan/math/prim/mat/err/is_symmetric.hpp
@@ -30,8 +30,7 @@ inline bool is_symmetric(
       return true;
     for (size_type m = 0; m < k; ++m) {
       for (size_type n = m + 1; n < k; ++n) {
-        if (!fabs(value_of(y(m, n)) - value_of(y(n, m)))
-            <= CONSTRAINT_TOLERANCE)
+        if (!(fabs(value_of(y(m, n)) - value_of(y(n, m))) <= CONSTRAINT_TOLERANCE))
           return false;
       }
     }

--- a/stan/math/prim/mat/err/is_symmetric.hpp
+++ b/stan/math/prim/mat/err/is_symmetric.hpp
@@ -1,0 +1,46 @@
+#ifndef STAN_MATH_PRIM_MAT_ERR_IS_SYMMETRIC_HPP
+#define STAN_MATH_PRIM_MAT_ERR_IS_SYMMETRIC_HPP
+
+#include <stan/math/prim/mat/err/constraint_tolerance.hpp>
+#include <stan/math/prim/mat/err/is_square.hpp>
+#include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <stan/math/prim/mat/meta/index_type.hpp>
+#include <stan/math/prim/mat/fun/value_of.hpp>
+
+namespace stan {
+namespace math {
+
+/**
+ * Return <code>true</code> if the matrix is square, and no element
+ * not on the main diagonal is <code>NaN</code>.
+ * @tparam T_y Type of scalar, requires class method <code>.rows()</code>
+ * @param y Matrix to test
+ * @return <code>true</code> if the matrix is square, and no
+ *    element not on the main diagonal is <code>NaN</code>
+ */
+template <typename T_y>
+inline bool is_symmetric(
+    const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>& y) {
+  if (is_square(y)) {
+
+    typedef typename 
+      index_type<Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>>::type size_type;
+
+    size_type k = y.rows();
+    if (k == 1)
+      return true;
+    for (size_type m = 0; m < k; ++m) {
+      for (size_type n = m + 1; n < k; ++n) {
+        if (!fabs(value_of(y(m, n)) - value_of(y(n, m)))
+            <= CONSTRAINT_TOLERANCE)
+          return false;
+      }
+    }
+    return true;
+  }
+  return false;
+}
+
+}  // namespace math
+}  // namespace stan
+#endif

--- a/stan/math/prim/mat/err/is_unit_vector.hpp
+++ b/stan/math/prim/mat/err/is_unit_vector.hpp
@@ -1,0 +1,38 @@
+#ifndef STAN_MATH_PRIM_MAT_ERR_IS_UNIT_VECTOR_HPP
+#define STAN_MATH_PRIM_MAT_ERR_IS_UNIT_VECTOR_HPP
+
+#include <stan/math/prim/arr/err/is_nonzero_size.hpp>
+#include <stan/math/prim/mat/err/constraint_tolerance.hpp>
+#include <stan/math/prim/mat/fun/Eigen.hpp>
+
+namespace stan {
+namespace math {
+
+/**
+ * Return <code>true</code> if the vector is not a unit vector or if any
+ * element is <code>NaN</code>.
+ * A valid unit vector is one where the square elements
+ * summed is equal to 1. This function tests that the sum
+ * is within the tolerance specified by <code>CONSTRAINT_TOLERANCE</code>.
+ * This function only accpets <code>Eigen::Matrix</code> vectors, statically
+ * typed vectors, not general matrices with 1 column.
+ * @tparam T_prob Scalar type of the vector, reqires class method
+ *   <code>.squaredNorm()</code>
+ * @param theta Eigen vector to test
+ * @return <code>true</code> if the vector is not a unit
+ *   vector or if any element is <code>NaN</code>
+ */
+
+template <typename T_prob>
+inline bool is_unit_vector(
+    const Eigen::Matrix<T_prob, Eigen::Dynamic, 1>& theta) {
+  if (is_nonzero_size(theta)) {
+    T_prob seq = theta.squaredNorm();
+    return fabs(1.0 - seq) <= CONSTRAINT_TOLERANCE;
+  }
+  return false;
+}
+
+}  // namespace math
+}  // namespace stan
+#endif

--- a/stan/math/prim/mat/fun/sort_indices.hpp
+++ b/stan/math/prim/mat/fun/sort_indices.hpp
@@ -10,7 +10,7 @@
 namespace stan {
 namespace math {
 
-/**
+/*
  * A comparator that works for any container type that has the
  * brackets operator.
  *

--- a/stan/math/prim/mat/prob/multi_normal_cholesky_lpdf.hpp
+++ b/stan/math/prim/mat/prob/multi_normal_cholesky_lpdf.hpp
@@ -15,6 +15,7 @@
 #include <stan/math/prim/scal/fun/constants.hpp>
 #include <stan/math/prim/scal/meta/max_size_mvt.hpp>
 #include <stan/math/prim/scal/meta/include_summand.hpp>
+#include <stan/math/prim/scal/meta/likely.hpp>
 #include <stan/math/prim/scal/meta/return_type.hpp>
 #include <boost/random/normal_distribution.hpp>
 #include <boost/random/variate_generator.hpp>

--- a/stan/math/prim/scal.hpp
+++ b/stan/math/prim/scal.hpp
@@ -58,6 +58,11 @@
 #include <stan/math/prim/scal/err/domain_error_vec.hpp>
 #include <stan/math/prim/scal/err/invalid_argument.hpp>
 #include <stan/math/prim/scal/err/invalid_argument_vec.hpp>
+#include <stan/math/prim/scal/err/is_less_or_equal.hpp>
+#include <stan/math/prim/scal/err/is_not_nan.hpp>
+#include <stan/math/prim/scal/err/is_positive_size.hpp>
+#include <stan/math/prim/scal/err/is_positive.hpp>
+#include <stan/math/prim/scal/err/is_scal_finite.hpp>
 #include <stan/math/prim/scal/err/is_size_match.hpp>
 #include <stan/math/prim/scal/err/out_of_range.hpp>
 

--- a/stan/math/prim/scal/err/check_2F1_converges.hpp
+++ b/stan/math/prim/scal/err/check_2F1_converges.hpp
@@ -16,19 +16,16 @@ namespace math {
  * Check if the hypergeometric function (2F1) called with
  * supplied arguments will converge, assuming arguments are
  * finite values.
- *
  * @tparam T_a1 Type of a1
  * @tparam T_a2 Type of a2
  * @tparam T_b1 Type of b1
  * @tparam T_z Type of z
- *
  * @param function Name of function ultimately relying on 2F1 (for error
  *   messages)
  * @param a1 Variable to check
  * @param a2 Variable to check
  * @param b1 Variable to check
  * @param z Variable to check
- *
  * @throw <code>domain_error</code> if 2F1(a1, a2, b1, z)
  *   does not meet convergence conditions, or if any coefficient is NaN.
  */
@@ -37,7 +34,7 @@ inline void check_2F1_converges(const char* function, const T_a1& a1,
                                 const T_a2& a2, const T_b1& b1, const T_z& z) {
   using std::fabs;
   using std::floor;
-
+  
   check_not_nan("check_3F2_converges", "a1", a1);
   check_not_nan("check_3F2_converges", "a2", a2);
   check_not_nan("check_3F2_converges", "b1", b1);

--- a/stan/math/prim/scal/err/check_2F1_converges.hpp
+++ b/stan/math/prim/scal/err/check_2F1_converges.hpp
@@ -34,7 +34,7 @@ inline void check_2F1_converges(const char* function, const T_a1& a1,
                                 const T_a2& a2, const T_b1& b1, const T_z& z) {
   using std::fabs;
   using std::floor;
-  
+
   check_not_nan("check_3F2_converges", "a1", a1);
   check_not_nan("check_3F2_converges", "a2", a2);
   check_not_nan("check_3F2_converges", "b1", b1);

--- a/stan/math/prim/scal/err/check_3F2_converges.hpp
+++ b/stan/math/prim/scal/err/check_3F2_converges.hpp
@@ -16,14 +16,12 @@ namespace math {
  * Check if the hypergeometric function (3F2) called with
  * supplied arguments will converge, assuming arguments are
  * finite values.
- *
  * @tparam T_a1 Type of a1
  * @tparam T_a2 Type of a2
  * @tparam T_a3 Type of a3
  * @tparam T_b1 Type of b1
  * @tparam T_b2 Type of b2
  * @tparam T_z Type of z
- *
  * @param function Name of function ultimately relying on 3F2 (for error
  &   messages)
  * @param a1 Variable to check
@@ -32,7 +30,6 @@ namespace math {
  * @param b1 Variable to check
  * @param b2 Variable to check
  * @param z Variable to check
- *
  * @throw <code>domain_error</code> if 3F2(a1, a2, a3, b1, b2, z)
  *   does not meet convergence conditions, or if any coefficient is NaN.
  */
@@ -43,7 +40,7 @@ inline void check_3F2_converges(const char* function, const T_a1& a1,
                                 const T_b2& b2, const T_z& z) {
   using std::fabs;
   using std::floor;
-
+  
   check_not_nan("check_3F2_converges", "a1", a1);
   check_not_nan("check_3F2_converges", "a2", a2);
   check_not_nan("check_3F2_converges", "a3", a3);

--- a/stan/math/prim/scal/err/check_3F2_converges.hpp
+++ b/stan/math/prim/scal/err/check_3F2_converges.hpp
@@ -40,7 +40,7 @@ inline void check_3F2_converges(const char* function, const T_a1& a1,
                                 const T_b2& b2, const T_z& z) {
   using std::fabs;
   using std::floor;
-  
+
   check_not_nan("check_3F2_converges", "a1", a1);
   check_not_nan("check_3F2_converges", "a2", a2);
   check_not_nan("check_3F2_converges", "a3", a3);

--- a/stan/math/prim/scal/err/check_bounded.hpp
+++ b/stan/math/prim/scal/err/check_bounded.hpp
@@ -10,25 +10,21 @@
 
 namespace stan {
 namespace math {
-
+    
 namespace internal {
 
 // implemented using structs because there is no partial specialization
 // for templated functions
-//
 // default implementation works for scalar T_y. T_low and T_high can
 // be either scalar or vector
-//
 // throws if y, low, or high is nan
 template <typename T_y, typename T_low, typename T_high, bool y_is_vec>
 struct bounded {
   static void check(const char* function, const char* name, const T_y& y,
                     const T_low& low, const T_high& high) {
-    using stan::max_size;
-
     scalar_seq_view<T_low> low_vec(low);
     scalar_seq_view<T_high> high_vec(high);
-    for (size_t n = 0; n < max_size(low, high); n++) {
+    for (size_t n = 0; n < stan::max_size(low, high); n++) {
       if (!(low_vec[n] <= y && y <= high_vec[n])) {
         std::stringstream msg;
         msg << ", but must be in the interval ";
@@ -44,13 +40,10 @@ template <typename T_y, typename T_low, typename T_high>
 struct bounded<T_y, T_low, T_high, true> {
   static void check(const char* function, const char* name, const T_y& y,
                     const T_low& low, const T_high& high) {
-    using stan::get;
-    using stan::length;
-
     scalar_seq_view<T_low> low_vec(low);
     scalar_seq_view<T_high> high_vec(high);
-    for (size_t n = 0; n < length(y); n++) {
-      if (!(low_vec[n] <= get(y, n) && get(y, n) <= high_vec[n])) {
+    for (size_t n = 0; n < stan::length(y); n++) {
+      if (!(low_vec[n] <= stan::get(y, n) && stan::get(y, n) <= high_vec[n])) {
         std::stringstream msg;
         msg << ", but must be in the interval ";
         msg << "[" << low_vec[n] << ", " << high_vec[n] << "]";
@@ -63,19 +56,15 @@ struct bounded<T_y, T_low, T_high, true> {
 }  // namespace internal
 
 /**
- * Check if the value is between the low and high
- * values, inclusively.
- *
+ * Check if the value is between the low and high values, inclusively.
  * @tparam T_y Type of value
  * @tparam T_low Type of low value
  * @tparam T_high Type of high value
- *
  * @param function Function name (for error messages)
  * @param name Variable name (for error messages)
  * @param y Value to check
  * @param low Low bound
  * @param high High bound
- *
  * @throw <code>std::domain_error</code> otherwise. This also throws
  *   if any of the arguments are NaN.
  */

--- a/stan/math/prim/scal/err/check_bounded.hpp
+++ b/stan/math/prim/scal/err/check_bounded.hpp
@@ -10,7 +10,7 @@
 
 namespace stan {
 namespace math {
-    
+
 namespace internal {
 
 // implemented using structs because there is no partial specialization

--- a/stan/math/prim/scal/err/check_consistent_size.hpp
+++ b/stan/math/prim/scal/err/check_consistent_size.hpp
@@ -10,25 +10,20 @@ namespace stan {
 namespace math {
 
 /**
- * Check if the dimension of x is consistent, which
- * is defined to be <code>expected_size</code> if x is a vector or 1 if x
- * is not a vector.
- *
+ * Check if the dimension of x is consistent, which is defined to be 
+ * <code>expected_size</code> if x is a vector or 1 if x is not a vector.
  * @tparam T Type of value
- *
  * @param function Function name (for error messages)
  * @param name Variable name (for error messages)
  * @param x Variable to check for consistent size
  * @param expected_size Expected size if x is a vector
- *
  * @throw <code>invalid_argument</code> if the size is inconsistent
  */
 template <typename T>
 inline void check_consistent_size(const char* function, const char* name,
                                   const T& x, size_t expected_size) {
-  if (!is_vector<T>::value)
-    return;
-  if (is_vector<T>::value && expected_size == stan::size_of(x))
+  if (!is_vector<T>::value
+      || is_vector<T>::value && expected_size == stan::size_of(x))
     return;
 
   std::stringstream msg;

--- a/stan/math/prim/scal/err/check_consistent_size.hpp
+++ b/stan/math/prim/scal/err/check_consistent_size.hpp
@@ -10,7 +10,7 @@ namespace stan {
 namespace math {
 
 /**
- * Check if the dimension of x is consistent, which is defined to be 
+ * Check if the dimension of x is consistent, which is defined to be
  * <code>expected_size</code> if x is a vector or 1 if x is not a vector.
  * @tparam T Type of value
  * @param function Function name (for error messages)

--- a/stan/math/prim/scal/err/check_consistent_size.hpp
+++ b/stan/math/prim/scal/err/check_consistent_size.hpp
@@ -23,7 +23,7 @@ template <typename T>
 inline void check_consistent_size(const char* function, const char* name,
                                   const T& x, size_t expected_size) {
   if (!is_vector<T>::value
-      || is_vector<T>::value && expected_size == stan::size_of(x))
+      || (is_vector<T>::value && expected_size == stan::size_of(x)))
     return;
 
   std::stringstream msg;

--- a/stan/math/prim/scal/err/check_consistent_sizes.hpp
+++ b/stan/math/prim/scal/err/check_consistent_sizes.hpp
@@ -8,21 +8,16 @@ namespace stan {
 namespace math {
 
 /**
- * Check if the dimension of x1 is consistent
- * with x2.
- *
+ * Check if the dimension of x1 is consistent with x2.
  * Consistent size is defined as having the same size if vector-like or
  * being a scalar.
- *
  * @tparam T1 Type of x1
  * @tparam T2 Type of x2
- *
  * @param function Function name (for error messages)
  * @param name1 Variable name (for error messages)
  * @param x1 Variable to check for consistent size
  * @param name2 Variable name (for error messages)
  * @param x2 Variable to check for consistent size
- *
  * @throw <code>invalid_argument</code> if sizes are inconsistent
  */
 template <typename T1, typename T2>
@@ -36,16 +31,12 @@ inline void check_consistent_sizes(const char* function, const char* name1,
 }
 
 /**
- * Check if the dimension of x1, x2, and x3 are
- * consistent.
- *
+ * Check if the dimension of x1, x2, and x3 areconsistent.
  * Consistent size is defined as having the same size if vector-like or
  * being a scalar.
- *
  * @tparam T1 Type of x1
  * @tparam T2 Type of x2
  * @tparam T3 Type of x3
- *
  * @param function Function name (for error messages)
  * @param name1 Variable name (for error messages)
  * @param x1 Variable to check for consistent size
@@ -53,7 +44,6 @@ inline void check_consistent_sizes(const char* function, const char* name1,
  * @param x2 Variable to check for consistent size
  * @param name3 Variable name (for error messages)
  * @param x3 Variable to check for consistent size
- *
  * @throw <code>invalid_argument</code> if sizes are inconsistent
  */
 template <typename T1, typename T2, typename T3>
@@ -70,17 +60,13 @@ inline void check_consistent_sizes(const char* function, const char* name1,
 }
 
 /**
- * Check if the dimension of x1, x2, x3, and x4
- * are consistent.
- *
+ * Check if the dimension of x1, x2, x3, and x4are consistent.
  * Consistent size is defined as having the same size if
  * vector-like or being a scalar.
- *
  * @tparam T1 Type of x1
  * @tparam T2 Type of x2
  * @tparam T3 Type of x3
  * @tparam T4 Type of x4
- *
  * @param function Function name (for error messages)
  * @param name1 Variable name (for error messages)
  * @param x1 Variable to check for consistent size
@@ -90,7 +76,6 @@ inline void check_consistent_sizes(const char* function, const char* name1,
  * @param x3 Variable to check for consistent size
  * @param name4 Variable name (for error messages)
  * @param x4 Variable to check for consistent size
- *
  * @throw <code>invalid_argument</code> if sizes are inconsistent
  */
 template <typename T1, typename T2, typename T3, typename T4>

--- a/stan/math/prim/scal/err/check_finite.hpp
+++ b/stan/math/prim/scal/err/check_finite.hpp
@@ -15,7 +15,7 @@ namespace internal {
 template <typename T_y, bool is_vec>
 struct finite {
   static void check(const char* function, const char* name, const T_y& y) {
-    if (!(boost::math::isfinite)(value_of_rec(y)))
+    if (!(boost::math::isfinite(value_of_rec(y))))
       domain_error(function, name, y, "is ", ", but must be finite!");
   }
 };
@@ -23,9 +23,8 @@ struct finite {
 template <typename T_y>
 struct finite<T_y, true> {
   static void check(const char* function, const char* name, const T_y& y) {
-    using stan::length;
-    for (size_t n = 0; n < length(y); n++) {
-      if (!(boost::math::isfinite)(value_of_rec(stan::get(y, n))))
+    for (size_t n = 0; n < stan::length(y); n++) {
+      if (!(boost::math::isfinite(value_of_rec(stan::get(y, n)))))
         domain_error_vec(function, name, y, n, "is ", ", but must be finite!");
     }
   }
@@ -34,18 +33,13 @@ struct finite<T_y, true> {
 
 /**
  * Check if <code>y</code> is finite.
- *
  * This function is vectorized and will check each element of
  * <code>y</code>.
- *
  * @tparam T_y Type of y
- *
  * @param function Function name (for error messages)
  * @param name Variable name (for error messages)
  * @param y Variable to check
- *
- * @throw <code>domain_error</code> if y is infinity, -infinity, or
- *   NaN.
+ * @throw <code>domain_error</code> if y is infinity, -infinity, or NaN
  */
 template <typename T_y>
 inline void check_finite(const char* function, const char* name, const T_y& y) {

--- a/stan/math/prim/scal/err/check_greater.hpp
+++ b/stan/math/prim/scal/err/check_greater.hpp
@@ -17,9 +17,8 @@ template <typename T_y, typename T_low, bool is_vec>
 struct greater {
   static void check(const char* function, const char* name, const T_y& y,
                     const T_low& low) {
-    using stan::length;
     scalar_seq_view<T_low> low_vec(low);
-    for (size_t n = 0; n < length(low); n++) {
+    for (size_t n = 0; n < stan::length(low); n++) {
       if (!(y > low_vec[n])) {
         std::stringstream msg;
         msg << ", but must be greater than ";
@@ -35,9 +34,8 @@ template <typename T_y, typename T_low>
 struct greater<T_y, T_low, true> {
   static void check(const char* function, const char* name, const T_y& y,
                     const T_low& low) {
-    using stan::length;
     scalar_seq_view<T_low> low_vec(low);
-    for (size_t n = 0; n < length(y); n++) {
+    for (size_t n = 0; n < stan::length(y); n++) {
       if (!(stan::get(y, n) > low_vec[n])) {
         std::stringstream msg;
         msg << ", but must be greater than ";
@@ -51,20 +49,15 @@ struct greater<T_y, T_low, true> {
 }  // namespace internal
 
 /**
- * Check if <code>y</code> is strictly greater
- * than <code>low</code>.
- *
+ * Check if <code>y</code> is strictly greater than <code>low</code>.
  * This function is vectorized and will check each element of
  * <code>y</code> against each element of <code>low</code>.
- *
  * @tparam T_y Type of y
  * @tparam T_low Type of lower bound
- *
  * @param function Function name (for error messages)
  * @param name Variable name (for error messages)
  * @param y Variable to check
  * @param low Lower bound
- *
  * @throw <code>domain_error</code> if y is not greater than low or
  *   if any element of y or low is NaN.
  */

--- a/stan/math/prim/scal/err/check_greater_or_equal.hpp
+++ b/stan/math/prim/scal/err/check_greater_or_equal.hpp
@@ -16,9 +16,8 @@ template <typename T_y, typename T_low, bool is_vec>
 struct greater_or_equal {
   static void check(const char* function, const char* name, const T_y& y,
                     const T_low& low) {
-    using stan::length;
     scalar_seq_view<T_low> low_vec(low);
-    for (size_t n = 0; n < length(low); n++) {
+    for (size_t n = 0; n < stan::length(low); n++) {
       if (!(y >= low_vec[n])) {
         std::stringstream msg;
         msg << ", but must be greater than or equal to ";
@@ -34,11 +33,9 @@ template <typename T_y, typename T_low>
 struct greater_or_equal<T_y, T_low, true> {
   static void check(const char* function, const char* name, const T_y& y,
                     const T_low& low) {
-    using stan::get;
-    using stan::length;
     scalar_seq_view<T_low> low_vec(low);
-    for (size_t n = 0; n < length(y); n++) {
-      if (!(get(y, n) >= low_vec[n])) {
+    for (size_t n = 0; n < stan::length(y); n++) {
+      if (!(stan::get(y, n) >= low_vec[n])) {
         std::stringstream msg;
         msg << ", but must be greater than or equal to ";
         msg << low_vec[n];
@@ -51,20 +48,15 @@ struct greater_or_equal<T_y, T_low, true> {
 }  // namespace internal
 
 /**
- * Check if <code>y</code> is greater or equal
- * than <code>low</code>.
- *
+ * Check if <code>y</code> is greater or equal than <code>low</code>.
  * This function is vectorized and will check each element of
  * <code>y</code> against each element of <code>low</code>.
- *
  * @tparam T_y Type of y
  * @tparam T_low Type of lower bound
- *
  * @param function Function name (for error messages)
  * @param name Variable name (for error messages)
  * @param y Variable to check
  * @param low Lower bound
- *
  * @throw <code>domain_error</code> if y is not greater or equal to low or
  *   if any element of y or low is NaN.
  */

--- a/stan/math/prim/scal/err/check_less.hpp
+++ b/stan/math/prim/scal/err/check_less.hpp
@@ -17,9 +17,8 @@ template <typename T_y, typename T_high, bool is_vec>
 struct less {
   static void check(const char* function, const char* name, const T_y& y,
                     const T_high& high) {
-    using stan::length;
     scalar_seq_view<T_high> high_vec(high);
-    for (size_t n = 0; n < length(high); n++) {
+    for (size_t n = 0; n < stan::length(high); n++) {
       if (!(y < high_vec[n])) {
         std::stringstream msg;
         msg << ", but must be less than ";
@@ -35,9 +34,8 @@ template <typename T_y, typename T_high>
 struct less<T_y, T_high, true> {
   static void check(const char* function, const char* name, const T_y& y,
                     const T_high& high) {
-    using stan::length;
     scalar_seq_view<T_high> high_vec(high);
-    for (size_t n = 0; n < length(y); n++) {
+    for (size_t n = 0; n < stan::length(y); n++) {
       if (!(stan::get(y, n) < high_vec[n])) {
         std::stringstream msg;
         msg << ", but must be less than ";
@@ -51,20 +49,15 @@ struct less<T_y, T_high, true> {
 }  // namespace internal
 
 /**
- * Check if <code>y</code> is strictly less
- * than <code>high</code>.
- *
+ * Check if <code>y</code> is strictly less than <code>high</code>.
  * This function is vectorized and will check each element of
  * <code>y</code> against each element of <code>high</code>.
- *
  * @tparam T_y Type of y
  * @tparam T_high Type of upper bound
- *
  * @param function Function name (for error messages)
  * @param name Variable name (for error messages)
  * @param y Variable to check
  * @param high Upper bound
- *
  * @throw <code>domain_error</code> if y is not less than low
  *   or if any element of y or high is NaN.
  */

--- a/stan/math/prim/scal/err/check_less_or_equal.hpp
+++ b/stan/math/prim/scal/err/check_less_or_equal.hpp
@@ -17,9 +17,8 @@ template <typename T_y, typename T_high, bool is_vec>
 struct less_or_equal {
   static void check(const char* function, const char* name, const T_y& y,
                     const T_high& high) {
-    using stan::length;
     scalar_seq_view<T_high> high_vec(high);
-    for (size_t n = 0; n < length(high); n++) {
+    for (size_t n = 0; n < stan::length(high); n++) {
       if (!(y <= high_vec[n])) {
         std::stringstream msg;
         msg << ", but must be less than or equal to ";
@@ -35,9 +34,8 @@ template <typename T_y, typename T_high>
 struct less_or_equal<T_y, T_high, true> {
   static void check(const char* function, const char* name, const T_y& y,
                     const T_high& high) {
-    using stan::length;
     scalar_seq_view<T_high> high_vec(high);
-    for (size_t n = 0; n < length(y); n++) {
+    for (size_t n = 0; n < stan::length(y); n++) {
       if (!(stan::get(y, n) <= high_vec[n])) {
         std::stringstream msg;
         msg << ", but must be less than or equal to ";
@@ -51,22 +49,17 @@ struct less_or_equal<T_y, T_high, true> {
 }  // namespace internal
 
 /**
- * Check if <code>y</code> is less or equal to
- * <code>high</code>.
- *
+ * Check if <code>y</code> is less or equal to <code>high</code>.
  * This function is vectorized and will check each element of
  * <code>y</code> against each element of <code>high</code>.
- *
  * @tparam T_y Type of y
  * @tparam T_high Type of upper bound
- *
  * @param function Function name (for error messages)
  * @param name Variable name (for error messages)
  * @param y Variable to check
  * @param high Upper bound
- *
  * @throw <code>std::domain_error</code> if y is not less than or equal
- *   to low or if any element of y or high is NaN.
+ *   to low or if any element of y or high is NaN
  */
 template <typename T_y, typename T_high>
 inline void check_less_or_equal(const char* function, const char* name,

--- a/stan/math/prim/scal/err/check_nonnegative.hpp
+++ b/stan/math/prim/scal/err/check_nonnegative.hpp
@@ -25,9 +25,7 @@ struct nonnegative {
 template <typename T_y>
 struct nonnegative<T_y, true> {
   static void check(const char* function, const char* name, const T_y& y) {
-    using stan::length;
-
-    for (size_t n = 0; n < length(y); n++) {
+    for (size_t n = 0; n < stan::length(y); n++) {
       if (!std::is_unsigned<typename value_type<T_y>::type>::value
           && !(stan::get(y, n) >= 0))
         domain_error_vec(function, name, y, n, "is ", ", but must be >= 0!");
@@ -38,16 +36,11 @@ struct nonnegative<T_y, true> {
 
 /**
  * Check if <code>y</code> is non-negative.
- *
- * This function is vectorized and will check each element of
- * <code>y</code>.
- *
+ * This function is vectorized and will check each element of <code>y</code>.
  * @tparam T_y Type of y
- *
  * @param function Function name (for error messages)
  * @param name Variable name (for error messages)
  * @param y Variable to check
- *
  * @throw <code>domain_error</code> if y is negative or
  *   if any element of y is NaN.
  */

--- a/stan/math/prim/scal/err/check_not_nan.hpp
+++ b/stan/math/prim/scal/err/check_not_nan.hpp
@@ -32,20 +32,15 @@ struct not_nan<T_y, true> {
 }  // namespace internal
 
 /**
- * Check if <code>y</code> is not
- * <code>NaN</code>.
- *
+ * Check if <code>y</code> is not <code>NaN</code>.
  * This function is vectorized and will check each element of
  * <code>y</code>. If any element is <code>NaN</code>, this
  * function will throw an exception.
- *
  * @tparam T_y Type of y
- *
  * @param function Function name (for error messages)
  * @param name Variable name (for error messages)
  * @param y Variable to check
- *
- * @throw <code>domain_error</code> if any element of y is NaN.
+ * @throw <code>domain_error</code> if any element of y is NaN
  */
 template <typename T_y>
 inline void check_not_nan(const char* function, const char* name,

--- a/stan/math/prim/scal/err/check_positive.hpp
+++ b/stan/math/prim/scal/err/check_positive.hpp
@@ -27,8 +27,7 @@ struct positive {
 template <typename T_y>
 struct positive<T_y, true> {
   static void check(const char* function, const char* name, const T_y& y) {
-    using stan::length;
-    for (size_t n = 0; n < length(y); n++) {
+    for (size_t n = 0; n < stan::length(y); n++) {
       if (!std::is_unsigned<typename value_type<T_y>::type>::value
           && !(stan::get(y, n) > 0))
         domain_error_vec(function, name, y, n, "is ", ", but must be > 0!");
@@ -40,16 +39,12 @@ struct positive<T_y, true> {
 
 /**
  * Check if <code>y</code> is positive.
- *
  * This function is vectorized and will check each element of
  * <code>y</code>.
- *
  * @tparam T_y Type of y
- *
  * @param function Function name (for error messages)
  * @param name Variable name (for error messages)
  * @param y Variable to check
- *
  * @throw <code>domain_error</code> if y is negative or zero or
  *   if any element of y is NaN.
  */

--- a/stan/math/prim/scal/err/check_positive_finite.hpp
+++ b/stan/math/prim/scal/err/check_positive_finite.hpp
@@ -9,16 +9,12 @@ namespace math {
 
 /**
  * Check if <code>y</code> is positive and finite.
- *
  * This function is vectorized and will check each element of
  * <code>y</code>.
- *
  * @tparam T_y Type of y
- *
  * @param function Function name (for error messages)
  * @param name Variable name (for error messages)
  * @param y Variable to check
- *
  * @throw <code>domain_error</code> if any element of y is not positive or
  *   if any element of y is NaN.
  */

--- a/stan/math/prim/scal/err/check_positive_size.hpp
+++ b/stan/math/prim/scal/err/check_positive_size.hpp
@@ -10,12 +10,10 @@ namespace math {
 
 /**
  * Check if <code>size</code> is positive.
- *
  * @param function Function name (for error messages)
  * @param name Variable name (for error messages)
  * @param expr Expression for the dimension size (for error messages)
  * @param size Size value to check
- *
  * @throw <code>std::invalid_argument</code> if <code>size</code> is
  *   zero or negative.
  */

--- a/stan/math/prim/scal/err/check_size_match.hpp
+++ b/stan/math/prim/scal/err/check_size_match.hpp
@@ -3,7 +3,6 @@
 
 #include <boost/type_traits/common_type.hpp>
 #include <stan/math/prim/scal/err/invalid_argument.hpp>
-#include <stan/math/prim/scal/meta/likely.hpp>
 #include <sstream>
 #include <string>
 
@@ -12,23 +11,19 @@ namespace math {
 
 /**
  * Check if the provided sizes match.
- *
  * @tparam T_size1 Type of size 1
  * @tparam T_size2 Type of size 2
- *
  * @param function Function name (for error messages)
  * @param name_i Variable name 1 (for error messages)
- * @param i Size 1
+ * @param i Variable size 1
  * @param name_j Variable name 2 (for error messages)
- * @param j Size 2
- *
- * @throw <code>std::invalid_argument</code> if the sizes
- *   do not match
+ * @param j Variable size 2
+ * @throw <code>std::invalid_argument</code> if the sizes do not match
  */
 template <typename T_size1, typename T_size2>
 inline void check_size_match(const char* function, const char* name_i,
                              T_size1 i, const char* name_j, T_size2 j) {
-  if (likely(i == static_cast<T_size1>(j)))
+  if (i == static_cast<T_size1>(j))
     return;
 
   std::ostringstream msg;
@@ -39,26 +34,22 @@ inline void check_size_match(const char* function, const char* name_i,
 
 /**
  * Check if the provided sizes match.
- *
  * @tparam T_size1 Type of size 1
  * @tparam T_size2 Type of size 2
- *
  * @param function Function name (for error messages)
  * @param expr_i Expression for variable name 1 (for error messages)
  * @param name_i Variable name 1 (for error messages)
- * @param i Size 1
+ * @param i Variable size 1
  * @param expr_j Expression for variable name 2 (for error messages)
  * @param name_j Variable name 2 (for error messages)
- * @param j Size 2
- *
- * @throw <code>std::invalid_argument</code> if the sizes
- *   do not match
+ * @param j Variable size 2
+ * @throw <code>std::invalid_argument</code> if the sizes do not match
  */
 template <typename T_size1, typename T_size2>
 inline void check_size_match(const char* function, const char* expr_i,
                              const char* name_i, T_size1 i, const char* expr_j,
                              const char* name_j, T_size2 j) {
-  if (likely(i == static_cast<T_size1>(j)))
+  if (i == static_cast<T_size1>(j))
     return;
   std::ostringstream updated_name;
   updated_name << expr_i << name_i;

--- a/stan/math/prim/scal/err/domain_error.hpp
+++ b/stan/math/prim/scal/err/domain_error.hpp
@@ -10,13 +10,10 @@ namespace math {
 
 /**
  * Throw a domain error with a consistently formatted message.
- *
  * This is an abstraction for all Stan functions to use when throwing
  * domain errors. This will allow us to change the behavior for all
  * functions at once.
- *
  * The message is: "<function>: <name> <msg1><y><msg2>"
- *
  * @tparam T Type of variable.
  * @param[in] function Name of the function.
  * @param[in] name Name of the variable.
@@ -37,13 +34,10 @@ inline void domain_error(const char* function, const char* name, const T& y,
 
 /**
  * Throw a domain error with a consistently formatted message.
- *
  * This is an abstraction for all Stan functions to use when throwing
  * domain errors. This will allow us to change the behavior for all
  * functions at once.
- *
  * The message is: * "<function>: <name> <msg1><y>"
- *
  * @tparam T Type of variable.
  * @param[in] function Name of the function.
  * @param[in] name Name of the variable.

--- a/stan/math/prim/scal/err/domain_error_vec.hpp
+++ b/stan/math/prim/scal/err/domain_error_vec.hpp
@@ -13,17 +13,13 @@ namespace math {
 
 /**
  * Throw a domain error with a consistently formatted message.
- *
  * This is an abstraction for all Stan functions to use when throwing
  * domain errors. This will allow us to change the behavior for all
  * functions at once. (We've already changed behavior mulitple times up
  * to Stan v2.5.0.)
- *
- * The message is:
- * "<function>: <name>[<i+error_index>] <msg1><y>"
+ * The message is: "<function>: <name>[<i+error_index>] <msg1><y>"
  *    where error_index is the value of stan::error_index::value
  * which indicates whether the message should be 0 or 1 indexed.
- *
  * @tparam T Type of variable
  * @param function Name of the function
  * @param name Name of the variable
@@ -44,17 +40,13 @@ inline void domain_error_vec(const char* function, const char* name, const T& y,
 
 /**
  * Throw a domain error with a consistently formatted message.
- *
  * This is an abstraction for all Stan functions to use when throwing
  * domain errors. This will allow us to change the behavior for all
  * functions at once. (We've already changed behavior mulitple times up
  * to Stan v2.5.0.)
- *
- * The message is:
- * "<function>: <name>[<i+error_index>] <msg1><y>"
+ * The message is: "<function>: <name>[<i+error_index>] <msg1><y>"
  *   where error_index is the value of stan::error_index::value
  * which indicates whether the message should be 0 or 1 indexed.
- *
  * @tparam T Type of variable
  * @param function Name of the function
  * @param name Name of the variable

--- a/stan/math/prim/scal/err/invalid_argument.hpp
+++ b/stan/math/prim/scal/err/invalid_argument.hpp
@@ -7,14 +7,12 @@
 
 namespace stan {
 namespace math {
-
 /**
  * Throw an invalid_argument exception with a consistently formatted message.
  * This is an abstraction for all Stan functions to use when throwing
  * invalid argument. This will allow us to change the behavior for all
  * functions at once.
- * The message is:
- * "<function>: <name> <msg1><y><msg2>"
+ * The message is: "<function>: <name> <msg1><y><msg2>"
  * @tparam T Type of variable
  * @param function Name of the function
  * @param name Name of the variable
@@ -37,7 +35,7 @@ inline void invalid_argument(const char* function, const char* name, const T& y,
  * invalid argument. This will allow us to change the behavior for all
  * functions at once. (We've already changed behavior mulitple times up
  * to Stan v2.5.0.)
- * The message is: <function>: <name> <msg1><y>"
+ * The message is: "<function>: <name> <msg1><y>"
  * @tparam T Type of variable
  * @param function Name of the function
  * @param name Name of the variable

--- a/stan/math/prim/scal/err/invalid_argument.hpp
+++ b/stan/math/prim/scal/err/invalid_argument.hpp
@@ -10,14 +10,11 @@ namespace math {
 
 /**
  * Throw an invalid_argument exception with a consistently formatted message.
- *
  * This is an abstraction for all Stan functions to use when throwing
  * invalid argument. This will allow us to change the behavior for all
  * functions at once.
- *
  * The message is:
  * "<function>: <name> <msg1><y><msg2>"
- *
  * @tparam T Type of variable
  * @param function Name of the function
  * @param name Name of the variable
@@ -30,23 +27,17 @@ template <typename T>
 inline void invalid_argument(const char* function, const char* name, const T& y,
                              const char* msg1, const char* msg2) {
   std::ostringstream message;
-
   message << function << ": " << name << " " << msg1 << y << msg2;
-
   throw std::invalid_argument(message.str());
 }
 
 /**
  * Throw an invalid_argument exception with a consistently formatted message.
- *
  * This is an abstraction for all Stan functions to use when throwing
  * invalid argument. This will allow us to change the behavior for all
  * functions at once. (We've already changed behavior mulitple times up
  * to Stan v2.5.0.)
- *
- * The message is:
- * "<function>: <name> <msg1><y>"
- *
+ * The message is: <function>: <name> <msg1><y>"
  * @tparam T Type of variable
  * @param function Name of the function
  * @param name Name of the variable

--- a/stan/math/prim/scal/err/invalid_argument_vec.hpp
+++ b/stan/math/prim/scal/err/invalid_argument_vec.hpp
@@ -13,17 +13,14 @@ namespace math {
 
 /**
  * Throw an invalid argument exception with a consistently formatted message.
- *
  * This is an abstraction for all Stan functions to use when throwing
  * invalid arguments. This will allow us to change the behavior for all
  * functions at once. (We've already changed behavior mulitple times up
  * to Stan v2.5.0.)
- *
  * The message is:
  * "<function>: <name>[<i+error_index>] <msg1><y>"
  *    where error_index is the value of stan::error_index::value
  * which indicates whether the message should be 0 or 1 indexed.
- *
  * @tparam T Type of variable
  * @param function Name of the function
  * @param name Name of the variable
@@ -45,17 +42,14 @@ inline void invalid_argument_vec(const char* function, const char* name,
 
 /**
  * Throw an invalid argument exception with a consistently formatted message.
- *
  * This is an abstraction for all Stan functions to use when throwing
  * invalid arguments. This will allow us to change the behavior for all
  * functions at once. (We've already changed behavior mulitple times up
  * to Stan v2.5.0.)
- *
  * The message is:
  * "<function>: <name>[<i+error_index>] <msg1><y>"
  *   where error_index is the value of stan::error_index::value
  * which indicates whether the message should be 0 or 1 indexed.
- *
  * @tparam T Type of variable
  * @param function Name of the function
  * @param name Name of the variable

--- a/stan/math/prim/scal/err/is_less_or_equal.hpp
+++ b/stan/math/prim/scal/err/is_less_or_equal.hpp
@@ -1,0 +1,36 @@
+#ifndef STAN_MATH_PRIM_SCAL_ERR_IS_LESS_OR_EQUAL_HPP
+#define STAN_MATH_PRIM_SCAL_ERR_IS_LESS_OR_EQUAL_HPP
+
+#include <stan/math/prim/scal/meta/get.hpp>
+#include <stan/math/prim/scal/meta/length.hpp>
+#include <stan/math/prim/scal/meta/is_vector_like.hpp>
+#include <stan/math/prim/scal/meta/scalar_seq_view.hpp>
+
+namespace stan {
+namespace math {
+
+/**
+ * Return <code>true</code> if <code>y</code> is less or equal to
+ * <code>high</code>.
+ * This function is vectorized and will check each element of
+ * <code>y</code> against each element of <code>high</code>.
+ * @tparam T_y Type of y
+ * @tparam T_high Type of upper bound
+ * @param y Variable to check
+ * @param high Upper bound
+ * @return <code>true</code> if y is less than or equal
+ *   to low and if and element of y or high is NaN
+ */
+template <typename T_y, typename T_high>
+inline bool is_less_or_equal(const T_y& y, const T_high& high) {
+  scalar_seq_view<T_high> high_vec(high);
+  for (size_t n = 0; n < stan::length(high); n++) {
+    if (!(stan::get(y, n) <= high_vec[n]))
+      return false;
+  }
+  return true;
+}
+
+}  // namespace math
+}  // namespace stan
+#endif

--- a/stan/math/prim/scal/err/is_not_nan.hpp
+++ b/stan/math/prim/scal/err/is_not_nan.hpp
@@ -1,0 +1,33 @@
+#ifndef STAN_MATH_PRIM_SCAL_ERR_IS_NOT_NAN_HPP
+#define STAN_MATH_PRIM_SCAL_ERR_IS_NOT_NAN_HPP
+
+#include <stan/math/prim/scal/meta/get.hpp>
+#include <stan/math/prim/scal/meta/length.hpp>
+#include <stan/math/prim/scal/meta/is_vector_like.hpp>
+#include <stan/math/prim/scal/fun/value_of_rec.hpp>
+#include <stan/math/prim/scal/fun/is_nan.hpp>
+
+namespace stan {
+namespace math {
+
+/**
+ * Return <code>true</code> if <code>y</code> is not <code>NaN</code>.
+ * This function is vectorized and will check each element of
+ * <code>y</code>. If no element is <code>NaN</code>, this
+ * function will return <code>true</code>.
+ * @tparam T_y Type of y
+ * @param y Variable to check
+ * @return <code>true</code> if no element of y is NaN
+ */
+template <typename T_y>
+inline bool is_not_nan(const T_y& y) {
+  for (size_t n = 0; n < stan::length(y); ++n) {
+    if (is_nan(value_of_rec(stan::get(y, n))))
+      return false;
+  }
+  return true;
+}
+
+}  // namespace math
+}  // namespace stan
+#endif

--- a/stan/math/prim/scal/err/is_positive.hpp
+++ b/stan/math/prim/scal/err/is_positive.hpp
@@ -1,0 +1,31 @@
+#ifndef STAN_MATH_PRIM_SCAL_ERR_IS_POSITIVE_HPP
+#define STAN_MATH_PRIM_SCAL_ERR_IS_POSITIVE_HPP
+
+#include <stan/math/prim/scal/meta/get.hpp>
+#include <stan/math/prim/scal/meta/length.hpp>
+#include <stan/math/prim/scal/meta/value_type.hpp>
+#include <boost/type_traits/is_unsigned.hpp>
+
+namespace stan {
+namespace math {
+
+/**
+ * Return <code>true</code> if <code>y</code> is positive.
+ * This function is vectorized and will check each element of
+ * <code>y</code>.
+ * @tparam T_y Type of y
+ * @param y Variable to check
+ * @return <code>true</code> if vector contains only positive elements
+ */
+template <typename T_y>
+inline bool is_positive(const T_y& y) {
+  for (size_t n = 0; n < stan::length(y); n++) {
+    if (!boost::is_unsigned<T_y>::value && !(stan::get(y, n) > 0))
+      return false;
+  }
+  return true;
+}
+
+}  // namespace math
+}  // namespace stan
+#endif

--- a/stan/math/prim/scal/err/is_positive.hpp
+++ b/stan/math/prim/scal/err/is_positive.hpp
@@ -8,7 +8,6 @@
 
 namespace stan {
 namespace math {
-
 /**
  * Return <code>true</code> if <code>y</code> is positive.
  * This function is vectorized and will check each element of
@@ -20,7 +19,7 @@ namespace math {
 template <typename T_y>
 inline bool is_positive(const T_y& y) {
   for (size_t n = 0; n < stan::length(y); n++) {
-    if (!boost::is_unsigned<T_y>::value && !(stan::get(y, n) > 0))
+    if (!std::is_unsigned<T_y>::value && !(stan::get(y, n) > 0))
       return false;
   }
   return true;

--- a/stan/math/prim/scal/err/is_positive.hpp
+++ b/stan/math/prim/scal/err/is_positive.hpp
@@ -4,7 +4,7 @@
 #include <stan/math/prim/scal/meta/get.hpp>
 #include <stan/math/prim/scal/meta/length.hpp>
 #include <stan/math/prim/scal/meta/value_type.hpp>
-#include <stan/math/prim/scal/meta/is_vector_like.hpp>
+#include <type_traits>
 
 namespace stan {
 namespace math {
@@ -19,7 +19,7 @@ namespace math {
 template <typename T_y>
 inline bool is_positive(const T_y& y) {
   for (size_t n = 0; n < stan::length(y); n++) {
-    if (!std::is_unsigned<T_y>::value && !(stan::get(y, n) > 0))
+    if (!(std::is_unsigned<T_y>::value && !(stan::get(y, n) > 0)))
       return false;
   }
   return true;

--- a/stan/math/prim/scal/err/is_positive.hpp
+++ b/stan/math/prim/scal/err/is_positive.hpp
@@ -19,7 +19,7 @@ namespace math {
 template <typename T_y>
 inline bool is_positive(const T_y& y) {
   for (size_t n = 0; n < stan::length(y); n++) {
-    if (!boost::is_unsigned<T_y>::value && !(stan::get(y, n) > 0))
+    if (!std::is_unsigned<T_y>::value && !(stan::get(y, n) > 0))
       return false;
   }
   return true;

--- a/stan/math/prim/scal/err/is_positive.hpp
+++ b/stan/math/prim/scal/err/is_positive.hpp
@@ -4,7 +4,7 @@
 #include <stan/math/prim/scal/meta/get.hpp>
 #include <stan/math/prim/scal/meta/length.hpp>
 #include <stan/math/prim/scal/meta/value_type.hpp>
-#include <boost/type_traits/is_unsigned.hpp>
+#include <stan/math/prim/scal/meta/is_vector_like.hpp>
 
 namespace stan {
 namespace math {

--- a/stan/math/prim/scal/err/is_positive_size.hpp
+++ b/stan/math/prim/scal/err/is_positive_size.hpp
@@ -1,0 +1,16 @@
+#ifndef STAN_MATH_PRIM_SCAL_ERR_CHECK_IS_POSITIVE_SIZE_HPP
+#define STAN_MATH_PRIM_SCAL_ERR_CHECK_IS_POSITIVE_SIZE_HPP
+
+namespace stan {
+namespace math {
+
+/**
+ * Return <code>true</code> if <code>size</code> is positive.
+ * @param size Size value to check
+ * @return <code>true</code> if <code>size</code> is not zero or negative.
+ */
+inline bool is_positive_size(int size) { return size > 0; }
+
+}  // namespace math
+}  // namespace stan
+#endif

--- a/stan/math/prim/scal/err/is_scal_finite.hpp
+++ b/stan/math/prim/scal/err/is_scal_finite.hpp
@@ -1,0 +1,32 @@
+#ifndef STAN_MATH_PRIM_SCAL_ERR_IS_SCAL_FINITE_HPP
+#define STAN_MATH_PRIM_SCAL_ERR_IS_SCAL_FINITE_HPP
+
+#include <stan/math/prim/scal/meta/get.hpp>
+#include <stan/math/prim/scal/meta/length.hpp>
+#include <stan/math/prim/scal/meta/is_vector_like.hpp>
+#include <stan/math/prim/scal/fun/value_of_rec.hpp>
+#include <boost/math/special_functions/fpclassify.hpp>
+
+namespace stan {
+namespace math {
+
+/**
+ * Return <code>true</code> if <code>y</code> is finite.
+ * This function is vectorized and will check each element of
+ * <code>y</code>.
+ * @tparam T_y Type of y
+ * @param y Variable to check
+ * @throw <code>true</code> if y is not infinity, -infinity, or NaN
+ */
+template <typename T_y>
+inline bool is_scal_finite(const T_y& y) {
+  for (size_t n = 0; n < stan::length(y); ++n) {
+    if (!(boost::math::isfinite(value_of_rec(stan::get(y, n)))))
+      return false;
+  }
+  return true;
+}
+
+}  // namespace math
+}  // namespace stan
+#endif

--- a/stan/math/prim/scal/err/is_size_match.hpp
+++ b/stan/math/prim/scal/err/is_size_match.hpp
@@ -2,6 +2,7 @@
 #define STAN_MATH_PRIM_SCAL_ERR_IS_SIZE_MATCH_HPP
 
 #include <boost/type_traits/common_type.hpp>
+#include <stan/math/prim/scal/meta/likely.hpp>
 
 namespace stan {
 namespace math {
@@ -10,8 +11,8 @@ namespace math {
  * Return <code>true</code> if the provided sizes match.
  * @tparam T_size1 Type of size 1
  * @tparam T_size2 Type of size 2
- * @param i Size 1
- * @param j Size 2
+ * @param i Size of variable 1
+ * @param j Size of variable 2
  * @return <code>true</code> if provided dimensions match
  */
 template <typename T_size1, typename T_size2>

--- a/stan/math/prim/scal/err/out_of_range.hpp
+++ b/stan/math/prim/scal/err/out_of_range.hpp
@@ -11,15 +11,12 @@ namespace math {
 
 /**
  * Throw an out_of_range exception with a consistently formatted message.
- *
  * This is an abstraction for all Stan functions to use when throwing
  * out of range. This will allow us to change the behavior for all
  * functions at once.
- *
  * The message is:
  * "<function>: index <index> out of range; expecting index to be between "
  * "1 and <max><msg1><msg2>"
- *
  * @param function Name of the function
  * @param max Max
  * @param index Index
@@ -30,12 +27,10 @@ namespace math {
 inline void out_of_range(const char* function, int max, int index,
                          const char* msg1 = "", const char* msg2 = "") {
   std::ostringstream message;
-
   message << function << ": accessing element out of range. "
           << "index " << index << " out of range; "
           << "expecting index to be between " << stan::error_index::value
           << " and " << stan::error_index::value - 1 + max << msg1 << msg2;
-
   throw std::out_of_range(message.str());
 }
 

--- a/stan/math/prim/scal/err/system_error.hpp
+++ b/stan/math/prim/scal/err/system_error.hpp
@@ -10,13 +10,10 @@ namespace math {
 
 /**
  * Throw a system error with a consistently formatted message.
- *
  * This is an abstraction for all Stan functions to use when throwing
  * system errors. This will allow us to change the behavior for all
  * functions at once.
- *
  * The message is: "<function>: <name> <msg1><y><msg2>"
- *
  * @param[in] function Name of the function.
  * @param[in] name Name of the variable.
  * @param[in] y Error code.
@@ -34,13 +31,10 @@ inline void system_error(const char* function, const char* name, const int& y,
 
 /**
  * Throw a system error with a consistently formatted message.
- *
  * This is an abstraction for all Stan functions to use when throwing
  * system errors. This will allow us to change the behavior for all
  * functions at once.
- *
  * The message is: * "<function>: <name> <msg1><y>"
- *
  * @param[in] function Name of the function.
  * @param[in] name Name of the variable.
  * @param[in] y Error code.

--- a/stan/math/rev/scal/fun/log_inv_logit_diff.hpp
+++ b/stan/math/rev/scal/fun/log_inv_logit_diff.hpp
@@ -10,7 +10,7 @@
 namespace stan {
 namespace math {
 
-/**
+/*
  * Returns the natural logarithm of the difference of the
  * inverse logits of the specified arguments and its gradients.
  *

--- a/stan/math/rev/scal/fun/log_inv_logit_diff.hpp
+++ b/stan/math/rev/scal/fun/log_inv_logit_diff.hpp
@@ -27,12 +27,12 @@ namespace math {
     \frac{\partial }{\partial x} = -\frac{e^y}{e^x-e^y}-\frac{e^y}{e^y+1}
    \f]
  *
- * @tparam T1 Type of x argument.
- * @tparam T2 Type of y argument.
- * @param x Argument.
- * @param y Argument.
+ * @tparam T1 Type of x argument
+ * @tparam T2 Type of y argument
+ * @param a Argument
+ * @param b Argument
  * @return Result of log difference of inverse logits of arguments
- *          and gradients.
+ *          and gradients
  */
 namespace internal {
 class log_inv_logit_diff_vv_vari : public op_vv_vari {

--- a/test/unit/math/prim/mat/err/check_pos_definite_test.cpp
+++ b/test/unit/math/prim/mat/err/check_pos_definite_test.cpp
@@ -4,6 +4,8 @@
 #include <limits>
 #include <string>
 
+using stan::math::check_pos_definite;
+
 const char* function = "function";
 class ErrorHandlingMatrix : public ::testing::Test {
  public:
@@ -13,8 +15,6 @@ class ErrorHandlingMatrix : public ::testing::Test {
 };
 
 TEST_F(ErrorHandlingMatrix, checkPosDefinite) {
-  using stan::math::check_pos_definite;
-
   y.resize(1, 1);
   y << 1;
   EXPECT_NO_THROW(check_pos_definite(function, "y", y));
@@ -39,7 +39,6 @@ TEST_F(ErrorHandlingMatrix, checkPosDefinite) {
 }
 
 TEST_F(ErrorHandlingMatrix, checkPosDefinite_not_square) {
-  using stan::math::check_pos_definite;
   std::stringstream expected_msg;
 
   y.resize(3, 4);
@@ -59,7 +58,6 @@ TEST_F(ErrorHandlingMatrix, checkPosDefinite_not_square) {
 }
 
 TEST_F(ErrorHandlingMatrix, checkPosDefinite_0_size) {
-  using stan::math::check_pos_definite;
   std::string expected_msg;
 
   expected_msg
@@ -79,7 +77,6 @@ TEST_F(ErrorHandlingMatrix, checkPosDefinite_0_size) {
 }
 
 TEST_F(ErrorHandlingMatrix, checkPosDefinite_non_symmetric) {
-  using stan::math::check_pos_definite;
   std::string expected_msg;
 
   y.resize(3, 3);
@@ -98,7 +95,6 @@ TEST_F(ErrorHandlingMatrix, checkPosDefinite_non_symmetric) {
 }
 
 TEST_F(ErrorHandlingMatrix, checkPosDefinite_non_pos_definite) {
-  using stan::math::check_pos_definite;
   std::stringstream expected_msg1_mat;
   std::stringstream expected_msg1_llt;
   std::stringstream expected_msg1_ldlt;
@@ -154,7 +150,6 @@ TEST_F(ErrorHandlingMatrix, checkPosDefinite_non_pos_definite) {
 
 TEST_F(ErrorHandlingMatrix, checkPosDefinite_nan) {
   double nan = std::numeric_limits<double>::quiet_NaN();
-  using stan::math::check_pos_definite;
 
   y.resize(1, 1);
   y << nan;

--- a/test/unit/math/prim/mat/err/is_cholesky_factor_corr_test.cpp
+++ b/test/unit/math/prim/mat/err/is_cholesky_factor_corr_test.cpp
@@ -1,0 +1,68 @@
+#include <stan/math/prim/mat.hpp>
+#include <gtest/gtest.h>
+#include <limits>
+
+TEST(ErrorHandlingMatrix, isCorrCholeskyMatrix) {
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> y;
+
+  using stan::math::is_cholesky_factor_corr;
+  using std::sqrt;
+
+  y.resize(1, 1);
+  y << 1;
+  EXPECT_TRUE(is_cholesky_factor_corr(y));
+
+  y.resize(3, 3);
+  y << 1, 0, 0, sqrt(0.5), sqrt(0.5), 0, sqrt(0.25), sqrt(0.25), sqrt(0.5);
+  EXPECT_TRUE(is_cholesky_factor_corr(y));
+
+  // not positive
+  y.resize(1, 1);
+  y << -1;
+  EXPECT_FALSE(is_cholesky_factor_corr(y));
+
+  // not lower triangular
+  y.resize(3, 3);
+  y << 1, 2, 3, 0, 5, 6, 0, 0, 9;
+  EXPECT_FALSE(is_cholesky_factor_corr(y));
+
+  // not positive
+  y.resize(3, 3);
+  y << 1, 0, 0, 2, -1, 0, 1, 2, 3;
+  EXPECT_FALSE(is_cholesky_factor_corr(y));
+
+  // not rectangular
+  y.resize(2, 3);
+  y << 1, 2, 3, 4, 5, 6;
+  EXPECT_FALSE(is_cholesky_factor_corr(y));
+  y.resize(3, 2);
+  y << 1, 0, 2, 3, 4, 5;
+  EXPECT_FALSE(is_cholesky_factor_corr(y));
+
+  // not unit vectors
+  y.resize(3, 3);
+  y << 1, 0, 0, 1, 1, 0, 1, 1, 1;
+  EXPECT_FALSE(is_cholesky_factor_corr(y));
+}
+
+TEST(ErrorHandlingMatrix, isCorrCholeskyMatrix_nan) {
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> y;
+  double nan = std::numeric_limits<double>::quiet_NaN();
+
+  using stan::math::is_cholesky_factor_corr;
+  using std::sqrt;
+  
+  y.resize(1, 1);
+  y << nan;
+  EXPECT_FALSE(is_cholesky_factor_corr(y));
+
+  y.resize(3, 3);
+  y << 1, 0, 0, sqrt(0.5), sqrt(0.5), 0, sqrt(0.25), sqrt(0.25), sqrt(0.5);
+  EXPECT_TRUE(is_cholesky_factor_corr(y));
+
+  for (int i = 0; i < y.size(); i++) {
+    y(i) = nan;
+    EXPECT_FALSE(is_cholesky_factor_corr(y));
+    y << 1, 0, 0, sqrt(0.5), sqrt(0.5), 0, sqrt(0.25), sqrt(0.25), sqrt(0.5);
+  }
+}

--- a/test/unit/math/prim/mat/err/is_cholesky_factor_corr_test.cpp
+++ b/test/unit/math/prim/mat/err/is_cholesky_factor_corr_test.cpp
@@ -51,7 +51,7 @@ TEST(ErrorHandlingMatrix, isCorrCholeskyMatrix_nan) {
 
   using stan::math::is_cholesky_factor_corr;
   using std::sqrt;
-  
+
   y.resize(1, 1);
   y << nan;
   EXPECT_FALSE(is_cholesky_factor_corr(y));

--- a/test/unit/math/prim/mat/err/is_cholesky_factor_test.cpp
+++ b/test/unit/math/prim/mat/err/is_cholesky_factor_test.cpp
@@ -1,0 +1,86 @@
+#include <stan/math/prim/mat.hpp>
+#include <gtest/gtest.h>
+#include <limits>
+
+TEST(ErrorHandlingMatrix, isCovCholeskyMatrix) {
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> y;
+
+  using stan::math::is_cholesky_factor;
+
+  y.resize(1, 1);
+  y << 1;
+  EXPECT_TRUE(is_cholesky_factor(y));
+
+  y.resize(3, 3);
+  y << 1, 0, 0, 1, 1, 0, 1, 1, 1;
+  EXPECT_TRUE(is_cholesky_factor(y));
+
+  // not positive
+  y.resize(1, 1);
+  y << -1;
+  EXPECT_FALSE(is_cholesky_factor(y));
+
+  // not lower triangular
+  y.resize(3, 3);
+  y << 1, 2, 3, 4, 5, 6, 7, 8, 9;
+  EXPECT_FALSE(is_cholesky_factor(y));
+
+  // not positive
+  y.resize(3, 3);
+  y << 1, 0, 0, 2, -1, 0, 1, 2, 3;
+  EXPECT_FALSE(is_cholesky_factor(y));
+
+  // not rectangular
+  y.resize(2, 3);
+  y << 1, 2, 3, 4, 5, 6;
+  EXPECT_FALSE(is_cholesky_factor(y));
+
+  y.resize(3, 2);
+  y << 1, 0, 2, 3, 4, 5;
+  EXPECT_TRUE(is_cholesky_factor(y));
+
+  y(0, 1) = 1.5;
+  EXPECT_FALSE(is_cholesky_factor(y));
+}
+
+TEST(ErrorHandlingMatrix, isCovCholeskyMatrix_nan) {
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> y;
+  double nan = std::numeric_limits<double>::quiet_NaN();
+
+  using stan::math::is_cholesky_factor;
+
+  y.resize(1, 1);
+  y << nan;
+  EXPECT_FALSE(is_cholesky_factor(y));
+
+  y.resize(3, 3);
+  y << nan, 0, 0, nan, nan, 0, nan, nan, nan;
+  EXPECT_FALSE(is_cholesky_factor(y));
+
+  // not positive
+  y.resize(1, 1);
+  y << nan;
+  EXPECT_FALSE(is_cholesky_factor(y));
+
+  // not lower triangular
+  y.resize(3, 3);
+  y << 1, nan, 3, 4, 5, nan, 7, 8, 9;
+  EXPECT_FALSE(is_cholesky_factor(y));
+
+  // not positive
+  y.resize(3, 3);
+  y << 1, 0, 0, 2, nan, 0, 1, 2, 3;
+  EXPECT_FALSE(is_cholesky_factor(y));
+
+  // not rectangular
+  y.resize(2, 3);
+  y << 1, 2, nan, nan, 5, 6;
+  EXPECT_FALSE(is_cholesky_factor(y));
+
+  y.resize(3, 2);
+  y << 1, 0, 2, nan, 4, 5;
+  EXPECT_FALSE(is_cholesky_factor(y));
+
+  y(0, 1) = nan;
+  EXPECT_FALSE(is_cholesky_factor(y));
+}

--- a/test/unit/math/prim/mat/err/is_column_index_test.cpp
+++ b/test/unit/math/prim/mat/err/is_column_index_test.cpp
@@ -1,0 +1,42 @@
+#include <stan/math/prim/mat.hpp>
+#include <gtest/gtest.h>
+#include <limits>
+
+TEST(ErrorHandlingMatrix, isColumnIndexMatrix) {
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> y;
+  size_t i;
+
+  i = 2;
+  y.resize(3, 3);
+  EXPECT_TRUE(stan::math::is_column_index(y, i));
+
+  i = 3;
+  EXPECT_TRUE(stan::math::is_column_index(y, i));
+
+  y.resize(3, 2);
+  EXPECT_FALSE(stan::math::is_column_index(y, i));
+
+  i = 0;
+  EXPECT_FALSE(stan::math::is_column_index(y, i));
+}
+
+TEST(ErrorHandlingMatrix, isColumnIndexMatrix_nan) {
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> y;
+  double nan = std::numeric_limits<double>::quiet_NaN();
+  size_t i;
+
+  i = 2;
+  y.resize(3, 3);
+  y << nan, nan, nan, nan, nan, nan, nan, nan, nan;
+  EXPECT_TRUE(stan::math::is_column_index(y, i));
+
+  i = 3;
+  EXPECT_TRUE(stan::math::is_column_index(y, i));
+
+  y.resize(3, 2);
+  y << nan, nan, nan, nan, nan, nan;
+  EXPECT_FALSE(stan::math::is_column_index(y, i));
+
+  i = 0;
+  EXPECT_FALSE(stan::math::is_column_index(y, i));
+}

--- a/test/unit/math/prim/mat/err/is_corr_matrix_test.cpp
+++ b/test/unit/math/prim/mat/err/is_corr_matrix_test.cpp
@@ -1,0 +1,33 @@
+#include <stan/math/prim/mat.hpp>
+#include <gtest/gtest.h>
+#include <limits>
+#include <string>
+
+using stan::math::is_corr_matrix;
+
+TEST(ErrorHandlingMatrix, isCorrMatrix) {
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> y;
+  y.resize(2, 2);
+
+  y << 1, 0, 0, 1;
+  EXPECT_TRUE(is_corr_matrix(y));
+
+  y << 10, 0, 0, 10;
+  EXPECT_FALSE(is_corr_matrix(y));
+}
+
+TEST(ErrorHandlingMatrix, isCorrMatrix_nan) {
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> y;
+  y.resize(2, 2);
+  double nan = std::numeric_limits<double>::quiet_NaN();
+
+  for (int i = 0; i < y.size(); i++) {
+    y << 1, 0, 0, 1;
+    y(i) = nan;
+    EXPECT_FALSE(is_corr_matrix(y));
+
+    y << 10, 0, 0, 10;
+    y(i) = nan;
+    EXPECT_FALSE(is_corr_matrix(y));
+  }
+}

--- a/test/unit/math/prim/mat/err/is_cov_matrix_test.cpp
+++ b/test/unit/math/prim/mat/err/is_cov_matrix_test.cpp
@@ -1,0 +1,31 @@
+#include <stan/math/prim/mat.hpp>
+#include <gtest/gtest.h>
+#include <limits>
+
+TEST(ErrorHandlingMatrix, isCovMatrix) {
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> y;
+
+  y.resize(3, 3);
+  y << 2, -1, 0, -1, 2, -1, 0, -1, 2;
+  EXPECT_TRUE(stan::math::is_cov_matrix(y));
+
+  y << 1, 2, 3, 2, 1, 2, 3, 2, 1;
+  EXPECT_FALSE(stan::math::is_cov_matrix(y));
+}
+
+TEST(ErrorHandlingMatrix, isCovMatrix_nan) {
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> y;
+  double nan = std::numeric_limits<double>::quiet_NaN();
+
+  y.resize(3, 3);
+  y << 2, -1, 0, -1, 2, -1, 0, -1, 2;
+  EXPECT_TRUE(stan::math::is_cov_matrix(y));
+
+  for (int i = 0; i < y.size(); i++) {
+    y.resize(3, 3);
+    y << 2, -1, 0, -1, 2, -1, 0, -1, 2;
+    y(i) = nan;
+    EXPECT_FALSE(stan::math::is_cov_matrix(y));
+    y << 2, -1, 0, -1, 2, -1, 0, -1, 2;
+  }
+}

--- a/test/unit/math/prim/mat/err/is_ldlt_factor_test.cpp
+++ b/test/unit/math/prim/mat/err/is_ldlt_factor_test.cpp
@@ -1,0 +1,31 @@
+#include <stan/math/prim/mat.hpp>
+#include <gtest/gtest.h>
+#include <limits>
+
+TEST(ErrorHandlingMatrix, isLDLTFactor_nan) {
+  using stan::math::is_ldlt_factor;
+
+  double nan = std::numeric_limits<double>::quiet_NaN();
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> x(2, 2);
+  stan::math::LDLT_factor<double, -1, -1> ldlt_x;
+
+  x << nan, 1, 1, 3;
+  ldlt_x.compute(x);
+  EXPECT_FALSE(ldlt_x.success());
+  EXPECT_FALSE(is_ldlt_factor(ldlt_x));
+
+  x << 3, nan, 1, 3;
+  ldlt_x.compute(x);
+  EXPECT_TRUE(ldlt_x.success());
+  EXPECT_TRUE(is_ldlt_factor(ldlt_x));
+
+  x << 3, 1, nan, 3;
+  ldlt_x.compute(x);
+  EXPECT_FALSE(ldlt_x.success());
+  EXPECT_FALSE(is_ldlt_factor(ldlt_x));
+
+  x << 3, 1, 1, nan;
+  ldlt_x.compute(x);
+  EXPECT_FALSE(ldlt_x.success());
+  EXPECT_FALSE(is_ldlt_factor(ldlt_x));
+}

--- a/test/unit/math/prim/mat/err/is_lower_triangular_test.cpp
+++ b/test/unit/math/prim/mat/err/is_lower_triangular_test.cpp
@@ -1,0 +1,76 @@
+#include <stan/math/prim/mat.hpp>
+#include <gtest/gtest.h>
+#include <limits>
+#include <string>
+
+TEST(ErrorHandlingMatrix, isLowerTriangular) {
+  using stan::math::is_lower_triangular;
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> y;
+
+  y.resize(1, 1);
+  y << 1;
+  EXPECT_TRUE(is_lower_triangular(y));
+
+  y.resize(1, 2);
+  y << 1, 0;
+  EXPECT_TRUE(is_lower_triangular(y));
+
+  y(0, 1) = 1;
+  EXPECT_FALSE(is_lower_triangular(y));
+
+  y.resize(2, 2);
+  y << 1, 0, 2, 3;
+  EXPECT_TRUE(is_lower_triangular(y));
+
+  y << 1, 2, 3, 4;
+  EXPECT_FALSE(is_lower_triangular(y));
+
+  y.resize(3, 2);
+  y << 1, 0, 2, 3, 4, 5;
+  EXPECT_TRUE(is_lower_triangular(y));
+
+  y(0, 1) = 1.5;
+  EXPECT_FALSE(is_lower_triangular(y));
+
+  y.resize(2, 3);
+  y << 1, 0, 0, 4, 5, 0;
+  EXPECT_TRUE(is_lower_triangular(y));
+}
+
+TEST(ErrorHandlingMatrix, isLowerTriangular_nan) {
+  using stan::math::is_lower_triangular;
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> y;
+  double nan = std::numeric_limits<double>::quiet_NaN();
+
+  y.resize(1, 1);
+  y << nan;
+  EXPECT_TRUE(is_lower_triangular(y));
+
+  y.resize(1, 2);
+  y << nan, 0;
+  EXPECT_TRUE(is_lower_triangular(y));
+
+  y(0, 1) = nan;
+  EXPECT_FALSE(is_lower_triangular(y));
+
+  y.resize(2, 2);
+  y << nan, 0, nan, nan;
+  EXPECT_TRUE(is_lower_triangular(y));
+
+  y << 1, nan, nan, 4;
+  EXPECT_FALSE(is_lower_triangular(y));
+
+  y.resize(3, 2);
+  y << nan, 0, 2, nan, 4, 5;
+  EXPECT_TRUE(is_lower_triangular(y));
+
+  y(0, 1) = nan;
+  EXPECT_FALSE(is_lower_triangular(y));
+
+  y.resize(2, 3);
+  y << nan, 0, 0, 4, nan, 0;
+  EXPECT_TRUE(is_lower_triangular(y));
+
+  y(0, 2) = nan;
+  EXPECT_FALSE(is_lower_triangular(y));
+}

--- a/test/unit/math/prim/mat/err/is_mat_finite_test.cpp
+++ b/test/unit/math/prim/mat/err/is_mat_finite_test.cpp
@@ -1,0 +1,41 @@
+#include <stan/math/prim/mat.hpp>
+#include <gtest/gtest.h>
+#include <limits>
+#include <string>
+
+using stan::math::is_mat_finite;
+
+// ---------- is_mat_finite: matrix tests ----------
+TEST(ErrorHandlingScalar, isMatFinite_Matrix) {
+  Eigen::Matrix<double, Eigen::Dynamic, 1> x;
+
+  x.resize(3);
+  x << -1, 0, 1;
+  EXPECT_TRUE(is_mat_finite(x));
+
+  x.resize(3);
+  x << -1, 0, std::numeric_limits<double>::infinity();
+  EXPECT_FALSE(is_mat_finite(x));
+
+  x.resize(3);
+  x << -1, 0, -std::numeric_limits<double>::infinity();
+  EXPECT_FALSE(is_mat_finite(x));
+
+  x.resize(3);
+  x << -1, 0, std::numeric_limits<double>::quiet_NaN();
+  EXPECT_FALSE(is_mat_finite(x));
+}
+
+TEST(ErrorHandlingScalar, isMatFinite_nan) {
+  double nan = std::numeric_limits<double>::quiet_NaN();
+
+  Eigen::Matrix<double, Eigen::Dynamic, 1> x_mat(3);
+  x_mat << nan, 0, 1;
+  EXPECT_FALSE(is_mat_finite(x_mat));
+
+  x_mat << 1, nan, 1;
+  EXPECT_FALSE(is_mat_finite(x_mat));
+
+  x_mat << 1, 0, nan;
+  EXPECT_FALSE(is_mat_finite(x_mat));
+}

--- a/test/unit/math/prim/mat/err/is_matching_dims_test.cpp
+++ b/test/unit/math/prim/mat/err/is_matching_dims_test.cpp
@@ -1,0 +1,73 @@
+#include <stan/math/prim/mat.hpp>
+#include <gtest/gtest.h>
+#include <test/unit/util.hpp>
+#include <limits>
+
+TEST(ErrorHandlingMatrix, isMatchingDimsMatrix) {
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> y;
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> x;
+
+  y.resize(3, 3);
+  x.resize(3, 3);
+  EXPECT_TRUE(stan::math::is_matching_dims(x, y));
+
+  x.resize(0, 0);
+  y.resize(0, 0);
+  EXPECT_TRUE(stan::math::is_matching_dims(x, y));
+
+  y.resize(1, 2);
+  EXPECT_FALSE(stan::math::is_matching_dims(x, y));
+
+  x.resize(2, 1);
+  EXPECT_FALSE(stan::math::is_matching_dims(x, y));
+}
+
+TEST(ErrorHandlingMatrix, isMatchingDimsMatrix_nan) {
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> y;
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> x;
+  double nan = std::numeric_limits<double>::quiet_NaN();
+
+  y.resize(3, 3);
+  x.resize(3, 3);
+  y << nan, nan, nan, nan, nan, nan, nan, nan, nan;
+  x << nan, nan, nan, nan, nan, nan, nan, nan, nan;
+  EXPECT_TRUE(stan::math::is_matching_dims(x, y));
+
+  x.resize(0, 0);
+  y.resize(0, 0);
+  EXPECT_TRUE(stan::math::is_matching_dims(x, y));
+
+  y.resize(1, 2);
+  y << nan, nan;
+  EXPECT_FALSE(stan::math::is_matching_dims(x, y));
+
+  x.resize(2, 1);
+  x << nan, nan;
+  EXPECT_FALSE(stan::math::is_matching_dims(x, y));
+}
+
+TEST(ErrorHandlingMatrix, isMatchingDims_compile_time_sizes) {
+  using stan::math::is_matching_dims;
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> m_dynamic;
+  Eigen::Matrix<double, 2, 2> m_2x2;
+  Eigen::Matrix<double, Eigen::Dynamic, 1> vector(4);
+  Eigen::Matrix<double, 1, Eigen::Dynamic> rowvector(4);
+
+  m_dynamic.resize(2, 2);
+  EXPECT_TRUE(is_matching_dims(m_dynamic, m_2x2));
+
+  m_dynamic.resize(3, 3);
+  EXPECT_FALSE(is_matching_dims(m_dynamic, m_2x2));
+
+  m_dynamic.resize(4, 1);
+  EXPECT_TRUE(is_matching_dims(m_dynamic, vector));
+
+  m_dynamic.resize(3, 1);
+  EXPECT_FALSE(is_matching_dims(m_dynamic, vector));
+
+  m_dynamic.resize(1, 4);
+  EXPECT_TRUE(is_matching_dims(m_dynamic, rowvector));
+
+  m_dynamic.resize(1, 3);
+  EXPECT_FALSE(is_matching_dims(m_dynamic, rowvector));
+}

--- a/test/unit/math/prim/mat/err/is_pos_definite_test.cpp
+++ b/test/unit/math/prim/mat/err/is_pos_definite_test.cpp
@@ -1,0 +1,156 @@
+#include <stan/math/prim/mat.hpp>
+#include <gtest/gtest.h>
+#include <test/unit/util.hpp>
+#include <limits>
+
+using stan::math::is_pos_definite;
+
+class ErrorHandlingMatrix : public ::testing::Test {
+ public:
+  void SetUp() {}
+
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> y;
+};
+
+TEST_F(ErrorHandlingMatrix, isPosDefinite) {
+  y.resize(1, 1);
+  y << 1;
+  EXPECT_TRUE(is_pos_definite(y));
+
+  Eigen::LLT<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> > llt_1(y);
+  EXPECT_TRUE(is_pos_definite(llt_1));
+
+  Eigen::LDLT<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> > ldlt_1
+      = y.ldlt();
+  EXPECT_TRUE(is_pos_definite(ldlt_1));
+
+  y.resize(3, 3);
+  y << 1, 0, 0, 0, 1, 0, 0, 0, 1;
+  EXPECT_TRUE(is_pos_definite(y));
+
+  Eigen::LLT<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> > llt_2(y);
+  EXPECT_TRUE(is_pos_definite(llt_2));
+
+  Eigen::LDLT<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> > ldlt_2
+      = y.ldlt();
+  EXPECT_TRUE(is_pos_definite(ldlt_2));
+}
+
+TEST_F(ErrorHandlingMatrix, isPosDefinite_not_square) {
+  y.resize(3, 4);
+  EXPECT_FALSE(is_pos_definite(y));
+  y.resize(2, 3);
+  y << 1, 1, 1, 1, 1, 1;
+  Eigen::LLT<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> > llt(
+      y.rows());
+  // FIXME
+  // Linux behavior for handling assertion thrown by llt.compute(y)
+  // differs from mac; produces a core dump
+  EXPECT_DEATH(llt.compute(y), "");
+  EXPECT_DEATH(y.ldlt(), "");
+}
+
+TEST_F(ErrorHandlingMatrix, isPosDefinite_0_size) {
+  EXPECT_FALSE(is_pos_definite(y));
+
+  Eigen::MatrixXd x;
+  x.resize(0, 0);
+  Eigen::LLT<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> > llt(
+      x.rows());
+  llt.compute(x);
+  EXPECT_TRUE(is_pos_definite(llt));
+
+  Eigen::LDLT<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> > ldlt(
+      x.rows());
+  EXPECT_DEATH(ldlt.compute(x), "");
+}
+
+TEST_F(ErrorHandlingMatrix, isPosDefinite_non_symmetric) {
+  y.resize(3, 3);
+  y << 1, 0, 0, 0, 1, 0.5, 0, 0, 1;
+  EXPECT_FALSE(is_pos_definite(y));
+
+  Eigen::LLT<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> > llt(y);
+  EXPECT_TRUE(is_pos_definite(llt));
+
+  Eigen::LDLT<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> > ldlt
+      = y.ldlt();
+  EXPECT_TRUE(is_pos_definite(ldlt));
+}
+
+TEST_F(ErrorHandlingMatrix, isPosDefinite_non_pos_definite) {
+  y.resize(3, 3);
+  y << -1, 0, 0, 0, -1, 0, 0, 0, -1;
+  EXPECT_FALSE(is_pos_definite(y));
+
+  Eigen::LLT<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> > llt_err1(
+      y);
+  EXPECT_FALSE(is_pos_definite(llt_err1));
+
+  Eigen::LDLT<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> > ldlt_err1
+      = y.ldlt();
+  EXPECT_FALSE(is_pos_definite(ldlt_err1));
+
+  y.resize(2, 2);
+  y << 1, 2, 2, 1;
+  EXPECT_FALSE(is_pos_definite(y));
+
+  Eigen::LLT<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> > llt_err2(
+      y);
+  EXPECT_FALSE(is_pos_definite(llt_err2));
+
+  Eigen::LDLT<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> > ldlt_err2
+      = y.ldlt();
+  EXPECT_FALSE(is_pos_definite(ldlt_err2));
+
+  y << 1, 1, 1, 1;
+  EXPECT_FALSE(is_pos_definite(y));
+
+  Eigen::LLT<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> > llt_err3(
+      y);
+  EXPECT_FALSE(is_pos_definite(llt_err3));
+
+  Eigen::LDLT<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> > ldlt_err3
+      = y.ldlt();
+  EXPECT_FALSE(is_pos_definite(ldlt_err3));
+}
+
+TEST_F(ErrorHandlingMatrix, isPosDefinite_nan) {
+  double nan = std::numeric_limits<double>::quiet_NaN();
+
+  y.resize(1, 1);
+  y << nan;
+  EXPECT_FALSE(is_pos_definite(y));
+
+  Eigen::LLT<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> > llt_err1(
+      y);
+  EXPECT_FALSE(is_pos_definite(llt_err1));
+
+  Eigen::LDLT<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> > ldlt_err1
+      = y.ldlt();
+  EXPECT_FALSE(is_pos_definite(ldlt_err1));
+
+  y.resize(3, 3);
+  y << 2, -1, 0, -1, 2, -1, 0, -1, 2;
+  EXPECT_TRUE(is_pos_definite(y));
+  for (int i = 0; i < y.rows(); i++)
+    for (int j = 0; j < y.cols(); j++) {
+      y << 2, -1, 0, -1, 2, -1, 0, -1, 2;
+      y(i, j) = nan;
+      if (i >= j) {
+        EXPECT_FALSE(is_pos_definite(y));
+      }
+    }
+
+  y << 2, -1, nan, -1, 2, -1, nan, -1, nan;
+  Eigen::LLT<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> > llt_err2(
+      y);
+  EXPECT_FALSE(is_pos_definite(llt_err2));
+
+  Eigen::LDLT<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> > ldlt_err2
+      = y.ldlt();
+  EXPECT_FALSE(is_pos_definite(ldlt_err2));
+
+  y << 0, 0, 0, 0, 0, 0, 0, 0, 0;
+  EXPECT_FALSE(is_pos_definite(y));
+}

--- a/test/unit/math/prim/mat/err/is_square_test.cpp
+++ b/test/unit/math/prim/mat/err/is_square_test.cpp
@@ -1,0 +1,43 @@
+#include <stan/math/prim/mat.hpp>
+#include <gtest/gtest.h>
+#include <limits>
+
+TEST(ErrorHandlingMatrix, isSquareMatrix) {
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> y;
+
+  y.resize(3, 3);
+  EXPECT_TRUE(stan::math::is_square(y));
+
+  y.resize(3, 2);
+  EXPECT_FALSE(stan::math::is_square(y));
+}
+
+TEST(ErrorHandlingMatrix, isSquareMatrix_nan) {
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> y;
+  double nan = std::numeric_limits<double>::quiet_NaN();
+
+  y.resize(3, 3);
+  y << nan, nan, nan, nan, nan, nan, nan, nan, nan;
+  EXPECT_TRUE(stan::math::is_square(y));
+
+  y.resize(3, 2);
+  y << nan, nan, nan, nan, nan, nan;
+  EXPECT_FALSE(stan::math::is_square(y));
+}
+
+TEST(ErrorHandlingMatrix, isSquareMatrix_0x0) {
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> y;
+
+  y.resize(0, 0);
+  EXPECT_TRUE(stan::math::is_square(y));
+}
+
+TEST(ErrorHandlingMatrix, isSquareMatrix_0_size) {
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> y;
+
+  y.resize(0, 10);
+  EXPECT_FALSE(stan::math::is_square(y));
+
+  y.resize(10, 0);
+  EXPECT_FALSE(stan::math::is_square(y));
+}

--- a/test/unit/math/prim/mat/err/is_symmetric_test.cpp
+++ b/test/unit/math/prim/mat/err/is_symmetric_test.cpp
@@ -1,0 +1,47 @@
+#include <stan/math/prim/mat.hpp>
+#include <gtest/gtest.h>
+#include <limits>
+#include <string>
+
+TEST(ErrorHandlingMatrix, isSymmetric) {
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> y;
+
+  y.resize(2, 2);
+  y << 1, 3, 3, 1;
+  EXPECT_TRUE(stan::math::is_symmetric(y));
+
+  y << 1, 3.5, 3, 1;
+  EXPECT_FALSE(stan::math::is_symmetric(y));
+}
+
+TEST(ErrorHandlingMatrix, isSymmetric_one_indexed_message) {
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> y;
+  std::string message;
+
+  y.resize(2, 2);
+  y << 1, 0, 3, 1;
+  EXPECT_FALSE(stan::math::is_symmetric(y));
+}
+
+TEST(ErrorHandlingMatrix, isSymmetric_nan) {
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> y;
+  double nan = std::numeric_limits<double>::quiet_NaN();
+
+  y.resize(2, 2);
+  y << 1, nan, 3, 1;
+  EXPECT_FALSE(stan::math::is_symmetric(y));
+
+  y << nan, 3, 3, 1;
+  EXPECT_TRUE(stan::math::is_symmetric(y));
+
+  y.resize(1, 1);
+  y << nan;
+  EXPECT_TRUE(stan::math::is_symmetric(y));
+}
+
+TEST(ErrorHandlingMatrix, isSymmetric_non_square) {
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> y;
+
+  y.resize(2, 3);
+  EXPECT_FALSE(stan::math::is_symmetric(y));
+}

--- a/test/unit/math/prim/mat/err/is_unit_vector_test.cpp
+++ b/test/unit/math/prim/mat/err/is_unit_vector_test.cpp
@@ -1,0 +1,35 @@
+#include <stan/math/prim/mat.hpp>
+#include <gtest/gtest.h>
+#include <test/unit/util.hpp>
+#include <limits>
+
+TEST(ErrorHandlingMatrix, isUnitVector) {
+  Eigen::Matrix<double, Eigen::Dynamic, 1> y(2);
+
+  y << sqrt(0.5), sqrt(0.5);
+  EXPECT_TRUE(stan::math::is_unit_vector(y));
+
+  y[1] = 0;
+  EXPECT_FALSE(stan::math::is_unit_vector(y));
+}
+
+TEST(ErrorHandlingMatrix, isUnitVector_nan) {
+  Eigen::Matrix<double, Eigen::Dynamic, 1> y(2);
+  double nan = std::numeric_limits<double>::quiet_NaN();
+
+  y << nan, sqrt(0.5);
+  EXPECT_FALSE(stan::math::is_unit_vector(y));
+
+  y << sqrt(0.5), nan;
+  EXPECT_FALSE(stan::math::is_unit_vector(y));
+
+  y << nan, nan;
+  EXPECT_FALSE(stan::math::is_unit_vector(y));
+}
+
+TEST(ErrorHandlingMatrix, isUnitVector_0_size) {
+  using stan::math::is_unit_vector;
+  Eigen::Matrix<double, Eigen::Dynamic, 1> y(0, 1);
+
+  EXPECT_FALSE(is_unit_vector(y));
+}

--- a/test/unit/math/prim/scal/err/is_less_or_equal_test.cpp
+++ b/test/unit/math/prim/scal/err/is_less_or_equal_test.cpp
@@ -1,0 +1,39 @@
+#include <stan/math/prim/scal.hpp>
+#include <gtest/gtest.h>
+#include <limits>
+
+using stan::math::is_less_or_equal;
+
+TEST(ErrorHandlingScalar, isLessOrEqual) {
+  double x = -10.0;
+  double lb = 0.0;
+
+  EXPECT_TRUE(is_less_or_equal(x, lb));
+
+  x = 1.0;
+  EXPECT_FALSE(is_less_or_equal(x, lb));
+
+  x = lb;
+  EXPECT_TRUE(is_less_or_equal(x, lb));
+
+  x = -std::numeric_limits<double>::infinity();
+  EXPECT_TRUE(is_less_or_equal(x, lb));
+
+  x = -10.0;
+  lb = -std::numeric_limits<double>::infinity();
+  EXPECT_FALSE(is_less_or_equal(x, lb));
+
+  x = -std::numeric_limits<double>::infinity();
+  lb = -std::numeric_limits<double>::infinity();
+  EXPECT_TRUE(is_less_or_equal(x, lb));
+}
+
+TEST(ErrorHandlingScalar, isLessOrEqual_nan) {
+  double x = 10.0;
+  double lb = 0.0;
+  double nan = std::numeric_limits<double>::quiet_NaN();
+
+  EXPECT_FALSE(is_less_or_equal(nan, lb));
+  EXPECT_FALSE(is_less_or_equal(x, nan));
+  EXPECT_FALSE(is_less_or_equal(nan, nan));
+}

--- a/test/unit/math/prim/scal/err/is_not_nan_test.cpp
+++ b/test/unit/math/prim/scal/err/is_not_nan_test.cpp
@@ -1,0 +1,20 @@
+#include <stan/math/prim/scal.hpp>
+#include <gtest/gtest.h>
+#include <limits>
+
+using stan::math::is_not_nan;
+
+TEST(ErrorHandlingScalar, isNotNan) {
+  double x = 0;
+
+  EXPECT_TRUE(is_not_nan(x));
+
+  x = std::numeric_limits<double>::infinity();
+  EXPECT_TRUE(is_not_nan(x));
+
+  x = -std::numeric_limits<double>::infinity();
+  EXPECT_TRUE(is_not_nan(x));
+
+  x = std::numeric_limits<double>::quiet_NaN();
+  EXPECT_FALSE(is_not_nan(x));
+}

--- a/test/unit/math/prim/scal/err/is_positive_size_test.cpp
+++ b/test/unit/math/prim/scal/err/is_positive_size_test.cpp
@@ -1,0 +1,14 @@
+#include <stan/math/prim/scal.hpp>
+#include <gtest/gtest.h>
+#include <test/unit/util.hpp>
+#include <string>
+
+TEST(ErrorHandlingScalar, isPositiveSize) {
+  using stan::math::is_positive_size;
+
+  EXPECT_TRUE(is_positive_size(10));
+
+  EXPECT_FALSE(is_positive_size(0));
+
+  EXPECT_FALSE(is_positive_size(-1));
+}

--- a/test/unit/math/prim/scal/err/is_positive_test.cpp
+++ b/test/unit/math/prim/scal/err/is_positive_test.cpp
@@ -1,0 +1,14 @@
+#include <stan/math/prim/scal.hpp>
+#include <gtest/gtest.h>
+#include <limits>
+
+TEST(ErrorHandlingScalar, isPositive) {
+  using stan::math::is_positive;
+  EXPECT_TRUE(is_positive(3.0));
+}
+
+TEST(ErrorHandlingScalar, isPositive_nan) {
+  using stan::math::is_positive;
+  double nan = std::numeric_limits<double>::quiet_NaN();
+  EXPECT_FALSE(is_positive(nan));
+}

--- a/test/unit/math/prim/scal/err/is_scal_finite_test.cpp
+++ b/test/unit/math/prim/scal/err/is_scal_finite_test.cpp
@@ -1,0 +1,24 @@
+#include <stan/math/prim/scal.hpp>
+#include <gtest/gtest.h>
+#include <limits>
+
+using stan::math::is_scal_finite;
+
+TEST(ErrorHandlingScalar, isScalFinite) {
+  double x = 0;
+  EXPECT_TRUE(is_scal_finite(x));
+
+  x = std::numeric_limits<double>::infinity();
+  EXPECT_FALSE(is_scal_finite(x));
+
+  x = -std::numeric_limits<double>::infinity();
+  EXPECT_FALSE(is_scal_finite(x));
+
+  x = std::numeric_limits<double>::quiet_NaN();
+  EXPECT_FALSE(is_scal_finite(x));
+}
+
+TEST(ErrorHandlingScalar, isScalFinite_nan) {
+  double nan = std::numeric_limits<double>::quiet_NaN();
+  EXPECT_FALSE(is_scal_finite(nan));
+}


### PR DESCRIPTION
## Summary

Adds test functions with bool return statements rather then calling `domain_error` like existing `check_*` functions. These functions are being deployed to help improve developer productivity when building new features in `stan-dev/math`.

https://github.com/stan-dev/math/issues/50

Complements an earlier PR with further development in `./prim/mat/err/` and `./prim/scal/err` and related `test` files. There is another batch still in progress. Once this phase is completed a review of the `check_*` functions will commence looking into incorporating the `is_*` functions in a way which improves those `domain_error` calling functions messages. For example `scal/err/check_positive` will be updated to use `scal/err/is_positive` in a future PR.

This PR is not exhaustive to the completion of Issue #50. There are 19 `is_*` functions in this PR and another 20 remaining  for full replication of the `check_*` functions. It is intended that they will be debugged and pushed in a future PR ideally to limit size of each PR. Largely the rest of these `is_*` functions are complete pending integration of the headers and test cases (both factors which postponed this PR). 

Some of the files touched in this PR may not be directly related to the `is_*` functions being created and are limited minor syntax alterations. This is an ongoing process.   

## Tests

Each function included has its own test file modeled off the existing tests used for the check functions. In my environment all of these replicated tests pass as expected. 

## Side Effects

None applicable.

## Checklist

- [x] Math issue #(50)

- [x] Copyright holder: (Same as source)

- [x] the basic tests are passing

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested