### PR TITLE
Remove unnecessary uses of VectorBuilder in pareto_type_2 functions

### DIFF
--- a/stan/math/prim/prob/pareto_type_2_cdf.hpp
+++ b/stan/math/prim/prob/pareto_type_2_cdf.hpp
@@ -48,13 +48,14 @@ return_type_t<T_y, T_loc, T_scale, T_shape> pareto_type_2_cdf(
     const T_partials_return mu_dbl = value_of(mu_vec[n]);
     const T_partials_return lambda_dbl = value_of(lambda_vec[n]);
     const T_partials_return alpha_dbl = value_of(alpha_vec[n]);
-    const T_partials_return temp = lambda_dbl + y_dbl - mu_dbl;
+    const T_partials_return sum_dbl = lambda_dbl + y_dbl - mu_dbl;
+    const T_partials_return temp = sum_dbl / lambda_dbl;
 
     const T_partials_return p1_pow_alpha = pow(temp, -alpha_dbl);
     const T_partials_return grad_1_2
         = is_constant_all<T_y, T_loc, T_scale>::value
               ? 0
-              : p1_pow_alpha / temp * alpha_dbl;
+              : p1_pow_alpha / sum_dbl * alpha_dbl;
 
     const T_partials_return Pn = 1.0 - p1_pow_alpha;
 
@@ -71,8 +72,7 @@ return_type_t<T_y, T_loc, T_scale, T_shape> pareto_type_2_cdf(
           += (mu_dbl - y_dbl) * grad_1_2 / (lambda_dbl * Pn);
     }
     if (!is_constant_all<T_shape>::value) {
-      ops_partials.edge4_.partials_[n]
-          += log(temp / lambda_dbl) * p1_pow_alpha / Pn;
+      ops_partials.edge4_.partials_[n] += log(temp) * p1_pow_alpha / Pn;
     }
   }
 

--- a/stan/math/prim/prob/pareto_type_2_cdf.hpp
+++ b/stan/math/prim/prob/pareto_type_2_cdf.hpp
@@ -15,12 +15,11 @@ return_type_t<T_y, T_loc, T_scale, T_shape> pareto_type_2_cdf(
     const T_y& y, const T_loc& mu, const T_scale& lambda,
     const T_shape& alpha) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale, T_shape>;
+  static const char* function = "pareto_type_2_cdf";
 
   if (size_zero(y, mu, lambda, alpha)) {
     return 1.0;
   }
-
-  static const char* function = "pareto_type_2_cdf";
 
   using std::log;
   using std::pow;
