### PR TITLE
Increase tolerances in substract_vec_mat test

### DIFF
--- a/test/unit/math/mix/mat/fun/subtract_test.cpp
+++ b/test/unit/math/mix/mat/fun/subtract_test.cpp
@@ -81,6 +81,9 @@ TEST(MathMixMatFun, subtract_scalar_mat) {
 TEST(MathMixMatFun, subtract_vec_mat) {
   auto f
       = [](const auto& x, const auto& y) { return stan::math::subtract(x, y); };
+  stan::test::ad_tolerances tols;
+  tols.hessian_hessian_ = 5e-3;
+  tols.hessian_fvar_hessian_ = 5e-3;
 
   Eigen::VectorXd v5(5);
   v5 << 1, 2, 3, 4, 5;
@@ -90,8 +93,8 @@ TEST(MathMixMatFun, subtract_vec_mat) {
   v5 << 1, 2, 3, 4, 5;
   Eigen::VectorXd rv5b(5);
   v5 << 2, 3, 4, 5, 6;
-  stan::test::expect_ad(f, v5, v5b);
-  stan::test::expect_ad(f, rv5, rv5b);
+  stan::test::expect_ad(tols, f, v5, v5b);
+  stan::test::expect_ad(tols, f, rv5, rv5b);
 }
 
 TEST(MathMixMatFun, subtract_mat_mat) {


### PR DESCRIPTION
## Summary

We are still experiencing some issues on develop after https://github.com/stan-dev/math/pull/1469 was merged. This increases the tolerances for another test. If new test failures come up then I would say we should increase the tolerance globally. I will also investigate what causes the "randomness" of this tests that does not use any randomness whatsoever. Might be limited to Windows.

## Tests

This increases the tolerances in the tests.

## Side Effects

/

## Checklist

- [x] Math issue #1453 

- [x] Copyright holder: Rok Češnovar

- [x] the basic tests are passing

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
