### PR TITLE
optimized matrix-vector and vector-matrix multiply

### DIFF
--- a/stan/math/opencl/kernel_cl.hpp
+++ b/stan/math/opencl/kernel_cl.hpp
@@ -82,7 +82,7 @@ class kernel_functor {
                  std::map<const char*, int> options) {
     auto base_opts = opencl_context.base_opts();
     for (auto& it : options) {
-      if (base_opts[it.first] != it.second) {
+      if (base_opts[it.first] > it.second) {
         base_opts[it.first] = it.second;
       }
     }

--- a/stan/math/opencl/kernel_cl.hpp
+++ b/stan/math/opencl/kernel_cl.hpp
@@ -82,7 +82,7 @@ class kernel_functor {
                  std::map<const char*, int> options) {
     auto base_opts = opencl_context.base_opts();
     for (auto& it : options) {
-      if (base_opts[it.first] > it.second) {
+      if (base_opts[it.first] != it.second) {
         base_opts[it.first] = it.second;
       }
     }

--- a/stan/math/opencl/kernel_cl.hpp
+++ b/stan/math/opencl/kernel_cl.hpp
@@ -82,7 +82,7 @@ class kernel_functor {
                  std::map<const char*, int> options) {
     auto base_opts = opencl_context.base_opts();
     for (auto& it : options) {
-      if (base_opts[it.first] != it.second) {
+      if (!base_opts[it.first] || base_opts[it.first] > it.second) {
         base_opts[it.first] = it.second;
       }
     }

--- a/stan/math/opencl/kernel_cl.hpp
+++ b/stan/math/opencl/kernel_cl.hpp
@@ -82,7 +82,7 @@ class kernel_functor {
                  std::map<const char*, int> options) {
     auto base_opts = opencl_context.base_opts();
     for (auto& it : options) {
-      if (!base_opts[it.first] || base_opts[it.first] > it.second) {
+      if (base_opts[it.first] != it.second) {
         base_opts[it.first] = it.second;
       }
     }

--- a/stan/math/opencl/kernels/matrix_multiply.hpp
+++ b/stan/math/opencl/kernels/matrix_multiply.hpp
@@ -114,6 +114,84 @@ const local_range_kernel<cl::Buffer, cl::Buffer, cl::Buffer, int, int, int,
     matrix_multiply("matrix_multiply", matrix_multiply_kernel_code,
                     {{"THREAD_BLOCK_SIZE", 32}, {"WORK_PER_THREAD", 8}});
 
+// \cond
+const char* matrix_vector_multiply_kernel_code = STRINGIFY(
+// \endcond
+    /**
+     * Matrix-vector multiplication R=A*B on the OpenCL device
+     *
+     * @param[in] A matrix in matrix-vector multiplication
+     * @param[in] B the vector in matri-vector multiplication
+     * @param[out] R the output vector
+     * @param[in] M Number of rows for matrix A
+     * @param[in] N Number of cols for matrix A and number of rows for vector B
+     */
+    __kernel void matrix_vector_multiply(const __global double* A, const __global double* B, __global double* R, const int M, const int N) {
+      const int gid = get_global_id(0);
+
+      double acc = 0;
+      for (int i = 0, j=0; i < N; i ++, j += M) {
+        acc += A[j+gid] * B[i];
+      }
+      R[gid]=acc;
+    }
+// \cond
+);
+// \endcond
+
+/**
+ * See the docs for \link kernels/matrix_multiply.hpp matrix_vector_multiply() \endlink
+ */
+const global_range_kernel<cl::Buffer, cl::Buffer, cl::Buffer, int, int>
+        matrix_vector_multiply("matrix_vector_multiply", matrix_vector_multiply_kernel_code);
+
+// \cond
+const char* vector_matrix_multiply_kernel_code = STRINGIFY(
+// \endcond
+    /**
+     * Vector-matrix multiplication R=A*B on the OpenCL device
+     *
+     * @param[in] M matrix in vector-matrix multiplication
+     * @param[in] V the vector in vector-matrix multiplication
+     * @param[out] R the output vector
+     * @param[in] N Number of cols for vector A and number of rows for matrix B
+     * @param[in] K Number of cols for matrix B
+     */
+        __kernel void vector_matrix_multiply(const __global double* A, const __global double* B, __global double* R, const int N, const int K) {
+          const int lid = get_local_id(0);
+          const int gid = get_global_id(0);
+          const int wgid = get_group_id(0);
+
+          double acc = 0;
+          for (int i = lid; i < N; i += 64) {
+            acc += A[i] * B[i + wgid * N];
+          }
+          __local double res_loc[64];
+          res_loc[lid] = acc;
+          barrier(CLK_LOCAL_MEM_FENCE);
+          if (lid < 16) {
+            res_loc[lid] += res_loc[lid + 16] + res_loc[lid + 32] + res_loc[lid + 48];
+          }
+          barrier(CLK_LOCAL_MEM_FENCE);
+          if (lid < 4) {
+            res_loc[lid] += res_loc[lid + 4] + res_loc[lid + 8] + res_loc[lid + 12];
+          }
+          barrier(CLK_LOCAL_MEM_FENCE);
+          if (lid == 0) {
+            acc = res_loc[lid] + res_loc[lid + 1] + res_loc[lid + 2] + res_loc[lid + 3];
+            R[wgid] = acc;
+          }
+        }
+// \cond
+);
+// \endcond
+
+/**
+ * See the docs for \link kernels/matrix_multiply.hpp vector_matrix_multiply() \endlink
+ */
+const local_range_kernel<cl::Buffer, cl::Buffer, cl::Buffer, int, int>
+        vector_matrix_multiply("vector_matrix_multiply", vector_matrix_multiply_kernel_code);
+
 }  // namespace opencl_kernels
 }  // namespace math
 }  // namespace stan

--- a/stan/math/opencl/kernels/matrix_multiply.hpp
+++ b/stan/math/opencl/kernels/matrix_multiply.hpp
@@ -115,13 +115,13 @@ const local_range_kernel<cl::Buffer, cl::Buffer, cl::Buffer, int, int, int,
                     {{"THREAD_BLOCK_SIZE", 32}, {"WORK_PER_THREAD", 8}});
 
 // \cond
-const char* matrix_vector_multiply_kernel_code = STRINGIFY(
+static const char* matrix_vector_multiply_kernel_code = STRINGIFY(
     // \endcond
     /**
      * Matrix-vector multiplication R=A*B on the OpenCL device
      *
      * @param[in] A matrix in matrix-vector multiplication
-     * @param[in] B the vector in matri-vector multiplication
+     * @param[in] B vector in matrix-vector multiplication
      * @param[out] R the output vector
      * @param[in] M Number of rows for matrix A
      * @param[in] N Number of cols for matrix A and number of rows for vector B
@@ -150,18 +150,18 @@ const global_range_kernel<cl::Buffer, cl::Buffer, cl::Buffer, int, int>
                            matrix_vector_multiply_kernel_code);
 
 // \cond
-const char* vector_matrix_multiply_kernel_code = STRINGIFY(
+static const char* row_vector_matrix_multiply_kernel_code = STRINGIFY(
     // \endcond
     /**
-     * Vector-matrix multiplication R=A*B on the OpenCL device
+     * Row vector-matrix multiplication R=A*B on the OpenCL device
      *
-     * @param[in] A matrix in vector-matrix multiplication
-     * @param[in] B the vector in vector-matrix multiplication
+     * @param[in] A row vector in row vector-matrix multiplication
+     * @param[in] B matrix in row vector-matrix multiplication
      * @param[out] R the output vector
      * @param[in] N Number of cols for vector A and number of rows for matrix B
      * @param[in] K Number of cols for matrix B
      */
-    __kernel void vector_matrix_multiply(
+    __kernel void row_vector_matrix_multiply(
         const __global double* A, const __global double* B, __global double* R,
         const int N, const int K) {
       const int lid = get_local_id(0);
@@ -195,12 +195,12 @@ const char* vector_matrix_multiply_kernel_code = STRINGIFY(
 // \endcond
 
 /**
- * See the docs for \link kernels/matrix_multiply.hpp vector_matrix_multiply()
+ * See the docs for \link kernels/matrix_multiply.hpp row_vector_matrix_multiply()
  * \endlink
  */
 const local_range_kernel<cl::Buffer, cl::Buffer, cl::Buffer, int, int>
-    vector_matrix_multiply("vector_matrix_multiply",
-                           vector_matrix_multiply_kernel_code);
+    row_vector_matrix_multiply("row_vector_matrix_multiply",
+                           row_vector_matrix_multiply_kernel_code);
 
 }  // namespace opencl_kernels
 }  // namespace math

--- a/stan/math/opencl/kernels/matrix_multiply.hpp
+++ b/stan/math/opencl/kernels/matrix_multiply.hpp
@@ -143,42 +143,40 @@ const local_range_kernel<cl::Buffer, cl::Buffer, cl::Buffer, int, int, int,
 
 // \cond
 static const char* matrix_vector_multiply_kernel_code = STRINGIFY(
-// \endcond
-/**
- * Matrix-vector multiplication R=A*B on the OpenCL device
- *
- * @param[in] A matrix in matrix-vector multiplication
- * @param[in] B vector in matrix-vector multiplication
- * @param[out] R the output vector
- * @param[in] M Number of rows for matrix A
- * @param[in] N Number of cols for matrix A and number of rows for vector B
- */
-        __kernel void matrix_vector_multiply(
-                const __global double* A, const __global double* B,
-                __global double* R,
-                const int M, const int N, unsigned int lower_upper_A,
-                unsigned int lower_upper_B) {
-          const int gid = get_global_id(0);
+    // \endcond
+    /**
+     * Matrix-vector multiplication R=A*B on the OpenCL device
+     *
+     * @param[in] A matrix in matrix-vector multiplication
+     * @param[in] B vector in matrix-vector multiplication
+     * @param[out] R the output vector
+     * @param[in] M Number of rows for matrix A
+     * @param[in] N Number of cols for matrix A and number of rows for vector B
+     */
+    __kernel void matrix_vector_multiply(
+        const __global double* A, const __global double* B, __global double* R,
+        const int M, const int N, unsigned int lower_upper_A,
+        unsigned int lower_upper_B) {
+      const int gid = get_global_id(0);
 
-          int start=0;
-          int stop=N;
-          if(lower_upper_A==UPPER){
-            start=gid;
-          }
-          else if(lower_upper_A==LOWER){
-            stop=gid+1;
-          }
-          if(lower_upper_B==UPPER){
-            stop=1;
-          }
+      int start = 0;
+      int stop = N;
+      if (lower_upper_A == UPPER) {
+        start = gid;
+      } else if (lower_upper_A == LOWER) {
+        stop = gid + 1;
+      }
+      if (lower_upper_B == UPPER) {
+        stop = 1;
+      }
 
-          double acc = 0;
-          for (int i = start, j = M * start; i < stop; i++, j += M) {
-            acc += A[j + gid] * B[i];
-          }
-          R[gid] = acc;
-        }
-// \cond
+      double acc = 0;
+      for (int i = start, j = M * start; i < stop; i++, j += M) {
+        acc += A[j + gid] * B[i];
+      }
+      R[gid] = acc;
+    }
+    // \cond
 );
 // \endcond
 
@@ -186,65 +184,64 @@ static const char* matrix_vector_multiply_kernel_code = STRINGIFY(
  * See the docs for \link kernels/matrix_multiply.hpp matrix_vector_multiply()
  * \endlink
  */
-const global_range_kernel<cl::Buffer, cl::Buffer, cl::Buffer, int, int, TriangularViewCL, TriangularViewCL>
-        matrix_vector_multiply("matrix_vector_multiply",
-                               matrix_vector_multiply_kernel_code);
+const global_range_kernel<cl::Buffer, cl::Buffer, cl::Buffer, int, int,
+                          TriangularViewCL, TriangularViewCL>
+    matrix_vector_multiply("matrix_vector_multiply",
+                           matrix_vector_multiply_kernel_code);
 
 // \cond
 static const char* row_vector_matrix_multiply_kernel_code = STRINGIFY(
-// \endcond
-/**
- * Row vector-matrix multiplication R=A*B on the OpenCL device
- *
- * @param[in] A row vector in row vector-matrix multiplication
- * @param[in] B matrix in row vector-matrix multiplication
- * @param[out] R the output vector
- * @param[in] N Number of cols for vector A and number of rows for matrix B
- * @param[in] K Number of cols for matrix B
- */
-        __kernel void row_vector_matrix_multiply(
-                const __global double* A, const __global double* B,
-                __global double* R,
-                const int N, const int K, unsigned int lower_upper_A,
-                unsigned int lower_upper_B) {
-          const int lid = get_local_id(0);
-          const int gid = get_global_id(0);
-          const int wgid = get_group_id(0);
+    // \endcond
+    /**
+     * Row vector-matrix multiplication R=A*B on the OpenCL device
+     *
+     * @param[in] A row vector in row vector-matrix multiplication
+     * @param[in] B matrix in row vector-matrix multiplication
+     * @param[out] R the output vector
+     * @param[in] N Number of cols for vector A and number of rows for matrix B
+     * @param[in] K Number of cols for matrix B
+     */
+    __kernel void row_vector_matrix_multiply(
+        const __global double* A, const __global double* B, __global double* R,
+        const int N, const int K, unsigned int lower_upper_A,
+        unsigned int lower_upper_B) {
+      const int lid = get_local_id(0);
+      const int gid = get_global_id(0);
+      const int wgid = get_group_id(0);
 
-          int start=0;
-          int stop=N;
-          if(lower_upper_B==UPPER){
-            stop=wgid+1;
-          }
-          else if(lower_upper_B==LOWER){
-            start=wgid;
-          }
-          if(lower_upper_A==LOWER){
-            stop=1;
-          }
+      int start = 0;
+      int stop = N;
+      if (lower_upper_B == UPPER) {
+        stop = wgid + 1;
+      } else if (lower_upper_B == LOWER) {
+        start = wgid;
+      }
+      if (lower_upper_A == LOWER) {
+        stop = 1;
+      }
 
-          double acc = 0;
-          for (int i = lid + start; i < stop; i += LOCAL_SIZE_) {
-            acc += A[i] * B[i + wgid * N];
-          }
+      double acc = 0;
+      for (int i = lid + start; i < stop; i += LOCAL_SIZE_) {
+        acc += A[i] * B[i + wgid * N];
+      }
 
-          __local double res_loc[LOCAL_SIZE_];
-          res_loc[lid] = acc;
-          barrier(CLK_LOCAL_MEM_FENCE);
-          for (int step = LOCAL_SIZE_ / REDUCTION_STEP_SIZE;
-               step > 0; step /= REDUCTION_STEP_SIZE) {
-            if (lid < step) {
-              for (int i = 1; i < REDUCTION_STEP_SIZE; i++) {
-                res_loc[lid] += res_loc[lid + step * i];
-              }
-            }
-            barrier(CLK_LOCAL_MEM_FENCE);
-          }
-          if (lid == 0) {
-            R[wgid] = res_loc[0];
+      __local double res_loc[LOCAL_SIZE_];
+      res_loc[lid] = acc;
+      barrier(CLK_LOCAL_MEM_FENCE);
+      for (int step = LOCAL_SIZE_ / REDUCTION_STEP_SIZE; step > 0;
+           step /= REDUCTION_STEP_SIZE) {
+        if (lid < step) {
+          for (int i = 1; i < REDUCTION_STEP_SIZE; i++) {
+            res_loc[lid] += res_loc[lid + step * i];
           }
         }
-// \cond
+        barrier(CLK_LOCAL_MEM_FENCE);
+      }
+      if (lid == 0) {
+        R[wgid] = res_loc[0];
+      }
+    }
+    // \cond
 );
 // \endcond
 
@@ -252,11 +249,12 @@ static const char* row_vector_matrix_multiply_kernel_code = STRINGIFY(
  * See the docs for \link kernels/matrix_multiply.hpp
  * row_vector_matrix_multiply() \endlink
  */
-const local_range_kernel<cl::Buffer, cl::Buffer, cl::Buffer, int, int, TriangularViewCL, TriangularViewCL>
-        row_vector_matrix_multiply("row_vector_matrix_multiply",
-                                   row_vector_matrix_multiply_kernel_code,
-                                   {{"LOCAL_SIZE_",         64},
-                                    {"REDUCTION_STEP_SIZE", 4}});
+const local_range_kernel<cl::Buffer, cl::Buffer, cl::Buffer, int, int,
+                         TriangularViewCL, TriangularViewCL>
+    row_vector_matrix_multiply("row_vector_matrix_multiply",
+                               row_vector_matrix_multiply_kernel_code,
+                               {{"LOCAL_SIZE_", 64},
+                                {"REDUCTION_STEP_SIZE", 4}});
 
 }  // namespace opencl_kernels
 }  // namespace math

--- a/stan/math/opencl/kernels/matrix_multiply.hpp
+++ b/stan/math/opencl/kernels/matrix_multiply.hpp
@@ -116,28 +116,29 @@ const local_range_kernel<cl::Buffer, cl::Buffer, cl::Buffer, int, int, int,
 
 // \cond
 static const char* matrix_vector_multiply_kernel_code = STRINGIFY(
-    // \endcond
-    /**
-     * Matrix-vector multiplication R=A*B on the OpenCL device
-     *
-     * @param[in] A matrix in matrix-vector multiplication
-     * @param[in] B vector in matrix-vector multiplication
-     * @param[out] R the output vector
-     * @param[in] M Number of rows for matrix A
-     * @param[in] N Number of cols for matrix A and number of rows for vector B
-     */
-    __kernel void matrix_vector_multiply(
-        const __global double* A, const __global double* B, __global double* R,
-        const int M, const int N) {
-      const int gid = get_global_id(0);
+// \endcond
+/**
+ * Matrix-vector multiplication R=A*B on the OpenCL device
+ *
+ * @param[in] A matrix in matrix-vector multiplication
+ * @param[in] B vector in matrix-vector multiplication
+ * @param[out] R the output vector
+ * @param[in] M Number of rows for matrix A
+ * @param[in] N Number of cols for matrix A and number of rows for vector B
+ */
+        __kernel void matrix_vector_multiply(
+                const __global double* A, const __global double* B,
+                __global double* R,
+                const int M, const int N) {
+          const int gid = get_global_id(0);
 
-      double acc = 0;
-      for (int i = 0, j = 0; i < N; i++, j += M) {
-        acc += A[j + gid] * B[i];
-      }
-      R[gid] = acc;
-    }
-    // \cond
+          double acc = 0;
+          for (int i = 0, j = 0; i < N; i++, j += M) {
+            acc += A[j + gid] * B[i];
+          }
+          R[gid] = acc;
+        }
+// \cond
 );
 // \endcond
 
@@ -146,48 +147,50 @@ static const char* matrix_vector_multiply_kernel_code = STRINGIFY(
  * \endlink
  */
 const global_range_kernel<cl::Buffer, cl::Buffer, cl::Buffer, int, int>
-    matrix_vector_multiply("matrix_vector_multiply",
-                           matrix_vector_multiply_kernel_code);
+        matrix_vector_multiply("matrix_vector_multiply",
+                               matrix_vector_multiply_kernel_code);
 
 // \cond
 static const char* row_vector_matrix_multiply_kernel_code = STRINGIFY(
-    // \endcond
-    /**
-     * Row vector-matrix multiplication R=A*B on the OpenCL device
-     *
-     * @param[in] A row vector in row vector-matrix multiplication
-     * @param[in] B matrix in row vector-matrix multiplication
-     * @param[out] R the output vector
-     * @param[in] N Number of cols for vector A and number of rows for matrix B
-     * @param[in] K Number of cols for matrix B
-     */
-    __kernel void row_vector_matrix_multiply(
-        const __global double* A, const __global double* B, __global double* R,
-        const int N, const int K) {
-      const int lid = get_local_id(0);
-      const int gid = get_global_id(0);
-      const int wgid = get_group_id(0);
+// \endcond
+/**
+ * Row vector-matrix multiplication R=A*B on the OpenCL device
+ *
+ * @param[in] A row vector in row vector-matrix multiplication
+ * @param[in] B matrix in row vector-matrix multiplication
+ * @param[out] R the output vector
+ * @param[in] N Number of cols for vector A and number of rows for matrix B
+ * @param[in] K Number of cols for matrix B
+ */
+        __kernel void row_vector_matrix_multiply(
+                const __global double* A, const __global double* B,
+                __global double* R,
+                const int N, const int K) {
+          const int lid = get_local_id(0);
+          const int gid = get_global_id(0);
+          const int wgid = get_group_id(0);
 
-      double acc = 0;
-      for (int i = lid; i < N; i += LOCAL_SIZE_) {
-        acc += A[i] * B[i + wgid * N];
-      }
-      __local double res_loc[LOCAL_SIZE_];
-      res_loc[lid] = acc;
-      barrier(CLK_LOCAL_MEM_FENCE);
-      for(int step = LOCAL_SIZE_/REDUCTION_STEP_SIZE; step>0; step/=REDUCTION_STEP_SIZE){
-        if (lid < step) {
-          for(int i=1;i<REDUCTION_STEP_SIZE;i++){
-            res_loc[lid] += res_loc[lid + step*i];
+          double acc = 0;
+          for (int i = lid; i < N; i += LOCAL_SIZE_) {
+            acc += A[i] * B[i + wgid * N];
+          }
+          __local double res_loc[LOCAL_SIZE_];
+          res_loc[lid] = acc;
+          barrier(CLK_LOCAL_MEM_FENCE);
+          for (int step = LOCAL_SIZE_ / REDUCTION_STEP_SIZE;
+               step > 0; step /= REDUCTION_STEP_SIZE) {
+            if (lid < step) {
+              for (int i = 1; i < REDUCTION_STEP_SIZE; i++) {
+                res_loc[lid] += res_loc[lid + step * i];
+              }
+            }
+            barrier(CLK_LOCAL_MEM_FENCE);
+          }
+          if (lid == 0) {
+            R[wgid] = res_loc[0];
           }
         }
-        barrier(CLK_LOCAL_MEM_FENCE);
-      }
-      if (lid == 0) {
-        R[wgid] = res_loc[0];
-      }
-    }
-    // \cond
+// \cond
 );
 // \endcond
 
@@ -196,8 +199,10 @@ static const char* row_vector_matrix_multiply_kernel_code = STRINGIFY(
  * row_vector_matrix_multiply() \endlink
  */
 const local_range_kernel<cl::Buffer, cl::Buffer, cl::Buffer, int, int>
-    row_vector_matrix_multiply("row_vector_matrix_multiply",
-                               row_vector_matrix_multiply_kernel_code, {{"LOCAL_SIZE_", 64}, {"REDUCTION_STEP_SIZE", 4}});
+        row_vector_matrix_multiply("row_vector_matrix_multiply",
+                                   row_vector_matrix_multiply_kernel_code,
+                                   {{"LOCAL_SIZE_",         64},
+                                    {"REDUCTION_STEP_SIZE", 4}});
 
 }  // namespace opencl_kernels
 }  // namespace math

--- a/stan/math/opencl/kernels/matrix_multiply.hpp
+++ b/stan/math/opencl/kernels/matrix_multiply.hpp
@@ -161,16 +161,9 @@ static const char* matrix_vector_multiply_kernel_code = STRINGIFY(
         unsigned int lower_upper_B) {
       const int gid = get_global_id(0);
 
-      int start = 0;
-      int stop = N;
-      if (lower_upper_A == UPPER) {
-        start = gid;
-      } else if (lower_upper_A == LOWER) {
-        stop = gid + 1;
-      }
-      if (lower_upper_B == UPPER) {
-        stop = 1;
-      }
+      const int start = lower_upper_A == UPPER ? gid : 0;
+      const int stop = lower_upper_B == UPPER ? 1 :
+                      (lower_upper_A == LOWER ? gid + 1 : N);
 
       double acc = 0;
       for (int i = start, j = M * start; i < stop; i++, j += M) {
@@ -200,7 +193,7 @@ static const char* row_vector_matrix_multiply_kernel_code = STRINGIFY(
      * @param[in] A row vector in row vector-matrix multiplication
      * @param[in] B matrix in row vector-matrix multiplication
      * @param[out] R the output vector
-     * @param[in] N Number of cols for vector A and number of rows for matrix B
+     * @param[in] N Number of cols for row vector A and number of rows for matrix B
      * @param[in] K Number of cols for matrix B
      * @param[in] lower_upper_A the triangularity of A (lower, upper or none)
      * @param[in] lower_upper_B the triangularity of B (lower, upper or none)
@@ -213,16 +206,9 @@ static const char* row_vector_matrix_multiply_kernel_code = STRINGIFY(
       const int gid = get_global_id(0);
       const int wgid = get_group_id(0);
 
-      int start = 0;
-      int stop = N;
-      if (lower_upper_B == UPPER) {
-        stop = wgid + 1;
-      } else if (lower_upper_B == LOWER) {
-        start = wgid;
-      }
-      if (lower_upper_A == LOWER) {
-        stop = 1;
-      }
+      const int start = lower_upper_B == LOWER ? wgid : 0;
+      const int stop = lower_upper_A == LOWER ? 1 :
+                       (lower_upper_B == UPPER) ? wgid + 1 : N;
 
       double acc = 0;
       for (int i = lid + start; i < stop; i += LOCAL_SIZE_) {

--- a/stan/math/opencl/kernels/matrix_multiply.hpp
+++ b/stan/math/opencl/kernels/matrix_multiply.hpp
@@ -151,8 +151,8 @@ const char* vector_matrix_multiply_kernel_code = STRINGIFY(
     /**
      * Vector-matrix multiplication R=A*B on the OpenCL device
      *
-     * @param[in] M matrix in vector-matrix multiplication
-     * @param[in] V the vector in vector-matrix multiplication
+     * @param[in] A matrix in vector-matrix multiplication
+     * @param[in] B the vector in vector-matrix multiplication
      * @param[out] R the output vector
      * @param[in] N Number of cols for vector A and number of rows for matrix B
      * @param[in] K Number of cols for matrix B

--- a/stan/math/opencl/kernels/matrix_multiply.hpp
+++ b/stan/math/opencl/kernels/matrix_multiply.hpp
@@ -195,12 +195,12 @@ static const char* row_vector_matrix_multiply_kernel_code = STRINGIFY(
 // \endcond
 
 /**
- * See the docs for \link kernels/matrix_multiply.hpp row_vector_matrix_multiply()
- * \endlink
+ * See the docs for \link kernels/matrix_multiply.hpp
+ * row_vector_matrix_multiply() \endlink
  */
 const local_range_kernel<cl::Buffer, cl::Buffer, cl::Buffer, int, int>
     row_vector_matrix_multiply("row_vector_matrix_multiply",
-                           row_vector_matrix_multiply_kernel_code);
+                               row_vector_matrix_multiply_kernel_code);
 
 }  // namespace opencl_kernels
 }  // namespace math

--- a/stan/math/opencl/kernels/matrix_multiply.hpp
+++ b/stan/math/opencl/kernels/matrix_multiply.hpp
@@ -162,8 +162,8 @@ static const char* matrix_vector_multiply_kernel_code = STRINGIFY(
       const int gid = get_global_id(0);
 
       const int start = lower_upper_A == UPPER ? gid : 0;
-      const int stop = lower_upper_B == UPPER ? 1 :
-                      (lower_upper_A == LOWER ? gid + 1 : N);
+      const int stop
+          = lower_upper_B == UPPER ? 1 : (lower_upper_A == LOWER ? gid + 1 : N);
 
       double acc = 0;
       for (int i = start, j = M * start; i < stop; i++, j += M) {
@@ -193,7 +193,8 @@ static const char* row_vector_matrix_multiply_kernel_code = STRINGIFY(
      * @param[in] A row vector in row vector-matrix multiplication
      * @param[in] B matrix in row vector-matrix multiplication
      * @param[out] R the output vector
-     * @param[in] N Number of cols for row vector A and number of rows for matrix B
+     * @param[in] N Number of cols for row vector A and number of rows for
+     * matrix B
      * @param[in] K Number of cols for matrix B
      * @param[in] lower_upper_A the triangularity of A (lower, upper or none)
      * @param[in] lower_upper_B the triangularity of B (lower, upper or none)
@@ -207,8 +208,9 @@ static const char* row_vector_matrix_multiply_kernel_code = STRINGIFY(
       const int wgid = get_group_id(0);
 
       const int start = lower_upper_B == LOWER ? wgid : 0;
-      const int stop = lower_upper_A == LOWER ? 1 :
-                       (lower_upper_B == UPPER) ? wgid + 1 : N;
+      const int stop = lower_upper_A == LOWER
+                           ? 1
+                           : (lower_upper_B == UPPER) ? wgid + 1 : N;
 
       double acc = 0;
       for (int i = lid + start; i < stop; i += LOCAL_SIZE_) {

--- a/stan/math/opencl/kernels/matrix_multiply.hpp
+++ b/stan/math/opencl/kernels/matrix_multiply.hpp
@@ -152,6 +152,8 @@ static const char* matrix_vector_multiply_kernel_code = STRINGIFY(
      * @param[out] R the output vector
      * @param[in] M Number of rows for matrix A
      * @param[in] N Number of cols for matrix A and number of rows for vector B
+     * @param[in] lower_upper_A the triangularity of A (lower, upper or none)
+     * @param[in] lower_upper_B the triangularity of B (lower, upper or none)
      */
     __kernel void matrix_vector_multiply(
         const __global double* A, const __global double* B, __global double* R,
@@ -200,6 +202,8 @@ static const char* row_vector_matrix_multiply_kernel_code = STRINGIFY(
      * @param[out] R the output vector
      * @param[in] N Number of cols for vector A and number of rows for matrix B
      * @param[in] K Number of cols for matrix B
+     * @param[in] lower_upper_A the triangularity of A (lower, upper or none)
+     * @param[in] lower_upper_B the triangularity of B (lower, upper or none)
      */
     __kernel void row_vector_matrix_multiply(
         const __global double* A, const __global double* B, __global double* R,

--- a/stan/math/opencl/multiply.hpp
+++ b/stan/math/opencl/multiply.hpp
@@ -39,11 +39,12 @@ inline auto multiply(const matrix_cl& A, const matrix_cl& B) {
   }
   if (A.rows() == 1 && triangular_view_A == TriangularViewCL::Entire
       && triangular_view_B == TriangularViewCL::Entire) {
-    int local_size = opencl_kernels::row_vector_matrix_multiply.make_functor.get_opts().at("LOCAL_SIZE_");
+    int local_size = opencl_kernels::row_vector_matrix_multiply.make_functor.
+            get_opts().at("LOCAL_SIZE_");
     try {
       opencl_kernels::row_vector_matrix_multiply(
-          cl::NDRange(temp.cols() * local_size), cl::NDRange(local_size), A.buffer(),
-          B.buffer(), temp.buffer(), B.rows(), B.cols());
+          cl::NDRange(temp.cols() * local_size), cl::NDRange(local_size),
+          A.buffer(), B.buffer(), temp.buffer(), B.rows(), B.cols());
     } catch (cl::Error& e) {
       check_opencl_error("row_vector - matrix multiply", e);
     }

--- a/stan/math/opencl/multiply.hpp
+++ b/stan/math/opencl/multiply.hpp
@@ -37,25 +37,23 @@ inline auto multiply(const matrix_cl& A, const matrix_cl& B) {
     temp.zeros();
     return temp;
   }
-  if (A.rows() == 1 && triangular_view_A == TriangularViewCL::Entire
-      && triangular_view_B == TriangularViewCL::Entire) {
+  if (A.rows() == 1) {
     int local_size = opencl_kernels::row_vector_matrix_multiply.make_functor.
             get_opts().at("LOCAL_SIZE_");
     try {
       opencl_kernels::row_vector_matrix_multiply(
           cl::NDRange(temp.cols() * local_size), cl::NDRange(local_size),
-          A.buffer(), B.buffer(), temp.buffer(), B.rows(), B.cols());
+          A.buffer(), B.buffer(), temp.buffer(), B.rows(), B.cols(), triangular_view_A, triangular_view_B);
     } catch (cl::Error& e) {
       check_opencl_error("row_vector - matrix multiply", e);
     }
     return temp;
   }
-  if (B.cols() == 1 && triangular_view_A == TriangularViewCL::Entire
-      && triangular_view_B == TriangularViewCL::Entire) {
+  if (B.cols() == 1) {
     try {
       opencl_kernels::matrix_vector_multiply(cl::NDRange(temp.rows()),
                                              A.buffer(), B.buffer(),
-                                             temp.buffer(), A.rows(), A.cols());
+                                             temp.buffer(), A.rows(), A.cols(), triangular_view_A, triangular_view_B);
     } catch (cl::Error& e) {
       check_opencl_error("matrix - vector multiply", e);
     }

--- a/stan/math/opencl/multiply.hpp
+++ b/stan/math/opencl/multiply.hpp
@@ -38,7 +38,7 @@ inline auto multiply(const matrix_cl& A, const matrix_cl& B) {
     return temp;
   }
   if (A.rows() == 1) {
-    int local_size
+    const int local_size
         = opencl_kernels::row_vector_matrix_multiply.make_functor.get_opts().at(
             "LOCAL_SIZE_");
     try {

--- a/stan/math/opencl/multiply.hpp
+++ b/stan/math/opencl/multiply.hpp
@@ -39,12 +39,13 @@ inline auto multiply(const matrix_cl& A, const matrix_cl& B) {
   }
   if (A.rows() == 1 && triangular_view_A == TriangularViewCL::Entire
       && triangular_view_B == TriangularViewCL::Entire) {
+    int local_size = opencl_kernels::row_vector_matrix_multiply.make_functor.get_opts().at("LOCAL_SIZE_");
     try {
       opencl_kernels::row_vector_matrix_multiply(
-          cl::NDRange(temp.cols() * 64), cl::NDRange(64), A.buffer(),
+          cl::NDRange(temp.cols() * local_size), cl::NDRange(local_size), A.buffer(),
           B.buffer(), temp.buffer(), B.rows(), B.cols());
     } catch (cl::Error& e) {
-      check_opencl_error("multiply", e);
+      check_opencl_error("row_vector - matrix multiply", e);
     }
     return temp;
   }
@@ -55,7 +56,7 @@ inline auto multiply(const matrix_cl& A, const matrix_cl& B) {
                                              A.buffer(), B.buffer(),
                                              temp.buffer(), A.rows(), A.cols());
     } catch (cl::Error& e) {
-      check_opencl_error("multiply", e);
+      check_opencl_error("matrix - vector multiply", e);
     }
     return temp;
   }

--- a/stan/math/opencl/multiply.hpp
+++ b/stan/math/opencl/multiply.hpp
@@ -38,12 +38,14 @@ inline auto multiply(const matrix_cl& A, const matrix_cl& B) {
     return temp;
   }
   if (A.rows() == 1) {
-    int local_size = opencl_kernels::row_vector_matrix_multiply.make_functor.
-            get_opts().at("LOCAL_SIZE_");
+    int local_size
+        = opencl_kernels::row_vector_matrix_multiply.make_functor.get_opts().at(
+            "LOCAL_SIZE_");
     try {
       opencl_kernels::row_vector_matrix_multiply(
           cl::NDRange(temp.cols() * local_size), cl::NDRange(local_size),
-          A.buffer(), B.buffer(), temp.buffer(), B.rows(), B.cols(), triangular_view_A, triangular_view_B);
+          A.buffer(), B.buffer(), temp.buffer(), B.rows(), B.cols(),
+          triangular_view_A, triangular_view_B);
     } catch (cl::Error& e) {
       check_opencl_error("row_vector - matrix multiply", e);
     }
@@ -51,9 +53,9 @@ inline auto multiply(const matrix_cl& A, const matrix_cl& B) {
   }
   if (B.cols() == 1) {
     try {
-      opencl_kernels::matrix_vector_multiply(cl::NDRange(temp.rows()),
-                                             A.buffer(), B.buffer(),
-                                             temp.buffer(), A.rows(), A.cols(), triangular_view_A, triangular_view_B);
+      opencl_kernels::matrix_vector_multiply(
+          cl::NDRange(temp.rows()), A.buffer(), B.buffer(), temp.buffer(),
+          A.rows(), A.cols(), triangular_view_A, triangular_view_B);
     } catch (cl::Error& e) {
       check_opencl_error("matrix - vector multiply", e);
     }

--- a/stan/math/opencl/multiply.hpp
+++ b/stan/math/opencl/multiply.hpp
@@ -37,6 +37,22 @@ inline auto multiply(const matrix_cl& A, const matrix_cl& B) {
     temp.zeros();
     return temp;
   }
+  if(A.rows()==1 && triangular_view_A == TriangularViewCL::Entire && triangular_view_B == TriangularViewCL::Entire){
+    try{
+      opencl_kernels::vector_matrix_multiply(cl::NDRange(temp.cols()*64), cl::NDRange(64), A.buffer(), B.buffer(), temp.buffer(), B.rows(), B.cols());
+    } catch (cl::Error& e) {
+      check_opencl_error("multiply", e);
+    }
+    return temp;
+  }
+  if(B.cols()==1 && triangular_view_A == TriangularViewCL::Entire && triangular_view_B == TriangularViewCL::Entire){
+    try{
+      opencl_kernels::matrix_vector_multiply(cl::NDRange(temp.rows()), A.buffer(), B.buffer(), temp.buffer(), A.rows(), A.cols());
+    } catch (cl::Error& e) {
+      check_opencl_error("multiply", e);
+    }
+    return temp;
+  }
   int local = opencl_kernels::matrix_multiply.make_functor.get_opts().at(
       "THREAD_BLOCK_SIZE");
   int Mpad = ((A.rows() + local - 1) / local) * local;

--- a/stan/math/opencl/multiply.hpp
+++ b/stan/math/opencl/multiply.hpp
@@ -40,7 +40,7 @@ inline auto multiply(const matrix_cl& A, const matrix_cl& B) {
   if (A.rows() == 1 && triangular_view_A == TriangularViewCL::Entire
       && triangular_view_B == TriangularViewCL::Entire) {
     try {
-      opencl_kernels::vector_matrix_multiply(
+      opencl_kernels::row_vector_matrix_multiply(
           cl::NDRange(temp.cols() * 64), cl::NDRange(64), A.buffer(),
           B.buffer(), temp.buffer(), B.rows(), B.cols());
     } catch (cl::Error& e) {

--- a/stan/math/opencl/opencl_context.hpp
+++ b/stan/math/opencl/opencl_context.hpp
@@ -136,7 +136,7 @@ class opencl_context_base {
       }
       if (max_thread_block_size_ < base_opts_["LOCAL_SIZE_"]) {
         // must be a power of base_opts_["REDUCTION_STEP_SIZE"]
-        int p = std::log(max_thread_block_size_)
+        const int p = std::log(max_thread_block_size_)
                 / std::log(base_opts_["REDUCTION_STEP_SIZE"]);
         base_opts_["LOCAL_SIZE_"]
             = std::pow(base_opts_["REDUCTION_STEP_SIZE"], p);

--- a/stan/math/opencl/opencl_context.hpp
+++ b/stan/math/opencl/opencl_context.hpp
@@ -137,7 +137,7 @@ class opencl_context_base {
       if (max_thread_block_size_ < base_opts_["LOCAL_SIZE_"]) {
         // must be a power of base_opts_["REDUCTION_STEP_SIZE"]
         const int p = std::log(max_thread_block_size_)
-                / std::log(base_opts_["REDUCTION_STEP_SIZE"]);
+                      / std::log(base_opts_["REDUCTION_STEP_SIZE"]);
         base_opts_["LOCAL_SIZE_"]
             = std::pow(base_opts_["REDUCTION_STEP_SIZE"], p);
       }

--- a/stan/math/opencl/opencl_context.hpp
+++ b/stan/math/opencl/opencl_context.hpp
@@ -138,7 +138,8 @@ class opencl_context_base {
         // must be a power of base_opts_["REDUCTION_STEP_SIZE"]
         int p = std::log(max_thread_block_size_)
                 / std::log(base_opts_["REDUCTION_STEP_SIZE"]);
-        base_opts_["LOCAL_SIZE_"] = std::pow(base_opts_["REDUCTION_STEP_SIZE"], p);
+        base_opts_["LOCAL_SIZE_"]
+            = std::pow(base_opts_["REDUCTION_STEP_SIZE"], p);
       }
       // Thread block size for the Cholesky
       // TODO(Steve): This should be tuned in a higher part of the stan language

--- a/stan/math/opencl/opencl_context.hpp
+++ b/stan/math/opencl/opencl_context.hpp
@@ -138,7 +138,7 @@ class opencl_context_base {
         // must be a power of base_opts_["REDUCTION_STEP_SIZE"]
         int p = std::log(max_thread_block_size_)
                 / std::log(base_opts_["REDUCTION_STEP_SIZE"]);
-        base_opts_["LOCAL_SIZE_"] = pow(base_opts_["REDUCTION_STEP_SIZE"], p);
+        base_opts_["LOCAL_SIZE_"] = std::pow(base_opts_["REDUCTION_STEP_SIZE"], p);
       }
       // Thread block size for the Cholesky
       // TODO(Steve): This should be tuned in a higher part of the stan language

--- a/stan/math/opencl/opencl_context.hpp
+++ b/stan/math/opencl/opencl_context.hpp
@@ -134,6 +134,11 @@ class opencl_context_base {
         base_opts_["THREAD_BLOCK_SIZE"] = thread_block_size_sqrt;
         base_opts_["WORK_PER_THREAD"] = 1;
       }
+      if(max_thread_block_size_ < base_opts_["LOCAL_SIZE_"]){
+        //must be a power of base_opts_["REDUCTION_STEP_SIZE"]
+        int p = log(max_thread_block_size_)/log(base_opts_["REDUCTION_STEP_SIZE"]);
+        base_opts_["LOCAL_SIZE_"] = pow(base_opts_["REDUCTION_STEP_SIZE"], p);
+      }
       // Thread block size for the Cholesky
       // TODO(Steve): This should be tuned in a higher part of the stan language
       if (max_thread_block_size_ >= 256) {
@@ -167,7 +172,9 @@ class opencl_context_base {
          {"UPPER_TO_LOWER", static_cast<int>(TriangularMapCL::UpperToLower)},
          {"LOWER_TO_UPPER", static_cast<int>(TriangularMapCL::LowerToUpper)},
          {"THREAD_BLOCK_SIZE", 32},
-         {"WORK_PER_THREAD", 8}};
+         {"WORK_PER_THREAD", 8},
+         {"REDUCTION_STEP_SIZE", 4},
+         {"LOCAL_SIZE_", 64}};
   // TODO(Steve): Make these tunable during warmup
   struct tuning_struct {
     // Used in stan/math/opencl/cholesky_decompose

--- a/stan/math/opencl/opencl_context.hpp
+++ b/stan/math/opencl/opencl_context.hpp
@@ -136,8 +136,8 @@ class opencl_context_base {
       }
       if (max_thread_block_size_ < base_opts_["LOCAL_SIZE_"]) {
         // must be a power of base_opts_["REDUCTION_STEP_SIZE"]
-        int p = log(max_thread_block_size_)
-                / log(base_opts_["REDUCTION_STEP_SIZE"]);
+        int p = std::log(max_thread_block_size_)
+                / std::log(base_opts_["REDUCTION_STEP_SIZE"]);
         base_opts_["LOCAL_SIZE_"] = pow(base_opts_["REDUCTION_STEP_SIZE"], p);
       }
       // Thread block size for the Cholesky

--- a/test/unit/math/opencl/multiply_test.cpp
+++ b/test/unit/math/opencl/multiply_test.cpp
@@ -119,6 +119,78 @@ TEST(MathMatrix, row_vector_vector) {
   EXPECT_MATRIX_NEAR(m1, m1_cl_res, 1e-10);
 }
 
+TEST(MathMatrix, matrix_vector_small) {
+  auto m = stan::math::matrix_d::Random(4, 5).eval();
+  auto v = stan::math::vector_d::Random(5).eval();
+  stan::math::matrix_d m0(4, 1);
+  stan::math::matrix_d m0_cl_res(4, 1);
+
+  m0 = m * v;
+
+  stan::math::matrix_cl v_cl(v);
+  stan::math::matrix_cl m_cl(m);
+  stan::math::matrix_cl m0_cl(4, 1);
+
+  m0_cl = m_cl * v_cl;
+  stan::math::copy(m0_cl_res, m0_cl);
+
+  EXPECT_MATRIX_NEAR(m0, m0_cl_res, 1e-10);
+}
+
+TEST(MathMatrix, matrix_vector_big) {
+  auto m = stan::math::matrix_d::Random(400, 600).eval();
+  auto v = stan::math::vector_d::Random(600).eval();
+  stan::math::matrix_d m0(400, 1);
+  stan::math::matrix_d m0_cl_res(400, 1);
+
+  m0 = m * v;
+
+  stan::math::matrix_cl v_cl(v);
+  stan::math::matrix_cl m_cl(m);
+  stan::math::matrix_cl m0_cl(400, 1);
+
+  m0_cl = m_cl * v_cl;
+  stan::math::copy(m0_cl_res, m0_cl);
+
+  EXPECT_MATRIX_NEAR(m0, m0_cl_res, 1e-10);
+}
+
+TEST(MathMatrix, row_vector_matrix_small) {
+  auto m = stan::math::matrix_d::Random(5,4).eval();
+  auto rv = stan::math::row_vector_d::Random(5).eval();
+  stan::math::matrix_d m0(1, 4);
+  stan::math::matrix_d m0_cl_res(1, 4);
+
+  m0 = rv * m;
+
+  stan::math::matrix_cl m_cl(m);
+  stan::math::matrix_cl rv_cl(rv);
+  stan::math::matrix_cl m0_cl(1, 4);
+
+  m0_cl = rv_cl * m_cl;
+  stan::math::copy(m0_cl_res, m0_cl);
+
+  EXPECT_MATRIX_NEAR(m0, m0_cl_res, 1e-10);
+}
+
+TEST(MathMatrix, row_vector_matrix_big) {
+  auto m = stan::math::matrix_d::Random(600,400).eval();
+  auto rv = stan::math::row_vector_d::Random(600).eval();
+  stan::math::matrix_d m0(1, 400);
+  stan::math::matrix_d m0_cl_res(1, 400);
+
+  m0 = rv * m;
+
+  stan::math::matrix_cl m_cl(m);
+  stan::math::matrix_cl rv_cl(rv);
+  stan::math::matrix_cl m0_cl(1, 400);
+
+  m0_cl = rv_cl * m_cl;
+  stan::math::copy(m0_cl_res, m0_cl);
+
+  EXPECT_MATRIX_NEAR(m0, m0_cl_res, 1e-10);
+}
+
 TEST(MathMatrix, multiply_small) {
   using stan::math::multiply;
   auto m1 = stan::math::matrix_d::Random(3, 3).eval();

--- a/test/unit/math/opencl/multiply_test.cpp
+++ b/test/unit/math/opencl/multiply_test.cpp
@@ -191,6 +191,224 @@ TEST(MathMatrix, row_vector_matrix_big) {
   EXPECT_MATRIX_NEAR(m0, m0_cl_res, 1e-10);
 }
 
+TEST(MathMatrix, matrix_vector_tri_small) {
+  auto m = stan::math::matrix_d::Random(4, 5).eval();
+  auto v = stan::math::vector_d::Random(5).eval();
+  stan::math::matrix_d m0(4, 1);
+  stan::math::matrix_d m0_cl_res(4, 1);
+
+  stan::math::matrix_cl v_cl(v);
+  stan::math::matrix_cl m_cl(m);
+  stan::math::matrix_cl m0_cl(4, 1);
+
+  m0 = m * v.triangularView<Eigen::Lower>();
+  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Entire, stan::math::TriangularViewCL::Lower>(m_cl, v_cl);
+  stan::math::copy(m0_cl_res, m0_cl);
+  EXPECT_MATRIX_NEAR(m0, m0_cl_res, 1e-10);
+
+  m0 = m.triangularView<Eigen::Lower>() * v;
+  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Lower, stan::math::TriangularViewCL::Entire>(m_cl, v_cl);
+  stan::math::copy(m0_cl_res, m0_cl);
+  EXPECT_MATRIX_NEAR(m0, m0_cl_res, 1e-10);
+
+  m0 = m * v.triangularView<Eigen::Upper>();
+  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Entire, stan::math::TriangularViewCL::Upper>(m_cl, v_cl);
+  stan::math::copy(m0_cl_res, m0_cl);
+  EXPECT_MATRIX_NEAR(m0, m0_cl_res, 1e-10);
+
+  m0 = m.triangularView<Eigen::Upper>() * v;
+  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Upper, stan::math::TriangularViewCL::Entire>(m_cl, v_cl);
+  stan::math::copy(m0_cl_res, m0_cl);
+  EXPECT_MATRIX_NEAR(m0, m0_cl_res, 1e-10);
+
+  //the cast is needed because operator* for for two triangular views does not exist
+  m0 = static_cast<Eigen::MatrixXd>(m.triangularView<Eigen::Lower>()) * v.triangularView<Eigen::Lower>();
+  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Lower, stan::math::TriangularViewCL::Lower>(m_cl, v_cl);
+  stan::math::copy(m0_cl_res, m0_cl);
+  EXPECT_MATRIX_NEAR(m0, m0_cl_res, 1e-10);
+
+  m0 = static_cast<Eigen::MatrixXd>(m.triangularView<Eigen::Upper>()) * v.triangularView<Eigen::Upper>();
+  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Upper, stan::math::TriangularViewCL::Upper>(m_cl, v_cl);
+  stan::math::copy(m0_cl_res, m0_cl);
+  EXPECT_MATRIX_NEAR(m0, m0_cl_res, 1e-10);
+
+  m0 = static_cast<Eigen::MatrixXd>(m.triangularView<Eigen::Lower>()) * v.triangularView<Eigen::Upper>();
+  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Lower, stan::math::TriangularViewCL::Upper>(m_cl, v_cl);
+  stan::math::copy(m0_cl_res, m0_cl);
+  EXPECT_MATRIX_NEAR(m0, m0_cl_res, 1e-10);
+
+  m0 = static_cast<Eigen::MatrixXd>(m.triangularView<Eigen::Upper>()) * v.triangularView<Eigen::Lower>();
+  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Upper, stan::math::TriangularViewCL::Lower>(m_cl, v_cl);
+  stan::math::copy(m0_cl_res, m0_cl);
+  EXPECT_MATRIX_NEAR(m0, m0_cl_res, 1e-10);
+}
+
+TEST(MathMatrix, matrix_vector_tri_big) {
+  auto m = stan::math::matrix_d::Random(400, 600).eval();
+  auto v = stan::math::vector_d::Random(600).eval();
+  stan::math::matrix_d m0(400, 1);
+  stan::math::matrix_d m0_cl_res(400, 1);
+
+  stan::math::matrix_cl v_cl(v);
+  stan::math::matrix_cl m_cl(m);
+  stan::math::matrix_cl m0_cl(400, 1);
+
+  m0 = m * v.triangularView<Eigen::Lower>();
+  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Entire, stan::math::TriangularViewCL::Lower>(m_cl, v_cl);
+  stan::math::copy(m0_cl_res, m0_cl);
+  EXPECT_MATRIX_NEAR(m0, m0_cl_res, 1e-10);
+
+  m0 = m.triangularView<Eigen::Lower>() * v;
+  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Lower, stan::math::TriangularViewCL::Entire>(m_cl, v_cl);
+  stan::math::copy(m0_cl_res, m0_cl);
+  EXPECT_MATRIX_NEAR(m0, m0_cl_res, 1e-10);
+
+  m0 = m * v.triangularView<Eigen::Upper>();
+  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Entire, stan::math::TriangularViewCL::Upper>(m_cl, v_cl);
+  stan::math::copy(m0_cl_res, m0_cl);
+  EXPECT_MATRIX_NEAR(m0, m0_cl_res, 1e-10);
+
+  m0 = m.triangularView<Eigen::Upper>() * v;
+  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Upper, stan::math::TriangularViewCL::Entire>(m_cl, v_cl);
+  stan::math::copy(m0_cl_res, m0_cl);
+  EXPECT_MATRIX_NEAR(m0, m0_cl_res, 1e-10);
+
+  //the cast is needed because operator* for for two triangular views does not exist
+  m0 = static_cast<Eigen::MatrixXd>(m.triangularView<Eigen::Lower>()) * v.triangularView<Eigen::Lower>();
+  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Lower, stan::math::TriangularViewCL::Lower>(m_cl, v_cl);
+  stan::math::copy(m0_cl_res, m0_cl);
+  EXPECT_MATRIX_NEAR(m0, m0_cl_res, 1e-10);
+
+  m0 = static_cast<Eigen::MatrixXd>(m.triangularView<Eigen::Upper>()) * v.triangularView<Eigen::Upper>();
+  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Upper, stan::math::TriangularViewCL::Upper>(m_cl, v_cl);
+  stan::math::copy(m0_cl_res, m0_cl);
+  EXPECT_MATRIX_NEAR(m0, m0_cl_res, 1e-10);
+
+  m0 = static_cast<Eigen::MatrixXd>(m.triangularView<Eigen::Lower>()) * v.triangularView<Eigen::Upper>();
+  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Lower, stan::math::TriangularViewCL::Upper>(m_cl, v_cl);
+  stan::math::copy(m0_cl_res, m0_cl);
+  EXPECT_MATRIX_NEAR(m0, m0_cl_res, 1e-10);
+
+  m0 = static_cast<Eigen::MatrixXd>(m.triangularView<Eigen::Upper>()) * v.triangularView<Eigen::Lower>();
+  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Upper, stan::math::TriangularViewCL::Lower>(m_cl, v_cl);
+  stan::math::copy(m0_cl_res, m0_cl);
+  EXPECT_MATRIX_NEAR(m0, m0_cl_res, 1e-10);
+}
+
+TEST(MathMatrix, row_vector_matrix_tri_small) {
+  auto m = stan::math::matrix_d::Random(5, 4).eval();
+  auto rv = stan::math::row_vector_d::Random(5).eval();
+  stan::math::matrix_d m0(1, 4);
+  stan::math::matrix_d m0_cl_res(1, 4);
+
+  stan::math::matrix_cl m_cl(m);
+  stan::math::matrix_cl rv_cl(rv);
+  stan::math::matrix_cl m0_cl(1, 4);
+
+  m0 = rv * m;
+  m0_cl = rv_cl * m_cl;
+  stan::math::copy(m0_cl_res, m0_cl);
+  EXPECT_MATRIX_NEAR(m0, m0_cl_res, 1e-10);
+
+  m0 = rv * m.triangularView<Eigen::Lower>();
+  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Entire, stan::math::TriangularViewCL::Lower>(rv_cl, m_cl);
+  stan::math::copy(m0_cl_res, m0_cl);
+  EXPECT_MATRIX_NEAR(m0, m0_cl_res, 1e-10);
+
+  m0 = rv.triangularView<Eigen::Lower>() * m;
+  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Lower, stan::math::TriangularViewCL::Entire>(rv_cl, m_cl);
+  stan::math::copy(m0_cl_res, m0_cl);
+  EXPECT_MATRIX_NEAR(m0, m0_cl_res, 1e-10);
+
+  m0 = rv * m.triangularView<Eigen::Upper>();
+  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Entire, stan::math::TriangularViewCL::Upper>(rv_cl, m_cl);
+  stan::math::copy(m0_cl_res, m0_cl);
+  EXPECT_MATRIX_NEAR(m0, m0_cl_res, 1e-10);
+
+  m0 = rv.triangularView<Eigen::Upper>() * m;
+  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Upper, stan::math::TriangularViewCL::Entire>(rv_cl, m_cl);
+  stan::math::copy(m0_cl_res, m0_cl);
+  EXPECT_MATRIX_NEAR(m0, m0_cl_res, 1e-10);
+
+  //the cast is needed because operator* for for two triangular views does not exist
+  m0 = static_cast<Eigen::MatrixXd>(rv.triangularView<Eigen::Lower>()) * m.triangularView<Eigen::Lower>();
+  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Lower, stan::math::TriangularViewCL::Lower>(rv_cl, m_cl);
+  stan::math::copy(m0_cl_res, m0_cl);
+  EXPECT_MATRIX_NEAR(m0, m0_cl_res, 1e-10);
+
+  m0 = static_cast<Eigen::MatrixXd>(rv.triangularView<Eigen::Upper>()) * m.triangularView<Eigen::Upper>();
+  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Upper, stan::math::TriangularViewCL::Upper>(rv_cl, m_cl);
+  stan::math::copy(m0_cl_res, m0_cl);
+  EXPECT_MATRIX_NEAR(m0, m0_cl_res, 1e-10);
+
+  m0 = static_cast<Eigen::MatrixXd>(rv.triangularView<Eigen::Lower>()) * m.triangularView<Eigen::Upper>();
+  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Lower, stan::math::TriangularViewCL::Upper>(rv_cl, m_cl);
+  stan::math::copy(m0_cl_res, m0_cl);
+  EXPECT_MATRIX_NEAR(m0, m0_cl_res, 1e-10);
+
+  m0 = static_cast<Eigen::MatrixXd>(rv.triangularView<Eigen::Upper>()) * m.triangularView<Eigen::Lower>();
+  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Upper, stan::math::TriangularViewCL::Lower>(rv_cl, m_cl);
+  stan::math::copy(m0_cl_res, m0_cl);
+  EXPECT_MATRIX_NEAR(m0, m0_cl_res, 1e-10);
+}
+
+TEST(MathMatrix, row_vector_matrix_tri_big) {
+  auto m = stan::math::matrix_d::Random(600, 400).eval();
+  auto rv = stan::math::row_vector_d::Random(600).eval();
+  stan::math::matrix_d m0(1, 400);
+  stan::math::matrix_d m0_cl_res(1, 400);
+
+  stan::math::matrix_cl m_cl(m);
+  stan::math::matrix_cl rv_cl(rv);
+  stan::math::matrix_cl m0_cl(1, 400);
+
+  m0 = rv * m;
+  m0_cl = rv_cl * m_cl;
+  stan::math::copy(m0_cl_res, m0_cl);
+  EXPECT_MATRIX_NEAR(m0, m0_cl_res, 1e-10);
+
+  m0 = rv * m.triangularView<Eigen::Lower>();
+  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Entire, stan::math::TriangularViewCL::Lower>(rv_cl, m_cl);
+  stan::math::copy(m0_cl_res, m0_cl);
+  EXPECT_MATRIX_NEAR(m0, m0_cl_res, 1e-10);
+
+  m0 = rv.triangularView<Eigen::Lower>() * m;
+  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Lower, stan::math::TriangularViewCL::Entire>(rv_cl, m_cl);
+  stan::math::copy(m0_cl_res, m0_cl);
+  EXPECT_MATRIX_NEAR(m0, m0_cl_res, 1e-10);
+
+  m0 = rv * m.triangularView<Eigen::Upper>();
+  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Entire, stan::math::TriangularViewCL::Upper>(rv_cl, m_cl);
+  stan::math::copy(m0_cl_res, m0_cl);
+  EXPECT_MATRIX_NEAR(m0, m0_cl_res, 1e-10);
+
+  m0 = rv.triangularView<Eigen::Upper>() * m;
+  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Upper, stan::math::TriangularViewCL::Entire>(rv_cl, m_cl);
+  stan::math::copy(m0_cl_res, m0_cl);
+  EXPECT_MATRIX_NEAR(m0, m0_cl_res, 1e-10);
+
+  //the cast is needed because operator* for for two triangular views does not exist
+  m0 = static_cast<Eigen::MatrixXd>(rv.triangularView<Eigen::Lower>()) * m.triangularView<Eigen::Lower>();
+  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Lower, stan::math::TriangularViewCL::Lower>(rv_cl, m_cl);
+  stan::math::copy(m0_cl_res, m0_cl);
+  EXPECT_MATRIX_NEAR(m0, m0_cl_res, 1e-10);
+
+  m0 = static_cast<Eigen::MatrixXd>(rv.triangularView<Eigen::Upper>()) * m.triangularView<Eigen::Upper>();
+  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Upper, stan::math::TriangularViewCL::Upper>(rv_cl, m_cl);
+  stan::math::copy(m0_cl_res, m0_cl);
+  EXPECT_MATRIX_NEAR(m0, m0_cl_res, 1e-10);
+
+  m0 = static_cast<Eigen::MatrixXd>(rv.triangularView<Eigen::Lower>()) * m.triangularView<Eigen::Upper>();
+  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Lower, stan::math::TriangularViewCL::Upper>(rv_cl, m_cl);
+  stan::math::copy(m0_cl_res, m0_cl);
+  EXPECT_MATRIX_NEAR(m0, m0_cl_res, 1e-10);
+
+  m0 = static_cast<Eigen::MatrixXd>(rv.triangularView<Eigen::Upper>()) * m.triangularView<Eigen::Lower>();
+  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Upper, stan::math::TriangularViewCL::Lower>(rv_cl, m_cl);
+  stan::math::copy(m0_cl_res, m0_cl);
+  EXPECT_MATRIX_NEAR(m0, m0_cl_res, 1e-10);
+}
+
 TEST(MathMatrix, multiply_small) {
   using stan::math::multiply;
   auto m1 = stan::math::matrix_d::Random(3, 3).eval();

--- a/test/unit/math/opencl/multiply_test.cpp
+++ b/test/unit/math/opencl/multiply_test.cpp
@@ -202,43 +202,64 @@ TEST(MathMatrix, matrix_vector_tri_small) {
   stan::math::matrix_cl m0_cl(4, 1);
 
   m0 = m * v.triangularView<Eigen::Lower>();
-  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Entire, stan::math::TriangularViewCL::Lower>(m_cl, v_cl);
+  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Entire,
+                                       stan::math::TriangularViewCL::Lower>(
+      m_cl, v_cl);
   stan::math::copy(m0_cl_res, m0_cl);
   EXPECT_MATRIX_NEAR(m0, m0_cl_res, 1e-10);
 
   m0 = m.triangularView<Eigen::Lower>() * v;
-  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Lower, stan::math::TriangularViewCL::Entire>(m_cl, v_cl);
+  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Lower,
+                                       stan::math::TriangularViewCL::Entire>(
+      m_cl, v_cl);
   stan::math::copy(m0_cl_res, m0_cl);
   EXPECT_MATRIX_NEAR(m0, m0_cl_res, 1e-10);
 
   m0 = m * v.triangularView<Eigen::Upper>();
-  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Entire, stan::math::TriangularViewCL::Upper>(m_cl, v_cl);
+  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Entire,
+                                       stan::math::TriangularViewCL::Upper>(
+      m_cl, v_cl);
   stan::math::copy(m0_cl_res, m0_cl);
   EXPECT_MATRIX_NEAR(m0, m0_cl_res, 1e-10);
 
   m0 = m.triangularView<Eigen::Upper>() * v;
-  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Upper, stan::math::TriangularViewCL::Entire>(m_cl, v_cl);
+  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Upper,
+                                       stan::math::TriangularViewCL::Entire>(
+      m_cl, v_cl);
   stan::math::copy(m0_cl_res, m0_cl);
   EXPECT_MATRIX_NEAR(m0, m0_cl_res, 1e-10);
 
-  //the cast is needed because operator* for for two triangular views does not exist
-  m0 = static_cast<Eigen::MatrixXd>(m.triangularView<Eigen::Lower>()) * v.triangularView<Eigen::Lower>();
-  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Lower, stan::math::TriangularViewCL::Lower>(m_cl, v_cl);
+  // the cast is needed because operator* for for two triangular views does not
+  // exist
+  m0 = static_cast<Eigen::MatrixXd>(m.triangularView<Eigen::Lower>())
+       * v.triangularView<Eigen::Lower>();
+  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Lower,
+                                       stan::math::TriangularViewCL::Lower>(
+      m_cl, v_cl);
   stan::math::copy(m0_cl_res, m0_cl);
   EXPECT_MATRIX_NEAR(m0, m0_cl_res, 1e-10);
 
-  m0 = static_cast<Eigen::MatrixXd>(m.triangularView<Eigen::Upper>()) * v.triangularView<Eigen::Upper>();
-  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Upper, stan::math::TriangularViewCL::Upper>(m_cl, v_cl);
+  m0 = static_cast<Eigen::MatrixXd>(m.triangularView<Eigen::Upper>())
+       * v.triangularView<Eigen::Upper>();
+  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Upper,
+                                       stan::math::TriangularViewCL::Upper>(
+      m_cl, v_cl);
   stan::math::copy(m0_cl_res, m0_cl);
   EXPECT_MATRIX_NEAR(m0, m0_cl_res, 1e-10);
 
-  m0 = static_cast<Eigen::MatrixXd>(m.triangularView<Eigen::Lower>()) * v.triangularView<Eigen::Upper>();
-  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Lower, stan::math::TriangularViewCL::Upper>(m_cl, v_cl);
+  m0 = static_cast<Eigen::MatrixXd>(m.triangularView<Eigen::Lower>())
+       * v.triangularView<Eigen::Upper>();
+  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Lower,
+                                       stan::math::TriangularViewCL::Upper>(
+      m_cl, v_cl);
   stan::math::copy(m0_cl_res, m0_cl);
   EXPECT_MATRIX_NEAR(m0, m0_cl_res, 1e-10);
 
-  m0 = static_cast<Eigen::MatrixXd>(m.triangularView<Eigen::Upper>()) * v.triangularView<Eigen::Lower>();
-  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Upper, stan::math::TriangularViewCL::Lower>(m_cl, v_cl);
+  m0 = static_cast<Eigen::MatrixXd>(m.triangularView<Eigen::Upper>())
+       * v.triangularView<Eigen::Lower>();
+  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Upper,
+                                       stan::math::TriangularViewCL::Lower>(
+      m_cl, v_cl);
   stan::math::copy(m0_cl_res, m0_cl);
   EXPECT_MATRIX_NEAR(m0, m0_cl_res, 1e-10);
 }
@@ -254,43 +275,64 @@ TEST(MathMatrix, matrix_vector_tri_big) {
   stan::math::matrix_cl m0_cl(400, 1);
 
   m0 = m * v.triangularView<Eigen::Lower>();
-  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Entire, stan::math::TriangularViewCL::Lower>(m_cl, v_cl);
+  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Entire,
+                                       stan::math::TriangularViewCL::Lower>(
+      m_cl, v_cl);
   stan::math::copy(m0_cl_res, m0_cl);
   EXPECT_MATRIX_NEAR(m0, m0_cl_res, 1e-10);
 
   m0 = m.triangularView<Eigen::Lower>() * v;
-  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Lower, stan::math::TriangularViewCL::Entire>(m_cl, v_cl);
+  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Lower,
+                                       stan::math::TriangularViewCL::Entire>(
+      m_cl, v_cl);
   stan::math::copy(m0_cl_res, m0_cl);
   EXPECT_MATRIX_NEAR(m0, m0_cl_res, 1e-10);
 
   m0 = m * v.triangularView<Eigen::Upper>();
-  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Entire, stan::math::TriangularViewCL::Upper>(m_cl, v_cl);
+  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Entire,
+                                       stan::math::TriangularViewCL::Upper>(
+      m_cl, v_cl);
   stan::math::copy(m0_cl_res, m0_cl);
   EXPECT_MATRIX_NEAR(m0, m0_cl_res, 1e-10);
 
   m0 = m.triangularView<Eigen::Upper>() * v;
-  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Upper, stan::math::TriangularViewCL::Entire>(m_cl, v_cl);
+  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Upper,
+                                       stan::math::TriangularViewCL::Entire>(
+      m_cl, v_cl);
   stan::math::copy(m0_cl_res, m0_cl);
   EXPECT_MATRIX_NEAR(m0, m0_cl_res, 1e-10);
 
-  //the cast is needed because operator* for for two triangular views does not exist
-  m0 = static_cast<Eigen::MatrixXd>(m.triangularView<Eigen::Lower>()) * v.triangularView<Eigen::Lower>();
-  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Lower, stan::math::TriangularViewCL::Lower>(m_cl, v_cl);
+  // the cast is needed because operator* for for two triangular views does not
+  // exist
+  m0 = static_cast<Eigen::MatrixXd>(m.triangularView<Eigen::Lower>())
+       * v.triangularView<Eigen::Lower>();
+  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Lower,
+                                       stan::math::TriangularViewCL::Lower>(
+      m_cl, v_cl);
   stan::math::copy(m0_cl_res, m0_cl);
   EXPECT_MATRIX_NEAR(m0, m0_cl_res, 1e-10);
 
-  m0 = static_cast<Eigen::MatrixXd>(m.triangularView<Eigen::Upper>()) * v.triangularView<Eigen::Upper>();
-  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Upper, stan::math::TriangularViewCL::Upper>(m_cl, v_cl);
+  m0 = static_cast<Eigen::MatrixXd>(m.triangularView<Eigen::Upper>())
+       * v.triangularView<Eigen::Upper>();
+  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Upper,
+                                       stan::math::TriangularViewCL::Upper>(
+      m_cl, v_cl);
   stan::math::copy(m0_cl_res, m0_cl);
   EXPECT_MATRIX_NEAR(m0, m0_cl_res, 1e-10);
 
-  m0 = static_cast<Eigen::MatrixXd>(m.triangularView<Eigen::Lower>()) * v.triangularView<Eigen::Upper>();
-  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Lower, stan::math::TriangularViewCL::Upper>(m_cl, v_cl);
+  m0 = static_cast<Eigen::MatrixXd>(m.triangularView<Eigen::Lower>())
+       * v.triangularView<Eigen::Upper>();
+  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Lower,
+                                       stan::math::TriangularViewCL::Upper>(
+      m_cl, v_cl);
   stan::math::copy(m0_cl_res, m0_cl);
   EXPECT_MATRIX_NEAR(m0, m0_cl_res, 1e-10);
 
-  m0 = static_cast<Eigen::MatrixXd>(m.triangularView<Eigen::Upper>()) * v.triangularView<Eigen::Lower>();
-  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Upper, stan::math::TriangularViewCL::Lower>(m_cl, v_cl);
+  m0 = static_cast<Eigen::MatrixXd>(m.triangularView<Eigen::Upper>())
+       * v.triangularView<Eigen::Lower>();
+  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Upper,
+                                       stan::math::TriangularViewCL::Lower>(
+      m_cl, v_cl);
   stan::math::copy(m0_cl_res, m0_cl);
   EXPECT_MATRIX_NEAR(m0, m0_cl_res, 1e-10);
 }
@@ -311,43 +353,64 @@ TEST(MathMatrix, row_vector_matrix_tri_small) {
   EXPECT_MATRIX_NEAR(m0, m0_cl_res, 1e-10);
 
   m0 = rv * m.triangularView<Eigen::Lower>();
-  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Entire, stan::math::TriangularViewCL::Lower>(rv_cl, m_cl);
+  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Entire,
+                                       stan::math::TriangularViewCL::Lower>(
+      rv_cl, m_cl);
   stan::math::copy(m0_cl_res, m0_cl);
   EXPECT_MATRIX_NEAR(m0, m0_cl_res, 1e-10);
 
   m0 = rv.triangularView<Eigen::Lower>() * m;
-  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Lower, stan::math::TriangularViewCL::Entire>(rv_cl, m_cl);
+  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Lower,
+                                       stan::math::TriangularViewCL::Entire>(
+      rv_cl, m_cl);
   stan::math::copy(m0_cl_res, m0_cl);
   EXPECT_MATRIX_NEAR(m0, m0_cl_res, 1e-10);
 
   m0 = rv * m.triangularView<Eigen::Upper>();
-  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Entire, stan::math::TriangularViewCL::Upper>(rv_cl, m_cl);
+  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Entire,
+                                       stan::math::TriangularViewCL::Upper>(
+      rv_cl, m_cl);
   stan::math::copy(m0_cl_res, m0_cl);
   EXPECT_MATRIX_NEAR(m0, m0_cl_res, 1e-10);
 
   m0 = rv.triangularView<Eigen::Upper>() * m;
-  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Upper, stan::math::TriangularViewCL::Entire>(rv_cl, m_cl);
+  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Upper,
+                                       stan::math::TriangularViewCL::Entire>(
+      rv_cl, m_cl);
   stan::math::copy(m0_cl_res, m0_cl);
   EXPECT_MATRIX_NEAR(m0, m0_cl_res, 1e-10);
 
-  //the cast is needed because operator* for for two triangular views does not exist
-  m0 = static_cast<Eigen::MatrixXd>(rv.triangularView<Eigen::Lower>()) * m.triangularView<Eigen::Lower>();
-  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Lower, stan::math::TriangularViewCL::Lower>(rv_cl, m_cl);
+  // the cast is needed because operator* for for two triangular views does not
+  // exist
+  m0 = static_cast<Eigen::MatrixXd>(rv.triangularView<Eigen::Lower>())
+       * m.triangularView<Eigen::Lower>();
+  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Lower,
+                                       stan::math::TriangularViewCL::Lower>(
+      rv_cl, m_cl);
   stan::math::copy(m0_cl_res, m0_cl);
   EXPECT_MATRIX_NEAR(m0, m0_cl_res, 1e-10);
 
-  m0 = static_cast<Eigen::MatrixXd>(rv.triangularView<Eigen::Upper>()) * m.triangularView<Eigen::Upper>();
-  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Upper, stan::math::TriangularViewCL::Upper>(rv_cl, m_cl);
+  m0 = static_cast<Eigen::MatrixXd>(rv.triangularView<Eigen::Upper>())
+       * m.triangularView<Eigen::Upper>();
+  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Upper,
+                                       stan::math::TriangularViewCL::Upper>(
+      rv_cl, m_cl);
   stan::math::copy(m0_cl_res, m0_cl);
   EXPECT_MATRIX_NEAR(m0, m0_cl_res, 1e-10);
 
-  m0 = static_cast<Eigen::MatrixXd>(rv.triangularView<Eigen::Lower>()) * m.triangularView<Eigen::Upper>();
-  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Lower, stan::math::TriangularViewCL::Upper>(rv_cl, m_cl);
+  m0 = static_cast<Eigen::MatrixXd>(rv.triangularView<Eigen::Lower>())
+       * m.triangularView<Eigen::Upper>();
+  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Lower,
+                                       stan::math::TriangularViewCL::Upper>(
+      rv_cl, m_cl);
   stan::math::copy(m0_cl_res, m0_cl);
   EXPECT_MATRIX_NEAR(m0, m0_cl_res, 1e-10);
 
-  m0 = static_cast<Eigen::MatrixXd>(rv.triangularView<Eigen::Upper>()) * m.triangularView<Eigen::Lower>();
-  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Upper, stan::math::TriangularViewCL::Lower>(rv_cl, m_cl);
+  m0 = static_cast<Eigen::MatrixXd>(rv.triangularView<Eigen::Upper>())
+       * m.triangularView<Eigen::Lower>();
+  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Upper,
+                                       stan::math::TriangularViewCL::Lower>(
+      rv_cl, m_cl);
   stan::math::copy(m0_cl_res, m0_cl);
   EXPECT_MATRIX_NEAR(m0, m0_cl_res, 1e-10);
 }
@@ -368,43 +431,64 @@ TEST(MathMatrix, row_vector_matrix_tri_big) {
   EXPECT_MATRIX_NEAR(m0, m0_cl_res, 1e-10);
 
   m0 = rv * m.triangularView<Eigen::Lower>();
-  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Entire, stan::math::TriangularViewCL::Lower>(rv_cl, m_cl);
+  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Entire,
+                                       stan::math::TriangularViewCL::Lower>(
+      rv_cl, m_cl);
   stan::math::copy(m0_cl_res, m0_cl);
   EXPECT_MATRIX_NEAR(m0, m0_cl_res, 1e-10);
 
   m0 = rv.triangularView<Eigen::Lower>() * m;
-  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Lower, stan::math::TriangularViewCL::Entire>(rv_cl, m_cl);
+  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Lower,
+                                       stan::math::TriangularViewCL::Entire>(
+      rv_cl, m_cl);
   stan::math::copy(m0_cl_res, m0_cl);
   EXPECT_MATRIX_NEAR(m0, m0_cl_res, 1e-10);
 
   m0 = rv * m.triangularView<Eigen::Upper>();
-  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Entire, stan::math::TriangularViewCL::Upper>(rv_cl, m_cl);
+  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Entire,
+                                       stan::math::TriangularViewCL::Upper>(
+      rv_cl, m_cl);
   stan::math::copy(m0_cl_res, m0_cl);
   EXPECT_MATRIX_NEAR(m0, m0_cl_res, 1e-10);
 
   m0 = rv.triangularView<Eigen::Upper>() * m;
-  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Upper, stan::math::TriangularViewCL::Entire>(rv_cl, m_cl);
+  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Upper,
+                                       stan::math::TriangularViewCL::Entire>(
+      rv_cl, m_cl);
   stan::math::copy(m0_cl_res, m0_cl);
   EXPECT_MATRIX_NEAR(m0, m0_cl_res, 1e-10);
 
-  //the cast is needed because operator* for for two triangular views does not exist
-  m0 = static_cast<Eigen::MatrixXd>(rv.triangularView<Eigen::Lower>()) * m.triangularView<Eigen::Lower>();
-  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Lower, stan::math::TriangularViewCL::Lower>(rv_cl, m_cl);
+  // the cast is needed because operator* for for two triangular views does not
+  // exist
+  m0 = static_cast<Eigen::MatrixXd>(rv.triangularView<Eigen::Lower>())
+       * m.triangularView<Eigen::Lower>();
+  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Lower,
+                                       stan::math::TriangularViewCL::Lower>(
+      rv_cl, m_cl);
   stan::math::copy(m0_cl_res, m0_cl);
   EXPECT_MATRIX_NEAR(m0, m0_cl_res, 1e-10);
 
-  m0 = static_cast<Eigen::MatrixXd>(rv.triangularView<Eigen::Upper>()) * m.triangularView<Eigen::Upper>();
-  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Upper, stan::math::TriangularViewCL::Upper>(rv_cl, m_cl);
+  m0 = static_cast<Eigen::MatrixXd>(rv.triangularView<Eigen::Upper>())
+       * m.triangularView<Eigen::Upper>();
+  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Upper,
+                                       stan::math::TriangularViewCL::Upper>(
+      rv_cl, m_cl);
   stan::math::copy(m0_cl_res, m0_cl);
   EXPECT_MATRIX_NEAR(m0, m0_cl_res, 1e-10);
 
-  m0 = static_cast<Eigen::MatrixXd>(rv.triangularView<Eigen::Lower>()) * m.triangularView<Eigen::Upper>();
-  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Lower, stan::math::TriangularViewCL::Upper>(rv_cl, m_cl);
+  m0 = static_cast<Eigen::MatrixXd>(rv.triangularView<Eigen::Lower>())
+       * m.triangularView<Eigen::Upper>();
+  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Lower,
+                                       stan::math::TriangularViewCL::Upper>(
+      rv_cl, m_cl);
   stan::math::copy(m0_cl_res, m0_cl);
   EXPECT_MATRIX_NEAR(m0, m0_cl_res, 1e-10);
 
-  m0 = static_cast<Eigen::MatrixXd>(rv.triangularView<Eigen::Upper>()) * m.triangularView<Eigen::Lower>();
-  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Upper, stan::math::TriangularViewCL::Lower>(rv_cl, m_cl);
+  m0 = static_cast<Eigen::MatrixXd>(rv.triangularView<Eigen::Upper>())
+       * m.triangularView<Eigen::Lower>();
+  m0_cl = stan::math::opencl::multiply<stan::math::TriangularViewCL::Upper,
+                                       stan::math::TriangularViewCL::Lower>(
+      rv_cl, m_cl);
   stan::math::copy(m0_cl_res, m0_cl);
   EXPECT_MATRIX_NEAR(m0, m0_cl_res, 1e-10);
 }


### PR DESCRIPTION
## Summary
Adds two new opencl kernels for operations matrix\*vector and vector\*matrix. They are used within `multiply(matrix_cl, matrix_cl)` when appropriate. Both are significantly faster than general kernel for matrix multiplication.

## Tests
New tests are added to opencl/multiply_test.cpp for cases matrix\*vector and vector\*matrix.

## Side Effects

None

## Checklist

- [ ] Math issue #1191

- [ ] Copyright holder: Tadej Ciglarič, University of Ljubljana

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [ ] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [ ] the code is written in idiomatic C++ and changes are documented in the doxygen

- [ ] the new changes are tested
