### PR TITLE
Remind to run make test-math-dependencies from PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -34,6 +34,7 @@ Are there any side effects that we should be aware of?
 
     - unit tests pass (to run, use: `./runTests.py test/unit`)
     - header checks pass, (`make test-headers`)
+    - dependencies checks pass, (`make test-math-dependencies`)
     - docs build, (`make doxygen`)
     - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)
 


### PR DESCRIPTION
## Summary

Adds an entry to the PR template (no additional checkboxes). Fixes #1651.

## Tests

Nothing.

## Side Effects

None.

## Checklist

- [X] Math issue #1651

- [X] Copyright holder: Marco Colombo

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [X] the new changes are tested
