### PR TITLE
Remove unnecessary calculations in exp mod normal by storing intermediate results

### DIFF
--- a/stan/math/prim/prob/exp_mod_normal_cdf.hpp
+++ b/stan/math/prim/prob/exp_mod_normal_cdf.hpp
@@ -61,12 +61,11 @@ return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_cdf(
     const T_partials_return sigma_dbl = value_of(sigma_vec[n]);
     const T_partials_return lambda_dbl = value_of(lambda_vec[n]);
     const T_partials_return inv_sigma = inv(sigma_dbl);
-    const T_partials_return u = lambda_dbl * (y_dbl - mu_dbl);
+    const T_partials_return diff = y_dbl - mu_dbl;
+    const T_partials_return scaled_diff = diff * INV_SQRT_TWO * inv_sigma;
+    const T_partials_return u = lambda_dbl * diff;
     const T_partials_return v = lambda_dbl * sigma_dbl;
     const T_partials_return v_over_sqrt_two = v * INV_SQRT_TWO;
-    const T_partials_return scaled_diff
-        = (y_dbl - mu_dbl) * INV_SQRT_TWO * inv_sigma;
-    const T_partials_return scaled_diff_sq = scaled_diff * scaled_diff;
     const T_partials_return erf_calc
         = 0.5 * (1 + erf(-v_over_sqrt_two + scaled_diff));
     const T_partials_return exp_term = exp(0.5 * square(v) - u);
@@ -76,7 +75,7 @@ return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_cdf(
         = SQRT_TWO_OVER_SQRT_PI * 0.5 * exp_term
           * exp(-square(scaled_diff - v_over_sqrt_two)) * inv_sigma;
     const T_partials_return deriv_3
-        = SQRT_TWO_OVER_SQRT_PI * 0.5 * exp(-scaled_diff_sq) * inv_sigma;
+        = SQRT_TWO_OVER_SQRT_PI * 0.5 * exp(-square(scaled_diff)) * inv_sigma;
 
     const T_partials_return cdf_n
         = 0.5 + 0.5 * erf(u / (v * SQRT_TWO)) - exp_term * erf_calc;
@@ -100,7 +99,7 @@ return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_cdf(
           += exp_term
              * (SQRT_TWO_OVER_SQRT_PI * 0.5 * sigma_dbl
                     * exp(-square(v_over_sqrt_two - scaled_diff))
-                - (v * sigma_dbl + mu_dbl - y_dbl) * erf_calc)
+                - (v * sigma_dbl - diff) * erf_calc)
              / cdf_n;
     }
   }

