### PR TITLE
Documentation fixups for expect_ad.

### DIFF
--- a/test/unit/math/test_ad.hpp
+++ b/test/unit/math/test_ad.hpp
@@ -27,6 +27,7 @@ namespace internal {
  * documentation for `expect_near`.
  *
  * @tparam F type of functor
+ * @param tols tolerances for test
  * @param f functor to test
  * @param x value to test
  * @param fx expected value
@@ -65,6 +66,7 @@ void test_gradient(const ad_tolerances& tols, const F& f,
  * documentation for `expect_near`.
  *
  * @tparam F type of functor
+ * @param tols tolerances for test
  * @param f functor to test
  * @param x value to test
  * @param fx expected value
@@ -104,6 +106,7 @@ void test_gradient_fvar(const ad_tolerances& tols, const F& f,
  * documentation for `expect_near`.
  *
  * @tparam F type of functor
+ * @param tols tolerances for test
  * @param f functor to test
  * @param x value to test
  * @param fx expected value
@@ -147,6 +150,7 @@ void test_hessian_fvar(const ad_tolerances& tols, const F& f,
  * documentation for `expect_near`.
  *
  * @tparam F type of functor
+ * @param tols tolerances for test
  * @param f functor to test
  * @param x value to test
  * @param fx expected value
@@ -188,6 +192,7 @@ void test_hessian(const ad_tolerances& tols, const F& f,
  * documentation for `expect_near`.
  *
  * @tparam F type of functor
+ * @param tols tolerances for test
  * @param f functor to test
  * @param x value to test
  * @param fx expected value
@@ -218,7 +223,7 @@ void test_grad_hessian(const ad_tolerances& tols, const F& f,
 
 /**
  * For the specified functor and argument, test that automatic
- * differentiation provides the value as the double-based version and
+ * differentiation provides the same value as the double-based version and
  * the same derivatives as finite differences over the double
  * version.  It also tests that an autodiff version throws an
  * exception if and only if the double-based version throws an
@@ -228,14 +233,8 @@ void test_grad_hessian(const ad_tolerances& tols, const F& f,
  * <p>The functor to test must define `T operator()(const
  * Matrix<T, -1, 1>& x) const;` for relevant `double` and autodiff types.
  *
- * <p>All results are tested for relative tolerance at thresholds
- * `1e-8` for values, `1e-4` for gradients (1st order derivatives),
- * `1e-3` for Hessians (2nd order derivatives), and `1e-2` for
- * gradients of Hessians (3rd order derivatives).  The reason for such
- * seemingly lax tests is that finite differences can be highly
- * unstable.
- *
  * @tparam G type of polymorphic functor
+ * @param tols tolerances for test
  * @param g polymorphic functor from vectors to scalars
  * @param x argument to test
  */
@@ -360,6 +359,7 @@ void expect_all_throw(const F& f, double x1, double x2, double x3) {
  * returning a single component of the value
  * @tparam Ts type pack for arguments to original functor with double
  * scalar types
+ * @param tols tolerances for test
  * @param f functor to evaluate
  * @param g serialized functor taking an Eigen vector and returning a
  * serialized container of the original output
@@ -396,6 +396,7 @@ void expect_ad_helper(const ad_tolerances& tols, const F& f, const G& g,
  *
  * @tparam F type of functor to test
  * @tparam T type of first argument with double-based scalar
+ * @param tols tolerances for test
  * @param f functor to test
  * @param x argument to test
  */
@@ -421,6 +422,7 @@ void expect_ad_v(const ad_tolerances& tols, const F& f, const T& x) {
  *
  * @tparam F type of functor to test
  * @tparam T type of first argument with double-based scalar
+ * @param tols tolerances for test
  * @param f functor to test
  * @param x argument to test
  */
@@ -453,6 +455,8 @@ void expect_ad_v(const ad_tolerances& tols, const F& f, int x) {
  * @tparam F type of functor to test
  * @tparam T1 type of first argument with double-based scalar
  * @tparam T2 type of second argument with double-based scalar
+ * @param tols tolerances for test
+ * @param f functor to test
  * @param x1 first argument
  * @param x2 second argument
  */
@@ -562,6 +566,8 @@ void expect_ad_vv(const ad_tolerances& tols, const F& f, int x1, int x2) {
  * @tparam T1 type of first argument with double-based scalar
  * @tparam T2 type of second argument with double-based scalar
  * @tparam T3 type of third argument with double-based scalar
+ * @param tols tolerances for test
+ * @param f functor to test
  * @param x1 first argument
  * @param x2 second argument
  * @param x3 third argument
@@ -632,18 +638,6 @@ void expect_ad_vvv(const ad_tolerances& tols, const F& f, const T1& x1,
                              x3);
 }
 
-/**
- * Test that the specified binary functor and arguments produce for
- * every autodiff type the same value as the double-based version and
- * the same derivatives as finite differences when both arguments are
- * autodiff variables.
- *
- * @tparam F type of functor to test
- * @tparam T3 type of third argument with double-based scalar
- * @param x1 first argument
- * @param x2 second argument
- * @param x3 third argument
- */
 template <typename F, typename T3>
 void expect_ad_vvv(const ad_tolerances& tols, const F& f, int x1, int x2,
                    const T3& x3) {
@@ -673,19 +667,6 @@ void expect_ad_vvv(const ad_tolerances& tols, const F& f, int x1, int x2,
   expect_ad_vv(tols, g13, x1, x3);
 }
 
-/**
- * Test that the specified ternary functor and arguments produce for
- * every autodiff type the same value as the double-based version and
- * the same derivatives as finite differences when both arguments are
- * autodiff variables.
- *
- * @tparam F type of functor to test
- * @tparam T2 type of second argument with double-based scalar
- * @tparam T3 type of third argument with double-based scalar
- * @param x1 first argument
- * @param x2 second argument
- * @param x3 third argument
- */
 template <typename F, typename T2, typename T3>
 void expect_ad_vvv(const ad_tolerances& tols, const F& f, int x1, const T2& x2,
                    const T3& x3) {
@@ -710,19 +691,6 @@ void expect_ad_vvv(const ad_tolerances& tols, const F& f, int x1, const T2& x2,
   expect_ad_vv(tols, g23, x2, x3);
 }
 
-/**
- * Test that the specified ternary functor and arguments produce for
- * every autodiff type the same value as the double-based version and
- * the same derivatives as finite differences when both arguments are
- * autodiff variables.
- *
- * @tparam F type of functor to test
- * @tparam T1 type of first argument with double-based scalar
- * @tparam T3 type of third argument with double-based scalar
- * @param x1 first argument
- * @param x2 second argument
- * @param x3 third argument
- */
 template <typename F, typename T1, typename T3>
 void expect_ad_vvv(const ad_tolerances& tols, const F& f, const T1& x1, int x2,
                    const T3& x3) {
@@ -747,19 +715,6 @@ void expect_ad_vvv(const ad_tolerances& tols, const F& f, const T1& x1, int x2,
   expect_ad_vv(tols, g13, x1, x3);
 }
 
-/**
- * Test that the specified ternary functor and arguments produce for
- * every autodiff type the same value as the double-based version and
- * the same derivatives as finite differences when both arguments are
- * autodiff variables.
- *
- * @tparam F type of functor to test
- * @tparam T1 type of first argument with double-based scalar
- * @tparam T2 type of second argument with double-based scalar
- * @param x1 first argument
- * @param x2 second argument
- * @param x3 third argument
- */
 template <typename F, typename T1, typename T2>
 void expect_ad_vvv(const ad_tolerances& tols, const F& f, const T1& x1,
                    const T2& x2, int x3) {
@@ -784,18 +739,6 @@ void expect_ad_vvv(const ad_tolerances& tols, const F& f, const T1& x1,
   expect_ad_vv(tols, g12, x1, x2);
 }
 
-/**
- * Test that the specified ternary functor and arguments produce for
- * every autodiff type the same value as the double-based version and
- * the same derivatives as finite differences when both arguments are
- * autodiff variables.
- *
- * @tparam F type of functor to test
- * @tparam T2 type of second argument with double-based scalar
- * @param x1 first argument
- * @param x2 second argument
- * @param x3 third argument
- */
 template <typename F, typename T2>
 void expect_ad_vvv(const ad_tolerances& tols, const F& f, int x1, const T2& x2,
                    int x3) {
@@ -825,18 +768,6 @@ void expect_ad_vvv(const ad_tolerances& tols, const F& f, int x1, const T2& x2,
   expect_ad_vv(tols, g12, x1, x2);
 }
 
-/**
- * Test that the specified ternary functor and arguments produce for
- * every autodiff type the same value as the double-based version and
- * the same derivatives as finite differences when both arguments are
- * autodiff variables.
- *
- * @tparam F type of functor to test
- * @tparam T1 type of first argument with double-based scalar
- * @param x1 first argument
- * @param x2 second argument
- * @param x3 third argument
- */
 template <typename F, typename T1>
 void expect_ad_vvv(const ad_tolerances& tols, const F& f, const T1& x1, int x2,
                    int x3) {
@@ -1135,7 +1066,7 @@ void expect_ad(const F& f, const T& x) {
  * @tparam T2 type of double- or int-based second argument
  * @param tols tolerances for test
  * @param f functor to test
- * param x1 first argument to test
+ * @param x1 first argument to test
  * @param x2 second argument to test
  */
 template <typename F, typename T1, typename T2>
@@ -1147,13 +1078,13 @@ void expect_ad(const ad_tolerances& tols, const F& f, const T1& x1,
 /**
  * Test that the specified binary function produces autodiff values
  * and derivatives consistent with primitive int and double inputs and
- * finite differences.  Uses default tolerances.
+ * finite differences at default tolerances.
  *
  * @tparam F type of binary polymorphic functor to test
  * @tparam T1 type of double- or int-based first argument
  * @tparam T2 type of double- or int-based second argument
  * @param f functor to test
- * param x1 first argument to test
+ * @param x1 first argument to test
  * @param x2 second argument to test
  */
 template <typename F, typename T1, typename T2>
@@ -1174,7 +1105,7 @@ void expect_ad(const F& f, const T1& x1, const T2& x2) {
  * @tparam T3 type of double- or int-based third argument
  * @param tols tolerances for test
  * @param f functor to test
- * param x1 first argument to test
+ * @param x1 first argument to test
  * @param x2 second argument to test
  * @param x3 third argument to test
  */
@@ -1187,14 +1118,14 @@ void expect_ad(const ad_tolerances& tols, const F& f, const T1& x1,
 /**
  * Test that the specified ternary function produces autodiff values
  * and derivatives consistent with primitive int and double inputs and
- * finite differences.  Uses default tolerances.
+ * finite differences at default tolerances.
  *
  * @tparam F type of binary polymorphic functor to test
  * @tparam T1 type of double- or int-based first argument
  * @tparam T2 type of double- or int-based second argument
  * @tparam T3 type of double- or int-based third argument
  * @param f functor to test
- * param x1 first argument to test
+ * @param x1 first argument to test
  * @param x2 second argument to test
  * @param x3 third argument to test
  */
@@ -1212,6 +1143,7 @@ void expect_ad(const F& f, const T1& x1, const T2& x2, const T3& x3) {
  *
  * @tparam F type of poymorphic, vectorized functor to test
  * @tparam T1 type of first argument (integer or double)
+ * @param tols tolerances for test
  * @param f functor to test
  * @param x1 value to test
  */
@@ -1451,8 +1383,8 @@ void expect_unary_vectorized_helper(const ad_tolerances& tols, const F& f, T x,
 }  // namespace internal
 
 /**
- * Teset that the specified vectorized unary function has value and
- * derivative behavior matching the primtive instantiation with finite
+ * Test that the specified vectorized unary function has value and
+ * derivative behavior matching the primitive instantiation with finite
  * differences.  Tests both scalar and container behavior.  Integer
  * arguments will be preserved through to function calls.
  *
@@ -1473,10 +1405,8 @@ void expect_unary_vectorized(const ad_tolerances& tols, const F& f, Ts... xs) {
  * values and finite differences.  Tests both scalars and containers.
  *
  * @tparam F type of function to test
- * @tparam T type of first argument to test
  * @tparam Ts type of remaining arguments to test
  * @param f function to test
- * @param x argument to test
  * @param xs arguments to test
  */
 template <typename F, typename... Ts>
@@ -1535,7 +1465,7 @@ void expect_common_comparison(const F& f) {
 /**
  * Test that the two specified functions either both throw or have the
  * same return value for the specified argument.  If the argument is
- * an intger, it will be passed through to the functions as such.
+ * an integer, it will be passed through to the functions as such.
  *
  * @tparam F1 type of first function
  * @tparam F2 type of second function


### PR DESCRIPTION
## Summary

Some documentation cleanup in test_ad. expect_ad_vvv had one copy of its docs for each of its overloads, but expect_ad_vv had only a single copy on the first overload. For consistency I deleted the copies on expect_ad_vvv. It's internal use, so anyone reading that doc is looking at the code anyway and they can scroll up.

## Tests

None.

## Side Effects

None.

## Checklist

- [X] Math issue #1533

- [X] Copyright holder: Peter Wicks Stringfield

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [X] the new changes are tested
