### PR TITLE
Remove redundant checks in matrix functions

### DIFF
--- a/stan/math/fwd/mat/fun/quad_form_sym.hpp
+++ b/stan/math/fwd/mat/fun/quad_form_sym.hpp
@@ -12,7 +12,6 @@ template <int RA, int CA, int RB, int CB, typename T>
 inline Eigen::Matrix<fvar<T>, CB, CB> quad_form_sym(
     const Eigen::Matrix<fvar<T>, RA, CA>& A,
     const Eigen::Matrix<double, RB, CB>& B) {
-  check_square("quad_form_sym", "A", A);
   check_multiplicable("quad_form_sym", "A", A, "B", B);
   check_symmetric("quad_form_sym", "A", A);
   Eigen::Matrix<fvar<T>, CB, CB> ret(multiply(transpose(B), multiply(A, B)));

--- a/stan/math/fwd/mat/fun/quad_form_sym.hpp
+++ b/stan/math/fwd/mat/fun/quad_form_sym.hpp
@@ -21,7 +21,6 @@ inline Eigen::Matrix<fvar<T>, CB, CB> quad_form_sym(
 template <int RA, int CA, int RB, typename T>
 inline fvar<T> quad_form_sym(const Eigen::Matrix<fvar<T>, RA, CA>& A,
                              const Eigen::Matrix<double, RB, 1>& B) {
-  check_square("quad_form_sym", "A", A);
   check_multiplicable("quad_form_sym", "A", A, "B", B);
   check_symmetric("quad_form_sym", "A", A);
   return dot_product(B, multiply(A, B));
@@ -30,7 +29,6 @@ template <int RA, int CA, int RB, int CB, typename T>
 inline Eigen::Matrix<fvar<T>, CB, CB> quad_form_sym(
     const Eigen::Matrix<double, RA, CA>& A,
     const Eigen::Matrix<fvar<T>, RB, CB>& B) {
-  check_square("quad_form_sym", "A", A);
   check_multiplicable("quad_form_sym", "A", A, "B", B);
   check_symmetric("quad_form_sym", "A", A);
   Eigen::Matrix<fvar<T>, CB, CB> ret(multiply(transpose(B), multiply(A, B)));
@@ -40,7 +38,6 @@ inline Eigen::Matrix<fvar<T>, CB, CB> quad_form_sym(
 template <int RA, int CA, int RB, typename T>
 inline fvar<T> quad_form_sym(const Eigen::Matrix<double, RA, CA>& A,
                              const Eigen::Matrix<fvar<T>, RB, 1>& B) {
-  check_square("quad_form_sym", "A", A);
   check_multiplicable("quad_form_sym", "A", A, "B", B);
   check_symmetric("quad_form_sym", "A", A);
   return dot_product(B, multiply(A, B));

--- a/stan/math/opencl/prim/cholesky_decompose.hpp
+++ b/stan/math/opencl/prim/cholesky_decompose.hpp
@@ -23,7 +23,6 @@ namespace math {
  */
 template <typename T, typename = require_floating_point_t<T>>
 inline matrix_cl<T> cholesky_decompose(matrix_cl<T>& A) {
-  check_square("cholesky_decompose", "A", A);
   check_symmetric("cholesky_decompose", "A", A);
   matrix_cl<T> res = copy_cl(A);
   if (res.rows() == 0) {

--- a/stan/math/prim/mat/err/check_corr_matrix.hpp
+++ b/stan/math/prim/mat/err/check_corr_matrix.hpp
@@ -5,7 +5,7 @@
 #include <stan/math/prim/scal/err/domain_error.hpp>
 #include <stan/math/prim/scal/err/check_positive.hpp>
 #include <stan/math/prim/mat/err/check_pos_definite.hpp>
-#include <stan/math/prim/scal/err/check_size_match.hpp>
+#include <stan/math/prim/mat/err/check_square.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <sstream>
 #include <string>
@@ -37,8 +37,7 @@ inline void check_corr_matrix(
   using size_type = typename index_type<
       Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic> >::type;
 
-  check_size_match(function, "Rows of correlation matrix", y.rows(),
-                   "columns of correlation matrix", y.cols());
+  check_square(function, name, y);
   check_positive(function, name, "rows", y.rows());
 
   for (size_type k = 0; k < y.rows(); ++k) {

--- a/stan/math/prim/mat/err/check_corr_matrix.hpp
+++ b/stan/math/prim/mat/err/check_corr_matrix.hpp
@@ -5,7 +5,6 @@
 #include <stan/math/prim/scal/err/domain_error.hpp>
 #include <stan/math/prim/scal/err/check_positive.hpp>
 #include <stan/math/prim/mat/err/check_pos_definite.hpp>
-#include <stan/math/prim/mat/err/check_symmetric.hpp>
 #include <stan/math/prim/scal/err/check_size_match.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <sstream>
@@ -41,7 +40,6 @@ inline void check_corr_matrix(
   check_size_match(function, "Rows of correlation matrix", y.rows(),
                    "columns of correlation matrix", y.cols());
   check_positive(function, name, "rows", y.rows());
-  check_symmetric(function, "y", y);
 
   for (size_type k = 0; k < y.rows(); ++k) {
     if (!(fabs(y(k, k) - 1.0) <= CONSTRAINT_TOLERANCE)) {

--- a/stan/math/prim/mat/err/check_corr_matrix.hpp
+++ b/stan/math/prim/mat/err/check_corr_matrix.hpp
@@ -3,7 +3,6 @@
 
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/scal/err/domain_error.hpp>
-#include <stan/math/prim/scal/err/check_positive.hpp>
 #include <stan/math/prim/mat/err/check_pos_definite.hpp>
 #include <stan/math/prim/mat/err/check_square.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
@@ -38,7 +37,6 @@ inline void check_corr_matrix(
       Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic> >::type;
 
   check_square(function, name, y);
-  check_positive(function, name, "rows", y.rows());
 
   for (size_type k = 0; k < y.rows(); ++k) {
     if (!(fabs(y(k, k) - 1.0) <= CONSTRAINT_TOLERANCE)) {

--- a/stan/math/prim/mat/err/check_pos_definite.hpp
+++ b/stan/math/prim/mat/err/check_pos_definite.hpp
@@ -29,6 +29,8 @@ inline void check_pos_definite(const char* function, const char* name,
                                const Eigen::Matrix<T_y, -1, -1>& y) {
   check_symmetric(function, name, y);
   check_positive(function, name, "rows", y.rows());
+  check_not_nan(function, name, y);
+
   if (y.rows() == 1 && !(y(0, 0) > CONSTRAINT_TOLERANCE)) {
     domain_error(function, name, "is not positive definite.", "");
   }
@@ -38,7 +40,6 @@ inline void check_pos_definite(const char* function, const char* name,
       || (cholesky.vectorD().array() <= 0.0).any()) {
     domain_error(function, name, "is not positive definite.", "");
   }
-  check_not_nan(function, name, y);
 }
 
 /**

--- a/stan/math/prim/mat/err/check_pos_semidefinite.hpp
+++ b/stan/math/prim/mat/err/check_pos_semidefinite.hpp
@@ -31,6 +31,7 @@ inline void check_pos_semidefinite(
     const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>& y) {
   check_symmetric(function, name, y);
   check_positive(function, name, "rows", y.rows());
+  check_not_nan(function, name, y);
 
   if (y.rows() == 1 && !(y(0, 0) >= 0.0)) {
     domain_error(function, name, "is not positive semi-definite.", "");
@@ -44,7 +45,6 @@ inline void check_pos_semidefinite(
       || (cholesky.vectorD().array() < 0.0).any()) {
     domain_error(function, name, "is not positive semi-definite.", "");
   }
-  check_not_nan(function, name, y);
 }
 
 /**

--- a/stan/math/prim/mat/err/check_spsd_matrix.hpp
+++ b/stan/math/prim/mat/err/check_spsd_matrix.hpp
@@ -3,10 +3,7 @@
 
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
-#include <stan/math/prim/scal/err/check_positive.hpp>
 #include <stan/math/prim/mat/err/check_pos_semidefinite.hpp>
-#include <stan/math/prim/mat/err/check_symmetric.hpp>
-#include <stan/math/prim/mat/err/check_square.hpp>
 
 namespace stan {
 namespace math {
@@ -26,9 +23,6 @@ template <typename T_y>
 inline void check_spsd_matrix(
     const char* function, const char* name,
     const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>& y) {
-  check_square(function, name, y);
-  check_positive(function, name, "rows()", y.rows());
-  check_symmetric(function, name, y);
   check_pos_semidefinite(function, name, y);
 }
 

--- a/stan/math/prim/mat/fun/cholesky_decompose.hpp
+++ b/stan/math/prim/mat/fun/cholesky_decompose.hpp
@@ -31,7 +31,6 @@ namespace math {
 template <typename T>
 inline Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> cholesky_decompose(
     const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& m) {
-  check_square("cholesky_decompose", "m", m);
   check_symmetric("cholesky_decompose", "m", m);
   Eigen::LLT<Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> > llt(m.rows());
   llt.compute(m);

--- a/stan/math/prim/mat/fun/inverse_spd.hpp
+++ b/stan/math/prim/mat/fun/inverse_spd.hpp
@@ -3,7 +3,6 @@
 
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/mat/err/check_nonempty.hpp>
-#include <stan/math/prim/mat/err/check_square.hpp>
 #include <stan/math/prim/mat/err/check_symmetric.hpp>
 #include <stan/math/prim/scal/err/domain_error.hpp>
 
@@ -22,7 +21,6 @@ inline Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> inverse_spd(
   using Eigen::LDLT;
   using Eigen::Matrix;
   check_nonempty("inverse_spd", "m", m);
-  check_square("inverse_spd", "m", m);
   check_symmetric("inverse_spd", "m", m);
   Matrix<T, Dynamic, Dynamic> mmt = T(0.5) * (m + m.transpose());
   LDLT<Matrix<T, Dynamic, Dynamic> > ldlt(mmt);

--- a/stan/math/prim/mat/fun/log_determinant_spd.hpp
+++ b/stan/math/prim/mat/fun/log_determinant_spd.hpp
@@ -2,7 +2,6 @@
 #define STAN_MATH_PRIM_MAT_FUN_LOG_DETERMINANT_SPD_HPP
 
 #include <stan/math/prim/mat/fun/Eigen.hpp>
-#include <stan/math/prim/mat/err/check_square.hpp>
 #include <stan/math/prim/mat/err/check_symmetric.hpp>
 #include <cmath>
 
@@ -19,7 +18,6 @@ namespace math {
 template <typename T, int R, int C>
 inline T log_determinant_spd(const Eigen::Matrix<T, R, C>& m) {
   using std::log;
-  check_square("log_determinant_spd", "m", m);
   check_symmetric("log_determinant_spd", "m", m);
   if (m.size() == 0)
     return 0;

--- a/stan/math/prim/mat/fun/mdivide_left_spd.hpp
+++ b/stan/math/prim/mat/fun/mdivide_left_spd.hpp
@@ -6,8 +6,6 @@
 #include <stan/math/prim/mat/fun/promote_common.hpp>
 #include <stan/math/prim/mat/err/check_multiplicable.hpp>
 #include <stan/math/prim/mat/err/check_pos_definite.hpp>
-#include <stan/math/prim/mat/err/check_symmetric.hpp>
-#include <stan/math/prim/mat/err/check_square.hpp>
 
 namespace stan {
 namespace math {
@@ -24,10 +22,8 @@ namespace math {
 template <typename T1, typename T2, int R1, int C1, int R2, int C2>
 inline Eigen::Matrix<return_type_t<T1, T2>, R1, C2> mdivide_left_spd(
     const Eigen::Matrix<T1, R1, C1> &A, const Eigen::Matrix<T2, R2, C2> &b) {
-  check_symmetric("mdivide_left_spd", "A", A);
-  check_pos_definite("mdivide_left_spd", "A", A);
-  check_square("mdivide_left_spd", "A", A);
   check_multiplicable("mdivide_left_spd", "A", A, "b", b);
+  check_pos_definite("mdivide_left_spd", "A", A);
   return promote_common<Eigen::Matrix<T1, R1, C1>, Eigen::Matrix<T2, R1, C1> >(
              A)
       .llt()

--- a/stan/math/prim/mat/fun/mdivide_right_spd.hpp
+++ b/stan/math/prim/mat/fun/mdivide_right_spd.hpp
@@ -6,8 +6,6 @@
 #include <stan/math/prim/mat/fun/transpose.hpp>
 #include <stan/math/prim/mat/err/check_multiplicable.hpp>
 #include <stan/math/prim/mat/err/check_pos_definite.hpp>
-#include <stan/math/prim/mat/err/check_symmetric.hpp>
-#include <stan/math/prim/mat/err/check_square.hpp>
 #include <boost/math/tools/promotion.hpp>
 
 namespace stan {
@@ -25,9 +23,7 @@ namespace math {
 template <typename T1, typename T2, int R1, int C1, int R2, int C2>
 inline Eigen::Matrix<return_type_t<T1, T2>, R1, C2> mdivide_right_spd(
     const Eigen::Matrix<T1, R1, C1> &b, const Eigen::Matrix<T2, R2, C2> &A) {
-  check_square("mdivide_right_spd", "A", A);
   check_multiplicable("mdivide_right_spd", "b", b, "A", A);
-  check_symmetric("mdivide_right_spd", "A", A);
   check_pos_definite("mdivide_right_spd", "A", A);
   // FIXME: After allowing for general MatrixBase in mdivide_left_spd,
   //        change to b.transpose()

--- a/stan/math/prim/mat/fun/quad_form_sym.hpp
+++ b/stan/math/prim/mat/fun/quad_form_sym.hpp
@@ -3,7 +3,6 @@
 
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/mat/err/check_multiplicable.hpp>
-#include <stan/math/prim/mat/err/check_square.hpp>
 #include <stan/math/prim/mat/err/check_symmetric.hpp>
 
 namespace stan {
@@ -12,7 +11,6 @@ namespace math {
 template <int RA, int CA, int RB, int CB, typename T>
 inline Eigen::Matrix<T, CB, CB> quad_form_sym(
     const Eigen::Matrix<T, RA, CA>& A, const Eigen::Matrix<T, RB, CB>& B) {
-  check_square("quad_form_sym", "A", A);
   check_multiplicable("quad_form_sym", "A", A, "B", B);
   check_symmetric("quad_form_sym", "A", A);
   Eigen::Matrix<T, CB, CB> ret(B.transpose() * A * B);
@@ -22,7 +20,6 @@ inline Eigen::Matrix<T, CB, CB> quad_form_sym(
 template <int RA, int CA, int RB, typename T>
 inline T quad_form_sym(const Eigen::Matrix<T, RA, CA>& A,
                        const Eigen::Matrix<T, RB, 1>& B) {
-  check_square("quad_form_sym", "A", A);
   check_multiplicable("quad_form_sym", "A", A, "B", B);
   check_symmetric("quad_form_sym", "A", A);
   return B.dot(A * B);

--- a/stan/math/prim/mat/prob/gaussian_dlm_obs_lpdf.hpp
+++ b/stan/math/prim/mat/prob/gaussian_dlm_obs_lpdf.hpp
@@ -249,14 +249,12 @@ gaussian_dlm_obs_lpdf(
   check_size_match(function, "rows of W", W.rows(), "rows of G", G.rows());
   // TODO(anyone): support infinite W
   check_finite(function, "W", W);
-  check_not_nan(function, "W", W);
   check_size_match(function, "size of m0", m0.size(), "rows of G", G.rows());
   check_finite(function, "m0", m0);
   check_not_nan(function, "m0", m0);
   check_pos_definite(function, "C0", C0);
   check_size_match(function, "rows of C0", C0.rows(), "rows of G", G.rows());
   check_finite(function, "C0", C0);
-  check_not_nan(function, "C0", C0);
 
   if (y.cols() == 0 || y.rows() == 0) {
     return 0;

--- a/stan/math/rev/mat/fun/log_determinant_spd.hpp
+++ b/stan/math/rev/mat/fun/log_determinant_spd.hpp
@@ -4,7 +4,6 @@
 #include <stan/math/rev/meta.hpp>
 #include <stan/math/prim/scal/err/domain_error.hpp>
 #include <stan/math/prim/scal/err/check_finite.hpp>
-#include <stan/math/prim/mat/err/check_square.hpp>
 #include <stan/math/prim/mat/err/check_symmetric.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/mat/fun/typedefs.hpp>
@@ -15,7 +14,6 @@ namespace math {
 
 template <int R, int C>
 inline var log_determinant_spd(const Eigen::Matrix<var, R, C>& m) {
-  check_square("log_determinant_spd", "m", m);
   check_symmetric("log_determinant_spd", "m", m);
   if (m.size() == 0)
     return 0;

--- a/stan/math/rev/mat/fun/quad_form.hpp
+++ b/stan/math/rev/mat/fun/quad_form.hpp
@@ -9,7 +9,6 @@
 #include <stan/math/prim/mat/fun/quad_form.hpp>
 #include <stan/math/prim/mat/err/check_multiplicable.hpp>
 #include <stan/math/prim/mat/err/check_square.hpp>
-#include <stan/math/prim/mat/err/check_symmetric.hpp>
 #include <type_traits>
 
 namespace stan {

--- a/stan/math/rev/mat/fun/quad_form_sym.hpp
+++ b/stan/math/rev/mat/fun/quad_form_sym.hpp
@@ -5,7 +5,6 @@
 #include <stan/math/rev/core.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/mat/err/check_multiplicable.hpp>
-#include <stan/math/prim/mat/err/check_square.hpp>
 #include <stan/math/prim/mat/err/check_symmetric.hpp>
 #include <stan/math/rev/mat/fun/quad_form.hpp>
 #include <type_traits>
@@ -17,7 +16,6 @@ template <typename Ta, int Ra, int Ca, typename Tb, int Rb, int Cb,
           require_any_var_t<Ta, Tb>...>
 inline Eigen::Matrix<var, Cb, Cb> quad_form_sym(
     const Eigen::Matrix<Ta, Ra, Ca>& A, const Eigen::Matrix<Tb, Rb, Cb>& B) {
-  check_square("quad_form", "A", A);
   check_symmetric("quad_form_sym", "A", A);
   check_multiplicable("quad_form_sym", "A", A, "B", B);
 
@@ -31,7 +29,6 @@ template <typename Ta, int Ra, int Ca, typename Tb, int Rb,
           require_any_var_t<Ta, Tb>...>
 inline var quad_form_sym(const Eigen::Matrix<Ta, Ra, Ca>& A,
                          const Eigen::Matrix<Tb, Rb, 1>& B) {
-  check_square("quad_form", "A", A);
   check_symmetric("quad_form_sym", "A", A);
   check_multiplicable("quad_form_sym", "A", A, "B", B);
 

--- a/test/unit/math/opencl/cholesky_decompose_test.cpp
+++ b/test/unit/math/opencl/cholesky_decompose_test.cpp
@@ -40,7 +40,6 @@ void cholesky_decompose_test(int size) {
   stan::math::matrix_d m1_cpu(size, size);
   stan::math::matrix_d m1_cl(size, size);
 
-  stan::math::check_square("cholesky_decompose", "m", m1_pos_def);
   stan::math::check_symmetric("cholesky_decompose", "m", m1_pos_def);
   Eigen::LLT<stan::math::matrix_d> llt(m1_pos_def.rows());
   llt.compute(m1_pos_def);

--- a/test/unit/math/opencl/prim/cholesky_decompose_test.cpp
+++ b/test/unit/math/opencl/prim/cholesky_decompose_test.cpp
@@ -62,7 +62,6 @@ void cholesky_decompose_test(int size) {
   stan::math::matrix_d m1_pos_def
       = m1 * m1.transpose() + size * Eigen::MatrixXd::Identity(size, size);
 
-  stan::math::check_square("cholesky_decompose", "m", m1_pos_def);
   stan::math::check_symmetric("cholesky_decompose", "m", m1_pos_def);
   Eigen::LLT<stan::math::matrix_d> llt(m1_pos_def.rows());
   llt.compute(m1_pos_def);

--- a/test/unit/math/prim/mat/err/check_pos_definite_test.cpp
+++ b/test/unit/math/prim/mat/err/check_pos_definite_test.cpp
@@ -143,7 +143,7 @@ TEST_F(ErrorHandlingMatrix, checkPosDefinite_nan) {
   y << nan;
 
   std::stringstream expected_msg;
-  expected_msg << "function: y is not positive definite.";
+  expected_msg << "function: y[1] is nan, but must not be nan!";
   EXPECT_THROW_MSG(check_pos_definite(function, "y", y), std::domain_error,
                    expected_msg.str());
 


### PR DESCRIPTION
## Summary

Fixes #88. This consists of the following:
- remove `check_square` if there is already a `check_symmetric`
- remove `check_symmetric` if there is already a `check_pos_definite` or `check_pos_semidefinite`
- remove `check_not_nan` if there is already a `check_pos_definite` or `check_spsd_matrix`
- move `check_pos_definite` after `check_multiplicable`
- move `check_not_nan` before computaton of Cholesky factors
- remove no longer needed headers

The excessive `stan::math` qualifications must have been fixed at some point.

## Tests

This is code cleanup, so no new tests, the existing ones should be fine.

## Side Effects

None.

## Checklist

- [X] Math issue #88

- [X] Copyright holder: Marco Colombo

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [X] the new changes are tested
