### PR TITLE
Remove const qualifier from matrix_cl rows & cols

### DIFF
--- a/test/unit/math/opencl/copy_test.cpp
+++ b/test/unit/math/opencl/copy_test.cpp
@@ -71,14 +71,8 @@ TEST(MathMatrixCL, matrix_cl_matrix_copy_arithmetic) {
   double test_val = 5;
   // Use this for successful copy
   stan::math::matrix_cl<double> d22_cl(1, 1);
-  // Use this for failure copy
-  stan::math::matrix_cl<double> d222_cl(2, 3);
   EXPECT_NO_THROW(d22_cl = stan::math::to_matrix_cl(test_val));
   EXPECT_NO_THROW(test_val = stan::math::from_matrix_cl_error_code(d22_cl));
-  EXPECT_THROW(d222_cl = stan::math::to_matrix_cl(test_val),
-               std::invalid_argument);
-  EXPECT_THROW(test_val = stan::math::from_matrix_cl_error_code(d222_cl),
-               std::invalid_argument);
 }
 
 TEST(MathMatrixCL, matrix_cl_pack_unpack_copy_lower) {


### PR DESCRIPTION
## Summary

This PR fixes #1360 by removing the const qualifier from rows and cols on `matrix_cl`. This PR also removes the restriction of moving/copying/assigning a different size matrix_cl to another. 

This is the same behavior `Eigen` allows for matrices that don't have compile time set rows and columns, so I think this is OK.

## Tests

No new tests. The test that expected throws due to moves/copies/assignment to matrices of a different size were removed.

## Side Effects

/

## Checklist

- [x] Math issue #1360 

- [x] Copyright holder: Rok Češnovar (Univ. of Ljubljana)

- [x] the basic tests are passing

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
