### PR TITLE
Add discrete_range_rng(lower, upper) and discrete_range_lpmf

### DIFF
--- a/stan/math/prim/prob.hpp
+++ b/stan/math/prim/prob.hpp
@@ -75,6 +75,8 @@
 #include <stan/math/prim/prob/dirichlet_lpdf.hpp>
 #include <stan/math/prim/prob/dirichlet_lpmf.hpp>
 #include <stan/math/prim/prob/dirichlet_rng.hpp>
+#include <stan/math/prim/prob/discrete_range_log.hpp>
+#include <stan/math/prim/prob/discrete_range_lpmf.hpp>
 #include <stan/math/prim/prob/discrete_range_rng.hpp>
 #include <stan/math/prim/prob/double_exponential_ccdf_log.hpp>
 #include <stan/math/prim/prob/double_exponential_cdf.hpp>

--- a/stan/math/prim/prob.hpp
+++ b/stan/math/prim/prob.hpp
@@ -75,6 +75,7 @@
 #include <stan/math/prim/prob/dirichlet_lpdf.hpp>
 #include <stan/math/prim/prob/dirichlet_lpmf.hpp>
 #include <stan/math/prim/prob/dirichlet_rng.hpp>
+#include <stan/math/prim/prob/discrete_range_rng.hpp>
 #include <stan/math/prim/prob/double_exponential_ccdf_log.hpp>
 #include <stan/math/prim/prob/double_exponential_cdf.hpp>
 #include <stan/math/prim/prob/double_exponential_cdf_log.hpp>

--- a/stan/math/prim/prob/discrete_range_log.hpp
+++ b/stan/math/prim/prob/discrete_range_log.hpp
@@ -1,0 +1,29 @@
+#ifndef STAN_MATH_PRIM_PROB_DISCRETE_RANGE_LOG_HPP
+#define STAN_MATH_PRIM_PROB_DISCRETE_RANGE_LOG_HPP
+
+#include <stan/math/prim/prob/discrete_range_lpmf.hpp>
+
+namespace stan {
+namespace math {
+
+/** \ingroup prob_dists
+ * @deprecated use <code>discrete_range_lpmf</code>
+ */
+template <bool propto, typename T_y, typename T_lower, typename T_upper>
+double discrete_range_log(const T_y& y, const T_lower& lower,
+                          const T_upper& upper) {
+  return discrete_range_lpmf<propto, T_y, T_lower, T_upper>(y, lower, upper);
+}
+
+/** \ingroup prob_dists
+ * @deprecated use <code>discrete_range_lpmf</code>
+ */
+template <typename T_y, typename T_lower, typename T_upper>
+inline double discrete_range_log(const T_y& y, const T_lower& lower,
+                                 const T_upper& upper) {
+  return discrete_range_lpmf<T_y, T_lower, T_upper>(y, lower, upper);
+}
+
+}  // namespace math
+}  // namespace stan
+#endif

