### PR TITLE
Interchange loops for divide and multiply

### DIFF
--- a/stan/math/fwd/mat/fun/divide.hpp
+++ b/stan/math/fwd/mat/fun/divide.hpp
@@ -11,8 +11,8 @@ template <typename T, int R, int C>
 inline Eigen::Matrix<fvar<T>, R, C> divide(
     const Eigen::Matrix<fvar<T>, R, C>& v, const fvar<T>& c) {
   Eigen::Matrix<fvar<T>, R, C> res(v.rows(), v.cols());
-  for (int i = 0; i < v.rows(); i++) {
-    for (int j = 0; j < v.cols(); j++) {
+  for (int j = 0; j < v.cols(); j++) {
+    for (int i = 0; i < v.rows(); i++) {
       res(i, j) = v(i, j) / c;
     }
   }
@@ -23,8 +23,8 @@ template <typename T, int R, int C>
 inline Eigen::Matrix<fvar<T>, R, C> divide(
     const Eigen::Matrix<fvar<T>, R, C>& v, double c) {
   Eigen::Matrix<fvar<T>, R, C> res(v.rows(), v.cols());
-  for (int i = 0; i < v.rows(); i++) {
-    for (int j = 0; j < v.cols(); j++) {
+  for (int j = 0; j < v.cols(); j++) {
+    for (int i = 0; i < v.rows(); i++) {
       res(i, j) = v(i, j) / c;
     }
   }
@@ -35,8 +35,8 @@ template <typename T, int R, int C>
 inline Eigen::Matrix<fvar<T>, R, C> divide(const Eigen::Matrix<double, R, C>& v,
                                            const fvar<T>& c) {
   Eigen::Matrix<fvar<T>, R, C> res(v.rows(), v.cols());
-  for (int i = 0; i < v.rows(); i++) {
-    for (int j = 0; j < v.cols(); j++) {
+  for (int j = 0; j < v.cols(); j++) {
+    for (int i = 0; i < v.rows(); i++) {
       res(i, j) = v(i, j) / c;
     }
   }

--- a/stan/math/fwd/mat/fun/divide.hpp
+++ b/stan/math/fwd/mat/fun/divide.hpp
@@ -11,11 +11,8 @@ template <typename T, int R, int C>
 inline Eigen::Matrix<fvar<T>, R, C> divide(
     const Eigen::Matrix<fvar<T>, R, C>& v, const fvar<T>& c) {
   Eigen::Matrix<fvar<T>, R, C> res(v.rows(), v.cols());
-  for (int j = 0; j < v.cols(); j++) {
-    for (int i = 0; i < v.rows(); i++) {
-      res(i, j) = v(i, j) / c;
-    }
-  }
+  for (int i = 0; i < v.size(); i++)
+    res(i) = v(i) / c;
   return res;
 }
 
@@ -23,11 +20,8 @@ template <typename T, int R, int C>
 inline Eigen::Matrix<fvar<T>, R, C> divide(
     const Eigen::Matrix<fvar<T>, R, C>& v, double c) {
   Eigen::Matrix<fvar<T>, R, C> res(v.rows(), v.cols());
-  for (int j = 0; j < v.cols(); j++) {
-    for (int i = 0; i < v.rows(); i++) {
-      res(i, j) = v(i, j) / c;
-    }
-  }
+  for (int i = 0; i < v.size(); i++)
+    res(i) = v(i) / c;
   return res;
 }
 
@@ -35,11 +29,8 @@ template <typename T, int R, int C>
 inline Eigen::Matrix<fvar<T>, R, C> divide(const Eigen::Matrix<double, R, C>& v,
                                            const fvar<T>& c) {
   Eigen::Matrix<fvar<T>, R, C> res(v.rows(), v.cols());
-  for (int j = 0; j < v.cols(); j++) {
-    for (int i = 0; i < v.rows(); i++) {
-      res(i, j) = v(i, j) / c;
-    }
-  }
+  for (int i = 0; i < v.size(); i++)
+    res(i) = v(i) / c;
   return res;
 }
 

--- a/stan/math/fwd/mat/fun/multiply.hpp
+++ b/stan/math/fwd/mat/fun/multiply.hpp
@@ -14,11 +14,8 @@ template <typename T, int R1, int C1>
 inline Eigen::Matrix<fvar<T>, R1, C1> multiply(
     const Eigen::Matrix<fvar<T>, R1, C1>& m, const fvar<T>& c) {
   Eigen::Matrix<fvar<T>, R1, C1> res(m.rows(), m.cols());
-  for (int j = 0; j < m.cols(); j++) {
-    for (int i = 0; i < m.rows(); i++) {
-      res(i, j) = c * m(i, j);
-    }
-  }
+  for (int i = 0; i < m.size(); i++)
+    res(i) = c * m(i);
   return res;
 }
 
@@ -26,11 +23,8 @@ template <typename T, int R2, int C2>
 inline Eigen::Matrix<fvar<T>, R2, C2> multiply(
     const Eigen::Matrix<fvar<T>, R2, C2>& m, double c) {
   Eigen::Matrix<fvar<T>, R2, C2> res(m.rows(), m.cols());
-  for (int j = 0; j < m.cols(); j++) {
-    for (int i = 0; i < m.rows(); i++) {
-      res(i, j) = c * m(i, j);
-    }
-  }
+  for (int i = 0; i < m.size(); i++)
+    res(i) = c * m(i);
   return res;
 }
 
@@ -38,11 +32,8 @@ template <typename T, int R1, int C1>
 inline Eigen::Matrix<fvar<T>, R1, C1> multiply(
     const Eigen::Matrix<double, R1, C1>& m, const fvar<T>& c) {
   Eigen::Matrix<fvar<T>, R1, C1> res(m.rows(), m.cols());
-  for (int j = 0; j < m.cols(); j++) {
-    for (int i = 0; i < m.rows(); i++) {
-      res(i, j) = c * m(i, j);
-    }
-  }
+  for (int i = 0; i < m.size(); i++)
+    res(i) = c * m(i);
   return res;
 }
 

--- a/stan/math/fwd/mat/fun/multiply.hpp
+++ b/stan/math/fwd/mat/fun/multiply.hpp
@@ -14,8 +14,8 @@ template <typename T, int R1, int C1>
 inline Eigen::Matrix<fvar<T>, R1, C1> multiply(
     const Eigen::Matrix<fvar<T>, R1, C1>& m, const fvar<T>& c) {
   Eigen::Matrix<fvar<T>, R1, C1> res(m.rows(), m.cols());
-  for (int i = 0; i < m.rows(); i++) {
-    for (int j = 0; j < m.cols(); j++) {
+  for (int j = 0; j < m.cols(); j++) {
+    for (int i = 0; i < m.rows(); i++) {
       res(i, j) = c * m(i, j);
     }
   }
@@ -26,8 +26,8 @@ template <typename T, int R2, int C2>
 inline Eigen::Matrix<fvar<T>, R2, C2> multiply(
     const Eigen::Matrix<fvar<T>, R2, C2>& m, double c) {
   Eigen::Matrix<fvar<T>, R2, C2> res(m.rows(), m.cols());
-  for (int i = 0; i < m.rows(); i++) {
-    for (int j = 0; j < m.cols(); j++) {
+  for (int j = 0; j < m.cols(); j++) {
+    for (int i = 0; i < m.rows(); i++) {
       res(i, j) = c * m(i, j);
     }
   }
@@ -38,8 +38,8 @@ template <typename T, int R1, int C1>
 inline Eigen::Matrix<fvar<T>, R1, C1> multiply(
     const Eigen::Matrix<double, R1, C1>& m, const fvar<T>& c) {
   Eigen::Matrix<fvar<T>, R1, C1> res(m.rows(), m.cols());
-  for (int i = 0; i < m.rows(); i++) {
-    for (int j = 0; j < m.cols(); j++) {
+  for (int j = 0; j < m.cols(); j++) {
+    for (int i = 0; i < m.rows(); i++) {
       res(i, j) = c * m(i, j);
     }
   }

--- a/test/unit/math/mix/mat/fun/divide_test.cpp
+++ b/test/unit/math/mix/mat/fun/divide_test.cpp
@@ -1,4 +1,5 @@
 #include <test/unit/math/test_ad.hpp>
+#include <limits>
 
 TEST(MathMixMatFun, divide) {
   auto f
@@ -31,10 +32,26 @@ TEST(MathMixMatFun, divide) {
   u << 100, 0, -3, 4;
   stan::test::expect_ad(f, u, x2);
 
-  Eigen::MatrixXd m00(0, 0);
   Eigen::VectorXd v0(0);
   Eigen::RowVectorXd rv0(0);
+  Eigen::MatrixXd m00(0, 0);
   stan::test::expect_ad(f, v0, x1);
   stan::test::expect_ad(f, rv0, x1);
   stan::test::expect_ad(f, m00, x1);
+
+  stan::test::expect_ad(f, u, 0.0);
+  stan::test::expect_ad(f, rv, 0.0);
+  stan::test::expect_ad(f, p, 0.0);
+
+  Eigen::RowVectorXd rv4(4);
+  rv4 << -5, 10, 7, 8.2;
+  stan::test::expect_ad(f, rv4, x2);
+
+  double inf = std::numeric_limits<double>::infinity();
+  double nan = std::numeric_limits<double>::quiet_NaN();
+  for (double value : {inf, -inf, nan}) {
+    stan::test::expect_ad(f, u, value);
+    stan::test::expect_ad(f, rv4, value);
+    stan::test::expect_ad(f, p, value);
+  }
 }

--- a/test/unit/math/prim/mat/fun/divide_test.cpp
+++ b/test/unit/math/prim/mat/fun/divide_test.cpp
@@ -1,13 +1,43 @@
 #include <stan/math/prim/mat.hpp>
+#include <test/unit/math/prim/mat/fun/expect_matrix_eq.hpp>
 #include <gtest/gtest.h>
+#include <limits>
 
 TEST(MathMatrixPrimMat, divide) {
-  stan::math::vector_d v0;
-  stan::math::row_vector_d rv0;
-  stan::math::matrix_d m0;
-
   using stan::math::divide;
-  EXPECT_NO_THROW(divide(v0, 2.0));
-  EXPECT_NO_THROW(divide(rv0, 2.0));
-  EXPECT_NO_THROW(divide(m0, 2.0));
+  stan::math::vector_d v0(3);
+  stan::math::row_vector_d rv0(3);
+  stan::math::matrix_d m0(3, 3);
+
+  v0 << 1.0, 2.0, 3.0;
+  rv0 << 1.0, 2.0, 3.0;
+  m0 << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0;
+
+  stan::math::vector_d v0_over_2(3);
+  stan::math::row_vector_d rv0_over_2(3);
+  stan::math::matrix_d m0_over_2(3, 3);
+  v0_over_2 << 0.5, 1.0, 1.5;
+  rv0_over_2 << 0.5, 1.0, 1.5;
+  m0_over_2 << 0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5;
+
+  expect_matrix_eq(v0_over_2, divide(v0, 2.0));
+  expect_matrix_eq(rv0_over_2, divide(rv0, 2.0));
+  expect_matrix_eq(m0_over_2, divide(m0, 2.0));
+
+  double inf = std::numeric_limits<double>::infinity();
+  double nan = std::numeric_limits<double>::quiet_NaN();
+  for (double value : {inf, -inf, nan}) {
+    EXPECT_NO_THROW(divide(v0, value));
+    EXPECT_NO_THROW(divide(rv0, value));
+    EXPECT_NO_THROW(divide(m0, value));
+    stan::math::vector_d v1 = v0;
+    stan::math::row_vector_d rv1 = rv0;
+    stan::math::matrix_d m1 = m0;
+    v1(1) = value;
+    rv1(1) = value;
+    m1(1, 1) = value;
+    EXPECT_NO_THROW(divide(v1, 2.0));
+    EXPECT_NO_THROW(divide(rv1, 2.0));
+    EXPECT_NO_THROW(divide(m1, 2.0));
+  }
 }


### PR DESCRIPTION
## Summary

Partially addresses #1490. If I understand correctly, Eigen matrices are column major and these loops can be trivially interchanged. The compiler probably does it anyway.

## Tests

Multiply tests:
test/unit/math/prim/mat/fun/multiply_test.c(Same tests as in #XXX.pp
test/unit/math/mix/mat/fun/multiply_test.cpp

Divide tests:
test/unit/math/prim/mat/fun/divide_test.cpp
test/unit/math/mix/mat/fun/divide_test.cpp

Divide had no real primitive mode tests, so I added some.

## Side Effects

None.

## Checklist

- [X] Math issue #1490

- [X] Copyright holder: Peter Wicks Stringfield

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [X] the new changes are tested
