### PR TITLE
Iissue 1197 eigen methods for autodiff types

### DIFF
--- a/stan/math/fwd/core/fvar.hpp
+++ b/stan/math/fwd/core/fvar.hpp
@@ -40,6 +40,11 @@ namespace math {
 template <typename T>
 struct fvar {
   /**
+   * The type of this variable.
+   */
+  typedef T type;
+
+  /**
    * The value of this variable.
    */
   T val_;

--- a/stan/math/fwd/mat.hpp
+++ b/stan/math/fwd/mat.hpp
@@ -1,12 +1,12 @@
 #ifndef STAN_MATH_FWD_MAT_HPP
 #define STAN_MATH_FWD_MAT_HPP
 
+#include <stan/math/prim/mat.hpp>
 #include <stan/math/fwd/core.hpp>
 #include <stan/math/fwd/scal/meta/is_fvar.hpp>
 #include <stan/math/fwd/scal/meta/partials_type.hpp>
 
 #include <stan/math/fwd/mat/vectorize/apply_scalar_unary.hpp>
-#include <stan/math/prim/mat.hpp>
 #include <stan/math/fwd/arr.hpp>
 
 #include <stan/math/fwd/mat/fun/Eigen_NumTraits.hpp>

--- a/stan/math/fwd/mat/fun/determinant.hpp
+++ b/stan/math/fwd/mat/fun/determinant.hpp
@@ -3,14 +3,7 @@
 
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/fwd/core.hpp>
-#include <stan/math/fwd/mat/fun/typedefs.hpp>
-#include <stan/math/prim/mat/fun/multiply.hpp>
-#include <stan/math/fwd/mat/fun/multiply.hpp>
-#include <stan/math/prim/mat/fun/inverse.hpp>
-#include <stan/math/fwd/mat/fun/inverse.hpp>
 #include <stan/math/prim/mat/err/check_square.hpp>
-#include <boost/math/tools/promotion.hpp>
-#include <vector>
 
 namespace stan {
 namespace math {
@@ -18,24 +11,11 @@ namespace math {
 template <typename T, int R, int C>
 inline fvar<T> determinant(const Eigen::Matrix<fvar<T>, R, C>& m) {
   check_square("determinant", "m", m);
-  Eigen::Matrix<T, R, C> m_deriv(m.rows(), m.cols());
-  Eigen::Matrix<T, R, C> m_val(m.rows(), m.cols());
-
-  for (size_type i = 0; i < m.rows(); i++) {
-    for (size_type j = 0; j < m.cols(); j++) {
-      m_deriv(i, j) = m(i, j).d_;
-      m_val(i, j) = m(i, j).val_;
-    }
-  }
-
-  Eigen::Matrix<T, R, C> m_inv = inverse(m_val);
-  m_deriv = multiply(m_inv, m_deriv);
 
   fvar<T> result;
-  result.val_ = m_val.determinant();
-  result.d_ = result.val_ * m_deriv.trace();
+  result.val_ = m.val_().determinant();
+  result.d_ = result.val_ * (m.val_().inverse() * m.d_()).trace();
 
-  // FIXME:  I think this will overcopy compared to retur fvar<T>(...);
   return result;
 }
 

--- a/stan/math/mix/mat.hpp
+++ b/stan/math/mix/mat.hpp
@@ -1,13 +1,13 @@
 #ifndef STAN_MATH_MIX_MAT_HPP
 #define STAN_MATH_MIX_MAT_HPP
 
+#include <stan/math/prim/mat.hpp>
+
 #include <stan/math/mix/mat/fun/typedefs.hpp>
 
 #include <stan/math/rev/mat.hpp>
 
 #include <stan/math/fwd/mat.hpp>
-
-#include <stan/math/prim/mat.hpp>
 
 #include <stan/math/mix/mat/functor/derivative.hpp>
 #include <stan/math/mix/mat/functor/finite_diff_grad_hessian.hpp>

--- a/stan/math/prim/mat.hpp
+++ b/stan/math/prim/mat.hpp
@@ -1,6 +1,8 @@
 #ifndef STAN_MATH_PRIM_MAT_HPP
 #define STAN_MATH_PRIM_MAT_HPP
 
+#include <stan/math/prim/mat/fun/Eigen.hpp>
+
 #include <stan/math/prim/arr/meta/get.hpp>
 #include <stan/math/prim/arr/meta/index_type.hpp>
 #include <stan/math/prim/arr/meta/is_vector.hpp>
@@ -48,7 +50,6 @@
 #include <stan/math/prim/mat/err/constraint_tolerance.hpp>
 #include <stan/math/prim/mat/err/validate_non_negative_index.hpp>
 
-#include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/mat/fun/LDLT_factor.hpp>
 #include <stan/math/prim/mat/fun/Phi.hpp>
 #include <stan/math/prim/mat/fun/Phi_approx.hpp>

--- a/stan/math/prim/mat/fun/Eigen.hpp
+++ b/stan/math/prim/mat/fun/Eigen.hpp
@@ -1,6 +1,8 @@
 #ifndef STAN_MATH_PRIM_MAT_FUN_EIGEN_HPP
 #define STAN_MATH_PRIM_MAT_FUN_EIGEN_HPP
 
+#define EIGEN_MATRIXBASE_PLUGIN "stan/math/prim/mat/matrix_addons.h"
+
 #include <Eigen/Dense>
 #include <Eigen/QR>
 #include <Eigen/src/Core/NumTraits.h>

--- a/stan/math/prim/mat/matrix_addons.h
+++ b/stan/math/prim/mat/matrix_addons.h
@@ -1,0 +1,129 @@
+/**
+ * Structure to return value from an fvar. The first definition takes
+ * a const fvar and returns a const double (for reading from a const matrix).
+ * The second definition takes a non-const fvar and returns a non-const
+ * double (for writing to a non-const matrix)
+ */
+struct val__Op {
+  EIGEN_EMPTY_STRUCT_CTOR(val__Op)
+  typedef typename Scalar::type result_type;
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const result_type& 
+    operator()(const Scalar &v) const { return v.val_; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE result_type& 
+    operator()(Scalar &v) const { return v.val_; }
+};
+
+/**
+ * Coefficient-wise function applying val__Op struct to a matrix of const fvar<T>
+ * and returning a matrix of type T containing the values
+ */
+inline const CwiseUnaryView<val__Op, const Derived>
+val_() const { return CwiseUnaryView<val__Op, const Derived>
+    (derived(), val__Op());
+}
+
+/**
+ * Coefficient-wise function applying val__Op struct to a matrix of fvar<T>
+ * and returning a view to a matrix of type T of the values that can
+ * be modified
+ */
+inline CwiseUnaryView<val__Op, Derived>
+val_() { return CwiseUnaryView<val__Op, Derived>
+    (derived(), val__Op());
+}
+
+/**
+ * Structure to return tangent from an fvar. The first definition takes
+ * a const fvar and returns a const double (for reading from a const matrix).
+ * The second definition takes a non-const fvar and returns a non-const
+ * double (for writing to a non-const matrix)
+ */
+struct d__Op {
+  EIGEN_EMPTY_STRUCT_CTOR(d__Op)
+  typedef typename Scalar::type result_type;
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const result_type& 
+    operator()(const Scalar &v) const { return v.d_; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE result_type& 
+    operator()(Scalar &v) const { return v.d_; }
+};
+
+/**
+ * Coefficient-wise function applying d__Op struct to a matrix of const fvar<T>
+ * and returning a const matrix of type T containing the tangents
+ */
+inline const CwiseUnaryView<d__Op, const Derived>
+d_() const { return CwiseUnaryView<d__Op, const Derived>
+    (derived(), d__Op());
+}
+
+/**
+ * Coefficient-wise function applying d__Op struct to a matrix of fvar<T>
+ * and returning a view to a matrix of type T of the tangents that can
+ * be modified
+ */
+inline CwiseUnaryView<d__Op, Derived>
+d_() { return CwiseUnaryView<d__Op, Derived>
+    (derived(), d__Op());
+}
+
+/**
+ * Structure to return value from a var. The definition takes
+ * a const var and returns a const double (for reading from a const matrix).
+ */
+struct val_Op {
+  EIGEN_EMPTY_STRUCT_CTOR(val_Op)
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const double& 
+    operator()(const Scalar &v) const { return v.vi_->val_; }
+};
+
+/**
+ * Coefficient-wise function applying val_Op struct to a matrix of const var
+ * and returning a const matrix of type T containing the values
+ */
+inline const CwiseUnaryView<val_Op, const Derived>
+val() const { return CwiseUnaryView<val_Op, const Derived>
+    (derived(), val_Op());
+}
+
+/**
+ * Structure to return adjoint from a var. The first definition takes
+ * a const var and returns a const double (for reading from a const matrix).
+ * The second definition takes a non-const var and returns a non-const
+ * double (for writing to a non-const matrix)
+ */
+struct adj_Op {
+  EIGEN_EMPTY_STRUCT_CTOR(adj_Op)
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const double& 
+    operator()(const Scalar &v) const { return v.vi_->adj_; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE double& 
+    operator()(Scalar &v) const { return v.vi_->adj_; }
+};
+
+/**
+ * Coefficient-wise function applying adj_Op struct to a matrix of const var
+ * and returning a const matrix of type T containing the values
+ */
+inline const CwiseUnaryView<adj_Op, const Derived>
+adj() const { return CwiseUnaryView<adj_Op, const Derived>
+    (derived(), adj_Op());
+}
+
+/**
+ * Coefficient-wise function applying adj_Op struct to a matrix of var
+ * and returning a view to a matrix of type T of the adjoints that can
+ * be modified
+ */
+inline CwiseUnaryView<adj_Op, Derived>
+adj() { return CwiseUnaryView<adj_Op, Derived>
+    (derived(), adj_Op());
+}

--- a/stan/math/rev/mat.hpp
+++ b/stan/math/rev/mat.hpp
@@ -1,6 +1,8 @@
 #ifndef STAN_MATH_REV_MAT_HPP
 #define STAN_MATH_REV_MAT_HPP
 
+#include <stan/math/prim/mat.hpp>
+
 #include <stan/math/rev/core.hpp>
 #include <stan/math/rev/scal/meta/is_var.hpp>
 #include <stan/math/rev/scal/meta/partials_type.hpp>
@@ -9,7 +11,6 @@
 #include <stan/math/rev/mat/fun/Eigen_NumTraits.hpp>
 
 #include <stan/math/rev/mat/vectorize/apply_scalar_unary.hpp>
-#include <stan/math/prim/mat.hpp>
 #include <stan/math/rev/arr.hpp>
 
 #include <stan/math/rev/mat/fun/cholesky_decompose.hpp>

--- a/test/unit/math/fwd/mat/fun/determinant_test.cpp
+++ b/test/unit/math/fwd/mat/fun/determinant_test.cpp
@@ -1,3 +1,4 @@
+#include <stan/math/fwd/mat/fun/determinant.hpp>
 #include <stan/math/fwd/mat.hpp>
 #include <gtest/gtest.h>
 


### PR DESCRIPTION
## Summary

Uses Eigen's plugin system to add methods for extracting and manipulating the values/gradients from matrices of fvar and var.

For ```var```:

- ```.val()``` provides read-only access to the values
- ```.adj()``` provides read and write access to the adjoints

For ```fvar<T>```:

- ```.val_()``` provides read and write access to the values
- ```.d_()```  provides read and write access to the tangents

This also works with mixed-mode variables, such as ```fvar<var>``` (e.g. ```.val_().val()```)

This requires that the header ```prim/mat/fun/Eigen.hpp``` be included before any other Eigen headers.

I had to modify the ```fvar``` struct to have a method for returning the type of the containing variable. Without this, another header file would have been needed (like ```partials_type``)`

## Tests

```fwd/mat/fun/determinant``` has been re-written to use the new methods

## Side Effects

None

## Checklist

- [x] Math issue #1197

- [x] Copyright holder: Andrew Johnson

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
