### PR TITLE
Remove Boost deprecation warning

### DIFF
--- a/test/unit/math/rev/prob/inv_gamma_test.cpp
+++ b/test/unit/math/rev/prob/inv_gamma_test.cpp
@@ -1,5 +1,5 @@
 #include <stan/math/rev.hpp>
-#include <boost/math/tools/numerical_differentiation.hpp>
+#include <boost/math/differentiation/finite_difference.hpp>
 #include <boost/math/special_functions/digamma.hpp>
 #include <gtest/gtest.h>
 #include <vector>


### PR DESCRIPTION
## Summary

Replaces a deprecated header with the suggested one. Fixes #1672.

## Tests

None.

## Side Effects

None.

## Checklist

- [X] Math issue #1672

- [X] Copyright holder: Marco Colombo

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)
