### PR TITLE
feature/issue 1122 Add missing metaprogram tests

### DIFF
--- a/test/unit/math/fwd/scal/meta/is_fvar_test.cpp
+++ b/test/unit/math/fwd/scal/meta/is_fvar_test.cpp
@@ -1,0 +1,11 @@
+#include <stan/math/fwd/scal.hpp>
+#include <gtest/gtest.h>
+
+TEST(MetaTraits, is_fvar) {
+  using stan::is_fvar;
+  using stan::math::fvar;
+  EXPECT_TRUE(is_fvar<fvar<int>>::value);
+  EXPECT_TRUE(is_fvar<fvar<double>>::value);
+  EXPECT_TRUE(is_fvar<fvar<fvar<double>>>::value);
+  EXPECT_TRUE(is_fvar<fvar<fvar<fvar<double>>>>::value);
+}

--- a/test/unit/math/prim/arr/meta/index_type_test.cpp
+++ b/test/unit/math/prim/arr/meta/index_type_test.cpp
@@ -1,4 +1,4 @@
-#include <stan/math/prim/scal.hpp>
+#include <stan/math/prim/arr.hpp>
 #include <stan/math/prim/arr/meta/index_type.hpp>
 #include <test/unit/math/prim/scal/fun/promote_type_test_util.hpp>
 #include <gtest/gtest.h>

--- a/test/unit/math/prim/arr/meta/size_of_test.cpp
+++ b/test/unit/math/prim/arr/meta/size_of_test.cpp
@@ -1,0 +1,17 @@
+#include <stan/math/prim/arr.hpp>
+#include <gtest/gtest.h>
+#include <vector>
+#include <Eigen/Dense>
+
+TEST(MetaTraits, size_of) {
+  using stan::size_of;
+
+  std::vector<double> x2(3);
+  EXPECT_EQ(3U, size_of(x2));
+
+  std::vector<std::vector<double>> x3(6);
+  EXPECT_EQ(6U, size_of(x3));
+
+  std::vector<Eigen::MatrixXd> x4(8);
+  EXPECT_EQ(8U, size_of(x4));
+}

--- a/test/unit/math/prim/arr/meta/size_of_test.cpp
+++ b/test/unit/math/prim/arr/meta/size_of_test.cpp
@@ -1,7 +1,7 @@
 #include <stan/math/prim/arr.hpp>
 #include <gtest/gtest.h>
-#include <vector>
 #include <Eigen/Dense>
