### PR TITLE
[WIP] Have enable_if's in require_* return int

### DIFF
--- a/stan/math/prim/meta/require_generics.hpp
+++ b/stan/math/prim/meta/require_generics.hpp
@@ -189,7 +189,8 @@ using require_not_t = std::enable_if_t<!Check::value, int>;
  * Returns a type void if all conditions are true and otherwise fails.
  */
 template <class... Checks>
-using require_all_t = std::enable_if_t<math::conjunction<Checks...>::value, int>;
+using require_all_t
+    = std::enable_if_t<math::conjunction<Checks...>::value, int>;
 
 /**
  * If any condition is true, template is enabled.
@@ -197,7 +198,8 @@ using require_all_t = std::enable_if_t<math::conjunction<Checks...>::value, int>
  * Returns a type void if any of the conditions are true and otherwise fails.
  */
 template <class... Checks>
-using require_any_t = std::enable_if_t<math::disjunction<Checks...>::value, int>;
+using require_any_t
+    = std::enable_if_t<math::disjunction<Checks...>::value, int>;
 
 /**
  * If all conditions are false, template is enabled.

--- a/stan/math/prim/meta/require_generics.hpp
+++ b/stan/math/prim/meta/require_generics.hpp
@@ -176,20 +176,20 @@ struct is_eigen_vector_scalar_check
  * If condition is true, template is enabled
  */
 template <class Check>
-using require_t = std::enable_if_t<Check::value>;
+using require_t = std::enable_if_t<Check::value, int>;
 
 /**
  * If condition is false, template is disabled
  */
 template <typename Check>
-using require_not_t = std::enable_if_t<!Check::value>;
+using require_not_t = std::enable_if_t<!Check::value, int>;
 
 /**
  * If all conditions are true, template is enabled
  * Returns a type void if all conditions are true and otherwise fails.
  */
 template <class... Checks>
-using require_all_t = std::enable_if_t<math::conjunction<Checks...>::value>;
+using require_all_t = std::enable_if_t<math::conjunction<Checks...>::value, int>;
 
 /**
  * If any condition is true, template is enabled.
@@ -197,7 +197,7 @@ using require_all_t = std::enable_if_t<math::conjunction<Checks...>::value>;
  * Returns a type void if any of the conditions are true and otherwise fails.
  */
 template <class... Checks>
-using require_any_t = std::enable_if_t<math::disjunction<Checks...>::value>;
+using require_any_t = std::enable_if_t<math::disjunction<Checks...>::value, int>;
 
 /**
  * If all conditions are false, template is enabled.
@@ -206,7 +206,7 @@ using require_any_t = std::enable_if_t<math::disjunction<Checks...>::value>;
  */
 template <class... Checks>
 using require_all_not_t
-    = std::enable_if_t<!math::disjunction<Checks...>::value>;
+    = std::enable_if_t<!math::disjunction<Checks...>::value, int>;
 
 /**
  * If any condition is false, template is enabled.
@@ -215,7 +215,7 @@ using require_all_not_t
  */
 template <class... Checks>
 using require_any_not_t
-    = std::enable_if_t<!math::conjunction<Checks...>::value>;
+    = std::enable_if_t<!math::conjunction<Checks...>::value, int>;
 
 /**
  * Require both types to be the same


### PR DESCRIPTION

## Summary

The `require_t` frequently use `...` which for 
```
template <typename T, require_arithmetic_t<T>...`
```

would produce a non type template parameter pack. This came from [this](https://www.fluentcpp.com/2019/08/23/how-to-make-sfinae-pretty-and-robust/) article. A recent comment brought up this could create a `void...` which is ill formed by the standard. The fix is to just have `enable_if` in the bottom level `require_t` definitions return back an `int` so that the non type template parameter pack is now `int...` which is well formed

This could be the cause of the windows machine failing. I wanted to put this up to let the windows machines run on it and if it fixes that then I'll fill out an issue and write more in depth on why this is happening. If you check out the comments section of that blog post there's a big discussion on this

## Tests

no new tests

## Side Effects

Removes ill formed template expressions

## Checklist

- [ ] Math issue #(issue number)

- [ ] Copyright holder: (fill in copyright holder information)

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [ ] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [ ] the code is written in idiomatic C++ and changes are documented in the doxygen

- [ ] the new changes are tested
