### PR TITLE
follow-up fixes for matrix exponentials on size 0 inputs

### DIFF
--- a/stan/math/prim/mat/fun/matrix_exp_multiply.hpp
+++ b/stan/math/prim/mat/fun/matrix_exp_multiply.hpp
@@ -18,10 +18,11 @@ namespace math {
 template <int Cb>
 inline Eigen::Matrix<double, -1, Cb> matrix_exp_multiply(
     const Eigen::MatrixXd& A, const Eigen::Matrix<double, -1, Cb>& B) {
-  check_multiplicable("scale_matrix_exp_multiply", "A", A, "B", B);
-  check_square("scale_matrix_exp_multiply", "input matrix", A);
-  if (A.size() == 0)
+  if (A.size() == 0 && B.size() == 0)
     return {};
+
+  check_multiplicable("matrix_exp_multiply", "A", A, "B", B);
+  check_square("matrix_exp_multiply", "input matrix", A);
 
   return matrix_exp_action_handler().action(A, B);
 }

--- a/stan/math/prim/mat/fun/scale_matrix_exp_multiply.hpp
+++ b/stan/math/prim/mat/fun/scale_matrix_exp_multiply.hpp
@@ -20,10 +20,11 @@ template <int Cb>
 inline Eigen::Matrix<double, -1, Cb> scale_matrix_exp_multiply(
     const double& t, const Eigen::MatrixXd& A,
     const Eigen::Matrix<double, -1, Cb>& B) {
+  if (A.size() == 0 && B.size() == 0)
+    return {};
+
   check_multiplicable("scale_matrix_exp_multiply", "A", A, "B", B);
   check_square("scale_matrix_exp_multiply", "input matrix", A);
-  if (A.size() == 0)
-    return {};
 
   return matrix_exp_action_handler().action(A, B, t);
 }

--- a/stan/math/rev/mat/fun/matrix_exp_multiply.hpp
+++ b/stan/math/rev/mat/fun/matrix_exp_multiply.hpp
@@ -25,10 +25,11 @@ template <typename Ta, typename Tb, int Cb>
 inline Eigen::Matrix<typename stan::return_type<Ta, Tb>::type, -1, Cb>
 matrix_exp_multiply(const Eigen::Matrix<Ta, -1, -1>& A,
                     const Eigen::Matrix<Tb, -1, Cb>& B) {
+  if (A.size() == 0 && B.size() == 0)
+    return {};
+
   check_multiplicable("matrix_exp_multiply", "A", A, "B", B);
   check_square("matrix_exp_multiply", "input matrix", A);
-  if (A.size() == 0)
-    return {};
 
   return multiply(matrix_exp(A), B);
 }

--- a/stan/math/rev/mat/fun/scale_matrix_exp_multiply.hpp
+++ b/stan/math/rev/mat/fun/scale_matrix_exp_multiply.hpp
@@ -28,10 +28,11 @@ template <typename Ta, typename Tb, int Cb>
 inline Eigen::Matrix<typename stan::return_type<Ta, Tb>::type, -1, Cb>
 scale_matrix_exp_multiply(const double& t, const Eigen::Matrix<Ta, -1, -1>& A,
                           const Eigen::Matrix<Tb, -1, Cb>& B) {
+  if (A.size() == 0 && B.size() == 0)
+    return {};
+
   check_multiplicable("scale_matrix_exp_multiply", "A", A, "B", B);
   check_square("scale_matrix_exp_multiply", "input matrix", A);
-  if (A.size() == 0)
-    return {};
 
   return multiply(matrix_exp(multiply(A, t)), B);
 }

--- a/test/unit/math/prim/mat/fun/matrix_exp_multiply_test.cpp
+++ b/test/unit/math/prim/mat/fun/matrix_exp_multiply_test.cpp
@@ -43,7 +43,7 @@ TEST(MathMatrix, matrix_exp_multiply) {
 
 TEST(MathMatrix, matrix_exp_multiply_exception) {
   using stan::math::matrix_exp_multiply;
-  {  // nonzero size
+  {  // multiplicable
     Eigen::MatrixXd A(0, 0);
     Eigen::MatrixXd B = Eigen::MatrixXd::Random(1, 2);
     EXPECT_THROW(matrix_exp_multiply(A, B), std::invalid_argument);
@@ -53,6 +53,12 @@ TEST(MathMatrix, matrix_exp_multiply_exception) {
   {  // multiplicable
     Eigen::MatrixXd A = Eigen::MatrixXd::Random(2, 2);
     Eigen::MatrixXd B = Eigen::MatrixXd::Random(3, 2);
+    EXPECT_THROW(matrix_exp_multiply(A, B), std::invalid_argument);
+  }
+
+  {  // square
+    Eigen::MatrixXd A(0, 1);
+    Eigen::MatrixXd B(1, 2);
     EXPECT_THROW(matrix_exp_multiply(A, B), std::invalid_argument);
   }
 

--- a/test/unit/math/prim/mat/fun/matrix_exp_multiply_test.cpp
+++ b/test/unit/math/prim/mat/fun/matrix_exp_multiply_test.cpp
@@ -29,6 +29,12 @@ inline void test_matrix_exp_multiply() {
 }
 
 TEST(MathMatrix, matrix_exp_multiply) {
+
+  // the helper above doesn't handle 0 size inputs
+  Eigen::MatrixXd A(0, 0);
+  Eigen::MatrixXd B(0, 0);
+  EXPECT_EQ(stan::math::matrix_exp_multiply(A, B), A);
+
   test_matrix_exp_multiply<1, 1>();
   test_matrix_exp_multiply<1, 5>();
   test_matrix_exp_multiply<5, 1>();

--- a/test/unit/math/prim/mat/fun/matrix_exp_multiply_test.cpp
+++ b/test/unit/math/prim/mat/fun/matrix_exp_multiply_test.cpp
@@ -29,7 +29,6 @@ inline void test_matrix_exp_multiply() {
 }
 
 TEST(MathMatrix, matrix_exp_multiply) {
-
   // the helper above doesn't handle 0 size inputs
   Eigen::MatrixXd A(0, 0);
   Eigen::MatrixXd B(0, 0);

--- a/test/unit/math/prim/mat/fun/matrix_exp_multiply_test.cpp
+++ b/test/unit/math/prim/mat/fun/matrix_exp_multiply_test.cpp
@@ -32,7 +32,7 @@ TEST(MathMatrix, matrix_exp_multiply) {
   // the helper above doesn't handle 0 size inputs
   Eigen::MatrixXd A(0, 0);
   Eigen::MatrixXd B(0, 0);
-  EXPECT_EQ(stan::math::matrix_exp_multiply(A, B), A);
+  EXPECT_EQ(stan::math::matrix_exp_multiply(A, B).size(), 0);
 
   test_matrix_exp_multiply<1, 1>();
   test_matrix_exp_multiply<1, 5>();

--- a/test/unit/math/prim/mat/fun/scale_matrix_exp_multiply_test.cpp
+++ b/test/unit/math/prim/mat/fun/scale_matrix_exp_multiply_test.cpp
@@ -46,7 +46,7 @@ TEST(MathMatrix, scale_matrix_exp_multiply) {
 TEST(MathMatrix, scale_matrix_exp_multiply_exception) {
   using stan::math::scale_matrix_exp_multiply;
   const double t = 1.0;
-  {  // nonzero size
+  {  // multiplicable
     Eigen::MatrixXd A(0, 0);
     Eigen::MatrixXd B = Eigen::MatrixXd::Random(1, 2);
     EXPECT_THROW(scale_matrix_exp_multiply(t, A, B), std::invalid_argument);
@@ -56,6 +56,12 @@ TEST(MathMatrix, scale_matrix_exp_multiply_exception) {
   {  // multiplicable
     Eigen::MatrixXd A = Eigen::MatrixXd::Random(2, 2);
     Eigen::MatrixXd B = Eigen::MatrixXd::Random(3, 2);
+    EXPECT_THROW(scale_matrix_exp_multiply(t, A, B), std::invalid_argument);
+  }
+
+  {  // square
+    Eigen::MatrixXd A(0, 1);
+    Eigen::MatrixXd B(1, 2);
     EXPECT_THROW(scale_matrix_exp_multiply(t, A, B), std::invalid_argument);
   }
 

--- a/test/unit/math/prim/mat/fun/scale_matrix_exp_multiply_test.cpp
+++ b/test/unit/math/prim/mat/fun/scale_matrix_exp_multiply_test.cpp
@@ -30,6 +30,13 @@ inline void test_scale_matrix_exp_multiply() {
 }
 
 TEST(MathMatrix, scale_matrix_exp_multiply) {
+
+  // the helper above doesn't handle 0 size inputs
+  const double t = 1.0;
+  Eigen::MatrixXd A(0, 0);
+  Eigen::MatrixXd B(0, 0);
+  EXPECT_EQ(stan::math::scale_matrix_exp_multiply(t, A, B).size(), 0);
+
   test_scale_matrix_exp_multiply<1, 1>();
   test_scale_matrix_exp_multiply<1, 5>();
   test_scale_matrix_exp_multiply<5, 1>();

--- a/test/unit/math/prim/mat/fun/scale_matrix_exp_multiply_test.cpp
+++ b/test/unit/math/prim/mat/fun/scale_matrix_exp_multiply_test.cpp
@@ -30,7 +30,6 @@ inline void test_scale_matrix_exp_multiply() {
 }
 
 TEST(MathMatrix, scale_matrix_exp_multiply) {
-
   // the helper above doesn't handle 0 size inputs
   const double t = 1.0;
   Eigen::MatrixXd A(0, 0);

--- a/test/unit/math/rev/mat/fun/scale_matrix_exp_multiply_test.cpp
+++ b/test/unit/math/rev/mat/fun/scale_matrix_exp_multiply_test.cpp
@@ -182,6 +182,14 @@ TEST(MathMatrix, scale_matrix_exp_multiply_vv) {
   test_scale_matrix_exp_multiply_vv(8, 2);
 }
 
+TEST(MathMatrix, matrix_exp_multiply_0x0) {
+  using stan::math::var;
+  const double t = 1.0;
+  Eigen::Matrix<var, -1, -1> A(0, 0);
+  Eigen::Matrix<var, -1, -1> B(0, 0);
+  EXPECT_EQ(stan::math::scale_matrix_exp_multiply(t, A, B).size(), 0);
+}
+
 TEST(MathMatrix, scale_matrix_exp_multiply_exception) {
   using stan::math::var;
   const double t = 1.0;

--- a/test/unit/math/rev/mat/fun/scale_matrix_exp_multiply_test.cpp
+++ b/test/unit/math/rev/mat/fun/scale_matrix_exp_multiply_test.cpp
@@ -193,7 +193,7 @@ TEST(MathMatrix, matrix_exp_multiply_0x0) {
 TEST(MathMatrix, scale_matrix_exp_multiply_exception) {
   using stan::math::var;
   const double t = 1.0;
-  {  // nonzero size
+  {  // multiplicable
     Eigen::Matrix<var, -1, -1> A(0, 0);
     Eigen::Matrix<var, -1, -1> B = Eigen::Matrix<var, -1, -1>::Random(1, 2);
     EXPECT_THROW(scale_matrix_exp_multiply(t, A, B), std::invalid_argument);
@@ -203,6 +203,12 @@ TEST(MathMatrix, scale_matrix_exp_multiply_exception) {
   {  // multiplicable
     Eigen::Matrix<var, -1, -1> A = Eigen::Matrix<var, -1, -1>::Random(2, 2);
     Eigen::Matrix<var, -1, -1> B = Eigen::Matrix<var, -1, -1>::Random(3, 2);
+    EXPECT_THROW(scale_matrix_exp_multiply(t, A, B), std::invalid_argument);
+  }
+
+  {  // square
+    Eigen::Matrix<var, -1, -1> A = Eigen::Matrix<var, -1, -1>::Random(0, 1);
+    Eigen::Matrix<var, -1, -1> B = Eigen::Matrix<var, -1, -1>::Random(1, 2);
     EXPECT_THROW(scale_matrix_exp_multiply(t, A, B), std::invalid_argument);
   }
 


### PR DESCRIPTION
## Summary

The checks for 0 size for `matrix_exp_multiply` and `scale_matrix_exp_multiply` introduced in #1457 should happen before `check_multipliable`, as the latter throws on size 0 inputs. This was not caught by the existing tests. I've now added tests for this, and I have patches that move those 0 size checks around so that those functions really return an empty matrix on size 0 inputs.

## Tests

Added tests that fail with #1457 but succed with this PR.

## Side Effects

None

## Checklist

- [X] Math issue #1456

- [X] Copyright holder: Marco Colombo

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [X] the new changes are tested
