### PR TITLE
Revert reverted async temporaries fix

### DIFF
--- a/stan/math/opencl/copy.hpp
+++ b/stan/math/opencl/copy.hpp
@@ -25,36 +25,62 @@
 
 namespace stan {
 namespace math {
-
 /**
  * Copies the source Eigen matrix to
  * the destination matrix that is stored
  * on the OpenCL device.
  *
- * @tparam R Compile time rows of the Eigen matrix
- * @tparam C Compile time columns of the Eigen matrix
  * @param src source Eigen matrix
  * @return matrix_cl with a copy of the data in the source matrix
  */
-template <typename T, int R, int C, typename = require_arithmetic_t<T>>
-inline matrix_cl<T> to_matrix_cl(const Eigen::Matrix<T, R, C>& src) {
-  matrix_cl<T> dst(src.rows(), src.cols());
+template <typename Mat, typename Mat_scalar = scalar_type_t<Mat>,
+          require_eigen_t<Mat>...>
+inline matrix_cl<Mat_scalar> to_matrix_cl(Mat&& src) {
+  matrix_cl<Mat_scalar> dst(src.rows(), src.cols());
   if (src.size() == 0) {
     return dst;
   }
   try {
-    /**
-     * Writes the contents of src to the OpenCL buffer
-     * starting at the offset 0
-     * CL_FALSE denotes that the call is non-blocking
-     * This means that future kernels need to know about the copy_event
-     * So that they do not execute until this transfer finishes.
-     */
-    cl::Event copy_event;
-    const cl::CommandQueue& queue = opencl_context.queue();
-    queue.enqueueWriteBuffer(dst.buffer(), CL_FALSE, 0, sizeof(T) * dst.size(),
-                             src.data(), &dst.write_events(), &copy_event);
-    dst.add_write_event(copy_event);
+    cl::Event transfer_event;
+    cl::CommandQueue& queue = opencl_context.queue();
+    queue.enqueueWriteBuffer(
+        dst.buffer(),
+        opencl_context.in_order()
+            || std::is_rvalue_reference<Mat_scalar&&>::value,
+        0, sizeof(Mat_scalar) * src.size(), src.eval().data(), nullptr,
+        &transfer_event);
+    dst.add_write_event(transfer_event);
+  } catch (const cl::Error& e) {
+    check_opencl_error("copy Eigen->(OpenCL)", e);
+  }
+  return dst;
+}
+
+/**
+ * Copies the source std::vector to
+ * the destination matrix that is stored
+ * on the OpenCL device.
+ *
+ * @param src source std::vector
+ * @return matrix_cl with a copy of the data in the source matrix
+ */
+template <typename Vec, typename Vec_scalar = scalar_type_t<Vec>,
+          require_std_vector_t<Vec>...>
+inline matrix_cl<Vec_scalar> to_matrix_cl(Vec&& src) {
+  matrix_cl<Vec_scalar> dst(src.size(), 1);
+  if (src.size() == 0) {
+    return dst;
+  }
+  try {
+    cl::Event transfer_event;
+    cl::CommandQueue& queue = opencl_context.queue();
+    queue.enqueueWriteBuffer(
+        dst.buffer(),
+        opencl_context.in_order()
+            || std::is_rvalue_reference<Vec_scalar&&>::value,
+        0, sizeof(Vec_scalar) * src.size(), src.data(), nullptr,
+        &transfer_event);
+    dst.add_write_event(transfer_event);
   } catch (const cl::Error& e) {
     check_opencl_error("copy Eigen->(OpenCL)", e);
   }
@@ -88,8 +114,9 @@ inline Eigen::Matrix<T, R, C> from_matrix_cl(const matrix_cl<T>& src) {
      */
     cl::Event copy_event;
     const cl::CommandQueue queue = opencl_context.queue();
-    queue.enqueueReadBuffer(src.buffer(), CL_FALSE, 0, sizeof(T) * dst.size(),
-                            dst.data(), &src.write_events(), &copy_event);
+    queue.enqueueReadBuffer(src.buffer(), opencl_context.in_order(), 0,
+                            sizeof(T) * dst.size(), dst.data(),
+                            &src.write_events(), &copy_event);
     copy_event.wait();
     src.clear_write_events();
   } catch (const cl::Error& e) {
@@ -123,7 +150,7 @@ inline std::vector<T> packed_copy(const matrix_cl<T>& src) {
     const std::vector<cl::Event> mat_events
         = vec_concat(packed.read_write_events(), src.write_events());
     cl::Event copy_event;
-    queue.enqueueReadBuffer(packed.buffer(), CL_FALSE, 0,
+    queue.enqueueReadBuffer(packed.buffer(), opencl_context.in_order(), 0,
                             sizeof(T) * packed_size, dst.data(), &mat_events,
                             &copy_event);
     copy_event.wait();
@@ -147,23 +174,25 @@ inline std::vector<T> packed_copy(const matrix_cl<T>& src) {
  * size of the vector does not match the expected size
  * for the packed triangular matrix
  */
-template <matrix_cl_view matrix_view, typename T,
-          typename = require_arithmetic_t<T>>
-inline matrix_cl<T> packed_copy(const std::vector<T>& src, int rows) {
+template <matrix_cl_view matrix_view, typename Vec,
+          typename Vec_scalar = scalar_type_t<Vec>,
+          require_std_vector_t<Vec>...>
+inline matrix_cl<Vec_scalar> packed_copy(Vec&& src, int rows) {
   const int packed_size = rows * (rows + 1) / 2;
   check_size_match("copy (packed std::vector -> OpenCL)", "src.size()",
                    src.size(), "rows * (rows + 1) / 2", packed_size);
-  matrix_cl<T> dst(rows, rows, matrix_view);
+  matrix_cl<Vec_scalar> dst(rows, rows, matrix_view);
   if (dst.size() == 0) {
     return dst;
   }
   try {
-    matrix_cl<T> packed(packed_size, 1);
+    matrix_cl<Vec_scalar> packed(packed_size, 1);
     cl::Event packed_event;
     const cl::CommandQueue queue = opencl_context.queue();
-    queue.enqueueWriteBuffer(packed.buffer(), CL_FALSE, 0,
-                             sizeof(T) * packed_size, src.data(), nullptr,
-                             &packed_event);
+    queue.enqueueWriteBuffer(
+        packed.buffer(),
+        opencl_context.in_order() || std::is_rvalue_reference<Vec&&>::value, 0,
+        sizeof(Vec_scalar) * packed_size, src.data(), nullptr, &packed_event);
     packed.add_write_event(packed_event);
     stan::math::opencl_kernels::unpack(cl::NDRange(dst.rows(), dst.rows()), dst,
                                        packed, dst.rows(), dst.rows(),
@@ -226,8 +255,8 @@ inline T from_matrix_cl_error_code(const matrix_cl<T>& src) {
   try {
     cl::Event copy_event;
     const cl::CommandQueue queue = opencl_context.queue();
-    queue.enqueueReadBuffer(src.buffer(), CL_FALSE, 0, sizeof(T), &dst,
-                            &src.write_events(), &copy_event);
+    queue.enqueueReadBuffer(src.buffer(), opencl_context.in_order(), 0,
+                            sizeof(T), &dst, &src.write_events(), &copy_event);
     copy_event.wait();
     src.clear_write_events();
   } catch (const cl::Error& e) {
@@ -242,9 +271,9 @@ inline T from_matrix_cl_error_code(const matrix_cl<T>& src) {
  * @param src Arithmetic to receive the matrix_cl value.
  * @return A 1x1 matrix on the device.
  */
-template <typename T, typename = require_arithmetic_t<T>>
-inline matrix_cl<T> to_matrix_cl(const T& src) {
-  matrix_cl<T> dst(1, 1);
+template <typename T, typename = require_arithmetic_t<std::decay_t<T>>>
+inline matrix_cl<std::decay_t<T>> to_matrix_cl(T&& src) {
+  matrix_cl<std::decay_t<T>> dst(1, 1);
   check_size_match("to_matrix_cl ((OpenCL) -> (OpenCL))", "src.rows()",
                    dst.rows(), "dst.rows()", 1);
   check_size_match("to_matrix_cl ((OpenCL) -> (OpenCL))", "src.cols()",
@@ -252,8 +281,10 @@ inline matrix_cl<T> to_matrix_cl(const T& src) {
   try {
     cl::Event copy_event;
     const cl::CommandQueue queue = opencl_context.queue();
-    queue.enqueueWriteBuffer(dst.buffer(), CL_FALSE, 0, sizeof(T), &src,
-                             &dst.write_events(), &copy_event);
+    queue.enqueueWriteBuffer(
+        dst.buffer(),
+        opencl_context.in_order() || std::is_rvalue_reference<T&&>::value, 0,
+        sizeof(std::decay_t<T>), &src, &dst.write_events(), &copy_event);
     dst.add_write_event(copy_event);
   } catch (const cl::Error& e) {
     check_opencl_error("to_matrix_cl (OpenCL)->(OpenCL)", e);

--- a/stan/math/opencl/matrix_cl.hpp
+++ b/stan/math/opencl/matrix_cl.hpp
@@ -322,7 +322,7 @@ class matrix_cl<T, require_arithmetic_t<T>> {
       cl::CommandQueue& queue = opencl_context.queue();
       queue.enqueueWriteBuffer(
           this->buffer_cl_,
-          opencl_context.in_order() || std::is_rvalue_reference<Mat&&>::value,
+          opencl_context.in_order() || std::is_rvalue_reference<Mat&&>::value || !is_eigen_matrix<Mat>::value,
           0, sizeof(T) * A.size(), A.eval().data(), nullptr, &transfer_event);
       this->add_write_event(transfer_event);
     } catch (const cl::Error& e) {

--- a/stan/math/opencl/matrix_cl.hpp
+++ b/stan/math/opencl/matrix_cl.hpp
@@ -322,7 +322,8 @@ class matrix_cl<T, require_arithmetic_t<T>> {
       cl::CommandQueue& queue = opencl_context.queue();
       queue.enqueueWriteBuffer(
           this->buffer_cl_,
-          opencl_context.in_order() || std::is_rvalue_reference<Mat&&>::value || !is_eigen_matrix<Mat>::value,
+          opencl_context.in_order() || std::is_rvalue_reference<Mat&&>::value
+              || !is_eigen_matrix<Mat>::value,
           0, sizeof(T) * A.size(), A.eval().data(), nullptr, &transfer_event);
       this->add_write_event(transfer_event);
     } catch (const cl::Error& e) {

--- a/stan/math/opencl/opencl_context.hpp
+++ b/stan/math/opencl/opencl_context.hpp
@@ -101,8 +101,10 @@ class opencl_context_base {
       if (device_properties & CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE) {
         command_queue_ = cl::CommandQueue(
             context_, device_, CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE, nullptr);
+        in_order_ = CL_FALSE;
       } else {
         command_queue_ = cl::CommandQueue(context_, device_, 0, nullptr);
+        in_order_ = CL_TRUE;
       }
       int thread_block_size_sqrt
           = static_cast<int>(sqrt(static_cast<double>(max_thread_block_size_)));
@@ -144,7 +146,7 @@ class opencl_context_base {
   std::string device_name_;          // The name of OpenCL device
   size_t max_thread_block_size_;  // The maximum size of a block of workers on
                                   // the device
-
+  bool in_order_;                 // Whether to use out of order execution.
   // Holds Default parameter values for each Kernel.
   using map_base_opts = std::map<std::string, int>;
   map_base_opts base_opts_
@@ -369,6 +371,13 @@ class opencl_context {
    */
   inline std::vector<cl::Platform> platform() {
     return {opencl_context_base::getInstance().platform_};
+  }
+  /**
+   * Return a bool representing whether the write to the OpenCL device are
+   * blocking
+   */
+  inline bool in_order() {
+    return opencl_context_base::getInstance().in_order_;
   }
 };
 static opencl_context opencl_context;

--- a/stan/math/prim/mat/meta/is_eigen.hpp
+++ b/stan/math/prim/mat/meta/is_eigen.hpp
@@ -36,5 +36,18 @@ struct is_eigen<
     T, std::enable_if_t<internal::is_eigen_base<std::decay_t<T>>::value>>
     : std::true_type {};
 
+namespace internal {
+template <typename T>
+struct is_eigen_matrix_impl : std::false_type {};
+template <typename T, int R, int C>
+struct is_eigen_matrix_impl<Eigen::Matrix<T, R, C>> : std::true_type {};
+template <typename T>
+struct is_eigen_matrix_impl<Eigen::SparseMatrix<T>> : std::true_type {};
+
+}  // namespace internal
+
+template <typename T>
+struct is_eigen_matrix : internal::is_eigen_matrix_impl<std::decay_t<T>> {};
+
 }  // namespace stan
 #endif

--- a/test/unit/math/opencl/copy_test.cpp
+++ b/test/unit/math/opencl/copy_test.cpp
@@ -8,6 +8,209 @@
 #include <algorithm>
 #include <vector>
 
+TEST(MathMatrixGPU, copy_rvalue_constructor) {
+  using Eigen::Dynamic;
+  using Eigen::Matrix;
+  using Eigen::MatrixXd;
+  using stan::math::from_matrix_cl;
+  using stan::math::matrix_cl;
+  int N = 100;
+  MatrixXd a = MatrixXd::Random(N, N);
+  MatrixXd b = MatrixXd::Random(N, N);
+  matrix_cl<double> c_cl(a + b);  // the problem
+  // attempt to scramble the memory that was used by the temporary
+  MatrixXd w = a - b;
+
+  // make compiler think a and b were changed, so second sum can not be
+  // optimized away
+  volatile int i = 19;
+  volatile double no_opt = a(i);
+  a(i) = no_opt;
+  no_opt = b(i);
+  b(i) = no_opt;
+
+  MatrixXd correct = a + b;
+  MatrixXd result = from_matrix_cl(c_cl);
+  for (int i = 0; i < N * N; i++) {
+    EXPECT_EQ(result(i), correct(i));
+  }
+  no_opt = w.array().sum();
+}
+
+TEST(MathMatrixGPU, copy_rvalue_constructor_eval) {
+  using Eigen::Dynamic;
+  using Eigen::Matrix;
+  using Eigen::MatrixXd;
+  using stan::math::from_matrix_cl;
+  using stan::math::matrix_cl;
+  int N = 100;
+  MatrixXd a = MatrixXd::Random(N, N);
+  MatrixXd b = MatrixXd::Random(N, N);
+  matrix_cl<double> c_cl(
+      (a + b).eval());  // the problem, this case with .eval()
+  // attempt to scramble the memory that was used by the temporary
+  MatrixXd w = a - b;
+
+  // make compiler think a and b were changed, so second sum can not be
+  // optimized away
+  volatile int i = 19;
+  volatile double no_opt = a(i);
+  a(i) = no_opt;
+  no_opt = b(i);
+  b(i) = no_opt;
+
+  MatrixXd correct = a + b;
+  MatrixXd result = from_matrix_cl(c_cl);
+  for (int i = 0; i < N * N; i++) {
+    EXPECT_EQ(result(i), correct(i));
+  }
+  no_opt = w.array().sum();
+}
+
+TEST(MathMatrixGPU, copy_rvalue_to_matrix_cl) {
+  using Eigen::Dynamic;
+  using Eigen::Matrix;
+  using Eigen::MatrixXd;
+  using stan::math::from_matrix_cl;
+  using stan::math::matrix_cl;
+  int N = 100;
+  MatrixXd a = MatrixXd::Random(N, N);
+  MatrixXd b = MatrixXd::Random(N, N);
+  matrix_cl<double> c_cl = stan::math::to_matrix_cl(a + b);  // the problem
+  // attempt to scramble the memory that was used by the temporary
+  MatrixXd w = a - b;
+
+  // make compiler think a and b were changed, so second sum can not be
+  // optimized away
+  volatile int i = 19;
+  volatile double no_opt = a(i);
+  a(i) = no_opt;
+  no_opt = b(i);
+  b(i) = no_opt;
+
+  MatrixXd correct = a + b;
+  MatrixXd result = from_matrix_cl(c_cl);
+  for (int i = 0; i < N * N; i++) {
+    EXPECT_EQ(result(i), correct(i));
+  }
+  no_opt = w.array().sum();
+}
+
+TEST(MathMatrixGPU, copy_rvalue_to_matrix_cl_eval) {
+  using Eigen::Dynamic;
+  using Eigen::Matrix;
+  using Eigen::MatrixXd;
+  using stan::math::from_matrix_cl;
+  using stan::math::matrix_cl;
+  int N = 100;
+  MatrixXd a = MatrixXd::Random(N, N);
+  MatrixXd b = MatrixXd::Random(N, N);
+  matrix_cl<double> c_cl
+      = stan::math::to_matrix_cl((a + b).eval());  // the problem
+  // attempt to scramble the memory that was used by the temporary
+  MatrixXd w = a - b;
+
+  // make compiler think a and b were changed, so second sum can not be
+  // optimized away
+  volatile int i = 19;
+  volatile double no_opt = a(i);
+  a(i) = no_opt;
+  no_opt = b(i);
+  b(i) = no_opt;
+
+  MatrixXd correct = a + b;
+  MatrixXd result = from_matrix_cl(c_cl);
+  for (int i = 0; i < N * N; i++) {
+    EXPECT_EQ(result(i), correct(i));
+  }
+  no_opt = w.array().sum();
+}
+
+TEST(MathMatrixGPU, copy_rvalue_to_matrix_cl_scalar) {
+  using Eigen::Dynamic;
+  using Eigen::Matrix;
+  using Eigen::MatrixXd;
+  using stan::math::from_matrix_cl;
+  using stan::math::matrix_cl;
+  double a = 1.0;
+  double b = 2.0;
+  double c = 3.0;
+  double d = 4.0;
+  matrix_cl<double> c_cl
+      = stan::math::to_matrix_cl(a + b + c + d);  // the problem
+  // attempt to scramble the memory that was used by the temporary
+  double f = a - b - c - d;
+
+  // make compiler think a and b were changed, so second sum can not be
+  // optimized away
+  volatile double no_opt = a;
+  a = no_opt;
+  no_opt = b;
+  b = no_opt;
+
+  double correct = a + b + c + d;
+  MatrixXd result = from_matrix_cl(c_cl);
+  EXPECT_EQ(result(0), correct);
+  no_opt = f + b + c + d;
+}
+
+TEST(MathMatrixGPU, copy_rvalue_constructor_scalar) {
+  using Eigen::Dynamic;
+  using Eigen::Matrix;
+  using Eigen::MatrixXd;
+  using stan::math::from_matrix_cl;
+  using stan::math::matrix_cl;
+  double a = 1.0;
+  double b = 2.0;
+  double c = 3.0;
+  double d = 4.0;
+  matrix_cl<double> c_cl(a + b + c + d);  // the problem
+  // attempt to scramble the memory that was used by the temporary
+  double f = a - b - c - d;
+
+  // make compiler think a and b were changed, so second sum can not be
+  // optimized away
+  volatile double no_opt = a;
+  a = no_opt;
+  no_opt = b;
+  b = no_opt;
+
+  double correct = a + b + c + d;
+  MatrixXd result = from_matrix_cl(c_cl);
+  EXPECT_EQ(result(0), correct);
+  no_opt = f + b + c + d;
+}
+
+TEST(MathMatrixGPU, std_vector_copy_rvalue_constructor) {
+  using Eigen::MatrixXd;
+  using stan::math::from_matrix_cl;
+  using stan::math::matrix_cl;
+
+  matrix_cl<double> c_cl(
+      std::vector<double>({1, 2, 3, 4, 5, 6}));  // the problem
+
+  std::vector<int> correct{1, 2, 3, 4, 5, 6};
+  MatrixXd result = from_matrix_cl(c_cl);
+  for (int i = 0; i < correct.size(); i++) {
+    EXPECT_EQ(result(i), correct[i]);
+  }
+}
+
+TEST(MathMatrixGPU, std_vector_copy_rvalue_to_matrix_cl) {
+  using Eigen::MatrixXd;
+  using stan::math::from_matrix_cl;
+  using stan::math::matrix_cl;
+
+  matrix_cl<double> c_cl = stan::math::to_matrix_cl(
+      std::vector<double>({1, 2, 3, 4, 5, 6}));  // the problem
+
+  std::vector<int> correct{1, 2, 3, 4, 5, 6};
+  MatrixXd result = from_matrix_cl(c_cl);
+  for (int i = 0; i < correct.size(); i++) {
+    EXPECT_EQ(result(i), correct[i]);
+  }
+}
+
 TEST(MathMatrixGPU, matrix_cl_vector_copy) {
   stan::math::vector_d d1_cpu;
   stan::math::vector_d d1_a_cpu;
@@ -29,6 +232,32 @@ TEST(MathMatrixGPU, matrix_cl_vector_copy) {
   EXPECT_EQ(1, d1_b_cpu(0));
   EXPECT_EQ(2, d1_b_cpu(1));
   EXPECT_EQ(3, d1_b_cpu(2));
+}
+
+TEST(MathMatrixGPU, matrix_cl_std_vector_copy) {
+  std::vector<double> d1_cpu{10.0, 20.0, 30.0};
+  std::vector<double> d_empty;
+  stan::math::matrix_d d1_cpu_ret;
+
+  stan::math::matrix_cl<double> d11_cl = stan::math::to_matrix_cl(d1_cpu);
+  stan::math::matrix_cl<double> d_empty_cl;
+  EXPECT_NO_THROW(d_empty_cl = stan::math::to_matrix_cl(d_empty));
+  EXPECT_NO_THROW(d1_cpu_ret = stan::math::from_matrix_cl(d11_cl));
+  EXPECT_EQ(10.0, d1_cpu_ret(0));
+  EXPECT_EQ(20.0, d1_cpu_ret(1));
+  EXPECT_EQ(30.0, d1_cpu_ret(2));
+}
+
+TEST(MathMatrixGPU, matrix_cl_packed_std_vector_copy_rvalue) {
+  stan::math::matrix_d d1_cpu_ret;
+
+  stan::math::matrix_cl<double> d11_cl
+      = stan::math::packed_copy<stan::math::matrix_cl_view::Lower>(
+          std::vector<double>({10.0, 20.0, 30.0}), 2);
+  EXPECT_NO_THROW(d1_cpu_ret = stan::math::from_matrix_cl(d11_cl));
+  EXPECT_EQ(10.0, d1_cpu_ret(0, 0));
+  EXPECT_EQ(20.0, d1_cpu_ret(1, 0));
+  EXPECT_EQ(30.0, d1_cpu_ret(1, 1));
 }
 
 TEST(MathMatrixCL, matrix_cl_matrix_copy) {
@@ -84,8 +313,9 @@ TEST(MathMatrixCL, matrix_cl_pack_unpack_copy_lower) {
     packed_mat[i] = i;
   }
   stan::math::matrix_d m_flat_cpu(size, size);
-  auto m_cl = stan::math::packed_copy<stan::math::matrix_cl_view::Lower>(
-      packed_mat, size);
+  stan::math::matrix_cl<double> m_cl
+      = stan::math::packed_copy<stan::math::matrix_cl_view::Lower>(packed_mat,
+                                                                   size);
   m_flat_cpu = stan::math::from_matrix_cl(m_cl);
   size_t pos = 0;
   for (size_t j = 0; j < size; ++j) {

--- a/test/unit/math/prim/mat/meta/is_eigen_test.cpp
+++ b/test/unit/math/prim/mat/meta/is_eigen_test.cpp
@@ -28,3 +28,29 @@ TEST(MathMeta, primitive) {
   EXPECT_TRUE((is_eigen<decltype(a * b)>::value));
   EXPECT_TRUE((is_eigen<decltype(a * b + a.transpose())>::value));
 }
+
+TEST(MathMeta, expression) {
+  using stan::is_eigen_matrix;
+  EXPECT_FALSE((is_eigen_matrix<bool>::value));
+  EXPECT_FALSE((is_eigen_matrix<double>::value));
+  EXPECT_FALSE((is_eigen_matrix<int>::value));
+
+  EXPECT_FALSE((is_eigen_matrix<std::vector<double>>::value));
+
+  EXPECT_FALSE((is_eigen_matrix<Eigen::EigenBase<Eigen::MatrixXd>>::value));
+  EXPECT_TRUE((is_eigen_matrix<Eigen::Matrix<double, -1, -1>>::value));
+  Eigen::SparseMatrix<double> sparse_mat;
+  EXPECT_TRUE((is_eigen_matrix<decltype(sparse_mat)>::value));
+  EXPECT_FALSE((is_eigen_matrix<Eigen::MatrixBase<Eigen::MatrixXd>>::value));
+
+  EXPECT_TRUE((is_eigen_matrix<const Eigen::Matrix<double, -1, -1>>::value));
+  EXPECT_TRUE((is_eigen_matrix<Eigen::SparseMatrix<double>&>::value));
+  EXPECT_FALSE((is_eigen_matrix<
+                Eigen::MatrixBase<Eigen::Matrix<double, -1, -1>>&&>::value));
+
+  Eigen::Matrix<double, -1, -1> a;
+  Eigen::Matrix<double, -1, -1> b;
+
+  EXPECT_FALSE((is_eigen_matrix<decltype(a * b)>::value));
+  EXPECT_FALSE((is_eigen_matrix<decltype(a * b + a.transpose())>::value));
+}


### PR DESCRIPTION
## Summary

As was discovered by @t4c1 the reverted async temporaries PR that was reverted in #1410 was not the cause of the fails of GPU tests on develop (see https://github.com/stan-dev/math/issues/1408#issuecomment-545393272). This PR reverts the revert and also applies another fix that was suggested by @t4c1 to avoid the temporaries bug when the input is not an Eigen::Matrix.

## Tests

/

## Side Effects

/

## Checklist

- [x] Math issue #1408

- [x] Copyright holder: Rok Češnovar, Tadej Ciglarič, University of Ljubljana

- [x] the basic tests are passing

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
