### PR TITLE
OpenCL asynchronous copy of destroyed object bug demo

### DIFF
--- a/test/unit/math/opencl/copy_test.cpp
+++ b/test/unit/math/opencl/copy_test.cpp
@@ -9,18 +9,20 @@
 #include <vector>
 
 TEST(MathMatrixGPU, copy_destroyed) {
+  using Eigen::Dynamic;
   using Eigen::Matrix;
   using Eigen::MatrixXd;
-  using Eigen::Dynamic;
-  using stan::math::matrix_cl;
   using stan::math::from_matrix_cl;
-  int N=100;
-  MatrixXd a = MatrixXd::Random(N,N);
-  MatrixXd b = MatrixXd::Random(N,N);
-  matrix_cl<double> c_cl(a+b); //the problem
-  MatrixXd w = a - b; //attempt to scramble the memory that was used by the temporary
+  using stan::math::matrix_cl;
+  int N = 100;
+  MatrixXd a = MatrixXd::Random(N, N);
+  MatrixXd b = MatrixXd::Random(N, N);
+  matrix_cl<double> c_cl(a + b);  // the problem
+  MatrixXd w
+      = a - b;  // attempt to scramble the memory that was used by the temporary
 
-  //make compiler think a and b were changed, so second sum can not be optimized away
+  // make compiler think a and b were changed, so second sum can not be
+  // optimized away
   volatile int i = 19;
   volatile double no_opt = a(i);
   a(i) = no_opt;
@@ -29,7 +31,7 @@ TEST(MathMatrixGPU, copy_destroyed) {
 
   MatrixXd correct = a + b;
   MatrixXd result = from_matrix_cl(c_cl);
-  for(int i=0;i<N*N;i++){
+  for (int i = 0; i < N * N; i++) {
     EXPECT_EQ(result(i), correct(i));
   }
   no_opt = w.array().sum();

--- a/test/unit/math/opencl/copy_test.cpp
+++ b/test/unit/math/opencl/copy_test.cpp
@@ -8,6 +8,33 @@
 #include <algorithm>
 #include <vector>
 
+TEST(MathMatrixGPU, copy_destroyed) {
+  using Eigen::Matrix;
+  using Eigen::MatrixXd;
+  using Eigen::Dynamic;
+  using stan::math::matrix_cl;
+  using stan::math::from_matrix_cl;
+  int N=100;
+  MatrixXd a = MatrixXd::Random(N,N);
+  MatrixXd b = MatrixXd::Random(N,N);
+  matrix_cl<double> c_cl(a+b); //the problem
+  MatrixXd w = a - b; //attempt to scramble the memory that was used by the temporary
+
+  //make compiler think a and b were changed, so second sum can not be optimized away
+  volatile int i = 19;
+  volatile double no_opt = a(i);
+  a(i) = no_opt;
+  no_opt = b(i);
+  b(i) = no_opt;
+
+  MatrixXd correct = a + b;
+  MatrixXd result = from_matrix_cl(c_cl);
+  for(int i=0;i<N*N;i++){
+    EXPECT_EQ(result(i), correct(i));
+  }
+  no_opt = w.array().sum();
+}
+
 TEST(MathMatrixGPU, matrix_cl_vector_copy) {
   stan::math::vector_d d1_cpu;
   stan::math::vector_d d1_a_cpu;


### PR DESCRIPTION
## Summary

A test showing a bug in how we construct matrix_cl.

## Tests


## Side Effects


## Checklist

- [x] Math issue #1346 

- [x] Copyright holder: Tadej Ciglarič (University of Ljubljana)

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [ ] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [ ] the code is written in idiomatic C++ and changes are documented in the doxygen

- [ ] the new changes are tested
