### PR TITLE
Use Eigen's aligned_malloc and aligned_free in stack_alloc

### DIFF
--- a/make/compiler_flags
+++ b/make/compiler_flags
@@ -88,7 +88,7 @@ CXXFLAGS_SUNDIALS ?= -pipe
 # LDLIBS_MPI
 
 # Eigen Flags
-CXXFLAGS_EIGEN ?= -DEIGEN_MAX_ALIGN_BYTES=64
+CXXFLAGS_EIGEN ?= -DEIGEN_MAX_ALIGN_BYTES=32
 
 ################################################################################
 # Update compiler flags with operating system specific modifications

--- a/make/compiler_flags
+++ b/make/compiler_flags
@@ -87,6 +87,9 @@ CXXFLAGS_SUNDIALS ?= -pipe
 # LDFLAGS_MPI
 # LDLIBS_MPI
 
+# Eigen Flags
+CXXFLAGS_EIGEN ?= -DEIGEN_MAX_ALIGN_BYTES=64
+
 ################################################################################
 # Update compiler flags with operating system specific modifications
 ##

--- a/stan/math/memory/stack_alloc.hpp
+++ b/stan/math/memory/stack_alloc.hpp
@@ -38,14 +38,6 @@ const size_t DEFAULT_INITIAL_NBYTES = 1 << 16;  // 64KB
 // big fun to inline, but only called twice
 inline char* eight_byte_aligned_malloc(size_t size) {
   char* ptr = static_cast<char*>(Eigen::internal::aligned_malloc(size));
-  if (!ptr)
-    return ptr;  // malloc failed to alloc
-  if (!is_aligned(ptr, 8U)) {
-    std::stringstream s;
-    s << "invalid alignment to 8 bytes, ptr="
-      << reinterpret_cast<uintptr_t>(ptr) << std::endl;
-    throw std::runtime_error(s.str());
-  }
   return ptr;
 }
 }  // namespace internal

--- a/stan/math/memory/stack_alloc.hpp
+++ b/stan/math/memory/stack_alloc.hpp
@@ -5,6 +5,7 @@
 //            is best we can do to get safe pointer casts to uints.
 #include <stdint.h>
 #include <stan/math/prim/meta.hpp>
+#include <Eigen/src/Core/util/Memory.h>
 #include <cstdlib>
 #include <cstddef>
 #include <sstream>
