### PR TITLE
Refactor rev/mat with eigen plugin methods

### DIFF
--- a/stan/math/prim/mat/eigen_plugins.h
+++ b/stan/math/prim/mat/eigen_plugins.h
@@ -43,6 +43,11 @@ using forward_return_t = std::conditional_t<std::is_const<std::remove_reference_
  * check a combination of whether the input is a pointer (i.e. vari*)
  * and/or whether the input has member ".d_" (i.e. fvar).
  *
+ * There are two methods for returning doubles unchanged. One which takes a reference
+ * to a double and returns the same reference, used when 'chaining' methods
+ * (i.e. A.adj().val()). The other for passing and returning by value, used directly 
+ * with matrices of doubles (i.e. A.val(), where A is of type MatrixXd).
+ *
  * For definitions of EIGEN_EMPTY_STRUCT_CTOR, EIGEN_DEVICE_FUNC, and
  * EIGEN_STRONG_INLINE; see: https://eigen.tuxfamily.org/dox/XprHelper_8h_source.html
  */
@@ -68,15 +73,17 @@ struct val_Op{
     std::enable_if_t<is_fvar<T>::value, forward_return_t<T>>
       operator()(T &v) const { return v.val_; }
 
-  //Returns double unchanged from input
+  //Returns double unchanged from input (by value)
   template<typename T = Scalar>
   EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE
     std::enable_if_t<std::is_arithmetic<T>::value, double_return_t<T>>
       operator()(T v) const { return v; }
 
+  //Returns double unchanged from input (by reference)
   EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE
   const double& operator()(const double& v) const { return v; }
 
+  //Returns double unchanged from input (by reference)
   EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE
   double& operator()(double& v) const { return v; }
 };

