### PR TITLE
remove discontinuity in lub_constrain; fixes #1441

### DIFF
--- a/stan/math/prim/fun/identity_constrain.hpp
+++ b/stan/math/prim/fun/identity_constrain.hpp
@@ -30,12 +30,13 @@ inline T identity_constrain(const T& x) {
  * <p>This method is effectively a no-op and mainly useful as a
  * placeholder in auto-generated code.
  *
- * @tparam T type of scalar.
+ * @tparam T type of scalar
+ * @tparam S type of log probability
  * @param[in] x scalar
  * @return transformed input
  */
-template <typename T>
-inline T identity_constrain(const T& x, T& /*lp*/) {
+template <typename T, typename S>
+inline T identity_constrain(const T& x, S& lp) {
   return x;
 }
 

--- a/stan/math/prim/fun/lb_constrain.hpp
+++ b/stan/math/prim/fun/lb_constrain.hpp
@@ -47,15 +47,16 @@ inline return_type_t<T, L> lb_constrain(const T& x, const L& lb) {
  * If the lower bound is negative infinity, this function
  * reduces to <code>identity_constraint(x, lp)</code>.
  *
- * @tparam T type of scalar.
- * @tparam L type of lower bound.
+ * @tparam T type of scalar
+ * @tparam L type of lower bound
+ * @tparam S type of log probability
  * @param[in] x unconstrained scalar input
  * @param[in] lb lower bound on output
- * @param[in,out] lp Reference to log probability to increment.
+ * @param[in,out] lp reference to log probability to increment
  * @return lower-bound constrained value corresponding to inputs
  */
-template <typename T, typename L>
-inline return_type_t<T, L> lb_constrain(const T& x, const L& lb, T& lp) {
+template <typename T, typename L, typename S>
+inline return_type_t<T, L> lb_constrain(const T& x, const L& lb, S& lp) {
   using std::exp;
   if (lb == NEGATIVE_INFTY) {
     return identity_constrain(x, lp);

--- a/stan/math/prim/fun/lub_constrain.hpp
+++ b/stan/math/prim/fun/lub_constrain.hpp
@@ -109,14 +109,12 @@ inline return_type_t<T, L, U> lub_constrain(const T& x, const L& lb,
   if (ub == INFTY) {
     return lb_constrain(x, lb, lp);
   }
-  T inv_logit_x;
+  T inv_logit_x = inv_logit(x);
   if (x > 0) {
     T exp_minus_x = exp(-x);
-    inv_logit_x = inv_logit(x);
     lp += log(ub - lb) - x - 2 * log1p(exp_minus_x);
   } else {
     T exp_x = exp(x);
-    inv_logit_x = inv_logit(x);
     lp += log(ub - lb) + x - 2 * log1p(exp_x);
   }
   return fma(ub - lb, inv_logit_x, lb);

--- a/stan/math/prim/fun/ub_constrain.hpp
+++ b/stan/math/prim/fun/ub_constrain.hpp
@@ -56,13 +56,14 @@ inline return_type_t<T, U> ub_constrain(const T& x, const U& ub) {
  *
  * @tparam T type of scalar
  * @tparam U type of upper bound
- * @param[in] x free scalar.
+ * @tparam S type of log probability
+ * @param[in] x free scalar
  * @param[in] ub upper bound
  * @param[in,out] lp log density
  * @return scalar constrained to have upper bound
  */
-template <typename T, typename U>
-inline return_type_t<T, U> ub_constrain(const T& x, const U& ub, T& lp) {
+template <typename T, typename U, typename S>
+inline return_type_t<T, U> ub_constrain(const T& x, const U& ub, S& lp) {
   using std::exp;
   if (ub == INFTY) {
     return identity_constrain(x, lp);

--- a/test/unit/math/prim/fun/lub_transform_test.cpp
+++ b/test/unit/math/prim/fun/lub_transform_test.cpp
@@ -90,3 +90,8 @@ TEST(prob_transform, lub_rt) {
   double xcfc = stan::math::lub_constrain(xcf, 2.0, 4.0);
   EXPECT_FLOAT_EQ(xc, xcfc);
 }
+TEST(prob_transform, underflow) {
+  EXPECT_EQ(0, stan::math::lub_constrain(-1000, 0, 1));
+  double lp = 0;
+  EXPECT_EQ(0, stan::math::lub_constrain(-1000, 0, 1, lp));
+}


### PR DESCRIPTION
## Summary

Fixed a discontinuity in `lub_constrain`
Generalized the `lp` template parameters in `{lub,lb,ub,identity}_constrain`

## Tests

Added test of boundary conditions in `lub_transform_test.cpp`

## Side Effects

Now lub_constrain underflows instead of having a discontinuity

## Checklist

- [x] Math issue #1441

- [x] Copyright holder: Columbia University

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
