### PR TITLE
Don't throw when computing the inverse of a size zero matrix

### DIFF
--- a/stan/math/fwd/fun/crossprod.hpp
+++ b/stan/math/fwd/fun/crossprod.hpp
@@ -12,7 +12,7 @@ template <typename T, int R, int C>
 inline Eigen::Matrix<fvar<T>, C, C> crossprod(
     const Eigen::Matrix<fvar<T>, R, C>& m) {
   if (m.rows() == 0) {
-    return Eigen::Matrix<fvar<T>, C, C>(0, 0);
+    return {};
   }
   return multiply(transpose(m), m);
 }

--- a/stan/math/fwd/fun/inverse.hpp
+++ b/stan/math/fwd/fun/inverse.hpp
@@ -12,11 +12,26 @@
 namespace stan {
 namespace math {
 
+/**
+ * Forward mode specialization of calculating the inverse of the matrix.
+ *
+ * @tparam T type of elements in the matrix
+ * @tparam R number of rows, can be Eigen::Dynamic
+ * @tparam C number of columns, can be Eigen::Dynamic
+ *
+ * @param m specified matrix
+ * @return Inverse of the matrix (an empty matrix if the specified matrix has
+ * size zero).
+ * @throw std::invalid_argument if the matrix is not square.
+ */
 template <typename T, int R, int C>
 inline Eigen::Matrix<fvar<T>, R, C> inverse(
     const Eigen::Matrix<fvar<T>, R, C>& m) {
-  check_nonempty("inverse", "m", m);
   check_square("inverse", "m", m);
+  if (m.size() == 0) {
+    return {};
+  }
+
   Eigen::Matrix<T, R, C> m_deriv(m.rows(), m.cols());
   Eigen::Matrix<T, R, C> m_inv(m.rows(), m.cols());
 

--- a/stan/math/fwd/fun/multiply_lower_tri_self_transpose.hpp
+++ b/stan/math/fwd/fun/multiply_lower_tri_self_transpose.hpp
@@ -13,7 +13,7 @@ template <typename T, int R, int C>
 inline Eigen::Matrix<fvar<T>, R, R> multiply_lower_tri_self_transpose(
     const Eigen::Matrix<fvar<T>, R, C>& m) {
   if (m.rows() == 0) {
-    return Eigen::Matrix<fvar<T>, R, R>(0, 0);
+    return {};
   }
   Eigen::Matrix<fvar<T>, R, C> L(m.rows(), m.cols());
   L.setZero();

--- a/stan/math/fwd/fun/tcrossprod.hpp
+++ b/stan/math/fwd/fun/tcrossprod.hpp
@@ -12,7 +12,7 @@ template <typename T, int R, int C>
 inline Eigen::Matrix<fvar<T>, R, R> tcrossprod(
     const Eigen::Matrix<fvar<T>, R, C>& m) {
   if (m.rows() == 0) {
-    return Eigen::Matrix<fvar<T>, R, R>(0, 0);
+    return {};
   }
   return multiply(m, transpose(m));
 }

--- a/stan/math/prim/fun/inverse.hpp
+++ b/stan/math/prim/fun/inverse.hpp
@@ -14,13 +14,18 @@ namespace math {
  * @tparam R number of rows, can be Eigen::Dynamic
  * @tparam C number of columns, can be Eigen::Dynamic
  *
- * @param m Specified matrix.
- * @return Inverse of the matrix.
+ * @param m specified matrix
+ * @return Inverse of the matrix (an empty matrix if the specified matrix has
+ * size zero).
+ * @throw std::invalid_argument if the matrix is not square.
  */
 template <typename T, int R, int C>
 inline Eigen::Matrix<T, R, C> inverse(const Eigen::Matrix<T, R, C>& m) {
-  check_nonempty("inverse", "m", m);
   check_square("inverse", "m", m);
+  if (m.size() == 0) {
+    return {};
+  }
+
   return m.inverse();
 }
 

--- a/stan/math/prim/fun/inverse_spd.hpp
+++ b/stan/math/prim/fun/inverse_spd.hpp
@@ -11,8 +11,11 @@ namespace math {
  * Returns the inverse of the specified symmetric, pos/neg-definite matrix.
  *
  * @tparam T type of elements in the matrix
- * @param m Specified matrix.
- * @return Inverse of the matrix.
+ * @param m specified matrix
+ * @return Inverse of the matrix (an empty matrix if the specified matrix has
+ * size zero).
+ * @throw std::invalid_argument if the matrix is not symmetric.
+ * @throw std::domain_error if the matrix is not positive definite.
  */
 template <typename T>
 inline Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> inverse_spd(
@@ -20,8 +23,11 @@ inline Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> inverse_spd(
   using Eigen::Dynamic;
   using Eigen::LDLT;
   using Eigen::Matrix;
-  check_nonempty("inverse_spd", "m", m);
   check_symmetric("inverse_spd", "m", m);
+  if (m.size() == 0) {
+    return {};
+  }
+
   Matrix<T, Dynamic, Dynamic> mmt = T(0.5) * (m + m.transpose());
   LDLT<Matrix<T, Dynamic, Dynamic> > ldlt(mmt);
   if (ldlt.info() != Eigen::Success) {

--- a/stan/math/prim/fun/tcrossprod.hpp
+++ b/stan/math/prim/fun/tcrossprod.hpp
@@ -19,7 +19,7 @@ namespace math {
 template <int R, int C>
 inline Eigen::MatrixXd tcrossprod(const Eigen::Matrix<double, R, C>& M) {
   if (M.rows() == 0) {
-    return matrix_d(0, 0);
+    return {};
   }
   if (M.rows() == 1) {
     return M * M.transpose();

--- a/stan/math/prim/fun/to_matrix.hpp
+++ b/stan/math/prim/fun/to_matrix.hpp
@@ -40,7 +40,7 @@ inline Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> to_matrix(
     const std::vector<Eigen::Matrix<T, 1, Eigen::Dynamic> >& x) {
   int rows = x.size();
   if (rows == 0) {
-    return Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>(0, 0);
+    return {};
   }
   int cols = x[0].size();
   Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> result(rows, cols);
@@ -65,8 +65,7 @@ inline Eigen::Matrix<return_type_t<T, double>, Eigen::Dynamic, Eigen::Dynamic>
 to_matrix(const std::vector<std::vector<T> >& x) {
   size_t rows = x.size();
   if (rows == 0) {
-    return Eigen::Matrix<return_type_t<T, double>, Eigen::Dynamic,
-                         Eigen::Dynamic>(0, 0);
+    return {};
   }
   size_t cols = x[0].size();
   Eigen::Matrix<return_type_t<T, double>, Eigen::Dynamic, Eigen::Dynamic>

--- a/stan/math/rev/fun/inverse.hpp
+++ b/stan/math/rev/fun/inverse.hpp
@@ -70,12 +70,17 @@ class inverse_vari : public vari {
 /**
  * Reverse mode specialization of calculating the inverse of the matrix.
  *
- * @param m Specified matrix.
- * @return Inverse of the matrix.
+ * @param m specified matrix
+ * @return Inverse of the matrix (an empty matrix if the specified matrix has
+ * size zero).
+ * @throw std::invalid_argument if the matrix is not square.
  */
 inline matrix_v inverse(const matrix_v &m) {
   check_square("inverse", "m", m);
-  check_nonempty("inverse", "m", m);
+  if (m.size() == 0) {
+    return matrix_v(0, 0);
+  }
+
   matrix_v res(m.rows(), m.cols());
   internal::inverse_vari *baseVari = new internal::inverse_vari(m);
   res.vi() = Eigen::Map<matrix_vi>(baseVari->vari_ref_A_inv_, res.rows(),

--- a/stan/math/rev/fun/inverse.hpp
+++ b/stan/math/rev/fun/inverse.hpp
@@ -78,7 +78,7 @@ class inverse_vari : public vari {
 inline matrix_v inverse(const matrix_v &m) {
   check_square("inverse", "m", m);
   if (m.size() == 0) {
-    return matrix_v(0, 0);
+    return {};
   }
 
   matrix_v res(m.rows(), m.cols());

--- a/stan/math/rev/fun/tcrossprod.hpp
+++ b/stan/math/rev/fun/tcrossprod.hpp
@@ -25,7 +25,7 @@ template <int R, int C>
 inline Eigen::Matrix<var, -1, -1> tcrossprod(
     const Eigen::Matrix<var, R, C>& M) {
   if (M.rows() == 0) {
-    return matrix_v(0, 0);
+    return {};
   }
   // if (M.rows() == 1)
   //   return M * M.transpose();

--- a/test/unit/math/mix/fun/inverse_test.cpp
+++ b/test/unit/math/mix/fun/inverse_test.cpp
@@ -4,11 +4,8 @@
 TEST(mathMixMatFun, inverse) {
   auto f = [](const auto& x) { return stan::math::inverse(x); };
 
-  Eigen::Matrix<stan::math::var, -1, -1> t(0, 0);
-  EXPECT_THROW(stan::math::inverse(t), std::invalid_argument);
-
-  Eigen::MatrixXd t2(0, 0);
-  stan::test::expect_ad(f, t2);
+  Eigen::MatrixXd t(0, 0);
+  stan::test::expect_ad(f, t);
 
   Eigen::MatrixXd u(1, 1);
   u << 2;

--- a/test/unit/math/prim/fun/inverse_spd_test.cpp
+++ b/test/unit/math/prim/fun/inverse_spd_test.cpp
@@ -1,12 +1,15 @@
 #include <stan/math/prim.hpp>
 #include <gtest/gtest.h>
 
-TEST(MathMatrixPrimMat, inverse_spd_exception) {
-  using stan::math::inverse_spd;
-
-  // empty
+TEST(MathMatrixPrim, inverse_spd) {
   stan::math::matrix_d m0(0, 0);
-  EXPECT_THROW(inverse_spd(m0), std::invalid_argument);
+  stan::math::matrix_d inv = stan::math::inverse_spd(m0);
+  EXPECT_EQ(0, inv.rows());
+  EXPECT_EQ(0, inv.cols());
+}
+
+TEST(MathMatrixPrim, inverse_spd_exception) {
+  using stan::math::inverse_spd;
 
   stan::math::matrix_d m1(2, 3);
 
@@ -18,9 +21,9 @@ TEST(MathMatrixPrimMat, inverse_spd_exception) {
 
   // non-symmetric
   m2 << 1, 2, 3, 4, 5, 6, 7, 8, 9;
-  EXPECT_THROW(inverse_spd(m1), std::invalid_argument);
+  EXPECT_THROW(inverse_spd(m2), std::domain_error);
 
   // not positive definite
   m2 << 1, 2, 3, 2, 4, 5, 3, 5, 6;
-  EXPECT_THROW(inverse_spd(m1), std::invalid_argument);
+  EXPECT_THROW(inverse_spd(m2), std::domain_error);
 }

--- a/test/unit/math/prim/fun/inverse_test.cpp
+++ b/test/unit/math/prim/fun/inverse_test.cpp
@@ -1,11 +1,15 @@
 #include <stan/math/prim.hpp>
 #include <gtest/gtest.h>
 
-TEST(MathMatrixPrimMat, inverse_exception) {
-  using stan::math::inverse;
-
+TEST(MathMatrixPrim, inverse) {
   stan::math::matrix_d m0(0, 0);
-  EXPECT_THROW(inverse(m0), std::invalid_argument);
+  stan::math::matrix_d inv = stan::math::inverse(m0);
+  EXPECT_EQ(0, inv.rows());
+  EXPECT_EQ(0, inv.cols());
+}
+
+TEST(MathMatrixPrim, inverse_exception) {
+  using stan::math::inverse;
 
   stan::math::matrix_d m1(2, 3);
   m1 << 1, 2, 3, 4, 5, 6;


### PR DESCRIPTION
## Summary
This reverts the earlier decision to throw when computing the inverse of a size zero matrix, as discussed in #1689. We need to return an empty matrix ourselves because Eigen asserts when computing the inverse of an empty matrix. Fixes #1463. Fixes #1432.

## Tests

Updated accordingly. There were also a couple of errors in those tests concerning the type of exception thrown.

## Side Effects

None.

## Checklist

- [X] Math issue #1463, #1432

- [X] Copyright holder: Marco Colombo

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [X] the new changes are tested
