### PR TITLE
Make use of new Windows agent in Jenkins GPU steps

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -64,6 +64,7 @@ pipeline {
                 script{
                     env.OS = checkOs()
                     env.ASSIGNED_NODE = "${NODE_NAME}"
+                    println("${NODE_NAME}")
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -59,9 +59,11 @@ pipeline {
     }
     stages {
         stage("Determine OS"){
+            agent { label "gpu" }
             steps{
                 script{
                     env.OS = checkOs()
+                    env.ASSIGNED_NODE = "${NODE_NAME}"
                 }
             }
         }
@@ -167,7 +169,7 @@ pipeline {
                 when {
                     environment name: "OS", value: "unix"
                 }
-                agent { label "gpu" }
+                agent { label "${env.ASSIGNED_NODE}" }
                 steps {
                     deleteDir()
                     unstash 'MathSetup'
@@ -183,7 +185,7 @@ pipeline {
                 when {
                     environment name: "OS", value: "windows"
                 }
-                agent { label "gpu" }
+                agent { label "${env.ASSIGNED_NODE}" }
                 steps {
                     deleteDirWin()
                     unstash 'MathSetup'
@@ -215,7 +217,7 @@ pipeline {
                     when {
                         environment name: "OS", value: "unix"
                     }                        
-                    agent { label "gpu" }
+                    agent { label "${env.ASSIGNED_NODE}" }
                     steps {
                         deleteDir()
                         unstash 'MathSetup'
@@ -231,7 +233,7 @@ pipeline {
                     when {
                         environment name: "OS", value: "windows"
                     }  
-                    agent { label "gpu" }
+                    agent { label "${env.ASSIGNED_NODE}" }
                     steps {
                         deleteDir()
                         unstash 'MathSetup'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -235,7 +235,7 @@ pipeline {
                     }  
                     agent { label "${env.ASSIGNED_NODE}" }
                     steps {
-                        deleteDir()
+                        deleteDirWin()
                         unstash 'MathSetup'
                         bat "bash -cl \"echo CXX=${env.CXX} -Werror > make/local\""
                         bat "bash -cl \"echo STAN_OPENCL=true>> make/local\""
@@ -246,7 +246,7 @@ pipeline {
                         """
                         runTestsWin("test/unit")
                     }
-                    post { always { retry(3) { deleteDir() } } }
+                    post { always { retry(3) { deleteDirWin() } } }
                 }
             }
         }


### PR DESCRIPTION
Modified Jenkinsfile to check OS type and then based on the agent OS decide which stage it should run. This was done so we can offload jobs that use a GPU on the new windows instance.

## Summary

This PR will allow Jenkins to run `Headers check with OpenCL` and `Full unit with GPU` stages on the new windows machine. This was done to speedup a bit the CI/CD by offloading GPU tests to this machine too.

## Side Effects

Not that I'm aware of but @rok-cesnovar can confirm, thanks!