### PR TITLE
Add specializations of multiply to reduce overpromotions to var

### DIFF
--- a/stan/math/rev/mat/fun/multiply.hpp
+++ b/stan/math/rev/mat/fun/multiply.hpp
@@ -578,12 +578,30 @@ inline Eigen::Matrix<var, R, C> multiply(const var& c,
   return m * c;
 }
 
+/**
+ * Return the product of scalar and matrix.
+ * @tparam Arith an arithmetic type
+ * @tparam R number of rows or Eigen::Dynamic
+ * @tparam C number of columns or Eigen::Dynamic
+ * @param[in] c scalar of arithmetic type
+ * @param[in] m matrix of var type
+ * @return Product of scalar and matrix
+ */
 template <typename Arith, int R, int C, typename = require_arithmetic_t<Arith>>
 inline Eigen::Matrix<var, R, C> multiply(const Arith& c,
                                          const Eigen::Matrix<var, R, C>& m) {
   return m * c;
 }
 
+/**
+ * Return the product of scalar and matrix.
+ * @tparam Arith an arithmetic type
+ * @tparam R number of rows or Eigen::Dynamic
+ * @tparam C number of columns or Eigen::Dynamic
+ * @param[in] c scalar of var type
+ * @param[in] m matrix of arithmetic type
+ * @return Product of scalar and matrix
+ */
 template <typename Arith, int R, int C, typename = require_arithmetic_t<Arith>>
 inline Eigen::Matrix<var, R, C> multiply(const var& c,
                                          const Eigen::Matrix<Arith, R, C>& m) {
@@ -604,12 +622,30 @@ inline Eigen::Matrix<var, R, C> multiply(const Eigen::Matrix<var, R, C>& m,
   return m * c;
 }
 
+/**
+ * Return the product of matrix and scalar.
+ * @tparam Arith an arithmetic type
+ * @tparam R number of rows or Eigen::Dynamic
+ * @tparam C number of columns or Eigen::Dynamic
+ * @param[in] m matrix of arithmetic type
+ * @param[in] c scalar of var type
+ * @return Product of matrix and scalar
+ */
 template <typename Arith, int R, int C, typename = require_arithmetic_t<Arith>>
 inline Eigen::Matrix<var, R, C> multiply(const Eigen::Matrix<Arith, R, C>& m,
                                          const var& c) {
   return m * c;
 }
 
+/**
+ * Return the product of matrix and scalar.
+ * @tparam Arith an arithmetic type
+ * @tparam R number of rows or Eigen::Dynamic
+ * @tparam C number of columns or Eigen::Dynamic
+ * @param[in] m matrix of var type
+ * @param[in] c scalar of arithmetic type
+ * @return Product of matrix and scalar
+ */
 template <typename Arith, int R, int C, typename = require_arithmetic_t<Arith>>
 inline Eigen::Matrix<var, R, C> multiply(const Eigen::Matrix<var, R, C>& m,
                                          const Arith& c) {

--- a/stan/math/rev/mat/fun/multiply.hpp
+++ b/stan/math/rev/mat/fun/multiply.hpp
@@ -582,15 +582,13 @@ inline Eigen::Matrix<var, R2, C2> multiply(const T1& c,
   return to_var(m) * to_var(c);
 }
 
-template <typename T1, int R2, int C2,
-typename = require_arithmetic_t<T1>>
+template <typename T1, int R2, int C2, typename = require_arithmetic_t<T1>>
 inline Eigen::Matrix<var, R2, C2> multiply(
     const T1& c, const Eigen::Matrix<var, R2, C2>& m) {
   return m * c;
 }
 
-template <typename T2, int R2, int C2,
-          typename = require_arithmetic_t<T2>>
+template <typename T2, int R2, int C2, typename = require_arithmetic_t<T2>>
 inline Eigen::Matrix<var, R2, C2> multiply(const var& c,
                                            const Eigen::Matrix<T2, R2, C2>& m) {
   return m * c;
@@ -613,15 +611,13 @@ inline Eigen::Matrix<var, R1, C1> multiply(const Eigen::Matrix<T1, R1, C1>& m,
   return to_var(m) * to_var(c);
 }
 
-template <typename T1, int R1, int C1,
-          typename = require_arithmetic_t<T1>>
+template <typename T1, int R1, int C1, typename = require_arithmetic_t<T1>>
 inline Eigen::Matrix<var, R1, C1> multiply(const Eigen::Matrix<T1, R1, C1>& m,
                                            const var& c) {
   return m * c;
 }
 
-template <int R1, int C1, typename T2,
-          typename = require_arithmetic_t<T2>>
+template <int R1, int C1, typename T2, typename = require_arithmetic_t<T2>>
 inline Eigen::Matrix<var, R1, C1> multiply(const Eigen::Matrix<var, R1, C1>& m,
                                            const T2& c) {
   return m * c;

--- a/stan/math/rev/mat/fun/multiply.hpp
+++ b/stan/math/rev/mat/fun/multiply.hpp
@@ -579,9 +579,21 @@ template <typename T1, typename T2, int R2, int C2,
           typename = require_any_var_t<T1, T2>>
 inline Eigen::Matrix<var, R2, C2> multiply(const T1& c,
                                            const Eigen::Matrix<T2, R2, C2>& m) {
-  // TODO(trangucci) pull out to eliminate overpromotion of one side
-  // move to matrix.hpp w. promotion?
   return to_var(m) * to_var(c);
+}
+
+template <typename T1, int R2, int C2,
+typename = require_arithmetic_t<T1>>
+inline Eigen::Matrix<var, R2, C2> multiply(
+    const T1& c, const Eigen::Matrix<var, R2, C2>& m) {
+  return m * c;
+}
+
+template <typename T2, int R2, int C2,
+          typename = require_arithmetic_t<T2>>
+inline Eigen::Matrix<var, R2, C2> multiply(const var& c,
+                                           const Eigen::Matrix<T2, R2, C2>& m) {
+  return m * c;
 }
 
 /**
@@ -598,9 +610,21 @@ template <typename T1, int R1, int C1, typename T2,
           typename = require_any_var_t<T1, T2>>
 inline Eigen::Matrix<var, R1, C1> multiply(const Eigen::Matrix<T1, R1, C1>& m,
                                            const T2& c) {
-  // TODO(trangucci) pull out to eliminate overpromotion of one side
-  // move to matrix.hpp w. promotion?
   return to_var(m) * to_var(c);
+}
+
+template <typename T1, int R1, int C1,
+          typename = require_arithmetic_t<T1>>
+inline Eigen::Matrix<var, R1, C1> multiply(const Eigen::Matrix<T1, R1, C1>& m,
+                                           const var& c) {
+  return m * c;
+}
+
+template <int R1, int C1, typename T2,
+          typename = require_arithmetic_t<T2>>
+inline Eigen::Matrix<var, R1, C1> multiply(const Eigen::Matrix<var, R1, C1>& m,
+                                           const T2& c) {
+  return m * c;
 }
 
 /**

--- a/stan/math/rev/mat/fun/multiply.hpp
+++ b/stan/math/rev/mat/fun/multiply.hpp
@@ -3,7 +3,6 @@
 
 #include <stan/math/rev/meta.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
-#include <stan/math/rev/mat/fun/to_var.hpp>
 #include <stan/math/rev/core.hpp>
 #include <stan/math/prim/mat/err/check_multiplicable.hpp>
 #include <stan/math/prim/scal/err/check_not_nan.hpp>
@@ -567,19 +566,16 @@ inline return_type_t<T1, T2> multiply(const T1& v, const T2& c) {
 
 /**
  * Return the product of scalar and matrix.
- * @tparam T1 scalar type v
- * @tparam T2 scalar type matrix m
- * @tparam R2 Rows matrix m
- * @tparam C2 Columns matrix m
- * @param[in] c Specified scalar
- * @param[in] m Matrix
+ * @tparam R number of rows or Eigen::Dynamic
+ * @tparam C number of columns or Eigen::Dynamic
+ * @param[in] c scalar of var type
+ * @param[in] m matrix of var type
  * @return Product of scalar and matrix
  */
-template <typename T1, typename T2, int R2, int C2,
-          typename = require_any_var_t<T1, T2>>
-inline Eigen::Matrix<var, R2, C2> multiply(const T1& c,
-                                           const Eigen::Matrix<T2, R2, C2>& m) {
-  return to_var(m) * to_var(c);
+template <int R, int C>
+inline Eigen::Matrix<var, R, C> multiply(const var& c,
+                                         const Eigen::Matrix<var, R, C>& m) {
+  return m * c;
 }
 
 template <typename Arith, int R, int C, typename = require_arithmetic_t<Arith>>
@@ -595,20 +591,17 @@ inline Eigen::Matrix<var, R, C> multiply(const var& c,
 }
 
 /**
- * Return the product of scalar and matrix.
- * @tparam T1 scalar type matrix m
- * @tparam T2 scalar type v
- * @tparam R1 Rows matrix m
- * @tparam C1 Columns matrix m
- * @param[in] c Specified scalar
- * @param[in] m Matrix
- * @return Product of scalar and matrix
+ * Return the product of matrix and scalar.
+ * @tparam R number of rows or Eigen::Dynamic
+ * @tparam C number of columns or Eigen::Dynamic
+ * @param[in] m matrix of var type
+ * @param[in] c scalar of var type
+ * @return Product of matrix and scalar
  */
-template <typename T1, int R1, int C1, typename T2,
-          typename = require_any_var_t<T1, T2>>
-inline Eigen::Matrix<var, R1, C1> multiply(const Eigen::Matrix<T1, R1, C1>& m,
-                                           const T2& c) {
-  return to_var(m) * to_var(c);
+template <int R, int C>
+inline Eigen::Matrix<var, R, C> multiply(const Eigen::Matrix<var, R, C>& m,
+                                         const var& c) {
+  return m * c;
 }
 
 template <typename Arith, int R, int C, typename = require_arithmetic_t<Arith>>

--- a/stan/math/rev/mat/fun/multiply.hpp
+++ b/stan/math/rev/mat/fun/multiply.hpp
@@ -582,15 +582,15 @@ inline Eigen::Matrix<var, R2, C2> multiply(const T1& c,
   return to_var(m) * to_var(c);
 }
 
-template <typename T1, int R2, int C2, typename = require_arithmetic_t<T1>>
-inline Eigen::Matrix<var, R2, C2> multiply(
-    const T1& c, const Eigen::Matrix<var, R2, C2>& m) {
+template <typename Arith, int R, int C, typename = require_arithmetic_t<Arith>>
+inline Eigen::Matrix<var, R, C> multiply(const Arith& c,
+                                         const Eigen::Matrix<var, R, C>& m) {
   return m * c;
 }
 
-template <typename T2, int R2, int C2, typename = require_arithmetic_t<T2>>
-inline Eigen::Matrix<var, R2, C2> multiply(const var& c,
-                                           const Eigen::Matrix<T2, R2, C2>& m) {
+template <typename Arith, int R, int C, typename = require_arithmetic_t<Arith>>
+inline Eigen::Matrix<var, R, C> multiply(const var& c,
+                                         const Eigen::Matrix<Arith, R, C>& m) {
   return m * c;
 }
 
@@ -611,15 +611,15 @@ inline Eigen::Matrix<var, R1, C1> multiply(const Eigen::Matrix<T1, R1, C1>& m,
   return to_var(m) * to_var(c);
 }
 
-template <typename T1, int R1, int C1, typename = require_arithmetic_t<T1>>
-inline Eigen::Matrix<var, R1, C1> multiply(const Eigen::Matrix<T1, R1, C1>& m,
-                                           const var& c) {
+template <typename Arith, int R, int C, typename = require_arithmetic_t<Arith>>
+inline Eigen::Matrix<var, R, C> multiply(const Eigen::Matrix<Arith, R, C>& m,
+                                         const var& c) {
   return m * c;
 }
 
-template <int R1, int C1, typename T2, typename = require_arithmetic_t<T2>>
-inline Eigen::Matrix<var, R1, C1> multiply(const Eigen::Matrix<var, R1, C1>& m,
-                                           const T2& c) {
+template <typename Arith, int R, int C, typename = require_arithmetic_t<Arith>>
+inline Eigen::Matrix<var, R, C> multiply(const Eigen::Matrix<var, R, C>& m,
+                                         const Arith& c) {
   return m * c;
 }
 


### PR DESCRIPTION
## Summary

This is an attempt to fix #355. It adds some specializations to `rev/mat/fun/multiply.hpp` so that arithmetic types don't get promoted to `var`. I'm not entirely sure this is what was desired, but we can take it from there.

## Tests

Current tests should be enough.

## Side Effects

None.

## Checklist

- [X] Math issue #355

- [X] Copyright holder: Marco Colombo

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [X] the new changes are tested