### PR TITLE
Make log_determinant_spd work with size 0 inputs

### DIFF
--- a/stan/math/prim/mat/fun/log_determinant_spd.hpp
+++ b/stan/math/prim/mat/fun/log_determinant_spd.hpp
@@ -21,6 +21,9 @@ inline T log_determinant_spd(const Eigen::Matrix<T, R, C>& m) {
   using std::log;
   check_square("log_determinant_spd", "m", m);
   check_symmetric("log_determinant_spd", "m", m);
+  if (m.size() == 0)
+    return 0;
+
   return m.ldlt().vectorD().array().log().sum();
 }
 

--- a/stan/math/rev/mat/fun/log_determinant_spd.hpp
+++ b/stan/math/rev/mat/fun/log_determinant_spd.hpp
@@ -17,6 +17,8 @@ template <int R, int C>
 inline var log_determinant_spd(const Eigen::Matrix<var, R, C>& m) {
   check_square("log_determinant_spd", "m", m);
   check_symmetric("log_determinant_spd", "m", m);
+  if (m.size() == 0)
+    return 0;
 
   matrix_d m_d = m.val();
 

--- a/test/unit/math/mix/mat/fun/log_determinant_spd_test.cpp
+++ b/test/unit/math/mix/mat/fun/log_determinant_spd_test.cpp
@@ -10,6 +10,9 @@ TEST(MathMixMatFun, logDeterminantSpd) {
   // for testing error conditions
   auto g = [](const auto& x) { return stan::math::log_determinant_spd(x); };
 
+  Eigen::MatrixXd m00(0, 0);
+  stan::test::expect_ad(f, m00);
+
   Eigen::MatrixXd a(2, 2);
   a << 3, 0, 0, 4;
   stan::test::expect_ad(f, a);


### PR DESCRIPTION
## Summary

Fix #1434 so that in case of matrix of size 0 we return 0 immediately.

## Tests

Added test mentioned in the issue.

## Side Effects

None.

## Checklist

- [X] Math issue #1434

- [X] Copyright holder: Marco Colombo

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [X] the new changes are tested
