### PR TITLE
Generalize */fun starting with a-chol2

### DIFF
--- a/stan/math/fwd/fun/mdivide_left.hpp
+++ b/stan/math/fwd/fun/mdivide_left.hpp
@@ -54,7 +54,8 @@ mdivide_left(const T1& A, const T2& b) {
   return to_fvar(inv_A_mult_b, deriv);
 }
 
-template <typename T1, typename T2, require_eigen_vt<std::is_arithmetic, T1>* = nullptr,
+template <typename T1, typename T2,
+          require_eigen_vt<std::is_arithmetic, T1>* = nullptr,
           require_eigen_vt<is_fvar, T2>* = nullptr>
 inline Eigen::Matrix<value_type_t<T2>, T1::RowsAtCompileTime,
                      T2::ColsAtCompileTime>

--- a/stan/math/fwd/fun/mdivide_left.hpp
+++ b/stan/math/fwd/fun/mdivide_left.hpp
@@ -13,10 +13,18 @@
 namespace stan {
 namespace math {
 
-template <typename T, int R1, int C1, int R2, int C2>
-inline Eigen::Matrix<fvar<T>, R1, C2> mdivide_left(
-    const Eigen::Matrix<fvar<T>, R1, C1> &A,
-    const Eigen::Matrix<fvar<T>, R2, C2> &b) {
+template <typename T1, typename T2,
+          require_all_eigen_vt<is_fvar, T1, T2>* = nullptr,
+          require_same_vt<T1, T2>* = nullptr>
+inline Eigen::Matrix<value_type_t<T1>, T1::RowsAtCompileTime,
+                     T2::ColsAtCompileTime>
+mdivide_left(const T1& A, const T2& b) {
+  using T = typename value_type_t<T1>::Scalar;
+  constexpr int R1 = T1::RowsAtCompileTime;
+  constexpr int C1 = T1::ColsAtCompileTime;
+  constexpr int R2 = T2::RowsAtCompileTime;
+  constexpr int C2 = T2::ColsAtCompileTime;
+
   check_square("mdivide_left", "A", A);
   check_multiplicable("mdivide_left", "A", A, "b", b);
 
@@ -28,17 +36,19 @@ inline Eigen::Matrix<fvar<T>, R1, C2> mdivide_left(
   Eigen::Matrix<T, R2, C2> val_b(b.rows(), b.cols());
   Eigen::Matrix<T, R2, C2> deriv_b(b.rows(), b.cols());
 
+  const Eigen::Ref<const plain_type_t<T1>>& A_ref = A;
   for (int j = 0; j < A.cols(); j++) {
     for (int i = 0; i < A.rows(); i++) {
-      val_A(i, j) = A(i, j).val_;
-      deriv_A(i, j) = A(i, j).d_;
+      val_A(i, j) = A_ref(i, j).val_;
+      deriv_A(i, j) = A_ref(i, j).d_;
     }
   }
 
+  const Eigen::Ref<const plain_type_t<T2>>& b_ref = b;
   for (int j = 0; j < b.cols(); j++) {
     for (int i = 0; i < b.rows(); i++) {
-      val_b(i, j) = b(i, j).val_;
-      deriv_b(i, j) = b(i, j).d_;
+      val_b(i, j) = b_ref(i, j).val_;
+      deriv_b(i, j) = b_ref(i, j).d_;
     }
   }
 
@@ -52,30 +62,47 @@ inline Eigen::Matrix<fvar<T>, R1, C2> mdivide_left(
   return to_fvar(inv_A_mult_b, deriv);
 }
 
-template <typename T, int R1, int C1, int R2, int C2>
-inline Eigen::Matrix<fvar<T>, R1, C2> mdivide_left(
-    const Eigen::Matrix<double, R1, C1> &A,
-    const Eigen::Matrix<fvar<T>, R2, C2> &b) {
+template <typename T1, typename T2, require_eigen_t<T1>* = nullptr,
+          require_same_vt<double, T1>* = nullptr,
+          require_eigen_vt<is_fvar, T2>* = nullptr>
+inline Eigen::Matrix<value_type_t<T2>, T1::RowsAtCompileTime,
+                     T2::ColsAtCompileTime>
+mdivide_left(const T1& A, const T2& b) {
+  using T = typename value_type_t<T2>::Scalar;
+  constexpr int R1 = T1::RowsAtCompileTime;
+  constexpr int C1 = T1::ColsAtCompileTime;
+  constexpr int R2 = T2::RowsAtCompileTime;
+  constexpr int C2 = T2::ColsAtCompileTime;
+
   check_square("mdivide_left", "A", A);
   check_multiplicable("mdivide_left", "A", A, "b", b);
 
   Eigen::Matrix<T, R2, C2> val_b(b.rows(), b.cols());
   Eigen::Matrix<T, R2, C2> deriv_b(b.rows(), b.cols());
 
+  const Eigen::Ref<const plain_type_t<T2>>& b_ref = b;
   for (int j = 0; j < b.cols(); j++) {
     for (int i = 0; i < b.rows(); i++) {
-      val_b(i, j) = b(i, j).val_;
-      deriv_b(i, j) = b(i, j).d_;
+      val_b(i, j) = b_ref(i, j).val_;
+      deriv_b(i, j) = b_ref(i, j).d_;
     }
   }
 
   return to_fvar(mdivide_left(A, val_b), mdivide_left(A, deriv_b));
 }
 
-template <typename T, int R1, int C1, int R2, int C2>
-inline Eigen::Matrix<fvar<T>, R1, C2> mdivide_left(
-    const Eigen::Matrix<fvar<T>, R1, C1> &A,
-    const Eigen::Matrix<double, R2, C2> &b) {
+template <typename T1, typename T2, require_eigen_vt<is_fvar, T1>* = nullptr,
+          require_eigen_t<T2>* = nullptr,
+          require_same_vt<double, T2>* = nullptr>
+inline Eigen::Matrix<value_type_t<T1>, T1::RowsAtCompileTime,
+                     T2::ColsAtCompileTime>
+mdivide_left(const T1& A, const T2& b) {
+  using T = typename value_type_t<T1>::Scalar;
+  constexpr int R1 = T1::RowsAtCompileTime;
+  constexpr int C1 = T1::ColsAtCompileTime;
+  constexpr int R2 = T2::RowsAtCompileTime;
+  constexpr int C2 = T2::ColsAtCompileTime;
+
   check_square("mdivide_left", "A", A);
   check_multiplicable("mdivide_left", "A", A, "b", b);
 
@@ -84,10 +111,11 @@ inline Eigen::Matrix<fvar<T>, R1, C2> mdivide_left(
   Eigen::Matrix<T, R1, C1> val_A(A.rows(), A.cols());
   Eigen::Matrix<T, R1, C1> deriv_A(A.rows(), A.cols());
 
+  const Eigen::Ref<const plain_type_t<T1>>& A_ref = A;
   for (int j = 0; j < A.cols(); j++) {
     for (int i = 0; i < A.rows(); i++) {
-      val_A(i, j) = A(i, j).val_;
-      deriv_A(i, j) = A(i, j).d_;
+      val_A(i, j) = A_ref(i, j).val_;
+      deriv_A(i, j) = A_ref(i, j).d_;
     }
   }
 

--- a/stan/math/fwd/fun/mdivide_left.hpp
+++ b/stan/math/fwd/fun/mdivide_left.hpp
@@ -20,9 +20,7 @@ inline Eigen::Matrix<value_type_t<T1>, T1::RowsAtCompileTime,
                      T2::ColsAtCompileTime>
 mdivide_left(const T1& A, const T2& b) {
   using T = typename value_type_t<T1>::Scalar;
-  constexpr int R1 = T1::RowsAtCompileTime;
-  constexpr int C1 = T1::ColsAtCompileTime;
-  constexpr int R2 = T2::RowsAtCompileTime;
+  constexpr int S1 = T1::RowsAtCompileTime;
   constexpr int C2 = T2::ColsAtCompileTime;
 
   check_square("mdivide_left", "A", A);
@@ -31,14 +29,13 @@ mdivide_left(const T1& A, const T2& b) {
     return {0, b.cols()};
   }
 
-  Eigen::Matrix<T, R1, C2> inv_A_mult_b(A.rows(), b.cols());
-  Eigen::Matrix<T, R1, C2> inv_A_mult_deriv_b(A.rows(), b.cols());
-  Eigen::Matrix<T, R1, C1> inv_A_mult_deriv_A(A.rows(), A.cols());
-  Eigen::Matrix<T, R1, C1> val_A(A.rows(), A.cols());
-  Eigen::Matrix<T, R1, C1> deriv_A(A.rows(), A.cols());
-  Eigen::Matrix<T, R2, C2> val_b(b.rows(), b.cols());
-  Eigen::Matrix<T, R2, C2> deriv_b(b.rows(), b.cols());
+  Eigen::Matrix<T, S1, C2> inv_A_mult_b(A.rows(), b.cols());
+  Eigen::Matrix<T, S1, C2> inv_A_mult_deriv_b(A.rows(), b.cols());
+  Eigen::Matrix<T, S1, S1> inv_A_mult_deriv_A(A.rows(), A.cols());
+  Eigen::Matrix<T, S1, S1> val_A(A.rows(), A.cols());
+  Eigen::Matrix<T, S1, S1> deriv_A(A.rows(), A.cols());
 
+  const Eigen::Ref<const plain_type_t<T2>>& b_ref = b;
   const Eigen::Ref<const plain_type_t<T1>>& A_ref = A;
   for (int j = 0; j < A.cols(); j++) {
     for (int i = 0; i < A.rows(); i++) {
@@ -47,34 +44,23 @@ mdivide_left(const T1& A, const T2& b) {
     }
   }
 
-  const Eigen::Ref<const plain_type_t<T2>>& b_ref = b;
-  for (int j = 0; j < b.cols(); j++) {
-    for (int i = 0; i < b.rows(); i++) {
-      val_b(i, j) = b_ref(i, j).val_;
-      deriv_b(i, j) = b_ref(i, j).d_;
-    }
-  }
-
-  inv_A_mult_b = mdivide_left(val_A, val_b);
-  inv_A_mult_deriv_b = mdivide_left(val_A, deriv_b);
+  inv_A_mult_b = mdivide_left(val_A, b_ref.val());
+  inv_A_mult_deriv_b = mdivide_left(val_A, b_ref.d());
   inv_A_mult_deriv_A = mdivide_left(val_A, deriv_A);
 
-  Eigen::Matrix<T, R1, C2> deriv(A.rows(), b.cols());
+  Eigen::Matrix<T, S1, C2> deriv(A.rows(), b.cols());
   deriv = inv_A_mult_deriv_b - multiply(inv_A_mult_deriv_A, inv_A_mult_b);
 
   return to_fvar(inv_A_mult_b, deriv);
 }
 
-template <typename T1, typename T2, require_eigen_t<T1>* = nullptr,
-          require_same_vt<double, T1>* = nullptr,
+template <typename T1, typename T2, require_eigen_vt<std::is_arithmetic, T1>* = nullptr,
           require_eigen_vt<is_fvar, T2>* = nullptr>
 inline Eigen::Matrix<value_type_t<T2>, T1::RowsAtCompileTime,
                      T2::ColsAtCompileTime>
 mdivide_left(const T1& A, const T2& b) {
   using T = typename value_type_t<T2>::Scalar;
-  constexpr int R1 = T1::RowsAtCompileTime;
-  constexpr int C1 = T1::ColsAtCompileTime;
-  constexpr int R2 = T2::RowsAtCompileTime;
+  constexpr int S1 = T1::RowsAtCompileTime;
   constexpr int C2 = T2::ColsAtCompileTime;
 
   check_square("mdivide_left", "A", A);
@@ -83,30 +69,18 @@ mdivide_left(const T1& A, const T2& b) {
     return {0, b.cols()};
   }
 
-  Eigen::Matrix<T, R2, C2> val_b(b.rows(), b.cols());
-  Eigen::Matrix<T, R2, C2> deriv_b(b.rows(), b.cols());
-
   const Eigen::Ref<const plain_type_t<T2>>& b_ref = b;
-  for (int j = 0; j < b.cols(); j++) {
-    for (int i = 0; i < b.rows(); i++) {
-      val_b(i, j) = b_ref(i, j).val_;
-      deriv_b(i, j) = b_ref(i, j).d_;
-    }
-  }
 
-  return to_fvar(mdivide_left(A, val_b), mdivide_left(A, deriv_b));
+  return to_fvar(mdivide_left(A, b_ref.val()), mdivide_left(A, b_ref.d()));
 }
 
 template <typename T1, typename T2, require_eigen_vt<is_fvar, T1>* = nullptr,
-          require_eigen_t<T2>* = nullptr,
-          require_same_vt<double, T2>* = nullptr>
+          require_eigen_vt<std::is_arithmetic, T2>* = nullptr>
 inline Eigen::Matrix<value_type_t<T1>, T1::RowsAtCompileTime,
                      T2::ColsAtCompileTime>
 mdivide_left(const T1& A, const T2& b) {
   using T = typename value_type_t<T1>::Scalar;
-  constexpr int R1 = T1::RowsAtCompileTime;
-  constexpr int C1 = T1::ColsAtCompileTime;
-  constexpr int R2 = T2::RowsAtCompileTime;
+  constexpr int S1 = T1::RowsAtCompileTime;
   constexpr int C2 = T2::ColsAtCompileTime;
 
   check_square("mdivide_left", "A", A);
@@ -115,10 +89,10 @@ mdivide_left(const T1& A, const T2& b) {
     return {0, b.cols()};
   }
 
-  Eigen::Matrix<T, R1, C2> inv_A_mult_b(A.rows(), b.cols());
-  Eigen::Matrix<T, R1, C1> inv_A_mult_deriv_A(A.rows(), A.cols());
-  Eigen::Matrix<T, R1, C1> val_A(A.rows(), A.cols());
-  Eigen::Matrix<T, R1, C1> deriv_A(A.rows(), A.cols());
+  Eigen::Matrix<T, S1, C2> inv_A_mult_b(A.rows(), b.cols());
+  Eigen::Matrix<T, S1, S1> inv_A_mult_deriv_A(A.rows(), A.cols());
+  Eigen::Matrix<T, S1, S1> val_A(A.rows(), A.cols());
+  Eigen::Matrix<T, S1, S1> deriv_A(A.rows(), A.cols());
 
   const Eigen::Ref<const plain_type_t<T1>>& A_ref = A;
   for (int j = 0; j < A.cols(); j++) {
@@ -131,7 +105,7 @@ mdivide_left(const T1& A, const T2& b) {
   inv_A_mult_b = mdivide_left(val_A, b);
   inv_A_mult_deriv_A = mdivide_left(val_A, deriv_A);
 
-  Eigen::Matrix<T, R1, C2> deriv(A.rows(), b.cols());
+  Eigen::Matrix<T, S1, C2> deriv(A.rows(), b.cols());
   deriv = -multiply(inv_A_mult_deriv_A, inv_A_mult_b);
 
   return to_fvar(inv_A_mult_b, deriv);

--- a/stan/math/fwd/fun/mdivide_left_tri_low.hpp
+++ b/stan/math/fwd/fun/mdivide_left_tri_low.hpp
@@ -12,10 +12,18 @@
 namespace stan {
 namespace math {
 
-template <typename T, int R1, int C1, int R2, int C2>
-inline Eigen::Matrix<fvar<T>, R1, C2> mdivide_left_tri_low(
-    const Eigen::Matrix<fvar<T>, R1, C1>& A,
-    const Eigen::Matrix<fvar<T>, R2, C2>& b) {
+template <typename T1, typename T2,
+          require_all_eigen_vt<is_fvar, T1, T2>* = nullptr,
+          require_same_vt<T1, T2>* = nullptr>
+inline Eigen::Matrix<value_type_t<T1>, T1::RowsAtCompileTime,
+                     T2::ColsAtCompileTime>
+mdivide_left_tri_low(const T1& A, const T2& b) {
+  using T = typename value_type_t<T1>::Scalar;
+  constexpr int R1 = T1::RowsAtCompileTime;
+  constexpr int C1 = T1::ColsAtCompileTime;
+  constexpr int R2 = T2::RowsAtCompileTime;
+  constexpr int C2 = T2::ColsAtCompileTime;
+
   check_square("mdivide_left_tri_low", "A", A);
   check_multiplicable("mdivide_left_tri_low", "A", A, "b", b);
 
@@ -29,17 +37,19 @@ inline Eigen::Matrix<fvar<T>, R1, C2> mdivide_left_tri_low(
   val_A.setZero();
   deriv_A.setZero();
 
+  const Eigen::Ref<const plain_type_t<T1>>& A_ref = A;
   for (size_type j = 0; j < A.cols(); j++) {
     for (size_type i = j; i < A.rows(); i++) {
-      val_A(i, j) = A(i, j).val_;
-      deriv_A(i, j) = A(i, j).d_;
+      val_A(i, j) = A_ref(i, j).val_;
+      deriv_A(i, j) = A_ref(i, j).d_;
     }
   }
 
+  const Eigen::Ref<const plain_type_t<T2>>& b_ref = b;
   for (size_type j = 0; j < b.cols(); j++) {
     for (size_type i = 0; i < b.rows(); i++) {
-      val_b(i, j) = b(i, j).val_;
-      deriv_b(i, j) = b(i, j).d_;
+      val_b(i, j) = b_ref(i, j).val_;
+      deriv_b(i, j) = b_ref(i, j).d_;
     }
   }
 
@@ -53,10 +63,18 @@ inline Eigen::Matrix<fvar<T>, R1, C2> mdivide_left_tri_low(
   return to_fvar(inv_A_mult_b, deriv);
 }
 
-template <typename T, int R1, int C1, int R2, int C2>
-inline Eigen::Matrix<fvar<T>, R1, C2> mdivide_left_tri_low(
-    const Eigen::Matrix<double, R1, C1>& A,
-    const Eigen::Matrix<fvar<T>, R2, C2>& b) {
+template <typename T1, typename T2, require_eigen_t<T1>* = nullptr,
+          require_same_vt<double, T1>* = nullptr,
+          require_eigen_vt<is_fvar, T2>* = nullptr>
+inline Eigen::Matrix<value_type_t<T2>, T1::RowsAtCompileTime,
+                     T2::ColsAtCompileTime>
+mdivide_left_tri_low(const T1& A, const T2& b) {
+  using T = typename value_type_t<T2>::Scalar;
+  constexpr int R1 = T1::RowsAtCompileTime;
+  constexpr int C1 = T1::ColsAtCompileTime;
+  constexpr int R2 = T2::RowsAtCompileTime;
+  constexpr int C2 = T2::ColsAtCompileTime;
+
   check_square("mdivide_left_tri_low", "A", A);
   check_multiplicable("mdivide_left_tri_low", "A", A, "b", b);
 
@@ -67,16 +85,18 @@ inline Eigen::Matrix<fvar<T>, R1, C2> mdivide_left_tri_low(
   Eigen::Matrix<double, R1, C1> val_A(A.rows(), A.cols());
   val_A.setZero();
 
+  const Eigen::Ref<const plain_type_t<T1>>& A_ref = A;
   for (size_type j = 0; j < A.cols(); j++) {
     for (size_type i = j; i < A.rows(); i++) {
-      val_A(i, j) = A(i, j);
+      val_A(i, j) = A_ref(i, j);
     }
   }
 
+  const Eigen::Ref<const plain_type_t<T2>>& b_ref = b;
   for (size_type j = 0; j < b.cols(); j++) {
     for (size_type i = 0; i < b.rows(); i++) {
-      val_b(i, j) = b(i, j).val_;
-      deriv_b(i, j) = b(i, j).d_;
+      val_b(i, j) = b_ref(i, j).val_;
+      deriv_b(i, j) = b_ref(i, j).d_;
     }
   }
 
@@ -89,10 +109,18 @@ inline Eigen::Matrix<fvar<T>, R1, C2> mdivide_left_tri_low(
   return to_fvar(inv_A_mult_b, deriv);
 }
 
-template <typename T, int R1, int C1, int R2, int C2>
-inline Eigen::Matrix<fvar<T>, R1, C2> mdivide_left_tri_low(
-    const Eigen::Matrix<fvar<T>, R1, C1>& A,
-    const Eigen::Matrix<double, R2, C2>& b) {
+template <typename T1, typename T2, require_eigen_vt<is_fvar, T1>* = nullptr,
+          require_eigen_t<T2>* = nullptr,
+          require_same_vt<double, T2>* = nullptr>
+inline Eigen::Matrix<value_type_t<T1>, T1::RowsAtCompileTime,
+                     T2::ColsAtCompileTime>
+mdivide_left_tri_low(const T1& A, const T2& b) {
+  using T = typename value_type_t<T1>::Scalar;
+  constexpr int R1 = T1::RowsAtCompileTime;
+  constexpr int C1 = T1::ColsAtCompileTime;
+  constexpr int R2 = T2::RowsAtCompileTime;
+  constexpr int C2 = T2::ColsAtCompileTime;
+
   check_square("mdivide_left_tri_low", "A", A);
   check_multiplicable("mdivide_left_tri_low", "A", A, "b", b);
 
@@ -103,10 +131,11 @@ inline Eigen::Matrix<fvar<T>, R1, C2> mdivide_left_tri_low(
   val_A.setZero();
   deriv_A.setZero();
 
+  const Eigen::Ref<const plain_type_t<T1>>& A_ref = A;
   for (size_type j = 0; j < A.cols(); j++) {
     for (size_type i = j; i < A.rows(); i++) {
-      val_A(i, j) = A(i, j).val_;
-      deriv_A(i, j) = A(i, j).d_;
+      val_A(i, j) = A_ref(i, j).val_;
+      deriv_A(i, j) = A_ref(i, j).d_;
     }
   }
 

--- a/stan/math/fwd/fun/mdivide_left_tri_low.hpp
+++ b/stan/math/fwd/fun/mdivide_left_tri_low.hpp
@@ -44,7 +44,9 @@ mdivide_left_tri_low(const T1& A, const T2& b) {
 
   Eigen::Matrix<T, S1, C2> inv_A_mult_b = mdivide_left(val_A, b_ref.val());
 
-  return to_fvar(inv_A_mult_b, mdivide_left(val_A, b_ref.d()) - multiply(mdivide_left(val_A, deriv_A), inv_A_mult_b));
+  return to_fvar(inv_A_mult_b,
+                 mdivide_left(val_A, b_ref.d())
+                     - multiply(mdivide_left(val_A, deriv_A), inv_A_mult_b));
 }
 
 template <typename T1, typename T2, require_eigen_t<T1>* = nullptr,
@@ -74,7 +76,8 @@ mdivide_left_tri_low(const T1& A, const T2& b) {
     }
   }
 
-  return to_fvar(mdivide_left(val_A, b_ref.val()), mdivide_left(val_A, b_ref.d()));
+  return to_fvar(mdivide_left(val_A, b_ref.val()),
+                 mdivide_left(val_A, b_ref.d()));
 }
 
 template <typename T1, typename T2, require_eigen_vt<is_fvar, T1>* = nullptr,
@@ -108,7 +111,8 @@ mdivide_left_tri_low(const T1& A, const T2& b) {
 
   Eigen::Matrix<T, S1, C2> inv_A_mult_b = mdivide_left(val_A, b);
 
-  return to_fvar(inv_A_mult_b, -multiply(mdivide_left(val_A, deriv_A), inv_A_mult_b));
+  return to_fvar(inv_A_mult_b,
+                 -multiply(mdivide_left(val_A, deriv_A), inv_A_mult_b));
 }
 
 }  // namespace math

--- a/stan/math/fwd/fun/mdivide_left_tri_low.hpp
+++ b/stan/math/fwd/fun/mdivide_left_tri_low.hpp
@@ -19,9 +19,7 @@ inline Eigen::Matrix<value_type_t<T1>, T1::RowsAtCompileTime,
                      T2::ColsAtCompileTime>
 mdivide_left_tri_low(const T1& A, const T2& b) {
   using T = typename value_type_t<T1>::Scalar;
-  constexpr int R1 = T1::RowsAtCompileTime;
-  constexpr int C1 = T1::ColsAtCompileTime;
-  constexpr int R2 = T2::RowsAtCompileTime;
+  constexpr int S1 = T1::RowsAtCompileTime;
   constexpr int C2 = T2::ColsAtCompileTime;
 
   check_square("mdivide_left_tri_low", "A", A);
@@ -30,16 +28,12 @@ mdivide_left_tri_low(const T1& A, const T2& b) {
     return {0, b.cols()};
   }
 
-  Eigen::Matrix<T, R1, C2> inv_A_mult_b(A.rows(), b.cols());
-  Eigen::Matrix<T, R1, C2> inv_A_mult_deriv_b(A.rows(), b.cols());
-  Eigen::Matrix<T, R1, C1> inv_A_mult_deriv_A(A.rows(), A.cols());
-  Eigen::Matrix<T, R1, C1> val_A(A.rows(), A.cols());
-  Eigen::Matrix<T, R1, C1> deriv_A(A.rows(), A.cols());
-  Eigen::Matrix<T, R2, C2> val_b(b.rows(), b.cols());
-  Eigen::Matrix<T, R2, C2> deriv_b(b.rows(), b.cols());
+  Eigen::Matrix<T, S1, S1> val_A(A.rows(), A.cols());
+  Eigen::Matrix<T, S1, S1> deriv_A(A.rows(), A.cols());
   val_A.setZero();
   deriv_A.setZero();
 
+  const Eigen::Ref<const plain_type_t<T2>>& b_ref = b;
   const Eigen::Ref<const plain_type_t<T1>>& A_ref = A;
   for (size_type j = 0; j < A.cols(); j++) {
     for (size_type i = j; i < A.rows(); i++) {
@@ -48,22 +42,9 @@ mdivide_left_tri_low(const T1& A, const T2& b) {
     }
   }
 
-  const Eigen::Ref<const plain_type_t<T2>>& b_ref = b;
-  for (size_type j = 0; j < b.cols(); j++) {
-    for (size_type i = 0; i < b.rows(); i++) {
-      val_b(i, j) = b_ref(i, j).val_;
-      deriv_b(i, j) = b_ref(i, j).d_;
-    }
-  }
+  Eigen::Matrix<T, S1, C2> inv_A_mult_b = mdivide_left(val_A, b_ref.val());
 
-  inv_A_mult_b = mdivide_left(val_A, val_b);
-  inv_A_mult_deriv_b = mdivide_left(val_A, deriv_b);
-  inv_A_mult_deriv_A = mdivide_left(val_A, deriv_A);
-
-  Eigen::Matrix<T, R1, C2> deriv(A.rows(), b.cols());
-  deriv = inv_A_mult_deriv_b - multiply(inv_A_mult_deriv_A, inv_A_mult_b);
-
-  return to_fvar(inv_A_mult_b, deriv);
+  return to_fvar(inv_A_mult_b, mdivide_left(val_A, b_ref.d()) - multiply(mdivide_left(val_A, deriv_A), inv_A_mult_b));
 }
 
 template <typename T1, typename T2, require_eigen_t<T1>* = nullptr,
@@ -73,9 +54,7 @@ inline Eigen::Matrix<value_type_t<T2>, T1::RowsAtCompileTime,
                      T2::ColsAtCompileTime>
 mdivide_left_tri_low(const T1& A, const T2& b) {
   using T = typename value_type_t<T2>::Scalar;
-  constexpr int R1 = T1::RowsAtCompileTime;
-  constexpr int C1 = T1::ColsAtCompileTime;
-  constexpr int R2 = T2::RowsAtCompileTime;
+  constexpr int S1 = T1::RowsAtCompileTime;
   constexpr int C2 = T2::ColsAtCompileTime;
 
   check_square("mdivide_left_tri_low", "A", A);
@@ -84,13 +63,10 @@ mdivide_left_tri_low(const T1& A, const T2& b) {
     return {0, b.cols()};
   }
 
-  Eigen::Matrix<T, R1, C2> inv_A_mult_b(A.rows(), b.cols());
-  Eigen::Matrix<T, R1, C2> inv_A_mult_deriv_b(A.rows(), b.cols());
-  Eigen::Matrix<T, R2, C2> val_b(b.rows(), b.cols());
-  Eigen::Matrix<T, R2, C2> deriv_b(b.rows(), b.cols());
-  Eigen::Matrix<double, R1, C1> val_A(A.rows(), A.cols());
+  Eigen::Matrix<double, S1, S1> val_A(A.rows(), A.cols());
   val_A.setZero();
 
+  const Eigen::Ref<const plain_type_t<T2>>& b_ref = b;
   const Eigen::Ref<const plain_type_t<T1>>& A_ref = A;
   for (size_type j = 0; j < A.cols(); j++) {
     for (size_type i = j; i < A.rows(); i++) {
@@ -98,21 +74,7 @@ mdivide_left_tri_low(const T1& A, const T2& b) {
     }
   }
 
-  const Eigen::Ref<const plain_type_t<T2>>& b_ref = b;
-  for (size_type j = 0; j < b.cols(); j++) {
-    for (size_type i = 0; i < b.rows(); i++) {
-      val_b(i, j) = b_ref(i, j).val_;
-      deriv_b(i, j) = b_ref(i, j).d_;
-    }
-  }
-
-  inv_A_mult_b = mdivide_left(val_A, val_b);
-  inv_A_mult_deriv_b = mdivide_left(val_A, deriv_b);
-
-  Eigen::Matrix<T, R1, C2> deriv(A.rows(), b.cols());
-  deriv = inv_A_mult_deriv_b;
-
-  return to_fvar(inv_A_mult_b, deriv);
+  return to_fvar(mdivide_left(val_A, b_ref.val()), mdivide_left(val_A, b_ref.d()));
 }
 
 template <typename T1, typename T2, require_eigen_vt<is_fvar, T1>* = nullptr,
@@ -122,9 +84,7 @@ inline Eigen::Matrix<value_type_t<T1>, T1::RowsAtCompileTime,
                      T2::ColsAtCompileTime>
 mdivide_left_tri_low(const T1& A, const T2& b) {
   using T = typename value_type_t<T1>::Scalar;
-  constexpr int R1 = T1::RowsAtCompileTime;
-  constexpr int C1 = T1::ColsAtCompileTime;
-  constexpr int R2 = T2::RowsAtCompileTime;
+  constexpr int S1 = T1::RowsAtCompileTime;
   constexpr int C2 = T2::ColsAtCompileTime;
 
   check_square("mdivide_left_tri_low", "A", A);
@@ -133,10 +93,8 @@ mdivide_left_tri_low(const T1& A, const T2& b) {
     return {0, b.cols()};
   }
 
-  Eigen::Matrix<T, R1, C2> inv_A_mult_b(A.rows(), b.cols());
-  Eigen::Matrix<T, R1, C1> inv_A_mult_deriv_A(A.rows(), A.cols());
-  Eigen::Matrix<T, R1, C1> val_A(A.rows(), A.cols());
-  Eigen::Matrix<T, R1, C1> deriv_A(A.rows(), A.cols());
+  Eigen::Matrix<T, S1, S1> val_A(A.rows(), A.cols());
+  Eigen::Matrix<T, S1, S1> deriv_A(A.rows(), A.cols());
   val_A.setZero();
   deriv_A.setZero();
 
@@ -148,13 +106,9 @@ mdivide_left_tri_low(const T1& A, const T2& b) {
     }
   }
 
-  inv_A_mult_b = mdivide_left(val_A, b);
-  inv_A_mult_deriv_A = mdivide_left(val_A, deriv_A);
+  Eigen::Matrix<T, S1, C2> inv_A_mult_b = mdivide_left(val_A, b);
 
-  Eigen::Matrix<T, R1, C2> deriv(A.rows(), b.cols());
-  deriv = -multiply(inv_A_mult_deriv_A, inv_A_mult_b);
-
-  return to_fvar(inv_A_mult_b, deriv);
+  return to_fvar(inv_A_mult_b, -multiply(mdivide_left(val_A, deriv_A), inv_A_mult_b));
 }
 
 }  // namespace math

--- a/stan/math/prim/err/check_lower_triangular.hpp
+++ b/stan/math/prim/err/check_lower_triangular.hpp
@@ -35,7 +35,7 @@ inline void check_lower_triangular(const char* function, const char* name,
             << " " << name << "[" << stan::error_index::value + m << ","
             << stan::error_index::value + n << "]=";
         std::string msg_str(msg.str());
-        throw_domain_error(function, name, y(m, n), msg_str.c_str());
+        throw_domain_error(function, name, y_ref(m, n), msg_str.c_str());
       }
     }
   }

--- a/stan/math/prim/err/check_lower_triangular.hpp
+++ b/stan/math/prim/err/check_lower_triangular.hpp
@@ -23,13 +23,13 @@ namespace math {
  *   lower triangular or if any element in the upper triangular
  *   portion is NaN
  */
-template <typename T_y>
-inline void check_lower_triangular(
-    const char* function, const char* name,
-    const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>& y) {
+template <typename T_y, require_eigen_t<T_y>* = nullptr>
+inline void check_lower_triangular(const char* function, const char* name,
+                                   const T_y& y) {
+  const Eigen::Ref<const plain_type_t<T_y>>& y_ref = y;
   for (int n = 1; n < y.cols(); ++n) {
     for (int m = 0; m < n && m < y.rows(); ++m) {
-      if (y(m, n) != 0) {
+      if (y_ref(m, n) != 0) {
         std::stringstream msg;
         msg << "is not lower triangular;"
             << " " << name << "[" << stan::error_index::value + m << ","

--- a/stan/math/prim/err/check_square.hpp
+++ b/stan/math/prim/err/check_square.hpp
@@ -11,16 +11,14 @@ namespace math {
 
 /**
  * Check if the specified matrix is square. This check allows 0x0 matrices.
- * @tparam T Type of scalar
+ * @tparam T Type of matrix
  * @param function Function name (for error messages)
  * @param name Variable name (for error messages)
  * @param y Matrix to test
  * @throw <code>std::invalid_argument</code> if the matrix is not square
  */
-template <typename T_y>
-inline void check_square(
-    const char* function, const char* name,
-    const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>& y) {
+template <typename T_y, require_eigen_t<T_y>* = nullptr>
+inline void check_square(const char* function, const char* name, const T_y& y) {
   check_size_match(function, "Expecting a square matrix; rows of ", name,
                    y.rows(), "columns of ", name, y.cols());
 }

--- a/stan/math/prim/fun/accumulator.hpp
+++ b/stan/math/prim/fun/accumulator.hpp
@@ -73,15 +73,14 @@ class accumulator {
    * Add each entry in the specified matrix, vector, or row vector
    * of values to the buffer.
    *
-   * @tparam S type of values in matrix
-   * @tparam R number of rows, can be Eigen::Dynamic
-   * @tparam C number of columns, can be Eigen::Dynamic
+   * @tparam S type of the matrix
    * @param m Matrix of values to add
    */
-  template <typename S, int R, int C>
-  void add(const Eigen::Matrix<S, R, C>& m) {
+  template <typename S, require_eigen_t<S>* = nullptr>
+  void add(const S& m) {
+    const auto& m_eval = m.eval();
     for (int i = 0; i < m.size(); ++i) {
-      this->add(m(i));
+      this->add(m_eval.coeff(i));
     }
   }
 

--- a/stan/math/prim/fun/add_diag.hpp
+++ b/stan/math/prim/fun/add_diag.hpp
@@ -13,49 +13,28 @@ namespace math {
  * Returns a Matrix with values added along the main diagonal
  *
  * @tparam T_m type of element in Eigen::Matrix
- * @tparam T_a Type of element to add along the diagonal
+ * @tparam T_a Type of element(s) to add along the diagonal
  *
  * @param mat a matrix
- * @param to_add value to add along the diagonal
+ * @param to_add scalar value or column vector or row vector to add along the
+ * diagonal
  * @return a matrix with to_add added along main diagonal
  */
-template <typename T_m, typename T_a>
+template <typename T_m, typename T_a, typename = require_eigen_t<T_m>,
+          typename
+          = require_t<disjunction<is_eigen_vector<T_a>, is_stan_scalar<T_a>>>>
 inline typename Eigen::Matrix<return_type_t<T_m, T_a>, Eigen::Dynamic,
                               Eigen::Dynamic>
-add_diag(const Eigen::Matrix<T_m, Eigen::Dynamic, Eigen::Dynamic> &mat,
-         const T_a &to_add) {
+add_diag(const T_m &mat, const T_a &to_add) {
+  if (is_vector<T_a>::value) {
+    const size_t length_diag = std::min(mat.rows(), mat.cols());
+    check_consistent_size("add_diag", "number of elements of to_add", to_add,
+                          length_diag);
+  }
   Eigen::Matrix<return_type_t<T_m, T_a>, Eigen::Dynamic, Eigen::Dynamic> out
       = mat;
-  out.diagonal().array() += to_add;
-  return out;
-}
-
-/**
- * Returns a Matrix with values added along the main diagonal
- *
- * @tparam T_m type of element in Eigen::Matrix
- * @tparam T_a Type of element to add along the diagonal
- * @tparam R number of rows, can be Eigen::Dynamic
- * @tparam C number of columns, can be Eigen::Dynamic
- *
- * @param mat a matrix
- * @param to_add Sequence of values to add along the diagonal
- * @return a matrix with to_add added along main diagonal
- * @throw invalid_argument if to_add is vector-like but does not have
- * the same number of elements as the main diagonal of mat
- */
-template <typename T_m, typename T_a, int R, int C>
-inline typename Eigen::Matrix<return_type_t<T_m, T_a>, Eigen::Dynamic,
-                              Eigen::Dynamic>
-add_diag(const Eigen::Matrix<T_m, Eigen::Dynamic, Eigen::Dynamic> &mat,
-         const Eigen::Matrix<T_a, R, C> &to_add) {
-  const size_t length_diag = std::min(mat.rows(), mat.cols());
-  check_consistent_size("add_diag", "number of elements of to_add", to_add,
-                        length_diag);
-
-  Eigen::Matrix<return_type_t<T_m, T_a>, Eigen::Dynamic, Eigen::Dynamic> out
-      = mat;
-  out.diagonal() += to_add;
+  out.diagonal().array()
+      += as_array_or_scalar(as_column_vector_or_scalar(to_add));
   return out;
 }
 

--- a/stan/math/prim/fun/add_diag.hpp
+++ b/stan/math/prim/fun/add_diag.hpp
@@ -21,8 +21,7 @@ namespace math {
  * @return a matrix with to_add added along main diagonal
  */
 template <typename T_m, typename T_a, typename = require_eigen_t<T_m>,
-          typename
-          = require_any_t<is_eigen_vector<T_a>, is_stan_scalar<T_a>>>
+          typename = require_any_t<is_eigen_vector<T_a>, is_stan_scalar<T_a>>>
 inline typename Eigen::Matrix<return_type_t<T_m, T_a>, Eigen::Dynamic,
                               Eigen::Dynamic>
 add_diag(const T_m &mat, const T_a &to_add) {

--- a/stan/math/prim/fun/add_diag.hpp
+++ b/stan/math/prim/fun/add_diag.hpp
@@ -22,7 +22,7 @@ namespace math {
  */
 template <typename T_m, typename T_a, typename = require_eigen_t<T_m>,
           typename
-          = require_t<disjunction<is_eigen_vector<T_a>, is_stan_scalar<T_a>>>>
+          = require_any_t<is_eigen_vector<T_a>, is_stan_scalar<T_a>>>
 inline typename Eigen::Matrix<return_type_t<T_m, T_a>, Eigen::Dynamic,
                               Eigen::Dynamic>
 add_diag(const T_m &mat, const T_a &to_add) {

--- a/stan/math/prim/fun/append_col.hpp
+++ b/stan/math/prim/fun/append_col.hpp
@@ -14,31 +14,30 @@ namespace math {
  * first argument matrix, that is, putting them side by side, with
  * the first matrix followed by the second matrix.
  *
- * The inputs can be
- * (matrix, matrix),
- * (matrix, vector),
- * (vector, matrix), or
- * (vector, vector)
- * and the output is always a matrix.
+ * Given input types result in following outputs:
+ * (matrix, matrix) -> matrix,
+ * (matrix, vector) -> matrix,
+ * (vector, matrix) -> matrix,
+ * (vector, vector) -> matrix,
+ * (row vector, row vector) -> row_vector.
  *
- * @tparam T1 type of elements in the first matrix
- * @tparam T2 type of elements in the second matrix
- * @tparam R1 number of rows in the first matrix, can be Eigen::Dynamic
- * @tparam C1 number of columns in the first matrix, can be Eigen::Dynamic
- * @tparam R2 number of rows in the second matrix, can be Eigen::Dynamic
- * @tparam C2 number of columns in the second matrix, can be Eigen::Dynamic
+ * @tparam T1 type of the first matrix
+ * @tparam T2 type of the second matrix
  *
  * @param A First matrix.
  * @param B Second matrix.
  * @return Result of appending the first matrix followed by the
  * second matrix side by side.
  */
-template <typename T1, typename T2, int R1, int C1, int R2, int C2>
-inline Eigen::Matrix<return_type_t<T1, T2>, Eigen::Dynamic, Eigen::Dynamic>
-append_col(const Eigen::Matrix<T1, R1, C1>& A,
-           const Eigen::Matrix<T2, R2, C2>& B) {
+template <typename T1, typename T2, typename = require_all_eigen_t<T1, T2>>
+inline auto append_col(const T1& A, const T2& B) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
+  using T_return = return_type_t<T1, T2>;
+  constexpr int row_type
+      = (T1::RowsAtCompileTime == 1 && T2::RowsAtCompileTime == 1)
+            ? 1
+            : Eigen::Dynamic;
 
   int Arows = A.rows();
   int Brows = B.rows();
@@ -46,120 +45,9 @@ append_col(const Eigen::Matrix<T1, R1, C1>& A,
   int Bcols = B.cols();
   check_size_match("append_col", "rows of A", Arows, "rows of B", Brows);
 
-  Matrix<return_type_t<T1, T2>, Dynamic, Dynamic> result(Arows, Acols + Bcols);
-  for (int j = 0; j < Acols; j++) {
-    for (int i = 0; i < Arows; i++) {
-      result(i, j) = A(i, j);
-    }
-  }
-
-  for (int j = Acols, k = 0; k < Bcols; j++, k++) {
-    for (int i = 0; i < Arows; i++) {
-      result(i, j) = B(i, k);
-    }
-  }
-  return result;
-}
-
-/**
- * Return the result of concatenating the first row vector followed
- * by the second row vector side by side, with the result being a
- * row vector.
- *
- * This function applies to (row_vector, row_vector) and returns a
- * row_vector.
- *
- * @tparam T1 type of elements in the first row vector
- * @tparam T2 type of elements in the second row vector
- * @tparam C1 number of columns in the first row vector, can be Eigen::Dynamic
- * @tparam C2 number of columns in the second row vector, can be Eigen::Dynamic
- *
- * @param A First vector.
- * @param B Second vector
- * @return Result of appending the second row vector to the right
- * of the first row vector.
- */
-template <typename T1, typename T2, int C1, int C2>
-inline Eigen::Matrix<return_type_t<T1, T2>, 1, Eigen::Dynamic> append_col(
-    const Eigen::Matrix<T1, 1, C1>& A, const Eigen::Matrix<T2, 1, C2>& B) {
-  using Eigen::Dynamic;
-  using Eigen::Matrix;
-
-  int Asize = A.size();
-  int Bsize = B.size();
-  Matrix<return_type_t<T1, T2>, 1, Dynamic> result(Asize + Bsize);
-  for (int i = 0; i < Asize; i++) {
-    result(i) = A(i);
-  }
-  for (int i = 0, j = Asize; i < Bsize; i++, j++) {
-    result(j) = B(i);
-  }
-  return result;
-}
-
-/**
- * Return the result of appending the second argument matrix after the
- * first argument matrix, that is, putting them side by side, with
- * the first matrix followed by the second matrix.   This is an
- * overloaded template function for the case when both matrices
- * have the same type.
- *
- * The inputs can be
- * (matrix, matrix),
- * (matrix, vector),
- * (vector, matrix), or
- * (vector, vector),
- * and the output is always a matrix.
- *
- * @tparam T type of elements in both matrices
- * @tparam R1 number of rows in the first matrix, can be Eigen::Dynamic
- * @tparam C1 number of columns in the first matrix, can be Eigen::Dynamic
- * @tparam R2 number of rows in the second matrix, can be Eigen::Dynamic
- * @tparam C2 number of columns in the second matrix, can be Eigen::Dynamic
- *
- * @param A First matrix.
- * @param B Second matrix.
- * @return Result of appending the first matrix followed by the
- * second matrix side by side.
- */
-template <typename T, int R1, int C1, int R2, int C2>
-inline Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> append_col(
-    const Eigen::Matrix<T, R1, C1>& A, const Eigen::Matrix<T, R2, C2>& B) {
-  using Eigen::Dynamic;
-  using Eigen::Matrix;
-
-  check_size_match("append_col", "rows of A", A.rows(), "rows of B", B.rows());
-
-  Matrix<T, Dynamic, Dynamic> result(A.rows(), A.cols() + B.cols());
-  result << A, B;
-  return result;
-}
-
-/**
- * Return the result of concatenating the first row vector followed
- * by the second row vector side by side, with the result being a
- * row vector.
- *
- * This function applies to (row_vector, row_vector) and returns a
- * row_vector.
- *
- * @tparam T type of elements in both vectors
- * @tparam C1 number of columns in the first row vector, can be Eigen::Dynamic
- * @tparam C2 number of columns in the second row vector, can be Eigen::Dynamic
- *
- * @param A First vector.
- * @param B Second vector
- * @return Result of appending the second row vector to the right
- * of the first row vector.
- */
-template <typename T, int C1, int C2>
-inline Eigen::Matrix<T, 1, Eigen::Dynamic> append_col(
-    const Eigen::Matrix<T, 1, C1>& A, const Eigen::Matrix<T, 1, C2>& B) {
-  using Eigen::Dynamic;
-  using Eigen::Matrix;
-
-  Matrix<T, 1, Dynamic> result(A.size() + B.size());
-  result << A, B;
+  Matrix<T_return, row_type, Dynamic> result(Arows, Acols + Bcols);
+  result.leftCols(Acols) = A.template cast<T_return>();
+  result.rightCols(Bcols) = B.template cast<T_return>();
   return result;
 }
 
@@ -170,21 +58,20 @@ inline Eigen::Matrix<T, 1, Eigen::Dynamic> append_col(
  * This function applies to (scalar, row vector) and returns a
  * row vector.
  *
- * @tparam T1 type of the scalar
- * @tparam T2 type of elements in the row vector
- * @tparam R number of rows, can be Eigen::Dynamic
- * @tparam C number of columns, can be Eigen::Dynamic
+ * @tparam Scal type of the scalar
+ * @tparam RowVec type of the row vector
  *
  * @param A scalar.
  * @param B row vector.
  * @return Result of stacking the scalar on top of the row vector.
  */
-template <typename T1, typename T2, int R, int C>
-inline Eigen::Matrix<return_type_t<T1, T2>, 1, Eigen::Dynamic> append_col(
-    const T1& A, const Eigen::Matrix<T2, R, C>& B) {
+template <typename Scal, typename RowVec, require_stan_scalar_t<Scal>* = nullptr,
+          require_t<is_eigen_row_vector<RowVec>>* = nullptr>
+inline Eigen::Matrix<return_type_t<Scal, RowVec>, 1, Eigen::Dynamic> append_col(
+    const Scal& A, const RowVec& B) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
-  using return_type = return_type_t<T1, T2>;
+  using return_type = return_type_t<Scal, RowVec>;
 
   Matrix<return_type, 1, Dynamic> result(B.size() + 1);
   result << A, B.template cast<return_type>();
@@ -198,21 +85,21 @@ inline Eigen::Matrix<return_type_t<T1, T2>, 1, Eigen::Dynamic> append_col(
  * This function applies to (row vector, scalar) and returns a
  * row vector.
  *
- * @tparam T1 type of elements in the row vector
- * @tparam T2 type of the scalar
- * @tparam R number of rows, can be Eigen::Dynamic
- * @tparam C number of columns, can be Eigen::Dynamic
+ * @tparam RowVec type of the row vector
+ * @tparam Scal type of the scalar
  *
  * @param A row vector.
  * @param B scalar.
  * @return Result of stacking the row vector on top of the scalar.
  */
-template <typename T1, typename T2, int R, int C>
-inline Eigen::Matrix<return_type_t<T1, T2>, 1, Eigen::Dynamic> append_col(
-    const Eigen::Matrix<T1, R, C>& A, const T2& B) {
+template <typename RowVec, typename Scal,
+          require_t<is_eigen_row_vector<RowVec>>* = nullptr,
+          require_stan_scalar_t<Scal>* = nullptr>
+inline Eigen::Matrix<return_type_t<RowVec, Scal>, 1, Eigen::Dynamic> append_col(
+    const RowVec& A, const Scal& B) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
-  using return_type = return_type_t<T1, T2>;
+  using return_type = return_type_t<RowVec, Scal>;
 
   Matrix<return_type, 1, Dynamic> result(A.size() + 1);
   result << A.template cast<return_type>(), B;

--- a/stan/math/prim/fun/append_col.hpp
+++ b/stan/math/prim/fun/append_col.hpp
@@ -72,10 +72,10 @@ inline Eigen::Matrix<return_type_t<Scal, RowVec>, 1, Eigen::Dynamic> append_col(
     const Scal& A, const RowVec& B) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
-  using return_type = return_type_t<Scal, RowVec>;
+  using T_return = return_type_t<Scal, RowVec>;
 
-  Matrix<return_type, 1, Dynamic> result(B.size() + 1);
-  result << A, B.template cast<return_type>();
+  Matrix<T_return, 1, Dynamic> result(B.size() + 1);
+  result << A, B.template cast<T_return>();
   return result;
 }
 
@@ -100,10 +100,10 @@ inline Eigen::Matrix<return_type_t<RowVec, Scal>, 1, Eigen::Dynamic> append_col(
     const RowVec& A, const Scal& B) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
-  using return_type = return_type_t<RowVec, Scal>;
+  using T_return = return_type_t<RowVec, Scal>;
 
-  Matrix<return_type, 1, Dynamic> result(A.size() + 1);
-  result << A.template cast<return_type>(), B;
+  Matrix<T_return, 1, Dynamic> result(A.size() + 1);
+  result << A.template cast<T_return>(), B;
   return result;
 }
 

--- a/stan/math/prim/fun/append_col.hpp
+++ b/stan/math/prim/fun/append_col.hpp
@@ -65,7 +65,8 @@ inline auto append_col(const T1& A, const T2& B) {
  * @param B row vector.
  * @return Result of stacking the scalar on top of the row vector.
  */
-template <typename Scal, typename RowVec, require_stan_scalar_t<Scal>* = nullptr,
+template <typename Scal, typename RowVec,
+          require_stan_scalar_t<Scal>* = nullptr,
           require_t<is_eigen_row_vector<RowVec>>* = nullptr>
 inline Eigen::Matrix<return_type_t<Scal, RowVec>, 1, Eigen::Dynamic> append_col(
     const Scal& A, const RowVec& B) {

--- a/stan/math/prim/fun/append_row.hpp
+++ b/stan/math/prim/fun/append_row.hpp
@@ -62,7 +62,8 @@ inline auto append_row(const T1& A, const T2& B) {
  * @param B vector.
  * @return Result of stacking the scalar on top of the vector.
  */
-template <typename Scal, typename ColVec, require_stan_scalar_t<Scal>* = nullptr,
+template <typename Scal, typename ColVec,
+          require_stan_scalar_t<Scal>* = nullptr,
           require_t<is_eigen_col_vector<ColVec>>* = nullptr>
 inline Eigen::Matrix<return_type_t<Scal, ColVec>, Eigen::Dynamic, 1> append_row(
     const Scal& A, const ColVec& B) {

--- a/stan/math/prim/fun/append_row.hpp
+++ b/stan/math/prim/fun/append_row.hpp
@@ -69,10 +69,10 @@ inline Eigen::Matrix<return_type_t<Scal, ColVec>, Eigen::Dynamic, 1> append_row(
     const Scal& A, const ColVec& B) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
-  using return_type = return_type_t<Scal, ColVec>;
+  using T_return = return_type_t<Scal, ColVec>;
 
-  Matrix<return_type, Dynamic, 1> result(B.size() + 1);
-  result << A, B.template cast<return_type>();
+  Matrix<T_return, Dynamic, 1> result(B.size() + 1);
+  result << A, B.template cast<T_return>();
   return result;
 }
 
@@ -96,10 +96,10 @@ inline Eigen::Matrix<return_type_t<ColVec, Scal>, Eigen::Dynamic, 1> append_row(
     const ColVec& A, const Scal& B) {
   using Eigen::Dynamic;
   using Eigen::Matrix;
-  using return_type = return_type_t<ColVec, Scal>;
+  using T_return = return_type_t<ColVec, Scal>;
 
-  Matrix<return_type, Dynamic, 1> result(A.size() + 1);
-  result << A.template cast<return_type>(), B;
+  Matrix<T_return, Dynamic, 1> result(A.size() + 1);
+  result << A.template cast<T_return>(), B;
   return result;
 }
 

--- a/stan/math/prim/fun/assign.hpp
+++ b/stan/math/prim/fun/assign.hpp
@@ -41,7 +41,8 @@ inline void print_mat_size(std::ostream& o) {
  * @param x Left-hand side.
  * @param y Right-hand side.
  */
-template <typename T_lhs, typename T_rhs, require_all_stan_scalar_t<T_lhs, T_rhs>* = nullptr>
+template <typename T_lhs, typename T_rhs,
+          require_all_stan_scalar_t<T_lhs, T_rhs>* = nullptr>
 inline void assign(T_lhs& x, const T_rhs& y) {
   x = y;
 }
@@ -61,7 +62,8 @@ inline void assign(T_lhs& x, const T_rhs& y) {
  * @param y Right-hand side matrix.
  * @throw std::invalid_argument if sizes do not match.
  */
-template <typename T_lhs, typename T_rhs, require_all_eigen_t<T_lhs, T_rhs>* = nullptr>
+template <typename T_lhs, typename T_rhs,
+          require_all_eigen_t<T_lhs, T_rhs>* = nullptr>
 inline void assign(T_lhs&& x, const T_rhs& y) {
   check_matching_dims("assign", "left-hand-side", x, "right-hand-side", y);
   x = y.template cast<value_type_t<T_lhs>>();

--- a/stan/math/prim/fun/assign.hpp
+++ b/stan/math/prim/fun/assign.hpp
@@ -41,7 +41,7 @@ inline void print_mat_size(std::ostream& o) {
  * @param x Left-hand side.
  * @param y Right-hand side.
  */
-template <typename T_lhs, typename T_rhs>
+template <typename T_lhs, typename T_rhs, require_all_stan_scalar_t<T_lhs, T_rhs>* = nullptr>
 inline void assign(T_lhs& x, const T_rhs& y) {
   x = y;
 }
@@ -52,101 +52,19 @@ inline void assign(T_lhs& x, const T_rhs& y) {
  *
  * The <code>assign()</code> function is overloaded.  This
  * instance will be called for arguments that are both
- * <code>Eigen::Matrix</code> types, but whose shapes  are not
- * compatible.  The shapes are specified in the row and column
- * template parameters.
+ * <code>Eigen::Matrix</code> types.
  *
- * @tparam T_lhs type of elements in the left-hand side matrix
- * @tparam T_rhs type of elements in the right-hand side matrix
- * @tparam R1 number of rows in the left-hand side matrix or Eigen::Dynamic
- * @tparam C1 number of columns in the left-hand side matrix or Eigen::Dynamic
- * @tparam R2 number of rows in the right-hand side matrix or Eigen::Dynamic
- * @tparam C2 number of columns in the right-hand side matrix or Eigen::Dynamic
- *
- * @param x Left-hand side matrix.
- * @param y Right-hand side matrix.
- * @throw std::invalid_argument
- */
-template <typename T_lhs, typename T_rhs, int R1, int C1, int R2, int C2>
-inline void assign(Eigen::Matrix<T_lhs, R1, C1>& x,
-                   const Eigen::Matrix<T_rhs, R2, C2>& y) {
-  std::stringstream ss;
-  ss << "shapes must match, but found"
-     << " left-hand side rows=";
-  print_mat_size<R1>(ss);
-  ss << "; left-hand side cols=";
-  print_mat_size<C1>(ss);
-  ss << "; right-hand side rows=";
-  print_mat_size<R2>(ss);
-  ss << "; right-hand side cols=";
-  print_mat_size<C2>(ss);
-  std::string ss_str(ss.str());
-  invalid_argument("assign(Eigen::Matrix, Eigen::Matrix)", "", "",
-                   ss_str.c_str());
-}
-
-/**
- * Copy the right-hand side's value to the left-hand side
- * variable.
- *
- * The <code>assign()</code> function is overloaded.  This
- * instance will be called for arguments that are both
- * <code>Eigen::Matrix</code> types and whose shapes match.  The
- * shapes are specified in the row and column template parameters.
- *
- * @tparam T_lhs type of elements in the left-hand side matrix
- * @tparam T_rhs type of elements in the right-hand side matrix
- * @tparam R number of rows, can be Eigen::Dynamic
- * @tparam C number of columns, can be Eigen::Dynamic
+ * @tparam T_lhs type of the left-hand side matrix
+ * @tparam T_rhs type of the right-hand side matrix
  *
  * @param x Left-hand side matrix.
  * @param y Right-hand side matrix.
  * @throw std::invalid_argument if sizes do not match.
  */
-template <typename T_lhs, typename T_rhs, int R, int C>
-inline void assign(Eigen::Matrix<T_lhs, R, C>& x,
-                   const Eigen::Matrix<T_rhs, R, C>& y) {
+template <typename T_lhs, typename T_rhs, require_all_eigen_t<T_lhs, T_rhs>* = nullptr>
+inline void assign(T_lhs&& x, const T_rhs& y) {
   check_matching_dims("assign", "left-hand-side", x, "right-hand-side", y);
-  for (int i = 0; i < x.size(); ++i) {
-    assign(x(i), y(i));
-  }
-}
-
-/**
- * Copy the right-hand side's value to the left-hand side
- * variable.
- *
- * <p>The <code>assign()</code> function is overloaded.  This
- * instance will be called for arguments that are both
- * <code>Eigen::Matrix</code> types and whose shapes match.  The
- * shape of the right-hand side matrix is specified in the row and
- * column shape template parameters.
- *
- * <p>The left-hand side is intentionally not a reference, because
- * that won't match generally enough;  instead, a non-reference is
- * used, which still holds onto a reference to the contained
- * matrix and thus still updates the appropriate values.
- *
- * @tparam T_lhs type of matrix block elements
- * @tparam T type of elements in the right-hand side matrix
- * @tparam R number of rows, can be Eigen::Dynamic
- * @tparam C number of columns, can be Eigen::Dynamic
- *
- * @param x Left-hand side block view of matrix.
- * @param y Right-hand side matrix.
- * @throw std::invalid_argument if sizes do not match.
- */
-template <typename T_lhs, typename T, int R, int C>
-inline void assign(Eigen::Block<T_lhs> x, const Eigen::Matrix<T, R, C>& y) {
-  check_size_match("assign", "left-hand side rows", x.rows(),
-                   "right-hand side rows", y.rows());
-  check_size_match("assign", "left-hand side cols", x.cols(),
-                   "right-hand side cols", y.cols());
-  for (int n = 0; n < y.cols(); ++n) {
-    for (int m = 0; m < y.rows(); ++m) {
-      assign(x(m, n), y(m, n));
-    }
-  }
+  x = y.template cast<value_type_t<T_lhs>>();
 }
 
 /**

--- a/stan/math/prim/fun/chol2inv.hpp
+++ b/stan/math/prim/fun/chol2inv.hpp
@@ -20,22 +20,22 @@ namespace math {
  * @throw std::domain_error If the input matrix is not square or
  *  lower triangular
  */
-template <typename T>
-Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> chol2inv(
-    const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& L) {
-  check_square("chol2inv", "L", L);
-  check_lower_triangular("chol2inv", "L", L);
+template <typename T, require_eigen_t<T>* = nullptr>
+plain_type_t<T> chol2inv(const T& L) {
+  const Eigen::Ref<const plain_type_t<T>>& L_ref = L;
+  check_square("chol2inv", "L", L_ref);
+  check_lower_triangular("chol2inv", "L", L_ref);
   int K = L.rows();
-  using matrix_t = Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>;
+  using matrix_t = plain_type_t<T>;
   if (K == 0) {
-    return L;
+    return L_ref;
   }
   if (K == 1) {
     matrix_t X(1, 1);
-    X.coeffRef(0) = inv_square(L.coeff(0));
+    X.coeffRef(0) = inv_square(L_ref.coeff(0, 0));
     return X;
   }
-  matrix_t L_inv = mdivide_left_tri_low(L, matrix_t::Identity(K, K).eval());
+  matrix_t L_inv = mdivide_left_tri_low(L_ref, matrix_t::Identity(K, K).eval());
   matrix_t X(K, K);
   for (int k = 0; k < K; ++k) {
     X.coeffRef(k, k) = dot_self(L_inv.col(k).tail(K - k).eval());

--- a/stan/math/prim/fun/chol2inv.hpp
+++ b/stan/math/prim/fun/chol2inv.hpp
@@ -26,17 +26,17 @@ plain_type_t<T> chol2inv(const T& L) {
   check_square("chol2inv", "L", L_ref);
   check_lower_triangular("chol2inv", "L", L_ref);
   int K = L.rows();
-  using matrix_t = plain_type_t<T>;
+  using T_result = plain_type_t<T>;
   if (K == 0) {
     return L_ref;
   }
   if (K == 1) {
-    matrix_t X(1, 1);
+    T_result X(1, 1);
     X.coeffRef(0) = inv_square(L_ref.coeff(0, 0));
     return X;
   }
-  matrix_t L_inv = mdivide_left_tri_low(L_ref, matrix_t::Identity(K, K).eval());
-  matrix_t X(K, K);
+  T_result L_inv = mdivide_left_tri_low(L_ref, T_result::Identity(K, K));
+  T_result X(K, K);
   for (int k = 0; k < K; ++k) {
     X.coeffRef(k, k) = dot_self(L_inv.col(k).tail(K - k).eval());
     for (int j = k + 1; j < K; ++j) {

--- a/stan/math/prim/fun/mdivide_left.hpp
+++ b/stan/math/prim/fun/mdivide_left.hpp
@@ -20,7 +20,8 @@ namespace math {
  * @throws std::domain_error if A is not square or the rows of b don't
  * match the size of A.
  */
-template <typename T1, typename T2, require_all_eigen_vt<std::is_arithmetic, T1, T2>* = nullptr>
+template <typename T1, typename T2,
+          require_all_eigen_vt<std::is_arithmetic, T1, T2>* = nullptr>
 inline Eigen::Matrix<return_type_t<T1, T2>, T1::RowsAtCompileTime,
                      T2::ColsAtCompileTime>
 mdivide_left(const T1& A, const T2& b) {

--- a/stan/math/prim/fun/mdivide_left.hpp
+++ b/stan/math/prim/fun/mdivide_left.hpp
@@ -11,14 +11,8 @@ namespace math {
 /**
  * Returns the solution of the system Ax=b.
  *
- * @tparam T1 type of elements in first matrix
- * @tparam T2 type of elements in right-hand side matrix or vector
- * @tparam R1 number of rows in the first matrix, can be Eigen::Dynamic
- * @tparam C1 number of columns in the first matrix, can be Eigen::Dynamic
- * @tparam R2 number of rows in the right-hand side matrix, can be
- *         Eigen::Dynamic
- * @tparam C2 number of columns in the right-hand side matrix, can be
- *         Eigen::Dynamic
+ * @tparam T1 type of the first matrix
+ * @tparam T2 type of the right-hand side matrix or vector
  *
  * @param A Matrix.
  * @param b Right hand side matrix or vector.
@@ -26,14 +20,18 @@ namespace math {
  * @throws std::domain_error if A is not square or the rows of b don't
  * match the size of A.
  */
-template <typename T1, typename T2, int R1, int C1, int R2, int C2>
-inline Eigen::Matrix<return_type_t<T1, T2>, R1, C2> mdivide_left(
-    const Eigen::Matrix<T1, R1, C1> &A, const Eigen::Matrix<T2, R2, C2> &b) {
+template <typename T1, typename T2, require_all_eigen_vt<std::is_arithmetic, T1, T2>* = nullptr>
+inline Eigen::Matrix<return_type_t<T1, T2>, T1::RowsAtCompileTime,
+                     T2::ColsAtCompileTime>
+mdivide_left(const T1& A, const T2& b) {
   check_square("mdivide_left", "A", A);
   check_multiplicable("mdivide_left", "A", A, "b", b);
 
-  return Eigen::Matrix<return_type_t<T1, T2>, R1, C1>(A).lu().solve(
-      Eigen::Matrix<return_type_t<T1, T2>, R2, C2>(b));
+  return Eigen::Matrix<return_type_t<T1, T2>, T1::RowsAtCompileTime,
+                       T1::ColsAtCompileTime>(A)
+      .lu()
+      .solve(Eigen::Matrix<return_type_t<T1, T2>, T2::RowsAtCompileTime,
+                           T2::ColsAtCompileTime>(b));
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/mdivide_left_tri.hpp
+++ b/stan/math/prim/fun/mdivide_left_tri.hpp
@@ -28,7 +28,7 @@ namespace math {
 template <Eigen::UpLoType TriView, typename T1, typename T2,
           require_all_eigen_t<T1, T2> * = nullptr,
           require_any_not_same_vt<double, T1, T2> * = nullptr,
-          require_all_not_eigen_vt<is_var, T1, T2>* = nullptr>
+          require_all_not_eigen_vt<is_var, T1, T2> * = nullptr>
 inline Eigen::Matrix<return_type_t<T1, T2>, T1::RowsAtCompileTime,
                      T2::ColsAtCompileTime>
 mdivide_left_tri(const T1 &A, const T2 &b) {

--- a/stan/math/prim/fun/mdivide_left_tri.hpp
+++ b/stan/math/prim/fun/mdivide_left_tri.hpp
@@ -16,14 +16,8 @@ namespace math {
  *
  * @tparam TriView Specifies whether A is upper (Eigen::Upper)
  * or lower triangular (Eigen::Lower).
- * @tparam T1 type of elements in the triangular matrix
- * @tparam T2 type of elements in the right-hand side matrix or vector
- * @tparam R1 number of rows in the triangular matrix, can be Eigen::Dynamic
- * @tparam C1 number of columns in the triangular matrix, can be Eigen::Dynamic
- * @tparam R2 number of rows in the right-hand side matrix, can be
- *         Eigen::Dynamic
- * @tparam C2 number of columns in the right-hand side matrix, can be
- *         Eigen::Dynamic
+ * @tparam T1 type of the triangular matrix
+ * @tparam T2 type of the right-hand side matrix or vector
  *
  * @param A Triangular matrix.
  * @param b Right hand side matrix or vector.
@@ -31,35 +25,38 @@ namespace math {
  * @throws std::domain_error if A is not square or the rows of b don't
  * match the size of A.
  */
-template <int TriView, typename T1, typename T2, int R1, int C1, int R2, int C2>
-inline Eigen::Matrix<return_type_t<T1, T2>, R1, C2> mdivide_left_tri(
-    const Eigen::Matrix<T1, R1, C1> &A, const Eigen::Matrix<T2, R2, C2> &b) {
+template <Eigen::UpLoType TriView, typename T1, typename T2,
+          require_all_eigen_t<T1, T2> * = nullptr,
+          require_any_not_same_vt<double, T1, T2> * = nullptr,
+          require_all_not_eigen_vt<is_var, T1, T2>* = nullptr>
+inline Eigen::Matrix<return_type_t<T1, T2>, T1::RowsAtCompileTime,
+                     T2::ColsAtCompileTime>
+mdivide_left_tri(const T1 &A, const T2 &b) {
+  using T_return = return_type_t<T1, T2>;
   check_square("mdivide_left_tri", "A", A);
   check_multiplicable("mdivide_left_tri", "A", A, "b", b);
 
-  return Eigen::Matrix<return_type_t<T1, T2>, R1, C1>(A)
+  return A.template cast<T_return>()
+      .eval()
       .template triangularView<TriView>()
-      .solve(Eigen::Matrix<return_type_t<T1, T2>, R2, C2>(b));
+      .solve(b.template cast<T_return>().eval());
 }
 
 /**
  * Returns the solution of the system Ax=b when A is triangular and b=I.
  *
- * @tparam T type of elements in the matrix
- * @tparam R1 number of rows, can be Eigen::Dynamic
- * @tparam C1 number of columns, can be Eigen::Dynamic
+ * @tparam T type of the matrix
  *
  * @param A Triangular matrix.
  * @return x = A^-1 .
  * @throws std::domain_error if A is not square
  */
-template <int TriView, typename T, int R1, int C1>
-inline Eigen::Matrix<T, R1, C1> mdivide_left_tri(
-    const Eigen::Matrix<T, R1, C1> &A) {
+template <Eigen::UpLoType TriView, typename T, require_eigen_t<T> * = nullptr,
+          require_not_same_vt<double, T> * = nullptr>
+inline plain_type_t<T> mdivide_left_tri(const T &A) {
   check_square("mdivide_left_tri", "A", A);
   int n = A.rows();
-  Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> b;
-  b.setIdentity(n, n);
+  plain_type_t<T> b = plain_type_t<T>::Identity(n, n);
   A.template triangularView<TriView>().solveInPlace(b);
   return b;
 }
@@ -70,12 +67,8 @@ inline Eigen::Matrix<T, R1, C1> mdivide_left_tri(
  *
  * @tparam TriView Specifies whether A is upper (Eigen::Upper)
  * or lower triangular (Eigen::Lower).
- * @tparam T1 type of elements in the triangular matrix
- * @tparam T2 type of elements in the right-hand side matrix or vector
- * @tparam R1 number of rows in the triangular matrix, can be Eigen::Dynamic
- * @tparam C1 number of columns in the triangular matrix, can be Eigen::Dynamic
- * @tparam R2 number of rows in the right-hand side matrix, can be
- *         Eigen::Dynamic
+ * @tparam T1 type of the triangular matrix
+ * @tparam T2 type of the right-hand side matrix or vector
  *
  * @param A Triangular matrix.
  * @param b Right hand side matrix or vector.
@@ -83,10 +76,11 @@ inline Eigen::Matrix<T, R1, C1> mdivide_left_tri(
  * @throws std::domain_error if A is not square or the rows of b don't
  * match the size of A.
  */
-template <Eigen::UpLoType TriView, int R1, int C1, int R2, int C2>
-inline Eigen::Matrix<double, R1, C2> mdivide_left_tri(
-    const Eigen::Matrix<double, R1, C1> &A,
-    const Eigen::Matrix<double, R2, C2> &b) {
+template <Eigen::UpLoType TriView, typename T1, typename T2,
+          require_all_eigen_t<T1, T2> * = nullptr,
+          require_all_same_vt<double, T1, T2> * = nullptr>
+inline Eigen::Matrix<double, T1::RowsAtCompileTime, T2::ColsAtCompileTime>
+mdivide_left_tri(const T1 &A, const T2 &b) {
   check_square("mdivide_left_tri", "A", A);
   check_multiplicable("mdivide_left_tri", "A", A, "b", b);
 #ifdef STAN_OPENCL
@@ -111,16 +105,15 @@ inline Eigen::Matrix<double, R1, C2> mdivide_left_tri(
  *
  * @tparam TriView Specifies whether A is upper (Eigen::Upper)
  * or lower triangular (Eigen::Lower).
- * @tparam R1 number of rows, can be Eigen::Dynamic
- * @tparam C1 number of columns, can be Eigen::Dynamic
+ * @tparam T type of the matrix
  *
  * @param A Triangular matrix.
  * @return x = A^-1 .
  * @throws std::domain_error if A is not square
  */
-template <Eigen::UpLoType TriView, int R1, int C1>
-inline Eigen::Matrix<double, R1, C1> mdivide_left_tri(
-    const Eigen::Matrix<double, R1, C1> &A) {
+template <Eigen::UpLoType TriView, typename T, require_eigen_t<T> * = nullptr,
+          require_same_vt<double, T> * = nullptr>
+inline plain_type_t<T> mdivide_left_tri(const T &A) {
   check_square("mdivide_left_tri", "A", A);
   const int n = A.rows();
 #ifdef STAN_OPENCL
@@ -131,8 +124,7 @@ inline Eigen::Matrix<double, R1, C1> mdivide_left_tri(
     return from_matrix_cl(A_cl);
   } else {
 #endif
-    Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> b;
-    b.setIdentity(n, n);
+    plain_type_t<T> b = plain_type_t<T>::Identity(n, n);
     A.template triangularView<TriView>().solveInPlace(b);
     return b;
 #ifdef STAN_OPENCL

--- a/stan/math/prim/fun/mdivide_left_tri_low.hpp
+++ b/stan/math/prim/fun/mdivide_left_tri_low.hpp
@@ -15,12 +15,8 @@ namespace math {
  * <code>b</code> is more arithmetically stable than calling
  * <code>inv(A) * b</code>.
  *
- * @tparam T1 type of elements in the divisor matrix
- * @tparam T2 type of elements in the dividend matrix
- * @tparam R1 number rows in the divisor matrix, can be Eigen::Dynamic
- * @tparam C1 number columns in the divisor matrix, can be Eigen::Dynamic
- * @tparam R2 number rows in the dividend matrix, can be Eigen::Dynamic
- * @tparam C2 number columns in the dividend matrix, can be Eigen::Dynamic
+ * @tparam T1 type of the divisor matrix
+ * @tparam T2 type of the dividend matrix
  *
  * @param A divisor, an invertible square matrix
  * @param b dividend, a matrix or vector with the same number of
@@ -30,17 +26,19 @@ namespace math {
  *   the dividend does not have the same number of rows as the
  *   divisor has columns.
  */
-template <typename T1, typename T2, int R1, int C1, int R2, int C2>
-inline Eigen::Matrix<return_type_t<T1, T2>, R1, C2> mdivide_left_tri_low(
-    const Eigen::Matrix<T1, R1, C1> &A, const Eigen::Matrix<T2, R2, C2> &b) {
+template <typename T1, typename T2, require_all_eigen_t<T1, T2>* = nullptr,
+          require_all_not_eigen_vt<is_fvar, T1, T2>* = nullptr>
+inline Eigen::Matrix<return_type_t<T1, T2>, T1::RowsAtCompileTime,
+                     T2::ColsAtCompileTime>
+mdivide_left_tri_low(const T1& A, const T2& b) {
   check_square("mdivide_left_tri_low", "A", A);
   check_multiplicable("mdivide_left_tri_low", "A", A, "b", b);
   return mdivide_left_tri<Eigen::Lower>(A, b);
 }
 
-template <typename T, int R1, int C1>
-inline Eigen::Matrix<T, R1, C1> mdivide_left_tri_low(
-    const Eigen::Matrix<T, R1, C1> &A) {
+template <typename T, require_eigen_t<T>* = nullptr,
+          require_not_eigen_vt<is_fvar, T>* = nullptr>
+inline plain_type_t<T> mdivide_left_tri_low(const T& A) {
   check_square("mdivide_left_tri_low", "A", A);
   return mdivide_left_tri<Eigen::Lower>(A);
 }

--- a/stan/math/rev/fun/mdivide_left.hpp
+++ b/stan/math/rev/fun/mdivide_left.hpp
@@ -172,10 +172,12 @@ class mdivide_left_vd_vari : public vari {
 };
 }  // namespace internal
 
-template <int R1, int C1, int R2, int C2>
-inline Eigen::Matrix<var, R1, C2> mdivide_left(
-    const Eigen::Matrix<var, R1, C1> &A, const Eigen::Matrix<var, R2, C2> &b) {
-  Eigen::Matrix<var, R1, C2> res(b.rows(), b.cols());
+template <typename T1, typename T2,
+          require_all_eigen_vt<is_var, T1, T2> * = nullptr>
+inline Eigen::Matrix<var, T1::RowsAtCompileTime, T2::ColsAtCompileTime>
+mdivide_left(const T1 &A, const T2 &b) {
+  Eigen::Matrix<var, T1::RowsAtCompileTime, T2::ColsAtCompileTime> res(
+      b.rows(), b.cols());
 
   check_square("mdivide_left", "A", A);
   check_multiplicable("mdivide_left", "A", A, "b", b);
@@ -184,19 +186,22 @@ inline Eigen::Matrix<var, R1, C2> mdivide_left(
   // expression graph to evaluate the adjoint, but is not needed
   // for the returned matrix.  Memory will be cleaned up with the
   // arena allocator.
-  internal::mdivide_left_vv_vari<R1, C1, R2, C2> *baseVari
-      = new internal::mdivide_left_vv_vari<R1, C1, R2, C2>(A, b);
+  auto *baseVari = new internal::mdivide_left_vv_vari<
+      T1::RowsAtCompileTime, T1::ColsAtCompileTime, T2::RowsAtCompileTime,
+      T2::ColsAtCompileTime>(A, b);
 
   res.vi() = Eigen::Map<matrix_vi>(baseVari->variRefC_, res.rows(), res.cols());
 
   return res;
 }
 
-template <int R1, int C1, int R2, int C2>
-inline Eigen::Matrix<var, R1, C2> mdivide_left(
-    const Eigen::Matrix<var, R1, C1> &A,
-    const Eigen::Matrix<double, R2, C2> &b) {
-  Eigen::Matrix<var, R1, C2> res(b.rows(), b.cols());
+template <typename T1, typename T2, require_eigen_vt<is_var, T1> * = nullptr,
+          require_eigen_t<T2> * = nullptr,
+          require_same_vt<double, T2> * = nullptr>
+inline Eigen::Matrix<var, T1::RowsAtCompileTime, T2::ColsAtCompileTime>
+mdivide_left(const T1 &A, const T2 &b) {
+  Eigen::Matrix<var, T1::RowsAtCompileTime, T2::ColsAtCompileTime> res(
+      b.rows(), b.cols());
 
   check_square("mdivide_left", "A", A);
   check_multiplicable("mdivide_left", "A", A, "b", b);
@@ -205,19 +210,22 @@ inline Eigen::Matrix<var, R1, C2> mdivide_left(
   // expression graph to evaluate the adjoint, but is not needed
   // for the returned matrix.  Memory will be cleaned up with the
   // arena allocator.
-  internal::mdivide_left_vd_vari<R1, C1, R2, C2> *baseVari
-      = new internal::mdivide_left_vd_vari<R1, C1, R2, C2>(A, b);
+  auto *baseVari = new internal::mdivide_left_vd_vari<
+      T1::RowsAtCompileTime, T1::ColsAtCompileTime, T2::RowsAtCompileTime,
+      T2::ColsAtCompileTime>(A, b);
 
   res.vi() = Eigen::Map<matrix_vi>(baseVari->variRefC_, res.rows(), res.cols());
 
   return res;
 }
 
-template <int R1, int C1, int R2, int C2>
-inline Eigen::Matrix<var, R1, C2> mdivide_left(
-    const Eigen::Matrix<double, R1, C1> &A,
-    const Eigen::Matrix<var, R2, C2> &b) {
-  Eigen::Matrix<var, R1, C2> res(b.rows(), b.cols());
+template <typename T1, typename T2, require_eigen_t<T1> * = nullptr,
+          require_same_vt<double, T1> * = nullptr,
+          require_eigen_vt<is_var, T2> * = nullptr>
+inline Eigen::Matrix<var, T1::RowsAtCompileTime, T2::ColsAtCompileTime>
+mdivide_left(const T1 &A, const T2 &b) {
+  Eigen::Matrix<var, T1::RowsAtCompileTime, T2::ColsAtCompileTime> res(
+      b.rows(), b.cols());
 
   check_square("mdivide_left", "A", A);
   check_multiplicable("mdivide_left", "A", A, "b", b);
@@ -226,8 +234,9 @@ inline Eigen::Matrix<var, R1, C2> mdivide_left(
   // expression graph to evaluate the adjoint, but is not needed
   // for the returned matrix.  Memory will be cleaned up with the
   // arena allocator.
-  internal::mdivide_left_dv_vari<R1, C1, R2, C2> *baseVari
-      = new internal::mdivide_left_dv_vari<R1, C1, R2, C2>(A, b);
+  auto *baseVari = new internal::mdivide_left_dv_vari<
+      T1::RowsAtCompileTime, T1::ColsAtCompileTime, T2::RowsAtCompileTime,
+      T2::ColsAtCompileTime>(A, b);
 
   res.vi() = Eigen::Map<matrix_vi>(baseVari->variRefC_, res.rows(), res.cols());
 

--- a/stan/math/rev/fun/mdivide_left.hpp
+++ b/stan/math/rev/fun/mdivide_left.hpp
@@ -198,8 +198,7 @@ mdivide_left(const T1 &A, const T2 &b) {
 }
 
 template <typename T1, typename T2, require_eigen_vt<is_var, T1> * = nullptr,
-          require_eigen_t<T2> * = nullptr,
-          require_same_vt<double, T2> * = nullptr>
+          require_eigen_vt<std::is_arithmetic,T2> * = nullptr>
 inline Eigen::Matrix<var, T1::RowsAtCompileTime, T2::ColsAtCompileTime>
 mdivide_left(const T1 &A, const T2 &b) {
   check_square("mdivide_left", "A", A);
@@ -223,8 +222,7 @@ mdivide_left(const T1 &A, const T2 &b) {
   return res;
 }
 
-template <typename T1, typename T2, require_eigen_t<T1> * = nullptr,
-          require_same_vt<double, T1> * = nullptr,
+template <typename T1, typename T2, require_eigen_vt<std::is_arithmetic,T1> * = nullptr,
           require_eigen_vt<is_var, T2> * = nullptr>
 inline Eigen::Matrix<var, T1::RowsAtCompileTime, T2::ColsAtCompileTime>
 mdivide_left(const T1 &A, const T2 &b) {

--- a/stan/math/rev/fun/mdivide_left.hpp
+++ b/stan/math/rev/fun/mdivide_left.hpp
@@ -198,7 +198,7 @@ mdivide_left(const T1 &A, const T2 &b) {
 }
 
 template <typename T1, typename T2, require_eigen_vt<is_var, T1> * = nullptr,
-          require_eigen_vt<std::is_arithmetic,T2> * = nullptr>
+          require_eigen_vt<std::is_arithmetic, T2> * = nullptr>
 inline Eigen::Matrix<var, T1::RowsAtCompileTime, T2::ColsAtCompileTime>
 mdivide_left(const T1 &A, const T2 &b) {
   check_square("mdivide_left", "A", A);
@@ -222,7 +222,8 @@ mdivide_left(const T1 &A, const T2 &b) {
   return res;
 }
 
-template <typename T1, typename T2, require_eigen_vt<std::is_arithmetic,T1> * = nullptr,
+template <typename T1, typename T2,
+          require_eigen_vt<std::is_arithmetic, T1> * = nullptr,
           require_eigen_vt<is_var, T2> * = nullptr>
 inline Eigen::Matrix<var, T1::RowsAtCompileTime, T2::ColsAtCompileTime>
 mdivide_left(const T1 &A, const T2 &b) {

--- a/stan/math/rev/fun/mdivide_left_tri.hpp
+++ b/stan/math/rev/fun/mdivide_left_tri.hpp
@@ -325,7 +325,7 @@ mdivide_left_tri(const T1 &A, const T2 &b) {
   // expression graph to evaluate the adjoint, but is not needed
   // for the returned matrix.  Memory will be cleaned up with the
   // arena allocator.
-  auto* baseVari = new internal::mdivide_left_tri_vv_vari<
+  auto *baseVari = new internal::mdivide_left_tri_vv_vari<
       TriView, T1::RowsAtCompileTime, T1::ColsAtCompileTime,
       T2::RowsAtCompileTime, T2::ColsAtCompileTime>(A, b);
 
@@ -350,7 +350,7 @@ mdivide_left_tri(const T1 &A, const T2 &b) {
   // expression graph to evaluate the adjoint, but is not needed
   // for the returned matrix.  Memory will be cleaned up with the
   // arena allocator.
-  auto* baseVari = new internal::mdivide_left_tri_dv_vari<
+  auto *baseVari = new internal::mdivide_left_tri_dv_vari<
       TriView, T1::RowsAtCompileTime, T1::ColsAtCompileTime,
       T2::RowsAtCompileTime, T2::ColsAtCompileTime>(A, b);
 
@@ -375,7 +375,7 @@ mdivide_left_tri(const T1 &A, const T2 &b) {
   // expression graph to evaluate the adjoint, but is not needed
   // for the returned matrix.  Memory will be cleaned up with the
   // arena allocator.
-  auto* baseVari = new internal::mdivide_left_tri_vd_vari<
+  auto *baseVari = new internal::mdivide_left_tri_vd_vari<
       TriView, T1::RowsAtCompileTime, T1::ColsAtCompileTime,
       T2::RowsAtCompileTime, T2::ColsAtCompileTime>(A, b);
 

--- a/stan/math/rev/fun/mdivide_left_tri.hpp
+++ b/stan/math/rev/fun/mdivide_left_tri.hpp
@@ -311,10 +311,12 @@ class mdivide_left_tri_vd_vari : public vari {
 };
 }  // namespace internal
 
-template <Eigen::UpLoType TriView, int R1, int C1, int R2, int C2>
-inline Eigen::Matrix<var, R1, C2> mdivide_left_tri(
-    const Eigen::Matrix<var, R1, C1> &A, const Eigen::Matrix<var, R2, C2> &b) {
-  Eigen::Matrix<var, R1, C2> res(b.rows(), b.cols());
+template <Eigen::UpLoType TriView, typename T1, typename T2,
+          require_all_eigen_vt<is_var, T1, T2> * = nullptr>
+inline Eigen::Matrix<var, T1::RowsAtCompileTime, T2::ColsAtCompileTime>
+mdivide_left_tri(const T1 &A, const T2 &b) {
+  Eigen::Matrix<var, T1::RowsAtCompileTime, T2::ColsAtCompileTime> res(
+      b.rows(), b.cols());
 
   check_square("mdivide_left_tri", "A", A);
   check_multiplicable("mdivide_left_tri", "A", A, "b", b);
@@ -323,19 +325,23 @@ inline Eigen::Matrix<var, R1, C2> mdivide_left_tri(
   // expression graph to evaluate the adjoint, but is not needed
   // for the returned matrix.  Memory will be cleaned up with the
   // arena allocator.
-  internal::mdivide_left_tri_vv_vari<TriView, R1, C1, R2, C2> *baseVari
-      = new internal::mdivide_left_tri_vv_vari<TriView, R1, C1, R2, C2>(A, b);
+  auto* baseVari = new internal::mdivide_left_tri_vv_vari<
+      TriView, T1::RowsAtCompileTime, T1::ColsAtCompileTime,
+      T2::RowsAtCompileTime, T2::ColsAtCompileTime>(A, b);
 
   res.vi()
       = Eigen::Map<matrix_vi>(&(baseVari->variRefC_[0]), b.rows(), b.cols());
 
   return res;
 }
-template <Eigen::UpLoType TriView, int R1, int C1, int R2, int C2>
-inline Eigen::Matrix<var, R1, C2> mdivide_left_tri(
-    const Eigen::Matrix<double, R1, C1> &A,
-    const Eigen::Matrix<var, R2, C2> &b) {
-  Eigen::Matrix<var, R1, C2> res(b.rows(), b.cols());
+template <Eigen::UpLoType TriView, typename T1, typename T2,
+          require_eigen_t<T1> * = nullptr,
+          require_same_vt<double, T1> * = nullptr,
+          require_eigen_vt<is_var, T2> * = nullptr>
+inline Eigen::Matrix<var, T1::RowsAtCompileTime, T2::ColsAtCompileTime>
+mdivide_left_tri(const T1 &A, const T2 &b) {
+  Eigen::Matrix<var, T1::RowsAtCompileTime, T2::ColsAtCompileTime> res(
+      b.rows(), b.cols());
 
   check_square("mdivide_left_tri", "A", A);
   check_multiplicable("mdivide_left_tri", "A", A, "b", b);
@@ -344,19 +350,23 @@ inline Eigen::Matrix<var, R1, C2> mdivide_left_tri(
   // expression graph to evaluate the adjoint, but is not needed
   // for the returned matrix.  Memory will be cleaned up with the
   // arena allocator.
-  internal::mdivide_left_tri_dv_vari<TriView, R1, C1, R2, C2> *baseVari
-      = new internal::mdivide_left_tri_dv_vari<TriView, R1, C1, R2, C2>(A, b);
+  auto* baseVari = new internal::mdivide_left_tri_dv_vari<
+      TriView, T1::RowsAtCompileTime, T1::ColsAtCompileTime,
+      T2::RowsAtCompileTime, T2::ColsAtCompileTime>(A, b);
 
   res.vi()
       = Eigen::Map<matrix_vi>(&(baseVari->variRefC_[0]), b.rows(), b.cols());
 
   return res;
 }
-template <Eigen::UpLoType TriView, int R1, int C1, int R2, int C2>
-inline Eigen::Matrix<var, R1, C2> mdivide_left_tri(
-    const Eigen::Matrix<var, R1, C1> &A,
-    const Eigen::Matrix<double, R2, C2> &b) {
-  Eigen::Matrix<var, R1, C2> res(b.rows(), b.cols());
+template <Eigen::UpLoType TriView, typename T1, typename T2,
+          require_eigen_vt<is_var, T1> * = nullptr,
+          require_eigen_t<T2> * = nullptr,
+          require_same_vt<double, T2> * = nullptr>
+inline Eigen::Matrix<var, T1::RowsAtCompileTime, T2::ColsAtCompileTime>
+mdivide_left_tri(const T1 &A, const T2 &b) {
+  Eigen::Matrix<var, T1::RowsAtCompileTime, T2::ColsAtCompileTime> res(
+      b.rows(), b.cols());
 
   check_square("mdivide_left_tri", "A", A);
   check_multiplicable("mdivide_left_tri", "A", A, "b", b);
@@ -365,8 +375,9 @@ inline Eigen::Matrix<var, R1, C2> mdivide_left_tri(
   // expression graph to evaluate the adjoint, but is not needed
   // for the returned matrix.  Memory will be cleaned up with the
   // arena allocator.
-  internal::mdivide_left_tri_vd_vari<TriView, R1, C1, R2, C2> *baseVari
-      = new internal::mdivide_left_tri_vd_vari<TriView, R1, C1, R2, C2>(A, b);
+  auto* baseVari = new internal::mdivide_left_tri_vd_vari<
+      TriView, T1::RowsAtCompileTime, T1::ColsAtCompileTime,
+      T2::RowsAtCompileTime, T2::ColsAtCompileTime>(A, b);
 
   res.vi()
       = Eigen::Map<matrix_vi>(&(baseVari->variRefC_[0]), b.rows(), b.cols());

--- a/test/unit/math/fwd/fun/assign_test.cpp
+++ b/test/unit/math/fwd/fun/assign_test.cpp
@@ -73,9 +73,6 @@ TEST(AgradFwdMatrixAssign, eigen_row_vector_fvar_double_shape_mismatch) {
   Matrix<fvar<double>, Dynamic, Dynamic> zzz(3, 1);
   zzz << 1, 2, 3;
   EXPECT_THROW(assign(x, zzz), std::invalid_argument);
-
-  Matrix<fvar<double>, Dynamic, Dynamic> zzzz(1, 3);
-  EXPECT_THROW(assign(x, zzzz), std::invalid_argument);
 }
 
 TEST(AgradFwdMatrixAssign, eigen_matrix_fvar_double_to_fvar_double) {
@@ -332,9 +329,6 @@ TEST(AgradFwdMatrixAssign, eigen_row_vector_fvar_fvar_double_shape_mismatch) {
   Matrix<fvar<fvar<double> >, Dynamic, Dynamic> zzz(3, 1);
   zzz << 1, 2, 3;
   EXPECT_THROW(assign(x, zzz), std::invalid_argument);
-
-  Matrix<fvar<fvar<double> >, Dynamic, Dynamic> zzzz(1, 3);
-  EXPECT_THROW(assign(x, zzzz), std::invalid_argument);
 }
 
 TEST(AgradFwdMatrixAssign, eigen_matrix_fvar_fvar_double_to_fvar_fvar_double) {

--- a/test/unit/math/mix/fun/assign_test.cpp
+++ b/test/unit/math/mix/fun/assign_test.cpp
@@ -95,9 +95,6 @@ TEST(AgradMixMatrixAssign, eigen_row_vector_fvar_var_shape_mismatch) {
   Matrix<fvar<var>, Dynamic, Dynamic> zzz(3, 1);
   zzz << 1, 2, 3;
   EXPECT_THROW(assign(x, zzz), std::invalid_argument);
-
-  Matrix<fvar<var>, Dynamic, Dynamic> zzzz(1, 3);
-  EXPECT_THROW(assign(x, zzzz), std::invalid_argument);
 }
 
 TEST(AgradMixMatrixAssign, eigen_matrix_fvar_var_to_fvar_var) {
@@ -422,9 +419,6 @@ TEST(AgradMixMatrixAssign, eigen_row_vector_fvar_fvar_var_shape_mismatch) {
   Matrix<fvar<fvar<var> >, Dynamic, Dynamic> zzz(3, 1);
   zzz << 1, 2, 3;
   EXPECT_THROW(assign(x, zzz), std::invalid_argument);
-
-  Matrix<fvar<fvar<var> >, Dynamic, Dynamic> zzzz(1, 3);
-  EXPECT_THROW(assign(x, zzzz), std::invalid_argument);
 }
 
 TEST(AgradMixMatrixAssign, eigen_matrix_fvar_fvar_var_to_fvar_fvar_var) {

--- a/test/unit/math/prim/fun/append_col_test.cpp
+++ b/test/unit/math/prim/fun/append_col_test.cpp
@@ -175,3 +175,11 @@ TEST(MathMatrixPrimMat, append_col) {
   correct_type_row_vector(append_col(rv3, -4.31));
   correct_type_row_vector(append_col(5.23, rv3));
 }
+
+
+TEST(MathMatrixPrimMat, append_col_different_types) {
+  Eigen::MatrixXd m_d(3, 3);
+  Eigen::MatrixXi m_i(3, 3);
+
+  EXPECT_NO_THROW(stan::math::append_col(m_d, m_i));
+}

--- a/test/unit/math/prim/fun/append_col_test.cpp
+++ b/test/unit/math/prim/fun/append_col_test.cpp
@@ -176,7 +176,6 @@ TEST(MathMatrixPrimMat, append_col) {
   correct_type_row_vector(append_col(5.23, rv3));
 }
 
-
 TEST(MathMatrixPrimMat, append_col_different_types) {
   Eigen::MatrixXd m_d(3, 3);
   Eigen::MatrixXi m_i(3, 3);

--- a/test/unit/math/prim/fun/append_row_test.cpp
+++ b/test/unit/math/prim/fun/append_row_test.cpp
@@ -176,3 +176,10 @@ TEST(MathMatrixPrimMat, append_row) {
   correct_type_vector(append_row(v3, -4.31));
   correct_type_vector(append_row(5.23, v3));
 }
+
+TEST(MathMatrixPrimMat, append_row_different_types) {
+  Eigen::MatrixXd m_d(3, 3);
+  Eigen::MatrixXi m_i(3, 3);
+
+  EXPECT_NO_THROW(stan::math::append_row(m_d, m_i));
+}

--- a/test/unit/math/prim/fun/assign_test.cpp
+++ b/test/unit/math/prim/fun/assign_test.cpp
@@ -21,7 +21,7 @@ TEST(MathMatrixAssign, print_mat_size) {
   test_print_mat_size<10>("10");
 }
 
-TEST(MathMatrixAssign, realToDouble) {
+TEST(MathMatrixAssign, intToDouble) {
   double a = 2.7;
   int b = 0;
   EXPECT_NO_THROW(stan::math::assign(b, a));
@@ -60,12 +60,12 @@ TEST(MathMatrixAssign, matSizeMismatch) {
   Matrix<double, -1, -1> m3(10, 10);
   Matrix<double, -1, -1> m4(2, 3);
   EXPECT_THROW_MSG(assign(m3.block(1, 1, 7, 3), m4), std::exception,
-                   "left-hand side rows (7) and right-hand"
-                   " side rows (2) must match in size");
+                   "Rows of left-hand-side (7) and rows of"
+                   " right-hand-side (2) must match in size");
 
   EXPECT_THROW_MSG(assign(m3.block(1, 1, 2, 5), m4), std::exception,
-                   "assign: left-hand side cols (5) and"
-                   " right-hand side cols (3) must match in size");
+                   "Columns of left-hand-side (5) and columns"
+                   " of right-hand-side (3) must match in size");
 }
 
 TEST(MathMatrixAssign, test_int) {
@@ -185,9 +185,6 @@ TEST(MathMatrixAssign, eigenRowVectorShapeMismatch) {
   Matrix<double, Dynamic, Dynamic> zzz(3, 1);
   zzz << 1, 2, 3;
   EXPECT_THROW(assign(x, zzz), std::invalid_argument);
-
-  Matrix<double, Dynamic, Dynamic> zzzz(1, 3);
-  EXPECT_THROW(assign(x, zzzz), std::invalid_argument);
 }
 
 TEST(MathMatrixAssign, eigenMatrixDoubleToDouble) {


### PR DESCRIPTION
## Summary

Generalizes inputs to functions that start with a - chol2. `chol2inv` depends on `mdivide_left`, `mdivide_left_tri` and `mdivide_left_tri_low` so these were generalized as well.

## Tests
`assign()` had different requirements wrt compile time size for Eigen matrices and Eigen blocks. I changed that so it accepts all assignments Eigen does (It previously did that for blocks. For matrices it required same compile time sizes). That also changed some tests.

## Side Effects
None.

## Checklist

- [x] Math issue #1470

- [x] Copyright holder: Tadej Ciglarič
    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
