### PR TITLE
fix matrix_cl_view test

### DIFF
--- a/stan/math/opencl/matrix_cl_view.hpp
+++ b/stan/math/opencl/matrix_cl_view.hpp
@@ -70,7 +70,7 @@ inline const matrix_cl_view transpose(const matrix_cl_view view) {
  */
 inline const matrix_cl_view invert(const matrix_cl_view view) {
   typedef typename std::underlying_type<matrix_cl_view>::type underlying;
-  return static_cast<matrix_cl_view>(~static_cast<underlying>(view));
+  return static_cast<matrix_cl_view>(static_cast<underlying>(matrix_cl_view::Entire) & ~static_cast<underlying>(view));
 }
 
 /**

--- a/stan/math/opencl/matrix_cl_view.hpp
+++ b/stan/math/opencl/matrix_cl_view.hpp
@@ -70,7 +70,9 @@ inline const matrix_cl_view transpose(const matrix_cl_view view) {
  */
 inline const matrix_cl_view invert(const matrix_cl_view view) {
   typedef typename std::underlying_type<matrix_cl_view>::type underlying;
-  return static_cast<matrix_cl_view>(static_cast<underlying>(matrix_cl_view::Entire) & ~static_cast<underlying>(view));
+  return static_cast<matrix_cl_view>(
+      static_cast<underlying>(matrix_cl_view::Entire)
+      & ~static_cast<underlying>(view));
 }
 
 /**

--- a/test/unit/math/opencl/matrix_cl_view_test.cpp
+++ b/test/unit/math/opencl/matrix_cl_view_test.cpp
@@ -93,15 +93,15 @@ TEST(matrix_cl_view, invert) {
   EXPECT_EQ(matrix_cl_view::Diagonal, invert(matrix_cl_view::Entire));
 }
 
-TEST(matrix_cl_view, from_eigen_triangular_type) {
-  using stan::math::from_eigen_triangular_type;
+TEST(matrix_cl_view, from_eigen_uplo_type) {
+  using stan::math::from_eigen_uplo_type;
   using stan::math::matrix_cl_view;
-  EXPECT_EQ(matrix_cl_view::Lower, from_eigen_triangular_type(Eigen::Lower));
-  EXPECT_EQ(matrix_cl_view::Upper, from_eigen_triangular_type(Eigen::Upper));
+  EXPECT_EQ(matrix_cl_view::Lower, from_eigen_uplo_type(Eigen::Lower));
+  EXPECT_EQ(matrix_cl_view::Upper, from_eigen_uplo_type(Eigen::Upper));
   EXPECT_EQ(matrix_cl_view::Entire,
-            from_eigen_triangular_type(Eigen::SelfAdjoint));
+            from_eigen_uplo_type(Eigen::SelfAdjoint));
   EXPECT_EQ(matrix_cl_view::Entire,
-            from_eigen_triangular_type(Eigen::UnitDiag));
+            from_eigen_uplo_type(Eigen::UnitDiag));
 }
 
 #endif

--- a/test/unit/math/opencl/matrix_cl_view_test.cpp
+++ b/test/unit/math/opencl/matrix_cl_view_test.cpp
@@ -98,10 +98,8 @@ TEST(matrix_cl_view, from_eigen_uplo_type) {
   using stan::math::matrix_cl_view;
   EXPECT_EQ(matrix_cl_view::Lower, from_eigen_uplo_type(Eigen::Lower));
   EXPECT_EQ(matrix_cl_view::Upper, from_eigen_uplo_type(Eigen::Upper));
-  EXPECT_EQ(matrix_cl_view::Entire,
-            from_eigen_uplo_type(Eigen::SelfAdjoint));
-  EXPECT_EQ(matrix_cl_view::Entire,
-            from_eigen_uplo_type(Eigen::UnitDiag));
+  EXPECT_EQ(matrix_cl_view::Entire, from_eigen_uplo_type(Eigen::SelfAdjoint));
+  EXPECT_EQ(matrix_cl_view::Entire, from_eigen_uplo_type(Eigen::UnitDiag));
 }
 
 #endif


### PR DESCRIPTION
## Summary

File with tests for `matrix_cl_view` diid not end with `_test.cpp` so `runTests.py` did not run it. This PR fixes that and a few bugs that were consequently not caught.

## Checklist

- [x] Math issue #1312

- [x] Copyright holder: Tadej Ciglarič (University of Ljubljana)

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
