### PR TITLE
bugfix: mdivide_left_tri_test random failures

### DIFF
--- a/stan/math/opencl/kernel_cl.hpp
+++ b/stan/math/opencl/kernel_cl.hpp
@@ -167,7 +167,7 @@ struct select_event_helper<in_buffer, K> {
 template <typename K>
 struct select_event_helper<out_buffer, K> {
   inline const std::vector<cl::Event> get(const stan::math::matrix_cl<K>& m) {
-    return m.read_events();
+    return m.read_write_events();
   }
 };
 

--- a/stan/math/opencl/tri_inverse.hpp
+++ b/stan/math/opencl/tri_inverse.hpp
@@ -80,7 +80,6 @@ inline matrix_cl<T> tri_inverse(const matrix_cl<T>& A) {
   matrix_cl<T> inv_mat(A);
   matrix_cl<T> zero_mat(A_rows_padded - A.rows(), A_rows_padded);
   zero_mat.template zeros<stan::math::matrix_cl_view::Entire>();
-  temp.template zeros<stan::math::matrix_cl_view::Entire>();
   inv_padded.template zeros<stan::math::matrix_cl_view::Entire>();
   if (tri_view == matrix_cl_view::Upper) {
     inv_mat = transpose(inv_mat);

--- a/test/unit/math/opencl/kernel_cl_test.cpp
+++ b/test/unit/math/opencl/kernel_cl_test.cpp
@@ -5,6 +5,10 @@
 #include <gtest/gtest.h>
 #include <algorithm>
 
+#define EXPECT_MATRIX_NEAR(A, B, DELTA) \
+  for (int i = 0; i < A.size(); i++)    \
+    EXPECT_NEAR(A(i), B(i), DELTA);
+
 TEST(MathGpu, make_kernel) {
   stan::math::matrix_d m0(3, 3);
   stan::math::matrix_d m0_dst(3, 3);
@@ -16,4 +20,42 @@ TEST(MathGpu, make_kernel) {
                                         m00_dst, m00, m00.rows(), m00.cols());
   m0_dst = stan::math::from_matrix_cl(m00_dst);
 }
+
+TEST(MathGpu, write_after_write) {
+  using stan::math::matrix_cl;
+
+  for (int j = 0; j < 1000; j++) {
+    matrix_cl<double> m_cl(3, 3);
+
+    for (int i = 0; i < 4; i++) {
+      stan::math::opencl_kernels::fill(cl::NDRange(3, 3), m_cl, i, 3, 3,
+                                       stan::math::matrix_cl_view::Entire);
+    }
+
+    stan::math::matrix_d res = stan::math::from_matrix_cl(m_cl);
+    stan::math::matrix_d correct = stan::math::matrix_d::Constant(3, 3, 3);
+
+    EXPECT_MATRIX_NEAR(res, correct, 1e-13);
+  }
+}
+
+TEST(MathGpu, read_after_write_and_write_after_read) {
+  using stan::math::matrix_cl;
+
+  matrix_cl<double> m_cl(3, 3);
+  matrix_cl<double> ms_cl[1000];
+  for (int j = 0; j < 1000; j++) {
+    stan::math::opencl_kernels::fill(cl::NDRange(3, 3), m_cl, j, 3, 3,
+                                     stan::math::matrix_cl_view::Entire);
+
+    ms_cl[j] = m_cl;
+  }
+  for (int j = 0; j < 1000; j++) {
+    stan::math::matrix_d res = stan::math::from_matrix_cl(ms_cl[j]);
+    stan::math::matrix_d correct = stan::math::matrix_d::Constant(3, 3, j);
+
+    EXPECT_MATRIX_NEAR(res, correct, 1e-13);
+  }
+}
+
 #endif


### PR DESCRIPTION
## Summary
Kernels now also wait on write events of their `out_buffer` arguments. This fixes the undeterministic bug that caused `stan-math\test\unit\math\rev\mat\mdivide_left_tri_test.cpp` to randomly fail. 

Also the unnecessary call to `.zeros()` in `tri_inverse()` is removed. That was overwritten by next call to `batch_identity` anyway and caused the bug when those two kernels were executed in wrong order.

## Tests

Added tests for checking that multiple asynchronous kernel invocations are executed in correct order.

## Side Effects

None.

## Checklist

- [x] Math issue #1408

- [x] Copyright holder: Tadej Ciglarič

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
