### PR TITLE
Fixed matrix_cl copying and moving

### DIFF
--- a/stan/math/opencl/matrix_cl.hpp
+++ b/stan/math/opencl/matrix_cl.hpp
@@ -206,8 +206,8 @@ class matrix_cl<T, enable_if_arithmetic<T>> {
         rows_(A.rows_),
         cols_(A.cols_),
         view_(A.view_),
-        read_events_(std::move(A.read_events_)),
-        write_events_(std::move(A.write_events_)) {}
+        write_events_(std::move(A.write_events_)),
+        read_events_(std::move(A.read_events_)) {}
 
   /**
    * Constructor for the matrix_cl that
@@ -380,8 +380,8 @@ class matrix_cl<T, enable_if_arithmetic<T>> {
     this->wait_for_read_write_events();
     buffer_cl_ = a.buffer();
     view_ = a.view();
-    read_events_ = std::move(a.read_events_);
     write_events_ = std::move(a.write_events_);
+    read_events_ = std::move(a.read_events_);
     return *this;
   }
 

--- a/stan/math/opencl/matrix_cl.hpp
+++ b/stan/math/opencl/matrix_cl.hpp
@@ -184,6 +184,8 @@ class matrix_cl<T, enable_if_arithmetic<T>> {
       : rows_(A.rows()), cols_(A.cols()), view_(A.view()) {
     if (A.size() == 0)
       return;
+    this->wait_for_read_write_events();
+    A.wait_for_write_events();
     cl::Context& ctx = opencl_context.context();
     cl::CommandQueue queue = opencl_context.queue();
     try {
@@ -193,10 +195,13 @@ class matrix_cl<T, enable_if_arithmetic<T>> {
                               A.size() * sizeof(T), &A.write_events(),
                               &cstr_event);
       this->add_write_event(cstr_event);
+      A.add_read_event(cstr_event);
     } catch (const cl::Error& e) {
       check_opencl_error("copy (OpenCL)->(OpenCL)", e);
     }
   }
+
+  matrix_cl(matrix_cl<T>&& A) : buffer_cl_(A.buffer_cl_), rows_(A.rows_), cols_(A.cols_), view_(A.view_), read_events_(std::move(A.read_events_)), write_events_(std::move(A.write_events_)) {}
 
   /**
    * Constructor for the matrix_cl that
@@ -338,10 +343,39 @@ class matrix_cl<T, enable_if_arithmetic<T>> {
                      a.rows(), "destination.rows()", rows());
     check_size_match("assignment of (OpenCL) matrices", "source.cols()",
                      a.cols(), "destination.cols()", cols());
+    if (a.size() == 0)
+      return;
+    view_ = a.view();
+    this->wait_for_read_write_events();
+    a.wait_for_write_events();
+    cl::CommandQueue queue = opencl_context.queue();
+    try {
+      cl::Event copy_event;
+      queue.enqueueCopyBuffer(a.buffer(), this->buffer(), 0, 0,
+                              a.size() * sizeof(T), &a.write_events(),
+                              &copy_event);
+      this->add_write_event(copy_event);
+      a.add_read_event(copy_event);
+    } catch (const cl::Error& e) {
+      check_opencl_error("copy (OpenCL)->(OpenCL)", e);
+    }
+    return *this;
+  }
+
+  /**
+   * Move a \c matrix_cl to another
+   */
+  matrix_cl<T>& operator=(matrix_cl<T>&& a) {
+    check_size_match("move of (OpenCL) matrix", "source.rows()",
+                     a.rows(), "destination.rows()", rows());
+    check_size_match("move of (OpenCL) matrix", "source.cols()",
+                     a.cols(), "destination.cols()", cols());
     // Need to wait for all of matrices events before destroying old buffer
     this->wait_for_read_write_events();
     buffer_cl_ = a.buffer();
     view_ = a.view();
+    read_events_ = std::move(a.read_events_);
+    write_events_ = std::move(a.write_events_);
     return *this;
   }
 

--- a/stan/math/opencl/matrix_cl.hpp
+++ b/stan/math/opencl/matrix_cl.hpp
@@ -185,7 +185,6 @@ class matrix_cl<T, enable_if_arithmetic<T>> {
     if (A.size() == 0)
       return;
     this->wait_for_read_write_events();
-    A.wait_for_write_events();
     cl::Context& ctx = opencl_context.context();
     cl::CommandQueue queue = opencl_context.queue();
     try {
@@ -353,7 +352,6 @@ class matrix_cl<T, enable_if_arithmetic<T>> {
       return *this;
     view_ = a.view();
     this->wait_for_read_write_events();
-    a.wait_for_write_events();
     cl::CommandQueue queue = opencl_context.queue();
     try {
       cl::Event copy_event;

--- a/stan/math/opencl/matrix_cl.hpp
+++ b/stan/math/opencl/matrix_cl.hpp
@@ -350,7 +350,7 @@ class matrix_cl<T, enable_if_arithmetic<T>> {
     check_size_match("assignment of (OpenCL) matrices", "source.cols()",
                      a.cols(), "destination.cols()", cols());
     if (a.size() == 0)
-      return;
+      return *this;
     view_ = a.view();
     this->wait_for_read_write_events();
     a.wait_for_write_events();

--- a/stan/math/opencl/matrix_cl.hpp
+++ b/stan/math/opencl/matrix_cl.hpp
@@ -201,7 +201,13 @@ class matrix_cl<T, enable_if_arithmetic<T>> {
     }
   }
 
-  matrix_cl(matrix_cl<T>&& A) : buffer_cl_(A.buffer_cl_), rows_(A.rows_), cols_(A.cols_), view_(A.view_), read_events_(std::move(A.read_events_)), write_events_(std::move(A.write_events_)) {}
+  matrix_cl(matrix_cl<T>&& A)
+      : buffer_cl_(A.buffer_cl_),
+        rows_(A.rows_),
+        cols_(A.cols_),
+        view_(A.view_),
+        read_events_(std::move(A.read_events_)),
+        write_events_(std::move(A.write_events_)) {}
 
   /**
    * Constructor for the matrix_cl that
@@ -366,10 +372,10 @@ class matrix_cl<T, enable_if_arithmetic<T>> {
    * Move a \c matrix_cl to another
    */
   matrix_cl<T>& operator=(matrix_cl<T>&& a) {
-    check_size_match("move of (OpenCL) matrix", "source.rows()",
-                     a.rows(), "destination.rows()", rows());
-    check_size_match("move of (OpenCL) matrix", "source.cols()",
-                     a.cols(), "destination.cols()", cols());
+    check_size_match("move of (OpenCL) matrix", "source.rows()", a.rows(),
+                     "destination.rows()", rows());
+    check_size_match("move of (OpenCL) matrix", "source.cols()", a.cols(),
+                     "destination.cols()", cols());
     // Need to wait for all of matrices events before destroying old buffer
     this->wait_for_read_write_events();
     buffer_cl_ = a.buffer();


### PR DESCRIPTION
## Summary

Changed matrix_cl copy assigment to do a deep copy. Added move constructor and move assignment operator. Fixed an event related bug in copy constructor.

## Tests
Nothing new.

## Side Effects
matrix_cl assignments now do a deep copy. Moving matrix_cl (such as returning from function) will not do deep copy even if compiled does not do copy elision.

## Checklist

- [x] Math issue #1307 

- [x] Copyright holder: Tadej Ciglarič (University of Ljubljana)

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