--- a/stan/math/rev/mat/fun/LDLT_alloc.hpp
+++ b/stan/math/rev/mat/fun/LDLT_alloc.hpp
@@ -29,19 +29,9 @@ class LDLT_alloc : public chainable_alloc {
    * called elsewhere.
    **/
   inline void compute(const Eigen::Matrix<var, R, C> &A) {
-    Eigen::Matrix<double, R, C> Ad(A.rows(), A.cols());
-
     N_ = A.rows();
-    variA_.resize(A.rows(), A.cols());
-
-    for (size_t j = 0; j < N_; j++) {
-      for (size_t i = 0; i < N_; i++) {
-        Ad(i, j) = A(i, j).val();
-        variA_(i, j) = A(i, j).vi_;
-      }
-    }
-
-    ldlt_.compute(Ad);
+    variA_ = A.vi();
+    ldlt_.compute(A.val());
   }
 
   // Compute the log(abs(det(A))).  This is just a convenience function.

--- a/stan/math/rev/mat/fun/dot_product.hpp
+++ b/stan/math/rev/mat/fun/dot_product.hpp
@@ -52,10 +52,12 @@ class dot_product_vari : public vari {
   template <typename Derived1, typename Derived2>
   inline static double var_dot(const Eigen::DenseBase<Derived1>& v1,
                                const Eigen::DenseBase<Derived2>& v2) {
-    vector_d vd1 = Eigen::Ref<const Eigen::Matrix<
-                                  typename Derived1::Scalar, -1, 1>>(v1).val();
-    vector_d vd2 = Eigen::Ref<const Eigen::Matrix<
-                                  typename Derived2::Scalar, -1, 1>>(v2).val();
+    vector_d vd1
+        = Eigen::Ref<const Eigen::Matrix<typename Derived1::Scalar, -1, 1>>(v1)
+              .val();
+    vector_d vd2
+        = Eigen::Ref<const Eigen::Matrix<typename Derived2::Scalar, -1, 1>>(v2)
+              .val();
     return vd1.dot(vd2);
   }
   inline void chain(vari** v1, vari** v2) {
@@ -66,11 +68,11 @@ class dot_product_vari : public vari {
   }
   inline void chain(double* v1, vari** v2) {
     Eigen::Map<vector_vi>(v2, length_).adj()
-      += adj_ * Eigen::Map<vector_d>(v1, length_);
+        += adj_ * Eigen::Map<vector_d>(v1, length_);
   }
   inline void chain(vari** v1, double* v2) {
     Eigen::Map<vector_vi>(v1, length_).adj()
-      += adj_ * Eigen::Map<vector_d>(v2, length_);
+        += adj_ * Eigen::Map<vector_d>(v2, length_);
   }
   inline void initialize(vari**& mem_v, const var* inv,
                          vari** shared = nullptr) {
@@ -78,7 +80,7 @@ class dot_product_vari : public vari {
       mem_v = reinterpret_cast<vari**>(
           ChainableStack::instance_->memalloc_.alloc(length_ * sizeof(vari*)));
       Eigen::Map<vector_vi>(mem_v, length_)
-        = Eigen::Map<const vector_v>(inv, length_).vi();
+          = Eigen::Map<const vector_v>(inv, length_).vi();
     } else {
       mem_v = shared;
     }
@@ -90,7 +92,7 @@ class dot_product_vari : public vari {
       mem_v = reinterpret_cast<vari**>(
           ChainableStack::instance_->memalloc_.alloc(length_ * sizeof(vari*)));
       Eigen::Map<vector_vi>(mem_v, length_)
-        = Eigen::Map<const vector_v>(&inv(0), length_).vi();
+          = Eigen::Map<const vector_v>(&inv(0), length_).vi();
     } else {
       mem_v = shared;
     }
@@ -114,7 +116,7 @@ class dot_product_vari : public vari {
       mem_d = reinterpret_cast<double*>(
           ChainableStack::instance_->memalloc_.alloc(length_ * sizeof(double)));
       Eigen::Map<vector_d>(mem_d, length_)
-        = Eigen::Map<const vector_d>(&ind(0), length_);
+          = Eigen::Map<const vector_d>(&ind(0), length_);
     } else {
       mem_d = shared;
     }

--- a/stan/math/rev/mat/fun/dot_product.hpp
+++ b/stan/math/rev/mat/fun/dot_product.hpp
@@ -3,6 +3,7 @@
 
 #include <stan/math/rev/meta.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <stan/math/prim/mat/fun/typedefs.hpp>
 #include <stan/math/prim/mat/err/check_vector.hpp>
 #include <stan/math/prim/arr/err/check_matching_sizes.hpp>
 #include <stan/math/prim/scal/fun/value_of.hpp>
@@ -36,56 +37,48 @@ class dot_product_vari : public vari {
   size_t length_;
 
   inline static double var_dot(vari** v1, vari** v2, size_t length) {
-    Eigen::VectorXd vd1(length), vd2(length);
-    for (size_t i = 0; i < length; i++) {
-      vd1[i] = v1[i]->val_;
-      vd2[i] = v2[i]->val_;
-    }
-    return vd1.dot(vd2);
+    Eigen::Map<vector_vi> vd1(v1, length);
+    Eigen::Map<vector_vi> vd2(v2, length);
+
+    return vd1.val().dot(vd2.val());
   }
 
   inline static double var_dot(const T1* v1, const T2* v2, size_t length) {
-    Eigen::VectorXd vd1(length), vd2(length);
-    for (size_t i = 0; i < length; i++) {
-      vd1[i] = value_of(v1[i]);
-      vd2[i] = value_of(v2[i]);
-    }
-    return vd1.dot(vd2);
+    Eigen::Map<const Eigen::Matrix<T1, -1, 1>> vd1(v1, length);
+    Eigen::Map<const Eigen::Matrix<T2, -1, 1>> vd2(v2, length);
+    return vd1.val().dot(vd2.val());
   }
 
   template <typename Derived1, typename Derived2>
   inline static double var_dot(const Eigen::DenseBase<Derived1>& v1,
                                const Eigen::DenseBase<Derived2>& v2) {
-    Eigen::VectorXd vd1(v1.size()), vd2(v1.size());
-    for (int i = 0; i < v1.size(); i++) {
-      vd1[i] = value_of(v1[i]);
-      vd2[i] = value_of(v2[i]);
-    }
+    vector_d vd1 = Eigen::Ref<const Eigen::Matrix<
+                                  typename Derived1::Scalar, -1, 1>>(v1).val();
+    vector_d vd2 = Eigen::Ref<const Eigen::Matrix<
+                                  typename Derived2::Scalar, -1, 1>>(v2).val();
     return vd1.dot(vd2);
   }
   inline void chain(vari** v1, vari** v2) {
-    for (size_t i = 0; i < length_; i++) {
-      v1[i]->adj_ += adj_ * v2_[i]->val_;
-      v2[i]->adj_ += adj_ * v1_[i]->val_;
-    }
+    Eigen::Map<vector_vi> vd1(v1, length_);
+    Eigen::Map<vector_vi> vd2(v2, length_);
+    vd1.adj() += adj_ * vd2.val();
+    vd2.adj() += adj_ * vd1.val();
   }
   inline void chain(double* v1, vari** v2) {
-    for (size_t i = 0; i < length_; i++) {
-      v2[i]->adj_ += adj_ * v1_[i];
-    }
+    Eigen::Map<vector_vi>(v2, length_).adj()
+      += adj_ * Eigen::Map<vector_d>(v1, length_);
   }
   inline void chain(vari** v1, double* v2) {
-    for (size_t i = 0; i < length_; i++) {
-      v1[i]->adj_ += adj_ * v2_[i];
-    }
+    Eigen::Map<vector_vi>(v1, length_).adj()
+      += adj_ * Eigen::Map<vector_d>(v2, length_);
   }
   inline void initialize(vari**& mem_v, const var* inv,
                          vari** shared = nullptr) {
     if (shared == nullptr) {
       mem_v = reinterpret_cast<vari**>(
           ChainableStack::instance_->memalloc_.alloc(length_ * sizeof(vari*)));
-      for (size_t i = 0; i < length_; i++)
-        mem_v[i] = inv[i].vi_;
+      Eigen::Map<vector_vi>(mem_v, length_)
+        = Eigen::Map<const vector_v>(inv, length_).vi();
     } else {
       mem_v = shared;
     }
@@ -96,8 +89,8 @@ class dot_product_vari : public vari {
     if (shared == nullptr) {
       mem_v = reinterpret_cast<vari**>(
           ChainableStack::instance_->memalloc_.alloc(length_ * sizeof(vari*)));
-      for (size_t i = 0; i < length_; i++)
-        mem_v[i] = inv(i).vi_;
+      Eigen::Map<vector_vi>(mem_v, length_)
+        = Eigen::Map<const vector_v>(&inv(0), length_).vi();
     } else {
       mem_v = shared;
     }
@@ -120,8 +113,8 @@ class dot_product_vari : public vari {
     if (shared == nullptr) {
       mem_d = reinterpret_cast<double*>(
           ChainableStack::instance_->memalloc_.alloc(length_ * sizeof(double)));
-      for (size_t i = 0; i < length_; i++)
-        mem_d[i] = ind(i);
+      Eigen::Map<vector_d>(mem_d, length_)
+        = Eigen::Map<const vector_d>(&ind(0), length_);
     } else {
       mem_d = shared;
     }

--- a/stan/math/rev/mat/fun/dot_product.hpp
+++ b/stan/math/rev/mat/fun/dot_product.hpp
@@ -92,7 +92,7 @@ class dot_product_vari : public vari {
       mem_v = reinterpret_cast<vari**>(
           ChainableStack::instance_->memalloc_.alloc(length_ * sizeof(vari*)));
       Eigen::Map<vector_vi>(mem_v, length_)
-          = Eigen::Map<const vector_v>(&inv(0), length_).vi();
+          = Eigen::Ref<const vector_v>(inv).vi();
     } else {
       mem_v = shared;
     }
@@ -116,7 +116,7 @@ class dot_product_vari : public vari {
       mem_d = reinterpret_cast<double*>(
           ChainableStack::instance_->memalloc_.alloc(length_ * sizeof(double)));
       Eigen::Map<vector_d>(mem_d, length_)
-          = Eigen::Map<const vector_d>(&ind(0), length_);
+          = Eigen::Ref<const vector_d>(ind);
     } else {
       mem_d = shared;
     }

--- a/stan/math/rev/mat/fun/dot_product.hpp
+++ b/stan/math/rev/mat/fun/dot_product.hpp
@@ -115,8 +115,7 @@ class dot_product_vari : public vari {
     if (shared == nullptr) {
       mem_d = reinterpret_cast<double*>(
           ChainableStack::instance_->memalloc_.alloc(length_ * sizeof(double)));
-      Eigen::Map<vector_d>(mem_d, length_)
-          = Eigen::Ref<const vector_d>(ind);
+      Eigen::Map<vector_d>(mem_d, length_) = Eigen::Ref<const vector_d>(ind);
     } else {
       mem_d = shared;
     }

--- a/stan/math/rev/mat/fun/dot_self.hpp
+++ b/stan/math/rev/mat/fun/dot_self.hpp
@@ -32,7 +32,7 @@ class dot_self_vari : public vari {
   explicit dot_self_vari(const Eigen::Matrix<var, R, C>& v)
       : vari(var_dot_self(v)), size_(v.size()) {
     v_ = reinterpret_cast<vari**>(
-          ChainableStack::instance_->memalloc_.alloc(size_ * sizeof(vari*)));
+        ChainableStack::instance_->memalloc_.alloc(size_ * sizeof(vari*)));
     Eigen::Map<matrix_vi>(v_, v.rows(), v.cols()) = v.vi();
   }
   inline static double square(double x) { return square(x); }

--- a/stan/math/rev/mat/fun/dot_self.hpp
+++ b/stan/math/rev/mat/fun/dot_self.hpp
@@ -4,6 +4,7 @@
 #include <stan/math/rev/meta.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/mat/err/check_vector.hpp>
+#include <stan/math/prim/scal/fun/square.hpp>
 #include <stan/math/rev/core.hpp>
 #include <vector>
 
@@ -24,41 +25,31 @@ class dot_self_vari : public vari {
       : vari(var_dot_self(v)), size_(v.size()) {
     v_ = reinterpret_cast<vari**>(
         ChainableStack::instance_->memalloc_.alloc(size_ * sizeof(vari*)));
-    for (size_t i = 0; i < size_; i++)
-      v_[i] = v[i].vi_;
+
+    Eigen::Map<vector_vi>(v_, size_) = Eigen::Ref<const vector_v>(v).vi();
   }
   template <int R, int C>
   explicit dot_self_vari(const Eigen::Matrix<var, R, C>& v)
       : vari(var_dot_self(v)), size_(v.size()) {
     v_ = reinterpret_cast<vari**>(
-        ChainableStack::instance_->memalloc_.alloc(size_ * sizeof(vari*)));
-    for (size_t i = 0; i < size_; ++i)
-      v_[i] = v(i).vi_;
+          ChainableStack::instance_->memalloc_.alloc(size_ * sizeof(vari*)));
+    Eigen::Map<matrix_vi>(v_, v.rows(), v.cols()) = v.vi();
   }
-  inline static double square(double x) { return x * x; }
+  inline static double square(double x) { return square(x); }
   inline static double var_dot_self(vari** v, size_t size) {
-    double sum = 0.0;
-    for (size_t i = 0; i < size; ++i)
-      sum += square(v[i]->val_);
-    return sum;
+    return Eigen::Map<vector_vi>(v, size).val().squaredNorm();
   }
   template <typename Derived>
   double var_dot_self(const Eigen::DenseBase<Derived>& v) {
-    double sum = 0.0;
-    for (int i = 0; i < v.size(); ++i)
-      sum += square(v(i).vi_->val_);
-    return sum;
+    return Eigen::Ref<const vector_v>(v).val().squaredNorm();
   }
   template <int R, int C>
   inline static double var_dot_self(const Eigen::Matrix<var, R, C>& v) {
-    double sum = 0.0;
-    for (int i = 0; i < v.size(); ++i)
-      sum += square(v(i).vi_->val_);
-    return sum;
+    return v.val().squaredNorm();
   }
   virtual void chain() {
-    for (size_t i = 0; i < size_; ++i)
-      v_[i]->adj_ += adj_ * 2.0 * v_[i]->val_;
+    Eigen::Map<vector_vi> v_map(v_, size_);
+    v_map.adj() += adj_ * 2.0 * v_map.val();
   }
 };
 }  // namespace internal

--- a/stan/math/rev/mat/fun/grad.hpp
+++ b/stan/math/rev/mat/fun/grad.hpp
@@ -25,9 +25,7 @@ namespace math {
 inline void grad(var& v, Eigen::Matrix<var, Eigen::Dynamic, 1>& x,
                  Eigen::VectorXd& g) {
   grad(v.vi_);
-  g.resize(x.size());
-  for (int i = 0; i < x.size(); ++i)
-    g(i) = x(i).vi_->adj_;
+  g = x.adj();
 }
 
 }  // namespace math

--- a/stan/math/rev/mat/fun/initialize_variable.hpp
+++ b/stan/math/rev/mat/fun/initialize_variable.hpp
@@ -24,7 +24,7 @@ inline void initialize_variable(var& variable, const var& value) {
 template <int R, int C>
 inline void initialize_variable(Eigen::Matrix<var, R, C>& matrix,
                                 const var& value) {
-    matrix.fill(value);
+  matrix.fill(value);
 }
 
 /**

--- a/stan/math/rev/mat/fun/initialize_variable.hpp
+++ b/stan/math/rev/mat/fun/initialize_variable.hpp
@@ -24,8 +24,7 @@ inline void initialize_variable(var& variable, const var& value) {
 template <int R, int C>
 inline void initialize_variable(Eigen::Matrix<var, R, C>& matrix,
                                 const var& value) {
-  for (int i = 0; i < matrix.size(); ++i)
-    matrix(i) = value;
+    matrix.fill(value);
 }
 
 /**

--- a/stan/math/rev/mat/fun/log_determinant.hpp
+++ b/stan/math/rev/mat/fun/log_determinant.hpp
@@ -3,6 +3,7 @@
 
 #include <stan/math/rev/meta.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <stan/math/prim/mat/fun/typedefs.hpp>
 #include <stan/math/prim/mat/err/check_square.hpp>
 #include <stan/math/rev/core.hpp>
 
@@ -15,27 +16,20 @@ inline var log_determinant(const Eigen::Matrix<var, R, C>& m) {
 
   math::check_square("log_determinant", "m", m);
 
-  Matrix<double, R, C> m_d(m.rows(), m.cols());
-  for (int i = 0; i < m.size(); ++i)
-    m_d(i) = m(i).val();
-
   Eigen::FullPivHouseholderQR<Matrix<double, R, C> > hh
-      = m_d.fullPivHouseholderQr();
-
-  double val = hh.logAbsDeterminant();
+      = m.val().fullPivHouseholderQr();
 
   vari** varis
       = ChainableStack::instance_->memalloc_.alloc_array<vari*>(m.size());
-  for (int i = 0; i < m.size(); ++i)
-    varis[i] = m(i).vi_;
+  Eigen::Map<matrix_vi>(varis, m.rows(), m.cols()) = m.vi();
 
-  Matrix<double, R, C> m_inv_transpose = hh.inverse().transpose();
   double* gradients
       = ChainableStack::instance_->memalloc_.alloc_array<double>(m.size());
-  for (int i = 0; i < m.size(); ++i)
-    gradients[i] = m_inv_transpose(i);
+  Eigen::Map<matrix_d>(gradients, m.rows(), m.cols())
+                                                = hh.inverse().transpose();
 
-  return var(new precomputed_gradients_vari(val, m.size(), varis, gradients));
+  return var(new precomputed_gradients_vari(hh.logAbsDeterminant(), m.size(),
+                                            varis, gradients));
 }
 
 }  // namespace math

--- a/stan/math/rev/mat/fun/log_determinant.hpp
+++ b/stan/math/rev/mat/fun/log_determinant.hpp
@@ -26,7 +26,7 @@ inline var log_determinant(const Eigen::Matrix<var, R, C>& m) {
   double* gradients
       = ChainableStack::instance_->memalloc_.alloc_array<double>(m.size());
   Eigen::Map<matrix_d>(gradients, m.rows(), m.cols())
-                                                = hh.inverse().transpose();
+      = hh.inverse().transpose();
 
   return var(new precomputed_gradients_vari(hh.logAbsDeterminant(), m.size(),
                                             varis, gradients));

--- a/stan/math/rev/mat/fun/log_determinant_ldlt.hpp
+++ b/stan/math/rev/mat/fun/log_determinant_ldlt.hpp
@@ -32,14 +32,8 @@ class log_det_ldlt_vari : public vari {
     // If we start computing Jacobians, this may be a bit inefficient
     invA.setIdentity(alloc_ldlt_->N_, alloc_ldlt_->N_);
     alloc_ldlt_->ldlt_.solveInPlace(invA);
-
-    for (size_t j = 0; j < alloc_ldlt_->N_; j++) {
-      for (size_t i = 0; i < alloc_ldlt_->N_; i++) {
-        alloc_ldlt_->variA_(i, j)->adj_ += adj_ * invA(i, j);
-      }
-    }
+    const_cast<matrix_vi&>(alloc_ldlt_->variA_).adj() += adj_ * invA;
   }
-
   const LDLT_alloc<R, C> *alloc_ldlt_;
 };
 }  // namespace internal

--- a/stan/math/rev/mat/fun/log_determinant_ldlt.hpp
+++ b/stan/math/rev/mat/fun/log_determinant_ldlt.hpp
@@ -32,7 +32,7 @@ class log_det_ldlt_vari : public vari {
     // If we start computing Jacobians, this may be a bit inefficient
     invA.setIdentity(alloc_ldlt_->N_, alloc_ldlt_->N_);
     alloc_ldlt_->ldlt_.solveInPlace(invA);
-    const_cast<matrix_vi&>(alloc_ldlt_->variA_).adj() += adj_ * invA;
+    const_cast<matrix_vi &>(alloc_ldlt_->variA_).adj() += adj_ * invA;
   }
   const LDLT_alloc<R, C> *alloc_ldlt_;
 };

--- a/stan/math/rev/mat/fun/log_determinant_spd.hpp
+++ b/stan/math/rev/mat/fun/log_determinant_spd.hpp
@@ -6,6 +6,7 @@
 #include <stan/math/prim/scal/err/check_finite.hpp>
 #include <stan/math/prim/mat/err/check_square.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <stan/math/prim/mat/fun/typedefs.hpp>
 #include <stan/math/rev/core.hpp>
 
 namespace stan {
@@ -13,15 +14,11 @@ namespace math {
 
 template <int R, int C>
 inline var log_determinant_spd(const Eigen::Matrix<var, R, C>& m) {
-  using Eigen::Matrix;
-
   check_square("log_determinant_spd", "m", m);
 
-  Matrix<double, R, C> m_d(m.rows(), m.cols());
-  for (int i = 0; i < m.size(); ++i)
-    m_d(i) = m(i).val();
+  matrix_d m_d = m.val();
 
-  Eigen::LDLT<Matrix<double, R, C> > ldlt(m_d);
+  Eigen::LDLT<matrix_d> ldlt(m_d);
   if (ldlt.info() != Eigen::Success) {
     double y = 0;
     domain_error("log_determinant_spd", "matrix argument", y,
@@ -45,13 +42,11 @@ inline var log_determinant_spd(const Eigen::Matrix<var, R, C>& m) {
 
   vari** operands
       = ChainableStack::instance_->memalloc_.alloc_array<vari*>(m.size());
-  for (int i = 0; i < m.size(); ++i)
-    operands[i] = m(i).vi_;
+  Eigen::Map<matrix_vi>(operands, m.rows(), m.cols()) = m.vi();
 
   double* gradients
       = ChainableStack::instance_->memalloc_.alloc_array<double>(m.size());
-  for (int i = 0; i < m.size(); ++i)
-    gradients[i] = m_d(i);
+  Eigen::Map<matrix_d>(gradients, m.rows(), m.cols()) = m_d;
 
   return var(
       new precomputed_gradients_vari(val, m.size(), operands, gradients));

--- a/stan/math/rev/mat/fun/log_softmax.hpp
+++ b/stan/math/rev/mat/fun/log_softmax.hpp
@@ -60,8 +60,8 @@ inline Eigen::Matrix<var, Eigen::Dynamic, 1> log_softmax(
   check_nonzero_size("log_softmax", "alpha", alpha);
 
   // TODO(carpenter): replace with array alloc
-  vari** alpha_vi_array = reinterpret_cast<vari**>(
-      vari::operator new(sizeof(vari*) * a_size));
+  vari** alpha_vi_array
+      = reinterpret_cast<vari**>(vari::operator new(sizeof(vari*) * a_size));
   Eigen::Map<vector_vi>(alpha_vi_array, a_size) = alpha.vi();
 
   vector_d alpha_d = alpha.val();
@@ -77,15 +77,15 @@ inline Eigen::Matrix<var, Eigen::Dynamic, 1> log_softmax(
 
   // end fold
   // TODO(carpenter): replace with array alloc
-  double* softmax_alpha_d_array = reinterpret_cast<double*>(
-      vari::operator new(sizeof(double) * a_size));
+  double* softmax_alpha_d_array
+      = reinterpret_cast<double*>(vari::operator new(sizeof(double) * a_size));
   Eigen::Map<vector_d>(softmax_alpha_d_array, a_size) = softmax_alpha_d;
 
   vector_v log_softmax_alpha(a_size);
   for (int k = 0; k < a_size; ++k)
     log_softmax_alpha(k) = var(new internal::log_softmax_elt_vari(
-        log_softmax_alpha_d[k], alpha_vi_array, softmax_alpha_d_array,
-        a_size, k));
+        log_softmax_alpha_d[k], alpha_vi_array, softmax_alpha_d_array, a_size,
+        k));
   return log_softmax_alpha;
 }
 

--- a/stan/math/rev/mat/fun/log_softmax.hpp
+++ b/stan/math/rev/mat/fun/log_softmax.hpp
@@ -1,11 +1,12 @@
 #ifndef STAN_MATH_REV_MAT_FUN_LOG_SOFTMAX_HPP
 #define STAN_MATH_REV_MAT_FUN_LOG_SOFTMAX_HPP
 
-#include <stan/math/rev/meta.hpp>
 #include <stan/math/prim/arr/err/check_nonzero_size.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/mat/fun/log_softmax.hpp>
 #include <stan/math/prim/mat/fun/softmax.hpp>
+#include <stan/math/rev/mat/fun/typedefs.hpp>
+#include <stan/math/prim/mat/fun/typedefs.hpp>
 #include <stan/math/rev/core.hpp>
 #include <cmath>
 #include <vector>
@@ -54,55 +55,37 @@ class log_softmax_elt_vari : public vari {
  */
 inline Eigen::Matrix<var, Eigen::Dynamic, 1> log_softmax(
     const Eigen::Matrix<var, Eigen::Dynamic, 1>& alpha) {
-  using Eigen::Dynamic;
-  using Eigen::Matrix;
+  const int a_size = alpha.size();
 
   check_nonzero_size("log_softmax", "alpha", alpha);
 
   // TODO(carpenter): replace with array alloc
   vari** alpha_vi_array = reinterpret_cast<vari**>(
-      vari::operator new(sizeof(vari*) * alpha.size()));
-  for (int i = 0; i < alpha.size(); ++i)
-    alpha_vi_array[i] = alpha(i).vi_;
+      vari::operator new(sizeof(vari*) * a_size));
+  Eigen::Map<vector_vi>(alpha_vi_array, a_size) = alpha.vi();
 
-  Matrix<double, Dynamic, 1> alpha_d(alpha.size());
-  for (int i = 0; i < alpha_d.size(); ++i)
-    alpha_d(i) = alpha(i).val();
+  vector_d alpha_d = alpha.val();
 
   // fold logic of math::softmax() and math::log_softmax()
   // to save computations
 
-  Matrix<double, Dynamic, 1> softmax_alpha_d(alpha_d.size());
-  Matrix<double, Dynamic, 1> log_softmax_alpha_d(alpha_d.size());
-
-  double max_v = alpha_d.maxCoeff();
-
-  double sum = 0.0;
-  for (int i = 0; i < alpha_d.size(); ++i) {
-    softmax_alpha_d(i) = std::exp(alpha_d(i) - max_v);
-    sum += softmax_alpha_d(i);
-  }
-
-  for (int i = 0; i < alpha_d.size(); ++i)
-    softmax_alpha_d(i) /= sum;
-  double log_sum = std::log(sum);
-
-  for (int i = 0; i < alpha_d.size(); ++i)
-    log_softmax_alpha_d(i) = (alpha_d(i) - max_v) - log_sum;
+  vector_d diff = (alpha_d.array() - alpha_d.maxCoeff());
+  vector_d softmax_alpha_d = diff.array().exp();
+  double sum = softmax_alpha_d.sum();
+  softmax_alpha_d.array() /= sum;
+  vector_d log_softmax_alpha_d = diff.array() - std::log(sum);
 
   // end fold
   // TODO(carpenter): replace with array alloc
   double* softmax_alpha_d_array = reinterpret_cast<double*>(
-      vari::operator new(sizeof(double) * alpha_d.size()));
+      vari::operator new(sizeof(double) * a_size));
+  Eigen::Map<vector_d>(softmax_alpha_d_array, a_size) = softmax_alpha_d;
 
-  for (int i = 0; i < alpha_d.size(); ++i)
-    softmax_alpha_d_array[i] = softmax_alpha_d(i);
-
-  Matrix<var, Dynamic, 1> log_softmax_alpha(alpha.size());
-  for (int k = 0; k < log_softmax_alpha.size(); ++k)
+  vector_v log_softmax_alpha(a_size);
+  for (int k = 0; k < a_size; ++k)
     log_softmax_alpha(k) = var(new internal::log_softmax_elt_vari(
         log_softmax_alpha_d[k], alpha_vi_array, softmax_alpha_d_array,
-        alpha.size(), k));
+        a_size, k));
   return log_softmax_alpha;
 }
 

--- a/stan/math/rev/mat/fun/mdivide_left.hpp
+++ b/stan/math/rev/mat/fun/mdivide_left.hpp
@@ -3,6 +3,7 @@
 
 #include <stan/math/rev/meta.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <stan/math/prim/mat/fun/typedefs.hpp>
 #include <stan/math/prim/mat/err/check_multiplicable.hpp>
 #include <stan/math/rev/core.hpp>
 #include <stan/math/rev/mat/fun/typedefs.hpp>
@@ -45,67 +46,28 @@ class mdivide_left_vv_vari : public vari {
             ChainableStack::instance_->memalloc_.alloc(sizeof(vari *) * B.rows()
                                                        * B.cols()))) {
     using Eigen::Map;
-    using Eigen::Matrix;
 
-    size_t pos = 0;
-    for (size_type j = 0; j < M_; j++) {
-      for (size_type i = 0; i < M_; i++) {
-        variRefA_[pos] = A(i, j).vi_;
-        A_[pos++] = A(i, j).val();
-      }
-    }
+    Map<matrix_d> Ad(A_, M_, M_);
+    Map<matrix_d> Cd(C_, M_, N_);
+    Ad = A.val();
+    Cd = Ad.colPivHouseholderQr().solve(B.val());
 
-    pos = 0;
-    for (size_type j = 0; j < N_; j++) {
-      for (size_type i = 0; i < M_; i++) {
-        variRefB_[pos] = B(i, j).vi_;
-        C_[pos++] = B(i, j).val();
-      }
-    }
-
-    Matrix<double, R1, C2> C(M_, N_);
-    C = Map<Matrix<double, R1, C2> >(C_, M_, N_);
-
-    C = Map<Matrix<double, R1, C1> >(A_, M_, M_).colPivHouseholderQr().solve(C);
-
-    pos = 0;
-    for (size_type j = 0; j < N_; j++) {
-      for (size_type i = 0; i < M_; i++) {
-        C_[pos] = C(i, j);
-        variRefC_[pos] = new vari(C_[pos], false);
-        pos++;
-      }
-    }
+    Map<matrix_vi>(variRefA_, M_, M_) = A.vi();
+    Map<matrix_vi>(variRefB_, M_, N_) = B.vi();
+    Map<matrix_vi>(variRefC_, M_, N_)
+                    = Cd.unaryExpr([](double x) { return new vari(x, false); });
   }
 
   virtual void chain() {
     using Eigen::Map;
-    using Eigen::Matrix;
-    Eigen::Matrix<double, R1, C1> adjA(M_, M_);
-    Eigen::Matrix<double, R2, C2> adjB(M_, N_);
-    Eigen::Matrix<double, R1, C2> adjC(M_, N_);
+    matrix_d adjB = Map<matrix_d>(A_, M_, M_)
+                               .transpose()
+                               .colPivHouseholderQr()
+                               .solve(Map<matrix_vi>(variRefC_, M_, N_).adj());
 
-    size_t pos = 0;
-    for (size_type j = 0; j < adjC.cols(); j++)
-      for (size_type i = 0; i < adjC.rows(); i++)
-        adjC(i, j) = variRefC_[pos++]->adj_;
-
-    adjB = Map<Matrix<double, R1, C1> >(A_, M_, M_)
-               .transpose()
-               .colPivHouseholderQr()
-               .solve(adjC);
-    adjA.noalias()
-        = -adjB * Map<Matrix<double, R1, C2> >(C_, M_, N_).transpose();
-
-    pos = 0;
-    for (size_type j = 0; j < adjA.cols(); j++)
-      for (size_type i = 0; i < adjA.rows(); i++)
-        variRefA_[pos++]->adj_ += adjA(i, j);
-
-    pos = 0;
-    for (size_type j = 0; j < adjB.cols(); j++)
-      for (size_type i = 0; i < adjB.rows(); i++)
-        variRefB_[pos++]->adj_ += adjB(i, j);
+    Map<matrix_vi>(variRefA_, M_, M_).adj()
+                              -= adjB * Map<matrix_d>(C_, M_, N_).transpose();
+    Map<matrix_vi>(variRefB_, M_, N_).adj() += adjB;
   }
 };
 
@@ -137,58 +99,24 @@ class mdivide_left_dv_vari : public vari {
             ChainableStack::instance_->memalloc_.alloc(sizeof(vari *) * B.rows()
                                                        * B.cols()))) {
     using Eigen::Map;
-    using Eigen::Matrix;
 
-    size_t pos = 0;
-    for (size_type j = 0; j < M_; j++) {
-      for (size_type i = 0; i < M_; i++) {
-        A_[pos++] = A(i, j);
-      }
-    }
-
-    pos = 0;
-    for (size_type j = 0; j < N_; j++) {
-      for (size_type i = 0; i < M_; i++) {
-        variRefB_[pos] = B(i, j).vi_;
-        C_[pos++] = B(i, j).val();
-      }
-    }
-
-    Matrix<double, R1, C2> C(M_, N_);
-    C = Map<Matrix<double, R1, C2> >(C_, M_, N_);
-
-    C = Map<Matrix<double, R1, C1> >(A_, M_, M_).colPivHouseholderQr().solve(C);
-
-    pos = 0;
-    for (size_type j = 0; j < N_; j++) {
-      for (size_type i = 0; i < M_; i++) {
-        C_[pos] = C(i, j);
-        variRefC_[pos] = new vari(C_[pos], false);
-        pos++;
-      }
-    }
+    Map<matrix_d> Ad(A_, M_, M_);
+    Map<matrix_d> Cd(C_, M_, N_);
+    Ad = A;
+    Cd = Ad.colPivHouseholderQr().solve(B.val());
+    Map<matrix_vi>(variRefB_, M_, N_) = B.vi();
+    Map<matrix_vi>(variRefC_, M_, N_)
+                    = Cd.unaryExpr([](double x) { return new vari(x, false); });
   }
 
   virtual void chain() {
     using Eigen::Map;
-    using Eigen::Matrix;
-    Eigen::Matrix<double, R2, C2> adjB(M_, N_);
-    Eigen::Matrix<double, R1, C2> adjC(M_, N_);
 
-    size_t pos = 0;
-    for (size_type j = 0; j < adjC.cols(); j++)
-      for (size_type i = 0; i < adjC.rows(); i++)
-        adjC(i, j) = variRefC_[pos++]->adj_;
-
-    adjB = Map<Matrix<double, R1, C1> >(A_, M_, M_)
-               .transpose()
-               .colPivHouseholderQr()
-               .solve(adjC);
-
-    pos = 0;
-    for (size_type j = 0; j < adjB.cols(); j++)
-      for (size_type i = 0; i < adjB.rows(); i++)
-        variRefB_[pos++]->adj_ += adjB(i, j);
+    Map<matrix_vi>(variRefB_, M_, N_).adj() +=
+                          Map<matrix_d>(A_, M_, M_)
+                               .transpose()
+                               .colPivHouseholderQr()
+                               .solve(Map<matrix_vi>(variRefC_, M_, N_).adj());
   }
 };
 
