### PR TITLE
Fix develop

### DIFF
--- a/test/unit/math/rev/prob/categorical_logit_glm_lpmf_test.cpp
+++ b/test/unit/math/rev/prob/categorical_logit_glm_lpmf_test.cpp
@@ -4,7 +4,7 @@
 #include <stan/math/prim/scal/fun/value_of.hpp>
 #include <stan/math/prim/meta/return_type.hpp>
 #include <stan/math/prim/err/check_consistent_size.hpp>
-#include <stan/math/prim/mat/prob/categorical_logit_lpmf.hpp>
+#include <stan/math/prim/prob/categorical_logit_lpmf.hpp>
 #include <cmath>
 #include <vector>
 


### PR DESCRIPTION
## Summary

After #1574 was merged we are experiencing failures on develop. Its a result of a bad merge that occured after #1572 and #1574 were merged. When I tried merging these two PRs locally I had to fix a merge conflict (the one causing errors right now). But Github allowed merging the latter PR without the need to fix the conflict. Hence the develop fail.

I apologize for any inconvenience.

- [x] Copyright holder: Rok Češnovar

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
