### PR TITLE
Cleanup in poisson_cdf, poisson_lccdf and poisson_lcdf

### DIFF
--- a/stan/math/prim/prob/poisson_cdf.hpp
+++ b/stan/math/prim/prob/poisson_cdf.hpp
@@ -59,7 +59,7 @@ return_type_t<T_rate> poisson_cdf(const T_n& n, const T_rate& lambda) {
       tgamma_n_plus_one[i] = tgamma(n_vec[i] + 1.0);
     }
     for (size_t i = 0; i < size_lambda; i++) {
-      exp_minus_lambda[i] = exp(-lambda[i]);
+      exp_minus_lambda[i] = exp(-value_of(lambda_vec[i]));
     }
   }
 
@@ -77,9 +77,9 @@ return_type_t<T_rate> poisson_cdf(const T_n& n, const T_rate& lambda) {
     P *= Pi;
 
     if (!is_constant_all<T_rate>::value) {
-      ops_partials.edge1_.partials_[i] -= exp_minus_lambda
+      ops_partials.edge1_.partials_[i] -= exp_minus_lambda[i]
                                           * pow(lambda_dbl, n_dbl)
-                                          / (tgamma_n_plus_one * Pi);
+                                          / (tgamma_n_plus_one[i] * Pi);
     }
   }
 

--- a/stan/math/prim/prob/poisson_cdf.hpp
+++ b/stan/math/prim/prob/poisson_cdf.hpp
@@ -3,8 +3,8 @@
 
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/err.hpp>
-#include <stan/math/prim/fun/size_zero.hpp>
 #include <stan/math/prim/fun/gamma_q.hpp>
+#include <stan/math/prim/fun/size_zero.hpp>
 #include <stan/math/prim/fun/tgamma.hpp>
 #include <stan/math/prim/fun/value_of.hpp>
 #include <cmath>
