### PR TITLE
Make corr_matrix_transform work for size 0 inputs

### DIFF
--- a/stan/math/prim/mat/fun/read_corr_matrix.hpp
+++ b/stan/math/prim/mat/fun/read_corr_matrix.hpp
@@ -25,7 +25,7 @@ template <typename T>
 Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> read_corr_matrix(
     const Eigen::Array<T, Eigen::Dynamic, 1>& CPCs, size_t K) {
   if (K == 0)
-    return Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>();
+    return {};
 
   Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> L = read_corr_L(CPCs, K);
   return multiply_lower_tri_self_transpose(L);

--- a/stan/math/prim/mat/fun/read_corr_matrix.hpp
+++ b/stan/math/prim/mat/fun/read_corr_matrix.hpp
@@ -24,6 +24,9 @@ namespace math {
 template <typename T>
 Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> read_corr_matrix(
     const Eigen::Array<T, Eigen::Dynamic, 1>& CPCs, size_t K) {
+  if (K == 0)
+    return Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>();
+
   Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> L = read_corr_L(CPCs, K);
   return multiply_lower_tri_self_transpose(L);
 }
@@ -49,6 +52,9 @@ Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> read_corr_matrix(
 template <typename T>
 Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> read_corr_matrix(
     const Eigen::Array<T, Eigen::Dynamic, 1>& CPCs, size_t K, T& log_prob) {
+  if (K == 0)
+    return Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>();
+
   Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> L
       = read_corr_L(CPCs, K, log_prob);
   return multiply_lower_tri_self_transpose(L);

--- a/test/unit/math/mix/mat/fun/corr_matrix_constrain_test.cpp
+++ b/test/unit/math/mix/mat/fun/corr_matrix_constrain_test.cpp
@@ -48,6 +48,9 @@ void expect_corr_matrix_transform(const T& x) {
 TEST(MathMixMatFun, corr_matrixTransform) {
   // sizes must be (n choose 2)
 
+  Eigen::VectorXd v0(0);
+  expect_corr_matrix_transform(v0);
+
   Eigen::VectorXd v1(1);
   v1 << -1.7;
   expect_corr_matrix_transform(v1);


### PR DESCRIPTION
## Summary

Fixes #1430.

## Tests

Added test mentioned in the issue.

## Side Effects

None.

## Checklist

- [X] Math issue #1430

- [X] Copyright holder: Marco Colombo

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [X] the new changes are tested