@@ -220,51 +148,28 @@ class mdivide_left_vd_vari : public vari {
             ChainableStack::instance_->memalloc_.alloc(sizeof(vari *) * B.rows()
                                                        * B.cols()))) {
     using Eigen::Map;
-    using Eigen::Matrix;
 
-    size_t pos = 0;
-    for (size_type j = 0; j < M_; j++) {
-      for (size_type i = 0; i < M_; i++) {
-        variRefA_[pos] = A(i, j).vi_;
-        A_[pos++] = A(i, j).val();
-      }
-    }
+    Map<matrix_vi>(variRefA_, M_, M_) = A.vi();
+    Map<matrix_d> Ad(A_, M_, M_);
+    Map<matrix_d> Cd(C_, M_, N_);
 
-    Matrix<double, R1, C2> C(M_, N_);
-    C = Map<Matrix<double, R1, C1> >(A_, M_, M_).colPivHouseholderQr().solve(B);
-
-    pos = 0;
-    for (size_type j = 0; j < N_; j++) {
-      for (size_type i = 0; i < M_; i++) {
-        C_[pos] = C(i, j);
-        variRefC_[pos] = new vari(C_[pos], false);
-        pos++;
-      }
-    }
+    Ad = A.val();
+    Cd = Ad.colPivHouseholderQr().solve(B);
+    Map<matrix_vi>(variRefC_, M_, N_)
+                    = Cd.unaryExpr([](double x) { return new vari(x, false); });
   }
 
   virtual void chain() {
     using Eigen::Map;
-    using Eigen::Matrix;
-    Eigen::Matrix<double, R1, C1> adjA(M_, M_);
-    Eigen::Matrix<double, R1, C2> adjC(M_, N_);
 
-    size_t pos = 0;
-    for (size_type j = 0; j < adjC.cols(); j++)
-      for (size_type i = 0; i < adjC.rows(); i++)
-        adjC(i, j) = variRefC_[pos++]->adj_;
+    matrix_d adjC = Map<matrix_vi>(variRefC_, M_, N_).adj();
 
-    // FIXME: add .noalias() to LHS
-    adjA = -Map<Matrix<double, R1, C1> >(A_, M_, M_)
-                .transpose()
-                .colPivHouseholderQr()
-                .solve(adjC
-                       * Map<Matrix<double, R1, C2> >(C_, M_, N_).transpose());
-
-    pos = 0;
-    for (size_type j = 0; j < adjA.cols(); j++)
-      for (size_type i = 0; i < adjA.rows(); i++)
-        variRefA_[pos++]->adj_ += adjA(i, j);
+    Map<matrix_vi>(variRefA_, M_, M_).adj()
+                          -= Map<matrix_d>(A_, M_, M_)
+                                .transpose()
+                                .colPivHouseholderQr()
+                                .solve(adjC
+                                       * Map<matrix_d>(C_, M_, N_).transpose());
   }
 };
 }  // namespace internal
@@ -284,10 +189,7 @@ inline Eigen::Matrix<var, R1, C2> mdivide_left(
   internal::mdivide_left_vv_vari<R1, C1, R2, C2> *baseVari
       = new internal::mdivide_left_vv_vari<R1, C1, R2, C2>(A, b);
 
-  size_t pos = 0;
-  for (size_type j = 0; j < res.cols(); j++)
-    for (size_type i = 0; i < res.rows(); i++)
-      res(i, j).vi_ = baseVari->variRefC_[pos++];
+  res.vi() = Eigen::Map<matrix_vi>(baseVari->variRefC_, res.rows(), res.cols());
 
   return res;
 }
@@ -308,10 +210,7 @@ inline Eigen::Matrix<var, R1, C2> mdivide_left(
   internal::mdivide_left_vd_vari<R1, C1, R2, C2> *baseVari
       = new internal::mdivide_left_vd_vari<R1, C1, R2, C2>(A, b);
 
-  size_t pos = 0;
-  for (size_type j = 0; j < res.cols(); j++)
-    for (size_type i = 0; i < res.rows(); i++)
-      res(i, j).vi_ = baseVari->variRefC_[pos++];
+  res.vi() = Eigen::Map<matrix_vi>(baseVari->variRefC_, res.rows(), res.cols());
 
   return res;
 }
@@ -332,10 +231,7 @@ inline Eigen::Matrix<var, R1, C2> mdivide_left(
   internal::mdivide_left_dv_vari<R1, C1, R2, C2> *baseVari
       = new internal::mdivide_left_dv_vari<R1, C1, R2, C2>(A, b);
 
-  size_t pos = 0;
-  for (size_type j = 0; j < res.cols(); j++)
-    for (size_type i = 0; i < res.rows(); i++)
-      res(i, j).vi_ = baseVari->variRefC_[pos++];
+  res.vi() = Eigen::Map<matrix_vi>(baseVari->variRefC_, res.rows(), res.cols());
 
   return res;
 }

--- a/stan/math/rev/mat/fun/mdivide_left.hpp
+++ b/stan/math/rev/mat/fun/mdivide_left.hpp
@@ -55,18 +55,18 @@ class mdivide_left_vv_vari : public vari {
     Map<matrix_vi>(variRefA_, M_, M_) = A.vi();
     Map<matrix_vi>(variRefB_, M_, N_) = B.vi();
     Map<matrix_vi>(variRefC_, M_, N_)
-                    = Cd.unaryExpr([](double x) { return new vari(x, false); });
+        = Cd.unaryExpr([](double x) { return new vari(x, false); });
   }
 
   virtual void chain() {
     using Eigen::Map;
     matrix_d adjB = Map<matrix_d>(A_, M_, M_)
-                               .transpose()
-                               .colPivHouseholderQr()
-                               .solve(Map<matrix_vi>(variRefC_, M_, N_).adj());
+                        .transpose()
+                        .colPivHouseholderQr()
+                        .solve(Map<matrix_vi>(variRefC_, M_, N_).adj());
 
     Map<matrix_vi>(variRefA_, M_, M_).adj()
-                              -= adjB * Map<matrix_d>(C_, M_, N_).transpose();
+        -= adjB * Map<matrix_d>(C_, M_, N_).transpose();
     Map<matrix_vi>(variRefB_, M_, N_).adj() += adjB;
   }
 };
@@ -106,17 +106,17 @@ class mdivide_left_dv_vari : public vari {
     Cd = Ad.colPivHouseholderQr().solve(B.val());
     Map<matrix_vi>(variRefB_, M_, N_) = B.vi();
     Map<matrix_vi>(variRefC_, M_, N_)
-                    = Cd.unaryExpr([](double x) { return new vari(x, false); });
+        = Cd.unaryExpr([](double x) { return new vari(x, false); });
   }
 
   virtual void chain() {
     using Eigen::Map;
 
-    Map<matrix_vi>(variRefB_, M_, N_).adj() +=
-                          Map<matrix_d>(A_, M_, M_)
-                               .transpose()
-                               .colPivHouseholderQr()
-                               .solve(Map<matrix_vi>(variRefC_, M_, N_).adj());
+    Map<matrix_vi>(variRefB_, M_, N_).adj()
+        += Map<matrix_d>(A_, M_, M_)
+               .transpose()
+               .colPivHouseholderQr()
+               .solve(Map<matrix_vi>(variRefC_, M_, N_).adj());
   }
 };
 
@@ -156,7 +156,7 @@ class mdivide_left_vd_vari : public vari {
     Ad = A.val();
     Cd = Ad.colPivHouseholderQr().solve(B);
     Map<matrix_vi>(variRefC_, M_, N_)
-                    = Cd.unaryExpr([](double x) { return new vari(x, false); });
+        = Cd.unaryExpr([](double x) { return new vari(x, false); });
   }
 
   virtual void chain() {
@@ -165,11 +165,10 @@ class mdivide_left_vd_vari : public vari {
     matrix_d adjC = Map<matrix_vi>(variRefC_, M_, N_).adj();
 
     Map<matrix_vi>(variRefA_, M_, M_).adj()
-                          -= Map<matrix_d>(A_, M_, M_)
-                                .transpose()
-                                .colPivHouseholderQr()
-                                .solve(adjC
-                                       * Map<matrix_d>(C_, M_, N_).transpose());
+        -= Map<matrix_d>(A_, M_, M_)
+               .transpose()
+               .colPivHouseholderQr()
+               .solve(adjC * Map<matrix_d>(C_, M_, N_).transpose());
   }
 };
 }  // namespace internal

