### PR TITLE
Fix two doxygen warnings caused by the presence of .md in the URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ Required Libraries
 ------------------
 Stan Math depends on four libraries:
 
-- Boost (version 1.69.0): [Boost Home Page](http://www.boost.org)
-- Eigen (version 3.3.3): [Eigen Home Page](http://eigen.tuxfamily.org/index.php?title=Main_Page)
-- SUNDIALS (version 4.1.0): [Sundials Home Page](http://computation.llnl.gov/projects/sundials/sundials-software)
+- Boost (version 1.69.0): [Boost Home Page](https://www.boost.org)
+- Eigen (version 3.3.3): [Eigen Home Page](https://eigen.tuxfamily.org/index.php?title=Main_Page)
+- SUNDIALS (version 4.1.0): [Sundials Home Page](https://computation.llnl.gov/projects/sundials/sundials-software)
 - Intel TBB (version 2019_U8): [Intel TBB Home Page](https://www.threadingbuildingblocks.org)
 
 These are distributed under the `lib/` subdirectory. Only these versions of the dependent libraries have been tested with Stan Math.
@@ -22,7 +22,7 @@ These are distributed under the `lib/` subdirectory. Only these versions of the 
 Documentation
 ------------
 
-Documentation for Stan math is available at [mc-stan.org/math](http://mc-stan.org/math/)
+Documentation for Stan math is available at [mc-stan.org/math](https://mc-stan.org/math/)
 
 Installation
 ------------

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The <b>Stan Math Library</b> is a C++, reverse-mode automatic differentiation li
 
 Licensing
 ---------
-The Stan Math Library is licensed under the [new BSD license](https://github.com/stan-dev/math/blob/develop/LICENSE.md).
+The Stan Math Library is licensed under the [new BSD license](https://github.com/stan-dev/math/blob/develop/LICENSE%2Emd).
 
 The Stan Math Library depends on the Intel TBB library which is licensed under the Apache 2.0 license. This dependency implies an additional restriction as compared to the new BSD lincense alone. The Apache 2.0 license is incompatible with GPL-2 licensed code if distributed as a unitary binary. You may refer to the Apache 2.0 evaluation page on the [Stan Math wiki](https://github.com/stan-dev/math/wiki/Apache-2.0-License-Evaluation).
 

--- a/doxygen/contributor_help_pages/developer_doc.md
+++ b/doxygen/contributor_help_pages/developer_doc.md
@@ -2,7 +2,7 @@
 
 Thanks for checking out these docs. This is where you'll find information on contributing to the [Math library](https://github.com/stan-dev/math), how the source code is laid out, and other technical details that could help. This wiki focuses on things relevant to the Math library. There's also a separate [Stan wiki](https://github.com/stan-dev/stan/wiki) for things related to the language, services, algorithms.
 
-This wiki is a work in progress. If you have suggestions, please update the wiki or mention it on our forums on [this thread](http://discourse.mc-stan.org/t/what-doc-would-help-developers-of-the-math-library/).
+This wiki is a work in progress. If you have suggestions, please update the wiki or mention it on our forums on [this thread](https://discourse.mc-stan.org/t/what-doc-would-help-developers-of-the-math-library/).
 
 -----------------
 
@@ -92,7 +92,7 @@ See the [Code Review Guidelines](https://github.com/stan-dev/math/wiki/Developer
 
 ## Discussion
 
-For general questions, please ask on the forums with the ["Developers" tag](http://discourse.mc-stan.org/c/stan-dev).
+For general questions, please ask on the forums with the ["Developers" tag](https://discourse.mc-stan.org/c/stan-dev).
 
 
 
@@ -388,7 +388,7 @@ See [Discourse: Boost defines](https://discourse.mc-stan.org/t/boost-defines/100
 - Description of how to use/print the gradient functions in Stan, and any other diagnostic tools for making sure our code/math is accurate ( some_var_.grad(vars, grad)) and then (for (auto g : grad) { std::cout << g << std::endl;}
 
 - How does the architecture from rev-> prim work? I threw some print statements in gp_exp_quad_cov formerly (cov_exp_quad) to see how it works. rev fuctions are precompiled, and then call some of the prim functions on runtime? How does this work exactly? What kind of templating it happening to make sure rev is going to which prim? Can we have a quick visualization on a simple stan program to know what’s happening?
-- where to find doxygen: http://mc-stan.org/math
+- where to find doxygen: https://mc-stan.org/math
 
 - Intro to C++ concepts needed to develop for Stan.
 - Description of directory structure of the Stan source

--- a/doxygen/contributor_help_pages/developer_doc.md
+++ b/doxygen/contributor_help_pages/developer_doc.md
@@ -37,7 +37,7 @@ For implementation details of the Math library's automatic differentiation, plea
 
 # Licensing
 
-We're committed to having a permissive open-source license. The Math library is [licensed with the BSD 3-Clause License](https://github.com/stan-dev/math/blob/develop/LICENSE.md) and we only accept changes to the code base that compatible with this license.
+We're committed to having a permissive open-source license. The Math library is [licensed with the BSD 3-Clause License](https://github.com/stan-dev/math/blob/develop/LICENSE%2Emd) and we only accept changes to the code base that compatible with this license.
 
 # Contributing
 


### PR DESCRIPTION
## Summary

Following on from #1544, this fixes these two more warnings:
```
contributor_help_pages/developer_doc.md:42: warning: unable to resolve reference to `https:' for \ref command
README.md:8: warning: unable to resolve reference to `https:' for \ref command
```
These were caused by linking to urls that ended with `.md`, which is one of the extensions that doxygen tests for documents to parse. 

By using the URL encoding symbol `%2E` instead of `.`, we can avoid the warning while keeping the URL still functional: https://github.com/stan-dev/math/blob/develop/LICENSE%2Emd

## Tests
None.

## Side Effects

None

## Checklist

- [X] Math issue #1543

- [X] Copyright holder: Marco Colombo

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - docs build, (`make doxygen`)

- [X] the new changes are tested