### PR TITLE
better handling of size 0 inputs

### DIFF
--- a/stan/math/prim/mat/err/check_corr_matrix.hpp
+++ b/stan/math/prim/mat/err/check_corr_matrix.hpp
@@ -25,7 +25,6 @@ namespace math {
  * @param name Name of the variable
  * @param y Matrix to test
  * @throw <code>std::invalid_argument</code> if the matrix is not square
- *   or if the matrix is 0x0
  * @throw <code>std::domain_error</code> if the matrix is non-symmetric,
  *   diagonals not near 1, not positive definite, or any of the
  *   elements nan
@@ -39,6 +38,10 @@ inline void check_corr_matrix(
 
   check_square(function, name, y);
   using std::fabs;
+  if (y.size() == 0) {
+    return;
+  }
+
   for (size_type k = 0; k < y.rows(); ++k) {
     if (!(fabs(y(k, k) - 1.0) <= CONSTRAINT_TOLERANCE)) {
       std::ostringstream msg;

--- a/stan/math/prim/mat/err/check_symmetric.hpp
+++ b/stan/math/prim/mat/err/check_symmetric.hpp
@@ -37,7 +37,7 @@ inline void check_symmetric(
       Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>>::type;
 
   size_type k = y.rows();
-  if (k == 1) {
+  if (k <= 1) {
     return;
   }
   for (size_type m = 0; m < k; ++m) {

--- a/stan/math/prim/mat/fun/matrix_exp.hpp
+++ b/stan/math/prim/mat/fun/matrix_exp.hpp
@@ -16,6 +16,8 @@ namespace math {
  * input matrix.
  * @param[in] A Matrix to exponentiate.
  * @return Matrix exponential, dynamically-sized.
+ * @throw <code>std::invalid_argument</code> if the input matrix
+ * is not square.
  */
 template <typename T>
 inline Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> matrix_exp(
@@ -34,7 +36,7 @@ inline Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> matrix_exp(
 
 /**
  * Return the matrix exponential of the input
- * statically-sized matrix.
+ * statically-sized square matrix.
  *
  * @tparam T type of scalar of the elements of
  * input matrix.

--- a/stan/math/prim/mat/fun/matrix_exp_multiply.hpp
+++ b/stan/math/prim/mat/fun/matrix_exp_multiply.hpp
@@ -18,11 +18,12 @@ namespace math {
 template <int Cb>
 inline Eigen::Matrix<double, -1, Cb> matrix_exp_multiply(
     const Eigen::MatrixXd& A, const Eigen::Matrix<double, -1, Cb>& B) {
-  if (A.size() == 0 && B.size() == 0)
-    return {};
+  check_square("matrix_exp_multiply", "input matrix", A);
+  if (A.size() == 0 && B.rows() == 0) {
+    return Eigen::Matrix<double, -1, Cb>(0, B.cols());
+  }
 
   check_multiplicable("matrix_exp_multiply", "A", A, "B", B);
-  check_square("matrix_exp_multiply", "input matrix", A);
 
   return matrix_exp_action_handler().action(A, B);
 }

--- a/stan/math/prim/mat/fun/matrix_exp_pade.hpp
+++ b/stan/math/prim/mat/fun/matrix_exp_pade.hpp
@@ -1,6 +1,7 @@
 #ifndef STAN_MATH_PRIM_MAT_FUN_MATRIX_EXP_PADE_HPP
 #define STAN_MATH_PRIM_MAT_FUN_MATRIX_EXP_PADE_HPP
 
+#include <stan/math/prim/mat/err/check_square.hpp>
 #include <stan/math/prim/mat/fun/MatrixExponential.h>
 
 namespace stan {
@@ -18,10 +19,13 @@ namespace math {
  */
 template <typename MatrixType>
 MatrixType matrix_exp_pade(const MatrixType& arg) {
+  check_square("matrix_exp_pade", "arg", arg);
+  if (arg.size() == 0) {
+    return {};
+  }
+
   MatrixType U, V;
   int squarings;
-  if (arg.size() == 0)
-    return {};
 
   Eigen::matrix_exp_computeUV<MatrixType>::run(arg, U, V, squarings, arg(0, 0));
   // Pade approximant is

--- a/stan/math/prim/mat/fun/mdivide_left_ldlt.hpp
+++ b/stan/math/prim/mat/fun/mdivide_left_ldlt.hpp
@@ -22,8 +22,7 @@ template <int R1, int C1, int R2, int C2, typename T1, typename T2>
 inline Eigen::Matrix<return_type_t<T1, T2>, R1, C2> mdivide_left_ldlt(
     const LDLT_factor<T1, R1, C1> &A, const Eigen::Matrix<T2, R2, C2> &b) {
   if (A.cols() == 0 && b.rows() == 0) {
-    Eigen::Matrix<return_type_t<T1, T2>, R1, C2> res(0, b.cols());
-    return res;
+    return Eigen::Matrix<return_type_t<T1, T2>, R1, C2>(0, b.cols());
   }
 
   check_multiplicable("mdivide_left_ldlt", "A", A, "b", b);

--- a/stan/math/prim/mat/fun/mdivide_left_ldlt.hpp
+++ b/stan/math/prim/mat/fun/mdivide_left_ldlt.hpp
@@ -22,7 +22,8 @@ template <int R1, int C1, int R2, int C2, typename T1, typename T2>
 inline Eigen::Matrix<return_type_t<T1, T2>, R1, C2> mdivide_left_ldlt(
     const LDLT_factor<T1, R1, C1> &A, const Eigen::Matrix<T2, R2, C2> &b) {
   if (A.cols() == 0 && b.rows() == 0) {
-    return {};
+    Eigen::Matrix<return_type_t<T1, T2>, R1, C2> res(0, b.cols());
+    return res;
   }
 
   check_multiplicable("mdivide_left_ldlt", "A", A, "b", b);

--- a/stan/math/prim/mat/fun/mdivide_right_ldlt.hpp
+++ b/stan/math/prim/mat/fun/mdivide_right_ldlt.hpp
@@ -22,7 +22,7 @@ template <typename T1, typename T2, int R1, int C1, int R2, int C2>
 inline Eigen::Matrix<return_type_t<T1, T2>, R1, C2> mdivide_right_ldlt(
     const Eigen::Matrix<T1, R1, C1> &b, const LDLT_factor<T2, R2, C2> &A) {
   if (b.cols() == 0 && A.rows() == 0) {
-    return {};
+    return Eigen::Matrix<return_type_t<T1, T2>, R1, C2>(b.rows(), 0);
   }
 
   check_multiplicable("mdivide_right_ldlt", "b", b, "A", A);
@@ -35,7 +35,7 @@ inline Eigen::Matrix<double, R1, C2> mdivide_right_ldlt(
     const Eigen::Matrix<double, R1, C1> &b,
     const LDLT_factor<double, R2, C2> &A) {
   if (b.cols() == 0 && A.rows() == 0) {
-    return {};
+    return Eigen::Matrix<double, R1, C2>(b.rows(), 0);
   }
 
   check_multiplicable("mdivide_right_ldlt", "b", b, "A", A);

--- a/stan/math/prim/mat/fun/scale_matrix_exp_multiply.hpp
+++ b/stan/math/prim/mat/fun/scale_matrix_exp_multiply.hpp
@@ -24,11 +24,12 @@ template <int Cb>
 inline Eigen::Matrix<double, -1, Cb> scale_matrix_exp_multiply(
     const double& t, const Eigen::MatrixXd& A,
     const Eigen::Matrix<double, -1, Cb>& B) {
-  if (A.size() == 0 && B.size() == 0)
-    return {};
+  check_square("scale_matrix_exp_multiply", "input matrix", A);
+  if (A.size() == 0 && B.rows() == 0) {
+    return Eigen::Matrix<double, -1, Cb>(0, B.cols());
+  }
 
   check_multiplicable("scale_matrix_exp_multiply", "A", A, "B", B);
-  check_square("scale_matrix_exp_multiply", "input matrix", A);
 
   return matrix_exp_action_handler().action(A, B, t);
 }
@@ -51,11 +52,13 @@ template <typename Tt, typename Ta, typename Tb, int Cb>
 inline Eigen::Matrix<stan::return_type_t<Tt, Ta, Tb>, -1, Cb>
 scale_matrix_exp_multiply(const Tt& t, const Eigen::Matrix<Ta, -1, -1>& A,
                           const Eigen::Matrix<Tb, -1, Cb>& B) {
-  check_multiplicable("scale_matrix_exp_multiply", "A", A, "B", B);
   check_square("scale_matrix_exp_multiply", "input matrix", A);
-  if (A.size() == 0 && B.size() == 0) {
-    return {};
+  if (A.size() == 0 && B.rows() == 0) {
+    return Eigen::Matrix<stan::return_type_t<Tt, Ta, Tb>, -1, Cb>(0, B.cols());
   }
+
+  check_multiplicable("scale_matrix_exp_multiply", "A", A, "B", B);
+
   return multiply(matrix_exp(multiply(A, t)), B);
 }
 

--- a/stan/math/prim/mat/fun/trace_inv_quad_form_ldlt.hpp
+++ b/stan/math/prim/mat/fun/trace_inv_quad_form_ldlt.hpp
@@ -22,7 +22,7 @@ template <typename T1, typename T2, int R2, int C2, int R3, int C3,
           typename = require_any_not_var_t<T1, T2>>
 inline return_type_t<T1, T2> trace_inv_quad_form_ldlt(
     const LDLT_factor<T1, R2, C2> &A, const Eigen::Matrix<T2, R3, C3> &B) {
-  if (A.rows() == 0 && B.size() == 0) {
+  if (A.rows() == 0 && B.rows() == 0) {
     return 0;
   }
 

--- a/stan/math/rev/mat/fun/matrix_exp_multiply.hpp
+++ b/stan/math/rev/mat/fun/matrix_exp_multiply.hpp
@@ -25,11 +25,13 @@ template <typename Ta, typename Tb, int Cb>
 inline Eigen::Matrix<typename stan::return_type<Ta, Tb>::type, -1, Cb>
 matrix_exp_multiply(const Eigen::Matrix<Ta, -1, -1>& A,
                     const Eigen::Matrix<Tb, -1, Cb>& B) {
-  if (A.size() == 0 && B.size() == 0)
-    return {};
+  check_square("matrix_exp_multiply", "input matrix", A);
+  if (A.size() == 0 && B.rows() == 0) {
+    Eigen::Matrix<typename stan::return_type_t<Ta, Tb>, -1, Cb> res(0, B.cols());
+    return res;
+  }
 
   check_multiplicable("matrix_exp_multiply", "A", A, "B", B);
-  check_square("matrix_exp_multiply", "input matrix", A);
 
   return multiply(matrix_exp(A), B);
 }

--- a/stan/math/rev/mat/fun/matrix_exp_multiply.hpp
+++ b/stan/math/rev/mat/fun/matrix_exp_multiply.hpp
@@ -27,8 +27,8 @@ matrix_exp_multiply(const Eigen::Matrix<Ta, -1, -1>& A,
                     const Eigen::Matrix<Tb, -1, Cb>& B) {
   check_square("matrix_exp_multiply", "input matrix", A);
   if (A.size() == 0 && B.rows() == 0) {
-    return Eigen::Matrix<typename stan::return_type_t<Ta, Tb>,
-                                                      -1, Cb>(0, B.cols());
+    return Eigen::Matrix<typename stan::return_type_t<Ta, Tb>, -1, Cb>(
+        0, B.cols());
   }
 
   check_multiplicable("matrix_exp_multiply", "A", A, "B", B);

--- a/stan/math/rev/mat/fun/matrix_exp_multiply.hpp
+++ b/stan/math/rev/mat/fun/matrix_exp_multiply.hpp
@@ -27,9 +27,8 @@ matrix_exp_multiply(const Eigen::Matrix<Ta, -1, -1>& A,
                     const Eigen::Matrix<Tb, -1, Cb>& B) {
   check_square("matrix_exp_multiply", "input matrix", A);
   if (A.size() == 0 && B.rows() == 0) {
-    Eigen::Matrix<typename stan::return_type_t<Ta, Tb>, -1, Cb> res(0,
-                                                                    B.cols());
-    return res;
+    return Eigen::Matrix<typename stan::return_type_t<Ta, Tb>,
+                                                      -1, Cb>(0, B.cols());
   }
 
   check_multiplicable("matrix_exp_multiply", "A", A, "B", B);

--- a/stan/math/rev/mat/fun/matrix_exp_multiply.hpp
+++ b/stan/math/rev/mat/fun/matrix_exp_multiply.hpp
@@ -27,7 +27,8 @@ matrix_exp_multiply(const Eigen::Matrix<Ta, -1, -1>& A,
                     const Eigen::Matrix<Tb, -1, Cb>& B) {
   check_square("matrix_exp_multiply", "input matrix", A);
   if (A.size() == 0 && B.rows() == 0) {
-    Eigen::Matrix<typename stan::return_type_t<Ta, Tb>, -1, Cb> res(0, B.cols());
+    Eigen::Matrix<typename stan::return_type_t<Ta, Tb>, -1, Cb> res(0,
+                                                                    B.cols());
     return res;
   }
 

--- a/stan/math/rev/mat/fun/mdivide_left_ldlt.hpp
+++ b/stan/math/rev/mat/fun/mdivide_left_ldlt.hpp
@@ -178,9 +178,8 @@ template <int R1, int C1, int R2, int C2>
 inline Eigen::Matrix<var, R1, C2> mdivide_left_ldlt(
     const LDLT_factor<var, R1, C1> &A, const Eigen::Matrix<var, R2, C2> &b) {
   Eigen::Matrix<var, R1, C2> res(b.rows(), b.cols());
-
   if (A.cols() == 0 && b.rows() == 0) {
-    return {};
+    return res;
   }
 
   check_multiplicable("mdivide_left_ldlt", "A", A, "b", b);
@@ -205,7 +204,7 @@ inline Eigen::Matrix<var, R1, C2> mdivide_left_ldlt(
     const LDLT_factor<var, R1, C1> &A, const Eigen::Matrix<double, R2, C2> &b) {
   Eigen::Matrix<var, R1, C2> res(b.rows(), b.cols());
   if (A.cols() == 0 && b.rows() == 0) {
-    return {};
+    return res;
   }
 
   check_multiplicable("mdivide_left_ldlt", "A", A, "b", b);
@@ -230,7 +229,7 @@ inline Eigen::Matrix<var, R1, C2> mdivide_left_ldlt(
     const LDLT_factor<double, R1, C1> &A, const Eigen::Matrix<var, R2, C2> &b) {
   Eigen::Matrix<var, R1, C2> res(b.rows(), b.cols());
   if (A.cols() == 0 && b.rows() == 0) {
-    return {};
+    return res;
   }
 
   check_multiplicable("mdivide_left_ldlt", "A", A, "b", b);

--- a/stan/math/rev/mat/fun/trace_inv_quad_form_ldlt.hpp
+++ b/stan/math/rev/mat/fun/trace_inv_quad_form_ldlt.hpp
@@ -147,7 +147,7 @@ template <typename T2, int R2, int C2, typename T3, int R3, int C3,
           typename = require_any_var_t<T2, T3>>
 inline return_type_t<T2, T3> trace_inv_quad_form_ldlt(
     const LDLT_factor<T2, R2, C2> &A, const Eigen::Matrix<T3, R3, C3> &B) {
-  if (A.rows() == 0 && B.size() == 0) {
+  if (A.rows() == 0 && B.rows() == 0) {
     return 0;
   }
 

--- a/test/unit/math/mix/mat/fun/matrix_exp_multiply_test.cpp
+++ b/test/unit/math/mix/mat/fun/matrix_exp_multiply_test.cpp
@@ -23,6 +23,9 @@ TEST(MathMixMatFun, matrixExpMultiply) {
   Eigen::MatrixXd m00(0, 0);
   stan::test::expect_ad(f, m00, m00);
 
+  Eigen::MatrixXd m02(0, 2);
+  stan::test::expect_ad(f, m00, m02);
+
   stan::test::ad_tolerances tols;
   tols.hessian_hessian_ = 1e-2;
   tols.hessian_fvar_hessian_ = 1e-2;

--- a/test/unit/math/mix/mat/fun/matrix_exp_pade_test.cpp
+++ b/test/unit/math/mix/mat/fun/matrix_exp_pade_test.cpp
@@ -6,6 +6,9 @@ TEST(MathMixMatFun, matrixExpPade) {
   Eigen::MatrixXd m00(0, 0);
   stan::test::expect_ad(f, m00);
 
+  Eigen::MatrixXd m02(0, 2);
+  stan::test::expect_ad(f, m02);
+
   Eigen::MatrixXd a1(1, 1);
   a1 << 1;
   stan::test::expect_ad(f, a1);

--- a/test/unit/math/mix/mat/fun/trace_inv_quad_form_ldlt_test.cpp
+++ b/test/unit/math/mix/mat/fun/trace_inv_quad_form_ldlt_test.cpp
@@ -7,8 +7,10 @@ TEST(MathMixMatFun, traceInvQuadFormLdlt) {
   };
 
   Eigen::MatrixXd m00(0, 0);
+  Eigen::MatrixXd m02(0, 2);
   Eigen::VectorXd v0(0);
   stan::test::expect_ad(f, m00, m00);
+  stan::test::expect_ad(f, m00, m02);
   stan::test::expect_ad(f, m00, v0);
 
   Eigen::MatrixXd a11(1, 1);

--- a/test/unit/math/prim/mat/err/check_symmetric_test.cpp
+++ b/test/unit/math/prim/mat/err/check_symmetric_test.cpp
@@ -6,6 +6,13 @@
 TEST(ErrorHandlingMatrix, checkSymmetric) {
   Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> y;
 
+  y.resize(0, 0);
+  EXPECT_NO_THROW(stan::math::check_symmetric("checkSymmetric", "y", y));
+
+  y.resize(1, 1);
+  y << 1;
+  EXPECT_NO_THROW(stan::math::check_symmetric("checkSymmetric", "y", y));
+
   y.resize(2, 2);
   y << 1, 3, 3, 1;
   EXPECT_NO_THROW(stan::math::check_symmetric("checkSymmetric", "y", y));

--- a/test/unit/math/prim/mat/fun/matrix_exp_multiply_test.cpp
+++ b/test/unit/math/prim/mat/fun/matrix_exp_multiply_test.cpp
@@ -34,6 +34,11 @@ TEST(MathMatrixPrimMat, matrix_exp_multiply) {
   Eigen::MatrixXd B(0, 0);
   EXPECT_EQ(stan::math::matrix_exp_multiply(A, B).size(), 0);
 
+  Eigen::MatrixXd C(0, 2);
+  Eigen::MatrixXd M = stan::math::matrix_exp_multiply(A, C);
+  EXPECT_EQ(A.rows(), M.rows());
+  EXPECT_EQ(C.cols(), M.cols());
+
   test_matrix_exp_multiply<1, 1>();
   test_matrix_exp_multiply<1, 5>();
   test_matrix_exp_multiply<5, 1>();

--- a/test/unit/math/prim/mat/fun/matrix_exp_pade_test.cpp
+++ b/test/unit/math/prim/mat/fun/matrix_exp_pade_test.cpp
@@ -84,3 +84,9 @@ TEST(MathMatrixPrimMat, matrix_exp_pade_100x100) {
     for (int j = 0; j < size; j++)
       EXPECT_NEAR(exp_A(i, j), expm_A(i, j), rel_err);
 }
+
+TEST(MathMatrixPrimMat, matrix_exp_pade_0x1) {
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> m1(0, 1);
+
+  EXPECT_THROW(stan::math::matrix_exp_pade(m1), std::invalid_argument);
+}

--- a/test/unit/math/prim/mat/fun/mdivide_left_ldlt_test.cpp
+++ b/test/unit/math/prim/mat/fun/mdivide_left_ldlt_test.cpp
@@ -17,3 +17,16 @@ TEST(MathMatrixPrimMat, mdivide_left_ldlt_val) {
   EXPECT_NEAR(0.0, I(1, 0), 1.0E-12);
   EXPECT_NEAR(1.0, I(1, 1), 1.0e-12);
 }
+
+TEST(MathMatrixPrimMat, mdivide_left_ldlt_val_0x0) {
+  stan::math::LDLT_factor<double, -1, -1> ldlt_A;
+  stan::math::matrix_d B(0, 0), C(0, 2);
+
+  auto M = mdivide_left_ldlt(ldlt_A, B);
+  EXPECT_EQ(0, M.rows());
+  EXPECT_EQ(B.cols(), M.cols());
+
+  auto N = mdivide_left_ldlt(ldlt_A, C);
+  EXPECT_EQ(0, N.rows());
+  EXPECT_EQ(C.cols(), N.cols());
+}

--- a/test/unit/math/prim/mat/fun/mdivide_right_ldlt_test.cpp
+++ b/test/unit/math/prim/mat/fun/mdivide_right_ldlt_test.cpp
@@ -17,3 +17,16 @@ TEST(MathMatrixPrimMat, mdivide_right_ldlt_val) {
   EXPECT_NEAR(0.0, I(1, 0), 1.0E-12);
   EXPECT_NEAR(1.0, I(1, 1), 1.0e-12);
 }
+
+TEST(MathMatrixPrimMat, mdivide_right_ldlt_val_0x0) {
+  stan::math::LDLT_factor<double, -1, -1> ldlt_A;
+  stan::math::matrix_d B(0, 0), C(2, 0);
+
+  auto M = mdivide_right_ldlt(B, ldlt_A);
+  EXPECT_EQ(0, M.rows());
+  EXPECT_EQ(B.cols(), M.cols());
+
+  auto N = mdivide_right_ldlt(C, ldlt_A);
+  EXPECT_EQ(C.rows(), N.rows());
+  EXPECT_EQ(0, N.cols());
+}

--- a/test/unit/math/prim/mat/fun/scale_matrix_exp_multiply_test.cpp
+++ b/test/unit/math/prim/mat/fun/scale_matrix_exp_multiply_test.cpp
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+#include <test/unit/util.hpp>
 #include <test/unit/math/prim/mat/util.hpp>
 #include <stan/math/prim/mat/fun/matrix_exp.hpp>
 #include <stan/math/prim/mat/fun/scale_matrix_exp_multiply.hpp>
@@ -35,6 +36,11 @@ TEST(MathMatrixPrimMat, scale_matrix_exp_multiply) {
   Eigen::MatrixXd A(0, 0);
   Eigen::MatrixXd B(0, 0);
   EXPECT_EQ(stan::math::scale_matrix_exp_multiply(t, A, B).size(), 0);
+
+  Eigen::MatrixXd C(0, 2);
+  Eigen::MatrixXd M = stan::math::scale_matrix_exp_multiply(t, A, C);
+  EXPECT_EQ(A.rows(), M.rows());
+  EXPECT_EQ(C.cols(), M.cols());
 
   test_scale_matrix_exp_multiply<1, 1>();
   test_scale_matrix_exp_multiply<1, 5>();

--- a/test/unit/math/prim/mat/fun/trace_inv_quad_form_ldlt_test.cpp
+++ b/test/unit/math/prim/mat/fun/trace_inv_quad_form_ldlt_test.cpp
@@ -16,7 +16,6 @@ TEST(MathMatrixPrimMat, trace_inv_quad_form_ldlt) {
 }
 
 TEST(MathMatrixPrimMat, trace_inv_quad_form_ldlt_0x0) {
-
   stan::math::LDLT_factor<double, -1, -1> ldlt_A;
   stan::math::matrix_d B(0, 0), C(0, 2), D(2, 0);
 

--- a/test/unit/math/prim/mat/fun/trace_inv_quad_form_ldlt_test.cpp
+++ b/test/unit/math/prim/mat/fun/trace_inv_quad_form_ldlt_test.cpp
@@ -14,3 +14,14 @@ TEST(MathMatrixPrimMat, trace_inv_quad_form_ldlt) {
   EXPECT_FLOAT_EQ((B.transpose() * A.inverse() * B).trace(),
                   trace_inv_quad_form_ldlt(ldlt_A, B));
 }
+
+TEST(MathMatrixPrimMat, trace_inv_quad_form_ldlt_0x0) {
+
+  stan::math::LDLT_factor<double, -1, -1> ldlt_A;
+  stan::math::matrix_d B(0, 0), C(0, 2), D(2, 0);
+
+  EXPECT_FLOAT_EQ(0, trace_inv_quad_form_ldlt(ldlt_A, B));
+  EXPECT_FLOAT_EQ(0, trace_inv_quad_form_ldlt(ldlt_A, C));
+
+  EXPECT_THROW(trace_inv_quad_form_ldlt(ldlt_A, D), std::invalid_argument);
+}


### PR DESCRIPTION
## Summary

The following is done:
- `matrix_exp_multiply`, `scale_matrix_exp_multiply` and `matrix_exp_pade`: move `check_square` at the beginning, so that it throws if `A` is not square (currently it returns an empty matrix if any dimension is 0)
- `scale_matrix_exp_multiply`: it returns a rectangular matrix with 0 rows if `A` is empty and `B` has zero rows (currently it returns a square empty matrix)
- `mdivide_left_ldlt`: it returns a rectangular matrix with 0 rows if `A` is empty and `b` has zero rows (currently it returns a square empty matrix)
- `mdivide_right_ldlt`: it returns a rectangular matrix with 0 columns if `A` is empty and `b` has zero columns (currently it returns a square empty matrix)
- `trace_inv_quad_form_ldlt`: use `B.rows()` instead of `B.size()`, so we ensure that matrices are multipliable before returning 0

This also:
- avoids extra work in `check_symmetric` by checking if the size of the square matrix is 0
- same for `check_corr_matrix`, so that for size 0 matrix it returns instead of throwing

Fixes #1515.

## Tests

I've added a bunch of tests that check for all of the above. It's still worth checking for more cases that I might have missed. I'm also not entirely convinced that my mental mapping of prim/rev/mix is complete or correct, so it's possible I've missed something.

## Side Effects

None.

## Checklist

- [X] Math issue #1515

- [X] Copyright holder: Marco Colombo

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [X] the new changes are tested
