### PR TITLE
[Jenkins] Move windows tests to later in the build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -172,15 +172,6 @@ pipeline {
                     }
                     post { always { retry(3) { deleteDir() } } }
                 }
-                stage('Windows Headers & Unit') {
-                    agent { label 'windows' }
-                    steps {
-                        deleteDirWin()
-                        unstash 'MathSetup'
-                        bat "make -j${env.PARALLEL} test-headers"
-                        runTestsWin("test/unit")
-                    }
-                }
             }
         }
         stage('Always-run tests part 2') {
@@ -224,6 +215,15 @@ pipeline {
                         runTests("test/unit -f map_rect")
                     }
                     post { always { retry(3) { deleteDir() } } }
+                }
+                stage('Windows Headers & Unit') {
+                    agent { label 'windows' }
+                    steps {
+                        deleteDirWin()
+                        unstash 'MathSetup'
+                        bat "make -j${env.PARALLEL} test-headers"
+                        runTestsWin("test/unit")
+                    }
                 }
             }
         }


### PR DESCRIPTION
Windows is a big bottleneck right now. with this PR, they'll still always run on every PR but this way they won't run until after the unit tests have already passed in some other configuration. As is, unit tests could fail on Linux and Mac and we'd still queue up and take up an hour of time on Windows even though we tend not to learn something new with Windows tests. Seems like a good general rule to run uncorrelated tests at the same time and if those pass run the correlated tests to be more sure.
