### PR TITLE
make read_corr_L deal with size-1 correlation matrices

### DIFF
--- a/stan/math/prim/fun/corr_matrix_constrain.hpp
+++ b/stan/math/prim/fun/corr_matrix_constrain.hpp
@@ -38,10 +38,8 @@ namespace math {
 template <typename T>
 Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> corr_matrix_constrain(
     const Eigen::Matrix<T, Eigen::Dynamic, 1>& x,
-    typename math::index_type<Eigen::Matrix<T, Eigen::Dynamic, 1>>::type k) {
-  using Eigen::Dynamic;
-  using Eigen::Matrix;
-  using size_type = typename index_type<Matrix<T, Dynamic, 1>>::type;
+    math::index_type_t<Eigen::Matrix<T, Eigen::Dynamic, 1>> k) {
+  using size_type = index_type_t<Eigen::Matrix<T, Eigen::Dynamic, 1>>;
 
   size_type k_choose_2 = (k * (k - 1)) / 2;
   check_size_match("cov_matrix_constrain", "x.size()", x.size(), "k_choose_2",
@@ -75,17 +73,14 @@ Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> corr_matrix_constrain(
 template <typename T>
 Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> corr_matrix_constrain(
     const Eigen::Matrix<T, Eigen::Dynamic, 1>& x,
-    typename math::index_type<Eigen::Matrix<T, Eigen::Dynamic, 1>>::type k,
-    T& lp) {
+    math::index_type_t<Eigen::Matrix<T, Eigen::Dynamic, 1>> k, T& lp) {
+  using size_type = index_type_t<Eigen::Matrix<T, Eigen::Dynamic, 1>>;
   using Eigen::Array;
-  using Eigen::Dynamic;
-  using Eigen::Matrix;
-  using size_type = typename index_type<Matrix<T, Dynamic, 1>>::type;
 
   size_type k_choose_2 = (k * (k - 1)) / 2;
   check_size_match("cov_matrix_constrain", "x.size()", x.size(), "k_choose_2",
                    k_choose_2);
-  Array<T, Dynamic, 1> cpcs(k_choose_2);
+  Array<T, Eigen::Dynamic, 1> cpcs(k_choose_2);
   for (size_type i = 0; i < k_choose_2; ++i) {
     cpcs[i] = corr_constrain(x[i], lp);
   }

--- a/stan/math/prim/fun/read_corr_L.hpp
+++ b/stan/math/prim/fun/read_corr_L.hpp
@@ -36,10 +36,11 @@ template <typename T>
 Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> read_corr_L(
     const Eigen::Array<T, Eigen::Dynamic, 1>& CPCs,  // on (-1, 1)
     size_t K) {
+  if (K == 0) {
+    return {};
+  }
   if (K == 1) {
-    Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> L(1, 1);
-    L(0) = 1;
-    return L;
+    return Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>::Identity(1, 1);
   }
 
   using std::sqrt;
@@ -95,10 +96,11 @@ Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> read_corr_L(
 template <typename T>
 Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> read_corr_L(
     const Eigen::Array<T, Eigen::Dynamic, 1>& CPCs, size_t K, T& log_prob) {
+  if (K == 0) {
+    return {};
+  }
   if (K == 1) {
-    Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> L(1, 1);
-    L(0) = 1;
-    return L;
+    return Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>::Identity(1, 1);
   }
 
   Eigen::Matrix<T, Eigen::Dynamic, 1> values(CPCs.rows() - 1);

--- a/stan/math/prim/fun/read_corr_L.hpp
+++ b/stan/math/prim/fun/read_corr_L.hpp
@@ -36,6 +36,12 @@ template <typename T>
 Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> read_corr_L(
     const Eigen::Array<T, Eigen::Dynamic, 1>& CPCs,  // on (-1, 1)
     size_t K) {
+  if (K == 1) {
+    Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> L(1, 1);
+    L(0) = 1;
+    return L;
+  }
+
   using std::sqrt;
   Eigen::Array<T, Eigen::Dynamic, 1> temp;
   Eigen::Array<T, Eigen::Dynamic, 1> acc(K - 1);
@@ -89,6 +95,12 @@ Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> read_corr_L(
 template <typename T>
 Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> read_corr_L(
     const Eigen::Array<T, Eigen::Dynamic, 1>& CPCs, size_t K, T& log_prob) {
+  if (K == 1) {
+    Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> L(1, 1);
+    L(0) = 1;
+    return L;
+  }
+
   Eigen::Matrix<T, Eigen::Dynamic, 1> values(CPCs.rows() - 1);
   size_t pos = 0;
   // no need to abs() because this Jacobian determinant

--- a/stan/math/prim/fun/read_corr_matrix.hpp
+++ b/stan/math/prim/fun/read_corr_matrix.hpp
@@ -24,8 +24,9 @@ namespace math {
 template <typename T>
 Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> read_corr_matrix(
     const Eigen::Array<T, Eigen::Dynamic, 1>& CPCs, size_t K) {
-  if (K == 0)
+  if (K == 0) {
     return {};
+  }
 
   Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> L = read_corr_L(CPCs, K);
   return multiply_lower_tri_self_transpose(L);
@@ -52,8 +53,9 @@ Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> read_corr_matrix(
 template <typename T>
 Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> read_corr_matrix(
     const Eigen::Array<T, Eigen::Dynamic, 1>& CPCs, size_t K, T& log_prob) {
-  if (K == 0)
-    return Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>();
+  if (K == 0) {
+    return {};
+  }
 
   Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> L
       = read_corr_L(CPCs, K, log_prob);

--- a/test/unit/math/prim/fun/corr_matrix_transform_test.cpp
+++ b/test/unit/math/prim/fun/corr_matrix_transform_test.cpp
@@ -25,6 +25,17 @@ TEST(prob_transform, corr_matrix_j2x2) {
   expect_matrix_eq(x, xrt);
 }
 
+TEST(prob_transform, corr_matrix_j1x1) {
+  // tests K=1, which has a different implementation
+  size_t K = 1;
+  size_t K_choose_2 = 0;
+  Eigen::VectorXd x(K_choose_2);
+  double lp = -12.9;
+  Eigen::MatrixXd y = stan::math::corr_matrix_constrain(x, K, lp);
+  Eigen::VectorXd xrt = stan::math::corr_matrix_free(y);
+  expect_matrix_eq(x, xrt);
+}
+
 TEST(prob_transform, corr_matrix_constrain_exception) {
   unsigned int K = 4;
   unsigned int K_choose_2 = 6;

--- a/test/unit/math/prim/fun/corr_matrix_transform_test.cpp
+++ b/test/unit/math/prim/fun/corr_matrix_transform_test.cpp
@@ -1,43 +1,34 @@
 #include <stan/math/prim.hpp>
+#include <test/unit/math/prim/fun/expect_matrix_eq.hpp>
 #include <gtest/gtest.h>
-
-using Eigen::Dynamic;
-using Eigen::Matrix;
 
 TEST(prob_transform, corr_matrix_j) {
   size_t K = 4;
   size_t K_choose_2 = 6;
-  Matrix<double, Dynamic, 1> x(K_choose_2);
+  Eigen::VectorXd x(K_choose_2);
   x << -1.0, 2.0, 0.0, 1.0, 3.0, -1.5;
   double lp = -12.9;
-  Matrix<double, Dynamic, Dynamic> y
-      = stan::math::corr_matrix_constrain(x, K, lp);
-  Matrix<double, Dynamic, 1> xrt = stan::math::corr_matrix_free(y);
-  EXPECT_EQ(x.size(), xrt.size());
-  for (int i = 0; i < x.size(); ++i) {
-    EXPECT_FLOAT_EQ(x[i], xrt[i]);
-  }
+  Eigen::MatrixXd y = stan::math::corr_matrix_constrain(x, K, lp);
+  Eigen::VectorXd xrt = stan::math::corr_matrix_free(y);
+  expect_matrix_eq(x, xrt);
 }
+
 TEST(prob_transform, corr_matrix_j2x2) {
-  // tests K=2 boundary case, which has a different implementation
+  // tests K=2 boundary case
   size_t K = 2;
   size_t K_choose_2 = 1;
-  Matrix<double, Dynamic, 1> x(K_choose_2);
+  Eigen::VectorXd x(K_choose_2);
   x << -1.3;
   double lp = -12.9;
-  Matrix<double, Dynamic, Dynamic> y
-      = stan::math::corr_matrix_constrain(x, K, lp);
-  Matrix<double, Dynamic, 1> xrt = stan::math::corr_matrix_free(y);
-  EXPECT_EQ(x.size(), xrt.size());
-  for (int i = 0; i < x.size(); ++i) {
-    EXPECT_FLOAT_EQ(x[i], xrt[i]);
-  }
+  Eigen::MatrixXd y = stan::math::corr_matrix_constrain(x, K, lp);
+  Eigen::VectorXd xrt = stan::math::corr_matrix_free(y);
+  expect_matrix_eq(x, xrt);
 }
 
 TEST(prob_transform, corr_matrix_constrain_exception) {
   unsigned int K = 4;
   unsigned int K_choose_2 = 6;
-  Matrix<double, Dynamic, 1> x(K_choose_2 - 1);
+  Eigen::VectorXd x(K_choose_2 - 1);
   double lp = -12.9;
 
   EXPECT_THROW(stan::math::corr_matrix_constrain(x, K), std::invalid_argument);
@@ -49,20 +40,22 @@ TEST(prob_transform, corr_matrix_constrain_exception) {
   EXPECT_THROW(stan::math::corr_matrix_constrain(x, K, lp),
                std::invalid_argument);
 }
+
 TEST(prob_transform, corr_matrix_rt) {
   unsigned int K = 4;
   unsigned int K_choose_2 = 6;
-  Matrix<double, Dynamic, 1> x(K_choose_2);
+  Eigen::VectorXd x(K_choose_2);
   x << -1.0, 2.0, 0.0, 1.0, 3.0, -1.5;
-  Matrix<double, Dynamic, Dynamic> y = stan::math::corr_matrix_constrain(x, K);
-  Matrix<double, Dynamic, 1> xrt = stan::math::corr_matrix_free(y);
+  Eigen::MatrixXd y = stan::math::corr_matrix_constrain(x, K);
+  Eigen::VectorXd xrt = stan::math::corr_matrix_free(y);
   EXPECT_EQ(x.size(), xrt.size());
   for (int i = 0; i < x.size(); ++i) {
     EXPECT_FLOAT_EQ(x[i], xrt[i]);
   }
 }
+
 TEST(prob_transform, corr_matrix_free_exception) {
-  Matrix<double, Dynamic, Dynamic> y;
+  Eigen::MatrixXd y;
 
   EXPECT_THROW(stan::math::corr_matrix_free(y), std::invalid_argument);
   y.resize(0, 10);


### PR DESCRIPTION
## Summary

This adds an early return in `read_corr_L` so that if the input matrix has size 1, it returns the correct Cholesky factor without triggering assertions for out of bounds indices. Fixes #1629.

## Tests
Added  test for size-1 input.

## Side Effects

None.

## Checklist

- [X] Math issue #1629

- [X] Copyright holder: Marco Colombo

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [X] the new changes are tested