--- a/stan/math/prim/prob/discrete_range_lpmf.hpp
+++ b/stan/math/prim/prob/discrete_range_lpmf.hpp
@@ -1,0 +1,96 @@
+#ifndef STAN_MATH_PRIM_PROB_DISCRETE_RANGE_LPMF_HPP
+#define STAN_MATH_PRIM_PROB_DISCRETE_RANGE_LPMF_HPP
+
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/err.hpp>
+#include <stan/math/prim/fun/constants.hpp>
+#include <stan/math/prim/fun/inv.hpp>
+#include <stan/math/prim/fun/log.hpp>
+#include <stan/math/prim/fun/max_size.hpp>
+#include <stan/math/prim/fun/size_zero.hpp>
+#include <stan/math/prim/fun/value_of.hpp>
+#include <cmath>
+
+namespace stan {
+namespace math {
+
+/** \ingroup prob_dists
+ * Return the log PMF of a discrete range for the given y, lower and upper
+ * bound.
+ *
+ * `lower` and `upper` can each be a scalar or a one-dimensional container.
+ * Any non-scalar inputs must be the same size.
+ *
+ * @tparam T_y type of scalar, either int or std::vector<int>
+ * @tparam T_lower type of lower bound, either int or std::vector<int>
+ * @tparam T_upper type of upper bound, either int or std::vector<int>
+ *
+ * @param y random variable
+ * @param lower lower bound
+ * @param upper upper bound
+ * @return Log probability. If containers are supplied, returns the log sum
+ * of the probabilities.
+ * @throw std::domain_error if upper is smaller than lower.
+ * @throw std::invalid_argument if non-scalar arguments are of different
+ * sizes.
+ */
+template <bool propto, typename T_y, typename T_lower, typename T_upper>
+double discrete_range_lpmf(const T_y& y, const T_lower& lower,
+                           const T_upper& upper) {
+  static const char* function = "discrete_range_lpmf";
+
+  using std::log;
+
+  if (size_zero(y, lower, upper)) {
+    return 0.0;
+  }
+
+  check_not_nan(function, "Random variable", y);
+  check_consistent_sizes(function, "Lower bound parameter", lower,
+                         "Upper bound parameter", upper);
+  check_greater_or_equal(function, "Upper bound parameter", upper, lower);
+
+  if (!include_summand<propto>::value) {
+    return 0.0;
+  }
+
+  double logp(0.0);
+
+  scalar_seq_view<T_y> y_vec(y);
+  scalar_seq_view<T_lower> lower_vec(lower);
+  scalar_seq_view<T_upper> upper_vec(upper);
+  size_t size_lower_upper = max_size(lower, upper);
+  size_t N = max_size(y, lower, upper);
+
+  for (size_t n = 0; n < N; ++n) {
+    const double y_dbl = value_of(y_vec[n]);
+    if (y_dbl < value_of(lower_vec[n]) || y_dbl > value_of(upper_vec[n])) {
+      return LOG_ZERO;
+    }
+  }
+
+  VectorBuilder<true, double, T_lower, T_upper> log_upper_minus_lower(
+      size_lower_upper);
+
+  for (size_t i = 0; i < size_lower_upper; i++) {
+    const double lower_dbl = value_of(lower_vec[i]);
+    const double upper_dbl = value_of(upper_vec[i]);
+    log_upper_minus_lower[i] = log(upper_dbl - lower_dbl + 1);
+  }
+
+  for (size_t n = 0; n < N; n++) {
+    logp -= log_upper_minus_lower[n];
+  }
+
+  return logp;
+}
+
+template <typename T_y, typename T_lower, typename T_upper>
+inline double discrete_range_lpmf(const T_y& y, const T_lower& lower,
+                                  const T_upper& upper) {
+  return discrete_range_lpmf<false>(y, lower, upper);
+}
+
+}  // namespace math
+}  // namespace stan
+#endif

