### PR TITLE
Fix boundary check for hypergeometric_lpmf()

### DIFF
--- a/stan/math/prim/scal/prob/hypergeometric_lpmf.hpp
+++ b/stan/math/prim/scal/prob/hypergeometric_lpmf.hpp
@@ -5,6 +5,7 @@
 #include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
 #include <stan/math/prim/scal/err/check_bounded.hpp>
 #include <stan/math/prim/scal/err/check_greater.hpp>
+#include <stan/math/prim/scal/err/check_greater_or_equal.hpp>
 #include <stan/math/prim/scal/fun/size_zero.hpp>
 #include <stan/math/prim/scal/fun/binomial_coefficient_log.hpp>
 
@@ -31,7 +32,7 @@ double hypergeometric_lpmf(const T_n& n, const T_N& N, const T_a& a,
 
   double logp(0.0);
   check_bounded(function, "Successes variable", n, 0, a);
-  check_greater(function, "Draws parameter", N, n);
+  check_greater_or_equal(function, "Draws parameter", N, n);
   for (size_t i = 0; i < size; i++) {
     check_bounded(function, "Draws parameter minus successes variable",
                   N_vec[i] - n_vec[i], 0, b_vec[i]);

--- a/test/prob/hypergeometric/hypergeometric_test.hpp
+++ b/test/prob/hypergeometric/hypergeometric_test.hpp
@@ -5,7 +5,7 @@ using stan::math::var;
 using std::numeric_limits;
 using std::vector;
 
-class AgradDistributionsNegBinomial : public AgradDistributionTest {
+class AgradDistributionsHypergeometric : public AgradDistributionTest {
  public:
   void valid_values(vector<vector<double> >& parameters,
                     vector<double>& log_prob) {
@@ -17,6 +17,14 @@ class AgradDistributionsNegBinomial : public AgradDistributionTest {
     param[3] = 10;  // b
     parameters.push_back(param);
     log_prob.push_back(-4.119424246619123763935);  // expected log_prob
+
+    // case for n == N
+    param[0] = 3;   // n
+    param[1] = 3;   // N
+    param[2] = 8;   // a
+    param[3] = 10;  // b
+    parameters.push_back(param);
+    log_prob.push_back(-2.679062664228958112744);  // expected log_prob
   }
 
   void invalid_values(vector<size_t>& index, vector<double>& value) {

--- a/test/prob/hypergeometric/hypergeometric_test.hpp
+++ b/test/prob/hypergeometric/hypergeometric_test.hpp
@@ -19,12 +19,12 @@ class AgradDistributionsHypergeometric : public AgradDistributionTest {
     log_prob.push_back(-4.119424246619123763935);  // expected log_prob
 
     // case for n == N
-    param[0] = 3;   // n
-    param[1] = 3;   // N
-    param[2] = 8;   // a
+    param[0] = 5;   // n
+    param[1] = 5;   // N
+    param[2] = 10;  // a
     param[3] = 10;  // b
     parameters.push_back(param);
-    log_prob.push_back(-2.679062664228958112744);  // expected log_prob
+    log_prob.push_back(-4.119424246619123763935);  // expected log_prob
   }
 
   void invalid_values(vector<size_t>& index, vector<double>& value) {

--- a/test/unit/math/prim/scal/prob/hypergeometric_log_test.cpp
+++ b/test/unit/math/prim/scal/prob/hypergeometric_log_test.cpp
@@ -27,3 +27,12 @@ TEST(ProbHypergeometric, log_matches_lpmf) {
       (stan::math::hypergeometric_lpmf<int, int, double, double>(n, N, a, b)),
       (stan::math::hypergeometric_log<int, int, double, double>(n, N, a, b)));
 }
+
+TEST(ProbHypergeometric, n_equal_N) {
+  int n = 2;
+  int N = 2;
+  int a = 2;
+  int b = 4;
+
+  EXPECT_NO_THROW(stan::math::hypergeometric_lpmf(n, N, a, b));
+}


### PR DESCRIPTION
# Summary

Fixes an overly stringent check in `hypergeometric_lpmf()` so that the function  can be applied also in the case when `n == N`.

## Tests

Added a unit test and a distribution test (the class of which was named incorrectly, hence the rename).

## Side Effects

None.

## Checklist

- [X] Math issue https://github.com/stan-dev/stan/issues/2667

- [X] Copyright holder: Marco Colombo

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [X] the new changes are tested
