### PR TITLE
fix check on beta_proportion_* argument

### DIFF
--- a/stan/math/prim/scal/prob/beta_proportion_lccdf.hpp
+++ b/stan/math/prim/scal/prob/beta_proportion_lccdf.hpp
@@ -3,6 +3,7 @@
 
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
+#include <stan/math/prim/scal/err/check_less.hpp>
 #include <stan/math/prim/scal/err/check_less_or_equal.hpp>
 #include <stan/math/prim/scal/err/check_nonnegative.hpp>
 #include <stan/math/prim/scal/err/check_not_nan.hpp>
@@ -53,7 +54,7 @@ return_type_t<T_y, T_loc, T_prec> beta_proportion_lccdf(const T_y& y,
   T_partials_return ccdf_log(0.0);
 
   check_positive(function, "Location parameter", mu);
-  check_less_or_equal(function, "Location parameter", mu, 1.0);
+  check_less(function, "Location parameter", mu, 1.0);
   check_positive_finite(function, "Precision parameter", kappa);
   check_not_nan(function, "Random variable", y);
   check_nonnegative(function, "Random variable", y);

--- a/stan/math/prim/scal/prob/beta_proportion_lcdf.hpp
+++ b/stan/math/prim/scal/prob/beta_proportion_lcdf.hpp
@@ -3,6 +3,7 @@
 
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
+#include <stan/math/prim/scal/err/check_less.hpp>
 #include <stan/math/prim/scal/err/check_less_or_equal.hpp>
 #include <stan/math/prim/scal/err/check_nonnegative.hpp>
 #include <stan/math/prim/scal/err/check_not_nan.hpp>
@@ -54,7 +55,7 @@ return_type_t<T_y, T_loc, T_prec> beta_proportion_lcdf(const T_y& y,
   T_partials_return cdf_log(0.0);
 
   check_positive(function, "Location parameter", mu);
-  check_less_or_equal(function, "Location parameter", mu, 1.0);
+  check_less(function, "Location parameter", mu, 1.0);
   check_positive_finite(function, "Precision parameter", kappa);
   check_not_nan(function, "Random variable", y);
   check_nonnegative(function, "Random variable", y);

--- a/stan/math/prim/scal/prob/beta_proportion_lpdf.hpp
+++ b/stan/math/prim/scal/prob/beta_proportion_lpdf.hpp
@@ -3,6 +3,7 @@
 
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
+#include <stan/math/prim/scal/err/check_less.hpp>
 #include <stan/math/prim/scal/err/check_less_or_equal.hpp>
 #include <stan/math/prim/scal/err/check_nonnegative.hpp>
 #include <stan/math/prim/scal/err/check_not_nan.hpp>
@@ -48,7 +49,7 @@ return_type_t<T_y, T_loc, T_prec> beta_proportion_lpdf(const T_y& y,
   using T_partials_return = partials_return_t<T_y, T_loc, T_prec>;
   using std::log;
   check_positive(function, "Location parameter", mu);
-  check_less_or_equal(function, "Location parameter", mu, 1.0);
+  check_less(function, "Location parameter", mu, 1.0);
   check_positive_finite(function, "Precision parameter", kappa);
   check_not_nan(function, "Random variable", y);
   check_nonnegative(function, "Random variable", y);

--- a/stan/math/prim/scal/prob/beta_proportion_rng.hpp
+++ b/stan/math/prim/scal/prob/beta_proportion_rng.hpp
@@ -36,7 +36,7 @@ beta_proportion_rng(const T_loc &mu, const T_prec &kappa, RNG &rng) {
   static const char *function = "beta_proportion_rng";
 
   check_positive(function, "Location parameter", mu);
-  check_less_or_equal(function, "Location parameter", mu, 1.0);
+  check_less(function, "Location parameter", mu, 1.0);
   check_positive_finite(function, "Precision parameter", kappa);
   check_consistent_sizes(function, "Location parameter", mu,
                          "Precision parameter", kappa);

--- a/stan/math/prim/scal/prob/beta_proportion_rng.hpp
+++ b/stan/math/prim/scal/prob/beta_proportion_rng.hpp
@@ -4,6 +4,7 @@
 #include <stan/math/prim/meta.hpp>
 #include <boost/random/variate_generator.hpp>
 #include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
+#include <stan/math/prim/scal/err/check_less.hpp>
 #include <stan/math/prim/scal/err/check_positive_finite.hpp>
 #include <stan/math/prim/scal/err/check_positive.hpp>
 

--- a/test/prob/beta_proportion/beta_proportion_ccdf_log_test.hpp
+++ b/test/prob/beta_proportion/beta_proportion_ccdf_log_test.hpp
@@ -41,6 +41,9 @@ class AgradCcdfLogBetaProportion : public AgradCcdfLogTest {
     value.push_back(0.0);
 
     index.push_back(1U);
+    value.push_back(1.0);
+
+    index.push_back(1U);
     value.push_back(numeric_limits<double>::infinity());
 
     // kappa

--- a/test/prob/beta_proportion/beta_proportion_cdf_log_test.hpp
+++ b/test/prob/beta_proportion/beta_proportion_cdf_log_test.hpp
@@ -40,6 +40,9 @@ class AgradCdfLogBetaProportion : public AgradCdfLogTest {
     value.push_back(0.0);
 
     index.push_back(1U);
+    value.push_back(1.0);
+
+    index.push_back(1U);
     value.push_back(numeric_limits<double>::infinity());
 
     // kappa

--- a/test/prob/beta_proportion/beta_proportion_test.hpp
+++ b/test/prob/beta_proportion/beta_proportion_test.hpp
@@ -43,6 +43,9 @@ class AgradDistributionsBetaProportion : public AgradDistributionTest {
     value.push_back(0.0);
 
     index.push_back(1U);
+    value.push_back(1.0);
+
+    index.push_back(1U);
     value.push_back(-1.0);
 
     index.push_back(1U);


### PR DESCRIPTION
## Summary

Fixes #1413.

## Tests

Added tests for `mu = 1.0`.

## Side Effects

None

## Checklist

- [X] Math issue #1413

- [X] Copyright holder: Marco Colombo

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [X] the new changes are tested
