### PR TITLE
Fix beta binomial CDF/CCDF at the zero boundary

### DIFF
--- a/stan/math/prim/scal/prob/beta_binomial_cdf.hpp
+++ b/stan/math/prim/scal/prob/beta_binomial_cdf.hpp
@@ -27,6 +27,7 @@ namespace math {
  * @tparam T_N type of population size parameter
  * @tparam T_size1 type of prior success parameter
  * @tparam T_size2 type of prior failure parameter
+ *
  * @param n success parameter
  * @param N population size parameter
  * @param alpha prior success parameter
@@ -69,7 +70,7 @@ return_type_t<T_size1, T_size2> beta_binomial_cdf(const T_n& n, const T_N& N,
   // Explicit return for extreme values
   // The gradients are technically ill-defined, but treated as zero
   for (size_t i = 0; i < stan::length(n); i++) {
-    if (value_of(n_vec[i]) <= 0) {
+    if (value_of(n_vec[i]) < 0) {
       return ops_partials.build(0.0);
     }
   }

--- a/stan/math/prim/scal/prob/beta_binomial_lccdf.hpp
+++ b/stan/math/prim/scal/prob/beta_binomial_lccdf.hpp
@@ -27,6 +27,7 @@ namespace math {
  * @tparam T_N type of population size parameter
  * @tparam T_size1 type of prior success parameter
  * @tparam T_size2 type of prior failure parameter
+ *
  * @param n success parameter
  * @param N population size parameter
  * @param alpha prior success parameter
@@ -68,16 +69,16 @@ return_type_t<T_size1, T_size2> beta_binomial_lccdf(const T_n& n, const T_N& N,
   operands_and_partials<T_size1, T_size2> ops_partials(alpha, beta);
 
   // Explicit return for extreme values
-  // The gradients are technically ill-defined, but treated as neg infinity
+  // The gradients are technically ill-defined, but treated as zero
   for (size_t i = 0; i < stan::length(n); i++) {
-    if (value_of(n_vec[i]) <= 0) {
+    if (value_of(n_vec[i]) < 0) {
       return ops_partials.build(0.0);
     }
   }
 
   for (size_t i = 0; i < size; i++) {
     // Explicit results for extreme values
-    // The gradients are technically ill-defined, but treated as zero
+    // The gradients are technically ill-defined, but treated as neg infinity
     if (value_of(n_vec[i]) >= value_of(N_vec[i])) {
       return ops_partials.build(negative_infinity());
     }

--- a/stan/math/prim/scal/prob/beta_binomial_lcdf.hpp
+++ b/stan/math/prim/scal/prob/beta_binomial_lcdf.hpp
@@ -27,6 +27,7 @@ namespace math {
  * @tparam T_N type of population size parameter
  * @tparam T_size1 type of prior success parameter
  * @tparam T_size2 type of prior failure parameter
+ *
  * @param n success parameter
  * @param N population size parameter
  * @param alpha prior success parameter
@@ -70,7 +71,7 @@ return_type_t<T_size1, T_size2> beta_binomial_lcdf(const T_n& n, const T_N& N,
   // Explicit return for extreme values
   // The gradients are technically ill-defined, but treated as neg infinity
   for (size_t i = 0; i < stan::length(n); i++) {
-    if (value_of(n_vec[i]) <= 0) {
+    if (value_of(n_vec[i]) < 0) {
       return ops_partials.build(negative_infinity());
     }
   }

--- a/test/unit/math/prim/scal/prob/beta_binomial_ccdf_log_test.cpp
+++ b/test/unit/math/prim/scal/prob/beta_binomial_ccdf_log_test.cpp
@@ -1,5 +1,6 @@
 #include <stan/math/prim/scal.hpp>
 #include <gtest/gtest.h>
+#include <cmath>
 
 TEST(ProbBetaBinomial, ccdf_log_matches_lccdf) {
   int n = 2;
@@ -13,4 +14,19 @@ TEST(ProbBetaBinomial, ccdf_log_matches_lccdf) {
                       n, N, alpha, beta)),
                   (stan::math::beta_binomial_ccdf_log<int, int, double, double>(
                       n, N, alpha, beta)));
+}
+
+TEST(ProbBetaBinomial, lccdf_matches_lpmf) {
+  int n = 10;
+  int N = 10;
+  double alpha = 4.0;
+  double beta = 5.5;
+
+  double pmf_sum = 1.0;
+  for (int i = 0; i <= n; ++i) {
+    pmf_sum -= std::exp(stan::math::beta_binomial_lpmf(i, N, alpha, beta));
+    EXPECT_NEAR(pmf_sum,
+                std::exp(stan::math::beta_binomial_lccdf(i, N, alpha, beta)),
+                1e-8);
+  }
 }

--- a/test/unit/math/prim/scal/prob/beta_binomial_cdf_log_test.cpp
+++ b/test/unit/math/prim/scal/prob/beta_binomial_cdf_log_test.cpp
@@ -14,30 +14,19 @@ TEST(ProbBetaBinomial, cdf_log_matches_lcdf) {
               stan::math::beta_binomial_cdf_log(n, N, alpha, beta), 1e-8);
 }
 
-TEST(ProbBetaBinomial, lcdf_like_lcdf) {
-  int n = 10;
-  int N = 10;
-  double alpha = 3.0;
-  double beta = 1.0;
-
-  EXPECT_NEAR(0.0, stan::math::beta_binomial_lcdf(n, N, alpha, beta), 1e-8);
-  EXPECT_NEAR(
-      0.0, std::exp(stan::math::beta_binomial_lcdf(0.0, N, alpha, beta)), 1e-8);
-}
-
 TEST(ProbBetaBinomial, lcdf_matches_lpmf) {
-  int n = 9;
+  int n = 10;
   int N = 10;
   double alpha = 3.0;
   double beta = 2.1;
 
   double pmf_sum = 0.0;
-  for (int i = 0; i <= n; ++i)
+  for (int i = 0; i <= n; ++i) {
     pmf_sum += std::exp(stan::math::beta_binomial_lpmf(i, N, alpha, beta));
-
-  EXPECT_NEAR(pmf_sum,
-              std::exp(stan::math::beta_binomial_lcdf(n, N, alpha, beta)),
-              1e-8);
+    EXPECT_NEAR(pmf_sum,
+                std::exp(stan::math::beta_binomial_lcdf(i, N, alpha, beta)),
+                1e-8);
+  }
 }
 
 TEST(ProbBetaBinomial, lcdf_matches_mathematica) {


### PR DESCRIPTION
## Summary

The beta binomial CDF/CCDF return the wrong value for `n = 0`. This addresses that problem so that at `n = 0` the CDF equates the pmf at the same point, and the CCDF is 1 -  pmf, as expected. Fixes #688.

## Tests

The existing `test/unit/math/prim/scal/prob/beta_binomial_cdf_log_test.cpp` expected the wrong result (0.0) at `n = 0`. Rather than having a separate test for the boundaries (weirdly named `lcdf_like_lcdf`), I extended the `lcdf_matches_lpmf` test to include and test both upper and lower boundary, as well as all intermediate points.

There were no test for boundaries in the `beta_binomial_ccdf_log_test.cpp` file, so I added one similar to the cdf version.

## Side Effects

None.

## Checklist

- [X] Math issue #688

- [X] Copyright holder: Marco Colombo

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [X] the new changes are tested