### PR TITLE
avoid unneccessary chain calls on the state used in ODE functor

### DIFF
--- a/stan/math/rev/functor/coupled_ode_system.hpp
+++ b/stan/math/rev/functor/coupled_ode_system.hpp
@@ -119,7 +119,10 @@ struct coupled_ode_system<F, double, var> {
     try {
       start_nested();
 
-      const vector<var> y_vars(z.begin(), z.begin() + N_);
+      vector<var> y_vars;
+      y_vars.reserve(N_);
+      for (std::size_t i = 0; i < N_; ++i)
+        y_vars.emplace_back(var(new vari(z[i], false)));
 
       vector<var> dy_dt_vars = f_(t, y_vars, theta_nochain_, x_, x_int_, msgs_);
 
@@ -276,7 +279,10 @@ struct coupled_ode_system<F, var, double> {
     try {
       start_nested();
 
-      const vector<var> y_vars(z.begin(), z.begin() + N_);
+      vector<var> y_vars;
+      y_vars.reserve(N_);
+      for (std::size_t i = 0; i < N_; ++i)
+        y_vars.emplace_back(var(new vari(z[i], false)));
 
       vector<var> dy_dt_vars = f_(t, y_vars, theta_dbl_, x_, x_int_, msgs_);
 
@@ -454,7 +460,10 @@ struct coupled_ode_system<F, var, var> {
     try {
       start_nested();
 
-      const vector<var> y_vars(z.begin(), z.begin() + N_);
+      vector<var> y_vars;
+      y_vars.reserve(N_);
+      for (std::size_t i = 0; i < N_; ++i)
+        y_vars.emplace_back(var(new vari(z[i], false)));
 
       vector<var> dy_dt_vars = f_(t, y_vars, theta_nochain_, x_, x_int_, msgs_);
 

--- a/stan/math/rev/functor/coupled_ode_system.hpp
+++ b/stan/math/rev/functor/coupled_ode_system.hpp
@@ -94,7 +94,7 @@ struct coupled_ode_system<F, double, var> {
         size_(N_ + N_ * M_),
         msgs_(msgs) {
     for (const var& p : theta) {
-      theta_nochain_.emplace_back(var(new vari(p.val(), false)));
+      theta_nochain_.emplace_back(new vari(p.val(), false));
     }
   }
 
@@ -122,7 +122,7 @@ struct coupled_ode_system<F, double, var> {
       vector<var> y_vars;
       y_vars.reserve(N_);
       for (std::size_t i = 0; i < N_; ++i)
-        y_vars.emplace_back(var(new vari(z[i], false)));
+        y_vars.emplace_back(new vari(z[i], false));
 
       vector<var> dy_dt_vars = f_(t, y_vars, theta_nochain_, x_, x_int_, msgs_);
 
@@ -282,7 +282,7 @@ struct coupled_ode_system<F, var, double> {
       vector<var> y_vars;
       y_vars.reserve(N_);
       for (std::size_t i = 0; i < N_; ++i)
-        y_vars.emplace_back(var(new vari(z[i], false)));
+        y_vars.emplace_back(new vari(z[i], false));
 
       vector<var> dy_dt_vars = f_(t, y_vars, theta_dbl_, x_, x_int_, msgs_);
 
@@ -435,7 +435,7 @@ struct coupled_ode_system<F, var, var> {
         size_(N_ + N_ * (N_ + M_)),
         msgs_(msgs) {
     for (const var& p : theta) {
-      theta_nochain_.emplace_back(var(new vari(p.val(), false)));
+      theta_nochain_.emplace_back(new vari(p.val(), false));
     }
   }
 
@@ -463,7 +463,7 @@ struct coupled_ode_system<F, var, var> {
       vector<var> y_vars;
       y_vars.reserve(N_);
       for (std::size_t i = 0; i < N_; ++i)
-        y_vars.emplace_back(var(new vari(z[i], false)));
+        y_vars.emplace_back(new vari(z[i], false));
 
       vector<var> dy_dt_vars = f_(t, y_vars, theta_nochain_, x_, x_int_, msgs_);
 


### PR DESCRIPTION
## Summary

Speedup ODE integration by keeping the var chain stack a bit smaller by not putting the states onto the chain stack, but the nochain stack.

## Tests

NA

## Side Effects

Are there any side effects that we should be aware of?

## Checklist

- [X] Math issue #1631 

- [X] Copyright holder: Sebastian Weber

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [X] the new changes are tested
