### PR TITLE
Fix typo "Probabilites" to "Probabilities"

### DIFF
--- a/stan/math/prim/mat/prob/multinomial_lpmf.hpp
+++ b/stan/math/prim/mat/prob/multinomial_lpmf.hpp
@@ -28,7 +28,7 @@ typename boost::math::tools::promote_args<T_prob>::type multinomial_lpmf(
 
   typename promote_args<T_prob>::type lp(0.0);
   check_nonnegative(function, "Number of trials variable", ns);
-  check_simplex(function, "Probabilites parameter", theta);
+  check_simplex(function, "Probabilities parameter", theta);
   check_size_match(function, "Size of number of trials variable", ns.size(),
                    "rows of probabilities parameter", theta.rows());
 

--- a/stan/math/prim/mat/prob/multinomial_rng.hpp
+++ b/stan/math/prim/mat/prob/multinomial_rng.hpp
@@ -22,7 +22,7 @@ inline std::vector<int> multinomial_rng(
     const Eigen::Matrix<double, Eigen::Dynamic, 1>& theta, int N, RNG& rng) {
   static const char* function = "multinomial_rng";
 
-  check_simplex(function, "Probabilites parameter", theta);
+  check_simplex(function, "Probabilities parameter", theta);
   check_positive(function, "number of trials variables", N);
 
   std::vector<int> result(theta.size(), 0);


### PR DESCRIPTION
## Summary

Fixes typos in multinomial lpdf and rng (https://github.com/stan-dev/math/issues/1174)

## Tests

No changes in tests.

## Side Effects

Output messages have changed to fix a typo, but nothing should be keyed off of the text of an error message.

## Checklist

- [ ] Math issue #1174 

- [ ] Copyright holder: Jouni Helske

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [ ] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [ ] the code is written in idiomatic C++ and changes are documented in the doxygen

- [ ] the new changes are tested
