### PR TITLE
Keep computations in log space and simplify expressions in beta binomial_*cdf

### DIFF
--- a/stan/math/prim/prob/beta_binomial_cdf.hpp
+++ b/stan/math/prim/prob/beta_binomial_cdf.hpp
@@ -9,7 +9,7 @@
 #include <stan/math/prim/fun/exp.hpp>
 #include <stan/math/prim/fun/F32.hpp>
 #include <stan/math/prim/fun/grad_F32.hpp>
-#include <stan/math/prim/fun/lgamma.hpp>
+#include <stan/math/prim/fun/lbeta.hpp>
 #include <stan/math/prim/fun/max_size.hpp>
 #include <stan/math/prim/fun/size.hpp>
 #include <stan/math/prim/fun/size_zero.hpp>
@@ -87,46 +87,37 @@ return_type_t<T_size1, T_size2> beta_binomial_cdf(const T_n& n, const T_N& N,
     const T_partials_return N_dbl = value_of(N_vec[i]);
     const T_partials_return alpha_dbl = value_of(alpha_vec[i]);
     const T_partials_return beta_dbl = value_of(beta_vec[i]);
-
+    const T_partials_return N_minus_n = N_dbl - n_dbl;
     const T_partials_return mu = alpha_dbl + n_dbl + 1;
-    const T_partials_return nu = beta_dbl + N_dbl - n_dbl - 1;
+    const T_partials_return nu = beta_dbl + N_minus_n - 1;
+    const T_partials_return one = 1;
 
     const T_partials_return F
-        = F32((T_partials_return)1, mu, -N_dbl + n_dbl + 1, n_dbl + 2, 1 - nu,
-              (T_partials_return)1);
+        = F32(one, mu, 1 - N_minus_n, n_dbl + 2, 1 - nu, one);
 
-    T_partials_return C = lgamma(nu) - lgamma(N_dbl - n_dbl);
-    C += lgamma(mu) - lgamma(n_dbl + 2);
-    C += lgamma(N_dbl + 2) - lgamma(N_dbl + alpha_dbl + beta_dbl);
-    C = exp(C);
-
-    C *= F / stan::math::beta(alpha_dbl, beta_dbl);
-    C /= N_dbl + 1;
+    T_partials_return C = lbeta(nu, mu) - lbeta(alpha_dbl, beta_dbl)
+                          - lbeta(N_minus_n, n_dbl + 2);
+    C = F * exp(C) / (N_dbl + 1);
 
     const T_partials_return Pi = 1 - C;
 
     P *= Pi;
 
     T_partials_return dF[6];
-    T_partials_return digammaOne = 0;
-    T_partials_return digammaTwo = 0;
+    T_partials_return digammaDiff = 0;
 
     if (!is_constant_all<T_size1, T_size2>::value) {
-      digammaOne = digamma(mu + nu);
-      digammaTwo = digamma(alpha_dbl + beta_dbl);
-      grad_F32(dF, (T_partials_return)1, mu, -N_dbl + n_dbl + 1, n_dbl + 2,
-               1 - nu, (T_partials_return)1);
+      digammaDiff = digamma(mu + nu) - digamma(alpha_dbl + beta_dbl);
+      grad_F32(dF, one, mu, 1 - N_minus_n, n_dbl + 2, 1 - nu, one);
     }
     if (!is_constant_all<T_size1>::value) {
-      const T_partials_return g = -C
-                                  * (digamma(mu) - digammaOne + dF[1] / F
-                                     - digamma(alpha_dbl) + digammaTwo);
+      const T_partials_return g
+          = -C * (digamma(mu) - digamma(alpha_dbl) - digammaDiff + dF[1] / F);
       ops_partials.edge1_.partials_[i] += g / Pi;
     }
     if (!is_constant_all<T_size2>::value) {
-      const T_partials_return g = -C
-                                  * (digamma(nu) - digammaOne - dF[4] / F
-                                     - digamma(beta_dbl) + digammaTwo);
+      const T_partials_return g
+          = -C * (digamma(nu) - digamma(beta_dbl) - digammaDiff - dF[4] / F);
       ops_partials.edge2_.partials_[i] += g / Pi;
     }
   }

