### PR TITLE
Bugfix/issue 1548 requires all not

### DIFF
--- a/stan/math/prim/mat/fun/trace_gen_inv_quad_form_ldlt.hpp
+++ b/stan/math/prim/mat/fun/trace_gen_inv_quad_form_ldlt.hpp
@@ -38,7 +38,7 @@ namespace math {
  * be multiplied by D.
  */
 template <typename T1, typename T2, typename T3, int R1, int C1, int R2, int C2,
-          int R3, int C3, typename = require_any_not_var_t<T1, T2, T3>>
+          int R3, int C3, typename = require_all_not_var_t<T1, T2, T3>>
 inline return_type_t<T1, T2, T3> trace_gen_inv_quad_form_ldlt(
     const Eigen::Matrix<T1, R1, C1> &D, const LDLT_factor<T2, R2, C2> &A,
     const Eigen::Matrix<T3, R3, C3> &B) {

--- a/stan/math/prim/mat/fun/trace_gen_quad_form.hpp
+++ b/stan/math/prim/mat/fun/trace_gen_quad_form.hpp
@@ -36,7 +36,7 @@ namespace math {
  * be multiplied by D.
  */
 template <typename TD, int RD, int CD, typename TA, int RA, int CA, typename TB,
-          int RB, int CB, typename = require_any_not_var_t<TD, TA, TB>>
+          int RB, int CB, typename = require_all_not_var_t<TD, TA, TB>>
 inline return_type_t<TD, TA, TB> trace_gen_quad_form(
     const Eigen::Matrix<TD, RD, CD> &D, const Eigen::Matrix<TA, RA, CA> &A,
     const Eigen::Matrix<TB, RB, CB> &B) {

--- a/stan/math/prim/mat/fun/trace_inv_quad_form_ldlt.hpp
+++ b/stan/math/prim/mat/fun/trace_inv_quad_form_ldlt.hpp
@@ -29,7 +29,7 @@ namespace math {
  *
  */
 template <typename T1, typename T2, int R2, int C2, int R3, int C3,
-          typename = require_any_not_var_t<T1, T2>>
+          typename = require_all_not_var_t<T1, T2>>
 inline return_type_t<T1, T2> trace_inv_quad_form_ldlt(
     const LDLT_factor<T1, R2, C2> &A, const Eigen::Matrix<T2, R3, C3> &B) {
   if (A.rows() == 0 && B.rows() == 0) {

--- a/stan/math/prim/meta/require_generics.hpp
+++ b/stan/math/prim/meta/require_generics.hpp
@@ -204,7 +204,7 @@ using require_any_t = std::enable_if_t<math::disjunction<Checks...>::value>;
  */
 template <class... Checks>
 using require_all_not_t
-    = std::enable_if_t<!math::conjunction<Checks...>::value>;
+    = std::enable_if_t<!math::disjunction<Checks...>::value>;
 
 /**
  * If any condition is false, template is enabled.
@@ -213,7 +213,7 @@ using require_all_not_t
  */
 template <class... Checks>
 using require_any_not_t
-    = std::enable_if_t<!math::disjunction<Checks...>::value>;
+    = std::enable_if_t<!math::conjunction<Checks...>::value>;
 
 /**
  * Require both types to be the same
@@ -236,9 +236,12 @@ template <typename T, typename... Types>
 using require_all_same_t
     = require_all_t<std::is_same<std::decay_t<T>, std::decay_t<Types>>...>;
 
+/**
+ * Require the first type to differ from at least one of the rest
+ */
 template <typename T, typename... Types>
 using require_any_not_same_t
-    = require_all_not_t<std::is_same<std::decay_t<T>, std::decay_t<Types>>...>;
+    = require_any_not_t<std::is_same<std::decay_t<T>, std::decay_t<Types>>...>;
 
 /**
  * Require both types to be the same
@@ -268,7 +271,7 @@ using require_all_same_st
  */
 template <typename T, typename... Types>
 using require_any_not_same_st
-    = require_all_not_t<std::is_same<scalar_type_t<std::decay_t<T>>,
+    = require_any_not_t<std::is_same<scalar_type_t<std::decay_t<T>>,
                                      scalar_type_t<std::decay_t<Types>>>...>;
 
 /**
@@ -295,7 +298,7 @@ using require_all_same_vt
 
 template <typename T, typename... Types>
 using require_any_not_same_vt
-    = require_all_not_t<std::is_same<value_type_t<std::decay_t<T>>,
+    = require_any_not_t<std::is_same<value_type_t<std::decay_t<T>>,
                                      value_type_t<std::decay_t<Types>>>...>;
 
 /**
@@ -323,7 +326,7 @@ using require_all_convertible_t = require_all_t<
  * require T is not convertible to any Types
  */
 template <typename T, typename... Types>
-using require_any_not_convertible_t = require_all_not_t<
+using require_any_not_convertible_t = require_any_not_t<
     std::is_convertible<std::decay_t<T>, std::decay_t<Types>>...>;
 
 /**

--- a/test/unit/math/opencl/require_generics_test.cpp
+++ b/test/unit/math/opencl/require_generics_test.cpp
@@ -105,12 +105,12 @@ TEST(requires, any_not_matrix_cl_test) {
   EXPECT_FALSE((require_any_not_matrix_cl_tester<std::is_floating_point,
                                                  matrix_cl<double>,
                                                  matrix_cl<double>>::value));
-  EXPECT_FALSE((require_any_not_matrix_cl_tester<std::is_floating_point, double,
+  EXPECT_TRUE((require_any_not_matrix_cl_tester<std::is_floating_point, double,
                                                  matrix_cl<double>>::value));
-  EXPECT_FALSE(
+  EXPECT_TRUE(
       (require_any_not_matrix_cl_tester<std::is_floating_point,
                                         matrix_cl<double>, double>::value));
-  EXPECT_FALSE((require_any_not_matrix_cl_tester<std::is_floating_point,
+  EXPECT_TRUE((require_any_not_matrix_cl_tester<std::is_floating_point,
                                                  matrix_cl<std::string>,
                                                  matrix_cl<double>>::value));
   EXPECT_TRUE((require_any_not_matrix_cl_tester<std::is_floating_point, int,
@@ -171,12 +171,12 @@ TEST(requires, all_not_matrix_cl_test) {
   EXPECT_FALSE((require_all_not_matrix_cl_tester<std::is_floating_point,
                                                  matrix_cl<double>,
                                                  matrix_cl<double>>::value));
-  EXPECT_TRUE((require_all_not_matrix_cl_tester<std::is_floating_point, double,
+  EXPECT_FALSE((require_all_not_matrix_cl_tester<std::is_floating_point, double,
                                                 matrix_cl<double>>::value));
-  EXPECT_TRUE(
+  EXPECT_FALSE(
       (require_all_not_matrix_cl_tester<std::is_floating_point,
                                         matrix_cl<double>, double>::value));
-  EXPECT_TRUE((require_all_not_matrix_cl_tester<std::is_floating_point,
+  EXPECT_FALSE((require_all_not_matrix_cl_tester<std::is_floating_point,
                                                 matrix_cl<std::string>,
                                                 matrix_cl<double>>::value));
   EXPECT_TRUE((require_all_not_matrix_cl_tester<std::is_floating_point, int,

--- a/test/unit/math/opencl/require_generics_test.cpp
+++ b/test/unit/math/opencl/require_generics_test.cpp
@@ -106,13 +106,13 @@ TEST(requires, any_not_matrix_cl_test) {
                                                  matrix_cl<double>,
                                                  matrix_cl<double>>::value));
   EXPECT_TRUE((require_any_not_matrix_cl_tester<std::is_floating_point, double,
-                                                 matrix_cl<double>>::value));
+                                                matrix_cl<double>>::value));
   EXPECT_TRUE(
       (require_any_not_matrix_cl_tester<std::is_floating_point,
                                         matrix_cl<double>, double>::value));
   EXPECT_TRUE((require_any_not_matrix_cl_tester<std::is_floating_point,
-                                                 matrix_cl<std::string>,
-                                                 matrix_cl<double>>::value));
+                                                matrix_cl<std::string>,
+                                                matrix_cl<double>>::value));
   EXPECT_TRUE((require_any_not_matrix_cl_tester<std::is_floating_point, int,
                                                 std::string>::value));
   EXPECT_TRUE((require_any_not_matrix_cl_tester<std::is_arithmetic, double,
@@ -172,13 +172,13 @@ TEST(requires, all_not_matrix_cl_test) {
                                                  matrix_cl<double>,
                                                  matrix_cl<double>>::value));
   EXPECT_FALSE((require_all_not_matrix_cl_tester<std::is_floating_point, double,
-                                                matrix_cl<double>>::value));
+                                                 matrix_cl<double>>::value));
   EXPECT_FALSE(
       (require_all_not_matrix_cl_tester<std::is_floating_point,
                                         matrix_cl<double>, double>::value));
   EXPECT_FALSE((require_all_not_matrix_cl_tester<std::is_floating_point,
-                                                matrix_cl<std::string>,
-                                                matrix_cl<double>>::value));
+                                                 matrix_cl<std::string>,
+                                                 matrix_cl<double>>::value));
   EXPECT_TRUE((require_all_not_matrix_cl_tester<std::is_floating_point, int,
                                                 std::string>::value));
   EXPECT_TRUE((require_all_not_matrix_cl_tester<std::is_arithmetic, double,

--- a/test/unit/math/prim/meta/require_generics_test.cpp
+++ b/test/unit/math/prim/meta/require_generics_test.cpp
@@ -27,8 +27,8 @@ TEST(requires_prim_scal, all_not_test) {
                                         std::false_type>::value));
   EXPECT_FALSE((require_variadic_checker<require_all_not_t, std::true_type,
                                          std::true_type>::value));
-  EXPECT_TRUE((require_variadic_checker<require_all_not_t, std::true_type,
-                                        std::false_type>::value));
+  EXPECT_FALSE((require_variadic_checker<require_all_not_t, std::true_type,
+                                         std::false_type>::value));
 }
 
 TEST(requires_prim_scal, any_not_test) {
@@ -38,8 +38,8 @@ TEST(requires_prim_scal, any_not_test) {
                                         std::false_type>::value));
   EXPECT_FALSE((require_variadic_checker<require_any_not_t, std::true_type,
                                          std::true_type>::value));
-  EXPECT_FALSE((require_variadic_checker<require_any_not_t, std::true_type,
-                                         std::false_type>::value));
+  EXPECT_TRUE((require_variadic_checker<require_any_not_t, std::true_type,
+                                        std::false_type>::value));
 }
 
 TEST(requires_prim_scal, all_test) {
@@ -97,9 +97,11 @@ TEST(requires_prim_scal, all_same_test) {
       (require_variadic_checker<require_all_same_t, int, int, int>::value));
 }
 
-TEST(requires_prim_scal, all_not_same_test) {
+TEST(requires_prim_scal, any_not_same_test) {
   using stan::require_any_not_same_t;
   using stan::test::require_variadic_checker;
+  EXPECT_TRUE((require_variadic_checker<require_any_not_same_t, double, int,
+                                        int>::value));
   EXPECT_TRUE((require_variadic_checker<require_any_not_same_t, double, int,
                                         double>::value));
   EXPECT_FALSE((require_variadic_checker<require_any_not_same_t, double, double,
@@ -135,6 +137,8 @@ TEST(requires_prim_scal, all_convertible_test) {
   using stan::require_all_convertible_t;
   using stan::test::require_variadic_checker;
   EXPECT_FALSE((require_variadic_checker<require_all_convertible_t, double,
+                                         std::string, std::string>::value));
+  EXPECT_FALSE((require_variadic_checker<require_all_convertible_t, double,
                                          std::string, double>::value));
   EXPECT_TRUE((require_variadic_checker<require_all_convertible_t, double, int,
                                         int>::value));
@@ -142,9 +146,11 @@ TEST(requires_prim_scal, all_convertible_test) {
                                         int>::value));
 }
 
-TEST(requires_prim_scal, all_not_convertible_test) {
+TEST(requires_prim_scal, any_not_convertible_test) {
   using stan::require_any_not_convertible_t;
   using stan::test::require_variadic_checker;
+  EXPECT_TRUE((require_variadic_checker<require_any_not_convertible_t, double,
+                                        std::string, std::string>::value));
   EXPECT_TRUE((require_variadic_checker<require_any_not_convertible_t, double,
                                         int, std::string>::value));
   EXPECT_FALSE((require_variadic_checker<require_any_not_convertible_t, double,
@@ -508,9 +514,12 @@ TEST(requires_prim_mat, all_same_vtest) {
                                         eigen_x<int>, eigen_x<int>>::value));
 }
 
-TEST(requires_prim_mat, all_not_same_vtest) {
+TEST(requires_prim_mat, any_not_same_vtest) {
   using stan::require_any_not_same_vt;
   using stan::test::require_variadic_checker;
+  EXPECT_TRUE(
+      (require_variadic_checker<require_any_not_same_vt, eigen_x<double>,
+                                eigen_x<int>, eigen_x<int>>::value));
   EXPECT_TRUE(
       (require_variadic_checker<require_any_not_same_vt, eigen_x<double>,
                                 eigen_x<int>, eigen_x<double>>::value));
@@ -556,9 +565,12 @@ TEST(requires_prim_mat, all_same_stest) {
                                         eigen_x<int>, eigen_x<int>>::value));
 }
 
-TEST(requires_prim_mat, all_not_same_stest) {
+TEST(requires_prim_mat, any_not_same_stest) {
   using stan::require_any_not_same_st;
   using stan::test::require_variadic_checker;
+  EXPECT_TRUE(
+      (require_variadic_checker<require_any_not_same_st, eigen_x<double>,
+                                eigen_x<int>, eigen_x<int>>::value));
   EXPECT_TRUE(
       (require_variadic_checker<require_any_not_same_st, eigen_x<double>,
                                 eigen_x<int>, eigen_x<double>>::value));

--- a/test/unit/math/require_util.hpp
+++ b/test/unit/math/require_util.hpp
@@ -124,28 +124,28 @@ struct require_scal_checker {
   }
   static void all() {
     using stan::test::require_variadic_checker;
-    EXPECT_FALSE((require_variadic_checker<checker, dummy, dummy>::value));
+    EXPECT_FALSE((require_variadic_checker<checker, dummy>::value));
     EXPECT_FALSE((require_variadic_checker<checker, dummy, Types...>::value));
     EXPECT_FALSE((require_variadic_checker<checker, Types..., dummy>::value));
     EXPECT_TRUE((require_variadic_checker<checker, Types...>::value));
   }
   static void all_not() {
     using stan::test::require_variadic_checker;
-    EXPECT_TRUE((require_variadic_checker<checker, dummy, dummy>::value));
+    EXPECT_TRUE((require_variadic_checker<checker, dummy>::value));
     EXPECT_FALSE((require_variadic_checker<checker, dummy, Types...>::value));
     EXPECT_FALSE((require_variadic_checker<checker, Types..., dummy>::value));
     EXPECT_FALSE((require_variadic_checker<checker, Types...>::value));
   }
   static void any() {
     using stan::test::require_variadic_checker;
-    EXPECT_FALSE((require_variadic_checker<checker, dummy, dummy>::value));
+    EXPECT_FALSE((require_variadic_checker<checker, dummy>::value));
     EXPECT_TRUE((require_variadic_checker<checker, dummy, Types...>::value));
     EXPECT_TRUE((require_variadic_checker<checker, Types..., dummy>::value));
     EXPECT_TRUE((require_variadic_checker<checker, Types...>::value));
   }
   static void any_not() {
     using stan::test::require_variadic_checker;
-    EXPECT_TRUE((require_variadic_checker<checker, dummy, dummy>::value));
+    EXPECT_TRUE((require_variadic_checker<checker, dummy>::value));
     EXPECT_TRUE((require_variadic_checker<checker, dummy, Types...>::value));
     EXPECT_TRUE((require_variadic_checker<checker, Types..., dummy>::value));
     EXPECT_FALSE((require_variadic_checker<checker, Types...>::value));

--- a/test/unit/math/require_util.hpp
+++ b/test/unit/math/require_util.hpp
@@ -107,9 +107,8 @@ struct require_scal_checker {
 
   static void all_not() {
     using stan::test::require_variadic_checker;
-    EXPECT_TRUE((require_variadic_checker<checker, dummy, Types...>::value));
-    EXPECT_TRUE((require_variadic_checker<checker, Types..., dummy>::value));
-    EXPECT_FALSE((require_variadic_checker<checker, Types...>::value));
+    EXPECT_TRUE((require_variadic_checker<checker, dummy, dummy>::value));
+    EXPECT_FALSE((require_variadic_checker<checker, Types..., dummy>::value));
   }
 
   static void any() {
@@ -120,8 +119,9 @@ struct require_scal_checker {
 
   static void any_not() {
     using stan::test::require_variadic_checker;
-    EXPECT_TRUE((require_variadic_checker<checker, dummy, dummy>::value));
-    EXPECT_FALSE((require_variadic_checker<checker, Types..., dummy>::value));
+    EXPECT_TRUE((require_variadic_checker<checker, dummy, Types...>::value));
+    EXPECT_TRUE((require_variadic_checker<checker, Types..., dummy>::value));
+    EXPECT_FALSE((require_variadic_checker<checker, Types...>::value));
   }
 };
 
@@ -221,17 +221,17 @@ struct require_container_checker {
     EXPECT_FALSE((variadic_container_require_tester<checker, ContainerCheck,
                                                     Container<double>,
                                                     Container<double>>::value));
-    EXPECT_FALSE((variadic_container_require_tester<checker, ContainerCheck,
-                                                    Container<float>,
-                                                    Container<double>>::value));
-    EXPECT_TRUE(
+    EXPECT_FALSE(
         (variadic_container_require_tester<checker, ContainerCheck, double,
                                            Container<double>>::value));
-    EXPECT_TRUE(
+    EXPECT_FALSE(
         (variadic_container_require_tester<checker, ContainerCheck,
                                            Container<double>, double>::value));
+    EXPECT_FALSE((variadic_container_require_tester<checker, ContainerCheck,
+                                                    Container<std::string>,
+                                                    Container<double>>::value));
     EXPECT_TRUE((variadic_container_require_tester<checker, ContainerCheck, int,
-                                                   std::string>::value));
+                                                   float>::value));
     EXPECT_TRUE((variadic_container_require_tester<checker, ContainerCheck,
                                                    double, double>::value));
   }
@@ -263,17 +263,17 @@ struct require_container_checker {
     EXPECT_FALSE((variadic_container_require_tester<checker, ContainerCheck,
                                                     Container<double>,
                                                     Container<double>>::value));
-    EXPECT_FALSE(
+    EXPECT_FALSE((variadic_container_require_tester<checker, ContainerCheck,
+                                                    Container<float>,
+                                                    Container<double>>::value));
+    EXPECT_TRUE(
         (variadic_container_require_tester<checker, ContainerCheck, double,
                                            Container<double>>::value));
-    EXPECT_FALSE(
+    EXPECT_TRUE(
         (variadic_container_require_tester<checker, ContainerCheck,
                                            Container<double>, double>::value));
-    EXPECT_FALSE((variadic_container_require_tester<checker, ContainerCheck,
-                                                    Container<std::string>,
-                                                    Container<double>>::value));
     EXPECT_TRUE((variadic_container_require_tester<checker, ContainerCheck, int,
-                                                   float>::value));
+                                                   std::string>::value));
     EXPECT_TRUE((variadic_container_require_tester<checker, ContainerCheck,
                                                    double, double>::value));
   }

--- a/test/unit/math/require_util.hpp
+++ b/test/unit/math/require_util.hpp
@@ -113,38 +113,32 @@ template <template <class...> class checker, typename... Types>
 struct require_scal_checker {
   struct dummy {};
   static void unary() {
-    using stan::test::unary_require_tester;
     EXPECT_FALSE((unary_require_tester<checker, dummy>::value));
     EXPECT_TRUE((unary_require_tester<checker, Types...>::value));
   }
   static void not_unary() {
-    using stan::test::unary_require_tester;
     EXPECT_TRUE((unary_not_require_tester<checker, dummy>::value));
     EXPECT_FALSE((unary_not_require_tester<checker, Types...>::value));
   }
   static void all() {
-    using stan::test::require_variadic_checker;
     EXPECT_FALSE((require_variadic_checker<checker, dummy>::value));
     EXPECT_FALSE((require_variadic_checker<checker, dummy, Types...>::value));
     EXPECT_FALSE((require_variadic_checker<checker, Types..., dummy>::value));
     EXPECT_TRUE((require_variadic_checker<checker, Types...>::value));
   }
   static void all_not() {
-    using stan::test::require_variadic_checker;
     EXPECT_TRUE((require_variadic_checker<checker, dummy>::value));
     EXPECT_FALSE((require_variadic_checker<checker, dummy, Types...>::value));
     EXPECT_FALSE((require_variadic_checker<checker, Types..., dummy>::value));
     EXPECT_FALSE((require_variadic_checker<checker, Types...>::value));
   }
   static void any() {
-    using stan::test::require_variadic_checker;
     EXPECT_FALSE((require_variadic_checker<checker, dummy>::value));
     EXPECT_TRUE((require_variadic_checker<checker, dummy, Types...>::value));
     EXPECT_TRUE((require_variadic_checker<checker, Types..., dummy>::value));
     EXPECT_TRUE((require_variadic_checker<checker, Types...>::value));
   }
   static void any_not() {
-    using stan::test::require_variadic_checker;
     EXPECT_TRUE((require_variadic_checker<checker, dummy>::value));
     EXPECT_TRUE((require_variadic_checker<checker, dummy, Types...>::value));
     EXPECT_TRUE((require_variadic_checker<checker, Types..., dummy>::value));
@@ -202,7 +196,6 @@ template <template <template <class...> class TypeCheck, class...>
 struct require_container_checker {
   template <template <class...> class ContainerCheck>
   static void unary() {
-    using stan::test::unary_container_require_tester;
     EXPECT_FALSE((unary_container_require_tester<checker, ContainerCheck,
                                                  double>::value));
     EXPECT_TRUE((unary_container_require_tester<checker, ContainerCheck,
@@ -213,7 +206,6 @@ struct require_container_checker {
 
   template <template <class...> class ContainerCheck>
   static void not_unary() {
-    using stan::test::unary_container_require_tester;
     EXPECT_TRUE((unary_container_require_tester<checker, ContainerCheck,
                                                 double>::value));
     EXPECT_FALSE((unary_container_require_tester<checker, ContainerCheck,
@@ -224,7 +216,6 @@ struct require_container_checker {
 
   template <template <class...> class ContainerCheck>
   static void all() {
-    using stan::test::variadic_container_require_tester;
     EXPECT_TRUE((variadic_container_require_tester<checker, ContainerCheck,
                                                    Container<double>,
                                                    Container<double>>::value));
@@ -245,7 +236,6 @@ struct require_container_checker {
 
   template <template <class...> class ContainerCheck>
   static void all_not() {
-    using stan::test::variadic_container_require_tester;
     EXPECT_FALSE((variadic_container_require_tester<checker, ContainerCheck,
                                                     Container<double>,
                                                     Container<double>>::value));
@@ -266,7 +256,6 @@ struct require_container_checker {
 
   template <template <class...> class ContainerCheck>
   static void any() {
-    using stan::test::variadic_container_require_tester;
     EXPECT_TRUE((variadic_container_require_tester<checker, ContainerCheck,
                                                    Container<double>,
                                                    Container<double>>::value));
@@ -287,7 +276,6 @@ struct require_container_checker {
 
   template <template <class...> class ContainerCheck>
   static void any_not() {
-    using stan::test::require_variadic_checker;
     EXPECT_FALSE((variadic_container_require_tester<checker, ContainerCheck,
                                                     Container<double>,
                                                     Container<double>>::value));

--- a/test/unit/math/require_util.hpp
+++ b/test/unit/math/require_util.hpp
@@ -124,6 +124,7 @@ struct require_scal_checker {
   }
   static void all() {
     using stan::test::require_variadic_checker;
+    EXPECT_FALSE((require_variadic_checker<checker, dummy, dummy>::value));
     EXPECT_FALSE((require_variadic_checker<checker, dummy, Types...>::value));
     EXPECT_FALSE((require_variadic_checker<checker, Types..., dummy>::value));
     EXPECT_TRUE((require_variadic_checker<checker, Types...>::value));
@@ -131,15 +132,20 @@ struct require_scal_checker {
   static void all_not() {
     using stan::test::require_variadic_checker;
     EXPECT_TRUE((require_variadic_checker<checker, dummy, dummy>::value));
+    EXPECT_FALSE((require_variadic_checker<checker, dummy, Types...>::value));
     EXPECT_FALSE((require_variadic_checker<checker, Types..., dummy>::value));
+    EXPECT_FALSE((require_variadic_checker<checker, Types...>::value));
   }
   static void any() {
     using stan::test::require_variadic_checker;
     EXPECT_FALSE((require_variadic_checker<checker, dummy, dummy>::value));
+    EXPECT_TRUE((require_variadic_checker<checker, dummy, Types...>::value));
     EXPECT_TRUE((require_variadic_checker<checker, Types..., dummy>::value));
+    EXPECT_TRUE((require_variadic_checker<checker, Types...>::value));
   }
   static void any_not() {
     using stan::test::require_variadic_checker;
+    EXPECT_TRUE((require_variadic_checker<checker, dummy, dummy>::value));
     EXPECT_TRUE((require_variadic_checker<checker, dummy, Types...>::value));
     EXPECT_TRUE((require_variadic_checker<checker, Types..., dummy>::value));
     EXPECT_FALSE((require_variadic_checker<checker, Types...>::value));

--- a/test/unit/math/require_util.hpp
+++ b/test/unit/math/require_util.hpp
@@ -30,6 +30,14 @@ struct conjunction<B1> : B1 {};
 template <class B1, class... Bn>
 struct conjunction<B1, Bn...>
     : std::conditional_t<bool(B1::value), conjunction<Bn...>, B1> {};
+
+template <class...>
+struct disjunction : std::true_type {};
+template <class B1>
+struct disjunction<B1> : B1 {};
+template <class B1, class... Bn>
+struct disjunction<B1, Bn...>
+    : std::conditional_t<bool(B1::value), B1, disjunction<Bn...>> {};
 }  // namespace internal
 
 /**
@@ -70,6 +78,22 @@ template <template <class...> class Check>
 struct unary_require_tester<Check, void> : std::true_type {};
 
 /**
+ * Used for checking an enable_if alias, when the enable_if goes off
+ * the struct holds a /c value of true, else false.
+ * @tparam Check The enable_if alias.
+ * @tparam Types Parameter pack of types that will be checked individually.
+ * @note Because of /c disjunction, the member /c value will only be true
+ *  if at least one of the types passes.
+ */
+template <template <class...> class Check, typename... Types>
+struct unary_not_require_tester
+    : internal::disjunction<unary_require_tester_impl<Check, Types>...> {};
+
+// For the end of recursion
+template <template <class...> class Check>
+struct unary_not_require_tester<Check, void> : std::true_type {};
+
+/**
  * This is the same as above, but instead all types are checked at once
  * since this is used for the require_any/all type checks
  */
@@ -95,8 +119,8 @@ struct require_scal_checker {
   }
   static void not_unary() {
     using stan::test::unary_require_tester;
-    EXPECT_TRUE((unary_require_tester<checker, dummy>::value));
-    EXPECT_FALSE((unary_require_tester<checker, Types...>::value));
+    EXPECT_TRUE((unary_not_require_tester<checker, dummy>::value));
+    EXPECT_FALSE((unary_not_require_tester<checker, Types...>::value));
   }
   static void all() {
     using stan::test::require_variadic_checker;
@@ -104,19 +128,16 @@ struct require_scal_checker {
     EXPECT_FALSE((require_variadic_checker<checker, Types..., dummy>::value));
     EXPECT_TRUE((require_variadic_checker<checker, Types...>::value));
   }
-
   static void all_not() {
     using stan::test::require_variadic_checker;
     EXPECT_TRUE((require_variadic_checker<checker, dummy, dummy>::value));
     EXPECT_FALSE((require_variadic_checker<checker, Types..., dummy>::value));
   }
-
   static void any() {
     using stan::test::require_variadic_checker;
     EXPECT_FALSE((require_variadic_checker<checker, dummy, dummy>::value));
     EXPECT_TRUE((require_variadic_checker<checker, Types..., dummy>::value));
   }
-
   static void any_not() {
     using stan::test::require_variadic_checker;
     EXPECT_TRUE((require_variadic_checker<checker, dummy, Types...>::value));
@@ -183,6 +204,7 @@ struct require_container_checker {
     EXPECT_TRUE((unary_container_require_tester<checker, ContainerCheck,
                                                 Container<float>>::value));
   }
+
   template <template <class...> class ContainerCheck>
   static void not_unary() {
     using stan::test::unary_container_require_tester;


### PR DESCRIPTION
## Summary

Fixes #1548.

This is the core of this PR:
```
 * If all conditions are false, template is enabled.
...
template <class... Checks>
using require_all_not_t
-    = std::enable_if_t<!math::conjunction<Checks...>::value>;
+    = std::enable_if_t<!math::disjunction<Checks...>::value>;
...
 * If any condition is false, template is enabled.
...
template <class... Checks>
using require_any_not_t
-    = std::enable_if_t<!math::disjunction<Checks...>::value>;
+    = std::enable_if_t<!math::conjunction<Checks...>::value>;
```

After this change, the documentation is correct, require_all_not_t enables the template iff all conditions are false; and require_any_not_t enables the template iff any condition is false.

## Tests

The tests for any_not and all_not were consistent with the old implementations and basically had to be swapped as well.

## Side Effects

This is a breaking change for users of require_(any|all)\_not_* functions, other than require_any_not_same_t, require_any_not_convertible_t, require_any_not_same_vt, and require_any_not_same_st; those four functions did not change in behavior. Others, like require_all_not_var_t did.

I fixed all the users inside of the math library.

## Checklist

- [X] Math issue #1548

- [X] Copyright holder: Peter Wicks Stringfield

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [X] the new changes are tested
