### PR TITLE
Glm broadcasting on GPU

### DIFF
--- a/stan/math/opencl/kernels/bernoulli_logit_glm_lpmf.hpp
+++ b/stan/math/opencl/kernels/bernoulli_logit_glm_lpmf.hpp
@@ -29,6 +29,8 @@ static const char* bernoulli_logit_glm_kernel_code = STRINGIFY(
      * @param[in] beta weight vector
      * @param N number of cases
      * @param M number of attributes
+     * @param is_y_vector 0 or 1 - whether y is a vector (alternatively
+     * it is a scalar)
      * @param is_alpha_vector 0 or 1 - whether alpha is a vector (alternatively
      * it is a scalar)
      * @param need_theta_derivative interpreted as boolean - whether
@@ -41,8 +43,8 @@ static const char* bernoulli_logit_glm_kernel_code = STRINGIFY(
         __global double* theta_derivative_sum, const __global int* y_global,
         const __global double* x, const __global double* alpha,
         const __global double* beta, const int N, const int M,
-        const int is_alpha_vector, const int need_theta_derivative,
-        const int need_theta_derivative_sum) {
+        const int is_y_vector, const int is_alpha_vector,
+        const int need_theta_derivative, const int need_theta_derivative_sum) {
       const int gid = get_global_id(0);
       const int lid = get_local_id(0);
       const int lsize = get_local_size(0);
@@ -59,7 +61,7 @@ static const char* bernoulli_logit_glm_kernel_code = STRINGIFY(
         for (int i = 0, j = 0; i < M; i++, j += N) {
           ytheta += x[j + gid] * beta[i];
         }
-        const int y = y_global[gid];
+        const int y = y_global[gid * is_y_vector];
         const double sign_ = 2 * y - 1;
         ytheta += alpha[gid * is_alpha_vector];
         ytheta *= sign_;
@@ -131,7 +133,7 @@ static const char* bernoulli_logit_glm_kernel_code = STRINGIFY(
  * bernoulli_logit_glm() \endlink
  */
 const kernel_cl<out_buffer, out_buffer, out_buffer, in_buffer, in_buffer,
-                in_buffer, in_buffer, int, int, int, int, int>
+                in_buffer, in_buffer, int, int, int, int, int, int>
     bernoulli_logit_glm("bernoulli_logit_glm",
                         {bernoulli_logit_glm_kernel_code},
                         {{"REDUCTION_STEP_SIZE", 4}, {"LOCAL_SIZE_", 64}});

--- a/stan/math/opencl/kernels/neg_binomial_2_log_glm_lpmf.hpp
+++ b/stan/math/opencl/kernels/neg_binomial_2_log_glm_lpmf.hpp
@@ -32,6 +32,8 @@ static const char* neg_binomial_2_log_glm_kernel_code = STRINGIFY(
      * @param[in] phi_global (vector of) precision parameter(s)
      * @param N number of cases
      * @param M number of attributes
+     * @param is_y_vector 0 or 1 - whether y is a vector (alternatively
+     * it is a scalar)
      * @param is_alpha_vector 0 or 1 - whether alpha is a vector (alternatively
      * it is a scalar)
      * @param is_phi_vector 0 or 1 - whether phi is a vector (alternatively it
@@ -60,12 +62,12 @@ static const char* neg_binomial_2_log_glm_kernel_code = STRINGIFY(
         __global double* phi_derivative_global, const __global int* y_global,
         const __global double* x, const __global double* alpha,
         const __global double* beta, const __global double* phi_global,
-        const int N, const int M, const int is_alpha_vector,
-        const int is_phi_vector, const int need_theta_derivative,
-        const int need_theta_derivative_sum, const int need_phi_derivative,
-        const int need_phi_derivative_sum, const int need_logp1,
-        const int need_logp2, const int need_logp3, const int need_logp4,
-        const int need_logp5) {
+        const int N, const int M, const int is_y_vector,
+        const int is_alpha_vector, const int is_phi_vector,
+        const int need_theta_derivative, const int need_theta_derivative_sum,
+        const int need_phi_derivative, const int need_phi_derivative_sum,
+        const int need_logp1, const int need_logp2, const int need_logp3,
+        const int need_logp4, const int need_logp5) {
       const int gid = get_global_id(0);
       const int lid = get_local_id(0);
       const int lsize = get_local_size(0);
@@ -84,7 +86,7 @@ static const char* neg_binomial_2_log_glm_kernel_code = STRINGIFY(
           theta += x[j + gid] * beta[i];
         }
         double phi = phi_global[gid * is_phi_vector];
-        double y = y_global[gid];
+        double y = y_global[gid * is_y_vector];
         if (!isfinite(theta) || y < 0 || !isfinite(phi)) {
           logp = NAN;
         }
@@ -195,7 +197,7 @@ static const char* neg_binomial_2_log_glm_kernel_code = STRINGIFY(
  */
 const kernel_cl<out_buffer, out_buffer, out_buffer, out_buffer, in_buffer,
                 in_buffer, in_buffer, in_buffer, in_buffer, int, int, int, int,
-                int, int, int, int, int, int, int, int, int>
+                int, int, int, int, int, int, int, int, int, int>
     neg_binomial_2_log_glm("neg_binomial_2_log_glm",
                            {digamma_device_function,
                             neg_binomial_2_log_glm_kernel_code},

--- a/stan/math/opencl/kernels/poisson_log_glm_lpmf.hpp
+++ b/stan/math/opencl/kernels/poisson_log_glm_lpmf.hpp
@@ -28,6 +28,8 @@ static const char* poisson_log_glm_kernel_code = STRINGIFY(
      * @param[in] beta weight vector
      * @param N number of cases
      * @param M number of attributes
+     * @param is_y_vector 0 or 1 - whether y is a vector (alternatively
+     * it is a scalar)
      * @param is_alpha_vector 0 or 1 - whether alpha is a vector (alternatively
      * it is a scalar)
      * @param need_logp1 interpreted as boolean - whether first part of
@@ -40,8 +42,8 @@ static const char* poisson_log_glm_kernel_code = STRINGIFY(
         __global double* theta_derivative_sum, __global double* logp_global,
         const __global int* y_global, const __global double* x,
         const __global double* alpha, const __global double* beta, const int N,
-        const int M, const int is_alpha_vector, const int need_logp1,
-        const int need_logp2) {
+        const int M, const int is_y_vector, const int is_alpha_vector,
+        const int need_logp1, const int need_logp2) {
       const int gid = get_global_id(0);
       const int lid = get_local_id(0);
       const int lsize = get_local_size(0);
@@ -59,7 +61,7 @@ static const char* poisson_log_glm_kernel_code = STRINGIFY(
         }
 
         theta += alpha[gid * is_alpha_vector];
-        const double y = y_global[gid];
+        const double y = y_global[gid * is_y_vector];
         const double exp_theta = exp(theta);
         theta_derivative = y - exp_theta;
         if (y < 0 || !isfinite(theta)) {
@@ -119,7 +121,7 @@ static const char* poisson_log_glm_kernel_code = STRINGIFY(
  * See the docs for \link kernels/subtract.hpp subtract() \endlink
  */
 const kernel_cl<out_buffer, out_buffer, out_buffer, in_buffer, in_buffer,
-                in_buffer, in_buffer, int, int, int, int, int>
+                in_buffer, in_buffer, int, int, int, int, int, int>
     poisson_log_glm("poisson_log_glm", {poisson_log_glm_kernel_code},
                     {{"REDUCTION_STEP_SIZE", 4}, {"LOCAL_SIZE_", 64}});
 

--- a/stan/math/opencl/prim/bernoulli_logit_glm_lpmf.hpp
+++ b/stan/math/opencl/prim/bernoulli_logit_glm_lpmf.hpp
@@ -32,8 +32,10 @@ namespace math {
  * value (for models with constant intercept);
  * @tparam T_beta type of the weight vector;
  * this can also be a single value;
- * @param y_cl binary vector parameter on OpenCL device
- * @param x_cl design matrix on OpenCL device
+ * @param y_cl binary scalar or vector parameter on OpenCL device. If it is a
+ * scalar it will be broadcast - used for all instances.
+ * @param x_cl design matrix on OpenCL device. This overload does not support
+ * broadcasting of a row vector x!
  * @param alpha intercept (in log odds)
  * @param beta weight vector
  * @return log probability or log sum of probabilities
@@ -55,11 +57,13 @@ return_type_t<T_alpha, T_beta> bernoulli_logit_glm_lpmf(
   const size_t N = x_cl.rows();
   const size_t M = x_cl.cols();
 
-  check_size_match(function, "Rows of ", "x_cl", N, "rows of ", "y_cl",
-                   y_cl.rows());
+  if (y_cl.size() != 1) {
+    check_size_match(function, "Rows of ", "x_cl", N, "rows of ", "y_cl",
+                     y_cl.rows());
+  }
   check_consistent_size(function, "Weight vector", beta, M);
   if (is_vector<T_alpha>::value) {
-    check_size_match(function, "Rows of ", "y_cl", N, "size of ", "alpha",
+    check_size_match(function, "Rows of ", "x_cl", N, "size of ", "alpha",
                      length(alpha));
   }
 
@@ -97,8 +101,8 @@ return_type_t<T_alpha, T_beta> bernoulli_logit_glm_lpmf(
     opencl_kernels::bernoulli_logit_glm(
         cl::NDRange(local_size * wgs), cl::NDRange(local_size), logp_cl,
         theta_derivative_cl, theta_derivative_sum_cl, y_cl, x_cl, alpha_cl,
-        beta_cl, N, M, length(alpha) != 1, need_theta_derivative,
-        need_theta_derivative_sum);
+        beta_cl, N, M, y_cl.size() != 1, length(alpha) != 1,
+        need_theta_derivative, need_theta_derivative_sum);
   } catch (const cl::Error &e) {
     check_opencl_error(function, e);
   }

--- a/stan/math/opencl/prim/categorical_logit_glm_lpmf.hpp
+++ b/stan/math/opencl/prim/categorical_logit_glm_lpmf.hpp
@@ -26,7 +26,7 @@ namespace math {
  * @param y_cl a scalar or vector of classes. If it is a scalar it will be
  * broadcast - used for all instances. Values should be between 1 and number of
  * classes, including endpoints.
- * @param x_cl design matrix or row vector. This overload does not support
+ * @param x_cl design matrix on OpenCL device. This overload does not support
  * broadcasting of a row vector x!
  * @param alpha intercept vector (in log odds)
  * @param beta weight matrix

--- a/stan/math/opencl/prim/neg_binomial_2_log_glm_lpmf.hpp
+++ b/stan/math/opencl/prim/neg_binomial_2_log_glm_lpmf.hpp
@@ -41,8 +41,10 @@ namespace math {
  * @tparam T_precision type of the (positive) precision(s);
  * this can be a vector (of the same length as y, for heteroskedasticity)
  * or a scalar.
- * @param y_cl failures count vector parameter on OpenCL device
- * @param x_cl design matrix on OpenCL device
+ * @param y_cl failures count scalar or vector parameter on OpenCL device. If it
+ * is a scalar it will be broadcast - used for all instances.
+ * @param x_cl design matrix on OpenCL device. This overload does not support
+ * broadcasting of a row vector x!
  * @param alpha intercept (in log odds)
  * @param beta weight vector
  * @param phi (vector of) precision parameter(s)
@@ -69,15 +71,17 @@ return_type_t<T_alpha, T_beta, T_precision> neg_binomial_2_log_glm_lpmf(
   const size_t N = x_cl.rows();
   const size_t M = x_cl.cols();
 
-  check_size_match(function, "Rows of ", "x_cl", N, "rows of ", "y_cl",
-                   y_cl.rows());
+  if (y_cl.size() != 1) {
+    check_size_match(function, "Rows of ", "x_cl", N, "rows of ", "y_cl",
+                     y_cl.rows());
+  }
   check_consistent_size(function, "Weight vector", beta, M);
   if (is_vector<T_precision>::value) {
-    check_size_match(function, "Rows of ", "y_cl", N, "size of ", "phi",
+    check_size_match(function, "Rows of ", "x_cl", N, "size of ", "phi",
                      length(phi));
   }
   if (is_vector<T_alpha>::value) {
-    check_size_match(function, "Rows of ", "y_cl", N, "size of ", "alpha",
+    check_size_match(function, "Rows of ", "x_cl", N, "size of ", "alpha",
                      length(alpha));
   }
   check_positive_finite(function, "Precision parameter", phi);
@@ -133,10 +137,10 @@ return_type_t<T_alpha, T_beta, T_precision> neg_binomial_2_log_glm_lpmf(
     opencl_kernels::neg_binomial_2_log_glm(
         cl::NDRange(local_size * wgs), cl::NDRange(local_size), logp_cl,
         theta_derivative_cl, theta_derivative_sum_cl, phi_derivative_cl, y_cl,
-        x_cl, alpha_cl, beta_cl, phi_cl, N, M, length(alpha) != 1,
-        length(phi) != 1, need_theta_derivative, need_theta_derivative_sum,
-        need_phi_derivative, need_phi_derivative_sum, need_logp1, need_logp2,
-        need_logp3, need_logp4, need_logp5);
+        x_cl, alpha_cl, beta_cl, phi_cl, N, M, y_cl.size() != 1,
+        length(alpha) != 1, length(phi) != 1, need_theta_derivative,
+        need_theta_derivative_sum, need_phi_derivative, need_phi_derivative_sum,
+        need_logp1, need_logp2, need_logp3, need_logp4, need_logp5);
   } catch (const cl::Error& e) {
     check_opencl_error(function, e);
   }

--- a/stan/math/opencl/prim/normal_id_glm_lpdf.hpp
+++ b/stan/math/opencl/prim/normal_id_glm_lpdf.hpp
@@ -36,8 +36,10 @@ namespace math {
  * @tparam T_scale type of the (positive) scale(s);
  * this can be a vector (of the same length as y, for heteroskedasticity)
  * or a scalar.
- * @param y_cl vector parameter on OpenCL device
- * @param x_cl design matrix on OpenCL device
+ * @param y_cl scalar or vector parameter on OpenCL device. If it is a scalar it
+ * will be broadcast - used for all instances.
+ * @param x_cl design matrix on OpenCL device. This overload does not support
+ * broadcasting of a row vector x!
  * @param alpha intercept (in log odds)
  * @param beta weight vector
  * @param sigma (Sequence of) scale parameters for the normal
@@ -67,15 +69,17 @@ return_type_t<T_alpha, T_beta, T_scale> normal_id_glm_lpdf(
   const size_t M = x_cl.cols();
 
   check_positive_finite(function, "Scale vector", sigma);
-  check_size_match(function, "Rows of ", "x_cl", N, "rows of ", "y_cl",
-                   y_cl.rows());
+  if (y_cl.size() != 1) {
+    check_size_match(function, "Rows of ", "x_cl", N, "rows of ", "y_cl",
+                     y_cl.size());
+  }
   check_consistent_size(function, "Weight vector", beta, M);
   if (is_vector<T_scale>::value) {
-    check_size_match(function, "Rows of ", "y_cl", N, "size of ", "sigma",
+    check_size_match(function, "Rows of ", "x_cl", N, "size of ", "sigma",
                      length(sigma));
   }
   if (is_vector<T_alpha>::value) {
-    check_size_match(function, "Rows of ", "y_cl", N, "size of ", "alpha",
+    check_size_match(function, "Rows of ", "x_cl", N, "size of ", "alpha",
                      length(alpha));
   }
 
@@ -126,8 +130,9 @@ return_type_t<T_alpha, T_beta, T_scale> normal_id_glm_lpdf(
         mu_derivative_cl, mu_derivative_sum_cl,
         y_minus_mu_over_sigma_squared_sum_cl, sigma_derivative_cl,
         log_sigma_sum_cl, y_cl, x_cl, alpha_cl, beta_cl, sigma_cl, N, M,
-        length(alpha) != 1, length(sigma) != 1, need_mu_derivative,
-        need_mu_derivative_sum, need_sigma_derivative, need_log_sigma_sum);
+        y_cl.size() != 1, length(alpha) != 1, length(sigma) != 1,
+        need_mu_derivative, need_mu_derivative_sum, need_sigma_derivative,
+        need_log_sigma_sum);
   } catch (const cl::Error &e) {
     check_opencl_error(function, e);
   }

--- a/stan/math/opencl/prim/poisson_log_glm_lpmf.hpp
+++ b/stan/math/opencl/prim/poisson_log_glm_lpmf.hpp
@@ -30,8 +30,10 @@ namespace math {
  * value (for models with constant intercept);
  * @tparam T_beta type of the weight vector;
  * this can also be a single value;
- * @param y_cl positive integer vector parameter on OpenCL device
- * @param x_cl design matrix on OpenCL device
+ * @param y_cl positive integer scalar or vector parameter on OpenCL device. If
+ * it is a scalar it will be broadcast - used for all instances.
+ * @param x_cl design matrix on OpenCL device. This overload does not support
+ * broadcasting of a row vector x!
  * @param alpha intercept (in log odds)
  * @param beta weight vector
  * @return log probability or log sum of probabilities
@@ -53,11 +55,13 @@ return_type_t<T_alpha, T_beta> poisson_log_glm_lpmf(
   const size_t N = x_cl.rows();
   const size_t M = x_cl.cols();
 
-  check_size_match(function, "Rows of ", "x_cl", N, "rows of ", "y_cl",
-                   y_cl.rows());
+  if (y_cl.size() != 1) {
+    check_size_match(function, "Rows of ", "x_cl", N, "rows of ", "y_cl",
+                     y_cl.rows());
+  }
   check_consistent_size(function, "Weight vector", beta, M);
   if (is_vector<T_alpha>::value) {
-    check_size_match(function, "Rows of ", "y_cl", N, "size of ", "alpha",
+    check_size_match(function, "Rows of ", "x_cl", N, "size of ", "alpha",
                      length(alpha));
   }
   if (N == 0) {
@@ -93,7 +97,8 @@ return_type_t<T_alpha, T_beta> poisson_log_glm_lpmf(
     opencl_kernels::poisson_log_glm(
         cl::NDRange(local_size * wgs), cl::NDRange(local_size),
         theta_derivative_cl, theta_derivative_sum_cl, logp_cl, y_cl, x_cl,
-        alpha_cl, beta_cl, N, M, length(alpha) != 1, need_logp1, need_logp2);
+        alpha_cl, beta_cl, N, M, y_cl.size() != 1, length(alpha) != 1,
+        need_logp1, need_logp2);
   } catch (const cl::Error& e) {
     check_opencl_error(function, e);
   }

--- a/test/unit/math/opencl/rev/bernoulli_logit_glm_lpmf_test.cpp
+++ b/test/unit/math/opencl/rev/bernoulli_logit_glm_lpmf_test.cpp
@@ -161,8 +161,8 @@ TEST(ProbDistributionsBernoulliLogitGLM, gpu_broadcast_y) {
 
   var res1
       = stan::math::bernoulli_logit_glm_lpmf(y_cl, x_cl, alpha_var1, beta_var1);
-  var res2
-      = stan::math::bernoulli_logit_glm_lpmf(y_vec_cl, x_cl, alpha_var2, beta_var2);
+  var res2 = stan::math::bernoulli_logit_glm_lpmf(y_vec_cl, x_cl, alpha_var2,
+                                                  beta_var2);
 
   (res1 + res2).grad();
 

--- a/test/unit/math/opencl/rev/bernoulli_logit_glm_lpmf_test.cpp
+++ b/test/unit/math/opencl/rev/bernoulli_logit_glm_lpmf_test.cpp
@@ -128,6 +128,52 @@ TEST(ProbDistributionsBernoulliLogitGLM, gpu_matches_cpu_small_simple) {
                   beta_var2.adj().eval());
 }
 
+TEST(ProbDistributionsBernoulliLogitGLM, gpu_broadcast_y) {
+  double eps = 1e-9;
+  int N = 3;
+  int M = 2;
+
+  int y = 1;
+  vector<int> y_vec{y, y, y};
+  Matrix<double, Dynamic, Dynamic> x(N, M);
+  x << -12, 46, -42, 24, 25, 27;
+  Matrix<double, Dynamic, 1> beta(M, 1);
+  beta << 0.3, 2;
+  double alpha = 0.3;
+
+  matrix_cl<double> x_cl(x);
+  matrix_cl<int> y_cl(y);
+  matrix_cl<int> y_vec_cl(y_vec, N, 1);
+
+  expect_near_rel(
+      "poisson_log_glm_lpmf (OpenCL)",
+      stan::math::bernoulli_logit_glm_lpmf(y_cl, x_cl, alpha, beta),
+      stan::math::bernoulli_logit_glm_lpmf(y_vec_cl, x_cl, alpha, beta));
+  expect_near_rel(
+      "poisson_log_glm_lpmf (OpenCL)",
+      stan::math::bernoulli_logit_glm_lpmf<true>(y_cl, x_cl, alpha, beta),
+      stan::math::bernoulli_logit_glm_lpmf<true>(y_vec_cl, x_cl, alpha, beta));
+
+  Matrix<var, Dynamic, 1> beta_var1 = beta;
+  Matrix<var, Dynamic, 1> beta_var2 = beta;
+  var alpha_var1 = alpha;
+  var alpha_var2 = alpha;
+
+  var res1
+      = stan::math::bernoulli_logit_glm_lpmf(y_cl, x_cl, alpha_var1, beta_var1);
+  var res2
+      = stan::math::bernoulli_logit_glm_lpmf(y_vec_cl, x_cl, alpha_var2, beta_var2);
+
+  (res1 + res2).grad();
+
+  expect_near_rel("poisson_log_glm_lpmf (OpenCL)", res1.val(), res2.val());
+
+  expect_near_rel("poisson_log_glm_lpmf (OpenCL)", alpha_var1.adj(),
+                  alpha_var2.adj());
+  expect_near_rel("poisson_log_glm_lpmf (OpenCL)", beta_var1.adj().eval(),
+                  beta_var2.adj().eval());
+}
+
 TEST(ProbDistributionsBernoulliLogitGLM, gpu_matches_cpu_zero_instances) {
   double eps = 1e-9;
   int N = 0;


### PR DESCRIPTION
## Summary

This adds broadcasting to GPU implementations of GLMs. Since broadcasting of x would be faster on CPU only broadcasting of y is supported in GPU implementations.

## Tests

Added tests that check broadcasting forks.

## Side Effects

None.

## Checklist

- [x] Math issue #1378 

- [x] Copyright holder: Tadej Ciglarič

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
