### PR TITLE
Flatten: add stan/math/prim/meta.hpp, stan/math/rev/meta.hpp, stan/math/fwd/meta.hpp, stan/math/mix/meta.hpp

### DIFF
--- a/stan/math/fwd/arr.hpp
+++ b/stan/math/fwd/arr.hpp
@@ -2,8 +2,7 @@
 #define STAN_MATH_FWD_ARR_HPP
 
 #include <stan/math/fwd/core.hpp>
-#include <stan/math/fwd/scal/meta/is_fvar.hpp>
-#include <stan/math/fwd/scal/meta/partials_type.hpp>
+#include <stan/math/fwd/meta.hpp>
 
 #include <stan/math/prim/arr.hpp>
 #include <stan/math/fwd/scal.hpp>

--- a/stan/math/fwd/mat.hpp
+++ b/stan/math/fwd/mat.hpp
@@ -2,9 +2,7 @@
 #define STAN_MATH_FWD_MAT_HPP
 
 #include <stan/math/fwd/core.hpp>
-#include <stan/math/fwd/scal/meta/is_fvar.hpp>
-#include <stan/math/fwd/scal/meta/partials_type.hpp>
-#include <stan/math/fwd/mat/meta/operands_and_partials.hpp>
+#include <stan/math/fwd/meta.hpp>
 
 #include <stan/math/fwd/mat/vectorize/apply_scalar_unary.hpp>
 #include <stan/math/prim/mat.hpp>

--- a/stan/math/fwd/meta.hpp
+++ b/stan/math/fwd/meta.hpp
@@ -1,0 +1,8 @@
+#ifndef STAN_MATH_FWD_META_HPP
+#define STAN_MATH_FWD_META_HPP
+
+#include <stan/math/fwd/scal/meta/is_fvar.hpp>
+#include <stan/math/fwd/scal/meta/partials_type.hpp>
+#include <stan/math/fwd/mat/meta/operands_and_partials.hpp>
+
+#endif

--- a/stan/math/fwd/meta.hpp
+++ b/stan/math/fwd/meta.hpp
@@ -5,4 +5,7 @@
 #include <stan/math/fwd/scal/meta/partials_type.hpp>
 #include <stan/math/fwd/mat/meta/operands_and_partials.hpp>
 
+#include <stan/math/fwd/scal/meta/ad_promotable.hpp>
+#include <stan/math/fwd/scal/meta/operands_and_partials.hpp>
+
 #endif

--- a/stan/math/fwd/scal.hpp
+++ b/stan/math/fwd/scal.hpp
@@ -2,10 +2,7 @@
 #define STAN_MATH_FWD_SCAL_HPP
 
 #include <stan/math/fwd/core.hpp>
-#include <stan/math/fwd/scal/meta/ad_promotable.hpp>
-#include <stan/math/fwd/scal/meta/is_fvar.hpp>
-#include <stan/math/fwd/scal/meta/partials_type.hpp>
-#include <stan/math/fwd/scal/meta/operands_and_partials.hpp>
+#include <stan/math/fwd/meta.hpp>
 
 #include <stan/math/prim/scal.hpp>
 

--- a/stan/math/mix/arr.hpp
+++ b/stan/math/mix/arr.hpp
@@ -1,13 +1,7 @@
 #ifndef STAN_MATH_MIX_ARR_HPP
 #define STAN_MATH_MIX_ARR_HPP
 
-#include <stan/math/fwd/core.hpp>
-#include <stan/math/fwd/scal/meta/is_fvar.hpp>
-#include <stan/math/fwd/scal/meta/partials_type.hpp>
-
-#include <stan/math/rev/core.hpp>
-#include <stan/math/rev/scal/meta/is_var.hpp>
-#include <stan/math/rev/scal/meta/partials_type.hpp>
+#include <stan/math/mix/meta.hpp>
 
 #include <stan/math/prim/arr.hpp>
 #include <stan/math/fwd/arr.hpp>

