### PR TITLE
Issue 1362 - Vectorised Dirichlet distribution

### DIFF
--- a/stan/math/prim/mat/prob/dirichlet_lpmf.hpp
+++ b/stan/math/prim/mat/prob/dirichlet_lpmf.hpp
@@ -65,7 +65,7 @@ return_type_t<T_prob, T_prior_size> dirichlet_lpmf(const T_prob& theta,
   const size_t t_length = max_size_mvt(theta, alpha);
 
   check_consistent_sizes(function, "probabilities", theta_vec[0],
-                         "prior sample sizes",alpha_vec[0]);
+                         "prior sample sizes", alpha_vec[0]);
 
   for (size_t t = 0; t < t_length; t++) {
     check_positive(function, "prior sample sizes", alpha_vec[t]);
@@ -117,7 +117,6 @@ return_type_t<T_prob, T_prior_size> dirichlet_lpmf(const T_prob& theta,
   }
 
   return ops_partials.build(lp);
-
 }
 
 template <typename T_prob, typename T_prior_size>

--- a/stan/math/prim/mat/prob/dirichlet_lpmf.hpp
+++ b/stan/math/prim/mat/prob/dirichlet_lpmf.hpp
@@ -21,18 +21,24 @@ namespace math {
  *
  * \f[
  * \theta\sim\mbox{Dirichlet}(\alpha_1,\ldots,\alpha_k)\\
- * \log(p(\theta\,|\,\alpha_1,\ldots,\alpha_k))=\log\left(\frac{\Gamma(\alpha_1+\cdots+\alpha_k)}{\Gamma(\alpha_1)+\cdots+\Gamma(\alpha_k)}*
- * \left(\theta_1^{\alpha_1-1}+\cdots+\theta_k^{\alpha_k-1}\right)\right)\\
- * =\log(\Gamma(\alpha_1+\cdots+\alpha_k))-\left(\log(\Gamma(\alpha_1))+\cdots+\log(\Gamma(\alpha_k))\right)+(\alpha_1-1)\log(\theta_1)+\cdots+(\alpha_k-1)\log(\theta_k)
+ * \log(p(\theta\,|\,\alpha_1,\ldots,\alpha_k))=\log\left(
+ * \frac{\Gamma(\alpha_1+\cdots+\alpha_k)}{\Gamma(\alpha_1)+
+ * \cdots+\Gamma(\alpha_k)}* \left(\theta_1^{\alpha_1-1}+
+ * \cdots+\theta_k^{\alpha_k-1}\right)\right)\\
+ * =\log(\Gamma(\alpha_1+\cdots+\alpha_k))-\left(
+ * \log(\Gamma(\alpha_1))+\cdots+\log(\Gamma(\alpha_k))\right)+
+ * (\alpha_1-1)\log(\theta_1)+\cdots+(\alpha_k-1)\log(\theta_k)
  * \f]
  *
  * \f[
  * \frac{\partial }{\partial
- * \theta_x}\log(p(\theta\,|\,\alpha_1,\ldots,\alpha_k))=\frac{\alpha_x-1}{\theta_x}
+ * \theta_x}\log(p(\theta\,|\,\alpha_1,\ldots,\alpha_k))=
+ * \frac{\alpha_x-1}{\theta_x}
  * \f]
  *
  * \f[
- * \frac{\partial}{\partial\alpha_x}\log(p(\theta\,|\,\alpha_1,\ldots,\alpha_k))=\psi_{(0)}(\sum\alpha)-\psi_{(0)}(\alpha_x)+\log\theta_x
+ * \frac{\partial}{\partial\alpha_x}\log(p(\theta\,|\,\alpha_1,\ldots,\alpha_k))
+ * =\psi_{(0)}(\sum\alpha)-\psi_{(0)}(\alpha_x)+\log\theta_x
  * \f]
  *
  * @param theta A scalar vector.
