### PR TITLE
Eliminate unnecessary loop.

### DIFF
--- a/stan/math/prim/prob/gaussian_dlm_obs_lpdf.hpp
+++ b/stan/math/prim/prob/gaussian_dlm_obs_lpdf.hpp
@@ -112,15 +112,8 @@ gaussian_dlm_obs_lpdf(
     Eigen::Matrix<T_lp, Eigen::Dynamic, 1> m(n);
     Eigen::Matrix<T_lp, Eigen::Dynamic, Eigen::Dynamic> C(n, n);
 
-    // TODO(anyone): how to recast matrices
-    for (int i = 0; i < m0.size(); i++) {
-      m(i) = m0(i);
-    }
-    for (int i = 0; i < C0.rows(); i++) {
-      for (int j = 0; j < C0.cols(); j++) {
-        C(i, j) = C0(i, j);
-      }
-    }
+    m = m0;
+    C = C0;
 
     Eigen::Matrix<return_type_t<T_y>, Eigen::Dynamic, 1> yi(r);
     Eigen::Matrix<T_lp, Eigen::Dynamic, 1> a(n);
@@ -272,15 +265,8 @@ gaussian_dlm_obs_lpdf(
     Eigen::Matrix<T_lp, Eigen::Dynamic, 1> m(n);
     Eigen::Matrix<T_lp, Eigen::Dynamic, Eigen::Dynamic> C(n, n);
 
-    // TODO(anyone): how to recast matrices
-    for (int i = 0; i < m0.size(); i++) {
-      m(i) = m0(i);
-    }
-    for (int i = 0; i < C0.rows(); i++) {
-      for (int j = 0; j < C0.cols(); j++) {
-        C(i, j) = C0(i, j);
-      }
-    }
+    m = m0;
+    C = C0;
 
     for (int i = 0; i < y.cols(); i++) {
       // Predict state

--- a/stan/math/prim/prob/gaussian_dlm_obs_lpdf.hpp
+++ b/stan/math/prim/prob/gaussian_dlm_obs_lpdf.hpp
@@ -109,12 +109,8 @@ gaussian_dlm_obs_lpdf(
   }
 
   if (include_summand<propto, T_y, T_F, T_G, T_V, T_W, T_m0, T_C0>::value) {
-    Eigen::Matrix<T_lp, Eigen::Dynamic, 1> m(n);
-    Eigen::Matrix<T_lp, Eigen::Dynamic, Eigen::Dynamic> C(n, n);
-
-    m = m0;
-    C = C0;
-
+    Eigen::Matrix<T_lp, Eigen::Dynamic, 1> m{m0};
+    Eigen::Matrix<T_lp, Eigen::Dynamic, Eigen::Dynamic> C{C0};
     Eigen::Matrix<return_type_t<T_y>, Eigen::Dynamic, 1> yi(r);
     Eigen::Matrix<T_lp, Eigen::Dynamic, 1> a(n);
     Eigen::Matrix<T_lp, Eigen::Dynamic, Eigen::Dynamic> R(n, n);
@@ -262,11 +258,8 @@ gaussian_dlm_obs_lpdf(
     T_lp e;
     Eigen::Matrix<T_lp, Eigen::Dynamic, 1> A(n);
     Eigen::Matrix<T_lp, Eigen::Dynamic, 1> Fj(n);
-    Eigen::Matrix<T_lp, Eigen::Dynamic, 1> m(n);
-    Eigen::Matrix<T_lp, Eigen::Dynamic, Eigen::Dynamic> C(n, n);
-
-    m = m0;
-    C = C0;
+    Eigen::Matrix<T_lp, Eigen::Dynamic, 1> m{m0};
+    Eigen::Matrix<T_lp, Eigen::Dynamic, Eigen::Dynamic> C{C0};
 
     for (int i = 0; i < y.cols(); i++) {
       // Predict state


### PR DESCRIPTION
## Summary

Eliminate this last loop and close #1490. This is trivial when C and C0 are the same type, sometimes C0 is double and C is an autodiff type, and the automatic conversion is correct. Likewise m and m0.

## Tests

This function is tested in:
test/unit/math/prim/prob/gaussian_dlm_obs_test.cpp

These tests don't exercise the condition in which C and C0 are different types.

## Side Effects

None.

## Checklist

- [X] Math issue #1490

- [X] Copyright holder: Peter Wicks Stringfield

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [X] the new changes are tested
