### PR TITLE
Feature/issue 1490 loop order

### DIFF
--- a/stan/math/fwd/mat/fun/inverse.hpp
+++ b/stan/math/fwd/mat/fun/inverse.hpp
@@ -15,12 +15,13 @@ namespace math {
 template <typename T, int R, int C>
 inline Eigen::Matrix<fvar<T>, R, C> inverse(
     const Eigen::Matrix<fvar<T>, R, C>& m) {
+  check_nonempty("inverse", "m", m);
   check_square("inverse", "m", m);
   Eigen::Matrix<T, R, C> m_deriv(m.rows(), m.cols());
   Eigen::Matrix<T, R, C> m_inv(m.rows(), m.cols());
 
-  for (size_type i = 0; i < m.rows(); i++) {
-    for (size_type j = 0; j < m.cols(); j++) {
+  for (size_type j = 0; j < m.cols(); j++) {
+    for (size_type i = 0; i < m.rows(); i++) {
       m_inv(i, j) = m(i, j).val_;
       m_deriv(i, j) = m(i, j).d_;
     }

--- a/stan/math/fwd/mat/fun/mdivide_left_ldlt.hpp
+++ b/stan/math/fwd/mat/fun/mdivide_left_ldlt.hpp
@@ -26,8 +26,8 @@ inline Eigen::Matrix<fvar<T2>, R1, C2> mdivide_left_ldlt(
 
   Eigen::Matrix<T2, R2, C2> b_val(b.rows(), b.cols());
   Eigen::Matrix<T2, R2, C2> b_der(b.rows(), b.cols());
-  for (int i = 0; i < b.rows(); i++) {
-    for (int j = 0; j < b.cols(); j++) {
+  for (int j = 0; j < b.cols(); j++) {
+    for (int i = 0; i < b.rows(); i++) {
       b_val(i, j) = b(i, j).val_;
       b_der(i, j) = b(i, j).d_;
     }

--- a/stan/math/fwd/mat/fun/to_fvar.hpp
+++ b/stan/math/fwd/mat/fun/to_fvar.hpp
@@ -48,8 +48,8 @@ inline Eigen::Matrix<fvar<T>, R, C> to_fvar(
     const Eigen::Matrix<T, R, C>& val, const Eigen::Matrix<T, R, C>& deriv) {
   check_matching_dims("to_fvar", "value", val, "deriv", deriv);
   Eigen::Matrix<fvar<T>, R, C> ret(val.rows(), val.cols());
-  for (int i = 0; i < val.rows(); i++) {
-    for (int j = 0; j < val.cols(); j++) {
+  for (int j = 0; j < val.cols(); j++) {
+    for (int i = 0; i < val.rows(); i++) {
       ret(i, j).val_ = val(i, j);
       ret(i, j).d_ = deriv(i, j);
     }

--- a/stan/math/prim/mat/prob/lkj_cov_lpdf.hpp
+++ b/stan/math/prim/mat/prob/lkj_cov_lpdf.hpp
@@ -32,11 +32,7 @@ return_type_t<T_y, T_loc, T_scale, T_shape> lkj_cov_lpdf(
   check_positive(function, "Shape parameter", eta);
   check_finite(function, "Location parameter", mu);
   check_finite(function, "Scale parameter", sigma);
-  for (int m = 0; m < y.rows(); ++m) {
-    for (int n = 0; n < y.cols(); ++n) {
-      check_finite(function, "Covariance matrix", y(m, n));
-    }
-  }
+  check_finite(function, "Covariance matrix", y);
 
   const unsigned int K = y.rows();
   const Eigen::Array<T_y, Eigen::Dynamic, 1> sds = y.diagonal().array().sqrt();
@@ -77,6 +73,7 @@ return_type_t<T_y, T_loc, T_scale, T_shape> lkj_cov_lpdf(
   check_positive(function, "Shape parameter", eta);
   check_finite(function, "Location parameter", mu);
   check_finite(function, "Scale parameter", sigma);
+  check_finite(function, "Covariance matrix", y);
 
   const unsigned int K = y.rows();
   const Eigen::Array<T_y, Eigen::Dynamic, 1> sds = y.diagonal().array().sqrt();

--- a/stan/math/prim/mat/prob/matrix_normal_prec_rng.hpp
+++ b/stan/math/prim/mat/prob/matrix_normal_prec_rng.hpp
@@ -98,8 +98,8 @@ inline Eigen::MatrixXd matrix_normal_prec_rng(const Eigen::MatrixXd &Mu,
       = Sigma_ldlt.vectorD().array().inverse().sqrt().matrix();
   Eigen::VectorXd col_stddev
       = D_ldlt.vectorD().array().inverse().sqrt().matrix();
-  for (int row = 0; row < m; ++row) {
-    for (int col = 0; col < n; ++col) {
+  for (int col = 0; col < n; ++col) {
+    for (int row = 0; row < m; ++row) {
       double stddev = row_stddev(row) * col_stddev(col);
       // C(row, col) = std_normal_rng();
       X(row, col) = stddev * std_normal_rng();

--- a/stan/math/rev/mat/functor/kinsol_data.hpp
+++ b/stan/math/rev/mat/functor/kinsol_data.hpp
@@ -33,8 +33,8 @@ struct kinsol_J_f {
     Eigen::MatrixXd Jac;
     jacobian(system, to_vector(x_vec), fx, Jac);
 
-    for (int i = 0; i < Jac.rows(); i++)
-      for (int j = 0; j < Jac.cols(); j++)
+    for (int j = 0; j < Jac.cols(); j++)
+      for (int i = 0; i < Jac.rows(); i++)
         SM_ELEMENT_D(J, i, j) = Jac(i, j);
 
     return 0;

--- a/test/unit/math/prim/mat/prob/lkj_cov_test.cpp
+++ b/test/unit/math/prim/mat/prob/lkj_cov_test.cpp
@@ -1,52 +1,131 @@
 #include <stan/math/prim/mat.hpp>
 #include <gtest/gtest.h>
-#include <random>
+#include <boost/random/mersenne_twister.hpp>
+#include <boost/math/distributions.hpp>
 
 TEST(ProbDistributionsLkjCov, testIdentity) {
-  std::random_device rd;
-  std::mt19937 mt(rd());
+  boost::random::mt19937 rng;
   unsigned int K = 4;
   Eigen::MatrixXd Sigma(K, K);
   Sigma.setZero();
   Sigma.diagonal().setOnes();
-  double eta = rd() / static_cast<double>(RAND_MAX) + 0.5;
-  double f = stan::math::do_lkj_constant(eta, K);
-  EXPECT_FLOAT_EQ(f, stan::math::lkj_corr_log(Sigma, eta));
+  double mu = 0;
+  Eigen::VectorXd muV = Eigen::VectorXd::Zero(K);
+  double sd = 1;
+  Eigen::VectorXd sdV = Eigen::VectorXd::Ones(K);
+  double eta = stan::math::uniform_rng(0.5, 1.5, rng);
+  double f = stan::math::do_lkj_constant(eta, K)
+             + K * stan::math::lognormal_lpdf(1, 0, 1);
+  EXPECT_FLOAT_EQ(f, stan::math::lkj_cov_lpdf(Sigma, mu, sd, eta));
+  EXPECT_FLOAT_EQ(f, stan::math::lkj_cov_lpdf(Sigma, muV, sdV, eta));
   eta = 1.0;
-  f = stan::math::do_lkj_constant(eta, K);
-  EXPECT_FLOAT_EQ(f, stan::math::lkj_corr_log(Sigma, eta));
+  f = stan::math::do_lkj_constant(eta, K)
+      + K * stan::math::lognormal_lpdf(1, 0, 1);
+  EXPECT_FLOAT_EQ(f, stan::math::lkj_cov_lpdf(Sigma, mu, sd, eta));
+  EXPECT_FLOAT_EQ(f, stan::math::lkj_cov_lpdf(Sigma, muV, sdV, eta));
 }
 
 TEST(ProbDistributionsLkjCov, testHalf) {
-  std::random_device rd;
-  std::mt19937 mt(rd());
+  boost::random::mt19937 rng;
   unsigned int K = 4;
   Eigen::MatrixXd Sigma(K, K);
   Sigma.setConstant(0.5);
   Sigma.diagonal().setOnes();
-  double eta = rd() / static_cast<double>(RAND_MAX) + 0.5;
-  double f = stan::math::do_lkj_constant(eta, K);
-  EXPECT_FLOAT_EQ(f + (eta - 1.0) * log(0.3125),
-                  stan::math::lkj_corr_log(Sigma, eta));
+  double mu = 0;
+  Eigen::VectorXd muV = Eigen::VectorXd::Zero(K);
+  double sd = 1;
+  Eigen::VectorXd sdV = Eigen::VectorXd::Ones(K);
+  double eta = stan::math::uniform_rng(0.5, 1.5, rng);
+  double f = stan::math::do_lkj_constant(eta, K)
+             + K * stan::math::lognormal_lpdf(1, 0, 1)
+             + (eta - 1.0) * log(0.3125);
+  EXPECT_FLOAT_EQ(f, stan::math::lkj_cov_lpdf(Sigma, mu, sd, eta));
+  EXPECT_FLOAT_EQ(f, stan::math::lkj_cov_lpdf(Sigma, muV, sdV, eta));
   eta = 1.0;
-  f = stan::math::do_lkj_constant(eta, K);
-  EXPECT_FLOAT_EQ(f, stan::math::lkj_corr_log(Sigma, eta));
+  f = stan::math::do_lkj_constant(eta, K)
+      + K * stan::math::lognormal_lpdf(1, 0, 1);
+  EXPECT_FLOAT_EQ(f, stan::math::lkj_cov_lpdf(Sigma, mu, sd, eta));
+  EXPECT_FLOAT_EQ(f, stan::math::lkj_cov_lpdf(Sigma, muV, sdV, eta));
 }
 
-TEST(ProbDistributionsLkjCov, Sigma) {
-  std::random_device rd;
-  std::mt19937 mt(rd());
+TEST(ProbDistributionsLkjCov, ErrorChecks) {
+  boost::random::mt19937 rng;
   unsigned int K = 4;
   Eigen::MatrixXd Sigma(K, K);
   Sigma.setZero();
   Sigma.diagonal().setOnes();
-  double eta = rd() / static_cast<double>(RAND_MAX) + 0.5;
-  EXPECT_NO_THROW(stan::math::lkj_corr_log(Sigma, eta));
+  double mu = 0;
+  Eigen::VectorXd muV = Eigen::VectorXd::Zero(K);
+  double sd = 1;
+  Eigen::VectorXd sdV = Eigen::VectorXd::Ones(K);
+  double eta = stan::math::uniform_rng(0.5, 1.5, rng);
+  EXPECT_NO_THROW(stan::math::lkj_cov_lpdf(Sigma, mu, sd, eta));
 
-  EXPECT_THROW(stan::math::lkj_corr_log(Sigma, -eta), std::domain_error);
+  // Error checks for non vectorized version.
 
-  Sigma = Sigma * -1.0;
-  EXPECT_THROW(stan::math::lkj_corr_log(Sigma, eta), std::domain_error);
-  Sigma = Sigma * (0.0 / 0.0);
-  EXPECT_THROW(stan::math::lkj_corr_log(Sigma, eta), std::domain_error);
+  EXPECT_NO_THROW(stan::math::lkj_cov_lpdf(Sigma, -1, sd, eta));
+  EXPECT_THROW(
+      stan::math::lkj_cov_lpdf(Sigma, stan::math::NOT_A_NUMBER, sd, eta),
+      std::domain_error);
+  EXPECT_THROW(stan::math::lkj_cov_lpdf(Sigma, stan::math::INFTY, sd, eta),
+               std::domain_error);
+  EXPECT_THROW(
+      stan::math::lkj_cov_lpdf(Sigma, stan::math::NEGATIVE_INFTY, sd, eta),
+      std::domain_error);
+
+  EXPECT_THROW(stan::math::lkj_cov_lpdf(Sigma, mu, -1, eta), std::domain_error);
+  EXPECT_THROW(
+      stan::math::lkj_cov_lpdf(Sigma, mu, stan::math::NOT_A_NUMBER, eta),
+      std::domain_error);
+  EXPECT_THROW(stan::math::lkj_cov_lpdf(Sigma, mu, stan::math::INFTY, eta),
+               std::domain_error);
+  EXPECT_THROW(
+      stan::math::lkj_cov_lpdf(Sigma, mu, stan::math::NEGATIVE_INFTY, eta),
+      std::domain_error);
+
+  EXPECT_THROW(stan::math::lkj_cov_lpdf(Sigma, mu, sd, -1), std::domain_error);
+  EXPECT_THROW(
+      stan::math::lkj_cov_lpdf(Sigma, muV, sd, stan::math::NOT_A_NUMBER),
+      std::domain_error);
+  EXPECT_NO_THROW(stan::math::lkj_cov_lpdf(Sigma, mu, sd, stan::math::INFTY));
+  EXPECT_THROW(
+      stan::math::lkj_cov_lpdf(Sigma, mu, sd, stan::math::NEGATIVE_INFTY),
+      std::domain_error);
+
+  // Vectorized.
+
+  Eigen::VectorXd muV1 = -muV;
+  EXPECT_NO_THROW(stan::math::lkj_cov_lpdf(Sigma, muV1, sdV, eta));
+  muV1 = stan::math::NOT_A_NUMBER * muV;
+  EXPECT_THROW(stan::math::lkj_cov_lpdf(Sigma, muV1, sdV, eta),
+               std::domain_error);
+  muV1 = stan::math::INFTY * muV;
+  EXPECT_THROW(stan::math::lkj_cov_lpdf(Sigma, muV1, sdV, eta),
+               std::domain_error);
+  muV1 = stan::math::NEGATIVE_INFTY * muV;
+  EXPECT_THROW(stan::math::lkj_cov_lpdf(Sigma, muV1, sdV, eta),
+               std::domain_error);
+
+  Eigen::VectorXd sdV1 = -sdV;
+  EXPECT_THROW(stan::math::lkj_cov_lpdf(Sigma, muV, sdV1, eta),
+               std::domain_error);
+  sdV1 = stan::math::NOT_A_NUMBER * sdV;
+  EXPECT_THROW(stan::math::lkj_cov_lpdf(Sigma, muV, sdV1, eta),
+               std::domain_error);
+  sdV1 = stan::math::INFTY * sdV;
+  EXPECT_THROW(stan::math::lkj_cov_lpdf(Sigma, muV, sdV1, eta),
+               std::domain_error);
+  sdV1 = stan::math::NEGATIVE_INFTY * sdV;
+  EXPECT_THROW(stan::math::lkj_cov_lpdf(Sigma, muV, sdV1, eta),
+               std::domain_error);
+
+  EXPECT_THROW(stan::math::lkj_cov_lpdf(Sigma, muV, sdV, -1),
+               std::domain_error);
+  EXPECT_THROW(
+      stan::math::lkj_cov_lpdf(Sigma, muV, sdV, stan::math::NOT_A_NUMBER),
+      std::domain_error);
+  EXPECT_NO_THROW(stan::math::lkj_cov_lpdf(Sigma, muV, sdV, stan::math::INFTY));
+  EXPECT_THROW(
+      stan::math::lkj_cov_lpdf(Sigma, muV, sdV, stan::math::NEGATIVE_INFTY),
+      std::domain_error);
 }


### PR DESCRIPTION
## Summary

Partially addresses #1490.

Eliminates instances of row-major iteration across a column-major Eigen matrix in six places:
stan/math/prim/mat/prob/lkj_cov_lpdf.hpp
stan/math/prim/mat/prob/matrix_normal_prec_rng.hpp
stan/math/fwd/mat/fun/to_fvar.hpp
stan/math/fwd/mat/fun/mdivide_left_ldlt.hpp
stan/math/fwd/mat/fun/inverse.hpp
stan/math/rev/mat/functor/kinsol_data.hpp

I can trivially break this into multiple PRs if that would make it easier.

This pattern occurs frequently when handling matrices of fvars (especially in the mdivide_foo family):
```
for (int j = 0; j < b.cols(); j++) {
  for (int i = 0; i < b.rows(); i++) {
       b_val(i, j) = b(i, j).val_;
       b_der(i, j) = b(i, j).d_;
```

There were three places where it was row-col instead of col-row. I fixed that.

It could be:
```
b_val = b.val();
b_der = b.d();
```

Which would be two walks across b. Well, technically val and d both return CWiseUnaryOps, and the walks happen when they are turned into dense matrices.

kinsol_data is tested indirectly, via its uses in the algebra solvers.

In Stan, lkj_cov_lpdf is depreciated in favor of lkj_corr_lpdf. Also lkj_cov_lpdf had no tests. The file that was supposed to contain its tests just had a copy of the lkj_corr_lpdf tests. I've added a few tests for error conditions in lkj_cov_lpdf, but its still not proper coverage.

When reviewing the lkj tests, note the following: if y is a covariance matrix, and D is a diagonal matrix with Dii = 1/sqrt[yii], then DyD is the associated correlation matrix. Now if yii = 1, mu_i = 0, sd_i = 1, then:
```
lkj_cov_lpdf[y, mu, sigma, eta]
    ~= lkj_corr_lpdf[DyD, eta] + sum_i lognormal_lpdf[sqrt[yii], mu_i, sigma_i]
    = lkj_corr_lpdf[y, eta] + sum_i lognormal_lpdf[1, 0, 1]
    = lkj_corr_lpdf[y, eta] + size_of_y * lognormal_lpdf[1, 0, 1]
```

## Tests

Added tests:
test/unit/math/prim/mat/prob/lkj_cov_test.cpp

Old tests:
test/unit/math/mix/mat/fun/inverse_test.cpp
test/unit/math/prim/mat/fun/inverse_test.cpp
test/unit/math/prim/mat/prob/matrix_normal_prec_rng_test.cpp
test/unit/math/mix/mat/fun/to_fvar_test.cpp
test/unit/math/fwd/mat/fun/to_fvar_test.cpp
test/unit/math/mix/mat/fun/mdivide_left_ldlt_test.cpp
test/unit/math/prim/mat/fun/mdivide_left_ldlt_test.cpp
test/unit/math/rev/mat/functor/algebra_solver_fp_test.cpp
test/unit/math/rev/mat/functor/algebra_solver_test.cpp

## Side Effects

None.

## Checklist

- [X] Math issue #1490

- [X] Copyright holder: Peter Wicks Stringfield

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [X] the new changes are tested