--- a/stan/math/rev/mat/fun/mdivide_left_ldlt.hpp
+++ b/stan/math/rev/mat/fun/mdivide_left_ldlt.hpp
@@ -4,6 +4,7 @@
 #include <stan/math/rev/meta.hpp>
 #include <stan/math/rev/core.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <stan/math/prim/mat/fun/typedefs.hpp>
 #include <stan/math/rev/mat/fun/LDLT_alloc.hpp>
 #include <stan/math/rev/mat/fun/LDLT_factor.hpp>
 #include <stan/math/prim/mat/err/check_multiplicable.hpp>
@@ -58,47 +59,21 @@ class mdivide_left_ldlt_vv_vari : public vari {
                                                        * B.cols()))),
         alloc_(new mdivide_left_ldlt_alloc<R1, C1, R2, C2>()),
         alloc_ldlt_(A.alloc_) {
-    int pos = 0;
-    alloc_->C_.resize(M_, N_);
-    for (int j = 0; j < N_; j++) {
-      for (int i = 0; i < M_; i++) {
-        variRefB_[pos] = B(i, j).vi_;
-        alloc_->C_(i, j) = B(i, j).val();
-        pos++;
-      }
-    }
-
+    Eigen::Map<matrix_vi>(variRefB_, M_, N_) = B.vi();
+    alloc_->C_ = B.val();
     alloc_ldlt_->ldlt_.solveInPlace(alloc_->C_);
-
-    pos = 0;
-    for (int j = 0; j < N_; j++) {
-      for (int i = 0; i < M_; i++) {
-        variRefC_[pos] = new vari(alloc_->C_(i, j), false);
-        pos++;
-      }
-    }
+    Eigen::Map<matrix_vi>(variRefC_, M_, N_)
+            = alloc_->C_.unaryExpr([](double x) { return new vari(x, false); });
   }
 
   virtual void chain() {
-    Eigen::Matrix<double, R1, C1> adjA(M_, M_);
-    Eigen::Matrix<double, R2, C2> adjB(M_, N_);
-
-    int pos = 0;
-    for (int j = 0; j < N_; j++)
-      for (int i = 0; i < M_; i++)
-        adjB(i, j) = variRefC_[pos++]->adj_;
+    matrix_d adjB = Eigen::Map<matrix_vi>(variRefC_, M_, N_).adj();
 
     alloc_ldlt_->ldlt_.solveInPlace(adjB);
-    adjA.noalias() = -adjB * alloc_->C_.transpose();
 
-    for (int j = 0; j < M_; j++)
-      for (int i = 0; i < M_; i++)
-        alloc_ldlt_->variA_(i, j)->adj_ += adjA(i, j);
-
-    pos = 0;
-    for (int j = 0; j < N_; j++)
-      for (int i = 0; i < M_; i++)
-        variRefB_[pos++]->adj_ += adjB(i, j);
+    const_cast<matrix_vi&>(alloc_ldlt_->variA_).adj()
+                                              -= adjB * alloc_->C_.transpose();
+    Eigen::Map<matrix_vi>(variRefB_, M_, N_).adj() += adjB;
   }
 };
 
@@ -133,45 +108,18 @@ class mdivide_left_ldlt_dv_vari : public vari {
             ChainableStack::instance_->memalloc_.alloc(sizeof(vari *) * B.rows()
                                                        * B.cols()))),
         alloc_(new mdivide_left_ldlt_alloc<R1, C1, R2, C2>()) {
-    using Eigen::Map;
-    using Eigen::Matrix;
-
-    int pos = 0;
-    alloc_->C_.resize(M_, N_);
-    for (int j = 0; j < N_; j++) {
-      for (int i = 0; i < M_; i++) {
-        variRefB_[pos] = B(i, j).vi_;
-        alloc_->C_(i, j) = B(i, j).val();
-        pos++;
-      }
-    }
-
+    Eigen::Map<matrix_vi>(variRefB_, M_, N_) = B.vi();
+    alloc_->C_ = B.val();
     alloc_->ldltP_ = A.ldltP_;
     alloc_->ldltP_->solveInPlace(alloc_->C_);
-
-    pos = 0;
-    for (int j = 0; j < N_; j++) {
-      for (int i = 0; i < M_; i++) {
-        variRefC_[pos] = new vari(alloc_->C_(i, j), false);
-        pos++;
-      }
-    }
+    Eigen::Map<matrix_vi>(variRefC_, M_, N_)
+            = alloc_->C_.unaryExpr([](double x) { return new vari(x, false); });
   }
 
   virtual void chain() {
-    Eigen::Matrix<double, R2, C2> adjB(M_, N_);
-
-    int pos = 0;
-    for (int j = 0; j < adjB.cols(); j++)
-      for (int i = 0; i < adjB.rows(); i++)
-        adjB(i, j) = variRefC_[pos++]->adj_;
-
+    matrix_d adjB = Eigen::Map<matrix_vi>(variRefC_, M_, N_).adj();
     alloc_->ldltP_->solveInPlace(adjB);
-
-    pos = 0;
-    for (int j = 0; j < adjB.cols(); j++)
-      for (int i = 0; i < adjB.rows(); i++)
-        variRefB_[pos++]->adj_ += adjB(i, j);
+    Eigen::Map<matrix_vi>(variRefB_, M_, N_).adj() += adjB;
   }
 };
 
@@ -206,30 +154,15 @@ class mdivide_left_ldlt_vd_vari : public vari {
         alloc_ldlt_(A.alloc_) {
     alloc_->C_ = B;
     alloc_ldlt_->ldlt_.solveInPlace(alloc_->C_);
-
-    int pos = 0;
-    for (int j = 0; j < N_; j++) {
-      for (int i = 0; i < M_; i++) {
-        variRefC_[pos] = new vari(alloc_->C_(i, j), false);
-        pos++;
-      }
-    }
+    Eigen::Map<matrix_vi>(variRefC_, M_, N_)
+            = alloc_->C_.unaryExpr([](double x) { return new vari(x, false); });
   }
 
   virtual void chain() {
-    Eigen::Matrix<double, R1, C1> adjA(M_, M_);
-    Eigen::Matrix<double, R1, C2> adjC(M_, N_);
+    matrix_d adjC = Eigen::Map<matrix_vi>(variRefC_, M_, N_).adj();
 
-    int pos = 0;
-    for (int j = 0; j < adjC.cols(); j++)
-      for (int i = 0; i < adjC.rows(); i++)
-        adjC(i, j) = variRefC_[pos++]->adj_;
-
-    adjA = -alloc_ldlt_->ldlt_.solve(adjC * alloc_->C_.transpose());
-
-    for (int j = 0; j < adjA.cols(); j++)
-      for (int i = 0; i < adjA.rows(); i++)
-        alloc_ldlt_->variA_(i, j)->adj_ += adjA(i, j);
+    const_cast<matrix_vi&>(alloc_ldlt_->variA_).adj()
+        -= alloc_ldlt_->ldlt_.solve(adjC * alloc_->C_.transpose());
   }
 };
 }  // namespace internal
@@ -251,10 +184,7 @@ inline Eigen::Matrix<var, R1, C2> mdivide_left_ldlt(
   internal::mdivide_left_ldlt_vv_vari<R1, C1, R2, C2> *baseVari
       = new internal::mdivide_left_ldlt_vv_vari<R1, C1, R2, C2>(A, b);
 
-  int pos = 0;
-  for (int j = 0; j < res.cols(); j++)
-    for (int i = 0; i < res.rows(); i++)
-      res(i, j).vi_ = baseVari->variRefC_[pos++];
+  res.vi() = Eigen::Map<matrix_vi>(baseVari->variRefC_, res.rows(), res.cols());
 
   return res;
 }
@@ -276,10 +206,7 @@ inline Eigen::Matrix<var, R1, C2> mdivide_left_ldlt(
   internal::mdivide_left_ldlt_vd_vari<R1, C1, R2, C2> *baseVari
       = new internal::mdivide_left_ldlt_vd_vari<R1, C1, R2, C2>(A, b);
 
-  int pos = 0;
-  for (int j = 0; j < res.cols(); j++)
-    for (int i = 0; i < res.rows(); i++)
-      res(i, j).vi_ = baseVari->variRefC_[pos++];
+  res.vi() = Eigen::Map<matrix_vi>(baseVari->variRefC_, res.rows(), res.cols());
 
   return res;
 }
@@ -301,10 +228,7 @@ inline Eigen::Matrix<var, R1, C2> mdivide_left_ldlt(
   internal::mdivide_left_ldlt_dv_vari<R1, C1, R2, C2> *baseVari
       = new internal::mdivide_left_ldlt_dv_vari<R1, C1, R2, C2>(A, b);
 
-  int pos = 0;
-  for (int j = 0; j < res.cols(); j++)
-    for (int i = 0; i < res.rows(); i++)
-      res(i, j).vi_ = baseVari->variRefC_[pos++];
+  res.vi() = Eigen::Map<matrix_vi>(baseVari->variRefC_, res.rows(), res.cols());
 
   return res;
 }

--- a/stan/math/rev/mat/fun/mdivide_left_ldlt.hpp
+++ b/stan/math/rev/mat/fun/mdivide_left_ldlt.hpp
@@ -63,7 +63,7 @@ class mdivide_left_ldlt_vv_vari : public vari {
     alloc_->C_ = B.val();
     alloc_ldlt_->ldlt_.solveInPlace(alloc_->C_);
     Eigen::Map<matrix_vi>(variRefC_, M_, N_)
-            = alloc_->C_.unaryExpr([](double x) { return new vari(x, false); });
+        = alloc_->C_.unaryExpr([](double x) { return new vari(x, false); });
   }
 
   virtual void chain() {
@@ -71,8 +71,8 @@ class mdivide_left_ldlt_vv_vari : public vari {
 
     alloc_ldlt_->ldlt_.solveInPlace(adjB);
 
-    const_cast<matrix_vi&>(alloc_ldlt_->variA_).adj()
-                                              -= adjB * alloc_->C_.transpose();
+    const_cast<matrix_vi &>(alloc_ldlt_->variA_).adj()
+        -= adjB * alloc_->C_.transpose();
     Eigen::Map<matrix_vi>(variRefB_, M_, N_).adj() += adjB;
   }
 };
@@ -113,7 +113,7 @@ class mdivide_left_ldlt_dv_vari : public vari {
     alloc_->ldltP_ = A.ldltP_;
     alloc_->ldltP_->solveInPlace(alloc_->C_);
     Eigen::Map<matrix_vi>(variRefC_, M_, N_)
-            = alloc_->C_.unaryExpr([](double x) { return new vari(x, false); });
+        = alloc_->C_.unaryExpr([](double x) { return new vari(x, false); });
   }
 
   virtual void chain() {
@@ -155,13 +155,13 @@ class mdivide_left_ldlt_vd_vari : public vari {
     alloc_->C_ = B;
     alloc_ldlt_->ldlt_.solveInPlace(alloc_->C_);
     Eigen::Map<matrix_vi>(variRefC_, M_, N_)
-            = alloc_->C_.unaryExpr([](double x) { return new vari(x, false); });
+        = alloc_->C_.unaryExpr([](double x) { return new vari(x, false); });
   }
 
   virtual void chain() {
     matrix_d adjC = Eigen::Map<matrix_vi>(variRefC_, M_, N_).adj();
 
-    const_cast<matrix_vi&>(alloc_ldlt_->variA_).adj()
+    const_cast<matrix_vi &>(alloc_ldlt_->variA_).adj()
         -= alloc_ldlt_->ldlt_.solve(adjC * alloc_->C_.transpose());
   }
 };

--- a/stan/math/rev/mat/fun/mdivide_left_spd.hpp
+++ b/stan/math/rev/mat/fun/mdivide_left_spd.hpp
@@ -6,6 +6,7 @@
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/mat/err/check_multiplicable.hpp>
 #include <stan/math/rev/mat/fun/typedefs.hpp>
+#include <stan/math/prim/mat/fun/typedefs.hpp>
 #include <stan/math/prim/mat/err/check_square.hpp>
 #include <vector>
 
@@ -47,65 +48,22 @@ class mdivide_left_spd_vv_vari : public vari {
             ChainableStack::instance_->memalloc_.alloc(sizeof(vari *) * B.rows()
                                                        * B.cols()))),
         alloc_(new mdivide_left_spd_alloc<R1, C1, R2, C2>()) {
-    using Eigen::Map;
-    using Eigen::Matrix;
-
-    Matrix<double, R1, C1> Ad(A.rows(), A.cols());
-
-    size_t pos = 0;
-    for (size_type j = 0; j < M_; j++) {
-      for (size_type i = 0; i < M_; i++) {
-        variRefA_[pos] = A(i, j).vi_;
-        Ad(i, j) = A(i, j).val();
-        pos++;
-      }
-    }
-
-    pos = 0;
-    alloc_->C_.resize(M_, N_);
-    for (size_type j = 0; j < N_; j++) {
-      for (size_type i = 0; i < M_; i++) {
-        variRefB_[pos] = B(i, j).vi_;
-        alloc_->C_(i, j) = B(i, j).val();
-        pos++;
-      }
-    }
-
-    alloc_->llt_ = Ad.llt();
+    Eigen::Map<matrix_vi>(variRefA_, M_, M_) = A.vi();
+    Eigen::Map<matrix_vi>(variRefB_, M_, N_) = B.vi();
+    alloc_->C_ = B.val();
+    alloc_->llt_ = A.val().llt();
     alloc_->llt_.solveInPlace(alloc_->C_);
 
-    pos = 0;
-    for (size_type j = 0; j < N_; j++) {
-      for (size_type i = 0; i < M_; i++) {
-        variRefC_[pos] = new vari(alloc_->C_(i, j), false);
-        pos++;
-      }
-    }
+    Eigen::Map<matrix_vi>(variRefC_, M_, N_)
+            = alloc_->C_.unaryExpr([](double x) { return new vari(x, false); });
   }
 
   virtual void chain() {
-    using Eigen::Map;
-    using Eigen::Matrix;
-    Eigen::Matrix<double, R1, C1> adjA(M_, M_);
-    Eigen::Matrix<double, R2, C2> adjB(M_, N_);
-
-    size_t pos = 0;
-    for (size_type j = 0; j < N_; j++)
-      for (size_type i = 0; i < M_; i++)
-        adjB(i, j) = variRefC_[pos++]->adj_;
-
+    matrix_d adjB = Eigen::Map<matrix_vi>(variRefC_, M_, N_).adj();
     alloc_->llt_.solveInPlace(adjB);
-    adjA.noalias() = -adjB * alloc_->C_.transpose();
-
-    pos = 0;
-    for (size_type j = 0; j < M_; j++)
-      for (size_type i = 0; i < M_; i++)
-        variRefA_[pos++]->adj_ += adjA(i, j);
-
-    pos = 0;
-    for (size_type j = 0; j < N_; j++)
-      for (size_type i = 0; i < M_; i++)
-        variRefB_[pos++]->adj_ += adjB(i, j);
+    Eigen::Map<matrix_vi>(variRefA_, M_, M_).adj()
+                                               -= adjB * alloc_->C_.transpose();
+    Eigen::Map<matrix_vi>(variRefB_, M_, N_).adj() += adjB;
   }
 };
 
@@ -130,47 +88,19 @@ class mdivide_left_spd_dv_vari : public vari {
             ChainableStack::instance_->memalloc_.alloc(sizeof(vari *) * B.rows()
                                                        * B.cols()))),
         alloc_(new mdivide_left_spd_alloc<R1, C1, R2, C2>()) {
-    using Eigen::Map;
-    using Eigen::Matrix;
-
-    size_t pos = 0;
-    alloc_->C_.resize(M_, N_);
-    for (size_type j = 0; j < N_; j++) {
-      for (size_type i = 0; i < M_; i++) {
-        variRefB_[pos] = B(i, j).vi_;
-        alloc_->C_(i, j) = B(i, j).val();
-        pos++;
-      }
-    }
-
+    alloc_->C_ = B.val();
+    Eigen::Map<matrix_vi>(variRefB_, M_, N_) = B.vi();
     alloc_->llt_ = A.llt();
     alloc_->llt_.solveInPlace(alloc_->C_);
 
-    pos = 0;
-    for (size_type j = 0; j < N_; j++) {
-      for (size_type i = 0; i < M_; i++) {
-        variRefC_[pos] = new vari(alloc_->C_(i, j), false);
-        pos++;
-      }
-    }
+    Eigen::Map<matrix_vi>(variRefC_, M_, N_)
+            = alloc_->C_.unaryExpr([](double x) { return new vari(x, false); });
   }
 
   virtual void chain() {
-    using Eigen::Map;
-    using Eigen::Matrix;
-    Eigen::Matrix<double, R2, C2> adjB(M_, N_);
-
-    size_t pos = 0;
-    for (size_type j = 0; j < adjB.cols(); j++)
-      for (size_type i = 0; i < adjB.rows(); i++)
-        adjB(i, j) = variRefC_[pos++]->adj_;
-
+    matrix_d adjB = Eigen::Map<matrix_vi>(variRefC_, M_, N_).adj();
     alloc_->llt_.solveInPlace(adjB);
-
-    pos = 0;
-    for (size_type j = 0; j < adjB.cols(); j++)
-      for (size_type i = 0; i < adjB.rows(); i++)
-        variRefB_[pos++]->adj_ += adjB(i, j);
+    Eigen::Map<matrix_vi>(variRefB_, M_, N_).adj() += adjB;
   }
 };
 
@@ -195,49 +125,18 @@ class mdivide_left_spd_vd_vari : public vari {
             ChainableStack::instance_->memalloc_.alloc(sizeof(vari *) * B.rows()
                                                        * B.cols()))),
         alloc_(new mdivide_left_spd_alloc<R1, C1, R2, C2>()) {
-    using Eigen::Map;
-    using Eigen::Matrix;
-
-    Matrix<double, R1, C1> Ad(A.rows(), A.cols());
-
-    size_t pos = 0;
-    for (size_type j = 0; j < M_; j++) {
-      for (size_type i = 0; i < M_; i++) {
-        variRefA_[pos] = A(i, j).vi_;
-        Ad(i, j) = A(i, j).val();
-        pos++;
-      }
-    }
-
-    alloc_->llt_ = Ad.llt();
+    Eigen::Map<matrix_vi>(variRefA_, M_, M_) = A.vi();
+    alloc_->llt_ = A.val().llt();
     alloc_->C_ = alloc_->llt_.solve(B);
 
-    pos = 0;
-    for (size_type j = 0; j < N_; j++) {
-      for (size_type i = 0; i < M_; i++) {
-        variRefC_[pos] = new vari(alloc_->C_(i, j), false);
-        pos++;
-      }
-    }
+    Eigen::Map<matrix_vi>(variRefC_, M_, N_)
+            = alloc_->C_.unaryExpr([](double x) { return new vari(x, false); });
   }
 
   virtual void chain() {
-    using Eigen::Map;
-    using Eigen::Matrix;
-    Eigen::Matrix<double, R1, C1> adjA(M_, M_);
-    Eigen::Matrix<double, R1, C2> adjC(M_, N_);
-
-    size_t pos = 0;
-    for (size_type j = 0; j < adjC.cols(); j++)
-      for (size_type i = 0; i < adjC.rows(); i++)
-        adjC(i, j) = variRefC_[pos++]->adj_;
-
-    adjA = -alloc_->llt_.solve(adjC * alloc_->C_.transpose());
-
-    pos = 0;
-    for (size_type j = 0; j < adjA.cols(); j++)
-      for (size_type i = 0; i < adjA.rows(); i++)
-        variRefA_[pos++]->adj_ += adjA(i, j);
+    matrix_d adjC = Eigen::Map<matrix_vi>(variRefC_, M_, N_).adj();
+    Eigen::Map<matrix_vi>(variRefA_, M_, M_).adj()
+      -= alloc_->llt_.solve(adjC * alloc_->C_.transpose());
   }
 };
 }  // namespace internal
@@ -257,11 +156,8 @@ inline Eigen::Matrix<var, R1, C2> mdivide_left_spd(
   internal::mdivide_left_spd_vv_vari<R1, C1, R2, C2> *baseVari
       = new internal::mdivide_left_spd_vv_vari<R1, C1, R2, C2>(A, b);
 
-  size_t pos = 0;
-  for (size_type j = 0; j < res.cols(); j++)
-    for (size_type i = 0; i < res.rows(); i++)
-      res(i, j).vi_ = baseVari->variRefC_[pos++];
-
+  res.vi() = Eigen::Map<matrix_vi>(&baseVari->variRefC_[0],
+                                   b.rows(), b.cols());
   return res;
 }
 
@@ -281,11 +177,8 @@ inline Eigen::Matrix<var, R1, C2> mdivide_left_spd(
   internal::mdivide_left_spd_vd_vari<R1, C1, R2, C2> *baseVari
       = new internal::mdivide_left_spd_vd_vari<R1, C1, R2, C2>(A, b);
 
-  size_t pos = 0;
-  for (size_type j = 0; j < res.cols(); j++)
-    for (size_type i = 0; i < res.rows(); i++)
-      res(i, j).vi_ = baseVari->variRefC_[pos++];
-
+  res.vi() = Eigen::Map<matrix_vi>(&baseVari->variRefC_[0],
+                                   b.rows(), b.cols());
   return res;
 }
 
@@ -305,10 +198,8 @@ inline Eigen::Matrix<var, R1, C2> mdivide_left_spd(
   internal::mdivide_left_spd_dv_vari<R1, C1, R2, C2> *baseVari
       = new internal::mdivide_left_spd_dv_vari<R1, C1, R2, C2>(A, b);
 
-  size_t pos = 0;
-  for (size_type j = 0; j < res.cols(); j++)
-    for (size_type i = 0; i < res.rows(); i++)
-      res(i, j).vi_ = baseVari->variRefC_[pos++];
+  res.vi() = Eigen::Map<matrix_vi>(&baseVari->variRefC_[0],
+                                   b.rows(), b.cols());
 
   return res;
 }

--- a/stan/math/rev/mat/fun/mdivide_left_spd.hpp
+++ b/stan/math/rev/mat/fun/mdivide_left_spd.hpp
@@ -55,14 +55,14 @@ class mdivide_left_spd_vv_vari : public vari {
     alloc_->llt_.solveInPlace(alloc_->C_);
 
     Eigen::Map<matrix_vi>(variRefC_, M_, N_)
-            = alloc_->C_.unaryExpr([](double x) { return new vari(x, false); });
+        = alloc_->C_.unaryExpr([](double x) { return new vari(x, false); });
   }
 
   virtual void chain() {
     matrix_d adjB = Eigen::Map<matrix_vi>(variRefC_, M_, N_).adj();
     alloc_->llt_.solveInPlace(adjB);
     Eigen::Map<matrix_vi>(variRefA_, M_, M_).adj()
-                                               -= adjB * alloc_->C_.transpose();
+        -= adjB * alloc_->C_.transpose();
     Eigen::Map<matrix_vi>(variRefB_, M_, N_).adj() += adjB;
   }
 };
@@ -94,7 +94,7 @@ class mdivide_left_spd_dv_vari : public vari {
     alloc_->llt_.solveInPlace(alloc_->C_);
 
     Eigen::Map<matrix_vi>(variRefC_, M_, N_)
-            = alloc_->C_.unaryExpr([](double x) { return new vari(x, false); });
+        = alloc_->C_.unaryExpr([](double x) { return new vari(x, false); });
   }
 
   virtual void chain() {
@@ -130,13 +130,13 @@ class mdivide_left_spd_vd_vari : public vari {
     alloc_->C_ = alloc_->llt_.solve(B);
 
     Eigen::Map<matrix_vi>(variRefC_, M_, N_)
-            = alloc_->C_.unaryExpr([](double x) { return new vari(x, false); });
+        = alloc_->C_.unaryExpr([](double x) { return new vari(x, false); });
   }
 
   virtual void chain() {
     matrix_d adjC = Eigen::Map<matrix_vi>(variRefC_, M_, N_).adj();
     Eigen::Map<matrix_vi>(variRefA_, M_, M_).adj()
-      -= alloc_->llt_.solve(adjC * alloc_->C_.transpose());
+        -= alloc_->llt_.solve(adjC * alloc_->C_.transpose());
   }
 };
 }  // namespace internal
@@ -156,8 +156,7 @@ inline Eigen::Matrix<var, R1, C2> mdivide_left_spd(
   internal::mdivide_left_spd_vv_vari<R1, C1, R2, C2> *baseVari
       = new internal::mdivide_left_spd_vv_vari<R1, C1, R2, C2>(A, b);
 
-  res.vi() = Eigen::Map<matrix_vi>(&baseVari->variRefC_[0],
-                                   b.rows(), b.cols());
+  res.vi() = Eigen::Map<matrix_vi>(&baseVari->variRefC_[0], b.rows(), b.cols());
   return res;
 }
 
@@ -177,8 +176,7 @@ inline Eigen::Matrix<var, R1, C2> mdivide_left_spd(
   internal::mdivide_left_spd_vd_vari<R1, C1, R2, C2> *baseVari
       = new internal::mdivide_left_spd_vd_vari<R1, C1, R2, C2>(A, b);
 
-  res.vi() = Eigen::Map<matrix_vi>(&baseVari->variRefC_[0],
-                                   b.rows(), b.cols());
+  res.vi() = Eigen::Map<matrix_vi>(&baseVari->variRefC_[0], b.rows(), b.cols());
   return res;
 }
 
@@ -198,8 +196,7 @@ inline Eigen::Matrix<var, R1, C2> mdivide_left_spd(
   internal::mdivide_left_spd_dv_vari<R1, C1, R2, C2> *baseVari
       = new internal::mdivide_left_spd_dv_vari<R1, C1, R2, C2>(A, b);
 
-  res.vi() = Eigen::Map<matrix_vi>(&baseVari->variRefC_[0],
-                                   b.rows(), b.cols());
+  res.vi() = Eigen::Map<matrix_vi>(&baseVari->variRefC_[0], b.rows(), b.cols());
 
   return res;
 }

--- a/stan/math/rev/mat/fun/mdivide_left_tri.hpp
+++ b/stan/math/rev/mat/fun/mdivide_left_tri.hpp
@@ -64,16 +64,16 @@ class mdivide_left_tri_vv_vari : public vari {
     Map<matrix_vi>(variRefB_, M_, N_) = B.vi();
     c_map = a_map.template triangularView<TriView>().solve(c_map);
     Map<matrix_vi>(variRefC_, M_, N_)
-            = c_map.unaryExpr([](double x) { return new vari(x, false); });
+        = c_map.unaryExpr([](double x) { return new vari(x, false); });
   }
 
   virtual void chain() {
     using Eigen::Map;
 
     matrix_d adjB = Map<matrix_d>(A_, M_, M_)
-                       .template triangularView<TriView>()
-                       .transpose()
-                       .solve(Map<matrix_vi>(variRefC_, M_, N_).adj());
+                        .template triangularView<TriView>()
+                        .transpose()
+                        .solve(Map<matrix_vi>(variRefC_, M_, N_).adj());
     matrix_d adjA = -adjB * Map<matrix_d>(C_, M_, N_).transpose();
 
     size_t pos = 0;
@@ -124,20 +124,21 @@ class mdivide_left_tri_dv_vari : public vari {
     Map<matrix_d> c_map(C_, M_, N_);
 
     c_map = B.val();
-    c_map = Map<matrix_d>(A_, M_, M_).template triangularView<TriView>()
-                                     .solve(c_map);
+    c_map = Map<matrix_d>(A_, M_, M_)
+                .template triangularView<TriView>()
+                .solve(c_map);
     Map<matrix_vi>(variRefC_, M_, N_)
-            = c_map.unaryExpr([](double x) { return new vari(x, false); });
+        = c_map.unaryExpr([](double x) { return new vari(x, false); });
   }
 
   virtual void chain() {
     using Eigen::Map;
 
     Map<matrix_vi>(variRefB_, M_, N_).adj()
-              += Map<matrix_d>(A_, M_, M_)
-                     .template triangularView<TriView>()
-                     .transpose()
-                     .solve(Map<matrix_vi>(variRefC_, M_, N_).adj());
+        += Map<matrix_d>(A_, M_, M_)
+               .template triangularView<TriView>()
+               .transpose()
+               .solve(Map<matrix_vi>(variRefC_, M_, N_).adj());
   }
 };
 