--- a/stan/math/prim/prob/exp_mod_normal_cdf.hpp
+++ b/stan/math/prim/prob/exp_mod_normal_cdf.hpp
@@ -48,37 +48,37 @@ return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_cdf(
   scalar_seq_view<T_inv_scale> lambda_vec(lambda);
   size_t N = max_size(y, mu, sigma, lambda);
 
-  for (size_t n = 0; n < N; n++) {
-    if (is_inf(y_vec[n])) {
-      if (y_vec[n] < 0.0) {
-        return ops_partials.build(0.0);
-      }
+  for (size_t n = 0, size_y = size(y); n < size_y; n++) {
+    if (is_inf(y_vec[n]) && y_vec[n] < 0.0) {
+      return ops_partials.build(0.0);
     }
+  }
 
+  for (size_t n = 0; n < N; n++) {
     const T_partials_return y_dbl = value_of(y_vec[n]);
     const T_partials_return mu_dbl = value_of(mu_vec[n]);
     const T_partials_return sigma_dbl = value_of(sigma_vec[n]);
     const T_partials_return lambda_dbl = value_of(lambda_vec[n]);
     const T_partials_return u = lambda_dbl * (y_dbl - mu_dbl);
     const T_partials_return v = lambda_dbl * sigma_dbl;
-    const T_partials_return v_sq = v * v;
-    const T_partials_return v_over_sqrt_two = v / SQRT_TWO;
+    const T_partials_return v_over_sqrt_two = v * INV_SQRT_TWO;
+    const T_partials_return inv_sigma = 1 / sigma_dbl;
     const T_partials_return scaled_diff
-        = (y_dbl - mu_dbl) / (SQRT_TWO * sigma_dbl);
+        = (y_dbl - mu_dbl) * INV_SQRT_TWO * inv_sigma;
     const T_partials_return scaled_diff_sq = scaled_diff * scaled_diff;
     const T_partials_return erf_calc
         = 0.5 * (1 + erf(-v_over_sqrt_two + scaled_diff));
-    const T_partials_return deriv_1
-        = lambda_dbl * exp(0.5 * v_sq - u) * erf_calc;
-    const T_partials_return deriv_2
-        = SQRT_TWO_OVER_SQRT_PI * 0.5
-          * exp(0.5 * v_sq - square(scaled_diff - v_over_sqrt_two) - u)
-          / sigma_dbl;
-    const T_partials_return deriv_3
-        = SQRT_TWO_OVER_SQRT_PI * 0.5 * exp(-scaled_diff_sq) / sigma_dbl;
+    const T_partials_return exp_term = exp(0.5 * square(v) - u);
 
-    const T_partials_return cdf_n = 0.5 * (1 + erf(u / (v * SQRT_TWO)))
-                                    - exp(-u + v_sq * 0.5) * (erf_calc);
+    const T_partials_return deriv_1 = lambda_dbl * exp_term * erf_calc;
+    const T_partials_return deriv_2
+        = SQRT_TWO_OVER_SQRT_PI * 0.5 * exp_term
+          * exp(-square(scaled_diff - v_over_sqrt_two)) * inv_sigma;
+    const T_partials_return deriv_3
+        = SQRT_TWO_OVER_SQRT_PI * 0.5 * exp(-scaled_diff_sq) * inv_sigma;
+
+    const T_partials_return cdf_n
+        = 0.5 * (1 + erf(u / (v * SQRT_TWO))) - exp_term * erf_calc;
 
     cdf *= cdf_n;
 
@@ -87,20 +87,17 @@ return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_cdf(
     }
     if (!is_constant_all<T_loc>::value) {
       ops_partials.edge2_.partials_[n]
-          += (-deriv_1 + deriv_2 - deriv_3) / cdf_n;
+          -= (deriv_1 - deriv_2 + deriv_3) / cdf_n;
     }
     if (!is_constant_all<T_scale>::value) {
       ops_partials.edge3_.partials_[n]
-          += (-deriv_1 * v - deriv_3 * scaled_diff * SQRT_TWO
-              - deriv_2 * sigma_dbl * SQRT_TWO
-                    * (-SQRT_TWO * 0.5
-                           * (-lambda_dbl + scaled_diff * SQRT_TWO / sigma_dbl)
-                       - SQRT_TWO * lambda_dbl))
+          -= (deriv_1 * v + deriv_3 * scaled_diff * SQRT_TWO
+              - deriv_2 * (v + SQRT_TWO * scaled_diff))
              / cdf_n;
     }
     if (!is_constant_all<T_inv_scale>::value) {
       ops_partials.edge4_.partials_[n]
-          += exp(0.5 * v_sq - u)
+          += exp_term
              * (SQRT_TWO_OVER_SQRT_PI * 0.5 * sigma_dbl
                     * exp(-square(v_over_sqrt_two - scaled_diff))
                 - (v * sigma_dbl + mu_dbl - y_dbl) * erf_calc)

--- a/stan/math/prim/prob/exp_mod_normal_cdf.hpp
+++ b/stan/math/prim/prob/exp_mod_normal_cdf.hpp
@@ -5,6 +5,7 @@
 #include <stan/math/prim/err.hpp>
 #include <stan/math/prim/scal/fun/constants.hpp>
 #include <stan/math/prim/scal/fun/erf.hpp>
+#include <stan/math/prim/scal/fun/inv.hpp>
 #include <stan/math/prim/scal/fun/is_inf.hpp>
 #include <stan/math/prim/scal/fun/size_zero.hpp>
 #include <stan/math/prim/scal/fun/square.hpp>
@@ -59,10 +60,10 @@ return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_cdf(
     const T_partials_return mu_dbl = value_of(mu_vec[n]);
     const T_partials_return sigma_dbl = value_of(sigma_vec[n]);
     const T_partials_return lambda_dbl = value_of(lambda_vec[n]);
+    const T_partials_return inv_sigma = inv(sigma_dbl);
     const T_partials_return u = lambda_dbl * (y_dbl - mu_dbl);
     const T_partials_return v = lambda_dbl * sigma_dbl;
     const T_partials_return v_over_sqrt_two = v * INV_SQRT_TWO;
-    const T_partials_return inv_sigma = 1 / sigma_dbl;
     const T_partials_return scaled_diff
         = (y_dbl - mu_dbl) * INV_SQRT_TWO * inv_sigma;
     const T_partials_return scaled_diff_sq = scaled_diff * scaled_diff;
@@ -78,7 +79,7 @@ return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_cdf(
         = SQRT_TWO_OVER_SQRT_PI * 0.5 * exp(-scaled_diff_sq) * inv_sigma;
 
     const T_partials_return cdf_n
-        = 0.5 * (1 + erf(u / (v * SQRT_TWO))) - exp_term * erf_calc;
+        = 0.5 + 0.5 * erf(u / (v * SQRT_TWO)) - exp_term * erf_calc;
 
     cdf *= cdf_n;
 

--- a/stan/math/prim/prob/exp_mod_normal_cdf.hpp
+++ b/stan/math/prim/prob/exp_mod_normal_cdf.hpp
@@ -86,8 +86,7 @@ return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_cdf(
       ops_partials.edge1_.partials_[n] += (deriv_1 - deriv_2 + deriv_3) / cdf_n;
     }
     if (!is_constant_all<T_loc>::value) {
-      ops_partials.edge2_.partials_[n]
-          -= (deriv_1 - deriv_2 + deriv_3) / cdf_n;
+      ops_partials.edge2_.partials_[n] -= (deriv_1 - deriv_2 + deriv_3) / cdf_n;
     }
     if (!is_constant_all<T_scale>::value) {
       ops_partials.edge3_.partials_[n]

--- a/stan/math/prim/prob/exp_mod_normal_lccdf.hpp
+++ b/stan/math/prim/prob/exp_mod_normal_lccdf.hpp
@@ -5,6 +5,7 @@
 #include <stan/math/prim/err.hpp>
 #include <stan/math/prim/scal/fun/constants.hpp>
 #include <stan/math/prim/scal/fun/erf.hpp>
+#include <stan/math/prim/scal/fun/inv.hpp>
 #include <stan/math/prim/scal/fun/is_inf.hpp>
 #include <stan/math/prim/scal/fun/size_zero.hpp>
 #include <stan/math/prim/scal/fun/square.hpp>
@@ -50,8 +51,7 @@ return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_lccdf(
 
   for (size_t n = 0, size_y = size(y); n < size_y; n++) {
     if (is_inf(y_vec[n])) {
-      return y_vec[n] > 0.0 ? ops_partials.build(negative_infinity())
-                            : ops_partials.build(0.0);
+      return ops_partials.build(y_vec[n] > 0 ? negative_infinity() : 0);
     }
   }
 
@@ -60,10 +60,10 @@ return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_lccdf(
     const T_partials_return mu_dbl = value_of(mu_vec[n]);
     const T_partials_return sigma_dbl = value_of(sigma_vec[n]);
     const T_partials_return lambda_dbl = value_of(lambda_vec[n]);
+    const T_partials_return inv_sigma = inv(sigma_dbl);
     const T_partials_return u = lambda_dbl * (y_dbl - mu_dbl);
     const T_partials_return v = lambda_dbl * sigma_dbl;
     const T_partials_return v_over_sqrt_two = v * INV_SQRT_TWO;
-    const T_partials_return inv_sigma = 1 / sigma_dbl;
     const T_partials_return scaled_diff
         = (y_dbl - mu_dbl) * INV_SQRT_TWO * inv_sigma;
     const T_partials_return scaled_diff_sq = scaled_diff * scaled_diff;
@@ -79,7 +79,7 @@ return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_lccdf(
         = SQRT_TWO_OVER_SQRT_PI * 0.5 * exp(-scaled_diff_sq) * inv_sigma;
 
     const T_partials_return ccdf_n
-        = 1.0 - 0.5 * (1 + erf(u / (v * SQRT_TWO))) + exp_term * erf_calc;
+        = 0.5 - 0.5 * erf(u / (v * SQRT_TWO)) + exp_term * erf_calc;
 
     ccdf_log += log(ccdf_n);
 

--- a/stan/math/prim/prob/exp_mod_normal_lccdf.hpp
+++ b/stan/math/prim/prob/exp_mod_normal_lccdf.hpp
@@ -48,69 +48,65 @@ return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_lccdf(
   scalar_seq_view<T_inv_scale> lambda_vec(lambda);
   size_t N = max_size(y, mu, sigma, lambda);
 
-  for (size_t n = 0; n < N; n++) {
+  for (size_t n = 0, size_y = size(y); n < size_y; n++) {
     if (is_inf(y_vec[n])) {
-      if (y_vec[n] > 0.0) {
-        return ops_partials.build(negative_infinity());
-      } else {
-        return ops_partials.build(0.0);
-      }
+      return y_vec[n] > 0.0 ? ops_partials.build(negative_infinity())
+                            : ops_partials.build(0.0);
     }
+  }
 
+  for (size_t n = 0; n < N; n++) {
     const T_partials_return y_dbl = value_of(y_vec[n]);
     const T_partials_return mu_dbl = value_of(mu_vec[n]);
     const T_partials_return sigma_dbl = value_of(sigma_vec[n]);
     const T_partials_return lambda_dbl = value_of(lambda_vec[n]);
     const T_partials_return u = lambda_dbl * (y_dbl - mu_dbl);
     const T_partials_return v = lambda_dbl * sigma_dbl;
-    const T_partials_return v_sq = v * v;
-    const T_partials_return v_over_sqrt_two = v / SQRT_TWO;
+    const T_partials_return v_over_sqrt_two = v * INV_SQRT_TWO;
+    const T_partials_return inv_sigma = 1 / sigma_dbl;
     const T_partials_return scaled_diff
-        = (y_dbl - mu_dbl) / (SQRT_TWO * sigma_dbl);
+        = (y_dbl - mu_dbl) * INV_SQRT_TWO * inv_sigma;
     const T_partials_return scaled_diff_sq = scaled_diff * scaled_diff;
-    const T_partials_return erf_calc1 = 0.5 * (1 + erf(u / (v * SQRT_TWO)));
-    const T_partials_return erf_calc2
+    const T_partials_return erf_calc
         = 0.5 * (1 + erf(u / (v * SQRT_TWO) - v_over_sqrt_two));
+    const T_partials_return exp_term = exp(0.5 * square(v) - u);
 
-    const T_partials_return deriv_1
-        = lambda_dbl * exp(0.5 * v_sq - u) * erf_calc2;
+    const T_partials_return deriv_1 = lambda_dbl * exp_term * erf_calc;
     const T_partials_return deriv_2
-        = SQRT_TWO_OVER_SQRT_PI * 0.5
-          * exp(0.5 * v_sq - square(-scaled_diff + v_over_sqrt_two) - u)
-          / sigma_dbl;
+        = SQRT_TWO_OVER_SQRT_PI * 0.5 * exp_term
+          * exp(-square(-scaled_diff + v_over_sqrt_two)) * inv_sigma;
     const T_partials_return deriv_3
-        = SQRT_TWO_OVER_SQRT_PI * 0.5 * exp(-scaled_diff_sq) / sigma_dbl;
+        = SQRT_TWO_OVER_SQRT_PI * 0.5 * exp(-scaled_diff_sq) * inv_sigma;
 
-    const T_partials_return ccdf_
-        = 1.0 - erf_calc1 + exp(-u + v_sq * 0.5) * (erf_calc2);
+    const T_partials_return ccdf_n
+        = 1.0 - 0.5 * (1 + erf(u / (v * SQRT_TWO))) + exp_term * erf_calc;
 
-    ccdf_log += log(ccdf_);
+    ccdf_log += log(ccdf_n);
 
     if (!is_constant_all<T_y>::value) {
-      ops_partials.edge1_.partials_[n] -= (deriv_1 - deriv_2 + deriv_3) / ccdf_;
+      ops_partials.edge1_.partials_[n]
+          -= (deriv_1 - deriv_2 + deriv_3) / ccdf_n;
     }
     if (!is_constant_all<T_loc>::value) {
       ops_partials.edge2_.partials_[n]
-          -= (-deriv_1 + deriv_2 - deriv_3) / ccdf_;
+          += (deriv_1 - deriv_2 + deriv_3) / ccdf_n;
     }
     if (!is_constant_all<T_scale>::value) {
       ops_partials.edge3_.partials_[n]
-          -= (-deriv_1 * v - deriv_3 * scaled_diff * SQRT_TWO
-              - deriv_2 * sigma_dbl * SQRT_TWO
-                    * (-SQRT_TWO * 0.5
-                           * (-lambda_dbl + scaled_diff * SQRT_TWO / sigma_dbl)
-                       - SQRT_TWO * lambda_dbl))
-             / ccdf_;
+          += (deriv_1 * v + deriv_3 * scaled_diff * SQRT_TWO
+              - deriv_2 * (v + SQRT_TWO * scaled_diff))
+             / ccdf_n;
     }
     if (!is_constant_all<T_inv_scale>::value) {
       ops_partials.edge4_.partials_[n]
-          -= exp(0.5 * v_sq - u)
+          -= exp_term
              * (SQRT_TWO_OVER_SQRT_PI * 0.5 * sigma_dbl
                     * exp(-square(v_over_sqrt_two - scaled_diff))
-                - (v * sigma_dbl + mu_dbl - y_dbl) * erf_calc2)
-             / ccdf_;
+                - (v * sigma_dbl + mu_dbl - y_dbl) * erf_calc)
+             / ccdf_n;
     }
   }
+
   return ops_partials.build(ccdf_log);
 }
 

--- a/stan/math/prim/prob/exp_mod_normal_lccdf.hpp
+++ b/stan/math/prim/prob/exp_mod_normal_lccdf.hpp
@@ -61,12 +61,11 @@ return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_lccdf(
     const T_partials_return sigma_dbl = value_of(sigma_vec[n]);
     const T_partials_return lambda_dbl = value_of(lambda_vec[n]);
     const T_partials_return inv_sigma = inv(sigma_dbl);
-    const T_partials_return u = lambda_dbl * (y_dbl - mu_dbl);
+    const T_partials_return diff = y_dbl - mu_dbl;
+    const T_partials_return u = lambda_dbl * diff;
     const T_partials_return v = lambda_dbl * sigma_dbl;
     const T_partials_return v_over_sqrt_two = v * INV_SQRT_TWO;
-    const T_partials_return scaled_diff
-        = (y_dbl - mu_dbl) * INV_SQRT_TWO * inv_sigma;
-    const T_partials_return scaled_diff_sq = scaled_diff * scaled_diff;
+    const T_partials_return scaled_diff = diff * INV_SQRT_TWO * inv_sigma;
     const T_partials_return erf_calc
         = 0.5 * (1 + erf(u / (v * SQRT_TWO) - v_over_sqrt_two));
     const T_partials_return exp_term = exp(0.5 * square(v) - u);
@@ -76,7 +75,7 @@ return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_lccdf(
         = SQRT_TWO_OVER_SQRT_PI * 0.5 * exp_term
           * exp(-square(-scaled_diff + v_over_sqrt_two)) * inv_sigma;
     const T_partials_return deriv_3
-        = SQRT_TWO_OVER_SQRT_PI * 0.5 * exp(-scaled_diff_sq) * inv_sigma;
+        = SQRT_TWO_OVER_SQRT_PI * 0.5 * exp(-square(scaled_diff)) * inv_sigma;
 
     const T_partials_return ccdf_n
         = 0.5 - 0.5 * erf(u / (v * SQRT_TWO)) + exp_term * erf_calc;
@@ -102,7 +101,7 @@ return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_lccdf(
           -= exp_term
              * (SQRT_TWO_OVER_SQRT_PI * 0.5 * sigma_dbl
                     * exp(-square(v_over_sqrt_two - scaled_diff))
-                - (v * sigma_dbl + mu_dbl - y_dbl) * erf_calc)
+                - (v * sigma_dbl - diff) * erf_calc)
              / ccdf_n;
     }
   }

--- a/stan/math/prim/prob/exp_mod_normal_lcdf.hpp
+++ b/stan/math/prim/prob/exp_mod_normal_lcdf.hpp
@@ -5,6 +5,7 @@
 #include <stan/math/prim/err.hpp>
 #include <stan/math/prim/scal/fun/constants.hpp>
 #include <stan/math/prim/scal/fun/erf.hpp>
+#include <stan/math/prim/scal/fun/inv.hpp>
 #include <stan/math/prim/scal/fun/is_inf.hpp>
 #include <stan/math/prim/scal/fun/size_zero.hpp>
 #include <stan/math/prim/scal/fun/square.hpp>
@@ -51,8 +52,7 @@ return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_lcdf(
 
   for (size_t n = 0, size_y = size(y); n < size_y; n++) {
     if (is_inf(y_vec[n])) {
-      return y_vec[n] < 0.0 ? ops_partials.build(negative_infinity())
-                            : ops_partials.build(0.0);
+      return ops_partials.build(y_vec[n] < 0 ? negative_infinity() : 0);
     }
   }
 
@@ -61,10 +61,10 @@ return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_lcdf(
     const T_partials_return mu_dbl = value_of(mu_vec[n]);
     const T_partials_return sigma_dbl = value_of(sigma_vec[n]);
     const T_partials_return lambda_dbl = value_of(lambda_vec[n]);
+    const T_partials_return inv_sigma = inv(sigma_dbl);
     const T_partials_return u = lambda_dbl * (y_dbl - mu_dbl);
     const T_partials_return v = lambda_dbl * sigma_dbl;
     const T_partials_return v_over_sqrt_two = v * INV_SQRT_TWO;
-    const T_partials_return inv_sigma = 1 / sigma_dbl;
     const T_partials_return scaled_diff
         = (y_dbl - mu_dbl) * INV_SQRT_TWO * inv_sigma;
     const T_partials_return scaled_diff_sq = scaled_diff * scaled_diff;
@@ -80,7 +80,7 @@ return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_lcdf(
         = SQRT_TWO_OVER_SQRT_PI * 0.5 * exp(-scaled_diff_sq) * inv_sigma;
 
     const T_partials_return cdf_n
-        = 0.5 * (1 + erf(u / (v * SQRT_TWO))) - exp_term * erf_calc;
+        = 0.5 + 0.5 * erf(u / (v * SQRT_TWO)) - exp_term * erf_calc;
 
     cdf_log += log(cdf_n);
 

--- a/stan/math/prim/prob/exp_mod_normal_lcdf.hpp
+++ b/stan/math/prim/prob/exp_mod_normal_lcdf.hpp
@@ -88,8 +88,7 @@ return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_lcdf(
       ops_partials.edge1_.partials_[n] += (deriv_1 - deriv_2 + deriv_3) / cdf_n;
     }
     if (!is_constant_all<T_loc>::value) {
-      ops_partials.edge2_.partials_[n]
-          -= (deriv_1 - deriv_2 + deriv_3) / cdf_n;
+      ops_partials.edge2_.partials_[n] -= (deriv_1 - deriv_2 + deriv_3) / cdf_n;
     }
     if (!is_constant_all<T_scale>::value) {
       ops_partials.edge3_.partials_[n]

--- a/stan/math/prim/prob/exp_mod_normal_lcdf.hpp
+++ b/stan/math/prim/prob/exp_mod_normal_lcdf.hpp
@@ -62,12 +62,11 @@ return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_lcdf(
     const T_partials_return sigma_dbl = value_of(sigma_vec[n]);
     const T_partials_return lambda_dbl = value_of(lambda_vec[n]);
     const T_partials_return inv_sigma = inv(sigma_dbl);
-    const T_partials_return u = lambda_dbl * (y_dbl - mu_dbl);
+    const T_partials_return diff = y_dbl - mu_dbl;
+    const T_partials_return u = lambda_dbl * diff;
     const T_partials_return v = lambda_dbl * sigma_dbl;
     const T_partials_return v_over_sqrt_two = v * INV_SQRT_TWO;
-    const T_partials_return scaled_diff
-        = (y_dbl - mu_dbl) * INV_SQRT_TWO * inv_sigma;
-    const T_partials_return scaled_diff_sq = scaled_diff * scaled_diff;
+    const T_partials_return scaled_diff = diff * INV_SQRT_TWO * inv_sigma;
     const T_partials_return erf_calc
         = 0.5 * (1 + erf(u / (v * SQRT_TWO) - v_over_sqrt_two));
     const T_partials_return exp_term = exp(0.5 * square(v) - u);
@@ -77,7 +76,7 @@ return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_lcdf(
         = SQRT_TWO_OVER_SQRT_PI * 0.5 * exp_term
           * exp(-square(scaled_diff - v_over_sqrt_two)) * inv_sigma;
     const T_partials_return deriv_3
-        = SQRT_TWO_OVER_SQRT_PI * 0.5 * exp(-scaled_diff_sq) * inv_sigma;
+        = SQRT_TWO_OVER_SQRT_PI * 0.5 * exp(-square(scaled_diff)) * inv_sigma;
 
     const T_partials_return cdf_n
         = 0.5 + 0.5 * erf(u / (v * SQRT_TWO)) - exp_term * erf_calc;
@@ -101,7 +100,7 @@ return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_lcdf(
           += exp_term
              * (SQRT_TWO_OVER_SQRT_PI * 0.5 * sigma_dbl
                     * exp(-square(v_over_sqrt_two - scaled_diff))
-                - (v * sigma_dbl + mu_dbl - y_dbl) * erf_calc)
+                - (v * sigma_dbl - diff) * erf_calc)
              / cdf_n;
     }
   }

--- a/stan/math/prim/prob/exp_mod_normal_lcdf.hpp
+++ b/stan/math/prim/prob/exp_mod_normal_lcdf.hpp
@@ -49,40 +49,38 @@ return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_lcdf(
   scalar_seq_view<T_inv_scale> lambda_vec(lambda);
   size_t N = max_size(y, mu, sigma, lambda);
 
-  for (size_t n = 0; n < N; n++) {
+  for (size_t n = 0, size_y = size(y); n < size_y; n++) {
     if (is_inf(y_vec[n])) {
-      if (y_vec[n] < 0.0) {
-        return ops_partials.build(negative_infinity());
-      } else {
-        return ops_partials.build(0.0);
-      }
+      return y_vec[n] < 0.0 ? ops_partials.build(negative_infinity())
+                            : ops_partials.build(0.0);
     }
+  }
 
+  for (size_t n = 0; n < N; n++) {
     const T_partials_return y_dbl = value_of(y_vec[n]);
     const T_partials_return mu_dbl = value_of(mu_vec[n]);
     const T_partials_return sigma_dbl = value_of(sigma_vec[n]);
     const T_partials_return lambda_dbl = value_of(lambda_vec[n]);
     const T_partials_return u = lambda_dbl * (y_dbl - mu_dbl);
     const T_partials_return v = lambda_dbl * sigma_dbl;
-    const T_partials_return v_sq = v * v;
-    const T_partials_return v_over_sqrt_two = v / SQRT_TWO;
+    const T_partials_return v_over_sqrt_two = v * INV_SQRT_TWO;
+    const T_partials_return inv_sigma = 1 / sigma_dbl;
     const T_partials_return scaled_diff
-        = (y_dbl - mu_dbl) / (SQRT_TWO * sigma_dbl);
+        = (y_dbl - mu_dbl) * INV_SQRT_TWO * inv_sigma;
     const T_partials_return scaled_diff_sq = scaled_diff * scaled_diff;
-    const T_partials_return erf_calc1 = 0.5 * (1 + erf(u / (v * SQRT_TWO)));
-    const T_partials_return erf_calc2
+    const T_partials_return erf_calc
         = 0.5 * (1 + erf(u / (v * SQRT_TWO) - v_over_sqrt_two));
-    const T_partials_return deriv_1
-        = lambda_dbl * exp(0.5 * v_sq - u) * erf_calc2;
+    const T_partials_return exp_term = exp(0.5 * square(v) - u);
+
+    const T_partials_return deriv_1 = lambda_dbl * exp_term * erf_calc;
     const T_partials_return deriv_2
-        = SQRT_TWO_OVER_SQRT_PI * 0.5
-          * exp(0.5 * v_sq - square(-scaled_diff + v_over_sqrt_two) - u)
-          / sigma_dbl;
+        = SQRT_TWO_OVER_SQRT_PI * 0.5 * exp_term
+          * exp(-square(scaled_diff - v_over_sqrt_two)) * inv_sigma;
     const T_partials_return deriv_3
-        = SQRT_TWO_OVER_SQRT_PI * 0.5 * exp(-scaled_diff_sq) / sigma_dbl;
+        = SQRT_TWO_OVER_SQRT_PI * 0.5 * exp(-scaled_diff_sq) * inv_sigma;
 
     const T_partials_return cdf_n
-        = erf_calc1 - exp(-u + v_sq * 0.5) * (erf_calc2);
+        = 0.5 * (1 + erf(u / (v * SQRT_TWO))) - exp_term * erf_calc;
 
     cdf_log += log(cdf_n);
 
@@ -91,23 +89,20 @@ return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_lcdf(
     }
     if (!is_constant_all<T_loc>::value) {
       ops_partials.edge2_.partials_[n]
-          += (-deriv_1 + deriv_2 - deriv_3) / cdf_n;
+          -= (deriv_1 - deriv_2 + deriv_3) / cdf_n;
     }
     if (!is_constant_all<T_scale>::value) {
       ops_partials.edge3_.partials_[n]
-          += (-deriv_1 * v - deriv_3 * scaled_diff * SQRT_TWO
-              - deriv_2 * sigma_dbl * SQRT_TWO
-                    * (-SQRT_TWO * 0.5
-                           * (-lambda_dbl + scaled_diff * SQRT_TWO / sigma_dbl)
-                       - SQRT_TWO * lambda_dbl))
+          -= (deriv_1 * v + deriv_3 * scaled_diff * SQRT_TWO
+              - deriv_2 * (v + SQRT_TWO * scaled_diff))
              / cdf_n;
     }
     if (!is_constant_all<T_inv_scale>::value) {
       ops_partials.edge4_.partials_[n]
-          += exp(0.5 * v_sq - u)
+          += exp_term
              * (SQRT_TWO_OVER_SQRT_PI * 0.5 * sigma_dbl
                     * exp(-square(v_over_sqrt_two - scaled_diff))
-                - (v * sigma_dbl + mu_dbl - y_dbl) * erf_calc2)
+                - (v * sigma_dbl + mu_dbl - y_dbl) * erf_calc)
              / cdf_n;
     }
   }

--- a/stan/math/prim/prob/exp_mod_normal_lpdf.hpp
+++ b/stan/math/prim/prob/exp_mod_normal_lpdf.hpp
@@ -5,6 +5,7 @@
 #include <stan/math/prim/err.hpp>
 #include <stan/math/prim/scal/fun/constants.hpp>
 #include <stan/math/prim/scal/fun/erfc.hpp>
+#include <stan/math/prim/scal/fun/inv.hpp>
 #include <stan/math/prim/scal/fun/size_zero.hpp>
 #include <stan/math/prim/scal/fun/square.hpp>
 #include <stan/math/prim/scal/fun/value_of.hpp>
@@ -57,8 +58,7 @@ return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_lpdf(
     const T_partials_return mu_dbl = value_of(mu_vec[n]);
     const T_partials_return sigma_dbl = value_of(sigma_vec[n]);
     const T_partials_return lambda_dbl = value_of(lambda_vec[n]);
-
-    const T_partials_return inv_sigma = 1 / sigma_dbl;
+    const T_partials_return inv_sigma = inv(sigma_dbl);
     const T_partials_return sigma_sq = square(sigma_dbl);
     const T_partials_return lambda_sigma_sq = lambda_dbl * sigma_sq;
     const T_partials_return mu_minus_y = mu_dbl - y_dbl;
@@ -90,7 +90,7 @@ return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_lpdf(
              + deriv_logerfc * (-mu_minus_y / sigma_sq + lambda_dbl);
     }
     if (!is_constant_all<T_inv_scale>::value) {
-      ops_partials.edge4_.partials_[n] += 1 / lambda_dbl + lambda_sigma_sq
+      ops_partials.edge4_.partials_[n] += inv(lambda_dbl) + lambda_sigma_sq
                                           + mu_minus_y
                                           + deriv_logerfc * sigma_dbl;
     }

--- a/stan/math/prim/prob/exp_mod_normal_lpdf.hpp
+++ b/stan/math/prim/prob/exp_mod_normal_lpdf.hpp
@@ -6,6 +6,7 @@
 #include <stan/math/prim/scal/fun/constants.hpp>
 #include <stan/math/prim/scal/fun/erfc.hpp>
 #include <stan/math/prim/scal/fun/size_zero.hpp>
+#include <stan/math/prim/scal/fun/square.hpp>
 #include <stan/math/prim/scal/fun/value_of.hpp>
 #include <cmath>
 
@@ -57,46 +58,42 @@ return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_lpdf(
     const T_partials_return sigma_dbl = value_of(sigma_vec[n]);
     const T_partials_return lambda_dbl = value_of(lambda_vec[n]);
 
+    const T_partials_return inv_sqrt2_inv_sigma = INV_SQRT_TWO / sigma_dbl;
+    const T_partials_return sigma_sq = square(sigma_dbl);
+    const T_partials_return lambda_sigma_sq = lambda_dbl * sigma_sq;
+    const T_partials_return term1 = lambda_sigma_sq - y_dbl;
+    const T_partials_return term2 = (mu_dbl + term1) * inv_sqrt2_inv_sigma;
+    const T_partials_return erfc_term2 = erfc(term2);
+    const T_partials_return deriv_logerfc
+        = NEG_TWO_OVER_SQRT_PI * exp(-square(term2)) / erfc_term2;
+
     if (include_summand<propto>::value) {
       logp -= LOG_TWO;
     }
     if (include_summand<propto, T_inv_scale>::value) {
       logp += log(lambda_dbl);
     }
-    logp += lambda_dbl
-                * (mu_dbl + 0.5 * lambda_dbl * sigma_dbl * sigma_dbl - y_dbl)
-            + log(erfc((mu_dbl + lambda_dbl * sigma_dbl * sigma_dbl - y_dbl)
-                       / (SQRT_TWO * sigma_dbl)));
-
-    const T_partials_return deriv_logerfc
-        = NEG_TWO_OVER_SQRT_PI
-          * exp(-(mu_dbl + lambda_dbl * sigma_dbl * sigma_dbl - y_dbl)
-                / (SQRT_TWO * sigma_dbl)
-                * (mu_dbl + lambda_dbl * sigma_dbl * sigma_dbl - y_dbl)
-                / (sigma_dbl * SQRT_TWO))
-          / erfc((mu_dbl + lambda_dbl * sigma_dbl * sigma_dbl - y_dbl)
-                 / (sigma_dbl * SQRT_TWO));
+    logp += lambda_dbl * (mu_dbl + 0.5 * (term1 - y_dbl)) + log(erfc_term2);
 
     if (!is_constant_all<T_y>::value) {
       ops_partials.edge1_.partials_[n]
-          += -lambda_dbl + deriv_logerfc * -1.0 / (sigma_dbl * SQRT_TWO);
+          -= lambda_dbl + deriv_logerfc * inv_sqrt2_inv_sigma;
     }
     if (!is_constant_all<T_loc>::value) {
       ops_partials.edge2_.partials_[n]
-          += lambda_dbl + deriv_logerfc / (sigma_dbl * SQRT_TWO);
+          += lambda_dbl + deriv_logerfc * inv_sqrt2_inv_sigma;
     }
     if (!is_constant_all<T_scale>::value) {
       ops_partials.edge3_.partials_[n]
           += sigma_dbl * lambda_dbl * lambda_dbl
              + deriv_logerfc
-                   * (-mu_dbl / (sigma_dbl * sigma_dbl * SQRT_TWO)
-                      + lambda_dbl / SQRT_TWO
-                      + y_dbl / (sigma_dbl * sigma_dbl * SQRT_TWO));
+                   * ((y_dbl - mu_dbl) / sigma_sq
+                      + lambda_dbl) * INV_SQRT_TWO;
     }
     if (!is_constant_all<T_inv_scale>::value) {
       ops_partials.edge4_.partials_[n]
-          += 1 / lambda_dbl + lambda_dbl * sigma_dbl * sigma_dbl + mu_dbl
-             - y_dbl + deriv_logerfc * sigma_dbl / SQRT_TWO;
+          += 1 / lambda_dbl + lambda_sigma_sq + mu_dbl - y_dbl
+             + deriv_logerfc * sigma_dbl * INV_SQRT_TWO;
     }
   }
   return ops_partials.build(logp);

--- a/test/unit/math/prim/prob/exp_mod_normal_cdf_log_test.cpp
+++ b/test/unit/math/prim/prob/exp_mod_normal_cdf_log_test.cpp
@@ -1,7 +1,7 @@
 #include <stan/math/prim/scal.hpp>
 #include <gtest/gtest.h>
 
-TEST(ProbFoo, cdf_log_matches_lcdf) {
+TEST(ProbExpModNormal, cdf_log_matches_lcdf) {
   double y = 0.8;
   double mu = 1.1;
   double sigma = 2.3;


### PR DESCRIPTION
## Summary

This is a cleanup of the `exp_mod_normal_{cdf,lcdf,lccdf,lpdf}` functions. The main changes concern the use of local variables for intermediate calculations that can be reused throughout the functions. In doing that, it became clear that some expressions could be further simplified.

For the `*cdf` functions this also moves the check for early return outside of the main loop, so that it loops the correct number of times and if the condition is triggered, no computations will be wasted.

Fixes #1599.

## Tests

Existing tests should be enough, as this is only cleanup.

## Side Effects

None.

## Checklist

- [X] Math issue #1599

- [X] Copyright holder: Marco Colombo

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [X] the new changes are tested