### PR TITLE
Reuse intermediate computations in distributions part 1

### DIFF
--- a/stan/math/prim/prob/bernoulli_lccdf.hpp
+++ b/stan/math/prim/prob/bernoulli_lccdf.hpp
@@ -4,6 +4,7 @@
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/err.hpp>
 #include <stan/math/prim/fun/constants.hpp>
+#include <stan/math/prim/fun/inv.hpp>
 #include <stan/math/prim/fun/log.hpp>
 #include <stan/math/prim/fun/max_size.hpp>
 #include <stan/math/prim/fun/size.hpp>
@@ -52,29 +53,28 @@ return_type_t<T_prob> bernoulli_lccdf(const T_n& n, const T_prob& theta) {
   // Explicit return for extreme values
   // The gradients are technically ill-defined, but treated as zero
   for (size_t i = 0; i < stan::math::size(n); i++) {
-    if (value_of(n_vec[i]) < 0) {
+    const double n_dbl = value_of(n_vec[i]);
+    if (n_dbl < 0) {
       return ops_partials.build(0.0);
+    }
+    if (n_dbl >= 1) {
+      return ops_partials.build(NEGATIVE_INFTY);
     }
   }
 
   for (size_t i = 0; i < max_size_seq_view; i++) {
-    // Explicit results for extreme values
-    // The gradients are technically ill-defined, but treated as zero
-    if (value_of(n_vec[i]) >= 1) {
-      return ops_partials.build(negative_infinity());
-    } else {
-      const T_partials_return Pi = value_of(theta_vec[i]);
+    const T_partials_return Pi = value_of(theta_vec[i]);
 
-      P += log(Pi);
+    P += log(Pi);
 
-      if (!is_constant_all<T_prob>::value) {
-        ops_partials.edge1_.partials_[i] += 1 / Pi;
-      }
+    if (!is_constant_all<T_prob>::value) {
+      ops_partials.edge1_.partials_[i] += inv(Pi);
     }
   }
 
   return ops_partials.build(P);
 }
+
 }  // namespace math
 }  // namespace stan
 #endif

--- a/stan/math/prim/prob/bernoulli_lcdf.hpp
+++ b/stan/math/prim/prob/bernoulli_lcdf.hpp
@@ -4,6 +4,7 @@
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/err.hpp>
 #include <stan/math/prim/fun/constants.hpp>
+#include <stan/math/prim/fun/inv.hpp>
 #include <stan/math/prim/fun/log.hpp>
 #include <stan/math/prim/fun/max_size.hpp>
 #include <stan/math/prim/fun/size.hpp>
