### PR TITLE
Bugfix/fix test headers with opencl

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -142,15 +142,32 @@ pipeline {
                 }
             }
         }
-        stage('Headers check') {
-            agent any
-            steps {
-                deleteDir()
-                unstash 'MathSetup'
-                sh "echo CXX=${env.CXX} -Werror > make/local"
-                sh "make -j${env.PARALLEL} test-headers"
-            }
-            post { always { deleteDir() } }
+        stage('Headers checks') {
+            parallel {
+              stage('Headers check') {
+                agent any
+                steps {
+                    deleteDir()
+                    unstash 'MathSetup'
+                    sh "echo CXX=${env.CXX} -Werror > make/local"
+                    sh "make -j${env.PARALLEL} test-headers"
+                }
+                post { always { deleteDir() } }
+              }
+              stage('Headers check with OpenCL') {
+                agent { label "gpu" }
+                steps {
+                    deleteDir()
+                    unstash 'MathSetup'
+                    sh "echo CXX=${env.CXX} -Werror > make/local"
+                    sh "echo STAN_OPENCL=true>> make/local"
+                    sh "echo OPENCL_PLATFORM_ID=0>> make/local"
+                    sh "echo OPENCL_DEVICE_ID=${OPENCL_DEVICE_ID}>> make/local"
+                    sh "make -j${env.PARALLEL} test-headers"
+                }
+                post { always { deleteDir() } }
+              }
+           }
         }
         stage('Always-run tests part 1') {
             parallel {
@@ -175,7 +192,6 @@ pipeline {
                         sh "echo STAN_OPENCL=true>> make/local"
                         sh "echo OPENCL_PLATFORM_ID=0>> make/local"
                         sh "echo OPENCL_DEVICE_ID=${OPENCL_DEVICE_ID}>> make/local"
-                        sh "make -j${env.PARALLEL} test-headers"
                         runTests("test/unit")
                     }
                     post { always { retry(3) { deleteDir() } } }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -175,6 +175,7 @@ pipeline {
                         sh "echo STAN_OPENCL=true>> make/local"
                         sh "echo OPENCL_PLATFORM_ID=0>> make/local"
                         sh "echo OPENCL_DEVICE_ID=${OPENCL_DEVICE_ID}>> make/local"
+                        sh "make -j${env.PARALLEL} test-headers"
                         runTests("test/unit")
                     }
                     post { always { retry(3) { deleteDir() } } }

--- a/stan/math/opencl/kernels/device_functions/log1m_exp.hpp
+++ b/stan/math/opencl/kernels/device_functions/log1m_exp.hpp
@@ -1,6 +1,7 @@
 #ifndef STAN_MATH_OPENCL_KERNELS_DEVICE_FUNCTIONS_LOG1M_EXP_HPP
 #define STAN_MATH_OPENCL_KERNELS_DEVICE_FUNCTIONS_LOG1M_EXP_HPP
 #ifdef STAN_OPENCL
+#include <stan/math/opencl/stringify.hpp>
 #include <string>
 
 namespace stan {

--- a/stan/math/opencl/kernels/device_functions/log1p_exp.hpp
+++ b/stan/math/opencl/kernels/device_functions/log1p_exp.hpp
@@ -1,6 +1,7 @@
 #ifndef STAN_MATH_OPENCL_KERNELS_DEVICE_FUNCTIONS_LOG1P_EXP_HPP
 #define STAN_MATH_OPENCL_KERNELS_DEVICE_FUNCTIONS_LOG1P_EXP_HPP
 #ifdef STAN_OPENCL
+#include <stan/math/opencl/stringify.hpp>
 #include <string>
 
 namespace stan {

--- a/stan/math/opencl/prim/bernoulli_logit_glm_lpmf.hpp
+++ b/stan/math/opencl/prim/bernoulli_logit_glm_lpmf.hpp
@@ -12,9 +12,10 @@
 #include <stan/math/prim/mat/fun/sum.hpp>
 #include <stan/math/prim/arr/fun/value_of_rec.hpp>
 #include <stan/math/prim/scal/fun/size_zero.hpp>
-
 #include <stan/math/prim/mat/fun/value_of.hpp>
 #include <stan/math/prim/arr/fun/value_of.hpp>
+#include <stan/math/opencl/copy.hpp>
+#include <stan/math/opencl/kernel_generator.hpp>
 #include <stan/math/opencl/kernels/bernoulli_logit_glm_lpmf.hpp>
 
 #include <cmath>

--- a/stan/math/opencl/prim/categorical_logit_glm_lpmf.hpp
+++ b/stan/math/opencl/prim/categorical_logit_glm_lpmf.hpp
@@ -3,14 +3,19 @@
 #ifdef STAN_OPENCL
 
 #include <stan/math/prim/meta.hpp>
+
 #include <stan/math/prim/scal/err/check_bounded.hpp>
 #include <stan/math/prim/scal/err/check_consistent_size.hpp>
+#include <stan/math/prim/scal/err/check_finite.hpp>
 #include <stan/math/prim/scal/fun/size_zero.hpp>
 #include <stan/math/prim/mat/fun/sum.hpp>
 #include <Eigen/Core>
 
 #include <stan/math/opencl/matrix_cl.hpp>
+#include <stan/math/opencl/copy.hpp>
+#include <stan/math/opencl/kernel_generator.hpp>
 #include <stan/math/opencl/kernels/categorical_logit_glm_lpmf.hpp>
+#include <stan/math/opencl/prim/transpose.hpp>
 
 namespace stan {
 namespace math {

--- a/stan/math/opencl/prim/neg_binomial_2_log_glm_lpmf.hpp
+++ b/stan/math/opencl/prim/neg_binomial_2_log_glm_lpmf.hpp
@@ -20,7 +20,6 @@
 #include <stan/math/opencl/kernel_generator.hpp>
 #include <stan/math/opencl/kernels/neg_binomial_2_log_glm_lpmf.hpp>
 
-
 #include <vector>
 #include <cmath>
 

--- a/stan/math/opencl/prim/neg_binomial_2_log_glm_lpmf.hpp
+++ b/stan/math/opencl/prim/neg_binomial_2_log_glm_lpmf.hpp
@@ -13,9 +13,13 @@
 #include <stan/math/prim/mat/fun/lgamma.hpp>
 #include <stan/math/prim/mat/fun/value_of_rec.hpp>
 #include <stan/math/prim/arr/fun/value_of_rec.hpp>
+#include <stan/math/prim/arr/fun/sum.hpp>
 #include <stan/math/prim/scal/fun/sum.hpp>
-
+#include <stan/math/prim/mat/fun/sum.hpp>
+#include <stan/math/opencl/copy.hpp>
+#include <stan/math/opencl/kernel_generator.hpp>
 #include <stan/math/opencl/kernels/neg_binomial_2_log_glm_lpmf.hpp>
+
 
 #include <vector>
 #include <cmath>

--- a/stan/math/opencl/prim/normal_id_glm_lpdf.hpp
+++ b/stan/math/opencl/prim/normal_id_glm_lpdf.hpp
@@ -11,8 +11,9 @@
 #include <stan/math/prim/scal/fun/size_zero.hpp>
 #include <stan/math/prim/scal/fun/sum.hpp>
 #include <stan/math/prim/arr/fun/value_of_rec.hpp>
+#include <stan/math/prim/mat/fun/sum.hpp>
 #include <stan/math/prim/mat/prob/normal_id_glm_lpdf.hpp>
-
+#include <stan/math/opencl/copy.hpp>
 #include <stan/math/opencl/kernels/normal_id_glm_lpdf.hpp>
 #include <stan/math/opencl/matrix_cl.hpp>
 #include <stan/math/opencl/kernel_generator.hpp>

--- a/stan/math/opencl/prim/ordered_logistic_glm_lpmf.hpp
+++ b/stan/math/opencl/prim/ordered_logistic_glm_lpmf.hpp
@@ -13,7 +13,10 @@
 #include <stan/math/prim/mat/fun/log1m_exp.hpp>
 #include <stan/math/prim/mat/fun/sum.hpp>
 #include <stan/math/prim/meta.hpp>
+
+#include <stan/math/opencl/copy.hpp>
 #include <stan/math/opencl/matrix_cl.hpp>
+#include <stan/math/opencl/kernel_generator.hpp>
 #include <stan/math/opencl/kernels/ordered_logistic_glm_lpmf.hpp>
 #include <cmath>
 

--- a/stan/math/opencl/prim/poisson_log_glm_lpmf.hpp
+++ b/stan/math/opencl/prim/poisson_log_glm_lpmf.hpp
@@ -5,6 +5,7 @@
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/scal/err/check_consistent_sizes.hpp>
 #include <stan/math/prim/scal/err/check_nonnegative.hpp>
+#include <stan/math/prim/mat/err/check_finite.hpp>
 #include <stan/math/prim/scal/fun/constants.hpp>
 #include <stan/math/prim/scal/fun/size_zero.hpp>
 #include <stan/math/prim/mat/fun/value_of_rec.hpp>
@@ -12,7 +13,12 @@
 #include <stan/math/prim/mat/fun/value_of.hpp>
 #include <stan/math/prim/arr/fun/value_of.hpp>
 #include <stan/math/prim/mat/fun/sum.hpp>
+#include <stan/math/opencl/copy.hpp>
+#include <stan/math/opencl/matrix_cl.hpp>
+#include <stan/math/opencl/multiply.hpp>
+#include <stan/math/opencl/kernel_generator.hpp>
 #include <stan/math/opencl/kernels/poisson_log_glm_lpmf.hpp>
+
 #include <cmath>
 #include <limits>
 

--- a/stan/math/opencl/rev/sub_block.hpp
+++ b/stan/math/opencl/rev/sub_block.hpp
@@ -2,9 +2,10 @@
 #define STAN_MATH_OPENCL_REV_SUB_BLOCK_HPP
 #ifdef STAN_OPENCL
 
+#include <stan/math/prim/mat/fun/typedefs.hpp>
 #include <stan/math/opencl/opencl_context.hpp>
-#include <stan/math/opencl/sub_block.hpp>
 #include <stan/math/opencl/rev/matrix_cl.hpp>
+#include <stan/math/opencl/sub_block.hpp>
 #include <cl.hpp>
 #include <vector>
 

--- a/stan/math/opencl/rev/triangular_transpose.hpp
+++ b/stan/math/opencl/rev/triangular_transpose.hpp
@@ -2,6 +2,7 @@
 #define STAN_MATH_OPENCL_REV_TRIANGULAR_TRANSPOSE_HPP
 #ifdef STAN_OPENCL
 
+#include <stan/math/prim/mat/fun/typedefs.hpp>
 #include <stan/math/opencl/matrix_cl_view.hpp>
 #include <stan/math/opencl/triangular_transpose.hpp>
 #include <stan/math/opencl/rev/matrix_cl.hpp>

--- a/stan/math/opencl/rev/zeros.hpp
+++ b/stan/math/opencl/rev/zeros.hpp
@@ -2,6 +2,7 @@
 #define STAN_MATH_OPENCL_REV_ZEROS_HPP
 #ifdef STAN_OPENCL
 
+#include <stan/math/prim/mat/fun/typedefs.hpp>
 #include <stan/math/opencl/opencl_context.hpp>
 #include <stan/math/opencl/matrix_cl_view.hpp>
 #include <stan/math/opencl/matrix_cl.hpp>

--- a/stan/math/prim/mat/fun/divide_columns.hpp
+++ b/stan/math/prim/mat/fun/divide_columns.hpp
@@ -3,6 +3,7 @@
 
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <stan/math/prim/scal/err/check_size_match.hpp>
 #include <stan/math/prim/scal/fun/divide.hpp>
 #include <vector>
 

--- a/stan/math/rev/mat/fun/mdivide_left_tri.hpp
+++ b/stan/math/rev/mat/fun/mdivide_left_tri.hpp
@@ -8,7 +8,9 @@
 #include <stan/math/rev/core.hpp>
 #include <stan/math/rev/mat/fun/typedefs.hpp>
 #include <stan/math/prim/mat/fun/typedefs.hpp>
-
+#ifdef STAN_OPENCL
+#include <stan/math/opencl/opencl.hpp>
+#endif
 namespace stan {
 namespace math {
 


### PR DESCRIPTION
## Summary

We have a bunch of `make test-headers` errors if you run it with STAN_OPENCL=true. I am fixing those issues and adding the test-headers check with STAN_OPENCL to Jenkins.

## Tests

This adds a `sh "make -j${env.PARALLEL} test-headers"` to the Full unit with GPU stage in order to prevent this from happening again. This adds 4-5 minutes to testing but the entire testing procedure takes 7-8 hours so I think we can live with that. We could also split it out.

## Side Effects

/

## Checklist

- [x] Math issue #1485 

- [x] Copyright holder: Rok Češnovar, Univ. of Ljubljana

- [x] the basic tests are passing

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
