### PR TITLE
[WIP] Bugfix/issue 1533 test ad

### DIFF
--- a/test/unit/math/test_ad.hpp
+++ b/test/unit/math/test_ad.hpp
@@ -487,13 +487,6 @@ void expect_ad_vv(const ad_tolerances& tols, const F& f, const T1& x1,
 
 template <typename F, typename T2>
 void expect_ad_vv(const ad_tolerances& tols, const F& f, int x1, const T2& x2) {
-  try {
-    f(x1, x2);
-  } catch (...) {
-    expect_all_throw(f, x1, x2);
-    return;
-  }
-
   double x1_dbl = static_cast<double>(x1);
 
   // expect same result with int or and cast to double
@@ -509,13 +502,6 @@ void expect_ad_vv(const ad_tolerances& tols, const F& f, int x1, const T2& x2) {
 
 template <typename F, typename T1>
 void expect_ad_vv(const ad_tolerances& tols, const F& f, const T1& x1, int x2) {
-  try {
-    f(x1, x2);
-  } catch (...) {
-    expect_all_throw(f, x1, x2);
-    return;
-  }
-
   double x2_dbl = static_cast<double>(x2);
 
   // expect same result with int or and cast to double
@@ -647,13 +633,6 @@ void expect_ad_vvv(const ad_tolerances& tols, const F& f, const T1& x1,
 template <typename F, typename T3>
 void expect_ad_vvv(const ad_tolerances& tols, const F& f, int x1, int x2,
                    const T3& x3) {
-  try {
-    f(x1, x2, x3);
-  } catch (...) {
-    expect_all_throw(f, x1, x2, x3);
-    return;
-  }
-
   double x1_dbl = static_cast<double>(x1);
   double x2_dbl = static_cast<double>(x2);
 
@@ -689,13 +668,6 @@ void expect_ad_vvv(const ad_tolerances& tols, const F& f, int x1, int x2,
 template <typename F, typename T2, typename T3>
 void expect_ad_vvv(const ad_tolerances& tols, const F& f, int x1, const T2& x2,
                    const T3& x3) {
-  try {
-    f(x1, x2, x3);
-  } catch (...) {
-    expect_all_throw(f, x1, x2, x3);
-    return;
-  }
-
   double x1_dbl = static_cast<double>(x1);
 
   // test all promotion patterns
@@ -726,13 +698,6 @@ void expect_ad_vvv(const ad_tolerances& tols, const F& f, int x1, const T2& x2,
 template <typename F, typename T1, typename T3>
 void expect_ad_vvv(const ad_tolerances& tols, const F& f, const T1& x1, int x2,
                    const T3& x3) {
-  try {
-    f(x1, x2, x3);
-  } catch (...) {
-    expect_all_throw(f, x1, x2, x3);
-    return;
-  }
-
   double x2_dbl = static_cast<double>(x2);
 
   // test promotion
@@ -763,13 +728,6 @@ void expect_ad_vvv(const ad_tolerances& tols, const F& f, const T1& x1, int x2,
 template <typename F, typename T1, typename T2>
 void expect_ad_vvv(const ad_tolerances& tols, const F& f, const T1& x1,
                    const T2& x2, int x3) {
-  try {
-    f(x1, x2, x3);
-  } catch (...) {
-    expect_all_throw(f, x1, x2, x3);
-    return;
-  }
-
   double x3_dbl = static_cast<double>(x3);
 
   // test promotion
@@ -799,13 +757,6 @@ void expect_ad_vvv(const ad_tolerances& tols, const F& f, const T1& x1,
 template <typename F, typename T2>
 void expect_ad_vvv(const ad_tolerances& tols, const F& f, int x1, const T2& x2,
                    int x3) {
-  try {
-    f(x1, x2, x3);
-  } catch (...) {
-    expect_all_throw(f, x1, x2, x3);
-    return;
-  }
-
   double x1_dbl = static_cast<double>(x1);
   double x3_dbl = static_cast<double>(x3);
 
@@ -840,13 +791,6 @@ void expect_ad_vvv(const ad_tolerances& tols, const F& f, int x1, const T2& x2,
 template <typename F, typename T1>
 void expect_ad_vvv(const ad_tolerances& tols, const F& f, const T1& x1, int x2,
                    int x3) {
-  try {
-    f(x1, x2, x3);
-  } catch (...) {
-    expect_all_throw(f, x1, x2, x3);
-    return;
-  }
-
   double x2_dbl = static_cast<double>(x2);
   double x3_dbl = static_cast<double>(x3);
 

--- a/test/unit/math/test_ad_test.cpp
+++ b/test/unit/math/test_ad_test.cpp
@@ -69,7 +69,7 @@ void expect_test_combinator_to_fail(const G& test_combinator, const F& f,
       "Expected: 1 non-fatal failure");
 }
 
-TEST(test_unit_math_test_mix, test_expect_test_combinator_to_fail) {
+TEST(test_unit_math_test_ad, test_expect_test_combinator_to_fail) {
   auto combinator_that_succeeds = [](auto& f) {};
   auto combinator_that_fails = [](auto& f) { ADD_FAILURE() << ""; };
   auto combinator_that_fails_twice = [](auto& f) {
@@ -148,7 +148,7 @@ T f_match(const T& x) {
   return -2 * x;
 }
 double f_match(const double& x) { return -2 * x; }
-TEST(test_ad, match) {
+TEST(test_unit_math_test_ad, match) {
   double x = 3.2;
   auto g = [](const auto& u) { return f_match(u); };
   stan::test::expect_ad(g, x);
@@ -162,7 +162,7 @@ T f_mismatch(const T& x) {
   return -2 * x;
 }
 stan::math::var f_mismatch(const stan::math::var& x) { return 2 * x; }
-TEST(test_ad, mismatch) {
+TEST(test_unit_math_test_ad, mismatch) {
   double x = 3.2;
   auto g = [](const auto& u) { return f_mismatch(u); };
   expect_expect_ad_failure(g, x);
@@ -180,7 +180,7 @@ double f_misthrow(const double& x) {
   return -2 * x;
 }
 
-TEST(test_ad, misthrow) {
+TEST(test_unit_math_test_ad, misthrow) {
   double x = 1.73;
   auto h = [](const auto& u) { return f_misthrow(u); };
   expect_expect_ad_failure(h, x);
@@ -203,7 +203,7 @@ stan::return_type_t<T1> binary_function_misthrow(T1 x1, int x2) {
   return x1vec[0] + x2vec[0];
 }
 
-TEST(test_ad, misthrow_binary) {
+TEST(test_unit_math_test_ad, misthrow_binary) {
   auto g = [](const auto& x1, const auto& x2) {
     return binary_function_misthrow(x1, x2);
   };
@@ -234,7 +234,7 @@ stan::return_type_t<T1, stan::math::var> binary_function_misthrow_2(
   return x1vec[0] + x2vec[0];
 }
 
-TEST(test_ad, misthrow_binary_2) {
+TEST(test_unit_math_test_ad, misthrow_binary_2) {
   auto g = [](const auto& x1, const auto& x2) {
     return binary_function_misthrow_2(x1, x2);
   };
@@ -263,7 +263,7 @@ stan::return_type_t<T1, T2> ternary_function_misthrow(T1 x1, T2 x2, int x3) {
   return x1vec[0] + x2vec[0] + x3vec[0];
 }
 
-TEST(test_ad, misthrow_ternary) {
+TEST(test_unit_math_test_ad, misthrow_ternary) {
   auto g = [](const auto& x1, const auto& x2, const auto& x3) {
     return ternary_function_misthrow(x1, x2, x3);
   };
@@ -299,7 +299,7 @@ stan::return_type_t<T1, T2, stan::math::var> ternary_function_misthrow_2(
   return x1vec[0] + x2vec[0] + x3vec[0];
 }
 
-TEST(test_ad, misthrow_ternary_2) {
+TEST(test_unit_math_test_ad, misthrow_ternary_2) {
   auto g = [](const auto& x1, const auto& x2, const auto& x3) {
     return ternary_function_misthrow_2(x1, x2, x3);
   };
@@ -332,7 +332,7 @@ struct foo_fun {
 int foo_fun::calls_int_ = -1;
 int foo_fun::calls_t_ = -1;
 
-TEST(test_ad, integerGetsPassed) {
+TEST(test_unit_math_test_ad, integerGetsPassed) {
   // double arguments will not call int version
   foo_fun h;
   foo_fun::calls_int_ = 0;
@@ -416,7 +416,7 @@ int bar_fun::calls_int1_ = -1;
 int bar_fun::calls_int2_ = -1;
 int bar_fun::calls_int12_ = -1;
 
-TEST(testAd, integerGetsPassedBinary) {
+TEST(test_unit_math_test_ad, integerGetsPassedBinary) {
   bar_fun f;
 
   bar_fun::reset();
@@ -485,7 +485,7 @@ inline typename stan::math::apply_scalar_unary<baz_fun, T>::return_t baz(
   return stan::math::apply_scalar_unary<baz_fun, T>::apply(x);
 }
 
-TEST(testAd, integerGetsPassedVectorized) {
+TEST(test_unit_math_test_ad, integerGetsPassedVectorized) {
   auto h = [&](auto x) { return baz(x); };
 
   baz_int = 0;
@@ -617,7 +617,7 @@ int ternary_fun::calls_int13_ = 0;
 int ternary_fun::calls_int23_ = 0;
 int ternary_fun::calls_int123_ = 0;
 
-TEST(testUnitMath, testAdTernaryIntPassed) {
+TEST(test_unit_math_test_ad, testAdTernaryIntPassed) {
   ternary_fun f;
 
   // { }


### PR DESCRIPTION
#  Summary

Fixes #1533. The catch_all_throw calls I deleted here are redundant. catch_all_throw is called properly on the serialized version of the functor down in expect_ad_helper.

I also introduced a function expect_expect_ad_failure(f, xs...) which is just a negated form of expect_ad. It succeeds if and only if expect_ad fails. This function is currently confined to test_ad_test.cpp, where it is used to verify that expect_ad catches certain types of failures. GTEST provides only lukewarm support for writing such a negated test, so I had to jump through a couple hoops.

## Tests

Test that expect_ad can be called with combinations of ints and Ts, for some T which is not a double. Test that mismatched exceptions are still being caught.

## Side Effects

None.

## Checklist

- [X] Math issue #1533 

- [X] Copyright holder: Peter Wicks Stringfield

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [X] the new changes are tested
