### PR TITLE
Avoid 'Blocked loading mixed active content' errors

### DIFF
--- a/doxygen/doxygen.cfg
+++ b/doxygen/doxygen.cfg
@@ -1511,7 +1511,7 @@ MATHJAX_FORMAT         = HTML-CSS
 # The default value is: http://cdn.mathjax.org/mathjax/latest.
 # This tag requires that the tag USE_MATHJAX is set to YES.
 
-MATHJAX_RELPATH        = http://cdn.mathjax.org/mathjax/latest
+MATHJAX_RELPATH        = https://cdn.mathjax.org/mathjax/latest
 
 # The MATHJAX_EXTENSIONS tag can be used to specify one or more MathJax
 # extension names that should be enabled during MathJax rendering. For example


### PR DESCRIPTION
## Summary
This configures the mathjax resources from to be loaded from an `https` url. Doing this should stop the browser from blocking what it believes to be insecure content, and should fix #1721.

## Tests

Not necessary, and should be skipped by default! :)

## Side Effects

None.

## Checklist

- [X] Math issue #1721

- [X] Copyright holder: Marco Colombo

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)