### PR TITLE
Fix variables in OpenCL kernels without type

### DIFF
--- a/stan/math/opencl/kernels/multiply_transpose.hpp
+++ b/stan/math/opencl/kernels/multiply_transpose.hpp
@@ -57,8 +57,8 @@ static const std::string multiply_transpose_kernel_code = STRINGIFY(
           // each thread copies WORK_PER_THREAD values to the
           // local memory
           for (int w = 0; w < WORK_PER_THREAD; w++) {
-            const A_temp_j = tiled_j + w * THREAD_BLOCK_SIZE_COL;
-            const AT_temp_j = j + w * THREAD_BLOCK_SIZE_COL;
+            const int A_temp_j = tiled_j + w * THREAD_BLOCK_SIZE_COL;
+            const int AT_temp_j = j + w * THREAD_BLOCK_SIZE_COL;
             if (A_temp_j >= N || i >= M) {
               A_local[thread_block_col + w * THREAD_BLOCK_SIZE_COL]
                      [thread_block_row]


### PR DESCRIPTION
## Summary

Adds type to two variables in `multiply_transpose` OpenCL kernel that were previously declared just as `const`.

## Tests
None.

## Side Effects
None.

## Checklist

- [x] Math issue #1645 

- [x] Copyright holder: Tadej Ciglarič

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
