### PR TITLE
catch by const reference

### DIFF
--- a/stan/math/prim/core/init_threadpool_tbb.hpp
+++ b/stan/math/prim/core/init_threadpool_tbb.hpp
@@ -47,7 +47,7 @@ inline int get_num_threads() {
                          "The STAN_NUM_THREADS environment variable is '",
                          "' but it must be positive or -1");
       }
-    } catch (boost::bad_lexical_cast) {
+    } catch (const boost::bad_lexical_cast&) {
       invalid_argument("get_num_threads(int)", "STAN_NUM_THREADS",
                        env_stan_num_threads,
                        "The STAN_NUM_THREADS environment variable is '",


### PR DESCRIPTION
## Summary

This pull request changes

`catch (boost::bad_lexical_cast)`

to

`catch (const boost::bad_lexical_cast&)`

and fixes #1608 

## Tests

None

## Side Effects

Eliminates a warning

## Checklist

- [X] Math issue #1608

- [X] Copyright holder: Trustees of Columbia University

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [X] the new changes are tested
