### PR TITLE
Make the matrix exponential functions work on 0 size inputs

### DIFF
--- a/stan/math/prim/mat/fun/matrix_exp.hpp
+++ b/stan/math/prim/mat/fun/matrix_exp.hpp
@@ -14,13 +14,14 @@ namespace math {
  * @tparam T type of scalar of the elements of
  * input matrix.
  * @param[in] A Matrix to exponentiate.
- * @return Matrix exponential, dynacally-sized.
+ * @return Matrix exponential, dynamically-sized.
  */
 template <typename T>
 inline Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> matrix_exp(
     const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& A) {
-  check_nonzero_size("matrix_exp", "input matrix", A);
   check_square("matrix_exp", "input matrix", A);
+  if (A.size() == 0)
+    return {};
 
   return (A.cols() == 2
           && square(value_of(A(0, 0)) - value_of(A(1, 1)))
@@ -42,7 +43,8 @@ inline Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> matrix_exp(
  */
 template <typename T, int N>
 inline Eigen::Matrix<T, N, N> matrix_exp(const Eigen::Matrix<T, N, N>& A) {
-  check_nonzero_size("matrix_exp", "input matrix", A);
+  if (N == 0)
+    return {};
 
   return (N == 2
           && square(value_of(A(0, 0)) - value_of(A(1, 1)))

--- a/stan/math/prim/mat/fun/matrix_exp_multiply.hpp
+++ b/stan/math/prim/mat/fun/matrix_exp_multiply.hpp
@@ -18,10 +18,11 @@ namespace math {
 template <int Cb>
 inline Eigen::Matrix<double, -1, Cb> matrix_exp_multiply(
     const Eigen::MatrixXd& A, const Eigen::Matrix<double, -1, Cb>& B) {
-  check_nonzero_size("scale_matrix_exp_multiply", "input matrix", A);
-  check_nonzero_size("scale_matrix_exp_multiply", "input matrix", B);
   check_multiplicable("scale_matrix_exp_multiply", "A", A, "B", B);
   check_square("scale_matrix_exp_multiply", "input matrix", A);
+  if (A.size() == 0)
+    return {};
+
   return matrix_exp_action_handler().action(A, B);
 }
 

--- a/stan/math/prim/mat/fun/scale_matrix_exp_multiply.hpp
+++ b/stan/math/prim/mat/fun/scale_matrix_exp_multiply.hpp
@@ -20,10 +20,11 @@ template <int Cb>
 inline Eigen::Matrix<double, -1, Cb> scale_matrix_exp_multiply(
     const double& t, const Eigen::MatrixXd& A,
     const Eigen::Matrix<double, -1, Cb>& B) {
-  check_nonzero_size("scale_matrix_exp_multiply", "input matrix", A);
-  check_nonzero_size("scale_matrix_exp_multiply", "input matrix", B);
   check_multiplicable("scale_matrix_exp_multiply", "A", A, "B", B);
   check_square("scale_matrix_exp_multiply", "input matrix", A);
+  if (A.size() == 0)
+    return {};
+
   return matrix_exp_action_handler().action(A, B, t);
 }
 

--- a/stan/math/rev/mat/fun/matrix_exp_multiply.hpp
+++ b/stan/math/rev/mat/fun/matrix_exp_multiply.hpp
@@ -3,7 +3,6 @@
 
 #include <stan/math/rev/meta.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
-#include <stan/math/prim/arr/err/check_nonzero_size.hpp>
 #include <stan/math/prim/mat/err/check_multiplicable.hpp>
 #include <stan/math/prim/mat/err/check_square.hpp>
 #include <stan/math/prim/mat/fun/matrix_exp.hpp>
@@ -26,10 +25,11 @@ template <typename Ta, typename Tb, int Cb>
 inline Eigen::Matrix<typename stan::return_type<Ta, Tb>::type, -1, Cb>
 matrix_exp_multiply(const Eigen::Matrix<Ta, -1, -1>& A,
                     const Eigen::Matrix<Tb, -1, Cb>& B) {
-  check_nonzero_size("matrix_exp_multiply", "input matrix", A);
-  check_nonzero_size("matrix_exp_multiply", "input matrix", B);
   check_multiplicable("matrix_exp_multiply", "A", A, "B", B);
   check_square("matrix_exp_multiply", "input matrix", A);
+  if (A.size() == 0)
+    return {};
+
   return multiply(matrix_exp(A), B);
 }
 

--- a/stan/math/rev/mat/fun/scale_matrix_exp_multiply.hpp
+++ b/stan/math/rev/mat/fun/scale_matrix_exp_multiply.hpp
@@ -3,7 +3,6 @@
 
 #include <stan/math/rev/meta.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
-#include <stan/math/prim/arr/err/check_nonzero_size.hpp>
 #include <stan/math/prim/mat/err/check_multiplicable.hpp>
 #include <stan/math/prim/mat/err/check_square.hpp>
 #include <stan/math/prim/mat/fun/matrix_exp.hpp>
@@ -29,10 +28,11 @@ template <typename Ta, typename Tb, int Cb>
 inline Eigen::Matrix<typename stan::return_type<Ta, Tb>::type, -1, Cb>
 scale_matrix_exp_multiply(const double& t, const Eigen::Matrix<Ta, -1, -1>& A,
                           const Eigen::Matrix<Tb, -1, Cb>& B) {
-  check_nonzero_size("scale_matrix_exp_multiply", "input matrix", A);
-  check_nonzero_size("scale_matrix_exp_multiply", "input matrix", B);
   check_multiplicable("scale_matrix_exp_multiply", "A", A, "B", B);
   check_square("scale_matrix_exp_multiply", "input matrix", A);
+  if (A.size() == 0)
+    return {};
+
   return multiply(matrix_exp(multiply(A, t)), B);
 }
 

--- a/test/unit/math/prim/mat/fun/matrix_exp_pade_test.cpp
+++ b/test/unit/math/prim/mat/fun/matrix_exp_pade_test.cpp
@@ -5,6 +5,12 @@
 #include <algorithm>
 #include <random>
 
+TEST(MathMatrix, matrix_exp_pade_0x0) {
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> m1(0, 0);
+
+  expect_matrix_eq(m1, stan::math::matrix_exp_pade(m1));
+}
+
 TEST(MathMatrix, matrix_exp_pade_1x1) {
   Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> m1(1, 1), m2(1, 1);
   m1 << 0;

--- a/test/unit/math/prim/mat/fun/matrix_exp_test.cpp
+++ b/test/unit/math/prim/mat/fun/matrix_exp_test.cpp
@@ -6,6 +6,12 @@
 #include <algorithm>
 #include <random>
 
+TEST(MathMatrix, matrix_exp_0x0) {
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> m1(0, 0);
+
+  expect_matrix_eq(m1, stan::math::matrix_exp(m1));
+}
+
 TEST(MathMatrix, matrix_exp_1x1) {
   Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> m1(1, 1), m2(1, 1);
   m1 << 0;
@@ -95,7 +101,7 @@ TEST(MathMatrix, matrix_exp_exceptions) {
 
   Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> m1(0, 0), m2(1, 2);
 
-  EXPECT_THROW(matrix_exp(m1), std::invalid_argument);
+  EXPECT_NO_THROW(matrix_exp(m1));
   EXPECT_THROW(matrix_exp(m2), std::invalid_argument);
 }
 


### PR DESCRIPTION
## Summary

This fixes #1456, so that for size 0 inputs the matrix exponential functions return an empty matrix.

## Tests

There are already tests for size 0 inputs regarding these functions, I've added a couple more and modified one that was expecting a throw. It's worth checking that I haven't missed any.

## Side Effects

None.

## Checklist

- [X] Math issue #1456

- [X] Copyright holder: Marco Colombo

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [X] the new changes are tested
