### PR TITLE
Feature/issue 988 matrix divide

### DIFF
--- a/stan/math/prim/mat/fun/divide.hpp
+++ b/stan/math/prim/mat/fun/divide.hpp
@@ -9,12 +9,14 @@ namespace stan {
 namespace math {
 
 /**
- * Return specified matrix divided by specified scalar.
- * @tparam R Row type for matrix.
- * @tparam C Column type for matrix.
- * @param m Matrix.
- * @param c Scalar.
- * @return Matrix divided by scalar.
+ * Return matrix divided by scalar.
+ * @tparam R number of rows or Eigen::Dynamic
+ * @tparam C number of columns or Eigen::Dynamic
+ * @tparam T1 type of coefficients in matrix
+ * @tparam T2 type of scalar
+ * @param[in] m specified matrix
+ * @param[in] c specified scalar
+ * @return matrix divided by the scalar
  */
 template <int R, int C, typename T1, typename T2,
           typename = require_all_arithmetic_t<T1, T2>>

--- a/stan/math/rev/mat/fun/divide.hpp
+++ b/stan/math/rev/mat/fun/divide.hpp
@@ -28,9 +28,8 @@ class matrix_scalar_divide_dv_vari : public vari {
         adjResultRef_(ChainableStack::instance_->memalloc_.alloc_array<vari*>(
             m.rows() * m.cols())),
         invc_(1.0 / c.val()) {
-    Eigen::Matrix<double, R, C> result = invc_ * m;
     Eigen::Map<matrix_vi>(adjResultRef_, rows_, cols_)
-        = result.unaryExpr([](double x) { return new vari(x, false); });
+        = (invc_ * m).unaryExpr([](double x) { return new vari(x, false); });
   }
 
   virtual void chain() {
@@ -60,9 +59,10 @@ class matrix_scalar_divide_vd_vari : public vari {
             m.rows() * m.cols())),
         invc_(1.0 / c) {
     Eigen::Map<matrix_vi>(adjMRef_, rows_, cols_) = m.vi();
-    Eigen::Matrix<double, R, C> result = invc_ * m.val();
     Eigen::Map<matrix_vi>(adjResultRef_, rows_, cols_)
-        = result.unaryExpr([](double x) { return new vari(x, false); });
+        = (invc_ * m.val()).unaryExpr([](double x) {
+            return new vari(x, false);
+          });
   }
 
   virtual void chain() {
@@ -94,9 +94,10 @@ class matrix_scalar_divide_vv_vari : public vari {
             m.rows() * m.cols())),
         invc_(1.0 / c.val()) {
     Eigen::Map<matrix_vi>(adjMRef_, rows_, cols_) = m.vi();
-    Eigen::Matrix<double, R, C> result = invc_ * m.val();
     Eigen::Map<matrix_vi>(adjResultRef_, rows_, cols_)
-        = result.unaryExpr([](double x) { return new vari(x, false); });
+        = (invc_ * m.val()).unaryExpr([](double x) {
+            return new vari(x, false);
+          });
   }
 
   virtual void chain() {

--- a/stan/math/rev/mat/fun/divide.hpp
+++ b/stan/math/rev/mat/fun/divide.hpp
@@ -10,11 +10,14 @@ namespace stan {
 namespace math {
 
 /**
- * Return the division of the specified column vector by
- * the specified scalar.
- * @param[in] v Specified vector.
- * @param[in] c Specified scalar.
- * @return Vector divided by the scalar.
+ * Return matrix divided by scalar.
+ * @tparam T1 TODO deleting this anyway
+ * @tparam T2 TODO deleting this anyway
+ * @tparam R number of rows or Eigen::Dynamic
+ * @tparam C number of columns or Eigen::Dynamic
+ * @param[in] m specified matrix
+ * @param[in] c specified scalar
+ * @return matrix divided by the scalar
  */
 template <typename T1, typename T2, int R, int C,
           typename = require_any_var_t<T1, T2>>
@@ -22,7 +25,6 @@ inline Eigen::Matrix<var, R, C> divide(const Eigen::Matrix<T1, R, C>& v,
                                        const T2& c) {
   return to_var(v) / to_var(c);
 }
-
 }  // namespace math
 }  // namespace stan
 #endif

--- a/stan/math/rev/mat/fun/divide.hpp
+++ b/stan/math/rev/mat/fun/divide.hpp
@@ -9,22 +9,167 @@
 namespace stan {
 namespace math {
 
+namespace internal {
+template <int R, int C>
+class matrix_scalar_divide_vari_dv : public vari {
+ public:
+  int rows_;
+  int cols_;
+  vari* adjCRef_;
+  vari** adjResultRef_;
+  double invc;
+
+  explicit matrix_scalar_divide_vari_dv(const Eigen::Matrix<double, R, C>& m,
+                                        const var& c)
+      : vari(0.0),
+        rows_(m.rows()),
+        cols_(m.cols()),
+        adjCRef_(c.vi_),
+        adjResultRef_(ChainableStack::instance_->memalloc_.alloc_array<vari*>(
+            m.rows() * m.cols())) {
+    double c_d = c.val();
+    invc = 1.0 / c_d;
+    Eigen::Matrix<double, R, C> result = invc * m;
+    Eigen::Map<matrix_vi>(adjResultRef_, rows_, cols_)
+        = result.unaryExpr([](double x) { return new vari(x, false); });
+  }
+
+  virtual void chain() {
+    Eigen::Map<matrix_vi> adjResult(adjResultRef_, rows_, cols_);
+    adjCRef_->adj_
+        += -1.0 * invc
+           * (adjResult.adj().array() * adjResult.val().array()).sum();
+  }
+};
+
+template <int R, int C>
+class matrix_scalar_divide_vari_vd : public vari {
+ public:
+  int rows_;
+  int cols_;
+  vari** adjMRef_;
+  vari** adjResultRef_;
+  double invc;
+
+  explicit matrix_scalar_divide_vari_vd(const Eigen::Matrix<var, R, C>& m,
+                                        const double& c)
+      : vari(0.0),
+        rows_(m.rows()),
+        cols_(m.cols()),
+        adjMRef_(ChainableStack::instance_->memalloc_.alloc_array<vari*>(
+            m.rows() * m.cols())),
+        adjResultRef_(ChainableStack::instance_->memalloc_.alloc_array<vari*>(
+            m.rows() * m.cols())) {
+    Eigen::Map<matrix_vi>(adjMRef_, rows_, cols_) = m.vi();
+    invc = 1.0 / c;
+    Eigen::Matrix<double, R, C> result = invc * m.val();
+    Eigen::Map<matrix_vi>(adjResultRef_, rows_, cols_)
+        = result.unaryExpr([](double x) { return new vari(x, false); });
+  }
+
+  virtual void chain() {
+    Eigen::Map<matrix_vi> adjM(adjMRef_, rows_, cols_);
+    Eigen::Map<matrix_vi> adjResult(adjResultRef_, rows_, cols_);
+    adjM.adj() += invc * adjResult.adj();
+  }
+};
+
+template <int R, int C>
+class matrix_scalar_divide_vari_vv : public vari {
+ public:
+  int rows_;
+  int cols_;
+  vari** adjMRef_;
+  vari* adjC_;
+  vari** adjResultRef_;
+  double invc;
+
+  explicit matrix_scalar_divide_vari_vv(const Eigen::Matrix<var, R, C>& m,
+                                        const var& c)
+      : vari(0.0),
+        rows_(m.rows()),
+        cols_(m.cols()),
+        adjMRef_(ChainableStack::instance_->memalloc_.alloc_array<vari*>(
+            m.rows() * m.cols())),
+        adjC_(c.vi_),
+        adjResultRef_(ChainableStack::instance_->memalloc_.alloc_array<vari*>(
+            m.rows() * m.cols())) {
+    Eigen::Map<matrix_vi>(adjMRef_, rows_, cols_) = m.vi();
+    double c_d = c.val();
+    invc = 1.0 / c_d;
+    Eigen::Matrix<double, R, C> result = invc * m.val();
+    Eigen::Map<matrix_vi>(adjResultRef_, rows_, cols_)
+        = result.unaryExpr([](double x) { return new vari(x, false); });
+  }
+
+  virtual void chain() {
+    Eigen::Map<matrix_vi> adjM(adjMRef_, rows_, cols_);
+    Eigen::Map<matrix_vi> adjResult(adjResultRef_, rows_, cols_);
+    adjC_->adj_ += -1.0 * invc
+                   * (adjResult.adj().array() * adjResult.val().array()).sum();
+    adjM.adj() += invc * adjResult.adj();
+  }
+};
+
+}  // namespace internal
+
 /**
  * Return matrix divided by scalar.
- * @tparam T1 TODO deleting this anyway
- * @tparam T2 TODO deleting this anyway
  * @tparam R number of rows or Eigen::Dynamic
  * @tparam C number of columns or Eigen::Dynamic
  * @param[in] m specified matrix
  * @param[in] c specified scalar
  * @return matrix divided by the scalar
  */
-template <typename T1, typename T2, int R, int C,
-          typename = require_any_var_t<T1, T2>>
-inline Eigen::Matrix<var, R, C> divide(const Eigen::Matrix<T1, R, C>& v,
-                                       const T2& c) {
-  return to_var(v) / to_var(c);
+template <int R, int C>
+inline Eigen::Matrix<var, R, C> divide(const Eigen::Matrix<double, R, C>& m,
+                                       const var& c) {
+  internal::matrix_scalar_divide_vari_dv<R, C>* baseVari
+      = new internal::matrix_scalar_divide_vari_dv<R, C>(m, c);
+  Eigen::Matrix<var, R, C> result(m.rows(), m.cols());
+  result.vi()
+      = Eigen::Map<matrix_vi>(baseVari->adjResultRef_, m.rows(), m.cols());
+  return result;
 }
+
+/**
+ * Return matrix divided by scalar.
+ * @tparam R number of rows or Eigen::Dynamic
+ * @tparam C number of columns or Eigen::Dynamic
+ * @param[in] m specified matrix
+ * @param[in] c specified scalar
+ * @return matrix divided by the scalar
+ */
+template <int R, int C>
+inline Eigen::Matrix<var, R, C> divide(const Eigen::Matrix<var, R, C>& m,
+                                       const double& c) {
+  internal::matrix_scalar_divide_vari_vd<R, C>* baseVari
+      = new internal::matrix_scalar_divide_vari_vd<R, C>(m, c);
+  Eigen::Matrix<var, R, C> result(m.rows(), m.cols());
+  result.vi()
+      = Eigen::Map<matrix_vi>(baseVari->adjResultRef_, m.rows(), m.cols());
+  return result;
+}
+
+/**
+ * Return matrix divided by scalar.
+ * @tparam R number of rows or Eigen::Dynamic
+ * @tparam C number of columns or Eigen::Dynamic
+ * @param[in] m specified matrix
+ * @param[in] c specified scalar
+ * @return matrix divided by the scalar
+ */
+template <int R, int C>
+inline Eigen::Matrix<var, R, C> divide(const Eigen::Matrix<var, R, C>& m,
+                                       const var& c) {
+  internal::matrix_scalar_divide_vari_vv<R, C>* baseVari
+      = new internal::matrix_scalar_divide_vari_vv<R, C>(m, c);
+  Eigen::Matrix<var, R, C> result(m.rows(), m.cols());
+  result.vi()
+      = Eigen::Map<matrix_vi>(baseVari->adjResultRef_, m.rows(), m.cols());
+  return result;
+}
+
 }  // namespace math
 }  // namespace stan
 #endif

--- a/stan/math/rev/mat/fun/divide.hpp
+++ b/stan/math/rev/mat/fun/divide.hpp
@@ -11,25 +11,24 @@ namespace math {
 
 namespace internal {
 template <int R, int C>
-class matrix_scalar_divide_vari_dv : public vari {
+class matrix_scalar_divide_dv_vari : public vari {
  public:
   int rows_;
   int cols_;
   vari* adjCRef_;
   vari** adjResultRef_;
-  double invc;
+  double invc_;
 
-  explicit matrix_scalar_divide_vari_dv(const Eigen::Matrix<double, R, C>& m,
+  explicit matrix_scalar_divide_dv_vari(const Eigen::Matrix<double, R, C>& m,
                                         const var& c)
-      : vari(0.0),
+      : vari(0),
         rows_(m.rows()),
         cols_(m.cols()),
         adjCRef_(c.vi_),
         adjResultRef_(ChainableStack::instance_->memalloc_.alloc_array<vari*>(
-            m.rows() * m.cols())) {
-    double c_d = c.val();
-    invc = 1.0 / c_d;
-    Eigen::Matrix<double, R, C> result = invc * m;
+            m.rows() * m.cols())),
+        invc_(1.0 / c.val()) {
+    Eigen::Matrix<double, R, C> result = invc_ * m;
     Eigen::Map<matrix_vi>(adjResultRef_, rows_, cols_)
         = result.unaryExpr([](double x) { return new vari(x, false); });
   }
@@ -37,32 +36,31 @@ class matrix_scalar_divide_vari_dv : public vari {
   virtual void chain() {
     Eigen::Map<matrix_vi> adjResult(adjResultRef_, rows_, cols_);
     adjCRef_->adj_
-        += -1.0 * invc
-           * (adjResult.adj().array() * adjResult.val().array()).sum();
+        -= invc_ * (adjResult.adj().array() * adjResult.val().array()).sum();
   }
 };
 
 template <int R, int C>
-class matrix_scalar_divide_vari_vd : public vari {
+class matrix_scalar_divide_vd_vari : public vari {
  public:
   int rows_;
   int cols_;
   vari** adjMRef_;
   vari** adjResultRef_;
-  double invc;
+  double invc_;
 
-  explicit matrix_scalar_divide_vari_vd(const Eigen::Matrix<var, R, C>& m,
+  explicit matrix_scalar_divide_vd_vari(const Eigen::Matrix<var, R, C>& m,
                                         const double& c)
-      : vari(0.0),
+      : vari(0),
         rows_(m.rows()),
         cols_(m.cols()),
         adjMRef_(ChainableStack::instance_->memalloc_.alloc_array<vari*>(
             m.rows() * m.cols())),
         adjResultRef_(ChainableStack::instance_->memalloc_.alloc_array<vari*>(
-            m.rows() * m.cols())) {
+            m.rows() * m.cols())),
+        invc_(1.0 / c) {
     Eigen::Map<matrix_vi>(adjMRef_, rows_, cols_) = m.vi();
-    invc = 1.0 / c;
-    Eigen::Matrix<double, R, C> result = invc * m.val();
+    Eigen::Matrix<double, R, C> result = invc_ * m.val();
     Eigen::Map<matrix_vi>(adjResultRef_, rows_, cols_)
         = result.unaryExpr([](double x) { return new vari(x, false); });
   }
@@ -70,34 +68,33 @@ class matrix_scalar_divide_vari_vd : public vari {
   virtual void chain() {
     Eigen::Map<matrix_vi> adjM(adjMRef_, rows_, cols_);
     Eigen::Map<matrix_vi> adjResult(adjResultRef_, rows_, cols_);
-    adjM.adj() += invc * adjResult.adj();
+    adjM.adj() += invc_ * adjResult.adj();
   }
 };
 
 template <int R, int C>
-class matrix_scalar_divide_vari_vv : public vari {
+class matrix_scalar_divide_vv_vari : public vari {
  public:
   int rows_;
   int cols_;
   vari** adjMRef_;
   vari* adjC_;
   vari** adjResultRef_;
-  double invc;
+  double invc_;
 
-  explicit matrix_scalar_divide_vari_vv(const Eigen::Matrix<var, R, C>& m,
+  explicit matrix_scalar_divide_vv_vari(const Eigen::Matrix<var, R, C>& m,
                                         const var& c)
-      : vari(0.0),
+      : vari(0),
         rows_(m.rows()),
         cols_(m.cols()),
         adjMRef_(ChainableStack::instance_->memalloc_.alloc_array<vari*>(
             m.rows() * m.cols())),
         adjC_(c.vi_),
         adjResultRef_(ChainableStack::instance_->memalloc_.alloc_array<vari*>(
-            m.rows() * m.cols())) {
+            m.rows() * m.cols())),
+        invc_(1.0 / c.val()) {
     Eigen::Map<matrix_vi>(adjMRef_, rows_, cols_) = m.vi();
-    double c_d = c.val();
-    invc = 1.0 / c_d;
-    Eigen::Matrix<double, R, C> result = invc * m.val();
+    Eigen::Matrix<double, R, C> result = invc_ * m.val();
     Eigen::Map<matrix_vi>(adjResultRef_, rows_, cols_)
         = result.unaryExpr([](double x) { return new vari(x, false); });
   }
@@ -105,9 +102,9 @@ class matrix_scalar_divide_vari_vv : public vari {
   virtual void chain() {
     Eigen::Map<matrix_vi> adjM(adjMRef_, rows_, cols_);
     Eigen::Map<matrix_vi> adjResult(adjResultRef_, rows_, cols_);
-    adjC_->adj_ += -1.0 * invc
-                   * (adjResult.adj().array() * adjResult.val().array()).sum();
-    adjM.adj() += invc * adjResult.adj();
+    adjC_->adj_
+        -= invc_ * (adjResult.adj().array() * adjResult.val().array()).sum();
+    adjM.adj() += invc_ * adjResult.adj();
   }
 };
 
@@ -124,8 +121,8 @@ class matrix_scalar_divide_vari_vv : public vari {
 template <int R, int C>
 inline Eigen::Matrix<var, R, C> divide(const Eigen::Matrix<double, R, C>& m,
                                        const var& c) {
-  internal::matrix_scalar_divide_vari_dv<R, C>* baseVari
-      = new internal::matrix_scalar_divide_vari_dv<R, C>(m, c);
+  internal::matrix_scalar_divide_dv_vari<R, C>* baseVari
+      = new internal::matrix_scalar_divide_dv_vari<R, C>(m, c);
   Eigen::Matrix<var, R, C> result(m.rows(), m.cols());
   result.vi()
       = Eigen::Map<matrix_vi>(baseVari->adjResultRef_, m.rows(), m.cols());
@@ -143,8 +140,8 @@ inline Eigen::Matrix<var, R, C> divide(const Eigen::Matrix<double, R, C>& m,
 template <int R, int C>
 inline Eigen::Matrix<var, R, C> divide(const Eigen::Matrix<var, R, C>& m,
                                        const double& c) {
-  internal::matrix_scalar_divide_vari_vd<R, C>* baseVari
-      = new internal::matrix_scalar_divide_vari_vd<R, C>(m, c);
+  internal::matrix_scalar_divide_vd_vari<R, C>* baseVari
+      = new internal::matrix_scalar_divide_vd_vari<R, C>(m, c);
   Eigen::Matrix<var, R, C> result(m.rows(), m.cols());
   result.vi()
       = Eigen::Map<matrix_vi>(baseVari->adjResultRef_, m.rows(), m.cols());
@@ -162,8 +159,8 @@ inline Eigen::Matrix<var, R, C> divide(const Eigen::Matrix<var, R, C>& m,
 template <int R, int C>
 inline Eigen::Matrix<var, R, C> divide(const Eigen::Matrix<var, R, C>& m,
                                        const var& c) {
-  internal::matrix_scalar_divide_vari_vv<R, C>* baseVari
-      = new internal::matrix_scalar_divide_vari_vv<R, C>(m, c);
+  internal::matrix_scalar_divide_vv_vari<R, C>* baseVari
+      = new internal::matrix_scalar_divide_vv_vari<R, C>(m, c);
   Eigen::Matrix<var, R, C> result(m.rows(), m.cols());
   result.vi()
       = Eigen::Map<matrix_vi>(baseVari->adjResultRef_, m.rows(), m.cols());

--- a/test/unit/math/mix/mat/fun/divide_test.cpp
+++ b/test/unit/math/mix/mat/fun/divide_test.cpp
@@ -53,23 +53,5 @@ TEST(MathMixMatFun, divide) {
     stan::test::expect_ad(f, u, value);
     stan::test::expect_ad(f, rv4, value);
     stan::test::expect_ad(f, p, value);
-    stan::math::vector_d v1 = u;
-    stan::math::row_vector_d rv1 = rv4;
-    stan::math::matrix_d m1 = p;
-    v1(1) = value;
-    rv1(1) = value;
-    m1(1, 1) = value;
-    // XXX TODO: These fail, because there is no check_finite usage, and the
-    // nans/infs propagate through autodiff and finite diff differently.
-    // In particular:
-    // f[x,y] = x/y
-    // f_x[x,y] = 1/y
-    // f_x[nan,1] = 1 (autodiff answer)
-    // f_x[nan,1] ~ (1/n) (f[nan+1/n,1] - f[nan,1])
-    //            = (1/n) (nan - nan)
-    //            = nan (finite diff answer)
-    // stan::test::expect_ad(f, v1, 2.0);
-    // stan::test::expect_ad(f, rv1, 2.0);
-    // stan::test::expect_ad(f, m1, 2.0);
   }
 }

--- a/test/unit/math/mix/mat/fun/divide_test.cpp
+++ b/test/unit/math/mix/mat/fun/divide_test.cpp
@@ -1,4 +1,5 @@
 #include <test/unit/math/test_ad.hpp>
+#include <limits>
 
 TEST(MathMixMatFun, divide) {
   auto f
@@ -31,10 +32,44 @@ TEST(MathMixMatFun, divide) {
   u << 100, 0, -3, 4;
   stan::test::expect_ad(f, u, x2);
 
-  Eigen::MatrixXd m00(0, 0);
   Eigen::VectorXd v0(0);
   Eigen::RowVectorXd rv0(0);
+  Eigen::MatrixXd m00(0, 0);
   stan::test::expect_ad(f, v0, x1);
   stan::test::expect_ad(f, rv0, x1);
   stan::test::expect_ad(f, m00, x1);
+
+  stan::test::expect_ad(f, u, 0.0);
+  stan::test::expect_ad(f, rv, 0.0);
+  stan::test::expect_ad(f, p, 0.0);
+
+  Eigen::RowVectorXd rv4(4);
+  rv4 << -5, 10, 7, 8.2;
+  stan::test::expect_ad(f, rv4, x2);
+
+  double inf = std::numeric_limits<double>::infinity();
+  double nan = std::numeric_limits<double>::quiet_NaN();
+  for (double value : {inf, -inf, nan}) {
+    stan::test::expect_ad(f, u, value);
+    stan::test::expect_ad(f, rv4, value);
+    stan::test::expect_ad(f, p, value);
+    stan::math::vector_d v1 = u;
+    stan::math::row_vector_d rv1 = rv4;
+    stan::math::matrix_d m1 = p;
+    v1(1) = value;
+    rv1(1) = value;
+    m1(1, 1) = value;
+    // XXX TODO: These fail, because there is no check_finite usage, and the
+    // nans/infs propagate through autodiff and finite diff differently.
+    // In particular:
+    // f[x,y] = x/y
+    // f_x[x,y] = 1/y
+    // f_x[nan,1] = 1 (autodiff answer)
+    // f_x[nan,1] ~ (1/n) (f[nan+1/n,1] - f[nan,1])
+    //            = (1/n) (nan - nan)
+    //            = nan (finite diff answer)
+    // stan::test::expect_ad(f, v1, 2.0);
+    // stan::test::expect_ad(f, rv1, 2.0);
+    // stan::test::expect_ad(f, m1, 2.0);
+  }
 }

--- a/test/unit/math/prim/mat/fun/divide_test.cpp
+++ b/test/unit/math/prim/mat/fun/divide_test.cpp
@@ -1,13 +1,43 @@
 #include <stan/math/prim/mat.hpp>
+#include <test/unit/math/prim/mat/fun/expect_matrix_eq.hpp>
 #include <gtest/gtest.h>
+#include <limits>
 
 TEST(MathMatrixPrimMat, divide) {
-  stan::math::vector_d v0;
-  stan::math::row_vector_d rv0;
-  stan::math::matrix_d m0;
-
   using stan::math::divide;
-  EXPECT_NO_THROW(divide(v0, 2.0));
-  EXPECT_NO_THROW(divide(rv0, 2.0));
-  EXPECT_NO_THROW(divide(m0, 2.0));
+  stan::math::vector_d v0(3);
+  stan::math::row_vector_d rv0(3);
+  stan::math::matrix_d m0(3, 3);
+
+  v0 << 1.0, 2.0, 3.0;
+  rv0 << 1.0, 2.0, 3.0;
+  m0 << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0;
+
+  stan::math::vector_d v0_over_2(3);
+  stan::math::row_vector_d rv0_over_2(3);
+  stan::math::matrix_d m0_over_2(3, 3);
+  v0_over_2 << 0.5, 1.0, 1.5;
+  rv0_over_2 << 0.5, 1.0, 1.5;
+  m0_over_2 << 0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5;
+
+  expect_matrix_eq(v0_over_2, divide(v0, 2.0));
+  expect_matrix_eq(rv0_over_2, divide(rv0, 2.0));
+  expect_matrix_eq(m0_over_2, divide(m0, 2.0));
+
+  double inf = std::numeric_limits<double>::infinity();
+  double nan = std::numeric_limits<double>::quiet_NaN();
+  for (double value : {inf, -inf, nan}) {
+    EXPECT_NO_THROW(divide(v0, value));
+    EXPECT_NO_THROW(divide(rv0, value));
+    EXPECT_NO_THROW(divide(m0, value));
+    stan::math::vector_d v1 = v0;
+    stan::math::row_vector_d rv1 = rv0;
+    stan::math::matrix_d m1 = m0;
+    v1(1) = value;
+    rv1(1) = value;
+    m1(1, 1) = value;
+    EXPECT_NO_THROW(divide(v1, 2.0));
+    EXPECT_NO_THROW(divide(rv1, 2.0));
+    EXPECT_NO_THROW(divide(m1, 2.0));
+  }
 }


### PR DESCRIPTION
## Summary

Analytic derivatives for M/c where M is matrix T1 and c is scalar T2. 

(The discussion in #988 is a bit out of date, the templating on the prim version was cleaned up by 3b459c9553; so the promotion to var is the only issue mentioned in that ticket that remained to be addressed. Closes #988.)

The key bit of math:
```
...
class matrix_scalar_divide_vari_vv : public vari {
  ...
  virtual void chain() {
    ...
    adjC_->adj_ += -1.0 * invc
                   * (adjResult.adj().array() * adjResult.val().array()).sum();
    adjM.adj() += invc * adjResult.adj();
...
```
f[M, c] = M/c
f_c[M, c] = -M/c^2 = (-1/c) * f[M, c].
f_M[M, c] = 1/c

I wanted to say
```
TEST(MathMixMatFun, divide) {
    ...
    Eigen::VectorXd u(4);
    u << nan, 0, -3, 4;
    stan::test::expect_ad(f, u, 2.0);
...
```

But of course, nans propagate through the analytic derivatives and the finite differences differently, so this fails. Adding check_finite to every implementation of divide would ensure consistency, but as I understand, there's a thread on the mailing list for that discussion. And that would probably call for a performance test, since division is supposed to be kind of free. So I didn't do that here. (But its easy enough to add those checks if desired.)

In particular:
```
f[x,y] = x/y
f_x[x,y] = 1/y
f_x[nan,1] = 1 (analytic/autodiff answer)
f_x[nan,1] ~ (1/n) (f[nan+1/n,1] - f[nan,1])
           = (1/n) (nan - nan)
           = nan (finite diff answer)
```

## Tests

This function had a nice set of expect_ad tests already. There were no real primitive mode tests, so I added some. (Same tests as in #1491.)

## Side Effects

None.

## Checklist

- [X] Math issue #988

- [X] Copyright holder: Peter Wicks Stringfield

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [X] the new changes are tested