@@ -44,54 +43,36 @@ return_type_t<T_y, T_loc, T_scale, T_shape> pareto_type_2_cdf(
   operands_and_partials<T_y, T_loc, T_scale, T_shape> ops_partials(
       y, mu, lambda, alpha);
 
-  VectorBuilder<true, T_partials_return, T_y, T_loc, T_scale, T_shape>
-      p1_pow_alpha(N);
-
-  VectorBuilder<!is_constant_all<T_y, T_loc, T_scale>::value, T_partials_return,
-                T_y, T_loc, T_scale, T_shape>
-      grad_1_2(N);
-
-  VectorBuilder<!is_constant_all<T_shape, T_y>::value, T_partials_return, T_y,
-                T_loc, T_scale, T_shape>
-      grad_3(N);
-
-  for (size_t i = 0; i < N; i++) {
-    const T_partials_return lambda_dbl = value_of(lambda_vec[i]);
-    const T_partials_return alpha_dbl = value_of(alpha_vec[i]);
-    const T_partials_return temp
-        = 1 + (value_of(y_vec[i]) - value_of(mu_vec[i])) / lambda_dbl;
-    p1_pow_alpha[i] = pow(temp, -alpha_dbl);
-
-    if (!is_constant_all<T_y, T_loc, T_scale>::value) {
-      grad_1_2[i] = p1_pow_alpha[i] / temp * alpha_dbl / lambda_dbl;
-    }
-
-    if (!is_constant_all<T_shape>::value) {
-      grad_3[i] = log(temp) * p1_pow_alpha[i];
-    }
-  }
-
   for (size_t n = 0; n < N; n++) {
     const T_partials_return y_dbl = value_of(y_vec[n]);
     const T_partials_return mu_dbl = value_of(mu_vec[n]);
     const T_partials_return lambda_dbl = value_of(lambda_vec[n]);
+    const T_partials_return alpha_dbl = value_of(alpha_vec[n]);
+    const T_partials_return temp = lambda_dbl + y_dbl - mu_dbl;
 
-    const T_partials_return Pn = 1.0 - p1_pow_alpha[n];
+    const T_partials_return p1_pow_alpha = pow(temp, -alpha_dbl);
+    const T_partials_return grad_1_2
+        = is_constant_all<T_y, T_loc, T_scale>::value
+              ? 0
+              : p1_pow_alpha / temp * alpha_dbl;
+
+    const T_partials_return Pn = 1.0 - p1_pow_alpha;
 
     P *= Pn;
 
     if (!is_constant_all<T_y>::value) {
-      ops_partials.edge1_.partials_[n] += grad_1_2[n] / Pn;
+      ops_partials.edge1_.partials_[n] += grad_1_2 / Pn;
     }
     if (!is_constant_all<T_loc>::value) {
-      ops_partials.edge2_.partials_[n] -= grad_1_2[n] / Pn;
+      ops_partials.edge2_.partials_[n] -= grad_1_2 / Pn;
     }
     if (!is_constant_all<T_scale>::value) {
       ops_partials.edge3_.partials_[n]
-          += (mu_dbl - y_dbl) * grad_1_2[n] / lambda_dbl / Pn;
+          += (mu_dbl - y_dbl) * grad_1_2 / (lambda_dbl * Pn);
     }
     if (!is_constant_all<T_shape>::value) {
-      ops_partials.edge4_.partials_[n] += grad_3[n] / Pn;
+      ops_partials.edge4_.partials_[n]
+          += log(temp / lambda_dbl) * p1_pow_alpha / Pn;
     }
   }
 

--- a/stan/math/prim/prob/pareto_type_2_lccdf.hpp
+++ b/stan/math/prim/prob/pareto_type_2_lccdf.hpp
@@ -15,12 +15,11 @@ return_type_t<T_y, T_loc, T_scale, T_shape> pareto_type_2_lccdf(
     const T_y& y, const T_loc& mu, const T_scale& lambda,
     const T_shape& alpha) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale, T_shape>;
+  static const char* function = "pareto_type_2_lccdf";
 
   if (size_zero(y, mu, lambda, alpha)) {
     return 0.0;
   }
-
-  static const char* function = "pareto_type_2_lccdf";
 
   using std::log;
 
@@ -43,57 +42,38 @@ return_type_t<T_y, T_loc, T_scale, T_shape> pareto_type_2_lccdf(
   operands_and_partials<T_y, T_loc, T_scale, T_shape> ops_partials(
       y, mu, lambda, alpha);
 
-  VectorBuilder<true, T_partials_return, T_y, T_loc, T_scale, T_shape> ccdf_log(
-      N);
-
-  VectorBuilder<!is_constant_all<T_y, T_loc, T_scale, T_shape>::value,
-                T_partials_return, T_y, T_loc, T_scale, T_shape>
-      a_over_lambda_plus_y(N);
-
-  VectorBuilder<!is_constant_all<T_shape>::value, T_partials_return, T_y, T_loc,
-                T_scale, T_shape>
-      log_1p_y_over_lambda(N);
-
-  for (size_t i = 0; i < N; i++) {
-    const T_partials_return y_dbl = value_of(y_vec[i]);
-    const T_partials_return mu_dbl = value_of(mu_vec[i]);
-    const T_partials_return lambda_dbl = value_of(lambda_vec[i]);
-    const T_partials_return alpha_dbl = value_of(alpha_vec[i]);
-    const T_partials_return temp = 1.0 + (y_dbl - mu_dbl) / lambda_dbl;
-    const T_partials_return log_temp = log(temp);
-
-    ccdf_log[i] = -alpha_dbl * log_temp;
-
-    if (!is_constant_all<T_y, T_loc, T_scale, T_shape>::value) {
-      a_over_lambda_plus_y[i] = alpha_dbl / (y_dbl - mu_dbl + lambda_dbl);
-    }
-
-    if (!is_constant_all<T_shape>::value) {
-      log_1p_y_over_lambda[i] = log_temp;
-    }
-  }
-
   for (size_t n = 0; n < N; n++) {
     const T_partials_return y_dbl = value_of(y_vec[n]);
     const T_partials_return mu_dbl = value_of(mu_vec[n]);
     const T_partials_return lambda_dbl = value_of(lambda_vec[n]);
+    const T_partials_return alpha_dbl = value_of(alpha_vec[n]);
+    const T_partials_return temp = 1.0 + (y_dbl - mu_dbl) / lambda_dbl;
 
-    P += ccdf_log[n];
+    const T_partials_return log_temp = log(temp);
+    const T_partials_return rep_deriv
+        = is_constant_all<T_y, T_loc, T_scale, T_shape>::value
+              ? 0
+              : alpha_dbl / (y_dbl - mu_dbl + lambda_dbl);
+
+    const T_partials_return ccdf_log = -alpha_dbl * log_temp;
+
+    P += ccdf_log;
 
     if (!is_constant_all<T_y>::value) {
-      ops_partials.edge1_.partials_[n] -= a_over_lambda_plus_y[n];
+      ops_partials.edge1_.partials_[n] -= rep_deriv;
     }
     if (!is_constant_all<T_loc>::value) {
-      ops_partials.edge2_.partials_[n] += a_over_lambda_plus_y[n];
+      ops_partials.edge2_.partials_[n] += rep_deriv;
     }
     if (!is_constant_all<T_scale>::value) {
       ops_partials.edge3_.partials_[n]
-          += a_over_lambda_plus_y[n] * (y_dbl - mu_dbl) / lambda_dbl;
+          += rep_deriv * (y_dbl - mu_dbl) / lambda_dbl;
     }
     if (!is_constant_all<T_shape>::value) {
-      ops_partials.edge4_.partials_[n] -= log_1p_y_over_lambda[n];
+      ops_partials.edge4_.partials_[n] -= log_temp;
     }
   }
+
   return ops_partials.build(P);
 }
 

--- a/stan/math/prim/prob/pareto_type_2_lcdf.hpp
+++ b/stan/math/prim/prob/pareto_type_2_lcdf.hpp
@@ -16,12 +16,11 @@ return_type_t<T_y, T_loc, T_scale, T_shape> pareto_type_2_lcdf(
     const T_y& y, const T_loc& mu, const T_scale& lambda,
     const T_shape& alpha) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale, T_shape>;
+  static const char* function = "pareto_type_2_lcdf";
 
   if (size_zero(y, mu, lambda, alpha)) {
     return 0.0;
   }
-
-  static const char* function = "pareto_type_2_lcdf";
 
   using std::log;
   using std::pow;
@@ -45,40 +44,25 @@ return_type_t<T_y, T_loc, T_scale, T_shape> pareto_type_2_lcdf(
   operands_and_partials<T_y, T_loc, T_scale, T_shape> ops_partials(
       y, mu, lambda, alpha);
 
-  VectorBuilder<true, T_partials_return, T_y, T_loc, T_scale, T_shape> cdf_log(
-      N);
-
-  VectorBuilder<true, T_partials_return, T_y, T_loc, T_scale, T_shape>
-      inv_p1_pow_alpha_minus_one(N);
-
-  VectorBuilder<!is_constant_all<T_shape>::value, T_partials_return, T_y, T_loc,
-                T_scale, T_shape>
-      log_1p_y_over_lambda(N);
-
-  for (size_t i = 0; i < N; i++) {
-    const T_partials_return temp = 1.0
-                                   + (value_of(y_vec[i]) - value_of(mu_vec[i]))
-                                         / value_of(lambda_vec[i]);
-    const T_partials_return p1_pow_alpha = pow(temp, value_of(alpha_vec[i]));
-    cdf_log[i] = log1m(1.0 / p1_pow_alpha);
-
-    inv_p1_pow_alpha_minus_one[i] = 1.0 / (p1_pow_alpha - 1.0);
-
-    if (!is_constant_all<T_shape>::value) {
-      log_1p_y_over_lambda[i] = log(temp);
-    }
-  }
-
   for (size_t n = 0; n < N; n++) {
     const T_partials_return y_dbl = value_of(y_vec[n]);
     const T_partials_return mu_dbl = value_of(mu_vec[n]);
     const T_partials_return lambda_dbl = value_of(lambda_vec[n]);
     const T_partials_return alpha_dbl = value_of(alpha_vec[n]);
+    const T_partials_return temp = 1.0 + (y_dbl - mu_dbl) / lambda_dbl;
 
-    const T_partials_return grad_1_2 = alpha_dbl * inv_p1_pow_alpha_minus_one[n]
-                                       / (lambda_dbl - mu_dbl + y_dbl);
+    const T_partials_return p1_pow_alpha = pow(temp, alpha_dbl);
+    const T_partials_return inv_p1_pow_alpha_minus_one
+        = inv(p1_pow_alpha - 1.0);
+    const T_partials_return grad_1_2
+        = is_constant_all<T_y, T_loc, T_scale>::value
+              ? 0
+              : alpha_dbl * inv_p1_pow_alpha_minus_one
+                    / (lambda_dbl - mu_dbl + y_dbl);
 
-    P += cdf_log[n];
+    const T_partials_return cdf_log = log1m(1.0 / p1_pow_alpha);
+
+    P += cdf_log;
 
     if (!is_constant_all<T_y>::value) {
       ops_partials.edge1_.partials_[n] += grad_1_2;
@@ -92,9 +76,10 @@ return_type_t<T_y, T_loc, T_scale, T_shape> pareto_type_2_lcdf(
     }
     if (!is_constant_all<T_shape>::value) {
       ops_partials.edge4_.partials_[n]
-          += log_1p_y_over_lambda[n] * inv_p1_pow_alpha_minus_one[n];
+          += log(temp) * inv_p1_pow_alpha_minus_one;
     }
   }
+
   return ops_partials.build(P);
 }
 

--- a/stan/math/prim/prob/pareto_type_2_lpdf.hpp
+++ b/stan/math/prim/prob/pareto_type_2_lpdf.hpp
@@ -48,14 +48,6 @@ return_type_t<T_y, T_loc, T_scale, T_shape> pareto_type_2_lpdf(
   operands_and_partials<T_y, T_loc, T_scale, T_shape> ops_partials(
       y, mu, lambda, alpha);
 
-  VectorBuilder<include_summand<propto, T_y, T_loc, T_scale, T_shape>::value,
-                T_partials_return, T_y, T_loc, T_scale>
-      log1p_scaled_diff(N);
-  for (size_t n = 0; n < N; n++) {
-    log1p_scaled_diff[n] = log1p((value_of(y_vec[n]) - value_of(mu_vec[n]))
-                                 / value_of(lambda_vec[n]));
-  }
-
   VectorBuilder<include_summand<propto, T_scale>::value, T_partials_return,
                 T_scale>
       log_lambda(size(lambda));
@@ -87,10 +79,14 @@ return_type_t<T_y, T_loc, T_scale, T_shape> pareto_type_2_lpdf(
     const T_partials_return mu_dbl = value_of(mu_vec[n]);
     const T_partials_return lambda_dbl = value_of(lambda_vec[n]);
     const T_partials_return alpha_dbl = value_of(alpha_vec[n]);
-    const T_partials_return sum_dbl = lambda_dbl + y_dbl - mu_dbl;
-    const T_partials_return inv_sum = 1.0 / sum_dbl;
-    const T_partials_return alpha_div_sum = alpha_dbl / sum_dbl;
+    const T_partials_return inv_sum = 1.0 / (lambda_dbl + y_dbl - mu_dbl);
+    const T_partials_return alpha_div_sum = alpha_dbl * inv_sum;
     const T_partials_return deriv_1_2 = inv_sum + alpha_div_sum;
+
+    const T_partials_return log1p_scaled_diff
+        = include_summand<propto, T_y, T_scale, T_shape>::value
+              ? log1p((y_dbl - mu_dbl) / lambda_dbl)
+              : 0;
 
     if (include_summand<propto, T_shape>::value) {
       logp += log_alpha[n];
@@ -99,7 +95,7 @@ return_type_t<T_y, T_loc, T_scale, T_shape> pareto_type_2_lpdf(
       logp -= log_lambda[n];
     }
     if (include_summand<propto, T_y, T_scale, T_shape>::value) {
-      logp -= (alpha_dbl + 1.0) * log1p_scaled_diff[n];
+      logp -= (alpha_dbl + 1.0) * log1p_scaled_diff;
     }
 
     if (!is_constant_all<T_y>::value) {
@@ -113,7 +109,7 @@ return_type_t<T_y, T_loc, T_scale, T_shape> pareto_type_2_lpdf(
           -= alpha_div_sum * (mu_dbl - y_dbl) / lambda_dbl + inv_sum;
     }
     if (!is_constant_all<T_shape>::value) {
-      ops_partials.edge4_.partials_[n] += inv_alpha[n] - log1p_scaled_diff[n];
+      ops_partials.edge4_.partials_[n] += inv_alpha[n] - log1p_scaled_diff;
     }
   }
   return ops_partials.build(logp);


### PR DESCRIPTION
## Summary

This removes all unnecessary uses of `VectorBuilder` in the `pareto_type_2_*` functions. Changes are quite obvious and follow the approach laid out in the issue. Essentially, rather than setting up `VectorBuilders` for `1..N` (so with no computation being saved if any parameter was a scalar and all others were vectors), we compute the quantities at each iteration as required.

The only case that's slightly different is for `pareto_type_2_lpdf`, in which `log1p_scaled_diff` before was always computed, even though it was needed only for some settings of the paramers. Now we can save a few computations in the cases when they are not needed.

Fixes #1589.

## Tests

No new tests, this is cleanup.

## Side Effects

None.

## Checklist

- [X] Math issue #1589

- [X] Copyright holder: Marco Colombo

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [X] the new changes are tested
