### PR TITLE
Throw when computing inverse of a size 0 matrix

### DIFF
--- a/stan/math/prim/mat/fun/inverse.hpp
+++ b/stan/math/prim/mat/fun/inverse.hpp
@@ -2,6 +2,7 @@
 #define STAN_MATH_PRIM_MAT_FUN_INVERSE_HPP
 
 #include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <stan/math/prim/mat/err/check_nonempty.hpp>
 #include <stan/math/prim/mat/err/check_square.hpp>
 
 namespace stan {
@@ -14,6 +15,7 @@ namespace math {
  */
 template <typename T, int R, int C>
 inline Eigen::Matrix<T, R, C> inverse(const Eigen::Matrix<T, R, C>& m) {
+  check_nonempty("inverse", "m", m);
   check_square("inverse", "m", m);
   return m.inverse();
 }

--- a/test/unit/math/mix/mat/fun/inverse_test.cpp
+++ b/test/unit/math/mix/mat/fun/inverse_test.cpp
@@ -10,9 +10,8 @@ TEST(mathMixMatFun, inverse) {
   // fails with assertion from Eigen
   // stan::test::expect_ad(f, t);
 
-  // fails with assertion from Eigen
-  // Eigen::MatrixXd t2(0, 0);
-  // EXPECT_THROW(stan::math::inverse(t2), std::invalid_argument);
+  Eigen::MatrixXd t2(0, 0);
+  stan::test::expect_ad(f, t2);
 
   Eigen::MatrixXd u(1, 1);
   u << 2;

--- a/test/unit/math/mix/mat/fun/inverse_test.cpp
+++ b/test/unit/math/mix/mat/fun/inverse_test.cpp
@@ -7,9 +7,6 @@ TEST(mathMixMatFun, inverse) {
   Eigen::Matrix<stan::math::var, -1, -1> t(0, 0);
   EXPECT_THROW(stan::math::inverse(t), std::invalid_argument);
 
-  // fails with assertion from Eigen
-  // stan::test::expect_ad(f, t);
-
   Eigen::MatrixXd t2(0, 0);
   stan::test::expect_ad(f, t2);
 

--- a/test/unit/math/prim/mat/fun/inverse_test.cpp
+++ b/test/unit/math/prim/mat/fun/inverse_test.cpp
@@ -2,9 +2,12 @@
 #include <gtest/gtest.h>
 
 TEST(MathMatrix, inverse_exception) {
+  using stan::math::inverse;
+
+  stan::math::matrix_d m0(0, 0);
+  EXPECT_THROW(inverse(m0), std::invalid_argument);
+
   stan::math::matrix_d m1(2, 3);
   m1 << 1, 2, 3, 4, 5, 6;
-
-  using stan::math::inverse;
   EXPECT_THROW(inverse(m1), std::invalid_argument);
 }


### PR DESCRIPTION
## Summary

Fixes #1463.

## Tests

Added test mentioned in the issue and another one too.

## Side Effects

None.

## Checklist

- [X] Math issue #1463

- [X] Copyright holder: Marco Colombo

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [X] the new changes are tested
