### PR TITLE
Check for consistent sizes before comparing arguments

### DIFF
--- a/stan/math/prim/prob/hypergeometric_lpmf.hpp
+++ b/stan/math/prim/prob/hypergeometric_lpmf.hpp
@@ -30,6 +30,9 @@ double hypergeometric_lpmf(const T_n& n, const T_N& N, const T_a& a,
 
   double logp(0.0);
   check_bounded(function, "Successes variable", n, 0, a);
+  check_consistent_sizes(function, "Successes variable", n, "Draws parameter",
+                         N, "Successes in population parameter", a,
+                         "Failures in population parameter", b);
   check_greater_or_equal(function, "Draws parameter", N, n);
   for (size_t i = 0; i < max_size_seq_view; i++) {
     check_bounded(function, "Draws parameter minus successes variable",
@@ -37,9 +40,6 @@ double hypergeometric_lpmf(const T_n& n, const T_N& N, const T_a& a,
     check_bounded(function, "Draws parameter", N_vec[i], 0,
                   a_vec[i] + b_vec[i]);
   }
-  check_consistent_sizes(function, "Successes variable", n, "Draws parameter",
-                         N, "Successes in population parameter", a,
-                         "Failures in population parameter", b);
 
   if (!include_summand<propto>::value) {
     return 0.0;

--- a/stan/math/prim/prob/pareto_type_2_cdf.hpp
+++ b/stan/math/prim/prob/pareto_type_2_cdf.hpp
@@ -28,13 +28,14 @@ return_type_t<T_y, T_loc, T_scale, T_shape> pareto_type_2_cdf(
 
   T_partials_return P(1.0);
 
-  check_greater_or_equal(function, "Random variable", y, mu);
   check_not_nan(function, "Random variable", y);
   check_nonnegative(function, "Random variable", y);
   check_positive_finite(function, "Scale parameter", lambda);
   check_positive_finite(function, "Shape parameter", alpha);
-  check_consistent_sizes(function, "Random variable", y, "Scale parameter",
-                         lambda, "Shape parameter", alpha);
+  check_consistent_sizes(function, "Random variable", y, "Location parameter",
+                         mu, "Scale parameter", lambda, "Shape parameter",
+                         alpha);
+  check_greater_or_equal(function, "Random variable", y, mu);
 
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_loc> mu_vec(mu);

--- a/stan/math/prim/prob/pareto_type_2_lccdf.hpp
+++ b/stan/math/prim/prob/pareto_type_2_lccdf.hpp
@@ -26,13 +26,14 @@ return_type_t<T_y, T_loc, T_scale, T_shape> pareto_type_2_lccdf(
 
   T_partials_return P(0.0);
 
-  check_greater_or_equal(function, "Random variable", y, mu);
   check_not_nan(function, "Random variable", y);
   check_nonnegative(function, "Random variable", y);
   check_positive_finite(function, "Scale parameter", lambda);
   check_positive_finite(function, "Shape parameter", alpha);
-  check_consistent_sizes(function, "Random variable", y, "Scale parameter",
-                         lambda, "Shape parameter", alpha);
+  check_consistent_sizes(function, "Random variable", y, "Location parameter",
+                         mu, "Scale parameter", lambda, "Shape parameter",
+                         alpha);
+  check_greater_or_equal(function, "Random variable", y, mu);
 
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_loc> mu_vec(mu);

--- a/stan/math/prim/prob/pareto_type_2_lcdf.hpp
+++ b/stan/math/prim/prob/pareto_type_2_lcdf.hpp
@@ -28,13 +28,14 @@ return_type_t<T_y, T_loc, T_scale, T_shape> pareto_type_2_lcdf(
 
   T_partials_return P(0.0);
 
-  check_greater_or_equal(function, "Random variable", y, mu);
   check_not_nan(function, "Random variable", y);
   check_nonnegative(function, "Random variable", y);
   check_positive_finite(function, "Scale parameter", lambda);
   check_positive_finite(function, "Shape parameter", alpha);
-  check_consistent_sizes(function, "Random variable", y, "Scale parameter",
-                         lambda, "Shape parameter", alpha);
+  check_consistent_sizes(function, "Random variable", y, "Location parameter",
+                         mu, "Scale parameter", lambda, "Shape parameter",
+                         alpha);
+  check_greater_or_equal(function, "Random variable", y, mu);
 
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_loc> mu_vec(mu);

--- a/stan/math/prim/prob/pareto_type_2_lpdf.hpp
+++ b/stan/math/prim/prob/pareto_type_2_lpdf.hpp
@@ -30,12 +30,13 @@ return_type_t<T_y, T_loc, T_scale, T_shape> pareto_type_2_lpdf(
 
   T_partials_return logp(0.0);
 
-  check_greater_or_equal(function, "Random variable", y, mu);
   check_not_nan(function, "Random variable", y);
   check_positive_finite(function, "Scale parameter", lambda);
   check_positive_finite(function, "Shape parameter", alpha);
-  check_consistent_sizes(function, "Random variable", y, "Scale parameter",
-                         lambda, "Shape parameter", alpha);
+  check_consistent_sizes(function, "Random variable", y, "Location parameter",
+                         mu, "Scale parameter", lambda, "Shape parameter",
+                         alpha);
+  check_greater_or_equal(function, "Random variable", y, mu);
 
   if (!include_summand<propto, T_y, T_loc, T_scale, T_shape>::value) {
     return 0.0;

--- a/stan/math/prim/prob/uniform_lpdf.hpp
+++ b/stan/math/prim/prob/uniform_lpdf.hpp
@@ -50,10 +50,10 @@ return_type_t<T_y, T_low, T_high> uniform_lpdf(const T_y& y, const T_low& alpha,
   check_not_nan(function, "Random variable", y);
   check_finite(function, "Lower bound parameter", alpha);
   check_finite(function, "Upper bound parameter", beta);
-  check_greater(function, "Upper bound parameter", beta, alpha);
   check_consistent_sizes(function, "Random variable", y,
                          "Lower bound parameter", alpha,
                          "Upper bound parameter", beta);
+  check_greater(function, "Upper bound parameter", beta, alpha);
 
   if (!include_summand<propto, T_y, T_low, T_high>::value) {
     return 0.0;


### PR DESCRIPTION
## Summary
This moves the `check_consistent_sizes` before other checks that involve looping over vectors. For the `pareto_type_2` functions, one of the function arguments was not being tested, so I've added it to the checks. Fixes #1681.

## Tests

No new tests.

## Side Effects

None.

## Checklist

- [X] Math issue #1681

- [X] Copyright holder: Marco Colombo

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [X] the new changes are tested
