### PR TITLE
implement GPU caching

### DIFF
--- a/stan/math/opencl/matrix_cl.hpp
+++ b/stan/math/opencl/matrix_cl.hpp
@@ -180,7 +180,9 @@ class matrix_cl<T, enable_if_arithmetic<T>> {
   cl::Buffer& buffer() { return buffer_cl_; }
   matrix_cl() : rows_(0), cols_(0) {}
 
-  matrix_cl(cl::Buffer& A, const int R, const int C, matrix_cl_view partial_view = matrix_cl_view::Entire) : rows_(R), cols_(C), view_(partial_view) {
+  matrix_cl(cl::Buffer& A, const int R, const int C,
+            matrix_cl_view partial_view = matrix_cl_view::Entire)
+      : rows_(R), cols_(C), view_(partial_view) {
     buffer_cl_ = A;
   }
 
@@ -345,41 +347,46 @@ class matrix_cl<T, enable_if_arithmetic<T>> {
     }
   }
 
-    /**
-   * Constructs a const matrix_cl that contains a copy of the Eigen matrix on the OpenCL device.
-   * If the matrix already has a cached copy on the device, the cache is used and no copying is done.
-   * Changing the resulting matrix_cl would change cache, so do not do it! If changes are needed a copy must be made.
+  /**
+   * Constructs a const matrix_cl that contains a copy of the Eigen matrix on
+   * the OpenCL device. If the matrix already has a cached copy on the device,
+   * the cache is used and no copying is done. Changing the resulting matrix_cl
+   * would change cache, so do not do it! If changes are needed a copy must be
+   * made.
    *
    * @tparam R row type of input matrix
    * @tparam C column type of input matrix
    * @param A the Eigen matrix
    * @param partial_view which part of the matrix is used
    */
-    template <int R, int C>
-    static matrix_cl<T> constant(const Eigen::Matrix<T, R, C>& A, matrix_cl_view partial_view = matrix_cl_view::Entire){
+  template <int R, int C>
+  static matrix_cl<T> constant(const Eigen::Matrix<T, R, C>& A,
+                               matrix_cl_view partial_view
+                               = matrix_cl_view::Entire) {
 #ifdef STAN_OPENCL_CACHE
-      if (A.opencl_buffer_() != NULL) {
-        return matrix_cl<T>(A.opencl_buffer_, A.rows(), A.cols(), partial_view);
-      }
-      else{
-        matrix_cl<T> res(A, partial_view);
-        A.opencl_buffer_ = res.buffer();
-        return res;
-      }
+    if (A.opencl_buffer_() != NULL) {
+      return matrix_cl<T>(A.opencl_buffer_, A.rows(), A.cols(), partial_view);
+    } else {
+      matrix_cl<T> res(A, partial_view);
+      A.opencl_buffer_ = res.buffer();
+      return res;
+    }
 #else
-      return matrix_cl<T>(A, partial_view);
+    return matrix_cl<T>(A, partial_view);
 #endif
-    }
+  }
 
-    /**
-      * Constructs a const matrix_cl that contains a single value on the OpenCL device.
-      *
-      * @param A the value
-      * @param partial_view which part of the matrix is used
-      */
-    static matrix_cl<T> constant(T A, matrix_cl_view partial_view = matrix_cl_view::Entire){
-      return matrix_cl<T>(A);
-    }
+  /**
+   * Constructs a const matrix_cl that contains a single value on the OpenCL
+   * device.
+   *
+   * @param A the value
+   * @param partial_view which part of the matrix is used
+   */
+  static matrix_cl<T> constant(T A, matrix_cl_view partial_view
+                                    = matrix_cl_view::Entire) {
+    return matrix_cl<T>(A);
+  }
 
   /**
    * Construct from \c array of doubles with given rows and columns

--- a/stan/math/opencl/matrix_cl.hpp
+++ b/stan/math/opencl/matrix_cl.hpp
@@ -181,7 +181,8 @@ class matrix_cl<T, enable_if_arithmetic<T>> {
   matrix_cl() : rows_(0), cols_(0) {}
 
   /**
-   * Construct a matrix_cl<T> from an existing cl::Buffer object. The matrix directly uses given buffer - no copying is done.
+   * Construct a matrix_cl<T> from an existing cl::Buffer object. The matrix
+   * directly uses given buffer - no copying is done.
    *
    * @param A the cl::Buffer object to construct the matrix from
    * @param R number of rows

--- a/stan/math/opencl/matrix_cl.hpp
+++ b/stan/math/opencl/matrix_cl.hpp
@@ -180,6 +180,10 @@ class matrix_cl<T, enable_if_arithmetic<T>> {
   cl::Buffer& buffer() { return buffer_cl_; }
   matrix_cl() : rows_(0), cols_(0) {}
 
+  matrix_cl(cl::Buffer& A, const int R, const int C, matrix_cl_view partial_view = matrix_cl_view::Entire) : rows_(R), cols_(C), view_(partial_view) {
+    buffer_cl_ = A;
+  }
+
   matrix_cl(const matrix_cl<T>& A)
       : rows_(A.rows()), cols_(A.cols()), view_(A.view()) {
     if (A.size() == 0)
@@ -340,6 +344,42 @@ class matrix_cl<T, enable_if_arithmetic<T>> {
       check_opencl_error("matrix constructor", e);
     }
   }
+
+    /**
+   * Constructs a const matrix_cl that contains a copy of the Eigen matrix on the OpenCL device.
+   * If the matrix already has a cached copy on the device, the cache is used and no copying is done.
+   * Changing the resulting matrix_cl would change cache, so do not do it! If changes are needed a copy must be made.
+   *
+   * @tparam R row type of input matrix
+   * @tparam C column type of input matrix
+   * @param A the Eigen matrix
+   * @param partial_view which part of the matrix is used
+   */
+    template <int R, int C>
+    static matrix_cl<T> constant(const Eigen::Matrix<T, R, C>& A, matrix_cl_view partial_view = matrix_cl_view::Entire){
+#ifdef STAN_OPENCL_CACHE
+      if (A.opencl_buffer_() != NULL) {
+        return matrix_cl<T>(A.opencl_buffer_, A.rows(), A.cols(), partial_view);
+      }
+      else{
+        matrix_cl<T> res(A, partial_view);
+        A.opencl_buffer_ = res.buffer();
+        return res;
+      }
+#else
+      return matrix_cl<T>(A, partial_view);
+#endif
+    }
+
+    /**
+      * Constructs a const matrix_cl that contains a single value on the OpenCL device.
+      *
+      * @param A the value
+      * @param partial_view which part of the matrix is used
+      */
+    static matrix_cl<T> constant(T A, matrix_cl_view partial_view = matrix_cl_view::Entire){
+      return matrix_cl<T>(A);
+    }
 
   /**
    * Construct from \c array of doubles with given rows and columns

--- a/stan/math/opencl/matrix_cl.hpp
+++ b/stan/math/opencl/matrix_cl.hpp
@@ -191,9 +191,7 @@ class matrix_cl<T, enable_if_arithmetic<T>> {
    */
   matrix_cl(cl::Buffer& A, const int R, const int C,
             matrix_cl_view partial_view = matrix_cl_view::Entire)
-      : rows_(R), cols_(C), view_(partial_view) {
-    buffer_cl_ = A;
-  }
+      : buffer_cl_(A), rows_(R), cols_(C), view_(partial_view) {}
 
   matrix_cl(const matrix_cl<T>& A)
       : rows_(A.rows()), cols_(A.cols()), view_(A.view()) {

--- a/stan/math/opencl/matrix_cl.hpp
+++ b/stan/math/opencl/matrix_cl.hpp
@@ -180,6 +180,14 @@ class matrix_cl<T, enable_if_arithmetic<T>> {
   cl::Buffer& buffer() { return buffer_cl_; }
   matrix_cl() : rows_(0), cols_(0) {}
 
+  /**
+   * Construct a matrix_cl<T> from an existing cl::Buffer object. The matrix directly uses given buffer - no copying is done.
+   *
+   * @param A the cl::Buffer object to construct the matrix from
+   * @param R number of rows
+   * @param C number of columns
+   * @param partial_view view of the matrix
+   */
   matrix_cl(cl::Buffer& A, const int R, const int C,
             matrix_cl_view partial_view = matrix_cl_view::Entire)
       : rows_(R), cols_(C), view_(partial_view) {
@@ -363,7 +371,7 @@ class matrix_cl<T, enable_if_arithmetic<T>> {
   static matrix_cl<T> constant(const Eigen::Matrix<T, R, C>& A,
                                matrix_cl_view partial_view
                                = matrix_cl_view::Entire) {
-#ifdef STAN_OPENCL_CACHE
+#ifndef STAN_OPENCL_NOCACHE
     if (A.opencl_buffer_() != NULL) {
       return matrix_cl<T>(A.opencl_buffer_, A.rows(), A.cols(), partial_view);
     } else {

--- a/stan/math/prim/mat/eigen_plugins.h
+++ b/stan/math/prim/mat/eigen_plugins.h
@@ -200,7 +200,7 @@ vi() { return CwiseUnaryView<vi_Op, Derived>(derived());
 }
 
 #ifdef STAN_OPENCL
-#ifdef STAN_OPENCL_CACHE
+#ifndef STAN_OPENCL_NOCACHE
 mutable cl::Buffer opencl_buffer_;
 #endif
 #endif

--- a/stan/math/prim/mat/eigen_plugins.h
+++ b/stan/math/prim/mat/eigen_plugins.h
@@ -199,6 +199,12 @@ inline CwiseUnaryView<vi_Op, Derived>
 vi() { return CwiseUnaryView<vi_Op, Derived>(derived());
 }
 
+#ifdef STAN_OPENCL
+#ifdef STAN_OPENCL_CACHE
+mutable cl::Buffer opencl_buffer_;
+#endif
+#endif
+
 #define EIGEN_STAN_MATRIXBASE_PLUGIN
 
 #endif

--- a/stan/math/prim/mat/fun/Eigen.hpp
+++ b/stan/math/prim/mat/fun/Eigen.hpp
@@ -1,6 +1,12 @@
 #ifndef STAN_MATH_PRIM_MAT_FUN_EIGEN_HPP
 #define STAN_MATH_PRIM_MAT_FUN_EIGEN_HPP
 
+#ifdef STAN_OPENCL
+#ifdef STAN_OPENCL_CACHE
+#include <CL/cl.hpp>
+#endif
+#endif
+
 #ifdef EIGEN_MATRIXBASE_PLUGIN
 #ifndef EIGEN_STAN_MATRIXBASE_PLUGIN
 #error "Stan uses Eigen's EIGEN_MATRIXBASE_PLUGIN macro. To use your own "

--- a/stan/math/prim/mat/fun/Eigen.hpp
+++ b/stan/math/prim/mat/fun/Eigen.hpp
@@ -2,7 +2,7 @@
 #define STAN_MATH_PRIM_MAT_FUN_EIGEN_HPP
 
 #ifdef STAN_OPENCL
-#ifdef STAN_OPENCL_CACHE
+#ifndef STAN_OPENCL_NOCACHE
 #include <CL/cl.hpp>
 #endif
 #endif

--- a/test/unit/math/opencl/matrix_cl_test.cpp
+++ b/test/unit/math/opencl/matrix_cl_test.cpp
@@ -2,6 +2,7 @@
 #include <stan/math/prim/mat/fun/typedefs.hpp>
 #include <stan/math/opencl/opencl_context.hpp>
 #include <stan/math/opencl/matrix_cl.hpp>
+#include <stan/math/opencl/copy.hpp>
 #include <stan/math/opencl/sub_block.hpp>
 #include <gtest/gtest.h>
 #include <algorithm>
@@ -25,5 +26,24 @@ TEST(MathMatrixCL, matrix_cl_types_creation) {
   test_matrix_creation<int>();
   test_matrix_creation<long double>();
 }
+
+#ifdef STAN_OPENCL_CACHE
+TEST(MathMatrixCL, matrix_cl_cache) {
+  using stan::math::matrix_cl;
+  Eigen::MatrixXd m(2,2);
+  m << 1, 2, 3, 4;
+
+  const matrix_cl<double> m1_cl = matrix_cl<double>::constant(m);
+
+  cl_mem mem_handle = m.opencl_buffer_();
+  EXPECT_EQ(mem_handle, m1_cl.buffer()());
+
+  const matrix_cl<double> m2_cl = matrix_cl<double>::constant(m);
+
+  EXPECT_EQ(mem_handle, m.opencl_buffer_());
+  EXPECT_EQ(mem_handle, m1_cl.buffer()());
+  EXPECT_EQ(mem_handle, m2_cl.buffer()());
+}
+#endif
 
 #endif

--- a/test/unit/math/opencl/matrix_cl_test.cpp
+++ b/test/unit/math/opencl/matrix_cl_test.cpp
@@ -27,7 +27,7 @@ TEST(MathMatrixCL, matrix_cl_types_creation) {
   test_matrix_creation<long double>();
 }
 
-#ifdef STAN_OPENCL_CACHE
+#ifndef STAN_OPENCL_NOCACHE
 TEST(MathMatrixCL, matrix_cl_cache) {
   using stan::math::matrix_cl;
   Eigen::MatrixXd m(2, 2);
@@ -44,6 +44,27 @@ TEST(MathMatrixCL, matrix_cl_cache) {
   EXPECT_EQ(mem_handle, m1_cl.buffer()());
   EXPECT_EQ(mem_handle, m2_cl.buffer()());
 }
+#else
+TEST(MathMatrixCL, matrix_cl_nocache) {
+  using stan::math::matrix_cl;
+  Eigen::MatrixXd m(2, 2);
+  m << 1, 2, 3, 4;
+
+  const matrix_cl<double> m1_cl = matrix_cl<double>::constant(m);
+  const matrix_cl<double> m2_cl = matrix_cl<double>::constant(m);
+
+  EXPECT_NE(m1_cl.buffer()(), m2_cl.buffer()());
+}
 #endif
 
+TEST(MathMatrixCL, matrix_cl_constructor_nocache) {
+  using stan::math::matrix_cl;
+  Eigen::MatrixXd m(2, 2);
+  m << 1, 2, 3, 4;
+
+  const matrix_cl<double> m1_cl(m);
+  const matrix_cl<double> m2_cl(m);
+
+  EXPECT_NE(m1_cl.buffer()(), m2_cl.buffer()());
+}
 #endif

--- a/test/unit/math/opencl/matrix_cl_test.cpp
+++ b/test/unit/math/opencl/matrix_cl_test.cpp
@@ -30,7 +30,7 @@ TEST(MathMatrixCL, matrix_cl_types_creation) {
 #ifdef STAN_OPENCL_CACHE
 TEST(MathMatrixCL, matrix_cl_cache) {
   using stan::math::matrix_cl;
-  Eigen::MatrixXd m(2,2);
+  Eigen::MatrixXd m(2, 2);
   m << 1, 2, 3, 4;
 
   const matrix_cl<double> m1_cl = matrix_cl<double>::constant(m);

--- a/test/unit/math/rev/mat/meta/operands_and_partials_test.cpp
+++ b/test/unit/math/rev/mat/meta/operands_and_partials_test.cpp
@@ -3,6 +3,10 @@
 #include <gtest/gtest.h>
 #include <vector>
 
+#if defined(STAN_OPENCL) && !defined(STAN_OPENCL_NOCACHE)
+#include <CL/cl.hpp>
+#endif
+
 TEST(AgradPartialsVari, OperandsAndPartialsScal) {
   using stan::math::operands_and_partials;
   using stan::math::var;
@@ -290,9 +294,13 @@ TEST(AgradPartialsVari, OperandsAndPartialsMultivarMixed) {
   o4.edge1_.partials_vec_[0] += d_vec1;
   o4.edge3_.partials_vec_[0] += d_vec2;
 
+#if defined(STAN_OPENCL) && !defined(STAN_OPENCL_NOCACHE)
+  EXPECT_EQ(2 * sizeof(d_vec1) + 6 * sizeof(&v_vec) - sizeof(cl::Buffer), sizeof(o4));
+#else
   // 2 partials stdvecs, 4 pointers to edges, 2 pointers to operands
   // vecs
   EXPECT_EQ(2 * sizeof(d_vec1) + 6 * sizeof(&v_vec), sizeof(o4));
+#endif
 
   std::vector<double> grad;
   var v = o4.build(10.0);

--- a/test/unit/math/rev/mat/meta/operands_and_partials_test.cpp
+++ b/test/unit/math/rev/mat/meta/operands_and_partials_test.cpp
@@ -295,7 +295,8 @@ TEST(AgradPartialsVari, OperandsAndPartialsMultivarMixed) {
   o4.edge3_.partials_vec_[0] += d_vec2;
 
 #if defined(STAN_OPENCL) && !defined(STAN_OPENCL_NOCACHE)
-  EXPECT_EQ(2 * sizeof(d_vec1) + 6 * sizeof(&v_vec) - sizeof(cl::Buffer), sizeof(o4));
+  EXPECT_EQ(2 * sizeof(d_vec1) + 6 * sizeof(&v_vec) - sizeof(cl::Buffer),
+            sizeof(o4));
 #else
   // 2 partials stdvecs, 4 pointers to edges, 2 pointers to operands
   // vecs


### PR DESCRIPTION
## Summary

Implements option for caching of matrices on GPU. Compared to PR #1065 this is simpler as only constant matrices are cached.

## Tests

Added a test to `matrix_cl_test.cpp`.

## Side Effects
caching  - `matrix_cl<T>::constant()` should only be used on matrices that do not change.

## Checklist

- [x] Math issue #1319 

- [x] Copyright holder: Tadej Ciglarič (University of Ljubljana)

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