@@ -36,7 +37,7 @@ const size_t DEFAULT_INITIAL_NBYTES = 1 << 16;  // 64KB
 // FIXME: enforce alignment
 // big fun to inline, but only called twice
 inline char* eight_byte_aligned_malloc(size_t size) {
-  char* ptr = static_cast<char*>(malloc(size));
+  char* ptr = static_cast<char*>(Eigen::internal::aligned_malloc(size));
   if (!ptr)
     return ptr;  // malloc failed to alloc
   if (!is_aligned(ptr, 8U)) {

--- a/stan/math/memory/stack_alloc.hpp
+++ b/stan/math/memory/stack_alloc.hpp
@@ -145,7 +145,7 @@ class stack_alloc {
     // free ALL blocks
     for (auto& block : blocks_)
       if (block)
-        Eigen::internal::aligned_free(block);(block);
+        Eigen::internal::aligned_free(block);
   }
 
   /**
@@ -231,7 +231,7 @@ class stack_alloc {
     // frees all BUT the first (index 0) block
     for (size_t i = 1; i < blocks_.size(); ++i)
       if (blocks_[i])
-        Eigen::internal::aligned_free(block);(blocks_[i]);
+        Eigen::internal::aligned_free(blocks_[i]);
     sizes_.resize(1);
     blocks_.resize(1);
     recover_all();

--- a/stan/math/memory/stack_alloc.hpp
+++ b/stan/math/memory/stack_alloc.hpp
@@ -145,7 +145,7 @@ class stack_alloc {
     // free ALL blocks
     for (auto& block : blocks_)
       if (block)
-        free(block);
+        Eigen::internal::aligned_free(block);(block);
   }
 
   /**
@@ -231,7 +231,7 @@ class stack_alloc {
     // frees all BUT the first (index 0) block
     for (size_t i = 1; i < blocks_.size(); ++i)
       if (blocks_[i])
-        free(blocks_[i]);
+        Eigen::internal::aligned_free(block);(blocks_[i]);
     sizes_.resize(1);
     blocks_.resize(1);
     recover_all();


### PR DESCRIPTION
## Summary

There's been a [`FIXME`](https://github.com/stan-dev/math/blob/develop/stan/math/memory/stack_alloc.hpp#L36) in the `stack_alloc` class for a while now saying

```
// FIXME: enforce alignment
```

So, I started looking into how to enforce alignment and it turns out, not easy! I started reading Eigen's [`Memory.h`](https://github.com/eigenteam/eigen-git-mirror/blob/master/Eigen/src/Core/util/Memory.h) file to see how they do it. Lots of gotchas here and there.

So, I figured why don't we just use their stuff? Below are the cmdstan performance tests that just replace `malloc` and `free` with Eigen's `aligned_malloc` and `aligned_free`.

```
('stat_comp_benchmarks/benchmarks/gp_pois_regr/gp_pois_regr.stan', 1.0)
('stat_comp_benchmarks/benchmarks/low_dim_corr_gauss/low_dim_corr_gauss.stan', 0.94)
('stat_comp_benchmarks/benchmarks/arK/arK.stan', 1.0)
('stat_comp_benchmarks/benchmarks/pkpd/one_comp_mm_elim_abs.stan', 0.98)
('stat_comp_benchmarks/benchmarks/eight_schools/eight_schools.stan', 1.02)
('stat_comp_benchmarks/benchmarks/irt_2pl/irt_2pl.stan', 0.98)
('stat_comp_benchmarks/benchmarks/gp_regr/gp_regr.stan', 0.98)
('performance.compilation', 1.0)
('stat_comp_benchmarks/benchmarks/low_dim_gauss_mix_collapse/low_dim_gauss_mix_collapse.stan', 0.99)
('stat_comp_benchmarks/benchmarks/low_dim_gauss_mix/low_dim_gauss_mix.stan', 0.98)
('stat_comp_benchmarks/benchmarks/sir/sir.stan', 1.06)
('stat_comp_benchmarks/benchmarks/pkpd/sim_one_comp_mm_elim_abs.stan', 0.97)
('stat_comp_benchmarks/benchmarks/garch/garch.stan', 0.97)
('stat_comp_benchmarks/benchmarks/gp_regr/gen_gp_data.stan', 1.07)
('stat_comp_benchmarks/benchmarks/arma/arma.stan', 1.08)
1.00239340085
```

For a few models this doesn't seem to matter much, but for the ones that have contiguous access like arma and sir it seems like this is good.  

The one major issue is that `aligned_malloc` and `aligned_free` sit in `Eigen::internal` and it's certainly not good to rely on stuff they don't expose. Would we want to rip this out of Eigen for ourselves? Or is okay to use this internal part of Eigen?

If we went the route of ripping this stuff out I'd like to take it all the way and actually write a `aligned_allocator` like Eigen does that uses Stan's local allocator for the standard containers. i.e. for the code in `sum_v_vari` I think having our own allocator type would let us do something like

```cpp
class sum_v_vari : public vari {
 protected:
  std::vector<vari, stan_local_allocator<vari>> v_;
  size_t length_;

  inline static double sum_of_val(const std::vector<var>& v) {
    double result = 0;
    for (auto x : v)
      result += x.val();
    return result;
  }

 public:
  explicit sum_v_vari(double value, vari** v, size_t length)
      : vari(value), v_(v), length_(length) {}

  explicit sum_v_vari(const std::vector<var>& v1)
      : vari(sum_of_val(v1)),
        v_(v1), // I think something like this would 'just work'??
        length_(v1.size()) {
  }
```

Though I have to guess someone has thought of this before. Is there a reason we never went this route?

## Tests

No new tests

## Side Effects

We now use Eigen's aligned_malloc and aligned_free. 

## Checklist

- [ ] Math issue #(issue number)

- [ ] Copyright holder: (fill in copyright holder information)
Steve Bronder

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [ ] the code is written in idiomatic C++ and changes are documented in the doxygen

- [ ] the new changes are tested
