### PR TITLE
Remove EXPECT_DEATH unit tests that fail when -NDEBUG is set 

### DIFF
--- a/test/unit/math/prim/mat/err/check_pos_definite_test.cpp
+++ b/test/unit/math/prim/mat/err/check_pos_definite_test.cpp
@@ -46,15 +46,6 @@ TEST_F(ErrorHandlingMatrix, checkPosDefinite_not_square) {
                << "y (4) must match in size";
   EXPECT_THROW_MSG(check_pos_definite(function, "y", y), std::invalid_argument,
                    expected_msg.str());
-  y.resize(2, 3);
-  y << 1, 1, 1, 1, 1, 1;
-  Eigen::LLT<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> > llt(
-      y.rows());
-  // FIXME
-  // Linux behavior for handling assertion thrown by llt.compute(y)
-  // differs from mac; produces a core dump
-  EXPECT_DEATH(llt.compute(y), "");
-  EXPECT_DEATH(y.ldlt(), "");
 }
 
 TEST_F(ErrorHandlingMatrix, checkPosDefinite_0_size) {
@@ -71,9 +62,6 @@ TEST_F(ErrorHandlingMatrix, checkPosDefinite_0_size) {
       x.rows());
   llt.compute(x);
   EXPECT_NO_THROW(check_pos_definite(function, "x", llt));
-  Eigen::LDLT<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> > ldlt(
-      x.rows());
-  EXPECT_DEATH(ldlt.compute(x), "");
 }
 
 TEST_F(ErrorHandlingMatrix, checkPosDefinite_non_symmetric) {

--- a/test/unit/math/prim/mat/err/is_pos_definite_test.cpp
+++ b/test/unit/math/prim/mat/err/is_pos_definite_test.cpp
@@ -39,15 +39,6 @@ TEST_F(ErrorHandlingMatrix, isPosDefinite) {
 TEST_F(ErrorHandlingMatrix, isPosDefinite_not_square) {
   y.resize(3, 4);
   EXPECT_FALSE(is_pos_definite(y));
-  y.resize(2, 3);
-  y << 1, 1, 1, 1, 1, 1;
-  Eigen::LLT<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> > llt(
-      y.rows());
-  // FIXME
-  // Linux behavior for handling assertion thrown by llt.compute(y)
-  // differs from mac; produces a core dump
-  EXPECT_DEATH(llt.compute(y), "");
-  EXPECT_DEATH(y.ldlt(), "");
 }
 
 TEST_F(ErrorHandlingMatrix, isPosDefinite_0_size) {
@@ -59,10 +50,6 @@ TEST_F(ErrorHandlingMatrix, isPosDefinite_0_size) {
       x.rows());
   llt.compute(x);
   EXPECT_TRUE(is_pos_definite(llt));
-
-  Eigen::LDLT<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> > ldlt(
-      x.rows());
-  EXPECT_DEATH(ldlt.compute(x), "");
 }
 
 TEST_F(ErrorHandlingMatrix, isPosDefinite_non_symmetric) {


### PR DESCRIPTION
## Summary

This solves #1313 

The tests that are being removed for 2 reasons:
- they are testing direct `Eigen` function calls which is not something we need to test in the first place
- the tests cant and will not work when `-NDEBUG` is set

## Tests

Some tests are being removed.

## Side Effects

We are now not testing some Eigen functionalities, but I dont think that is bad. We are working under the assumption that Eigen works.

## Checklist

- [x] Math issue #1313

- [x] Copyright holder: Rok Češnovar

- [x] the basic tests are passing

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