--- a/stan/math/mix/mat.hpp
+++ b/stan/math/mix/mat.hpp
@@ -2,6 +2,7 @@
 #define STAN_MATH_MIX_MAT_HPP
 
 #include <stan/math/mix/mat/fun/typedefs.hpp>
+#include <stan/math/mix/meta.hpp>
 
 #include <stan/math/rev/mat.hpp>
 

--- a/stan/math/mix/meta.hpp
+++ b/stan/math/mix/meta.hpp
@@ -1,4 +1,8 @@
 #ifndef STAN_MATH_MIX_META_HPP
 #define STAN_MATH_MIX_META_HPP
 
+#include <stan/math/fwd/meta.hpp>
+#include <stan/math/rev/meta.hpp>
+#include <stan/math/prim/meta.hpp>
+
 #endif

--- a/stan/math/mix/meta.hpp
+++ b/stan/math/mix/meta.hpp
@@ -1,6 +1,18 @@
 #ifndef STAN_MATH_MIX_META_HPP
 #define STAN_MATH_MIX_META_HPP
 
+#include <stan/math/prim/scal/meta/ad_promotable.hpp>
+#include <stan/math/rev/scal/meta/ad_promotable.hpp>
+#include <stan/math/fwd/scal/meta/ad_promotable.hpp>
+
+#include <stan/math/fwd/core.hpp>
+#include <stan/math/fwd/scal/meta/is_fvar.hpp>
+#include <stan/math/fwd/scal/meta/partials_type.hpp>
+
+#include <stan/math/rev/core.hpp>
+#include <stan/math/rev/scal/meta/is_var.hpp>
+#include <stan/math/rev/scal/meta/partials_type.hpp>
+
 #include <stan/math/fwd/meta.hpp>
 #include <stan/math/rev/meta.hpp>
 #include <stan/math/prim/meta.hpp>

--- a/stan/math/mix/meta.hpp
+++ b/stan/math/mix/meta.hpp
@@ -1,0 +1,4 @@
+#ifndef STAN_MATH_MIX_META_HPP
+#define STAN_MATH_MIX_META_HPP
+
+#endif

--- a/stan/math/mix/scal.hpp
+++ b/stan/math/mix/scal.hpp
@@ -1,19 +1,7 @@
 #ifndef STAN_MATH_MIX_SCAL_HPP
 #define STAN_MATH_MIX_SCAL_HPP
 
-#include <stan/math/prim/scal/meta/ad_promotable.hpp>
-#include <stan/math/rev/scal/meta/ad_promotable.hpp>
-#include <stan/math/fwd/scal/meta/ad_promotable.hpp>
-
-#include <stan/math/fwd/core.hpp>
-#include <stan/math/fwd/scal/meta/is_fvar.hpp>
-#include <stan/math/fwd/scal/meta/partials_type.hpp>
-#include <stan/math/fwd/scal/meta/operands_and_partials.hpp>
-
-#include <stan/math/rev/core.hpp>
-#include <stan/math/rev/scal/meta/is_var.hpp>
-#include <stan/math/rev/scal/meta/partials_type.hpp>
-#include <stan/math/rev/scal/meta/operands_and_partials.hpp>
+#include <stan/math/mix/meta.hpp>
 
 #include <stan/math/prim/scal.hpp>
 #include <stan/math/fwd/scal.hpp>

--- a/stan/math/prim/arr.hpp
+++ b/stan/math/prim/arr.hpp
@@ -1,16 +1,7 @@
 #ifndef STAN_MATH_PRIM_ARR_HPP
 #define STAN_MATH_PRIM_ARR_HPP
 
-#include <stan/math/prim/arr/meta/as_scalar.hpp>
-#include <stan/math/prim/arr/meta/contains_std_vector.hpp>
-#include <stan/math/prim/arr/meta/get.hpp>
-#include <stan/math/prim/arr/meta/index_type.hpp>
-#include <stan/math/prim/arr/meta/is_constant_struct.hpp>
-#include <stan/math/prim/arr/meta/is_vector.hpp>
-#include <stan/math/prim/arr/meta/length.hpp>
-#include <stan/math/prim/arr/meta/scalar_type.hpp>
-#include <stan/math/prim/arr/meta/value_type.hpp>
-#include <stan/math/prim/arr/meta/VectorBuilderHelper.hpp>
+#include <stan/math/prim/meta.hpp>
 
 #include <stan/math/prim/arr/err/check_matching_sizes.hpp>
 #include <stan/math/prim/arr/err/check_nonzero_size.hpp>

