### PR TITLE
Add positive definite checks to mdivide_left_spd

### DIFF
--- a/stan/math/rev/fun/mdivide_left_spd.hpp
+++ b/stan/math/rev/fun/mdivide_left_spd.hpp
@@ -147,6 +147,7 @@ inline Eigen::Matrix<var, R1, C2> mdivide_left_spd(
 
   check_square("mdivide_left_spd", "A", A);
   check_multiplicable("mdivide_left_spd", "A", A, "b", b);
+  check_pos_definite("mdivide_left_spd", "A", A);
 
   // NOTE: this is not a memory leak, this vari is used in the
   // expression graph to evaluate the adjoint, but is not needed
@@ -167,6 +168,7 @@ inline Eigen::Matrix<var, R1, C2> mdivide_left_spd(
 
   check_square("mdivide_left_spd", "A", A);
   check_multiplicable("mdivide_left_spd", "A", A, "b", b);
+  check_pos_definite("mdivide_left_spd", "A", A);
 
   // NOTE: this is not a memory leak, this vari is used in the
   // expression graph to evaluate the adjoint, but is not needed
@@ -187,6 +189,7 @@ inline Eigen::Matrix<var, R1, C2> mdivide_left_spd(
 
   check_square("mdivide_left_spd", "A", A);
   check_multiplicable("mdivide_left_spd", "A", A, "b", b);
+  check_pos_definite("mdivide_left_spd", "A", A);
 
   // NOTE: this is not a memory leak, this vari is used in the
   // expression graph to evaluate the adjoint, but is not needed

--- a/test/unit/math/mix/fun/mdivide_left_spd_test.cpp
+++ b/test/unit/math/mix/fun/mdivide_left_spd_test.cpp
@@ -59,10 +59,9 @@ TEST(MathMixMatFun, mdivideLeftSpd) {
   stan::test::expect_ad(f, c, a);
   stan::test::expect_ad(f, c, d);
 
-  // FIXME(carpenter): double throws (correct) but var doesn't (incorrect)
   // exceptions: not pos def
-  // stan::test::expect_ad(f, m33, m33);
-  // stan::test::expect_ad(f, m33, v3);
+  stan::test::expect_ad(f, m33, m33);
+  stan::test::expect_ad(f, m33, v3);
 
   // exceptions: wrong sizes
   stan::test::expect_ad(f, m33, m44);

--- a/test/unit/math/mix/fun/mdivide_right_spd_test.cpp
+++ b/test/unit/math/mix/fun/mdivide_right_spd_test.cpp
@@ -53,6 +53,7 @@ TEST(MathMixMatFun, mdivideRightSpd) {
   Eigen::MatrixXd m33 = Eigen::MatrixXd::Zero(3, 3);
   Eigen::MatrixXd m44 = Eigen::MatrixXd::Zero(4, 4);
   Eigen::VectorXd v3 = Eigen::VectorXd::Zero(3);
+  Eigen::RowVectorXd rv3 = Eigen::RowVectorXd::Zero(3);
   Eigen::RowVectorXd rv4 = Eigen::RowVectorXd::Zero(4);
 
   // exceptions: wrong sizes
@@ -62,8 +63,7 @@ TEST(MathMixMatFun, mdivideRightSpd) {
   // exceptions: wrong types
   stan::test::expect_ad(f, v3, m33);
 
-  // FIXME(carpenter): double throws (correct) but var doesn't (incorrect)
   // exceptions: not pos def
-  // stan::test::expect_ad(f, m33, m33);
-  // stan::test::expect_ad(f, m33, v3);
+  stan::test::expect_ad(f, m33, m33);
+  stan::test::expect_ad(f, rv3, m33);
 }


### PR DESCRIPTION
## Summary

This makes `mdivide_left_spd` throw if the argument is not a positive definite matrix. Fixes #1687.

## Tests
There were already tests commented out for this, so I only had to uncomment them.

## Side Effects

None.

## Checklist

- [X] Math issue #1687

- [X] Copyright holder: Marco Colombo

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [X] the new changes are tested
