### PR TITLE
Run CI/CD only on Source Code

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -170,12 +170,12 @@ pipeline {
                     sh "git clean -xffd"
 
                     def commitHash = sh(script: "git rev-parse HEAD | tr '\\n' ' '", returnStdout: true)
-                    sh(script: "git pull && git checkout develop", returnStdout: false)
+                    sh(script: "git pull && git checkout ${CHANGE_TARGET}", returnStdout: false)
 
                     def bashScript = """
                         for i in ${scPaths};
                         do
-                            git diff ${commitHash}develop -- \$i
+                            git diff ${commitHash} ${CHANGE_TARGET} -- \$i
                         done
                     """
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,7 @@ def deleteDirWin() {
 def sourceCodePaths(){
     // These paths will be passed to git diff
     // If there are changes to them, CI/CD will continue else skip
-    def paths = ['src', 'make', 'lib', 'test', 'runTests.py', 'runChecks.py', 'makefile', 'Jenkinsfile', '.clang-format']
+    def paths = ['stan', 'make', 'lib', 'test', 'runTests.py', 'runChecks.py', 'makefile', 'Jenkinsfile', '.clang-format']
     def bashArray = ""
 
     for(path in paths){
@@ -200,6 +200,11 @@ pipeline {
             }
         }
         stage('Headers checks') {
+            when {
+                expression {
+                    !skipRemainingStages
+                }
+            }
             parallel {
               stage('Headers check') {
                 agent any

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -341,8 +341,13 @@ pipeline {
                 anyOf { 
                     branch 'develop'
                     branch 'master'
-                    expression { 
-                        !skipRemainingStages
+                    allOf {
+                        expression { 
+                            !skipRemainingStages
+                        }
+                        not expression { 
+                            env.BRANCH_NAME ==~ /PR-\d+/ 
+                        }
                     }
                 } 
             }
@@ -390,14 +395,7 @@ pipeline {
         }
         stage('Upload doxygen') {
             agent any
-            when { 
-                anyOf { 
-                    branch 'develop'
-                    expression { 
-                        !skipRemainingStages
-                    }
-                } 
-            }
+            when { branch 'develop'}
             steps {
                 deleteDir()
                 retry(3) { checkout scm }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -166,6 +166,9 @@ pipeline {
             steps{
                 script {         
 
+                    retry(3) { checkout scm }
+                    sh "git clean -xffd"
+
                     def commitHash = sh(script: "git rev-parse HEAD | tr '\\n' ' '", returnStdout: true)
                     sh(script: "git pull && git checkout develop", returnStdout: false)
 
@@ -188,6 +191,11 @@ pipeline {
                         println "There aren't any differences in the source code, CI/CD will not run."
                         skipRemainingStages = true
                     }
+                }
+            }
+            post {
+                always {
+                    deleteDir()
                 }
             }
         }
@@ -365,7 +373,7 @@ pipeline {
         }
         stage('Upstream tests') {
             when { 
-                anyOf {
+                allOf {
                     expression { 
                         env.BRANCH_NAME ==~ /PR-\d+/ 
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -200,11 +200,6 @@ pipeline {
             }
         }
         stage('Headers checks') {
-            when {
-                expression {
-                    !skipRemainingStages
-                }
-            }
             parallel {
               stage('Headers check') {
                 agent any
@@ -336,21 +331,7 @@ pipeline {
             }
         }
         stage('Additional merge tests') {
-            //when { anyOf { branch 'develop'; branch 'master' } }
-            when { 
-                anyOf { 
-                    branch 'develop'
-                    branch 'master'
-                    allOf {
-                        expression { 
-                            !skipRemainingStages
-                        }
-                        not expression { 
-                            env.BRANCH_NAME ==~ /PR-\d+/ 
-                        }
-                    }
-                } 
-            }
+            when { anyOf { branch 'develop'; branch 'master' } }
             parallel {
                 stage('Linux Unit with Threading') {
                     agent { label 'linux' }


### PR DESCRIPTION
## Summary

Jenkins will now skip ci/cd pipeline if source code file paths defied in the Jenkinsfile do not have changes.

## Checklist

- [x] Math issue #1658 

- [ ] Copyright holder: (fill in copyright holder information)

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [ ] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [ ] the code is written in idiomatic C++ and changes are documented in the doxygen

- [ ] the new changes are tested