--- a/stan/math/prim/mat.hpp
+++ b/stan/math/prim/mat.hpp
@@ -1,27 +1,7 @@
 #ifndef STAN_MATH_PRIM_MAT_HPP
 #define STAN_MATH_PRIM_MAT_HPP
 
-#include <stan/math/prim/arr/meta/get.hpp>
-#include <stan/math/prim/arr/meta/index_type.hpp>
-#include <stan/math/prim/arr/meta/is_vector.hpp>
-#include <stan/math/prim/arr/meta/length.hpp>
-
-#include <stan/math/prim/mat/meta/as_array_or_scalar.hpp>
-#include <stan/math/prim/mat/meta/as_column_vector_or_scalar.hpp>
-#include <stan/math/prim/mat/meta/as_scalar.hpp>
-#include <stan/math/prim/mat/meta/broadcast_array.hpp>
-#include <stan/math/prim/mat/meta/get.hpp>
-#include <stan/math/prim/mat/meta/index_type.hpp>
-#include <stan/math/prim/mat/meta/is_constant_struct.hpp>
-#include <stan/math/prim/mat/meta/is_vector.hpp>
-#include <stan/math/prim/mat/meta/is_vector_like.hpp>
-#include <stan/math/prim/mat/meta/length.hpp>
-#include <stan/math/prim/mat/meta/length_mvt.hpp>
-#include <stan/math/prim/mat/meta/operands_and_partials.hpp>
-#include <stan/math/prim/mat/meta/scalar_type.hpp>
-#include <stan/math/prim/mat/meta/seq_view.hpp>
-#include <stan/math/prim/mat/meta/value_type.hpp>
-#include <stan/math/prim/mat/meta/vector_seq_view.hpp>
+#include <stan/math/prim/meta.hpp>
 
 #include <stan/math/prim/mat/err/check_cholesky_factor.hpp>
 #include <stan/math/prim/mat/err/check_cholesky_factor_corr.hpp>

--- a/stan/math/prim/meta.hpp
+++ b/stan/math/prim/meta.hpp
@@ -23,4 +23,53 @@
 #include <stan/math/prim/mat/meta/value_type.hpp>
 #include <stan/math/prim/mat/meta/vector_seq_view.hpp>
 
