### PR TITLE
Feature/issue 1465 standalone

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Documentation for Stan math is available at [mc-stan.org/math](https://mc-stan.o
 
 Installation
 ------------
-The Stan Math Library is a C++ library which depends on the Intel TBB library and requires for some functionality (ordinary differential equations and root solving) on the Sundials library.
+The Stan Math Library is a C++ library which depends on the Intel TBB library and requires for some functionality (ordinary differential equations and root solving) on the Sundials library. As build system the make facility is used to manage all dependencies.
 
 A simple hello world program using Stan Math is as follows:
 
@@ -45,12 +45,13 @@ If this is in the file `/path/to/foo/foo.cpp`, then you can compile and run this
 
 ```bash
 > cd /path/to/foo
-> clang++ -std=c++1y -I /path/to/stan-math -I /path/to/Eigen -I /path/to/boost -I /path/to/sundials -I /path/to/tbb -L /path/to/tbb-libs -ltbb -D_REENTRANT  foo.cpp
-> ./a.out
+> make -f path/to/stan-math/make/standalone math-libs
+> make -f path/to/stan-math/make/standalone foo
+> ./foo
 log normal(1 | 2, 3)=-2.07311
 ```
 
-The `-I` includes provide paths pointing to the five necessary includes:
+The first make command with the `math-libs` target ensures that all binary dependencies are build and ready to use. The second make command ensures that all dependencies of Stan Math are available to the compiler which are:
 
 * Stan Math Library:  path to source directory that contains `stan` as a subdirectory
 * Eigen C++ Matrix Library:  path to source directory that contains `Eigen` as a subdirectory
@@ -60,11 +61,16 @@ The `-I` includes provide paths pointing to the five necessary includes:
 
 Note that the paths should *not* include the final directories `stan`, `Eigen`, or `boost` on the paths.  An example of a real instantiation:
 
-```
-clang++ -std=c++1y -I ~/stan-dev/math -I ~/stan-dev/math/lib/eigen_3.3.3/ -I ~/stan-dev/math/lib/boost_1.69.0/ -I ~/stan-dev/math/lib/sundials_4.1.0/include  -I ~/stan-dev/math/lib/tbb_2019_U8/include -L ~/stan-dev/math/lib/tbb -ltbb -Wl,-rpath,"~/stan-dev/math/lib/tbb" -D_REENTRANT foo.cpp
+```bash
+> make -f ~/stan-dev/math/make/standalone math-libs
+> make -f ~/stan-dev/math/make/standalone foo
 ```
 
-The following directories all exist below the links given to `-I`: `~/stan-dev/math/stan` and `~/stan-dev/math/lib/eigen_3.3.3/Eigen` and `~/stan-dev/math/lib/boost_1.69.0/boost` and `~/stan-dev/math/lib/sundials_4.1.0/include` and `~/stan-dev/math/lib/tbb_2019_U8/include`. The `~/stan-dev/math/lib/tbb` directory is created by the stan-math makefiles automatically when running any unit test (for example with `./runTests.py test/unit/math/rev/core/agrad_test.cpp`). The `-Wl,-rpath,...` instruct the linker to hard-code the path to the Intel TBB library inside the stan-math directory into the final binary. This way the Intel TBB is found when executing the program.
+The `math-libs` target must only be called a single time and can be omitted for subsequent compilations.
+
+The standalone makefile ensure that all the required `-I` include statements are given to the compiler and the necessary libraries are linked: `~/stan-dev/math/stan` and `~/stan-dev/math/lib/eigen_3.3.3/Eigen` and `~/stan-dev/math/lib/boost_1.69.0/boost` and `~/stan-dev/math/lib/sundials_4.1.0/include` and `~/stan-dev/math/lib/tbb_2019_U8/include`. The `~/stan-dev/math/lib/tbb` directory is created by the math-libs makefile target automatically. The `-Wl,-rpath,...` instruct the linker to hard-code the path to the Intel TBB library inside the stan-math directory into the final binary. This way the Intel TBB is found when executing the program.
+
+Note for Windows users: On Windows the rpath feature to hardcode an absolute path to a dynamically loaded library does not work. On Windows the TBB dynamic library tbb.dll is located in the math/lib/tbb directory. The user can choose to either copy this file to the same directory of the executable or to add the directory path/to/math/lib/tbb as absolute path to the system wide PATH variable.
 
 Other Compilers
 ---------------

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ The `math-libs` target must only be called a single time and can be omitted for 
 
 The standalone makefile ensure that all the required `-I` include statements are given to the compiler and the necessary libraries are linked: `~/stan-dev/math/stan` and `~/stan-dev/math/lib/eigen_3.3.3/Eigen` and `~/stan-dev/math/lib/boost_1.69.0/boost` and `~/stan-dev/math/lib/sundials_4.1.0/include` and `~/stan-dev/math/lib/tbb_2019_U8/include`. The `~/stan-dev/math/lib/tbb` directory is created by the math-libs makefile target automatically. The `-Wl,-rpath,...` instruct the linker to hard-code the path to the Intel TBB library inside the stan-math directory into the final binary. This way the Intel TBB is found when executing the program.
 
-Note for Windows users: On Windows the rpath feature to hardcode an absolute path to a dynamically loaded library does not work. On Windows the TBB dynamic library tbb.dll is located in the math/lib/tbb directory. The user can choose to either copy this file to the same directory of the executable or to add the directory path/to/math/lib/tbb as absolute path to the system wide PATH variable.
+Note for Windows users: On Windows the rpath feature as used by Stan Math to hardcode an absolute path to a dynamically loaded library does not work. On Windows the TBB dynamic library `tbb.dll` is located in the `math/lib/tbb` directory. The user can choose to either copy this file to the same directory of the executable or to add the directory `path/to/math/lib/tbb` as absolute path to the system wide `PATH` variable.
 
 Other Compilers
 ---------------

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Documentation for Stan math is available at [mc-stan.org/math](https://mc-stan.o
 
 Installation
 ------------
-The Stan Math Library is a C++ library which depends on the Intel TBB library and requires for some functionality (ordinary differential equations and root solving) on the Sundials library. As build system the make facility is used to manage all dependencies.
+The Stan Math Library is a C++ library which depends on the Intel TBB library and requires for some functionality (ordinary differential equations and root solving) on the Sundials library. The build system used is the make facility, which is used to manage all dependencies.
 
 A simple hello world program using Stan Math is as follows:
 
@@ -51,7 +51,7 @@ If this is in the file `/path/to/foo/foo.cpp`, then you can compile and run this
 log normal(1 | 2, 3)=-2.07311
 ```
 
-The first make command with the `math-libs` target ensures that all binary dependencies are build and ready to use. The second make command ensures that all dependencies of Stan Math are available to the compiler which are:
+The first make command with the `math-libs` target ensures that all binary dependencies are build and ready to use. The second make command ensures that all dependencies of Stan Math are available to the compiler. These are:
 
 * Stan Math Library:  path to source directory that contains `stan` as a subdirectory
 * Eigen C++ Matrix Library:  path to source directory that contains `Eigen` as a subdirectory
@@ -66,12 +66,20 @@ Note that the paths should *not* include the final directories `stan`, `Eigen`, 
 > make -f ~/stan-dev/math/make/standalone foo
 ```
 
-The `math-libs` target must only be called a single time and can be omitted for subsequent compilations.
+The `math-libs` target has to be called only once, and can be omitted for subsequent compilations.
 
-The standalone makefile ensure that all the required `-I` include statements are given to the compiler and the necessary libraries are linked: `~/stan-dev/math/stan` and `~/stan-dev/math/lib/eigen_3.3.3/Eigen` and `~/stan-dev/math/lib/boost_1.69.0/boost` and `~/stan-dev/math/lib/sundials_4.1.0/include` and `~/stan-dev/math/lib/tbb_2019_U8/include`. The `~/stan-dev/math/lib/tbb` directory is created by the math-libs makefile target automatically. The `-Wl,-rpath,...` instruct the linker to hard-code the path to the Intel TBB library inside the stan-math directory into the final binary. This way the Intel TBB is found when executing the program.
+The standalone makefile ensures that all the required `-I` include statements are given to the compiler and the necessary libraries are linked: `~/stan-dev/math/stan` and `~/stan-dev/math/lib/eigen_3.3.3/Eigen` and `~/stan-dev/math/lib/boost_1.69.0/boost` and `~/stan-dev/math/lib/sundials_4.1.0/include` and `~/stan-dev/math/lib/tbb_2019_U8/include`. The `~/stan-dev/math/lib/tbb` directory is created by the `math-libs` makefile target automatically. The flags `-Wl,-rpath,...` instruct the linker to hard-code the path to the Intel TBB library inside the stan-math directory into the final binary. This way the Intel TBB is found when executing the program.
 
-Note for Windows users: On Windows the rpath feature as used by Stan Math to hardcode an absolute path to a dynamically loaded library does not work. On Windows the TBB dynamic library `tbb.dll` is located in the `math/lib/tbb` directory. The user can choose to either copy this file to the same directory of the executable or to add the directory `path/to/math/lib/tbb` as absolute path to the system wide `PATH` variable.
+Note for Windows users: On Windows the `-rpath` feature as used by Stan Math to hardcode an absolute path to a dynamically loaded library does not work. On Windows the Intel TBB dynamic library `tbb.dll` is located in the `math/lib/tbb` directory. The user can choose to copy this file to the same directory of the executable or to add the directory `path/to/math/lib/tbb` as absolute path to the system-wide `PATH` variable.
 
-Other Compilers
----------------
-There's nothing special about `clang++` --- the `g++` compiler behaves the same way.  You'll need to modify the commands for other compilers, which will need to be up-to-date enough to compile the Stan Math Library.
+Compilers
+---------
+The above example will use the default compiler of the system as determined by `make`. On Linux this is usually `g++`, on MacOS `clang++`, and for Windows this is `g++` if the RTools for Windows are used. There's nothing special about any of these and they can be changed through the `CXX` variable of `make`. The recommended way to set this variable for the Stan Math library is by creating a `path/to/math/make/local` file. Defining `CXX=g++` in this file will ensure that always the GNU C++ compiler is used, for example. The compiler must be able to fully support C++11 and partially the C++14 standard. The `g++` 4.9.3 version part of RTools for Windows currently defines the minimal C++ feature set required by the Stan Math library.
+
+Note that whenever the compiler is changed, the user usually must clean all binary dependencies with the command
+```bash
+> make -f path/to/stan-math/make/standalone math-clean
+> make -f path/to/stan-math/make/standalone math-libs
+```
+in order to clean and rebuild the binary dependencies with the new compiler.
+

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ If this is in the file `/path/to/foo/foo.cpp`, then you can compile and run this
 log normal(1 | 2, 3)=-2.07311
 ```
 
-The first make command with the `math-libs` target ensures that all binary dependencies are build and ready to use. The second make command ensures that all dependencies of Stan Math are available to the compiler. These are:
+The first make command with the `math-libs` target ensures that all binary dependencies are built and ready to use. The second make command ensures that all dependencies of Stan Math are available to the compiler. These are:
 
 * Stan Math Library:  path to source directory that contains `stan` as a subdirectory
 * Eigen C++ Matrix Library:  path to source directory that contains `Eigen` as a subdirectory
@@ -74,12 +74,12 @@ Note for Windows users: On Windows the `-rpath` feature as used by Stan Math to 
 
 Compilers
 ---------
-The above example will use the default compiler of the system as determined by `make`. On Linux this is usually `g++`, on MacOS `clang++`, and for Windows this is `g++` if the RTools for Windows are used. There's nothing special about any of these and they can be changed through the `CXX` variable of `make`. The recommended way to set this variable for the Stan Math library is by creating a `path/to/math/make/local` file. Defining `CXX=g++` in this file will ensure that always the GNU C++ compiler is used, for example. The compiler must be able to fully support C++11 and partially the C++14 standard. The `g++` 4.9.3 version part of RTools for Windows currently defines the minimal C++ feature set required by the Stan Math library.
+The above example will use the default compiler of the system as determined by `make`. On Linux this is usually `g++`, on MacOS `clang++`, and for Windows this is `g++` if the RTools for Windows are used. There's nothing special about any of these and they can be changed through the `CXX` variable of `make`. The recommended way to set this variable for the Stan Math library is by creating a `make/local` file within the Stan Math library directory. Defining `CXX=g++` in this file will ensure that the GNU C++ compiler is always used, for example. The compiler must be able to fully support C++11 and partially the C++14 standard. The `g++` 4.9.3 version part of RTools for Windows currently defines the minimal C++ feature set required by the Stan Math library.
 
-Note that whenever the compiler is changed, the user usually must clean all binary dependencies with the command
+Note that whenever the compiler is changed, the user usually must clean and rebuild all binary dependencies with the commands:
 ```bash
 > make -f path/to/stan-math/make/standalone math-clean
 > make -f path/to/stan-math/make/standalone math-libs
 ```
-in order to clean and rebuild the binary dependencies with the new compiler.
+This ensures that the binary dependencies are created with the new compiler.
 

--- a/make/standalone
+++ b/make/standalone
@@ -1,0 +1,34 @@
+# makefile to be used for standalone compliation of
+# C++ programs. Note that the dependend libraries
+# must be compiled first by the math-libs target
+#
+# Example for hello-math.cpp C++ program:
+#
+# make -f path/to/math/make/standalone math-libs
+# make -f path/to/math/make/standalone hello-math
+#
+# in case this makefile is used within another makefile
+# via an include statement then the user is advised to
+# define the MATH variable to point to the stan-math root
+# directory (with a trailing "/").
+
+MATH_MAKE ?=$(dir $(abspath $(firstword $(MAKEFILE_LIST))))
+MATH ?= $(realpath $(MATH_MAKE)..)/
+include $(MATH)make/compiler_flags
+include $(MATH)make/libraries
+
+# Stan math programs must include the TBB.
+# The sundials libraries are only needed for
+# programs using the stiff ode solver or the
+# algebra solver
+MATH_LIBS ?= $(TBB_TARGETS) $(LIBSUNDIALS)
+
+LDFLAGS += $(MATH_LIBS)
+
+math-libs : $(MATH_LIBS)
+
+##
+# Debug target that allows you to print a variable
+##
+print-%  : ; @echo $* = $($*)
+

--- a/make/standalone
+++ b/make/standalone
@@ -14,18 +14,24 @@
 
 MATH_MAKE ?=$(dir $(abspath $(firstword $(MAKEFILE_LIST))))
 MATH ?= $(realpath $(MATH_MAKE)..)/
-include $(MATH)make/compiler_flags
-include $(MATH)make/libraries
+-include $(HOME)/.config/stan/make.local
+-include $(MATH)make/local
+-include $(MATH)make/compiler_flags
+-include $(MATH)make/libraries
 
 # Stan math programs must include the TBB.
 # The sundials libraries are only needed for
 # programs using the stiff ode solver or the
 # algebra solver
-MATH_LIBS ?= $(TBB_TARGETS) $(LIBSUNDIALS)
+MATH_LIBS ?= $(TBB_TARGETS) $(LIBSUNDIALS) $(MPI_TARGETS)
 
 LDFLAGS += $(MATH_LIBS)
 
 math-libs : $(MATH_LIBS)
+
+.PHONY: math-clean
+math-clean : clean-libraries
+
 
 ##
 # Debug target that allows you to print a variable


### PR DESCRIPTION
## Summary

This introduces a small makefile which will help users of the Stan Math C++ library to compile programs on their own. The `make/standalone` makefile makes building of the math libraries straightforward and allows building of C++ easily using the make facility.

The `README.md` is updated to use the new standalone makefile in order to demonstrate building a small hello world program which got a little more complicated since the 3.0 release as the TBB must be linked in dynamically which is now being handled automatically through make.

## Tests

NA

## Side Effects

NA

## Checklist

- [X] Math issue #1465

- [X] Copyright holder: Sebastian Weber

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [X] the new changes are tested
