### PR TITLE
make develop build again

### DIFF
--- a/test/unit/math/rev/prob/inv_gamma_test.cpp
+++ b/test/unit/math/rev/prob/inv_gamma_test.cpp
@@ -1,4 +1,4 @@
-#include <stan/math/rev/scal.hpp>
+#include <stan/math/rev.hpp>
 #include <boost/math/tools/numerical_differentiation.hpp>
 #include <boost/math/special_functions/digamma.hpp>
 #include <gtest/gtest.h>

--- a/test/unit/math/rev/prob/weibull_test.cpp
+++ b/test/unit/math/rev/prob/weibull_test.cpp
@@ -1,4 +1,4 @@
-#include <stan/math/rev/scal.hpp>
+#include <stan/math/rev.hpp>
 #include <gtest/gtest.h>
 #include <vector>
 #include <algorithm>


### PR DESCRIPTION
## Summary
When I merged #1575 I hadn't noticed that two tests used headers from before flatten. This is an alternative to the full revert of #1664. Sorry for the disruption!

## Tests

Make them work again!

## Side Effects

None.

## Checklist

- [X] Math issue #1575

- [X] Copyright holder: Marco Colombo

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [X] the new changes are tested
