### PR TITLE
use correct LDLIBS variable to get correct order for compiling with g++

### DIFF
--- a/make/standalone
+++ b/make/standalone
@@ -23,9 +23,9 @@ MATH ?= $(realpath $(MATH_MAKE)..)/
 # The sundials libraries are only needed for
 # programs using the stiff ode solver or the
 # algebra solver
-MATH_LIBS ?= $(TBB_TARGETS) $(LIBSUNDIALS) $(MPI_TARGETS)
+MATH_LIBS ?= $(LIBSUNDIALS) $(MPI_TARGETS) $(TBB_TARGETS)
 
-LDFLAGS += $(MATH_LIBS)
+LDLIBS += $(MATH_LIBS)
 
 math-libs : $(MATH_LIBS)
 


### PR DESCRIPTION
## Summary

Fixes issue #1613 ... this actually fixes the standalone makefile to now also work with g++

## Tests

Take the hello world example from the README.md and compile it with g++ using the instructions in the README.md with the standalone feature - while being on an Ubuntu system.

## Side Effects

None

## Checklist

- [X] Math issue #1613 

- [X] Copyright holder: Sebastian Weber

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [X] the new changes are tested
