### PR TITLE
Make some *_ldlt functions work with size 0 inputs

### DIFF
--- a/stan/math/prim/mat/fun/log_determinant_ldlt.hpp
+++ b/stan/math/prim/mat/fun/log_determinant_ldlt.hpp
@@ -9,6 +9,10 @@ namespace math {
 // Returns log(abs(det(A))) given a LDLT_factor of A
 template <int R, int C, typename T>
 inline T log_determinant_ldlt(LDLT_factor<T, R, C> &A) {
+  if (A.rows() == 0) {
+    return 0;
+  }
+
   return A.log_abs_det();
 }
 

--- a/stan/math/prim/mat/fun/mdivide_left_ldlt.hpp
+++ b/stan/math/prim/mat/fun/mdivide_left_ldlt.hpp
@@ -15,13 +15,17 @@ namespace math {
  * Returns the solution of the system Ax=b given an LDLT_factor of A
  * @param A LDLT_factor
  * @param b Right hand side matrix or vector.
- * @return x = b A^-1, solution of the linear system.
+ * @return x = A^-1 b, solution of the linear system.
  * @throws std::domain_error if rows of b don't match the size of A.
  */
 
 template <int R1, int C1, int R2, int C2, typename T1, typename T2>
 inline Eigen::Matrix<return_type_t<T1, T2>, R1, C2> mdivide_left_ldlt(
     const LDLT_factor<T1, R1, C1> &A, const Eigen::Matrix<T2, R2, C2> &b) {
+  if (A.cols() == 0 && b.rows() == 0) {
+    return {};
+  }
+
   check_multiplicable("mdivide_left_ldlt", "A", A, "b", b);
 
   return A.solve(

--- a/stan/math/prim/mat/fun/mdivide_right_ldlt.hpp
+++ b/stan/math/prim/mat/fun/mdivide_right_ldlt.hpp
@@ -15,13 +15,17 @@ namespace math {
  * Returns the solution of the system xA=b given an LDLT_factor of A
  * @param A LDLT_factor
  * @param b Right hand side matrix or vector.
- * @return x = A^-1 b, solution of the linear system.
+ * @return x = b A^-1, solution of the linear system.
  * @throws std::domain_error if rows of b don't match the size of A.
  */
 
 template <typename T1, typename T2, int R1, int C1, int R2, int C2>
 inline Eigen::Matrix<return_type_t<T1, T2>, R1, C2> mdivide_right_ldlt(
     const Eigen::Matrix<T1, R1, C1> &b, const LDLT_factor<T2, R2, C2> &A) {
+  if (b.cols() == 0 && A.rows() == 0) {
+    return {};
+  }
+
   check_multiplicable("mdivide_right_ldlt", "b", b, "A", A);
 
   return transpose(mdivide_left_ldlt(A, transpose(b)));
@@ -31,7 +35,12 @@ template <int R1, int C1, int R2, int C2>
 inline Eigen::Matrix<double, R1, C2> mdivide_right_ldlt(
     const Eigen::Matrix<double, R1, C1> &b,
     const LDLT_factor<double, R2, C2> &A) {
+  if (b.cols() == 0 && A.rows() == 0) {
+    return {};
+  }
+
   check_multiplicable("mdivide_right_ldlt", "b", b, "A", A);
+
   return A.solveRight(b);
 }
 

--- a/stan/math/prim/mat/fun/trace_inv_quad_form_ldlt.hpp
+++ b/stan/math/prim/mat/fun/trace_inv_quad_form_ldlt.hpp
@@ -22,6 +22,10 @@ template <typename T1, typename T2, int R2, int C2, int R3, int C3,
           typename = require_any_not_var_t<T1, T2>>
 inline return_type_t<T1, T2> trace_inv_quad_form_ldlt(
     const LDLT_factor<T1, R2, C2> &A, const Eigen::Matrix<T2, R3, C3> &B) {
+  if (A.rows() == 0 && B.size() == 0) {
+    return 0;
+  }
+
   check_multiplicable("trace_inv_quad_form_ldlt", "A", A, "B", B);
 
   return trace(multiply(transpose(B), mdivide_left_ldlt(A, B)));

--- a/stan/math/rev/mat/fun/log_determinant_ldlt.hpp
+++ b/stan/math/rev/mat/fun/log_determinant_ldlt.hpp
@@ -40,6 +40,10 @@ class log_det_ldlt_vari : public vari {
 
 template <int R, int C>
 var log_determinant_ldlt(LDLT_factor<var, R, C> &A) {
+  if (A.rows() == 0) {
+    return 0;
+  }
+
   return var(new internal::log_det_ldlt_vari<R, C>(A));
 }
 

--- a/stan/math/rev/mat/fun/mdivide_left_ldlt.hpp
+++ b/stan/math/rev/mat/fun/mdivide_left_ldlt.hpp
@@ -32,7 +32,7 @@ class mdivide_left_ldlt_alloc : public chainable_alloc {
  * used in the other matrix operations where there is one "master"
  * vari whose value is never used and a large number of "slave" varis
  * whose chain() functions are never called because their adjoints are
- * set by the "mater" vari.
+ * set by the "master" vari.
  *
  * This class handles the var/var case.
  **/
@@ -83,7 +83,7 @@ class mdivide_left_ldlt_vv_vari : public vari {
  * used in the other matrix operations where there is one "master"
  * vari whose value is never used and a large number of "slave" varis
  * whose chain() functions are never called because their adjoints are
- * set by the "mater" vari.
+ * set by the "master" vari.
  *
  * This class handles the double/var case.
  **/
@@ -129,7 +129,7 @@ class mdivide_left_ldlt_dv_vari : public vari {
  * used in the other matrix operations where there is one "master"
  * vari whose value is never used and a large number of "slave" varis
  * whose chain() functions are never called because their adjoints are
- * set by the "mater" vari.
+ * set by the "master" vari.
  *
  * This class handles the var/double case.
  **/
@@ -171,13 +171,17 @@ class mdivide_left_ldlt_vd_vari : public vari {
  * Returns the solution of the system Ax=b given an LDLT_factor of A
  * @param A LDLT_factor
  * @param b Right hand side matrix or vector.
- * @return x = b A^-1, solution of the linear system.
+ * @return x = A^-1 b, solution of the linear system.
  * @throws std::domain_error if rows of b don't match the size of A.
  */
 template <int R1, int C1, int R2, int C2>
 inline Eigen::Matrix<var, R1, C2> mdivide_left_ldlt(
     const LDLT_factor<var, R1, C1> &A, const Eigen::Matrix<var, R2, C2> &b) {
   Eigen::Matrix<var, R1, C2> res(b.rows(), b.cols());
+
+  if (A.cols() == 0 && b.rows() == 0) {
+    return {};
+  }
 
   check_multiplicable("mdivide_left_ldlt", "A", A, "b", b);
 
@@ -193,13 +197,16 @@ inline Eigen::Matrix<var, R1, C2> mdivide_left_ldlt(
  * Returns the solution of the system Ax=b given an LDLT_factor of A
  * @param A LDLT_factor
  * @param b Right hand side matrix or vector.
- * @return x = b A^-1, solution of the linear system.
+ * @return x = A^-1 b, solution of the linear system.
  * @throws std::domain_error if rows of b don't match the size of A.
  */
 template <int R1, int C1, int R2, int C2>
 inline Eigen::Matrix<var, R1, C2> mdivide_left_ldlt(
     const LDLT_factor<var, R1, C1> &A, const Eigen::Matrix<double, R2, C2> &b) {
   Eigen::Matrix<var, R1, C2> res(b.rows(), b.cols());
+  if (A.cols() == 0 && b.rows() == 0) {
+    return {};
+  }
 
   check_multiplicable("mdivide_left_ldlt", "A", A, "b", b);
 
@@ -215,13 +222,16 @@ inline Eigen::Matrix<var, R1, C2> mdivide_left_ldlt(
  * Returns the solution of the system Ax=b given an LDLT_factor of A
  * @param A LDLT_factor
  * @param b Right hand side matrix or vector.
- * @return x = b A^-1, solution of the linear system.
+ * @return x = A^-1 b, solution of the linear system.
  * @throws std::domain_error if rows of b don't match the size of A.
  */
 template <int R1, int C1, int R2, int C2>
 inline Eigen::Matrix<var, R1, C2> mdivide_left_ldlt(
     const LDLT_factor<double, R1, C1> &A, const Eigen::Matrix<var, R2, C2> &b) {
   Eigen::Matrix<var, R1, C2> res(b.rows(), b.cols());
+  if (A.cols() == 0 && b.rows() == 0) {
+    return {};
+  }
 
   check_multiplicable("mdivide_left_ldlt", "A", A, "b", b);
 

--- a/stan/math/rev/mat/fun/trace_inv_quad_form_ldlt.hpp
+++ b/stan/math/rev/mat/fun/trace_inv_quad_form_ldlt.hpp
@@ -147,6 +147,10 @@ template <typename T2, int R2, int C2, typename T3, int R3, int C3,
           typename = require_any_var_t<T2, T3>>
 inline return_type_t<T2, T3> trace_inv_quad_form_ldlt(
     const LDLT_factor<T2, R2, C2> &A, const Eigen::Matrix<T3, R3, C3> &B) {
+  if (A.rows() == 0 && B.size() == 0) {
+    return 0;
+  }
+
   check_multiplicable("trace_inv_quad_form_ldlt", "A", A, "B", B);
 
   internal::trace_inv_quad_form_ldlt_impl<T2, R2, C2, T3, R3, C3> *impl_

--- a/test/unit/math/mix/mat/fun/log_determinant_ldlt_test.cpp
+++ b/test/unit/math/mix/mat/fun/log_determinant_ldlt_test.cpp
@@ -7,6 +7,9 @@ TEST(MathMixMatFun, logDeterminantLdlt) {
     return stan::math::log_determinant_ldlt(y);
   };
 
+  Eigen::MatrixXd a00(0, 0);
+  stan::test::expect_ad(f, a00);
+
   Eigen::MatrixXd a(2, 2);
   a << 3, 0, 0, 4;
   stan::test::expect_ad(f, a);

--- a/test/unit/math/mix/mat/fun/mdivide_left_ldlt_test.cpp
+++ b/test/unit/math/mix/mat/fun/mdivide_left_ldlt_test.cpp
@@ -5,6 +5,11 @@ TEST(MathMixMatFun, mdivideLeftLdlt) {
     return stan::math::mdivide_left_ldlt(stan::test::ldlt_factor(x), y);
   };
 
+  Eigen::MatrixXd m00(0, 0);
+  Eigen::VectorXd v0(0);
+  stan::test::expect_ad(f, m00, m00);
+  stan::test::expect_ad(f, m00, v0);
+
   Eigen::MatrixXd a(1, 1);
   a << 2;
   Eigen::MatrixXd b(1, 1);

--- a/test/unit/math/mix/mat/fun/mdivide_right_ldlt_test.cpp
+++ b/test/unit/math/mix/mat/fun/mdivide_right_ldlt_test.cpp
@@ -6,6 +6,11 @@ TEST(MathMixMatFun, mdivideRightLdlt) {
     return stan::math::mdivide_right_ldlt(x, stan::test::ldlt_factor(y));
   };
 
+  Eigen::MatrixXd m00(0, 0);
+  Eigen::RowVectorXd rv0(0);
+  stan::test::expect_ad(f, m00, m00);
+  stan::test::expect_ad(f, rv0, m00);
+
   Eigen::MatrixXd a(1, 1);
   a << 2;
   Eigen::MatrixXd b(1, 1);

--- a/test/unit/math/mix/mat/fun/trace_inv_quad_form_ldlt_test.cpp
+++ b/test/unit/math/mix/mat/fun/trace_inv_quad_form_ldlt_test.cpp
@@ -6,6 +6,11 @@ TEST(MathMixMatFun, traceInvQuadFormLdlt) {
     return stan::math::trace_inv_quad_form_ldlt(x_ldlt, y);
   };
 
+  Eigen::MatrixXd m00(0, 0);
+  Eigen::VectorXd v0(0);
+  stan::test::expect_ad(f, m00, m00);
+  stan::test::expect_ad(f, m00, v0);
+
   Eigen::MatrixXd a11(1, 1);
   a11 << 1;
   Eigen::VectorXd a1(1);

--- a/test/unit/math/prim/mat/fun/log_determinant_ldlt_test.cpp
+++ b/test/unit/math/prim/mat/fun/log_determinant_ldlt_test.cpp
@@ -1,7 +1,7 @@
 #include <stan/math/prim/mat.hpp>
 #include <gtest/gtest.h>
 
-TEST(MathMatrix, log_deterimant_ldlt) {
+TEST(MathMatrix, log_determinant_ldlt) {
   using stan::math::determinant;
   using std::fabs;
   using std::log;
@@ -20,4 +20,16 @@ TEST(MathMatrix, log_deterimant_ldlt) {
   ldlt_x.compute(x);
   ASSERT_TRUE(ldlt_x.success());
   EXPECT_FLOAT_EQ(log(3.0), stan::math::log_determinant_ldlt(ldlt_x));
+}
+
+TEST(MathMatrix, log_determinant_ldlt_0x0) {
+  using stan::math::determinant;
+  using std::fabs;
+  using std::log;
+
+  stan::math::matrix_d x(0, 0);
+  stan::math::LDLT_factor<double, -1, -1> ldlt_x;
+
+  EXPECT_FLOAT_EQ(log(fabs(determinant(x))),
+                  stan::math::log_determinant_ldlt(ldlt_x));
 }

--- a/test/unit/math/test_ad.hpp
+++ b/test/unit/math/test_ad.hpp
@@ -1288,6 +1288,10 @@ Eigen::VectorXd to_row_vector(const Eigen::Matrix<double, R, C>& x) {
 template <typename T>
 auto ldlt_factor(const Eigen::Matrix<T, -1, -1>& x) {
   stan::math::LDLT_factor<T, -1, -1> ldlt_x;
+  if (x.size() == 0) {
+    return ldlt_x;
+  }
+
   Eigen::Matrix<T, -1, -1> x_sym = (x + x.transpose()) * 0.5;
   ldlt_x.compute(x_sym);
   return ldlt_x;


### PR DESCRIPTION
## Summary

This makes `log_determinant_ldlt` , `mdivide_left_ldlt`, `mdivide_right_ldlt` and `trace_inv_quad_form_ldlt` work sith size 0 inputs. Fixes #1433, fixes #1436, fixes #1438 and fixes #1440.

For these to work correctly in tests, `stan::test::ldlt_factor` had to be modified so that it didn't attempt to compute the Cholesky factorization on an empty matrix (it would cause a segmentation fault at the end of tests otherwise).

## Tests

Added tests mentioned in the various issues.

## Side Effects

None

## Checklist

- [X] Math issue #1433, #1436, #1438, #1440

- [X] Copyright holder: Marco Colombo

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [ ] the new changes are tested