@@ -30,20 +30,36 @@ return_type_t<T_rate> poisson_cdf(const T_n& n, const T_rate& lambda) {
   check_consistent_sizes(function, "Random variable", n, "Rate parameter",
                          lambda);
 
-  scalar_seq_view<T_n> n_vec(n);
-  scalar_seq_view<T_rate> lambda_vec(lambda);
-  size_t max_size_seq_view = max_size(n, lambda);
-
   using std::exp;
   using std::pow;
 
   operands_and_partials<T_rate> ops_partials(lambda);
 
+  scalar_seq_view<T_n> n_vec(n);
+  scalar_seq_view<T_rate> lambda_vec(lambda);
+  size_t size_n = size(n);
+  size_t size_lambda = size(lambda);
+  size_t max_size_seq_view = max_size(n, lambda);
+
   // Explicit return for extreme values
   // The gradients are technically ill-defined, but treated as zero
-  for (size_t i = 0; i < size(n); i++) {
+  for (size_t i = 0; i < size_n; i++) {
     if (value_of(n_vec[i]) < 0) {
       return ops_partials.build(0.0);
+    }
+  }
+
+  VectorBuilder<!is_constant_all<T_rate>::value, T_partials_return, T_n>
+      tgamma_n_plus_one(size_n);
+  VectorBuilder<!is_constant_all<T_rate>::value, T_partials_return, T_rate>
+      exp_minus_lambda(size_lambda);
+
+  if (!is_constant_all<T_rate>::value) {
+    for (size_t i = 0; i < size_n; i++) {
+      tgamma_n_plus_one[i] = tgamma(n_vec[i] + 1.0);
+    }
+    for (size_t i = 0; i < size_lambda; i++) {
+      exp_minus_lambda[i] = exp(-lambda[i]);
     }
   }
 
@@ -61,16 +77,18 @@ return_type_t<T_rate> poisson_cdf(const T_n& n, const T_rate& lambda) {
     P *= Pi;
 
     if (!is_constant_all<T_rate>::value) {
-      ops_partials.edge1_.partials_[i]
-          -= exp(-lambda_dbl) * pow(lambda_dbl, n_dbl) / tgamma(n_dbl + 1) / Pi;
+      ops_partials.edge1_.partials_[i] -= exp_minus_lambda
+                                          * pow(lambda_dbl, n_dbl)
+                                          / (tgamma_n_plus_one * Pi);
     }
   }
 
   if (!is_constant_all<T_rate>::value) {
-    for (size_t i = 0; i < size(lambda); ++i) {
+    for (size_t i = 0; i < size_lambda; ++i) {
       ops_partials.edge1_.partials_[i] *= P;
     }
   }
+
   return ops_partials.build(P);
 }
 

--- a/stan/math/prim/prob/poisson_lccdf.hpp
+++ b/stan/math/prim/prob/poisson_lccdf.hpp
@@ -59,7 +59,7 @@ return_type_t<T_rate> poisson_lccdf(const T_n& n, const T_rate& lambda) {
       lgamma_n_plus_one[i] = lgamma(n_vec[i] + 1.0);
     }
     for (size_t i = 0; i < size_lambda; i++) {
-      log_lambda[i] = log(lambda_vec[i]);
+      log_lambda[i] = log(value_of(lambda_vec[i]));
     }
   }
 

--- a/stan/math/prim/prob/poisson_lccdf.hpp
+++ b/stan/math/prim/prob/poisson_lccdf.hpp
@@ -3,10 +3,10 @@
 
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/err.hpp>
-#include <stan/math/prim/fun/size_zero.hpp>
 #include <stan/math/prim/fun/constants.hpp>
 #include <stan/math/prim/fun/gamma_p.hpp>
 #include <stan/math/prim/fun/lgamma.hpp>
+#include <stan/math/prim/fun/size_zero.hpp>
 #include <stan/math/prim/fun/value_of.hpp>
 #include <cmath>
 #include <limits>
@@ -30,20 +30,36 @@ return_type_t<T_rate> poisson_lccdf(const T_n& n, const T_rate& lambda) {
   check_consistent_sizes(function, "Random variable", n, "Rate parameter",
                          lambda);
 
-  scalar_seq_view<T_n> n_vec(n);
-  scalar_seq_view<T_rate> lambda_vec(lambda);
-  size_t max_size_seq_view = max_size(n, lambda);
-
   using std::exp;
   using std::log;
 
   operands_and_partials<T_rate> ops_partials(lambda);
 
+  scalar_seq_view<T_n> n_vec(n);
+  scalar_seq_view<T_rate> lambda_vec(lambda);
+  size_t size_n = size(n);
+  size_t size_lambda = size(lambda);
+  size_t max_size_seq_view = max_size(n, lambda);
+
   // Explicit return for extreme values
   // The gradients are technically ill-defined, but treated as neg infinity
-  for (size_t i = 0; i < size(n); i++) {
+  for (size_t i = 0; i < size_n; i++) {
     if (value_of(n_vec[i]) < 0) {
       return ops_partials.build(0.0);
+    }
+  }
+
+  VectorBuilder<!is_constant_all<T_rate>::value, T_partials_return, T_n>
+      lgamma_n_plus_one(size_n);
+  VectorBuilder<!is_constant_all<T_rate>::value, T_partials_return, T_rate>
+      log_lambda(size_lambda);
+
+  if (!is_constant_all<T_rate>::value) {
+    for (size_t i = 0; i < size_n; i++) {
+      lgamma_n_plus_one[i] = lgamma(n_vec[i] + 1.0);
+    }
+    for (size_t i = 0; i < size_lambda; i++) {
+      log_lambda[i] = log(lambda_vec[i]);
     }
   }
 
@@ -61,10 +77,11 @@ return_type_t<T_rate> poisson_lccdf(const T_n& n, const T_rate& lambda) {
     P += log_Pi;
 
     if (!is_constant_all<T_rate>::value) {
-      ops_partials.edge1_.partials_[i] += exp(
-          n_dbl * log(lambda_dbl) - lambda_dbl - lgamma(n_dbl + 1) - log_Pi);
+      ops_partials.edge1_.partials_[i] += exp(n_dbl * log_lambda[i] - lambda_dbl
+                                              - lgamma_n_plus_one[i] - log_Pi);
     }
   }
+
   return ops_partials.build(P);
 }
 

--- a/stan/math/prim/prob/poisson_lcdf.hpp
+++ b/stan/math/prim/prob/poisson_lcdf.hpp
@@ -59,7 +59,7 @@ return_type_t<T_rate> poisson_lcdf(const T_n& n, const T_rate& lambda) {
       lgamma_n_plus_one[i] = lgamma(n_vec[i] + 1.0);
     }
     for (size_t i = 0; i < size_lambda; i++) {
-      log_lambda[i] = log(lambda_vec[i]);
+      log_lambda[i] = log(value_of(lambda_vec[i]));
     }
   }
 

--- a/stan/math/prim/prob/poisson_lcdf.hpp
+++ b/stan/math/prim/prob/poisson_lcdf.hpp
@@ -3,10 +3,10 @@
 
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/err.hpp>
-#include <stan/math/prim/fun/size_zero.hpp>
 #include <stan/math/prim/fun/constants.hpp>
 #include <stan/math/prim/fun/gamma_q.hpp>
 #include <stan/math/prim/fun/lgamma.hpp>
+#include <stan/math/prim/fun/size_zero.hpp>
 #include <stan/math/prim/fun/value_of.hpp>
 #include <cmath>
 #include <limits>
@@ -30,20 +30,36 @@ return_type_t<T_rate> poisson_lcdf(const T_n& n, const T_rate& lambda) {
   check_consistent_sizes(function, "Random variable", n, "Rate parameter",
                          lambda);
 
-  scalar_seq_view<T_n> n_vec(n);
-  scalar_seq_view<T_rate> lambda_vec(lambda);
-  size_t max_size_seq_view = max_size(n, lambda);
-
   using std::exp;
   using std::log;
 
   operands_and_partials<T_rate> ops_partials(lambda);
 
+  scalar_seq_view<T_n> n_vec(n);
+  scalar_seq_view<T_rate> lambda_vec(lambda);
+  size_t size_n = size(n);
+  size_t size_lambda = size(lambda);
+  size_t max_size_seq_view = max_size(n, lambda);
+
   // Explicit return for extreme values
   // The gradients are technically ill-defined, but treated as neg infinity
-  for (size_t i = 0; i < size(n); i++) {
+  for (size_t i = 0; i < size_n; i++) {
     if (value_of(n_vec[i]) < 0) {
       return ops_partials.build(negative_infinity());
+    }
+  }
+
+  VectorBuilder<!is_constant_all<T_rate>::value, T_partials_return, T_n>
+      lgamma_n_plus_one(size_n);
+  VectorBuilder<!is_constant_all<T_rate>::value, T_partials_return, T_rate>
+      log_lambda(size_lambda);
+
+  if (!is_constant_all<T_rate>::value) {
+    for (size_t i = 0; i < size_n; i++) {
+      lgamma_n_plus_one[i] = lgamma(n_vec[i] + 1.0);
+    }
+    for (size_t i = 0; i < size_lambda; i++) {
+      log_lambda[i] = log(lambda_vec[i]);
     }
   }
 
@@ -61,10 +77,11 @@ return_type_t<T_rate> poisson_lcdf(const T_n& n, const T_rate& lambda) {
     P += log_Pi;
 
     if (!is_constant_all<T_rate>::value) {
-      ops_partials.edge1_.partials_[i] += -exp(
-          n_dbl * log(lambda_dbl) - lambda_dbl - lgamma(n_dbl + 1) - log_Pi);
+      ops_partials.edge1_.partials_[i] -= exp(n_dbl * log_lambda[i] - lambda_dbl
+                                              - lgamma_n_plus_one[i] - log_Pi);
     }
   }
+
   return ops_partials.build(P);
 }
 


### PR DESCRIPTION
## Summary
This uses `VectorBuilder` to precompute values to be used later on in loops. Fixes #1654.

## Tests

No new tests.

## Side Effects

None.

## Checklist

- [X] Math issue #1654

- [X] Copyright holder: Marco Colombo

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [X] the new changes are tested