+#include <stan/math/prim/arr/meta/as_scalar.hpp>
+#include <stan/math/prim/arr/meta/contains_std_vector.hpp>
+#include <stan/math/prim/arr/meta/get.hpp>
+#include <stan/math/prim/arr/meta/index_type.hpp>
+#include <stan/math/prim/arr/meta/is_constant_struct.hpp>
+#include <stan/math/prim/arr/meta/is_vector.hpp>
+#include <stan/math/prim/arr/meta/length.hpp>
+#include <stan/math/prim/arr/meta/scalar_type.hpp>
+#include <stan/math/prim/arr/meta/value_type.hpp>
+#include <stan/math/prim/arr/meta/VectorBuilderHelper.hpp>
+
+#include <stan/math/prim/scal/meta/ad_promotable.hpp>
+#include <stan/math/prim/scal/meta/as_array_or_scalar.hpp>
+#include <stan/math/prim/scal/meta/as_column_vector_or_scalar.hpp>
+#include <stan/math/prim/scal/meta/as_scalar.hpp>
+#include <stan/math/prim/scal/meta/child_type.hpp>
+#include <stan/math/prim/scal/meta/contains_fvar.hpp>
+#include <stan/math/prim/scal/meta/contains_nonconstant_struct.hpp>
+#include <stan/math/prim/scal/meta/contains_std_vector.hpp>
+#include <stan/math/prim/scal/meta/contains_vector.hpp>
+#include <stan/math/prim/scal/meta/error_index.hpp>
+#include <stan/math/prim/scal/meta/get.hpp>
+#include <stan/math/prim/scal/meta/include_summand.hpp>
+#include <stan/math/prim/scal/meta/index_type.hpp>
+#include <stan/math/prim/scal/meta/is_constant.hpp>
+#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
+#include <stan/math/prim/scal/meta/is_nonconstant_struct.hpp>
+#include <stan/math/prim/scal/meta/is_fvar.hpp>
+#include <stan/math/prim/scal/meta/is_var.hpp>
+#include <stan/math/prim/scal/meta/is_var_or_arithmetic.hpp>
+#include <stan/math/prim/scal/meta/is_vector.hpp>
+#include <stan/math/prim/scal/meta/is_vector_like.hpp>
+#include <stan/math/prim/scal/meta/length.hpp>
+#include <stan/math/prim/scal/meta/length_mvt.hpp>
+#include <stan/math/prim/scal/meta/likely.hpp>
+#include <stan/math/prim/scal/meta/max_size.hpp>
+#include <stan/math/prim/scal/meta/max_size_mvt.hpp>
+#include <stan/math/prim/scal/meta/operands_and_partials.hpp>
+#include <stan/math/prim/scal/meta/partials_return_type.hpp>
+#include <stan/math/prim/scal/meta/partials_type.hpp>
+#include <stan/math/prim/scal/meta/return_type.hpp>
+#include <stan/math/prim/scal/meta/scalar_seq_view.hpp>
+#include <stan/math/prim/scal/meta/scalar_type.hpp>
+#include <stan/math/prim/scal/meta/scalar_type_pre.hpp>
+#include <stan/math/prim/scal/meta/size_of.hpp>
+#include <stan/math/prim/scal/meta/value_type.hpp>
+#include <stan/math/prim/scal/meta/StdVectorBuilder.hpp>
+#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
+
 #endif

--- a/stan/math/prim/meta.hpp
+++ b/stan/math/prim/meta.hpp
@@ -25,11 +25,7 @@
 
 #include <stan/math/prim/arr/meta/as_scalar.hpp>
 #include <stan/math/prim/arr/meta/contains_std_vector.hpp>
-#include <stan/math/prim/arr/meta/get.hpp>
-#include <stan/math/prim/arr/meta/index_type.hpp>
 #include <stan/math/prim/arr/meta/is_constant_struct.hpp>
-#include <stan/math/prim/arr/meta/is_vector.hpp>
-#include <stan/math/prim/arr/meta/length.hpp>
 #include <stan/math/prim/arr/meta/scalar_type.hpp>
 #include <stan/math/prim/arr/meta/value_type.hpp>
 #include <stan/math/prim/arr/meta/VectorBuilderHelper.hpp>

--- a/stan/math/prim/meta.hpp
+++ b/stan/math/prim/meta.hpp
@@ -1,0 +1,26 @@
+#ifndef STAN_MATH_PRIM_META_HPP
+#define STAN_MATH_PRIM_META_HPP
+
+#include <stan/math/prim/arr/meta/get.hpp>
+#include <stan/math/prim/arr/meta/index_type.hpp>
+#include <stan/math/prim/arr/meta/is_vector.hpp>
+#include <stan/math/prim/arr/meta/length.hpp>
+
+#include <stan/math/prim/mat/meta/as_array_or_scalar.hpp>
+#include <stan/math/prim/mat/meta/as_column_vector_or_scalar.hpp>
+#include <stan/math/prim/mat/meta/as_scalar.hpp>
+#include <stan/math/prim/mat/meta/broadcast_array.hpp>
+#include <stan/math/prim/mat/meta/get.hpp>
+#include <stan/math/prim/mat/meta/index_type.hpp>
+#include <stan/math/prim/mat/meta/is_constant_struct.hpp>
+#include <stan/math/prim/mat/meta/is_vector.hpp>
+#include <stan/math/prim/mat/meta/is_vector_like.hpp>
+#include <stan/math/prim/mat/meta/length.hpp>
+#include <stan/math/prim/mat/meta/length_mvt.hpp>
+#include <stan/math/prim/mat/meta/operands_and_partials.hpp>
+#include <stan/math/prim/mat/meta/scalar_type.hpp>
+#include <stan/math/prim/mat/meta/seq_view.hpp>
+#include <stan/math/prim/mat/meta/value_type.hpp>
+#include <stan/math/prim/mat/meta/vector_seq_view.hpp>
+
+#endif