@@ -53,7 +54,7 @@ return_type_t<T_prob> bernoulli_lcdf(const T_n& n, const T_prob& theta) {
   // The gradients are technically ill-defined, but treated as zero
   for (size_t i = 0; i < stan::math::size(n); i++) {
     if (value_of(n_vec[i]) < 0) {
-      return ops_partials.build(negative_infinity());
+      return ops_partials.build(NEGATIVE_INFTY);
     }
   }
 
@@ -69,7 +70,7 @@ return_type_t<T_prob> bernoulli_lcdf(const T_n& n, const T_prob& theta) {
     P += log(Pi);
 
     if (!is_constant_all<T_prob>::value) {
-      ops_partials.edge1_.partials_[i] -= 1 / Pi;
+      ops_partials.edge1_.partials_[i] -= inv(Pi);
     }
   }
 

--- a/stan/math/prim/prob/bernoulli_logit_glm_lpmf.hpp
+++ b/stan/math/prim/prob/bernoulli_logit_glm_lpmf.hpp
@@ -21,6 +21,7 @@ namespace math {
  * compute a more efficient version of bernoulli_logit_lpmf(y, alpha + x * beta)
  * by using analytically simplified gradients.
  * If containers are supplied, returns the log sum of the probabilities.
+ *
  * @tparam T_y type of binary vector of dependent variables (labels);
  * this can also be a single binary value;
  * @tparam T_x_scalar type of a scalar in the matrix of independent variables
@@ -30,8 +31,8 @@ namespace math {
  * @tparam T_alpha type of the intercept(s);
  * this can be a vector (of the same length as y) of intercepts or a single
  * value (for models with constant intercept);
- * @tparam T_beta type of the weight vector;
- * this can also be a single value;
+ * @tparam T_beta type of the weight vector
+ *
  * @param y binary scalar or vector parameter. If it is a scalar it will be
  * broadcast - used for all instances.
  * @param x design matrix or row vector. If it is a row vector it will be
@@ -43,7 +44,6 @@ namespace math {
  * @throw std::domain_error if y is not binary.
  * @throw std::invalid_argument if container sizes mismatch.
  */
-
 template <bool propto, typename T_y, typename T_x_scalar, int T_x_rows,
           typename T_alpha, typename T_beta>
 return_type_t<T_x_scalar, T_alpha, T_beta> bernoulli_logit_glm_lpmf(

--- a/stan/math/prim/prob/bernoulli_lpmf.hpp
+++ b/stan/math/prim/prob/bernoulli_lpmf.hpp
@@ -3,6 +3,7 @@
 
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/err.hpp>
+#include <stan/math/prim/fun/inv.hpp>
 #include <stan/math/prim/fun/log.hpp>
 #include <stan/math/prim/fun/log1m.hpp>
 #include <stan/math/prim/fun/max_size.hpp>
@@ -95,9 +96,9 @@ return_type_t<T_prob> bernoulli_lpmf(const T_n& n, const T_prob& theta) {
 
       if (!is_constant_all<T_prob>::value) {
         if (n_int == 1) {
-          ops_partials.edge1_.partials_[n] += 1.0 / theta_dbl;
+          ops_partials.edge1_.partials_[n] += inv(theta_dbl);
         } else {
-          ops_partials.edge1_.partials_[n] += 1.0 / (theta_dbl - 1);
+          ops_partials.edge1_.partials_[n] += inv(theta_dbl - 1);
         }
       }
     }

--- a/stan/math/prim/prob/beta_binomial_cdf.hpp
+++ b/stan/math/prim/prob/beta_binomial_cdf.hpp
@@ -103,21 +103,23 @@ return_type_t<T_size1, T_size2> beta_binomial_cdf(const T_n& n, const T_N& N,
 
     P *= Pi;
 
-    T_partials_return dF[6];
-    T_partials_return digammaDiff = 0;
+    T_partials_return digammaDiff
+        = is_constant_all<T_size1, T_size2>::value
+              ? 0
+              : digamma(alpha_dbl + beta_dbl) - digamma(mu + nu);
 
+    T_partials_return dF[6];
     if (!is_constant_all<T_size1, T_size2>::value) {
-      digammaDiff = digamma(mu + nu) - digamma(alpha_dbl + beta_dbl);
       grad_F32(dF, one, mu, 1 - N_minus_n, n_dbl + 2, 1 - nu, one);
     }
     if (!is_constant_all<T_size1>::value) {
       const T_partials_return g
-          = -C * (digamma(mu) - digamma(alpha_dbl) - digammaDiff + dF[1] / F);
+          = -C * (digamma(mu) - digamma(alpha_dbl) + digammaDiff + dF[1] / F);
       ops_partials.edge1_.partials_[i] += g / Pi;
     }
     if (!is_constant_all<T_size2>::value) {
       const T_partials_return g
-          = -C * (digamma(nu) - digamma(beta_dbl) - digammaDiff - dF[4] / F);
+          = -C * (digamma(nu) - digamma(beta_dbl) + digammaDiff - dF[4] / F);
       ops_partials.edge2_.partials_[i] += g / Pi;
     }
   }

--- a/stan/math/prim/prob/beta_binomial_lccdf.hpp
+++ b/stan/math/prim/prob/beta_binomial_lccdf.hpp
@@ -103,20 +103,22 @@ return_type_t<T_size1, T_size2> beta_binomial_lccdf(const T_n& n, const T_N& N,
 
     P += log(Pi);
 
-    T_partials_return dF[6];
-    T_partials_return digammaDiff = 0;
+    T_partials_return digammaDiff
+        = is_constant_all<T_size1, T_size2>::value
+              ? 0
+              : digamma(alpha_dbl + beta_dbl) - digamma(mu + nu);
 
+    T_partials_return dF[6];
     if (!is_constant_all<T_size1, T_size2>::value) {
-      digammaDiff = digamma(mu + nu) - digamma(alpha_dbl + beta_dbl);
       grad_F32(dF, one, mu, -N_dbl + n_dbl + 1, n_dbl + 2, 1 - nu, one);
     }
     if (!is_constant_all<T_size1>::value) {
       ops_partials.edge1_.partials_[i]
-          += digamma(mu) - digamma(alpha_dbl) - digammaDiff + dF[1] / F;
+          += digamma(mu) - digamma(alpha_dbl) + digammaDiff + dF[1] / F;
     }
     if (!is_constant_all<T_size2>::value) {
       ops_partials.edge2_.partials_[i]
-          += digamma(nu) - digamma(beta_dbl) - digammaDiff - dF[4] / F;
+          += digamma(nu) - digamma(beta_dbl) + digammaDiff - dF[4] / F;
     }
   }
 

--- a/stan/math/prim/prob/beta_binomial_lpmf.hpp
+++ b/stan/math/prim/prob/beta_binomial_lpmf.hpp
@@ -64,6 +64,10 @@ return_type_t<T_size1, T_size2> beta_binomial_lpmf(const T_n& n, const T_N& N,
   scalar_seq_view<T_N> N_vec(N);
   scalar_seq_view<T_size1> alpha_vec(alpha);
   scalar_seq_view<T_size2> beta_vec(beta);
+  size_t size_alpha = stan::math::size(alpha);
+  size_t size_beta = stan::math::size(beta);
+  size_t size_n_N = max_size(n, N);
+  size_t size_alpha_beta = max_size(alpha, beta);
   size_t max_size_seq_view = max_size(n, N, alpha, beta);
 
   for (size_t i = 0; i < max_size_seq_view; i++) {
@@ -73,73 +77,79 @@ return_type_t<T_size1, T_size2> beta_binomial_lpmf(const T_n& n, const T_N& N,
   }
 
   VectorBuilder<include_summand<propto>::value, T_partials_return, T_n, T_N>
-      normalizing_constant(max_size(N, n));
-  for (size_t i = 0; i < max_size(N, n); i++)
+      normalizing_constant(size_n_N);
+  for (size_t i = 0; i < size_n_N; i++)
     if (include_summand<propto>::value)
       normalizing_constant[i] = binomial_coefficient_log(N_vec[i], n_vec[i]);
 
-  VectorBuilder<include_summand<propto, T_size1, T_size2>::value,
-                T_partials_return, T_n, T_N, T_size1, T_size2>
-      lbeta_numerator(max_size_seq_view);
-  for (size_t i = 0; i < max_size_seq_view; i++)
-    lbeta_numerator[i] = lbeta(n_vec[i] + value_of(alpha_vec[i]),
-                               N_vec[i] - n_vec[i] + value_of(beta_vec[i]));
-
-  VectorBuilder<include_summand<propto, T_size1, T_size2>::value,
-                T_partials_return, T_size1, T_size2>
-      lbeta_denominator(max_size(alpha, beta));
-  for (size_t i = 0; i < max_size(alpha, beta); i++)
+  VectorBuilder<true, T_partials_return, T_size1, T_size2> lbeta_denominator(
+      size_alpha_beta);
+  for (size_t i = 0; i < size_alpha_beta; i++) {
     lbeta_denominator[i] = lbeta(value_of(alpha_vec[i]), value_of(beta_vec[i]));
+  }
+
+  VectorBuilder<true, T_partials_return, T_n, T_N, T_size1, T_size2> lbeta_diff(
+      max_size_seq_view);
+  for (size_t i = 0; i < max_size_seq_view; i++) {
+    lbeta_diff[i] = lbeta(n_vec[i] + value_of(alpha_vec[i]),
+                          N_vec[i] - n_vec[i] + value_of(beta_vec[i]))
+                    - lbeta_denominator[i];
+  }
 
   VectorBuilder<!is_constant_all<T_size1>::value, T_partials_return, T_n,
                 T_size1>
       digamma_n_plus_alpha(max_size(n, alpha));
-  for (size_t i = 0; i < max_size(n, alpha); i++)
-    if (!is_constant_all<T_size1>::value)
+  if (!is_constant_all<T_size1>::value) {
+    for (size_t i = 0; i < max_size(n, alpha); i++) {
       digamma_n_plus_alpha[i] = digamma(n_vec[i] + value_of(alpha_vec[i]));
-
-  VectorBuilder<!is_constant_all<T_size1, T_size2>::value, T_partials_return,
-                T_N, T_size1, T_size2>
-      digamma_N_plus_alpha_plus_beta(max_size(N, alpha, beta));
-  for (size_t i = 0; i < max_size(N, alpha, beta); i++)
-    if (!is_constant_all<T_size1, T_size2>::value)
-      digamma_N_plus_alpha_plus_beta[i]
-          = digamma(N_vec[i] + value_of(alpha_vec[i]) + value_of(beta_vec[i]));
+    }
+  }
 
   VectorBuilder<!is_constant_all<T_size1, T_size2>::value, T_partials_return,
                 T_size1, T_size2>
-      digamma_alpha_plus_beta(max_size(alpha, beta));
-  for (size_t i = 0; i < max_size(alpha, beta); i++)
-    if (!is_constant_all<T_size1, T_size2>::value)
+      digamma_alpha_plus_beta(size_alpha_beta);
+  if (!is_constant_all<T_size1, T_size2>::value) {
+    for (size_t i = 0; i < size_alpha_beta; i++) {
       digamma_alpha_plus_beta[i]
           = digamma(value_of(alpha_vec[i]) + value_of(beta_vec[i]));
+    }
+  }
+
+  VectorBuilder<!is_constant_all<T_size1, T_size2>::value, T_partials_return,
+                T_N, T_size1, T_size2>
+      digamma_diff(max_size(N, alpha, beta));
+  if (!is_constant_all<T_size1, T_size2>::value) {
+    for (size_t i = 0; i < max_size(N, alpha, beta); i++) {
+      digamma_diff[i] = digamma_alpha_plus_beta[i]
+                        - digamma(N_vec[i] + value_of(alpha_vec[i])
+                                  + value_of(beta_vec[i]));
+    }
+  }
 
   VectorBuilder<!is_constant_all<T_size1>::value, T_partials_return, T_size1>
-      digamma_alpha(size(alpha));
-  for (size_t i = 0; i < stan::math::size(alpha); i++)
+      digamma_alpha(size_alpha);
+  for (size_t i = 0; i < size_alpha; i++)
     if (!is_constant_all<T_size1>::value)
       digamma_alpha[i] = digamma(value_of(alpha_vec[i]));
 
   VectorBuilder<!is_constant_all<T_size2>::value, T_partials_return, T_size2>
-      digamma_beta(size(beta));
-  for (size_t i = 0; i < stan::math::size(beta); i++)
+      digamma_beta(size_beta);
+  for (size_t i = 0; i < size_beta; i++)
     if (!is_constant_all<T_size2>::value)
       digamma_beta[i] = digamma(value_of(beta_vec[i]));
 
   for (size_t i = 0; i < max_size_seq_view; i++) {
     if (include_summand<propto>::value)
       logp += normalizing_constant[i];
-    logp += lbeta_numerator[i] - lbeta_denominator[i];
+    logp += lbeta_diff[i];
 
     if (!is_constant_all<T_size1>::value)
       ops_partials.edge1_.partials_[i]
-          += digamma_n_plus_alpha[i] - digamma_N_plus_alpha_plus_beta[i]
-             + digamma_alpha_plus_beta[i] - digamma_alpha[i];
+          += digamma_n_plus_alpha[i] + digamma_diff[i] - digamma_alpha[i];
     if (!is_constant_all<T_size2>::value)
       ops_partials.edge2_.partials_[i]
           += digamma(value_of(N_vec[i] - n_vec[i] + beta_vec[i]))
-             - digamma_N_plus_alpha_plus_beta[i] + digamma_alpha_plus_beta[i]
-             - digamma_beta[i];
+             + digamma_diff[i] - digamma_beta[i];
   }
   return ops_partials.build(logp);
 }

--- a/stan/math/prim/prob/beta_cdf.hpp
+++ b/stan/math/prim/prob/beta_cdf.hpp
@@ -8,6 +8,7 @@
 #include <stan/math/prim/fun/inc_beta_dda.hpp>
 #include <stan/math/prim/fun/inc_beta_ddb.hpp>
 #include <stan/math/prim/fun/inc_beta_ddz.hpp>
+#include <stan/math/prim/fun/inv.hpp>
 #include <stan/math/prim/fun/max_size.hpp>
 #include <stan/math/prim/fun/size.hpp>
 #include <stan/math/prim/fun/size_zero.hpp>
@@ -54,6 +55,9 @@ return_type_t<T_y, T_scale_succ, T_scale_fail> beta_cdf(
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_scale_succ> alpha_vec(alpha);
   scalar_seq_view<T_scale_fail> beta_vec(beta);
+  size_t size_alpha = stan::math::size(alpha);
+  size_t size_beta = stan::math::size(beta);
+  size_t size_alpha_beta = max_size(alpha, beta);
   size_t N = max_size(y, alpha, beta);
 
   operands_and_partials<T_y, T_scale_succ, T_scale_fail> ops_partials(y, alpha,
@@ -67,60 +71,66 @@ return_type_t<T_y, T_scale_succ, T_scale_fail> beta_cdf(
     }
   }
 
-  VectorBuilder<!is_constant_all<T_scale_succ, T_scale_fail>::value,
-                T_partials_return, T_scale_succ, T_scale_fail>
-      digamma_alpha_vec(max_size(alpha, beta));
+  VectorBuilder<!is_constant_all<T_scale_succ>::value, T_partials_return,
+                T_scale_succ>
+      digamma_alpha(size_alpha);
+  if (!is_constant_all<T_scale_succ>::value) {
+    for (size_t n = 0; n < size_alpha; n++) {
+      digamma_alpha[n] = digamma(value_of(alpha_vec[n]));
+    }
+  }
+
+  VectorBuilder<!is_constant_all<T_scale_fail>::value, T_partials_return,
+                T_scale_fail>
+      digamma_beta(size_beta);
+  if (!is_constant_all<T_scale_fail>::value) {
+    for (size_t n = 0; n < size_beta; n++) {
+      digamma_beta[n] = digamma(value_of(beta_vec[n]));
+    }
+  }
 
   VectorBuilder<!is_constant_all<T_scale_succ, T_scale_fail>::value,
                 T_partials_return, T_scale_succ, T_scale_fail>
-      digamma_beta_vec(max_size(alpha, beta));
-
-  VectorBuilder<!is_constant_all<T_scale_succ, T_scale_fail>::value,
-                T_partials_return, T_scale_succ, T_scale_fail>
-      digamma_sum_vec(max_size(alpha, beta));
-
+      digamma_sum(size_alpha_beta);
   if (!is_constant_all<T_scale_succ, T_scale_fail>::value) {
-    for (size_t n = 0; n < N; n++) {
-      const T_partials_return alpha_dbl = value_of(alpha_vec[n]);
-      const T_partials_return beta_dbl = value_of(beta_vec[n]);
-
-      digamma_alpha_vec[n] = digamma(alpha_dbl);
-      digamma_beta_vec[n] = digamma(beta_dbl);
-      digamma_sum_vec[n] = digamma(alpha_dbl + beta_dbl);
+    for (size_t n = 0; n < size_alpha_beta; n++) {
+      digamma_sum[n] = digamma(value_of(alpha_vec[n]) + value_of(beta_vec[n]));
     }
   }
 
   for (size_t n = 0; n < N; n++) {
+    const T_partials_return y_dbl = value_of(y_vec[n]);
+
     // Explicit results for extreme values
     // The gradients are technically ill-defined, but treated as zero
-    if (value_of(y_vec[n]) >= 1.0) {
+    if (y_dbl >= 1.0) {
       continue;
     }
 
-    const T_partials_return y_dbl = value_of(y_vec[n]);
     const T_partials_return alpha_dbl = value_of(alpha_vec[n]);
     const T_partials_return beta_dbl = value_of(beta_vec[n]);
-
     const T_partials_return Pn = inc_beta(alpha_dbl, beta_dbl, y_dbl);
+    const T_partials_return inv_Pn
+        = is_constant_all<T_y, T_scale_succ, T_scale_fail>::value ? 0 : inv(Pn);
 
     P *= Pn;
 
     if (!is_constant_all<T_y>::value) {
       ops_partials.edge1_.partials_[n]
-          += inc_beta_ddz(alpha_dbl, beta_dbl, y_dbl) / Pn;
+          += inc_beta_ddz(alpha_dbl, beta_dbl, y_dbl) * inv_Pn;
     }
 
     if (!is_constant_all<T_scale_succ>::value) {
       ops_partials.edge2_.partials_[n]
-          += inc_beta_dda(alpha_dbl, beta_dbl, y_dbl, digamma_alpha_vec[n],
-                          digamma_sum_vec[n])
-             / Pn;
+          += inc_beta_dda(alpha_dbl, beta_dbl, y_dbl, digamma_alpha[n],
+                          digamma_sum[n])
+             * inv_Pn;
     }
     if (!is_constant_all<T_scale_fail>::value) {
       ops_partials.edge3_.partials_[n]
-          += inc_beta_ddb(alpha_dbl, beta_dbl, y_dbl, digamma_beta_vec[n],
-                          digamma_sum_vec[n])
-             / Pn;
+          += inc_beta_ddb(alpha_dbl, beta_dbl, y_dbl, digamma_beta[n],
+                          digamma_sum[n])
+             * inv_Pn;
     }
   }
 

--- a/stan/math/prim/prob/beta_lccdf.hpp
+++ b/stan/math/prim/prob/beta_lccdf.hpp
@@ -7,6 +7,7 @@
 #include <stan/math/prim/fun/digamma.hpp>
 #include <stan/math/prim/fun/grad_reg_inc_beta.hpp>
 #include <stan/math/prim/fun/inc_beta.hpp>
+#include <stan/math/prim/fun/inv.hpp>
 #include <stan/math/prim/fun/log.hpp>
 #include <stan/math/prim/fun/max_size.hpp>
 #include <stan/math/prim/fun/size_zero.hpp>
@@ -59,6 +60,9 @@ return_type_t<T_y, T_scale_succ, T_scale_fail> beta_lccdf(
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_scale_succ> alpha_vec(alpha);
   scalar_seq_view<T_scale_fail> beta_vec(beta);
+  size_t size_alpha = stan::math::size(alpha);
+  size_t size_beta = stan::math::size(beta);
+  size_t size_alpha_beta = max_size(alpha, beta);
   size_t N = max_size(y, alpha, beta);
 
   operands_and_partials<T_y, T_scale_succ, T_scale_fail> ops_partials(y, alpha,
@@ -69,23 +73,24 @@ return_type_t<T_y, T_scale_succ, T_scale_fail> beta_lccdf(
   using std::pow;
 
   VectorBuilder<!is_constant_all<T_scale_succ, T_scale_fail>::value,
-                T_partials_return, T_scale_succ, T_scale_fail>
-      digamma_alpha_vec(max_size(alpha, beta));
+                T_partials_return, T_scale_succ>
+      digamma_alpha(size_alpha);
+  VectorBuilder<!is_constant_all<T_scale_succ, T_scale_fail>::value,
+                T_partials_return, T_scale_fail>
+      digamma_beta(size_beta);
   VectorBuilder<!is_constant_all<T_scale_succ, T_scale_fail>::value,
                 T_partials_return, T_scale_succ, T_scale_fail>
-      digamma_beta_vec(max_size(alpha, beta));
-  VectorBuilder<!is_constant_all<T_scale_succ, T_scale_fail>::value,
-                T_partials_return, T_scale_succ, T_scale_fail>
-      digamma_sum_vec(max_size(alpha, beta));
+      digamma_sum(size_alpha_beta);
 
   if (!is_constant_all<T_scale_succ, T_scale_fail>::value) {
-    for (size_t i = 0; i < max_size(alpha, beta); i++) {
-      const T_partials_return alpha_dbl = value_of(alpha_vec[i]);
-      const T_partials_return beta_dbl = value_of(beta_vec[i]);
-
-      digamma_alpha_vec[i] = digamma(alpha_dbl);
-      digamma_beta_vec[i] = digamma(beta_dbl);
-      digamma_sum_vec[i] = digamma(alpha_dbl + beta_dbl);
+    for (size_t i = 0; i < size_alpha; i++) {
+      digamma_alpha[i] = digamma(value_of(alpha_vec[i]));
+    }
+    for (size_t i = 0; i < size_beta; i++) {
+      digamma_beta[i] = digamma(value_of(beta_vec[i]));
+    }
+    for (size_t i = 0; i < size_alpha_beta; i++) {
+      digamma_sum[i] = digamma(value_of(alpha_vec[i]) + value_of(beta_vec[i]));
     }
   }
 
@@ -95,30 +100,30 @@ return_type_t<T_y, T_scale_succ, T_scale_fail> beta_lccdf(
     const T_partials_return beta_dbl = value_of(beta_vec[n]);
     const T_partials_return betafunc_dbl
         = stan::math::beta(alpha_dbl, beta_dbl);
-
     const T_partials_return Pn = 1.0 - inc_beta(alpha_dbl, beta_dbl, y_dbl);
+    const T_partials_return inv_Pn
+        = is_constant_all<T_y, T_scale_succ, T_scale_fail>::value ? 0 : inv(Pn);
 
     ccdf_log += log(Pn);
 
     if (!is_constant_all<T_y>::value) {
       ops_partials.edge1_.partials_[n] -= pow(1 - y_dbl, beta_dbl - 1)
-                                          * pow(y_dbl, alpha_dbl - 1)
-                                          / betafunc_dbl / Pn;
+                                          * pow(y_dbl, alpha_dbl - 1) * inv_Pn
+                                          / betafunc_dbl;
     }
 
     T_partials_return g1 = 0;
     T_partials_return g2 = 0;
 
     if (!is_constant_all<T_scale_succ, T_scale_fail>::value) {
-      grad_reg_inc_beta(g1, g2, alpha_dbl, beta_dbl, y_dbl,
-                        digamma_alpha_vec[n], digamma_beta_vec[n],
-                        digamma_sum_vec[n], betafunc_dbl);
+      grad_reg_inc_beta(g1, g2, alpha_dbl, beta_dbl, y_dbl, digamma_alpha[n],
+                        digamma_beta[n], digamma_sum[n], betafunc_dbl);
     }
     if (!is_constant_all<T_scale_succ>::value) {
-      ops_partials.edge2_.partials_[n] -= g1 / Pn;
+      ops_partials.edge2_.partials_[n] -= g1 * inv_Pn;
     }
     if (!is_constant_all<T_scale_fail>::value) {
-      ops_partials.edge3_.partials_[n] -= g2 / Pn;
+      ops_partials.edge3_.partials_[n] -= g2 * inv_Pn;
     }
   }
   return ops_partials.build(ccdf_log);

--- a/stan/math/prim/prob/beta_lcdf.hpp
+++ b/stan/math/prim/prob/beta_lcdf.hpp
@@ -7,6 +7,7 @@
 #include <stan/math/prim/fun/digamma.hpp>
 #include <stan/math/prim/fun/grad_reg_inc_beta.hpp>
 #include <stan/math/prim/fun/inc_beta.hpp>
+#include <stan/math/prim/fun/inv.hpp>
 #include <stan/math/prim/fun/log.hpp>
 #include <stan/math/prim/fun/max_size.hpp>
 #include <stan/math/prim/fun/size_zero.hpp>
@@ -29,7 +30,7 @@ namespace math {
  * @param y (Sequence of) scalar(s) between zero and one
  * @param alpha (Sequence of) success parameter(s)
  * @param beta (Sequence of) failure parameter(s)
- * @return log probability or sum of log of proabilities
+ * @return log probability or sum of log of probabilities
  * @throw std::domain_error if alpha or beta is negative
  * @throw std::domain_error if y is not a valid probability
  * @throw std::invalid_argument if container sizes mismatch
@@ -59,6 +60,9 @@ return_type_t<T_y, T_scale_succ, T_scale_fail> beta_lcdf(
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_scale_succ> alpha_vec(alpha);
   scalar_seq_view<T_scale_fail> beta_vec(beta);
+  size_t size_alpha = stan::math::size(alpha);
+  size_t size_beta = stan::math::size(beta);
+  size_t size_alpha_beta = max_size(alpha, beta);
   size_t N = max_size(y, alpha, beta);
 
   operands_and_partials<T_y, T_scale_succ, T_scale_fail> ops_partials(y, alpha,
@@ -69,25 +73,24 @@ return_type_t<T_y, T_scale_succ, T_scale_fail> beta_lcdf(
   using std::pow;
 
   VectorBuilder<!is_constant_all<T_scale_succ, T_scale_fail>::value,
-                T_partials_return, T_scale_succ, T_scale_fail>
-      digamma_alpha_vec(max_size(alpha, beta));
-
+                T_partials_return, T_scale_succ>
+      digamma_alpha(size_alpha);
+  VectorBuilder<!is_constant_all<T_scale_succ, T_scale_fail>::value,
+                T_partials_return, T_scale_fail>
+      digamma_beta(size_beta);
   VectorBuilder<!is_constant_all<T_scale_succ, T_scale_fail>::value,
                 T_partials_return, T_scale_succ, T_scale_fail>
-      digamma_beta_vec(max_size(alpha, beta));
-
-  VectorBuilder<!is_constant_all<T_scale_succ, T_scale_fail>::value,
-                T_partials_return, T_scale_succ, T_scale_fail>
-      digamma_sum_vec(max_size(alpha, beta));
+      digamma_sum(size_alpha_beta);
 
   if (!is_constant_all<T_scale_succ, T_scale_fail>::value) {
-    for (size_t i = 0; i < max_size(alpha, beta); i++) {
-      const T_partials_return alpha_dbl = value_of(alpha_vec[i]);
-      const T_partials_return beta_dbl = value_of(beta_vec[i]);
-
-      digamma_alpha_vec[i] = digamma(alpha_dbl);
-      digamma_beta_vec[i] = digamma(beta_dbl);
-      digamma_sum_vec[i] = digamma(alpha_dbl + beta_dbl);
+    for (size_t i = 0; i < size_alpha; i++) {
+      digamma_alpha[i] = digamma(value_of(alpha_vec[i]));
+    }
+    for (size_t i = 0; i < size_beta; i++) {
+      digamma_beta[i] = digamma(value_of(beta_vec[i]));
+    }
+    for (size_t i = 0; i < size_alpha_beta; i++) {
+      digamma_sum[i] = digamma(value_of(alpha_vec[i]) + value_of(beta_vec[i]));
     }
   }
 
@@ -98,28 +101,29 @@ return_type_t<T_y, T_scale_succ, T_scale_fail> beta_lcdf(
     const T_partials_return betafunc_dbl
         = stan::math::beta(alpha_dbl, beta_dbl);
     const T_partials_return Pn = inc_beta(alpha_dbl, beta_dbl, y_dbl);
+    const T_partials_return inv_Pn
+        = is_constant_all<T_y, T_scale_succ, T_scale_fail>::value ? 0 : inv(Pn);
 
     cdf_log += log(Pn);
 
     if (!is_constant_all<T_y>::value) {
       ops_partials.edge1_.partials_[n] += pow(1 - y_dbl, beta_dbl - 1)
-                                          * pow(y_dbl, alpha_dbl - 1)
-                                          / betafunc_dbl / Pn;
+                                          * pow(y_dbl, alpha_dbl - 1) * inv_Pn
+                                          / betafunc_dbl;
     }
 
     T_partials_return g1 = 0;
     T_partials_return g2 = 0;
 
     if (!is_constant_all<T_scale_succ, T_scale_fail>::value) {
-      grad_reg_inc_beta(g1, g2, alpha_dbl, beta_dbl, y_dbl,
-                        digamma_alpha_vec[n], digamma_beta_vec[n],
-                        digamma_sum_vec[n], betafunc_dbl);
+      grad_reg_inc_beta(g1, g2, alpha_dbl, beta_dbl, y_dbl, digamma_alpha[n],
+                        digamma_beta[n], digamma_sum[n], betafunc_dbl);
     }
     if (!is_constant_all<T_scale_succ>::value) {
-      ops_partials.edge2_.partials_[n] += g1 / Pn;
+      ops_partials.edge2_.partials_[n] += g1 * inv_Pn;
     }
     if (!is_constant_all<T_scale_fail>::value) {
-      ops_partials.edge3_.partials_[n] += g2 / Pn;
+      ops_partials.edge3_.partials_[n] += g2 * inv_Pn;
     }
   }
 

--- a/stan/math/prim/prob/beta_log.hpp
+++ b/stan/math/prim/prob/beta_log.hpp
@@ -2,31 +2,13 @@
 #define STAN_MATH_PRIM_PROB_BETA_LOG_HPP
 
 #include <stan/math/prim/meta.hpp>
-#include <stan/math/prim/fun/size.hpp>
 #include <stan/math/prim/prob/beta_lpdf.hpp>
 
 namespace stan {
 namespace math {
 
 /** \ingroup prob_dists
- * The log of the beta density for the specified scalar(s) given the specified
- * sample size(s). y, alpha, or beta can each either be scalar or a
- * vector. Any vector inputs must be the same length.
- *
- * <p> The result log probability is defined to be the sum of
- * the log probabilities for each observation/alpha/beta triple.
- *
- * Prior sample sizes, alpha and beta, must be greater than 0.
- *
  * @deprecated use <code>beta_lpdf</code>
- *
- * @param y (Sequence of) scalar(s).
- * @param alpha (Sequence of) prior sample size(s).
- * @param beta (Sequence of) prior sample size(s).
- * @return The log of the product of densities.
- * @tparam T_y Type of scalar outcome.
- * @tparam T_scale_succ Type of prior scale for successes.
- * @tparam T_scale_fail Type of prior scale for failures.
  */
 template <bool propto, typename T_y, typename T_scale_succ,
           typename T_scale_fail>

--- a/stan/math/prim/prob/beta_lpdf.hpp
+++ b/stan/math/prim/prob/beta_lpdf.hpp
@@ -64,6 +64,9 @@ return_type_t<T_y, T_scale_succ, T_scale_fail> beta_lpdf(
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_scale_succ> alpha_vec(alpha);
   scalar_seq_view<T_scale_fail> beta_vec(beta);
+  size_t size_y = stan::math::size(y);
+  size_t size_alpha = stan::math::size(alpha);
+  size_t size_beta = stan::math::size(beta);
   size_t N = max_size(y, alpha, beta);
 
   for (size_t n = 0; n < N; n++) {
@@ -78,12 +81,12 @@ return_type_t<T_y, T_scale_succ, T_scale_fail> beta_lpdf(
 
   VectorBuilder<include_summand<propto, T_y, T_scale_succ>::value,
                 T_partials_return, T_y>
-      log_y(size(y));
+      log_y(size_y);
   VectorBuilder<include_summand<propto, T_y, T_scale_fail>::value,
                 T_partials_return, T_y>
-      log1m_y(size(y));
+      log1m_y(size_y);
 
-  for (size_t n = 0; n < stan::math::size(y); n++) {
+  for (size_t n = 0; n < size_y; n++) {
     if (include_summand<propto, T_y, T_scale_succ>::value) {
       log_y[n] = log(value_of(y_vec[n]));
     }
@@ -94,51 +97,52 @@ return_type_t<T_y, T_scale_succ, T_scale_fail> beta_lpdf(
 
   VectorBuilder<include_summand<propto, T_scale_succ>::value, T_partials_return,
                 T_scale_succ>
-      lgamma_alpha(size(alpha));
+      lgamma_alpha(size_alpha);
   VectorBuilder<!is_constant_all<T_scale_succ>::value, T_partials_return,
                 T_scale_succ>
-      digamma_alpha(size(alpha));
-  for (size_t n = 0; n < stan::math::size(alpha); n++) {
-    if (include_summand<propto, T_scale_succ>::value) {
-      lgamma_alpha[n] = lgamma(value_of(alpha_vec[n]));
-    }
-    if (!is_constant_all<T_scale_succ>::value) {
-      digamma_alpha[n] = digamma(value_of(alpha_vec[n]));
+      digamma_alpha(size_alpha);
+  if (include_summand<propto, T_scale_succ>::value) {
+    for (size_t n = 0; n < size_alpha; n++) {
+      const T_partials_return alpha_dbl = value_of(alpha_vec[n]);
+      lgamma_alpha[n] = lgamma(alpha_dbl);
+      if (!is_constant_all<T_scale_succ>::value) {
+        digamma_alpha[n] = digamma(alpha_dbl);
+      }
     }
   }
 
   VectorBuilder<include_summand<propto, T_scale_fail>::value, T_partials_return,
                 T_scale_fail>
-      lgamma_beta(size(beta));
+      lgamma_beta(size_beta);
   VectorBuilder<!is_constant_all<T_scale_fail>::value, T_partials_return,
                 T_scale_fail>
-      digamma_beta(size(beta));
+      digamma_beta(size_beta);
 
-  for (size_t n = 0; n < stan::math::size(beta); n++) {
-    if (include_summand<propto, T_scale_fail>::value) {
-      lgamma_beta[n] = lgamma(value_of(beta_vec[n]));
-    }
-    if (!is_constant_all<T_scale_fail>::value) {
-      digamma_beta[n] = digamma(value_of(beta_vec[n]));
+  if (include_summand<propto, T_scale_fail>::value) {
+    for (size_t n = 0; n < size_beta; n++) {
+      const T_partials_return beta_dbl = value_of(beta_vec[n]);
+      lgamma_beta[n] = lgamma(beta_dbl);
+      if (!is_constant_all<T_scale_fail>::value) {
+        digamma_beta[n] = digamma(beta_dbl);
+      }
     }
   }
 
   VectorBuilder<include_summand<propto, T_scale_succ, T_scale_fail>::value,
                 T_partials_return, T_scale_succ, T_scale_fail>
       lgamma_alpha_beta(max_size(alpha, beta));
-
   VectorBuilder<!is_constant_all<T_scale_succ, T_scale_fail>::value,
                 T_partials_return, T_scale_succ, T_scale_fail>
       digamma_alpha_beta(max_size(alpha, beta));
 
-  for (size_t n = 0; n < max_size(alpha, beta); n++) {
-    const T_partials_return alpha_beta
-        = value_of(alpha_vec[n]) + value_of(beta_vec[n]);
-    if (include_summand<propto, T_scale_succ, T_scale_fail>::value) {
+  if (include_summand<propto, T_scale_succ, T_scale_fail>::value) {
+    for (size_t n = 0; n < max_size(alpha, beta); n++) {
+      const T_partials_return alpha_beta
+          = value_of(alpha_vec[n]) + value_of(beta_vec[n]);
       lgamma_alpha_beta[n] = lgamma(alpha_beta);
-    }
-    if (!is_constant_all<T_scale_succ, T_scale_fail>::value) {
-      digamma_alpha_beta[n] = digamma(alpha_beta);
+      if (!is_constant_all<T_scale_succ, T_scale_fail>::value) {
+        digamma_alpha_beta[n] = digamma(alpha_beta);
+      }
     }
   }
 

--- a/stan/math/prim/prob/beta_proportion_ccdf_log.hpp
+++ b/stan/math/prim/prob/beta_proportion_ccdf_log.hpp
@@ -8,26 +8,7 @@ namespace stan {
 namespace math {
 
 /** \ingroup prob_dists
- * Returns the beta log complementary cumulative distribution function
- * for specified probability, location, and precision parameters:
- * beta_proportion_lccdf(y | mu, kappa) = beta_lccdf(y | mu * kappa, (1 -
- * mu) * kappa).  Any arguments other than scalars must be containers of
- * the same size.  With non-scalar arguments, the return is the sum of
- * the log ccdfs with scalars broadcast as necessary.
- *
  * @deprecated use <code>beta_proportion_lccdf</code>
- *
- * @tparam T_y type of y
- * @tparam T_loc type of location parameter
- * @tparam T_prec type of precision parameter
- * @param y (Sequence of) scalar(s) between zero and one
- * @param mu (Sequence of) location parameter(s)
- * @param kappa (Sequence of) precision parameter(s)
- * @return log probability or sum of log of probabilities
- * @throw std::domain_error if mu is outside (0, 1)
- * @throw std::domain_error if kappa is nonpositive
- * @throw std::domain_error if 1 - y is not a valid probability
- * @throw std::invalid_argument if container sizes mismatch
  */
 template <typename T_y, typename T_loc, typename T_prec>
 return_type_t<T_y, T_loc, T_prec> beta_proportion_ccdf_log(

--- a/stan/math/prim/prob/beta_proportion_cdf_log.hpp
+++ b/stan/math/prim/prob/beta_proportion_cdf_log.hpp
@@ -8,26 +8,7 @@ namespace stan {
 namespace math {
 
 /** \ingroup prob_dists
- * Returns the beta log cumulative distribution function
- * for specified probability, location, and precision parameters:
- * beta_proportion_lcdf(y | mu, kappa) = beta_lcdf(y | mu * kappa, (1 -
- * mu) * kappa).  Any arguments other than scalars must be containers of
- * the same size.  With non-scalar arguments, the return is the sum of
- * the log cdfs with scalars broadcast as necessary.
- *
  * @deprecated use <code>beta_proportion_lcdf</code>
- *
- * @tparam T_y type of y
- * @tparam T_loc type of location parameter
- * @tparam T_prec type of precision parameter
- * @param y (Sequence of) scalar(s) between zero and one
- * @param mu (Sequence of) location parameter(s)
- * @param kappa (Sequence of) precision parameter(s)
- * @return log probability or sum of log of probabilities
- * @throw std::domain_error if mu is outside of (0, 1)
- * @throw std::domain_error if kappa is nonpositive
- * @throw std::domain_error if y is not a valid probability
- * @throw std::invalid_argument if container sizes mismatch
  */
 template <typename T_y, typename T_loc, typename T_prec>
 return_type_t<T_y, T_loc, T_prec> beta_proportion_cdf_log(const T_y& y,

--- a/stan/math/prim/prob/beta_proportion_lccdf.hpp
+++ b/stan/math/prim/prob/beta_proportion_lccdf.hpp
@@ -7,6 +7,7 @@
 #include <stan/math/prim/fun/beta.hpp>
 #include <stan/math/prim/fun/grad_reg_inc_beta.hpp>
 #include <stan/math/prim/fun/inc_beta.hpp>
+#include <stan/math/prim/fun/inv.hpp>
 #include <stan/math/prim/fun/log.hpp>
 #include <stan/math/prim/fun/max_size.hpp>
 #include <stan/math/prim/fun/size.hpp>
@@ -63,6 +64,8 @@ return_type_t<T_y, T_loc, T_prec> beta_proportion_lccdf(const T_y& y,
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_loc> mu_vec(mu);
   scalar_seq_view<T_prec> kappa_vec(kappa);
+  size_t size_kappa = stan::math::size(kappa);
+  size_t size_mu_kappa = max_size(mu, kappa);
   size_t N = max_size(y, mu, kappa);
 
   operands_and_partials<T_y, T_loc, T_prec> ops_partials(y, mu, kappa);
@@ -73,26 +76,23 @@ return_type_t<T_y, T_loc, T_prec> beta_proportion_lccdf(const T_y& y,
 
   VectorBuilder<!is_constant_all<T_loc, T_prec>::value, T_partials_return,
                 T_loc, T_prec>
-      digamma_mukappa(max_size(mu, kappa));
+      digamma_mukappa(size_mu_kappa);
   VectorBuilder<!is_constant_all<T_loc, T_prec>::value, T_partials_return,
                 T_loc, T_prec>
-      digamma_kappa_mukappa(max_size(mu, kappa));
+      digamma_kappa_mukappa(size_mu_kappa);
   VectorBuilder<!is_constant_all<T_loc, T_prec>::value, T_partials_return,
                 T_prec>
-      digamma_kappa(size(kappa));
+      digamma_kappa(size_kappa);
 
   if (!is_constant_all<T_loc, T_prec>::value) {
-    for (size_t i = 0; i < max_size(mu, kappa); i++) {
-      const T_partials_return mukappa_dbl
-          = value_of(mu_vec[i]) * value_of(kappa_vec[i]);
-      const T_partials_return kappa_mukappa_dbl
-          = value_of(kappa_vec[i]) - mukappa_dbl;
-
+    for (size_t i = 0; i < size_mu_kappa; i++) {
+      const T_partials_return kappa_dbl = value_of(kappa_vec[i]);
+      const T_partials_return mukappa_dbl = value_of(mu_vec[i]) * kappa_dbl;
       digamma_mukappa[i] = digamma(mukappa_dbl);
-      digamma_kappa_mukappa[i] = digamma(kappa_mukappa_dbl);
+      digamma_kappa_mukappa[i] = digamma(kappa_dbl - mukappa_dbl);
     }
 
-    for (size_t i = 0; i < stan::math::size(kappa); i++) {
+    for (size_t i = 0; i < size_kappa; i++) {
       digamma_kappa[i] = digamma(value_of(kappa_vec[i]));
     }
   }
@@ -109,10 +109,13 @@ return_type_t<T_y, T_loc, T_prec> beta_proportion_lccdf(const T_y& y,
 
     ccdf_log += log(Pn);
 
+    const T_partials_return inv_Pn
+        = is_constant_all<T_y, T_loc, T_prec>::value ? 0 : inv(Pn);
+
     if (!is_constant_all<T_y>::value) {
       ops_partials.edge1_.partials_[n] -= pow(1 - y_dbl, kappa_mukappa_dbl - 1)
-                                          * pow(y_dbl, mukappa_dbl - 1)
-                                          / betafunc_dbl / Pn;
+                                          * pow(y_dbl, mukappa_dbl - 1) * inv_Pn
+                                          / betafunc_dbl;
     }
 
     T_partials_return g1 = 0;
@@ -124,11 +127,11 @@ return_type_t<T_y, T_loc, T_prec> beta_proportion_lccdf(const T_y& y,
                         digamma_kappa[n], betafunc_dbl);
     }
     if (!is_constant_all<T_loc>::value) {
-      ops_partials.edge2_.partials_[n] -= kappa_dbl * (g1 - g2) / Pn;
+      ops_partials.edge2_.partials_[n] -= kappa_dbl * (g1 - g2) * inv_Pn;
     }
     if (!is_constant_all<T_prec>::value) {
       ops_partials.edge3_.partials_[n]
-          -= (g1 * mu_dbl + g2 * (1 - mu_dbl)) / Pn;
+          -= (g1 * mu_dbl + g2 * (1 - mu_dbl)) * inv_Pn;
     }
   }
   return ops_partials.build(ccdf_log);

--- a/stan/math/prim/prob/beta_proportion_lcdf.hpp
+++ b/stan/math/prim/prob/beta_proportion_lcdf.hpp
@@ -8,6 +8,7 @@
 #include <stan/math/prim/fun/digamma.hpp>
 #include <stan/math/prim/fun/grad_reg_inc_beta.hpp>
 #include <stan/math/prim/fun/inc_beta.hpp>
+#include <stan/math/prim/fun/inv.hpp>
 #include <stan/math/prim/fun/log.hpp>
 #include <stan/math/prim/fun/max_size.hpp>
 #include <stan/math/prim/fun/size.hpp>
@@ -64,6 +65,8 @@ return_type_t<T_y, T_loc, T_prec> beta_proportion_lcdf(const T_y& y,
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_loc> mu_vec(mu);
   scalar_seq_view<T_prec> kappa_vec(kappa);
+  size_t size_kappa = stan::math::size(kappa);
+  size_t size_mu_kappa = max_size(mu, kappa);
   size_t N = max_size(y, mu, kappa);
 
   operands_and_partials<T_y, T_loc, T_prec> ops_partials(y, mu, kappa);
@@ -74,26 +77,22 @@ return_type_t<T_y, T_loc, T_prec> beta_proportion_lcdf(const T_y& y,
 
   VectorBuilder<!is_constant_all<T_loc, T_prec>::value, T_partials_return,
                 T_loc, T_prec>
-      digamma_mukappa(max_size(mu, kappa));
+      digamma_mukappa(size_mu_kappa);
   VectorBuilder<!is_constant_all<T_loc, T_prec>::value, T_partials_return,
                 T_loc, T_prec>
-      digamma_kappa_mukappa(max_size(mu, kappa));
+      digamma_kappa_mukappa(size_mu_kappa);
   VectorBuilder<!is_constant_all<T_loc, T_prec>::value, T_partials_return,
                 T_prec>
-      digamma_kappa(size(kappa));
+      digamma_kappa(size_kappa);
 
   if (!is_constant_all<T_loc, T_prec>::value) {
-    for (size_t i = 0; i < max_size(mu, kappa); i++) {
-      const T_partials_return mukappa_dbl
-          = value_of(mu_vec[i]) * value_of(kappa_vec[i]);
-      const T_partials_return kappa_mukappa_dbl
-          = value_of(kappa_vec[i]) - mukappa_dbl;
-
+    for (size_t i = 0; i < size_mu_kappa; i++) {
+      const T_partials_return kappa_dbl = value_of(kappa_vec[i]);
+      const T_partials_return mukappa_dbl = value_of(mu_vec[i]) * kappa_dbl;
       digamma_mukappa[i] = digamma(mukappa_dbl);
-      digamma_kappa_mukappa[i] = digamma(kappa_mukappa_dbl);
+      digamma_kappa_mukappa[i] = digamma(kappa_dbl - mukappa_dbl);
     }
-
-    for (size_t i = 0; i < stan::math::size(kappa); i++) {
+    for (size_t i = 0; i < size_kappa; i++) {
       digamma_kappa[i] = digamma(value_of(kappa_vec[i]));
     }
   }
@@ -110,10 +109,13 @@ return_type_t<T_y, T_loc, T_prec> beta_proportion_lcdf(const T_y& y,
 
     cdf_log += log(Pn);
 
+    const T_partials_return inv_Pn
+        = is_constant_all<T_y, T_loc, T_prec>::value ? 0 : inv(Pn);
+
     if (!is_constant_all<T_y>::value) {
       ops_partials.edge1_.partials_[n] += pow(1 - y_dbl, kappa_mukappa_dbl - 1)
-                                          * pow(y_dbl, mukappa_dbl - 1)
-                                          / betafunc_dbl / Pn;
+                                          * pow(y_dbl, mukappa_dbl - 1) * inv_Pn
+                                          / betafunc_dbl;
     }
 
     T_partials_return g1 = 0;
@@ -125,11 +127,11 @@ return_type_t<T_y, T_loc, T_prec> beta_proportion_lcdf(const T_y& y,
                         digamma_kappa[n], betafunc_dbl);
     }
     if (!is_constant_all<T_loc>::value) {
-      ops_partials.edge2_.partials_[n] += kappa_dbl * (g1 - g2) / Pn;
+      ops_partials.edge2_.partials_[n] += kappa_dbl * (g1 - g2) * inv_Pn;
     }
     if (!is_constant_all<T_prec>::value) {
       ops_partials.edge3_.partials_[n]
-          += (g1 * mu_dbl + g2 * (1 - mu_dbl)) / Pn;
+          += (g1 * mu_dbl + g2 * (1 - mu_dbl)) * inv_Pn;
     }
   }
 

--- a/stan/math/prim/prob/beta_proportion_log.hpp
+++ b/stan/math/prim/prob/beta_proportion_log.hpp
@@ -8,27 +8,7 @@ namespace stan {
 namespace math {
 
 /** \ingroup prob_dists
- * The log of the beta density for specified y, location, and
- * precision: beta_proportion_lpdf(y | mu, kappa) = beta_lpdf(y | mu *
- * kappa, (1 - mu) * kappa).  Any arguments other than scalars must be
- * containers of the same size.  With non-scalar arguments, the return
- * is the sum of the log pdfs with scalars broadcast as necessary.
- *
- * <p> The result log probability is defined to be the sum of
- * the log probabilities for each observation/mu/kappa triple.
- *
- * Prior location, mu, must be contained in (0, 1).  Prior precision
- * must be positive.
- *
  * @deprecated use <code>beta_proportion_lpdf</code>
- *
- * @param y (Sequence of) scalar(s) between zero and one
- * @param mu (Sequence of) location parameter(s)
- * @param kappa (Sequence of) precision parameter(s)
- * @return The log of the product of densities.
- * @tparam T_y Type of scalar outcome.
- * @tparam T_loc Type of prior location.
- * @tparam T_prec Type of prior precision.
  */
 template <bool propto, typename T_y, typename T_loc, typename T_prec>
 return_type_t<T_y, T_loc, T_prec> beta_proportion_log(const T_y& y,

--- a/stan/math/prim/prob/binomial_cdf.hpp
+++ b/stan/math/prim/prob/binomial_cdf.hpp
@@ -68,25 +68,26 @@ return_type_t<T_prob> binomial_cdf(const T_n& n, const T_N& N,
   }
 
   for (size_t i = 0; i < max_size_seq_view; i++) {
+    const T_partials_return n_dbl = value_of(n_vec[i]);
+    const T_partials_return N_dbl = value_of(N_vec[i]);
+
     // Explicit results for extreme values
     // The gradients are technically ill-defined, but treated as zero
-    if (value_of(n_vec[i]) >= value_of(N_vec[i])) {
+    if (n_dbl >= N_dbl) {
       continue;
     }
 
-    const T_partials_return n_dbl = value_of(n_vec[i]);
-    const T_partials_return N_dbl = value_of(N_vec[i]);
     const T_partials_return theta_dbl = value_of(theta_vec[i]);
-    const T_partials_return betafunc = beta(N_dbl - n_dbl, n_dbl + 1);
     const T_partials_return Pi
         = inc_beta(N_dbl - n_dbl, n_dbl + 1, 1 - theta_dbl);
 
     P *= Pi;
 
     if (!is_constant_all<T_prob>::value) {
+      const T_partials_return denom = beta(N_dbl - n_dbl, n_dbl + 1) * Pi;
       ops_partials.edge1_.partials_[i]
           -= pow(theta_dbl, n_dbl) * pow(1 - theta_dbl, N_dbl - n_dbl - 1)
-             / betafunc / Pi;
+             / denom;
     }
   }
 

--- a/stan/math/prim/prob/binomial_lccdf.hpp
+++ b/stan/math/prim/prob/binomial_lccdf.hpp
@@ -72,24 +72,26 @@ return_type_t<T_prob> binomial_lccdf(const T_n& n, const T_N& N,
   }
 
   for (size_t i = 0; i < max_size_seq_view; i++) {
-    // Explicit results for extreme values
-    // The gradients are technically ill-defined, but treated as zero
-    if (value_of(n_vec[i]) >= value_of(N_vec[i])) {
-      return ops_partials.build(negative_infinity());
-    }
     const T_partials_return n_dbl = value_of(n_vec[i]);
     const T_partials_return N_dbl = value_of(N_vec[i]);
+
+    // Explicit results for extreme values
+    // The gradients are technically ill-defined, but treated as zero
+    if (n_dbl >= N_dbl) {
+      return ops_partials.build(NEGATIVE_INFTY);
+    }
+
     const T_partials_return theta_dbl = value_of(theta_vec[i]);
-    const T_partials_return betafunc = beta(N_dbl - n_dbl, n_dbl + 1);
     const T_partials_return Pi
         = 1.0 - inc_beta(N_dbl - n_dbl, n_dbl + 1, 1 - theta_dbl);
 
     P += log(Pi);
 
     if (!is_constant_all<T_prob>::value) {
+      const T_partials_return denom = beta(N_dbl - n_dbl, n_dbl + 1) * Pi;
       ops_partials.edge1_.partials_[i]
           += pow(theta_dbl, n_dbl) * pow(1 - theta_dbl, N_dbl - n_dbl - 1)
-             / betafunc / Pi;
+             / denom;
     }
   }
 

--- a/stan/math/prim/prob/binomial_lcdf.hpp
+++ b/stan/math/prim/prob/binomial_lcdf.hpp
@@ -67,29 +67,31 @@ return_type_t<T_prob> binomial_lcdf(const T_n& n, const T_N& N,
   // but treated as negative infinity
   for (size_t i = 0; i < stan::math::size(n); i++) {
     if (value_of(n_vec[i]) < 0) {
-      return ops_partials.build(negative_infinity());
+      return ops_partials.build(NEGATIVE_INFTY);
     }
   }
 
   for (size_t i = 0; i < max_size_seq_view; i++) {
-    // Explicit results for extreme values
-    // The gradients are technically ill-defined, but treated as zero
-    if (value_of(n_vec[i]) >= value_of(N_vec[i])) {
-      continue;
-    }
     const T_partials_return n_dbl = value_of(n_vec[i]);
     const T_partials_return N_dbl = value_of(N_vec[i]);
+
+    // Explicit results for extreme values
+    // The gradients are technically ill-defined, but treated as zero
+    if (n_dbl >= N_dbl) {
+      continue;
+    }
+
     const T_partials_return theta_dbl = value_of(theta_vec[i]);
-    const T_partials_return betafunc = beta(N_dbl - n_dbl, n_dbl + 1);
     const T_partials_return Pi
         = inc_beta(N_dbl - n_dbl, n_dbl + 1, 1 - theta_dbl);
 
     P += log(Pi);
 
     if (!is_constant_all<T_prob>::value) {
+      const T_partials_return denom = beta(N_dbl - n_dbl, n_dbl + 1) * Pi;
       ops_partials.edge1_.partials_[i]
           -= pow(theta_dbl, n_dbl) * pow(1 - theta_dbl, N_dbl - n_dbl - 1)
-             / betafunc / Pi;
+             / denom;
     }
   }
   return ops_partials.build(P);

--- a/stan/math/prim/prob/binomial_logit_lpmf.hpp
+++ b/stan/math/prim/prob/binomial_logit_lpmf.hpp
@@ -7,7 +7,7 @@
 #include <stan/math/prim/fun/inc_beta.hpp>
 #include <stan/math/prim/fun/inv_logit.hpp>
 #include <stan/math/prim/fun/lbeta.hpp>
-#include <stan/math/prim/fun/log_inv_logit.hpp>
+#include <stan/math/prim/fun/log.hpp>
 #include <stan/math/prim/fun/max_size.hpp>
 #include <stan/math/prim/fun/size.hpp>
 #include <stan/math/prim/fun/size_zero.hpp>
@@ -25,9 +25,7 @@ namespace math {
  * @param n successes variable
  * @param N population size parameter
  * @param alpha logit transformed probability parameter
- *
  * @return log probability or log sum of probabilities
- *
  * @throw std::domain_error if N is negative or probability parameter is invalid
  * @throw std::invalid_argument if vector sizes do not match
  */
@@ -54,9 +52,12 @@ return_type_t<T_prob> binomial_logit_lpmf(const T_n& n, const T_N& N,
     return 0.0;
   }
 
+  using std::log;
+
   scalar_seq_view<T_n> n_vec(n);
   scalar_seq_view<T_N> N_vec(N);
   scalar_seq_view<T_prob> alpha_vec(alpha);
+  size_t size_alpha = stan::math::size(alpha);
   size_t max_size_seq_view = max_size(n, N, alpha);
 
   operands_and_partials<T_prob> ops_partials(alpha);
@@ -67,16 +68,20 @@ return_type_t<T_prob> binomial_logit_lpmf(const T_n& n, const T_N& N,
     }
   }
 
+  VectorBuilder<true, T_partials_return, T_prob> inv_logit_alpha(size_alpha);
+  VectorBuilder<true, T_partials_return, T_prob> inv_logit_neg_alpha(
+      size_alpha);
   VectorBuilder<true, T_partials_return, T_prob> log_inv_logit_alpha(
-      stan::math::size(alpha));
-  for (size_t i = 0; i < stan::math::size(alpha); ++i) {
-    log_inv_logit_alpha[i] = log_inv_logit(value_of(alpha_vec[i]));
-  }
-
+      size_alpha);
   VectorBuilder<true, T_partials_return, T_prob> log_inv_logit_neg_alpha(
-      stan::math::size(alpha));
-  for (size_t i = 0; i < stan::math::size(alpha); ++i) {
-    log_inv_logit_neg_alpha[i] = log_inv_logit(-value_of(alpha_vec[i]));
+      size_alpha);
+
+  for (size_t i = 0; i < size_alpha; ++i) {
+    const T_partials_return alpha_dbl = value_of(alpha_vec[i]);
+    inv_logit_alpha[i] = inv_logit(alpha_dbl);
+    inv_logit_neg_alpha[i] = inv_logit(-alpha_dbl);
+    log_inv_logit_alpha[i] = log(inv_logit_alpha[i]);
+    log_inv_logit_neg_alpha[i] = log(inv_logit_neg_alpha[i]);
   }
 
   for (size_t i = 0; i < max_size_seq_view; ++i) {
@@ -84,24 +89,22 @@ return_type_t<T_prob> binomial_logit_lpmf(const T_n& n, const T_N& N,
             + (N_vec[i] - n_vec[i]) * log_inv_logit_neg_alpha[i];
   }
 
-  if (size(alpha) == 1) {
-    T_partials_return temp1 = 0;
-    T_partials_return temp2 = 0;
-    for (size_t i = 0; i < max_size_seq_view; ++i) {
-      temp1 += n_vec[i];
-      temp2 += N_vec[i] - n_vec[i];
-    }
-    if (!is_constant_all<T_prob>::value) {
+  if (!is_constant_all<T_prob>::value) {
+    if (size_alpha == 1) {
+      T_partials_return sum_n = 0;
+      T_partials_return sum_N = 0;
+      for (size_t i = 0; i < max_size_seq_view; ++i) {
+        sum_n += n_vec[i];
+        sum_N += N_vec[i];
+      }
       ops_partials.edge1_.partials_[0]
-          += temp1 * inv_logit(-value_of(alpha_vec[0]))
-             - temp2 * inv_logit(value_of(alpha_vec[0]));
-    }
-  } else {
-    if (!is_constant_all<T_prob>::value) {
+          += sum_n * inv_logit_neg_alpha[0]
+             - (sum_N - sum_n) * inv_logit_alpha[0];
+    } else {
       for (size_t i = 0; i < max_size_seq_view; ++i) {
         ops_partials.edge1_.partials_[i]
-            += n_vec[i] * inv_logit(-value_of(alpha_vec[i]))
-               - (N_vec[i] - n_vec[i]) * inv_logit(value_of(alpha_vec[i]));
+            += n_vec[i] * inv_logit_neg_alpha[i]
+               - (N_vec[i] - n_vec[i]) * inv_logit_alpha[i];
       }
     }
   }

--- a/stan/math/prim/prob/double_exponential_cdf.hpp
+++ b/stan/math/prim/prob/double_exponential_cdf.hpp
@@ -4,6 +4,7 @@
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/err.hpp>
 #include <stan/math/prim/fun/exp.hpp>
+#include <stan/math/prim/fun/inv.hpp>
 #include <stan/math/prim/fun/max_size.hpp>
 #include <stan/math/prim/fun/size_zero.hpp>
 #include <stan/math/prim/fun/value_of.hpp>
@@ -49,19 +50,28 @@ return_type_t<T_y, T_loc, T_scale> double_exponential_cdf(
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_loc> mu_vec(mu);
   scalar_seq_view<T_scale> sigma_vec(sigma);
+  size_t size_sigma = stan::math::size(sigma);
   size_t N = max_size(y, mu, sigma);
+
+  VectorBuilder<true, T_partials_return, T_scale> inv_sigma(size_sigma);
+  for (size_t i = 0; i < size_sigma; i++) {
+    inv_sigma[i] = inv(value_of(sigma_vec[i]));
+  }
+
+  VectorBuilder<true, T_partials_return, T_y, T_loc, T_scale> scaled_diff(N);
+  VectorBuilder<true, T_partials_return, T_y, T_loc, T_scale> exp_scaled_diff(
+      N);
 
   for (size_t n = 0; n < N; n++) {
     const T_partials_return y_dbl = value_of(y_vec[n]);
     const T_partials_return mu_dbl = value_of(mu_vec[n]);
-    const T_partials_return sigma_dbl = value_of(sigma_vec[n]);
-    const T_partials_return scaled_diff = (y_dbl - mu_dbl) / (sigma_dbl);
-    const T_partials_return exp_scaled_diff = exp(scaled_diff);
+    scaled_diff[n] = (y_dbl - mu_dbl) * inv_sigma[n];
+    exp_scaled_diff[n] = exp(scaled_diff[n]);
 
     if (y_dbl < mu_dbl) {
-      cdf *= exp_scaled_diff * 0.5;
+      cdf *= exp_scaled_diff[n] * 0.5;
     } else {
-      cdf *= 1.0 - 0.5 / exp_scaled_diff;
+      cdf *= 1.0 - 0.5 / exp_scaled_diff[n];
     }
   }
 
@@ -69,32 +79,19 @@ return_type_t<T_y, T_loc, T_scale> double_exponential_cdf(
     const T_partials_return y_dbl = value_of(y_vec[n]);
     const T_partials_return mu_dbl = value_of(mu_vec[n]);
     const T_partials_return sigma_dbl = value_of(sigma_vec[n]);
-    const T_partials_return scaled_diff = (y_dbl - mu_dbl) / sigma_dbl;
-    const T_partials_return exp_scaled_diff = exp(scaled_diff);
-    const T_partials_return inv_sigma = 1.0 / sigma_dbl;
 
-    if (y_dbl < mu_dbl) {
-      if (!is_constant_all<T_y>::value) {
-        ops_partials.edge1_.partials_[n] += inv_sigma * cdf;
-      }
-      if (!is_constant_all<T_loc>::value) {
-        ops_partials.edge2_.partials_[n] -= inv_sigma * cdf;
-      }
-      if (!is_constant_all<T_scale>::value) {
-        ops_partials.edge3_.partials_[n] -= scaled_diff * inv_sigma * cdf;
-      }
-    } else {
-      const T_partials_return rep_deriv
-          = cdf * inv_sigma / (2.0 * exp_scaled_diff - 1.0);
-      if (!is_constant_all<T_y>::value) {
-        ops_partials.edge1_.partials_[n] += rep_deriv;
-      }
-      if (!is_constant_all<T_loc>::value) {
-        ops_partials.edge2_.partials_[n] -= rep_deriv;
-      }
-      if (!is_constant_all<T_scale>::value) {
-        ops_partials.edge3_.partials_[n] -= rep_deriv * scaled_diff;
-      }
+    const T_partials_return rep_deriv
+        = y_dbl < mu_dbl ? cdf * inv_sigma[n]
+                         : cdf * inv_sigma[n] / (2 * exp_scaled_diff[n] - 1);
+
+    if (!is_constant_all<T_y>::value) {
+      ops_partials.edge1_.partials_[n] += rep_deriv;
+    }
+    if (!is_constant_all<T_loc>::value) {
+      ops_partials.edge2_.partials_[n] -= rep_deriv;
+    }
+    if (!is_constant_all<T_scale>::value) {
+      ops_partials.edge3_.partials_[n] -= rep_deriv * scaled_diff[n];
     }
   }
   return ops_partials.build(cdf);

--- a/stan/math/prim/prob/double_exponential_lccdf.hpp
+++ b/stan/math/prim/prob/double_exponential_lccdf.hpp
@@ -5,6 +5,7 @@
 #include <stan/math/prim/err.hpp>
 #include <stan/math/prim/fun/constants.hpp>
 #include <stan/math/prim/fun/exp.hpp>
+#include <stan/math/prim/fun/inv.hpp>
 #include <stan/math/prim/fun/log1m.hpp>
 #include <stan/math/prim/fun/max_size.hpp>
 #include <stan/math/prim/fun/size_zero.hpp>
@@ -55,39 +56,37 @@ return_type_t<T_y, T_loc, T_scale> double_exponential_lccdf(
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_loc> mu_vec(mu);
   scalar_seq_view<T_scale> sigma_vec(sigma);
+  size_t size_sigma = stan::math::size(sigma);
   size_t N = max_size(y, mu, sigma);
+
+  VectorBuilder<true, T_partials_return, T_scale> inv_sigma(size_sigma);
+  for (size_t i = 0; i < size_sigma; i++) {
+    inv_sigma[i] = inv(value_of(sigma_vec[i]));
+  }
 
   for (size_t n = 0; n < N; n++) {
     const T_partials_return y_dbl = value_of(y_vec[n]);
     const T_partials_return mu_dbl = value_of(mu_vec[n]);
-    const T_partials_return sigma_dbl = value_of(sigma_vec[n]);
-    const T_partials_return scaled_diff = (y_dbl - mu_dbl) / sigma_dbl;
-    const T_partials_return inv_sigma = 1.0 / sigma_dbl;
+    const T_partials_return scaled_diff = (y_dbl - mu_dbl) * inv_sigma[n];
+
+    const T_partials_return rep_deriv
+        = y_dbl < mu_dbl ? inv_sigma[n] * inv(2 * exp(-scaled_diff) - 1)
+                         : inv_sigma[n];
+
     if (y_dbl < mu_dbl) {
       ccdf_log += log1m(0.5 * exp(scaled_diff));
-
-      const T_partials_return rep_deriv = 1.0 / (2.0 * exp(-scaled_diff) - 1.0);
-      if (!is_constant_all<T_y>::value) {
-        ops_partials.edge1_.partials_[n] -= rep_deriv * inv_sigma;
-      }
-      if (!is_constant_all<T_loc>::value) {
-        ops_partials.edge2_.partials_[n] += rep_deriv * inv_sigma;
-      }
-      if (!is_constant_all<T_scale>::value) {
-        ops_partials.edge3_.partials_[n] += rep_deriv * scaled_diff * inv_sigma;
-      }
     } else {
       ccdf_log += LOG_HALF - scaled_diff;
+    }
 
-      if (!is_constant_all<T_y>::value) {
-        ops_partials.edge1_.partials_[n] -= inv_sigma;
-      }
-      if (!is_constant_all<T_loc>::value) {
-        ops_partials.edge2_.partials_[n] += inv_sigma;
-      }
-      if (!is_constant_all<T_scale>::value) {
-        ops_partials.edge3_.partials_[n] += scaled_diff * inv_sigma;
-      }
+    if (!is_constant_all<T_y>::value) {
+      ops_partials.edge1_.partials_[n] -= rep_deriv;
+    }
+    if (!is_constant_all<T_loc>::value) {
+      ops_partials.edge2_.partials_[n] += rep_deriv;
+    }
+    if (!is_constant_all<T_scale>::value) {
+      ops_partials.edge3_.partials_[n] += rep_deriv * scaled_diff;
     }
   }
   return ops_partials.build(ccdf_log);

--- a/stan/math/prim/prob/double_exponential_lcdf.hpp
+++ b/stan/math/prim/prob/double_exponential_lcdf.hpp
@@ -5,6 +5,7 @@
 #include <stan/math/prim/err.hpp>
 #include <stan/math/prim/fun/constants.hpp>
 #include <stan/math/prim/fun/exp.hpp>
+#include <stan/math/prim/fun/inv.hpp>
 #include <stan/math/prim/fun/log1m.hpp>
 #include <stan/math/prim/fun/max_size.hpp>
 #include <stan/math/prim/fun/size_zero.hpp>
@@ -54,39 +55,37 @@ return_type_t<T_y, T_loc, T_scale> double_exponential_lcdf(
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_loc> mu_vec(mu);
   scalar_seq_view<T_scale> sigma_vec(sigma);
+  size_t size_sigma = stan::math::size(sigma);
   size_t N = max_size(y, mu, sigma);
+
+  VectorBuilder<true, T_partials_return, T_scale> inv_sigma(size_sigma);
+  for (size_t i = 0; i < size_sigma; i++) {
+    inv_sigma[i] = inv(value_of(sigma_vec[i]));
+  }
 
   for (size_t n = 0; n < N; n++) {
     const T_partials_return y_dbl = value_of(y_vec[n]);
     const T_partials_return mu_dbl = value_of(mu_vec[n]);
-    const T_partials_return sigma_dbl = value_of(sigma_vec[n]);
-    const T_partials_return scaled_diff = (y_dbl - mu_dbl) / sigma_dbl;
-    const T_partials_return inv_sigma = 1.0 / sigma_dbl;
+    const T_partials_return scaled_diff = (y_dbl - mu_dbl) * inv_sigma[n];
+
+    const T_partials_return rep_deriv
+        = y_dbl < mu_dbl ? inv_sigma[n]
+                         : inv_sigma[n] * inv(2 * exp(scaled_diff) - 1);
+
     if (y_dbl < mu_dbl) {
       cdf_log += LOG_HALF + scaled_diff;
-
-      if (!is_constant_all<T_y>::value) {
-        ops_partials.edge1_.partials_[n] += inv_sigma;
-      }
-      if (!is_constant_all<T_loc>::value) {
-        ops_partials.edge2_.partials_[n] -= inv_sigma;
-      }
-      if (!is_constant_all<T_scale>::value) {
-        ops_partials.edge3_.partials_[n] -= scaled_diff * inv_sigma;
-      }
     } else {
       cdf_log += log1m(0.5 * exp(-scaled_diff));
+    }
 
-      const T_partials_return rep_deriv = 1.0 / (2.0 * exp(scaled_diff) - 1.0);
-      if (!is_constant_all<T_y>::value) {
-        ops_partials.edge1_.partials_[n] += rep_deriv * inv_sigma;
-      }
-      if (!is_constant_all<T_loc>::value) {
-        ops_partials.edge2_.partials_[n] -= rep_deriv * inv_sigma;
-      }
-      if (!is_constant_all<T_scale>::value) {
-        ops_partials.edge3_.partials_[n] -= rep_deriv * scaled_diff * inv_sigma;
-      }
+    if (!is_constant_all<T_y>::value) {
+      ops_partials.edge1_.partials_[n] += rep_deriv;
+    }
+    if (!is_constant_all<T_loc>::value) {
+      ops_partials.edge2_.partials_[n] -= rep_deriv;
+    }
+    if (!is_constant_all<T_scale>::value) {
+      ops_partials.edge3_.partials_[n] -= rep_deriv * scaled_diff;
     }
   }
   return ops_partials.build(cdf_log);

--- a/stan/math/prim/prob/double_exponential_lpdf.hpp
+++ b/stan/math/prim/prob/double_exponential_lpdf.hpp
@@ -5,6 +5,7 @@
 #include <stan/math/prim/err.hpp>
 #include <stan/math/prim/fun/constants.hpp>
 #include <stan/math/prim/fun/fabs.hpp>
+#include <stan/math/prim/fun/inv.hpp>
 #include <stan/math/prim/fun/max_size.hpp>
 #include <stan/math/prim/fun/log.hpp>
 #include <stan/math/prim/fun/sign.hpp>
@@ -57,34 +58,27 @@ return_type_t<T_y, T_loc, T_scale> double_exponential_lpdf(
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_loc> mu_vec(mu);
   scalar_seq_view<T_scale> sigma_vec(sigma);
+  size_t size_sigma = stan::math::size(sigma);
   size_t N = max_size(y, mu, sigma);
   operands_and_partials<T_y, T_loc, T_scale> ops_partials(y, mu, sigma);
 
-  VectorBuilder<include_summand<propto, T_y, T_loc, T_scale>::value,
-                T_partials_return, T_scale>
-      inv_sigma(size(sigma));
-  VectorBuilder<!is_constant_all<T_scale>::value, T_partials_return, T_scale>
-      inv_sigma_squared(size(sigma));
+  VectorBuilder<true, T_partials_return, T_scale> inv_sigma(size_sigma);
   VectorBuilder<include_summand<propto, T_scale>::value, T_partials_return,
                 T_scale>
-      log_sigma(size(sigma));
-  for (size_t i = 0; i < stan::math::size(sigma); i++) {
+      log_sigma(size_sigma);
+  for (size_t i = 0; i < size_sigma; i++) {
     const T_partials_return sigma_dbl = value_of(sigma_vec[i]);
-    inv_sigma[i] = 1.0 / sigma_dbl;
+    inv_sigma[i] = inv(sigma_dbl);
     if (include_summand<propto, T_scale>::value) {
-      log_sigma[i] = log(value_of(sigma_vec[i]));
-    }
-    if (!is_constant_all<T_scale>::value) {
-      inv_sigma_squared[i] = inv_sigma[i] * inv_sigma[i];
+      log_sigma[i] = log(sigma_dbl);
     }
   }
 
   for (size_t n = 0; n < N; n++) {
     const T_partials_return y_dbl = value_of(y_vec[n]);
     const T_partials_return mu_dbl = value_of(mu_vec[n]);
-
     const T_partials_return y_m_mu = y_dbl - mu_dbl;
-    const T_partials_return fabs_y_m_mu = fabs(y_m_mu);
+    const T_partials_return scaled_diff = fabs(y_m_mu) * inv_sigma[n];
 
     if (include_summand<propto>::value) {
       logp -= LOG_TWO;
@@ -92,21 +86,18 @@ return_type_t<T_y, T_loc, T_scale> double_exponential_lpdf(
     if (include_summand<propto, T_scale>::value) {
       logp -= log_sigma[n];
     }
-    logp -= fabs_y_m_mu * inv_sigma[n];
+    logp -= scaled_diff;
 
-    T_partials_return sign_y_m_mu_times_inv_sigma(0);
-    if (!is_constant_all<T_y, T_loc>::value) {
-      sign_y_m_mu_times_inv_sigma = sign(y_m_mu) * inv_sigma[n];
-    }
+    T_partials_return rep_deriv
+        = is_constant_all<T_y, T_loc>::value ? 0 : sign(y_m_mu) * inv_sigma[n];
     if (!is_constant_all<T_y>::value) {
-      ops_partials.edge1_.partials_[n] -= sign_y_m_mu_times_inv_sigma;
+      ops_partials.edge1_.partials_[n] -= rep_deriv;
     }
     if (!is_constant_all<T_loc>::value) {
-      ops_partials.edge2_.partials_[n] += sign_y_m_mu_times_inv_sigma;
+      ops_partials.edge2_.partials_[n] += rep_deriv;
     }
     if (!is_constant_all<T_scale>::value) {
-      ops_partials.edge3_.partials_[n]
-          += -inv_sigma[n] + fabs_y_m_mu * inv_sigma_squared[n];
+      ops_partials.edge3_.partials_[n] -= inv_sigma[n] * (1 - scaled_diff);
     }
   }
   return ops_partials.build(logp);

--- a/stan/math/prim/prob/exp_mod_normal_cdf.hpp
+++ b/stan/math/prim/prob/exp_mod_normal_cdf.hpp
@@ -23,7 +23,6 @@ return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_cdf(
     const T_y& y, const T_loc& mu, const T_scale& sigma,
     const T_inv_scale& lambda) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale, T_inv_scale>;
-
   static const char* function = "exp_mod_normal_cdf";
 
   T_partials_return cdf(1.0);
@@ -50,9 +49,10 @@ return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_cdf(
   scalar_seq_view<T_loc> mu_vec(mu);
   scalar_seq_view<T_scale> sigma_vec(sigma);
   scalar_seq_view<T_inv_scale> lambda_vec(lambda);
+  size_t size_y = stan::math::size(y);
   size_t N = max_size(y, mu, sigma, lambda);
 
-  for (size_t n = 0, size_y = stan::math::size(y); n < size_y; n++) {
+  for (size_t n = 0; n < size_y; n++) {
     if (is_inf(y_vec[n]) && y_vec[n] < 0.0) {
       return ops_partials.build(0.0);
     }
@@ -65,23 +65,22 @@ return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_cdf(
     const T_partials_return lambda_dbl = value_of(lambda_vec[n]);
     const T_partials_return inv_sigma = inv(sigma_dbl);
     const T_partials_return diff = y_dbl - mu_dbl;
-    const T_partials_return scaled_diff = diff * INV_SQRT_TWO * inv_sigma;
     const T_partials_return u = lambda_dbl * diff;
     const T_partials_return v = lambda_dbl * sigma_dbl;
-    const T_partials_return v_over_sqrt_two = v * INV_SQRT_TWO;
-    const T_partials_return erf_calc
-        = 0.5 * (1 + erf(-v_over_sqrt_two + scaled_diff));
+    const T_partials_return scaled_diff = diff * INV_SQRT_TWO * inv_sigma;
+    const T_partials_return scaled_diff_diff = scaled_diff - v * INV_SQRT_TWO;
+    const T_partials_return erf_calc = 0.5 * (1 + erf(scaled_diff_diff));
     const T_partials_return exp_term = exp(0.5 * square(v) - u);
+    const T_partials_return exp_term_2 = exp(-square(scaled_diff_diff));
 
     const T_partials_return deriv_1 = lambda_dbl * exp_term * erf_calc;
     const T_partials_return deriv_2
-        = INV_SQRT_TWO_PI * exp_term
-          * exp(-square(scaled_diff - v_over_sqrt_two)) * inv_sigma;
+        = INV_SQRT_TWO_PI * exp_term * exp_term_2 * inv_sigma;
     const T_partials_return deriv_3
         = INV_SQRT_TWO_PI * exp(-square(scaled_diff)) * inv_sigma;
 
     const T_partials_return cdf_n
-        = 0.5 + 0.5 * erf(u / (v * SQRT_TWO)) - exp_term * erf_calc;
+        = 0.5 + 0.5 * erf(scaled_diff) - exp_term * erf_calc;
 
     cdf *= cdf_n;
 
@@ -93,22 +92,21 @@ return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_cdf(
     }
     if (!is_constant_all<T_scale>::value) {
       ops_partials.edge3_.partials_[n]
-          -= (deriv_1 * v + deriv_3 * scaled_diff * SQRT_TWO
-              - deriv_2 * (v + SQRT_TWO * scaled_diff))
+          -= ((deriv_1 - deriv_2) * v
+              + (deriv_3 - deriv_2) * scaled_diff * SQRT_TWO)
              / cdf_n;
     }
     if (!is_constant_all<T_inv_scale>::value) {
       ops_partials.edge4_.partials_[n]
           += exp_term
-             * (INV_SQRT_TWO_PI * sigma_dbl
-                    * exp(-square(v_over_sqrt_two - scaled_diff))
+             * (INV_SQRT_TWO_PI * sigma_dbl * exp_term_2
                 - (v * sigma_dbl - diff) * erf_calc)
              / cdf_n;
     }
   }
 
   if (!is_constant_all<T_y>::value) {
-    for (size_t n = 0; n < stan::math::size(y); ++n) {
+    for (size_t n = 0; n < size_y; ++n) {
       ops_partials.edge1_.partials_[n] *= cdf;
     }
   }

--- a/stan/math/prim/prob/exp_mod_normal_lccdf.hpp
+++ b/stan/math/prim/prob/exp_mod_normal_lccdf.hpp
@@ -68,21 +68,20 @@ return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_lccdf(
     const T_partials_return diff = y_dbl - mu_dbl;
     const T_partials_return u = lambda_dbl * diff;
     const T_partials_return v = lambda_dbl * sigma_dbl;
-    const T_partials_return v_over_sqrt_two = v * INV_SQRT_TWO;
     const T_partials_return scaled_diff = diff * INV_SQRT_TWO * inv_sigma;
-    const T_partials_return erf_calc
-        = 0.5 * (1 + erf(u / (v * SQRT_TWO) - v_over_sqrt_two));
+    const T_partials_return scaled_diff_diff = scaled_diff - v * INV_SQRT_TWO;
+    const T_partials_return erf_calc = 0.5 * (1 + erf(scaled_diff_diff));
     const T_partials_return exp_term = exp(0.5 * square(v) - u);
+    const T_partials_return exp_term_2 = exp(-square(scaled_diff_diff));
 
     const T_partials_return deriv_1 = lambda_dbl * exp_term * erf_calc;
     const T_partials_return deriv_2
-        = INV_SQRT_TWO_PI * exp_term
-          * exp(-square(-scaled_diff + v_over_sqrt_two)) * inv_sigma;
+        = INV_SQRT_TWO_PI * exp_term * exp_term_2 * inv_sigma;
     const T_partials_return deriv_3
         = INV_SQRT_TWO_PI * exp(-square(scaled_diff)) * inv_sigma;
 
     const T_partials_return ccdf_n
-        = 0.5 - 0.5 * erf(u / (v * SQRT_TWO)) + exp_term * erf_calc;
+        = 0.5 - 0.5 * erf(scaled_diff) + exp_term * erf_calc;
 
     ccdf_log += log(ccdf_n);
 
@@ -96,15 +95,14 @@ return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_lccdf(
     }
     if (!is_constant_all<T_scale>::value) {
       ops_partials.edge3_.partials_[n]
-          += (deriv_1 * v + deriv_3 * scaled_diff * SQRT_TWO
-              - deriv_2 * (v + SQRT_TWO * scaled_diff))
+          += ((deriv_1 - deriv_2) * v
+              + (deriv_3 - deriv_2) * scaled_diff * SQRT_TWO)
              / ccdf_n;
     }
     if (!is_constant_all<T_inv_scale>::value) {
       ops_partials.edge4_.partials_[n]
           -= exp_term
-             * (INV_SQRT_TWO_PI * sigma_dbl
-                    * exp(-square(v_over_sqrt_two - scaled_diff))
+             * (INV_SQRT_TWO_PI * sigma_dbl * exp_term_2
                 - (v * sigma_dbl - diff) * erf_calc)
              / ccdf_n;
     }

--- a/stan/math/prim/prob/exp_mod_normal_lcdf.hpp
+++ b/stan/math/prim/prob/exp_mod_normal_lcdf.hpp
@@ -69,21 +69,20 @@ return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_lcdf(
     const T_partials_return diff = y_dbl - mu_dbl;
     const T_partials_return u = lambda_dbl * diff;
     const T_partials_return v = lambda_dbl * sigma_dbl;
-    const T_partials_return v_over_sqrt_two = v * INV_SQRT_TWO;
     const T_partials_return scaled_diff = diff * INV_SQRT_TWO * inv_sigma;
-    const T_partials_return erf_calc
-        = 0.5 * (1 + erf(u / (v * SQRT_TWO) - v_over_sqrt_two));
+    const T_partials_return scaled_diff_diff = scaled_diff - v * INV_SQRT_TWO;
+    const T_partials_return erf_calc = 0.5 * (1 + erf(scaled_diff_diff));
     const T_partials_return exp_term = exp(0.5 * square(v) - u);
+    const T_partials_return exp_term_2 = exp(-square(scaled_diff_diff));
 
     const T_partials_return deriv_1 = lambda_dbl * exp_term * erf_calc;
     const T_partials_return deriv_2
-        = INV_SQRT_TWO_PI * exp_term
-          * exp(-square(scaled_diff - v_over_sqrt_two)) * inv_sigma;
+        = INV_SQRT_TWO_PI * exp_term * exp_term_2 * inv_sigma;
     const T_partials_return deriv_3
         = INV_SQRT_TWO_PI * exp(-square(scaled_diff)) * inv_sigma;
 
     const T_partials_return cdf_n
-        = 0.5 + 0.5 * erf(u / (v * SQRT_TWO)) - exp_term * erf_calc;
+        = 0.5 + 0.5 * erf(scaled_diff) - exp_term * erf_calc;
 
     cdf_log += log(cdf_n);
 
@@ -95,15 +94,14 @@ return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_lcdf(
     }
     if (!is_constant_all<T_scale>::value) {
       ops_partials.edge3_.partials_[n]
-          -= (deriv_1 * v + deriv_3 * scaled_diff * SQRT_TWO
-              - deriv_2 * (v + SQRT_TWO * scaled_diff))
+          -= ((deriv_1 - deriv_2) * v
+              + (deriv_3 - deriv_2) * scaled_diff * SQRT_TWO)
              / cdf_n;
     }
     if (!is_constant_all<T_inv_scale>::value) {
       ops_partials.edge4_.partials_[n]
           += exp_term
-             * (INV_SQRT_TWO_PI * sigma_dbl
-                    * exp(-square(v_over_sqrt_two - scaled_diff))
+             * (INV_SQRT_TWO_PI * sigma_dbl * exp_term_2
                 - (v * sigma_dbl - diff) * erf_calc)
              / cdf_n;
     }

--- a/stan/math/prim/prob/exponential_cdf.hpp
+++ b/stan/math/prim/prob/exponential_cdf.hpp
@@ -19,10 +19,10 @@ namespace math {
  * Inverse scale parameter must be greater than 0.
  * y must be greater than or equal to 0.
  *
+ * @tparam T_y type of scalar
+ * @tparam T_inv_scale type of inverse scale
  * @param y A scalar variable.
  * @param beta Inverse scale parameter.
- * @tparam T_y Type of scalar.
- * @tparam T_inv_scale Type of inverse scale.
  */
 template <typename T_y, typename T_inv_scale>
 return_type_t<T_y, T_inv_scale> exponential_cdf(const T_y& y,
@@ -47,25 +47,30 @@ return_type_t<T_y, T_inv_scale> exponential_cdf(const T_y& y,
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_inv_scale> beta_vec(beta);
   size_t N = max_size(y, beta);
+
+  VectorBuilder<!is_constant_all<T_y, T_inv_scale>::value, T_partials_return,
+                T_y, T_inv_scale>
+      rep_deriv(N);
   for (size_t n = 0; n < N; n++) {
     const T_partials_return beta_dbl = value_of(beta_vec[n]);
     const T_partials_return y_dbl = value_of(y_vec[n]);
-    const T_partials_return one_m_exp = 1.0 - exp(-beta_dbl * y_dbl);
+    const T_partials_return exp_val = exp(-beta_dbl * y_dbl);
+    const T_partials_return one_m_exp = 1 - exp_val;
 
+    if (!is_constant_all<T_y, T_inv_scale>::value) {
+      rep_deriv[n] = exp_val / one_m_exp;
+    }
     cdf *= one_m_exp;
   }
 
   for (size_t n = 0; n < N; n++) {
-    const T_partials_return beta_dbl = value_of(beta_vec[n]);
-    const T_partials_return y_dbl = value_of(y_vec[n]);
-    const T_partials_return one_m_exp = 1.0 - exp(-beta_dbl * y_dbl);
-
-    T_partials_return rep_deriv = exp(-beta_dbl * y_dbl) / one_m_exp;
     if (!is_constant_all<T_y>::value) {
-      ops_partials.edge1_.partials_[n] += rep_deriv * beta_dbl * cdf;
+      ops_partials.edge1_.partials_[n]
+          += value_of(beta_vec[n]) * rep_deriv[n] * cdf;
     }
     if (!is_constant_all<T_inv_scale>::value) {
-      ops_partials.edge2_.partials_[n] += rep_deriv * y_dbl * cdf;
+      ops_partials.edge2_.partials_[n]
+          += value_of(y_vec[n]) * rep_deriv[n] * cdf;
     }
   }
   return ops_partials.build(cdf);

--- a/stan/math/prim/prob/exponential_lccdf.hpp
+++ b/stan/math/prim/prob/exponential_lccdf.hpp
@@ -31,6 +31,7 @@ return_type_t<T_y, T_inv_scale> exponential_lccdf(const T_y& y,
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_inv_scale> beta_vec(beta);
   size_t N = max_size(y, beta);
+
   for (size_t n = 0; n < N; n++) {
     const T_partials_return beta_dbl = value_of(beta_vec[n]);
     const T_partials_return y_dbl = value_of(y_vec[n]);

--- a/stan/math/prim/prob/exponential_lcdf.hpp
+++ b/stan/math/prim/prob/exponential_lcdf.hpp
@@ -37,13 +37,16 @@ return_type_t<T_y, T_inv_scale> exponential_lcdf(const T_y& y,
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_inv_scale> beta_vec(beta);
   size_t N = max_size(y, beta);
+
   for (size_t n = 0; n < N; n++) {
     const T_partials_return beta_dbl = value_of(beta_vec[n]);
     const T_partials_return y_dbl = value_of(y_vec[n]);
-    T_partials_return one_m_exp = 1.0 - exp(-beta_dbl * y_dbl);
+    T_partials_return exp_val = exp(-beta_dbl * y_dbl);
+    T_partials_return one_m_exp = 1.0 - exp_val;
     cdf_log += log(one_m_exp);
 
-    T_partials_return rep_deriv = -exp(-beta_dbl * y_dbl) / one_m_exp;
+    T_partials_return rep_deriv
+        = is_constant_all<T_y, T_inv_scale>::value ? 0 : -exp_val / one_m_exp;
     if (!is_constant_all<T_y>::value) {
       ops_partials.edge1_.partials_[n] -= rep_deriv * beta_dbl;
     }

--- a/stan/math/prim/prob/exponential_log.hpp
+++ b/stan/math/prim/prob/exponential_log.hpp
@@ -8,32 +8,7 @@ namespace stan {
 namespace math {
 
 /** \ingroup prob_dists
- * The log of an exponential density for y with the specified
- * inverse scale parameter.
- * Inverse scale parameter must be greater than 0.
- * y must be greater than or equal to 0.
- *
- \f{eqnarray*}{
- y
- &\sim&
- \mbox{\sf{Expon}}(\beta) \\
- \log (p (y \, |\, \beta) )
- &=&
- \log \left( \beta \exp^{-\beta y} \right) \\
- &=&
- \log (\beta) - \beta y \\
- & &
- \mathrm{where} \; y > 0
- \f}
- *
  * @deprecated use <code>exponential_lpdf</code>
- *
- * @param y A scalar variable.
- * @param beta Inverse scale parameter.
- * @throw std::domain_error if beta is not greater than 0.
- * @throw std::domain_error if y is not greater than or equal to 0.
- * @tparam T_y Type of scalar.
- * @tparam T_inv_scale Type of inverse scale.
  */
 template <bool propto, typename T_y, typename T_inv_scale>
 return_type_t<T_y, T_inv_scale> exponential_log(const T_y& y,

--- a/stan/math/prim/prob/exponential_lpdf.hpp
+++ b/stan/math/prim/prob/exponential_lpdf.hpp
@@ -4,6 +4,7 @@
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/err.hpp>
 #include <stan/math/prim/fun/constants.hpp>
+#include <stan/math/prim/fun/inv.hpp>
 #include <stan/math/prim/fun/log.hpp>
 #include <stan/math/prim/fun/max_size.hpp>
 #include <stan/math/prim/fun/size.hpp>
@@ -60,13 +61,14 @@ return_type_t<T_y, T_inv_scale> exponential_lpdf(const T_y& y,
 
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_inv_scale> beta_vec(beta);
+  size_t size_beta = stan::math::size(beta);
   size_t N = max_size(y, beta);
 
   VectorBuilder<include_summand<propto, T_inv_scale>::value, T_partials_return,
                 T_inv_scale>
-      log_beta(size(beta));
-  for (size_t i = 0; i < stan::math::size(beta); i++) {
-    if (include_summand<propto, T_inv_scale>::value) {
+      log_beta(size_beta);
+  if (include_summand<propto, T_inv_scale>::value) {
+    for (size_t i = 0; i < size_beta; i++) {
       log_beta[i] = log(value_of(beta_vec[i]));
     }
   }
@@ -87,7 +89,7 @@ return_type_t<T_y, T_inv_scale> exponential_lpdf(const T_y& y,
       ops_partials.edge1_.partials_[n] -= beta_dbl;
     }
     if (!is_constant_all<T_inv_scale>::value) {
-      ops_partials.edge2_.partials_[n] += 1 / beta_dbl - y_dbl;
+      ops_partials.edge2_.partials_[n] += inv(beta_dbl) - y_dbl;
     }
   }
   return ops_partials.build(logp);


### PR DESCRIPTION
## Summary
This is the first of a few PRs that aim to clean up the distributions so that we make better use of intermediate computations and composed functions.

This covers the following distributions:
- bernoulli
- bernoulli_logit_glm
- beta
- beta_binomial
- beta_proportion
- binomial
- double_exponential
- exponential
- exp_mod_normal

## Tests

None, this is just cleanup.

## Side Effects

None.

## Checklist

- [X] Math issue: #1230

- [X] Copyright holder: Marco Colombo

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [X] the new changes are tested