### PR TITLE
Make trace_gen_inv_quad_form_ldlt work with size 0 input

### DIFF
--- a/stan/math/prim/mat/fun/trace_gen_inv_quad_form_ldlt.hpp
+++ b/stan/math/prim/mat/fun/trace_gen_inv_quad_form_ldlt.hpp
@@ -25,6 +25,10 @@ inline return_type_t<T1, T2, T3> trace_gen_inv_quad_form_ldlt(
     const Eigen::Matrix<T1, R1, C1> &D, const LDLT_factor<T2, R2, C2> &A,
     const Eigen::Matrix<T3, R3, C3> &B) {
   check_square("trace_gen_inv_quad_form_ldlt", "D", D);
+  if (D.size() == 0 && A.cols() == 0 && B.rows() == 0 && B.cols() == 0) {
+    return 0;
+  }
+
   check_multiplicable("trace_gen_inv_quad_form_ldlt", "A", A, "B", B);
   check_multiplicable("trace_gen_inv_quad_form_ldlt", "B", B, "D", D);
 

--- a/stan/math/rev/mat/fun/trace_gen_inv_quad_form_ldlt.hpp
+++ b/stan/math/rev/mat/fun/trace_gen_inv_quad_form_ldlt.hpp
@@ -23,6 +23,10 @@ inline var trace_gen_inv_quad_form_ldlt(const Eigen::Matrix<T1, R1, C1> &D,
                                         const LDLT_factor<T2, R2, C2> &A,
                                         const Eigen::Matrix<T3, R3, C3> &B) {
   check_square("trace_gen_inv_quad_form_ldlt", "D", D);
+  if (D.size() == 0 && A.cols() == 0 && B.rows() == 0 && B.cols() == 0) {
+    return 0;
+  }
+
   check_multiplicable("trace_gen_inv_quad_form_ldlt", "A", A, "B", B);
   check_multiplicable("trace_gen_inv_quad_form_ldlt", "B", B, "D", D);
 

--- a/test/unit/math/mix/mat/fun/trace_gen_inv_quad_form_ldlt_test.cpp
+++ b/test/unit/math/mix/mat/fun/trace_gen_inv_quad_form_ldlt_test.cpp
@@ -2,6 +2,10 @@
 
 template <typename T>
 stan::math::LDLT_factor<T, -1, -1> to_ldlt(const Eigen::Matrix<T, -1, -1>& a) {
+  if (a.size() == 0) {
+    return {};
+  }
+
   stan::math::LDLT_factor<T, -1, -1> ldlt_a;
   ldlt_a.compute(a);
   return ldlt_a;
@@ -13,11 +17,13 @@ TEST(mathMixMatFun, traceGenInvQuadForm) {
     return stan::math::trace_gen_inv_quad_form_ldlt(c, ldlt_a, b);
   };
 
-  // TODO(carpenter): shold pass; issue #1447
-  // Eigen::MatrixXd a00(0, 0);
-  // Eigen::MatrixXd b00(0, 0);
-  // Eigen::MatrixXd c00(0, 0);
-  // stan::test::expect_ad(f, c00, a00, b00);
+  Eigen::MatrixXd a00(0, 0);
+  Eigen::MatrixXd b00(0, 0);
+  Eigen::MatrixXd c00(0, 0);
+  stan::test::expect_ad(f, c00, a00, b00);
+
+  Eigen::MatrixXd b02(0, 2);
+  stan::test::expect_ad(f, c00, a00, b02);
 
   Eigen::MatrixXd a11(1, 1);
   a11 << 1;

--- a/test/unit/math/prim/mat/fun/trace_gen_inv_quad_form_ldlt_test.cpp
+++ b/test/unit/math/prim/mat/fun/trace_gen_inv_quad_form_ldlt_test.cpp
@@ -9,6 +9,14 @@
 
 TEST(MathMatrixPrimMat, trace_gen_inv_quad_form_ldlt) {
   using stan::math::matrix_d;
+  using stan::math::trace_gen_inv_quad_form_ldlt;
+
+  matrix_d D00(0, 0), B00(0, 0), B02(0, 2);
+  stan::math::LDLT_factor<double, 0, 0> ldlt_A0;
+  EXPECT_FLOAT_EQ(0, trace_gen_inv_quad_form_ldlt(D00, ldlt_A0, B00));
+  EXPECT_THROW(trace_gen_inv_quad_form_ldlt(D00, ldlt_A0, B02),
+               std::invalid_argument);
+
   matrix_d D(2, 2), A(4, 4), B(4, 2), gen_inv_quad_form;
 
   D << 1, 2, 3, 4;


### PR DESCRIPTION
## Summary

This adds some checks for size 0 inputs so we can return 0 immediately without failing later on. These checks have to be before `check_multipliable` because that throws on size 0 inputs. For the test in mix to work, I had to add a little workaround to the `to_ldlt` function so that it returns an empty `LDLT_factor` if the input is an empty matrix. Fixes #1447.

## Tests

I added those that @bob-carpenter had originally written and commented out. I've also added equivalent tests in prim.

## Side Effects

None.

## Checklist

- [X] Math issue #1447

- [X] Copyright holder: Marco Colombo

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [X] the new changes are tested
