### PR TITLE
reverts changes to beta binomial

### DIFF
--- a/stan/math/prim/scal/prob/beta_binomial_lpmf.hpp
+++ b/stan/math/prim/scal/prob/beta_binomial_lpmf.hpp
@@ -41,13 +41,12 @@ return_type_t<T_size1, T_size2> beta_binomial_lpmf(const T_n& n, const T_N& N,
                                                    const T_size1& alpha,
                                                    const T_size2& beta) {
   static const char* function = "beta_binomial_lpmf";
-  using T_partials = partials_return_t<T_size1, T_size2>;
+  using T_partials_return = partials_return_t<T_size1, T_size2>;
 
-  if (size_zero(n, N, alpha, beta)) {
+  if (size_zero(n, N, alpha, beta))
     return 0.0;
-  }
 
-  T_partials logp(0.0);
+  T_partials_return logp(0.0);
   check_nonnegative(function, "Population size parameter", N);
   check_positive_finite(function, "First prior sample size parameter", alpha);
   check_positive_finite(function, "Second prior sample size parameter", beta);
@@ -56,17 +55,16 @@ return_type_t<T_size1, T_size2> beta_binomial_lpmf(const T_n& n, const T_N& N,
                          "First prior sample size parameter", alpha,
                          "Second prior sample size parameter", beta);
 
-  if (!include_summand<propto, T_size1, T_size2>::value) {
+  if (!include_summand<propto, T_size1, T_size2>::value)
     return 0.0;
-  }
 
   operands_and_partials<T_size1, T_size2> ops_partials(alpha, beta);
 
-  const scalar_seq_view<T_n> n_vec(n);
-  const scalar_seq_view<T_N> N_vec(N);
-  const scalar_seq_view<T_size1> alpha_vec(alpha);
-  const scalar_seq_view<T_size2> beta_vec(beta);
-  const auto size = max_size(n, N, alpha, beta);
+  scalar_seq_view<T_n> n_vec(n);
+  scalar_seq_view<T_N> N_vec(N);
+  scalar_seq_view<T_size1> alpha_vec(alpha);
+  scalar_seq_view<T_size2> beta_vec(beta);
+  size_t size = max_size(n, N, alpha, beta);
 
   for (size_t i = 0; i < size; i++) {
     if (n_vec[i] < 0 || n_vec[i] > N_vec[i]) {
@@ -74,50 +72,79 @@ return_type_t<T_size1, T_size2> beta_binomial_lpmf(const T_n& n, const T_N& N,
     }
   }
 
-  if (include_summand<propto>::value) {
-    for (size_t i = 0; i < size; i++) {
-      // normalizing constant
-      logp += binomial_coefficient_log(N_vec[i], n_vec[i]);
-      // log numerator - denominator
-      logp += lbeta(n_vec[i] + value_of(alpha_vec[i]),
-                    N_vec[i] - n_vec[i] + value_of(beta_vec[i]))
-              - lbeta(value_of(alpha_vec[i]), value_of(beta_vec[i]));
-    }
-  }
+  VectorBuilder<include_summand<propto>::value, T_partials_return, T_n, T_N>
+      normalizing_constant(max_size(N, n));
+  for (size_t i = 0; i < max_size(N, n); i++)
+    if (include_summand<propto>::value)
+      normalizing_constant[i] = binomial_coefficient_log(N_vec[i], n_vec[i]);
 
-  VectorBuilder<!is_constant_all<T_size1, T_size2>::value, T_partials, T_N,
-                T_size1, T_size2>
-      digamma_N_plus_alpha_plus_beta(size);
-  VectorBuilder<!is_constant_all<T_size1, T_size2>::value, T_partials, T_size1,
-                T_size2>
-      digamma_alpha_plus_beta(size);
-  if (!is_constant_all<T_size1, T_size2>::value) {
-    for (size_t i = 0; i < size; i++) {
+  VectorBuilder<include_summand<propto, T_size1, T_size2>::value,
+                T_partials_return, T_n, T_N, T_size1, T_size2>
+      lbeta_numerator(size);
+  for (size_t i = 0; i < size; i++)
+    if (include_summand<propto, T_size1, T_size2>::value)
+      lbeta_numerator[i] = lbeta(n_vec[i] + value_of(alpha_vec[i]),
+                                 N_vec[i] - n_vec[i] + value_of(beta_vec[i]));
+
+  VectorBuilder<include_summand<propto, T_size1, T_size2>::value,
+                T_partials_return, T_size1, T_size2>
+      lbeta_denominator(max_size(alpha, beta));
+  for (size_t i = 0; i < max_size(alpha, beta); i++)
+    if (include_summand<propto, T_size1, T_size2>::value)
+      lbeta_denominator[i]
+          = lbeta(value_of(alpha_vec[i]), value_of(beta_vec[i]));
+
+  VectorBuilder<!is_constant_all<T_size1>::value, T_partials_return, T_n,
+                T_size1>
+      digamma_n_plus_alpha(max_size(n, alpha));
+  for (size_t i = 0; i < max_size(n, alpha); i++)
+    if (!is_constant_all<T_size1>::value)
+      digamma_n_plus_alpha[i] = digamma(n_vec[i] + value_of(alpha_vec[i]));
+
+  VectorBuilder<!is_constant_all<T_size1, T_size2>::value, T_partials_return,
+                T_N, T_size1, T_size2>
+      digamma_N_plus_alpha_plus_beta(max_size(N, alpha, beta));
+  for (size_t i = 0; i < max_size(N, alpha, beta); i++)
+    if (!is_constant_all<T_size1, T_size2>::value)
       digamma_N_plus_alpha_plus_beta[i]
           = digamma(N_vec[i] + value_of(alpha_vec[i]) + value_of(beta_vec[i]));
+
+  VectorBuilder<!is_constant_all<T_size1, T_size2>::value, T_partials_return,
+                T_size1, T_size2>
+      digamma_alpha_plus_beta(max_size(alpha, beta));
+  for (size_t i = 0; i < max_size(alpha, beta); i++)
+    if (!is_constant_all<T_size1, T_size2>::value)
       digamma_alpha_plus_beta[i]
           = digamma(value_of(alpha_vec[i]) + value_of(beta_vec[i]));
-    }
-  }
 
-  if (!is_constant_all<T_size1>::value) {
-    for (size_t i = 0; i < size; i++) {
+  VectorBuilder<!is_constant_all<T_size1>::value, T_partials_return, T_size1>
+      digamma_alpha(length(alpha));
+  for (size_t i = 0; i < length(alpha); i++)
+    if (!is_constant_all<T_size1>::value)
+      digamma_alpha[i] = digamma(value_of(alpha_vec[i]));
+
+  VectorBuilder<!is_constant_all<T_size2>::value, T_partials_return, T_size2>
+      digamma_beta(length(beta));
+  for (size_t i = 0; i < length(beta); i++)
+    if (!is_constant_all<T_size2>::value)
+      digamma_beta[i] = digamma(value_of(beta_vec[i]));
+
+  for (size_t i = 0; i < size; i++) {
+    if (include_summand<propto>::value)
+      logp += normalizing_constant[i];
+    if (include_summand<propto, T_size1, T_size2>::value)
+      logp += lbeta_numerator[i] - lbeta_denominator[i];
+
+    if (!is_constant_all<T_size1>::value)
       ops_partials.edge1_.partials_[i]
-          += digamma(n_vec[i] + value_of(alpha_vec[i]))
-             - digamma_N_plus_alpha_plus_beta[i] + digamma_alpha_plus_beta[i]
-             - digamma(value_of(alpha_vec[i]));
-    }
-  }
-
-  if (!is_constant_all<T_size2>::value) {
-    for (size_t i = 0; i < size; i++) {
+          += digamma_n_plus_alpha[i] - digamma_N_plus_alpha_plus_beta[i]
+             + digamma_alpha_plus_beta[i] - digamma_alpha[i];
+    if (!is_constant_all<T_size2>::value)
       ops_partials.edge2_.partials_[i]
           += digamma(value_of(N_vec[i] - n_vec[i] + beta_vec[i]))
              - digamma_N_plus_alpha_plus_beta[i] + digamma_alpha_plus_beta[i]
-             - digamma(value_of(beta_vec[i]));
-    }
+             - digamma_beta[i];
   }
-
   return ops_partials.build(logp);
 }
 


### PR DESCRIPTION

## Summary

See discourse discussion [here](https://discourse.mc-stan.org/t/rstan-works-but-cmdstan-does-not-for-a-beta-binomial-model/12364/3)

It looks like I goofed up beta_binomial_lpmf with this change. 

## Checklist

- [x] Math issue #1308 

- [x] Copyright holder: Steve Bronder

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
