### PR TITLE
Reorder constants.hpp and cleanup

### DIFF
--- a/stan/math/prim/prob/cauchy_lpdf.hpp
+++ b/stan/math/prim/prob/cauchy_lpdf.hpp
@@ -85,7 +85,7 @@ return_type_t<T_y, T_loc, T_scale> cauchy_lpdf(const T_y& y, const T_loc& mu,
         = y_minus_mu_over_sigma * y_minus_mu_over_sigma;
 
     if (include_summand<propto>::value) {
-      logp += NEG_LOG_PI;
+      logp -= LOG_PI;
     }
     if (include_summand<propto, T_scale>::value) {
       logp -= log_sigma[n];

--- a/stan/math/prim/prob/chi_square_lpdf.hpp
+++ b/stan/math/prim/prob/chi_square_lpdf.hpp
@@ -102,7 +102,7 @@ return_type_t<T_y, T_dof> chi_square_lpdf(const T_y& y, const T_dof& nu) {
     const T_partials_return nu_dbl = value_of(nu_vec[n]);
     const T_partials_return half_nu = 0.5 * nu_dbl;
     if (include_summand<propto, T_dof>::value) {
-      logp += nu_dbl * NEG_LOG_TWO_OVER_TWO - lgamma_half_nu[n];
+      logp -= nu_dbl * HALF_LOG_TWO + lgamma_half_nu[n];
     }
     logp += (half_nu - 1.0) * log_y[n];
 
@@ -114,9 +114,8 @@ return_type_t<T_y, T_dof> chi_square_lpdf(const T_y& y, const T_dof& nu) {
       ops_partials.edge1_.partials_[n] += (half_nu - 1.0) * inv_y[n] - 0.5;
     }
     if (!is_constant_all<T_dof>::value) {
-      ops_partials.edge2_.partials_[n] += NEG_LOG_TWO_OVER_TWO
-                                          - digamma_half_nu_over_two[n]
-                                          + log_y[n] * 0.5;
+      ops_partials.edge2_.partials_[n]
+          -= HALF_LOG_TWO + digamma_half_nu_over_two[n] - log_y[n] * 0.5;
     }
   }
   return ops_partials.build(logp);

--- a/stan/math/prim/prob/double_exponential_lccdf.hpp
+++ b/stan/math/prim/prob/double_exponential_lccdf.hpp
@@ -3,9 +3,10 @@
 
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/err.hpp>
+#include <stan/math/prim/scal/fun/constants.hpp>
+#include <stan/math/prim/scal/fun/log1m.hpp>
 #include <stan/math/prim/scal/fun/size_zero.hpp>
 #include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/fun/log1m.hpp>
 #include <cmath>
 
 namespace stan {
@@ -52,7 +53,6 @@ return_type_t<T_y, T_loc, T_scale> double_exponential_lccdf(
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_loc> mu_vec(mu);
   scalar_seq_view<T_scale> sigma_vec(sigma);
-  const double log_half = std::log(0.5);
   size_t N = max_size(y, mu, sigma);
 
   for (size_t n = 0; n < N; n++) {
@@ -75,7 +75,7 @@ return_type_t<T_y, T_loc, T_scale> double_exponential_lccdf(
         ops_partials.edge3_.partials_[n] += rep_deriv * scaled_diff * inv_sigma;
       }
     } else {
-      ccdf_log += log_half - scaled_diff;
+      ccdf_log += LOG_HALF - scaled_diff;
 
       if (!is_constant_all<T_y>::value) {
         ops_partials.edge1_.partials_[n] -= inv_sigma;

--- a/stan/math/prim/prob/double_exponential_lcdf.hpp
+++ b/stan/math/prim/prob/double_exponential_lcdf.hpp
@@ -3,9 +3,10 @@
 
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/err.hpp>
+#include <stan/math/prim/scal/fun/constants.hpp>
+#include <stan/math/prim/scal/fun/log1m.hpp>
 #include <stan/math/prim/scal/fun/size_zero.hpp>
 #include <stan/math/prim/scal/fun/value_of.hpp>
-#include <stan/math/prim/scal/fun/log1m.hpp>
 #include <cmath>
 
 namespace stan {
@@ -51,7 +52,6 @@ return_type_t<T_y, T_loc, T_scale> double_exponential_lcdf(
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_loc> mu_vec(mu);
   scalar_seq_view<T_scale> sigma_vec(sigma);
-  const double log_half = std::log(0.5);
   size_t N = max_size(y, mu, sigma);
 
   for (size_t n = 0; n < N; n++) {
@@ -61,7 +61,7 @@ return_type_t<T_y, T_loc, T_scale> double_exponential_lcdf(
     const T_partials_return scaled_diff = (y_dbl - mu_dbl) / sigma_dbl;
     const T_partials_return inv_sigma = 1.0 / sigma_dbl;
     if (y_dbl < mu_dbl) {
-      cdf_log += log_half + scaled_diff;
+      cdf_log += LOG_HALF + scaled_diff;
 
       if (!is_constant_all<T_y>::value) {
         ops_partials.edge1_.partials_[n] += inv_sigma;

--- a/stan/math/prim/prob/double_exponential_lpdf.hpp
+++ b/stan/math/prim/prob/double_exponential_lpdf.hpp
@@ -3,10 +3,10 @@
 
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/err.hpp>
-#include <stan/math/prim/scal/fun/size_zero.hpp>
-#include <stan/math/prim/scal/fun/value_of.hpp>
 #include <stan/math/prim/scal/fun/constants.hpp>
 #include <stan/math/prim/scal/fun/sign.hpp>
+#include <stan/math/prim/scal/fun/size_zero.hpp>
+#include <stan/math/prim/scal/fun/value_of.hpp>
 #include <cmath>
 
 namespace stan {
@@ -83,7 +83,7 @@ return_type_t<T_y, T_loc, T_scale> double_exponential_lpdf(
     const T_partials_return fabs_y_m_mu = fabs(y_m_mu);
 
     if (include_summand<propto>::value) {
-      logp += NEG_LOG_TWO;
+      logp -= LOG_TWO;
     }
     if (include_summand<propto, T_scale>::value) {
       logp -= log_sigma[n];

--- a/stan/math/prim/prob/exp_mod_normal_cdf.hpp
+++ b/stan/math/prim/prob/exp_mod_normal_cdf.hpp
@@ -72,10 +72,10 @@ return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_cdf(
 
     const T_partials_return deriv_1 = lambda_dbl * exp_term * erf_calc;
     const T_partials_return deriv_2
-        = SQRT_TWO_OVER_SQRT_PI * 0.5 * exp_term
+        = INV_SQRT_TWO_PI * exp_term
           * exp(-square(scaled_diff - v_over_sqrt_two)) * inv_sigma;
     const T_partials_return deriv_3
-        = SQRT_TWO_OVER_SQRT_PI * 0.5 * exp(-square(scaled_diff)) * inv_sigma;
+        = INV_SQRT_TWO_PI * exp(-square(scaled_diff)) * inv_sigma;
 
     const T_partials_return cdf_n
         = 0.5 + 0.5 * erf(u / (v * SQRT_TWO)) - exp_term * erf_calc;
@@ -97,7 +97,7 @@ return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_cdf(
     if (!is_constant_all<T_inv_scale>::value) {
       ops_partials.edge4_.partials_[n]
           += exp_term
-             * (SQRT_TWO_OVER_SQRT_PI * 0.5 * sigma_dbl
+             * (INV_SQRT_TWO_PI * sigma_dbl
                     * exp(-square(v_over_sqrt_two - scaled_diff))
                 - (v * sigma_dbl - diff) * erf_calc)
              / cdf_n;

--- a/stan/math/prim/prob/exp_mod_normal_lccdf.hpp
+++ b/stan/math/prim/prob/exp_mod_normal_lccdf.hpp
@@ -72,10 +72,10 @@ return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_lccdf(
 
     const T_partials_return deriv_1 = lambda_dbl * exp_term * erf_calc;
     const T_partials_return deriv_2
-        = SQRT_TWO_OVER_SQRT_PI * 0.5 * exp_term
+        = INV_SQRT_TWO_PI * exp_term
           * exp(-square(-scaled_diff + v_over_sqrt_two)) * inv_sigma;
     const T_partials_return deriv_3
-        = SQRT_TWO_OVER_SQRT_PI * 0.5 * exp(-square(scaled_diff)) * inv_sigma;
+        = INV_SQRT_TWO_PI * exp(-square(scaled_diff)) * inv_sigma;
 
     const T_partials_return ccdf_n
         = 0.5 - 0.5 * erf(u / (v * SQRT_TWO)) + exp_term * erf_calc;
@@ -99,7 +99,7 @@ return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_lccdf(
     if (!is_constant_all<T_inv_scale>::value) {
       ops_partials.edge4_.partials_[n]
           -= exp_term
-             * (SQRT_TWO_OVER_SQRT_PI * 0.5 * sigma_dbl
+             * (INV_SQRT_TWO_PI * sigma_dbl
                     * exp(-square(v_over_sqrt_two - scaled_diff))
                 - (v * sigma_dbl - diff) * erf_calc)
              / ccdf_n;

--- a/stan/math/prim/prob/exp_mod_normal_lcdf.hpp
+++ b/stan/math/prim/prob/exp_mod_normal_lcdf.hpp
@@ -73,10 +73,10 @@ return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_lcdf(
 
     const T_partials_return deriv_1 = lambda_dbl * exp_term * erf_calc;
     const T_partials_return deriv_2
-        = SQRT_TWO_OVER_SQRT_PI * 0.5 * exp_term
+        = INV_SQRT_TWO_PI * exp_term
           * exp(-square(scaled_diff - v_over_sqrt_two)) * inv_sigma;
     const T_partials_return deriv_3
-        = SQRT_TWO_OVER_SQRT_PI * 0.5 * exp(-square(scaled_diff)) * inv_sigma;
+        = INV_SQRT_TWO_PI * exp(-square(scaled_diff)) * inv_sigma;
 
     const T_partials_return cdf_n
         = 0.5 + 0.5 * erf(u / (v * SQRT_TWO)) - exp_term * erf_calc;
@@ -98,7 +98,7 @@ return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_lcdf(
     if (!is_constant_all<T_inv_scale>::value) {
       ops_partials.edge4_.partials_[n]
           += exp_term
-             * (SQRT_TWO_OVER_SQRT_PI * 0.5 * sigma_dbl
+             * (INV_SQRT_TWO_PI * sigma_dbl
                     * exp(-square(v_over_sqrt_two - scaled_diff))
                 - (v * sigma_dbl - diff) * erf_calc)
              / cdf_n;

--- a/stan/math/prim/prob/gaussian_dlm_obs_lpdf.hpp
+++ b/stan/math/prim/prob/gaussian_dlm_obs_lpdf.hpp
@@ -105,7 +105,7 @@ gaussian_dlm_obs_lpdf(
 
   T_lp lp(0);
   if (include_summand<propto>::value) {
-    lp -= 0.5 * LOG_TWO_PI * r * T;
+    lp -= HALF_LOG_TWO_PI * r * T;
   }
 
   if (include_summand<propto, T_y, T_F, T_G, T_V, T_W, T_m0, T_C0>::value) {
@@ -259,7 +259,7 @@ gaussian_dlm_obs_lpdf(
 
   T_lp lp(0);
   if (include_summand<propto>::value) {
-    lp -= 0.5 * LOG_TWO_PI * r * T;
+    lp -= HALF_LOG_TWO_PI * r * T;
   }
 
   if (include_summand<propto, T_y, T_F, T_G, T_V, T_W, T_m0, T_C0>::value) {

--- a/stan/math/prim/prob/gaussian_dlm_obs_lpdf.hpp
+++ b/stan/math/prim/prob/gaussian_dlm_obs_lpdf.hpp
@@ -259,7 +259,7 @@ gaussian_dlm_obs_lpdf(
 
   T_lp lp(0);
   if (include_summand<propto>::value) {
-    lp += 0.5 * NEG_LOG_TWO_PI * r * T;
+    lp -= 0.5 * LOG_TWO_PI * r * T;
   }
 
   if (include_summand<propto, T_y, T_F, T_G, T_V, T_W, T_m0, T_C0>::value) {

--- a/stan/math/prim/prob/inv_chi_square_lpdf.hpp
+++ b/stan/math/prim/prob/inv_chi_square_lpdf.hpp
@@ -97,7 +97,7 @@ return_type_t<T_y, T_dof> inv_chi_square_lpdf(const T_y& y, const T_dof& nu) {
     const T_partials_return half_nu = 0.5 * nu_dbl;
 
     if (include_summand<propto, T_dof>::value) {
-      logp += nu_dbl * NEG_LOG_TWO_OVER_TWO - lgamma_half_nu[n];
+      logp -= nu_dbl * HALF_LOG_TWO + lgamma_half_nu[n];
     }
     if (include_summand<propto, T_y, T_dof>::value) {
       logp -= (half_nu + 1.0) * log_y[n];
@@ -111,9 +111,8 @@ return_type_t<T_y, T_dof> inv_chi_square_lpdf(const T_y& y, const T_dof& nu) {
           += -(half_nu + 1.0) * inv_y[n] + 0.5 * inv_y[n] * inv_y[n];
     }
     if (!is_constant_all<T_dof>::value) {
-      ops_partials.edge2_.partials_[n] += NEG_LOG_TWO_OVER_TWO
-                                          - digamma_half_nu_over_two[n]
-                                          - 0.5 * log_y[n];
+      ops_partials.edge2_.partials_[n]
+          -= HALF_LOG_TWO + digamma_half_nu_over_two[n] + 0.5 * log_y[n];
     }
   }
   return ops_partials.build(logp);

--- a/stan/math/prim/prob/inv_wishart_lpdf.hpp
+++ b/stan/math/prim/prob/inv_wishart_lpdf.hpp
@@ -91,7 +91,7 @@ return_type_t<T_y, T_dof, T_scale> inv_wishart_lpdf(
     lp -= 0.5 * trace(Winv_S);
   }
   if (include_summand<propto, T_dof, T_scale>::value) {
-    lp += nu * k * NEG_LOG_TWO_OVER_TWO;
+    lp -= nu * k * HALF_LOG_TWO;
   }
   return lp;
 }

--- a/stan/math/prim/prob/lognormal_cdf.hpp
+++ b/stan/math/prim/prob/lognormal_cdf.hpp
@@ -52,9 +52,8 @@ return_type_t<T_y, T_loc, T_scale> lognormal_cdf(const T_y& y, const T_loc& mu,
     const T_partials_return sigma_dbl = value_of(sigma_vec[n]);
     const T_partials_return scaled_diff
         = (log(y_dbl) - mu_dbl) / (sigma_dbl * SQRT_TWO);
-    const T_partials_return rep_deriv = SQRT_TWO_OVER_SQRT_PI * 0.5
-                                        * exp(-scaled_diff * scaled_diff)
-                                        / sigma_dbl;
+    const T_partials_return rep_deriv
+        = INV_SQRT_TWO_PI * exp(-scaled_diff * scaled_diff) / sigma_dbl;
 
     const T_partials_return cdf_n = 0.5 * erfc(-scaled_diff);
     cdf *= cdf_n;

--- a/stan/math/prim/prob/lognormal_lcdf.hpp
+++ b/stan/math/prim/prob/lognormal_lcdf.hpp
@@ -45,8 +45,6 @@ return_type_t<T_y, T_loc, T_scale> lognormal_lcdf(const T_y& y, const T_loc& mu,
     }
   }
 
-  const double log_half = std::log(0.5);
-
   for (size_t n = 0; n < N; n++) {
     const T_partials_return y_dbl = value_of(y_vec[n]);
     const T_partials_return mu_dbl = value_of(mu_vec[n]);
@@ -57,7 +55,7 @@ return_type_t<T_y, T_loc, T_scale> lognormal_lcdf(const T_y& y, const T_loc& mu,
         = SQRT_TWO_OVER_SQRT_PI * exp(-scaled_diff * scaled_diff) / sigma_dbl;
 
     const T_partials_return erfc_calc = erfc(-scaled_diff);
-    cdf_log += log_half + log(erfc_calc);
+    cdf_log += LOG_HALF + log(erfc_calc);
 
     if (!is_constant_all<T_y>::value) {
       ops_partials.edge1_.partials_[n] += rep_deriv / erfc_calc / y_dbl;

--- a/stan/math/prim/prob/normal_cdf.hpp
+++ b/stan/math/prim/prob/normal_cdf.hpp
@@ -79,7 +79,7 @@ inline return_type_t<T_y, T_loc, T_scale> normal_cdf(const T_y& y,
       const T_partials_return rep_deriv
           = (scaled_diff < -37.5 * INV_SQRT_TWO)
                 ? 0.0
-                : SQRT_TWO_OVER_SQRT_PI * 0.5 * exp(-scaled_diff * scaled_diff)
+                : INV_SQRT_TWO_PI * exp(-scaled_diff * scaled_diff)
                       / (cdf_n * sigma_dbl);
       if (!is_constant_all<T_y>::value) {
         ops_partials.edge1_.partials_[n] += rep_deriv;

--- a/stan/math/prim/prob/normal_lcdf.hpp
+++ b/stan/math/prim/prob/normal_lcdf.hpp
@@ -92,7 +92,7 @@ inline return_type_t<T_y, T_loc, T_scale> normal_lcdf(const T_y& y,
           = -0.00233520497626869185443 - 0.0605183413124413191178 / x2
             - 0.527905102951428412248 / x4 - 1.87295284992346047209 / x6
             - 2.56852019228982242072 / x8 - 1.0 / x10;
-      cdf_log += LOG_HALF + log(1.0 / SQRT_PI + (temp_p / temp_q) / x2)
+      cdf_log += LOG_HALF + log(INV_SQRT_PI + (temp_p / temp_q) / x2)
                  - log(-scaled_diff) - x2;
     } else {
       // scaled_diff^10 term will overflow

--- a/stan/math/prim/prob/skew_normal_cdf.hpp
+++ b/stan/math/prim/prob/skew_normal_cdf.hpp
@@ -62,7 +62,7 @@ return_type_t<T_y, T_loc, T_scale, T_shape> skew_normal_cdf(
     cdf *= cdf_;
 
     const T_partials_return deriv_erfc
-        = SQRT_TWO_OVER_SQRT_PI * 0.5 * exp(-scaled_diff_sq) / sigma_dbl;
+        = INV_SQRT_TWO_PI * exp(-scaled_diff_sq) / sigma_dbl;
     const T_partials_return deriv_owens
         = erf(alpha_dbl * scaled_diff) * exp(-scaled_diff_sq)
           / SQRT_TWO_OVER_SQRT_PI / (-TWO_PI) / sigma_dbl;

--- a/stan/math/prim/prob/skew_normal_lccdf.hpp
+++ b/stan/math/prim/prob/skew_normal_lccdf.hpp
@@ -63,7 +63,7 @@ return_type_t<T_y, T_loc, T_scale, T_shape> skew_normal_lccdf(
     ccdf_log += log(ccdf_log_);
 
     const T_partials_return deriv_erfc
-        = SQRT_TWO_OVER_SQRT_PI * 0.5 * exp(-scaled_diff_sq) / sigma_dbl;
+        = INV_SQRT_TWO_PI * exp(-scaled_diff_sq) / sigma_dbl;
     const T_partials_return deriv_owens
         = erf(alpha_dbl * scaled_diff) * exp(-scaled_diff_sq)
           / SQRT_TWO_OVER_SQRT_PI / (-TWO_PI) / sigma_dbl;

--- a/stan/math/prim/prob/skew_normal_lcdf.hpp
+++ b/stan/math/prim/prob/skew_normal_lcdf.hpp
@@ -63,7 +63,7 @@ return_type_t<T_y, T_loc, T_scale, T_shape> skew_normal_lcdf(
     cdf_log += log(cdf_log_);
 
     const T_partials_return deriv_erfc
-        = SQRT_TWO_OVER_SQRT_PI * 0.5 * exp(-scaled_diff_sq) / sigma_dbl;
+        = INV_SQRT_TWO_PI * exp(-scaled_diff_sq) / sigma_dbl;
     const T_partials_return deriv_owens
         = erf(alpha_dbl * scaled_diff) * exp(-scaled_diff_sq)
           / SQRT_TWO_OVER_SQRT_PI / (-TWO_PI) / sigma_dbl;

--- a/stan/math/prim/prob/skew_normal_lpdf.hpp
+++ b/stan/math/prim/prob/skew_normal_lpdf.hpp
@@ -70,7 +70,7 @@ return_type_t<T_y, T_loc, T_scale, T_shape> skew_normal_lpdf(
         = (y_dbl - mu_dbl) * inv_sigma[n];
 
     if (include_summand<propto>::value) {
-      logp -= 0.5 * LOG_TWO_PI;
+      logp -= HALF_LOG_TWO_PI;
     }
     if (include_summand<propto, T_scale>::value) {
       logp -= log(sigma_dbl);

--- a/stan/math/prim/prob/std_normal_cdf.hpp
+++ b/stan/math/prim/prob/std_normal_cdf.hpp
@@ -59,9 +59,9 @@ inline return_type_t<T_y> std_normal_cdf(const T_y& y) {
 
     if (!is_constant_all<T_y>::value) {
       const T_partials_return rep_deriv
-          = (y_dbl < -37.5) ? 0.0
-                            : SQRT_TWO_OVER_SQRT_PI * 0.5
-                                  * exp(-scaled_y * scaled_y) / cdf_n;
+          = (y_dbl < -37.5)
+                ? 0.0
+                : INV_SQRT_TWO_PI * exp(-scaled_y * scaled_y) / cdf_n;
       if (!is_constant_all<T_y>::value) {
         ops_partials.edge1_.partials_[n] += rep_deriv;
       }

--- a/stan/math/prim/prob/student_t_lpdf.hpp
+++ b/stan/math/prim/prob/student_t_lpdf.hpp
@@ -150,7 +150,7 @@ return_type_t<T_y, T_dof, T_loc, T_scale> student_t_lpdf(const T_y& y,
     const T_partials_return sigma_dbl = value_of(sigma_vec[n]);
     const T_partials_return nu_dbl = value_of(nu_vec[n]);
     if (include_summand<propto>::value) {
-      logp += NEG_LOG_SQRT_PI;
+      logp -= LOG_SQRT_PI;
     }
     if (include_summand<propto, T_dof>::value) {
       logp += lgamma_half_nu_plus_half[n] - lgamma_half_nu[n] - 0.5 * log_nu[n];

--- a/stan/math/prim/prob/wishart_lpdf.hpp
+++ b/stan/math/prim/prob/wishart_lpdf.hpp
@@ -68,7 +68,7 @@ return_type_t<T_y, T_dof, T_scale> wishart_lpdf(
   check_ldlt_factor(function, "LDLT_Factor of scale parameter", ldlt_S);
 
   if (include_summand<propto, T_dof>::value) {
-    lp += nu * k * NEG_LOG_TWO_OVER_TWO;
+    lp -= nu * k * HALF_LOG_TWO;
   }
 
   if (include_summand<propto, T_dof>::value) {

--- a/stan/math/prim/scal/fun/constants.hpp
+++ b/stan/math/prim/scal/fun/constants.hpp
@@ -153,10 +153,10 @@ const double INV_SQRT_TWO_PI = inv(SQRT_TWO_PI);
 const double TWO_OVER_SQRT_PI = 2.0 / SQRT_PI;
 
 /**
- * The value of minus half the natural logarithm 2,
- * \f$ -\log(2) / 2 \f$.
+ * The value of half the natural logarithm 2,
+ * \f$ \log(2) / 2 \f$.
  */
-const double NEG_LOG_TWO_OVER_TWO = -0.5 * LOG_TWO;
+const double HALF_LOG_TWO = 0.5 * LOG_TWO;
 
 /**
  * The value of minus the natural logarithm of the square root of \f$ 2\pi \f$,

--- a/stan/math/prim/scal/fun/constants.hpp
+++ b/stan/math/prim/scal/fun/constants.hpp
@@ -11,34 +11,23 @@ namespace stan {
 namespace math {
 
 /**
- * The base of the natural logarithm,
- * \f$ e \f$.
+ * Return the base of the natural logarithm.
+ *
+ * @return Base of natural logarithm.
  */
-const double E = boost::math::constants::e<double>();
+inline double e() { return boost::math::constants::e<double>(); }
 
 /**
- * The value of the square root of 2,
- * \f$ \sqrt{2} \f$.
+ * Return the value of pi.
+ *
+ * @return Pi.
  */
-const double SQRT_TWO = std::sqrt(2.0);
+inline double pi() { return boost::math::constants::pi<double>(); }
 
 /**
- * The value of 1 over the square root of 2,
- * \f$ 1 / \sqrt{2} \f$.
+ * Smallest positive value.
  */
-const double INV_SQRT_TWO = inv(SQRT_TWO);
-
-/**
- * The natural logarithm of 2,
- * \f$ \log 2 \f$.
- */
-const double LOG_TWO = std::log(2.0);
-
-/**
- * The natural logarithm of 10,
- * \f$ \log 10 \f$.
- */
-const double LOG_TEN = std::log(10.0);
+const double EPSILON = std::numeric_limits<double>::epsilon();
 
 /**
  * Positive infinity.
@@ -56,28 +45,129 @@ const double NEGATIVE_INFTY = -INFTY;
 const double NOT_A_NUMBER = std::numeric_limits<double>::quiet_NaN();
 
 /**
- * Smallest positive value.
+ * Twice the value of \f$ \pi \f$,
+ * \f$ 2\pi \f$.
  */
-const double EPSILON = std::numeric_limits<double>::epsilon();
+const double TWO_PI = 2.0 * pi();
+
+/**
+ * The natural logarithm of 0,
+ * \f$ \log 0 \f$.
+ */
+const double LOG_ZERO = std::log(0.0);
+
+/**
+ * The natural logarithm of machine precision \f$ \epsilon \f$,
+ * \f$ \log \epsilon \f$.
+ */
+const double LOG_EPSILON = std::log(EPSILON);
+
+/**
+ * The natural logarithm of \f$ \pi \f$,
+ * \f$ \log \pi \f$.
+ */
+const double LOG_PI = std::log(pi());
+
+/**
+ * The natural logarithm of 0.5,
+ * \f$ \log 0.5 \f$.
+ */
+const double LOG_HALF = std::log(0.5);
+
+/**
+ * The natural logarithm of 2,
+ * \f$ \log 2 \f$.
+ */
+const double LOG_TWO = std::log(2.0);
+
+/**
+ * The natural logarithm of 2 plus the natural logarithm of \f$ \pi \f$,
+ * \f$ \log(2\pi) \f$.
+ */
+const double LOG_TWO_PI = LOG_TWO + LOG_PI;
+
+/**
+ * The value of one quarter the natural logarithm of \f$ \pi \f$,
+ * \f$ \log(\pi) / 4 \f$.
+ */
+const double LOG_PI_OVER_FOUR = 0.25 * LOG_PI;
+
+/**
+ * The natural logarithm of the square root of \f$ \pi \f$,
+ * \f$ \log(sqrt{\pi}) \f$.
+ */
+const double LOG_SQRT_PI = std::log(std::sqrt(pi()));
+
+/**
+ * The natural logarithm of 10,
+ * \f$ \log 10 \f$.
+ */
+const double LOG_TEN = std::log(10.0);
+
+/**
+ * The value of the square root of 2,
+ * \f$ \sqrt{2} \f$.
+ */
+const double SQRT_TWO = std::sqrt(2.0);
+
+/**
+ * The value of the square root of \f$ \pi \f$,
+ * \f$ \sqrt{\pi} \f$.
+ */
+const double SQRT_PI = std::sqrt(pi());
+
+/**
+ * The value of the square root of \f$ 2\pi \f$,
+ * \f$ \sqrt{2\pi} \f$.
+ */
+const double SQRT_TWO_PI = std::sqrt(TWO_PI);
+
+/**
+ * The square root of 2 divided by the square root of \f$ \pi \f$,
+ * \f$ \sqrt{2} / \sqrt{\pi} \f$.
+ */
+const double SQRT_TWO_OVER_SQRT_PI = SQRT_TWO / SQRT_PI;
+
+/**
+ * The value of 1 over the square root of 2,
+ * \f$ 1 / \sqrt{2} \f$.
+ */
+const double INV_SQRT_TWO = inv(SQRT_TWO);
+
+/**
+ * The value of 1 over the square root of \f$ \pi \f$,
+ * \f$ 1 / \sqrt{\pi} \f$.
+ */
+const double INV_SQRT_PI = inv(SQRT_PI);
+
+/**
+ * The value of 1 over the square root of \f$ 2\pi \f$,
+ * \f$ 1 / \sqrt{2\pi} \f$.
+ */
+const double INV_SQRT_TWO_PI = inv(SQRT_TWO_PI);
+
+/**
+ * The value of 2 over the square root of \f$ \pi \f$,
+ * \f$ 2 / \sqrt{\pi} \f$.
+ */
+const double TWO_OVER_SQRT_PI = 2.0 / SQRT_PI;
+
+/**
+ * The value of minus half the natural logarithm 2,
+ * \f$ -\log(2) / 2 \f$.
+ */
+const double NEG_LOG_TWO_OVER_TWO = -0.5 * LOG_TWO;
+
+/**
+ * The value of minus the natural logarithm of the square root of \f$ 2\pi \f$,
+ * \f$ -\log(\sqrt{2\pi}) \f$.
+ */
+const double NEG_LOG_SQRT_TWO_PI = -std::log(SQRT_TWO_PI);
 
 /**
  * Largest rate parameter allowed in Poisson RNG
  */
 const double POISSON_MAX_RATE = std::pow(2.0, 30);
-
-/**
- * Return the value of pi.
- *
- * @return Pi.
- */
-inline double pi() { return boost::math::constants::pi<double>(); }
-
-/**
- * Return the base of the natural logarithm.
- *
- * @return Base of natural logarithm.
- */
-inline double e() { return E; }
 
 /**
  * Return positive infinity.
@@ -107,38 +197,6 @@ inline double not_a_number() { return NOT_A_NUMBER; }
  * @return Minimum positive number.
  */
 inline double machine_precision() { return EPSILON; }
-
-const double SQRT_PI = std::sqrt(pi());
-
-const double INV_SQRT_PI = inv(SQRT_PI);
-
-const double TWO_OVER_SQRT_PI = 2.0 / SQRT_PI;
-
-const double SQRT_TWO_OVER_SQRT_PI = SQRT_TWO / SQRT_PI;
-
-const double TWO_PI = 2.0 * pi();
-
-const double SQRT_TWO_PI = std::sqrt(TWO_PI);
-
-const double INV_SQRT_TWO_PI = inv(SQRT_TWO_PI);
-
-const double LOG_PI = std::log(pi());
-
-const double LOG_PI_OVER_FOUR = LOG_PI / 4.0;
-
-const double LOG_SQRT_PI = std::log(SQRT_PI);
-
-const double LOG_ZERO = std::log(0.0);
-
-const double LOG_HALF = std::log(0.5);
-
-const double NEG_LOG_SQRT_TWO_PI = -std::log(SQRT_TWO_PI);
-
-const double NEG_LOG_TWO_OVER_TWO = -LOG_TWO / 2.0;
-
-const double LOG_TWO_PI = LOG_TWO + LOG_PI;
-
-const double LOG_EPSILON = std::log(EPSILON);
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/prim/scal/fun/constants.hpp
+++ b/stan/math/prim/scal/fun/constants.hpp
@@ -61,11 +61,6 @@ const double NOT_A_NUMBER = std::numeric_limits<double>::quiet_NaN();
 const double EPSILON = std::numeric_limits<double>::epsilon();
 
 /**
- * Largest negative value (i.e., smallest absolute value).
- */
-const double NEGATIVE_EPSILON = -EPSILON;
-
-/**
  * Largest rate parameter allowed in Poisson RNG
  */
 const double POISSON_MAX_RATE = std::pow(2.0, 30);
@@ -83,20 +78,6 @@ inline double pi() { return boost::math::constants::pi<double>(); }
  * @return Base of natural logarithm.
  */
 inline double e() { return E; }
-
-/**
- * Return the square root of two.
- *
- * @return Square root of two.
- */
-inline double sqrt2() { return SQRT_TWO; }
-
-/**
- * Return natural logarithm of ten.
- *
- * @return Natural logarithm of ten.
- */
-inline double log10() { return LOG_TEN; }
 
 /**
  * Return positive infinity.
@@ -133,8 +114,6 @@ const double INV_SQRT_PI = inv(SQRT_PI);
 
 const double TWO_OVER_SQRT_PI = 2.0 / SQRT_PI;
 
-const double NEG_TWO_OVER_SQRT_PI = -TWO_OVER_SQRT_PI;
-
 const double SQRT_TWO_OVER_SQRT_PI = SQRT_TWO / SQRT_PI;
 
 const double TWO_PI = 2.0 * pi();
@@ -153,19 +132,11 @@ const double LOG_ZERO = std::log(0.0);
 
 const double LOG_HALF = std::log(0.5);
 
-const double NEG_LOG_TWO = -LOG_TWO;
-
 const double NEG_LOG_SQRT_TWO_PI = -std::log(SQRT_TWO_PI);
-
-const double NEG_LOG_PI = -LOG_PI;
-
-const double NEG_LOG_SQRT_PI = -LOG_SQRT_PI;
 
 const double NEG_LOG_TWO_OVER_TWO = -LOG_TWO / 2.0;
 
 const double LOG_TWO_PI = LOG_TWO + LOG_PI;
-
-const double NEG_LOG_TWO_PI = -LOG_TWO_PI;
 
 const double LOG_EPSILON = std::log(EPSILON);
 

--- a/stan/math/prim/scal/fun/constants.hpp
+++ b/stan/math/prim/scal/fun/constants.hpp
@@ -10,6 +10,8 @@
 namespace stan {
 namespace math {
 
+// TODO(anyone) Use constexpr when moving to C++17
+
 /**
  * Return the base of the natural logarithm.
  *
@@ -203,6 +205,20 @@ inline double not_a_number() { return NOT_A_NUMBER; }
  * @return Minimum positive number.
  */
 inline double machine_precision() { return EPSILON; }
+
+/**
+ * Returns the natural logarithm of ten.
+ *
+ * @return Natural logarithm of ten.
+ */
+inline double log10() { return LOG_TEN; }
+
+/**
+ * Returns the square root of two.
+ *
+ * @return Square root of two.
+ */
+inline double sqrt2() { return SQRT_TWO; }
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/prim/scal/fun/constants.hpp
+++ b/stan/math/prim/scal/fun/constants.hpp
@@ -159,6 +159,12 @@ const double TWO_OVER_SQRT_PI = 2.0 / SQRT_PI;
 const double HALF_LOG_TWO = 0.5 * LOG_TWO;
 
 /**
+ * The value of half the natural logarithm \f$ 2\pi \f$,
+ * \f$ \log(2\pi) / 2 \f$.
+ */
+const double HALF_LOG_TWO_PI = 0.5 * LOG_TWO_PI;
+
+/**
  * The value of minus the natural logarithm of the square root of \f$ 2\pi \f$,
  * \f$ -\log(\sqrt{2\pi}) \f$.
  */

--- a/stan/math/prim/scal/fun/log_modified_bessel_first_kind.hpp
+++ b/stan/math/prim/scal/fun/log_modified_bessel_first_kind.hpp
@@ -181,7 +181,7 @@ inline return_type_t<T1, T2, double> log_modified_bessel_first_kind(
       num *= mu - 25;
       denom *= ex * 3;
       s -= num / denom;
-      s = z - log(sqrt(2 * z * pi())) + log(s);
+      s = z - log(sqrt(z * TWO_PI)) + log(s);
       return s;
     }
   }

--- a/stan/math/rev/fun/erfc.hpp
+++ b/stan/math/rev/fun/erfc.hpp
@@ -15,8 +15,7 @@ class erfc_vari : public op_v_vari {
  public:
   explicit erfc_vari(vari* avi) : op_v_vari(erfc(avi->val_), avi) {}
   void chain() {
-    avi_->adj_
-        += adj_ * NEG_TWO_OVER_SQRT_PI * std::exp(-avi_->val_ * avi_->val_);
+    avi_->adj_ -= adj_ * TWO_OVER_SQRT_PI * std::exp(-avi_->val_ * avi_->val_);
   }
 };
 }  // namespace internal

--- a/test/prob/cauchy/cauchy_test.hpp
+++ b/test/prob/cauchy/cauchy_test.hpp
@@ -77,8 +77,7 @@ class AgradDistributionsCauchy : public AgradDistributionTest {
       const T5&) {
     using stan::math::log1p;
     using stan::math::square;
-    return stan::math::NEG_LOG_PI - log(sigma)
-           - log1p(square((y - mu) / sigma));
+    return -stan::math::LOG_PI - log(sigma) - log1p(square((y - mu) / sigma));
   }
 };
 

--- a/test/prob/chi_square/chi_square_test.hpp
+++ b/test/prob/chi_square/chi_square_test.hpp
@@ -59,10 +59,10 @@ class AgradDistributionsChiSquare : public AgradDistributionTest {
       const T_y& y, const T_dof& nu, const T2&, const T3&, const T4&,
       const T5&) {
     using boost::math::lgamma;
-    using stan::math::NEG_LOG_TWO_OVER_TWO;
+    using stan::math::HALF_LOG_TWO;
     using stan::math::multiply_log;
 
-    return nu * NEG_LOG_TWO_OVER_TWO - lgamma(0.5 * nu)
+    return -nu * HALF_LOG_TWO - lgamma(0.5 * nu)
            + multiply_log(0.5 * nu - 1.0, y) - 0.5 * y;
   }
 };

--- a/test/prob/double_exponential/double_exponential_test.hpp
+++ b/test/prob/double_exponential/double_exponential_test.hpp
@@ -102,11 +102,11 @@ class AgradDistributionsDoubleExponential : public AgradDistributionTest {
   typename stan::return_type<T_y, T_loc, T_scale>::type log_prob_function(
       const T_y& y, const T_loc& mu, const T_scale& sigma, const T3&, const T4&,
       const T5&) {
-    using stan::math::NEG_LOG_TWO;
+    using stan::math::LOG_TWO;
     using std::fabs;
     using std::log;
 
-    return NEG_LOG_TWO - log(sigma) - fabs(y - mu) / sigma;
+    return -LOG_TWO - log(sigma) - fabs(y - mu) / sigma;
   }
 };
 

--- a/test/prob/exponential/exponential_test.hpp
+++ b/test/prob/exponential/exponential_test.hpp
@@ -70,10 +70,6 @@ class AgradDistributionsExponential : public AgradDistributionTest {
   typename stan::return_type<T_y, T_inv_scale>::type log_prob_function(
       const T_y& y, const T_inv_scale& beta, const T2&, const T3&, const T4&,
       const T5&) {
-    using boost::math::lgamma;
-    using stan::math::NEG_LOG_TWO_OVER_TWO;
-    using stan::math::multiply_log;
-
     return log(beta) - beta * y;
   }
 };

--- a/test/prob/inv_chi_square/inv_chi_square_test.hpp
+++ b/test/prob/inv_chi_square/inv_chi_square_test.hpp
@@ -60,10 +60,10 @@ class AgradDistributionsInvChiSquare : public AgradDistributionTest {
       const T_y& y, const T_dof& nu, const T2&, const T3&, const T4&,
       const T5&) {
     using boost::math::lgamma;
-    using stan::math::NEG_LOG_TWO_OVER_TWO;
+    using stan::math::HALF_LOG_TWO;
     using stan::math::multiply_log;
 
-    return nu * NEG_LOG_TWO_OVER_TWO - lgamma(0.5 * nu)
+    return -nu * HALF_LOG_TWO - lgamma(0.5 * nu)
            - multiply_log(0.5 * nu + 1.0, y) - 0.5 / y;
   }
 };

--- a/test/prob/normal/normal_test.hpp
+++ b/test/prob/normal/normal_test.hpp
@@ -80,6 +80,6 @@ class AgradDistributionNormal : public AgradDistributionTest {
                     const T3&, const T4&, const T5&) {
     using stan::math::pi;
     return -0.5 * (y - mu) * (y - mu) / (sigma * sigma) - log(sigma)
-           - log(sqrt(2.0 * pi()));
+           - log(stan::math::SQRT_TWO_PI);
   }
 };

--- a/test/prob/student_t/student_t_test.hpp
+++ b/test/prob/student_t/student_t_test.hpp
@@ -85,8 +85,8 @@ class AgradDistributionsStudentT : public AgradDistributionTest {
   log_prob_function(const T_y& y, const T_dof& nu, const T_loc& mu,
                     const T_scale& sigma, const T4&, const T5&) {
     using boost::math::lgamma;
-    using stan::math::log1p;
     using stan::math::LOG_SQRT_PI;
+    using stan::math::log1p;
     using stan::math::square;
     using std::log;
 

--- a/test/prob/student_t/student_t_test.hpp
+++ b/test/prob/student_t/student_t_test.hpp
@@ -85,12 +85,12 @@ class AgradDistributionsStudentT : public AgradDistributionTest {
   log_prob_function(const T_y& y, const T_dof& nu, const T_loc& mu,
                     const T_scale& sigma, const T4&, const T5&) {
     using boost::math::lgamma;
-    using stan::math::NEG_LOG_SQRT_PI;
     using stan::math::log1p;
+    using stan::math::LOG_SQRT_PI;
     using stan::math::square;
     using std::log;
 
-    return lgamma((nu + 1.0) / 2.0) - lgamma(nu / 2.0) + NEG_LOG_SQRT_PI
+    return lgamma((nu + 1.0) / 2.0) - lgamma(nu / 2.0) - LOG_SQRT_PI
            - 0.5 * log(nu) - log(sigma)
            - ((nu + 1.0) / 2.0) * log1p(square(((y - mu) / sigma)) / nu);
   }

--- a/test/prob/von_mises/von_mises_test.hpp
+++ b/test/prob/von_mises/von_mises_test.hpp
@@ -87,7 +87,7 @@ class AgradDistributionVonMises : public AgradDistributionTest {
     using stan::math::pi;
     using std::log;
 
-    return -log(2.0 * stan::math::pi())
-           - log(modified_bessel_first_kind(0, kappa)) + kappa * cos(mu - y);
+    return -stan::math::LOG_TWO_PI - log(modified_bessel_first_kind(0, kappa))
+           + kappa * cos(mu - y);
   }
 };

--- a/test/unit/math/prim/fun/constants_test.cpp
+++ b/test/unit/math/prim/fun/constants_test.cpp
@@ -23,20 +23,10 @@ TEST(MathsConstants, neg_infty) {
 TEST(MathsConstants, nan) { EXPECT_TRUE(std::isnan(stan::math::NOT_A_NUMBER)); }
 
 TEST(MathsConstants, epsilon) { EXPECT_TRUE(stan::math::EPSILON > 0.0); }
-TEST(MathsConstants, negative_epsilon) {
-  EXPECT_TRUE(stan::math::NEGATIVE_EPSILON < 0.0);
-}
-
 TEST(MathsConstants, pi_fun) {
   EXPECT_FLOAT_EQ(4.0 * std::atan(1.0), stan::math::pi());
 }
 TEST(MathsConstants, e_fun) { EXPECT_FLOAT_EQ(std::exp(1.0), stan::math::e()); }
-TEST(MathsConstants, sqrt2_fun) {
-  EXPECT_FLOAT_EQ(std::sqrt(2.0), stan::math::sqrt2());
-}
-TEST(MathsConstants, log10_fun) {
-  EXPECT_FLOAT_EQ(std::log(10.0), stan::math::log10());
-}
 
 TEST(MathsConstants, infty_fun) {
   EXPECT_FLOAT_EQ(std::numeric_limits<double>::infinity(),
@@ -55,10 +45,6 @@ TEST(MathsConstants, machine_precision_fun) {
 }
 TEST(MathsConstants, two_over_sqrt_pi) {
   EXPECT_FLOAT_EQ(1.128379167, stan::math::TWO_OVER_SQRT_PI);
-}
-TEST(MathsConstants, neg_two_over_sqrt_pi) {
-  EXPECT_FLOAT_EQ(-stan::math::TWO_OVER_SQRT_PI,
-                  stan::math::NEG_TWO_OVER_SQRT_PI);
 }
 TEST(MathsConstants, inv_sqrt_two_pi) {
   EXPECT_FLOAT_EQ(.39894228040, stan::math::INV_SQRT_TWO_PI);

--- a/test/unit/math/prim/fun/constants_test.cpp
+++ b/test/unit/math/prim/fun/constants_test.cpp
@@ -2,7 +2,6 @@
 #include <gtest/gtest.h>
 #include <limits>
 
-TEST(MathsConstants, e) { EXPECT_FLOAT_EQ(std::exp(1.0), stan::math::E); }
 TEST(MathsConstants, sqrt2) {
   EXPECT_FLOAT_EQ(std::sqrt(2.0), stan::math::SQRT_TWO);
 }

--- a/test/unit/math/prim/fun/constants_test.cpp
+++ b/test/unit/math/prim/fun/constants_test.cpp
@@ -26,6 +26,12 @@ TEST(MathsConstants, pi_fun) {
   EXPECT_FLOAT_EQ(4.0 * std::atan(1.0), stan::math::pi());
 }
 TEST(MathsConstants, e_fun) { EXPECT_FLOAT_EQ(std::exp(1.0), stan::math::e()); }
+TEST(MathsConstants, sqrt2_fun) {
+  EXPECT_FLOAT_EQ(std::sqrt(2.0), stan::math::sqrt2());
+}
+TEST(MathsConstants, log10_fun) {
+  EXPECT_FLOAT_EQ(std::log(10.0), stan::math::log10());
+}
 
 TEST(MathsConstants, infty_fun) {
   EXPECT_FLOAT_EQ(std::numeric_limits<double>::infinity(),


### PR DESCRIPTION
## Summary
This cleans up `constants.hpp` as detailed in #1605. The reordering of the file came out better than I expected: it starts with aliases for constants from boost or `std::numeric_limits`, then our constants ordered by type (log, sqrt, inv, others). Last I put the inline functions based on our constants. All constants are now documented.  Fixes #1605.

This removes the following constants: `NEG_LOG_PI`, `NEG_LOG_TWO`, `NEG_LOG_TWO_OVER_TWO`, `NEG_LOG_TWO_PI`, `NEG_LOG_SQRT_PI`, `NEG_TWO_OVER_SQRT_PI`, `NEGATIVE_EPSILON`.

This adds `HALF_LOG_TWO` (to replace `NEG_LOG_TWO_OVER_TWO`, with positive sign) and `HALF_LOG_TWO_PI`.

This replaces `SQRT_TWO_OVER_SQRT_PI * 0.5` with the equivalent (but shorter) `INV_SQRT_TWO_PI`.

## Tests
No new tests.

## Side Effects

None.

## Checklist

- [X] Math issue #1605

- [X] Copyright holder: Marco Colombo

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [X] the new changes are tested