### PR TITLE
Re-apply #1278 OpenCL prim multiply

### DIFF
--- a/stan/math/prim/mat/fun/cholesky_decompose.hpp
+++ b/stan/math/prim/mat/fun/cholesky_decompose.hpp
@@ -6,10 +6,7 @@
 #include <stan/math/prim/mat/err/check_square.hpp>
 #include <stan/math/prim/mat/err/check_symmetric.hpp>
 #ifdef STAN_OPENCL
-#include <stan/math/opencl/opencl_context.hpp>
-#include <stan/math/opencl/err/check_symmetric.hpp>
-#include <stan/math/opencl/cholesky_decompose.hpp>
-#include <stan/math/opencl/copy.hpp>
+#include <stan/math/opencl/opencl.hpp>
 #endif
 
 #include <cmath>

--- a/stan/math/prim/mat/fun/multiply.hpp
+++ b/stan/math/prim/mat/fun/multiply.hpp
@@ -5,6 +5,9 @@
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/arr/err/check_matching_sizes.hpp>
 #include <stan/math/prim/mat/err/check_multiplicable.hpp>
+#ifdef STAN_OPENCL
+#include <stan/math/opencl/opencl.hpp>
+#endif
 #include <type_traits>
 
 namespace stan {
@@ -55,7 +58,19 @@ template <int R1, int C1, int R2, int C2, typename T1, typename T2,
 inline Eigen::Matrix<return_type_t<T1, T2>, R1, C2> multiply(
     const Eigen::Matrix<T1, R1, C1>& m1, const Eigen::Matrix<T2, R2, C2>& m2) {
   check_multiplicable("multiply", "m1", m1, "m2", m2);
+#ifdef STAN_OPENCL
+  if (m1.rows() * m1.cols() * m2.cols()
+      > opencl_context.tuning_opts().multiply_dim_prod_worth_transfer) {
+    matrix_cl<double> m1_cl(m1);
+    matrix_cl<double> m2_cl(m2);
+    matrix_cl<double> m3_cl = m1_cl * m2_cl;
+    return from_matrix_cl(m3_cl);
+  } else {
+    return m1 * m2;
+  }
+#else
   return m1 * m2;
+#endif
 }
 
 /**

--- a/test/unit/math/prim/mat/fun/mdivide_left_tri_test.cpp
+++ b/test/unit/math/prim/mat/fun/mdivide_left_tri_test.cpp
@@ -2,10 +2,7 @@
 #include <gtest/gtest.h>
 
 #ifdef STAN_OPENCL
-#include <stan/math/opencl/opencl_context.hpp>
-#include <stan/math/opencl/multiply.hpp>
-#include <stan/math/opencl/copy.hpp>
-#include <stan/math/opencl/tri_inverse.hpp>
+#include <stan/math/opencl/opencl.hpp>
 #include <boost/random/mersenne_twister.hpp>
 #endif
 

--- a/test/unit/math/rev/mat/fun/cholesky_decompose_test.cpp
+++ b/test/unit/math/rev/mat/fun/cholesky_decompose_test.cpp
@@ -5,7 +5,7 @@
 #include <vector>
 
 #ifdef STAN_OPENCL
-#include <stan/math/opencl/opencl_context.hpp>
+#include <stan/math/opencl/opencl.hpp>
 #endif
 
 template <typename T_x>


### PR DESCRIPTION
## Summary

Reapplies the changes that were merged in #1278 and were removed as a result of a bad merge in #1289 

The only commit is the cherry pick of the merge.

## Tests

See #1278 

## Side Effects

/

## Checklist

- [x] Math issue #1221

- [x] Copyright holder: Rok Češnovar

- [x] the basic tests are passing

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
