### PR TITLE
Improve documentation of template parameters in prim/mat/fun

### DIFF
--- a/stan/math/prim/mat/fun/LDLT_factor.hpp
+++ b/stan/math/prim/mat/fun/LDLT_factor.hpp
@@ -18,12 +18,12 @@ namespace math {
  * <code>boost::shared_ptr</code>, which ensures that is freed
  * when the object is released.
  *
- * After the constructor and/or compute() is called users of
+ * After the constructor and/or compute() is called, users of
  * LDLT_factor are responsible for calling success() to
  * check whether the factorization has succeeded.  Use of an LDLT_factor
  * object (e.g., in mdivide_left_ldlt) is undefined if success() is false.
  *
- * It's usage pattern is:
+ * Its usage pattern is:
  *
  * ~~~
  * Eigen::Matrix<T, R, C> A1, A2;

--- a/stan/math/prim/mat/fun/LDLT_factor.hpp
+++ b/stan/math/prim/mat/fun/LDLT_factor.hpp
@@ -55,9 +55,9 @@ namespace math {
  * decomposed as LDL' where L is unit lower-triangular and D is
  * diagonal with positive diagonal elements.
  *
- * @tparam T scalare type held in the matrix
- * @tparam R rows (as in Eigen)
- * @tparam C columns (as in Eigen)
+ * @tparam T type of elements in the matrix
+ * @tparam R number of rows, can be Eigen::Dynamic
+ * @tparam C number of columns, can be Eigen::Dynamic
  */
 template <typename T, int R, int C>
 class LDLT_factor {
@@ -126,4 +126,5 @@ class LDLT_factor {
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/Phi.hpp
+++ b/stan/math/prim/mat/fun/Phi.hpp
@@ -9,8 +9,9 @@ namespace math {
 
 /**
  * Structure to wrap Phi() so it can be vectorized.
- * @param x Argument variable.
- * @tparam T Argument type.
+ *
+ * @tparam T type of argument
+ * @param x argument
  * @return Unit normal CDF of x.
  */
 struct Phi_fun {
@@ -22,8 +23,9 @@ struct Phi_fun {
 
 /**
  * Vectorized version of Phi().
- * @param x Container.
- * @tparam T Container type.
+ *
+ * @tparam T type of container
+ * @param x container
  * @return Unit normal CDF of each value in x.
  */
 template <typename T>

--- a/stan/math/prim/mat/fun/Phi_approx.hpp
+++ b/stan/math/prim/mat/fun/Phi_approx.hpp
@@ -17,7 +17,7 @@ struct Phi_approx_fun {
    *
    * @tparam T type of argument
    * @param x argument
-   * @return aprpoximate value of Phi applied to argument.
+   * @return approximate value of Phi applied to argument
    */
   template <typename T>
   static inline T fun(const T& x) {

--- a/stan/math/prim/mat/fun/Phi_approx.hpp
+++ b/stan/math/prim/mat/fun/Phi_approx.hpp
@@ -15,7 +15,7 @@ struct Phi_approx_fun {
    * Return the approximate value of the Phi() function applied to
    * the argument.
    *
-   * @tparam T argument type
+   * @tparam T type of argument
    * @param x argument
    * @return aprpoximate value of Phi applied to argument.
    */
@@ -31,7 +31,7 @@ struct Phi_approx_fun {
  * underlying scalar argument type to double if it is an integer,
  * and otherwise is the argument type.
  *
- * @tparam T container type
+ * @tparam T type of container
  * @param x container
  * @return elementwise Phi_approx of container elements
  */

--- a/stan/math/prim/mat/fun/accumulator.hpp
+++ b/stan/math/prim/mat/fun/accumulator.hpp
@@ -74,8 +74,8 @@ class accumulator {
    * of values to the buffer.
    *
    * @tparam S type of values in matrix
-   * @tparam R number of rows in matrix
-   * @tparam C number of columns in matrix
+   * @tparam R number of rows, can be Eigen::Dynamic
+   * @tparam C number of columns, can be Eigen::Dynamic
    * @param m Matrix of values to add
    */
   template <typename S, int R, int C>

--- a/stan/math/prim/mat/fun/acos.hpp
+++ b/stan/math/prim/mat/fun/acos.hpp
@@ -9,8 +9,9 @@ namespace math {
 
 /**
  * Structure to wrap acos() so it can be vectorized.
- * @param x Variable.
- * @tparam T Variable type.
+ *
+ * @tparam T type of variable
+ * @param x variable
  * @return Arc cosine of variable in radians.
  */
 struct acos_fun {
@@ -23,8 +24,9 @@ struct acos_fun {
 
 /**
  * Vectorized version of acos().
- * @param x Container of variables.
- * @tparam T Container type.
+ *
+ * @tparam T type of container
+ * @param x container
  * @return Arc cosine of each variable in the container, in radians.
  */
 template <typename T>

--- a/stan/math/prim/mat/fun/acosh.hpp
+++ b/stan/math/prim/mat/fun/acosh.hpp
@@ -14,9 +14,9 @@ struct acosh_fun {
   /**
    * Return the inverse hypberbolic cosine of the specified argument.
    *
-   * @param x Argument.
+   * @tparam T type of argument
+   * @param x argument
    * @return Inverse hyperbolic cosine of the argument.
-   * @tparam T Argument type.
    */
   template <typename T>
   static inline T fun(const T& x) {
@@ -30,8 +30,8 @@ struct acosh_fun {
  * underlying scalar argument type to double if it is an integer,
  * and otherwise is the argument type.
  *
- * @tparam T Container type.
- * @param x Container.
+ * @tparam T type of container
+ * @param x container
  * @return Elementwise acosh of members of container.
  */
 template <typename T>

--- a/stan/math/prim/mat/fun/add.hpp
+++ b/stan/math/prim/mat/fun/add.hpp
@@ -10,10 +10,12 @@ namespace math {
 /**
  * Return the sum of the specified matrices.  The two matrices
  * must have the same dimensions.
- * @tparam T1 Scalar type of first matrix.
- * @tparam T2 Scalar type of second matrix.
- * @tparam R Row type of matrices.
- * @tparam C Column type of matrices.
+ *
+ * @tparam T1 type of elements in the first matrix
+ * @tparam T2 type of elements in the second matrix
+ * @tparam R number of rows, can be Eigen::Dynamic
+ * @tparam C number of columns, can be Eigen::Dynamic
+ *
  * @param m1 First matrix.
  * @param m2 Second matrix.
  * @return Sum of the matrices.
@@ -30,8 +32,10 @@ inline Eigen::Matrix<return_type_t<T1, T2>, R, C> add(
 /**
  * Return the sum of the specified matrix and specified scalar.
  *
- * @tparam T1 Scalar type of matrix.
- * @tparam T2 Type of scalar.
+ * @tparam T1 type of elements in the matrix
+ * @tparam T2 type of scalar
+ * @tparam R number of rows, can be Eigen::Dynamic
+ * @tparam C number of columns, can be Eigen::Dynamic
  * @param m Matrix.
  * @param c Scalar.
  * @return The matrix plus the scalar.
@@ -45,8 +49,10 @@ inline Eigen::Matrix<return_type_t<T1, T2>, R, C> add(
 /**
  * Return the sum of the specified scalar and specified matrix.
  *
- * @tparam T1 Type of scalar.
- * @tparam T2 Scalar type of matrix.
+ * @tparam T1 type of scalar
+ * @tparam T2 type of elements in the matrix
+ * @tparam R number of rows, can be Eigen::Dynamic
+ * @tparam C number of columns, can be Eigen::Dynamic
  * @param c Scalar.
  * @param m Matrix.
  * @return The scalar plus the matrix.
@@ -59,4 +65,5 @@ inline Eigen::Matrix<return_type_t<T1, T2>, R, C> add(
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/add_diag.hpp
+++ b/stan/math/prim/mat/fun/add_diag.hpp
@@ -8,11 +8,13 @@
 
 namespace stan {
 namespace math {
+
 /**
  * Returns a Matrix with values added along the main diagonal
  *
  * @tparam T_m type of element in Eigen::Matrix
  * @tparam T_a Type of element to add along the diagonal
+ *
  * @param mat a matrix
  * @param to_add value to add along the diagonal
  * @return a matrix with to_add added along main diagonal
@@ -33,6 +35,9 @@ add_diag(const Eigen::Matrix<T_m, Eigen::Dynamic, Eigen::Dynamic> &mat,
  *
  * @tparam T_m type of element in Eigen::Matrix
  * @tparam T_a Type of element to add along the diagonal
+ * @tparam R number of rows, can be Eigen::Dynamic
+ * @tparam C number of columns, can be Eigen::Dynamic
+ *
  * @param mat a matrix
  * @param to_add Sequence of values to add along the diagonal
  * @return a matrix with to_add added along main diagonal
@@ -53,6 +58,8 @@ add_diag(const Eigen::Matrix<T_m, Eigen::Dynamic, Eigen::Dynamic> &mat,
   out.diagonal() += to_add;
   return out;
 }
+
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/append_array.hpp
+++ b/stan/math/prim/mat/fun/append_array.hpp
@@ -12,14 +12,15 @@
 
 namespace stan {
 namespace math {
+
 /**
  * Return the concatenation of two specified vectors in the order of
  *   the arguments.
  *
  * The return type is computed with append_return_type
  *
- * @tparam T1 Scalar type of first vector
- * @tparam T2 Scalar type of second vector
+ * @tparam T1 type of elements in first vector
+ * @tparam T2 type of elements in second vector
  * @param x First vector
  * @param y Second vector
  * @return A vector of x and y concatenated together (in that order)
@@ -50,7 +51,7 @@ append_array(const std::vector<T1>& x, const std::vector<T2>& y) {
  * Return the concatenation of two specified vectors in the order of
  *   the arguments.
  *
- * @tparam T1 Type of vectors
+ * @tparam T1 type of elements in both vectors
  * @param x First vector
  * @param y Second vector
  * @return A vector of x and y concatenated together (in that order)
@@ -75,6 +76,8 @@ inline std::vector<T1> append_array(const std::vector<T1>& x,
   z.insert(z.end(), y.begin(), y.end());
   return z;
 }
+
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/append_col.hpp
+++ b/stan/math/prim/mat/fun/append_col.hpp
@@ -21,12 +21,13 @@ namespace math {
  * (vector, vector)
  * and the output is always a matrix.
  *
- * @tparam T1 Scalar type of first matrix.
- * @tparam T2 Scalar type of second matrix.
- * @tparam R1 Row specification of first matrix.
- * @tparam C1 Column specification of first matrix.
- * @tparam R2 Row specification of second matrix.
- * @tparam C2 Column specification of second matrix.
+ * @tparam T1 type of elements in the first matrix
+ * @tparam T2 type of elements in the second matrix
+ * @tparam R1 number of rows in the first matrix, can be Eigen::Dynamic
+ * @tparam C1 number of columns in the first matrix, can be Eigen::Dynamic
+ * @tparam R2 number of rows in the second matrix, can be Eigen::Dynamic
+ * @tparam C2 number of columns in the second matrix, can be Eigen::Dynamic
+ *
  * @param A First matrix.
  * @param B Second matrix.
  * @return Result of appending the first matrix followed by the
@@ -68,10 +69,11 @@ append_col(const Eigen::Matrix<T1, R1, C1>& A,
  * This function applies to (row_vector, row_vector) and returns a
  * row_vector.
  *
- * @tparam T1 Scalar type of first row vector.
- * @tparam T2 Scalar type of second row vector.
- * @tparam C1 Column specification of first row vector.
- * @tparam C2 Column specification of second row vector.
+ * @tparam T1 type of elements in the first row vector
+ * @tparam T2 type of elements in the second row vector
+ * @tparam C1 number of columns in the first row vector, can be Eigen::Dynamic
+ * @tparam C2 number of columns in the second row vector, can be Eigen::Dynamic
+ *
  * @param A First vector.
  * @param B Second vector
  * @return Result of appending the second row vector to the right
@@ -109,11 +111,12 @@ inline Eigen::Matrix<return_type_t<T1, T2>, 1, Eigen::Dynamic> append_col(
  * (vector, vector),
  * and the output is always a matrix.
  *
- * @tparam T Scalar type of both matrices.
- * @tparam R1 Row specification of first matrix.
- * @tparam C1 Column specification of first matrix.
- * @tparam R2 Row specification of second matrix.
- * @tparam C2 Column specification of second matrix.
+ * @tparam T type of elements in both matrices
+ * @tparam R1 number of rows in the first matrix, can be Eigen::Dynamic
+ * @tparam C1 number of columns in the first matrix, can be Eigen::Dynamic
+ * @tparam R2 number of rows in the second matrix, can be Eigen::Dynamic
+ * @tparam C2 number of columns in the second matrix, can be Eigen::Dynamic
+ *
  * @param A First matrix.
  * @param B Second matrix.
  * @return Result of appending the first matrix followed by the
@@ -140,9 +143,10 @@ inline Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> append_col(
  * This function applies to (row_vector, row_vector) and returns a
  * row_vector.
  *
- * @tparam T Scalar type of both vectors.
- * @tparam C1 Column specification of first row vector.
- * @tparam C2 Column specification of second row vector.
+ * @tparam T type of elements in both vectors
+ * @tparam C1 number of columns in the first row vector, can be Eigen::Dynamic
+ * @tparam C2 number of columns in the second row vector, can be Eigen::Dynamic
+ *
  * @param A First vector.
  * @param B Second vector
  * @return Result of appending the second row vector to the right
@@ -166,9 +170,11 @@ inline Eigen::Matrix<T, 1, Eigen::Dynamic> append_col(
  * This function applies to (scalar, row vector) and returns a
  * row vector.
  *
- * @tparam T1 Scalar type of the scalar
- * @tparam T2 Scalar type of the row vector.
- * @tparam R Row specification of the row vector.
+ * @tparam T1 type of the scalar
+ * @tparam T2 type of elements in the row vector
+ * @tparam R number of rows, can be Eigen::Dynamic
+ * @tparam C number of columns, can be Eigen::Dynamic
+ *
  * @param A scalar.
  * @param B row vector.
  * @return Result of stacking the scalar on top of the row vector.
@@ -192,9 +198,11 @@ inline Eigen::Matrix<return_type_t<T1, T2>, 1, Eigen::Dynamic> append_col(
  * This function applies to (row vector, scalar) and returns a
  * row vector.
  *
- * @tparam T1 Scalar type of the row vector.
- * @tparam T2 Scalar type of the scalar
- * @tparam R Row specification of the row vector.
+ * @tparam T1 type of elements in the row vector
+ * @tparam T2 type of the scalar
+ * @tparam R number of rows, can be Eigen::Dynamic
+ * @tparam C number of columns, can be Eigen::Dynamic
+ *
  * @param A row vector.
  * @param B scalar.
  * @return Result of stacking the row vector on top of the scalar.
@@ -210,8 +218,8 @@ inline Eigen::Matrix<return_type_t<T1, T2>, 1, Eigen::Dynamic> append_col(
   result << A.template cast<return_type>(), B;
   return result;
 }
-}  // namespace math
 
+}  // namespace math
 }  // namespace stan
 
 #endif

--- a/stan/math/prim/mat/fun/append_col.hpp
+++ b/stan/math/prim/mat/fun/append_col.hpp
@@ -62,7 +62,7 @@ append_col(const Eigen::Matrix<T1, R1, C1>& A,
 }
 
 /**
- * Return the result of concatenaing the first row vector followed
+ * Return the result of concatenating the first row vector followed
  * by the second row vector side by side, with the result being a
  * row vector.
  *
@@ -136,7 +136,7 @@ inline Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> append_col(
 }
 
 /**
- * Return the result of concatenaing the first row vector followed
+ * Return the result of concatenating the first row vector followed
  * by the second row vector side by side, with the result being a
  * row vector.
  *

--- a/stan/math/prim/mat/fun/append_row.hpp
+++ b/stan/math/prim/mat/fun/append_row.hpp
@@ -20,12 +20,13 @@ namespace math {
  * (row_vector, row_vector),
  * and the output is always a matrix.
  *
- * @tparam T1 Scalar type of first matrix.
- * @tparam T2 Scalar type of second matrix.
- * @tparam R1 Row specification of first matrix.
- * @tparam C1 Column specification of first matrix.
- * @tparam R2 Row specification of second matrix.
- * @tparam C2 Column specification of second matrix.
+ * @tparam T1 type of elements in first matrix
+ * @tparam T2 type of elements in second matrix
+ * @tparam R1 number of rows in the first matrix, can be Eigen::Dynamic
+ * @tparam C1 number of columns in the first matrix, can be Eigen::Dynamic
+ * @tparam R2 number of rows in the second matrix, can be Eigen::Dynamic
+ * @tparam C2 number of columns in the second matrix, can be Eigen::Dynamic
+ *
  * @param A First matrix.
  * @param B Second matrix.
  * @return Result of stacking first matrix on top of second.
@@ -61,10 +62,11 @@ append_row(const Eigen::Matrix<T1, R1, C1>& A,
  *
  * This function applies to (vector, vector) and returns a vector.
  *
- * @tparam T1 Scalar type of first vector.
- * @tparam T2 Scalar type of second vector.
- * @tparam R1 Row specification of first vector.
- * @tparam R2 Row specification of second vector.
+ * @tparam T1 type of elements in first vector
+ * @tparam T2 type of elements in second vector
+ * @tparam R1 number of rows in the first vector, can be Eigen::Dynamic
+ * @tparam R2 number of rows in the second vector, can be Eigen::Dynamic
+ *
  * @param A First vector.
  * @param B Second vector.
  * @return Result of stacking first vector on top of the second
@@ -101,11 +103,12 @@ inline Eigen::Matrix<return_type_t<T1, T2>, Eigen::Dynamic, 1> append_row(
  * (row_vector, row_vector),
  * and the output is always a matrix.
  *
- * @tparam T Scalar type of both matrices.
- * @tparam R1 Row specification of first matrix.
- * @tparam C1 Column specification of first matrix.
- * @tparam R2 Row specification of second matrix.
- * @tparam C2 Column specification of second matrix.
+ * @tparam T type of elements in both matrices
+ * @tparam R1 number of rows in the first matrix, can be Eigen::Dynamic
+ * @tparam C1 number of columns in the first matrix, can be Eigen::Dynamic
+ * @tparam R2 number of rows in the second matrix, can be Eigen::Dynamic
+ * @tparam C2 number of columns in the second matrix, can be Eigen::Dynamic
+ *
  * @param A First matrix.
  * @param B Second matrix.
  * @return Result of stacking first matrix on top of second.
@@ -132,9 +135,10 @@ inline Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> append_row(
  *
  * This function applies to (vector, vector) and returns a vector.
  *
- * @tparam T Scalar type of both vectors.
- * @tparam R1 Row specification of first vector.
- * @tparam R2 Row specification of second vector.
+ * @tparam T type of elements in both vectors
+ * @tparam R1 number of rows in the first vector, can be Eigen::Dynamic
+ * @tparam R2 number of rows in the second vector, can be Eigen::Dynamic
+ *
  * @param A First vector.
  * @param B Second vector.
  * @return Result of stacking first vector on top of the second
@@ -157,9 +161,11 @@ inline Eigen::Matrix<T, Eigen::Dynamic, 1> append_row(
  *
  * This function applies to (scalar, vector) and returns a vector.
  *
- * @tparam T1 Scalar type of the scalar
- * @tparam T2 Scalar type of the vector.
- * @tparam R Row specification of the vector.
+ * @tparam T1 type of the scalar
+ * @tparam T2 type of elements in the vector
+ * @tparam R number of rows, can be Eigen::Dynamic
+ * @tparam C number of columns, can be Eigen::Dynamic
+ *
  * @param A scalar.
  * @param B vector.
  * @return Result of stacking the scalar on top of the vector.
@@ -182,9 +188,11 @@ inline Eigen::Matrix<return_type_t<T1, T2>, Eigen::Dynamic, 1> append_row(
  *
  * This function applies to (vector, scalar) and returns a vector.
  *
- * @tparam T1 Scalar type of the vector.
- * @tparam T2 Scalar type of the scalar
- * @tparam R Row specification of the vector.
+ * @tparam T1 type of elements in the vector
+ * @tparam T2 type of the scalar
+ * @tparam R number of rows, can be Eigen::Dynamic
+ * @tparam C number of columns, can be Eigen::Dynamic
+ *
  * @param A vector.
  * @param B scalar.
  * @return Result of stacking the vector on top of the scalar.
@@ -202,7 +210,6 @@ inline Eigen::Matrix<return_type_t<T1, T2>, Eigen::Dynamic, 1> append_row(
 }
 
 }  // namespace math
-
 }  // namespace stan
 
 #endif

--- a/stan/math/prim/mat/fun/asin.hpp
+++ b/stan/math/prim/mat/fun/asin.hpp
@@ -9,8 +9,9 @@ namespace math {
 
 /**
  * Structure to wrap asin() so it can be vectorized.
- * @param x Argument variable.
- * @tparam T Argument type.
+ *
+ * @tparam T type of argument
+ * @param x argument
  * @return Arcsine of x in radians.
  */
 struct asin_fun {
@@ -23,8 +24,9 @@ struct asin_fun {
 
 /**
  * Vectorized version of asin().
- * @param x Container of variables.
- * @tparam T Container type.
+ *
+ * @tparam T type of container
+ * @param x container
  * @return Arcsine of each variable in the container, in radians.
  */
 template <typename T>

--- a/stan/math/prim/mat/fun/asinh.hpp
+++ b/stan/math/prim/mat/fun/asinh.hpp
@@ -24,8 +24,8 @@ struct asinh_fun {
 /**
  * Vectorized version of asinh().
  *
- * @tparam T Container type.
- * @param x Container.
+ * @tparam T type of container
+ * @param x container
  * @return Inverse hyperbolic sine of each value in the container.
  */
 template <typename T>

--- a/stan/math/prim/mat/fun/assign.hpp
+++ b/stan/math/prim/mat/fun/assign.hpp
@@ -61,10 +61,11 @@ inline void assign(T_lhs& x, const T_rhs& y) {
  *
  * @tparam T_lhs Type of left-hand side matrix elements.
  * @tparam T_rhs Type of right-hand side matrix elements.
- * @tparam R1 Row shape of left-hand side matrix.
- * @tparam C1 Column shape of left-hand side matrix.
- * @tparam R2 Row shape of right-hand side matrix.
- * @tparam C2 Column shape of right-hand side matrix.
+ * @tparam R1 number of rows in the left-hand side matrix or Eigen::Dynamic
+ * @tparam C1 number of columns in the left-hand side matrix or Eigen::Dynamic
+ * @tparam R2 number of rows in the right-hand side matrix or Eigen::Dynamic
+ * @tparam C2 number of columns in the right-hand side matrix or Eigen::Dynamic
+ *
  * @param x Left-hand side matrix.
  * @param y Right-hand side matrix.
  * @throw std::invalid_argument
@@ -98,8 +99,9 @@ inline void assign(Eigen::Matrix<T_lhs, R1, C1>& x,
  *
  * @tparam T_lhs Type of left-hand side matrix elements.
  * @tparam T_rhs Type of right-hand side matrix elements.
- * @tparam R Row shape of both matrices.
- * @tparam C Column shape of both mtarices.
+ * @tparam R number of rows or Eigen::Dynamic
+ * @tparam C number of columns or Eigen::Dynamic
+ *
  * @param x Left-hand side matrix.
  * @param y Right-hand side matrix.
  * @throw std::invalid_argument if sizes do not match.
@@ -130,8 +132,9 @@ inline void assign(Eigen::Matrix<T_lhs, R, C>& x,
  *
  * @tparam T_lhs Type of matrix block elements.
  * @tparam T Type of right-hand side matrix elements.
- * @tparam R Row shape for right-hand side matrix.
- * @tparam C Column shape for right-hand side matrix.
+ * @tparam R number of rows or Eigen::Dynamic
+ * @tparam C number of columns or Eigen::Dynamic
+ *
  * @param x Left-hand side block view of matrix.
  * @param y Right-hand side matrix.
  * @throw std::invalid_argument if sizes do not match.
@@ -178,4 +181,5 @@ inline void assign(std::vector<T_lhs>& x, const std::vector<T_rhs>& y) {
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/atan.hpp
+++ b/stan/math/prim/mat/fun/atan.hpp
@@ -9,8 +9,9 @@ namespace math {
 
 /**
  * Structure to wrap atan() so it can be vectorized.
- * @param x Variable.
- * @tparam T Variable type.
+ *
+ * @tparam T type of variable
+ * @param x variable
  * @return Arctan of x in radians.
  */
 struct atan_fun {
@@ -23,8 +24,9 @@ struct atan_fun {
 
 /**
  * Vectorized version of atan().
- * @param x Container.
- * @tparam T Container type.
+ *
+ * @tparam T type of container
+ * @param x container
  * @return Arctan of each value in x, in radians.
  */
 template <typename T>

--- a/stan/math/prim/mat/fun/atanh.hpp
+++ b/stan/math/prim/mat/fun/atanh.hpp
@@ -14,9 +14,9 @@ struct atanh_fun {
   /**
    * Return the inverse hypberbolic tangent of the specified argument.
    *
-   * @param x Argument.
+   * @tparam T type of argument
+   * @param x argument
    * @return Inverse hyperbolic tangent of the argument.
-   * @tparam T Argument type.
    */
   template <typename T>
   static inline T fun(const T& x) {
@@ -30,8 +30,8 @@ struct atanh_fun {
  * underlying scalar argument type to double if it is an integer,
  * and otherwise is the argument type.
  *
- * @tparam T Container type.
- * @param x Container.
+ * @tparam T type of container
+ * @param x container
  * @return Elementwise atanh of members of container.
  */
 template <typename T>

--- a/stan/math/prim/mat/fun/autocorrelation.hpp
+++ b/stan/math/prim/mat/fun/autocorrelation.hpp
@@ -195,4 +195,5 @@ void autocorrelation(const Eigen::MatrixBase<DerivedA>& y,
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/autocovariance.hpp
+++ b/stan/math/prim/mat/fun/autocovariance.hpp
@@ -119,4 +119,5 @@ void autocovariance(const Eigen::MatrixBase<DerivedA>& y,
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/block.hpp
+++ b/stan/math/prim/mat/fun/block.hpp
@@ -11,6 +11,7 @@ namespace math {
 /**
  * Return a nrows x ncols submatrix starting at (i-1, j-1).
  *
+ * @tparam T type of elements in the matrix
  * @param m Matrix.
  * @param i Starting row.
  * @param j Starting column.
@@ -31,4 +32,5 @@ inline Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> block(
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/cbrt.hpp
+++ b/stan/math/prim/mat/fun/cbrt.hpp
@@ -9,8 +9,9 @@ namespace math {
 
 /**
  * Structure to wrap cbrt() so it can be vectorized.
- * @param x Variable.
- * @tparam T Variable type.
+ *
+ * @tparam T type of variable
+ * @param x variable
  * @return Cube root of x.
  */
 struct cbrt_fun {
@@ -22,8 +23,9 @@ struct cbrt_fun {
 
 /**
  * Vectorized version of cbrt().
- * @param x Container of variables.
- * @tparam T Container type.
+ *
+ * @tparam T type of container
+ * @param x container
  * @return Cube root of each value in x.
  */
 template <typename T>

--- a/stan/math/prim/mat/fun/ceil.hpp
+++ b/stan/math/prim/mat/fun/ceil.hpp
@@ -9,8 +9,9 @@ namespace math {
 
 /**
  * Structure to wrap ceil() so it can be vectorized.
- * @param x Variable.
- * @tparam T Variable type.
+ *
+ * @tparam T type of variable
+ * @param x variable
  * @return Least integer >= x.
  */
 struct ceil_fun {
@@ -23,8 +24,9 @@ struct ceil_fun {
 
 /**
  * Vectorized version of ceil().
- * @param x Container.
- * @tparam T Container type.
+ *
+ * @tparam T type of container
+ * @param x container
  * @return Least integer >= each value in x.
  */
 template <typename T>

--- a/stan/math/prim/mat/fun/chol2inv.hpp
+++ b/stan/math/prim/mat/fun/chol2inv.hpp
@@ -14,7 +14,8 @@ namespace math {
 
 /**
  * Returns the inverse of the matrix whose Cholesky factor is L
- * @tparam T The scalar type of the matrix
+ *
+ * @tparam T type of elements in the matrix
  * @param L Matrix that is a Cholesky factor.
  * @return The matrix inverse of L * L'
  * @throw std::domain_error If the input matrix is not square or
@@ -50,4 +51,5 @@ Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> chol2inv(
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/cholesky_decompose.hpp
+++ b/stan/math/prim/mat/fun/cholesky_decompose.hpp
@@ -20,6 +20,8 @@ namespace math {
  * value \f$L\f$ will be a lower-traingular matrix such that the
  * original matrix \f$A\f$ is given by
  * <p>\f$A = L \times L^T\f$.
+ *
+ * @tparam T type of elements in the matrix
  * @param m Symmetrix matrix.
  * @return Square root of matrix.
  * @note Because OpenCL only works on doubles there are two
@@ -44,6 +46,7 @@ inline Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> cholesky_decompose(
  * value \f$L\f$ will be a lower-traingular matrix such that the
  * original matrix \f$A\f$ is given by
  * <p>\f$A = L \times L^T\f$.
+ *
  * @param m Symmetrix matrix.
  * @return Square root of matrix.
  * @note Because OpenCL only works on doubles there are two
@@ -77,7 +80,8 @@ inline Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> cholesky_decompose(
   return llt.matrixL();
 #endif
 }
-}  // namespace math
 
+}  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/cholesky_decompose.hpp
+++ b/stan/math/prim/mat/fun/cholesky_decompose.hpp
@@ -17,7 +17,7 @@ namespace math {
 /**
  * Return the lower-triangular Cholesky factor (i.e., matrix
  * square root) of the specified square, symmetric matrix.  The return
- * value \f$L\f$ will be a lower-traingular matrix such that the
+ * value \f$L\f$ will be a lower-triangular matrix such that the
  * original matrix \f$A\f$ is given by
  * <p>\f$A = L \times L^T\f$.
  *
@@ -43,7 +43,7 @@ inline Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> cholesky_decompose(
 /**
  * Return the lower-triangular Cholesky factor (i.e., matrix
  * square root) of the specified square, symmetric matrix.  The return
- * value \f$L\f$ will be a lower-traingular matrix such that the
+ * value \f$L\f$ will be a lower-triangular matrix such that the
  * original matrix \f$A\f$ is given by
  * <p>\f$A = L \times L^T\f$.
  *

--- a/stan/math/prim/mat/fun/cholesky_factor_constrain.hpp
+++ b/stan/math/prim/mat/fun/cholesky_factor_constrain.hpp
@@ -17,7 +17,7 @@ namespace math {
  * specified vector.  A total of (N choose 2) + N + (M - N) * N
  * elements are required to read an M by N Cholesky factor.
  *
- * @tparam T Type of scalars in matrix
+ * @tparam T type of elements in the matrix
  * @param x Vector of unconstrained values
  * @param M Number of rows
  * @param N Number of columns
@@ -62,7 +62,7 @@ Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> cholesky_factor_constrain(
  * of (N choose 2) + N + N * (M - N) free parameters are required to read
  * an M by N Cholesky factor.
  *
- * @tparam T Type of scalars in matrix
+ * @tparam T type of elements in the matrix
  * @param x Vector of unconstrained values
  * @param M Number of rows
  * @param N Number of columns
@@ -87,4 +87,5 @@ Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> cholesky_factor_constrain(
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/cholesky_factor_free.hpp
+++ b/stan/math/prim/mat/fun/cholesky_factor_free.hpp
@@ -14,6 +14,7 @@ namespace math {
  * the specified Cholesky factor.  A Cholesky factor must be lower
  * triangular and have positive diagonal elements.
  *
+ * @tparam T type of elements in the Cholesky factor
  * @param y Cholesky factor.
  * @return Unconstrained parameters for Cholesky factor.
  * @throw std::domain_error If the matrix is not a Cholesky factor.
@@ -45,4 +46,5 @@ Eigen::Matrix<T, Eigen::Dynamic, 1> cholesky_factor_free(
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/col.hpp
+++ b/stan/math/prim/mat/fun/col.hpp
@@ -14,6 +14,7 @@ namespace math {
  * This is equivalent to calling <code>m.col(i - 1)</code> and
  * assigning the resulting template expression to a column vector.
  *
+ * @tparam T type of elements in the matrix
  * @param m Matrix.
  * @param j Column index (count from 1).
  * @return Specified column of the matrix.
@@ -28,4 +29,5 @@ inline Eigen::Matrix<T, Eigen::Dynamic, 1> col(
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/cols.hpp
+++ b/stan/math/prim/mat/fun/cols.hpp
@@ -10,9 +10,9 @@ namespace math {
  * Return the number of columns in the specified
  * matrix, vector, or row vector.
  *
- * @tparam T Type of matrix entries.
- * @tparam R Row type of matrix.
- * @tparam C Column type of matrix.
+ * @tparam T type of elements in the matrix
+ * @tparam R number of rows or Eigen::Dynamic
+ * @tparam C number of columns or Eigen::Dynamic
  * @param[in] m Input matrix, vector, or row vector.
  * @return Number of columns.
  */
@@ -23,4 +23,5 @@ inline int cols(const Eigen::Matrix<T, R, C>& m) {
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/columns_dot_product.hpp
+++ b/stan/math/prim/mat/fun/columns_dot_product.hpp
@@ -10,6 +10,11 @@ namespace math {
 /**
  * Returns the dot product of the specified vectors.
  *
+ * @tparam R1 number of rows, can be Eigen::Dynamic
+ * @tparam C1 number of columns, can be Eigen::Dynamic
+ * @tparam R2 number of rows, can be Eigen::Dynamic
+ * @tparam C2 number of columns, can be Eigen::Dynamic
+ *
  * @param v1 First vector.
  * @param v2 Second vector.
  * @return Dot product of the vectors.
@@ -26,4 +31,5 @@ inline Eigen::Matrix<double, 1, C1> columns_dot_product(
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/columns_dot_self.hpp
+++ b/stan/math/prim/mat/fun/columns_dot_self.hpp
@@ -8,8 +8,12 @@ namespace math {
 
 /**
  * Returns the dot product of each column of a matrix with itself.
+ *
+ * @tparam T type of elements in the matrix
+ * @tparam R number of rows or Eigen::Dynamic
+ * @tparam C number of columns or Eigen::Dynamic
+ *
  * @param x Matrix.
- * @tparam T scalar type
  */
 template <typename T, int R, int C>
 inline Eigen::Matrix<T, 1, C> columns_dot_self(
@@ -19,4 +23,5 @@ inline Eigen::Matrix<T, 1, C> columns_dot_self(
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/common_type.hpp
+++ b/stan/math/prim/mat/fun/common_type.hpp
@@ -6,15 +6,16 @@
 
 namespace stan {
 namespace math {
+
 /**
  * Struct which calculates type promotion over two types.
  *
  * <p>This specialization is for matrix types.
  *
- * @tparam T1 type of elements contained in Eigen::Matrix<T1>
- * @tparam T2 type of elements contained in Eigen::Matrix<T2>
- * @tparam R number of rows
- * @tparam C number of columns
+ * @tparam T1 type of elements in the first matrix
+ * @tparam T2 type of elements in the second matrix
+ * @tparam R number of rows, can be Eigen::Dynamic
+ * @tparam C number of columns, can be Eigen::Dynamic
  */
 template <typename T1, typename T2, int R, int C>
 struct common_type<Eigen::Matrix<T1, R, C>, Eigen::Matrix<T2, R, C> > {

--- a/stan/math/prim/mat/fun/corr_matrix_constrain.hpp
+++ b/stan/math/prim/mat/fun/corr_matrix_constrain.hpp
@@ -29,9 +29,9 @@ namespace math {
  * <p>The free vector entries are first constrained to be
  * valid correlation values using <code>corr_constrain(T)</code>.
  *
+ * @tparam T type of scalar
  * @param x Vector of unconstrained partial correlations.
  * @param k Dimensionality of returned correlation matrix.
- * @tparam T Type of scalar.
  * @throw std::invalid_argument if x is not a valid correlation
  * matrix.
  */
@@ -67,10 +67,10 @@ Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> corr_matrix_constrain(
  * defined in <code>corr_constrain(T, double)</code> for
  * this function.
  *
+ * @tparam T type of scalar
  * @param x Vector of unconstrained partial correlations.
  * @param k Dimensionality of returned correlation matrix.
  * @param lp Log probability reference to increment.
- * @tparam T Type of scalar.
  */
 template <typename T>
 Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> corr_matrix_constrain(
@@ -94,4 +94,5 @@ Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> corr_matrix_constrain(
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/corr_matrix_free.hpp
+++ b/stan/math/prim/mat/fun/corr_matrix_free.hpp
@@ -23,10 +23,10 @@ namespace math {
  * needs to compute the \f$k \choose 2\f$ partial correlations
  * and then free those.
  *
+ * @tparam T type of scalar
  * @param y The correlation matrix to free.
  * @return Vector of unconstrained values that produce the
  * specified correlation matrix when transformed.
- * @tparam T Type of scalar.
  * @throw std::domain_error if the correlation matrix has no
  *    elements or is not a square matrix.
  * @throw std::runtime_error if the correlation matrix cannot be
@@ -59,6 +59,8 @@ Eigen::Matrix<T, Eigen::Dynamic, 1> corr_matrix_free(
   }
   return x.matrix();
 }
+
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/cos.hpp
+++ b/stan/math/prim/mat/fun/cos.hpp
@@ -9,8 +9,9 @@ namespace math {
 
 /**
  * Structure to wrap cos() so it can be vectorized.
- * @param x Angle in radians.
- * @tparam T Variable type.
+ *
+ * @tparam T type of variable
+ * @param x angle in radians
  * @return Cosine of x.
  */
 struct cos_fun {
@@ -23,8 +24,9 @@ struct cos_fun {
 
 /**
  * Vectorized version of cos().
- * @param x Container of angles in radians.
- * @tparam T Container type.
+ *
+ * @tparam T type of container
+ * @param x angles in radians
  * @return Cosine of each value in x.
  */
 template <typename T>

--- a/stan/math/prim/mat/fun/cosh.hpp
+++ b/stan/math/prim/mat/fun/cosh.hpp
@@ -9,8 +9,9 @@ namespace math {
 
 /**
  * Structure to wrap cosh() so it can be vectorized.
- * @param x Angle in radians.
- * @tparam T Variable type.
+ *
+ * @tparam T type of argument
+ * @param x angle in radians
  * @return Hyperbolic cosine of x.
  */
 struct cosh_fun {
@@ -23,8 +24,9 @@ struct cosh_fun {
 
 /**
  * Vectorized version of cosh().
- * @param x Angle in radians.
- * @tparam T Variable type.
+ *
+ * @tparam T type of container
+ * @param x angles in radians
  * @return Hyberbolic cosine of x.
  */
 template <typename T>

--- a/stan/math/prim/mat/fun/cov_matrix_constrain.hpp
+++ b/stan/math/prim/mat/fun/cov_matrix_constrain.hpp
@@ -9,7 +9,6 @@
 #include <cmath>
 
 namespace stan {
-
 namespace math {
 
 /**
@@ -19,6 +18,7 @@ namespace math {
  *
  * <p>See <code>cov_matrix_free()</code> for the inverse transform.
  *
+ * @tparam T type of elements in the vector
  * @param x The vector to convert to a covariance matrix.
  * @param K The number of rows and columns of the resulting
  * covariance matrix.
@@ -56,6 +56,7 @@ Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> cov_matrix_constrain(
  *
  * <p>See <code>cov_matrix_free()</code> for the inverse transform.
  *
+ * @tparam T type of elements in the vector
  * @param x The vector to convert to a covariance matrix.
  * @param K The dimensions of the resulting covariance matrix.
  * @param lp Reference
@@ -95,4 +96,5 @@ Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> cov_matrix_constrain(
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/cov_matrix_constrain_lkj.hpp
+++ b/stan/math/prim/mat/fun/cov_matrix_constrain_lkj.hpp
@@ -57,7 +57,7 @@ Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> cov_matrix_constrain_lkj(
  * composing the log absolute Jacobian determinant for the
  * underlying correlation matrix as defined in
  * <code>cov_matrix_constrain(Matrix, size_t, T&)</code> with
- * the Jacobian of the transfrom of the correlation matrix
+ * the Jacobian of the transform of the correlation matrix
  * into a covariance matrix by scaling by standard deviations.
  *
  * @tparam T type of elements in the vector

--- a/stan/math/prim/mat/fun/cov_matrix_constrain_lkj.hpp
+++ b/stan/math/prim/mat/fun/cov_matrix_constrain_lkj.hpp
@@ -21,12 +21,12 @@ namespace math {
  * in <code>corr_matrix_constrain(Matrix, size_t)</code>
  * with the constrained deviations.
  *
+ * @tparam T type of elements in the vector
  * @param x Input vector of unconstrained partial correlations and
  * standard deviations.
  * @param k Dimensionality of returned covariance matrix.
  * @return Covariance matrix derived from the unconstrained partial
  * correlations and deviations.
- * @tparam T Type of scalar.
  */
 template <typename T>
 Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> cov_matrix_constrain_lkj(
@@ -60,13 +60,13 @@ Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> cov_matrix_constrain_lkj(
  * the Jacobian of the transfrom of the correlation matrix
  * into a covariance matrix by scaling by standard deviations.
  *
+ * @tparam T type of elements in the vector
  * @param x Input vector of unconstrained partial correlations and
  * standard deviations.
  * @param k Dimensionality of returned covariance matrix.
  * @param lp Log probability reference to increment.
  * @return Covariance matrix derived from the unconstrained partial
  * correlations and deviations.
- * @tparam T Type of scalar.
  */
 template <typename T>
 Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> cov_matrix_constrain_lkj(
@@ -85,7 +85,6 @@ Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> cov_matrix_constrain_lkj(
 }
 
 }  // namespace math
-
 }  // namespace stan
 
 #endif

--- a/stan/math/prim/mat/fun/cov_matrix_free.hpp
+++ b/stan/math/prim/mat/fun/cov_matrix_free.hpp
@@ -26,6 +26,7 @@ namespace math {
  * function to work), the symmetric view of its lower-triangular
  * view must be positive definite.
  *
+ * @tparam T type of elements in the matrix
  * @param y Matrix of dimensions K by K such that he symmetric
  * view of the lower-triangular view is positive definite.
  * @return Vector of size K plus (K choose 2) in (-inf, inf)
@@ -62,4 +63,5 @@ Eigen::Matrix<T, Eigen::Dynamic, 1> cov_matrix_free(
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/cov_matrix_free_lkj.hpp
+++ b/stan/math/prim/mat/fun/cov_matrix_free_lkj.hpp
@@ -19,10 +19,10 @@ namespace math {
  * inverse first factors out the deviations, then applies the
  * freeing transfrom of <code>corr_matrix_free(Matrix&)</code>.
  *
+ * @tparam T type of elements in the matrix
  * @param y Covariance matrix to free.
  * @return Vector of unconstrained values that transforms to the
  * specified covariance matrix.
- * @tparam T Type of scalar.
  * @throw std::domain_error if the correlation matrix has no
  *    elements or is not a square matrix.
  * @throw std::runtime_error if the correlation matrix cannot be
@@ -60,4 +60,5 @@ Eigen::Matrix<T, Eigen::Dynamic, 1> cov_matrix_free_lkj(
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/cov_matrix_free_lkj.hpp
+++ b/stan/math/prim/mat/fun/cov_matrix_free_lkj.hpp
@@ -17,7 +17,7 @@ namespace math {
  * <p>The constraining transform is defined as for
  * <code>cov_matrix_constrain(Matrix, size_t)</code>.  The
  * inverse first factors out the deviations, then applies the
- * freeing transfrom of <code>corr_matrix_free(Matrix&)</code>.
+ * freeing transform of <code>corr_matrix_free(Matrix&)</code>.
  *
  * @tparam T type of elements in the matrix
  * @param y Covariance matrix to free.

--- a/stan/math/prim/mat/fun/crossprod.hpp
+++ b/stan/math/prim/mat/fun/crossprod.hpp
@@ -10,6 +10,7 @@ namespace math {
 /**
  * Returns the result of pre-multiplying a matrix by its
  * own transpose.
+ *
  * @param M Matrix to multiply.
  * @return Transpose of M times M
  */
@@ -19,4 +20,5 @@ inline matrix_d crossprod(const matrix_d& M) {
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/csr_extract_u.hpp
+++ b/stan/math/prim/mat/fun/csr_extract_u.hpp
@@ -16,7 +16,7 @@ namespace math {
 /**
  * Extract the NZE index for each entry from a sparse matrix.
  *
- * @tparam T Type of matrix entries.
+ * @tparam T type of elements in the matrix
  * @param A Sparse matrix.
  * @return Vector of indexes into non-zero entries of A.
  */
@@ -33,7 +33,9 @@ const std::vector<int> csr_extract_u(
 /**
  * Extract the NZE index for each entry from a sparse matrix.
  *
- * @tparam T Type of matrix entries.
+ * @tparam T type of elements in the matrix
+ * @tparam R number of rows, can be Eigen::Dynamic
+ * @tparam C number of columns, can be Eigen::Dynamic
  * @param A Dense matrix.
  * @return Vector of indexes into non-zero entries of A.
  */

--- a/stan/math/prim/mat/fun/csr_extract_v.hpp
+++ b/stan/math/prim/mat/fun/csr_extract_v.hpp
@@ -17,7 +17,7 @@ namespace math {
  * Extract the column indexes for non-zero value from a sparse
  * matrix.
  *
- * @tparam T Type of matrix entries.
+ * @tparam T type of elements in the matrix
  * @param A Sparse matrix.
  * @return Vector of column indexes for non-zero entries of A.
  */
@@ -36,7 +36,10 @@ const std::vector<int> csr_extract_v(
  * matrix by converting to sparse and calling the sparse matrix
  * extractor.
  *
- * @tparam T Type of matrix entries.
+ * @tparam T type of elements in the matrix
+ * @tparam R number of rows, can be Eigen::Dynamic
+ * @tparam C number of columns, can be Eigen::Dynamic
+ *
  * @param[in] A dense matrix.
  * @return Vector of column indexes to non-zero entries of A.
  */
@@ -48,6 +51,7 @@ const std::vector<int> csr_extract_v(const Eigen::Matrix<T, R, C>& A) {
 }
 
 /** @} */  // end of csr_format group
+
 }  // namespace math
 }  // namespace stan
 

--- a/stan/math/prim/mat/fun/csr_extract_w.hpp
+++ b/stan/math/prim/mat/fun/csr_extract_w.hpp
@@ -12,7 +12,7 @@ namespace math {
 
 /* Extract the non-zero values from a sparse matrix.
  *
- * @tparam T Type of matrix entries.
+ * @tparam T type of elements in the matrix
  * @param[in] A sparse matrix.
  * @return Vector of non-zero entries of A.
  */
@@ -30,7 +30,10 @@ const Eigen::Matrix<T, Eigen::Dynamic, 1> csr_extract_w(
 /* Extract the non-zero values from a dense matrix by converting
  * to sparse and calling the sparse matrix extractor.
  *
- * @tparam T Type of matrix entries.
+ * @tparam T type of elements in the matrix
+ * @tparam R number of rows, can be Eigen::Dynamic
+ * @tparam C number of columns, can be Eigen::Dynamic
+ *
  * @param[in] A dense matrix.
  * @return Vector of non-zero entries of A.
  */
@@ -45,4 +48,5 @@ const Eigen::Matrix<T, Eigen::Dynamic, 1> csr_extract_w(
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/csr_matrix_times_vector.hpp
+++ b/stan/math/prim/mat/fun/csr_matrix_times_vector.hpp
@@ -11,6 +11,7 @@
 
 namespace stan {
 namespace math {
+
 /**
  * @defgroup csr_format Compressed Sparse Row matrix format.
  *  A compressed Sparse Row (CSR) sparse matrix is defined by four
@@ -50,8 +51,8 @@ namespace math {
  * column index of each value), the integer array u (containing
  * one-based indexes of where each row starts in w).
  *
- * @tparam T1 Type of sparse matrix entries.
- * @tparam T2 Type of dense vector entries.
+ * @tparam T1 type of elements in the sparse matrix
+ * @tparam T2 type of elements in the dense vector
  * @param m Number of rows in matrix.
  * @param n Number of columns in matrix.
  * @param w Vector of non-zero values in matrix.
@@ -111,4 +112,5 @@ csr_matrix_times_vector(int m, int n,
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/csr_to_dense_matrix.hpp
+++ b/stan/math/prim/mat/fun/csr_to_dense_matrix.hpp
@@ -18,7 +18,7 @@ namespace math {
 /**
  * Construct a dense Eigen matrix from the CSR format components.
  *
- * @tparam T Type of matrix entries.
+ * @tparam T type of elements in the matrix
  * @param[in] m Number of matrix rows.
  * @param[in] n Number of matrix columns.
  * @param[in] w Values of non-zero matrix entries.
@@ -67,4 +67,5 @@ inline Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> csr_to_dense_matrix(
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/csr_u_to_z.hpp
+++ b/stan/math/prim/mat/fun/csr_u_to_z.hpp
@@ -31,4 +31,5 @@ inline int csr_u_to_z(const std::vector<int>& u, int i) {
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/cumulative_sum.hpp
+++ b/stan/math/prim/mat/fun/cumulative_sum.hpp
@@ -16,7 +16,7 @@ namespace math {
  *
  * \code x[0], x[1] + x[2], ..., x[1] + , ..., + x[x.size()-1] @endcode
  *
- * @tparam T Scalar type of vector.
+ * @tparam T type of elements in the vector
  * @param x Vector of values.
  * @return Cumulative sum of values.
  */
@@ -38,9 +38,10 @@ inline std::vector<T> cumulative_sum(const std::vector<T>& x) {
  *
  * \code x(0), x(1) + x(2), ..., x(1) + , ..., + x(x.size()-1) @endcode
  *
- * @tparam T Scalar type of matrix.
- * @tparam R Row type of matrix.
- * @tparam C Column type of matrix.
+ * @tparam T type of elements in the matrix
+ * @tparam R number of rows, can be Eigen::Dynamic
+ * @tparam C number of columns, can be Eigen::Dynamic
+ *
  * @param m Matrix of values.
  * @return Cumulative sum of values.
  */
@@ -54,6 +55,8 @@ inline Eigen::Matrix<T, R, C> cumulative_sum(const Eigen::Matrix<T, R, C>& m) {
                    std::plus<T>());
   return result;
 }
+
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/determinant.hpp
+++ b/stan/math/prim/mat/fun/determinant.hpp
@@ -10,6 +10,10 @@ namespace math {
 /**
  * Returns the determinant of the specified square matrix.
  *
+ * @tparam T type of elements in the matrix
+ * @tparam R number of rows, can be Eigen::Dynamic
+ * @tparam C number of columns, can be Eigen::Dynamic
+ *
  * @param m Specified matrix.
  * @return Determinant of the matrix.
  * @throw std::domain_error if matrix is not square.
@@ -26,4 +30,5 @@ inline T determinant(const Eigen::Matrix<T, R, C>& m) {
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/diag_matrix.hpp
+++ b/stan/math/prim/mat/fun/diag_matrix.hpp
@@ -9,6 +9,8 @@ namespace math {
 /**
  * Return a square diagonal matrix with the specified vector of
  * coefficients as the diagonal values.
+ *
+ * @tparam T type of elements in the vector
  * @param[in] v Specified vector.
  * @return Diagonal matrix with vector as diagonal values.
  */
@@ -20,4 +22,5 @@ inline Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> diag_matrix(
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/diagonal.hpp
+++ b/stan/math/prim/mat/fun/diagonal.hpp
@@ -9,6 +9,8 @@ namespace math {
 /**
  * Return a column vector of the diagonal elements of the
  * specified matrix.  The matrix is not required to be square.
+ *
+ * @tparam T type of elements in the matrix
  * @param m Specified matrix.
  * @return Diagonal of the matrix.
  */
@@ -20,4 +22,5 @@ inline Eigen::Matrix<T, Eigen::Dynamic, 1> diagonal(
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/digamma.hpp
+++ b/stan/math/prim/mat/fun/digamma.hpp
@@ -9,8 +9,9 @@ namespace math {
 
 /**
  * Structure to wrap digamma() so it can be vectorized.
- * @param x Variable.
- * @tparam T Variable type.
+ *
+ * @tparam T type of variable
+ * @param x variable
  * @return Digamma function applied to x.
  * @throw std::domain_error if x is a negative integer or 0
  */
@@ -23,8 +24,9 @@ struct digamma_fun {
 
 /**
  * Vectorized version of digamma().
- * @param x Container.
- * @tparam T Container type.
+ *
+ * @tparam T type of container
+ * @param x container
  * @return Digamma function applied to each value in x.
  * @throw std::domain_error if any value is a negative integer or 0
  */

--- a/stan/math/prim/mat/fun/distance.hpp
+++ b/stan/math/prim/mat/fun/distance.hpp
@@ -13,6 +13,8 @@ namespace math {
 /**
  * Returns the distance between the specified vectors.
  *
+ * @tparam T1 type of elements in first vector
+ * @tparam T2 type of elements in second vector
  * @param v1 First vector.
  * @param v2 Second vector.
  * @return Dot product of the vectors.
@@ -31,4 +33,5 @@ inline return_type_t<T1, T2> distance(const Eigen::Matrix<T1, R1, C1>& v1,
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/divide.hpp
+++ b/stan/math/prim/mat/fun/divide.hpp
@@ -10,9 +10,10 @@ namespace math {
 
 /**
  * Return matrix divided by scalar.
- * @tparam R number of rows or Eigen::Dynamic
- * @tparam C number of columns or Eigen::Dynamic
- * @tparam T1 type of coefficients in matrix
+ *
+ * @tparam R number of rows, can be Eigen::Dynamic
+ * @tparam C number of columns, can be Eigen::Dynamic
+ * @tparam T1 type of elements in the matrix
  * @tparam T2 type of scalar
  * @param[in] m specified matrix
  * @param[in] c specified scalar
@@ -27,4 +28,5 @@ inline Eigen::Matrix<return_type_t<T1, T2>, R, C> divide(
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/divide_columns.hpp
+++ b/stan/math/prim/mat/fun/divide_columns.hpp
@@ -9,19 +9,16 @@
 
 namespace stan {
 namespace math {
+
 /**
  * Takes Stan data type vector[n] x[D] and divides column
  * vector in x element-wise by the values in vec
  *
  * @tparam T_x Type of dividend
  * @tparam T_v Scalar type of divisor
- * @tparam R   Row type of Eigen Matrices
- * @tparam C   Column type of Eigen Matrices
- *
  * @param x    std::vector of matrices
  * @param vec  std::vector of divisors
  * @throw std::invalid argument if D != length of vector
- *
  */
 template <typename T_x, typename T_v>
 inline typename std::vector<
@@ -44,6 +41,7 @@ divide_columns(const std::vector<Eigen::Matrix<T_x, Eigen::Dynamic, 1>> &x,
   }
   return out;
 }
+
 }  // namespace math
 }  // namespace stan
 

--- a/stan/math/prim/mat/fun/dot_product.hpp
+++ b/stan/math/prim/mat/fun/dot_product.hpp
@@ -8,6 +8,7 @@
 
 namespace stan {
 namespace math {
+
 /**
  * Returns the dot product of the specified vectors.
  *
@@ -25,8 +26,10 @@ inline double dot_product(const Eigen::Matrix<double, R1, C1> &v1,
   check_matching_sizes("dot_product", "v1", v1, "v2", v2);
   return v1.dot(v2);
 }
+
 /**
  * Returns the dot product of the specified arrays of doubles.
+ *
  * @param v1 First array.
  * @param v2 Second array.
  * @param length Length of both arrays.
@@ -38,8 +41,10 @@ inline double dot_product(const double *v1, const double *v2, size_t length) {
   }
   return result;
 }
+
 /**
  * Returns the dot product of the specified arrays of doubles.
+ *
  * @param v1 First array.
  * @param v2 Second array.
  * @throw std::domain_error if the vectors are not the same size.
@@ -49,6 +54,8 @@ inline double dot_product(const std::vector<double> &v1,
   check_matching_sizes("dot_product", "v1", v1, "v2", v2);
   return dot_product(&v1[0], &v2[0], v1.size());
 }
+
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/dot_self.hpp
+++ b/stan/math/prim/mat/fun/dot_self.hpp
@@ -9,9 +9,10 @@ namespace math {
 
 /**
  * Returns the dot product of the specified vector with itself.
+ *
+ * @tparam R number of rows, can be Eigen::Dynamic
+ * @tparam C number of columns, can be Eigen::Dynamic
  * @param v Vector.
- * @tparam R number of rows or <code>Eigen::Dynamic</code> for dynamic
- * @tparam C number of rows or <code>Eigen::Dyanmic</code> for dynamic
  * @throw std::domain_error If v is not vector dimensioned.
  */
 template <int R, int C>
@@ -22,4 +23,5 @@ inline double dot_self(const Eigen::Matrix<double, R, C>& v) {
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/eigenvalues_sym.hpp
+++ b/stan/math/prim/mat/fun/eigenvalues_sym.hpp
@@ -14,6 +14,8 @@ namespace math {
  * efficient than the general eigenvalues function for symmetric
  * matrices.
  * <p>See <code>eigen_decompose()</code> for more information.
+ *
+ * @tparam T type of elements in the matrix
  * @param m Specified matrix.
  * @return Eigenvalues of matrix.
  */
@@ -31,4 +33,5 @@ Eigen::Matrix<T, Eigen::Dynamic, 1> eigenvalues_sym(
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/elt_divide.hpp
+++ b/stan/math/prim/mat/fun/elt_divide.hpp
@@ -10,10 +10,11 @@ namespace math {
 /**
  * Return the elementwise division of the specified matrices.
  *
- * @tparam T1 Type of scalars in first matrix.
- * @tparam T2 Type of scalars in second matrix.
- * @tparam R Row type of both matrices.
- * @tparam C Column type of both matrices.
+ * @tparam T1 type of elements in first matrix
+ * @tparam T2 type of elements in second matrix
+ * @tparam R number of rows, can be Eigen::Dynamic
+ * @tparam C number of columns, can be Eigen::Dynamic
+ *
  * @param m1 First matrix
  * @param m2 Second matrix
  * @return Elementwise division of matrices.
@@ -30,10 +31,11 @@ Eigen::Matrix<return_type_t<T1, T2>, R, C> elt_divide(
  * Return the elementwise division of the specified matrix
  * by the specified scalar.
  *
- * @tparam T1 Type of scalars in the matrix.
- * @tparam T2 Type of the scalar.
- * @tparam R Row type of the matrix.
- * @tparam C Column type of the matrix.
+ * @tparam T1 type of elements in the matrix
+ * @tparam T2 type of the scalar
+ * @tparam R number of rows, can be Eigen::Dynamic
+ * @tparam C number of columns, can be Eigen::Dynamic
+ *
  * @param m matrix
  * @param s scalar
  * @return Elementwise division of a scalar by matrix.
@@ -48,10 +50,11 @@ Eigen::Matrix<return_type_t<T1, T2>, R, C> elt_divide(
  * Return the elementwise division of the specified scalar
  * by the specified matrix.
  *
- * @tparam T1 Type of the scalar.
- * @tparam T2 Type of scalars in the matrix.
- * @tparam R Row type of the matrix.
- * @tparam C Column type of the matrix.
+ * @tparam T1 type of the scalar
+ * @tparam T2 type of elements in the matrix
+ * @tparam R number of rows, can be Eigen::Dynamic
+ * @tparam C number of columns, can be Eigen::Dynamic
+ *
  * @param s scalar
  * @param m matrix
  * @return Elementwise division of a scalar by matrix.
@@ -64,4 +67,5 @@ Eigen::Matrix<return_type_t<T1, T2>, R, C> elt_divide(
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/elt_multiply.hpp
+++ b/stan/math/prim/mat/fun/elt_multiply.hpp
@@ -11,10 +11,11 @@ namespace math {
  * Return the elementwise multiplication of the specified
  * matrices.
  *
- * @tparam T1 Type of scalars in first matrix.
- * @tparam T2 Type of scalars in second matrix.
- * @tparam R Row type of both matrices.
- * @tparam C Column type of both matrices.
+ * @tparam T1 type of elements in first matrix
+ * @tparam T2 type of elements in second matrix
+ * @tparam R number of rows, can be Eigen::Dynamic
+ * @tparam C number of columns, can be Eigen::Dynamic
+ *
  * @param m1 First matrix
  * @param m2 Second matrix
  * @return Elementwise product of matrices.
@@ -28,4 +29,5 @@ Eigen::Matrix<return_type_t<T1, T2>, R, C> elt_multiply(
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/erf.hpp
+++ b/stan/math/prim/mat/fun/erf.hpp
@@ -10,8 +10,8 @@ namespace math {
 /**
  * Structure to wrap erf() so it can be vectorized.
  *
- * @tparam T Variable type.
- * @param x Variable.
+ * @tparam T type of variable
+ * @param x variable
  * @return Error function of x.
  */
 struct erf_fun {
@@ -24,8 +24,8 @@ struct erf_fun {
 /**
  * Vectorized version of erf().
  *
- * @tparam T Container type.
- * @param x Container.
+ * @tparam T type of container
+ * @param x container
  * @return Error function applied to each value in x.
  */
 template <typename T>

--- a/stan/math/prim/mat/fun/erfc.hpp
+++ b/stan/math/prim/mat/fun/erfc.hpp
@@ -9,8 +9,9 @@ namespace math {
 
 /**
  * Structure to wrap erfc() so that it can be vectorized.
- * @param x Variable.
- * @tparam T Variable type.
+ *
+ * @tparam T type of variable
+ * @param x variable
  * @return Complementary error function applied to x.
  */
 struct erfc_fun {
@@ -22,8 +23,9 @@ struct erfc_fun {
 
 /**
  * Vectorized version of erfc().
- * @param x Container.
- * @tparam T Container type.
+ *
+ * @tparam T type of container
+ * @param x container
  * @return Complementary error function applied to each value in x.
  */
 template <typename T>

--- a/stan/math/prim/mat/fun/exp.hpp
+++ b/stan/math/prim/mat/fun/exp.hpp
@@ -16,8 +16,8 @@ struct exp_fun {
   /**
    * Return the exponential of the specified scalar argument.
    *
-   * @tparam T Scalar argument type.
-   * @param[in] x Argument.
+   * @tparam T type of argument
+   * @param[in] x argument
    * @return Exponential of argument.
    */
   template <typename T>
@@ -32,8 +32,8 @@ struct exp_fun {
  * which may be a scalar or any Stan container of numeric scalars.
  * The return type is the same as the argument type.
  *
- * @tparam T Argument type.
- * @param[in] x Argument.
+ * @tparam T type of container
+ * @param[in] x container
  * @return Elementwise application of exponentiation to the argument.
  */
 template <typename T>

--- a/stan/math/prim/mat/fun/exp2.hpp
+++ b/stan/math/prim/mat/fun/exp2.hpp
@@ -15,9 +15,9 @@ struct exp2_fun {
   /**
    * Return the base two exponent of the specified argument.
    *
-   * @param x Argument.
+   * @tparam T type of argument
+   * @param x argument
    * @return Base two exponent of the argument.
-   * @tparam T Argument type.
    */
   template <typename T>
   static inline T fun(const T& x) {
@@ -31,8 +31,8 @@ struct exp2_fun {
  * underlying scalar argument type to double if it is an integer,
  * and otherwise is the argument type.
  *
- * @tparam T Container type.
- * @param x Container.
+ * @tparam T type of container
+ * @param x container
  * @return Elementwise exp2 of members of container.
  */
 template <typename T, typename = require_vector_like_t<T>>

--- a/stan/math/prim/mat/fun/expm1.hpp
+++ b/stan/math/prim/mat/fun/expm1.hpp
@@ -9,8 +9,9 @@ namespace math {
 
 /**
  * Structure to wrap expm1() so that it can be vectorized.
- * @param x Variable.
- * @tparam T Variable type.
+ *
+ * @tparam T type of variable
+ * @param x variable
  * @return Natural exponential of x minus one.
  */
 struct expm1_fun {
@@ -22,8 +23,9 @@ struct expm1_fun {
 
 /**
  * Vectorized version of expm1().
- * @param x Container.
- * @tparam T Container type.
+ *
+ * @tparam T type of container
+ * @param x container
  * @return Natural exponential of each value in x minus one.
  */
 template <typename T>

--- a/stan/math/prim/mat/fun/fabs.hpp
+++ b/stan/math/prim/mat/fun/fabs.hpp
@@ -10,8 +10,8 @@ namespace math {
 /**
  * Structure to wrap fabs() so that it can be vectorized.
  *
- * @param x Variable.
- * @tparam T Variable type.
+ * @tparam T type of variable
+ * @param x variable
  * @return Absolute value of x.
  */
 struct fabs_fun {
@@ -25,8 +25,8 @@ struct fabs_fun {
 /**
  * Vectorized version of fabs().
  *
- * @param x Container.
- * @tparam T Container type.
+ * @tparam T type of container
+ * @param x container
  * @return Absolute value of each value in x.
  */
 template <typename T>

--- a/stan/math/prim/mat/fun/factor_U.hpp
+++ b/stan/math/prim/mat/fun/factor_U.hpp
@@ -16,6 +16,7 @@ namespace math {
  * This function is intended to make starting values, given a unit
  * upper-triangular matrix U such that U'DU is a correlation matrix
  *
+ * @tparam T type of elements in the matrix
  * @param U Sigma matrix
  * @param CPCs fill this unbounded
  */

--- a/stan/math/prim/mat/fun/factor_cov_matrix.hpp
+++ b/stan/math/prim/mat/fun/factor_cov_matrix.hpp
@@ -15,6 +15,7 @@ namespace math {
  * The transformations are hard coded as log for standard
  * deviations and Fisher transformations (atanh()) of CPCs
  *
+ * @tparam T type of elements in the matrix and arrays
  * @param[in] Sigma covariance matrix
  * @param[out] CPCs fill this unbounded (does not resize)
  * @param[out] sds fill this unbounded (does not resize)
@@ -51,7 +52,6 @@ bool factor_cov_matrix(
 }
 
 }  // namespace math
-
 }  // namespace stan
 
 #endif

--- a/stan/math/prim/mat/fun/fill.hpp
+++ b/stan/math/prim/mat/fun/fill.hpp
@@ -11,10 +11,11 @@ namespace math {
  *
  * The specified matrix is filled by element.
  *
- * @tparam T Type of scalar for matrix container.
- * @tparam R Row type of matrix.
- * @tparam C Column type of matrix.
+ * @tparam T type of elements in the matrix
+ * @tparam R number of rows, can be Eigen::Dynamic
+ * @tparam C number of columns, can be Eigen::Dynamic
  * @tparam S Type of value.
+ *
  * @param x Container.
  * @param y Value.
  */
@@ -25,4 +26,5 @@ void fill(Eigen::Matrix<T, R, C>& x, const S& y) {
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/floor.hpp
+++ b/stan/math/prim/mat/fun/floor.hpp
@@ -9,8 +9,9 @@ namespace math {
 
 /**
  * Structure to wrap floor() so that it can be vectorized.
- * @param x Variable.
- * @tparam T Variable type.
+ *
+ * @tparam T type of variable
+ * @param x variable
  * @return Greatest integer <= x.
  */
 struct floor_fun {
@@ -23,8 +24,9 @@ struct floor_fun {
 
 /**
  * Vectorized version of floor().
- * @param x Container.
- * @tparam T Container type.
+ *
+ * @tparam T type of container
+ * @param x container
  * @return Greatest integer <= each value in x.
  */
 template <typename T>

--- a/stan/math/prim/mat/fun/get_base1.hpp
+++ b/stan/math/prim/mat/fun/get_base1.hpp
@@ -14,13 +14,13 @@ namespace math {
  * a <code>std::out_of_range</code> exception with the specified
  * error message and index indicated.
  *
+ * @tparam T type of value
  * @param x Vector from which to get a value.
  * @param i Index into vector plus 1.
  * @param error_msg Error message if the index is out of range.
  * @param idx Nested index level to report in error message if
  * the index is out of range.
  * @return Value of vector at <code>i - 1</code>
- * @tparam T type of value.
  * @throw std::out_of_range if idx is out of range.
  */
 template <typename T>
@@ -36,6 +36,7 @@ inline const T& get_base1(const std::vector<T>& x, size_t i,
  * a <code>std::out_of_range</code> exception with the specified
  * error message and index indicated.
  *
+ * @tparam T type of value
  * @param x Vector from which to get a value.
  * @param i1 First index plus 1.
  * @param i2 Second index plus 1.
@@ -43,7 +44,6 @@ inline const T& get_base1(const std::vector<T>& x, size_t i,
  * @param idx Nested index level to report in error message if
  * the index is out of range.
  * @return Value of vector at indexes.
- * @tparam T type of value.
  * @throw std::out_of_range if idx is out of range.
  */
 template <typename T>
@@ -59,6 +59,7 @@ inline const T& get_base1(const std::vector<std::vector<T> >& x, size_t i1,
  * a <code>std::out_of_range</code> exception with the specified
  * error message and index indicated.
  *
+ * @tparam T type of value
  * @param x Vector from which to get a value.
  * @param i1 First index plus 1.
  * @param i2 Second index plus 1.
@@ -67,7 +68,6 @@ inline const T& get_base1(const std::vector<std::vector<T> >& x, size_t i1,
  * @param idx Nested index level to report in error message if
  * the index is out of range.
  * @return Value of vector at indexes.
- * @tparam T type of value.
  * @throw std::out_of_range if idx is out of range.
  */
 template <typename T>
@@ -84,6 +84,7 @@ inline const T& get_base1(const std::vector<std::vector<std::vector<T> > >& x,
  * a <code>std::out_of_range</code> exception with the specified
  * error message and index indicated.
  *
+ * @tparam T type of value
  * @param x Vector from which to get a value.
  * @param i1 First index plus 1.
  * @param i2 Second index plus 1.
@@ -93,7 +94,6 @@ inline const T& get_base1(const std::vector<std::vector<std::vector<T> > >& x,
  * @param idx Nested index level to report in error message if
  * the index is out of range.
  * @return Value of vector at indexes.
- * @tparam T type of value.
  * @throw std::out_of_range if idx is out of range.
  */
 template <typename T>
@@ -111,6 +111,7 @@ inline const T& get_base1(
  * a <code>std::out_of_range</code> exception with the specified
  * error message and index indicated.
  *
+ * @tparam T type of value
  * @param x Vector from which to get a value.
  * @param i1 First index plus 1.
  * @param i2 Second index plus 1.
@@ -121,7 +122,6 @@ inline const T& get_base1(
  * @param idx Nested index level to report in error message if
  * the index is out of range.
  * @return Value of vector at indexes.
- * @tparam T type of value.
  * @throw std::out_of_range if idx is out of range.
  */
 template <typename T>
@@ -140,6 +140,7 @@ inline const T& get_base1(
  * a <code>std::out_of_range</code> exception with the specified
  * error message and index indicated.
  *
+ * @tparam T type of value
  * @param x Vector from which to get a value.
  * @param i1 First index plus 1.
  * @param i2 Second index plus 1.
@@ -151,7 +152,6 @@ inline const T& get_base1(
  * @param idx Nested index level to report in error message if
  * the index is out of range.
  * @return Value of vector at indexes.
- * @tparam T type of value.
  * @throw std::out_of_range if idx is out of range.
  */
 template <typename T>
@@ -170,6 +170,7 @@ inline const T& get_base1(
  * a <code>std::out_of_range</code> exception with the specified
  * error message and index indicated.
  *
+ * @tparam T type of value
  * @param x Vector from which to get a value.
  * @param i1 First index plus 1.
  * @param i2 Second index plus 1.
@@ -182,7 +183,6 @@ inline const T& get_base1(
  * @param idx Nested index level to report in error message if
  * the index is out of range.
  * @return Value of vector at indexes.
- * @tparam T type of value.
  * @throw std::out_of_range if idx is out of range.
  */
 template <typename T>
@@ -201,6 +201,7 @@ inline const T& get_base1(
  * a <code>std::out_of_range</code> exception with the specified
  * error message and index indicated.
  *
+ * @tparam T type of value
  * @param x Vector from which to get a value.
  * @param i1 First index plus 1.
  * @param i2 Second index plus 1.
@@ -214,7 +215,6 @@ inline const T& get_base1(
  * @param idx Nested index level to report in error message if
  * the index is out of range.
  * @return Value of vector at indexes.
- * @tparam T type of value.
  * @throw std::out_of_range if idx is out of range.
  */
 template <typename T>
@@ -238,13 +238,13 @@ inline const T& get_base1(
  * to get a row then using a second call to get the value at
  a specified column.
  *
+ * @tparam T type of value
  * @param x Matrix from which to get a row
  * @param m Index into matrix plus 1.
  * @param error_msg Error message if the index is out of range.
  * @param idx Nested index level to report in error message if
  * the index is out of range.
  * @return Row of matrix at <code>i - 1</code>.
- * @tparam T type of value.
  * @throw std::out_of_range if idx is out of range.
  */
 template <typename T>
@@ -261,6 +261,7 @@ inline Eigen::Matrix<T, 1, Eigen::Dynamic> get_base1(
  * throw a <code>std::out_of_range</code> exception with the
  * specified error message and index indicated.
  *
+ * @tparam T type of value
  * @param x Matrix from which to get a row
  * @param m Row index plus 1.
  * @param n Column index plus 1.
@@ -269,7 +270,6 @@ inline Eigen::Matrix<T, 1, Eigen::Dynamic> get_base1(
  * either index is out of range.
  * @return Value of matrix at row <code>m - 1</code> and column
  * <code>n - 1</code>.
- * @tparam T type of value.
  * @throw std::out_of_range if idx is out of range.
  */
 template <typename T>
@@ -287,13 +287,13 @@ inline const T& get_base1(
  * throw a <code>std::out_of_range</code> exception with the
  * specified error message and index indicated.
  *
+ * @tparam T type of value
  * @param x Column vector from which to get a value.
  * @param m Row index plus 1.
  * @param error_msg Error message if the index is out of range.
  * @param idx Nested index level to report in error message if
  * the index is out of range.
  * @return Value of column vector at row <code>m - 1</code>.
- * @tparam T type of value.
  * @throw std::out_of_range if idx is out of range.
  */
 template <typename T>
@@ -309,13 +309,13 @@ inline const T& get_base1(const Eigen::Matrix<T, Eigen::Dynamic, 1>& x,
  * throw a <code>std::out_of_range</code> exception with the
  * specified error message and index indicated.
  *
+ * @tparam T type of value
  * @param x Row vector from which to get a value.
  * @param n Column index plus 1.
  * @param error_msg Error message if the index is out of range.
  * @param idx Nested index level to report in error message if
  * the index is out of range.
  * @return Value of row vector at column <code>n - 1</code>.
- * @tparam T type of value.
  * @throw std::out_of_range if idx is out of range.
  */
 template <typename T>
@@ -327,4 +327,5 @@ inline const T& get_base1(const Eigen::Matrix<T, 1, Eigen::Dynamic>& x,
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/get_base1_lhs.hpp
+++ b/stan/math/prim/mat/fun/get_base1_lhs.hpp
@@ -14,13 +14,13 @@ namespace math {
  * a <code>std::out_of_range</code> exception with the specified
  * error message and index indicated.
  *
+ * @tparam T type of value
  * @param x Vector from which to get a value.
  * @param i Index into vector plus 1.
  * @param error_msg Error message if the index is out of range.
  * @param idx Nested index level to report in error message if
  * the index is out of range.
  * @return Value of vector at <code>i - 1</code>
- * @tparam T type of value.
  * @throw std::out_of_range if idx is out of range.
  */
 template <typename T>
@@ -36,6 +36,7 @@ inline T& get_base1_lhs(std::vector<T>& x, size_t i, const char* error_msg,
  * a <code>std::out_of_range</code> exception with the specified
  * error message and index indicated.
  *
+ * @tparam T type of value
  * @param x Vector from which to get a value.
  * @param i1 First index plus 1.
  * @param i2 Second index plus 1.
@@ -43,7 +44,6 @@ inline T& get_base1_lhs(std::vector<T>& x, size_t i, const char* error_msg,
  * @param idx Nested index level to report in error message if
  * the index is out of range.
  * @return Value of vector at indexes.
- * @tparam T type of value.
  * @throw std::out_of_range if idx is out of range.
  */
 template <typename T>
@@ -59,6 +59,7 @@ inline T& get_base1_lhs(std::vector<std::vector<T> >& x, size_t i1, size_t i2,
  * a <code>std::out_of_range</code> exception with the specified
  * error message and index indicated.
  *
+ * @tparam T type of value
  * @param x Vector from which to get a value.
  * @param i1 First index plus 1.
  * @param i2 Second index plus 1.
@@ -67,7 +68,6 @@ inline T& get_base1_lhs(std::vector<std::vector<T> >& x, size_t i1, size_t i2,
  * @param idx Nested index level to report in error message if
  * the index is out of range.
  * @return Value of vector at indexes.
- * @tparam T type of value.
  * @throw std::out_of_range if idx is out of range.
  */
 template <typename T>
@@ -84,6 +84,7 @@ inline T& get_base1_lhs(std::vector<std::vector<std::vector<T> > >& x,
  * a <code>std::out_of_range</code> exception with the specified
  * error message and index indicated.
  *
+ * @tparam T type of value
  * @param x Vector from which to get a value.
  * @param i1 First index plus 1.
  * @param i2 Second index plus 1.
@@ -93,7 +94,6 @@ inline T& get_base1_lhs(std::vector<std::vector<std::vector<T> > >& x,
  * @param idx Nested index level to report in error message if
  * the index is out of range.
  * @return Value of vector at indexes.
- * @tparam T type of value.
  * @throw std::out_of_range if idx is out of range.
  */
 template <typename T>
@@ -110,6 +110,7 @@ inline T& get_base1_lhs(
  * a <code>std::out_of_range</code> exception with the specified
  * error message and index indicated.
  *
+ * @tparam T type of value
  * @param x Vector from which to get a value.
  * @param i1 First index plus 1.
  * @param i2 Second index plus 1.
@@ -120,7 +121,6 @@ inline T& get_base1_lhs(
  * @param idx Nested index level to report in error message if
  * the index is out of range.
  * @return Value of vector at indexes.
- * @tparam T type of value.
  * @throw std::out_of_range if idx is out of range.
  */
 template <typename T>
@@ -138,6 +138,7 @@ inline T& get_base1_lhs(
  * a <code>std::out_of_range</code> exception with the specified
  * error message and index indicated.
  *
+ * @tparam T type of value
  * @param x Vector from which to get a value.
  * @param i1 First index plus 1.
  * @param i2 Second index plus 1.
@@ -149,7 +150,6 @@ inline T& get_base1_lhs(
  * @param idx Nested index level to report in error message if
  * the index is out of range.
  * @return Value of vector at indexes.
- * @tparam T type of value.
  * @throw std::out_of_range if idx is out of range.
  */
 template <typename T>
@@ -168,6 +168,7 @@ inline T& get_base1_lhs(
  * a <code>std::out_of_range</code> exception with the specified
  * error message and index indicated.
  *
+ * @tparam T type of value
  * @param x Vector from which to get a value.
  * @param i1 First index plus 1.
  * @param i2 Second index plus 1.
@@ -180,7 +181,6 @@ inline T& get_base1_lhs(
  * @param idx Nested index level to report in error message if
  * the index is out of range.
  * @return Value of vector at indexes.
- * @tparam T type of value.
  * @throw std::out_of_range if idx is out of range.
  */
 template <typename T>
@@ -199,6 +199,7 @@ inline T& get_base1_lhs(
  * a <code>std::out_of_range</code> exception with the specified
  * error message and index indicated.
  *
+ * @tparam T type of value
  * @param x Vector from which to get a value.
  * @param i1 First index plus 1.
  * @param i2 Second index plus 1.
@@ -212,7 +213,6 @@ inline T& get_base1_lhs(
  * @param idx Nested index level to report in error message if
  * the index is out of range.
  * @return Value of vector at indexes.
- * @tparam T type of value.
  * @throw std::out_of_range if idx is out of range.
  */
 template <typename T>
@@ -235,15 +235,15 @@ inline T& get_base1_lhs(
  * <b>Warning</b>:  Because a copy is involved, it is inefficient
  * to access element of matrices by first using this method
  * to get a row then using a second call to get the value at
- a specified column.
+ * a specified column.
  *
+ * @tparam T type of value
  * @param x Matrix from which to get a row
  * @param m Index into matrix plus 1.
  * @param error_msg Error message if the index is out of range.
  * @param idx Nested index level to report in error message if
  * the index is out of range.
  * @return Row of matrix at <code>i - 1</code>.
- * @tparam T type of value.
  * @throw std::out_of_range if idx is out of range.
  */
 template <typename T>
@@ -260,6 +260,7 @@ get_base1_lhs(Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& x, size_t m,
  * throw a <code>std::out_of_range</code> exception with the
  * specified error message and index indicated.
  *
+ * @tparam T type of value
  * @param x Matrix from which to get a row
  * @param m Row index plus 1.
  * @param n Column index plus 1.
@@ -268,7 +269,6 @@ get_base1_lhs(Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& x, size_t m,
  * either index is out of range.
  * @return Value of matrix at row <code>m - 1</code> and column
  * <code>n - 1</code>.
- * @tparam T type of value.
  * @throw std::out_of_range if idx is out of range.
  */
 template <typename T>
@@ -285,13 +285,13 @@ inline T& get_base1_lhs(Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& x,
  * throw a <code>std::out_of_range</code> exception with the
  * specified error message and index indicated.
  *
+ * @tparam T type of value
  * @param x Column vector from which to get a value.
  * @param m Row index plus 1.
  * @param error_msg Error message if the index is out of range.
  * @param idx Nested index level to report in error message if
  * the index is out of range.
  * @return Value of column vector at row <code>m - 1</code>.
- * @tparam T type of value.
  * @throw std::out_of_range if idx is out of range.
  */
 template <typename T>
@@ -307,13 +307,13 @@ inline T& get_base1_lhs(Eigen::Matrix<T, Eigen::Dynamic, 1>& x, size_t m,
  * throw a <code>std::out_of_range</code> exception with the
  * specified error message and index indicated.
  *
+ * @tparam T type of value
  * @param x Row vector from which to get a value.
  * @param n Column index plus 1.
  * @param error_msg Error message if the index is out of range.
  * @param idx Nested index level to report in error message if
  * the index is out of range.
  * @return Value of row vector at column <code>n - 1</code>.
- * @tparam T type of value.
  * @throw std::out_of_range if idx is out of range.
  */
 template <typename T>
@@ -325,4 +325,5 @@ inline T& get_base1_lhs(Eigen::Matrix<T, 1, Eigen::Dynamic>& x, size_t n,
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/gp_dot_prod_cov.hpp
+++ b/stan/math/prim/mat/fun/gp_dot_prod_cov.hpp
@@ -235,6 +235,8 @@ gp_dot_prod_cov(const std::vector<T_x1> &x1, const std::vector<T_x2> &x2,
   }
   return cov;
 }
+
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/head.hpp
+++ b/stan/math/prim/mat/fun/head.hpp
@@ -14,7 +14,7 @@ namespace math {
  * Return the specified number of elements as a vector
  * from the front of the specified vector.
  *
- * @tparam T Type of value in vector.
+ * @tparam T type of elements in the vector
  * @param v Vector input.
  * @param n Size of return.
  * @return The first n elements of v.
@@ -33,7 +33,7 @@ inline Eigen::Matrix<T, Eigen::Dynamic, 1> head(
  * Return the specified number of elements as a row vector
  * from the front of the specified row vector.
  *
- * @tparam T Type of value in vector.
+ * @tparam T type of elements in the vector
  * @param rv Row vector.
  * @param n Size of return row vector.
  * @return The first n elements of rv.
@@ -52,7 +52,7 @@ inline Eigen::Matrix<T, 1, Eigen::Dynamic> head(
  * Return the specified number of elements as a standard vector
  * from the front of the specified standard vector.
  *
- * @tparam T Type of value in vector.
+ * @tparam T type of elements in the vector
  * @param sv Standard vector.
  * @param n Size of return.
  * @return The first n elements of sv.
@@ -73,4 +73,5 @@ std::vector<T> head(const std::vector<T>& sv, size_t n) {
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/inv.hpp
+++ b/stan/math/prim/mat/fun/inv.hpp
@@ -9,8 +9,9 @@ namespace math {
 
 /**
  * Structure to wrap inv() so that it can be vectorized.
- * @param x Variable.
- * @tparam T Variable type.
+ *
+ * @tparam T type of variable
+ * @param x variable
  * @return 1 / x.
  */
 struct inv_fun {
@@ -22,8 +23,9 @@ struct inv_fun {
 
 /**
  * Vectorized version of inv().
- * @param x Container.
- * @tparam T Container type.
+ *
+ * @tparam T type of container
+ * @param x container
  * @return 1 divided by each value in x.
  */
 template <typename T>

--- a/stan/math/prim/mat/fun/inv_Phi.hpp
+++ b/stan/math/prim/mat/fun/inv_Phi.hpp
@@ -9,8 +9,9 @@ namespace math {
 
 /**
  * Structure to wrap inv_Phi() so it can be vectorized.
- * @param x Variable in range [0, 1].
- * @tparam T Variable type.
+ *
+ * @tparam T type of variable
+ * @param x variable in range [0, 1]
  * @return Inverse unit normal CDF of x.
  * @throw std::domain_error if x is not between 0 and 1.
  */
@@ -23,8 +24,9 @@ struct inv_Phi_fun {
 
 /**
  * Vectorized version of inv_Phi().
- * @param x Container of variables in range [0, 1].
- * @tparam T Container type.
+ *
+ * @tparam T type of container
+ * @param x variables in range [0, 1]
  * @return Inverse unit normal CDF of each value in x.
  * @throw std::domain_error if any value is not between 0 and 1.
  */

--- a/stan/math/prim/mat/fun/inv_cloglog.hpp
+++ b/stan/math/prim/mat/fun/inv_cloglog.hpp
@@ -9,8 +9,9 @@ namespace math {
 
 /**
  * Structure to wrap inv_cloglog() so that it can be vectorized.
- * @param x Variable.
- * @tparam T Variable type.
+ *
+ * @tparam T type of variable
+ * @param x variable
  * @return 1 - exp(-exp(x)).
  */
 struct inv_cloglog_fun {
@@ -22,8 +23,9 @@ struct inv_cloglog_fun {
 
 /**
  * Vectorized version of inv_cloglog().
- * @param x Container.
- * @tparam T Container type.
+ *
+ * @tparam T type of container
+ * @param x container
  * @return 1 - exp(-exp()) applied to each value in x.
  */
 template <typename T>

--- a/stan/math/prim/mat/fun/inv_logit.hpp
+++ b/stan/math/prim/mat/fun/inv_logit.hpp
@@ -9,8 +9,9 @@ namespace math {
 
 /**
  * Structure to wrap inv_logit() so that it can be vectorized.
- * @param x Variable.
- * @tparam T Variable type.
+ *
+ * @tparam T type of variable
+ * @param x variable
  * @return Inverse logit of x.
  */
 struct inv_logit_fun {
@@ -22,8 +23,9 @@ struct inv_logit_fun {
 
 /**
  * Vectorized version of inv_logit().
- * @param x Container.
- * @tparam T Container type.
+ *
+ * @tparam T type of container
+ * @param x container
  * @return Inverse logit applied to each value in x.
  */
 template <typename T>

--- a/stan/math/prim/mat/fun/inv_sqrt.hpp
+++ b/stan/math/prim/mat/fun/inv_sqrt.hpp
@@ -9,8 +9,9 @@ namespace math {
 
 /**
  * Structure to wrap inv_sqrt() so that it can be vectorized.
- * @param x Variable.
- * @tparam T Variable type.
+ *
+ * @tparam T type of variable
+ * @param x variable
  * @return 1 / sqrt of x.
  */
 struct inv_sqrt_fun {
@@ -22,8 +23,9 @@ struct inv_sqrt_fun {
 
 /**
  * Vectorized version of inv_sqrt().
- * @param x Container.
- * @tparam T Container type.
+ *
+ * @tparam T type of container
+ * @param x container
  * @return 1 / sqrt of each value in x.
  */
 template <typename T>

--- a/stan/math/prim/mat/fun/inv_square.hpp
+++ b/stan/math/prim/mat/fun/inv_square.hpp
@@ -9,8 +9,9 @@ namespace math {
 
 /**
  * Structure to wrap inv_square() so that it can be vectorized.
- * @param x Variable.
- * @tparam T Variable type.
+ *
+ * @tparam T type of variable
+ * @param x variable
  * @return 1 / x squared.
  */
 struct inv_square_fun {
@@ -22,8 +23,9 @@ struct inv_square_fun {
 
 /**
  * Vectorized version of inv_square().
- * @param x Container.
- * @tparam T Container type.
+ *
+ * @tparam T type of container
+ * @param x container
  * @return 1 / the square of each value in x.
  */
 template <typename T>

--- a/stan/math/prim/mat/fun/inverse.hpp
+++ b/stan/math/prim/mat/fun/inverse.hpp
@@ -10,6 +10,11 @@ namespace math {
 
 /**
  * Returns the inverse of the specified matrix.
+ *
+ * @tparam T type of elements in the matrix
+ * @tparam R number of rows, can be Eigen::Dynamic
+ * @tparam C number of columns, can be Eigen::Dynamic
+ *
  * @param m Specified matrix.
  * @return Inverse of the matrix.
  */
@@ -22,4 +27,5 @@ inline Eigen::Matrix<T, R, C> inverse(const Eigen::Matrix<T, R, C>& m) {
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/inverse_spd.hpp
+++ b/stan/math/prim/mat/fun/inverse_spd.hpp
@@ -11,6 +11,8 @@ namespace math {
 
 /**
  * Returns the inverse of the specified symmetric, pos/neg-definite matrix.
+ *
+ * @tparam T type of elements in the matrix
  * @param m Specified matrix.
  * @return Inverse of the matrix.
  */
@@ -42,4 +44,5 @@ inline Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> inverse_spd(
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/lgamma.hpp
+++ b/stan/math/prim/mat/fun/lgamma.hpp
@@ -9,8 +9,9 @@ namespace math {
 
 /**
  * Structure to wrap lgamma() so that it can be vectorized.
- * @param x Variable.
- * @tparam T Variable type.
+ *
+ * @tparam T type of variable
+ * @param x variable
  * @return Natural log of the gamma function applied to x.
  * @throw std::domain_error if x is a negative integer or 0.
  */
@@ -23,8 +24,9 @@ struct lgamma_fun {
 
 /**
  * Vectorized version of lgamma().
- * @param x Container.
- * @tparam T Container type.
+ *
+ * @tparam T type of container
+ * @param x container
  * @return Natural log of the gamma function
  *         applied to each value in x.
  * @throw std::domain_error if any value is a negative integer or 0.

--- a/stan/math/prim/mat/fun/log.hpp
+++ b/stan/math/prim/mat/fun/log.hpp
@@ -15,8 +15,8 @@ struct log_fun {
   /**
    * Return natural log of specified argument.
    *
-   * @tparam T Scalar argument type.
-   * @param[in] x Argument.
+   * @tparam T type of argument
+   * @param[in] x argument
    * @return Natural log of x.
    */
   template <typename T>
@@ -31,8 +31,8 @@ struct log_fun {
  * which may be a scalar or any Stan container of numeric scalars.
  * The return type is the same as the argument type.
  *
- * @tparam T Argument type.
- * @param[in] x Argument.
+ * @tparam T type of container
+ * @param[in] x container
  * @return Elementwise application of natural log to the argument.
  */
 template <typename T>

--- a/stan/math/prim/mat/fun/log10.hpp
+++ b/stan/math/prim/mat/fun/log10.hpp
@@ -9,8 +9,9 @@ namespace math {
 
 /**
  * Structure to wrap log10() so it can be vectorized.
- * @param x Variable.
- * @tparam T Variable type.
+ *
+ * @tparam T type of variable
+ * @param x variable
  * @return Log base-10 of x.
  */
 struct log10_fun {
@@ -23,8 +24,9 @@ struct log10_fun {
 
 /**
  * Vectorized version of log10().
- * @param x Container.
- * @tparam T Container type.
+ *
+ * @tparam T type of container
+ * @param x container
  * @return Log base-10 applied to each value in x.
  */
 template <typename T>

--- a/stan/math/prim/mat/fun/log1m.hpp
+++ b/stan/math/prim/mat/fun/log1m.hpp
@@ -9,8 +9,9 @@ namespace math {
 
 /**
  * Structure to wrap log1m() so it can be vectorized.
- * @param x Variable.
- * @tparam T Variable type.
+ *
+ * @tparam T type of variable
+ * @param x variable
  * @return Natural log of (1 - x).
  */
 struct log1m_fun {
@@ -22,8 +23,9 @@ struct log1m_fun {
 
 /**
  * Vectorized version of log1m().
- * @param x Container.
- * @tparam T Container type.
+ *
+ * @tparam T type of container
+ * @param x container
  * @return Natural log of 1 minus each value in x.
  */
 template <typename T>

--- a/stan/math/prim/mat/fun/log1m_exp.hpp
+++ b/stan/math/prim/mat/fun/log1m_exp.hpp
@@ -9,8 +9,9 @@ namespace math {
 
 /**
  * Structure to wrap log1m_exp() so it can be vectorized.
- * @param x Variable.
- * @tparam T Variable type.
+ *
+ * @tparam T type of variable
+ * @param x variable
  * @return Natural log of (1 - exp(x)).
  */
 struct log1m_exp_fun {
@@ -22,8 +23,9 @@ struct log1m_exp_fun {
 
 /**
  * Vectorized version of log1m_exp().
- * @param x Container.
- * @tparam T Container type.
+ *
+ * @tparam T type of container
+ * @param x container
  * @return Natural log of (1 - exp()) applied to each value in x.
  */
 template <typename T>

--- a/stan/math/prim/mat/fun/log1m_inv_logit.hpp
+++ b/stan/math/prim/mat/fun/log1m_inv_logit.hpp
@@ -15,7 +15,7 @@ struct log1m_inv_logit_fun {
    * Return the natural logarithm of one minus the inverse logit
    * of the specified argument.
    *
-   * @tparam T argument scalar type
+   * @tparam T type of argument
    * @param x argument
    * @return natural log of one minus inverse logit of argument
    */
@@ -31,8 +31,8 @@ struct log1m_inv_logit_fun {
  * The return type promotes the underlying scalar argument type to
  * double if it is an integer, and otherwise is the argument type.
  *
- * @tparam T Container type.
- * @param x Container.
+ * @tparam T type of container
+ * @param x container
  * @return Elementwise log1m_inv_logit of members of container.
  */
 template <typename T>

--- a/stan/math/prim/mat/fun/log1p.hpp
+++ b/stan/math/prim/mat/fun/log1p.hpp
@@ -14,9 +14,9 @@ struct log1p_fun {
   /**
    * Return the inverse hypberbolic cosine of the specified argument.
    *
-   * @param x Argument.
+   * @tparam T type of argument
+   * @param x argument
    * @return Inverse hyperbolic cosine of the argument.
-   * @tparam T Argument type.
    */
   template <typename T>
   static inline T fun(const T& x) {
@@ -30,8 +30,8 @@ struct log1p_fun {
  * underlying scalar argument type to double if it is an integer,
  * and otherwise is the argument type.
  *
- * @tparam T Container type.
- * @param x Container.
+ * @tparam T type of container
+ * @param x container
  * @return Elementwise log1p of members of container.
  */
 template <typename T>

--- a/stan/math/prim/mat/fun/log1p.hpp
+++ b/stan/math/prim/mat/fun/log1p.hpp
@@ -12,11 +12,11 @@ namespace math {
  */
 struct log1p_fun {
   /**
-   * Return the inverse hypberbolic cosine of the specified argument.
+   * Return the natural logarithm of one plus the specified value.
    *
    * @tparam T type of argument
    * @param x argument
-   * @return Inverse hyperbolic cosine of the argument.
+   * @return natural log of one plus the argument
    */
   template <typename T>
   static inline T fun(const T& x) {

--- a/stan/math/prim/mat/fun/log1p_exp.hpp
+++ b/stan/math/prim/mat/fun/log1p_exp.hpp
@@ -9,8 +9,9 @@ namespace math {
 
 /**
  * Structure to wrap log1m_exp() so that it can be vectorized.
- * @param x Variable.
- * @tparam T Variable type.
+ *
+ * @tparam T type of variable
+ * @param x variable
  * @return Natural log of (1 + exp(x)).
  */
 struct log1p_exp_fun {
@@ -22,8 +23,9 @@ struct log1p_exp_fun {
 
 /**
  * Vectorized version of log1m_exp().
- * @param x Container.
- * @tparam T Container type.
+ *
+ * @tparam T type of container
+ * @param x container
  * @return Natural log of (1 + exp()) applied to each value in x.
  */
 template <typename T>

--- a/stan/math/prim/mat/fun/log2.hpp
+++ b/stan/math/prim/mat/fun/log2.hpp
@@ -15,7 +15,7 @@ struct log2_fun {
   /**
    * Return the base two logarithm of the specified argument.
    *
-   * @tparam T argument type
+   * @tparam T type of argument
    * @param x argument
    * @return base two log of the argument
    */
@@ -31,7 +31,7 @@ struct log2_fun {
  * underlying scalar argument type to double if it is an integer,
  * and otherwise is the argument type.
  *
- * @tparam T container type
+ * @tparam T type of container
  * @param x container
  * @return elementwise log2 of container elements
  */

--- a/stan/math/prim/mat/fun/log_determinant.hpp
+++ b/stan/math/prim/mat/fun/log_determinant.hpp
@@ -10,6 +10,10 @@ namespace math {
 /**
  * Returns the log absolute determinant of the specified square matrix.
  *
+ * @tparam T type of elements in the matrix
+ * @tparam R number of rows, can be Eigen::Dynamic
+ * @tparam C number of columns, can be Eigen::Dynamic
+ *
  * @param m Specified matrix.
  * @return log absolute determinant of the matrix.
  * @throw std::domain_error if matrix is not square.
@@ -25,4 +29,5 @@ inline T log_determinant(const Eigen::Matrix<T, R, C>& m) {
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/log_determinant_ldlt.hpp
+++ b/stan/math/prim/mat/fun/log_determinant_ldlt.hpp
@@ -6,7 +6,16 @@
 namespace stan {
 namespace math {
 
-// Returns log(abs(det(A))) given a LDLT_factor of A
+/**
+ * Returns log(abs(det(A))) given a LDLT_factor of A
+ *
+ * @tparam T type of elements in the LDLT_factor
+ * @tparam R number of rows, can be Eigen::Dynamic
+ * @tparam C number of columns, can be Eigen::Dynamic
+ *
+ * @param A LDLT_factor
+ * @return the log(abs(det(A))
+ */
 template <int R, int C, typename T>
 inline T log_determinant_ldlt(LDLT_factor<T, R, C> &A) {
   if (A.rows() == 0) {
@@ -18,4 +27,5 @@ inline T log_determinant_ldlt(LDLT_factor<T, R, C> &A) {
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/log_determinant_spd.hpp
+++ b/stan/math/prim/mat/fun/log_determinant_spd.hpp
@@ -11,6 +11,10 @@ namespace math {
 /**
  * Returns the log absolute determinant of the specified square matrix.
  *
+ * @tparam T type of elements in the matrix
+ * @tparam R number of rows, can be Eigen::Dynamic
+ * @tparam C number of columns, can be Eigen::Dynamic
+ *
  * @param m specified matrix
  * @return log absolute determinant of the matrix
  * @throw std::domain_error if matrix is not square and symmetric
@@ -27,4 +31,5 @@ inline T log_determinant_spd(const Eigen::Matrix<T, R, C>& m) {
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/log_inv_logit.hpp
+++ b/stan/math/prim/mat/fun/log_inv_logit.hpp
@@ -31,7 +31,7 @@ struct log_inv_logit_fun {
  * The return type promotes the underlying scalar argument type to
  * double if it is an integer, and otherwise is the argument type.
  *
- * @tparam T container type
+ * @tparam T type of container
  * @param x container
  * @return elementwise log_inv_logit of members of container
  */

--- a/stan/math/prim/mat/fun/log_softmax.hpp
+++ b/stan/math/prim/mat/fun/log_softmax.hpp
@@ -32,7 +32,7 @@ namespace math {
  * \right.
  * \f$
  *
- * @tparam T Scalar type of values in vector.
+ * @tparam T type of elements in the vector
  * @param[in] v Vector to transform.
  * @return Unit simplex result of the softmax transform of the vector.
  */
@@ -45,4 +45,5 @@ inline Eigen::Matrix<T, Eigen::Dynamic, 1> log_softmax(
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/log_sum_exp.hpp
+++ b/stan/math/prim/mat/fun/log_sum_exp.hpp
@@ -20,6 +20,9 @@ namespace math {
  * \f$\log \sum_{n=1}^N \exp(x_n) = \max(x) + \log \sum_{n=1}^N \exp(x_n -
  * \max(x))\f$.
  *
+ * @tparam R number of rows, can be Eigen::Dynamic
+ * @tparam C number of columns, can be Eigen::Dynamic
+ *
  * @param[in] x Matrix of specified values
  * @return The log of the sum of the exponentiated vector values.
  */

--- a/stan/math/prim/mat/fun/logit.hpp
+++ b/stan/math/prim/mat/fun/logit.hpp
@@ -14,7 +14,7 @@ struct logit_fun {
   /**
    * Return the log odds of the specified argument.
    *
-   * @tparam T argument type
+   * @tparam T type of argument
    * @param x argument
    * @return log odds of the argument
    */
@@ -30,7 +30,7 @@ struct logit_fun {
  * underlying scalar argument type to double if it is an integer,
  * and otherwise is the argument type.
  *
- * @tparam T container type
+ * @tparam T type of container
  * @param x container
  * @return elementwise logit of container elements
  */

--- a/stan/math/prim/mat/fun/make_nu.hpp
+++ b/stan/math/prim/mat/fun/make_nu.hpp
@@ -11,6 +11,7 @@ namespace math {
  * Return the degrees of freedom for the t distribution that
  * corresponds to the shape parameter in the LKJ distribution.
  *
+ * @tparam T scalar type
  * @param eta LKJ distribution parameter in (0, inf)
  * @param K number of variables in correlation matrix
  */
@@ -42,4 +43,5 @@ Eigen::Array<T, Eigen::Dynamic, 1> make_nu(const T& eta, size_t K) {
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/matrix_exp.hpp
+++ b/stan/math/prim/mat/fun/matrix_exp.hpp
@@ -12,8 +12,7 @@ namespace math {
  * Return the matrix exponential of the input
  * matrix.
  *
- * @tparam T type of scalar of the elements of
- * input matrix.
+ * @tparam T type of elements in the matrix
  * @param[in] A Matrix to exponentiate.
  * @return Matrix exponential, dynamically-sized.
  * @throw <code>std::invalid_argument</code> if the input matrix
@@ -38,8 +37,7 @@ inline Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> matrix_exp(
  * Return the matrix exponential of the input
  * statically-sized square matrix.
  *
- * @tparam T type of scalar of the elements of
- * input matrix.
+ * @tparam T type of elements in the matrix
  * @tparam N size of the input square matrix.
  * @param[in] A Matrix to exponentiate.
  * @return Matrix exponential, statically-sized.
@@ -61,8 +59,7 @@ inline Eigen::Matrix<T, N, N> matrix_exp(const Eigen::Matrix<T, N, N>& A) {
  * Return the exponential of the input scalar when it's in
  * the form of Eigen matrix.
  *
- * @tparam T type of scalar of the elements of
- * input matrix.
+ * @tparam T type of elements in the matrix
  * @return 1x1 Matrix exponential, statically-sized.
  */
 template <typename T>
@@ -72,6 +69,8 @@ inline Eigen::Matrix<T, 1, 1> matrix_exp(const Eigen::Matrix<T, 1, 1>& A) {
   res << exp(A(0));
   return res;
 }
+
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/matrix_exp_2x2.hpp
+++ b/stan/math/prim/mat/fun/matrix_exp_2x2.hpp
@@ -13,7 +13,7 @@ namespace math {
  * algorithm: http://mathworld.wolfram.com/MatrixExponential.html
  * Note: algorithm only works if delta > 0;
  *
- * @tparam T type of scalar of the elements of input matrix.
+ * @tparam Mtype type of elements in the matrix
  * @param[in] A 2x2 matrix to exponentiate.
  * @return Matrix exponential of A.
  */
@@ -44,6 +44,8 @@ Mtype matrix_exp_2x2(const Mtype& A) {
 
   return B / delta;
 }
+
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/matrix_exp_multiply.hpp
+++ b/stan/math/prim/mat/fun/matrix_exp_multiply.hpp
@@ -10,7 +10,8 @@ namespace math {
 /**
  * Return product of exp(A) and B, where A is a NxN double matrix,
  * B is a NxCb double matrix, and t is a double
- * @tparam Cb Columns matrix B
+ *
+ * @tparam Cb number of columns in matrix B, can be Eigen::Dynamic
  * @param[in] A Matrix
  * @param[in] B Matrix
  * @return exponential of A multiplies B
@@ -30,4 +31,5 @@ inline Eigen::Matrix<double, -1, Cb> matrix_exp_multiply(
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/matrix_exp_pade.hpp
+++ b/stan/math/prim/mat/fun/matrix_exp_pade.hpp
@@ -12,8 +12,7 @@ namespace math {
  * approximation, coupled with scaling and
  * squaring.
  *
- * @tparam MatrixType scalar type of the elements
- * in the input matrix.
+ * @tparam MatrixType type of elements in the matrix
  * @param[in] arg matrix to exponentiate.
  * @return Matrix exponential of input matrix.
  */
@@ -39,6 +38,8 @@ MatrixType matrix_exp_pade(const MatrixType& arg) {
   // repeated squaring
   return pade_approximation;
 }
+
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/matrix_power.hpp
+++ b/stan/math/prim/mat/fun/matrix_power.hpp
@@ -8,12 +8,14 @@
 
 namespace stan {
 namespace math {
+
 /**
  * Returns the nth power of the specific matrix. M^n = M * M * ... * M.
  *
  * @tparam T type of elements in the matrix
- * @tparam R number of rows in matrix
- * @tparam C number of columns in matrix
+ * @tparam R number of rows, can be Eigen::Dynamic
+ * @tparam C number of columns, can be Eigen::Dynamic
+ *
  * @param[in] M a square matrix
  * @param[in] n exponent
  * @return nth power of M
@@ -53,4 +55,5 @@ inline Eigen::Matrix<T, R, C> operator^(const Eigen::Matrix<T, R, C> &M,
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/max.hpp
+++ b/stan/math/prim/mat/fun/max.hpp
@@ -13,6 +13,7 @@ namespace math {
 /**
  * Returns the maximum coefficient in the specified
  * column vector.
+ *
  * @param x specified vector
  * @return maximum coefficient value in the vector
  * @throws <code>std::invalid_argument</code> if the vector is size zero
@@ -26,7 +27,8 @@ inline int max(const std::vector<int>& x) {
 /**
  * Returns the maximum coefficient in the specified
  * column vector.
- * @tparam type of values being compared and returned
+ *
+ * @tparam type of elements in the vector
  * @param x specified vector
  * @return maximum coefficient value in the vector, or -infinity if the vector
  * is size zero
@@ -43,9 +45,11 @@ inline T max(const std::vector<T>& x) {
 /**
  * Returns the maximum coefficient in the specified
  * matrix, vector, or row vector.
- * @tparam T type of values being compared and returned
- * @tparam R number of rows or Eigen::Dynamic
- * @tparam C number of columns or Eigen::Dynamic
+ *
+ * @tparam T type of elements in the matrix
+ * @tparam R number of rows, can be Eigen::Dynamic
+ * @tparam C number of columns, can be Eigen::Dynamic
+ *
  * @param m specified matrix, vector, or row vector
  * @return maximum coefficient value in the vector, or -infinity if the vector
  * is size zero
@@ -60,4 +64,5 @@ inline T max(const Eigen::Matrix<T, R, C>& m) {
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/mdivide_left.hpp
+++ b/stan/math/prim/mat/fun/mdivide_left.hpp
@@ -11,6 +11,16 @@ namespace math {
 
 /**
  * Returns the solution of the system Ax=b.
+ *
+ * @tparam T1 type of elements in first matrix
+ * @tparam T2 type of elements in right-hand side matrix or vector
+ * @tparam R1 number of rows in the first matrix, can be Eigen::Dynamic
+ * @tparam C1 number of columns in the first matrix, can be Eigen::Dynamic
+ * @tparam R2 number of rows in the right-hand side matrix, can be
+ *         Eigen::Dynamic
+ * @tparam C2 number of columns in the right-hand side matrix, can be
+ *         Eigen::Dynamic
+ *
  * @param A Matrix.
  * @param b Right hand side matrix or vector.
  * @return x = A^-1 b, solution of the linear system.
@@ -32,4 +42,5 @@ inline Eigen::Matrix<return_type_t<T1, T2>, R1, C2> mdivide_left(
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/mdivide_left_ldlt.hpp
+++ b/stan/math/prim/mat/fun/mdivide_left_ldlt.hpp
@@ -12,12 +12,21 @@ namespace math {
 
 /**
  * Returns the solution of the system Ax=b given an LDLT_factor of A
+ *
+ * @tparam T1 type of elements in the LDLT_factor
+ * @tparam T2 type of elements in right-hand side matrix or vector
+ * @tparam R1 number of rows in the LDLT_factor, can be Eigen::Dynamic
+ * @tparam C1 number of columns in the LDLT_factor, can be Eigen::Dynamic
+ * @tparam R2 number of rows in the right-hand side matrix, can be
+ *         Eigen::Dynamic
+ * @tparam C2 number of columns in the right-hand side matrix, can be
+ *         Eigen::Dynamic
+ *
  * @param A LDLT_factor
  * @param b Right hand side matrix or vector.
  * @return x = A^-1 b, solution of the linear system.
  * @throws std::domain_error if rows of b don't match the size of A.
  */
-
 template <int R1, int C1, int R2, int C2, typename T1, typename T2>
 inline Eigen::Matrix<return_type_t<T1, T2>, R1, C2> mdivide_left_ldlt(
     const LDLT_factor<T1, R1, C1> &A, const Eigen::Matrix<T2, R2, C2> &b) {
@@ -33,4 +42,5 @@ inline Eigen::Matrix<return_type_t<T1, T2>, R1, C2> mdivide_left_ldlt(
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/mdivide_left_spd.hpp
+++ b/stan/math/prim/mat/fun/mdivide_left_spd.hpp
@@ -12,6 +12,16 @@ namespace math {
 /**
  * Returns the solution of the system Ax=b where A is symmetric positive
  * definite.
+ *
+ * @tparam T1 type of elements in the first matrix
+ * @tparam T2 type of elements in the right-hand side matrix or vector
+ * @tparam R1 number of rows in the first matrix, can be Eigen::Dynamic
+ * @tparam C1 number of columns in the first matrix, can be Eigen::Dynamic
+ * @tparam R2 number of rows in the right-hand side matrix, can be
+ *         Eigen::Dynamic
+ * @tparam C2 number of columns in the right-hand side matrix, can be
+ *         Eigen::Dynamic
+ *
  * @param A Matrix.
  * @param b Right hand side matrix or vector.
  * @return x = A^-1 b, solution of the linear system.
@@ -33,4 +43,5 @@ inline Eigen::Matrix<return_type_t<T1, T2>, R1, C2> mdivide_left_spd(
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/mdivide_left_tri.hpp
+++ b/stan/math/prim/mat/fun/mdivide_left_tri.hpp
@@ -8,19 +8,24 @@
 #ifdef STAN_OPENCL
 #include <stan/math/opencl/opencl.hpp>
 #endif
+
 namespace stan {
 namespace math {
 
 /**
  * Returns the solution of the system Ax=b when A is triangular.
+ *
  * @tparam TriView Specifies whether A is upper (Eigen::Upper)
  * or lower triangular (Eigen::Lower).
- * @tparam T1 type of elements in A
- * @tparam T2 type of elements in b
- * @tparam R1 number of rows in A
- * @tparam C1 number of columns in A
- * @tparam R2 number of rows in b
- * @tparam C2 number of columns in b
+ * @tparam T1 type of elements in the triangular matrix
+ * @tparam T2 type of elements in the right-hand side matrix or vector
+ * @tparam R1 number of rows in the triangular matrix, can be Eigen::Dynamic
+ * @tparam C1 number of columns in the triangular matrix, can be Eigen::Dynamic
+ * @tparam R2 number of rows in the right-hand side matrix, can be
+ *         Eigen::Dynamic
+ * @tparam C2 number of columns in the right-hand side matrix, can be
+ *         Eigen::Dynamic
+ *
  * @param A Triangular matrix.
  * @param b Right hand side matrix or vector.
  * @return x = A^-1 b, solution of the linear system.
@@ -42,9 +47,11 @@ inline Eigen::Matrix<return_type_t<T1, T2>, R1, C2> mdivide_left_tri(
 
 /**
  * Returns the solution of the system Ax=b when A is triangular and b=I.
- * @tparam T type of elements in A
- * @tparam R1 number of rows in A
- * @tparam C1 number of columns in A
+ *
+ * @tparam T type of elements in the matrix
+ * @tparam R1 number of rows, can be Eigen::Dynamic
+ * @tparam C1 number of columns, can be Eigen::Dynamic
+ *
  * @param A Triangular matrix.
  * @return x = A^-1 .
  * @throws std::domain_error if A is not square
@@ -63,12 +70,16 @@ inline Eigen::Matrix<T, R1, C1> mdivide_left_tri(
 /**
  * Returns the solution of the system Ax=b when A is triangular
  * and A and b are matrices of doubles.
+ *
  * @tparam TriView Specifies whether A is upper (Eigen::Upper)
  * or lower triangular (Eigen::Lower).
- * @tparam R1 number of rows in A
- * @tparam C1 number of columns in A
- * @tparam R2 number of rows in b
- * @tparam C2 number of columns in b
+ * @tparam T1 type of elements in the triangular matrix
+ * @tparam T2 type of elements in the right-hand side matrix or vector
+ * @tparam R1 number of rows in the triangular matrix, can be Eigen::Dynamic
+ * @tparam C1 number of columns in the triangular matrix, can be Eigen::Dynamic
+ * @tparam R2 number of rows in the right-hand side matrix, can be
+ *         Eigen::Dynamic
+ *
  * @param A Triangular matrix.
  * @param b Right hand side matrix or vector.
  * @return x = A^-1 b, solution of the linear system.
@@ -100,10 +111,12 @@ inline Eigen::Matrix<double, R1, C2> mdivide_left_tri(
 /**
  * Returns the solution of the system Ax=b when A is triangular, b=I and
  * both are matrices of doubles.
+ *
  * @tparam TriView Specifies whether A is upper (Eigen::Upper)
  * or lower triangular (Eigen::Lower).
- * @tparam R1 number of rows in A
- * @tparam C1 number of columns in A
+ * @tparam R1 number of rows, can be Eigen::Dynamic
+ * @tparam C1 number of columns, can be Eigen::Dynamic
+ *
  * @param A Triangular matrix.
  * @return x = A^-1 .
  * @throws std::domain_error if A is not square
@@ -132,4 +145,5 @@ inline Eigen::Matrix<double, R1, C1> mdivide_left_tri(
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/mdivide_left_tri_low.hpp
+++ b/stan/math/prim/mat/fun/mdivide_left_tri_low.hpp
@@ -16,12 +16,13 @@ namespace math {
  * <code>b</code> is more arithmetically stable than calling
  * <code>inv(A) * b</code>.
  *
- * @tparam T1 type of divisor matrix
- * @tparam T2 type of dividend matrix
- * @tparam R1 rows of divisor matrix
- * @tparam C1 columns of divisor matrix
- * @tparam R2 rows of dividen matrix
- * @tparam C2 rows of divisor matrix
+ * @tparam T1 type of elements in the divisor matrix
+ * @tparam T2 type of elements in the dividend matrix
+ * @tparam R1 number rows in the divisor matrix, can be Eigen::Dynamic
+ * @tparam C1 number columns in the divisor matrix, can be Eigen::Dynamic
+ * @tparam R2 number rows in the dividend matrix, can be Eigen::Dynamic
+ * @tparam C2 number columns in the dividend matrix, can be Eigen::Dynamic
+ *
  * @param A divisor, an invertible square matrix
  * @param b dividend, a matrix or vector with the same number of
  *   rows as the divisor has columns
@@ -47,4 +48,5 @@ inline Eigen::Matrix<T, R1, C1> mdivide_left_tri_low(
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/mdivide_right.hpp
+++ b/stan/math/prim/mat/fun/mdivide_right.hpp
@@ -10,7 +10,17 @@ namespace stan {
 namespace math {
 
 /**
- * Returns the solution of the system Ax=b.
+ * Returns the solution of the system xA=b.
+ *
+ * @tparam T1 type of elements in the right-hand side matrix or vector
+ * @tparam T2 type of elements in the second matrix
+ * @tparam R1 number of rows in the right-hand side matrix, can be
+ *         Eigen::Dynamic
+ * @tparam C1 number of columns in the right-hand side matrix, can be
+ *         Eigen::Dynamic
+ * @tparam R2 number of rows in the second matrix, can be Eigen::Dynamic
+ * @tparam C2 number of columns in the second matrix, can be Eigen::Dynamic
+ *
  * @param A Matrix.
  * @param b Right hand side matrix or vector.
  * @return x = b A^-1, solution of the linear system.
@@ -35,4 +45,5 @@ inline Eigen::Matrix<return_type_t<T1, T2>, R1, C2> mdivide_right(
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/mdivide_right_ldlt.hpp
+++ b/stan/math/prim/mat/fun/mdivide_right_ldlt.hpp
@@ -12,6 +12,16 @@ namespace math {
 
 /**
  * Returns the solution of the system xA=b given an LDLT_factor of A
+ *
+ * @tparam T1 type of elements in right-hand side matrix or vector
+ * @tparam T2 type of elements in the LDLT_factor
+ * @tparam R1 number of rows in the right-hand side matrix, can be
+ *         Eigen::Dynamic
+ * @tparam C1 number of columns in the right-hand side matrix, can be
+ *         Eigen::Dynamic
+ * @tparam R2 number of rows in the LDLT_factor, can be Eigen::Dynamic
+ * @tparam C2 number of columns in the LDLT_factor, can be Eigen::Dynamic
+ *
  * @param A LDLT_factor
  * @param b Right hand side matrix or vector.
  * @return x = b A^-1, solution of the linear system.
@@ -45,4 +55,5 @@ inline Eigen::Matrix<double, R1, C2> mdivide_right_ldlt(
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/mdivide_right_spd.hpp
+++ b/stan/math/prim/mat/fun/mdivide_right_spd.hpp
@@ -11,10 +11,20 @@ namespace stan {
 namespace math {
 
 /**
- * Returns the solution of the system Ax=b where A is symmetric
+ * Returns the solution of the system xA=b where A is symmetric
  * positive definite.
- * @param A Matrix.
- * @param b Right hand side matrix or vector.
+ *
+ * @tparam T1 type of elements in the right-hand side matrix or vector
+ * @tparam T2 type of elements in the second matrix
+ * @tparam R1 number of rows in the right-hand side matrix, can be
+ *         Eigen::Dynamic
+ * @tparam C1 number of columns in the right-hand side matrix, can be
+ *         Eigen::Dynamic
+ * @tparam R2 number of rows in the second matrix, can be Eigen::Dynamic
+ * @tparam C2 number of columns in the second matrix, can be Eigen::Dynamic
+ *
+ * @param b right-hand side matrix or vector
+ * @param A matrix
  * @return x = b A^-1, solution of the linear system.
  * @throws std::domain_error if A is not square or the rows of b don't
  * match the size of A.
@@ -31,4 +41,5 @@ inline Eigen::Matrix<return_type_t<T1, T2>, R1, C2> mdivide_right_spd(
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/mdivide_right_tri.hpp
+++ b/stan/math/prim/mat/fun/mdivide_right_tri.hpp
@@ -13,7 +13,19 @@ namespace stan {
 namespace math {
 
 /**
- * Returns the solution of the system Ax=b when A is triangular
+ * Returns the solution of the system xA=b when A is triangular
+ *
+ * @tparam TriView Specifies whether A is upper (Eigen::Upper)
+ * or lower triangular (Eigen::Lower).
+ * @tparam T1 type of elements in the right-hand side matrix or vector
+ * @tparam T2 type of elements in the triangular matrix
+ * @tparam R1 number of rows in the right-hand side matrix, can be
+ *         Eigen::Dynamic
+ * @tparam C1 number of columns in the right-hand side matrix, can be
+ *         Eigen::Dynamic
+ * @tparam R2 number of rows in the triangular matrix, can be Eigen::Dynamic
+ * @tparam C2 number of columns in the triangular matrix, can be Eigen::Dynamic
+ *
  * @param A Triangular matrix.  Specify upper or lower with TriView
  * being Eigen::Upper or Eigen::Lower.
  * @param b Right hand side matrix or vector.
@@ -44,8 +56,18 @@ inline Eigen::Matrix<return_type_t<T1, T2>, R1, C2> mdivide_right_tri(
 }
 
 /**
- * Returns the solution of the system Ax=b when A is triangular
+ * Returns the solution of the system xA=b when A is triangular
  * and A and b are matrices of doubles.
+ *
+ * @tparam TriView Specifies whether A is upper (Eigen::Upper)
+ * or lower triangular (Eigen::Lower).
+ * @tparam R1 number of rows in the right-hand side matrix, can be
+ *         Eigen::Dynamic
+ * @tparam C1 number of columns in the right-hand side matrix, can be
+ *         Eigen::Dynamic
+ * @tparam R2 number of rows in the triangular matrix, can be Eigen::Dynamic
+ * @tparam C2 number of columns in the triangular matrix, can be Eigen::Dynamic
+ *
  * @param A Triangular matrix.  Specify upper or lower with TriView
  * being Eigen::Upper or Eigen::Lower.
  * @param b Right hand side matrix or vector.
@@ -80,4 +102,5 @@ inline Eigen::Matrix<double, R1, C2> mdivide_right_tri(
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/mdivide_right_tri_low.hpp
+++ b/stan/math/prim/mat/fun/mdivide_right_tri_low.hpp
@@ -9,10 +9,20 @@ namespace stan {
 namespace math {
 
 /**
- * Returns the solution of the system tri(A)x=b when tri(A) is a
+ * Returns the solution of the system x tri(A) = b when tri(A) is a
  * lower triangular view of the matrix A.
- * @param A Matrix.
- * @param b Right hand side matrix or vector.
+ *
+ * @tparam T1 type of elements in the right-hand side matrix or vector
+ * @tparam T2 type of elements in the second matrix
+ * @tparam R1 number of rows in the right-hand side matrix, can be
+ *         Eigen::Dynamic
+ * @tparam C1 number of columns in the right-hand side matrix, can be
+ *         Eigen::Dynamic
+ * @tparam R2 number of rows in the second matrix, can be Eigen::Dynamic
+ * @tparam C2 number of columns in the second matrix, can be Eigen::Dynamic
+ *
+ * @param b right-hand side matrix or vector
+ * @param A matrix
  * @return x = b * tri(A)^-1, solution of the linear system.
  * @throws std::domain_error if A is not square or the rows of b don't
  * match the size of A.
@@ -27,4 +37,5 @@ inline Eigen::Matrix<return_type_t<T1, T2>, R1, C2> mdivide_right_tri_low(
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/mean.hpp
+++ b/stan/math/prim/mat/fun/mean.hpp
@@ -11,6 +11,8 @@ namespace math {
 /**
  * Returns the sample mean (i.e., average) of the coefficients
  * in the specified standard vector.
+ *
+ * @tparam T type of elements in the vector
  * @param v Specified vector.
  * @return Sample mean of vector coefficients.
  * @throws std::domain_error if the size of the vector is less
@@ -26,6 +28,11 @@ inline return_type_t<T> mean(const std::vector<T>& v) {
 /**
  * Returns the sample mean (i.e., average) of the coefficients
  * in the specified vector, row vector, or matrix.
+ *
+ * @tparam T type of elements in the matrix
+ * @tparam R number of rows, can be Eigen::Dynamic
+ * @tparam C number of columns, can be Eigen::Dynamic
+ *
  * @param m Specified vector, row vector, or matrix.
  * @return Sample mean of vector coefficients.
  */
@@ -37,4 +44,5 @@ inline return_type_t<T> mean(const Eigen::Matrix<T, R, C>& m) {
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/min.hpp
+++ b/stan/math/prim/mat/fun/min.hpp
@@ -13,6 +13,7 @@ namespace math {
 /**
  * Returns the minimum coefficient in the specified
  * column vector.
+ *
  * @param x specified vector
  * @return minimum coefficient value in the vector
  * @throws <code>std::invalid_argument</code> if the vector is size zero
@@ -26,7 +27,8 @@ inline int min(const std::vector<int>& x) {
 /**
  * Returns the minimum coefficient in the specified
  * column vector.
- * @tparam type of values being compared and returned
+ *
+ * @tparam T type of elements in the vector
  * @param x specified vector
  * @return minimum coefficient value in the vector, or infinity if the vector is
  * size zero
@@ -43,9 +45,10 @@ inline T min(const std::vector<T>& x) {
 /**
  * Returns the minimum coefficient in the specified
  * matrix, vector, or row vector.
- * @tparam T type of values being compared and returned
- * @tparam R number of rows or Eigen::Dynamic
- * @tparam C number of columns or Eigen::Dynamic
+ *
+ * @tparam T type of elements in the matrix, vector or row vector
+ * @tparam R number of rows, can be Eigen::Dynamic
+ * @tparam C number of columns, can be Eigen::Dynamic
  * @param m specified matrix, vector, or row vector
  * @return minimum coefficient value in the vector, or infinity if the vector is
  * size zero
@@ -60,4 +63,5 @@ inline T min(const Eigen::Matrix<T, R, C>& m) {
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/minus.hpp
+++ b/stan/math/prim/mat/fun/minus.hpp
@@ -18,4 +18,5 @@ inline T minus(const T& x) {
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/multiply.hpp
+++ b/stan/math/prim/mat/fun/multiply.hpp
@@ -15,10 +15,12 @@ namespace math {
 
 /**
  * Return specified matrix multiplied by specified scalar.
- * @tparam R number of rows or Eigen::Dynamic
- * @tparam C number of columns or Eigen::Dynamic
- * @tparam T1 type of elements in matrix
+ *
+ * @tparam R number of rows, can be Eigen::Dynamic
+ * @tparam C number of columns, can be Eigen::Dynamic
+ * @tparam T1 type of elements in the matrix
  * @tparam T2 type of scalar
+ *
  * @param m matrix
  * @param c scalar
  * @return product of matrix and scalar
@@ -32,10 +34,12 @@ inline Eigen::Matrix<return_type_t<T1, T2>, R, C> multiply(
 
 /**
  * Return specified scalar multiplied by specified matrix.
- * @tparam R number of rows or Eigen::Dynamic
- * @tparam C number of columns or Eigen::Dynamic
+ *
+ * @tparam R number of rows, can be Eigen::Dynamic
+ * @tparam C number of columns, can be Eigen::Dynamic
  * @tparam T1 type of scalar
- * @tparam T2 type of elements in matrix
+ * @tparam T2 type of elements in the matrix
+ *
  * @param c scalar
  * @param m matrix
  * @return product of scalar and matrix
@@ -51,12 +55,14 @@ inline Eigen::Matrix<return_type_t<T1, T2>, R, C> multiply(
  * Return the product of the specified matrices.  The number of
  * columns in the first matrix must be the same as the number of rows
  * in the second matrix.
+ *
  * @tparam R1 number of rows in the first matrix, can be Eigen::Dynamic
  * @tparam C1 number of columns in the first matrix, can be Eigen::Dynamic
  * @tparam R2 number of rows in the second matrix, can be Eigen::Dynamic
  * @tparam C2 number of columns in the second matrix, can be Eigen::Dynamic
  * @tparam T1 type of elements in first matrix
  * @tparam T2 type of elements in second matrix
+ *
  * @param m1 first matrix
  * @param m2 second matrix
  * @return the product of the first and second matrices
@@ -87,10 +93,12 @@ inline Eigen::Matrix<return_type_t<T1, T2>, R1, C2> multiply(
  * Return the scalar product of the specified row vector and
  * specified column vector.  The return is the same as the dot
  * product.  The two vectors must be the same size.
+ *
  * @tparam C1 number of columns in row vector, can be Eigen::Dynamic
  * @tparam R2 number of rows in column vector, can be Eigen::Dynamic
  * @tparam T1 type of elements in row vector
  * @tparam T2 type of elements in column vector
+ *
  * @param rv row vector
  * @param v column vector
  * @return scalar result of multiplying row vector by column vector
@@ -106,6 +114,7 @@ inline return_type_t<T1, T2> multiply(const Eigen::Matrix<T1, 1, C1>& rv,
 
 /**
  * Return product of scalars.
+ *
  * @tparam T1 type of first scalar
  * @tparam T2 type of second scalar
  * @param m scalar
@@ -119,4 +128,5 @@ inline return_type_t<T1, T2> multiply(T1 m, T2 c) {
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/multiply_lower_tri_self_transpose.hpp
+++ b/stan/math/prim/mat/fun/multiply_lower_tri_self_transpose.hpp
@@ -10,6 +10,7 @@ namespace math {
 /**
  * Returns the result of multiplying the lower triangular
  * portion of the input matrix by its own transpose.
+ *
  * @param L Matrix to multiply.
  * @return The lower triangular values in L times their own
  * transpose.
@@ -40,4 +41,5 @@ inline matrix_d multiply_lower_tri_self_transpose(const matrix_d& L) {
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/num_elements.hpp
+++ b/stan/math/prim/mat/fun/num_elements.hpp
@@ -10,6 +10,7 @@ namespace math {
 /**
  * Returns 1, the number of elements in a primitive type.
  *
+ * @tparam T scalar type
  * @param x Argument of primitive type.
  * @return 1
  */
@@ -20,6 +21,10 @@ inline int num_elements(const T& x) {
 
 /**
  * Returns the size of the specified matrix.
+ *
+ * @tparam T type of elements in the matrix
+ * @tparam R number of rows, can be Eigen::Dynamic
+ * @tparam C number of columns, can be Eigen::Dynamic
  *
  * @param m argument matrix
  * @return size of matrix
@@ -34,6 +39,7 @@ inline int num_elements(const Eigen::Matrix<T, R, C>& m) {
  * This assumes it is not ragged and that each of its contained
  * elements has the same number of elements.
  *
+ * @tparam T type of elements in the vector
  * @param v argument vector
  * @return number of contained arguments
  */
@@ -47,4 +53,5 @@ inline int num_elements(const std::vector<T>& v) {
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/ordered_constrain.hpp
+++ b/stan/math/prim/mat/fun/ordered_constrain.hpp
@@ -13,6 +13,7 @@ namespace math {
  * free vector.  The returned constrained vector will have the
  * same dimensionality as the specified free vector.
  *
+ * @tparam T type of elements in the vector
  * @param x Free vector of scalars.
  * @return Positive, increasing ordered vector.
  * @tparam T Type of scalar.
@@ -45,10 +46,10 @@ Eigen::Matrix<T, Eigen::Dynamic, 1> ordered_constrain(
  * of the transform.  The returned constrained vector
  * will have the same dimensionality as the specified free vector.
  *
+ * @tparam T type of elements in the vector
  * @param x Free vector of scalars.
  * @param lp Log probability reference.
  * @return Positive, increasing ordered vector.
- * @tparam T Type of scalar.
  */
 template <typename T>
 inline Eigen::Matrix<T, Eigen::Dynamic, 1> ordered_constrain(
@@ -65,7 +66,6 @@ inline Eigen::Matrix<T, Eigen::Dynamic, 1> ordered_constrain(
 }
 
 }  // namespace math
-
 }  // namespace stan
 
 #endif

--- a/stan/math/prim/mat/fun/ordered_free.hpp
+++ b/stan/math/prim/mat/fun/ordered_free.hpp
@@ -8,6 +8,7 @@
 
 namespace stan {
 namespace math {
+
 /**
  * Return the vector of unconstrained scalars that transform to
  * the specified positive ordered vector.
@@ -15,9 +16,9 @@ namespace math {
  * <p>This function inverts the constraining operation defined in
  * <code>ordered_constrain(Matrix)</code>,
  *
+ * @tparam T type of elements in the vector
  * @param y Vector of positive, ordered scalars.
  * @return Free vector that transforms into the input vector.
- * @tparam T Type of scalar.
  * @throw std::domain_error if y is not a vector of positive,
  *   ordered scalars.
  */
@@ -41,6 +42,8 @@ Eigen::Matrix<T, Eigen::Dynamic, 1> ordered_free(
   }
   return x;
 }
+
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/positive_ordered_constrain.hpp
+++ b/stan/math/prim/mat/fun/positive_ordered_constrain.hpp
@@ -13,9 +13,9 @@ namespace math {
  * free vector.  The returned constrained vector will have the
  * same dimensionality as the specified free vector.
  *
+ * @tparam T type of elements in the vector
  * @param x Free vector of scalars.
  * @return Positive, increasing ordered vector.
- * @tparam T Type of scalar.
  */
 template <typename T>
 Eigen::Matrix<T, Eigen::Dynamic, 1> positive_ordered_constrain(
@@ -44,10 +44,10 @@ Eigen::Matrix<T, Eigen::Dynamic, 1> positive_ordered_constrain(
  * of the transform.  The returned constrained vector
  * will have the same dimensionality as the specified free vector.
  *
+ * @tparam T type of elements in the vector
  * @param x Free vector of scalars.
  * @param lp Log probability reference.
  * @return Positive, increasing ordered vector.
- * @tparam T Type of scalar.
  */
 template <typename T>
 inline Eigen::Matrix<T, Eigen::Dynamic, 1> positive_ordered_constrain(
@@ -63,7 +63,6 @@ inline Eigen::Matrix<T, Eigen::Dynamic, 1> positive_ordered_constrain(
 }
 
 }  // namespace math
-
 }  // namespace stan
 
 #endif

--- a/stan/math/prim/mat/fun/positive_ordered_free.hpp
+++ b/stan/math/prim/mat/fun/positive_ordered_free.hpp
@@ -8,6 +8,7 @@
 
 namespace stan {
 namespace math {
+
 /**
  * Return the vector of unconstrained scalars that transform to
  * the specified positive ordered vector.
@@ -15,9 +16,9 @@ namespace math {
  * <p>This function inverts the constraining operation defined in
  * <code>positive_ordered_constrain(Matrix)</code>,
  *
+ * @tparam T type of elements in the vector
  * @param y Vector of positive, ordered scalars.
  * @return Free vector that transforms into the input vector.
- * @tparam T Type of scalar.
  * @throw std::domain_error if y is not a vector of positive,
  *   ordered scalars.
  */
@@ -42,6 +43,8 @@ Eigen::Matrix<T, Eigen::Dynamic, 1> positive_ordered_free(
   }
   return x;
 }
+
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/prod.hpp
+++ b/stan/math/prim/mat/fun/prod.hpp
@@ -10,6 +10,8 @@ namespace math {
 /**
  * Returns the product of the coefficients of the specified
  * standard vector.
+ *
+ * @tparam T type of elements in the vector
  * @param v Specified vector.
  * @return Product of coefficients of vector.
  */
@@ -25,6 +27,8 @@ inline T prod(const std::vector<T>& v) {
 /**
  * Returns the product of the coefficients of the specified
  * column vector.
+ *
+ * @tparam T type of elements in the vector
  * @param v Specified vector.
  * @return Product of coefficients of vector.
  */
@@ -38,4 +42,5 @@ inline T prod(const Eigen::Matrix<T, R, C>& v) {
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/promote_common.hpp
+++ b/stan/math/prim/mat/fun/promote_common.hpp
@@ -15,6 +15,7 @@ namespace math {
  * @tparam T1 first type
  * @tparam T2 second type
  * @tparam F type of container elements, must be either T1 or T2
+ *
  * @param u elements to promote
  * @return the result of promoting elements
  */

--- a/stan/math/prim/mat/fun/promote_elements.hpp
+++ b/stan/math/prim/mat/fun/promote_elements.hpp
@@ -15,6 +15,8 @@ namespace math {
  *
  * @tparam T type of promoted elements
  * @tparam S type of input elements, must be assignable to T
+ * @tparam R number of rows, can be Eigen::Dynamic
+ * @tparam C number of columns, can be Eigen::Dynamic
  */
 template <typename T, typename S, int R, int C>
 struct promote_elements<Eigen::Matrix<T, R, C>, Eigen::Matrix<S, R, C> > {
@@ -39,7 +41,9 @@ struct promote_elements<Eigen::Matrix<T, R, C>, Eigen::Matrix<S, R, C> > {
  *
  * <p>This specialization promotes matrix elements of the same type.
  *
- * @tparam T type of elements
+ * @tparam T type of elements in the matrices
+ * @tparam R number of rows, can be Eigen::Dynamic
+ * @tparam C number of columns, can be Eigen::Dynamic
  */
 template <typename T, int R, int C>
 struct promote_elements<Eigen::Matrix<T, R, C>, Eigen::Matrix<T, R, C> > {

--- a/stan/math/prim/mat/fun/qr_Q.hpp
+++ b/stan/math/prim/mat/fun/qr_Q.hpp
@@ -11,8 +11,9 @@ namespace math {
 
 /**
  * Returns the orthogonal factor of the fat QR decomposition
+ *
+ * @tparam T type of elements in the matrix
  * @param m Matrix.
- * @tparam T scalar type
  * @return Orthogonal matrix with maximal columns
  */
 template <typename T>
@@ -34,4 +35,5 @@ Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> qr_Q(
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/qr_R.hpp
+++ b/stan/math/prim/mat/fun/qr_R.hpp
@@ -11,8 +11,9 @@ namespace math {
 
 /**
  * Returns the upper triangular factor of the fat QR decomposition
+ *
+ * @tparam T type of elements in the matrix
  * @param m Matrix.
- * @tparam T scalar type
  * @return Upper triangular matrix with maximal rows
  */
 template <typename T>
@@ -37,6 +38,8 @@ Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> qr_R(
   }
   return R;
 }
+
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/qr_thin_Q.hpp
+++ b/stan/math/prim/mat/fun/qr_thin_Q.hpp
@@ -11,8 +11,9 @@ namespace math {
 
 /**
  * Returns the orthogonal factor of the thin QR decomposition
+ *
+ * @tparam T type of elements in the matrix
  * @param m Matrix.
- * @tparam T scalar type
  * @return Orthogonal matrix with minimal columns
  */
 template <typename T>
@@ -34,4 +35,5 @@ Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> qr_thin_Q(
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/qr_thin_R.hpp
+++ b/stan/math/prim/mat/fun/qr_thin_R.hpp
@@ -11,8 +11,9 @@ namespace math {
 
 /**
  * Returns the upper triangular factor of the thin QR decomposition
+ *
+ * @tparam T type of elements in the matrix
  * @param m Matrix.
- * @tparam T scalar type
  * @return Upper triangular matrix with minimal rows
  */
 template <typename T>
@@ -37,4 +38,5 @@ Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> qr_thin_R(
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/quad_form_diag.hpp
+++ b/stan/math/prim/mat/fun/quad_form_diag.hpp
@@ -22,4 +22,5 @@ quad_form_diag(const Eigen::Matrix<T1, Eigen::Dynamic, Eigen::Dynamic>& mat,
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/quad_form_sym.hpp
+++ b/stan/math/prim/mat/fun/quad_form_sym.hpp
@@ -27,4 +27,5 @@ inline T quad_form_sym(const Eigen::Matrix<T, RA, CA>& A,
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/rank.hpp
+++ b/stan/math/prim/mat/fun/rank.hpp
@@ -31,4 +31,5 @@ inline int rank(const C& v, int s) {
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/read_corr_L.hpp
+++ b/stan/math/prim/mat/fun/read_corr_L.hpp
@@ -25,13 +25,12 @@ namespace math {
  * <p>See <code>read_corr_matrix(Array, size_t, T)</code>
  * for more information.
  *
+ * @tparam T type of elements in the array
  * @param CPCs The (K choose 2) canonical partial correlations in
  * (-1, 1).
  * @param K Dimensionality of correlation matrix.
  * @return Cholesky factor of correlation matrix for specified
  * canonical partial correlations.
-
- * @tparam T Type of underlying scalar.
  */
 template <typename T>
 Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> read_corr_L(
@@ -78,6 +77,7 @@ Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> read_corr_L(
  * extended onion method Journal of Multivariate Analysis 100
  * (2009) 1989–2001 </li></ul>
  *
+ * @tparam T type of elements in the array
  * @param CPCs The (K choose 2) canonical partial correlations in
  * (-1, 1).
  * @param K Dimensionality of correlation matrix.
@@ -85,7 +85,6 @@ Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> read_corr_L(
  * Jacobian determinant.
  * @return Cholesky factor of correlation matrix for specified
  * partial correlations.
- * @tparam T Type of underlying scalar.
  */
 template <typename T>
 Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> read_corr_L(
@@ -108,4 +107,5 @@ Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> read_corr_L(
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/read_corr_matrix.hpp
+++ b/stan/math/prim/mat/fun/read_corr_matrix.hpp
@@ -15,11 +15,11 @@ namespace math {
  * <p>See <code>read_corr_matrix(Array, size_t, T)</code>
  * for more information.
  *
+ * @tparam T type of elements in the array
  * @param CPCs The (K choose 2) canonical partial correlations in (-1, 1).
  * @param K Dimensionality of correlation matrix.
  * @return Cholesky factor of correlation matrix for specified
  * canonical partial correlations.
- * @tparam T Type of underlying scalar.
  */
 template <typename T>
 Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> read_corr_matrix(
@@ -41,13 +41,13 @@ Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> read_corr_matrix(
  * the Cholesky factor of the correlation matrix rather than the
  * correlation matrix itself in statistical calculations.
  *
+ * @tparam T type of elements in the array
  * @param CPCs The (K choose 2) canonical partial correlations in
  * (-1, 1).
  * @param K Dimensionality of correlation matrix.
  * @param log_prob Reference to variable to increment with the log
  * Jacobian determinant.
  * @return Correlation matrix for specified partial correlations.
- * @tparam T Type of underlying scalar.
  */
 template <typename T>
 Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> read_corr_matrix(
@@ -61,7 +61,6 @@ Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> read_corr_matrix(
 }
 
 }  // namespace math
-
 }  // namespace stan
 
 #endif

--- a/stan/math/prim/mat/fun/read_cov_L.hpp
+++ b/stan/math/prim/mat/fun/read_cov_L.hpp
@@ -11,6 +11,7 @@ namespace math {
  * This is the function that should be called prior to evaluating
  * the density of any elliptical distribution
  *
+ * @tparam T type of elements in the arrays
  * @param CPCs on (-1, 1)
  * @param sds on (0, inf)
  * @param log_prob the log probability value to increment with the Jacobian
@@ -29,4 +30,5 @@ Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> read_cov_L(
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/read_cov_matrix.hpp
+++ b/stan/math/prim/mat/fun/read_cov_matrix.hpp
@@ -12,6 +12,7 @@ namespace math {
  * A generally worse alternative to call prior to evaluating the
  * density of an elliptical distribution
  *
+ * @tparam T type of elements in the arrays
  * @param CPCs on (-1, 1)
  * @param sds on (0, inf)
  * @param log_prob the log probability value to increment with the Jacobian
@@ -30,6 +31,7 @@ Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> read_cov_matrix(
  *
  * Builds a covariance matrix from CPCs and standard deviations
  *
+ * @tparam T type of elements in the arrays
  * @param CPCs in (-1, 1)
  * @param sds in (0, inf)
  */
@@ -45,7 +47,6 @@ Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> read_cov_matrix(
 }
 
 }  // namespace math
-
 }  // namespace stan
 
 #endif

--- a/stan/math/prim/mat/fun/resize.hpp
+++ b/stan/math/prim/mat/fun/resize.hpp
@@ -35,9 +35,9 @@ void resize(std::vector<T>& x, const std::vector<int>& dims, int pos) {
  * which must bottom out at scalar values, Eigen vectors
  * or Eigen matrices.
  *
+ * @tparam T type of object being resized
  * @param x Array-like object to resize.
  * @param dims New dimensions.
- * @tparam T Type of object being resized.
  */
 template <typename T>
 inline void resize(T& x, std::vector<int> dims) {
@@ -46,4 +46,5 @@ inline void resize(T& x, std::vector<int> dims) {
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/round.hpp
+++ b/stan/math/prim/mat/fun/round.hpp
@@ -9,8 +9,9 @@ namespace math {
 
 /**
  * Structure to wrap round() so it can be vectorized.
- * @param x Argument variable.
- * @tparam T Argument type.
+ *
+ * @tparam T type of argument
+ * @param x argument variable
  * @return Rounded value of x.
  */
 struct round_fun {
@@ -22,8 +23,9 @@ struct round_fun {
 
 /**
  * Vectorized version of round.
- * @param x Container.
- * @tparam T Container type.
+ *
+ * @tparam T type of container
+ * @param x container
  * @return Rounded value of each value in x.
  */
 template <typename T>

--- a/stan/math/prim/mat/fun/row.hpp
+++ b/stan/math/prim/mat/fun/row.hpp
@@ -14,7 +14,7 @@ namespace math {
  * This is equivalent to calling <code>m.row(i - 1)</code> and
  * assigning the resulting template expression to a row vector.
  *
- * @tparam T Scalar value type for matrix.
+ * @tparam T type of elements in the matrix
  * @param m Matrix.
  * @param i Row index (count from 1).
  * @return Specified row of the matrix.
@@ -30,4 +30,5 @@ inline Eigen::Matrix<T, 1, Eigen::Dynamic> row(
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/rows.hpp
+++ b/stan/math/prim/mat/fun/rows.hpp
@@ -10,9 +10,10 @@ namespace math {
  * Return the number of rows in the specified
  * matrix, vector, or row vector.
  *
- * @tparam T Type of matrix entries.
- * @tparam R Row type of matrix.
- * @tparam C Column type of matrix.
+ * @tparam T type of elements in the matrix
+ * @tparam R number of rows, can be Eigen::Dynamic
+ * @tparam C number of columns, can be Eigen::Dynamic
+ *
  * @param[in] m Input matrix, vector, or row vector.
  * @return Number of rows.
  */
@@ -23,4 +24,5 @@ inline int rows(const Eigen::Matrix<T, R, C>& m) {
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/rows_dot_product.hpp
+++ b/stan/math/prim/mat/fun/rows_dot_product.hpp
@@ -10,6 +10,11 @@ namespace math {
 /**
  * Returns the dot product of the specified vectors.
  *
+ * @tparam R1 number of rows in the first vector, can be Eigen::Dynamic
+ * @tparam C1 number of columns in the first vector, can be Eigen::Dynamic
+ * @tparam R2 number of rows in the second vector, can be Eigen::Dynamic
+ * @tparam C2 number of columns in the second vector, can be Eigen::Dynamic
+ *
  * @param v1 First vector.
  * @param v2 Second vector.
  * @return Dot product of the vectors.
@@ -26,4 +31,5 @@ inline Eigen::Matrix<double, R1, 1> rows_dot_product(
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/rows_dot_self.hpp
+++ b/stan/math/prim/mat/fun/rows_dot_self.hpp
@@ -8,8 +8,12 @@ namespace math {
 
 /**
  * Returns the dot product of each row of a matrix with itself.
- * @param x Matrix.
- * @tparam T scalar type
+ *
+ * @tparam T type of elements in the matrix
+ * @tparam R number of rows, can be Eigen::Dynamic
+ * @tparam C number of columns, can be Eigen::Dynamic
+ *
+ * @param x matrix
  */
 template <typename T, int R, int C>
 inline Eigen::Matrix<T, R, 1> rows_dot_self(const Eigen::Matrix<T, R, C>& x) {
@@ -18,4 +22,5 @@ inline Eigen::Matrix<T, R, 1> rows_dot_self(const Eigen::Matrix<T, R, C>& x) {
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/sd.hpp
+++ b/stan/math/prim/mat/fun/sd.hpp
@@ -14,6 +14,8 @@ namespace math {
 /**
  * Returns the unbiased sample standard deviation of the
  * coefficients in the specified column vector.
+ *
+ * @tparam T type of elements in the vector
  * @param v Specified vector.
  * @return Sample variance of vector.
  */
@@ -29,6 +31,11 @@ inline return_type_t<T> sd(const std::vector<T>& v) {
 /**
  * Returns the unbiased sample standard deviation of the
  * coefficients in the specified vector, row vector, or matrix.
+ *
+ * @tparam T type of elements in the vector, row vector, or matrix
+ * @tparam R number of rows, can be Eigen::Dynamic
+ * @tparam C number of columns, can be Eigen::Dynamic
+ *
  * @param m Specified vector, row vector or matrix.
  * @return Sample variance.
  */
@@ -44,4 +51,5 @@ inline return_type_t<T> sd(const Eigen::Matrix<T, R, C>& m) {
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/segment.hpp
+++ b/stan/math/prim/mat/fun/segment.hpp
@@ -12,6 +12,8 @@ namespace math {
 /**
  * Return the specified number of elements as a vector starting
  * from the specified element - 1 of the specified vector.
+ *
+ * @tparam T type of elements in the vector
  */
 template <typename T>
 inline Eigen::Matrix<T, Eigen::Dynamic, 1> segment(
@@ -58,4 +60,5 @@ std::vector<T> segment(const std::vector<T>& sv, size_t i, size_t n) {
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/simplex_constrain.hpp
+++ b/stan/math/prim/mat/fun/simplex_constrain.hpp
@@ -20,9 +20,9 @@ namespace math {
  *
  * The transform is based on a centered stick-breaking process.
  *
+ * @tparam T type of elements in the vector
  * @param y Free vector input of dimensionality K - 1.
  * @return Simplex of dimensionality K.
- * @tparam T Type of scalar.
  */
 template <typename T>
 Eigen::Matrix<T, Eigen::Dynamic, 1> simplex_constrain(
@@ -53,10 +53,10 @@ Eigen::Matrix<T, Eigen::Dynamic, 1> simplex_constrain(
  * The simplex transform is defined through a centered
  * stick-breaking process.
  *
+ * @tparam T type of elements in the vector
  * @param y Free vector input of dimensionality K - 1.
  * @param lp Log probability reference to increment.
  * @return Simplex of dimensionality K.
- * @tparam T Type of scalar.
  */
 template <typename T>
 Eigen::Matrix<T, Eigen::Dynamic, 1> simplex_constrain(
@@ -85,7 +85,6 @@ Eigen::Matrix<T, Eigen::Dynamic, 1> simplex_constrain(
 }
 
 }  // namespace math
-
 }  // namespace stan
 
 #endif

--- a/stan/math/prim/mat/fun/simplex_free.hpp
+++ b/stan/math/prim/mat/fun/simplex_free.hpp
@@ -20,7 +20,7 @@ namespace math {
  *
  * @tparam T type of elements in the simplex
  * @param x Simplex of dimensionality K.
- * @return Free vector of dimensionality (K-1) that transfroms to
+ * @return Free vector of dimensionality (K-1) that transforms to
  * the simplex.
  * @throw std::domain_error if x is not a valid simplex
  */

--- a/stan/math/prim/mat/fun/simplex_free.hpp
+++ b/stan/math/prim/mat/fun/simplex_free.hpp
@@ -18,10 +18,10 @@ namespace math {
  * <p>The simplex transform is defined through a centered
  * stick-breaking process.
  *
+ * @tparam T type of elements in the simplex
  * @param x Simplex of dimensionality K.
  * @return Free vector of dimensionality (K-1) that transfroms to
  * the simplex.
- * @tparam T Type of scalar.
  * @throw std::domain_error if x is not a valid simplex
  */
 template <typename T>
@@ -48,4 +48,5 @@ Eigen::Matrix<T, Eigen::Dynamic, 1> simplex_free(
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/sin.hpp
+++ b/stan/math/prim/mat/fun/sin.hpp
@@ -9,8 +9,9 @@ namespace math {
 
 /**
  * Structure to wrap sin() so it can be vectorized.
- * @param x Angle in radians.
- * @tparam T Argument type.
+ *
+ * @tparam T type of argument
+ * @param x angle in radians
  * @return Sine of x.
  */
 struct sin_fun {
@@ -23,8 +24,9 @@ struct sin_fun {
 
 /**
  * Vectorized version of sin().
- * @param x Container of angles in radians.
- * @tparam T Container type.
+ *
+ * @tparam T type of container
+ * @param x angles in radians
  * @return Sine of each value in x.
  */
 template <typename T>

--- a/stan/math/prim/mat/fun/singular_values.hpp
+++ b/stan/math/prim/mat/fun/singular_values.hpp
@@ -11,6 +11,8 @@ namespace math {
  * in decreasing order of magnitude.
  * <p>See the documentation for <code>svd()</code> for
  * information on the singular values.
+ *
+ * @tparam T type of elements in the matrix
  * @param m Specified matrix.
  * @return Singular values of the matrix.
  */
@@ -26,4 +28,5 @@ Eigen::Matrix<T, Eigen::Dynamic, 1> singular_values(
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/sinh.hpp
+++ b/stan/math/prim/mat/fun/sinh.hpp
@@ -9,8 +9,9 @@ namespace math {
 
 /**
  * Structure to wrap sinh() so that it can be vectorized.
- * @param x Angle in radians.
- * @tparam T Variable type.
+ *
+ * @tparam T type of argument
+ * @param x angle in radians
  * @return Hyperbolic sine of x.
  */
 struct sinh_fun {
@@ -23,8 +24,9 @@ struct sinh_fun {
 
 /**
  * Vectorized version of sinh().
- * @param x Container of variables.
- * @tparam T Container type.
+ *
+ * @tparam T type of container
+ * @param x container
  * @return Hyperbolic sine of each variable in x.
  */
 template <typename T>

--- a/stan/math/prim/mat/fun/size.hpp
+++ b/stan/math/prim/mat/fun/size.hpp
@@ -9,7 +9,7 @@ namespace math {
 /**
  * Return the size of the specified standard vector.
  *
- * @tparam T Type of elements.
+ * @tparam T type of elements in the vector
  * @param[in] x Input vector.
  * @return Size of input vector.
  */
@@ -20,4 +20,5 @@ inline int size(const std::vector<T>& x) {
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/softmax.hpp
+++ b/stan/math/prim/mat/fun/softmax.hpp
@@ -37,7 +37,7 @@ namespace math {
  * \end{array}
  * \f$
  *
- * @tparam T Scalar type of values in vector.
+ * @tparam T type of elements in the vector
  * @param[in] v Vector to transform.
  * @return Unit simplex result of the softmax transform of the vector.
  */
@@ -53,4 +53,5 @@ inline Eigen::Matrix<T, Eigen::Dynamic, 1> softmax(
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/sort_asc.hpp
+++ b/stan/math/prim/mat/fun/sort_asc.hpp
@@ -11,7 +11,10 @@ namespace math {
 /**
  * Return the specified vector in ascending order.
  *
- * @tparam T Type of elements contained in vector.
+ * @tparam T type of elements in the vector
+ * @tparam R number of rows, can be Eigen::Dynamic
+ * @tparam C number of columns, can be Eigen::Dynamic
+ *
  * @param xs Vector to order.
  * @return Vector in ascending order.
  * @throw std::domain_error If any of the values are NaN.
@@ -25,4 +28,5 @@ inline Eigen::Matrix<T, R, C> sort_asc(Eigen::Matrix<T, R, C> xs) {
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/sort_desc.hpp
+++ b/stan/math/prim/mat/fun/sort_desc.hpp
@@ -13,7 +13,10 @@ namespace math {
 /**
  * Return the specified vector in descending order.
  *
- * @tparam T Type of elements contained in vector.
+ * @tparam T type of elements in the vector
+ * @tparam R number of rows, can be Eigen::Dynamic
+ * @tparam C number of columns, can be Eigen::Dynamic
+ *
  * @param xs Vector to order.
  * @return Vector in descending order.
  * @throw std::domain_error If any of the values are NaN.
@@ -27,4 +30,5 @@ inline Eigen::Matrix<T, R, C> sort_desc(Eigen::Matrix<T, R, C> xs) {
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/sort_indices.hpp
+++ b/stan/math/prim/mat/fun/sort_indices.hpp
@@ -75,4 +75,5 @@ std::vector<int> sort_indices(const C& xs) {
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/sort_indices_asc.hpp
+++ b/stan/math/prim/mat/fun/sort_indices_asc.hpp
@@ -24,4 +24,5 @@ std::vector<int> sort_indices_asc(const C& xs) {
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/sort_indices_desc.hpp
+++ b/stan/math/prim/mat/fun/sort_indices_desc.hpp
@@ -24,4 +24,5 @@ std::vector<int> sort_indices_desc(const C& xs) {
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/sqrt.hpp
+++ b/stan/math/prim/mat/fun/sqrt.hpp
@@ -9,8 +9,9 @@ namespace math {
 
 /**
  * Structure to wrap sqrt() so that it can be vectorized.
- * @param x Variable.
- * @tparam T Variable type.
+ *
+ * @tparam T type of variable
+ * @param x variable
  * @return Square root of x.
  */
 struct sqrt_fun {
@@ -23,8 +24,9 @@ struct sqrt_fun {
 
 /**
  * Vectorized version of sqrt().
- * @param x Container.
- * @tparam T Container type.
+ *
+ * @tparam T type of container
+ * @param x container
  * @return Square root of each value in x.
  */
 template <typename T>

--- a/stan/math/prim/mat/fun/square.hpp
+++ b/stan/math/prim/mat/fun/square.hpp
@@ -9,8 +9,9 @@ namespace math {
 
 /**
  * Structure to wrap square() so that it can be vectorized.
- * @param x Variable.
- * @tparam T Variable type.
+ *
+ * @tparam T type of variable
+ * @param x variable
  * @return x squared.
  */
 struct square_fun {
@@ -22,8 +23,9 @@ struct square_fun {
 
 /**
  * Vectorized version of square().
- * @param x Container.
- * @tparam T Container type.
+ *
+ * @tparam T type of container
+ * @param x container
  * @return Each value in x squared.
  */
 template <typename T>

--- a/stan/math/prim/mat/fun/squared_distance.hpp
+++ b/stan/math/prim/mat/fun/squared_distance.hpp
@@ -13,8 +13,8 @@ namespace math {
  * Returns the squared distance between the specified vectors
  * of the same dimensions.
  *
- * @tparam R Rows at compile time of vector inputs
- * @tparam C columns at compile time of vector inputs
+ * @tparam R number of rows, can be Eigen::Dynamic
+ * @tparam C number of columns, can be Eigen::Dynamic
  * @param v1 First vector.
  * @param v2 Second vector.
  * @return Dot product of the vectors.
@@ -34,10 +34,11 @@ inline double squared_distance(const Eigen::Matrix<double, R, C>& v1,
  * Returns the squared distance between the specified vectors
  * of the same dimensions.
  *
- * @tparam R1 Rows at compile time of first vector input
- * @tparam C1 Columns at compile time of first vector input
- * @tparam R2 Rows at compile time of second vector input
- * @tparam C2 Columns at compile time of second vector input
+ * @tparam R1 number of rows in the first vector, can be Eigen::Dynamic
+ * @tparam C1 number of columns in the first vector, can be Eigen::Dynamic
+ * @tparam R2 number of rows in the second vector, can be Eigen::Dynamic
+ * @tparam C2 number of columns in the second vector, can be Eigen::Dynamic
+ *
  * @param v1 First vector.
  * @param v2 Second vector.
  * @return Dot product of the vectors.
@@ -55,4 +56,5 @@ inline double squared_distance(const Eigen::Matrix<double, R1, C1>& v1,
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/sub_col.hpp
+++ b/stan/math/prim/mat/fun/sub_col.hpp
@@ -11,6 +11,7 @@ namespace math {
 /**
  * Return a nrows x 1 subcolumn starting at (i-1, j-1).
  *
+ * @tparam T type of elements in the matrix
  * @param m Matrix.
  * @param i Starting row + 1.
  * @param j Starting column + 1.
@@ -31,4 +32,5 @@ inline Eigen::Matrix<T, Eigen::Dynamic, 1> sub_col(
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/sub_row.hpp
+++ b/stan/math/prim/mat/fun/sub_row.hpp
@@ -11,6 +11,7 @@ namespace math {
 /**
  * Return a 1 x nrows subrow starting at (i-1, j-1).
  *
+ * @tparam T type of elements in the matrix
  * @param m Matrix Input matrix.
  * @param i Starting row + 1.
  * @param j Starting column + 1.
@@ -31,4 +32,5 @@ inline Eigen::Matrix<T, 1, Eigen::Dynamic> sub_row(
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/subtract.hpp
+++ b/stan/math/prim/mat/fun/subtract.hpp
@@ -12,10 +12,11 @@ namespace math {
  * from the first specified matrix.  The return scalar type is the
  * promotion of the input types.
  *
- * @tparam T1 Scalar type of first matrix.
- * @tparam T2 Scalar type of second matrix.
- * @tparam R Row type of matrices.
- * @tparam C Column type of matrices.
+ * @tparam T1 type of elements in the first matrix
+ * @tparam T2 type of elements in the second matrix
+ * @tparam R number of rows, can be Eigen::Dynamic
+ * @tparam C number of columns, can be Eigen::Dynamic
+ *
  * @param m1 First matrix.
  * @param m2 Second matrix.
  * @return Difference between first matrix and second matrix.
@@ -41,4 +42,5 @@ inline Eigen::Matrix<return_type_t<T1, T2>, R, C> subtract(
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/sum.hpp
+++ b/stan/math/prim/mat/fun/sum.hpp
@@ -11,8 +11,8 @@ namespace math {
  * Returns the sum of the coefficients of the specified
  * Eigen Matrix, Array or expression.
  *
- * @tparam Derived Derived argument type.
- * @param v Specified argument.
+ * @tparam Derived type of argument
+ * @param v argument
  * @return Sum of coefficients of argument.
  */
 template <typename Derived>
@@ -23,4 +23,5 @@ inline typename Eigen::DenseBase<Derived>::Scalar sum(
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/tail.hpp
+++ b/stan/math/prim/mat/fun/tail.hpp
@@ -15,7 +15,7 @@ namespace math {
  * Return the specified number of elements as a vector
  * from the back of the specified vector.
  *
- * @tparam T Type of value in vector.
+ * @tparam T type of elements in the vector
  * @param v Vector input.
  * @param n Size of return.
  * @return The last n elements of v.
@@ -34,7 +34,7 @@ inline Eigen::Matrix<T, Eigen::Dynamic, 1> tail(
  * Return the specified number of elements as a row vector
  * from the back of the specified row vector.
  *
- * @tparam T Type of value in vector.
+ * @tparam T type of elements in the vector
  * @param rv Row vector.
  * @param n Size of return row vector.
  * @return The last n elements of rv.
@@ -53,7 +53,7 @@ inline Eigen::Matrix<T, 1, Eigen::Dynamic> tail(
  * Return the specified number of elements as a standard vector
  * from the back of the specified standard vector.
  *
- * @tparam T Type of value in vector.
+ * @tparam T type of elements in the vector
  * @param sv Standard vector.
  * @param n Size of return.
  * @return The last n elements of sv.
@@ -74,4 +74,5 @@ std::vector<T> tail(const std::vector<T>& sv, size_t n) {
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/tan.hpp
+++ b/stan/math/prim/mat/fun/tan.hpp
@@ -9,8 +9,9 @@ namespace math {
 
 /**
  * Structure to wrap tan() so that it can be vectorized.
- * @param x Angle in radians.
- * @tparam T Variable type.
+ *
+ * @tparam T type of argument
+ * @param x angle in radians
  * @return Tangent of x.
  */
 struct tan_fun {
@@ -23,8 +24,9 @@ struct tan_fun {
 
 /**
  * Vectorized version of tan().
- * @param x Container of angles in radians.
- * @tparam T Container type.
+ *
+ * @tparam T type of container
+ * @param x angles in radians
  * @return Tangent of each value in x.
  */
 template <typename T>

--- a/stan/math/prim/mat/fun/tanh.hpp
+++ b/stan/math/prim/mat/fun/tanh.hpp
@@ -9,8 +9,9 @@ namespace math {
 
 /**
  * Structure to wrap tanh() so that it can be vectorized.
- * @param x Angle in radians.
- * @tparam T Variable type.
+ *
+ * @tparam T type of argument
+ * @param x angle in radians
  * @return Hyperbolic tangent of x.
  */
 struct tanh_fun {
@@ -23,8 +24,9 @@ struct tanh_fun {
 
 /**
  * Vectorized version of tanh().
- * @param x Container of angles in radians.
- * @tparam T Container type.
+ *
+ * @tparam T type of container
+ * @param x angles in radians
  * @return Hyperbolic tangent of each value in x.
  */
 template <typename T>

--- a/stan/math/prim/mat/fun/tcrossprod.hpp
+++ b/stan/math/prim/mat/fun/tcrossprod.hpp
@@ -10,6 +10,9 @@ namespace math {
 /**
  * Returns the result of post-multiplying a matrix by its
  * own transpose.
+ *
+ * @tparam R number of rows, can be Eigen::Dynamic
+ * @tparam C number of columns, can be Eigen::Dynamic
  * @param M Matrix to multiply.
  * @return M times its transpose.
  */
@@ -27,4 +30,5 @@ inline Eigen::MatrixXd tcrossprod(const Eigen::Matrix<double, R, C>& M) {
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/tgamma.hpp
+++ b/stan/math/prim/mat/fun/tgamma.hpp
@@ -9,8 +9,9 @@ namespace math {
 
 /**
  * Structure to wrap tgamma() so that it can be vectorized.
- * @param x Variable.
- * @tparam T Variable type.
+ *
+ * @tparam T type of variable
+ * @param x variable
  * @return Gamma function applied to x.
  * @throw std::domain_error if x is 0 or a negative integer
  */
@@ -23,8 +24,9 @@ struct tgamma_fun {
 
 /**
  * Vectorized version of tgamma().
- * @param x Container.
- * @tparam T Container type.
+ *
+ * @tparam T type of container
+ * @param x container
  * @return Gamma function applied to each value in x.
  * @throw std::domain_error if any value is 0 or a negative integer
  */

--- a/stan/math/prim/mat/fun/to_matrix.hpp
+++ b/stan/math/prim/mat/fun/to_matrix.hpp
@@ -8,15 +8,17 @@
 
 namespace stan {
 namespace math {
+
 /**
  * Returns a matrix with dynamic dimensions constructed from an
  * Eigen matrix which is either a row vector, column vector,
  * or matrix.
  * The runtime dimensions will be the same as the input.
  *
- * @tparam T type of the scalar
- * @tparam R number of rows
- * @tparam C number of columns
+ * @tparam T type of the elements in the matrix
+ * @tparam R number of rows, can be Eigen::Dynamic
+ * @tparam C number of columns, can be Eigen::Dynamic
+ *
  * @param x matrix
  * @return the matrix representation of the input
  */
@@ -30,7 +32,7 @@ inline Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> to_matrix(
  * Returns a matrix representation of a standard vector of Eigen
  * row vectors with the same dimensions and indexing order.
  *
- * @tparam T type of the scalar
+ * @tparam T type of the elements in the vector
  * @param x Eigen vector of vectors of scalar values
  * @return the matrix representation of the input
  */
@@ -55,7 +57,7 @@ inline Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> to_matrix(
  * Returns a matrix representation of the standard vector of
  * standard vectors with the same dimensions and indexing order.
  *
- * @tparam T type of the scalar
+ * @tparam T type of elements in the vector
  * @param x vector of vectors of scalar values
  * @return the matrix representation of the input
  */
@@ -82,7 +84,10 @@ to_matrix(const std::vector<std::vector<T> >& x) {
  * Returns a matrix representation of the vector in column-major
  * order with the specified number of rows and columns.
  *
- * @tparam T type of the scalar
+ * @tparam T type of elements in the matrix
+ * @tparam R number of rows, can be Eigen::Dynamic
+ * @tparam C number of columns, can be Eigen::Dynamic
+ *
  * @param x matrix
  * @param m rows
  * @param n columns
@@ -104,7 +109,7 @@ inline Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> to_matrix(
  * Returns a matrix representation of the vector in column-major
  * order with the specified number of rows and columns.
  *
- * @tparam T type of the scalar
+ * @tparam T type of elements in the vector
  * @param x vector of values
  * @param m rows
  * @param n columns
@@ -148,7 +153,10 @@ inline Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> to_matrix(
  * Returns a matrix representation of the vector in column-major
  * order with the specified number of rows and columns.
  *
- * @tparam T type of the scalar
+ * @tparam T type of elements in the matrix
+ * @tparam R number of rows, can be Eigen::Dynamic
+ * @tparam C number of columns, can be Eigen::Dynamic
+ *
  * @param x matrix
  * @param m rows
  * @param n columns
@@ -181,7 +189,7 @@ inline Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> to_matrix(
  * Returns a matrix representation of the vector in column-major
  * order with the specified number of rows and columns.
  *
- * @tparam T type of the scalar
+ * @tparam T type of elements in the vector
  * @param x vector of values
  * @param m rows
  * @param n columns
@@ -213,4 +221,5 @@ to_matrix(const std::vector<T>& x, int m, int n, bool col_major) {
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/to_row_vector.hpp
+++ b/stan/math/prim/mat/fun/to_row_vector.hpp
@@ -2,7 +2,6 @@
 #define STAN_MATH_PRIM_MAT_FUN_TO_ROW_VECTOR_HPP
 
 #include <stan/math/prim/mat/fun/Eigen.hpp>
-// stan::scalar_type
 #include <vector>
 
 namespace stan {

--- a/stan/math/prim/mat/fun/to_vector.hpp
+++ b/stan/math/prim/mat/fun/to_vector.hpp
@@ -2,7 +2,6 @@
 #define STAN_MATH_PRIM_MAT_FUN_TO_VECTOR_HPP
 
 #include <stan/math/prim/mat/fun/Eigen.hpp>
-// stan::scalar_type
 #include <vector>
 
 namespace stan {

--- a/stan/math/prim/mat/fun/trace.hpp
+++ b/stan/math/prim/mat/fun/trace.hpp
@@ -12,6 +12,7 @@ namespace math {
  * The matrix is not required to be square.  Returns 0 if
  * matrix is empty.
  *
+ * @tparam T type of the elements in the matrix
  * @param[in] m Specified matrix.
  * @return Trace of the matrix.
  */
@@ -24,6 +25,8 @@ template <typename T>
 inline T trace(const T& m) {
   return m;
 }
+
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/trace_gen_inv_quad_form_ldlt.hpp
+++ b/stan/math/prim/mat/fun/trace_gen_inv_quad_form_ldlt.hpp
@@ -18,6 +18,24 @@ namespace math {
  * Compute the trace of an inverse quadratic form.  I.E., this computes
  *       trace(D B^T A^-1 B)
  * where D is a square matrix and the LDLT_factor of A is provided.
+ *
+ * @tparam T1 type of elements in the first matrix
+ * @tparam T2 type of elements in the LDLT_factor
+ * @tparam T3 type of elements in the third matrix
+ * @tparam R1 number of rows in the first matrix, can be Eigen::Dynamic
+ * @tparam C1 number of columns in the first matrix, can be Eigen::Dynamic
+ * @tparam R2 number of rows in the LDLT_factor, can be Eigen::Dynamic
+ * @tparam C2 number of columns in the LDLT_factor, can be Eigen::Dynamic
+ * @tparam R3 number of rows in the third matrix, can be Eigen::Dynamic
+ * @tparam C3 number of columns in the third matrix, can be Eigen::Dynamic
+ *
+ * @param D multiplier
+ * @param A LDLT_factor
+ * @param B inner term in quadratic form
+ * @return trace(D * B^T * A^-1 * B)
+ * @throw std::domain_error if D is not square
+ * @throw std::domain_error if A cannot be multiplied by B or B cannot
+ * be multiplied by D.
  */
 template <typename T1, typename T2, typename T3, int R1, int C1, int R2, int C2,
           int R3, int C3, typename = require_any_not_var_t<T1, T2, T3>>
@@ -37,4 +55,5 @@ inline return_type_t<T1, T2, T3> trace_gen_inv_quad_form_ldlt(
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/trace_gen_quad_form.hpp
+++ b/stan/math/prim/mat/fun/trace_gen_quad_form.hpp
@@ -12,19 +12,21 @@
 
 namespace stan {
 namespace math {
+
 /**
  * Return the trace of D times the quadratic form of B and A.
  * That is, `trace_gen_quad_form(D, A, B) = trace(D * B' * A * B).`
  *
- * @tparam TD type of first argument scalar
- * @tparam RD first argument number of rows or `Eigen::Dynamic`
- * @tparam CD first argument number of columns or `Eigen::Dynamic`
- * @tparam TA type of second argument scalar
- * @tparam RA second argument number of rows or `Eigen::Dynamic`
- * @tparam CA second argument number of columns or `Eigen::Dynamic`
- * @tparam TB type of third argument scalar
- * @tparam RB third argument number of rows or `Eigen::Dynamic`
- * @tparam CB third argument number of columns or `Eigen::Dynamic`
+ * @tparam TD type of elements in the first matrix
+ * @tparam TA type of elements in the second matrix
+ * @tparam TB type of elements in the third matrix
+ * @tparam RD number of rows in the first matrix, can be Eigen::Dynamic
+ * @tparam CD number of columns in the first matrix, can be Eigen::Dynamic
+ * @tparam RA number of rows in the second matrix, can be Eigen::Dynamic
+ * @tparam CA number of columns in the second matrix, can be Eigen::Dynamic
+ * @tparam RB number of rows in the third matrix, can be Eigen::Dynamic
+ * @tparam CB number of columns in the third matrix, can be Eigen::Dynamic
+ *
  * @param D multiplier
  * @param A outside term in quadratic form
  * @param B inner term in quadratic form
@@ -51,13 +53,13 @@ inline return_type_t<TD, TA, TB> trace_gen_quad_form(
  * This is the double-only overload to allow Eigen's expression
  * templates to be used for efficiency.
  *
- * @tparam RD first argument number of rows or `Eigen::Dynamic`
- * @tparam CD first argument number of columns or `Eigen::Dynamic`
- * @tparam RA second argument number of rows or `Eigen::Dynamic`
- * @tparam CA second argument number of columns or `Eigen::Dynamic`
- * @tparam TB type of third argument scalar
- * @tparam RB third argument number of rows or `Eigen::Dynamic`
- * @tparam CB third argument number of columns or `Eigen::Dynamic`
+ * @tparam RD number of rows in the first matrix, can be Eigen::Dynamic
+ * @tparam CD number of columns in the first matrix, can be Eigen::Dynamic
+ * @tparam RA number of rows in the second matrix, can be Eigen::Dynamic
+ * @tparam CA number of columns in the second matrix, can be Eigen::Dynamic
+ * @tparam RB number of rows in the third matrix, can be Eigen::Dynamic
+ * @tparam CB number of columns in the third matrix, can be Eigen::Dynamic
+ *
  * @param D multiplier
  * @param A outside term in quadratic form
  * @param B inner term in quadratic form
@@ -66,7 +68,7 @@ inline return_type_t<TD, TA, TB> trace_gen_quad_form(
  * @throw std::domain_error if A cannot be multiplied by B or B cannot
  * be multiplied by D.
  */
-template <int RD, int CD, int RA, int CA, typename TB, int RB, int CB>
+template <int RD, int CD, int RA, int CA, int RB, int CB>
 inline double trace_gen_quad_form(const Eigen::Matrix<double, RD, CD> &D,
                                   const Eigen::Matrix<double, RA, CA> &A,
                                   const Eigen::Matrix<double, RB, CB> &B) {
@@ -79,4 +81,5 @@ inline double trace_gen_quad_form(const Eigen::Matrix<double, RD, CD> &D,
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/trace_gen_quad_form.hpp
+++ b/stan/math/prim/mat/fun/trace_gen_quad_form.hpp
@@ -57,6 +57,7 @@ inline return_type_t<TD, TA, TB> trace_gen_quad_form(
  * @tparam CD number of columns in the first matrix, can be Eigen::Dynamic
  * @tparam RA number of rows in the second matrix, can be Eigen::Dynamic
  * @tparam CA number of columns in the second matrix, can be Eigen::Dynamic
+ * @tparam TB type of elements in the third matrix
  * @tparam RB number of rows in the third matrix, can be Eigen::Dynamic
  * @tparam CB number of columns in the third matrix, can be Eigen::Dynamic
  *
@@ -68,7 +69,7 @@ inline return_type_t<TD, TA, TB> trace_gen_quad_form(
  * @throw std::domain_error if A cannot be multiplied by B or B cannot
  * be multiplied by D.
  */
-template <int RD, int CD, int RA, int CA, int RB, int CB>
+template <int RD, int CD, int RA, int CA, typename TB, int RB, int CB>
 inline double trace_gen_quad_form(const Eigen::Matrix<double, RD, CD> &D,
                                   const Eigen::Matrix<double, RA, CA> &A,
                                   const Eigen::Matrix<double, RB, CB> &B) {

--- a/stan/math/prim/mat/fun/trace_inv_quad_form_ldlt.hpp
+++ b/stan/math/prim/mat/fun/trace_inv_quad_form_ldlt.hpp
@@ -17,6 +17,16 @@ namespace math {
  * Compute the trace of an inverse quadratic form.  I.E., this computes
  *       trace(B^T A^-1 B)
  * where the LDLT_factor of A is provided.
+ *
+ * @tparam T1 type of elements in the first matrix and the LDLT_factor
+ * @tparam T2 type of elements in the second matrix
+ * @tparam R1 number of rows in the first matrix, can be Eigen::Dynamic
+ * @tparam C1 number of columns in the first matrix, can be Eigen::Dynamic
+ * @tparam R2 number of rows in the LDLT_factor, can be Eigen::Dynamic
+ * @tparam C2 number of columns in the LDLT_factor, can be Eigen::Dynamic
+ * @tparam R3 number of rows in the third matrix, can be Eigen::Dynamic
+ * @tparam C3 number of columns in the third matrix, can be Eigen::Dynamic
+ *
  */
 template <typename T1, typename T2, int R2, int C2, int R3, int C3,
           typename = require_any_not_var_t<T1, T2>>
@@ -33,4 +43,5 @@ inline return_type_t<T1, T2> trace_inv_quad_form_ldlt(
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/trace_quad_form.hpp
+++ b/stan/math/prim/mat/fun/trace_quad_form.hpp
@@ -7,9 +7,21 @@
 
 namespace stan {
 namespace math {
+
 /**
  * Compute trace(B^T A B).
- **/
+ *
+ * @tparam RA number of rows in the first matrix, can be Eigen::Dynamic
+ * @tparam CA number of columns in the first matrix, can be Eigen::Dynamic
+ * @tparam RB number of rows in the second matrix, can be Eigen::Dynamic
+ * @tparam CB number of columns in the second matrix, can be Eigen::Dynamic
+ *
+ * @param A matrix
+ * @param B matrix
+ * @return The trace of B^T A B
+ * @throw std::domain_error if A is not square
+ * @throw std::domain_error if A cannot be multiplied by B
+ */
 template <int RA, int CA, int RB, int CB>
 inline double trace_quad_form(const Eigen::Matrix<double, RA, CA> &A,
                               const Eigen::Matrix<double, RB, CB> &B) {
@@ -21,4 +33,5 @@ inline double trace_quad_form(const Eigen::Matrix<double, RA, CA> &A,
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/trigamma.hpp
+++ b/stan/math/prim/mat/fun/trigamma.hpp
@@ -17,7 +17,7 @@ struct trigamma_fun {
    *
    * @tparam T type of argument
    * @param x argument
-   * @return aprpoximate value of Phi applied to argument.
+   * @return approximate value of Phi applied to argument
    */
   template <typename T>
   static inline T fun(const T& x) {

--- a/stan/math/prim/mat/fun/trigamma.hpp
+++ b/stan/math/prim/mat/fun/trigamma.hpp
@@ -15,7 +15,7 @@ struct trigamma_fun {
    * Return the approximate value of the Phi() function applied to
    * the argument.
    *
-   * @tparam T argument type
+   * @tparam T type of argument
    * @param x argument
    * @return aprpoximate value of Phi applied to argument.
    */
@@ -31,7 +31,7 @@ struct trigamma_fun {
  * underlying scalar argument type to double if it is an integer,
  * and otherwise is the argument type.
  *
- * @tparam T container type
+ * @tparam T type of container
  * @param x container
  * @return elementwise trigamma of container elements
  */

--- a/stan/math/prim/mat/fun/trunc.hpp
+++ b/stan/math/prim/mat/fun/trunc.hpp
@@ -15,7 +15,7 @@ struct trunc_fun {
    * Return the truncation of the specified argument to the
    * nearest value.
    *
-   * @tparam T argument type
+   * @tparam T type of argument
    * @param x argument
    * @return truncation of the argument
    */
@@ -31,7 +31,7 @@ struct trunc_fun {
  * underlying scalar argument type to double if it is an integer,
  * and otherwise is the argument type.
  *
- * @tparam T container type
+ * @tparam T type of container
  * @param x container
  * @return elementwise trunc of container elements
  */

--- a/stan/math/prim/mat/fun/unit_vector_constrain.hpp
+++ b/stan/math/prim/mat/fun/unit_vector_constrain.hpp
@@ -18,7 +18,7 @@ namespace math {
  * href="https://en.wikipedia.org/wiki/N-sphere#Generating_random_points">the
  * Wikipedia page on generating random points on an N-sphere</a>.
  *
- * @tparam T Scalar type.
+ * @tparam T type of elements in the vector
  * @param y vector of K unrestricted variables
  * @return Unit length vector of dimension K
  */
@@ -36,10 +36,13 @@ Eigen::Matrix<T, R, C> unit_vector_constrain(const Eigen::Matrix<T, R, C>& y) {
  * Return the unit length vector corresponding to the free vector y.
  * See https://en.wikipedia.org/wiki/N-sphere#Generating_random_points
  *
+ * @tparam T type of elements in the vector
+ * @tparam R number of rows in the matrix, can be Eigen::Dynamic
+ * @tparam C number of columns in the matrix, can be Eigen::Dynamic
+ *
  * @param y vector of K unrestricted variables
  * @return Unit length vector of dimension K
  * @param lp Log probability reference to increment.
- * @tparam T Scalar type.
  */
 template <typename T, int R, int C>
 Eigen::Matrix<T, R, C> unit_vector_constrain(const Eigen::Matrix<T, R, C>& y,
@@ -55,4 +58,5 @@ Eigen::Matrix<T, R, C> unit_vector_constrain(const Eigen::Matrix<T, R, C>& y,
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/unit_vector_free.hpp
+++ b/stan/math/prim/mat/fun/unit_vector_free.hpp
@@ -14,10 +14,10 @@ namespace math {
  * However, we are just fixing the unidentified radius to 1.
  * Thus, the transformation is just the identity
  *
+ * @tparam T type of elements in the vector
  * @param x unit vector of dimension K
  * @return Unit vector of dimension K considered "free"
- * @tparam T Scalar type.
- **/
+ */
 template <typename T>
 Eigen::Matrix<T, Eigen::Dynamic, 1> unit_vector_free(
     const Eigen::Matrix<T, Eigen::Dynamic, 1>& x) {
@@ -27,4 +27,5 @@ Eigen::Matrix<T, Eigen::Dynamic, 1> unit_vector_free(
 
 }  // namespace math
 }  // namespace stan
+
 #endif

--- a/stan/math/prim/mat/fun/value_of.hpp
+++ b/stan/math/prim/mat/fun/value_of.hpp
@@ -14,9 +14,10 @@ namespace math {
  * T must implement value_of. See
  * test/math/fwd/mat/fun/value_of.cpp for fvar and var usage.
  *
- * @tparam T Scalar type in matrix
- * @tparam R Rows of matrix
- * @tparam C Columns of matrix
+ * @tparam T type of elements in the matrix
+ * @tparam R number of rows in the matrix, can be Eigen::Dynamic
+ * @tparam C number of columns in the matrix, can be Eigen::Dynamic
+ *
  * @param[in] M Matrix to be converted
  * @return Matrix of values
  **/
@@ -40,6 +41,9 @@ inline Eigen::Matrix<typename child_type<T>::type, R, C> value_of(
  *
  * <p>This inline pass-through no-op should be compiled away.
  *
+ * @tparam R number of rows in the matrix, can be Eigen::Dynamic
+ * @tparam C number of columns in the matrix, can be Eigen::Dynamic
+ *
  * @param x Specified matrix.
  * @return Specified matrix.
  */
@@ -56,6 +60,9 @@ inline const Eigen::Matrix<double, R, C>& value_of(
  * implementation using static casts.
  *
  * <p>This inline pass-through no-op should be compiled away.
+ *
+ * @tparam R number of rows in the matrix, can be Eigen::Dynamic
+ * @tparam C number of columns in the matrix, can be Eigen::Dynamic
  *
  * @param x Specified matrix.
  * @return Specified matrix.

--- a/stan/math/prim/mat/fun/value_of_rec.hpp
+++ b/stan/math/prim/mat/fun/value_of_rec.hpp
@@ -13,9 +13,10 @@ namespace math {
  * T must implement value_of_rec. See
  * test/unit/math/fwd/mat/fun/value_of_test.cpp for fvar and var usage.
  *
- * @tparam T Scalar type in matrix
- * @tparam R Rows of matrix
- * @tparam C Columns of matrix
+ * @tparam T type of elements in the matrix
+ * @tparam R number of rows in the matrix, can be Eigen::Dynamic
+ * @tparam C number of columns in the matrix, can be Eigen::Dynamic
+ *
  * @param[in] M Matrix to be converted
  * @return Matrix of values
  **/
@@ -38,6 +39,9 @@ inline Eigen::Matrix<double, R, C> value_of_rec(
  * implementation using static casts.
  *
  * <p>This inline pass-through no-op should be compiled away.
+ *
+ * @tparam R number of rows in the matrix, can be Eigen::Dynamic
+ * @tparam C number of columns in the matrix, can be Eigen::Dynamic
  *
  * @param x Specified matrix.
  * @return Specified matrix.

--- a/stan/math/prim/mat/fun/variance.hpp
+++ b/stan/math/prim/mat/fun/variance.hpp
@@ -12,7 +12,8 @@ namespace math {
 /**
  * Returns the sample variance (divide by length - 1) of the
  * coefficients in the specified standard vector.
- * @tparam T type of scalar
+ *
+ * @tparam T type of elements in the vector
  * @param v specified vector
  * @return sample variance of vector
  * @throw <code>std::invalid_argument</code> if the vector has size zero
@@ -35,9 +36,11 @@ inline return_type_t<T> variance(const std::vector<T>& v) {
 /**
  * Returns the sample variance (divide by length - 1) of the
  * coefficients in the specified matrix
- * @tparam T type of scalar
- * @tparam R number of rows or Eigen::Dynamic
- * @tparam C number of columns or Eigen::Dynamic
+ *
+ * @tparam T type of elements in the vector
+ * @tparam R number of rows in the matrix, can be Eigen::Dynamic
+ * @tparam C number of columns in the matrix, can be Eigen::Dynamic
+ *
  * @param m matrix
  * @return sample variance of coefficients
  * @throw <code>std::invalid_argument</code> if the matrix has size zero
@@ -60,4 +63,5 @@ inline return_type_t<T> variance(const Eigen::Matrix<T, R, C>& m) {
 
 }  // namespace math
 }  // namespace stan
+
 #endif


### PR DESCRIPTION
## Summary

This is a step towards #1473, limited to `prim/mat/fun`. It started as documenting the matrix rows and columns, but it grew to other template parameters that were often missing. I tried to keep wording and formatting consistent everywhere (we are not very consistent overall, but that's for a different time).

## Tests

None.

## Side Effects

None.

## Checklist

- [X] Math issue #1473

- [X] Copyright holder: Marco Colombo

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen
