### PR TITLE
add the range_* functions

### DIFF
--- a/stan/math/prim/fun.hpp
+++ b/stan/math/prim/fun.hpp
@@ -137,6 +137,9 @@
 #include <stan/math/prim/fun/ldexp.hpp>
 #include <stan/math/prim/fun/LDLT_factor.hpp>
 #include <stan/math/prim/fun/lgamma.hpp>
+#include <stan/math/prim/fun/linspaced_array.hpp>
+#include <stan/math/prim/fun/linspaced_row_vector.hpp>
+#include <stan/math/prim/fun/linspaced_vector.hpp>
 #include <stan/math/prim/fun/lmgamma.hpp>
 #include <stan/math/prim/fun/log.hpp>
 #include <stan/math/prim/fun/log10.hpp>
@@ -265,9 +268,6 @@
 #include <stan/math/prim/fun/sort_indices.hpp>
 #include <stan/math/prim/fun/sort_indices_asc.hpp>
 #include <stan/math/prim/fun/sort_indices_desc.hpp>
-#include <stan/math/prim/fun/spaced_array.hpp>
-#include <stan/math/prim/fun/spaced_row_vector.hpp>
-#include <stan/math/prim/fun/spaced_vector.hpp>
 #include <stan/math/prim/fun/sqrt.hpp>
 #include <stan/math/prim/fun/square.hpp>
 #include <stan/math/prim/fun/squared_distance.hpp>

--- a/stan/math/prim/fun.hpp
+++ b/stan/math/prim/fun.hpp
@@ -228,6 +228,9 @@
 #include <stan/math/prim/fun/quad_form.hpp>
 #include <stan/math/prim/fun/quad_form_diag.hpp>
 #include <stan/math/prim/fun/quad_form_sym.hpp>
+#include <stan/math/prim/fun/range_array.hpp>
+#include <stan/math/prim/fun/range_row_vector.hpp>
+#include <stan/math/prim/fun/range_vector.hpp>
 #include <stan/math/prim/fun/rank.hpp>
 #include <stan/math/prim/fun/read_corr_L.hpp>
 #include <stan/math/prim/fun/read_corr_matrix.hpp>

--- a/stan/math/prim/fun/linspaced_array.hpp
+++ b/stan/math/prim/fun/linspaced_array.hpp
@@ -1,5 +1,5 @@
-#ifndef STAN_MATH_PRIM_FUN_SPACED_ARRAY_HPP
-#define STAN_MATH_PRIM_FUN_SPACED_ARRAY_HPP
+#ifndef STAN_MATH_PRIM_FUN_LINSPACED_ARRAY_HPP
+#define STAN_MATH_PRIM_FUN_LINSPACED_ARRAY_HPP
 
 #include <stan/math/prim/err.hpp>
 #include <stan/math/prim/fun/Eigen.hpp>
