### PR TITLE
Make log_sum_exp return negative infinity for size 0 inputs

### DIFF
--- a/stan/math/prim/mat/fun/log_sum_exp.hpp
+++ b/stan/math/prim/mat/fun/log_sum_exp.hpp
@@ -25,8 +25,9 @@ namespace math {
  */
 template <int R, int C>
 double log_sum_exp(const Eigen::Matrix<double, R, C>& x) {
-  if (x.size() == 0)
+  if (x.size() == 0) {
     return -std::numeric_limits<double>::infinity();
+  }
 
   const double max = x.maxCoeff();
   if (!std::isfinite(max)) {

--- a/stan/math/prim/mat/fun/log_sum_exp.hpp
+++ b/stan/math/prim/mat/fun/log_sum_exp.hpp
@@ -4,6 +4,7 @@
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <vector>
 #include <cmath>
+#include <limits>
 
 namespace stan {
 namespace math {
@@ -24,6 +25,9 @@ namespace math {
  */
 template <int R, int C>
 double log_sum_exp(const Eigen::Matrix<double, R, C>& x) {
+  if (x.size() == 0)
+    return -std::numeric_limits<double>::infinity();
+
   const double max = x.maxCoeff();
   if (!std::isfinite(max)) {
     return max;

--- a/stan/math/rev/mat/fun/log_sum_exp.hpp
+++ b/stan/math/rev/mat/fun/log_sum_exp.hpp
@@ -19,8 +19,9 @@ namespace internal {
 
 template <int R, int C>
 inline double log_sum_exp_as_double(const Eigen::Matrix<var, R, C>& x) {
-  if (x.size() == 0)
+  if (x.size() == 0) {
     return -std::numeric_limits<double>::infinity();
+  }
 
   const double max = x.val().maxCoeff();
   if (!std::isfinite(max)) {

--- a/stan/math/rev/mat/fun/log_sum_exp.hpp
+++ b/stan/math/rev/mat/fun/log_sum_exp.hpp
@@ -19,6 +19,9 @@ namespace internal {
 
 template <int R, int C>
 inline double log_sum_exp_as_double(const Eigen::Matrix<var, R, C>& x) {
+  if (x.size() == 0)
+    return -std::numeric_limits<double>::infinity();
+
   const double max = x.val().maxCoeff();
   if (!std::isfinite(max)) {
     return max;

--- a/test/unit/math/mix/mat/fun/log_sum_exp_test.cpp
+++ b/test/unit/math/mix/mat/fun/log_sum_exp_test.cpp
@@ -5,6 +5,9 @@
 TEST(MathMixMatFun, logSumExp) {
   auto f = [](const auto& x) { return stan::math::log_sum_exp(x); };
 
+  Eigen::VectorXd x0(0);
+  stan::test::expect_ad(f, x0);
+
   Eigen::VectorXd x1(1);
   x1 << 0;
 


### PR DESCRIPTION
## Summary

This fixes #1416 by making log_sum_exp return negative infinity for size 0 inputs.

## Tests

Added test mentioned in https://github.com/stan-dev/math/issues/1416#issuecomment-545579652.

## Side Effects

None.

## Checklist

- [X] Math issue #1416

- [x] Copyright holder: Marco Colombo

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
