### PR TITLE
Adds const ref and ref returns for to_var/fvar methods

### DIFF
--- a/stan/math/fwd/mat/fun/to_fvar.hpp
+++ b/stan/math/fwd/mat/fun/to_fvar.hpp
@@ -10,9 +10,10 @@ namespace stan {
 namespace math {
 
 template <int R, int C, typename T>
-inline Eigen::Matrix<T, R, C> to_fvar(const Eigen::Matrix<T, R, C>& m) {
-  return m;
-}
+inline const Eigen::Matrix<T, R, C> to_fvar(const Eigen::Matrix<T, R, C>& m) {return m;}
+
+template <int R, int C, typename T>
+inline Eigen::Matrix<T, R, C>& to_fvar(Eigen::Matrix<T, R, C>& m) {return m;}
 
 template <int R, int C>
 inline Eigen::Matrix<fvar<double>, R, C> to_fvar(

--- a/stan/math/fwd/scal/fun/to_fvar.hpp
+++ b/stan/math/fwd/scal/fun/to_fvar.hpp
@@ -13,9 +13,10 @@ inline fvar<T> to_fvar(const T& x) {
 }
 
 template <typename T>
-inline fvar<T> to_fvar(const fvar<T>& x) {
-  return x;
-}
+inline const fvar<T>& to_fvar(const fvar<T>& x) { return x; }
+
+template <typename T>
+inline fvar<T>& to_fvar(fvar<T>& x) { return x; }
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/rev/arr/fun/to_var.hpp
+++ b/stan/math/rev/arr/fun/to_var.hpp
@@ -31,7 +31,8 @@ inline std::vector<var> to_var(const std::vector<double>& v) {
  * @param[in] v A std::vector<var>
  * @return A std::vector<var>
  */
-inline std::vector<var> to_var(const std::vector<var>& v) { return v; }
+inline const std::vector<var>& to_var(const std::vector<var>& v) { return v; }
+inline std::vector<var>& to_var(std::vector<var>& v) { return v; }
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/rev/mat/fun/to_var.hpp
+++ b/stan/math/rev/mat/fun/to_var.hpp
@@ -31,7 +31,8 @@ inline matrix_v to_var(const matrix_d& m) {
  * @param[in] m A Matrix with automatic differentiation variables.
  * @return A Matrix with automatic differentiation variables.
  */
-inline matrix_v to_var(const matrix_v& m) { return m; }
+inline matrix_v& to_var(matrix_v& m) { return m; }
+inline const matrix_v& to_var(const matrix_v& m) { return m; }
 /**
  * Converts argument to an automatic differentiation variable.
  *
@@ -54,7 +55,8 @@ inline vector_v to_var(const vector_d& v) {
  * @return A Vector of automatic differentiation variables with
  *   values of v
  */
-inline vector_v to_var(const vector_v& v) { return v; }
+inline const vector_v& to_var(const vector_v& v) { return v; }
+inline vector_v& to_var(vector_v& v) { return v; }
 /**
  * Converts argument to an automatic differentiation variable.
  *
@@ -77,7 +79,8 @@ inline row_vector_v to_var(const row_vector_d& rv) {
  * @return A row vector with automatic differentiation variables
  *    with values of rv.
  */
-inline row_vector_v to_var(const row_vector_v& rv) { return rv; }
+inline const row_vector_v& to_var(const row_vector_v& rv) { return rv; }
+inline row_vector_v& to_var(row_vector_v& rv) { return rv; }
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/rev/scal/fun/to_var.hpp
+++ b/stan/math/rev/scal/fun/to_var.hpp
@@ -25,7 +25,8 @@ inline var to_var(double x) { return var(x); }
  * @param[in] x An automatic differentiation variable.
  * @return An automatic differentiation variable with the input value.
  */
-inline var to_var(const var& x) { return x; }
+inline var& to_var(var& x) { return x; }
+inline const var& to_var(const var& x) { return x; }
 
 }  // namespace math
 }  // namespace stan


### PR DESCRIPTION
## Summary

The functions `to_var` and `to_fvar` looked like

```cpp
inline matrix_v to_var(const matrix_v& m) { return m; }
```

So in cases of an rvalue on input for the above this would cause a copy (I'm pretty sure because of the const on input that's right?). We know for these specializations they are in/out style functions and can change them like the below so rvalues don't have to be copied and instead references are moved through the function

```cpp
inline const vector_v& to_var(const vector_v& v) { return v; }
inline vector_v& to_var(vector_v& v) { return v; }
```

## Tests

refactor so no new tests

## Side Effects

When `to_var` receives a container filled with vars already it will return a reference to the input container.

## Checklist

- [ ] Math issue #(issue number)

- [x] Copyright holder: Steve Bronder

- [ ] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