@@ -23,8 +23,8 @@ namespace math {
  * @throw std::domain_error if K is negative, if low is nan or infinite,
  * if high is nan or infinite, or if high is less than low.
  */
-inline std::vector<double> spaced_array(int K, double low, double high) {
-  static const char* function = "spaced_array";
+inline std::vector<double> linspaced_array(int K, double low, double high) {
+  static const char* function = "linspaced_array";
   check_nonnegative(function, "size", K);
   check_finite(function, "low", low);
   check_finite(function, "high", high);

--- a/stan/math/prim/fun/linspaced_row_vector.hpp
+++ b/stan/math/prim/fun/linspaced_row_vector.hpp
@@ -1,5 +1,5 @@
-#ifndef STAN_MATH_PRIM_FUN_SPACED_VECTOR_HPP
-#define STAN_MATH_PRIM_FUN_SPACED_VECTOR_HPP
+#ifndef STAN_MATH_PRIM_FUN_LINSPACED_ROW_VECTOR_HPP
+#define STAN_MATH_PRIM_FUN_LINSPACED_ROW_VECTOR_HPP
 
 #include <stan/math/prim/err.hpp>
 #include <stan/math/prim/fun/Eigen.hpp>
@@ -8,28 +8,28 @@ namespace stan {
 namespace math {
 
 /**
- * Return a vector of linearly spaced elements.
+ * Return a row vector of linearly spaced elements.
  *
- * This produces a vector from low to high (included) with elements spaced
+ * This produces a row vector from low to high (included) with elements spaced
  * as (high - low) / (K - 1). For K=1, the vector will contain the high value;
  * for K=0 it returns an empty vector.
  *
- * @param K size of the vector
+ * @param K size of the row vector
  * @param low smallest value
  * @param high largest value
- * @return A vector of size K with elements linearly spaced between
+ * @return A row vector of size K with elements linearly spaced between
  * low and high.
  * @throw std::domain_error if K is negative, if low is nan or infinite,
  * if high is nan or infinite, or if high is less than low.
  */
-inline Eigen::VectorXd spaced_vector(int K, double low, double high) {
-  static const char* function = "spaced_vector";
+inline Eigen::RowVectorXd linspaced_row_vector(int K, double low, double high) {
+  static const char* function = "linspaced_row_vector";
   check_nonnegative(function, "size", K);
   check_finite(function, "low", low);
   check_finite(function, "high", high);
   check_greater_or_equal(function, "high", high, low);
 
-  return Eigen::VectorXd::LinSpaced(K, low, high);
+  return Eigen::RowVectorXd::LinSpaced(K, low, high);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/linspaced_vector.hpp
+++ b/stan/math/prim/fun/linspaced_vector.hpp
@@ -1,5 +1,5 @@
-#ifndef STAN_MATH_PRIM_FUN_SPACED_ROW_VECTOR_HPP
-#define STAN_MATH_PRIM_FUN_SPACED_ROW_VECTOR_HPP
+#ifndef STAN_MATH_PRIM_FUN_LINSPACED_VECTOR_HPP
+#define STAN_MATH_PRIM_FUN_LINSPACED_VECTOR_HPP
 
 #include <stan/math/prim/err.hpp>
 #include <stan/math/prim/fun/Eigen.hpp>
@@ -8,28 +8,28 @@ namespace stan {
 namespace math {
 
 /**
- * Return a row vector of linearly spaced elements.
+ * Return a vector of linearly spaced elements.
  *
- * This produces a row vector from low to high (included) with elements spaced
+ * This produces a vector from low to high (included) with elements spaced
  * as (high - low) / (K - 1). For K=1, the vector will contain the high value;
  * for K=0 it returns an empty vector.
  *
- * @param K size of the row vector
+ * @param K size of the vector
  * @param low smallest value
  * @param high largest value
- * @return A row vector of size K with elements linearly spaced between
+ * @return A vector of size K with elements linearly spaced between
  * low and high.
  * @throw std::domain_error if K is negative, if low is nan or infinite,
  * if high is nan or infinite, or if high is less than low.
  */
-inline Eigen::RowVectorXd spaced_row_vector(int K, double low, double high) {
-  static const char* function = "spaced_row_vector";
+inline Eigen::VectorXd linspaced_vector(int K, double low, double high) {
+  static const char* function = "linspaced_vector";
   check_nonnegative(function, "size", K);
   check_finite(function, "low", low);
   check_finite(function, "high", high);
   check_greater_or_equal(function, "high", high, low);
 
-  return Eigen::RowVectorXd::LinSpaced(K, low, high);
+  return Eigen::VectorXd::LinSpaced(K, low, high);
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/range_array.hpp
+++ b/stan/math/prim/fun/range_array.hpp
@@ -1,0 +1,47 @@
+#ifndef STAN_MATH_PRIM_FUN_RANGE_ARRAY_HPP
+#define STAN_MATH_PRIM_FUN_RANGE_ARRAY_HPP
+
+#include <stan/math/prim/err.hpp>
+#include <stan/math/prim/fun/Eigen.hpp>
+#include <cmath>
+#include <vector>
+
+namespace stan {
+namespace math {
+
+/**
+ * Return an array with elements from `low` (included) to `high` (excluded)
+ * linearly spaced according to `by`.
+ *
+ * This produces a sequence of numbers low, low + by, min + 2*by, ...
+ * up to but not including high. If low = high or by > high - low, the
+ * resulting array will contain only 1 element equal to low.
+ *
+ * @param low smallest value
+ * @param high largest value
+ * @param by spacing between elements
+ * @return An array with elements between `low` and `high`, linearly spaced
+ * according to `by`.
+ * @throw std::domain_error if `low` is nan or infinite, if `high` is nan or
+ * infinite, or if `high` is less than `low,` or if `by` is not positive.
+ */
+inline std::vector<double> range_array(double low, double high, double by) {
+  static const char* function = "range_array";
+  check_finite(function, "low", low);
+  check_finite(function, "high", high);
+  check_greater_or_equal(function, "high", high, low);
+  check_positive_finite(function, "by", by);
+
+  if (low == high) {
+    return {low};
+  }
+
+  size_t K = std::ceil((high - low) / by);
+  Eigen::VectorXd v = Eigen::VectorXd::LinSpaced(K, low, low + (K - 1) * by);
+  return {&v[0], &v[0] + K};
+}
+
+}  // namespace math
+}  // namespace stan
+
+#endif

--- a/stan/math/prim/fun/range_row_vector.hpp
+++ b/stan/math/prim/fun/range_row_vector.hpp
@@ -1,0 +1,45 @@
+#ifndef STAN_MATH_PRIM_FUN_RANGE_ROW_VECTOR_HPP
+#define STAN_MATH_PRIM_FUN_RANGE_ROW_VECTOR_HPP
+
+#include <stan/math/prim/err.hpp>
+#include <stan/math/prim/fun/Eigen.hpp>
+#include <cmath>
+
+namespace stan {
+namespace math {
+
+/**
+ * Return a row vector with elements from `low` (included) to `high` (excluded)
+ * linearly spaced according to `by`.
+ *
+ * This produces a sequence of numbers low, low + by, min + 2*by, ...
+ * up to but not including high. If low = high or by > high - low, the
+ * resulting array will contain only 1 element equal to low.
+ *
+ * @param low smallest value
+ * @param high largest value
+ * @param by spacing between elements
+ * @return A row vector with elements between `low` and `high`, linearly spaced
+ * according to `by`.
+ * @throw std::domain_error if `low` is nan or infinite, if `high` is nan or
+ * infinite, or if `high` is less than `low,` or if `by` is not positive.
+ */
+inline Eigen::RowVectorXd range_row_vector(double low, double high, double by) {
+  static const char* function = "range_row_vector";
+  check_finite(function, "low", low);
+  check_finite(function, "high", high);
+  check_greater_or_equal(function, "high", high, low);
+  check_positive_finite(function, "by", by);
+
+  if (low == high) {
+    return Eigen::RowVectorXd::Constant(1, low);
+  }
+
+  size_t K = std::ceil((high - low) / by);
+  return Eigen::RowVectorXd::LinSpaced(K, low, low + (K - 1) * by);
+}
+
+}  // namespace math
+}  // namespace stan
+
+#endif

--- a/stan/math/prim/fun/range_vector.hpp
+++ b/stan/math/prim/fun/range_vector.hpp
@@ -1,0 +1,45 @@
+#ifndef STAN_MATH_PRIM_FUN_RANGE_VECTOR_HPP
+#define STAN_MATH_PRIM_FUN_RANGE_VECTOR_HPP
+
+#include <stan/math/prim/err.hpp>
+#include <stan/math/prim/fun/Eigen.hpp>
+#include <cmath>
+
+namespace stan {
+namespace math {
+
+/**
+ * Return a vector with elements from `low` (included) to `high` (excluded)
+ * linearly spaced according to `by`.
+ *
+ * This produces a sequence of numbers low, low + by, min + 2*by, ...
+ * up to but not including high. If low = high or by > high - low, the
+ * resulting array will contain only 1 element equal to low.
+ *
+ * @param low smallest value
+ * @param high largest value
+ * @param by spacing between elements
+ * @return A vector with elements between `low` and `high`, linearly spaced
+ * according to `by`.
+ * @throw std::domain_error if `low` is nan or infinite, if `high` is nan or
+ * infinite, or if `high` is less than `low`, or if `by` is not positive.
+ */
+inline Eigen::VectorXd range_vector(double low, double high, double by) {
+  static const char* function = "range_vector";
+  check_finite(function, "low", low);
+  check_finite(function, "high", high);
+  check_greater_or_equal(function, "high", high, low);
+  check_positive_finite(function, "by", by);
+
+  if (low == high) {
+    return Eigen::VectorXd::Constant(1, low);
+  }
+
+  size_t K = std::ceil((high - low) / by);
+  return Eigen::VectorXd::LinSpaced(K, low, low + (K - 1) * by);
+}
+
+}  // namespace math
+}  // namespace stan
+
+#endif

--- a/test/unit/math/prim/fun/range_array_test.cpp
+++ b/test/unit/math/prim/fun/range_array_test.cpp
@@ -1,0 +1,45 @@
+#include <stan/math/prim.hpp>
+#include <test/unit/math/prim/fun/expect_matrix_eq.hpp>
+#include <gtest/gtest.h>
+#include <limits>
+#include <vector>
+
+void expect_range_array(double low, double high, double by,
+                        const std::vector<double>& expected) {
+  std::vector<double> found = stan::math::range_array(low, high, by);
+  expect_std_vector_eq(expected, found);
+}
+
+TEST(MathFunctions, range_array) {
+  std::vector<double> v{1};
+  expect_range_array(1, 1, 1, v);
+  expect_range_array(1, 2, 1, v);
+  expect_range_array(1, 2, 5, v);
+
+  double by = 0.5;
+  std::vector<double> v1{1, 1.5, 2, 2.5, 3};
+  expect_range_array(1, 3.49, by, v1);
+  expect_range_array(1, 3.50, by, v1);
+
+  std::vector<double> v2{1, 1.5, 2, 2.5, 3, 3.5};
+  expect_range_array(1, 3.51, by, v2);
+}
+
+TEST(MathFunctions, range_array_throw) {
+  using stan::math::range_array;
+  double inf = std::numeric_limits<double>::infinity();
+  double nan = std::numeric_limits<double>::quiet_NaN();
+  double by = 0.5;
+  double low = -2;
+  double high = 6;
+
+  EXPECT_THROW(range_array(low, high, 0), std::domain_error);
+  EXPECT_THROW(range_array(low, high, -1), std::domain_error);
+
+  EXPECT_THROW(range_array(inf, high, by), std::domain_error);
+  EXPECT_THROW(range_array(nan, high, by), std::domain_error);
+
+  EXPECT_THROW(range_array(low, low - 1, by), std::domain_error);
+  EXPECT_THROW(range_array(low, inf, by), std::domain_error);
+  EXPECT_THROW(range_array(low, nan, by), std::domain_error);
+}

--- a/test/unit/math/prim/fun/range_row_vector_test.cpp
+++ b/test/unit/math/prim/fun/range_row_vector_test.cpp
@@ -1,0 +1,47 @@
+#include <stan/math/prim.hpp>
+#include <test/unit/math/prim/fun/expect_matrix_eq.hpp>
+#include <gtest/gtest.h>
+#include <limits>
+
+void expect_range_row_vector(double low, double high, double by,
+                             const Eigen::RowVectorXd& expected) {
+  Eigen::RowVectorXd found = stan::math::range_row_vector(low, high, by);
+  expect_matrix_eq(expected, found);
+}
+
+TEST(MathFunctions, range_row_vector) {
+  Eigen::RowVectorXd v(1);
+  v << 1;
+  expect_range_row_vector(1, 1, 1, v);
+  expect_range_row_vector(1, 2, 1, v);
+  expect_range_row_vector(1, 2, 5, v);
+
+  double by = 0.5;
+  Eigen::RowVectorXd v1(5);
+  v1 << 1, 1.5, 2, 2.5, 3;
+  expect_range_row_vector(1, 3.49, by, v1);
+  expect_range_row_vector(1, 3.50, by, v1);
+
+  Eigen::RowVectorXd v2(6);
+  v2 << v1, 3.5;
+  expect_range_row_vector(1, 3.51, by, v2);
+}
+
+TEST(MathFunctions, range_row_vector_throw) {
+  using stan::math::range_row_vector;
+  double inf = std::numeric_limits<double>::infinity();
+  double nan = std::numeric_limits<double>::quiet_NaN();
+  double by = 0.5;
+  double low = -2;
+  double high = 6;
+
+  EXPECT_THROW(range_row_vector(low, high, 0), std::domain_error);
+  EXPECT_THROW(range_row_vector(low, high, -1), std::domain_error);
+
+  EXPECT_THROW(range_row_vector(inf, high, by), std::domain_error);
+  EXPECT_THROW(range_row_vector(nan, high, by), std::domain_error);
+
+  EXPECT_THROW(range_row_vector(low, low - 1, by), std::domain_error);
+  EXPECT_THROW(range_row_vector(low, inf, by), std::domain_error);
+  EXPECT_THROW(range_row_vector(low, nan, by), std::domain_error);
+}

--- a/test/unit/math/prim/fun/range_vector_test.cpp
+++ b/test/unit/math/prim/fun/range_vector_test.cpp
@@ -1,0 +1,47 @@
+#include <stan/math/prim.hpp>
+#include <test/unit/math/prim/fun/expect_matrix_eq.hpp>
+#include <gtest/gtest.h>
+#include <limits>
+
+void expect_range_vector(double low, double high, double by,
+                         const Eigen::VectorXd& expected) {
+  Eigen::VectorXd found = stan::math::range_vector(low, high, by);
+  expect_matrix_eq(expected, found);
+}
+
+TEST(MathFunctions, range_vector) {
+  Eigen::VectorXd v(1);
+  v << 1;
+  expect_range_vector(1, 1, 1, v);
+  expect_range_vector(1, 2, 1, v);
+  expect_range_vector(1, 2, 5, v);
+
+  double by = 0.5;
+  Eigen::VectorXd v1(5);
+  v1 << 1, 1.5, 2, 2.5, 3;
+  expect_range_vector(1, 3.49, by, v1);
+  expect_range_vector(1, 3.50, by, v1);
+
+  Eigen::VectorXd v2(6);
+  v2 << v1, 3.5;
+  expect_range_vector(1, 3.51, by, v2);
+}
+
+TEST(MathFunctions, range_vector_throw) {
+  using stan::math::range_vector;
+  double inf = std::numeric_limits<double>::infinity();
+  double nan = std::numeric_limits<double>::quiet_NaN();
+  double by = 0.5;
+  double low = -2;
+  double high = 6;
+
+  EXPECT_THROW(range_vector(low, high, 0), std::domain_error);
+  EXPECT_THROW(range_vector(low, high, -1), std::domain_error);
+
+  EXPECT_THROW(range_vector(inf, high, by), std::domain_error);
+  EXPECT_THROW(range_vector(nan, high, by), std::domain_error);
+
+  EXPECT_THROW(range_vector(low, low - 1, by), std::domain_error);
+  EXPECT_THROW(range_vector(low, inf, by), std::domain_error);
+  EXPECT_THROW(range_vector(low, nan, by), std::domain_error);
+}

--- a/test/unit/math/prim/fun/spaced_array_test.cpp
+++ b/test/unit/math/prim/fun/spaced_array_test.cpp
@@ -4,33 +4,33 @@
 #include <limits>
 #include <vector>
 
-void expect_spaced_array(int K, double low, double high,
-                         const std::vector<double>& expected) {
-  std::vector<double> found = stan::math::spaced_array(K, low, high);
+void expect_linspaced_array(int K, double low, double high,
+                            const std::vector<double>& expected) {
+  std::vector<double> found = stan::math::linspaced_array(K, low, high);
   expect_std_vector_eq(expected, found);
 }
 
-TEST(MathFunctions, spaced_array) {
-  expect_spaced_array(0, 1, 5, {});
-  expect_spaced_array(1, 1, 5, {5});
-  expect_spaced_array(5, 1, 5, {1, 2, 3, 4, 5});
-  expect_spaced_array(5, -2, 2, {-2, -1, 0, 1, 2});
+TEST(MathFunctions, linspaced_array) {
+  expect_linspaced_array(0, 1, 5, {});
+  expect_linspaced_array(1, 1, 5, {5});
+  expect_linspaced_array(5, 1, 5, {1, 2, 3, 4, 5});
+  expect_linspaced_array(5, -2, 2, {-2, -1, 0, 1, 2});
 }
 
-TEST(MathFunctions, spaced_array_throw) {
-  using stan::math::spaced_array;
+TEST(MathFunctions, linspaced_array_throw) {
+  using stan::math::linspaced_array;
   double inf = std::numeric_limits<double>::infinity();
   double nan = std::numeric_limits<double>::quiet_NaN();
   int K = 5;
   double low = -2;
   double high = 6;
 
-  EXPECT_THROW(spaced_array(-1, low, high), std::domain_error);
+  EXPECT_THROW(linspaced_array(-1, low, high), std::domain_error);
 
-  EXPECT_THROW(spaced_array(K, inf, high), std::domain_error);
-  EXPECT_THROW(spaced_array(K, nan, high), std::domain_error);
+  EXPECT_THROW(linspaced_array(K, inf, high), std::domain_error);
+  EXPECT_THROW(linspaced_array(K, nan, high), std::domain_error);
 
-  EXPECT_THROW(spaced_array(K, low, low - 1), std::domain_error);
-  EXPECT_THROW(spaced_array(K, low, inf), std::domain_error);
-  EXPECT_THROW(spaced_array(K, low, nan), std::domain_error);
+  EXPECT_THROW(linspaced_array(K, low, low - 1), std::domain_error);
+  EXPECT_THROW(linspaced_array(K, low, inf), std::domain_error);
+  EXPECT_THROW(linspaced_array(K, low, nan), std::domain_error);
 }

--- a/test/unit/math/prim/fun/spaced_row_vector_test.cpp
+++ b/test/unit/math/prim/fun/spaced_row_vector_test.cpp
@@ -3,43 +3,43 @@
 #include <gtest/gtest.h>
 #include <limits>
 
-void expect_spaced_row_vector(int K, double low, double high,
-                              const Eigen::RowVectorXd& expected) {
-  Eigen::RowVectorXd found = stan::math::spaced_row_vector(K, low, high);
+void expect_linspaced_row_vector(int K, double low, double high,
+                                 const Eigen::RowVectorXd& expected) {
+  Eigen::RowVectorXd found = stan::math::linspaced_row_vector(K, low, high);
   expect_matrix_eq(expected, found);
 }
 
-TEST(MathFunctions, spaced_row_vector) {
-  expect_spaced_row_vector(0, 1, 5, {});
+TEST(MathFunctions, linspaced_row_vector) {
+  expect_linspaced_row_vector(0, 1, 5, {});
 
   Eigen::RowVectorXd v(1);
   v << 5;
-  expect_spaced_row_vector(1, 1, 5, v);
+  expect_linspaced_row_vector(1, 1, 5, v);
 
   int K = 5;
   Eigen::RowVectorXd v1(K);
   v1 << 1, 2, 3, 4, 5;
-  expect_spaced_row_vector(K, 1, 5, v1);
+  expect_linspaced_row_vector(K, 1, 5, v1);
 
   Eigen::RowVectorXd v2(K);
   v2 << -2, -1, 0, 1, 2;
-  expect_spaced_row_vector(K, -2, 2, v2);
+  expect_linspaced_row_vector(K, -2, 2, v2);
 }
 
-TEST(MathFunctions, spaced_row_vector_throw) {
-  using stan::math::spaced_row_vector;
+TEST(MathFunctions, linspaced_row_vector_throw) {
+  using stan::math::linspaced_row_vector;
   double inf = std::numeric_limits<double>::infinity();
   double nan = std::numeric_limits<double>::quiet_NaN();
   int K = 5;
   double low = -2;
   double high = 6;
 
-  EXPECT_THROW(spaced_row_vector(-1, low, high), std::domain_error);
+  EXPECT_THROW(linspaced_row_vector(-1, low, high), std::domain_error);
 
-  EXPECT_THROW(spaced_row_vector(K, inf, high), std::domain_error);
-  EXPECT_THROW(spaced_row_vector(K, nan, high), std::domain_error);
+  EXPECT_THROW(linspaced_row_vector(K, inf, high), std::domain_error);
+  EXPECT_THROW(linspaced_row_vector(K, nan, high), std::domain_error);
 
-  EXPECT_THROW(spaced_row_vector(K, low, low - 1), std::domain_error);
-  EXPECT_THROW(spaced_row_vector(K, low, inf), std::domain_error);
-  EXPECT_THROW(spaced_row_vector(K, low, nan), std::domain_error);
+  EXPECT_THROW(linspaced_row_vector(K, low, low - 1), std::domain_error);
+  EXPECT_THROW(linspaced_row_vector(K, low, inf), std::domain_error);
+  EXPECT_THROW(linspaced_row_vector(K, low, nan), std::domain_error);
 }

--- a/test/unit/math/prim/fun/spaced_vector_test.cpp
+++ b/test/unit/math/prim/fun/spaced_vector_test.cpp
@@ -3,43 +3,43 @@
 #include <gtest/gtest.h>
 #include <limits>
 
-void expect_spaced_vector(int K, double low, double high,
-                          const Eigen::VectorXd& expected) {
-  Eigen::VectorXd found = stan::math::spaced_vector(K, low, high);
+void expect_linspaced_vector(int K, double low, double high,
+                             const Eigen::VectorXd& expected) {
+  Eigen::VectorXd found = stan::math::linspaced_vector(K, low, high);
   expect_matrix_eq(expected, found);
 }
 
-TEST(MathFunctions, spaced_vector) {
-  expect_spaced_vector(0, 1, 5, {});
+TEST(MathFunctions, linspaced_vector) {
+  expect_linspaced_vector(0, 1, 5, {});
 
   Eigen::VectorXd v(1);
   v << 5;
-  expect_spaced_vector(1, 1, 5, v);
+  expect_linspaced_vector(1, 1, 5, v);
 
   int K = 5;
   Eigen::VectorXd v1(K);
   v1 << 1, 2, 3, 4, 5;
-  expect_spaced_vector(K, 1, 5, v1);
+  expect_linspaced_vector(K, 1, 5, v1);
 
   Eigen::VectorXd v2(K);
   v2 << -2, -1, 0, 1, 2;
-  expect_spaced_vector(K, -2, 2, v2);
+  expect_linspaced_vector(K, -2, 2, v2);
 }
 
-TEST(MathFunctions, spaced_vector_throw) {
-  using stan::math::spaced_vector;
+TEST(MathFunctions, linspaced_vector_throw) {
+  using stan::math::linspaced_vector;
   double inf = std::numeric_limits<double>::infinity();
   double nan = std::numeric_limits<double>::quiet_NaN();
   int K = 5;
   double low = -2;
   double high = 6;
 
-  EXPECT_THROW(spaced_vector(-1, low, high), std::domain_error);
+  EXPECT_THROW(linspaced_vector(-1, low, high), std::domain_error);
 
-  EXPECT_THROW(spaced_vector(K, inf, high), std::domain_error);
-  EXPECT_THROW(spaced_vector(K, nan, high), std::domain_error);
+  EXPECT_THROW(linspaced_vector(K, inf, high), std::domain_error);
+  EXPECT_THROW(linspaced_vector(K, nan, high), std::domain_error);
 
-  EXPECT_THROW(spaced_vector(K, low, low - 1), std::domain_error);
-  EXPECT_THROW(spaced_vector(K, low, inf), std::domain_error);
-  EXPECT_THROW(spaced_vector(K, low, nan), std::domain_error);
+  EXPECT_THROW(linspaced_vector(K, low, low - 1), std::domain_error);
+  EXPECT_THROW(linspaced_vector(K, low, inf), std::domain_error);
+  EXPECT_THROW(linspaced_vector(K, low, nan), std::domain_error);
 }


### PR DESCRIPTION
## Summary

This adds the `range_array`, `range_vector` and `range_row_vector` functions to help construct containers of linearly spaced elements between `low` and `high` and separated by `by`. Fixes #838.

This also renames the spaced_vector functions to linspaced_vector, following the suggestion and discussion in #838.

## Tests
Added tests.

## Side Effects

None.

## Checklist

- [X] Math issue #838

- [X] Copyright holder: Marco Colombo

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [X] the new changes are tested
