### PR TITLE
Remove size zero checks from check_multiplicable

### DIFF
--- a/stan/math/fwd/fun/mdivide_left.hpp
+++ b/stan/math/fwd/fun/mdivide_left.hpp
@@ -19,6 +19,9 @@ inline Eigen::Matrix<fvar<T>, R1, C2> mdivide_left(
     const Eigen::Matrix<fvar<T>, R2, C2> &b) {
   check_square("mdivide_left", "A", A);
   check_multiplicable("mdivide_left", "A", A, "b", b);
+  if (A.size() == 0) {
+    return Eigen::Matrix<fvar<T>, R1, C2>(0, b.cols());
+  }
 
   Eigen::Matrix<T, R1, C2> inv_A_mult_b(A.rows(), b.cols());
   Eigen::Matrix<T, R1, C2> inv_A_mult_deriv_b(A.rows(), b.cols());
@@ -58,6 +61,9 @@ inline Eigen::Matrix<fvar<T>, R1, C2> mdivide_left(
     const Eigen::Matrix<fvar<T>, R2, C2> &b) {
   check_square("mdivide_left", "A", A);
   check_multiplicable("mdivide_left", "A", A, "b", b);
+  if (A.size() == 0) {
+    return Eigen::Matrix<fvar<T>, R1, C2>(0, b.cols());
+  }
 
   Eigen::Matrix<T, R2, C2> val_b(b.rows(), b.cols());
   Eigen::Matrix<T, R2, C2> deriv_b(b.rows(), b.cols());
@@ -78,6 +84,9 @@ inline Eigen::Matrix<fvar<T>, R1, C2> mdivide_left(
     const Eigen::Matrix<double, R2, C2> &b) {
   check_square("mdivide_left", "A", A);
   check_multiplicable("mdivide_left", "A", A, "b", b);
+  if (A.size() == 0) {
+    return Eigen::Matrix<fvar<T>, R1, C2>(0, b.cols());
+  }
 
   Eigen::Matrix<T, R1, C2> inv_A_mult_b(A.rows(), b.cols());
   Eigen::Matrix<T, R1, C1> inv_A_mult_deriv_A(A.rows(), A.cols());

--- a/stan/math/fwd/fun/mdivide_left.hpp
+++ b/stan/math/fwd/fun/mdivide_left.hpp
@@ -20,7 +20,7 @@ inline Eigen::Matrix<fvar<T>, R1, C2> mdivide_left(
   check_square("mdivide_left", "A", A);
   check_multiplicable("mdivide_left", "A", A, "b", b);
   if (A.size() == 0) {
-    return Eigen::Matrix<fvar<T>, R1, C2>(0, b.cols());
+    return {0, b.cols()};
   }
 
   Eigen::Matrix<T, R1, C2> inv_A_mult_b(A.rows(), b.cols());
@@ -62,7 +62,7 @@ inline Eigen::Matrix<fvar<T>, R1, C2> mdivide_left(
   check_square("mdivide_left", "A", A);
   check_multiplicable("mdivide_left", "A", A, "b", b);
   if (A.size() == 0) {
-    return Eigen::Matrix<fvar<T>, R1, C2>(0, b.cols());
+    return {0, b.cols()};
   }
 
   Eigen::Matrix<T, R2, C2> val_b(b.rows(), b.cols());
@@ -85,7 +85,7 @@ inline Eigen::Matrix<fvar<T>, R1, C2> mdivide_left(
   check_square("mdivide_left", "A", A);
   check_multiplicable("mdivide_left", "A", A, "b", b);
   if (A.size() == 0) {
-    return Eigen::Matrix<fvar<T>, R1, C2>(0, b.cols());
+    return {0, b.cols()};
   }
 
   Eigen::Matrix<T, R1, C2> inv_A_mult_b(A.rows(), b.cols());

--- a/stan/math/fwd/fun/mdivide_left_tri_low.hpp
+++ b/stan/math/fwd/fun/mdivide_left_tri_low.hpp
@@ -18,6 +18,9 @@ inline Eigen::Matrix<fvar<T>, R1, C2> mdivide_left_tri_low(
     const Eigen::Matrix<fvar<T>, R2, C2>& b) {
   check_square("mdivide_left_tri_low", "A", A);
   check_multiplicable("mdivide_left_tri_low", "A", A, "b", b);
+  if (A.size() == 0) {
+    return Eigen::Matrix<fvar<T>, R1, C2>(0, b.cols());
+  }
 
   Eigen::Matrix<T, R1, C2> inv_A_mult_b(A.rows(), b.cols());
   Eigen::Matrix<T, R1, C2> inv_A_mult_deriv_b(A.rows(), b.cols());
@@ -59,6 +62,9 @@ inline Eigen::Matrix<fvar<T>, R1, C2> mdivide_left_tri_low(
     const Eigen::Matrix<fvar<T>, R2, C2>& b) {
   check_square("mdivide_left_tri_low", "A", A);
   check_multiplicable("mdivide_left_tri_low", "A", A, "b", b);
+  if (A.size() == 0) {
+    return Eigen::Matrix<fvar<T>, R1, C2>(0, b.cols());
+  }
 
   Eigen::Matrix<T, R1, C2> inv_A_mult_b(A.rows(), b.cols());
   Eigen::Matrix<T, R1, C2> inv_A_mult_deriv_b(A.rows(), b.cols());
@@ -95,6 +101,9 @@ inline Eigen::Matrix<fvar<T>, R1, C2> mdivide_left_tri_low(
     const Eigen::Matrix<double, R2, C2>& b) {
   check_square("mdivide_left_tri_low", "A", A);
   check_multiplicable("mdivide_left_tri_low", "A", A, "b", b);
+  if (A.size() == 0) {
+    return Eigen::Matrix<fvar<T>, R1, C2>(0, b.cols());
+  }
 
   Eigen::Matrix<T, R1, C2> inv_A_mult_b(A.rows(), b.cols());
   Eigen::Matrix<T, R1, C1> inv_A_mult_deriv_A(A.rows(), A.cols());

--- a/stan/math/fwd/fun/mdivide_left_tri_low.hpp
+++ b/stan/math/fwd/fun/mdivide_left_tri_low.hpp
@@ -19,7 +19,7 @@ inline Eigen::Matrix<fvar<T>, R1, C2> mdivide_left_tri_low(
   check_square("mdivide_left_tri_low", "A", A);
   check_multiplicable("mdivide_left_tri_low", "A", A, "b", b);
   if (A.size() == 0) {
-    return Eigen::Matrix<fvar<T>, R1, C2>(0, b.cols());
+    return {0, b.cols()};
   }
 
   Eigen::Matrix<T, R1, C2> inv_A_mult_b(A.rows(), b.cols());
@@ -63,7 +63,7 @@ inline Eigen::Matrix<fvar<T>, R1, C2> mdivide_left_tri_low(
   check_square("mdivide_left_tri_low", "A", A);
   check_multiplicable("mdivide_left_tri_low", "A", A, "b", b);
   if (A.size() == 0) {
-    return Eigen::Matrix<fvar<T>, R1, C2>(0, b.cols());
+    return {0, b.cols()};
   }
 
   Eigen::Matrix<T, R1, C2> inv_A_mult_b(A.rows(), b.cols());
@@ -102,7 +102,7 @@ inline Eigen::Matrix<fvar<T>, R1, C2> mdivide_left_tri_low(
   check_square("mdivide_left_tri_low", "A", A);
   check_multiplicable("mdivide_left_tri_low", "A", A, "b", b);
   if (A.size() == 0) {
-    return Eigen::Matrix<fvar<T>, R1, C2>(0, b.cols());
+    return {0, b.cols()};
   }
 
   Eigen::Matrix<T, R1, C2> inv_A_mult_b(A.rows(), b.cols());

--- a/stan/math/fwd/fun/mdivide_right.hpp
+++ b/stan/math/fwd/fun/mdivide_right.hpp
@@ -20,7 +20,7 @@ inline Eigen::Matrix<fvar<T>, R1, C2> mdivide_right(
   check_square("mdivide_right", "b", b);
   check_multiplicable("mdivide_right", "A", A, "b", b);
   if (b.size() == 0) {
-    return Eigen::Matrix<fvar<T>, R1, C2>(A.rows(), 0);
+    return {A.rows(), 0};
   }
 
   Eigen::Matrix<T, R1, C2> A_mult_inv_b(A.rows(), b.cols());
@@ -62,7 +62,7 @@ inline Eigen::Matrix<fvar<T>, R1, C2> mdivide_right(
   check_square("mdivide_right", "b", b);
   check_multiplicable("mdivide_right", "A", A, "b", b);
   if (b.size() == 0) {
-    return Eigen::Matrix<fvar<T>, R1, C2>(A.rows(), 0);
+    return {A.rows(), 0};
   }
 
   Eigen::Matrix<T, R2, C2> deriv_b_mult_inv_b(b.rows(), b.cols());
@@ -86,7 +86,7 @@ inline Eigen::Matrix<fvar<T>, R1, C2> mdivide_right(
   check_square("mdivide_right", "b", b);
   check_multiplicable("mdivide_right", "A", A, "b", b);
   if (b.size() == 0) {
-    return Eigen::Matrix<fvar<T>, R1, C2>(A.rows(), 0);
+    return {A.rows(), 0};
   }
 
   Eigen::Matrix<T, R1, C2> A_mult_inv_b(A.rows(), b.cols());

--- a/stan/math/fwd/fun/mdivide_right.hpp
+++ b/stan/math/fwd/fun/mdivide_right.hpp
@@ -19,6 +19,9 @@ inline Eigen::Matrix<fvar<T>, R1, C2> mdivide_right(
     const Eigen::Matrix<fvar<T>, R2, C2> &b) {
   check_square("mdivide_right", "b", b);
   check_multiplicable("mdivide_right", "A", A, "b", b);
+  if (b.size() == 0) {
+    return Eigen::Matrix<fvar<T>, R1, C2>(A.rows(), 0);
+  }
 
   Eigen::Matrix<T, R1, C2> A_mult_inv_b(A.rows(), b.cols());
   Eigen::Matrix<T, R1, C2> deriv_A_mult_inv_b(A.rows(), b.cols());
@@ -58,6 +61,9 @@ inline Eigen::Matrix<fvar<T>, R1, C2> mdivide_right(
     const Eigen::Matrix<double, R2, C2> &b) {
   check_square("mdivide_right", "b", b);
   check_multiplicable("mdivide_right", "A", A, "b", b);
+  if (b.size() == 0) {
+    return Eigen::Matrix<fvar<T>, R1, C2>(A.rows(), 0);
+  }
 
   Eigen::Matrix<T, R2, C2> deriv_b_mult_inv_b(b.rows(), b.cols());
   Eigen::Matrix<T, R1, C1> val_A(A.rows(), A.cols());
@@ -79,6 +85,10 @@ inline Eigen::Matrix<fvar<T>, R1, C2> mdivide_right(
     const Eigen::Matrix<fvar<T>, R2, C2> &b) {
   check_square("mdivide_right", "b", b);
   check_multiplicable("mdivide_right", "A", A, "b", b);
+  if (b.size() == 0) {
+    return Eigen::Matrix<fvar<T>, R1, C2>(A.rows(), 0);
+  }
+
   Eigen::Matrix<T, R1, C2> A_mult_inv_b(A.rows(), b.cols());
   Eigen::Matrix<T, R2, C2> deriv_b_mult_inv_b(b.rows(), b.cols());
   Eigen::Matrix<T, R2, C2> val_b(b.rows(), b.cols());

--- a/stan/math/fwd/fun/mdivide_right_tri_low.hpp
+++ b/stan/math/fwd/fun/mdivide_right_tri_low.hpp
@@ -17,6 +17,9 @@ inline Eigen::Matrix<fvar<T>, R1, C1> mdivide_right_tri_low(
     const Eigen::Matrix<fvar<T>, R2, C2> &b) {
   check_square("mdivide_right_tri_low", "b", b);
   check_multiplicable("mdivide_right_tri_low", "A", A, "b", b);
+  if (b.size() == 0) {
+    return Eigen::Matrix<fvar<T>, R1, C2>(A.rows(), 0);
+  }
 
   Eigen::Matrix<T, R1, C2> A_mult_inv_b(A.rows(), b.cols());
   Eigen::Matrix<T, R1, C2> deriv_A_mult_inv_b(A.rows(), b.cols());
@@ -58,6 +61,9 @@ inline Eigen::Matrix<fvar<T>, R1, C2> mdivide_right_tri_low(
     const Eigen::Matrix<double, R2, C2> &b) {
   check_square("mdivide_right_tri_low", "b", b);
   check_multiplicable("mdivide_right_tri_low", "A", A, "b", b);
+  if (b.size() == 0) {
+    return Eigen::Matrix<fvar<T>, R1, C2>(A.rows(), 0);
+  }
 
   Eigen::Matrix<T, R2, C2> deriv_b_mult_inv_b(b.rows(), b.cols());
   Eigen::Matrix<T, R1, C1> val_A(A.rows(), A.cols());
@@ -87,6 +93,9 @@ inline Eigen::Matrix<fvar<T>, R1, C2> mdivide_right_tri_low(
     const Eigen::Matrix<fvar<T>, R2, C2> &b) {
   check_square("mdivide_right_tri_low", "b", b);
   check_multiplicable("mdivide_right_tri_low", "A", A, "b", b);
+  if (b.size() == 0) {
+    return Eigen::Matrix<fvar<T>, R1, C2>(A.rows(), 0);
+  }
 
   Eigen::Matrix<T, R1, C2> A_mult_inv_b(A.rows(), b.cols());
   Eigen::Matrix<T, R2, C2> deriv_b_mult_inv_b(b.rows(), b.cols());

--- a/stan/math/fwd/fun/mdivide_right_tri_low.hpp
+++ b/stan/math/fwd/fun/mdivide_right_tri_low.hpp
@@ -18,7 +18,7 @@ inline Eigen::Matrix<fvar<T>, R1, C1> mdivide_right_tri_low(
   check_square("mdivide_right_tri_low", "b", b);
   check_multiplicable("mdivide_right_tri_low", "A", A, "b", b);
   if (b.size() == 0) {
-    return Eigen::Matrix<fvar<T>, R1, C2>(A.rows(), 0);
+    return {A.rows(), 0};
   }
 
   Eigen::Matrix<T, R1, C2> A_mult_inv_b(A.rows(), b.cols());
@@ -62,7 +62,7 @@ inline Eigen::Matrix<fvar<T>, R1, C2> mdivide_right_tri_low(
   check_square("mdivide_right_tri_low", "b", b);
   check_multiplicable("mdivide_right_tri_low", "A", A, "b", b);
   if (b.size() == 0) {
-    return Eigen::Matrix<fvar<T>, R1, C2>(A.rows(), 0);
+    return {A.rows(), 0};
   }
 
   Eigen::Matrix<T, R2, C2> deriv_b_mult_inv_b(b.rows(), b.cols());
@@ -94,7 +94,7 @@ inline Eigen::Matrix<fvar<T>, R1, C2> mdivide_right_tri_low(
   check_square("mdivide_right_tri_low", "b", b);
   check_multiplicable("mdivide_right_tri_low", "A", A, "b", b);
   if (b.size() == 0) {
-    return Eigen::Matrix<fvar<T>, R1, C2>(A.rows(), 0);
+    return {A.rows(), 0};
   }
 
   Eigen::Matrix<T, R1, C2> A_mult_inv_b(A.rows(), b.cols());

--- a/stan/math/fwd/fun/multiply.hpp
+++ b/stan/math/fwd/fun/multiply.hpp
@@ -16,8 +16,7 @@ template <typename Mat1, typename Mat2,
           require_same_vt<Mat1, Mat2>* = nullptr,
           require_not_eigen_row_and_col_t<Mat1, Mat2>* = nullptr>
 inline auto multiply(const Mat1& m1, const Mat2& m2) {
-  check_size_match("multiply", "Columns of m1", m1.cols(), "Rows of m2",
-                   m2.rows());
+  check_multiplicable("multiply", "m1", m1, "m2", m2);
   return m1 * m2;
 }
 
@@ -26,8 +25,7 @@ template <typename Mat1, typename Mat2,
           require_eigen_vt<std::is_floating_point, Mat2>* = nullptr,
           require_not_eigen_row_and_col_t<Mat1, Mat2>* = nullptr>
 inline auto multiply(const Mat1& m1, const Mat2& m2) {
-  check_size_match("multiply", "Columns of m1", m1.cols(), "Rows of m2",
-                   m2.rows());
+  check_multiplicable("multiply", "m1", m1, "m2", m2);
   Eigen::Matrix<value_type_t<Mat1>, Mat1::RowsAtCompileTime,
                 Mat2::ColsAtCompileTime>
       result(m1.rows(), m2.cols());
@@ -46,8 +44,7 @@ template <typename Mat1, typename Mat2,
           require_eigen_vt<is_fvar, Mat2>* = nullptr,
           require_not_eigen_row_and_col_t<Mat1, Mat2>* = nullptr>
 inline auto multiply(const Mat1& m1, const Mat2& m2) {
-  check_size_match("multiply", "Columns of m1", m1.cols(), "Rows of m2",
-                   m2.rows());
+  check_multiplicable("multiply", "m1", m1, "m2", m2);
   Eigen::Matrix<value_type_t<Mat2>, Mat1::RowsAtCompileTime,
                 Mat2::ColsAtCompileTime>
       result(m1.rows(), m2.cols());

--- a/stan/math/prim/err/check_multiplicable.hpp
+++ b/stan/math/prim/err/check_multiplicable.hpp
@@ -29,11 +29,8 @@ namespace math {
 template <typename T1, typename T2>
 inline void check_multiplicable(const char* function, const char* name1,
                                 const T1& y1, const char* name2, const T2& y2) {
-  check_positive(function, name1, "rows()", y1.rows());
-  check_positive(function, name2, "cols()", y2.cols());
   check_size_match(function, "Columns of ", name1, y1.cols(), "Rows of ", name2,
                    y2.rows());
-  check_positive(function, name1, "cols()", y1.cols());
 }
 }  // namespace math
 }  // namespace stan

--- a/stan/math/prim/fun/matrix_exp_multiply.hpp
+++ b/stan/math/prim/fun/matrix_exp_multiply.hpp
@@ -20,11 +20,10 @@ template <int Cb>
 inline Eigen::Matrix<double, -1, Cb> matrix_exp_multiply(
     const Eigen::MatrixXd& A, const Eigen::Matrix<double, -1, Cb>& B) {
   check_square("matrix_exp_multiply", "input matrix", A);
-  if (A.size() == 0 && B.rows() == 0) {
+  check_multiplicable("matrix_exp_multiply", "A", A, "B", B);
+  if (A.size() == 0) {
     return Eigen::Matrix<double, -1, Cb>(0, B.cols());
   }
-
-  check_multiplicable("matrix_exp_multiply", "A", A, "B", B);
 
   return matrix_exp_action_handler().action(A, B);
 }

--- a/stan/math/prim/fun/matrix_exp_multiply.hpp
+++ b/stan/math/prim/fun/matrix_exp_multiply.hpp
@@ -22,7 +22,7 @@ inline Eigen::Matrix<double, -1, Cb> matrix_exp_multiply(
   check_square("matrix_exp_multiply", "input matrix", A);
   check_multiplicable("matrix_exp_multiply", "A", A, "B", B);
   if (A.size() == 0) {
-    return Eigen::Matrix<double, -1, Cb>(0, B.cols());
+    return {0, B.cols()};
   }
 
   return matrix_exp_action_handler().action(A, B);

--- a/stan/math/prim/fun/mdivide_left.hpp
+++ b/stan/math/prim/fun/mdivide_left.hpp
@@ -32,7 +32,7 @@ inline Eigen::Matrix<return_type_t<T1, T2>, R1, C2> mdivide_left(
   check_square("mdivide_left", "A", A);
   check_multiplicable("mdivide_left", "A", A, "b", b);
   if (A.size() == 0) {
-    return Eigen::Matrix<return_type_t<T1, T2>, R1, C2>(0, b.cols());
+    return {0, b.cols()};
   }
 
   return Eigen::Matrix<return_type_t<T1, T2>, R1, C1>(A).lu().solve(

--- a/stan/math/prim/fun/mdivide_left.hpp
+++ b/stan/math/prim/fun/mdivide_left.hpp
@@ -31,6 +31,9 @@ inline Eigen::Matrix<return_type_t<T1, T2>, R1, C2> mdivide_left(
     const Eigen::Matrix<T1, R1, C1> &A, const Eigen::Matrix<T2, R2, C2> &b) {
   check_square("mdivide_left", "A", A);
   check_multiplicable("mdivide_left", "A", A, "b", b);
+  if (A.size() == 0) {
+    return Eigen::Matrix<return_type_t<T1, T2>, R1, C2>(0, b.cols());
+  }
 
   return Eigen::Matrix<return_type_t<T1, T2>, R1, C1>(A).lu().solve(
       Eigen::Matrix<return_type_t<T1, T2>, R2, C2>(b));

--- a/stan/math/prim/fun/mdivide_left_ldlt.hpp
+++ b/stan/math/prim/fun/mdivide_left_ldlt.hpp
@@ -32,7 +32,7 @@ inline Eigen::Matrix<return_type_t<T1, T2>, R1, C2> mdivide_left_ldlt(
     const LDLT_factor<T1, R1, C1> &A, const Eigen::Matrix<T2, R2, C2> &b) {
   check_multiplicable("mdivide_left_ldlt", "A", A, "b", b);
   if (A.cols() == 0) {
-    return Eigen::Matrix<return_type_t<T1, T2>, R1, C2>(0, b.cols());
+    return {0, b.cols()};
   }
 
   return A.solve(Eigen::Matrix<return_type_t<T1, T2>, R2, C2>(b));

--- a/stan/math/prim/fun/mdivide_left_ldlt.hpp
+++ b/stan/math/prim/fun/mdivide_left_ldlt.hpp
@@ -30,11 +30,10 @@ namespace math {
 template <int R1, int C1, int R2, int C2, typename T1, typename T2>
 inline Eigen::Matrix<return_type_t<T1, T2>, R1, C2> mdivide_left_ldlt(
     const LDLT_factor<T1, R1, C1> &A, const Eigen::Matrix<T2, R2, C2> &b) {
-  if (A.cols() == 0 && b.rows() == 0) {
+  check_multiplicable("mdivide_left_ldlt", "A", A, "b", b);
+  if (A.cols() == 0) {
     return Eigen::Matrix<return_type_t<T1, T2>, R1, C2>(0, b.cols());
   }
-
-  check_multiplicable("mdivide_left_ldlt", "A", A, "b", b);
 
   return A.solve(Eigen::Matrix<return_type_t<T1, T2>, R2, C2>(b));
 }

--- a/stan/math/prim/fun/mdivide_left_spd.hpp
+++ b/stan/math/prim/fun/mdivide_left_spd.hpp
@@ -32,9 +32,11 @@ inline Eigen::Matrix<return_type_t<T1, T2>, R1, C2> mdivide_left_spd(
     const Eigen::Matrix<T1, R1, C1> &A, const Eigen::Matrix<T2, R2, C2> &b) {
   static const char *function = "mdivide_left_spd";
   check_multiplicable(function, "A", A, "b", b);
-  check_positive(function, "rows", A.rows());
   check_symmetric(function, "A", A);
   check_not_nan(function, "A", A);
+  if (A.size() == 0) {
+    return Eigen::Matrix<return_type_t<T1, T2>, R1, C2>(0, b.cols());
+  }
 
   auto llt = Eigen::Matrix<return_type_t<T1, T2>, R1, C1>(A).llt();
   check_pos_definite(function, "A", llt);

--- a/stan/math/prim/fun/mdivide_left_spd.hpp
+++ b/stan/math/prim/fun/mdivide_left_spd.hpp
@@ -35,7 +35,7 @@ inline Eigen::Matrix<return_type_t<T1, T2>, R1, C2> mdivide_left_spd(
   check_symmetric(function, "A", A);
   check_not_nan(function, "A", A);
   if (A.size() == 0) {
-    return Eigen::Matrix<return_type_t<T1, T2>, R1, C2>(0, b.cols());
+    return {0, b.cols()};
   }
 
   auto llt = Eigen::Matrix<return_type_t<T1, T2>, R1, C1>(A).llt();

--- a/stan/math/prim/fun/mdivide_left_tri.hpp
+++ b/stan/math/prim/fun/mdivide_left_tri.hpp
@@ -37,7 +37,7 @@ inline Eigen::Matrix<return_type_t<T1, T2>, R1, C2> mdivide_left_tri(
   check_square("mdivide_left_tri", "A", A);
   check_multiplicable("mdivide_left_tri", "A", A, "b", b);
   if (A.rows() == 0) {
-    return Eigen::Matrix<return_type_t<T1, T2>, R1, C2>(0, b.cols());
+    return {0, b.cols()};
   }
 
   return Eigen::Matrix<return_type_t<T1, T2>, R1, C1>(A)
@@ -97,7 +97,7 @@ inline Eigen::Matrix<double, R1, C2> mdivide_left_tri(
   check_square("mdivide_left_tri", "A", A);
   check_multiplicable("mdivide_left_tri", "A", A, "b", b);
   if (A.rows() == 0) {
-    return Eigen::MatrixXd(0, b.cols());
+    return {0, b.cols()};
   }
 
 #ifdef STAN_OPENCL

--- a/stan/math/prim/fun/mdivide_left_tri.hpp
+++ b/stan/math/prim/fun/mdivide_left_tri.hpp
@@ -36,6 +36,9 @@ inline Eigen::Matrix<return_type_t<T1, T2>, R1, C2> mdivide_left_tri(
     const Eigen::Matrix<T1, R1, C1> &A, const Eigen::Matrix<T2, R2, C2> &b) {
   check_square("mdivide_left_tri", "A", A);
   check_multiplicable("mdivide_left_tri", "A", A, "b", b);
+  if (A.rows() == 0) {
+    return Eigen::Matrix<return_type_t<T1, T2>, R1, C2>(0, b.cols());
+  }
 
   return Eigen::Matrix<return_type_t<T1, T2>, R1, C1>(A)
       .template triangularView<TriView>()
@@ -57,6 +60,10 @@ template <int TriView, typename T, int R1, int C1>
 inline Eigen::Matrix<T, R1, C1> mdivide_left_tri(
     const Eigen::Matrix<T, R1, C1> &A) {
   check_square("mdivide_left_tri", "A", A);
+  if (A.rows() == 0) {
+    return {};
+  }
+
   int n = A.rows();
   Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> b;
   b.setIdentity(n, n);
@@ -89,6 +96,10 @@ inline Eigen::Matrix<double, R1, C2> mdivide_left_tri(
     const Eigen::Matrix<double, R2, C2> &b) {
   check_square("mdivide_left_tri", "A", A);
   check_multiplicable("mdivide_left_tri", "A", A, "b", b);
+  if (A.rows() == 0) {
+    return Eigen::MatrixXd(0, b.cols());
+  }
+
 #ifdef STAN_OPENCL
   if (A.rows()
       >= opencl_context.tuning_opts().tri_inverse_size_worth_transfer) {
@@ -122,6 +133,10 @@ template <Eigen::UpLoType TriView, int R1, int C1>
 inline Eigen::Matrix<double, R1, C1> mdivide_left_tri(
     const Eigen::Matrix<double, R1, C1> &A) {
   check_square("mdivide_left_tri", "A", A);
+  if (A.rows() == 0) {
+    return {};
+  }
+
   const int n = A.rows();
 #ifdef STAN_OPENCL
   if (A.rows()

--- a/stan/math/prim/fun/mdivide_left_tri_low.hpp
+++ b/stan/math/prim/fun/mdivide_left_tri_low.hpp
@@ -36,7 +36,7 @@ inline Eigen::Matrix<return_type_t<T1, T2>, R1, C2> mdivide_left_tri_low(
   check_square("mdivide_left_tri_low", "A", A);
   check_multiplicable("mdivide_left_tri_low", "A", A, "b", b);
   if (A.rows() == 0) {
-    return Eigen::Matrix<return_type_t<T1, T2>, R1, C2>(0, b.cols());
+    return {0, b.cols()};
   }
 
   return mdivide_left_tri<Eigen::Lower>(A, b);

--- a/stan/math/prim/fun/mdivide_left_tri_low.hpp
+++ b/stan/math/prim/fun/mdivide_left_tri_low.hpp
@@ -35,6 +35,10 @@ inline Eigen::Matrix<return_type_t<T1, T2>, R1, C2> mdivide_left_tri_low(
     const Eigen::Matrix<T1, R1, C1> &A, const Eigen::Matrix<T2, R2, C2> &b) {
   check_square("mdivide_left_tri_low", "A", A);
   check_multiplicable("mdivide_left_tri_low", "A", A, "b", b);
+  if (A.rows() == 0) {
+    return Eigen::Matrix<return_type_t<T1, T2>, R1, C2>(0, b.cols());
+  }
+
   return mdivide_left_tri<Eigen::Lower>(A, b);
 }
 
@@ -42,6 +46,10 @@ template <typename T, int R1, int C1>
 inline Eigen::Matrix<T, R1, C1> mdivide_left_tri_low(
     const Eigen::Matrix<T, R1, C1> &A) {
   check_square("mdivide_left_tri_low", "A", A);
+  if (A.rows() == 0) {
+    return {};
+  }
+
   return mdivide_left_tri<Eigen::Lower>(A);
 }
 

--- a/stan/math/prim/fun/mdivide_right.hpp
+++ b/stan/math/prim/fun/mdivide_right.hpp
@@ -31,6 +31,9 @@ inline Eigen::Matrix<return_type_t<T1, T2>, R1, C2> mdivide_right(
     const Eigen::Matrix<T1, R1, C1> &b, const Eigen::Matrix<T2, R2, C2> &A) {
   check_square("mdivide_right", "A", A);
   check_multiplicable("mdivide_right", "b", b, "A", A);
+  if (A.size() == 0) {
+    return Eigen::Matrix<return_type_t<T1, T2>, R1, C2>(b.rows(), 0);
+  }
 
   return Eigen::Matrix<return_type_t<T1, T2>, R2, C2>(A)
       .transpose()

--- a/stan/math/prim/fun/mdivide_right.hpp
+++ b/stan/math/prim/fun/mdivide_right.hpp
@@ -32,7 +32,7 @@ inline Eigen::Matrix<return_type_t<T1, T2>, R1, C2> mdivide_right(
   check_square("mdivide_right", "A", A);
   check_multiplicable("mdivide_right", "b", b, "A", A);
   if (A.size() == 0) {
-    return Eigen::Matrix<return_type_t<T1, T2>, R1, C2>(b.rows(), 0);
+    return {b.rows(), 0};
   }
 
   return Eigen::Matrix<return_type_t<T1, T2>, R2, C2>(A)

--- a/stan/math/prim/fun/mdivide_right_ldlt.hpp
+++ b/stan/math/prim/fun/mdivide_right_ldlt.hpp
@@ -32,7 +32,7 @@ inline Eigen::Matrix<return_type_t<T1, T2>, R1, C2> mdivide_right_ldlt(
     const Eigen::Matrix<T1, R1, C1> &b, const LDLT_factor<T2, R2, C2> &A) {
   check_multiplicable("mdivide_right_ldlt", "b", b, "A", A);
   if (A.rows() == 0) {
-    return Eigen::Matrix<return_type_t<T1, T2>, R1, C2>(b.rows(), 0);
+    return {b.rows(), 0};
   }
 
   return transpose(mdivide_left_ldlt(A, transpose(b)));
@@ -44,7 +44,7 @@ inline Eigen::Matrix<double, R1, C2> mdivide_right_ldlt(
     const LDLT_factor<double, R2, C2> &A) {
   check_multiplicable("mdivide_right_ldlt", "b", b, "A", A);
   if (A.rows() == 0) {
-    return Eigen::Matrix<double, R1, C2>(b.rows(), 0);
+    return {b.rows(), 0};
   }
 
   return A.solveRight(b);

--- a/stan/math/prim/fun/mdivide_right_ldlt.hpp
+++ b/stan/math/prim/fun/mdivide_right_ldlt.hpp
@@ -30,11 +30,10 @@ namespace math {
 template <typename T1, typename T2, int R1, int C1, int R2, int C2>
 inline Eigen::Matrix<return_type_t<T1, T2>, R1, C2> mdivide_right_ldlt(
     const Eigen::Matrix<T1, R1, C1> &b, const LDLT_factor<T2, R2, C2> &A) {
-  if (b.cols() == 0 && A.rows() == 0) {
+  check_multiplicable("mdivide_right_ldlt", "b", b, "A", A);
+  if (A.rows() == 0) {
     return Eigen::Matrix<return_type_t<T1, T2>, R1, C2>(b.rows(), 0);
   }
-
-  check_multiplicable("mdivide_right_ldlt", "b", b, "A", A);
 
   return transpose(mdivide_left_ldlt(A, transpose(b)));
 }
@@ -43,11 +42,10 @@ template <int R1, int C1, int R2, int C2>
 inline Eigen::Matrix<double, R1, C2> mdivide_right_ldlt(
     const Eigen::Matrix<double, R1, C1> &b,
     const LDLT_factor<double, R2, C2> &A) {
-  if (b.cols() == 0 && A.rows() == 0) {
+  check_multiplicable("mdivide_right_ldlt", "b", b, "A", A);
+  if (A.rows() == 0) {
     return Eigen::Matrix<double, R1, C2>(b.rows(), 0);
   }
-
-  check_multiplicable("mdivide_right_ldlt", "b", b, "A", A);
 
   return A.solveRight(b);
 }

--- a/stan/math/prim/fun/mdivide_right_spd.hpp
+++ b/stan/math/prim/fun/mdivide_right_spd.hpp
@@ -33,9 +33,12 @@ inline Eigen::Matrix<return_type_t<T1, T2>, R1, C2> mdivide_right_spd(
     const Eigen::Matrix<T1, R1, C1> &b, const Eigen::Matrix<T2, R2, C2> &A) {
   static const char *function = "mdivide_right_spd";
   check_multiplicable(function, "b", b, "A", A);
-  check_positive(function, "rows", A.rows());
   check_symmetric(function, "A", A);
   check_not_nan(function, "A", A);
+  if (A.size() == 0) {
+    return Eigen::Matrix<return_type_t<T1, T2>, R1, C2>(b.rows(), 0);
+  }
+
   // FIXME: After allowing for general MatrixBase in mdivide_left_spd,
   //        change to b.transpose()
   return mdivide_left_spd(A, transpose(b)).transpose();

--- a/stan/math/prim/fun/mdivide_right_spd.hpp
+++ b/stan/math/prim/fun/mdivide_right_spd.hpp
@@ -36,7 +36,7 @@ inline Eigen::Matrix<return_type_t<T1, T2>, R1, C2> mdivide_right_spd(
   check_symmetric(function, "A", A);
   check_not_nan(function, "A", A);
   if (A.size() == 0) {
-    return Eigen::Matrix<return_type_t<T1, T2>, R1, C2>(b.rows(), 0);
+    return {b.rows(), 0};
   }
 
   // FIXME: After allowing for general MatrixBase in mdivide_left_spd,

--- a/stan/math/prim/fun/mdivide_right_tri.hpp
+++ b/stan/math/prim/fun/mdivide_right_tri.hpp
@@ -43,6 +43,9 @@ inline Eigen::Matrix<return_type_t<T1, T2>, R1, C2> mdivide_right_tri(
                        "triangular view must be Eigen::Lower or Eigen::Upper",
                        "", "");
   }
+  if (A.rows() == 0) {
+    return Eigen::Matrix<return_type_t<T1, T2>, R1, C2>(b.rows(), 0);
+  }
 
   return Eigen::Matrix<return_type_t<T1, T2>, R2, C2>(A)
       .template triangularView<TriView>()
@@ -77,6 +80,10 @@ inline Eigen::Matrix<double, R1, C2> mdivide_right_tri(
     const Eigen::Matrix<double, R2, C2> &A) {
   check_square("mdivide_right_tri", "A", A);
   check_multiplicable("mdivide_right_tri", "b", b, "A", A);
+  if (A.rows() == 0) {
+    return Eigen::Matrix<double, R1, C2>(b.rows(), 0);
+  }
+
 #ifdef STAN_OPENCL
   if (A.rows()
       >= opencl_context.tuning_opts().tri_inverse_size_worth_transfer) {

--- a/stan/math/prim/fun/mdivide_right_tri.hpp
+++ b/stan/math/prim/fun/mdivide_right_tri.hpp
@@ -44,7 +44,7 @@ inline Eigen::Matrix<return_type_t<T1, T2>, R1, C2> mdivide_right_tri(
                        "", "");
   }
   if (A.rows() == 0) {
-    return Eigen::Matrix<return_type_t<T1, T2>, R1, C2>(b.rows(), 0);
+    return {b.rows(), 0};
   }
 
   return Eigen::Matrix<return_type_t<T1, T2>, R2, C2>(A)
@@ -81,7 +81,7 @@ inline Eigen::Matrix<double, R1, C2> mdivide_right_tri(
   check_square("mdivide_right_tri", "A", A);
   check_multiplicable("mdivide_right_tri", "b", b, "A", A);
   if (A.rows() == 0) {
-    return Eigen::Matrix<double, R1, C2>(b.rows(), 0);
+    return {b.rows(), 0};
   }
 
 #ifdef STAN_OPENCL

--- a/stan/math/prim/fun/multiply.hpp
+++ b/stan/math/prim/fun/multiply.hpp
@@ -92,8 +92,8 @@ template <typename Mat1, typename Mat2,
           require_not_eigen_row_and_col_t<Mat1, Mat2>* = nullptr>
 inline auto multiply(const Mat1& m1, const Mat2& m2)
     -> decltype((m1 * m2).eval()) {
-  check_size_match("multiply", "Columns of m1", m1.cols(), "Rows of m2",
-                   m2.rows());
+  check_multiplicable("multiply", "m1", m1, "m2", m2);
+
 #ifdef STAN_OPENCL
   if (m1.rows() * m1.cols() * m2.cols()
       > opencl_context.tuning_opts().multiply_dim_prod_worth_transfer) {
@@ -128,7 +128,7 @@ template <typename RowVec, typename ColVec,
                                 scalar_type_t<ColVec>>* = nullptr,
           require_eigen_row_and_col_t<RowVec, ColVec>* = nullptr>
 inline auto multiply(const RowVec& rv, const ColVec& v) {
-  check_matching_sizes("multiply", "rv", rv, "v", v);
+  check_multiplicable("multiply", "rv", rv, "v", v);
   return dot_product(rv, v);
 }
 

--- a/stan/math/prim/fun/quad_form_diag.hpp
+++ b/stan/math/prim/fun/quad_form_diag.hpp
@@ -13,7 +13,7 @@ quad_form_diag(const Eigen::Matrix<T1, Eigen::Dynamic, Eigen::Dynamic>& mat,
                const Eigen::Matrix<T2, R, C>& vec) {
   check_vector("quad_form_diag", "vec", vec);
   check_square("quad_form_diag", "mat", mat);
-  check_multiplicable("quad_form_diag", mat, vec);
+  check_multiplicable("quad_form_diag", "mat", mat, "vec", vec);
   return vec.asDiagonal() * mat * vec.asDiagonal();
 }
 

--- a/stan/math/prim/fun/quad_form_diag.hpp
+++ b/stan/math/prim/fun/quad_form_diag.hpp
@@ -13,7 +13,8 @@ quad_form_diag(const Eigen::Matrix<T1, Eigen::Dynamic, Eigen::Dynamic>& mat,
                const Eigen::Matrix<T2, R, C>& vec) {
   check_vector("quad_form_diag", "vec", vec);
   check_square("quad_form_diag", "mat", mat);
-  check_multiplicable("quad_form_diag", "mat", mat, "vec", vec);
+  check_size_match("quad_form_diag", "rows of mat", mat.rows(), "size of vec",
+                   vec.size());
   return vec.asDiagonal() * mat * vec.asDiagonal();
 }
 

--- a/stan/math/prim/fun/quad_form_diag.hpp
+++ b/stan/math/prim/fun/quad_form_diag.hpp
@@ -13,8 +13,7 @@ quad_form_diag(const Eigen::Matrix<T1, Eigen::Dynamic, Eigen::Dynamic>& mat,
                const Eigen::Matrix<T2, R, C>& vec) {
   check_vector("quad_form_diag", "vec", vec);
   check_square("quad_form_diag", "mat", mat);
-  check_size_match("quad_form_diag", "rows of mat", mat.rows(), "size of vec",
-                   vec.size());
+  check_multiplicable("quad_form_diag", mat, vec);
   return vec.asDiagonal() * mat * vec.asDiagonal();
 }
 

--- a/stan/math/prim/fun/scale_matrix_exp_multiply.hpp
+++ b/stan/math/prim/fun/scale_matrix_exp_multiply.hpp
@@ -29,7 +29,7 @@ inline Eigen::Matrix<double, -1, Cb> scale_matrix_exp_multiply(
   check_square("scale_matrix_exp_multiply", "input matrix", A);
   check_multiplicable("scale_matrix_exp_multiply", "A", A, "B", B);
   if (A.size() == 0) {
-    return Eigen::Matrix<double, -1, Cb>(0, B.cols());
+    return {0, B.cols()};
   }
 
   return matrix_exp_action_handler().action(A, B, t);
@@ -56,7 +56,7 @@ scale_matrix_exp_multiply(const Tt& t, const Eigen::Matrix<Ta, -1, -1>& A,
   check_square("scale_matrix_exp_multiply", "input matrix", A);
   check_multiplicable("scale_matrix_exp_multiply", "A", A, "B", B);
   if (A.size() == 0) {
-    return Eigen::Matrix<return_type_t<Tt, Ta, Tb>, -1, Cb>(0, B.cols());
+    return {0, B.cols()};
   }
 
   return multiply(matrix_exp(multiply(A, t)), B);

--- a/stan/math/prim/fun/scale_matrix_exp_multiply.hpp
+++ b/stan/math/prim/fun/scale_matrix_exp_multiply.hpp
@@ -27,11 +27,10 @@ inline Eigen::Matrix<double, -1, Cb> scale_matrix_exp_multiply(
     const double& t, const Eigen::MatrixXd& A,
     const Eigen::Matrix<double, -1, Cb>& B) {
   check_square("scale_matrix_exp_multiply", "input matrix", A);
-  if (A.size() == 0 && B.rows() == 0) {
+  check_multiplicable("scale_matrix_exp_multiply", "A", A, "B", B);
+  if (A.size() == 0) {
     return Eigen::Matrix<double, -1, Cb>(0, B.cols());
   }
-
-  check_multiplicable("scale_matrix_exp_multiply", "A", A, "B", B);
 
   return matrix_exp_action_handler().action(A, B, t);
 }
@@ -55,11 +54,10 @@ inline Eigen::Matrix<return_type_t<Tt, Ta, Tb>, -1, Cb>
 scale_matrix_exp_multiply(const Tt& t, const Eigen::Matrix<Ta, -1, -1>& A,
                           const Eigen::Matrix<Tb, -1, Cb>& B) {
   check_square("scale_matrix_exp_multiply", "input matrix", A);
-  if (A.size() == 0 && B.rows() == 0) {
+  check_multiplicable("scale_matrix_exp_multiply", "A", A, "B", B);
+  if (A.size() == 0) {
     return Eigen::Matrix<return_type_t<Tt, Ta, Tb>, -1, Cb>(0, B.cols());
   }
-
-  check_multiplicable("scale_matrix_exp_multiply", "A", A, "B", B);
 
   return multiply(matrix_exp(multiply(A, t)), B);
 }

--- a/stan/math/prim/fun/trace_gen_inv_quad_form_ldlt.hpp
+++ b/stan/math/prim/fun/trace_gen_inv_quad_form_ldlt.hpp
@@ -44,7 +44,7 @@ inline return_type_t<T1, T2, T3> trace_gen_inv_quad_form_ldlt(
   check_square("trace_gen_inv_quad_form_ldlt", "D", D);
   check_multiplicable("trace_gen_inv_quad_form_ldlt", "A", A, "B", B);
   check_multiplicable("trace_gen_inv_quad_form_ldlt", "B", B, "D", D);
-  if (D.size() == 0 && A.cols() == 0) {
+  if (D.size() == 0 || A.cols() == 0) {
     return 0;
   }
 

--- a/stan/math/prim/fun/trace_gen_inv_quad_form_ldlt.hpp
+++ b/stan/math/prim/fun/trace_gen_inv_quad_form_ldlt.hpp
@@ -42,12 +42,11 @@ inline return_type_t<T1, T2, T3> trace_gen_inv_quad_form_ldlt(
     const Eigen::Matrix<T1, R1, C1> &D, const LDLT_factor<T2, R2, C2> &A,
     const Eigen::Matrix<T3, R3, C3> &B) {
   check_square("trace_gen_inv_quad_form_ldlt", "D", D);
-  if (D.size() == 0 && A.cols() == 0 && B.rows() == 0 && B.cols() == 0) {
-    return 0;
-  }
-
   check_multiplicable("trace_gen_inv_quad_form_ldlt", "A", A, "B", B);
   check_multiplicable("trace_gen_inv_quad_form_ldlt", "B", B, "D", D);
+  if (D.size() == 0 && A.cols() == 0) {
+    return 0;
+  }
 
   return trace(multiply(multiply(D, transpose(B)), mdivide_left_ldlt(A, B)));
 }

--- a/stan/math/prim/fun/trace_inv_quad_form_ldlt.hpp
+++ b/stan/math/prim/fun/trace_inv_quad_form_ldlt.hpp
@@ -32,11 +32,10 @@ template <typename T1, typename T2, int R2, int C2, int R3, int C3,
           typename = require_all_not_var_t<T1, T2>>
 inline return_type_t<T1, T2> trace_inv_quad_form_ldlt(
     const LDLT_factor<T1, R2, C2> &A, const Eigen::Matrix<T2, R3, C3> &B) {
-  if (A.rows() == 0 && B.rows() == 0) {
+  check_multiplicable("trace_inv_quad_form_ldlt", "A", A, "B", B);
+  if (A.cols() == 0) {
     return 0;
   }
-
-  check_multiplicable("trace_inv_quad_form_ldlt", "A", A, "B", B);
 
   return trace(multiply(transpose(B), mdivide_left_ldlt(A, B)));
 }

--- a/stan/math/rev/fun/matrix_exp_multiply.hpp
+++ b/stan/math/rev/fun/matrix_exp_multiply.hpp
@@ -26,11 +26,10 @@ template <typename Ta, typename Tb, int Cb>
 inline Eigen::Matrix<return_type_t<Ta, Tb>, -1, Cb> matrix_exp_multiply(
     const Eigen::Matrix<Ta, -1, -1>& A, const Eigen::Matrix<Tb, -1, Cb>& B) {
   check_square("matrix_exp_multiply", "input matrix", A);
-  if (A.size() == 0 && B.rows() == 0) {
+  check_multiplicable("matrix_exp_multiply", "A", A, "B", B);
+  if (A.size() == 0) {
     return Eigen::Matrix<return_type_t<Ta, Tb>, -1, Cb>(0, B.cols());
   }
-
-  check_multiplicable("matrix_exp_multiply", "A", A, "B", B);
 
   return multiply(matrix_exp(A), B);
 }

--- a/stan/math/rev/fun/matrix_exp_multiply.hpp
+++ b/stan/math/rev/fun/matrix_exp_multiply.hpp
@@ -28,7 +28,7 @@ inline Eigen::Matrix<return_type_t<Ta, Tb>, -1, Cb> matrix_exp_multiply(
   check_square("matrix_exp_multiply", "input matrix", A);
   check_multiplicable("matrix_exp_multiply", "A", A, "B", B);
   if (A.size() == 0) {
-    return Eigen::Matrix<return_type_t<Ta, Tb>, -1, Cb>(0, B.cols());
+    return {0, B.cols()};
   }
 
   return multiply(matrix_exp(A), B);

--- a/stan/math/rev/fun/mdivide_left.hpp
+++ b/stan/math/rev/fun/mdivide_left.hpp
@@ -175,12 +175,10 @@ class mdivide_left_vd_vari : public vari {
 template <int R1, int C1, int R2, int C2>
 inline Eigen::Matrix<var, R1, C2> mdivide_left(
     const Eigen::Matrix<var, R1, C1> &A, const Eigen::Matrix<var, R2, C2> &b) {
-  Eigen::Matrix<var, R1, C2> res(b.rows(), b.cols());
-
   check_square("mdivide_left", "A", A);
   check_multiplicable("mdivide_left", "A", A, "b", b);
   if (A.size() == 0) {
-    return res;
+    return {0, b.cols()};
   }
 
   // NOTE: this is not a memory leak, this vari is used in the
@@ -190,6 +188,7 @@ inline Eigen::Matrix<var, R1, C2> mdivide_left(
   internal::mdivide_left_vv_vari<R1, C1, R2, C2> *baseVari
       = new internal::mdivide_left_vv_vari<R1, C1, R2, C2>(A, b);
 
+  Eigen::Matrix<var, R1, C2> res(b.rows(), b.cols());
   res.vi() = Eigen::Map<matrix_vi>(baseVari->variRefC_, res.rows(), res.cols());
 
   return res;
@@ -199,12 +198,10 @@ template <int R1, int C1, int R2, int C2>
 inline Eigen::Matrix<var, R1, C2> mdivide_left(
     const Eigen::Matrix<var, R1, C1> &A,
     const Eigen::Matrix<double, R2, C2> &b) {
-  Eigen::Matrix<var, R1, C2> res(b.rows(), b.cols());
-
   check_square("mdivide_left", "A", A);
   check_multiplicable("mdivide_left", "A", A, "b", b);
   if (A.size() == 0) {
-    return res;
+    return {0, b.cols()};
   }
 
   // NOTE: this is not a memory leak, this vari is used in the
@@ -214,6 +211,7 @@ inline Eigen::Matrix<var, R1, C2> mdivide_left(
   internal::mdivide_left_vd_vari<R1, C1, R2, C2> *baseVari
       = new internal::mdivide_left_vd_vari<R1, C1, R2, C2>(A, b);
 
+  Eigen::Matrix<var, R1, C2> res(b.rows(), b.cols());
   res.vi() = Eigen::Map<matrix_vi>(baseVari->variRefC_, res.rows(), res.cols());
 
   return res;
@@ -223,12 +221,10 @@ template <int R1, int C1, int R2, int C2>
 inline Eigen::Matrix<var, R1, C2> mdivide_left(
     const Eigen::Matrix<double, R1, C1> &A,
     const Eigen::Matrix<var, R2, C2> &b) {
-  Eigen::Matrix<var, R1, C2> res(b.rows(), b.cols());
-
   check_square("mdivide_left", "A", A);
   check_multiplicable("mdivide_left", "A", A, "b", b);
   if (A.size() == 0) {
-    return res;
+    return {0, b.cols()};
   }
 
   // NOTE: this is not a memory leak, this vari is used in the
@@ -238,6 +234,7 @@ inline Eigen::Matrix<var, R1, C2> mdivide_left(
   internal::mdivide_left_dv_vari<R1, C1, R2, C2> *baseVari
       = new internal::mdivide_left_dv_vari<R1, C1, R2, C2>(A, b);
 
+  Eigen::Matrix<var, R1, C2> res(b.rows(), b.cols());
   res.vi() = Eigen::Map<matrix_vi>(baseVari->variRefC_, res.rows(), res.cols());
 
   return res;

--- a/stan/math/rev/fun/mdivide_left.hpp
+++ b/stan/math/rev/fun/mdivide_left.hpp
@@ -179,6 +179,9 @@ inline Eigen::Matrix<var, R1, C2> mdivide_left(
 
   check_square("mdivide_left", "A", A);
   check_multiplicable("mdivide_left", "A", A, "b", b);
+  if (A.size() == 0) {
+    return res;
+  }
 
   // NOTE: this is not a memory leak, this vari is used in the
   // expression graph to evaluate the adjoint, but is not needed
@@ -200,6 +203,9 @@ inline Eigen::Matrix<var, R1, C2> mdivide_left(
 
   check_square("mdivide_left", "A", A);
   check_multiplicable("mdivide_left", "A", A, "b", b);
+  if (A.size() == 0) {
+    return res;
+  }
 
   // NOTE: this is not a memory leak, this vari is used in the
   // expression graph to evaluate the adjoint, but is not needed
@@ -221,6 +227,9 @@ inline Eigen::Matrix<var, R1, C2> mdivide_left(
 
   check_square("mdivide_left", "A", A);
   check_multiplicable("mdivide_left", "A", A, "b", b);
+  if (A.size() == 0) {
+    return res;
+  }
 
   // NOTE: this is not a memory leak, this vari is used in the
   // expression graph to evaluate the adjoint, but is not needed

--- a/stan/math/rev/fun/mdivide_left_ldlt.hpp
+++ b/stan/math/rev/fun/mdivide_left_ldlt.hpp
@@ -208,14 +208,14 @@ template <int R1, int C1, int R2, int C2>
 inline Eigen::Matrix<var, R1, C2> mdivide_left_ldlt(
     const LDLT_factor<var, R1, C1> &A, const Eigen::Matrix<var, R2, C2> &b) {
   check_multiplicable("mdivide_left_ldlt", "A", A, "b", b);
-  Eigen::Matrix<var, R1, C2> res(b.rows(), b.cols());
   if (A.cols() == 0) {
-    return res;
+    return {0, b.cols()};
   }
 
   internal::mdivide_left_ldlt_vv_vari<R1, C1, R2, C2> *baseVari
       = new internal::mdivide_left_ldlt_vv_vari<R1, C1, R2, C2>(A, b);
 
+  Eigen::Matrix<var, R1, C2> res(b.rows(), b.cols());
   res.vi() = Eigen::Map<matrix_vi>(baseVari->variRefC_, res.rows(), res.cols());
 
   return res;
@@ -240,14 +240,14 @@ template <int R1, int C1, int R2, int C2>
 inline Eigen::Matrix<var, R1, C2> mdivide_left_ldlt(
     const LDLT_factor<var, R1, C1> &A, const Eigen::Matrix<double, R2, C2> &b) {
   check_multiplicable("mdivide_left_ldlt", "A", A, "b", b);
-  Eigen::Matrix<var, R1, C2> res(b.rows(), b.cols());
   if (A.cols() == 0) {
-    return res;
+    return {0, b.cols()};
   }
 
   internal::mdivide_left_ldlt_vd_vari<R1, C1, R2, C2> *baseVari
       = new internal::mdivide_left_ldlt_vd_vari<R1, C1, R2, C2>(A, b);
 
+  Eigen::Matrix<var, R1, C2> res(b.rows(), b.cols());
   res.vi() = Eigen::Map<matrix_vi>(baseVari->variRefC_, res.rows(), res.cols());
 
   return res;
@@ -272,14 +272,14 @@ template <int R1, int C1, int R2, int C2>
 inline Eigen::Matrix<var, R1, C2> mdivide_left_ldlt(
     const LDLT_factor<double, R1, C1> &A, const Eigen::Matrix<var, R2, C2> &b) {
   check_multiplicable("mdivide_left_ldlt", "A", A, "b", b);
-  Eigen::Matrix<var, R1, C2> res(b.rows(), b.cols());
   if (A.cols() == 0) {
-    return res;
+    return {0, b.cols()};
   }
 
   internal::mdivide_left_ldlt_dv_vari<R1, C1, R2, C2> *baseVari
       = new internal::mdivide_left_ldlt_dv_vari<R1, C1, R2, C2>(A, b);
 
+  Eigen::Matrix<var, R1, C2> res(b.rows(), b.cols());
   res.vi() = Eigen::Map<matrix_vi>(baseVari->variRefC_, res.rows(), res.cols());
 
   return res;

--- a/stan/math/rev/fun/mdivide_left_ldlt.hpp
+++ b/stan/math/rev/fun/mdivide_left_ldlt.hpp
@@ -207,12 +207,11 @@ class mdivide_left_ldlt_vd_vari : public vari {
 template <int R1, int C1, int R2, int C2>
 inline Eigen::Matrix<var, R1, C2> mdivide_left_ldlt(
     const LDLT_factor<var, R1, C1> &A, const Eigen::Matrix<var, R2, C2> &b) {
+  check_multiplicable("mdivide_left_ldlt", "A", A, "b", b);
   Eigen::Matrix<var, R1, C2> res(b.rows(), b.cols());
-  if (A.cols() == 0 && b.rows() == 0) {
+  if (A.cols() == 0) {
     return res;
   }
-
-  check_multiplicable("mdivide_left_ldlt", "A", A, "b", b);
 
   internal::mdivide_left_ldlt_vv_vari<R1, C1, R2, C2> *baseVari
       = new internal::mdivide_left_ldlt_vv_vari<R1, C1, R2, C2>(A, b);
@@ -240,12 +239,11 @@ inline Eigen::Matrix<var, R1, C2> mdivide_left_ldlt(
 template <int R1, int C1, int R2, int C2>
 inline Eigen::Matrix<var, R1, C2> mdivide_left_ldlt(
     const LDLT_factor<var, R1, C1> &A, const Eigen::Matrix<double, R2, C2> &b) {
+  check_multiplicable("mdivide_left_ldlt", "A", A, "b", b);
   Eigen::Matrix<var, R1, C2> res(b.rows(), b.cols());
-  if (A.cols() == 0 && b.rows() == 0) {
+  if (A.cols() == 0) {
     return res;
   }
-
-  check_multiplicable("mdivide_left_ldlt", "A", A, "b", b);
 
   internal::mdivide_left_ldlt_vd_vari<R1, C1, R2, C2> *baseVari
       = new internal::mdivide_left_ldlt_vd_vari<R1, C1, R2, C2>(A, b);
@@ -273,12 +271,11 @@ inline Eigen::Matrix<var, R1, C2> mdivide_left_ldlt(
 template <int R1, int C1, int R2, int C2>
 inline Eigen::Matrix<var, R1, C2> mdivide_left_ldlt(
     const LDLT_factor<double, R1, C1> &A, const Eigen::Matrix<var, R2, C2> &b) {
+  check_multiplicable("mdivide_left_ldlt", "A", A, "b", b);
   Eigen::Matrix<var, R1, C2> res(b.rows(), b.cols());
-  if (A.cols() == 0 && b.rows() == 0) {
+  if (A.cols() == 0) {
     return res;
   }
-
-  check_multiplicable("mdivide_left_ldlt", "A", A, "b", b);
 
   internal::mdivide_left_ldlt_dv_vari<R1, C1, R2, C2> *baseVari
       = new internal::mdivide_left_ldlt_dv_vari<R1, C1, R2, C2>(A, b);

--- a/stan/math/rev/fun/mdivide_left_spd.hpp
+++ b/stan/math/rev/fun/mdivide_left_spd.hpp
@@ -149,9 +149,11 @@ inline Eigen::Matrix<var, R1, C2> mdivide_left_spd(
   Eigen::Matrix<var, R1, C2> res(b.rows(), b.cols());
   static const char *function = "mdivide_left_spd";
   check_multiplicable(function, "A", A, "b", b);
-  check_positive(function, "rows", A.rows());
   check_symmetric(function, "A", A);
   check_not_nan(function, "A", A);
+  if (A.size() == 0) {
+    return res;
+  }
 
   // NOTE: this is not a memory leak, this vari is used in the
   // expression graph to evaluate the adjoint, but is not needed
@@ -168,11 +170,14 @@ template <int R1, int C1, int R2, int C2>
 inline Eigen::Matrix<var, R1, C2> mdivide_left_spd(
     const Eigen::Matrix<var, R1, C1> &A,
     const Eigen::Matrix<double, R2, C2> &b) {
+  Eigen::Matrix<var, R1, C2> res(b.rows(), b.cols());
   static const char *function = "mdivide_left_spd";
   check_multiplicable(function, "A", A, "b", b);
-  check_positive(function, "rows", A.rows());
   check_symmetric(function, "A", A);
   check_not_nan(function, "A", A);
+  if (A.size() == 0) {
+    return res;
+  }
 
   // NOTE: this is not a memory leak, this vari is used in the
   // expression graph to evaluate the adjoint, but is not needed
@@ -181,7 +186,6 @@ inline Eigen::Matrix<var, R1, C2> mdivide_left_spd(
   internal::mdivide_left_spd_vd_vari<R1, C1, R2, C2> *baseVari
       = new internal::mdivide_left_spd_vd_vari<R1, C1, R2, C2>(A, b);
 
-  Eigen::Matrix<var, R1, C2> res(b.rows(), b.cols());
   res.vi() = Eigen::Map<matrix_vi>(&baseVari->variRefC_[0], b.rows(), b.cols());
   return res;
 }
@@ -190,11 +194,14 @@ template <int R1, int C1, int R2, int C2>
 inline Eigen::Matrix<var, R1, C2> mdivide_left_spd(
     const Eigen::Matrix<double, R1, C1> &A,
     const Eigen::Matrix<var, R2, C2> &b) {
+  Eigen::Matrix<var, R1, C2> res(b.rows(), b.cols());
   static const char *function = "mdivide_left_spd";
   check_multiplicable(function, "A", A, "b", b);
-  check_positive(function, "rows", A.rows());
   check_symmetric(function, "A", A);
   check_not_nan(function, "A", A);
+  if (A.size() == 0) {
+    return res;
+  }
 
   // NOTE: this is not a memory leak, this vari is used in the
   // expression graph to evaluate the adjoint, but is not needed
@@ -203,7 +210,6 @@ inline Eigen::Matrix<var, R1, C2> mdivide_left_spd(
   internal::mdivide_left_spd_dv_vari<R1, C1, R2, C2> *baseVari
       = new internal::mdivide_left_spd_dv_vari<R1, C1, R2, C2>(A, b);
 
-  Eigen::Matrix<var, R1, C2> res(b.rows(), b.cols());
   res.vi() = Eigen::Map<matrix_vi>(&baseVari->variRefC_[0], b.rows(), b.cols());
 
   return res;

--- a/stan/math/rev/fun/mdivide_left_spd.hpp
+++ b/stan/math/rev/fun/mdivide_left_spd.hpp
@@ -146,13 +146,12 @@ class mdivide_left_spd_vd_vari : public vari {
 template <int R1, int C1, int R2, int C2>
 inline Eigen::Matrix<var, R1, C2> mdivide_left_spd(
     const Eigen::Matrix<var, R1, C1> &A, const Eigen::Matrix<var, R2, C2> &b) {
-  Eigen::Matrix<var, R1, C2> res(b.rows(), b.cols());
   static const char *function = "mdivide_left_spd";
   check_multiplicable(function, "A", A, "b", b);
   check_symmetric(function, "A", A);
   check_not_nan(function, "A", A);
   if (A.size() == 0) {
-    return res;
+    return {0, b.cols()};
   }
 
   // NOTE: this is not a memory leak, this vari is used in the
@@ -162,6 +161,7 @@ inline Eigen::Matrix<var, R1, C2> mdivide_left_spd(
   internal::mdivide_left_spd_vv_vari<R1, C1, R2, C2> *baseVari
       = new internal::mdivide_left_spd_vv_vari<R1, C1, R2, C2>(A, b);
 
+  Eigen::Matrix<var, R1, C2> res(b.rows(), b.cols());
   res.vi() = Eigen::Map<matrix_vi>(&baseVari->variRefC_[0], b.rows(), b.cols());
   return res;
 }
@@ -170,13 +170,12 @@ template <int R1, int C1, int R2, int C2>
 inline Eigen::Matrix<var, R1, C2> mdivide_left_spd(
     const Eigen::Matrix<var, R1, C1> &A,
     const Eigen::Matrix<double, R2, C2> &b) {
-  Eigen::Matrix<var, R1, C2> res(b.rows(), b.cols());
   static const char *function = "mdivide_left_spd";
   check_multiplicable(function, "A", A, "b", b);
   check_symmetric(function, "A", A);
   check_not_nan(function, "A", A);
   if (A.size() == 0) {
-    return res;
+    return {0, b.cols()};
   }
 
   // NOTE: this is not a memory leak, this vari is used in the
@@ -186,6 +185,7 @@ inline Eigen::Matrix<var, R1, C2> mdivide_left_spd(
   internal::mdivide_left_spd_vd_vari<R1, C1, R2, C2> *baseVari
       = new internal::mdivide_left_spd_vd_vari<R1, C1, R2, C2>(A, b);
 
+  Eigen::Matrix<var, R1, C2> res(b.rows(), b.cols());
   res.vi() = Eigen::Map<matrix_vi>(&baseVari->variRefC_[0], b.rows(), b.cols());
   return res;
 }
@@ -194,13 +194,12 @@ template <int R1, int C1, int R2, int C2>
 inline Eigen::Matrix<var, R1, C2> mdivide_left_spd(
     const Eigen::Matrix<double, R1, C1> &A,
     const Eigen::Matrix<var, R2, C2> &b) {
-  Eigen::Matrix<var, R1, C2> res(b.rows(), b.cols());
   static const char *function = "mdivide_left_spd";
   check_multiplicable(function, "A", A, "b", b);
   check_symmetric(function, "A", A);
   check_not_nan(function, "A", A);
   if (A.size() == 0) {
-    return res;
+    return {0, b.cols()};
   }
 
   // NOTE: this is not a memory leak, this vari is used in the
@@ -210,6 +209,7 @@ inline Eigen::Matrix<var, R1, C2> mdivide_left_spd(
   internal::mdivide_left_spd_dv_vari<R1, C1, R2, C2> *baseVari
       = new internal::mdivide_left_spd_dv_vari<R1, C1, R2, C2>(A, b);
 
+  Eigen::Matrix<var, R1, C2> res(b.rows(), b.cols());
   res.vi() = Eigen::Map<matrix_vi>(&baseVari->variRefC_[0], b.rows(), b.cols());
 
   return res;

--- a/stan/math/rev/fun/mdivide_left_tri.hpp
+++ b/stan/math/rev/fun/mdivide_left_tri.hpp
@@ -314,12 +314,10 @@ class mdivide_left_tri_vd_vari : public vari {
 template <Eigen::UpLoType TriView, int R1, int C1, int R2, int C2>
 inline Eigen::Matrix<var, R1, C2> mdivide_left_tri(
     const Eigen::Matrix<var, R1, C1> &A, const Eigen::Matrix<var, R2, C2> &b) {
-  Eigen::Matrix<var, R1, C2> res(b.rows(), b.cols());
-
   check_square("mdivide_left_tri", "A", A);
   check_multiplicable("mdivide_left_tri", "A", A, "b", b);
   if (A.rows() == 0) {
-    return res;
+    return {0, b.cols()};
   }
 
   // NOTE: this is not a memory leak, this vari is used in the
@@ -329,6 +327,7 @@ inline Eigen::Matrix<var, R1, C2> mdivide_left_tri(
   internal::mdivide_left_tri_vv_vari<TriView, R1, C1, R2, C2> *baseVari
       = new internal::mdivide_left_tri_vv_vari<TriView, R1, C1, R2, C2>(A, b);
 
+  Eigen::Matrix<var, R1, C2> res(b.rows(), b.cols());
   res.vi()
       = Eigen::Map<matrix_vi>(&(baseVari->variRefC_[0]), b.rows(), b.cols());
 
@@ -338,12 +337,10 @@ template <Eigen::UpLoType TriView, int R1, int C1, int R2, int C2>
 inline Eigen::Matrix<var, R1, C2> mdivide_left_tri(
     const Eigen::Matrix<double, R1, C1> &A,
     const Eigen::Matrix<var, R2, C2> &b) {
-  Eigen::Matrix<var, R1, C2> res(b.rows(), b.cols());
-
   check_square("mdivide_left_tri", "A", A);
   check_multiplicable("mdivide_left_tri", "A", A, "b", b);
   if (A.rows() == 0) {
-    return res;
+    return {0, b.cols()};
   }
 
   // NOTE: this is not a memory leak, this vari is used in the
@@ -353,6 +350,7 @@ inline Eigen::Matrix<var, R1, C2> mdivide_left_tri(
   internal::mdivide_left_tri_dv_vari<TriView, R1, C1, R2, C2> *baseVari
       = new internal::mdivide_left_tri_dv_vari<TriView, R1, C1, R2, C2>(A, b);
 
+  Eigen::Matrix<var, R1, C2> res(b.rows(), b.cols());
   res.vi()
       = Eigen::Map<matrix_vi>(&(baseVari->variRefC_[0]), b.rows(), b.cols());
 
@@ -362,12 +360,10 @@ template <Eigen::UpLoType TriView, int R1, int C1, int R2, int C2>
 inline Eigen::Matrix<var, R1, C2> mdivide_left_tri(
     const Eigen::Matrix<var, R1, C1> &A,
     const Eigen::Matrix<double, R2, C2> &b) {
-  Eigen::Matrix<var, R1, C2> res(b.rows(), b.cols());
-
   check_square("mdivide_left_tri", "A", A);
   check_multiplicable("mdivide_left_tri", "A", A, "b", b);
   if (A.rows() == 0) {
-    return res;
+    return {0, b.cols()};
   }
 
   // NOTE: this is not a memory leak, this vari is used in the
@@ -377,6 +373,7 @@ inline Eigen::Matrix<var, R1, C2> mdivide_left_tri(
   internal::mdivide_left_tri_vd_vari<TriView, R1, C1, R2, C2> *baseVari
       = new internal::mdivide_left_tri_vd_vari<TriView, R1, C1, R2, C2>(A, b);
 
+  Eigen::Matrix<var, R1, C2> res(b.rows(), b.cols());
   res.vi()
       = Eigen::Map<matrix_vi>(&(baseVari->variRefC_[0]), b.rows(), b.cols());
 

--- a/stan/math/rev/fun/mdivide_left_tri.hpp
+++ b/stan/math/rev/fun/mdivide_left_tri.hpp
@@ -318,6 +318,9 @@ inline Eigen::Matrix<var, R1, C2> mdivide_left_tri(
 
   check_square("mdivide_left_tri", "A", A);
   check_multiplicable("mdivide_left_tri", "A", A, "b", b);
+  if (A.rows() == 0) {
+    return res;
+  }
 
   // NOTE: this is not a memory leak, this vari is used in the
   // expression graph to evaluate the adjoint, but is not needed
@@ -339,6 +342,9 @@ inline Eigen::Matrix<var, R1, C2> mdivide_left_tri(
 
   check_square("mdivide_left_tri", "A", A);
   check_multiplicable("mdivide_left_tri", "A", A, "b", b);
+  if (A.rows() == 0) {
+    return res;
+  }
 
   // NOTE: this is not a memory leak, this vari is used in the
   // expression graph to evaluate the adjoint, but is not needed
@@ -360,6 +366,9 @@ inline Eigen::Matrix<var, R1, C2> mdivide_left_tri(
 
   check_square("mdivide_left_tri", "A", A);
   check_multiplicable("mdivide_left_tri", "A", A, "b", b);
+  if (A.rows() == 0) {
+    return res;
+  }
 
   // NOTE: this is not a memory leak, this vari is used in the
   // expression graph to evaluate the adjoint, but is not needed

--- a/stan/math/rev/fun/multiply.hpp
+++ b/stan/math/rev/fun/multiply.hpp
@@ -565,7 +565,7 @@ inline auto multiply(const Mat1& A, const Mat2& B) {
   constexpr int Ra = Mat1::RowsAtCompileTime;
   constexpr int Ca = Mat1::ColsAtCompileTime;
   constexpr int Cb = Mat2::ColsAtCompileTime;
-  check_size_match("multiply", "Columns of A", A.cols(), "Rows of B", B.rows());
+  check_multiplicable("multiply", "A", A, "B", B);
   check_not_nan("multiply", "A", A);
   check_not_nan("multiply", "B", B);
 
@@ -598,7 +598,7 @@ inline var multiply(const RowVec& A, const ColVec& B) {
   using RowVecScalar = value_type_t<RowVec>;
   using ColVecScalar = value_type_t<ColVec>;
   constexpr int Ca = RowVec::ColsAtCompileTime;
-  check_matching_sizes("multiply", "A", A, "B", B);
+  check_multiplicable("multiply", "A", A, "B", B);
   check_not_nan("multiply", "A", A);
   check_not_nan("multiply", "B", B);
 

--- a/stan/math/rev/fun/quad_form_sym.hpp
+++ b/stan/math/rev/fun/quad_form_sym.hpp
@@ -33,8 +33,8 @@ template <typename Ta, int Ra, int Ca, typename Tb, int Rb, int Cb,
           require_any_var_t<Ta, Tb>...>
 inline Eigen::Matrix<var, Cb, Cb> quad_form_sym(
     const Eigen::Matrix<Ta, Ra, Ca>& A, const Eigen::Matrix<Tb, Rb, Cb>& B) {
-  check_symmetric("quad_form_sym", "A", A);
   check_multiplicable("quad_form_sym", "A", A, "B", B);
+  check_symmetric("quad_form_sym", "A", A);
 
   internal::quad_form_vari<Ta, Ra, Ca, Tb, Rb, Cb>* baseVari
       = new internal::quad_form_vari<Ta, Ra, Ca, Tb, Rb, Cb>(A, B, true);
@@ -61,8 +61,8 @@ template <typename Ta, int Ra, int Ca, typename Tb, int Rb,
           require_any_var_t<Ta, Tb>...>
 inline var quad_form_sym(const Eigen::Matrix<Ta, Ra, Ca>& A,
                          const Eigen::Matrix<Tb, Rb, 1>& B) {
-  check_symmetric("quad_form_sym", "A", A);
   check_multiplicable("quad_form_sym", "A", A, "B", B);
+  check_symmetric("quad_form_sym", "A", A);
 
   internal::quad_form_vari<Ta, Ra, Ca, Tb, Rb, 1>* baseVari
       = new internal::quad_form_vari<Ta, Ra, Ca, Tb, Rb, 1>(A, B, true);

--- a/stan/math/rev/fun/trace_gen_inv_quad_form_ldlt.hpp
+++ b/stan/math/rev/fun/trace_gen_inv_quad_form_ldlt.hpp
@@ -40,7 +40,7 @@ inline var trace_gen_inv_quad_form_ldlt(const Eigen::Matrix<T1, R1, C1> &D,
   check_square("trace_gen_inv_quad_form_ldlt", "D", D);
   check_multiplicable("trace_gen_inv_quad_form_ldlt", "A", A, "B", B);
   check_multiplicable("trace_gen_inv_quad_form_ldlt", "B", B, "D", D);
-  if (D.size() == 0 && A.cols() == 0) {
+  if (D.size() == 0 || A.cols() == 0) {
     return 0;
   }
 

--- a/stan/math/rev/fun/trace_gen_inv_quad_form_ldlt.hpp
+++ b/stan/math/rev/fun/trace_gen_inv_quad_form_ldlt.hpp
@@ -38,12 +38,11 @@ inline var trace_gen_inv_quad_form_ldlt(const Eigen::Matrix<T1, R1, C1> &D,
                                         const LDLT_factor<T2, R2, C2> &A,
                                         const Eigen::Matrix<T3, R3, C3> &B) {
   check_square("trace_gen_inv_quad_form_ldlt", "D", D);
-  if (D.size() == 0 && A.cols() == 0 && B.rows() == 0 && B.cols() == 0) {
-    return 0;
-  }
-
   check_multiplicable("trace_gen_inv_quad_form_ldlt", "A", A, "B", B);
   check_multiplicable("trace_gen_inv_quad_form_ldlt", "B", B, "D", D);
+  if (D.size() == 0 && A.cols() == 0) {
+    return 0;
+  }
 
   internal::trace_inv_quad_form_ldlt_impl<T2, R2, C2, T3, R3, C3> *_impl
       = new internal::trace_inv_quad_form_ldlt_impl<T2, R2, C2, T3, R3, C3>(

--- a/stan/math/rev/fun/trace_inv_quad_form_ldlt.hpp
+++ b/stan/math/rev/fun/trace_inv_quad_form_ldlt.hpp
@@ -158,11 +158,10 @@ template <typename T2, int R2, int C2, typename T3, int R3, int C3,
           typename = require_any_var_t<T2, T3>>
 inline return_type_t<T2, T3> trace_inv_quad_form_ldlt(
     const LDLT_factor<T2, R2, C2> &A, const Eigen::Matrix<T3, R3, C3> &B) {
-  if (A.rows() == 0 && B.rows() == 0) {
+  check_multiplicable("trace_inv_quad_form_ldlt", "A", A, "B", B);
+  if (A.cols() == 0) {
     return 0;
   }
-
-  check_multiplicable("trace_inv_quad_form_ldlt", "A", A, "B", B);
 
   internal::trace_inv_quad_form_ldlt_impl<T2, R2, C2, T3, R3, C3> *impl_
       = new internal::trace_inv_quad_form_ldlt_impl<T2, R2, C2, T3, R3, C3>(A,

--- a/test/unit/math/mix/fun/quad_form_sym_test.cpp
+++ b/test/unit/math/mix/fun/quad_form_sym_test.cpp
@@ -9,6 +9,7 @@ TEST(MathMixMatFun, quadFormSym) {
   };
 
   Eigen::MatrixXd a00;
+  Eigen::MatrixXd a02(0, 2);
   Eigen::MatrixXd a11(1, 1);
   a11 << 1;
   Eigen::MatrixXd b11(1, 1);
@@ -37,6 +38,8 @@ TEST(MathMixMatFun, quadFormSym) {
   tols.hessian_fvar_hessian_ = 2e-1;
 
   stan::test::expect_ad(f, a00, a00);
+  stan::test::expect_ad(f, a00, a02);
+
   stan::test::expect_ad(f, a11, b11);
   stan::test::expect_ad(tols, f, a22, b22);
   stan::test::expect_ad(f, a22, b23);
@@ -52,6 +55,8 @@ TEST(MathMixMatFun, quadFormSym) {
   auto g = [](const auto& x, const auto& y) {
     return stan::math::quad_form_sym(x, y);
   };
+
+  stan::test::expect_ad(g, a02, a22);
 
   Eigen::MatrixXd u(4, 4);
   u << 2, 3, 4, 5, 6, 10, 2, 2, 7, 2, 7, 1, 8, 2, 1, 112;

--- a/test/unit/math/mix/fun/quad_form_test.cpp
+++ b/test/unit/math/mix/fun/quad_form_test.cpp
@@ -8,6 +8,7 @@ TEST(MathMixMatFun, quadForm) {
   };
 
   Eigen::MatrixXd a00;
+  Eigen::MatrixXd a02(0, 2);
   Eigen::MatrixXd a11(1, 1);
   a11 << 1;
   Eigen::MatrixXd b11(1, 1);
@@ -36,6 +37,9 @@ TEST(MathMixMatFun, quadForm) {
   tols.hessian_fvar_hessian_ = 2e-1;
 
   stan::test::expect_ad(f, a00, a00);
+  stan::test::expect_ad(f, a00, a02);
+  stan::test::expect_ad(f, a02, a22);
+
   stan::test::expect_ad(f, a11, b11);
   stan::test::expect_ad(tols, f, a22, b22);
   stan::test::expect_ad(f, a22, b23);

--- a/test/unit/math/prim/err/check_multiplicable_test.cpp
+++ b/test/unit/math/prim/err/check_multiplicable_test.cpp
@@ -33,21 +33,18 @@ TEST(ErrorHandlingMatrix, checkMultiplicableMatrix_0) {
 
   x.resize(3, 0);
   y.resize(0, 3);
-  EXPECT_THROW(
-      stan::math::check_multiplicable("checkMultiplicable", "x", x, "y", y),
-      std::invalid_argument);
+  EXPECT_NO_THROW(
+      stan::math::check_multiplicable("checkMultiplicable", "x", x, "y", y));
 
   x.resize(0, 4);
   y.resize(4, 3);
-  EXPECT_THROW(
-      stan::math::check_multiplicable("checkMultiplicable", "x", x, "y", y),
-      std::invalid_argument);
+  EXPECT_NO_THROW(
+      stan::math::check_multiplicable("checkMultiplicable", "x", x, "y", y));
 
   x.resize(3, 4);
   y.resize(4, 0);
-  EXPECT_THROW(
-      stan::math::check_multiplicable("checkMultiplicable", "x", x, "y", y),
-      std::invalid_argument);
+  EXPECT_NO_THROW(
+      stan::math::check_multiplicable("checkMultiplicable", "x", x, "y", y));
 }
 
 TEST(ErrorHandlingMatrix, checkMultiplicableMatrix_nan) {

--- a/test/unit/math/prim/fun/mdivide_left_spd_test.cpp
+++ b/test/unit/math/prim/fun/mdivide_left_spd_test.cpp
@@ -18,14 +18,18 @@ TEST(MathMatrixPrim, mdivide_left_spd_val) {
 
 TEST(MathMatrixPrim, mdivide_left_spd_size_zero) {
   using stan::math::mdivide_left_spd;
-  stan::math::matrix_d m1, m2;
+  stan::math::matrix_d m1, m2, res;
 
   m1.resize(2, 2);
   m1 << 7, 2, 2, 4;
   m2.resize(2, 0);
-  EXPECT_THROW(mdivide_left_spd(m1, m2), std::invalid_argument);
+  res = mdivide_left_spd(m1, m2);
+  EXPECT_EQ(m1.rows(), res.rows());
+  EXPECT_EQ(m2.cols(), res.cols());
 
   m1.resize(0, 0);
   m2.resize(0, 2);
-  EXPECT_THROW(mdivide_left_spd(m1, m2), std::invalid_argument);
+  res = mdivide_left_spd(m1, m2);
+  EXPECT_EQ(m1.rows(), res.rows());
+  EXPECT_EQ(m2.cols(), res.cols());
 }

--- a/test/unit/math/prim/fun/mdivide_left_test.cpp
+++ b/test/unit/math/prim/fun/mdivide_left_test.cpp
@@ -28,6 +28,7 @@ TEST(MathMatrixPrim, mdivide_left_size_zero) {
   stan::math::matrix_d m1, m2, res;
 
   m1.resize(2, 2);
+  m1 << 3, 5, 7, 11;
   m2.resize(2, 0);
   res = mdivide_left(m1, m2);
   EXPECT_EQ(m1.rows(), res.rows());

--- a/test/unit/math/prim/fun/mdivide_left_test.cpp
+++ b/test/unit/math/prim/fun/mdivide_left_test.cpp
@@ -25,14 +25,17 @@ TEST(MathMatrixPrim, mdivide_left_val2) {
 
 TEST(MathMatrixPrim, mdivide_left_size_zero) {
   using stan::math::mdivide_left;
-  stan::math::matrix_d m1, m2;
+  stan::math::matrix_d m1, m2, res;
 
   m1.resize(2, 2);
-  m1 << 3, 5, 7, 11;
   m2.resize(2, 0);
-  EXPECT_THROW(mdivide_left(m1, m2), std::invalid_argument);
+  res = mdivide_left(m1, m2);
+  EXPECT_EQ(m1.rows(), res.rows());
+  EXPECT_EQ(m2.cols(), res.cols());
 
   m1.resize(0, 0);
   m2.resize(0, 2);
-  EXPECT_THROW(mdivide_left(m1, m2), std::invalid_argument);
+  res = mdivide_left(m1, m2);
+  EXPECT_EQ(m1.rows(), res.rows());
+  EXPECT_EQ(m2.cols(), res.cols());
 }

--- a/test/unit/math/prim/fun/mdivide_left_tri_low_test.cpp
+++ b/test/unit/math/prim/fun/mdivide_left_tri_low_test.cpp
@@ -8,13 +8,21 @@
 
 TEST(MathMatrixPrim, mdivide_left_tri_low_val) {
   using stan::math::mdivide_left_tri_low;
-  stan::math::matrix_d I = Eigen::MatrixXd::Identity(2, 2);
 
+  stan::math::matrix_d I = Eigen::MatrixXd::Identity(2, 2);
   stan::math::matrix_d Ad(2, 2);
   Ad << 2.0, 0.0, 5.0, 7.0;
   expect_matrix_eq(I, mdivide_left_tri_low(Ad, Ad));
 
   stan::math::matrix_d A_Ainv = Ad * mdivide_left_tri_low(Ad);
+  EXPECT_MATRIX_NEAR(I, A_Ainv, 1e-15);
+
+  I = Eigen::MatrixXd::Identity(1, 1);
+  Ad.resize(1, 1);
+  Ad << 2;
+  expect_matrix_eq(I, mdivide_left_tri_low(Ad, Ad));
+
+  A_Ainv = Ad * mdivide_left_tri_low(Ad);
   EXPECT_MATRIX_NEAR(I, A_Ainv, 1e-15);
 }
 

--- a/test/unit/math/prim/fun/mdivide_left_tri_low_test.cpp
+++ b/test/unit/math/prim/fun/mdivide_left_tri_low_test.cpp
@@ -1,0 +1,38 @@
+#include <stan/math/prim.hpp>
+#include <test/unit/math/prim/fun/expect_matrix_eq.hpp>
+#include <gtest/gtest.h>
+
+#define EXPECT_MATRIX_NEAR(A, B, DELTA) \
+  for (int i = 0; i < A.size(); i++)    \
+    EXPECT_NEAR(A(i), B(i), DELTA);
+
+TEST(MathMatrixPrim, mdivide_left_tri_low_val) {
+  using stan::math::mdivide_left_tri_low;
+  stan::math::matrix_d I = Eigen::MatrixXd::Identity(2, 2);
+
+  stan::math::matrix_d Ad(2, 2);
+  Ad << 2.0, 0.0, 5.0, 7.0;
+  expect_matrix_eq(I, mdivide_left_tri_low(Ad, Ad));
+
+  stan::math::matrix_d A_Ainv = Ad * mdivide_left_tri_low(Ad);
+  EXPECT_MATRIX_NEAR(I, A_Ainv, 1e-15);
+}
+
+TEST(MathMatrixPrim, mdivide_left_tri_low_size_zero) {
+  using stan::math::mdivide_left_tri_low;
+  stan::math::matrix_d Ad(0, 0);
+  stan::math::matrix_d b0(0, 2);
+  stan::math::matrix_d I;
+
+  I = mdivide_left_tri_low(Ad, Ad);
+  EXPECT_EQ(0, I.rows());
+  EXPECT_EQ(0, I.cols());
+
+  I = mdivide_left_tri_low(Ad);
+  EXPECT_EQ(0, I.rows());
+  EXPECT_EQ(0, I.cols());
+
+  I = mdivide_left_tri_low(Ad, b0);
+  EXPECT_EQ(0, I.rows());
+  EXPECT_EQ(b0.cols(), I.cols());
+}

--- a/test/unit/math/prim/fun/mdivide_left_tri_test.cpp
+++ b/test/unit/math/prim/fun/mdivide_left_tri_test.cpp
@@ -26,6 +26,37 @@ TEST(MathMatrixPrim, mdivide_left_tri_val) {
   expect_matrix_eq(I, mdivide_left_tri<Eigen::Upper>(Ad, Ad));
 }
 
+TEST(MathMatrixPrim, mdivide_left_tri_size_zero) {
+  using stan::math::mdivide_left_tri;
+  stan::math::matrix_d Ad(0, 0);
+  stan::math::matrix_d b0(0, 2);
+  stan::math::matrix_d I;
+
+  I = mdivide_left_tri<Eigen::Lower>(Ad, Ad);
+  EXPECT_EQ(0, I.rows());
+  EXPECT_EQ(0, I.cols());
+
+  I = mdivide_left_tri<Eigen::Upper>(Ad, Ad);
+  EXPECT_EQ(0, I.rows());
+  EXPECT_EQ(0, I.cols());
+
+  I = mdivide_left_tri<Eigen::Lower>(Ad);
+  EXPECT_EQ(0, I.rows());
+  EXPECT_EQ(0, I.cols());
+
+  I = mdivide_left_tri<Eigen::Upper>(Ad);
+  EXPECT_EQ(0, I.rows());
+  EXPECT_EQ(0, I.cols());
+
+  I = mdivide_left_tri<Eigen::Lower>(Ad, b0);
+  EXPECT_EQ(0, I.rows());
+  EXPECT_EQ(b0.cols(), I.cols());
+
+  I = mdivide_left_tri<Eigen::Upper>(Ad, b0);
+  EXPECT_EQ(0, I.rows());
+  EXPECT_EQ(b0.cols(), I.cols());
+}
+
 #ifdef STAN_OPENCL
 void mdivide_left_tri_lower_cl_test(int size) {
   boost::random::mt19937 rng;

--- a/test/unit/math/prim/fun/mdivide_right_spd_test.cpp
+++ b/test/unit/math/prim/fun/mdivide_right_spd_test.cpp
@@ -18,14 +18,18 @@ TEST(MathMatrixPrim, mdivide_right_spd_val) {
 
 TEST(MathMatrixPrim, mdivide_right_spd_size_zero) {
   using stan::math::mdivide_right_spd;
-  stan::math::matrix_d m1, m2;
+  stan::math::matrix_d m1, m2, res;
 
   m1.resize(0, 2);
   m2.resize(2, 2);
   m2 << 7, 2, 2, 4;
-  EXPECT_THROW(mdivide_right_spd(m1, m2), std::invalid_argument);
+  res = mdivide_right_spd(m1, m2);
+  EXPECT_EQ(m1.rows(), res.rows());
+  EXPECT_EQ(m2.cols(), res.cols());
 
   m1.resize(2, 0);
   m2.resize(0, 0);
-  EXPECT_THROW(mdivide_right_spd(m1, m2), std::invalid_argument);
+  res = mdivide_right_spd(m1, m2);
+  EXPECT_EQ(m1.rows(), res.rows());
+  EXPECT_EQ(m2.cols(), res.cols());
 }

--- a/test/unit/math/prim/fun/mdivide_right_test.cpp
+++ b/test/unit/math/prim/fun/mdivide_right_test.cpp
@@ -25,14 +25,17 @@ TEST(MathMatrixPrim, mdivide_right_val2) {
 
 TEST(MathMatrixPrim, mdivide_right_size_zero) {
   using stan::math::mdivide_right;
-  stan::math::matrix_d m1, m2;
+  stan::math::matrix_d m1, m2, res;
 
   m1.resize(0, 2);
   m2.resize(2, 2);
-  m2 << 3, 5, 7, 11;
-  EXPECT_THROW(mdivide_right(m1, m2), std::invalid_argument);
+  res = mdivide_right(m1, m2);
+  EXPECT_EQ(m1.rows(), res.rows());
+  EXPECT_EQ(m2.cols(), res.cols());
 
   m1.resize(2, 0);
   m2.resize(0, 0);
-  EXPECT_THROW(mdivide_right(m1, m2), std::invalid_argument);
+  res = mdivide_right(m1, m2);
+  EXPECT_EQ(m1.rows(), res.rows());
+  EXPECT_EQ(m2.cols(), res.cols());
 }

--- a/test/unit/math/prim/fun/mdivide_right_test.cpp
+++ b/test/unit/math/prim/fun/mdivide_right_test.cpp
@@ -29,6 +29,7 @@ TEST(MathMatrixPrim, mdivide_right_size_zero) {
 
   m1.resize(0, 2);
   m2.resize(2, 2);
+  m2 << 3, 5, 7, 11;
   res = mdivide_right(m1, m2);
   EXPECT_EQ(m1.rows(), res.rows());
   EXPECT_EQ(m2.cols(), res.cols());

--- a/test/unit/math/prim/fun/mdivide_right_tri_test.cpp
+++ b/test/unit/math/prim/fun/mdivide_right_tri_test.cpp
@@ -23,6 +23,29 @@ TEST(MathMatrixPrim, mdivide_right_tri_val) {
   expect_matrix_eq(I, mdivide_right_tri<Eigen::Upper>(Ad, Ad));
 }
 
+TEST(MathMatrixPrim, mdivide_right_tri_size_zero) {
+  using stan::math::mdivide_right_tri;
+  stan::math::matrix_d Ad(0, 0);
+  stan::math::matrix_d b0(2, 0);
+  stan::math::matrix_d I;
+
+  I = mdivide_right_tri<Eigen::Lower>(Ad, Ad);
+  EXPECT_EQ(0, I.rows());
+  EXPECT_EQ(0, I.cols());
+
+  I = mdivide_right_tri<Eigen::Upper>(Ad, Ad);
+  EXPECT_EQ(0, I.rows());
+  EXPECT_EQ(0, I.cols());
+
+  I = mdivide_right_tri<Eigen::Lower>(b0, Ad);
+  EXPECT_EQ(b0.rows(), I.rows());
+  EXPECT_EQ(0, I.cols());
+
+  I = mdivide_right_tri<Eigen::Upper>(b0, Ad);
+  EXPECT_EQ(b0.rows(), I.rows());
+  EXPECT_EQ(0, I.cols());
+}
+
 #ifdef STAN_OPENCL
 
 void mdivide_right_tri_cl_test(int size) {

--- a/test/unit/math/prim/fun/quad_form_sym_test.cpp
+++ b/test/unit/math/prim/fun/quad_form_sym_test.cpp
@@ -7,7 +7,16 @@ TEST(MathMatrixPrim, quad_form_sym_mat) {
 
   matrix_d resd;
   matrix_d m0;
-  EXPECT_THROW(quad_form_sym(m0, m0), std::invalid_argument);
+
+  matrix_d m02(0, 2);
+  matrix_d m22(2, 2);
+  m22 << 1, 2, 2, 4;
+  EXPECT_THROW(quad_form_sym(m02, m22), std::invalid_argument);
+  EXPECT_THROW(quad_form_sym(m22, m02), std::invalid_argument);
+
+  resd = quad_form_sym(m0, m0);
+  EXPECT_EQ(0, resd.rows());
+  EXPECT_EQ(0, resd.cols());
 
   matrix_d m1(1, 1);
   m1 << 2;
@@ -50,7 +59,7 @@ TEST(MathMatrixPrim, quad_form_sym_vec) {
 
   matrix_d m0;
   vector_d v0;
-  EXPECT_THROW(quad_form_sym(m0, v0), std::invalid_argument);
+  EXPECT_EQ(0, quad_form_sym(m0, v0));
 
   matrix_d m1(1, 1);
   m1 << 2;

--- a/test/unit/math/prim/fun/quad_form_sym_test.cpp
+++ b/test/unit/math/prim/fun/quad_form_sym_test.cpp
@@ -18,6 +18,10 @@ TEST(MathMatrixPrim, quad_form_sym_mat) {
   EXPECT_EQ(0, resd.rows());
   EXPECT_EQ(0, resd.cols());
 
+  resd = quad_form_sym(m0, m02);
+  EXPECT_EQ(2, resd.rows());
+  EXPECT_EQ(2, resd.cols());
+
   matrix_d m1(1, 1);
   m1 << 2;
   resd = quad_form_sym(m1, m1);

--- a/test/unit/math/prim/fun/quad_form_test.cpp
+++ b/test/unit/math/prim/fun/quad_form_test.cpp
@@ -7,7 +7,14 @@ TEST(MathMatrixPrim, quad_form_mat) {
 
   matrix_d resd;
   matrix_d m0;
-  EXPECT_THROW(quad_form(m0, m0), std::invalid_argument);
+  resd = quad_form(m0, m0);
+  EXPECT_EQ(0, resd.rows());
+  EXPECT_EQ(0, resd.cols());
+
+  matrix_d m02(0, 2);
+  resd = quad_form(m0, m02);
+  EXPECT_EQ(2, resd.rows());
+  EXPECT_EQ(2, resd.cols());
 
   matrix_d m1(1, 1);
   m1 << 2;
@@ -43,7 +50,7 @@ TEST(MathMatrixPrim, quad_form_vec) {
 
   matrix_d m0;
   vector_d v0;
-  EXPECT_THROW(quad_form(m0, v0), std::invalid_argument);
+  EXPECT_FLOAT_EQ(0, quad_form(m0, v0));
 
   matrix_d m1(1, 1);
   m1 << 2;

--- a/test/unit/math/prim/fun/trace_gen_inv_quad_form_ldlt_test.cpp
+++ b/test/unit/math/prim/fun/trace_gen_inv_quad_form_ldlt_test.cpp
@@ -1,20 +1,20 @@
 #include <stan/math/prim.hpp>
 #include <gtest/gtest.h>
 
-/*
- * Compute the trace of an inverse quadratic form.  I.E., this computes
- *       trace(D B^T A^-1 B)
- * where D is a square matrix and the LDLT_factor of A is provided.
- */
-
-TEST(MathMatrixPrimMat, trace_gen_inv_quad_form_ldlt) {
+TEST(MathMatrixPrim, trace_gen_inv_quad_form_ldlt) {
   using stan::math::matrix_d;
   using stan::math::trace_gen_inv_quad_form_ldlt;
 
-  matrix_d D00(0, 0), B00(0, 0), B02(0, 2);
   stan::math::LDLT_factor<double, 0, 0> ldlt_A0;
+  matrix_d B00(0, 0), B02(0, 2);
+  matrix_d D00(0, 0), D22(2, 2);
+  D22 << 1, 2, 3, 4;
+
   EXPECT_FLOAT_EQ(0, trace_gen_inv_quad_form_ldlt(D00, ldlt_A0, B00));
+  EXPECT_FLOAT_EQ(0, trace_gen_inv_quad_form_ldlt(D22, ldlt_A0, B02));
   EXPECT_THROW(trace_gen_inv_quad_form_ldlt(D00, ldlt_A0, B02),
+               std::invalid_argument);
+  EXPECT_THROW(trace_gen_inv_quad_form_ldlt(B02, ldlt_A0, B00),
                std::invalid_argument);
 
   matrix_d D(2, 2), A(4, 4), B(4, 2), gen_inv_quad_form;

--- a/test/unit/math/prim/fun/trace_gen_quad_form_test.cpp
+++ b/test/unit/math/prim/fun/trace_gen_quad_form_test.cpp
@@ -1,7 +1,7 @@
 #include <stan/math/prim.hpp>
 #include <gtest/gtest.h>
 
-TEST(MathMatrixPrimMat, trace_gen_quad_form_mat) {
+TEST(MathMatrixPrim, trace_gen_quad_form) {
   using stan::math::matrix_d;
   using stan::math::trace_gen_quad_form;
 
@@ -15,7 +15,27 @@ TEST(MathMatrixPrimMat, trace_gen_quad_form_mat) {
       1.0, 112.0;
   cd.setIdentity(2, 2);
 
-  // double-double-double
   res = trace_gen_quad_form(cd, ad, bd);
   EXPECT_FLOAT_EQ(26758, res);
+
+  EXPECT_THROW(trace_gen_quad_form(ad, ad, bd), std::invalid_argument);
+  EXPECT_THROW(trace_gen_quad_form(bd, ad, bd), std::invalid_argument);
+  EXPECT_THROW(trace_gen_quad_form(ad, bd, bd), std::invalid_argument);
+}
+
+TEST(MathMatrixPrim, trace_gen_quad_form_size_zero) {
+  using stan::math::matrix_d;
+  using stan::math::trace_gen_quad_form;
+
+  matrix_d a00, b00, d00;
+  matrix_d b02(0, 2);
+  matrix_d d22(2, 2);
+  d22 << 1, 2, 3, 4;
+  double res;
+
+  res = trace_gen_quad_form(d00, a00, b00);
+  EXPECT_FLOAT_EQ(0, res);
+
+  res = trace_gen_quad_form(d22, a00, b02);
+  EXPECT_FLOAT_EQ(0, res);
 }

--- a/test/unit/math/prim/fun/trace_quad_form_test.cpp
+++ b/test/unit/math/prim/fun/trace_quad_form_test.cpp
@@ -1,7 +1,7 @@
 #include <stan/math/prim.hpp>
 #include <gtest/gtest.h>
 
-TEST(MathMatrixPrimMat, trace_quad_form_mat) {
+TEST(MathMatrixPrim, trace_quad_form) {
   using stan::math::matrix_d;
   using stan::math::trace_quad_form;
 
@@ -12,7 +12,24 @@ TEST(MathMatrixPrimMat, trace_quad_form_mat) {
   ad << 2.0, 3.0, 4.0, 5.0, 6.0, 10.0, 2.0, 2.0, 7.0, 2.0, 7.0, 1.0, 8.0, 2.0,
       1.0, 112.0;
 
-  // double-double
   res = trace_quad_form(ad, bd);
   EXPECT_FLOAT_EQ(26758, res);
+
+  EXPECT_THROW(trace_quad_form(bd, ad), std::invalid_argument);
+  EXPECT_THROW(trace_quad_form(bd, bd), std::invalid_argument);
+}
+
+TEST(MathMatrixPrim, trace_quad_form_size_zero) {
+  using stan::math::matrix_d;
+  using stan::math::trace_quad_form;
+
+  matrix_d a00, b00;
+  matrix_d b02(0, 2);
+  double res;
+
+  res = trace_quad_form(a00, b00);
+  EXPECT_FLOAT_EQ(0, res);
+
+  res = trace_quad_form(a00, b02);
+  EXPECT_FLOAT_EQ(0, res);
 }


### PR DESCRIPTION
## Summary
This removes the `check_positive` calls from `check_multiplicable`, so that we can multiply matrices/vectors even if they have size 0. This means that for several functions, we need to return early for size 0 inputs with the correct result, as otherwise Eigen might raise some assertions. This restores the `check_multiplicable` tests inside `multiply.hpp` that were removed in #1685.

Perhaps, the only less obvious change concerns the following functions:
- `matrix_exp_multiply` and `scale_matrix_exp_multiply`
- `mdivide_left_ldlt` and `mdivide_right_ldlt`
- `trace_gen_inv_quad_form_ldlt`, `trace_inv_quad_form_ldlt`
For these functions, we move the `check_multiplicable` earlier as now it doesn't interferes with the size 0 check. The latter can then be simplified since we know that A and B are multiplicable.

Instead, for `quad_form_sym` we now move `check_multiplicable` before `check_symmetric` because it's cheaper.

Fixes #1689.

## Tests
Tests have been changed to account for the fact that now these functions don't throw. They have also been expanded to account for more boundary conditions. Note that some tests had already been added in #1698 and #1715, especially the mix tests for `mdivide_*`.

## Side Effects

None?

## Checklist

- [X] Math issue #1689

- [X] Copyright holder: Marco Colombo

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [X] the new changes are tested