### PR TITLE
GLM tests improvements

### DIFF
--- a/test/unit/math/rev/mat/prob/bernoulli_logit_glm_lpmf_test.cpp
+++ b/test/unit/math/rev/mat/prob/bernoulli_logit_glm_lpmf_test.cpp
@@ -9,12 +9,12 @@
 using Eigen::Dynamic;
 using Eigen::Matrix;
 using stan::math::var;
+using std::vector;
 
 //  We check that the values of the new regression match those of one built
 //  from existing primitives.
 TEST(ProbDistributionsBernoulliLogitGLM, glm_matches_bernoulli_logit_doubles) {
-  Matrix<int, Dynamic, 1> y(3, 1);
-  y << 1, 0, 1;
+  vector<int> y{1, 0, 1};
   Matrix<double, Dynamic, Dynamic> x(3, 2);
   x << -12, 46, -42, 24, 25, 27;
   Matrix<double, Dynamic, 1> beta(2, 1);
@@ -36,7 +36,7 @@ TEST(ProbDistributionsBernoulliLogitGLM, glm_matches_bernoulli_logit_doubles) {
 TEST(ProbDistributionsBernoulliLogitGLM,
      glm_matches_bernoulli_logit_doubles_rand) {
   for (size_t ii = 0; ii < 200; ii++) {
-    Matrix<int, Dynamic, 1> y(3, 1);
+    vector<int> y(3);
     for (size_t i = 0; i < 3; i++) {
       y[i] = Matrix<unsigned int, 1, 1>::Random(1, 1)[0] % 2;
     }
@@ -61,8 +61,7 @@ TEST(ProbDistributionsBernoulliLogitGLM,
 //  We check that the gradients of the new regression match those of one built
 //  from existing primitives.
 TEST(ProbDistributionsBernoulliLogitGLM, glm_matches_bernoulli_logit_vars) {
-  Matrix<int, Dynamic, 1> y(3, 1);
-  y << 1, 0, 1;
+  vector<int> y{1, 0, 1};
   Matrix<var, Dynamic, Dynamic> x(3, 2);
   x << -1234, 46, -42, 24, 25, 27;
   Matrix<var, Dynamic, 1> beta(2, 1);
@@ -88,8 +87,7 @@ TEST(ProbDistributionsBernoulliLogitGLM, glm_matches_bernoulli_logit_vars) {
 
   stan::math::recover_memory();
 
-  Matrix<int, Dynamic, 1> y2(3, 1);
-  y2 << 1, 0, 1;
+  vector<int> y2{1, 0, 1};
   Matrix<var, Dynamic, Dynamic> x2(3, 2);
   x2 << -1234, 46, -42, 24, 25, 27;
   Matrix<var, Dynamic, 1> beta2(2, 1);
@@ -114,7 +112,7 @@ TEST(ProbDistributionsBernoulliLogitGLM, glm_matches_bernoulli_logit_vars) {
 TEST(ProbDistributionsBernoulliLogitGLM,
      glm_matches_bernoulli_logit_vars_rand) {
   for (size_t ii = 0; ii < 42; ii++) {
-    Matrix<int, Dynamic, 1> y(3, 1);
+    vector<int> y(3);
     for (size_t i = 0; i < 3; i++) {
       y[i] = Matrix<unsigned int, 1, 1>::Random(1, 1)[0] % 2;
     }
@@ -171,7 +169,7 @@ TEST(ProbDistributionsBernoulliLogitGLM,
 TEST(ProbDistributionsBernoulliLogitGLM,
      glm_matches_bernoulli_logit_vars_rand_scal_beta) {
   for (size_t ii = 0; ii < 42; ii++) {
-    Matrix<int, Dynamic, 1> y(3, 1);
+    vector<int> y(3);
     for (size_t i = 0; i < 3; i++) {
       y[i] = Matrix<unsigned int, 1, 1>::Random(1, 1)[0] % 2;
     }
@@ -217,7 +215,7 @@ TEST(ProbDistributionsBernoulliLogitGLM,
 TEST(ProbDistributionsBernoulliLogitGLM,
      glm_matches_bernoulli_varying_intercept) {
   for (size_t ii = 0; ii < 42; ii++) {
-    Matrix<int, Dynamic, 1> y(3, 1);
+    vector<int> y(3);
     for (size_t i = 0; i < 3; i++) {
       y[i] = Matrix<unsigned int, 1, 1>::Random(1, 1)[0] % 2;
     }
@@ -280,7 +278,7 @@ TEST(ProbDistributionsBernoulliLogitGLM,
   double value2 = 0;
 
   int i = 1;
-  std::vector<double> vi = {{1, 0}};
+  std::vector<int> vi = {{1, 0}};
   double d = 1.0;
   std::vector<double> vd = {{1.0, 2.0}};
   Eigen::VectorXd ev(2);

--- a/test/unit/math/rev/mat/prob/neg_binomial_2_log_glm_lpmf_test.cpp
+++ b/test/unit/math/rev/mat/prob/neg_binomial_2_log_glm_lpmf_test.cpp
@@ -7,13 +7,13 @@
 using Eigen::Dynamic;
 using Eigen::Matrix;
 using stan::math::var;
+using std::vector;
 
 //  We check that the values of the new regression match those of one built
 //  from existing primitives.
 TEST(ProbDistributionsNegBinomial2LogGLM,
      glm_matches_neg_binomial_2_log_doubles) {
-  Matrix<int, Dynamic, 1> y(3, 1);
-  y << 1, 0, 1;
+  vector<int> y{1, 0, 1};
   Matrix<double, Dynamic, Dynamic> x(3, 2);
   x << -12, 46, -42, 24, 25, 27;
   Matrix<double, Dynamic, 1> beta(2, 1);
@@ -35,7 +35,7 @@ TEST(ProbDistributionsNegBinomial2LogGLM,
 TEST(ProbDistributionsNegBinomial2LogGLM,
      glm_matches_neg_binomial_2_log_doubles_rand) {
   for (size_t ii = 0; ii < 42; ii++) {
-    Matrix<int, Dynamic, 1> y(3, 1);
+    vector<int> y(3);
     for (size_t i = 0; i < 3; i++) {
       y[i] = Matrix<unsigned int, 1, 1>::Random(1, 1)[0] % 200;
     }
@@ -60,8 +60,7 @@ TEST(ProbDistributionsNegBinomial2LogGLM,
 //  We check that the gradients of the new regression match those of one built
 //  from existing primitives.
 TEST(ProbDistributionsNegBinomial2LogGLM, glm_matches_neg_binomial_2_log_vars) {
-  Matrix<int, Dynamic, 1> y(3, 1);
-  y << 1, 0, 1;
+  vector<int> y{1, 0, 1};
   Matrix<var, Dynamic, Dynamic> x(3, 2);
   x << -12, 46, -42, 24, 25, 27;
   Matrix<var, Dynamic, 1> beta(2, 1);
@@ -88,8 +87,7 @@ TEST(ProbDistributionsNegBinomial2LogGLM, glm_matches_neg_binomial_2_log_vars) {
 
   stan::math::recover_memory();
 
-  Matrix<int, Dynamic, 1> y2(3, 1);
-  y2 << 1, 0, 1;
+  vector<int> y2{1, 0, 1};
   Matrix<var, Dynamic, Dynamic> x2(3, 2);
   x2 << -12, 46, -42, 24, 25, 27;
   Matrix<var, Dynamic, 1> beta2(2, 1);
@@ -117,7 +115,7 @@ TEST(ProbDistributionsNegBinomial2LogGLM, glm_matches_neg_binomial_2_log_vars) {
 TEST(ProbDistributionsNegBinomial2LogGLM,
      glm_matches_neg_binomial_2_log_vars_rand) {
   for (size_t ii = 0; ii < 200; ii++) {
-    Matrix<int, Dynamic, 1> y(3, 1);
+    vector<int> y(3);
     for (size_t i = 0; i < 3; i++) {
       y[i] = Matrix<unsigned int, 1, 1>::Random(1, 1)[0] % 200;
     }
@@ -176,7 +174,7 @@ TEST(ProbDistributionsNegBinomial2LogGLM,
 TEST(ProbDistributionsNegBinomial2LogGLM,
      glm_matches_neg_binomial_2_log_vars_rand_scal_beta) {
   for (size_t ii = 0; ii < 42; ii++) {
-    Matrix<int, Dynamic, 1> y(3, 1);
+    vector<int> y(3);
     for (size_t i = 0; i < 3; i++) {
       y[i] = Matrix<unsigned int, 1, 1>::Random(1, 1)[0] % 200;
     }
@@ -228,7 +226,7 @@ TEST(ProbDistributionsNegBinomial2LogGLM,
 TEST(ProbDistributionsNegBinomial2LogGLM,
      glm_matches_neg_binomial_2_log_varying_intercept) {
   for (size_t ii = 0; ii < 200; ii++) {
-    Matrix<int, Dynamic, 1> y(3, 1);
+    vector<int> y(3);
     for (size_t i = 0; i < 3; i++) {
       y[i] = Matrix<unsigned int, 1, 1>::Random(1, 1)[0] % 200;
     }

--- a/test/unit/math/rev/mat/prob/poisson_log_glm_lpmf_test.cpp
+++ b/test/unit/math/rev/mat/prob/poisson_log_glm_lpmf_test.cpp
@@ -7,12 +7,12 @@
 using Eigen::Dynamic;
 using Eigen::Matrix;
 using stan::math::var;
+using std::vector;
 
 //  We check that the values of the new regression match those of one built
 //  from existing primitives.
 TEST(ProbDistributionsPoissonLogGLM, glm_matches_poisson_log_doubles) {
-  Matrix<int, Dynamic, 1> y(3, 1);
-  y << 15, 3, 5;
+  vector<int> y{15, 3, 5};
   Matrix<double, Dynamic, Dynamic> x(3, 2);
   x << -12, 46, -42, 24, 25, 27;
   Matrix<double, Dynamic, 1> beta(2, 1);
@@ -30,7 +30,7 @@ TEST(ProbDistributionsPoissonLogGLM, glm_matches_poisson_log_doubles) {
 //  from existing primitives.
 TEST(ProbDistributionsPoissonLogGLM, glm_matches_poisson_log_doubles_rand) {
   for (size_t ii = 0; ii < 42; ii++) {
-    Matrix<int, Dynamic, 1> y(3, 1);
+    vector<int> y(3);
     for (size_t i = 0; i < 3; i++) {
       y[i] = Matrix<unsigned int, 1, 1>::Random(1, 1)[0] % 200;
     }
@@ -53,8 +53,7 @@ TEST(ProbDistributionsPoissonLogGLM, glm_matches_poisson_log_doubles_rand) {
 //  We check that the gradients of the new regression match those of one built
 //  from existing primitives.
 TEST(ProbDistributionsPoissonLogGLM, glm_matches_poisson_log_vars) {
-  Matrix<int, Dynamic, 1> y(3, 1);
-  y << 14, 2, 5;
+  vector<int> y{14, 2, 5};
   Matrix<var, Dynamic, Dynamic> x(3, 2);
   x << -12, 46, -42, 24, 25, 27;
   Matrix<var, Dynamic, 1> beta(2, 1);
@@ -79,8 +78,7 @@ TEST(ProbDistributionsPoissonLogGLM, glm_matches_poisson_log_vars) {
 
   stan::math::recover_memory();
 
-  Matrix<int, Dynamic, 1> y2(3, 1);
-  y2 << 14, 2, 5;
+  vector<int> y2{14, 2, 5};
   Matrix<var, Dynamic, Dynamic> x2(3, 2);
   x2 << -12, 46, -42, 24, 25, 27;
   Matrix<var, Dynamic, 1> beta2(2, 1);
@@ -101,7 +99,7 @@ TEST(ProbDistributionsPoissonLogGLM, glm_matches_poisson_log_vars) {
 //  from existing primitives.
 TEST(ProbDistributionsPoissonLogGLM, glm_matches_poisson_log_vars_rand) {
   for (size_t ii = 0; ii < 200; ii++) {
-    Matrix<int, Dynamic, 1> y(3, 1);
+    vector<int> y(3);
     for (size_t i = 0; i < 3; i++) {
       y[i] = Matrix<unsigned int, 1, 1>::Random(1, 1)[0] % 200;
     }
@@ -153,7 +151,7 @@ TEST(ProbDistributionsPoissonLogGLM, glm_matches_poisson_log_vars_rand) {
 TEST(ProbDistributionsPoissonLogGLM,
      glm_matches_poisson_log_vars_rand_scal_beta) {
   for (size_t ii = 0; ii < 42; ii++) {
-    Matrix<int, Dynamic, 1> y(3, 1);
+    vector<int> y(3);
     for (size_t i = 0; i < 3; i++) {
       y[i] = Matrix<unsigned int, 1, 1>::Random(1, 1)[0] % 200;
     }
@@ -198,7 +196,7 @@ TEST(ProbDistributionsPoissonLogGLM,
 //  from existing primitives, for the GLM with varying intercept.
 TEST(ProbDistributionsPoissonLogGLM, glm_matches_poisson_varying_intercept) {
   for (size_t ii = 0; ii < 42; ii++) {
-    Matrix<int, Dynamic, 1> y(3, 1);
+    vector<int> y(3);
     for (size_t i = 0; i < 3; i++) {
       y[i] = Matrix<unsigned int, 1, 1>::Random(1, 1)[0] % 200;
     }


### PR DESCRIPTION
## Summary

Changes testing of GLMs that accept integer y from using `Eigen::Matrix<int, Dynamic, 1>` to `std::vector<int>`. See the issue #1260 for more info.

## Checklist

- [x] Math issue #1260 

- [x] Copyright holder: Tadej Ciglarič, University of Ljubljana

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
