### PR TITLE
Add singular_values test for size zero input

### DIFF
--- a/stan/math/prim/mat/fun/singular_values.hpp
+++ b/stan/math/prim/mat/fun/singular_values.hpp
@@ -19,8 +19,9 @@ namespace math {
 template <typename T>
 Eigen::Matrix<T, Eigen::Dynamic, 1> singular_values(
     const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& m) {
-  if (m.size() == 0)
-    return Eigen::Matrix<T, 0, 1>();
+  if (m.size() == 0) {
+    return {};
+  }
 
   return Eigen::JacobiSVD<Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> >(m)
       .singularValues();

--- a/test/unit/math/prim/mat/fun/singular_values_test.cpp
+++ b/test/unit/math/prim/mat/fun/singular_values_test.cpp
@@ -2,9 +2,12 @@
 #include <gtest/gtest.h>
 
 TEST(MathMatrixPrimMat, singular_values) {
-  stan::math::matrix_d m0(1, 1);
-  m0 << 1.0;
-
   using stan::math::singular_values;
+
+  stan::math::matrix_d m0(0, 0);
   EXPECT_NO_THROW(singular_values(m0));
+
+  stan::math::matrix_d m1(1, 1);
+  m1 << 1.0;
+  EXPECT_NO_THROW(singular_values(m1));
 }


### PR DESCRIPTION
## Summary

When fixing #1439 we didn't add a prim test for `singular_values` if the input was size zero. I'm also sneaking in a trivial code cleanup for the function itself.

## Tests

Added test that we don't throw on size zero input.

## Side Effects

None

## Checklist

- [X] Math issue #1439

- [X] Copyright holder: Marco Colombo

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [X] the new changes are tested
