### PR TITLE
Remove last few unnecessary include_summand<> checks

### DIFF
--- a/stan/math/opencl/prim/normal_id_glm_lpdf.hpp
+++ b/stan/math/opencl/prim/normal_id_glm_lpdf.hpp
@@ -191,9 +191,8 @@ return_type_t<T_alpha, T_beta, T_scale> normal_id_glm_lpdf(
       logp -= N * log(forward_as<double>(sigma_val));
     }
   }
-  if (include_summand<propto, T_alpha, T_beta, T_scale>::value) {
-    logp -= 0.5 * y_scaled_sq_sum;
-  }
+  logp -= 0.5 * y_scaled_sq_sum;
+
   return ops_partials.build(logp);
 }
 

--- a/stan/math/prim/mat/prob/normal_id_glm_lpdf.hpp
+++ b/stan/math/prim/mat/prob/normal_id_glm_lpdf.hpp
@@ -194,10 +194,8 @@ return_type_t<T_y, T_x_scalar, T_alpha, T_beta, T_scale> normal_id_glm_lpdf(
       logp -= N_instances * log(forward_as<double>(sigma_val));
     }
   }
-  if (include_summand<propto, T_y, T_x_scalar, T_alpha, T_beta,
-                      T_scale>::value) {
-    logp -= 0.5 * y_scaled_sq_sum;
-  }
+  logp -= 0.5 * y_scaled_sq_sum;
+
   return ops_partials.build(logp);
 }
 

--- a/stan/math/prim/scal/prob/beta_binomial_lpmf.hpp
+++ b/stan/math/prim/scal/prob/beta_binomial_lpmf.hpp
@@ -82,17 +82,14 @@ return_type_t<T_size1, T_size2> beta_binomial_lpmf(const T_n& n, const T_N& N,
                 T_partials_return, T_n, T_N, T_size1, T_size2>
       lbeta_numerator(size);
   for (size_t i = 0; i < size; i++)
-    if (include_summand<propto, T_size1, T_size2>::value)
-      lbeta_numerator[i] = lbeta(n_vec[i] + value_of(alpha_vec[i]),
-                                 N_vec[i] - n_vec[i] + value_of(beta_vec[i]));
+    lbeta_numerator[i] = lbeta(n_vec[i] + value_of(alpha_vec[i]),
+                               N_vec[i] - n_vec[i] + value_of(beta_vec[i]));
 
   VectorBuilder<include_summand<propto, T_size1, T_size2>::value,
                 T_partials_return, T_size1, T_size2>
       lbeta_denominator(max_size(alpha, beta));
   for (size_t i = 0; i < max_size(alpha, beta); i++)
-    if (include_summand<propto, T_size1, T_size2>::value)
-      lbeta_denominator[i]
-          = lbeta(value_of(alpha_vec[i]), value_of(beta_vec[i]));
+    lbeta_denominator[i] = lbeta(value_of(alpha_vec[i]), value_of(beta_vec[i]));
 
   VectorBuilder<!is_constant_all<T_size1>::value, T_partials_return, T_n,
                 T_size1>
@@ -132,8 +129,7 @@ return_type_t<T_size1, T_size2> beta_binomial_lpmf(const T_n& n, const T_N& N,
   for (size_t i = 0; i < size; i++) {
     if (include_summand<propto>::value)
       logp += normalizing_constant[i];
-    if (include_summand<propto, T_size1, T_size2>::value)
-      logp += lbeta_numerator[i] - lbeta_denominator[i];
+    logp += lbeta_numerator[i] - lbeta_denominator[i];
 
     if (!is_constant_all<T_size1>::value)
       ops_partials.edge1_.partials_[i]

--- a/stan/math/prim/scal/prob/chi_square_lpdf.hpp
+++ b/stan/math/prim/scal/prob/chi_square_lpdf.hpp
@@ -71,9 +71,7 @@ return_type_t<T_y, T_dof> chi_square_lpdf(const T_y& y, const T_dof& nu) {
                 T_y>
       log_y(length(y));
   for (size_t i = 0; i < length(y); i++) {
-    if (include_summand<propto, T_y, T_dof>::value) {
-      log_y[i] = log(value_of(y_vec[i]));
-    }
+    log_y[i] = log(value_of(y_vec[i]));
   }
 
   VectorBuilder<include_summand<propto, T_y>::value, T_partials_return, T_y>
@@ -109,9 +107,8 @@ return_type_t<T_y, T_dof> chi_square_lpdf(const T_y& y, const T_dof& nu) {
     if (include_summand<propto, T_dof>::value) {
       logp += nu_dbl * NEG_LOG_TWO_OVER_TWO - lgamma_half_nu[n];
     }
-    if (include_summand<propto, T_y, T_dof>::value) {
-      logp += (half_nu - 1.0) * log_y[n];
-    }
+    logp += (half_nu - 1.0) * log_y[n];
+
     if (include_summand<propto, T_y>::value) {
       logp -= half_y;
     }


### PR DESCRIPTION
## Summary

This removes some checks that have already been evaluated earlier in each function, so by that point they are unnecessary. This includes two changes to `beta_binomial` that had been reverted in #1331.

As suggested by @rok-cesnovar, I also looked under `opencl`, and only `normal_id_glm_lpdf` contained such code, while the rest seems fine. So overall this fixes #1519.

## Tests

No new tests, this is only cleanup.

## Side Effects

None.

## Checklist

- [X] Math issue #1519

- [X] Copyright holder: Marco Colombo

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [X] the new changes are tested
