### PR TITLE
Cleanup unnecessary prim/fun signatures and checks (redundant as of C++11)

### DIFF
--- a/stan/math/prim/fun/acosh.hpp
+++ b/stan/math/prim/fun/acosh.hpp
@@ -19,16 +19,8 @@ namespace math {
  * @throw std::domain_error If argument is less than 1.
  */
 inline double acosh(double x) {
-  if (is_nan(x)) {
-    return x;
-  } else {
-    check_greater_or_equal("acosh", "x", x, 1.0);
-#ifdef _WIN32
-    if (is_inf(x))
-      return x;
-#endif
-    return std::acosh(x);
-  }
+  check_greater_or_equal("acosh", "x", x, 1.0);
+  return std::acosh(x);
 }
 
 /**
@@ -39,16 +31,8 @@ inline double acosh(double x) {
  * @throw std::domain_error If argument is less than 1.
  */
 inline double acosh(int x) {
-  if (is_nan(x)) {
-    return x;
-  } else {
-    check_greater_or_equal("acosh", "x", x, 1);
-#ifdef _WIN32
-    if (is_inf(x))
-      return x;
-#endif
-    return std::acosh(x);
-  }
+  check_greater_or_equal("acosh", "x", x, 1);
+  return std::acosh(x);
 }
 
 /**

--- a/stan/math/prim/fun/acosh.hpp
+++ b/stan/math/prim/fun/acosh.hpp
@@ -19,11 +19,11 @@ namespace math {
  * @throw std::domain_error If argument is less than 1.
  */
 inline double acosh(double x) {
-  if (is_nan(x)) {	  
+  if (is_nan(x)) {
     return x;
-  } else {	
-    check_greater_or_equal("acosh", "x", x, 1.0);	
-    return std::acosh(x);	
+  } else {
+    check_greater_or_equal("acosh", "x", x, 1.0);
+    return std::acosh(x);
   }
 }
 

--- a/stan/math/prim/fun/acosh.hpp
+++ b/stan/math/prim/fun/acosh.hpp
@@ -19,8 +19,12 @@ namespace math {
  * @throw std::domain_error If argument is less than 1.
  */
 inline double acosh(double x) {
-  check_greater_or_equal("acosh", "x", x, 1.0);
-  return std::acosh(x);
+  if (is_nan(x)) {	  
+    return x;
+  } else {	
+    check_greater_or_equal("acosh", "x", x, 1.0);	
+    return std::acosh(x);	
+  }
 }
 
 /**

--- a/stan/math/prim/fun/asinh.hpp
+++ b/stan/math/prim/fun/asinh.hpp
@@ -8,25 +8,6 @@ namespace stan {
 namespace math {
 
 /**
- * Return the inverse hyperbolic sine of the specified value.
- * Returns infinity for infinity argument and -infinity for
- * -infinity argument.
- * Returns nan for nan argument.
- *
- * @param[in] x Argument.
- * @return Inverse hyperbolic sine of the argument.
- */
-inline double asinh(double x) { return std::asinh(x); }
-
-/**
- * Integer version of asinh.
- *
- * @param[in] x Argument.
- * @return Inverse hyperbolic sine of the argument.
- */
-inline double asinh(int x) { return std::asinh(x); }
-
-/**
  * Structure to wrap asinh() so it can be vectorized.
  *
  * @tparam T argument scalar type
@@ -36,6 +17,7 @@ inline double asinh(int x) { return std::asinh(x); }
 struct asinh_fun {
   template <typename T>
   static inline T fun(const T& x) {
+    using std::asinh;
     return asinh(x);
   }
 };

--- a/stan/math/prim/fun/atanh.hpp
+++ b/stan/math/prim/fun/atanh.hpp
@@ -22,9 +22,9 @@ namespace math {
 inline double atanh(double x) {
   if (is_nan(x)) {
     return x;
-  } else {	
-    check_bounded("atanh", "x", x, -1.0, 1.0);	
-    return std::atanh(x);	
+  } else {
+    check_bounded("atanh", "x", x, -1.0, 1.0);
+    return std::atanh(x);
   }
 }
 

--- a/stan/math/prim/fun/atanh.hpp
+++ b/stan/math/prim/fun/atanh.hpp
@@ -20,8 +20,12 @@ namespace math {
  * @throw std::domain_error If argument is not in [-1, 1].
  */
 inline double atanh(double x) {
-  check_bounded("atanh", "x", x, -1.0, 1.0);
-  return std::atanh(x);
+  if (is_nan(x)) {
+    return x;
+  } else {	
+    check_bounded("atanh", "x", x, -1.0, 1.0);	
+    return std::atanh(x);	
+  }
 }
 
 /**

--- a/stan/math/prim/fun/atanh.hpp
+++ b/stan/math/prim/fun/atanh.hpp
@@ -20,12 +20,8 @@ namespace math {
  * @throw std::domain_error If argument is not in [-1, 1].
  */
 inline double atanh(double x) {
-  if (is_nan(x)) {
-    return x;
-  } else {
-    check_bounded("atanh", "x", x, -1.0, 1.0);
-    return std::atanh(x);
-  }
+  check_bounded("atanh", "x", x, -1.0, 1.0);
+  return std::atanh(x);
 }
 
 /**
@@ -36,12 +32,8 @@ inline double atanh(double x) {
  * @throw std::domain_error If argument is less than 1.
  */
 inline double atanh(int x) {
-  if (is_nan(x)) {
-    return x;
-  } else {
-    check_bounded("atanh", "x", x, -1, 1);
-    return std::atanh(x);
-  }
+  check_bounded("atanh", "x", x, -1, 1);
+  return std::atanh(x);
 }
 
 /**

--- a/stan/math/prim/fun/cbrt.hpp
+++ b/stan/math/prim/fun/cbrt.hpp
@@ -8,24 +8,6 @@ namespace stan {
 namespace math {
 
 /**
- * Return the cube root of the specified value
- *
- * @param[in] x Argument.
- * @return Cube root of the argument.
- * @throw std::domain_error If argument is negative.
- */
-inline double cbrt(double x) { return std::cbrt(x); }
-
-/**
- * Integer version of cbrt.
- *
- * @param[in] x Argument.
- * @return Cube root of the argument.
- * @throw std::domain_error If argument is less than 1.
- */
-inline double cbrt(int x) { return std::cbrt(x); }
-
-/**
  * Structure to wrap cbrt() so it can be vectorized.
  *
  * @tparam T type of variable
@@ -35,6 +17,7 @@ inline double cbrt(int x) { return std::cbrt(x); }
 struct cbrt_fun {
   template <typename T>
   static inline T fun(const T& x) {
+    using std::cbrt;
     return cbrt(x);
   }
 };

--- a/stan/math/prim/fun/erf.hpp
+++ b/stan/math/prim/fun/erf.hpp
@@ -8,27 +8,6 @@ namespace stan {
 namespace math {
 
 /**
- * Return the error function of the specified value.
- *
- * \f[
- * \mbox{erf}(x) = \frac{2}{\sqrt{\pi}} \int_0^x e^{-t^2} dt
- * \f]
- *
- * @param[in] x Argument.
- * @return Error function of the argument.
- */
-inline double erf(double x) { return std::erf(x); }
-
-/**
- * Return the error function of the specified argument.  This
- * version is required to disambiguate <code>erf(int)</code>.
- *
- * @param[in] x Argument.
- * @return Error function of the argument.
- */
-inline double erf(int x) { return std::erf(x); }
-
-/**
  * Structure to wrap erf() so it can be vectorized.
  *
  * @tparam T type of variable
@@ -38,6 +17,7 @@ inline double erf(int x) { return std::erf(x); }
 struct erf_fun {
   template <typename T>
   static inline T fun(const T& x) {
+    using std::erf;
     return erf(x);
   }
 };

--- a/stan/math/prim/fun/erfc.hpp
+++ b/stan/math/prim/fun/erfc.hpp
@@ -8,27 +8,6 @@ namespace stan {
 namespace math {
 
 /**
- * Return the complementary error function of the specified value.
- *
- * \f[
- * \mbox{erfc}(x) = 1 - \frac{2}{\sqrt{\pi}} \int_0^x e^{-t^2} dt
- * \f]
- *
- * @param[in] x Argument.
- * @return Complementary error function of the argument.
- */
-inline double erfc(double x) { return std::erfc(x); }
-
-/**
- * Return the error function of the specified argument.  This
- * version is required to disambiguate <code>erfc(int)</code>.
- *
- * @param[in] x Argument.
- * @return Complementary error function value of the argument.
- */
-inline double erfc(int x) { return std::erfc(x); }
-
-/**
  * Structure to wrap erfc() so that it can be vectorized.
  *
  * @tparam T type of variable
@@ -38,6 +17,7 @@ inline double erfc(int x) { return std::erfc(x); }
 struct erfc_fun {
   template <typename T>
   static inline T fun(const T& x) {
+    using std::erfc;
     return erfc(x);
   }
 };

--- a/stan/math/prim/fun/exp.hpp
+++ b/stan/math/prim/fun/exp.hpp
@@ -36,7 +36,8 @@ struct exp_fun {
  * @param[in] x container
  * @return Elementwise application of exponentiation to the argument.
  */
-template <typename T, typename = require_not_eigen_vt<std::is_arithmetic, T>, typename = require_not_double_or_int_t<T>>
+template <typename T, typename = require_not_eigen_vt<std::is_arithmetic, T>,
+          typename = require_not_double_or_int_t<T>>
 inline auto exp(const T& x) {
   return apply_scalar_unary<exp_fun, T>::apply(x);
 }

--- a/stan/math/prim/fun/exp.hpp
+++ b/stan/math/prim/fun/exp.hpp
@@ -36,7 +36,7 @@ struct exp_fun {
  * @param[in] x container
  * @return Elementwise application of exponentiation to the argument.
  */
-template <typename T, typename = require_not_eigen_vt<std::is_arithmetic, T>>
+template <typename T, typename = require_not_eigen_vt<std::is_arithmetic, T>, typename = require_not_double_or_int_t<T>>
 inline auto exp(const T& x) {
   return apply_scalar_unary<exp_fun, T>::apply(x);
 }

--- a/stan/math/prim/fun/exp.hpp
+++ b/stan/math/prim/fun/exp.hpp
@@ -36,8 +36,7 @@ struct exp_fun {
  * @param[in] x container
  * @return Elementwise application of exponentiation to the argument.
  */
-template <typename T, typename = require_not_eigen_vt<std::is_arithmetic, T>,
-          typename = require_not_double_or_int_t<T>>
+template <typename T, typename = require_not_eigen_vt<std::is_arithmetic, T>>
 inline auto exp(const T& x) {
   return apply_scalar_unary<exp_fun, T>::apply(x);
 }

--- a/stan/math/prim/fun/exp.hpp
+++ b/stan/math/prim/fun/exp.hpp
@@ -9,15 +9,6 @@ namespace stan {
 namespace math {
 
 /**
- * Return the natural exponential of the specified argument.  This
- * version is required to disambiguate <code>exp(int)</code>.
- *
- * @param[in] x Argument.
- * @return Natural exponential of argument.
- */
-inline double exp(int x) { return std::exp(x); }
-
-/**
  * Structure to wrap <code>exp()</code> so that it can be
  * vectorized.
  */

--- a/stan/math/prim/fun/expm1.hpp
+++ b/stan/math/prim/fun/expm1.hpp
@@ -8,24 +8,6 @@ namespace stan {
 namespace math {
 
 /**
- * Return the natural exponentiation of x minus one.
- * Returns infinity for infinity argument and -infinity for
- * -infinity argument.
- *
- * @param[in] x Argument.
- * @return Natural exponentiation of argument minus one.
- */
-inline double expm1(double x) { return std::expm1(x); }
-
-/**
- * Integer version of expm1.
- *
- * @param[in] x Argument.
- * @return Natural exponentiation of argument minus one.
- */
-inline double expm1(int x) { return std::expm1(x); }
-
-/**
  * Structure to wrap expm1() so that it can be vectorized.
  *
  * @tparam T type of variable
@@ -35,6 +17,7 @@ inline double expm1(int x) { return std::expm1(x); }
 struct expm1_fun {
   template <typename T>
   static inline T fun(const T& x) {
+    using std::expm1;
     return expm1(x);
   }
 };

--- a/stan/math/prim/fun/gp_matern32_cov.hpp
+++ b/stan/math/prim/fun/gp_matern32_cov.hpp
@@ -41,7 +41,6 @@ gp_matern32_cov(const std::vector<T_x> &x, const T_s &sigma,
                 const T_l &length_scale) {
   using std::exp;
   using std::pow;
-  using std::sqrt;
 
   size_t x_size = size(x);
   Eigen::Matrix<return_type_t<T_x, T_s, T_l>, Eigen::Dynamic, Eigen::Dynamic>
@@ -66,8 +65,8 @@ gp_matern32_cov(const std::vector<T_x> &x, const T_s &sigma,
   check_positive_finite(function, "length scale", length_scale);
 
   T_s sigma_sq = square(sigma);
-  T_l root_3_inv_l = sqrt(3.0) / length_scale;
-  T_l neg_root_3_inv_l = -1.0 * sqrt(3.0) / length_scale;
+  T_l root_3_inv_l = std::sqrt(3.0) / length_scale;
+  T_l neg_root_3_inv_l = -1.0 * std::sqrt(3.0) / length_scale;
 
   for (size_t i = 0; i < x_size; ++i) {
     cov(i, i) = sigma_sq;
@@ -130,8 +129,8 @@ gp_matern32_cov(const std::vector<Eigen::Matrix<T_x, -1, 1>> &x,
                    "number of length scales", l_size);
 
   T_s sigma_sq = square(sigma);
-  double root_3 = sqrt(3.0);
-  double neg_root_3 = -1.0 * sqrt(3.0);
+  double root_3 = std::sqrt(3.0);
+  double neg_root_3 = -1.0 * std::sqrt(3.0);
 
   std::vector<Eigen::Matrix<return_type_t<T_x, T_l>, -1, 1>> x_new
       = divide_columns(x, length_scale);
@@ -209,8 +208,8 @@ gp_matern32_cov(const std::vector<T_x1> &x1, const std::vector<T_x2> &x2,
   check_positive_finite(function, "length scale", length_scale);
 
   T_s sigma_sq = square(sigma);
-  T_l root_3_inv_l_sq = sqrt(3.0) / length_scale;
-  T_l neg_root_3_inv_l_sq = -1.0 * sqrt(3.0) / length_scale;
+  T_l root_3_inv_l_sq = std::sqrt(3.0) / length_scale;
+  T_l neg_root_3_inv_l_sq = -1.0 * std::sqrt(3.0) / length_scale;
 
   for (size_t i = 0; i < x1_size; ++i) {
     for (size_t j = 0; j < x2_size; ++j) {
@@ -290,8 +289,8 @@ gp_matern32_cov(const std::vector<Eigen::Matrix<T_x1, -1, 1>> &x1,
   }
 
   T_s sigma_sq = square(sigma);
-  double root_3 = sqrt(3.0);
-  double neg_root_3 = -1.0 * sqrt(3.0);
+  double root_3 = std::sqrt(3.0);
+  double neg_root_3 = -1.0 * std::sqrt(3.0);
 
   std::vector<Eigen::Matrix<return_type_t<T_x1, T_l>, -1, 1>> x1_new
       = divide_columns(x1, length_scale);

--- a/stan/math/prim/fun/gp_matern32_cov.hpp
+++ b/stan/math/prim/fun/gp_matern32_cov.hpp
@@ -66,14 +66,13 @@ gp_matern32_cov(const std::vector<T_x> &x, const T_s &sigma,
 
   T_s sigma_sq = square(sigma);
   T_l root_3_inv_l = std::sqrt(3.0) / length_scale;
-  T_l neg_root_3_inv_l = -1.0 * std::sqrt(3.0) / length_scale;
 
   for (size_t i = 0; i < x_size; ++i) {
     cov(i, i) = sigma_sq;
     for (size_t j = i + 1; j < x_size; ++j) {
       return_type_t<T_x> dist = distance(x[i], x[j]);
       cov(i, j) = sigma_sq * (1.0 + root_3_inv_l * dist)
-                  * exp(neg_root_3_inv_l * dist);
+                  * exp(-root_3_inv_l * dist);
       cov(j, i) = cov(i, j);
     }
   }
@@ -130,7 +129,6 @@ gp_matern32_cov(const std::vector<Eigen::Matrix<T_x, -1, 1>> &x,
 
   T_s sigma_sq = square(sigma);
   double root_3 = std::sqrt(3.0);
-  double neg_root_3 = -1.0 * std::sqrt(3.0);
 
   std::vector<Eigen::Matrix<return_type_t<T_x, T_l>, -1, 1>> x_new
       = divide_columns(x, length_scale);
@@ -138,7 +136,7 @@ gp_matern32_cov(const std::vector<Eigen::Matrix<T_x, -1, 1>> &x,
   for (size_t i = 0; i < x_size; ++i) {
     for (size_t j = i; j < x_size; ++j) {
       return_type_t<T_x, T_l> dist = distance(x_new[i], x_new[j]);
-      cov(i, j) = sigma_sq * (1.0 + root_3 * dist) * exp(neg_root_3 * dist);
+      cov(i, j) = sigma_sq * (1.0 + root_3 * dist) * exp(-root_3 * dist);
       cov(j, i) = cov(i, j);
     }
   }
@@ -209,13 +207,12 @@ gp_matern32_cov(const std::vector<T_x1> &x1, const std::vector<T_x2> &x2,
 
   T_s sigma_sq = square(sigma);
   T_l root_3_inv_l_sq = std::sqrt(3.0) / length_scale;
-  T_l neg_root_3_inv_l_sq = -1.0 * std::sqrt(3.0) / length_scale;
 
   for (size_t i = 0; i < x1_size; ++i) {
     for (size_t j = 0; j < x2_size; ++j) {
       return_type_t<T_x1, T_x2> dist = distance(x1[i], x2[j]);
       cov(i, j) = sigma_sq * (1.0 + root_3_inv_l_sq * dist)
-                  * exp(neg_root_3_inv_l_sq * dist);
+                  * exp(-root_3_inv_l_sq * dist);
     }
   }
   return cov;
@@ -290,7 +287,6 @@ gp_matern32_cov(const std::vector<Eigen::Matrix<T_x1, -1, 1>> &x1,
 
   T_s sigma_sq = square(sigma);
   double root_3 = std::sqrt(3.0);
-  double neg_root_3 = -1.0 * std::sqrt(3.0);
 
   std::vector<Eigen::Matrix<return_type_t<T_x1, T_l>, -1, 1>> x1_new
       = divide_columns(x1, length_scale);
@@ -300,7 +296,7 @@ gp_matern32_cov(const std::vector<Eigen::Matrix<T_x1, -1, 1>> &x1,
   for (size_t i = 0; i < x1_size; ++i) {
     for (size_t j = 0; j < x2_size; ++j) {
       return_type_t<T_x1, T_x2, T_l> dist = distance(x1_new[i], x2_new[j]);
-      cov(i, j) = sigma_sq * (1.0 + root_3 * dist) * exp(neg_root_3 * dist);
+      cov(i, j) = sigma_sq * (1.0 + root_3 * dist) * exp(-root_3 * dist);
     }
   }
   return cov;

--- a/stan/math/prim/fun/gp_matern32_cov.hpp
+++ b/stan/math/prim/fun/gp_matern32_cov.hpp
@@ -71,8 +71,8 @@ gp_matern32_cov(const std::vector<T_x> &x, const T_s &sigma,
     cov(i, i) = sigma_sq;
     for (size_t j = i + 1; j < x_size; ++j) {
       return_type_t<T_x> dist = distance(x[i], x[j]);
-      cov(i, j) = sigma_sq * (1.0 + root_3_inv_l * dist)
-                  * exp(-root_3_inv_l * dist);
+      cov(i, j)
+          = sigma_sq * (1.0 + root_3_inv_l * dist) * exp(-root_3_inv_l * dist);
       cov(j, i) = cov(i, j);
     }
   }

--- a/stan/math/prim/fun/gp_matern52_cov.hpp
+++ b/stan/math/prim/fun/gp_matern52_cov.hpp
@@ -127,7 +127,6 @@ gp_matern52_cov(const std::vector<Eigen::Matrix<T_x, Eigen::Dynamic, 1>> &x,
   T_s sigma_sq = square(sigma);
   double root_5 = std::sqrt(5.0);
   double five_thirds = 5.0 / 3.0;
-  double neg_root_5 = -root_5;
 
   std::vector<Eigen::Matrix<return_type_t<T_x, T_l>, -1, 1>> x_new
       = divide_columns(x, length_scale);
@@ -139,7 +138,7 @@ gp_matern52_cov(const std::vector<Eigen::Matrix<T_x, Eigen::Dynamic, 1>> &x,
           = squared_distance(x_new[i], x_new[j]);
       return_type_t<T_x, T_l> dist = sqrt(sq_distance);
       cov(i, j) = sigma_sq * (1.0 + root_5 * dist + five_thirds * sq_distance)
-                  * exp(neg_root_5 * dist);
+                  * exp(-root_5 * dist);
       cov(j, i) = cov(i, j);
     }
   }
@@ -198,7 +197,6 @@ gp_matern52_cov(const std::vector<T_x1> &x1, const std::vector<T_x2> &x2,
   T_s sigma_sq = square(sigma);
   T_l root_5_inv_l = std::sqrt(5.0) / length_scale;
   T_l inv_l_sq_5_3 = 5.0 / (3.0 * square(length_scale));
-  T_l neg_root_5_inv_l = -std::sqrt(5.0) / length_scale;
 
   for (size_t i = 0; i < x1_size; ++i) {
     for (size_t j = 0; j < x2_size; ++j) {
@@ -206,7 +204,7 @@ gp_matern52_cov(const std::vector<T_x1> &x1, const std::vector<T_x2> &x2,
       return_type_t<T_x1, T_x2> dist = sqrt(sq_distance);
       cov(i, j) = sigma_sq
                   * (1.0 + root_5_inv_l * dist + inv_l_sq_5_3 * sq_distance)
-                  * exp(neg_root_5_inv_l * dist);
+                  * exp(-root_5_inv_l * dist);
     }
   }
   return cov;
@@ -275,7 +273,6 @@ gp_matern52_cov(const std::vector<Eigen::Matrix<T_x1, Eigen::Dynamic, 1>> &x1,
   T_s sigma_sq = square(sigma);
   double root_5 = std::sqrt(5.0);
   double five_thirds = 5.0 / 3.0;
-  double neg_root_5 = -root_5;
 
   std::vector<Eigen::Matrix<return_type_t<T_x1, T_l>, -1, 1>> x1_new
       = divide_columns(x1, length_scale);
@@ -288,7 +285,7 @@ gp_matern52_cov(const std::vector<Eigen::Matrix<T_x1, Eigen::Dynamic, 1>> &x1,
           = squared_distance(x1_new[i], x2_new[j]);
       return_type_t<T_x1, T_x2, T_l> dist = sqrt(sq_distance);
       cov(i, j) = sigma_sq * (1.0 + root_5 * dist + five_thirds * sq_distance)
-                  * exp(neg_root_5 * dist);
+                  * exp(-root_5 * dist);
     }
   }
   return cov;

--- a/stan/math/prim/fun/gp_matern52_cov.hpp
+++ b/stan/math/prim/fun/gp_matern52_cov.hpp
@@ -59,9 +59,9 @@ gp_matern52_cov(const std::vector<T_x> &x, const T_s &sigma,
   check_positive_finite("gp_matern52_cov", "length scale", length_scale);
 
   T_s sigma_sq = square(sigma);
-  T_l root_5_inv_l = sqrt(5.0) / length_scale;
+  T_l root_5_inv_l = std::sqrt(5.0) / length_scale;
   T_l inv_l_sq_5_3 = 5.0 / (3.0 * square(length_scale));
-  T_l neg_root_5_inv_l = -sqrt(5.0) / length_scale;
+  T_l neg_root_5_inv_l = -std::sqrt(5.0) / length_scale;
 
   for (size_t i = 0; i < x_size; ++i) {
     cov(i, i) = sigma_sq;
@@ -125,7 +125,7 @@ gp_matern52_cov(const std::vector<Eigen::Matrix<T_x, Eigen::Dynamic, 1>> &x,
                    "number of length scales", l_size);
 
   T_s sigma_sq = square(sigma);
-  double root_5 = sqrt(5.0);
+  double root_5 = std::sqrt(5.0);
   double five_thirds = 5.0 / 3.0;
   double neg_root_5 = -root_5;
 
@@ -196,9 +196,9 @@ gp_matern52_cov(const std::vector<T_x1> &x1, const std::vector<T_x2> &x2,
   check_positive_finite("gp_matern52_cov", "length scale", length_scale);
 
   T_s sigma_sq = square(sigma);
-  T_l root_5_inv_l = sqrt(5.0) / length_scale;
+  T_l root_5_inv_l = std::sqrt(5.0) / length_scale;
   T_l inv_l_sq_5_3 = 5.0 / (3.0 * square(length_scale));
-  T_l neg_root_5_inv_l = -sqrt(5.0) / length_scale;
+  T_l neg_root_5_inv_l = -std::sqrt(5.0) / length_scale;
 
   for (size_t i = 0; i < x1_size; ++i) {
     for (size_t j = 0; j < x2_size; ++j) {
@@ -273,7 +273,7 @@ gp_matern52_cov(const std::vector<Eigen::Matrix<T_x1, Eigen::Dynamic, 1>> &x1,
                    "number of length scales", l_size);
 
   T_s sigma_sq = square(sigma);
-  double root_5 = sqrt(5.0);
+  double root_5 = std::sqrt(5.0);
   double five_thirds = 5.0 / 3.0;
   double neg_root_5 = -root_5;
 

--- a/stan/math/prim/fun/lbeta.hpp
+++ b/stan/math/prim/fun/lbeta.hpp
@@ -12,6 +12,7 @@
 #include <stan/math/prim/fun/log_sum_exp.hpp>
 #include <stan/math/prim/fun/log1m.hpp>
 #include <stan/math/prim/fun/multiply_log.hpp>
+#include <cmath>
 
 namespace stan {
 namespace math {
@@ -64,6 +65,7 @@ namespace math {
  */
 template <typename T1, typename T2>
 return_type_t<T1, T2> lbeta(const T1 a, const T2 b) {
+  using std::log;
   using T_ret = return_type_t<T1, T2>;
 
   if (is_any_nan(a, b)) {

--- a/stan/math/prim/fun/lgamma_stirling.hpp
+++ b/stan/math/prim/fun/lgamma_stirling.hpp
@@ -23,6 +23,7 @@ namespace math {
  */
 template <typename T>
 return_type_t<T> lgamma_stirling(const T x) {
+  using std::log;
   return HALF_LOG_TWO_PI + (x - 0.5) * log(x) - x;
 }
 

--- a/stan/math/prim/fun/log.hpp
+++ b/stan/math/prim/fun/log.hpp
@@ -36,7 +36,7 @@ struct log_fun {
  * @param[in] x container
  * @return Elementwise application of natural log to the argument.
  */
-template <typename T, typename = require_not_eigen_vt<std::is_arithmetic, T>>
+template <typename T, typename = require_not_eigen_vt<std::is_arithmetic, T>, typename = require_not_double_or_int_t<T>>
 inline auto log(const T& x) {
   return apply_scalar_unary<log_fun, T>::apply(x);
 }

--- a/stan/math/prim/fun/log.hpp
+++ b/stan/math/prim/fun/log.hpp
@@ -36,8 +36,7 @@ struct log_fun {
  * @param[in] x container
  * @return Elementwise application of natural log to the argument.
  */
-template <typename T, typename = require_not_eigen_vt<std::is_arithmetic, T>,
-          typename = require_not_double_or_int_t<T>>
+template <typename T, typename = require_not_eigen_vt<std::is_arithmetic, T>>
 inline auto log(const T& x) {
   return apply_scalar_unary<log_fun, T>::apply(x);
 }

--- a/stan/math/prim/fun/log.hpp
+++ b/stan/math/prim/fun/log.hpp
@@ -36,7 +36,8 @@ struct log_fun {
  * @param[in] x container
  * @return Elementwise application of natural log to the argument.
  */
-template <typename T, typename = require_not_eigen_vt<std::is_arithmetic, T>, typename = require_not_double_or_int_t<T>>
+template <typename T, typename = require_not_eigen_vt<std::is_arithmetic, T>,
+          typename = require_not_double_or_int_t<T>>
 inline auto log(const T& x) {
   return apply_scalar_unary<log_fun, T>::apply(x);
 }

--- a/stan/math/prim/fun/log.hpp
+++ b/stan/math/prim/fun/log.hpp
@@ -10,15 +10,6 @@ namespace stan {
 namespace math {
 
 /**
- * Return the natural log of the specified argument.  This version
- * is required to disambiguate <code>log(int)</code>.
- *
- * @param[in] x Argument.
- * @return Natural log of argument.
- */
-inline double log(int x) { return std::log(x); }
-
-/**
  * Structure to wrap log() so that it can be vectorized.
  */
 struct log_fun {

--- a/stan/math/prim/fun/log1p.hpp
+++ b/stan/math/prim/fun/log1p.hpp
@@ -27,12 +27,8 @@ namespace math {
  * @throw std::domain_error If argument is less than -1.
  */
 inline double log1p(double x) {
-  if (is_nan(x)) {
-    return x;
-  } else {
-    check_greater_or_equal("log1p", "x", x, -1.0);
-    return std::log1p(x);
-  }
+  check_greater_or_equal("log1p", "x", x, -1.0);
+  return std::log1p(x);
 }
 
 /**
@@ -45,12 +41,8 @@ inline double log1p(double x) {
  * @throw std::domain_error If argument is less than -1.
  */
 inline double log1p(int x) {
-  if (is_nan(x)) {
-    return x;
-  } else {
-    check_greater_or_equal("log1p", "x", x, -1);
-    return std::log1p(x);
-  }
+  check_greater_or_equal("log1p", "x", x, -1);
+  return std::log1p(x);
 }
 
 /**

--- a/stan/math/prim/fun/log1p.hpp
+++ b/stan/math/prim/fun/log1p.hpp
@@ -27,8 +27,12 @@ namespace math {
  * @throw std::domain_error If argument is less than -1.
  */
 inline double log1p(double x) {
-  check_greater_or_equal("log1p", "x", x, -1.0);
-  return std::log1p(x);
+  if (is_nan(x)) {
+    return x;
+  } else {
+    check_greater_or_equal("log1p", "x", x, -1.0);
+    return std::log1p(x);
+  }
 }
 
 /**

--- a/stan/math/prim/fun/round.hpp
+++ b/stan/math/prim/fun/round.hpp
@@ -9,24 +9,6 @@ namespace stan {
 namespace math {
 
 /**
- * Return the closest integer to the specified argument, with
- * halfway cases rounded away from zero.
- *
- * @param x Argument.
- * @return The rounded value of the argument.
- */
-inline double round(double x) { return std::round(x); }
-
-/**
- * Return the closest integer to the specified argument, with
- * halfway cases rounded away from zero.
- *
- * @param x Argument.
- * @return The rounded value of the argument.
- */
-inline double round(int x) { return std::round(x); }
-
-/**
  * Structure to wrap round() so it can be vectorized.
  *
  * @tparam T type of argument
@@ -36,6 +18,7 @@ inline double round(int x) { return std::round(x); }
 struct round_fun {
   template <typename T>
   static inline T fun(const T& x) {
+    using std::round;
     return round(x);
   }
 };

--- a/stan/math/prim/fun/sqrt.hpp
+++ b/stan/math/prim/fun/sqrt.hpp
@@ -30,7 +30,8 @@ struct sqrt_fun {
  * @param x container
  * @return Square root of each value in x.
  */
-template <typename T, typename = require_not_eigen_vt<std::is_arithmetic, T>, typename = require_not_double_or_int_t<T>>
+template <typename T, typename = require_not_eigen_vt<std::is_arithmetic, T>,
+          typename = require_not_double_or_int_t<T>>
 inline auto sqrt(const T& x) {
   return apply_scalar_unary<sqrt_fun, T>::apply(x);
 }

--- a/stan/math/prim/fun/sqrt.hpp
+++ b/stan/math/prim/fun/sqrt.hpp
@@ -30,8 +30,7 @@ struct sqrt_fun {
  * @param x container
  * @return Square root of each value in x.
  */
-template <typename T, typename = require_not_eigen_vt<std::is_arithmetic, T>,
-          typename = require_not_double_or_int_t<T>>
+template <typename T, typename = require_not_eigen_vt<std::is_arithmetic, T>>
 inline auto sqrt(const T& x) {
   return apply_scalar_unary<sqrt_fun, T>::apply(x);
 }

--- a/stan/math/prim/fun/sqrt.hpp
+++ b/stan/math/prim/fun/sqrt.hpp
@@ -30,7 +30,7 @@ struct sqrt_fun {
  * @param x container
  * @return Square root of each value in x.
  */
-template <typename T, typename = require_not_eigen_vt<std::is_arithmetic, T>>
+template <typename T, typename = require_not_eigen_vt<std::is_arithmetic, T>, typename = require_not_double_or_int_t<T>>
 inline auto sqrt(const T& x) {
   return apply_scalar_unary<sqrt_fun, T>::apply(x);
 }

--- a/stan/math/prim/fun/sqrt.hpp
+++ b/stan/math/prim/fun/sqrt.hpp
@@ -9,15 +9,6 @@ namespace stan {
 namespace math {
 
 /**
- * Return the square root of the specified argument.  This
- * version is required to disambiguate <code>sqrt(int)</code>.
- *
- * @param[in] x Argument.
- * @return Natural exponential of argument.
- */
-inline double sqrt(int x) { return std::sqrt(x); }
-
-/**
  * Structure to wrap sqrt() so that it can be vectorized.
  *
  * @tparam T type of variable

--- a/stan/math/prim/fun/trunc.hpp
+++ b/stan/math/prim/fun/trunc.hpp
@@ -8,24 +8,6 @@ namespace stan {
 namespace math {
 
 /**
- * Return the nearest integral value that is not larger in
- * magnitude than the specified argument.
- *
- * @param[in] x Argument.
- * @return The truncated argument.
- */
-inline double trunc(double x) { return std::trunc(x); }
-
-/**
- * Return the nearest integral value that is not larger in
- * magnitude than the specified argument.
- *
- * @param[in] x Argument.
- * @return The truncated argument.
- */
-inline double trunc(int x) { return std::trunc(x); }
-
-/**
  * Structure to wrap trunc() so it can be vectorized.
  */
 struct trunc_fun {
@@ -39,6 +21,7 @@ struct trunc_fun {
    */
   template <typename T>
   static inline T fun(const T& x) {
+    using std::trunc;
     return trunc(x);
   }
 };

--- a/test/unit/math/prim/fun/exp_test.cpp
+++ b/test/unit/math/prim/fun/exp_test.cpp
@@ -1,11 +1,10 @@
 #include <stan/math.hpp>
 #include <gtest/gtest.h>
+#include <cmath> 
 
 TEST(MathFunctions, expInt) {
-  using stan::math::exp;
-  using std::exp;
-  EXPECT_FLOAT_EQ(std::exp(3), exp(3));
-  EXPECT_FLOAT_EQ(std::exp(3.0), exp(3.0));
+  EXPECT_FLOAT_EQ(std::exp(3), stan::math::exp(3));
+  EXPECT_FLOAT_EQ(std::exp(3.0), stan::math::exp(3.0));
 }
 
 TEST(MathFunctions, exp_works_with_other_functions) {

--- a/test/unit/math/prim/fun/exp_test.cpp
+++ b/test/unit/math/prim/fun/exp_test.cpp
@@ -1,6 +1,6 @@
 #include <stan/math.hpp>
 #include <gtest/gtest.h>
-#include <cmath> 
+#include <cmath>
 
 TEST(MathFunctions, expInt) {
   EXPECT_FLOAT_EQ(std::exp(3), stan::math::exp(3));

--- a/test/unit/math/prim/fun/log_test.cpp
+++ b/test/unit/math/prim/fun/log_test.cpp
@@ -1,11 +1,10 @@
 #include <stan/math.hpp>
 #include <gtest/gtest.h>
+#include <cmath>
 
 TEST(MathFunctions, logInt) {
-  using stan::math::log;
-  using std::log;
-  EXPECT_FLOAT_EQ(std::log(3), log(3));
-  EXPECT_FLOAT_EQ(std::log(3.0), log(3.0));
+  EXPECT_FLOAT_EQ(std::log(3), stan::math::log(3));
+  EXPECT_FLOAT_EQ(std::log(3.0), stan::math::log(3.0));
 }
 
 TEST(MathFunctions, log_works_with_other_functions) {

--- a/test/unit/math/prim/fun/sqrt_test.cpp
+++ b/test/unit/math/prim/fun/sqrt_test.cpp
@@ -2,10 +2,8 @@
 #include <gtest/gtest.h>
 
 TEST(MathFunctions, sqrtInt) {
-  using stan::math::sqrt;
-  using std::sqrt;
-  EXPECT_FLOAT_EQ(std::sqrt(3.0), sqrt(3));
-  EXPECT_TRUE(stan::math::is_nan(sqrt(-2)));
+  EXPECT_FLOAT_EQ(std::sqrt(3.0), stan::math::sqrt(3));
+  EXPECT_TRUE(stan::math::is_nan(stan::math::sqrt(-2)));
 }
 
 TEST(MathFunctions, sqrt_works_with_other_functions) {


### PR DESCRIPTION
## Summary

C++11 added overloads for integers for some of the base functions. Previously Stan Math had its own overloads for these to avoid ambiguity with (var) overloads as it wasnt clear whether to promote to double or var. 

This PR removes the following:
    - asinh(double) and asinh(int)
    - cbrt(double), cbrt(int)
    - erf(double), erf(int)
    - erfc(double), erf(int)
    - exp(int)
    - expm1(int)
    - log(int)
    - sqrt(int)
    - round(double), round(int)
    - trunc(double), trunc(int)

The following integer overloads will stay in: 
- acosh, atanh, log1p (I cleaned up these a bit because I dont think is_nan on integer values is needed). The overloads have to stay because Stan Math throws for some input values, std:: returns nan and std:: throws for value we want to throw ourselves.
- lgamma (no changes here, this will stay because std::lgamma is not thread-safe)

Due to removing some signatures I had to fix the functions to now use std for double/int inputs. And that then led to a minor code cleanup in gp_matern* files.

This now also fixes #1704 by including `cmath` and adding using `std::log` statements in lgamma_stirling and lbeta.

## Tests

No new tests, existing tests cover all the cases.

## Side Effects

Hopefully none.

## Checklist

- [x] Math issue #1692 

- [x] Copyright holder: Rok Češnovar

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
