### PR TITLE
Move vectorize files to meta folder

### DIFF
--- a/stan/math/fwd.hpp
+++ b/stan/math/fwd.hpp
@@ -5,7 +5,6 @@
 
 #include <stan/math/fwd/core.hpp>
 #include <stan/math/fwd/meta.hpp>
-#include <stan/math/fwd/vectorize.hpp>
 #include <stan/math/prim.hpp>
 
 #include <stan/math/fwd/fun.hpp>

--- a/stan/math/fwd/fun/log_softmax.hpp
+++ b/stan/math/fwd/fun/log_softmax.hpp
@@ -3,11 +3,10 @@
 
 #include <stan/math/fwd/core.hpp>
 #include <stan/math/fwd/fun/softmax.hpp>
+#include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/fun/Eigen.hpp>
 #include <stan/math/prim/fun/log_softmax.hpp>
 #include <stan/math/prim/fun/softmax.hpp>
-#include <stan/math/prim/meta.hpp>
-#include <stan/math/prim/vectorize/apply_vector_unary.hpp>
 
 namespace stan {
 namespace math {

--- a/stan/math/fwd/fun/log_sum_exp.hpp
+++ b/stan/math/fwd/fun/log_sum_exp.hpp
@@ -3,10 +3,10 @@
 
 #include <stan/math/fwd/meta.hpp>
 #include <stan/math/fwd/core.hpp>
+#include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/fun/Eigen.hpp>
 #include <stan/math/prim/fun/constants.hpp>
 #include <stan/math/prim/fun/log_sum_exp.hpp>
-#include <stan/math/prim/vectorize/apply_vector_unary.hpp>
 #include <cmath>
 #include <vector>
 

--- a/stan/math/fwd/meta.hpp
+++ b/stan/math/fwd/meta.hpp
@@ -1,6 +1,7 @@
 #ifndef STAN_MATH_FWD_META_HPP
 #define STAN_MATH_FWD_META_HPP
 
+#include <stan/math/fwd/meta/apply_scalar_unary.hpp>
 #include <stan/math/fwd/meta/is_fvar.hpp>
 #include <stan/math/fwd/meta/partials_type.hpp>
 #include <stan/math/fwd/meta/operands_and_partials.hpp>

--- a/stan/math/fwd/meta/apply_scalar_unary.hpp
+++ b/stan/math/fwd/meta/apply_scalar_unary.hpp
@@ -1,7 +1,7 @@
-#ifndef STAN_MATH_FWD_VECTORIZE_APPLY_SCALAR_UNARY_HPP
-#define STAN_MATH_FWD_VECTORIZE_APPLY_SCALAR_UNARY_HPP
+#ifndef STAN_MATH_FWD_META_APPLY_SCALAR_UNARY_HPP
+#define STAN_MATH_FWD_META_APPLY_SCALAR_UNARY_HPP
 
-#include <stan/math/prim/vectorize/apply_scalar_unary.hpp>
+#include <stan/math/prim/meta/apply_scalar_unary.hpp>
 #include <stan/math/fwd/core/fvar.hpp>
 
 namespace stan {

--- a/stan/math/fwd/vectorize.hpp
+++ b/stan/math/fwd/vectorize.hpp
@@ -1,6 +1,0 @@
-#ifndef STAN_MATH_FWD_VECTORIZE_HPP
-#define STAN_MATH_FWD_VECTORIZE_HPP
-
-#include <stan/math/fwd/vectorize/apply_scalar_unary.hpp>
-
-#endif

--- a/stan/math/prim.hpp
+++ b/stan/math/prim.hpp
@@ -10,6 +10,5 @@
 #include <stan/math/prim/fun.hpp>
 #include <stan/math/prim/functor.hpp>
 #include <stan/math/prim/prob.hpp>
-#include <stan/math/prim/vectorize.hpp>
 
 #endif

--- a/stan/math/prim/fun/Phi.hpp
+++ b/stan/math/prim/fun/Phi.hpp
@@ -7,7 +7,6 @@
 #include <stan/math/prim/fun/erf.hpp>
 #include <stan/math/prim/fun/erfc.hpp>
 #include <stan/math/prim/fun/Phi.hpp>
-#include <stan/math/prim/vectorize/apply_scalar_unary.hpp>
 
 namespace stan {
 namespace math {

--- a/stan/math/prim/fun/Phi_approx.hpp
+++ b/stan/math/prim/fun/Phi_approx.hpp
@@ -3,7 +3,6 @@
 
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/fun/inv_logit.hpp>
-#include <stan/math/prim/vectorize/apply_scalar_unary.hpp>
 #include <cmath>
 
 namespace stan {

--- a/stan/math/prim/fun/acos.hpp
+++ b/stan/math/prim/fun/acos.hpp
@@ -1,9 +1,8 @@
 #ifndef STAN_MATH_PRIM_FUN_ACOS_HPP
 #define STAN_MATH_PRIM_FUN_ACOS_HPP
 
-#include <stan/math/prim/fun/Eigen.hpp>
 #include <stan/math/prim/meta.hpp>
-#include <stan/math/prim/vectorize/apply_scalar_unary.hpp>
+#include <stan/math/prim/fun/Eigen.hpp>
 #include <cmath>
 
 namespace stan {

--- a/stan/math/prim/fun/acosh.hpp
+++ b/stan/math/prim/fun/acosh.hpp
@@ -5,7 +5,6 @@
 #include <stan/math/prim/err.hpp>
 #include <stan/math/prim/fun/is_inf.hpp>
 #include <stan/math/prim/fun/is_nan.hpp>
-#include <stan/math/prim/vectorize/apply_scalar_unary.hpp>
 #include <cmath>
 
 namespace stan {

--- a/stan/math/prim/fun/asin.hpp
+++ b/stan/math/prim/fun/asin.hpp
@@ -3,7 +3,6 @@
 
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/fun/Eigen.hpp>
-#include <stan/math/prim/vectorize/apply_scalar_unary.hpp>
 #include <cmath>
 
 namespace stan {

--- a/stan/math/prim/fun/asinh.hpp
+++ b/stan/math/prim/fun/asinh.hpp
@@ -2,7 +2,6 @@
 #define STAN_MATH_PRIM_FUN_ASINH_HPP
 
 #include <stan/math/prim/meta.hpp>
-#include <stan/math/prim/vectorize/apply_scalar_unary.hpp>
 #include <cmath>
 
 namespace stan {

--- a/stan/math/prim/fun/atan.hpp
+++ b/stan/math/prim/fun/atan.hpp
@@ -3,7 +3,6 @@
 
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/fun/Eigen.hpp>
-#include <stan/math/prim/vectorize/apply_scalar_unary.hpp>
 #include <cmath>
 
 namespace stan {

--- a/stan/math/prim/fun/atanh.hpp
+++ b/stan/math/prim/fun/atanh.hpp
@@ -4,7 +4,6 @@
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/err.hpp>
 #include <stan/math/prim/fun/is_nan.hpp>
-#include <stan/math/prim/vectorize/apply_scalar_unary.hpp>
 #include <cmath>
 
 namespace stan {

--- a/stan/math/prim/fun/cbrt.hpp
+++ b/stan/math/prim/fun/cbrt.hpp
@@ -2,7 +2,6 @@
 #define STAN_MATH_PRIM_FUN_CBRT_HPP
 
 #include <stan/math/prim/meta.hpp>
-#include <stan/math/prim/vectorize/apply_scalar_unary.hpp>
 #include <cmath>
 
 namespace stan {

--- a/stan/math/prim/fun/ceil.hpp
+++ b/stan/math/prim/fun/ceil.hpp
@@ -1,9 +1,8 @@
 #ifndef STAN_MATH_PRIM_FUN_CEIL_HPP
 #define STAN_MATH_PRIM_FUN_CEIL_HPP
 
-#include <stan/math/prim/fun/Eigen.hpp>
 #include <stan/math/prim/meta.hpp>
-#include <stan/math/prim/vectorize/apply_scalar_unary.hpp>
+#include <stan/math/prim/fun/Eigen.hpp>
 #include <cmath>
 
 namespace stan {

--- a/stan/math/prim/fun/cos.hpp
+++ b/stan/math/prim/fun/cos.hpp
@@ -3,7 +3,6 @@
 
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/fun/Eigen.hpp>
-#include <stan/math/prim/vectorize/apply_scalar_unary.hpp>
 #include <cmath>
 
 namespace stan {

--- a/stan/math/prim/fun/cosh.hpp
+++ b/stan/math/prim/fun/cosh.hpp
@@ -1,9 +1,8 @@
 #ifndef STAN_MATH_PRIM_FUN_COSH_HPP
 #define STAN_MATH_PRIM_FUN_COSH_HPP
 
-#include <stan/math/prim/fun/Eigen.hpp>
 #include <stan/math/prim/meta.hpp>
-#include <stan/math/prim/vectorize/apply_scalar_unary.hpp>
+#include <stan/math/prim/fun/Eigen.hpp>
 #include <cmath>
 
 namespace stan {

--- a/stan/math/prim/fun/digamma.hpp
+++ b/stan/math/prim/fun/digamma.hpp
@@ -3,7 +3,6 @@
 
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/fun/boost_policy.hpp>
-#include <stan/math/prim/vectorize/apply_scalar_unary.hpp>
 #include <boost/math/special_functions/digamma.hpp>
 
 namespace stan {

--- a/stan/math/prim/fun/erf.hpp
+++ b/stan/math/prim/fun/erf.hpp
@@ -2,7 +2,6 @@
 #define STAN_MATH_PRIM_FUN_ERF_HPP
 
 #include <stan/math/prim/meta.hpp>
-#include <stan/math/prim/vectorize/apply_scalar_unary.hpp>
 #include <cmath>
 
 namespace stan {

--- a/stan/math/prim/fun/erfc.hpp
+++ b/stan/math/prim/fun/erfc.hpp
@@ -2,7 +2,6 @@
 #define STAN_MATH_PRIM_FUN_ERFC_HPP
 
 #include <stan/math/prim/meta.hpp>
-#include <stan/math/prim/vectorize/apply_scalar_unary.hpp>
 #include <cmath>
 
 namespace stan {

--- a/stan/math/prim/fun/exp.hpp
+++ b/stan/math/prim/fun/exp.hpp
@@ -3,7 +3,6 @@
 
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/fun/Eigen.hpp>
-#include <stan/math/prim/vectorize/apply_scalar_unary.hpp>
 #include <cmath>
 
 namespace stan {

--- a/stan/math/prim/fun/exp2.hpp
+++ b/stan/math/prim/fun/exp2.hpp
@@ -2,7 +2,6 @@
 #define STAN_MATH_PRIM_FUN_EXP2_HPP
 
 #include <stan/math/prim/meta.hpp>
-#include <stan/math/prim/vectorize/apply_scalar_unary.hpp>
 #include <cmath>
 
 namespace stan {

--- a/stan/math/prim/fun/expm1.hpp
+++ b/stan/math/prim/fun/expm1.hpp
@@ -2,7 +2,6 @@
 #define STAN_MATH_PRIM_FUN_EXPM1_HPP
 
 #include <stan/math/prim/meta.hpp>
-#include <stan/math/prim/vectorize/apply_scalar_unary.hpp>
 #include <cmath>
 
 namespace stan {

--- a/stan/math/prim/fun/fabs.hpp
+++ b/stan/math/prim/fun/fabs.hpp
@@ -3,7 +3,6 @@
 
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/fun/Eigen.hpp>
-#include <stan/math/prim/vectorize/apply_scalar_unary.hpp>
 #include <cmath>
 
 namespace stan {

--- a/stan/math/prim/fun/floor.hpp
+++ b/stan/math/prim/fun/floor.hpp
@@ -3,7 +3,6 @@
 
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/fun/Eigen.hpp>
-#include <stan/math/prim/vectorize/apply_scalar_unary.hpp>
 #include <cmath>
 
 namespace stan {

--- a/stan/math/prim/fun/inv.hpp
+++ b/stan/math/prim/fun/inv.hpp
@@ -3,7 +3,6 @@
 
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/fun/Eigen.hpp>
-#include <stan/math/prim/vectorize/apply_scalar_unary.hpp>
 
 namespace stan {
 namespace math {

--- a/stan/math/prim/fun/inv_Phi.hpp
+++ b/stan/math/prim/fun/inv_Phi.hpp
@@ -7,7 +7,6 @@
 #include <stan/math/prim/fun/log1m.hpp>
 #include <stan/math/prim/fun/Phi.hpp>
 #include <stan/math/prim/fun/square.hpp>
-#include <stan/math/prim/vectorize/apply_scalar_unary.hpp>
 #include <cmath>
 
 namespace stan {

--- a/stan/math/prim/fun/inv_cloglog.hpp
+++ b/stan/math/prim/fun/inv_cloglog.hpp
@@ -3,7 +3,6 @@
 
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/fun/exp.hpp>
-#include <stan/math/prim/vectorize/apply_scalar_unary.hpp>
 #include <cmath>
 
 namespace stan {

--- a/stan/math/prim/fun/inv_logit.hpp
+++ b/stan/math/prim/fun/inv_logit.hpp
@@ -3,7 +3,6 @@
 
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/fun/constants.hpp>
-#include <stan/math/prim/vectorize/apply_scalar_unary.hpp>
 #include <cmath>
 
 namespace stan {

--- a/stan/math/prim/fun/inv_sqrt.hpp
+++ b/stan/math/prim/fun/inv_sqrt.hpp
@@ -4,7 +4,6 @@
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/fun/Eigen.hpp>
 #include <stan/math/prim/fun/inv.hpp>
-#include <stan/math/prim/vectorize/apply_scalar_unary.hpp>
 #include <cmath>
 
 namespace stan {

--- a/stan/math/prim/fun/inv_square.hpp
+++ b/stan/math/prim/fun/inv_square.hpp
@@ -1,10 +1,10 @@
 #ifndef STAN_MATH_PRIM_FUN_INV_SQUARE_HPP
 #define STAN_MATH_PRIM_FUN_INV_SQUARE_HPP
 
+#include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/fun/inv.hpp>
 #include <stan/math/prim/fun/square.hpp>
 #include <stan/math/prim/fun/inv_square.hpp>
-#include <stan/math/prim/vectorize/apply_scalar_unary.hpp>
 
 namespace stan {
 namespace math {

--- a/stan/math/prim/fun/lgamma.hpp
+++ b/stan/math/prim/fun/lgamma.hpp
@@ -29,7 +29,6 @@
 #include <limits>
 #endif
 #include <stan/math/prim/meta.hpp>
-#include <stan/math/prim/vectorize/apply_scalar_unary.hpp>
 
 namespace stan {
 namespace math {

--- a/stan/math/prim/fun/log.hpp
+++ b/stan/math/prim/fun/log.hpp
@@ -4,7 +4,6 @@
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/fun/Eigen.hpp>
 #include <stan/math/prim/fun/log.hpp>
-#include <stan/math/prim/vectorize/apply_scalar_unary.hpp>
 #include <cmath>
 
 namespace stan {

--- a/stan/math/prim/fun/log10.hpp
+++ b/stan/math/prim/fun/log10.hpp
@@ -3,7 +3,6 @@
 
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/fun/Eigen.hpp>
-#include <stan/math/prim/vectorize/apply_scalar_unary.hpp>
 #include <cmath>
 
 namespace stan {

--- a/stan/math/prim/fun/log1m.hpp
+++ b/stan/math/prim/fun/log1m.hpp
@@ -5,7 +5,6 @@
 #include <stan/math/prim/err.hpp>
 #include <stan/math/prim/fun/is_nan.hpp>
 #include <stan/math/prim/fun/log1p.hpp>
-#include <stan/math/prim/vectorize/apply_scalar_unary.hpp>
 
 namespace stan {
 namespace math {

--- a/stan/math/prim/fun/log1m_exp.hpp
+++ b/stan/math/prim/fun/log1m_exp.hpp
@@ -5,7 +5,6 @@
 #include <stan/math/prim/fun/constants.hpp>
 #include <stan/math/prim/fun/expm1.hpp>
 #include <stan/math/prim/fun/log1m.hpp>
-#include <stan/math/prim/vectorize/apply_scalar_unary.hpp>
 #include <cmath>
 
 namespace stan {

--- a/stan/math/prim/fun/log1m_inv_logit.hpp
+++ b/stan/math/prim/fun/log1m_inv_logit.hpp
@@ -3,7 +3,6 @@
 
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/fun/log1p.hpp>
-#include <stan/math/prim/vectorize/apply_scalar_unary.hpp>
 #include <cmath>
 
 namespace stan {

--- a/stan/math/prim/fun/log1p.hpp
+++ b/stan/math/prim/fun/log1p.hpp
@@ -6,7 +6,6 @@
 #include <stan/math/prim/fun/Eigen.hpp>
 #include <stan/math/prim/fun/is_nan.hpp>
 #include <stan/math/prim/fun/log1p.hpp>
-#include <stan/math/prim/vectorize/apply_scalar_unary.hpp>
 #include <cmath>
 
 namespace stan {

--- a/stan/math/prim/fun/log1p_exp.hpp
+++ b/stan/math/prim/fun/log1p_exp.hpp
@@ -3,7 +3,6 @@
 
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/fun/log1p.hpp>
-#include <stan/math/prim/vectorize/apply_scalar_unary.hpp>
 #include <cmath>
 
 namespace stan {

--- a/stan/math/prim/fun/log2.hpp
+++ b/stan/math/prim/fun/log2.hpp
@@ -3,7 +3,6 @@
 
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/fun/constants.hpp>
-#include <stan/math/prim/vectorize/apply_scalar_unary.hpp>
 #include <cmath>
 
 namespace stan {

--- a/stan/math/prim/fun/log_inv_logit.hpp
+++ b/stan/math/prim/fun/log_inv_logit.hpp
@@ -3,7 +3,6 @@
 
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/fun/log1p.hpp>
-#include <stan/math/prim/vectorize/apply_scalar_unary.hpp>
 #include <cmath>
 
 namespace stan {

--- a/stan/math/prim/fun/log_softmax.hpp
+++ b/stan/math/prim/fun/log_softmax.hpp
@@ -1,10 +1,10 @@
 #ifndef STAN_MATH_PRIM_FUN_LOG_SOFTMAX_HPP
 #define STAN_MATH_PRIM_FUN_LOG_SOFTMAX_HPP
 
+#include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/err.hpp>
 #include <stan/math/prim/fun/Eigen.hpp>
 #include <stan/math/prim/fun/log_sum_exp.hpp>
-#include <stan/math/prim/vectorize/apply_vector_unary.hpp>
 
 namespace stan {
 namespace math {

--- a/stan/math/prim/fun/log_sum_exp.hpp
+++ b/stan/math/prim/fun/log_sum_exp.hpp
@@ -5,7 +5,6 @@
 #include <stan/math/prim/fun/constants.hpp>
 #include <stan/math/prim/fun/Eigen.hpp>
 #include <stan/math/prim/fun/log1p_exp.hpp>
-#include <stan/math/prim/vectorize/apply_vector_unary.hpp>
 #include <cmath>
 #include <vector>
 

--- a/stan/math/prim/fun/logit.hpp
+++ b/stan/math/prim/fun/logit.hpp
@@ -2,7 +2,6 @@
 #define STAN_MATH_PRIM_FUN_LOGIT_HPP
 
 #include <stan/math/prim/meta.hpp>
-#include <stan/math/prim/vectorize/apply_scalar_unary.hpp>
 #include <cmath>
 
 namespace stan {

--- a/stan/math/prim/fun/round.hpp
+++ b/stan/math/prim/fun/round.hpp
@@ -3,7 +3,6 @@
 
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/fun/Eigen.hpp>
-#include <stan/math/prim/vectorize/apply_scalar_unary.hpp>
 #include <cmath>
 
 namespace stan {

--- a/stan/math/prim/fun/sin.hpp
+++ b/stan/math/prim/fun/sin.hpp
@@ -1,9 +1,8 @@
 #ifndef STAN_MATH_PRIM_FUN_SIN_HPP
 #define STAN_MATH_PRIM_FUN_SIN_HPP
 
-#include <stan/math/prim/fun/Eigen.hpp>
 #include <stan/math/prim/meta.hpp>
-#include <stan/math/prim/vectorize/apply_scalar_unary.hpp>
+#include <stan/math/prim/fun/Eigen.hpp>
 #include <cmath>
 
 namespace stan {

--- a/stan/math/prim/fun/sinh.hpp
+++ b/stan/math/prim/fun/sinh.hpp
@@ -3,7 +3,6 @@
 
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/fun/Eigen.hpp>
-#include <stan/math/prim/vectorize/apply_scalar_unary.hpp>
 #include <cmath>
 
 namespace stan {

--- a/stan/math/prim/fun/sqrt.hpp
+++ b/stan/math/prim/fun/sqrt.hpp
@@ -3,7 +3,6 @@
 
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/fun/Eigen.hpp>
-#include <stan/math/prim/vectorize/apply_scalar_unary.hpp>
 #include <cmath>
 
 namespace stan {

--- a/stan/math/prim/fun/square.hpp
+++ b/stan/math/prim/fun/square.hpp
@@ -4,7 +4,6 @@
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/fun/Eigen.hpp>
 #include <stan/math/prim/fun/square.hpp>
-#include <stan/math/prim/vectorize/apply_scalar_unary.hpp>
 #include <cmath>
 
 namespace stan {

--- a/stan/math/prim/fun/tan.hpp
+++ b/stan/math/prim/fun/tan.hpp
@@ -3,7 +3,6 @@
 
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/fun/Eigen.hpp>
-#include <stan/math/prim/vectorize/apply_scalar_unary.hpp>
 #include <cmath>
 
 namespace stan {

--- a/stan/math/prim/fun/tanh.hpp
+++ b/stan/math/prim/fun/tanh.hpp
@@ -3,7 +3,6 @@
 
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/fun/Eigen.hpp>
-#include <stan/math/prim/vectorize/apply_scalar_unary.hpp>
 #include <cmath>
 
 namespace stan {

--- a/stan/math/prim/fun/tgamma.hpp
+++ b/stan/math/prim/fun/tgamma.hpp
@@ -4,7 +4,6 @@
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/err.hpp>
 #include <stan/math/prim/fun/is_nonpositive_integer.hpp>
-#include <stan/math/prim/vectorize/apply_scalar_unary.hpp>
 #include <cmath>
 
 namespace stan {

--- a/stan/math/prim/fun/trigamma.hpp
+++ b/stan/math/prim/fun/trigamma.hpp
@@ -3,9 +3,8 @@
 
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/fun/constants.hpp>
-#include <stan/math/prim/fun/square.hpp>
 #include <stan/math/prim/fun/inv_square.hpp>
-#include <stan/math/prim/vectorize/apply_scalar_unary.hpp>
+#include <stan/math/prim/fun/square.hpp>
 #include <cmath>
 
 // Reference:

--- a/stan/math/prim/fun/trunc.hpp
+++ b/stan/math/prim/fun/trunc.hpp
@@ -2,7 +2,6 @@
 #define STAN_MATH_PRIM_FUN_TRUNC_HPP
 
 #include <stan/math/prim/meta.hpp>
-#include <stan/math/prim/vectorize/apply_scalar_unary.hpp>
 #include <cmath>
 
 namespace stan {

--- a/stan/math/prim/meta.hpp
+++ b/stan/math/prim/meta.hpp
@@ -1,8 +1,10 @@
 #ifndef STAN_MATH_PRIM_META_HPP
 #define STAN_MATH_PRIM_META_HPP
 
-#include <stan/math/prim/meta/append_return_type.hpp>
 #include <stan/math/prim/meta/ad_promotable.hpp>
+#include <stan/math/prim/meta/append_return_type.hpp>
+#include <stan/math/prim/meta/apply_scalar_unary.hpp>
+#include <stan/math/prim/meta/apply_vector_unary.hpp>
 #include <stan/math/prim/meta/as_array_or_scalar.hpp>
 #include <stan/math/prim/meta/as_column_vector_or_scalar.hpp>
 #include <stan/math/prim/meta/bool_constant.hpp>

--- a/stan/math/prim/meta/apply_scalar_unary.hpp
+++ b/stan/math/prim/meta/apply_scalar_unary.hpp
@@ -1,8 +1,8 @@
-#ifndef STAN_MATH_PRIM_VECTORIZE_APPLY_SCALAR_UNARY_HPP
-#define STAN_MATH_PRIM_VECTORIZE_APPLY_SCALAR_UNARY_HPP
+#ifndef STAN_MATH_PRIM_META_APPLY_SCALAR_UNARY_HPP
+#define STAN_MATH_PRIM_META_APPLY_SCALAR_UNARY_HPP
 
 #include <stan/math/prim/fun/Eigen.hpp>
-#include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/meta/require_generics.hpp>
 #include <utility>
 #include <vector>
 

--- a/stan/math/prim/meta/apply_vector_unary.hpp
+++ b/stan/math/prim/meta/apply_vector_unary.hpp
@@ -1,8 +1,9 @@
-#ifndef STAN_MATH_PRIM_VECTORIZE_APPLY_VECTOR_UNARY_HPP
-#define STAN_MATH_PRIM_VECTORIZE_APPLY_VECTOR_UNARY_HPP
+#ifndef STAN_MATH_PRIM_META_APPLY_VECTOR_UNARY_HPP
+#define STAN_MATH_PRIM_META_APPLY_VECTOR_UNARY_HPP
 
 #include <stan/math/prim/fun/Eigen.hpp>
-#include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/meta/as_column_vector_or_scalar.hpp>
+#include <stan/math/prim/meta/require_generics.hpp>
 #include <vector>
 
 namespace stan {

--- a/stan/math/prim/vectorize.hpp
+++ b/stan/math/prim/vectorize.hpp
@@ -1,6 +1,0 @@
-#ifndef STAN_MATH_PRIM_VECTORIZE_HPP
-#define STAN_MATH_PRIM_VECTORIZE_HPP
-
-#include <stan/math/prim/vectorize/apply_scalar_unary.hpp>
-
-#endif

--- a/stan/math/rev.hpp
+++ b/stan/math/rev.hpp
@@ -6,8 +6,6 @@
 #include <stan/math/rev/core.hpp>
 #include <stan/math/rev/meta.hpp>
 
-#include <stan/math/rev/vectorize.hpp>
-
 #include <stan/math/prim.hpp>
 
 #include <stan/math/rev/fun.hpp>

--- a/stan/math/rev/fun/log_softmax.hpp
+++ b/stan/math/rev/fun/log_softmax.hpp
@@ -3,12 +3,12 @@
 
 #include <stan/math/rev/core.hpp>
 #include <stan/math/rev/fun/typedefs.hpp>
+#include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/err.hpp>
 #include <stan/math/prim/fun/Eigen.hpp>
 #include <stan/math/prim/fun/log_softmax.hpp>
 #include <stan/math/prim/fun/softmax.hpp>
 #include <stan/math/prim/fun/typedefs.hpp>
-#include <stan/math/prim/vectorize/apply_vector_unary.hpp>
 #include <cmath>
 #include <vector>
 

--- a/stan/math/rev/fun/log_sum_exp.hpp
+++ b/stan/math/rev/fun/log_sum_exp.hpp
@@ -5,10 +5,10 @@
 #include <stan/math/rev/core.hpp>
 #include <stan/math/rev/fun/calculate_chain.hpp>
 #include <stan/math/rev/fun/typedefs.hpp>
+#include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/fun/constants.hpp>
 #include <stan/math/prim/fun/Eigen.hpp>
 #include <stan/math/prim/fun/log_sum_exp.hpp>
-#include <stan/math/prim/vectorize/apply_vector_unary.hpp>
 #include <cmath>
 #include <vector>
 

--- a/stan/math/rev/meta.hpp
+++ b/stan/math/rev/meta.hpp
@@ -1,6 +1,7 @@
 #ifndef STAN_MATH_REV_META_HPP
 #define STAN_MATH_REV_META_HPP
 
+#include <stan/math/rev/meta/apply_scalar_unary.hpp>
 #include <stan/math/rev/meta/is_var.hpp>
 #include <stan/math/rev/meta/partials_type.hpp>
 #include <stan/math/rev/meta/operands_and_partials.hpp>

--- a/stan/math/rev/meta/apply_scalar_unary.hpp
+++ b/stan/math/rev/meta/apply_scalar_unary.hpp
@@ -1,7 +1,7 @@
-#ifndef STAN_MATH_REV_VECTORIZE_APPLY_SCALAR_UNARY_HPP
-#define STAN_MATH_REV_VECTORIZE_APPLY_SCALAR_UNARY_HPP
+#ifndef STAN_MATH_REV_META_APPLY_SCALAR_UNARY_HPP
+#define STAN_MATH_REV_META_APPLY_SCALAR_UNARY_HPP
 
-#include <stan/math/prim/vectorize/apply_scalar_unary.hpp>
+#include <stan/math/prim/meta/apply_scalar_unary.hpp>
 #include <stan/math/rev/core/var.hpp>
 
 namespace stan {

--- a/stan/math/rev/vectorize.hpp
+++ b/stan/math/rev/vectorize.hpp
@@ -1,6 +1,0 @@
-#ifndef STAN_MATH_REV_VECTORIZE_HPP
-#define STAN_MATH_REV_VECTORIZE_HPP
-
-#include <stan/math/rev/vectorize/apply_scalar_unary.hpp>
-
-#endif


### PR DESCRIPTION
## Summary

This removes the vectorize directory and `vectorize.hpp`, by moving headers to the meta folder and `meta.hpp`. Fixes #1595.

## Tests

No new tests.

## Side Effects

None.

## Checklist

- [X] Math issue #1595

- [X] Copyright holder: Marco Colombo

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [X] the new changes are tested
