### PR TITLE
bugfix/issue 336 length 0 checks after consistency check

### DIFF
--- a/stan/math/prim/mat/prob/bernoulli_logit_glm_lpmf.hpp
+++ b/stan/math/prim/mat/prob/bernoulli_logit_glm_lpmf.hpp
@@ -70,7 +70,6 @@ typename return_type<T_x, T_alpha, T_beta>::type bernoulli_logit_glm_lpmf(
   using Eigen::Matrix;
   using std::exp;
 
-
   const size_t N = x.rows();
   const size_t M = x.cols();
 

--- a/stan/math/prim/mat/prob/bernoulli_logit_glm_lpmf.hpp
+++ b/stan/math/prim/mat/prob/bernoulli_logit_glm_lpmf.hpp
@@ -22,7 +22,6 @@
 #include <stan/math/prim/mat/meta/is_vector.hpp>
 #include <stan/math/prim/scal/meta/scalar_seq_view.hpp>
 #include <stan/math/prim/scal/fun/size_zero.hpp>
-#include <boost/random/variate_generator.hpp>
 #include <cmath>
 
 namespace stan {
@@ -71,10 +70,6 @@ typename return_type<T_x, T_alpha, T_beta>::type bernoulli_logit_glm_lpmf(
   using Eigen::Matrix;
   using std::exp;
 
-  if (size_zero(y, x, beta))
-    return 0.0;
-
-  T_partials_return logp(0.0);
 
   const size_t N = x.rows();
   const size_t M = x.cols();
@@ -86,9 +81,13 @@ typename return_type<T_x, T_alpha, T_beta>::type bernoulli_logit_glm_lpmf(
     check_consistent_sizes(function, "Vector of intercepts", alpha,
                            "Vector of dependent variables", y);
 
+  if (size_zero(y, x, beta))
+    return 0.0;
+
   if (!include_summand<propto, T_x, T_alpha, T_beta>::value)
     return 0.0;
 
+  T_partials_return logp(0.0);
   const auto &x_val = value_of_rec(x);
   const auto &y_val = value_of_rec(y);
   const auto &beta_val = value_of_rec(beta);

--- a/stan/math/prim/mat/prob/bernoulli_logit_glm_lpmf.hpp
+++ b/stan/math/prim/mat/prob/bernoulli_logit_glm_lpmf.hpp
@@ -81,12 +81,12 @@ typename return_type<T_x, T_alpha, T_beta>::type bernoulli_logit_glm_lpmf(
                            "Vector of dependent variables", y);
 
   if (size_zero(y, x, beta))
-    return 0.0;
+    return 0;
 
   if (!include_summand<propto, T_x, T_alpha, T_beta>::value)
-    return 0.0;
+    return 0;
 
-  T_partials_return logp(0.0);
+  T_partials_return logp(0);
   const auto &x_val = value_of_rec(x);
   const auto &y_val = value_of_rec(y);
   const auto &beta_val = value_of_rec(beta);

--- a/stan/math/prim/mat/prob/gaussian_dlm_obs_lpdf.hpp
+++ b/stan/math/prim/mat/prob/gaussian_dlm_obs_lpdf.hpp
@@ -104,11 +104,11 @@ gaussian_dlm_obs_lpdf(
   check_size_match(function, "rows of C0", C0.rows(), "rows of G", G.rows());
   check_pos_definite(function, "C0", C0);
   check_finite(function, "C0", C0);
-
-  T_lp lp(0.0);
+  
   if (size_zero(y))
-    return lp;
+    return 0;
 
+  T_lp lp(0);
   if (include_summand<propto>::value) {
     lp -= 0.5 * LOG_TWO_PI * r * T;
   }
@@ -230,8 +230,6 @@ gaussian_dlm_obs_lpdf(
   typedef
       typename return_type<T_y, typename return_type<T_F, T_G, T_V, T_W, T_m0,
                                                      T_C0>::type>::type T_lp;
-  T_lp lp(0.0);
-
   using std::log;
 
   int r = y.rows();  // number of variables
@@ -266,8 +264,9 @@ gaussian_dlm_obs_lpdf(
   check_not_nan(function, "C0", C0);
 
   if (y.cols() == 0 || y.rows() == 0)
-    return lp;
+    return 0;
 
+  T_lp lp(0);
   if (include_summand<propto>::value) {
     lp += 0.5 * NEG_LOG_TWO_PI * r * T;
   }

--- a/stan/math/prim/mat/prob/gaussian_dlm_obs_lpdf.hpp
+++ b/stan/math/prim/mat/prob/gaussian_dlm_obs_lpdf.hpp
@@ -107,7 +107,7 @@ gaussian_dlm_obs_lpdf(
 
   T_lp lp(0.0);
   if (size_zero(y))
-    return lp;  
+    return lp;
 
   if (include_summand<propto>::value) {
     lp -= 0.5 * LOG_TWO_PI * r * T;

--- a/stan/math/prim/mat/prob/gaussian_dlm_obs_lpdf.hpp
+++ b/stan/math/prim/mat/prob/gaussian_dlm_obs_lpdf.hpp
@@ -1,8 +1,6 @@
 #ifndef STAN_MATH_PRIM_MAT_PROB_GAUSSIAN_DLM_OBS_LPDF_HPP
 #define STAN_MATH_PRIM_MAT_PROB_GAUSSIAN_DLM_OBS_LPDF_HPP
 
-#include <boost/random/normal_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
 #include <stan/math/prim/mat/err/check_pos_definite.hpp>
 #include <stan/math/prim/scal/err/check_size_match.hpp>
 #include <stan/math/prim/mat/err/check_spsd_matrix.hpp>
@@ -82,8 +80,6 @@ gaussian_dlm_obs_lpdf(
   typedef
       typename return_type<T_y, typename return_type<T_F, T_G, T_V, T_W, T_m0,
                                                      T_C0>::type>::type T_lp;
-  T_lp lp(0.0);
-
   int r = y.rows();  // number of variables
   int T = y.cols();  // number of observations
   int n = G.rows();  // number of states
@@ -109,8 +105,9 @@ gaussian_dlm_obs_lpdf(
   check_pos_definite(function, "C0", C0);
   check_finite(function, "C0", C0);
 
-  if (y.cols() == 0 || y.rows() == 0)
-    return lp;
+  T_lp lp(0.0);
+  if (size_zero(y))
+    return lp;  
 
   if (include_summand<propto>::value) {
     lp -= 0.5 * LOG_TWO_PI * r * T;

--- a/stan/math/prim/mat/prob/gaussian_dlm_obs_lpdf.hpp
+++ b/stan/math/prim/mat/prob/gaussian_dlm_obs_lpdf.hpp
@@ -104,7 +104,7 @@ gaussian_dlm_obs_lpdf(
   check_size_match(function, "rows of C0", C0.rows(), "rows of G", G.rows());
   check_pos_definite(function, "C0", C0);
   check_finite(function, "C0", C0);
-  
+
   if (size_zero(y))
     return 0;
 

--- a/stan/math/prim/mat/prob/multi_gp_cholesky_lpdf.hpp
+++ b/stan/math/prim/mat/prob/multi_gp_cholesky_lpdf.hpp
@@ -45,7 +45,7 @@ multi_gp_cholesky_lpdf(
   static const char* function = "multi_gp_cholesky_lpdf";
   typedef
       typename boost::math::tools::promote_args<T_y, T_covar, T_w>::type T_lp;
-  
+
   check_size_match(function, "Size of random variable (rows y)", y.rows(),
                    "Size of kernel scales (w)", w.size());
   check_size_match(function, "Size of random variable", y.cols(),

--- a/stan/math/prim/mat/prob/multi_gp_cholesky_lpdf.hpp
+++ b/stan/math/prim/mat/prob/multi_gp_cholesky_lpdf.hpp
@@ -45,8 +45,7 @@ multi_gp_cholesky_lpdf(
   static const char* function = "multi_gp_cholesky_lpdf";
   typedef
       typename boost::math::tools::promote_args<T_y, T_covar, T_w>::type T_lp;
-  T_lp lp(0.0);
-
+  
   check_size_match(function, "Size of random variable (rows y)", y.rows(),
                    "Size of kernel scales (w)", w.size());
   check_size_match(function, "Size of random variable", y.cols(),
@@ -55,6 +54,7 @@ multi_gp_cholesky_lpdf(
   check_positive(function, "Kernel scales", w);
   check_finite(function, "Random variable", y);
 
+  T_lp lp(0.0);
   if (y.rows() == 0)
     return lp;
 

--- a/stan/math/prim/mat/prob/multi_gp_cholesky_lpdf.hpp
+++ b/stan/math/prim/mat/prob/multi_gp_cholesky_lpdf.hpp
@@ -54,10 +54,10 @@ multi_gp_cholesky_lpdf(
   check_positive(function, "Kernel scales", w);
   check_finite(function, "Random variable", y);
 
-  T_lp lp(0.0);
   if (y.rows() == 0)
-    return lp;
+    return 0;
 
+  T_lp lp(0);
   if (include_summand<propto>::value) {
     lp += NEG_LOG_SQRT_TWO_PI * y.rows() * y.cols();
   }
@@ -71,7 +71,7 @@ multi_gp_cholesky_lpdf(
   }
 
   if (include_summand<propto, T_y, T_w, T_covar>::value) {
-    T_lp sum_lp_vec(0.0);
+    T_lp sum_lp_vec(0);
     for (int i = 0; i < y.rows(); i++) {
       Eigen::Matrix<T_y, Eigen::Dynamic, 1> y_row(y.row(i));
       Eigen::Matrix<

--- a/stan/math/prim/mat/prob/multi_normal_cholesky_lpdf.hpp
+++ b/stan/math/prim/mat/prob/multi_normal_cholesky_lpdf.hpp
@@ -63,7 +63,7 @@ typename return_type<T_y, T_loc, T_covar>::type multi_normal_cholesky_lpdf(
   size_t number_of_y = length_mvt(y);
   size_t number_of_mu = length_mvt(mu);
   if (number_of_y == 0 || number_of_mu == 0)
-    return 0.0;
+    return 0;
   vector_seq_view<T_y> y_vec(y);
   vector_seq_view<T_loc> mu_vec(mu);
   const size_t size_vec = max_size_mvt(y, mu);
@@ -112,9 +112,9 @@ typename return_type<T_y, T_loc, T_covar>::type multi_normal_cholesky_lpdf(
   }
 
   if (unlikely(size_y == 0))
-    return T_return(0.0);
+    return T_return(0);
 
-  T_partials_return logp(0.0);
+  T_partials_return logp(0);
   operands_and_partials<T_y, T_loc, T_covar> ops_partials(y, mu, L);
 
   if (include_summand<propto>::value)

--- a/stan/math/prim/mat/prob/multi_normal_cholesky_lpdf.hpp
+++ b/stan/math/prim/mat/prob/multi_normal_cholesky_lpdf.hpp
@@ -19,8 +19,6 @@
 #include <stan/math/prim/scal/meta/include_summand.hpp>
 #include <stan/math/prim/scal/meta/likely.hpp>
 #include <stan/math/prim/scal/meta/return_type.hpp>
-#include <boost/random/normal_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
 
 namespace stan {
 namespace math {
@@ -61,12 +59,11 @@ typename return_type<T_y, T_loc, T_covar>::type multi_normal_cholesky_lpdf(
   typedef Eigen::Matrix<T_partials_return, 1, Eigen::Dynamic>
       row_vector_partials_t;
 
+  check_consistent_sizes_mvt(function, "y", y, "mu", mu);
   size_t number_of_y = length_mvt(y);
   size_t number_of_mu = length_mvt(mu);
   if (number_of_y == 0 || number_of_mu == 0)
     return 0.0;
-  check_consistent_sizes_mvt(function, "y", y, "mu", mu);
-
   vector_seq_view<T_y> y_vec(y);
   vector_seq_view<T_loc> mu_vec(mu);
   const size_t size_vec = max_size_mvt(y, mu);

--- a/stan/math/prim/mat/prob/multi_normal_lpdf.hpp
+++ b/stan/math/prim/mat/prob/multi_normal_lpdf.hpp
@@ -16,8 +16,6 @@
 #include <stan/math/prim/scal/meta/return_type.hpp>
 #include <stan/math/prim/scal/meta/max_size_mvt.hpp>
 #include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <boost/random/normal_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
 
 namespace stan {
 namespace math {
@@ -28,7 +26,6 @@ typename return_type<T_y, T_loc, T_covar>::type multi_normal_lpdf(
   static const char* function = "multi_normal_lpdf";
   typedef typename scalar_type<T_covar>::type T_covar_elem;
   typedef typename return_type<T_y, T_loc, T_covar>::type lp_type;
-  lp_type lp(0.0);
 
   using Eigen::Dynamic;
 
@@ -45,6 +42,7 @@ typename return_type<T_y, T_loc, T_covar>::type multi_normal_lpdf(
     return 0.0;
   check_consistent_sizes_mvt(function, "y", y, "mu", mu);
 
+  lp_type lp(0.0);
   vector_seq_view<T_y> y_vec(y);
   vector_seq_view<T_loc> mu_vec(mu);
   size_t size_vec = max_size_mvt(y, mu);

--- a/stan/math/prim/mat/prob/multi_normal_prec_lpdf.hpp
+++ b/stan/math/prim/mat/prob/multi_normal_prec_lpdf.hpp
@@ -37,7 +37,6 @@ typename return_type<T_y, T_loc, T_covar>::type multi_normal_prec_lpdf(
   static const char* function = "multi_normal_prec_lpdf";
   typedef typename scalar_type<T_covar>::type T_covar_elem;
   typedef typename return_type<T_y, T_loc, T_covar>::type lp_type;
-  lp_type lp(0.0);
 
   check_positive(function, "Precision matrix rows", Sigma.rows());
   check_symmetric(function, "Precision matrix", Sigma);
@@ -54,6 +53,7 @@ typename return_type<T_y, T_loc, T_covar>::type multi_normal_prec_lpdf(
     return 0.0;
   check_consistent_sizes_mvt(function, "y", y, "mu", mu);
 
+  lp_type lp(0.0);
   vector_seq_view<T_y> y_vec(y);
   vector_seq_view<T_loc> mu_vec(mu);
   size_t size_vec = max_size_mvt(y, mu);

--- a/stan/math/prim/mat/prob/multi_normal_prec_lpdf.hpp
+++ b/stan/math/prim/mat/prob/multi_normal_prec_lpdf.hpp
@@ -50,10 +50,10 @@ typename return_type<T_y, T_loc, T_covar>::type multi_normal_prec_lpdf(
   size_t number_of_y = length_mvt(y);
   size_t number_of_mu = length_mvt(mu);
   if (number_of_y == 0 || number_of_mu == 0)
-    return 0.0;
+    return 0;
   check_consistent_sizes_mvt(function, "y", y, "mu", mu);
 
-  lp_type lp(0.0);
+  lp_type lp(0);
   vector_seq_view<T_y> y_vec(y);
   vector_seq_view<T_loc> mu_vec(mu);
   size_t size_vec = max_size_mvt(y, mu);

--- a/stan/math/prim/mat/prob/multi_student_t_lpdf.hpp
+++ b/stan/math/prim/mat/prob/multi_student_t_lpdf.hpp
@@ -37,6 +37,7 @@ template <bool propto, typename T_y, typename T_dof, typename T_loc,
 typename return_type<T_y, T_dof, T_loc, T_scale>::type multi_student_t_lpdf(
     const T_y& y, const T_dof& nu, const T_loc& mu, const T_scale& Sigma) {
   static const char* function = "multi_student_t";
+  using std::log;
   typedef typename scalar_type<T_scale>::type T_scale_elem;
   typedef typename return_type<T_y, T_dof, T_loc, T_scale>::type lp_type;
 
@@ -52,10 +53,9 @@ typename return_type<T_y, T_dof, T_loc, T_scale>::type multi_student_t_lpdf(
   size_t number_of_y = length_mvt(y);
   size_t number_of_mu = length_mvt(mu);
   if (number_of_y == 0 || number_of_mu == 0)
-    return 0.0;
+    return 0;
   check_consistent_sizes_mvt(function, "y", y, "mu", mu);
 
-  lp_type lp(0.0);
   vector_seq_view<T_y> y_vec(y);
   vector_seq_view<T_loc> mu_vec(mu);
   size_t size_vec = max_size_mvt(y, mu);
@@ -109,12 +109,14 @@ typename return_type<T_y, T_dof, T_loc, T_scale>::type multi_student_t_lpdf(
   check_ldlt_factor(function, "LDLT_Factor of scale parameter", ldlt_Sigma);
 
   if (size_y == 0)
-    return lp;
+    return 0;
+
+  lp_type lp(0);
 
   if (include_summand<propto, T_dof>::value) {
     lp += lgamma(0.5 * (nu + size_y)) * size_vec;
     lp -= lgamma(0.5 * nu) * size_vec;
-    lp -= (0.5 * size_y) * std::log(nu) * size_vec;
+    lp -= (0.5 * size_y) * log(nu) * size_vec;
   }
 
   if (include_summand<propto>::value)

--- a/stan/math/prim/mat/prob/multi_student_t_lpdf.hpp
+++ b/stan/math/prim/mat/prob/multi_student_t_lpdf.hpp
@@ -20,7 +20,6 @@
 #include <stan/math/prim/scal/meta/length_mvt.hpp>
 #include <stan/math/prim/scal/meta/include_summand.hpp>
 #include <boost/math/special_functions/gamma.hpp>
-#include <boost/random/variate_generator.hpp>
 #include <cmath>
 #include <cstdlib>
 
@@ -38,12 +37,8 @@ template <bool propto, typename T_y, typename T_dof, typename T_loc,
 typename return_type<T_y, T_dof, T_loc, T_scale>::type multi_student_t_lpdf(
     const T_y& y, const T_dof& nu, const T_loc& mu, const T_scale& Sigma) {
   static const char* function = "multi_student_t";
-
-  using std::log;
-
   typedef typename scalar_type<T_scale>::type T_scale_elem;
   typedef typename return_type<T_y, T_dof, T_loc, T_scale>::type lp_type;
-  lp_type lp(0.0);
 
   check_not_nan(function, "Degrees of freedom parameter", nu);
   check_positive(function, "Degrees of freedom parameter", nu);
@@ -60,6 +55,7 @@ typename return_type<T_y, T_dof, T_loc, T_scale>::type multi_student_t_lpdf(
     return 0.0;
   check_consistent_sizes_mvt(function, "y", y, "mu", mu);
 
+  lp_type lp(0.0);
   vector_seq_view<T_y> y_vec(y);
   vector_seq_view<T_loc> mu_vec(mu);
   size_t size_vec = max_size_mvt(y, mu);
@@ -118,7 +114,7 @@ typename return_type<T_y, T_dof, T_loc, T_scale>::type multi_student_t_lpdf(
   if (include_summand<propto, T_dof>::value) {
     lp += lgamma(0.5 * (nu + size_y)) * size_vec;
     lp -= lgamma(0.5 * nu) * size_vec;
-    lp -= (0.5 * size_y) * log(nu) * size_vec;
+    lp -= (0.5 * size_y) * std::log(nu) * size_vec;
   }
 
   if (include_summand<propto>::value)

--- a/stan/math/prim/mat/prob/neg_binomial_2_log_glm_lpmf.hpp
+++ b/stan/math/prim/mat/prob/neg_binomial_2_log_glm_lpmf.hpp
@@ -102,14 +102,13 @@ neg_binomial_2_log_glm_lpmf(const T_y& y, const T_x& x, const T_alpha& alpha,
     check_consistent_sizes(function, "Vector of intercepts", alpha,
                            "Vector of dependent variables", y);
 
-  if (!length(y) || !length(x) || !length(beta) || !length(phi))
+  if (size_zero(y, x, beta, phi)
     return 0.0;
-
-  T_partials_return logp(0.0);
 
   if (!include_summand<propto, T_x, T_alpha, T_beta, T_precision>::value)
     return 0.0;
 
+  T_partials_return logp(0.0);
   const auto& x_val = value_of_rec(x);
   const auto& y_val = value_of_rec(y);
   const auto& beta_val = value_of_rec(beta);

--- a/stan/math/prim/mat/prob/neg_binomial_2_log_glm_lpmf.hpp
+++ b/stan/math/prim/mat/prob/neg_binomial_2_log_glm_lpmf.hpp
@@ -102,7 +102,7 @@ neg_binomial_2_log_glm_lpmf(const T_y& y, const T_x& x, const T_alpha& alpha,
     check_consistent_sizes(function, "Vector of intercepts", alpha,
                            "Vector of dependent variables", y);
 
-  if (size_zero(y, x, beta, phi)
+  if (size_zero(y, x, beta, phi))
     return 0.0;
 
   if (!include_summand<propto, T_x, T_alpha, T_beta, T_precision>::value)

--- a/stan/math/prim/mat/prob/neg_binomial_2_log_glm_lpmf.hpp
+++ b/stan/math/prim/mat/prob/neg_binomial_2_log_glm_lpmf.hpp
@@ -85,6 +85,8 @@ neg_binomial_2_log_glm_lpmf(const T_y& y, const T_x& x, const T_alpha& alpha,
   using Eigen::Array;
   using Eigen::Dynamic;
   using Eigen::Matrix;
+  using Eigen::exp;
+  using Eigen::log1p;
 
   const size_t N = x.rows();
   const size_t M = x.cols();
@@ -103,12 +105,12 @@ neg_binomial_2_log_glm_lpmf(const T_y& y, const T_x& x, const T_alpha& alpha,
                            "Vector of dependent variables", y);
 
   if (size_zero(y, x, beta, phi))
-    return 0.0;
+    return 0;
 
   if (!include_summand<propto, T_x, T_alpha, T_beta, T_precision>::value)
-    return 0.0;
+    return 0;
 
-  T_partials_return logp(0.0);
+  T_partials_return logp(0);
   const auto& x_val = value_of_rec(x);
   const auto& y_val = value_of_rec(y);
   const auto& beta_val = value_of_rec(beta);
@@ -129,8 +131,8 @@ neg_binomial_2_log_glm_lpmf(const T_y& y, const T_x& x, const T_alpha& alpha,
   T_precision_val log_phi = log(phi_arr);
   Array<T_partials_return, Dynamic, 1> logsumexp_theta_logphi
       = (theta > log_phi)
-            .select(theta + Eigen::log1p(Eigen::exp(log_phi - theta)),
-                    log_phi + Eigen::log1p(Eigen::exp(theta - log_phi)));
+            .select(theta + log1p(exp(log_phi - theta)),
+                    log_phi + log1p(exp(theta - log_phi)));
 
   T_sum_val y_plus_phi = y_arr + phi_arr;
 

--- a/stan/math/prim/mat/prob/neg_binomial_2_log_glm_lpmf.hpp
+++ b/stan/math/prim/mat/prob/neg_binomial_2_log_glm_lpmf.hpp
@@ -85,14 +85,6 @@ neg_binomial_2_log_glm_lpmf(const T_y& y, const T_x& x, const T_alpha& alpha,
   using Eigen::Array;
   using Eigen::Dynamic;
   using Eigen::Matrix;
-  using Eigen::exp;
-  using Eigen::log1p;
-
-  if (!(stan::length(y) && stan::length(x) && stan::length(beta)
-        && stan::length(phi)))
-    return 0.0;
-
-  T_partials_return logp(0.0);
 
   const size_t N = x.rows();
   const size_t M = x.cols();
@@ -109,6 +101,11 @@ neg_binomial_2_log_glm_lpmf(const T_y& y, const T_x& x, const T_alpha& alpha,
   if (is_vector<T_alpha>::value)
     check_consistent_sizes(function, "Vector of intercepts", alpha,
                            "Vector of dependent variables", y);
+
+  if (!length(y) || !length(x) || !length(beta) || !length(phi))
+    return 0.0;
+
+  T_partials_return logp(0.0);
 
   if (!include_summand<propto, T_x, T_alpha, T_beta, T_precision>::value)
     return 0.0;
@@ -133,8 +130,8 @@ neg_binomial_2_log_glm_lpmf(const T_y& y, const T_x& x, const T_alpha& alpha,
   T_precision_val log_phi = log(phi_arr);
   Array<T_partials_return, Dynamic, 1> logsumexp_theta_logphi
       = (theta > log_phi)
-            .select(theta + log1p(exp(log_phi - theta)),
-                    log_phi + log1p(exp(theta - log_phi)));
+            .select(theta + Eigen::log1p(Eigen::exp(log_phi - theta)),
+                    log_phi + Eigen::log1p(Eigen::exp(theta - log_phi)));
 
   T_sum_val y_plus_phi = y_arr + phi_arr;
 

--- a/stan/math/prim/mat/prob/normal_id_glm_lpdf.hpp
+++ b/stan/math/prim/mat/prob/normal_id_glm_lpdf.hpp
@@ -85,10 +85,10 @@ normal_id_glm_lpdf(const T_y &y, const T_x &x, const T_alpha &alpha,
     check_consistent_sizes(function, "Vector of intercepts", alpha,
                            "Vector of dependent variables", y);
   if (size_zero(y, x, beta, sigma))
-    return 0.0;
+    return 0;
 
   if (!include_summand<propto, T_y, T_x, T_alpha, T_beta, T_scale>::value)
-    return 0.0;
+    return 0;
 
   const auto &x_val = value_of_rec(x);
   const auto &beta_val = value_of_rec(beta);

--- a/stan/math/prim/mat/prob/normal_id_glm_lpdf.hpp
+++ b/stan/math/prim/mat/prob/normal_id_glm_lpdf.hpp
@@ -11,6 +11,7 @@
 #include <stan/math/prim/scal/meta/include_summand.hpp>
 #include <stan/math/prim/mat/meta/is_vector.hpp>
 #include <stan/math/prim/scal/meta/scalar_seq_view.hpp>
+#include <stan/math/prim/scal/fun/size_zero.hpp>
 #include <stan/math/prim/scal/fun/sum.hpp>
 #include <stan/math/prim/scal/meta/as_array_or_scalar.hpp>
 #include <stan/math/prim/scal/meta/as_scalar.hpp>
@@ -70,9 +71,6 @@ normal_id_glm_lpdf(const T_y &y, const T_x &x, const T_alpha &alpha,
   using Eigen::Array;
   using Eigen::Dynamic;
   using Eigen::Matrix;
-  using std::exp;
-
-  
 
   const size_t N = x.rows();
   const size_t M = x.cols();
@@ -86,8 +84,7 @@ normal_id_glm_lpdf(const T_y &y, const T_x &x, const T_alpha &alpha,
   if (is_vector<T_alpha>::value)
     check_consistent_sizes(function, "Vector of intercepts", alpha,
                            "Vector of dependent variables", y);
-
-  if (!length(y) || !length(x) || !length(beta) || !length(sigma))
+  if (size_zero(y, x, beta, sigma))
     return 0.0;
 
   if (!include_summand<propto, T_y, T_x, T_alpha, T_beta, T_scale>::value)

--- a/stan/math/prim/mat/prob/normal_id_glm_lpdf.hpp
+++ b/stan/math/prim/mat/prob/normal_id_glm_lpdf.hpp
@@ -72,9 +72,7 @@ normal_id_glm_lpdf(const T_y &y, const T_x &x, const T_alpha &alpha,
   using Eigen::Matrix;
   using std::exp;
 
-  if (!(stan::length(y) && stan::length(x) && stan::length(beta)
-        && stan::length(sigma)))
-    return 0.0;
+  
 
   const size_t N = x.rows();
   const size_t M = x.cols();
@@ -88,6 +86,9 @@ normal_id_glm_lpdf(const T_y &y, const T_x &x, const T_alpha &alpha,
   if (is_vector<T_alpha>::value)
     check_consistent_sizes(function, "Vector of intercepts", alpha,
                            "Vector of dependent variables", y);
+
+  if (!length(y) || !length(x) || !length(beta) || !length(sigma))
+    return 0.0;
 
   if (!include_summand<propto, T_y, T_x, T_alpha, T_beta, T_scale>::value)
     return 0.0;

--- a/stan/math/prim/mat/prob/poisson_log_glm_lpmf.hpp
+++ b/stan/math/prim/mat/prob/poisson_log_glm_lpmf.hpp
@@ -8,6 +8,7 @@
 #include <stan/math/prim/scal/err/check_nonnegative.hpp>
 #include <stan/math/prim/scal/fun/constants.hpp>
 #include <stan/math/prim/scal/fun/lgamma.hpp>
+#include <stan/math/prim/scal/fun/size_zero.hpp>
 #include <stan/math/prim/mat/fun/value_of_rec.hpp>
 #include <stan/math/prim/arr/fun/value_of_rec.hpp>
 #include <stan/math/prim/scal/meta/include_summand.hpp>
@@ -75,7 +76,7 @@ typename return_type<T_x, T_alpha, T_beta>::type poisson_log_glm_lpmf(
   if (is_vector<T_alpha>::value)
     check_consistent_sizes(function, "Vector of intercepts", alpha,
                            "Vector of dependent variables", y);
-  if (!length(y) || !length(x) || !length(beta))
+  if (size_zero(y, x, beta))
     return 0.0;
 
   if (!include_summand<propto, T_x, T_alpha, T_beta>::value)

--- a/stan/math/prim/mat/prob/poisson_log_glm_lpmf.hpp
+++ b/stan/math/prim/mat/prob/poisson_log_glm_lpmf.hpp
@@ -66,6 +66,7 @@ typename return_type<T_x, T_alpha, T_beta>::type poisson_log_glm_lpmf(
 
   using Eigen::Dynamic;
   using Eigen::Matrix;
+  using std::exp;
 
   const size_t N = x.rows();
   const size_t M = x.cols();
@@ -77,12 +78,12 @@ typename return_type<T_x, T_alpha, T_beta>::type poisson_log_glm_lpmf(
     check_consistent_sizes(function, "Vector of intercepts", alpha,
                            "Vector of dependent variables", y);
   if (size_zero(y, x, beta))
-    return 0.0;
+    return 0;
 
   if (!include_summand<propto, T_x, T_alpha, T_beta>::value)
-    return 0.0;
+    return 0;
 
-  T_partials_return logp(0.0);
+  T_partials_return logp(0);
 
   const auto& x_val = value_of_rec(x);
   const auto& y_val = value_of_rec(y);
@@ -97,7 +98,7 @@ typename return_type<T_x, T_alpha, T_beta>::type poisson_log_glm_lpmf(
   theta.array() += as_array_or_scalar(alpha_val_vec);
 
   Matrix<T_partials_return, Dynamic, 1> theta_derivative
-      = as_array_or_scalar(y_val_vec) - std::exp(theta.array());
+      = as_array_or_scalar(y_val_vec) - exp(theta.array());
   double theta_derivative_sum = sum(theta_derivative);
   if (!std::isfinite(theta_derivative_sum)) {
     check_finite(function, "Weight vector", beta);
@@ -113,7 +114,7 @@ typename return_type<T_x, T_alpha, T_beta>::type poisson_log_glm_lpmf(
   }
   if (include_summand<propto, T_partials_return>::value) {
     logp += sum(as_array_or_scalar(y_val_vec) * theta.array()
-                - std::exp(theta.array()));
+                - exp(theta.array()));
   }
 
   // Compute the necessary derivatives.

--- a/stan/math/prim/scal/prob/beta_lpdf.hpp
+++ b/stan/math/prim/scal/prob/beta_lpdf.hpp
@@ -59,13 +59,6 @@ typename return_type<T_y, T_scale_succ, T_scale_fail>::type beta_lpdf(
       typename stan::partials_return_type<T_y, T_scale_succ, T_scale_fail>::type
           T_partials_return;
 
-  using std::log;
-
-  if (size_zero(y, alpha, beta))
-    return 0.0;
-
-  T_partials_return logp(0.0);
-
   check_positive_finite(function, "First shape parameter", alpha);
   check_positive_finite(function, "Second shape parameter", beta);
   check_not_nan(function, "Random variable", y);
@@ -74,10 +67,13 @@ typename return_type<T_y, T_scale_succ, T_scale_fail>::type beta_lpdf(
                          "Second shape parameter", beta);
   check_nonnegative(function, "Random variable", y);
   check_less_or_equal(function, "Random variable", y, 1);
-
+  
+  if (size_zero(y, alpha, beta))
+    return 0.0;
   if (!include_summand<propto, T_y, T_scale_succ, T_scale_fail>::value)
     return 0.0;
 
+  T_partials_return logp(0.0);
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_scale_succ> alpha_vec(alpha);
   scalar_seq_view<T_scale_fail> beta_vec(beta);
@@ -101,7 +97,7 @@ typename return_type<T_y, T_scale_succ, T_scale_fail>::type beta_lpdf(
 
   for (size_t n = 0; n < length(y); n++) {
     if (include_summand<propto, T_y, T_scale_succ>::value)
-      log_y[n] = log(value_of(y_vec[n]));
+      log_y[n] = std::log(value_of(y_vec[n]));
     if (include_summand<propto, T_y, T_scale_fail>::value)
       log1m_y[n] = log1m(value_of(y_vec[n]));
   }

--- a/stan/math/prim/scal/prob/beta_lpdf.hpp
+++ b/stan/math/prim/scal/prob/beta_lpdf.hpp
@@ -67,7 +67,7 @@ typename return_type<T_y, T_scale_succ, T_scale_fail>::type beta_lpdf(
                          "Second shape parameter", beta);
   check_nonnegative(function, "Random variable", y);
   check_less_or_equal(function, "Random variable", y, 1);
-  
+
   if (size_zero(y, alpha, beta))
     return 0.0;
   if (!include_summand<propto, T_y, T_scale_succ, T_scale_fail>::value)

--- a/stan/math/prim/scal/prob/beta_lpdf.hpp
+++ b/stan/math/prim/scal/prob/beta_lpdf.hpp
@@ -58,7 +58,7 @@ typename return_type<T_y, T_scale_succ, T_scale_fail>::type beta_lpdf(
   typedef
       typename stan::partials_return_type<T_y, T_scale_succ, T_scale_fail>::type
           T_partials_return;
-
+  using std::log;
   check_positive_finite(function, "First shape parameter", alpha);
   check_positive_finite(function, "Second shape parameter", beta);
   check_not_nan(function, "Random variable", y);
@@ -69,11 +69,11 @@ typename return_type<T_y, T_scale_succ, T_scale_fail>::type beta_lpdf(
   check_less_or_equal(function, "Random variable", y, 1);
 
   if (size_zero(y, alpha, beta))
-    return 0.0;
+    return 0;
   if (!include_summand<propto, T_y, T_scale_succ, T_scale_fail>::value)
-    return 0.0;
+    return 0;
 
-  T_partials_return logp(0.0);
+  T_partials_return logp(0);
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_scale_succ> alpha_vec(alpha);
   scalar_seq_view<T_scale_fail> beta_vec(beta);
@@ -97,7 +97,7 @@ typename return_type<T_y, T_scale_succ, T_scale_fail>::type beta_lpdf(
 
   for (size_t n = 0; n < length(y); n++) {
     if (include_summand<propto, T_y, T_scale_succ>::value)
-      log_y[n] = std::log(value_of(y_vec[n]));
+      log_y[n] = log(value_of(y_vec[n]));
     if (include_summand<propto, T_y, T_scale_fail>::value)
       log1m_y[n] = log1m(value_of(y_vec[n]));
   }

--- a/stan/math/prim/scal/prob/beta_proportion_lpdf.hpp
+++ b/stan/math/prim/scal/prob/beta_proportion_lpdf.hpp
@@ -53,7 +53,7 @@ typename return_type<T_y, T_loc, T_prec>::type beta_proportion_lpdf(
 
   typedef typename stan::partials_return_type<T_y, T_loc, T_prec>::type
       T_partials_return;
-
+  using std::log;
   check_positive(function, "Location parameter", mu);
   check_less_or_equal(function, "Location parameter", mu, 1.0);
   check_positive_finite(function, "Precision parameter", kappa);
@@ -63,10 +63,10 @@ typename return_type<T_y, T_loc, T_prec>::type beta_proportion_lpdf(
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Precision parameter", kappa);
   if (size_zero(y, mu, kappa))
-    return 0.0;
+    return 0;
   if (!include_summand<propto, T_y, T_loc, T_prec>::value)
-    return 0.0;
-  T_partials_return logp(0.0);
+    return 0;
+  T_partials_return logp(0);
 
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_loc> mu_vec(mu);
@@ -91,7 +91,7 @@ typename return_type<T_y, T_loc, T_prec>::type beta_proportion_lpdf(
 
   for (size_t n = 0; n < length(y); n++) {
     if (include_summand<propto, T_y, T_loc, T_prec>::value) {
-      log_y[n] = std::log(value_of(y_vec[n]));
+      log_y[n] = log(value_of(y_vec[n]));
       log1m_y[n] = log1m(value_of(y_vec[n]));
     }
   }

--- a/stan/math/prim/scal/prob/beta_proportion_lpdf.hpp
+++ b/stan/math/prim/scal/prob/beta_proportion_lpdf.hpp
@@ -54,13 +54,6 @@ typename return_type<T_y, T_loc, T_prec>::type beta_proportion_lpdf(
   typedef typename stan::partials_return_type<T_y, T_loc, T_prec>::type
       T_partials_return;
 
-  using std::log;
-
-  if (size_zero(y, mu, kappa))
-    return 0.0;
-
-  T_partials_return logp(0.0);
-
   check_positive(function, "Location parameter", mu);
   check_less_or_equal(function, "Location parameter", mu, 1.0);
   check_positive_finite(function, "Precision parameter", kappa);
@@ -69,9 +62,11 @@ typename return_type<T_y, T_loc, T_prec>::type beta_proportion_lpdf(
   check_less_or_equal(function, "Random variable", y, 1.0);
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Precision parameter", kappa);
-
+  if (size_zero(y, mu, kappa))
+    return 0.0;
   if (!include_summand<propto, T_y, T_loc, T_prec>::value)
     return 0.0;
+  T_partials_return logp(0.0);
 
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_loc> mu_vec(mu);
@@ -96,7 +91,7 @@ typename return_type<T_y, T_loc, T_prec>::type beta_proportion_lpdf(
 
   for (size_t n = 0; n < length(y); n++) {
     if (include_summand<propto, T_y, T_loc, T_prec>::value) {
-      log_y[n] = log(value_of(y_vec[n]));
+      log_y[n] = std::log(value_of(y_vec[n]));
       log1m_y[n] = log1m(value_of(y_vec[n]));
     }
   }

--- a/stan/math/prim/scal/prob/chi_square_lpdf.hpp
+++ b/stan/math/prim/scal/prob/chi_square_lpdf.hpp
@@ -52,15 +52,15 @@ typename return_type<T_y, T_dof>::type chi_square_lpdf(const T_y& y,
   typedef
       typename stan::partials_return_type<T_y, T_dof>::type T_partials_return;
 
-  if (size_zero(y, nu))
-    return 0.0;
-
-  T_partials_return logp(0.0);
   check_not_nan(function, "Random variable", y);
   check_nonnegative(function, "Random variable", y);
   check_positive_finite(function, "Degrees of freedom parameter", nu);
   check_consistent_sizes(function, "Random variable", y,
                          "Degrees of freedom parameter", nu);
+  if (size_zero(y, nu))
+    return 0.0;
+
+  T_partials_return logp(0.0);
 
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_dof> nu_vec(nu);

--- a/stan/math/prim/scal/prob/chi_square_lpdf.hpp
+++ b/stan/math/prim/scal/prob/chi_square_lpdf.hpp
@@ -58,9 +58,9 @@ typename return_type<T_y, T_dof>::type chi_square_lpdf(const T_y& y,
   check_consistent_sizes(function, "Random variable", y,
                          "Degrees of freedom parameter", nu);
   if (size_zero(y, nu))
-    return 0.0;
+    return 0;
 
-  T_partials_return logp(0.0);
+  T_partials_return logp(0);
 
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_dof> nu_vec(nu);

--- a/stan/math/prim/scal/prob/frechet_lpdf.hpp
+++ b/stan/math/prim/scal/prob/frechet_lpdf.hpp
@@ -34,7 +34,7 @@ typename return_type<T_y, T_shape, T_scale>::type frechet_lpdf(
   static const char* function = "frechet_lpdf";
   typedef typename stan::partials_return_type<T_y, T_shape, T_scale>::type
       T_partials_return;
-
+  using std::log;
   check_positive(function, "Random variable", y);
   check_positive_finite(function, "Shape parameter", alpha);
   check_positive_finite(function, "Scale parameter", sigma);
@@ -42,11 +42,11 @@ typename return_type<T_y, T_shape, T_scale>::type frechet_lpdf(
                          alpha, "Scale parameter", sigma);
 
   if (size_zero(y, alpha, sigma))
-    return 0.0;
+    return 0;
   if (!include_summand<propto, T_y, T_shape, T_scale>::value)
-    return 0.0;
+    return 0;
 
-  T_partials_return logp(0.0);
+  T_partials_return logp(0);
 
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_shape> alpha_vec(alpha);
@@ -58,21 +58,21 @@ typename return_type<T_y, T_shape, T_scale>::type frechet_lpdf(
       log_alpha(length(alpha));
   for (size_t i = 0; i < length(alpha); i++)
     if (include_summand<propto, T_shape>::value)
-      log_alpha[i] = std::log(value_of(alpha_vec[i]));
+      log_alpha[i] = log(value_of(alpha_vec[i]));
 
   VectorBuilder<include_summand<propto, T_y, T_shape>::value, T_partials_return,
                 T_y>
       log_y(length(y));
   for (size_t i = 0; i < length(y); i++)
     if (include_summand<propto, T_y, T_shape>::value)
-      log_y[i] = std::log(value_of(y_vec[i]));
+      log_y[i] = log(value_of(y_vec[i]));
 
   VectorBuilder<include_summand<propto, T_shape, T_scale>::value,
                 T_partials_return, T_scale>
       log_sigma(length(sigma));
   for (size_t i = 0; i < length(sigma); i++)
     if (include_summand<propto, T_shape, T_scale>::value)
-      log_sigma[i] = std::log(value_of(sigma_vec[i]));
+      log_sigma[i] = log(value_of(sigma_vec[i]));
 
   VectorBuilder<include_summand<propto, T_y, T_shape, T_scale>::value,
                 T_partials_return, T_y>

--- a/stan/math/prim/scal/prob/frechet_lpdf.hpp
+++ b/stan/math/prim/scal/prob/frechet_lpdf.hpp
@@ -35,20 +35,18 @@ typename return_type<T_y, T_shape, T_scale>::type frechet_lpdf(
   typedef typename stan::partials_return_type<T_y, T_shape, T_scale>::type
       T_partials_return;
 
-  using std::log;
-
-  if (size_zero(y, alpha, sigma))
-    return 0.0;
-
-  T_partials_return logp(0.0);
   check_positive(function, "Random variable", y);
   check_positive_finite(function, "Shape parameter", alpha);
   check_positive_finite(function, "Scale parameter", sigma);
   check_consistent_sizes(function, "Random variable", y, "Shape parameter",
                          alpha, "Scale parameter", sigma);
 
+  if (size_zero(y, alpha, sigma))
+    return 0.0;
   if (!include_summand<propto, T_y, T_shape, T_scale>::value)
     return 0.0;
+
+  T_partials_return logp(0.0);
 
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_shape> alpha_vec(alpha);
@@ -60,21 +58,21 @@ typename return_type<T_y, T_shape, T_scale>::type frechet_lpdf(
       log_alpha(length(alpha));
   for (size_t i = 0; i < length(alpha); i++)
     if (include_summand<propto, T_shape>::value)
-      log_alpha[i] = log(value_of(alpha_vec[i]));
+      log_alpha[i] = std::log(value_of(alpha_vec[i]));
 
   VectorBuilder<include_summand<propto, T_y, T_shape>::value, T_partials_return,
                 T_y>
       log_y(length(y));
   for (size_t i = 0; i < length(y); i++)
     if (include_summand<propto, T_y, T_shape>::value)
-      log_y[i] = log(value_of(y_vec[i]));
+      log_y[i] = std::log(value_of(y_vec[i]));
 
   VectorBuilder<include_summand<propto, T_shape, T_scale>::value,
                 T_partials_return, T_scale>
       log_sigma(length(sigma));
   for (size_t i = 0; i < length(sigma); i++)
     if (include_summand<propto, T_shape, T_scale>::value)
-      log_sigma[i] = log(value_of(sigma_vec[i]));
+      log_sigma[i] = std::log(value_of(sigma_vec[i]));
 
   VectorBuilder<include_summand<propto, T_y, T_shape, T_scale>::value,
                 T_partials_return, T_y>

--- a/stan/math/prim/scal/prob/inv_chi_square_lpdf.hpp
+++ b/stan/math/prim/scal/prob/inv_chi_square_lpdf.hpp
@@ -59,9 +59,9 @@ typename return_type<T_y, T_dof>::type inv_chi_square_lpdf(const T_y& y,
   check_consistent_sizes(function, "Random variable", y,
                          "Degrees of freedom parameter", nu);
   if (size_zero(y, nu))
-    return 0.0;
+    return 0;
 
-  T_partials_return logp(0.0);
+  T_partials_return logp(0);
 
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_dof> nu_vec(nu);

--- a/stan/math/prim/scal/prob/inv_chi_square_lpdf.hpp
+++ b/stan/math/prim/scal/prob/inv_chi_square_lpdf.hpp
@@ -54,14 +54,14 @@ typename return_type<T_y, T_dof>::type inv_chi_square_lpdf(const T_y& y,
   typedef
       typename stan::partials_return_type<T_y, T_dof>::type T_partials_return;
 
-  if (size_zero(y, nu))
-    return 0.0;
-
-  T_partials_return logp(0.0);
   check_positive_finite(function, "Degrees of freedom parameter", nu);
   check_not_nan(function, "Random variable", y);
   check_consistent_sizes(function, "Random variable", y,
                          "Degrees of freedom parameter", nu);
+  if (size_zero(y, nu))
+    return 0.0;
+
+  T_partials_return logp(0.0);
 
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_dof> nu_vec(nu);

--- a/stan/math/prim/scal/prob/inv_gamma_lpdf.hpp
+++ b/stan/math/prim/scal/prob/inv_gamma_lpdf.hpp
@@ -58,12 +58,12 @@ typename return_type<T_y, T_shape, T_scale>::type inv_gamma_lpdf(
   check_consistent_sizes(function, "Random variable", y, "Shape parameter",
                          alpha, "Scale parameter", beta);
   if (size_zero(y, alpha, beta))
-    return 0.0;
+    return 0;
 
   if (!include_summand<propto, T_y, T_shape, T_scale>::value)
-    return 0.0;
+    return 0;
 
-  T_partials_return logp(0.0);
+  T_partials_return logp(0);
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_shape> alpha_vec(alpha);
   scalar_seq_view<T_scale> beta_vec(beta);

--- a/stan/math/prim/scal/prob/inv_gamma_lpdf.hpp
+++ b/stan/math/prim/scal/prob/inv_gamma_lpdf.hpp
@@ -52,22 +52,18 @@ typename return_type<T_y, T_shape, T_scale>::type inv_gamma_lpdf(
   typedef typename stan::partials_return_type<T_y, T_shape, T_scale>::type
       T_partials_return;
 
-  using boost::math::tools::promote_args;
-
-  if (size_zero(y, alpha, beta))
-    return 0.0;
-
-  T_partials_return logp(0.0);
-
   check_not_nan(function, "Random variable", y);
   check_positive_finite(function, "Shape parameter", alpha);
   check_positive_finite(function, "Scale parameter", beta);
   check_consistent_sizes(function, "Random variable", y, "Shape parameter",
                          alpha, "Scale parameter", beta);
+  if (size_zero(y, alpha, beta))
+    return 0.0;
 
   if (!include_summand<propto, T_y, T_shape, T_scale>::value)
     return 0.0;
 
+  T_partials_return logp(0.0);
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_shape> alpha_vec(alpha);
   scalar_seq_view<T_scale> beta_vec(beta);

--- a/stan/math/prim/scal/prob/lognormal_lpdf.hpp
+++ b/stan/math/prim/scal/prob/lognormal_lpdf.hpp
@@ -41,9 +41,9 @@ typename return_type<T_y, T_loc, T_scale>::type lognormal_lpdf(
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Scale parameter", sigma);
   if (size_zero(y, mu, sigma))
-    return 0.0;
+    return 0;
 
-  T_partials_return logp(0.0);
+  T_partials_return logp(0);
 
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_loc> mu_vec(mu);

--- a/stan/math/prim/scal/prob/lognormal_lpdf.hpp
+++ b/stan/math/prim/scal/prob/lognormal_lpdf.hpp
@@ -34,17 +34,16 @@ typename return_type<T_y, T_loc, T_scale>::type lognormal_lpdf(
   typedef typename stan::partials_return_type<T_y, T_loc, T_scale>::type
       T_partials_return;
 
-  if (size_zero(y, mu, sigma))
-    return 0.0;
-
-  T_partials_return logp(0.0);
-
   check_not_nan(function, "Random variable", y);
   check_nonnegative(function, "Random variable", y);
   check_finite(function, "Location parameter", mu);
   check_positive_finite(function, "Scale parameter", sigma);
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Scale parameter", sigma);
+  if (size_zero(y, mu, sigma))
+    return 0.0;
+
+  T_partials_return logp(0.0);
 
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_loc> mu_vec(mu);

--- a/stan/math/prim/scal/prob/pareto_lpdf.hpp
+++ b/stan/math/prim/scal/prob/pareto_lpdf.hpp
@@ -31,19 +31,19 @@ typename return_type<T_y, T_scale, T_shape>::type pareto_lpdf(
   static const char* function = "pareto_lpdf";
   typedef typename stan::partials_return_type<T_y, T_scale, T_shape>::type
       T_partials_return;
-
+  using std::log;
   check_not_nan(function, "Random variable", y);
   check_positive_finite(function, "Scale parameter", y_min);
   check_positive_finite(function, "Shape parameter", alpha);
   check_consistent_sizes(function, "Random variable", y, "Scale parameter",
                          y_min, "Shape parameter", alpha);
   if (size_zero(y, y_min, alpha))
-    return 0.0;
+    return 0;
 
   if (!include_summand<propto, T_y, T_scale, T_shape>::value)
-    return 0.0;
+    return 0;
 
-  T_partials_return logp(0.0);
+  T_partials_return logp(0);
 
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_scale> y_min_vec(y_min);
@@ -62,7 +62,7 @@ typename return_type<T_y, T_scale, T_shape>::type pareto_lpdf(
       log_y(length(y));
   if (include_summand<propto, T_y, T_shape>::value) {
     for (size_t n = 0; n < length(y); n++)
-      log_y[n] = std::log(value_of(y_vec[n]));
+      log_y[n] = log(value_of(y_vec[n]));
   }
 
   VectorBuilder<contains_nonconstant_struct<T_y, T_shape>::value,
@@ -78,7 +78,7 @@ typename return_type<T_y, T_scale, T_shape>::type pareto_lpdf(
       log_y_min(length(y_min));
   if (include_summand<propto, T_scale, T_shape>::value) {
     for (size_t n = 0; n < length(y_min); n++)
-      log_y_min[n] = std::log(value_of(y_min_vec[n]));
+      log_y_min[n] = log(value_of(y_min_vec[n]));
   }
 
   VectorBuilder<include_summand<propto, T_shape>::value, T_partials_return,
@@ -86,7 +86,7 @@ typename return_type<T_y, T_scale, T_shape>::type pareto_lpdf(
       log_alpha(length(alpha));
   if (include_summand<propto, T_shape>::value) {
     for (size_t n = 0; n < length(alpha); n++)
-      log_alpha[n] = std::log(value_of(alpha_vec[n]));
+      log_alpha[n] = log(value_of(alpha_vec[n]));
   }
 
   for (size_t n = 0; n < N; n++) {

--- a/stan/math/prim/scal/prob/pareto_lpdf.hpp
+++ b/stan/math/prim/scal/prob/pareto_lpdf.hpp
@@ -32,21 +32,18 @@ typename return_type<T_y, T_scale, T_shape>::type pareto_lpdf(
   typedef typename stan::partials_return_type<T_y, T_scale, T_shape>::type
       T_partials_return;
 
-  using std::log;
-
-  if (size_zero(y, y_min, alpha))
-    return 0.0;
-
-  T_partials_return logp(0.0);
-
   check_not_nan(function, "Random variable", y);
   check_positive_finite(function, "Scale parameter", y_min);
   check_positive_finite(function, "Shape parameter", alpha);
   check_consistent_sizes(function, "Random variable", y, "Scale parameter",
                          y_min, "Shape parameter", alpha);
+  if (size_zero(y, y_min, alpha))
+    return 0.0;
 
   if (!include_summand<propto, T_y, T_scale, T_shape>::value)
     return 0.0;
+
+  T_partials_return logp(0.0);
 
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_scale> y_min_vec(y_min);
@@ -65,7 +62,7 @@ typename return_type<T_y, T_scale, T_shape>::type pareto_lpdf(
       log_y(length(y));
   if (include_summand<propto, T_y, T_shape>::value) {
     for (size_t n = 0; n < length(y); n++)
-      log_y[n] = log(value_of(y_vec[n]));
+      log_y[n] = std::log(value_of(y_vec[n]));
   }
 
   VectorBuilder<contains_nonconstant_struct<T_y, T_shape>::value,
@@ -81,7 +78,7 @@ typename return_type<T_y, T_scale, T_shape>::type pareto_lpdf(
       log_y_min(length(y_min));
   if (include_summand<propto, T_scale, T_shape>::value) {
     for (size_t n = 0; n < length(y_min); n++)
-      log_y_min[n] = log(value_of(y_min_vec[n]));
+      log_y_min[n] = std::log(value_of(y_min_vec[n]));
   }
 
   VectorBuilder<include_summand<propto, T_shape>::value, T_partials_return,
@@ -89,7 +86,7 @@ typename return_type<T_y, T_scale, T_shape>::type pareto_lpdf(
       log_alpha(length(alpha));
   if (include_summand<propto, T_shape>::value) {
     for (size_t n = 0; n < length(alpha); n++)
-      log_alpha[n] = log(value_of(alpha_vec[n]));
+      log_alpha[n] = std::log(value_of(alpha_vec[n]));
   }
 
   for (size_t n = 0; n < N; n++) {

--- a/stan/math/prim/scal/prob/scaled_inv_chi_square_lpdf.hpp
+++ b/stan/math/prim/scal/prob/scaled_inv_chi_square_lpdf.hpp
@@ -54,9 +54,6 @@ typename return_type<T_y, T_dof, T_scale>::type scaled_inv_chi_square_lpdf(
   typedef typename stan::partials_return_type<T_y, T_dof, T_scale>::type
       T_partials_return;
 
-  if (size_zero(y, nu, s))
-    return 0.0;
-
   T_partials_return logp(0.0);
   check_not_nan(function, "Random variable", y);
   check_positive_finite(function, "Degrees of freedom parameter", nu);
@@ -64,7 +61,8 @@ typename return_type<T_y, T_dof, T_scale>::type scaled_inv_chi_square_lpdf(
   check_consistent_sizes(function, "Random variable", y,
                          "Degrees of freedom parameter", nu, "Scale parameter",
                          s);
-
+  if (size_zero(y, nu, s))
+    return 0.0;
   if (!include_summand<propto, T_y, T_dof, T_scale>::value)
     return 0.0;
 

--- a/stan/math/prim/scal/prob/scaled_inv_chi_square_lpdf.hpp
+++ b/stan/math/prim/scal/prob/scaled_inv_chi_square_lpdf.hpp
@@ -54,7 +54,6 @@ typename return_type<T_y, T_dof, T_scale>::type scaled_inv_chi_square_lpdf(
   typedef typename stan::partials_return_type<T_y, T_dof, T_scale>::type
       T_partials_return;
 
-  T_partials_return logp(0.0);
   check_not_nan(function, "Random variable", y);
   check_positive_finite(function, "Degrees of freedom parameter", nu);
   check_positive_finite(function, "Scale parameter", s);
@@ -62,10 +61,10 @@ typename return_type<T_y, T_dof, T_scale>::type scaled_inv_chi_square_lpdf(
                          "Degrees of freedom parameter", nu, "Scale parameter",
                          s);
   if (size_zero(y, nu, s))
-    return 0.0;
+    return 0;
   if (!include_summand<propto, T_y, T_dof, T_scale>::value)
-    return 0.0;
-
+    return 0;
+  T_partials_return logp(0);
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_dof> nu_vec(nu);
   scalar_seq_view<T_scale> s_vec(s);

--- a/stan/math/prim/scal/prob/weibull_lpdf.hpp
+++ b/stan/math/prim/scal/prob/weibull_lpdf.hpp
@@ -46,18 +46,17 @@ typename return_type<T_y, T_shape, T_scale>::type weibull_lpdf(
       T_partials_return;
 
   using std::log;
-
-  T_partials_return logp(0.0);
   check_finite(function, "Random variable", y);
   check_positive_finite(function, "Shape parameter", alpha);
   check_positive_finite(function, "Scale parameter", sigma);
   check_consistent_sizes(function, "Random variable", y, "Shape parameter",
                          alpha, "Scale parameter", sigma);
   if (size_zero(y, alpha, sigma))
-    return 0.0;
+    return 0;
   if (!include_summand<propto, T_y, T_shape, T_scale>::value)
-    return 0.0;
+    return 0;
 
+  T_partials_return logp(0);
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_shape> alpha_vec(alpha);
   scalar_seq_view<T_scale> sigma_vec(sigma);

--- a/stan/math/prim/scal/prob/weibull_lpdf.hpp
+++ b/stan/math/prim/scal/prob/weibull_lpdf.hpp
@@ -47,16 +47,14 @@ typename return_type<T_y, T_shape, T_scale>::type weibull_lpdf(
 
   using std::log;
 
-  if (size_zero(y, alpha, sigma))
-    return 0.0;
-
   T_partials_return logp(0.0);
   check_finite(function, "Random variable", y);
   check_positive_finite(function, "Shape parameter", alpha);
   check_positive_finite(function, "Scale parameter", sigma);
   check_consistent_sizes(function, "Random variable", y, "Shape parameter",
                          alpha, "Scale parameter", sigma);
-
+  if (size_zero(y, alpha, sigma))
+    return 0.0;
   if (!include_summand<propto, T_y, T_shape, T_scale>::value)
     return 0.0;
 


### PR DESCRIPTION
## Summary

Fixing an old issue #336. This PR does the following cleanup in lpmf and lpdf files: 
- `!(length(a) && length(b)...)` is replaced with `size_zero(a,b,...)`
- `size_zero` checks are moved under the consistency checks to identify bugs more easily
- `T_lp lp(0.0);`, `T_partials_return logp(0.0);` etc were moved to be allocated after the checks pass

## Tests

No new tests.

## Side Effects

/

## Checklist

- [x] Math issue #336

- [x] Copyright holder: Rok Češnovar, Univ. of Ljubljana

- [x] the basic tests are passing

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [] the new changes are tested
