### PR TITLE
avoid random segfaults at program exit

### DIFF
--- a/stan/math/rev/core/init_chainablestack.hpp
+++ b/stan/math/rev/core/init_chainablestack.hpp
@@ -33,9 +33,7 @@ class ad_tape_observer : public tbb::task_scheduler_observer {
     observe(true);             // activates the observer
   }
 
-  ~ad_tape_observer() {
-    observe(false);
-  }
+  ~ad_tape_observer() { observe(false); }
 
   void on_scheduler_entry(bool worker) {
     std::lock_guard<std::mutex> thread_tape_map_lock(thread_tape_map_mutex_);

--- a/stan/math/rev/core/init_chainablestack.hpp
+++ b/stan/math/rev/core/init_chainablestack.hpp
@@ -33,6 +33,10 @@ class ad_tape_observer : public tbb::task_scheduler_observer {
     observe(true);             // activates the observer
   }
 
+  ~ad_tape_observer() {
+    observe(false);
+  }
+
   void on_scheduler_entry(bool worker) {
     std::lock_guard<std::mutex> thread_tape_map_lock(thread_tape_map_mutex_);
     const std::thread::id thread_id = std::this_thread::get_id();


### PR DESCRIPTION
## Summary

Avoid random segfaults at program exit due to use of already deallocated objects in the global TBB thread pool observer.

## Tests

I was not able to write a reproducible test as this is similar to the static init order problem and has a random nature. The model referred to in the issue #1637 now runs without segfaults for me. 

## Side Effects

No

## Checklist

- [X] Math issue #1637 

- [X] Copyright holder: Sebastian Weber

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [X] the new changes are tested
