### PR TITLE
Improve out_of_range message on size 0 arrays

### DIFF
--- a/stan/math/prim/scal/err/out_of_range.hpp
+++ b/stan/math/prim/scal/err/out_of_range.hpp
@@ -28,9 +28,14 @@ inline void out_of_range(const char* function, int max, int index,
                          const char* msg1 = "", const char* msg2 = "") {
   std::ostringstream message;
   message << function << ": accessing element out of range. "
-          << "index " << index << " out of range; "
-          << "expecting index to be between " << stan::error_index::value
-          << " and " << stan::error_index::value - 1 + max << msg1 << msg2;
+          << "index " << index << " out of range; ";
+
+  if (max == 0) {
+    message << "container is empty and cannot be indexed" << msg1 << msg2;
+  } else {
+    message << "expecting index to be between " << stan::error_index::value
+            << " and " << stan::error_index::value - 1 + max << msg1 << msg2;
+  }
   throw std::out_of_range(message.str());
 }
 

--- a/test/unit/math/prim/mat/err/check_range_test.cpp
+++ b/test/unit/math/prim/mat/err/check_range_test.cpp
@@ -15,14 +15,21 @@ TEST(ErrorHandlingMatrix, checkRange_6_arg_std_vector) {
   EXPECT_NO_THROW(check_range("function", "x", 4, 3, 4, ""));
   EXPECT_NO_THROW(check_range("function", "x", 4, 4, 4, ""));
 
-  std::string expected_message;
-  expected_message
+  std::string expected_message
       = "function: accessing element out of range. "
         "index 12 out of range; "
         "expecting index to be between 1 and 4; "
         "index position = 4";
   EXPECT_THROW_MSG(check_range("function", "x", 4, 12, 4, ""),
                    std::out_of_range, expected_message);
+
+  std::string expected_message_empty_container
+      = "function: accessing element out of range. "
+        "index 0 out of range; "
+        "container is empty and cannot be indexed; "
+        "index position = 4";
+  EXPECT_THROW_MSG(check_range("function", "x", 0, 0, 4, ""),
+                   std::out_of_range, expected_message_empty_container);
 }
 
 TEST(ErrorHandlingMatrix, checkRange_4_arg_std_vector) {
@@ -36,11 +43,17 @@ TEST(ErrorHandlingMatrix, checkRange_4_arg_std_vector) {
   EXPECT_NO_THROW(check_range("function", "x", 4, 3));
   EXPECT_NO_THROW(check_range("function", "x", 4, 4));
 
-  std::string expected_message;
-  expected_message
+  std::string expected_message
       = "function: accessing element out of range. "
         "index 12 out of range; "
         "expecting index to be between 1 and 4";
   EXPECT_THROW_MSG(check_range("function", "x", 4, 12), std::out_of_range,
                    expected_message);
+
+  std::string expected_message_empty_container
+      = "function: accessing element out of range. "
+        "index 0 out of range; "
+        "container is empty and cannot be indexed";
+  EXPECT_THROW_MSG(check_range("function", "x", 0, 0),
+                   std::out_of_range, expected_message_empty_container);
 }

--- a/test/unit/math/prim/mat/err/check_range_test.cpp
+++ b/test/unit/math/prim/mat/err/check_range_test.cpp
@@ -28,8 +28,8 @@ TEST(ErrorHandlingMatrix, checkRange_6_arg_std_vector) {
         "index 0 out of range; "
         "container is empty and cannot be indexed; "
         "index position = 4";
-  EXPECT_THROW_MSG(check_range("function", "x", 0, 0, 4, ""),
-                   std::out_of_range, expected_message_empty_container);
+  EXPECT_THROW_MSG(check_range("function", "x", 0, 0, 4, ""), std::out_of_range,
+                   expected_message_empty_container);
 }
 
 TEST(ErrorHandlingMatrix, checkRange_4_arg_std_vector) {
@@ -54,6 +54,6 @@ TEST(ErrorHandlingMatrix, checkRange_4_arg_std_vector) {
       = "function: accessing element out of range. "
         "index 0 out of range; "
         "container is empty and cannot be indexed";
-  EXPECT_THROW_MSG(check_range("function", "x", 0, 0),
-                   std::out_of_range, expected_message_empty_container);
+  EXPECT_THROW_MSG(check_range("function", "x", 0, 0), std::out_of_range,
+                   expected_message_empty_container);
 }

--- a/test/unit/math/prim/scal/err/out_of_range_test.cpp
+++ b/test/unit/math/prim/scal/err/out_of_range_test.cpp
@@ -45,8 +45,8 @@ class ErrorHandlingScalar_out_of_range : public ::testing::Test {
     expected_message << "function: "
                      << "accessing element out of range. "
                      << "index " << i << " out of range; "
-                     << "container is empty and cannot be indexed"
-                     << msg1_ << msg2_;
+                     << "container is empty and cannot be indexed" << msg1_
+                     << msg2_;
     return expected_message.str();
   }
 

--- a/test/unit/math/prim/scal/err/out_of_range_test.cpp
+++ b/test/unit/math/prim/scal/err/out_of_range_test.cpp
@@ -40,6 +40,17 @@ class ErrorHandlingScalar_out_of_range : public ::testing::Test {
   }
 
   template <class T>
+  std::string expected_message_empty_container(T y, size_t i) {
+    std::stringstream expected_message;
+    expected_message << "function: "
+                     << "accessing element out of range. "
+                     << "index " << i << " out of range; "
+                     << "container is empty and cannot be indexed"
+                     << msg1_ << msg2_;
+    return expected_message.str();
+  }
+
+  template <class T>
   void test_throw(T y, size_t i) {
     using stan::math::out_of_range;
 
@@ -52,6 +63,14 @@ class ErrorHandlingScalar_out_of_range : public ::testing::Test {
     EXPECT_THROW_MSG(out_of_range(function_, y.size(), i), std::out_of_range,
                      expected_message_with_0_messages(y, i));
   }
+
+  template <class T>
+  void test_throw_empty(T y, size_t i) {
+    using stan::math::out_of_range;
+
+    EXPECT_THROW_MSG(out_of_range(function_, y.size(), i, msg1_, msg2_),
+                     std::out_of_range, expected_message_empty_container(y, i));
+  }
 };
 
 TEST_F(ErrorHandlingScalar_out_of_range, double_prim_scal) {
@@ -59,4 +78,9 @@ TEST_F(ErrorHandlingScalar_out_of_range, double_prim_scal) {
 
   test_throw(y, 0);
   test_throw(y, 5);
+
+  std::vector<double> z;
+
+  test_throw_empty(z, 0);
+  test_throw_empty(z, 5);
 }


### PR DESCRIPTION
## Summary

This returns a special message if a container is empty, while keeping the existing message unchanged for all other cases. I think the wording "container is empty and cannot be indexed" is quite clear, but I'm open to suggestions for improvement. Fixes #458.

## Tests
Added tests for size 0 arrays to both `out_of_range_test.cpp` and `check_range_test.cpp`.

## Side Effects

None.

## Checklist

- [X] Math issue #458

- [X] Copyright holder: Marco Colombo

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [X] the new changes are tested
