### PR TITLE
Fix gamma p tests

### DIFF
--- a/test/unit/math/mix/scal/fun/gamma_p_test.cpp
+++ b/test/unit/math/mix/scal/fun/gamma_p_test.cpp
@@ -40,12 +40,9 @@ TEST(mathMixScalFun, gammaP) {
   }
 }
 
-
 // separate tests when a is positive_infinity
 TEST(mathMixScalFun, gammaP_pos_inf) {
-  auto g = [](const auto& x) {
-    return stan::math::gamma_p(x(0), x(1));
-  };  
+  auto g = [](const auto& x) { return stan::math::gamma_p(x(0), x(1)); };
   stan::math::vector_d x(2);
   x << 0.5001, stan::math::positive_infinity();
   Eigen::Matrix<double, Eigen::Dynamic, 1> grad_ad;

--- a/test/unit/math/mix/scal/fun/gamma_p_test.cpp
+++ b/test/unit/math/mix/scal/fun/gamma_p_test.cpp
@@ -1,9 +1,78 @@
 #include <test/unit/math/test_ad.hpp>
+#include <test/unit/math/expect_near_rel.hpp>
+#include <stan/math/prim/mat.hpp>
+#include <stan/math/mix/mat.hpp>
+
+struct fun1 {
+  template <typename T>
+  inline T operator()(const Eigen::Matrix<T, Eigen::Dynamic, 1>& x) const {
+    return stan::math::gamma_p(x(0), x(1));
+  }
+};
 
 TEST(mathMixScalFun, gammaP) {
   auto f = [](const auto& x1, const auto& x2) {
     return stan::math::gamma_p(x1, x2);
   };
-  stan::test::expect_common_nonzero_binary(f);
+  // common nonzero double arguments excluding positive infinity
+  // due to issues with finite diff gradient
+  const std::vector<double> args{ -1.3, 0.49, 0.99, 1.01, stan::math::negative_infinity(), stan::math::not_a_number()};
+  auto int_args = stan::test::internal::common_nonzero_int_args();
+  for (double x1 : args)
+    for (double x2 : args) {
+      stan::test::expect_ad(f, x1, x2);
+    }
+  for (double x1 : args)
+    for (int x2 : int_args) {
+      stan::test::expect_ad(f, x1, x2);
+    }
+  for (int x1 : int_args)
+    for (double x2 : args) {
+      stan::test::expect_ad(f, x1, x2);
+    }
+  for (int x1 : int_args)
+    for (int x2 : int_args) {
+      stan::test::expect_ad(f, x1, x2);
+    }
   stan::test::expect_ad(f, 0.5001, 1.0001);
+}
+
+// separate tests when a is positive_infinity
+TEST(mathMixScalFun, gammaP_pos_inf) {
+  stan::math::vector_d x(2);
+  x << 0.5001, stan::math::positive_infinity();
+  Eigen::Matrix<double, Eigen::Dynamic, 1> grad_ad;
+  double fx_ad = 1;
+  fun1 g;
+  stan::math::gradient<fun1>(g, x, fx_ad, grad_ad);
+  stan::test::expect_near_rel("gradient() val", 1, fx_ad, 1e-8);
+  stan::test::expect_near_rel("gradient() grad z", stan::math::not_a_number(), grad_ad(0), 1e-3);
+  stan::test::expect_near_rel("gradient() grad a", stan::math::not_a_number(), grad_ad(1), 1e-3);
+
+  Eigen::Matrix<double, Eigen::Dynamic, 1> grad_ad_fvar;
+  stan::math::gradient<double, fun1>(g, x, fx_ad, grad_ad_fvar);
+  stan::test::expect_near_rel("gradient_fvar() val", 1, fx_ad, 1e-8);
+  stan::test::expect_near_rel("gradient_fvar() grad z", stan::math::not_a_number(), grad_ad_fvar(0), 1e-3);
+  stan::test::expect_near_rel("gradient_fvar() grad a", stan::math::not_a_number(), grad_ad_fvar(1), 1e-3);
+
+  Eigen::Matrix<double, Eigen::Dynamic, 1> hessian_grad_ad;
+  Eigen::MatrixXd H_ad;
+  stan::math::hessian(g, x, fx_ad, hessian_grad_ad, H_ad);
+  stan::test::expect_near_rel("hessian() val", 1, fx_ad, 1e-8);
+  stan::test::expect_near_rel("hessian() grad z", stan::math::not_a_number(), hessian_grad_ad(0), 1e-3);
+  stan::test::expect_near_rel("hessian() grad a", stan::math::not_a_number(), hessian_grad_ad(1), 1e-3);
+  stan::test::expect_near_rel("hessian() Hessian z", stan::math::not_a_number(), H_ad(0), 1e-3);
+  stan::test::expect_near_rel("hessian() Hessian a", stan::math::not_a_number(), H_ad(1), 1e-3);
+  
+  std::vector<Eigen::MatrixXd> grad_H_ad;
+  stan::math::grad_hessian(g, x, fx_ad, H_ad, grad_H_ad);
+  stan::test::expect_near_rel("grad_hessian() val", 1, fx_ad, 1e-8);
+  for(int i = 0; i < H_ad.size(); i++) {
+    stan::test::expect_near_rel("grad_hessian() Hessian", 0, H_ad(i), 1e-3);
+  }
+  for(int i = 0; i < grad_H_ad.size(); i++) {
+    for(int j = 0; j < grad_H_ad[i].size(); j++) {
+      stan::test::expect_near_rel("gradient() grad Hessian", stan::math::not_a_number(), grad_H_ad[i](i), 1e-3);
+    }
+  }
 }

--- a/test/unit/math/mix/scal/fun/gamma_p_test.cpp
+++ b/test/unit/math/mix/scal/fun/gamma_p_test.cpp
@@ -3,13 +3,6 @@
 #include <stan/math/prim/mat.hpp>
 #include <stan/math/mix/mat.hpp>
 
-struct fun1 {
-  template <typename T>
-  inline T operator()(const Eigen::Matrix<T, Eigen::Dynamic, 1>& x) const {
-    return stan::math::gamma_p(x(0), x(1));
-  }
-};
-
 TEST(mathMixScalFun, gammaP) {
   auto f = [](const auto& x1, const auto& x2) {
     return stan::math::gamma_p(x1, x2);

--- a/test/unit/math/mix/scal/fun/gamma_p_test.cpp
+++ b/test/unit/math/mix/scal/fun/gamma_p_test.cpp
@@ -16,7 +16,12 @@ TEST(mathMixScalFun, gammaP) {
   };
   // common nonzero double arguments excluding positive infinity
   // due to issues with finite diff gradient
-  const std::vector<double> args{ -1.3, 0.49, 0.99, 1.01, stan::math::negative_infinity(), stan::math::not_a_number()};
+  const std::vector<double> args{-1.3,
+                                 0.49,
+                                 0.99,
+                                 1.01,
+                                 stan::math::negative_infinity(),
+                                 stan::math::not_a_number()};
   auto int_args = stan::test::internal::common_nonzero_int_args();
   for (double x1 : args)
     for (double x2 : args) {
@@ -35,11 +40,11 @@ TEST(mathMixScalFun, gammaP) {
       stan::test::expect_ad(f, x1, x2);
     }
   for (double x2 : args) {
-      stan::test::expect_ad(f, stan::math::positive_infinity(), x2);
-    }
+    stan::test::expect_ad(f, stan::math::positive_infinity(), x2);
+  }
   for (int x2 : int_args) {
-      stan::test::expect_ad(f, stan::math::positive_infinity(), x2);
-    }
+    stan::test::expect_ad(f, stan::math::positive_infinity(), x2);
+  }
 }
 
 // separate tests when a is positive_infinity
@@ -51,33 +56,45 @@ TEST(mathMixScalFun, gammaP_pos_inf) {
   fun1 g;
   stan::math::gradient<fun1>(g, x, fx_ad, grad_ad);
   stan::test::expect_near_rel("gradient() val", 1, fx_ad, 1e-8);
-  stan::test::expect_near_rel("gradient() grad z", stan::math::not_a_number(), grad_ad(0), 1e-3);
-  stan::test::expect_near_rel("gradient() grad a", stan::math::not_a_number(), grad_ad(1), 1e-3);
+  stan::test::expect_near_rel("gradient() grad z", stan::math::not_a_number(),
+                              grad_ad(0), 1e-3);
+  stan::test::expect_near_rel("gradient() grad a", stan::math::not_a_number(),
+                              grad_ad(1), 1e-3);
 
   Eigen::Matrix<double, Eigen::Dynamic, 1> grad_ad_fvar;
   stan::math::gradient<double, fun1>(g, x, fx_ad, grad_ad_fvar);
   stan::test::expect_near_rel("gradient_fvar() val", 1, fx_ad, 1e-8);
-  stan::test::expect_near_rel("gradient_fvar() grad z", stan::math::not_a_number(), grad_ad_fvar(0), 1e-3);
-  stan::test::expect_near_rel("gradient_fvar() grad a", stan::math::not_a_number(), grad_ad_fvar(1), 1e-3);
+  stan::test::expect_near_rel("gradient_fvar() grad z",
+                              stan::math::not_a_number(), grad_ad_fvar(0),
+                              1e-3);
+  stan::test::expect_near_rel("gradient_fvar() grad a",
+                              stan::math::not_a_number(), grad_ad_fvar(1),
+                              1e-3);
 
   Eigen::Matrix<double, Eigen::Dynamic, 1> hessian_grad_ad;
   Eigen::MatrixXd H_ad;
   stan::math::hessian(g, x, fx_ad, hessian_grad_ad, H_ad);
   stan::test::expect_near_rel("hessian() val", 1, fx_ad, 1e-8);
-  stan::test::expect_near_rel("hessian() grad z", stan::math::not_a_number(), hessian_grad_ad(0), 1e-3);
-  stan::test::expect_near_rel("hessian() grad a", stan::math::not_a_number(), hessian_grad_ad(1), 1e-3);
-  stan::test::expect_near_rel("hessian() Hessian z", stan::math::not_a_number(), H_ad(0), 1e-3);
-  stan::test::expect_near_rel("hessian() Hessian a", stan::math::not_a_number(), H_ad(1), 1e-3);
-  
+  stan::test::expect_near_rel("hessian() grad z", stan::math::not_a_number(),
+                              hessian_grad_ad(0), 1e-3);
+  stan::test::expect_near_rel("hessian() grad a", stan::math::not_a_number(),
+                              hessian_grad_ad(1), 1e-3);
+  stan::test::expect_near_rel("hessian() Hessian z", stan::math::not_a_number(),
+                              H_ad(0), 1e-3);
+  stan::test::expect_near_rel("hessian() Hessian a", stan::math::not_a_number(),
+                              H_ad(1), 1e-3);
+
   std::vector<Eigen::MatrixXd> grad_H_ad;
   stan::math::grad_hessian(g, x, fx_ad, H_ad, grad_H_ad);
   stan::test::expect_near_rel("grad_hessian() val", 1, fx_ad, 1e-8);
-  for(int i = 0; i < H_ad.size(); i++) {
+  for (int i = 0; i < H_ad.size(); i++) {
     stan::test::expect_near_rel("grad_hessian() Hessian", 0, H_ad(i), 1e-3);
   }
-  for(int i = 0; i < grad_H_ad.size(); i++) {
-    for(int j = 0; j < grad_H_ad[i].size(); j++) {
-      stan::test::expect_near_rel("gradient() grad Hessian", stan::math::not_a_number(), grad_H_ad[i](i), 1e-3);
+  for (int i = 0; i < grad_H_ad.size(); i++) {
+    for (int j = 0; j < grad_H_ad[i].size(); j++) {
+      stan::test::expect_near_rel("gradient() grad Hessian",
+                                  stan::math::not_a_number(), grad_H_ad[i](i),
+                                  1e-3);
     }
   }
 }

--- a/test/unit/math/mix/scal/fun/gamma_p_test.cpp
+++ b/test/unit/math/mix/scal/fun/gamma_p_test.cpp
@@ -1,7 +1,7 @@
 #include <test/unit/math/test_ad.hpp>
 #include <test/unit/math/expect_near_rel.hpp>
-#include <stan/math/prim/mat.hpp>
 #include <stan/math/mix/mat.hpp>
+#include <vector>
 
 TEST(mathMixScalFun, gammaP) {
   auto f = [](const auto& x1, const auto& x2) {

--- a/test/unit/math/mix/scal/fun/gamma_p_test.cpp
+++ b/test/unit/math/mix/scal/fun/gamma_p_test.cpp
@@ -47,14 +47,18 @@ TEST(mathMixScalFun, gammaP) {
   }
 }
 
+
 // separate tests when a is positive_infinity
 TEST(mathMixScalFun, gammaP_pos_inf) {
+  auto g = [](const auto& x) {
+    return stan::math::gamma_p(x(0), x(1));
+  };  
   stan::math::vector_d x(2);
   x << 0.5001, stan::math::positive_infinity();
   Eigen::Matrix<double, Eigen::Dynamic, 1> grad_ad;
   double fx_ad = 1;
-  fun1 g;
-  stan::math::gradient<fun1>(g, x, fx_ad, grad_ad);
+
+  stan::math::gradient(g, x, fx_ad, grad_ad);
   stan::test::expect_near_rel("gradient() val", 1, fx_ad, 1e-8);
   stan::test::expect_near_rel("gradient() grad z", stan::math::not_a_number(),
                               grad_ad(0), 1e-3);
@@ -62,7 +66,7 @@ TEST(mathMixScalFun, gammaP_pos_inf) {
                               grad_ad(1), 1e-3);
 
   Eigen::Matrix<double, Eigen::Dynamic, 1> grad_ad_fvar;
-  stan::math::gradient<double, fun1>(g, x, fx_ad, grad_ad_fvar);
+  stan::math::gradient<double>(g, x, fx_ad, grad_ad_fvar);
   stan::test::expect_near_rel("gradient_fvar() val", 1, fx_ad, 1e-8);
   stan::test::expect_near_rel("gradient_fvar() grad z",
                               stan::math::not_a_number(), grad_ad_fvar(0),

--- a/test/unit/math/mix/scal/fun/gamma_p_test.cpp
+++ b/test/unit/math/mix/scal/fun/gamma_p_test.cpp
@@ -34,7 +34,12 @@ TEST(mathMixScalFun, gammaP) {
     for (int x2 : int_args) {
       stan::test::expect_ad(f, x1, x2);
     }
-  stan::test::expect_ad(f, 0.5001, 1.0001);
+  for (double x2 : args) {
+      stan::test::expect_ad(f, stan::math::positive_infinity(), x2);
+    }
+  for (int x2 : int_args) {
+      stan::test::expect_ad(f, stan::math::positive_infinity(), x2);
+    }
 }
 
 // separate tests when a is positive_infinity

--- a/test/unit/math/prim/scal/fun/gamma_p_test.cpp
+++ b/test/unit/math/prim/scal/fun/gamma_p_test.cpp
@@ -10,8 +10,10 @@ TEST(MathFunctions, gamma_p) {
   EXPECT_FLOAT_EQ(0.82755178, gamma_p(0.1, 0.1));
   EXPECT_FLOAT_EQ(0.76189667, gamma_p(3.0, 4.0));
   EXPECT_FLOAT_EQ(0.35276812, gamma_p(4.0, 3.0));
+  EXPECT_FLOAT_EQ(1, gamma_p(1.0, stan::math::positive_infinity()));
   EXPECT_THROW(gamma_p(-4.0, 3.0), std::domain_error);
   EXPECT_THROW(gamma_p(4.0, -3.0), std::domain_error);
+  EXPECT_THROW(gamma_p(1.0, stan::math::negative_infinity()), std::domain_error);
 }
 
 TEST(MathFunctions, gamma_p_nan) {

--- a/test/unit/math/prim/scal/fun/gamma_p_test.cpp
+++ b/test/unit/math/prim/scal/fun/gamma_p_test.cpp
@@ -13,7 +13,8 @@ TEST(MathFunctions, gamma_p) {
   EXPECT_FLOAT_EQ(1, gamma_p(1.0, stan::math::positive_infinity()));
   EXPECT_THROW(gamma_p(-4.0, 3.0), std::domain_error);
   EXPECT_THROW(gamma_p(4.0, -3.0), std::domain_error);
-  EXPECT_THROW(gamma_p(1.0, stan::math::negative_infinity()), std::domain_error);
+  EXPECT_THROW(gamma_p(1.0, stan::math::negative_infinity()),
+               std::domain_error);
 }
 
 TEST(MathFunctions, gamma_p_nan) {


### PR DESCRIPTION
## Summary

This PR addresses the issues with testing the `gamma_p` function when `a = +Inf`. [See discussion](https://github.com/stan-dev/math/pull/1524#issuecomment-567042857) for more details.

This still tests `gamma_p` for all common nonzero arguments, but excludes cases where `a=+Inf` which are now tested separately without using finite diff.

Also adds a prim test for the same case. This will only pass with Boost 1.72 so this PR is made to the boost upgrade branch. Once its approved we can also merge the boost upgrade PR.

## Tests

This PR is only tests.

## Side Effects

/

## Checklist

- [x] Math issue #1523 

- [x] Copyright holder: Rok Češnovar

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)