### PR TITLE
Make determinant work consistently on size 0 inputs

### DIFF
--- a/stan/math/prim/mat/fun/determinant.hpp
+++ b/stan/math/prim/mat/fun/determinant.hpp
@@ -17,6 +17,9 @@ namespace math {
 template <typename T, int R, int C>
 inline T determinant(const Eigen::Matrix<T, R, C>& m) {
   check_square("determinant", "m", m);
+  if (m.size() == 0)
+    return 1;
+
   return m.determinant();
 }
 

--- a/stan/math/prim/mat/fun/determinant.hpp
+++ b/stan/math/prim/mat/fun/determinant.hpp
@@ -17,8 +17,9 @@ namespace math {
 template <typename T, int R, int C>
 inline T determinant(const Eigen::Matrix<T, R, C>& m) {
   check_square("determinant", "m", m);
-  if (m.size() == 0)
+  if (m.size() == 0) {
     return 1;
+  }
 
   return m.determinant();
 }

--- a/stan/math/rev/mat/fun/determinant.hpp
+++ b/stan/math/rev/mat/fun/determinant.hpp
@@ -47,8 +47,9 @@ class determinant_vari : public vari {
 template <int R, int C>
 inline var determinant(const Eigen::Matrix<var, R, C>& m) {
   check_square("determinant", "m", m);
-  if (m.size() == 0)
+  if (m.size() == 0) {
     return 1;
+  }
 
   return var(new internal::determinant_vari<R, C>(m));
 }

--- a/stan/math/rev/mat/fun/determinant.hpp
+++ b/stan/math/rev/mat/fun/determinant.hpp
@@ -47,6 +47,9 @@ class determinant_vari : public vari {
 template <int R, int C>
 inline var determinant(const Eigen::Matrix<var, R, C>& m) {
   check_square("determinant", "m", m);
+  if (m.size() == 0)
+    return 1;
+
   return var(new internal::determinant_vari<R, C>(m));
 }
 

--- a/test/unit/math/mix/mat/fun/determinant_test.cpp
+++ b/test/unit/math/mix/mat/fun/determinant_test.cpp
@@ -9,6 +9,8 @@ TEST(MathMixMatFun, determinant) {
   tols.hessian_hessian_ = 1e-2;       // default 1e-3
   tols.hessian_fvar_hessian_ = 1e-2;  // default 1e-3
 
+  Eigen::MatrixXd z(0, 0);
+
   Eigen::MatrixXd a(1, 1);
   a << -1;
 
@@ -33,6 +35,6 @@ TEST(MathMixMatFun, determinant) {
     }
   }
 
-  for (const auto& x : std::vector<Eigen::MatrixXd>{a, b, c, d, e, g})
+  for (const auto& x : std::vector<Eigen::MatrixXd>{z, a, b, c, d, e, g})
     stan::test::expect_ad(tols, f, x);
 }


### PR DESCRIPTION
## Summary

Fixes #1431 by returning 1 for size 0 inputs.

## Tests

Added the one mentioned in the issue.

## Side Effects

None.

## Checklist

- [X] Math issue #1431

- [X] Copyright holder: Marco Colombo

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [X] the new changes are tested
