### PR TITLE
Add include_summand_b as replacement for include_summand<...>::value

### DIFF
--- a/stan/math/opencl/prim/bernoulli_logit_glm_lpmf.hpp
+++ b/stan/math/opencl/prim/bernoulli_logit_glm_lpmf.hpp
@@ -71,7 +71,7 @@ return_type_t<T_alpha, T_beta> bernoulli_logit_glm_lpmf(
     return 0;
   }
 
-  if (!include_summand<propto, T_alpha, T_beta>::value) {
+  if (!include_summand_b<propto, T_alpha, T_beta>) {
     return 0;
   }
 

--- a/stan/math/opencl/prim/categorical_logit_glm_lpmf.hpp
+++ b/stan/math/opencl/prim/categorical_logit_glm_lpmf.hpp
@@ -63,7 +63,7 @@ return_type_t<T_alpha_scalar, T_beta_scalar> categorical_logit_glm_lpmf(
     return 0;
   }
 
-  if (!include_summand<propto, T_alpha_scalar, T_beta_scalar>::value) {
+  if (!include_summand_b<propto, T_alpha_scalar, T_beta_scalar>) {
     return 0;
   }
 

--- a/stan/math/opencl/prim/neg_binomial_2_log_glm_lpmf.hpp
+++ b/stan/math/opencl/prim/neg_binomial_2_log_glm_lpmf.hpp
@@ -124,7 +124,7 @@ return_type_t<T_alpha, T_beta, T_precision> neg_binomial_2_log_glm_lpmf(
       need_phi_derivative ? (need_phi_derivative_sum ? wgs : N) : 0, 1);
   const bool need_logp1 = include_summand_b<propto>;
   const bool need_logp2
-      = include_summand_b<propto, T_precision> && is_vector<T_precision>;
+      = include_summand_b<propto, T_precision> && is_vector<T_precision>::value;
   const bool need_logp3
       = include_summand_b<propto, T_alpha, T_beta, T_precision>;
   const bool need_logp4 = include_summand_b<propto, T_alpha, T_beta>;

--- a/stan/math/opencl/prim/neg_binomial_2_log_glm_lpmf.hpp
+++ b/stan/math/opencl/prim/neg_binomial_2_log_glm_lpmf.hpp
@@ -123,7 +123,7 @@ return_type_t<T_alpha, T_beta, T_precision> neg_binomial_2_log_glm_lpmf(
   matrix_cl<double> phi_derivative_cl(
       need_phi_derivative ? (need_phi_derivative_sum ? wgs : N) : 0, 1);
   const bool need_logp1 = include_summand_b<propto>;
-  const bool need_logp
+  const bool need_logp2
       = include_summand_b<propto, T_precision> && is_vector<T_precision>;
   const bool need_logp3
       = include_summand_b<propto, T_alpha, T_beta, T_precision>;

--- a/stan/math/opencl/prim/neg_binomial_2_log_glm_lpmf.hpp
+++ b/stan/math/opencl/prim/neg_binomial_2_log_glm_lpmf.hpp
@@ -90,7 +90,7 @@ return_type_t<T_alpha, T_beta, T_precision> neg_binomial_2_log_glm_lpmf(
     return 0;
   }
 
-  if (!include_summand<propto, T_alpha, T_beta, T_precision>::value) {
+  if (!include_summand_b<propto, T_alpha, T_beta, T_precision>) {
     return 0;
   }
 
@@ -122,13 +122,13 @@ return_type_t<T_alpha, T_beta, T_precision> neg_binomial_2_log_glm_lpmf(
       = !is_constant_all<T_precision>::value || need_phi_derivative_sum;
   matrix_cl<double> phi_derivative_cl(
       need_phi_derivative ? (need_phi_derivative_sum ? wgs : N) : 0, 1);
-  const bool need_logp1 = include_summand<propto>::value;
-  const bool need_logp2 = include_summand<propto, T_precision>::value
+  const bool need_logp1 = include_summand_b<propto>;
+  const bool need_logp2 = include_summand_b<propto, T_precision>
                           && is_vector<T_precision>::value;
   const bool need_logp3
-      = include_summand<propto, T_alpha, T_beta, T_precision>::value;
-  const bool need_logp4 = include_summand<propto, T_alpha, T_beta>::value;
-  const bool need_logp5 = include_summand<propto, T_precision>::value;
+      = include_summand_b<propto, T_alpha, T_beta, T_precision>;
+  const bool need_logp4 = include_summand_b<propto, T_alpha, T_beta>;
+  const bool need_logp5 = include_summand_b<propto, T_precision>;
   const bool need_logp
       = need_logp1 || need_logp2 || need_logp3 || need_logp4 || need_logp5;
   matrix_cl<double> logp_cl(need_logp ? wgs : 0, 1);
@@ -157,7 +157,7 @@ return_type_t<T_alpha, T_beta, T_precision> neg_binomial_2_log_glm_lpmf(
     logp += logp_sum;
   }
 
-  if (include_summand<propto, T_precision>::value
+  if (include_summand_b<propto, T_precision>
       && !is_vector<T_precision>::value) {
     logp += N
             * (multiply_log(forward_as<double>(phi_val),

--- a/stan/math/opencl/prim/neg_binomial_2_log_glm_lpmf.hpp
+++ b/stan/math/opencl/prim/neg_binomial_2_log_glm_lpmf.hpp
@@ -123,8 +123,8 @@ return_type_t<T_alpha, T_beta, T_precision> neg_binomial_2_log_glm_lpmf(
   matrix_cl<double> phi_derivative_cl(
       need_phi_derivative ? (need_phi_derivative_sum ? wgs : N) : 0, 1);
   const bool need_logp1 = include_summand_b<propto>;
-  const bool need_logp2
-      = include_summand_b<propto, T_precision> && is_vector<T_precision>::value;
+  const bool need_logp
+      = include_summand_b<propto, T_precision> && is_vector<T_precision>;
   const bool need_logp3
       = include_summand_b<propto, T_alpha, T_beta, T_precision>;
   const bool need_logp4 = include_summand_b<propto, T_alpha, T_beta>;

--- a/stan/math/opencl/prim/neg_binomial_2_log_glm_lpmf.hpp
+++ b/stan/math/opencl/prim/neg_binomial_2_log_glm_lpmf.hpp
@@ -123,8 +123,8 @@ return_type_t<T_alpha, T_beta, T_precision> neg_binomial_2_log_glm_lpmf(
   matrix_cl<double> phi_derivative_cl(
       need_phi_derivative ? (need_phi_derivative_sum ? wgs : N) : 0, 1);
   const bool need_logp1 = include_summand_b<propto>;
-  const bool need_logp2 = include_summand_b<propto, T_precision>
-                          && is_vector<T_precision>::value;
+  const bool need_logp2
+      = include_summand_b<propto, T_precision> && is_vector<T_precision>::value;
   const bool need_logp3
       = include_summand_b<propto, T_alpha, T_beta, T_precision>;
   const bool need_logp4 = include_summand_b<propto, T_alpha, T_beta>;
@@ -157,8 +157,8 @@ return_type_t<T_alpha, T_beta, T_precision> neg_binomial_2_log_glm_lpmf(
     logp += logp_sum;
   }
 
-  if (include_summand_b<propto, T_precision>
-      && !is_vector<T_precision>::value) {
+  if (include_summand_b<propto,
+                        T_precision> && !is_vector<T_precision>::value) {
     logp += N
             * (multiply_log(forward_as<double>(phi_val),
                             forward_as<double>(phi_val))

--- a/stan/math/opencl/prim/normal_id_glm_lpdf.hpp
+++ b/stan/math/opencl/prim/normal_id_glm_lpdf.hpp
@@ -122,7 +122,7 @@ return_type_t<T_alpha, T_beta, T_scale> normal_id_glm_lpdf(
       = !is_constant_all<T_scale>::value && is_vector<T_scale>::value;
   matrix_cl<double> sigma_derivative_cl(need_sigma_derivative ? N : 0, 1);
   const bool need_log_sigma_sum
-      = include_summand_b<propto, T_scale>::value && is_vector<T_scale>;
+      = include_summand_b<propto, T_scale> && is_vector<T_scale>;
   matrix_cl<double> log_sigma_sum_cl(need_log_sigma_sum ? wgs : 0, 1);
 
   try {

--- a/stan/math/opencl/prim/normal_id_glm_lpdf.hpp
+++ b/stan/math/opencl/prim/normal_id_glm_lpdf.hpp
@@ -122,7 +122,7 @@ return_type_t<T_alpha, T_beta, T_scale> normal_id_glm_lpdf(
       = !is_constant_all<T_scale>::value && is_vector<T_scale>::value;
   matrix_cl<double> sigma_derivative_cl(need_sigma_derivative ? N : 0, 1);
   const bool need_log_sigma_sum
-      = include_summand_b<propto, T_scale> && is_vector<T_scale>;
+      = include_summand_b<propto, T_scale> && is_vector<T_scale>::value;
   matrix_cl<double> log_sigma_sum_cl(need_log_sigma_sum ? wgs : 0, 1);
 
   try {

--- a/stan/math/opencl/prim/normal_id_glm_lpdf.hpp
+++ b/stan/math/opencl/prim/normal_id_glm_lpdf.hpp
@@ -84,7 +84,7 @@ return_type_t<T_alpha, T_beta, T_scale> normal_id_glm_lpdf(
                      length(alpha));
   }
 
-  if (!include_summand<propto, T_alpha, T_beta, T_scale>::value) {
+  if (!include_summand_b<propto, T_alpha, T_beta, T_scale>) {
     return 0;
   }
 
@@ -122,7 +122,7 @@ return_type_t<T_alpha, T_beta, T_scale> normal_id_glm_lpdf(
       = !is_constant_all<T_scale>::value && is_vector<T_scale>::value;
   matrix_cl<double> sigma_derivative_cl(need_sigma_derivative ? N : 0, 1);
   const bool need_log_sigma_sum
-      = include_summand<propto, T_scale>::value && is_vector<T_scale>::value;
+      = include_summand_b<propto, T_scale>::value && is_vector<T_scale>;
   matrix_cl<double> log_sigma_sum_cl(need_log_sigma_sum ? wgs : 0, 1);
 
   try {
@@ -180,17 +180,17 @@ return_type_t<T_alpha, T_beta, T_scale> normal_id_glm_lpdf(
 
   // Compute log probability.
   T_partials_return logp(0.0);
-  if (include_summand<propto>::value) {
+  if (include_summand_b<propto>) {
     logp += NEG_LOG_SQRT_TWO_PI * N;
   }
-  if (include_summand<propto, T_scale>::value) {
+  if (include_summand_b<propto, T_scale>) {
     if (is_vector<T_scale>::value) {
       logp -= sum(from_matrix_cl(log_sigma_sum_cl));
     } else {
       logp -= N * log(forward_as<double>(sigma_val));
     }
   }
-  if (include_summand<propto, T_alpha, T_beta, T_scale>::value) {
+  if (include_summand_b<propto, T_alpha, T_beta, T_scale>) {
     logp -= 0.5 * y_scaled_sq_sum;
   }
   return ops_partials.build(logp);

--- a/stan/math/opencl/prim/ordered_logistic_glm_lpmf.hpp
+++ b/stan/math/opencl/prim/ordered_logistic_glm_lpmf.hpp
@@ -79,7 +79,7 @@ ordered_logistic_glm_lpmf(
     return 0;
   }
 
-  if (!include_summand<propto, T_beta_scalar, T_cuts_scalar>::value) {
+  if (!include_summand_b<propto, T_beta_scalar, T_cuts_scalar>) {
     return 0;
   }
 

--- a/stan/math/opencl/prim/poisson_log_glm_lpmf.hpp
+++ b/stan/math/opencl/prim/poisson_log_glm_lpmf.hpp
@@ -67,7 +67,7 @@ return_type_t<T_alpha, T_beta> poisson_log_glm_lpmf(
     return 0;
   }
 
-  if (!include_summand<propto, T_alpha, T_beta>::value) {
+  if (!include_summand_b<propto, T_alpha, T_beta>) {
     return 0;
   }
 
@@ -88,8 +88,8 @@ return_type_t<T_alpha, T_beta> poisson_log_glm_lpmf(
 
   matrix_cl<double> theta_derivative_cl(N, 1);
   matrix_cl<double> theta_derivative_sum_cl(wgs, 1);
-  const bool need_logp1 = include_summand<propto>::value;
-  const bool need_logp2 = include_summand<propto, T_partials_return>::value;
+  const bool need_logp1 = include_summand_b<propto>;
+  const bool need_logp2 = include_summand_b<propto, T_partials_return>;
   matrix_cl<double> logp_cl((need_logp1 || need_logp2) ? wgs : 0, 1);
 
   try {

--- a/stan/math/prim/mat/prob/bernoulli_logit_glm_lpmf.hpp
+++ b/stan/math/prim/mat/prob/bernoulli_logit_glm_lpmf.hpp
@@ -81,7 +81,7 @@ return_type_t<T_x_scalar, T_alpha, T_beta> bernoulli_logit_glm_lpmf(
     return 0;
   }
 
-  if (!include_summand<propto, T_x_scalar, T_alpha, T_beta>::value) {
+  if (!include_summand_b<propto, T_x_scalar, T_alpha, T_beta>) {
     return 0;
   }
 

--- a/stan/math/prim/mat/prob/categorical_logit_glm_lpmf.hpp
+++ b/stan/math/prim/mat/prob/categorical_logit_glm_lpmf.hpp
@@ -67,8 +67,7 @@ categorical_logit_glm_lpmf(
     return 0;
   }
 
-  if (!include_summand<propto, T_x_scalar, T_alpha_scalar,
-                       T_beta_scalar>::value) {
+  if (!include_summand_b<propto, T_x_scalar, T_alpha_scalar, T_beta_scalar>) {
     return 0;
   }
 

--- a/stan/math/prim/mat/prob/categorical_logit_lpmf.hpp
+++ b/stan/math/prim/mat/prob/categorical_logit_lpmf.hpp
@@ -23,7 +23,7 @@ return_type_t<T_prob> categorical_logit_lpmf(
                 beta.size());
   check_finite(function, "log odds parameter", beta);
 
-  if (!include_summand<propto, T_prob>::value) {
+  if (!include_summand_b<propto, T_prob>) {
     return 0.0;
   }
 
@@ -49,7 +49,7 @@ return_type_t<T_prob> categorical_logit_lpmf(
   }
   check_finite(function, "log odds parameter", beta);
 
-  if (!include_summand<propto, T_prob>::value) {
+  if (!include_summand_b<propto, T_prob>) {
     return 0.0;
   }
 

--- a/stan/math/prim/mat/prob/categorical_lpmf.hpp
+++ b/stan/math/prim/mat/prob/categorical_lpmf.hpp
@@ -24,7 +24,7 @@ return_type_t<T_prob> categorical_lpmf(
   check_bounded(function, "Number of categories", n, lb, theta.size());
   check_simplex(function, "Probabilities parameter", theta);
 
-  if (include_summand<propto, T_prob>::value) {
+  if (include_summand_b<propto, T_prob>) {
     return log(theta(n - 1));
   }
   return 0.0;
@@ -55,7 +55,7 @@ return_type_t<T_prob> categorical_lpmf(
 
   check_simplex(function, "Probabilities parameter", theta);
 
-  if (!include_summand<propto, T_prob>::value) {
+  if (!include_summand_b<propto, T_prob>) {
     return 0.0;
   }
 

--- a/stan/math/prim/mat/prob/dirichlet_lpdf.hpp
+++ b/stan/math/prim/mat/prob/dirichlet_lpdf.hpp
@@ -84,7 +84,7 @@ return_type_t<T_prob, T_prior_size> dirichlet_lpdf(const T_prob& theta,
 
   T_partials_return lp(0.0);
 
-  if (include_summand<propto, T_prior_size>::value) {
+  if (include_summand_b<propto, T_prior_size>) {
     lp += (lgamma(alpha_dbl.colwise().sum())
            - lgamma(alpha_dbl).colwise().sum())
               .sum();
@@ -93,7 +93,7 @@ return_type_t<T_prob, T_prior_size> dirichlet_lpdf(const T_prob& theta,
   const auto& alpha_m_1 = (alpha_dbl.array() - 1.0);
   const auto& theta_log = theta_dbl.array().log();
 
-  if (include_summand<propto, T_prob, T_prior_size>::value) {
+  if (include_summand_b<propto, T_prob, T_prior_size>) {
     lp += (theta_log * alpha_m_1).sum();
   }
 

--- a/stan/math/prim/mat/prob/gaussian_dlm_obs_lpdf.hpp
+++ b/stan/math/prim/mat/prob/gaussian_dlm_obs_lpdf.hpp
@@ -109,11 +109,11 @@ gaussian_dlm_obs_lpdf(
   }
 
   T_lp lp(0);
-  if (include_summand<propto>::value) {
+  if (include_summand_b<propto>) {
     lp -= 0.5 * LOG_TWO_PI * r * T;
   }
 
-  if (include_summand<propto, T_y, T_F, T_G, T_V, T_W, T_m0, T_C0>::value) {
+  if (include_summand_b<propto, T_y, T_F, T_G, T_V, T_W, T_m0, T_C0>) {
     Eigen::Matrix<T_lp, Eigen::Dynamic, 1> m(n);
     Eigen::Matrix<T_lp, Eigen::Dynamic, Eigen::Dynamic> C(n, n);
 
@@ -263,11 +263,11 @@ gaussian_dlm_obs_lpdf(
   }
 
   T_lp lp(0);
-  if (include_summand<propto>::value) {
+  if (include_summand_b<propto>) {
     lp += 0.5 * NEG_LOG_TWO_PI * r * T;
   }
 
-  if (include_summand<propto, T_y, T_F, T_G, T_V, T_W, T_m0, T_C0>::value) {
+  if (include_summand_b<propto, T_y, T_F, T_G, T_V, T_W, T_m0, T_C0>) {
     T_lp f;
     T_lp Q;
     T_lp Q_inv;

--- a/stan/math/prim/mat/prob/inv_wishart_lpdf.hpp
+++ b/stan/math/prim/mat/prob/inv_wishart_lpdf.hpp
@@ -67,16 +67,16 @@ return_type_t<T_y, T_dof, T_scale> inv_wishart_lpdf(
   LDLT_factor<T_scale, Eigen::Dynamic, Eigen::Dynamic> ldlt_S(S);
   check_ldlt_factor(function, "LDLT_Factor of scale parameter", ldlt_S);
 
-  if (include_summand<propto, T_dof>::value) {
+  if (include_summand_b<propto, T_dof>) {
     lp -= lmgamma(k, 0.5 * nu);
   }
-  if (include_summand<propto, T_dof, T_scale>::value) {
+  if (include_summand_b<propto, T_dof, T_scale>) {
     lp += 0.5 * nu * log_determinant_ldlt(ldlt_S);
   }
-  if (include_summand<propto, T_y, T_dof, T_scale>::value) {
+  if (include_summand_b<propto, T_y, T_dof, T_scale>) {
     lp -= 0.5 * (nu + k + 1.0) * log_determinant_ldlt(ldlt_W);
   }
-  if (include_summand<propto, T_y, T_scale>::value) {
+  if (include_summand_b<propto, T_y, T_scale>) {
     //    L = crossprod(mdivide_left_tri_low(L));
     //    Eigen::Matrix<T_y, Eigen::Dynamic, 1> W_inv_vec = Eigen::Map<
     //      const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic> >(
@@ -93,7 +93,7 @@ return_type_t<T_y, T_dof, T_scale> inv_wishart_lpdf(
                 S.template selfadjointView<Eigen::Lower>())));
     lp -= 0.5 * trace(Winv_S);
   }
-  if (include_summand<propto, T_dof, T_scale>::value) {
+  if (include_summand_b<propto, T_dof, T_scale>) {
     lp += nu * k * NEG_LOG_TWO_OVER_TWO;
   }
   return lp;

--- a/stan/math/prim/mat/prob/lkj_corr_cholesky_lpdf.hpp
+++ b/stan/math/prim/mat/prob/lkj_corr_cholesky_lpdf.hpp
@@ -28,10 +28,10 @@ return_type_t<T_covar, T_shape> lkj_corr_cholesky_lpdf(
     return 0.0;
   }
 
-  if (include_summand<propto, T_shape>::value) {
+  if (include_summand_b<propto, T_shape>) {
     lp += do_lkj_constant(eta, K);
   }
-  if (include_summand<propto, T_covar, T_shape>::value) {
+  if (include_summand_b<propto, T_covar, T_shape>) {
     const int Km1 = K - 1;
     Eigen::Matrix<T_covar, Eigen::Dynamic, 1> log_diagonals
         = L.diagonal().tail(Km1).array().log();

--- a/stan/math/prim/mat/prob/lkj_corr_lpdf.hpp
+++ b/stan/math/prim/mat/prob/lkj_corr_lpdf.hpp
@@ -58,7 +58,7 @@ return_type_t<T_y, T_shape> lkj_corr_lpdf(
     return 0.0;
   }
 
-  if (include_summand<propto, T_shape>::value) {
+  if (include_summand_b<propto, T_shape>) {
     lp += do_lkj_constant(eta, K);
   }
 
@@ -67,7 +67,7 @@ return_type_t<T_y, T_shape> lkj_corr_lpdf(
     return lp;
   }
 
-  if (!include_summand<propto, T_y, T_shape>::value) {
+  if (!include_summand_b<propto, T_y, T_shape>) {
     return lp;
   }
 

--- a/stan/math/prim/mat/prob/matrix_normal_prec_lpdf.hpp
+++ b/stan/math/prim/mat/prob/matrix_normal_prec_lpdf.hpp
@@ -65,19 +65,19 @@ return_type_t<T_y, T_Mu, T_Sigma, T_D> matrix_normal_prec_lpdf(
   check_finite(function, "Location parameter", Mu);
   check_finite(function, "Random variable", y);
 
-  if (include_summand<propto>::value) {
+  if (include_summand_b<propto>) {
     lp += NEG_LOG_SQRT_TWO_PI * y.cols() * y.rows();
   }
 
-  if (include_summand<propto, T_Sigma>::value) {
+  if (include_summand_b<propto, T_Sigma>) {
     lp += log_determinant_ldlt(ldlt_Sigma) * (0.5 * y.rows());
   }
 
-  if (include_summand<propto, T_D>::value) {
+  if (include_summand_b<propto, T_D>) {
     lp += log_determinant_ldlt(ldlt_D) * (0.5 * y.cols());
   }
 
-  if (include_summand<propto, T_y, T_Mu, T_Sigma, T_D>::value) {
+  if (include_summand_b<propto, T_y, T_Mu, T_Sigma, T_D>) {
     lp -= 0.5 * trace_gen_quad_form(D, Sigma, subtract(y, Mu));
   }
   return lp;

--- a/stan/math/prim/mat/prob/multi_gp_cholesky_lpdf.hpp
+++ b/stan/math/prim/mat/prob/multi_gp_cholesky_lpdf.hpp
@@ -55,19 +55,19 @@ return_type_t<T_y, T_covar, T_w> multi_gp_cholesky_lpdf(
   }
 
   T_lp lp(0);
-  if (include_summand<propto>::value) {
+  if (include_summand_b<propto>) {
     lp += NEG_LOG_SQRT_TWO_PI * y.rows() * y.cols();
   }
 
-  if (include_summand<propto, T_covar>::value) {
+  if (include_summand_b<propto, T_covar>) {
     lp -= L.diagonal().array().log().sum() * y.rows();
   }
 
-  if (include_summand<propto, T_w>::value) {
+  if (include_summand_b<propto, T_w>) {
     lp += 0.5 * y.cols() * sum(log(w));
   }
 
-  if (include_summand<propto, T_y, T_w, T_covar>::value) {
+  if (include_summand_b<propto, T_y, T_w, T_covar>) {
     T_lp sum_lp_vec(0);
     for (int i = 0; i < y.rows(); i++) {
       Eigen::Matrix<T_y, Eigen::Dynamic, 1> y_row(y.row(i));

--- a/stan/math/prim/mat/prob/multi_gp_lpdf.hpp
+++ b/stan/math/prim/mat/prob/multi_gp_lpdf.hpp
@@ -61,19 +61,19 @@ return_type_t<T_y, T_covar, T_w> multi_gp_lpdf(
     return lp;
   }
 
-  if (include_summand<propto>::value) {
+  if (include_summand_b<propto>) {
     lp += NEG_LOG_SQRT_TWO_PI * y.rows() * y.cols();
   }
 
-  if (include_summand<propto, T_covar>::value) {
+  if (include_summand_b<propto, T_covar>) {
     lp -= 0.5 * log_determinant_ldlt(ldlt_Sigma) * y.rows();
   }
 
-  if (include_summand<propto, T_w>::value) {
+  if (include_summand_b<propto, T_w>) {
     lp += (0.5 * y.cols()) * sum(log(w));
   }
 
-  if (include_summand<propto, T_y, T_w, T_covar>::value) {
+  if (include_summand_b<propto, T_y, T_w, T_covar>) {
     Eigen::Matrix<T_w, Eigen::Dynamic, Eigen::Dynamic> w_mat(w.asDiagonal());
     Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic> yT(y.transpose());
     lp -= 0.5 * trace_gen_inv_quad_form_ldlt(w_mat, ldlt_Sigma, yT);

--- a/stan/math/prim/mat/prob/multi_normal_cholesky_lpdf.hpp
+++ b/stan/math/prim/mat/prob/multi_normal_cholesky_lpdf.hpp
@@ -110,14 +110,14 @@ return_type_t<T_y, T_loc, T_covar> multi_normal_cholesky_lpdf(
   T_partials_return logp(0);
   operands_and_partials<T_y, T_loc, T_covar> ops_partials(y, mu, L);
 
-  if (include_summand<propto>::value) {
+  if (include_summand_b<propto>) {
     logp += NEG_LOG_SQRT_TWO_PI * size_y * size_vec;
   }
 
   const matrix_partials_t inv_L_dbl
       = mdivide_left_tri<Eigen::Lower>(value_of(L));
 
-  if (include_summand<propto, T_y, T_loc, T_covar_elem>::value) {
+  if (include_summand_b<propto, T_y, T_loc, T_covar_elem>) {
     for (size_t i = 0; i < size_vec; i++) {
       vector_partials_t y_minus_mu_dbl(size_y);
       for (int j = 0; j < size_y; j++) {
@@ -149,7 +149,7 @@ return_type_t<T_y, T_loc, T_covar> multi_normal_cholesky_lpdf(
     }
   }
 
-  if (include_summand<propto, T_covar_elem>::value) {
+  if (include_summand_b<propto, T_covar_elem>) {
     logp += inv_L_dbl.diagonal().array().log().sum() * size_vec;
     if (!is_constant_all<T_covar>::value) {
       ops_partials.edge3_.partials_ -= size_vec * inv_L_dbl.transpose();

--- a/stan/math/prim/mat/prob/multi_normal_lpdf.hpp
+++ b/stan/math/prim/mat/prob/multi_normal_lpdf.hpp
@@ -96,15 +96,15 @@ return_type_t<T_y, T_loc, T_covar> multi_normal_lpdf(const T_y& y,
     return lp;
   }
 
-  if (include_summand<propto>::value) {
+  if (include_summand_b<propto>) {
     lp += NEG_LOG_SQRT_TWO_PI * size_y * size_vec;
   }
 
-  if (include_summand<propto, T_covar_elem>::value) {
+  if (include_summand_b<propto, T_covar_elem>) {
     lp -= 0.5 * log_determinant_ldlt(ldlt_Sigma) * size_vec;
   }
 
-  if (include_summand<propto, T_y, T_loc, T_covar_elem>::value) {
+  if (include_summand_b<propto, T_y, T_loc, T_covar_elem>) {
     lp_type sum_lp_vec(0.0);
     for (size_t i = 0; i < size_vec; i++) {
       Eigen::Matrix<return_type_t<T_y, T_loc>, Dynamic, 1> y_minus_mu(size_y);

--- a/stan/math/prim/mat/prob/multi_normal_prec_lpdf.hpp
+++ b/stan/math/prim/mat/prob/multi_normal_prec_lpdf.hpp
@@ -96,15 +96,15 @@ return_type_t<T_y, T_loc, T_covar> multi_normal_prec_lpdf(
     return lp;
   }
 
-  if (include_summand<propto, T_covar_elem>::value) {
+  if (include_summand_b<propto, T_covar_elem>) {
     lp += 0.5 * log_determinant_ldlt(ldlt_Sigma) * size_vec;
   }
 
-  if (include_summand<propto>::value) {
+  if (include_summand_b<propto>) {
     lp += NEG_LOG_SQRT_TWO_PI * size_y * size_vec;
   }
 
-  if (include_summand<propto, T_y, T_loc, T_covar_elem>::value) {
+  if (include_summand_b<propto, T_y, T_loc, T_covar_elem>) {
     lp_type sum_lp_vec(0.0);
     for (size_t i = 0; i < size_vec; i++) {
       Eigen::Matrix<return_type_t<T_y, T_loc>, Eigen::Dynamic, 1> y_minus_mu(

--- a/stan/math/prim/mat/prob/multi_student_t_lpdf.hpp
+++ b/stan/math/prim/mat/prob/multi_student_t_lpdf.hpp
@@ -110,23 +110,23 @@ return_type_t<T_y, T_dof, T_loc, T_scale> multi_student_t_lpdf(
 
   lp_type lp(0);
 
-  if (include_summand<propto, T_dof>::value) {
+  if (include_summand_b<propto, T_dof>) {
     lp += lgamma(0.5 * (nu + size_y)) * size_vec;
     lp -= lgamma(0.5 * nu) * size_vec;
     lp -= (0.5 * size_y) * log(nu) * size_vec;
   }
 
-  if (include_summand<propto>::value) {
+  if (include_summand_b<propto>) {
     lp -= (0.5 * size_y) * LOG_PI * size_vec;
   }
 
   using Eigen::Array;
 
-  if (include_summand<propto, T_scale_elem>::value) {
+  if (include_summand_b<propto, T_scale_elem>) {
     lp -= 0.5 * log_determinant_ldlt(ldlt_Sigma) * size_vec;
   }
 
-  if (include_summand<propto, T_y, T_dof, T_loc, T_scale_elem>::value) {
+  if (include_summand_b<propto, T_y, T_dof, T_loc, T_scale_elem>) {
     lp_type sum_lp_vec(0.0);
     for (size_t i = 0; i < size_vec; i++) {
       Eigen::Matrix<return_type_t<T_y, T_loc>, Eigen::Dynamic, 1> y_minus_mu(

--- a/stan/math/prim/mat/prob/multinomial_lpmf.hpp
+++ b/stan/math/prim/mat/prob/multinomial_lpmf.hpp
@@ -25,7 +25,7 @@ return_type_t<T_prob> multinomial_lpmf(
   check_size_match(function, "Size of number of trials variable", ns.size(),
                    "rows of probabilities parameter", theta.rows());
 
-  if (include_summand<propto>::value) {
+  if (include_summand_b<propto>) {
     double sum = 1.0;
     for (int n : ns) {
       sum += n;
@@ -35,7 +35,7 @@ return_type_t<T_prob> multinomial_lpmf(
       lp -= lgamma(n + 1.0);
     }
   }
-  if (include_summand<propto, T_prob>::value) {
+  if (include_summand_b<propto, T_prob>) {
     for (unsigned int i = 0; i < ns.size(); ++i) {
       lp += multiply_log(ns[i], theta[i]);
     }

--- a/stan/math/prim/mat/prob/neg_binomial_2_log_glm_lpmf.hpp
+++ b/stan/math/prim/mat/prob/neg_binomial_2_log_glm_lpmf.hpp
@@ -100,8 +100,7 @@ neg_binomial_2_log_glm_lpmf(
     return 0;
   }
 
-  if (!include_summand<propto, T_x_scalar, T_alpha, T_beta,
-                       T_precision>::value) {
+  if (!include_summand_b<propto, T_x_scalar, T_alpha, T_beta, T_precision>) {
     return 0;
   }
 
@@ -138,14 +137,14 @@ neg_binomial_2_log_glm_lpmf(
   T_sum_val y_plus_phi = y_arr + phi_arr;
 
   // Compute the log-density.
-  if (include_summand<propto>::value) {
+  if (include_summand_b<propto>) {
     if (is_vector<T_y>::value) {
       logp -= sum(lgamma(y_arr + 1));
     } else {
       logp -= sum(lgamma(y_arr + 1)) * N_instances;
     }
   }
-  if (include_summand<propto, T_precision>::value) {
+  if (include_summand_b<propto, T_precision>) {
     if (is_vector<T_precision>::value) {
       scalar_seq_view<decltype(phi_val)> phi_vec(phi_val);
       for (size_t n = 0; n < N_instances; ++n) {
@@ -160,10 +159,10 @@ neg_binomial_2_log_glm_lpmf(
   }
   logp -= sum(y_plus_phi * logsumexp_theta_logphi);
 
-  if (include_summand<propto, T_x_scalar, T_alpha, T_beta>::value) {
+  if (include_summand_b<propto, T_x_scalar, T_alpha, T_beta>) {
     logp += sum(y_arr * theta);
   }
-  if (include_summand<propto, T_precision>::value) {
+  if (include_summand_b<propto, T_precision>) {
     if (is_vector<T_y>::value || is_vector<T_precision>::value) {
       logp += sum(lgamma(y_plus_phi));
     } else {

--- a/stan/math/prim/mat/prob/normal_id_glm_lpdf.hpp
+++ b/stan/math/prim/mat/prob/normal_id_glm_lpdf.hpp
@@ -86,8 +86,7 @@ return_type_t<T_y, T_x_scalar, T_alpha, T_beta, T_scale> normal_id_glm_lpdf(
     return 0;
   }
 
-  if (!include_summand<propto, T_y, T_x_scalar, T_alpha, T_beta,
-                       T_scale>::value) {
+  if (!include_summand_b<propto, T_y, T_x_scalar, T_alpha, T_beta, T_scale>) {
     return 0;
   }
 
@@ -184,18 +183,17 @@ return_type_t<T_y, T_x_scalar, T_alpha, T_beta, T_scale> normal_id_glm_lpdf(
 
   // Compute log probability.
   T_partials_return logp(0.0);
-  if (include_summand<propto>::value) {
+  if (include_summand_b<propto>) {
     logp += NEG_LOG_SQRT_TWO_PI * N_instances;
   }
-  if (include_summand<propto, T_scale>::value) {
+  if (include_summand_b<propto, T_scale>) {
     if (is_vector<T_scale>::value) {
       logp -= sum(log(sigma_val_vec));
     } else {
       logp -= N_instances * log(forward_as<double>(sigma_val));
     }
   }
-  if (include_summand<propto, T_y, T_x_scalar, T_alpha, T_beta,
-                      T_scale>::value) {
+  if (include_summand_b<propto, T_y, T_x_scalar, T_alpha, T_beta, T_scale>) {
     logp -= 0.5 * y_scaled_sq_sum;
   }
   return ops_partials.build(logp);

--- a/stan/math/prim/mat/prob/ordered_logistic_glm_lpmf.hpp
+++ b/stan/math/prim/mat/prob/ordered_logistic_glm_lpmf.hpp
@@ -83,7 +83,7 @@ ordered_logistic_glm_lpmf(
   if (size_zero(y, cuts))
     return 0;
 
-  if (!include_summand<propto, T_x_scalar, T_beta_scalar, T_cuts_scalar>::value)
+  if (!include_summand_b<propto, T_x_scalar, T_beta_scalar, T_cuts_scalar>)
     return 0;
 
   const auto& x_val = value_of_rec(x);

--- a/stan/math/prim/mat/prob/poisson_log_glm_lpmf.hpp
+++ b/stan/math/prim/mat/prob/poisson_log_glm_lpmf.hpp
@@ -77,7 +77,7 @@ return_type_t<T_x_scalar, T_alpha, T_beta> poisson_log_glm_lpmf(
     return 0;
   }
 
-  if (!include_summand<propto, T_x_scalar, T_alpha, T_beta>::value) {
+  if (!include_summand_b<propto, T_x_scalar, T_alpha, T_beta>) {
     return 0;
   }
 
@@ -109,14 +109,14 @@ return_type_t<T_x_scalar, T_alpha, T_beta> poisson_log_glm_lpmf(
     check_finite(function, "Intercept", alpha);
     check_finite(function, "Matrix of independent variables", theta);
   }
-  if (include_summand<propto>::value) {
+  if (include_summand_b<propto>) {
     if (is_vector<T_y>::value) {
       logp -= sum(lgamma(as_array_or_scalar(y_val_vec) + 1));
     } else {
       logp -= lgamma(forward_as<double>(y_val) + 1);
     }
   }
-  if (include_summand<propto, T_partials_return>::value) {
+  if (include_summand_b<propto, T_partials_return>) {
     logp += sum(as_array_or_scalar(y_val_vec) * theta.array()
                 - exp(theta.array()));
   }

--- a/stan/math/prim/mat/prob/wishart_lpdf.hpp
+++ b/stan/math/prim/mat/prob/wishart_lpdf.hpp
@@ -70,26 +70,26 @@ return_type_t<T_y, T_dof, T_scale> wishart_lpdf(
   LDLT_factor<T_scale, Eigen::Dynamic, Eigen::Dynamic> ldlt_S(S);
   check_ldlt_factor(function, "LDLT_Factor of scale parameter", ldlt_S);
 
-  if (include_summand<propto, T_dof>::value) {
+  if (include_summand_b<propto, T_dof>) {
     lp += nu * k * NEG_LOG_TWO_OVER_TWO;
   }
 
-  if (include_summand<propto, T_dof>::value) {
+  if (include_summand_b<propto, T_dof>) {
     lp -= lmgamma(k, 0.5 * nu);
   }
 
-  if (include_summand<propto, T_dof, T_scale>::value) {
+  if (include_summand_b<propto, T_dof, T_scale>) {
     lp -= 0.5 * nu * log_determinant_ldlt(ldlt_S);
   }
 
-  if (include_summand<propto, T_scale, T_y>::value) {
+  if (include_summand_b<propto, T_scale, T_y>) {
     Matrix<return_type_t<T_y, T_scale>, Dynamic, Dynamic> Sinv_W(
         mdivide_left_ldlt(ldlt_S, static_cast<Matrix<T_y, Dynamic, Dynamic> >(
                                       W.template selfadjointView<Lower>())));
     lp -= 0.5 * trace(Sinv_W);
   }
 
-  if (include_summand<propto, T_y, T_dof>::value && nu != (k + 1)) {
+  if (include_summand_b<propto, T_y, T_dof> && nu != (k + 1)) {
     lp += 0.5 * (nu - k - 1.0) * log_determinant_ldlt(ldlt_W);
   }
   return lp;

--- a/stan/math/prim/meta/include_summand.hpp
+++ b/stan/math/prim/meta/include_summand.hpp
@@ -49,8 +49,10 @@ struct include_summand<propto, T>
           !propto
           || !stan::is_constant_all<typename scalar_type<T>::type>::value)> {};
 
-}  // namespace math
+template <bool propto, typename... T_pack>
+constexpr bool include_summand_b = include_summand<propto, T_pack...>::value;
 
+}  // namespace math
 }  // namespace stan
 
 #endif

--- a/stan/math/prim/scal/prob/bernoulli_logit_lpmf.hpp
+++ b/stan/math/prim/scal/prob/bernoulli_logit_lpmf.hpp
@@ -43,7 +43,7 @@ return_type_t<T_prob> bernoulli_logit_lpmf(const T_n& n, const T_prob& theta) {
   check_consistent_sizes(function, "Random variable", n,
                          "Probability parameter", theta);
 
-  if (!include_summand<propto, T_prob>::value) {
+  if (!include_summand_b<propto, T_prob>) {
     return 0.0;
   }
 

--- a/stan/math/prim/scal/prob/bernoulli_lpmf.hpp
+++ b/stan/math/prim/scal/prob/bernoulli_lpmf.hpp
@@ -44,7 +44,7 @@ return_type_t<T_prob> bernoulli_lpmf(const T_n& n, const T_prob& theta) {
   check_consistent_sizes(function, "Random variable", n,
                          "Probability parameter", theta);
 
-  if (!include_summand<propto, T_prob>::value) {
+  if (!include_summand_b<propto, T_prob>) {
     return 0.0;
   }
 

--- a/stan/math/prim/scal/prob/beta_binomial_lpmf.hpp
+++ b/stan/math/prim/scal/prob/beta_binomial_lpmf.hpp
@@ -56,7 +56,7 @@ return_type_t<T_size1, T_size2> beta_binomial_lpmf(const T_n& n, const T_N& N,
                          "First prior sample size parameter", alpha,
                          "Second prior sample size parameter", beta);
 
-  if (!include_summand<propto, T_size1, T_size2>::value) {
+  if (!include_summand_b<propto, T_size1, T_size2>) {
     return 0.0;
   }
 
@@ -74,7 +74,7 @@ return_type_t<T_size1, T_size2> beta_binomial_lpmf(const T_n& n, const T_N& N,
     }
   }
 
-  if (include_summand<propto>::value) {
+  if (include_summand_b<propto>) {
     for (size_t i = 0; i < size; i++) {
       // normalizing constant
       logp += binomial_coefficient_log(N_vec[i], n_vec[i]);

--- a/stan/math/prim/scal/prob/beta_lpdf.hpp
+++ b/stan/math/prim/scal/prob/beta_lpdf.hpp
@@ -77,11 +77,11 @@ return_type_t<T_y, T_scale_succ, T_scale_fail> beta_lpdf(
   operands_and_partials<T_y, T_scale_succ, T_scale_fail> ops_partials(y, alpha,
                                                                       beta);
 
-  VectorBuilder<include_summand_b<propto, T_y, T_scale_succ>,
-                T_partials_return, T_y>
+  VectorBuilder<include_summand_b<propto, T_y, T_scale_succ>, T_partials_return,
+                T_y>
       log_y(length(y));
-  VectorBuilder<include_summand_b<propto, T_y, T_scale_fail>,
-                T_partials_return, T_y>
+  VectorBuilder<include_summand_b<propto, T_y, T_scale_fail>, T_partials_return,
+                T_y>
       log1m_y(length(y));
 
   for (size_t n = 0; n < length(y); n++) {

--- a/stan/math/prim/scal/prob/beta_lpdf.hpp
+++ b/stan/math/prim/scal/prob/beta_lpdf.hpp
@@ -57,7 +57,7 @@ return_type_t<T_y, T_scale_succ, T_scale_fail> beta_lpdf(
   if (size_zero(y, alpha, beta)) {
     return 0;
   }
-  if (!include_summand<propto, T_y, T_scale_succ, T_scale_fail>::value) {
+  if (!include_summand_b<propto, T_y, T_scale_succ, T_scale_fail>) {
     return 0;
   }
 
@@ -77,30 +77,30 @@ return_type_t<T_y, T_scale_succ, T_scale_fail> beta_lpdf(
   operands_and_partials<T_y, T_scale_succ, T_scale_fail> ops_partials(y, alpha,
                                                                       beta);
 
-  VectorBuilder<include_summand<propto, T_y, T_scale_succ>::value,
+  VectorBuilder<include_summand_b<propto, T_y, T_scale_succ>,
                 T_partials_return, T_y>
       log_y(length(y));
-  VectorBuilder<include_summand<propto, T_y, T_scale_fail>::value,
+  VectorBuilder<include_summand_b<propto, T_y, T_scale_fail>,
                 T_partials_return, T_y>
       log1m_y(length(y));
 
   for (size_t n = 0; n < length(y); n++) {
-    if (include_summand<propto, T_y, T_scale_succ>::value) {
+    if (include_summand_b<propto, T_y, T_scale_succ>) {
       log_y[n] = log(value_of(y_vec[n]));
     }
-    if (include_summand<propto, T_y, T_scale_fail>::value) {
+    if (include_summand_b<propto, T_y, T_scale_fail>) {
       log1m_y[n] = log1m(value_of(y_vec[n]));
     }
   }
 
-  VectorBuilder<include_summand<propto, T_scale_succ>::value, T_partials_return,
+  VectorBuilder<include_summand_b<propto, T_scale_succ>, T_partials_return,
                 T_scale_succ>
       lgamma_alpha(length(alpha));
   VectorBuilder<!is_constant_all<T_scale_succ>::value, T_partials_return,
                 T_scale_succ>
       digamma_alpha(length(alpha));
   for (size_t n = 0; n < length(alpha); n++) {
-    if (include_summand<propto, T_scale_succ>::value) {
+    if (include_summand_b<propto, T_scale_succ>) {
       lgamma_alpha[n] = lgamma(value_of(alpha_vec[n]));
     }
     if (!is_constant_all<T_scale_succ>::value) {
@@ -108,7 +108,7 @@ return_type_t<T_y, T_scale_succ, T_scale_fail> beta_lpdf(
     }
   }
 
-  VectorBuilder<include_summand<propto, T_scale_fail>::value, T_partials_return,
+  VectorBuilder<include_summand_b<propto, T_scale_fail>, T_partials_return,
                 T_scale_fail>
       lgamma_beta(length(beta));
   VectorBuilder<!is_constant_all<T_scale_fail>::value, T_partials_return,
@@ -116,7 +116,7 @@ return_type_t<T_y, T_scale_succ, T_scale_fail> beta_lpdf(
       digamma_beta(length(beta));
 
   for (size_t n = 0; n < length(beta); n++) {
-    if (include_summand<propto, T_scale_fail>::value) {
+    if (include_summand_b<propto, T_scale_fail>) {
       lgamma_beta[n] = lgamma(value_of(beta_vec[n]));
     }
     if (!is_constant_all<T_scale_fail>::value) {
@@ -124,7 +124,7 @@ return_type_t<T_y, T_scale_succ, T_scale_fail> beta_lpdf(
     }
   }
 
-  VectorBuilder<include_summand<propto, T_scale_succ, T_scale_fail>::value,
+  VectorBuilder<include_summand_b<propto, T_scale_succ, T_scale_fail>,
                 T_partials_return, T_scale_succ, T_scale_fail>
       lgamma_alpha_beta(max_size(alpha, beta));
 
@@ -135,7 +135,7 @@ return_type_t<T_y, T_scale_succ, T_scale_fail> beta_lpdf(
   for (size_t n = 0; n < max_size(alpha, beta); n++) {
     const T_partials_return alpha_beta
         = value_of(alpha_vec[n]) + value_of(beta_vec[n]);
-    if (include_summand<propto, T_scale_succ, T_scale_fail>::value) {
+    if (include_summand_b<propto, T_scale_succ, T_scale_fail>) {
       lgamma_alpha_beta[n] = lgamma(alpha_beta);
     }
     if (!is_constant_all<T_scale_succ, T_scale_fail>::value) {
@@ -148,19 +148,19 @@ return_type_t<T_y, T_scale_succ, T_scale_fail> beta_lpdf(
     const T_partials_return alpha_dbl = value_of(alpha_vec[n]);
     const T_partials_return beta_dbl = value_of(beta_vec[n]);
 
-    if (include_summand<propto, T_scale_succ, T_scale_fail>::value) {
+    if (include_summand_b<propto, T_scale_succ, T_scale_fail>) {
       logp += lgamma_alpha_beta[n];
     }
-    if (include_summand<propto, T_scale_succ>::value) {
+    if (include_summand_b<propto, T_scale_succ>) {
       logp -= lgamma_alpha[n];
     }
-    if (include_summand<propto, T_scale_fail>::value) {
+    if (include_summand_b<propto, T_scale_fail>) {
       logp -= lgamma_beta[n];
     }
-    if (include_summand<propto, T_y, T_scale_succ>::value) {
+    if (include_summand_b<propto, T_y, T_scale_succ>) {
       logp += (alpha_dbl - 1.0) * log_y[n];
     }
-    if (include_summand<propto, T_y, T_scale_fail>::value) {
+    if (include_summand_b<propto, T_y, T_scale_fail>) {
       logp += (beta_dbl - 1.0) * log1m_y[n];
     }
 

--- a/stan/math/prim/scal/prob/beta_proportion_lpdf.hpp
+++ b/stan/math/prim/scal/prob/beta_proportion_lpdf.hpp
@@ -91,11 +91,11 @@ return_type_t<T_y, T_loc, T_prec> beta_proportion_lpdf(const T_y& y,
     log1m_y[n] = log1m(value_of(y_vec[n]));
   }
 
-  VectorBuilder<include_summand_b<propto, T_loc, T_prec>,
-                T_partials_return, T_loc, T_prec>
+  VectorBuilder<include_summand_b<propto, T_loc, T_prec>, T_partials_return,
+                T_loc, T_prec>
       lgamma_mukappa(N_mukappa);
-  VectorBuilder<include_summand_b<propto, T_loc, T_prec>,
-                T_partials_return, T_loc, T_prec>
+  VectorBuilder<include_summand_b<propto, T_loc, T_prec>, T_partials_return,
+                T_loc, T_prec>
       lgamma_kappa_mukappa(N_mukappa);
   VectorBuilder<!is_constant_all<T_loc, T_prec>::value, T_partials_return,
                 T_loc, T_prec>

--- a/stan/math/prim/scal/prob/beta_proportion_lpdf.hpp
+++ b/stan/math/prim/scal/prob/beta_proportion_lpdf.hpp
@@ -59,7 +59,7 @@ return_type_t<T_y, T_loc, T_prec> beta_proportion_lpdf(const T_y& y,
   if (size_zero(y, mu, kappa)) {
     return 0;
   }
-  if (!include_summand<propto, T_y, T_loc, T_prec>::value) {
+  if (!include_summand_b<propto, T_y, T_loc, T_prec>) {
     return 0;
   }
   T_partials_return logp(0);
@@ -79,10 +79,10 @@ return_type_t<T_y, T_loc, T_prec> beta_proportion_lpdf(const T_y& y,
 
   operands_and_partials<T_y, T_loc, T_prec> ops_partials(y, mu, kappa);
 
-  VectorBuilder<include_summand<propto, T_y, T_loc, T_prec>::value,
+  VectorBuilder<include_summand_b<propto, T_y, T_loc, T_prec>,
                 T_partials_return, T_y>
       log_y(length(y));
-  VectorBuilder<include_summand<propto, T_y, T_loc, T_prec>::value,
+  VectorBuilder<include_summand_b<propto, T_y, T_loc, T_prec>,
                 T_partials_return, T_y>
       log1m_y(length(y));
 
@@ -91,10 +91,10 @@ return_type_t<T_y, T_loc, T_prec> beta_proportion_lpdf(const T_y& y,
     log1m_y[n] = log1m(value_of(y_vec[n]));
   }
 
-  VectorBuilder<include_summand<propto, T_loc, T_prec>::value,
+  VectorBuilder<include_summand_b<propto, T_loc, T_prec>,
                 T_partials_return, T_loc, T_prec>
       lgamma_mukappa(N_mukappa);
-  VectorBuilder<include_summand<propto, T_loc, T_prec>::value,
+  VectorBuilder<include_summand_b<propto, T_loc, T_prec>,
                 T_partials_return, T_loc, T_prec>
       lgamma_kappa_mukappa(N_mukappa);
   VectorBuilder<!is_constant_all<T_loc, T_prec>::value, T_partials_return,
@@ -110,7 +110,7 @@ return_type_t<T_y, T_loc, T_prec> beta_proportion_lpdf(const T_y& y,
     const T_partials_return kappa_mukappa_dbl
         = value_of(kappa_vec[n]) - mukappa_dbl;
 
-    if (include_summand<propto, T_loc, T_prec>::value) {
+    if (include_summand_b<propto, T_loc, T_prec>) {
       lgamma_mukappa[n] = lgamma(mukappa_dbl);
       lgamma_kappa_mukappa[n] = lgamma(kappa_mukappa_dbl);
     }
@@ -121,14 +121,13 @@ return_type_t<T_y, T_loc, T_prec> beta_proportion_lpdf(const T_y& y,
     }
   }
 
-  VectorBuilder<include_summand<propto, T_prec>::value, T_partials_return,
-                T_prec>
+  VectorBuilder<include_summand_b<propto, T_prec>, T_partials_return, T_prec>
       lgamma_kappa(length(kappa));
   VectorBuilder<!is_constant_all<T_prec>::value, T_partials_return, T_prec>
       digamma_kappa(length(kappa));
 
   for (size_t n = 0; n < length(kappa); n++) {
-    if (include_summand<propto, T_prec>::value) {
+    if (include_summand_b<propto, T_prec>) {
       lgamma_kappa[n] = lgamma(value_of(kappa_vec[n]));
     }
 
@@ -142,10 +141,10 @@ return_type_t<T_y, T_loc, T_prec> beta_proportion_lpdf(const T_y& y,
     const T_partials_return mu_dbl = value_of(mu_vec[n]);
     const T_partials_return kappa_dbl = value_of(kappa_vec[n]);
 
-    if (include_summand<propto, T_prec>::value) {
+    if (include_summand_b<propto, T_prec>) {
       logp += lgamma_kappa[n];
     }
-    if (include_summand<propto, T_loc, T_prec>::value) {
+    if (include_summand_b<propto, T_loc, T_prec>) {
       logp -= lgamma_mukappa[n] + lgamma_kappa_mukappa[n];
     }
     const T_partials_return mukappa_dbl = mu_dbl * kappa_dbl;

--- a/stan/math/prim/scal/prob/binomial_logit_lpmf.hpp
+++ b/stan/math/prim/scal/prob/binomial_logit_lpmf.hpp
@@ -51,7 +51,7 @@ return_type_t<T_prob> binomial_logit_lpmf(const T_n& n, const T_N& N,
                          "Population size parameter", N,
                          "Probability parameter", alpha);
 
-  if (!include_summand<propto, T_prob>::value) {
+  if (!include_summand_b<propto, T_prob>) {
     return 0.0;
   }
 
@@ -62,7 +62,7 @@ return_type_t<T_prob> binomial_logit_lpmf(const T_n& n, const T_N& N,
 
   operands_and_partials<T_prob> ops_partials(alpha);
 
-  if (include_summand<propto>::value) {
+  if (include_summand_b<propto>) {
     for (size_t i = 0; i < size; ++i) {
       logp += binomial_coefficient_log(N_vec[i], n_vec[i]);
     }

--- a/stan/math/prim/scal/prob/binomial_lpmf.hpp
+++ b/stan/math/prim/scal/prob/binomial_lpmf.hpp
@@ -52,7 +52,7 @@ return_type_t<T_prob> binomial_lpmf(const T_n& n, const T_N& N,
                          "Population size parameter", N,
                          "Probability parameter", theta);
 
-  if (!include_summand<propto, T_prob>::value) {
+  if (!include_summand_b<propto, T_prob>) {
     return 0.0;
   }
 
@@ -63,7 +63,7 @@ return_type_t<T_prob> binomial_lpmf(const T_n& n, const T_N& N,
 
   operands_and_partials<T_prob> ops_partials(theta);
 
-  if (include_summand<propto>::value) {
+  if (include_summand_b<propto>) {
     for (size_t i = 0; i < size; ++i) {
       logp += binomial_coefficient_log(N_vec[i], n_vec[i]);
     }

--- a/stan/math/prim/scal/prob/cauchy_lpdf.hpp
+++ b/stan/math/prim/scal/prob/cauchy_lpdf.hpp
@@ -50,7 +50,7 @@ return_type_t<T_y, T_loc, T_scale> cauchy_lpdf(const T_y& y, const T_loc& mu,
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Scale parameter", sigma);
 
-  if (!include_summand<propto, T_y, T_loc, T_scale>::value) {
+  if (!include_summand_b<propto, T_y, T_loc, T_scale>) {
     return 0.0;
   }
 
@@ -63,14 +63,13 @@ return_type_t<T_y, T_loc, T_scale> cauchy_lpdf(const T_y& y, const T_loc& mu,
 
   VectorBuilder<true, T_partials_return, T_scale> inv_sigma(length(sigma));
   VectorBuilder<true, T_partials_return, T_scale> sigma_squared(length(sigma));
-  VectorBuilder<include_summand<propto, T_scale>::value, T_partials_return,
-                T_scale>
+  VectorBuilder<include_summand_b<propto, T_scale>, T_partials_return, T_scale>
       log_sigma(length(sigma));
   for (size_t i = 0; i < length(sigma); i++) {
     const T_partials_return sigma_dbl = value_of(sigma_vec[i]);
     inv_sigma[i] = 1.0 / sigma_dbl;
     sigma_squared[i] = sigma_dbl * sigma_dbl;
-    if (include_summand<propto, T_scale>::value) {
+    if (include_summand_b<propto, T_scale>) {
       log_sigma[i] = log(sigma_dbl);
     }
   }
@@ -87,10 +86,10 @@ return_type_t<T_y, T_loc, T_scale> cauchy_lpdf(const T_y& y, const T_loc& mu,
     const T_partials_return y_minus_mu_over_sigma_squared
         = y_minus_mu_over_sigma * y_minus_mu_over_sigma;
 
-    if (include_summand<propto>::value) {
+    if (include_summand_b<propto>) {
       logp += NEG_LOG_PI;
     }
-    if (include_summand<propto, T_scale>::value) {
+    if (include_summand_b<propto, T_scale>) {
       logp -= log_sigma[n];
     }
     logp -= log1p(y_minus_mu_over_sigma_squared);

--- a/stan/math/prim/scal/prob/chi_square_lpdf.hpp
+++ b/stan/math/prim/scal/prob/chi_square_lpdf.hpp
@@ -75,8 +75,8 @@ return_type_t<T_y, T_dof> chi_square_lpdf(const T_y& y, const T_dof& nu) {
     }
   }
 
-  VectorBuilder<include_summand_b<propto, T_y>, T_partials_return, T_y>
-      inv_y(length(y));
+  VectorBuilder<include_summand_b<propto, T_y>, T_partials_return, T_y> inv_y(
+      length(y));
   for (size_t i = 0; i < length(y); i++) {
     if (include_summand_b<propto, T_y>) {
       inv_y[i] = 1.0 / value_of(y_vec[i]);

--- a/stan/math/prim/scal/prob/chi_square_lpdf.hpp
+++ b/stan/math/prim/scal/prob/chi_square_lpdf.hpp
@@ -61,37 +61,36 @@ return_type_t<T_y, T_dof> chi_square_lpdf(const T_y& y, const T_dof& nu) {
     }
   }
 
-  if (!include_summand<propto, T_y, T_dof>::value) {
+  if (!include_summand_b<propto, T_y, T_dof>) {
     return 0.0;
   }
 
   using std::log;
 
-  VectorBuilder<include_summand<propto, T_y, T_dof>::value, T_partials_return,
-                T_y>
+  VectorBuilder<include_summand_b<propto, T_y, T_dof>, T_partials_return, T_y>
       log_y(length(y));
   for (size_t i = 0; i < length(y); i++) {
-    if (include_summand<propto, T_y, T_dof>::value) {
+    if (include_summand_b<propto, T_y, T_dof>) {
       log_y[i] = log(value_of(y_vec[i]));
     }
   }
 
-  VectorBuilder<include_summand<propto, T_y>::value, T_partials_return, T_y>
+  VectorBuilder<include_summand_b<propto, T_y>, T_partials_return, T_y>
       inv_y(length(y));
   for (size_t i = 0; i < length(y); i++) {
-    if (include_summand<propto, T_y>::value) {
+    if (include_summand_b<propto, T_y>) {
       inv_y[i] = 1.0 / value_of(y_vec[i]);
     }
   }
 
-  VectorBuilder<include_summand<propto, T_dof>::value, T_partials_return, T_dof>
+  VectorBuilder<include_summand_b<propto, T_dof>, T_partials_return, T_dof>
       lgamma_half_nu(length(nu));
   VectorBuilder<!is_constant_all<T_dof>::value, T_partials_return, T_dof>
       digamma_half_nu_over_two(length(nu));
 
   for (size_t i = 0; i < length(nu); i++) {
     T_partials_return half_nu = 0.5 * value_of(nu_vec[i]);
-    if (include_summand<propto, T_dof>::value) {
+    if (include_summand_b<propto, T_dof>) {
       lgamma_half_nu[i] = lgamma(half_nu);
     }
     if (!is_constant_all<T_dof>::value) {
@@ -106,13 +105,13 @@ return_type_t<T_y, T_dof> chi_square_lpdf(const T_y& y, const T_dof& nu) {
     const T_partials_return half_y = 0.5 * y_dbl;
     const T_partials_return nu_dbl = value_of(nu_vec[n]);
     const T_partials_return half_nu = 0.5 * nu_dbl;
-    if (include_summand<propto, T_dof>::value) {
+    if (include_summand_b<propto, T_dof>) {
       logp += nu_dbl * NEG_LOG_TWO_OVER_TWO - lgamma_half_nu[n];
     }
-    if (include_summand<propto, T_y, T_dof>::value) {
+    if (include_summand_b<propto, T_y, T_dof>) {
       logp += (half_nu - 1.0) * log_y[n];
     }
-    if (include_summand<propto, T_y>::value) {
+    if (include_summand_b<propto, T_y>) {
       logp -= half_y;
     }
 

--- a/stan/math/prim/scal/prob/double_exponential_lpdf.hpp
+++ b/stan/math/prim/scal/prob/double_exponential_lpdf.hpp
@@ -63,8 +63,7 @@ return_type_t<T_y, T_loc, T_scale> double_exponential_lpdf(
       inv_sigma(length(sigma));
   VectorBuilder<!is_constant_all<T_scale>::value, T_partials_return, T_scale>
       inv_sigma_squared(length(sigma));
-  VectorBuilder<include_summand_b<propto, T_scale>, T_partials_return,
-                T_scale>
+  VectorBuilder<include_summand_b<propto, T_scale>, T_partials_return, T_scale>
       log_sigma(length(sigma));
   for (size_t i = 0; i < length(sigma); i++) {
     const T_partials_return sigma_dbl = value_of(sigma_vec[i]);

--- a/stan/math/prim/scal/prob/double_exponential_lpdf.hpp
+++ b/stan/math/prim/scal/prob/double_exponential_lpdf.hpp
@@ -48,7 +48,7 @@ return_type_t<T_y, T_loc, T_scale> double_exponential_lpdf(
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Shape parameter", sigma);
 
-  if (!include_summand<propto, T_y, T_loc, T_scale>::value) {
+  if (!include_summand_b<propto, T_y, T_loc, T_scale>) {
     return 0.0;
   }
 
@@ -58,18 +58,18 @@ return_type_t<T_y, T_loc, T_scale> double_exponential_lpdf(
   size_t N = max_size(y, mu, sigma);
   operands_and_partials<T_y, T_loc, T_scale> ops_partials(y, mu, sigma);
 
-  VectorBuilder<include_summand<propto, T_y, T_loc, T_scale>::value,
+  VectorBuilder<include_summand_b<propto, T_y, T_loc, T_scale>,
                 T_partials_return, T_scale>
       inv_sigma(length(sigma));
   VectorBuilder<!is_constant_all<T_scale>::value, T_partials_return, T_scale>
       inv_sigma_squared(length(sigma));
-  VectorBuilder<include_summand<propto, T_scale>::value, T_partials_return,
+  VectorBuilder<include_summand_b<propto, T_scale>, T_partials_return,
                 T_scale>
       log_sigma(length(sigma));
   for (size_t i = 0; i < length(sigma); i++) {
     const T_partials_return sigma_dbl = value_of(sigma_vec[i]);
     inv_sigma[i] = 1.0 / sigma_dbl;
-    if (include_summand<propto, T_scale>::value) {
+    if (include_summand_b<propto, T_scale>) {
       log_sigma[i] = log(value_of(sigma_vec[i]));
     }
     if (!is_constant_all<T_scale>::value) {
@@ -84,10 +84,10 @@ return_type_t<T_y, T_loc, T_scale> double_exponential_lpdf(
     const T_partials_return y_m_mu = y_dbl - mu_dbl;
     const T_partials_return fabs_y_m_mu = fabs(y_m_mu);
 
-    if (include_summand<propto>::value) {
+    if (include_summand_b<propto>) {
       logp += NEG_LOG_TWO;
     }
-    if (include_summand<propto, T_scale>::value) {
+    if (include_summand_b<propto, T_scale>) {
       logp -= log_sigma[n];
     }
     logp -= fabs_y_m_mu * inv_sigma[n];

--- a/stan/math/prim/scal/prob/exp_mod_normal_lpdf.hpp
+++ b/stan/math/prim/scal/prob/exp_mod_normal_lpdf.hpp
@@ -37,7 +37,7 @@ return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_lpdf(
                          mu, "Scale parameter", sigma, "Inv_scale paramter",
                          lambda);
 
-  if (!include_summand<propto, T_y, T_loc, T_scale, T_inv_scale>::value) {
+  if (!include_summand_b<propto, T_y, T_loc, T_scale, T_inv_scale>) {
     return 0.0;
   }
 
@@ -62,10 +62,10 @@ return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_lpdf(
 
     const T_partials_return pi_dbl = boost::math::constants::pi<double>();
 
-    if (include_summand<propto>::value) {
+    if (include_summand_b<propto>) {
       logp -= log(2.0);
     }
-    if (include_summand<propto, T_inv_scale>::value) {
+    if (include_summand_b<propto, T_inv_scale>) {
       logp += log(lambda_dbl);
     }
     logp += lambda_dbl

--- a/stan/math/prim/scal/prob/exponential_lpdf.hpp
+++ b/stan/math/prim/scal/prob/exponential_lpdf.hpp
@@ -61,11 +61,11 @@ return_type_t<T_y, T_inv_scale> exponential_lpdf(const T_y& y,
   scalar_seq_view<T_inv_scale> beta_vec(beta);
   size_t N = max_size(y, beta);
 
-  VectorBuilder<include_summand<propto, T_inv_scale>::value, T_partials_return,
+  VectorBuilder<include_summand_b<propto, T_inv_scale>, T_partials_return,
                 T_inv_scale>
       log_beta(length(beta));
   for (size_t i = 0; i < length(beta); i++) {
-    if (include_summand<propto, T_inv_scale>::value) {
+    if (include_summand_b<propto, T_inv_scale>) {
       log_beta[i] = log(value_of(beta_vec[i]));
     }
   }
@@ -75,10 +75,10 @@ return_type_t<T_y, T_inv_scale> exponential_lpdf(const T_y& y,
   for (size_t n = 0; n < N; n++) {
     const T_partials_return beta_dbl = value_of(beta_vec[n]);
     const T_partials_return y_dbl = value_of(y_vec[n]);
-    if (include_summand<propto, T_inv_scale>::value) {
+    if (include_summand_b<propto, T_inv_scale>) {
       logp += log_beta[n];
     }
-    if (include_summand<propto, T_y, T_inv_scale>::value) {
+    if (include_summand_b<propto, T_y, T_inv_scale>) {
       logp -= beta_dbl * y_dbl;
     }
 

--- a/stan/math/prim/scal/prob/frechet_lpdf.hpp
+++ b/stan/math/prim/scal/prob/frechet_lpdf.hpp
@@ -50,8 +50,7 @@ return_type_t<T_y, T_shape, T_scale> frechet_lpdf(const T_y& y,
   scalar_seq_view<T_scale> sigma_vec(sigma);
   size_t N = max_size(y, alpha, sigma);
 
-  VectorBuilder<include_summand_b<propto, T_shape>, T_partials_return,
-                T_shape>
+  VectorBuilder<include_summand_b<propto, T_shape>, T_partials_return, T_shape>
       log_alpha(length(alpha));
   for (size_t i = 0; i < length(alpha); i++) {
     if (include_summand_b<propto, T_shape>) {
@@ -67,8 +66,8 @@ return_type_t<T_y, T_shape, T_scale> frechet_lpdf(const T_y& y,
     }
   }
 
-  VectorBuilder<include_summand_b<propto, T_shape, T_scale>,
-                T_partials_return, T_scale>
+  VectorBuilder<include_summand_b<propto, T_shape, T_scale>, T_partials_return,
+                T_scale>
       log_sigma(length(sigma));
   for (size_t i = 0; i < length(sigma); i++) {
     if (include_summand_b<propto, T_shape, T_scale>) {

--- a/stan/math/prim/scal/prob/frechet_lpdf.hpp
+++ b/stan/math/prim/scal/prob/frechet_lpdf.hpp
@@ -37,7 +37,7 @@ return_type_t<T_y, T_shape, T_scale> frechet_lpdf(const T_y& y,
   if (size_zero(y, alpha, sigma)) {
     return 0;
   }
-  if (!include_summand<propto, T_y, T_shape, T_scale>::value) {
+  if (!include_summand_b<propto, T_y, T_shape, T_scale>) {
     return 0;
   }
 
@@ -50,41 +50,40 @@ return_type_t<T_y, T_shape, T_scale> frechet_lpdf(const T_y& y,
   scalar_seq_view<T_scale> sigma_vec(sigma);
   size_t N = max_size(y, alpha, sigma);
 
-  VectorBuilder<include_summand<propto, T_shape>::value, T_partials_return,
+  VectorBuilder<include_summand_b<propto, T_shape>, T_partials_return,
                 T_shape>
       log_alpha(length(alpha));
   for (size_t i = 0; i < length(alpha); i++) {
-    if (include_summand<propto, T_shape>::value) {
+    if (include_summand_b<propto, T_shape>) {
       log_alpha[i] = log(value_of(alpha_vec[i]));
     }
   }
 
-  VectorBuilder<include_summand<propto, T_y, T_shape>::value, T_partials_return,
-                T_y>
+  VectorBuilder<include_summand_b<propto, T_y, T_shape>, T_partials_return, T_y>
       log_y(length(y));
   for (size_t i = 0; i < length(y); i++) {
-    if (include_summand<propto, T_y, T_shape>::value) {
+    if (include_summand_b<propto, T_y, T_shape>) {
       log_y[i] = log(value_of(y_vec[i]));
     }
   }
 
-  VectorBuilder<include_summand<propto, T_shape, T_scale>::value,
+  VectorBuilder<include_summand_b<propto, T_shape, T_scale>,
                 T_partials_return, T_scale>
       log_sigma(length(sigma));
   for (size_t i = 0; i < length(sigma); i++) {
-    if (include_summand<propto, T_shape, T_scale>::value) {
+    if (include_summand_b<propto, T_shape, T_scale>) {
       log_sigma[i] = log(value_of(sigma_vec[i]));
     }
   }
 
-  VectorBuilder<include_summand<propto, T_y, T_shape, T_scale>::value,
+  VectorBuilder<include_summand_b<propto, T_y, T_shape, T_scale>,
                 T_partials_return, T_y>
       inv_y(length(y));
   for (size_t i = 0; i < length(y); i++) {
     inv_y[i] = 1.0 / value_of(y_vec[i]);
   }
 
-  VectorBuilder<include_summand<propto, T_y, T_shape, T_scale>::value,
+  VectorBuilder<include_summand_b<propto, T_y, T_shape, T_scale>,
                 T_partials_return, T_y, T_shape, T_scale>
       sigma_div_y_pow_alpha(N);
   for (size_t i = 0; i < N; i++) {
@@ -96,13 +95,13 @@ return_type_t<T_y, T_shape, T_scale> frechet_lpdf(const T_y& y,
   operands_and_partials<T_y, T_shape, T_scale> ops_partials(y, alpha, sigma);
   for (size_t n = 0; n < N; n++) {
     const T_partials_return alpha_dbl = value_of(alpha_vec[n]);
-    if (include_summand<propto, T_shape>::value) {
+    if (include_summand_b<propto, T_shape>) {
       logp += log_alpha[n];
     }
-    if (include_summand<propto, T_y, T_shape>::value) {
+    if (include_summand_b<propto, T_y, T_shape>) {
       logp -= (alpha_dbl + 1.0) * log_y[n];
     }
-    if (include_summand<propto, T_shape, T_scale>::value) {
+    if (include_summand_b<propto, T_shape, T_scale>) {
       logp += alpha_dbl * log_sigma[n];
     }
     logp -= sigma_div_y_pow_alpha[n];

--- a/stan/math/prim/scal/prob/gamma_lpdf.hpp
+++ b/stan/math/prim/scal/prob/gamma_lpdf.hpp
@@ -57,7 +57,7 @@ return_type_t<T_y, T_shape, T_inv_scale> gamma_lpdf(const T_y& y,
   check_consistent_sizes(function, "Random variable", y, "Shape parameter",
                          alpha, "Inverse scale parameter", beta);
 
-  if (!include_summand<propto, T_y, T_shape, T_inv_scale>::value) {
+  if (!include_summand_b<propto, T_y, T_shape, T_inv_scale>) {
     return 0.0;
   }
 
@@ -77,10 +77,10 @@ return_type_t<T_y, T_shape, T_inv_scale> gamma_lpdf(const T_y& y,
 
   using std::log;
 
-  VectorBuilder<include_summand<propto, T_y, T_shape>::value, T_partials_return,
+  VectorBuilder<include_summand_b<propto, T_y, T_shape>, T_partials_return,
                 T_y>
       log_y(length(y));
-  if (include_summand<propto, T_y, T_shape>::value) {
+  if (include_summand_b<propto, T_y, T_shape>) {
     for (size_t n = 0; n < length(y); n++) {
       if (value_of(y_vec[n]) > 0) {
         log_y[n] = log(value_of(y_vec[n]));
@@ -88,13 +88,13 @@ return_type_t<T_y, T_shape, T_inv_scale> gamma_lpdf(const T_y& y,
     }
   }
 
-  VectorBuilder<include_summand<propto, T_shape>::value, T_partials_return,
+  VectorBuilder<include_summand_b<propto, T_shape>, T_partials_return,
                 T_shape>
       lgamma_alpha(length(alpha));
   VectorBuilder<!is_constant_all<T_shape>::value, T_partials_return, T_shape>
       digamma_alpha(length(alpha));
   for (size_t n = 0; n < length(alpha); n++) {
-    if (include_summand<propto, T_shape>::value) {
+    if (include_summand_b<propto, T_shape>) {
       lgamma_alpha[n] = lgamma(value_of(alpha_vec[n]));
     }
     if (!is_constant_all<T_shape>::value) {
@@ -102,10 +102,10 @@ return_type_t<T_y, T_shape, T_inv_scale> gamma_lpdf(const T_y& y,
     }
   }
 
-  VectorBuilder<include_summand<propto, T_shape, T_inv_scale>::value,
+  VectorBuilder<include_summand_b<propto, T_shape, T_inv_scale>,
                 T_partials_return, T_inv_scale>
       log_beta(length(beta));
-  if (include_summand<propto, T_shape, T_inv_scale>::value) {
+  if (include_summand_b<propto, T_shape, T_inv_scale>) {
     for (size_t n = 0; n < length(beta); n++) {
       log_beta[n] = log(value_of(beta_vec[n]));
     }
@@ -116,16 +116,16 @@ return_type_t<T_y, T_shape, T_inv_scale> gamma_lpdf(const T_y& y,
     const T_partials_return alpha_dbl = value_of(alpha_vec[n]);
     const T_partials_return beta_dbl = value_of(beta_vec[n]);
 
-    if (include_summand<propto, T_shape>::value) {
+    if (include_summand_b<propto, T_shape>) {
       logp -= lgamma_alpha[n];
     }
-    if (include_summand<propto, T_shape, T_inv_scale>::value) {
+    if (include_summand_b<propto, T_shape, T_inv_scale>) {
       logp += alpha_dbl * log_beta[n];
     }
-    if (include_summand<propto, T_y, T_shape>::value) {
+    if (include_summand_b<propto, T_y, T_shape>) {
       logp += (alpha_dbl - 1.0) * log_y[n];
     }
-    if (include_summand<propto, T_y, T_inv_scale>::value) {
+    if (include_summand_b<propto, T_y, T_inv_scale>) {
       logp -= beta_dbl * y_dbl;
     }
 

--- a/stan/math/prim/scal/prob/gamma_lpdf.hpp
+++ b/stan/math/prim/scal/prob/gamma_lpdf.hpp
@@ -77,8 +77,7 @@ return_type_t<T_y, T_shape, T_inv_scale> gamma_lpdf(const T_y& y,
 
   using std::log;
 
-  VectorBuilder<include_summand_b<propto, T_y, T_shape>, T_partials_return,
-                T_y>
+  VectorBuilder<include_summand_b<propto, T_y, T_shape>, T_partials_return, T_y>
       log_y(length(y));
   if (include_summand_b<propto, T_y, T_shape>) {
     for (size_t n = 0; n < length(y); n++) {
@@ -88,8 +87,7 @@ return_type_t<T_y, T_shape, T_inv_scale> gamma_lpdf(const T_y& y,
     }
   }
 
-  VectorBuilder<include_summand_b<propto, T_shape>, T_partials_return,
-                T_shape>
+  VectorBuilder<include_summand_b<propto, T_shape>, T_partials_return, T_shape>
       lgamma_alpha(length(alpha));
   VectorBuilder<!is_constant_all<T_shape>::value, T_partials_return, T_shape>
       digamma_alpha(length(alpha));

--- a/stan/math/prim/scal/prob/gumbel_lpdf.hpp
+++ b/stan/math/prim/scal/prob/gumbel_lpdf.hpp
@@ -49,7 +49,7 @@ return_type_t<T_y, T_loc, T_scale> gumbel_lpdf(const T_y& y, const T_loc& mu,
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Scale parameter", beta);
 
-  if (!include_summand<propto, T_y, T_loc, T_scale>::value) {
+  if (!include_summand_b<propto, T_y, T_loc, T_scale>) {
     return 0.0;
   }
 
@@ -61,12 +61,12 @@ return_type_t<T_y, T_loc, T_scale> gumbel_lpdf(const T_y& y, const T_loc& mu,
   size_t N = max_size(y, mu, beta);
 
   VectorBuilder<true, T_partials_return, T_scale> inv_beta(length(beta));
-  VectorBuilder<include_summand<propto, T_scale>::value, T_partials_return,
+  VectorBuilder<include_summand_b<propto, T_scale>, T_partials_return,
                 T_scale>
       log_beta(length(beta));
   for (size_t i = 0; i < length(beta); i++) {
     inv_beta[i] = 1.0 / value_of(beta_vec[i]);
-    if (include_summand<propto, T_scale>::value) {
+    if (include_summand_b<propto, T_scale>) {
       log_beta[i] = log(value_of(beta_vec[i]));
     }
   }
@@ -78,7 +78,7 @@ return_type_t<T_y, T_loc, T_scale> gumbel_lpdf(const T_y& y, const T_loc& mu,
     const T_partials_return y_minus_mu_over_beta
         = (y_dbl - mu_dbl) * inv_beta[n];
 
-    if (include_summand<propto, T_scale>::value) {
+    if (include_summand_b<propto, T_scale>) {
       logp -= log_beta[n];
     }
     logp += -y_minus_mu_over_beta - exp(-y_minus_mu_over_beta);

--- a/stan/math/prim/scal/prob/gumbel_lpdf.hpp
+++ b/stan/math/prim/scal/prob/gumbel_lpdf.hpp
@@ -61,8 +61,7 @@ return_type_t<T_y, T_loc, T_scale> gumbel_lpdf(const T_y& y, const T_loc& mu,
   size_t N = max_size(y, mu, beta);
 
   VectorBuilder<true, T_partials_return, T_scale> inv_beta(length(beta));
-  VectorBuilder<include_summand_b<propto, T_scale>, T_partials_return,
-                T_scale>
+  VectorBuilder<include_summand_b<propto, T_scale>, T_partials_return, T_scale>
       log_beta(length(beta));
   for (size_t i = 0; i < length(beta); i++) {
     inv_beta[i] = 1.0 / value_of(beta_vec[i]);

--- a/stan/math/prim/scal/prob/hypergeometric_lpmf.hpp
+++ b/stan/math/prim/scal/prob/hypergeometric_lpmf.hpp
@@ -43,7 +43,7 @@ double hypergeometric_lpmf(const T_n& n, const T_N& N, const T_a& a,
                          N, "Successes in population parameter", a,
                          "Failures in population parameter", b);
 
-  if (!include_summand<propto>::value) {
+  if (!include_summand_b<propto>) {
     return 0.0;
   }
 

--- a/stan/math/prim/scal/prob/inv_chi_square_lpdf.hpp
+++ b/stan/math/prim/scal/prob/inv_chi_square_lpdf.hpp
@@ -70,8 +70,8 @@ return_type_t<T_y, T_dof> inv_chi_square_lpdf(const T_y& y, const T_dof& nu) {
     }
   }
 
-  VectorBuilder<include_summand_b<propto, T_y>, T_partials_return, T_y>
-      inv_y(length(y));
+  VectorBuilder<include_summand_b<propto, T_y>, T_partials_return, T_y> inv_y(
+      length(y));
   for (size_t i = 0; i < length(y); i++) {
     if (include_summand_b<propto, T_y>) {
       inv_y[i] = 1.0 / value_of(y_vec[i]);

--- a/stan/math/prim/scal/prob/inv_chi_square_lpdf.hpp
+++ b/stan/math/prim/scal/prob/inv_chi_square_lpdf.hpp
@@ -62,30 +62,29 @@ return_type_t<T_y, T_dof> inv_chi_square_lpdf(const T_y& y, const T_dof& nu) {
 
   using std::log;
 
-  VectorBuilder<include_summand<propto, T_y, T_dof>::value, T_partials_return,
-                T_y>
+  VectorBuilder<include_summand_b<propto, T_y, T_dof>, T_partials_return, T_y>
       log_y(length(y));
   for (size_t i = 0; i < length(y); i++) {
-    if (include_summand<propto, T_y, T_dof>::value) {
+    if (include_summand_b<propto, T_y, T_dof>) {
       log_y[i] = log(value_of(y_vec[i]));
     }
   }
 
-  VectorBuilder<include_summand<propto, T_y>::value, T_partials_return, T_y>
+  VectorBuilder<include_summand_b<propto, T_y>, T_partials_return, T_y>
       inv_y(length(y));
   for (size_t i = 0; i < length(y); i++) {
-    if (include_summand<propto, T_y>::value) {
+    if (include_summand_b<propto, T_y>) {
       inv_y[i] = 1.0 / value_of(y_vec[i]);
     }
   }
 
-  VectorBuilder<include_summand<propto, T_dof>::value, T_partials_return, T_dof>
+  VectorBuilder<include_summand_b<propto, T_dof>, T_partials_return, T_dof>
       lgamma_half_nu(length(nu));
   VectorBuilder<!is_constant_all<T_dof>::value, T_partials_return, T_dof>
       digamma_half_nu_over_two(length(nu));
   for (size_t i = 0; i < length(nu); i++) {
     T_partials_return half_nu = 0.5 * value_of(nu_vec[i]);
-    if (include_summand<propto, T_dof>::value) {
+    if (include_summand_b<propto, T_dof>) {
       lgamma_half_nu[i] = lgamma(half_nu);
     }
     if (!is_constant_all<T_dof>::value) {
@@ -98,13 +97,13 @@ return_type_t<T_y, T_dof> inv_chi_square_lpdf(const T_y& y, const T_dof& nu) {
     const T_partials_return nu_dbl = value_of(nu_vec[n]);
     const T_partials_return half_nu = 0.5 * nu_dbl;
 
-    if (include_summand<propto, T_dof>::value) {
+    if (include_summand_b<propto, T_dof>) {
       logp += nu_dbl * NEG_LOG_TWO_OVER_TWO - lgamma_half_nu[n];
     }
-    if (include_summand<propto, T_y, T_dof>::value) {
+    if (include_summand_b<propto, T_y, T_dof>) {
       logp -= (half_nu + 1.0) * log_y[n];
     }
-    if (include_summand<propto, T_y>::value) {
+    if (include_summand_b<propto, T_y>) {
       logp -= 0.5 * inv_y[n];
     }
 

--- a/stan/math/prim/scal/prob/inv_gamma_lpdf.hpp
+++ b/stan/math/prim/scal/prob/inv_gamma_lpdf.hpp
@@ -47,7 +47,7 @@ return_type_t<T_y, T_shape, T_scale> inv_gamma_lpdf(const T_y& y,
     return 0;
   }
 
-  if (!include_summand<propto, T_y, T_shape, T_scale>::value) {
+  if (!include_summand_b<propto, T_y, T_shape, T_scale>) {
     return 0;
   }
 
@@ -68,30 +68,28 @@ return_type_t<T_y, T_shape, T_scale> inv_gamma_lpdf(const T_y& y,
 
   using std::log;
 
-  VectorBuilder<include_summand<propto, T_y, T_shape>::value, T_partials_return,
-                T_y>
+  VectorBuilder<include_summand_b<propto, T_y, T_shape>, T_partials_return, T_y>
       log_y(length(y));
-  VectorBuilder<include_summand<propto, T_y, T_scale>::value, T_partials_return,
-                T_y>
+  VectorBuilder<include_summand_b<propto, T_y, T_scale>, T_partials_return, T_y>
       inv_y(length(y));
   for (size_t n = 0; n < length(y); n++) {
-    if (include_summand<propto, T_y, T_shape>::value) {
+    if (include_summand_b<propto, T_y, T_shape>) {
       if (value_of(y_vec[n]) > 0) {
         log_y[n] = log(value_of(y_vec[n]));
       }
     }
-    if (include_summand<propto, T_y, T_scale>::value) {
+    if (include_summand_b<propto, T_y, T_scale>) {
       inv_y[n] = 1.0 / value_of(y_vec[n]);
     }
   }
 
-  VectorBuilder<include_summand<propto, T_shape>::value, T_partials_return,
+  VectorBuilder<include_summand_b<propto, T_shape>, T_partials_return,
                 T_shape>
       lgamma_alpha(length(alpha));
   VectorBuilder<!is_constant_all<T_shape>::value, T_partials_return, T_shape>
       digamma_alpha(length(alpha));
   for (size_t n = 0; n < length(alpha); n++) {
-    if (include_summand<propto, T_shape>::value) {
+    if (include_summand_b<propto, T_shape>) {
       lgamma_alpha[n] = lgamma(value_of(alpha_vec[n]));
     }
     if (!is_constant_all<T_shape>::value) {
@@ -99,10 +97,10 @@ return_type_t<T_y, T_shape, T_scale> inv_gamma_lpdf(const T_y& y,
     }
   }
 
-  VectorBuilder<include_summand<propto, T_shape, T_scale>::value,
+  VectorBuilder<include_summand_b<propto, T_shape, T_scale>,
                 T_partials_return, T_scale>
       log_beta(length(beta));
-  if (include_summand<propto, T_shape, T_scale>::value) {
+  if (include_summand_b<propto, T_shape, T_scale>) {
     for (size_t n = 0; n < length(beta); n++) {
       log_beta[n] = log(value_of(beta_vec[n]));
     }
@@ -112,16 +110,16 @@ return_type_t<T_y, T_shape, T_scale> inv_gamma_lpdf(const T_y& y,
     const T_partials_return alpha_dbl = value_of(alpha_vec[n]);
     const T_partials_return beta_dbl = value_of(beta_vec[n]);
 
-    if (include_summand<propto, T_shape>::value) {
+    if (include_summand_b<propto, T_shape>) {
       logp -= lgamma_alpha[n];
     }
-    if (include_summand<propto, T_shape, T_scale>::value) {
+    if (include_summand_b<propto, T_shape, T_scale>) {
       logp += alpha_dbl * log_beta[n];
     }
-    if (include_summand<propto, T_y, T_shape>::value) {
+    if (include_summand_b<propto, T_y, T_shape>) {
       logp -= (alpha_dbl + 1.0) * log_y[n];
     }
-    if (include_summand<propto, T_y, T_scale>::value) {
+    if (include_summand_b<propto, T_y, T_scale>) {
       logp -= beta_dbl * inv_y[n];
     }
 

--- a/stan/math/prim/scal/prob/inv_gamma_lpdf.hpp
+++ b/stan/math/prim/scal/prob/inv_gamma_lpdf.hpp
@@ -83,8 +83,7 @@ return_type_t<T_y, T_shape, T_scale> inv_gamma_lpdf(const T_y& y,
     }
   }
 
-  VectorBuilder<include_summand_b<propto, T_shape>, T_partials_return,
-                T_shape>
+  VectorBuilder<include_summand_b<propto, T_shape>, T_partials_return, T_shape>
       lgamma_alpha(length(alpha));
   VectorBuilder<!is_constant_all<T_shape>::value, T_partials_return, T_shape>
       digamma_alpha(length(alpha));
@@ -97,8 +96,8 @@ return_type_t<T_y, T_shape, T_scale> inv_gamma_lpdf(const T_y& y,
     }
   }
 
-  VectorBuilder<include_summand_b<propto, T_shape, T_scale>,
-                T_partials_return, T_scale>
+  VectorBuilder<include_summand_b<propto, T_shape, T_scale>, T_partials_return,
+                T_scale>
       log_beta(length(beta));
   if (include_summand_b<propto, T_shape, T_scale>) {
     for (size_t n = 0; n < length(beta); n++) {

--- a/stan/math/prim/scal/prob/logistic_lpdf.hpp
+++ b/stan/math/prim/scal/prob/logistic_lpdf.hpp
@@ -35,7 +35,7 @@ return_type_t<T_y, T_loc, T_scale> logistic_lpdf(const T_y& y, const T_loc& mu,
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Scale parameter", sigma);
 
-  if (!include_summand<propto, T_y, T_loc, T_scale>::value) {
+  if (!include_summand_b<propto, T_y, T_loc, T_scale>) {
     return 0.0;
   }
 
@@ -47,12 +47,12 @@ return_type_t<T_y, T_loc, T_scale> logistic_lpdf(const T_y& y, const T_loc& mu,
   size_t N = max_size(y, mu, sigma);
 
   VectorBuilder<true, T_partials_return, T_scale> inv_sigma(length(sigma));
-  VectorBuilder<include_summand<propto, T_scale>::value, T_partials_return,
+  VectorBuilder<include_summand_b<propto, T_scale>, T_partials_return,
                 T_scale>
       log_sigma(length(sigma));
   for (size_t i = 0; i < length(sigma); i++) {
     inv_sigma[i] = 1.0 / value_of(sigma_vec[i]);
-    if (include_summand<propto, T_scale>::value) {
+    if (include_summand_b<propto, T_scale>) {
       log_sigma[i] = log(value_of(sigma_vec[i]));
     }
   }
@@ -85,7 +85,7 @@ return_type_t<T_y, T_loc, T_scale> logistic_lpdf(const T_y& y, const T_loc& mu,
     }
 
     logp -= y_minus_mu_div_sigma;
-    if (include_summand<propto, T_scale>::value) {
+    if (include_summand_b<propto, T_scale>) {
       logp -= log_sigma[n];
     }
     logp -= 2.0 * log1p(exp_m_y_minus_mu_div_sigma);

--- a/stan/math/prim/scal/prob/logistic_lpdf.hpp
+++ b/stan/math/prim/scal/prob/logistic_lpdf.hpp
@@ -47,8 +47,7 @@ return_type_t<T_y, T_loc, T_scale> logistic_lpdf(const T_y& y, const T_loc& mu,
   size_t N = max_size(y, mu, sigma);
 
   VectorBuilder<true, T_partials_return, T_scale> inv_sigma(length(sigma));
-  VectorBuilder<include_summand_b<propto, T_scale>, T_partials_return,
-                T_scale>
+  VectorBuilder<include_summand_b<propto, T_scale>, T_partials_return, T_scale>
       log_sigma(length(sigma));
   for (size_t i = 0; i < length(sigma); i++) {
     inv_sigma[i] = 1.0 / value_of(sigma_vec[i]);

--- a/stan/math/prim/scal/prob/lognormal_lpdf.hpp
+++ b/stan/math/prim/scal/prob/lognormal_lpdf.hpp
@@ -49,36 +49,35 @@ return_type_t<T_y, T_loc, T_scale> lognormal_lpdf(const T_y& y, const T_loc& mu,
 
   using std::log;
 
-  VectorBuilder<include_summand<propto, T_scale>::value, T_partials_return,
-                T_scale>
+  VectorBuilder<include_summand_b<propto, T_scale>, T_partials_return, T_scale>
       log_sigma(length(sigma));
-  if (include_summand<propto, T_scale>::value) {
+  if (include_summand_b<propto, T_scale>) {
     for (size_t n = 0; n < length(sigma); n++) {
       log_sigma[n] = log(value_of(sigma_vec[n]));
     }
   }
 
-  VectorBuilder<include_summand<propto, T_y, T_loc, T_scale>::value,
+  VectorBuilder<include_summand_b<propto, T_y, T_loc, T_scale>,
                 T_partials_return, T_scale>
       inv_sigma(length(sigma));
-  VectorBuilder<include_summand<propto, T_y, T_loc, T_scale>::value,
+  VectorBuilder<include_summand_b<propto, T_y, T_loc, T_scale>,
                 T_partials_return, T_scale>
       inv_sigma_sq(length(sigma));
-  if (include_summand<propto, T_y, T_loc, T_scale>::value) {
+  if (include_summand_b<propto, T_y, T_loc, T_scale>) {
     for (size_t n = 0; n < length(sigma); n++) {
       inv_sigma[n] = 1 / value_of(sigma_vec[n]);
     }
   }
-  if (include_summand<propto, T_y, T_loc, T_scale>::value) {
+  if (include_summand_b<propto, T_y, T_loc, T_scale>) {
     for (size_t n = 0; n < length(sigma); n++) {
       inv_sigma_sq[n] = inv_sigma[n] * inv_sigma[n];
     }
   }
 
-  VectorBuilder<include_summand<propto, T_y, T_loc, T_scale>::value,
+  VectorBuilder<include_summand_b<propto, T_y, T_loc, T_scale>,
                 T_partials_return, T_y>
       log_y(length(y));
-  if (include_summand<propto, T_y, T_loc, T_scale>::value) {
+  if (include_summand_b<propto, T_y, T_loc, T_scale>) {
     for (size_t n = 0; n < length(y); n++) {
       log_y[n] = log(value_of(y_vec[n]));
     }
@@ -92,7 +91,7 @@ return_type_t<T_y, T_loc, T_scale> lognormal_lpdf(const T_y& y, const T_loc& mu,
     }
   }
 
-  if (include_summand<propto>::value) {
+  if (include_summand_b<propto>) {
     logp += N * NEG_LOG_SQRT_TWO_PI;
   }
 
@@ -100,7 +99,7 @@ return_type_t<T_y, T_loc, T_scale> lognormal_lpdf(const T_y& y, const T_loc& mu,
     const T_partials_return mu_dbl = value_of(mu_vec[n]);
 
     T_partials_return logy_m_mu(0);
-    if (include_summand<propto, T_y, T_loc, T_scale>::value) {
+    if (include_summand_b<propto, T_y, T_loc, T_scale>) {
       logy_m_mu = log_y[n] - mu_dbl;
     }
 
@@ -110,13 +109,13 @@ return_type_t<T_y, T_loc, T_scale> lognormal_lpdf(const T_y& y, const T_loc& mu,
       logy_m_mu_div_sigma = logy_m_mu * inv_sigma_sq[n];
     }
 
-    if (include_summand<propto, T_scale>::value) {
+    if (include_summand_b<propto, T_scale>) {
       logp -= log_sigma[n];
     }
-    if (include_summand<propto, T_y>::value) {
+    if (include_summand_b<propto, T_y>) {
       logp -= log_y[n];
     }
-    if (include_summand<propto, T_y, T_loc, T_scale>::value) {
+    if (include_summand_b<propto, T_y, T_loc, T_scale>) {
       logp -= 0.5 * logy_m_mu_sq * inv_sigma_sq[n];
     }
 

--- a/stan/math/prim/scal/prob/neg_binomial_2_log_lpmf.hpp
+++ b/stan/math/prim/scal/prob/neg_binomial_2_log_lpmf.hpp
@@ -39,7 +39,7 @@ return_type_t<T_log_location, T_precision> neg_binomial_2_log_lpmf(
                          "Log location parameter", eta, "Precision parameter",
                          phi);
 
-  if (!include_summand<propto, T_log_location, T_precision>::value) {
+  if (!include_summand_b<propto, T_log_location, T_precision>) {
     return 0.0;
   }
 
@@ -83,16 +83,16 @@ return_type_t<T_log_location, T_precision> neg_binomial_2_log_lpmf(
   }
 
   for (size_t i = 0; i < size; i++) {
-    if (include_summand<propto>::value) {
+    if (include_summand_b<propto>) {
       logp -= lgamma(n_vec[i] + 1.0);
     }
-    if (include_summand<propto, T_precision>::value) {
+    if (include_summand_b<propto, T_precision>) {
       logp += multiply_log(phi__[i], phi__[i]) - lgamma(phi__[i]);
     }
-    if (include_summand<propto, T_log_location>::value) {
+    if (include_summand_b<propto, T_log_location>) {
       logp += n_vec[i] * eta__[i];
     }
-    if (include_summand<propto, T_precision>::value) {
+    if (include_summand_b<propto, T_precision>) {
       logp += lgamma(n_plus_phi[i]);
     }
     logp -= (n_plus_phi[i]) * logsumexp_eta_logphi[i];

--- a/stan/math/prim/scal/prob/neg_binomial_2_lpmf.hpp
+++ b/stan/math/prim/scal/prob/neg_binomial_2_lpmf.hpp
@@ -35,7 +35,7 @@ return_type_t<T_location, T_precision> neg_binomial_2_lpmf(
   check_consistent_sizes(function, "Failures variable", n, "Location parameter",
                          mu, "Precision parameter", phi);
 
-  if (!include_summand<propto, T_location, T_precision>::value) {
+  if (!include_summand_b<propto, T_location, T_precision>) {
     return 0.0;
   }
 
@@ -78,16 +78,16 @@ return_type_t<T_location, T_precision> neg_binomial_2_lpmf(
   }
 
   for (size_t i = 0; i < size; i++) {
-    if (include_summand<propto>::value) {
+    if (include_summand_b<propto>) {
       logp -= lgamma(n_vec[i] + 1.0);
     }
-    if (include_summand<propto, T_precision>::value) {
+    if (include_summand_b<propto, T_precision>) {
       logp += multiply_log(phi__[i], phi__[i]) - lgamma(phi__[i]);
     }
-    if (include_summand<propto, T_location>::value) {
+    if (include_summand_b<propto, T_location>) {
       logp += multiply_log(n_vec[i], mu__[i]);
     }
-    if (include_summand<propto, T_precision>::value) {
+    if (include_summand_b<propto, T_precision>) {
       logp += lgamma(n_plus_phi[i]);
     }
     logp -= (n_plus_phi[i]) * log_mu_plus_phi[i];

--- a/stan/math/prim/scal/prob/neg_binomial_lpmf.hpp
+++ b/stan/math/prim/scal/prob/neg_binomial_lpmf.hpp
@@ -37,7 +37,7 @@ return_type_t<T_shape, T_inv_scale> neg_binomial_lpmf(const T_n& n,
   check_consistent_sizes(function, "Failures variable", n, "Shape parameter",
                          alpha, "Inverse scale parameter", beta);
 
-  if (!include_summand<propto, T_shape, T_inv_scale>::value) {
+  if (!include_summand_b<propto, T_shape, T_inv_scale>) {
     return 0.0;
   }
 
@@ -105,7 +105,7 @@ return_type_t<T_shape, T_inv_scale> neg_binomial_lpmf(const T_n& n,
 
   for (size_t i = 0; i < size; i++) {
     if (alpha_vec[i] > 1e10) {  // reduces numerically to Poisson
-      if (include_summand<propto>::value) {
+      if (include_summand_b<propto>) {
         logp -= lgamma(n_vec[i] + 1.0);
       }
       logp += multiply_log(n_vec[i], lambda[i]) - lambda[i];
@@ -119,7 +119,7 @@ return_type_t<T_shape, T_inv_scale> neg_binomial_lpmf(const T_n& n,
             += (lambda[i] - n_vec[i]) / value_of(beta_vec[i]);
       }
     } else {  // standard density definition
-      if (include_summand<propto, T_shape>::value) {
+      if (include_summand_b<propto, T_shape>) {
         if (n_vec[i] != 0) {
           logp += binomial_coefficient_log(
               n_vec[i] + value_of(alpha_vec[i]) - 1.0, n_vec[i]);

--- a/stan/math/prim/scal/prob/normal_lpdf.hpp
+++ b/stan/math/prim/scal/prob/normal_lpdf.hpp
@@ -65,8 +65,7 @@ inline return_type_t<T_y, T_loc, T_scale> normal_lpdf(const T_y& y,
   size_t N = max_size(y, mu, sigma);
 
   VectorBuilder<true, T_partials_return, T_scale> inv_sigma(length(sigma));
-  VectorBuilder<include_summand_b<propto, T_scale>, T_partials_return,
-                T_scale>
+  VectorBuilder<include_summand_b<propto, T_scale>, T_partials_return, T_scale>
       log_sigma(length(sigma));
   for (size_t i = 0; i < length(sigma); i++) {
     inv_sigma[i] = 1.0 / value_of(sigma_vec[i]);

--- a/stan/math/prim/scal/prob/normal_lpdf.hpp
+++ b/stan/math/prim/scal/prob/normal_lpdf.hpp
@@ -53,7 +53,7 @@ inline return_type_t<T_y, T_loc, T_scale> normal_lpdf(const T_y& y,
   check_positive(function, "Scale parameter", sigma);
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Scale parameter", sigma);
-  if (!include_summand<propto, T_y, T_loc, T_scale>::value) {
+  if (!include_summand_b<propto, T_y, T_loc, T_scale>) {
     return 0.0;
   }
 
@@ -65,12 +65,12 @@ inline return_type_t<T_y, T_loc, T_scale> normal_lpdf(const T_y& y,
   size_t N = max_size(y, mu, sigma);
 
   VectorBuilder<true, T_partials_return, T_scale> inv_sigma(length(sigma));
-  VectorBuilder<include_summand<propto, T_scale>::value, T_partials_return,
+  VectorBuilder<include_summand_b<propto, T_scale>, T_partials_return,
                 T_scale>
       log_sigma(length(sigma));
   for (size_t i = 0; i < length(sigma); i++) {
     inv_sigma[i] = 1.0 / value_of(sigma_vec[i]);
-    if (include_summand<propto, T_scale>::value) {
+    if (include_summand_b<propto, T_scale>) {
       log_sigma[i] = log(value_of(sigma_vec[i]));
     }
   }
@@ -86,10 +86,10 @@ inline return_type_t<T_y, T_loc, T_scale> normal_lpdf(const T_y& y,
 
     static double NEGATIVE_HALF = -0.5;
 
-    if (include_summand<propto>::value) {
+    if (include_summand_b<propto>) {
       logp += NEG_LOG_SQRT_TWO_PI;
     }
-    if (include_summand<propto, T_scale>::value) {
+    if (include_summand_b<propto, T_scale>) {
       logp -= log_sigma[n];
     }
     logp += NEGATIVE_HALF * y_minus_mu_over_sigma_squared;

--- a/stan/math/prim/scal/prob/normal_sufficient_lpdf.hpp
+++ b/stan/math/prim/scal/prob/normal_sufficient_lpdf.hpp
@@ -76,7 +76,7 @@ return_type_t<T_y, T_s, T_loc, T_scale> normal_sufficient_lpdf(
                          s_squared, "Number of observations", n_obs,
                          "Location parameter", mu, "Scale parameter", sigma);
   // check if no variables are involved and prop-to
-  if (!include_summand<propto, T_y, T_s, T_loc, T_scale>::value) {
+  if (!include_summand_b<propto, T_y, T_s, T_loc, T_scale>) {
     return 0.0;
   }
 
@@ -99,11 +99,11 @@ return_type_t<T_y, T_s, T_loc, T_scale> normal_sufficient_lpdf(
     const T_partials_return sigma_dbl = value_of(sigma_vec[i]);
     const T_partials_return sigma_squared = pow(sigma_dbl, 2);
 
-    if (include_summand<propto>::value) {
+    if (include_summand_b<propto>) {
       logp += NEG_LOG_SQRT_TWO_PI * n_obs_dbl;
     }
 
-    if (include_summand<propto, T_scale>::value) {
+    if (include_summand_b<propto, T_scale>) {
       logp -= n_obs_dbl * log(sigma_dbl);
     }
 

--- a/stan/math/prim/scal/prob/pareto_lpdf.hpp
+++ b/stan/math/prim/scal/prob/pareto_lpdf.hpp
@@ -30,7 +30,7 @@ return_type_t<T_y, T_scale, T_shape> pareto_lpdf(const T_y& y,
     return 0;
   }
 
-  if (!include_summand<propto, T_y, T_scale, T_shape>::value) {
+  if (!include_summand_b<propto, T_y, T_scale, T_shape>) {
     return 0;
   }
 
@@ -49,10 +49,9 @@ return_type_t<T_y, T_scale, T_shape> pareto_lpdf(const T_y& y,
 
   operands_and_partials<T_y, T_scale, T_shape> ops_partials(y, y_min, alpha);
 
-  VectorBuilder<include_summand<propto, T_y, T_shape>::value, T_partials_return,
-                T_y>
+  VectorBuilder<include_summand_b<propto, T_y, T_shape>, T_partials_return, T_y>
       log_y(length(y));
-  if (include_summand<propto, T_y, T_shape>::value) {
+  if (include_summand_b<propto, T_y, T_shape>) {
     for (size_t n = 0; n < length(y); n++) {
       log_y[n] = log(value_of(y_vec[n]));
     }
@@ -66,19 +65,19 @@ return_type_t<T_y, T_scale, T_shape> pareto_lpdf(const T_y& y,
     }
   }
 
-  VectorBuilder<include_summand<propto, T_scale, T_shape>::value,
+  VectorBuilder<include_summand_b<propto, T_scale, T_shape>,
                 T_partials_return, T_scale>
       log_y_min(length(y_min));
-  if (include_summand<propto, T_scale, T_shape>::value) {
+  if (include_summand_b<propto, T_scale, T_shape>) {
     for (size_t n = 0; n < length(y_min); n++) {
       log_y_min[n] = log(value_of(y_min_vec[n]));
     }
   }
 
-  VectorBuilder<include_summand<propto, T_shape>::value, T_partials_return,
+  VectorBuilder<include_summand_b<propto, T_shape>, T_partials_return,
                 T_shape>
       log_alpha(length(alpha));
-  if (include_summand<propto, T_shape>::value) {
+  if (include_summand_b<propto, T_shape>) {
     for (size_t n = 0; n < length(alpha); n++) {
       log_alpha[n] = log(value_of(alpha_vec[n]));
     }
@@ -86,13 +85,13 @@ return_type_t<T_y, T_scale, T_shape> pareto_lpdf(const T_y& y,
 
   for (size_t n = 0; n < N; n++) {
     const T_partials_return alpha_dbl = value_of(alpha_vec[n]);
-    if (include_summand<propto, T_shape>::value) {
+    if (include_summand_b<propto, T_shape>) {
       logp += log_alpha[n];
     }
-    if (include_summand<propto, T_scale, T_shape>::value) {
+    if (include_summand_b<propto, T_scale, T_shape>) {
       logp += alpha_dbl * log_y_min[n];
     }
-    if (include_summand<propto, T_y, T_shape>::value) {
+    if (include_summand_b<propto, T_y, T_shape>) {
       logp -= alpha_dbl * log_y[n] + log_y[n];
     }
 

--- a/stan/math/prim/scal/prob/pareto_lpdf.hpp
+++ b/stan/math/prim/scal/prob/pareto_lpdf.hpp
@@ -65,8 +65,8 @@ return_type_t<T_y, T_scale, T_shape> pareto_lpdf(const T_y& y,
     }
   }
 
-  VectorBuilder<include_summand_b<propto, T_scale, T_shape>,
-                T_partials_return, T_scale>
+  VectorBuilder<include_summand_b<propto, T_scale, T_shape>, T_partials_return,
+                T_scale>
       log_y_min(length(y_min));
   if (include_summand_b<propto, T_scale, T_shape>) {
     for (size_t n = 0; n < length(y_min); n++) {
@@ -74,8 +74,7 @@ return_type_t<T_y, T_scale, T_shape> pareto_lpdf(const T_y& y,
     }
   }
 
-  VectorBuilder<include_summand_b<propto, T_shape>, T_partials_return,
-                T_shape>
+  VectorBuilder<include_summand_b<propto, T_shape>, T_partials_return, T_shape>
       log_alpha(length(alpha));
   if (include_summand_b<propto, T_shape>) {
     for (size_t n = 0; n < length(alpha); n++) {

--- a/stan/math/prim/scal/prob/pareto_type_2_lpdf.hpp
+++ b/stan/math/prim/scal/prob/pareto_type_2_lpdf.hpp
@@ -39,7 +39,7 @@ return_type_t<T_y, T_loc, T_scale, T_shape> pareto_type_2_lpdf(
   check_consistent_sizes(function, "Random variable", y, "Scale parameter",
                          lambda, "Shape parameter", alpha);
 
-  if (!include_summand<propto, T_y, T_loc, T_scale, T_shape>::value) {
+  if (!include_summand_b<propto, T_y, T_loc, T_scale, T_shape>) {
     return 0.0;
   }
 
@@ -52,7 +52,7 @@ return_type_t<T_y, T_loc, T_scale, T_shape> pareto_type_2_lpdf(
   operands_and_partials<T_y, T_loc, T_scale, T_shape> ops_partials(
       y, mu, lambda, alpha);
 
-  VectorBuilder<include_summand<propto, T_y, T_loc, T_scale, T_shape>::value,
+  VectorBuilder<include_summand_b<propto, T_y, T_loc, T_scale, T_shape>,
                 T_partials_return, T_y, T_loc, T_scale>
       log1p_scaled_diff(N);
   for (size_t n = 0; n < N; n++) {
@@ -60,19 +60,17 @@ return_type_t<T_y, T_loc, T_scale, T_shape> pareto_type_2_lpdf(
                                  / value_of(lambda_vec[n]));
   }
 
-  VectorBuilder<include_summand<propto, T_scale>::value, T_partials_return,
-                T_scale>
+  VectorBuilder<include_summand_b<propto, T_scale>, T_partials_return, T_scale>
       log_lambda(length(lambda));
-  if (include_summand<propto, T_scale>::value) {
+  if (include_summand_b<propto, T_scale>) {
     for (size_t n = 0; n < length(lambda); n++) {
       log_lambda[n] = log(value_of(lambda_vec[n]));
     }
   }
 
-  VectorBuilder<include_summand<propto, T_shape>::value, T_partials_return,
-                T_shape>
+  VectorBuilder<include_summand_b<propto, T_shape>, T_partials_return, T_shape>
       log_alpha(length(alpha));
-  if (include_summand<propto, T_shape>::value) {
+  if (include_summand_b<propto, T_shape>) {
     for (size_t n = 0; n < length(alpha); n++) {
       log_alpha[n] = log(value_of(alpha_vec[n]));
     }
@@ -96,13 +94,13 @@ return_type_t<T_y, T_loc, T_scale, T_shape> pareto_type_2_lpdf(
     const T_partials_return alpha_div_sum = alpha_dbl / sum_dbl;
     const T_partials_return deriv_1_2 = inv_sum + alpha_div_sum;
 
-    if (include_summand<propto, T_shape>::value) {
+    if (include_summand_b<propto, T_shape>) {
       logp += log_alpha[n];
     }
-    if (include_summand<propto, T_scale>::value) {
+    if (include_summand_b<propto, T_scale>) {
       logp -= log_lambda[n];
     }
-    if (include_summand<propto, T_y, T_scale, T_shape>::value) {
+    if (include_summand_b<propto, T_y, T_scale, T_shape>) {
       logp -= (alpha_dbl + 1.0) * log1p_scaled_diff[n];
     }
 

--- a/stan/math/prim/scal/prob/poisson_log_lpmf.hpp
+++ b/stan/math/prim/scal/prob/poisson_log_lpmf.hpp
@@ -36,7 +36,7 @@ return_type_t<T_log_rate> poisson_log_lpmf(const T_n& n,
   check_consistent_sizes(function, "Random variable", n, "Log rate parameter",
                          alpha);
 
-  if (!include_summand<propto, T_log_rate>::value) {
+  if (!include_summand_b<propto, T_log_rate>) {
     return 0.0;
   }
 
@@ -60,7 +60,7 @@ return_type_t<T_log_rate> poisson_log_lpmf(const T_n& n,
   operands_and_partials<T_log_rate> ops_partials(alpha);
 
   // FIXME: cache value_of for alpha_vec?  faster if only one?
-  VectorBuilder<include_summand<propto, T_log_rate>::value, T_partials_return,
+  VectorBuilder<include_summand_b<propto, T_log_rate>, T_partials_return,
                 T_log_rate>
       exp_alpha(length(alpha));
   for (size_t i = 0; i < length(alpha); i++) {
@@ -70,7 +70,7 @@ return_type_t<T_log_rate> poisson_log_lpmf(const T_n& n,
   for (size_t i = 0; i < size; i++) {
     if (!(alpha_vec[i] == -std::numeric_limits<double>::infinity()
           && n_vec[i] == 0)) {
-      if (include_summand<propto>::value) {
+      if (include_summand_b<propto>) {
         logp -= lgamma(n_vec[i] + 1.0);
       }
       logp += n_vec[i] * value_of(alpha_vec[i]) - exp_alpha[i];

--- a/stan/math/prim/scal/prob/poisson_lpmf.hpp
+++ b/stan/math/prim/scal/prob/poisson_lpmf.hpp
@@ -35,7 +35,7 @@ return_type_t<T_rate> poisson_lpmf(const T_n& n, const T_rate& lambda) {
   check_consistent_sizes(function, "Random variable", n, "Rate parameter",
                          lambda);
 
-  if (!include_summand<propto, T_rate>::value) {
+  if (!include_summand_b<propto, T_rate>) {
     return 0.0;
   }
 
@@ -58,7 +58,7 @@ return_type_t<T_rate> poisson_lpmf(const T_n& n, const T_rate& lambda) {
 
   for (size_t i = 0; i < size; i++) {
     if (!(lambda_vec[i] == 0 && n_vec[i] == 0)) {
-      if (include_summand<propto>::value) {
+      if (include_summand_b<propto>) {
         logp -= lgamma(n_vec[i] + 1.0);
       }
       logp += multiply_log(n_vec[i], value_of(lambda_vec[i]))

--- a/stan/math/prim/scal/prob/rayleigh_cdf.hpp
+++ b/stan/math/prim/scal/prob/rayleigh_cdf.hpp
@@ -51,7 +51,7 @@ return_type_t<T_y, T_scale> rayleigh_cdf(const T_y& y, const T_scale& sigma) {
     const T_partials_return inv_sigma_sqr = inv_sigma[n] * inv_sigma[n];
     const T_partials_return exp_val = exp(-0.5 * y_sqr * inv_sigma_sqr);
 
-    if (include_summand<false, T_y, T_scale>::value) {
+    if (include_summand_b<false, T_y, T_scale>) {
       cdf *= (1.0 - exp_val);
     }
   }

--- a/stan/math/prim/scal/prob/rayleigh_lccdf.hpp
+++ b/stan/math/prim/scal/prob/rayleigh_lccdf.hpp
@@ -47,7 +47,7 @@ return_type_t<T_y, T_scale> rayleigh_lccdf(const T_y& y, const T_scale& sigma) {
     const T_partials_return y_sqr = y_dbl * y_dbl;
     const T_partials_return inv_sigma_sqr = inv_sigma[n] * inv_sigma[n];
 
-    if (include_summand<false, T_y, T_scale>::value) {
+    if (include_summand_b<false, T_y, T_scale>) {
       ccdf_log += -0.5 * y_sqr * inv_sigma_sqr;
     }
 

--- a/stan/math/prim/scal/prob/rayleigh_lcdf.hpp
+++ b/stan/math/prim/scal/prob/rayleigh_lcdf.hpp
@@ -52,7 +52,7 @@ return_type_t<T_y, T_scale> rayleigh_lcdf(const T_y& y, const T_scale& sigma) {
     const T_partials_return exp_val = exp(-0.5 * y_sqr * inv_sigma_sqr);
     const T_partials_return exp_div_1m_exp = exp_val / (1.0 - exp_val);
 
-    if (include_summand<false, T_y, T_scale>::value) {
+    if (include_summand_b<false, T_y, T_scale>) {
       cdf_log += log1m(exp_val);
     }
 

--- a/stan/math/prim/scal/prob/rayleigh_lpdf.hpp
+++ b/stan/math/prim/scal/prob/rayleigh_lpdf.hpp
@@ -32,7 +32,7 @@ return_type_t<T_y, T_scale> rayleigh_lpdf(const T_y& y, const T_scale& sigma) {
   check_consistent_sizes(function, "Random variable", y, "Scale parameter",
                          sigma);
 
-  if (!include_summand<propto, T_y, T_scale>::value) {
+  if (!include_summand_b<propto, T_y, T_scale>) {
     return 0.0;
   }
 
@@ -43,12 +43,12 @@ return_type_t<T_y, T_scale> rayleigh_lpdf(const T_y& y, const T_scale& sigma) {
   size_t N = max_size(y, sigma);
 
   VectorBuilder<true, T_partials_return, T_scale> inv_sigma(length(sigma));
-  VectorBuilder<include_summand<propto, T_scale>::value, T_partials_return,
+  VectorBuilder<include_summand_b<propto, T_scale>, T_partials_return,
                 T_scale>
       log_sigma(length(sigma));
   for (size_t i = 0; i < length(sigma); i++) {
     inv_sigma[i] = 1.0 / value_of(sigma_vec[i]);
-    if (include_summand<propto, T_scale>::value) {
+    if (include_summand_b<propto, T_scale>) {
       log_sigma[i] = log(value_of(sigma_vec[i]));
     }
   }
@@ -58,10 +58,10 @@ return_type_t<T_y, T_scale> rayleigh_lpdf(const T_y& y, const T_scale& sigma) {
     const T_partials_return y_over_sigma = y_dbl * inv_sigma[n];
     static double NEGATIVE_HALF = -0.5;
 
-    if (include_summand<propto, T_scale>::value) {
+    if (include_summand_b<propto, T_scale>) {
       logp -= 2.0 * log_sigma[n];
     }
-    if (include_summand<propto, T_y>::value) {
+    if (include_summand_b<propto, T_y>) {
       logp += log(y_dbl);
     }
     logp += NEGATIVE_HALF * y_over_sigma * y_over_sigma;

--- a/stan/math/prim/scal/prob/rayleigh_lpdf.hpp
+++ b/stan/math/prim/scal/prob/rayleigh_lpdf.hpp
@@ -43,8 +43,7 @@ return_type_t<T_y, T_scale> rayleigh_lpdf(const T_y& y, const T_scale& sigma) {
   size_t N = max_size(y, sigma);
 
   VectorBuilder<true, T_partials_return, T_scale> inv_sigma(length(sigma));
-  VectorBuilder<include_summand_b<propto, T_scale>, T_partials_return,
-                T_scale>
+  VectorBuilder<include_summand_b<propto, T_scale>, T_partials_return, T_scale>
       log_sigma(length(sigma));
   for (size_t i = 0; i < length(sigma); i++) {
     inv_sigma[i] = 1.0 / value_of(sigma_vec[i]);

--- a/stan/math/prim/scal/prob/scaled_inv_chi_square_lpdf.hpp
+++ b/stan/math/prim/scal/prob/scaled_inv_chi_square_lpdf.hpp
@@ -51,7 +51,7 @@ return_type_t<T_y, T_dof, T_scale> scaled_inv_chi_square_lpdf(
   if (size_zero(y, nu, s)) {
     return 0;
   }
-  if (!include_summand<propto, T_y, T_dof, T_scale>::value) {
+  if (!include_summand_b<propto, T_y, T_dof, T_scale>) {
     return 0;
   }
   T_partials_return logp(0);
@@ -68,53 +68,52 @@ return_type_t<T_y, T_dof, T_scale> scaled_inv_chi_square_lpdf(
 
   using std::log;
 
-  VectorBuilder<include_summand<propto, T_dof, T_y, T_scale>::value,
+  VectorBuilder<include_summand_b<propto, T_dof, T_y, T_scale>,
                 T_partials_return, T_dof>
       half_nu(length(nu));
   for (size_t i = 0; i < length(nu); i++) {
-    if (include_summand<propto, T_dof, T_y, T_scale>::value) {
+    if (include_summand_b<propto, T_dof, T_y, T_scale>) {
       half_nu[i] = 0.5 * value_of(nu_vec[i]);
     }
   }
 
-  VectorBuilder<include_summand<propto, T_dof, T_y>::value, T_partials_return,
-                T_y>
+  VectorBuilder<include_summand_b<propto, T_dof, T_y>, T_partials_return, T_y>
       log_y(length(y));
   for (size_t i = 0; i < length(y); i++) {
-    if (include_summand<propto, T_dof, T_y>::value) {
+    if (include_summand_b<propto, T_dof, T_y>) {
       log_y[i] = log(value_of(y_vec[i]));
     }
   }
 
-  VectorBuilder<include_summand<propto, T_dof, T_y, T_scale>::value,
+  VectorBuilder<include_summand_b<propto, T_dof, T_y, T_scale>,
                 T_partials_return, T_y>
       inv_y(length(y));
   for (size_t i = 0; i < length(y); i++) {
-    if (include_summand<propto, T_dof, T_y, T_scale>::value) {
+    if (include_summand_b<propto, T_dof, T_y, T_scale>) {
       inv_y[i] = 1.0 / value_of(y_vec[i]);
     }
   }
 
-  VectorBuilder<include_summand<propto, T_dof, T_scale>::value,
+  VectorBuilder<include_summand_b<propto, T_dof, T_scale>,
                 T_partials_return, T_scale>
       log_s(length(s));
   for (size_t i = 0; i < length(s); i++) {
-    if (include_summand<propto, T_dof, T_scale>::value) {
+    if (include_summand_b<propto, T_dof, T_scale>) {
       log_s[i] = log(value_of(s_vec[i]));
     }
   }
 
-  VectorBuilder<include_summand<propto, T_dof>::value, T_partials_return, T_dof>
+  VectorBuilder<include_summand_b<propto, T_dof>, T_partials_return, T_dof>
       log_half_nu(length(nu));
-  VectorBuilder<include_summand<propto, T_dof>::value, T_partials_return, T_dof>
+  VectorBuilder<include_summand_b<propto, T_dof>, T_partials_return, T_dof>
       lgamma_half_nu(length(nu));
   VectorBuilder<!is_constant_all<T_dof>::value, T_partials_return, T_dof>
       digamma_half_nu_over_two(length(nu));
   for (size_t i = 0; i < length(nu); i++) {
-    if (include_summand<propto, T_dof>::value) {
+    if (include_summand_b<propto, T_dof>) {
       lgamma_half_nu[i] = lgamma(half_nu[i]);
     }
-    if (include_summand<propto, T_dof>::value) {
+    if (include_summand_b<propto, T_dof>) {
       log_half_nu[i] = log(half_nu[i]);
     }
     if (!is_constant_all<T_dof>::value) {
@@ -126,16 +125,16 @@ return_type_t<T_y, T_dof, T_scale> scaled_inv_chi_square_lpdf(
   for (size_t n = 0; n < N; n++) {
     const T_partials_return s_dbl = value_of(s_vec[n]);
     const T_partials_return nu_dbl = value_of(nu_vec[n]);
-    if (include_summand<propto, T_dof>::value) {
+    if (include_summand_b<propto, T_dof>) {
       logp += half_nu[n] * log_half_nu[n] - lgamma_half_nu[n];
     }
-    if (include_summand<propto, T_dof, T_scale>::value) {
+    if (include_summand_b<propto, T_dof, T_scale>) {
       logp += nu_dbl * log_s[n];
     }
-    if (include_summand<propto, T_dof, T_y>::value) {
+    if (include_summand_b<propto, T_dof, T_y>) {
       logp -= (half_nu[n] + 1.0) * log_y[n];
     }
-    if (include_summand<propto, T_dof, T_y, T_scale>::value) {
+    if (include_summand_b<propto, T_dof, T_y, T_scale>) {
       logp -= half_nu[n] * s_dbl * s_dbl * inv_y[n];
     }
 

--- a/stan/math/prim/scal/prob/scaled_inv_chi_square_lpdf.hpp
+++ b/stan/math/prim/scal/prob/scaled_inv_chi_square_lpdf.hpp
@@ -94,8 +94,8 @@ return_type_t<T_y, T_dof, T_scale> scaled_inv_chi_square_lpdf(
     }
   }
 
-  VectorBuilder<include_summand_b<propto, T_dof, T_scale>,
-                T_partials_return, T_scale>
+  VectorBuilder<include_summand_b<propto, T_dof, T_scale>, T_partials_return,
+                T_scale>
       log_s(length(s));
   for (size_t i = 0; i < length(s); i++) {
     if (include_summand_b<propto, T_dof, T_scale>) {

--- a/stan/math/prim/scal/prob/skew_normal_lpdf.hpp
+++ b/stan/math/prim/scal/prob/skew_normal_lpdf.hpp
@@ -53,8 +53,7 @@ return_type_t<T_y, T_loc, T_scale, T_shape> skew_normal_lpdf(
   size_t N = max_size(y, mu, sigma, alpha);
 
   VectorBuilder<true, T_partials_return, T_scale> inv_sigma(length(sigma));
-  VectorBuilder<include_summand_b<propto, T_scale>, T_partials_return,
-                T_scale>
+  VectorBuilder<include_summand_b<propto, T_scale>, T_partials_return, T_scale>
       log_sigma(length(sigma));
   for (size_t i = 0; i < length(sigma); i++) {
     inv_sigma[i] = 1.0 / value_of(sigma_vec[i]);

--- a/stan/math/prim/scal/prob/skew_normal_lpdf.hpp
+++ b/stan/math/prim/scal/prob/skew_normal_lpdf.hpp
@@ -39,7 +39,7 @@ return_type_t<T_y, T_loc, T_scale, T_shape> skew_normal_lpdf(
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Scale parameter", sigma, "Shape paramter", alpha);
 
-  if (!include_summand<propto, T_y, T_loc, T_scale, T_shape>::value) {
+  if (!include_summand_b<propto, T_y, T_loc, T_scale, T_shape>) {
     return 0.0;
   }
 
@@ -53,12 +53,12 @@ return_type_t<T_y, T_loc, T_scale, T_shape> skew_normal_lpdf(
   size_t N = max_size(y, mu, sigma, alpha);
 
   VectorBuilder<true, T_partials_return, T_scale> inv_sigma(length(sigma));
-  VectorBuilder<include_summand<propto, T_scale>::value, T_partials_return,
+  VectorBuilder<include_summand_b<propto, T_scale>, T_partials_return,
                 T_scale>
       log_sigma(length(sigma));
   for (size_t i = 0; i < length(sigma); i++) {
     inv_sigma[i] = 1.0 / value_of(sigma_vec[i]);
-    if (include_summand<propto, T_scale>::value) {
+    if (include_summand_b<propto, T_scale>) {
       log_sigma[i] = log(value_of(sigma_vec[i]));
     }
   }
@@ -73,13 +73,13 @@ return_type_t<T_y, T_loc, T_scale, T_shape> skew_normal_lpdf(
         = (y_dbl - mu_dbl) * inv_sigma[n];
     const double pi_dbl = pi();
 
-    if (include_summand<propto>::value) {
+    if (include_summand_b<propto>) {
       logp -= 0.5 * log(2.0 * pi_dbl);
     }
-    if (include_summand<propto, T_scale>::value) {
+    if (include_summand_b<propto, T_scale>) {
       logp -= log(sigma_dbl);
     }
-    if (include_summand<propto, T_y, T_loc, T_scale>::value) {
+    if (include_summand_b<propto, T_y, T_loc, T_scale>) {
       logp -= y_minus_mu_over_sigma * y_minus_mu_over_sigma / 2.0;
     }
     logp += log(erfc(-alpha_dbl * y_minus_mu_over_sigma / std::sqrt(2.0)));

--- a/stan/math/prim/scal/prob/std_normal_lpdf.hpp
+++ b/stan/math/prim/scal/prob/std_normal_lpdf.hpp
@@ -33,7 +33,7 @@ return_type_t<T_y> std_normal_lpdf(const T_y& y) {
 
   check_not_nan(function, "Random variable", y);
 
-  if (!include_summand<propto, T_y>::value) {
+  if (!include_summand_b<propto, T_y>) {
     return 0.0;
   }
 
@@ -48,7 +48,7 @@ return_type_t<T_y> std_normal_lpdf(const T_y& y) {
     }
   }
   logp *= -0.5;
-  if (include_summand<propto>::value) {
+  if (include_summand_b<propto>) {
     logp += NEG_LOG_SQRT_TWO_PI * length(y);
   }
   return ops_partials.build(logp);

--- a/stan/math/prim/scal/prob/student_t_lpdf.hpp
+++ b/stan/math/prim/scal/prob/student_t_lpdf.hpp
@@ -69,7 +69,7 @@ return_type_t<T_y, T_dof, T_loc, T_scale> student_t_lpdf(const T_y& y,
                          "Degrees of freedom parameter", nu,
                          "Location parameter", mu, "Scale parameter", sigma);
 
-  if (!include_summand<propto, T_y, T_dof, T_loc, T_scale>::value) {
+  if (!include_summand_b<propto, T_y, T_dof, T_loc, T_scale>) {
     return 0.0;
   }
 
@@ -81,18 +81,18 @@ return_type_t<T_y, T_dof, T_loc, T_scale> student_t_lpdf(const T_y& y,
 
   using std::log;
 
-  VectorBuilder<include_summand<propto, T_y, T_dof, T_loc, T_scale>::value,
+  VectorBuilder<include_summand_b<propto, T_y, T_dof, T_loc, T_scale>,
                 T_partials_return, T_dof>
       half_nu(length(nu));
   for (size_t i = 0; i < length(nu); i++) {
     half_nu[i] = 0.5 * value_of(nu_vec[i]);
   }
 
-  VectorBuilder<include_summand<propto, T_dof>::value, T_partials_return, T_dof>
+  VectorBuilder<include_summand_b<propto, T_dof>, T_partials_return, T_dof>
       lgamma_half_nu(length(nu));
-  VectorBuilder<include_summand<propto, T_dof>::value, T_partials_return, T_dof>
+  VectorBuilder<include_summand_b<propto, T_dof>, T_partials_return, T_dof>
       lgamma_half_nu_plus_half(length(nu));
-  if (include_summand<propto, T_dof>::value) {
+  if (include_summand_b<propto, T_dof>) {
     for (size_t i = 0; i < length(nu); i++) {
       lgamma_half_nu[i] = lgamma(half_nu[i]);
       lgamma_half_nu_plus_half[i] = lgamma(half_nu[i] + 0.5);
@@ -110,28 +110,28 @@ return_type_t<T_y, T_dof, T_loc, T_scale> student_t_lpdf(const T_y& y,
     }
   }
 
-  VectorBuilder<include_summand<propto, T_dof>::value, T_partials_return, T_dof>
+  VectorBuilder<include_summand_b<propto, T_dof>, T_partials_return, T_dof>
       log_nu(length(nu));
   for (size_t i = 0; i < length(nu); i++) {
-    if (include_summand<propto, T_dof>::value) {
+    if (include_summand_b<propto, T_dof>) {
       log_nu[i] = log(value_of(nu_vec[i]));
     }
   }
 
-  VectorBuilder<include_summand<propto, T_scale>::value, T_partials_return,
+  VectorBuilder<include_summand_b<propto, T_scale>, T_partials_return,
                 T_scale>
       log_sigma(length(sigma));
   for (size_t i = 0; i < length(sigma); i++) {
-    if (include_summand<propto, T_scale>::value) {
+    if (include_summand_b<propto, T_scale>) {
       log_sigma[i] = log(value_of(sigma_vec[i]));
     }
   }
 
-  VectorBuilder<include_summand<propto, T_y, T_dof, T_loc, T_scale>::value,
+  VectorBuilder<include_summand_b<propto, T_y, T_dof, T_loc, T_scale>,
                 T_partials_return, T_y, T_dof, T_loc, T_scale>
       square_y_minus_mu_over_sigma__over_nu(N);
 
-  VectorBuilder<include_summand<propto, T_y, T_dof, T_loc, T_scale>::value,
+  VectorBuilder<include_summand_b<propto, T_y, T_dof, T_loc, T_scale>,
                 T_partials_return, T_y, T_dof, T_loc, T_scale>
       log1p_exp(N);
 
@@ -152,13 +152,13 @@ return_type_t<T_y, T_dof, T_loc, T_scale> student_t_lpdf(const T_y& y,
     const T_partials_return mu_dbl = value_of(mu_vec[n]);
     const T_partials_return sigma_dbl = value_of(sigma_vec[n]);
     const T_partials_return nu_dbl = value_of(nu_vec[n]);
-    if (include_summand<propto>::value) {
+    if (include_summand_b<propto>) {
       logp += NEG_LOG_SQRT_PI;
     }
-    if (include_summand<propto, T_dof>::value) {
+    if (include_summand_b<propto, T_dof>) {
       logp += lgamma_half_nu_plus_half[n] - lgamma_half_nu[n] - 0.5 * log_nu[n];
     }
-    if (include_summand<propto, T_scale>::value) {
+    if (include_summand_b<propto, T_scale>) {
       logp -= log_sigma[n];
     }
     logp -= (half_nu[n] + 0.5) * log1p_exp[n];

--- a/stan/math/prim/scal/prob/student_t_lpdf.hpp
+++ b/stan/math/prim/scal/prob/student_t_lpdf.hpp
@@ -118,8 +118,7 @@ return_type_t<T_y, T_dof, T_loc, T_scale> student_t_lpdf(const T_y& y,
     }
   }
 
-  VectorBuilder<include_summand_b<propto, T_scale>, T_partials_return,
-                T_scale>
+  VectorBuilder<include_summand_b<propto, T_scale>, T_partials_return, T_scale>
       log_sigma(length(sigma));
   for (size_t i = 0; i < length(sigma); i++) {
     if (include_summand_b<propto, T_scale>) {

--- a/stan/math/prim/scal/prob/uniform_lpdf.hpp
+++ b/stan/math/prim/scal/prob/uniform_lpdf.hpp
@@ -73,8 +73,8 @@ return_type_t<T_y, T_low, T_high> uniform_lpdf(const T_y& y, const T_low& alpha,
     }
   }
 
-  VectorBuilder<include_summand_b<propto, T_low, T_high>,
-                T_partials_return, T_low, T_high>
+  VectorBuilder<include_summand_b<propto, T_low, T_high>, T_partials_return,
+                T_low, T_high>
       inv_beta_minus_alpha(max_size(alpha, beta));
   for (size_t i = 0; i < max_size(alpha, beta); i++) {
     if (include_summand_b<propto, T_low, T_high>) {
@@ -83,8 +83,8 @@ return_type_t<T_y, T_low, T_high> uniform_lpdf(const T_y& y, const T_low& alpha,
     }
   }
 
-  VectorBuilder<include_summand_b<propto, T_low, T_high>,
-                T_partials_return, T_low, T_high>
+  VectorBuilder<include_summand_b<propto, T_low, T_high>, T_partials_return,
+                T_low, T_high>
       log_beta_minus_alpha(max_size(alpha, beta));
   for (size_t i = 0; i < max_size(alpha, beta); i++) {
     if (include_summand_b<propto, T_low, T_high>) {

--- a/stan/math/prim/scal/prob/uniform_lpdf.hpp
+++ b/stan/math/prim/scal/prob/uniform_lpdf.hpp
@@ -57,7 +57,7 @@ return_type_t<T_y, T_low, T_high> uniform_lpdf(const T_y& y, const T_low& alpha,
                          "Lower bound parameter", alpha,
                          "Upper bound parameter", beta);
 
-  if (!include_summand<propto, T_y, T_low, T_high>::value) {
+  if (!include_summand_b<propto, T_y, T_low, T_high>) {
     return 0.0;
   }
 
@@ -73,21 +73,21 @@ return_type_t<T_y, T_low, T_high> uniform_lpdf(const T_y& y, const T_low& alpha,
     }
   }
 
-  VectorBuilder<include_summand<propto, T_low, T_high>::value,
+  VectorBuilder<include_summand_b<propto, T_low, T_high>,
                 T_partials_return, T_low, T_high>
       inv_beta_minus_alpha(max_size(alpha, beta));
   for (size_t i = 0; i < max_size(alpha, beta); i++) {
-    if (include_summand<propto, T_low, T_high>::value) {
+    if (include_summand_b<propto, T_low, T_high>) {
       inv_beta_minus_alpha[i]
           = 1.0 / (value_of(beta_vec[i]) - value_of(alpha_vec[i]));
     }
   }
 
-  VectorBuilder<include_summand<propto, T_low, T_high>::value,
+  VectorBuilder<include_summand_b<propto, T_low, T_high>,
                 T_partials_return, T_low, T_high>
       log_beta_minus_alpha(max_size(alpha, beta));
   for (size_t i = 0; i < max_size(alpha, beta); i++) {
-    if (include_summand<propto, T_low, T_high>::value) {
+    if (include_summand_b<propto, T_low, T_high>) {
       log_beta_minus_alpha[i]
           = log(value_of(beta_vec[i]) - value_of(alpha_vec[i]));
     }
@@ -95,7 +95,7 @@ return_type_t<T_y, T_low, T_high> uniform_lpdf(const T_y& y, const T_low& alpha,
 
   operands_and_partials<T_y, T_low, T_high> ops_partials(y, alpha, beta);
   for (size_t n = 0; n < N; n++) {
-    if (include_summand<propto, T_low, T_high>::value) {
+    if (include_summand_b<propto, T_low, T_high>) {
       logp -= log_beta_minus_alpha[n];
     }
 

--- a/stan/math/prim/scal/prob/von_mises_lpdf.hpp
+++ b/stan/math/prim/scal/prob/von_mises_lpdf.hpp
@@ -38,7 +38,7 @@ return_type_t<T_y, T_loc, T_scale> von_mises_lpdf(T_y const& y, T_loc const& mu,
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Scale parameter", kappa);
 
-  if (!include_summand<propto, T_y, T_loc, T_scale>::value) {
+  if (!include_summand_b<propto, T_y, T_loc, T_scale>) {
     return logp;
   }
 
@@ -46,7 +46,7 @@ return_type_t<T_y, T_loc, T_scale> von_mises_lpdf(T_y const& y, T_loc const& mu,
   const bool mu_const = is_constant_all<T_loc>::value;
   const bool kappa_const = is_constant_all<T_scale>::value;
 
-  const bool compute_bessel0 = include_summand<propto, T_scale>::value;
+  const bool compute_bessel0 = include_summand_b<propto, T_scale>;
   const bool compute_bessel1 = !kappa_const;
   const double TWO_PI = 2.0 * pi();
 
@@ -55,12 +55,11 @@ return_type_t<T_y, T_loc, T_scale> von_mises_lpdf(T_y const& y, T_loc const& mu,
   scalar_seq_view<T_scale> kappa_vec(kappa);
 
   VectorBuilder<true, T_partials_return, T_scale> kappa_dbl(length(kappa));
-  VectorBuilder<include_summand<propto, T_scale>::value, T_partials_return,
-                T_scale>
+  VectorBuilder<include_summand_b<propto, T_scale>, T_partials_return, T_scale>
       log_bessel0(length(kappa));
   for (size_t i = 0; i < length(kappa); i++) {
     kappa_dbl[i] = value_of(kappa_vec[i]);
-    if (include_summand<propto, T_scale>::value) {
+    if (include_summand_b<propto, T_scale>) {
       log_bessel0[i]
           = log_modified_bessel_first_kind(0, value_of(kappa_vec[i]));
     }
@@ -86,10 +85,10 @@ return_type_t<T_y, T_loc, T_scale> von_mises_lpdf(T_y const& y, T_loc const& mu,
     const T_partials_return kappa_sin = kappa_dbl[n] * sin(mu_dbl - y_dbl);
     const T_partials_return kappa_cos = kappa_dbl[n] * cos(mu_dbl - y_dbl);
 
-    if (include_summand<propto>::value) {
+    if (include_summand_b<propto>) {
       logp -= LOG_TWO_PI;
     }
-    if (include_summand<propto, T_scale>::value) {
+    if (include_summand_b<propto, T_scale>) {
       logp -= log_bessel0[n];
     }
     logp += kappa_cos;

--- a/stan/math/prim/scal/prob/weibull_lpdf.hpp
+++ b/stan/math/prim/scal/prob/weibull_lpdf.hpp
@@ -62,8 +62,7 @@ return_type_t<T_y, T_shape, T_scale> weibull_lpdf(const T_y& y,
     }
   }
 
-  VectorBuilder<include_summand_b<propto, T_shape>, T_partials_return,
-                T_shape>
+  VectorBuilder<include_summand_b<propto, T_shape>, T_partials_return, T_shape>
       log_alpha(length(alpha));
   for (size_t i = 0; i < length(alpha); i++) {
     if (include_summand_b<propto, T_shape>) {
@@ -79,8 +78,8 @@ return_type_t<T_y, T_shape, T_scale> weibull_lpdf(const T_y& y,
     }
   }
 
-  VectorBuilder<include_summand_b<propto, T_shape, T_scale>,
-                T_partials_return, T_scale>
+  VectorBuilder<include_summand_b<propto, T_shape, T_scale>, T_partials_return,
+                T_scale>
       log_sigma(length(sigma));
   for (size_t i = 0; i < length(sigma); i++) {
     if (include_summand_b<propto, T_shape, T_scale>) {

--- a/stan/math/prim/scal/prob/weibull_lpdf.hpp
+++ b/stan/math/prim/scal/prob/weibull_lpdf.hpp
@@ -45,7 +45,7 @@ return_type_t<T_y, T_shape, T_scale> weibull_lpdf(const T_y& y,
   if (size_zero(y, alpha, sigma)) {
     return 0;
   }
-  if (!include_summand<propto, T_y, T_shape, T_scale>::value) {
+  if (!include_summand_b<propto, T_y, T_shape, T_scale>) {
     return 0;
   }
 
@@ -62,41 +62,40 @@ return_type_t<T_y, T_shape, T_scale> weibull_lpdf(const T_y& y,
     }
   }
 
-  VectorBuilder<include_summand<propto, T_shape>::value, T_partials_return,
+  VectorBuilder<include_summand_b<propto, T_shape>, T_partials_return,
                 T_shape>
       log_alpha(length(alpha));
   for (size_t i = 0; i < length(alpha); i++) {
-    if (include_summand<propto, T_shape>::value) {
+    if (include_summand_b<propto, T_shape>) {
       log_alpha[i] = log(value_of(alpha_vec[i]));
     }
   }
 
-  VectorBuilder<include_summand<propto, T_y, T_shape>::value, T_partials_return,
-                T_y>
+  VectorBuilder<include_summand_b<propto, T_y, T_shape>, T_partials_return, T_y>
       log_y(length(y));
   for (size_t i = 0; i < length(y); i++) {
-    if (include_summand<propto, T_y, T_shape>::value) {
+    if (include_summand_b<propto, T_y, T_shape>) {
       log_y[i] = log(value_of(y_vec[i]));
     }
   }
 
-  VectorBuilder<include_summand<propto, T_shape, T_scale>::value,
+  VectorBuilder<include_summand_b<propto, T_shape, T_scale>,
                 T_partials_return, T_scale>
       log_sigma(length(sigma));
   for (size_t i = 0; i < length(sigma); i++) {
-    if (include_summand<propto, T_shape, T_scale>::value) {
+    if (include_summand_b<propto, T_shape, T_scale>) {
       log_sigma[i] = log(value_of(sigma_vec[i]));
     }
   }
 
-  VectorBuilder<include_summand<propto, T_y, T_shape, T_scale>::value,
+  VectorBuilder<include_summand_b<propto, T_y, T_shape, T_scale>,
                 T_partials_return, T_scale>
       inv_sigma(length(sigma));
   for (size_t i = 0; i < length(sigma); i++) {
     inv_sigma[i] = 1.0 / value_of(sigma_vec[i]);
   }
 
-  VectorBuilder<include_summand<propto, T_y, T_shape, T_scale>::value,
+  VectorBuilder<include_summand_b<propto, T_y, T_shape, T_scale>,
                 T_partials_return, T_y, T_shape, T_scale>
       y_div_sigma_pow_alpha(N);
   for (size_t i = 0; i < N; i++) {
@@ -108,13 +107,13 @@ return_type_t<T_y, T_shape, T_scale> weibull_lpdf(const T_y& y,
   operands_and_partials<T_y, T_shape, T_scale> ops_partials(y, alpha, sigma);
   for (size_t n = 0; n < N; n++) {
     const T_partials_return alpha_dbl = value_of(alpha_vec[n]);
-    if (include_summand<propto, T_shape>::value) {
+    if (include_summand_b<propto, T_shape>) {
       logp += log_alpha[n];
     }
-    if (include_summand<propto, T_y, T_shape>::value) {
+    if (include_summand_b<propto, T_y, T_shape>) {
       logp += (alpha_dbl - 1.0) * log_y[n];
     }
-    if (include_summand<propto, T_shape, T_scale>::value) {
+    if (include_summand_b<propto, T_shape, T_scale>) {
       logp -= alpha_dbl * log_sigma[n];
     }
     logp -= y_div_sigma_pow_alpha[n];

--- a/stan/math/prim/scal/prob/wiener_lpdf.hpp
+++ b/stan/math/prim/scal/prob/wiener_lpdf.hpp
@@ -136,7 +136,7 @@ return_type_t<T_y, T_alpha, T_tau, T_beta, T_delta> wiener_lpdf(
     }
   }
 
-  if (!include_summand<propto, T_y, T_alpha, T_tau, T_beta, T_delta>::value) {
+  if (!include_summand_b<propto, T_y, T_alpha, T_tau, T_beta, T_delta>) {
     return 0;
   }
 

--- a/test/prob/frechet/frechet_test.hpp
+++ b/test/prob/frechet/frechet_test.hpp
@@ -69,7 +69,6 @@ class AgradDistributionsFrechet : public AgradDistributionTest {
   typename stan::return_type<T_y, T_shape, T_scale>::type log_prob_function(
       const T_y& y, const T_shape& alpha, const T_scale& sigma, const T3&,
       const T4&, const T5&) {
-    using stan::math::include_summand;
     using stan::math::multiply_log;
     using stan::math::value_of;
     using std::log;

--- a/test/prob/normal_sufficient/normal_sufficient_test.hpp
+++ b/test/prob/normal_sufficient/normal_sufficient_test.hpp
@@ -96,12 +96,12 @@ class AgradDistributionNormalSufficient : public AgradDistributionTest {
     using stan::math::pi;
     using stan::math::square;
     typename stan::return_type<T_y, T_s, T_n, T_loc, T_scale>::type lp(0.0);
-    if (include_summand<true, T_scale>::value)
+    if (include_summand_b<true, T_scale>)
       lp -= n_obs * log(sigma);
 
     lp -= (s_squared + n_obs * pow(y_bar - mu, 2)) / (2 * pow(sigma, 2));
 
-    if (include_summand<true>::value)
+    if (include_summand_b<true>)
       lp -= log(sqrt(2.0 * pi()));
     return lp;
   }

--- a/test/prob/uniform/uniform_ccdf_log_test.hpp
+++ b/test/prob/uniform/uniform_ccdf_log_test.hpp
@@ -59,7 +59,6 @@ class AgradCcdfLogUniform : public AgradCcdfLogTest {
       const T_y& y, const T_low& alpha, const T_high& beta, const T3&,
       const T4&, const T5&) {
     using stan::math::LOG_ZERO;
-    using stan::math::include_summand;
 
     if (y < alpha || y > beta)
       return 0.0;

--- a/test/prob/uniform/uniform_cdf_log_test.hpp
+++ b/test/prob/uniform/uniform_cdf_log_test.hpp
@@ -59,7 +59,6 @@ class AgradCdfLogUniform : public AgradCdfLogTest {
       const T_y& y, const T_low& alpha, const T_high& beta, const T3&,
       const T4&, const T5&) {
     using stan::math::LOG_ZERO;
-    using stan::math::include_summand;
 
     if (y < alpha || y > beta)
       return LOG_ZERO;

--- a/test/prob/uniform/uniform_cdf_test.hpp
+++ b/test/prob/uniform/uniform_cdf_test.hpp
@@ -60,7 +60,6 @@ class AgradCdfUniform : public AgradCdfTest {
       const T_y& y, const T_low& alpha, const T_high& beta, const T3&,
       const T4&, const T5&) {
     using stan::math::LOG_ZERO;
-    using stan::math::include_summand;
 
     if (y < alpha || y > beta)
       return 0.0;

--- a/test/unit/math/fwd/meta/include_summand_test.cpp
+++ b/test/unit/math/fwd/meta/include_summand_test.cpp
@@ -14,9 +14,8 @@ TEST(MathMetaFwd, IncludeSummandProptoTrueFvarFvarDouble) {
 }
 
 TEST(MathMetaFwd, IncludeSummandProtoTrueFvarDoubleTen) {
-  EXPECT_TRUE(
-      (include_summand_b<true, double, fvar<double>, int, fvar<double>, double,
-                         double, int, int, fvar<double>, int>));
+  EXPECT_TRUE((include_summand_b<true, double, fvar<double>, int, fvar<double>,
+                                 double, double, int, int, fvar<double>, int>));
 }
 
 TEST(MathMetaFwd, IncludeSummandProtoTrueFvarFvarDoubleTen) {

--- a/test/unit/math/fwd/meta/include_summand_test.cpp
+++ b/test/unit/math/fwd/meta/include_summand_test.cpp
@@ -3,24 +3,24 @@
 #include <test/unit/util.hpp>
 
 using stan::math::fvar;
-using stan::math::include_summand;
+using stan::math::include_summand_b;
 
 TEST(MathMetaFwd, IncludeSummandProptoTrueFvarDouble) {
-  EXPECT_TRUE((include_summand<true, fvar<double> >::value));
+  EXPECT_TRUE((include_summand_b<true, fvar<double>>));
 }
 
 TEST(MathMetaFwd, IncludeSummandProptoTrueFvarFvarDouble) {
-  EXPECT_TRUE((include_summand<true, fvar<fvar<double> > >::value));
+  EXPECT_TRUE((include_summand_b<true, fvar<fvar<double>>>));
 }
 
 TEST(MathMetaFwd, IncludeSummandProtoTrueFvarDoubleTen) {
   EXPECT_TRUE(
-      (include_summand<true, double, fvar<double>, int, fvar<double>, double,
-                       double, int, int, fvar<double>, int>::value));
+      (include_summand_b<true, double, fvar<double>, int, fvar<double>, double,
+                         double, int, int, fvar<double>, int>));
 }
 
 TEST(MathMetaFwd, IncludeSummandProtoTrueFvarFvarDoubleTen) {
-  EXPECT_TRUE((include_summand<true, double, fvar<fvar<double> >, int,
-                               fvar<fvar<double> >, double, double, int, int,
-                               fvar<fvar<double> >, int>::value));
+  EXPECT_TRUE((include_summand_b<true, double, fvar<fvar<double>>, int,
+                                 fvar<fvar<double>>, double, double, int, int,
+                                 fvar<fvar<double>>, int>));
 }

--- a/test/unit/math/mix/meta/include_summand_test.cpp
+++ b/test/unit/math/mix/meta/include_summand_test.cpp
@@ -4,23 +4,31 @@
 
 using stan::math::fvar;
 using stan::math::include_summand;
+using stan::math::include_summand_b;
 using stan::math::var;
 
 TEST(MathMetaMix, IncludeSummandProptoTrueFvarVar) {
   EXPECT_TRUE((include_summand<true, fvar<var> >::value));
+  EXPECT_TRUE((include_summand_b<true, fvar<var>>));
 }
 
 TEST(MathMetaMix, IncludeSummandProptoTrueFvarFvarVar) {
   EXPECT_TRUE((include_summand<true, fvar<fvar<var> > >::value));
+  EXPECT_TRUE((include_summand_b<true, fvar<fvar<var>>>));
 }
 
 TEST(MathMetaMix, IncludeSummandProtoTrueFvarVarTen) {
   EXPECT_TRUE((include_summand<true, double, fvar<var>, int, fvar<var>, double,
                                double, int, int, fvar<var>, int>::value));
+  EXPECT_TRUE((include_summand_b<true, double, fvar<var>, int, fvar<var>,
+                                 double, double, int, int, fvar<var>, int>));
 }
 
 TEST(MathMetaMix, IncludeSummandProtoTrueFvarFvarVarTen) {
   EXPECT_TRUE((
       include_summand<true, double, fvar<fvar<var> >, int, fvar<fvar<var> >,
                       double, double, int, int, fvar<fvar<var> >, int>::value));
+  EXPECT_TRUE((
+      include_summand_b<true, double, fvar<fvar<var>>, int, fvar<fvar<var>>,
+                        double, double, int, int, fvar<fvar<var>>, int>));
 }

--- a/test/unit/math/mix/meta/include_summand_test.cpp
+++ b/test/unit/math/mix/meta/include_summand_test.cpp
@@ -8,12 +8,12 @@ using stan::math::include_summand_b;
 using stan::math::var;
 
 TEST(MathMetaMix, IncludeSummandProptoTrueFvarVar) {
-  EXPECT_TRUE((include_summand<true, fvar<var> >::value));
+  EXPECT_TRUE((include_summand<true, fvar<var>>::value));
   EXPECT_TRUE((include_summand_b<true, fvar<var>>));
 }
 
 TEST(MathMetaMix, IncludeSummandProptoTrueFvarFvarVar) {
-  EXPECT_TRUE((include_summand<true, fvar<fvar<var> > >::value));
+  EXPECT_TRUE((include_summand<true, fvar<fvar<var>>>::value));
   EXPECT_TRUE((include_summand_b<true, fvar<fvar<var>>>));
 }
 
@@ -25,10 +25,10 @@ TEST(MathMetaMix, IncludeSummandProtoTrueFvarVarTen) {
 }
 
 TEST(MathMetaMix, IncludeSummandProtoTrueFvarFvarVarTen) {
-  EXPECT_TRUE((
-      include_summand<true, double, fvar<fvar<var> >, int, fvar<fvar<var> >,
-                      double, double, int, int, fvar<fvar<var> >, int>::value));
-  EXPECT_TRUE((
-      include_summand_b<true, double, fvar<fvar<var>>, int, fvar<fvar<var>>,
-                        double, double, int, int, fvar<fvar<var>>, int>));
+  EXPECT_TRUE(
+      (include_summand<true, double, fvar<fvar<var>>, int, fvar<fvar<var>>,
+                       double, double, int, int, fvar<fvar<var>>, int>::value));
+  EXPECT_TRUE(
+      (include_summand_b<true, double, fvar<fvar<var>>, int, fvar<fvar<var>>,
+                         double, double, int, int, fvar<fvar<var>>, int>));
 }

--- a/test/unit/math/prim/meta/include_summand_test.cpp
+++ b/test/unit/math/prim/meta/include_summand_test.cpp
@@ -2,26 +2,26 @@
 #include <gtest/gtest.h>
 #include <test/unit/util.hpp>
 
-using stan::math::include_summand;
+using stan::math::include_summand_b;
 
 TEST(MathMetaPrim, IncludeSummandProptoFalse) {
-  EXPECT_TRUE(include_summand<false>::value);
+  EXPECT_TRUE(include_summand_b<false>);
 }
 
 TEST(MathMetaPrim, IncludeSummandProptoTrueInt) {
-  EXPECT_FALSE((include_summand<true, int>::value));
+  EXPECT_FALSE((include_summand_b<true, int>));
 }
 
 TEST(MathMetaPrim, IncludeSummandProptoTrueDouble) {
-  EXPECT_FALSE((include_summand<true, double>::value));
+  EXPECT_FALSE((include_summand_b<true, double>));
 }
 
 TEST(MathMetaPrim, IncludeSummandConstantPropToTrueTen) {
-  EXPECT_FALSE((include_summand<true, double, double, int, int, double, double,
-                                int, int, double, int>::value));
+  EXPECT_FALSE((include_summand_b<true, double, double, int, int, double,
+                                  double, int, int, double, int>));
 }
 
 TEST(MathMetaPrim, IncludeSummandConstantProptoFalseTen) {
-  EXPECT_TRUE((include_summand<false, double, double, int, int, double, double,
-                               int, int, double, int>::value));
+  EXPECT_TRUE((include_summand_b<false, double, double, int, int, double,
+                                 double, int, int, double, int>));
 }

--- a/test/unit/math/rev/meta/include_summand_test.cpp
+++ b/test/unit/math/rev/meta/include_summand_test.cpp
@@ -3,14 +3,14 @@
 #include <test/unit/util.hpp>
 #include <gtest/gtest.h>
 
-using stan::math::include_summand;
+using stan::math::include_summand_b;
 using stan::math::var;
 
 TEST(MetaTraitsRevScal, IncludeSummandProptoTrueVar) {
-  EXPECT_TRUE((include_summand<true, var>::value));
+  EXPECT_TRUE((include_summand_b<true, var>));
 }
 
 TEST(MetaTraitsRevScal, IncludeSummandProtoTrueVarTen) {
-  EXPECT_TRUE((include_summand<true, double, var, int, var, double, double, int,
-                               int, var, int>::value));
+  EXPECT_TRUE((include_summand_b<true, double, var, int, var, double, double,
+                                 int, int, var, int>));
 }


### PR DESCRIPTION
## Summary

This introduces `include_summand_b` (where the `_b` marks the fact that this function returns a boolean value) to clean up places where we've been using `include_summand<...>::value`. This was done semi-automatically with a regexp replacement, plus a few manual adjustments. Fixes #1521.

## Tests

Existing tests for `include_summand` have been changed to use `include_summand_b`. In `test/unit/math/mix/meta/include_summand_test.cpp` where I kept both side by side, as perhaps we also want to test `include_summand` directly: let me know if it's not necessary!

## Side Effects

None.

## Checklist

- [X] Math issue #1521

- [X] Copyright holder: Marco Colombo

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [X] the new changes are tested
