### PR TITLE
Add vector construction utilities

### DIFF
--- a/stan/math/prim/fun.hpp
+++ b/stan/math/prim/fun.hpp
@@ -197,6 +197,7 @@
 #include <stan/math/prim/fun/num_elements.hpp>
 #include <stan/math/prim/fun/offset_multiplier_constrain.hpp>
 #include <stan/math/prim/fun/offset_multiplier_free.hpp>
+#include <stan/math/prim/fun/one_hot_vector.hpp>
 #include <stan/math/prim/fun/ones_vector.hpp>
 #include <stan/math/prim/fun/ordered_constrain.hpp>
 #include <stan/math/prim/fun/ordered_free.hpp>
@@ -241,6 +242,7 @@
 #include <stan/math/prim/fun/scaled_add.hpp>
 #include <stan/math/prim/fun/sd.hpp>
 #include <stan/math/prim/fun/segment.hpp>
+#include <stan/math/prim/fun/set_spaced_vector.hpp>
 #include <stan/math/prim/fun/sign.hpp>
 #include <stan/math/prim/fun/simplex_constrain.hpp>
 #include <stan/math/prim/fun/simplex_free.hpp>
@@ -284,6 +286,7 @@
 #include <stan/math/prim/fun/typedefs.hpp>
 #include <stan/math/prim/fun/ub_constrain.hpp>
 #include <stan/math/prim/fun/ub_free.hpp>
+#include <stan/math/prim/fun/uniform_simplex.hpp>
 #include <stan/math/prim/fun/unit_vector_constrain.hpp>
 #include <stan/math/prim/fun/unit_vector_free.hpp>
 #include <stan/math/prim/fun/value_of.hpp>

--- a/stan/math/prim/fun.hpp
+++ b/stan/math/prim/fun.hpp
@@ -40,6 +40,7 @@
 #include <stan/math/prim/fun/columns_dot_product.hpp>
 #include <stan/math/prim/fun/columns_dot_self.hpp>
 #include <stan/math/prim/fun/common_type.hpp>
+#include <stan/math/prim/fun/constant_vector.hpp>
 #include <stan/math/prim/fun/constants.hpp>
 #include <stan/math/prim/fun/corr_constrain.hpp>
 #include <stan/math/prim/fun/corr_free.hpp>
@@ -196,6 +197,7 @@
 #include <stan/math/prim/fun/num_elements.hpp>
 #include <stan/math/prim/fun/offset_multiplier_constrain.hpp>
 #include <stan/math/prim/fun/offset_multiplier_free.hpp>
+#include <stan/math/prim/fun/ones_vector.hpp>
 #include <stan/math/prim/fun/ordered_constrain.hpp>
 #include <stan/math/prim/fun/ordered_free.hpp>
 #include <stan/math/prim/fun/owens_t.hpp>
@@ -289,5 +291,6 @@
 #include <stan/math/prim/fun/variance.hpp>
 #include <stan/math/prim/fun/welford_covar_estimator.hpp>
 #include <stan/math/prim/fun/welford_var_estimator.hpp>
+#include <stan/math/prim/fun/zeros_vector.hpp>
 
 #endif

--- a/stan/math/prim/fun.hpp
+++ b/stan/math/prim/fun.hpp
@@ -114,6 +114,7 @@
 #include <stan/math/prim/fun/hypot.hpp>
 #include <stan/math/prim/fun/identity_constrain.hpp>
 #include <stan/math/prim/fun/identity_free.hpp>
+#include <stan/math/prim/fun/identity_matrix.hpp>
 #include <stan/math/prim/fun/if_else.hpp>
 #include <stan/math/prim/fun/inc_beta.hpp>
 #include <stan/math/prim/fun/initialize.hpp>

