### PR TITLE
Explicitly call stan::math::size (fix ambiguous call versus std::size)

### DIFF
--- a/stan/math/prim/err/check_consistent_size.hpp
+++ b/stan/math/prim/err/check_consistent_size.hpp
@@ -24,7 +24,7 @@ template <typename T>
 inline void check_consistent_size(const char* function, const char* name,
                                   const T& x, size_t expected_size) {
   if (!is_vector<T>::value
-      || (is_vector<T>::value && expected_size == size(x))) {
+      || (is_vector<T>::value && expected_size == stan::math::size(x))) {
     return;
   }
 
@@ -36,7 +36,7 @@ inline void check_consistent_size(const char* function, const char* name,
       << "multidimensional values of the same shape.";
   std::string msg_str(msg.str());
 
-  invalid_argument(function, name, size(x),
+  invalid_argument(function, name, stan::math::size(x),
                    "has dimension = ", msg_str.c_str());
 }
 

--- a/stan/math/prim/err/check_consistent_sizes.hpp
+++ b/stan/math/prim/err/check_consistent_sizes.hpp
@@ -26,8 +26,8 @@ template <typename T1, typename T2>
 inline void check_consistent_sizes(const char* function, const char* name1,
                                    const T1& x1, const char* name2,
                                    const T2& x2) {
-  size_t max_size = std::max(is_vector<T1>::value * size(x1),
-                             is_vector<T2>::value * size(x2));
+  size_t max_size = std::max(is_vector<T1>::value * stan::math::size(x1),
+                             is_vector<T2>::value * stan::math::size(x2));
   check_consistent_size(function, name1, x1, max_size);
   check_consistent_size(function, name2, x2, max_size);
 }
@@ -53,9 +53,10 @@ inline void check_consistent_sizes(const char* function, const char* name1,
                                    const T1& x1, const char* name2,
                                    const T2& x2, const char* name3,
                                    const T3& x3) {
-  size_t max_size = std::max(is_vector<T1>::value * size(x1),
-                             std::max(is_vector<T2>::value * size(x2),
-                                      is_vector<T3>::value * size(x3)));
+  size_t max_size
+      = std::max(is_vector<T1>::value * stan::math::size(x1),
+                 std::max(is_vector<T2>::value * stan::math::size(x2),
+                          is_vector<T3>::value * stan::math::size(x3)));
   check_consistent_size(function, name1, x1, max_size);
   check_consistent_size(function, name2, x2, max_size);
   check_consistent_size(function, name3, x3, max_size);
@@ -86,11 +87,11 @@ inline void check_consistent_sizes(const char* function, const char* name1,
                                    const T2& x2, const char* name3,
                                    const T3& x3, const char* name4,
                                    const T4& x4) {
-  size_t max_size
-      = std::max(is_vector<T1>::value * size(x1),
-                 std::max(is_vector<T2>::value * size(x2),
-                          std::max(is_vector<T3>::value * size(x3),
-                                   is_vector<T4>::value * size(x4))));
+  size_t max_size = std::max(
+      is_vector<T1>::value * stan::math::size(x1),
+      std::max(is_vector<T2>::value * stan::math::size(x2),
+               std::max(is_vector<T3>::value * stan::math::size(x3),
+                        is_vector<T4>::value * stan::math::size(x4))));
   check_consistent_size(function, name1, x1, max_size);
   check_consistent_size(function, name2, x2, max_size);
   check_consistent_size(function, name3, x3, max_size);
@@ -104,8 +105,10 @@ inline void check_consistent_sizes(const char* function, const char* name1,
                                    const T4& x4, const char* name5,
                                    const T5& x5) {
   size_t max_size = std::max(
-      size(x1),
-      std::max(size(x2), std::max(size(x3), std::max(size(x4), size(x5)))));
+      stan::math::size(x1),
+      std::max(stan::math::size(x2),
+               std::max(stan::math::size(x3),
+                        std::max(stan::math::size(x4), stan::math::size(x5)))));
   check_consistent_size(function, name1, x1, max_size);
   check_consistent_size(function, name2, x2, max_size);
   check_consistent_size(function, name3, x3, max_size);


### PR DESCRIPTION

## Summary

I'm getting ambiguous call errors when compiling `stan/math/prim/err/check_consistent_size.hpp` and `stan/math/prim/err/check_consistent_sizes.hpp` using a very recent LLVM clang and libc++

    $ .../bin/clang++ --version
    clang version 11.0.0 (https://github.com/llvm/llvm-project.git 8acedb595d039f68ad15f9e5f2e6cb79729307e4)
    Target: x86_64-apple-darwin19.3.0
    Thread model: posix

Explicitly calling `stan::math::size` seems both the intended behavior as well as solving the issue.

## Tests

N/A

## Side Effects

Shouldn't be any.

## Checklist

- [ ] Math issue #(issue number)

I did not create an issue.

- [x] Copyright holder: (fill in copyright holder information)

Tal Kedar

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
