### PR TITLE
fix develop

### DIFF
--- a/stan/math/fwd/fun/quad_form.hpp
+++ b/stan/math/fwd/fun/quad_form.hpp
@@ -2,8 +2,8 @@
 #define STAN_MATH_FWD_FUN_QUAD_FORM_HPP
 
 #include <stan/math/fwd/core.hpp>
-#include <stan/math/fwd/fun/dot_product.hpp>
 #include <stan/math/fwd/fun/multiply.hpp>
+#include <stan/math/prim/fun/dot_product.hpp>
 
 namespace stan {
 namespace math {


### PR DESCRIPTION
## Summary

Fix for develop. PR #1628  that was merged last has removed `fwd/fun/dot_product.hpp`. However  PR #1698 added an include to that file. PR #1698 was merged after the tests in #1628 passed and there was no conflict that would require an additional merge and tests. Hence this PR.

## Tests

/

## Side Effects

/

## Checklist

- [x] Copyright holder: Rok Češnovar

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
