### PR TITLE
Rename local variables with trailing underscores

### DIFF
--- a/stan/math/opencl/kernels/bernoulli_logit_glm_lpmf.hpp
+++ b/stan/math/opencl/kernels/bernoulli_logit_glm_lpmf.hpp
@@ -1,4 +1,3 @@
-
 #ifndef STAN_MATH_OPENCL_KERNELS_BERNOULLI_LOGIT_GLM_LPMF_HPP
 #define STAN_MATH_OPENCL_KERNELS_BERNOULLI_LOGIT_GLM_LPMF_HPP
 #ifdef STAN_OPENCL
@@ -62,9 +61,9 @@ static const char* bernoulli_logit_glm_kernel_code = STRINGIFY(
           ytheta += x[j + gid] * beta[i];
         }
         const int y = y_global[gid * is_y_vector];
-        const double sign_ = 2 * y - 1;
+        const double sign = 2 * y - 1;
         ytheta += alpha[gid * is_alpha_vector];
-        ytheta *= sign_;
+        ytheta *= sign;
         if (y > 1 || y < 0 || !isfinite(ytheta)) {
           // this signals that an exception must be raised
           logp = NAN;
@@ -77,10 +76,10 @@ static const char* bernoulli_logit_glm_kernel_code = STRINGIFY(
           theta_derivative = -exp_m_ytheta;
         } else if (ytheta < -cutoff) {
           logp += ytheta;
-          theta_derivative = sign_;
+          theta_derivative = sign;
         } else {
           logp += -log1p(exp_m_ytheta);
-          theta_derivative = sign_ * exp_m_ytheta / (exp_m_ytheta + 1);
+          theta_derivative = sign * exp_m_ytheta / (exp_m_ytheta + 1);
         }
 
         if (need_theta_derivative) {

--- a/stan/math/prim/prob/exp_mod_normal_cdf.hpp
+++ b/stan/math/prim/prob/exp_mod_normal_cdf.hpp
@@ -18,10 +18,9 @@ template <typename T_y, typename T_loc, typename T_scale, typename T_inv_scale>
 return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_cdf(
     const T_y& y, const T_loc& mu, const T_scale& sigma,
     const T_inv_scale& lambda) {
+  using T_partials_return = partials_return_t<T_y, T_loc, T_scale, T_inv_scale>;
+
   static const char* function = "exp_mod_normal_cdf";
-  typedef
-      typename stan::partials_return_type<T_y, T_loc, T_scale,
-                                          T_inv_scale>::type T_partials_return;
 
   T_partials_return cdf(1.0);
   if (size_zero(y, mu, sigma, lambda)) {
@@ -78,16 +77,17 @@ return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_cdf(
     const T_partials_return deriv_3
         = SQRT_TWO_OVER_SQRT_PI * 0.5 * exp(-scaled_diff_sq) / sigma_dbl;
 
-    const T_partials_return cdf_ = 0.5 * (1 + erf(u / (v * SQRT_TWO)))
-                                   - exp(-u + v_sq * 0.5) * (erf_calc);
+    const T_partials_return cdf_n = 0.5 * (1 + erf(u / (v * SQRT_TWO)))
+                                    - exp(-u + v_sq * 0.5) * (erf_calc);
 
-    cdf *= cdf_;
+    cdf *= cdf_n;
 
     if (!is_constant_all<T_y>::value) {
-      ops_partials.edge1_.partials_[n] += (deriv_1 - deriv_2 + deriv_3) / cdf_;
+      ops_partials.edge1_.partials_[n] += (deriv_1 - deriv_2 + deriv_3) / cdf_n;
     }
     if (!is_constant_all<T_loc>::value) {
-      ops_partials.edge2_.partials_[n] += (-deriv_1 + deriv_2 - deriv_3) / cdf_;
+      ops_partials.edge2_.partials_[n]
+          += (-deriv_1 + deriv_2 - deriv_3) / cdf_n;
     }
     if (!is_constant_all<T_scale>::value) {
       ops_partials.edge3_.partials_[n]
@@ -96,7 +96,7 @@ return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_cdf(
                     * (-SQRT_TWO * 0.5
                            * (-lambda_dbl + scaled_diff * SQRT_TWO / sigma_dbl)
                        - SQRT_TWO * lambda_dbl))
-             / cdf_;
+             / cdf_n;
     }
     if (!is_constant_all<T_inv_scale>::value) {
       ops_partials.edge4_.partials_[n]
@@ -104,7 +104,7 @@ return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_cdf(
              * (SQRT_TWO_OVER_SQRT_PI * 0.5 * sigma_dbl
                     * exp(-square(v_over_sqrt_two - scaled_diff))
                 - (v * sigma_dbl + mu_dbl - y_dbl) * erf_calc)
-             / cdf_;
+             / cdf_n;
     }
   }
 

--- a/stan/math/prim/prob/exp_mod_normal_lcdf.hpp
+++ b/stan/math/prim/prob/exp_mod_normal_lcdf.hpp
@@ -18,10 +18,9 @@ template <typename T_y, typename T_loc, typename T_scale, typename T_inv_scale>
 return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_lcdf(
     const T_y& y, const T_loc& mu, const T_scale& sigma,
     const T_inv_scale& lambda) {
+  using T_partials_return = partials_return_t<T_y, T_loc, T_scale, T_inv_scale>;
+
   static const char* function = "exp_mod_normal_lcdf";
-  typedef
-      typename stan::partials_return_type<T_y, T_loc, T_scale,
-                                          T_inv_scale>::type T_partials_return;
 
   T_partials_return cdf_log(0.0);
   if (size_zero(y, mu, sigma, lambda)) {
@@ -82,18 +81,17 @@ return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_lcdf(
     const T_partials_return deriv_3
         = SQRT_TWO_OVER_SQRT_PI * 0.5 * exp(-scaled_diff_sq) / sigma_dbl;
 
-    const T_partials_return denom = erf_calc1 - erf_calc2 * exp(0.5 * v_sq - u);
-    const T_partials_return cdf_
+    const T_partials_return cdf_n
         = erf_calc1 - exp(-u + v_sq * 0.5) * (erf_calc2);
 
-    cdf_log += log(cdf_);
+    cdf_log += log(cdf_n);
 
     if (!is_constant_all<T_y>::value) {
-      ops_partials.edge1_.partials_[n] += (deriv_1 - deriv_2 + deriv_3) / denom;
+      ops_partials.edge1_.partials_[n] += (deriv_1 - deriv_2 + deriv_3) / cdf_n;
     }
     if (!is_constant_all<T_loc>::value) {
       ops_partials.edge2_.partials_[n]
-          += (-deriv_1 + deriv_2 - deriv_3) / denom;
+          += (-deriv_1 + deriv_2 - deriv_3) / cdf_n;
     }
     if (!is_constant_all<T_scale>::value) {
       ops_partials.edge3_.partials_[n]
@@ -102,7 +100,7 @@ return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_lcdf(
                     * (-SQRT_TWO * 0.5
                            * (-lambda_dbl + scaled_diff * SQRT_TWO / sigma_dbl)
                        - SQRT_TWO * lambda_dbl))
-             / denom;
+             / cdf_n;
     }
     if (!is_constant_all<T_inv_scale>::value) {
       ops_partials.edge4_.partials_[n]
@@ -110,7 +108,7 @@ return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_lcdf(
              * (SQRT_TWO_OVER_SQRT_PI * 0.5 * sigma_dbl
                     * exp(-square(v_over_sqrt_two - scaled_diff))
                 - (v * sigma_dbl + mu_dbl - y_dbl) * erf_calc2)
-             / denom;
+             / cdf_n;
     }
   }
   return ops_partials.build(cdf_log);

--- a/stan/math/prim/prob/frechet_cdf.hpp
+++ b/stan/math/prim/prob/frechet_cdf.hpp
@@ -42,23 +42,24 @@ return_type_t<T_y, T_shape, T_scale> frechet_cdf(const T_y& y,
   scalar_seq_view<T_scale> sigma_vec(sigma);
   scalar_seq_view<T_shape> alpha_vec(alpha);
   size_t N = max_size(y, sigma, alpha);
+
   for (size_t n = 0; n < N; n++) {
     const T_partials_return y_dbl = value_of(y_vec[n]);
     const T_partials_return sigma_dbl = value_of(sigma_vec[n]);
     const T_partials_return alpha_dbl = value_of(alpha_vec[n]);
-    const T_partials_return pow_ = pow(sigma_dbl / y_dbl, alpha_dbl);
-    const T_partials_return cdf_ = exp(-pow_);
+    const T_partials_return pow_n = pow(sigma_dbl / y_dbl, alpha_dbl);
+    const T_partials_return cdf_n = exp(-pow_n);
 
-    cdf *= cdf_;
+    cdf *= cdf_n;
 
     if (!is_constant_all<T_y>::value) {
-      ops_partials.edge1_.partials_[n] += pow_ * alpha_dbl / y_dbl;
+      ops_partials.edge1_.partials_[n] += pow_n * alpha_dbl / y_dbl;
     }
     if (!is_constant_all<T_shape>::value) {
-      ops_partials.edge2_.partials_[n] += pow_ * log(y_dbl / sigma_dbl);
+      ops_partials.edge2_.partials_[n] += pow_n * log(y_dbl / sigma_dbl);
     }
     if (!is_constant_all<T_scale>::value) {
-      ops_partials.edge3_.partials_[n] -= pow_ * alpha_dbl / sigma_dbl;
+      ops_partials.edge3_.partials_[n] -= pow_n * alpha_dbl / sigma_dbl;
     }
   }
 

--- a/stan/math/prim/prob/frechet_lccdf.hpp
+++ b/stan/math/prim/prob/frechet_lccdf.hpp
@@ -47,20 +47,20 @@ return_type_t<T_y, T_shape, T_scale> frechet_lccdf(const T_y& y,
     const T_partials_return y_dbl = value_of(y_vec[n]);
     const T_partials_return sigma_dbl = value_of(sigma_vec[n]);
     const T_partials_return alpha_dbl = value_of(alpha_vec[n]);
-    const T_partials_return pow_ = pow(sigma_dbl / y_dbl, alpha_dbl);
-    const T_partials_return exp_ = exp(-pow_);
+    const T_partials_return pow_n = pow(sigma_dbl / y_dbl, alpha_dbl);
+    const T_partials_return exp_n = exp(-pow_n);
 
-    ccdf_log += log1m(exp_);
+    ccdf_log += log1m(exp_n);
 
-    const T_partials_return rep_deriv_ = pow_ / (1.0 / exp_ - 1);
+    const T_partials_return rep_deriv = pow_n / (1.0 / exp_n - 1);
     if (!is_constant_all<T_y>::value) {
-      ops_partials.edge1_.partials_[n] -= alpha_dbl / y_dbl * rep_deriv_;
+      ops_partials.edge1_.partials_[n] -= alpha_dbl / y_dbl * rep_deriv;
     }
     if (!is_constant_all<T_shape>::value) {
-      ops_partials.edge2_.partials_[n] -= log(y_dbl / sigma_dbl) * rep_deriv_;
+      ops_partials.edge2_.partials_[n] -= log(y_dbl / sigma_dbl) * rep_deriv;
     }
     if (!is_constant_all<T_scale>::value) {
-      ops_partials.edge3_.partials_[n] += alpha_dbl / sigma_dbl * rep_deriv_;
+      ops_partials.edge3_.partials_[n] += alpha_dbl / sigma_dbl * rep_deriv;
     }
   }
   return ops_partials.build(ccdf_log);

--- a/stan/math/prim/prob/frechet_lcdf.hpp
+++ b/stan/math/prim/prob/frechet_lcdf.hpp
@@ -45,18 +45,18 @@ return_type_t<T_y, T_shape, T_scale> frechet_lcdf(const T_y& y,
     const T_partials_return y_dbl = value_of(y_vec[n]);
     const T_partials_return sigma_dbl = value_of(sigma_vec[n]);
     const T_partials_return alpha_dbl = value_of(alpha_vec[n]);
-    const T_partials_return pow_ = pow(sigma_dbl / y_dbl, alpha_dbl);
+    const T_partials_return pow_n = pow(sigma_dbl / y_dbl, alpha_dbl);
 
-    cdf_log -= pow_;
+    cdf_log -= pow_n;
 
     if (!is_constant_all<T_y>::value) {
-      ops_partials.edge1_.partials_[n] += pow_ * alpha_dbl / y_dbl;
+      ops_partials.edge1_.partials_[n] += pow_n * alpha_dbl / y_dbl;
     }
     if (!is_constant_all<T_shape>::value) {
-      ops_partials.edge2_.partials_[n] += pow_ * log(y_dbl / sigma_dbl);
+      ops_partials.edge2_.partials_[n] += pow_n * log(y_dbl / sigma_dbl);
     }
     if (!is_constant_all<T_scale>::value) {
-      ops_partials.edge3_.partials_[n] -= pow_ * alpha_dbl / sigma_dbl;
+      ops_partials.edge3_.partials_[n] -= pow_n * alpha_dbl / sigma_dbl;
     }
   }
   return ops_partials.build(cdf_log);

--- a/stan/math/prim/prob/gumbel_cdf.hpp
+++ b/stan/math/prim/prob/gumbel_cdf.hpp
@@ -59,17 +59,17 @@ return_type_t<T_y, T_loc, T_scale> gumbel_cdf(const T_y& y, const T_loc& mu,
     const T_partials_return scaled_diff = (y_dbl - mu_dbl) / beta_dbl;
     const T_partials_return rep_deriv
         = exp(-scaled_diff - exp(-scaled_diff)) / beta_dbl;
-    const T_partials_return cdf_ = exp(-exp(-scaled_diff));
-    cdf *= cdf_;
+    const T_partials_return cdf_n = exp(-exp(-scaled_diff));
+    cdf *= cdf_n;
 
     if (!is_constant_all<T_y>::value) {
-      ops_partials.edge1_.partials_[n] += rep_deriv / cdf_;
+      ops_partials.edge1_.partials_[n] += rep_deriv / cdf_n;
     }
     if (!is_constant_all<T_loc>::value) {
-      ops_partials.edge2_.partials_[n] -= rep_deriv / cdf_;
+      ops_partials.edge2_.partials_[n] -= rep_deriv / cdf_n;
     }
     if (!is_constant_all<T_scale>::value) {
-      ops_partials.edge3_.partials_[n] -= rep_deriv * scaled_diff / cdf_;
+      ops_partials.edge3_.partials_[n] -= rep_deriv * scaled_diff / cdf_n;
     }
   }
 

--- a/stan/math/prim/prob/gumbel_lccdf.hpp
+++ b/stan/math/prim/prob/gumbel_lccdf.hpp
@@ -60,17 +60,17 @@ return_type_t<T_y, T_loc, T_scale> gumbel_lccdf(const T_y& y, const T_loc& mu,
     const T_partials_return scaled_diff = (y_dbl - mu_dbl) / beta_dbl;
     const T_partials_return rep_deriv
         = exp(-scaled_diff - exp(-scaled_diff)) / beta_dbl;
-    const T_partials_return ccdf_log_ = 1.0 - exp(-exp(-scaled_diff));
-    ccdf_log += log(ccdf_log_);
+    const T_partials_return ccdf_log_n = 1.0 - exp(-exp(-scaled_diff));
+    ccdf_log += log(ccdf_log_n);
 
     if (!is_constant_all<T_y>::value) {
-      ops_partials.edge1_.partials_[n] -= rep_deriv / ccdf_log_;
+      ops_partials.edge1_.partials_[n] -= rep_deriv / ccdf_log_n;
     }
     if (!is_constant_all<T_loc>::value) {
-      ops_partials.edge2_.partials_[n] += rep_deriv / ccdf_log_;
+      ops_partials.edge2_.partials_[n] += rep_deriv / ccdf_log_n;
     }
     if (!is_constant_all<T_scale>::value) {
-      ops_partials.edge3_.partials_[n] += rep_deriv * scaled_diff / ccdf_log_;
+      ops_partials.edge3_.partials_[n] += rep_deriv * scaled_diff / ccdf_log_n;
     }
   }
 

--- a/stan/math/prim/prob/lognormal_cdf.hpp
+++ b/stan/math/prim/prob/lognormal_cdf.hpp
@@ -56,18 +56,18 @@ return_type_t<T_y, T_loc, T_scale> lognormal_cdf(const T_y& y, const T_loc& mu,
                                         * exp(-scaled_diff * scaled_diff)
                                         / sigma_dbl;
 
-    const T_partials_return cdf_ = 0.5 * erfc(-scaled_diff);
-    cdf *= cdf_;
+    const T_partials_return cdf_n = 0.5 * erfc(-scaled_diff);
+    cdf *= cdf_n;
 
     if (!is_constant_all<T_y>::value) {
-      ops_partials.edge1_.partials_[n] += rep_deriv / cdf_ / y_dbl;
+      ops_partials.edge1_.partials_[n] += rep_deriv / cdf_n / y_dbl;
     }
     if (!is_constant_all<T_loc>::value) {
-      ops_partials.edge2_.partials_[n] -= rep_deriv / cdf_;
+      ops_partials.edge2_.partials_[n] -= rep_deriv / cdf_n;
     }
     if (!is_constant_all<T_scale>::value) {
       ops_partials.edge3_.partials_[n]
-          -= rep_deriv * scaled_diff * SQRT_TWO / cdf_;
+          -= rep_deriv * scaled_diff * SQRT_TWO / cdf_n;
     }
   }
 

--- a/stan/math/prim/prob/multi_normal_cholesky_lpdf.hpp
+++ b/stan/math/prim/prob/multi_normal_cholesky_lpdf.hpp
@@ -62,7 +62,7 @@ return_type_t<T_y, T_loc, T_covar> multi_normal_cholesky_lpdf(
   if (likely(size_vec > 1)) {
     // check size consistency of all random variables y
     int size_y_old = size_y;
-    for (size_t i = 1, size_ = size_mvt(y); i < size_; i++) {
+    for (size_t i = 1, size_mvt_y = size_mvt(y); i < size_mvt_y; i++) {
       int size_y_new = y_vec[i].size();
       check_size_match(function,
                        "Size of one of the vectors of "
@@ -75,7 +75,7 @@ return_type_t<T_y, T_loc, T_covar> multi_normal_cholesky_lpdf(
     }
     // check size consistency of all means mu
     int size_mu_old = size_mu;
-    for (size_t i = 1, size_ = size_mvt(mu); i < size_; i++) {
+    for (size_t i = 1, size_mvt_mu = size_mvt(mu); i < size_mvt_mu; i++) {
       int size_mu_new = mu_vec[i].size();
       check_size_match(function,
                        "Size of one of the vectors of "

--- a/stan/math/prim/prob/multi_normal_lpdf.hpp
+++ b/stan/math/prim/prob/multi_normal_lpdf.hpp
@@ -44,7 +44,7 @@ return_type_t<T_y, T_loc, T_covar> multi_normal_lpdf(const T_y& y,
   if (size_vec > 1) {
     int size_y_old = size_y;
     int size_y_new;
-    for (size_t i = 1, size_ = size_mvt(y); i < size_; i++) {
+    for (size_t i = 1, size_mvt_y = size_mvt(y); i < size_mvt_y; i++) {
       int size_y_new = y_vec[i].size();
       check_size_match(function,
                        "Size of one of the vectors of "
@@ -57,7 +57,7 @@ return_type_t<T_y, T_loc, T_covar> multi_normal_lpdf(const T_y& y,
     }
     int size_mu_old = size_mu;
     int size_mu_new;
-    for (size_t i = 1, size_ = size_mvt(mu); i < size_; i++) {
+    for (size_t i = 1, size_mvt_mu = size_mvt(mu); i < size_mvt_mu; i++) {
       int size_mu_new = mu_vec[i].size();
       check_size_match(function,
                        "Size of one of the vectors of "

--- a/stan/math/prim/prob/multi_normal_prec_lpdf.hpp
+++ b/stan/math/prim/prob/multi_normal_prec_lpdf.hpp
@@ -44,7 +44,7 @@ return_type_t<T_y, T_loc, T_covar> multi_normal_prec_lpdf(
   if (size_vec > 1) {
     int size_y_old = size_y;
     int size_y_new;
-    for (size_t i = 1, size_ = size_mvt(y); i < size_; i++) {
+    for (size_t i = 1, size_mvt_y = size_mvt(y); i < size_mvt_y; i++) {
       int size_y_new = y_vec[i].size();
       check_size_match(function,
                        "Size of one of the vectors "
@@ -57,7 +57,7 @@ return_type_t<T_y, T_loc, T_covar> multi_normal_prec_lpdf(
     }
     int size_mu_old = size_mu;
     int size_mu_new;
-    for (size_t i = 1, size_ = size_mvt(mu); i < size_; i++) {
+    for (size_t i = 1, size_mvt_mu = size_mvt(mu); i < size_mvt_mu; i++) {
       int size_mu_new = mu_vec[i].size();
       check_size_match(function,
                        "Size of one of the vectors "

--- a/stan/math/prim/prob/multi_student_t_lpdf.hpp
+++ b/stan/math/prim/prob/multi_student_t_lpdf.hpp
@@ -55,7 +55,7 @@ return_type_t<T_y, T_dof, T_loc, T_scale> multi_student_t_lpdf(
   if (size_vec > 1) {
     int size_y_old = size_y;
     int size_y_new;
-    for (size_t i = 1, size_ = size_mvt(y); i < size_; i++) {
+    for (size_t i = 1, size_mvt_y = size_mvt(y); i < size_mvt_y; i++) {
       int size_y_new = y_vec[i].size();
       check_size_match(
           function, "Size of one of the vectors of the random variable",
@@ -65,7 +65,7 @@ return_type_t<T_y, T_dof, T_loc, T_scale> multi_student_t_lpdf(
     }
     int size_mu_old = size_mu;
     int size_mu_new;
-    for (size_t i = 1, size_ = size_mvt(mu); i < size_; i++) {
+    for (size_t i = 1, size_mvt_mu = size_mvt(mu); i < size_mvt_mu; i++) {
       int size_mu_new = mu_vec[i].size();
       check_size_match(function,
                        "Size of one of the vectors "

--- a/stan/math/prim/prob/normal_cdf.hpp
+++ b/stan/math/prim/prob/normal_cdf.hpp
@@ -62,25 +62,25 @@ inline return_type_t<T_y, T_loc, T_scale> normal_cdf(const T_y& y,
     const T_partials_return sigma_dbl = value_of(sigma_vec[n]);
     const T_partials_return scaled_diff
         = (y_dbl - mu_dbl) / (sigma_dbl * SQRT_TWO);
-    T_partials_return cdf_;
+    T_partials_return cdf_n;
     if (scaled_diff < -37.5 * INV_SQRT_TWO) {
-      cdf_ = 0.0;
+      cdf_n = 0.0;
     } else if (scaled_diff < -5.0 * INV_SQRT_TWO) {
-      cdf_ = 0.5 * erfc(-scaled_diff);
+      cdf_n = 0.5 * erfc(-scaled_diff);
     } else if (scaled_diff > 8.25 * INV_SQRT_TWO) {
-      cdf_ = 1;
+      cdf_n = 1;
     } else {
-      cdf_ = 0.5 * (1.0 + erf(scaled_diff));
+      cdf_n = 0.5 * (1.0 + erf(scaled_diff));
     }
 
-    cdf *= cdf_;
+    cdf *= cdf_n;
 
     if (!is_constant_all<T_y, T_loc, T_scale>::value) {
       const T_partials_return rep_deriv
           = (scaled_diff < -37.5 * INV_SQRT_TWO)
                 ? 0.0
                 : SQRT_TWO_OVER_SQRT_PI * 0.5 * exp(-scaled_diff * scaled_diff)
-                      / cdf_ / sigma_dbl;
+                      / (cdf_n * sigma_dbl);
       if (!is_constant_all<T_y>::value) {
         ops_partials.edge1_.partials_[n] += rep_deriv;
       }

--- a/stan/math/prim/prob/uniform_cdf.hpp
+++ b/stan/math/prim/prob/uniform_cdf.hpp
@@ -46,16 +46,16 @@ return_type_t<T_y, T_low, T_high> uniform_cdf(const T_y& y, const T_low& alpha,
     const T_partials_return alpha_dbl = value_of(alpha_vec[n]);
     const T_partials_return beta_dbl = value_of(beta_vec[n]);
     const T_partials_return b_min_a = beta_dbl - alpha_dbl;
-    const T_partials_return cdf_ = (y_dbl - alpha_dbl) / b_min_a;
+    const T_partials_return cdf_n = (y_dbl - alpha_dbl) / b_min_a;
 
-    cdf *= cdf_;
+    cdf *= cdf_n;
 
     if (!is_constant_all<T_y>::value) {
-      ops_partials.edge1_.partials_[n] += 1.0 / b_min_a / cdf_;
+      ops_partials.edge1_.partials_[n] += 1.0 / (b_min_a * cdf_n);
     }
     if (!is_constant_all<T_low>::value) {
       ops_partials.edge2_.partials_[n]
-          += (y_dbl - beta_dbl) / b_min_a / b_min_a / cdf_;
+          += (y_dbl - beta_dbl) / (b_min_a * b_min_a * cdf_n);
     }
     if (!is_constant_all<T_high>::value) {
       ops_partials.edge3_.partials_[n] -= 1.0 / b_min_a;

--- a/stan/math/prim/prob/uniform_lccdf.hpp
+++ b/stan/math/prim/prob/uniform_lccdf.hpp
@@ -54,20 +54,20 @@ return_type_t<T_y, T_low, T_high> uniform_lccdf(const T_y& y,
     const T_partials_return alpha_dbl = value_of(alpha_vec[n]);
     const T_partials_return beta_dbl = value_of(beta_vec[n]);
     const T_partials_return b_min_a = beta_dbl - alpha_dbl;
-    const T_partials_return ccdf_log_ = 1.0 - (y_dbl - alpha_dbl) / b_min_a;
+    const T_partials_return ccdf_log_n = 1.0 - (y_dbl - alpha_dbl) / b_min_a;
 
-    ccdf_log += log(ccdf_log_);
+    ccdf_log += log(ccdf_log_n);
 
     if (!is_constant_all<T_y>::value) {
-      ops_partials.edge1_.partials_[n] -= 1.0 / b_min_a / ccdf_log_;
+      ops_partials.edge1_.partials_[n] -= 1.0 / (b_min_a * ccdf_log_n);
     }
     if (!is_constant_all<T_low>::value) {
       ops_partials.edge2_.partials_[n]
-          -= (y_dbl - beta_dbl) / b_min_a / b_min_a / ccdf_log_;
+          -= (y_dbl - beta_dbl) / (b_min_a * b_min_a * ccdf_log_n);
     }
     if (!is_constant_all<T_high>::value) {
       ops_partials.edge3_.partials_[n]
-          += (y_dbl - alpha_dbl) / b_min_a / b_min_a / ccdf_log_;
+          += (y_dbl - alpha_dbl) / (b_min_a * b_min_a * ccdf_log_n);
     }
   }
   return ops_partials.build(ccdf_log);

--- a/stan/math/prim/prob/uniform_lcdf.hpp
+++ b/stan/math/prim/prob/uniform_lcdf.hpp
@@ -54,16 +54,16 @@ return_type_t<T_y, T_low, T_high> uniform_lcdf(const T_y& y, const T_low& alpha,
     const T_partials_return alpha_dbl = value_of(alpha_vec[n]);
     const T_partials_return beta_dbl = value_of(beta_vec[n]);
     const T_partials_return b_min_a = beta_dbl - alpha_dbl;
-    const T_partials_return cdf_log_ = (y_dbl - alpha_dbl) / b_min_a;
+    const T_partials_return cdf_log_n = (y_dbl - alpha_dbl) / b_min_a;
 
-    cdf_log += log(cdf_log_);
+    cdf_log += log(cdf_log_n);
 
     if (!is_constant_all<T_y>::value) {
-      ops_partials.edge1_.partials_[n] += 1.0 / b_min_a / cdf_log_;
+      ops_partials.edge1_.partials_[n] += 1.0 / (b_min_a * cdf_log_n);
     }
     if (!is_constant_all<T_low>::value) {
       ops_partials.edge2_.partials_[n]
-          += (y_dbl - beta_dbl) / b_min_a / b_min_a / cdf_log_;
+          += (y_dbl - beta_dbl) / (b_min_a * b_min_a * cdf_log_n);
     }
     if (!is_constant_all<T_high>::value) {
       ops_partials.edge3_.partials_[n] -= 1.0 / b_min_a;

--- a/stan/math/prim/prob/von_mises_lpdf.hpp
+++ b/stan/math/prim/prob/von_mises_lpdf.hpp
@@ -68,8 +68,8 @@ return_type_t<T_y, T_loc, T_scale> von_mises_lpdf(T_y const& y, T_loc const& mu,
   size_t N = max_size(y, mu, kappa);
 
   for (size_t n = 0; n < N; n++) {
-    const T_partials_return y_ = value_of(y_vec[n]);
-    const T_partials_return y_dbl = y_ - floor(y_ / TWO_PI) * TWO_PI;
+    const T_partials_return y_val = value_of(y_vec[n]);
+    const T_partials_return y_dbl = y_val - floor(y_val / TWO_PI) * TWO_PI;
     const T_partials_return mu_dbl = value_of(mu_vec[n]);
 
     T_partials_return bessel0 = 0;

--- a/stan/math/prim/prob/weibull_cdf.hpp
+++ b/stan/math/prim/prob/weibull_cdf.hpp
@@ -55,13 +55,13 @@ return_type_t<T_y, T_shape, T_scale> weibull_cdf(const T_y& y,
     const T_partials_return y_dbl = value_of(y_vec[n]);
     const T_partials_return sigma_dbl = value_of(sigma_vec[n]);
     const T_partials_return alpha_dbl = value_of(alpha_vec[n]);
-    const T_partials_return pow_ = pow(y_dbl / sigma_dbl, alpha_dbl);
-    const T_partials_return exp_ = exp(-pow_);
-    const T_partials_return cdf_ = 1.0 - exp_;
+    const T_partials_return pow_n = pow(y_dbl / sigma_dbl, alpha_dbl);
+    const T_partials_return exp_n = exp(-pow_n);
+    const T_partials_return cdf_n = 1.0 - exp_n;
 
-    cdf *= cdf_;
+    cdf *= cdf_n;
 
-    const T_partials_return rep_deriv = exp_ * pow_ / cdf_;
+    const T_partials_return rep_deriv = exp_n * pow_n / cdf_n;
     if (!is_constant_all<T_y>::value) {
       ops_partials.edge1_.partials_[n] += rep_deriv * alpha_dbl / y_dbl;
     }

--- a/stan/math/prim/prob/weibull_lccdf.hpp
+++ b/stan/math/prim/prob/weibull_lccdf.hpp
@@ -54,18 +54,18 @@ return_type_t<T_y, T_shape, T_scale> weibull_lccdf(const T_y& y,
     const T_partials_return y_dbl = value_of(y_vec[n]);
     const T_partials_return sigma_dbl = value_of(sigma_vec[n]);
     const T_partials_return alpha_dbl = value_of(alpha_vec[n]);
-    const T_partials_return pow_ = pow(y_dbl / sigma_dbl, alpha_dbl);
+    const T_partials_return pow_n = pow(y_dbl / sigma_dbl, alpha_dbl);
 
-    ccdf_log -= pow_;
+    ccdf_log -= pow_n;
 
     if (!is_constant_all<T_y>::value) {
-      ops_partials.edge1_.partials_[n] -= alpha_dbl / y_dbl * pow_;
+      ops_partials.edge1_.partials_[n] -= alpha_dbl / y_dbl * pow_n;
     }
     if (!is_constant_all<T_shape>::value) {
-      ops_partials.edge2_.partials_[n] -= log(y_dbl / sigma_dbl) * pow_;
+      ops_partials.edge2_.partials_[n] -= log(y_dbl / sigma_dbl) * pow_n;
     }
     if (!is_constant_all<T_scale>::value) {
-      ops_partials.edge3_.partials_[n] += alpha_dbl / sigma_dbl * pow_;
+      ops_partials.edge3_.partials_[n] += alpha_dbl / sigma_dbl * pow_n;
     }
   }
   return ops_partials.build(ccdf_log);

--- a/stan/math/prim/prob/weibull_lcdf.hpp
+++ b/stan/math/prim/prob/weibull_lcdf.hpp
@@ -55,13 +55,13 @@ return_type_t<T_y, T_shape, T_scale> weibull_lcdf(const T_y& y,
     const T_partials_return y_dbl = value_of(y_vec[n]);
     const T_partials_return sigma_dbl = value_of(sigma_vec[n]);
     const T_partials_return alpha_dbl = value_of(alpha_vec[n]);
-    const T_partials_return pow_ = pow(y_dbl / sigma_dbl, alpha_dbl);
-    const T_partials_return exp_ = exp(-pow_);
-    const T_partials_return cdf_ = 1.0 - exp_;
+    const T_partials_return pow_n = pow(y_dbl / sigma_dbl, alpha_dbl);
+    const T_partials_return exp_n = exp(-pow_n);
+    const T_partials_return cdf_n = 1.0 - exp_n;
 
-    cdf_log += log(cdf_);
+    cdf_log += log(cdf_n);
 
-    const T_partials_return rep_deriv = pow_ / (1.0 / exp_ - 1.0);
+    const T_partials_return rep_deriv = pow_n / (1.0 / exp_n - 1.0);
     if (!is_constant_all<T_y>::value) {
       ops_partials.edge1_.partials_[n] += rep_deriv * alpha_dbl / y_dbl;
     }


### PR DESCRIPTION
## Summary

These are all occurrences I found. The remaining uses of trailing underscores in variable names are in class members. Fixes #1581.

## Tests

Nothing new, this is just cleanup.

## Side Effects

None.

## Checklist

- [X] Math issue #1581

- [X] Copyright holder: Marco Colombo

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [X] the new changes are tested