--- a/stan/math/prim/prob/beta_binomial_lccdf.hpp
+++ b/stan/math/prim/prob/beta_binomial_lccdf.hpp
@@ -9,7 +9,7 @@
 #include <stan/math/prim/fun/exp.hpp>
 #include <stan/math/prim/fun/F32.hpp>
 #include <stan/math/prim/fun/grad_F32.hpp>
-#include <stan/math/prim/fun/lgamma.hpp>
+#include <stan/math/prim/fun/lbeta.hpp>
 #include <stan/math/prim/fun/log.hpp>
 #include <stan/math/prim/fun/max_size.hpp>
 #include <stan/math/prim/fun/size.hpp>
@@ -89,47 +89,34 @@ return_type_t<T_size1, T_size2> beta_binomial_lccdf(const T_n& n, const T_N& N,
     const T_partials_return N_dbl = value_of(N_vec[i]);
     const T_partials_return alpha_dbl = value_of(alpha_vec[i]);
     const T_partials_return beta_dbl = value_of(beta_vec[i]);
-
     const T_partials_return mu = alpha_dbl + n_dbl + 1;
     const T_partials_return nu = beta_dbl + N_dbl - n_dbl - 1;
+    const T_partials_return one = 1;
 
     const T_partials_return F
-        = F32((T_partials_return)1, mu, -N_dbl + n_dbl + 1, n_dbl + 2, 1 - nu,
-              (T_partials_return)1);
-
-    T_partials_return C = lgamma(nu) - lgamma(N_dbl - n_dbl);
-    C += lgamma(mu) - lgamma(n_dbl + 2);
-    C += lgamma(N_dbl + 2) - lgamma(N_dbl + alpha_dbl + beta_dbl);
-    C = exp(C);
-
-    C *= F / stan::math::beta(alpha_dbl, beta_dbl);
-    C /= N_dbl + 1;
+        = F32(one, mu, -N_dbl + n_dbl + 1, n_dbl + 2, 1 - nu, one);
+    T_partials_return C = lbeta(nu, mu) - lbeta(alpha_dbl, beta_dbl)
+                          - lbeta(N_dbl - n_dbl, n_dbl + 2);
+    C = F * exp(C) / (N_dbl + 1);
 
     const T_partials_return Pi = C;
 
     P += log(Pi);
 
     T_partials_return dF[6];
-    T_partials_return digammaOne = 0;
-    T_partials_return digammaTwo = 0;
+    T_partials_return digammaDiff = 0;
 
     if (!is_constant_all<T_size1, T_size2>::value) {
-      digammaOne = digamma(mu + nu);
-      digammaTwo = digamma(alpha_dbl + beta_dbl);
-      grad_F32(dF, (T_partials_return)1, mu, -N_dbl + n_dbl + 1, n_dbl + 2,
-               1 - nu, (T_partials_return)1);
+      digammaDiff = digamma(mu + nu) - digamma(alpha_dbl + beta_dbl);
+      grad_F32(dF, one, mu, -N_dbl + n_dbl + 1, n_dbl + 2, 1 - nu, one);
     }
     if (!is_constant_all<T_size1>::value) {
-      const T_partials_return g = -C
-                                  * (digamma(mu) - digammaOne + dF[1] / F
-                                     - digamma(alpha_dbl) + digammaTwo);
-      ops_partials.edge1_.partials_[i] -= g / Pi;
+      ops_partials.edge1_.partials_[i]
+          += digamma(mu) - digamma(alpha_dbl) - digammaDiff + dF[1] / F;
     }
     if (!is_constant_all<T_size2>::value) {
-      const T_partials_return g = -C
-                                  * (digamma(nu) - digammaOne - dF[4] / F
-                                     - digamma(beta_dbl) + digammaTwo);
-      ops_partials.edge2_.partials_[i] -= g / Pi;
+      ops_partials.edge2_.partials_[i]
+          += digamma(nu) - digamma(beta_dbl) - digammaDiff - dF[4] / F;
     }
   }
 

--- a/stan/math/prim/prob/beta_binomial_lcdf.hpp
+++ b/stan/math/prim/prob/beta_binomial_lcdf.hpp
@@ -9,7 +9,7 @@
 #include <stan/math/prim/fun/exp.hpp>
 #include <stan/math/prim/fun/F32.hpp>
 #include <stan/math/prim/fun/grad_F32.hpp>
