### PR TITLE
Initialize variables in tests

### DIFF
--- a/test/unit/math/prim/mat/fun/cholesky_corr_transform_test.cpp
+++ b/test/unit/math/prim/mat/fun/cholesky_corr_transform_test.cpp
@@ -55,7 +55,7 @@ void test_cholesky_correlation_values(
       EXPECT_FLOAT_EQ(L(m, n), x(m, n));
 
   // test transform roundtrip with Jacobian (Jacobian itself tested above)
-  double lp;
+  double lp = 0;
   Matrix<double, Dynamic, Dynamic> x2
       = stan::math::cholesky_corr_constrain(y, K, lp);
 

--- a/test/unit/math/prim/mat/fun/cholesky_factor_transform_test.cpp
+++ b/test/unit/math/prim/mat/fun/cholesky_factor_transform_test.cpp
@@ -29,7 +29,7 @@ TEST(ProbTransform, choleskyFactorLogJacobian) {
   using Eigen::Matrix;
   using stan::math::cholesky_factor_constrain;
 
-  double lp;
+  double lp = 0;
   Matrix<double, Dynamic, 1> x(3);
 
   x.resize(1);

--- a/test/unit/math/prim/mat/fun/simplex_transform_test.cpp
+++ b/test/unit/math/prim/mat/fun/simplex_transform_test.cpp
@@ -36,7 +36,7 @@ TEST(prob_transform, simplex_rt) {
 TEST(prob_transform, simplex_match) {
   Matrix<double, Dynamic, 1> x(3);
   x << 1.0, -1.0, 2.0;
-  double lp;
+  double lp = 0;
   Matrix<double, Dynamic, 1> y = stan::math::simplex_constrain(x);
   Matrix<double, Dynamic, 1> y2 = stan::math::simplex_constrain(x, lp);
 

--- a/test/unit/math/prim/mat/fun/unit_vector_transform_test.cpp
+++ b/test/unit/math/prim/mat/fun/unit_vector_transform_test.cpp
@@ -38,7 +38,7 @@ TEST(prob_transform, unit_vector_rt) {
 TEST(prob_transform, unit_vector_match) {
   Matrix<double, Dynamic, 1> x(3);
   x << 1.0, -1.0, 2.0;
-  double lp;
+  double lp = 0;
   using stan::math::unit_vector_constrain;
   Matrix<double, Dynamic, 1> y = unit_vector_constrain(x);
   Matrix<double, Dynamic, 1> y2 = stan::math::unit_vector_constrain(x, lp);


### PR DESCRIPTION
## Summary

Some tests used passed the `lp` variable before being initialized to functions that modify it. I run them through valgrind and it didn't complain, although I would have thought they would be a problem. As the tests were not checking the value of this variable after the call to the function, this change is mainly for coding style. Fixes #827.

## Tests
No new tests.

## Side Effects

None.

## Checklist

- [X] Math issue #827

- [X] Copyright holder: Marco Colombo

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [X] the new changes are tested
