### PR TITLE
Feature/0051 ad test framework

### DIFF
--- a/test/unit/math/mix/mat/util/autodiff_tester.hpp
+++ b/test/unit/math/mix/mat/util/autodiff_tester.hpp
@@ -114,7 +114,7 @@ void test_value(const F& f, const Eigen::VectorXd& x, double fx) {
  */
 template <typename F>
 void test_gradient(const F& f, const Eigen::VectorXd& x, double fx,
-                   bool test_derivs) {
+                   bool test_derivs = true) {
   Eigen::VectorXd grad_ad;
   double fx_ad = fx;
   gradient<F>(f, x, fx_ad, grad_ad);
@@ -135,7 +135,7 @@ void test_gradient(const F& f, const Eigen::VectorXd& x, double fx,
  */
 template <typename F>
 void test_gradient_fvar(const F& f, const Eigen::VectorXd& x, double fx,
-                        bool test_derivs) {
+                        bool test_derivs = true) {
   Eigen::VectorXd grad_ad;
   double fx_ad = fx;
   gradient<double, F>(f, x, fx_ad, grad_ad);
@@ -156,7 +156,7 @@ void test_gradient_fvar(const F& f, const Eigen::VectorXd& x, double fx,
  */
 template <typename F>
 void test_hessian_fvar(const F& f, const Eigen::VectorXd& x, double fx,
-                       bool test_derivs) {
+                       bool test_derivs = true) {
   double fx_ad;
   Eigen::VectorXd grad_ad;
   Eigen::MatrixXd H_ad;
@@ -180,7 +180,7 @@ void test_hessian_fvar(const F& f, const Eigen::VectorXd& x, double fx,
  */
 template <typename F>
 void test_hessian(const F& f, const Eigen::VectorXd& x, double fx,
-                  bool test_derivs) {
+                  bool test_derivs = true) {
   double fx_ad;
   Eigen::VectorXd grad_ad;
   Eigen::MatrixXd H_ad;
@@ -204,7 +204,7 @@ void test_hessian(const F& f, const Eigen::VectorXd& x, double fx,
  */
 template <typename F>
 void test_grad_hessian(const F& f, const Eigen::VectorXd& x, double fx,
-                       bool test_derivs) {
+                       bool test_derivs = true) {
   double fx_ad;
   Eigen::MatrixXd H_ad;
   std::vector<Eigen::MatrixXd> grad_H_ad;

--- a/test/unit/math/mix/mat/util/autodiff_tester.hpp
+++ b/test/unit/math/mix/mat/util/autodiff_tester.hpp
@@ -102,7 +102,8 @@ void expect_near(const std::string& msg, const Eigen::Matrix<T, R, C>& x1,
 template <typename F>
 void test_value(const F& f, const Eigen::VectorXd& x, double fx) {
   if (is_nan(fx))
-    EXPECT_TRUE(is_nan(f(x))) << "test_value is_nan(" << f(x) << std::endl;
+    EXPECT_TRUE(is_nan(f(x)))
+        << "test_value is_nan(" << f(x) << ")" << std::endl;
   else
     expect_near("test_value fx == f(x)", fx, f(x));
 }

--- a/test/unit/math/test_ad.hpp
+++ b/test/unit/math/test_ad.hpp
@@ -4,6 +4,7 @@
 #include <stan/math.hpp>
 #include <test/unit/math/util.hpp>
 #include <test/unit/math/mix/mat/util/autodiff_tester.hpp>
+#include <gtest/gtest.h>
 #include <string>
 #include <vector>
 
@@ -162,30 +163,6 @@ void expect_ad_v(const F& f, const T1& x1) {
   };
   expect_ad_helper(f, h, serialize_args(x1), x1);
 }
-
-// CLIENT AUTODIFF TEST FUNCTIONS
-//
-// [this is for the Wiki, but I'm leaving it here for review]
-//
-// These are the public test functions that expect a functor
-// f encapsulating a polymorphic call to a Stan function and
-// a sequence of arguments with double-based scalars.
-//
-// These functions evaluate that all levels of functional autodiff
-// provide the same answers as finite differences on the double-based
-// implementations, including exception behavior.  To completely
-// test a new differentiable function, a developer need only
-//
-// (a) independently test the double-based implementation, and
-//
-// (b) use these functions to provide arguments to test at all
-//     levels of autodiff.
-//
-// The underlying heavy lifting is provided in the file
-//     unit/math/mix/mat/util/autodiff_tester.hpp
-//
-// Example use cases are provided in this directory in file
-//     test_ad_test.cpp.
 
 /**
  * Test that the specified polymorphic unary functor produces autodiff

--- a/test/unit/math/test_ad.hpp
+++ b/test/unit/math/test_ad.hpp
@@ -1,0 +1,75 @@
+#ifndef TEST_UNIT_MATH_TEST_AD_HPP
+#define TEST_UNIT_MATH_TEST_AD_HPP
+
+#include <stan/math.hpp>
+#include <test/unit/math/util.hpp>
+#include <test/unit/math/mix/mat/util/autodiff_tester.hpp>
+#include <string>
+#include <vector>
+
+namespace stan {
+namespace test {
+
+template <typename T>
+Eigen::Matrix<T, -1, 1> to_eigen_vector(const std::vector<T>& x) {
+  return Eigen::Map<const Eigen::Matrix<T, -1, 1>>(x.data(), x.size());
+}
+
+template <typename T, int R, int C>
+std::vector<T> to_std_vector(const Eigen::Matrix<T, R, C>& x) {
+  std::vector<T> y;
+  y.reserve(x.size());
+  for (int i = 0; i < x.size(); ++i)
+    y.push_back(x(i));
+  return y;
+}
+
+// g : Eigen::Matrix<T, -1, 1> -> T
+template <typename G>
+void expect_ad_helper(const G& g, const std::vector<double>& xs) {
+  static const bool TEST_DERIVS = true;
+  Eigen::VectorXd x = to_eigen_vector(xs);
+  double gx;
+  try {
+    gx = g(x);
+    stan::math::test::test_gradient(g, x, gx, TEST_DERIVS);
+    stan::math::test::test_gradient_fvar(g, x, gx, TEST_DERIVS);
+    stan::math::test::test_hessian(g, x, gx, TEST_DERIVS);
+    stan::math::test::test_hessian_fvar(g, x, gx, TEST_DERIVS);
+    stan::math::test::test_grad_hessian(g, x, gx, TEST_DERIVS);
+  } catch (...) {
+    stan::math::test::expect_all_throw(g, x);
+  }
+}
+
+// f : T -> U  and  x : T  for any Stan-legal types T, U
+// x will be double-based in the call, but f must be polymorphic
+template <typename F, typename T>
+void expect_ad(const F& f, const T& x) {
+  std::vector<double> xs = serialize<double>(x);
+  try {
+    auto y = f(x);
+    std::vector<double> ys = serialize<double>(y);
+    for (size_t i = 0; i < ys.size(); ++i) {
+      // v : Matrix<T, -1, 1>
+      // g : Matrix<T, -1, 1> -> T
+      // T == decltype(v)::Scalar (will be instantiated to autodiff var)
+      auto g = [&](const auto& v) {
+        typedef typename scalar_type<decltype(v)>::type scalar_t;
+        deserializer<scalar_t> ds(to_std_vector(v));
+        return serialize<scalar_t>(f(ds.read(x)))[i];
+      };
+      expect_ad_helper(g, xs);
+    }
+  } catch (...) {
+    std::cout << "Errorful inputs not yet testable.";
+  }
+}
+
+template <typename F, typename T1, typename T2>
+void expect_binary_ad(const F& f, const T1& x1, const T2& x2) {}
+
+}  // namespace test
+}  // namespace stan
+
+#endif

--- a/test/unit/math/test_ad.hpp
+++ b/test/unit/math/test_ad.hpp
@@ -230,10 +230,10 @@ void expect_ad(const F& f, const T1& x1, const T2& x2) {
  */
 template <typename F, typename T1>
 void expect_ad_vectorized(const F& f, const T1& x1) {
-  using std::vector;
-  using Eigen::VectorXd;
-  using Eigen::RowVectorXd;
   using Eigen::MatrixXd;
+  using Eigen::RowVectorXd;
+  using Eigen::VectorXd;
+  using std::vector;
   typedef vector<double> vector_dbl;
   typedef vector<vector<double>> vector2_dbl;
   typedef vector<vector<vector<double>>> vector3_dbl;

--- a/test/unit/math/test_ad.hpp
+++ b/test/unit/math/test_ad.hpp
@@ -41,7 +41,7 @@ void expect_ad_vv(const F& f, const T1& x1, const T2& x2) {
   auto h = [&](const int& i) {
     return [&](const auto& v) {
       typedef typename scalar_type<decltype(v)>::type scalar_t;
-      deserializer<scalar_t> ds(to_std_vector(v));
+      deserializer<scalar_t> ds(v);
       auto x1ds = ds.read(x1);
       auto x2ds = ds.read(x2);
       return serialize<scalar_t>(f(x1ds, x2ds))[i];
@@ -56,7 +56,7 @@ void expect_ad_vd(const F& f, const T1& x1, const T2& x2) {
   auto h = [&](const int& i) {
     return [&](const auto& v) {
       typedef typename scalar_type<decltype(v)>::type scalar_t;
-      deserializer<scalar_t> ds(to_std_vector(v));
+      deserializer<scalar_t> ds(v);
       auto x1ds = ds.read(x1);
       return serialize<scalar_t>(f(x1ds, x2))[i];
     };
@@ -70,7 +70,7 @@ void expect_ad_dv(const F& f, const T1& x1, const T2& x2) {
   auto h = [&](const int& i) {
     return [&](const auto& v) {
       typedef typename scalar_type<decltype(v)>::type scalar_t;
-      deserializer<scalar_t> ds(to_std_vector(v));
+      deserializer<scalar_t> ds(v);
       auto x2ds = ds.read(x2);
       return serialize<scalar_t>(f(x1, x2ds))[i];
     };
@@ -84,7 +84,7 @@ void expect_ad_v(const F& f, const T& x) {
   auto h = [&](const int& i) {
     return [&](const auto& v) {
       typedef typename scalar_type<decltype(v)>::type scalar_t;
-      deserializer<scalar_t> ds(to_std_vector(v));
+      deserializer<scalar_t> ds(v);
       return serialize<scalar_t>(f(ds.read(x)))[i];
     };
   };

--- a/test/unit/math/test_ad.hpp
+++ b/test/unit/math/test_ad.hpp
@@ -10,135 +10,122 @@
 namespace stan {
 namespace test {
 
-template <typename T>
-Eigen::Matrix<T, -1, 1> to_eigen_vector(const std::vector<T>& x) {
-  return Eigen::Map<const Eigen::Matrix<T, -1, 1>>(x.data(), x.size());
-}
-
-template <typename T, int R, int C>
-std::vector<T> to_std_vector(const Eigen::Matrix<T, R, C>& x) {
-  std::vector<T> y;
-  y.reserve(x.size());
-  for (int i = 0; i < x.size(); ++i)
-    y.push_back(x(i));
-  return y;
-}
-
-// g : Eigen::Matrix<T, -1, 1> -> T
 template <typename G>
-void expect_ad_helper(const G& g, const std::vector<double>& xs) {
+void expect_ad_derivatives(const G& g, const std::vector<double>& xs) {
   static const bool TEST_DERIVS = true;
   Eigen::VectorXd x = to_eigen_vector(xs);
-  double gx;
+  double gx = g(x);
+  stan::math::test::test_gradient(g, x, gx, TEST_DERIVS);
+  stan::math::test::test_gradient_fvar(g, x, gx, TEST_DERIVS);
+  stan::math::test::test_hessian(g, x, gx, TEST_DERIVS);
+  stan::math::test::test_hessian_fvar(g, x, gx, TEST_DERIVS);
+  stan::math::test::test_grad_hessian(g, x, gx, TEST_DERIVS);
+}
+
+template <typename F, typename H, typename... Ts>
+void expect_ad_helper(const F& f, const H& h, const std::vector<double>& x_sv,
+                      Ts... xs) {
+  size_t result_size;
   try {
-    gx = g(x);
-    stan::math::test::test_gradient(g, x, gx, TEST_DERIVS);
-    stan::math::test::test_gradient_fvar(g, x, gx, TEST_DERIVS);
-    stan::math::test::test_hessian(g, x, gx, TEST_DERIVS);
-    stan::math::test::test_hessian_fvar(g, x, gx, TEST_DERIVS);
-    stan::math::test::test_grad_hessian(g, x, gx, TEST_DERIVS);
+    auto y = f(xs...);
+    result_size = serialize<double>(y).size();
   } catch (...) {
-    stan::math::test::expect_all_throw(g, x);
+    stan::math::test::expect_all_throw(h(0), to_eigen_vector(x_sv));
   }
+  for (size_t i = 0; i < result_size; ++i)
+    expect_ad_derivatives(h(i), x_sv);
 }
 
 template <typename F, typename T1, typename T2>
 void expect_ad_vv(const F& f, const T1& x1, const T2& x2) {
-  std::vector<double> xs = serialize<double>(x1, x2);  // *****
-  try {
-    auto y = f(x1, x2);  // *****
-    std::vector<double> ys = serialize<double>(y);
-    for (size_t i = 0; i < ys.size(); ++i) {
-      auto g = [&](const auto& v) {
-        typedef typename scalar_type<decltype(v)>::type scalar_t;
-        deserializer<scalar_t> ds(to_std_vector(v));
-        auto x1ds = ds.read(x1);                       // *****
-        auto x2ds = ds.read(x2);                       // *****
-        return serialize<scalar_t>(f(x1ds, x2ds))[i];  // *****
-      };
-      expect_ad_helper(g, xs);
-    }
-  } catch (...) {
-    std::cout << "Errorful inputs not yet testable.";
-  }
-}
-
-template <typename F, typename T1, typename T2>
-void expect_ad_dv(const F& f, const T1& x1, const T2& x2) {
-  std::vector<double> xs = serialize<double>(x2);
-  try {
-    auto y = f(x1, x2);
-    std::vector<double> ys = serialize<double>(y);
-    for (size_t i = 0; i < ys.size(); ++i) {
-      auto g = [&](const auto& v) {
-        typedef typename scalar_type<decltype(v)>::type scalar_t;
-        deserializer<scalar_t> ds(to_std_vector(v));
-        auto x2ds = ds.read(x2);
-        return serialize<scalar_t>(f(x1, x2ds))[i];
-      };
-      expect_ad_helper(g, xs);
-    }
-  } catch (...) {
-    std::cout << "Errorful inputs not yet testable.";
-  }
+  auto h = [&](const int& i) {
+    return [&](const auto& v) {
+      typedef typename scalar_type<decltype(v)>::type scalar_t;
+      deserializer<scalar_t> ds(to_std_vector(v));
+      auto x1ds = ds.read(x1);
+      auto x2ds = ds.read(x2);
+      return serialize<scalar_t>(f(x1ds, x2ds))[i];
+    };
+  };
+  std::vector<double> x_sv = serialize<double>(x1, x2);
+  expect_ad_helper(f, h, x_sv, x1, x2);
 }
 
 template <typename F, typename T1, typename T2>
 void expect_ad_vd(const F& f, const T1& x1, const T2& x2) {
-  std::vector<double> xs = serialize<double>(x1);
-  try {
-    auto y = f(x1, x2);
-    std::vector<double> ys = serialize<double>(y);
-    for (size_t i = 0; i < ys.size(); ++i) {
-      auto g = [&](const auto& v) {
-        typedef typename scalar_type<decltype(v)>::type scalar_t;
-        deserializer<scalar_t> ds(to_std_vector(v));
-        auto x1ds = ds.read(x1);
-        return serialize<scalar_t>(f(x1ds, x2))[i];
-      };
-      expect_ad_helper(g, xs);
-    }
-  } catch (...) {
-    std::cout << "Errorful inputs not yet testable.";
-  }
+  auto h = [&](const int& i) {
+    return [&](const auto& v) {
+      typedef typename scalar_type<decltype(v)>::type scalar_t;
+      deserializer<scalar_t> ds(to_std_vector(v));
+      auto x1ds = ds.read(x1);
+      return serialize<scalar_t>(f(x1ds, x2))[i];
+    };
+  };
+  std::vector<double> x_sv = serialize<double>(x1);
+  expect_ad_helper(f, h, x_sv, x1, x2);
 }
 
-// f : T -> U  and  x : T  for any Stan-legal types T, U
-// x will be double-based in the call, but f must be polymorphic
+template <typename F, typename T1, typename T2>
+void expect_ad_dv(const F& f, const T1& x1, const T2& x2) {
+  auto h = [&](const int& i) {
+    return [&](const auto& v) {
+      typedef typename scalar_type<decltype(v)>::type scalar_t;
+      deserializer<scalar_t> ds(to_std_vector(v));
+      auto x2ds = ds.read(x2);
+      return serialize<scalar_t>(f(x1, x2ds))[i];
+    };
+  };
+  std::vector<double> x_sv = serialize<double>(x2);
+  expect_ad_helper(f, h, x_sv, x1, x2);
+}
+
 template <typename F, typename T>
 void expect_ad_v(const F& f, const T& x) {
-  std::vector<double> xs = serialize<double>(x);
-  try {
-    auto y = f(x);
-    std::vector<double> ys = serialize<double>(y);
-    for (size_t i = 0; i < ys.size(); ++i) {
-      // v : Matrix<T, -1, 1>
-      // g : Matrix<T, -1, 1> -> T
-      // T == decltype(v)::Scalar (will be instantiated to autodiff var)
-      auto g = [&](const auto& v) {
-        typedef typename scalar_type<decltype(v)>::type scalar_t;
-        deserializer<scalar_t> ds(to_std_vector(v));
-        return serialize<scalar_t>(f(ds.read(x)))[i];
-      };
-      expect_ad_helper(g, xs);
-    }
-  } catch (...) {
-    std::cout << "Errorful inputs not yet testable.";
-  }
+  auto h = [&](const int& i) {
+    return [&](const auto& v) {
+      typedef typename scalar_type<decltype(v)>::type scalar_t;
+      deserializer<scalar_t> ds(to_std_vector(v));
+      return serialize<scalar_t>(f(ds.read(x)))[i];
+    };
+  };
+  std::vector<double> x_sv = serialize<double>(x);
+  expect_ad_helper(f, h, x_sv, x);
 }
 
-// UNARY TEST FUNCTION
+// CLIENT AUTODIFF TEST FUNCTIONS
+//
+// These are the public test functions that expect a functor
+// f encapsulating a polymorphic call to a Stan function and
+// a sequence of arguments with double-based scalars.
+//
+// These functions evaluate that all levels of functional autodiff
+// provide the same answers as finite differences on the double-based
+// implementations, including exception behavior.  To completely
+// test a new differentiable function, a developer need only
+//
+// (a) independently test the double-based implementation, and
+//
+// (b) use these functions to provide arguments to test at all
+//     levels of autodiff.
+//
+// The underlying heavy lifting is provided in the file
+//     unit/math/mix/mat/util/autodiff_tester.hpp
+//
+// Example use cases are provided in this directory in file
+//     test_ad_test.cpp.
+
+// Unary function autodiff tester
 template <typename F, typename T>
 void expect_ad(const F& f, const T& x) {
   expect_ad_v(f, x);
 }
 
-// BINARY TEST FUNCTION
+// Binary function autodiff tester
 template <typename F, typename T1, typename T2>
 void expect_ad(const F& f, const T1& x1, const T2& x2) {
   expect_ad_vv(f, x1, x2);
-  // expect_ad_vd(f, x1, x2);
-  // expect_ad_dv(f, x1, x2);
+  expect_ad_vd(f, x1, x2);
+  expect_ad_dv(f, x1, x2);
 }
 
 }  // namespace test

--- a/test/unit/math/test_ad_test.cpp
+++ b/test/unit/math/test_ad_test.cpp
@@ -47,3 +47,47 @@ TEST(test_unit_math_test_ad, test_ad_binary) {
   double y2 = std::numeric_limits<double>::quiet_NaN();
   stan::test::expect_ad(g, x, y2);
 }
+
+// OVERLOADED FUNCTION EXAMPLES THAT PASS AND FAIL AD TESTS
+
+// double overload matches template behavior
+template <typename T>
+T f_match(const T& x) {
+  return -2 * x;
+}
+double f_match(const double& x) { return -2 * x; }
+
+// double overload does not match template behavior for value
+template <typename T>
+T f_mismatch(const T& x) {
+  return -2 * x;
+}
+double f_mismatch(const double& x) { return 2 * x; }
+
+// double overload does not match template behavior for exceptionsalue
+template <typename T>
+T f_misthrow(const T& x) {
+  return -2 * x;
+}
+double f_misthrow(const double& x) {
+  throw std::runtime_error("f_misthrow(double) called");
+  return -2 * x;
+}
+
+TEST(test_unit_math_test_ad, test_ad_unary_fail) {
+  double x = 3.2;
+
+  // expect the matched function's test to succeed
+  auto f = [](const auto& u) { return f_match(u); };
+  stan::test::expect_ad(f, x);
+
+  // expect the mismatched function's test to fail
+  auto g = [](const auto& u) { return f_mismatch(u); };
+  // include following line to show value error behavior
+  // stan::test::expect_ad(g, x);
+
+  // expect the misthrown function's test to fail
+  auto h = [](const auto& u) { return f_misthrow(u); };
+  // include following line to show exception error behavior
+  // stan::test::expect_ad(h, x);
+}

--- a/test/unit/math/test_ad_test.cpp
+++ b/test/unit/math/test_ad_test.cpp
@@ -74,6 +74,15 @@ double f_misthrow(const double& x) {
   return -2 * x;
 }
 
+// VECTORIZED FUNCTION EXAMPLE THAT PASSES
+
+TEST(test_unit_math_test_ad, expect_ad_vectorized) {
+  // log10() is vectorized
+  auto g = [](const auto& u) { return stan::math::log10(u); };
+
+  stan::test::expect_ad_vectorized(g, 3.2);
+}
+
 TEST(test_unit_math_test_ad, test_ad_unary_fail) {
   double x = 3.2;
 

--- a/test/unit/math/test_ad_test.cpp
+++ b/test/unit/math/test_ad_test.cpp
@@ -24,17 +24,44 @@ TEST(test_unit_math_test_ad, to_eigen_vector) {
     EXPECT_EQ(v[i], vv(i));
 }
 
-struct foo {
-  template <typename T>
-  Eigen::Matrix<T, -1, -1> operator()(
-      const Eigen::Matrix<T, -1, -1>& bar) const {
-    return -bar;
-  }
-};
+// this is just a dummy to evaluate unary ad tests
+template <typename T>
+Eigen::Matrix<T, -1, -1> foo(const Eigen::Matrix<T, -1, -1>& x) {
+  return -2 * x;
+}
 
-TEST(test_unit_math_test_ad, test_ad) {
+TEST(test_unit_math_test_ad, test_ad_unary) {
   Eigen::MatrixXd x(2, 3);
   x << 1, 2, 3, 4, 5, 6;
-  foo f;
-  stan::test::expect_ad(f, x);
+
+  // stan::test::expect_ad(foo, x);  // ILLEGAL: can't infer type of foo
+
+  auto g = [](const auto& u) { return foo(u); };
+  stan::test::expect_ad(g, x);
+}
+
+// dummy to evaluate binary ad tests
+// template <typename T1, typename T2>
+// Eigen::Matrix<typename boost::math::tools::promote_args<T1, T2>::type, -1,
+// -1> bar(const Eigen::Matrix<T1, -1, -1>& x, const T2& y) {
+//   using Eigen::Matrix;
+//   using boost::math::tools::promote_args;
+//   typedef Matrix<typename promote_args<T1, T2>::type, -1, -1> return_t;
+//   Eigen::Matrix<return_t, -1, -1> z(x.rows(), x.cols());
+//   // for (int i = 0; i < z.size(); ++i) {
+//   // return_t a = x(i);
+//   // a += y;
+//   // z(i) = a;
+//   // }
+//   return z;
+// }
+
+TEST(test_unit_math_test_ad, test_ad_binary) {
+  Eigen::MatrixXd x(2, 3);
+  x << 1, 2, 3, 4, 5, 6;
+  double y = -3;
+
+  auto g
+      = [](const auto& u, const auto& v) { return stan::math::multiply(u, v); };
+  stan::test::expect_ad(g, x, y);
 }

--- a/test/unit/math/test_ad_test.cpp
+++ b/test/unit/math/test_ad_test.cpp
@@ -1,4 +1,6 @@
 #include <test/unit/math/test_ad.hpp>
+#include <limits>
+#include <vector>
 
 TEST(test_unit_math_test_ad, test_ad_unary) {
   Eigen::MatrixXd x(2, 2);

--- a/test/unit/math/test_ad_test.cpp
+++ b/test/unit/math/test_ad_test.cpp
@@ -1,0 +1,40 @@
+#include <test/unit/math/test_ad.hpp>
+#include <gtest/gtest.h>
+
+TEST(test_unit_math_test_ad, to_std_vector) {
+  Eigen::VectorXd u(0);
+  EXPECT_EQ(0, stan::test::to_std_vector(u).size());
+
+  Eigen::VectorXd x(3);
+  x << 1, 2, 3;
+  std::vector<double> y = stan::test::to_std_vector(x);
+  EXPECT_EQ(3, y.size());
+  for (int i = 0; i < 3; ++i)
+    EXPECT_EQ(x(i), y[i]);
+}
+
+TEST(test_unit_math_test_ad, to_eigen_vector) {
+  std::vector<double> u;
+  EXPECT_EQ(0, stan::test::to_eigen_vector(u).size());
+
+  std::vector<double> v{1, 2, 3};
+  Eigen::VectorXd vv = stan::test::to_eigen_vector(v);
+  EXPECT_EQ(3, vv.size());
+  for (int i = 0; i < 3; ++i)
+    EXPECT_EQ(v[i], vv(i));
+}
+
+struct foo {
+  template <typename T>
+  Eigen::Matrix<T, -1, -1> operator()(
+      const Eigen::Matrix<T, -1, -1>& bar) const {
+    return -bar;
+  }
+};
+
+TEST(test_unit_math_test_ad, test_ad) {
+  Eigen::MatrixXd x(2, 3);
+  x << 1, 2, 3, 4, 5, 6;
+  foo f;
+  stan::test::expect_ad(f, x);
+}

--- a/test/unit/math/test_ad_test.cpp
+++ b/test/unit/math/test_ad_test.cpp
@@ -1,28 +1,4 @@
 #include <test/unit/math/test_ad.hpp>
-#include <gtest/gtest.h>
-
-TEST(test_unit_math_test_ad, to_std_vector) {
-  Eigen::VectorXd u(0);
-  EXPECT_EQ(0, stan::test::to_std_vector(u).size());
-
-  Eigen::VectorXd x(3);
-  x << 1, 2, 3;
-  std::vector<double> y = stan::test::to_std_vector(x);
-  EXPECT_EQ(3, y.size());
-  for (int i = 0; i < 3; ++i)
-    EXPECT_EQ(x(i), y[i]);
-}
-
-TEST(test_unit_math_test_ad, to_eigen_vector) {
-  std::vector<double> u;
-  EXPECT_EQ(0, stan::test::to_eigen_vector(u).size());
-
-  std::vector<double> v{1, 2, 3};
-  Eigen::VectorXd vv = stan::test::to_eigen_vector(v);
-  EXPECT_EQ(3, vv.size());
-  for (int i = 0; i < 3; ++i)
-    EXPECT_EQ(v[i], vv(i));
-}
 
 TEST(test_unit_math_test_ad, test_ad_unary) {
   Eigen::MatrixXd x(2, 2);
@@ -48,21 +24,45 @@ TEST(test_unit_math_test_ad, test_ad_binary) {
   stan::test::expect_ad(g, x, y2);
 }
 
-// OVERLOADED FUNCTION EXAMPLES THAT PASS AND FAIL AD TESTS
+// VECTORIZED UNARY FUNCTION THAT PASSES
 
-// double overload matches template behavior
+// log10 is vectorized, so uses vectorized test
+TEST(test_unit_math_test_ad, expect_ad_vectorized) {
+  auto g = [](const auto& u) { return stan::math::log10(u); };
+
+  stan::test::expect_ad_vectorized(g, 3.2);
+}
+
+// OVERLOAD THAT PASSES
+
+// double overload matches template behavior and passes tests
 template <typename T>
 T f_match(const T& x) {
   return -2 * x;
 }
 double f_match(const double& x) { return -2 * x; }
+TEST(test_ad, match) {
+  double x = 3.2;
+  auto g = [](const auto& u) { return f_match(u); };
+  stan::test::expect_ad(g, x);
+}
+
+// OVERLOAD THAT FAILS DUE TO MISMATCHED VALUE / DERIVATIVE
 
 // double overload does not match template behavior for value
 template <typename T>
 T f_mismatch(const T& x) {
   return -2 * x;
 }
-double f_mismatch(const double& x) { return 2 * x; }
+stan::math::var f_mismatch(const stan::math::var& x) { return 2 * x; }
+TEST(test_ad, mismatch) {
+  double x = 3.2;
+  auto g = [](const auto& u) { return f_mismatch(u); };
+  // include following line to show exception error behavior
+  // stan::test::expect_ad(g, x);
+}
+
+// OVERLOAD THAT FAILS DUE TO MISMATCHED EXCEPTION CONDITIONS
 
 // double overload does not match template behavior for exceptionsalue
 template <typename T>
@@ -74,28 +74,8 @@ double f_misthrow(const double& x) {
   return -2 * x;
 }
 
-// VECTORIZED FUNCTION EXAMPLE THAT PASSES
-
-TEST(test_unit_math_test_ad, expect_ad_vectorized) {
-  // log10() is vectorized
-  auto g = [](const auto& u) { return stan::math::log10(u); };
-
-  stan::test::expect_ad_vectorized(g, 3.2);
-}
-
-TEST(test_unit_math_test_ad, test_ad_unary_fail) {
-  double x = 3.2;
-
-  // expect the matched function's test to succeed
-  auto f = [](const auto& u) { return f_match(u); };
-  stan::test::expect_ad(f, x);
-
-  // expect the mismatched function's test to fail
-  auto g = [](const auto& u) { return f_mismatch(u); };
-  // include following line to show value error behavior
-  // stan::test::expect_ad(g, x);
-
-  // expect the misthrown function's test to fail
+TEST(test_ad, misthrow) {
+  double x = 1.73;
   auto h = [](const auto& u) { return f_misthrow(u); };
   // include following line to show exception error behavior
   // stan::test::expect_ad(h, x);

--- a/test/unit/math/test_ad_test.cpp
+++ b/test/unit/math/test_ad_test.cpp
@@ -24,44 +24,26 @@ TEST(test_unit_math_test_ad, to_eigen_vector) {
     EXPECT_EQ(v[i], vv(i));
 }
 
-// this is just a dummy to evaluate unary ad tests
-template <typename T>
-Eigen::Matrix<T, -1, -1> foo(const Eigen::Matrix<T, -1, -1>& x) {
-  return -2 * x;
-}
-
 TEST(test_unit_math_test_ad, test_ad_unary) {
-  Eigen::MatrixXd x(2, 3);
-  x << 1, 2, 3, 4, 5, 6;
+  Eigen::MatrixXd x(2, 2);
+  x << 1.9, 0.3, 0.3, 1.7;
 
-  // stan::test::expect_ad(foo, x);  // ILLEGAL: can't infer type of foo
-
-  auto g = [](const auto& u) { return foo(u); };
+  auto g = [](const auto& u) { return stan::math::inverse(u); };
   stan::test::expect_ad(g, x);
-}
 
-// dummy to evaluate binary ad tests
-// template <typename T1, typename T2>
-// Eigen::Matrix<typename boost::math::tools::promote_args<T1, T2>::type, -1,
-// -1> bar(const Eigen::Matrix<T1, -1, -1>& x, const T2& y) {
-//   using Eigen::Matrix;
-//   using boost::math::tools::promote_args;
-//   typedef Matrix<typename promote_args<T1, T2>::type, -1, -1> return_t;
-//   Eigen::Matrix<return_t, -1, -1> z(x.rows(), x.cols());
-//   // for (int i = 0; i < z.size(); ++i) {
-//   // return_t a = x(i);
-//   // a += y;
-//   // z(i) = a;
-//   // }
-//   return z;
-// }
+  // need functor because can't infer template param F of expect_ad
+  // stan::test::expect_ad(inverse, x);  // won't compile
+}
 
 TEST(test_unit_math_test_ad, test_ad_binary) {
+  auto g
+      = [](const auto& u, const auto& v) { return stan::math::multiply(u, v); };
+
   Eigen::MatrixXd x(2, 3);
   x << 1, 2, 3, 4, 5, 6;
   double y = -3;
-
-  auto g
-      = [](const auto& u, const auto& v) { return stan::math::multiply(u, v); };
   stan::test::expect_ad(g, x, y);
+
+  double y2 = std::numeric_limits<double>::quiet_NaN();
+  stan::test::expect_ad(g, x, y2);
 }

--- a/test/unit/math/util.hpp
+++ b/test/unit/math/util.hpp
@@ -1,0 +1,77 @@
+#ifndef TEST_UNIT_MATH_UTIL_HPP
+#define TEST_UNIT_MATH_UTIL_HPP
+
+#include <stan/math.hpp>
+#include <string>
+#include <vector>
+
+namespace stan {
+namespace test {
+
+template <typename T>
+struct deserializer {
+  size_t position_;
+
+  const std::vector<T> vals_;
+
+  deserializer(const std::vector<T>& vals) : position_(0), vals_(vals) {}
+
+  template <typename U>
+  T read(const U& x) {
+    return vals_[position_++];
+  }
+
+  template <typename U>
+  std::vector<T> read(const std::vector<U>& x) {
+    std::vector<T> y;
+    y.reserve(x.size());
+    for (size_t i = 0; i < x.size(); ++i)
+      y.push_back(read(x[i]));
+    return y;
+  }
+
+  template <typename U, int R, int C>
+  Eigen::Matrix<T, R, C> read(const Eigen::Matrix<U, R, C>& x) {
+    Eigen::Matrix<T, R, C> y(x.rows(), x.cols());
+    for (int i = 0; i < x.size(); ++i)
+      y(i) = read(x(i));
+    return y;
+  }
+};
+
+template <typename T>
+deserializer<T> deserializer_factory(const std::vector<T>& vals) {
+  return deserializer<T>(vals);
+}
+
+template <typename T>
+struct serializer {
+  std::vector<T> vals_;
+
+  serializer() : vals_() {}
+
+  // U assignable to T
+  template <typename U>
+  void write(const U& x) {
+    vals_.push_back(x);
+  }
+
+  // U assignable to T
+  template <typename U>
+  void write(const std::vector<U>& x) {
+    for (size_t i = 0; i < x.size(); ++i)
+      write(x[i]);
+  }
+
+  // U assignable to T
+  template <typename U, int R, int C>
+  void write(const Eigen::Matrix<U, R, C>& x) {
+    for (int i = 0; i < x.size(); ++i)
+      write(x(i));
+  }
+};
+
+}  // namespace test
+}  // namespace stan
+
+#endif

--- a/test/unit/math/util.hpp
+++ b/test/unit/math/util.hpp
@@ -8,11 +8,30 @@
 namespace stan {
 namespace test {
 
+/**
+ * Return the Eigen vector with the same size and elements as the
+ * specified standard vector.  Elements are copied from the specifed
+ * input vector.
+ *
+ * @tparam T type of scalars in containers
+ * @param x standard vector to copy
+ * @return Eigen vector corresponding to specified standard vector
+ */
 template <typename T>
 Eigen::Matrix<T, -1, 1> to_eigen_vector(const std::vector<T>& x) {
   return Eigen::Map<const Eigen::Matrix<T, -1, 1>>(x.data(), x.size());
 }
 
+/**
+ * Return the standard vector with the same size and elements as the
+ * specified Eigen matrix, vector, or row vector.
+ *
+ * @tparam T type of scalars in containers
+ * @tparam R row specification of input matrix
+ * @tparam C column specification of input matrix
+ * @param x Eigen matrix, vector, or row vector to copy
+ * @return standard vector corresponding to input
+ */
 template <typename T, int R, int C>
 std::vector<T> to_std_vector(const Eigen::Matrix<T, R, C>& x) {
   std::vector<T> y;
@@ -22,22 +41,70 @@ std::vector<T> to_std_vector(const Eigen::Matrix<T, R, C>& x) {
   return y;
 }
 
+/**
+ * A class to store a sequence of values which can be deserialized
+ * back into structured objects such as scalars, vectors, and
+ * matrixes.
+ *
+ * @tparam T type of scalars
+ */
 template <typename T>
 struct deserializer {
+  /**
+   * Type of scalars in all objects.
+   */
   typedef T scalar_t;
+
+  /**
+   * Current read position.
+   */
   size_t position_;
 
+  /**
+   * The sequence of values to deserialize.
+   */
   const std::vector<T> vals_;
 
+  /**
+   * Construct a deserializer from the specified sequence of values.
+   *
+   * @param vals values to deserialize
+   */
   deserializer(const std::vector<T>& vals) : position_(0), vals_(vals) {}
+
+  /**
+   * Construct a deserializer from the specified sequence of values.
+   *
+   * @param vals values to deserialize
+   */
   deserializer(const Eigen::Matrix<T, -1, 1>& v_vals)
       : position_(0), vals_(to_std_vector(v_vals)) {}
 
+  /**
+   * Read a scalar conforming to the shape of the specified argument,
+   * here a scalar.  The specified argument is only used for its
+   * shape---there is no relationship between the type of argument and
+   * type of result.
+   *
+   * @tparam U type of pattern scalar
+   * @param x pattern argument to determine result shape and size
+   * @return deserialized value with shape and size matching argument
+   */
   template <typename U>
   T read(const U& x) {
     return vals_[position_++];
   }
 
+  /**
+   * Read a standard vector conforming to the shape of the specified
+   * argument, here a standard vector.  The specified argument is only
+   * used for its shape---there is no relationship between the type of
+   * argument and type of result.
+   *
+   * @tparam U type of pattern scalar
+   * @param x pattern argument to determine result shape and size
+   * @return deserialized value with shape and size matching argument
+   */
   template <typename U>
   std::vector<T> read(const std::vector<U>& x) {
     std::vector<T> y;
@@ -47,6 +114,18 @@ struct deserializer {
     return y;
   }
 
+  /**
+   * Read a standard vector conforming to the shape of the specified
+   * argument, here an Eigen matrix, vector, or row vector. The
+   * specified argument is only used for its shape---there is no
+   * relationship between the type of argument and type of result.
+   *
+   * @tparam U type of pattern scalar
+   * @tparam R row specification for Eigen container
+   * @tparam C column specification for Eigen container
+   * @param x pattern argument to determine result shape and size
+   * @return deserialized value with shape and size matching argument
+   */
   template <typename U, int R, int C>
   Eigen::Matrix<T, R, C> read(const Eigen::Matrix<U, R, C>& x) {
     Eigen::Matrix<T, R, C> y(x.rows(), x.cols());
@@ -56,47 +135,106 @@ struct deserializer {
   }
 };
 
-template <typename T>
-deserializer<T> to_deserializer(const std::vector<T>& vals) {
-  return deserializer<T>(vals);
-}
-template <typename T>
-deserializer<T> to_deserializer(const Eigen::Matrix<T, -1, 1>& vals) {
-  return deserializer<T>(vals);
-}
-
+/**
+ * A structure to serialize structures to an internall stored sequence
+ * of scalars.
+ *
+ * @tparam T underlying scalar type
+ */
 template <typename T>
 struct serializer {
+  /**
+   * Scalar type of serializer.
+   */
   typedef T scalar_t;
+
+  /**
+   * Container for serialized values.
+   */
   std::vector<T> vals_;
 
+  /**
+   * Construct a serializer.
+   */
   serializer() : vals_() {}
 
-  // U assignable to T
+  /**
+   * Serialize the specified scalar.
+   *
+   * @tparam U type of specified scalar; must be assignable to T
+   * @param x scalar to serialize
+   */
   template <typename U>
   void write(const U& x) {
     vals_.push_back(x);
   }
 
-  // U assignable to T
+  /**
+   * Serialize the specified standard vector.
+   *
+   * @tparam U type of scalars; must be assignable to T
+   * @param x vector to serialize
+   */
   template <typename U>
   void write(const std::vector<U>& x) {
     for (size_t i = 0; i < x.size(); ++i)
       write(x[i]);
   }
 
-  // U assignable to T
+  /**
+   * Serialize the specified Eigen container.
+   *
+   * @tparam U type of scalars; must be assignable to T
+   * @tparam R row specification of Eigen container
+   * @tparam C column specification of Eigen container
+   * @param x Eigen container to serialize.
+   */
   template <typename U, int R, int C>
   void write(const Eigen::Matrix<U, R, C>& x) {
     for (int i = 0; i < x.size(); ++i)
       write(x(i));
   }
 
+  /**
+   * Return the serialized values as a standard vector.
+   *
+   * @return serialized values
+   */
   const std::vector<T>& array_vals() { return vals_; }
+
+  /**
+   * Return the serialized values as an Eigen vector.
+   *
+   * @return serialized values
+   */
   const Eigen::Matrix<T, -1, 1>& vector_vals() {
     return to_eigen_vector(vals_);
   }
 };
+
+/**
+ * Return a deserializer based on the specified values.
+ *
+ * @tparam T type of scalars in argument container and return
+ * @param vals values to deserialize
+ * @return deserializer based on specified values
+ */
+template <typename T>
+deserializer<T> to_deserializer(const std::vector<T>& vals) {
+  return deserializer<T>(vals);
+}
+
+/**
+ * Return a deserializer based on the specified values.
+ *
+ * @tparam T type of scalars in argument container and return
+ * @param vals values to deserialize
+ * @return deserializer based on specified values
+ */
+template <typename T>
+deserializer<T> to_deserializer(const Eigen::Matrix<T, -1, 1>& vals) {
+  return deserializer<T>(vals);
+}
 
 template <typename U>
 void serialize_helper(serializer<U>& s) {}
@@ -107,6 +245,15 @@ void serialize_helper(serializer<U>& s, const T& x, const Ts... xs) {
   serialize_helper(s, xs...);
 }
 
+/**
+ * Serialize the specified sequence of objects, which all must have
+ * scalar types assignable to the result scalar type.
+ *
+ * @tparam U type of scalar in result vector
+ * @tparam Ts argument types
+ * @param xs arguments
+ * @return serialized form of arguments
+ */
 template <typename U, typename... Ts>
 std::vector<U> serialize(const Ts... xs) {
   serializer<U> s;
@@ -114,11 +261,26 @@ std::vector<U> serialize(const Ts... xs) {
   return s.vals_;
 }
 
+/**
+ * Serialized the specified single argument.
+ *
+ * @tparam T type of argument
+ * @param x argument to serialize
+ * @return serialized argument
+ */
 template <typename T>
 std::vector<typename scalar_type<T>::type> serialize_return(const T& x) {
   return serialize<typename scalar_type<T>::type>(x);
 }
 
+/**
+ * Serialize the specified sequence of structured objects with
+ * double-based scalars into an Eigen vector of double values.
+ *
+ * @tparam Ts types of argument sequence
+ * @param xs arguments to serialize
+ * @return serialized form of arguments
+ */
 template <typename... Ts>
 Eigen::VectorXd serialize_args(const Ts... xs) {
   return to_eigen_vector(serialize<double>(xs...));

--- a/test/unit/math/util.hpp
+++ b/test/unit/math/util.hpp
@@ -70,14 +70,15 @@ struct deserializer {
    *
    * @param vals values to deserialize
    */
-  deserializer(const std::vector<T>& vals) : position_(0), vals_(vals) {}
+  explicit deserializer(const std::vector<T>& vals)
+      : position_(0), vals_(vals) {}
 
   /**
    * Construct a deserializer from the specified sequence of values.
    *
    * @param vals values to deserialize
    */
-  deserializer(const Eigen::Matrix<T, -1, 1>& v_vals)
+  explicit deserializer(const Eigen::Matrix<T, -1, 1>& v_vals)
       : position_(0), vals_(to_std_vector(v_vals)) {}
 
   /**

--- a/test/unit/math/util.hpp
+++ b/test/unit/math/util.hpp
@@ -71,6 +71,22 @@ struct serializer {
   }
 };
 
+template <typename U>
+void serialize(serializer<U>& s) {}
+
+template <typename U, typename T, typename... Ts>
+void serialize(serializer<U>& s, const T& x, const Ts... xs) {
+  s.write(x);
+  serialize(s, xs...);
+}
+
+template <typename U, typename... Ts>
+std::vector<U> serialize(const Ts... xs) {
+  serializer<U> s;
+  serialize(s, xs...);
+  return s.vals_;
+}
+
 }  // namespace test
 }  // namespace stan
 

--- a/test/unit/math/util.hpp
+++ b/test/unit/math/util.hpp
@@ -101,13 +101,14 @@ struct deserializer {
    * used for its shape---there is no relationship between the type of
    * argument and type of result.
    *
-   * @tparam U type of pattern scalar
+   * @tparam U type of pattern sequence elements
    * @param x pattern argument to determine result shape and size
    * @return deserialized value with shape and size matching argument
    */
   template <typename U>
-  std::vector<T> read(const std::vector<U>& x) {
-    std::vector<T> y;
+  typename stan::math::promote_scalar_type<T, std::vector<U>>::type read(
+      const std::vector<U>& x) {
+    typename stan::math::promote_scalar_type<T, std::vector<U>>::type y;
     y.reserve(x.size());
     for (size_t i = 0; i < x.size(); ++i)
       y.push_back(read(x[i]));

--- a/test/unit/math/util.hpp
+++ b/test/unit/math/util.hpp
@@ -87,6 +87,20 @@ std::vector<U> serialize(const Ts... xs) {
   return s.vals_;
 }
 
+template <typename T>
+Eigen::Matrix<T, -1, 1> to_eigen_vector(const std::vector<T>& x) {
+  return Eigen::Map<const Eigen::Matrix<T, -1, 1>>(x.data(), x.size());
+}
+
+template <typename T, int R, int C>
+std::vector<T> to_std_vector(const Eigen::Matrix<T, R, C>& x) {
+  std::vector<T> y;
+  y.reserve(x.size());
+  for (int i = 0; i < x.size(); ++i)
+    y.push_back(x(i));
+  return y;
+}
+
 }  // namespace test
 }  // namespace stan
 

--- a/test/unit/math/util_test.cpp
+++ b/test/unit/math/util_test.cpp
@@ -1,5 +1,6 @@
 #include <test/unit/math/util.hpp>
 #include <gtest/gtest.h>
+#include <vector>
 
 TEST(test_unit_math_test_ad, to_std_vector) {
   Eigen::VectorXd u(0);
@@ -48,8 +49,7 @@ TEST(test_unit_math_util, serializer_deserializer) {
   for (size_t i = 0; i < expected.size(); ++i)
     EXPECT_EQ(expected[i], s.vals_[i]);
 
-  stan::test::deserializer<double> d
-      = stan::test::deserializer_factory(s.vals_);
+  stan::test::deserializer<double> d = stan::test::to_deserializer(s.vals_);
 
   EXPECT_EQ(3.2, d.read(0.0));
   EXPECT_EQ(-1, d.read(0.0));

--- a/test/unit/math/util_test.cpp
+++ b/test/unit/math/util_test.cpp
@@ -1,6 +1,29 @@
 #include <test/unit/math/util.hpp>
 #include <gtest/gtest.h>
 
+TEST(test_unit_math_test_ad, to_std_vector) {
+  Eigen::VectorXd u(0);
+  EXPECT_EQ(0, stan::test::to_std_vector(u).size());
+
+  Eigen::VectorXd x(3);
+  x << 1, 2, 3;
+  std::vector<double> y = stan::test::to_std_vector(x);
+  EXPECT_EQ(3, y.size());
+  for (int i = 0; i < 3; ++i)
+    EXPECT_EQ(x(i), y[i]);
+}
+
+TEST(test_unit_math_test_ad, to_eigen_vector) {
+  std::vector<double> u;
+  EXPECT_EQ(0, stan::test::to_eigen_vector(u).size());
+
+  std::vector<double> v{1, 2, 3};
+  Eigen::VectorXd vv = stan::test::to_eigen_vector(v);
+  EXPECT_EQ(3, vv.size());
+  for (int i = 0; i < 3; ++i)
+    EXPECT_EQ(v[i], vv(i));
+}
+
 TEST(test_unit_math_util, serializer_deserializer) {
   stan::test::serializer<double> s;
 

--- a/test/unit/math/util_test.cpp
+++ b/test/unit/math/util_test.cpp
@@ -1,0 +1,50 @@
+#include <test/unit/math/util.hpp>
+#include <gtest/gtest.h>
+
+TEST(test_unit_math_util, serialization) {
+  stan::test::serializer<double> s;
+
+  s.write(3.2);
+  s.write(-1);
+  s.write(std::vector<double>{10, 20, 30});
+
+  Eigen::VectorXd a(2);
+  a << -10, -20;
+  s.write(a);
+
+  Eigen::RowVectorXd b(3);
+  b << 101, 102, 103;
+  s.write(b);
+
+  Eigen::MatrixXd c(3, 2);
+  c << 1, 2, 3, 4, 5, 6;  // << is row major; index order is col major
+  s.write(c);
+
+  std::vector<double> expected{3.2, -1,  10, 20, 30, -10, -20, 101,
+                               102, 103, 1,  3,  5,  2,   4,   6};
+  for (size_t i = 0; i < expected.size(); ++i)
+    EXPECT_EQ(expected[i], s.vals_[i]);
+
+  stan::test::deserializer<double> d
+      = stan::test::deserializer_factory(s.vals_);
+
+  EXPECT_EQ(3.2, d.read(0.0));
+  EXPECT_EQ(-1, d.read(0.0));
+  std::vector<double> x = d.read(std::vector<double>{0, 0, 0});
+  EXPECT_EQ(10, x[0]);
+  EXPECT_EQ(20, x[1]);
+  EXPECT_EQ(30, x[2]);
+  Eigen::VectorXd y = d.read(Eigen::VectorXd(2));
+  EXPECT_EQ(-10, y(0));
+  EXPECT_EQ(-20, y(1));
+  Eigen::RowVectorXd z = d.read(Eigen::RowVectorXd(3));
+  EXPECT_EQ(-10, y(0));
+  EXPECT_EQ(-20, y(1));
+  Eigen::MatrixXd u = d.read(Eigen::MatrixXd(3, 2));
+  EXPECT_EQ(1, u(0, 0));
+  EXPECT_EQ(2, u(0, 1));
+  EXPECT_EQ(3, u(1, 0));
+  EXPECT_EQ(4, u(1, 1));
+  EXPECT_EQ(5, u(2, 0));
+  EXPECT_EQ(6, u(2, 1));
+}

--- a/test/unit/math/util_test.cpp
+++ b/test/unit/math/util_test.cpp
@@ -1,7 +1,7 @@
 #include <test/unit/math/util.hpp>
 #include <gtest/gtest.h>
 
-TEST(test_unit_math_util, serialization) {
+TEST(test_unit_math_util, serializer_deserializer) {
   stan::test::serializer<double> s;
 
   s.write(3.2);
@@ -47,4 +47,19 @@ TEST(test_unit_math_util, serialization) {
   EXPECT_EQ(4, u(1, 1));
   EXPECT_EQ(5, u(2, 0));
   EXPECT_EQ(6, u(2, 1));
+}
+
+TEST(test_unit_math_util, serialize) {
+  std::vector<double> xs = stan::test::serialize<double>();
+  EXPECT_EQ(0, xs.size());
+
+  double a = 2;
+  std::vector<double> b{3, 4, 5};
+  Eigen::MatrixXd c(2, 3);
+  c << -1, -2, -3, -4, -5, -6;
+  std::vector<double> ys = stan::test::serialize<double>(a, b, c);
+
+  std::vector<double> expected{2, 3, 4, 5, -1, -4, -2, -5, -3, -6};
+  for (size_t i = 0; i < expected.size(); ++i)
+    EXPECT_EQ(expected[i], ys[i]);
 }


### PR DESCRIPTION
## Summary

Introduce a new autodiff testing framework to test everything but distribution functions at all levels of autodiff and all configurations of inputs.

The user-facing description of how to use this new testing framework is available on an [autodiff testing framework Wiki](https://github.com/stan-dev/math/wiki/Automatic-Differentiation-Testing-Framework).  The Wiki is marked as a work-in-progress.

After this PR is merged, we can simplify and complete all the existing autodiff tests to use the new framework, at which point we can remove the two existing frameworks (for base mixed results and for serialization---the probability function framework is staying put for the time being).

## Tests

The file `test/unit/math/test_ad_test.cpp` contains end-to-end unit tests deploying the testing framework on real examples from Stan.   There area also more detailed unit tests for new utilities.

## Side Effects

No.

## Checklist

- [x] Math issue #51

- [x] Copyright holder: Columbia University

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested