### PR TITLE
issue 1279 - Remove deprecated Eigen content from math headers

### DIFF
--- a/stan/math/fwd/mat/fun/Eigen_NumTraits.hpp
+++ b/stan/math/fwd/mat/fun/Eigen_NumTraits.hpp
@@ -52,14 +52,12 @@ struct NumTraits<stan::math::fvar<T>> : GenericNumTraits<stan::math::fvar<T>> {
   static int digits10() { return std::numeric_limits<double>::digits10; }
 };
 
-namespace internal {
-
 /**
  * Scalar product traits specialization for Eigen for forward-mode
  * autodiff variables.
  */
-template <typename T>
-struct scalar_product_traits<stan::math::fvar<T>, double> {
+template <typename T, typename BinaryOp>
+struct ScalarBinaryOpTraits<stan::math::fvar<T>, double, BinaryOp> {
   typedef stan::math::fvar<T> ReturnType;
 };
 
@@ -67,11 +65,10 @@ struct scalar_product_traits<stan::math::fvar<T>, double> {
  * Scalar product traits specialization for Eigen for forward-mode
  * autodiff variables.
  */
-template <typename T>
-struct scalar_product_traits<double, stan::math::fvar<T>> {
+template <typename T, typename BinaryOp>
+struct ScalarBinaryOpTraits<double, stan::math::fvar<T>, BinaryOp> {
   typedef stan::math::fvar<T> ReturnType;
 };
-}  // namespace internal
 
 }  // namespace Eigen
 #endif

--- a/stan/math/prim/mat/fun/LDLT_factor.hpp
+++ b/stan/math/prim/mat/fun/LDLT_factor.hpp
@@ -99,19 +99,11 @@ class LDLT_factor {
     ldltP_->solveInPlace(invA);
   }
 
-#if EIGEN_VERSION_AT_LEAST(3, 3, 0)
   template <typename Rhs>
   inline const Eigen::Solve<ldlt_t, Rhs> solve(
       const Eigen::MatrixBase<Rhs>& b) const {
     return ldltP_->solve(b);
   }
-#else
-  template <typename Rhs>
-  inline const Eigen::internal::solve_retval<ldlt_t, Rhs> solve(
-      const Eigen::MatrixBase<Rhs>& b) const {
-    return ldltP_->solve(b);
-  }
-#endif
 
   inline matrix_t solveRight(const matrix_t& B) const {
     return ldltP_->solve(B.transpose()).transpose();

--- a/stan/math/rev/mat/fun/Eigen_NumTraits.hpp
+++ b/stan/math/rev/mat/fun/Eigen_NumTraits.hpp
@@ -79,6 +79,24 @@ struct NumTraits<stan::math::var> : GenericNumTraits<stan::math::var> {
   static int digits10() { return std::numeric_limits<double>::digits10; }
 };
 
+/**
+ * Scalar product traits specialization for Eigen for reverse-mode
+ * autodiff variables.
+ */
+template <typename BinaryOp>
+struct ScalarBinaryOpTraits<stan::math::var, double, BinaryOp> {
+  typedef stan::math::var ReturnType;
+};
+
+/**
+ * Scalar product traits specialization for Eigen for reverse-mode
+ * autodiff variables.
+ */
+template <typename BinaryOp>
+struct ScalarBinaryOpTraits<double, stan::math::var, BinaryOp> {
+  typedef stan::math::var ReturnType;
+};
+
 namespace internal {
 /**
  * Partial specialization of Eigen's remove_all struct to stop
@@ -87,25 +105,6 @@ namespace internal {
 template <>
 struct remove_all<stan::math::vari*> {
   typedef stan::math::vari* type;
-};
-
-#if EIGEN_VERSION_AT_LEAST(3, 3, 0)
-/**
- * Scalar product traits specialization for Eigen for reverse-mode
- * autodiff variables.
- */
-template <>
-struct scalar_product_traits<stan::math::var, double> {
-  typedef stan::math::var ReturnType;
-};
-
-/**
- * Scalar product traits specialization for Eigen for reverse-mode
- * autodiff variables.
- */
-template <>
-struct scalar_product_traits<double, stan::math::var> {
-  typedef stan::math::var ReturnType;
 };
 
 /**
@@ -248,129 +247,6 @@ struct general_matrix_matrix_product<Index, stan::math::var, LhsStorageOrder,
         alpha, blocking, info);
   }
 };
-#else
-/**
- * Implemented this for printing to stream.
- */
-template <>
-struct significant_decimals_default_impl<stan::math::var, false> {
-  static inline int run() {
-    using std::ceil;
-    using std::log;
-    return cast<double, int>(
-        ceil(-log(std::numeric_limits<double>::epsilon()) / log(10.0)));
-  }
-};
-
-/**
- * Scalar product traits override for Eigen for automatic
- * gradient variables.
- */
-template <>
-struct scalar_product_traits<stan::math::var, double> {
-  typedef stan::math::var ReturnType;
-};
-
-/**
- * Scalar product traits override for Eigen for automatic
- * gradient variables.
- */
-template <>
-struct scalar_product_traits<double, stan::math::var> {
-  typedef stan::math::var ReturnType;
-};
-
-/**
- * Override matrix-vector and matrix-matrix products to use more efficient
- * implementation.
- */
-template <typename Index, bool ConjugateLhs, bool ConjugateRhs>
-struct general_matrix_vector_product<Index, stan::math::var, ColMajor,
-                                     ConjugateLhs, stan::math::var,
-                                     ConjugateRhs> {
-  typedef stan::math::var LhsScalar;
-  typedef stan::math::var RhsScalar;
-  typedef typename scalar_product_traits<LhsScalar, RhsScalar>::ReturnType
-      ResScalar;
-  enum { LhsStorageOrder = ColMajor };
-
-  EIGEN_DONT_INLINE static void run(Index rows, Index cols,
-                                    const LhsScalar* lhs, Index lhsStride,
-                                    const RhsScalar* rhs, Index rhsIncr,
-                                    ResScalar* res, Index resIncr,
-                                    const ResScalar& alpha) {
-    for (Index i = 0; i < rows; i++) {
-      res[i * resIncr] += stan::math::var(new stan::math::gevv_vvv_vari(
-          &alpha,
-          (static_cast<int>(LhsStorageOrder) == static_cast<int>(ColMajor))
-              ? (&lhs[i])
-              : (&lhs[i * lhsStride]),
-          (static_cast<int>(LhsStorageOrder) == static_cast<int>(ColMajor))
-              ? (lhsStride)
-              : (1),
-          rhs, rhsIncr, cols));
-    }
-  }
-};
-template <typename Index, bool ConjugateLhs, bool ConjugateRhs>
-struct general_matrix_vector_product<Index, stan::math::var, RowMajor,
-                                     ConjugateLhs, stan::math::var,
-                                     ConjugateRhs> {
-  typedef stan::math::var LhsScalar;
-  typedef stan::math::var RhsScalar;
-  typedef typename scalar_product_traits<LhsScalar, RhsScalar>::ReturnType
-      ResScalar;
-  enum { LhsStorageOrder = RowMajor };
-
-  EIGEN_DONT_INLINE static void run(Index rows, Index cols,
-                                    const LhsScalar* lhs, Index lhsStride,
-                                    const RhsScalar* rhs, Index rhsIncr,
-                                    ResScalar* res, Index resIncr,
-                                    const RhsScalar& alpha) {
-    for (Index i = 0; i < rows; i++) {
-      res[i * resIncr] += stan::math::var(new stan::math::gevv_vvv_vari(
-          &alpha,
-          (static_cast<int>(LhsStorageOrder) == static_cast<int>(ColMajor))
-              ? (&lhs[i])
-              : (&lhs[i * lhsStride]),
-          (static_cast<int>(LhsStorageOrder) == static_cast<int>(ColMajor))
-              ? (lhsStride)
-              : (1),
-          rhs, rhsIncr, cols));
-    }
-  }
-};
-template <typename Index, int LhsStorageOrder, bool ConjugateLhs,
-          int RhsStorageOrder, bool ConjugateRhs>
-struct general_matrix_matrix_product<Index, stan::math::var, LhsStorageOrder,
-                                     ConjugateLhs, stan::math::var,
-                                     RhsStorageOrder, ConjugateRhs, ColMajor> {
-  typedef stan::math::var LhsScalar;
-  typedef stan::math::var RhsScalar;
-  typedef typename scalar_product_traits<LhsScalar, RhsScalar>::ReturnType
-      ResScalar;
-  static void run(Index rows, Index cols, Index depth, const LhsScalar* lhs,
-                  Index lhsStride, const RhsScalar* rhs, Index rhsStride,
-                  ResScalar* res, Index resStride, const ResScalar& alpha,
-                  level3_blocking<LhsScalar, RhsScalar>& /* blocking */,
-                  GemmParallelInfo<Index>* /* info = 0 */) {
-    for (Index i = 0; i < cols; i++) {
-      general_matrix_vector_product<
-          Index, LhsScalar, LhsStorageOrder, ConjugateLhs, RhsScalar,
-          ConjugateRhs>::run(rows, depth, lhs, lhsStride,
-                             &rhs[(static_cast<int>(RhsStorageOrder)
-                                   == static_cast<int>(ColMajor))
-                                      ? (i * rhsStride)
-                                      : (i)],
-                             (static_cast<int>(RhsStorageOrder)
-                              == static_cast<int>(ColMajor))
-                                 ? (1)
-                                 : (rhsStride),
-                             &res[i * resStride], 1, alpha);
-    }
-  }
-};
-#endif
 }  // namespace internal
 }  // namespace Eigen
 #endif


### PR DESCRIPTION
## Summary

Removes outdated ```EIGEN_VERSION_AT_LEAST(3, 3, 0)``` ifdefs and replaces ```scalar_product_op_traits``` with ```ScalarBinaryOpTraits```

## Tests
N/A

## Side Effects
Code reduction

## Checklist

- [X] Math issue #1279 

- [X] Copyright holder: Andrew Johnson

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [X] the new changes are tested
