### PR TITLE
Feature/issue 1142 Remove padding from OpenCL general matrix multiply

### DIFF
--- a/stan/math/opencl/kernels/matrix_multiply.hpp
+++ b/stan/math/opencl/kernels/matrix_multiply.hpp
@@ -81,7 +81,7 @@ static const char* matrix_multiply_kernel_code = STRINGIFY(
           // the diagonal if the matrix is upper triangular
           const A_temp_j = tiled_j + w * THREAD_BLOCK_SIZE_COL;
           const B_temp_j = j + w * THREAD_BLOCK_SIZE_COL;
-          if((tiled_j + w * THREAD_BLOCK_SIZE_COL) >= K && i >= M
+          if((tiled_j + w * THREAD_BLOCK_SIZE_COL) >= K || i >= M
              || (lower_upper_A == LOWER && A_temp_j > i)
              || (lower_upper_A == UPPER && A_temp_j < i)) {
             A_local[thread_block_col + w * THREAD_BLOCK_SIZE_COL]
@@ -91,7 +91,7 @@ static const char* matrix_multiply_kernel_code = STRINGIFY(
                   [thread_block_row]
                 = A[A_temp_j * M + i];
           }
-          if(B_temp_j >= N && tiled_i >= K
+          if(B_temp_j >= N || tiled_i >= K
              || (lower_upper_B == LOWER && B_temp_j > tiled_i)
              || (lower_upper_B == UPPER && B_temp_j < tiled_i)) {
             B_local[thread_block_col + w * THREAD_BLOCK_SIZE_COL]

--- a/stan/math/opencl/kernels/matrix_multiply.hpp
+++ b/stan/math/opencl/kernels/matrix_multiply.hpp
@@ -84,24 +84,26 @@ static const char* matrix_multiply_kernel_code = STRINGIFY(
           // check if the indexes are outside the matrix
           // or under/above the diagonal with upper/lower
           // triangular matrices
-          if(A_temp_j >= K || i >= M
-             || (lower_upper_A == LOWER && A_temp_j > i)
-             || (lower_upper_A == UPPER && A_temp_j < i)) {
+          if (A_temp_j >= K || i >= M
+              || (lower_upper_A == LOWER && A_temp_j > i)
+              || (lower_upper_A == UPPER && A_temp_j < i)) {
             A_local[thread_block_col + w * THREAD_BLOCK_SIZE_COL]
-                 [thread_block_row] = 0.0;
+                   [thread_block_row]
+                = 0.0;
           } else {
             A_local[thread_block_col + w * THREAD_BLOCK_SIZE_COL]
-                  [thread_block_row]
+                   [thread_block_row]
                 = A[A_temp_j * M + i];
           }
-          if(B_temp_j >= N || tiled_i >= K
-             || (lower_upper_B == LOWER && B_temp_j > tiled_i)
-             || (lower_upper_B == UPPER && B_temp_j < tiled_i)) {
+          if (B_temp_j >= N || tiled_i >= K
+              || (lower_upper_B == LOWER && B_temp_j > tiled_i)
+              || (lower_upper_B == UPPER && B_temp_j < tiled_i)) {
             B_local[thread_block_col + w * THREAD_BLOCK_SIZE_COL]
-                  [thread_block_row] = 0.0;
+                   [thread_block_row]
+                = 0.0;
           } else {
             B_local[thread_block_col + w * THREAD_BLOCK_SIZE_COL]
-                  [thread_block_row]
+                   [thread_block_row]
                 = B[B_temp_j * K + tiled_i];
           }
         }
@@ -121,7 +123,7 @@ static const char* matrix_multiply_kernel_code = STRINGIFY(
         // padded threads should not access C
         if ((j + w * THREAD_BLOCK_SIZE_COL) < N && i < M) {
           C[(j + w * THREAD_BLOCK_SIZE_COL) * M + i] = acc[w];
-        }        
+        }
       }
     }
     // \cond

--- a/stan/math/opencl/kernels/matrix_multiply.hpp
+++ b/stan/math/opencl/kernels/matrix_multiply.hpp
@@ -79,32 +79,32 @@ static const char* matrix_multiply_kernel_code = STRINGIFY(
           // For the tiles on the diagonal we can ignore the values over
           // the diagonal if the matrix is lower triangular or under
           // the diagonal if the matrix is upper triangular
-          const A_temp_j = tiled_j + w * THREAD_BLOCK_SIZE_COL;
-          const B_temp_j = j + w * THREAD_BLOCK_SIZE_COL;
+          const A_curr_j = tiled_j + w * THREAD_BLOCK_SIZE_COL;
+          const B_curr_j = j + w * THREAD_BLOCK_SIZE_COL;
           // check if the indexes are outside the matrix
           // or under/above the diagonal with upper/lower
           // triangular matrices
-          if (A_temp_j >= K || i >= M
-              || (lower_upper_A == LOWER && A_temp_j > i)
-              || (lower_upper_A == UPPER && A_temp_j < i)) {
+          if (A_curr_j >= K || i >= M
+              || (lower_upper_A == LOWER && A_curr_j > i)
+              || (lower_upper_A == UPPER && A_curr_j < i)) {
             A_local[thread_block_col + w * THREAD_BLOCK_SIZE_COL]
                    [thread_block_row]
                 = 0.0;
           } else {
             A_local[thread_block_col + w * THREAD_BLOCK_SIZE_COL]
                    [thread_block_row]
-                = A[A_temp_j * M + i];
+                = A[A_curr_j * M + i];
           }
-          if (B_temp_j >= N || tiled_i >= K
-              || (lower_upper_B == LOWER && B_temp_j > tiled_i)
-              || (lower_upper_B == UPPER && B_temp_j < tiled_i)) {
+          if (B_curr_j >= N || tiled_i >= K
+              || (lower_upper_B == LOWER && B_curr_j > tiled_i)
+              || (lower_upper_B == UPPER && B_curr_j < tiled_i)) {
             B_local[thread_block_col + w * THREAD_BLOCK_SIZE_COL]
                    [thread_block_row]
                 = 0.0;
           } else {
             B_local[thread_block_col + w * THREAD_BLOCK_SIZE_COL]
                    [thread_block_row]
-                = B[B_temp_j * K + tiled_i];
+                = B[B_curr_j * K + tiled_i];
           }
         }
         barrier(CLK_LOCAL_MEM_FENCE);

--- a/stan/math/opencl/kernels/matrix_multiply.hpp
+++ b/stan/math/opencl/kernels/matrix_multiply.hpp
@@ -117,10 +117,13 @@ static const char* matrix_multiply_kernel_code = STRINGIFY(
         }
         barrier(CLK_LOCAL_MEM_FENCE);
       }
-      // save the values
+      // each thread saves WORK_PER_THREAD values
       for (int w = 0; w < WORK_PER_THREAD; w++) {
-        // each thread saves WORK_PER_THREAD values
-        // padded threads should not access C
+        // This prevents threads from accessing elements 
+        // outside the allocated memory for C. The check
+        // is in the loop because some threads
+        // can be assigned elements in and out of
+        // the allocated memory.
         if ((j + w * THREAD_BLOCK_SIZE_COL) < N && i < M) {
           C[(j + w * THREAD_BLOCK_SIZE_COL) * M + i] = acc[w];
         }

--- a/stan/math/opencl/kernels/matrix_multiply.hpp
+++ b/stan/math/opencl/kernels/matrix_multiply.hpp
@@ -119,7 +119,7 @@ static const char* matrix_multiply_kernel_code = STRINGIFY(
       }
       // each thread saves WORK_PER_THREAD values
       for (int w = 0; w < WORK_PER_THREAD; w++) {
-        // This prevents threads from accessing elements 
+        // This prevents threads from accessing elements
         // outside the allocated memory for C. The check
         // is in the loop because some threads
         // can be assigned elements in and out of

--- a/stan/math/opencl/kernels/matrix_multiply.hpp
+++ b/stan/math/opencl/kernels/matrix_multiply.hpp
@@ -81,7 +81,10 @@ static const char* matrix_multiply_kernel_code = STRINGIFY(
           // the diagonal if the matrix is upper triangular
           const A_temp_j = tiled_j + w * THREAD_BLOCK_SIZE_COL;
           const B_temp_j = j + w * THREAD_BLOCK_SIZE_COL;
-          if((tiled_j + w * THREAD_BLOCK_SIZE_COL) >= K || i >= M
+          // check if the indexes are outside the matrix
+          // or under/above the diagonal with upper/lower
+          // triangular matrices
+          if(A_temp_j >= K || i >= M
              || (lower_upper_A == LOWER && A_temp_j > i)
              || (lower_upper_A == UPPER && A_temp_j < i)) {
             A_local[thread_block_col + w * THREAD_BLOCK_SIZE_COL]
@@ -115,6 +118,7 @@ static const char* matrix_multiply_kernel_code = STRINGIFY(
       // save the values
       for (int w = 0; w < WORK_PER_THREAD; w++) {
         // each thread saves WORK_PER_THREAD values
+        // padded threads should not access C
         if ((j + w * THREAD_BLOCK_SIZE_COL) < N && i < M) {
           C[(j + w * THREAD_BLOCK_SIZE_COL) * M + i] = acc[w];
         }        

--- a/stan/math/opencl/kernels/multiply_transpose.hpp
+++ b/stan/math/opencl/kernels/multiply_transpose.hpp
@@ -94,7 +94,7 @@ static const char* multiply_transpose_kernel_code = STRINGIFY(
         // save the values
         for (int w = 0; w < WORK_PER_THREAD; w++) {
           // padded threads should not access B
-          if ((j + w * THREAD_BLOCK_SIZE_COL) < N && i < M) {
+          if ((j + w * THREAD_BLOCK_SIZE_COL) < M && i < M) {
             // each thread saves WORK_PER_THREAD values
             if ((j + w * THREAD_BLOCK_SIZE_COL) <= i) {
               B[i + (j + w * THREAD_BLOCK_SIZE_COL) * M] = acc[w];

--- a/stan/math/opencl/kernels/multiply_transpose.hpp
+++ b/stan/math/opencl/kernels/multiply_transpose.hpp
@@ -52,7 +52,6 @@ static const char* multiply_transpose_kernel_code = STRINGIFY(
           const int tiled_i = THREAD_BLOCK_SIZE * tile_ind + thread_block_row;
           const int tiled_j = THREAD_BLOCK_SIZE * tile_ind + thread_block_col;
           // if the data needs to be loaded to local memory
-
           // each thread copies WORK_PER_THREAD values to the
           // local memory
           for (int w = 0; w < WORK_PER_THREAD; w++) {

--- a/stan/math/opencl/kernels/multiply_transpose.hpp
+++ b/stan/math/opencl/kernels/multiply_transpose.hpp
@@ -56,14 +56,25 @@ static const char* multiply_transpose_kernel_code = STRINGIFY(
           // each thread copies WORK_PER_THREAD values to the
           // local memory
           for (int w = 0; w < WORK_PER_THREAD; w++) {
-            A_local[thread_block_col + w * THREAD_BLOCK_SIZE_COL]
-                   [thread_block_row]
-                = A[i + (tiled_j + w * THREAD_BLOCK_SIZE_COL) * M];
-            B_local[thread_block_col + w * THREAD_BLOCK_SIZE_COL]
-                   [thread_block_row]
-                = A[(j + w * THREAD_BLOCK_SIZE_COL) + tiled_i * M];
+            const A_temp_j = tiled_j + w * THREAD_BLOCK_SIZE_COL;
+            const AT_temp_j = j + w * THREAD_BLOCK_SIZE_COL;
+            if(A_temp_j >= N || i >= M) {
+              A_local[thread_block_col + w * THREAD_BLOCK_SIZE_COL]
+                    [thread_block_row] = 0.0;
+            } else {
+              A_local[thread_block_col + w * THREAD_BLOCK_SIZE_COL]
+                    [thread_block_row]
+                  = A[A_temp_j * M + i];
+            }
+            if(AT_temp_j >= M || tiled_i >= N) {
+              B_local[thread_block_col + w * THREAD_BLOCK_SIZE_COL]
+                    [thread_block_row] = 0.0;
+            } else {
+              B_local[thread_block_col + w * THREAD_BLOCK_SIZE_COL]
+                    [thread_block_row]
+                  =  A[AT_temp_j + tiled_i * M];
+            }
           }
-
           // wait till all tile values are loaded to the local memory
           barrier(CLK_LOCAL_MEM_FENCE);
           // multiply the tile products
@@ -81,10 +92,13 @@ static const char* multiply_transpose_kernel_code = STRINGIFY(
         }
         // save the values
         for (int w = 0; w < WORK_PER_THREAD; w++) {
-          // each thread saves WORK_PER_THREAD values
-          if ((j + w * THREAD_BLOCK_SIZE_COL) <= i) {
-            B[i + (j + w * THREAD_BLOCK_SIZE_COL) * M] = acc[w];
-            B[(j + w * THREAD_BLOCK_SIZE_COL) + i * M] = acc[w];
+          // padded threads should not access B
+          if ((j + w * THREAD_BLOCK_SIZE_COL) < N && i < M) {
+            // each thread saves WORK_PER_THREAD values
+            if ((j + w * THREAD_BLOCK_SIZE_COL) <= i) {
+              B[i + (j + w * THREAD_BLOCK_SIZE_COL) * M] = acc[w];
+              B[(j + w * THREAD_BLOCK_SIZE_COL) + i * M] = acc[w];
+            }
           }
         }
       }

--- a/stan/math/opencl/kernels/multiply_transpose.hpp
+++ b/stan/math/opencl/kernels/multiply_transpose.hpp
@@ -93,12 +93,12 @@ static const char* multiply_transpose_kernel_code = STRINGIFY(
         }
         // each thread saves WORK_PER_THREAD values to C
         for (int w = 0; w < WORK_PER_THREAD; w++) {
-        // This prevents threads from accessing elements 
-        // outside the allocated memory for C. The check
-        // is in the loop because some threads
-        // can be assigned elements in and out of
-        // the allocated memory.
-          if ((j + w * THREAD_BLOCK_SIZE_COL) < M && i < M) {            
+          // This prevents threads from accessing elements
+          // outside the allocated memory for C. The check
+          // is in the loop because some threads
+          // can be assigned elements in and out of
+          // the allocated memory.
+          if ((j + w * THREAD_BLOCK_SIZE_COL) < M && i < M) {
             if ((j + w * THREAD_BLOCK_SIZE_COL) <= i) {
               B[i + (j + w * THREAD_BLOCK_SIZE_COL) * M] = acc[w];
               B[(j + w * THREAD_BLOCK_SIZE_COL) + i * M] = acc[w];

--- a/stan/math/opencl/kernels/multiply_transpose.hpp
+++ b/stan/math/opencl/kernels/multiply_transpose.hpp
@@ -91,11 +91,14 @@ static const char* multiply_transpose_kernel_code = STRINGIFY(
           }
           barrier(CLK_LOCAL_MEM_FENCE);
         }
-        // save the values
+        // each thread saves WORK_PER_THREAD values to C
         for (int w = 0; w < WORK_PER_THREAD; w++) {
-          // padded threads should not access B
-          if ((j + w * THREAD_BLOCK_SIZE_COL) < M && i < M) {
-            // each thread saves WORK_PER_THREAD values
+        // This prevents threads from accessing elements 
+        // outside the allocated memory for C. The check
+        // is in the loop because some threads
+        // can be assigned elements in and out of
+        // the allocated memory.
+          if ((j + w * THREAD_BLOCK_SIZE_COL) < M && i < M) {            
             if ((j + w * THREAD_BLOCK_SIZE_COL) <= i) {
               B[i + (j + w * THREAD_BLOCK_SIZE_COL) * M] = acc[w];
               B[(j + w * THREAD_BLOCK_SIZE_COL) + i * M] = acc[w];

--- a/stan/math/opencl/kernels/multiply_transpose.hpp
+++ b/stan/math/opencl/kernels/multiply_transpose.hpp
@@ -57,21 +57,23 @@ static const char* multiply_transpose_kernel_code = STRINGIFY(
           for (int w = 0; w < WORK_PER_THREAD; w++) {
             const A_temp_j = tiled_j + w * THREAD_BLOCK_SIZE_COL;
             const AT_temp_j = j + w * THREAD_BLOCK_SIZE_COL;
-            if(A_temp_j >= N || i >= M) {
+            if (A_temp_j >= N || i >= M) {
               A_local[thread_block_col + w * THREAD_BLOCK_SIZE_COL]
-                    [thread_block_row] = 0.0;
+                     [thread_block_row]
+                  = 0.0;
             } else {
               A_local[thread_block_col + w * THREAD_BLOCK_SIZE_COL]
-                    [thread_block_row]
+                     [thread_block_row]
                   = A[A_temp_j * M + i];
             }
-            if(AT_temp_j >= M || tiled_i >= N) {
+            if (AT_temp_j >= M || tiled_i >= N) {
               B_local[thread_block_col + w * THREAD_BLOCK_SIZE_COL]
-                    [thread_block_row] = 0.0;
+                     [thread_block_row]
+                  = 0.0;
             } else {
               B_local[thread_block_col + w * THREAD_BLOCK_SIZE_COL]
-                    [thread_block_row]
-                  =  A[AT_temp_j + tiled_i * M];
+                     [thread_block_row]
+                  = A[AT_temp_j + tiled_i * M];
             }
           }
           // wait till all tile values are loaded to the local memory

--- a/stan/math/opencl/multiply.hpp
+++ b/stan/math/opencl/multiply.hpp
@@ -46,8 +46,8 @@ inline auto multiply(const matrix_cl& A, const matrix_cl& B) {
   try {
     opencl_kernels::matrix_multiply(
         cl::NDRange(Mpad, Npad / wpt), cl::NDRange(local, local / wpt),
-        A.buffer(), B.buffer(), temp.buffer(), A.rows(),
-        B.cols(), B.rows(), triangular_view_A, triangular_view_B);
+        A.buffer(), B.buffer(), temp.buffer(), A.rows(), B.cols(), B.rows(),
+        triangular_view_A, triangular_view_B);
   } catch (cl::Error& e) {
     check_opencl_error("multiply", e);
   }

--- a/stan/math/opencl/multiply.hpp
+++ b/stan/math/opencl/multiply.hpp
@@ -41,32 +41,16 @@ inline auto multiply(const matrix_cl& A, const matrix_cl& B) {
       "THREAD_BLOCK_SIZE");
   int Mpad = ((A.rows() + local - 1) / local) * local;
   int Npad = ((B.cols() + local - 1) / local) * local;
-  int Kpad = ((A.cols() + local - 1) / local) * local;
-  // padding the matrices so the dimensions are divisible with local
-  // improves performance and readability because we can omit
-  // if statements in the
-  // multiply kernel
-  matrix_cl tempPad(Mpad, Npad);
-  matrix_cl Apad(Mpad, Kpad);
-  matrix_cl Bpad(Kpad, Npad);
-  opencl_kernels::zeros(cl::NDRange(Mpad, Kpad), Apad.buffer(), Mpad, Kpad,
-                        TriangularViewCL::Entire);
-  opencl_kernels::zeros(cl::NDRange(Kpad, Npad), Bpad.buffer(), Kpad, Npad,
-                        TriangularViewCL::Entire);
-  Apad.sub_block<triangular_view_A>(A, 0, 0, 0, 0, A.rows(), A.cols());
-  Bpad.sub_block<triangular_view_B>(B, 0, 0, 0, 0, B.rows(), B.cols());
   int wpt = opencl_kernels::matrix_multiply.make_functor.get_opts().at(
       "WORK_PER_THREAD");
   try {
     opencl_kernels::matrix_multiply(
         cl::NDRange(Mpad, Npad / wpt), cl::NDRange(local, local / wpt),
-        Apad.buffer(), Bpad.buffer(), tempPad.buffer(), Apad.rows(),
-        Bpad.cols(), Bpad.rows(), triangular_view_A, triangular_view_B);
+        A.buffer(), B.buffer(), temp.buffer(), A.rows(),
+        B.cols(), B.rows(), triangular_view_A, triangular_view_B);
   } catch (cl::Error& e) {
     check_opencl_error("multiply", e);
   }
-  // unpadding the result matrix
-  temp.sub_block(tempPad, 0, 0, 0, 0, temp.rows(), temp.cols());
   return temp;
 }
 }  // namespace opencl

--- a/stan/math/opencl/multiply_transpose.hpp
+++ b/stan/math/opencl/multiply_transpose.hpp
@@ -27,22 +27,15 @@ inline matrix_cl multiply_transpose(const matrix_cl& A) {
   int local = opencl_kernels::multiply_transpose.make_functor.get_opts().at(
       "THREAD_BLOCK_SIZE");
   int Mpad = ((A.rows() + local - 1) / local) * local;
-  int Npad = ((A.cols() + local - 1) / local) * local;
-  matrix_cl tempPad(Mpad, Mpad);
-  matrix_cl Apad(Mpad, Npad);
-  opencl_kernels::zeros(cl::NDRange(Mpad, Npad), Apad.buffer(), Mpad, Npad,
-                        TriangularViewCL::Entire);
-  Apad.sub_block(A, 0, 0, 0, 0, A.rows(), A.cols());
   int wpt = opencl_kernels::multiply_transpose.make_functor.get_opts().at(
       "WORK_PER_THREAD");
   try {
     opencl_kernels::multiply_transpose(
         cl::NDRange(Mpad, Mpad / wpt), cl::NDRange(local, local / wpt),
-        Apad.buffer(), tempPad.buffer(), Apad.rows(), Apad.cols());
+        A.buffer(), temp.buffer(), A.rows(), A.cols());
   } catch (cl::Error& e) {
     check_opencl_error("multiply self transpose", e);
   }
-  temp.sub_block(tempPad, 0, 0, 0, 0, temp.rows(), temp.cols());
   return temp;
 }
 }  // namespace math

--- a/test/unit/math/opencl/multiply_test.cpp
+++ b/test/unit/math/opencl/multiply_test.cpp
@@ -223,7 +223,6 @@ TEST(MathMatrix, upper_tri_rect_multiply_small) {
   auto m2 = stan::math::matrix_d::Random(3, 3).eval();
   stan::math::matrix_d m3_cl_res(3, 3);
 
-  
   stan::math::matrix_cl m11(m1);
   m1.triangularView<Eigen::StrictlyLower>().setZero();
   stan::math::matrix_cl m22(m2);

--- a/test/unit/math/opencl/multiply_test.cpp
+++ b/test/unit/math/opencl/multiply_test.cpp
@@ -223,9 +223,9 @@ TEST(MathMatrix, upper_tri_rect_multiply_small) {
   auto m2 = stan::math::matrix_d::Random(3, 3).eval();
   stan::math::matrix_d m3_cl_res(3, 3);
 
-  m1.triangularView<Eigen::StrictlyLower>().setZero();
-
+  
   stan::math::matrix_cl m11(m1);
+  m1.triangularView<Eigen::StrictlyLower>().setZero();
   stan::math::matrix_cl m22(m2);
 
   auto m3 = (m1 * m2).eval();
@@ -265,9 +265,8 @@ TEST(MathMatrix, upper_tri_rect_multiply_big_rect) {
   auto m2 = stan::math::matrix_d::Random(size, size * 3).eval();
   stan::math::matrix_d m3_cl_res(size, size * 3);
 
-  m1.triangularView<Eigen::StrictlyLower>().setZero();
-
   stan::math::matrix_cl m11(m1);
+  m1.triangularView<Eigen::StrictlyLower>().setZero();
   stan::math::matrix_cl m22(m2);
 
   auto m3 = (m1 * m2).eval();
@@ -329,10 +328,10 @@ TEST(MathMatrix, rect_lower_tri_multiply_big_rect) {
   auto m2 = stan::math::matrix_d::Random(size, size * 3).eval();
   stan::math::matrix_d m3_cl_res(size, size * 3);
 
-  m2.triangularView<Eigen::StrictlyUpper>().setZero();
-
   stan::math::matrix_cl m11(m1);
   stan::math::matrix_cl m22(m2);
+
+  m2.triangularView<Eigen::StrictlyUpper>().setZero();
 
   auto m3 = (m1 * m2).eval();
 

--- a/test/unit/math/opencl/multiply_transpose_test.cpp
+++ b/test/unit/math/opencl/multiply_transpose_test.cpp
@@ -103,4 +103,24 @@ TEST(AgradRevMatrix, multiply_transposed_big_non_square) {
   EXPECT_MATRIX_NEAR(m2, m2_gpu, 1e-10);
 }
 
+TEST(AgradRevMatrix, multiply_transposed_big_x) {
+  using stan::math::multiply;
+  stan::math::matrix_d m2, m2_gpu;
+
+  int size_x = 200;
+  int size_y = 50;
+  auto m1 = stan::math::matrix_d::Random(size_x, size_y).eval();
+  m2.resize(size_x, size_x);
+  m2_gpu.resize(size_x, size_x);
+
+  m2 = m1 * m1.transpose();
+
+  stan::math::matrix_cl m11(m1);
+  stan::math::matrix_cl m22(size_x, size_x);
+  m22 = stan::math::multiply_transpose(m11);
+  stan::math::copy(m2_gpu, m22);
+
+  EXPECT_MATRIX_NEAR(m2, m2_gpu, 1e-10);
+}
+
 #endif


### PR DESCRIPTION
## Summary

This PR removes the use of padding for the input and output matrices in the general matrix multiplication and multiply transpose. Padding was used mainly to simplify the code and provide some performances boosts with large matrices. 

Benchmarks shown below indicate that removing the padding  reduces the execution time for smaller matrices to about 45% and that the execution time increases for 5% at maximum for large matrices. But for that 5% of execution time with padding we actually more than double the memory footprint. Which to me is not a worthy sacrifice. 

The performance loss is smaller for rectangular input matrices that suppose to come up more often in matrix multiplications in Stan (as far as I know, there was some discussion on Discourse some time ago). 

At square matrix multiplication with N=10000 the loss is 1.5%, at rectangular matrix multiply [4000, 24000] x [24000, 4000] that has similar sized matrices, the loss is around 0.8% (see [rect_mult_padding_perf.txt](https://github.com/stan-dev/math/files/3000540/rect_mult_padding_perf.txt)). 

Removing padding will also enable easier optimizations for multiplications of rectangular matrices where the common dimension is larger: [N, K] x [K, M] where K >>> N,M; the extreme cases of this are matrix x row_vector or vector x matrix, otherwise for example [500, 10000] x [10000 x 10]. I managed to get around 20%-50% reduction in those cases (will open once this PR gets merged, if it does).

Will post the same results on a Windows machine with and AMD GPU. The V100 AWS gives comparable results to the presented that were obtained on an Ubuntu system with the TitanXP.

Benchmark results:
```
Padding:
------------------------------------------------------------
Benchmark                     Time           CPU Iterations
------------------------------------------------------------
BM_square_mult/100       117878 ns     117880 ns       5403
BM_square_mult/200       172075 ns     172073 ns       4028
BM_square_mult/300       687443 ns     686188 ns       1003
BM_square_mult/400      1287351 ns    1285840 ns        540
BM_square_mult/500      1704510 ns    1701650 ns        409
BM_square_mult/600      2479740 ns    2477277 ns        280
BM_square_mult/700      3135085 ns    3131587 ns        224
BM_square_mult/800      4299533 ns    4297548 ns        163
BM_square_mult/900      6151174 ns    6145165 ns        110
BM_square_mult/1000     7500103 ns    7498104 ns         92
BM_square_mult/2000    49935540 ns   49907178 ns         14
BM_square_mult/3000   158138707 ns  158139698 ns          5
BM_square_mult/4000   377430860 ns  377441717 ns          2
BM_square_mult/5000   703299608 ns  703224491 ns          1
BM_square_mult/6000  1205413056 ns 1205430843 ns          1
BM_square_mult/7000  1899133406 ns 1898768774 ns          1
BM_square_mult/8000  2821377736 ns 2821007537 ns          1
BM_square_mult/9000  4041553169 ns 4040393951 ns          1
BM_square_mult/10000 5583241541 ns 5581643557 ns          1
BM_square_mult/12000 9695023441 ns 9693572307 ns          1
BM_square_mult/14000 15454004596 ns 15451043311 ns          1

No padding:
------------------------------------------------------------
Benchmark                     Time           CPU Iterations
------------------------------------------------------------
BM_square_mult/100        50532 ns      50498 ns      11740
BM_square_mult/200       101143 ns     101145 ns       6830
BM_square_mult/300       245366 ns     245226 ns       2849
BM_square_mult/400       624087 ns     623715 ns       1095
BM_square_mult/500      1055132 ns    1054575 ns        657
BM_square_mult/600      1544709 ns    1543279 ns        450
BM_square_mult/700      2306728 ns    2305893 ns        304
BM_square_mult/800      3314078 ns    3311070 ns        212
BM_square_mult/900      5022115 ns    5021233 ns        136
BM_square_mult/1000     6382371 ns    6377514 ns        108
BM_square_mult/2000    47042385 ns   47042352 ns         15
BM_square_mult/3000   156150004 ns  155448507 ns          5
BM_square_mult/4000   360692166 ns  360493414 ns          2
BM_square_mult/5000   711667850 ns  711671852 ns          1
BM_square_mult/6000  1217096868 ns 1216713130 ns          1
BM_square_mult/7000  1924372568 ns 1923841980 ns          1
BM_square_mult/8000  2963520069 ns 2963505009 ns          1
BM_square_mult/9000  4354807345 ns 4354897041 ns          1
BM_square_mult/10000 5857150628 ns 5857236273 ns          1
BM_square_mult/12000 9789256097 ns 9789489058 ns          1
BM_square_mult/14000 15648197309 ns 15647315947 ns          1
```

## Tests

Run `/opencl/multiply_test.cpp` and `/opencl/multiply_transpose.cpp`. 

This PR expands test coverage for triangular multiplication when the input is not zeroed-out.

## Side Effects

Some performance loss in larger matrix multiplications for the sake of smaller memory footprint.
The kernel for general matrix multiply is also a bit more complex now.

## Checklist

- [x] Math issue #1142 

- [x] Copyright holder: Rok Češnovar, Univ. of Ljubljana

- [x] the basic tests are passing

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
