### PR TITLE
[WIP] Add copy and move constructors to classes with non-default destructors

### DIFF
--- a/stan/math/memory/stack_alloc.hpp
+++ b/stan/math/memory/stack_alloc.hpp
@@ -153,6 +153,10 @@ class stack_alloc {
       }
     }
   }
+  stack_alloc(stack_alloc&&) = default;
+  stack_alloc& operator=(stack_alloc&&) = default;
+  stack_alloc(const stack_alloc&) = default;
+  stack_alloc& operator=(const stack_alloc&) = default;
 
   /**
    * Return a newly allocated block of memory of the appropriate

--- a/stan/math/rev/core/autodiffstackstorage.hpp
+++ b/stan/math/rev/core/autodiffstackstorage.hpp
@@ -97,10 +97,17 @@ struct AutodiffStackSingleton {
       instance_ = nullptr;
     }
   }
+  explicit AutodiffStackSingleton(AutodiffStackSingleton_t const &) = delete;
+  AutodiffStackSingleton &operator=(const AutodiffStackSingleton_t &) = delete;
+  explicit AutodiffStackSingleton(AutodiffStackSingleton_t&&) = delete;
+  AutodiffStackSingleton &operator=(AutodiffStackSingleton_t&&) = delete;
 
   struct AutodiffStackStorage {
     AutodiffStackStorage &operator=(const AutodiffStackStorage &) = delete;
-
+    AutodiffStackStorage &operator=(AutodiffStackStorage&&) = delete;
+    AutodiffStackStorage(const AutodiffStackStorage&) = delete;
+    AutodiffStackStorage(AutodiffStackStorage&&) = delete;
+    AutodiffStackStorage() = default;
     std::vector<ChainableT *> var_stack_;
     std::vector<ChainableT *> var_nochain_stack_;
     std::vector<ChainableAllocT *> var_alloc_stack_;
@@ -111,9 +118,6 @@ struct AutodiffStackSingleton {
     std::vector<size_t> nested_var_nochain_stack_sizes_;
     std::vector<size_t> nested_var_alloc_stack_starts_;
   };
-
-  explicit AutodiffStackSingleton(AutodiffStackSingleton_t const &) = delete;
-  AutodiffStackSingleton &operator=(const AutodiffStackSingleton_t &) = delete;
 
   static STAN_THREADS_DEF AutodiffStackStorage *instance_;
 

--- a/stan/math/rev/core/gevv_vvv_vari.hpp
+++ b/stan/math/rev/core/gevv_vvv_vari.hpp
@@ -44,6 +44,12 @@ class gevv_vvv_vari : public vari {
     }
   }
   virtual ~gevv_vvv_vari() {}
+  gevv_vvv_vari() = default;
+  explicit gevv_vvv_vari(gevv_vvv_vari&&) = default;
+  gevv_vvv_vari& operator=(gevv_vvv_vari&&) = default;
+  explicit gevv_vvv_vari(const gevv_vvv_vari&) = default;
+  gevv_vvv_vari& operator=(const gevv_vvv_vari&) = default;
+
   void chain() {
     const double adj_alpha = adj_ * alpha_->val_;
     for (size_t i = 0; i < length_; i++) {

--- a/stan/math/rev/core/vari.hpp
+++ b/stan/math/rev/core/vari.hpp
@@ -82,11 +82,7 @@ class vari {
   /**
    * Vari default constructor assumes the var goes on the stack tape
    */
-<<<<<<< HEAD
   vari() { ChainableStack::instance_->var_stack_.emplace_back(this); }
