### PR TITLE
make key of map for opencl kernel options into a string

### DIFF
--- a/stan/math/opencl/kernel_cl.hpp
+++ b/stan/math/opencl/kernel_cl.hpp
@@ -220,14 +220,14 @@ inline const std::vector<cl::Event> select_events(
  */
 inline auto compile_kernel(const char* name,
                            const std::vector<const char*>& sources,
-                           std::map<const char*, int>& options) {
+                           std::map<std::string, int>& options) {
   std::string kernel_opts = "";
   for (auto&& comp_opts : options) {
     kernel_opts += std::string(" -D") + comp_opts.first + "="
                    + std::to_string(comp_opts.second);
   }
   std::string kernel_source;
-  for (const char* source : sources) {
+  for (auto&& source : sources) {
     kernel_source.append(source);
   }
   cl::Program program;
@@ -260,7 +260,7 @@ template <typename... Args>
 class kernel_functor {
  private:
   cl::Kernel kernel_;
-  std::map<const char*, int> opts_;
+  std::map<std::string, int> opts_;
 
  public:
   /**
@@ -270,7 +270,7 @@ class kernel_functor {
    * @param options The values of macros to be passed at compile time.
    */
   kernel_functor(const char* name, const std::vector<const char*>& sources,
-                 const std::map<const char*, int>& options) {
+                 const std::map<std::string, int>& options) {
     auto base_opts = opencl_context.base_opts();
     for (auto& it : options) {
       if (base_opts[it.first] > it.second) {
@@ -286,7 +286,7 @@ class kernel_functor {
   /**
    * @return The options that the kernel was compiled with.
    */
-  inline const std::map<const char*, int>& get_opts() const { return opts_; }
+  inline const std::map<std::string, int>& get_opts() const { return opts_; }
 };
 
 /**
@@ -305,7 +305,7 @@ struct kernel_cl {
    * @param options The values of macros to be passed at compile time.
    */
   kernel_cl(const char* name, const char* source,
-            const std::map<const char*, int>& options = {})
+            const std::map<std::string, int>& options = {})
       : make_functor(name, {source}, options) {}
   /**
    * Creates functor for kernels that only need access to defining
@@ -315,7 +315,7 @@ struct kernel_cl {
    * @param options The values of macros to be passed at compile time.
    */
   kernel_cl(const char* name, const std::vector<const char*>& sources,
-            const std::map<const char*, int>& options = {})
+            const std::map<std::string, int>& options = {})
       : make_functor(name, sources, options) {}
   /**
    * Executes a kernel

--- a/stan/math/opencl/opencl_context.hpp
+++ b/stan/math/opencl/opencl_context.hpp
@@ -173,7 +173,7 @@ class opencl_context_base {
                                   // the device
 
   // Holds Default parameter values for each Kernel.
-  typedef std::map<const char*, int> map_base_opts;
+  typedef std::map<std::string, int> map_base_opts;
   map_base_opts base_opts_
       = {{"LOWER", static_cast<int>(TriangularViewCL::Lower)},
          {"UPPER", static_cast<int>(TriangularViewCL::Upper)},


### PR DESCRIPTION

## Summary

As described in [this](https://discourse.mc-stan.org/t/opencl-work-per-thread-0/10057) discourse thread @alashworth found a bug when we grab the macros for the OpenCL kernels. We were using a map as `std::map<const char*, int>`, but when we tried updating new options in the kernels this would do a pointer comparison instead of a comparison of the non-null elements of the const char array.

This PR fixes this by just using a `string` instead of a `const char*` for the key

## Tests

Idk if it's necessary but we could add a test for the `opencl_context` where we check all the values of the keys internal elements are unique. But we use a std::string now so idt we need to.

## Checklist

- [x] Math issue #1297

- [x] Copyright holder: Steve Bronder

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
