### PR TITLE
Rename dirichlet_lpmf to dirichlet_lpdf

### DIFF
--- a/stan/math/prim/mat.hpp
+++ b/stan/math/prim/mat.hpp
@@ -276,6 +276,7 @@
 #include <stan/math/prim/mat/prob/categorical_lpmf.hpp>
 #include <stan/math/prim/mat/prob/categorical_rng.hpp>
 #include <stan/math/prim/mat/prob/dirichlet_log.hpp>
+#include <stan/math/prim/mat/prob/dirichlet_lpdf.hpp>
 #include <stan/math/prim/mat/prob/dirichlet_lpmf.hpp>
 #include <stan/math/prim/mat/prob/dirichlet_rng.hpp>
 #include <stan/math/prim/mat/prob/gaussian_dlm_obs_log.hpp>

--- a/stan/math/prim/mat/prob/dirichlet_log.hpp
+++ b/stan/math/prim/mat/prob/dirichlet_log.hpp
@@ -2,7 +2,7 @@
 #define STAN_MATH_PRIM_MAT_PROB_DIRICHLET_LOG_HPP
 
 #include <stan/math/prim/meta.hpp>
-#include <stan/math/prim/mat/prob/dirichlet_lpmf.hpp>
+#include <stan/math/prim/mat/prob/dirichlet_lpdf.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 
 namespace stan {
@@ -15,7 +15,7 @@ namespace math {
  * Each element of theta must be greater than or 0.
  * Theta sums to 1.
  *
- * @deprecated use <code>dirichlet_lpmf</code>
+ * @deprecated use <code>dirichlet_lpdf</code>
  *
  * @param theta A scalar vector.
  * @param alpha Prior sample sizes.
@@ -30,16 +30,16 @@ namespace math {
 template <bool propto, typename T_prob, typename T_prior_size>
 return_type_t<T_prob, T_prior_size> dirichlet_log(const T_prob& theta,
                                                   const T_prior_size& alpha) {
-  return dirichlet_lpmf<propto, T_prob, T_prior_size>(theta, alpha);
+  return dirichlet_lpdf<propto, T_prob, T_prior_size>(theta, alpha);
 }
 
 /** \ingroup multivar_dists
- * @deprecated use <code>dirichlet_lpmf</code>
+ * @deprecated use <code>dirichlet_lpdf</code>
  */
 template <typename T_prob, typename T_prior_size>
 return_type_t<T_prob, T_prior_size> dirichlet_log(const T_prob& theta,
                                                   const T_prior_size& alpha) {
-  return dirichlet_lpmf<T_prob, T_prior_size>(theta, alpha);
+  return dirichlet_lpdf<T_prob, T_prior_size>(theta, alpha);
 }
 
 }  // namespace math

--- a/stan/math/prim/mat/prob/dirichlet_lpdf.hpp
+++ b/stan/math/prim/mat/prob/dirichlet_lpdf.hpp
@@ -1,0 +1,125 @@
+#ifndef STAN_MATH_PRIM_MAT_PROB_DIRICHLET_LPDF_HPP
+#define STAN_MATH_PRIM_MAT_PROB_DIRICHLET_LPDF_HPP
+
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
+#include <stan/math/prim/scal/err/check_positive.hpp>
+#include <stan/math/prim/mat/err/check_simplex.hpp>
+#include <stan/math/prim/mat/fun/lgamma.hpp>
+#include <stan/math/prim/mat/fun/digamma.hpp>
+#include <stan/math/prim/mat/fun/value_of.hpp>
+
+namespace stan {
+namespace math {
+
+/** \ingroup multivar_dists
+ * The log of the Dirichlet density for the given theta and
+ * a vector of prior sample sizes, alpha.
+ * Each element of alpha must be greater than 0.
+ * Each element of theta must be greater than or 0.
+ * Theta sums to 1.
+ *
+ * \f[
+ * \theta\sim\mbox{Dirichlet}(\alpha_1,\ldots,\alpha_k)\\
+ * \log(p(\theta\,|\,\alpha_1,\ldots,\alpha_k))=\log\left(
+ * \frac{\Gamma(\alpha_1+\cdots+\alpha_k)}{\Gamma(\alpha_1)+
+ * \cdots+\Gamma(\alpha_k)}* \left(\theta_1^{\alpha_1-1}+
+ * \cdots+\theta_k^{\alpha_k-1}\right)\right)\\
+ * =\log(\Gamma(\alpha_1+\cdots+\alpha_k))-\left(
+ * \log(\Gamma(\alpha_1))+\cdots+\log(\Gamma(\alpha_k))\right)+
+ * (\alpha_1-1)\log(\theta_1)+\cdots+(\alpha_k-1)\log(\theta_k)
+ * \f]
+ *
+ * \f[
+ * \frac{\partial }{\partial
+ * \theta_x}\log(p(\theta\,|\,\alpha_1,\ldots,\alpha_k))=
+ * \frac{\alpha_x-1}{\theta_x}
+ * \f]
+ *
+ * \f[
+ * \frac{\partial}{\partial\alpha_x}\log(p(\theta\,|\,\alpha_1,\ldots,\alpha_k))
+ * =\psi_{(0)}(\sum\alpha)-\psi_{(0)}(\alpha_x)+\log\theta_x
+ * \f]
+ *
+ * @param theta A scalar vector.
+ * @param alpha Prior sample sizes.
+ * @return The log of the Dirichlet density.
+ * @throw std::domain_error if any element of alpha is less than
+ * or equal to 0.
+ * @throw std::domain_error if any element of theta is less than 0.
+ * @throw std::domain_error if the sum of theta is not 1.
+ * @tparam T_prob Type of scalar.
+ * @tparam T_prior_size Type of prior sample sizes.
+ */
+template <bool propto, typename T_prob, typename T_prior_size>
+return_type_t<T_prob, T_prior_size> dirichlet_lpdf(const T_prob& theta,
+                                                   const T_prior_size& alpha) {
+  static const char* function = "dirichlet_lpdf";
+
+  using T_partials_return = partials_return_t<T_prob, T_prior_size>;
+  using T_partials_vec = typename Eigen::Matrix<T_partials_return, -1, 1>;
+  using T_partials_mat = typename Eigen::Matrix<T_partials_return, -1, -1>;
+
+  vector_seq_view<T_prob> theta_vec(theta);
+  vector_seq_view<T_prior_size> alpha_vec(alpha);
+  const size_t t_length = max_size_mvt(theta, alpha);
+
+  check_consistent_sizes(function, "probabilities", theta_vec[0],
+                         "prior sample sizes", alpha_vec[0]);
+
+  for (size_t t = 0; t < t_length; t++) {
+    check_positive(function, "prior sample sizes", alpha_vec[t]);
+    check_simplex(function, "probabilities", theta_vec[t]);
+  }
+
+  const size_t t_size = theta_vec[0].size();
+
+  T_partials_mat theta_dbl(t_size, t_length);
+  for (size_t t = 0; t < t_length; t++)
+    theta_dbl.col(t) = value_of(theta_vec[t]);
+
+  T_partials_mat alpha_dbl(t_size, t_length);
+  for (size_t t = 0; t < t_length; t++)
+    alpha_dbl.col(t) = value_of(alpha_vec[t]);
+
+  T_partials_return lp(0.0);
+
+  if (include_summand<propto, T_prior_size>::value) {
+    lp += (lgamma(alpha_dbl.colwise().sum())
+           - lgamma(alpha_dbl).colwise().sum())
+              .sum();
+  }
+
+  const auto& alpha_m_1 = (alpha_dbl.array() - 1.0);
+  const auto& theta_log = theta_dbl.array().log();
+
+  if (include_summand<propto, T_prob, T_prior_size>::value) {
+    lp += (theta_log * alpha_m_1).sum();
+  }
+
+  operands_and_partials<T_prob, T_prior_size> ops_partials(theta, alpha);
+  if (!is_constant_all<T_prob>::value) {
+    const auto& theta_deriv = (alpha_m_1 / theta_dbl.array()).matrix();
+    for (size_t t = 0; t < t_length; t++)
+      ops_partials.edge1_.partials_vec_[t] += theta_deriv.col(t);
+  }
+
+  if (!is_constant_all<T_prior_size>::value) {
+    for (size_t t = 0; t < t_length; t++)
+      ops_partials.edge2_.partials_vec_[t]
+          += (digamma(alpha_dbl.col(t).sum())
+              - digamma(alpha_dbl).col(t).array() + theta_log.col(t))
+                 .matrix();
+  }
+  return ops_partials.build(lp);
+}
+
+template <typename T_prob, typename T_prior_size>
+return_type_t<T_prob, T_prior_size> dirichlet_lpdf(const T_prob& theta,
+                                                   const T_prior_size& alpha) {
+  return dirichlet_lpdf<false>(theta, alpha);
+}
+
+}  // namespace math
+}  // namespace stan
+#endif

--- a/stan/math/prim/mat/prob/dirichlet_lpmf.hpp
+++ b/stan/math/prim/mat/prob/dirichlet_lpmf.hpp
@@ -2,122 +2,24 @@
 #define STAN_MATH_PRIM_MAT_PROB_DIRICHLET_LPMF_HPP
 
 #include <stan/math/prim/meta.hpp>
-#include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
-#include <stan/math/prim/scal/err/check_positive.hpp>
-#include <stan/math/prim/mat/err/check_simplex.hpp>
-#include <stan/math/prim/mat/fun/lgamma.hpp>
-#include <stan/math/prim/mat/fun/digamma.hpp>
-#include <stan/math/prim/mat/fun/value_of.hpp>
+#include <stan/math/prim/mat/prob/dirichlet_lpdf.hpp>
 
 namespace stan {
 namespace math {
 
 /** \ingroup multivar_dists
- * The log of the Dirichlet density for the given theta and
- * a vector of prior sample sizes, alpha.
- * Each element of alpha must be greater than 0.
- * Each element of theta must be greater than or 0.
- * Theta sums to 1.
- *
- * \f[
- * \theta\sim\mbox{Dirichlet}(\alpha_1,\ldots,\alpha_k)\\
- * \log(p(\theta\,|\,\alpha_1,\ldots,\alpha_k))=\log\left(
- * \frac{\Gamma(\alpha_1+\cdots+\alpha_k)}{\Gamma(\alpha_1)+
- * \cdots+\Gamma(\alpha_k)}* \left(\theta_1^{\alpha_1-1}+
- * \cdots+\theta_k^{\alpha_k-1}\right)\right)\\
- * =\log(\Gamma(\alpha_1+\cdots+\alpha_k))-\left(
- * \log(\Gamma(\alpha_1))+\cdots+\log(\Gamma(\alpha_k))\right)+
- * (\alpha_1-1)\log(\theta_1)+\cdots+(\alpha_k-1)\log(\theta_k)
- * \f]
- *
- * \f[
- * \frac{\partial }{\partial
- * \theta_x}\log(p(\theta\,|\,\alpha_1,\ldots,\alpha_k))=
- * \frac{\alpha_x-1}{\theta_x}
- * \f]
- *
- * \f[
- * \frac{\partial}{\partial\alpha_x}\log(p(\theta\,|\,\alpha_1,\ldots,\alpha_k))
- * =\psi_{(0)}(\sum\alpha)-\psi_{(0)}(\alpha_x)+\log\theta_x
- * \f]
- *
- * @param theta A scalar vector.
- * @param alpha Prior sample sizes.
- * @return The log of the Dirichlet density.
- * @throw std::domain_error if any element of alpha is less than
- * or equal to 0.
- * @throw std::domain_error if any element of theta is less than 0.
- * @throw std::domain_error if the sum of theta is not 1.
- * @tparam T_prob Type of scalar.
- * @tparam T_prior_size Type of prior sample sizes.
+ * @deprecated use <code>dirichlet_lpdf</code>
  */
 template <bool propto, typename T_prob, typename T_prior_size>
 return_type_t<T_prob, T_prior_size> dirichlet_lpmf(const T_prob& theta,
                                                    const T_prior_size& alpha) {
-  static const char* function = "dirichlet_lpmf";
-
-  using T_partials_return = partials_return_t<T_prob, T_prior_size>;
-  using T_partials_vec = typename Eigen::Matrix<T_partials_return, -1, 1>;
-  using T_partials_mat = typename Eigen::Matrix<T_partials_return, -1, -1>;
-
-  vector_seq_view<T_prob> theta_vec(theta);
-  vector_seq_view<T_prior_size> alpha_vec(alpha);
-  const size_t t_length = max_size_mvt(theta, alpha);
-
-  check_consistent_sizes(function, "probabilities", theta_vec[0],
-                         "prior sample sizes", alpha_vec[0]);
-
-  for (size_t t = 0; t < t_length; t++) {
-    check_positive(function, "prior sample sizes", alpha_vec[t]);
-    check_simplex(function, "probabilities", theta_vec[t]);
-  }
-
-  const size_t t_size = theta_vec[0].size();
-
-  T_partials_mat theta_dbl(t_size, t_length);
-  for (size_t t = 0; t < t_length; t++)
-    theta_dbl.col(t) = value_of(theta_vec[t]);
-
-  T_partials_mat alpha_dbl(t_size, t_length);
-  for (size_t t = 0; t < t_length; t++)
-    alpha_dbl.col(t) = value_of(alpha_vec[t]);
-
-  T_partials_return lp(0.0);
-
-  if (include_summand<propto, T_prior_size>::value) {
-    lp += (lgamma(alpha_dbl.colwise().sum())
-           - lgamma(alpha_dbl).colwise().sum())
-              .sum();
-  }
-
-  const auto& alpha_m_1 = (alpha_dbl.array() - 1.0);
-  const auto& theta_log = theta_dbl.array().log();
-
-  if (include_summand<propto, T_prob, T_prior_size>::value) {
-    lp += (theta_log * alpha_m_1).sum();
-  }
-
-  operands_and_partials<T_prob, T_prior_size> ops_partials(theta, alpha);
-  if (!is_constant_all<T_prob>::value) {
-    const auto& theta_deriv = (alpha_m_1 / theta_dbl.array()).matrix();
-    for (size_t t = 0; t < t_length; t++)
-      ops_partials.edge1_.partials_vec_[t] += theta_deriv.col(t);
-  }
-
-  if (!is_constant_all<T_prior_size>::value) {
-    for (size_t t = 0; t < t_length; t++)
-      ops_partials.edge2_.partials_vec_[t]
-          += (digamma(alpha_dbl.col(t).sum())
-              - digamma(alpha_dbl).col(t).array() + theta_log.col(t))
-                 .matrix();
-  }
-  return ops_partials.build(lp);
+  return dirichlet_lpdf<propto, T_prob, T_prior_size>(theta, alpha);
 }
 
 template <typename T_prob, typename T_prior_size>
 return_type_t<T_prob, T_prior_size> dirichlet_lpmf(const T_prob& theta,
                                                    const T_prior_size& alpha) {
-  return dirichlet_lpmf<false>(theta, alpha);
+  return dirichlet_lpdf<T_prob, T_prior_size>(theta, alpha);
 }
 
 }  // namespace math

--- a/test/unit/math/prim/mat/prob/dirichlet_log_test.cpp
+++ b/test/unit/math/prim/mat/prob/dirichlet_log_test.cpp
@@ -2,25 +2,25 @@
 #include <stan/math/prim/mat.hpp>
 #include <gtest/gtest.h>
 
-TEST(ProbDirichlet, log_matches_lpmf) {
+TEST(ProbDirichlet, log_matches_lpdf) {
   using stan::math::vector_d;
   Eigen::Matrix<double, Eigen::Dynamic, 1> theta(3, 1);
   theta << 0.2, 0.3, 0.5;
   Eigen::Matrix<double, Eigen::Dynamic, 1> alpha(3, 1);
   alpha << 1.0, 1.0, 1.0;
   EXPECT_FLOAT_EQ(
-      (stan::math::dirichlet_lpmf<true, vector_d, vector_d>(theta, alpha)),
+      (stan::math::dirichlet_lpdf<true, vector_d, vector_d>(theta, alpha)),
       (stan::math::dirichlet_log<true, vector_d, vector_d>(theta, alpha)));
   EXPECT_FLOAT_EQ(
-      (stan::math::dirichlet_lpmf<false, vector_d, vector_d>(theta, alpha)),
+      (stan::math::dirichlet_lpdf<false, vector_d, vector_d>(theta, alpha)),
       (stan::math::dirichlet_log<false, vector_d, vector_d>(theta, alpha)));
   EXPECT_FLOAT_EQ(
-      (stan::math::dirichlet_lpmf<vector_d, vector_d>(theta, alpha)),
+      (stan::math::dirichlet_lpdf<vector_d, vector_d>(theta, alpha)),
       (stan::math::dirichlet_log<vector_d, vector_d>(theta, alpha)));
-  EXPECT_FLOAT_EQ((stan::math::dirichlet_lpmf(theta, alpha)),
+  EXPECT_FLOAT_EQ((stan::math::dirichlet_lpdf(theta, alpha)),
                   (stan::math::dirichlet_log(theta, alpha)));
-  EXPECT_FLOAT_EQ((stan::math::dirichlet_lpmf<true>(theta, alpha)),
+  EXPECT_FLOAT_EQ((stan::math::dirichlet_lpdf<true>(theta, alpha)),
                   (stan::math::dirichlet_log<true>(theta, alpha)));
-  EXPECT_FLOAT_EQ((stan::math::dirichlet_lpmf<false>(theta, alpha)),
+  EXPECT_FLOAT_EQ((stan::math::dirichlet_lpdf<false>(theta, alpha)),
                   (stan::math::dirichlet_log<false>(theta, alpha)));
 }


### PR DESCRIPTION
## Summary

This renames `dirichlet_lpmf` to `dirichlet_lpdf` and marks the former as deprecated, while keeping the old header around for backward compatibility and delegating to the lpdf version (similarly to what is done for `dirichlet_log`).

The wrongly named function doesn't seem to be used in the stan-dev repositories, and was not exposed in the main docs (although it appears in the doxygen documentation). Fixes #1488.

## Tests

The existing test has been updated to use the new name. I've also tested the same with the older name to ensure that it would still work for users of the wrongly named header.

## Side Effects

None.

## Checklist

- [X] Math issue #1488

- [X] Copyright holder: Marco Colombo

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [X] the new changes are tested