@@ -188,7 +189,7 @@ class mdivide_left_tri_vd_vari : public vari {
 
     Cd = Ad.template triangularView<TriView>().solve(B);
     Map<matrix_vi>(variRefC_, M_, N_)
-                  = Cd.unaryExpr([](double x) { return new vari(x, false); });
+        = Cd.unaryExpr([](double x) { return new vari(x, false); });
   }
 
   virtual void chain() {
@@ -235,8 +236,8 @@ inline Eigen::Matrix<var, R1, C2> mdivide_left_tri(
   internal::mdivide_left_tri_vv_vari<TriView, R1, C1, R2, C2> *baseVari
       = new internal::mdivide_left_tri_vv_vari<TriView, R1, C1, R2, C2>(A, b);
 
-  res.vi() = Eigen::Map<matrix_vi>(&(baseVari->variRefC_[0]),
-                                   b.rows(), b.cols());
+  res.vi()
+      = Eigen::Map<matrix_vi>(&(baseVari->variRefC_[0]), b.rows(), b.cols());
 
   return res;
 }
@@ -256,8 +257,8 @@ inline Eigen::Matrix<var, R1, C2> mdivide_left_tri(
   internal::mdivide_left_tri_dv_vari<TriView, R1, C1, R2, C2> *baseVari
       = new internal::mdivide_left_tri_dv_vari<TriView, R1, C1, R2, C2>(A, b);
 
-  res.vi() = Eigen::Map<matrix_vi>(&(baseVari->variRefC_[0]),
-                                   b.rows(), b.cols());
+  res.vi()
+      = Eigen::Map<matrix_vi>(&(baseVari->variRefC_[0]), b.rows(), b.cols());
 
   return res;
 }
@@ -277,8 +278,8 @@ inline Eigen::Matrix<var, R1, C2> mdivide_left_tri(
   internal::mdivide_left_tri_vd_vari<TriView, R1, C1, R2, C2> *baseVari
       = new internal::mdivide_left_tri_vd_vari<TriView, R1, C1, R2, C2>(A, b);
 
-  res.vi() = Eigen::Map<matrix_vi>(&(baseVari->variRefC_[0]),
-                                   b.rows(), b.cols());
+  res.vi()
+      = Eigen::Map<matrix_vi>(&(baseVari->variRefC_[0]), b.rows(), b.cols());
 
   return res;
 }

--- a/stan/math/rev/mat/fun/mdivide_left_tri.hpp
+++ b/stan/math/rev/mat/fun/mdivide_left_tri.hpp
@@ -7,6 +7,7 @@
 #include <stan/math/prim/mat/err/check_square.hpp>
 #include <stan/math/rev/core.hpp>
 #include <stan/math/rev/mat/fun/typedefs.hpp>
+#include <stan/math/prim/mat/fun/typedefs.hpp>
 
 namespace stan {
 namespace math {
@@ -44,7 +45,6 @@ class mdivide_left_tri_vv_vari : public vari {
             ChainableStack::instance_->memalloc_.alloc(sizeof(vari *) * B.rows()
                                                        * B.cols()))) {
     using Eigen::Map;
-    using Eigen::Matrix;
 
     size_t pos = 0;
     if (TriView == Eigen::Lower) {
@@ -57,58 +57,26 @@ class mdivide_left_tri_vv_vari : public vari {
           variRefA_[pos++] = A(i, j).vi_;
     }
 
-    pos = 0;
-    for (size_type j = 0; j < M_; j++) {
-      for (size_type i = 0; i < M_; i++) {
-        A_[pos++] = A(i, j).val();
-      }
-    }
-
-    pos = 0;
-    for (size_type j = 0; j < N_; j++) {
-      for (size_type i = 0; i < M_; i++) {
-        variRefB_[pos] = B(i, j).vi_;
-        C_[pos++] = B(i, j).val();
-      }
-    }
-
-    Matrix<double, R1, C2> C(M_, N_);
-    C = Map<Matrix<double, R1, C2> >(C_, M_, N_);
-
-    C = Map<Matrix<double, R1, C1> >(A_, M_, M_)
-            .template triangularView<TriView>()
-            .solve(C);
-
-    pos = 0;
-    for (size_type j = 0; j < N_; j++) {
-      for (size_type i = 0; i < M_; i++) {
-        C_[pos] = C(i, j);
-        variRefC_[pos] = new vari(C_[pos], false);
-        pos++;
-      }
-    }
+    Map<matrix_d> a_map(A_, M_, M_);
+    Map<matrix_d> c_map(C_, M_, N_);
+    a_map = A.val();
+    c_map = B.val();
+    Map<matrix_vi>(variRefB_, M_, N_) = B.vi();
+    c_map = a_map.template triangularView<TriView>().solve(c_map);
+    Map<matrix_vi>(variRefC_, M_, N_)
+            = c_map.unaryExpr([](double x) { return new vari(x, false); });
   }
 
   virtual void chain() {
     using Eigen::Map;
-    using Eigen::Matrix;
-    Matrix<double, R1, C1> adjA(M_, M_);
-    Matrix<double, R2, C2> adjB(M_, N_);
-    Matrix<double, R1, C2> adjC(M_, N_);
+
+    matrix_d adjB = Map<matrix_d>(A_, M_, M_)
+                       .template triangularView<TriView>()
+                       .transpose()
+                       .solve(Map<matrix_vi>(variRefC_, M_, N_).adj());
+    matrix_d adjA = -adjB * Map<matrix_d>(C_, M_, N_).transpose();
 
     size_t pos = 0;
-    for (size_type j = 0; j < adjC.cols(); j++)
-      for (size_type i = 0; i < adjC.rows(); i++)
-        adjC(i, j) = variRefC_[pos++]->adj_;
-
-    adjB = Map<Matrix<double, R1, C1> >(A_, M_, M_)
-               .template triangularView<TriView>()
-               .transpose()
-               .solve(adjC);
-    adjA.noalias()
-        = -adjB * Map<Matrix<double, R1, C2> >(C_, M_, N_).transpose();
-
-    pos = 0;
     if (TriView == Eigen::Lower) {
       for (size_type j = 0; j < adjA.cols(); j++)
         for (size_type i = j; i < adjA.rows(); i++)
@@ -118,11 +86,7 @@ class mdivide_left_tri_vv_vari : public vari {
         for (size_type i = 0; i < j + 1; i++)
           variRefA_[pos++]->adj_ += adjA(i, j);
     }
-
-    pos = 0;
-    for (size_type j = 0; j < adjB.cols(); j++)
-      for (size_type i = 0; i < adjB.rows(); i++)
-        variRefB_[pos++]->adj_ += adjB(i, j);
+    Map<matrix_vi>(variRefB_, M_, N_).adj() += adjB;
   }
 };
 
@@ -154,60 +118,26 @@ class mdivide_left_tri_dv_vari : public vari {
             ChainableStack::instance_->memalloc_.alloc(sizeof(vari *) * B.rows()
                                                        * B.cols()))) {
     using Eigen::Map;
-    using Eigen::Matrix;
 
-    size_t pos = 0;
-    for (size_type j = 0; j < M_; j++) {
-      for (size_type i = 0; i < M_; i++) {
-        A_[pos++] = A(i, j);
-      }
-    }
+    Map<matrix_d>(A_, M_, M_) = A;
+    Map<matrix_vi>(variRefB_, M_, N_) = B.vi();
+    Map<matrix_d> c_map(C_, M_, N_);
 
-    pos = 0;
-    for (size_type j = 0; j < N_; j++) {
-      for (size_type i = 0; i < M_; i++) {
-        variRefB_[pos] = B(i, j).vi_;
-        C_[pos++] = B(i, j).val();
-      }
-    }
-
-    Matrix<double, R1, C2> C(M_, N_);
-    C = Map<Matrix<double, R1, C2> >(C_, M_, N_);
-
-    C = Map<Matrix<double, R1, C1> >(A_, M_, M_)
-            .template triangularView<TriView>()
-            .solve(C);
-
-    pos = 0;
-    for (size_type j = 0; j < N_; j++) {
-      for (size_type i = 0; i < M_; i++) {
-        C_[pos] = C(i, j);
-        variRefC_[pos] = new vari(C_[pos], false);
-        pos++;
-      }
-    }
+    c_map = B.val();
+    c_map = Map<matrix_d>(A_, M_, M_).template triangularView<TriView>()
+                                     .solve(c_map);
+    Map<matrix_vi>(variRefC_, M_, N_)
+            = c_map.unaryExpr([](double x) { return new vari(x, false); });
   }
 
   virtual void chain() {
     using Eigen::Map;
-    using Eigen::Matrix;
-    Matrix<double, R2, C2> adjB(M_, N_);
-    Matrix<double, R1, C2> adjC(M_, N_);
 
-    size_t pos = 0;
-    for (size_type j = 0; j < adjC.cols(); j++)
-      for (size_type i = 0; i < adjC.rows(); i++)
-        adjC(i, j) = variRefC_[pos++]->adj_;
-
-    adjB = Map<Matrix<double, R1, C1> >(A_, M_, M_)
-               .template triangularView<TriView>()
-               .transpose()
-               .solve(adjC);
-
-    pos = 0;
-    for (size_type j = 0; j < adjB.cols(); j++)
-      for (size_type i = 0; i < adjB.rows(); i++)
-        variRefB_[pos++]->adj_ += adjB(i, j);
+    Map<matrix_vi>(variRefB_, M_, N_).adj()
+              += Map<matrix_d>(A_, M_, M_)
+                     .template triangularView<TriView>()
+                     .transpose()
+                     .solve(Map<matrix_vi>(variRefC_, M_, N_).adj());
   }
 };
 
@@ -252,26 +182,13 @@ class mdivide_left_tri_vd_vari : public vari {
           variRefA_[pos++] = A(i, j).vi_;
     }
 
-    pos = 0;
-    for (size_type j = 0; j < M_; j++) {
-      for (size_type i = 0; i < M_; i++) {
-        A_[pos++] = A(i, j).val();
-      }
-    }
+    Map<matrix_d> Ad(A_, M_, M_);
+    Map<matrix_d> Cd(C_, M_, N_);
+    Ad = A.val();
 
-    Matrix<double, R1, C2> C(M_, N_);
-    C = Map<Matrix<double, R1, C1> >(A_, M_, M_)
-            .template triangularView<TriView>()
-            .solve(B);
-
-    pos = 0;
-    for (size_type j = 0; j < N_; j++) {
-      for (size_type i = 0; i < M_; i++) {
-        C_[pos] = C(i, j);
-        variRefC_[pos] = new vari(C_[pos], false);
-        pos++;
-      }
-    }
+    Cd = Ad.template triangularView<TriView>().solve(B);
+    Map<matrix_vi>(variRefC_, M_, N_)
+                  = Cd.unaryExpr([](double x) { return new vari(x, false); });
   }
 
   virtual void chain() {
@@ -280,10 +197,7 @@ class mdivide_left_tri_vd_vari : public vari {
     Matrix<double, R1, C1> adjA(M_, M_);
     Matrix<double, R1, C2> adjC(M_, N_);
 
-    size_t pos = 0;
-    for (size_type j = 0; j < adjC.cols(); j++)
-      for (size_type i = 0; i < adjC.rows(); i++)
-        adjC(i, j) = variRefC_[pos++]->adj_;
+    adjC = Map<matrix_vi>(variRefC_, M_, N_).adj();
 
     adjA.noalias()
         = -Map<Matrix<double, R1, C1> >(A_, M_, M_)
@@ -292,7 +206,7 @@ class mdivide_left_tri_vd_vari : public vari {
                .solve(adjC
                       * Map<Matrix<double, R1, C2> >(C_, M_, N_).transpose());
 
-    pos = 0;
+    size_t pos = 0;
     if (TriView == Eigen::Lower) {
       for (size_type j = 0; j < adjA.cols(); j++)
         for (size_type i = j; i < adjA.rows(); i++)
@@ -321,10 +235,8 @@ inline Eigen::Matrix<var, R1, C2> mdivide_left_tri(
   internal::mdivide_left_tri_vv_vari<TriView, R1, C1, R2, C2> *baseVari
       = new internal::mdivide_left_tri_vv_vari<TriView, R1, C1, R2, C2>(A, b);
 
-  size_t pos = 0;
-  for (size_type j = 0; j < res.cols(); j++)
-    for (size_type i = 0; i < res.rows(); i++)
-      res(i, j).vi_ = baseVari->variRefC_[pos++];
+  res.vi() = Eigen::Map<matrix_vi>(&(baseVari->variRefC_[0]),
+                                   b.rows(), b.cols());
 
   return res;
 }
@@ -344,10 +256,8 @@ inline Eigen::Matrix<var, R1, C2> mdivide_left_tri(
   internal::mdivide_left_tri_dv_vari<TriView, R1, C1, R2, C2> *baseVari
       = new internal::mdivide_left_tri_dv_vari<TriView, R1, C1, R2, C2>(A, b);
 
-  size_t pos = 0;
-  for (size_type j = 0; j < res.cols(); j++)
-    for (size_type i = 0; i < res.rows(); i++)
-      res(i, j).vi_ = baseVari->variRefC_[pos++];
+  res.vi() = Eigen::Map<matrix_vi>(&(baseVari->variRefC_[0]),
+                                   b.rows(), b.cols());
 
   return res;
 }
@@ -367,10 +277,8 @@ inline Eigen::Matrix<var, R1, C2> mdivide_left_tri(
   internal::mdivide_left_tri_vd_vari<TriView, R1, C1, R2, C2> *baseVari
       = new internal::mdivide_left_tri_vd_vari<TriView, R1, C1, R2, C2>(A, b);
 
-  size_t pos = 0;
-  for (size_type j = 0; j < res.cols(); j++)
-    for (size_type i = 0; i < res.rows(); i++)
-      res(i, j).vi_ = baseVari->variRefC_[pos++];
+  res.vi() = Eigen::Map<matrix_vi>(&(baseVari->variRefC_[0]),
+                                   b.rows(), b.cols());
 
   return res;
 }

--- a/stan/math/rev/mat/fun/multiply.hpp
+++ b/stan/math/rev/mat/fun/multiply.hpp
@@ -85,7 +85,7 @@ class multiply_mat_vari : public vari {
     Bd = B.val();
 
     Map<matrix_vi>(variRefAB_, A_rows_, B_cols_)
-            = (Ad * Bd).unaryExpr([](double x) { return new vari(x, false); });
+        = (Ad * Bd).unaryExpr([](double x) { return new vari(x, false); });
   }
 
   virtual void chain() {
@@ -94,9 +94,9 @@ class multiply_mat_vari : public vari {
 
     adjAB = Map<matrix_vi>(variRefAB_, A_rows_, B_cols_).adj();
     Map<matrix_vi>(variRefA_, A_rows_, A_cols_).adj()
-                  += adjAB * Map<matrix_d>(Bd_, A_cols_, B_cols_).transpose();
+        += adjAB * Map<matrix_d>(Bd_, A_cols_, B_cols_).transpose();
     Map<matrix_vi>(variRefB_, A_cols_, B_cols_).adj()
-                  += Map<matrix_d>(Ad_, A_rows_, A_cols_).transpose() * adjAB;
+        += Map<matrix_d>(Ad_, A_rows_, A_cols_).transpose() * adjAB;
   }
 };
 
@@ -238,7 +238,7 @@ class multiply_mat_vari<double, Ra, Ca, Tb, Cb> : public vari {
     Bd = B.val();
 
     Map<matrix_vi>(variRefAB_, A_rows_, B_cols_)
-            = (Ad * Bd).unaryExpr([](double x) { return new vari(x, false); });
+        = (Ad * Bd).unaryExpr([](double x) { return new vari(x, false); });
   }
 
   virtual void chain() {
@@ -246,8 +246,7 @@ class multiply_mat_vari<double, Ra, Ca, Tb, Cb> : public vari {
     matrix_d adjAB = Map<matrix_vi>(variRefAB_, A_rows_, B_cols_).adj();
 
     Map<matrix_vi>(variRefB_, A_cols_, B_cols_).adj()
-                  += Map<matrix_d>(Ad_, A_rows_, A_cols_).transpose()
-                          * adjAB;
+        += Map<matrix_d>(Ad_, A_rows_, A_cols_).transpose() * adjAB;
   }
 };
 
@@ -311,7 +310,7 @@ class multiply_mat_vari<double, 1, Ca, Tb, 1> : public vari {
   virtual void chain() {
     using Eigen::Map;
     Map<vector_vi>(variRefB_, size_).adj()
-                              += Map<vector_d>(Ad_, size_) * variRefAB_->adj_;
+        += Map<vector_d>(Ad_, size_) * variRefAB_->adj_;
   }
 };
 
@@ -382,7 +381,7 @@ class multiply_mat_vari<Ta, Ra, Ca, double, Cb> : public vari {
     Bd = B.val();
 
     Map<matrix_vi>(variRefAB_, A_rows_, B_cols_)
-            = (Ad * Bd).unaryExpr([](double x) { return new vari(x, false); });
+        = (Ad * Bd).unaryExpr([](double x) { return new vari(x, false); });
   }
 
   virtual void chain() {
@@ -390,8 +389,7 @@ class multiply_mat_vari<Ta, Ra, Ca, double, Cb> : public vari {
     matrix_d adjAB = Map<matrix_vi>(variRefAB_, A_rows_, B_cols_).adj();
 
     Map<matrix_vi>(variRefA_, A_rows_, A_cols_).adj()
-                      += adjAB
-                            * Map<matrix_d>(Bd_, A_cols_, B_cols_).transpose();
+        += adjAB * Map<matrix_d>(Bd_, A_cols_, B_cols_).transpose();
   }
 };
 
@@ -460,7 +458,7 @@ class multiply_mat_vari<Ta, 1, Ca, double, 1> : public vari {
     using Eigen::Map;
 
     Map<row_vector_vi>(variRefA_, size_).adj()
-                          += variRefAB_->adj_ * Map<row_vector_d>(Bd_, size_);
+        += variRefAB_->adj_ * Map<row_vector_d>(Bd_, size_);
   }
 };
 
@@ -543,8 +541,8 @@ multiply(const Eigen::Matrix<Ta, Ra, Ca>& A,
   multiply_mat_vari<Ta, Ra, Ca, Tb, Cb>* baseVari
       = new multiply_mat_vari<Ta, Ra, Ca, Tb, Cb>(A, B);
   Eigen::Matrix<var, Ra, Cb> AB_v(A.rows(), B.cols());
-  AB_v.vi() = Eigen::Map<matrix_vi>(&baseVari->variRefAB_[0],
-                                    A.rows(), B.cols());
+  AB_v.vi()
+      = Eigen::Map<matrix_vi>(&baseVari->variRefAB_[0], A.rows(), B.cols());
 
   return AB_v;
 }

--- a/stan/math/rev/mat/fun/quad_form.hpp
+++ b/stan/math/rev/mat/fun/quad_form.hpp
@@ -4,6 +4,7 @@
 #include <stan/math/rev/meta.hpp>
 #include <stan/math/rev/core.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <stan/math/prim/mat/fun/typedefs.hpp>
 #include <stan/math/prim/mat/fun/value_of.hpp>
 #include <stan/math/prim/mat/fun/quad_form.hpp>
 #include <stan/math/prim/mat/err/check_multiplicable.hpp>
@@ -20,7 +21,7 @@ class quad_form_vari_alloc : public chainable_alloc {
  private:
   inline void compute(const Eigen::Matrix<double, Ra, Ca>& A,
                       const Eigen::Matrix<double, Rb, Cb>& B) {
-    Eigen::Matrix<double, Cb, Cb> Cd(B.transpose() * A * B);
+    matrix_d Cd = B.transpose() * A * B;
     for (int j = 0; j < C_.cols(); j++) {
       for (int i = 0; i < C_.rows(); i++) {
         if (sym_) {
@@ -60,22 +61,13 @@ class quad_form_vari : public vari {
   inline void chainA(Eigen::Matrix<var, Ra, Ca>& A,
                      const Eigen::Matrix<double, Rb, Cb>& Bd,
                      const Eigen::Matrix<double, Cb, Cb>& adjC) {
-    Eigen::Matrix<double, Ra, Ca> adjA(Bd * adjC * Bd.transpose());
-    for (int j = 0; j < A.cols(); j++) {
-      for (int i = 0; i < A.rows(); i++) {
-        A(i, j).vi_->adj_ += adjA(i, j);
-      }
-    }
+    A.adj() += Bd * adjC * Bd.transpose();
   }
   inline void chainB(Eigen::Matrix<var, Rb, Cb>& B,
                      const Eigen::Matrix<double, Ra, Ca>& Ad,
                      const Eigen::Matrix<double, Rb, Cb>& Bd,
                      const Eigen::Matrix<double, Cb, Cb>& adjC) {
-    Eigen::Matrix<double, Ra, Ca> adjB(Ad * Bd * adjC.transpose()
-                                       + Ad.transpose() * Bd * adjC);
-    for (int j = 0; j < B.cols(); j++)
-      for (int i = 0; i < B.rows(); i++)
-        B(i, j).vi_->adj_ += adjB(i, j);
+    B.adj() += Ad * Bd * adjC.transpose() + Ad.transpose() * Bd * adjC;
   }
 
   inline void chainAB(Eigen::Matrix<Ta, Ra, Ca>& A,
@@ -95,11 +87,7 @@ class quad_form_vari : public vari {
   }
 
   virtual void chain() {
-    Eigen::Matrix<double, Cb, Cb> adjC(impl_->C_.rows(), impl_->C_.cols());
-
-    for (int j = 0; j < impl_->C_.cols(); j++)
-      for (int i = 0; i < impl_->C_.rows(); i++)
-        adjC(i, j) = impl_->C_(i, j).vi_->adj_;
+    matrix_d adjC = impl_->C_.adj();
 
     chainAB(impl_->A_, impl_->B_, value_of(impl_->A_), value_of(impl_->B_),
             adjC);

--- a/stan/math/rev/mat/fun/sd.hpp
+++ b/stan/math/rev/mat/fun/sd.hpp
@@ -4,6 +4,8 @@
 #include <stan/math/rev/meta.hpp>
 #include <stan/math/prim/arr/err/check_nonzero_size.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <stan/math/prim/mat/fun/typedefs.hpp>
+#include <stan/math/prim/scal/fun/inv_sqrt.hpp>
 #include <stan/math/rev/core.hpp>
 #include <cmath>
 #include <vector>
@@ -20,29 +22,24 @@ inline var calc_sd(size_t size, const var* dtrs) {
   using std::sqrt;
   vari** varis = reinterpret_cast<vari**>(
       ChainableStack::instance_->memalloc_.alloc(size * sizeof(vari*)));
-  for (size_t i = 0; i < size; ++i)
-    varis[i] = dtrs[i].vi_;
-  double sum = 0.0;
-  for (size_t i = 0; i < size; ++i)
-    sum += dtrs[i].vi_->val_;
-  double mean = sum / size;
-  double sum_of_squares = 0;
-  for (size_t i = 0; i < size; ++i) {
-    double diff = dtrs[i].vi_->val_ - mean;
-    sum_of_squares += diff * diff;
-  }
-  double variance = sum_of_squares / (size - 1);
-  double sd = sqrt(variance);
   double* partials = reinterpret_cast<double*>(
       ChainableStack::instance_->memalloc_.alloc(size * sizeof(double)));
+  Eigen::Map<vector_vi> varis_map(varis, size);
+  Eigen::Map<const vector_v> dtrs_map(dtrs, size);
+  Eigen::Map<vector_d> partials_map(partials, size);
+
+  double size_m1 = size - 1;
+  varis_map = dtrs_map.vi();
+  vector_d dtrs_val = dtrs_map.val();
+  double mean = dtrs_val.mean();
+  vector_d diff = dtrs_val.array() - mean;
+  double sum_of_squares = diff.squaredNorm();
+  double sd = sqrt(sum_of_squares / size_m1);
+
   if (sum_of_squares < 1e-20) {
-    double grad_limit = 1 / std::sqrt(static_cast<double>(size));
-    for (size_t i = 0; i < size; ++i)
-      partials[i] = grad_limit;
+    partials_map.fill(inv_sqrt(static_cast<double>(size)));
   } else {
-    double multiplier = 1 / (sd * (size - 1));
-    for (size_t i = 0; i < size; ++i)
-      partials[i] = multiplier * (dtrs[i].vi_->val_ - mean);
+    partials_map = diff.array() / (sd * size_m1);
   }
   return var(new stored_gradient_vari(sd, size, varis, partials));
 }

--- a/stan/math/rev/mat/fun/softmax.hpp
+++ b/stan/math/rev/mat/fun/softmax.hpp
@@ -3,6 +3,7 @@
 
 #include <stan/math/rev/meta.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <stan/math/prim/mat/fun/typedefs.hpp>
 #include <stan/math/prim/mat/fun/softmax.hpp>
 #include <stan/math/rev/mat/functor/adj_jac_apply.hpp>
 #include <vector>
@@ -50,13 +51,10 @@ class softmax_op {
   std::tuple<Eigen::VectorXd> multiply_adjoint_jacobian(
       const std::array<bool, size>& needs_adj,
       const Eigen::VectorXd& adj) const {
-    Eigen::VectorXd adj_times_jac(N_);
-    Eigen::Map<Eigen::Matrix<double, Eigen::Dynamic, 1> > y(y_, N_);
+    vector_d adj_times_jac(N_);
+    Eigen::Map<vector_d> y(y_, N_);
 
-    double adj_dot_y = adj.dot(y);
-    for (int n = 0; n < N_; ++n) {
-      adj_times_jac(n) = -y(n) * adj_dot_y + y(n) * adj(n);
-    }
+    adj_times_jac = -y * adj.dot(y) + y.cwiseProduct(adj);
 
     return std::make_tuple(adj_times_jac);
   }

--- a/stan/math/rev/mat/fun/squared_distance.hpp
+++ b/stan/math/rev/mat/fun/squared_distance.hpp
@@ -27,7 +27,8 @@ class squared_distance_vv_vari : public vari {
     typedef typename index_type<matrix_v>::type idx_t;
 
     return (Eigen::Ref<const vector_v>(v1).val()
-                - Eigen::Ref<const vector_v>(v2).val()).squaredNorm();
+            - Eigen::Ref<const vector_v>(v2).val())
+        .squaredNorm();
   }
 
  public:
@@ -63,7 +64,8 @@ class squared_distance_vd_vari : public vari {
     typedef typename index_type<matrix_d>::type idx_t;
 
     return (Eigen::Ref<const vector_v>(v1).val()
-                - Eigen::Ref<const vector_d>(v2)).squaredNorm();
+            - Eigen::Ref<const vector_d>(v2))
+        .squaredNorm();
   }
 
  public:
@@ -80,8 +82,8 @@ class squared_distance_vd_vari : public vari {
   }
   virtual void chain() {
     Eigen::Map<vector_vi> v1_map(v1_, length_);
-    v1_map.adj() += 2 * adj_ * (v1_map.val()
-                                        - Eigen::Map<vector_d>(v2_, length_));
+    v1_map.adj()
+        += 2 * adj_ * (v1_map.val() - Eigen::Map<vector_d>(v2_, length_));
   }
 };
 }  // namespace internal

--- a/stan/math/rev/mat/fun/squared_distance.hpp
+++ b/stan/math/rev/mat/fun/squared_distance.hpp
@@ -6,6 +6,7 @@
 #include <stan/math/prim/mat/err/check_vector.hpp>
 #include <stan/math/prim/arr/err/check_matching_sizes.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <stan/math/prim/mat/fun/typedefs.hpp>
 #include <vector>
 
 namespace stan {
@@ -23,14 +24,10 @@ class squared_distance_vv_vari : public vari {
   inline static double var_squared_distance(
       const Eigen::Matrix<var, R1, C1>& v1,
       const Eigen::Matrix<var, R2, C2>& v2) {
-    using Eigen::Matrix;
-    typedef typename index_type<Matrix<var, R1, R2> >::type idx_t;
-    double result = 0;
-    for (idx_t i = 0; i < v1.size(); i++) {
-      double diff = v1(i).vi_->val_ - v2(i).vi_->val_;
-      result += diff * diff;
-    }
-    return result;
+    typedef typename index_type<matrix_v>::type idx_t;
+
+    return (Eigen::Ref<const vector_v>(v1).val()
+                - Eigen::Ref<const vector_v>(v2).val()).squaredNorm();
   }
 
  public:
@@ -40,20 +37,17 @@ class squared_distance_vv_vari : public vari {
       : vari(var_squared_distance(v1, v2)), length_(v1.size()) {
     v1_ = reinterpret_cast<vari**>(
         ChainableStack::instance_->memalloc_.alloc(length_ * sizeof(vari*)));
-    for (size_t i = 0; i < length_; i++)
-      v1_[i] = v1(i).vi_;
-
     v2_ = reinterpret_cast<vari**>(
         ChainableStack::instance_->memalloc_.alloc(length_ * sizeof(vari*)));
-    for (size_t i = 0; i < length_; i++)
-      v2_[i] = v2(i).vi_;
+    Eigen::Map<vector_vi>(v1_, length_) = v1.vi();
+    Eigen::Map<vector_vi>(v2_, length_) = v2.vi();
   }
   virtual void chain() {
-    for (size_t i = 0; i < length_; i++) {
-      double di = 2 * adj_ * (v1_[i]->val_ - v2_[i]->val_);
-      v1_[i]->adj_ += di;
-      v2_[i]->adj_ -= di;
-    }
+    Eigen::Map<vector_vi> v1_map(v1_, length_);
+    Eigen::Map<vector_vi> v2_map(v2_, length_);
+    vector_d di = 2 * adj_ * (v1_map.val() - v2_map.val());
+    v1_map.adj() += di;
+    v2_map.adj() -= di;
   }
 };
 class squared_distance_vd_vari : public vari {
@@ -66,15 +60,10 @@ class squared_distance_vd_vari : public vari {
   inline static double var_squared_distance(
       const Eigen::Matrix<var, R1, C1>& v1,
       const Eigen::Matrix<double, R2, C2>& v2) {
-    using Eigen::Matrix;
-    typedef typename index_type<Matrix<double, R1, C1> >::type idx_t;
+    typedef typename index_type<matrix_d>::type idx_t;
 
-    double result = 0;
-    for (idx_t i = 0; i < v1.size(); i++) {
-      double diff = v1(i).vi_->val_ - v2(i);
-      result += diff * diff;
-    }
-    return result;
+    return (Eigen::Ref<const vector_v>(v1).val()
+                - Eigen::Ref<const vector_d>(v2)).squaredNorm();
   }
 
  public:
@@ -84,18 +73,15 @@ class squared_distance_vd_vari : public vari {
       : vari(var_squared_distance(v1, v2)), length_(v1.size()) {
     v1_ = reinterpret_cast<vari**>(
         ChainableStack::instance_->memalloc_.alloc(length_ * sizeof(vari*)));
-    for (size_t i = 0; i < length_; i++)
-      v1_[i] = v1(i).vi_;
-
     v2_ = reinterpret_cast<double*>(
         ChainableStack::instance_->memalloc_.alloc(length_ * sizeof(double)));
-    for (size_t i = 0; i < length_; i++)
-      v2_[i] = v2(i);
+    Eigen::Map<vector_vi>(v1_, length_) = v1.vi();
+    Eigen::Map<vector_d>(v2_, length_) = v2;
   }
   virtual void chain() {
-    for (size_t i = 0; i < length_; i++) {
-      v1_[i]->adj_ += 2 * adj_ * (v1_[i]->val_ - v2_[i]);
-    }
+    Eigen::Map<vector_vi> v1_map(v1_, length_);
+    v1_map.adj() += 2 * adj_ * (v1_map.val()
+                                        - Eigen::Map<vector_d>(v2_, length_));
   }
 };
 }  // namespace internal

--- a/stan/math/rev/mat/fun/sum.hpp
+++ b/stan/math/rev/mat/fun/sum.hpp
@@ -18,10 +18,7 @@ class sum_eigen_v_vari : public sum_v_vari {
  protected:
   template <typename Derived>
   inline static double sum_of_val(const Eigen::DenseBase<Derived>& v) {
-    double result = 0;
-    for (int i = 0; i < v.size(); i++)
-      result += v(i).vi_->val_;
-    return result;
+    return Eigen::Ref<const matrix_v>(v).val().sum();
   }
 
  public:
@@ -32,8 +29,7 @@ class sum_eigen_v_vari : public sum_v_vari {
             reinterpret_cast<vari**>(ChainableStack::instance_->memalloc_.alloc(
                 v1.size() * sizeof(vari*))),
             v1.size()) {
-    for (size_t i = 0; i < length_; i++)
-      v_[i] = v1(i).vi_;
+    Eigen::Map<matrix_vi>(v_, v1.rows(), v1.cols()) = v1.vi();
   }
 };
 

--- a/stan/math/rev/mat/fun/to_var.hpp
+++ b/stan/math/rev/mat/fun/to_var.hpp
@@ -20,10 +20,7 @@ namespace math {
  * @return A Matrix with automatic differentiation variables
  */
 inline matrix_v to_var(const matrix_d& m) {
-  matrix_v m_v(m.rows(), m.cols());
-  for (int j = 0; j < m.cols(); ++j)
-    for (int i = 0; i < m.rows(); ++i)
-      m_v(i, j) = m(i, j);
+  matrix_v m_v = m;
   return m_v;
 }
 /**
@@ -45,9 +42,7 @@ inline matrix_v to_var(const matrix_v& m) { return m; }
  *   values of v
  */
 inline vector_v to_var(const vector_d& v) {
-  vector_v v_v(v.size());
-  for (int i = 0; i < v.size(); ++i)
-    v_v[i] = v[i];
+  vector_v v_v = v;
   return v_v;
 }
 /**
@@ -70,9 +65,7 @@ inline vector_v to_var(const vector_v& v) { return v; }
  *   values of rv.
  */
 inline row_vector_v to_var(const row_vector_d& rv) {
-  row_vector_v rv_v(rv.size());
-  for (int i = 0; i < rv.size(); ++i)
-    rv_v[i] = rv[i];
+  row_vector_v rv_v = rv;
   return rv_v;
 }
 /**

--- a/stan/math/rev/mat/fun/trace_gen_quad_form.hpp
+++ b/stan/math/rev/mat/fun/trace_gen_quad_form.hpp
@@ -51,24 +51,12 @@ class trace_gen_quad_form_vari : public vari {
     if (varB || varD)
       AtB.noalias() = A.transpose() * B;
 
-    if (varB) {
-      Eigen::Matrix<double, Rb, Cb> adjB(adj * (A * BD + AtB * D.transpose()));
-      for (int j = 0; j < B.cols(); j++)
-        for (int i = 0; i < B.rows(); i++)
-          (*varB)(i, j).vi_->adj_ += adjB(i, j);
-    }
-    if (varA) {
-      Eigen::Matrix<double, Ra, Ca> adjA(adj * (B * BD.transpose()));
-      for (int j = 0; j < A.cols(); j++)
-        for (int i = 0; i < A.rows(); i++)
-          (*varA)(i, j).vi_->adj_ += adjA(i, j);
-    }
-    if (varD) {
-      Eigen::Matrix<double, Rd, Cd> adjD(adj * (B.transpose() * AtB));
-      for (int j = 0; j < D.cols(); j++)
-        for (int i = 0; i < D.rows(); i++)
-          (*varD)(i, j).vi_->adj_ += adjD(i, j);
-    }
+    if (varB)
+      (*varB).adj() += adj * (A * BD + AtB * D.transpose());
+    if (varA)
+      (*varA).adj() += adj * (B * BD.transpose());
+    if (varD)
+      (*varD).adj() += adj * (B.transpose() * AtB);
   }
 
  public:

--- a/stan/math/rev/mat/fun/trace_inv_quad_form_ldlt.hpp
+++ b/stan/math/rev/mat/fun/trace_inv_quad_form_ldlt.hpp
@@ -3,6 +3,7 @@
 
 #include <stan/math/rev/meta.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <stan/math/prim/mat/fun/typedefs.hpp>
 #include <stan/math/rev/core.hpp>
 #include <stan/math/rev/mat/fun/LDLT_alloc.hpp>
 #include <stan/math/rev/mat/fun/LDLT_factor.hpp>
@@ -17,14 +18,8 @@ template <typename T2, int R2, int C2, typename T3, int R3, int C3>
 class trace_inv_quad_form_ldlt_impl : public chainable_alloc {
  protected:
   inline void initializeB(const Eigen::Matrix<var, R3, C3> &B, bool haveD) {
-    Eigen::Matrix<double, R3, C3> Bd(B.rows(), B.cols());
-    variB_.resize(B.rows(), B.cols());
-    for (int j = 0; j < B.cols(); j++) {
-      for (int i = 0; i < B.rows(); i++) {
-        variB_(i, j) = B(i, j).vi_;
-        Bd(i, j) = B(i, j).val();
-      }
-    }
+    matrix_d Bd = B.val();
+    variB_ = B.vi();
     AinvB_ = ldlt_.solve(Bd);
     if (haveD)
       C_.noalias() = Bd.transpose() * AinvB_;
@@ -41,14 +36,8 @@ class trace_inv_quad_form_ldlt_impl : public chainable_alloc {
 
   template <int R1, int C1>
   inline void initializeD(const Eigen::Matrix<var, R1, C1> &D) {
-    D_.resize(D.rows(), D.cols());
-    variD_.resize(D.rows(), D.cols());
-    for (int j = 0; j < D.cols(); j++) {
-      for (int i = 0; i < D.rows(); i++) {
-        variD_(i, j) = D(i, j).vi_;
-        D_(i, j) = D(i, j).val();
-      }
-    }
+    D_ = D.val();
+    variD_ = D.vi();
   }
   template <int R1, int C1>
   inline void initializeD(const Eigen::Matrix<double, R1, C1> &D) {
@@ -75,11 +64,11 @@ class trace_inv_quad_form_ldlt_impl : public chainable_alloc {
 
   const int Dtype_;  // 0 = double, 1 = var, 2 = missing
   LDLT_factor<T2, R2, C2> ldlt_;
-  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> D_;
-  Eigen::Matrix<vari *, Eigen::Dynamic, Eigen::Dynamic> variD_;
-  Eigen::Matrix<vari *, R3, C3> variB_;
-  Eigen::Matrix<double, R3, C3> AinvB_;
-  Eigen::Matrix<double, C3, C3> C_;
+  matrix_d D_;
+  matrix_vi variD_;
+  matrix_vi variB_;
+  matrix_d AinvB_;
+  matrix_d C_;
   double value_;
 };
 
@@ -105,23 +94,19 @@ class trace_inv_quad_form_ldlt_vari : public vari {
     else
       aA.noalias() = -adj * (impl->AinvB_ * impl->AinvB_.transpose());
 
-    for (int j = 0; j < aA.cols(); j++)
-      for (int i = 0; i < aA.rows(); i++)
-        impl->ldlt_.alloc_->variA_(i, j)->adj_ += aA(i, j);
+    impl->ldlt_.alloc_->variA_.adj() += aA;
   }
   static inline void chainB(
       double adj,
       trace_inv_quad_form_ldlt_impl<T2, R2, C2, var, R3, C3> *impl) {
-    Eigen::Matrix<double, R3, C3> aB;
+    matrix_d aB;
 
     if (impl->Dtype_ != 2)
       aB.noalias() = adj * impl->AinvB_ * (impl->D_ + impl->D_.transpose());
     else
       aB.noalias() = 2 * adj * impl->AinvB_;
 
-    for (int j = 0; j < aB.cols(); j++)
-      for (int i = 0; i < aB.rows(); i++)
-        impl->variB_(i, j)->adj_ += aB(i, j);
+    impl->variB_.adj() += aB;
   }
 
  public:
@@ -138,11 +123,8 @@ class trace_inv_quad_form_ldlt_vari : public vari {
 
     chainB(adj_, impl_);
 
-    if (impl_->Dtype_ == 1) {
-      for (int j = 0; j < impl_->variD_.cols(); j++)
-        for (int i = 0; i < impl_->variD_.rows(); i++)
-          impl_->variD_(i, j)->adj_ += adj_ * impl_->C_(i, j);
-    }
+    if (impl_->Dtype_ == 1)
+      impl_->variD_.adj() += adj_ * impl_->C_;
   }
 
   trace_inv_quad_form_ldlt_impl<T2, R2, C2, T3, R3, C3> *impl_;

--- a/stan/math/rev/mat/fun/trace_quad_form.hpp
+++ b/stan/math/rev/mat/fun/trace_quad_form.hpp
@@ -42,19 +42,13 @@ class trace_quad_form_vari : public vari {
   static inline void chainA(Eigen::Matrix<var, Ra, Ca>& A,
                             const Eigen::Matrix<double, Rb, Cb>& Bd,
                             double adjC) {
-    Eigen::Matrix<double, Ra, Ca> adjA(adjC * Bd * Bd.transpose());
-    for (int j = 0; j < A.cols(); j++)
-      for (int i = 0; i < A.rows(); i++)
-        A(i, j).vi_->adj_ += adjA(i, j);
+    A.adj() += adjC * Bd * Bd.transpose();
   }
   static inline void chainB(Eigen::Matrix<var, Rb, Cb>& B,
                             const Eigen::Matrix<double, Ra, Ca>& Ad,
                             const Eigen::Matrix<double, Rb, Cb>& Bd,
                             double adjC) {
-    Eigen::Matrix<double, Ra, Ca> adjB(adjC * (Ad + Ad.transpose()) * Bd);
-    for (int j = 0; j < B.cols(); j++)
-      for (int i = 0; i < B.rows(); i++)
-        B(i, j).vi_->adj_ += adjB(i, j);
+    B.adj() += adjC * (Ad + Ad.transpose()) * Bd;
   }
 
   inline void chainAB(Eigen::Matrix<Ta, Ra, Ca>& A,

--- a/stan/math/rev/mat/fun/unit_vector_constrain.hpp
+++ b/stan/math/rev/mat/fun/unit_vector_constrain.hpp
@@ -4,6 +4,7 @@
 #include <stan/math/rev/meta.hpp>
 #include <stan/math/prim/arr/err/check_nonzero_size.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <stan/math/prim/mat/fun/typedefs.hpp>
 #include <stan/math/prim/mat/fun/dot_self.hpp>
 #include <stan/math/prim/mat/err/check_vector.hpp>
 #include <stan/math/prim/scal/err/check_positive_finite.hpp>
@@ -33,7 +34,7 @@ class unit_vector_elt_vari : public vari {
         idx_(idx),
         norm_(norm) {}
   void chain() {
-    const double cubed_norm = norm_ * norm_ * norm_;
+    const double cubed_norm = std::pow(norm_, 3);
     for (int m = 0; m < size_; ++m) {
       y_[m]->adj_
           -= adj_ * unit_vector_y_[m] * unit_vector_y_[idx_] / cubed_norm;
@@ -57,29 +58,24 @@ Eigen::Matrix<var, R, C> unit_vector_constrain(
     const Eigen::Matrix<var, R, C>& y) {
   check_vector("unit_vector", "y", y);
   check_nonzero_size("unit_vector", "y", y);
+  vector_d y_d = y.val();
 
   vari** y_vi_array = reinterpret_cast<vari**>(
       ChainableStack::instance_->memalloc_.alloc(sizeof(vari*) * y.size()));
-  for (int i = 0; i < y.size(); ++i)
-    y_vi_array[i] = y.coeff(i).vi_;
-
-  Eigen::VectorXd y_d(y.size());
-  for (int i = 0; i < y.size(); ++i)
-    y_d.coeffRef(i) = y.coeff(i).val();
-
-  const double norm = y_d.norm();
-  check_positive_finite("unit_vector", "norm", norm);
-  Eigen::VectorXd unit_vector_d = y_d / norm;
-
   double* unit_vector_y_d_array = reinterpret_cast<double*>(
       ChainableStack::instance_->memalloc_.alloc(sizeof(double) * y_d.size()));
-  for (int i = 0; i < y_d.size(); ++i)
-    unit_vector_y_d_array[i] = unit_vector_d.coeff(i);
+
+  Eigen::Map<vector_vi>(y_vi_array, y.size()) = y.vi();
+  const double norm = y_d.norm();
+
+  check_positive_finite("unit_vector", "norm", norm);
+  Eigen::Map<vector_d> unit_vecd(unit_vector_y_d_array, y.size());
+  unit_vecd = y_d / norm;
 
   Eigen::Matrix<var, R, C> unit_vector_y(y.size());
   for (int k = 0; k < y.size(); ++k)
     unit_vector_y.coeffRef(k) = var(new internal::unit_vector_elt_vari(
-        unit_vector_d[k], y_vi_array, unit_vector_y_d_array, y.size(), k,
+        unit_vecd[k], y_vi_array, unit_vector_y_d_array, y.size(), k,
         norm));
   return unit_vector_y;
 }

--- a/stan/math/rev/mat/fun/unit_vector_constrain.hpp
+++ b/stan/math/rev/mat/fun/unit_vector_constrain.hpp
@@ -75,8 +75,7 @@ Eigen::Matrix<var, R, C> unit_vector_constrain(
   Eigen::Matrix<var, R, C> unit_vector_y(y.size());
   for (int k = 0; k < y.size(); ++k)
     unit_vector_y.coeffRef(k) = var(new internal::unit_vector_elt_vari(
-        unit_vecd[k], y_vi_array, unit_vector_y_d_array, y.size(), k,
-        norm));
+        unit_vecd[k], y_vi_array, unit_vector_y_d_array, y.size(), k, norm));
   return unit_vector_y;
 }
 


### PR DESCRIPTION
## Summary

Updates the methods used in ```rev/mat/fun``` to use the new eigen plugin methods added in #1216

While updating functions I found some use-cases where the ```.val()``` method was failing for matrices/vectors of doubles, so that has also been fixed.

The following functions have been changed:

- LDLT_alloc
- dot_product
- dot_self
- grad
- initialize_variable
- log_determinant
- log_determinant_ldlt
- log_determinant_spd
- log_softmax
- mdivide_left
- mdivide_left_ldlt
- mdivide_left_spd
- mdivide_left_tri
- multiply
- quad_form
- sd
- softmax
- squared_distance
- sum
- to_var
- trace_gen_quad_form
- trace_inv_quad_form_ldlt
- trace_quad_form
- unit_vector_constrain
- variance

## Tests

Tests have not been changed

## Side Effects
Code reduction

## Checklist

- [X] Math issue #1197

- [X] Copyright holder: Andrew Johnson

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses: 
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [X] the new changes are tested
