### PR TITLE
Make log_determinant work with size 0 inputs

### DIFF
--- a/stan/math/prim/mat/fun/log_determinant.hpp
+++ b/stan/math/prim/mat/fun/log_determinant.hpp
@@ -17,6 +17,9 @@ namespace math {
 template <typename T, int R, int C>
 inline T log_determinant(const Eigen::Matrix<T, R, C>& m) {
   check_square("log_determinant", "m", m);
+  if (m.size() == 0)
+    return 0;
+
   return m.colPivHouseholderQr().logAbsDeterminant();
 }
 

--- a/test/unit/math/mix/mat/fun/log_determinant_test.cpp
+++ b/test/unit/math/mix/mat/fun/log_determinant_test.cpp
@@ -4,6 +4,9 @@
 TEST(MathMixMatFun, logDeterminant) {
   auto f = [](const auto& x) { return stan::math::log_determinant(x); };
 
+  Eigen::MatrixXd m00(0, 0);
+  stan::test::expect_ad(f, m00);
+
   // repeat symmetric pos def tests
   Eigen::MatrixXd a(2, 2);
   a << 3, 0, 0, 4;


### PR DESCRIPTION
## Summary

Fixes #1437 so that in case of matrix of size 0 (which has determinant 1) we return 0 immediately.

## Tests

Added tests suggested in the issue.

## Side Effects

None.

## Checklist

- [X] Math issue #(issue number)

- [X] Copyright holder: Marco Colombo

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [X] the new changes are tested