@@ -52,44 +58,66 @@ return_type_t<T_prob, T_prior_size> dirichlet_lpmf(const T_prob& theta,
 
   using T_partials_return = partials_return_t<T_prob, T_prior_size>;
   using T_partials_vec = typename Eigen::Matrix<T_partials_return, -1, 1>;
-
-  check_consistent_sizes(function, "probabilities", theta, "prior sample sizes",
-                         alpha);
-  check_positive(function, "prior sample sizes", alpha);
-  check_simplex(function, "probabilities", theta);
+  using T_partials_mat = typename Eigen::Matrix<T_partials_return, -1, -1>;
 
   vector_seq_view<T_prob> theta_vec(theta);
-  T_partials_vec theta_dbl = value_of(theta_vec[0]);
-
   vector_seq_view<T_prior_size> alpha_vec(alpha);
-  T_partials_vec alpha_dbl = value_of(alpha_vec[0]);
+  const size_t t_length = max_size_mvt(theta, alpha);
+
+  check_consistent_sizes(function, "probabilities", theta_vec[0],
+                         "prior sample sizes",alpha_vec[0]);
+
+  for (size_t t = 0; t < t_length; t++) {
+    check_positive(function, "prior sample sizes", alpha_vec[t]);
+    check_simplex(function, "probabilities", theta_vec[t]);
+}
+
+  const size_t t_size = theta_vec[0].size();
+
+  T_partials_mat theta_dbl(t_size, t_length);
+  for (size_t t = 0; t < t_length; t++)
+    theta_dbl.col(t) = value_of(theta_vec[t]);
+
+  T_partials_mat alpha_dbl(t_size, t_length);
+  for (size_t t = 0; t < t_length; t++)
+    alpha_dbl.col(t) = value_of(alpha_vec[t]);
+
+  T_partials_mat alpha_m_1 = (alpha_dbl.array() - 1.0);
 
   T_partials_return lp(0.0);
 
   if (include_summand<propto, T_prior_size>::value) {
-    lp += lgamma(alpha_dbl.sum()) - lgamma(alpha_dbl).sum();
+    lp += (lgamma(alpha_dbl.colwise().sum())
+            - lgamma(alpha_dbl).colwise().sum()).sum();
   }
 
   if (include_summand<propto, T_prob, T_prior_size>::value) {
-    lp += (theta_dbl.array().log() * (alpha_dbl.array() - 1.0)).sum();
+    lp += (theta_dbl.array().log() * alpha_m_1.array()).sum();
   }
-
-  T_partials_vec theta_deriv = (alpha_dbl.array() - 1.0) / theta_dbl.array();
-
-  T_partials_vec alpha_deriv = digamma(alpha_dbl.sum())
-                               - digamma(alpha_dbl).array()
-                               + theta_dbl.array().log();
 
   operands_and_partials<T_prob, T_prior_size> ops_partials(theta, alpha);
-  if (!is_constant_all<T_prob>::value) {
-    ops_partials.edge1_.partials_ = theta_deriv;
-  }
+  if (!is_constant_all<T_prob, T_prior_size>::value) {
+    T_partials_mat theta_deriv = alpha_m_1.array() / theta_dbl.array();
 
-  if (!is_constant_all<T_prior_size>::value) {
-    ops_partials.edge2_.partials_ = alpha_deriv;
+    T_partials_mat alpha_deriv(t_size, t_length);
+    for (size_t t = 0; t < t_length; t++)
+      alpha_deriv.col(t) = digamma(alpha_dbl.col(t).sum())
+                                 - digamma(alpha_dbl).col(t).array()
+                                 + theta_dbl.col(t).array().log();
+
+    if (!is_constant_all<T_prob>::value) {
+      for (size_t t = 0; t < t_length; t++)
+        ops_partials.edge1_.partials_vec_[t] += theta_deriv.col(t);
+    }
+
+    if (!is_constant_all<T_prior_size>::value) {
+    for (size_t t = 0; t < t_length; t++)
+      ops_partials.edge2_.partials_vec_[t] += alpha_deriv.col(t);
+    }
   }
 
   return ops_partials.build(lp);
+
 }
 
 template <typename T_prob, typename T_prior_size>

--- a/test/unit/math/mix/mat/prob/dirichlet_test.cpp
+++ b/test/unit/math/mix/mat/prob/dirichlet_test.cpp
@@ -18,10 +18,16 @@ TEST(ProbDistributions, fvar_var) {
     theta(i).d_ = 1.0;
     alpha(i).d_ = 1.0;
   }
+  std::vector<Matrix<fvar<var>, Dynamic, 1>> tvec{theta, theta};
+  std::vector<Matrix<fvar<var>, Dynamic, 1>> avec{alpha, alpha};
 
   EXPECT_FLOAT_EQ(0.6931472,
                   stan::math::dirichlet_log(theta, alpha).val_.val());
   EXPECT_FLOAT_EQ(0.99344212, stan::math::dirichlet_log(theta, alpha).d_.val());
+
+  EXPECT_FLOAT_EQ(0.6931472 * 2,
+                  stan::math::dirichlet_log(tvec, alpha).val_.val());
+  EXPECT_FLOAT_EQ(0.99344212 * 2, stan::math::dirichlet_log(tvec, alpha).d_.val());
 
   Matrix<fvar<var>, Dynamic, 1> theta2(4, 1);
   theta2 << 0.01, 0.01, 0.8, 0.18;

--- a/test/unit/math/mix/mat/prob/dirichlet_test.cpp
+++ b/test/unit/math/mix/mat/prob/dirichlet_test.cpp
@@ -2,6 +2,7 @@
 #include <gtest/gtest.h>
 #include <boost/random/mersenne_twister.hpp>
 #include <boost/math/distributions.hpp>
+#include <vector>
 
 using Eigen::Dynamic;
 using Eigen::Matrix;
@@ -18,16 +19,10 @@ TEST(ProbDistributions, fvar_var) {
     theta(i).d_ = 1.0;
     alpha(i).d_ = 1.0;
   }
-  std::vector<Matrix<fvar<var>, Dynamic, 1>> tvec{theta, theta};
-  std::vector<Matrix<fvar<var>, Dynamic, 1>> avec{alpha, alpha};
 
   EXPECT_FLOAT_EQ(0.6931472,
                   stan::math::dirichlet_log(theta, alpha).val_.val());
   EXPECT_FLOAT_EQ(0.99344212, stan::math::dirichlet_log(theta, alpha).d_.val());
-
-  EXPECT_FLOAT_EQ(0.6931472 * 2,
-                  stan::math::dirichlet_log(tvec, alpha).val_.val());
-  EXPECT_FLOAT_EQ(0.99344212 * 2, stan::math::dirichlet_log(tvec, alpha).d_.val());
 
   Matrix<fvar<var>, Dynamic, 1> theta2(4, 1);
   theta2 << 0.01, 0.01, 0.8, 0.18;
@@ -43,6 +38,61 @@ TEST(ProbDistributions, fvar_var) {
   EXPECT_FLOAT_EQ(2017.2858,
                   stan::math::dirichlet_log(theta2, alpha2).d_.val());
 }
+
+TEST(ProbDistributions, fvar_varVectorised) {
+  using stan::math::dirichlet_log;
+  using stan::math::fvar;
+  using stan::math::var;
+
+  Matrix<fvar<var>, Dynamic, 1> theta1(3, 1), theta2(3, 1), theta3(3, 1);
+  theta1 << 0.2, 0.3, 0.5;
+  theta2 << 0.1, 0.8, 0.1;
+  theta3 << 0.6, 0.1, 0.3;
+
+  Matrix<fvar<var>, Dynamic, 1> alpha1(3, 1), alpha2(3, 1), alpha3(3, 1);
+  alpha1 << 1.0, 1.0, 1.0;
+  alpha2 << 6.2, 3.5, 9.1;
+  alpha3 << 2.5, 7.4, 6.1;
+
+  std::vector<Matrix<fvar<var>, Dynamic, 1>> theta_vec(3);
+  theta_vec[0] = theta1;
+  theta_vec[1] = theta2;
+  theta_vec[2] = theta3;
+
+  std::vector<Matrix<fvar<var>, Dynamic, 1>> alpha_vec(3);
+  alpha_vec[0] = alpha1;
+  alpha_vec[1] = alpha2;
+  alpha_vec[2] = alpha3;
+
+  Matrix<fvar<var>, Dynamic, 1> result(3);
+  result[0] = dirichlet_log(theta1, alpha1);
+  result[1] = dirichlet_log(theta2, alpha2);
+  result[2] = dirichlet_log(theta3, alpha3);
+
+  fvar<var> out = dirichlet_log(theta_vec, alpha_vec);
+
+  EXPECT_FLOAT_EQ(result.val().val().sum(), out.val_.val());
+  EXPECT_FLOAT_EQ(result.d().val().sum(), out.d_.val());
+
+  result[0] = dirichlet_log(theta1, alpha1);
+  result[1] = dirichlet_log(theta2, alpha1);
+  result[2] = dirichlet_log(theta3, alpha1);
+
+  out = dirichlet_log(theta_vec, alpha1);
+
+  EXPECT_FLOAT_EQ(result.val().val().sum(), out.val_.val());
+  EXPECT_FLOAT_EQ(result.d().val().sum(), out.d_.val());
+
+  result[0] = dirichlet_log(theta1, alpha1);
+  result[1] = dirichlet_log(theta1, alpha2);
+  result[2] = dirichlet_log(theta1, alpha3);
+
+  out = dirichlet_log(theta1, alpha_vec);
+
+  EXPECT_FLOAT_EQ(result.val().val().sum(), out.val_.val());
+  EXPECT_FLOAT_EQ(result.d().val().sum(), out.d_.val());
+}
+
 
 TEST(ProbDistributions, fvar_fvar_var) {
   using stan::math::fvar;
@@ -75,4 +125,58 @@ TEST(ProbDistributions, fvar_fvar_var) {
                   stan::math::dirichlet_log(theta2, alpha2).val_.val_.val());
   EXPECT_FLOAT_EQ(2017.2858,
                   stan::math::dirichlet_log(theta2, alpha2).d_.val_.val());
+}
+
+TEST(ProbDistributions, fvar_fvar_varVectorised) {
+  using stan::math::dirichlet_log;
+  using stan::math::fvar;
+  using stan::math::var;
+
+  Matrix<fvar<fvar<var>>, Dynamic, 1> theta1(3, 1), theta2(3, 1), theta3(3, 1);
+  theta1 << 0.2, 0.3, 0.5;
+  theta2 << 0.1, 0.8, 0.1;
+  theta3 << 0.6, 0.1, 0.3;
+
+  Matrix<fvar<fvar<var>>, Dynamic, 1> alpha1(3, 1), alpha2(3, 1), alpha3(3, 1);
+  alpha1 << 1.0, 1.0, 1.0;
+  alpha2 << 6.2, 3.5, 9.1;
+  alpha3 << 2.5, 7.4, 6.1;
+
+  std::vector<Matrix<fvar<fvar<var>>, Dynamic, 1>> theta_vec(3);
+  theta_vec[0] = theta1;
+  theta_vec[1] = theta2;
+  theta_vec[2] = theta3;
+
+  std::vector<Matrix<fvar<fvar<var>>, Dynamic, 1>> alpha_vec(3);
+  alpha_vec[0] = alpha1;
+  alpha_vec[1] = alpha2;
+  alpha_vec[2] = alpha3;
+
+  Matrix<fvar<fvar<var>>, Dynamic, 1> result(3);
+  result[0] = dirichlet_log(theta1, alpha1);
+  result[1] = dirichlet_log(theta2, alpha2);
+  result[2] = dirichlet_log(theta3, alpha3);
+
+  fvar<fvar<var>> out = dirichlet_log(theta_vec, alpha_vec);
+
+  EXPECT_FLOAT_EQ(result.val().val().val().sum(), out.val_.val_.val());
+  EXPECT_FLOAT_EQ(result.d().val().val().sum(), out.d_.val_.val());
+
+  result[0] = dirichlet_log(theta1, alpha1);
+  result[1] = dirichlet_log(theta2, alpha1);
+  result[2] = dirichlet_log(theta3, alpha1);
+
+  out = dirichlet_log(theta_vec, alpha1);
+
+  EXPECT_FLOAT_EQ(result.val().val().val().sum(), out.val_.val_.val());
+  EXPECT_FLOAT_EQ(result.d().val().val().sum(), out.d_.val_.val());
+
+  result[0] = dirichlet_log(theta1, alpha1);
+  result[1] = dirichlet_log(theta1, alpha2);
+  result[2] = dirichlet_log(theta1, alpha3);
+
+  out = dirichlet_log(theta1, alpha_vec);
+
+  EXPECT_FLOAT_EQ(result.val().val().val().sum(), out.val_.val_.val());
+  EXPECT_FLOAT_EQ(result.d().val().val().sum(), out.d_.val_.val());
 }

--- a/test/unit/math/prim/mat/prob/dirichlet_test.cpp
+++ b/test/unit/math/prim/mat/prob/dirichlet_test.cpp
@@ -11,9 +11,14 @@ using Eigen::VectorXd;
 TEST(ProbDistributions, Dirichlet) {
   Matrix<double, Dynamic, 1> theta(3, 1);
   theta << 0.2, 0.3, 0.5;
+  std::vector<Matrix<double, Dynamic, 1>> tvec{theta, theta};
   Matrix<double, Dynamic, 1> alpha(3, 1);
   alpha << 1.0, 1.0, 1.0;
+  std::vector<Matrix<double, Dynamic, 1>> avec{alpha, alpha};
   EXPECT_FLOAT_EQ(0.6931472, stan::math::dirichlet_log(theta, alpha));
+  EXPECT_FLOAT_EQ(0.6931472 * 2, stan::math::dirichlet_log(tvec, alpha));
+  EXPECT_FLOAT_EQ(0.6931472 * 2, stan::math::dirichlet_log(theta, avec));
+  EXPECT_FLOAT_EQ(0.6931472 * 2, stan::math::dirichlet_log(tvec, avec));
 
   Matrix<double, Dynamic, 1> theta2(4, 1);
   theta2 << 0.01, 0.01, 0.8, 0.18;

--- a/test/unit/math/prim/mat/prob/dirichlet_test.cpp
+++ b/test/unit/math/prim/mat/prob/dirichlet_test.cpp
@@ -11,20 +11,57 @@ using Eigen::VectorXd;
 TEST(ProbDistributions, Dirichlet) {
   Matrix<double, Dynamic, 1> theta(3, 1);
   theta << 0.2, 0.3, 0.5;
-  std::vector<Matrix<double, Dynamic, 1>> tvec{theta, theta};
   Matrix<double, Dynamic, 1> alpha(3, 1);
   alpha << 1.0, 1.0, 1.0;
-  std::vector<Matrix<double, Dynamic, 1>> avec{alpha, alpha};
   EXPECT_FLOAT_EQ(0.6931472, stan::math::dirichlet_log(theta, alpha));
-  EXPECT_FLOAT_EQ(0.6931472 * 2, stan::math::dirichlet_log(tvec, alpha));
-  EXPECT_FLOAT_EQ(0.6931472 * 2, stan::math::dirichlet_log(theta, avec));
-  EXPECT_FLOAT_EQ(0.6931472 * 2, stan::math::dirichlet_log(tvec, avec));
 
   Matrix<double, Dynamic, 1> theta2(4, 1);
   theta2 << 0.01, 0.01, 0.8, 0.18;
   Matrix<double, Dynamic, 1> alpha2(4, 1);
   alpha2 << 10.5, 11.5, 19.3, 5.1;
   EXPECT_FLOAT_EQ(-43.40045, stan::math::dirichlet_log(theta2, alpha2));
+}
+
+TEST(ProbDistributions, DirichletVectorised) {
+  using stan::math::dirichlet_log;
+  Matrix<double, Dynamic, 1> theta1(3, 1), theta2(3, 1), theta3(3, 1);
+  theta1 << 0.2, 0.3, 0.5;
+  theta2 << 0.1, 0.8, 0.1;
+  theta3 << 0.6, 0.1, 0.3;
+
+  Matrix<double, Dynamic, 1> alpha1(3, 1), alpha2(3, 1), alpha3(3, 1);
+  alpha1 << 1.0, 1.0, 1.0;
+  alpha2 << 6.2, 3.5, 9.1;
+  alpha3 << 2.5, 7.4, 6.1;
+
+  std::vector<Matrix<double, Dynamic, 1>> theta_vec(3);
+  theta_vec[0] = theta1;
+  theta_vec[1] = theta2;
+  theta_vec[2] = theta3;
+
+  std::vector<Matrix<double, Dynamic, 1>> alpha_vec(3);
+  alpha_vec[0] = alpha1;
+  alpha_vec[1] = alpha2;
+  alpha_vec[2] = alpha3;
+
+  Matrix<double, Dynamic, 1> result(3);
+  result[0] = dirichlet_log(theta1, alpha1);
+  result[1] = dirichlet_log(theta2, alpha2);
+  result[2] = dirichlet_log(theta3, alpha3);
+
+  EXPECT_FLOAT_EQ(result.sum(), dirichlet_log(theta_vec, alpha_vec));
+
+  result[0] = dirichlet_log(theta1, alpha1);
+  result[1] = dirichlet_log(theta2, alpha1);
+  result[2] = dirichlet_log(theta3, alpha1);
+
+  EXPECT_FLOAT_EQ(result.sum(), dirichlet_log(theta_vec, alpha1));
+
+  result[0] = dirichlet_log(theta1, alpha1);
+  result[1] = dirichlet_log(theta1, alpha2);
+  result[2] = dirichlet_log(theta1, alpha3);
+
+  EXPECT_FLOAT_EQ(result.sum(), dirichlet_log(theta1, alpha_vec));
 }
 
 TEST(ProbDistributions, DirichletPropto) {


### PR DESCRIPTION
## Summary
This pull extends the dirichlet distribution to work with arrays of vectors without the need to loop over each vector in the array.

```
std::vector<VectorXd> ~ dirichlet(VectorXd)
VectorXd ~ dirichlet(std::vector<VectorXd>)
std::vector<VectorXd> ~ dirichlet(std::vector<VectorXd>)
```

## Tests

Tests are added for both values and derivatives of vectorised versions

## Side Effects
N/A

## Checklist

- [x] Math issue #1362 

- [x] Copyright holder: Andrew Johnson

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