-#include <stan/math/prim/fun/lgamma.hpp>
+#include <stan/math/prim/fun/lbeta.hpp>
 #include <stan/math/prim/fun/log.hpp>
 #include <stan/math/prim/fun/max_size.hpp>
 #include <stan/math/prim/fun/size.hpp>
@@ -89,46 +89,36 @@ return_type_t<T_size1, T_size2> beta_binomial_lcdf(const T_n& n, const T_N& N,
     const T_partials_return N_dbl = value_of(N_vec[i]);
     const T_partials_return alpha_dbl = value_of(alpha_vec[i]);
     const T_partials_return beta_dbl = value_of(beta_vec[i]);
-
+    const T_partials_return N_minus_n = N_dbl - n_dbl;
     const T_partials_return mu = alpha_dbl + n_dbl + 1;
-    const T_partials_return nu = beta_dbl + N_dbl - n_dbl - 1;
+    const T_partials_return nu = beta_dbl + N_minus_n - 1;
+    const T_partials_return one = 1;
 
-    T_partials_return F;
-    F = F32((T_partials_return)1, mu, -N_dbl + n_dbl + 1, n_dbl + 2, 1 - nu,
-            (T_partials_return)1);
-
-    T_partials_return C = lgamma(nu) - lgamma(N_dbl - n_dbl);
-    C += lgamma(mu) - lgamma(n_dbl + 2);
-    C += lgamma(N_dbl + 2) - lgamma(N_dbl + alpha_dbl + beta_dbl);
-    C = exp(C);
-
-    C *= F / stan::math::beta(alpha_dbl, beta_dbl);
-    C /= N_dbl + 1;
+    const T_partials_return F
+        = F32(one, mu, 1 - N_minus_n, n_dbl + 2, 1 - nu, one);
+    T_partials_return C = lbeta(nu, mu) - lbeta(alpha_dbl, beta_dbl)
+                          - lbeta(N_minus_n, n_dbl + 2);
+    C = F * exp(C) / (N_dbl + 1);
 
     const T_partials_return Pi = 1 - C;
 
     P += log(Pi);
 
     T_partials_return dF[6];
-    T_partials_return digammaOne = 0;
-    T_partials_return digammaTwo = 0;
+    T_partials_return digammaDiff = 0;
 
     if (!is_constant_all<T_size1, T_size2>::value) {
-      digammaOne = digamma(mu + nu);
-      digammaTwo = digamma(alpha_dbl + beta_dbl);
-      grad_F32(dF, (T_partials_return)1, mu, -N_dbl + n_dbl + 1, n_dbl + 2,
-               1 - nu, (T_partials_return)1);
+      digammaDiff = digamma(mu + nu) - digamma(alpha_dbl + beta_dbl);
+      grad_F32(dF, one, mu, 1 - N_minus_n, n_dbl + 2, 1 - nu, one);
     }
     if (!is_constant_all<T_size1>::value) {
-      const T_partials_return g = -C
-                                  * (digamma(mu) - digammaOne + dF[1] / F
-                                     - digamma(alpha_dbl) + digammaTwo);
+      const T_partials_return g
+          = -C * (digamma(mu) - digamma(alpha_dbl) - digammaDiff + dF[1] / F);
       ops_partials.edge1_.partials_[i] += g / Pi;
     }
     if (!is_constant_all<T_size2>::value) {
-      const T_partials_return g = -C
-                                  * (digamma(nu) - digammaOne - dF[4] / F
-                                     - digamma(beta_dbl) + digammaTwo);
+      const T_partials_return g
+          = -C * (digamma(nu) - digamma(beta_dbl) - digammaDiff - dF[4] / F);
       ops_partials.edge2_.partials_[i] += g / Pi;
     }
   }


### PR DESCRIPTION
## Summary
In #912 @nhuurre noticed that computations for the `beta_binomial` *cdf functions switch from log space to linear space halfway through. He also noticed that there is no gain in using the `lgamma` instead of `lbeta`, as we are effectively still computing all terms: switching to `lbeta` makes the code a bit more readable. This also does a bit of general cleanup to save on some intermediate computations.

This doesn't solve the issue of loss of precision, but will make it easier to investigate that going forward.

## Tests

No new tests, this is just cleanup.

## Side Effects

None.

## Checklist

- [X] Math issue #912

- [X] Copyright holder: Marco Colombo

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [X] the new changes are tested
