### PR TITLE
speedup gradient functional

### DIFF
--- a/stan/math/rev/functor/gradient.hpp
+++ b/stan/math/rev/functor/gradient.hpp
@@ -43,7 +43,9 @@ void gradient(const F& f, const Eigen::Matrix<double, Eigen::Dynamic, 1>& x,
               double& fx, Eigen::Matrix<double, Eigen::Dynamic, 1>& grad_fx) {
   start_nested();
   try {
-    Eigen::Matrix<var, Eigen::Dynamic, 1> x_var(x);
+    Eigen::Matrix<var, Eigen::Dynamic, 1> x_var(x.size());
+    for (int i = 0; i < x.size(); ++i)
+      x_var(i) = var(new vari(x(i), false));
     var fx_var = f(x_var);
     fx = fx_var.val();
     grad_fx.resize(x.size());


### PR DESCRIPTION
## Summary

Reverse mode autodiff performance is affected by `chain` function calls. This PR removes unnecessary `chain` calls for the gradient functional by putting the primary variables on the nochain stack such that the chain method is not run for these variables which is not needed as these are the root nodes.

## Tests

None

## Side Effects

All models should run somewhat faster as we save virtual function calls.

## Checklist

- [X] Math issue #1633 

- [X] Copyright holder: Sebastian Weber

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [X] the new changes are tested
