### PR TITLE
Add /lib/tbb/** to the .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,6 @@ compile_commands.json
 
 # Visual Studio Project Setup
 .vscode/*
+
+# Ignore things made with tbb
+lib/tbb/**


### PR DESCRIPTION

## Summary

Adds stuff from /lib/tbb/** to the .gitignore

## Side Effects

Things in /lib/tbb/ are ignored when doing git commit --all etc.

## Checklist

- [x] Math issue #1377

- [x] Copyright holder: Steve Bronder

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
