### PR TITLE
Remove uses of boost::promote_args and boost/math/tools/promotion.hpp

### DIFF
--- a/stan/math/fwd/scal/fun/log_mix.hpp
+++ b/stan/math/fwd/scal/fun/log_mix.hpp
@@ -5,7 +5,6 @@
 #include <stan/math/fwd/core.hpp>
 #include <stan/math/prim/scal/fun/value_of.hpp>
 #include <stan/math/prim/scal/fun/log_mix.hpp>
-#include <boost/math/tools/promotion.hpp>
 #include <cmath>
 #include <type_traits>
 

--- a/stan/math/prim/arr/fun/common_type.hpp
+++ b/stan/math/prim/arr/fun/common_type.hpp
@@ -3,7 +3,6 @@
 
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/scal/fun/common_type.hpp>
-#include <boost/math/tools/promotion.hpp>
 #include <vector>
 
 namespace stan {

--- a/stan/math/prim/mat/fun/add.hpp
+++ b/stan/math/prim/mat/fun/add.hpp
@@ -1,7 +1,6 @@
 #ifndef STAN_MATH_PRIM_MAT_FUN_ADD_HPP
 #define STAN_MATH_PRIM_MAT_FUN_ADD_HPP
 
-#include <boost/math/tools/promotion.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/mat/err/check_matching_dims.hpp>
 

--- a/stan/math/prim/mat/fun/csr_matrix_times_vector.hpp
+++ b/stan/math/prim/mat/fun/csr_matrix_times_vector.hpp
@@ -7,7 +7,6 @@
 #include <stan/math/prim/scal/err/check_size_match.hpp>
 #include <stan/math/prim/scal/err/check_positive.hpp>
 #include <stan/math/prim/mat/err/check_range.hpp>
-#include <boost/math/tools/promotion.hpp>
 #include <vector>
 
 namespace stan {

--- a/stan/math/prim/mat/fun/diag_post_multiply.hpp
+++ b/stan/math/prim/mat/fun/diag_post_multiply.hpp
@@ -4,7 +4,6 @@
 #include <stan/math/prim/mat/err/check_vector.hpp>
 #include <stan/math/prim/scal/err/check_size_match.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
-#include <boost/math/tools/promotion.hpp>
 
 namespace stan {
 namespace math {

--- a/stan/math/prim/mat/fun/diag_pre_multiply.hpp
+++ b/stan/math/prim/mat/fun/diag_pre_multiply.hpp
@@ -4,7 +4,6 @@
 #include <stan/math/prim/mat/err/check_vector.hpp>
 #include <stan/math/prim/scal/err/check_size_match.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
-#include <boost/math/tools/promotion.hpp>
 
 namespace stan {
 namespace math {

--- a/stan/math/prim/mat/fun/distance.hpp
+++ b/stan/math/prim/mat/fun/distance.hpp
@@ -5,7 +5,6 @@
 #include <stan/math/prim/mat/fun/squared_distance.hpp>
 #include <stan/math/prim/mat/err/check_vector.hpp>
 #include <stan/math/prim/arr/err/check_matching_sizes.hpp>
-#include <boost/math/tools/promotion.hpp>
 
 namespace stan {
 namespace math {

--- a/stan/math/prim/mat/fun/elt_divide.hpp
+++ b/stan/math/prim/mat/fun/elt_divide.hpp
@@ -1,7 +1,6 @@
 #ifndef STAN_MATH_PRIM_MAT_FUN_ELT_DIVIDE_HPP
 #define STAN_MATH_PRIM_MAT_FUN_ELT_DIVIDE_HPP
 
-#include <boost/math/tools/promotion.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/mat/err/check_matching_dims.hpp>
 

--- a/stan/math/prim/mat/fun/elt_multiply.hpp
+++ b/stan/math/prim/mat/fun/elt_multiply.hpp
@@ -1,7 +1,6 @@
 #ifndef STAN_MATH_PRIM_MAT_FUN_ELT_MULTIPLY_HPP
 #define STAN_MATH_PRIM_MAT_FUN_ELT_MULTIPLY_HPP
 
-#include <boost/math/tools/promotion.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/mat/err/check_matching_dims.hpp>
 

--- a/stan/math/prim/mat/fun/get_lp.hpp
+++ b/stan/math/prim/mat/fun/get_lp.hpp
@@ -1,7 +1,6 @@
 #ifndef STAN_MATH_PRIM_MAT_FUN_GET_LP_HPP
 #define STAN_MATH_PRIM_MAT_FUN_GET_LP_HPP
 
-#include <boost/math/tools/promotion.hpp>
 #include <stan/math/prim/mat/fun/accumulator.hpp>
 
 namespace stan {

--- a/stan/math/prim/mat/fun/mdivide_left.hpp
+++ b/stan/math/prim/mat/fun/mdivide_left.hpp
@@ -1,7 +1,6 @@
 #ifndef STAN_MATH_PRIM_MAT_FUN_MDIVIDE_LEFT_HPP
 #define STAN_MATH_PRIM_MAT_FUN_MDIVIDE_LEFT_HPP
 
-#include <boost/math/tools/promotion.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/mat/fun/promote_common.hpp>
 #include <stan/math/prim/mat/err/check_multiplicable.hpp>

--- a/stan/math/prim/mat/fun/mdivide_left_ldlt.hpp
+++ b/stan/math/prim/mat/fun/mdivide_left_ldlt.hpp
@@ -1,7 +1,6 @@
 #ifndef STAN_MATH_PRIM_MAT_FUN_MDIVIDE_LEFT_LDLT_HPP
 #define STAN_MATH_PRIM_MAT_FUN_MDIVIDE_LEFT_LDLT_HPP
 
-#include <boost/math/tools/promotion.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/mat/fun/LDLT_factor.hpp>
 #include <stan/math/prim/mat/err/check_multiplicable.hpp>

--- a/stan/math/prim/mat/fun/mdivide_left_spd.hpp
+++ b/stan/math/prim/mat/fun/mdivide_left_spd.hpp
@@ -1,7 +1,6 @@
 #ifndef STAN_MATH_PRIM_MAT_FUN_MDIVIDE_LEFT_SPD_HPP
 #define STAN_MATH_PRIM_MAT_FUN_MDIVIDE_LEFT_SPD_HPP
 
-#include <boost/math/tools/promotion.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/mat/fun/promote_common.hpp>
 #include <stan/math/prim/mat/err/check_multiplicable.hpp>

--- a/stan/math/prim/mat/fun/mdivide_left_tri.hpp
+++ b/stan/math/prim/mat/fun/mdivide_left_tri.hpp
@@ -1,7 +1,6 @@
 #ifndef STAN_MATH_PRIM_MAT_FUN_MDIVIDE_LEFT_TRI_HPP
 #define STAN_MATH_PRIM_MAT_FUN_MDIVIDE_LEFT_TRI_HPP
 
-#include <boost/math/tools/promotion.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/mat/fun/promote_common.hpp>
 #include <stan/math/prim/mat/err/check_multiplicable.hpp>

--- a/stan/math/prim/mat/fun/mdivide_left_tri_low.hpp
+++ b/stan/math/prim/mat/fun/mdivide_left_tri_low.hpp
@@ -1,7 +1,6 @@
 #ifndef STAN_MATH_PRIM_MAT_FUN_MDIVIDE_LEFT_TRI_LOW_HPP
 #define STAN_MATH_PRIM_MAT_FUN_MDIVIDE_LEFT_TRI_LOW_HPP
 
-#include <boost/math/tools/promotion.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/mat/fun/mdivide_left_tri.hpp>
 #include <stan/math/prim/mat/err/check_square.hpp>

--- a/stan/math/prim/mat/fun/mdivide_right.hpp
+++ b/stan/math/prim/mat/fun/mdivide_right.hpp
@@ -5,7 +5,6 @@
 #include <stan/math/prim/mat/fun/promote_common.hpp>
 #include <stan/math/prim/mat/err/check_multiplicable.hpp>
 #include <stan/math/prim/mat/err/check_square.hpp>
-#include <boost/math/tools/promotion.hpp>
 
 namespace stan {
 namespace math {

--- a/stan/math/prim/mat/fun/mdivide_right_ldlt.hpp
+++ b/stan/math/prim/mat/fun/mdivide_right_ldlt.hpp
@@ -6,7 +6,6 @@
 #include <stan/math/prim/mat/fun/mdivide_left_ldlt.hpp>
 #include <stan/math/prim/mat/fun/transpose.hpp>
 #include <stan/math/prim/mat/err/check_multiplicable.hpp>
-#include <boost/math/tools/promotion.hpp>
 
 namespace stan {
 namespace math {

--- a/stan/math/prim/mat/fun/mdivide_right_spd.hpp
+++ b/stan/math/prim/mat/fun/mdivide_right_spd.hpp
@@ -6,7 +6,6 @@
 #include <stan/math/prim/mat/fun/transpose.hpp>
 #include <stan/math/prim/mat/err/check_multiplicable.hpp>
 #include <stan/math/prim/mat/err/check_pos_definite.hpp>
-#include <boost/math/tools/promotion.hpp>
 
 namespace stan {
 namespace math {

--- a/stan/math/prim/mat/fun/mdivide_right_tri.hpp
+++ b/stan/math/prim/mat/fun/mdivide_right_tri.hpp
@@ -8,7 +8,6 @@
 #include <stan/math/prim/mat/err/check_multiplicable.hpp>
 #include <stan/math/prim/mat/err/check_square.hpp>
 #include <stan/math/prim/scal/err/domain_error.hpp>
-#include <boost/math/tools/promotion.hpp>
 
 namespace stan {
 namespace math {

--- a/stan/math/prim/mat/fun/mdivide_right_tri_low.hpp
+++ b/stan/math/prim/mat/fun/mdivide_right_tri_low.hpp
@@ -1,7 +1,6 @@
 #ifndef STAN_MATH_PRIM_MAT_FUN_MDIVIDE_RIGHT_TRI_LOW_HPP
 #define STAN_MATH_PRIM_MAT_FUN_MDIVIDE_RIGHT_TRI_LOW_HPP
 
-#include <boost/math/tools/promotion.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/mat/fun/mdivide_right_tri.hpp>
 #include <stan/math/prim/mat/fun/promote_common.hpp>

--- a/stan/math/prim/mat/fun/mean.hpp
+++ b/stan/math/prim/mat/fun/mean.hpp
@@ -3,7 +3,6 @@
 
 #include <stan/math/prim/arr/err/check_nonzero_size.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
-#include <boost/math/tools/promotion.hpp>
 #include <vector>
 
 namespace stan {

--- a/stan/math/prim/mat/fun/quad_form_diag.hpp
+++ b/stan/math/prim/mat/fun/quad_form_diag.hpp
@@ -2,7 +2,6 @@
 #define STAN_MATH_PRIM_MAT_FUN_QUAD_FORM_DIAG_HPP
 
 #include <stan/math/prim/mat/fun/Eigen.hpp>
-#include <boost/math/tools/promotion.hpp>
 #include <stan/math/prim/mat/err/check_square.hpp>
 #include <stan/math/prim/mat/err/check_vector.hpp>
 #include <stan/math/prim/scal/err/check_size_match.hpp>

--- a/stan/math/prim/mat/fun/rep_matrix.hpp
+++ b/stan/math/prim/mat/fun/rep_matrix.hpp
@@ -1,7 +1,6 @@
 #ifndef STAN_MATH_PRIM_MAT_FUN_REP_MATRIX_HPP
 #define STAN_MATH_PRIM_MAT_FUN_REP_MATRIX_HPP
 
-#include <boost/math/tools/promotion.hpp>
 #include <stan/math/prim/scal/err/check_nonnegative.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 

--- a/stan/math/prim/mat/fun/rep_row_vector.hpp
+++ b/stan/math/prim/mat/fun/rep_row_vector.hpp
@@ -1,7 +1,6 @@
 #ifndef STAN_MATH_PRIM_MAT_FUN_REP_ROW_VECTOR_HPP
 #define STAN_MATH_PRIM_MAT_FUN_REP_ROW_VECTOR_HPP
 
-#include <boost/math/tools/promotion.hpp>
 #include <stan/math/prim/scal/err/check_nonnegative.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 

--- a/stan/math/prim/mat/fun/rep_vector.hpp
+++ b/stan/math/prim/mat/fun/rep_vector.hpp
@@ -1,7 +1,6 @@
 #ifndef STAN_MATH_PRIM_MAT_FUN_REP_VECTOR_HPP
 #define STAN_MATH_PRIM_MAT_FUN_REP_VECTOR_HPP
 
-#include <boost/math/tools/promotion.hpp>
 #include <stan/math/prim/scal/err/check_nonnegative.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 

--- a/stan/math/prim/mat/fun/sd.hpp
+++ b/stan/math/prim/mat/fun/sd.hpp
@@ -4,7 +4,6 @@
 #include <stan/math/prim/arr/err/check_nonzero_size.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/mat/fun/variance.hpp>
-#include <boost/math/tools/promotion.hpp>
 #include <vector>
 
 namespace stan {

--- a/stan/math/prim/mat/fun/subtract.hpp
+++ b/stan/math/prim/mat/fun/subtract.hpp
@@ -1,7 +1,6 @@
 #ifndef STAN_MATH_PRIM_MAT_FUN_SUBTRACT_HPP
 #define STAN_MATH_PRIM_MAT_FUN_SUBTRACT_HPP
 
-#include <boost/math/tools/promotion.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/mat/err/check_matching_dims.hpp>
 

--- a/stan/math/prim/mat/fun/to_matrix.hpp
+++ b/stan/math/prim/mat/fun/to_matrix.hpp
@@ -1,7 +1,6 @@
 #ifndef STAN_MATH_PRIM_MAT_FUN_TO_MATRIX_HPP
 #define STAN_MATH_PRIM_MAT_FUN_TO_MATRIX_HPP
 
-#include <boost/math/tools/promotion.hpp>
 #include <stan/math/prim/scal/err/check_size_match.hpp>
 #include <stan/math/prim/scal/err/invalid_argument.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
@@ -63,7 +62,6 @@ inline Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> to_matrix(
 template <typename T>
 inline Eigen::Matrix<return_type_t<T, double>, Eigen::Dynamic, Eigen::Dynamic>
 to_matrix(const std::vector<std::vector<T> >& x) {
-  using boost::math::tools::promote_args;
   size_t rows = x.size();
   if (rows == 0) {
     return Eigen::Matrix<return_type_t<T, double>, Eigen::Dynamic,

--- a/stan/math/prim/mat/fun/variance.hpp
+++ b/stan/math/prim/mat/fun/variance.hpp
@@ -4,7 +4,6 @@
 #include <stan/math/prim/arr/err/check_nonzero_size.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/mat/fun/mean.hpp>
-#include <boost/math/tools/promotion.hpp>
 #include <vector>
 
 namespace stan {

--- a/stan/math/prim/mat/prob/categorical_log.hpp
+++ b/stan/math/prim/mat/prob/categorical_log.hpp
@@ -4,7 +4,6 @@
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/mat/prob/categorical_lpmf.hpp>
-#include <boost/math/tools/promotion.hpp>
 #include <vector>
 
 namespace stan {

--- a/stan/math/prim/mat/prob/categorical_logit_log.hpp
+++ b/stan/math/prim/mat/prob/categorical_logit_log.hpp
@@ -4,7 +4,6 @@
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/mat/prob/categorical_logit_lpmf.hpp>
-#include <boost/math/tools/promotion.hpp>
 #include <vector>
 
 namespace stan {

--- a/stan/math/prim/mat/prob/categorical_logit_lpmf.hpp
+++ b/stan/math/prim/mat/prob/categorical_logit_lpmf.hpp
@@ -8,7 +8,6 @@
 #include <stan/math/prim/mat/fun/log_softmax.hpp>
 #include <stan/math/prim/mat/fun/log_sum_exp.hpp>
 #include <stan/math/prim/mat/fun/sum.hpp>
-#include <boost/math/tools/promotion.hpp>
 #include <vector>
 
 namespace stan {

--- a/stan/math/prim/mat/prob/categorical_lpmf.hpp
+++ b/stan/math/prim/mat/prob/categorical_lpmf.hpp
@@ -5,7 +5,6 @@
 #include <stan/math/prim/mat/err/check_simplex.hpp>
 #include <stan/math/prim/scal/err/check_bounded.hpp>
 #include <stan/math/prim/mat/fun/sum.hpp>
-#include <boost/math/tools/promotion.hpp>
 #include <cmath>
 #include <vector>
 

--- a/stan/math/prim/mat/prob/dirichlet_log.hpp
+++ b/stan/math/prim/mat/prob/dirichlet_log.hpp
@@ -3,7 +3,6 @@
 
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/mat/prob/dirichlet_lpmf.hpp>
-#include <boost/math/tools/promotion.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 
 namespace stan {

--- a/stan/math/prim/mat/prob/inv_wishart_log.hpp
+++ b/stan/math/prim/mat/prob/inv_wishart_log.hpp
@@ -4,7 +4,6 @@
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/mat/prob/inv_wishart_lpdf.hpp>
-#include <boost/math/tools/promotion.hpp>
 
 namespace stan {
 namespace math {

--- a/stan/math/prim/mat/prob/inv_wishart_lpdf.hpp
+++ b/stan/math/prim/mat/prob/inv_wishart_lpdf.hpp
@@ -52,7 +52,6 @@ return_type_t<T_y, T_dof, T_scale> inv_wishart_lpdf(
 
   using Eigen::Dynamic;
   using Eigen::Matrix;
-  using boost::math::tools::promote_args;
 
   typename index_type<Matrix<T_scale, Dynamic, Dynamic> >::type k = S.rows();
   return_type_t<T_y, T_dof, T_scale> lp(0.0);

--- a/stan/math/prim/mat/prob/lkj_corr_cholesky_log.hpp
+++ b/stan/math/prim/mat/prob/lkj_corr_cholesky_log.hpp
@@ -4,7 +4,6 @@
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/mat/prob/lkj_corr_cholesky_lpdf.hpp>
-#include <boost/math/tools/promotion.hpp>
 
 namespace stan {
 namespace math {

--- a/stan/math/prim/mat/prob/lkj_corr_cholesky_lpdf.hpp
+++ b/stan/math/prim/mat/prob/lkj_corr_cholesky_lpdf.hpp
@@ -18,8 +18,6 @@ return_type_t<T_covar, T_shape> lkj_corr_cholesky_lpdf(
     const T_shape& eta) {
   static const char* function = "lkj_corr_cholesky_lpdf";
 
-  using boost::math::tools::promote_args;
-
   using lp_ret = return_type_t<T_covar, T_shape>;
   lp_ret lp(0.0);
   check_positive(function, "Shape parameter", eta);

--- a/stan/math/prim/mat/prob/lkj_corr_log.hpp
+++ b/stan/math/prim/mat/prob/lkj_corr_log.hpp
@@ -4,7 +4,6 @@
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/mat/prob/lkj_corr_lpdf.hpp>
-#include <boost/math/tools/promotion.hpp>
 
 namespace stan {
 namespace math {

--- a/stan/math/prim/mat/prob/lkj_corr_lpdf.hpp
+++ b/stan/math/prim/mat/prob/lkj_corr_lpdf.hpp
@@ -49,8 +49,6 @@ return_type_t<T_y, T_shape> lkj_corr_lpdf(
     const T_shape& eta) {
   static const char* function = "lkj_corr_lpdf";
 
-  using boost::math::tools::promote_args;
-
   return_type_t<T_y, T_shape> lp(0.0);
   check_positive(function, "Shape parameter", eta);
   check_corr_matrix(function, "Correlation matrix", y);

--- a/stan/math/prim/mat/prob/lkj_cov_log.hpp
+++ b/stan/math/prim/mat/prob/lkj_cov_log.hpp
@@ -4,7 +4,6 @@
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/mat/prob/lkj_cov_lpdf.hpp>
-#include <boost/math/tools/promotion.hpp>
 
 namespace stan {
 namespace math {

--- a/stan/math/prim/mat/prob/lkj_cov_lpdf.hpp
+++ b/stan/math/prim/mat/prob/lkj_cov_lpdf.hpp
@@ -56,11 +56,11 @@ return_type_t<T_y, T_loc, T_scale, T_shape> lkj_cov_lpdf(
 }
 
 template <typename T_y, typename T_loc, typename T_scale, typename T_shape>
-inline promote_args_t<T_y, T_loc, T_scale, T_shape>
-lkj_cov_lpdf(const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>& y,
-             const Eigen::Matrix<T_loc, Eigen::Dynamic, 1>& mu,
-             const Eigen::Matrix<T_scale, Eigen::Dynamic, 1>& sigma,
-             const T_shape& eta) {
+inline promote_args_t<T_y, T_loc, T_scale, T_shape> lkj_cov_lpdf(
+    const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>& y,
+    const Eigen::Matrix<T_loc, Eigen::Dynamic, 1>& mu,
+    const Eigen::Matrix<T_scale, Eigen::Dynamic, 1>& sigma,
+    const T_shape& eta) {
   return lkj_cov_lpdf<false>(y, mu, sigma, eta);
 }
 

--- a/stan/math/prim/mat/prob/lkj_cov_lpdf.hpp
+++ b/stan/math/prim/mat/prob/lkj_cov_lpdf.hpp
@@ -56,7 +56,7 @@ return_type_t<T_y, T_loc, T_scale, T_shape> lkj_cov_lpdf(
 }
 
 template <typename T_y, typename T_loc, typename T_scale, typename T_shape>
-inline promote_args_t<T_y, T_loc, T_scale, T_shape> lkj_cov_lpdf(
+inline return_type_t<T_y, T_loc, T_scale, T_shape> lkj_cov_lpdf(
     const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>& y,
     const Eigen::Matrix<T_loc, Eigen::Dynamic, 1>& mu,
     const Eigen::Matrix<T_scale, Eigen::Dynamic, 1>& sigma,

--- a/stan/math/prim/mat/prob/lkj_cov_lpdf.hpp
+++ b/stan/math/prim/mat/prob/lkj_cov_lpdf.hpp
@@ -23,8 +23,6 @@ return_type_t<T_y, T_loc, T_scale, T_shape> lkj_cov_lpdf(
     const T_shape& eta) {
   static const char* function = "lkj_cov_lpdf";
 
-  using boost::math::tools::promote_args;
-
   return_type_t<T_y, T_loc, T_scale, T_shape> lp(0.0);
   check_size_match(function, "Rows of location parameter", mu.rows(),
                    "columns of scale parameter", sigma.rows());
@@ -58,8 +56,7 @@ return_type_t<T_y, T_loc, T_scale, T_shape> lkj_cov_lpdf(
 }
 
 template <typename T_y, typename T_loc, typename T_scale, typename T_shape>
-inline typename boost::math::tools::promote_args<T_y, T_loc, T_scale,
-                                                 T_shape>::type
+inline promote_args_t<T_y, T_loc, T_scale, T_shape>
 lkj_cov_lpdf(const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>& y,
              const Eigen::Matrix<T_loc, Eigen::Dynamic, 1>& mu,
              const Eigen::Matrix<T_scale, Eigen::Dynamic, 1>& sigma,

--- a/stan/math/prim/mat/prob/matrix_normal_prec_log.hpp
+++ b/stan/math/prim/mat/prob/matrix_normal_prec_log.hpp
@@ -4,7 +4,6 @@
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/mat/prob/matrix_normal_prec_lpdf.hpp>
-#include <boost/math/tools/promotion.hpp>
 
 namespace stan {
 namespace math {

--- a/stan/math/prim/mat/prob/multi_gp_cholesky_log.hpp
+++ b/stan/math/prim/mat/prob/multi_gp_cholesky_log.hpp
@@ -4,7 +4,6 @@
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/mat/prob/multi_gp_cholesky_lpdf.hpp>
-#include <boost/math/tools/promotion.hpp>
 
 namespace stan {
 namespace math {

--- a/stan/math/prim/mat/prob/multi_gp_log.hpp
+++ b/stan/math/prim/mat/prob/multi_gp_log.hpp
@@ -4,7 +4,6 @@
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/mat/prob/multi_gp_lpdf.hpp>
-#include <boost/math/tools/promotion.hpp>
 
 namespace stan {
 namespace math {

--- a/stan/math/prim/mat/prob/multi_normal_cholesky_log.hpp
+++ b/stan/math/prim/mat/prob/multi_normal_cholesky_log.hpp
@@ -4,7 +4,6 @@
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/mat/prob/multi_normal_cholesky_lpdf.hpp>
-#include <boost/math/tools/promotion.hpp>
 
 namespace stan {
 namespace math {

--- a/stan/math/prim/mat/prob/multinomial_log.hpp
+++ b/stan/math/prim/mat/prob/multinomial_log.hpp
@@ -4,7 +4,6 @@
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/mat/prob/multinomial_lpmf.hpp>
-#include <boost/math/tools/promotion.hpp>
 #include <vector>
 
 namespace stan {

--- a/stan/math/prim/mat/prob/multinomial_lpmf.hpp
+++ b/stan/math/prim/mat/prob/multinomial_lpmf.hpp
@@ -19,8 +19,6 @@ return_type_t<T_prob> multinomial_lpmf(
     const Eigen::Matrix<T_prob, Eigen::Dynamic, 1>& theta) {
   static const char* function = "multinomial_lpmf";
 
-  using boost::math::tools::promote_args;
-
   return_type_t<T_prob> lp(0.0);
   check_nonnegative(function, "Number of trials variable", ns);
   check_simplex(function, "Probabilities parameter", theta);

--- a/stan/math/prim/mat/prob/wishart_log.hpp
+++ b/stan/math/prim/mat/prob/wishart_log.hpp
@@ -4,7 +4,6 @@
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/prim/mat/prob/wishart_lpdf.hpp>
-#include <boost/math/tools/promotion.hpp>
 
 namespace stan {
 namespace math {

--- a/stan/math/prim/mat/prob/wishart_lpdf.hpp
+++ b/stan/math/prim/mat/prob/wishart_lpdf.hpp
@@ -55,7 +55,6 @@ return_type_t<T_y, T_dof, T_scale> wishart_lpdf(
   using Eigen::Dynamic;
   using Eigen::Lower;
   using Eigen::Matrix;
-  using boost::math::tools::promote_args;
 
   typename index_type<Matrix<T_scale, Dynamic, Dynamic> >::type k = W.rows();
   return_type_t<T_y, T_dof, T_scale> lp(0.0);

--- a/stan/math/prim/scal/fun/beta.hpp
+++ b/stan/math/prim/scal/fun/beta.hpp
@@ -2,7 +2,6 @@
 #define STAN_MATH_PRIM_SCAL_FUN_BETA_HPP
 
 #include <stan/math/prim/meta.hpp>
-#include <boost/math/tools/promotion.hpp>
 #include <stan/math/prim/scal/fun/lgamma.hpp>
 
 namespace stan {

--- a/stan/math/prim/scal/fun/binomial_coefficient_log.hpp
+++ b/stan/math/prim/scal/fun/binomial_coefficient_log.hpp
@@ -5,7 +5,6 @@
 #include <stan/math/prim/scal/fun/inv.hpp>
 #include <stan/math/prim/scal/fun/lgamma.hpp>
 #include <stan/math/prim/scal/fun/multiply_log.hpp>
-#include <boost/math/tools/promotion.hpp>
 
 namespace stan {
 namespace math {

--- a/stan/math/prim/scal/fun/common_type.hpp
+++ b/stan/math/prim/scal/fun/common_type.hpp
@@ -2,7 +2,6 @@
 #define STAN_MATH_PRIM_SCAL_FUN_COMMON_TYPE_HPP
 
 #include <stan/math/prim/meta.hpp>
-#include <boost/math/tools/promotion.hpp>
 
 namespace stan {
 namespace math {

--- a/stan/math/prim/scal/fun/if_else.hpp
+++ b/stan/math/prim/scal/fun/if_else.hpp
@@ -2,7 +2,6 @@
 #define STAN_MATH_PRIM_SCAL_FUN_IF_ELSE_HPP
 
 #include <stan/math/prim/meta.hpp>
-#include <boost/math/tools/promotion.hpp>
 
 namespace stan {
 namespace math {

--- a/stan/math/prim/scal/fun/lb_constrain.hpp
+++ b/stan/math/prim/scal/fun/lb_constrain.hpp
@@ -2,7 +2,6 @@
 #define STAN_MATH_PRIM_SCAL_FUN_LB_CONSTRAIN_HPP
 
 #include <stan/math/prim/meta.hpp>
-#include <boost/math/tools/promotion.hpp>
 #include <stan/math/prim/scal/fun/identity_constrain.hpp>
 #include <stan/math/prim/scal/fun/constants.hpp>
 #include <cmath>

--- a/stan/math/prim/scal/fun/lb_free.hpp
+++ b/stan/math/prim/scal/fun/lb_free.hpp
@@ -5,7 +5,6 @@
 #include <stan/math/prim/scal/fun/identity_free.hpp>
 #include <stan/math/prim/scal/fun/constants.hpp>
 #include <stan/math/prim/scal/err/check_greater_or_equal.hpp>
-#include <boost/math/tools/promotion.hpp>
 #include <cmath>
 
 namespace stan {

--- a/stan/math/prim/scal/fun/lbeta.hpp
+++ b/stan/math/prim/scal/fun/lbeta.hpp
@@ -2,7 +2,6 @@
 #define STAN_MATH_PRIM_SCAL_FUN_LBETA_HPP
 
 #include <stan/math/prim/meta.hpp>
-#include <boost/math/tools/promotion.hpp>
 #include <stan/math/prim/scal/fun/lgamma.hpp>
 
 namespace stan {

--- a/stan/math/prim/scal/fun/lmgamma.hpp
+++ b/stan/math/prim/scal/fun/lmgamma.hpp
@@ -2,7 +2,6 @@
 #define STAN_MATH_PRIM_SCAL_FUN_LMGAMMA_HPP
 
 #include <stan/math/prim/meta.hpp>
-#include <boost/math/tools/promotion.hpp>
 #include <stan/math/prim/scal/fun/constants.hpp>
 #include <stan/math/prim/scal/fun/lgamma.hpp>
 

--- a/stan/math/prim/scal/fun/log_diff_exp.hpp
+++ b/stan/math/prim/scal/fun/log_diff_exp.hpp
@@ -4,7 +4,6 @@
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/scal/fun/log1m_exp.hpp>
 #include <stan/math/prim/scal/fun/constants.hpp>
-#include <boost/math/tools/promotion.hpp>
 
 namespace stan {
 namespace math {

--- a/stan/math/prim/scal/fun/log_inv_logit_diff.hpp
+++ b/stan/math/prim/scal/fun/log_inv_logit_diff.hpp
@@ -4,7 +4,6 @@
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/scal/fun/log1m_exp.hpp>
 #include <stan/math/prim/scal/fun/log1p_exp.hpp>
-#include <boost/math/tools/promotion.hpp>
 
 namespace stan {
 namespace math {

--- a/stan/math/prim/scal/fun/log_sum_exp.hpp
+++ b/stan/math/prim/scal/fun/log_sum_exp.hpp
@@ -4,7 +4,6 @@
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/scal/fun/log1p_exp.hpp>
 #include <stan/math/prim/scal/fun/constants.hpp>
-#include <boost/math/tools/promotion.hpp>
 
 namespace stan {
 namespace math {

--- a/stan/math/prim/scal/fun/lub_constrain.hpp
+++ b/stan/math/prim/scal/fun/lub_constrain.hpp
@@ -6,7 +6,6 @@
 #include <stan/math/prim/scal/fun/lb_constrain.hpp>
 #include <stan/math/prim/scal/fun/ub_constrain.hpp>
 #include <stan/math/prim/scal/fun/fma.hpp>
-#include <boost/math/tools/promotion.hpp>
 #include <cmath>
 #include <limits>
 

--- a/stan/math/prim/scal/fun/multiply_log.hpp
+++ b/stan/math/prim/scal/fun/multiply_log.hpp
@@ -2,7 +2,6 @@
 #define STAN_MATH_PRIM_SCAL_FUN_MULTIPLY_LOG_HPP
 
 #include <stan/math/prim/meta.hpp>
-#include <boost/math/tools/promotion.hpp>
 
 namespace stan {
 namespace math {

--- a/stan/math/prim/scal/fun/offset_multiplier_constrain.hpp
+++ b/stan/math/prim/scal/fun/offset_multiplier_constrain.hpp
@@ -1,7 +1,6 @@
 #ifndef STAN_MATH_PRIM_SCAL_FUN_OFFSET_MULTIPLIER_CONSTRAIN_HPP
 #define STAN_MATH_PRIM_SCAL_FUN_OFFSET_MULTIPLIER_CONSTRAIN_HPP
 
-#include <boost/math/tools/promotion.hpp>
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/scal/fun/identity_constrain.hpp>
 #include <stan/math/prim/scal/fun/multiply_log.hpp>

--- a/stan/math/prim/scal/fun/offset_multiplier_free.hpp
+++ b/stan/math/prim/scal/fun/offset_multiplier_free.hpp
@@ -5,7 +5,6 @@
 #include <stan/math/prim/scal/fun/identity_free.hpp>
 #include <stan/math/prim/scal/err/check_positive_finite.hpp>
 #include <stan/math/prim/scal/err/check_finite.hpp>
-#include <boost/math/tools/promotion.hpp>
 #include <cmath>
 #include <limits>
 

--- a/stan/math/prim/scal/fun/ub_constrain.hpp
+++ b/stan/math/prim/scal/fun/ub_constrain.hpp
@@ -2,7 +2,6 @@
 #define STAN_MATH_PRIM_SCAL_FUN_UB_CONSTRAIN_HPP
 
 #include <stan/math/prim/meta.hpp>
-#include <boost/math/tools/promotion.hpp>
 #include <stan/math/prim/scal/fun/identity_constrain.hpp>
 #include <stan/math/prim/scal/fun/constants.hpp>
 #include <cmath>

--- a/stan/math/prim/scal/fun/ub_free.hpp
+++ b/stan/math/prim/scal/fun/ub_free.hpp
@@ -5,7 +5,6 @@
 #include <stan/math/prim/scal/fun/identity_free.hpp>
 #include <stan/math/prim/scal/fun/constants.hpp>
 #include <stan/math/prim/scal/err/check_less_or_equal.hpp>
-#include <boost/math/tools/promotion.hpp>
 #include <limits>
 
 namespace stan {

--- a/stan/math/prim/scal/meta/partials_return_type.hpp
+++ b/stan/math/prim/scal/meta/partials_return_type.hpp
@@ -4,7 +4,6 @@
 #include <stan/math/prim/scal/meta/partials_type.hpp>
 #include <stan/math/prim/scal/meta/promote_args.hpp>
 #include <stan/math/prim/scal/meta/scalar_type.hpp>
-#include <boost/math/tools/promotion.hpp>
 #include <type_traits>
 
 namespace stan {

--- a/stan/math/prim/scal/meta/return_type.hpp
+++ b/stan/math/prim/scal/meta/return_type.hpp
@@ -3,7 +3,6 @@
 
 #include <stan/math/prim/scal/meta/promote_args.hpp>
 #include <stan/math/prim/scal/meta/scalar_type.hpp>
-#include <boost/math/tools/promotion.hpp>
 
 namespace stan {
 

--- a/stan/math/prim/scal/prob/frechet_cdf.hpp
+++ b/stan/math/prim/scal/prob/frechet_cdf.hpp
@@ -27,7 +27,6 @@ return_type_t<T_y, T_shape, T_scale> frechet_cdf(const T_y& y,
 
   static const char* function = "frechet_cdf";
 
-  using boost::math::tools::promote_args;
   using std::exp;
   using std::log;
 

--- a/stan/math/prim/scal/prob/frechet_lccdf.hpp
+++ b/stan/math/prim/scal/prob/frechet_lccdf.hpp
@@ -27,8 +27,6 @@ return_type_t<T_y, T_shape, T_scale> frechet_lccdf(const T_y& y,
 
   static const char* function = "frechet_lccdf";
 
-  using boost::math::tools::promote_args;
-
   if (size_zero(y, alpha, sigma)) {
     return 0.0;
   }

--- a/stan/math/prim/scal/prob/frechet_lcdf.hpp
+++ b/stan/math/prim/scal/prob/frechet_lcdf.hpp
@@ -27,7 +27,6 @@ return_type_t<T_y, T_shape, T_scale> frechet_lcdf(const T_y& y,
 
   static const char* function = "frechet_lcdf";
 
-  using boost::math::tools::promote_args;
   using std::log;
 
   if (size_zero(y, alpha, sigma)) {

--- a/stan/math/prim/scal/prob/gamma_cdf.hpp
+++ b/stan/math/prim/scal/prob/gamma_cdf.hpp
@@ -49,7 +49,6 @@ return_type_t<T_y, T_shape, T_inv_scale> gamma_cdf(const T_y& y,
 
   static const char* function = "gamma_cdf";
 
-  using boost::math::tools::promote_args;
   using std::exp;
 
   T_partials_return P(1.0);

--- a/stan/math/prim/scal/prob/wiener_log.hpp
+++ b/stan/math/prim/scal/prob/wiener_log.hpp
@@ -3,7 +3,6 @@
 
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/scal/prob/wiener_lpdf.hpp>
-#include <boost/math/tools/promotion.hpp>
 
 namespace stan {
 namespace math {

--- a/stan/math/rev/mat/fun/multiply.hpp
+++ b/stan/math/rev/mat/fun/multiply.hpp
@@ -9,7 +9,6 @@
 #include <stan/math/prim/scal/err/check_not_nan.hpp>
 #include <stan/math/prim/mat.hpp>
 #include <stan/math/prim/meta.hpp>
-#include <boost/math/tools/promotion.hpp>
 #include <type_traits>
 
 namespace stan {

--- a/test/unit/math/fwd/scal/fun/nan_util.hpp
+++ b/test/unit/math/fwd/scal/fun/nan_util.hpp
@@ -3,7 +3,6 @@
 
 #include <stan/math/fwd/scal.hpp>
 #include <boost/math/special_functions/fpclassify.hpp>
-#include <boost/math/tools/promotion.hpp>
 #include <Eigen/Dense>
 #include <limits>
 

--- a/test/unit/math/mix/scal/fun/nan_util.hpp
+++ b/test/unit/math/mix/scal/fun/nan_util.hpp
@@ -2,7 +2,6 @@
 #define TEST_UNIT_MATH_MIX_SCAL_FUN_NAN_UTIL_HPP
 
 #include <boost/math/special_functions/fpclassify.hpp>
-#include <boost/math/tools/promotion.hpp>
 #include <limits>
 
 template <typename F>

--- a/test/unit/math/rev/mat/functor/util_algebra_solver.hpp
+++ b/test/unit/math/rev/mat/functor/util_algebra_solver.hpp
@@ -34,12 +34,12 @@ Eigen::Matrix<T2, Eigen::Dynamic, 1> general_algebra_solver(
 
 struct simple_eq_functor {
   template <typename T0, typename T1>
-  inline Eigen::Matrix<stan::promote_args_t<T0, T1>, Eigen::Dynamic, 1>
+  inline Eigen::Matrix<stan::return_type_t<T0, T1>, Eigen::Dynamic, 1>
   operator()(const Eigen::Matrix<T0, Eigen::Dynamic, 1>& x,
              const Eigen::Matrix<T1, Eigen::Dynamic, 1>& y,
              const std::vector<double>& dat, const std::vector<int>& dat_int,
              std::ostream* pstream__) const {
-    Eigen::Matrix<stan::promote_args_t<T0, T1>, Eigen::Dynamic, 1> z(2);
+    Eigen::Matrix<stan::return_type_t<T0, T1>, Eigen::Dynamic, 1> z(2);
     z(0) = x(0) - y(0) * y(1);
     z(1) = x(1) - y(2);
     return z;
@@ -48,12 +48,12 @@ struct simple_eq_functor {
 
 struct simple_eq_functor_nopara {
   template <typename T0, typename T1>
-  inline Eigen::Matrix<stan::promote_args_t<T0, T1>, Eigen::Dynamic, 1>
+  inline Eigen::Matrix<stan::return_type_t<T0, T1>, Eigen::Dynamic, 1>
   operator()(const Eigen::Matrix<T0, Eigen::Dynamic, 1>& x,
              const Eigen::Matrix<T1, Eigen::Dynamic, 1>& y,
              const std::vector<double>& dat, const std::vector<int>& dat_int,
              std::ostream* pstream__) const {
-    Eigen::Matrix<stan::promote_args_t<T0, T1>, Eigen::Dynamic, 1> z(2);
+    Eigen::Matrix<stan::return_type_t<T0, T1>, Eigen::Dynamic, 1> z(2);
     z(0) = x(0) - dat[0] * dat[1];
     z(1) = x(1) - dat[2];
     return z;
@@ -62,12 +62,12 @@ struct simple_eq_functor_nopara {
 
 struct non_linear_eq_functor {
   template <typename T0, typename T1>
-  inline Eigen::Matrix<stan::promote_args_t<T0, T1>, Eigen::Dynamic, 1>
+  inline Eigen::Matrix<stan::return_type_t<T0, T1>, Eigen::Dynamic, 1>
   operator()(const Eigen::Matrix<T0, Eigen::Dynamic, 1>& x,
              const Eigen::Matrix<T1, Eigen::Dynamic, 1>& y,
              const std::vector<double>& dat, const std::vector<int>& dat_int,
              std::ostream* pstream__) const {
-    Eigen::Matrix<stan::promote_args_t<T0, T1>, Eigen::Dynamic, 1> z(3);
+    Eigen::Matrix<stan::return_type_t<T0, T1>, Eigen::Dynamic, 1> z(3);
     z(0) = x(2) - y(2);
     z(1) = x(0) * x(1) - y(0) * y(1);
     z(2) = x(2) / x(0) + y(2) / y(0);
@@ -77,12 +77,12 @@ struct non_linear_eq_functor {
 
 struct non_square_eq_functor {
   template <typename T0, typename T1>
-  inline Eigen::Matrix<stan::promote_args_t<T0, T1>, Eigen::Dynamic, 1>
+  inline Eigen::Matrix<stan::return_type_t<T0, T1>, Eigen::Dynamic, 1>
   operator()(const Eigen::Matrix<T0, Eigen::Dynamic, 1>& x,
              const Eigen::Matrix<T1, Eigen::Dynamic, 1>& y,
              const std::vector<double>& dat, const std::vector<int>& dat_int,
              std::ostream* pstream__) const {
-    Eigen::Matrix<stan::promote_args_t<T0, T1>, Eigen::Dynamic, 1> z(2);
+    Eigen::Matrix<stan::return_type_t<T0, T1>, Eigen::Dynamic, 1> z(2);
     z(0) = x(0) - y(0);
     z(1) = x(1) * x(2) - y(1);
     return z;
@@ -91,12 +91,12 @@ struct non_square_eq_functor {
 
 struct unsolvable_eq_functor {
   template <typename T0, typename T1>
-  inline Eigen::Matrix<stan::promote_args_t<T0, T1>, Eigen::Dynamic, 1>
+  inline Eigen::Matrix<stan::return_type_t<T0, T1>, Eigen::Dynamic, 1>
   operator()(const Eigen::Matrix<T0, Eigen::Dynamic, 1>& x,
              const Eigen::Matrix<T1, Eigen::Dynamic, 1>& y,
              const std::vector<double>& dat, const std::vector<int>& dat_int,
              std::ostream* pstream__) const {
-    Eigen::Matrix<stan::promote_args_t<T0, T1>, Eigen::Dynamic, 1> z(2);
+    Eigen::Matrix<stan::return_type_t<T0, T1>, Eigen::Dynamic, 1> z(2);
     z(0) = x(0) * x(0) + y(0);
     z(1) = x(1) * x(1) + y(1);
     return z;
@@ -106,12 +106,12 @@ struct unsolvable_eq_functor {
 // Degenerate roots: each solution can either be y(0) or y(1).
 struct degenerate_eq_functor {
   template <typename T0, typename T1>
-  inline Eigen::Matrix<stan::promote_args_t<T0, T1>, Eigen::Dynamic, 1>
+  inline Eigen::Matrix<stan::return_type_t<T0, T1>, Eigen::Dynamic, 1>
   operator()(const Eigen::Matrix<T0, Eigen::Dynamic, 1>& x,
              const Eigen::Matrix<T1, Eigen::Dynamic, 1>& y,
              const std::vector<double>& dat, const std::vector<int>& dat_int,
              std::ostream* pstream__) const {
-    Eigen::Matrix<stan::promote_args_t<T0, T1>, Eigen::Dynamic, 1> z(2);
+    Eigen::Matrix<stan::return_type_t<T0, T1>, Eigen::Dynamic, 1> z(2);
     z(0) = (x(0) - y(0)) * (x(1) - y(1));
     z(1) = (x(0) - y(1)) * (x(1) - y(0));
     return z;

--- a/test/unit/math/rev/mat/functor/util_algebra_solver.hpp
+++ b/test/unit/math/rev/mat/functor/util_algebra_solver.hpp
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+#include <stan/math/prim/meta.hpp>
 #include <stan/math/rev/mat/functor/algebra_solver_powell.hpp>
 #include <stan/math/rev/mat/functor/algebra_solver_newton.hpp>
 #include <test/unit/util.hpp>
@@ -33,14 +34,12 @@ Eigen::Matrix<T2, Eigen::Dynamic, 1> general_algebra_solver(
 
 struct simple_eq_functor {
   template <typename T0, typename T1>
-  inline Eigen::Matrix<typename boost::math::tools::promote_args<T0, T1>::type,
-                       Eigen::Dynamic, 1>
+  inline Eigen::Matrix<stan::promote_args_t<T0, T1>, Eigen::Dynamic, 1>
   operator()(const Eigen::Matrix<T0, Eigen::Dynamic, 1>& x,
              const Eigen::Matrix<T1, Eigen::Dynamic, 1>& y,
              const std::vector<double>& dat, const std::vector<int>& dat_int,
              std::ostream* pstream__) const {
-    typedef typename boost::math::tools::promote_args<T0, T1>::type scalar;
-    Eigen::Matrix<scalar, Eigen::Dynamic, 1> z(2);
+    Eigen::Matrix<stan::promote_args_t<T0, T1>, Eigen::Dynamic, 1> z(2);
     z(0) = x(0) - y(0) * y(1);
     z(1) = x(1) - y(2);
     return z;
@@ -49,14 +48,12 @@ struct simple_eq_functor {
 
 struct simple_eq_functor_nopara {
   template <typename T0, typename T1>
-  inline Eigen::Matrix<typename boost::math::tools::promote_args<T0, T1>::type,
-                       Eigen::Dynamic, 1>
+  inline Eigen::Matrix<stan::promote_args_t<T0, T1>, Eigen::Dynamic, 1>
   operator()(const Eigen::Matrix<T0, Eigen::Dynamic, 1>& x,
              const Eigen::Matrix<T1, Eigen::Dynamic, 1>& y,
              const std::vector<double>& dat, const std::vector<int>& dat_int,
              std::ostream* pstream__) const {
-    typedef typename boost::math::tools::promote_args<T0, T1>::type scalar;
-    Eigen::Matrix<scalar, Eigen::Dynamic, 1> z(2);
+    Eigen::Matrix<stan::promote_args_t<T0, T1>, Eigen::Dynamic, 1> z(2);
     z(0) = x(0) - dat[0] * dat[1];
     z(1) = x(1) - dat[2];
     return z;
@@ -65,14 +62,12 @@ struct simple_eq_functor_nopara {
 
 struct non_linear_eq_functor {
   template <typename T0, typename T1>
-  inline Eigen::Matrix<typename boost::math::tools::promote_args<T0, T1>::type,
-                       Eigen::Dynamic, 1>
+  inline Eigen::Matrix<stan::promote_args_t<T0, T1>, Eigen::Dynamic, 1>
   operator()(const Eigen::Matrix<T0, Eigen::Dynamic, 1>& x,
              const Eigen::Matrix<T1, Eigen::Dynamic, 1>& y,
              const std::vector<double>& dat, const std::vector<int>& dat_int,
              std::ostream* pstream__) const {
-    typedef typename boost::math::tools::promote_args<T0, T1>::type scalar;
-    Eigen::Matrix<scalar, Eigen::Dynamic, 1> z(3);
+    Eigen::Matrix<stan::promote_args_t<T0, T1>, Eigen::Dynamic, 1> z(3);
     z(0) = x(2) - y(2);
     z(1) = x(0) * x(1) - y(0) * y(1);
     z(2) = x(2) / x(0) + y(2) / y(0);
@@ -82,14 +77,12 @@ struct non_linear_eq_functor {
 
 struct non_square_eq_functor {
   template <typename T0, typename T1>
-  inline Eigen::Matrix<typename boost::math::tools::promote_args<T0, T1>::type,
-                       Eigen::Dynamic, 1>
+  inline Eigen::Matrix<stan::promote_args_t<T0, T1>, Eigen::Dynamic, 1>
   operator()(const Eigen::Matrix<T0, Eigen::Dynamic, 1>& x,
              const Eigen::Matrix<T1, Eigen::Dynamic, 1>& y,
              const std::vector<double>& dat, const std::vector<int>& dat_int,
              std::ostream* pstream__) const {
-    typedef typename boost::math::tools::promote_args<T0, T1>::type scalar;
-    Eigen::Matrix<scalar, Eigen::Dynamic, 1> z(2);
+    Eigen::Matrix<stan::promote_args_t<T0, T1>, Eigen::Dynamic, 1> z(2);
     z(0) = x(0) - y(0);
     z(1) = x(1) * x(2) - y(1);
     return z;
@@ -98,14 +91,12 @@ struct non_square_eq_functor {
 
 struct unsolvable_eq_functor {
   template <typename T0, typename T1>
-  inline Eigen::Matrix<typename boost::math::tools::promote_args<T0, T1>::type,
-                       Eigen::Dynamic, 1>
+  inline Eigen::Matrix<stan::promote_args_t<T0, T1>, Eigen::Dynamic, 1>
   operator()(const Eigen::Matrix<T0, Eigen::Dynamic, 1>& x,
              const Eigen::Matrix<T1, Eigen::Dynamic, 1>& y,
              const std::vector<double>& dat, const std::vector<int>& dat_int,
              std::ostream* pstream__) const {
-    typedef typename boost::math::tools::promote_args<T0, T1>::type scalar;
-    Eigen::Matrix<scalar, Eigen::Dynamic, 1> z(2);
+    Eigen::Matrix<stan::promote_args_t<T0, T1>, Eigen::Dynamic, 1> z(2);
     z(0) = x(0) * x(0) + y(0);
     z(1) = x(1) * x(1) + y(1);
     return z;
@@ -115,14 +106,12 @@ struct unsolvable_eq_functor {
 // Degenerate roots: each solution can either be y(0) or y(1).
 struct degenerate_eq_functor {
   template <typename T0, typename T1>
-  inline Eigen::Matrix<typename boost::math::tools::promote_args<T0, T1>::type,
-                       Eigen::Dynamic, 1>
+  inline Eigen::Matrix<stan::promote_args_t<T0, T1>, Eigen::Dynamic, 1>
   operator()(const Eigen::Matrix<T0, Eigen::Dynamic, 1>& x,
              const Eigen::Matrix<T1, Eigen::Dynamic, 1>& y,
              const std::vector<double>& dat, const std::vector<int>& dat_int,
              std::ostream* pstream__) const {
-    typedef typename boost::math::tools::promote_args<T0, T1>::type scalar;
-    Eigen::Matrix<scalar, Eigen::Dynamic, 1> z(2);
+    Eigen::Matrix<stan::promote_args_t<T0, T1>, Eigen::Dynamic, 1> z(2);
     z(0) = (x(0) - y(0)) * (x(1) - y(1));
     z(1) = (x(0) - y(1)) * (x(1) - y(0));
     return z;

--- a/test/unit/math/rev/mat/prob/multi_normal2_test.cpp
+++ b/test/unit/math/rev/mat/prob/multi_normal2_test.cpp
@@ -229,9 +229,9 @@ struct vectorized_multi_normal_fun {
   }
 
   template <typename T_y, typename T_mu, typename T_sigma>
-  stan::promote_args_t<T_y, T_mu, T_sigma>
-  operator()(const std::vector<T_y>& y_vec, const std::vector<T_mu>& mu_vec,
-             const std::vector<T_sigma>& sigma_vec) const {
+  stan::promote_args_t<T_y, T_mu, T_sigma> operator()(
+      const std::vector<T_y>& y_vec, const std::vector<T_mu>& mu_vec,
+      const std::vector<T_sigma>& sigma_vec) const {
     vector<Matrix<T_y, is_row_vec_y, is_row_vec_y * -1> > y(
         L_, Matrix<T_y, is_row_vec_y, is_row_vec_y * -1>(K_));
     vector<Matrix<T_mu, is_row_vec_mu, is_row_vec_mu * -1> > mu(

--- a/test/unit/math/rev/mat/prob/multi_normal2_test.cpp
+++ b/test/unit/math/rev/mat/prob/multi_normal2_test.cpp
@@ -229,7 +229,7 @@ struct vectorized_multi_normal_fun {
   }
 
   template <typename T_y, typename T_mu, typename T_sigma>
-  stan::promote_args_t<T_y, T_mu, T_sigma> operator()(
+  stan::return_type_t<T_y, T_mu, T_sigma> operator()(
       const std::vector<T_y>& y_vec, const std::vector<T_mu>& mu_vec,
       const std::vector<T_sigma>& sigma_vec) const {
     vector<Matrix<T_y, is_row_vec_y, is_row_vec_y * -1> > y(

--- a/test/unit/math/rev/mat/prob/multi_normal2_test.cpp
+++ b/test/unit/math/rev/mat/prob/multi_normal2_test.cpp
@@ -229,7 +229,7 @@ struct vectorized_multi_normal_fun {
   }
 
   template <typename T_y, typename T_mu, typename T_sigma>
-  typename boost::math::tools::promote_args<T_y, T_mu, T_sigma>::type
+  stan::promote_args_t<T_y, T_mu, T_sigma>
   operator()(const std::vector<T_y>& y_vec, const std::vector<T_mu>& mu_vec,
              const std::vector<T_sigma>& sigma_vec) const {
     vector<Matrix<T_y, is_row_vec_y, is_row_vec_y * -1> > y(

--- a/test/unit/math/rev/mat/prob/multi_normal_cholesky2_test.cpp
+++ b/test/unit/math/rev/mat/prob/multi_normal_cholesky2_test.cpp
@@ -92,9 +92,9 @@ struct vectorized_multi_normal_cholesky_fun {
   }
 
   template <typename T_y, typename T_mu, typename T_sigma>
-  stan::promote_args_t<T_y, T_mu, T_sigma>
-  operator()(const std::vector<T_y>& y_vec, const std::vector<T_mu>& mu_vec,
-             const std::vector<T_sigma>& sigma_vec) const {
+  stan::promote_args_t<T_y, T_mu, T_sigma> operator()(
+      const std::vector<T_y>& y_vec, const std::vector<T_mu>& mu_vec,
+      const std::vector<T_sigma>& sigma_vec) const {
     vector<Matrix<T_y, is_row_vec_y, is_row_vec_y * -1> > y(
         L_, Matrix<T_y, is_row_vec_y, is_row_vec_y * -1>(K_));
     vector<Matrix<T_mu, is_row_vec_mu, is_row_vec_mu * -1> > mu(

--- a/test/unit/math/rev/mat/prob/multi_normal_cholesky2_test.cpp
+++ b/test/unit/math/rev/mat/prob/multi_normal_cholesky2_test.cpp
@@ -92,7 +92,7 @@ struct vectorized_multi_normal_cholesky_fun {
   }
 
   template <typename T_y, typename T_mu, typename T_sigma>
-  typename boost::math::tools::promote_args<T_y, T_mu, T_sigma>::type
+  stan::promote_args_t<T_y, T_mu, T_sigma>
   operator()(const std::vector<T_y>& y_vec, const std::vector<T_mu>& mu_vec,
              const std::vector<T_sigma>& sigma_vec) const {
     vector<Matrix<T_y, is_row_vec_y, is_row_vec_y * -1> > y(

--- a/test/unit/math/rev/mat/prob/multi_normal_prec2_test.cpp
+++ b/test/unit/math/rev/mat/prob/multi_normal_prec2_test.cpp
@@ -155,7 +155,7 @@ struct vectorized_multi_normal_prec_fun {
   }
 
   template <typename T_y, typename T_mu, typename T_sigma>
-  typename boost::math::tools::promote_args<T_y, T_mu, T_sigma>::type
+  stan::promote_args_t<T_y, T_mu, T_sigma>
   operator()(const std::vector<T_y>& y_vec, const std::vector<T_mu>& mu_vec,
              const std::vector<T_sigma>& sigma_vec) const {
     vector<Matrix<T_y, is_row_vec_y, is_row_vec_y * -1> > y(

--- a/test/unit/math/rev/mat/prob/multi_normal_prec2_test.cpp
+++ b/test/unit/math/rev/mat/prob/multi_normal_prec2_test.cpp
@@ -155,9 +155,9 @@ struct vectorized_multi_normal_prec_fun {
   }
 
   template <typename T_y, typename T_mu, typename T_sigma>
-  stan::promote_args_t<T_y, T_mu, T_sigma>
-  operator()(const std::vector<T_y>& y_vec, const std::vector<T_mu>& mu_vec,
-             const std::vector<T_sigma>& sigma_vec) const {
+  stan::promote_args_t<T_y, T_mu, T_sigma> operator()(
+      const std::vector<T_y>& y_vec, const std::vector<T_mu>& mu_vec,
+      const std::vector<T_sigma>& sigma_vec) const {
     vector<Matrix<T_y, is_row_vec_y, is_row_vec_y * -1> > y(
         L_, Matrix<T_y, is_row_vec_y, is_row_vec_y * -1>(K_));
     vector<Matrix<T_mu, is_row_vec_mu, is_row_vec_mu * -1> > mu(

--- a/test/unit/math/rev/mat/prob/multi_normal_prec2_test.cpp
+++ b/test/unit/math/rev/mat/prob/multi_normal_prec2_test.cpp
@@ -155,7 +155,7 @@ struct vectorized_multi_normal_prec_fun {
   }
 
   template <typename T_y, typename T_mu, typename T_sigma>
-  stan::promote_args_t<T_y, T_mu, T_sigma> operator()(
+  stan::return_type_t<T_y, T_mu, T_sigma> operator()(
       const std::vector<T_y>& y_vec, const std::vector<T_mu>& mu_vec,
       const std::vector<T_sigma>& sigma_vec) const {
     vector<Matrix<T_y, is_row_vec_y, is_row_vec_y * -1> > y(

--- a/test/unit/math/rev/mat/prob/multi_student_t2_test.cpp
+++ b/test/unit/math/rev/mat/prob/multi_student_t2_test.cpp
@@ -226,9 +226,9 @@ struct vectorized_multi_student_t_fun {
   }
 
   template <typename T_y, typename T_mu, typename T_sigma, typename T_nu>
-  stan::promote_args_t<T_y, T_mu, T_sigma, T_nu>
-  operator()(const std::vector<T_y>& y_vec, const std::vector<T_mu>& mu_vec,
-             const std::vector<T_sigma>& sigma_vec, const T_nu& nu) const {
+  stan::promote_args_t<T_y, T_mu, T_sigma, T_nu> operator()(
+      const std::vector<T_y>& y_vec, const std::vector<T_mu>& mu_vec,
+      const std::vector<T_sigma>& sigma_vec, const T_nu& nu) const {
     vector<Matrix<T_y, is_row_vec_y, is_row_vec_y * -1> > y(
         L_, Matrix<T_y, is_row_vec_y, is_row_vec_y * -1>(K_));
     vector<Matrix<T_mu, is_row_vec_mu, is_row_vec_mu * -1> > mu(

--- a/test/unit/math/rev/mat/prob/multi_student_t2_test.cpp
+++ b/test/unit/math/rev/mat/prob/multi_student_t2_test.cpp
@@ -226,7 +226,7 @@ struct vectorized_multi_student_t_fun {
   }
 
   template <typename T_y, typename T_mu, typename T_sigma, typename T_nu>
-  typename boost::math::tools::promote_args<T_y, T_mu, T_sigma, T_nu>::type
+  stan::promote_args_t<T_y, T_mu, T_sigma, T_nu>
   operator()(const std::vector<T_y>& y_vec, const std::vector<T_mu>& mu_vec,
              const std::vector<T_sigma>& sigma_vec, const T_nu& nu) const {
     vector<Matrix<T_y, is_row_vec_y, is_row_vec_y * -1> > y(

--- a/test/unit/math/rev/mat/prob/multi_student_t2_test.cpp
+++ b/test/unit/math/rev/mat/prob/multi_student_t2_test.cpp
@@ -226,7 +226,7 @@ struct vectorized_multi_student_t_fun {
   }
 
   template <typename T_y, typename T_mu, typename T_sigma, typename T_nu>
-  stan::promote_args_t<T_y, T_mu, T_sigma, T_nu> operator()(
+  stan::return_type_t<T_y, T_mu, T_sigma, T_nu> operator()(
       const std::vector<T_y>& y_vec, const std::vector<T_mu>& mu_vec,
       const std::vector<T_sigma>& sigma_vec, const T_nu& nu) const {
     vector<Matrix<T_y, is_row_vec_y, is_row_vec_y * -1> > y(

--- a/test/unit/math_include_test.cpp
+++ b/test/unit/math_include_test.cpp
@@ -1,5 +1,4 @@
 #include <stan/math.hpp>
-#include <boost/math/tools/promotion.hpp>
 #include <gtest/gtest.h>
 #include <Eigen/Dense>
 #include <cmath>
@@ -59,7 +58,7 @@ TEST_F(Math, paper_example_2) {
 
 namespace paper {  // paper_example_3
 template <typename T1, typename T2, typename T3>
-inline typename boost::math::tools::promote_args<T1, T2, T3>::type normal_log(
+inline stan::promote_args_t<T1, T2, T3> normal_log(
     const T1& y, const T2& mu, const T3& sigma) {
   using std::log;
   using std::pow;

--- a/test/unit/math_include_test.cpp
+++ b/test/unit/math_include_test.cpp
@@ -58,8 +58,8 @@ TEST_F(Math, paper_example_2) {
 
 namespace paper {  // paper_example_3
 template <typename T1, typename T2, typename T3>
-inline stan::promote_args_t<T1, T2, T3> normal_log(const T1& y, const T2& mu,
-                                                   const T3& sigma) {
+inline stan::return_type_t<T1, T2, T3> normal_log(const T1& y, const T2& mu,
+                                                  const T3& sigma) {
   using std::log;
   using std::pow;
   return -0.5 * pow((y - mu) / sigma, 2.0) - log(sigma)

--- a/test/unit/math_include_test.cpp
+++ b/test/unit/math_include_test.cpp
@@ -58,8 +58,8 @@ TEST_F(Math, paper_example_2) {
 
 namespace paper {  // paper_example_3
 template <typename T1, typename T2, typename T3>
-inline stan::promote_args_t<T1, T2, T3> normal_log(
-    const T1& y, const T2& mu, const T3& sigma) {
+inline stan::promote_args_t<T1, T2, T3> normal_log(const T1& y, const T2& mu,
+                                                   const T3& sigma) {
   using std::log;
   using std::pow;
   return -0.5 * pow((y - mu) / sigma, 2.0) - log(sigma)


### PR DESCRIPTION
## Summary

There was only one remaining use of boost::promote_args, and a number of using/includes were left over of other template metaprogramming cleanups. Fixes #1426.

## Tests

Existing tests should be enough.

## Side Effects

None.

## Checklist

- [X] Math issue #1426

- [X] Copyright holder: Marco Colombo

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