--- a/stan/math/prim/scal.hpp
+++ b/stan/math/prim/scal.hpp
@@ -3,43 +3,7 @@
 
 #include <stan/math/version.hpp>
 
-#include <stan/math/prim/scal/meta/ad_promotable.hpp>
-#include <stan/math/prim/scal/meta/as_array_or_scalar.hpp>
-#include <stan/math/prim/scal/meta/as_column_vector_or_scalar.hpp>
-#include <stan/math/prim/scal/meta/as_scalar.hpp>
-#include <stan/math/prim/scal/meta/child_type.hpp>
-#include <stan/math/prim/scal/meta/contains_fvar.hpp>
-#include <stan/math/prim/scal/meta/contains_nonconstant_struct.hpp>
-#include <stan/math/prim/scal/meta/contains_std_vector.hpp>
-#include <stan/math/prim/scal/meta/contains_vector.hpp>
-#include <stan/math/prim/scal/meta/error_index.hpp>
-#include <stan/math/prim/scal/meta/get.hpp>
-#include <stan/math/prim/scal/meta/include_summand.hpp>
-#include <stan/math/prim/scal/meta/index_type.hpp>
-#include <stan/math/prim/scal/meta/is_constant.hpp>
-#include <stan/math/prim/scal/meta/is_constant_struct.hpp>
-#include <stan/math/prim/scal/meta/is_nonconstant_struct.hpp>
-#include <stan/math/prim/scal/meta/is_fvar.hpp>
-#include <stan/math/prim/scal/meta/is_var.hpp>
-#include <stan/math/prim/scal/meta/is_var_or_arithmetic.hpp>
-#include <stan/math/prim/scal/meta/is_vector.hpp>
-#include <stan/math/prim/scal/meta/is_vector_like.hpp>
-#include <stan/math/prim/scal/meta/length.hpp>
-#include <stan/math/prim/scal/meta/length_mvt.hpp>
-#include <stan/math/prim/scal/meta/likely.hpp>
-#include <stan/math/prim/scal/meta/max_size.hpp>
-#include <stan/math/prim/scal/meta/max_size_mvt.hpp>
-#include <stan/math/prim/scal/meta/operands_and_partials.hpp>
-#include <stan/math/prim/scal/meta/partials_return_type.hpp>
-#include <stan/math/prim/scal/meta/partials_type.hpp>
-#include <stan/math/prim/scal/meta/return_type.hpp>
-#include <stan/math/prim/scal/meta/scalar_seq_view.hpp>
-#include <stan/math/prim/scal/meta/scalar_type.hpp>
-#include <stan/math/prim/scal/meta/scalar_type_pre.hpp>
-#include <stan/math/prim/scal/meta/size_of.hpp>
-#include <stan/math/prim/scal/meta/value_type.hpp>
-#include <stan/math/prim/scal/meta/StdVectorBuilder.hpp>
-#include <stan/math/prim/scal/meta/VectorBuilder.hpp>
+#include <stan/math/prim/meta.hpp>
 
 #include <stan/math/prim/scal/err/check_2F1_converges.hpp>
 #include <stan/math/prim/scal/err/check_3F2_converges.hpp>

--- a/stan/math/rev/arr.hpp
+++ b/stan/math/rev/arr.hpp
@@ -2,8 +2,7 @@
 #define STAN_MATH_REV_ARR_HPP
 
 #include <stan/math/rev/core.hpp>
-#include <stan/math/rev/scal/meta/is_var.hpp>
-#include <stan/math/rev/scal/meta/partials_type.hpp>
+#include <stan/math/rev/meta.hpp>
 
 #include <stan/math/prim/arr.hpp>
 #include <stan/math/rev/scal.hpp>

