### PR TITLE
Increase tolerances for add_vec_mat

### DIFF
--- a/test/unit/math/mix/mat/fun/add_test.cpp
+++ b/test/unit/math/mix/mat/fun/add_test.cpp
@@ -77,6 +77,9 @@ TEST(MathMixMatFun, add_scalar_mat) {
 
 TEST(MathMixMatFun, add_vec_mat) {
   auto f = [](const auto& x, const auto& y) { return stan::math::add(x, y); };
+  stan::test::ad_tolerances tols;
+  tols.hessian_hessian_ = 5e-3;
+  tols.hessian_fvar_hessian_ = 5e-3;
 
   Eigen::VectorXd v5(5);
   v5 << 1, 2, 3, 4, 5;
@@ -86,8 +89,8 @@ TEST(MathMixMatFun, add_vec_mat) {
   v5 << 1, 2, 3, 4, 5;
   Eigen::VectorXd rv5b(5);
   v5 << 2, 3, 4, 5, 6;
-  stan::test::expect_ad(f, v5, v5b);
-  stan::test::expect_ad(f, rv5, rv5b);
+  stan::test::expect_ad(tols, f, v5, v5b);
+  stan::test::expect_ad(tols, f, rv5, rv5b);
 }
 
 TEST(MathMixMatFun, add_mat_mat) {


### PR DESCRIPTION
# Summary

We are currently experiencing issues on `develop`. @bob-carpenter [suggested](https://github.com/stan-dev/math/issues/1453) to increase the tolerances for the particular test that fails randomly. So this PR does just that. I am starting with 5E-3 and if that will still cause issues we can increase that to 1E-2.

## Tests

/

## Side Effects

/

## Checklist

- [x] Math issue #1453

- [x] Copyright holder: Rok Češnovar

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
