### PR TITLE
Revert "pull request #1407 from bstatcomp/matrix_cl_refactor"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,8 +11,8 @@ def runTests(String testPath) {
 def runTestsWin(String testPath) {
     withEnv(['PATH+TBB=./lib/tbb']) {
        bat "echo $PATH"
-       bat "runTests.py -j4 ${testPath} --make-only"
-       try { bat "runTests.py -j4 ${testPath}" }
+       bat "runTests.py -j12 ${testPath} --make-only"
+       try { bat "runTests.py -j12 ${testPath}" }
        finally { junit 'test/**/*.xml' }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,8 +11,8 @@ def runTests(String testPath) {
 def runTestsWin(String testPath) {
     withEnv(['PATH+TBB=./lib/tbb']) {
        bat "echo $PATH"
-       bat "runTests.py -j${env.PARALLEL} ${testPath} --make-only"
-       try { bat "runTests.py -j${env.PARALLEL} ${testPath}" }
+       bat "runTests.py -j4 ${testPath} --make-only"
+       try { bat "runTests.py -j4 ${testPath}" }
        finally { junit 'test/**/*.xml' }
     }
 }
@@ -160,7 +160,7 @@ pipeline {
                         deleteDir()
                         unstash 'MathSetup'
                         sh "echo CXX=${MPICXX} >> make/local"
-                        sh "echo CXX_TYPE=gcc >> make/local"                        
+                        sh "echo CXX_TYPE=gcc >> make/local"
                         sh "echo STAN_MPI=true >> make/local"
                         runTests("test/unit")
                     }

--- a/stan/math/opencl/copy.hpp
+++ b/stan/math/opencl/copy.hpp
@@ -36,7 +36,24 @@ namespace math {
 template <typename Mat, typename Mat_scalar = scalar_type_t<Mat>,
           require_eigen_t<Mat>...>
 inline matrix_cl<Mat_scalar> to_matrix_cl(Mat&& src) {
-  return matrix_cl<Mat_scalar>(src);
+  matrix_cl<Mat_scalar> dst(src.rows(), src.cols());
+  if (src.size() == 0) {
+    return dst;
+  }
+  try {
+    cl::Event transfer_event;
+    cl::CommandQueue& queue = opencl_context.queue();
+    queue.enqueueWriteBuffer(
+        dst.buffer(),
+        opencl_context.in_order()
+            || std::is_rvalue_reference<Mat_scalar&&>::value,
+        0, sizeof(Mat_scalar) * src.size(), src.eval().data(), nullptr,
+        &transfer_event);
+    dst.add_write_event(transfer_event);
+  } catch (const cl::Error& e) {
+    check_opencl_error("copy Eigen->(OpenCL)", e);
+  }
+  return dst;
 }
 
 /**
@@ -50,7 +67,24 @@ inline matrix_cl<Mat_scalar> to_matrix_cl(Mat&& src) {
 template <typename Vec, typename Vec_scalar = scalar_type_t<Vec>,
           require_std_vector_t<Vec>...>
 inline matrix_cl<Vec_scalar> to_matrix_cl(Vec&& src) {
-  return matrix_cl<Vec_scalar>(src);
+  matrix_cl<Vec_scalar> dst(src.size(), 1);
+  if (src.size() == 0) {
+    return dst;
+  }
+  try {
+    cl::Event transfer_event;
+    cl::CommandQueue& queue = opencl_context.queue();
+    queue.enqueueWriteBuffer(
+        dst.buffer(),
+        opencl_context.in_order()
+            || std::is_rvalue_reference<Vec_scalar&&>::value,
+        0, sizeof(Vec_scalar) * src.size(), src.data(), nullptr,
+        &transfer_event);
+    dst.add_write_event(transfer_event);
+  } catch (const cl::Error& e) {
+    check_opencl_error("copy Eigen->(OpenCL)", e);
+  }
+  return dst;
 }
 
 /**
@@ -181,7 +215,28 @@ inline matrix_cl<Vec_scalar> packed_copy(Vec&& src, int rows) {
  */
 template <typename T, typename = require_arithmetic_t<T>>
 inline matrix_cl<T> copy_cl(const matrix_cl<T>& src) {
-  return matrix_cl<T>(src);
+  matrix_cl<T> dst(src.rows(), src.cols(), src.view());
+  if (src.size() == 0) {
+    return dst;
+  }
+  try {
+    /**
+     * Copies the contents of the src buffer to the dst buffer
+     * see the matrix_cl(matrix_cl&) constructor
+     *  for explanation
+     */
+    cl::CommandQueue queue = opencl_context.queue();
+    const std::vector<cl::Event> mat_events
+        = vec_concat(dst.read_write_events(), src.write_events());
+    cl::Event copy_event;
+    queue.enqueueCopyBuffer(src.buffer(), dst.buffer(), 0, 0,
+                            sizeof(T) * src.size(), &mat_events, &copy_event);
+    dst.add_write_event(copy_event);
+    src.add_read_event(copy_event);
+  } catch (const cl::Error& e) {
+    check_opencl_error("copy_cl (OpenCL)->(OpenCL)", e);
+  }
+  return dst;
 }
 
 /**
@@ -218,7 +273,23 @@ inline T from_matrix_cl_error_code(const matrix_cl<T>& src) {
  */
 template <typename T, typename = require_arithmetic_t<std::decay_t<T>>>
 inline matrix_cl<std::decay_t<T>> to_matrix_cl(T&& src) {
-  return matrix_cl<std::decay_t<T>>(src);
+  matrix_cl<std::decay_t<T>> dst(1, 1);
+  check_size_match("to_matrix_cl ((OpenCL) -> (OpenCL))", "src.rows()",
+                   dst.rows(), "dst.rows()", 1);
+  check_size_match("to_matrix_cl ((OpenCL) -> (OpenCL))", "src.cols()",
+                   dst.cols(), "dst.cols()", 1);
+  try {
+    cl::Event copy_event;
+    const cl::CommandQueue queue = opencl_context.queue();
+    queue.enqueueWriteBuffer(
+        dst.buffer(),
+        opencl_context.in_order() || std::is_rvalue_reference<T&&>::value, 0,
+        sizeof(std::decay_t<T>), &src, &dst.write_events(), &copy_event);
+    dst.add_write_event(copy_event);
+  } catch (const cl::Error& e) {
+    check_opencl_error("to_matrix_cl (OpenCL)->(OpenCL)", e);
+  }
+  return dst;
 }
 
 }  // namespace math

--- a/stan/math/opencl/matrix_cl.hpp
+++ b/stan/math/opencl/matrix_cl.hpp
@@ -193,23 +193,28 @@ class matrix_cl<T, require_arithmetic_t<T>> {
             matrix_cl_view partial_view = matrix_cl_view::Entire)
       : buffer_cl_(A), rows_(R), cols_(C), view_(partial_view) {}
 
-  /**
-   * Copy constructor.
-   * @param A matrix_cl to copy
-   */
   matrix_cl(const matrix_cl<T>& A)
       : rows_(A.rows()), cols_(A.cols()), view_(A.view()) {
     if (A.size() == 0) {
       return;
     }
-    initialize_buffer(A);
+    this->wait_for_read_write_events();
+    cl::Context& ctx = opencl_context.context();
+    cl::CommandQueue queue = opencl_context.queue();
+    try {
+      buffer_cl_ = cl::Buffer(ctx, CL_MEM_READ_WRITE, sizeof(T) * this->size());
+      cl::Event cstr_event;
+      queue.enqueueCopyBuffer(A.buffer(), this->buffer(), 0, 0,
+                              A.size() * sizeof(T), &A.write_events(),
+                              &cstr_event);
+      this->add_write_event(cstr_event);
+      A.add_read_event(cstr_event);
+    } catch (const cl::Error& e) {
+      check_opencl_error("copy (OpenCL)->(OpenCL)", e);
+    }
   }
 
-  /**
-   * Move constructor.
-   * @param A matrix_cl to move
-   */
-  matrix_cl(matrix_cl<T>&& A)
+  explicit matrix_cl(matrix_cl<T>&& A)
       : buffer_cl_(std::move(A.buffer_cl_)),
         rows_(A.rows_),
         cols_(A.cols_),
@@ -218,16 +223,13 @@ class matrix_cl<T, require_arithmetic_t<T>> {
         read_events_(std::move(A.read_events_)) {}
 
   /**
-   * Constructor for the matrix_cl that creates a copy of a std::vector of Eigen
-   * matrices on the OpenCL device. Each matrix is flattened into one column
-   * of the resulting matrix_cl.
+   * Constructor for the matrix_cl that
+   * creates a copy of the Eigen matrix on the OpenCL device.
    *
-   * @param A the vector of  Eigen matrices
+   * @param A the Eigen matrix
    *
    * @throw <code>std::invalid_argument</code> if the
    * matrices do not have matching dimensions
-   * @throw <code>std::system_error</code> if the memory on the device could not
-   * be allocated
    */
   template <typename Vec, require_std_vector_vt<is_eigen, Vec>...,
             require_same_st<Vec, T>...>
@@ -236,12 +238,23 @@ class matrix_cl<T, require_arithmetic_t<T>> {
     if (this->size() == 0) {
       return;
     }
+
     cl::Context& ctx = opencl_context.context();
     cl::CommandQueue& queue = opencl_context.queue();
+    // creates the OpenCL buffer to copy the Eigen
+    // matrix to the OpenCL device
     buffer_cl_ = cl::Buffer(ctx, CL_MEM_READ_WRITE, sizeof(T) * size());
     for (int i = 0, offset_size = 0; i < cols_; i++, offset_size += rows_) {
       check_size_match("matrix constructor", "input rows", A[i].size(),
                        "matrix_cl rows", rows_);
+      /**
+       * Writes the contents of A[i] to the OpenCL buffer
+       * starting at the offset sizeof(double)*start.
+       * CL_TRUE denotes that the call is blocking as
+       * we do not want to execute any further kernels
+       * on the device until we are sure that the data
+       * is finished transfering
+       */
       cl::Event write_event;
       queue.enqueueWriteBuffer(
           buffer_cl_,
@@ -263,8 +276,8 @@ class matrix_cl<T, require_arithmetic_t<T>> {
    * @param cols number of matrix columns, must be greater or equal to 0
    * @param partial_view which part of the matrix is used
    *
-   * @throw <code>std::system_error</code> if the memory on the device could not
-   * be allocated
+   * @throw <code>std::system_error</code> if the
+   * matrices do not have matching dimensions
    *
    */
   matrix_cl(const int rows, const int cols,
@@ -275,6 +288,7 @@ class matrix_cl<T, require_arithmetic_t<T>> {
     }
     cl::Context& ctx = opencl_context.context();
     try {
+      // creates the OpenCL buffer of the provided size
       buffer_cl_
           = cl::Buffer(ctx, CL_MEM_READ_WRITE, sizeof(T) * rows_ * cols_);
     } catch (const cl::Error& e) {
@@ -291,15 +305,30 @@ class matrix_cl<T, require_arithmetic_t<T>> {
    * @param A the \c Eigen \c Matrix
    * @param partial_view which part of the matrix is used
    *
-   * @throw <code>std::system_error</code> if the memory on the device could not
-   * be allocated
+   * @throw <code>std::system_error</code> if the
+   * matrices do not have matching dimensions
    */
   template <typename Mat, require_eigen_t<Mat>..., require_same_vt<Mat, T>...>
   explicit matrix_cl(Mat&& A,
                      matrix_cl_view partial_view = matrix_cl_view::Entire)
       : rows_(A.rows()), cols_(A.cols()), view_(partial_view) {
-    initialize_buffer<std::is_rvalue_reference<Mat&&>::value
-                      || !is_eigen_matrix<Mat>::value>(A.eval().data());
+    if (size() == 0) {
+      return;
+    }
+    cl::Context& ctx = opencl_context.context();
+    try {
+      buffer_cl_ = cl::Buffer(ctx, CL_MEM_READ_WRITE, sizeof(T) * A.size());
+      cl::Event transfer_event;
+      cl::CommandQueue& queue = opencl_context.queue();
+      queue.enqueueWriteBuffer(
+          this->buffer_cl_,
+          opencl_context.in_order() || std::is_rvalue_reference<Mat&&>::value
+              || !is_eigen_matrix<Mat>::value,
+          0, sizeof(T) * A.size(), A.eval().data(), nullptr, &transfer_event);
+      this->add_write_event(transfer_event);
+    } catch (const cl::Error& e) {
+      check_opencl_error("matrix constructor", e);
+    }
   }
 
   /**
@@ -309,16 +338,25 @@ class matrix_cl<T, require_arithmetic_t<T>> {
    *
    * @param A the scalar
    * @param partial_view which part of the matrix is used
-   *
-   * @throw <code>std::system_error</code> if the memory on the device could not
-   * be allocated
    */
   template <typename Scal,
             typename = require_same_t<T, std::remove_reference_t<Scal>>>
   explicit matrix_cl(Scal&& A,
                      matrix_cl_view partial_view = matrix_cl_view::Diagonal)
       : rows_(1), cols_(1), view_(partial_view) {
-    initialize_buffer<std::is_rvalue_reference<Scal&&>::value>(&A);
+    cl::Context& ctx = opencl_context.context();
+    cl::CommandQueue& queue = opencl_context.queue();
+    try {
+      buffer_cl_ = cl::Buffer(ctx, CL_MEM_READ_WRITE, sizeof(std::decay_t<T>));
+      cl::Event transfer_event;
+      queue.enqueueWriteBuffer(
+          buffer_cl_,
+          opencl_context.in_order() || std::is_rvalue_reference<T&&>::value, 0,
+          sizeof(std::decay_t<T>), &A, nullptr, &transfer_event);
+      this->add_write_event(transfer_event);
+    } catch (const cl::Error& e) {
+      check_opencl_error("matrix constructor", e);
+    }
   }
 
   /**
@@ -326,9 +364,8 @@ class matrix_cl<T, require_arithmetic_t<T>> {
    *
    * @param A Standard vector
    * @param partial_view which part of the matrix is used
-   *
-   * @throw <code>std::system_error</code> if the memory on the device could not
-   * be allocated
+   * @throw <code>std::system_error</code> if the
+   * matrices do not have matching dimensions
    */
   template <typename Vec, require_std_vector_t<Vec>...,
             require_same_vt<Vec, T>...>
@@ -343,16 +380,30 @@ class matrix_cl<T, require_arithmetic_t<T>> {
    * @param R Number of rows the matrix should have.
    * @param C Number of columns the matrix should have.
    * @param partial_view which part of the matrix is used
-   *
-   * @throw <code>std::system_error</code> if the memory on the device could not
-   * be allocated
+   * @throw <code>std::system_error</code> if the
+   * matrices do not have matching dimensions
    */
   template <typename Vec, require_std_vector_t<Vec>...,
             require_same_vt<Vec, T>...>
   explicit matrix_cl(Vec&& A, const int& R, const int& C,
                      matrix_cl_view partial_view = matrix_cl_view::Entire)
       : rows_(R), cols_(C), view_(partial_view) {
-    initialize_buffer<std::is_rvalue_reference<Vec&&>::value>(A.data());
+    if (size() == 0) {
+      return;
+    }
+    cl::Context& ctx = opencl_context.context();
+    cl::CommandQueue& queue = opencl_context.queue();
+    try {
+      buffer_cl_ = cl::Buffer(ctx, CL_MEM_READ_WRITE, sizeof(T) * A.size());
+      cl::Event transfer_event;
+      queue.enqueueWriteBuffer(
+          buffer_cl_,
+          opencl_context.in_order() || std::is_rvalue_reference<Vec&&>::value,
+          0, sizeof(T) * A.size(), A.data(), nullptr, &transfer_event);
+      this->add_write_event(transfer_event);
+    } catch (const cl::Error& e) {
+      check_opencl_error("matrix constructor", e);
+    }
   }
 
   /**
@@ -362,19 +413,31 @@ class matrix_cl<T, require_arithmetic_t<T>> {
    * @param R Number of rows the matrix should have.
    * @param C Number of columns the matrix should have.
    * @param partial_view which part of the matrix is used
-   *
-   * @throw <code>std::system_error</code> if the memory on the device could not
-   * be allocated
+   * @throw <code>std::system_error</code> if the
+   * matrices do not have matching dimensions
    */
   template <typename U, require_same_t<T, U>...>
   explicit matrix_cl(const U* A, const int& R, const int& C,
                      matrix_cl_view partial_view = matrix_cl_view::Entire)
       : rows_(R), cols_(C), view_(partial_view) {
-    initialize_buffer(A);
+    if (size() == 0) {
+      return;
+    }
+    cl::Context& ctx = opencl_context.context();
+    cl::CommandQueue& queue = opencl_context.queue();
+    try {
+      buffer_cl_ = cl::Buffer(ctx, CL_MEM_READ_WRITE, sizeof(T) * size());
+      cl::Event transfer_event;
+      queue.enqueueWriteBuffer(buffer_cl_, opencl_context.in_order(), 0,
+                               sizeof(T) * size(), A, nullptr, &transfer_event);
+      this->add_write_event(transfer_event);
+    } catch (const cl::Error& e) {
+      check_opencl_error("matrix constructor", e);
+    }
   }
 
   /**
-   * Move assignment operator.
+   * Assign a \c matrix_cl to another
    */
   matrix_cl<T>& operator=(matrix_cl<T>&& a) {
     view_ = a.view();
@@ -388,66 +451,28 @@ class matrix_cl<T, require_arithmetic_t<T>> {
   }
 
   /**
-   * Copy assignment operator.
+   * Assign a \c matrix_cl to another
    */
   matrix_cl<T>& operator=(const matrix_cl<T>& a) {
     this->view_ = a.view();
     this->rows_ = a.rows();
     this->cols_ = a.cols();
-    this->wait_for_read_write_events();
-    initialize_buffer(a);
-    return *this;
-  }
-
- private:
-  /**
-   * Initializes the OpencL buffer of this matrix by copying the data from given
-   * buffer. Assumes that size of \c this is already set and matches the
-   * buffer size.
-   * @tparam in_order whether copying must be done in order
-   * @param A pointer to buffer
-   */
-  template <bool in_order = false>
-  void initialize_buffer(const T* A) {
-    if (size() == 0) {
-      return;
-    }
-    cl::Context& ctx = opencl_context.context();
-    cl::CommandQueue& queue = opencl_context.queue();
-    try {
-      buffer_cl_ = cl::Buffer(ctx, CL_MEM_READ_WRITE, sizeof(T) * size());
-      cl::Event transfer_event;
-      queue.enqueueWriteBuffer(buffer_cl_,
-                               opencl_context.in_order() || in_order, 0,
-                               sizeof(T) * size(), A, nullptr, &transfer_event);
-      this->add_write_event(transfer_event);
-    } catch (const cl::Error& e) {
-      check_opencl_error("initialize_buffer", e);
-    }
-  }
-
-  /**
-   * Initializes the OpencL buffer of this matrix by copying the data from given
-   * matrix_cl. Assumes that size of \c this is already set and matches the
-   * size of given matrix.
-   * @param A matrix_cl
-   */
-  void initialize_buffer(const matrix_cl<T>& A) {
     cl::Context& ctx = opencl_context.context();
     cl::CommandQueue queue = opencl_context.queue();
     try {
       buffer_cl_ = cl::Buffer(ctx, CL_MEM_READ_WRITE, sizeof(T) * this->size());
       cl::Event cstr_event;
-      queue.enqueueCopyBuffer(A.buffer(), this->buffer(), 0, 0,
-                              A.size() * sizeof(T), &A.write_events(),
+      queue.enqueueCopyBuffer(a.buffer(), this->buffer(), 0, 0,
+                              a.size() * sizeof(T), &a.write_events(),
                               &cstr_event);
       this->add_write_event(cstr_event);
-      A.add_read_event(cstr_event);
+      a.add_read_event(cstr_event);
     } catch (const cl::Error& e) {
       check_opencl_error("copy (OpenCL)->(OpenCL)", e);
     }
+    return *this;
   }
-};
+};  // namespace math
 
 template <typename T>
 using matrix_cl_prim = matrix_cl<T, require_arithmetic_t<T>>;


### PR DESCRIPTION

This reverts commit 6723f81778f3ba939a95908c70d1514bfd322713, reversing
changes made to 6455b691681c11e11c3c6ecc6de39a9cf5c3c206.

## Checklist

- [x] Math issue #1407

- [x] Copyright holder: Steve Bronder

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
