### PR TITLE
Use vectorized log() instead of Eigen's version

### DIFF
--- a/stan/math/prim/mat/fun/LDLT_factor.hpp
+++ b/stan/math/prim/mat/fun/LDLT_factor.hpp
@@ -3,6 +3,8 @@
 
 #include <stan/math/prim/err/check_square.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <stan/math/prim/mat/fun/log.hpp>
+#include <stan/math/prim/mat/fun/sum.hpp>
 #include <stan/math/prim/scal/fun/is_nan.hpp>
 #include <boost/shared_ptr.hpp>
 
@@ -96,7 +98,7 @@ class LDLT_factor {
     return true;
   }
 
-  inline T log_abs_det() const { return ldltP_->vectorD().array().log().sum(); }
+  inline T log_abs_det() const { return sum(log(ldltP_->vectorD())); }
 
   inline void inverse(matrix_t& invA) const {
     invA.setIdentity(N_);

--- a/stan/math/prim/mat/fun/log_determinant_spd.hpp
+++ b/stan/math/prim/mat/fun/log_determinant_spd.hpp
@@ -3,6 +3,8 @@
 
 #include <stan/math/prim/err.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <stan/math/prim/mat/fun/log.hpp>
+#include <stan/math/prim/mat/fun/sum.hpp>
 #include <cmath>
 
 namespace stan {
@@ -26,7 +28,7 @@ inline T log_determinant_spd(const Eigen::Matrix<T, R, C>& m) {
   if (m.size() == 0)
     return 0;
 
-  return m.ldlt().vectorD().array().log().sum();
+  return sum(log(m.ldlt().vectorD().array()));
 }
 
 }  // namespace math

--- a/stan/math/prim/mat/fun/read_cov_L.hpp
+++ b/stan/math/prim/mat/fun/read_cov_L.hpp
@@ -2,6 +2,8 @@
 #define STAN_MATH_PRIM_MAT_FUN_READ_COV_L_HPP
 
 #include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <stan/math/prim/mat/fun/log.hpp>
+#include <stan/math/prim/mat/fun/sum.hpp>
 #include <stan/math/prim/scal/fun/constants.hpp>
 
 namespace stan {
@@ -24,7 +26,7 @@ Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> read_cov_L(
     const Eigen::Array<T, Eigen::Dynamic, 1>& sds, T& log_prob) {
   size_t K = sds.rows();
   // adjust due to transformation from correlations to covariances
-  log_prob += (sds.log().sum() + LOG_TWO) * K;
+  log_prob += (sum(log(sds)) + LOG_TWO) * K;
   return sds.matrix().asDiagonal() * read_corr_L(CPCs, K, log_prob);
 }
 

--- a/stan/math/prim/prob/lkj_corr_cholesky_lpdf.hpp
+++ b/stan/math/prim/prob/lkj_corr_cholesky_lpdf.hpp
@@ -5,6 +5,7 @@
 #include <stan/math/prim/err.hpp>
 #include <stan/math/prim/mat/fun/make_nu.hpp>
 #include <stan/math/prim/prob/lkj_corr_log.hpp>
+#include <stan/math/prim/mat/fun/log.hpp>
 #include <stan/math/prim/mat/fun/multiply.hpp>
 
 namespace stan {
@@ -34,7 +35,7 @@ return_type_t<T_covar, T_shape> lkj_corr_cholesky_lpdf(
   if (include_summand<propto, T_covar, T_shape>::value) {
     const int Km1 = K - 1;
     Eigen::Matrix<T_covar, Eigen::Dynamic, 1> log_diagonals
-        = L.diagonal().tail(Km1).array().log();
+        = log(L.diagonal().tail(Km1).array());
     Eigen::Matrix<lp_ret, Eigen::Dynamic, 1> values(Km1);
     for (int k = 0; k < Km1; k++) {
       values(k) = (Km1 - k - 1) * log_diagonals(k);

--- a/stan/math/prim/prob/lkj_corr_lpdf.hpp
+++ b/stan/math/prim/prob/lkj_corr_lpdf.hpp
@@ -5,6 +5,8 @@
 #include <stan/math/prim/err.hpp>
 #include <stan/math/prim/scal/fun/constants.hpp>
 #include <stan/math/prim/scal/fun/lgamma.hpp>
+#include <stan/math/prim/mat/fun/log.hpp>
+#include <stan/math/prim/mat/fun/sum.hpp>
 
 namespace stan {
 namespace math {
@@ -69,9 +71,8 @@ return_type_t<T_y, T_shape> lkj_corr_lpdf(
     return lp;
   }
 
-  Eigen::Matrix<T_y, Eigen::Dynamic, 1> values
-      = y.ldlt().vectorD().array().log().matrix();
-  lp += (eta - 1.0) * sum(values);
+  T_y sum_values = sum(log(y.ldlt().vectorD()));
+  lp += (eta - 1.0) * sum_values;
   return lp;
 }
 

--- a/stan/math/prim/prob/multi_gp_cholesky_lpdf.hpp
+++ b/stan/math/prim/prob/multi_gp_cholesky_lpdf.hpp
@@ -11,6 +11,7 @@
 
 namespace stan {
 namespace math {
+
 /** \ingroup multivar_dists
  * The log of a multivariate Gaussian Process for the given y, w, and
  * a Cholesky factor L of the kernel matrix Sigma.
@@ -21,6 +22,10 @@ namespace math {
  * This distribution is equivalent to:
  *    for (i in 1:d) row(y, i) ~ multi_normal(0, (1/w[i])*LL').
  *
+ * @tparam T_y type of scalar
+ * @tparam T_covar type of kernel
+ * @tparam T_w type of weight
+ *
  * @param y A dxN matrix
  * @param L The Cholesky decomposition of a kernel matrix
  * @param w A d-dimensional vector of positve inverse scale parameters for each
@@ -28,9 +33,6 @@ namespace math {
  * @return The log of the multivariate GP density.
  * @throw std::domain_error if Sigma is not square, not symmetric,
  * or not semi-positive definite.
- * @tparam T_y Type of scalar.
- * @tparam T_covar Type of kernel.
- * @tparam T_w Type of weight.
  */
 template <bool propto, typename T_y, typename T_covar, typename T_w>
 return_type_t<T_y, T_covar, T_w> multi_gp_cholesky_lpdf(
@@ -58,7 +60,7 @@ return_type_t<T_y, T_covar, T_w> multi_gp_cholesky_lpdf(
   }
 
   if (include_summand<propto, T_covar>::value) {
-    lp -= L.diagonal().array().log().sum() * y.rows();
+    lp -= sum(log(L.diagonal())) * y.rows();
   }
 
   if (include_summand<propto, T_w>::value) {

--- a/stan/math/prim/prob/multi_normal_cholesky_lpdf.hpp
+++ b/stan/math/prim/prob/multi_normal_cholesky_lpdf.hpp
@@ -5,12 +5,14 @@
 #include <stan/math/prim/err.hpp>
 #include <stan/math/prim/mat/fun/dot_self.hpp>
 #include <stan/math/prim/mat/fun/log.hpp>
+#include <stan/math/prim/mat/fun/sum.hpp>
 #include <stan/math/prim/mat/fun/mdivide_left_tri.hpp>
 #include <stan/math/prim/mat/fun/transpose.hpp>
 #include <stan/math/prim/scal/fun/constants.hpp>
 
 namespace stan {
 namespace math {
+
 /** \ingroup multivar_dists
  * The log of the multivariate normal density for the given y, mu, and
  * a Cholesky factor L of the variance matrix.
@@ -147,7 +149,7 @@ return_type_t<T_y, T_loc, T_covar> multi_normal_cholesky_lpdf(
   }
 
   if (include_summand<propto, T_covar_elem>::value) {
-    logp += inv_L_dbl.diagonal().array().log().sum() * size_vec;
+    logp += sum(log(inv_L_dbl.diagonal())) * size_vec;
     if (!is_constant_all<T_covar>::value) {
       ops_partials.edge3_.partials_ -= size_vec * inv_L_dbl.transpose();
     }

--- a/stan/math/rev/mat/fun/LDLT_alloc.hpp
+++ b/stan/math/rev/mat/fun/LDLT_alloc.hpp
@@ -3,10 +3,13 @@
 
 #include <stan/math/rev/meta.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <stan/math/prim/mat/fun/log.hpp>
+#include <stan/math/prim/mat/fun/sum.hpp>
 #include <stan/math/rev/core.hpp>
 
 namespace stan {
 namespace math {
+
 /**
  * This object stores the actual (double typed) LDLT factorization of
  * an Eigen::Matrix<var> along with pointers to its vari's which allow the
@@ -36,13 +39,14 @@ class LDLT_alloc : public chainable_alloc {
 
   // Compute the log(abs(det(A))).  This is just a convenience function.
   inline double log_abs_det() const {
-    return ldlt_.vectorD().array().log().sum();
+    return sum(log(ldlt_.vectorD().array()));
   }
 
   size_t N_;
   Eigen::LDLT<Eigen::Matrix<double, R, C> > ldlt_;
   Eigen::Matrix<vari *, R, C> variA_;
 };
+
 }  // namespace math
 }  // namespace stan
 #endif

--- a/stan/math/rev/mat/fun/log_determinant_spd.hpp
+++ b/stan/math/rev/mat/fun/log_determinant_spd.hpp
@@ -4,6 +4,8 @@
 #include <stan/math/rev/meta.hpp>
 #include <stan/math/prim/err.hpp>
 #include <stan/math/prim/mat/fun/Eigen.hpp>
+#include <stan/math/prim/mat/fun/log.hpp>
+#include <stan/math/prim/mat/fun/sum.hpp>
 #include <stan/math/prim/mat/fun/typedefs.hpp>
 #include <stan/math/rev/core.hpp>
 
@@ -35,7 +37,7 @@ inline var log_determinant_spd(const Eigen::Matrix<var, R, C>& m) {
                        "matrix is negative definite");
   }
 
-  double val = ldlt.vectorD().array().log().sum();
+  double val = sum(log(ldlt.vectorD()));
 
   check_finite("log_determinant_spd",
                "log determininant of the matrix argument", val);


### PR DESCRIPTION
## Summary

Following the advice in https://github.com/stan-dev/math/issues/83#issuecomment-297506294, this replaces the current uses of Eigen's `.log()` with `stan::math::log`. In most cases, we are summing after taking logs, so we can use `stan::math::sum` too.

## Tests

No new tests.

## Side Effects

None.

## Checklist

- [X] Math issue #83

- [X] Copyright holder: Marco Colombo

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [X] the new changes are tested
