### PR TITLE
Fixes includes for stan/math/fwd/mat/meta/operands_and_partials.hpp

### DIFF
--- a/stan/math/fwd/mat.hpp
+++ b/stan/math/fwd/mat.hpp
@@ -4,6 +4,7 @@
 #include <stan/math/fwd/core.hpp>
 #include <stan/math/fwd/scal/meta/is_fvar.hpp>
 #include <stan/math/fwd/scal/meta/partials_type.hpp>
+#include <stan/math/fwd/mat/meta/operands_and_partials.hpp>
 
 #include <stan/math/fwd/mat/vectorize/apply_scalar_unary.hpp>
 #include <stan/math/prim/mat.hpp>
@@ -46,7 +47,5 @@
 #include <stan/math/fwd/mat/functor/gradient.hpp>
 #include <stan/math/fwd/mat/functor/hessian.hpp>
 #include <stan/math/fwd/mat/functor/jacobian.hpp>
-
-#include <stan/math/fwd/mat/meta/operands_and_partials.hpp>
 
 #endif

--- a/stan/math/fwd/mat/meta/operands_and_partials.hpp
+++ b/stan/math/fwd/mat/meta/operands_and_partials.hpp
@@ -1,9 +1,10 @@
 #ifndef STAN_MATH_FWD_MAT_META_OPERANDS_AND_PARTIALS_HPP
 #define STAN_MATH_FWD_MAT_META_OPERANDS_AND_PARTIALS_HPP
 
-#include <stan/math/fwd/scal/meta/operands_and_partials.hpp>
-#include <stan/math/prim/scal/meta/broadcast_array.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <stan/math/prim/arr/meta/length.hpp>
+#include <stan/math/prim/scal/meta/broadcast_array.hpp>
+#include <stan/math/fwd/scal/meta/operands_and_partials.hpp>
 #include <vector>
 
 namespace stan {


### PR DESCRIPTION
## Summary
1. Adds missing includes to `operands_and_partials.hpp`.
2. Moves the includes in `stan/math/fwd/mat.hpp` so the meta headers are at the beginning.

## Tests
No new tests.

After the first commit (moving the includes in `stan/math/fwd/mat.hpp`), the unit tests fail. After the second commit, they pass.

## Side Effects

None. (This should make #937 easier.)

## Checklist

- [x] Math issue #1253

- [x] Copyright holder: Generable

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