-=======
-  vari() { ChainableStack::instance_->var_stack_.emplace_back(this); };
->>>>>>> 5277f39098712cf25452dfed653e8878ba5acd2e
 
   /**
    * Copy constructor

--- a/stan/math/rev/core/vari.hpp
+++ b/stan/math/rev/core/vari.hpp
@@ -84,7 +84,7 @@ class vari {
    */
   vari() {
     ChainableStack::instance_->var_stack_.emplace_back(this);
-  };
+  }
 
   /**
    * Copy constructor

--- a/stan/math/rev/core/vari.hpp
+++ b/stan/math/rev/core/vari.hpp
@@ -103,8 +103,8 @@ class vari {
    * @param x vari to be assigned by copies of it's elements
    */
   vari& operator=(const vari& x) {
+    // Val is const and cannot be assigned to
     //this->val_ = x.val_;
-    // Adjoint is const and cannot be assigned to
     this->adj_ = x.adj_;
     if (x.stacked_ && !this->stacked_) {
       ChainableStack::instance_->var_stack_.emplace_back(this);
@@ -137,8 +137,8 @@ class vari {
    * moves will still leaving 'moved' from object in a valid and coherent state.
    */
   vari& operator=(vari&& x) noexcept {
+    // Val is const and cannot be assigned to
     //this->val_ = x.val_;
-    // Adjoint is const and cannot be assigned to
     this->adj_ = x.adj_;
     if (x.stacked_ && !this->stacked_) {
       ChainableStack::instance_->var_stack_.emplace_back(std::move(this));

--- a/stan/math/rev/core/vari.hpp
+++ b/stan/math/rev/core/vari.hpp
@@ -124,9 +124,9 @@ class vari {
    */
   explicit vari(vari&& x) noexcept : val_(x.val_), adj_(x.adj_), stacked_(x.stacked_) {
     if (this->stacked_) {
-      ChainableStack::instance_->var_stack_.emplace_back(std::move(this));
+      ChainableStack::instance_->var_stack_.emplace_back(this);
     } else {
-      ChainableStack::instance_->var_nochain_stack_.emplace_back(std::move(this));
+      ChainableStack::instance_->var_nochain_stack_.emplace_back(this);
     }
   }
 

--- a/stan/math/rev/core/vari.hpp
+++ b/stan/math/rev/core/vari.hpp
@@ -58,13 +58,13 @@ class vari {
    * @param x Value of the constructed variable.
    */
   explicit vari(double x) : val_(x) {
-    ChainableStack::instance_->var_stack_.push_back(this);
+    ChainableStack::instance_->var_stack_.emplace_back(this);
   }
   vari(double x, bool stacked) : val_(x), stacked_(stacked) {
     if (stacked) {
-      ChainableStack::instance_->var_stack_.push_back(this);
+      ChainableStack::instance_->var_stack_.emplace_back(this);
     } else {
-      ChainableStack::instance_->var_nochain_stack_.push_back(this);
+      ChainableStack::instance_->var_nochain_stack_.emplace_back(this);
     }
   }
 
@@ -83,7 +83,7 @@ class vari {
    * Vari default constructor assumes the var goes on the stack tape
    */
   vari() {
-    ChainableStack::instance_->var_stack_.push_back(this);
+    ChainableStack::instance_->var_stack_.emplace_back(this);
   };
 
   /**
@@ -92,9 +92,9 @@ class vari {
    */
   explicit vari(const vari& x) : val_(x.val_), adj_(x.adj_), stacked_(x.stacked_) {
     if (this->stacked_) {
-      ChainableStack::instance_->var_stack_.push_back(this);
+      ChainableStack::instance_->var_stack_.emplace_back(this);
     } else {
-      ChainableStack::instance_->var_nochain_stack_.push_back(this);
+      ChainableStack::instance_->var_nochain_stack_.emplace_back(this);
     }
   }
 
@@ -107,9 +107,9 @@ class vari {
     // Adjoint is const and cannot be assigned to
     this->adj_ = x.adj_;
     if (x.stacked_ && !this->stacked_) {
-      ChainableStack::instance_->var_stack_.push_back(this);
+      ChainableStack::instance_->var_stack_.emplace_back(this);
     } else if (!x.stacked_ && this->stacked_) {
-      ChainableStack::instance_->var_nochain_stack_.push_back(this);
+      ChainableStack::instance_->var_nochain_stack_.emplace_back(this);
     }
     this->stacked_ = x.stacked_;
     return *this;
@@ -124,9 +124,9 @@ class vari {
    */
   explicit vari(vari&& x) noexcept : val_(x.val_), adj_(x.adj_), stacked_(x.stacked_) {
     if (this->stacked_) {
-      ChainableStack::instance_->var_stack_.push_back(std::move(this));
+      ChainableStack::instance_->var_stack_.emplace_back(std::move(this));
     } else {
-      ChainableStack::instance_->var_nochain_stack_.push_back(std::move(this));
+      ChainableStack::instance_->var_nochain_stack_.emplace_back(std::move(this));
     }
   }
 
@@ -141,9 +141,9 @@ class vari {
     // Adjoint is const and cannot be assigned to
     this->adj_ = x.adj_;
     if (x.stacked_ && !this->stacked_) {
-      ChainableStack::instance_->var_stack_.push_back(std::move(this));
+      ChainableStack::instance_->var_stack_.emplace_back(std::move(this));
     } else if (!x.stacked_ && this->stacked_) {
-      ChainableStack::instance_->var_nochain_stack_.push_back(std::move(this));
+      ChainableStack::instance_->var_nochain_stack_.emplace_back(std::move(this));
     }
     this->stacked_ = x.stacked_;
     return *this;

--- a/stan/math/rev/core/vari.hpp
+++ b/stan/math/rev/core/vari.hpp
@@ -83,9 +83,7 @@ class vari {
    * Vari default constructor assumes the var goes on the stack tape
    */
 <<<<<<< HEAD
-  vari() {
-    ChainableStack::instance_->var_stack_.emplace_back(this);
-  }
+  vari() { ChainableStack::instance_->var_stack_.emplace_back(this); }
 =======
   vari() { ChainableStack::instance_->var_stack_.emplace_back(this); };
 >>>>>>> 5277f39098712cf25452dfed653e8878ba5acd2e

--- a/stan/math/rev/core/vari.hpp
+++ b/stan/math/rev/core/vari.hpp
@@ -4,6 +4,7 @@
 #include <stan/math/rev/core/chainable_alloc.hpp>
 #include <stan/math/rev/core/chainablestack.hpp>
 #include <ostream>
+#include <utility>
 
 namespace stan {
 namespace math {
@@ -35,13 +36,14 @@ class vari {
   /**
    * The value of this variable.
    */
-  const double val_;
+  const double val_{0.0};
 
   /**
    * The adjoint of this variable, which is the partial derivative
    * of this variable with respect to the root variable.
    */
-  double adj_;
+  double adj_{0.0};
+  bool stacked_{false};
 
   /**
    * Construct a variable implementation from a value.  The
@@ -55,11 +57,10 @@ class vari {
    *
    * @param x Value of the constructed variable.
    */
-  explicit vari(double x) : val_(x), adj_(0.0) {
+  explicit vari(double x) : val_(x) {
     ChainableStack::instance_->var_stack_.push_back(this);
   }
-
-  vari(double x, bool stacked) : val_(x), adj_(0.0) {
+  vari(double x, bool stacked) : val_(x), stacked_(stacked) {
     if (stacked) {
       ChainableStack::instance_->var_stack_.push_back(this);
     } else {
@@ -77,6 +78,76 @@ class vari {
   virtual ~vari() {
     // this will never get called
   }
+
+  /**
+   * Vari default constructor assumes the var goes on the stack tape
+   */
+  vari() {
+    ChainableStack::instance_->var_stack_.push_back(this);
+  };
+
+  /**
+   * Copy constructor
+   * @param x vari to be copied
+   */
+  explicit vari(const vari& x) : val_(x.val_), adj_(x.adj_), stacked_(x.stacked_) {
+    if (this->stacked_) {
+      ChainableStack::instance_->var_stack_.push_back(this);
+    } else {
+      ChainableStack::instance_->var_nochain_stack_.push_back(this);
+    }
+  }
+
+  /**
+   * Copy assignment
+   * @param x vari to be assigned by copies of it's elements
+   */
+  vari& operator=(const vari& x) {
+    //this->val_ = x.val_;
+    // Adjoint is const and cannot be assigned to
+    this->adj_ = x.adj_;
+    if (x.stacked_ && !this->stacked_) {
+      ChainableStack::instance_->var_stack_.push_back(this);
+    } else if (!x.stacked_ && this->stacked_) {
+      ChainableStack::instance_->var_nochain_stack_.push_back(this);
+    }
+    this->stacked_ = x.stacked_;
+    return *this;
+
+  }
+
+  /**
+   * Move constructor
+   * @param x vari to be assigned
+   * Note: Because these members are 'plain old data' copies will be as fast as
+   * moves while still leaving 'moved' from objects in a valid and coherent state.
+   */
+  explicit vari(vari&& x) noexcept : val_(x.val_), adj_(x.adj_), stacked_(x.stacked_) {
+    if (this->stacked_) {
+      ChainableStack::instance_->var_stack_.push_back(std::move(this));
+    } else {
+      ChainableStack::instance_->var_nochain_stack_.push_back(std::move(this));
+    }
+  }
+
+  /**
+   * Move constructor
+   * @param x vari to be assigned
+   * Note: Because these members are plain old data copies will be as fast as
+   * moves will still leaving 'moved' from object in a valid and coherent state.
+   */
+  vari& operator=(vari&& x) noexcept {
+    //this->val_ = x.val_;
+    // Adjoint is const and cannot be assigned to
+    this->adj_ = x.adj_;
+    if (x.stacked_ && !this->stacked_) {
+      ChainableStack::instance_->var_stack_.push_back(std::move(this));
+    } else if (!x.stacked_ && this->stacked_) {
+      ChainableStack::instance_->var_nochain_stack_.push_back(std::move(this));
+    }
+    this->stacked_ = x.stacked_;
+    return *this;
+  };
 
   /**
    * Apply the chain rule to this variable based on the variables

--- a/stan/math/rev/mat/fun/mdivide_left_ldlt.hpp
+++ b/stan/math/rev/mat/fun/mdivide_left_ldlt.hpp
@@ -16,7 +16,7 @@ template <int R1, int C1, int R2, int C2>
 class mdivide_left_ldlt_alloc : public chainable_alloc {
  public:
   virtual ~mdivide_left_ldlt_alloc() {}
-  explicit mdivide_left_ldlt_alloc() = default;
+  mdivide_left_ldlt_alloc() = default;
   explicit mdivide_left_ldlt_alloc(mdivide_left_ldlt_alloc&&) = default;
   mdivide_left_ldlt_alloc& operator=(mdivide_left_ldlt_alloc&&) = default;
   explicit mdivide_left_ldlt_alloc(const mdivide_left_ldlt_alloc&) = default;

--- a/stan/math/rev/mat/fun/mdivide_left_ldlt.hpp
+++ b/stan/math/rev/mat/fun/mdivide_left_ldlt.hpp
@@ -16,6 +16,12 @@ template <int R1, int C1, int R2, int C2>
 class mdivide_left_ldlt_alloc : public chainable_alloc {
  public:
   virtual ~mdivide_left_ldlt_alloc() {}
+  explicit mdivide_left_ldlt_alloc() = default;
+  explicit mdivide_left_ldlt_alloc(mdivide_left_ldlt_alloc&&) = default;
+  mdivide_left_ldlt_alloc& operator=(mdivide_left_ldlt_alloc&&) = default;
+  explicit mdivide_left_ldlt_alloc(const mdivide_left_ldlt_alloc&) = default;
+  mdivide_left_ldlt_alloc& operator=(const mdivide_left_ldlt_alloc&) = default;
+
 
   /**
    * This share_ptr is used to prevent copying the LDLT factorizations

--- a/stan/math/rev/mat/fun/mdivide_left_spd.hpp
+++ b/stan/math/rev/mat/fun/mdivide_left_spd.hpp
@@ -18,7 +18,7 @@ template <int R1, int C1, int R2, int C2>
 class mdivide_left_spd_alloc : public chainable_alloc {
  public:
    virtual ~mdivide_left_spd_alloc() {}
-  explicit mdivide_left_spd_alloc() = default;
+  mdivide_left_spd_alloc() = default;
   explicit mdivide_left_spd_alloc(mdivide_left_spd_alloc&&) = default;
   mdivide_left_spd_alloc& operator=(mdivide_left_spd_alloc&&) = default;
   explicit mdivide_left_spd_alloc(const mdivide_left_spd_alloc&) = default;

--- a/stan/math/rev/mat/fun/mdivide_left_spd.hpp
+++ b/stan/math/rev/mat/fun/mdivide_left_spd.hpp
@@ -17,7 +17,12 @@ namespace internal {
 template <int R1, int C1, int R2, int C2>
 class mdivide_left_spd_alloc : public chainable_alloc {
  public:
-  virtual ~mdivide_left_spd_alloc() {}
+   virtual ~mdivide_left_spd_alloc() {}
+  explicit mdivide_left_spd_alloc() = default;
+  explicit mdivide_left_spd_alloc(mdivide_left_spd_alloc&&) = default;
+  mdivide_left_spd_alloc& operator=(mdivide_left_spd_alloc&&) = default;
+  explicit mdivide_left_spd_alloc(const mdivide_left_spd_alloc&) = default;
+  mdivide_left_spd_alloc& operator=(const mdivide_left_spd_alloc&) = default;
 
   Eigen::LLT<Eigen::Matrix<double, R1, C1> > llt_;
   Eigen::Matrix<double, R2, C2> C_;

--- a/stan/math/rev/mat/functor/cvodes_ode_data.hpp
+++ b/stan/math/rev/mat/functor/cvodes_ode_data.hpp
@@ -106,6 +106,12 @@ class cvodes_ode_data {
       N_VDestroyVectorArray_Serial(nv_state_sens_, S_);
     }
   }
+  cvodes_ode_data() = default;
+  explicit cvodes_ode_data(cvodes_ode_data&&) = default;
+  cvodes_ode_data& operator=(cvodes_ode_data&&) = default;
+  explicit cvodes_ode_data(const cvodes_ode_data&) = default;
+  cvodes_ode_data& operator=(const cvodes_ode_data&) = default;
+
 
   /**
    * Implements the function of type CVRhsFn which is the user-defined

--- a/stan/math/rev/mat/functor/idas_forward_system.hpp
+++ b/stan/math/rev/mat/functor/idas_forward_system.hpp
@@ -70,6 +70,12 @@ class idas_forward_system : public idas_system<F, Tyy, Typ, Tpar> {
       N_VDestroyVectorArray_Serial(this->nv_yps_, this->ns_);
     }
   }
+  idas_forward_system() = default;
+  explicit idas_forward_system(idas_forward_system&&) = default;
+  idas_forward_system& operator=(idas_forward_system&&) = default;
+  explicit idas_forward_system(const idas_forward_system&) = default;
+  idas_forward_system& operator=(const idas_forward_system&) = default;
+
 
   /**
    * return N_Vector pointer array of sensitivity

--- a/stan/math/rev/mat/functor/idas_system.hpp
+++ b/stan/math/rev/mat/functor/idas_system.hpp
@@ -190,6 +190,12 @@ class idas_system {
     N_VDestroy_Serial(id_);
     IDAFree(&mem_);
   }
+  idas_system() = default;
+  explicit idas_system(idas_system&&) = default;
+  idas_system& operator=(idas_system&&) = default;
+  explicit idas_system(const idas_system&) = default;
+  idas_system& operator=(const idas_system&) = default;
+
 
   /**
    * return reference to current N_Vector of unknown variable

--- a/stan/math/rev/mat/functor/kinsol_data.hpp
+++ b/stan/math/rev/mat/functor/kinsol_data.hpp
@@ -91,6 +91,12 @@ class kinsol_system_data {
     SUNMatDestroy(J_);
     KINFree(&kinsol_memory_);
   }
+  kinsol_system_data() = default;
+  explicit kinsol_system_data(kinsol_system_data&&) = default;
+  kinsol_system_data& operator=(kinsol_system_data&&) = default;
+  explicit kinsol_system_data(const kinsol_system_data&) = default;
+  kinsol_system_data& operator=(const kinsol_system_data&) = default;
+
 
   /* Implements the user-defined function passed to KINSOL. */
   static int kinsol_f_system(N_Vector x, N_Vector f, void* user_data) {


### PR DESCRIPTION
## Summary

TL;DR: Rule of 5 for our classes that's almost always the default constructors defined explicitly

When a class has only a non-default destructor defined C++ will only generate implicit copy constructors while not generating move constructors. Explicitly defining move constructors (even default defined ones) makes C++ not generate implicit copy constructors. So you need them all if you want moves essentially. I was goofing around today and did that for all the classes that have virtual or custom destructors defined. 96% of it was just adding stuff like 

```cpp
  gevv_vvv_vari() = default;
  explicit gevv_vvv_vari(gevv_vvv_vari&&) = default;
  gevv_vvv_vari& operator=(gevv_vvv_vari&&) = default;
  explicit gevv_vvv_vari(const gevv_vvv_vari&) = default;
  gevv_vvv_vari& operator=(const gevv_vvv_vari&) = default;
```

But for things like `vari` there are particulars that I'll discuss below. The functions that this touch are

#### Memory Stuff
1. `stack_alloc`
    - Or should the copy and move constructors be deleted for stack_alloc?
2. `vari`
    - I'm not sure if I implemented these correctly, mostly surrounding `var_stack` part of the `chainableAllocator`.
3. `gevv_vvv_vari`
4. `mdivide_left_ldlt_alloc`

(3) and (4) are pretty standard imo and I don't see any weirds coming from them, tbh we could probably just delete the empty destructor since eod it is still calling the destructors of it's members

### ODE Solvers
5. cvodes_ode_data
6. idas_forward_system
7. idas_system
8. kinsol_system_data

@yizhang-yiz I know you folks have to interact with a C API for sundials, does it make sense to move those objects in the class with the default move constructor? We can remove those if you don't want them.

I also deleted the move constructor and assignment operator for `AutodiffStackStorage` and `AutodiffStackSingleton`. They are implicitly not created but since the purpose of that class is to be a singleton I think it's better to be explicit.

## Tests

Part of the WIP is making sure these moves make sense

## Side Effects

Usually I say something like "I hope not!" here but this time, Yes! Sort of. If the compiler has an opportunity to use a move for these classes, it can! 99% of the time this is inconsequential since we don't use `std::forward` or `std::move` very often and we also use `const&` for the input of our signatures. But say we had a function like below.

```c++
template <typename T, require_var<T>...>
inline var atan(T&& a) { return {new internal::atan_vari(a.vi_)}; }
```

Well now we could call that function from a higher scope like ```atan(std::forward<Var>(my_var))```.  Or ala eigen

```cpp
A = B.unaryExpr([](auto&& x) { return atan(x) })
```

Though I'm not sure if the eigen one is as interesting

But thats the jist, yes there are side-effects. We'll be able to start thinking about moving memory down just like how RVO sends it up.

### I'm Not 100% on Vari's assignments

It looks like this, the members are plain old data so it's fine to just copy them

```cpp
  vari& operator=(vari&& x) noexcept {
    // (1) Val is const and cannot be assigned to
    //this->val_ = x.val_;
    this->adj_ = x.adj_;
    if (x.stacked_ && !this->stacked_) { // (2)
      ChainableStack::instance_->var_stack_.emplace_back(std::move(this));
    } else if (!x.stacked_ && this->stacked_) {
      ChainableStack::instance_->var_nochain_stack_.emplace_back(std::move(this));
    }
    this->stacked_ = x.stacked_;
    return *this;
  };
```

1. (this also applies to the copy assignment) Conceptually, does it make sense to do an assignment to another `vari`? The `val_ `member is const so we can't change it, but that just means we can only change `adj_`. Removing the const on `val_` feels like a not small thing to do so I wanted to check whether there's another solution besides removing that const which feels like a possible issue.

2. Will there ever be a circumstance where a vari from the `var_stack_` will be assigned to a `vari` from the `var_nochain_stack_` ala below? Also the `std::move(this)` is kind of dumb looking, but in my brain, if something sits in the var_stack_` that is assigned from a thing on the `var_nochain_stack_`, shouldn't it be moved to `var_nochain_stack_`? tbh I'm pretty not sure how to operate on this one.

## Checklist

- [x] Math issue #1308

- [x] Copyright holder: Steve Bronder

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [ ] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [ ] the new changes are tested
