### PR TITLE
Revert GPU caching

### DIFF
--- a/stan/math/opencl/matrix_cl.hpp
+++ b/stan/math/opencl/matrix_cl.hpp
@@ -180,19 +180,6 @@ class matrix_cl<T, enable_if_arithmetic<T>> {
   cl::Buffer& buffer() { return buffer_cl_; }
   matrix_cl() : rows_(0), cols_(0) {}
 
-  /**
-   * Construct a matrix_cl<T> from an existing cl::Buffer object. The matrix
-   * directly uses given buffer - no copying is done.
-   *
-   * @param A the cl::Buffer object to construct the matrix from
-   * @param R number of rows
-   * @param C number of columns
-   * @param partial_view view of the matrix
-   */
-  matrix_cl(cl::Buffer& A, const int R, const int C,
-            matrix_cl_view partial_view = matrix_cl_view::Entire)
-      : buffer_cl_(A), rows_(R), cols_(C), view_(partial_view) {}
-
   matrix_cl(const matrix_cl<T>& A)
       : rows_(A.rows()), cols_(A.cols()), view_(A.view()) {
     if (A.size() == 0) {
@@ -378,63 +365,6 @@ class matrix_cl<T, enable_if_arithmetic<T>> {
     } catch (const cl::Error& e) {
       check_opencl_error("matrix constructor", e);
     }
-  }
-
-  /**
-   * Constructs a const matrix_cl that contains a copy of the Eigen matrix on
-   * the OpenCL device. If the matrix already has a cached copy on the device,
-   * the cache is used and no copying is done. Changing the resulting matrix_cl
-   * would change cache, so do not do it! If changes are needed a copy must be
-   * made.
-   *
-   * @tparam R row type of input matrix
-   * @tparam C column type of input matrix
-   * @param A the Eigen matrix
-   * @param partial_view which part of the matrix is used
-   */
-  template <int R, int C>
-  static matrix_cl<T> constant(const Eigen::Matrix<T, R, C>& A,
-                               matrix_cl_view partial_view
-                               = matrix_cl_view::Entire) {
-#ifndef STAN_OPENCL_NOCACHE
-    if (A.opencl_buffer_() != NULL) {
-      return matrix_cl<T>(A.opencl_buffer_, A.rows(), A.cols(), partial_view);
-    } else {
-      matrix_cl<T> res(A, partial_view);
-      A.opencl_buffer_ = res.buffer();
-      return res;
-    }
-#else
-    return matrix_cl<T>(A, partial_view);
-#endif
-  }
-
-  /**
-   * Constructs a const matrix_cl that contains a copy of the Eigen matrix on
-   * the OpenCL device. \c Eigen \c Map can not be cached.
-   *
-   * @tparam R row type of input matrix
-   * @tparam C column type of input matrix
-   * @param A the \c Eigen \c Map
-   * @param partial_view which part of the matrix is used
-   */
-  template <int R, int C>
-  static matrix_cl<T> constant(
-      const Eigen::Map<const Eigen::Matrix<T, R, C>>& A,
-      matrix_cl_view partial_view = matrix_cl_view::Entire) {
-    return matrix_cl<T>(A, partial_view);
-  }
-
-  /**
-   * Constructs a const matrix_cl that contains a single value on the OpenCL
-   * device.
-   *
-   * @param A the value
-   * @param partial_view which part of the matrix is used
-   */
-  static matrix_cl<T> constant(T A, matrix_cl_view partial_view
-                                    = matrix_cl_view::Entire) {
-    return matrix_cl<T>(A);
   }
 
   /**

--- a/stan/math/opencl/matrix_cl.hpp
+++ b/stan/math/opencl/matrix_cl.hpp
@@ -180,6 +180,19 @@ class matrix_cl<T, enable_if_arithmetic<T>> {
   cl::Buffer& buffer() { return buffer_cl_; }
   matrix_cl() : rows_(0), cols_(0) {}
 
+  /**	
+   * Construct a matrix_cl<T> from an existing cl::Buffer object. The matrix	
+   * directly uses given buffer - no copying is done.	
+   *	
+   * @param A the cl::Buffer object to construct the matrix from	
+   * @param R number of rows	
+   * @param C number of columns	
+   * @param partial_view view of the matrix	
+   */	
+  matrix_cl(cl::Buffer& A, const int R, const int C,	
+            matrix_cl_view partial_view = matrix_cl_view::Entire)	
+      : buffer_cl_(A), rows_(R), cols_(C), view_(partial_view) {}
+
   matrix_cl(const matrix_cl<T>& A)
       : rows_(A.rows()), cols_(A.cols()), view_(A.view()) {
     if (A.size() == 0) {

--- a/stan/math/opencl/matrix_cl.hpp
+++ b/stan/math/opencl/matrix_cl.hpp
@@ -180,17 +180,17 @@ class matrix_cl<T, enable_if_arithmetic<T>> {
   cl::Buffer& buffer() { return buffer_cl_; }
   matrix_cl() : rows_(0), cols_(0) {}
 
-  /**	
-   * Construct a matrix_cl<T> from an existing cl::Buffer object. The matrix	
-   * directly uses given buffer - no copying is done.	
-   *	
-   * @param A the cl::Buffer object to construct the matrix from	
-   * @param R number of rows	
-   * @param C number of columns	
-   * @param partial_view view of the matrix	
-   */	
-  matrix_cl(cl::Buffer& A, const int R, const int C,	
-            matrix_cl_view partial_view = matrix_cl_view::Entire)	
+  /**
+   * Construct a matrix_cl<T> from an existing cl::Buffer object. The matrix
+   * directly uses given buffer - no copying is done.
+   *
+   * @param A the cl::Buffer object to construct the matrix from
+   * @param R number of rows
+   * @param C number of columns
+   * @param partial_view view of the matrix
+   */
+  matrix_cl(cl::Buffer& A, const int R, const int C,
+            matrix_cl_view partial_view = matrix_cl_view::Entire)
       : buffer_cl_(A), rows_(R), cols_(C), view_(partial_view) {}
 
   matrix_cl(const matrix_cl<T>& A)

--- a/stan/math/prim/mat/eigen_plugins.h
+++ b/stan/math/prim/mat/eigen_plugins.h
@@ -199,12 +199,6 @@ inline CwiseUnaryView<vi_Op, Derived>
 vi() { return CwiseUnaryView<vi_Op, Derived>(derived());
 }
 
-#ifdef STAN_OPENCL
-#ifndef STAN_OPENCL_NOCACHE
-mutable cl::Buffer opencl_buffer_;
-#endif
-#endif
-
 #define EIGEN_STAN_MATRIXBASE_PLUGIN
 
 #endif

--- a/stan/math/prim/mat/fun/Eigen.hpp
+++ b/stan/math/prim/mat/fun/Eigen.hpp
@@ -1,12 +1,6 @@
 #ifndef STAN_MATH_PRIM_MAT_FUN_EIGEN_HPP
 #define STAN_MATH_PRIM_MAT_FUN_EIGEN_HPP
 
-#ifdef STAN_OPENCL
-#ifndef STAN_OPENCL_NOCACHE
-#include <cl.hpp>
-#endif
-#endif
-
 #ifdef EIGEN_MATRIXBASE_PLUGIN
 #ifndef EIGEN_STAN_MATRIXBASE_PLUGIN
 #error "Stan uses Eigen's EIGEN_MATRIXBASE_PLUGIN macro. To use your own "

--- a/stan/math/prim/mat/prob/normal_id_glm_lpdf.hpp
+++ b/stan/math/prim/mat/prob/normal_id_glm_lpdf.hpp
@@ -118,8 +118,8 @@ return_type_t<T_y, T_x, T_alpha, T_beta, T_scale> normal_id_glm_lpdf(
       = opencl_kernels::normal_id_glm.get_option("LOCAL_SIZE_");
   const int wgs = (N + local_size - 1) / local_size;
 
-  const matrix_cl<double> y_cl = matrix_cl<double>::constant(y_val_vec);
-  const matrix_cl<double> x_cl = matrix_cl<double>::constant(x_val);
+  const matrix_cl<double> y_cl(y_val_vec);
+  const matrix_cl<double> x_cl(x_val);
   matrix_cl<double> beta_cl(beta_val_vec);
   matrix_cl<double> alpha_cl(alpha_val_vec);
   matrix_cl<double> sigma_cl(sigma_val_vec);

--- a/test/unit/math/opencl/matrix_cl_test.cpp
+++ b/test/unit/math/opencl/matrix_cl_test.cpp
@@ -2,7 +2,6 @@
 #include <stan/math/prim/mat/fun/typedefs.hpp>
 #include <stan/math/opencl/opencl_context.hpp>
 #include <stan/math/opencl/matrix_cl.hpp>
-#include <stan/math/opencl/copy.hpp>
 #include <stan/math/opencl/sub_block.hpp>
 #include <gtest/gtest.h>
 #include <algorithm>
@@ -27,44 +26,4 @@ TEST(MathMatrixCL, matrix_cl_types_creation) {
   test_matrix_creation<long double>();
 }
 
-#ifndef STAN_OPENCL_NOCACHE
-TEST(MathMatrixCL, matrix_cl_cache) {
-  using stan::math::matrix_cl;
-  Eigen::MatrixXd m(2, 2);
-  m << 1, 2, 3, 4;
-
-  const matrix_cl<double> m1_cl = matrix_cl<double>::constant(m);
-
-  cl_mem mem_handle = m.opencl_buffer_();
-  EXPECT_EQ(mem_handle, m1_cl.buffer()());
-
-  const matrix_cl<double> m2_cl = matrix_cl<double>::constant(m);
-
-  EXPECT_EQ(mem_handle, m.opencl_buffer_());
-  EXPECT_EQ(mem_handle, m1_cl.buffer()());
-  EXPECT_EQ(mem_handle, m2_cl.buffer()());
-}
-#else
-TEST(MathMatrixCL, matrix_cl_nocache) {
-  using stan::math::matrix_cl;
-  Eigen::MatrixXd m(2, 2);
-  m << 1, 2, 3, 4;
-
-  const matrix_cl<double> m1_cl = matrix_cl<double>::constant(m);
-  const matrix_cl<double> m2_cl = matrix_cl<double>::constant(m);
-
-  EXPECT_NE(m1_cl.buffer()(), m2_cl.buffer()());
-}
-#endif
-
-TEST(MathMatrixCL, matrix_cl_constructor_nocache) {
-  using stan::math::matrix_cl;
-  Eigen::MatrixXd m(2, 2);
-  m << 1, 2, 3, 4;
-
-  const matrix_cl<double> m1_cl(m);
-  const matrix_cl<double> m2_cl(m);
-
-  EXPECT_NE(m1_cl.buffer()(), m2_cl.buffer()());
-}
 #endif

--- a/test/unit/math/rev/mat/meta/operands_and_partials_test.cpp
+++ b/test/unit/math/rev/mat/meta/operands_and_partials_test.cpp
@@ -3,10 +3,6 @@
 #include <gtest/gtest.h>
 #include <vector>
 
-#if defined(STAN_OPENCL) && !defined(STAN_OPENCL_NOCACHE)
-#include <cl.hpp>
-#endif
-
 TEST(AgradPartialsVari, OperandsAndPartialsScal) {
   using stan::math::operands_and_partials;
   using stan::math::var;
@@ -294,14 +290,9 @@ TEST(AgradPartialsVari, OperandsAndPartialsMultivarMixed) {
   o4.edge1_.partials_vec_[0] += d_vec1;
   o4.edge3_.partials_vec_[0] += d_vec2;
 
-#if defined(STAN_OPENCL) && !defined(STAN_OPENCL_NOCACHE)
-  EXPECT_EQ(2 * sizeof(d_vec1) + 6 * sizeof(&v_vec) - sizeof(cl::Buffer),
-            sizeof(o4));
-#else
   // 2 partials stdvecs, 4 pointers to edges, 2 pointers to operands
   // vecs
   EXPECT_EQ(2 * sizeof(d_vec1) + 6 * sizeof(&v_vec), sizeof(o4));
-#endif
 
   std::vector<double> grad;
   var v = o4.build(10.0);


### PR DESCRIPTION
## Summary

Reverts GPU caching merged in #1320 and removes the `::constant` call inside normal_id_glm_lpdf. We are reverting this because we discovered issues that could arise with this implementation of caching mainly because the const qualifier restriction for cached matrices can be avoided fairly easy. 

See the discussion in the original PR for detailed reasons and examples.

## Tests

Just a revert.

## Side Effects

GPU normal_id_glm_lpdf is now slow for the time being. That will be resolved separately.

## Checklist

- [x] Math issue #1319 

- [x] Copyright holder: Rok Češnovar

- [x] the basic tests are passing

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
