### PR TITLE
Remove extra parens around equality checks

### DIFF
--- a/stan/math/prim/mat/prob/lkj_corr_cholesky_lpdf.hpp
+++ b/stan/math/prim/mat/prob/lkj_corr_cholesky_lpdf.hpp
@@ -39,8 +39,7 @@ return_type_t<T_covar, T_shape> lkj_corr_cholesky_lpdf(
     for (int k = 0; k < Km1; k++) {
       values(k) = (Km1 - k - 1) * log_diagonals(k);
     }
-    if ((eta == 1.0)
-        && stan::is_constant_all<typename stan::scalar_type<T_shape> >::value) {
+    if (eta == 1.0 && is_constant_all<scalar_type<T_shape>>::value) {
       lp += sum(values);
       return (lp);
     }

--- a/stan/math/prim/mat/prob/lkj_corr_lpdf.hpp
+++ b/stan/math/prim/mat/prob/lkj_corr_lpdf.hpp
@@ -62,8 +62,7 @@ return_type_t<T_y, T_shape> lkj_corr_lpdf(
     lp += do_lkj_constant(eta, K);
   }
 
-  if ((eta == 1.0)
-      && stan::is_constant_all<typename stan::scalar_type<T_shape> >::value) {
+  if (eta == 1.0 && is_constant_all<scalar_type<T_shape>>::value) {
     return lp;
   }
 

--- a/stan/math/prim/scal/fun/lub_constrain.hpp
+++ b/stan/math/prim/scal/fun/lub_constrain.hpp
@@ -56,17 +56,17 @@ inline return_type_t<T, L, U> lub_constrain(const T& x, const L& lb,
   if (x > 0) {
     inv_logit_x = inv_logit(x);
     // Prevent x from reaching one unless it really really should.
-    if ((x < INFTY) && (inv_logit_x == 1)) {
+    if (x < INFTY && inv_logit_x == 1) {
       inv_logit_x = 1 - 1e-15;
     }
   } else {
     inv_logit_x = inv_logit(x);
     // Prevent x from reaching zero unless it really really should.
-    if ((x > NEGATIVE_INFTY) && (inv_logit_x == 0)) {
+    if (x > NEGATIVE_INFTY && inv_logit_x == 0) {
       inv_logit_x = 1e-15;
     }
   }
-  return fma((ub - lb), inv_logit_x, lb);
+  return fma(ub - lb, inv_logit_x, lb);
 }
 
 /**
@@ -128,7 +128,7 @@ inline return_type_t<T, L, U> lub_constrain(const T& x, const L& lb,
     inv_logit_x = inv_logit(x);
     lp += log(ub - lb) - x - 2 * log1p(exp_minus_x);
     // Prevent x from reaching one unless it really really should.
-    if ((x < INFTY) && (inv_logit_x == 1)) {
+    if (x < INFTY && inv_logit_x == 1) {
       inv_logit_x = 1 - 1e-15;
     }
   } else {
@@ -136,11 +136,11 @@ inline return_type_t<T, L, U> lub_constrain(const T& x, const L& lb,
     inv_logit_x = inv_logit(x);
     lp += log(ub - lb) + x - 2 * log1p(exp_x);
     // Prevent x from reaching zero unless it really really should.
-    if ((x > NEGATIVE_INFTY) && (inv_logit_x == 0)) {
+    if (x > NEGATIVE_INFTY && inv_logit_x == 0) {
       inv_logit_x = 1e-15;
     }
   }
-  return fma((ub - lb), inv_logit_x, lb);
+  return fma(ub - lb, inv_logit_x, lb);
 }
 
 }  // namespace math

--- a/stan/math/prim/scal/fun/trigamma.hpp
+++ b/stan/math/prim/scal/fun/trigamma.hpp
@@ -48,14 +48,14 @@ inline T trigamma_impl(const T& x) {
 
   // negative integers and zero return postiive infinity
   // see http://mathworld.wolfram.com/PolygammaFunction.html
-  if ((x <= 0.0) && (floor(x) == x)) {
+  if (x <= 0.0 && floor(x) == x) {
     value = positive_infinity();
     return value;
   }
 
   // negative non-integers: use the reflection formula
   // see http://mathworld.wolfram.com/PolygammaFunction.html
-  if ((x <= 0) && (floor(x) != x)) {
+  if (x <= 0 && floor(x) != x) {
     value = -trigamma_impl(-x + 1.0) + square(pi() / sin(-pi() * x));
     return value;
   }


### PR DESCRIPTION
## Summary

Besides the extra parens mentioned in #593, I found a few more. The only other case I spotted but decided not to change was in `stan/math/prim/scal/fun/sign.hpp`, as I thought it would be slightly more clear as is:
```
return (z == 0) ? 0 : z < 0 ? -1 : 1;
```
I also looked around inequality checks, but found none to fix. Fixes #593. 

## Tests

Nothing new.

## Side Effects

None.

## Checklist

- [X] Math issue #593

- [X] Copyright holder: Marco Colombo

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [X] the new changes are tested