--- a/stan/math/rev/mat.hpp
+++ b/stan/math/rev/mat.hpp
@@ -2,9 +2,7 @@
 #define STAN_MATH_REV_MAT_HPP
 
 #include <stan/math/rev/core.hpp>
-#include <stan/math/rev/scal/meta/is_var.hpp>
-#include <stan/math/rev/scal/meta/partials_type.hpp>
-#include <stan/math/rev/mat/meta/operands_and_partials.hpp>
+#include <stan/math/rev/meta.hpp>
 
 #include <stan/math/rev/mat/fun/Eigen_NumTraits.hpp>
 

--- a/stan/math/rev/meta.hpp
+++ b/stan/math/rev/meta.hpp
@@ -5,12 +5,7 @@
 #include <stan/math/rev/scal/meta/partials_type.hpp>
 #include <stan/math/rev/mat/meta/operands_and_partials.hpp>
 
-#include <stan/math/rev/scal/meta/is_var.hpp>
-#include <stan/math/rev/scal/meta/partials_type.hpp>
-
 #include <stan/math/rev/scal/meta/ad_promotable.hpp>
-#include <stan/math/rev/scal/meta/is_var.hpp>
-#include <stan/math/rev/scal/meta/partials_type.hpp>
 #include <stan/math/rev/scal/meta/operands_and_partials.hpp>
 
 #endif

--- a/stan/math/rev/meta.hpp
+++ b/stan/math/rev/meta.hpp
@@ -1,0 +1,8 @@
+#ifndef STAN_MATH_REV_META_HPP
+#define STAN_MATH_REV_META_HPP
+
+#include <stan/math/rev/scal/meta/is_var.hpp>
+#include <stan/math/rev/scal/meta/partials_type.hpp>
+#include <stan/math/rev/mat/meta/operands_and_partials.hpp>
+
+#endif

--- a/stan/math/rev/meta.hpp
+++ b/stan/math/rev/meta.hpp
@@ -5,4 +5,12 @@
 #include <stan/math/rev/scal/meta/partials_type.hpp>
 #include <stan/math/rev/mat/meta/operands_and_partials.hpp>
 
+#include <stan/math/rev/scal/meta/is_var.hpp>
+#include <stan/math/rev/scal/meta/partials_type.hpp>
+
+#include <stan/math/rev/scal/meta/ad_promotable.hpp>
+#include <stan/math/rev/scal/meta/is_var.hpp>
+#include <stan/math/rev/scal/meta/partials_type.hpp>
+#include <stan/math/rev/scal/meta/operands_and_partials.hpp>
+
 #endif

--- a/stan/math/rev/scal.hpp
+++ b/stan/math/rev/scal.hpp
@@ -2,10 +2,7 @@
 #define STAN_MATH_REV_SCAL_HPP
 
 #include <stan/math/rev/core.hpp>
-#include <stan/math/rev/scal/meta/ad_promotable.hpp>
-#include <stan/math/rev/scal/meta/is_var.hpp>
-#include <stan/math/rev/scal/meta/partials_type.hpp>
-#include <stan/math/rev/scal/meta/operands_and_partials.hpp>
+#include <stan/math/rev/meta.hpp>
 
 #include <stan/math/prim/scal.hpp>
 

