### PR TITLE
Make matrix_exp_pade work on size 0 inputs

### DIFF
--- a/stan/math/prim/mat/fun/MatrixExponential.h
+++ b/stan/math/prim/mat/fun/MatrixExponential.h
@@ -55,7 +55,7 @@ namespace Eigen {
   };
 
 
-  /** \brief Compute the (5,5)-Pad&eacute; approximant to the exponential.
+  /** \brief Compute the (3,3)-Pad&eacute; approximant to the exponential.
    *
    *  After exit, \f$ (V+U)(V-U)^{-1} \f$ is the Pad&eacute;
    *  approximant of \f$ \exp(A) \f$ around \f$ A = 0 \f$.

--- a/stan/math/prim/mat/fun/matrix_exp_pade.hpp
+++ b/stan/math/prim/mat/fun/matrix_exp_pade.hpp
@@ -1,7 +1,6 @@
 #ifndef STAN_MATH_PRIM_MAT_FUN_MATRIX_EXP_PADE_HPP
 #define STAN_MATH_PRIM_MAT_FUN_MATRIX_EXP_PADE_HPP
 
-#include <stan/math/prim/mat/err/check_nonempty.hpp>
 #include <stan/math/prim/mat/fun/MatrixExponential.h>
 
 namespace stan {

--- a/stan/math/prim/mat/fun/matrix_exp_pade.hpp
+++ b/stan/math/prim/mat/fun/matrix_exp_pade.hpp
@@ -1,6 +1,7 @@
 #ifndef STAN_MATH_PRIM_MAT_FUN_MATRIX_EXP_PADE_HPP
 #define STAN_MATH_PRIM_MAT_FUN_MATRIX_EXP_PADE_HPP
 
+#include <stan/math/prim/mat/err/check_nonempty.hpp>
 #include <stan/math/prim/mat/fun/MatrixExponential.h>
 
 namespace stan {
@@ -20,6 +21,7 @@ template <typename MatrixType>
 MatrixType matrix_exp_pade(const MatrixType& arg) {
   MatrixType U, V;
   int squarings;
+  check_nonempty("matrix_exp_pade", "arg", arg);
   Eigen::matrix_exp_computeUV<MatrixType>::run(arg, U, V, squarings, arg(0, 0));
   // Pade approximant is
   // (U+V) / (-U+V)

--- a/stan/math/prim/mat/fun/matrix_exp_pade.hpp
+++ b/stan/math/prim/mat/fun/matrix_exp_pade.hpp
@@ -21,7 +21,9 @@ template <typename MatrixType>
 MatrixType matrix_exp_pade(const MatrixType& arg) {
   MatrixType U, V;
   int squarings;
-  check_nonempty("matrix_exp_pade", "arg", arg);
+  if (arg.size() == 0)
+    return {};
+
   Eigen::matrix_exp_computeUV<MatrixType>::run(arg, U, V, squarings, arg(0, 0));
   // Pade approximant is
   // (U+V) / (-U+V)

--- a/test/unit/math/mix/mat/fun/matrix_exp_pade_test.cpp
+++ b/test/unit/math/mix/mat/fun/matrix_exp_pade_test.cpp
@@ -3,6 +3,9 @@
 TEST(MathMixMatFun, matrixExpPade) {
   auto f = [](const auto& x) { return stan::math::matrix_exp_pade(x); };
 
+  Eigen::MatrixXd m00(0, 0);
+  stan::test::expect_ad(f, m00);
+
   Eigen::MatrixXd a1(1, 1);
   a1 << 1;
   stan::test::expect_ad(f, a1);


### PR DESCRIPTION
## Summary

Fixes #1435 so that on inputs of size 0 it returns an empty matrix.

## Tests

Added test mentioned in the issue.

## Side Effects

None.

## Checklist

- [X] Math issue #1435

- [X] Copyright holder: Marco Colombo

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [X] the new changes are tested
