### PR TITLE
Check for positive definiteness only after computing the LLT factors

### DIFF
--- a/stan/math/prim/err/check_pos_definite.hpp
+++ b/stan/math/prim/err/check_pos_definite.hpp
@@ -15,14 +15,19 @@ namespace math {
 
 /**
  * Check if the specified square, symmetric matrix is positive definite.
- * @tparam T_y Type of scalar of the matrix
- * @param function Function name (for error messages)
- * @param name Variable name (for error messages)
- * @param y Matrix to test
- * @throw <code>std::invalid_argument</code> if the matrix is not square
+ *
+ * This computes an LDLT decomposition to establish positive definiteness,
+ * so it can be expensive. If an LDLT or LLT decomposition is available,
+ * that should be tested instead.
+ *
+ * @tparam T_y type of elements in the matrix
+ * @param function function name (for error messages)
+ * @param name variable name (for error messages)
+ * @param y matrix to test
+ * @throw std::invalid_argument if the matrix is not square
  * or if the matrix has 0 size.
- * @throw <code>std::domain_error</code> if the matrix is not symmetric,
- * if it is not positive definite, or if any element is <code>NaN</code>
+ * @throw std::domain_error if the matrix is not symmetric,
+ * if it is not positive definite, or if any element is NaN
  */
 template <typename T_y>
 inline void check_pos_definite(const char* function, const char* name,
@@ -43,14 +48,14 @@ inline void check_pos_definite(const char* function, const char* name,
 }
 
 /**
- * Check if the specified LDLT transform of a matrix is positive definite.
- * @tparam Derived Derived type of the Eigen::LDLT transform.
- * @param function Function name (for error messages)
- * @param name Variable name (for error messages)
+ * Check if the specified LDLT decomposition of a matrix is positive definite.
+ *
+ * @tparam Derived type of the Eigen::LDLT decomposition
+ * @param function function name (for error messages)
+ * @param name variable name (for error messages)
  * @param cholesky Eigen::LDLT to test, whose progenitor
  * must not have any NaN elements
- * @throw <code>std::domain_error</code> if the matrix is not
- * positive definite
+ * @throw std::domain_error if the matrix is not positive definite
  */
 template <typename Derived>
 inline void check_pos_definite(const char* function, const char* name,
@@ -62,15 +67,15 @@ inline void check_pos_definite(const char* function, const char* name,
 }
 
 /**
- * Check if the specified LLT decomposition transform resulted in
- * <code>Eigen::Success</code>
- * @tparam Derived Derived type of the Eigen::LLT transform.
- * @param function Function name (for error messages)
- * @param name Variable name (for error messages)
+ * Check if the specified LLT decomposition was successful.
+ *
+ * @tparam Derived type of the Eigen::LLT decomposition
+ * @param function function name (for error messages)
+ * @param name variable name (for error messages)
  * @param cholesky Eigen::LLT to test, whose progenitor
  * must not have any NaN elements
- * @throw <code>std::domain_error</code> if the diagonal of the
- * L matrix is not positive
+ * @throw std::domain_error if the decomposition failed or the
+ * diagonal of the L matrix is not positive
  */
 template <typename Derived>
 inline void check_pos_definite(const char* function, const char* name,

--- a/stan/math/prim/fun/cholesky_decompose.hpp
+++ b/stan/math/prim/fun/cholesky_decompose.hpp
@@ -32,6 +32,7 @@ template <typename T>
 inline Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> cholesky_decompose(
     const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& m) {
   check_symmetric("cholesky_decompose", "m", m);
+  check_not_nan("cholesky_decompose", "m", m);
   Eigen::LLT<Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> > llt(m.rows());
   llt.compute(m);
   check_pos_definite("cholesky_decompose", "m", llt);
@@ -56,7 +57,7 @@ inline Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> cholesky_decompose(
 template <>
 inline Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> cholesky_decompose(
     const Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>& m) {
-  check_square("cholesky_decompose", "m", m);
+  check_not_nan("cholesky_decompose", "m", m);
 #ifdef STAN_OPENCL
   if (m.rows() >= opencl_context.tuning_opts().cholesky_size_worth_transfer) {
     matrix_cl<double> m_chol(m);

--- a/stan/math/prim/fun/mdivide_left_spd.hpp
+++ b/stan/math/prim/fun/mdivide_left_spd.hpp
@@ -30,14 +30,15 @@ namespace math {
 template <typename T1, typename T2, int R1, int C1, int R2, int C2>
 inline Eigen::Matrix<return_type_t<T1, T2>, R1, C2> mdivide_left_spd(
     const Eigen::Matrix<T1, R1, C1> &A, const Eigen::Matrix<T2, R2, C2> &b) {
-  check_multiplicable("mdivide_left_spd", "A", A, "b", b);
-  check_pos_definite("mdivide_left_spd", "A", A);
-  return promote_common<Eigen::Matrix<T1, R1, C1>, Eigen::Matrix<T2, R1, C1> >(
-             A)
-      .llt()
-      .solve(
-          promote_common<Eigen::Matrix<T1, R2, C2>, Eigen::Matrix<T2, R2, C2> >(
-              b));
+  static const char* function = "mdivide_left_spd";
+  check_multiplicable(function, "A", A, "b", b);
+  check_positive(function, "rows", A.rows());
+  check_symmetric(function, "A", A);
+  check_not_nan(function, "A", A);
+
+  auto llt = Eigen::Matrix<return_type_t<T1, T2>, R1, C1>(A).llt();
+  check_pos_definite(function, "A", llt);
+  return llt.solve(Eigen::Matrix<return_type_t<T1, T2>, R2, C2>(b));
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/mdivide_left_spd.hpp
+++ b/stan/math/prim/fun/mdivide_left_spd.hpp
@@ -30,7 +30,7 @@ namespace math {
 template <typename T1, typename T2, int R1, int C1, int R2, int C2>
 inline Eigen::Matrix<return_type_t<T1, T2>, R1, C2> mdivide_left_spd(
     const Eigen::Matrix<T1, R1, C1> &A, const Eigen::Matrix<T2, R2, C2> &b) {
-  static const char* function = "mdivide_left_spd";
+  static const char *function = "mdivide_left_spd";
   check_multiplicable(function, "A", A, "b", b);
   check_positive(function, "rows", A.rows());
   check_symmetric(function, "A", A);

--- a/stan/math/prim/fun/mdivide_right_spd.hpp
+++ b/stan/math/prim/fun/mdivide_right_spd.hpp
@@ -31,8 +31,11 @@ namespace math {
 template <typename T1, typename T2, int R1, int C1, int R2, int C2>
 inline Eigen::Matrix<return_type_t<T1, T2>, R1, C2> mdivide_right_spd(
     const Eigen::Matrix<T1, R1, C1> &b, const Eigen::Matrix<T2, R2, C2> &A) {
-  check_multiplicable("mdivide_right_spd", "b", b, "A", A);
-  check_pos_definite("mdivide_right_spd", "A", A);
+  static const char* function = "mdivide_right_spd";
+  check_multiplicable(function, "b", b, "A", A);
+  check_positive(function, "rows", A.rows());
+  check_symmetric(function, "A", A);
+  check_not_nan(function, "A", A);
   // FIXME: After allowing for general MatrixBase in mdivide_left_spd,
   //        change to b.transpose()
   return mdivide_left_spd(A, transpose(b)).transpose();

--- a/stan/math/prim/fun/mdivide_right_spd.hpp
+++ b/stan/math/prim/fun/mdivide_right_spd.hpp
@@ -31,7 +31,7 @@ namespace math {
 template <typename T1, typename T2, int R1, int C1, int R2, int C2>
 inline Eigen::Matrix<return_type_t<T1, T2>, R1, C2> mdivide_right_spd(
     const Eigen::Matrix<T1, R1, C1> &b, const Eigen::Matrix<T2, R2, C2> &A) {
-  static const char* function = "mdivide_right_spd";
+  static const char *function = "mdivide_right_spd";
   check_multiplicable(function, "b", b, "A", A);
   check_positive(function, "rows", A.rows());
   check_symmetric(function, "A", A);

--- a/stan/math/prim/prob/multi_normal_rng.hpp
+++ b/stan/math/prim/prob/multi_normal_rng.hpp
@@ -37,6 +37,7 @@ multi_normal_rng(const T_loc& mu,
   static const char* function = "multi_normal_rng";
 
   check_positive(function, "Covariance matrix rows", S.rows());
+  check_not_nan(function, "Covariance matrix", S);
   check_symmetric(function, "Covariance matrix", S);
   Eigen::LLT<Eigen::MatrixXd> llt_of_S = S.llt();
   check_pos_definite("multi_normal_rng", "covariance matrix argument",

--- a/stan/math/prim/prob/multi_student_t_rng.hpp
+++ b/stan/math/prim/prob/multi_student_t_rng.hpp
@@ -44,6 +44,7 @@ multi_student_t_rng(
   check_not_nan(function, "Degrees of freedom parameter", nu);
   check_positive(function, "Degrees of freedom parameter", nu);
   check_positive(function, "Covariance matrix rows", S.rows());
+  check_not_nan(function, "Covariance matrix", S);
   check_symmetric(function, "Covariance matrix", S);
   Eigen::LLT<Eigen::MatrixXd> llt_of_S = S.llt();
   check_pos_definite(function, "covariance matrix argument", llt_of_S);

--- a/stan/math/rev/fun/cholesky_decompose.hpp
+++ b/stan/math/rev/fun/cholesky_decompose.hpp
@@ -376,14 +376,14 @@ class cholesky_opencl : public vari {
  */
 inline Eigen::Matrix<var, -1, -1> cholesky_decompose(
     const Eigen::Matrix<var, -1, -1>& A) {
-  check_square("cholesky_decompose", "A", A);
+  check_not_nan("cholesky_decompose", "A", A);
   Eigen::Matrix<double, -1, -1> L_A(value_of_rec(A));
 #ifdef STAN_OPENCL
   L_A = cholesky_decompose(L_A);
 #else
   check_symmetric("cholesky_decompose", "A", A);
   Eigen::LLT<Eigen::Ref<Eigen::MatrixXd>, Eigen::Lower> L_factor(L_A);
-  check_pos_definite("cholesky_decompose", "m", L_factor);
+  check_pos_definite("cholesky_decompose", "A", L_factor);
 #endif
   // Memory allocated in arena.
   // cholesky_scalar gradient faster for small matrices compared to

--- a/stan/math/rev/fun/mdivide_left_spd.hpp
+++ b/stan/math/rev/fun/mdivide_left_spd.hpp
@@ -51,6 +51,7 @@ class mdivide_left_spd_vv_vari : public vari {
     Eigen::Map<matrix_vi>(variRefB_, M_, N_) = B.vi();
     alloc_->C_ = B.val();
     alloc_->llt_ = A.val().llt();
+    check_pos_definite("mdivide_left_spd", "A", alloc_->llt_);
     alloc_->llt_.solveInPlace(alloc_->C_);
 
     Eigen::Map<matrix_vi>(variRefC_, M_, N_)
@@ -90,6 +91,7 @@ class mdivide_left_spd_dv_vari : public vari {
     alloc_->C_ = B.val();
     Eigen::Map<matrix_vi>(variRefB_, M_, N_) = B.vi();
     alloc_->llt_ = A.llt();
+    check_pos_definite("mdivide_left_spd", "A", alloc_->llt_);
     alloc_->llt_.solveInPlace(alloc_->C_);
 
     Eigen::Map<matrix_vi>(variRefC_, M_, N_)
@@ -126,6 +128,7 @@ class mdivide_left_spd_vd_vari : public vari {
         alloc_(new mdivide_left_spd_alloc<R1, C1, R2, C2>()) {
     Eigen::Map<matrix_vi>(variRefA_, M_, M_) = A.vi();
     alloc_->llt_ = A.val().llt();
+    check_pos_definite("mdivide_left_spd", "A", alloc_->llt_);
     alloc_->C_ = alloc_->llt_.solve(B);
 
     Eigen::Map<matrix_vi>(variRefC_, M_, N_)
@@ -144,10 +147,11 @@ template <int R1, int C1, int R2, int C2>
 inline Eigen::Matrix<var, R1, C2> mdivide_left_spd(
     const Eigen::Matrix<var, R1, C1> &A, const Eigen::Matrix<var, R2, C2> &b) {
   Eigen::Matrix<var, R1, C2> res(b.rows(), b.cols());
-
-  check_square("mdivide_left_spd", "A", A);
-  check_multiplicable("mdivide_left_spd", "A", A, "b", b);
-  check_pos_definite("mdivide_left_spd", "A", A);
+  static const char* function = "mdivide_left_spd";
+  check_multiplicable(function, "A", A, "b", b);
+  check_positive(function, "rows", A.rows());
+  check_symmetric(function, "A", A);
+  check_not_nan(function, "A", A);
 
   // NOTE: this is not a memory leak, this vari is used in the
   // expression graph to evaluate the adjoint, but is not needed
@@ -164,11 +168,11 @@ template <int R1, int C1, int R2, int C2>
 inline Eigen::Matrix<var, R1, C2> mdivide_left_spd(
     const Eigen::Matrix<var, R1, C1> &A,
     const Eigen::Matrix<double, R2, C2> &b) {
-  Eigen::Matrix<var, R1, C2> res(b.rows(), b.cols());
-
-  check_square("mdivide_left_spd", "A", A);
-  check_multiplicable("mdivide_left_spd", "A", A, "b", b);
-  check_pos_definite("mdivide_left_spd", "A", A);
+  static const char* function = "mdivide_left_spd";
+  check_multiplicable(function, "A", A, "b", b);
+  check_positive(function, "rows", A.rows());
+  check_symmetric(function, "A", A);
+  check_not_nan(function, "A", A);
 
   // NOTE: this is not a memory leak, this vari is used in the
   // expression graph to evaluate the adjoint, but is not needed
@@ -177,6 +181,7 @@ inline Eigen::Matrix<var, R1, C2> mdivide_left_spd(
   internal::mdivide_left_spd_vd_vari<R1, C1, R2, C2> *baseVari
       = new internal::mdivide_left_spd_vd_vari<R1, C1, R2, C2>(A, b);
 
+  Eigen::Matrix<var, R1, C2> res(b.rows(), b.cols());
   res.vi() = Eigen::Map<matrix_vi>(&baseVari->variRefC_[0], b.rows(), b.cols());
   return res;
 }
@@ -185,11 +190,11 @@ template <int R1, int C1, int R2, int C2>
 inline Eigen::Matrix<var, R1, C2> mdivide_left_spd(
     const Eigen::Matrix<double, R1, C1> &A,
     const Eigen::Matrix<var, R2, C2> &b) {
-  Eigen::Matrix<var, R1, C2> res(b.rows(), b.cols());
-
-  check_square("mdivide_left_spd", "A", A);
-  check_multiplicable("mdivide_left_spd", "A", A, "b", b);
-  check_pos_definite("mdivide_left_spd", "A", A);
+  static const char* function = "mdivide_left_spd";
+  check_multiplicable(function, "A", A, "b", b);
+  check_positive(function, "rows", A.rows());
+  check_symmetric(function, "A", A);
+  check_not_nan(function, "A", A);
 
   // NOTE: this is not a memory leak, this vari is used in the
   // expression graph to evaluate the adjoint, but is not needed
@@ -198,6 +203,7 @@ inline Eigen::Matrix<var, R1, C2> mdivide_left_spd(
   internal::mdivide_left_spd_dv_vari<R1, C1, R2, C2> *baseVari
       = new internal::mdivide_left_spd_dv_vari<R1, C1, R2, C2>(A, b);
 
+  Eigen::Matrix<var, R1, C2> res(b.rows(), b.cols());
   res.vi() = Eigen::Map<matrix_vi>(&baseVari->variRefC_[0], b.rows(), b.cols());
 
   return res;

--- a/stan/math/rev/fun/mdivide_left_spd.hpp
+++ b/stan/math/rev/fun/mdivide_left_spd.hpp
@@ -147,7 +147,7 @@ template <int R1, int C1, int R2, int C2>
 inline Eigen::Matrix<var, R1, C2> mdivide_left_spd(
     const Eigen::Matrix<var, R1, C1> &A, const Eigen::Matrix<var, R2, C2> &b) {
   Eigen::Matrix<var, R1, C2> res(b.rows(), b.cols());
-  static const char* function = "mdivide_left_spd";
+  static const char *function = "mdivide_left_spd";
   check_multiplicable(function, "A", A, "b", b);
   check_positive(function, "rows", A.rows());
   check_symmetric(function, "A", A);
@@ -168,7 +168,7 @@ template <int R1, int C1, int R2, int C2>
 inline Eigen::Matrix<var, R1, C2> mdivide_left_spd(
     const Eigen::Matrix<var, R1, C1> &A,
     const Eigen::Matrix<double, R2, C2> &b) {
-  static const char* function = "mdivide_left_spd";
+  static const char *function = "mdivide_left_spd";
   check_multiplicable(function, "A", A, "b", b);
   check_positive(function, "rows", A.rows());
   check_symmetric(function, "A", A);
@@ -190,7 +190,7 @@ template <int R1, int C1, int R2, int C2>
 inline Eigen::Matrix<var, R1, C2> mdivide_left_spd(
     const Eigen::Matrix<double, R1, C1> &A,
     const Eigen::Matrix<var, R2, C2> &b) {
-  static const char* function = "mdivide_left_spd";
+  static const char *function = "mdivide_left_spd";
   check_multiplicable(function, "A", A, "b", b);
   check_positive(function, "rows", A.rows());
   check_symmetric(function, "A", A);


### PR DESCRIPTION
## Summary
This uses the `check_pos_definite` overload to check an LLT decompositions after it's computed, rather than using the generic `check_pos_definite` on the original matrix, as that would compute and then discard an LDLT decomposition of the matrix. Fixes #1693.

Since this other overload doesn't first check for NaNs or symmetry, I added those where necessary. Note that it's not necessary to check explicitly for a square matrix if we also check for symmetry, because the latter implies the former, that's why I removed some `check_square` in a couple of places.

I had a very brief look at the performance impact with this code:
```
TEST(MathMatrixPrim, mdivide_spd) {
  const int size = 100; // 200
  stan::math::vector_d d = Eigen::VectorXd::Ones(size) * 20;
  stan::math::matrix_d diag = d.asDiagonal();
  stan::math::matrix_d R = Eigen::MatrixXd::Random(size, size);
  stan::math::matrix_d A = 0.5 * (R + R.transpose()) + diag;

  for (int i = 0; i < 100; i++) {
    stan::math::matrix_d m1 = stan::math::mdivide_left_spd(A, A);
    stan::math::matrix_d m2 = stan::math::mdivide_right_spd(A, A);
  }
}
```
size 100: from 8706ms to 7011ms
size 200: from 49912ms to 40712ms

## Tests

No new tests.

## Side Effects

None.

## Checklist

- [X] Math issue #1693

- [X] Copyright holder: Marco Colombo

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [X] the new changes are tested
