### PR TITLE
Throw from inverse_spd on size 0 inputs

### DIFF
--- a/stan/math/prim/mat/fun/inverse_spd.hpp
+++ b/stan/math/prim/mat/fun/inverse_spd.hpp
@@ -2,6 +2,7 @@
 #define STAN_MATH_PRIM_MAT_FUN_INVERSE_SPD_HPP
 
 #include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <stan/math/prim/mat/err/check_nonempty.hpp>
 #include <stan/math/prim/mat/err/check_square.hpp>
 #include <stan/math/prim/mat/err/check_symmetric.hpp>
 #include <stan/math/prim/scal/err/domain_error.hpp>
@@ -20,6 +21,7 @@ inline Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> inverse_spd(
   using Eigen::Dynamic;
   using Eigen::LDLT;
   using Eigen::Matrix;
+  check_nonempty("inverse_spd", "m", m);
   check_square("inverse_spd", "m", m);
   check_symmetric("inverse_spd", "m", m);
   Matrix<T, Dynamic, Dynamic> mmt = T(0.5) * (m + m.transpose());

--- a/test/unit/math/mix/mat/fun/inverse_spd_test.cpp
+++ b/test/unit/math/mix/mat/fun/inverse_spd_test.cpp
@@ -8,6 +8,9 @@ TEST(MathMixMatFun, inverseSpd) {
     return stan::math::inverse_spd(y);
   };
 
+  Eigen::MatrixXd m00(0, 0);
+  stan::test::expect_ad(f, m00);
+
   Eigen::MatrixXd m11(1, 1);
   m11 << 1.3;
   stan::test::expect_ad(f, m11);

--- a/test/unit/math/prim/mat/fun/inverse_spd_test.cpp
+++ b/test/unit/math/prim/mat/fun/inverse_spd_test.cpp
@@ -4,6 +4,10 @@
 TEST(MathMatrix, inverse_spd_exception) {
   using stan::math::inverse_spd;
 
+  // empty
+  stan::math::matrix_d m0(0, 0);
+  EXPECT_THROW(inverse_spd(m0), std::invalid_argument);
+
   stan::math::matrix_d m1(2, 3);
 
   // non-square


### PR DESCRIPTION
## Summary

Fixes #1432.

## Tests

Added the test mentioned in the issue.

## Side Effects

None.

## Checklist

- [X] Math issue #1432

- [X] Copyright holder: Marco Colombo

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [X] the new changes are tested
