### PR TITLE
allow spaces in path leading to stan-directory in makefiles

### DIFF
--- a/make/compiler_flags
+++ b/make/compiler_flags
@@ -189,6 +189,7 @@ endif
 # TBB_LIBRARIES variable overrides the default.
 
 TBB_BIN ?= $(MATH)lib/tbb
+TBB_RELATIVE_PATH ?= ../$(notdir $(TBB))
 TBB_BIN_ABSOLUTE_PATH = $(abspath $(TBB_BIN))
 TBB_ABSOLUTE_PATH = $(abspath $(TBB))
 
@@ -199,13 +200,13 @@ else
 endif
 
 ifeq ($(OS),Windows_NT)
-  TBB_TARGETS ?= $(addsuffix $(LIBRARY_SUFFIX),$(addprefix $(TBB_BIN)/,$(TBB_LIBRARIES)))
+  TBB_TARGETS ?= $(addprefix $(TBB_BIN)/,$(addsuffix $(LIBRARY_SUFFIX),$(TBB_LIBRARIES)))
 endif
 ifeq ($(OS),Darwin)
-  TBB_TARGETS ?= $(addsuffix $(LIBRARY_SUFFIX),$(addprefix $(TBB_BIN)/lib,$(TBB_LIBRARIES)))
+  TBB_TARGETS ?= $(addprefix $(TBB_BIN)/lib,$(addsuffix $(LIBRARY_SUFFIX), $(TBB_LIBRARIES)))
 endif
 ifeq ($(OS),Linux)
-  TBB_TARGETS ?= $(addsuffix $(LIBRARY_SUFFIX).2,$(addprefix $(TBB_BIN)/lib,$(TBB_LIBRARIES)))
+  TBB_TARGETS ?= $(addprefix $(TBB_BIN)/lib,$(addsuffix $(LIBRARY_SUFFIX).2,$(TBB_LIBRARIES)))
 endif
 
 

--- a/make/libraries
+++ b/make/libraries
@@ -137,11 +137,11 @@ $(TBB_BIN)/tbb-make-check:
 $(TBB_BIN)/tbb.def: $(TBB_BIN)/tbb-make-check $(TBB_BIN)/tbbmalloc.def
 	@mkdir -p $(TBB_BIN)
 	touch $(TBB_BIN)/version_$(notdir $(TBB))
-	tbb_root="$(TBB_ABSOLUTE_PATH)" CXX="$(CXX)" CC="$(TBB_CC)" LDFLAGS="$(LDFLAGS_TBB)" $(MAKE) -C $(TBB_BIN) -r -f "$(TBB_ABSOLUTE_PATH)/build/Makefile.tbb" compiler=$(TBB_CXX_TYPE) cfg=release stdver=c++1y
+	tbb_root="$(TBB_RELATIVE_PATH)" CXX="$(CXX)" CC="$(TBB_CC)" LDFLAGS='$(LDFLAGS_TBB)' $(MAKE) -C "$(TBB_BIN)" -r -f "$(TBB_ABSOLUTE_PATH)/build/Makefile.tbb" compiler=$(TBB_CXX_TYPE) cfg=release stdver=c++1y
 
 $(TBB_BIN)/tbbmalloc.def: $(TBB_BIN)/tbb-make-check
 	@mkdir -p $(TBB_BIN)
-	tbb_root="$(TBB_ABSOLUTE_PATH)" CXX="$(CXX)" CC="$(TBB_CC)" LDFLAGS="$(LDFLAGS_TBB)" $(MAKE) -C $(TBB_BIN) -r -f "$(TBB_ABSOLUTE_PATH)/build/Makefile.tbbmalloc" compiler=$(TBB_CXX_TYPE) cfg=release stdver=c++1y malloc
+	tbb_root="$(TBB_RELATIVE_PATH)" CXX="$(CXX)" CC="$(TBB_CC)" LDFLAGS='$(LDFLAGS_TBB)' $(MAKE) -C "$(TBB_BIN)" -r -f "$(TBB_ABSOLUTE_PATH)/build/Makefile.tbbmalloc" compiler=$(TBB_CXX_TYPE) cfg=release stdver=c++1y malloc
 
 $(TBB_BIN)/libtbb.dylib: $(TBB_BIN)/tbb.def
 $(TBB_BIN)/libtbbmalloc.dylib: $(TBB_BIN)/tbbmalloc.def


### PR DESCRIPTION
## Summary

Avoid trouble with TBB makefiles if the path leading up to Stan-math (or cmdstan) contain any spaces. This basically works around bugs in makefile commands. 

## Side Effects

None

## Checklist

- [ ] Math issue #(issue number)

- [X] Copyright holder: Sebastian Weber

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [X] the new changes are tested
