### PR TITLE
Bugfix/doxygen build doc fixes

### DIFF
--- a/stan/math/opencl/kernels/neg_binomial_2_log_glm_lpmf.hpp
+++ b/stan/math/opencl/kernels/neg_binomial_2_log_glm_lpmf.hpp
@@ -193,7 +193,8 @@ static const char* neg_binomial_2_log_glm_kernel_code = STRINGIFY(
 // \endcond
 
 /** \ingroup opencl_kernels
- * See the docs for \link kernels/subtract.hpp subtract() \endlink
+ * See the docs for \link kernels/neg_binomial_2_log_glm_lpmf.hpp
+ * neg_binomial_2_log_glm_lpmf() \endlink
  */
 const kernel_cl<out_buffer, out_buffer, out_buffer, out_buffer, in_buffer,
                 in_buffer, in_buffer, in_buffer, in_buffer, int, int, int, int,

--- a/stan/math/opencl/kernels/poisson_log_glm_lpmf.hpp
+++ b/stan/math/opencl/kernels/poisson_log_glm_lpmf.hpp
@@ -118,7 +118,8 @@ static const char* poisson_log_glm_kernel_code = STRINGIFY(
 // \endcond
 
 /** \ingroup opencl_kernels
- * See the docs for \link kernels/subtract.hpp subtract() \endlink
+ * See the docs for \link kernels/poisson_log_glm_lpmf.hpp
+ * poisson_log_glm_lpmf() \endlink
  */
 const kernel_cl<out_buffer, out_buffer, out_buffer, in_buffer, in_buffer,
                 in_buffer, in_buffer, int, int, int, int, int, int>

--- a/stan/math/prim/meta/get.hpp
+++ b/stan/math/prim/meta/get.hpp
@@ -39,7 +39,7 @@ inline T get(const std::vector<T>& x, size_t n) {
 /** \ingroup type_trait
  * Returns the n-th element of the provided Eigen matrix.
  *
- * @param x input \c Eigen \c Matrix or expression
+ * @param m input \c Eigen \c Matrix or expression
  * @param n index of the element to return
  * @return n-th element of the \c Eigen \c Matrix or expression
  */


### PR DESCRIPTION
## Summary

Fixes #1543 

Couple quick documentation fixups. The kernel files define two functions, and the documentation of the second is supposed to link to the documentation of the first. Looks like a copy-paste error using the code in the (no-longer-existent) subtract.hpp as a template.

## Tests

None.

## Side Effects

None.

## Checklist

- [X] Math issue #1543

- [X] Copyright holder: Peter Wicks Stringfield

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [X] the new changes are tested
