### PR TITLE
mdivide_right_tri can use OpenCL

### DIFF
--- a/stan/math/prim/mat/fun/mdivide_right_tri.hpp
+++ b/stan/math/prim/mat/fun/mdivide_right_tri.hpp
@@ -22,7 +22,7 @@ namespace math {
  * @throws std::domain_error if A is not square or the rows of b don't
  * match the size of A.
  */
-template <int TriView, typename T1, typename T2, int R1, int C1, int R2, int C2>
+template <Eigen::UpLoType TriView, typename T1, typename T2, int R1, int C1, int R2, int C2>
 inline Eigen::Matrix<return_type_t<T1, T2>, R1, C2> mdivide_right_tri(
     const Eigen::Matrix<T1, R1, C1> &b, const Eigen::Matrix<T2, R2, C2> &A) {
   check_square("mdivide_right_tri", "A", A);
@@ -40,6 +40,36 @@ inline Eigen::Matrix<return_type_t<T1, T2>, R1, C2> mdivide_right_tri(
               b)
               .transpose())
       .transpose();
+}
+
+/**
+ * Returns the solution of the system Ax=b when A is triangular
+ * and A and b are matrices of doubles.
+ * @param A Triangular matrix.  Specify upper or lower with TriView
+ * being Eigen::Upper or Eigen::Lower.
+ * @param b Right hand side matrix or vector.
+ * @return x = b A^-1, solution of the linear system.
+ * @throws std::domain_error if A is not square or the rows of b don't
+ * match the size of A.
+ */
+template <Eigen::UpLoType TriView, int R1, int C1, int R2, int C2>
+inline Eigen::Matrix<double, R1, C2> mdivide_right_tri(const Eigen::Matrix<double, R1, C1> &b, const Eigen::Matrix<double, R2, C2> &A) {
+  check_square("mdivide_right_tri", "A", A);
+  check_multiplicable("mdivide_right_tri", "b", b, "A", A);
+#ifdef STAN_OPENCL
+  if (A.rows()
+      >= opencl_context.tuning_opts().tri_inverse_size_worth_transfer) {
+    matrix_cl<double> A_cl(A, from_eigen_uplo_type(TriView));
+    matrix_cl<double> b_cl(b);
+    matrix_cl<double> A_inv_cl = tri_inverse(A_cl);
+    matrix_cl<double> C_cl = b_cl * A_inv_cl;
+    return from_matrix_cl(C_cl);
+  } else {
+#endif
+    return A.template triangularView<TriView>().transpose().solve(b.transpose()).transpose();
+#ifdef STAN_OPENCL
+  }
+#endif
 }
 
 }  // namespace math

