### PR TITLE
Allow multiply for size 0 inputs

### DIFF
--- a/stan/math/fwd/fun/multiply.hpp
+++ b/stan/math/fwd/fun/multiply.hpp
@@ -59,7 +59,8 @@ template <typename T, int R1, int C1, int R2, int C2>
 inline Eigen::Matrix<fvar<T>, R1, C2> multiply(
     const Eigen::Matrix<fvar<T>, R1, C1>& m1,
     const Eigen::Matrix<fvar<T>, R2, C2>& m2) {
-  check_multiplicable("multiply", "m1", m1, "m2", m2);
+  check_size_match("multiply", "Columns of m1", m1.cols(), "Rows of m2",
+                   m2.rows());
   Eigen::Matrix<fvar<T>, R1, C2> result(m1.rows(), m2.cols());
   for (size_type i = 0; i < m1.rows(); i++) {
     Eigen::Matrix<fvar<T>, 1, C1> crow = m1.row(i);
@@ -75,7 +76,8 @@ template <typename T, int R1, int C1, int R2, int C2>
 inline Eigen::Matrix<fvar<T>, R1, C2> multiply(
     const Eigen::Matrix<fvar<T>, R1, C1>& m1,
     const Eigen::Matrix<double, R2, C2>& m2) {
-  check_multiplicable("multiply", "m1", m1, "m2", m2);
+  check_size_match("multiply", "Columns of m1", m1.cols(), "Rows of m2",
+                   m2.rows());
   Eigen::Matrix<fvar<T>, R1, C2> result(m1.rows(), m2.cols());
   for (size_type i = 0; i < m1.rows(); i++) {
     Eigen::Matrix<fvar<T>, 1, C1> crow = m1.row(i);
@@ -91,7 +93,8 @@ template <typename T, int R1, int C1, int R2, int C2>
 inline Eigen::Matrix<fvar<T>, R1, C2> multiply(
     const Eigen::Matrix<double, R1, C1>& m1,
     const Eigen::Matrix<fvar<T>, R2, C2>& m2) {
-  check_multiplicable("multiply", "m1", m1, "m2", m2);
+  check_size_match("multiply", "Columns of m1", m1.cols(), "Rows of m2",
+                   m2.rows());
   Eigen::Matrix<fvar<T>, R1, C2> result(m1.rows(), m2.cols());
   for (size_type i = 0; i < m1.rows(); i++) {
     Eigen::Matrix<double, 1, C1> crow = m1.row(i);
@@ -106,21 +109,22 @@ inline Eigen::Matrix<fvar<T>, R1, C2> multiply(
 template <typename T, int C1, int R2>
 inline fvar<T> multiply(const Eigen::Matrix<fvar<T>, 1, C1>& rv,
                         const Eigen::Matrix<fvar<T>, R2, 1>& v) {
-  check_multiplicable("multiply", "rv", rv, "v", v);
+  check_matching_sizes("multiply", "rv", rv, "v", v);
   return dot_product(rv, v);
 }
 
 template <typename T, int C1, int R2>
 inline fvar<T> multiply(const Eigen::Matrix<fvar<T>, 1, C1>& rv,
                         const Eigen::Matrix<double, R2, 1>& v) {
-  check_multiplicable("multiply", "rv", rv, "v", v);
+  check_matching_sizes("multiply", "rv", rv, "v", v);
   return dot_product(rv, v);
 }
 
 template <typename T, int C1, int R2>
 inline fvar<T> multiply(const Eigen::Matrix<double, 1, C1>& rv,
                         const Eigen::Matrix<fvar<T>, R2, 1>& v) {
-  check_multiplicable("multiply", "rv", rv, "v", v);
+  check_matching_sizes("multiply", "rv", rv, "v", v);
+
   return dot_product(rv, v);
 }
 

--- a/stan/math/prim/fun/multiply.hpp
+++ b/stan/math/prim/fun/multiply.hpp
@@ -72,7 +72,8 @@ template <int R1, int C1, int R2, int C2, typename T1, typename T2,
           typename = require_all_arithmetic_t<T1, T2>>
 inline Eigen::Matrix<return_type_t<T1, T2>, R1, C2> multiply(
     const Eigen::Matrix<T1, R1, C1>& m1, const Eigen::Matrix<T2, R2, C2>& m2) {
-  check_multiplicable("multiply", "m1", m1, "m2", m2);
+  check_size_match("multiply", "Columns of m1", m1.cols(), "Rows of m2",
+                   m2.rows());
 #ifdef STAN_OPENCL
   if (m1.rows() * m1.cols() * m2.cols()
       > opencl_context.tuning_opts().multiply_dim_prod_worth_transfer) {

--- a/stan/math/rev/fun/multiply.hpp
+++ b/stan/math/rev/fun/multiply.hpp
@@ -673,7 +673,7 @@ template <typename Ta, int Ra, int Ca, typename Tb, int Cb,
           typename = require_any_var_t<Ta, Tb>>
 inline Eigen::Matrix<var, Ra, Cb> multiply(const Eigen::Matrix<Ta, Ra, Ca>& A,
                                            const Eigen::Matrix<Tb, Ca, Cb>& B) {
-  check_multiplicable("multiply", "A", A, "B", B);
+  check_size_match("multiply", "Columns of A", A.cols(), "Rows of B", B.rows());
   check_not_nan("multiply", "A", A);
   check_not_nan("multiply", "B", B);
 
@@ -703,7 +703,7 @@ template <typename Ta, int Ca, typename Tb,
           typename = require_any_var_t<Ta, Tb>>
 inline var multiply(const Eigen::Matrix<Ta, 1, Ca>& A,
                     const Eigen::Matrix<Tb, Ca, 1>& B) {
-  check_multiplicable("multiply", "A", A, "B", B);
+  check_matching_sizes("multiply", "A", A, "B", B);
   check_not_nan("multiply", "A", A);
   check_not_nan("multiply", "B", B);
 

--- a/test/unit/math/mix/fun/multiply_test.cpp
+++ b/test/unit/math/mix/fun/multiply_test.cpp
@@ -37,6 +37,8 @@ TEST(mathMixMatFun, multiply) {
   stan::test::expect_ad(f, a, m00);
   stan::test::expect_ad(f, m00, a);
   stan::test::expect_ad(f, m00, v0);
+  stan::test::expect_ad(f, rv0, v0);
+  stan::test::expect_ad(f, v0, rv0);
   stan::test::expect_ad(f, rv0, m00);
   stan::test::expect_ad(f, m00, m00);
 
@@ -76,24 +78,6 @@ TEST(mathMixMatFun, multiply) {
   stan::test::expect_ad(tols, f, u_tr, u);
   stan::test::expect_ad(tols, f, u, vv);
   stan::test::expect_ad(tols, f, rvv, u);
-
-  // TODO(carpenter):  multiplying by size zero should return size zero
-  // the functions need to be fixed then the following will pass
-
-  // Eigen::VectorXd v0(0);
-  // Eigen::RowVectorXd rv0(0);
-  // Eigen::MatrixXd m00(0, 0);
-  // stan::test::expect_ad(tols, f, a, v0);
-  // stan::test::expect_ad(tols, f, v0, a);
-  // stan::test::expect_ad(tols, f, a, rv0);
-  // stan::test::expect_ad(tols, f, rv0, a);
-  // stan::test::expect_ad(tols, f, rv0, v0);
-  // stan::test::expect_ad(tols, f, v0, rv0);
-  // stan::test::expect_ad(tols, f, a, m00);
-  // stan::test::expect_ad(tols, f, m00, a);
-  // stan::test::expect_ad(tols, f, m00, v0);
-  // stan::test::expect_ad(tols, f, rv0, m00);
-  // stan::test::expect_ad(tols, f, m00, m00);
 
   // exception cases
   // can't compile mismatched dimensions, so no tests

--- a/test/unit/math/prim/fun/multiply_test.cpp
+++ b/test/unit/math/prim/fun/multiply_test.cpp
@@ -1,7 +1,7 @@
 #include <stan/math/prim.hpp>
 #include <gtest/gtest.h>
 
-TEST(MathMatrixPrimMat, multiply_c_v) {
+TEST(MathMatrixPrim, multiply_c_v) {
   stan::math::vector_d v(3);
   v << 1, 2, 3;
   stan::math::vector_d result = stan::math::multiply(2.0, v);
@@ -9,7 +9,7 @@ TEST(MathMatrixPrimMat, multiply_c_v) {
   EXPECT_FLOAT_EQ(4.0, result(1));
   EXPECT_FLOAT_EQ(6.0, result(2));
 }
-TEST(MathMatrixPrimMat, multiply_c_rv) {
+TEST(MathMatrixPrim, multiply_c_rv) {
   stan::math::row_vector_d rv(3);
   rv << 1, 2, 3;
   stan::math::row_vector_d result = stan::math::multiply(2.0, rv);
@@ -17,7 +17,7 @@ TEST(MathMatrixPrimMat, multiply_c_rv) {
   EXPECT_FLOAT_EQ(4.0, result(1));
   EXPECT_FLOAT_EQ(6.0, result(2));
 }
-TEST(MathMatrixPrimMat, multiply_c_m) {
+TEST(MathMatrixPrim, multiply_c_m) {
   stan::math::matrix_d m(2, 3);
   m << 1, 2, 3, 4, 5, 6;
   stan::math::matrix_d result = stan::math::multiply(2.0, m);
@@ -29,7 +29,45 @@ TEST(MathMatrixPrimMat, multiply_c_m) {
   EXPECT_FLOAT_EQ(12.0, result(1, 2));
 }
 
-TEST(MathMatrixPrimMat, multiply_rv_v_exception) {
+TEST(MathMatrixPrim, multiply_size_zero) {
+  stan::math::matrix_d m1, m2, res;
+  stan::math::vector_d v;
+  stan::math::row_vector_d rv;
+
+  rv.resize(0);
+  v.resize(0);
+  EXPECT_NO_THROW(stan::math::multiply(rv, v));
+  EXPECT_NO_THROW(stan::math::multiply(v, rv));
+  EXPECT_NO_THROW(stan::math::multiply(3, v));
+  EXPECT_NO_THROW(stan::math::multiply(v, 3));
+  EXPECT_NO_THROW(stan::math::multiply(3, rv));
+  EXPECT_NO_THROW(stan::math::multiply(rv, 3));
+
+  m1.resize(3, 0);
+  v.resize(0);
+  res = stan::math::multiply(m1, v);
+  EXPECT_EQ(m1.rows(), res.rows());
+  EXPECT_EQ(v.cols(), res.cols());
+
+  rv.resize(0);
+  m2.resize(0, 3);
+  res = stan::math::multiply(rv, m2);
+  EXPECT_EQ(rv.rows(), res.rows());
+  EXPECT_EQ(m2.cols(), res.cols());
+
+  m1.resize(2, 0);
+  m2.resize(0, 3);
+  res = stan::math::multiply(m1, m2);
+  EXPECT_EQ(m1.rows(), res.rows());
+  EXPECT_EQ(m2.cols(), res.cols());
+
+  EXPECT_NO_THROW(stan::math::multiply(m1, 3));
+  EXPECT_NO_THROW(stan::math::multiply(m2, 3));
+  EXPECT_NO_THROW(stan::math::multiply(3, m1));
+  EXPECT_NO_THROW(stan::math::multiply(3, m2));
+}
+
+TEST(MathMatrixPrim, multiply_rv_v_exception) {
   stan::math::row_vector_d rv;
   stan::math::vector_d v;
 
@@ -37,15 +75,11 @@ TEST(MathMatrixPrimMat, multiply_rv_v_exception) {
   v.resize(3);
   EXPECT_NO_THROW(stan::math::multiply(rv, v));
 
-  rv.resize(0);
-  v.resize(0);
-  EXPECT_NO_THROW(stan::math::multiply(rv, v));
-
   rv.resize(2);
   v.resize(3);
   EXPECT_THROW(stan::math::multiply(rv, v), std::invalid_argument);
 }
-TEST(MathMatrixPrimMat, multiply_m_v_exception) {
+TEST(MathMatrixPrim, multiply_m_v_exception) {
   stan::math::matrix_d m;
   stan::math::vector_d v;
 
@@ -53,15 +87,11 @@ TEST(MathMatrixPrimMat, multiply_m_v_exception) {
   v.resize(5);
   EXPECT_NO_THROW(stan::math::multiply(m, v));
 
-  m.resize(3, 0);
-  v.resize(0);
-  EXPECT_THROW(stan::math::multiply(m, v), std::invalid_argument);
-
   m.resize(2, 3);
   v.resize(2);
   EXPECT_THROW(stan::math::multiply(m, v), std::invalid_argument);
 }
-TEST(MathMatrixPrimMat, multiply_rv_m_exception) {
+TEST(MathMatrixPrim, multiply_rv_m_exception) {
   stan::math::row_vector_d rv;
   stan::math::matrix_d m;
 
@@ -69,31 +99,23 @@ TEST(MathMatrixPrimMat, multiply_rv_m_exception) {
   m.resize(3, 5);
   EXPECT_NO_THROW(stan::math::multiply(rv, m));
 
-  rv.resize(0);
-  m.resize(0, 3);
-  EXPECT_THROW(stan::math::multiply(rv, m), std::invalid_argument);
-
   rv.resize(3);
   m.resize(2, 3);
   EXPECT_THROW(stan::math::multiply(rv, m), std::invalid_argument);
 }
-TEST(MathMatrixPrimMat, multiply_m_m_exception) {
+TEST(MathMatrixPrim, multiply_m_m_exception) {
   stan::math::matrix_d m1, m2;
 
   m1.resize(1, 3);
   m2.resize(3, 5);
   EXPECT_NO_THROW(stan::math::multiply(m1, m2));
 
-  m1.resize(2, 0);
-  m2.resize(0, 3);
-  EXPECT_THROW(stan::math::multiply(m1, m2), std::invalid_argument);
-
   m1.resize(4, 3);
   m2.resize(2, 3);
   EXPECT_THROW(stan::math::multiply(m1, m2), std::invalid_argument);
 }
 
-TEST(MathMatrixPrimMat, multiply) {
+TEST(MathMatrixPrim, multiply) {
   stan::math::vector_d v0;
   stan::math::row_vector_d rv0;
   stan::math::matrix_d m0;
@@ -107,7 +129,7 @@ TEST(MathMatrixPrimMat, multiply) {
   EXPECT_NO_THROW(multiply(2.0, m0));
 }
 
-TEST(MathMatrixPrimMat, multiply_int) {
+TEST(MathMatrixPrim, multiply_int) {
   using stan::math::assign;
   using stan::math::multiply;
 
@@ -120,7 +142,7 @@ TEST(MathMatrixPrimMat, multiply_int) {
   assign(t_vec, multiply(vec, d_int));
 }
 
-TEST(MathMatrixPrimMat, multiply_vector_int) {
+TEST(MathMatrixPrim, multiply_vector_int) {
   using stan::math::multiply;
   using stan::math::vector_d;
 
@@ -139,7 +161,7 @@ TEST(MathMatrixPrimMat, multiply_vector_int) {
   for (int i = 0; i < A.size(); i++)    \
     EXPECT_NEAR(A(i), B(i), DELTA);
 
-TEST(MathMatrixPrimMat, multiply_opencl) {
+TEST(MathMatrixPrim, multiply_opencl) {
   int multiply_dim_prod_worth_transfer
       = stan::math::opencl_context.tuning_opts()
             .multiply_dim_prod_worth_transfer;


### PR DESCRIPTION
## Summary

This is a minimal set of changes to allow calling `multiply` even when any of the inputs has a size 0 dimension. Given that the current `check_multiplicable` enforces positive sizes, we replace it with `check_size_match` when checking if matrix dimensions are compatible, and `check_matching_sizes` when checking that two vectors have the same length.

## Tests

Changed some `EXPECT_THROW` to `EXPECT_NO_THROW` and added tests that the resulting matrix has the correct dimension. There were already mix tests for size 0 inputs, I've expanded them a bit (and removed the commented out set of tests, since they were already running in an earlier block).

## Side Effects

None.

## Checklist

- [X] Math issue #1669

- [X] Copyright holder: Marco Colombo

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [X] the new changes are tested
