### PR TITLE
Make singular_values work with size 0 input

### DIFF
--- a/stan/math/prim/mat/fun/singular_values.hpp
+++ b/stan/math/prim/mat/fun/singular_values.hpp
@@ -17,7 +17,7 @@ namespace math {
 template <typename T>
 Eigen::Matrix<T, Eigen::Dynamic, 1> singular_values(
     const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& m) {
-  if (m.rows() == 0 || m.cols() == 0)
+  if (m.size() == 0)
     return Eigen::Matrix<T, 0, 1>();
 
   return Eigen::JacobiSVD<Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> >(m)

--- a/stan/math/prim/mat/fun/singular_values.hpp
+++ b/stan/math/prim/mat/fun/singular_values.hpp
@@ -10,13 +10,17 @@ namespace math {
  * Return the vector of the singular values of the specified matrix
  * in decreasing order of magnitude.
  * <p>See the documentation for <code>svd()</code> for
- * information on the signular values.
+ * information on the singular values.
  * @param m Specified matrix.
  * @return Singular values of the matrix.
  */
 template <typename T>
 Eigen::Matrix<T, Eigen::Dynamic, 1> singular_values(
     const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& m) {
+
+  if (m.rows() == 0 || m.cols() == 0)
+    return Eigen::Matrix<T, 0, 1>();
+
   return Eigen::JacobiSVD<Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> >(m)
       .singularValues();
 }

--- a/stan/math/prim/mat/fun/singular_values.hpp
+++ b/stan/math/prim/mat/fun/singular_values.hpp
@@ -17,7 +17,6 @@ namespace math {
 template <typename T>
 Eigen::Matrix<T, Eigen::Dynamic, 1> singular_values(
     const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& m) {
-
   if (m.rows() == 0 || m.cols() == 0)
     return Eigen::Matrix<T, 0, 1>();
 

--- a/test/unit/math/mix/mat/fun/singular_values_test.cpp
+++ b/test/unit/math/mix/mat/fun/singular_values_test.cpp
@@ -7,6 +7,9 @@ TEST(MathMixMatFun, singularValues) {
   tols.hessian_hessian_ = 1e-2;
   tols.hessian_fvar_hessian_ = 1e-2;
 
+  Eigen::MatrixXd m00(0, 0);
+  stan::test::expect_ad(f, m00);
+
   Eigen::MatrixXd m11(1, 1);
   m11 << 1.1;
   stan::test::expect_ad(tols, f, m11);


### PR DESCRIPTION
## Summary

Fixes #1439 so that in case of size 0 input we return before getting into Eigen.

## Tests

Added test suggested in the issue.

## Side Effects

None.

## Checklist

- [X] Math issue #1439

- [X] Copyright holder: Marco Colombo

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [X] the new changes are tested
