### PR TITLE
Fix integrate_1d to use msgs ostream pointer like all other functions

### DIFF
--- a/stan/math/prim/arr/functor/integrate_1d.hpp
+++ b/stan/math/prim/arr/functor/integrate_1d.hpp
@@ -195,7 +195,7 @@ template <typename F>
 inline double integrate_1d(
     const F& f, const double a, const double b,
     const std::vector<double>& theta, const std::vector<double>& x_r,
-    const std::vector<int>& x_i, std::ostream& msgs,
+    const std::vector<int>& x_i, std::ostream* msgs,
     const double relative_tolerance
     = std::sqrt(std::numeric_limits<double>::epsilon())) {
   static const char* function = "integrate_1d";
@@ -209,7 +209,7 @@ inline double integrate_1d(
   } else {
     return integrate(
         std::bind<double>(f, std::placeholders::_1, std::placeholders::_2,
-                          theta, x_r, x_i, &msgs),
+                          theta, x_r, x_i, msgs),
         a, b, relative_tolerance);
   }
 }

--- a/stan/math/rev/arr/functor/integrate_1d.hpp
+++ b/stan/math/rev/arr/functor/integrate_1d.hpp
@@ -32,7 +32,7 @@ inline double gradient_of_f(const F &f, const double &x, const double &xc,
                             const std::vector<double> &theta_vals,
                             const std::vector<double> &x_r,
                             const std::vector<int> &x_i, size_t n,
-                            std::ostream &msgs) {
+                            std::ostream* msgs) {
   double gradient = 0.0;
   start_nested();
   std::vector<var> theta_var(theta_vals.size());
@@ -40,7 +40,7 @@ inline double gradient_of_f(const F &f, const double &x, const double &xc,
     for (size_t i = 0; i < theta_vals.size(); i++) {
       theta_var[i] = theta_vals[i];
     }
-    var fx = f(x, xc, theta_var, x_r, x_i, &msgs);
+    var fx = f(x, xc, theta_var, x_r, x_i, msgs);
     fx.grad();
     gradient = theta_var[n].adj();
     if (is_nan(gradient)) {
@@ -119,7 +119,7 @@ template <typename F, typename T_a, typename T_b, typename T_theta,
 inline return_type_t<T_a, T_b, T_theta> integrate_1d(
     const F &f, const T_a &a, const T_b &b, const std::vector<T_theta> &theta,
     const std::vector<double> &x_r, const std::vector<int> &x_i,
-    std::ostream &msgs,
+    std::ostream *msgs,
     const double relative_tolerance
     = std::sqrt(std::numeric_limits<double>::epsilon())) {
   static const char *function = "integrate_1d";
@@ -134,7 +134,7 @@ inline return_type_t<T_a, T_b, T_theta> integrate_1d(
   } else {
     double integral = integrate(
         std::bind<double>(f, std::placeholders::_1, std::placeholders::_2,
-                          value_of(theta), x_r, x_i, &msgs),
+                          value_of(theta), x_r, x_i, msgs),
         value_of(a), value_of(b), relative_tolerance);
 
     size_t N_theta_vars = is_var<T_theta>::value ? theta.size() : 0;
@@ -148,7 +148,7 @@ inline return_type_t<T_a, T_b, T_theta> integrate_1d(
         dintegral_dtheta[n] = integrate(
             std::bind<double>(gradient_of_f<F>, f, std::placeholders::_1,
                               std::placeholders::_2, theta_vals, x_r, x_i, n,
-                              std::ref(msgs)),
+                              msgs),
             value_of(a), value_of(b), relative_tolerance);
         theta_concat[n] = theta[n];
       }
@@ -157,13 +157,13 @@ inline return_type_t<T_a, T_b, T_theta> integrate_1d(
     if (!is_inf(a) && is_var<T_a>::value) {
       theta_concat.push_back(a);
       dintegral_dtheta.push_back(
-          -value_of(f(value_of(a), 0.0, theta, x_r, x_i, &msgs)));
+          -value_of(f(value_of(a), 0.0, theta, x_r, x_i, msgs)));
     }
 
     if (!is_inf(b) && is_var<T_b>::value) {
       theta_concat.push_back(b);
       dintegral_dtheta.push_back(
-          value_of(f(value_of(b), 0.0, theta, x_r, x_i, &msgs)));
+          value_of(f(value_of(b), 0.0, theta, x_r, x_i, msgs)));
     }
 
     return precomputed_gradients(integral, theta_concat, dintegral_dtheta);

--- a/stan/math/rev/arr/functor/integrate_1d.hpp
+++ b/stan/math/rev/arr/functor/integrate_1d.hpp
@@ -32,7 +32,7 @@ inline double gradient_of_f(const F &f, const double &x, const double &xc,
                             const std::vector<double> &theta_vals,
                             const std::vector<double> &x_r,
                             const std::vector<int> &x_i, size_t n,
-                            std::ostream* msgs) {
+                            std::ostream *msgs) {
   double gradient = 0.0;
   start_nested();
   std::vector<var> theta_var(theta_vals.size());

--- a/test/unit/math/prim/arr/functor/integrate_1d_test.cpp
+++ b/test/unit/math/prim/arr/functor/integrate_1d_test.cpp
@@ -6,7 +6,7 @@
 #include <sstream>
 #include <vector>
 
-std::ostringstream* msgs = nullptr;
+std::ostringstream *msgs = nullptr;
 
 struct f1 {
   template <typename T1, typename T2>

--- a/test/unit/math/prim/arr/functor/integrate_1d_test.cpp
+++ b/test/unit/math/prim/arr/functor/integrate_1d_test.cpp
@@ -6,7 +6,7 @@
 #include <sstream>
 #include <vector>
 
-std::ostringstream msgs;
+std::ostringstream* msgs = nullptr;
 
 struct f1 {
   template <typename T1, typename T2>

--- a/test/unit/math/rev/arr/functor/integrate_1d_test.cpp
+++ b/test/unit/math/rev/arr/functor/integrate_1d_test.cpp
@@ -8,7 +8,7 @@
 #include <limits>
 #include <sstream>
 
-std::ostringstream* msgs = nullptr;
+std::ostringstream *msgs = nullptr;
 
 struct f1 {
   template <typename T1, typename T2, typename T3>

--- a/test/unit/math/rev/arr/functor/integrate_1d_test.cpp
+++ b/test/unit/math/rev/arr/functor/integrate_1d_test.cpp
@@ -8,7 +8,7 @@
 #include <limits>
 #include <sstream>
 
-std::ostringstream msgs;
+std::ostringstream* msgs = nullptr;
 
 struct f1 {
   template <typename T1, typename T2, typename T3>


### PR DESCRIPTION
## Summary

Minor refactor of integrate_1d to use std::ostream* instead of std::ostream& like all other functions. Likely an oversight from its initial implementation.

## Checklist

- [x] Math issue: Fixes #933 

- [x] Copyright holder: (fill in copyright holder information)

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses: Columbia University
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen
