### PR TITLE
Jenkins Windows: build libs before tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ def runTests(String testPath) {
 def runTestsWin(String testPath) {
     withEnv(['PATH+TBB=./lib/tbb']) {
        bat "echo $PATH"
-       bat "make make/standalone math-libs"
+       bat "mingw32-make.exe make/standalone math-libs"
        bat "runTests.py -j${env.PARALLEL} ${testPath} --make-only"
        try { bat "runTests.py -j${env.PARALLEL} ${testPath}" }
        finally { junit 'test/**/*.xml' }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,6 +11,7 @@ def runTests(String testPath) {
 def runTestsWin(String testPath) {
     withEnv(['PATH+TBB=./lib/tbb']) {
        bat "echo $PATH"
+       bat "make make/standalone math-libs"
        bat "runTests.py -j${env.PARALLEL} ${testPath} --make-only"
        try { bat "runTests.py -j${env.PARALLEL} ${testPath}" }
        finally { junit 'test/**/*.xml' }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ def runTests(String testPath) {
 def runTestsWin(String testPath) {
     withEnv(['PATH+TBB=./lib/tbb']) {
        bat "echo $PATH"
-       bat "mingw32-make.exe make/standalone math-libs"
+       bat "mingw32-make.exe -f make/standalone math-libs"
        bat "runTests.py -j${env.PARALLEL} ${testPath} --make-only"
        try { bat "runTests.py -j${env.PARALLEL} ${testPath}" }
        finally { junit 'test/**/*.xml' }


### PR DESCRIPTION
## Summary

This changes how we run tests on Jenkins Windows nodes by first building the libraries to avoid issues with building the sundials .a files that have been occurring lately.

## Tests

/

## Side Effects

/

## Checklist

- [x] Copyright holder: Rok Češnovar

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
