### PR TITLE
Clean up code to use index_type_t,  return_type_t and partials_return_t

### DIFF
--- a/doxygen/contributor_help_pages/distribution_tests.md
+++ b/doxygen/contributor_help_pages/distribution_tests.md
@@ -101,7 +101,7 @@ Before diving into details, the overall structure of the test file is:
 ```
   template <class T_n, class T_prob, typename T2,
             typename T3, typename T4, typename T5>
-  typename stan::return_type<T_n, T_prob>::type
+  stan::return_type_t<T_n, T_prob>
   log_prob(const T_n& n, const T_prob& theta, const T2&,
            const T3&, const T4&, const T5&)
 ```
@@ -110,7 +110,7 @@ Before diving into details, the overall structure of the test file is:
   template <bool propto,
             class T_n, class T_prob, typename T2,
             typename T3, typename T4, typename T5>
-  typename stan::return_type<T_n, T_prob>::type
+  stan::return_type_t<T_n, T_prob>
   log_prob(const T_n& n, const T_prob& theta, const T2&,
            const T3&, const T4&, const T5&)
 ```
@@ -118,7 +118,7 @@ Before diving into details, the overall structure of the test file is:
 ```
   template <class T_n, class T_prob, typename T2,
             typename T3, typename T4, typename T5>
-  typename stan::return_type<T_n, T_prob>::type
+  stan::return_type_t<T_n, T_prob>
   log_prob_function(const T_n& n, const T_prob& theta, const T2&,
                     const T3&, const T4&, const T5&)
 ```

--- a/stan/math/fwd/fun/fma.hpp
+++ b/stan/math/fwd/fun/fma.hpp
@@ -56,9 +56,10 @@ namespace math {
  * @return Product of the first two values plus the third.
  */
 template <typename T1, typename T2, typename T3>
-inline fvar<typename stan::return_type<T1, T2, T3>::type> fma(
-    const fvar<T1>& x1, const fvar<T2>& x2, const fvar<T3>& x3) {
-  return fvar<typename stan::return_type<T1, T2, T3>::type>(
+inline fvar<return_type_t<T1, T2, T3>> fma(const fvar<T1>& x1,
+                                           const fvar<T2>& x2,
+                                           const fvar<T3>& x3) {
+  return fvar<return_type_t<T1, T2, T3>>(
       fma(x1.val_, x2.val_, x3.val_),
       x1.d_ * x2.val_ + x2.d_ * x1.val_ + x3.d_);
 }
@@ -67,60 +68,57 @@ inline fvar<typename stan::return_type<T1, T2, T3>::type> fma(
  * See all-var input signature for details on the function and derivatives.
  */
 template <typename T1, typename T2, typename T3>
-inline fvar<typename stan::return_type<T1, T2, T3>::type> fma(
-    const T1& x1, const fvar<T2>& x2, const fvar<T3>& x3) {
-  return fvar<typename stan::return_type<T1, T2, T3>::type>(
-      fma(x1, x2.val_, x3.val_), x2.d_ * x1 + x3.d_);
+inline fvar<return_type_t<T1, T2, T3>> fma(const T1& x1, const fvar<T2>& x2,
+                                           const fvar<T3>& x3) {
+  return fvar<return_type_t<T1, T2, T3>>(fma(x1, x2.val_, x3.val_),
+                                         x2.d_ * x1 + x3.d_);
 }
 
 /**
  * See all-var input signature for details on the function and derivatives.
  */
 template <typename T1, typename T2, typename T3>
-inline fvar<typename stan::return_type<T1, T2, T3>::type> fma(
-    const fvar<T1>& x1, const T2& x2, const fvar<T3>& x3) {
-  return fvar<typename stan::return_type<T1, T2, T3>::type>(
-      fma(x1.val_, x2, x3.val_), x1.d_ * x2 + x3.d_);
+inline fvar<return_type_t<T1, T2, T3>> fma(const fvar<T1>& x1, const T2& x2,
+                                           const fvar<T3>& x3) {
+  return fvar<return_type_t<T1, T2, T3>>(fma(x1.val_, x2, x3.val_),
+                                         x1.d_ * x2 + x3.d_);
 }
 
 /**
  * See all-var input signature for details on the function and derivatives.
  */
 template <typename T1, typename T2, typename T3>
-inline fvar<typename stan::return_type<T1, T2, T3>::type> fma(
-    const fvar<T1>& x1, const fvar<T2>& x2, const T3& x3) {
-  return fvar<typename stan::return_type<T1, T2, T3>::type>(
-      fma(x1.val_, x2.val_, x3), x1.d_ * x2.val_ + x2.d_ * x1.val_);
+inline fvar<return_type_t<T1, T2, T3>> fma(const fvar<T1>& x1,
+                                           const fvar<T2>& x2, const T3& x3) {
+  return fvar<return_type_t<T1, T2, T3>>(fma(x1.val_, x2.val_, x3),
+                                         x1.d_ * x2.val_ + x2.d_ * x1.val_);
 }
 
 /**
  * See all-var input signature for details on the function and derivatives.
  */
 template <typename T1, typename T2, typename T3>
-inline fvar<typename stan::return_type<T1, T2, T3>::type> fma(
-    const T1& x1, const T2& x2, const fvar<T3>& x3) {
-  return fvar<typename stan::return_type<T1, T2, T3>::type>(
-      fma(x1, x2, x3.val_), x3.d_);
+inline fvar<return_type_t<T1, T2, T3>> fma(const T1& x1, const T2& x2,
+                                           const fvar<T3>& x3) {
+  return fvar<return_type_t<T1, T2, T3>>(fma(x1, x2, x3.val_), x3.d_);
 }
 
 /**
  * See all-var input signature for details on the function and derivatives.
  */
 template <typename T1, typename T2, typename T3>
-inline fvar<typename stan::return_type<T1, T2, T3>::type> fma(
-    const fvar<T1>& x1, const T2& x2, const T3& x3) {
-  return fvar<typename stan::return_type<T1, T2, T3>::type>(
-      fma(x1.val_, x2, x3), x1.d_ * x2);
+inline fvar<return_type_t<T1, T2, T3>> fma(const fvar<T1>& x1, const T2& x2,
+                                           const T3& x3) {
+  return fvar<return_type_t<T1, T2, T3>>(fma(x1.val_, x2, x3), x1.d_ * x2);
 }
 
 /**
  * See all-var input signature for details on the function and derivatives.
  */
 template <typename T1, typename T2, typename T3>
-inline fvar<typename stan::return_type<T1, T2, T3>::type> fma(
-    const T1& x1, const fvar<T2>& x2, const T3& x3) {
-  return fvar<typename stan::return_type<T1, T2, T3>::type>(
-      fma(x1, x2.val_, x3), x2.d_ * x1);
+inline fvar<return_type_t<T1, T2, T3>> fma(const T1& x1, const fvar<T2>& x2,
+                                           const T3& x3) {
+  return fvar<return_type_t<T1, T2, T3>>(fma(x1, x2.val_, x3), x2.d_ * x1);
 }
 
 }  // namespace math

--- a/stan/math/fwd/fun/lmgamma.hpp
+++ b/stan/math/fwd/fun/lmgamma.hpp
@@ -11,15 +11,13 @@ namespace stan {
 namespace math {
 
 template <typename T>
-inline fvar<typename stan::return_type<T, int>::type> lmgamma(
-    int x1, const fvar<T>& x2) {
+inline fvar<return_type_t<T, int>> lmgamma(int x1, const fvar<T>& x2) {
   using std::log;
   T deriv = 0;
   for (int count = 1; count < x1 + 1; count++) {
     deriv += x2.d_ * digamma(x2.val_ + (1.0 - count) / 2.0);
   }
-  return fvar<typename stan::return_type<T, int>::type>(lmgamma(x1, x2.val_),
-                                                        deriv);
+  return fvar<return_type_t<T, int>>(lmgamma(x1, x2.val_), deriv);
 }
 }  // namespace math
 }  // namespace stan

--- a/stan/math/opencl/prim/ordered_logistic_glm_lpmf.hpp
+++ b/stan/math/opencl/prim/ordered_logistic_glm_lpmf.hpp
@@ -49,8 +49,7 @@ return_type_t<T_beta_scalar, T_cuts_scalar> ordered_logistic_glm_lpmf(
   using Eigen::Matrix;
   using Eigen::VectorXd;
   using std::isfinite;
-  using T_partials_return =
-      typename partials_return_type<T_beta_scalar, T_cuts_scalar>::type;
+  using T_partials_return = partials_return_t<T_beta_scalar, T_cuts_scalar>;
 
   static const char* function = "ordered_logistic_glm_lpmf";
 

--- a/stan/math/opencl/prim/ordered_logistic_glm_lpmf.hpp
+++ b/stan/math/opencl/prim/ordered_logistic_glm_lpmf.hpp
@@ -40,8 +40,7 @@ namespace math {
  * @throw std::invalid_argument if container sizes mismatch.
  */
 template <bool propto, typename T_beta_scalar, typename T_cuts_scalar>
-typename stan::return_type_t<T_beta_scalar, T_cuts_scalar>
-ordered_logistic_glm_lpmf(
+return_type_t<T_beta_scalar, T_cuts_scalar> ordered_logistic_glm_lpmf(
     const matrix_cl<int>& y_cl, const matrix_cl<double>& x_cl,
     const Eigen::Matrix<T_beta_scalar, Eigen::Dynamic, 1>& beta,
     const Eigen::Matrix<T_cuts_scalar, Eigen::Dynamic, 1>& cuts) {
@@ -137,8 +136,7 @@ ordered_logistic_glm_lpmf(
 }
 
 template <typename T_beta_scalar, typename T_cuts_scalar>
-typename return_type<T_beta_scalar, T_cuts_scalar>::type
-ordered_logistic_glm_lpmf(
+return_type_t<T_beta_scalar, T_cuts_scalar> ordered_logistic_glm_lpmf(
     const matrix_cl<int>& y, const matrix_cl<double>& x,
     const Eigen::Matrix<T_beta_scalar, Eigen::Dynamic, 1>& beta,
     const Eigen::Matrix<T_cuts_scalar, Eigen::Dynamic, 1>& cuts) {

--- a/stan/math/prim/err/check_corr_matrix.hpp
+++ b/stan/math/prim/err/check_corr_matrix.hpp
@@ -33,8 +33,8 @@ template <typename T_y>
 inline void check_corr_matrix(
     const char* function, const char* name,
     const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>& y) {
-  using size_type = typename index_type<
-      Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic> >::type;
+  using size_type
+      = index_type_t<Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>>;
 
   check_square(function, name, y);
   using std::fabs;

--- a/stan/math/prim/err/check_ordered.hpp
+++ b/stan/math/prim/err/check_ordered.hpp
@@ -24,10 +24,9 @@ namespace math {
 template <typename T_y>
 void check_ordered(const char* function, const char* name,
                    const Eigen::Matrix<T_y, Eigen::Dynamic, 1>& y) {
-  typedef
-      typename index_type<Eigen::Matrix<T_y, Eigen::Dynamic, 1> >::type size_t;
+  using size_type = index_type_t<Eigen::Matrix<T_y, Eigen::Dynamic, 1>>;
 
-  for (size_t n = 1; n < y.size(); n++) {
+  for (size_type n = 1; n < y.size(); n++) {
     if (!(y[n] > y[n - 1])) {
       std::ostringstream msg1;
       msg1 << "is not a valid ordered vector."
@@ -69,6 +68,7 @@ void check_ordered(const char* function, const char* name,
     }
   }
 }
+
 }  // namespace math
 }  // namespace stan
 #endif

--- a/stan/math/prim/err/check_simplex.hpp
+++ b/stan/math/prim/err/check_simplex.hpp
@@ -33,8 +33,7 @@ namespace math {
 template <typename T_prob>
 void check_simplex(const char* function, const char* name,
                    const Eigen::Matrix<T_prob, Eigen::Dynamic, 1>& theta) {
-  using size_type =
-      typename index_type<Eigen::Matrix<T_prob, Eigen::Dynamic, 1> >::type;
+  using size_type = index_type_t<Eigen::Matrix<T_prob, Eigen::Dynamic, 1>>;
   using std::fabs;
   check_nonzero_size(function, name, theta);
   if (!(fabs(1.0 - theta.sum()) <= CONSTRAINT_TOLERANCE)) {
@@ -58,6 +57,7 @@ void check_simplex(const char* function, const char* name,
     }
   }
 }
+
 }  // namespace math
 }  // namespace stan
 #endif

--- a/stan/math/prim/err/check_symmetric.hpp
+++ b/stan/math/prim/err/check_symmetric.hpp
@@ -33,8 +33,8 @@ inline void check_symmetric(
     const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>& y) {
   check_square(function, name, y);
   using std::fabs;
-  using size_type = typename index_type<
-      Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>>::type;
+  using size_type
+      = index_type_t<Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>>;
 
   size_type k = y.rows();
   if (k <= 1) {

--- a/stan/math/prim/err/is_symmetric.hpp
+++ b/stan/math/prim/err/is_symmetric.hpp
@@ -10,6 +10,7 @@
 
 namespace stan {
 namespace math {
+
 /**
  * Return <code>true</code> if the matrix is square, and no element
  * not on the main diagonal is <code>NaN</code>.
@@ -25,8 +26,8 @@ inline bool is_symmetric(
     return false;
   }
 
-  using size_type = typename index_type<
-      Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>>::type;
+  using size_type
+      = index_type_t<Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>>;
 
   size_type k = y.rows();
   if (k == 1) {

--- a/stan/math/prim/fun/corr_matrix_free.hpp
+++ b/stan/math/prim/fun/corr_matrix_free.hpp
@@ -38,8 +38,7 @@ Eigen::Matrix<T, Eigen::Dynamic, 1> corr_matrix_free(
 
   using Eigen::Array;
   using Eigen::Dynamic;
-  using Eigen::Matrix;
-  using size_type = typename index_type<Matrix<T, Dynamic, 1>>::type;
+  using size_type = index_type_t<Eigen::Matrix<T, Eigen::Dynamic, 1>>;
 
   size_type k = y.rows();
   size_type k_choose_2 = (k * (k - 1)) / 2;

--- a/stan/math/prim/fun/cov_matrix_constrain.hpp
+++ b/stan/math/prim/fun/cov_matrix_constrain.hpp
@@ -31,7 +31,7 @@ Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> cov_matrix_constrain(
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using std::exp;
-  using index_t = typename index_type<Matrix<T, Dynamic, Dynamic>>::type;
+  using index_t = index_type_t<Matrix<T, Dynamic, Dynamic>>;
 
   Matrix<T, Dynamic, Dynamic> L(K, K);
   check_size_match("cov_matrix_constrain", "x.size()", x.size(),
@@ -72,7 +72,7 @@ Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> cov_matrix_constrain(
   using Eigen::Matrix;
   using std::exp;
   using std::log;
-  using index_t = typename index_type<Matrix<T, Dynamic, Dynamic>>::type;
+  using index_t = index_type_t<Matrix<T, Dynamic, Dynamic>>;
   check_size_match("cov_matrix_constrain", "x.size()", x.size(),
                    "K + (K choose 2)", (K * (K + 1)) / 2);
   Matrix<T, Dynamic, Dynamic> L(K, K);

--- a/stan/math/prim/fun/cov_matrix_free_lkj.hpp
+++ b/stan/math/prim/fun/cov_matrix_free_lkj.hpp
@@ -32,7 +32,7 @@ Eigen::Matrix<T, Eigen::Dynamic, 1> cov_matrix_free_lkj(
   using Eigen::Array;
   using Eigen::Dynamic;
   using Eigen::Matrix;
-  using size_type = typename index_type<Matrix<T, Dynamic, Dynamic>>::type;
+  using size_type = index_type_t<Matrix<T, Dynamic, Dynamic>>;
 
   check_nonzero_size("cov_matrix_free_lkj", "y", y);
   check_square("cov_matrix_free_lkj", "y", y);

--- a/stan/math/prim/fun/make_nu.hpp
+++ b/stan/math/prim/fun/make_nu.hpp
@@ -17,14 +17,11 @@ namespace math {
  */
 template <typename T>
 Eigen::Array<T, Eigen::Dynamic, 1> make_nu(const T& eta, size_t K) {
-  using Eigen::Array;
-  using Eigen::Dynamic;
-  using Eigen::Matrix;
-  using size_type = typename index_type<Matrix<T, Dynamic, 1>>::type;
+  using size_type = index_type_t<Eigen::Matrix<T, Eigen::Dynamic, 1>>;
 
   // Best (1978) implies nu = 2 * alpha for the dof in a t
   // distribution that generates a beta variate on (-1, 1)
-  Array<T, Dynamic, 1> nu(K * (K - 1) / 2);
+  Eigen::Array<T, Eigen::Dynamic, 1> nu(K * (K - 1) / 2);
   T alpha = eta + 0.5 * (K - 2.0);  // from Lewandowski et. al.
   T alpha2 = 2.0 * alpha;
   for (size_type j = 0; j < (K - 1); ++j) {

--- a/stan/math/prim/fun/ordered_constrain.hpp
+++ b/stan/math/prim/fun/ordered_constrain.hpp
@@ -24,8 +24,7 @@ Eigen::Matrix<T, Eigen::Dynamic, 1> ordered_constrain(
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using std::exp;
-
-  using size_type = typename index_type<Matrix<T, Dynamic, 1>>::type;
+  using size_type = index_type_t<Matrix<T, Dynamic, 1>>;
 
   size_type k = x.size();
   Matrix<T, Dynamic, 1> y(k);
@@ -54,10 +53,7 @@ Eigen::Matrix<T, Eigen::Dynamic, 1> ordered_constrain(
 template <typename T>
 inline Eigen::Matrix<T, Eigen::Dynamic, 1> ordered_constrain(
     const Eigen::Matrix<T, Eigen::Dynamic, 1>& x, T& lp) {
-  using Eigen::Dynamic;
-  using Eigen::Matrix;
-
-  using size_type = typename index_type<Matrix<T, Dynamic, 1>>::type;
+  using size_type = index_type_t<Eigen::Matrix<T, Eigen::Dynamic, 1>>;
 
   for (size_type i = 1; i < x.size(); ++i) {
     lp += x(i);

--- a/stan/math/prim/fun/ordered_free.hpp
+++ b/stan/math/prim/fun/ordered_free.hpp
@@ -29,7 +29,7 @@ Eigen::Matrix<T, Eigen::Dynamic, 1> ordered_free(
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using std::log;
-  using size_type = typename index_type<Matrix<T, Dynamic, 1>>::type;
+  using size_type = index_type_t<Matrix<T, Dynamic, 1>>;
 
   size_type k = y.size();
   Matrix<T, Dynamic, 1> x(k);

--- a/stan/math/prim/fun/positive_ordered_constrain.hpp
+++ b/stan/math/prim/fun/positive_ordered_constrain.hpp
@@ -23,7 +23,7 @@ Eigen::Matrix<T, Eigen::Dynamic, 1> positive_ordered_constrain(
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using std::exp;
-  using size_type = typename index_type<Matrix<T, Dynamic, 1>>::type;
+  using size_type = index_type_t<Matrix<T, Dynamic, 1>>;
 
   size_type k = x.size();
   Matrix<T, Dynamic, 1> y(k);
@@ -52,9 +52,7 @@ Eigen::Matrix<T, Eigen::Dynamic, 1> positive_ordered_constrain(
 template <typename T>
 inline Eigen::Matrix<T, Eigen::Dynamic, 1> positive_ordered_constrain(
     const Eigen::Matrix<T, Eigen::Dynamic, 1>& x, T& lp) {
-  using Eigen::Dynamic;
-  using Eigen::Matrix;
-  using size_type = typename index_type<Matrix<T, Dynamic, 1>>::type;
+  using size_type = index_type_t<Eigen::Matrix<T, Eigen::Dynamic, 1>>;
 
   for (size_type i = 0; i < x.size(); ++i) {
     lp += x(i);

--- a/stan/math/prim/fun/positive_ordered_free.hpp
+++ b/stan/math/prim/fun/positive_ordered_free.hpp
@@ -28,7 +28,7 @@ Eigen::Matrix<T, Eigen::Dynamic, 1> positive_ordered_free(
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using std::log;
-  using size_type = typename index_type<Matrix<T, Dynamic, 1>>::type;
+  using size_type = index_type_t<Matrix<T, Dynamic, 1>>;
 
   check_positive_ordered("stan::math::positive_ordered_free",
                          "Positive ordered variable", y);

--- a/stan/math/prim/fun/promote_scalar.hpp
+++ b/stan/math/prim/fun/promote_scalar.hpp
@@ -86,7 +86,7 @@ struct promote_scalar_struct<T, std::vector<S>> {
   static std::vector<typename promote_scalar_type<T, S>::type> apply(
       const std::vector<S>& x) {
     using return_t = std::vector<typename promote_scalar_type<T, S>::type>;
-    using idx_t = typename index_type<return_t>::type;
+    using idx_t = index_type_t<return_t>;
     return_t y(x.size());
     for (idx_t i = 0; i < x.size(); ++i) {
       y[i] = promote_scalar_struct<T, S>::apply(x[i]);

--- a/stan/math/prim/fun/rank.hpp
+++ b/stan/math/prim/fun/rank.hpp
@@ -21,7 +21,7 @@ inline int rank(const C& v, int s) {
   check_range("rank", "v", v.size(), s);
   --s;  // adjust for indexing by one
   int count = 0;
-  for (typename index_type<C>::type i = 0; i < v.size(); ++i) {
+  for (index_type_t<C> i = 0; i < v.size(); ++i) {
     if (v[i] < v[s]) {
       ++count;
     }

--- a/stan/math/prim/fun/scale_matrix_exp_multiply.hpp
+++ b/stan/math/prim/fun/scale_matrix_exp_multiply.hpp
@@ -49,12 +49,12 @@ inline Eigen::Matrix<double, -1, Cb> scale_matrix_exp_multiply(
  * @return exponential of At multiplies B
  */
 template <typename Tt, typename Ta, typename Tb, int Cb>
-inline Eigen::Matrix<stan::return_type_t<Tt, Ta, Tb>, -1, Cb>
+inline Eigen::Matrix<return_type_t<Tt, Ta, Tb>, -1, Cb>
 scale_matrix_exp_multiply(const Tt& t, const Eigen::Matrix<Ta, -1, -1>& A,
                           const Eigen::Matrix<Tb, -1, Cb>& B) {
   check_square("scale_matrix_exp_multiply", "input matrix", A);
   if (A.size() == 0 && B.rows() == 0) {
-    return Eigen::Matrix<stan::return_type_t<Tt, Ta, Tb>, -1, Cb>(0, B.cols());
+    return Eigen::Matrix<return_type_t<Tt, Ta, Tb>, -1, Cb>(0, B.cols());
   }
 
   check_multiplicable("scale_matrix_exp_multiply", "A", A, "B", B);

--- a/stan/math/prim/fun/simplex_constrain.hpp
+++ b/stan/math/prim/fun/simplex_constrain.hpp
@@ -31,7 +31,7 @@ Eigen::Matrix<T, Eigen::Dynamic, 1> simplex_constrain(
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using std::log;
-  using size_type = typename index_type<Matrix<T, Dynamic, 1>>::type;
+  using size_type = index_type_t<Matrix<T, Dynamic, 1>>;
 
   int Km1 = y.size();
   Matrix<T, Dynamic, 1> x(Km1 + 1);
@@ -65,7 +65,7 @@ Eigen::Matrix<T, Eigen::Dynamic, 1> simplex_constrain(
   using Eigen::Matrix;
   using std::log;
 
-  using size_type = typename index_type<Matrix<T, Dynamic, 1>>::type;
+  using size_type = index_type_t<Matrix<T, Dynamic, 1>>;
 
   int Km1 = y.size();  // K = Km1 + 1
   Matrix<T, Dynamic, 1> x(Km1 + 1);

--- a/stan/math/prim/fun/simplex_free.hpp
+++ b/stan/math/prim/fun/simplex_free.hpp
@@ -27,11 +27,8 @@ namespace math {
 template <typename T>
 Eigen::Matrix<T, Eigen::Dynamic, 1> simplex_free(
     const Eigen::Matrix<T, Eigen::Dynamic, 1>& x) {
-  using Eigen::Dynamic;
-  using Eigen::Matrix;
   using std::log;
-
-  using size_type = typename index_type<Matrix<T, Dynamic, 1>>::type;
+  using size_type = index_type_t<Eigen::Matrix<T, Eigen::Dynamic, 1>>;
 
   check_simplex("stan::math::simplex_free", "Simplex variable", x);
   int Km1 = x.size() - 1;

--- a/stan/math/prim/fun/sort_indices.hpp
+++ b/stan/math/prim/fun/sort_indices.hpp
@@ -61,7 +61,7 @@ class index_comparator {
  */
 template <bool ascending, typename C>
 std::vector<int> sort_indices(const C& xs) {
-  using idx_t = typename index_type<C>::type;
+  using idx_t = index_type_t<C>;
   idx_t xs_size = xs.size();
   std::vector<int> idxs;
   idxs.resize(xs_size);

--- a/stan/math/prim/fun/tail.hpp
+++ b/stan/math/prim/fun/tail.hpp
@@ -59,7 +59,7 @@ inline Eigen::Matrix<T, 1, Eigen::Dynamic> tail(
  */
 template <typename T>
 std::vector<T> tail(const std::vector<T>& sv, size_t n) {
-  using idx_t = typename index_type<std::vector<T> >::type;
+  using idx_t = index_type_t<std::vector<T>>;
   if (n != 0) {
     check_std_vector_index("tail", "n", sv, n);
   }

--- a/stan/math/prim/prob/inv_wishart_lpdf.hpp
+++ b/stan/math/prim/prob/inv_wishart_lpdf.hpp
@@ -11,6 +11,7 @@
 
 namespace stan {
 namespace math {
+
 /** \ingroup multivar_dists
  * The log of the Inverse-Wishart density for the given W, degrees
  * of freedom, and scale matrix.
@@ -50,7 +51,7 @@ return_type_t<T_y, T_dof, T_scale> inv_wishart_lpdf(
   using Eigen::Dynamic;
   using Eigen::Matrix;
 
-  typename index_type<Matrix<T_scale, Dynamic, Dynamic> >::type k = S.rows();
+  index_type_t<Matrix<T_scale, Dynamic, Dynamic>> k = S.rows();
   return_type_t<T_y, T_dof, T_scale> lp(0.0);
 
   check_greater(function, "Degrees of freedom parameter", nu, k - 1);
@@ -85,8 +86,7 @@ return_type_t<T_y, T_dof, T_scale> inv_wishart_lpdf(
     Eigen::Matrix<return_type_t<T_y, T_scale>, Eigen::Dynamic, Eigen::Dynamic>
         Winv_S(mdivide_left_ldlt(
             ldlt_W,
-            static_cast<
-                Eigen::Matrix<T_scale, Eigen::Dynamic, Eigen::Dynamic> >(
+            static_cast<Eigen::Matrix<T_scale, Eigen::Dynamic, Eigen::Dynamic>>(
                 S.template selfadjointView<Eigen::Lower>())));
     lp -= 0.5 * trace(Winv_S);
   }

--- a/stan/math/prim/prob/inv_wishart_rng.hpp
+++ b/stan/math/prim/prob/inv_wishart_rng.hpp
@@ -15,7 +15,7 @@ inline Eigen::MatrixXd inv_wishart_rng(double nu, const Eigen::MatrixXd& S,
   static const char* function = "inv_wishart_rng";
 
   using Eigen::MatrixXd;
-  typename index_type<MatrixXd>::type k = S.rows();
+  index_type_t<MatrixXd> k = S.rows();
 
   check_greater(function, "degrees of freedom > dims - 1", nu, k - 1);
   check_square(function, "scale parameter", S);

--- a/stan/math/prim/prob/neg_binomial_2_log_lpmf.hpp
+++ b/stan/math/prim/prob/neg_binomial_2_log_lpmf.hpp
@@ -20,9 +20,7 @@ template <bool propto, typename T_n, typename T_log_location,
           typename T_precision>
 return_type_t<T_log_location, T_precision> neg_binomial_2_log_lpmf(
     const T_n& n, const T_log_location& eta, const T_precision& phi) {
-  typedef
-      typename stan::partials_return_type<T_n, T_log_location,
-                                          T_precision>::type T_partials_return;
+  using T_partials_return = partials_return_t<T_n, T_log_location, T_precision>;
 
   static const char* function = "neg_binomial_2_log_lpmf";
 
@@ -126,6 +124,7 @@ inline return_type_t<T_log_location, T_precision> neg_binomial_2_log_lpmf(
     const T_n& n, const T_log_location& eta, const T_precision& phi) {
   return neg_binomial_2_log_lpmf<false>(n, eta, phi);
 }
+
 }  // namespace math
 }  // namespace stan
 #endif

--- a/stan/math/prim/prob/ordered_logistic_glm_lpmf.hpp
+++ b/stan/math/prim/prob/ordered_logistic_glm_lpmf.hpp
@@ -39,7 +39,7 @@ namespace math {
  */
 template <bool propto, typename T_y, typename T_x_scalar, int T_x_rows,
           typename T_beta_scalar, typename T_cuts_scalar>
-typename stan::return_type_t<T_x_scalar, T_beta_scalar, T_cuts_scalar>
+return_type_t<T_x_scalar, T_beta_scalar, T_cuts_scalar>
 ordered_logistic_glm_lpmf(
     const T_y& y, const Eigen::Matrix<T_x_scalar, T_x_rows, Eigen::Dynamic>& x,
     const Eigen::Matrix<T_beta_scalar, Eigen::Dynamic, 1>& beta,
@@ -195,7 +195,7 @@ ordered_logistic_glm_lpmf(
 
 template <typename T_y, typename T_x_scalar, int T_x_rows,
           typename T_beta_scalar, typename T_cuts_scalar>
-typename stan::return_type_t<T_x_scalar, T_beta_scalar, T_cuts_scalar>
+return_type_t<T_x_scalar, T_beta_scalar, T_cuts_scalar>
 ordered_logistic_glm_lpmf(
     const T_y& y, const Eigen::Matrix<T_x_scalar, T_x_rows, Eigen::Dynamic>& x,
     const Eigen::Matrix<T_beta_scalar, Eigen::Dynamic, 1>& beta,

--- a/stan/math/prim/prob/ordered_logistic_glm_lpmf.hpp
+++ b/stan/math/prim/prob/ordered_logistic_glm_lpmf.hpp
@@ -51,8 +51,8 @@ ordered_logistic_glm_lpmf(
   using std::exp;
   using std::isfinite;
 
-  typedef typename partials_return_type<T_y, T_x_scalar, T_beta_scalar,
-                                        T_cuts_scalar>::type T_partials_return;
+  using T_partials_return
+      = partials_return_t<T_y, T_x_scalar, T_beta_scalar, T_cuts_scalar>;
   typedef typename std::conditional_t<T_x_rows == 1, double, VectorXd>
       T_location;
 

--- a/stan/math/prim/prob/wishart_lpdf.hpp
+++ b/stan/math/prim/prob/wishart_lpdf.hpp
@@ -53,7 +53,7 @@ return_type_t<T_y, T_dof, T_scale> wishart_lpdf(
   using Eigen::Lower;
   using Eigen::Matrix;
 
-  typename index_type<Matrix<T_scale, Dynamic, Dynamic> >::type k = W.rows();
+  index_type_t<Matrix<T_scale, Dynamic, Dynamic>> k = W.rows();
   return_type_t<T_y, T_dof, T_scale> lp(0.0);
   check_greater(function, "Degrees of freedom parameter", nu, k - 1);
   check_square(function, "random variable", W);
@@ -81,7 +81,7 @@ return_type_t<T_y, T_dof, T_scale> wishart_lpdf(
 
   if (include_summand<propto, T_scale, T_y>::value) {
     Matrix<return_type_t<T_y, T_scale>, Dynamic, Dynamic> Sinv_W(
-        mdivide_left_ldlt(ldlt_S, static_cast<Matrix<T_y, Dynamic, Dynamic> >(
+        mdivide_left_ldlt(ldlt_S, static_cast<Matrix<T_y, Dynamic, Dynamic>>(
                                       W.template selfadjointView<Lower>())));
     lp -= 0.5 * trace(Sinv_W);
   }

--- a/stan/math/prim/prob/wishart_rng.hpp
+++ b/stan/math/prim/prob/wishart_rng.hpp
@@ -17,7 +17,7 @@ inline Eigen::MatrixXd wishart_rng(double nu, const Eigen::MatrixXd& S,
   static const char* function = "wishart_rng";
 
   using Eigen::MatrixXd;
-  typename index_type<MatrixXd>::type k = S.rows();
+  index_type_t<MatrixXd> k = S.rows();
 
   check_square(function, "scale parameter", S);
   check_greater(function, "degrees of freedom > dims - 1", nu, k - 1);

--- a/stan/math/rev/fun/matrix_exp_multiply.hpp
+++ b/stan/math/rev/fun/matrix_exp_multiply.hpp
@@ -23,13 +23,11 @@ namespace math {
  * @return exponential of A multiplies B
  */
 template <typename Ta, typename Tb, int Cb>
-inline Eigen::Matrix<typename stan::return_type<Ta, Tb>::type, -1, Cb>
-matrix_exp_multiply(const Eigen::Matrix<Ta, -1, -1>& A,
-                    const Eigen::Matrix<Tb, -1, Cb>& B) {
+inline Eigen::Matrix<return_type_t<Ta, Tb>, -1, Cb> matrix_exp_multiply(
+    const Eigen::Matrix<Ta, -1, -1>& A, const Eigen::Matrix<Tb, -1, Cb>& B) {
   check_square("matrix_exp_multiply", "input matrix", A);
   if (A.size() == 0 && B.rows() == 0) {
-    return Eigen::Matrix<typename stan::return_type_t<Ta, Tb>, -1, Cb>(
-        0, B.cols());
+    return Eigen::Matrix<return_type_t<Ta, Tb>, -1, Cb>(0, B.cols());
   }
 
   check_multiplicable("matrix_exp_multiply", "A", A, "B", B);

--- a/stan/math/rev/fun/squared_distance.hpp
+++ b/stan/math/rev/fun/squared_distance.hpp
@@ -66,7 +66,7 @@ class squared_distance_vv_vari : public vari {
   inline static double var_squared_distance(
       const Eigen::Matrix<var, R1, C1>& v1,
       const Eigen::Matrix<var, R2, C2>& v2) {
-    using idx_t = typename index_type<matrix_v>::type;
+    using idx_t = index_type_t<matrix_v>;
 
     return (Eigen::Ref<const vector_v>(v1).val()
             - Eigen::Ref<const vector_v>(v2).val())
@@ -103,7 +103,7 @@ class squared_distance_vd_vari : public vari {
   inline static double var_squared_distance(
       const Eigen::Matrix<var, R1, C1>& v1,
       const Eigen::Matrix<double, R2, C2>& v2) {
-    using idx_t = typename index_type<matrix_d>::type;
+    using idx_t = index_type_t<matrix_d>;
 
     return (Eigen::Ref<const vector_v>(v1).val()
             - Eigen::Ref<const vector_d>(v2))

--- a/stan/math/rev/functor/cvodes_integrator.hpp
+++ b/stan/math/rev/functor/cvodes_integrator.hpp
@@ -71,8 +71,7 @@ class cvodes_integrator {
    */
   template <typename F, typename T_initial, typename T_param, typename T_t0,
             typename T_ts>
-  std::vector<std::vector<
-      typename stan::return_type<T_initial, T_param, T_t0, T_ts>::type>>
+  std::vector<std::vector<return_type_t<T_initial, T_param, T_t0, T_ts>>>
   integrate(const F& f, const std::vector<T_initial>& y0, const T_t0& t0,
             const std::vector<T_ts>& ts, const std::vector<T_param>& theta,
             const std::vector<double>& x, const std::vector<int>& x_int,
@@ -123,9 +122,7 @@ class cvodes_integrator {
 
     const size_t coupled_size = cvodes_data.coupled_ode_.size();
 
-    std::vector<std::vector<
-        typename stan::return_type<T_initial, T_param, T_t0, T_ts>::type>>
-        y;
+    std::vector<std::vector<return_type_t<T_initial, T_param, T_t0, T_ts>>> y;
     coupled_ode_observer<F, T_initial, T_param, T_t0, T_ts> observer(
         f, y0, theta, t0, ts, x, x_int, msgs, y);
 

--- a/stan/math/rev/functor/idas_system.hpp
+++ b/stan/math/rev/functor/idas_system.hpp
@@ -112,7 +112,7 @@ class idas_system {
   static constexpr bool is_var_par = stan::is_var<Tpar>::value;
   static constexpr bool need_sens = is_var_yy0 || is_var_yp0 || is_var_par;
 
-  using scalar_type = typename stan::return_type<Tyy, Typ, Tpar>::type;
+  using scalar_type = return_type_t<Tyy, Typ, Tpar>;
   using return_type = std::vector<std::vector<scalar_type> >;
 
   /**

--- a/stan/math/rev/functor/integrate_ode_adams.hpp
+++ b/stan/math/rev/functor/integrate_ode_adams.hpp
@@ -11,8 +11,7 @@ namespace math {
 
 template <typename F, typename T_initial, typename T_param, typename T_t0,
           typename T_ts>
-std::vector<std::vector<
-    typename stan::return_type<T_initial, T_param, T_t0, T_ts>::type>>
+std::vector<std::vector<return_type_t<T_initial, T_param, T_t0, T_ts>>>
 integrate_ode_adams(const F& f, const std::vector<T_initial>& y0,
                     const T_t0& t0, const std::vector<T_ts>& ts,
                     const std::vector<T_param>& theta,

--- a/stan/math/rev/functor/integrate_ode_bdf.hpp
+++ b/stan/math/rev/functor/integrate_ode_bdf.hpp
@@ -11,8 +11,7 @@ namespace math {
 
 template <typename F, typename T_initial, typename T_param, typename T_t0,
           typename T_ts>
-std::vector<std::vector<
-    typename stan::return_type<T_initial, T_param, T_t0, T_ts>::type>>
+std::vector<std::vector<return_type_t<T_initial, T_param, T_t0, T_ts>>>
 integrate_ode_bdf(const F& f, const std::vector<T_initial>& y0, const T_t0& t0,
                   const std::vector<T_ts>& ts,
                   const std::vector<T_param>& theta,

--- a/stan/math/rev/functor/map_rect_concurrent.hpp
+++ b/stan/math/rev/functor/map_rect_concurrent.hpp
@@ -20,8 +20,7 @@ namespace internal {
 
 template <int call_id, typename F, typename T_shared_param,
           typename T_job_param>
-Eigen::Matrix<typename stan::return_type<T_shared_param, T_job_param>::type,
-              Eigen::Dynamic, 1>
+Eigen::Matrix<return_type_t<T_shared_param, T_job_param>, Eigen::Dynamic, 1>
 map_rect_concurrent(
     const Eigen::Matrix<T_shared_param, Eigen::Dynamic, 1>& shared_params,
     const std::vector<Eigen::Matrix<T_job_param, Eigen::Dynamic, 1>>&

--- a/test/prob/bernoulli/bernoulli_ccdf_log_test.hpp
+++ b/test/prob/bernoulli/bernoulli_ccdf_log_test.hpp
@@ -32,18 +32,18 @@ class AgradCcdfLogBernoulli : public AgradCcdfLogTest {
 
   template <typename T_n, typename T_prob, typename T2, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_prob>::type ccdf_log(const T_n& n,
-                                                    const T_prob& theta,
-                                                    const T2&, const T3&,
-                                                    const T4&, const T5&) {
+  stan::return_type_t<T_prob> ccdf_log(const T_n& n, const T_prob& theta,
+                                       const T2&, const T3&, const T4&,
+                                       const T5&) {
     return stan::math::bernoulli_ccdf_log(n, theta);
   }
 
   template <typename T_n, typename T_prob, typename T2, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_prob>::type ccdf_log_function(
-      const T_n& n, const T_prob& theta, const T2&, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_prob> ccdf_log_function(const T_n& n,
+                                                const T_prob& theta, const T2&,
+                                                const T3&, const T4&,
+                                                const T5&) {
     if (n < 0)
       return 0.0;
     if (n < 1)

--- a/test/prob/bernoulli/bernoulli_cdf_log_test.hpp
+++ b/test/prob/bernoulli/bernoulli_cdf_log_test.hpp
@@ -37,18 +37,18 @@ class AgradCdfLogBernoulli : public AgradCdfLogTest {
 
   template <typename T_n, typename T_prob, typename T2, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_prob>::type cdf_log(const T_n& n,
-                                                   const T_prob& theta,
-                                                   const T2&, const T3&,
-                                                   const T4&, const T5&) {
+  stan::return_type_t<T_prob> cdf_log(const T_n& n, const T_prob& theta,
+                                      const T2&, const T3&, const T4&,
+                                      const T5&) {
     return stan::math::bernoulli_cdf_log(n, theta);
   }
 
   template <typename T_n, typename T_prob, typename T2, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_prob>::type cdf_log_function(
-      const T_n& n, const T_prob& theta, const T2&, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_prob> cdf_log_function(const T_n& n,
+                                               const T_prob& theta, const T2&,
+                                               const T3&, const T4&,
+                                               const T5&) {
     if (n < 0)
       return stan::math::negative_infinity();
     if (n < 1)

--- a/test/prob/bernoulli/bernoulli_cdf_test.hpp
+++ b/test/prob/bernoulli/bernoulli_cdf_test.hpp
@@ -36,19 +36,16 @@ class AgradCdfBernoulli : public AgradCdfTest {
 
   template <typename T_n, typename T_prob, typename T2, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_prob>::type cdf(const T_n& n,
-                                               const T_prob& theta, const T2&,
-                                               const T3&, const T4&,
-                                               const T5&) {
+  stan::return_type_t<T_prob> cdf(const T_n& n, const T_prob& theta, const T2&,
+                                  const T3&, const T4&, const T5&) {
     return stan::math::bernoulli_cdf(n, theta);
   }
 
   template <typename T_n, typename T_prob, typename T2, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_prob>::type cdf_function(const T_n& n,
-                                                        const T_prob& theta,
-                                                        const T2&, const T3&,
-                                                        const T4&, const T5&) {
+  stan::return_type_t<T_prob> cdf_function(const T_n& n, const T_prob& theta,
+                                           const T2&, const T3&, const T4&,
+                                           const T5&) {
     if (n < 0)
       return 0;
     if (n < 1)

--- a/test/prob/bernoulli/bernoulli_logit_test.hpp
+++ b/test/prob/bernoulli/bernoulli_logit_test.hpp
@@ -62,27 +62,26 @@ class AgradDistributionsBernoulliLogistic : public AgradDistributionTest {
 
   template <class T_n, class T_prob, typename T2, typename T3, typename T4,
             typename T5>
-  typename stan::return_type<T_n, T_prob>::type log_prob(const T_n& n,
-                                                         const T_prob& theta,
-                                                         const T2&, const T3&,
-                                                         const T4&, const T5&) {
+  stan::return_type_t<T_n, T_prob> log_prob(const T_n& n, const T_prob& theta,
+                                            const T2&, const T3&, const T4&,
+                                            const T5&) {
     return stan::math::bernoulli_logit_log(n, theta);
   }
 
   template <bool propto, class T_n, class T_prob, typename T2, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_n, T_prob>::type log_prob(const T_n& n,
-                                                         const T_prob& theta,
-                                                         const T2&, const T3&,
-                                                         const T4&, const T5&) {
+  stan::return_type_t<T_n, T_prob> log_prob(const T_n& n, const T_prob& theta,
+                                            const T2&, const T3&, const T4&,
+                                            const T5&) {
     return stan::math::bernoulli_logit_log<propto>(n, theta);
   }
 
   template <class T_n, class T_prob, typename T2, typename T3, typename T4,
             typename T5>
-  typename stan::return_type<T_n, T_prob>::type log_prob_function(
-      const T_n& n, const T_prob& theta, const T2&, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_n, T_prob> log_prob_function(const T_n& n,
+                                                     const T_prob& theta,
+                                                     const T2&, const T3&,
+                                                     const T4&, const T5&) {
     using stan::math::log1m;
     using std::log;
     T_prob ntheta = (2 * n - 1) * theta;

--- a/test/prob/bernoulli/bernoulli_test.hpp
+++ b/test/prob/bernoulli/bernoulli_test.hpp
@@ -51,27 +51,26 @@ class AgradDistributionsBernoulli : public AgradDistributionTest {
 
   template <class T_n, class T_prob, typename T2, typename T3, typename T4,
             typename T5>
-  typename stan::return_type<T_n, T_prob>::type log_prob(const T_n& n,
-                                                         const T_prob& theta,
-                                                         const T2&, const T3&,
-                                                         const T4&, const T5&) {
+  stan::return_type_t<T_n, T_prob> log_prob(const T_n& n, const T_prob& theta,
+                                            const T2&, const T3&, const T4&,
+                                            const T5&) {
     return stan::math::bernoulli_log(n, theta);
   }
 
   template <bool propto, class T_n, class T_prob, typename T2, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_n, T_prob>::type log_prob(const T_n& n,
-                                                         const T_prob& theta,
-                                                         const T2&, const T3&,
-                                                         const T4&, const T5&) {
+  stan::return_type_t<T_n, T_prob> log_prob(const T_n& n, const T_prob& theta,
+                                            const T2&, const T3&, const T4&,
+                                            const T5&) {
     return stan::math::bernoulli_log<propto>(n, theta);
   }
 
   template <class T_n, class T_prob, typename T2, typename T3, typename T4,
             typename T5>
-  typename stan::return_type<T_n, T_prob>::type log_prob_function(
-      const T_n& n, const T_prob& theta, const T2&, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_n, T_prob> log_prob_function(const T_n& n,
+                                                     const T_prob& theta,
+                                                     const T2&, const T3&,
+                                                     const T4&, const T5&) {
     using stan::math::log1m;
     using std::log;
     if (n == 1)

--- a/test/prob/beta/beta_ccdf_log_test.hpp
+++ b/test/prob/beta/beta_ccdf_log_test.hpp
@@ -57,7 +57,7 @@ class AgradCcdfLogBeta : public AgradCcdfLogTest {
 
   template <typename T_y, typename T_scale_succ, typename T_scale_fail,
             typename T3, typename T4, typename T5>
-  typename stan::return_type<T_y, T_scale_succ, T_scale_fail>::type ccdf_log(
+  stan::return_type_t<T_y, T_scale_succ, T_scale_fail> ccdf_log(
       const T_y& y, const T_scale_succ& alpha, const T_scale_fail& beta,
       const T3&, const T4&, const T5&) {
     return stan::math::beta_ccdf_log(y, alpha, beta);
@@ -65,9 +65,9 @@ class AgradCcdfLogBeta : public AgradCcdfLogTest {
 
   template <typename T_y, typename T_scale_succ, typename T_scale_fail,
             typename T3, typename T4, typename T5>
-  typename stan::return_type<T_y, T_scale_succ, T_scale_fail>::type
-  ccdf_log_function(const T_y& y, const T_scale_succ& alpha,
-                    const T_scale_fail& beta, const T3&, const T4&, const T5&) {
+  stan::return_type_t<T_y, T_scale_succ, T_scale_fail> ccdf_log_function(
+      const T_y& y, const T_scale_succ& alpha, const T_scale_fail& beta,
+      const T3&, const T4&, const T5&) {
     return stan::math::beta_ccdf_log(y, alpha, beta);
   }
 };

--- a/test/prob/beta/beta_cdf_log_test.hpp
+++ b/test/prob/beta/beta_cdf_log_test.hpp
@@ -57,7 +57,7 @@ class AgradCdfLogBeta : public AgradCdfLogTest {
 
   template <typename T_y, typename T_scale_succ, typename T_scale_fail,
             typename T3, typename T4, typename T5>
-  typename stan::return_type<T_y, T_scale_succ, T_scale_fail>::type cdf_log(
+  stan::return_type_t<T_y, T_scale_succ, T_scale_fail> cdf_log(
       const T_y& y, const T_scale_succ& alpha, const T_scale_fail& beta,
       const T3&, const T4&, const T5&) {
     return stan::math::beta_cdf_log(y, alpha, beta);
@@ -65,9 +65,9 @@ class AgradCdfLogBeta : public AgradCdfLogTest {
 
   template <typename T_y, typename T_scale_succ, typename T_scale_fail,
             typename T3, typename T4, typename T5>
-  typename stan::return_type<T_y, T_scale_succ, T_scale_fail>::type
-  cdf_log_function(const T_y& y, const T_scale_succ& alpha,
-                   const T_scale_fail& beta, const T3&, const T4&, const T5&) {
+  stan::return_type_t<T_y, T_scale_succ, T_scale_fail> cdf_log_function(
+      const T_y& y, const T_scale_succ& alpha, const T_scale_fail& beta,
+      const T3&, const T4&, const T5&) {
     return stan::math::beta_cdf_log(y, alpha, beta);
   }
 };

--- a/test/prob/beta/beta_cdf_test.hpp
+++ b/test/prob/beta/beta_cdf_test.hpp
@@ -56,7 +56,7 @@ class AgradCdfBeta : public AgradCdfTest {
 
   template <typename T_y, typename T_scale_succ, typename T_scale_fail,
             typename T3, typename T4, typename T5>
-  typename stan::return_type<T_y, T_scale_succ, T_scale_fail>::type cdf(
+  stan::return_type_t<T_y, T_scale_succ, T_scale_fail> cdf(
       const T_y& y, const T_scale_succ& alpha, const T_scale_fail& beta,
       const T3&, const T4&, const T5&) {
     return stan::math::beta_cdf(y, alpha, beta);
@@ -64,9 +64,9 @@ class AgradCdfBeta : public AgradCdfTest {
 
   template <typename T_y, typename T_scale_succ, typename T_scale_fail,
             typename T3, typename T4, typename T5>
-  typename stan::return_type<T_y, T_scale_succ, T_scale_fail>::type
-  cdf_function(const T_y& y, const T_scale_succ& alpha,
-               const T_scale_fail& beta, const T3&, const T4&, const T5&) {
+  stan::return_type_t<T_y, T_scale_succ, T_scale_fail> cdf_function(
+      const T_y& y, const T_scale_succ& alpha, const T_scale_fail& beta,
+      const T3&, const T4&, const T5&) {
     return stan::math::beta_cdf(y, alpha, beta);
   }
 };

--- a/test/prob/beta/beta_test.hpp
+++ b/test/prob/beta/beta_test.hpp
@@ -61,25 +61,29 @@ class AgradDistributionsBeta : public AgradDistributionTest {
 
   template <typename T_y, typename T_scale1, typename T_scale2, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_scale1, T_scale2>::type log_prob(
-      const T_y& y, const T_scale1& alpha, const T_scale2& beta, const T3&,
-      const T4&, const T5&) {
+  stan::return_type_t<T_y, T_scale1, T_scale2> log_prob(const T_y& y,
+                                                        const T_scale1& alpha,
+                                                        const T_scale2& beta,
+                                                        const T3&, const T4&,
+                                                        const T5&) {
     return stan::math::beta_log(y, alpha, beta);
   }
 
   template <bool propto, typename T_y, typename T_scale1, typename T_scale2,
             typename T3, typename T4, typename T5>
-  typename stan::return_type<T_y, T_scale1, T_scale2>::type log_prob(
-      const T_y& y, const T_scale1& alpha, const T_scale2& beta, const T3&,
-      const T4&, const T5&) {
+  stan::return_type_t<T_y, T_scale1, T_scale2> log_prob(const T_y& y,
+                                                        const T_scale1& alpha,
+                                                        const T_scale2& beta,
+                                                        const T3&, const T4&,
+                                                        const T5&) {
     return stan::math::beta_log<propto>(y, alpha, beta);
   }
 
   template <typename T_y, typename T_scale1, typename T_scale2, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_scale1, T_scale2, T3, T4, T5>::type
-  log_prob_function(const T_y& y, const T_scale1& alpha, const T_scale2& beta,
-                    const T3&, const T4&, const T5&) {
+  stan::return_type_t<T_y, T_scale1, T_scale2, T3, T4, T5> log_prob_function(
+      const T_y& y, const T_scale1& alpha, const T_scale2& beta, const T3&,
+      const T4&, const T5&) {
     using stan::math::log1m;
     using std::log;
 

--- a/test/prob/beta_binomial/beta_binomial_ccdf_log_test.hpp
+++ b/test/prob/beta_binomial/beta_binomial_ccdf_log_test.hpp
@@ -42,22 +42,23 @@ class AgradCcdfLogBetaBinomial : public AgradCcdfLogTest {
 
   template <typename T_n, typename T_N, typename T_size1, typename T_size2,
             typename T4, typename T5>
-  typename stan::return_type<T_size1, T_size2>::type ccdf_log(
-      const T_n& n, const T_N& N, const T_size1& alpha, const T_size2& beta,
-      const T4&, const T5&) {
+  stan::return_type_t<T_size1, T_size2> ccdf_log(const T_n& n, const T_N& N,
+                                                 const T_size1& alpha,
+                                                 const T_size2& beta, const T4&,
+                                                 const T5&) {
     return stan::math::beta_binomial_ccdf_log(n, N, alpha, beta);
   }
 
   template <typename T_n, typename T_N, typename T_size1, typename T_size2,
             typename T4, typename T5>
-  typename stan::return_type<T_size1, T_size2>::type ccdf_log_function(
+  stan::return_type_t<T_size1, T_size2> ccdf_log_function(
       const T_n& n, const T_N& N, const T_size1& alpha, const T_size2& beta,
       const T4&, const T5&) {
     using boost::math::binomial_coefficient;
     using stan::math::lbeta;
     using std::exp;
 
-    typename stan::return_type<T_size1, T_size2>::type cdf(0);
+    stan::return_type_t<T_size1, T_size2> cdf(0);
 
     for (int i = 0; i <= n; i++) {
       cdf += binomial_coefficient<double>(N, i)

--- a/test/prob/beta_binomial/beta_binomial_cdf_log_test.hpp
+++ b/test/prob/beta_binomial/beta_binomial_cdf_log_test.hpp
@@ -41,22 +41,25 @@ class AgradCdfLogBetaBinomial : public AgradCdfLogTest {
 
   template <typename T_n, typename T_N, typename T_size1, typename T_size2,
             typename T4, typename T5>
-  typename stan::return_type<T_size1, T_size2>::type cdf_log(
-      const T_n& n, const T_N& N, const T_size1& alpha, const T_size2& beta,
-      const T4&, const T5&) {
+  stan::return_type_t<T_size1, T_size2> cdf_log(const T_n& n, const T_N& N,
+                                                const T_size1& alpha,
+                                                const T_size2& beta, const T4&,
+                                                const T5&) {
     return stan::math::beta_binomial_cdf_log(n, N, alpha, beta);
   }
 
   template <typename T_n, typename T_N, typename T_size1, typename T_size2,
             typename T4, typename T5>
-  typename stan::return_type<T_size1, T_size2>::type cdf_log_function(
-      const T_n& n, const T_N& N, const T_size1& alpha, const T_size2& beta,
-      const T4&, const T5&) {
+  stan::return_type_t<T_size1, T_size2> cdf_log_function(const T_n& n,
+                                                         const T_N& N,
+                                                         const T_size1& alpha,
+                                                         const T_size2& beta,
+                                                         const T4&, const T5&) {
     using boost::math::binomial_coefficient;
     using stan::math::lbeta;
     using std::exp;
 
-    typename stan::return_type<T_size1, T_size2>::type cdf(0);
+    stan::return_type_t<T_size1, T_size2> cdf(0);
 
     for (int i = 0; i <= n; i++) {
       cdf += binomial_coefficient<double>(N, i)

--- a/test/prob/beta_binomial/beta_binomial_cdf_test.hpp
+++ b/test/prob/beta_binomial/beta_binomial_cdf_test.hpp
@@ -40,24 +40,24 @@ class AgradCdfBetaBinomial : public AgradCdfTest {
 
   template <typename T_n, typename T_N, typename T_size1, typename T_size2,
             typename T4, typename T5>
-  typename stan::return_type<T_size1, T_size2>::type cdf(const T_n& n,
-                                                         const T_N& N,
-                                                         const T_size1& alpha,
-                                                         const T_size2& beta,
-                                                         const T4&, const T5&) {
+  stan::return_type_t<T_size1, T_size2> cdf(const T_n& n, const T_N& N,
+                                            const T_size1& alpha,
+                                            const T_size2& beta, const T4&,
+                                            const T5&) {
     return stan::math::beta_binomial_cdf(n, N, alpha, beta);
   }
 
   template <typename T_n, typename T_N, typename T_size1, typename T_size2,
             typename T4, typename T5>
-  typename stan::return_type<T_size1, T_size2>::type cdf_function(
-      const T_n& n, const T_N& N, const T_size1& alpha, const T_size2& beta,
-      const T4&, const T5&) {
+  stan::return_type_t<T_size1, T_size2> cdf_function(const T_n& n, const T_N& N,
+                                                     const T_size1& alpha,
+                                                     const T_size2& beta,
+                                                     const T4&, const T5&) {
     using boost::math::binomial_coefficient;
     using stan::math::lbeta;
     using std::exp;
 
-    typename stan::return_type<T_size1, T_size2>::type cdf(0);
+    stan::return_type_t<T_size1, T_size2> cdf(0);
 
     for (int i = 0; i <= n; i++) {
       cdf += binomial_coefficient<double>(N, i)

--- a/test/prob/beta_binomial/beta_binomial_test.hpp
+++ b/test/prob/beta_binomial/beta_binomial_test.hpp
@@ -57,23 +57,25 @@ class AgradDistributionsBetaBinomial : public AgradDistributionTest {
 
   template <class T_n, class T_N, class T_size1, class T_size2, typename T4,
             typename T5>
-  typename stan::return_type<T_size1, T_size2>::type log_prob(
-      const T_n& n, const T_N& N, const T_size1& alpha, const T_size2& beta,
-      const T4&, const T5&) {
+  stan::return_type_t<T_size1, T_size2> log_prob(const T_n& n, const T_N& N,
+                                                 const T_size1& alpha,
+                                                 const T_size2& beta, const T4&,
+                                                 const T5&) {
     return stan::math::beta_binomial_log(n, N, alpha, beta);
   }
 
   template <bool propto, class T_n, class T_N, class T_size1, class T_size2,
             typename T4, typename T5>
-  typename stan::return_type<T_size1, T_size2>::type log_prob(
-      const T_n& n, const T_N& N, const T_size1& alpha, const T_size2& beta,
-      const T4&, const T5&) {
+  stan::return_type_t<T_size1, T_size2> log_prob(const T_n& n, const T_N& N,
+                                                 const T_size1& alpha,
+                                                 const T_size2& beta, const T4&,
+                                                 const T5&) {
     return stan::math::beta_binomial_log<propto>(n, N, alpha, beta);
   }
 
   template <class T_n, class T_N, class T_size1, class T_size2, typename T4,
             typename T5>
-  typename stan::return_type<T_size1, T_size2>::type log_prob_function(
+  stan::return_type_t<T_size1, T_size2> log_prob_function(
       const T_n& n, const T_N& N, const T_size1& alpha, const T_size2& beta,
       const T4&, const T5&) {
     using stan::math::binomial_coefficient_log;

--- a/test/prob/beta_proportion/beta_proportion_ccdf_log_test.hpp
+++ b/test/prob/beta_proportion/beta_proportion_ccdf_log_test.hpp
@@ -67,15 +67,17 @@ class AgradCcdfLogBetaProportion : public AgradCcdfLogTest {
 
   template <typename T_y, typename T_loc, typename T_prec, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_prec>::type ccdf_log(
-      const T_y& y, const T_loc& mu, const T_prec& kappa, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_y, T_loc, T_prec> ccdf_log(const T_y& y,
+                                                   const T_loc& mu,
+                                                   const T_prec& kappa,
+                                                   const T3&, const T4&,
+                                                   const T5&) {
     return stan::math::beta_proportion_lccdf(y, mu, kappa);
   }
 
   template <typename T_y, typename T_loc, typename T_prec, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_prec>::type ccdf_log_function(
+  stan::return_type_t<T_y, T_loc, T_prec> ccdf_log_function(
       const T_y& y, const T_loc& mu, const T_prec& kappa, const T3&, const T4&,
       const T5&) {
     return stan::math::beta_proportion_lccdf(y, mu, kappa);

--- a/test/prob/beta_proportion/beta_proportion_cdf_log_test.hpp
+++ b/test/prob/beta_proportion/beta_proportion_cdf_log_test.hpp
@@ -66,17 +66,20 @@ class AgradCdfLogBetaProportion : public AgradCdfLogTest {
 
   template <typename T_y, typename T_loc, typename T_prec, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_prec>::type cdf_log(
-      const T_y& y, const T_loc& mu, const T_prec& kappa, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_y, T_loc, T_prec> cdf_log(const T_y& y, const T_loc& mu,
+                                                  const T_prec& kappa,
+                                                  const T3&, const T4&,
+                                                  const T5&) {
     return stan::math::beta_proportion_lcdf(y, mu, kappa);
   }
 
   template <typename T_y, typename T_loc, typename T_prec, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_prec>::type cdf_log_function(
-      const T_y& y, const T_loc& mu, const T_prec& kappa, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_y, T_loc, T_prec> cdf_log_function(const T_y& y,
+                                                           const T_loc& mu,
+                                                           const T_prec& kappa,
+                                                           const T3&, const T4&,
+                                                           const T5&) {
     return stan::math::beta_proportion_lcdf(y, mu, kappa);
   }
 };

--- a/test/prob/beta_proportion/beta_proportion_test.hpp
+++ b/test/prob/beta_proportion/beta_proportion_test.hpp
@@ -70,25 +70,29 @@ class AgradDistributionsBetaProportion : public AgradDistributionTest {
 
   template <typename T_y, typename T_loc, typename T_prec, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_prec>::type log_prob(
-      const T_y& y, const T_loc& mu, const T_prec& kappa, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_y, T_loc, T_prec> log_prob(const T_y& y,
+                                                   const T_loc& mu,
+                                                   const T_prec& kappa,
+                                                   const T3&, const T4&,
+                                                   const T5&) {
     return stan::math::beta_proportion_lpdf(y, mu, kappa);
   }
 
   template <bool propto, typename T_y, typename T_loc, typename T_prec,
             typename T3, typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_prec>::type log_prob(
-      const T_y& y, const T_loc& mu, const T_prec& kappa, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_y, T_loc, T_prec> log_prob(const T_y& y,
+                                                   const T_loc& mu,
+                                                   const T_prec& kappa,
+                                                   const T3&, const T4&,
+                                                   const T5&) {
     return stan::math::beta_proportion_lpdf<propto>(y, mu, kappa);
   }
 
   template <typename T_y, typename T_loc, typename T_prec, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_prec, T3, T4, T5>::type
-  log_prob_function(const T_y& y, const T_loc& mu, const T_prec& kappa,
-                    const T3&, const T4&, const T5&) {
+  stan::return_type_t<T_y, T_loc, T_prec, T3, T4, T5> log_prob_function(
+      const T_y& y, const T_loc& mu, const T_prec& kappa, const T3&, const T4&,
+      const T5&) {
     using stan::math::log1m;
     using std::log;
     return (mu * kappa - 1.0) * log(y) + ((1.0 - mu) * kappa - 1.0) * log1m(y)

--- a/test/prob/binomial/binomial_ccdf_log_test.hpp
+++ b/test/prob/binomial/binomial_ccdf_log_test.hpp
@@ -39,23 +39,22 @@ class AgradCcdfLogBinomial : public AgradCcdfLogTest {
 
   template <typename T_n, typename T_N, typename T_prob, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_prob>::type ccdf_log(const T_n& n, const T_N& N,
-                                                    const T_prob& theta,
-                                                    const T3&, const T4&,
-                                                    const T5&) {
+  stan::return_type_t<T_prob> ccdf_log(const T_n& n, const T_N& N,
+                                       const T_prob& theta, const T3&,
+                                       const T4&, const T5&) {
     return stan::math::binomial_ccdf_log(n, N, theta);
   }
 
   template <typename T_n, typename T_N, typename T_prob, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_prob>::type ccdf_log_function(
-      const T_n& n, const T_N& N, const T_prob& theta, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_prob> ccdf_log_function(const T_n& n, const T_N& N,
+                                                const T_prob& theta, const T3&,
+                                                const T4&, const T5&) {
     using boost::math::binomial_coefficient;
     using std::exp;
     using std::log;
 
-    typename stan::return_type<T_prob>::type cdf(0);
+    stan::return_type_t<T_prob> cdf(0);
 
     for (int i = 0; i <= n; i++) {
       cdf += binomial_coefficient<double>(N, i)

--- a/test/prob/binomial/binomial_cdf_log_test.hpp
+++ b/test/prob/binomial/binomial_cdf_log_test.hpp
@@ -38,23 +38,22 @@ class AgradCdfLogBinomial : public AgradCdfLogTest {
 
   template <typename T_n, typename T_N, typename T_prob, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_prob>::type cdf_log(const T_n& n, const T_N& N,
-                                                   const T_prob& theta,
-                                                   const T3&, const T4&,
-                                                   const T5&) {
+  stan::return_type_t<T_prob> cdf_log(const T_n& n, const T_N& N,
+                                      const T_prob& theta, const T3&, const T4&,
+                                      const T5&) {
     return stan::math::binomial_cdf_log(n, N, theta);
   }
 
   template <typename T_n, typename T_N, typename T_prob, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_prob>::type cdf_log_function(
-      const T_n& n, const T_N& N, const T_prob& theta, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_prob> cdf_log_function(const T_n& n, const T_N& N,
+                                               const T_prob& theta, const T3&,
+                                               const T4&, const T5&) {
     using boost::math::binomial_coefficient;
     using std::exp;
     using std::log;
 
-    typename stan::return_type<T_prob>::type cdf(0);
+    stan::return_type_t<T_prob> cdf(0);
 
     for (int i = 0; i <= n; i++) {
       cdf += binomial_coefficient<double>(N, i)

--- a/test/prob/binomial/binomial_cdf_test.hpp
+++ b/test/prob/binomial/binomial_cdf_test.hpp
@@ -37,24 +37,22 @@ class AgradCdfBinomial : public AgradCdfTest {
 
   template <typename T_n, typename T_N, typename T_prob, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_prob>::type cdf(const T_n& n, const T_N& N,
-                                               const T_prob& theta, const T3&,
-                                               const T4&, const T5&) {
+  stan::return_type_t<T_prob> cdf(const T_n& n, const T_N& N,
+                                  const T_prob& theta, const T3&, const T4&,
+                                  const T5&) {
     return stan::math::binomial_cdf(n, N, theta);
   }
 
   template <typename T_n, typename T_N, typename T_prob, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_prob>::type cdf_function(const T_n& n,
-                                                        const T_N& N,
-                                                        const T_prob& theta,
-                                                        const T3&, const T4&,
-                                                        const T5&) {
+  stan::return_type_t<T_prob> cdf_function(const T_n& n, const T_N& N,
+                                           const T_prob& theta, const T3&,
+                                           const T4&, const T5&) {
     using boost::math::binomial_coefficient;
     using std::exp;
     using std::log;
 
-    typename stan::return_type<T_prob>::type cdf(1);
+    stan::return_type_t<T_prob> cdf(1);
 
     for (int i = 0; i <= n; i++) {
       cdf *= binomial_coefficient<double>(N, i)

--- a/test/prob/binomial/binomial_logit_test.hpp
+++ b/test/prob/binomial/binomial_logit_test.hpp
@@ -41,27 +41,25 @@ class AgradDistributionsBinomialLogit : public AgradDistributionTest {
 
   template <class T_n, class T_N, class T_prob, typename T3, typename T4,
             typename T5>
-  typename stan::return_type<T_prob>::type log_prob(const T_n& n, const T_N& N,
-                                                    const T_prob& alpha,
-                                                    const T3&, const T4&,
-                                                    const T5&) {
+  stan::return_type_t<T_prob> log_prob(const T_n& n, const T_N& N,
+                                       const T_prob& alpha, const T3&,
+                                       const T4&, const T5&) {
     return stan::math::binomial_logit_log(n, N, alpha);
   }
 
   template <bool propto, class T_n, class T_N, class T_prob, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_prob>::type log_prob(const T_n& n, const T_N& N,
-                                                    const T_prob& alpha,
-                                                    const T3&, const T4&,
-                                                    const T5&) {
+  stan::return_type_t<T_prob> log_prob(const T_n& n, const T_N& N,
+                                       const T_prob& alpha, const T3&,
+                                       const T4&, const T5&) {
     return stan::math::binomial_logit_log<propto>(n, N, alpha);
   }
 
   template <class T_n, class T_N, class T_prob, typename T3, typename T4,
             typename T5>
-  typename stan::return_type<T_prob>::type log_prob_function(
-      const T_n& n, const T_N& N, const T_prob& alpha, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_prob> log_prob_function(const T_n& n, const T_N& N,
+                                                const T_prob& alpha, const T3&,
+                                                const T4&, const T5&) {
     using stan::math::binomial_coefficient_log;
     using stan::math::inv_logit;
     using stan::math::log1m;

--- a/test/prob/binomial/binomial_test.hpp
+++ b/test/prob/binomial/binomial_test.hpp
@@ -43,27 +43,25 @@ class AgradDistributionsBinomial : public AgradDistributionTest {
 
   template <class T_n, class T_N, class T_prob, typename T3, typename T4,
             typename T5>
-  typename stan::return_type<T_prob>::type log_prob(const T_n& n, const T_N& N,
-                                                    const T_prob& theta,
-                                                    const T3&, const T4&,
-                                                    const T5&) {
+  stan::return_type_t<T_prob> log_prob(const T_n& n, const T_N& N,
+                                       const T_prob& theta, const T3&,
+                                       const T4&, const T5&) {
     return stan::math::binomial_log(n, N, theta);
   }
 
   template <bool propto, class T_n, class T_N, class T_prob, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_prob>::type log_prob(const T_n& n, const T_N& N,
-                                                    const T_prob& theta,
-                                                    const T3&, const T4&,
-                                                    const T5&) {
+  stan::return_type_t<T_prob> log_prob(const T_n& n, const T_N& N,
+                                       const T_prob& theta, const T3&,
+                                       const T4&, const T5&) {
     return stan::math::binomial_log<propto>(n, N, theta);
   }
 
   template <class T_n, class T_N, class T_prob, typename T3, typename T4,
             typename T5>
-  typename stan::return_type<T_prob>::type log_prob_function(
-      const T_n& n, const T_N& N, const T_prob& theta, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_prob> log_prob_function(const T_n& n, const T_N& N,
+                                                const T_prob& theta, const T3&,
+                                                const T4&, const T5&) {
     using stan::math::binomial_coefficient_log;
     using stan::math::log1m;
     using stan::math::multiply_log;

--- a/test/prob/cauchy/cauchy_ccdf_log_test.hpp
+++ b/test/prob/cauchy/cauchy_ccdf_log_test.hpp
@@ -62,15 +62,17 @@ class AgradCcdfLogCauchy : public AgradCcdfLogTest {
 
   template <typename T_y, typename T_loc, typename T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale>::type ccdf_log(
-      const T_y& y, const T_loc& mu, const T_scale& sigma, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_y, T_loc, T_scale> ccdf_log(const T_y& y,
+                                                    const T_loc& mu,
+                                                    const T_scale& sigma,
+                                                    const T3&, const T4&,
+                                                    const T5&) {
     return stan::math::cauchy_ccdf_log(y, mu, sigma);
   }
 
   template <typename T_y, typename T_loc, typename T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale>::type ccdf_log_function(
+  stan::return_type_t<T_y, T_loc, T_scale> ccdf_log_function(
       const T_y& y, const T_loc& mu, const T_scale& sigma, const T3&, const T4&,
       const T5&) {
     using stan::math::pi;

--- a/test/prob/cauchy/cauchy_cdf_log_test.hpp
+++ b/test/prob/cauchy/cauchy_cdf_log_test.hpp
@@ -60,15 +60,17 @@ class AgradCdfLogCauchy : public AgradCdfLogTest {
 
   template <typename T_y, typename T_loc, typename T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale>::type cdf_log(
-      const T_y& y, const T_loc& mu, const T_scale& sigma, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_y, T_loc, T_scale> cdf_log(const T_y& y,
+                                                   const T_loc& mu,
+                                                   const T_scale& sigma,
+                                                   const T3&, const T4&,
+                                                   const T5&) {
     return stan::math::cauchy_cdf_log(y, mu, sigma);
   }
 
   template <typename T_y, typename T_loc, typename T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale>::type cdf_log_function(
+  stan::return_type_t<T_y, T_loc, T_scale> cdf_log_function(
       const T_y& y, const T_loc& mu, const T_scale& sigma, const T3&, const T4&,
       const T5&) {
     using stan::math::pi;

--- a/test/prob/cauchy/cauchy_cdf_test.hpp
+++ b/test/prob/cauchy/cauchy_cdf_test.hpp
@@ -59,17 +59,19 @@ class AgradCdfCauchy : public AgradCdfTest {
 
   template <typename T_y, typename T_loc, typename T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale>::type cdf(
-      const T_y& y, const T_loc& mu, const T_scale& sigma, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_y, T_loc, T_scale> cdf(const T_y& y, const T_loc& mu,
+                                               const T_scale& sigma, const T3&,
+                                               const T4&, const T5&) {
     return stan::math::cauchy_cdf(y, mu, sigma);
   }
 
   template <typename T_y, typename T_loc, typename T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale>::type cdf_function(
-      const T_y& y, const T_loc& mu, const T_scale& sigma, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_y, T_loc, T_scale> cdf_function(const T_y& y,
+                                                        const T_loc& mu,
+                                                        const T_scale& sigma,
+                                                        const T3&, const T4&,
+                                                        const T5&) {
     using stan::math::pi;
     using std::atan2;
     return atan2(y - mu, sigma) / pi() + 0.5;

--- a/test/prob/cauchy/cauchy_test.hpp
+++ b/test/prob/cauchy/cauchy_test.hpp
@@ -56,23 +56,27 @@ class AgradDistributionsCauchy : public AgradDistributionTest {
 
   template <typename T_y, typename T_loc, typename T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale>::type log_prob(
-      const T_y& y, const T_loc& mu, const T_scale& sigma, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_y, T_loc, T_scale> log_prob(const T_y& y,
+                                                    const T_loc& mu,
+                                                    const T_scale& sigma,
+                                                    const T3&, const T4&,
+                                                    const T5&) {
     return stan::math::cauchy_log(y, mu, sigma);
   }
 
   template <bool propto, typename T_y, typename T_loc, typename T_scale,
             typename T3, typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale>::type log_prob(
-      const T_y& y, const T_loc& mu, const T_scale& sigma, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_y, T_loc, T_scale> log_prob(const T_y& y,
+                                                    const T_loc& mu,
+                                                    const T_scale& sigma,
+                                                    const T3&, const T4&,
+                                                    const T5&) {
     return stan::math::cauchy_log<propto>(y, mu, sigma);
   }
 
   template <typename T_y, typename T_loc, typename T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale>::type log_prob_function(
+  stan::return_type_t<T_y, T_loc, T_scale> log_prob_function(
       const T_y& y, const T_loc& mu, const T_scale& sigma, const T3&, const T4&,
       const T5&) {
     using stan::math::log1p;

--- a/test/prob/chi_square/chi_square_ccdf_log_test.hpp
+++ b/test/prob/chi_square/chi_square_ccdf_log_test.hpp
@@ -48,17 +48,18 @@ class AgradCcdfLogChiSquare : public AgradCcdfLogTest {
 
   template <typename T_y, typename T_dof, typename T2, typename T3, typename T4,
             typename T5>
-  typename stan::return_type<T_y, T_dof, T2>::type ccdf_log(
-      const T_y& y, const T_dof& nu, const T2&, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_y, T_dof, T2> ccdf_log(const T_y& y, const T_dof& nu,
+                                               const T2&, const T3&, const T4&,
+                                               const T5&) {
     return stan::math::chi_square_ccdf_log(y, nu);
   }
 
   template <typename T_y, typename T_dof, typename T2, typename T3, typename T4,
             typename T5>
-  typename stan::return_type<T_y, T_dof, T2>::type ccdf_log_function(
-      const T_y& y, const T_dof& nu, const T2&, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_y, T_dof, T2> ccdf_log_function(const T_y& y,
+                                                        const T_dof& nu,
+                                                        const T2&, const T3&,
+                                                        const T4&, const T5&) {
     using stan::math::gamma_q;
     using std::log;
 

--- a/test/prob/chi_square/chi_square_cdf_log_test.hpp
+++ b/test/prob/chi_square/chi_square_cdf_log_test.hpp
@@ -46,19 +46,18 @@ class AgradCdfLogChiSquare : public AgradCdfLogTest {
 
   template <typename T_y, typename T_dof, typename T2, typename T3, typename T4,
             typename T5>
-  typename stan::return_type<T_y, T_dof, T2>::type cdf_log(const T_y& y,
-                                                           const T_dof& nu,
-                                                           const T2&, const T3&,
-                                                           const T4&,
-                                                           const T5&) {
+  stan::return_type_t<T_y, T_dof, T2> cdf_log(const T_y& y, const T_dof& nu,
+                                              const T2&, const T3&, const T4&,
+                                              const T5&) {
     return stan::math::chi_square_cdf_log(y, nu);
   }
 
   template <typename T_y, typename T_dof, typename T2, typename T3, typename T4,
             typename T5>
-  typename stan::return_type<T_y, T_dof, T2>::type cdf_log_function(
-      const T_y& y, const T_dof& nu, const T2&, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_y, T_dof, T2> cdf_log_function(const T_y& y,
+                                                       const T_dof& nu,
+                                                       const T2&, const T3&,
+                                                       const T4&, const T5&) {
     using stan::math::gamma_p;
     using std::log;
 

--- a/test/prob/chi_square/chi_square_cdf_test.hpp
+++ b/test/prob/chi_square/chi_square_cdf_test.hpp
@@ -45,18 +45,18 @@ class AgradCdfChiSquare : public AgradCdfTest {
 
   template <typename T_y, typename T_dof, typename T2, typename T3, typename T4,
             typename T5>
-  typename stan::return_type<T_y, T_dof, T2>::type cdf(const T_y& y,
-                                                       const T_dof& nu,
-                                                       const T2&, const T3&,
-                                                       const T4&, const T5&) {
+  stan::return_type_t<T_y, T_dof, T2> cdf(const T_y& y, const T_dof& nu,
+                                          const T2&, const T3&, const T4&,
+                                          const T5&) {
     return stan::math::chi_square_cdf(y, nu);
   }
 
   template <typename T_y, typename T_dof, typename T2, typename T3, typename T4,
             typename T5>
-  typename stan::return_type<T_y, T_dof, T2>::type cdf_function(
-      const T_y& y, const T_dof& nu, const T2&, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_y, T_dof, T2> cdf_function(const T_y& y,
+                                                   const T_dof& nu, const T2&,
+                                                   const T3&, const T4&,
+                                                   const T5&) {
     using stan::math::gamma_p;
 
     return gamma_p(nu * 0.5, y * 0.5);

--- a/test/prob/chi_square/chi_square_test.hpp
+++ b/test/prob/chi_square/chi_square_test.hpp
@@ -38,26 +38,26 @@ class AgradDistributionsChiSquare : public AgradDistributionTest {
 
   template <typename T_y, typename T_dof, typename T2, typename T3, typename T4,
             typename T5>
-  typename stan::return_type<T_y, T_dof, T2>::type log_prob(
-      const T_y& y, const T_dof& nu, const T2&, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_y, T_dof, T2> log_prob(const T_y& y, const T_dof& nu,
+                                               const T2&, const T3&, const T4&,
+                                               const T5&) {
     return stan::math::chi_square_log(y, nu);
   }
 
   template <bool propto, typename T_y, typename T_dof, typename T2, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_dof>::type log_prob(const T_y& y,
-                                                        const T_dof& nu,
-                                                        const T2&, const T3&,
-                                                        const T4&, const T5&) {
+  stan::return_type_t<T_y, T_dof> log_prob(const T_y& y, const T_dof& nu,
+                                           const T2&, const T3&, const T4&,
+                                           const T5&) {
     return stan::math::chi_square_log<propto>(y, nu);
   }
 
   template <typename T_y, typename T_dof, typename T2, typename T3, typename T4,
             typename T5>
-  typename stan::return_type<T_y, T_dof>::type log_prob_function(
-      const T_y& y, const T_dof& nu, const T2&, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_y, T_dof> log_prob_function(const T_y& y,
+                                                    const T_dof& nu, const T2&,
+                                                    const T3&, const T4&,
+                                                    const T5&) {
     using boost::math::lgamma;
     using stan::math::HALF_LOG_TWO;
     using stan::math::multiply_log;

--- a/test/prob/double_exponential/double_exponential_ccdf_log_test.hpp
+++ b/test/prob/double_exponential/double_exponential_ccdf_log_test.hpp
@@ -86,15 +86,17 @@ class AgradCcdfLogDoubleExponential : public AgradCcdfLogTest {
 
   template <typename T_y, typename T_loc, typename T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale>::type ccdf_log(
-      const T_y& y, const T_loc& mu, const T_scale& sigma, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_y, T_loc, T_scale> ccdf_log(const T_y& y,
+                                                    const T_loc& mu,
+                                                    const T_scale& sigma,
+                                                    const T3&, const T4&,
+                                                    const T5&) {
     return stan::math::double_exponential_ccdf_log(y, mu, sigma);
   }
 
   template <typename T_y, typename T_loc, typename T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale>::type ccdf_log_function(
+  stan::return_type_t<T_y, T_loc, T_scale> ccdf_log_function(
       const T_y& y, const T_loc& mu, const T_scale& sigma, const T3&, const T4&,
       const T5&) {
     return stan::math::double_exponential_ccdf_log(y, mu, sigma);

--- a/test/prob/double_exponential/double_exponential_cdf_log_test.hpp
+++ b/test/prob/double_exponential/double_exponential_cdf_log_test.hpp
@@ -83,15 +83,17 @@ class AgradCdfLogDoubleExponential : public AgradCdfLogTest {
 
   template <typename T_y, typename T_loc, typename T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale>::type cdf_log(
-      const T_y& y, const T_loc& mu, const T_scale& sigma, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_y, T_loc, T_scale> cdf_log(const T_y& y,
+                                                   const T_loc& mu,
+                                                   const T_scale& sigma,
+                                                   const T3&, const T4&,
+                                                   const T5&) {
     return stan::math::double_exponential_cdf_log(y, mu, sigma);
   }
 
   template <typename T_y, typename T_loc, typename T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale>::type cdf_log_function(
+  stan::return_type_t<T_y, T_loc, T_scale> cdf_log_function(
       const T_y& y, const T_loc& mu, const T_scale& sigma, const T3&, const T4&,
       const T5&) {
     return stan::math::double_exponential_cdf_log(y, mu, sigma);

--- a/test/prob/double_exponential/double_exponential_cdf_test.hpp
+++ b/test/prob/double_exponential/double_exponential_cdf_test.hpp
@@ -80,17 +80,19 @@ class AgradCdfDoubleExponential : public AgradCdfTest {
 
   template <typename T_y, typename T_loc, typename T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale>::type cdf(
-      const T_y& y, const T_loc& mu, const T_scale& sigma, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_y, T_loc, T_scale> cdf(const T_y& y, const T_loc& mu,
+                                               const T_scale& sigma, const T3&,
+                                               const T4&, const T5&) {
     return stan::math::double_exponential_cdf(y, mu, sigma);
   }
 
   template <typename T_y, typename T_loc, typename T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale>::type cdf_function(
-      const T_y& y, const T_loc& mu, const T_scale& sigma, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_y, T_loc, T_scale> cdf_function(const T_y& y,
+                                                        const T_loc& mu,
+                                                        const T_scale& sigma,
+                                                        const T3&, const T4&,
+                                                        const T5&) {
     return stan::math::double_exponential_cdf(y, mu, sigma);
   }
 };

--- a/test/prob/double_exponential/double_exponential_test.hpp
+++ b/test/prob/double_exponential/double_exponential_test.hpp
@@ -83,23 +83,27 @@ class AgradDistributionsDoubleExponential : public AgradDistributionTest {
 
   template <typename T_y, typename T_loc, typename T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale>::type log_prob(
-      const T_y& y, const T_loc& mu, const T_scale& sigma, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_y, T_loc, T_scale> log_prob(const T_y& y,
+                                                    const T_loc& mu,
+                                                    const T_scale& sigma,
+                                                    const T3&, const T4&,
+                                                    const T5&) {
     return stan::math::double_exponential_log(y, mu, sigma);
   }
 
   template <bool propto, typename T_y, typename T_loc, typename T_scale,
             typename T3, typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale>::type log_prob(
-      const T_y& y, const T_loc& mu, const T_scale& sigma, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_y, T_loc, T_scale> log_prob(const T_y& y,
+                                                    const T_loc& mu,
+                                                    const T_scale& sigma,
+                                                    const T3&, const T4&,
+                                                    const T5&) {
     return stan::math::double_exponential_log<propto>(y, mu, sigma);
   }
 
   template <typename T_y, typename T_loc, typename T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale>::type log_prob_function(
+  stan::return_type_t<T_y, T_loc, T_scale> log_prob_function(
       const T_y& y, const T_loc& mu, const T_scale& sigma, const T3&, const T4&,
       const T5&) {
     using stan::math::LOG_TWO;

--- a/test/prob/exp_mod_normal/exp_mod_normal_ccdf_log_test.hpp
+++ b/test/prob/exp_mod_normal/exp_mod_normal_ccdf_log_test.hpp
@@ -68,7 +68,7 @@ class AgradCcdfLogExpModNormal : public AgradCcdfLogTest {
 
   template <typename T_y, typename T_loc, typename T_scale,
             typename T_inv_scale, typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale, T_inv_scale>::type ccdf_log(
+  stan::return_type_t<T_y, T_loc, T_scale, T_inv_scale> ccdf_log(
       const T_y& y, const T_loc& mu, const T_scale& sigma,
       const T_inv_scale& lambda, const T4&, const T5&) {
     return stan::math::exp_mod_normal_ccdf_log(y, mu, sigma, lambda);
@@ -76,9 +76,9 @@ class AgradCcdfLogExpModNormal : public AgradCcdfLogTest {
 
   template <typename T_y, typename T_loc, typename T_scale,
             typename T_inv_scale, typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale, T_inv_scale>::type
-  ccdf_log_function(const T_y& y, const T_loc& mu, const T_scale& sigma,
-                    const T_inv_scale& lambda, const T4&, const T5&) {
+  stan::return_type_t<T_y, T_loc, T_scale, T_inv_scale> ccdf_log_function(
+      const T_y& y, const T_loc& mu, const T_scale& sigma,
+      const T_inv_scale& lambda, const T4&, const T5&) {
     return log(
         1.0
         - (0.5 * (1 + erf((y - mu) / (sqrt(2.0) * sigma)))

--- a/test/prob/exp_mod_normal/exp_mod_normal_cdf_log_test.hpp
+++ b/test/prob/exp_mod_normal/exp_mod_normal_cdf_log_test.hpp
@@ -66,7 +66,7 @@ class AgradCdfLogExpModNormal : public AgradCdfLogTest {
 
   template <typename T_y, typename T_loc, typename T_scale,
             typename T_inv_scale, typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale, T_inv_scale>::type cdf_log(
+  stan::return_type_t<T_y, T_loc, T_scale, T_inv_scale> cdf_log(
       const T_y& y, const T_loc& mu, const T_scale& sigma,
       const T_inv_scale& lambda, const T4&, const T5&) {
     return stan::math::exp_mod_normal_cdf_log(y, mu, sigma, lambda);
@@ -74,9 +74,9 @@ class AgradCdfLogExpModNormal : public AgradCdfLogTest {
 
   template <typename T_y, typename T_loc, typename T_scale,
             typename T_inv_scale, typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale, T_inv_scale>::type
-  cdf_log_function(const T_y& y, const T_loc& mu, const T_scale& sigma,
-                   const T_inv_scale& lambda, const T4&, const T5&) {
+  stan::return_type_t<T_y, T_loc, T_scale, T_inv_scale> cdf_log_function(
+      const T_y& y, const T_loc& mu, const T_scale& sigma,
+      const T_inv_scale& lambda, const T4&, const T5&) {
     return log(0.5 * (1 + erf((y - mu) / (sqrt(2.0) * sigma)))
                - exp(-lambda * (y - mu) + lambda * sigma * lambda * sigma / 2.0)
                      * 0.5

--- a/test/prob/exp_mod_normal/exp_mod_normal_cdf_test.hpp
+++ b/test/prob/exp_mod_normal/exp_mod_normal_cdf_test.hpp
@@ -79,7 +79,7 @@ class AgradCdfExpModNormal : public AgradCdfTest {
 
   template <typename T_y, typename T_loc, typename T_scale,
             typename T_inv_scale, typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale, T_inv_scale>::type cdf(
+  stan::return_type_t<T_y, T_loc, T_scale, T_inv_scale> cdf(
       const T_y& y, const T_loc& mu, const T_scale& sigma,
       const T_inv_scale& lambda, const T4&, const T5&) {
     return stan::math::exp_mod_normal_cdf(y, mu, sigma, lambda);
@@ -87,9 +87,9 @@ class AgradCdfExpModNormal : public AgradCdfTest {
 
   template <typename T_y, typename T_loc, typename T_scale,
             typename T_inv_scale, typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale, T_inv_scale>::type
-  cdf_function(const T_y& y, const T_loc& mu, const T_scale& sigma,
-               const T_inv_scale& lambda, const T4&, const T5&) {
+  stan::return_type_t<T_y, T_loc, T_scale, T_inv_scale> cdf_function(
+      const T_y& y, const T_loc& mu, const T_scale& sigma,
+      const T_inv_scale& lambda, const T4&, const T5&) {
     return 0.5 * (1 + erf((y - mu) / (sqrt(2.0) * sigma)))
            - exp(-lambda * (y - mu) + lambda * sigma * lambda * sigma / 2.0)
                  * (0.5

--- a/test/prob/exp_mod_normal/exp_mod_normal_test.hpp
+++ b/test/prob/exp_mod_normal/exp_mod_normal_test.hpp
@@ -73,7 +73,7 @@ class AgradDistributionExpModNormal : public AgradDistributionTest {
 
   template <typename T_y, typename T_loc, typename T_scale,
             typename T_inv_scale, typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale, T_inv_scale>::type log_prob(
+  stan::return_type_t<T_y, T_loc, T_scale, T_inv_scale> log_prob(
       const T_y& y, const T_loc& mu, const T_scale& sigma,
       const T_inv_scale& lambda, const T4&, const T5&) {
     return stan::math::exp_mod_normal_log(y, mu, sigma, lambda);
@@ -81,7 +81,7 @@ class AgradDistributionExpModNormal : public AgradDistributionTest {
 
   template <bool propto, typename T_y, typename T_loc, typename T_scale,
             typename T_inv_scale, typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale, T_inv_scale>::type log_prob(
+  stan::return_type_t<T_y, T_loc, T_scale, T_inv_scale> log_prob(
       const T_y& y, const T_loc& mu, const T_scale& sigma,
       const T_inv_scale& lambda, const T4&, const T5&) {
     return stan::math::exp_mod_normal_log<propto>(y, mu, sigma, lambda);
@@ -89,9 +89,9 @@ class AgradDistributionExpModNormal : public AgradDistributionTest {
 
   template <typename T_y, typename T_loc, typename T_scale,
             typename T_inv_scale, typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale, T_inv_scale>::type
-  log_prob_function(const T_y& y, const T_loc& mu, const T_scale& sigma,
-                    const T_inv_scale& lambda, const T4&, const T5&) {
+  stan::return_type_t<T_y, T_loc, T_scale, T_inv_scale> log_prob_function(
+      const T_y& y, const T_loc& mu, const T_scale& sigma,
+      const T_inv_scale& lambda, const T4&, const T5&) {
     return log(2) + log(lambda)
            + lambda * (mu + 0.5 * lambda * sigma * sigma - y)
            + log(erfc((mu + lambda * sigma * sigma - y) / (sqrt(2.0) * sigma)));

--- a/test/prob/exponential/exponential_ccdf_log_test.hpp
+++ b/test/prob/exponential/exponential_ccdf_log_test.hpp
@@ -52,15 +52,16 @@ class AgradCcdfLogExponential : public AgradCcdfLogTest {
 
   template <typename T_y, typename T_inv_scale, typename T2, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_inv_scale>::type ccdf_log(
-      const T_y& y, const T_inv_scale& beta, const T2&, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_y, T_inv_scale> ccdf_log(const T_y& y,
+                                                 const T_inv_scale& beta,
+                                                 const T2&, const T3&,
+                                                 const T4&, const T5&) {
     return stan::math::exponential_ccdf_log(y, beta);
   }
 
   template <typename T_y, typename T_inv_scale, typename T2, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_inv_scale>::type ccdf_log_function(
+  stan::return_type_t<T_y, T_inv_scale> ccdf_log_function(
       const T_y& y, const T_inv_scale& beta, const T2&, const T3&, const T4&,
       const T5&) {
     using std::exp;

--- a/test/prob/exponential/exponential_cdf_log_test.hpp
+++ b/test/prob/exponential/exponential_cdf_log_test.hpp
@@ -52,15 +52,16 @@ class AgradCdfLogExponential : public AgradCdfLogTest {
 
   template <typename T_y, typename T_inv_scale, typename T2, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_inv_scale>::type cdf_log(
-      const T_y& y, const T_inv_scale& beta, const T2&, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_y, T_inv_scale> cdf_log(const T_y& y,
+                                                const T_inv_scale& beta,
+                                                const T2&, const T3&, const T4&,
+                                                const T5&) {
     return stan::math::exponential_cdf_log(y, beta);
   }
 
   template <typename T_y, typename T_inv_scale, typename T2, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_inv_scale>::type cdf_log_function(
+  stan::return_type_t<T_y, T_inv_scale> cdf_log_function(
       const T_y& y, const T_inv_scale& beta, const T2&, const T3&, const T4&,
       const T5&) {
     using std::exp;

--- a/test/prob/exponential/exponential_cdf_test.hpp
+++ b/test/prob/exponential/exponential_cdf_test.hpp
@@ -51,17 +51,18 @@ class AgradCdfExponential : public AgradCdfTest {
 
   template <typename T_y, typename T_inv_scale, typename T2, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_inv_scale>::type cdf(
-      const T_y& y, const T_inv_scale& beta, const T2&, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_y, T_inv_scale> cdf(const T_y& y,
+                                            const T_inv_scale& beta, const T2&,
+                                            const T3&, const T4&, const T5&) {
     return stan::math::exponential_cdf(y, beta);
   }
 
   template <typename T_y, typename T_inv_scale, typename T2, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_inv_scale>::type cdf_function(
-      const T_y& y, const T_inv_scale& beta, const T2&, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_y, T_inv_scale> cdf_function(const T_y& y,
+                                                     const T_inv_scale& beta,
+                                                     const T2&, const T3&,
+                                                     const T4&, const T5&) {
     using std::exp;
     using std::log;
 

--- a/test/prob/exponential/exponential_test.hpp
+++ b/test/prob/exponential/exponential_test.hpp
@@ -51,23 +51,25 @@ class AgradDistributionsExponential : public AgradDistributionTest {
 
   template <typename T_y, typename T_inv_scale, typename T2, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_inv_scale>::type log_prob(
-      const T_y& y, const T_inv_scale& beta, const T2&, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_y, T_inv_scale> log_prob(const T_y& y,
+                                                 const T_inv_scale& beta,
+                                                 const T2&, const T3&,
+                                                 const T4&, const T5&) {
     return stan::math::exponential_log(y, beta);
   }
 
   template <bool propto, typename T_y, typename T_inv_scale, typename T2,
             typename T3, typename T4, typename T5>
-  typename stan::return_type<T_y, T_inv_scale>::type log_prob(
-      const T_y& y, const T_inv_scale& beta, const T2&, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_y, T_inv_scale> log_prob(const T_y& y,
+                                                 const T_inv_scale& beta,
+                                                 const T2&, const T3&,
+                                                 const T4&, const T5&) {
     return stan::math::exponential_log<propto>(y, beta);
   }
 
   template <typename T_y, typename T_inv_scale, typename T2, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_inv_scale>::type log_prob_function(
+  stan::return_type_t<T_y, T_inv_scale> log_prob_function(
       const T_y& y, const T_inv_scale& beta, const T2&, const T3&, const T4&,
       const T5&) {
     return log(beta) - beta * y;

--- a/test/prob/frechet/frechet_ccdf_log_test.hpp
+++ b/test/prob/frechet/frechet_ccdf_log_test.hpp
@@ -56,15 +56,17 @@ class AgradCcdfLogFrechet : public AgradCcdfLogTest {
 
   template <typename T_y, typename T_shape, typename T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_shape, T_scale>::type ccdf_log(
-      const T_y& y, const T_shape& alpha, const T_scale& sigma, const T3&,
-      const T4&, const T5&) {
+  stan::return_type_t<T_y, T_shape, T_scale> ccdf_log(const T_y& y,
+                                                      const T_shape& alpha,
+                                                      const T_scale& sigma,
+                                                      const T3&, const T4&,
+                                                      const T5&) {
     return stan::math::frechet_ccdf_log(y, alpha, sigma);
   }
 
   template <typename T_y, typename T_shape, typename T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_shape, T_scale>::type ccdf_log_function(
+  stan::return_type_t<T_y, T_shape, T_scale> ccdf_log_function(
       const T_y& y, const T_shape& alpha, const T_scale& sigma, const T3&,
       const T4&, const T5&) {
     using std::exp;

--- a/test/prob/frechet/frechet_cdf_log_test.hpp
+++ b/test/prob/frechet/frechet_cdf_log_test.hpp
@@ -61,15 +61,17 @@ class AgradCdfLogFrechet : public AgradCdfLogTest {
 
   template <typename T_y, typename T_shape, typename T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_shape, T_scale>::type cdf_log(
-      const T_y& y, const T_shape& alpha, const T_scale& sigma, const T3&,
-      const T4&, const T5&) {
+  stan::return_type_t<T_y, T_shape, T_scale> cdf_log(const T_y& y,
+                                                     const T_shape& alpha,
+                                                     const T_scale& sigma,
+                                                     const T3&, const T4&,
+                                                     const T5&) {
     return stan::math::frechet_cdf_log(y, alpha, sigma);
   }
 
   template <typename T_y, typename T_shape, typename T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_shape, T_scale>::type cdf_log_function(
+  stan::return_type_t<T_y, T_shape, T_scale> cdf_log_function(
       const T_y& y, const T_shape& alpha, const T_scale& sigma, const T3&,
       const T4&, const T5&) {
     using std::log;

--- a/test/prob/frechet/frechet_cdf_test.hpp
+++ b/test/prob/frechet/frechet_cdf_test.hpp
@@ -60,17 +60,21 @@ class AgradCdfFrechet : public AgradCdfTest {
 
   template <typename T_y, typename T_shape, typename T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_shape, T_scale>::type cdf(
-      const T_y& y, const T_shape& alpha, const T_scale& sigma, const T3&,
-      const T4&, const T5&) {
+  stan::return_type_t<T_y, T_shape, T_scale> cdf(const T_y& y,
+                                                 const T_shape& alpha,
+                                                 const T_scale& sigma,
+                                                 const T3&, const T4&,
+                                                 const T5&) {
     return stan::math::frechet_cdf(y, alpha, sigma);
   }
 
   template <typename T_y, typename T_shape, typename T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_shape, T_scale>::type cdf_function(
-      const T_y& y, const T_shape& alpha, const T_scale& sigma, const T3&,
-      const T4&, const T5&) {
+  stan::return_type_t<T_y, T_shape, T_scale> cdf_function(const T_y& y,
+                                                          const T_shape& alpha,
+                                                          const T_scale& sigma,
+                                                          const T3&, const T4&,
+                                                          const T5&) {
     using std::log;
     using std::pow;
     return exp(-pow(sigma / y, alpha));

--- a/test/prob/frechet/frechet_test.hpp
+++ b/test/prob/frechet/frechet_test.hpp
@@ -50,23 +50,27 @@ class AgradDistributionsFrechet : public AgradDistributionTest {
 
   template <typename T_y, typename T_shape, typename T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_shape, T_scale>::type log_prob(
-      const T_y& y, const T_shape& alpha, const T_scale& sigma, const T3&,
-      const T4&, const T5&) {
+  stan::return_type_t<T_y, T_shape, T_scale> log_prob(const T_y& y,
+                                                      const T_shape& alpha,
+                                                      const T_scale& sigma,
+                                                      const T3&, const T4&,
+                                                      const T5&) {
     return stan::math::frechet_log(y, alpha, sigma);
   }
 
   template <bool propto, typename T_y, typename T_shape, typename T_scale,
             typename T3, typename T4, typename T5>
-  typename stan::return_type<T_y, T_shape, T_scale>::type log_prob(
-      const T_y& y, const T_shape& alpha, const T_scale& sigma, const T3&,
-      const T4&, const T5&) {
+  stan::return_type_t<T_y, T_shape, T_scale> log_prob(const T_y& y,
+                                                      const T_shape& alpha,
+                                                      const T_scale& sigma,
+                                                      const T3&, const T4&,
+                                                      const T5&) {
     return stan::math::frechet_log<propto>(y, alpha, sigma);
   }
 
   template <typename T_y, typename T_shape, typename T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_shape, T_scale>::type log_prob_function(
+  stan::return_type_t<T_y, T_shape, T_scale> log_prob_function(
       const T_y& y, const T_shape& alpha, const T_scale& sigma, const T3&,
       const T4&, const T5&) {
     using stan::math::include_summand;

--- a/test/prob/gamma/gamma_ccdf_log_test.hpp
+++ b/test/prob/gamma/gamma_ccdf_log_test.hpp
@@ -79,7 +79,7 @@ class AgradCcdfLogGamma : public AgradCcdfLogTest {
 
   template <typename T_y, typename T_shape, typename T_inv_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_shape, T_inv_scale>::type ccdf_log(
+  stan::return_type_t<T_y, T_shape, T_inv_scale> ccdf_log(
       const T_y& y, const T_shape& alpha, const T_inv_scale& beta, const T3&,
       const T4&, const T5&) {
     return stan::math::gamma_ccdf_log(y, alpha, beta);
@@ -87,7 +87,7 @@ class AgradCcdfLogGamma : public AgradCcdfLogTest {
 
   template <typename T_y, typename T_shape, typename T_inv_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_shape, T_inv_scale>::type ccdf_log_function(
+  stan::return_type_t<T_y, T_shape, T_inv_scale> ccdf_log_function(
       const T_y& y, const T_shape& alpha, const T_inv_scale& beta, const T3&,
       const T4&, const T5&) {
     using boost::math::gamma_q;

--- a/test/prob/gamma/gamma_cdf_log_test.hpp
+++ b/test/prob/gamma/gamma_cdf_log_test.hpp
@@ -70,7 +70,7 @@ class AgradCdfLogGamma : public AgradCdfLogTest {
 
   template <typename T_y, typename T_shape, typename T_inv_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_shape, T_inv_scale>::type cdf_log(
+  stan::return_type_t<T_y, T_shape, T_inv_scale> cdf_log(
       const T_y& y, const T_shape& alpha, const T_inv_scale& beta, const T3&,
       const T4&, const T5&) {
     return stan::math::gamma_cdf_log(y, alpha, beta);
@@ -78,7 +78,7 @@ class AgradCdfLogGamma : public AgradCdfLogTest {
 
   template <typename T_y, typename T_shape, typename T_inv_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_shape, T_inv_scale>::type cdf_log_function(
+  stan::return_type_t<T_y, T_shape, T_inv_scale> cdf_log_function(
       const T_y& y, const T_shape& alpha, const T_inv_scale& beta, const T3&,
       const T4&, const T5&) {
     using boost::math::gamma_p;

--- a/test/prob/gamma/gamma_cdf_test.hpp
+++ b/test/prob/gamma/gamma_cdf_test.hpp
@@ -69,15 +69,17 @@ class AgradCdfGamma : public AgradCdfTest {
 
   template <typename T_y, typename T_shape, typename T_inv_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_shape, T_inv_scale>::type cdf(
-      const T_y& y, const T_shape& alpha, const T_inv_scale& beta, const T3&,
-      const T4&, const T5&) {
+  stan::return_type_t<T_y, T_shape, T_inv_scale> cdf(const T_y& y,
+                                                     const T_shape& alpha,
+                                                     const T_inv_scale& beta,
+                                                     const T3&, const T4&,
+                                                     const T5&) {
     return stan::math::gamma_cdf(y, alpha, beta);
   }
 
   template <typename T_y, typename T_shape, typename T_inv_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_shape, T_inv_scale>::type cdf_function(
+  stan::return_type_t<T_y, T_shape, T_inv_scale> cdf_function(
       const T_y& y, const T_shape& alpha, const T_inv_scale& beta, const T3&,
       const T4&, const T5&) {
     using boost::math::gamma_p;

--- a/test/prob/gamma/gamma_test.hpp
+++ b/test/prob/gamma/gamma_test.hpp
@@ -62,7 +62,7 @@ class AgradDistributionsGamma : public AgradDistributionTest {
 
   template <typename T_y, typename T_shape, typename T_inv_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_shape, T_inv_scale>::type log_prob(
+  stan::return_type_t<T_y, T_shape, T_inv_scale> log_prob(
       const T_y& y, const T_shape& alpha, const T_inv_scale& beta, const T3&,
       const T4&, const T5&) {
     return stan::math::gamma_log(y, alpha, beta);
@@ -70,7 +70,7 @@ class AgradDistributionsGamma : public AgradDistributionTest {
 
   template <bool propto, typename T_y, typename T_shape, typename T_inv_scale,
             typename T3, typename T4, typename T5>
-  typename stan::return_type<T_y, T_shape, T_inv_scale>::type log_prob(
+  stan::return_type_t<T_y, T_shape, T_inv_scale> log_prob(
       const T_y& y, const T_shape& alpha, const T_inv_scale& beta, const T3&,
       const T4&, const T5&) {
     return stan::math::gamma_log<propto>(y, alpha, beta);
@@ -78,7 +78,7 @@ class AgradDistributionsGamma : public AgradDistributionTest {
 
   template <typename T_y, typename T_shape, typename T_inv_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_shape, T_inv_scale>::type log_prob_function(
+  stan::return_type_t<T_y, T_shape, T_inv_scale> log_prob_function(
       const T_y& y, const T_shape& alpha, const T_inv_scale& beta, const T3&,
       const T4&, const T5&) {
     using stan::math::multiply_log;

--- a/test/prob/gumbel/gumbel_ccdf_log_test.hpp
+++ b/test/prob/gumbel/gumbel_ccdf_log_test.hpp
@@ -67,15 +67,17 @@ class AgradCcdfLogGumbel : public AgradCcdfLogTest {
 
   template <typename T_y, typename T_loc, typename T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale>::type ccdf_log(
-      const T_y& y, const T_loc& mu, const T_scale& beta, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_y, T_loc, T_scale> ccdf_log(const T_y& y,
+                                                    const T_loc& mu,
+                                                    const T_scale& beta,
+                                                    const T3&, const T4&,
+                                                    const T5&) {
     return stan::math::gumbel_ccdf_log(y, mu, beta);
   }
 
   template <typename T_y, typename T_loc, typename T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale>::type ccdf_log_function(
+  stan::return_type_t<T_y, T_loc, T_scale> ccdf_log_function(
       const T_y& y, const T_loc& mu, const T_scale& beta, const T3&, const T4&,
       const T5&) {
     return log(1.0 - exp(-exp(-(y - mu) / beta)));

--- a/test/prob/gumbel/gumbel_cdf_log_test.hpp
+++ b/test/prob/gumbel/gumbel_cdf_log_test.hpp
@@ -66,15 +66,17 @@ class AgradCdfLogGumbel : public AgradCdfLogTest {
 
   template <typename T_y, typename T_loc, typename T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale>::type cdf_log(
-      const T_y& y, const T_loc& mu, const T_scale& beta, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_y, T_loc, T_scale> cdf_log(const T_y& y,
+                                                   const T_loc& mu,
+                                                   const T_scale& beta,
+                                                   const T3&, const T4&,
+                                                   const T5&) {
     return stan::math::gumbel_cdf_log(y, mu, beta);
   }
 
   template <typename T_y, typename T_loc, typename T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale>::type cdf_log_function(
+  stan::return_type_t<T_y, T_loc, T_scale> cdf_log_function(
       const T_y& y, const T_loc& mu, const T_scale& beta, const T3&, const T4&,
       const T5&) {
     return -exp(-(y - mu) / beta);

--- a/test/prob/gumbel/gumbel_cdf_test.hpp
+++ b/test/prob/gumbel/gumbel_cdf_test.hpp
@@ -70,17 +70,19 @@ class AgradCdfGumbel : public AgradCdfTest {
 
   template <typename T_y, typename T_loc, typename T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale>::type cdf(
-      const T_y& y, const T_loc& mu, const T_scale& beta, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_y, T_loc, T_scale> cdf(const T_y& y, const T_loc& mu,
+                                               const T_scale& beta, const T3&,
+                                               const T4&, const T5&) {
     return stan::math::gumbel_cdf(y, mu, beta);
   }
 
   template <typename T_y, typename T_loc, typename T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale>::type cdf_function(
-      const T_y& y, const T_loc& mu, const T_scale& beta, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_y, T_loc, T_scale> cdf_function(const T_y& y,
+                                                        const T_loc& mu,
+                                                        const T_scale& beta,
+                                                        const T3&, const T4&,
+                                                        const T5&) {
     return exp(-exp(-(y - mu) / beta));
   }
 };

--- a/test/prob/gumbel/gumbel_test.hpp
+++ b/test/prob/gumbel/gumbel_test.hpp
@@ -65,23 +65,27 @@ class AgradDistributionGumbel : public AgradDistributionTest {
 
   template <typename T_y, typename T_loc, typename T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale>::type log_prob(
-      const T_y& y, const T_loc& mu, const T_scale& beta, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_y, T_loc, T_scale> log_prob(const T_y& y,
+                                                    const T_loc& mu,
+                                                    const T_scale& beta,
+                                                    const T3&, const T4&,
+                                                    const T5&) {
     return stan::math::gumbel_log(y, mu, beta);
   }
 
   template <bool propto, typename T_y, typename T_loc, typename T_scale,
             typename T3, typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale>::type log_prob(
-      const T_y& y, const T_loc& mu, const T_scale& beta, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_y, T_loc, T_scale> log_prob(const T_y& y,
+                                                    const T_loc& mu,
+                                                    const T_scale& beta,
+                                                    const T3&, const T4&,
+                                                    const T5&) {
     return stan::math::gumbel_log<propto>(y, mu, beta);
   }
 
   template <typename T_y, typename T_loc, typename T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale>::type log_prob_function(
+  stan::return_type_t<T_y, T_loc, T_scale> log_prob_function(
       const T_y& y, const T_loc& mu, const T_scale& beta, const T3&, const T4&,
       const T5&) {
     return -log(beta) - (y - mu) / beta + exp((mu - y) / beta);

--- a/test/prob/hypergeometric/hypergeometric_test.hpp
+++ b/test/prob/hypergeometric/hypergeometric_test.hpp
@@ -47,9 +47,9 @@ class AgradDistributionsHypergeometric : public AgradDistributionTest {
 
   template <class T_n, class T_N, class T_a, class T_b, typename T4,
             typename T5>
-  typename stan::return_type<T_n, T_N, T_a, T_b>::type log_prob(
-      const T_n& n, const T_N& N, const T_a& a, const T_b& b, const T4&,
-      const T5&) {
+  stan::return_type_t<T_n, T_N, T_a, T_b> log_prob(const T_n& n, const T_N& N,
+                                                   const T_a& a, const T_b& b,
+                                                   const T4&, const T5&) {
     return stan::math::hypergeometric_log(n, N, a, b);
   }
 

--- a/test/prob/inv_chi_square/inv_chi_square_ccdf_log_test.hpp
+++ b/test/prob/inv_chi_square/inv_chi_square_ccdf_log_test.hpp
@@ -42,18 +42,18 @@ class AgradCcdfLogInvChiSquare : public AgradCcdfLogTest {
 
   template <typename T_y, typename T_dof, typename T2, typename T3, typename T4,
             typename T5>
-  typename stan::return_type<T_y, T_dof>::type ccdf_log(const T_y& y,
-                                                        const T_dof& nu,
-                                                        const T2&, const T3&,
-                                                        const T4&, const T5&) {
+  stan::return_type_t<T_y, T_dof> ccdf_log(const T_y& y, const T_dof& nu,
+                                           const T2&, const T3&, const T4&,
+                                           const T5&) {
     return stan::math::inv_chi_square_ccdf_log(y, nu);
   }
 
   template <typename T_y, typename T_dof, typename T2, typename T3, typename T4,
             typename T5>
-  typename stan::return_type<T_y, T_dof>::type ccdf_log_function(
-      const T_y& y, const T_dof& nu, const T2&, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_y, T_dof> ccdf_log_function(const T_y& y,
+                                                    const T_dof& nu, const T2&,
+                                                    const T3&, const T4&,
+                                                    const T5&) {
     using stan::math::gamma_p;
 
     return log(1.0 - gamma_p(0.5 * nu, 0.5 / y));

--- a/test/prob/inv_chi_square/inv_chi_square_cdf_log_test.hpp
+++ b/test/prob/inv_chi_square/inv_chi_square_cdf_log_test.hpp
@@ -42,18 +42,18 @@ class AgradCdfLogInvChiSquare : public AgradCdfLogTest {
 
   template <typename T_y, typename T_dof, typename T2, typename T3, typename T4,
             typename T5>
-  typename stan::return_type<T_y, T_dof>::type cdf_log(const T_y& y,
-                                                       const T_dof& nu,
-                                                       const T2&, const T3&,
-                                                       const T4&, const T5&) {
+  stan::return_type_t<T_y, T_dof> cdf_log(const T_y& y, const T_dof& nu,
+                                          const T2&, const T3&, const T4&,
+                                          const T5&) {
     return stan::math::inv_chi_square_cdf_log(y, nu);
   }
 
   template <typename T_y, typename T_dof, typename T2, typename T3, typename T4,
             typename T5>
-  typename stan::return_type<T_y, T_dof>::type cdf_log_function(
-      const T_y& y, const T_dof& nu, const T2&, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_y, T_dof> cdf_log_function(const T_y& y,
+                                                   const T_dof& nu, const T2&,
+                                                   const T3&, const T4&,
+                                                   const T5&) {
     using stan::math::gamma_q;
 
     return log(gamma_q(0.5 * nu, 0.5 / y));

--- a/test/prob/inv_chi_square/inv_chi_square_cdf_test.hpp
+++ b/test/prob/inv_chi_square/inv_chi_square_cdf_test.hpp
@@ -40,18 +40,16 @@ class AgradCdfInvChiSquare : public AgradCdfTest {
 
   template <typename T_y, typename T_dof, typename T2, typename T3, typename T4,
             typename T5>
-  typename stan::return_type<T_y, T_dof>::type cdf(const T_y& y,
-                                                   const T_dof& nu, const T2&,
-                                                   const T3&, const T4&,
-                                                   const T5&) {
+  stan::return_type_t<T_y, T_dof> cdf(const T_y& y, const T_dof& nu, const T2&,
+                                      const T3&, const T4&, const T5&) {
     return stan::math::inv_chi_square_cdf(y, nu);
   }
 
   template <typename T_y, typename T_dof, typename T2, typename T3, typename T4,
             typename T5>
-  typename stan::return_type<T_y, T_dof>::type cdf_function(
-      const T_y& y, const T_dof& nu, const T2&, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_y, T_dof> cdf_function(const T_y& y, const T_dof& nu,
+                                               const T2&, const T3&, const T4&,
+                                               const T5&) {
     using stan::math::gamma_q;
 
     return gamma_q(0.5 * nu, 0.5 / y);

--- a/test/prob/inv_chi_square/inv_chi_square_test.hpp
+++ b/test/prob/inv_chi_square/inv_chi_square_test.hpp
@@ -38,27 +38,26 @@ class AgradDistributionsInvChiSquare : public AgradDistributionTest {
 
   template <typename T_y, typename T_dof, typename T2, typename T3, typename T4,
             typename T5>
-  typename stan::return_type<T_y, T_dof>::type log_prob(const T_y& y,
-                                                        const T_dof& nu,
-                                                        const T2&, const T3&,
-                                                        const T4&, const T5&) {
+  stan::return_type_t<T_y, T_dof> log_prob(const T_y& y, const T_dof& nu,
+                                           const T2&, const T3&, const T4&,
+                                           const T5&) {
     return stan::math::inv_chi_square_log(y, nu);
   }
 
   template <bool propto, typename T_y, typename T_dof, typename T2, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_dof>::type log_prob(const T_y& y,
-                                                        const T_dof& nu,
-                                                        const T2&, const T3&,
-                                                        const T4&, const T5&) {
+  stan::return_type_t<T_y, T_dof> log_prob(const T_y& y, const T_dof& nu,
+                                           const T2&, const T3&, const T4&,
+                                           const T5&) {
     return stan::math::inv_chi_square_log<propto>(y, nu);
   }
 
   template <typename T_y, typename T_dof, typename T2, typename T3, typename T4,
             typename T5>
-  typename stan::return_type<T_y, T_dof>::type log_prob_function(
-      const T_y& y, const T_dof& nu, const T2&, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_y, T_dof> log_prob_function(const T_y& y,
+                                                    const T_dof& nu, const T2&,
+                                                    const T3&, const T4&,
+                                                    const T5&) {
     using boost::math::lgamma;
     using stan::math::HALF_LOG_TWO;
     using stan::math::multiply_log;

--- a/test/prob/inv_gamma/inv_gamma_ccdf_log_test.hpp
+++ b/test/prob/inv_gamma/inv_gamma_ccdf_log_test.hpp
@@ -53,15 +53,17 @@ class AgradCcdfLogInvGamma : public AgradCcdfLogTest {
 
   template <typename T_y, typename T_shape, typename T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_shape, T_scale>::type ccdf_log(
-      const T_y& y, const T_shape& alpha, const T_scale& beta, const T3&,
-      const T4&, const T5&) {
+  stan::return_type_t<T_y, T_shape, T_scale> ccdf_log(const T_y& y,
+                                                      const T_shape& alpha,
+                                                      const T_scale& beta,
+                                                      const T3&, const T4&,
+                                                      const T5&) {
     return stan::math::inv_gamma_ccdf_log(y, alpha, beta);
   }
 
   template <typename T_y, typename T_shape, typename T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_shape, T_scale>::type ccdf_log_function(
+  stan::return_type_t<T_y, T_shape, T_scale> ccdf_log_function(
       const T_y& y, const T_shape& alpha, const T_scale& beta, const T3&,
       const T4&, const T5&) {
     using stan::math::gamma_p;

--- a/test/prob/inv_gamma/inv_gamma_cdf_log_test.hpp
+++ b/test/prob/inv_gamma/inv_gamma_cdf_log_test.hpp
@@ -53,15 +53,17 @@ class AgradCdfLogInvGamma : public AgradCdfLogTest {
 
   template <typename T_y, typename T_shape, typename T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_shape, T_scale>::type cdf_log(
-      const T_y& y, const T_shape& alpha, const T_scale& beta, const T3&,
-      const T4&, const T5&) {
+  stan::return_type_t<T_y, T_shape, T_scale> cdf_log(const T_y& y,
+                                                     const T_shape& alpha,
+                                                     const T_scale& beta,
+                                                     const T3&, const T4&,
+                                                     const T5&) {
     return stan::math::inv_gamma_cdf_log(y, alpha, beta);
   }
 
   template <typename T_y, typename T_shape, typename T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_shape, T_scale>::type cdf_log_function(
+  stan::return_type_t<T_y, T_shape, T_scale> cdf_log_function(
       const T_y& y, const T_shape& alpha, const T_scale& beta, const T3&,
       const T4&, const T5&) {
     using stan::math::gamma_q;

--- a/test/prob/inv_gamma/inv_gamma_cdf_test.hpp
+++ b/test/prob/inv_gamma/inv_gamma_cdf_test.hpp
@@ -51,17 +51,20 @@ class AgradCdfInvGamma : public AgradCdfTest {
 
   template <typename T_y, typename T_shape, typename T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_shape, T_scale>::type cdf(
-      const T_y& y, const T_shape& alpha, const T_scale& beta, const T3&,
-      const T4&, const T5&) {
+  stan::return_type_t<T_y, T_shape, T_scale> cdf(const T_y& y,
+                                                 const T_shape& alpha,
+                                                 const T_scale& beta, const T3&,
+                                                 const T4&, const T5&) {
     return stan::math::inv_gamma_cdf(y, alpha, beta);
   }
 
   template <typename T_y, typename T_shape, typename T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_shape, T_scale>::type cdf_function(
-      const T_y& y, const T_shape& alpha, const T_scale& beta, const T3&,
-      const T4&, const T5&) {
+  stan::return_type_t<T_y, T_shape, T_scale> cdf_function(const T_y& y,
+                                                          const T_shape& alpha,
+                                                          const T_scale& beta,
+                                                          const T3&, const T4&,
+                                                          const T5&) {
     using stan::math::gamma_q;
 
     return (gamma_q(alpha, beta / y));

--- a/test/prob/inv_gamma/inv_gamma_test.hpp
+++ b/test/prob/inv_gamma/inv_gamma_test.hpp
@@ -56,23 +56,27 @@ class AgradDistributionsInvGamma : public AgradDistributionTest {
 
   template <typename T_y, typename T_shape, typename T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_shape, T_scale>::type log_prob(
-      const T_y& y, const T_shape& alpha, const T_scale& beta, const T3&,
-      const T4&, const T5&) {
+  stan::return_type_t<T_y, T_shape, T_scale> log_prob(const T_y& y,
+                                                      const T_shape& alpha,
+                                                      const T_scale& beta,
+                                                      const T3&, const T4&,
+                                                      const T5&) {
     return stan::math::inv_gamma_log(y, alpha, beta);
   }
 
   template <bool propto, typename T_y, typename T_shape, typename T_scale,
             typename T3, typename T4, typename T5>
-  typename stan::return_type<T_y, T_shape, T_scale>::type log_prob(
-      const T_y& y, const T_shape& alpha, const T_scale& beta, const T3&,
-      const T4&, const T5&) {
+  stan::return_type_t<T_y, T_shape, T_scale> log_prob(const T_y& y,
+                                                      const T_shape& alpha,
+                                                      const T_scale& beta,
+                                                      const T3&, const T4&,
+                                                      const T5&) {
     return stan::math::inv_gamma_log<propto>(y, alpha, beta);
   }
 
   template <typename T_y, typename T_shape, typename T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_shape, T_scale>::type log_prob_function(
+  stan::return_type_t<T_y, T_shape, T_scale> log_prob_function(
       const T_y& y, const T_shape& alpha, const T_scale& beta, const T3&,
       const T4&, const T5&) {
     if (y <= 0)

--- a/test/prob/logistic/logistic_ccdf_log_test.hpp
+++ b/test/prob/logistic/logistic_ccdf_log_test.hpp
@@ -44,15 +44,17 @@ class AgradCcdfLogLogistic : public AgradCcdfLogTest {
 
   template <typename T_y, typename T_loc, typename T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale>::type ccdf_log(
-      const T_y& y, const T_loc& mu, const T_scale& sigma, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_y, T_loc, T_scale> ccdf_log(const T_y& y,
+                                                    const T_loc& mu,
+                                                    const T_scale& sigma,
+                                                    const T3&, const T4&,
+                                                    const T5&) {
     return stan::math::logistic_ccdf_log(y, mu, sigma);
   }
 
   template <typename T_y, typename T_loc, typename T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale>::type ccdf_log_function(
+  stan::return_type_t<T_y, T_loc, T_scale> ccdf_log_function(
       const T_y& y, const T_loc& mu, const T_scale& sigma, const T3&, const T4&,
       const T5&) {
     return log(1.0 - 1.0 / (1.0 + exp(-(y - mu) / sigma)));

--- a/test/prob/logistic/logistic_cdf_log_test.hpp
+++ b/test/prob/logistic/logistic_cdf_log_test.hpp
@@ -43,15 +43,17 @@ class AgradCdfLogLogistic : public AgradCdfLogTest {
 
   template <typename T_y, typename T_loc, typename T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale>::type cdf_log(
-      const T_y& y, const T_loc& mu, const T_scale& sigma, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_y, T_loc, T_scale> cdf_log(const T_y& y,
+                                                   const T_loc& mu,
+                                                   const T_scale& sigma,
+                                                   const T3&, const T4&,
+                                                   const T5&) {
     return stan::math::logistic_cdf_log(y, mu, sigma);
   }
 
   template <typename T_y, typename T_loc, typename T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale>::type cdf_log_function(
+  stan::return_type_t<T_y, T_loc, T_scale> cdf_log_function(
       const T_y& y, const T_loc& mu, const T_scale& sigma, const T3&, const T4&,
       const T5&) {
     return -log(1.0 + exp(-(y - mu) / sigma));

--- a/test/prob/logistic/logistic_cdf_test.hpp
+++ b/test/prob/logistic/logistic_cdf_test.hpp
@@ -42,17 +42,19 @@ class AgradCdfLogistic : public AgradCdfTest {
 
   template <typename T_y, typename T_loc, typename T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale>::type cdf(
-      const T_y& y, const T_loc& mu, const T_scale& sigma, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_y, T_loc, T_scale> cdf(const T_y& y, const T_loc& mu,
+                                               const T_scale& sigma, const T3&,
+                                               const T4&, const T5&) {
     return stan::math::logistic_cdf(y, mu, sigma);
   }
 
   template <typename T_y, typename T_loc, typename T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale>::type cdf_function(
-      const T_y& y, const T_loc& mu, const T_scale& sigma, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_y, T_loc, T_scale> cdf_function(const T_y& y,
+                                                        const T_loc& mu,
+                                                        const T_scale& sigma,
+                                                        const T3&, const T4&,
+                                                        const T5&) {
     return 1.0 / (1.0 + exp(-(y - mu) / sigma));
   }
 };

--- a/test/prob/logistic/logistic_test.hpp
+++ b/test/prob/logistic/logistic_test.hpp
@@ -50,23 +50,27 @@ class AgradDistributionsLogistic : public AgradDistributionTest {
 
   template <typename T_y, typename T_loc, typename T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale>::type log_prob(
-      const T_y& y, const T_loc& mu, const T_scale& sigma, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_y, T_loc, T_scale> log_prob(const T_y& y,
+                                                    const T_loc& mu,
+                                                    const T_scale& sigma,
+                                                    const T3&, const T4&,
+                                                    const T5&) {
     return stan::math::logistic_log(y, mu, sigma);
   }
 
   template <bool propto, typename T_y, typename T_loc, typename T_scale,
             typename T3, typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale>::type log_prob(
-      const T_y& y, const T_loc& mu, const T_scale& sigma, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_y, T_loc, T_scale> log_prob(const T_y& y,
+                                                    const T_loc& mu,
+                                                    const T_scale& sigma,
+                                                    const T3&, const T4&,
+                                                    const T5&) {
     return stan::math::logistic_log<propto>(y, mu, sigma);
   }
 
   template <typename T_y, typename T_loc, typename T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale>::type log_prob_function(
+  stan::return_type_t<T_y, T_loc, T_scale> log_prob_function(
       const T_y& y, const T_loc& mu, const T_scale& sigma, const T3&, const T4&,
       const T5&) {
     using stan::math::log1p;

--- a/test/prob/lognormal/lognormal_ccdf_log_test.hpp
+++ b/test/prob/lognormal/lognormal_ccdf_log_test.hpp
@@ -63,15 +63,17 @@ class AgradCcdfLogLognormal : public AgradCcdfLogTest {
 
   template <typename T_y, typename T_loc, typename T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale>::type ccdf_log(
-      const T_y& y, const T_loc& mu, const T_scale& sigma, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_y, T_loc, T_scale> ccdf_log(const T_y& y,
+                                                    const T_loc& mu,
+                                                    const T_scale& sigma,
+                                                    const T3&, const T4&,
+                                                    const T5&) {
     return stan::math::lognormal_ccdf_log(y, mu, sigma);
   }
 
   template <typename T_y, typename T_loc, typename T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale>::type ccdf_log_function(
+  stan::return_type_t<T_y, T_loc, T_scale> ccdf_log_function(
       const T_y& y, const T_loc& mu, const T_scale& sigma, const T3&, const T4&,
       const T5&) {
     return log(1.0 - 0.5 * erfc(-(log(y) - mu) / (std::sqrt(2) * sigma)));

--- a/test/prob/lognormal/lognormal_cdf_log_test.hpp
+++ b/test/prob/lognormal/lognormal_cdf_log_test.hpp
@@ -61,15 +61,17 @@ class AgradCdfLogLognormal : public AgradCdfLogTest {
 
   template <typename T_y, typename T_loc, typename T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale>::type cdf_log(
-      const T_y& y, const T_loc& mu, const T_scale& sigma, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_y, T_loc, T_scale> cdf_log(const T_y& y,
+                                                   const T_loc& mu,
+                                                   const T_scale& sigma,
+                                                   const T3&, const T4&,
+                                                   const T5&) {
     return stan::math::lognormal_cdf_log(y, mu, sigma);
   }
 
   template <typename T_y, typename T_loc, typename T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale>::type cdf_log_function(
+  stan::return_type_t<T_y, T_loc, T_scale> cdf_log_function(
       const T_y& y, const T_loc& mu, const T_scale& sigma, const T3&, const T4&,
       const T5&) {
     return log(0.5 * erfc(-(log(y) - mu) / (std::sqrt(2) * sigma)));

--- a/test/prob/lognormal/lognormal_cdf_test.hpp
+++ b/test/prob/lognormal/lognormal_cdf_test.hpp
@@ -60,17 +60,19 @@ class AgradCdfLognormal : public AgradCdfTest {
 
   template <typename T_y, typename T_loc, typename T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale>::type cdf(
-      const T_y& y, const T_loc& mu, const T_scale& sigma, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_y, T_loc, T_scale> cdf(const T_y& y, const T_loc& mu,
+                                               const T_scale& sigma, const T3&,
+                                               const T4&, const T5&) {
     return stan::math::lognormal_cdf(y, mu, sigma);
   }
 
   template <typename T_y, typename T_loc, typename T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale>::type cdf_function(
-      const T_y& y, const T_loc& mu, const T_scale& sigma, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_y, T_loc, T_scale> cdf_function(const T_y& y,
+                                                        const T_loc& mu,
+                                                        const T_scale& sigma,
+                                                        const T3&, const T4&,
+                                                        const T5&) {
     return 0.5 * erfc(-(log(y) - mu) / (std::sqrt(2) * sigma));
   }
 };

--- a/test/prob/lognormal/lognormal_test.hpp
+++ b/test/prob/lognormal/lognormal_test.hpp
@@ -50,23 +50,27 @@ class AgradDistributionsLognormal : public AgradDistributionTest {
 
   template <typename T_y, typename T_loc, typename T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale>::type log_prob(
-      const T_y& y, const T_loc& mu, const T_scale& sigma, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_y, T_loc, T_scale> log_prob(const T_y& y,
+                                                    const T_loc& mu,
+                                                    const T_scale& sigma,
+                                                    const T3&, const T4&,
+                                                    const T5&) {
     return stan::math::lognormal_log(y, mu, sigma);
   }
 
   template <bool propto, typename T_y, typename T_loc, typename T_scale,
             typename T3, typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale>::type log_prob(
-      const T_y& y, const T_loc& mu, const T_scale& sigma, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_y, T_loc, T_scale> log_prob(const T_y& y,
+                                                    const T_loc& mu,
+                                                    const T_scale& sigma,
+                                                    const T3&, const T4&,
+                                                    const T5&) {
     return stan::math::lognormal_log<propto>(y, mu, sigma);
   }
 
   template <typename T_y, typename T_loc, typename T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale>::type log_prob_function(
+  stan::return_type_t<T_y, T_loc, T_scale> log_prob_function(
       const T_y& y, const T_loc& mu, const T_scale& sigma, const T3&, const T4&,
       const T5&) {
     using stan::math::NEG_LOG_SQRT_TWO_PI;

--- a/test/prob/neg_binomial/neg_binomial_ccdf_log_test.hpp
+++ b/test/prob/neg_binomial/neg_binomial_ccdf_log_test.hpp
@@ -43,25 +43,27 @@ class AgradCcdfLogNegBinomial : public AgradCcdfLogTest {
 
   template <typename T_n, typename T_shape, typename T_inv_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_shape, T_inv_scale>::type ccdf_log(
-      const T_n& n, const T_shape& alpha, const T_inv_scale& beta, const T3&,
-      const T4&, const T5&) {
+  stan::return_type_t<T_shape, T_inv_scale> ccdf_log(const T_n& n,
+                                                     const T_shape& alpha,
+                                                     const T_inv_scale& beta,
+                                                     const T3&, const T4&,
+                                                     const T5&) {
     return stan::math::neg_binomial_ccdf_log(n, alpha, beta);
   }
 
   template <typename T_n, typename T_shape, typename T_inv_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_shape, T_inv_scale>::type ccdf_log_function(
+  stan::return_type_t<T_shape, T_inv_scale> ccdf_log_function(
       const T_n& n, const T_shape& alpha, const T_inv_scale& beta, const T3&,
       const T4&, const T5&) {
     using stan::math::binomial_coefficient_log;
     using std::exp;
     using std::log;
 
-    typename stan::return_type<T_shape, T_inv_scale>::type cdf(0);
+    stan::return_type_t<T_shape, T_inv_scale> cdf(0);
 
     for (int i = 0; i <= n; i++) {
-      typename stan::return_type<T_shape, T_inv_scale>::type temp;
+      stan::return_type_t<T_shape, T_inv_scale> temp;
       temp = binomial_coefficient_log(i + alpha - 1, i);
 
       cdf += exp(temp + alpha * log(beta / (1 + beta))

--- a/test/prob/neg_binomial/neg_binomial_cdf_log_test.hpp
+++ b/test/prob/neg_binomial/neg_binomial_cdf_log_test.hpp
@@ -41,25 +41,27 @@ class AgradCdfLogNegBinomial : public AgradCdfLogTest {
 
   template <typename T_n, typename T_shape, typename T_inv_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_shape, T_inv_scale>::type cdf_log(
-      const T_n& n, const T_shape& alpha, const T_inv_scale& beta, const T3&,
-      const T4&, const T5&) {
+  stan::return_type_t<T_shape, T_inv_scale> cdf_log(const T_n& n,
+                                                    const T_shape& alpha,
+                                                    const T_inv_scale& beta,
+                                                    const T3&, const T4&,
+                                                    const T5&) {
     return stan::math::neg_binomial_cdf_log(n, alpha, beta);
   }
 
   template <typename T_n, typename T_shape, typename T_inv_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_shape, T_inv_scale>::type cdf_log_function(
+  stan::return_type_t<T_shape, T_inv_scale> cdf_log_function(
       const T_n& n, const T_shape& alpha, const T_inv_scale& beta, const T3&,
       const T4&, const T5&) {
     using stan::math::binomial_coefficient_log;
     using std::exp;
     using std::log;
 
-    typename stan::return_type<T_shape, T_inv_scale>::type cdf(0);
+    stan::return_type_t<T_shape, T_inv_scale> cdf(0);
 
     for (int i = 0; i <= n; i++) {
-      typename stan::return_type<T_shape, T_inv_scale>::type temp;
+      stan::return_type_t<T_shape, T_inv_scale> temp;
       temp = binomial_coefficient_log(i + alpha - 1, i);
 
       cdf += exp(temp + alpha * log(beta / (1 + beta))

--- a/test/prob/neg_binomial/neg_binomial_cdf_test.hpp
+++ b/test/prob/neg_binomial/neg_binomial_cdf_test.hpp
@@ -40,25 +40,27 @@ class AgradCdfNegBinomial : public AgradCdfTest {
 
   template <typename T_n, typename T_shape, typename T_inv_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_shape, T_inv_scale>::type cdf(
-      const T_n& n, const T_shape& alpha, const T_inv_scale& beta, const T3&,
-      const T4&, const T5&) {
+  stan::return_type_t<T_shape, T_inv_scale> cdf(const T_n& n,
+                                                const T_shape& alpha,
+                                                const T_inv_scale& beta,
+                                                const T3&, const T4&,
+                                                const T5&) {
     return stan::math::neg_binomial_cdf(n, alpha, beta);
   }
 
   template <typename T_n, typename T_shape, typename T_inv_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_shape, T_inv_scale>::type cdf_function(
+  stan::return_type_t<T_shape, T_inv_scale> cdf_function(
       const T_n& n, const T_shape& alpha, const T_inv_scale& beta, const T3&,
       const T4&, const T5&) {
     using stan::math::binomial_coefficient_log;
     using std::exp;
     using std::log;
 
-    typename stan::return_type<T_shape, T_inv_scale>::type cdf(0);
+    stan::return_type_t<T_shape, T_inv_scale> cdf(0);
 
     for (int i = 0; i <= n; i++) {
-      typename stan::return_type<T_shape, T_inv_scale>::type temp;
+      stan::return_type_t<T_shape, T_inv_scale> temp;
       temp = binomial_coefficient_log(i + alpha - 1, i);
 
       cdf += exp(temp + alpha * log(beta / (1 + beta))

--- a/test/prob/neg_binomial/neg_binomial_test.hpp
+++ b/test/prob/neg_binomial/neg_binomial_test.hpp
@@ -47,23 +47,27 @@ class AgradDistributionsNegBinomial : public AgradDistributionTest {
 
   template <class T_n, class T_shape, class T_inv_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_shape, T_inv_scale>::type log_prob(
-      const T_n& n, const T_shape& alpha, const T_inv_scale& beta, const T3&,
-      const T4&, const T5&) {
+  stan::return_type_t<T_shape, T_inv_scale> log_prob(const T_n& n,
+                                                     const T_shape& alpha,
+                                                     const T_inv_scale& beta,
+                                                     const T3&, const T4&,
+                                                     const T5&) {
     return stan::math::neg_binomial_log(n, alpha, beta);
   }
 
   template <bool propto, class T_n, class T_shape, class T_inv_scale,
             typename T3, typename T4, typename T5>
-  typename stan::return_type<T_shape, T_inv_scale>::type log_prob(
-      const T_n& n, const T_shape& alpha, const T_inv_scale& beta, const T3&,
-      const T4&, const T5) {
+  stan::return_type_t<T_shape, T_inv_scale> log_prob(const T_n& n,
+                                                     const T_shape& alpha,
+                                                     const T_inv_scale& beta,
+                                                     const T3&, const T4&,
+                                                     const T5) {
     return stan::math::neg_binomial_log<propto>(n, alpha, beta);
   }
 
   template <class T_n, class T_shape, class T_inv_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_shape, T_inv_scale>::type log_prob_function(
+  stan::return_type_t<T_shape, T_inv_scale> log_prob_function(
       const T_n& n, const T_shape& alpha, const T_inv_scale& beta, const T3&,
       const T4&, const T5&) {
     using stan::math::binomial_coefficient_log;

--- a/test/prob/neg_binomial_2/neg_binomial_2_ccdf_log_test.hpp
+++ b/test/prob/neg_binomial_2/neg_binomial_2_ccdf_log_test.hpp
@@ -64,15 +64,17 @@ class AgradCdfLogNegBinomial2 : public AgradCcdfLogTest {
 
   template <typename T_n, typename T_location, typename T_precision,
             typename T3, typename T4, typename T5>
-  typename stan::return_type<T_location, T_precision>::type ccdf_log(
-      const T_n& n, const T_location& alpha, const T_precision& beta, const T3&,
-      const T4&, const T5&) {
+  stan::return_type_t<T_location, T_precision> ccdf_log(const T_n& n,
+                                                        const T_location& alpha,
+                                                        const T_precision& beta,
+                                                        const T3&, const T4&,
+                                                        const T5&) {
     return stan::math::neg_binomial_2_ccdf_log(n, alpha, beta);
   }
 
   template <typename T_n, typename T_location, typename T_precision,
             typename T3, typename T4, typename T5>
-  typename stan::return_type<T_location, T_precision>::type ccdf_log_function(
+  stan::return_type_t<T_location, T_precision> ccdf_log_function(
       const T_n& nn, const T_location& mu, const T_precision& phi, const T3&,
       const T4&, const T5&) {
     using stan::math::binomial_coefficient_log;
@@ -80,10 +82,10 @@ class AgradCdfLogNegBinomial2 : public AgradCcdfLogTest {
     using std::exp;
     using std::log;
 
-    typename stan::return_type<T_location, T_precision>::type ccdf(0);
+    stan::return_type_t<T_location, T_precision> ccdf(0);
 
     for (int n = 0; n <= nn; n++) {
-      typename stan::return_type<T_location, T_precision>::type lp(0);
+      stan::return_type_t<T_location, T_precision> lp(0);
       if (n != 0)
         lp += binomial_coefficient_log<
             typename stan::scalar_type<T_precision>::type>(n + phi - 1.0, n);

--- a/test/prob/neg_binomial_2/neg_binomial_2_cdf_log_test.hpp
+++ b/test/prob/neg_binomial_2/neg_binomial_2_cdf_log_test.hpp
@@ -59,15 +59,17 @@ class AgradCdfLogNegBinomial2 : public AgradCdfLogTest {
 
   template <typename T_n, typename T_location, typename T_precision,
             typename T3, typename T4, typename T5>
-  typename stan::return_type<T_location, T_precision>::type cdf_log(
-      const T_n& n, const T_location& alpha, const T_precision& beta, const T3&,
-      const T4&, const T5&) {
+  stan::return_type_t<T_location, T_precision> cdf_log(const T_n& n,
+                                                       const T_location& alpha,
+                                                       const T_precision& beta,
+                                                       const T3&, const T4&,
+                                                       const T5&) {
     return stan::math::neg_binomial_2_cdf_log(n, alpha, beta);
   }
 
   template <typename T_n, typename T_location, typename T_precision,
             typename T3, typename T4, typename T5>
-  typename stan::return_type<T_location, T_precision>::type cdf_log_function(
+  stan::return_type_t<T_location, T_precision> cdf_log_function(
       const T_n& nn, const T_location& mu, const T_precision& phi, const T3&,
       const T4&, const T5&) {
     using stan::math::binomial_coefficient_log;
@@ -75,10 +77,10 @@ class AgradCdfLogNegBinomial2 : public AgradCdfLogTest {
     using std::exp;
     using std::log;
 
-    typename stan::return_type<T_location, T_precision>::type cdf(0);
+    stan::return_type_t<T_location, T_precision> cdf(0);
 
     for (int n = 0; n <= nn; n++) {
-      typename stan::return_type<T_location, T_precision>::type lp(0);
+      stan::return_type_t<T_location, T_precision> lp(0);
       if (n != 0)
         lp += binomial_coefficient_log<
             typename stan::scalar_type<T_precision>::type>(n + phi - 1.0, n);

--- a/test/prob/neg_binomial_2/neg_binomial_2_cdf_test.hpp
+++ b/test/prob/neg_binomial_2/neg_binomial_2_cdf_test.hpp
@@ -70,15 +70,17 @@ class AgradCdfNegBinomial2 : public AgradCdfTest {
 
   template <typename T_n, typename T_location, typename T_precision,
             typename T3, typename T4, typename T5>
-  typename stan::return_type<T_location, T_precision>::type cdf(
-      const T_n& n, const T_location& alpha, const T_precision& beta, const T3&,
-      const T4&, const T5&) {
+  stan::return_type_t<T_location, T_precision> cdf(const T_n& n,
+                                                   const T_location& alpha,
+                                                   const T_precision& beta,
+                                                   const T3&, const T4&,
+                                                   const T5&) {
     return stan::math::neg_binomial_2_cdf(n, alpha, beta);
   }
 
   template <typename T_n, typename T_location, typename T_precision,
             typename T3, typename T4, typename T5>
-  typename stan::return_type<T_location, T_precision>::type cdf_function(
+  stan::return_type_t<T_location, T_precision> cdf_function(
       const T_n& nn, const T_location& mu, const T_precision& phi, const T3&,
       const T4&, const T5&) {
     using stan::math::binomial_coefficient_log;
@@ -86,10 +88,10 @@ class AgradCdfNegBinomial2 : public AgradCdfTest {
     using std::exp;
     using std::log;
 
-    typename stan::return_type<T_location, T_precision>::type cdf(0);
+    stan::return_type_t<T_location, T_precision> cdf(0);
 
     for (int n = 0; n <= nn; n++) {
-      typename stan::return_type<T_location, T_precision>::type lp(0);
+      stan::return_type_t<T_location, T_precision> lp(0);
       if (n != 0)
         lp += binomial_coefficient_log<
             typename stan::scalar_type<T_precision>::type>(n + phi - 1.0, n);

--- a/test/prob/neg_binomial_2/neg_binomial_2_log_test.hpp
+++ b/test/prob/neg_binomial_2/neg_binomial_2_log_test.hpp
@@ -48,7 +48,7 @@ class AgradDistributionsNegBinomial2Log : public AgradDistributionTest {
 
   template <class T_n, class T_log_location, class T_inv_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_log_location, T_inv_scale>::type log_prob(
+  stan::return_type_t<T_log_location, T_inv_scale> log_prob(
       const T_n& n, const T_log_location& eta, const T_inv_scale& phi,
       const T3&, const T4&, const T5&) {
     return stan::math::neg_binomial_2_log_log(n, eta, phi);
@@ -56,7 +56,7 @@ class AgradDistributionsNegBinomial2Log : public AgradDistributionTest {
 
   template <bool propto, class T_n, class T_log_location, class T_inv_scale,
             typename T3, typename T4, typename T5>
-  typename stan::return_type<T_log_location, T_inv_scale>::type log_prob(
+  stan::return_type_t<T_log_location, T_inv_scale> log_prob(
       const T_n& n, const T_log_location& eta, const T_inv_scale& phi,
       const T3&, const T4&, const T5&) {
     return stan::math::neg_binomial_2_log_log<propto>(n, eta, phi);
@@ -64,9 +64,9 @@ class AgradDistributionsNegBinomial2Log : public AgradDistributionTest {
 
   template <class T_n, class T_log_location, class T_inv_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_log_location, T_inv_scale>::type
-  log_prob_function(const T_n& n, const T_log_location& eta,
-                    const T_inv_scale& phi, const T3&, const T4&, const T5&) {
+  stan::return_type_t<T_log_location, T_inv_scale> log_prob_function(
+      const T_n& n, const T_log_location& eta, const T_inv_scale& phi,
+      const T3&, const T4&, const T5&) {
     using stan::math::binomial_coefficient_log;
     using stan::math::log_sum_exp;
     using stan::math::multiply_log;

--- a/test/prob/neg_binomial_2/neg_binomial_2_test.hpp
+++ b/test/prob/neg_binomial_2/neg_binomial_2_test.hpp
@@ -46,23 +46,27 @@ class AgradDistributionsNegBinomial2 : public AgradDistributionTest {
 
   template <class T_n, class T_location, class T_inv_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_location, T_inv_scale>::type log_prob(
-      const T_n& n, const T_location& mu, const T_inv_scale& phi, const T3&,
-      const T4&, const T5&) {
+  stan::return_type_t<T_location, T_inv_scale> log_prob(const T_n& n,
+                                                        const T_location& mu,
+                                                        const T_inv_scale& phi,
+                                                        const T3&, const T4&,
+                                                        const T5&) {
     return stan::math::neg_binomial_2_log(n, mu, phi);
   }
 
   template <bool propto, class T_n, class T_location, class T_inv_scale,
             typename T3, typename T4, typename T5>
-  typename stan::return_type<T_location, T_inv_scale>::type log_prob(
-      const T_n& n, const T_location& mu, const T_inv_scale& phi, const T3&,
-      const T4&, const T5&) {
+  stan::return_type_t<T_location, T_inv_scale> log_prob(const T_n& n,
+                                                        const T_location& mu,
+                                                        const T_inv_scale& phi,
+                                                        const T3&, const T4&,
+                                                        const T5&) {
     return stan::math::neg_binomial_2_log<propto>(n, mu, phi);
   }
 
   template <class T_n, class T_location, class T_inv_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_location, T_inv_scale>::type log_prob_function(
+  stan::return_type_t<T_location, T_inv_scale> log_prob_function(
       const T_n& n, const T_location& mu, const T_inv_scale& phi, const T3&,
       const T4&, const T5&) {
     using stan::math::binomial_coefficient_log;

--- a/test/prob/normal/normal_ccdf_log_test.hpp
+++ b/test/prob/normal/normal_ccdf_log_test.hpp
@@ -66,15 +66,17 @@ class AgradCcdfLogNormal : public AgradCcdfLogTest {
 
   template <typename T_y, typename T_loc, typename T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale>::type ccdf_log(
-      const T_y& y, const T_loc& mu, const T_scale& sigma, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_y, T_loc, T_scale> ccdf_log(const T_y& y,
+                                                    const T_loc& mu,
+                                                    const T_scale& sigma,
+                                                    const T3&, const T4&,
+                                                    const T5&) {
     return stan::math::normal_ccdf_log(y, mu, sigma);
   }
 
   template <typename T_y, typename T_loc, typename T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale>::type ccdf_log_function(
+  stan::return_type_t<T_y, T_loc, T_scale> ccdf_log_function(
       const T_y& y, const T_loc& mu, const T_scale& sigma, const T3&, const T4&,
       const T5&) {
     using stan::math::SQRT_TWO;

--- a/test/prob/normal/normal_cdf_log_test.hpp
+++ b/test/prob/normal/normal_cdf_log_test.hpp
@@ -70,15 +70,17 @@ class AgradCdfLogNormal : public AgradCdfLogTest {
 
   template <typename T_y, typename T_loc, typename T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale>::type cdf_log(
-      const T_y& y, const T_loc& mu, const T_scale& sigma, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_y, T_loc, T_scale> cdf_log(const T_y& y,
+                                                   const T_loc& mu,
+                                                   const T_scale& sigma,
+                                                   const T3&, const T4&,
+                                                   const T5&) {
     return stan::math::normal_cdf_log(y, mu, sigma);
   }
 
   template <typename T_y, typename T_loc, typename T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale>::type cdf_log_function(
+  stan::return_type_t<T_y, T_loc, T_scale> cdf_log_function(
       const T_y& y, const T_loc& mu, const T_scale& sigma, const T3&, const T4&,
       const T5&) {
     using stan::math::LOG_HALF;

--- a/test/prob/normal/normal_cdf_test.hpp
+++ b/test/prob/normal/normal_cdf_test.hpp
@@ -62,17 +62,19 @@ class AgradCdfNormal : public AgradCdfTest {
 
   template <typename T_y, typename T_loc, typename T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale>::type cdf(
-      const T_y& y, const T_loc& mu, const T_scale& sigma, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_y, T_loc, T_scale> cdf(const T_y& y, const T_loc& mu,
+                                               const T_scale& sigma, const T3&,
+                                               const T4&, const T5&) {
     return stan::math::normal_cdf(y, mu, sigma);
   }
 
   template <typename T_y, typename T_loc, typename T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale>::type cdf_function(
-      const T_y& y, const T_loc& mu, const T_scale& sigma, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_y, T_loc, T_scale> cdf_function(const T_y& y,
+                                                        const T_loc& mu,
+                                                        const T_scale& sigma,
+                                                        const T3&, const T4&,
+                                                        const T5&) {
     using stan::math::SQRT_TWO;
     return (0.5 + 0.5 * erf((y - mu) / (sigma * SQRT_TWO)));
   }

--- a/test/prob/normal/normal_test.hpp
+++ b/test/prob/normal/normal_test.hpp
@@ -59,25 +59,29 @@ class AgradDistributionNormal : public AgradDistributionTest {
 
   template <typename T_y, typename T_loc, typename T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale>::type log_prob(
-      const T_y& y, const T_loc& mu, const T_scale& sigma, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_y, T_loc, T_scale> log_prob(const T_y& y,
+                                                    const T_loc& mu,
+                                                    const T_scale& sigma,
+                                                    const T3&, const T4&,
+                                                    const T5&) {
     return stan::math::normal_log(y, mu, sigma);
   }
 
   template <bool propto, typename T_y, typename T_loc, typename T_scale,
             typename T3, typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale>::type log_prob(
-      const T_y& y, const T_loc& mu, const T_scale& sigma, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_y, T_loc, T_scale> log_prob(const T_y& y,
+                                                    const T_loc& mu,
+                                                    const T_scale& sigma,
+                                                    const T3&, const T4&,
+                                                    const T5&) {
     return stan::math::normal_log<propto>(y, mu, sigma);
   }
 
   template <typename T_y, typename T_loc, typename T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale, T3, T4, T5>::type
-  log_prob_function(const T_y& y, const T_loc& mu, const T_scale& sigma,
-                    const T3&, const T4&, const T5&) {
+  stan::return_type_t<T_y, T_loc, T_scale, T3, T4, T5> log_prob_function(
+      const T_y& y, const T_loc& mu, const T_scale& sigma, const T3&, const T4&,
+      const T5&) {
     using stan::math::pi;
     return -0.5 * (y - mu) * (y - mu) / (sigma * sigma) - log(sigma)
            - log(stan::math::SQRT_TWO_PI);

--- a/test/prob/normal_sufficient/normal_sufficient_test.hpp
+++ b/test/prob/normal_sufficient/normal_sufficient_test.hpp
@@ -71,7 +71,7 @@ class AgradDistributionNormalSufficient : public AgradDistributionTest {
 
   template <typename T_y, typename T_s, typename T_n, typename T_loc,
             typename T_scale, typename T5>
-  typename stan::return_type<T_y, T_s, T_n, T_loc, T_scale>::type log_prob(
+  stan::return_type_t<T_y, T_s, T_n, T_loc, T_scale> log_prob(
       const T_y& y_bar, const T_s& s_squared, const T_n& n_obs, const T_loc& mu,
       const T_scale& sigma, const T5&) {
     return stan::math::normal_sufficient_lpdf(y_bar, s_squared, n_obs, mu,
@@ -80,7 +80,7 @@ class AgradDistributionNormalSufficient : public AgradDistributionTest {
 
   template <bool propto, typename T_y, typename T_s, typename T_n,
             typename T_loc, typename T_scale, typename T5>
-  typename stan::return_type<T_y, T_s, T_n, T_loc, T_scale>::type log_prob(
+  stan::return_type_t<T_y, T_s, T_n, T_loc, T_scale> log_prob(
       const T_y& y_bar, const T_s& s_squared, const T_n& n_obs, const T_loc& mu,
       const T_scale& sigma, const T5&) {
     return stan::math::normal_sufficient_lpdf<propto>(y_bar, s_squared, n_obs,
@@ -89,13 +89,13 @@ class AgradDistributionNormalSufficient : public AgradDistributionTest {
 
   template <typename T_y, typename T_s, typename T_n, typename T_loc,
             typename T_scale, typename T5>
-  typename stan::return_type<T_y, T_s, T_n, T_loc, T_scale>::type
-  log_prob_function(const T_y& y_bar, const T_s& s_squared, const T_n& n_obs,
-                    const T_loc& mu, const T_scale& sigma, const T5&) {
+  stan::return_type_t<T_y, T_s, T_n, T_loc, T_scale> log_prob_function(
+      const T_y& y_bar, const T_s& s_squared, const T_n& n_obs, const T_loc& mu,
+      const T_scale& sigma, const T5&) {
     using stan::math::include_summand;
     using stan::math::pi;
     using stan::math::square;
-    typename stan::return_type<T_y, T_s, T_n, T_loc, T_scale>::type lp(0.0);
+    stan::return_type_t<T_y, T_s, T_n, T_loc, T_scale> lp(0.0);
     if (include_summand<true, T_scale>::value)
       lp -= n_obs * log(sigma);
 

--- a/test/prob/pareto/pareto_ccdf_log_test.hpp
+++ b/test/prob/pareto/pareto_ccdf_log_test.hpp
@@ -53,15 +53,17 @@ class AgradCcdfLogPareto : public AgradCcdfLogTest {
 
   template <typename T_y, typename T_scale, typename T_shape, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_scale, T_shape>::type ccdf_log(
-      const T_y& y, const T_scale& y_min, const T_shape& alpha, const T3&,
-      const T4&, const T5&) {
+  stan::return_type_t<T_y, T_scale, T_shape> ccdf_log(const T_y& y,
+                                                      const T_scale& y_min,
+                                                      const T_shape& alpha,
+                                                      const T3&, const T4&,
+                                                      const T5&) {
     return stan::math::pareto_ccdf_log(y, y_min, alpha);
   }
 
   template <typename T_y, typename T_scale, typename T_shape, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_scale, T_shape>::type ccdf_log_function(
+  stan::return_type_t<T_y, T_scale, T_shape> ccdf_log_function(
       const T_y& y, const T_scale& y_min, const T_shape& alpha, const T3&,
       const T4&, const T5&) {
     using std::exp;

--- a/test/prob/pareto/pareto_cdf_log_test.hpp
+++ b/test/prob/pareto/pareto_cdf_log_test.hpp
@@ -52,15 +52,17 @@ class AgradCdfLogPareto : public AgradCdfLogTest {
 
   template <typename T_y, typename T_scale, typename T_shape, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_scale, T_shape>::type cdf_log(
-      const T_y& y, const T_scale& y_min, const T_shape& alpha, const T3&,
-      const T4&, const T5&) {
+  stan::return_type_t<T_y, T_scale, T_shape> cdf_log(const T_y& y,
+                                                     const T_scale& y_min,
+                                                     const T_shape& alpha,
+                                                     const T3&, const T4&,
+                                                     const T5&) {
     return stan::math::pareto_cdf_log(y, y_min, alpha);
   }
 
   template <typename T_y, typename T_scale, typename T_shape, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_scale, T_shape>::type cdf_log_function(
+  stan::return_type_t<T_y, T_scale, T_shape> cdf_log_function(
       const T_y& y, const T_scale& y_min, const T_shape& alpha, const T3&,
       const T4&, const T5&) {
     using std::exp;

--- a/test/prob/pareto/pareto_cdf_test.hpp
+++ b/test/prob/pareto/pareto_cdf_test.hpp
@@ -51,17 +51,21 @@ class AgradCdfPareto : public AgradCdfTest {
 
   template <typename T_y, typename T_scale, typename T_shape, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_scale, T_shape>::type cdf(
-      const T_y& y, const T_scale& y_min, const T_shape& alpha, const T3&,
-      const T4&, const T5&) {
+  stan::return_type_t<T_y, T_scale, T_shape> cdf(const T_y& y,
+                                                 const T_scale& y_min,
+                                                 const T_shape& alpha,
+                                                 const T3&, const T4&,
+                                                 const T5&) {
     return stan::math::pareto_cdf(y, y_min, alpha);
   }
 
   template <typename T_y, typename T_scale, typename T_shape, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_scale, T_shape>::type cdf_function(
-      const T_y& y, const T_scale& y_min, const T_shape& alpha, const T3&,
-      const T4&, const T5&) {
+  stan::return_type_t<T_y, T_scale, T_shape> cdf_function(const T_y& y,
+                                                          const T_scale& y_min,
+                                                          const T_shape& alpha,
+                                                          const T3&, const T4&,
+                                                          const T5&) {
     using std::exp;
     using std::log;
     return 1.0 - exp(alpha * log(y_min / y));

--- a/test/prob/pareto/pareto_test.hpp
+++ b/test/prob/pareto/pareto_test.hpp
@@ -56,23 +56,27 @@ class AgradDistributionsPareto : public AgradDistributionTest {
 
   template <class T_y, class T_scale, class T_shape, typename T3, typename T4,
             typename T5>
-  typename stan::return_type<T_y, T_scale, T_shape>::type log_prob(
-      const T_y& y, const T_scale& y_min, const T_shape& alpha, const T3&,
-      const T4&, const T5&) {
+  stan::return_type_t<T_y, T_scale, T_shape> log_prob(const T_y& y,
+                                                      const T_scale& y_min,
+                                                      const T_shape& alpha,
+                                                      const T3&, const T4&,
+                                                      const T5&) {
     return stan::math::pareto_log(y, y_min, alpha);
   }
 
   template <bool propto, class T_y, class T_scale, class T_shape, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_scale, T_shape>::type log_prob(
-      const T_y& y, const T_scale& y_min, const T_shape& alpha, const T3&,
-      const T4&, const T5&) {
+  stan::return_type_t<T_y, T_scale, T_shape> log_prob(const T_y& y,
+                                                      const T_scale& y_min,
+                                                      const T_shape& alpha,
+                                                      const T3&, const T4&,
+                                                      const T5&) {
     return stan::math::pareto_log<propto>(y, y_min, alpha);
   }
 
   template <class T_y, class T_scale, class T_shape, typename T3, typename T4,
             typename T5>
-  typename stan::return_type<T_y, T_scale, T_shape>::type log_prob_function(
+  stan::return_type_t<T_y, T_scale, T_shape> log_prob_function(
       const T_y& y, const T_scale& y_min, const T_shape& alpha, const T3&,
       const T4&, const T5&) {
     using stan::math::LOG_ZERO;

--- a/test/prob/pareto_type_2/pareto_type_2_ccdf_log_test.hpp
+++ b/test/prob/pareto_type_2/pareto_type_2_ccdf_log_test.hpp
@@ -54,7 +54,7 @@ class AgradCcdfLogParetoType2 : public AgradCcdfLogTest {
 
   template <typename T_y, typename T_loc, typename T_scale, typename T_shape,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale, T_shape>::type ccdf_log(
+  stan::return_type_t<T_y, T_loc, T_scale, T_shape> ccdf_log(
       const T_y& y, const T_loc& mu, const T_scale& lambda,
       const T_shape& alpha, const T4&, const T5&) {
     return stan::math::pareto_type_2_ccdf_log(y, mu, lambda, alpha);
@@ -62,9 +62,9 @@ class AgradCcdfLogParetoType2 : public AgradCcdfLogTest {
 
   template <typename T_y, typename T_loc, typename T_scale, typename T_shape,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale, T_shape>::type
-  ccdf_log_function(const T_y& y, const T_loc& mu, const T_scale& lambda,
-                    const T_shape& alpha, const T4&, const T5&) {
+  stan::return_type_t<T_y, T_loc, T_scale, T_shape> ccdf_log_function(
+      const T_y& y, const T_loc& mu, const T_scale& lambda,
+      const T_shape& alpha, const T4&, const T5&) {
     using std::log;
     using std::pow;
     return log(pow(1.0 + (y - mu) / lambda, -alpha));

--- a/test/prob/pareto_type_2/pareto_type_2_cdf_log_test.hpp
+++ b/test/prob/pareto_type_2/pareto_type_2_cdf_log_test.hpp
@@ -53,7 +53,7 @@ class AgradCdfLogParetoType2 : public AgradCdfLogTest {
 
   template <typename T_y, typename T_loc, typename T_scale, typename T_shape,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale, T_shape>::type cdf_log(
+  stan::return_type_t<T_y, T_loc, T_scale, T_shape> cdf_log(
       const T_y& y, const T_loc& mu, const T_scale& lambda,
       const T_shape& alpha, const T4&, const T5&) {
     return stan::math::pareto_type_2_cdf_log(y, mu, lambda, alpha);
@@ -61,9 +61,9 @@ class AgradCdfLogParetoType2 : public AgradCdfLogTest {
 
   template <typename T_y, typename T_loc, typename T_scale, typename T_shape,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale, T_shape>::type
-  cdf_log_function(const T_y& y, const T_loc& mu, const T_scale& lambda,
-                   const T_shape& alpha, const T4&, const T5&) {
+  stan::return_type_t<T_y, T_loc, T_scale, T_shape> cdf_log_function(
+      const T_y& y, const T_loc& mu, const T_scale& lambda,
+      const T_shape& alpha, const T4&, const T5&) {
     using stan::math::log1m;
     using std::pow;
     return log1m(pow(1.0 + (y - mu) / lambda, -alpha));

--- a/test/prob/pareto_type_2/pareto_type_2_cdf_test.hpp
+++ b/test/prob/pareto_type_2/pareto_type_2_cdf_test.hpp
@@ -52,15 +52,17 @@ class AgradCdfParetoType2 : public AgradCdfTest {
 
   template <typename T_y, typename T_loc, typename T_scale, typename T_shape,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale, T_shape>::type cdf(
-      const T_y& y, const T_loc& mu, const T_scale& lambda,
-      const T_shape& alpha, const T4&, const T5&) {
+  stan::return_type_t<T_y, T_loc, T_scale, T_shape> cdf(const T_y& y,
+                                                        const T_loc& mu,
+                                                        const T_scale& lambda,
+                                                        const T_shape& alpha,
+                                                        const T4&, const T5&) {
     return stan::math::pareto_type_2_cdf(y, mu, lambda, alpha);
   }
 
   template <typename T_y, typename T_loc, typename T_scale, typename T_shape,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale, T_shape>::type cdf_function(
+  stan::return_type_t<T_y, T_loc, T_scale, T_shape> cdf_function(
       const T_y& y, const T_loc& mu, const T_scale& lambda,
       const T_shape& alpha, const T4&, const T5&) {
     using std::pow;

--- a/test/prob/pareto_type_2/pareto_type_2_test.hpp
+++ b/test/prob/pareto_type_2/pareto_type_2_test.hpp
@@ -60,7 +60,7 @@ class AgradDistributionParetoType2 : public AgradDistributionTest {
 
   template <class T_y, class T_loc, class T_scale, class T_shape, typename T4,
             typename T5>
-  typename stan::return_type<T_y, T_scale, T_shape, T_loc>::type log_prob(
+  stan::return_type_t<T_y, T_scale, T_shape, T_loc> log_prob(
       const T_y& y, const T_loc& mu, const T_scale& lambda,
       const T_shape& alpha, const T4&, const T5&) {
     return stan::math::pareto_type_2_log(y, mu, lambda, alpha);
@@ -68,7 +68,7 @@ class AgradDistributionParetoType2 : public AgradDistributionTest {
 
   template <bool propto, class T_y, class T_loc, class T_scale, class T_shape,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale, T_shape>::type log_prob(
+  stan::return_type_t<T_y, T_loc, T_scale, T_shape> log_prob(
       const T_y& y, const T_loc& mu, const T_scale& lambda,
       const T_shape& alpha, const T4&, const T5&) {
     return stan::math::pareto_type_2_log<propto>(y, mu, lambda, alpha);
@@ -76,9 +76,9 @@ class AgradDistributionParetoType2 : public AgradDistributionTest {
 
   template <class T_y, class T_loc, class T_scale, class T_shape, typename T4,
             typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale, T_shape>::type
-  log_prob_function(const T_y& y, const T_loc& mu, const T_scale& lambda,
-                    const T_shape& alpha, const T4&, const T5&) {
+  stan::return_type_t<T_y, T_loc, T_scale, T_shape> log_prob_function(
+      const T_y& y, const T_loc& mu, const T_scale& lambda,
+      const T_shape& alpha, const T4&, const T5&) {
     return log(alpha) - log(lambda) - (alpha + 1.0) * log1p((y - mu) / lambda);
   }
 };

--- a/test/prob/poisson/poisson_ccdf_log_test.hpp
+++ b/test/prob/poisson/poisson_ccdf_log_test.hpp
@@ -45,18 +45,18 @@ class AgradCcdfLogPoisson : public AgradCcdfLogTest {
 
   template <typename T_n, typename T_rate, typename T2, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_rate>::type ccdf_log(const T_n& n,
-                                                    const T_rate& lambda,
-                                                    const T2&, const T3&,
-                                                    const T4&, const T5&) {
+  stan::return_type_t<T_rate> ccdf_log(const T_n& n, const T_rate& lambda,
+                                       const T2&, const T3&, const T4&,
+                                       const T5&) {
     return stan::math::poisson_ccdf_log(n, lambda);
   }
 
   template <typename T_n, typename T_rate, typename T2, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_rate>::type ccdf_log_function(
-      const T_n& n, const T_rate& lambda, const T2&, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_rate> ccdf_log_function(const T_n& n,
+                                                const T_rate& lambda, const T2&,
+                                                const T3&, const T4&,
+                                                const T5&) {
     using boost::math::lgamma;
     using stan::math::exp;
     using stan::math::lgamma;
@@ -65,7 +65,7 @@ class AgradCcdfLogPoisson : public AgradCcdfLogTest {
     using std::log;
     using std::pow;
 
-    typename stan::return_type<T_rate>::type cdf(0);
+    stan::return_type_t<T_rate> cdf(0);
     for (int i = 0; i <= n; i++) {
       cdf += exp(i * log(lambda) - lgamma(i + 1));
     }

--- a/test/prob/poisson/poisson_cdf_log_test.hpp
+++ b/test/prob/poisson/poisson_cdf_log_test.hpp
@@ -42,18 +42,18 @@ class AgradCdfLogPoisson : public AgradCdfLogTest {
 
   template <typename T_n, typename T_rate, typename T2, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_rate>::type cdf_log(const T_n& n,
-                                                   const T_rate& lambda,
-                                                   const T2&, const T3&,
-                                                   const T4&, const T5&) {
+  stan::return_type_t<T_rate> cdf_log(const T_n& n, const T_rate& lambda,
+                                      const T2&, const T3&, const T4&,
+                                      const T5&) {
     return stan::math::poisson_cdf_log(n, lambda);
   }
 
   template <typename T_n, typename T_rate, typename T2, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_rate>::type cdf_log_function(
-      const T_n& n, const T_rate& lambda, const T2&, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_rate> cdf_log_function(const T_n& n,
+                                               const T_rate& lambda, const T2&,
+                                               const T3&, const T4&,
+                                               const T5&) {
     using boost::math::lgamma;
     using stan::math::exp;
     using stan::math::lgamma;
@@ -62,7 +62,7 @@ class AgradCdfLogPoisson : public AgradCdfLogTest {
     using std::log;
     using std::pow;
 
-    typename stan::return_type<T_rate>::type cdf(0);
+    stan::return_type_t<T_rate> cdf(0);
     for (int i = 0; i <= n; i++) {
       cdf += exp(i * log(lambda) - lgamma(i + 1));
     }

--- a/test/prob/poisson/poisson_cdf_test.hpp
+++ b/test/prob/poisson/poisson_cdf_test.hpp
@@ -41,19 +41,16 @@ class AgradCdfPoisson : public AgradCdfTest {
 
   template <typename T_n, typename T_rate, typename T2, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_rate>::type cdf(const T_n& n,
-                                               const T_rate& lambda, const T2&,
-                                               const T3&, const T4&,
-                                               const T5&) {
+  stan::return_type_t<T_rate> cdf(const T_n& n, const T_rate& lambda, const T2&,
+                                  const T3&, const T4&, const T5&) {
     return stan::math::poisson_cdf(n, lambda);
   }
 
   template <typename T_n, typename T_rate, typename T2, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_rate>::type cdf_function(const T_n& n,
-                                                        const T_rate& lambda,
-                                                        const T2&, const T3&,
-                                                        const T4&, const T5&) {
+  stan::return_type_t<T_rate> cdf_function(const T_n& n, const T_rate& lambda,
+                                           const T2&, const T3&, const T4&,
+                                           const T5&) {
     using boost::math::lgamma;
     using stan::math::exp;
     using stan::math::lgamma;
@@ -62,7 +59,7 @@ class AgradCdfPoisson : public AgradCdfTest {
     using std::log;
     using std::pow;
 
-    typename stan::return_type<T_rate>::type cdf(0);
+    stan::return_type_t<T_rate> cdf(0);
     for (int i = 0; i <= n; i++) {
       cdf += exp(i * log(lambda) - lgamma(i + 1));
     }

--- a/test/prob/poisson/poisson_log_test.hpp
+++ b/test/prob/poisson/poisson_log_test.hpp
@@ -40,27 +40,26 @@ class AgradDistributionsPoisson : public AgradDistributionTest {
 
   template <class T_n, class T_rate, typename T2, typename T3, typename T4,
             typename T5>
-  typename stan::return_type<T_n, T_rate>::type log_prob(const T_n& n,
-                                                         const T_rate& alpha,
-                                                         const T2&, const T3&,
-                                                         const T4&, const T5&) {
+  stan::return_type_t<T_n, T_rate> log_prob(const T_n& n, const T_rate& alpha,
+                                            const T2&, const T3&, const T4&,
+                                            const T5&) {
     return stan::math::poisson_log_log(n, alpha);
   }
 
   template <bool propto, class T_n, class T_rate, typename T2, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_n, T_rate>::type log_prob(const T_n& n,
-                                                         const T_rate& alpha,
-                                                         const T2&, const T3&,
-                                                         const T4&, const T5&) {
+  stan::return_type_t<T_n, T_rate> log_prob(const T_n& n, const T_rate& alpha,
+                                            const T2&, const T3&, const T4&,
+                                            const T5&) {
     return stan::math::poisson_log_log<propto>(n, alpha);
   }
 
   template <class T_n, class T_rate, typename T2, typename T3, typename T4,
             typename T5>
-  typename stan::return_type<T_n, T_rate>::type log_prob_function(
-      const T_n& n, const T_rate& alpha, const T2&, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_n, T_rate> log_prob_function(const T_n& n,
+                                                     const T_rate& alpha,
+                                                     const T2&, const T3&,
+                                                     const T4&, const T5&) {
     using boost::math::lgamma;
     using stan::math::LOG_ZERO;
     using stan::math::multiply_log;

--- a/test/prob/poisson/poisson_test.hpp
+++ b/test/prob/poisson/poisson_test.hpp
@@ -43,27 +43,26 @@ class AgradDistributionsPoisson : public AgradDistributionTest {
 
   template <class T_n, class T_rate, typename T2, typename T3, typename T4,
             typename T5>
-  typename stan::return_type<T_n, T_rate>::type log_prob(const T_n& n,
-                                                         const T_rate& lambda,
-                                                         const T2&, const T3&,
-                                                         const T4&, const T5&) {
+  stan::return_type_t<T_n, T_rate> log_prob(const T_n& n, const T_rate& lambda,
+                                            const T2&, const T3&, const T4&,
+                                            const T5&) {
     return stan::math::poisson_log(n, lambda);
   }
 
   template <bool propto, class T_n, class T_rate, typename T2, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_n, T_rate>::type log_prob(const T_n& n,
-                                                         const T_rate& lambda,
-                                                         const T2&, const T3&,
-                                                         const T4&, const T5&) {
+  stan::return_type_t<T_n, T_rate> log_prob(const T_n& n, const T_rate& lambda,
+                                            const T2&, const T3&, const T4&,
+                                            const T5&) {
     return stan::math::poisson_log<propto>(n, lambda);
   }
 
   template <class T_n, class T_rate, typename T2, typename T3, typename T4,
             typename T5>
-  typename stan::return_type<T_n, T_rate>::type log_prob_function(
-      const T_n& n, const T_rate& lambda, const T2&, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_n, T_rate> log_prob_function(const T_n& n,
+                                                     const T_rate& lambda,
+                                                     const T2&, const T3&,
+                                                     const T4&, const T5&) {
     using boost::math::lgamma;
     using stan::math::LOG_ZERO;
     using stan::math::multiply_log;

--- a/test/prob/rayleigh/rayleigh_ccdf_log_test.hpp
+++ b/test/prob/rayleigh/rayleigh_ccdf_log_test.hpp
@@ -57,19 +57,18 @@ class AgradCcdfLogRayleigh : public AgradCcdfLogTest {
 
   template <typename T_y, typename T_scale, typename T2, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_scale>::type ccdf_log(const T_y& y,
-                                                          const T_scale& sigma,
-                                                          const T2&, const T3&,
-                                                          const T4&,
-                                                          const T5&) {
+  stan::return_type_t<T_y, T_scale> ccdf_log(const T_y& y, const T_scale& sigma,
+                                             const T2&, const T3&, const T4&,
+                                             const T5&) {
     return stan::math::rayleigh_ccdf_log(y, sigma);
   }
 
   template <typename T_y, typename T_scale, typename T2, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_scale>::type ccdf_log_function(
-      const T_y& y, const T_scale& sigma, const T2&, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_y, T_scale> ccdf_log_function(const T_y& y,
+                                                      const T_scale& sigma,
+                                                      const T2&, const T3&,
+                                                      const T4&, const T5&) {
     return -0.5 * y * y / (sigma * sigma);
   }
 };

--- a/test/prob/rayleigh/rayleigh_cdf_log_test.hpp
+++ b/test/prob/rayleigh/rayleigh_cdf_log_test.hpp
@@ -56,18 +56,18 @@ class AgradCdfLogRayleigh : public AgradCdfLogTest {
 
   template <typename T_y, typename T_scale, typename T2, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_scale>::type cdf_log(const T_y& y,
-                                                         const T_scale& sigma,
-                                                         const T2&, const T3&,
-                                                         const T4&, const T5&) {
+  stan::return_type_t<T_y, T_scale> cdf_log(const T_y& y, const T_scale& sigma,
+                                            const T2&, const T3&, const T4&,
+                                            const T5&) {
     return stan::math::rayleigh_cdf_log(y, sigma);
   }
 
   template <typename T_y, typename T_scale, typename T2, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_scale>::type cdf_log_function(
-      const T_y& y, const T_scale& sigma, const T2&, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_y, T_scale> cdf_log_function(const T_y& y,
+                                                     const T_scale& sigma,
+                                                     const T2&, const T3&,
+                                                     const T4&, const T5&) {
     return log((1.0 - exp(-0.5 * y * y / (sigma * sigma))));
   }
 };

--- a/test/prob/rayleigh/rayleigh_cdf_test.hpp
+++ b/test/prob/rayleigh/rayleigh_cdf_test.hpp
@@ -55,18 +55,18 @@ class AgradCdfRayleigh : public AgradCdfTest {
 
   template <typename T_y, typename T_scale, typename T2, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_scale>::type cdf(const T_y& y,
-                                                     const T_scale& sigma,
-                                                     const T2&, const T3&,
-                                                     const T4&, const T5&) {
+  stan::return_type_t<T_y, T_scale> cdf(const T_y& y, const T_scale& sigma,
+                                        const T2&, const T3&, const T4&,
+                                        const T5&) {
     return stan::math::rayleigh_cdf(y, sigma);
   }
 
   template <typename T_y, typename T_scale, typename T2, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_scale>::type cdf_function(
-      const T_y& y, const T_scale& sigma, const T2&, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_y, T_scale> cdf_function(const T_y& y,
+                                                 const T_scale& sigma,
+                                                 const T2&, const T3&,
+                                                 const T4&, const T5&) {
     return (1.0 - exp(-0.5 * y * y / (sigma * sigma)));
   }
 };

--- a/test/prob/rayleigh/rayleigh_test.hpp
+++ b/test/prob/rayleigh/rayleigh_test.hpp
@@ -52,29 +52,26 @@ class AgradDistributionRayleigh : public AgradDistributionTest {
 
   template <typename T_y, typename T_scale, typename T2, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_scale>::type log_prob(const T_y& y,
-                                                          const T_scale& sigma,
-                                                          const T2&, const T3&,
-                                                          const T4&,
-                                                          const T5&) {
+  stan::return_type_t<T_y, T_scale> log_prob(const T_y& y, const T_scale& sigma,
+                                             const T2&, const T3&, const T4&,
+                                             const T5&) {
     return stan::math::rayleigh_log(y, sigma);
   }
 
   template <bool propto, typename T_y, typename T_scale, typename T2,
             typename T3, typename T4, typename T5>
-  typename stan::return_type<T_y, T_scale>::type log_prob(const T_y& y,
-                                                          const T_scale& sigma,
-                                                          const T2&, const T3&,
-                                                          const T4&,
-                                                          const T5&) {
+  stan::return_type_t<T_y, T_scale> log_prob(const T_y& y, const T_scale& sigma,
+                                             const T2&, const T3&, const T4&,
+                                             const T5&) {
     return stan::math::rayleigh_log<propto>(y, sigma);
   }
 
   template <typename T_y, typename T_scale, typename T2, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_scale>::type log_prob_function(
-      const T_y& y, const T_scale& sigma, const T2&, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_y, T_scale> log_prob_function(const T_y& y,
+                                                      const T_scale& sigma,
+                                                      const T2&, const T3&,
+                                                      const T4&, const T5&) {
     using stan::math::pi;
     using stan::math::square;
     return -0.5 * y * y / (sigma * sigma) - 2.0 * log(sigma) + log(y);

--- a/test/prob/scaled_inv_chi_square/scaled_inv_chi_square_ccdf_log_test.hpp
+++ b/test/prob/scaled_inv_chi_square/scaled_inv_chi_square_ccdf_log_test.hpp
@@ -53,15 +53,16 @@ class AgradCcdfLogScaledInvChiSquare : public AgradCcdfLogTest {
 
   template <typename T_y, typename T_dof, typename T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_dof, T_scale>::type ccdf_log(
-      const T_y& y, const T_dof& nu, const T_scale& s, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_y, T_dof, T_scale> ccdf_log(const T_y& y,
+                                                    const T_dof& nu,
+                                                    const T_scale& s, const T3&,
+                                                    const T4&, const T5&) {
     return stan::math::scaled_inv_chi_square_ccdf_log(y, nu, s);
   }
 
   template <typename T_y, typename T_dof, typename T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_dof, T_scale>::type ccdf_log_function(
+  stan::return_type_t<T_y, T_dof, T_scale> ccdf_log_function(
       const T_y& y, const T_dof& nu, const T_scale& s, const T3&, const T4&,
       const T5&) {
     using stan::math::gamma_p;

--- a/test/prob/scaled_inv_chi_square/scaled_inv_chi_square_cdf_log_test.hpp
+++ b/test/prob/scaled_inv_chi_square/scaled_inv_chi_square_cdf_log_test.hpp
@@ -53,15 +53,16 @@ class AgradCdfLogScaledInvChiSquare : public AgradCdfLogTest {
 
   template <typename T_y, typename T_dof, typename T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_dof, T_scale>::type cdf_log(
-      const T_y& y, const T_dof& nu, const T_scale& s, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_y, T_dof, T_scale> cdf_log(const T_y& y,
+                                                   const T_dof& nu,
+                                                   const T_scale& s, const T3&,
+                                                   const T4&, const T5&) {
     return stan::math::scaled_inv_chi_square_cdf_log(y, nu, s);
   }
 
   template <typename T_y, typename T_dof, typename T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_dof, T_scale>::type cdf_log_function(
+  stan::return_type_t<T_y, T_dof, T_scale> cdf_log_function(
       const T_y& y, const T_dof& nu, const T_scale& s, const T3&, const T4&,
       const T5&) {
     using stan::math::gamma_q;

--- a/test/prob/scaled_inv_chi_square/scaled_inv_chi_square_cdf_test.hpp
+++ b/test/prob/scaled_inv_chi_square/scaled_inv_chi_square_cdf_test.hpp
@@ -51,17 +51,19 @@ class AgradCdfScaledInvChiSquare : public AgradCdfTest {
 
   template <typename T_y, typename T_dof, typename T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_dof, T_scale>::type cdf(
-      const T_y& y, const T_dof& nu, const T_scale& s, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_y, T_dof, T_scale> cdf(const T_y& y, const T_dof& nu,
+                                               const T_scale& s, const T3&,
+                                               const T4&, const T5&) {
     return stan::math::scaled_inv_chi_square_cdf(y, nu, s);
   }
 
   template <typename T_y, typename T_dof, typename T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_dof, T_scale>::type cdf_function(
-      const T_y& y, const T_dof& nu, const T_scale& s, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_y, T_dof, T_scale> cdf_function(const T_y& y,
+                                                        const T_dof& nu,
+                                                        const T_scale& s,
+                                                        const T3&, const T4&,
+                                                        const T5&) {
     using stan::math::gamma_q;
 
     return (gamma_q(nu * 0.5, 0.5 * nu * s * s / y));

--- a/test/prob/scaled_inv_chi_square/scaled_inv_chi_square_test.hpp
+++ b/test/prob/scaled_inv_chi_square/scaled_inv_chi_square_test.hpp
@@ -53,23 +53,25 @@ class AgradDistributionsScaledInvChiSquare : public AgradDistributionTest {
 
   template <class T_y, class T_dof, class T_scale, typename T3, typename T4,
             typename T5>
-  typename stan::return_type<T_y, T_dof, T_scale>::type log_prob(
-      const T_y& y, const T_dof& nu, const T_scale& s, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_y, T_dof, T_scale> log_prob(const T_y& y,
+                                                    const T_dof& nu,
+                                                    const T_scale& s, const T3&,
+                                                    const T4&, const T5&) {
     return stan::math::scaled_inv_chi_square_log(y, nu, s);
   }
 
   template <bool propto, class T_y, class T_dof, class T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_dof, T_scale>::type log_prob(
-      const T_y& y, const T_dof& nu, const T_scale& s, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_y, T_dof, T_scale> log_prob(const T_y& y,
+                                                    const T_dof& nu,
+                                                    const T_scale& s, const T3&,
+                                                    const T4&, const T5&) {
     return stan::math::scaled_inv_chi_square_log<propto>(y, nu, s);
   }
 
   template <class T_y, class T_dof, class T_scale, typename T3, typename T4,
             typename T5>
-  typename stan::return_type<T_y, T_dof, T_scale>::type log_prob_function(
+  stan::return_type_t<T_y, T_dof, T_scale> log_prob_function(
       const T_y& y, const T_dof& nu, const T_scale& s, const T3&, const T4&,
       const T5&) {
     using stan::math::multiply_log;

--- a/test/prob/skew_normal/skew_normal_ccdf_log_test.hpp
+++ b/test/prob/skew_normal/skew_normal_ccdf_log_test.hpp
@@ -79,7 +79,7 @@ class AgradCcdfLogSkewNormal : public AgradCcdfLogTest {
 
   template <typename T_y, typename T_loc, typename T_scale, typename T_shape,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale, T_shape>::type ccdf_log(
+  stan::return_type_t<T_y, T_loc, T_scale, T_shape> ccdf_log(
       const T_y& y, const T_loc& mu, const T_scale& sigma, const T_shape& alpha,
       const T4&, const T5&) {
     return stan::math::skew_normal_ccdf_log(y, mu, sigma, alpha);
@@ -87,9 +87,9 @@ class AgradCcdfLogSkewNormal : public AgradCcdfLogTest {
 
   template <typename T_y, typename T_loc, typename T_scale, typename T_shape,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale, T_shape>::type
-  ccdf_log_function(const T_y& y, const T_loc& mu, const T_scale& sigma,
-                    const T_shape& alpha, const T4&, const T5&) {
+  stan::return_type_t<T_y, T_loc, T_scale, T_shape> ccdf_log_function(
+      const T_y& y, const T_loc& mu, const T_scale& sigma, const T_shape& alpha,
+      const T4&, const T5&) {
     using stan::math::owens_t;
     return log(1.0
                - (0.5 * erfc(-(y - mu) / (sqrt(2.0) * sigma))

--- a/test/prob/skew_normal/skew_normal_cdf_log_test.hpp
+++ b/test/prob/skew_normal/skew_normal_cdf_log_test.hpp
@@ -75,7 +75,7 @@ class AgradCdfLogSkewNormal : public AgradCdfLogTest {
 
   template <typename T_y, typename T_loc, typename T_scale, typename T_shape,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale, T_shape>::type cdf_log(
+  stan::return_type_t<T_y, T_loc, T_scale, T_shape> cdf_log(
       const T_y& y, const T_loc& mu, const T_scale& sigma, const T_shape& alpha,
       const T4&, const T5&) {
     return stan::math::skew_normal_cdf_log(y, mu, sigma, alpha);
@@ -83,9 +83,9 @@ class AgradCdfLogSkewNormal : public AgradCdfLogTest {
 
   template <typename T_y, typename T_loc, typename T_scale, typename T_shape,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale, T_shape>::type
-  cdf_log_function(const T_y& y, const T_loc& mu, const T_scale& sigma,
-                   const T_shape& alpha, const T4&, const T5&) {
+  stan::return_type_t<T_y, T_loc, T_scale, T_shape> cdf_log_function(
+      const T_y& y, const T_loc& mu, const T_scale& sigma, const T_shape& alpha,
+      const T4&, const T5&) {
     using stan::math::owens_t;
     return log(0.5 * erfc(-(y - mu) / (sqrt(2.0) * sigma))
                - 2.0 * owens_t((y - mu) / sigma, alpha));

--- a/test/prob/skew_normal/skew_normal_cdf_test.hpp
+++ b/test/prob/skew_normal/skew_normal_cdf_test.hpp
@@ -74,15 +74,17 @@ class AgradCdfSkewNormal : public AgradCdfTest {
 
   template <typename T_y, typename T_loc, typename T_scale, typename T_shape,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale, T_shape>::type cdf(
-      const T_y& y, const T_loc& mu, const T_scale& sigma, const T_shape& alpha,
-      const T4&, const T5&) {
+  stan::return_type_t<T_y, T_loc, T_scale, T_shape> cdf(const T_y& y,
+                                                        const T_loc& mu,
+                                                        const T_scale& sigma,
+                                                        const T_shape& alpha,
+                                                        const T4&, const T5&) {
     return stan::math::skew_normal_cdf(y, mu, sigma, alpha);
   }
 
   template <typename T_y, typename T_loc, typename T_scale, typename T_shape,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale, T_shape>::type cdf_function(
+  stan::return_type_t<T_y, T_loc, T_scale, T_shape> cdf_function(
       const T_y& y, const T_loc& mu, const T_scale& sigma, const T_shape& alpha,
       const T4&, const T5&) {
     using stan::math::owens_t;

--- a/test/prob/skew_normal/skew_normal_test.hpp
+++ b/test/prob/skew_normal/skew_normal_test.hpp
@@ -70,7 +70,7 @@ class AgradDistributionSkewNormal : public AgradDistributionTest {
 
   template <typename T_y, typename T_loc, typename T_scale, typename T_shape,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale, T_shape>::type log_prob(
+  stan::return_type_t<T_y, T_loc, T_scale, T_shape> log_prob(
       const T_y& y, const T_loc& mu, const T_scale& sigma, const T_shape& alpha,
       const T4&, const T5&) {
     return stan::math::skew_normal_log(y, mu, sigma, alpha);
@@ -78,7 +78,7 @@ class AgradDistributionSkewNormal : public AgradDistributionTest {
 
   template <bool propto, typename T_y, typename T_loc, typename T_scale,
             typename T_shape, typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale, T_shape>::type log_prob(
+  stan::return_type_t<T_y, T_loc, T_scale, T_shape> log_prob(
       const T_y& y, const T_loc& mu, const T_scale& sigma, const T_shape& alpha,
       const T4&, const T5&) {
     return stan::math::skew_normal_log<propto>(y, mu, sigma, alpha);
@@ -86,9 +86,9 @@ class AgradDistributionSkewNormal : public AgradDistributionTest {
 
   template <typename T_y, typename T_loc, typename T_scale, typename T_shape,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale, T_shape>::type
-  log_prob_function(const T_y& y, const T_loc& mu, const T_scale& sigma,
-                    const T_shape& alpha, const T4&, const T5&) {
+  stan::return_type_t<T_y, T_loc, T_scale, T_shape> log_prob_function(
+      const T_y& y, const T_loc& mu, const T_scale& sigma, const T_shape& alpha,
+      const T4&, const T5&) {
     return -0.5 * log(2.0 * stan::math::pi()) - log(sigma)
            - (y - mu) / sigma * (y - mu) / sigma * 0.5
            + log(erfc(-alpha * (y - mu) / (sigma * std::sqrt(2.0))));

--- a/test/prob/std_normal/std_normal_ccdf_log_test.hpp
+++ b/test/prob/std_normal/std_normal_ccdf_log_test.hpp
@@ -36,18 +36,15 @@ class AgradCcdfLogStdNormal : public AgradCcdfLogTest {
 
   template <typename T_y, typename T1, typename T2, typename T3, typename T4,
             typename T5>
-  typename stan::return_type<T_y>::type ccdf_log(const T_y& y, const T1,
-                                                 const T2, const T3&, const T4&,
-                                                 const T5&) {
+  stan::return_type_t<T_y> ccdf_log(const T_y& y, const T1, const T2, const T3&,
+                                    const T4&, const T5&) {
     return stan::math::std_normal_lccdf(y);
   }
 
   template <typename T_y, typename T1, typename T2, typename T3, typename T4,
             typename T5>
-  typename stan::return_type<T_y>::type ccdf_log_function(const T_y& y,
-                                                          const T1, const T2,
-                                                          const T3&, const T4&,
-                                                          const T5&) {
+  stan::return_type_t<T_y> ccdf_log_function(const T_y& y, const T1, const T2,
+                                             const T3&, const T4&, const T5&) {
     using std::log;
     return log(0.5 - 0.5 * erf(y * stan::math::INV_SQRT_TWO));
   }

--- a/test/prob/std_normal/std_normal_cdf_log_test.hpp
+++ b/test/prob/std_normal/std_normal_cdf_log_test.hpp
@@ -42,18 +42,15 @@ class AgradCdfLogNormal : public AgradCdfLogTest {
 
   template <typename T_y, typename T1, typename T2, typename T3, typename T4,
             typename T5>
-  typename stan::return_type<T_y>::type cdf_log(const T_y& y, const T1&,
-                                                const T2&, const T3&, const T4&,
-                                                const T5&) {
+  stan::return_type_t<T_y> cdf_log(const T_y& y, const T1&, const T2&,
+                                   const T3&, const T4&, const T5&) {
     return stan::math::std_normal_lcdf(y);
   }
 
   template <typename T_y, typename T1, typename T2, typename T3, typename T4,
             typename T5>
-  typename stan::return_type<T_y>::type cdf_log_function(const T_y& y,
-                                                         const T1&, const T2&,
-                                                         const T3&, const T4&,
-                                                         const T5&) {
+  stan::return_type_t<T_y> cdf_log_function(const T_y& y, const T1&, const T2&,
+                                            const T3&, const T4&, const T5&) {
     using stan::math::INV_SQRT_PI;
     using stan::math::INV_SQRT_TWO;
     using stan::math::LOG_HALF;

--- a/test/prob/std_normal/std_normal_cdf_test.hpp
+++ b/test/prob/std_normal/std_normal_cdf_test.hpp
@@ -35,16 +35,15 @@ class AgradCdfStdNormal : public AgradCdfTest {
 
   template <typename T_y, typename T1, typename T2, typename T3, typename T4,
             typename T5>
-  typename stan::return_type<T_y>::type cdf(const T_y& y, const T1&, const T2&,
-                                            const T3&, const T4&, const T5&) {
+  stan::return_type_t<T_y> cdf(const T_y& y, const T1&, const T2&, const T3&,
+                               const T4&, const T5&) {
     return stan::math::std_normal_cdf(y);
   }
 
   template <typename T_y, typename T1, typename T2, typename T3, typename T4,
             typename T5>
-  typename stan::return_type<T_y>::type cdf_function(const T_y& y, const T1&,
-                                                     const T2&, const T3&,
-                                                     const T4&, const T5&) {
+  stan::return_type_t<T_y> cdf_function(const T_y& y, const T1&, const T2&,
+                                        const T3&, const T4&, const T5&) {
     using stan::math::SQRT_TWO;
     return (0.5 + 0.5 * erf(y / SQRT_TWO));
   }

--- a/test/prob/std_normal/std_normal_test.hpp
+++ b/test/prob/std_normal/std_normal_test.hpp
@@ -28,23 +28,21 @@ class AgradDistributionStdNormal : public AgradDistributionTest {
 
   template <typename T_y, typename T1, typename T2, typename T3, typename T4,
             typename T5>
-  typename stan::return_type<T_y>::type log_prob(const T_y& y, const T1&,
-                                                 const T2&, const T3&,
-                                                 const T4&, const T5&) {
+  stan::return_type_t<T_y> log_prob(const T_y& y, const T1&, const T2&,
+                                    const T3&, const T4&, const T5&) {
     return stan::math::std_normal_lpdf(y);
   }
 
   template <bool propto, typename T_y, typename T1, typename T2, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y>::type log_prob(const T_y& y, const T1&,
-                                                 const T2&, const T3&,
-                                                 const T4&, const T5&) {
+  stan::return_type_t<T_y> log_prob(const T_y& y, const T1&, const T2&,
+                                    const T3&, const T4&, const T5&) {
     return stan::math::std_normal_lpdf<propto>(y);
   }
 
   template <typename T_y, typename T1, typename T2, typename T3, typename T4,
             typename T5>
-  typename stan::return_type<T_y, T1, T2, T3, T4, T5>::type log_prob_function(
+  stan::return_type_t<T_y, T1, T2, T3, T4, T5> log_prob_function(
       const T_y& y, const T1&, const T2&, const T3&, const T4&, const T5&) {
     using stan::math::pi;
     return -0.5 * y * y - log(sqrt(2.0 * pi()));

--- a/test/prob/student_t/student_t_ccdf_log_test.hpp
+++ b/test/prob/student_t/student_t_ccdf_log_test.hpp
@@ -63,7 +63,7 @@ class AgradCcdfLogStudentT : public AgradCcdfLogTest {
 
   template <typename T_y, typename T_dof, typename T_loc, typename T_scale,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_dof, T_loc, T_scale>::type ccdf_log(
+  stan::return_type_t<T_y, T_dof, T_loc, T_scale> ccdf_log(
       const T_y& y, const T_dof& nu, const T_loc& mu, const T_scale& sigma,
       const T4&, const T5&) {
     return stan::math::student_t_ccdf_log(y, nu, mu, sigma);
@@ -71,9 +71,9 @@ class AgradCcdfLogStudentT : public AgradCcdfLogTest {
 
   template <typename T_y, typename T_dof, typename T_loc, typename T_scale,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_dof, T_loc, T_scale>::type
-  ccdf_log_function(const T_y& y, const T_dof& nu, const T_loc& mu,
-                    const T_scale& sigma, const T4&, const T5&) {
+  stan::return_type_t<T_y, T_dof, T_loc, T_scale> ccdf_log_function(
+      const T_y& y, const T_dof& nu, const T_loc& mu, const T_scale& sigma,
+      const T4&, const T5&) {
     return stan::math::student_t_ccdf_log(y, nu, mu, sigma);
   }
 };

--- a/test/prob/student_t/student_t_cdf_log_test.hpp
+++ b/test/prob/student_t/student_t_cdf_log_test.hpp
@@ -61,7 +61,7 @@ class AgradCdfLogStudentT : public AgradCdfLogTest {
 
   template <typename T_y, typename T_dof, typename T_loc, typename T_scale,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_dof, T_loc, T_scale>::type cdf_log(
+  stan::return_type_t<T_y, T_dof, T_loc, T_scale> cdf_log(
       const T_y& y, const T_dof& nu, const T_loc& mu, const T_scale& sigma,
       const T4&, const T5&) {
     return stan::math::student_t_cdf_log(y, nu, mu, sigma);
@@ -69,7 +69,7 @@ class AgradCdfLogStudentT : public AgradCdfLogTest {
 
   template <typename T_y, typename T_dof, typename T_loc, typename T_scale,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_dof, T_loc, T_scale>::type cdf_log_function(
+  stan::return_type_t<T_y, T_dof, T_loc, T_scale> cdf_log_function(
       const T_y& y, const T_dof& nu, const T_loc& mu, const T_scale& sigma,
       const T4&, const T5&) {
     return stan::math::student_t_cdf_log(y, nu, mu, sigma);

--- a/test/prob/student_t/student_t_cdf_test.hpp
+++ b/test/prob/student_t/student_t_cdf_test.hpp
@@ -60,15 +60,17 @@ class AgradCdfStudentT : public AgradCdfTest {
 
   template <typename T_y, typename T_dof, typename T_loc, typename T_scale,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_dof, T_loc, T_scale>::type cdf(
-      const T_y& y, const T_dof& nu, const T_loc& mu, const T_scale& sigma,
-      const T4&, const T5&) {
+  stan::return_type_t<T_y, T_dof, T_loc, T_scale> cdf(const T_y& y,
+                                                      const T_dof& nu,
+                                                      const T_loc& mu,
+                                                      const T_scale& sigma,
+                                                      const T4&, const T5&) {
     return stan::math::student_t_cdf(y, nu, mu, sigma);
   }
 
   template <typename T_y, typename T_dof, typename T_loc, typename T_scale,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_dof, T_loc, T_scale>::type cdf_function(
+  stan::return_type_t<T_y, T_dof, T_loc, T_scale> cdf_function(
       const T_y& y, const T_dof& nu, const T_loc& mu, const T_scale& sigma,
       const T4&, const T5&) {
     return stan::math::student_t_cdf(y, nu, mu, sigma);

--- a/test/prob/student_t/student_t_test.hpp
+++ b/test/prob/student_t/student_t_test.hpp
@@ -85,8 +85,8 @@ class AgradDistributionsStudentT : public AgradDistributionTest {
       const T_y& y, const T_dof& nu, const T_loc& mu, const T_scale& sigma,
       const T4&, const T5&) {
     using boost::math::lgamma;
-    using stan::math::log1p;
     using stan::math::LOG_SQRT_PI;
+    using stan::math::log1p;
     using stan::math::square;
     using std::log;
 

--- a/test/prob/student_t/student_t_test.hpp
+++ b/test/prob/student_t/student_t_test.hpp
@@ -65,7 +65,7 @@ class AgradDistributionsStudentT : public AgradDistributionTest {
 
   template <class T_y, class T_dof, class T_loc, class T_scale, typename T4,
             typename T5>
-  typename stan::return_type<T_y, T_dof, T_loc, T_scale>::type log_prob(
+  stan::return_type_t<T_y, T_dof, T_loc, T_scale> log_prob(
       const T_y& y, const T_dof& nu, const T_loc& mu, const T_scale& sigma,
       const T4&, const T5&) {
     return stan::math::student_t_log(y, nu, mu, sigma);
@@ -73,7 +73,7 @@ class AgradDistributionsStudentT : public AgradDistributionTest {
 
   template <bool propto, class T_y, class T_dof, class T_loc, class T_scale,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_dof, T_loc, T_scale>::type log_prob(
+  stan::return_type_t<T_y, T_dof, T_loc, T_scale> log_prob(
       const T_y& y, const T_dof& nu, const T_loc& mu, const T_scale& sigma,
       const T4&, const T5&) {
     return stan::math::student_t_log<propto>(y, nu, mu, sigma);
@@ -81,12 +81,12 @@ class AgradDistributionsStudentT : public AgradDistributionTest {
 
   template <class T_y, class T_dof, class T_loc, class T_scale, typename T4,
             typename T5>
-  typename stan::return_type<T_y, T_dof, T_loc, T_scale>::type
-  log_prob_function(const T_y& y, const T_dof& nu, const T_loc& mu,
-                    const T_scale& sigma, const T4&, const T5&) {
+  stan::return_type_t<T_y, T_dof, T_loc, T_scale> log_prob_function(
+      const T_y& y, const T_dof& nu, const T_loc& mu, const T_scale& sigma,
+      const T4&, const T5&) {
     using boost::math::lgamma;
-    using stan::math::LOG_SQRT_PI;
     using stan::math::log1p;
+    using stan::math::LOG_SQRT_PI;
     using stan::math::square;
     using std::log;
 

--- a/test/prob/test_fixture_ccdf_log.hpp
+++ b/test/prob/test_fixture_ccdf_log.hpp
@@ -16,7 +16,7 @@ using std::vector;
 
 class AgradCcdfLogTest {
  public:
-  virtual void valid_values(vector<vector<double> >& /*parameters*/,
+  virtual void valid_values(vector<vector<double>>& /*parameters*/,
                             vector<double>& /* cdf_log */) {
     throw std::runtime_error("valid_values() not implemented");
   }
@@ -89,7 +89,7 @@ class AgradCcdfLogTestFixture : public ::testing::Test {
 
   void call_all_versions() {
     vector<double> ccdf_log;
-    vector<vector<double> > parameters;
+    vector<vector<double>> parameters;
     TestClass.valid_values(parameters, ccdf_log);
 
     T0 p0 = get_params<T0>(parameters, 0);
@@ -107,7 +107,7 @@ class AgradCcdfLogTestFixture : public ::testing::Test {
 
   void test_valid_values() {
     vector<double> expected_ccdf_log;
-    vector<vector<double> > parameters;
+    vector<vector<double>> parameters;
     TestClass.valid_values(parameters, expected_ccdf_log);
 
     for (size_t n = 0; n < parameters.size(); n++) {
@@ -287,18 +287,18 @@ class AgradCcdfLogTestFixture : public ::testing::Test {
 
   // works for fvar<fvar<double> >
   double calculate_gradients_1storder(vector<double>& grad,
-                                      fvar<fvar<double> >& ccdf_log,
+                                      fvar<fvar<double>>& ccdf_log,
                                       vector<var>& x) {
     x.push_back(ccdf_log.d_.val_);
     return ccdf_log.val().val();
   }
   double calculate_gradients_2ndorder(vector<double>& grad,
-                                      fvar<fvar<double> >& ccdf_log,
+                                      fvar<fvar<double>>& ccdf_log,
                                       vector<var>& x) {
     return ccdf_log.val().val();
   }
   double calculate_gradients_3rdorder(vector<double>& grad,
-                                      fvar<fvar<double> >& ccdf_log,
+                                      fvar<fvar<double>>& ccdf_log,
                                       vector<var>& x) {
     return ccdf_log.val().val();
   }
@@ -323,21 +323,21 @@ class AgradCcdfLogTestFixture : public ::testing::Test {
 
   // works for fvar<fvar<var> >
   double calculate_gradients_1storder(vector<double>& grad,
-                                      fvar<fvar<var> >& ccdf_log,
+                                      fvar<fvar<var>>& ccdf_log,
                                       vector<var>& x) {
     ccdf_log.val_.val_.grad(x, grad);
     stan::math::recover_memory();
     return ccdf_log.val_.val_.val();
   }
   double calculate_gradients_2ndorder(vector<double>& grad,
-                                      fvar<fvar<var> >& ccdf_log,
+                                      fvar<fvar<var>>& ccdf_log,
                                       vector<var>& x) {
     ccdf_log.d_.val_.grad(x, grad);
     stan::math::recover_memory();
     return ccdf_log.val_.val_.val();
   }
   double calculate_gradients_3rdorder(vector<double>& grad,
-                                      fvar<fvar<var> >& ccdf_log,
+                                      fvar<fvar<var>>& ccdf_log,
                                       vector<var>& x) {
     ccdf_log.d_.d_.grad(x, grad);
     stan::math::recover_memory();
@@ -369,25 +369,25 @@ class AgradCcdfLogTestFixture : public ::testing::Test {
       return;
     }
     vector<double> expected_ccdf_log;
-    vector<vector<double> > parameters;
+    vector<vector<double>> parameters;
     TestClass.valid_values(parameters, expected_ccdf_log);
 
     for (size_t n = 0; n < parameters.size(); n++) {
       vector<double> finite_diffs;
       vector<double> gradients;
 
-      if (!std::is_same<Scalar0, fvar<double> >::value
-          && !std::is_same<Scalar0, fvar<fvar<double> > >::value
-          && !std::is_same<Scalar1, fvar<double> >::value
-          && !std::is_same<Scalar1, fvar<fvar<double> > >::value
-          && !std::is_same<Scalar2, fvar<double> >::value
-          && !std::is_same<Scalar2, fvar<fvar<double> > >::value
-          && !std::is_same<Scalar3, fvar<double> >::value
-          && !std::is_same<Scalar3, fvar<fvar<double> > >::value
-          && !std::is_same<Scalar4, fvar<double> >::value
-          && !std::is_same<Scalar4, fvar<fvar<double> > >::value
-          && !std::is_same<Scalar5, fvar<double> >::value
-          && !std::is_same<Scalar5, fvar<fvar<double> > >::value) {
+      if (!std::is_same<Scalar0, fvar<double>>::value
+          && !std::is_same<Scalar0, fvar<fvar<double>>>::value
+          && !std::is_same<Scalar1, fvar<double>>::value
+          && !std::is_same<Scalar1, fvar<fvar<double>>>::value
+          && !std::is_same<Scalar2, fvar<double>>::value
+          && !std::is_same<Scalar2, fvar<fvar<double>>>::value
+          && !std::is_same<Scalar3, fvar<double>>::value
+          && !std::is_same<Scalar3, fvar<fvar<double>>>::value
+          && !std::is_same<Scalar4, fvar<double>>::value
+          && !std::is_same<Scalar4, fvar<fvar<double>>>::value
+          && !std::is_same<Scalar5, fvar<double>>::value
+          && !std::is_same<Scalar5, fvar<fvar<double>>>::value) {
         calculate_finite_diff(parameters[n], finite_diffs);
 
         Scalar0 p0 = get_param<Scalar0>(parameters[n], 0);
@@ -433,7 +433,7 @@ class AgradCcdfLogTestFixture : public ::testing::Test {
       return;
     }
     vector<double> ccdf_log;
-    vector<vector<double> > parameters;
+    vector<vector<double>> parameters;
     TestClass.valid_values(parameters, ccdf_log);
 
     for (size_t n = 0; n < parameters.size(); n++) {
@@ -520,7 +520,7 @@ class AgradCcdfLogTestFixture : public ::testing::Test {
     }
     const size_t N_REPEAT = 3;
     vector<double> expected_ccdf_log;
-    vector<vector<double> > parameters;
+    vector<vector<double>> parameters;
     TestClass.valid_values(parameters, expected_ccdf_log);
 
     for (size_t n = 0; n < parameters.size(); n++) {
@@ -582,38 +582,38 @@ class AgradCcdfLogTestFixture : public ::testing::Test {
       size_t pos_single = 0;
       size_t pos_multiple = 0;
       if (!is_constant_all<T0>::value && !is_empty<T0>::value
-          && !std::is_same<Scalar0, fvar<double> >::value
-          && !std::is_same<Scalar0, fvar<fvar<double> > >::value)
+          && !std::is_same<Scalar0, fvar<double>>::value
+          && !std::is_same<Scalar0, fvar<fvar<double>>>::value)
         test_multiple_gradient_values(
             is_vector<T0>::value, single_ccdf_log, single_gradients1,
             pos_single, multiple_gradients1, pos_multiple, N_REPEAT);
       if (!is_constant_all<T1>::value && !is_empty<T1>::value
-          && !std::is_same<Scalar1, fvar<double> >::value
-          && !std::is_same<Scalar1, fvar<fvar<double> > >::value)
+          && !std::is_same<Scalar1, fvar<double>>::value
+          && !std::is_same<Scalar1, fvar<fvar<double>>>::value)
         test_multiple_gradient_values(
             is_vector<T1>::value, single_ccdf_log, single_gradients1,
             pos_single, multiple_gradients1, pos_multiple, N_REPEAT);
       if (!is_constant_all<T2>::value && !is_empty<T2>::value
-          && !std::is_same<Scalar2, fvar<double> >::value
-          && !std::is_same<Scalar2, fvar<fvar<double> > >::value)
+          && !std::is_same<Scalar2, fvar<double>>::value
+          && !std::is_same<Scalar2, fvar<fvar<double>>>::value)
         test_multiple_gradient_values(
             is_vector<T2>::value, single_ccdf_log, single_gradients1,
             pos_single, multiple_gradients1, pos_multiple, N_REPEAT);
       if (!is_constant_all<T3>::value && !is_empty<T3>::value
-          && !std::is_same<Scalar3, fvar<double> >::value
-          && !std::is_same<Scalar3, fvar<fvar<double> > >::value)
+          && !std::is_same<Scalar3, fvar<double>>::value
+          && !std::is_same<Scalar3, fvar<fvar<double>>>::value)
         test_multiple_gradient_values(
             is_vector<T3>::value, single_ccdf_log, single_gradients1,
             pos_single, multiple_gradients1, pos_multiple, N_REPEAT);
       if (!is_constant_all<T4>::value && !is_empty<T4>::value
-          && !std::is_same<Scalar4, fvar<double> >::value
-          && !std::is_same<Scalar4, fvar<fvar<double> > >::value)
+          && !std::is_same<Scalar4, fvar<double>>::value
+          && !std::is_same<Scalar4, fvar<fvar<double>>>::value)
         test_multiple_gradient_values(
             is_vector<T4>::value, single_ccdf_log, single_gradients1,
             pos_single, multiple_gradients1, pos_multiple, N_REPEAT);
       if (!is_constant_all<T5>::value && !is_empty<T5>::value
-          && !std::is_same<Scalar5, fvar<double> >::value
-          && !std::is_same<Scalar5, fvar<fvar<double> > >::value)
+          && !std::is_same<Scalar5, fvar<double>>::value
+          && !std::is_same<Scalar5, fvar<fvar<double>>>::value)
         test_multiple_gradient_values(
             is_vector<T5>::value, single_ccdf_log, single_gradients1,
             pos_single, multiple_gradients1, pos_multiple, N_REPEAT);
@@ -621,38 +621,38 @@ class AgradCcdfLogTestFixture : public ::testing::Test {
       pos_single = 0;
       pos_multiple = 0;
       if (!is_constant_all<T0>::value && !is_empty<T0>::value
-          && (std::is_same<Scalar0, fvar<var> >::value
-              || std::is_same<Scalar0, fvar<fvar<var> > >::value))
+          && (std::is_same<Scalar0, fvar<var>>::value
+              || std::is_same<Scalar0, fvar<fvar<var>>>::value))
         test_multiple_gradient_values(
             is_vector<T0>::value, single_ccdf_log, single_gradients2,
             pos_single, multiple_gradients2, pos_multiple, N_REPEAT);
       if (!is_constant_all<T1>::value && !is_empty<T1>::value
-          && (std::is_same<Scalar1, fvar<var> >::value
-              || std::is_same<Scalar1, fvar<fvar<var> > >::value))
+          && (std::is_same<Scalar1, fvar<var>>::value
+              || std::is_same<Scalar1, fvar<fvar<var>>>::value))
         test_multiple_gradient_values(
             is_vector<T1>::value, single_ccdf_log, single_gradients2,
             pos_single, multiple_gradients2, pos_multiple, N_REPEAT);
       if (!is_constant_all<T2>::value && !is_empty<T2>::value
-          && (std::is_same<Scalar2, fvar<var> >::value
-              || std::is_same<Scalar2, fvar<fvar<var> > >::value))
+          && (std::is_same<Scalar2, fvar<var>>::value
+              || std::is_same<Scalar2, fvar<fvar<var>>>::value))
         test_multiple_gradient_values(
             is_vector<T2>::value, single_ccdf_log, single_gradients2,
             pos_single, multiple_gradients2, pos_multiple, N_REPEAT);
       if (!is_constant_all<T3>::value && !is_empty<T3>::value
-          && (std::is_same<Scalar3, fvar<var> >::value
-              || std::is_same<Scalar3, fvar<fvar<var> > >::value))
+          && (std::is_same<Scalar3, fvar<var>>::value
+              || std::is_same<Scalar3, fvar<fvar<var>>>::value))
         test_multiple_gradient_values(
             is_vector<T3>::value, single_ccdf_log, single_gradients2,
             pos_single, multiple_gradients2, pos_multiple, N_REPEAT);
       if (!is_constant_all<T4>::value && !is_empty<T4>::value
-          && (std::is_same<Scalar4, fvar<var> >::value
-              || std::is_same<Scalar4, fvar<fvar<var> > >::value))
+          && (std::is_same<Scalar4, fvar<var>>::value
+              || std::is_same<Scalar4, fvar<fvar<var>>>::value))
         test_multiple_gradient_values(
             is_vector<T4>::value, single_ccdf_log, single_gradients2,
             pos_single, multiple_gradients2, pos_multiple, N_REPEAT);
       if (!is_constant_all<T5>::value && !is_empty<T5>::value
-          && (std::is_same<Scalar5, fvar<var> >::value
-              || std::is_same<Scalar5, fvar<fvar<var> > >::value))
+          && (std::is_same<Scalar5, fvar<var>>::value
+              || std::is_same<Scalar5, fvar<fvar<var>>>::value))
         test_multiple_gradient_values(
             is_vector<T5>::value, single_ccdf_log, single_gradients2,
             pos_single, multiple_gradients2, pos_multiple, N_REPEAT);
@@ -660,32 +660,32 @@ class AgradCcdfLogTestFixture : public ::testing::Test {
       pos_single = 0;
       pos_multiple = 0;
       if (!is_constant_all<T0>::value && !is_empty<T0>::value
-          && std::is_same<Scalar0, fvar<fvar<var> > >::value)
+          && std::is_same<Scalar0, fvar<fvar<var>>>::value)
         test_multiple_gradient_values(
             is_vector<T0>::value, single_ccdf_log, single_gradients3,
             pos_single, multiple_gradients3, pos_multiple, N_REPEAT);
       if (!is_constant_all<T1>::value && !is_empty<T1>::value
-          && std::is_same<Scalar1, fvar<fvar<var> > >::value)
+          && std::is_same<Scalar1, fvar<fvar<var>>>::value)
         test_multiple_gradient_values(
             is_vector<T1>::value, single_ccdf_log, single_gradients3,
             pos_single, multiple_gradients3, pos_multiple, N_REPEAT);
       if (!is_constant_all<T2>::value && !is_empty<T2>::value
-          && std::is_same<Scalar2, fvar<fvar<var> > >::value)
+          && std::is_same<Scalar2, fvar<fvar<var>>>::value)
         test_multiple_gradient_values(
             is_vector<T2>::value, single_ccdf_log, single_gradients3,
             pos_single, multiple_gradients3, pos_multiple, N_REPEAT);
       if (!is_constant_all<T3>::value && !is_empty<T3>::value
-          && std::is_same<Scalar3, fvar<fvar<var> > >::value)
+          && std::is_same<Scalar3, fvar<fvar<var>>>::value)
         test_multiple_gradient_values(
             is_vector<T3>::value, single_ccdf_log, single_gradients3,
             pos_single, multiple_gradients3, pos_multiple, N_REPEAT);
       if (!is_constant_all<T4>::value && !is_empty<T4>::value
-          && std::is_same<Scalar4, fvar<fvar<var> > >::value)
+          && std::is_same<Scalar4, fvar<fvar<var>>>::value)
         test_multiple_gradient_values(
             is_vector<T4>::value, single_ccdf_log, single_gradients3,
             pos_single, multiple_gradients3, pos_multiple, N_REPEAT);
       if (!is_constant_all<T5>::value && !is_empty<T5>::value
-          && std::is_same<Scalar5, fvar<fvar<var> > >::value)
+          && std::is_same<Scalar5, fvar<fvar<var>>>::value)
         test_multiple_gradient_values(
             is_vector<T5>::value, single_ccdf_log, single_gradients3,
             pos_single, multiple_gradients3, pos_multiple, N_REPEAT);
@@ -696,7 +696,7 @@ class AgradCcdfLogTestFixture : public ::testing::Test {
     using stan::math::value_of;
     const size_t N_REPEAT = 3;
     vector<double> expected_ccdf_log;
-    vector<vector<double> > parameters;
+    vector<vector<double>> parameters;
     TestClass.valid_values(parameters, expected_ccdf_log);
 
     if (!TestClass.has_lower_bound()) {
@@ -733,7 +733,7 @@ class AgradCcdfLogTestFixture : public ::testing::Test {
     using stan::math::value_of;
     const size_t N_REPEAT = 3;
     vector<double> expected_ccdf_log;
-    vector<vector<double> > parameters;
+    vector<vector<double>> parameters;
     TestClass.valid_values(parameters, expected_ccdf_log);
 
     if (!TestClass.has_upper_bound()) {
@@ -773,7 +773,7 @@ class AgradCcdfLogTestFixture : public ::testing::Test {
     }
     const size_t N_REPEAT = 0;
     vector<double> expected_ccdf_log;
-    vector<vector<double> > parameters;
+    vector<vector<double>> parameters;
     TestClass.valid_values(parameters, expected_ccdf_log);
 
     T0 p0 = get_repeated_params<T0>(parameters[0], 0, N_REPEAT);
@@ -792,7 +792,7 @@ class AgradCcdfLogTestFixture : public ::testing::Test {
   }
 
   vector<double> first_valid_params() {
-    vector<vector<double> > params;
+    vector<vector<double>> params;
     vector<double> ccdf_log;
 
     TestClass.valid_values(params, ccdf_log);

--- a/test/prob/test_fixture_ccdf_log.hpp
+++ b/test/prob/test_fixture_ccdf_log.hpp
@@ -45,7 +45,7 @@ class AgradCcdfLogTest {
     typename T3, typename T4, typename T5,
     typename T6, typename T7, typename T8,
     typename T9>
-    typename stan::return_type<T_y, T_loc, T_scale>::type
+    stan::return_type_t<T_y, T_loc, T_scale>
     cdf_log(const T_y& y, const T_loc& mu, const T_scale& sigma,
     const T3&, const T4&, const T5&, const T6&, const T7&, const T8&, const T9&)
     { return stan::math::normal_cdf_log(y, mu, sigma);
@@ -55,7 +55,7 @@ class AgradCcdfLogTest {
     typename T3, typename T4, typename T5,
     typename T6, typename T7, typename T8,
     typename T9>
-    typename stan::return_type<T_y, T_loc, T_scale>::type
+    stan::return_type_t<T_y, T_loc, T_scale>
     cdf_log_function(const T_y& y, const T_loc& mu, const T_scale& sigma,
     const T3&, const T4&, const T5&, const T6&, const T7&, const T8&, const T9&)
     { using stan::math::erf; return (0.5 + 0.5 * erf((y - mu) / (sigma *
@@ -82,11 +82,10 @@ class AgradCcdfLogTestFixture : public ::testing::Test {
   typedef typename scalar_type<T4>::type Scalar4;
   typedef typename scalar_type<T5>::type Scalar5;
 
-  typedef typename stan::math::fvar<
-      typename stan::partials_return_type<T0, T1, T2, T3, T4, T5>::type>
-      T_fvar_return;
   typedef
-      typename stan::return_type<T0, T1, T2, T3, T4, T5>::type T_return_type;
+      typename stan::math::fvar<stan::partials_return_t<T0, T1, T2, T3, T4, T5>>
+          T_fvar_return;
+  using T_return_type = stan::return_type_t<T0, T1, T2, T3, T4, T5>;
 
   void call_all_versions() {
     vector<double> ccdf_log;

--- a/test/prob/test_fixture_cdf.hpp
+++ b/test/prob/test_fixture_cdf.hpp
@@ -16,7 +16,7 @@ using std::vector;
 
 class AgradCdfTest {
  public:
-  virtual void valid_values(vector<vector<double> >& /*parameters*/,
+  virtual void valid_values(vector<vector<double>>& /*parameters*/,
                             vector<double>& /* cdf */) {
     throw std::runtime_error("valid_values() not implemented");
   }
@@ -89,7 +89,7 @@ class AgradCdfTestFixture : public ::testing::Test {
 
   void call_all_versions() {
     vector<double> cdf;
-    vector<vector<double> > parameters;
+    vector<vector<double>> parameters;
     TestClass.valid_values(parameters, cdf);
 
     T0 p0 = get_params<T0>(parameters, 0);
@@ -106,7 +106,7 @@ class AgradCdfTestFixture : public ::testing::Test {
 
   void test_valid_values() {
     vector<double> expected_cdf;
-    vector<vector<double> > parameters;
+    vector<vector<double>> parameters;
     TestClass.valid_values(parameters, expected_cdf);
 
     for (size_t n = 0; n < parameters.size(); n++) {
@@ -286,19 +286,16 @@ class AgradCdfTestFixture : public ::testing::Test {
 
   // works for fvar<fvar<double> >
   double calculate_gradients_1storder(vector<double>& grad,
-                                      fvar<fvar<double> >& cdf,
-                                      vector<var>& x) {
+                                      fvar<fvar<double>>& cdf, vector<var>& x) {
     x.push_back(cdf.d_.val_);
     return cdf.val().val();
   }
   double calculate_gradients_2ndorder(vector<double>& grad,
-                                      fvar<fvar<double> >& cdf,
-                                      vector<var>& x) {
+                                      fvar<fvar<double>>& cdf, vector<var>& x) {
     return cdf.val().val();
   }
   double calculate_gradients_3rdorder(vector<double>& grad,
-                                      fvar<fvar<double> >& cdf,
-                                      vector<var>& x) {
+                                      fvar<fvar<double>>& cdf, vector<var>& x) {
     return cdf.val().val();
   }
 
@@ -322,19 +319,19 @@ class AgradCdfTestFixture : public ::testing::Test {
 
   // works for fvar<fvar<var> >
   double calculate_gradients_1storder(vector<double>& grad,
-                                      fvar<fvar<var> >& cdf, vector<var>& x) {
+                                      fvar<fvar<var>>& cdf, vector<var>& x) {
     cdf.val_.val_.grad(x, grad);
     stan::math::recover_memory();
     return cdf.val_.val_.val();
   }
   double calculate_gradients_2ndorder(vector<double>& grad,
-                                      fvar<fvar<var> >& cdf, vector<var>& x) {
+                                      fvar<fvar<var>>& cdf, vector<var>& x) {
     cdf.d_.val_.grad(x, grad);
     stan::math::recover_memory();
     return cdf.val_.val_.val();
   }
   double calculate_gradients_3rdorder(vector<double>& grad,
-                                      fvar<fvar<var> >& cdf, vector<var>& x) {
+                                      fvar<fvar<var>>& cdf, vector<var>& x) {
     cdf.d_.d_.grad(x, grad);
     stan::math::recover_memory();
     return cdf.val_.val_.val();
@@ -365,25 +362,25 @@ class AgradCdfTestFixture : public ::testing::Test {
       return;
     }
     vector<double> expected_cdf;
-    vector<vector<double> > parameters;
+    vector<vector<double>> parameters;
     TestClass.valid_values(parameters, expected_cdf);
 
     for (size_t n = 0; n < parameters.size(); n++) {
       vector<double> finite_diffs;
       vector<double> gradients;
 
-      if (!std::is_same<Scalar0, fvar<double> >::value
-          && !std::is_same<Scalar0, fvar<fvar<double> > >::value
-          && !std::is_same<Scalar1, fvar<double> >::value
-          && !std::is_same<Scalar1, fvar<fvar<double> > >::value
-          && !std::is_same<Scalar2, fvar<double> >::value
-          && !std::is_same<Scalar2, fvar<fvar<double> > >::value
-          && !std::is_same<Scalar3, fvar<double> >::value
-          && !std::is_same<Scalar3, fvar<fvar<double> > >::value
-          && !std::is_same<Scalar4, fvar<double> >::value
-          && !std::is_same<Scalar4, fvar<fvar<double> > >::value
-          && !std::is_same<Scalar5, fvar<double> >::value
-          && !std::is_same<Scalar5, fvar<fvar<double> > >::value) {
+      if (!std::is_same<Scalar0, fvar<double>>::value
+          && !std::is_same<Scalar0, fvar<fvar<double>>>::value
+          && !std::is_same<Scalar1, fvar<double>>::value
+          && !std::is_same<Scalar1, fvar<fvar<double>>>::value
+          && !std::is_same<Scalar2, fvar<double>>::value
+          && !std::is_same<Scalar2, fvar<fvar<double>>>::value
+          && !std::is_same<Scalar3, fvar<double>>::value
+          && !std::is_same<Scalar3, fvar<fvar<double>>>::value
+          && !std::is_same<Scalar4, fvar<double>>::value
+          && !std::is_same<Scalar4, fvar<fvar<double>>>::value
+          && !std::is_same<Scalar5, fvar<double>>::value
+          && !std::is_same<Scalar5, fvar<fvar<double>>>::value) {
         calculate_finite_diff(parameters[n], finite_diffs);
         Scalar0 p0 = get_param<Scalar0>(parameters[n], 0);
         Scalar1 p1 = get_param<Scalar1>(parameters[n], 1);
@@ -427,7 +424,7 @@ class AgradCdfTestFixture : public ::testing::Test {
       return;
     }
     vector<double> expected_cdf;
-    vector<vector<double> > parameters;
+    vector<vector<double>> parameters;
     TestClass.valid_values(parameters, expected_cdf);
 
     for (size_t n = 0; n < parameters.size(); n++) {
@@ -515,7 +512,7 @@ class AgradCdfTestFixture : public ::testing::Test {
 
     const size_t N_REPEAT = 3;
     vector<double> expected_cdf;
-    vector<vector<double> > parameters;
+    vector<vector<double>> parameters;
     TestClass.valid_values(parameters, expected_cdf);
 
     for (size_t n = 0; n < parameters.size(); n++) {
@@ -576,38 +573,38 @@ class AgradCdfTestFixture : public ::testing::Test {
       size_t pos_single = 0;
       size_t pos_multiple = 0;
       if (!is_constant_all<T0>::value && !is_empty<T0>::value
-          && !std::is_same<Scalar0, fvar<double> >::value
-          && !std::is_same<Scalar0, fvar<fvar<double> > >::value)
+          && !std::is_same<Scalar0, fvar<double>>::value
+          && !std::is_same<Scalar0, fvar<fvar<double>>>::value)
         test_multiple_gradient_values(
             is_vector<T0>::value, single_cdf, single_gradients1, pos_single,
             multiple_gradients1, pos_multiple, N_REPEAT);
       if (!is_constant_all<T1>::value && !is_empty<T1>::value
-          && !std::is_same<Scalar1, fvar<double> >::value
-          && !std::is_same<Scalar1, fvar<fvar<double> > >::value)
+          && !std::is_same<Scalar1, fvar<double>>::value
+          && !std::is_same<Scalar1, fvar<fvar<double>>>::value)
         test_multiple_gradient_values(
             is_vector<T1>::value, single_cdf, single_gradients1, pos_single,
             multiple_gradients1, pos_multiple, N_REPEAT);
       if (!is_constant_all<T2>::value && !is_empty<T2>::value
-          && !std::is_same<Scalar2, fvar<double> >::value
-          && !std::is_same<Scalar2, fvar<fvar<double> > >::value)
+          && !std::is_same<Scalar2, fvar<double>>::value
+          && !std::is_same<Scalar2, fvar<fvar<double>>>::value)
         test_multiple_gradient_values(
             is_vector<T2>::value, single_cdf, single_gradients1, pos_single,
             multiple_gradients1, pos_multiple, N_REPEAT);
       if (!is_constant_all<T3>::value && !is_empty<T3>::value
-          && !std::is_same<Scalar3, fvar<double> >::value
-          && !std::is_same<Scalar3, fvar<fvar<double> > >::value)
+          && !std::is_same<Scalar3, fvar<double>>::value
+          && !std::is_same<Scalar3, fvar<fvar<double>>>::value)
         test_multiple_gradient_values(
             is_vector<T3>::value, single_cdf, single_gradients1, pos_single,
             multiple_gradients1, pos_multiple, N_REPEAT);
       if (!is_constant_all<T4>::value && !is_empty<T4>::value
-          && !std::is_same<Scalar4, fvar<double> >::value
-          && !std::is_same<Scalar4, fvar<fvar<double> > >::value)
+          && !std::is_same<Scalar4, fvar<double>>::value
+          && !std::is_same<Scalar4, fvar<fvar<double>>>::value)
         test_multiple_gradient_values(
             is_vector<T4>::value, single_cdf, single_gradients1, pos_single,
             multiple_gradients1, pos_multiple, N_REPEAT);
       if (!is_constant_all<T5>::value && !is_empty<T5>::value
-          && !std::is_same<Scalar5, fvar<double> >::value
-          && !std::is_same<Scalar5, fvar<fvar<double> > >::value)
+          && !std::is_same<Scalar5, fvar<double>>::value
+          && !std::is_same<Scalar5, fvar<fvar<double>>>::value)
         test_multiple_gradient_values(
             is_vector<T5>::value, single_cdf, single_gradients1, pos_single,
             multiple_gradients1, pos_multiple, N_REPEAT);
@@ -615,38 +612,38 @@ class AgradCdfTestFixture : public ::testing::Test {
       pos_single = 0;
       pos_multiple = 0;
       if (!is_constant_all<T0>::value && !is_empty<T0>::value
-          && (std::is_same<Scalar0, fvar<var> >::value
-              || std::is_same<Scalar0, fvar<fvar<var> > >::value))
+          && (std::is_same<Scalar0, fvar<var>>::value
+              || std::is_same<Scalar0, fvar<fvar<var>>>::value))
         test_multiple_gradient_values(
             is_vector<T0>::value, single_cdf, single_gradients2, pos_single,
             multiple_gradients2, pos_multiple, N_REPEAT);
       if (!is_constant_all<T1>::value && !is_empty<T1>::value
-          && (std::is_same<Scalar1, fvar<var> >::value
-              || std::is_same<Scalar1, fvar<fvar<var> > >::value))
+          && (std::is_same<Scalar1, fvar<var>>::value
+              || std::is_same<Scalar1, fvar<fvar<var>>>::value))
         test_multiple_gradient_values(
             is_vector<T1>::value, single_cdf, single_gradients2, pos_single,
             multiple_gradients2, pos_multiple, N_REPEAT);
       if (!is_constant_all<T2>::value && !is_empty<T2>::value
-          && (std::is_same<Scalar2, fvar<var> >::value
-              || std::is_same<Scalar2, fvar<fvar<var> > >::value))
+          && (std::is_same<Scalar2, fvar<var>>::value
+              || std::is_same<Scalar2, fvar<fvar<var>>>::value))
         test_multiple_gradient_values(
             is_vector<T2>::value, single_cdf, single_gradients2, pos_single,
             multiple_gradients2, pos_multiple, N_REPEAT);
       if (!is_constant_all<T3>::value && !is_empty<T3>::value
-          && (std::is_same<Scalar3, fvar<var> >::value
-              || std::is_same<Scalar3, fvar<fvar<var> > >::value))
+          && (std::is_same<Scalar3, fvar<var>>::value
+              || std::is_same<Scalar3, fvar<fvar<var>>>::value))
         test_multiple_gradient_values(
             is_vector<T3>::value, single_cdf, single_gradients2, pos_single,
             multiple_gradients2, pos_multiple, N_REPEAT);
       if (!is_constant_all<T4>::value && !is_empty<T4>::value
-          && (std::is_same<Scalar4, fvar<var> >::value
-              || std::is_same<Scalar4, fvar<fvar<var> > >::value))
+          && (std::is_same<Scalar4, fvar<var>>::value
+              || std::is_same<Scalar4, fvar<fvar<var>>>::value))
         test_multiple_gradient_values(
             is_vector<T4>::value, single_cdf, single_gradients2, pos_single,
             multiple_gradients2, pos_multiple, N_REPEAT);
       if (!is_constant_all<T5>::value && !is_empty<T5>::value
-          && (std::is_same<Scalar5, fvar<var> >::value
-              || std::is_same<Scalar5, fvar<fvar<var> > >::value))
+          && (std::is_same<Scalar5, fvar<var>>::value
+              || std::is_same<Scalar5, fvar<fvar<var>>>::value))
         test_multiple_gradient_values(
             is_vector<T5>::value, single_cdf, single_gradients2, pos_single,
             multiple_gradients2, pos_multiple, N_REPEAT);
@@ -654,32 +651,32 @@ class AgradCdfTestFixture : public ::testing::Test {
       pos_single = 0;
       pos_multiple = 0;
       if (!is_constant_all<T0>::value && !is_empty<T0>::value
-          && std::is_same<Scalar0, fvar<fvar<var> > >::value)
+          && std::is_same<Scalar0, fvar<fvar<var>>>::value)
         test_multiple_gradient_values(
             is_vector<T0>::value, single_cdf, single_gradients3, pos_single,
             multiple_gradients3, pos_multiple, N_REPEAT);
       if (!is_constant_all<T1>::value && !is_empty<T1>::value
-          && std::is_same<Scalar1, fvar<fvar<var> > >::value)
+          && std::is_same<Scalar1, fvar<fvar<var>>>::value)
         test_multiple_gradient_values(
             is_vector<T1>::value, single_cdf, single_gradients3, pos_single,
             multiple_gradients3, pos_multiple, N_REPEAT);
       if (!is_constant_all<T2>::value && !is_empty<T2>::value
-          && std::is_same<Scalar2, fvar<fvar<var> > >::value)
+          && std::is_same<Scalar2, fvar<fvar<var>>>::value)
         test_multiple_gradient_values(
             is_vector<T2>::value, single_cdf, single_gradients3, pos_single,
             multiple_gradients3, pos_multiple, N_REPEAT);
       if (!is_constant_all<T3>::value && !is_empty<T3>::value
-          && std::is_same<Scalar3, fvar<fvar<var> > >::value)
+          && std::is_same<Scalar3, fvar<fvar<var>>>::value)
         test_multiple_gradient_values(
             is_vector<T3>::value, single_cdf, single_gradients3, pos_single,
             multiple_gradients3, pos_multiple, N_REPEAT);
       if (!is_constant_all<T4>::value && !is_empty<T4>::value
-          && std::is_same<Scalar4, fvar<fvar<var> > >::value)
+          && std::is_same<Scalar4, fvar<fvar<var>>>::value)
         test_multiple_gradient_values(
             is_vector<T4>::value, single_cdf, single_gradients3, pos_single,
             multiple_gradients3, pos_multiple, N_REPEAT);
       if (!is_constant_all<T5>::value && !is_empty<T5>::value
-          && std::is_same<Scalar5, fvar<fvar<var> > >::value)
+          && std::is_same<Scalar5, fvar<fvar<var>>>::value)
         test_multiple_gradient_values(
             is_vector<T5>::value, single_cdf, single_gradients3, pos_single,
             multiple_gradients3, pos_multiple, N_REPEAT);
@@ -690,7 +687,7 @@ class AgradCdfTestFixture : public ::testing::Test {
     using stan::math::value_of;
     const size_t N_REPEAT = 3;
     vector<double> expected_cdf;
-    vector<vector<double> > parameters;
+    vector<vector<double>> parameters;
     TestClass.valid_values(parameters, expected_cdf);
 
     if (!TestClass.has_lower_bound()) {
@@ -727,7 +724,7 @@ class AgradCdfTestFixture : public ::testing::Test {
     using stan::math::value_of;
     const size_t N_REPEAT = 3;
     vector<double> expected_cdf;
-    vector<vector<double> > parameters;
+    vector<vector<double>> parameters;
     TestClass.valid_values(parameters, expected_cdf);
 
     if (!TestClass.has_upper_bound()) {
@@ -768,7 +765,7 @@ class AgradCdfTestFixture : public ::testing::Test {
     }
     const size_t N_REPEAT = 0;
     vector<double> expected_cdf;
-    vector<vector<double> > parameters;
+    vector<vector<double>> parameters;
     TestClass.valid_values(parameters, expected_cdf);
 
     T0 p0 = get_repeated_params<T0>(parameters[0], 0, N_REPEAT);
@@ -785,7 +782,7 @@ class AgradCdfTestFixture : public ::testing::Test {
   }
 
   vector<double> first_valid_params() {
-    vector<vector<double> > params;
+    vector<vector<double>> params;
     vector<double> cdf;
 
     TestClass.valid_values(params, cdf);

--- a/test/prob/test_fixture_cdf.hpp
+++ b/test/prob/test_fixture_cdf.hpp
@@ -45,7 +45,7 @@ class AgradCdfTest {
     typename T3, typename T4, typename T5,
     typename T6, typename T7, typename T8,
     typename T9>
-    typename stan::return_type<T_y, T_loc, T_scale>::type
+    stan::return_type_t<T_y, T_loc, T_scale>
     cdf(const T_y& y, const T_loc& mu, const T_scale& sigma,
     const T3&, const T4&, const T5&, const T6&, const T7&, const T8&, const T9&)
     { return stan::math::normal_cdf(y, mu, sigma);
@@ -55,7 +55,7 @@ class AgradCdfTest {
     typename T3, typename T4, typename T5,
     typename T6, typename T7, typename T8,
     typename T9>
-    typename stan::return_type<T_y, T_loc, T_scale>::type
+    stan::return_type_t<T_y, T_loc, T_scale>
     cdf_function(const T_y& y, const T_loc& mu, const T_scale& sigma,
     const T3&, const T4&, const T5&, const T6&, const T7&, const T8&, const T9&)
     { using stan::math::erf; return (0.5 + 0.5 * erf((y - mu) / (sigma *
@@ -82,11 +82,10 @@ class AgradCdfTestFixture : public ::testing::Test {
   typedef typename scalar_type<T4>::type Scalar4;
   typedef typename scalar_type<T5>::type Scalar5;
 
-  typedef typename stan::math::fvar<
-      typename stan::partials_return_type<T0, T1, T2, T3, T4, T5>::type>
-      T_fvar_return;
   typedef
-      typename stan::return_type<T0, T1, T2, T3, T4, T5>::type T_return_type;
+      typename stan::math::fvar<stan::partials_return_t<T0, T1, T2, T3, T4, T5>>
+          T_fvar_return;
+  using T_return_type = stan::return_type_t<T0, T1, T2, T3, T4, T5>;
 
   void call_all_versions() {
     vector<double> cdf;

--- a/test/prob/test_fixture_cdf_log.hpp
+++ b/test/prob/test_fixture_cdf_log.hpp
@@ -45,7 +45,7 @@ class AgradCdfLogTest {
     typename T3, typename T4, typename T5,
     typename T6, typename T7, typename T8,
     typename T9>
-    typename stan::return_type<T_y, T_loc, T_scale>::type
+    stan::return_type_t<T_y, T_loc, T_scale>
     cdf_log(const T_y& y, const T_loc& mu, const T_scale& sigma,
     const T3&, const T4&, const T5&, const T6&, const T7&, const T8&, const T9&)
     { return stan::math::normal_cdf_log(y, mu, sigma);
@@ -55,7 +55,7 @@ class AgradCdfLogTest {
     typename T3, typename T4, typename T5,
     typename T6, typename T7, typename T8,
     typename T9>
-    typename stan::return_type<T_y, T_loc, T_scale>::type
+    stan::return_type_t<T_y, T_loc, T_scale>
     cdf_log_function(const T_y& y, const T_loc& mu, const T_scale& sigma,
     const T3&, const T4&, const T5&, const T6&, const T7&, const T8&, const T9&)
     { using stan::math::erf; return (0.5 + 0.5 * erf((y - mu) / (sigma *
@@ -82,11 +82,10 @@ class AgradCdfLogTestFixture : public ::testing::Test {
   typedef typename scalar_type<T4>::type Scalar4;
   typedef typename scalar_type<T5>::type Scalar5;
 
-  typedef typename stan::math::fvar<
-      typename stan::partials_return_type<T0, T1, T2, T3, T4, T5>::type>
-      T_fvar_return;
   typedef
-      typename stan::return_type<T0, T1, T2, T3, T4, T5>::type T_return_type;
+      typename stan::math::fvar<stan::partials_return_t<T0, T1, T2, T3, T4, T5>>
+          T_fvar_return;
+  using T_return_type = stan::return_type_t<T0, T1, T2, T3, T4, T5>;
 
   void call_all_versions() {
     vector<double> cdf_log;

--- a/test/prob/test_fixture_cdf_log.hpp
+++ b/test/prob/test_fixture_cdf_log.hpp
@@ -16,7 +16,7 @@ using std::vector;
 
 class AgradCdfLogTest {
  public:
-  virtual void valid_values(vector<vector<double> >& /*parameters*/,
+  virtual void valid_values(vector<vector<double>>& /*parameters*/,
                             vector<double>& /* cdf_log */) {
     throw std::runtime_error("valid_values() not implemented");
   }
@@ -89,7 +89,7 @@ class AgradCdfLogTestFixture : public ::testing::Test {
 
   void call_all_versions() {
     vector<double> cdf_log;
-    vector<vector<double> > parameters;
+    vector<vector<double>> parameters;
     TestClass.valid_values(parameters, cdf_log);
 
     T0 p0 = get_params<T0>(parameters, 0);
@@ -107,7 +107,7 @@ class AgradCdfLogTestFixture : public ::testing::Test {
 
   void test_valid_values() {
     vector<double> expected_cdf_log;
-    vector<vector<double> > parameters;
+    vector<vector<double>> parameters;
     TestClass.valid_values(parameters, expected_cdf_log);
 
     for (size_t n = 0; n < parameters.size(); n++) {
@@ -289,18 +289,18 @@ class AgradCdfLogTestFixture : public ::testing::Test {
 
   // works for fvar<fvar<double> >
   double calculate_gradients_1storder(vector<double>& grad,
-                                      fvar<fvar<double> >& cdf_log,
+                                      fvar<fvar<double>>& cdf_log,
                                       vector<var>& x) {
     x.push_back(cdf_log.d_.val_);
     return cdf_log.val().val();
   }
   double calculate_gradients_2ndorder(vector<double>& grad,
-                                      fvar<fvar<double> >& cdf_log,
+                                      fvar<fvar<double>>& cdf_log,
                                       vector<var>& x) {
     return cdf_log.val().val();
   }
   double calculate_gradients_3rdorder(vector<double>& grad,
-                                      fvar<fvar<double> >& cdf_log,
+                                      fvar<fvar<double>>& cdf_log,
                                       vector<var>& x) {
     return cdf_log.val().val();
   }
@@ -325,21 +325,21 @@ class AgradCdfLogTestFixture : public ::testing::Test {
 
   // works for fvar<fvar<var> >
   double calculate_gradients_1storder(vector<double>& grad,
-                                      fvar<fvar<var> >& cdf_log,
+                                      fvar<fvar<var>>& cdf_log,
                                       vector<var>& x) {
     cdf_log.val_.val_.grad(x, grad);
     stan::math::recover_memory();
     return cdf_log.val_.val_.val();
   }
   double calculate_gradients_2ndorder(vector<double>& grad,
-                                      fvar<fvar<var> >& cdf_log,
+                                      fvar<fvar<var>>& cdf_log,
                                       vector<var>& x) {
     cdf_log.d_.val_.grad(x, grad);
     stan::math::recover_memory();
     return cdf_log.val_.val_.val();
   }
   double calculate_gradients_3rdorder(vector<double>& grad,
-                                      fvar<fvar<var> >& cdf_log,
+                                      fvar<fvar<var>>& cdf_log,
                                       vector<var>& x) {
     cdf_log.d_.d_.grad(x, grad);
     stan::math::recover_memory();
@@ -371,25 +371,25 @@ class AgradCdfLogTestFixture : public ::testing::Test {
       return;
     }
     vector<double> expected_cdf_log;
-    vector<vector<double> > parameters;
+    vector<vector<double>> parameters;
     TestClass.valid_values(parameters, expected_cdf_log);
 
     for (size_t n = 0; n < parameters.size(); n++) {
       vector<double> finite_diffs;
       vector<double> gradients;
 
-      if (!std::is_same<Scalar0, fvar<double> >::value
-          && !std::is_same<Scalar0, fvar<fvar<double> > >::value
-          && !std::is_same<Scalar1, fvar<double> >::value
-          && !std::is_same<Scalar1, fvar<fvar<double> > >::value
-          && !std::is_same<Scalar2, fvar<double> >::value
-          && !std::is_same<Scalar2, fvar<fvar<double> > >::value
-          && !std::is_same<Scalar3, fvar<double> >::value
-          && !std::is_same<Scalar3, fvar<fvar<double> > >::value
-          && !std::is_same<Scalar4, fvar<double> >::value
-          && !std::is_same<Scalar4, fvar<fvar<double> > >::value
-          && !std::is_same<Scalar5, fvar<double> >::value
-          && !std::is_same<Scalar5, fvar<fvar<double> > >::value) {
+      if (!std::is_same<Scalar0, fvar<double>>::value
+          && !std::is_same<Scalar0, fvar<fvar<double>>>::value
+          && !std::is_same<Scalar1, fvar<double>>::value
+          && !std::is_same<Scalar1, fvar<fvar<double>>>::value
+          && !std::is_same<Scalar2, fvar<double>>::value
+          && !std::is_same<Scalar2, fvar<fvar<double>>>::value
+          && !std::is_same<Scalar3, fvar<double>>::value
+          && !std::is_same<Scalar3, fvar<fvar<double>>>::value
+          && !std::is_same<Scalar4, fvar<double>>::value
+          && !std::is_same<Scalar4, fvar<fvar<double>>>::value
+          && !std::is_same<Scalar5, fvar<double>>::value
+          && !std::is_same<Scalar5, fvar<fvar<double>>>::value) {
         calculate_finite_diff(parameters[n], finite_diffs);
         Scalar0 p0 = get_param<Scalar0>(parameters[n], 0);
         Scalar1 p1 = get_param<Scalar1>(parameters[n], 1);
@@ -434,7 +434,7 @@ class AgradCdfLogTestFixture : public ::testing::Test {
       return;
     }
     vector<double> cdf_log;
-    vector<vector<double> > parameters;
+    vector<vector<double>> parameters;
     TestClass.valid_values(parameters, cdf_log);
 
     for (size_t n = 0; n < parameters.size(); n++) {
@@ -521,7 +521,7 @@ class AgradCdfLogTestFixture : public ::testing::Test {
     }
     const size_t N_REPEAT = 3;
     vector<double> expected_cdf_log;
-    vector<vector<double> > parameters;
+    vector<vector<double>> parameters;
     TestClass.valid_values(parameters, expected_cdf_log);
 
     for (size_t n = 0; n < parameters.size(); n++) {
@@ -583,38 +583,38 @@ class AgradCdfLogTestFixture : public ::testing::Test {
       size_t pos_single = 0;
       size_t pos_multiple = 0;
       if (!is_constant_all<T0>::value && !is_empty<T0>::value
-          && !std::is_same<Scalar0, fvar<double> >::value
-          && !std::is_same<Scalar0, fvar<fvar<double> > >::value)
+          && !std::is_same<Scalar0, fvar<double>>::value
+          && !std::is_same<Scalar0, fvar<fvar<double>>>::value)
         test_multiple_gradient_values(
             is_vector<T0>::value, single_cdf_log, single_gradients1, pos_single,
             multiple_gradients1, pos_multiple, N_REPEAT);
       if (!is_constant_all<T1>::value && !is_empty<T1>::value
-          && !std::is_same<Scalar1, fvar<double> >::value
-          && !std::is_same<Scalar1, fvar<fvar<double> > >::value)
+          && !std::is_same<Scalar1, fvar<double>>::value
+          && !std::is_same<Scalar1, fvar<fvar<double>>>::value)
         test_multiple_gradient_values(
             is_vector<T1>::value, single_cdf_log, single_gradients1, pos_single,
             multiple_gradients1, pos_multiple, N_REPEAT);
       if (!is_constant_all<T2>::value && !is_empty<T2>::value
-          && !std::is_same<Scalar2, fvar<double> >::value
-          && !std::is_same<Scalar2, fvar<fvar<double> > >::value)
+          && !std::is_same<Scalar2, fvar<double>>::value
+          && !std::is_same<Scalar2, fvar<fvar<double>>>::value)
         test_multiple_gradient_values(
             is_vector<T2>::value, single_cdf_log, single_gradients1, pos_single,
             multiple_gradients1, pos_multiple, N_REPEAT);
       if (!is_constant_all<T3>::value && !is_empty<T3>::value
-          && !std::is_same<Scalar3, fvar<double> >::value
-          && !std::is_same<Scalar3, fvar<fvar<double> > >::value)
+          && !std::is_same<Scalar3, fvar<double>>::value
+          && !std::is_same<Scalar3, fvar<fvar<double>>>::value)
         test_multiple_gradient_values(
             is_vector<T3>::value, single_cdf_log, single_gradients1, pos_single,
             multiple_gradients1, pos_multiple, N_REPEAT);
       if (!is_constant_all<T4>::value && !is_empty<T4>::value
-          && !std::is_same<Scalar4, fvar<double> >::value
-          && !std::is_same<Scalar4, fvar<fvar<double> > >::value)
+          && !std::is_same<Scalar4, fvar<double>>::value
+          && !std::is_same<Scalar4, fvar<fvar<double>>>::value)
         test_multiple_gradient_values(
             is_vector<T4>::value, single_cdf_log, single_gradients1, pos_single,
             multiple_gradients1, pos_multiple, N_REPEAT);
       if (!is_constant_all<T5>::value && !is_empty<T5>::value
-          && !std::is_same<Scalar5, fvar<double> >::value
-          && !std::is_same<Scalar5, fvar<fvar<double> > >::value)
+          && !std::is_same<Scalar5, fvar<double>>::value
+          && !std::is_same<Scalar5, fvar<fvar<double>>>::value)
         test_multiple_gradient_values(
             is_vector<T5>::value, single_cdf_log, single_gradients1, pos_single,
             multiple_gradients1, pos_multiple, N_REPEAT);
@@ -622,38 +622,38 @@ class AgradCdfLogTestFixture : public ::testing::Test {
       pos_single = 0;
       pos_multiple = 0;
       if (!is_constant_all<T0>::value && !is_empty<T0>::value
-          && (std::is_same<Scalar0, fvar<var> >::value
-              || std::is_same<Scalar0, fvar<fvar<var> > >::value))
+          && (std::is_same<Scalar0, fvar<var>>::value
+              || std::is_same<Scalar0, fvar<fvar<var>>>::value))
         test_multiple_gradient_values(
             is_vector<T0>::value, single_cdf_log, single_gradients2, pos_single,
             multiple_gradients2, pos_multiple, N_REPEAT);
       if (!is_constant_all<T1>::value && !is_empty<T1>::value
-          && (std::is_same<Scalar1, fvar<var> >::value
-              || std::is_same<Scalar1, fvar<fvar<var> > >::value))
+          && (std::is_same<Scalar1, fvar<var>>::value
+              || std::is_same<Scalar1, fvar<fvar<var>>>::value))
         test_multiple_gradient_values(
             is_vector<T1>::value, single_cdf_log, single_gradients2, pos_single,
             multiple_gradients2, pos_multiple, N_REPEAT);
       if (!is_constant_all<T2>::value && !is_empty<T2>::value
-          && (std::is_same<Scalar2, fvar<var> >::value
-              || std::is_same<Scalar2, fvar<fvar<var> > >::value))
+          && (std::is_same<Scalar2, fvar<var>>::value
+              || std::is_same<Scalar2, fvar<fvar<var>>>::value))
         test_multiple_gradient_values(
             is_vector<T2>::value, single_cdf_log, single_gradients2, pos_single,
             multiple_gradients2, pos_multiple, N_REPEAT);
       if (!is_constant_all<T3>::value && !is_empty<T3>::value
-          && (std::is_same<Scalar3, fvar<var> >::value
-              || std::is_same<Scalar3, fvar<fvar<var> > >::value))
+          && (std::is_same<Scalar3, fvar<var>>::value
+              || std::is_same<Scalar3, fvar<fvar<var>>>::value))
         test_multiple_gradient_values(
             is_vector<T3>::value, single_cdf_log, single_gradients2, pos_single,
             multiple_gradients2, pos_multiple, N_REPEAT);
       if (!is_constant_all<T4>::value && !is_empty<T4>::value
-          && (std::is_same<Scalar4, fvar<var> >::value
-              || std::is_same<Scalar4, fvar<fvar<var> > >::value))
+          && (std::is_same<Scalar4, fvar<var>>::value
+              || std::is_same<Scalar4, fvar<fvar<var>>>::value))
         test_multiple_gradient_values(
             is_vector<T4>::value, single_cdf_log, single_gradients2, pos_single,
             multiple_gradients2, pos_multiple, N_REPEAT);
       if (!is_constant_all<T5>::value && !is_empty<T5>::value
-          && (std::is_same<Scalar5, fvar<var> >::value
-              || std::is_same<Scalar5, fvar<fvar<var> > >::value))
+          && (std::is_same<Scalar5, fvar<var>>::value
+              || std::is_same<Scalar5, fvar<fvar<var>>>::value))
         test_multiple_gradient_values(
             is_vector<T5>::value, single_cdf_log, single_gradients2, pos_single,
             multiple_gradients2, pos_multiple, N_REPEAT);
@@ -661,32 +661,32 @@ class AgradCdfLogTestFixture : public ::testing::Test {
       pos_single = 0;
       pos_multiple = 0;
       if (!is_constant_all<T0>::value && !is_empty<T0>::value
-          && std::is_same<Scalar0, fvar<fvar<var> > >::value)
+          && std::is_same<Scalar0, fvar<fvar<var>>>::value)
         test_multiple_gradient_values(
             is_vector<T0>::value, single_cdf_log, single_gradients3, pos_single,
             multiple_gradients3, pos_multiple, N_REPEAT);
       if (!is_constant_all<T1>::value && !is_empty<T1>::value
-          && std::is_same<Scalar1, fvar<fvar<var> > >::value)
+          && std::is_same<Scalar1, fvar<fvar<var>>>::value)
         test_multiple_gradient_values(
             is_vector<T1>::value, single_cdf_log, single_gradients3, pos_single,
             multiple_gradients3, pos_multiple, N_REPEAT);
       if (!is_constant_all<T2>::value && !is_empty<T2>::value
-          && std::is_same<Scalar2, fvar<fvar<var> > >::value)
+          && std::is_same<Scalar2, fvar<fvar<var>>>::value)
         test_multiple_gradient_values(
             is_vector<T2>::value, single_cdf_log, single_gradients3, pos_single,
             multiple_gradients3, pos_multiple, N_REPEAT);
       if (!is_constant_all<T3>::value && !is_empty<T3>::value
-          && std::is_same<Scalar3, fvar<fvar<var> > >::value)
+          && std::is_same<Scalar3, fvar<fvar<var>>>::value)
         test_multiple_gradient_values(
             is_vector<T3>::value, single_cdf_log, single_gradients3, pos_single,
             multiple_gradients3, pos_multiple, N_REPEAT);
       if (!is_constant_all<T4>::value && !is_empty<T4>::value
-          && std::is_same<Scalar4, fvar<fvar<var> > >::value)
+          && std::is_same<Scalar4, fvar<fvar<var>>>::value)
         test_multiple_gradient_values(
             is_vector<T4>::value, single_cdf_log, single_gradients3, pos_single,
             multiple_gradients3, pos_multiple, N_REPEAT);
       if (!is_constant_all<T5>::value && !is_empty<T5>::value
-          && std::is_same<Scalar5, fvar<fvar<var> > >::value)
+          && std::is_same<Scalar5, fvar<fvar<var>>>::value)
         test_multiple_gradient_values(
             is_vector<T5>::value, single_cdf_log, single_gradients3, pos_single,
             multiple_gradients3, pos_multiple, N_REPEAT);
@@ -697,7 +697,7 @@ class AgradCdfLogTestFixture : public ::testing::Test {
     using stan::math::value_of;
     const size_t N_REPEAT = 3;
     vector<double> expected_cdf_log;
-    vector<vector<double> > parameters;
+    vector<vector<double>> parameters;
     TestClass.valid_values(parameters, expected_cdf_log);
 
     if (!TestClass.has_lower_bound()) {
@@ -734,7 +734,7 @@ class AgradCdfLogTestFixture : public ::testing::Test {
     using stan::math::value_of;
     const size_t N_REPEAT = 3;
     vector<double> expected_cdf_log;
-    vector<vector<double> > parameters;
+    vector<vector<double>> parameters;
     TestClass.valid_values(parameters, expected_cdf_log);
 
     if (!TestClass.has_upper_bound()) {
@@ -774,7 +774,7 @@ class AgradCdfLogTestFixture : public ::testing::Test {
     }
     const size_t N_REPEAT = 0;
     vector<double> expected_cdf_log;
-    vector<vector<double> > parameters;
+    vector<vector<double>> parameters;
     TestClass.valid_values(parameters, expected_cdf_log);
 
     T0 p0 = get_repeated_params<T0>(parameters[0], 0, N_REPEAT);
@@ -792,7 +792,7 @@ class AgradCdfLogTestFixture : public ::testing::Test {
   }
 
   vector<double> first_valid_params() {
-    vector<vector<double> > params;
+    vector<vector<double>> params;
     vector<double> cdf_log;
 
     TestClass.valid_values(params, cdf_log);

--- a/test/prob/test_fixture_distr.hpp
+++ b/test/prob/test_fixture_distr.hpp
@@ -23,7 +23,7 @@ using std::vector;
  */
 class AgradDistributionTest {
  public:
-  virtual void valid_values(vector<vector<double> >& /*parameters*/,
+  virtual void valid_values(vector<vector<double>>& /*parameters*/,
                             vector<double>& /* log_prob */) {
     throw std::runtime_error("valid_values() not implemented");
   }
@@ -61,7 +61,7 @@ class AgradDistributionTestFixture : public ::testing::Test {
 
   void call_all_versions() {
     vector<double> log_prob;
-    vector<vector<double> > parameters;
+    vector<vector<double>> parameters;
     TestClass.valid_values(parameters, log_prob);
 
     T0 p0 = get_params<T0>(parameters, 0);
@@ -89,7 +89,7 @@ class AgradDistributionTestFixture : public ::testing::Test {
 
   void test_valid_values() {
     vector<double> log_prob;
-    vector<vector<double> > parameters;
+    vector<vector<double>> parameters;
     TestClass.valid_values(parameters, log_prob);
 
     for (size_t n = 0; n < parameters.size(); n++) {
@@ -212,7 +212,7 @@ class AgradDistributionTestFixture : public ::testing::Test {
       return;
     }
     vector<double> log_prob;
-    vector<vector<double> > parameters;
+    vector<vector<double>> parameters;
     TestClass.valid_values(parameters, log_prob);
     T_return_type reference_logprob_true;
     T_return_type reference_logprob_false;
@@ -348,18 +348,18 @@ class AgradDistributionTestFixture : public ::testing::Test {
 
   // works for fvar<fvar<double> >
   double calculate_gradients_1storder(vector<double>& grad,
-                                      fvar<fvar<double> >& logprob,
+                                      fvar<fvar<double>>& logprob,
                                       vector<var>& x) {
     x.push_back(logprob.d_.val_);
     return logprob.val().val();
   }
   double calculate_gradients_2ndorder(vector<double>& grad,
-                                      fvar<fvar<double> >& logprob,
+                                      fvar<fvar<double>>& logprob,
                                       vector<var>& x) {
     return logprob.val().val();
   }
   double calculate_gradients_3rdorder(vector<double>& grad,
-                                      fvar<fvar<double> >& logprob,
+                                      fvar<fvar<double>>& logprob,
                                       vector<var>& x) {
     return logprob.val().val();
   }
@@ -384,21 +384,21 @@ class AgradDistributionTestFixture : public ::testing::Test {
 
   // works for fvar<fvar<var> >
   double calculate_gradients_1storder(vector<double>& grad,
-                                      fvar<fvar<var> >& logprob,
+                                      fvar<fvar<var>>& logprob,
                                       vector<var>& x) {
     logprob.val_.val_.grad(x, grad);
     stan::math::recover_memory();
     return logprob.val_.val_.val();
   }
   double calculate_gradients_2ndorder(vector<double>& grad,
-                                      fvar<fvar<var> >& logprob,
+                                      fvar<fvar<var>>& logprob,
                                       vector<var>& x) {
     logprob.d_.val_.grad(x, grad);
     stan::math::recover_memory();
     return logprob.val_.val_.val();
   }
   double calculate_gradients_3rdorder(vector<double>& grad,
-                                      fvar<fvar<var> >& logprob,
+                                      fvar<fvar<var>>& logprob,
                                       vector<var>& x) {
     logprob.d_.d_.grad(x, grad);
     stan::math::recover_memory();
@@ -432,25 +432,25 @@ class AgradDistributionTestFixture : public ::testing::Test {
     }
 
     vector<double> log_prob;
-    vector<vector<double> > parameters;
+    vector<vector<double>> parameters;
     TestClass.valid_values(parameters, log_prob);
 
     for (size_t n = 0; n < parameters.size(); n++) {
       vector<double> finite_diffs;
       vector<double> gradients;
 
-      if (!std::is_same<Scalar0, fvar<double> >::value
-          && !std::is_same<Scalar0, fvar<fvar<double> > >::value
-          && !std::is_same<Scalar1, fvar<double> >::value
-          && !std::is_same<Scalar1, fvar<fvar<double> > >::value
-          && !std::is_same<Scalar2, fvar<double> >::value
-          && !std::is_same<Scalar2, fvar<fvar<double> > >::value
-          && !std::is_same<Scalar3, fvar<double> >::value
-          && !std::is_same<Scalar3, fvar<fvar<double> > >::value
-          && !std::is_same<Scalar4, fvar<double> >::value
-          && !std::is_same<Scalar4, fvar<fvar<double> > >::value
-          && !std::is_same<Scalar5, fvar<double> >::value
-          && !std::is_same<Scalar5, fvar<fvar<double> > >::value) {
+      if (!std::is_same<Scalar0, fvar<double>>::value
+          && !std::is_same<Scalar0, fvar<fvar<double>>>::value
+          && !std::is_same<Scalar1, fvar<double>>::value
+          && !std::is_same<Scalar1, fvar<fvar<double>>>::value
+          && !std::is_same<Scalar2, fvar<double>>::value
+          && !std::is_same<Scalar2, fvar<fvar<double>>>::value
+          && !std::is_same<Scalar3, fvar<double>>::value
+          && !std::is_same<Scalar3, fvar<fvar<double>>>::value
+          && !std::is_same<Scalar4, fvar<double>>::value
+          && !std::is_same<Scalar4, fvar<fvar<double>>>::value
+          && !std::is_same<Scalar5, fvar<double>>::value
+          && !std::is_same<Scalar5, fvar<fvar<double>>>::value) {
         calculate_finite_diff(parameters[n], finite_diffs);
 
         Scalar0 p0_ = get_param<Scalar0>(parameters[n], 0);
@@ -495,7 +495,7 @@ class AgradDistributionTestFixture : public ::testing::Test {
     }
 
     vector<double> log_prob;
-    vector<vector<double> > parameters;
+    vector<vector<double>> parameters;
     TestClass.valid_values(parameters, log_prob);
 
     for (size_t n = 0; n < parameters.size(); n++) {
@@ -585,7 +585,7 @@ class AgradDistributionTestFixture : public ::testing::Test {
     }
     const size_t N_REPEAT = 3;
     vector<double> log_prob;
-    vector<vector<double> > parameters;
+    vector<vector<double>> parameters;
     TestClass.valid_values(parameters, log_prob);
 
     for (size_t n = 0; n < parameters.size(); n++) {
@@ -647,38 +647,38 @@ class AgradDistributionTestFixture : public ::testing::Test {
       size_t pos_single = 0;
       size_t pos_multiple = 0;
       if (!is_constant_all<T0>::value && !is_empty<T0>::value
-          && !std::is_same<Scalar0, fvar<double> >::value
-          && !std::is_same<Scalar0, fvar<fvar<double> > >::value)
+          && !std::is_same<Scalar0, fvar<double>>::value
+          && !std::is_same<Scalar0, fvar<fvar<double>>>::value)
         test_multiple_gradient_values(is_vector<T0>::value, single_gradients1,
                                       pos_single, multiple_gradients1,
                                       pos_multiple, N_REPEAT);
       if (!is_constant_all<T1>::value && !is_empty<T1>::value
-          && !std::is_same<Scalar1, fvar<double> >::value
-          && !std::is_same<Scalar1, fvar<fvar<double> > >::value)
+          && !std::is_same<Scalar1, fvar<double>>::value
+          && !std::is_same<Scalar1, fvar<fvar<double>>>::value)
         test_multiple_gradient_values(is_vector<T1>::value, single_gradients1,
                                       pos_single, multiple_gradients1,
                                       pos_multiple, N_REPEAT);
       if (!is_constant_all<T2>::value && !is_empty<T2>::value
-          && !std::is_same<Scalar2, fvar<double> >::value
-          && !std::is_same<Scalar2, fvar<fvar<double> > >::value)
+          && !std::is_same<Scalar2, fvar<double>>::value
+          && !std::is_same<Scalar2, fvar<fvar<double>>>::value)
         test_multiple_gradient_values(is_vector<T2>::value, single_gradients1,
                                       pos_single, multiple_gradients1,
                                       pos_multiple, N_REPEAT);
       if (!is_constant_all<T3>::value && !is_empty<T3>::value
-          && !std::is_same<Scalar3, fvar<double> >::value
-          && !std::is_same<Scalar3, fvar<fvar<double> > >::value)
+          && !std::is_same<Scalar3, fvar<double>>::value
+          && !std::is_same<Scalar3, fvar<fvar<double>>>::value)
         test_multiple_gradient_values(is_vector<T3>::value, single_gradients1,
                                       pos_single, multiple_gradients1,
                                       pos_multiple, N_REPEAT);
       if (!is_constant_all<T4>::value && !is_empty<T4>::value
-          && !std::is_same<Scalar4, fvar<double> >::value
-          && !std::is_same<Scalar4, fvar<fvar<double> > >::value)
+          && !std::is_same<Scalar4, fvar<double>>::value
+          && !std::is_same<Scalar4, fvar<fvar<double>>>::value)
         test_multiple_gradient_values(is_vector<T4>::value, single_gradients1,
                                       pos_single, multiple_gradients1,
                                       pos_multiple, N_REPEAT);
       if (!is_constant_all<T5>::value && !is_empty<T5>::value
-          && !std::is_same<Scalar5, fvar<double> >::value
-          && !std::is_same<Scalar5, fvar<fvar<double> > >::value)
+          && !std::is_same<Scalar5, fvar<double>>::value
+          && !std::is_same<Scalar5, fvar<fvar<double>>>::value)
         test_multiple_gradient_values(is_vector<T5>::value, single_gradients1,
                                       pos_single, multiple_gradients1,
                                       pos_multiple, N_REPEAT);
@@ -686,38 +686,38 @@ class AgradDistributionTestFixture : public ::testing::Test {
       pos_single = 0;
       pos_multiple = 0;
       if (!is_constant_all<T0>::value && !is_empty<T0>::value
-          && (std::is_same<Scalar0, fvar<var> >::value
-              || std::is_same<Scalar0, fvar<fvar<var> > >::value))
+          && (std::is_same<Scalar0, fvar<var>>::value
+              || std::is_same<Scalar0, fvar<fvar<var>>>::value))
         test_multiple_gradient_values(is_vector<T0>::value, single_gradients2,
                                       pos_single, multiple_gradients2,
                                       pos_multiple, N_REPEAT);
       if (!is_constant_all<T1>::value && !is_empty<T1>::value
-          && (std::is_same<Scalar1, fvar<var> >::value
-              || std::is_same<Scalar1, fvar<fvar<var> > >::value))
+          && (std::is_same<Scalar1, fvar<var>>::value
+              || std::is_same<Scalar1, fvar<fvar<var>>>::value))
         test_multiple_gradient_values(is_vector<T1>::value, single_gradients2,
                                       pos_single, multiple_gradients2,
                                       pos_multiple, N_REPEAT);
       if (!is_constant_all<T2>::value && !is_empty<T2>::value
-          && (std::is_same<Scalar2, fvar<var> >::value
-              || std::is_same<Scalar2, fvar<fvar<var> > >::value))
+          && (std::is_same<Scalar2, fvar<var>>::value
+              || std::is_same<Scalar2, fvar<fvar<var>>>::value))
         test_multiple_gradient_values(is_vector<T2>::value, single_gradients2,
                                       pos_single, multiple_gradients2,
                                       pos_multiple, N_REPEAT);
       if (!is_constant_all<T3>::value && !is_empty<T3>::value
-          && (std::is_same<Scalar3, fvar<var> >::value
-              || std::is_same<Scalar3, fvar<fvar<var> > >::value))
+          && (std::is_same<Scalar3, fvar<var>>::value
+              || std::is_same<Scalar3, fvar<fvar<var>>>::value))
         test_multiple_gradient_values(is_vector<T3>::value, single_gradients2,
                                       pos_single, multiple_gradients2,
                                       pos_multiple, N_REPEAT);
       if (!is_constant_all<T4>::value && !is_empty<T4>::value
-          && (std::is_same<Scalar4, fvar<var> >::value
-              || std::is_same<Scalar4, fvar<fvar<var> > >::value))
+          && (std::is_same<Scalar4, fvar<var>>::value
+              || std::is_same<Scalar4, fvar<fvar<var>>>::value))
         test_multiple_gradient_values(is_vector<T4>::value, single_gradients2,
                                       pos_single, multiple_gradients2,
                                       pos_multiple, N_REPEAT);
       if (!is_constant_all<T5>::value && !is_empty<T5>::value
-          && (std::is_same<Scalar5, fvar<var> >::value
-              || std::is_same<Scalar5, fvar<fvar<var> > >::value))
+          && (std::is_same<Scalar5, fvar<var>>::value
+              || std::is_same<Scalar5, fvar<fvar<var>>>::value))
         test_multiple_gradient_values(is_vector<T5>::value, single_gradients2,
                                       pos_single, multiple_gradients2,
                                       pos_multiple, N_REPEAT);
@@ -725,32 +725,32 @@ class AgradDistributionTestFixture : public ::testing::Test {
       pos_single = 0;
       pos_multiple = 0;
       if (!is_constant_all<T0>::value && !is_empty<T0>::value
-          && std::is_same<Scalar0, fvar<fvar<var> > >::value)
+          && std::is_same<Scalar0, fvar<fvar<var>>>::value)
         test_multiple_gradient_values(is_vector<T0>::value, single_gradients3,
                                       pos_single, multiple_gradients3,
                                       pos_multiple, N_REPEAT);
       if (!is_constant_all<T1>::value && !is_empty<T1>::value
-          && std::is_same<Scalar1, fvar<fvar<var> > >::value)
+          && std::is_same<Scalar1, fvar<fvar<var>>>::value)
         test_multiple_gradient_values(is_vector<T1>::value, single_gradients3,
                                       pos_single, multiple_gradients3,
                                       pos_multiple, N_REPEAT);
       if (!is_constant_all<T2>::value && !is_empty<T2>::value
-          && std::is_same<Scalar2, fvar<fvar<var> > >::value)
+          && std::is_same<Scalar2, fvar<fvar<var>>>::value)
         test_multiple_gradient_values(is_vector<T2>::value, single_gradients3,
                                       pos_single, multiple_gradients3,
                                       pos_multiple, N_REPEAT);
       if (!is_constant_all<T3>::value && !is_empty<T3>::value
-          && std::is_same<Scalar3, fvar<fvar<var> > >::value)
+          && std::is_same<Scalar3, fvar<fvar<var>>>::value)
         test_multiple_gradient_values(is_vector<T3>::value, single_gradients3,
                                       pos_single, multiple_gradients3,
                                       pos_multiple, N_REPEAT);
       if (!is_constant_all<T4>::value && !is_empty<T4>::value
-          && std::is_same<Scalar4, fvar<fvar<var> > >::value)
+          && std::is_same<Scalar4, fvar<fvar<var>>>::value)
         test_multiple_gradient_values(is_vector<T4>::value, single_gradients3,
                                       pos_single, multiple_gradients3,
                                       pos_multiple, N_REPEAT);
       if (!is_constant_all<T5>::value && !is_empty<T5>::value
-          && std::is_same<Scalar5, fvar<fvar<var> > >::value)
+          && std::is_same<Scalar5, fvar<fvar<var>>>::value)
         test_multiple_gradient_values(is_vector<T5>::value, single_gradients3,
                                       pos_single, multiple_gradients3,
                                       pos_multiple, N_REPEAT);
@@ -764,7 +764,7 @@ class AgradDistributionTestFixture : public ::testing::Test {
     }
     const size_t N_REPEAT = 0;
     vector<double> log_prob;
-    vector<vector<double> > parameters;
+    vector<vector<double>> parameters;
     TestClass.valid_values(parameters, log_prob);
 
     T0 p0 = get_repeated_params<T0>(parameters[0], 0, N_REPEAT);
@@ -781,7 +781,7 @@ class AgradDistributionTestFixture : public ::testing::Test {
   }
 
   vector<double> first_valid_params() {
-    vector<vector<double> > params;
+    vector<vector<double>> params;
     vector<double> log_prob;
 
     TestClass.valid_values(params, log_prob);

--- a/test/prob/test_fixture_distr.hpp
+++ b/test/prob/test_fixture_distr.hpp
@@ -54,11 +54,10 @@ class AgradDistributionTestFixture : public ::testing::Test {
   typedef typename scalar_type<T4>::type Scalar4;
   typedef typename scalar_type<T5>::type Scalar5;
 
-  typedef typename stan::math::fvar<
-      typename stan::partials_return_type<T0, T1, T2, T3, T4, T5>::type>
-      T_fvar_return;
   typedef
-      typename stan::return_type<T0, T1, T2, T3, T4, T5>::type T_return_type;
+      typename stan::math::fvar<stan::partials_return_t<T0, T1, T2, T3, T4, T5>>
+          T_fvar_return;
+  using T_return_type = stan::return_type_t<T0, T1, T2, T3, T4, T5>;
 
   void call_all_versions() {
     vector<double> log_prob;

--- a/test/prob/uniform/uniform_ccdf_log_test.hpp
+++ b/test/prob/uniform/uniform_ccdf_log_test.hpp
@@ -47,15 +47,17 @@ class AgradCcdfLogUniform : public AgradCcdfLogTest {
 
   template <class T_y, class T_low, class T_high, typename T3, typename T4,
             typename T5>
-  typename stan::return_type<T_y, T_low, T_high>::type ccdf_log(
-      const T_y& y, const T_low& alpha, const T_high& beta, const T3&,
-      const T4&, const T5&) {
+  stan::return_type_t<T_y, T_low, T_high> ccdf_log(const T_y& y,
+                                                   const T_low& alpha,
+                                                   const T_high& beta,
+                                                   const T3&, const T4&,
+                                                   const T5&) {
     return stan::math::uniform_ccdf_log(y, alpha, beta);
   }
 
   template <class T_y, class T_low, class T_high, typename T3, typename T4,
             typename T5>
-  typename stan::return_type<T_y, T_low, T_high>::type ccdf_log_function(
+  stan::return_type_t<T_y, T_low, T_high> ccdf_log_function(
       const T_y& y, const T_low& alpha, const T_high& beta, const T3&,
       const T4&, const T5&) {
     using stan::math::LOG_ZERO;

--- a/test/prob/uniform/uniform_cdf_log_test.hpp
+++ b/test/prob/uniform/uniform_cdf_log_test.hpp
@@ -47,17 +47,20 @@ class AgradCdfLogUniform : public AgradCdfLogTest {
 
   template <class T_y, class T_low, class T_high, typename T3, typename T4,
             typename T5>
-  typename stan::return_type<T_y, T_low, T_high>::type cdf_log(
-      const T_y& y, const T_low& alpha, const T_high& beta, const T3&,
-      const T4&, const T5&) {
+  stan::return_type_t<T_y, T_low, T_high> cdf_log(const T_y& y,
+                                                  const T_low& alpha,
+                                                  const T_high& beta, const T3&,
+                                                  const T4&, const T5&) {
     return stan::math::uniform_cdf_log(y, alpha, beta);
   }
 
   template <class T_y, class T_low, class T_high, typename T3, typename T4,
             typename T5>
-  typename stan::return_type<T_y, T_low, T_high>::type cdf_log_function(
-      const T_y& y, const T_low& alpha, const T_high& beta, const T3&,
-      const T4&, const T5&) {
+  stan::return_type_t<T_y, T_low, T_high> cdf_log_function(const T_y& y,
+                                                           const T_low& alpha,
+                                                           const T_high& beta,
+                                                           const T3&, const T4&,
+                                                           const T5&) {
     using stan::math::LOG_ZERO;
     using stan::math::include_summand;
 

--- a/test/prob/uniform/uniform_cdf_test.hpp
+++ b/test/prob/uniform/uniform_cdf_test.hpp
@@ -46,19 +46,19 @@ class AgradCdfUniform : public AgradCdfTest {
 
   template <class T_y, class T_low, class T_high, typename T3, typename T4,
             typename T5>
-  typename stan::return_type<T_y, T_low, T_high>::type cdf(const T_y& y,
-                                                           const T_low& alpha,
-                                                           const T_high& beta,
-                                                           const T3&, const T4&,
-                                                           const T5&) {
+  stan::return_type_t<T_y, T_low, T_high> cdf(const T_y& y, const T_low& alpha,
+                                              const T_high& beta, const T3&,
+                                              const T4&, const T5&) {
     return stan::math::uniform_cdf(y, alpha, beta);
   }
 
   template <class T_y, class T_low, class T_high, typename T3, typename T4,
             typename T5>
-  typename stan::return_type<T_y, T_low, T_high>::type cdf_function(
-      const T_y& y, const T_low& alpha, const T_high& beta, const T3&,
-      const T4&, const T5&) {
+  stan::return_type_t<T_y, T_low, T_high> cdf_function(const T_y& y,
+                                                       const T_low& alpha,
+                                                       const T_high& beta,
+                                                       const T3&, const T4&,
+                                                       const T5&) {
     using stan::math::LOG_ZERO;
     using stan::math::include_summand;
 

--- a/test/prob/uniform/uniform_test.hpp
+++ b/test/prob/uniform/uniform_test.hpp
@@ -40,23 +40,27 @@ class AgradDistributionsUniform : public AgradDistributionTest {
 
   template <class T_y, class T_low, class T_high, typename T3, typename T4,
             typename T5>
-  typename stan::return_type<T_y, T_low, T_high>::type log_prob(
-      const T_y& y, const T_low& alpha, const T_high& beta, const T3&,
-      const T4&, const T5&) {
+  stan::return_type_t<T_y, T_low, T_high> log_prob(const T_y& y,
+                                                   const T_low& alpha,
+                                                   const T_high& beta,
+                                                   const T3&, const T4&,
+                                                   const T5&) {
     return stan::math::uniform_log(y, alpha, beta);
   }
 
   template <bool propto, class T_y, class T_low, class T_high, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_low, T_high>::type log_prob(
-      const T_y& y, const T_low& alpha, const T_high& beta, const T3&,
-      const T4&, const T5&) {
+  stan::return_type_t<T_y, T_low, T_high> log_prob(const T_y& y,
+                                                   const T_low& alpha,
+                                                   const T_high& beta,
+                                                   const T3&, const T4&,
+                                                   const T5&) {
     return stan::math::uniform_log<propto>(y, alpha, beta);
   }
 
   template <class T_y, class T_low, class T_high, typename T3, typename T4,
             typename T5>
-  typename stan::return_type<T_y, T_low, T_high>::type log_prob_function(
+  stan::return_type_t<T_y, T_low, T_high> log_prob_function(
       const T_y& y, const T_low& alpha, const T_high& beta, const T3&,
       const T4&, const T5&) {
     using stan::math::LOG_ZERO;

--- a/test/prob/utility.hpp
+++ b/test/prob/utility.hpp
@@ -56,7 +56,7 @@ std::ostream& operator<<(std::ostream& os, const vector<var>& param) {
 // ------------------------------------------------------------
 // default template handles Eigen::Matrix
 template <typename T>
-T get_params(const vector<vector<double> >& parameters, const size_t p) {
+T get_params(const vector<vector<double>>& parameters, const size_t p) {
   T param(parameters.size());
   for (size_t n = 0; n < parameters.size(); n++)
     if (p < parameters[0].size())
@@ -66,13 +66,13 @@ T get_params(const vector<vector<double> >& parameters, const size_t p) {
 
 // handle empty
 template <>
-empty get_params<empty>(const vector<vector<double> >& /*parameters*/,
+empty get_params<empty>(const vector<vector<double>>& /*parameters*/,
                         const size_t /*p*/) {
   return empty();
 }
 // handle scalars
 template <>
-double get_params<double>(const vector<vector<double> >& parameters,
+double get_params<double>(const vector<vector<double>>& parameters,
                           const size_t p) {
   double param(0);
   if (p < parameters[0].size())
@@ -80,15 +80,15 @@ double get_params<double>(const vector<vector<double> >& parameters,
   return param;
 }
 template <>
-var get_params<var>(const vector<vector<double> >& parameters, const size_t p) {
+var get_params<var>(const vector<vector<double>>& parameters, const size_t p) {
   var param(0);
   if (p < parameters[0].size())
     param = parameters[0][p];
   return param;
 }
 template <>
-fvar<double> get_params<fvar<double> >(
-    const vector<vector<double> >& parameters, const size_t p) {
+fvar<double> get_params<fvar<double>>(const vector<vector<double>>& parameters,
+                                      const size_t p) {
   fvar<double> param(0);
   if (p < parameters[0].size()) {
     param = parameters[0][p];
@@ -97,8 +97,8 @@ fvar<double> get_params<fvar<double> >(
   return param;
 }
 template <>
-fvar<var> get_params<fvar<var> >(const vector<vector<double> >& parameters,
-                                 const size_t p) {
+fvar<var> get_params<fvar<var>>(const vector<vector<double>>& parameters,
+                                const size_t p) {
   fvar<var> param(0);
   if (p < parameters[0].size()) {
     param = parameters[0][p];
@@ -107,9 +107,9 @@ fvar<var> get_params<fvar<var> >(const vector<vector<double> >& parameters,
   return param;
 }
 template <>
-fvar<fvar<double> > get_params<fvar<fvar<double> > >(
-    const vector<vector<double> >& parameters, const size_t p) {
-  fvar<fvar<double> > param(0);
+fvar<fvar<double>> get_params<fvar<fvar<double>>>(
+    const vector<vector<double>>& parameters, const size_t p) {
+  fvar<fvar<double>> param(0);
   if (p < parameters[0].size()) {
     param = parameters[0][p];
     param.d_ = 1.0;
@@ -117,9 +117,9 @@ fvar<fvar<double> > get_params<fvar<fvar<double> > >(
   return param;
 }
 template <>
-fvar<fvar<var> > get_params<fvar<fvar<var> > >(
-    const vector<vector<double> >& parameters, const size_t p) {
-  fvar<fvar<var> > param(0);
+fvar<fvar<var>> get_params<fvar<fvar<var>>>(
+    const vector<vector<double>>& parameters, const size_t p) {
+  fvar<fvar<var>> param(0);
   if (p < parameters[0].size()) {
     param = parameters[0][p];
     param.d_ = 1.0;
@@ -127,7 +127,7 @@ fvar<fvar<var> > get_params<fvar<fvar<var> > >(
   return param;
 }
 template <>
-int get_params<int>(const vector<vector<double> >& parameters, const size_t p) {
+int get_params<int>(const vector<vector<double>>& parameters, const size_t p) {
   int param(0);
   if (p < parameters[0].size())
     param = (int)parameters[0][p];
@@ -135,8 +135,8 @@ int get_params<int>(const vector<vector<double> >& parameters, const size_t p) {
 }
 // handle vectors
 template <>
-vector<int> get_params<vector<int> >(const vector<vector<double> >& parameters,
-                                     const size_t p) {
+vector<int> get_params<vector<int>>(const vector<vector<double>>& parameters,
+                                    const size_t p) {
   vector<int> param(parameters.size());
   for (size_t n = 0; n < parameters.size(); n++)
     if (p < parameters[0].size())
@@ -144,8 +144,8 @@ vector<int> get_params<vector<int> >(const vector<vector<double> >& parameters,
   return param;
 }
 template <>
-vector<double> get_params<vector<double> >(
-    const vector<vector<double> >& parameters, const size_t p) {
+vector<double> get_params<vector<double>>(
+    const vector<vector<double>>& parameters, const size_t p) {
   vector<double> param(parameters.size());
   for (size_t n = 0; n < parameters.size(); n++)
     if (p < parameters[0].size())
@@ -153,8 +153,8 @@ vector<double> get_params<vector<double> >(
   return param;
 }
 template <>
-vector<var> get_params<vector<var> >(const vector<vector<double> >& parameters,
-                                     const size_t p) {
+vector<var> get_params<vector<var>>(const vector<vector<double>>& parameters,
+                                    const size_t p) {
   vector<var> param(parameters.size());
   for (size_t n = 0; n < parameters.size(); n++)
     if (p < parameters[0].size())
@@ -162,9 +162,9 @@ vector<var> get_params<vector<var> >(const vector<vector<double> >& parameters,
   return param;
 }
 template <>
-vector<fvar<double> > get_params<vector<fvar<double> > >(
-    const vector<vector<double> >& parameters, const size_t p) {
-  vector<fvar<double> > param(parameters.size());
+vector<fvar<double>> get_params<vector<fvar<double>>>(
+    const vector<vector<double>>& parameters, const size_t p) {
+  vector<fvar<double>> param(parameters.size());
   for (size_t n = 0; n < parameters.size(); n++)
     if (p < parameters[0].size()) {
       param[n] = parameters[n][p];
@@ -173,9 +173,9 @@ vector<fvar<double> > get_params<vector<fvar<double> > >(
   return param;
 }
 template <>
-vector<fvar<var> > get_params<vector<fvar<var> > >(
-    const vector<vector<double> >& parameters, const size_t p) {
-  vector<fvar<var> > param(parameters.size());
+vector<fvar<var>> get_params<vector<fvar<var>>>(
+    const vector<vector<double>>& parameters, const size_t p) {
+  vector<fvar<var>> param(parameters.size());
   for (size_t n = 0; n < parameters.size(); n++)
     if (p < parameters[0].size()) {
       param[n] = parameters[n][p];
@@ -184,9 +184,9 @@ vector<fvar<var> > get_params<vector<fvar<var> > >(
   return param;
 }
 template <>
-vector<fvar<fvar<double> > > get_params<vector<fvar<fvar<double> > > >(
-    const vector<vector<double> >& parameters, const size_t p) {
-  vector<fvar<fvar<double> > > param(parameters.size());
+vector<fvar<fvar<double>>> get_params<vector<fvar<fvar<double>>>>(
+    const vector<vector<double>>& parameters, const size_t p) {
+  vector<fvar<fvar<double>>> param(parameters.size());
   for (size_t n = 0; n < parameters.size(); n++)
     if (p < parameters[0].size()) {
       param[n] = parameters[n][p];
@@ -195,9 +195,9 @@ vector<fvar<fvar<double> > > get_params<vector<fvar<fvar<double> > > >(
   return param;
 }
 template <>
-vector<fvar<fvar<var> > > get_params<vector<fvar<fvar<var> > > >(
-    const vector<vector<double> >& parameters, const size_t p) {
-  vector<fvar<fvar<var> > > param(parameters.size());
+vector<fvar<fvar<var>>> get_params<vector<fvar<fvar<var>>>>(
+    const vector<vector<double>>& parameters, const size_t p) {
+  vector<fvar<fvar<var>>> param(parameters.size());
   for (size_t n = 0; n < parameters.size(); n++)
     if (p < parameters[0].size()) {
       param[n] = parameters[n][p];
@@ -210,7 +210,7 @@ vector<fvar<fvar<var> > > get_params<vector<fvar<fvar<var> > > >(
 
 // default template handles Eigen::Matrix
 template <typename T>
-T get_params(const vector<vector<double> >& parameters, const size_t /*n*/,
+T get_params(const vector<vector<double>>& parameters, const size_t /*n*/,
              const size_t p) {
   T param(parameters.size());
   for (size_t i = 0; i < parameters.size(); i++)
@@ -221,13 +221,13 @@ T get_params(const vector<vector<double> >& parameters, const size_t /*n*/,
 
 // handle empty
 template <>
-empty get_params<empty>(const vector<vector<double> >& /*parameters*/,
+empty get_params<empty>(const vector<vector<double>>& /*parameters*/,
                         const size_t /*n*/, const size_t /*p*/) {
   return empty();
 }
 // handle scalars
 template <>
-double get_params<double>(const vector<vector<double> >& parameters,
+double get_params<double>(const vector<vector<double>>& parameters,
                           const size_t n, const size_t p) {
   double param(0);
   if (p < parameters[0].size())
@@ -235,7 +235,7 @@ double get_params<double>(const vector<vector<double> >& parameters,
   return param;
 }
 template <>
-var get_params<var>(const vector<vector<double> >& parameters, const size_t n,
+var get_params<var>(const vector<vector<double>>& parameters, const size_t n,
                     const size_t p) {
   var param(0);
   if (p < parameters[0].size())
@@ -243,8 +243,8 @@ var get_params<var>(const vector<vector<double> >& parameters, const size_t n,
   return param;
 }
 template <>
-fvar<double> get_params<fvar<double> >(
-    const vector<vector<double> >& parameters, const size_t n, const size_t p) {
+fvar<double> get_params<fvar<double>>(const vector<vector<double>>& parameters,
+                                      const size_t n, const size_t p) {
   fvar<double> param(0);
   if (p < parameters[0].size()) {
     param = parameters[n][p];
@@ -253,8 +253,8 @@ fvar<double> get_params<fvar<double> >(
   return param;
 }
 template <>
-fvar<var> get_params<fvar<var> >(const vector<vector<double> >& parameters,
-                                 const size_t n, const size_t p) {
+fvar<var> get_params<fvar<var>>(const vector<vector<double>>& parameters,
+                                const size_t n, const size_t p) {
   fvar<var> param(0);
   if (p < parameters[0].size()) {
     param = parameters[n][p];
@@ -263,9 +263,9 @@ fvar<var> get_params<fvar<var> >(const vector<vector<double> >& parameters,
   return param;
 }
 template <>
-fvar<fvar<double> > get_params<fvar<fvar<double> > >(
-    const vector<vector<double> >& parameters, const size_t n, const size_t p) {
-  fvar<fvar<double> > param(0);
+fvar<fvar<double>> get_params<fvar<fvar<double>>>(
+    const vector<vector<double>>& parameters, const size_t n, const size_t p) {
+  fvar<fvar<double>> param(0);
   if (p < parameters[0].size()) {
     param = parameters[n][p];
     param.d_ = 1.0;
@@ -273,9 +273,9 @@ fvar<fvar<double> > get_params<fvar<fvar<double> > >(
   return param;
 }
 template <>
-fvar<fvar<var> > get_params<fvar<fvar<var> > >(
-    const vector<vector<double> >& parameters, const size_t n, const size_t p) {
-  fvar<fvar<var> > param(0);
+fvar<fvar<var>> get_params<fvar<fvar<var>>>(
+    const vector<vector<double>>& parameters, const size_t n, const size_t p) {
+  fvar<fvar<var>> param(0);
   if (p < parameters[0].size()) {
     param = parameters[n][p];
     param.d_ = 1.0;
@@ -283,7 +283,7 @@ fvar<fvar<var> > get_params<fvar<fvar<var> > >(
   return param;
 }
 template <>
-int get_params<int>(const vector<vector<double> >& parameters, const size_t n,
+int get_params<int>(const vector<vector<double>>& parameters, const size_t n,
                     const size_t p) {
   int param(0);
   if (p < parameters[0].size())
@@ -292,8 +292,8 @@ int get_params<int>(const vector<vector<double> >& parameters, const size_t n,
 }
 // handle vectors
 template <>
-vector<int> get_params<vector<int> >(const vector<vector<double> >& parameters,
-                                     const size_t /*n*/, const size_t p) {
+vector<int> get_params<vector<int>>(const vector<vector<double>>& parameters,
+                                    const size_t /*n*/, const size_t p) {
   vector<int> param(parameters.size());
   for (size_t i = 0; i < parameters.size(); i++)
     if (p < parameters[0].size())
@@ -301,8 +301,8 @@ vector<int> get_params<vector<int> >(const vector<vector<double> >& parameters,
   return param;
 }
 template <>
-vector<double> get_params<vector<double> >(
-    const vector<vector<double> >& parameters, const size_t /*n*/,
+vector<double> get_params<vector<double>>(
+    const vector<vector<double>>& parameters, const size_t /*n*/,
     const size_t p) {
   vector<double> param(parameters.size());
   for (size_t i = 0; i < parameters.size(); i++)
@@ -311,8 +311,8 @@ vector<double> get_params<vector<double> >(
   return param;
 }
 template <>
-vector<var> get_params<vector<var> >(const vector<vector<double> >& parameters,
-                                     const size_t /*n*/, const size_t p) {
+vector<var> get_params<vector<var>>(const vector<vector<double>>& parameters,
+                                    const size_t /*n*/, const size_t p) {
   vector<var> param(parameters.size());
   for (size_t i = 0; i < parameters.size(); i++)
     if (p < parameters[0].size())
@@ -320,10 +320,10 @@ vector<var> get_params<vector<var> >(const vector<vector<double> >& parameters,
   return param;
 }
 template <>
-vector<fvar<double> > get_params<vector<fvar<double> > >(
-    const vector<vector<double> >& parameters, const size_t /*n*/,
+vector<fvar<double>> get_params<vector<fvar<double>>>(
+    const vector<vector<double>>& parameters, const size_t /*n*/,
     const size_t p) {
-  vector<fvar<double> > param(parameters.size());
+  vector<fvar<double>> param(parameters.size());
   for (size_t i = 0; i < parameters.size(); i++)
     if (p < parameters[0].size()) {
       param[i] = parameters[i][p];
@@ -332,10 +332,10 @@ vector<fvar<double> > get_params<vector<fvar<double> > >(
   return param;
 }
 template <>
-vector<fvar<var> > get_params<vector<fvar<var> > >(
-    const vector<vector<double> >& parameters, const size_t /*n*/,
+vector<fvar<var>> get_params<vector<fvar<var>>>(
+    const vector<vector<double>>& parameters, const size_t /*n*/,
     const size_t p) {
-  vector<fvar<var> > param(parameters.size());
+  vector<fvar<var>> param(parameters.size());
   for (size_t i = 0; i < parameters.size(); i++)
     if (p < parameters[0].size()) {
       param[i] = parameters[i][p];
@@ -344,10 +344,10 @@ vector<fvar<var> > get_params<vector<fvar<var> > >(
   return param;
 }
 template <>
-vector<fvar<fvar<double> > > get_params<vector<fvar<fvar<double> > > >(
-    const vector<vector<double> >& parameters, const size_t /*n*/,
+vector<fvar<fvar<double>>> get_params<vector<fvar<fvar<double>>>>(
+    const vector<vector<double>>& parameters, const size_t /*n*/,
     const size_t p) {
-  vector<fvar<fvar<double> > > param(parameters.size());
+  vector<fvar<fvar<double>>> param(parameters.size());
   for (size_t i = 0; i < parameters.size(); i++)
     if (p < parameters[0].size()) {
       param[i] = parameters[i][p];
@@ -356,10 +356,10 @@ vector<fvar<fvar<double> > > get_params<vector<fvar<fvar<double> > > >(
   return param;
 }
 template <>
-vector<fvar<fvar<var> > > get_params<vector<fvar<fvar<var> > > >(
-    const vector<vector<double> >& parameters, const size_t /*n*/,
+vector<fvar<fvar<var>>> get_params<vector<fvar<fvar<var>>>>(
+    const vector<vector<double>>& parameters, const size_t /*n*/,
     const size_t p) {
-  vector<fvar<fvar<var> > > param(parameters.size());
+  vector<fvar<fvar<var>>> param(parameters.size());
   for (size_t i = 0; i < parameters.size(); i++)
     if (p < parameters[0].size()) {
       param[i] = parameters[i][p];
@@ -408,9 +408,9 @@ var get_repeated_params<var>(const vector<double>& parameters, const size_t p,
   return param;
 }
 template <>
-fvar<double> get_repeated_params<fvar<double> >(
-    const vector<double>& parameters, const size_t p,
-    const size_t /*N_REPEAT*/) {
+fvar<double> get_repeated_params<fvar<double>>(const vector<double>& parameters,
+                                               const size_t p,
+                                               const size_t /*N_REPEAT*/) {
   fvar<double> param(0);
   if (p < parameters.size()) {
     param = parameters[p];
@@ -419,9 +419,9 @@ fvar<double> get_repeated_params<fvar<double> >(
   return param;
 }
 template <>
-fvar<var> get_repeated_params<fvar<var> >(const vector<double>& parameters,
-                                          const size_t p,
-                                          const size_t /*N_REPEAT*/) {
+fvar<var> get_repeated_params<fvar<var>>(const vector<double>& parameters,
+                                         const size_t p,
+                                         const size_t /*N_REPEAT*/) {
   fvar<var> param(0);
   if (p < parameters.size()) {
     param = parameters[p];
@@ -430,10 +430,10 @@ fvar<var> get_repeated_params<fvar<var> >(const vector<double>& parameters,
   return param;
 }
 template <>
-fvar<fvar<double> > get_repeated_params<fvar<fvar<double> > >(
+fvar<fvar<double>> get_repeated_params<fvar<fvar<double>>>(
     const vector<double>& parameters, const size_t p,
     const size_t /*N_REPEAT*/) {
-  fvar<fvar<double> > param(0);
+  fvar<fvar<double>> param(0);
   if (p < parameters.size()) {
     param = parameters[p];
     param.d_ = 1.0;
@@ -441,10 +441,10 @@ fvar<fvar<double> > get_repeated_params<fvar<fvar<double> > >(
   return param;
 }
 template <>
-fvar<fvar<var> > get_repeated_params<fvar<fvar<var> > >(
+fvar<fvar<var>> get_repeated_params<fvar<fvar<var>>>(
     const vector<double>& parameters, const size_t p,
     const size_t /*N_REPEAT*/) {
-  fvar<fvar<var> > param(0);
+  fvar<fvar<var>> param(0);
   if (p < parameters.size()) {
     param = parameters[p];
     param.d_ = 1.0;
@@ -461,9 +461,9 @@ int get_repeated_params<int>(const vector<double>& parameters, const size_t p,
 }
 // handle vectors
 template <>
-vector<int> get_repeated_params<vector<int> >(const vector<double>& parameters,
-                                              const size_t p,
-                                              const size_t N_REPEAT) {
+vector<int> get_repeated_params<vector<int>>(const vector<double>& parameters,
+                                             const size_t p,
+                                             const size_t N_REPEAT) {
   vector<int> param(N_REPEAT);
   for (size_t n = 0; n < N_REPEAT; n++)
     if (p < parameters.size())
@@ -471,7 +471,7 @@ vector<int> get_repeated_params<vector<int> >(const vector<double>& parameters,
   return param;
 }
 template <>
-vector<double> get_repeated_params<vector<double> >(
+vector<double> get_repeated_params<vector<double>>(
     const vector<double>& parameters, const size_t p, const size_t N_REPEAT) {
   vector<double> param(N_REPEAT);
   for (size_t n = 0; n < N_REPEAT; n++)
@@ -480,9 +480,9 @@ vector<double> get_repeated_params<vector<double> >(
   return param;
 }
 template <>
-vector<var> get_repeated_params<vector<var> >(const vector<double>& parameters,
-                                              const size_t p,
-                                              const size_t N_REPEAT) {
+vector<var> get_repeated_params<vector<var>>(const vector<double>& parameters,
+                                             const size_t p,
+                                             const size_t N_REPEAT) {
   vector<var> param(N_REPEAT);
   for (size_t n = 0; n < N_REPEAT; n++)
     if (p < parameters.size())
@@ -491,9 +491,9 @@ vector<var> get_repeated_params<vector<var> >(const vector<double>& parameters,
 }
 
 template <>
-vector<fvar<double> > get_repeated_params<vector<fvar<double> > >(
+vector<fvar<double>> get_repeated_params<vector<fvar<double>>>(
     const vector<double>& parameters, const size_t p, const size_t N_REPEAT) {
-  vector<fvar<double> > param(N_REPEAT);
+  vector<fvar<double>> param(N_REPEAT);
   for (size_t n = 0; n < N_REPEAT; n++)
     if (p < parameters.size()) {
       param[n] = parameters[p];
@@ -502,9 +502,9 @@ vector<fvar<double> > get_repeated_params<vector<fvar<double> > >(
   return param;
 }
 template <>
-vector<fvar<var> > get_repeated_params<vector<fvar<var> > >(
+vector<fvar<var>> get_repeated_params<vector<fvar<var>>>(
     const vector<double>& parameters, const size_t p, const size_t N_REPEAT) {
-  vector<fvar<var> > param(N_REPEAT);
+  vector<fvar<var>> param(N_REPEAT);
   for (size_t n = 0; n < N_REPEAT; n++)
     if (p < parameters.size()) {
       param[n] = parameters[p];
@@ -513,9 +513,9 @@ vector<fvar<var> > get_repeated_params<vector<fvar<var> > >(
   return param;
 }
 template <>
-vector<fvar<fvar<double> > > get_repeated_params<vector<fvar<fvar<double> > > >(
+vector<fvar<fvar<double>>> get_repeated_params<vector<fvar<fvar<double>>>>(
     const vector<double>& parameters, const size_t p, const size_t N_REPEAT) {
-  vector<fvar<fvar<double> > > param(N_REPEAT);
+  vector<fvar<fvar<double>>> param(N_REPEAT);
   for (size_t n = 0; n < N_REPEAT; n++)
     if (p < parameters.size()) {
       param[n] = parameters[p];
@@ -524,9 +524,9 @@ vector<fvar<fvar<double> > > get_repeated_params<vector<fvar<fvar<double> > > >(
   return param;
 }
 template <>
-vector<fvar<fvar<var> > > get_repeated_params<vector<fvar<fvar<var> > > >(
+vector<fvar<fvar<var>>> get_repeated_params<vector<fvar<fvar<var>>>>(
     const vector<double>& parameters, const size_t p, const size_t N_REPEAT) {
-  vector<fvar<fvar<var> > > param(N_REPEAT);
+  vector<fvar<fvar<var>>> param(N_REPEAT);
   for (size_t n = 0; n < N_REPEAT; n++)
     if (p < parameters.size()) {
       param[n] = parameters[p];
@@ -550,8 +550,8 @@ empty get_param<empty>(const vector<double>& /*params*/, const size_t /*n*/) {
   return empty();
 }
 template <>
-fvar<double> get_param<fvar<double> >(const vector<double>& params,
-                                      const size_t n) {
+fvar<double> get_param<fvar<double>>(const vector<double>& params,
+                                     const size_t n) {
   fvar<double> param = 0;
   if (n < params.size()) {
     param = params[n];
@@ -560,7 +560,7 @@ fvar<double> get_param<fvar<double> >(const vector<double>& params,
   return param;
 }
 template <>
-fvar<var> get_param<fvar<var> >(const vector<double>& params, const size_t n) {
+fvar<var> get_param<fvar<var>>(const vector<double>& params, const size_t n) {
   fvar<var> param = 0;
   if (n < params.size()) {
     param = params[n];
@@ -569,9 +569,9 @@ fvar<var> get_param<fvar<var> >(const vector<double>& params, const size_t n) {
   return param;
 }
 template <>
-fvar<fvar<double> > get_param<fvar<fvar<double> > >(
-    const vector<double>& params, const size_t n) {
-  fvar<fvar<double> > param = 0;
+fvar<fvar<double>> get_param<fvar<fvar<double>>>(const vector<double>& params,
+                                                 const size_t n) {
+  fvar<fvar<double>> param = 0;
   if (n < params.size()) {
     param = params[n];
     param.d_ = 1.0;
@@ -579,9 +579,9 @@ fvar<fvar<double> > get_param<fvar<fvar<double> > >(
   return param;
 }
 template <>
-fvar<fvar<var> > get_param<fvar<fvar<var> > >(const vector<double>& params,
-                                              const size_t n) {
-  fvar<fvar<var> > param = 0;
+fvar<fvar<var>> get_param<fvar<fvar<var>>>(const vector<double>& params,
+                                           const size_t n) {
+  fvar<fvar<var>> param = 0;
   if (n < params.size()) {
     param = params[n];
     param.d_ = 1.0;
@@ -593,7 +593,7 @@ fvar<fvar<var> > get_param<fvar<fvar<var> > >(const vector<double>& params,
 
 template <typename T>
 typename scalar_type<T>::type select_var_param(
-    const vector<vector<double> >& parameters, const size_t n, const size_t p) {
+    const vector<vector<double>>& parameters, const size_t n, const size_t p) {
   typename scalar_type<T>::type param(0);
   if (p < parameters[0].size()) {
     if (is_vector<T>::value && !is_constant_all<T>::value)
@@ -605,7 +605,7 @@ typename scalar_type<T>::type select_var_param(
 }
 
 template <>
-empty select_var_param<empty>(const vector<vector<double> >& /*parameters*/,
+empty select_var_param<empty>(const vector<vector<double>>& /*parameters*/,
                               const size_t /*n*/, const size_t /*p*/) {
   return empty();
 }
@@ -670,71 +670,71 @@ void add_var<var>(vector<var>& x, var& p) {
 }
 
 template <>
-void add_var<vector<var> >(vector<var>& x, vector<var>& p) {
+void add_var<vector<var>>(vector<var>& x, vector<var>& p) {
   x.insert(x.end(), p.begin(), p.end());
 }
 
 template <>
-void add_var<Eigen::Matrix<var, 1, Eigen::Dynamic> >(
+void add_var<Eigen::Matrix<var, 1, Eigen::Dynamic>>(
     vector<var>& x, Eigen::Matrix<var, 1, Eigen::Dynamic>& p) {
   for (size_type n = 0; n < p.size(); n++)
     x.push_back(p(n));
 }
 
 template <>
-void add_var<Eigen::Matrix<var, Eigen::Dynamic, 1> >(
+void add_var<Eigen::Matrix<var, Eigen::Dynamic, 1>>(
     vector<var>& x, Eigen::Matrix<var, Eigen::Dynamic, 1>& p) {
   for (size_type n = 0; n < p.size(); n++)
     x.push_back(p(n));
 }
 
 template <>
-void add_var<fvar<var> >(vector<var>& x, fvar<var>& p) {
+void add_var<fvar<var>>(vector<var>& x, fvar<var>& p) {
   x.push_back(p.val_);
 }
 
 template <>
-void add_var<vector<fvar<var> > >(vector<var>& x, vector<fvar<var> >& p) {
+void add_var<vector<fvar<var>>>(vector<var>& x, vector<fvar<var>>& p) {
   for (size_t n = 0; n < p.size(); n++)
     x.push_back(p[n].val_);
 }
 
 template <>
-void add_var<Eigen::Matrix<fvar<var>, 1, Eigen::Dynamic> >(
+void add_var<Eigen::Matrix<fvar<var>, 1, Eigen::Dynamic>>(
     vector<var>& x, Eigen::Matrix<fvar<var>, 1, Eigen::Dynamic>& p) {
   for (size_type n = 0; n < p.size(); n++)
     x.push_back(p(n).val_);
 }
 
 template <>
-void add_var<Eigen::Matrix<fvar<var>, Eigen::Dynamic, 1> >(
+void add_var<Eigen::Matrix<fvar<var>, Eigen::Dynamic, 1>>(
     vector<var>& x, Eigen::Matrix<fvar<var>, Eigen::Dynamic, 1>& p) {
   for (size_type n = 0; n < p.size(); n++)
     x.push_back(p(n).val_);
 }
 
 template <>
-void add_var<fvar<fvar<var> > >(vector<var>& x, fvar<fvar<var> >& p) {
+void add_var<fvar<fvar<var>>>(vector<var>& x, fvar<fvar<var>>& p) {
   x.push_back(p.val_.val_);
 }
 
 template <>
-void add_var<vector<fvar<fvar<var> > > >(vector<var>& x,
-                                         vector<fvar<fvar<var> > >& p) {
+void add_var<vector<fvar<fvar<var>>>>(vector<var>& x,
+                                      vector<fvar<fvar<var>>>& p) {
   for (size_t n = 0; n < p.size(); n++)
     x.push_back(p[n].val_.val_);
 }
 
 template <>
-void add_var<Eigen::Matrix<fvar<fvar<var> >, 1, Eigen::Dynamic> >(
-    vector<var>& x, Eigen::Matrix<fvar<fvar<var> >, 1, Eigen::Dynamic>& p) {
+void add_var<Eigen::Matrix<fvar<fvar<var>>, 1, Eigen::Dynamic>>(
+    vector<var>& x, Eigen::Matrix<fvar<fvar<var>>, 1, Eigen::Dynamic>& p) {
   for (size_type n = 0; n < p.size(); n++)
     x.push_back(p(n).val_.val_);
 }
 
 template <>
-void add_var<Eigen::Matrix<fvar<fvar<var> >, Eigen::Dynamic, 1> >(
-    vector<var>& x, Eigen::Matrix<fvar<fvar<var> >, Eigen::Dynamic, 1>& p) {
+void add_var<Eigen::Matrix<fvar<fvar<var>>, Eigen::Dynamic, 1>>(
+    vector<var>& x, Eigen::Matrix<fvar<fvar<var>>, Eigen::Dynamic, 1>& p) {
   for (size_type n = 0; n < p.size(); n++)
     x.push_back(p(n).val_.val_);
 }

--- a/test/prob/utility.hpp
+++ b/test/prob/utility.hpp
@@ -10,7 +10,7 @@ using stan::math::var;
 using stan::scalar_type;
 using std::vector;
 
-typedef stan::math::index_type<Eigen::Matrix<double, 1, 1> >::type size_type;
+using size_type = stan::math::index_type_t<Eigen::Matrix<double, 1, 1>>;
 
 // ------------------------------------------------------------
 

--- a/test/prob/von_mises/von_mises_test.hpp
+++ b/test/prob/von_mises/von_mises_test.hpp
@@ -64,23 +64,27 @@ class AgradDistributionVonMises : public AgradDistributionTest {
 
   template <typename T_y, typename T_loc, typename T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale>::type log_prob(
-      const T_y& y, const T_loc& mu, const T_scale& kappa, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_y, T_loc, T_scale> log_prob(const T_y& y,
+                                                    const T_loc& mu,
+                                                    const T_scale& kappa,
+                                                    const T3&, const T4&,
+                                                    const T5&) {
     return stan::math::von_mises_log(y, mu, kappa);
   }
 
   template <bool propto, typename T_y, typename T_loc, typename T_scale,
             typename T3, typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale>::type log_prob(
-      const T_y& y, const T_loc& mu, const T_scale& kappa, const T3&, const T4&,
-      const T5&) {
+  stan::return_type_t<T_y, T_loc, T_scale> log_prob(const T_y& y,
+                                                    const T_loc& mu,
+                                                    const T_scale& kappa,
+                                                    const T3&, const T4&,
+                                                    const T5&) {
     return stan::math::von_mises_log<propto>(y, mu, kappa);
   }
 
   template <typename T_y, typename T_loc, typename T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_loc, T_scale>::type log_prob_function(
+  stan::return_type_t<T_y, T_loc, T_scale> log_prob_function(
       const T_y& y, const T_loc& mu, const T_scale& kappa, const T3&, const T4&,
       const T5&) {
     using stan::math::modified_bessel_first_kind;

--- a/test/prob/weibull/weibull_ccdf_log_test.hpp
+++ b/test/prob/weibull/weibull_ccdf_log_test.hpp
@@ -63,15 +63,17 @@ class AgradCcdfLogWeibull : public AgradCcdfLogTest {
 
   template <typename T_y, typename T_shape, typename T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_shape, T_scale>::type ccdf_log(
-      const T_y& y, const T_shape& alpha, const T_scale& sigma, const T3&,
-      const T4&, const T5&) {
+  stan::return_type_t<T_y, T_shape, T_scale> ccdf_log(const T_y& y,
+                                                      const T_shape& alpha,
+                                                      const T_scale& sigma,
+                                                      const T3&, const T4&,
+                                                      const T5&) {
     return stan::math::weibull_ccdf_log(y, alpha, sigma);
   }
 
   template <typename T_y, typename T_shape, typename T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_shape, T_scale>::type ccdf_log_function(
+  stan::return_type_t<T_y, T_shape, T_scale> ccdf_log_function(
       const T_y& y, const T_shape& alpha, const T_scale& sigma, const T3&,
       const T4&, const T5&) {
     using std::log;

--- a/test/prob/weibull/weibull_cdf_log_test.hpp
+++ b/test/prob/weibull/weibull_cdf_log_test.hpp
@@ -61,15 +61,17 @@ class AgradCdfLogWeibull : public AgradCdfLogTest {
 
   template <typename T_y, typename T_shape, typename T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_shape, T_scale>::type cdf_log(
-      const T_y& y, const T_shape& alpha, const T_scale& sigma, const T3&,
-      const T4&, const T5&) {
+  stan::return_type_t<T_y, T_shape, T_scale> cdf_log(const T_y& y,
+                                                     const T_shape& alpha,
+                                                     const T_scale& sigma,
+                                                     const T3&, const T4&,
+                                                     const T5&) {
     return stan::math::weibull_cdf_log(y, alpha, sigma);
   }
 
   template <typename T_y, typename T_shape, typename T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_shape, T_scale>::type cdf_log_function(
+  stan::return_type_t<T_y, T_shape, T_scale> cdf_log_function(
       const T_y& y, const T_shape& alpha, const T_scale& sigma, const T3&,
       const T4&, const T5&) {
     using std::log;

--- a/test/prob/weibull/weibull_cdf_test.hpp
+++ b/test/prob/weibull/weibull_cdf_test.hpp
@@ -60,17 +60,21 @@ class AgradCdfWeibull : public AgradCdfTest {
 
   template <typename T_y, typename T_shape, typename T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_shape, T_scale>::type cdf(
-      const T_y& y, const T_shape& alpha, const T_scale& sigma, const T3&,
-      const T4&, const T5&) {
+  stan::return_type_t<T_y, T_shape, T_scale> cdf(const T_y& y,
+                                                 const T_shape& alpha,
+                                                 const T_scale& sigma,
+                                                 const T3&, const T4&,
+                                                 const T5&) {
     return stan::math::weibull_cdf(y, alpha, sigma);
   }
 
   template <typename T_y, typename T_shape, typename T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_shape, T_scale>::type cdf_function(
-      const T_y& y, const T_shape& alpha, const T_scale& sigma, const T3&,
-      const T4&, const T5&) {
+  stan::return_type_t<T_y, T_shape, T_scale> cdf_function(const T_y& y,
+                                                          const T_shape& alpha,
+                                                          const T_scale& sigma,
+                                                          const T3&, const T4&,
+                                                          const T5&) {
     using std::log;
     using std::pow;
     return 1.0 - exp(-pow(y / sigma, alpha));

--- a/test/prob/weibull/weibull_test.hpp
+++ b/test/prob/weibull/weibull_test.hpp
@@ -50,23 +50,27 @@ class AgradDistributionsWeibull : public AgradDistributionTest {
 
   template <typename T_y, typename T_shape, typename T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_shape, T_scale>::type log_prob(
-      const T_y& y, const T_shape& alpha, const T_scale& sigma, const T3&,
-      const T4&, const T5&) {
+  stan::return_type_t<T_y, T_shape, T_scale> log_prob(const T_y& y,
+                                                      const T_shape& alpha,
+                                                      const T_scale& sigma,
+                                                      const T3&, const T4&,
+                                                      const T5&) {
     return stan::math::weibull_log(y, alpha, sigma);
   }
 
   template <bool propto, typename T_y, typename T_shape, typename T_scale,
             typename T3, typename T4, typename T5>
-  typename stan::return_type<T_y, T_shape, T_scale>::type log_prob(
-      const T_y& y, const T_shape& alpha, const T_scale& sigma, const T3&,
-      const T4&, const T5&) {
+  stan::return_type_t<T_y, T_shape, T_scale> log_prob(const T_y& y,
+                                                      const T_shape& alpha,
+                                                      const T_scale& sigma,
+                                                      const T3&, const T4&,
+                                                      const T5&) {
     return stan::math::weibull_log<propto>(y, alpha, sigma);
   }
 
   template <typename T_y, typename T_shape, typename T_scale, typename T3,
             typename T4, typename T5>
-  typename stan::return_type<T_y, T_shape, T_scale>::type log_prob_function(
+  stan::return_type_t<T_y, T_shape, T_scale> log_prob_function(
       const T_y& y, const T_shape& alpha, const T_scale& sigma, const T3&,
       const T4&, const T5&) {
     using stan::math::multiply_log;

--- a/test/prob/wiener/wiener_test.hpp
+++ b/test/prob/wiener/wiener_test.hpp
@@ -77,23 +77,23 @@ class AgradDistributionWiener : public AgradDistributionTest {
 
   template <typename T_y, typename T_alpha, typename T_tau, typename T_beta,
             typename T_delta, typename T5>
-  typename stan::return_type<T_y, T_alpha, T_tau, T_beta, T_delta>::type
-  log_prob(const T_y& y, const T_alpha& alpha, const T_tau& tau,
-           const T_beta& beta, const T_delta& delta, const T5&) {
+  stan::return_type_t<T_y, T_alpha, T_tau, T_beta, T_delta> log_prob(
+      const T_y& y, const T_alpha& alpha, const T_tau& tau, const T_beta& beta,
+      const T_delta& delta, const T5&) {
     return stan::math::wiener_log(y, alpha, tau, beta, delta);
   }
 
   template <bool propto, typename T_y, typename T_alpha, typename T_tau,
             typename T_beta, typename T_delta, typename T5>
-  typename stan::return_type<T_y, T_alpha, T_tau, T_beta, T_delta>::type
-  log_prob(const T_y& y, const T_alpha& alpha, const T_tau& tau,
-           const T_beta& beta, const T_delta& delta, const T5&) {
+  stan::return_type_t<T_y, T_alpha, T_tau, T_beta, T_delta> log_prob(
+      const T_y& y, const T_alpha& alpha, const T_tau& tau, const T_beta& beta,
+      const T_delta& delta, const T5&) {
     return stan::math::wiener_log<propto>(y, alpha, tau, beta, delta);
   }
 
   template <typename T_y, typename T_alpha, typename T_tau, typename T_beta,
             typename T_delta, typename T5>
-  typename stan::return_type<T_y, T_alpha, T_tau, T_beta, T_delta, T5>::type
+  stan::return_type_t<T_y, T_alpha, T_tau, T_beta, T_delta, T5>
   log_prob_function(const T_y& y, const T_alpha& alpha, const T_tau& tau,
                     const T_beta& beta, const T_delta& delta, const T5&) {
     return stan::math::wiener_log<true>(y, alpha, tau, beta, delta);

--- a/test/unit/math/prim/fun/sort_indices_test.cpp
+++ b/test/unit/math/prim/fun/sort_indices_test.cpp
@@ -5,7 +5,7 @@
 template <typename T>
 void test_sort_indices_asc() {
   using stan::math::sort_indices_asc;
-  typedef typename stan::math::index_type<T>::type idx_t;
+  using idx_t = stan::math::index_type_t<T>;
 
   T c(1);
   c[0] = 1.7;
@@ -49,7 +49,7 @@ TEST(MathMatrixPrimMat, sort_indices_asc) {
 template <typename T>
 void test_sort_indices_desc() {
   using stan::math::sort_indices_desc;
-  typedef typename stan::math::index_type<T>::type idx_t;
+  using idx_t = stan::math::index_type_t<T>;
 
   T c(1);
   c[0] = 1.7;

--- a/test/unit/math/prim/fun/sort_test.cpp
+++ b/test/unit/math/prim/fun/sort_test.cpp
@@ -36,7 +36,7 @@ void test_sort_asc() {
 
   T z;
   EXPECT_NO_THROW(sort_asc(z));
-  EXPECT_EQ(typename index_type<T>::type(0), z.size());
+  EXPECT_EQ(index_type_t<T>(0), z.size());
 }
 
 TEST(MathMatrixPrimMat, sortAscStdVecNan) {
@@ -102,7 +102,7 @@ void test_sort_desc() {
 
   T z;
   EXPECT_NO_THROW(sort_desc(z));
-  EXPECT_EQ(typename index_type<T>::type(0), z.size());
+  EXPECT_EQ(index_type_t<T>(0), z.size());
 }
 
 TEST(MathMatrixPrimMat, sort_desc) {

--- a/test/unit/math/prim/fun/sort_test.cpp
+++ b/test/unit/math/prim/fun/sort_test.cpp
@@ -7,7 +7,7 @@
 
 template <typename T>
 void test_sort_asc() {
-  using stan::math::index_type;
+  using stan::math::index_type_t;
   using stan::math::sort_asc;
 
   T c(1);
@@ -73,7 +73,7 @@ TEST(MathMatrixPrimMat, sort_asc) {
 
 template <typename T>
 void test_sort_desc() {
-  using stan::math::index_type;
+  using stan::math::index_type_t;
   using stan::math::sort_desc;
 
   T c(1);

--- a/test/unit/math/prim/functor/faulty_functor.hpp
+++ b/test/unit/math/prim/functor/faulty_functor.hpp
@@ -6,12 +6,12 @@
 
 struct faulty_functor {
   template <typename T1, typename T2>
-  Eigen::Matrix<typename stan::return_type<T1, T2>::type, Eigen::Dynamic, 1>
-  operator()(const Eigen::Matrix<T1, Eigen::Dynamic, 1>& eta,
-             const Eigen::Matrix<T2, Eigen::Dynamic, 1>& theta,
-             const std::vector<double>& x_r, const std::vector<int>& x_i,
-             std::ostream* msgs = 0) const {
-    typedef typename stan::return_type<T1, T2>::type result_type;
+  Eigen::Matrix<stan::return_type_t<T1, T2>, Eigen::Dynamic, 1> operator()(
+      const Eigen::Matrix<T1, Eigen::Dynamic, 1>& eta,
+      const Eigen::Matrix<T2, Eigen::Dynamic, 1>& theta,
+      const std::vector<double>& x_r, const std::vector<int>& x_i,
+      std::ostream* msgs = 0) const {
+    using result_type = stan::return_type_t<T1, T2>;
     Eigen::Matrix<result_type, Eigen::Dynamic, 1> res;
     res.resize(2);
     res(0) = theta(0) * theta(0);

--- a/test/unit/math/prim/functor/forced_harmonic_oscillator.hpp
+++ b/test/unit/math/prim/functor/forced_harmonic_oscillator.hpp
@@ -7,7 +7,7 @@
 
 struct forced_harm_osc_ode_fun {
   template <typename T0, typename T1, typename T2>
-  inline std::vector<typename stan::return_type<T1, T2>::type>
+  inline std::vector<stan::return_type_t<T1, T2>>
   // initial time
   // initial positions
   // parameters
@@ -20,7 +20,7 @@ struct forced_harm_osc_ode_fun {
       throw std::domain_error(
           "this function was called with inconsistent state");
 
-    std::vector<typename stan::return_type<T1, T2>::type> res;
+    std::vector<stan::return_type_t<T1, T2>> res;
     res.push_back(y_in.at(1));
     res.push_back(-y_in.at(0) * sin(theta.at(1) * t_in)
                   - theta.at(0) * y_in.at(1));

--- a/test/unit/math/prim/functor/hard_work.hpp
+++ b/test/unit/math/prim/functor/hard_work.hpp
@@ -6,12 +6,12 @@
 struct hard_work {
   hard_work() {}
   template <typename T1, typename T2>
-  Eigen::Matrix<typename stan::return_type<T1, T2>::type, Eigen::Dynamic, 1>
-  operator()(const Eigen::Matrix<T1, Eigen::Dynamic, 1>& eta,
-             const Eigen::Matrix<T2, Eigen::Dynamic, 1>& theta,
-             const std::vector<double>& x_r, const std::vector<int>& x_i,
-             std::ostream* msgs = 0) const {
-    typedef typename stan::return_type<T1, T2>::type result_type;
+  Eigen::Matrix<stan::return_type_t<T1, T2>, Eigen::Dynamic, 1> operator()(
+      const Eigen::Matrix<T1, Eigen::Dynamic, 1>& eta,
+      const Eigen::Matrix<T2, Eigen::Dynamic, 1>& theta,
+      const std::vector<double>& x_r, const std::vector<int>& x_i,
+      std::ostream* msgs = 0) const {
+    using result_type = stan::return_type_t<T1, T2>;
     Eigen::Matrix<result_type, Eigen::Dynamic, 1> res;
     res.resize(2 + x_i[0]);
     res.setZero();

--- a/test/unit/math/prim/functor/harmonic_oscillator.hpp
+++ b/test/unit/math/prim/functor/harmonic_oscillator.hpp
@@ -7,7 +7,7 @@
 
 struct harm_osc_ode_fun {
   template <typename T0, typename T1, typename T2>
-  inline std::vector<typename stan::return_type<T1, T2>::type>
+  inline std::vector<stan::return_type_t<T1, T2>>
   // initial time
   // initial positions
   // parameters
@@ -20,7 +20,7 @@ struct harm_osc_ode_fun {
       throw std::domain_error(
           "this function was called with inconsistent state");
 
-    std::vector<typename stan::return_type<T1, T2>::type> res;
+    std::vector<stan::return_type_t<T1, T2>> res;
     res.push_back(y_in.at(1));
     res.push_back(-y_in.at(0) - theta.at(0) * y_in.at(1));
 
@@ -30,7 +30,7 @@ struct harm_osc_ode_fun {
 
 struct harm_osc_ode_data_fun {
   template <typename T0, typename T1, typename T2>
-  inline std::vector<typename stan::return_type<T1, T2>::type>
+  inline std::vector<stan::return_type_t<T1, T2>>
   // initial time
   // initial positions
   // parameters
@@ -43,7 +43,7 @@ struct harm_osc_ode_data_fun {
       throw std::domain_error(
           "this function was called with inconsistent state");
 
-    std::vector<typename stan::return_type<T1, T2>::type> res;
+    std::vector<stan::return_type_t<T1, T2>> res;
     res.push_back(x.at(0) * y_in.at(1) + x_int.at(0));
     res.push_back(-x.at(1) * y_in.at(0) - x.at(2) * theta.at(0) * y_in.at(1)
                   + x_int.at(1));
@@ -54,7 +54,7 @@ struct harm_osc_ode_data_fun {
 
 struct harm_osc_ode_wrong_size_1_fun {
   template <typename T0, typename T1, typename T2>
-  inline std::vector<typename stan::return_type<T1, T2>::type>
+  inline std::vector<stan::return_type_t<T1, T2>>
   // initial time
   // initial positions
   // parameters
@@ -67,7 +67,7 @@ struct harm_osc_ode_wrong_size_1_fun {
       throw std::domain_error(
           "this function was called with inconsistent state");
 
-    std::vector<typename stan::return_type<T1, T2>::type> res;
+    std::vector<stan::return_type_t<T1, T2>> res;
     res.push_back(y_in.at(1));
     res.push_back(-y_in.at(0) - theta.at(0) * y_in.at(1));
     res.push_back(0);
@@ -78,7 +78,7 @@ struct harm_osc_ode_wrong_size_1_fun {
 
 struct harm_osc_ode_wrong_size_2_fun {
   template <typename T0, typename T1, typename T2>
-  inline std::vector<typename stan::return_type<T1, T2>::type>
+  inline std::vector<stan::return_type_t<T1, T2>>
   // initial time
   // initial positions
   // parameters
@@ -91,7 +91,7 @@ struct harm_osc_ode_wrong_size_2_fun {
       throw std::domain_error(
           "this function was called with inconsistent state");
 
-    std::vector<typename stan::return_type<T1, T2>::type> res;
+    std::vector<stan::return_type_t<T1, T2>> res;
     res.push_back(0);
 
     return res;

--- a/test/unit/math/prim/functor/integrate_1d_test.cpp
+++ b/test/unit/math/prim/functor/integrate_1d_test.cpp
@@ -10,20 +10,22 @@ std::ostringstream *msgs = nullptr;
 
 struct f1 {
   template <typename T1, typename T2>
-  inline typename stan::return_type<T1, T2>::type operator()(
-      const T1 &x, const T1 &xc, const std::vector<T2> &theta,
-      const std::vector<double> &x_r, const std::vector<int> &x_i,
-      std::ostream *msgs) const {
+  inline stan::return_type_t<T1, T2> operator()(const T1 &x, const T1 &xc,
+                                                const std::vector<T2> &theta,
+                                                const std::vector<double> &x_r,
+                                                const std::vector<int> &x_i,
+                                                std::ostream *msgs) const {
     return exp(-x) / sqrt(x);
   }
 };
 
 struct f2 {
   template <typename T1, typename T2>
-  inline typename stan::return_type<T1, T2>::type operator()(
-      const T1 &x, const T1 &xc, const std::vector<T2> &theta,
-      const std::vector<double> &x_r, const std::vector<int> &x_i,
-      std::ostream *msgs) const {
+  inline stan::return_type_t<T1, T2> operator()(const T1 &x, const T1 &xc,
+                                                const std::vector<T2> &theta,
+                                                const std::vector<double> &x_r,
+                                                const std::vector<int> &x_i,
+                                                std::ostream *msgs) const {
     if (x <= 0.5) {
       return sqrt(x) / sqrt(1 - x * x);
     } else {
@@ -34,80 +36,88 @@ struct f2 {
 
 struct f3 {
   template <typename T1, typename T2>
-  inline typename stan::return_type<T1, T2>::type operator()(
-      const T1 &x, const T1 &xc, const std::vector<T2> &theta,
-      const std::vector<double> &x_r, const std::vector<int> &x_i,
-      std::ostream *msgs) const {
+  inline stan::return_type_t<T1, T2> operator()(const T1 &x, const T1 &xc,
+                                                const std::vector<T2> &theta,
+                                                const std::vector<double> &x_r,
+                                                const std::vector<int> &x_i,
+                                                std::ostream *msgs) const {
     return exp(-x);
   }
 };
 
 struct f4 {
   template <typename T1, typename T2>
-  inline typename stan::return_type<T1, T2>::type operator()(
-      const T1 &x, const T1 &xc, const std::vector<T2> &theta,
-      const std::vector<double> &x_r, const std::vector<int> &x_i,
-      std::ostream *msgs) const {
+  inline stan::return_type_t<T1, T2> operator()(const T1 &x, const T1 &xc,
+                                                const std::vector<T2> &theta,
+                                                const std::vector<double> &x_r,
+                                                const std::vector<int> &x_i,
+                                                std::ostream *msgs) const {
     return exp(x) + theta[0];
   }
 };
 
 struct f5 {
   template <typename T1, typename T2>
-  inline typename stan::return_type<T1, T2>::type operator()(
-      const T1 &x, const T1 &xc, const std::vector<T2> &theta,
-      const std::vector<double> &x_r, const std::vector<int> &x_i,
-      std::ostream *msgs) const {
+  inline stan::return_type_t<T1, T2> operator()(const T1 &x, const T1 &xc,
+                                                const std::vector<T2> &theta,
+                                                const std::vector<double> &x_r,
+                                                const std::vector<int> &x_i,
+                                                std::ostream *msgs) const {
     return exp(x) + pow(theta[0], 2) + pow(theta[1], 3);
   }
 };
 
 struct f6 {
   template <typename T1, typename T2>
-  inline typename stan::return_type<T1, T2>::type operator()(
-      const T1 &x, const T1 &xc, const std::vector<T2> &theta,
-      const std::vector<double> &x_r, const std::vector<int> &x_i,
-      std::ostream *msgs) const {
+  inline stan::return_type_t<T1, T2> operator()(const T1 &x, const T1 &xc,
+                                                const std::vector<T2> &theta,
+                                                const std::vector<double> &x_r,
+                                                const std::vector<int> &x_i,
+                                                std::ostream *msgs) const {
     return exp(x) + pow(x_i[0], 2) + pow(theta[0], 4) + 3 * theta[1];
   }
 };
 
 struct f7 {
   template <typename T1, typename T2>
-  inline typename stan::return_type<T1, T2>::type operator()(
-      const T1 &x, const T1 &xc, const std::vector<T2> &theta,
-      const std::vector<double> &x_r, const std::vector<int> &x_i,
-      std::ostream *msgs) const {
+  inline stan::return_type_t<T1, T2> operator()(const T1 &x, const T1 &xc,
+                                                const std::vector<T2> &theta,
+                                                const std::vector<double> &x_r,
+                                                const std::vector<int> &x_i,
+                                                std::ostream *msgs) const {
     return exp(x) + pow(x_r[0], 2) + pow(x_r[1], 5) + 3 * x_r[2];
   }
 };
 
 struct f8 {
   template <typename T1, typename T2>
-  inline typename stan::return_type<T1, T2>::type operator()(
-      const T1 &x, const T1 &xc, const std::vector<T2> &theta,
-      const std::vector<double> &x_r, const std::vector<int> &x_i,
-      std::ostream *msgs) const {
+  inline stan::return_type_t<T1, T2> operator()(const T1 &x, const T1 &xc,
+                                                const std::vector<T2> &theta,
+                                                const std::vector<double> &x_r,
+                                                const std::vector<int> &x_i,
+                                                std::ostream *msgs) const {
     return exp(-pow(x - theta[0], x_i[0]) / pow(x_r[0], x_i[0]));
   }
 };
 
 struct f9 {
   template <typename T1, typename T2>
-  inline typename stan::return_type<T1, T2>::type operator()(
-      const T1 &x, const T1 &xc, const std::vector<T2> &theta,
-      const std::vector<double> &x_r, const std::vector<int> &x_i,
-      std::ostream *msgs) const {
+  inline stan::return_type_t<T1, T2> operator()(const T1 &x, const T1 &xc,
+                                                const std::vector<T2> &theta,
+                                                const std::vector<double> &x_r,
+                                                const std::vector<int> &x_i,
+                                                std::ostream *msgs) const {
     return 1.0 / (1.0 + pow(x, x_i[0]) / theta[0]);
   }
 };
 
 struct f10 {
   template <typename T1, typename T2>
-  inline typename stan::return_type<T1, T2>::type operator()(
-      const T1 &x, const T1 &xc, const std::vector<T2> &theta,
-      const std::vector<double> &x_r, const std::vector<int> &x_i,
-      std::ostream *msgs) const {
+  inline stan::return_type_t<T1, T2> operator()(const T1 &x, const T1 &xc,
+                                                const std::vector<T2> &theta,
+                                                const std::vector<double> &x_r,
+                                                const std::vector<int> &x_i,
+                                                std::ostream *msgs) const {
     return pow(x, theta[0] - 1.0)
            * pow((x > 0.5) ? xc : (1 - x), theta[1] - 1.0);
   }
@@ -115,20 +125,22 @@ struct f10 {
 
 struct f11 {
   template <typename T1, typename T2>
-  inline typename stan::return_type<T1, T2>::type operator()(
-      const T1 &x, const T1 &xc, const std::vector<T2> &theta,
-      const std::vector<double> &x_r, const std::vector<int> &x_i,
-      std::ostream *msgs) const {
+  inline stan::return_type_t<T1, T2> operator()(const T1 &x, const T1 &xc,
+                                                const std::vector<T2> &theta,
+                                                const std::vector<double> &x_r,
+                                                const std::vector<int> &x_i,
+                                                std::ostream *msgs) const {
     return (std::isnan(xc)) ? xc : 0.0;
   }
 };
 
 struct f12 {
   template <typename T1, typename T2>
-  inline typename stan::return_type<T1, T2>::type operator()(
-      const T1 &x, const T1 &xc, const std::vector<T2> &theta,
-      const std::vector<double> &x_r, const std::vector<int> &x_i,
-      std::ostream *msgs) const {
+  inline stan::return_type_t<T1, T2> operator()(const T1 &x, const T1 &xc,
+                                                const std::vector<T2> &theta,
+                                                const std::vector<double> &x_r,
+                                                const std::vector<int> &x_i,
+                                                std::ostream *msgs) const {
     T1 out = stan::math::modified_bessel_second_kind(0, x);
     if (out > 0)
       return 2 * x * out;
@@ -138,10 +150,11 @@ struct f12 {
 
 struct f13 {
   template <typename T1, typename T2>
-  inline typename stan::return_type<T1, T2>::type operator()(
-      const T1 &x, const T1 &xc, const std::vector<T2> &theta,
-      const std::vector<double> &x_r, const std::vector<int> &x_i,
-      std::ostream *msgs) const {
+  inline stan::return_type_t<T1, T2> operator()(const T1 &x, const T1 &xc,
+                                                const std::vector<T2> &theta,
+                                                const std::vector<double> &x_r,
+                                                const std::vector<int> &x_i,
+                                                std::ostream *msgs) const {
     T1 out = stan::math::modified_bessel_second_kind(0, x);
     if (out > 0)
       return 2 * x * stan::math::square(out);
@@ -151,20 +164,22 @@ struct f13 {
 
 struct f14 {
   template <typename T1, typename T2>
-  inline typename stan::return_type<T1, T2>::type operator()(
-      const T1 &x, const T1 &xc, const std::vector<T2> &theta,
-      const std::vector<double> &x_r, const std::vector<int> &x_i,
-      std::ostream *msgs) const {
+  inline stan::return_type_t<T1, T2> operator()(const T1 &x, const T1 &xc,
+                                                const std::vector<T2> &theta,
+                                                const std::vector<double> &x_r,
+                                                const std::vector<int> &x_i,
+                                                std::ostream *msgs) const {
     return exp(x) * stan::math::inv_sqrt(x > 0.5 ? xc : 1 - x);
   }
 };
 
 struct f15 {
   template <typename T1, typename T2>
-  inline typename stan::return_type<T1, T2>::type operator()(
-      const T1 &x, const T1 &xc, const std::vector<T2> &theta,
-      const std::vector<double> &x_r, const std::vector<int> &x_i,
-      std::ostream *msgs) const {
+  inline stan::return_type_t<T1, T2> operator()(const T1 &x, const T1 &xc,
+                                                const std::vector<T2> &theta,
+                                                const std::vector<double> &x_r,
+                                                const std::vector<int> &x_i,
+                                                std::ostream *msgs) const {
     T1 x2 = x * x;
     T1 numer = x2 * log(x);
     T1 denom = x < 0.5 ? (x + 1) * (x - 1) : (x + 1) * -xc;
@@ -175,10 +190,11 @@ struct f15 {
 
 struct f16 {
   template <typename T1, typename T2>
-  inline typename stan::return_type<T1, T2>::type operator()(
-      const T1 &x, const T1 &xc, const std::vector<T2> &theta,
-      const std::vector<double> &x_r, const std::vector<int> &x_i,
-      std::ostream *msgs) const {
+  inline stan::return_type_t<T1, T2> operator()(const T1 &x, const T1 &xc,
+                                                const std::vector<T2> &theta,
+                                                const std::vector<double> &x_r,
+                                                const std::vector<int> &x_i,
+                                                std::ostream *msgs) const {
     return x * sin(x) / (1 + stan::math::square(cos(x)));
   }
 };

--- a/test/unit/math/prim/functor/lorenz.hpp
+++ b/test/unit/math/prim/functor/lorenz.hpp
@@ -4,7 +4,7 @@
 #include <vector>
 
 template <typename T0, typename T1, typename T2>
-inline std::vector<typename stan::return_type<T1, T2>::type>
+inline std::vector<stan::return_type_t<T1, T2>>
 // initial time
 // initial positions
 // parameters
@@ -13,7 +13,7 @@ inline std::vector<typename stan::return_type<T1, T2>::type>
 lorenz_ode(const T0& t_in, const std::vector<T1>& y_in,
            const std::vector<T2>& theta, const std::vector<double>& x,
            const std::vector<int>& x_int) {
-  std::vector<typename stan::return_type<T1, T2>::type> res;
+  std::vector<stan::return_type_t<T1, T2>> res;
   res.push_back(theta.at(0) * (y_in.at(1) - y_in.at(0)));
   res.push_back(theta.at(1) * y_in.at(0) - y_in.at(1)
                 - y_in.at(0) * y_in.at(2));
@@ -23,7 +23,7 @@ lorenz_ode(const T0& t_in, const std::vector<T1>& y_in,
 
 struct lorenz_ode_fun {
   template <typename T0, typename T1, typename T2>
-  inline std::vector<typename stan::return_type<T1, T2>::type>
+  inline std::vector<stan::return_type_t<T1, T2>>
   // initial time
   // initial positions
   // parameters

--- a/test/unit/math/prim/functor/mock_ode_functor.hpp
+++ b/test/unit/math/prim/functor/mock_ode_functor.hpp
@@ -2,11 +2,11 @@
 
 struct mock_ode_functor {
   template <typename T0, typename T1, typename T2>
-  inline std::vector<typename stan::return_type<T1, T2>::type> operator()(
+  inline std::vector<stan::return_type_t<T1, T2>> operator()(
       const T0& t_in, const std::vector<T1>& y_in, const std::vector<T2>& theta,
       const std::vector<double>& x, const std::vector<int>& x_int,
       std::ostream* msgs) const {
-    std::vector<typename stan::return_type<T1, T2>::type> states;
+    std::vector<stan::return_type_t<T1, T2>> states;
     states = y_in;
     return states;
   }

--- a/test/unit/math/prim/functor/mock_throwing_ode_functor.hpp
+++ b/test/unit/math/prim/functor/mock_throwing_ode_functor.hpp
@@ -17,7 +17,7 @@ struct mock_throwing_ode_functor {
   }
 
   template <typename T0, typename T1, typename T2>
-  inline std::vector<typename stan::return_type<T1, T2>::type> operator()(
+  inline std::vector<stan::return_type_t<T1, T2>> operator()(
       const T0& t_in, const std::vector<T1>& y_in, const std::vector<T2>& theta,
       const std::vector<double>& x, const std::vector<int>& x_int,
       std::ostream* msgs) const {

--- a/test/unit/math/rev/fun/util.hpp
+++ b/test/unit/math/rev/fun/util.hpp
@@ -101,7 +101,7 @@ void expect_near_relative(double u, double v) {
     EXPECT_NEAR(0, relative_diff(u, v), 1e-7);
 }
 
-typedef stan::math::index_type<Eigen::Matrix<double, -1, -1> >::type size_type;
+using size_type = stan::math::index_type_t<Eigen::Matrix<double, -1, -1>>;
 
 // Returns a matrix with the contents of a
 // vector; Fills the matrix column-wise

--- a/test/unit/math/rev/fun/util.hpp
+++ b/test/unit/math/rev/fun/util.hpp
@@ -165,12 +165,12 @@ Eigen::Matrix<double, 3, 3> norm_hess(
   return hess;
 }
 
-std::vector<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> >
+std::vector<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>>
 third_order_mixed_grad_hess(
     const Eigen::Matrix<double, Eigen::Dynamic, 1>& inp_vec) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
-  std::vector<Matrix<double, Dynamic, Dynamic> > grad_hess_ret;
+  std::vector<Matrix<double, Dynamic, Dynamic>> grad_hess_ret;
   for (int i = 0; i < inp_vec.size(); ++i)
     grad_hess_ret.push_back(Matrix<double, Dynamic, Dynamic>(3, 3));
 
@@ -194,12 +194,12 @@ third_order_mixed_grad_hess(
   return grad_hess_ret;
 }
 
-std::vector<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> >
+std::vector<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>>
 norm_grad_hess(const Eigen::Matrix<double, Eigen::Dynamic, 1>& inp_vec) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
 
-  std::vector<Matrix<double, Dynamic, Dynamic> > grad_hess;
+  std::vector<Matrix<double, Dynamic, Dynamic>> grad_hess;
 
   for (int i = 0; i < 3; ++i)
     grad_hess.push_back(Matrix<double, Dynamic, Dynamic>(3, 3));

--- a/test/unit/math/rev/functor/algebra_solver_fp_test.cpp
+++ b/test/unit/math/rev/functor/algebra_solver_fp_test.cpp
@@ -32,12 +32,12 @@ struct FP_exp_func_test : public ::testing::Test {
    */
   struct FP_exp_func {
     template <typename T0, typename T1>
-    inline Eigen::Matrix<typename stan::return_type<T0, T1>::type, -1, 1>
-    operator()(const Eigen::Matrix<T0, Eigen::Dynamic, 1>& x,
-               const Eigen::Matrix<T1, Eigen::Dynamic, 1>& y,
-               const std::vector<double>& x_r, const std::vector<int>& x_i,
-               std::ostream* pstream__) const {
-      using scalar = typename stan::return_type<T0, T1>::type;
+    inline Eigen::Matrix<stan::return_type_t<T0, T1>, -1, 1> operator()(
+        const Eigen::Matrix<T0, Eigen::Dynamic, 1>& x,
+        const Eigen::Matrix<T1, Eigen::Dynamic, 1>& y,
+        const std::vector<double>& x_r, const std::vector<int>& x_i,
+        std::ostream* pstream__) const {
+      using scalar = stan::return_type_t<T0, T1>;
       Eigen::Matrix<scalar, Eigen::Dynamic, 1> z(1);
       z(0) = stan::math::exp(-y(0) * x(0));
       return z;
@@ -91,12 +91,12 @@ struct FP_2d_func_test : public ::testing::Test {
    */
   struct FP_2d_func {
     template <typename T0, typename T1>
-    inline Eigen::Matrix<typename stan::return_type<T0, T1>::type, -1, 1>
-    operator()(const Eigen::Matrix<T0, Eigen::Dynamic, 1>& x,
-               const Eigen::Matrix<T1, Eigen::Dynamic, 1>& y,
-               const std::vector<double>& x_r, const std::vector<int>& x_i,
-               std::ostream* pstream__) const {
-      using scalar = typename stan::return_type<T0, T1>::type;
+    inline Eigen::Matrix<stan::return_type_t<T0, T1>, -1, 1> operator()(
+        const Eigen::Matrix<T0, Eigen::Dynamic, 1>& x,
+        const Eigen::Matrix<T1, Eigen::Dynamic, 1>& y,
+        const std::vector<double>& x_r, const std::vector<int>& x_i,
+        std::ostream* pstream__) const {
+      using scalar = stan::return_type_t<T0, T1>;
       Eigen::Matrix<scalar, Eigen::Dynamic, 1> z(2);
       z(0) = y(0) * sqrt(x(1));
       z(1) = y(1) * sqrt(y(2) - x(0) * x(0));
@@ -155,12 +155,12 @@ struct FP_degenerated_func_test : public ::testing::Test {
    */
   struct FP_degenerated_func {
     template <typename T0, typename T1>
-    inline Eigen::Matrix<typename stan::return_type<T0, T1>::type, -1, 1>
-    operator()(const Eigen::Matrix<T0, Eigen::Dynamic, 1>& x,
-               const Eigen::Matrix<T1, Eigen::Dynamic, 1>& y,
-               const std::vector<double>& x_r, const std::vector<int>& x_i,
-               std::ostream* pstream__) const {
-      using scalar = typename stan::return_type<T0, T1>::type;
+    inline Eigen::Matrix<stan::return_type_t<T0, T1>, -1, 1> operator()(
+        const Eigen::Matrix<T0, Eigen::Dynamic, 1>& x,
+        const Eigen::Matrix<T1, Eigen::Dynamic, 1>& y,
+        const std::vector<double>& x_r, const std::vector<int>& x_i,
+        std::ostream* pstream__) const {
+      using scalar = stan::return_type_t<T0, T1>;
       Eigen::Matrix<scalar, Eigen::Dynamic, 1> z(2);
       z(0) = y(0) + (x(0) - y(0)) * y(1) / x(1);
       z(1) = y(0) + (x(1) - y(0)) * y(1) / x(0);
@@ -218,12 +218,12 @@ struct FP_direct_prod_func_test : public ::testing::Test {
    */
   struct FP_direct_prod_func {
     template <typename T0, typename T1>
-    inline Eigen::Matrix<typename stan::return_type<T0, T1>::type, -1, 1>
-    operator()(const Eigen::Matrix<T0, Eigen::Dynamic, 1>& x,
-               const Eigen::Matrix<T1, Eigen::Dynamic, 1>& y,
-               const std::vector<double>& x_r, const std::vector<int>& x_i,
-               std::ostream* pstream__) const {
-      using scalar = typename stan::return_type<T0, T1>::type;
+    inline Eigen::Matrix<stan::return_type_t<T0, T1>, -1, 1> operator()(
+        const Eigen::Matrix<T0, Eigen::Dynamic, 1>& x,
+        const Eigen::Matrix<T1, Eigen::Dynamic, 1>& y,
+        const std::vector<double>& x_r, const std::vector<int>& x_i,
+        std::ostream* pstream__) const {
+      using scalar = stan::return_type_t<T0, T1>;
       const size_t n = x.size();
       Eigen::Matrix<scalar, -1, 1> z(n);
       const size_t m = 10;
@@ -249,12 +249,12 @@ struct FP_direct_prod_func_test : public ::testing::Test {
    */
   struct FP_direct_prod_newton_func {
     template <typename T0, typename T1>
-    inline Eigen::Matrix<typename stan::return_type<T0, T1>::type, -1, 1>
-    operator()(const Eigen::Matrix<T0, Eigen::Dynamic, 1>& x,
-               const Eigen::Matrix<T1, Eigen::Dynamic, 1>& y,
-               const std::vector<double>& x_r, const std::vector<int>& x_i,
-               std::ostream* pstream__) const {
-      using scalar = typename stan::return_type<T0, T1>::type;
+    inline Eigen::Matrix<stan::return_type_t<T0, T1>, -1, 1> operator()(
+        const Eigen::Matrix<T0, Eigen::Dynamic, 1>& x,
+        const Eigen::Matrix<T1, Eigen::Dynamic, 1>& y,
+        const std::vector<double>& x_r, const std::vector<int>& x_i,
+        std::ostream* pstream__) const {
+      using scalar = stan::return_type_t<T0, T1>;
       const size_t n = x.size();
       Eigen::Matrix<scalar, -1, 1> z(n);
       z = FP_direct_prod_func()(x, y, x_r, x_i, pstream__);

--- a/test/unit/math/rev/functor/coupled_mm.hpp
+++ b/test/unit/math/rev/functor/coupled_mm.hpp
@@ -6,7 +6,7 @@
 
 struct coupled_mm_ode_fun {
   template <typename T0, typename T1, typename T2>
-  inline std::vector<typename stan::return_type<T1, T2>::type>
+  inline std::vector<stan::return_type_t<T1, T2>>
   // initial time
   // initial positions
   // parameters
@@ -15,7 +15,7 @@ struct coupled_mm_ode_fun {
   operator()(const T0& t_in, const std::vector<T1>& y,
              const std::vector<T2>& parms, const std::vector<double>& sx,
              const std::vector<int>& sx_int, std::ostream* msgs) const {
-    std::vector<typename stan::return_type<T1, T2>::type> ydot(2);
+    std::vector<stan::return_type_t<T1, T2>> ydot(2);
 
     const T2 act = parms[0];
     const T2 KmA = parms[1];

--- a/test/unit/math/rev/functor/idas_integrator_test.cpp
+++ b/test/unit/math/rev/functor/idas_integrator_test.cpp
@@ -116,7 +116,7 @@ TEST_F(IDASIntegratorTest, idas_ivp_system_yy0) {
       f, eq_id, yy0, yp0, theta, x_r, x_i, msgs};
   idas_integrator solver(1e-4, 1e-8, 1e6);
 
-  std::vector<std::vector<double> > yy = solver.integrate(dae, t0, ts);
+  std::vector<std::vector<double>> yy = solver.integrate(dae, t0, ts);
   EXPECT_NEAR(0.985172, yy[0][0], 1e-6);
   EXPECT_NEAR(0.0147939, yy[0][2], 1e-6);
   EXPECT_NEAR(0.905521, yy[1][0], 1e-6);
@@ -134,7 +134,7 @@ TEST_F(IDASIntegratorTest, forward_sensitivity_theta_chemical) {
 
   idas_forward_system<chemical_kinetics, double, double, var> dae(
       f, eq_id, yy0, yp0, theta_var, x_r, x_i, msgs);
-  std::vector<std::vector<var> > yy = solver.integrate(dae, t0, ts);
+  std::vector<std::vector<var>> yy = solver.integrate(dae, t0, ts);
   EXPECT_NEAR(0.985172, value_of(yy[0][0]), 1e-6);
   EXPECT_NEAR(0.0147939, value_of(yy[0][2]), 1e-6);
   EXPECT_NEAR(0.905519, value_of(yy[1][0]), 1e-6);
@@ -148,8 +148,8 @@ TEST_F(IDASIntegratorTest, forward_sensitivity_theta_chemical) {
   idas_forward_system<chemical_kinetics, double, double, double> dae1(
       f, eq_id, yy0, yp0, theta1, x_r, x_i, msgs),
       dae2(f, eq_id, yy0, yp0, theta2, x_r, x_i, msgs);
-  std::vector<std::vector<double> > yy1 = solver.integrate(dae1, t0, ts);
-  std::vector<std::vector<double> > yy2 = solver.integrate(dae2, t0, ts);
+  std::vector<std::vector<double>> yy1 = solver.integrate(dae1, t0, ts);
+  std::vector<std::vector<double>> yy2 = solver.integrate(dae2, t0, ts);
 
   double yys_finite_diff;
   for (size_t i = 0; i < yy.size(); ++i) {
@@ -181,7 +181,7 @@ TEST_F(IDASIntegratorTest, forward_sensitivity_theta_prey) {
 
   idas_forward_system<prey_predator_harvest, double, double, var> dae(
       f2, eq_id, yy0, yp0, theta_var, x_r, x_i, msgs);
-  std::vector<std::vector<var> > yy = solver.integrate(dae, t0, ts);
+  std::vector<std::vector<var>> yy = solver.integrate(dae, t0, ts);
 
   // test derivatives against central difference results
   std::vector<double> g;
@@ -191,8 +191,8 @@ TEST_F(IDASIntegratorTest, forward_sensitivity_theta_prey) {
   idas_forward_system<prey_predator_harvest, double, double, double> dae1(
       f2, eq_id, yy0, yp0, theta1, x_r, x_i, msgs),
       dae2(f2, eq_id, yy0, yp0, theta2, x_r, x_i, msgs);
-  std::vector<std::vector<double> > yy1 = solver.integrate(dae1, t0, ts);
-  std::vector<std::vector<double> > yy2 = solver.integrate(dae2, t0, ts);
+  std::vector<std::vector<double>> yy1 = solver.integrate(dae1, t0, ts);
+  std::vector<std::vector<double>> yy2 = solver.integrate(dae2, t0, ts);
 
   double yys_finite_diff;
   for (size_t i = 0; i < yy.size(); ++i) {

--- a/test/unit/math/rev/functor/idas_integrator_test.cpp
+++ b/test/unit/math/rev/functor/idas_integrator_test.cpp
@@ -19,16 +19,15 @@
 
 struct chemical_kinetics {
   template <typename T0, typename TYY, typename TYP, typename TPAR>
-  inline std::vector<typename stan::return_type<TYY, TYP, TPAR>::type>
-  operator()(const T0& t_in, const std::vector<TYY>& yy,
-             const std::vector<TYP>& yp, const std::vector<TPAR>& theta,
-             const std::vector<double>& x_r, const std::vector<int>& x_i,
-             std::ostream* msgs) const {
+  inline std::vector<stan::return_type_t<TYY, TYP, TPAR>> operator()(
+      const T0& t_in, const std::vector<TYY>& yy, const std::vector<TYP>& yp,
+      const std::vector<TPAR>& theta, const std::vector<double>& x_r,
+      const std::vector<int>& x_i, std::ostream* msgs) const {
     if (yy.size() != 3 || yp.size() != 3)
       throw std::domain_error(
           "this function was called with inconsistent state");
 
-    std::vector<typename stan::return_type<TYY, TYP, TPAR>::type> res(3);
+    std::vector<stan::return_type_t<TYY, TYP, TPAR>> res(3);
 
     auto yy1 = yy.at(0);
     auto yy2 = yy.at(1);
@@ -51,16 +50,15 @@ struct chemical_kinetics {
 
 struct prey_predator_harvest {
   template <typename T0, typename TYY, typename TYP, typename TPAR>
-  inline std::vector<typename stan::return_type<TYY, TYP, TPAR>::type>
-  operator()(const T0& t_in, const std::vector<TYY>& yy,
-             const std::vector<TYP>& yp, const std::vector<TPAR>& theta,
-             const std::vector<double>& x_r, const std::vector<int>& x_i,
-             std::ostream* msgs) const {
+  inline std::vector<stan::return_type_t<TYY, TYP, TPAR>> operator()(
+      const T0& t_in, const std::vector<TYY>& yy, const std::vector<TYP>& yp,
+      const std::vector<TPAR>& theta, const std::vector<double>& x_r,
+      const std::vector<int>& x_i, std::ostream* msgs) const {
     if (yy.size() != 3 || yp.size() != 3)
       throw std::domain_error(
           "this function was called with inconsistent state");
 
-    std::vector<typename stan::return_type<TYY, TYP, TPAR>::type> res(3);
+    std::vector<stan::return_type_t<TYY, TYP, TPAR>> res(3);
 
     auto yy1 = yy.at(0);
     auto yy2 = yy.at(1);

--- a/test/unit/math/rev/functor/idas_system_test.cpp
+++ b/test/unit/math/rev/functor/idas_system_test.cpp
@@ -19,16 +19,15 @@
 
 struct chemical_kinetics {
   template <typename T0, typename TYY, typename TYP, typename TPAR>
-  inline std::vector<typename stan::return_type<TYY, TYP, TPAR>::type>
-  operator()(const T0& t_in, const std::vector<TYY>& yy,
-             const std::vector<TYP>& yp, const std::vector<TPAR>& theta,
-             const std::vector<double>& x_r, const std::vector<int>& x_i,
-             std::ostream* msgs) const {
+  inline std::vector<stan::return_type_t<TYY, TYP, TPAR>> operator()(
+      const T0& t_in, const std::vector<TYY>& yy, const std::vector<TYP>& yp,
+      const std::vector<TPAR>& theta, const std::vector<double>& x_r,
+      const std::vector<int>& x_i, std::ostream* msgs) const {
     if (yy.size() != 3 || yp.size() != 3)
       throw std::domain_error(
           "this function was called with inconsistent state");
 
-    std::vector<typename stan::return_type<TYY, TYP, TPAR>::type> res(3);
+    std::vector<stan::return_type_t<TYY, TYP, TPAR>> res(3);
 
     auto yy1 = yy.at(0);
     auto yy2 = yy.at(1);

--- a/test/unit/math/rev/functor/integrate_1d_test.cpp
+++ b/test/unit/math/rev/functor/integrate_1d_test.cpp
@@ -11,7 +11,7 @@ std::ostringstream *msgs = nullptr;
 
 struct f1 {
   template <typename T1, typename T2, typename T3>
-  inline typename stan::return_type<T1, T2, T3>::type operator()(
+  inline stan::return_type_t<T1, T2, T3> operator()(
       const T1 &x, const T2 &xc, const std::vector<T3> &theta,
       const std::vector<double> &x_r, const std::vector<int> &x_i,
       std::ostream *msgs) const {
@@ -21,7 +21,7 @@ struct f1 {
 
 struct f2 {
   template <typename T1, typename T2, typename T3>
-  inline typename stan::return_type<T1, T2, T3>::type operator()(
+  inline stan::return_type_t<T1, T2, T3> operator()(
       const T1 &x, const T2 &xc, const std::vector<T3> &theta,
       const std::vector<double> &x_r, const std::vector<int> &x_i,
       std::ostream *msgs) const {
@@ -31,7 +31,7 @@ struct f2 {
 
 struct f3 {
   template <typename T1, typename T2, typename T3>
-  inline typename stan::return_type<T1, T2, T3>::type operator()(
+  inline stan::return_type_t<T1, T2, T3> operator()(
       const T1 &x, const T2 &xc, const std::vector<T3> &theta,
       const std::vector<double> &x_r, const std::vector<int> &x_i,
       std::ostream *msgs) const {
@@ -42,7 +42,7 @@ struct f3 {
 
 struct f4 {
   template <typename T1, typename T2, typename T3>
-  inline typename stan::return_type<T1, T2, T3>::type operator()(
+  inline stan::return_type_t<T1, T2, T3> operator()(
       const T1 &x, const T2 &xc, const std::vector<T3> &theta,
       const std::vector<double> &x_r, const std::vector<int> &x_i,
       std::ostream *msgs) const {
@@ -52,7 +52,7 @@ struct f4 {
 
 struct f5 {
   template <typename T1, typename T2, typename T3>
-  inline typename stan::return_type<T1, T2, T3>::type operator()(
+  inline stan::return_type_t<T1, T2, T3> operator()(
       const T1 &x, const T2 &xc, const std::vector<T3> &theta,
       const std::vector<double> &x_r, const std::vector<int> &x_i,
       std::ostream *msgs) const {
@@ -62,7 +62,7 @@ struct f5 {
 
 struct f6 {
   template <typename T1, typename T2, typename T3>
-  inline typename stan::return_type<T1, T2, T3>::type operator()(
+  inline stan::return_type_t<T1, T2, T3> operator()(
       const T1 &x, const T2 &xc, const std::vector<T3> &theta,
       const std::vector<double> &x_r, const std::vector<int> &x_i,
       std::ostream *msgs) const {
@@ -72,7 +72,7 @@ struct f6 {
 
 struct f7 {
   template <typename T1, typename T2, typename T3>
-  inline typename stan::return_type<T1, T2, T3>::type operator()(
+  inline stan::return_type_t<T1, T2, T3> operator()(
       const T1 &x, const T2 &xc, const std::vector<T3> &theta,
       const std::vector<double> &x_r, const std::vector<int> &x_i,
       std::ostream *msgs) const {
@@ -82,7 +82,7 @@ struct f7 {
 
 struct f8 {
   template <typename T1, typename T2, typename T3>
-  inline typename stan::return_type<T1, T2, T3>::type operator()(
+  inline stan::return_type_t<T1, T2, T3> operator()(
       const T1 &x, const T2 &xc, const std::vector<T3> &theta,
       const std::vector<double> &x_r, const std::vector<int> &x_i,
       std::ostream *msgs) const {
@@ -92,7 +92,7 @@ struct f8 {
 
 struct f10 {
   template <typename T1, typename T2, typename T3>
-  inline typename stan::return_type<T1, T2, T3>::type operator()(
+  inline stan::return_type_t<T1, T2, T3> operator()(
       const T1 &x, const T2 &xc, const std::vector<T3> &theta,
       const std::vector<double> &x_r, const std::vector<int> &x_i,
       std::ostream *msgs) const {
@@ -102,7 +102,7 @@ struct f10 {
 
 struct f11 {
   template <typename T1, typename T2, typename T3>
-  inline typename stan::return_type<T1, T2, T3>::type operator()(
+  inline stan::return_type_t<T1, T2, T3> operator()(
       const T1 &x, const T2 &xc, const std::vector<T3> &theta,
       const std::vector<double> &x_r, const std::vector<int> &x_i,
       std::ostream *msgs) const {
@@ -113,7 +113,7 @@ struct f11 {
 
 struct f12 {
   template <typename T1, typename T2, typename T3>
-  inline typename stan::return_type<T1, T2, T3>::type operator()(
+  inline stan::return_type_t<T1, T2, T3> operator()(
       const T1 &x, const T2 &xc, const std::vector<T3> &theta,
       const std::vector<double> &x_r, const std::vector<int> &x_i,
       std::ostream *msgs) const {
@@ -126,7 +126,7 @@ struct f12 {
 
 struct f13 {
   template <typename T1, typename T2, typename T3>
-  inline typename stan::return_type<T1, T2, T3>::type operator()(
+  inline stan::return_type_t<T1, T2, T3> operator()(
       const T1 &x, const T2 &xc, const std::vector<T3> &theta,
       const std::vector<double> &x_r, const std::vector<int> &x_i,
       std::ostream *msgs) const {
@@ -169,7 +169,7 @@ double get_adjoint_if_var(double v) {
  * The prototype for f is:
  *   struct f10 {
  *     template <typename T1, typename T2, typename T3>
- *     inline typename stan::return_type<T1, T2, T3>::type operator()(
+ *     inline stan::return_type_t<T1, T2, T3> operator()(
  *         const T1& x, const T2& xc, const std::vector<T3>& theta, const
  * std::vector<double>& x_r, const std::vector<int>& x_i, std::ostream& msgs)
  * const {

--- a/test/unit/math/rev/functor/integrate_dae_test.cpp
+++ b/test/unit/math/rev/functor/integrate_dae_test.cpp
@@ -17,16 +17,15 @@
 
 struct chemical_kinetics {
   template <typename T0, typename TYY, typename TYP, typename TPAR>
-  inline std::vector<typename stan::return_type<TYY, TYP, TPAR>::type>
-  operator()(const T0& t_in, const std::vector<TYY>& yy,
-             const std::vector<TYP>& yp, const std::vector<TPAR>& theta,
-             const std::vector<double>& x_r, const std::vector<int>& x_i,
-             std::ostream* msgs) const {
+  inline std::vector<stan::return_type_t<TYY, TYP, TPAR>> operator()(
+      const T0& t_in, const std::vector<TYY>& yy, const std::vector<TYP>& yp,
+      const std::vector<TPAR>& theta, const std::vector<double>& x_r,
+      const std::vector<int>& x_i, std::ostream* msgs) const {
     if (yy.size() != 3 || yp.size() != 3)
       throw std::domain_error(
           "this function was called with inconsistent state");
 
-    std::vector<typename stan::return_type<TYY, TYP, TPAR>::type> res(3);
+    std::vector<stan::return_type_t<TYY, TYP, TPAR>> res(3);
 
     auto yy1 = yy.at(0);
     auto yy2 = yy.at(1);

--- a/test/unit/math/rev/functor/integrate_dae_test.cpp
+++ b/test/unit/math/rev/functor/integrate_dae_test.cpp
@@ -77,7 +77,7 @@ struct StanIntegrateDAETest : public ::testing::Test {
 TEST_F(StanIntegrateDAETest, idas_ivp_system_yy0) {
   using stan::math::idas_forward_system;
   using stan::math::integrate_dae;
-  std::vector<std::vector<double> > yy
+  std::vector<std::vector<double>> yy
       = integrate_dae(f, yy0, yp0, t0, ts, theta, x_r, x_i, 1e-4, 1e-8);
   EXPECT_NEAR(0.985172, yy[0][0], 1e-6);
   EXPECT_NEAR(0.0147939, yy[0][2], 1e-6);
@@ -95,7 +95,7 @@ TEST_F(StanIntegrateDAETest, forward_sensitivity_theta) {
 
   std::vector<var> theta_var = to_var(theta);
 
-  std::vector<std::vector<var> > yy
+  std::vector<std::vector<var>> yy
       = integrate_dae(f, yy0, yp0, t0, ts, theta_var, x_r, x_i, 1e-5, 1e-12);
   EXPECT_NEAR(0.985172, value_of(yy[0][0]), 1e-6);
   EXPECT_NEAR(0.0147939, value_of(yy[0][2]), 1e-6);
@@ -111,8 +111,8 @@ TEST_F(StanIntegrateDAETest, forward_sensitivity_theta) {
   idas_forward_system<chemical_kinetics, double, double, double> dae1(
       f, eq_id, yy0, yp0, theta1, x_r, x_i, msgs),
       dae2(f, eq_id, yy0, yp0, theta2, x_r, x_i, msgs);
-  std::vector<std::vector<double> > yy1 = solver.integrate(dae1, t0, ts);
-  std::vector<std::vector<double> > yy2 = solver.integrate(dae2, t0, ts);
+  std::vector<std::vector<double>> yy1 = solver.integrate(dae1, t0, ts);
+  std::vector<std::vector<double>> yy2 = solver.integrate(dae2, t0, ts);
 
   double yys_finite_diff = (yy2[3][1] - yy1[3][1]) / (2.0 * theta[0] * h);
   stan::math::set_zero_all_adjoints();

--- a/test/unit/math/rev/functor/integrate_ode_cvodes_grad_rev_test.cpp
+++ b/test/unit/math/rev/functor/integrate_ode_cvodes_grad_rev_test.cpp
@@ -35,7 +35,7 @@ double dy2_dchi(double t, double omega, double chi) {
 class sho_functor {
  public:
   template <typename T0, typename T1, typename T2>
-  inline std::vector<typename stan::return_type<T1, T2>::type> operator()(
+  inline std::vector<stan::return_type_t<T1, T2>> operator()(
       const T0& t_in,                 // time
       const std::vector<T1>& y_in,    // state
       const std::vector<T2>& theta,   // parameters
@@ -45,7 +45,7 @@ class sho_functor {
     if (y_in.size() != 2)
       throw std::domain_error("Functor called with inconsistent state");
 
-    std::vector<typename stan::return_type<T1, T2>::type> f;
+    std::vector<stan::return_type_t<T1, T2>> f;
     f.push_back(y_in.at(1));
     f.push_back(-theta.at(0) * theta.at(0) * y_in.at(0));
 

--- a/test/unit/math/rev/functor/integrate_ode_cvodes_grad_rev_test.cpp
+++ b/test/unit/math/rev/functor/integrate_ode_cvodes_grad_rev_test.cpp
@@ -77,7 +77,7 @@ class test_functor_double_var_1 {
     std::vector<double> data;
     std::vector<int> data_int;
 
-    std::vector<std::vector<T> > ys
+    std::vector<std::vector<T>> ys
         = (lmm_ == TEST_CVODES_ADAMS
                ? stan::math::integrate_ode_adams(sho, y0, t0, ts, theta, data,
                                                  data_int)
@@ -112,7 +112,7 @@ class test_functor_double_var_2 {
     std::vector<double> data;
     std::vector<int> data_int;
 
-    std::vector<std::vector<T> > ys
+    std::vector<std::vector<T>> ys
         = (lmm_ == TEST_CVODES_ADAMS
                ? stan::math::integrate_ode_adams(sho, y0, t0, ts, theta, data,
                                                  data_int)
@@ -187,7 +187,7 @@ class test_functor_var_double_1 {
     std::vector<double> data;
     std::vector<int> data_int;
 
-    std::vector<std::vector<T> > ys
+    std::vector<std::vector<T>> ys
         = (lmm_ == TEST_CVODES_ADAMS
                ? stan::math::integrate_ode_adams(sho, y0, t0, ts, theta, data,
                                                  data_int)
@@ -222,7 +222,7 @@ class test_functor_var_double_2 {
     std::vector<double> data;
     std::vector<int> data_int;
 
-    std::vector<std::vector<T> > ys
+    std::vector<std::vector<T>> ys
         = (lmm_ == TEST_CVODES_ADAMS
                ? stan::math::integrate_ode_adams(sho, y0, t0, ts, theta, data,
                                                  data_int)
@@ -297,7 +297,7 @@ class test_functor_var_var_1 {
     std::vector<double> data;
     std::vector<int> data_int;
 
-    std::vector<std::vector<T> > ys
+    std::vector<std::vector<T>> ys
         = (lmm_ == TEST_CVODES_ADAMS
                ? stan::math::integrate_ode_adams(sho, y0, t0, ts, theta, data,
                                                  data_int)
@@ -332,7 +332,7 @@ class test_functor_var_var_2 {
     std::vector<double> data;
     std::vector<int> data_int;
 
-    std::vector<std::vector<T> > ys
+    std::vector<std::vector<T>> ys
         = (lmm_ == TEST_CVODES_ADAMS
                ? stan::math::integrate_ode_adams(sho, y0, t0, ts, theta, data,
                                                  data_int)

--- a/test/unit/math/rev/functor/integrate_ode_rk45_grad_test.cpp
+++ b/test/unit/math/rev/functor/integrate_ode_rk45_grad_test.cpp
@@ -32,7 +32,7 @@ double dy2_dchi(double t, double omega, double chi) {
 class sho_functor {
  public:
   template <typename T0, typename T1, typename T2>
-  inline std::vector<typename stan::return_type<T1, T2>::type>
+  inline std::vector<stan::return_type_t<T1, T2>>
   // time
   // state
   // parameters
@@ -44,7 +44,7 @@ class sho_functor {
     if (y_in.size() != 2)
       throw std::domain_error("Functor called with inconsistent state");
 
-    std::vector<typename stan::return_type<T1, T2>::type> f;
+    std::vector<stan::return_type_t<T1, T2>> f;
     f.push_back(y_in.at(1));
     f.push_back(-theta.at(0) * theta.at(0) * y_in.at(0));
 

--- a/test/unit/math/rev/functor/integrate_ode_rk45_grad_test.cpp
+++ b/test/unit/math/rev/functor/integrate_ode_rk45_grad_test.cpp
@@ -72,7 +72,7 @@ class test_functor_double_var_1 {
     std::vector<double> data;
     std::vector<int> data_int;
 
-    std::vector<std::vector<T> > ys = stan::math::integrate_ode_rk45(
+    std::vector<std::vector<T>> ys = stan::math::integrate_ode_rk45(
         sho, y0, t0, ts, theta, data, data_int, 0);
 
     return ys[0][0];
@@ -99,7 +99,7 @@ class test_functor_double_var_2 {
     std::vector<double> data;
     std::vector<int> data_int;
 
-    std::vector<std::vector<T> > ys = stan::math::integrate_ode_rk45(
+    std::vector<std::vector<T>> ys = stan::math::integrate_ode_rk45(
         sho, y0, t0, ts, theta, data, data_int, 0);
 
     return ys[0][1];
@@ -150,7 +150,7 @@ class test_functor_var_double_1 {
     std::vector<double> data;
     std::vector<int> data_int;
 
-    std::vector<std::vector<T> > ys = stan::math::integrate_ode_rk45(
+    std::vector<std::vector<T>> ys = stan::math::integrate_ode_rk45(
         sho, y0, t0, ts, theta, data, data_int, 0);
 
     return ys[0][0];
@@ -177,7 +177,7 @@ class test_functor_var_double_2 {
     std::vector<double> data;
     std::vector<int> data_int;
 
-    std::vector<std::vector<T> > ys = stan::math::integrate_ode_rk45(
+    std::vector<std::vector<T>> ys = stan::math::integrate_ode_rk45(
         sho, y0, t0, ts, theta, data, data_int, 0);
 
     return ys[0][1];
@@ -228,7 +228,7 @@ class test_functor_var_var_1 {
     std::vector<double> data;
     std::vector<int> data_int;
 
-    std::vector<std::vector<T> > ys = stan::math::integrate_ode_rk45(
+    std::vector<std::vector<T>> ys = stan::math::integrate_ode_rk45(
         sho, y0, t0, ts, theta, data, data_int, 0);
 
     return ys[0][0];
@@ -255,7 +255,7 @@ class test_functor_var_var_2 {
     std::vector<double> data;
     std::vector<int> data_int;
 
-    std::vector<std::vector<T> > ys = stan::math::integrate_ode_rk45(
+    std::vector<std::vector<T>> ys = stan::math::integrate_ode_rk45(
         sho, y0, t0, ts, theta, data, data_int, 0);
 
     return ys[0][1];

--- a/test/unit/math/rev/prob/categorical_logit_glm_lpmf_test.cpp
+++ b/test/unit/math/rev/prob/categorical_logit_glm_lpmf_test.cpp
@@ -14,12 +14,11 @@ using stan::math::var;
 using std::vector;
 
 template <bool propto, typename T_x, typename T_alpha, typename T_beta>
-typename stan::return_type<T_x, T_alpha, T_beta>::type
-categorical_logit_glm_simple_lpmf(
+stan::return_type_t<T_x, T_alpha, T_beta> categorical_logit_glm_simple_lpmf(
     const vector<int>& y, const Matrix<T_x, Dynamic, Dynamic>& x,
     const T_alpha& alpha, const Matrix<T_beta, Dynamic, Dynamic>& beta) {
-  typedef typename stan::return_type<T_x, T_beta>::type T_x_beta;
-  typedef typename stan::return_type<T_x, T_beta, T_alpha>::type T_return;
+  using T_x_beta = stan::return_type_t<T_x, T_beta>;
+  using T_return = stan::return_type_t<T_x, T_beta, T_alpha>;
 
   const size_t N_instances = x.rows();
 

--- a/test/unit/math/rev/prob/lkj_corr_cholesky_test_functors.hpp
+++ b/test/unit/math/rev/prob/lkj_corr_cholesky_test_functors.hpp
@@ -6,14 +6,13 @@ namespace stan {
 namespace math {
 
 template <typename T_L, typename T_eta>
-typename return_type<T_eta, T_L>::type lkj_corr_cholesky_uc(
+return_type_t<T_eta, T_L> lkj_corr_cholesky_uc(
     Eigen::Matrix<T_L, Eigen::Dynamic, 1> L, T_eta eta, int K) {
   using math::cholesky_corr_constrain;
   using math::lkj_corr_cholesky_log;
   using math::positive_constrain;
 
-  typedef typename return_type<T_eta, T_L>::type rettype;
-  rettype lp(0.0);
+  return_type_t<T_eta, T_L> lp(0.0);
   Eigen::Matrix<T_L, Eigen::Dynamic, Eigen::Dynamic> L_c
       = cholesky_corr_constrain(L, K, lp);
   T_eta eta_c = positive_constrain(eta, lp);

--- a/test/unit/math/rev/prob/ordered_logistic_glm_lpmf_test.cpp
+++ b/test/unit/math/rev/prob/ordered_logistic_glm_lpmf_test.cpp
@@ -15,11 +15,10 @@ using stan::math::var;
 using std::vector;
 
 template <bool propto, typename T_x, typename T_beta, typename T_cuts>
-typename stan::return_type<T_x, T_beta, T_cuts>::type
-ordered_logistic_glm_simple_lpmf(const vector<int>& y,
-                                 const Matrix<T_x, Dynamic, Dynamic>& x,
-                                 const T_beta& beta, const T_cuts& cuts) {
-  typedef typename stan::return_type<T_x, T_beta>::type T_x_beta;
+stan::return_type_t<T_x, T_beta, T_cuts> ordered_logistic_glm_simple_lpmf(
+    const vector<int>& y, const Matrix<T_x, Dynamic, Dynamic>& x,
+    const T_beta& beta, const T_cuts& cuts) {
+  using T_x_beta = stan::return_type_t<T_x, T_beta>;
   using stan::math::as_column_vector_or_scalar;
 
   auto& beta_col = as_column_vector_or_scalar(beta);


### PR DESCRIPTION
## Summary

Fixes #1647.

## Tests
No new tests, but I'll update those constructs in the test files too.

## Side Effects

None.

## Checklist

- [X] Math issue #1647

- [X] Copyright holder: Marco Colombo

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [X] the new changes are tested
