### PR TITLE
fix returned expressions

### DIFF
--- a/stan/math/prim/fun/acos.hpp
+++ b/stan/math/prim/fun/acos.hpp
@@ -45,7 +45,7 @@ inline auto acos(const T& x) {
 template <typename Derived,
           typename = require_eigen_vt<std::is_arithmetic, Derived>>
 inline auto acos(const Eigen::MatrixBase<Derived>& x) {
-  return x.derived().array().acos().matrix();
+  return x.derived().array().acos().matrix().eval();
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/asin.hpp
+++ b/stan/math/prim/fun/asin.hpp
@@ -45,7 +45,7 @@ inline auto asin(const T& x) {
 template <typename Derived,
           typename = require_eigen_vt<std::is_arithmetic, Derived>>
 inline auto asin(const Eigen::MatrixBase<Derived>& x) {
-  return x.derived().array().asin().matrix();
+  return x.derived().array().asin().matrix().eval();
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/atan.hpp
+++ b/stan/math/prim/fun/atan.hpp
@@ -45,7 +45,7 @@ inline typename apply_scalar_unary<atan_fun, T>::return_t atan(const T& x) {
 template <typename Derived,
           typename = require_eigen_vt<std::is_arithmetic, Derived>>
 inline auto atan(const Eigen::MatrixBase<Derived>& x) {
-  return x.derived().array().atan().matrix();
+  return x.derived().array().atan().matrix().eval();
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/ceil.hpp
+++ b/stan/math/prim/fun/ceil.hpp
@@ -45,7 +45,7 @@ inline auto ceil(const T& x) {
 template <typename Derived,
           typename = require_eigen_vt<std::is_arithmetic, Derived>>
 inline auto ceil(const Eigen::MatrixBase<Derived>& x) {
-  return x.derived().array().ceil().matrix();
+  return x.derived().array().ceil().matrix().eval();
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/cos.hpp
+++ b/stan/math/prim/fun/cos.hpp
@@ -45,7 +45,7 @@ inline auto cos(const T& x) {
 template <typename Derived,
           typename = require_eigen_vt<std::is_arithmetic, Derived>>
 inline auto cos(const Eigen::MatrixBase<Derived>& x) {
-  return x.derived().array().cos().matrix();
+  return x.derived().array().cos().matrix().eval();
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/cosh.hpp
+++ b/stan/math/prim/fun/cosh.hpp
@@ -45,7 +45,7 @@ inline typename apply_scalar_unary<cosh_fun, T>::return_t cosh(const T& x) {
 template <typename Derived,
           typename = require_eigen_vt<std::is_arithmetic, Derived>>
 inline auto cosh(const Eigen::MatrixBase<Derived>& x) {
-  return x.derived().array().cosh().matrix();
+  return x.derived().array().cosh().matrix().eval();
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/exp.hpp
+++ b/stan/math/prim/fun/exp.hpp
@@ -60,7 +60,7 @@ inline auto exp(const T& x) {
 template <typename Derived,
           typename = require_eigen_vt<std::is_arithmetic, Derived>>
 inline auto exp(const Eigen::MatrixBase<Derived>& x) {
-  return x.derived().array().exp().matrix();
+  return x.derived().array().exp().matrix().eval();
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/fabs.hpp
+++ b/stan/math/prim/fun/fabs.hpp
@@ -45,7 +45,7 @@ inline typename apply_scalar_unary<fabs_fun, T>::return_t fabs(const T& x) {
 template <typename Derived,
           typename = require_eigen_vt<std::is_arithmetic, Derived>>
 inline auto fabs(const Eigen::MatrixBase<Derived>& x) {
-  return x.derived().array().abs().matrix();
+  return x.derived().array().abs().matrix().eval();
 }
 
 /**
@@ -57,7 +57,7 @@ inline auto fabs(const Eigen::MatrixBase<Derived>& x) {
 template <typename Derived,
           typename = require_eigen_vt<std::is_arithmetic, Derived>>
 inline auto fabs(const Eigen::ArrayBase<Derived>& x) {
-  return x.derived().abs();
+  return x.derived().abs().eval();
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/floor.hpp
+++ b/stan/math/prim/fun/floor.hpp
@@ -45,7 +45,7 @@ inline auto floor(const T& x) {
 template <typename Derived,
           typename = require_eigen_vt<std::is_arithmetic, Derived>>
 inline auto floor(const Eigen::MatrixBase<Derived>& x) {
-  return x.derived().array().floor().matrix();
+  return x.derived().array().floor().matrix().eval();
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/inv.hpp
+++ b/stan/math/prim/fun/inv.hpp
@@ -45,7 +45,7 @@ inline auto inv(const T& x) {
 template <typename Derived,
           typename = require_eigen_vt<std::is_arithmetic, Derived>>
 inline auto inv(const Eigen::MatrixBase<Derived>& x) {
-  return x.derived().array().inverse().matrix();
+  return x.derived().array().inverse().matrix().eval();
 }
 
 /**
@@ -57,7 +57,7 @@ inline auto inv(const Eigen::MatrixBase<Derived>& x) {
 template <typename Derived,
           typename = require_eigen_vt<std::is_arithmetic, Derived>>
 inline auto inv(const Eigen::ArrayBase<Derived>& x) {
-  return x.derived().inverse();
+  return x.derived().inverse().eval();
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/inv_cloglog.hpp
+++ b/stan/math/prim/fun/inv_cloglog.hpp
@@ -87,7 +87,7 @@ inline auto inv_cloglog(const T& x) {
 template <typename Derived,
           typename = require_eigen_vt<std::is_arithmetic, Derived>>
 inline auto inv_cloglog(const Eigen::MatrixBase<Derived>& x) {
-  return (1 - exp(-exp(x.derived().array()))).matrix();
+  return (1 - exp(-exp(x.derived().array()))).matrix().eval();
 }
 
 /**
@@ -99,7 +99,7 @@ inline auto inv_cloglog(const Eigen::MatrixBase<Derived>& x) {
 template <typename Derived,
           typename = require_eigen_vt<std::is_arithmetic, Derived>>
 inline auto inv_cloglog(const Eigen::ArrayBase<Derived>& x) {
-  return 1 - exp(-exp(x.derived()));
+  return (1 - exp(-exp(x.derived()))).eval();
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/inv_sqrt.hpp
+++ b/stan/math/prim/fun/inv_sqrt.hpp
@@ -50,7 +50,7 @@ inline auto inv_sqrt(const T& x) {
 template <typename Derived,
           typename = require_eigen_vt<std::is_arithmetic, Derived>>
 inline auto inv_sqrt(const Eigen::MatrixBase<Derived>& x) {
-  return x.derived().array().rsqrt().matrix();
+  return x.derived().array().rsqrt().matrix().eval();
 }
 
 /**
@@ -62,7 +62,7 @@ inline auto inv_sqrt(const Eigen::MatrixBase<Derived>& x) {
 template <typename Derived,
           typename = require_eigen_vt<std::is_arithmetic, Derived>>
 inline auto inv_sqrt(const Eigen::ArrayBase<Derived>& x) {
-  return x.derived().rsqrt();
+  return x.derived().rsqrt().eval();
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/log.hpp
+++ b/stan/math/prim/fun/log.hpp
@@ -60,7 +60,7 @@ inline auto log(const T& x) {
 template <typename Derived,
           typename = require_eigen_vt<std::is_arithmetic, Derived>>
 inline auto log(const Eigen::MatrixBase<Derived>& x) {
-  return x.derived().array().log().matrix();
+  return x.derived().array().log().matrix().eval();
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/log10.hpp
+++ b/stan/math/prim/fun/log10.hpp
@@ -45,7 +45,7 @@ inline auto log10(const T& x) {
 template <typename Derived,
           typename = require_eigen_vt<std::is_arithmetic, Derived>>
 inline auto log10(const Eigen::MatrixBase<Derived>& x) {
-  return x.derived().array().log10().matrix();
+  return x.derived().array().log10().matrix().eval();
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/log_softmax.hpp
+++ b/stan/math/prim/fun/log_softmax.hpp
@@ -41,7 +41,7 @@ template <typename T, require_t<std::is_arithmetic<scalar_type_t<T>>>...>
 inline auto log_softmax(const T& x) {
   return apply_vector_unary<T>::apply(x, [&](const auto& v) {
     check_nonzero_size("log_softmax", "v", v);
-    return (v.array() - log_sum_exp(v)).matrix();
+    return (v.array() - log_sum_exp(v)).matrix().eval();
   });
 }
 }  // namespace math

--- a/stan/math/prim/fun/minus.hpp
+++ b/stan/math/prim/fun/minus.hpp
@@ -1,6 +1,8 @@
 #ifndef STAN_MATH_PRIM_FUN_MINUS_HPP
 #define STAN_MATH_PRIM_FUN_MINUS_HPP
 
+#include <stan/math/prim/meta.hpp>
+
 namespace stan {
 namespace math {
 
@@ -12,8 +14,8 @@ namespace math {
  * @return Negation of subtrahend.
  */
 template <typename T>
-inline auto minus(const T& x) {
-  return (-x).eval();
+inline plain_type_t<T> minus(const T& x) {
+  return -x;
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/minus.hpp
+++ b/stan/math/prim/fun/minus.hpp
@@ -13,7 +13,7 @@ namespace math {
  */
 template <typename T>
 inline auto minus(const T& x) {
-  return -x;
+  return (-x).eval();
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/round.hpp
+++ b/stan/math/prim/fun/round.hpp
@@ -62,7 +62,7 @@ inline auto round(const T& x) {
 template <typename Derived,
           typename = require_eigen_vt<std::is_arithmetic, Derived>>
 inline auto round(const Eigen::MatrixBase<Derived>& x) {
-  return x.derived().array().round().matrix();
+  return x.derived().array().round().matrix().eval();
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/sin.hpp
+++ b/stan/math/prim/fun/sin.hpp
@@ -45,7 +45,7 @@ inline auto sin(const T& x) {
 template <typename Derived,
           typename = require_eigen_vt<std::is_arithmetic, Derived>>
 inline auto sin(const Eigen::MatrixBase<Derived>& x) {
-  return x.derived().array().sin().matrix();
+  return x.derived().array().sin().matrix().eval();
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/sinh.hpp
+++ b/stan/math/prim/fun/sinh.hpp
@@ -45,7 +45,7 @@ inline auto sinh(const T& x) {
 template <typename Derived,
           typename = require_eigen_vt<std::is_arithmetic, Derived>>
 inline auto sinh(const Eigen::MatrixBase<Derived>& x) {
-  return x.derived().array().sinh().matrix();
+  return x.derived().array().sinh().matrix().eval();
 }
 
 /**
@@ -57,7 +57,7 @@ inline auto sinh(const Eigen::MatrixBase<Derived>& x) {
 template <typename Derived,
           typename = require_eigen_vt<std::is_arithmetic, Derived>>
 inline auto sinh(const Eigen::ArrayBase<Derived>& x) {
-  return x.derived().sinh();
+  return x.derived().sinh().eval();
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/sqrt.hpp
+++ b/stan/math/prim/fun/sqrt.hpp
@@ -54,7 +54,7 @@ inline auto sqrt(const T& x) {
 template <typename Derived,
           typename = require_eigen_vt<std::is_arithmetic, Derived>>
 inline auto sqrt(const Eigen::MatrixBase<Derived>& x) {
-  return x.derived().array().sqrt().matrix();
+  return x.derived().array().sqrt().matrix().eval();
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/tan.hpp
+++ b/stan/math/prim/fun/tan.hpp
@@ -45,7 +45,7 @@ inline auto tan(const T& x) {
 template <typename Derived,
           typename = require_eigen_vt<std::is_arithmetic, Derived>>
 inline auto tan(const Eigen::MatrixBase<Derived>& x) {
-  return x.derived().array().tan().matrix();
+  return x.derived().array().tan().matrix().eval();
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/tanh.hpp
+++ b/stan/math/prim/fun/tanh.hpp
@@ -45,7 +45,7 @@ inline auto tanh(const T& x) {
 template <typename Derived,
           typename = require_eigen_vt<std::is_arithmetic, Derived>>
 inline auto tanh(const Eigen::MatrixBase<Derived>& x) {
-  return x.derived().array().tanh().matrix();
+  return x.derived().array().tanh().matrix().eval();
 }
 
 }  // namespace math

--- a/stan/math/prim/vectorize/apply_scalar_unary.hpp
+++ b/stan/math/prim/vectorize/apply_scalar_unary.hpp
@@ -60,7 +60,7 @@ struct apply_scalar_unary<F, T, require_eigen_t<T>> {
    */
   static inline auto apply(const T& x) {
     return x.unaryExpr(
-        [](scalar_t x) { return apply_scalar_unary<F, scalar_t>::apply(x); });
+        [](scalar_t x) { return apply_scalar_unary<F, scalar_t>::apply(x); }).eval();
   }
 
   /**

--- a/stan/math/prim/vectorize/apply_scalar_unary.hpp
+++ b/stan/math/prim/vectorize/apply_scalar_unary.hpp
@@ -59,8 +59,11 @@ struct apply_scalar_unary<F, T, require_eigen_t<T>> {
    * by F to the specified matrix.
    */
   static inline auto apply(const T& x) {
-    return x.unaryExpr(
-        [](scalar_t x) { return apply_scalar_unary<F, scalar_t>::apply(x); }).eval();
+    return x
+        .unaryExpr([](scalar_t x) {
+          return apply_scalar_unary<F, scalar_t>::apply(x);
+        })
+        .eval();
   }
 
   /**

--- a/test/unit/math/prim/fun/Phi_approx_test.cpp
+++ b/test/unit/math/prim/fun/Phi_approx_test.cpp
@@ -14,3 +14,11 @@ TEST(MathFunctions, Phi_approx_nan) {
 
   EXPECT_TRUE(std::isnan(stan::math::Phi_approx(nan)));
 }
+
+TEST(MathFunctions, Phi_approx__works_with_other_functions) {
+  Eigen::VectorXd a(5);
+  a << 1.1, 1.2, 1.3, 1.4, 1.5;
+  Eigen::RowVectorXd b(5);
+  b << 1.1, 1.2, 1.3, 1.4, 1.5;
+  stan::math::multiply(a, stan::math::Phi_approx(b));
+}

--- a/test/unit/math/prim/fun/Phi_test.cpp
+++ b/test/unit/math/prim/fun/Phi_test.cpp
@@ -118,3 +118,11 @@ TEST(MathFunctions, Phi_nan) {
   double nan = std::numeric_limits<double>::quiet_NaN();
   EXPECT_THROW(stan::math::Phi(nan), std::domain_error);
 }
+
+TEST(MathFunctions, Phi_works_with_other_functions) {
+  Eigen::VectorXd a(5);
+  a << 1.1, 1.2, 1.3, 1.4, 1.5;
+  Eigen::RowVectorXd b(5);
+  b << 1.1, 1.2, 1.3, 1.4, 1.5;
+  stan::math::multiply(a, stan::math::Phi(b));
+}

--- a/test/unit/math/prim/fun/acos_test.cpp
+++ b/test/unit/math/prim/fun/acos_test.cpp
@@ -8,8 +8,8 @@ TEST(primScalFun, acos) {
 
 TEST(MathFunctions, acos_works_with_other_functions) {
   Eigen::VectorXd a(5);
-  a << 1.1, 1.2, 1.3, 1.4, 1.5;
+  a << 0.1, 0.2, 0.3, 0.4, 0.5;
   Eigen::RowVectorXd b(5);
-  b << 1.1, 1.2, 1.3, 1.4, 1.5;
+  b << 0.1, 0.2, 0.3, 0.4, 0.5;
   stan::math::multiply(a, stan::math::acos(b));
 }

--- a/test/unit/math/prim/fun/acosh_test.cpp
+++ b/test/unit/math/prim/fun/acosh_test.cpp
@@ -26,3 +26,11 @@ TEST(MathFunctions, acosh_nan) {
   double nan = std::numeric_limits<double>::quiet_NaN();
   EXPECT_TRUE(std::isnan(stan::math::acosh(nan)));
 }
+
+TEST(MathFunctions, acosh_works_with_other_functions) {
+  Eigen::VectorXd a(5);
+  a << 1.1, 1.2, 1.3, 1.4, 1.5;
+  Eigen::RowVectorXd b(5);
+  b << 1.1, 1.2, 1.3, 1.4, 1.5;
+  stan::math::multiply(a, stan::math::acosh(b));
+}

--- a/test/unit/math/prim/fun/asin_test.cpp
+++ b/test/unit/math/prim/fun/asin_test.cpp
@@ -8,8 +8,8 @@ TEST(primScalFun, asin) {
 
 TEST(MathFunctions, asin_works_with_other_functions) {
   Eigen::VectorXd a(5);
-  a << 1.1, 1.2, 1.3, 1.4, 1.5;
+  a << 0.1, 0.2, 0.3, 0.4, 0.5;
   Eigen::RowVectorXd b(5);
-  b << 1.1, 1.2, 1.3, 1.4, 1.5;
+  b << 0.1, 0.2, 0.3, 0.4, 0.5;
   stan::math::multiply(a, stan::math::asin(b));
 }

--- a/test/unit/math/prim/fun/asin_test.cpp
+++ b/test/unit/math/prim/fun/asin_test.cpp
@@ -5,3 +5,11 @@ TEST(primScalFun, asin) {
   stan::test::expect_common_prim([](auto x) { return std::asin(x); },
                                  [](auto x) { return stan::math::asin(x); });
 }
+
+TEST(MathFunctions, asin_works_with_other_functions) {
+  Eigen::VectorXd a(5);
+  a << 1.1, 1.2, 1.3, 1.4, 1.5;
+  Eigen::RowVectorXd b(5);
+  b << 1.1, 1.2, 1.3, 1.4, 1.5;
+  stan::math::multiply(a, stan::math::asin(b));
+}

--- a/test/unit/math/prim/fun/asinh_test.cpp
+++ b/test/unit/math/prim/fun/asinh_test.cpp
@@ -22,3 +22,11 @@ TEST(MathFunctions, asinh_nan) {
   double nan = std::numeric_limits<double>::quiet_NaN();
   EXPECT_TRUE(std::isnan(stan::math::asinh(nan)));
 }
+
+TEST(MathFunctions, asinh_works_with_other_functions) {
+  Eigen::VectorXd a(5);
+  a << 1.1, 1.2, 1.3, 1.4, 1.5;
+  Eigen::RowVectorXd b(5);
+  b << 1.1, 1.2, 1.3, 1.4, 1.5;
+  stan::math::multiply(a, stan::math::asinh(b));
+}

--- a/test/unit/math/prim/fun/atan_test.cpp
+++ b/test/unit/math/prim/fun/atan_test.cpp
@@ -5,3 +5,11 @@ TEST(primScalFun, atan) {
   stan::test::expect_common_prim([](auto x) { return std::atan(x); },
                                  [](auto x) { return stan::math::atan(x); });
 }
+
+TEST(MathFunctions, atan_works_with_other_functions) {
+  Eigen::VectorXd a(5);
+  a << 1.1, 1.2, 1.3, 1.4, 1.5;
+  Eigen::RowVectorXd b(5);
+  b << 1.1, 1.2, 1.3, 1.4, 1.5;
+  stan::math::multiply(a, stan::math::atan(b));
+}

--- a/test/unit/math/prim/fun/atanh_test.cpp
+++ b/test/unit/math/prim/fun/atanh_test.cpp
@@ -27,3 +27,11 @@ TEST(MathFunctions, atanh_nan) {
   double nan = std::numeric_limits<double>::quiet_NaN();
   EXPECT_TRUE(std::isnan(stan::math::atanh(nan)));
 }
+
+TEST(MathFunctions, atanh_works_with_other_functions) {
+  Eigen::VectorXd a(5);
+  a << 1.1, 1.2, 1.3, 1.4, 1.5;
+  Eigen::RowVectorXd b(5);
+  b << 1.1, 1.2, 1.3, 1.4, 1.5;
+  stan::math::multiply(a, stan::math::atanh(b));
+}

--- a/test/unit/math/prim/fun/atanh_test.cpp
+++ b/test/unit/math/prim/fun/atanh_test.cpp
@@ -30,8 +30,8 @@ TEST(MathFunctions, atanh_nan) {
 
 TEST(MathFunctions, atanh_works_with_other_functions) {
   Eigen::VectorXd a(5);
-  a << 1.1, 1.2, 1.3, 1.4, 1.5;
+  a << 0.1, 0.2, 0.3, 0.4, 0.5;
   Eigen::RowVectorXd b(5);
-  b << 1.1, 1.2, 1.3, 1.4, 1.5;
+  b << 0.1, 0.2, 0.3, 0.4, 0.5;
   stan::math::multiply(a, stan::math::atanh(b));
 }

--- a/test/unit/math/prim/fun/cbrt_test.cpp
+++ b/test/unit/math/prim/fun/cbrt_test.cpp
@@ -24,3 +24,11 @@ TEST(MathFunctions, cbrt_nan) {
   double nan = std::numeric_limits<double>::quiet_NaN();
   EXPECT_TRUE(std::isnan(stan::math::cbrt(nan)));
 }
+
+TEST(MathFunctions, cbrt_works_with_other_functions) {
+  Eigen::VectorXd a(5);
+  a << 1.1, 1.2, 1.3, 1.4, 1.5;
+  Eigen::RowVectorXd b(5);
+  b << 1.1, 1.2, 1.3, 1.4, 1.5;
+  stan::math::multiply(a, stan::math::cbrt(b));
+}

--- a/test/unit/math/prim/fun/ceil_test.cpp
+++ b/test/unit/math/prim/fun/ceil_test.cpp
@@ -4,3 +4,11 @@ TEST(primScalFun, ceil) {
   stan::test::expect_common_prim([](auto x) { return std::ceil(x); },
                                  [](auto x) { return stan::math::ceil(x); });
 }
+
+TEST(MathFunctions, ceil_works_with_other_functions) {
+  Eigen::VectorXd a(5);
+  a << 1.1, 1.2, 1.3, 1.4, 1.5;
+  Eigen::RowVectorXd b(5);
+  b << 1.1, 1.2, 1.3, 1.4, 1.5;
+  stan::math::multiply(a, stan::math::ceil(b));
+}

--- a/test/unit/math/prim/fun/cos_test.cpp
+++ b/test/unit/math/prim/fun/cos_test.cpp
@@ -5,3 +5,11 @@ TEST(primScalFun, cos) {
   stan::test::expect_common_prim([](auto x) { return std::cos(x); },
                                  [](auto x) { return stan::math::cos(x); });
 }
+
+TEST(MathFunctions, cos_works_with_other_functions) {
+  Eigen::VectorXd a(5);
+  a << 1.1, 1.2, 1.3, 1.4, 1.5;
+  Eigen::RowVectorXd b(5);
+  b << 1.1, 1.2, 1.3, 1.4, 1.5;
+  stan::math::multiply(a, stan::math::cos(b));
+}

--- a/test/unit/math/prim/fun/cosh_test.cpp
+++ b/test/unit/math/prim/fun/cosh_test.cpp
@@ -1,0 +1,9 @@
+#include <stan/math/prim.hpp>
+
+TEST(MathFunctions, cosh_works_with_other_functions) {
+  Eigen::VectorXd a(5);
+  a << 1.1, 1.2, 1.3, 1.4, 1.5;
+  Eigen::RowVectorXd b(5);
+  b << 1.1, 1.2, 1.3, 1.4, 1.5;
+  stan::math::multiply(a, stan::math::cosh(b));
+}

--- a/test/unit/math/prim/fun/cosh_test.cpp
+++ b/test/unit/math/prim/fun/cosh_test.cpp
@@ -1,4 +1,5 @@
 #include <stan/math/prim.hpp>
+#include <test/unit/math/test_ad.hpp>
 
 TEST(MathFunctions, cosh_works_with_other_functions) {
   Eigen::VectorXd a(5);

--- a/test/unit/math/prim/fun/digamma_test.cpp
+++ b/test/unit/math/prim/fun/digamma_test.cpp
@@ -18,3 +18,11 @@ TEST(MathFunctions, digamma_nan) {
 
   EXPECT_TRUE(std::isnormal(stan::math::digamma(1.0E50)));
 }
+
+TEST(MathFunctions, digamma_works_with_other_functions) {
+  Eigen::VectorXd a(5);
+  a << 1.1, 1.2, 1.3, 1.4, 1.5;
+  Eigen::RowVectorXd b(5);
+  b << 1.1, 1.2, 1.3, 1.4, 1.5;
+  stan::math::multiply(a, stan::math::digamma(b));
+}

--- a/test/unit/math/prim/fun/erf_test.cpp
+++ b/test/unit/math/prim/fun/erf_test.cpp
@@ -20,3 +20,11 @@ TEST(MathFunctions, erfNan) {
   double nan = std::numeric_limits<double>::quiet_NaN();
   EXPECT_TRUE(std::isnan(stan::math::erf(nan)));
 }
+
+TEST(MathFunctions, erf_works_with_other_functions) {
+  Eigen::VectorXd a(5);
+  a << 1.1, 1.2, 1.3, 1.4, 1.5;
+  Eigen::RowVectorXd b(5);
+  b << 1.1, 1.2, 1.3, 1.4, 1.5;
+  stan::math::multiply(a, stan::math::erf(b));
+}

--- a/test/unit/math/prim/fun/erfc_test.cpp
+++ b/test/unit/math/prim/fun/erfc_test.cpp
@@ -21,3 +21,11 @@ TEST(MathFunctions, erfcNan) {
   double nan = std::numeric_limits<double>::quiet_NaN();
   EXPECT_TRUE(std::isnan(stan::math::erfc(nan)));
 }
+
+TEST(MathFunctions, erfc_works_with_other_functions) {
+  Eigen::VectorXd a(5);
+  a << 1.1, 1.2, 1.3, 1.4, 1.5;
+  Eigen::RowVectorXd b(5);
+  b << 1.1, 1.2, 1.3, 1.4, 1.5;
+  stan::math::multiply(a, stan::math::erfc(b));
+}

--- a/test/unit/math/prim/fun/exp2_test.cpp
+++ b/test/unit/math/prim/fun/exp2_test.cpp
@@ -35,3 +35,11 @@ TEST(MathFunctions, exp2_nan) {
 
   EXPECT_TRUE(std::isnan(stan::math::exp2(nan)));
 }
+
+TEST(MathFunctions, exp2_works_with_other_functions) {
+  Eigen::VectorXd a(5);
+  a << 1.1, 1.2, 1.3, 1.4, 1.5;
+  Eigen::RowVectorXd b(5);
+  b << 1.1, 1.2, 1.3, 1.4, 1.5;
+  stan::math::multiply(a, stan::math::exp2(b));
+}

--- a/test/unit/math/prim/fun/exp_test.cpp
+++ b/test/unit/math/prim/fun/exp_test.cpp
@@ -7,3 +7,11 @@ TEST(MathFunctions, expInt) {
   EXPECT_FLOAT_EQ(std::exp(3), exp(3));
   EXPECT_FLOAT_EQ(std::exp(3.0), exp(3.0));
 }
+
+TEST(MathFunctions, exp_works_with_other_functions) {
+  Eigen::VectorXd a(5);
+  a << 1.1, 1.2, 1.3, 1.4, 1.5;
+  Eigen::RowVectorXd b(5);
+  b << 1.1, 1.2, 1.3, 1.4, 1.5;
+  stan::math::multiply(a, stan::math::exp(b));
+}

--- a/test/unit/math/prim/fun/expm1_test.cpp
+++ b/test/unit/math/prim/fun/expm1_test.cpp
@@ -23,3 +23,11 @@ TEST(MathFunctions, expm1_nan) {
   double nan = std::numeric_limits<double>::quiet_NaN();
   EXPECT_TRUE(std::isnan(stan::math::expm1(nan)));
 }
+
+TEST(MathFunctions, expm1_works_with_other_functions) {
+  Eigen::VectorXd a(5);
+  a << 1.1, 1.2, 1.3, 1.4, 1.5;
+  Eigen::RowVectorXd b(5);
+  b << 1.1, 1.2, 1.3, 1.4, 1.5;
+  stan::math::multiply(a, stan::math::expm1(b));
+}

--- a/test/unit/math/prim/fun/fabs_test.cpp
+++ b/test/unit/math/prim/fun/fabs_test.cpp
@@ -5,3 +5,11 @@ TEST(primScalFun, fabs) {
   stan::test::expect_common_prim([](auto x) { return std::fabs(x); },
                                  [](auto x) { return stan::math::fabs(x); });
 }
+
+TEST(MathFunctions, fabs_works_with_other_functions) {
+  Eigen::VectorXd a(5);
+  a << 1.1, 1.2, 1.3, 1.4, 1.5;
+  Eigen::RowVectorXd b(5);
+  b << 1.1, 1.2, 1.3, 1.4, 1.5;
+  stan::math::multiply(a, stan::math::fabs(b));
+}

--- a/test/unit/math/prim/fun/floor_test.cpp
+++ b/test/unit/math/prim/fun/floor_test.cpp
@@ -4,3 +4,11 @@ TEST(primScalFun, floor) {
   stan::test::expect_common_prim([](auto x) { return std::floor(x); },
                                  [](auto x) { return stan::math::floor(x); });
 }
+
+TEST(MathFunctions, floor_works_with_other_functions) {
+  Eigen::VectorXd a(5);
+  a << 1.1, 1.2, 1.3, 1.4, 1.5;
+  Eigen::RowVectorXd b(5);
+  b << 1.1, 1.2, 1.3, 1.4, 1.5;
+  stan::math::multiply(a, stan::math::floor(b));
+}

--- a/test/unit/math/prim/fun/inv_Phi_test.cpp
+++ b/test/unit/math/prim/fun/inv_Phi_test.cpp
@@ -37,8 +37,8 @@ TEST(MathFunctions, inv_Phi_nan) {
 
 TEST(MathFunctions, inv_Phi_works_with_other_functions) {
   Eigen::VectorXd a(5);
-  a << 1.1, 1.2, 1.3, 1.4, 1.5;
+  a << 0.1, 0.2, 0.3, 0.4, 0.5;
   Eigen::RowVectorXd b(5);
-  b << 1.1, 1.2, 1.3, 1.4, 1.5;
+  b << 0.1, 0.2, 0.3, 0.4, 0.5;
   stan::math::multiply(a, stan::math::inv_Phi(b));
 }

--- a/test/unit/math/prim/fun/inv_Phi_test.cpp
+++ b/test/unit/math/prim/fun/inv_Phi_test.cpp
@@ -34,3 +34,11 @@ TEST(MathFunctions, inv_Phi_nan) {
   EXPECT_THROW(inv_Phi(-2.0), std::domain_error);
   EXPECT_THROW(inv_Phi(2.0), std::domain_error);
 }
+
+TEST(MathFunctions, inv_Phi_works_with_other_functions) {
+  Eigen::VectorXd a(5);
+  a << 1.1, 1.2, 1.3, 1.4, 1.5;
+  Eigen::RowVectorXd b(5);
+  b << 1.1, 1.2, 1.3, 1.4, 1.5;
+  stan::math::multiply(a, stan::math::inv_Phi(b));
+}

--- a/test/unit/math/prim/fun/inv_cloglog_test.cpp
+++ b/test/unit/math/prim/fun/inv_cloglog_test.cpp
@@ -14,3 +14,11 @@ TEST(MathFunctions, inv_cloglog_nan) {
 
   EXPECT_TRUE(std::isnan(stan::math::inv_cloglog(nan)));
 }
+
+TEST(MathFunctions, inv_cloglog_works_with_other_functions) {
+  Eigen::VectorXd a(5);
+  a << 1.1, 1.2, 1.3, 1.4, 1.5;
+  Eigen::RowVectorXd b(5);
+  b << 1.1, 1.2, 1.3, 1.4, 1.5;
+  stan::math::multiply(a, stan::math::inv_cloglog(b));
+}

--- a/test/unit/math/prim/fun/inv_logit_test.cpp
+++ b/test/unit/math/prim/fun/inv_logit_test.cpp
@@ -14,3 +14,11 @@ TEST(MathFunctions, inv_logit_nan) {
 
   EXPECT_TRUE(std::isnan(stan::math::inv_logit(nan)));
 }
+
+TEST(MathFunctions, inv_logit_works_with_other_functions) {
+  Eigen::VectorXd a(5);
+  a << 1.1, 1.2, 1.3, 1.4, 1.5;
+  Eigen::RowVectorXd b(5);
+  b << 1.1, 1.2, 1.3, 1.4, 1.5;
+  stan::math::multiply(a, stan::math::inv_logit(b));
+}

--- a/test/unit/math/prim/fun/inv_sqrt_test.cpp
+++ b/test/unit/math/prim/fun/inv_sqrt_test.cpp
@@ -22,3 +22,11 @@ TEST(MathFunctions, inv_sqrt_nan) {
 
   EXPECT_TRUE(std::isnan(stan::math::inv_sqrt(nan)));
 }
+
+TEST(MathFunctions, inv_sqrt_works_with_other_functions) {
+  Eigen::VectorXd a(5);
+  a << 1.1, 1.2, 1.3, 1.4, 1.5;
+  Eigen::RowVectorXd b(5);
+  b << 1.1, 1.2, 1.3, 1.4, 1.5;
+  stan::math::multiply(a, stan::math::inv_sqrt(b));
+}

--- a/test/unit/math/prim/fun/inv_square_test.cpp
+++ b/test/unit/math/prim/fun/inv_square_test.cpp
@@ -19,3 +19,11 @@ TEST(MathFunctions, inv_square_nan) {
 
   EXPECT_TRUE(std::isnan(stan::math::inv_square(nan)));
 }
+
+TEST(MathFunctions, inv_square_works_with_other_functions) {
+  Eigen::VectorXd a(5);
+  a << 1.1, 1.2, 1.3, 1.4, 1.5;
+  Eigen::RowVectorXd b(5);
+  b << 1.1, 1.2, 1.3, 1.4, 1.5;
+  stan::math::multiply(a, stan::math::inv_square(b));
+}

--- a/test/unit/math/prim/fun/inv_test.cpp
+++ b/test/unit/math/prim/fun/inv_test.cpp
@@ -19,3 +19,11 @@ TEST(MathFunctions, inv_nan) {
 
   EXPECT_TRUE(std::isnan(stan::math::inv(nan)));
 }
+
+TEST(MathFunctions, inv_works_with_other_functions) {
+  Eigen::VectorXd a(5);
+  a << 1.1, 1.2, 1.3, 1.4, 1.5;
+  Eigen::RowVectorXd b(5);
+  b << 1.1, 1.2, 1.3, 1.4, 1.5;
+  stan::math::multiply(a, stan::math::inv(b));
+}

--- a/test/unit/math/prim/fun/lgamma_test.cpp
+++ b/test/unit/math/prim/fun/lgamma_test.cpp
@@ -26,3 +26,11 @@ TEST(MathFunctions, lgamma_nan) {
   EXPECT_TRUE(
       std::isnormal(boost::math::lgamma(1.0E50, stan::math::boost_policy_t())));
 }
+
+TEST(MathFunctions, lgamma_works_with_other_functions) {
+  Eigen::VectorXd a(5);
+  a << 1.1, 1.2, 1.3, 1.4, 1.5;
+  Eigen::RowVectorXd b(5);
+  b << 1.1, 1.2, 1.3, 1.4, 1.5;
+  stan::math::multiply(a, stan::math::lgamma(b));
+}

--- a/test/unit/math/prim/fun/log10_test.cpp
+++ b/test/unit/math/prim/fun/log10_test.cpp
@@ -5,3 +5,11 @@ TEST(primScalFun, log10) {
   stan::test::expect_common_prim([](auto x) { return std::log10(x); },
                                  [](auto x) { return stan::math::log10(x); });
 }
+
+TEST(MathFunctions, log10_works_with_other_functions) {
+  Eigen::VectorXd a(5);
+  a << 1.1, 1.2, 1.3, 1.4, 1.5;
+  Eigen::RowVectorXd b(5);
+  b << 1.1, 1.2, 1.3, 1.4, 1.5;
+  stan::math::multiply(a, stan::math::log10(b));
+}

--- a/test/unit/math/prim/fun/log1m_test.cpp
+++ b/test/unit/math/prim/fun/log1m_test.cpp
@@ -25,8 +25,8 @@ TEST(MathFunctions, log1m_nan) {
 
 TEST(MathFunctions, log1m_works_with_other_functions) {
   Eigen::VectorXd a(5);
-  a << 1.1, 1.2, 1.3, 1.4, 1.5;
+  a << 0.1, 0.2, 0.3, 0.4, 0.5;
   Eigen::RowVectorXd b(5);
-  b << 1.1, 1.2, 1.3, 1.4, 1.5;
+  b << 0.1, 0.2, 0.3, 0.4, 0.5;
   stan::math::multiply(a, stan::math::log1m(b));
 }

--- a/test/unit/math/prim/fun/log1m_test.cpp
+++ b/test/unit/math/prim/fun/log1m_test.cpp
@@ -22,3 +22,11 @@ TEST(MathFunctions, log1m_nan) {
   double nan = std::numeric_limits<double>::quiet_NaN();
   EXPECT_TRUE(std::isnan(stan::math::log1m(nan)));
 }
+
+TEST(MathFunctions, log1m_works_with_other_functions) {
+  Eigen::VectorXd a(5);
+  a << 1.1, 1.2, 1.3, 1.4, 1.5;
+  Eigen::RowVectorXd b(5);
+  b << 1.1, 1.2, 1.3, 1.4, 1.5;
+  stan::math::multiply(a, stan::math::log1m(b));
+}

--- a/test/unit/math/prim/fun/log1p_exp_test.cpp
+++ b/test/unit/math/prim/fun/log1p_exp_test.cpp
@@ -16,3 +16,11 @@ TEST(MathFunctions, log1p_exp_nan) {
 
   EXPECT_TRUE(std::isnan(stan::math::log1p_exp(nan)));
 }
+
+TEST(MathFunctions, log1p_exp_works_with_other_functions) {
+  Eigen::VectorXd a(5);
+  a << 1.1, 1.2, 1.3, 1.4, 1.5;
+  Eigen::RowVectorXd b(5);
+  b << 1.1, 1.2, 1.3, 1.4, 1.5;
+  stan::math::multiply(a, stan::math::log1p_exp(b));
+}

--- a/test/unit/math/prim/fun/log1p_test.cpp
+++ b/test/unit/math/prim/fun/log1p_test.cpp
@@ -40,3 +40,11 @@ TEST(MathFunctions, log1p_nan) {
   double nan = std::numeric_limits<double>::quiet_NaN();
   EXPECT_TRUE(std::isnan(stan::math::log1p(nan)));
 }
+
+TEST(MathFunctions, log1p_works_with_other_functions) {
+  Eigen::VectorXd a(5);
+  a << 1.1, 1.2, 1.3, 1.4, 1.5;
+  Eigen::RowVectorXd b(5);
+  b << 1.1, 1.2, 1.3, 1.4, 1.5;
+  stan::math::multiply(a, stan::math::log1p(b));
+}

--- a/test/unit/math/prim/fun/log2_test.cpp
+++ b/test/unit/math/prim/fun/log2_test.cpp
@@ -22,3 +22,11 @@ TEST(MathFunctions, log2_nan) {
 
   EXPECT_TRUE(std::isnan(stan::math::log2(nan)));
 }
+
+TEST(MathFunctions, log2_works_with_other_functions) {
+  Eigen::VectorXd a(5);
+  a << 1.1, 1.2, 1.3, 1.4, 1.5;
+  Eigen::RowVectorXd b(5);
+  b << 1.1, 1.2, 1.3, 1.4, 1.5;
+  stan::math::multiply(a, stan::math::log2(b));
+}

--- a/test/unit/math/prim/fun/log_inv_logit_test.cpp
+++ b/test/unit/math/prim/fun/log_inv_logit_test.cpp
@@ -18,3 +18,11 @@ TEST(MathFunctions, log_inv_logit_nan) {
 
   EXPECT_TRUE(std::isnan(stan::math::log_inv_logit(nan)));
 }
+
+TEST(MathFunctions, log_inv_logit_works_with_other_functions) {
+  Eigen::VectorXd a(5);
+  a << 1.1, 1.2, 1.3, 1.4, 1.5;
+  Eigen::RowVectorXd b(5);
+  b << 1.1, 1.2, 1.3, 1.4, 1.5;
+  stan::math::multiply(a, stan::math::log_inv_logit(b));
+}

--- a/test/unit/math/prim/fun/log_softmax_test.cpp
+++ b/test/unit/math/prim/fun/log_softmax_test.cpp
@@ -71,3 +71,11 @@ TEST(MathMatrixPrimMat, log_softmax_exception) {
 
   EXPECT_THROW(log_softmax(v0), std::invalid_argument);
 }
+
+TEST(MathFunctions, log_softmax_works_with_other_functions) {
+  Eigen::VectorXd a(5);
+  a << 1.1, 1.2, 1.3, 1.4, 1.5;
+  Eigen::RowVectorXd b(5);
+  b << 1.1, 1.2, 1.3, 1.4, 1.5;
+  stan::math::multiply(a, stan::math::log_softmax(b));
+}

--- a/test/unit/math/prim/fun/log_test.cpp
+++ b/test/unit/math/prim/fun/log_test.cpp
@@ -7,3 +7,11 @@ TEST(MathFunctions, logInt) {
   EXPECT_FLOAT_EQ(std::log(3), log(3));
   EXPECT_FLOAT_EQ(std::log(3.0), log(3.0));
 }
+
+TEST(MathFunctions, log_works_with_other_functions) {
+  Eigen::VectorXd a(5);
+  a << 1.1, 1.2, 1.3, 1.4, 1.5;
+  Eigen::RowVectorXd b(5);
+  b << 1.1, 1.2, 1.3, 1.4, 1.5;
+  stan::math::multiply(a, stan::math::log(b));
+}

--- a/test/unit/math/prim/fun/logit_test.cpp
+++ b/test/unit/math/prim/fun/logit_test.cpp
@@ -14,3 +14,11 @@ TEST(MathFunctions, logit_nan) {
 
   EXPECT_TRUE(std::isnan(stan::math::logit(nan)));
 }
+
+TEST(MathFunctions, logit_works_with_other_functions) {
+  Eigen::VectorXd a(5);
+  a << 1.1, 1.2, 1.3, 1.4, 1.5;
+  Eigen::RowVectorXd b(5);
+  b << 1.1, 1.2, 1.3, 1.4, 1.5;
+  stan::math::multiply(a, stan::math::logit(b));
+}

--- a/test/unit/math/prim/fun/minus_test.cpp
+++ b/test/unit/math/prim/fun/minus_test.cpp
@@ -10,3 +10,11 @@ TEST(MathMatrixPrimMat, minus) {
   EXPECT_EQ(0, stan::math::minus(rv0).size());
   EXPECT_EQ(0, stan::math::minus(m0).size());
 }
+
+TEST(MathFunctions, minus_works_with_other_functions) {
+  Eigen::VectorXd a(5);
+  a << 1.1, 1.2, 1.3, 1.4, 1.5;
+  Eigen::RowVectorXd b(5);
+  b << 1.1, 1.2, 1.3, 1.4, 1.5;
+  stan::math::multiply(a, stan::math::minus(b));
+}

--- a/test/unit/math/prim/fun/round_test.cpp
+++ b/test/unit/math/prim/fun/round_test.cpp
@@ -17,3 +17,11 @@ TEST(MathFunctions, roundNaN) {
   double nan = std::numeric_limits<double>::quiet_NaN();
   EXPECT_TRUE(std::isnan(stan::math::round(nan)));
 }
+
+TEST(MathFunctions, round_works_with_other_functions) {
+  Eigen::VectorXd a(5);
+  a << 1.1, 1.2, 1.3, 1.4, 1.5;
+  Eigen::RowVectorXd b(5);
+  b << 1.1, 1.2, 1.3, 1.4, 1.5;
+  stan::math::multiply(a, stan::math::round(b));
+}

--- a/test/unit/math/prim/fun/sin_test.cpp
+++ b/test/unit/math/prim/fun/sin_test.cpp
@@ -5,3 +5,11 @@ TEST(primScalFun, sin) {
   stan::test::expect_common_prim([](auto x) { return std::sin(x); },
                                  [](auto x) { return stan::math::sin(x); });
 }
+
+TEST(MathFunctions, sin_works_with_other_functions) {
+  Eigen::VectorXd a(5);
+  a << 1.1, 1.2, 1.3, 1.4, 1.5;
+  Eigen::RowVectorXd b(5);
+  b << 1.1, 1.2, 1.3, 1.4, 1.5;
+  stan::math::multiply(a, stan::math::sin(b));
+}

--- a/test/unit/math/prim/fun/sinh_test.cpp
+++ b/test/unit/math/prim/fun/sinh_test.cpp
@@ -5,3 +5,11 @@ TEST(primScalFun, sinh) {
   stan::test::expect_common_prim([](auto x) { return std::sinh(x); },
                                  [](auto x) { return stan::math::sinh(x); });
 }
+
+TEST(MathFunctions, sinh_works_with_other_functions) {
+  Eigen::VectorXd a(5);
+  a << 1.1, 1.2, 1.3, 1.4, 1.5;
+  Eigen::RowVectorXd b(5);
+  b << 1.1, 1.2, 1.3, 1.4, 1.5;
+  stan::math::multiply(a, stan::math::sinh(b));
+}

--- a/test/unit/math/prim/fun/sqrt_test.cpp
+++ b/test/unit/math/prim/fun/sqrt_test.cpp
@@ -7,3 +7,11 @@ TEST(MathFunctions, sqrtInt) {
   EXPECT_FLOAT_EQ(std::sqrt(3.0), sqrt(3));
   EXPECT_TRUE(stan::math::is_nan(sqrt(-2)));
 }
+
+TEST(MathFunctions, sqrt_works_with_other_functions) {
+  Eigen::VectorXd a(5);
+  a << 1.1, 1.2, 1.3, 1.4, 1.5;
+  Eigen::RowVectorXd b(5);
+  b << 1.1, 1.2, 1.3, 1.4, 1.5;
+  stan::math::multiply(a, stan::math::sqrt(b));
+}

--- a/test/unit/math/prim/fun/square_test.cpp
+++ b/test/unit/math/prim/fun/square_test.cpp
@@ -3,7 +3,7 @@
 #include <cmath>
 #include <limits>
 
-TEST(MathsFunctions, square) {
+TEST(MathFunctions, square) {
   double y = 2.0;
   EXPECT_FLOAT_EQ(y * y, stan::math::square(y));
 
@@ -18,4 +18,10 @@ TEST(MathFunctions, square_nan) {
   double nan = std::numeric_limits<double>::quiet_NaN();
 
   EXPECT_TRUE(std::isnan(stan::math::square(nan)));
+}
+
+TEST(MathFunctions, square_works_with_other_functions) {
+  Eigen::VectorXd a(5);
+  Eigen::RowVectorXd b(5);
+  stan::math::multiply(a, stan::math::square(b));
 }

--- a/test/unit/math/prim/fun/square_test.cpp
+++ b/test/unit/math/prim/fun/square_test.cpp
@@ -22,6 +22,8 @@ TEST(MathFunctions, square_nan) {
 
 TEST(MathFunctions, square_works_with_other_functions) {
   Eigen::VectorXd a(5);
+  a << 1.1, 1.2, 1.3, 1.4, 1.5;
   Eigen::RowVectorXd b(5);
+  b << 1.1, 1.2, 1.3, 1.4, 1.5;
   stan::math::multiply(a, stan::math::square(b));
 }

--- a/test/unit/math/prim/fun/tan_test.cpp
+++ b/test/unit/math/prim/fun/tan_test.cpp
@@ -1,9 +1,9 @@
 #include <stan/math/prim.hpp>
 
-TEST(MathFunctions, acos_works_with_other_functions) {
+TEST(MathFunctions, tan_works_with_other_functions) {
   Eigen::VectorXd a(5);
   a << 1.1, 1.2, 1.3, 1.4, 1.5;
   Eigen::RowVectorXd b(5);
   b << 1.1, 1.2, 1.3, 1.4, 1.5;
-  stan::math::multiply(a, stan::math::acos(b));
+  stan::math::multiply(a, stan::math::tan(b));
 }

--- a/test/unit/math/prim/fun/tan_test.cpp
+++ b/test/unit/math/prim/fun/tan_test.cpp
@@ -1,10 +1,4 @@
 #include <stan/math/prim.hpp>
-#include <test/unit/math/test_ad.hpp>
-
-TEST(primScalFun, acos) {
-  stan::test::expect_common_prim([](auto x) { return std::acos(x); },
-                                 [](auto x) { return stan::math::acos(x); });
-}
 
 TEST(MathFunctions, acos_works_with_other_functions) {
   Eigen::VectorXd a(5);

--- a/test/unit/math/prim/fun/tan_test.cpp
+++ b/test/unit/math/prim/fun/tan_test.cpp
@@ -1,4 +1,5 @@
 #include <stan/math/prim.hpp>
+#include <test/unit/math/test_ad.hpp>
 
 TEST(MathFunctions, tan_works_with_other_functions) {
   Eigen::VectorXd a(5);

--- a/test/unit/math/prim/fun/tanh_test.cpp
+++ b/test/unit/math/prim/fun/tanh_test.cpp
@@ -5,3 +5,11 @@ TEST(primScalFun, tanh) {
   stan::test::expect_common_prim([](auto x) { return std::tanh(x); },
                                  [](auto x) { return stan::math::tanh(x); });
 }
+
+TEST(MathFunctions, tanh_works_with_other_functions) {
+  Eigen::VectorXd a(5);
+  a << 1.1, 1.2, 1.3, 1.4, 1.5;
+  Eigen::RowVectorXd b(5);
+  b << 1.1, 1.2, 1.3, 1.4, 1.5;
+  stan::math::multiply(a, stan::math::tanh(b));
+}

--- a/test/unit/math/prim/fun/tgamma_test.cpp
+++ b/test/unit/math/prim/fun/tgamma_test.cpp
@@ -20,3 +20,11 @@ TEST(MathFunctions, tgamma_nan) {
   double nan = std::numeric_limits<double>::quiet_NaN();
   EXPECT_TRUE(std::isnan(stan::math::tgamma(nan)));
 }
+
+TEST(MathFunctions, tgamma_works_with_other_functions) {
+  Eigen::VectorXd a(5);
+  a << 1.1, 1.2, 1.3, 1.4, 1.5;
+  Eigen::RowVectorXd b(5);
+  b << 1.1, 1.2, 1.3, 1.4, 1.5;
+  stan::math::multiply(a, stan::math::tgamma(b));
+}

--- a/test/unit/math/prim/fun/trigamma_test.cpp
+++ b/test/unit/math/prim/fun/trigamma_test.cpp
@@ -17,3 +17,11 @@ TEST(MathFunctions, trigamma_nan) {
 
   EXPECT_TRUE(std::isnan(stan::math::trigamma(nan)));
 }
+
+TEST(MathFunctions, trigamma_works_with_other_functions) {
+  Eigen::VectorXd a(5);
+  a << 1.1, 1.2, 1.3, 1.4, 1.5;
+  Eigen::RowVectorXd b(5);
+  b << 1.1, 1.2, 1.3, 1.4, 1.5;
+  stan::math::multiply(a, stan::math::trigamma(b));
+}

--- a/test/unit/math/prim/fun/trunc_test.cpp
+++ b/test/unit/math/prim/fun/trunc_test.cpp
@@ -17,3 +17,11 @@ TEST(MathFunctions, truncNaN) {
   double nan = std::numeric_limits<double>::quiet_NaN();
   EXPECT_TRUE(std::isnan(stan::math::trunc(nan)));
 }
+
+TEST(MathFunctions, trunc_works_with_other_functions) {
+  Eigen::VectorXd a(5);
+  a << 1.1, 1.2, 1.3, 1.4, 1.5;
+  Eigen::RowVectorXd b(5);
+  b << 1.1, 1.2, 1.3, 1.4, 1.5;
+  stan::math::multiply(a, stan::math::trunc(b));
+}


### PR DESCRIPTION
## Summary

PR #1471 generalized some functions to return Eigen expressions. In #1643 it was found that the change prevents compilation of some models. This PR fixes the problem by making those functions return `Eigen::Matrix` again.

## Tests

No tests, as this kind of problem is hard to test in general. But now I know this is an issue It will be simple not to repeat it.

## Side Effects

Maybe the code will be a bit slower, but the difference should be less than the speedup introduced in #1471, if it is present at all.

## Checklist

- [x] Math issue #1643

- [x] Copyright holder: Tadej Ciglarič

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [ ] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [ ] the new changes are tested
