### PR TITLE
Implement normal_id_glm_lpdf in OpenCL

### DIFF
--- a/stan/math/opencl/copy.hpp
+++ b/stan/math/opencl/copy.hpp
@@ -69,10 +69,10 @@ inline matrix_cl<T> to_matrix_cl(const Eigen::Matrix<T, R, C>& src) {
  * @param src source matrix on the OpenCL device
  * @return Eigen matrix with a copy of the data in the source matrix
  */
-template <typename T, typename = enable_if_arithmetic<T>>
-inline Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> from_matrix_cl(
+template <int R = Eigen::Dynamic, int C=Eigen::Dynamic, typename T, typename = enable_if_arithmetic<T>>
+inline Eigen::Matrix<T, R, C> from_matrix_cl(
     const matrix_cl<T>& src) {
-  Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> dst(src.rows(), src.cols());
+  Eigen::Matrix<T, R, C> dst(src.rows(), src.cols());
   if (src.size() == 0) {
     return dst;
   }

--- a/stan/math/opencl/kernels/normal_id_glm_lpdf.hpp
+++ b/stan/math/opencl/kernels/normal_id_glm_lpdf.hpp
@@ -1,0 +1,136 @@
+#ifndef STAN_MATH_OPENCL_KERNELS_NORMAL_ID_GLM_LPDF_HPP
+#define STAN_MATH_OPENCL_KERNELS_NORMAL_ID_GLM_LPDF_HPP
+#ifdef STAN_OPENCL
+
+#include <stan/math/opencl/kernel_cl.hpp>
+
+namespace stan {
+namespace math {
+namespace opencl_kernels {
+
+// \cond
+static const char *normal_id_glm_kernel_code = STRINGIFY(
+// \endcond
+        /**
+         * GPU implementation of Generalized Linear Model (GLM)
+         * with Normal distribution and identity link function.
+         *
+         * Must be run with at least N threads and local size equal to LOCAL_SIZE_.
+         * @param[in] y_glob vector parameter
+         * @param[in] x design matrix
+         * @param[in] alpha intercept (in log odds)
+         * @param[in] beta weight vector
+         * @param[in] sigma_glob (Sequence of) scale parameters for the normal
+         * @param[out] mu_derivative_glob intermediate variable used in the model
+         * @param[out] mu_derivative_sum partially summed mu_derivative_glob (1 value per work group)
+         * @param[out] y_minus_mu_over_sigma_squared_sum intermediate variable used in the model
+         * @param[out] sigma_derivative derivative with respect to sigma
+         * @param[out] partially summed logarithm of sigma (1 value per work group)
+         * @param N number of cases
+         * @param M number of attributes
+         * @param is_alpha_vector 0 or 1 - whether alpha is a vector (alternatively it is a scalar)
+         * @param is_sigma_vector 0 or 1 - whether sigma is a vector (alternatively it is a scalar)
+         * @param need_mu_derivative interpreted as boolean - whether mu_derivative needs to be computed
+         * @param need_mu_derivative_sum interpreted as boolean - whether mu_derivative_sum needs to be computed
+         * @param need_sigma_derivative interpreted as boolean - whether sigma_derivative needs to be computed
+         * @param need_log_sigma_sum interpreted as boolean - whether log_sigma_sum needs to be computed
+         */
+        __kernel void normal_id_glm(const __global double* y_glob, const __global double* x, const __global double* alpha, const __global double* beta, const __global double* sigma_glob,
+                                          __global double* mu_derivative_glob, __global double* mu_derivative_sum, __global double* y_minus_mu_over_sigma_squared_sum,
+                                          __global double* sigma_derivative, __global double* log_sigma_sum,
+                                          const int N, const int M, const int is_alpha_vector, const int is_sigma_vector, const int need_mu_derivative, const int need_mu_derivative_sum,
+                                          const int need_sigma_derivative, const int need_log_sigma_sum) {
+          const int gid = get_global_id(0);
+          const int lid = get_local_id(0);
+          const int lsize = get_local_size(0);
+          const int wgid = get_group_id(0);
+
+          __local double res_loc[LOCAL_SIZE_];
+
+          double y_minus_mu_over_sigma_squared = 0;
+          double log_sigma = 0;
+          double mu_derivative = 0;
+          if(gid<N){
+            double y_minus_mu_over_sigma=0;
+            for (int i = 0, j = 0; i < M; i++, j += N) {
+              y_minus_mu_over_sigma += x[j + gid] * beta[i];
+            }
+            double sigma = sigma_glob[gid * is_sigma_vector];
+            double inv_sigma = 1 / sigma;
+            y_minus_mu_over_sigma = (y_glob[gid] - y_minus_mu_over_sigma - alpha[gid*is_alpha_vector]) * inv_sigma;
+            mu_derivative = inv_sigma * y_minus_mu_over_sigma;
+            if(need_mu_derivative){
+              mu_derivative_glob[gid]=mu_derivative;
+            }
+            y_minus_mu_over_sigma_squared = y_minus_mu_over_sigma * y_minus_mu_over_sigma;
+            if(need_sigma_derivative){
+              sigma_derivative[gid]=(y_minus_mu_over_sigma_squared - 1) * inv_sigma;
+            }
+            if(need_log_sigma_sum){
+              log_sigma=log(sigma);
+            }
+          }
+          res_loc[lid] = y_minus_mu_over_sigma_squared;
+          barrier(CLK_LOCAL_MEM_FENCE);
+          for (int step = lsize / REDUCTION_STEP_SIZE; step > 0; step /= REDUCTION_STEP_SIZE) {
+            if (lid < step) {
+              for (int i = 1; i < REDUCTION_STEP_SIZE; i++) {
+                res_loc[lid] += res_loc[lid + step * i];
+              }
+            }
+            barrier(CLK_LOCAL_MEM_FENCE);
+          }
+          if (lid == 0) {
+            y_minus_mu_over_sigma_squared_sum[wgid] = res_loc[0];
+          }
+
+          if(need_mu_derivative_sum){
+            barrier(CLK_LOCAL_MEM_FENCE);
+            res_loc[lid] = mu_derivative;
+            barrier(CLK_LOCAL_MEM_FENCE);
+            for (int step = lsize / REDUCTION_STEP_SIZE; step > 0; step /= REDUCTION_STEP_SIZE) {
+              if (lid < step) {
+                for (int i = 1; i < REDUCTION_STEP_SIZE; i++) {
+                  res_loc[lid] += res_loc[lid + step * i];
+                }
+              }
+              barrier(CLK_LOCAL_MEM_FENCE);
+            }
+            if (lid == 0) {
+              mu_derivative_sum[wgid] = res_loc[0];
+            }
+          }
+
+          if(need_log_sigma_sum){
+            barrier(CLK_LOCAL_MEM_FENCE);
+            res_loc[lid] = log_sigma;
+            barrier(CLK_LOCAL_MEM_FENCE);
+            for (int step = lsize / REDUCTION_STEP_SIZE; step > 0; step /= REDUCTION_STEP_SIZE) {
+              if (lid < step) {
+                for (int i = 1; i < REDUCTION_STEP_SIZE; i++) {
+                  res_loc[lid] += res_loc[lid + step * i];
+                }
+              }
+              barrier(CLK_LOCAL_MEM_FENCE);
+            }
+            if (lid == 0) {
+              log_sigma_sum[wgid] = res_loc[0];
+            }
+          }
+        }
+// \cond
+);
+// \endcond
+
+/**
+ * See the docs for \link kernels/bernoulli_logit_glm_lpmf.hpp bernoulli_logit_glm() \endlink
+ */
+const kernel_cl<in_buffer, in_buffer, in_buffer, in_buffer, in_buffer, out_buffer, out_buffer, out_buffer, out_buffer, out_buffer, int, int, int, int, int, int, int, int>
+        normal_id_glm("normal_id_glm", {normal_id_glm_kernel_code}, {{"REDUCTION_STEP_SIZE",4},{"LOCAL_SIZE_", 64}});
+
+}  // namespace opencl_kernels
+}  // namespace math
+}  // namespace stan
+
+#endif
+#endif //STAN_MATH_OPENCL_KERNELS_NORMAL_ID_GLM_LPDF_HPP

--- a/stan/math/opencl/opencl_context.hpp
+++ b/stan/math/opencl/opencl_context.hpp
@@ -205,6 +205,9 @@ class opencl_context_base {
     // used in math/prim/mat/fun/mdivide_left_tri
     // and math/rev/mat/fun/mdivide_left_tri
     int tri_inverse_size_worth_transfer = 100;
+    // Used in stan/math/prim/mat/prob/normal_id_glm_lpdf
+    double normal_id_glm_coeff1 = 5.89929748e-07;
+    double normal_id_glm_coeff2 = 3.23325415e-06;
   } tuning_opts_;
 
   static opencl_context_base& getInstance() {

--- a/stan/math/prim/mat/prob/normal_id_glm_lpdf.hpp
+++ b/stan/math/prim/mat/prob/normal_id_glm_lpdf.hpp
@@ -9,6 +9,11 @@
 #include <stan/math/prim/scal/fun/size_zero.hpp>
 #include <stan/math/prim/scal/fun/sum.hpp>
 #include <stan/math/prim/arr/fun/value_of_rec.hpp>
+
+#include <stan/math/opencl/kernels/normal_id_glm_lpdf.hpp>
+#include <stan/math/opencl/matrix_cl.hpp>
+#include <stan/math/opencl/multiply.hpp>
+
 #include <cmath>
 
 namespace stan {
@@ -61,6 +66,7 @@ return_type_t<T_y, T_x, T_alpha, T_beta, T_scale> normal_id_glm_lpdf(
   using Eigen::Array;
   using Eigen::Dynamic;
   using Eigen::Matrix;
+  using Eigen::VectorXd;
 
   const size_t N = x.rows();
   const size_t M = x.cols();
@@ -92,56 +98,129 @@ return_type_t<T_y, T_x, T_alpha, T_beta, T_scale> normal_id_glm_lpdf(
   const auto &y_val_vec = as_column_vector_or_scalar(y_val);
 
   T_scale_val inv_sigma = 1 / as_array_or_scalar(sigma_val_vec);
-
-  Array<T_partials_return, Dynamic, 1> y_minus_mu_over_sigma
-      = x_val * beta_val_vec;
-  y_minus_mu_over_sigma = (as_array_or_scalar(y_val_vec) - y_minus_mu_over_sigma
-                           - as_array_or_scalar(alpha_val_vec))
-                          * inv_sigma;
-
-  // Compute the derivatives.
+  Matrix<T_partials_return, Dynamic, 1> y_minus_mu_over_sigma_mat(N);
+  auto y_minus_mu_over_sigma = y_minus_mu_over_sigma_mat.array();
+  
   operands_and_partials<T_y, T_x, T_alpha, T_beta, T_scale> ops_partials(
-      y, x, alpha, beta, sigma);
+          y, x, alpha, beta, sigma);
+
   double y_minus_mu_over_sigma_squared_sum;  // the most efficient way to
-                                             // calculate this depends on
-                                             // template parameters
-  if (!is_constant_all<T_y, T_x, T_beta, T_alpha>::value) {
-    Matrix<T_partials_return, Dynamic, 1> mu_derivative
-        = inv_sigma * y_minus_mu_over_sigma;
-    if (!is_constant_all<T_y>::value) {
-      ops_partials.edge1_.partials_ = -mu_derivative;
+  // calculate this depends on
+  // template parameters
+  
+#ifdef STAN_OPENCL
+  bool use_opencl = N * M * opencl_context.tuning_opts().normal_id_glm_coeff1 + N * opencl_context.tuning_opts().normal_id_glm_coeff2 > 1;
+  if(use_opencl) {
+    const int local_size = opencl_kernels::normal_id_glm.make_functor.get_opts().at("LOCAL_SIZE_");
+    const int wgs = (N + local_size - 1) / local_size;
+
+    const matrix_cl<double> y_cl = matrix_cl<double>::constant(y_val_vec);
+    const matrix_cl<double> x_cl = matrix_cl<double>::constant(x_val);
+    matrix_cl<double> beta_cl(beta_val_vec);
+    matrix_cl<double> alpha_cl(alpha_val_vec);
+    matrix_cl<double> sigma_cl(sigma_val_vec);
+
+    const bool need_mu_derivative = !is_constant_all<T_y,T_x,T_beta,T_alpha>::value;
+    matrix_cl<double> mu_derivative_cl(need_mu_derivative ? N : 0, 1);
+    const bool need_mu_derivative_sum = !is_constant_all<T_alpha>::value && !is_vector<T_alpha>::value;
+    matrix_cl<double> mu_derivative_sum_cl(need_mu_derivative_sum ? wgs : 0, 1);
+    matrix_cl<double> y_minus_mu_over_sigma_squared_sum_cl(wgs, 1);
+    const bool need_sigma_derivative = !is_constant_all<T_scale>::value && is_vector<T_scale>::value;
+    matrix_cl<double> sigma_derivative_cl(need_sigma_derivative ? N : 0, 1);
+    const bool need_log_sigma_sum = include_summand<propto, T_scale>::value && is_vector<T_scale>::value;
+    matrix_cl<double> log_sigma_sum_cl(need_log_sigma_sum ? wgs : 0, 1);
+
+    try {
+      opencl_kernels::normal_id_glm(cl::NDRange(local_size * wgs), cl::NDRange(local_size),
+                                    y_cl, x_cl, alpha_cl, beta_cl, sigma_cl,
+                                    mu_derivative_cl, mu_derivative_sum_cl, y_minus_mu_over_sigma_squared_sum_cl, sigma_derivative_cl, log_sigma_sum_cl,
+                                    N, M, length(alpha) != 1, length(sigma) != 1, need_mu_derivative, need_mu_derivative_sum, need_sigma_derivative, need_log_sigma_sum);
+    }
+    catch (const cl::Error& e) {
+      check_opencl_error(function, e);
+    }
+    y_minus_mu_over_sigma_squared_sum = sum(from_matrix_cl(y_minus_mu_over_sigma_squared_sum_cl));
+
+    if (!is_constant_all<T_y,T_x>::value || (!is_constant_all<T_alpha>::value && is_vector<T_alpha>::value)) {
+      Matrix<T_partials_return, Dynamic, 1> mu_derivative = from_matrix_cl(mu_derivative_cl);
+      if (!is_constant_all<T_y>::value) {
+        ops_partials.edge1_.partials_ = -mu_derivative;
+      }
+      if (!is_constant_all<T_alpha>::value && is_vector<T_alpha>::value) {
+        ops_partials.edge3_.partials_ = std::move(mu_derivative);
+      }
+    }
+    if (!is_constant_all<T_alpha>::value && !is_vector<T_alpha>::value) {
+      ops_partials.edge3_.partials_[0] = sum(from_matrix_cl(mu_derivative_sum_cl));
     }
     if (!is_constant_all<T_x>::value) {
-      ops_partials.edge2_.partials_
-          = (beta_val_vec * mu_derivative.transpose()).transpose();
+      const matrix_cl<double> beta_transpose_cl(beta_cl.buffer(), 1, beta_cl.rows()); //transposition of a vector can be done without copying
+      ops_partials.edge2_.partials_ = from_matrix_cl(mu_derivative_cl * beta_transpose_cl);
     }
     if (!is_constant_all<T_beta>::value) {
-      ops_partials.edge4_.partials_ = mu_derivative.transpose() * x_val;
-    }
-    if (!is_constant_all<T_alpha>::value) {
-      if (is_vector<T_alpha>::value)
-        ops_partials.edge3_.partials_ = mu_derivative;
-      else
-        ops_partials.edge3_.partials_[0] = sum(mu_derivative);
+      const matrix_cl<double> mu_derivative_transpose_cl(mu_derivative_cl.buffer(), 1, mu_derivative_cl.rows()); //transposition of a vector can be done without copying
+      ops_partials.edge4_.partials_ = from_matrix_cl<1, Dynamic>(mu_derivative_transpose_cl * x_cl);
     }
     if (!is_constant_all<T_scale>::value) {
       if (is_vector<T_scale>::value) {
-        Array<T_partials_return, Dynamic, 1> y_minus_mu_over_sigma_squared
-            = y_minus_mu_over_sigma * y_minus_mu_over_sigma;
-        y_minus_mu_over_sigma_squared_sum = sum(y_minus_mu_over_sigma_squared);
-        ops_partials.edge5_.partials_
-            = (y_minus_mu_over_sigma_squared - 1) * inv_sigma;
-      } else {
-        y_minus_mu_over_sigma_squared_sum
-            = sum(y_minus_mu_over_sigma * y_minus_mu_over_sigma);
+        ops_partials.edge5_.partials_ = from_matrix_cl<Dynamic,1>(sigma_derivative_cl);
+      }
+      else {
         ops_partials.edge5_.partials_[0]
-            = (y_minus_mu_over_sigma_squared_sum - N) * as_scalar(inv_sigma);
+                = (y_minus_mu_over_sigma_squared_sum - N) * as_scalar(inv_sigma);
       }
     }
-  } else {
-    y_minus_mu_over_sigma_squared_sum
-        = sum(y_minus_mu_over_sigma * y_minus_mu_over_sigma);
   }
+  else {
+#endif
+    y_minus_mu_over_sigma = x_val * beta_val_vec;
+    y_minus_mu_over_sigma = (as_array_or_scalar(y_val_vec) - y_minus_mu_over_sigma
+                             - as_array_or_scalar(alpha_val_vec))
+                            * inv_sigma;
+
+    if (!(is_constant_all<T_y,T_x,T_beta,T_alpha>::value)) {
+      Matrix<T_partials_return, Dynamic, 1> mu_derivative
+          = inv_sigma * y_minus_mu_over_sigma;
+      if (!is_constant_all<T_y>::value) {
+        ops_partials.edge1_.partials_ = -mu_derivative;
+      }
+      if (!is_constant_all<T_x>::value) {
+        ops_partials.edge2_.partials_
+                = (beta_val_vec * mu_derivative.transpose()).transpose();
+      }
+      if (!is_constant_all<T_beta>::value) {
+        ops_partials.edge4_.partials_ = mu_derivative.transpose() * x_val;
+      }
+      if (!is_constant_all<T_alpha>::value) {
+        if (is_vector<T_alpha>::value)
+          ops_partials.edge3_.partials_ = mu_derivative;
+        else {
+          ops_partials.edge3_.partials_[0] = sum(mu_derivative);
+        }
+      }
+      if (!is_constant_all<T_scale>::value) {
+        if (is_vector<T_scale>::value) {
+          Array<T_partials_return, Dynamic, 1> y_minus_mu_over_sigma_squared
+              = y_minus_mu_over_sigma * y_minus_mu_over_sigma;
+          y_minus_mu_over_sigma_squared_sum = sum(y_minus_mu_over_sigma_squared);
+          ops_partials.edge5_.partials_
+              = (y_minus_mu_over_sigma_squared - 1) * inv_sigma;
+        }
+        else {
+          y_minus_mu_over_sigma_squared_sum
+              = sum(y_minus_mu_over_sigma * y_minus_mu_over_sigma);
+          ops_partials.edge5_.partials_[0]
+                  = (y_minus_mu_over_sigma_squared_sum - N) * as_scalar(inv_sigma);
+        }
+      }
+    }
+    else {
+      y_minus_mu_over_sigma_squared_sum
+          = sum(y_minus_mu_over_sigma * y_minus_mu_over_sigma);
+    }
+#ifdef STAN_OPENCL
+  }
+#endif
 
   if (!std::isfinite(y_minus_mu_over_sigma_squared_sum)) {
     check_finite(function, "Vector of dependent variables", y);

--- a/test/unit/math/rev/mat/prob/normal_id_glm_lpdf_test.cpp
+++ b/test/unit/math/rev/mat/prob/normal_id_glm_lpdf_test.cpp
@@ -8,9 +8,17 @@ using Eigen::Dynamic;
 using Eigen::Matrix;
 using stan::math::var;
 
+void set_tuning_opts_to_use_gpu() {
+#ifdef STAN_OPENCL
+  stan::math::opencl_context.tuning_opts().normal_id_glm_coeff1 = 1;
+  stan::math::opencl_context.tuning_opts().normal_id_glm_coeff2 = 1;
+#endif
+}
+
 //  We check that the values of the new regression match those of one built
 //  from existing primitives.
 TEST(ProbDistributionsNormalIdGLM, glm_matches_normal_id_doubles) {
+  set_tuning_opts_to_use_gpu();
   Matrix<double, Dynamic, 1> y(3, 1);
   y << 51, 32, 12;
   Matrix<double, Dynamic, Dynamic> x(3, 2);
@@ -31,6 +39,7 @@ TEST(ProbDistributionsNormalIdGLM, glm_matches_normal_id_doubles) {
 //  We check that the values of the new regression match those of one built
 //  from existing primitives.
 TEST(ProbDistributionsNormalIdGLM, glm_matches_normal_id_doubles_rand) {
+  set_tuning_opts_to_use_gpu();
   for (size_t ii = 0; ii < 200; ii++) {
     Matrix<double, Dynamic, 1> y(3, 1);
     for (size_t i = 0; i < 3; i++) {
@@ -59,6 +68,7 @@ TEST(ProbDistributionsNormalIdGLM, glm_matches_normal_id_doubles_rand) {
 //  We check that the gradients of the new regression match those of one built
 //  from existing primitives.
 TEST(ProbDistributionsNormalIdGLM, glm_matches_normal_id_vars) {
+  set_tuning_opts_to_use_gpu();
   Matrix<var, Dynamic, 1> y(3, 1);
   y << 14, 32, 21;
   Matrix<var, Dynamic, Dynamic> x(3, 2);
@@ -118,6 +128,7 @@ TEST(ProbDistributionsNormalIdGLM, glm_matches_normal_id_vars) {
 //  We check that the gradients of the new regression match those of one built
 //  from existing primitives.
 TEST(ProbDistributionsNormalIdGLM, glm_matches_normal_id_vars_rand) {
+  set_tuning_opts_to_use_gpu();
   for (size_t ii = 0; ii < 42; ii++) {
     Matrix<double, Dynamic, 1> yreal = Matrix<double, Dynamic, 1>::Random(3, 1);
     Matrix<double, Dynamic, Dynamic> xreal
@@ -180,6 +191,7 @@ TEST(ProbDistributionsNormalIdGLM, glm_matches_normal_id_vars_rand) {
 //  We check that the gradients of the new regression match those of one built
 //  from existing primitives, in case beta is a scalar.
 TEST(ProbDistributionsNormalIdGLM, glm_matches_normal_id_vars_rand_scal_beta) {
+  set_tuning_opts_to_use_gpu();
   for (size_t ii = 0; ii < 42; ii++) {
     Matrix<double, Dynamic, 1> yreal = Matrix<double, Dynamic, 1>::Random(3, 1);
     Matrix<double, Dynamic, Dynamic> xreal
@@ -234,6 +246,7 @@ TEST(ProbDistributionsNormalIdGLM, glm_matches_normal_id_vars_rand_scal_beta) {
 //  We check that the gradients of the new regression match those of one built
 //  from existing primitives.
 TEST(ProbDistributionsNormalIdGLM, glm_matches_normal_id_varying_intercept) {
+  set_tuning_opts_to_use_gpu();
   for (size_t ii = 0; ii < 42; ii++) {
     Matrix<double, Dynamic, 1> yreal = Matrix<double, Dynamic, 1>::Random(3, 1);
     Matrix<double, Dynamic, Dynamic> xreal
@@ -298,6 +311,7 @@ TEST(ProbDistributionsNormalIdGLM, glm_matches_normal_id_varying_intercept) {
 //  from existing primitives.
 TEST(ProbDistributionsNormalIdGLM,
      glm_matches_normal_id_varying_intercept_and_scale) {
+  set_tuning_opts_to_use_gpu();
   for (size_t ii = 0; ii < 42; ii++) {
     Matrix<double, Dynamic, 1> yreal = Matrix<double, Dynamic, 1>::Random(3, 1);
     Matrix<double, Dynamic, Dynamic> xreal
@@ -363,6 +377,7 @@ TEST(ProbDistributionsNormalIdGLM,
 
 //  We check that we can instantiate all different interface types.
 TEST(ProbDistributionsNormalIdGLM, glm_matches_normal_id_interface_types) {
+  set_tuning_opts_to_use_gpu();
   double value = 0;
   double value2 = 0;
 
@@ -403,6 +418,7 @@ TEST(ProbDistributionsNormalIdGLM, glm_matches_normal_id_interface_types) {
 
 //  We check that the right errors are thrown.
 TEST(ProbDistributionsNormalIdGLM, glm_matches_normal_id_error_checking) {
+  set_tuning_opts_to_use_gpu();
   int N = 3;
   int M = 2;
   int W = 4;


### PR DESCRIPTION
## Summary

This implements `normal_id_glm_lpdf()` in OpenCL. A new `matrix_cl<T>` constructor was added that accepts a single scalar. `from_matrix_cl()` has two new template parameters that control compile-time row and column count of returned matrix.

## Tests
Existing `normal_id_glm_lpdf()` tests have been modified to always use GPU if compiling with OpenCL support.

## Side Effects
None.

## Checklist

- [ ] Math issue #1319

- [ ] Copyright holder: Tadej Ciglarič (University of Ljubljana)

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [ ] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [ ] the code is written in idiomatic C++ and changes are documented in the doxygen

- [ ] the new changes are tested
