### PR TITLE
replace std::ptr_fun with std::function

### DIFF
--- a/stan/math/prim/mat/err/is_lower_triangular.hpp
+++ b/stan/math/prim/mat/err/is_lower_triangular.hpp
@@ -22,7 +22,7 @@ inline double notNan(double x) { return std::isnan(x) ? 1.0 : x; }
 template <typename T_y>
 inline bool is_lower_triangular(
     const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>& y) {
-  return y.unaryExpr(std::ptr_fun(internal::notNan))
+  return y.unaryExpr(std::function<double(double)>(internal::notNan))
       .transpose()
       .isUpperTriangular();
 }


### PR DESCRIPTION
## Summary

std::ptr_fun was deprecated in C++11 and removed from the standard for C++17 (https://en.cppreference.com/w/cpp/utility/functional/ptr_fun)
std::function is supported since C++11 (https://en.cppreference.com/w/cpp/utility/functional/function)

## Tests

Nothing new, ./runTests.py test/unit/math/prim/mat/err/is_lower_triangular_test.cpp passes

## Side Effects

If we wanted to support earlier C++ standards (for RStan?), perhaps it's possible to detect whether to use std::ptr_fun or std::function at compile time

## Checklist

- [ ] Math issue #(issue number)

    I have not created an issue for this pull request.

- [x] Copyright holder: Tal Kedar

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
