### PR TITLE
Fix bug in stack_alloc_test

### DIFF
--- a/test/unit/math/memory/stack_alloc_test.cpp
+++ b/test/unit/math/memory/stack_alloc_test.cpp
@@ -25,7 +25,7 @@ TEST(MemoryStackAlloc, allocArrayBigger) {
   stan::math::stack_alloc allocator;
   biggy* x = allocator.alloc_array<biggy>(N);
   for (size_t i = 0; i < N; ++i)
-    for (size_t k = 1; k < K; ++k)
+    for (size_t k = 0; k < K; ++k)
       x[i].r[k] = k * i;
   for (size_t i = 0; i < N; ++i)
     for (size_t k = 0; k < K; ++k)


### PR DESCRIPTION
## Summary

Fixes #1372 

The inner loop start should be 0, but its 1.

## Tests

Fixes test in test/unit/math/memory/stack_alloc_test.cpp

## Side Effects

/

## Checklist

- [x] Math issue #1372

- [x] Copyright holder: Rok Češnovar

- [x] the basic tests are passing

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