--- a/stan/math/prim/prob/discrete_range_lpmf.hpp
+++ b/stan/math/prim/prob/discrete_range_lpmf.hpp
@@ -16,18 +16,25 @@ namespace math {
 
 /** \ingroup prob_dists
  * Return the log PMF of a discrete range for the given y, lower and upper
- * bound.
+ * bound (all integers).
+ *
+ \f{eqnarray*}{
+   y &\sim& \mbox{\sf{discrete\_range}}(lower, upper) \\
+     \log(p (y \, |\, lower, upper))
+        &=& \log \left( \frac{1}{upper - lower + 1} \right) \\
+        &=& -\log (upper - lower + 1)
+ \f}
  *
  * `lower` and `upper` can each be a scalar or a one-dimensional container.
- * Any non-scalar inputs must be the same size.
+ * Any container arguments must be the same size.
  *
  * @tparam T_y type of scalar, either int or std::vector<int>
  * @tparam T_lower type of lower bound, either int or std::vector<int>
  * @tparam T_upper type of upper bound, either int or std::vector<int>
  *
- * @param y random variable
- * @param lower lower bound
- * @param upper upper bound
+ * @param y integer random variable
+ * @param lower integer lower bound
+ * @param upper integer upper bound
  * @return Log probability. If containers are supplied, returns the log sum
  * of the probabilities.
  * @throw std::domain_error if upper is smaller than lower.
@@ -38,7 +45,6 @@ template <bool propto, typename T_y, typename T_lower, typename T_upper>
 double discrete_range_lpmf(const T_y& y, const T_lower& lower,
                            const T_upper& upper) {
   static const char* function = "discrete_range_lpmf";
-
   using std::log;
 
   if (size_zero(y, lower, upper)) {
@@ -53,8 +59,6 @@ double discrete_range_lpmf(const T_y& y, const T_lower& lower,
   if (!include_summand<propto>::value) {
     return 0.0;
   }
-
-  double logp(0.0);
 
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_lower> lower_vec(lower);
@@ -78,6 +82,7 @@ double discrete_range_lpmf(const T_y& y, const T_lower& lower,
     log_upper_minus_lower[i] = log(upper_dbl - lower_dbl + 1);
   }
 
+  double logp(0.0);
   for (size_t n = 0; n < N; n++) {
     logp -= log_upper_minus_lower[n];
   }

--- a/stan/math/prim/prob/discrete_range_rng.hpp
+++ b/stan/math/prim/prob/discrete_range_rng.hpp
@@ -34,8 +34,8 @@ namespace math {
 template <typename T_lower, typename T_upper, class RNG>
 inline typename VectorBuilder<true, int, T_lower, T_upper>::type
 discrete_range_rng(const T_lower& lower, const T_upper& upper, RNG& rng) {
-  using boost::variate_generator;
   using boost::random::uniform_int_distribution;
+  using boost::variate_generator;
 
   static const char* function = "discrete_range_rng";
 

--- a/stan/math/prim/prob/discrete_range_rng.hpp
+++ b/stan/math/prim/prob/discrete_range_rng.hpp
@@ -1,0 +1,65 @@
+#ifndef STAN_MATH_PRIM_PROB_DISCRETE_RANGE_RNG_HPP
+#define STAN_MATH_PRIM_PROB_DISCRETE_RANGE_RNG_HPP
+
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/err.hpp>
+#include <stan/math/prim/fun/max_size.hpp>
+#include <boost/random/uniform_int_distribution.hpp>
+#include <boost/random/variate_generator.hpp>
+
+namespace stan {
+namespace math {
+
+/** \ingroup prob_dists
+ * Return a discrete random variate for the given lower and upper bounds
+ * (inclusive) using the specified random number generator.
+ *
+ * `lower` and `upper` can each be a scalar or a one-dimensional container.
+ * Any non-scalar inputs must be the same size.
+ *
+ * @tparam T_lower type of lower bound
+ * @tparam T_upper type of upper bound
+ * @tparam RNG type of random number generator
+ *
+ * @param lower lower bound
+ * @param upper upper bound
+ * @param rng random number generator
+ * @return A (sequence of) discrete random variate(s) between `lower` and
+ * `upper`, both bounds included.
+ * @throw std::domain_error if lower or upper are non-finite, or if upper
+ * is smaller than lower
+ * @throw std::invalid_argument if non-scalar arguments are of different
+ * sizes
+ */
+template <typename T_lower, typename T_upper, class RNG>
+inline typename VectorBuilder<true, int, T_lower, T_upper>::type
+discrete_range_rng(const T_lower& lower, const T_upper& upper, RNG& rng) {
+  using boost::variate_generator;
+  using boost::random::uniform_int_distribution;
+
+  static const char* function = "discrete_range_rng";
+
+  check_finite(function, "Lower bound parameter", lower);
+  check_finite(function, "Upper bound parameter", upper);
+  check_consistent_sizes(function, "Lower bound parameter", lower,
+                         "Upper bound parameter", upper);
+  check_greater_or_equal(function, "Upper bound parameter", upper, lower);
+
+  scalar_seq_view<T_lower> lower_vec(lower);
+  scalar_seq_view<T_upper> upper_vec(upper);
+  size_t N = max_size(lower, upper);
+  VectorBuilder<true, int, T_lower, T_upper> output(N);
+
+  for (size_t n = 0; n < N; ++n) {
+    variate_generator<RNG&, uniform_int_distribution<>> discrete_range_rng(
+        rng, uniform_int_distribution<>(lower_vec[n], upper_vec[n]));
+
+    output[n] = discrete_range_rng();
+  }
+
+  return output.data();
+}
+
+}  // namespace math
+}  // namespace stan
+#endif

