### PR TITLE
Bugfix/issue 1533 test ad, attempt 2

### DIFF
--- a/test/unit/math/test_ad.hpp
+++ b/test/unit/math/test_ad.hpp
@@ -487,13 +487,6 @@ void expect_ad_vv(const ad_tolerances& tols, const F& f, const T1& x1,
 
 template <typename F, typename T2>
 void expect_ad_vv(const ad_tolerances& tols, const F& f, int x1, const T2& x2) {
-  try {
-    f(x1, x2);
-  } catch (...) {
-    expect_all_throw(f, x1, x2);
-    return;
-  }
-
   double x1_dbl = static_cast<double>(x1);
 
   // expect same result with int or and cast to double
@@ -509,13 +502,6 @@ void expect_ad_vv(const ad_tolerances& tols, const F& f, int x1, const T2& x2) {
 
 template <typename F, typename T1>
 void expect_ad_vv(const ad_tolerances& tols, const F& f, const T1& x1, int x2) {
-  try {
-    f(x1, x2);
-  } catch (...) {
-    expect_all_throw(f, x1, x2);
-    return;
-  }
-
   double x2_dbl = static_cast<double>(x2);
 
   // expect same result with int or and cast to double
@@ -647,13 +633,6 @@ void expect_ad_vvv(const ad_tolerances& tols, const F& f, const T1& x1,
 template <typename F, typename T3>
 void expect_ad_vvv(const ad_tolerances& tols, const F& f, int x1, int x2,
                    const T3& x3) {
-  try {
-    f(x1, x2, x3);
-  } catch (...) {
-    expect_all_throw(f, x1, x2, x3);
-    return;
-  }
-
   double x1_dbl = static_cast<double>(x1);
   double x2_dbl = static_cast<double>(x2);
 
@@ -689,13 +668,6 @@ void expect_ad_vvv(const ad_tolerances& tols, const F& f, int x1, int x2,
 template <typename F, typename T2, typename T3>
 void expect_ad_vvv(const ad_tolerances& tols, const F& f, int x1, const T2& x2,
                    const T3& x3) {
-  try {
-    f(x1, x2, x3);
-  } catch (...) {
-    expect_all_throw(f, x1, x2, x3);
-    return;
-  }
-
   double x1_dbl = static_cast<double>(x1);
 
   // test all promotion patterns
@@ -726,13 +698,6 @@ void expect_ad_vvv(const ad_tolerances& tols, const F& f, int x1, const T2& x2,
 template <typename F, typename T1, typename T3>
 void expect_ad_vvv(const ad_tolerances& tols, const F& f, const T1& x1, int x2,
                    const T3& x3) {
-  try {
-    f(x1, x2, x3);
-  } catch (...) {
-    expect_all_throw(f, x1, x2, x3);
-    return;
-  }
-
   double x2_dbl = static_cast<double>(x2);
 
   // test promotion
@@ -763,13 +728,6 @@ void expect_ad_vvv(const ad_tolerances& tols, const F& f, const T1& x1, int x2,
 template <typename F, typename T1, typename T2>
 void expect_ad_vvv(const ad_tolerances& tols, const F& f, const T1& x1,
                    const T2& x2, int x3) {
-  try {
-    f(x1, x2, x3);
-  } catch (...) {
-    expect_all_throw(f, x1, x2, x3);
-    return;
-  }
-
   double x3_dbl = static_cast<double>(x3);
 
   // test promotion
@@ -799,13 +757,6 @@ void expect_ad_vvv(const ad_tolerances& tols, const F& f, const T1& x1,
 template <typename F, typename T2>
 void expect_ad_vvv(const ad_tolerances& tols, const F& f, int x1, const T2& x2,
                    int x3) {
-  try {
-    f(x1, x2, x3);
-  } catch (...) {
-    expect_all_throw(f, x1, x2, x3);
-    return;
-  }
-
   double x1_dbl = static_cast<double>(x1);
   double x3_dbl = static_cast<double>(x3);
 
@@ -840,13 +791,6 @@ void expect_ad_vvv(const ad_tolerances& tols, const F& f, int x1, const T2& x2,
 template <typename F, typename T1>
 void expect_ad_vvv(const ad_tolerances& tols, const F& f, const T1& x1, int x2,
                    int x3) {
-  try {
-    f(x1, x2, x3);
-  } catch (...) {
-    expect_all_throw(f, x1, x2, x3);
-    return;
-  }
-
   double x2_dbl = static_cast<double>(x2);
   double x3_dbl = static_cast<double>(x3);
 

--- a/test/unit/math/test_ad.hpp
+++ b/test/unit/math/test_ad.hpp
@@ -489,8 +489,10 @@ template <typename F, typename T2>
 void expect_ad_vv(const ad_tolerances& tols, const F& f, int x1, const T2& x2) {
   double x1_dbl = static_cast<double>(x1);
 
-  // expect same result with int or and cast to double
-  expect_near_rel("expect_ad_vv(int, T2)", f(x1, x2), f(x1_dbl, x2));
+  // test value, exception handling checked recursively
+  try {
+    expect_near_rel("expect_ad_vv(int, T2)", f(x1, x2), f(x1_dbl, x2));
+  } catch (...) {}
 
   // expect autodiff to work at double value
   expect_ad_vv(tols, f, x1_dbl, x2);
@@ -504,8 +506,10 @@ template <typename F, typename T1>
 void expect_ad_vv(const ad_tolerances& tols, const F& f, const T1& x1, int x2) {
   double x2_dbl = static_cast<double>(x2);
 
-  // expect same result with int or and cast to double
-  expect_near_rel("expect_ad_vv(T1, int)", f(x1, x2), f(x1, x2_dbl));
+  // test value, exception handling checked recursively
+  try {
+    expect_near_rel("expect_ad_vv(T1, int)", f(x1, x2), f(x1, x2_dbl));
+  } catch (...) {}
 
   // expect autodiff to work at double value
   expect_ad_vv(tols, f, x1, x2_dbl);
@@ -640,9 +644,11 @@ void expect_ad_vvv(const ad_tolerances& tols, const F& f, int x1, int x2,
   expect_ad_vvv(tols, f, x1_dbl, x2, x3);
   expect_ad_vvv(tols, f, x1, x2_dbl, x3);
 
-  // test value
-  expect_near_rel("expect_ad_vvv(int, int, T3)", f(x1, x2, x3),
-                  f(x1_dbl, x2_dbl, x3));
+  // test value, exception handling checked recursively
+  try {
+    expect_near_rel("expect_ad_vvv(int, int, T3)", f(x1, x2, x3),
+                    f(x1_dbl, x2_dbl, x3));
+  } catch (...) {}
 
   // bind ints and test autodiff
   auto g23 = [=](const auto& u2, const auto& u3) { return f(x1, u2, u3); };
@@ -673,9 +679,11 @@ void expect_ad_vvv(const ad_tolerances& tols, const F& f, int x1, const T2& x2,
   // test all promotion patterns
   expect_ad_vvv(tols, f, x1_dbl, x2, x3);
 
-  // test value
-  expect_near_rel("expect_ad_vvv(int, T2, T3)", f(x1, x2, x3),
-                  f(x1_dbl, x2, x3));
+  // test value, exception handling checked recursively
+  try {
+    expect_near_rel("expect_ad_vvv(int, T2, T3)", f(x1, x2, x3),
+                    f(x1_dbl, x2, x3));
+  } catch (...) {}
 
   // bind ints and test autodiff
   auto g23 = [=](const auto& u2, const auto& u3) { return f(x1, u2, u3); };
@@ -703,9 +711,11 @@ void expect_ad_vvv(const ad_tolerances& tols, const F& f, const T1& x1, int x2,
   // test promotion
   expect_ad_vvv(tols, f, x1, x2_dbl, x3);
 
-  // test value
-  expect_near_rel("expect_ad_vvv(T1, int, T3)", f(x1, x2, x3),
-                  f(x1, x2_dbl, x3));
+  // test value, exception handling checked recursively
+  try {
+    expect_near_rel("expect_ad_vvv(T1, int, T3)", f(x1, x2, x3),
+                    f(x1, x2_dbl, x3));
+  } catch (...) {}
 
   // bind ints and test autodiff
   auto g13 = [=](const auto& u1, const auto& u3) { return f(u1, x2, u3); };
@@ -733,9 +743,11 @@ void expect_ad_vvv(const ad_tolerances& tols, const F& f, const T1& x1,
   // test promotion
   expect_ad_vvv(tols, f, x1, x2, x3_dbl);
 
-  // test value
-  expect_near_rel("expect_ad_vvv(T1, T2, int)", f(x1, x2, x3),
-                  f(x1, x2, x3_dbl));
+  // test value, exception handling checked recursively
+  try {
+    expect_near_rel("expect_ad_vvv(T1, T2, int)", f(x1, x2, x3),
+                    f(x1, x2, x3_dbl));
+  } catch (...) {}
 
   // bind ints and test autodiff
   auto g12 = [=](const auto& u1, const auto& u2) { return f(u1, u2, x3); };
@@ -764,9 +776,11 @@ void expect_ad_vvv(const ad_tolerances& tols, const F& f, int x1, const T2& x2,
   expect_ad_vvv(tols, f, x1_dbl, x2, x3);
   expect_ad_vvv(tols, f, x1, x2, x3_dbl);
 
-  // test value
-  expect_near_rel("expect_ad_vvv(int, T2, int)", f(x1, x2, x3),
-                  f(x1_dbl, x2, x3_dbl));
+  // test value, exception handling checked recursively
+  try {
+    expect_near_rel("expect_ad_vvv(int, T2, int)", f(x1, x2, x3),
+                    f(x1_dbl, x2, x3_dbl));
+  } catch (...) {}
 
   // bind ints and test autodiff
   auto g23 = [=](const auto& u2, const auto& u3) { return f(x1, u2, u3); };
@@ -798,9 +812,11 @@ void expect_ad_vvv(const ad_tolerances& tols, const F& f, const T1& x1, int x2,
   expect_ad_vvv(tols, f, x1, x2_dbl, x3);
   expect_ad_vvv(tols, f, x1, x2, x3_dbl);
 
-  // test value
-  expect_near_rel("expect_ad_vvv(T1, int, int)", f(x1, x2, x3),
-                  f(x1, x2_dbl, x3_dbl));
+  // test value, exception handling checked recursively
+  try {
+    expect_near_rel("expect_ad_vvv(T1, int, int)", f(x1, x2, x3),
+                    f(x1, x2_dbl, x3_dbl));
+  } catch (...) {}
 
   // bind ints and test autodiff
   auto g13 = [=](const auto& u1, const auto& u3) { return f(u1, x2, u3); };

--- a/test/unit/math/test_ad.hpp
+++ b/test/unit/math/test_ad.hpp
@@ -492,7 +492,8 @@ void expect_ad_vv(const ad_tolerances& tols, const F& f, int x1, const T2& x2) {
   // test value, exception handling checked recursively
   try {
     expect_near_rel("expect_ad_vv(int, T2)", f(x1, x2), f(x1_dbl, x2));
-  } catch (...) {}
+  } catch (...) {
+  }
 
   // expect autodiff to work at double value
   expect_ad_vv(tols, f, x1_dbl, x2);
@@ -509,7 +510,8 @@ void expect_ad_vv(const ad_tolerances& tols, const F& f, const T1& x1, int x2) {
   // test value, exception handling checked recursively
   try {
     expect_near_rel("expect_ad_vv(T1, int)", f(x1, x2), f(x1, x2_dbl));
-  } catch (...) {}
+  } catch (...) {
+  }
 
   // expect autodiff to work at double value
   expect_ad_vv(tols, f, x1, x2_dbl);
@@ -648,7 +650,8 @@ void expect_ad_vvv(const ad_tolerances& tols, const F& f, int x1, int x2,
   try {
     expect_near_rel("expect_ad_vvv(int, int, T3)", f(x1, x2, x3),
                     f(x1_dbl, x2_dbl, x3));
-  } catch (...) {}
+  } catch (...) {
+  }
 
   // bind ints and test autodiff
   auto g23 = [=](const auto& u2, const auto& u3) { return f(x1, u2, u3); };
@@ -683,7 +686,8 @@ void expect_ad_vvv(const ad_tolerances& tols, const F& f, int x1, const T2& x2,
   try {
     expect_near_rel("expect_ad_vvv(int, T2, T3)", f(x1, x2, x3),
                     f(x1_dbl, x2, x3));
-  } catch (...) {}
+  } catch (...) {
+  }
 
   // bind ints and test autodiff
   auto g23 = [=](const auto& u2, const auto& u3) { return f(x1, u2, u3); };
@@ -715,7 +719,8 @@ void expect_ad_vvv(const ad_tolerances& tols, const F& f, const T1& x1, int x2,
   try {
     expect_near_rel("expect_ad_vvv(T1, int, T3)", f(x1, x2, x3),
                     f(x1, x2_dbl, x3));
-  } catch (...) {}
+  } catch (...) {
+  }
 
   // bind ints and test autodiff
   auto g13 = [=](const auto& u1, const auto& u3) { return f(u1, x2, u3); };
@@ -747,7 +752,8 @@ void expect_ad_vvv(const ad_tolerances& tols, const F& f, const T1& x1,
   try {
     expect_near_rel("expect_ad_vvv(T1, T2, int)", f(x1, x2, x3),
                     f(x1, x2, x3_dbl));
-  } catch (...) {}
+  } catch (...) {
+  }
 
   // bind ints and test autodiff
   auto g12 = [=](const auto& u1, const auto& u2) { return f(u1, u2, x3); };
@@ -780,7 +786,8 @@ void expect_ad_vvv(const ad_tolerances& tols, const F& f, int x1, const T2& x2,
   try {
     expect_near_rel("expect_ad_vvv(int, T2, int)", f(x1, x2, x3),
                     f(x1_dbl, x2, x3_dbl));
-  } catch (...) {}
+  } catch (...) {
+  }
 
   // bind ints and test autodiff
   auto g23 = [=](const auto& u2, const auto& u3) { return f(x1, u2, u3); };
@@ -816,7 +823,8 @@ void expect_ad_vvv(const ad_tolerances& tols, const F& f, const T1& x1, int x2,
   try {
     expect_near_rel("expect_ad_vvv(T1, int, int)", f(x1, x2, x3),
                     f(x1, x2_dbl, x3_dbl));
-  } catch (...) {}
+  } catch (...) {
+  }
 
   // bind ints and test autodiff
   auto g13 = [=](const auto& u1, const auto& u3) { return f(u1, x2, u3); };
@@ -1430,8 +1438,8 @@ void expect_unary_vectorized(const ad_tolerances& tols, const F& f, Ts... xs) {
 /**
  * Test that the specified unary function produces derivatives and
  * values for the specified values that are consistent with primitive
- * values and finite differences.  Tests both scalars and containers.
- *
+ * values and finite differences.  Tests both scalars and containers.  Uses
+ * default tolerances.
  * @tparam F type of function to test
  * @tparam T type of first argument to test
  * @tparam Ts type of remaining arguments to test

--- a/test/unit/math/test_ad.hpp
+++ b/test/unit/math/test_ad.hpp
@@ -674,7 +674,7 @@ void expect_ad_vvv(const ad_tolerances& tols, const F& f, int x1, const T2& x2,
   expect_ad_vvv(tols, f, x1_dbl, x2, x3);
 
   // test value
-  expect_near_rel("expect_ad_vvv(int, int, T3)", f(x1, x2, x3),
+  expect_near_rel("expect_ad_vvv(int, T2, T3)", f(x1, x2, x3),
                   f(x1_dbl, x2, x3));
 
   // bind ints and test autodiff
@@ -704,7 +704,7 @@ void expect_ad_vvv(const ad_tolerances& tols, const F& f, const T1& x1, int x2,
   expect_ad_vvv(tols, f, x1, x2_dbl, x3);
 
   // test value
-  expect_near_rel("expect_ad_vvv(int, int, T3)", f(x1, x2, x3),
+  expect_near_rel("expect_ad_vvv(T1, int, T3)", f(x1, x2, x3),
                   f(x1, x2_dbl, x3));
 
   // bind ints and test autodiff
@@ -734,7 +734,7 @@ void expect_ad_vvv(const ad_tolerances& tols, const F& f, const T1& x1,
   expect_ad_vvv(tols, f, x1, x2, x3_dbl);
 
   // test value
-  expect_near_rel("expect_ad_vvv(int, int, T3)", f(x1, x2, x3),
+  expect_near_rel("expect_ad_vvv(T1, T2, int)", f(x1, x2, x3),
                   f(x1, x2, x3_dbl));
 
   // bind ints and test autodiff
@@ -765,7 +765,7 @@ void expect_ad_vvv(const ad_tolerances& tols, const F& f, int x1, const T2& x2,
   expect_ad_vvv(tols, f, x1, x2, x3_dbl);
 
   // test value
-  expect_near_rel("expect_ad_vvv(int, int, T3)", f(x1, x2, x3),
+  expect_near_rel("expect_ad_vvv(int, T2, int)", f(x1, x2, x3),
                   f(x1_dbl, x2, x3_dbl));
 
   // bind ints and test autodiff
@@ -799,7 +799,7 @@ void expect_ad_vvv(const ad_tolerances& tols, const F& f, const T1& x1, int x2,
   expect_ad_vvv(tols, f, x1, x2, x3_dbl);
 
   // test value
-  expect_near_rel("expect_ad_vvv(int, int, T3)", f(x1, x2, x3),
+  expect_near_rel("expect_ad_vvv(T1, int, int)", f(x1, x2, x3),
                   f(x1, x2_dbl, x3_dbl));
 
   // bind ints and test autodiff
@@ -826,7 +826,7 @@ void expect_ad_vvv(const ad_tolerances& tols, const F& f, int x1, int x2,
   double x3_dbl = static_cast<double>(x3);
 
   // test value
-  expect_near_rel("expect_ad_vvv(int, int, T3)", f(x1, x2, x3),
+  expect_near_rel("expect_ad_vvv(int, int, int)", f(x1, x2, x3),
                   f(x1_dbl, x2_dbl, x3_dbl));
 
   // test all promotion patterns;  includes all combos recursively

--- a/test/unit/math/test_ad_test.cpp
+++ b/test/unit/math/test_ad_test.cpp
@@ -69,7 +69,7 @@ void expect_test_combinator_to_fail(const G& test_combinator, const F& f,
       "Expected: 1 non-fatal failure");
 }
 
-TEST(test_unit_math_test_mix, test_expect_test_combinator_to_fail) {
+TEST(test_unit_math_test_ad, test_expect_test_combinator_to_fail) {
   auto combinator_that_succeeds = [](auto& f) {};
   auto combinator_that_fails = [](auto& f) { ADD_FAILURE() << ""; };
   auto combinator_that_fails_twice = [](auto& f) {
@@ -148,7 +148,7 @@ T f_match(const T& x) {
   return -2 * x;
 }
 double f_match(const double& x) { return -2 * x; }
-TEST(test_ad, match) {
+TEST(test_unit_math_test_ad, match) {
   double x = 3.2;
   auto g = [](const auto& u) { return f_match(u); };
   stan::test::expect_ad(g, x);
@@ -162,7 +162,7 @@ T f_mismatch(const T& x) {
   return -2 * x;
 }
 stan::math::var f_mismatch(const stan::math::var& x) { return 2 * x; }
-TEST(test_ad, mismatch) {
+TEST(test_unit_math_test_ad, mismatch) {
   double x = 3.2;
   auto g = [](const auto& u) { return f_mismatch(u); };
   expect_expect_ad_failure(g, x);
@@ -180,7 +180,7 @@ double f_misthrow(const double& x) {
   return -2 * x;
 }
 
-TEST(test_ad, misthrow) {
+TEST(test_unit_math_test_ad, misthrow) {
   double x = 1.73;
   auto h = [](const auto& u) { return f_misthrow(u); };
   expect_expect_ad_failure(h, x);
@@ -203,7 +203,7 @@ stan::return_type_t<T1> binary_function_misthrow(T1 x1, int x2) {
   return x1vec[0] + x2vec[0];
 }
 
-TEST(test_ad, misthrow_binary) {
+TEST(test_unit_math_test_ad, misthrow_binary) {
   auto g = [](const auto& x1, const auto& x2) {
     return binary_function_misthrow(x1, x2);
   };
@@ -234,7 +234,7 @@ stan::return_type_t<T1, stan::math::var> binary_function_misthrow_2(
   return x1vec[0] + x2vec[0];
 }
 
-TEST(test_ad, misthrow_binary_2) {
+TEST(test_unit_math_test_ad, misthrow_binary_2) {
   auto g = [](const auto& x1, const auto& x2) {
     return binary_function_misthrow_2(x1, x2);
   };
@@ -263,7 +263,7 @@ stan::return_type_t<T1, T2> ternary_function_misthrow(T1 x1, T2 x2, int x3) {
   return x1vec[0] + x2vec[0] + x3vec[0];
 }
 
-TEST(test_ad, misthrow_ternary) {
+TEST(test_unit_math_test_ad, misthrow_ternary) {
   auto g = [](const auto& x1, const auto& x2, const auto& x3) {
     return ternary_function_misthrow(x1, x2, x3);
   };
@@ -299,7 +299,7 @@ stan::return_type_t<T1, T2, stan::math::var> ternary_function_misthrow_2(
   return x1vec[0] + x2vec[0] + x3vec[0];
 }
 
-TEST(test_ad, misthrow_ternary_2) {
+TEST(test_unit_math_test_ad, misthrow_ternary_2) {
   auto g = [](const auto& x1, const auto& x2, const auto& x3) {
     return ternary_function_misthrow_2(x1, x2, x3);
   };
@@ -332,7 +332,7 @@ struct foo_fun {
 int foo_fun::calls_int_ = -1;
 int foo_fun::calls_t_ = -1;
 
-TEST(test_ad, integerGetsPassed) {
+TEST(test_unit_math_test_ad, integerGetsPassed) {
   // double arguments will not call int version
   foo_fun h;
   foo_fun::calls_int_ = 0;
@@ -416,7 +416,7 @@ int bar_fun::calls_int1_ = -1;
 int bar_fun::calls_int2_ = -1;
 int bar_fun::calls_int12_ = -1;
 
-TEST(testAd, integerGetsPassedBinary) {
+TEST(test_unit_math_test_ad, integerGetsPassedBinary) {
   bar_fun f;
 
   bar_fun::reset();
@@ -485,7 +485,7 @@ inline typename stan::math::apply_scalar_unary<baz_fun, T>::return_t baz(
   return stan::math::apply_scalar_unary<baz_fun, T>::apply(x);
 }
 
-TEST(testAd, integerGetsPassedVectorized) {
+TEST(test_unit_math_test_ad, integerGetsPassedVectorized) {
   auto h = [&](auto x) { return baz(x); };
 
   baz_int = 0;
@@ -617,7 +617,7 @@ int ternary_fun::calls_int13_ = 0;
 int ternary_fun::calls_int23_ = 0;
 int ternary_fun::calls_int123_ = 0;
 
-TEST(testUnitMath, testAdTernaryIntPassed) {
+TEST(test_unit_math_test_ad, testAdTernaryIntPassed) {
   ternary_fun f;
 
   // { }

--- a/test/unit/math/test_ad_test.cpp
+++ b/test/unit/math/test_ad_test.cpp
@@ -166,26 +166,14 @@ TEST(test_unit_math_test_ad, always_throws_case_handled_correctly) {
   auto f = [](const auto&... xs) { return always_throws(xs...); };
   std::vector<double> v{1, 2, 3};
   stan::test::expect_ad(f, 1.0);
+  stan::test::expect_ad(f, 1);
+  stan::test::expect_ad(f, v);
   stan::test::expect_ad(f, 1.0, 1.0);
   stan::test::expect_ad(f, v, 1.0);
-  stan::test::expect_ad(f, 1.0, v);
+  stan::test::expect_ad(f, 1, 1.0);
   stan::test::expect_ad(f, 1.0, 1.0, 1.0);
-  stan::test::expect_ad(f, v, 1.0, 1.0);
-  stan::test::expect_ad(f, 1.0, v, 1.0);
-  stan::test::expect_ad(f, 1.0, 1.0, v);
-  stan::test::expect_ad(f, 1);
-  stan::test::expect_ad(f, 1, 1);
-  stan::test::expect_ad(f, v, 1);
-  stan::test::expect_ad(f, 1, v);
   stan::test::expect_ad(f, 1, 1.0, 1.0);
-  stan::test::expect_ad(f, 1.0, 1, 1.0);
-  stan::test::expect_ad(f, 1.0, 1.0, 1);
-  stan::test::expect_ad(f, v, 1, 1.0);
-  stan::test::expect_ad(f, v, 1.0, 1);
-  stan::test::expect_ad(f, 1, v, 1.0);
-  stan::test::expect_ad(f, 1.0, v, 1);
-  stan::test::expect_ad(f, 1, 1.0, v);
-  stan::test::expect_ad(f, 1.0, 1, v);
+  stan::test::expect_ad(f, v, 1.0, 1.0);
 }
 
 // OVERLOAD THAT FAILS DUE TO MISMATCHED VALUE / DERIVATIVE
@@ -220,17 +208,16 @@ TEST(test_unit_math_test_ad, misthrow) {
   expect_expect_ad_failure(h, x);
 }
 
-// OVERLOAD THAT FAILS BECAUSE DOUBLE VERSION HAS MISMATCHED EXCEPTION CONDITIONS
+// OVERLOAD THAT FAILS BECAUSE DOUBLE VERSION HAS MISMATCHED EXCEPTION
+// CONDITIONS
 
 template <typename T1, typename... Ts>
-stan::return_type_t<T1, Ts...> double_version_throws(const T1& x1,
-                                                     const Ts&... xs) {
-  stan::scalar_seq_view<T1> x1vec(x1);
-  return x1vec[0];
+T1 double_version_throws(const T1& x1, const Ts&... xs) {
+  return x1;
 }
 
 template <typename... Ts>
-int double_version_throws(const double& x1, const Ts&... xs) {
+double double_version_throws(const double& x1, const Ts&... xs) {
   throw std::runtime_error("double_version_throws(int, Ts...) called");
   return x1;
 }
@@ -247,10 +234,8 @@ TEST(test_unit_math_test_ad, misthrow_in_double_version) {
 // OVERLOAD THAT FAILS BECAUSE INT VERSION HAS MISMATCHED EXCEPTION CONDITIONS
 
 template <typename T1, typename... Ts>
-stan::return_type_t<T1, Ts...> int_version_throws(const T1& x1,
-                                                  const Ts&... xs) {
-  stan::scalar_seq_view<T1> x1vec(x1);
-  return x1vec[0];
+T1 int_version_throws(const T1& x1, const Ts&... xs) {
+  return x1;
 }
 
 template <typename... Ts>
@@ -271,9 +256,8 @@ TEST(test_unit_math_test_ad, misthrow_in_int_version) {
 // OVERLOAD THAT FAILS BECAUSE VAR VERSION HAS MISMATCHED EXCEPTION CONDITIONS
 
 template <typename T1, typename... Ts>
-stan::return_type_t<T1> var_version_throws(const T1& x1, const Ts&... xs) {
-  stan::scalar_seq_view<T1> x1vec(x1);
-  return x1vec[0];
+T1 var_version_throws(const T1& x1, const Ts&... xs) {
+  return x1;
 }
 
 template <typename... Ts>

--- a/test/unit/math/test_ad_test.cpp
+++ b/test/unit/math/test_ad_test.cpp
@@ -716,3 +716,15 @@ TEST(test_unit_math_test_ad, testAdTernaryIntPassed) {
   EXPECT_LT(0, ternary_fun::calls_int23_);
   EXPECT_LT(0, ternary_fun::calls_int123_);
 }
+
+template <typename T>
+stan::return_type_t<T> prim_throws(const T& x) {
+  throw std::runtime_error("prim_throws(T) called");
+}
+
+TEST(test_unit_math_test_ad, int_arguments_safe_when_prim_throws) {
+  auto f = [](const auto& x) { return prim_throws(x); };
+  stan::test::expect_ad(f, 1.0);
+  // TODO(peterwicksstringfield) This is the problem with my first PR.
+  expect_expect_ad_failure(f, 1);
+}

--- a/test/unit/math/test_ad_test.cpp
+++ b/test/unit/math/test_ad_test.cpp
@@ -247,7 +247,8 @@ TEST(test_unit_math_test_ad, misthrow_in_double_version) {
 // OVERLOAD THAT FAILS BECAUSE INT VERSION HAS MISMATCHED EXCEPTION CONDITIONS
 
 template <typename T1, typename... Ts>
-stan::return_type_t<T1, Ts...> int_version_throws(const T1& x1, const Ts&... xs) {
+stan::return_type_t<T1, Ts...> int_version_throws(const T1& x1,
+                                                  const Ts&... xs) {
   stan::scalar_seq_view<T1> x1vec(x1);
   return x1vec[0];
 }
@@ -259,9 +260,7 @@ int int_version_throws(const int& x1, const Ts&... xs) {
 }
 
 TEST(test_unit_math_test_ad, misthrow_in_int_version) {
-  auto g = [](const auto&... xs) {
-             return int_version_throws(xs...);
-           };
+  auto g = [](const auto&... xs) { return int_version_throws(xs...); };
   std::vector<double> v{1, 2, 3};
   int i = 1;
   expect_expect_ad_failure(g, i);
@@ -284,9 +283,7 @@ stan::math::var var_version_throws(const stan::math::var& x1, const Ts&... xs) {
 }
 
 TEST(test_unit_math_test_ad, misthrow_in_var_version) {
-  auto g = [](const auto&... xs) {
-             return var_version_throws(xs...);
-           };
+  auto g = [](const auto&... xs) { return var_version_throws(xs...); };
   std::vector<double> v{1, 2, 3};
   double d = 1;
   expect_expect_ad_failure(g, d);
@@ -298,11 +295,13 @@ TEST(test_unit_math_test_ad, misthrow_in_var_version) {
 
 template <typename T, typename... Ts>
 stan::return_type_t<T, Ts...> bad_int_handling(const T& x, const Ts&... xs) {
-  return x/2;
+  return x / 2;
 }
 
 TEST(test_unit_math_test_ad, bad_int_handling_caught) {
-  auto f = [](const auto& x, const auto&... xs) { return bad_int_handling(x, xs...); };
+  auto f = [](const auto& x, const auto&... xs) {
+    return bad_int_handling(x, xs...);
+  };
   expect_expect_ad_failure(f, 1);
   expect_expect_ad_failure(f, 1, 1.0);
   expect_expect_ad_failure(f, 1, 1.0, 1.0);


### PR DESCRIPTION
#  Summary

Fixes #1533.

I also introduced a function expect_expect_ad_failure(f, xs...) which is just a negated form of expect_ad. It succeeds if and only if expect_ad fails. This function is currently confined to test_ad_test.cpp, where it is used to verify that expect_ad catches certain types of failures. GTEST provides only lukewarm support for writing such a negated test, so I had to jump through a couple hoops.

## Tests

Test that expect_ad can be called in all the intended ways, with various combinations of int/double/whatever. Test that mismatched exceptions and improper int handling are still being caught.

## Side Effects

None.

## Checklist

- [X] Math issue #1533 

- [X] Copyright holder: Peter Wicks Stringfield

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [X] the new changes are tested
