### PR TITLE
Improve tests and documentation for quad_form and quad_form_sym

### DIFF
--- a/stan/math/fwd/fun.hpp
+++ b/stan/math/fwd/fun.hpp
@@ -92,6 +92,7 @@
 #include <stan/math/fwd/fun/primitive_value.hpp>
 #include <stan/math/fwd/fun/qr_Q.hpp>
 #include <stan/math/fwd/fun/qr_R.hpp>
+#include <stan/math/fwd/fun/quad_form.hpp>
 #include <stan/math/fwd/fun/quad_form_sym.hpp>
 #include <stan/math/fwd/fun/rising_factorial.hpp>
 #include <stan/math/fwd/fun/round.hpp>

--- a/stan/math/fwd/fun/quad_form.hpp
+++ b/stan/math/fwd/fun/quad_form.hpp
@@ -9,7 +9,10 @@ namespace stan {
 namespace math {
 
 /**
- * Compute the quadratic form B^T A B.
+ * Return the quadratic form \f$ B^T A B \f$.
+ *
+ * Symmetry of the resulting matrix is not guaranteed due to numerical
+ * precision.
  *
  * @tparam Ta type of elements in the square matrix
  * @tparam Ra number of rows in the square matrix, can be Eigen::Dynamic
@@ -20,8 +23,7 @@ namespace math {
  *
  * @param A square matrix
  * @param B second matrix
- * @return The quadratic form B^T A B, which is a symmetric matrix of size Cb
- * (although symmetry is not guaranteed due to numerical precision).
+ * @return The quadratic form, which is a symmetric matrix of size Cb.
  * @throws std::invalid_argument if A is not square, or if A cannot be
  * multiplied by B
  */
@@ -35,7 +37,7 @@ inline Eigen::Matrix<return_type_t<Ta, Tb>, Cb, Cb> quad_form(
 }
 
 /**
- * Compute the quadratic form B^T A B.
+ * Return the quadratic form \f$ B^T A B \f$.
  *
  * @tparam Ta type of elements in the square matrix
  * @tparam Ra number of rows in the square matrix, can be Eigen::Dynamic
@@ -45,7 +47,7 @@ inline Eigen::Matrix<return_type_t<Ta, Tb>, Cb, Cb> quad_form(
  *
  * @param A square matrix
  * @param B vector
- * @return The quadratic form B^T A B, which is a scalar.
+ * @return The quadratic form (a scalar).
  * @throws std::invalid_argument if A is not square, or if A cannot be
  * multiplied by B
  */

--- a/stan/math/fwd/fun/quad_form.hpp
+++ b/stan/math/fwd/fun/quad_form.hpp
@@ -1,0 +1,64 @@
+#ifndef STAN_MATH_FWD_FUN_QUAD_FORM_HPP
+#define STAN_MATH_FWD_FUN_QUAD_FORM_HPP
+
+#include <stan/math/fwd/core.hpp>
+#include <stan/math/fwd/fun/dot_product.hpp>
+#include <stan/math/fwd/fun/multiply.hpp>
+
+namespace stan {
+namespace math {
+
+/**
+ * Compute the quadratic form B^T A B.
+ *
+ * @tparam Ta type of elements in the square matrix
+ * @tparam Ra number of rows in the square matrix, can be Eigen::Dynamic
+ * @tparam Ca number of columns in the square matrix, can be Eigen::Dynamic
+ * @tparam Tb type of elements in the second matrix
+ * @tparam Rb number of rows in the second matrix, can be Eigen::Dynamic
+ * @tparam Cb number of columns in the second matrix, can be Eigen::Dynamic
+ *
+ * @param A square matrix
+ * @param B second matrix
+ * @return The quadratic form B^T A B, which is a symmetric matrix of size Cb
+ * (although symmetry is not guaranteed due to numerical precision).
+ * @throws std::invalid_argument if A is not square, or if A cannot be
+ * multiplied by B
+ */
+template <typename Ta, int Ra, int Ca, typename Tb, int Rb, int Cb,
+          require_any_fvar_t<Ta, Tb>...>
+inline Eigen::Matrix<return_type_t<Ta, Tb>, Cb, Cb> quad_form(
+    const Eigen::Matrix<Ta, Ra, Ca>& A, const Eigen::Matrix<Tb, Rb, Cb>& B) {
+  check_square("quad_form", "A", A);
+  check_multiplicable("quad_form", "A", A, "B", B);
+  return multiply(transpose(B), multiply(A, B));
+}
+
+/**
+ * Compute the quadratic form B^T A B.
+ *
+ * @tparam Ta type of elements in the square matrix
+ * @tparam Ra number of rows in the square matrix, can be Eigen::Dynamic
+ * @tparam Ca number of columns in the square matrix, can be Eigen::Dynamic
+ * @tparam Tb type of elements in the vector
+ * @tparam Rb number of rows in the vector, can be Eigen::Dynamic
+ *
+ * @param A square matrix
+ * @param B vector
+ * @return The quadratic form B^T A B, which is a scalar.
+ * @throws std::invalid_argument if A is not square, or if A cannot be
+ * multiplied by B
+ */
+template <typename Ta, int Ra, int Ca, typename Tb, int Rb,
+          require_any_fvar_t<Ta, Tb>...>
+inline return_type_t<Ta, Tb> quad_form(const Eigen::Matrix<Ta, Ra, Ca>& A,
+                                       const Eigen::Matrix<Tb, Rb, 1>& B) {
+  check_square("quad_form", "A", A);
+  check_multiplicable("quad_form", "A", A, "B", B);
+  return dot_product(B, multiply(A, B));
+}
+
+}  // namespace math
+}  // namespace stan
+
+#endif

--- a/stan/math/fwd/fun/quad_form_sym.hpp
+++ b/stan/math/fwd/fun/quad_form_sym.hpp
@@ -8,40 +8,58 @@
 namespace stan {
 namespace math {
 
-template <int RA, int CA, int RB, int CB, typename T>
-inline Eigen::Matrix<fvar<T>, CB, CB> quad_form_sym(
-    const Eigen::Matrix<fvar<T>, RA, CA>& A,
-    const Eigen::Matrix<double, RB, CB>& B) {
+/**
+ * Compute the quadratic form B^T A B.
+ *
+ * @tparam TA type of elements in the symmetric matrix
+ * @tparam RA number of rows in the symmetric matrix, can be Eigen::Dynamic
+ * @tparam CA number of columns in the symmetric matrix, can be Eigen::Dynamic
+ * @tparam TB type of elements in the second matrix
+ * @tparam RB number of rows in the second matrix, can be Eigen::Dynamic
+ * @tparam CB number of columns in the second matrix, can be Eigen::Dynamic
+ *
+ * @param A symmetric matrix
+ * @param B second matrix
+ * @return The quadratic form B^T A B, which is guaranteed to be a symmetric
+ * matrix of size CB.
+ * @throws std::invalid_argument if A is not symmetric, or if A cannot be
+ * multiplied by B
+ */
+template <typename TA, int RA, int CA, typename TB, int RB, int CB,
+          require_any_fvar_t<TA, TB>...>
+inline Eigen::Matrix<return_type_t<TA, TB>, CB, CB> quad_form_sym(
+    const Eigen::Matrix<TA, RA, CA>& A, const Eigen::Matrix<TB, RB, CB>& B) {
+  using T = return_type_t<TA, TB>;
   check_multiplicable("quad_form_sym", "A", A, "B", B);
   check_symmetric("quad_form_sym", "A", A);
-  Eigen::Matrix<fvar<T>, CB, CB> ret(multiply(transpose(B), multiply(A, B)));
+  Eigen::Matrix<T, CB, CB> ret(multiply(transpose(B), multiply(A, B)));
   return T(0.5) * (ret + transpose(ret));
 }
 
-template <int RA, int CA, int RB, typename T>
-inline fvar<T> quad_form_sym(const Eigen::Matrix<fvar<T>, RA, CA>& A,
-                             const Eigen::Matrix<double, RB, 1>& B) {
+/**
+ * Compute the quadratic form B^T A B.
+ *
+ * @tparam TA type of elements in the symmetric matrix
+ * @tparam RA number of rows in the symmetric matrix, can be Eigen::Dynamic
+ * @tparam CA number of columns in the symmetric matrix, can be Eigen::Dynamic
+ * @tparam TB type of elements in the vector
+ * @tparam RB number of rows in the vector, can be Eigen::Dynamic
+ *
+ * @param A symmetric matrix
+ * @param B vector
+ * @return The quadratic form B^T A B, which is a scalar.
+ * @throws std::invalid_argument if A is not symmetric, or if A cannot be
+ * multiplied by B
+ */
+template <typename TA, int RA, int CA, typename TB, int RB,
+          require_any_fvar_t<TA, TB>...>
+inline return_type_t<TA, TB> quad_form_sym(const Eigen::Matrix<TA, RA, CA>& A,
+                                           const Eigen::Matrix<TB, RB, 1>& B) {
   check_multiplicable("quad_form_sym", "A", A, "B", B);
   check_symmetric("quad_form_sym", "A", A);
   return dot_product(B, multiply(A, B));
 }
-template <int RA, int CA, int RB, int CB, typename T>
-inline Eigen::Matrix<fvar<T>, CB, CB> quad_form_sym(
-    const Eigen::Matrix<double, RA, CA>& A,
-    const Eigen::Matrix<fvar<T>, RB, CB>& B) {
-  check_multiplicable("quad_form_sym", "A", A, "B", B);
-  check_symmetric("quad_form_sym", "A", A);
-  Eigen::Matrix<fvar<T>, CB, CB> ret(multiply(transpose(B), multiply(A, B)));
-  return T(0.5) * (ret + transpose(ret));
-}
 
-template <int RA, int CA, int RB, typename T>
-inline fvar<T> quad_form_sym(const Eigen::Matrix<double, RA, CA>& A,
-                             const Eigen::Matrix<fvar<T>, RB, 1>& B) {
-  check_multiplicable("quad_form_sym", "A", A, "B", B);
-  check_symmetric("quad_form_sym", "A", A);
-  return dot_product(B, multiply(A, B));
-}
 }  // namespace math
 }  // namespace stan
 

--- a/stan/math/fwd/fun/quad_form_sym.hpp
+++ b/stan/math/fwd/fun/quad_form_sym.hpp
@@ -9,7 +9,9 @@ namespace stan {
 namespace math {
 
 /**
- * Compute the quadratic form B^T A B.
+ * Return the quadratic form \f$ B^T A B \f$ of a symmetric matrix.
+ *
+ * Symmetry of the resulting matrix is guaranteed.
  *
  * @tparam TA type of elements in the symmetric matrix
  * @tparam RA number of rows in the symmetric matrix, can be Eigen::Dynamic
@@ -20,8 +22,7 @@ namespace math {
  *
  * @param A symmetric matrix
  * @param B second matrix
- * @return The quadratic form B^T A B, which is guaranteed to be a symmetric
- * matrix of size CB.
+ * @return The quadratic form, which is a symmetric matrix of size CB.
  * @throws std::invalid_argument if A is not symmetric, or if A cannot be
  * multiplied by B
  */
@@ -37,7 +38,7 @@ inline Eigen::Matrix<return_type_t<TA, TB>, CB, CB> quad_form_sym(
 }
 
 /**
- * Compute the quadratic form B^T A B.
+ * Return the quadratic form \f$ B^T A B \f$ of a symmetric matrix.
  *
  * @tparam TA type of elements in the symmetric matrix
  * @tparam RA number of rows in the symmetric matrix, can be Eigen::Dynamic
@@ -47,7 +48,7 @@ inline Eigen::Matrix<return_type_t<TA, TB>, CB, CB> quad_form_sym(
  *
  * @param A symmetric matrix
  * @param B vector
- * @return The quadratic form B^T A B, which is a scalar.
+ * @return The quadratic form (a scalar).
  * @throws std::invalid_argument if A is not symmetric, or if A cannot be
  * multiplied by B
  */

--- a/stan/math/prim/fun/quad_form.hpp
+++ b/stan/math/prim/fun/quad_form.hpp
@@ -8,8 +8,21 @@ namespace stan {
 namespace math {
 
 /**
- * Compute B^T A B
- **/
+ * Compute the quadratic form B^T A B.
+ *
+ * @tparam RA number of rows in the square matrix, can be Eigen::Dynamic
+ * @tparam CA number of columns in the square matrix, can be Eigen::Dynamic
+ * @tparam RB number of rows in the second matrix, can be Eigen::Dynamic
+ * @tparam CB number of columns in the second matrix, can be Eigen::Dynamic
+ * @tparam T type of elements
+ *
+ * @param A square matrix
+ * @param B second matrix
+ * @return The quadratic form B^T A B, which is a symmetric matrix of size CB
+ * (although symmetry is not guaranteed due to numerical precision).
+ * @throws std::invalid_argument if A is not square, or if A cannot be
+ * multiplied by B
+ */
 template <int RA, int CA, int RB, int CB, typename T>
 inline Eigen::Matrix<T, CB, CB> quad_form(const Eigen::Matrix<T, RA, CA>& A,
                                           const Eigen::Matrix<T, RB, CB>& B) {
@@ -18,6 +31,20 @@ inline Eigen::Matrix<T, CB, CB> quad_form(const Eigen::Matrix<T, RA, CA>& A,
   return B.transpose() * A * B;
 }
 
+/**
+ * Compute the quadratic form B^T A B.
+ *
+ * @tparam RA number of rows in the square matrix, can be Eigen::Dynamic
+ * @tparam CA number of columns in the square matrix, can be Eigen::Dynamic
+ * @tparam RB number of rows in the vector, can be Eigen::Dynamic
+ * @tparam T type of elements
+ *
+ * @param A square matrix
+ * @param B vector
+ * @return The quadratic form B^T A B, which is a scalar.
+ * @throws std::invalid_argument if A is not square, or if A cannot be
+ * multiplied by B
+ */
 template <int RA, int CA, int RB, typename T>
 inline T quad_form(const Eigen::Matrix<T, RA, CA>& A,
                    const Eigen::Matrix<T, RB, 1>& B) {

--- a/stan/math/prim/fun/quad_form.hpp
+++ b/stan/math/prim/fun/quad_form.hpp
@@ -8,7 +8,10 @@ namespace stan {
 namespace math {
 
 /**
- * Compute the quadratic form B^T A B.
+ * Return the quadratic form \f$ B^T A B \f$.
+ *
+ * Symmetry of the resulting matrix is not guaranteed due to numerical
+ * precision.
  *
  * @tparam RA number of rows in the square matrix, can be Eigen::Dynamic
  * @tparam CA number of columns in the square matrix, can be Eigen::Dynamic
@@ -18,8 +21,7 @@ namespace math {
  *
  * @param A square matrix
  * @param B second matrix
- * @return The quadratic form B^T A B, which is a symmetric matrix of size CB
- * (although symmetry is not guaranteed due to numerical precision).
+ * @return The quadratic form, which is a symmetric matrix of size CB.
  * @throws std::invalid_argument if A is not square, or if A cannot be
  * multiplied by B
  */
@@ -32,7 +34,7 @@ inline Eigen::Matrix<T, CB, CB> quad_form(const Eigen::Matrix<T, RA, CA>& A,
 }
 
 /**
- * Compute the quadratic form B^T A B.
+ * Return the quadratic form \f$ B^T A B \f$.
  *
  * @tparam RA number of rows in the square matrix, can be Eigen::Dynamic
  * @tparam CA number of columns in the square matrix, can be Eigen::Dynamic
@@ -41,7 +43,7 @@ inline Eigen::Matrix<T, CB, CB> quad_form(const Eigen::Matrix<T, RA, CA>& A,
  *
  * @param A square matrix
  * @param B vector
- * @return The quadratic form B^T A B, which is a scalar.
+ * @return The quadratic form (a scalar).
  * @throws std::invalid_argument if A is not square, or if A cannot be
  * multiplied by B
  */

--- a/stan/math/prim/fun/quad_form_sym.hpp
+++ b/stan/math/prim/fun/quad_form_sym.hpp
@@ -8,7 +8,9 @@ namespace stan {
 namespace math {
 
 /**
- * Compute the quadratic form B^T A B.
+ * Return the quadratic form \f$ B^T A B \f$ of a symmetric matrix.
+ *
+ * Symmetry of the resulting matrix is guaranteed.
  *
  * @tparam RA number of rows in the symmetric matrix, can be Eigen::Dynamic
  * @tparam CA number of columns in the symmetric matrix, can be Eigen::Dynamic
@@ -18,8 +20,7 @@ namespace math {
  *
  * @param A symmetric matrix
  * @param B second matrix
- * @return The quadratic form B^T A B, which is guaranteed to be a symmetric
- * matrix of size CB.
+ * @return The quadratic form, which is a symmetric matrix of size CB.
  * @throws std::invalid_argument if A is not symmetric, or if A cannot be
  * multiplied by B
  */
@@ -33,7 +34,7 @@ inline Eigen::Matrix<T, CB, CB> quad_form_sym(
 }
 
 /**
- * Compute the quadratic form B^T A B.
+ * Return the quadratic form \f$ B^T A B \f$ of a symmetric matrix.
  *
  * @tparam RA number of rows in the symmetric matrix, can be Eigen::Dynamic
  * @tparam CA number of columns in the symmetric matrix, can be Eigen::Dynamic
@@ -42,7 +43,7 @@ inline Eigen::Matrix<T, CB, CB> quad_form_sym(
  *
  * @param A symmetric matrix
  * @param B vector
- * @return The quadratic form B^T A B, which is a scalar.
+ * @return The quadratic form (a scalar).
  * @throws std::invalid_argument if A is not symmetric, or if A cannot be
  * multiplied by B
  */

--- a/stan/math/prim/fun/quad_form_sym.hpp
+++ b/stan/math/prim/fun/quad_form_sym.hpp
@@ -7,6 +7,22 @@
 namespace stan {
 namespace math {
 
+/**
+ * Compute the quadratic form B^T A B.
+ *
+ * @tparam RA number of rows in the symmetric matrix, can be Eigen::Dynamic
+ * @tparam CA number of columns in the symmetric matrix, can be Eigen::Dynamic
+ * @tparam RB number of rows in the second matrix, can be Eigen::Dynamic
+ * @tparam CB number of columns in the second matrix, can be Eigen::Dynamic
+ * @tparam TA type of elements
+ *
+ * @param A symmetric matrix
+ * @param B second matrix
+ * @return The quadratic form B^T A B, which is guaranteed to be a symmetric
+ * matrix of size CB.
+ * @throws std::invalid_argument if A is not symmetric, or if A cannot be
+ * multiplied by B
+ */
 template <int RA, int CA, int RB, int CB, typename T>
 inline Eigen::Matrix<T, CB, CB> quad_form_sym(
     const Eigen::Matrix<T, RA, CA>& A, const Eigen::Matrix<T, RB, CB>& B) {
@@ -16,6 +32,20 @@ inline Eigen::Matrix<T, CB, CB> quad_form_sym(
   return T(0.5) * (ret + ret.transpose());
 }
 
+/**
+ * Compute the quadratic form B^T A B.
+ *
+ * @tparam RA number of rows in the symmetric matrix, can be Eigen::Dynamic
+ * @tparam CA number of columns in the symmetric matrix, can be Eigen::Dynamic
+ * @tparam RB number of rows in the vector, can be Eigen::Dynamic
+ * @tparam T type of elements
+ *
+ * @param A symmetric matrix
+ * @param B vector
+ * @return The quadratic form B^T A B, which is a scalar.
+ * @throws std::invalid_argument if A is not symmetric, or if A cannot be
+ * multiplied by B
+ */
 template <int RA, int CA, int RB, typename T>
 inline T quad_form_sym(const Eigen::Matrix<T, RA, CA>& A,
                        const Eigen::Matrix<T, RB, 1>& B) {

--- a/stan/math/rev/fun/quad_form.hpp
+++ b/stan/math/rev/fun/quad_form.hpp
@@ -95,6 +95,23 @@ class quad_form_vari : public vari {
 };
 }  // namespace internal
 
+/**
+ * Compute the quadratic form B^T A B.
+ *
+ * @tparam Ta type of elements in the square matrix
+ * @tparam Ra number of rows in the square matrix, can be Eigen::Dynamic
+ * @tparam Ca number of columns in the square matrix, can be Eigen::Dynamic
+ * @tparam Tb type of elements in the second matrix
+ * @tparam Rb number of rows in the second matrix, can be Eigen::Dynamic
+ * @tparam Cb number of columns in the second matrix, can be Eigen::Dynamic
+ *
+ * @param A square matrix
+ * @param B second matrix
+ * @return The quadratic form B^T A B, which is a symmetric matrix of size Cb
+ * (although symmetry is not guaranteed due to numerical precision).
+ * @throws std::invalid_argument if A is not square, or if A cannot be
+ * multiplied by B
+ */
 template <typename Ta, int Ra, int Ca, typename Tb, int Rb, int Cb,
           require_any_var_t<Ta, Tb>...>
 inline Eigen::Matrix<var, Cb, Cb> quad_form(
@@ -108,6 +125,21 @@ inline Eigen::Matrix<var, Cb, Cb> quad_form(
   return baseVari->impl_->C_;
 }
 
+/**
+ * Compute the quadratic form B^T A B.
+ *
+ * @tparam Ta type of elements in the square matrix
+ * @tparam Ra number of rows in the square matrix, can be Eigen::Dynamic
+ * @tparam Ca number of columns in the square matrix, can be Eigen::Dynamic
+ * @tparam Tb type of elements in the vector
+ * @tparam Rb number of rows in the vector, can be Eigen::Dynamic
+ *
+ * @param A square matrix
+ * @param B vector
+ * @return The quadratic form B^T A B, which is a scalar.
+ * @throws std::invalid_argument if A is not square, or if A cannot be
+ * multiplied by B
+ */
 template <typename Ta, int Ra, int Ca, typename Tb, int Rb,
           require_any_var_t<Ta, Tb>...>
 inline var quad_form(const Eigen::Matrix<Ta, Ra, Ca>& A,

--- a/stan/math/rev/fun/quad_form.hpp
+++ b/stan/math/rev/fun/quad_form.hpp
@@ -95,12 +95,10 @@ class quad_form_vari : public vari {
 };
 }  // namespace internal
 
-template <typename Ta, int Ra, int Ca, typename Tb, int Rb, int Cb>
-inline typename std::enable_if<std::is_same<Ta, var>::value
-                                   || std::is_same<Tb, var>::value,
-                               Eigen::Matrix<var, Cb, Cb> >::type
-quad_form(const Eigen::Matrix<Ta, Ra, Ca>& A,
-          const Eigen::Matrix<Tb, Rb, Cb>& B) {
+template <typename Ta, int Ra, int Ca, typename Tb, int Rb, int Cb,
+          require_any_var_t<Ta, Tb>...>
+inline Eigen::Matrix<var, Cb, Cb> quad_form(
+    const Eigen::Matrix<Ta, Ra, Ca>& A, const Eigen::Matrix<Tb, Rb, Cb>& B) {
   check_square("quad_form", "A", A);
   check_multiplicable("quad_form", "A", A, "B", B);
 
@@ -110,11 +108,10 @@ quad_form(const Eigen::Matrix<Ta, Ra, Ca>& A,
   return baseVari->impl_->C_;
 }
 
-template <typename Ta, int Ra, int Ca, typename Tb, int Rb>
-inline typename std::enable_if<
-    std::is_same<Ta, var>::value || std::is_same<Tb, var>::value, var>::type
-quad_form(const Eigen::Matrix<Ta, Ra, Ca>& A,
-          const Eigen::Matrix<Tb, Rb, 1>& B) {
+template <typename Ta, int Ra, int Ca, typename Tb, int Rb,
+          require_any_var_t<Ta, Tb>...>
+inline var quad_form(const Eigen::Matrix<Ta, Ra, Ca>& A,
+                     const Eigen::Matrix<Tb, Rb, 1>& B) {
   check_square("quad_form", "A", A);
   check_multiplicable("quad_form", "A", A, "B", B);
 

--- a/stan/math/rev/fun/quad_form.hpp
+++ b/stan/math/rev/fun/quad_form.hpp
@@ -96,7 +96,10 @@ class quad_form_vari : public vari {
 }  // namespace internal
 
 /**
- * Compute the quadratic form B^T A B.
+ * Return the quadratic form \f$ B^T A B \f$.
+ *
+ * Symmetry of the resulting matrix is not guaranteed due to numerical
+ * precision.
  *
  * @tparam Ta type of elements in the square matrix
  * @tparam Ra number of rows in the square matrix, can be Eigen::Dynamic
@@ -107,8 +110,7 @@ class quad_form_vari : public vari {
  *
  * @param A square matrix
  * @param B second matrix
- * @return The quadratic form B^T A B, which is a symmetric matrix of size Cb
- * (although symmetry is not guaranteed due to numerical precision).
+ * @return The quadratic form, which is a symmetric matrix of size Cb.
  * @throws std::invalid_argument if A is not square, or if A cannot be
  * multiplied by B
  */
@@ -126,7 +128,7 @@ inline Eigen::Matrix<var, Cb, Cb> quad_form(
 }
 
 /**
- * Compute the quadratic form B^T A B.
+ * Return the quadratic form \f$ B^T A B \f$.
  *
  * @tparam Ta type of elements in the square matrix
  * @tparam Ra number of rows in the square matrix, can be Eigen::Dynamic
@@ -136,7 +138,7 @@ inline Eigen::Matrix<var, Cb, Cb> quad_form(
  *
  * @param A square matrix
  * @param B vector
- * @return The quadratic form B^T A B, which is a scalar.
+ * @return The quadratic form (a scalar).
  * @throws std::invalid_argument if A is not square, or if A cannot be
  * multiplied by B
  */

--- a/stan/math/rev/fun/quad_form_sym.hpp
+++ b/stan/math/rev/fun/quad_form_sym.hpp
@@ -11,6 +11,23 @@
 namespace stan {
 namespace math {
 
+/**
+ * Compute the quadratic form B^T A B.
+ *
+ * @tparam Ta type of elements in the symmetric matrix
+ * @tparam Ra number of rows in the symmetric matrix, can be Eigen::Dynamic
+ * @tparam Ca number of columns in the symmetric matrix, can be Eigen::Dynamic
+ * @tparam Tb type of elements in the second matrix
+ * @tparam Rb number of rows in the second matrix, can be Eigen::Dynamic
+ * @tparam Cb number of columns in the second matrix, can be Eigen::Dynamic
+ *
+ * @param A symmetric matrix
+ * @param B second matrix
+ * @return The quadratic form B^T A B, which is guaranteed to be a symmetric
+ * matrix of size Cb.
+ * @throws std::invalid_argument if A is not symmetric, or if A cannot be
+ * multiplied by B
+ */
 template <typename Ta, int Ra, int Ca, typename Tb, int Rb, int Cb,
           require_any_var_t<Ta, Tb>...>
 inline Eigen::Matrix<var, Cb, Cb> quad_form_sym(
@@ -24,6 +41,21 @@ inline Eigen::Matrix<var, Cb, Cb> quad_form_sym(
   return baseVari->impl_->C_;
 }
 
+/**
+ * Compute the quadratic form B^T A B.
+ *
+ * @tparam Ta type of elements in the symmetric matrix
+ * @tparam Ra number of rows in the symmetric matrix, can be Eigen::Dynamic
+ * @tparam Ca number of columns in the symmetric matrix, can be Eigen::Dynamic
+ * @tparam Tb type of elements in the vector
+ * @tparam Rb number of rows in the vector, can be Eigen::Dynamic
+ *
+ * @param A symmetric matrix
+ * @param B vector
+ * @return The quadratic form B^T A B, which is a scalar.
+ * @throws std::invalid_argument if A is not symmetric, or if A cannot be
+ * multiplied by B
+ */
 template <typename Ta, int Ra, int Ca, typename Tb, int Rb,
           require_any_var_t<Ta, Tb>...>
 inline var quad_form_sym(const Eigen::Matrix<Ta, Ra, Ca>& A,

--- a/stan/math/rev/fun/quad_form_sym.hpp
+++ b/stan/math/rev/fun/quad_form_sym.hpp
@@ -12,7 +12,9 @@ namespace stan {
 namespace math {
 
 /**
- * Compute the quadratic form B^T A B.
+ * Return the quadratic form \f$ B^T A B \f$ of a symmetric matrix.
+ *
+ * Symmetry of the resulting matrix is guaranteed.
  *
  * @tparam Ta type of elements in the symmetric matrix
  * @tparam Ra number of rows in the symmetric matrix, can be Eigen::Dynamic
@@ -23,8 +25,7 @@ namespace math {
  *
  * @param A symmetric matrix
  * @param B second matrix
- * @return The quadratic form B^T A B, which is guaranteed to be a symmetric
- * matrix of size Cb.
+ * @return The quadratic form, which is a symmetric matrix of size Cb.
  * @throws std::invalid_argument if A is not symmetric, or if A cannot be
  * multiplied by B
  */
@@ -42,7 +43,7 @@ inline Eigen::Matrix<var, Cb, Cb> quad_form_sym(
 }
 
 /**
- * Compute the quadratic form B^T A B.
+ * Return the quadratic form \f$ B^T A B \f$ of a symmetric matrix.
  *
  * @tparam Ta type of elements in the symmetric matrix
  * @tparam Ra number of rows in the symmetric matrix, can be Eigen::Dynamic
@@ -52,7 +53,7 @@ inline Eigen::Matrix<var, Cb, Cb> quad_form_sym(
  *
  * @param A symmetric matrix
  * @param B vector
- * @return The quadratic form B^T A B, which is a scalar.
+ * @return The quadratic form (a scalar).
  * @throws std::invalid_argument if A is not symmetric, or if A cannot be
  * multiplied by B
  */

--- a/test/unit/math/mix/fun/quad_form_test.cpp
+++ b/test/unit/math/mix/fun/quad_form_test.cpp
@@ -1,0 +1,48 @@
+#include <test/unit/math/test_ad.hpp>
+#include <test/unit/math/ad_tolerances.hpp>
+
+TEST(MathMixMatFun, quadForm) {
+  using stan::test::relative_tolerance;
+  auto f = [](const auto& x, const auto& y) {
+    return stan::math::quad_form(x, y);
+  };
+
+  Eigen::MatrixXd a00;
+  Eigen::MatrixXd a11(1, 1);
+  a11 << 1;
+  Eigen::MatrixXd b11(1, 1);
+  b11 << -2;
+  Eigen::MatrixXd a22(2, 2);
+  a22 << 1, 2, 3, 4;
+  Eigen::MatrixXd b22(2, 2);
+  b22 << -3, -2, -10, 112;
+  Eigen::MatrixXd b23(2, 3);
+  b23 << 1, 2, 3, 4, 5, 6;
+  Eigen::MatrixXd b42(4, 2);
+  b42 << 100, 10, 0, 1, -3, -3, 5, 2;
+  Eigen::MatrixXd a44(4, 4);
+  a44 << 2, 3, 4, 5, 6, 10, 2, 2, 7, 2, 7, 1, 8, 2, 1, 112;
+
+  Eigen::VectorXd v0(0);
+  Eigen::VectorXd v1(1);
+  v1 << 42;
+  Eigen::VectorXd v2(2);
+  v2 << -3, 13;
+  Eigen::VectorXd v4(4);
+  v4 << 100, 0, -3, 5;
+
+  stan::test::ad_tolerances tols;
+  tols.hessian_hessian_ = 2e-1;
+  tols.hessian_fvar_hessian_ = 2e-1;
+
+  stan::test::expect_ad(f, a00, a00);
+  stan::test::expect_ad(f, a11, b11);
+  stan::test::expect_ad(tols, f, a22, b22);
+  stan::test::expect_ad(f, a22, b23);
+  stan::test::expect_ad(tols, f, a44, b42);
+
+  stan::test::expect_ad(f, a00, v0);
+  stan::test::expect_ad(f, a11, v1);
+  stan::test::expect_ad(f, a22, v2);
+  stan::test::expect_ad(tols, f, a44, v4);
+}

--- a/test/unit/math/prim/fun/quad_form_diag_test.cpp
+++ b/test/unit/math/prim/fun/quad_form_diag_test.cpp
@@ -2,52 +2,49 @@
 #include <test/unit/math/prim/fun/expect_matrix_eq.hpp>
 #include <gtest/gtest.h>
 
-using Eigen::Dynamic;
-using Eigen::Matrix;
 using stan::math::quad_form_diag;
 
-TEST(MathMatrixPrimMat, quadFormDiag) {
-  Matrix<double, Dynamic, Dynamic> m(1, 1);
+TEST(MathMatrixPrim, quadFormDiag) {
+  Eigen::MatrixXd m(1, 1);
   m << 3;
 
-  Matrix<double, Dynamic, 1> v(1);
+  Eigen::VectorXd v(1);
   v << 9;
 
-  Matrix<double, Dynamic, Dynamic> v_m(1, 1);
-  v_m << 9;
+  Eigen::MatrixXd v_m = v.asDiagonal();
 
   expect_matrix_eq(v_m * m * v_m, quad_form_diag(m, v));
 }
-TEST(MathMatrixPrimMat, quadFormDiag2) {
-  Matrix<double, Dynamic, Dynamic> m(3, 3);
+
+TEST(MathMatrixPrim, quadFormDiag2) {
+  Eigen::MatrixXd m(3, 3);
   m << 1, 2, 3, 4, 5, 6, 7, 8, 9;
 
-  Matrix<double, Dynamic, 1> v(3);
+  Eigen::VectorXd v(3);
   v << 1, 2, 3;
 
-  Matrix<double, Dynamic, Dynamic> v_m(3, 3);
-  v_m << 1, 0, 0, 0, 2, 0, 0, 0, 3;
+  Eigen::MatrixXd v_m = v.asDiagonal();
 
   expect_matrix_eq(v_m * m * v_m, quad_form_diag(m, v));
 
-  Matrix<double, 1, Dynamic> rv(3);
+  Eigen::RowVectorXd rv(3);
   rv << 1, 2, 3;
   expect_matrix_eq(v_m * m * v_m, quad_form_diag(m, rv));
 }
 
-TEST(MathMatrixPrimMat, quadFormDiagException) {
-  Matrix<double, Dynamic, Dynamic> m(2, 2);
+TEST(MathMatrixPrim, quadFormDiagException) {
+  Eigen::MatrixXd m(2, 2);
   m << 2, 3, 4, 5;
   EXPECT_THROW(quad_form_diag(m, m), std::invalid_argument);
 
-  Matrix<double, Dynamic, 1> v(3);
+  Eigen::VectorXd v(3);
   v << 1, 2, 3;
   EXPECT_THROW(quad_form_diag(m, v), std::invalid_argument);
 
-  Matrix<double, Dynamic, Dynamic> m2(3, 2);
+  Eigen::MatrixXd m2(3, 2);
   m2 << 2, 3, 4, 5, 6, 7;
 
-  Matrix<double, Dynamic, 1> v2(2);
+  Eigen::VectorXd v2(2);
   v2 << 1, 2;
 
   EXPECT_THROW(quad_form_diag(m2, v), std::invalid_argument);

--- a/test/unit/math/prim/fun/quad_form_sym_test.cpp
+++ b/test/unit/math/prim/fun/quad_form_sym_test.cpp
@@ -3,6 +3,24 @@
 
 TEST(MathMatrixPrim, quad_form_sym_mat) {
   using stan::math::matrix_d;
+  using stan::math::quad_form_sym;
+
+  matrix_d resd;
+  matrix_d m0;
+  EXPECT_THROW(quad_form_sym(m0, m0), std::invalid_argument);
+
+  matrix_d m1(1, 1);
+  m1 << 2;
+  resd = quad_form_sym(m1, m1);
+  EXPECT_FLOAT_EQ(8, resd(0));
+
+  matrix_d m2(1, 2);
+  m2 << 1, 2;
+  resd = quad_form_sym(m1, m2);
+  EXPECT_FLOAT_EQ(2, resd(0, 0));
+  EXPECT_FLOAT_EQ(4, resd(0, 1));
+  EXPECT_FLOAT_EQ(4, resd(1, 0));
+  EXPECT_FLOAT_EQ(8, resd(1, 1));
 
   matrix_d ad(4, 4);
   matrix_d bd(4, 2);
@@ -11,17 +29,34 @@ TEST(MathMatrixPrim, quad_form_sym_mat) {
   ad << 2.0, 3.0, 4.0, 5.0, 3.0, 10.0, 2.0, 2.0, 4.0, 2.0, 7.0, 1.0, 5.0, 2.0,
       1.0, 112.0;
 
-  // double-double
-  matrix_d resd = stan::math::quad_form_sym(ad, bd);
+  resd = quad_form_sym(ad, bd);
   EXPECT_FLOAT_EQ(25433, resd(0, 0));
   EXPECT_FLOAT_EQ(3396, resd(0, 1));
   EXPECT_FLOAT_EQ(3396, resd(1, 0));
   EXPECT_FLOAT_EQ(725, resd(1, 1));
+
+  bd.resize(4, 3);
+  bd << 100, 10, 11, 0, 1, 12, -3, -3, 34, 5, 2, 44;
+  resd = quad_form_sym(ad, bd);
+  EXPECT_EQ(resd(1, 0), resd(0, 1));
+  EXPECT_EQ(resd(2, 0), resd(0, 2));
+  EXPECT_EQ(resd(2, 1), resd(1, 2));
 }
 
 TEST(MathMatrixPrim, quad_form_sym_vec) {
   using stan::math::matrix_d;
+  using stan::math::quad_form_sym;
   using stan::math::vector_d;
+
+  matrix_d m0;
+  vector_d v0;
+  EXPECT_THROW(quad_form_sym(m0, v0), std::invalid_argument);
+
+  matrix_d m1(1, 1);
+  m1 << 2;
+  vector_d v1(1);
+  v1 << 2;
+  EXPECT_FLOAT_EQ(8, quad_form_sym(m1, v1));
 
   matrix_d ad(4, 4);
   vector_d bd(4);
@@ -31,32 +66,8 @@ TEST(MathMatrixPrim, quad_form_sym_vec) {
   ad << 2.0, 3.0, 4.0, 5.0, 3.0, 10.0, 2.0, 2.0, 4.0, 2.0, 7.0, 1.0, 5.0, 2.0,
       1.0, 112.0;
 
-  // double-double
-  res = stan::math::quad_form_sym(ad, bd);
+  res = quad_form_sym(ad, bd);
   EXPECT_FLOAT_EQ(25433, res);
-}
-
-TEST(MathMatrixPrim, quad_form_sym_symmetry) {
-  using stan::math::matrix_d;
-  using stan::math::quad_form_sym;
-
-  matrix_d ad(4, 4);
-  matrix_d bd(4, 2);
-
-  bd << 100, 10, 0, 1, -3, -3, 5, 2;
-  ad << 2.0, 3.0, 4.0, 5.0, 3.0, 10.0, 2.0, 2.0, 4.0, 2.0, 7.0, 1.0, 5.0, 2.0,
-      1.0, 112.0;
-
-  // double-double
-  matrix_d resd = quad_form_sym(ad, bd);
-  EXPECT_EQ(resd(1, 0), resd(0, 1));
-
-  bd.resize(4, 3);
-  bd << 100, 10, 11, 0, 1, 12, -3, -3, 34, 5, 2, 44;
-  resd = quad_form_sym(ad, bd);
-  EXPECT_EQ(resd(1, 0), resd(0, 1));
-  EXPECT_EQ(resd(2, 0), resd(0, 2));
-  EXPECT_EQ(resd(2, 1), resd(1, 2));
 }
 
 TEST(MathMatrixPrim, quad_form_sym_asymmetric) {
@@ -69,6 +80,5 @@ TEST(MathMatrixPrim, quad_form_sym_asymmetric) {
   ad << 2.0, 3.0, 4.0, 5.0, 6.0, 10.0, 2.0, 2.0, 7.0, 2.0, 7.0, 1.0, 8.0, 2.0,
       1.0, 112.0;
 
-  // double-double
   EXPECT_THROW(stan::math::quad_form_sym(ad, bd), std::domain_error);
 }

--- a/test/unit/math/prim/fun/quad_form_sym_test.cpp
+++ b/test/unit/math/prim/fun/quad_form_sym_test.cpp
@@ -1,0 +1,74 @@
+#include <stan/math/prim.hpp>
+#include <gtest/gtest.h>
+
+TEST(MathMatrixPrim, quad_form_sym_mat) {
+  using stan::math::matrix_d;
+
+  matrix_d ad(4, 4);
+  matrix_d bd(4, 2);
+
+  bd << 100, 10, 0, 1, -3, -3, 5, 2;
+  ad << 2.0, 3.0, 4.0, 5.0, 3.0, 10.0, 2.0, 2.0, 4.0, 2.0, 7.0, 1.0, 5.0, 2.0,
+      1.0, 112.0;
+
+  // double-double
+  matrix_d resd = stan::math::quad_form_sym(ad, bd);
+  EXPECT_FLOAT_EQ(25433, resd(0, 0));
+  EXPECT_FLOAT_EQ(3396, resd(0, 1));
+  EXPECT_FLOAT_EQ(3396, resd(1, 0));
+  EXPECT_FLOAT_EQ(725, resd(1, 1));
+}
+
+TEST(MathMatrixPrim, quad_form_sym_vec) {
+  using stan::math::matrix_d;
+  using stan::math::vector_d;
+
+  matrix_d ad(4, 4);
+  vector_d bd(4);
+  double res;
+
+  bd << 100, 0, -3, 5;
+  ad << 2.0, 3.0, 4.0, 5.0, 3.0, 10.0, 2.0, 2.0, 4.0, 2.0, 7.0, 1.0, 5.0, 2.0,
+      1.0, 112.0;
+
+  // double-double
+  res = stan::math::quad_form_sym(ad, bd);
+  EXPECT_FLOAT_EQ(25433, res);
+}
+
+TEST(MathMatrixPrim, quad_form_sym_symmetry) {
+  using stan::math::matrix_d;
+  using stan::math::quad_form_sym;
+
+  matrix_d ad(4, 4);
+  matrix_d bd(4, 2);
+
+  bd << 100, 10, 0, 1, -3, -3, 5, 2;
+  ad << 2.0, 3.0, 4.0, 5.0, 3.0, 10.0, 2.0, 2.0, 4.0, 2.0, 7.0, 1.0, 5.0, 2.0,
+      1.0, 112.0;
+
+  // double-double
+  matrix_d resd = quad_form_sym(ad, bd);
+  EXPECT_EQ(resd(1, 0), resd(0, 1));
+
+  bd.resize(4, 3);
+  bd << 100, 10, 11, 0, 1, 12, -3, -3, 34, 5, 2, 44;
+  resd = quad_form_sym(ad, bd);
+  EXPECT_EQ(resd(1, 0), resd(0, 1));
+  EXPECT_EQ(resd(2, 0), resd(0, 2));
+  EXPECT_EQ(resd(2, 1), resd(1, 2));
+}
+
+TEST(MathMatrixPrim, quad_form_sym_asymmetric) {
+  using stan::math::matrix_d;
+
+  matrix_d ad(4, 4);
+  matrix_d bd(4, 2);
+
+  bd << 100, 10, 0, 1, -3, -3, 5, 2;
+  ad << 2.0, 3.0, 4.0, 5.0, 6.0, 10.0, 2.0, 2.0, 7.0, 2.0, 7.0, 1.0, 8.0, 2.0,
+      1.0, 112.0;
+
+  // double-double
+  EXPECT_THROW(stan::math::quad_form_sym(ad, bd), std::domain_error);
+}

--- a/test/unit/math/prim/fun/quad_form_test.cpp
+++ b/test/unit/math/prim/fun/quad_form_test.cpp
@@ -3,6 +3,24 @@
 
 TEST(MathMatrixPrim, quad_form_mat) {
   using stan::math::matrix_d;
+  using stan::math::quad_form;
+
+  matrix_d resd;
+  matrix_d m0;
+  EXPECT_THROW(quad_form(m0, m0), std::invalid_argument);
+
+  matrix_d m1(1, 1);
+  m1 << 2;
+  resd = quad_form(m1, m1);
+  EXPECT_FLOAT_EQ(8, resd(0));
+
+  matrix_d m2(1, 2);
+  m2 << 1, 2;
+  resd = quad_form(m1, m2);
+  EXPECT_FLOAT_EQ(2, resd(0, 0));
+  EXPECT_FLOAT_EQ(4, resd(0, 1));
+  EXPECT_FLOAT_EQ(4, resd(1, 0));
+  EXPECT_FLOAT_EQ(8, resd(1, 1));
 
   matrix_d ad(4, 4);
   matrix_d bd(4, 2);
@@ -11,8 +29,7 @@ TEST(MathMatrixPrim, quad_form_mat) {
   ad << 2.0, 3.0, 4.0, 5.0, 6.0, 10.0, 2.0, 2.0, 7.0, 2.0, 7.0, 1.0, 8.0, 2.0,
       1.0, 112.0;
 
-  // double-double
-  matrix_d resd = stan::math::quad_form(ad, bd);
+  resd = quad_form(ad, bd);
   EXPECT_FLOAT_EQ(26033, resd(0, 0));
   EXPECT_FLOAT_EQ(3456, resd(0, 1));
   EXPECT_FLOAT_EQ(3396, resd(1, 0));
@@ -21,7 +38,18 @@ TEST(MathMatrixPrim, quad_form_mat) {
 
 TEST(MathMatrixPrim, quad_form_vec) {
   using stan::math::matrix_d;
+  using stan::math::quad_form;
   using stan::math::vector_d;
+
+  matrix_d m0;
+  vector_d v0;
+  EXPECT_THROW(quad_form(m0, v0), std::invalid_argument);
+
+  matrix_d m1(1, 1);
+  m1 << 2;
+  vector_d v1(1);
+  v1 << 2;
+  EXPECT_FLOAT_EQ(8, quad_form(m1, v1));
 
   matrix_d ad(4, 4);
   vector_d bd(4);
@@ -31,7 +59,6 @@ TEST(MathMatrixPrim, quad_form_vec) {
   ad << 2.0, 3.0, 4.0, 5.0, 6.0, 10.0, 2.0, 2.0, 7.0, 2.0, 7.0, 1.0, 8.0, 2.0,
       1.0, 112.0;
 
-  // double-double
   res = stan::math::quad_form(ad, bd);
   EXPECT_FLOAT_EQ(26033, res);
 }

--- a/test/unit/math/prim/fun/quad_form_test.cpp
+++ b/test/unit/math/prim/fun/quad_form_test.cpp
@@ -3,7 +3,6 @@
 
 TEST(MathMatrixPrim, quad_form_mat) {
   using stan::math::matrix_d;
-  using stan::math::quad_form;
 
   matrix_d ad(4, 4);
   matrix_d bd(4, 2);
@@ -13,7 +12,7 @@ TEST(MathMatrixPrim, quad_form_mat) {
       1.0, 112.0;
 
   // double-double
-  matrix_d resd = quad_form(ad, bd);
+  matrix_d resd = stan::math::quad_form(ad, bd);
   EXPECT_FLOAT_EQ(26033, resd(0, 0));
   EXPECT_FLOAT_EQ(3456, resd(0, 1));
   EXPECT_FLOAT_EQ(3396, resd(1, 0));
@@ -22,7 +21,6 @@ TEST(MathMatrixPrim, quad_form_mat) {
 
 TEST(MathMatrixPrim, quad_form_vec) {
   using stan::math::matrix_d;
-  using stan::math::quad_form;
   using stan::math::vector_d;
 
   matrix_d ad(4, 4);
@@ -34,6 +32,6 @@ TEST(MathMatrixPrim, quad_form_vec) {
       1.0, 112.0;
 
   // double-double
-  res = quad_form(ad, bd);
+  res = stan::math::quad_form(ad, bd);
   EXPECT_FLOAT_EQ(26033, res);
 }

--- a/test/unit/math/prim/fun/quad_form_test.cpp
+++ b/test/unit/math/prim/fun/quad_form_test.cpp
@@ -1,7 +1,7 @@
 #include <stan/math/prim.hpp>
 #include <gtest/gtest.h>
 
-TEST(MathMatrixPrimMat, quad_form_mat) {
+TEST(MathMatrixPrim, quad_form_mat) {
   using stan::math::matrix_d;
   using stan::math::quad_form;
 
@@ -20,26 +20,7 @@ TEST(MathMatrixPrimMat, quad_form_mat) {
   EXPECT_FLOAT_EQ(725, resd(1, 1));
 }
 
-TEST(MathMatrixPrimMat, quad_form_sym_mat) {
-  using stan::math::matrix_d;
-  using stan::math::quad_form_sym;
-
-  matrix_d ad(4, 4);
-  matrix_d bd(4, 2);
-
-  bd << 100, 10, 0, 1, -3, -3, 5, 2;
-  ad << 2.0, 3.0, 4.0, 5.0, 3.0, 10.0, 2.0, 2.0, 4.0, 2.0, 7.0, 1.0, 5.0, 2.0,
-      1.0, 112.0;
-
-  // double-double
-  matrix_d resd = quad_form_sym(ad, bd);
-  EXPECT_FLOAT_EQ(25433, resd(0, 0));
-  EXPECT_FLOAT_EQ(3396, resd(0, 1));
-  EXPECT_FLOAT_EQ(3396, resd(1, 0));
-  EXPECT_FLOAT_EQ(725, resd(1, 1));
-}
-
-TEST(MathMatrixPrimMat, quad_form_vec) {
+TEST(MathMatrixPrim, quad_form_vec) {
   using stan::math::matrix_d;
   using stan::math::quad_form;
   using stan::math::vector_d;
@@ -55,60 +36,4 @@ TEST(MathMatrixPrimMat, quad_form_vec) {
   // double-double
   res = quad_form(ad, bd);
   EXPECT_FLOAT_EQ(26033, res);
-}
-
-TEST(MathMatrixPrimMat, quad_form_sym_vec) {
-  using stan::math::matrix_d;
-  using stan::math::quad_form_sym;
-  using stan::math::vector_d;
-
-  matrix_d ad(4, 4);
-  vector_d bd(4);
-  double res;
-
-  bd << 100, 0, -3, 5;
-  ad << 2.0, 3.0, 4.0, 5.0, 3.0, 10.0, 2.0, 2.0, 4.0, 2.0, 7.0, 1.0, 5.0, 2.0,
-      1.0, 112.0;
-
-  // double-double
-  res = quad_form_sym(ad, bd);
-  EXPECT_FLOAT_EQ(25433, res);
-}
-
-TEST(MathMatrixPrimMat, quad_form_sym_symmetry) {
-  using stan::math::matrix_d;
-  using stan::math::quad_form_sym;
-
-  matrix_d ad(4, 4);
-  matrix_d bd(4, 2);
-
-  bd << 100, 10, 0, 1, -3, -3, 5, 2;
-  ad << 2.0, 3.0, 4.0, 5.0, 3.0, 10.0, 2.0, 2.0, 4.0, 2.0, 7.0, 1.0, 5.0, 2.0,
-      1.0, 112.0;
-
-  // double-double
-  matrix_d resd = quad_form_sym(ad, bd);
-  EXPECT_EQ(resd(1, 0), resd(0, 1));
-
-  bd.resize(4, 3);
-  bd << 100, 10, 11, 0, 1, 12, -3, -3, 34, 5, 2, 44;
-  resd = quad_form_sym(ad, bd);
-  EXPECT_EQ(resd(1, 0), resd(0, 1));
-  EXPECT_EQ(resd(2, 0), resd(0, 2));
-  EXPECT_EQ(resd(2, 1), resd(1, 2));
-}
-
-TEST(MathMatrixPrimMat, quad_form_sym_asymmetric) {
-  using stan::math::matrix_d;
-  using stan::math::quad_form_sym;
-
-  matrix_d ad(4, 4);
-  matrix_d bd(4, 2);
-
-  bd << 100, 10, 0, 1, -3, -3, 5, 2;
-  ad << 2.0, 3.0, 4.0, 5.0, 6.0, 10.0, 2.0, 2.0, 7.0, 2.0, 7.0, 1.0, 8.0, 2.0,
-      1.0, 112.0;
-
-  // double-double
-  EXPECT_THROW(quad_form_sym(ad, bd), std::domain_error);
 }


### PR DESCRIPTION
## Summary
This started out to be a simple clean up of the `quad_form` and `quad_form_sym` tests, but it turned into a rabbit hole. There were a few issues around those functions:
- the prim tests were in a single file: I've now split them into one file per function
- the mix tests for `quad_form_sym` were broken because their input was not symmetric: I now symmetrize the input matrix so that tests execute as expected (this also required fixing some tolerances)
- again in that test, variable `b22` was not initialized, and variable `b23` was not used
- there were no mix tests for `quad_form`: this is because there was no fwd version of that function, which I've now added
- some implementations could be consolidated by better template metaprogramming
- there was no doxygen documentation, and now all files have some.

Fixes #1695.

## Tests
Added and fixed as mentioned above.

## Side Effects

None.

## Checklist

- [X] Math issue #1695

- [X] Copyright holder: Marco Colombo

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [X] the new changes are tested
