### PR TITLE
Clean up unnecessary checks in _lpmf/_lpdf functions

### DIFF
--- a/stan/math/prim/mat/prob/neg_binomial_2_log_glm_lpmf.hpp
+++ b/stan/math/prim/mat/prob/neg_binomial_2_log_glm_lpmf.hpp
@@ -158,10 +158,8 @@ neg_binomial_2_log_glm_lpmf(
                  - lgamma(forward_as<double>(phi_val)));
     }
   }
-  if (include_summand<propto, T_x_scalar, T_alpha, T_beta,
-                      T_precision>::value) {
-    logp -= sum(y_plus_phi * logsumexp_theta_logphi);
-  }
+  logp -= sum(y_plus_phi * logsumexp_theta_logphi);
+
   if (include_summand<propto, T_x_scalar, T_alpha, T_beta>::value) {
     logp += sum(y_arr * theta);
   }

--- a/stan/math/prim/scal/prob/beta_proportion_lpdf.hpp
+++ b/stan/math/prim/scal/prob/beta_proportion_lpdf.hpp
@@ -87,10 +87,8 @@ return_type_t<T_y, T_loc, T_prec> beta_proportion_lpdf(const T_y& y,
       log1m_y(length(y));
 
   for (size_t n = 0; n < length(y); n++) {
-    if (include_summand<propto, T_y, T_loc, T_prec>::value) {
-      log_y[n] = log(value_of(y_vec[n]));
-      log1m_y[n] = log1m(value_of(y_vec[n]));
-    }
+    log_y[n] = log(value_of(y_vec[n]));
+    log1m_y[n] = log1m(value_of(y_vec[n]));
   }
 
   VectorBuilder<include_summand<propto, T_loc, T_prec>::value,
@@ -150,11 +148,9 @@ return_type_t<T_y, T_loc, T_prec> beta_proportion_lpdf(const T_y& y,
     if (include_summand<propto, T_loc, T_prec>::value) {
       logp -= lgamma_mukappa[n] + lgamma_kappa_mukappa[n];
     }
-    if (include_summand<propto, T_y, T_loc, T_prec>::value) {
-      const T_partials_return mukappa_dbl = mu_dbl * kappa_dbl;
-      logp += (mukappa_dbl - 1) * log_y[n]
-              + (kappa_dbl - mukappa_dbl - 1) * log1m_y[n];
-    }
+    const T_partials_return mukappa_dbl = mu_dbl * kappa_dbl;
+    logp += (mukappa_dbl - 1) * log_y[n]
+            + (kappa_dbl - mukappa_dbl - 1) * log1m_y[n];
 
     if (!is_constant_all<T_y>::value) {
       const T_partials_return mukappa_dbl = mu_dbl * kappa_dbl;

--- a/stan/math/prim/scal/prob/cauchy_lpdf.hpp
+++ b/stan/math/prim/scal/prob/cauchy_lpdf.hpp
@@ -93,9 +93,7 @@ return_type_t<T_y, T_loc, T_scale> cauchy_lpdf(const T_y& y, const T_loc& mu,
     if (include_summand<propto, T_scale>::value) {
       logp -= log_sigma[n];
     }
-    if (include_summand<propto, T_y, T_loc, T_scale>::value) {
-      logp -= log1p(y_minus_mu_over_sigma_squared);
-    }
+    logp -= log1p(y_minus_mu_over_sigma_squared);
 
     if (!is_constant_all<T_y>::value) {
       ops_partials.edge1_.partials_[n]

--- a/stan/math/prim/scal/prob/double_exponential_lpdf.hpp
+++ b/stan/math/prim/scal/prob/double_exponential_lpdf.hpp
@@ -68,9 +68,7 @@ return_type_t<T_y, T_loc, T_scale> double_exponential_lpdf(
       log_sigma(length(sigma));
   for (size_t i = 0; i < length(sigma); i++) {
     const T_partials_return sigma_dbl = value_of(sigma_vec[i]);
-    if (include_summand<propto, T_y, T_loc, T_scale>::value) {
-      inv_sigma[i] = 1.0 / sigma_dbl;
-    }
+    inv_sigma[i] = 1.0 / sigma_dbl;
     if (include_summand<propto, T_scale>::value) {
       log_sigma[i] = log(value_of(sigma_vec[i]));
     }
@@ -92,9 +90,7 @@ return_type_t<T_y, T_loc, T_scale> double_exponential_lpdf(
     if (include_summand<propto, T_scale>::value) {
       logp -= log_sigma[n];
     }
-    if (include_summand<propto, T_y, T_loc, T_scale>::value) {
-      logp -= fabs_y_m_mu * inv_sigma[n];
-    }
+    logp -= fabs_y_m_mu * inv_sigma[n];
 
     T_partials_return sign_y_m_mu_times_inv_sigma(0);
     if (!is_constant_all<T_y, T_loc>::value) {

--- a/stan/math/prim/scal/prob/exp_mod_normal_lpdf.hpp
+++ b/stan/math/prim/scal/prob/exp_mod_normal_lpdf.hpp
@@ -68,12 +68,10 @@ return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_lpdf(
     if (include_summand<propto, T_inv_scale>::value) {
       logp += log(lambda_dbl);
     }
-    if (include_summand<propto, T_y, T_loc, T_scale, T_inv_scale>::value) {
-      logp += lambda_dbl
-                  * (mu_dbl + 0.5 * lambda_dbl * sigma_dbl * sigma_dbl - y_dbl)
-              + log(erfc((mu_dbl + lambda_dbl * sigma_dbl * sigma_dbl - y_dbl)
-                         / (sqrt(2.0) * sigma_dbl)));
-    }
+    logp += lambda_dbl
+                * (mu_dbl + 0.5 * lambda_dbl * sigma_dbl * sigma_dbl - y_dbl)
+            + log(erfc((mu_dbl + lambda_dbl * sigma_dbl * sigma_dbl - y_dbl)
+                       / (sqrt(2.0) * sigma_dbl)));
 
     const T_partials_return deriv_logerfc
         = -2.0 / sqrt(pi_dbl)

--- a/stan/math/prim/scal/prob/frechet_lpdf.hpp
+++ b/stan/math/prim/scal/prob/frechet_lpdf.hpp
@@ -81,20 +81,16 @@ return_type_t<T_y, T_shape, T_scale> frechet_lpdf(const T_y& y,
                 T_partials_return, T_y>
       inv_y(length(y));
   for (size_t i = 0; i < length(y); i++) {
-    if (include_summand<propto, T_y, T_shape, T_scale>::value) {
-      inv_y[i] = 1.0 / value_of(y_vec[i]);
-    }
+    inv_y[i] = 1.0 / value_of(y_vec[i]);
   }
 
   VectorBuilder<include_summand<propto, T_y, T_shape, T_scale>::value,
                 T_partials_return, T_y, T_shape, T_scale>
       sigma_div_y_pow_alpha(N);
   for (size_t i = 0; i < N; i++) {
-    if (include_summand<propto, T_y, T_shape, T_scale>::value) {
-      const T_partials_return alpha_dbl = value_of(alpha_vec[i]);
-      sigma_div_y_pow_alpha[i]
-          = pow(inv_y[i] * value_of(sigma_vec[i]), alpha_dbl);
-    }
+    const T_partials_return alpha_dbl = value_of(alpha_vec[i]);
+    sigma_div_y_pow_alpha[i]
+        = pow(inv_y[i] * value_of(sigma_vec[i]), alpha_dbl);
   }
 
   operands_and_partials<T_y, T_shape, T_scale> ops_partials(y, alpha, sigma);
@@ -109,9 +105,7 @@ return_type_t<T_y, T_shape, T_scale> frechet_lpdf(const T_y& y,
     if (include_summand<propto, T_shape, T_scale>::value) {
       logp += alpha_dbl * log_sigma[n];
     }
-    if (include_summand<propto, T_y, T_shape, T_scale>::value) {
-      logp -= sigma_div_y_pow_alpha[n];
-    }
+    logp -= sigma_div_y_pow_alpha[n];
 
     if (!is_constant_all<T_y>::value) {
       const T_partials_return inv_y_dbl = value_of(inv_y[n]);

--- a/stan/math/prim/scal/prob/gumbel_lpdf.hpp
+++ b/stan/math/prim/scal/prob/gumbel_lpdf.hpp
@@ -81,9 +81,7 @@ return_type_t<T_y, T_loc, T_scale> gumbel_lpdf(const T_y& y, const T_loc& mu,
     if (include_summand<propto, T_scale>::value) {
       logp -= log_beta[n];
     }
-    if (include_summand<propto, T_y, T_loc, T_scale>::value) {
-      logp += -y_minus_mu_over_beta - exp(-y_minus_mu_over_beta);
-    }
+    logp += -y_minus_mu_over_beta - exp(-y_minus_mu_over_beta);
 
     T_partials_return scaled_diff = inv_beta[n] * exp(-y_minus_mu_over_beta);
     if (!is_constant_all<T_y>::value) {

--- a/stan/math/prim/scal/prob/logistic_lpdf.hpp
+++ b/stan/math/prim/scal/prob/logistic_lpdf.hpp
@@ -78,23 +78,17 @@ return_type_t<T_y, T_loc, T_scale> logistic_lpdf(const T_y& y, const T_loc& mu,
     const T_partials_return y_minus_mu = y_dbl - mu_dbl;
     const T_partials_return y_minus_mu_div_sigma = y_minus_mu * inv_sigma[n];
     T_partials_return exp_m_y_minus_mu_div_sigma(0);
-    if (include_summand<propto, T_y, T_loc, T_scale>::value) {
-      exp_m_y_minus_mu_div_sigma = exp(-y_minus_mu_div_sigma);
-    }
+    exp_m_y_minus_mu_div_sigma = exp(-y_minus_mu_div_sigma);
     T_partials_return inv_1p_exp_y_minus_mu_div_sigma(0);
     if (!is_constant_all<T_y, T_scale>::value) {
       inv_1p_exp_y_minus_mu_div_sigma = 1 / (1 + exp(y_minus_mu_div_sigma));
     }
 
-    if (include_summand<propto, T_y, T_loc, T_scale>::value) {
-      logp -= y_minus_mu_div_sigma;
-    }
+    logp -= y_minus_mu_div_sigma;
     if (include_summand<propto, T_scale>::value) {
       logp -= log_sigma[n];
     }
-    if (include_summand<propto, T_y, T_loc, T_scale>::value) {
-      logp -= 2.0 * log1p(exp_m_y_minus_mu_div_sigma);
-    }
+    logp -= 2.0 * log1p(exp_m_y_minus_mu_div_sigma);
 
     if (!is_constant_all<T_y>::value) {
       ops_partials.edge1_.partials_[n]

--- a/stan/math/prim/scal/prob/neg_binomial_2_log_lpmf.hpp
+++ b/stan/math/prim/scal/prob/neg_binomial_2_log_lpmf.hpp
@@ -89,15 +89,13 @@ return_type_t<T_log_location, T_precision> neg_binomial_2_log_lpmf(
     if (include_summand<propto, T_precision>::value) {
       logp += multiply_log(phi__[i], phi__[i]) - lgamma(phi__[i]);
     }
-    if (include_summand<propto, T_log_location, T_precision>::value) {
-      logp -= (n_plus_phi[i]) * logsumexp_eta_logphi[i];
-    }
     if (include_summand<propto, T_log_location>::value) {
       logp += n_vec[i] * eta__[i];
     }
     if (include_summand<propto, T_precision>::value) {
       logp += lgamma(n_plus_phi[i]);
     }
+    logp -= (n_plus_phi[i]) * logsumexp_eta_logphi[i];
 
     if (!is_constant_all<T_log_location>::value) {
       ops_partials.edge1_.partials_[i]

--- a/stan/math/prim/scal/prob/neg_binomial_2_lpmf.hpp
+++ b/stan/math/prim/scal/prob/neg_binomial_2_lpmf.hpp
@@ -84,15 +84,13 @@ return_type_t<T_location, T_precision> neg_binomial_2_lpmf(
     if (include_summand<propto, T_precision>::value) {
       logp += multiply_log(phi__[i], phi__[i]) - lgamma(phi__[i]);
     }
-    if (include_summand<propto, T_location, T_precision>::value) {
-      logp -= (n_plus_phi[i]) * log_mu_plus_phi[i];
-    }
     if (include_summand<propto, T_location>::value) {
       logp += multiply_log(n_vec[i], mu__[i]);
     }
     if (include_summand<propto, T_precision>::value) {
       logp += lgamma(n_plus_phi[i]);
     }
+    logp -= (n_plus_phi[i]) * log_mu_plus_phi[i];
 
     // if phi is large we probably overflow, defer to Poisson:
     if (phi__[i] > 1e5) {

--- a/stan/math/prim/scal/prob/neg_binomial_lpmf.hpp
+++ b/stan/math/prim/scal/prob/neg_binomial_lpmf.hpp
@@ -108,9 +108,7 @@ return_type_t<T_shape, T_inv_scale> neg_binomial_lpmf(const T_n& n,
       if (include_summand<propto>::value) {
         logp -= lgamma(n_vec[i] + 1.0);
       }
-      if (include_summand<propto, T_shape, T_inv_scale>::value) {
-        logp += multiply_log(n_vec[i], lambda[i]) - lambda[i];
-      }
+      logp += multiply_log(n_vec[i], lambda[i]) - lambda[i];
 
       if (!is_constant_all<T_shape>::value) {
         ops_partials.edge1_.partials_[i]
@@ -127,9 +125,7 @@ return_type_t<T_shape, T_inv_scale> neg_binomial_lpmf(const T_n& n,
               n_vec[i] + value_of(alpha_vec[i]) - 1.0, n_vec[i]);
         }
       }
-      if (include_summand<propto, T_shape, T_inv_scale>::value) {
-        logp += alpha_times_log_beta_over_1p_beta[i] - n_vec[i] * log1p_beta[i];
-      }
+      logp += alpha_times_log_beta_over_1p_beta[i] - n_vec[i] * log1p_beta[i];
 
       if (!is_constant_all<T_shape>::value) {
         ops_partials.edge1_.partials_[i]

--- a/stan/math/prim/scal/prob/normal_lpdf.hpp
+++ b/stan/math/prim/scal/prob/normal_lpdf.hpp
@@ -92,9 +92,7 @@ inline return_type_t<T_y, T_loc, T_scale> normal_lpdf(const T_y& y,
     if (include_summand<propto, T_scale>::value) {
       logp -= log_sigma[n];
     }
-    if (include_summand<propto, T_y, T_loc, T_scale>::value) {
-      logp += NEGATIVE_HALF * y_minus_mu_over_sigma_squared;
-    }
+    logp += NEGATIVE_HALF * y_minus_mu_over_sigma_squared;
 
     T_partials_return scaled_diff = inv_sigma[n] * y_minus_mu_over_sigma;
     if (!is_constant_all<T_y>::value) {

--- a/stan/math/prim/scal/prob/pareto_type_2_lpdf.hpp
+++ b/stan/math/prim/scal/prob/pareto_type_2_lpdf.hpp
@@ -55,11 +55,9 @@ return_type_t<T_y, T_loc, T_scale, T_shape> pareto_type_2_lpdf(
   VectorBuilder<include_summand<propto, T_y, T_loc, T_scale, T_shape>::value,
                 T_partials_return, T_y, T_loc, T_scale>
       log1p_scaled_diff(N);
-  if (include_summand<propto, T_y, T_loc, T_scale, T_shape>::value) {
-    for (size_t n = 0; n < N; n++) {
-      log1p_scaled_diff[n] = log1p((value_of(y_vec[n]) - value_of(mu_vec[n]))
-                                   / value_of(lambda_vec[n]));
-    }
+  for (size_t n = 0; n < N; n++) {
+    log1p_scaled_diff[n] = log1p((value_of(y_vec[n]) - value_of(mu_vec[n]))
+                                 / value_of(lambda_vec[n]));
   }
 
   VectorBuilder<include_summand<propto, T_scale>::value, T_partials_return,

--- a/stan/math/prim/scal/prob/poisson_log_lpmf.hpp
+++ b/stan/math/prim/scal/prob/poisson_log_lpmf.hpp
@@ -64,9 +64,7 @@ return_type_t<T_log_rate> poisson_log_lpmf(const T_n& n,
                 T_log_rate>
       exp_alpha(length(alpha));
   for (size_t i = 0; i < length(alpha); i++) {
-    if (include_summand<propto, T_log_rate>::value) {
-      exp_alpha[i] = exp(value_of(alpha_vec[i]));
-    }
+    exp_alpha[i] = exp(value_of(alpha_vec[i]));
   }
 
   for (size_t i = 0; i < size; i++) {
@@ -75,9 +73,7 @@ return_type_t<T_log_rate> poisson_log_lpmf(const T_n& n,
       if (include_summand<propto>::value) {
         logp -= lgamma(n_vec[i] + 1.0);
       }
-      if (include_summand<propto, T_log_rate>::value) {
-        logp += n_vec[i] * value_of(alpha_vec[i]) - exp_alpha[i];
-      }
+      logp += n_vec[i] * value_of(alpha_vec[i]) - exp_alpha[i];
     }
 
     if (!is_constant_all<T_log_rate>::value) {

--- a/stan/math/prim/scal/prob/poisson_lpmf.hpp
+++ b/stan/math/prim/scal/prob/poisson_lpmf.hpp
@@ -61,10 +61,8 @@ return_type_t<T_rate> poisson_lpmf(const T_n& n, const T_rate& lambda) {
       if (include_summand<propto>::value) {
         logp -= lgamma(n_vec[i] + 1.0);
       }
-      if (include_summand<propto, T_rate>::value) {
-        logp += multiply_log(n_vec[i], value_of(lambda_vec[i]))
-                - value_of(lambda_vec[i]);
-      }
+      logp += multiply_log(n_vec[i], value_of(lambda_vec[i]))
+              - value_of(lambda_vec[i]);
     }
 
     if (!is_constant_all<T_rate>::value) {

--- a/stan/math/prim/scal/prob/skew_normal_lpdf.hpp
+++ b/stan/math/prim/scal/prob/skew_normal_lpdf.hpp
@@ -82,9 +82,7 @@ return_type_t<T_y, T_loc, T_scale, T_shape> skew_normal_lpdf(
     if (include_summand<propto, T_y, T_loc, T_scale>::value) {
       logp -= y_minus_mu_over_sigma * y_minus_mu_over_sigma / 2.0;
     }
-    if (include_summand<propto, T_y, T_loc, T_scale, T_shape>::value) {
-      logp += log(erfc(-alpha_dbl * y_minus_mu_over_sigma / std::sqrt(2.0)));
-    }
+    logp += log(erfc(-alpha_dbl * y_minus_mu_over_sigma / std::sqrt(2.0)));
 
     T_partials_return deriv_logerf
         = 2.0 / std::sqrt(pi_dbl)

--- a/stan/math/prim/scal/prob/student_t_lpdf.hpp
+++ b/stan/math/prim/scal/prob/student_t_lpdf.hpp
@@ -85,9 +85,7 @@ return_type_t<T_y, T_dof, T_loc, T_scale> student_t_lpdf(const T_y& y,
                 T_partials_return, T_dof>
       half_nu(length(nu));
   for (size_t i = 0; i < length(nu); i++) {
-    if (include_summand<propto, T_y, T_dof, T_loc, T_scale>::value) {
-      half_nu[i] = 0.5 * value_of(nu_vec[i]);
-    }
+    half_nu[i] = 0.5 * value_of(nu_vec[i]);
   }
 
   VectorBuilder<include_summand<propto, T_dof>::value, T_partials_return, T_dof>
@@ -138,15 +136,13 @@ return_type_t<T_y, T_dof, T_loc, T_scale> student_t_lpdf(const T_y& y,
       log1p_exp(N);
 
   for (size_t i = 0; i < N; i++) {
-    if (include_summand<propto, T_y, T_dof, T_loc, T_scale>::value) {
-      const T_partials_return y_dbl = value_of(y_vec[i]);
-      const T_partials_return mu_dbl = value_of(mu_vec[i]);
-      const T_partials_return sigma_dbl = value_of(sigma_vec[i]);
-      const T_partials_return nu_dbl = value_of(nu_vec[i]);
-      square_y_minus_mu_over_sigma__over_nu[i]
-          = square((y_dbl - mu_dbl) / sigma_dbl) / nu_dbl;
-      log1p_exp[i] = log1p(square_y_minus_mu_over_sigma__over_nu[i]);
-    }
+    const T_partials_return y_dbl = value_of(y_vec[i]);
+    const T_partials_return mu_dbl = value_of(mu_vec[i]);
+    const T_partials_return sigma_dbl = value_of(sigma_vec[i]);
+    const T_partials_return nu_dbl = value_of(nu_vec[i]);
+    square_y_minus_mu_over_sigma__over_nu[i]
+        = square((y_dbl - mu_dbl) / sigma_dbl) / nu_dbl;
+    log1p_exp[i] = log1p(square_y_minus_mu_over_sigma__over_nu[i]);
   }
 
   operands_and_partials<T_y, T_dof, T_loc, T_scale> ops_partials(y, nu, mu,
@@ -165,9 +161,7 @@ return_type_t<T_y, T_dof, T_loc, T_scale> student_t_lpdf(const T_y& y,
     if (include_summand<propto, T_scale>::value) {
       logp -= log_sigma[n];
     }
-    if (include_summand<propto, T_y, T_dof, T_loc, T_scale>::value) {
-      logp -= (half_nu[n] + 0.5) * log1p_exp[n];
-    }
+    logp -= (half_nu[n] + 0.5) * log1p_exp[n];
 
     if (!is_constant_all<T_y>::value) {
       ops_partials.edge1_.partials_[n]

--- a/stan/math/prim/scal/prob/von_mises_lpdf.hpp
+++ b/stan/math/prim/scal/prob/von_mises_lpdf.hpp
@@ -92,9 +92,7 @@ return_type_t<T_y, T_loc, T_scale> von_mises_lpdf(T_y const& y, T_loc const& mu,
     if (include_summand<propto, T_scale>::value) {
       logp -= log_bessel0[n];
     }
-    if (include_summand<propto, T_y, T_loc, T_scale>::value) {
-      logp += kappa_cos;
-    }
+    logp += kappa_cos;
 
     if (!y_const) {
       ops_partials.edge1_.partials_[n] += kappa_sin;

--- a/stan/math/prim/scal/prob/weibull_lpdf.hpp
+++ b/stan/math/prim/scal/prob/weibull_lpdf.hpp
@@ -93,20 +93,16 @@ return_type_t<T_y, T_shape, T_scale> weibull_lpdf(const T_y& y,
                 T_partials_return, T_scale>
       inv_sigma(length(sigma));
   for (size_t i = 0; i < length(sigma); i++) {
-    if (include_summand<propto, T_y, T_shape, T_scale>::value) {
-      inv_sigma[i] = 1.0 / value_of(sigma_vec[i]);
-    }
+    inv_sigma[i] = 1.0 / value_of(sigma_vec[i]);
   }
 
   VectorBuilder<include_summand<propto, T_y, T_shape, T_scale>::value,
                 T_partials_return, T_y, T_shape, T_scale>
       y_div_sigma_pow_alpha(N);
   for (size_t i = 0; i < N; i++) {
-    if (include_summand<propto, T_y, T_shape, T_scale>::value) {
-      const T_partials_return y_dbl = value_of(y_vec[i]);
-      const T_partials_return alpha_dbl = value_of(alpha_vec[i]);
-      y_div_sigma_pow_alpha[i] = pow(y_dbl * inv_sigma[i], alpha_dbl);
-    }
+    const T_partials_return y_dbl = value_of(y_vec[i]);
+    const T_partials_return alpha_dbl = value_of(alpha_vec[i]);
+    y_div_sigma_pow_alpha[i] = pow(y_dbl * inv_sigma[i], alpha_dbl);
   }
 
   operands_and_partials<T_y, T_shape, T_scale> ops_partials(y, alpha, sigma);
@@ -121,9 +117,7 @@ return_type_t<T_y, T_shape, T_scale> weibull_lpdf(const T_y& y,
     if (include_summand<propto, T_shape, T_scale>::value) {
       logp -= alpha_dbl * log_sigma[n];
     }
-    if (include_summand<propto, T_y, T_shape, T_scale>::value) {
-      logp -= y_div_sigma_pow_alpha[n];
-    }
+    logp -= y_div_sigma_pow_alpha[n];
 
     if (!is_constant_all<T_y>::value) {
       const T_partials_return inv_y = 1.0 / value_of(y_vec[n]);


### PR DESCRIPTION
## Summary

I've gone through all `*_lpmf` and `*_lpdf` functions we have in math. For cases where we have
```
if (!include_summand<propto, ...>::value) {
  return 0;
}
```
this removes any identical check (where the terms in `...` match exactly) from the subsequent code. This is a somewhat conservative fix, as there may be more cases that could be cleaned up if I had better understanding of the `include_summand` function. 

It probably helps to ignore space changes when reviewing. The only cases in which I moved a bit of code are in `stan/math/prim/scal/prob/neg_binomial_2_log_lpmf.hpp` and `stan/math/prim/scal/prob/neg_binomial_2_lpmf.hpp`, as it looked weird to have a single line of code in the middle of a long sequence of if blocks.

## Tests

The current distribution tests should be enough to test that there aren't unwanted changes being introduced.

## Side Effects

None.

## Checklist

- [X] Math issue #1519

- [X] Copyright holder: Marco Colombo

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [X] the new changes are tested
