### PR TITLE
Cleanup mdivide_* and tests

### DIFF
--- a/stan/math/fwd/fun/mdivide_left.hpp
+++ b/stan/math/fwd/fun/mdivide_left.hpp
@@ -5,7 +5,6 @@
 #include <stan/math/prim/fun/Eigen.hpp>
 #include <stan/math/prim/fun/mdivide_left.hpp>
 #include <stan/math/prim/fun/multiply.hpp>
-#include <stan/math/prim/fun/typedefs.hpp>
 #include <stan/math/fwd/core.hpp>
 #include <stan/math/fwd/fun/multiply.hpp>
 #include <stan/math/fwd/fun/to_fvar.hpp>

--- a/stan/math/fwd/fun/mdivide_left_tri_low.hpp
+++ b/stan/math/fwd/fun/mdivide_left_tri_low.hpp
@@ -13,7 +13,7 @@ namespace stan {
 namespace math {
 
 template <typename T, int R1, int C1, int R2, int C2>
-inline Eigen::Matrix<fvar<T>, R1, C1> mdivide_left_tri_low(
+inline Eigen::Matrix<fvar<T>, R1, C2> mdivide_left_tri_low(
     const Eigen::Matrix<fvar<T>, R1, C1>& A,
     const Eigen::Matrix<fvar<T>, R2, C2>& b) {
   check_square("mdivide_left_tri_low", "A", A);
@@ -54,7 +54,7 @@ inline Eigen::Matrix<fvar<T>, R1, C1> mdivide_left_tri_low(
 }
 
 template <typename T, int R1, int C1, int R2, int C2>
-inline Eigen::Matrix<fvar<T>, R1, C1> mdivide_left_tri_low(
+inline Eigen::Matrix<fvar<T>, R1, C2> mdivide_left_tri_low(
     const Eigen::Matrix<double, R1, C1>& A,
     const Eigen::Matrix<fvar<T>, R2, C2>& b) {
   check_square("mdivide_left_tri_low", "A", A);
@@ -90,7 +90,7 @@ inline Eigen::Matrix<fvar<T>, R1, C1> mdivide_left_tri_low(
 }
 
 template <typename T, int R1, int C1, int R2, int C2>
-inline Eigen::Matrix<fvar<T>, R1, C1> mdivide_left_tri_low(
+inline Eigen::Matrix<fvar<T>, R1, C2> mdivide_left_tri_low(
     const Eigen::Matrix<fvar<T>, R1, C1>& A,
     const Eigen::Matrix<double, R2, C2>& b) {
   check_square("mdivide_left_tri_low", "A", A);

--- a/stan/math/fwd/fun/mdivide_right.hpp
+++ b/stan/math/fwd/fun/mdivide_right.hpp
@@ -8,7 +8,6 @@
 #include <stan/math/fwd/core.hpp>
 #include <stan/math/fwd/fun/multiply.hpp>
 #include <stan/math/fwd/fun/to_fvar.hpp>
-#include <stan/math/fwd/fun/typedefs.hpp>
 #include <vector>
 
 namespace stan {

--- a/stan/math/opencl/prim/mdivide_left_tri_low.hpp
+++ b/stan/math/opencl/prim/mdivide_left_tri_low.hpp
@@ -6,11 +6,13 @@
 #include <stan/math/opencl/matrix_cl.hpp>
 #include <stan/math/opencl/multiply.hpp>
 #include <stan/math/opencl/tri_inverse.hpp>
+
 namespace stan {
 namespace math {
 
 /**
  * Returns the solution of the system Ax=b when A is lower triangular.
+ *
  * @tparam T1 type of elements in A
  * @tparam T2 type of elements in b
  * @param A Triangular matrix.
@@ -30,6 +32,7 @@ inline matrix_cl<return_type_t<T1, T2>> mdivide_left_tri_low(
 
 /**
  * Returns the solution of the system Ax=b when A is triangular and b=I.
+ *
  * @tparam T type of elements in A
  * @tparam R1 number of rows in A
  * @tparam C1 number of columns in A

--- a/stan/math/opencl/prim/mdivide_right_tri_low.hpp
+++ b/stan/math/opencl/prim/mdivide_right_tri_low.hpp
@@ -6,12 +6,14 @@
 #include <stan/math/opencl/matrix_cl.hpp>
 #include <stan/math/opencl/multiply.hpp>
 #include <stan/math/opencl/tri_inverse.hpp>
+
 namespace stan {
 namespace math {
 
 /**
  * Returns the solution of the system Ax=b where A is a
  * lower triangular matrix.
+ *
  * @param A Matrix.
  * @param b Right hand side matrix or vector.
  * @return x = b * tri(A)^-1, solution of the linear system.

--- a/stan/math/prim/fun/mdivide_left.hpp
+++ b/stan/math/prim/fun/mdivide_left.hpp
@@ -1,9 +1,9 @@
 #ifndef STAN_MATH_PRIM_FUN_MDIVIDE_LEFT_HPP
 #define STAN_MATH_PRIM_FUN_MDIVIDE_LEFT_HPP
 
+#include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/err.hpp>
 #include <stan/math/prim/fun/Eigen.hpp>
-#include <stan/math/prim/fun/promote_common.hpp>
 
 namespace stan {
 namespace math {
@@ -31,12 +31,10 @@ inline Eigen::Matrix<return_type_t<T1, T2>, R1, C2> mdivide_left(
     const Eigen::Matrix<T1, R1, C1> &A, const Eigen::Matrix<T2, R2, C2> &b) {
   check_square("mdivide_left", "A", A);
   check_multiplicable("mdivide_left", "A", A, "b", b);
-  return promote_common<Eigen::Matrix<T1, R1, C1>, Eigen::Matrix<T2, R1, C1> >(
-             A)
+
+  return Eigen::Matrix<return_type_t<T1, T2>, R1, C1>(A)
       .lu()
-      .solve(
-          promote_common<Eigen::Matrix<T1, R2, C2>, Eigen::Matrix<T2, R2, C2> >(
-              b));
+      .solve(Eigen::Matrix<return_type_t<T1, T2>, R2, C2>(b));
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/mdivide_left.hpp
+++ b/stan/math/prim/fun/mdivide_left.hpp
@@ -32,9 +32,8 @@ inline Eigen::Matrix<return_type_t<T1, T2>, R1, C2> mdivide_left(
   check_square("mdivide_left", "A", A);
   check_multiplicable("mdivide_left", "A", A, "b", b);
 
-  return Eigen::Matrix<return_type_t<T1, T2>, R1, C1>(A)
-      .lu()
-      .solve(Eigen::Matrix<return_type_t<T1, T2>, R2, C2>(b));
+  return Eigen::Matrix<return_type_t<T1, T2>, R1, C1>(A).lu().solve(
+      Eigen::Matrix<return_type_t<T1, T2>, R2, C2>(b));
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/mdivide_left_ldlt.hpp
+++ b/stan/math/prim/fun/mdivide_left_ldlt.hpp
@@ -1,10 +1,10 @@
 #ifndef STAN_MATH_PRIM_FUN_MDIVIDE_LEFT_LDLT_HPP
 #define STAN_MATH_PRIM_FUN_MDIVIDE_LEFT_LDLT_HPP
 
+#include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/err.hpp>
 #include <stan/math/prim/fun/Eigen.hpp>
 #include <stan/math/prim/fun/LDLT_factor.hpp>
-#include <stan/math/prim/fun/promote_common.hpp>
 #include <type_traits>
 
 namespace stan {
@@ -36,8 +36,7 @@ inline Eigen::Matrix<return_type_t<T1, T2>, R1, C2> mdivide_left_ldlt(
 
   check_multiplicable("mdivide_left_ldlt", "A", A, "b", b);
 
-  return A.solve(
-      promote_common<Eigen::Matrix<T1, R2, C2>, Eigen::Matrix<T2, R2, C2> >(b));
+  return A.solve(Eigen::Matrix<return_type_t<T1, T2>, R2, C2>(b));
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/mdivide_left_spd.hpp
+++ b/stan/math/prim/fun/mdivide_left_spd.hpp
@@ -1,9 +1,9 @@
 #ifndef STAN_MATH_PRIM_FUN_MDIVIDE_LEFT_SPD_HPP
 #define STAN_MATH_PRIM_FUN_MDIVIDE_LEFT_SPD_HPP
 
+#include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/err.hpp>
 #include <stan/math/prim/fun/Eigen.hpp>
-#include <stan/math/prim/fun/promote_common.hpp>
 
 namespace stan {
 namespace math {

--- a/stan/math/prim/fun/mdivide_left_tri.hpp
+++ b/stan/math/prim/fun/mdivide_left_tri.hpp
@@ -1,9 +1,9 @@
 #ifndef STAN_MATH_PRIM_FUN_MDIVIDE_LEFT_TRI_HPP
 #define STAN_MATH_PRIM_FUN_MDIVIDE_LEFT_TRI_HPP
 
+#include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/err.hpp>
 #include <stan/math/prim/fun/Eigen.hpp>
-#include <stan/math/prim/fun/promote_common.hpp>
 #ifdef STAN_OPENCL
 #include <stan/math/opencl/opencl.hpp>
 #endif
@@ -36,12 +36,10 @@ inline Eigen::Matrix<return_type_t<T1, T2>, R1, C2> mdivide_left_tri(
     const Eigen::Matrix<T1, R1, C1> &A, const Eigen::Matrix<T2, R2, C2> &b) {
   check_square("mdivide_left_tri", "A", A);
   check_multiplicable("mdivide_left_tri", "A", A, "b", b);
-  return promote_common<Eigen::Matrix<T1, R1, C1>, Eigen::Matrix<T2, R1, C1> >(
-             A)
+
+  return Eigen::Matrix<return_type_t<T1, T2>, R1, C1>(A)
       .template triangularView<TriView>()
-      .solve(
-          promote_common<Eigen::Matrix<T1, R2, C2>, Eigen::Matrix<T2, R2, C2> >(
-              b));
+      .solve(Eigen::Matrix<return_type_t<T1, T2>, R2, C2>(b));
 }
 
 /**

--- a/stan/math/prim/fun/mdivide_right.hpp
+++ b/stan/math/prim/fun/mdivide_right.hpp
@@ -1,9 +1,9 @@
 #ifndef STAN_MATH_PRIM_FUN_MDIVIDE_RIGHT_HPP
 #define STAN_MATH_PRIM_FUN_MDIVIDE_RIGHT_HPP
 
+#include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/err.hpp>
 #include <stan/math/prim/fun/Eigen.hpp>
-#include <stan/math/prim/fun/promote_common.hpp>
 
 namespace stan {
 namespace math {
@@ -31,14 +31,11 @@ inline Eigen::Matrix<return_type_t<T1, T2>, R1, C2> mdivide_right(
     const Eigen::Matrix<T1, R1, C1> &b, const Eigen::Matrix<T2, R2, C2> &A) {
   check_square("mdivide_right", "A", A);
   check_multiplicable("mdivide_right", "b", b, "A", A);
-  return promote_common<Eigen::Matrix<T1, R2, C2>, Eigen::Matrix<T2, R2, C2> >(
-             A)
+
+  return Eigen::Matrix<return_type_t<T1, T2>, R2, C2>(A)
       .transpose()
       .lu()
-      .solve(
-          promote_common<Eigen::Matrix<T1, R1, C1>, Eigen::Matrix<T2, R1, C1> >(
-              b)
-              .transpose())
+      .solve(Eigen::Matrix<return_type_t<T1, T2>, R1, C1>(b).transpose())
       .transpose();
 }
 

--- a/stan/math/prim/fun/mdivide_right_ldlt.hpp
+++ b/stan/math/prim/fun/mdivide_right_ldlt.hpp
@@ -27,7 +27,6 @@ namespace math {
  * @return x = b A^-1, solution of the linear system.
  * @throws std::domain_error if rows of b don't match the size of A.
  */
-
 template <typename T1, typename T2, int R1, int C1, int R2, int C2>
 inline Eigen::Matrix<return_type_t<T1, T2>, R1, C2> mdivide_right_ldlt(
     const Eigen::Matrix<T1, R1, C1> &b, const LDLT_factor<T2, R2, C2> &A) {

--- a/stan/math/prim/fun/mdivide_right_tri.hpp
+++ b/stan/math/prim/fun/mdivide_right_tri.hpp
@@ -1,9 +1,9 @@
 #ifndef STAN_MATH_PRIM_FUN_MDIVIDE_RIGHT_TRI_HPP
 #define STAN_MATH_PRIM_FUN_MDIVIDE_RIGHT_TRI_HPP
 
+#include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/err.hpp>
 #include <stan/math/prim/fun/Eigen.hpp>
-#include <stan/math/prim/fun/promote_common.hpp>
 #ifdef STAN_OPENCL
 #include <stan/math/opencl/opencl.hpp>
 #endif
@@ -43,14 +43,11 @@ inline Eigen::Matrix<return_type_t<T1, T2>, R1, C2> mdivide_right_tri(
                        "triangular view must be Eigen::Lower or Eigen::Upper",
                        "", "");
   }
-  return promote_common<Eigen::Matrix<T1, R2, C2>, Eigen::Matrix<T2, R2, C2> >(
-             A)
+
+  return Eigen::Matrix<return_type_t<T1, T2>, R2, C2>(A)
       .template triangularView<TriView>()
       .transpose()
-      .solve(
-          promote_common<Eigen::Matrix<T1, R1, C1>, Eigen::Matrix<T2, R1, C1> >(
-              b)
-              .transpose())
+      .solve(Eigen::Matrix<return_type_t<T1, T2>, R1, C1>(b).transpose())
       .transpose();
 }
 

--- a/stan/math/prim/fun/mdivide_right_tri_low.hpp
+++ b/stan/math/prim/fun/mdivide_right_tri_low.hpp
@@ -1,9 +1,9 @@
 #ifndef STAN_MATH_PRIM_FUN_MDIVIDE_RIGHT_TRI_LOW_HPP
 #define STAN_MATH_PRIM_FUN_MDIVIDE_RIGHT_TRI_LOW_HPP
 
+#include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/fun/Eigen.hpp>
 #include <stan/math/prim/fun/mdivide_right_tri.hpp>
-#include <stan/math/prim/fun/promote_common.hpp>
 
 namespace stan {
 namespace math {
@@ -31,8 +31,8 @@ template <typename T1, typename T2, int R1, int C1, int R2, int C2>
 inline Eigen::Matrix<return_type_t<T1, T2>, R1, C2> mdivide_right_tri_low(
     const Eigen::Matrix<T1, R1, C1> &b, const Eigen::Matrix<T2, R2, C2> &A) {
   return mdivide_right_tri<Eigen::Lower>(
-      promote_common<Eigen::Matrix<T1, R1, C1>, Eigen::Matrix<T2, R1, C1> >(b),
-      promote_common<Eigen::Matrix<T1, R2, C2>, Eigen::Matrix<T2, R2, C2> >(A));
+      Eigen::Matrix<return_type_t<T1, T2>, R1, C1>(b),
+      Eigen::Matrix<return_type_t<T1, T2>, R2, C2>(A));
 }
 
 }  // namespace math

--- a/test/unit/math/mix/fun/mdivide_left_spd_test.cpp
+++ b/test/unit/math/mix/fun/mdivide_left_spd_test.cpp
@@ -8,22 +8,25 @@ TEST(MathMixMatFun, mdivideLeftSpd) {
     return stan::math::mdivide_left_spd(x_sym, y);
   };
 
-  // signature 1 of 2: matrix-matrix
+  // size zero inputs
+  Eigen::MatrixXd m00(0, 0);
+  Eigen::MatrixXd m02(0, 2);
+  Eigen::VectorXd v0(0);
+  stan::test::expect_ad(f, m00, m00);
+  stan::test::expect_ad(f, m00, m02);
+  stan::test::expect_ad(f, m00, v0);
+
   Eigen::MatrixXd aa(1, 1);
   aa << 1;
   Eigen::MatrixXd bb(1, 1);
   bb << 2;
   stan::test::expect_ad(f, aa, bb);
+  Eigen::MatrixXd b0(1, 0);
+  stan::test::expect_ad(f, aa, b0);
 
-  // signature 2 of 2: matrix-vector
   Eigen::VectorXd cc(1);
   cc << 3;
   stan::test::expect_ad(f, aa, cc);
-
-  Eigen::MatrixXd m00(0, 0);
-  Eigen::VectorXd v0(0);
-  stan::test::expect_ad(f, m00, v0);
-  stan::test::expect_ad(f, m00, m00);
 
   Eigen::MatrixXd a(2, 2);
   a << 2, 3, 3, 7;
@@ -45,15 +48,12 @@ TEST(MathMixMatFun, mdivideLeftSpd) {
   // matrix, vector : ditto
   stan::test::expect_ad(f, a, d);
   stan::test::expect_ad(f, b, d);
-  stan::test::expect_ad(f, a, d);
-  stan::test::expect_ad(f, b, d);
 
   Eigen::MatrixXd m33 = Eigen::MatrixXd::Zero(3, 3);
   Eigen::MatrixXd m44 = Eigen::MatrixXd::Zero(4, 4);
   Eigen::VectorXd v3 = Eigen::VectorXd::Zero(3);
   Eigen::VectorXd v4 = Eigen::VectorXd::Zero(4);
   Eigen::RowVectorXd rv3 = Eigen::RowVectorXd::Zero(3);
-  Eigen::RowVectorXd rv4 = Eigen::RowVectorXd::Zero(4);
 
   // exceptions: not symmetric
   stan::test::expect_ad(f, c, a);

--- a/test/unit/math/mix/fun/mdivide_left_test.cpp
+++ b/test/unit/math/mix/fun/mdivide_left_test.cpp
@@ -3,28 +3,28 @@
 
 TEST(MathMixMatFun, mdivideLeft) {
   auto f = [](const auto& x, const auto& y) {
-    if (x.rows() != x.cols())
-      return stan::math::mdivide_left(x, y);
-    auto x_sym = ((x + x.transpose()) * 0.5).eval();  // sym for finite diffs
-    return stan::math::mdivide_left(x_sym, y);
+    return stan::math::mdivide_left(x, y);
   };
 
-  // signature 1 of 2: matrix-matrix
+  // size zero inputs
+  Eigen::MatrixXd m00(0, 0);
+  Eigen::MatrixXd m02(0, 2);
+  Eigen::VectorXd v0(0);
+  stan::test::expect_ad(f, m00, m00);
+  stan::test::expect_ad(f, m00, m02);
+  stan::test::expect_ad(f, m00, v0);
+
   Eigen::MatrixXd aa(1, 1);
   aa << 1;
   Eigen::MatrixXd bb(1, 1);
   bb << 2;
   stan::test::expect_ad(f, aa, bb);
+  Eigen::MatrixXd b0(1, 0);
+  stan::test::expect_ad(f, aa, b0);
 
-  // signature 2 of 2: matrix-vector
   Eigen::VectorXd cc(1);
   cc << 3;
   stan::test::expect_ad(f, aa, cc);
-
-  Eigen::MatrixXd m00(0, 0);
-  Eigen::VectorXd v0(0);
-  stan::test::expect_ad(f, m00, v0);
-  stan::test::expect_ad(f, m00, m00);
 
   Eigen::MatrixXd a(2, 2);
   a << 2, 3, 3, 7;
@@ -38,20 +38,29 @@ TEST(MathMixMatFun, mdivideLeft) {
   Eigen::MatrixXd d(2, 2);
   d << 2, 3, 5, 7;
 
-  Eigen::MatrixXd e(2, 2);
-  e << 1, 2, 3, 4;
+  Eigen::MatrixXd e(2, 0);
 
   Eigen::VectorXd g(2);
   g << 12, 13;
 
   // matrix, matrix
-  for (const auto& m1 : std::vector<Eigen::MatrixXd>{a, b, c, d, e})
-    for (const auto& m2 : std::vector<Eigen::MatrixXd>{a, b, c, d, e})
+  for (const auto& m1 : std::vector<Eigen::MatrixXd>{a, b, c, d}) {
+    for (const auto& m2 : std::vector<Eigen::MatrixXd>{a, b, c, d, e}) {
       stan::test::expect_ad(f, m1, m2);
+    }
+  }
 
   // matrix, vector
-  for (const auto& m : std::vector<Eigen::MatrixXd>{a, b, c, d, e})
+  for (const auto& m : std::vector<Eigen::MatrixXd>{a, b, c, d}) {
     stan::test::expect_ad(f, m, g);
+  }
+
+  Eigen::MatrixXd v(5, 5);
+  v << 20, 8, -9, 7, 5, 8, 20, 0, 4, 4, -9, 0, 20, 2, 5, 7, 4, 2, 20, -5, 5, 4,
+      5, -5, 20;
+  Eigen::VectorXd u(5);
+  u << 62, 84, 84, 76, 108;
+  stan::test::expect_ad(f, v, u);
 
   Eigen::MatrixXd m33 = Eigen::MatrixXd::Zero(3, 3);
   Eigen::MatrixXd m44 = Eigen::MatrixXd::Zero(4, 4);
@@ -59,10 +68,6 @@ TEST(MathMixMatFun, mdivideLeft) {
   Eigen::VectorXd v4 = Eigen::VectorXd::Zero(4);
   Eigen::RowVectorXd rv3 = Eigen::RowVectorXd::Zero(3);
   Eigen::RowVectorXd rv4 = Eigen::RowVectorXd::Zero(4);
-
-  // exceptions: not symmetric
-  stan::test::expect_ad(f, c, a);
-  stan::test::expect_ad(f, c, d);
 
   // exceptions: wrong sizes
   stan::test::expect_ad(f, m33, m44);

--- a/test/unit/math/mix/fun/mdivide_left_tri_low_test.cpp
+++ b/test/unit/math/mix/fun/mdivide_left_tri_low_test.cpp
@@ -3,9 +3,17 @@
 
 TEST(MathMixMatFun, mdivideLeftTriLow) {
   auto f = [](const auto& x, const auto& y) {
-    // no need to symmetrize becuase only uses view
+    // no need to symmetrize because only uses view
     return stan::math::mdivide_left_tri_low(x, y);
   };
+
+  // size zero inputs
+  Eigen::MatrixXd m00(0, 0);
+  Eigen::MatrixXd m02(0, 2);
+  Eigen::VectorXd v0(0);
+  stan::test::expect_ad(f, m00, m00);
+  stan::test::expect_ad(f, m00, m02);
+  stan::test::expect_ad(f, m00, v0);
 
   // signature 1 of 2: matrix-matrix
   Eigen::MatrixXd aa(1, 1);
@@ -18,11 +26,6 @@ TEST(MathMixMatFun, mdivideLeftTriLow) {
   Eigen::VectorXd cc(1);
   cc << 3;
   stan::test::expect_ad(f, aa, cc);
-
-  Eigen::MatrixXd m00(0, 0);
-  Eigen::VectorXd v0(0);
-  stan::test::expect_ad(f, m00, v0);
-  stan::test::expect_ad(f, m00, m00);
 
   Eigen::MatrixXd a(2, 2);
   a << 1, std::numeric_limits<double>::quiet_NaN(), -3, 5;

--- a/test/unit/math/mix/fun/mdivide_left_tri_test.cpp
+++ b/test/unit/math/mix/fun/mdivide_left_tri_test.cpp
@@ -1,5 +1,4 @@
 #include <test/unit/math/test_ad.hpp>
-#include <limits>
 
 TEST(MathMixMatFun, mdivideLeftTri) {
   auto f = [](const auto& x, const auto& y) {
@@ -8,6 +7,12 @@ TEST(MathMixMatFun, mdivideLeftTri) {
   auto f_up = [](const auto& x, const auto& y) {
     return stan::math::mdivide_left_tri<Eigen::Upper>(x, y);
   };
+
+  // size zero inputs
+  Eigen::MatrixXd m00(0, 0);
+  Eigen::VectorXd v0(0);
+  stan::test::expect_ad(f, m00, v0);
+  stan::test::expect_ad(f, m00, m00);
 
   // signature 1 of 2: matrix-matrix
   Eigen::MatrixXd aa(1, 1);
@@ -22,11 +27,6 @@ TEST(MathMixMatFun, mdivideLeftTri) {
   cc << 3;
   stan::test::expect_ad(f, aa, cc);
   stan::test::expect_ad(f_up, aa, cc);
-
-  Eigen::MatrixXd m00(0, 0);
-  Eigen::VectorXd v0(0);
-  stan::test::expect_ad(f, m00, v0);
-  stan::test::expect_ad(f, m00, m00);
 
   Eigen::MatrixXd a(2, 2);
   a << 2, 0, 5, 7;

--- a/test/unit/math/mix/fun/mdivide_right_spd_test.cpp
+++ b/test/unit/math/mix/fun/mdivide_right_spd_test.cpp
@@ -8,22 +8,25 @@ TEST(MathMixMatFun, mdivideRightSpd) {
     return stan::math::mdivide_right_spd(x, y_sym);
   };
 
-  // signature 1 of 2: matrix / matrix
+  // size zero inputs
+  Eigen::MatrixXd m00(0, 0);
+  Eigen::MatrixXd m20(2, 0);
+  Eigen::RowVectorXd rv0(0);
+  stan::test::expect_ad(f, m00, m00);
+  stan::test::expect_ad(f, m20, m00);
+  stan::test::expect_ad(f, rv0, m00);
+
   Eigen::MatrixXd aa(1, 1);
   aa << 1;
   Eigen::MatrixXd bb(1, 1);
   bb << 2;
   stan::test::expect_ad(f, aa, bb);
+  Eigen::MatrixXd a0(0, 1);
+  stan::test::expect_ad(f, a0, bb);
 
-  // signature 2 of 2: row-vector/ matrix
   Eigen::RowVectorXd cc(1);
   cc << 3;
   stan::test::expect_ad(f, cc, aa);
-
-  Eigen::MatrixXd m00(0, 0);
-  Eigen::RowVectorXd rv0(0);
-  stan::test::expect_ad(f, m00, m00);
-  stan::test::expect_ad(f, rv0, m00);
 
   Eigen::MatrixXd a(2, 2);
   a << 2, 3, 3, 7;
@@ -46,15 +49,19 @@ TEST(MathMixMatFun, mdivideRightSpd) {
   stan::test::expect_ad(f, d, a);
   stan::test::expect_ad(f, d, b);
 
-  // exceptions: not symmetric
-  stan::test::expect_ad(f, a, c);
-  stan::test::expect_ad(f, d, c);
-
   Eigen::MatrixXd m33 = Eigen::MatrixXd::Zero(3, 3);
   Eigen::MatrixXd m44 = Eigen::MatrixXd::Zero(4, 4);
   Eigen::VectorXd v3 = Eigen::VectorXd::Zero(3);
   Eigen::RowVectorXd rv3 = Eigen::RowVectorXd::Zero(3);
   Eigen::RowVectorXd rv4 = Eigen::RowVectorXd::Zero(4);
+
+  // exceptions: not symmetric
+  stan::test::expect_ad(f, a, c);
+  stan::test::expect_ad(f, d, c);
+
+  // exceptions: not pos def
+  stan::test::expect_ad(f, m33, m33);
+  stan::test::expect_ad(f, rv3, m33);
 
   // exceptions: wrong sizes
   stan::test::expect_ad(f, m33, m44);
@@ -62,8 +69,4 @@ TEST(MathMixMatFun, mdivideRightSpd) {
 
   // exceptions: wrong types
   stan::test::expect_ad(f, v3, m33);
-
-  // exceptions: not pos def
-  stan::test::expect_ad(f, m33, m33);
-  stan::test::expect_ad(f, rv3, m33);
 }

--- a/test/unit/math/mix/fun/mdivide_right_test.cpp
+++ b/test/unit/math/mix/fun/mdivide_right_test.cpp
@@ -1,78 +1,78 @@
 #include <test/unit/math/test_ad.hpp>
-
-#include <stan/math/mix.hpp>
-#include <gtest/gtest.h>
 #include <vector>
 
 TEST(MathMixMatFun, mdivideRight) {
-  using stan::test::relative_tolerance;
   auto f = [](const auto& x, const auto& y) {
     return stan::math::mdivide_right(x, y);
   };
 
+  // size zero inputs
   Eigen::MatrixXd m00(0, 0);
+  Eigen::MatrixXd m20(2, 0);
   Eigen::RowVectorXd rv0(0);
   stan::test::expect_ad(f, m00, m00);
+  stan::test::expect_ad(f, m20, m00);
   stan::test::expect_ad(f, rv0, m00);
 
-  Eigen::MatrixXd a(1, 1);
-  a << 2;
-  Eigen::MatrixXd b(1, 1);
-  b << 3;
-  stan::test::expect_ad(f, a, b);
+  Eigen::MatrixXd aa(1, 1);
+  aa << 2;
+  Eigen::MatrixXd bb(1, 1);
+  bb << 3;
+  stan::test::expect_ad(f, bb, aa);
+  Eigen::MatrixXd b0(0, 1);
+  stan::test::expect_ad(f, b0, aa);
 
-  Eigen::RowVectorXd g(1);
-  g << 3;
-  stan::test::expect_ad(f, g, a);
+  Eigen::RowVectorXd cc(1);
+  cc << 3;
+  stan::test::expect_ad(f, cc, aa);
+
+  Eigen::MatrixXd a(2, 2);
+  a << 2, 3, 3, 7;
+
+  Eigen::MatrixXd b(2, 2);
+  b << 2, 0, 0, 3;
 
   Eigen::MatrixXd c(2, 2);
-  c << 2, 3, 3, 7;
+  c << 12, 13, 15, 17;
+
   Eigen::MatrixXd d(2, 2);
-  d << 2, 0, 0, 3;
-  Eigen::MatrixXd ee(2, 2);
-  ee << 2, 3, 5, 7;
-  for (const auto& m1 : std::vector<Eigen::MatrixXd>{c, d, ee}) {
-    for (const auto& m2 : std::vector<Eigen::MatrixXd>{c, d, ee}) {
+  d << 2, 3, 5, 7;
+
+  Eigen::MatrixXd e(0, 2);
+
+  Eigen::RowVectorXd g(2);
+  g << 12, 13;
+
+  // matrix, matrix
+  for (const auto& m1 : std::vector<Eigen::MatrixXd>{a, b, c, d, e}) {
+    for (const auto& m2 : std::vector<Eigen::MatrixXd>{a, b, c, d}) {
       stan::test::expect_ad(f, m1, m2);
     }
   }
 
-  Eigen::RowVectorXd e(2);
-  e << 2, 3;
-  for (const auto& m1 : std::vector<Eigen::MatrixXd>{c, d, ee}) {
-    stan::test::expect_ad(f, e, m1);
+  // vector, matrix
+  for (const auto& m : std::vector<Eigen::MatrixXd>{a, b, c, d}) {
+    stan::test::expect_ad(f, g, m);
   }
 
-  Eigen::RowVectorXd h(2);
-  h << 5, 6;
-  Eigen::MatrixXd j(2, 2);
-  j << 1, 2, 3, 4;
-  stan::test::expect_ad(f, h, j);
-
-  // ill-formed matrix inputs compile then throw at runtime
-  Eigen::MatrixXd m33(3, 3);
-  m33 << 1, 2, 3, 4, 5, 6, 7, 8, 9;
-  Eigen::MatrixXd m44(4, 4);
-  m44 << 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16;
-
-  Eigen::VectorXd v3(3);
-  v3 << 1, 2, 3;
-
-  Eigen::RowVectorXd rv3(3);
-  rv3 << 1, 2, 3;
-
-  stan::test::ad_tolerances tols;
-  tols.hessian_hessian_ = relative_tolerance(1e-2, 1e-3);
-  tols.hessian_fvar_hessian_ = relative_tolerance(1e-2, 1e-3);
   Eigen::RowVectorXd u(5);
   u << 62, 84, 84, 76, 108;
   Eigen::MatrixXd v(5, 5);
   v << 20, 8, -9, 7, 5, 8, 20, 0, 4, 4, -9, 0, 20, 2, 5, 7, 4, 2, 20, -5, 5, 4,
       5, -5, 20;
-  stan::test::expect_ad(tols, f, u, v);
+  stan::test::expect_ad(f, u, v);
 
-  // ill-formed inputs
-  stan::test::expect_ad(f, m33, m44);  // wrong size
-  stan::test::expect_ad(f, rv3, m44);  // wrong size
-  stan::test::expect_ad(f, v3, m33);   // wrong type
+  Eigen::MatrixXd m33 = Eigen::MatrixXd::Zero(3, 3);
+  Eigen::MatrixXd m44 = Eigen::MatrixXd::Zero(4, 4);
+  Eigen::VectorXd v3 = Eigen::VectorXd::Zero(3);
+  Eigen::VectorXd v4 = Eigen::VectorXd::Zero(4);
+  Eigen::RowVectorXd rv3 = Eigen::RowVectorXd::Zero(3);
+  Eigen::RowVectorXd rv4 = Eigen::RowVectorXd::Zero(4);
+
+  // exceptions: wrong sizes
+  stan::test::expect_ad(f, m33, m44);
+  stan::test::expect_ad(f, rv3, m44);
+
+  // exceptions: wrong types
+  stan::test::expect_ad(f, v3, m33);
 }

--- a/test/unit/math/mix/fun/mdivide_right_tri_low_test.cpp
+++ b/test/unit/math/mix/fun/mdivide_right_tri_low_test.cpp
@@ -3,13 +3,16 @@
 
 TEST(MathMixMatFun, mdivideRightTriLow) {
   auto f = [](const auto& x, const auto& y) {
-    // no need to symmetrize becuase only uses view
+    // no need to symmetrize because only uses view
     return stan::math::mdivide_right_tri_low(x, y);
   };
 
+  // size zero inputs
   Eigen::MatrixXd m00(0, 0);
+  Eigen::MatrixXd m20(2, 0);
   Eigen::RowVectorXd rv0(0);
   stan::test::expect_ad(f, m00, m00);
+  stan::test::expect_ad(f, m20, m00);
   stan::test::expect_ad(f, rv0, m00);
 
   // signature 1 of 2: matrix / matrix

--- a/test/unit/math/mix/fun/mdivide_right_tri_test.cpp
+++ b/test/unit/math/mix/fun/mdivide_right_tri_test.cpp
@@ -8,6 +8,7 @@ TEST(MathMixMatFun, mdivideRightTri) {
     return stan::math::mdivide_right_tri<Eigen::Upper>(x, y);
   };
 
+  // size zero inputs
   Eigen::MatrixXd m00(0, 0);
   Eigen::RowVectorXd rv0(0);
   stan::test::expect_ad(f, m00, m00);

--- a/test/unit/math/prim/fun/mdivide_left_spd_test.cpp
+++ b/test/unit/math/prim/fun/mdivide_left_spd_test.cpp
@@ -1,16 +1,31 @@
 #include <stan/math/prim.hpp>
 #include <gtest/gtest.h>
 
-TEST(MathMatrixPrimMat, mdivide_left_spd_val) {
+TEST(MathMatrixPrim, mdivide_left_spd_val) {
   using stan::math::mdivide_left_spd;
   stan::math::matrix_d Ad(2, 2);
-  stan::math::matrix_d I;
-
   Ad << 2.0, 3.0, 3.0, 7.0;
 
-  I = mdivide_left_spd(Ad, Ad);
+  stan::math::matrix_d I = mdivide_left_spd(Ad, Ad);
   EXPECT_NEAR(1.0, I(0, 0), 1.0E-12);
   EXPECT_NEAR(0.0, I(0, 1), 1.0E-12);
   EXPECT_NEAR(0.0, I(1, 0), 1.0E-12);
   EXPECT_NEAR(1.0, I(1, 1), 1.0e-12);
+
+  Ad << 1, 1, 1, 1;
+  EXPECT_THROW(mdivide_left_spd(Ad, Ad), std::domain_error);
+}
+
+TEST(MathMatrixPrim, mdivide_left_spd_size_zero) {
+  using stan::math::mdivide_left_spd;
+  stan::math::matrix_d m1, m2;
+
+  m1.resize(2, 2);
+  m1 << 7, 2, 2, 4;
+  m2.resize(2, 0);
+  EXPECT_THROW(mdivide_left_spd(m1, m2), std::invalid_argument);
+
+  m1.resize(0, 0);
+  m2.resize(0, 2);
+  EXPECT_THROW(mdivide_left_spd(m1, m2), std::invalid_argument);
 }

--- a/test/unit/math/prim/fun/mdivide_left_test.cpp
+++ b/test/unit/math/prim/fun/mdivide_left_test.cpp
@@ -1,16 +1,38 @@
 #include <stan/math/prim.hpp>
+#include <test/unit/math/prim/fun/expect_matrix_eq.hpp>
 #include <gtest/gtest.h>
 
-TEST(MathMatrixPrimMat, mdivide_left_val) {
-  using stan::math::mdivide_left;
+TEST(MathMatrixPrim, mdivide_left_val) {
   stan::math::matrix_d Ad(2, 2);
-  stan::math::matrix_d I;
-
   Ad << 2.0, 3.0, 5.0, 7.0;
 
-  I = mdivide_left(Ad, Ad);
-  EXPECT_NEAR(1.0, I(0, 0), 1.0E-12);
-  EXPECT_NEAR(0.0, I(0, 1), 1.0E-12);
-  EXPECT_NEAR(0.0, I(1, 0), 1.0E-12);
-  EXPECT_NEAR(1.0, I(1, 1), 1.0e-12);
+  stan::math::matrix_d I = Eigen::MatrixXd::Identity(2, 2);
+  expect_matrix_eq(I, stan::math::mdivide_left(Ad, Ad));
+}
+
+TEST(MathMatrixPrim, mdivide_left_val2) {
+  stan::math::matrix_d A(5, 5);
+  stan::math::vector_d b(5);
+  stan::math::vector_d expected(5);
+
+  A << 1, 8, -9, 7, 5, 0, 1, 0, 4, 4, 0, 0, 1, 2, 5, 0, 0, 0, 1, -5, 0, 0, 0, 0,
+      1;
+  b << 19, 150, -170, 140, 31;
+  expected << -1204, -1154, -915, 295, 31;
+
+  expect_matrix_eq(expected, stan::math::mdivide_left(A, b));
+}
+
+TEST(MathMatrixPrim, mdivide_left_size_zero) {
+  using stan::math::mdivide_left;
+  stan::math::matrix_d m1, m2;
+
+  m1.resize(2, 2);
+  m1 << 3, 5, 7, 11;
+  m2.resize(2, 0);
+  EXPECT_THROW(mdivide_left(m1, m2), std::invalid_argument);
+
+  m1.resize(0, 0);
+  m2.resize(0, 2);
+  EXPECT_THROW(mdivide_left(m1, m2), std::invalid_argument);
 }

--- a/test/unit/math/prim/fun/mdivide_left_tri_test.cpp
+++ b/test/unit/math/prim/fun/mdivide_left_tri_test.cpp
@@ -1,4 +1,5 @@
 #include <stan/math/prim.hpp>
+#include <test/unit/math/prim/fun/expect_matrix_eq.hpp>
 #include <gtest/gtest.h>
 
 #ifdef STAN_OPENCL
@@ -10,34 +11,19 @@
   for (int i = 0; i < A.size(); i++)    \
     EXPECT_NEAR(A(i), B(i), DELTA);
 
-TEST(MathMatrixPrimMat, mdivide_left_tri_val) {
+TEST(MathMatrixPrim, mdivide_left_tri_val) {
   using stan::math::mdivide_left_tri;
+  stan::math::matrix_d I = Eigen::MatrixXd::Identity(2, 2);
+
   stan::math::matrix_d Ad(2, 2);
-  stan::math::matrix_d Ad_inv(2, 2);
-  stan::math::matrix_d I;
-
   Ad << 2.0, 0.0, 5.0, 7.0;
+  expect_matrix_eq(I, mdivide_left_tri<Eigen::Lower>(Ad, Ad));
 
-  I = mdivide_left_tri<Eigen::Lower>(Ad, Ad);
-  EXPECT_NEAR(1.0, I(0, 0), 1.0E-12);
-  EXPECT_NEAR(0.0, I(0, 1), 1.0E-12);
-  EXPECT_NEAR(0.0, I(1, 0), 1.0E-12);
-  EXPECT_NEAR(1.0, I(1, 1), 1.0e-12);
-
-  Ad_inv = mdivide_left_tri<Eigen::Lower>(Ad);
-  I = Ad * Ad_inv;
-  EXPECT_NEAR(1.0, I(0, 0), 1.0E-12);
-  EXPECT_NEAR(0.0, I(0, 1), 1.0E-12);
-  EXPECT_NEAR(0.0, I(1, 0), 1.0E-12);
-  EXPECT_NEAR(1.0, I(1, 1), 1.0e-12);
+  stan::math::matrix_d A_Ainv = Ad * mdivide_left_tri<Eigen::Lower>(Ad);
+  EXPECT_MATRIX_NEAR(I, A_Ainv, 1e-15);
 
   Ad << 2.0, 3.0, 0.0, 7.0;
-
-  I = mdivide_left_tri<Eigen::Upper>(Ad, Ad);
-  EXPECT_NEAR(1.0, I(0, 0), 1.0E-12);
-  EXPECT_NEAR(0.0, I(0, 1), 1.0E-12);
-  EXPECT_NEAR(0.0, I(1, 0), 1.0E-12);
-  EXPECT_NEAR(1.0, I(1, 1), 1.0e-12);
+  expect_matrix_eq(I, mdivide_left_tri<Eigen::Upper>(Ad, Ad));
 }
 
 #ifdef STAN_OPENCL

--- a/test/unit/math/prim/fun/mdivide_right_spd_test.cpp
+++ b/test/unit/math/prim/fun/mdivide_right_spd_test.cpp
@@ -1,16 +1,31 @@
 #include <stan/math/prim.hpp>
 #include <gtest/gtest.h>
 
-TEST(MathMatrixPrimMat, mdivide_right_spd_val) {
+TEST(MathMatrixPrim, mdivide_right_spd_val) {
   using stan::math::mdivide_right_spd;
   stan::math::matrix_d Ad(2, 2);
-  stan::math::matrix_d I;
-
   Ad << 2.0, 3.0, 3.0, 7.0;
 
-  I = mdivide_right_spd(Ad, Ad);
+  stan::math::matrix_d I = mdivide_right_spd(Ad, Ad);
   EXPECT_NEAR(1.0, I(0, 0), 1.0E-12);
   EXPECT_NEAR(0.0, I(0, 1), 1.0E-12);
   EXPECT_NEAR(0.0, I(1, 0), 1.0E-12);
   EXPECT_NEAR(1.0, I(1, 1), 1.0e-12);
+
+  Ad << 1, 1, 1, 1;
+  EXPECT_THROW(mdivide_right_spd(Ad, Ad), std::domain_error);
+}
+
+TEST(MathMatrixPrim, mdivide_right_spd_size_zero) {
+  using stan::math::mdivide_right_spd;
+  stan::math::matrix_d m1, m2;
+
+  m1.resize(0, 2);
+  m2.resize(2, 2);
+  m2 << 7, 2, 2, 4;
+  EXPECT_THROW(mdivide_right_spd(m1, m2), std::invalid_argument);
+
+  m1.resize(2, 0);
+  m2.resize(0, 0);
+  EXPECT_THROW(mdivide_right_spd(m1, m2), std::invalid_argument);
 }

--- a/test/unit/math/prim/fun/mdivide_right_test.cpp
+++ b/test/unit/math/prim/fun/mdivide_right_test.cpp
@@ -1,34 +1,38 @@
 #include <stan/math/prim.hpp>
+#include <test/unit/math/prim/fun/expect_matrix_eq.hpp>
 #include <gtest/gtest.h>
 
-TEST(MathMatrixPrimMat, mdivide_right_val) {
-  using stan::math::mdivide_right;
+TEST(MathMatrixPrim, mdivide_right_val) {
   stan::math::matrix_d Ad(2, 2);
-  stan::math::matrix_d I;
-
   Ad << 2.0, 3.0, 5.0, 7.0;
 
-  I = mdivide_right(Ad, Ad);
-  EXPECT_NEAR(1.0, I(0, 0), 1.0E-12);
-  EXPECT_NEAR(0.0, I(0, 1), 1.0E-12);
-  EXPECT_NEAR(0.0, I(1, 0), 1.0E-12);
-  EXPECT_NEAR(1.0, I(1, 1), 1.0e-12);
+  stan::math::matrix_d I = Eigen::MatrixXd::Identity(2, 2);
+  expect_matrix_eq(I, stan::math::mdivide_left(Ad, Ad));
 }
 
-TEST(MathMatrixPrimMat, mdivide_right_val2) {
-  using stan::math::mdivide_right;
+TEST(MathMatrixPrim, mdivide_right_val2) {
   stan::math::row_vector_d b(5);
   stan::math::matrix_d A(5, 5);
   stan::math::row_vector_d expected(5);
-  stan::math::row_vector_d x;
 
   b << 19, 150, -170, 140, 31;
   A << 1, 8, -9, 7, 5, 0, 1, 0, 4, 4, 0, 0, 1, 2, 5, 0, 0, 0, 1, -5, 0, 0, 0, 0,
       1;
   expected << 19, -2, 1, 13, 4;
-  x = mdivide_right(b, A);
 
-  ASSERT_EQ(expected.size(), x.size());
-  for (int n = 0; n < expected.size(); n++)
-    EXPECT_FLOAT_EQ(expected(n), x(n));
+  expect_matrix_eq(expected, stan::math::mdivide_right(b, A));
+}
+
+TEST(MathMatrixPrim, mdivide_right_size_zero) {
+  using stan::math::mdivide_right;
+  stan::math::matrix_d m1, m2;
+
+  m1.resize(0, 2);
+  m2.resize(2, 2);
+  m2 << 3, 5, 7, 11;
+  EXPECT_THROW(mdivide_right(m1, m2), std::invalid_argument);
+
+  m1.resize(2, 0);
+  m2.resize(0, 0);
+  EXPECT_THROW(mdivide_right(m1, m2), std::invalid_argument);
 }

--- a/test/unit/math/prim/fun/mdivide_right_tri_test.cpp
+++ b/test/unit/math/prim/fun/mdivide_right_tri_test.cpp
@@ -1,4 +1,5 @@
 #include <stan/math/prim.hpp>
+#include <test/unit/math/prim/fun/expect_matrix_eq.hpp>
 #include <gtest/gtest.h>
 
 #ifdef STAN_OPENCL
@@ -10,26 +11,16 @@
   for (int i = 0; i < A.size(); i++)    \
     EXPECT_NEAR(A(i), B(i), DELTA);
 
-TEST(MathMatrixPrimMat, mdivide_right_tri_val) {
+TEST(MathMatrixPrim, mdivide_right_tri_val) {
   using stan::math::mdivide_right_tri;
+  stan::math::matrix_d I = Eigen::MatrixXd::Identity(2, 2);
+
   stan::math::matrix_d Ad(2, 2);
-  stan::math::matrix_d I;
-
   Ad << 2.0, 0.0, 5.0, 7.0;
-
-  I = mdivide_right_tri<Eigen::Lower>(Ad, Ad);
-  EXPECT_NEAR(1.0, I(0, 0), 1.0E-12);
-  EXPECT_NEAR(0.0, I(0, 1), 1.0E-12);
-  EXPECT_NEAR(0.0, I(1, 0), 1.0E-12);
-  EXPECT_NEAR(1.0, I(1, 1), 1.0e-12);
+  expect_matrix_eq(I, mdivide_right_tri<Eigen::Lower>(Ad, Ad));
 
   Ad << 2.0, 3.0, 0.0, 7.0;
-
-  I = mdivide_right_tri<Eigen::Upper>(Ad, Ad);
-  EXPECT_NEAR(1.0, I(0, 0), 1.0E-12);
-  EXPECT_NEAR(0.0, I(0, 1), 1.0E-12);
-  EXPECT_NEAR(0.0, I(1, 0), 1.0E-12);
-  EXPECT_NEAR(1.0, I(1, 1), 1.0e-12);
+  expect_matrix_eq(I, mdivide_right_tri<Eigen::Upper>(Ad, Ad));
 }
 
 #ifdef STAN_OPENCL


### PR DESCRIPTION
## Summary

This cleans up the `mdivide` functions, mainly to use `return_type_t` instead of `promote_common`. There are a couple of unused header removed and a correction to the return type declared for the fwd version of `mdivide_left_tri_low`. Fixes #1714.

## Tests
Reworked and expanded so that the left and right versions contain the same tests. Some boundary condition tests will be completed in #1689.

## Side Effects

None.

## Checklist

- [X] Math issue #1714

- [X] Copyright holder: Marco Colombo

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [X] the new changes are tested
