### PR TITLE
Lift some check_foo functions out of loops.

### DIFF
--- a/stan/math/prim/err/check_cholesky_factor.hpp
+++ b/stan/math/prim/err/check_cholesky_factor.hpp
@@ -32,10 +32,7 @@ inline void check_cholesky_factor(
                       y.rows());
   check_positive(function, "columns of Cholesky factor", y.cols());
   check_lower_triangular(function, name, y);
-  for (int i = 0; i < y.cols(); ++i) {
-    // FIXME:  should report row
-    check_positive(function, name, y(i, i));
-  }
+  check_positive(function, name, y.diagonal());
 }
 
 }  // namespace math

--- a/stan/math/prim/err/check_cholesky_factor_corr.hpp
+++ b/stan/math/prim/err/check_cholesky_factor_corr.hpp
@@ -33,9 +33,7 @@ void check_cholesky_factor_corr(
     const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>& y) {
   check_square(function, name, y);
   check_lower_triangular(function, name, y);
-  for (int i = 0; i < y.rows(); ++i) {
-    check_positive(function, name, y(i, i));
-  }
+  check_positive(function, name, y.diagonal());
   for (int i = 0; i < y.rows(); ++i) {
     Eigen::Matrix<T_y, Eigen::Dynamic, 1> y_i = y.row(i).transpose();
     check_unit_vector(function, name, y_i);

--- a/stan/math/prim/fun/corr_matrix_free.hpp
+++ b/stan/math/prim/fun/corr_matrix_free.hpp
@@ -50,10 +50,8 @@ Eigen::Matrix<T, Eigen::Dynamic, 1> corr_matrix_free(
     throw_domain_error("corr_matrix_free", "factor_cov_matrix failed on y", y,
                        "");
   }
-  for (size_type i = 0; i < k; ++i) {
-    check_bounded("corr_matrix_free", "log(sd)", sds[i], -CONSTRAINT_TOLERANCE,
-                  CONSTRAINT_TOLERANCE);
-  }
+  check_bounded("corr_matrix_free", "log(sd)", sds, -CONSTRAINT_TOLERANCE,
+                CONSTRAINT_TOLERANCE);
   return x.matrix();
 }
 

--- a/stan/math/prim/fun/cov_matrix_free.hpp
+++ b/stan/math/prim/fun/cov_matrix_free.hpp
@@ -40,9 +40,7 @@ Eigen::Matrix<T, Eigen::Dynamic, 1> cov_matrix_free(
 
   using std::log;
   int K = y.rows();
-  for (int k = 0; k < K; ++k) {
-    check_positive("cov_matrix_free", "y", y(k, k));
-  }
+  check_positive("cov_matrix_free", "y", y.diagonal());
   Eigen::Matrix<T, Eigen::Dynamic, 1> x((K * (K + 1)) / 2);
   // FIXME: see Eigen LDLT for rank-revealing version -- use that
   // even if less efficient?

--- a/stan/math/prim/prob/categorical_logit_lpmf.hpp
+++ b/stan/math/prim/prob/categorical_logit_lpmf.hpp
@@ -41,10 +41,8 @@ return_type_t<T_prob> categorical_logit_lpmf(
     const Eigen::Matrix<T_prob, Eigen::Dynamic, 1>& beta) {
   static const char* function = "categorical_logit_lpmf";
 
-  for (const auto& x : ns) {
-    check_bounded(function, "categorical outcome out of support", x, 1,
-                  beta.size());
-  }
+  check_bounded(function, "categorical outcome out of support", ns, 1,
+                beta.size());
   check_finite(function, "log odds parameter", beta);
 
   if (!include_summand<propto, T_prob>::value) {

--- a/stan/math/prim/prob/categorical_lpmf.hpp
+++ b/stan/math/prim/prob/categorical_lpmf.hpp
@@ -47,11 +47,7 @@ return_type_t<T_prob> categorical_lpmf(
 
   int lb = 1;
 
-  for (size_t i = 0; i < ns.size(); ++i) {
-    check_bounded(function, "element of outcome array", ns[i], lb,
-                  theta.size());
-  }
-
+  check_bounded(function, "element of outcome array", ns, lb, theta.size());
   check_simplex(function, "Probabilities parameter", theta);
 
   if (!include_summand<propto, T_prob>::value) {

--- a/stan/math/prim/prob/ordered_logistic_lpmf.hpp
+++ b/stan/math/prim/prob/ordered_logistic_lpmf.hpp
@@ -93,10 +93,8 @@ return_type_t<T_loc, T_cut> ordered_logistic_lpmf(const T_y& y,
                      size_c_old);
   }
 
-  for (int n = 0; n < N; n++) {
-    check_bounded(function, "Random variable", y_vec[n], 1, K);
-    check_finite(function, "Location parameter", lam_vec[n]);
-  }
+  check_bounded(function, "Random variable", y, 1, K);
+  check_finite(function, "Location parameter", lambda);
 
   for (int i = 0; i < C_l; i++) {
     check_ordered(function, "Cut-points", c_vec[i]);

--- a/stan/math/prim/prob/ordered_logistic_rng.hpp
+++ b/stan/math/prim/prob/ordered_logistic_rng.hpp
@@ -19,9 +19,7 @@ inline int ordered_logistic_rng(
 
   check_finite(function, "Location parameter", eta);
   check_greater(function, "Size of cut points parameter", c.size(), 0);
-  for (int i = 1; i < c.size(); ++i) {
-    check_greater(function, "Cut points parameter", c(i), c(i - 1));
-  }
+  check_ordered(function, "Cut points parameter", c);
   check_finite(function, "Cut points parameter", c(c.size() - 1));
   check_finite(function, "Cut points parameter", c(0));
 

--- a/test/unit/math/prim/fun/cov_matrix_transform_test.cpp
+++ b/test/unit/math/prim/fun/cov_matrix_transform_test.cpp
@@ -34,9 +34,10 @@ TEST(prob_transform, cov_matrix_free_exception) {
   EXPECT_THROW(stan::math::cov_matrix_free(y), std::invalid_argument);
   y.resize(1, 2);
   EXPECT_THROW(stan::math::cov_matrix_free(y), std::invalid_argument);
-
   y.resize(2, 2);
   y << 0, 0, 0, 0;
+  EXPECT_THROW(stan::math::cov_matrix_free(y), std::domain_error);
+  y << 1, 0, 0, -1;
   EXPECT_THROW(stan::math::cov_matrix_free(y), std::domain_error);
 }
 TEST(covMatrixTransform, symmetry) {

--- a/test/unit/math/prim/prob/ordered_logistic_test.cpp
+++ b/test/unit/math/prim/prob/ordered_logistic_test.cpp
@@ -192,6 +192,10 @@ TEST(ProbDistributionOrderedLogistic, error_check) {
   c << -inf, 2.0, -5, inf;
   EXPECT_THROW(stan::math::ordered_logistic_rng(4.0, c, rng),
                std::domain_error);
+
+  c << -2, 5, 2.0, 10;
+  EXPECT_THROW(stan::math::ordered_logistic_rng(4.0, c, rng),
+               std::domain_error);
 }
 
 TEST(ProbDistributionOrderedLogistic, chiSquareGoodnessFitTest) {


### PR DESCRIPTION
## Summary

I found a few instances of:
```
for (i=...)
    check_foo(...x[i]...);
```

That can be replaced by:
```
check_foo(x)
```

This slightly improves the resulting error messages.

Closes #1625.

## Tests

test/unit/math/prim/err/check_cholesky_factor_test.cpp
test/unit/math/prim/err/check_cholesky_corr_factor_test.cpp
test/unit/math/prim/fun/corr_matrix_transform_test.cpp
test/unit/math/prim/fun/cov_matrix_transform_test.cpp
test/unit/math/prim/prob/categorical_test.cpp
test/unit/math/prim/prob/categorical_logit_test.cpp
test/unit/math/prim/prob/ordered_logistic_test.cpp

## Side Effects

No.

## Checklist

- [X] Math issue #1625

- [X] Copyright holder: Peter Wicks Stringfield

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [X] the new changes are tested