+#include <vector>
 
 TEST(MetaTraits, size_of) {
   using stan::size_of;

--- a/test/unit/math/prim/mat/meta/append_return_type_test.cpp
+++ b/test/unit/math/prim/mat/meta/append_return_type_test.cpp
@@ -1,0 +1,15 @@
+#include <stan/math/prim/mat.hpp>
+#include <gtest/gtest.h>
+#include <test/unit/util.hpp>
+#include <vector>
+
+
+using stan::math::append_return_type;
+
+TEST(MetaTraits, test_append_return_type) {
+  test::expect_same_type<int, append_return_type<int, int>::type>();
+  test::expect_same_type<double, append_return_type<double, double>::type>();
+  test::expect_same_type<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>,
+   append_return_type<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>,
+                      Eigen::Matrix<int, Eigen::Dynamic, Eigen::Dynamic>>::type>();
+}

--- a/test/unit/math/prim/mat/meta/append_return_type_test.cpp
+++ b/test/unit/math/prim/mat/meta/append_return_type_test.cpp
@@ -3,13 +3,14 @@
 #include <test/unit/util.hpp>
 #include <vector>
 
-
 using stan::math::append_return_type;
 
 TEST(MetaTraits, test_append_return_type) {
   test::expect_same_type<int, append_return_type<int, int>::type>();
   test::expect_same_type<double, append_return_type<double, double>::type>();
-  test::expect_same_type<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>,
-   append_return_type<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>,
-                      Eigen::Matrix<int, Eigen::Dynamic, Eigen::Dynamic>>::type>();
+  test::expect_same_type<
+      Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>,
+      append_return_type<
+          Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>,
+          Eigen::Matrix<int, Eigen::Dynamic, Eigen::Dynamic>>::type>();
 }

--- a/test/unit/math/prim/mat/meta/length_mvt_test.cpp
+++ b/test/unit/math/prim/mat/meta/length_mvt_test.cpp
@@ -1,0 +1,16 @@
+#include <stan/math/prim/mat.hpp>
+#include <gtest/gtest.h>
+#include <vector>
+
+TEST(MetaTraits, length_mvt) {
+  using stan::length_mvt;
+
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> x1(2, 3);
+  EXPECT_EQ(1U, length_mvt(x1));
+
+  std::vector<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>> x2(3);
+  EXPECT_EQ(3U, length_mvt(x2));
+
+  std::vector<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>> x3(7);
+  EXPECT_EQ(7U, length_mvt(x3));
+}

--- a/test/unit/math/prim/scal/meta/is_fvar_test.cpp
+++ b/test/unit/math/prim/scal/meta/is_fvar_test.cpp
@@ -1,0 +1,8 @@
+#include <stan/math/prim/scal.hpp>
+#include <gtest/gtest.h>
+
+TEST(MetaTraits, is_fvar) {
+  using stan::is_fvar;
+  EXPECT_FALSE(is_fvar<int>::value);
+  EXPECT_FALSE(is_fvar<double>::value);
+}

--- a/test/unit/math/prim/scal/meta/is_var_test.cpp
+++ b/test/unit/math/prim/scal/meta/is_var_test.cpp
@@ -1,0 +1,8 @@
+#include <stan/math/prim/scal.hpp>
+#include <gtest/gtest.h>
+
+TEST(MetaTraits, is_var) {
+  using stan::is_var;
+  EXPECT_FALSE(is_var<int>::value);
+  EXPECT_FALSE(is_var<double>::value);
+}

--- a/test/unit/math/prim/scal/meta/length_mvt_test.cpp
+++ b/test/unit/math/prim/scal/meta/length_mvt_test.cpp
@@ -10,5 +10,4 @@ TEST(MetaTraits, length_mvt) {
 
   int x2;
   EXPECT_THROW(length_mvt(x2), std::invalid_argument);
-
 }

--- a/test/unit/math/prim/scal/meta/length_mvt_test.cpp
+++ b/test/unit/math/prim/scal/meta/length_mvt_test.cpp
@@ -1,0 +1,14 @@
+#include <stan/math/prim/mat.hpp>
+#include <gtest/gtest.h>
+#include <vector>
+
+TEST(MetaTraits, length_mvt) {
+  using stan::length_mvt;
+
+  double x1;
+  EXPECT_THROW(length_mvt(x1), std::invalid_argument);
+
+  int x2;
+  EXPECT_THROW(length_mvt(x2), std::invalid_argument);
+
+}

--- a/test/unit/math/prim/scal/meta/max_size_mvt_test.cpp
+++ b/test/unit/math/prim/scal/meta/max_size_mvt_test.cpp
@@ -1,0 +1,13 @@
+#include <stan/math/prim/mat.hpp>
+#include <gtest/gtest.h>
+#include <vector>
+
+TEST(MetaTraits, max_size_mvt) {
+  using stan::max_size_mvt;
+
+  double x1 = 0, x2 = 1.0, x3 = -1.0, x4 = 4.0;
+  EXPECT_THROW(max_size_mvt(x1, x2), std::invalid_argument);
+  EXPECT_THROW(max_size_mvt(x1, x2, x3), std::invalid_argument);
+  EXPECT_THROW(max_size_mvt(x1, x2, x3, x4), std::invalid_argument);
+
+}

--- a/test/unit/math/prim/scal/meta/max_size_mvt_test.cpp
+++ b/test/unit/math/prim/scal/meta/max_size_mvt_test.cpp
@@ -9,5 +9,4 @@ TEST(MetaTraits, max_size_mvt) {
   EXPECT_THROW(max_size_mvt(x1, x2), std::invalid_argument);
   EXPECT_THROW(max_size_mvt(x1, x2, x3), std::invalid_argument);
   EXPECT_THROW(max_size_mvt(x1, x2, x3, x4), std::invalid_argument);
-
 }

--- a/test/unit/math/prim/scal/meta/max_size_test.cpp
+++ b/test/unit/math/prim/scal/meta/max_size_test.cpp
@@ -1,0 +1,13 @@
+#include <stan/math/prim/scal.hpp>
+#include <gtest/gtest.h>
+#include <vector>
+
+TEST(MetaTraits, length_mvt) {
+  using stan::max_size;
+
+  double x1 = 1.0, x2 = 0.0, x3 = 2.0, x4 = -3.0, x5 = -11.0;
+  EXPECT_EQ(1U, max_size(x1, x2));
+  EXPECT_EQ(1U, max_size(x1, x2, x3));
+  EXPECT_EQ(1U, max_size(x1, x2, x3, x4));
+  EXPECT_EQ(1U, max_size(x1, x2, x3, x4, x5));
+}

--- a/test/unit/math/prim/scal/meta/partials_return_type_test.cpp
+++ b/test/unit/math/prim/scal/meta/partials_return_type_test.cpp
@@ -1,14 +1,8 @@
 #include <stan/math/prim/scal.hpp>
-#include <stan/math/rev/scal.hpp>
-#include <stan/math/rev/core.hpp>
-#include <stan/math/fwd/core.hpp>
-#include <stan/math/fwd/scal.hpp>
 
 #include <gtest/gtest.h>
 #include <test/unit/util.hpp>
 
-using stan::math::fvar;
-using stan::math::var;
 using stan::partials_return_type;
 
 TEST(MetaTraits, PartialsReturnTypeDouble) {

--- a/test/unit/math/prim/scal/meta/partials_type_test.cpp
+++ b/test/unit/math/prim/scal/meta/partials_type_test.cpp
@@ -1,0 +1,18 @@
+#include <stan/math/prim/scal.hpp>
+
+#include <gtest/gtest.h>
+#include <test/unit/util.hpp>
+
+using stan::partials_type;
+
+TEST(MetaTraits, PartialsTypeDouble) {
+  test::expect_same_type<double, partials_type<double>::type>();
+}
+
+TEST(MetaTraits, PartialsTypeFloat) {
+  test::expect_same_type<float, partials_type<float>::type>();
+}
+
+TEST(MetaTraits, PartialsTypeInt) {
+  test::expect_same_type<int, partials_type<int>::type>();
+}

--- a/test/unit/math/prim/scal/meta/size_of_test.cpp
+++ b/test/unit/math/prim/scal/meta/size_of_test.cpp
@@ -1,0 +1,10 @@
+#include <stan/math/prim/scal.hpp>
+#include <gtest/gtest.h>
+#include <vector>
+#include <Eigen/Dense>
+
+TEST(MetaTraits, size_of) {
+  using stan::size_of;
+  double x1 = 2;
+  EXPECT_EQ(1U, size_of(x1));
+}

--- a/test/unit/math/prim/scal/meta/size_of_test.cpp
+++ b/test/unit/math/prim/scal/meta/size_of_test.cpp
@@ -1,7 +1,6 @@
 #include <stan/math/prim/scal.hpp>
 #include <gtest/gtest.h>
 #include <vector>
-#include <Eigen/Dense>
 
 TEST(MetaTraits, size_of) {
   using stan::size_of;

--- a/test/unit/math/rev/scal/meta/is_fvar_test.cpp
+++ b/test/unit/math/rev/scal/meta/is_fvar_test.cpp
@@ -1,0 +1,7 @@
+#include <stan/math/rev/scal.hpp>
+#include <gtest/gtest.h>
+
+TEST(MetaTraits, is_fvar) {
+  using stan::is_fvar;
+  EXPECT_FALSE(is_fvar<stan::math::var>::value);
+}

--- a/test/unit/math/rev/scal/meta/is_var_test.cpp
+++ b/test/unit/math/rev/scal/meta/is_var_test.cpp
@@ -1,0 +1,7 @@
+#include <stan/math/rev/scal.hpp>
+#include <gtest/gtest.h>
+
+TEST(MetaTraits, is_var) {
+  using stan::is_var;
+  EXPECT_FALSE(is_var<stan::math::var>::value);
+}

--- a/test/unit/math/rev/scal/meta/is_var_test.cpp
+++ b/test/unit/math/rev/scal/meta/is_var_test.cpp
@@ -3,5 +3,5 @@
 
 TEST(MetaTraits, is_var) {
   using stan::is_var;
-  EXPECT_FALSE(is_var<stan::math::var>::value);
+  EXPECT_TRUE(is_var<stan::math::var>::value);
 }


### PR DESCRIPTION
## Summary

This PR adds tests for the following meta programs:

```
fwd/scal
	is_fvar
prim/arr
	index_type
prim/mat
	append_return_type
	length_mvt
prim/scal
	is_fvar
	is_var
	length_mvt
	max_size_mvt
	max_size
	partials_type
	size_of
rev/scal
	is_var
```

It also removes the empty `prim/scal/meta/seq_view.hpp` file.

This only leaves [scalar_type_pre](https://github.com/stan-dev/math/blob/develop/stan/math/prim/scal/meta/scalar_type_pre.hpp) without any tests among metaprograms. If anyone has an idea how to test that function that would close out the tests part of #1122.

## Tests

Tests for all above mentioned metaprograms.

## Side Effects

/

## Checklist

- [x] Math issue #1122 

- [x] Copyright holder: Rok Češnovar, Univ. of Ljubljana

- [x] the basic tests are passing

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