--- a/stan/math/prim/prob/discrete_range_rng.hpp
+++ b/stan/math/prim/prob/discrete_range_rng.hpp
@@ -11,25 +11,24 @@ namespace stan {
 namespace math {
 
 /** \ingroup prob_dists
- * Return a discrete random variate for the given lower and upper bounds
+ * Return an integer random variate between the given lower and upper bounds
  * (inclusive) using the specified random number generator.
  *
  * `lower` and `upper` can each be a scalar or a one-dimensional container.
  * Any non-scalar inputs must be the same size.
  *
- * @tparam T_lower type of lower bound
- * @tparam T_upper type of upper bound
+ * @tparam T_lower type of lower bound, either int or std::vector<int>
+ * @tparam T_upper type of upper bound, either int or std::vector<int>
  * @tparam RNG type of random number generator
  *
  * @param lower lower bound
  * @param upper upper bound
  * @param rng random number generator
- * @return A (sequence of) discrete random variate(s) between `lower` and
+ * @return A (sequence of) integer random variate(s) between `lower` and
  * `upper`, both bounds included.
- * @throw std::domain_error if lower or upper are non-finite, or if upper
- * is smaller than lower
+ * @throw std::domain_error if upper is smaller than lower.
  * @throw std::invalid_argument if non-scalar arguments are of different
- * sizes
+ * sizes.
  */
 template <typename T_lower, typename T_upper, class RNG>
 inline typename VectorBuilder<true, int, T_lower, T_upper>::type
@@ -39,8 +38,6 @@ discrete_range_rng(const T_lower& lower, const T_upper& upper, RNG& rng) {
 
   static const char* function = "discrete_range_rng";
 
-  check_finite(function, "Lower bound parameter", lower);
-  check_finite(function, "Upper bound parameter", upper);
   check_consistent_sizes(function, "Lower bound parameter", lower,
                          "Upper bound parameter", upper);
   check_greater_or_equal(function, "Upper bound parameter", upper, lower);

--- a/test/prob/discrete_range/discrete_range_test.hpp
+++ b/test/prob/discrete_range/discrete_range_test.hpp
@@ -3,7 +3,7 @@
 
 using std::vector;
 
-class AgradDistributionsHypergeometric : public AgradDistributionTest {
+class AgradDistributionsDiscreteRange : public AgradDistributionTest {
  public:
   void valid_values(vector<vector<double>>& parameters,
                     vector<double>& log_prob) {

--- a/test/prob/discrete_range/discrete_range_test.hpp
+++ b/test/prob/discrete_range/discrete_range_test.hpp
@@ -1,0 +1,62 @@
+// Arguments: Ints, Ints, Ints
+#include <stan/math/prim.hpp>
+
+using std::vector;
+
+class AgradDistributionsHypergeometric : public AgradDistributionTest {
+ public:
+  void valid_values(vector<vector<double>>& parameters,
+                    vector<double>& log_prob) {
+    vector<double> param(3);
+
+    param[0] = 3;   // y
+    param[1] = 1;   // lower
+    param[2] = 10;  // upper
+    parameters.push_back(param);
+    log_prob.push_back(-2.302585092994045901094);  // expected log_prob
+
+    // case for lower == upper
+    param[0] = 5;  // y
+    param[1] = 5;  // lower
+    param[2] = 5;  // upper
+    parameters.push_back(param);
+    log_prob.push_back(0);  // expected log_prob
+  }
+
+  void invalid_values(vector<size_t>& /*index*/, vector<double>& /*value*/) {
+    // y
+
+    // lower
+
+    // upper
+  }
+
+  template <class T_y, class T_lower, class T_upper, class T3, typename T4,
+            typename T5>
+  stan::return_type_t<T_y, T_lower, T_upper> log_prob(const T_y& y,
+                                                      const T_lower& lower,
+                                                      const T_upper& upper,
+                                                      const T3&, const T4&,
+                                                      const T5&) {
+    return stan::math::discrete_range_lpmf(y, lower, upper);
+  }
+
+  template <bool propto, class T_y, class T_lower, class T_upper, class T3,
+            typename T4, typename T5>
+  double log_prob(const T_y& y, const T_lower& lower, const T_upper& upper,
+                  const T3&, const T4&, const T5&) {
+    return stan::math::discrete_range_lpmf<propto>(y, lower, upper);
+  }
+
+  template <class T_y, class T_lower, class T_upper, class T3, typename T4,
+            typename T5>
+  double log_prob_function(const T_y& y, const T_lower& lower,
+                           const T_upper& upper, const T3&, const T4&,
+                           const T5&) {
+    if (y < lower || y > upper) {
+      return stan::math::LOG_ZERO;
+    }
+
+    return -log(upper - lower + 1);
+  }
+};

--- a/test/unit/math/prim/prob/discrete_range_log_test.cpp
+++ b/test/unit/math/prim/prob/discrete_range_log_test.cpp
@@ -1,0 +1,24 @@
+#include <stan/math/prim.hpp>
+#include <gtest/gtest.h>
+
+TEST(ProbDiscreteRange, log_matches_lpmf) {
+  int y = 3;
+  int lower = -2;
+  int upper = 5;
+
+  EXPECT_FLOAT_EQ((stan::math::discrete_range_lpmf(y, lower, upper)),
+                  (stan::math::discrete_range_log(y, lower, upper)));
+  EXPECT_FLOAT_EQ((stan::math::discrete_range_lpmf<true>(y, lower, upper)),
+                  (stan::math::discrete_range_log<true>(y, lower, upper)));
+  EXPECT_FLOAT_EQ((stan::math::discrete_range_lpmf<false>(y, lower, upper)),
+                  (stan::math::discrete_range_log<false>(y, lower, upper)));
+  EXPECT_FLOAT_EQ(
+      (stan::math::discrete_range_lpmf<true, int, int, int>(y, lower, upper)),
+      (stan::math::discrete_range_log<true, int, int, int>(y, lower, upper)));
+  EXPECT_FLOAT_EQ(
+      (stan::math::discrete_range_lpmf<false, int, int, int>(y, lower, upper)),
+      (stan::math::discrete_range_log<false, int, int, int>(y, lower, upper)));
+  EXPECT_FLOAT_EQ(
+      (stan::math::discrete_range_lpmf<int, int, int>(y, lower, upper)),
+      (stan::math::discrete_range_log<int, int, int>(y, lower, upper)));
+}

--- a/test/unit/math/prim/prob/discrete_range_test.cpp
+++ b/test/unit/math/prim/prob/discrete_range_test.cpp
@@ -1,0 +1,73 @@
+#include <stan/math/prim.hpp>
+#include <boost/math/distributions.hpp>
+#include <boost/random/mersenne_twister.hpp>
+#include <gtest/gtest.h>
+#include <limits>
+#include <vector>
+
+TEST(ProbDistributionsDiscreteRange, error_check) {
+  using stan::math::discrete_range_rng;
+  boost::random::mt19937 rng;
+
+  double nan = std::numeric_limits<double>::quiet_NaN();
+  double inf = std::numeric_limits<double>::infinity();
+
+  Eigen::VectorXd lower(3);
+  Eigen::VectorXd upper(3);
+
+  lower << 5.0, 11.0, -15.0;
+  upper << 5.0, 15.0, -10.0;
+  EXPECT_NO_THROW(discrete_range_rng(lower, upper, rng));
+  EXPECT_THROW(discrete_range_rng(lower, 10, rng), std::domain_error);
+  EXPECT_THROW(discrete_range_rng(10, upper, rng), std::domain_error);
+
+  lower << -1e3, 1.1e3, 1e4;
+  upper << -1e2, 1.2e3, 1e5;
+  EXPECT_NO_THROW(discrete_range_rng(lower, upper, rng));
+
+  EXPECT_THROW(discrete_range_rng(nan, upper, rng), std::domain_error);
+  EXPECT_THROW(discrete_range_rng(inf, upper, rng), std::domain_error);
+  EXPECT_THROW(discrete_range_rng(-inf, upper, rng), std::domain_error);
+  EXPECT_THROW(discrete_range_rng(lower, nan, rng), std::domain_error);
+  EXPECT_THROW(discrete_range_rng(lower, inf, rng), std::domain_error);
+  EXPECT_THROW(discrete_range_rng(lower, -inf, rng), std::domain_error);
+
+  Eigen::VectorXd vec2(2);
+  vec2 << 1, 2;
+  EXPECT_THROW(discrete_range_rng(lower, vec2, rng), std::invalid_argument);
+  EXPECT_THROW(discrete_range_rng(vec2, upper, rng), std::invalid_argument);
+}
+
+TEST(ProbDistributionsDiscreteRange, chiSquareGoodnessFitTest) {
+  boost::random::mt19937 rng;
+
+  int N = 10000;
+  int lower = -3;
+  int upper = 20;
+
+  int K = upper - lower + 1;
+  boost::math::chi_squared mydist(K - 1);
+
+  int bin[K];
+  double expect[K];
+  double prop = static_cast<double>(N) / K;
+  for (int i = 0; i < K; i++) {
+    bin[i] = 0;
+    expect[i] = prop;
+  }
+
+  int count = 0;
+  while (count < N) {
+    int a = stan::math::discrete_range_rng(lower, upper, rng);
+    bin[a - lower]++;
+    count++;
+  }
+
+  double chi = 0;
+
+  for (int j = 0; j < K; j++) {
+    chi += (bin[j] - expect[j]) * (bin[j] - expect[j]) / expect[j];
+  }
+
+  EXPECT_TRUE(chi < quantile(complement(mydist, 1e-6)));
+}


### PR DESCRIPTION
## Summary

This adds support for new functions `discrete_range_rng(lower, upper)` and `discrete_range_lpmf(y, lower, upper)`, which allow to return a random discrete uniform variate between lower an upper (both extremes inclusive) and its log PMF. Fixes #719.

## Tests

Added. As far as I understand, there's no need to enforce `lower` and `upper` to be integers or integer arrays here, as that will be done when we expose the signatures, so tests don't include the case for which the arguments are not integers.

## Side Effects

None.

## Checklist

- [X] Math issue #719

- [X] Copyright holder: Marco Colombo

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [X] the new changes are tested