--- a/stan/math/prim/mat/fun/mdivide_right_tri.hpp
+++ b/stan/math/prim/mat/fun/mdivide_right_tri.hpp
@@ -22,7 +22,8 @@ namespace math {
  * @throws std::domain_error if A is not square or the rows of b don't
  * match the size of A.
  */
-template <Eigen::UpLoType TriView, typename T1, typename T2, int R1, int C1, int R2, int C2>
+template <Eigen::UpLoType TriView, typename T1, typename T2, int R1, int C1,
+          int R2, int C2>
 inline Eigen::Matrix<return_type_t<T1, T2>, R1, C2> mdivide_right_tri(
     const Eigen::Matrix<T1, R1, C1> &b, const Eigen::Matrix<T2, R2, C2> &A) {
   check_square("mdivide_right_tri", "A", A);
@@ -53,7 +54,9 @@ inline Eigen::Matrix<return_type_t<T1, T2>, R1, C2> mdivide_right_tri(
  * match the size of A.
  */
 template <Eigen::UpLoType TriView, int R1, int C1, int R2, int C2>
-inline Eigen::Matrix<double, R1, C2> mdivide_right_tri(const Eigen::Matrix<double, R1, C1> &b, const Eigen::Matrix<double, R2, C2> &A) {
+inline Eigen::Matrix<double, R1, C2> mdivide_right_tri(
+    const Eigen::Matrix<double, R1, C1> &b,
+    const Eigen::Matrix<double, R2, C2> &A) {
   check_square("mdivide_right_tri", "A", A);
   check_multiplicable("mdivide_right_tri", "b", b, "A", A);
 #ifdef STAN_OPENCL
@@ -66,7 +69,10 @@ inline Eigen::Matrix<double, R1, C2> mdivide_right_tri(const Eigen::Matrix<doubl
     return from_matrix_cl(C_cl);
   } else {
 #endif
-    return A.template triangularView<TriView>().transpose().solve(b.transpose()).transpose();
+    return A.template triangularView<TriView>()
+        .transpose()
+        .solve(b.transpose())
+        .transpose();
 #ifdef STAN_OPENCL
   }
 #endif

--- a/test/unit/math/prim/mat/fun/mdivide_right_tri_test.cpp
+++ b/test/unit/math/prim/mat/fun/mdivide_right_tri_test.cpp
@@ -1,6 +1,16 @@
 #include <stan/math/prim/mat.hpp>
 #include <gtest/gtest.h>
 
+#ifdef STAN_OPENCL
+#include <stan/math/opencl/opencl.hpp>
+#include <boost/random/mersenne_twister.hpp>
+#endif
+
+#define EXPECT_MATRIX_NEAR(A, B, DELTA) \
+  for (int i = 0; i < A.size(); i++)    \
+    EXPECT_NEAR(A(i), B(i), DELTA);
+
+
 TEST(MathMatrix, mdivide_right_tri_val) {
   using stan::math::mdivide_right_tri;
   stan::math::matrix_d Ad(2, 2);
@@ -22,3 +32,36 @@ TEST(MathMatrix, mdivide_right_tri_val) {
   EXPECT_NEAR(0.0, I(1, 0), 1.0E-12);
   EXPECT_NEAR(1.0, I(1, 1), 1.0e-12);
 }
+
+#ifdef STAN_OPENCL
+
+void mdivide_right_tri_cl_test(int size) {
+  boost::random::mt19937 rng;
+  stan::math::matrix_d m1(size, size);
+  for (int i = 0; i < size; i++) {
+    for (int j = 0; j < i; j++) {
+      m1(i, j) = stan::math::uniform_rng(-5, 5, rng);
+    }
+    m1(i, i) = 20.0;
+    for (int j = i + 1; j < size; j++) {
+      m1(i, j) = 0.0;
+    }
+  }
+
+  stan::math::opencl_context.tuning_opts().tri_inverse_size_worth_transfer
+          = size * 2;
+
+  stan::math::matrix_d m1_cpu
+          = stan::math::mdivide_right_tri<Eigen::Lower>(m1, m1);
+
+  stan::math::opencl_context.tuning_opts().tri_inverse_size_worth_transfer = 0;
+
+  stan::math::matrix_d m1_cl
+          = stan::math::mdivide_right_tri<Eigen::Lower>(m1, m1);
+
+  EXPECT_MATRIX_NEAR(m1_cpu, m1_cl, 1E-8);
+}
+TEST(MathMatrixCL, mdivide_right_tri_cl_small) { mdivide_right_tri_cl_test(3); }
+TEST(MathMatrixCL, mdivide_right_tri_cl_mid) { mdivide_right_tri_cl_test(100); }
+TEST(MathMatrixCL, mdivide_right_tri_cl_big) { mdivide_right_tri_cl_test(500); }
+#endif

--- a/test/unit/math/prim/mat/fun/mdivide_right_tri_test.cpp
+++ b/test/unit/math/prim/mat/fun/mdivide_right_tri_test.cpp
@@ -10,7 +10,6 @@
   for (int i = 0; i < A.size(); i++)    \
     EXPECT_NEAR(A(i), B(i), DELTA);
 
-
 TEST(MathMatrix, mdivide_right_tri_val) {
   using stan::math::mdivide_right_tri;
   stan::math::matrix_d Ad(2, 2);
@@ -49,15 +48,15 @@ void mdivide_right_tri_cl_test(int size) {
   }
 
   stan::math::opencl_context.tuning_opts().tri_inverse_size_worth_transfer
-          = size * 2;
+      = size * 2;
 
   stan::math::matrix_d m1_cpu
-          = stan::math::mdivide_right_tri<Eigen::Lower>(m1, m1);
+      = stan::math::mdivide_right_tri<Eigen::Lower>(m1, m1);
 
   stan::math::opencl_context.tuning_opts().tri_inverse_size_worth_transfer = 0;
 
   stan::math::matrix_d m1_cl
-          = stan::math::mdivide_right_tri<Eigen::Lower>(m1, m1);
+      = stan::math::mdivide_right_tri<Eigen::Lower>(m1, m1);
 
   EXPECT_MATRIX_NEAR(m1_cpu, m1_cl, 1E-8);
 }


### PR DESCRIPTION
## Summary

`mdivide_right_tri()` can now use OpenCL. The same changes in this PR mirror usage of OpenCL in `mdivide_left_tri()` - `tri_inverse()` and multiplication are used. There is no new OpenCL kernel code.

## Tests
Tests are almost the same as the ones for `mdivide_left_tri()`.

## Side Effects
None.

## Checklist

- [x] Math issue #1221 

- [x] Copyright holder: Tadej Ciglarič, University of Ljubljana

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