--- a/stan/math/prim/fun/constant_vector.hpp
+++ b/stan/math/prim/fun/constant_vector.hpp
@@ -15,7 +15,7 @@ namespace math {
  * @return A vector of length K with all elements initialised to
  * the same constant.
  */
-Eigen::VectorXd constant_vector(int K, double c) {
+inline Eigen::VectorXd constant_vector(int K, double c) {
   check_nonnegative("constant_vector", "length", K);
   return Eigen::VectorXd::Constant(K, c);
 }

--- a/stan/math/prim/fun/constant_vector.hpp
+++ b/stan/math/prim/fun/constant_vector.hpp
@@ -1,0 +1,26 @@
+#ifndef STAN_MATH_PRIM_FUN_CONSTANT_VECTOR_HPP
+#define STAN_MATH_PRIM_FUN_CONSTANT_VECTOR_HPP
+
+#include <stan/math/prim/err.hpp>
+#include <stan/math/prim/fun/Eigen.hpp>
+
+namespace stan {
+namespace math {
+
+/**
+ * Return a vector with elements set to the same constant
+ *
+ * @param K length of the vector
+ * @param c constant value
+ * @return A vector of length K with all elements initialised to
+ * the same constant.
+ */
+Eigen::VectorXd constant_vector(long K, double c) {
+  check_nonnegative("constant_vector", "length", K);
+  return Eigen::VectorXd::Constant(K, c);
+}
+
+}  // namespace math
+}  // namespace stan
+
+#endif

--- a/stan/math/prim/fun/constant_vector.hpp
+++ b/stan/math/prim/fun/constant_vector.hpp
@@ -10,13 +10,14 @@ namespace math {
 /**
  * Return a vector with elements set to the same constant
  *
- * @param K length of the vector
+ * @param K size of the vector
  * @param c constant value
- * @return A vector of length K with all elements initialised to
+ * @return A vector of size K with all elements initialised to
  * the same constant.
+ * @throw std::domain_error if K is negative.
  */
 inline Eigen::VectorXd constant_vector(int K, double c) {
-  check_nonnegative("constant_vector", "length", K);
+  check_nonnegative("constant_vector", "size", K);
   return Eigen::VectorXd::Constant(K, c);
 }
 

--- a/stan/math/prim/fun/constant_vector.hpp
+++ b/stan/math/prim/fun/constant_vector.hpp
@@ -15,7 +15,7 @@ namespace math {
  * @return A vector of length K with all elements initialised to
  * the same constant.
  */
-Eigen::VectorXd constant_vector(long K, double c) {
+Eigen::VectorXd constant_vector(int K, double c) {
   check_nonnegative("constant_vector", "length", K);
   return Eigen::VectorXd::Constant(K, c);
 }

--- a/stan/math/prim/fun/identity_matrix.hpp
+++ b/stan/math/prim/fun/identity_matrix.hpp
@@ -13,7 +13,7 @@ namespace math {
  * @param K size of the matrix
  * @return An identity matrix of size K.
  */
-Eigen::MatrixXd identity_matrix(long K) {
+Eigen::MatrixXd identity_matrix(int K) {
   check_nonnegative("identity_matrix", "size", K);
   return Eigen::MatrixXd::Identity(K, K);
 }

--- a/stan/math/prim/fun/identity_matrix.hpp
+++ b/stan/math/prim/fun/identity_matrix.hpp
@@ -13,7 +13,7 @@ namespace math {
  * @param K size of the matrix
  * @return An identity matrix of size K.
  */
-Eigen::MatrixXd identity_matrix(int K) {
+inline Eigen::MatrixXd identity_matrix(int K) {
   check_nonnegative("identity_matrix", "size", K);
   return Eigen::MatrixXd::Identity(K, K);
 }

--- a/stan/math/prim/fun/identity_matrix.hpp
+++ b/stan/math/prim/fun/identity_matrix.hpp
@@ -1,0 +1,24 @@
+#ifndef STAN_MATH_PRIM_FUN_IDENTITY_MATRIX_HPP
+#define STAN_MATH_PRIM_FUN_IDENTITY_MATRIX_HPP
+
+#include <stan/math/prim/err.hpp>
+#include <stan/math/prim/fun/Eigen.hpp>
+
+namespace stan {
+namespace math {
+
+/**
+ * Return a square identity matrix
+ *
+ * @param K size of the matrix
+ * @return An identity matrix of size K.
+ */
+Eigen::MatrixXd identity_matrix(long K) {
+  check_nonnegative("identity_matrix", "size", K);
+  return Eigen::MatrixXd::Identity(K, K);
+}
+
+}  // namespace math
+}  // namespace stan
+
+#endif

--- a/stan/math/prim/fun/identity_matrix.hpp
+++ b/stan/math/prim/fun/identity_matrix.hpp
@@ -12,6 +12,7 @@ namespace math {
  *
  * @param K size of the matrix
  * @return An identity matrix of size K.
+ * @throw std::domain_error if K is negative.
  */
 inline Eigen::MatrixXd identity_matrix(int K) {
   check_nonnegative("identity_matrix", "size", K);

--- a/stan/math/prim/fun/one_hot_vector.hpp
+++ b/stan/math/prim/fun/one_hot_vector.hpp
@@ -15,7 +15,7 @@ namespace math {
  * @return A vector of length K with all elements initialised to zero
  * and a 1 in the k-th position.
  */
-Eigen::VectorXd one_hot_vector(long K, long k) {
+Eigen::VectorXd one_hot_vector(int K, int k) {
   static const char* function = "one_hot_vector";
   check_nonnegative(function, "length", K);
   check_bounded(function, "k", k, 1, K);

--- a/stan/math/prim/fun/one_hot_vector.hpp
+++ b/stan/math/prim/fun/one_hot_vector.hpp
@@ -15,7 +15,7 @@ namespace math {
  * @return A vector of length K with all elements initialised to zero
  * and a 1 in the k-th position.
  */
-Eigen::VectorXd one_hot_vector(int K, int k) {
+inline Eigen::VectorXd one_hot_vector(int K, int k) {
   static const char* function = "one_hot_vector";
   check_nonnegative(function, "length", K);
   check_bounded(function, "k", k, 1, K);

--- a/stan/math/prim/fun/one_hot_vector.hpp
+++ b/stan/math/prim/fun/one_hot_vector.hpp
@@ -1,0 +1,31 @@
+#ifndef STAN_MATH_PRIM_FUN_ONE_HOT_VECTOR_HPP
+#define STAN_MATH_PRIM_FUN_ONE_HOT_VECTOR_HPP
+
+#include <stan/math/prim/err.hpp>
+#include <stan/math/prim/fun/Eigen.hpp>
+
+namespace stan {
+namespace math {
+
+/**
+ * Return a vector with 1 in the k-th position and zero elsewhere
+ *
+ * @param K length of the vector
+ * @param k position of the 1 (indexing from 1)
+ * @return A vector of length K with all elements initialised to zero
+ * and a 1 in the k-th position.
+ */
+Eigen::VectorXd one_hot_vector(long K, long k) {
+  static const char* function = "one_hot_vector";
+  check_nonnegative(function, "length", K);
+  check_bounded(function, "k", k, 1, K);
+
+  Eigen::VectorXd ret = Eigen::VectorXd::Zero(K);
+  ret(k - 1) = 1;
+  return ret;
+}
+
+}  // namespace math
+}  // namespace stan
+
+#endif

--- a/stan/math/prim/fun/one_hot_vector.hpp
+++ b/stan/math/prim/fun/one_hot_vector.hpp
@@ -10,14 +10,16 @@ namespace math {
 /**
  * Return a vector with 1 in the k-th position and zero elsewhere
  *
- * @param K length of the vector
+ * @param K size of the vector
  * @param k position of the 1 (indexing from 1)
- * @return A vector of length K with all elements initialised to zero
+ * @return A vector of size K with all elements initialised to zero
  * and a 1 in the k-th position.
+ * @throw std::domain_error if K is not positive, or if k is less than 1 or
+ * greater than K.
  */
 inline Eigen::VectorXd one_hot_vector(int K, int k) {
   static const char* function = "one_hot_vector";
-  check_nonnegative(function, "length", K);
+  check_positive(function, "size", K);
   check_bounded(function, "k", k, 1, K);
 
   Eigen::VectorXd ret = Eigen::VectorXd::Zero(K);

--- a/stan/math/prim/fun/ones_vector.hpp
+++ b/stan/math/prim/fun/ones_vector.hpp
@@ -13,7 +13,7 @@ namespace math {
  * @param K length of the vector
  * @return A vector of length K with all elements initialised to 1.
  */
-Eigen::VectorXd ones_vector(long K) {
+Eigen::VectorXd ones_vector(int K) {
   check_nonnegative("ones_vector", "length", K);
   return Eigen::VectorXd::Constant(K, 1);
 }

--- a/stan/math/prim/fun/ones_vector.hpp
+++ b/stan/math/prim/fun/ones_vector.hpp
@@ -1,0 +1,24 @@
+#ifndef STAN_MATH_PRIM_FUN_ONES_VECTOR_HPP
+#define STAN_MATH_PRIM_FUN_ONES_VECTOR_HPP
+
+#include <stan/math/prim/err.hpp>
+#include <stan/math/prim/fun/Eigen.hpp>
+
+namespace stan {
+namespace math {
+
+/**
+ * Return a vector of ones
+ *
+ * @param K length of the vector
+ * @return A vector of length K with all elements initialised to 1.
+ */
+Eigen::VectorXd ones_vector(long K) {
+  check_nonnegative("ones_vector", "length", K);
+  return Eigen::VectorXd::Constant(K, 1);
+}
+
+}  // namespace math
+}  // namespace stan
+
+#endif

--- a/stan/math/prim/fun/ones_vector.hpp
+++ b/stan/math/prim/fun/ones_vector.hpp
@@ -10,11 +10,12 @@ namespace math {
 /**
  * Return a vector of ones
  *
- * @param K length of the vector
- * @return A vector of length K with all elements initialised to 1.
+ * @param K size of the vector
+ * @return A vector of size K with all elements initialised to 1.
+ * @throw std::domain_error if K is negative.
  */
 inline Eigen::VectorXd ones_vector(int K) {
-  check_nonnegative("ones_vector", "length", K);
+  check_nonnegative("ones_vector", "size", K);
   return Eigen::VectorXd::Constant(K, 1);
 }
 

--- a/stan/math/prim/fun/ones_vector.hpp
+++ b/stan/math/prim/fun/ones_vector.hpp
@@ -13,7 +13,7 @@ namespace math {
  * @param K length of the vector
  * @return A vector of length K with all elements initialised to 1.
  */
-Eigen::VectorXd ones_vector(int K) {
+inline Eigen::VectorXd ones_vector(int K) {
   check_nonnegative("ones_vector", "length", K);
   return Eigen::VectorXd::Constant(K, 1);
 }

--- a/stan/math/prim/fun/set_spaced_vector.hpp
+++ b/stan/math/prim/fun/set_spaced_vector.hpp
@@ -10,15 +10,21 @@ namespace math {
 /**
  * Return a vector of linearly spaced elements
  *
- * @param K length of the vector
+ * This produces a vector from low to high (included) with elements spaced
+ * as (high - low) / (K - 1). For K=1, the vector will contain the high value;
+ * for K=0 it returns an empty vector.
+ *
+ * @param K size of the vector
  * @param low smallest value
  * @param high largest value
- * @return A vector of length K with elements linearly spaced between
+ * @return A vector of size K with elements linearly spaced between
  * low and high.
+ * @throw std::domain_error if K is negative, if low is nan or infinite,
+ * if high is nan or infinite, or if high is less than low.
  */
 inline Eigen::VectorXd set_spaced_vector(int K, double low, double high) {
   static const char* function = "set_spaced_vector";
-  check_nonnegative(function, "length", K);
+  check_nonnegative(function, "size", K);
   check_finite(function, "low", low);
   check_finite(function, "high", high);
   check_greater_or_equal(function, "high", high, low);

--- a/stan/math/prim/fun/set_spaced_vector.hpp
+++ b/stan/math/prim/fun/set_spaced_vector.hpp
@@ -16,7 +16,7 @@ namespace math {
  * @return A vector of length K with elements linearly spaced between
  * low and high.
  */
-Eigen::VectorXd set_spaced_vector(long K, double low, double high) {
+Eigen::VectorXd set_spaced_vector(int K, double low, double high) {
   static const char* function = "set_spaced_vector";
   check_nonnegative(function, "length", K);
   check_finite(function, "low", low);

--- a/stan/math/prim/fun/set_spaced_vector.hpp
+++ b/stan/math/prim/fun/set_spaced_vector.hpp
@@ -16,7 +16,7 @@ namespace math {
  * @return A vector of length K with elements linearly spaced between
  * low and high.
  */
-Eigen::VectorXd set_spaced_vector(int K, double low, double high) {
+inline Eigen::VectorXd set_spaced_vector(int K, double low, double high) {
   static const char* function = "set_spaced_vector";
   check_nonnegative(function, "length", K);
   check_finite(function, "low", low);

--- a/stan/math/prim/fun/set_spaced_vector.hpp
+++ b/stan/math/prim/fun/set_spaced_vector.hpp
@@ -1,0 +1,32 @@
+#ifndef STAN_MATH_PRIM_FUN_SET_SPACED_VECTOR_HPP
+#define STAN_MATH_PRIM_FUN_SET_SPACED_VECTOR_HPP
+
+#include <stan/math/prim/err.hpp>
+#include <stan/math/prim/fun/Eigen.hpp>
+
+namespace stan {
+namespace math {
+
+/**
+ * Return a vector of linearly spaced elements
+ *
+ * @param K length of the vector
+ * @param low smallest value
+ * @param high largest value
+ * @return A vector of length K with elements linearly spaced between
+ * low and high.
+ */
+Eigen::VectorXd set_spaced_vector(long K, double low, double high) {
+  static const char* function = "set_spaced_vector";
+  check_nonnegative(function, "length", K);
+  check_finite(function, "low", low);
+  check_finite(function, "high", high);
+  check_greater_or_equal(function, "high", high, low);
+
+  return Eigen::VectorXd::LinSpaced(K, low, high);
+}
+
+}  // namespace math
+}  // namespace stan
+
+#endif

--- a/stan/math/prim/fun/uniform_simplex.hpp
+++ b/stan/math/prim/fun/uniform_simplex.hpp
@@ -1,0 +1,24 @@
+#ifndef STAN_MATH_PRIM_FUN_UNIFORM_SIMPLEX_HPP
+#define STAN_MATH_PRIM_FUN_UNIFORM_SIMPLEX_HPP
+
+#include <stan/math/prim/err.hpp>
+#include <stan/math/prim/fun/Eigen.hpp>
+
+namespace stan {
+namespace math {
+
+/**
+ * Return a uniform simplex of length K
+ *
+ * @param K length of the simplex
+ * @return A vector of length K with all elements initialised to 1 / K.
+ */
+Eigen::VectorXd uniform_simplex(long K) {
+  check_nonnegative("uniform_simplex", "length", K);
+  return Eigen::VectorXd::Constant(K, 1.0 / K);
+}
+
+}  // namespace math
+}  // namespace stan
+
+#endif

--- a/stan/math/prim/fun/uniform_simplex.hpp
+++ b/stan/math/prim/fun/uniform_simplex.hpp
@@ -8,13 +8,15 @@ namespace stan {
 namespace math {
 
 /**
- * Return a uniform simplex of length K
+ * Return a uniform simplex of size K
  *
- * @param K length of the simplex
- * @return A vector of length K with all elements initialised to 1 / K.
+ * @param K size of the simplex
+ * @return A vector of size K with all elements initialised to 1 / K,
+ * so that their sum is equal to 1.
+ * @throw std::domain_error if K is not positive.
  */
 inline Eigen::VectorXd uniform_simplex(int K) {
-  check_nonnegative("uniform_simplex", "length", K);
+  check_positive("uniform_simplex", "size", K);
   return Eigen::VectorXd::Constant(K, 1.0 / K);
 }
 

--- a/stan/math/prim/fun/uniform_simplex.hpp
+++ b/stan/math/prim/fun/uniform_simplex.hpp
@@ -13,7 +13,7 @@ namespace math {
  * @param K length of the simplex
  * @return A vector of length K with all elements initialised to 1 / K.
  */
-Eigen::VectorXd uniform_simplex(int K) {
+inline Eigen::VectorXd uniform_simplex(int K) {
   check_nonnegative("uniform_simplex", "length", K);
   return Eigen::VectorXd::Constant(K, 1.0 / K);
 }

--- a/stan/math/prim/fun/uniform_simplex.hpp
+++ b/stan/math/prim/fun/uniform_simplex.hpp
@@ -13,7 +13,7 @@ namespace math {
  * @param K length of the simplex
  * @return A vector of length K with all elements initialised to 1 / K.
  */
-Eigen::VectorXd uniform_simplex(long K) {
+Eigen::VectorXd uniform_simplex(int K) {
   check_nonnegative("uniform_simplex", "length", K);
   return Eigen::VectorXd::Constant(K, 1.0 / K);
 }

--- a/stan/math/prim/fun/zeros_vector.hpp
+++ b/stan/math/prim/fun/zeros_vector.hpp
@@ -13,7 +13,7 @@ namespace math {
  * @param K length of the vector
  * @return A vector of length K with all elements initialised to 0.
  */
-Eigen::VectorXd zeros_vector(int K) {
+inline Eigen::VectorXd zeros_vector(int K) {
   check_nonnegative("ones_vector", "length", K);
   return Eigen::VectorXd::Zero(K);
 }

--- a/stan/math/prim/fun/zeros_vector.hpp
+++ b/stan/math/prim/fun/zeros_vector.hpp
@@ -10,11 +10,12 @@ namespace math {
 /**
  * Return a vector of zeros
  *
- * @param K length of the vector
- * @return A vector of length K with all elements initialised to 0.
+ * @param K size of the vector
+ * @return A vector of size K with all elements initialised to 0.
+ * @throw std::domain_error if K is negative.
  */
 inline Eigen::VectorXd zeros_vector(int K) {
-  check_nonnegative("ones_vector", "length", K);
+  check_nonnegative("ones_vector", "size", K);
   return Eigen::VectorXd::Zero(K);
 }
 

--- a/stan/math/prim/fun/zeros_vector.hpp
+++ b/stan/math/prim/fun/zeros_vector.hpp
@@ -1,0 +1,24 @@
+#ifndef STAN_MATH_PRIM_FUN_ZEROS_VECTOR_HPP
+#define STAN_MATH_PRIM_FUN_ZEROS_VECTOR_HPP
+
+#include <stan/math/prim/err.hpp>
+#include <stan/math/prim/fun/Eigen.hpp>
+
+namespace stan {
+namespace math {
+
+/**
+ * Return a vector of zeros
+ *
+ * @param K length of the vector
+ * @return A vector of length K with all elements initialised to 0.
+ */
+Eigen::VectorXd zeros_vector(long K) {
+  check_nonnegative("ones_vector", "length", K);
+  return Eigen::VectorXd::Zero(K);
+}
+
+}  // namespace math
+}  // namespace stan
+
+#endif

--- a/stan/math/prim/fun/zeros_vector.hpp
+++ b/stan/math/prim/fun/zeros_vector.hpp
@@ -13,7 +13,7 @@ namespace math {
  * @param K length of the vector
  * @return A vector of length K with all elements initialised to 0.
  */
-Eigen::VectorXd zeros_vector(long K) {
+Eigen::VectorXd zeros_vector(int K) {
   check_nonnegative("ones_vector", "length", K);
   return Eigen::VectorXd::Zero(K);
 }

--- a/test/unit/math/prim/fun/constant_vector_test.cpp
+++ b/test/unit/math/prim/fun/constant_vector_test.cpp
@@ -1,0 +1,38 @@
+#include <stan/math/prim.hpp>
+#include <gtest/gtest.h>
+#include <limits>
+
+TEST(MathFunctions, constant_vector) {
+  using Eigen::VectorXd;
+  using stan::math::constant_vector;
+
+  VectorXd u0 = constant_vector(0, 1);
+  EXPECT_EQ(0, u0.size());
+
+  double c = 3.14;
+  VectorXd u1 = constant_vector(1, c);
+  VectorXd v1(1);
+  v1 << c;
+  EXPECT_EQ(1, u1.size());
+  EXPECT_EQ(u1[0], v1[0]);
+
+  int k = 4;
+  VectorXd u2 = constant_vector(k, c);
+  VectorXd v2(k);
+  v2 << c, c, c, c;
+  EXPECT_EQ(k, u2.size());
+  for (int i = 0; i < k; i++) {
+    EXPECT_EQ(u2[i], v2[i]);
+  }
+}
+
+TEST(MathFunctions, constant_vector_throw) {
+  using stan::math::constant_vector;
+  double inf = std::numeric_limits<double>::infinity();
+  double nan = std::numeric_limits<double>::quiet_NaN();
+  double c = 3.14;
+
+  EXPECT_THROW(constant_vector(-1, c), std::domain_error);
+  EXPECT_THROW(constant_vector(inf, c), std::domain_error);
+  EXPECT_THROW(constant_vector(nan, c), std::domain_error);
+}

--- a/test/unit/math/prim/fun/constant_vector_test.cpp
+++ b/test/unit/math/prim/fun/constant_vector_test.cpp
@@ -1,4 +1,5 @@
 #include <stan/math/prim.hpp>
+#include <test/unit/math/prim/fun/expect_matrix_eq.hpp>
 #include <gtest/gtest.h>
 
 TEST(MathFunctions, constant_vector) {
@@ -9,25 +10,12 @@ TEST(MathFunctions, constant_vector) {
   EXPECT_EQ(0, u0.size());
 
   double c = 3.14;
-  VectorXd u1 = constant_vector(1, c);
-  VectorXd v1(1);
-  v1 << c;
-  EXPECT_EQ(1, u1.size());
-  EXPECT_EQ(u1[0], v1[0]);
-
-  int k = 4;
-  VectorXd u2 = constant_vector(k, c);
-  VectorXd v2(k);
-  v2 << c, c, c, c;
-  EXPECT_EQ(k, u2.size());
-  for (int i = 0; i < k; i++) {
-    EXPECT_EQ(u2[i], v2[i]);
+  for (int K = 1; K < 5; K++) {
+    VectorXd v = VectorXd::Constant(K, c);
+    expect_matrix_eq(v, constant_vector(K, c));
   }
 }
 
 TEST(MathFunctions, constant_vector_throw) {
-  using stan::math::constant_vector;
-  double c = 3.14;
-
-  EXPECT_THROW(constant_vector(-1, c), std::domain_error);
+  EXPECT_THROW(stan::math::constant_vector(-1, 3.14), std::domain_error);
 }

--- a/test/unit/math/prim/fun/constant_vector_test.cpp
+++ b/test/unit/math/prim/fun/constant_vector_test.cpp
@@ -1,6 +1,5 @@
 #include <stan/math/prim.hpp>
 #include <gtest/gtest.h>
-#include <limits>
 
 TEST(MathFunctions, constant_vector) {
   using Eigen::VectorXd;
@@ -28,11 +27,7 @@ TEST(MathFunctions, constant_vector) {
 
 TEST(MathFunctions, constant_vector_throw) {
   using stan::math::constant_vector;
-  double inf = std::numeric_limits<double>::infinity();
-  double nan = std::numeric_limits<double>::quiet_NaN();
   double c = 3.14;
 
   EXPECT_THROW(constant_vector(-1, c), std::domain_error);
-  EXPECT_THROW(constant_vector(inf, c), std::domain_error);
-  EXPECT_THROW(constant_vector(nan, c), std::domain_error);
 }

--- a/test/unit/math/prim/fun/identity_matrix_test.cpp
+++ b/test/unit/math/prim/fun/identity_matrix_test.cpp
@@ -1,4 +1,5 @@
 #include <stan/math/prim.hpp>
+#include <test/unit/math/prim/fun/expect_matrix_eq.hpp>
 #include <gtest/gtest.h>
 
 TEST(MathFunctions, identity_matrix) {
@@ -9,28 +10,12 @@ TEST(MathFunctions, identity_matrix) {
   EXPECT_EQ(0, u0.rows());
   EXPECT_EQ(0, u0.cols());
 
-  MatrixXd u1 = identity_matrix(1);
-  MatrixXd m1(1, 1);
-  m1 << 1;
-
-  EXPECT_EQ(1, u1.rows());
-  EXPECT_EQ(1, u1.cols());
-  EXPECT_EQ(u1(0), m1(0));
-
-  int K = 3;
-  MatrixXd u2 = identity_matrix(K);
-  MatrixXd m2(K, K);
-  m2 << 1, 0, 0, 0, 1, 0, 0, 0, 1;
-
-  EXPECT_EQ(K, u2.rows());
-  EXPECT_EQ(K, u2.cols());
-  for (int i = 0; i < m2.size(); i++) {
-    EXPECT_EQ(u2(i), m2(i));
+  for (int K = 1; K < 5; K++) {
+    MatrixXd m = Eigen::MatrixXd::Identity(K, K);
+    expect_matrix_eq(m, identity_matrix(K));
   }
 }
 
 TEST(MathFunctions, identity_matrix_throw) {
-  using stan::math::identity_matrix;
-
-  EXPECT_THROW(identity_matrix(-1), std::domain_error);
+  EXPECT_THROW(stan::math::identity_matrix(-1), std::domain_error);
 }

--- a/test/unit/math/prim/fun/identity_matrix_test.cpp
+++ b/test/unit/math/prim/fun/identity_matrix_test.cpp
@@ -1,0 +1,41 @@
+#include <stan/math/prim.hpp>
+#include <gtest/gtest.h>
+#include <limits>
+
+TEST(MathFunctions, identity_matrix) {
+  using Eigen::MatrixXd;
+  using stan::math::identity_matrix;
+
+  MatrixXd u0 = identity_matrix(0);
+  EXPECT_EQ(0, u0.rows());
+  EXPECT_EQ(0, u0.cols());
+
+  MatrixXd u1 = identity_matrix(1);
+  MatrixXd m1(1, 1);
+  m1 << 1;
+
+  EXPECT_EQ(1, u1.rows());
+  EXPECT_EQ(1, u1.cols());
+  EXPECT_EQ(u1(0), m1(0));
+
+  int K = 3;
+  MatrixXd u2 = identity_matrix(K);
+  MatrixXd m2(K, K);
+  m2 << 1, 0, 0, 0, 1, 0, 0, 0, 1;
+
+  EXPECT_EQ(K, u2.rows());
+  EXPECT_EQ(K, u2.cols());
+  for (int i = 0; i < m2.size(); i++) {
+    EXPECT_EQ(u2(i), m2(i));
+  }
+}
+
+TEST(MathFunctions, identity_matrix_throw) {
+  using stan::math::identity_matrix;
+  double inf = std::numeric_limits<double>::infinity();
+  double nan = std::numeric_limits<double>::quiet_NaN();
+
+  EXPECT_THROW(identity_matrix(-1), std::domain_error);
+  EXPECT_THROW(identity_matrix(inf), std::domain_error);
+  EXPECT_THROW(identity_matrix(nan), std::domain_error);
+}

--- a/test/unit/math/prim/fun/identity_matrix_test.cpp
+++ b/test/unit/math/prim/fun/identity_matrix_test.cpp
@@ -1,6 +1,5 @@
 #include <stan/math/prim.hpp>
 #include <gtest/gtest.h>
-#include <limits>
 
 TEST(MathFunctions, identity_matrix) {
   using Eigen::MatrixXd;
@@ -32,10 +31,6 @@ TEST(MathFunctions, identity_matrix) {
 
 TEST(MathFunctions, identity_matrix_throw) {
   using stan::math::identity_matrix;
-  double inf = std::numeric_limits<double>::infinity();
-  double nan = std::numeric_limits<double>::quiet_NaN();
 
   EXPECT_THROW(identity_matrix(-1), std::domain_error);
-  EXPECT_THROW(identity_matrix(inf), std::domain_error);
-  EXPECT_THROW(identity_matrix(nan), std::domain_error);
 }

--- a/test/unit/math/prim/fun/one_hot_vector_test.cpp
+++ b/test/unit/math/prim/fun/one_hot_vector_test.cpp
@@ -1,0 +1,46 @@
+#include <stan/math/prim.hpp>
+#include <gtest/gtest.h>
+#include <limits>
+
+TEST(MathFunctions, one_hot_vector) {
+  using Eigen::VectorXd;
+  using stan::math::one_hot_vector;
+
+  int K = 4;
+  VectorXd u1 = one_hot_vector(K, 1);
+  VectorXd v1(K);
+  v1 << 1, 0, 0, 0;
+
+  EXPECT_EQ(K, u1.size());
+  for (int i = 0; i < K; i++) {
+    EXPECT_EQ(u1[i], v1[i]);
+  }
+
+  int k = 4;
+  VectorXd u2 = one_hot_vector(K, k);
+  VectorXd v2(K);
+  v2 << 0, 0, 0, 1;
+
+  EXPECT_EQ(k, u2.size());
+  for (int i = 0; i < k; i++) {
+    EXPECT_EQ(u2[i], v2[i]);
+  }
+}
+
+TEST(MathFunctions, one_hot_vector_throw) {
+  using stan::math::one_hot_vector;
+  double inf = std::numeric_limits<double>::infinity();
+  double nan = std::numeric_limits<double>::quiet_NaN();
+  int K = 5;
+  int k = 2;
+
+  EXPECT_THROW(one_hot_vector(K, K + 1), std::domain_error);
+  EXPECT_THROW(one_hot_vector(K, 0), std::domain_error);
+  EXPECT_THROW(one_hot_vector(K, -1), std::domain_error);
+  EXPECT_THROW(one_hot_vector(K, inf), std::domain_error);
+  EXPECT_THROW(one_hot_vector(K, nan), std::domain_error);
+
+  EXPECT_THROW(one_hot_vector(-1, k), std::domain_error);
+  EXPECT_THROW(one_hot_vector(inf, k), std::domain_error);
+  EXPECT_THROW(one_hot_vector(nan, k), std::domain_error);
+}

--- a/test/unit/math/prim/fun/one_hot_vector_test.cpp
+++ b/test/unit/math/prim/fun/one_hot_vector_test.cpp
@@ -1,6 +1,5 @@
 #include <stan/math/prim.hpp>
 #include <gtest/gtest.h>
-#include <limits>
 
 TEST(MathFunctions, one_hot_vector) {
   using Eigen::VectorXd;
@@ -29,18 +28,11 @@ TEST(MathFunctions, one_hot_vector) {
 
 TEST(MathFunctions, one_hot_vector_throw) {
   using stan::math::one_hot_vector;
-  double inf = std::numeric_limits<double>::infinity();
-  double nan = std::numeric_limits<double>::quiet_NaN();
   int K = 5;
   int k = 2;
 
+  EXPECT_THROW(one_hot_vector(-1, k), std::domain_error);
   EXPECT_THROW(one_hot_vector(K, K + 1), std::domain_error);
   EXPECT_THROW(one_hot_vector(K, 0), std::domain_error);
   EXPECT_THROW(one_hot_vector(K, -1), std::domain_error);
-  EXPECT_THROW(one_hot_vector(K, inf), std::domain_error);
-  EXPECT_THROW(one_hot_vector(K, nan), std::domain_error);
-
-  EXPECT_THROW(one_hot_vector(-1, k), std::domain_error);
-  EXPECT_THROW(one_hot_vector(inf, k), std::domain_error);
-  EXPECT_THROW(one_hot_vector(nan, k), std::domain_error);
 }

--- a/test/unit/math/prim/fun/one_hot_vector_test.cpp
+++ b/test/unit/math/prim/fun/one_hot_vector_test.cpp
@@ -1,28 +1,17 @@
 #include <stan/math/prim.hpp>
+#include <test/unit/math/prim/fun/expect_matrix_eq.hpp>
 #include <gtest/gtest.h>
 
 TEST(MathFunctions, one_hot_vector) {
   using Eigen::VectorXd;
   using stan::math::one_hot_vector;
 
-  int K = 4;
-  VectorXd u1 = one_hot_vector(K, 1);
-  VectorXd v1(K);
-  v1 << 1, 0, 0, 0;
-
-  EXPECT_EQ(K, u1.size());
-  for (int i = 0; i < K; i++) {
-    EXPECT_EQ(u1[i], v1[i]);
-  }
-
-  int k = 4;
-  VectorXd u2 = one_hot_vector(K, k);
-  VectorXd v2(K);
-  v2 << 0, 0, 0, 1;
-
-  EXPECT_EQ(k, u2.size());
-  for (int i = 0; i < k; i++) {
-    EXPECT_EQ(u2[i], v2[i]);
+  for (int K = 1; K < 5; K++) {
+    for (int k = 1; k <= K; k++) {
+      Eigen::VectorXd y = Eigen::VectorXd::Zero(K);
+      y[k - 1] = 1;
+      expect_matrix_eq(y, one_hot_vector(K, k));
+    }
   }
 }
 
@@ -32,6 +21,7 @@ TEST(MathFunctions, one_hot_vector_throw) {
   int k = 2;
 
   EXPECT_THROW(one_hot_vector(-1, k), std::domain_error);
+  EXPECT_THROW(one_hot_vector(0, k), std::domain_error);
   EXPECT_THROW(one_hot_vector(K, K + 1), std::domain_error);
   EXPECT_THROW(one_hot_vector(K, 0), std::domain_error);
   EXPECT_THROW(one_hot_vector(K, -1), std::domain_error);

--- a/test/unit/math/prim/fun/ones_vector_test.cpp
+++ b/test/unit/math/prim/fun/ones_vector_test.cpp
@@ -1,4 +1,5 @@
 #include <stan/math/prim.hpp>
+#include <test/unit/math/prim/fun/expect_matrix_eq.hpp>
 #include <gtest/gtest.h>
 
 TEST(MathFunctions, ones_vector) {
@@ -8,24 +9,12 @@ TEST(MathFunctions, ones_vector) {
   VectorXd u0 = ones_vector(0);
   EXPECT_EQ(0, u0.size());
 
-  VectorXd u1 = ones_vector(1);
-  VectorXd v1(1);
-  v1 << 1;
-  EXPECT_EQ(1, u1.size());
-  EXPECT_EQ(u1[0], v1[0]);
-
-  int K = 4;
-  VectorXd u2 = ones_vector(K);
-  VectorXd v2(K);
-  v2 << 1, 1, 1, 1;
-  EXPECT_EQ(K, u2.size());
-  for (int i = 0; i < K; i++) {
-    EXPECT_EQ(u2[i], v2[i]);
+  for (int K = 1; K < 5; K++) {
+    Eigen::VectorXd y = Eigen::VectorXd::Constant(K, 1);
+    expect_matrix_eq(y, ones_vector(K));
   }
 }
 
 TEST(MathFunctions, ones_vector_throw) {
-  using stan::math::ones_vector;
-
-  EXPECT_THROW(ones_vector(-1), std::domain_error);
+  EXPECT_THROW(stan::math::ones_vector(-1), std::domain_error);
 }

--- a/test/unit/math/prim/fun/ones_vector_test.cpp
+++ b/test/unit/math/prim/fun/ones_vector_test.cpp
@@ -1,0 +1,36 @@
+#include <stan/math/prim.hpp>
+#include <gtest/gtest.h>
+#include <limits>
+
+TEST(MathFunctions, ones_vector) {
+  using Eigen::VectorXd;
+  using stan::math::ones_vector;
+
+  VectorXd u0 = ones_vector(0);
+  EXPECT_EQ(0, u0.size());
+
+  VectorXd u1 = ones_vector(1);
+  VectorXd v1(1);
+  v1 << 1;
+  EXPECT_EQ(1, u1.size());
+  EXPECT_EQ(u1[0], v1[0]);
+
+  int K = 4;
+  VectorXd u2 = ones_vector(K);
+  VectorXd v2(K);
+  v2 << 1, 1, 1, 1;
+  EXPECT_EQ(K, u2.size());
+  for (int i = 0; i < K; i++) {
+    EXPECT_EQ(u2[i], v2[i]);
+  }
+}
+
+TEST(MathFunctions, ones_vector_throw) {
+  using stan::math::ones_vector;
+  double inf = std::numeric_limits<double>::infinity();
+  double nan = std::numeric_limits<double>::quiet_NaN();
+
+  EXPECT_THROW(ones_vector(-1), std::domain_error);
+  EXPECT_THROW(ones_vector(inf), std::domain_error);
+  EXPECT_THROW(ones_vector(nan), std::domain_error);
+}

--- a/test/unit/math/prim/fun/ones_vector_test.cpp
+++ b/test/unit/math/prim/fun/ones_vector_test.cpp
@@ -1,6 +1,5 @@
 #include <stan/math/prim.hpp>
 #include <gtest/gtest.h>
-#include <limits>
 
 TEST(MathFunctions, ones_vector) {
   using Eigen::VectorXd;
@@ -27,10 +26,6 @@ TEST(MathFunctions, ones_vector) {
 
 TEST(MathFunctions, ones_vector_throw) {
   using stan::math::ones_vector;
-  double inf = std::numeric_limits<double>::infinity();
-  double nan = std::numeric_limits<double>::quiet_NaN();
 
   EXPECT_THROW(ones_vector(-1), std::domain_error);
-  EXPECT_THROW(ones_vector(inf), std::domain_error);
-  EXPECT_THROW(ones_vector(nan), std::domain_error);
 }

--- a/test/unit/math/prim/fun/set_spaced_vector_test.cpp
+++ b/test/unit/math/prim/fun/set_spaced_vector_test.cpp
@@ -42,8 +42,6 @@ TEST(MathFunctions, set_spaced_vector_throw) {
   double high = 6;
 
   EXPECT_THROW(set_spaced_vector(-1, low, high), std::domain_error);
-  EXPECT_THROW(set_spaced_vector(inf, low, high), std::domain_error);
-  EXPECT_THROW(set_spaced_vector(nan, low, high), std::domain_error);
 
   EXPECT_THROW(set_spaced_vector(K, inf, high), std::domain_error);
   EXPECT_THROW(set_spaced_vector(K, nan, high), std::domain_error);

--- a/test/unit/math/prim/fun/set_spaced_vector_test.cpp
+++ b/test/unit/math/prim/fun/set_spaced_vector_test.cpp
@@ -9,27 +9,29 @@ TEST(MathFunctions, set_spaced_vector) {
   VectorXd u0 = set_spaced_vector(0, 1, 2);
   EXPECT_EQ(0, u0.size());
 
+  double low = 1;
+  double high = 5;
+  VectorXd u11 = set_spaced_vector(1, low, high);
+  EXPECT_EQ(1, u11.size());
+  EXPECT_FLOAT_EQ(high, u11[0]);
+
   int K = 5;
-  double low1 = 1;
-  double high1 = 5;
-  VectorXd u1 = set_spaced_vector(K, low1, high1);
+  VectorXd u1 = set_spaced_vector(K, 1, 5);
   VectorXd v1(K);
   v1 << 1, 2, 3, 4, 5;
 
   EXPECT_EQ(K, u1.size());
   for (int i = 0; i < K; i++) {
-    EXPECT_EQ(u1[i], v1[i]);
+    EXPECT_FLOAT_EQ(u1[i], v1[i]);
   }
 
-  double low2 = -2;
-  double high2 = 2;
-  VectorXd u2 = set_spaced_vector(K, low2, high2);
+  VectorXd u2 = set_spaced_vector(K, -2, 2);
   VectorXd v2(K);
   v2 << -2, -1, 0, 1, 2;
 
   EXPECT_EQ(K, u2.size());
   for (int i = 0; i < K; i++) {
-    EXPECT_EQ(u2[i], v2[i]);
+    EXPECT_FLOAT_EQ(u2[i], v2[i]);
   }
 }
 

--- a/test/unit/math/prim/fun/set_spaced_vector_test.cpp
+++ b/test/unit/math/prim/fun/set_spaced_vector_test.cpp
@@ -1,0 +1,54 @@
+#include <stan/math/prim.hpp>
+#include <gtest/gtest.h>
+#include <limits>
+
+TEST(MathFunctions, set_spaced_vector) {
+  using Eigen::VectorXd;
+  using stan::math::set_spaced_vector;
+
+  VectorXd u0 = set_spaced_vector(0, 1, 2);
+  EXPECT_EQ(0, u0.size());
+
+  int K = 5;
+  double low1 = 1;
+  double high1 = 5;
+  VectorXd u1 = set_spaced_vector(K, low1, high1);
+  VectorXd v1(K);
+  v1 << 1, 2, 3, 4, 5;
+
+  EXPECT_EQ(K, u1.size());
+  for (int i = 0; i < K; i++) {
+    EXPECT_EQ(u1[i], v1[i]);
+  }
+
+  double low2 = -2;
+  double high2 = 2;
+  VectorXd u2 = set_spaced_vector(K, low2, high2);
+  VectorXd v2(K);
+  v2 << -2, -1, 0, 1, 2;
+
+  EXPECT_EQ(K, u2.size());
+  for (int i = 0; i < K; i++) {
+    EXPECT_EQ(u2[i], v2[i]);
+  }
+}
+
+TEST(MathFunctions, set_spaced_vector_throw) {
+  using stan::math::set_spaced_vector;
+  double inf = std::numeric_limits<double>::infinity();
+  double nan = std::numeric_limits<double>::quiet_NaN();
+  int K = 5;
+  double low = -2;
+  double high = 6;
+
+  EXPECT_THROW(set_spaced_vector(-1, low, high), std::domain_error);
+  EXPECT_THROW(set_spaced_vector(inf, low, high), std::domain_error);
+  EXPECT_THROW(set_spaced_vector(nan, low, high), std::domain_error);
+
+  EXPECT_THROW(set_spaced_vector(K, inf, high), std::domain_error);
+  EXPECT_THROW(set_spaced_vector(K, nan, high), std::domain_error);
+
+  EXPECT_THROW(set_spaced_vector(K, low, low - 1), std::domain_error);
+  EXPECT_THROW(set_spaced_vector(K, low, inf), std::domain_error);
+  EXPECT_THROW(set_spaced_vector(K, low, nan), std::domain_error);
+}

--- a/test/unit/math/prim/fun/uniform_simplex_test.cpp
+++ b/test/unit/math/prim/fun/uniform_simplex_test.cpp
@@ -1,0 +1,36 @@
+#include <stan/math/prim.hpp>
+#include <gtest/gtest.h>
+#include <limits>
+
+TEST(MathFunctions, uniform_simplex) {
+  using Eigen::VectorXd;
+  using stan::math::uniform_simplex;
+
+  VectorXd u0 = uniform_simplex(0);
+  EXPECT_EQ(0, u0.size());
+
+  VectorXd u1 = uniform_simplex(1);
+  VectorXd v1(1);
+  v1 << 1;
+  EXPECT_EQ(1, u1.size());
+  EXPECT_EQ(u1[0], v1[0]);
+
+  int K = 4;
+  VectorXd u2 = uniform_simplex(K);
+  VectorXd v2(K);
+  v2 << 0.25, 0.25, 0.25, 0.25;
+  EXPECT_EQ(K, u2.size());
+  for (int i = 0; i < K; i++) {
+    EXPECT_EQ(u2[i], v2[i]);
+  }
+}
+
+TEST(MathFunctions, uniform_simplex_throw) {
+  using stan::math::uniform_simplex;
+  double inf = std::numeric_limits<double>::infinity();
+  double nan = std::numeric_limits<double>::quiet_NaN();
+
+  EXPECT_THROW(uniform_simplex(-1), std::domain_error);
+  EXPECT_THROW(uniform_simplex(inf), std::domain_error);
+  EXPECT_THROW(uniform_simplex(nan), std::domain_error);
+}

--- a/test/unit/math/prim/fun/uniform_simplex_test.cpp
+++ b/test/unit/math/prim/fun/uniform_simplex_test.cpp
@@ -1,6 +1,5 @@
 #include <stan/math/prim.hpp>
 #include <gtest/gtest.h>
-#include <limits>
 
 TEST(MathFunctions, uniform_simplex) {
   using Eigen::VectorXd;
@@ -27,10 +26,6 @@ TEST(MathFunctions, uniform_simplex) {
 
 TEST(MathFunctions, uniform_simplex_throw) {
   using stan::math::uniform_simplex;
-  double inf = std::numeric_limits<double>::infinity();
-  double nan = std::numeric_limits<double>::quiet_NaN();
 
   EXPECT_THROW(uniform_simplex(-1), std::domain_error);
-  EXPECT_THROW(uniform_simplex(inf), std::domain_error);
-  EXPECT_THROW(uniform_simplex(nan), std::domain_error);
 }

--- a/test/unit/math/prim/fun/uniform_simplex_test.cpp
+++ b/test/unit/math/prim/fun/uniform_simplex_test.cpp
@@ -1,31 +1,19 @@
 #include <stan/math/prim.hpp>
+#include <test/unit/math/prim/fun/expect_matrix_eq.hpp>
 #include <gtest/gtest.h>
 
 TEST(MathFunctions, uniform_simplex) {
   using Eigen::VectorXd;
   using stan::math::uniform_simplex;
 
-  VectorXd u0 = uniform_simplex(0);
-  EXPECT_EQ(0, u0.size());
-
-  VectorXd u1 = uniform_simplex(1);
-  VectorXd v1(1);
-  v1 << 1;
-  EXPECT_EQ(1, u1.size());
-  EXPECT_EQ(u1[0], v1[0]);
-
-  int K = 4;
-  VectorXd u2 = uniform_simplex(K);
-  VectorXd v2(K);
-  v2 << 0.25, 0.25, 0.25, 0.25;
-  EXPECT_EQ(K, u2.size());
-  for (int i = 0; i < K; i++) {
-    EXPECT_EQ(u2[i], v2[i]);
+  for (int K = 1; K < 5; K++) {
+    Eigen::VectorXd v = Eigen::VectorXd::Constant(K, 1.0 / K);
+    expect_matrix_eq(v, uniform_simplex(K));
   }
 }
 
 TEST(MathFunctions, uniform_simplex_throw) {
   using stan::math::uniform_simplex;
-
   EXPECT_THROW(uniform_simplex(-1), std::domain_error);
+  EXPECT_THROW(uniform_simplex(0), std::domain_error);
 }

--- a/test/unit/math/prim/fun/zeros_vector_test.cpp
+++ b/test/unit/math/prim/fun/zeros_vector_test.cpp
@@ -1,0 +1,36 @@
+#include <stan/math/prim.hpp>
+#include <gtest/gtest.h>
+#include <limits>
+
+TEST(MathFunctions, zeros_vector) {
+  using Eigen::VectorXd;
+  using stan::math::zeros_vector;
+
+  VectorXd u0 = zeros_vector(0);
+  EXPECT_EQ(0, u0.size());
+
+  VectorXd u1 = zeros_vector(1);
+  VectorXd v1(1);
+  v1 << 0;
+  EXPECT_EQ(1, u1.size());
+  EXPECT_EQ(u1[0], v1[0]);
+
+  int K = 4;
+  VectorXd u2 = zeros_vector(K);
+  VectorXd v2(K);
+  v2 << 0, 0, 0, 0;
+  EXPECT_EQ(K, u2.size());
+  for (int i = 0; i < K; i++) {
+    EXPECT_EQ(u2[i], v2[i]);
+  }
+}
+
+TEST(MathFunctions, zeros_vector_throw) {
+  using stan::math::zeros_vector;
+  double inf = std::numeric_limits<double>::infinity();
+  double nan = std::numeric_limits<double>::quiet_NaN();
+
+  EXPECT_THROW(zeros_vector(-1), std::domain_error);
+  EXPECT_THROW(zeros_vector(inf), std::domain_error);
+  EXPECT_THROW(zeros_vector(nan), std::domain_error);
+}

--- a/test/unit/math/prim/fun/zeros_vector_test.cpp
+++ b/test/unit/math/prim/fun/zeros_vector_test.cpp
@@ -1,4 +1,5 @@
 #include <stan/math/prim.hpp>
+#include <test/unit/math/prim/fun/expect_matrix_eq.hpp>
 #include <gtest/gtest.h>
 
 TEST(MathFunctions, zeros_vector) {
@@ -8,24 +9,12 @@ TEST(MathFunctions, zeros_vector) {
   VectorXd u0 = zeros_vector(0);
   EXPECT_EQ(0, u0.size());
 
-  VectorXd u1 = zeros_vector(1);
-  VectorXd v1(1);
-  v1 << 0;
-  EXPECT_EQ(1, u1.size());
-  EXPECT_EQ(u1[0], v1[0]);
-
-  int K = 4;
-  VectorXd u2 = zeros_vector(K);
-  VectorXd v2(K);
-  v2 << 0, 0, 0, 0;
-  EXPECT_EQ(K, u2.size());
-  for (int i = 0; i < K; i++) {
-    EXPECT_EQ(u2[i], v2[i]);
+  for (int K = 1; K < 5; K++) {
+    Eigen::VectorXd v = Eigen::VectorXd::Zero(K);
+    expect_matrix_eq(v, zeros_vector(K));
   }
 }
 
 TEST(MathFunctions, zeros_vector_throw) {
-  using stan::math::zeros_vector;
-
-  EXPECT_THROW(zeros_vector(-1), std::domain_error);
+  EXPECT_THROW(stan::math::zeros_vector(-1), std::domain_error);
 }

--- a/test/unit/math/prim/fun/zeros_vector_test.cpp
+++ b/test/unit/math/prim/fun/zeros_vector_test.cpp
@@ -1,6 +1,5 @@
 #include <stan/math/prim.hpp>
 #include <gtest/gtest.h>
-#include <limits>
 
 TEST(MathFunctions, zeros_vector) {
   using Eigen::VectorXd;
@@ -27,10 +26,6 @@ TEST(MathFunctions, zeros_vector) {
 
 TEST(MathFunctions, zeros_vector_throw) {
   using stan::math::zeros_vector;
-  double inf = std::numeric_limits<double>::infinity();
-  double nan = std::numeric_limits<double>::quiet_NaN();
 
   EXPECT_THROW(zeros_vector(-1), std::domain_error);
-  EXPECT_THROW(zeros_vector(inf), std::domain_error);
-  EXPECT_THROW(zeros_vector(nan), std::domain_error);
 }


### PR DESCRIPTION
## Summary

This adds the following function signatures (well the underlying code to implement them):
- `vector constant_vector(int K, real c)`
- `vector one_hot_vector(int K, int k)`
- `vector set_spaced_vector(int K, real low, real high)`
- `vector uniform_simplex(int K)`
- `vector zeros_vector(int K)`
- `matrix identity_matrix(int K)`

This departs slightly from the signatures mentioned in #692 for `constant_vector`, `one_hot_vector` and `set_spaced_vector`, in that `K` is always the first parameter, which is also what Eigen uses.

## Tests

Added.

## Side Effects

None.

## Checklist

- [X] Math issue #692

- [X] Copyright holder: Marco Colombo

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [X] the new changes are tested
