### PR TITLE
[WIP] Refactor var ops to use one op_vari class instead of multiple classes

### DIFF
--- a/stan/math/opencl/rev/matrix_cl.hpp
+++ b/stan/math/opencl/rev/matrix_cl.hpp
@@ -28,11 +28,11 @@ class matrix_cl<T, require_var_t<T>> {
    */
   const int rows_;
   const int cols_;
-  mutable matrix_cl<double> val_;
-  mutable matrix_cl<double> adj_;
   matrix_cl_view view_{matrix_cl_view::Entire};
 
  public:
+  mutable matrix_cl<double> val_;
+  mutable matrix_cl<double> adj_;
   using Scalar = T;
   using type = T;
   inline int rows() const { return rows_; }

--- a/stan/math/rev/core.hpp
+++ b/stan/math/rev/core.hpp
@@ -16,6 +16,7 @@
 #include <stan/math/rev/core/grad.hpp>
 #include <stan/math/rev/core/matrix_vari.hpp>
 #include <stan/math/rev/core/nested_size.hpp>
+#include <stan/math/rev/core/op_vari.hpp>
 #include <stan/math/rev/core/operator_addition.hpp>
 #include <stan/math/rev/core/operator_divide_equal.hpp>
 #include <stan/math/rev/core/operator_division.hpp>

--- a/stan/math/rev/core/op_vari.hpp
+++ b/stan/math/rev/core/op_vari.hpp
@@ -1,0 +1,26 @@
+#ifndef STAN_MATH_REV_CORE_OP_VARI_HPP
+#define STAN_MATH_REV_CORE_OP_VARI_HPP
+
+#include <stan/math/rev/core/vari.hpp>
+#include <tuple>
+
+namespace stan {
+namespace math {
+
+template <typename... Types>
+class op_vari : public vari {
+ protected:
+    std::tuple<Types...> vi_;
+ public:
+   template <std::size_t Ind>
+   auto& get() {
+     return std::get<Ind>(vi_);
+   }
+
+  op_vari(double f, Types... args)
+      : vari(f), vi_(std::make_tuple(args...)) {}
+};
+
+}  // namespace math
+}  // namespace stan
+#endif

--- a/stan/math/rev/core/op_vari.hpp
+++ b/stan/math/rev/core/op_vari.hpp
@@ -18,6 +18,7 @@ class op_vari : public vari {
  protected:
     std::tuple<Types...> vi_; // Holds the objects needed in the reverse pass.
  public:
+   
    /**
     * Get an element from the tuple of vari ops. Because of name lookup rules
     *  this function needs to be called as \c this->template get<N>()

--- a/stan/math/rev/core/op_vari.hpp
+++ b/stan/math/rev/core/op_vari.hpp
@@ -17,8 +17,9 @@ template <typename... Types>
 class op_vari : public vari {
  protected:
   std::tuple<Types...> vi_;  // Holds the objects needed in the reverse pass.
+  
  public:
-   
+
   /**
    * Get an element from the tuple of vari ops. Because of name lookup rules
    *  this function needs to be called as \c this->template get<N>()

--- a/stan/math/rev/core/op_vari.hpp
+++ b/stan/math/rev/core/op_vari.hpp
@@ -7,18 +7,44 @@
 namespace stan {
 namespace math {
 
+/**
+ * Holds the elements needed in vari operations for the reverse pass and chain
+ * call.
+ *
+ * @tparam Types The types of the operation.
+ */
 template <typename... Types>
 class op_vari : public vari {
  protected:
-    std::tuple<Types...> vi_;
+    std::tuple<Types...> vi_; // Holds the objects needed in the reverse pass.
  public:
+   /**
+    * Get an element from the tuple of vari ops. Because of name lookup rules
+    *  this function needs to be called as \c this->template get<N>()
+    * @tparam Ind The index of the tuple to retrieve.
+    * @return the element inside of the tuple at index Ind.
+    */
    template <std::size_t Ind>
    auto& get() {
      return std::get<Ind>(vi_);
    }
 
-  op_vari(double f, Types... args)
-      : vari(f), vi_(std::make_tuple(args...)) {}
+   /**
+    * Return a reference to the tuple holding the vari ops. This is commonly
+    *  used in conjunction with \c std::get<N>()
+    * @return The tuple holding the vari ops.
+    */
+   auto& vi() {
+     return vi_;
+   }
+
+  /**
+   * Constructor for passing in vari and ops objects.
+   * @param val Value to initialize the vari to.
+   * @param args Ops passed into the tuple and used later in chain method.
+   */
+  op_vari(double val, Types... args)
+      : vari(val), vi_(std::make_tuple(args...)) {}
 };
 
 }  // namespace math

--- a/stan/math/rev/core/op_vari.hpp
+++ b/stan/math/rev/core/op_vari.hpp
@@ -19,7 +19,6 @@ class op_vari : public vari {
   std::tuple<Types...> vi_;  // Holds the objects needed in the reverse pass.
 
  public:
-   
   /**
    * Get an element from the tuple of vari ops. Because of name lookup rules
    *  this function needs to be called as \c this->template get<N>()

--- a/stan/math/rev/core/operator_addition.hpp
+++ b/stan/math/rev/core/operator_addition.hpp
@@ -145,6 +145,7 @@ inline var operator+(Arith a, var b) {
                                                           a)};  // by symmetry
 }
 
+
 }  // namespace math
 }  // namespace stan
 #endif

--- a/stan/math/rev/core/operator_addition.hpp
+++ b/stan/math/rev/core/operator_addition.hpp
@@ -145,7 +145,6 @@ inline var operator+(Arith a, var b) {
                                                           a)};  // by symmetry
 }
 
-
 }  // namespace math
 }  // namespace stan
 #endif

--- a/stan/math/rev/core/operator_plus_equal.hpp
+++ b/stan/math/rev/core/operator_plus_equal.hpp
@@ -9,7 +9,7 @@ namespace stan {
 namespace math {
 
 inline var& var::operator+=(var b) {
-  vi_ = new internal::add_vv_vari(vi_, b.vi_);
+  vi_ = new internal::add_vv_vari<vari*, vari*>(vi_, b.vi_);
   return *this;
 }
 

--- a/stan/math/rev/core/operator_plus_equal.hpp
+++ b/stan/math/rev/core/operator_plus_equal.hpp
@@ -9,7 +9,7 @@ namespace stan {
 namespace math {
 
 inline var& var::operator+=(var b) {
-  vi_ = new internal::add_vv_vari<vari*, vari*>(vi_, b.vi_);
+  vi_ = new internal::add_vari<vari*, vari*>(vi_, b.vi_);
   return *this;
 }
 
@@ -18,7 +18,7 @@ inline var& var::operator+=(Arith b) {
   if (b == 0.0) {
     return *this;
   }
-  vi_ = new internal::add_vd_vari(vi_, b);
+  vi_ = new internal::add_vari<vari*, double>(vi_, b);
   return *this;
 }
 


### PR DESCRIPTION
## Summary

Related to #1639 in that I'm trying to figure out how to use `matrix_cl<var>` types to push parts of the autodiff stack onto the gpu. It's not totally clear to me yet but I think the first step is making the vari operations more generic. 

For adding two vars, this PR uses a new class called `op_vari` that stores all of the objects needed for the reverse pass's `chain()` call into a tuple. This means we can remove all the specializations like `vv_vari`, `vd_vari`, `vvv_vari`, etc. The classes `add_vv_vari` and `add_vd_vari` have been replaced with a templated `add_vari` with specializations for the case of both inputs being `vari` and one input being a double.  This also adds an `is_vari` struct that checks if an input class is derived from a `vari`.

I think with the code here we can start thinking about how to call 

```cpp
add_vari<matrix_cl<var>, matrix_cl<var>>(a, b);
```

and what that should do. Though it's a separate issue than what this PR does, it is the intent

I'll review inline which pieces of the code I don't like or at least think can be improved.

This is just for adding with var types, then when we think this looks good enough we can add it for the rest of the operators.

## Tests

atm there are no new tests, but I will move the tests for `vv_vari` etc. into one test for `op_vari`

## Side Effects

Almost surely. The biggest things for devs are

1. Accessing the elements in the tuple for the reverse mode. We now have to access them either via `std::get<Ind>(this->vi())` or `this->template get<Ind>()` where `Ind` is a `size_t`. Tbh I don't enjoy either of how those look. Though I'm not sure if there are other alternatives.

2. Because the classes that hold the chain method for var operators are now templated we have to call `internal::add_vari<vari*, vari*>(a.vi_, b.vi_)}` instead of `internal::add_vv_vari(a.vi_, b.vi_)}`, etc.

## Checklist

- [x] Math issue #1639

- [x] Copyright holder: Steve Bronder

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [ ] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [ ] the new changes are tested