--- a/test/unit/math/prim/scal/meta/is_var_or_arihtmetic_test.cpp
+++ b/test/unit/math/prim/scal/meta/is_var_or_arihtmetic_test.cpp
@@ -7,7 +7,7 @@ TEST(MathMeta, is_var_or_arithmetic_simple) {
   using stan::is_var_or_arithmetic;
   EXPECT_TRUE(stan::is_var_or_arithmetic<double>::value);
   EXPECT_FALSE(stan::is_var_or_arithmetic<double&>::value);
-  EXPECT_FALSE(stan::is_var_or_arithmetic<std::vector<double>>::value);
+  EXPECT_TRUE(stan::is_var_or_arithmetic<std::vector<double>>::value);
 
   EXPECT_FALSE(stan::is_var_or_arithmetic<int&>::value);
   EXPECT_TRUE(stan::is_var_or_arithmetic<int>::value);
@@ -15,7 +15,7 @@ TEST(MathMeta, is_var_or_arithmetic_simple) {
   bool temp = is_var_or_arithmetic<int&, double>::value;
   EXPECT_FALSE(temp);
   temp = is_var_or_arithmetic<double, std::vector<double>>::value;
-  EXPECT_FALSE(temp);
+  EXPECT_TRUE(temp);
   temp = is_var_or_arithmetic<double, double, std::vector<double>, double,
                               std::vector<double>, double&>::value;
   EXPECT_FALSE(temp);

--- a/test/unit/math/rev/scal/meta/VectorBuilderHelper_test.cpp
+++ b/test/unit/math/rev/scal/meta/VectorBuilderHelper_test.cpp
@@ -12,16 +12,3 @@ TEST(MetaTraits, VectorBuilderHelper_false_true) {
   EXPECT_THROW(dvv1[0], std::logic_error);
   EXPECT_THROW(dvv1.data(), std::logic_error);
 }
-
-TEST(MetaTraits, VectorBuilderHelper_true_true) {
-  using stan::VectorBuilderHelper;
-  using stan::length;
-  using stan::math::var;
-
-  var a_var(1);
-
-  VectorBuilderHelper<double, true, true> dvv1(length(a_var));
-  EXPECT_THROW(dvv1[0], std::logic_error)
-      << "This uses the default template; if the arr version is included, "
-      << "it will use the template specialization.";
-}


### PR DESCRIPTION
## Summary

One step in getting closer to the flatten refactor. This PR adds four `meta.hpp` headers that the existing headers can include.

The goal of this PR is to create a seam (described in "Working with Legacy Code") which will allow us to work on flattening meta independently of everything else. The meta traits is the complicated, order-dependent piece of the code, so separating that out will make this easier.

This is only one step in flattening the dependency structure.

## More detail

The four new headers added are:

1. `stan/math/prim/meta.hpp`; included by `stan/math/prim/{scal, arr, mat}.hpp`
2. `stan/math/rev/meta.hpp`; included by `stan/math/rev/{scal, arr, mat}.hpp`
3. `stan/math/fwd/meta.hpp`; included by `stan/math/fwd/{scal, arr, mat}.hpp`
4. `stan/math/mix/meta.hpp`; included by `stan/math/mix/{scal, arr, mat}.hpp`

There is a side effect: by including `stan/math/prim/scal.hpp`, this will now instantiate the meta traits for matrix, so it does include Eigen. This is intended behavior and this is what will happen eventually when the refactor is done.

## Tests

All existing tests pass with this PR.

Two tests had to change, correctly, for this to work:
1. test/unit/math/prim/scal/meta/is_var_or_arihtmetic_test.cpp
2. test/unit/math/rev/scal/meta/VectorBuilderHelper_test.cpp

These tests were explicitly testing that without explicit instantiations of traits for `Eigen::Matrix` or `std::vector` it would call the base templated functions that have different behavior.

## Side Effects

With this PR, all the big header files will include `std::vector` and `Eigen::Matrix`. From a client perspective, the behavior of almost everything won't change. Some of the traits behavior does change (default behavior vs. template instantiation), but we wouldn't have encouraged clients to use these things directly.

This will simplify how add new traits.

## Notes to the reviewer

It's a little hard to see what's going on with the github interface. On a high level, what's happened is:
1. the includes for meta traits in `stan/math/prim/mat.hpp` were moved to `stan/math/prim/meta.hpp` (that's just all the includes). I had to trace through what those meta traits included and also moved all that into `stan/math/prim/meta.hpp`. So you'll see all the meta traits included there.
2. the explicit includes for the meta traits in `stan/math/prim/{scal, arr, mat}.hpp` have now been replaced with `stan/math/prim/meta.hpp`.
3. this process was repeated for `rev`, `fwd`, and `mix`.


## Checklist

- [x] Math issue #937; this is just one part

- [x] Copyright holder: Generable

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
