### PR TITLE
Documentation fixups

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,6 +9,8 @@ v3.2.0 (pending)
 metaprograms to deal with complex numbers and added a real_return program
 and helper metaprograms for intermediate and return types.
 
+Miscellaneous doxygen documentation cleanup.
+
 ======================================================================
 v3.1.0 (24 January 2020)
 ======================================================================

--- a/stan/math/fwd/core/operator_logical_and.hpp
+++ b/stan/math/fwd/core/operator_logical_and.hpp
@@ -13,7 +13,7 @@ namespace math {
  * @tparam value and tangent type for variables
  * @param[in] x first argument
  * @param[in] y second argument
- * @return conjunction of the argument's values
+ * @return conjunction of the arguments' values
  */
 template <typename T>
 inline bool operator&&(const fvar<T>& x, const fvar<T>& y) {

--- a/stan/math/fwd/core/operator_logical_and.hpp
+++ b/stan/math/fwd/core/operator_logical_and.hpp
@@ -13,7 +13,7 @@ namespace math {
  * @tparam value and tangent type for variables
  * @param[in] x first argument
  * @param[in] y second argument
- * @return disjuntion of the argument's values
+ * @return conjunction of the argument's values
  */
 template <typename T>
 inline bool operator&&(const fvar<T>& x, const fvar<T>& y) {

--- a/stan/math/fwd/core/operator_logical_or.hpp
+++ b/stan/math/fwd/core/operator_logical_or.hpp
@@ -13,7 +13,7 @@ namespace math {
  * @tparam value and tangent type for variables
  * @param[in] x first argument
  * @param[in] y second argument
- * @return disjuntion of the argument's values
+ * @return disjunction of the argument's values
  */
 template <typename T>
 inline bool operator||(const fvar<T>& x, const fvar<T>& y) {

--- a/stan/math/fwd/core/operator_logical_or.hpp
+++ b/stan/math/fwd/core/operator_logical_or.hpp
@@ -13,7 +13,7 @@ namespace math {
  * @tparam value and tangent type for variables
  * @param[in] x first argument
  * @param[in] y second argument
- * @return disjunction of the argument's values
+ * @return disjunction of the arguments' values
  */
 template <typename T>
 inline bool operator||(const fvar<T>& x, const fvar<T>& y) {

--- a/stan/math/fwd/fun/squared_distance.hpp
+++ b/stan/math/fwd/fun/squared_distance.hpp
@@ -19,7 +19,7 @@ namespace math {
  *
  * @param v1 First vector.
  * @param v2 Second vector.
- * @return Dot product of the vectors.
+ * @return Square of distance between vectors.
  * @throw std::domain_error If the vectors are not the same
  * size or if they are both not vector dimensioned.
  */
@@ -45,7 +45,7 @@ inline fvar<T> squared_distance(const Eigen::Matrix<fvar<T>, R, C>& v1,
  *
  * @param v1 First vector.
  * @param v2 Second vector.
- * @return Dot product of the vectors.
+ * @return Square of distance between vectors.
  * @throw std::domain_error If the vectors are not the same
  * size or if they are both not vector dimensioned.
  */
@@ -70,7 +70,7 @@ inline fvar<T> squared_distance(const Eigen::Matrix<fvar<T>, R1, C1>& v1,
  *
  * @param v1 First vector.
  * @param v2 Second vector.
- * @return Dot product of the vectors.
+ * @return Square of distance between vectors.
  * @throw std::domain_error If the vectors are not the same
  * size or if they are both not vector dimensioned.
  */
@@ -96,7 +96,7 @@ inline fvar<T> squared_distance(const Eigen::Matrix<double, R, C>& v1,
  *
  * @param v1 First vector.
  * @param v2 Second vector.
- * @return Dot product of the vectors.
+ * @return Square of distance between vectors.
  * @throw std::domain_error If the vectors are not the same
  * size or if they are both not vector dimensioned.
  */
@@ -121,7 +121,7 @@ inline fvar<T> squared_distance(const Eigen::Matrix<double, R1, C1>& v1,
  *
  * @param v1 First vector.
  * @param v2 Second vector.
- * @return Dot product of the vectors.
+ * @return Square of distance between vectors.
  * @throw std::domain_error If the vectors are not the same
  * size or if they are both not vector dimensioned.
  */
@@ -147,7 +147,7 @@ inline fvar<T> squared_distance(const Eigen::Matrix<fvar<T>, R, C>& v1,
  *
  * @param v1 First vector.
  * @param v2 Second vector.
- * @return Dot product of the vectors.
+ * @return Square of distance between vectors.
  * @throw std::domain_error If the vectors are not the same
  * size or if they are both not vector dimensioned.
  */

--- a/stan/math/memory/stack_alloc.hpp
+++ b/stan/math/memory/stack_alloc.hpp
@@ -161,7 +161,7 @@ class stack_alloc {
    * The allocated pointer will be 8-byte aligned.
    *
    * This function may call C++'s <code>malloc()</code> function,
-   * with any exceptions percolated throught this function.
+   * with any exceptions percolated through this function.
    *
    * @param len Number of bytes to allocate.
    * @return A pointer to the allocated memory.

--- a/stan/math/opencl/buffer_types.hpp
+++ b/stan/math/opencl/buffer_types.hpp
@@ -26,7 +26,7 @@ namespace internal {
  * meta template struct for changing read/write buffer argument types to
  * cl::Buffer types.
  * @tparam T A template typename that for cases of non-read/write buffers
- * will return a typedef holding only it's original type. For read and write
+ * will return a typedef holding only its original type. For read and write
  * buffers this will return a cl::Buffer type.
  */
 template <typename T = cl::Buffer>

--- a/stan/math/opencl/is_matrix_cl.hpp
+++ b/stan/math/opencl/is_matrix_cl.hpp
@@ -20,13 +20,13 @@ class matrix_cl {
 namespace internal {
 
 /** \ingroup opencl
- * This underlying implimentation is used when the type is not an std vector.
+ * This underlying implementation is used when the type is not an std vector.
  */
 template <typename T>
 struct is_matrix_cl_impl : std::false_type {};
 
 /** \ingroup opencl
- * This specialization implimentation has a static member named value when the
+ * This specialization implementation has a static member named value when the
  * template type is an std vector.
  */
 template <typename... Args>

--- a/stan/math/opencl/kernel_generator/binary_operation.hpp
+++ b/stan/math/opencl/kernel_generator/binary_operation.hpp
@@ -43,7 +43,7 @@ class binary_operation : public operation_cl<Derived, T_res, T_a, T_b> {
   /**
    * Constructor
    * @param a first argument of the binary operation
-   * @param b sedond argument of the binary operation
+   * @param b second argument of the binary operation
    * @param op operator used in the binary operation
    */
   binary_operation(T_a&& a, T_b&& b, const std::string& op)  // NOLINT

--- a/stan/math/opencl/kernel_generator/colwise_reduction.hpp
+++ b/stan/math/opencl/kernel_generator/colwise_reduction.hpp
@@ -59,7 +59,7 @@ class colwise_reduction
   /**
    * Generates kernel code for assigning this expression into result expression.
    * @param[in,out] generated set of (pointer to) already generated operations
-   * @param name_gen name generator for this kernel
+   * @param ng name generator for this kernel
    * @param i row index variable name
    * @param j column index variable name
    * @param result expression into which result is to be assigned
@@ -83,10 +83,10 @@ class colwise_reduction
 
   /**
    * generates kernel code for this and nested expressions.
-   * @param[in,out] generated set of already generated operations
-   * @param ng name generator for this kernel
    * @param i row index variable name
    * @param j column index variable name
+   * @param var_name_arg name of the variable in kernel that holds argument to
+   * this expression
    * @return part of kernel with code for this and nested expressions
    */
   inline kernel_parts generate(const std::string& i, const std::string& j,

--- a/stan/math/opencl/kernel_generator/load.hpp
+++ b/stan/math/opencl/kernel_generator/load.hpp
@@ -73,7 +73,7 @@ class load_
 
   /**
    * generates kernel code for this expression if it appears on the left hand
-   * side of an assigment.
+   * side of an assignment.
    * @param i row index variable name
    * @param j column index variable name
    * @return part of kernel with code for this expressions

--- a/stan/math/opencl/kernel_generator/operation_cl.hpp
+++ b/stan/math/opencl/kernel_generator/operation_cl.hpp
@@ -133,7 +133,7 @@ class operation_cl : public operation_cl_base {
   /**
    * Generates kernel code for assigning this expression into result expression.
    * @param[in,out] generated set of (pointer to) already generated operations
-   * @param name_gen name generator for this kernel
+   * @param ng name generator for this kernel
    * @param i row index variable name
    * @param j column index variable name
    * @param result expression into which result is to be assigned

--- a/stan/math/opencl/kernel_generator/operation_cl.hpp
+++ b/stan/math/opencl/kernel_generator/operation_cl.hpp
@@ -126,7 +126,7 @@ class operation_cl : public operation_cl_base {
     static std::string source;  // kernel source - not used anywhere. Only
                                 // intended for debugging.
     static cl::Kernel kernel;   // cached kernel - different for every
-                                // combination of template instantination of \c
+                                // combination of template instantiation of \c
                                 // operation and every \c T_lhs
   };
 

--- a/stan/math/opencl/kernel_generator/operation_cl_lhs.hpp
+++ b/stan/math/opencl/kernel_generator/operation_cl_lhs.hpp
@@ -32,7 +32,7 @@ class operation_cl_lhs : public operation_cl<Derived, Scalar, Args...> {
 
   /**
    * generates kernel code for this expression if it appears on the left hand
-   * side of an assigment.
+   * side of an assignment.
    * @param[in,out] generated set of (pointer to) already generated operations
    * @param name_gen name generator for this kernel
    * @param i row index variable name

--- a/stan/math/opencl/kernels/check_symmetric.hpp
+++ b/stan/math/opencl/kernels/check_symmetric.hpp
@@ -19,7 +19,7 @@ static const std::string is_symmetric_kernel_code = STRINGIFY(
      * @param rows The number of rows in matrix A.
      * @param cols The number of columns in matrix A.
      * @param[out] flag the flag to be written to if any diagonal is zero.
-     * @param tolerance The numerical tolerance to check wheter
+     * @param tolerance The numerical tolerance to check whether
      *   two values are equal
      * @note Code is a <code>const char*</code> held in
      * <code>is_symmetric_kernel_code.</code>

--- a/stan/math/opencl/kernels/helpers.hpp
+++ b/stan/math/opencl/kernels/helpers.hpp
@@ -8,7 +8,7 @@ namespace stan {
 namespace math {
 namespace opencl_kernels {
 
-/*
+/**
  * Defines helper macros for common matrix indexing operations
  */
 static const std::string indexing_helpers =
@@ -42,7 +42,7 @@ static const std::string indexing_helpers =
   #endif
   )";
 
-/*
+/**
  * Defines a helper macro for kernels with 2D local size
  */
 static const std::string thread_block_helpers =

--- a/stan/math/opencl/kernels/triangular_transpose.hpp
+++ b/stan/math/opencl/kernels/triangular_transpose.hpp
@@ -13,7 +13,7 @@ namespace opencl_kernels {
 static const std::string triangular_transpose_kernel_code = STRINGIFY(
     // \endcond
     /** \ingroup opencl_kernels
-     * Copies a lower/upper triangular of a matrix to it's upper/lower.
+     * Copies the lower/upper triangle of a matrix to its upper/lower triangle.
      *
      * @param[in,out] A The matrix.
      * @param rows The number of rows in A.

--- a/stan/math/opencl/matrix_cl.hpp
+++ b/stan/math/opencl/matrix_cl.hpp
@@ -20,7 +20,7 @@
 /** \ingroup opencl
  *  @file stan/math/opencl/matrix_cl.hpp
  *  @brief The matrix_cl class - allocates memory space on the OpenCL device,
- *    functions for transfering matrices to and from OpenCL devices
+ *    functions for transferring matrices to and from OpenCL devices
  */
 namespace stan {
 namespace math {
@@ -491,7 +491,7 @@ class matrix_cl<T, require_arithmetic_t<T>> {
 
  private:
   /** \ingroup opencl
-   * Initializes the OpencL buffer of this matrix by copying the data from given
+   * Initializes the OpenCL buffer of this matrix by copying the data from given
    * buffer. Assumes that size of \c this is already set and matches the
    * buffer size. If \c in_order is false the caller must make sure that data
    * is not deleted before copying is complete.
@@ -526,7 +526,7 @@ class matrix_cl<T, require_arithmetic_t<T>> {
   }
 
   /** \ingroup opencl
-   * Initializes the OpencL buffer of this matrix by copying the data from given
+   * Initializes the OpenCL buffer of this matrix by copying the data from given
    * object. Assumes that size of \c this is already set and matches the
    * buffer size. If the object is rvalue (temporary) it is first moved to heap
    * and callback is set to delete it after copying to OpenCL device is
@@ -563,7 +563,7 @@ class matrix_cl<T, require_arithmetic_t<T>> {
   }
 
   /** \ingroup opencl
-   * Initializes the OpencL buffer of this matrix by copying the data from given
+   * Initializes the OpenCL buffer of this matrix by copying the data from given
    * matrix_cl. Assumes that size of \c this is already set and matches the
    * size of given matrix.
    * @param A matrix_cl

--- a/stan/math/opencl/multiply_transpose.hpp
+++ b/stan/math/opencl/multiply_transpose.hpp
@@ -32,7 +32,7 @@ inline matrix_cl<T> multiply_transpose(const matrix_cl<T>& A) {
     return temp;
   }
   // padding the matrices so the dimensions are divisible with local
-  // improves performance becasuse we can omit if statements in the
+  // improves performance because we can omit if statements in the
   // multiply kernel
   int local = opencl_kernels::multiply_transpose.make_functor.get_opts().at(
       "THREAD_BLOCK_SIZE");

--- a/stan/math/opencl/opencl_context.hpp
+++ b/stan/math/opencl/opencl_context.hpp
@@ -47,9 +47,9 @@ namespace math {
  *
  * Some design decisions that may need to be addressed later:
  * - we are assuming a single OpenCL platform. We may want to run on multiple
- * platforms simulatenously
+ * platforms simultaneously
  * - we are assuming a single OpenCL device. We may want to run on multiple
- * devices simulatenously
+ * devices simultaneously
  */
 class opencl_context_base {
   friend class opencl_context;
@@ -345,7 +345,7 @@ class opencl_context {
    * Returns the maximum thread block size defined by
    * CL_DEVICE_MAX_WORK_GROUP_SIZE for the device in the context. This is the
    * maximum product of thread block dimensions for a particular device. IE a
-   * max workgoup of 256 would allow thread blocks of sizes (16,16), (128,2),
+   * max workgroup of 256 would allow thread blocks of sizes (16,16), (128,2),
    * (8, 32), etc.
    */
   inline int max_thread_block_size() {

--- a/stan/math/opencl/opencl_context.hpp
+++ b/stan/math/opencl/opencl_context.hpp
@@ -200,8 +200,8 @@ class opencl_context {
 
   /** \ingroup opencl
    * Returns the description of the OpenCL platform and device that is used.
-   * Devices will be an OpenCL and Platforms are a specific OpenCL implimenation
-   * such as AMD SDK's or Nvidia's OpenCL implimentation.
+   * Devices will be an OpenCL and Platforms are a specific OpenCL
+   * implementation such as AMD SDK's or Nvidia's OpenCL implementation.
    */
   inline std::string description() const {
     std::ostringstream msg;
@@ -257,7 +257,7 @@ class opencl_context {
   /** \ingroup opencl
    * Returns the description of the OpenCL platforms and devices that
    * are available. Devices will be an OpenCL and Platforms are a specific
-   * OpenCL implimenation such as AMD SDK's or Nvidia's OpenCL implimentation.
+   * OpenCL implementation such as AMD SDK's or Nvidia's OpenCL implementation.
    */
   inline std::string capabilities() const {
     std::vector<cl::Platform> all_platforms;

--- a/stan/math/opencl/prim/categorical_logit_glm_lpmf.hpp
+++ b/stan/math/opencl/prim/categorical_logit_glm_lpmf.hpp
@@ -21,7 +21,7 @@ namespace math {
  * Returns the log PMF of the Generalized Linear Model (GLM)
  * with categorical distribution and logit (softmax) link function.
  * This is an overload of the GLM in
- * prim/mar/prob/categorical_logit_glm_lpmf.hpp that is implemented in OpenCL.
+ * prim/prob/categorical_logit_glm_lpmf.hpp that is implemented in OpenCL.
  *
  * @tparam T_alpha_scalar type of scalar in the intercept vector
  * @tparam T_beta_scalar type of a scalar in the matrix of weights

--- a/stan/math/opencl/prim/neg_binomial_2_log_glm_lpmf.hpp
+++ b/stan/math/opencl/prim/neg_binomial_2_log_glm_lpmf.hpp
@@ -29,7 +29,7 @@ namespace math {
  * simplified gradients.
  * If containers are supplied, returns the log sum of the probabilities.
  * This is an overload of the GLM in
- * prim/mar/prob/neg_binomial_2_log_glm_lpdf.hpp that is implemented in OpenCL.
+ * prim/prob/neg_binomial_2_log_glm_lpdf.hpp that is implemented in OpenCL.
  * @tparam T_alpha type of the intercept(s);
  * this can be a vector (of the same length as y) of intercepts or a single
  * value (for models with constant intercept);

--- a/stan/math/opencl/prim/normal_id_glm_lpdf.hpp
+++ b/stan/math/opencl/prim/normal_id_glm_lpdf.hpp
@@ -23,7 +23,7 @@ namespace math {
  * Returns the log PDF of the Generalized Linear Model (GLM)
  * with Normal distribution and id link function.
  * If containers are supplied, returns the log sum of the probabilities.
- * This is an overload of the GLM in prim/mar/prob/normal_id_glm_lpdf.hpp
+ * This is an overload of the GLM in prim/prob/normal_id_glm_lpdf.hpp
  * that is implemented in OpenCL.
  * @tparam T_alpha type of the intercept(s);
  * this can be a vector (of the same length as y) of intercepts or a single

--- a/stan/math/opencl/prim/ordered_logistic_glm_lpmf.hpp
+++ b/stan/math/opencl/prim/ordered_logistic_glm_lpmf.hpp
@@ -23,7 +23,7 @@ namespace math {
  * This is equivalent to and faster than ordered_logistic_lpmf(y, x * beta,
  * cuts).
  * This is an overload of the GLM in
- * prim/mar/prob/ordered_logistic_glm_lpmf.hpp that is implemented in OpenCL.
+ * prim/prob/ordered_logistic_glm_lpmf.hpp that is implemented in OpenCL.
  *
  * @tparam T_beta_scalar type of a scalar in the vector of weights
  * @tparam T_cuts_scalar type of a scalar in the vector of cutpoints

--- a/stan/math/opencl/prim/rep_matrix.hpp
+++ b/stan/math/opencl/prim/rep_matrix.hpp
@@ -54,7 +54,7 @@ inline matrix_cl<T> rep_matrix(const matrix_cl<T>& x, int n, int m) {
  *
  * @tparam T type of elements in the input matrix
  * @param x the input matrix_cl (vector or row_vector)
- * @param m number of rows (if x is a row_vecotr) or columns
+ * @param m number of rows (if x is a row_vector) or columns
  *  (if x is a vector) in the results matrix
  *
  * @return result matrix with replicated rows or columns

--- a/stan/math/opencl/rev/triangular_transpose.hpp
+++ b/stan/math/opencl/rev/triangular_transpose.hpp
@@ -11,7 +11,7 @@ namespace stan {
 namespace math {
 
 /**
- * Copies a lower/upper triangular of a matrix to it's upper/lower.
+ * Copies the lower/upper triangle of a matrix to its upper/lower triangle.
  *
  * @tparam triangular_map Specifies if the copy is
  * lower-to-upper or upper-to-lower triangular. The value

--- a/stan/math/opencl/rev/zeros.hpp
+++ b/stan/math/opencl/rev/zeros.hpp
@@ -33,7 +33,7 @@ inline void matrix_cl<T, require_var_t<T>>::zeros() try {
 }
 
 /**
- * Stores zeros in the stricts triangular part (excluding the diagonal)
+ * Stores zeros in the structs triangular part (excluding the diagonal)
  * of a matrix on the OpenCL device.
  * Supports writing zeroes to the lower and upper triangular.
  * Throws if used with the Entire matrix_cl_view.

--- a/stan/math/opencl/rev/zeros.hpp
+++ b/stan/math/opencl/rev/zeros.hpp
@@ -33,7 +33,7 @@ inline void matrix_cl<T, require_var_t<T>>::zeros() try {
 }
 
 /**
- * Stores zeros in the structs triangular part (excluding the diagonal)
+ * Stores zeros in the strict's triangular part (excluding the diagonal)
  * of a matrix on the OpenCL device.
  * Supports writing zeroes to the lower and upper triangular.
  * Throws if used with the Entire matrix_cl_view.

--- a/stan/math/opencl/triangular_transpose.hpp
+++ b/stan/math/opencl/triangular_transpose.hpp
@@ -15,7 +15,7 @@ namespace stan {
 namespace math {
 
 /** \ingroup opencl
- * Copies a lower/upper triangular of a matrix to it's upper/lower.
+ * Copies the lower/upper triangle of a matrix to its upper/lower triangle.
  *
  * @tparam triangular_map Specifies if the copy is
  * lower-to-upper or upper-to-lower triangular. The value

--- a/stan/math/opencl/zeros.hpp
+++ b/stan/math/opencl/zeros.hpp
@@ -38,7 +38,7 @@ inline void matrix_cl<T, require_arithmetic_t<T>>::zeros() try {
 }
 
 /** \ingroup opencl
- * Stores zeros in the stricts triangular part (excluding the diagonal)
+ * Stores zeros in the structs triangular part (excluding the diagonal)
  * of a matrix on the OpenCL device.
  * Supports writing zeroes to the lower and upper triangular.
  * Throws if used with the Entire matrix_cl_view.

--- a/stan/math/opencl/zeros.hpp
+++ b/stan/math/opencl/zeros.hpp
@@ -38,7 +38,7 @@ inline void matrix_cl<T, require_arithmetic_t<T>>::zeros() try {
 }
 
 /** \ingroup opencl
- * Stores zeros in the structs triangular part (excluding the diagonal)
+ * Stores zeros in the strict's triangular part (excluding the diagonal)
  * of a matrix on the OpenCL device.
  * Supports writing zeroes to the lower and upper triangular.
  * Throws if used with the Entire matrix_cl_view.

--- a/stan/math/prim/err/check_finite.hpp
+++ b/stan/math/prim/err/check_finite.hpp
@@ -53,7 +53,7 @@ inline void check_finite(const char* function, const char* name, const T_y& y) {
   internal::finite<T_y, is_vector_like<T_y>::value>::check(function, name, y);
 }
 
-/*
+/**
  * Return <code>true</code> is the specified matrix is finite.
  *
  * @tparam T type of elements in the matrix

--- a/stan/math/prim/err/is_unit_vector.hpp
+++ b/stan/math/prim/err/is_unit_vector.hpp
@@ -16,9 +16,9 @@ namespace math {
  * A valid unit vector is one where the square elements
  * summed is equal to 1. This function tests that the sum
  * is within the tolerance specified by <code>CONSTRAINT_TOLERANCE</code>.
- * This function only accpets <code>Eigen::Matrix</code> vectors, statically
+ * This function only accepts <code>Eigen::Matrix</code> vectors, statically
  * typed vectors, not general matrices with 1 column.
- * @tparam T_prob Scalar type of the vector, reqires class method
+ * @tparam T_prob Scalar type of the vector, requires class method
  *   <code>.squaredNorm()</code>
  * @param theta Eigen vector to test
  * @return <code>true</code> if the vector is not a unit

--- a/stan/math/prim/fun/acosh.hpp
+++ b/stan/math/prim/fun/acosh.hpp
@@ -56,7 +56,7 @@ inline double acosh(int x) {
  */
 struct acosh_fun {
   /**
-   * Return the inverse hypberbolic cosine of the specified argument.
+   * Return the inverse hyperbolic cosine of the specified argument.
    *
    * @tparam T type of argument
    * @param x argument

--- a/stan/math/prim/fun/atanh.hpp
+++ b/stan/math/prim/fun/atanh.hpp
@@ -49,7 +49,7 @@ inline double atanh(int x) {
  */
 struct atanh_fun {
   /**
-   * Return the inverse hypberbolic tangent of the specified argument.
+   * Return the inverse hyperbolic tangent of the specified argument.
    *
    * @tparam T type of argument
    * @param x argument

--- a/stan/math/prim/fun/boost_policy.hpp
+++ b/stan/math/prim/fun/boost_policy.hpp
@@ -15,6 +15,7 @@ namespace math {
  * The non-default behavior from Boost's built-ins are
  * (1) overflow errors return error numbers on error.
  * (2) pole errors return error numbers on error.
+ * (3) doubles passed to Boost are not promoted to long double.
  */
 using boost_policy_t = boost::math::policies::policy<
     boost::math::policies::overflow_error<

--- a/stan/math/prim/fun/cholesky_decompose.hpp
+++ b/stan/math/prim/fun/cholesky_decompose.hpp
@@ -20,7 +20,7 @@ namespace math {
  * <p>\f$A = L \times L^T\f$.
  *
  * @tparam T type of elements in the matrix
- * @param m Symmetrix matrix.
+ * @param m Symmetric matrix.
  * @return Square root of matrix.
  * @note Because OpenCL only works on doubles there are two
  * <code>cholesky_decompose</code> functions. One that works on doubles
@@ -46,7 +46,7 @@ inline Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> cholesky_decompose(
  * original matrix \f$A\f$ is given by
  * <p>\f$A = L \times L^T\f$.
  *
- * @param m Symmetrix matrix.
+ * @param m Symmetric matrix.
  * @return Square root of matrix.
  * @note Because OpenCL only works on doubles there are two
  * <code>cholesky_decompose</code> functions. One that works on doubles

--- a/stan/math/prim/fun/cholesky_factor_free.hpp
+++ b/stan/math/prim/fun/cholesky_factor_free.hpp
@@ -11,7 +11,7 @@ namespace stan {
 namespace math {
 
 /**
- * Return the unconstrained vector of parameters correspdonding to
+ * Return the unconstrained vector of parameters corresponding to
  * the specified Cholesky factor.  A Cholesky factor must be lower
  * triangular and have positive diagonal elements.
  *

--- a/stan/math/prim/fun/distance.hpp
+++ b/stan/math/prim/fun/distance.hpp
@@ -31,10 +31,14 @@ inline return_type_t<T1, T2> distance(const T1& x1, const T2& x2) {
  * Returns the distance between the specified vectors.
  *
  * @tparam T1 type of elements in first vector
+ * @tparam R1 number of rows in the first vector, can be Eigen::Dynamic
+ * @tparam C1 number of columns in the first vector, can be Eigen::Dynamic
  * @tparam T2 type of elements in second vector
+ * @tparam R2 number of rows in the second vector, can be Eigen::Dynamic
+ * @tparam C2 number of columns in the second vector, can be Eigen::Dynamic
  * @param v1 First vector.
  * @param v2 Second vector.
- * @return Dot product of the vectors.
+ * @return Distance between vectors.
  * @throw std::domain_error If the vectors are not the same
  * size or if they are both not vector dimensioned.
  */

--- a/stan/math/prim/fun/fmin.hpp
+++ b/stan/math/prim/fun/fmin.hpp
@@ -9,7 +9,7 @@ namespace math {
 
 /**
  * Return the lesser of the two specified arguments.  If one is
- * greater than the other, return not-a-number.
+ * not-a-number, return the other.
  *
  * @param x First argument.
  * @param y Second argument.

--- a/stan/math/prim/fun/gp_exponential_cov.hpp
+++ b/stan/math/prim/fun/gp_exponential_cov.hpp
@@ -207,7 +207,7 @@ gp_exponential_cov(const std::vector<T_x1> &x1, const std::vector<T_x2> &x2,
  *
  * where \f$d(x, x')\f$ is the Euclidean distance
  *
- * This function is for the cross covariance matrix neededed
+ * This function is for the cross covariance matrix needed
  * to compute the posterior predictive density.
  *
  * @tparam T_x1 first type of std::vector of scalars

--- a/stan/math/prim/fun/gp_matern32_cov.hpp
+++ b/stan/math/prim/fun/gp_matern32_cov.hpp
@@ -151,7 +151,7 @@ gp_matern32_cov(const std::vector<Eigen::Matrix<T_x, -1, 1>> &x,
  *
  * where \f$d(x, x')\f$ is the Euclidean distance.
  *
- * This function is for the cross covariance matrix neededed
+ * This function is for the cross covariance matrix needed
  * to compute the posterior predictive density.
  *
  * @tparam T_x1 first type of scalars contained in vector x1
@@ -226,7 +226,7 @@ gp_matern32_cov(const std::vector<T_x1> &x1, const std::vector<T_x2> &x2,
  *
  * where \f$d(x, x')\f$ is the Euclidean distance
  *
- * This function is for the cross covariance matrix neededed
+ * This function is for the cross covariance matrix needed
  * to compute the posterior predictive density.
  *
  * @tparam T_x1 first type of std::vector of scalars

--- a/stan/math/prim/fun/grad_reg_lower_inc_gamma.hpp
+++ b/stan/math/prim/fun/grad_reg_lower_inc_gamma.hpp
@@ -25,7 +25,7 @@ namespace math {
  * Computes the gradient of the lower regularized incomplete
  * gamma function.
  *
- * The lower incomlete gamma function
+ * The lower incomplete gamma function
  * derivative w.r.t it's first parameter (a) seems to have no
  * standard source.  It also appears to have no widely known
  * approximate implementation.  Gautschi (1979) has a thorough

--- a/stan/math/prim/fun/grad_reg_lower_inc_gamma.hpp
+++ b/stan/math/prim/fun/grad_reg_lower_inc_gamma.hpp
@@ -26,7 +26,7 @@ namespace math {
  * gamma function.
  *
  * The lower incomplete gamma function
- * derivative w.r.t it's first parameter (a) seems to have no
+ * derivative w.r.t its first parameter (a) seems to have no
  * standard source.  It also appears to have no widely known
  * approximate implementation.  Gautschi (1979) has a thorough
  * discussion of the calculation of the lower regularized

--- a/stan/math/prim/fun/identity_constrain.hpp
+++ b/stan/math/prim/fun/identity_constrain.hpp
@@ -33,6 +33,7 @@ inline T identity_constrain(const T& x) {
  * @tparam T type of scalar
  * @tparam S type of log probability
  * @param[in] x scalar
+ * @param[in] lp log density reference
  * @return transformed input
  */
 template <typename T, typename S>

--- a/stan/math/prim/fun/inc_beta_dda.hpp
+++ b/stan/math/prim/fun/inc_beta_dda.hpp
@@ -16,7 +16,7 @@ namespace math {
 /**
  * Returns the partial derivative of the regularized
  * incomplete beta function, I_{z}(a, b) with respect to a.
- * The power series used to compute the deriative tends to
+ * The power series used to compute the derivative tends to
  * converge slowly when a and b are large, especially if z
  * approaches 1.  The implementation will throw an exception
  * if the series have not converged within 100,000 iterations.
@@ -68,7 +68,7 @@ T inc_beta_dda(T a, T b, T z, T digamma_a, T digamma_ab) {
 
   digamma_a += inv(a);  // Need digamma(a + 1), not digamma(a);
 
-  // Common prefactor to regularize numerator and denomentator
+  // Common prefactor to regularize numerator and denominator
   T prefactor = pow(a_plus_1 / a_plus_b, 3);
 
   T sum_numer = (digamma_ab - digamma_a) * prefactor;

--- a/stan/math/prim/fun/inc_beta_ddb.hpp
+++ b/stan/math/prim/fun/inc_beta_ddb.hpp
@@ -19,8 +19,8 @@ T inc_beta_dda(T a, T b, T z, T digamma_a, T digamma_ab);
 /**
  * Returns the partial derivative of the regularized
  * incomplete beta function, I_{z}(a, b) with respect to b.
- * The power series used to compute the deriative tends to
- * converge slowly when a and b are large, especailly if z
+ * The power series used to compute the derivative tends to
+ * converge slowly when a and b are large, especially if z
  * approaches 1.  The implementation will throw an exception
  * if the series have not converged within 100,000 iterations.
  * The current implementation has been tested for values
@@ -61,7 +61,7 @@ T inc_beta_ddb(T a, T b, T z, T digamma_b, T digamma_ab) {
   const T a_plus_b = a + b;
   const T a_plus_1 = a + 1;
 
-  // Common prefactor to regularize numerator and denomentator
+  // Common prefactor to regularize numerator and denominator
   T prefactor = pow(a_plus_1 / a_plus_b, 3);
 
   T sum_numer = digamma_ab * prefactor;

--- a/stan/math/prim/fun/inv_sqrt.hpp
+++ b/stan/math/prim/fun/inv_sqrt.hpp
@@ -46,7 +46,7 @@ inline auto inv_sqrt(const T& x) {
  *
  * @tparam Derived derived type of x
  * @param x Matrix or matrix expression
- * @return Arc cosine of each variable in the container, in radians.
+ * @return 1 / sqrt of each value in x.
  */
 template <typename Derived,
           typename = require_eigen_vt<std::is_arithmetic, Derived>>
@@ -59,7 +59,7 @@ inline auto inv_sqrt(const Eigen::MatrixBase<Derived>& x) {
  *
  * @tparam Derived derived type of x
  * @param x Matrix or matrix expression
- * @return Arc cosine of each variable in the container, in radians.
+ * @return 1 / sqrt of each value in x.
  */
 template <typename Derived,
           typename = require_eigen_vt<std::is_arithmetic, Derived>>

--- a/stan/math/prim/fun/inv_sqrt.hpp
+++ b/stan/math/prim/fun/inv_sqrt.hpp
@@ -20,7 +20,7 @@ inline double inv_sqrt(double x) {
  *
  * @tparam T type of variable
  * @param x variable
- * @return 1 / sqrt of x.
+ * @return inverse square root of x.
  */
 struct inv_sqrt_fun {
   template <typename T>
@@ -34,7 +34,7 @@ struct inv_sqrt_fun {
  *
  * @tparam T type of container
  * @param x container
- * @return 1 / sqrt of each value in x.
+ * @return inverse square root of each value in x.
  */
 template <typename T, typename = require_not_eigen_vt<std::is_arithmetic, T>>
 inline auto inv_sqrt(const T& x) {
@@ -46,7 +46,7 @@ inline auto inv_sqrt(const T& x) {
  *
  * @tparam Derived derived type of x
  * @param x Matrix or matrix expression
- * @return 1 / sqrt of each value in x.
+ * @return inverse square root of each value in x.
  */
 template <typename Derived,
           typename = require_eigen_vt<std::is_arithmetic, Derived>>
@@ -59,7 +59,7 @@ inline auto inv_sqrt(const Eigen::MatrixBase<Derived>& x) {
  *
  * @tparam Derived derived type of x
  * @param x Matrix or matrix expression
- * @return 1 / sqrt of each value in x.
+ * @return inverse square root of each value in x.
  */
 template <typename Derived,
           typename = require_eigen_vt<std::is_arithmetic, Derived>>

--- a/stan/math/prim/fun/lb_constrain.hpp
+++ b/stan/math/prim/fun/lb_constrain.hpp
@@ -26,8 +26,8 @@ namespace math {
  * @tparam T type of scalar
  * @tparam L type of lower bound
  * @param[in] x Unconstrained scalar input
- * @param[in] lb lower bound on constrained ouptut
- * @return lower bound constrained value correspdonding to inputs
+ * @param[in] lb lower bound on constrained output
+ * @return lower bound constrained value corresponding to inputs
  */
 template <typename T, typename L>
 inline return_type_t<T, L> lb_constrain(const T& x, const L& lb) {
@@ -39,7 +39,7 @@ inline return_type_t<T, L> lb_constrain(const T& x, const L& lb) {
 }
 
 /**
- * Return the lower-bounded value for the speicifed unconstrained
+ * Return the lower-bounded value for the specified unconstrained
  * input and specified lower bound, incrementing the specified
  * reference with the log absolute Jacobian determinant of the
  * transform.

--- a/stan/math/prim/fun/lgamma.hpp
+++ b/stan/math/prim/fun/lgamma.hpp
@@ -1,7 +1,7 @@
 #ifndef STAN_MATH_PRIM_FUN_LGAMMA_HPP
 #define STAN_MATH_PRIM_FUN_LGAMMA_HPP
 
-/*
+/**
  * The lgamma implementation in stan-math is based on either the
  * reentrant safe lgamma_r implementation from C or the
  * boost::math::lgamma implementation. The reentrant safe lgamma_r

--- a/stan/math/prim/fun/log.hpp
+++ b/stan/math/prim/fun/log.hpp
@@ -54,7 +54,7 @@ inline auto log(const T& x) {
  *
  * @tparam Derived derived type of x
  * @param x Matrix or matrix expression
- * @return Arc cosine of each variable in the container, in radians.
+ * @return Elementwise application of natural log to the argument.
  */
 template <typename Derived,
           typename = require_eigen_vt<std::is_arithmetic, Derived>>

--- a/stan/math/prim/fun/log10.hpp
+++ b/stan/math/prim/fun/log10.hpp
@@ -40,7 +40,7 @@ inline auto log10(const T& x) {
  *
  * @tparam Derived derived type of x
  * @param x Matrix or matrix expression
- * @return Arc cosine of each variable in the container, in radians.
+ * @return Log base-10 applied to each value in x.
  */
 template <typename Derived,
           typename = require_eigen_vt<std::is_arithmetic, Derived>>

--- a/stan/math/prim/fun/log_sum_exp.hpp
+++ b/stan/math/prim/fun/log_sum_exp.hpp
@@ -12,7 +12,7 @@ namespace stan {
 namespace math {
 
 /**
- * Calculates the log sum of exponetials without overflow.
+ * Calculates the log sum of exponentials without overflow.
  *
  * \f$\log (\exp(a) + \exp(b)) = m + \log(\exp(a-m) + \exp(b-m))\f$,
  *

--- a/stan/math/prim/fun/matrix_exp_action_handler.hpp
+++ b/stan/math/prim/fun/matrix_exp_action_handler.hpp
@@ -8,7 +8,7 @@
 namespace stan {
 namespace math {
 
-/*
+/**
  * The implementation of the work by Awad H. Al-Mohy and Nicholas J. Higham
  * "Computing the Action of the Matrix Exponential,
  * with an Application to Exponential Integrators"
@@ -35,7 +35,8 @@ class matrix_exp_action_handler {
   }
 
  public:
-  /* Perform the matrix exponential action exp(A*t)*B
+  /**
+   * Perform the matrix exponential action exp(A*t)*B
    * @param [in] mat matrix A
    * @param [in] b matrix B
    * @param [in] t double t, e.g. time.
@@ -85,7 +86,8 @@ class matrix_exp_action_handler {
     return res;
   }
 
-  /* Approximation is based on parameter "m" and "s",
+  /**
+   * Approximation is based on parameter "m" and "s",
    * proposed in CODE FRAGMENT 3.1 of the reference. The
    * parameters depend on matrix A, as well as limits
    * "m_max" & "p_max", defined in table 3.1 and eq. 3.11,

--- a/stan/math/prim/fun/matrix_exp_action_handler.hpp
+++ b/stan/math/prim/fun/matrix_exp_action_handler.hpp
@@ -9,7 +9,7 @@ namespace stan {
 namespace math {
 
 /*
- * The implemention of the work by Awad H. Al-Mohy and Nicholas J. Higham
+ * The implementation of the work by Awad H. Al-Mohy and Nicholas J. Higham
  * "Computing the Action of the Matrix Exponential,
  * with an Application to Exponential Integrators"
  * Read More: https://epubs.siam.org/doi/abs/10.1137/100788860

--- a/stan/math/prim/fun/offset_multiplier_constrain.hpp
+++ b/stan/math/prim/fun/offset_multiplier_constrain.hpp
@@ -31,7 +31,7 @@ namespace math {
  * @param[in] x Unconstrained scalar input
  * @param[in] mu offset of constrained output
  * @param[in] sigma multiplier of constrained output
- * @return linear transformed value correspdonding to inputs
+ * @return linear transformed value corresponding to inputs
  * @throw std::domain_error if sigma <= 0
  * @throw std::domain_error if mu is not finite
  */

--- a/stan/math/prim/fun/sort_indices.hpp
+++ b/stan/math/prim/fun/sort_indices.hpp
@@ -9,7 +9,7 @@
 namespace stan {
 namespace math {
 
-/*
+/**
  * A comparator that works for any container type that has the
  * brackets operator.
  *

--- a/stan/math/prim/fun/sort_indices.hpp
+++ b/stan/math/prim/fun/sort_indices.hpp
@@ -52,7 +52,7 @@ class index_comparator {
 /**
  * Return an integer array of indices of the specified container
  * sorting the values in ascending or descending order based on
- * the value of the first template prameter.
+ * the value of the first template parameter.
  *
  * @tparam ascending true if sort is in ascending order
  * @tparam C type of container

--- a/stan/math/prim/fun/sqrt.hpp
+++ b/stan/math/prim/fun/sqrt.hpp
@@ -13,7 +13,7 @@ namespace math {
  * version is required to disambiguate <code>sqrt(int)</code>.
  *
  * @param[in] x Argument.
- * @return Natural exponential of argument.
+ * @return Square root of x.
  */
 inline double sqrt(int x) { return std::sqrt(x); }
 

--- a/stan/math/prim/fun/squared_distance.hpp
+++ b/stan/math/prim/fun/squared_distance.hpp
@@ -14,7 +14,7 @@ namespace math {
  *
  * @param x1 First vector.
  * @param x2 Second vector.
- * @return Dot product of the vectors.
+ * @return Square of distance between vectors.
  * @throw std::domain_error If the vectors are not the same
  * size or if they are both not vector dimensioned.
  */
@@ -33,7 +33,7 @@ inline return_type_t<T1, T2> squared_distance(const T1& x1, const T2& x2) {
  * @tparam C number of columns, can be Eigen::Dynamic
  * @param v1 First vector.
  * @param v2 Second vector.
- * @return Dot product of the vectors.
+ * @return Square of distance between vectors.
  * @throw std::domain_error If the vectors are not the same
  * size or if they are both not vector dimensioned.
  */
@@ -57,7 +57,7 @@ inline double squared_distance(const Eigen::Matrix<double, R, C>& v1,
  *
  * @param v1 First vector.
  * @param v2 Second vector.
- * @return Dot product of the vectors.
+ * @return Square of distance between vectors.
  * @throw std::domain_error If the vectors are not the same
  * size or if they are both not vector dimensioned.
  */

--- a/stan/math/prim/fun/subtract.hpp
+++ b/stan/math/prim/fun/subtract.hpp
@@ -28,13 +28,13 @@ inline auto subtract(const Mat1& m1, const Mat2& m2) {
 
 /**
  * Return the result of subtracting the specified matrix from the specified
- * matrix.
+ * scalar.
  *
  * @tparam Scal type of the scalar
  * @tparam Mat type of the matrix or expression
  * @param c Scalar.
  * @param m Matrix or expression.
- * @return The matrix minus the scalar.
+ * @return The scalar minus the matrix.
  */
 template <typename Scal, typename Mat, typename = require_stan_scalar_t<Scal>,
           typename = require_eigen_t<Mat>>

--- a/stan/math/prim/fun/trace_gen_inv_quad_form_ldlt.hpp
+++ b/stan/math/prim/fun/trace_gen_inv_quad_form_ldlt.hpp
@@ -13,7 +13,7 @@
 namespace stan {
 namespace math {
 
-/*
+/**
  * Compute the trace of an inverse quadratic form.  I.E., this computes
  *       trace(D B^T A^-1 B)
  * where D is a square matrix and the LDLT_factor of A is provided.

--- a/stan/math/prim/fun/trace_inv_quad_form_ldlt.hpp
+++ b/stan/math/prim/fun/trace_inv_quad_form_ldlt.hpp
@@ -13,7 +13,7 @@
 namespace stan {
 namespace math {
 
-/*
+/**
  * Compute the trace of an inverse quadratic form.  I.E., this computes
  *       trace(B^T A^-1 B)
  * where the LDLT_factor of A is provided.

--- a/stan/math/prim/meta/as_column_vector_or_scalar.hpp
+++ b/stan/math/prim/meta/as_column_vector_or_scalar.hpp
@@ -53,7 +53,7 @@ inline auto as_column_vector_or_scalar(const T& a) {
  *
  * @tparam T Type of scalar element.
  * @param a Specified vector.
- * @return intut converted to a column vector.
+ * @return input converted to a column vector.
  */
 template <typename T>
 inline Eigen::Map<const Eigen::Matrix<T, Eigen::Dynamic, 1>>

--- a/stan/math/prim/meta/is_constant.hpp
+++ b/stan/math/prim/meta/is_constant.hpp
@@ -30,7 +30,7 @@ struct is_constant : bool_constant<std::is_convertible<T, double>::value> {};
 /** \ingroup type_trait
  * Metaprogram defining an enum <code>value</code> which
  * is <code>true</code> if all of the type parameters
- * are constant (i.e., primtive types) and
+ * are constant (i.e., primitive types) and
  * <code>false</code> otherwise.
  */
 template <typename... T>

--- a/stan/math/prim/meta/is_eigen.hpp
+++ b/stan/math/prim/meta/is_eigen.hpp
@@ -8,14 +8,14 @@
 namespace stan {
 
 /** \ingroup type_trait
- * Base implimentation to check whether a type is derived from EigenBase
+ * Base implementation to check whether a type is derived from EigenBase
  */
 template <typename T, typename = void>
 struct is_eigen : std::false_type {};
 
 namespace internal {
 /*
- * Underlying implimenation to check if a type is derived from EigenBase
+ * Underlying implementation to check if a type is derived from EigenBase
  */
 template <typename T>
 struct is_eigen_base

--- a/stan/math/prim/meta/is_eigen.hpp
+++ b/stan/math/prim/meta/is_eigen.hpp
@@ -14,7 +14,7 @@ template <typename T, typename = void>
 struct is_eigen : std::false_type {};
 
 namespace internal {
-/*
+/**
  * Underlying implementation to check if a type is derived from EigenBase
  */
 template <typename T>
@@ -33,7 +33,7 @@ struct is_eigen_base<Eigen::EigenBase<T>> : std::true_type {};
 
 }  // namespace internal
 
-/*
+/**
  * Checks whether type T is derived from EigenBase. If true this will have a
  * static member function named value with a type of true, else value is false.
  */

--- a/stan/math/prim/meta/is_vector.hpp
+++ b/stan/math/prim/meta/is_vector.hpp
@@ -9,14 +9,14 @@
 namespace stan {
 
 /** \ingroup type_trait
- * Base implimentation for checking if type is std vector
+ * Base implementation for checking if type is std vector
  */
 template <typename T, typename = void>
 struct is_std_vector : std::false_type {};
 
 namespace internal {
 /** \ingroup type_trait
- * Underlying implimentation for detecting if an Eigen Matrix is a column
+ * Underlying implementation for detecting if an Eigen Matrix is a column
  * vector.
  */
 template <typename T, bool = is_eigen<T>::value>
@@ -30,7 +30,7 @@ template <typename T>
 struct is_eigen_col_vector_impl<T, false> : std::false_type {};
 
 /** \ingroup type_trait
- * Underlying implimentation for detecting if an Eigen Matrix is a row vector.
+ * Underlying implementation for detecting if an Eigen Matrix is a row vector.
  */
 template <typename T, bool = is_eigen<T>::value>
 struct is_eigen_row_vector_impl
@@ -80,13 +80,13 @@ struct is_vector
 namespace internal {
 
 /** \ingroup type_trait
- * This underlying implimentation is used when the type is not an std vector.
+ * This underlying implementation is used when the type is not an std vector.
  */
 template <typename T>
 struct is_std_vector_impl : std::false_type {};
 
 /** \ingroup type_trait
- * This specialization implimentation has a static member named value when the
+ * This specialization implementation has a static member named value when the
  * template type is an std vector.
  */
 template <typename... Args>

--- a/stan/math/prim/meta/partials_type.hpp
+++ b/stan/math/prim/meta/partials_type.hpp
@@ -4,7 +4,7 @@
 namespace stan {
 
 /** \ingroup type_trait
- * This base implimentation will contain a static member function named type
+ * This base implementation will contain a static member function named type
  * equal to the type passed into it. When this is specialized for vars the type
  * will be double and fvar<T> will have a member type of value T.
  */

--- a/stan/math/prim/meta/require_generics.hpp
+++ b/stan/math/prim/meta/require_generics.hpp
@@ -693,7 +693,7 @@ using require_any_not_container_t
     = require_any_not_t<is_container<std::decay_t<Types>>...>;
 
 /**
- * Check a templated type to see if it and it's inner type pass a condiational
+ * Check a templated type to see if it and it's inner type pass a conditional
  * test.
  * @tparam ContainerCheck Templated struct or alias that wraps a static constant
  * value called type. Used to check the container satisfies a particular type

--- a/stan/math/prim/meta/require_generics.hpp
+++ b/stan/math/prim/meta/require_generics.hpp
@@ -232,7 +232,7 @@ using require_not_same_t
     = require_not_t<std::is_same<std::decay_t<T>, std::decay_t<S>>>;
 
 /**
- * Require both types to not be the same
+ * Require all types to be the same
  */
 template <typename T, typename... Types>
 using require_all_same_t
@@ -261,7 +261,7 @@ using require_not_same_st
                                  scalar_type_t<std::decay_t<S>>>>;
 
 /**
- * Require both types to not be the same
+ * Require all types to be the same
  */
 template <typename T, typename... Types>
 using require_all_same_st
@@ -291,7 +291,7 @@ using require_not_same_vt = require_not_t<
     std::is_same<value_type_t<std::decay_t<T>>, value_type_t<std::decay_t<S>>>>;
 
 /**
- * Require both types to not be the same
+ * Require all types to be the same
  */
 template <typename T, typename... Types>
 using require_all_same_vt
@@ -693,7 +693,7 @@ using require_any_not_container_t
     = require_any_not_t<is_container<std::decay_t<Types>>...>;
 
 /**
- * Check a templated type to see if it and it's inner type pass a conditional
+ * Check a templated type to see if it and its inner type pass a conditional
  * test.
  * @tparam ContainerCheck Templated struct or alias that wraps a static constant
  * value called type. Used to check the container satisfies a particular type

--- a/stan/math/prim/meta/return_type.hpp
+++ b/stan/math/prim/meta/return_type.hpp
@@ -14,7 +14,7 @@ namespace stan {
  * Provides a member type alias named `type`, the value of which is
  * the least type under Stan's assignability relation that can be
  * assigned a `double` and all of the base types of the specified
- * arguments after removing qualfifiers (`const` and `volatile`) and
+ * arguments after removing qualifiers (`const` and `volatile`) and
  * decaying (lvalue to rvalue by removing references) and array to
  * pointer).   This type trait is used to calculate the return type
  * of real-valued functions involving heterogeneous arguments.
@@ -106,7 +106,7 @@ using row_vector_return_t = Eigen::Matrix<real_return_t<Ts...>, 1, -1>;
 /**
  * Defines a member type named `type` that is the least scalar type to
  * which both template parameter scalar types are assignable in Stan.
- * The ordering of types for which this is the leasst-upper-bound
+ * The ordering of types for which this is the least-upper-bound
  * operation is defined in the class documentation for `return_type`.
  *
  * @tparam T1 first scalar type

--- a/stan/math/prim/prob/beta_lccdf.hpp
+++ b/stan/math/prim/prob/beta_lccdf.hpp
@@ -30,7 +30,7 @@ namespace math {
  * @param y (Sequence of) scalar(s) between zero and one
  * @param alpha (Sequence of) success parameter(s)
  * @param beta (Sequence of) failure parameter(s)
- * @return log probability or sum of log of proabilities
+ * @return log probability or sum of log of probabilities
  * @throw std::domain_error if alpha or beta is negative
  * @throw std::domain_error if y is not a valid probability
  * @throw std::invalid_argument if container sizes mismatch

--- a/stan/math/prim/prob/chi_square_log.hpp
+++ b/stan/math/prim/prob/chi_square_log.hpp
@@ -10,7 +10,7 @@ namespace math {
 /** \ingroup prob_dists
  * The log of a chi-squared density for y with the specified
  * degrees of freedom parameter.
- * The degrees of freedom prarameter must be greater than 0.
+ * The degrees of freedom parameter must be greater than 0.
  * y must be greater than or equal to 0.
  *
  \f{eqnarray*}{

--- a/stan/math/prim/prob/chi_square_lpdf.hpp
+++ b/stan/math/prim/prob/chi_square_lpdf.hpp
@@ -19,7 +19,7 @@ namespace math {
 /** \ingroup prob_dists
  * The log of a chi-squared density for y with the specified
  * degrees of freedom parameter.
- * The degrees of freedom prarameter must be greater than 0.
+ * The degrees of freedom parameter must be greater than 0.
  * y must be greater than or equal to 0.
  *
  \f{eqnarray*}{

--- a/stan/math/prim/prob/inv_chi_square_log.hpp
+++ b/stan/math/prim/prob/inv_chi_square_log.hpp
@@ -10,7 +10,7 @@ namespace math {
 /** \ingroup prob_dists
  * The log of an inverse chi-squared density for y with the specified
  * degrees of freedom parameter.
- * The degrees of freedom prarameter must be greater than 0.
+ * The degrees of freedom parameter must be greater than 0.
  * y must be greater than 0.
  *
  \f{eqnarray*}{

--- a/stan/math/prim/prob/inv_chi_square_lpdf.hpp
+++ b/stan/math/prim/prob/inv_chi_square_lpdf.hpp
@@ -20,7 +20,7 @@ namespace math {
 /** \ingroup prob_dists
  * The log of an inverse chi-squared density for y with the specified
  * degrees of freedom parameter.
- * The degrees of freedom prarameter must be greater than 0.
+ * The degrees of freedom parameter must be greater than 0.
  * y must be greater than 0.
  *
  \f{eqnarray*}{

--- a/stan/math/prim/prob/multi_gp_cholesky_log.hpp
+++ b/stan/math/prim/prob/multi_gp_cholesky_log.hpp
@@ -21,7 +21,7 @@ namespace math {
  *
  * @param y A dxN matrix
  * @param L The Cholesky decomposition of a kernel matrix
- * @param w A d-dimensional vector of positve inverse scale parameters for each
+ * @param w A d-dimensional vector of positive inverse scale parameters for each
  * output.
  * @return The log of the multivariate GP density.
  * @throw std::domain_error if Sigma is not square, not symmetric,

--- a/stan/math/prim/prob/multi_gp_cholesky_lpdf.hpp
+++ b/stan/math/prim/prob/multi_gp_cholesky_lpdf.hpp
@@ -28,7 +28,7 @@ namespace math {
  *
  * @param y A dxN matrix
  * @param L The Cholesky decomposition of a kernel matrix
- * @param w A d-dimensional vector of positve inverse scale parameters for each
+ * @param w A d-dimensional vector of positive inverse scale parameters for each
  * output.
  * @return The log of the multivariate GP density.
  * @throw std::domain_error if Sigma is not square, not symmetric,

--- a/stan/math/prim/prob/multi_gp_log.hpp
+++ b/stan/math/prim/prob/multi_gp_log.hpp
@@ -20,7 +20,7 @@ namespace math {
  *
  * @param y A dxN matrix
  * @param Sigma The NxN kernel matrix
- * @param w A d-dimensional vector of positve inverse scale parameters for each
+ * @param w A d-dimensional vector of positive inverse scale parameters for each
  * output.
  * @return The log of the multivariate GP density.
  * @throw std::domain_error if Sigma is not square, not symmetric,

--- a/stan/math/prim/prob/multi_gp_lpdf.hpp
+++ b/stan/math/prim/prob/multi_gp_lpdf.hpp
@@ -20,7 +20,7 @@ namespace math {
  *
  * @param y A dxN matrix
  * @param Sigma The NxN kernel matrix
- * @param w A d-dimensional vector of positve inverse scale parameters for each
+ * @param w A d-dimensional vector of positive inverse scale parameters for each
  * output.
  * @return The log of the multivariate GP density.
  * @throw std::domain_error if Sigma is not square, not symmetric,

--- a/stan/math/prim/prob/multi_normal_cholesky_rng.hpp
+++ b/stan/math/prim/prob/multi_normal_cholesky_rng.hpp
@@ -18,7 +18,7 @@ namespace math {
  * mu can be either an Eigen::VectorXd, an Eigen::RowVectorXd, or a std::vector
  * of either of those types.
  *
- * @tparam T_loc Type of location paramater
+ * @tparam T_loc Type of location parameter
  * @tparam RNG Type of pseudo-random number generator
  * @param mu (Sequence of) location parameter(s)
  * @param L Lower Cholesky factor of target covariance matrix

--- a/stan/math/prim/prob/multi_normal_prec_rng.hpp
+++ b/stan/math/prim/prob/multi_normal_prec_rng.hpp
@@ -17,7 +17,7 @@ namespace math {
  * mu can be either an Eigen::VectorXd, an Eigen::RowVectorXd, or a
  * std::vector of either of those types.
  *
- * @tparam T_loc Type of location paramater
+ * @tparam T_loc Type of location parameter
  * @tparam RNG Type of pseudo-random number generator
  * @param mu (Sequence of) location parameter(s)
  * @param S Precision matrix

--- a/stan/math/prim/prob/multi_normal_rng.hpp
+++ b/stan/math/prim/prob/multi_normal_rng.hpp
@@ -17,7 +17,7 @@ namespace math {
  * mu can be either an Eigen::VectorXd, an Eigen::RowVectorXd, or a std::vector
  * of either of those types.
  *
- * @tparam T_loc Type of location paramater
+ * @tparam T_loc Type of location parameter
  * @tparam RNG Type of pseudo-random number generator
  * @param mu (Sequence of) location parameter(s)
  * @param S Covariance matrix

--- a/stan/math/prim/prob/multi_student_t_rng.hpp
+++ b/stan/math/prim/prob/multi_student_t_rng.hpp
@@ -19,7 +19,7 @@ namespace math {
  * mu can be either an Eigen::VectorXd, an Eigen::RowVectorXd, or a std::vector
  * of either of those types.
  *
- * @tparam T_loc Type of location paramater
+ * @tparam T_loc Type of location parameter
  * @tparam RNG Type of pseudo-random number generator
  * @param nu degrees of freedom parameter
  * @param mu (Sequence of) location parameter(s)

--- a/stan/math/prim/prob/normal_cdf.hpp
+++ b/stan/math/prim/prob/normal_cdf.hpp
@@ -24,7 +24,7 @@ namespace math {
  *
  * @param y A scalar variate.
  * @param mu The location of the normal distribution.
- * @param sigma The scale of the normal distriubtion
+ * @param sigma The scale of the normal distribution
  * @return The unit normal cdf evaluated at the specified arguments.
  * @tparam T_y Type of y.
  * @tparam T_loc Type of mean parameter.

--- a/stan/math/prim/prob/normal_cdf.hpp
+++ b/stan/math/prim/prob/normal_cdf.hpp
@@ -28,7 +28,7 @@ namespace math {
  * @return The unit normal cdf evaluated at the specified arguments.
  * @tparam T_y Type of y.
  * @tparam T_loc Type of mean parameter.
- * @tparam T_scale Type of standard deviation paramater.
+ * @tparam T_scale Type of standard deviation parameter.
  */
 template <typename T_y, typename T_loc, typename T_scale>
 inline return_type_t<T_y, T_loc, T_scale> normal_cdf(const T_y& y,

--- a/stan/math/prim/prob/normal_sufficient_lpdf.hpp
+++ b/stan/math/prim/prob/normal_sufficient_lpdf.hpp
@@ -18,7 +18,7 @@ namespace math {
 /** \ingroup prob_dists
  * The log of the normal density for the specified scalar(s) given
  * the specified mean(s) and deviation(s).
- * y, s_quared, mu, or sigma can each be either
+ * y, s_squared, mu, or sigma can each be either
  * a scalar, a std vector or Eigen vector.
  * n can be either a single int or an std vector of ints.
  * Any vector inputs must be the same length.

--- a/stan/math/prim/prob/weibull_cdf.hpp
+++ b/stan/math/prim/prob/weibull_cdf.hpp
@@ -21,7 +21,7 @@ namespace math {
  *
  * @tparam T_y type of real parameter
  * @tparam T_shape type of shape parameter
- * @tparam T_scale type of scale paramater
+ * @tparam T_scale type of scale parameter
  * @param y real parameter
  * @param alpha shape parameter
  * @param sigma scale parameter

--- a/stan/math/prim/prob/weibull_lccdf.hpp
+++ b/stan/math/prim/prob/weibull_lccdf.hpp
@@ -19,7 +19,7 @@ namespace math {
  *
  * @tparam T_y type of real parameter
  * @tparam T_shape type of shape parameter
- * @tparam T_scale type of scale paramater
+ * @tparam T_scale type of scale parameter
  * @param y real parameter
  * @param alpha shape parameter
  * @param sigma scale parameter

--- a/stan/math/prim/prob/weibull_lcdf.hpp
+++ b/stan/math/prim/prob/weibull_lcdf.hpp
@@ -20,7 +20,7 @@ namespace math {
  *
  * @tparam T_y type of real parameter
  * @tparam T_shape type of shape parameter
- * @tparam T_scale type of scale paramater
+ * @tparam T_scale type of scale parameter
  * @param y real parameter
  * @param alpha shape parameter
  * @param sigma scale parameter

--- a/stan/math/prim/prob/weibull_lpdf.hpp
+++ b/stan/math/prim/prob/weibull_lpdf.hpp
@@ -21,7 +21,7 @@ namespace math {
  *
  * @tparam T_y type of real parameter
  * @tparam T_shape type of shape parameter
- * @tparam T_scale type of scale paramater
+ * @tparam T_scale type of scale parameter
  * @param y real parameter
  * @param alpha shape parameter
  * @param sigma scale parameter

--- a/stan/math/rev/core/autodiffstackstorage.hpp
+++ b/stan/math/rev/core/autodiffstackstorage.hpp
@@ -51,7 +51,7 @@ namespace math {
  * TLS. Thus, only the __thread keyword guarantees that constant
  * initialization and its implied speedup, is used.
  *
- * The initialzation of the AD instance at run-time is handled by the
+ * The initialization of the AD instance at run-time is handled by the
  * lifetime of a AutodiffStackSingleton object. More specifically, the
  * first instance of the AutodiffStackSingleton object will initialize
  * the AD instance and take ownership (it is the only one instance

--- a/stan/math/rev/core/operator_logical_and.hpp
+++ b/stan/math/rev/core/operator_logical_and.hpp
@@ -13,7 +13,7 @@ namespace math {
  *
  * @param[in] x first argument
  * @param[in] y second argument
- * @return disjuntion of the argument's values
+ * @return conjunction of the argument's values
  */
 inline bool operator&&(var x, var y) { return x.val() && y.val(); }
 

--- a/stan/math/rev/core/operator_logical_and.hpp
+++ b/stan/math/rev/core/operator_logical_and.hpp
@@ -13,7 +13,7 @@ namespace math {
  *
  * @param[in] x first argument
  * @param[in] y second argument
- * @return conjunction of the argument's values
+ * @return conjunction of the arguments' values
  */
 inline bool operator&&(var x, var y) { return x.val() && y.val(); }
 

--- a/stan/math/rev/core/operator_logical_or.hpp
+++ b/stan/math/rev/core/operator_logical_or.hpp
@@ -13,7 +13,7 @@ namespace math {
  *
  * @param[in] x first argument
  * @param[in] y second argument
- * @return disjuntion of the argument's values
+ * @return disjunction of the argument's values
  */
 inline bool operator||(var x, var y) { return x.val() || y.val(); }
 

--- a/stan/math/rev/core/operator_logical_or.hpp
+++ b/stan/math/rev/core/operator_logical_or.hpp
@@ -13,7 +13,7 @@ namespace math {
  *
  * @param[in] x first argument
  * @param[in] y second argument
- * @return disjunction of the argument's values
+ * @return disjunction of the arguments' values
  */
 inline bool operator||(var x, var y) { return x.val() || y.val(); }
 

--- a/stan/math/rev/core/operator_subtraction.hpp
+++ b/stan/math/rev/core/operator_subtraction.hpp
@@ -129,7 +129,7 @@ inline var operator-(var a, Arith b) {
  * @tparam Arith An arithmetic type
  * @param a First scalar operand.
  * @param b Second variable operand.
- * @return Result of sutracting a variable from a scalar.
+ * @return Result of subtracting a variable from a scalar.
  */
 template <typename Arith, require_arithmetic_t<Arith>...>
 inline var operator-(Arith a, var b) {

--- a/stan/math/rev/core/var.hpp
+++ b/stan/math/rev/core/var.hpp
@@ -438,7 +438,7 @@ class var {
    * that the result is an assignable lvalue.
    *
    * @param b The scalar to multiply this variable by.
-   * @return The result of multplying this variable by the specified
+   * @return The result of multiplying this variable by the specified
    * variable.
    */
   template <typename Arith, require_arithmetic_t<Arith>...>

--- a/stan/math/rev/fun/LDLT_factor.hpp
+++ b/stan/math/rev/fun/LDLT_factor.hpp
@@ -131,7 +131,7 @@ class LDLT_factor<var, R, C> {
   /**
    * The LDLT_alloc object actually contains the factorization but is
    * derived from the chainable_alloc class so that it is allocated on the
-   * vari stack.  This ensures that it's lifespan is longer than the
+   * vari stack.  This ensures that its lifespan is longer than the
    * LDLT_factor object which created it.  This is needed because the
    * factorization is required during the chain() calls which happen
    * after an LDLT_factor object will most likely have been destroyed.

--- a/stan/math/rev/fun/beta.hpp
+++ b/stan/math/rev/fun/beta.hpp
@@ -41,7 +41,8 @@ class beta_dv_vari : public op_dv_vari {
   }
 };
 }  // namespace internal
-/*
+
+/**
  * Returns the beta function and gradients for two var inputs.
  *
    \f[
@@ -70,7 +71,7 @@ inline var beta(const var& a, const var& b) {
   return var(new internal::beta_vv_vari(a.vi_, b.vi_));
 }
 
-/*
+/**
  * Returns the beta function and gradient for first var input.
  *
    \f[
@@ -92,7 +93,7 @@ inline var beta(const var& a, double b) {
   return var(new internal::beta_vd_vari(a.vi_, b));
 }
 
-/*
+/**
  * Returns the beta function and gradient for second var input.
  *
    \f[

--- a/stan/math/rev/fun/fdim.hpp
+++ b/stan/math/rev/fun/fdim.hpp
@@ -54,7 +54,7 @@ class fdim_dv_vari : public op_dv_vari {
  * Return the positive difference between the first variable's the value
  * and the second's (C99, C++11).
  *
- * The function values and deriatives are defined by
+ * The function values and derivatives are defined by
  *
    \f[
    \mbox{fdim}(x, y) =

--- a/stan/math/rev/fun/fma.hpp
+++ b/stan/math/rev/fun/fma.hpp
@@ -231,7 +231,7 @@ inline var fma(Ta&& a, Tb&& b, const var& c) {
  * (C99).  This function returns the product of the first two
  * arguments plus the third argument.
  *
- * The partial derivaties are
+ * The partial derivatives are
  *
  * \f$\frac{\partial}{\partial y} (c * y) + z = c\f$, and
  *

--- a/stan/math/rev/fun/fmax.hpp
+++ b/stan/math/rev/fun/fmax.hpp
@@ -77,7 +77,7 @@ inline var fmax(const var& a, const var& b) {
  * scalar to a variable if it is larger (C99).
  *
  * For <code>fmax(a, b)</code>, if a's value is greater than b,
- * then a is returned, otherwise a fesh variable implementation
+ * then a is returned, otherwise a fresh variable implementation
  * wrapping the value b is returned.
  *
  * @param a First variable.

--- a/stan/math/rev/fun/lbeta.hpp
+++ b/stan/math/rev/fun/lbeta.hpp
@@ -41,7 +41,7 @@ class lbeta_dv_vari : public op_dv_vari {
 };
 }  // namespace internal
 
-/*
+/**
  * Returns the natural logarithm of the beta function and its gradients.
  *
    \f[
@@ -65,7 +65,7 @@ inline var lbeta(const var& a, const var& b) {
   return var(new internal::lbeta_vv_vari(a.vi_, b.vi_));
 }
 
-/*
+/**
  * Returns the natural logarithm of the beta function and its gradients.
  *
    \f[
@@ -84,7 +84,7 @@ inline var lbeta(const var& a, double b) {
   return var(new internal::lbeta_vd_vari(a.vi_, b));
 }
 
-/*
+/**
  * Returns the natural logarithm of the beta function and its gradients.
  *
    \f[

--- a/stan/math/rev/fun/lgamma.hpp
+++ b/stan/math/rev/fun/lgamma.hpp
@@ -20,7 +20,7 @@ class lgamma_vari : public op_v_vari {
 /**
  * The log gamma function for variables (C99).
  *
- * The derivatie is the digamma function,
+ * The derivative is the digamma function,
  *
  * \f$\frac{d}{dx} \Gamma(x) = \psi^{(0)}(x)\f$.
  *

--- a/stan/math/rev/fun/log1m_exp.hpp
+++ b/stan/math/rev/fun/log1m_exp.hpp
@@ -22,7 +22,7 @@ class log1m_exp_v_vari : public op_v_vari {
  * Return the log of 1 minus the exponential of the specified
  * variable.
  *
- * <p>The deriative of <code>log(1 - exp(x))</code> with respect
+ * <p>The derivative of <code>log(1 - exp(x))</code> with respect
  * to <code>x</code> is <code>-1 / expm1(-x)</code>.
  *
  * @param[in] x Argument.

--- a/stan/math/rev/fun/log_inv_logit_diff.hpp
+++ b/stan/math/rev/fun/log_inv_logit_diff.hpp
@@ -11,7 +11,7 @@
 namespace stan {
 namespace math {
 
-/*
+/**
  * Returns the natural logarithm of the difference of the
  * inverse logits of the specified arguments and its gradients.
  *

--- a/stan/math/rev/fun/multiply.hpp
+++ b/stan/math/rev/fun/multiply.hpp
@@ -545,11 +545,8 @@ class multiply_mat_vari<Ta, 1, Ca, double, 1> : public vari {
 /**
  * Return the product of two matrices.
  *
- * @tparam Ta type of elements in matrix A
- * @tparam Ra number of rows in matrix A, can be Eigen::Dynamic
- * @tparam Ca number of columns in matrix A and rows in matrix B
- * @tparam Tb type of elements in matrix B
- * @tparam Cb number of columns in matrix B, can be Eigen::Dynamic
+ * @tparam Mat1 type of first matrix
+ * @tparam Mat2 type of second matrix
  *
  * @param[in] A Matrix
  * @param[in] B Matrix

--- a/stan/math/rev/fun/multiply_log.hpp
+++ b/stan/math/rev/fun/multiply_log.hpp
@@ -63,8 +63,8 @@ class multiply_log_dv_vari : public op_dv_vari {
  * Return the value of a*log(b).
  *
  * When both a and b are 0, the value returned is 0.
- * The partial deriviative with respect to a is log(b).
- * The partial deriviative with respect to b is a/b. When
+ * The partial derivative with respect to a is log(b).
+ * The partial derivative with respect to b is a/b. When
  * a and b are both 0, this is set to Inf.
  *
  * @param a First variable.
@@ -78,7 +78,7 @@ inline var multiply_log(const var& a, const var& b) {
  * Return the value of a*log(b).
  *
  * When both a and b are 0, the value returned is 0.
- * The partial deriviative with respect to a is log(b).
+ * The partial derivative with respect to a is log(b).
  *
  * @param a First variable.
  * @param b Second scalar.
@@ -91,7 +91,7 @@ inline var multiply_log(const var& a, double b) {
  * Return the value of a*log(b).
  *
  * When both a and b are 0, the value returned is 0.
- * The partial deriviative with respect to b is a/b. When
+ * The partial derivative with respect to b is a/b. When
  * a and b are both 0, this is set to Inf.
  *
  * @param a First scalar.

--- a/stan/math/rev/fun/ordered_constrain.hpp
+++ b/stan/math/rev/fun/ordered_constrain.hpp
@@ -49,7 +49,7 @@ class ordered_constrain_op {
     return y;
   }
 
-  /*
+  /**
    * Compute the result of multiply the transpose of the adjoint vector times
    * the Jacobian of the ordered_constrain operator.
    *

--- a/stan/math/rev/fun/positive_ordered_constrain.hpp
+++ b/stan/math/rev/fun/positive_ordered_constrain.hpp
@@ -49,7 +49,7 @@ class positive_ordered_constrain_op {
     return y;
   }
 
-  /*
+  /**
    * Compute the result of multiply the transpose of the adjoint vector times
    * the Jacobian of the positive_ordered_constrain operator.
    *

--- a/stan/math/rev/fun/sd.hpp
+++ b/stan/math/rev/fun/sd.hpp
@@ -60,7 +60,7 @@ inline var sd(const std::vector<var>& v) {
   return internal::calc_sd(v.size(), &v[0]);
 }
 
-/*
+/**
  * Return the sample standard deviation of the specified vector,
  * row vector, or matrix.  Raise domain error if size is not
  * greater than zero.

--- a/stan/math/rev/fun/simplex_constrain.hpp
+++ b/stan/math/rev/fun/simplex_constrain.hpp
@@ -53,7 +53,7 @@ class simplex_constrain_op {
     return x;
   }
 
-  /*
+  /**
    * Compute the result of multiply the transpose of the adjoint vector times
    * the Jacobian of the simplex_constrain operator.
    *

--- a/stan/math/rev/fun/softmax.hpp
+++ b/stan/math/rev/fun/softmax.hpp
@@ -20,14 +20,14 @@ class softmax_op {
  public:
   softmax_op() : N_(0), y_(nullptr) {}
 
-  /*
+  /**
    * Compute the softmax of the unconstrained input vector
    *
    * @param alpha Unconstrained input vector.
    * @return Softmax of the input.
    */
   template <std::size_t size>
-  Eigen::VectorXd operator()(const std::array<bool, size>& needs_adj,
+  Eigen::VectorXd operator()(const std::array<bool, size>& /* needs_adj */,
                              const Eigen::VectorXd& alpha) {
     N_ = alpha.size();
     y_ = ChainableStack::instance_->memalloc_.alloc_array<double>(N_);
@@ -39,7 +39,7 @@ class softmax_op {
     return y;
   }
 
-  /*
+  /**
    * Compute the result of multiply the transpose of the adjoint vector times
    * the Jacobian of the softmax operator. It is more efficient to do this
    * without actually computing the Jacobian and doing the vector-matrix
@@ -50,7 +50,7 @@ class softmax_op {
    */
   template <std::size_t size>
   std::tuple<Eigen::VectorXd> multiply_adjoint_jacobian(
-      const std::array<bool, size>& needs_adj,
+      const std::array<bool, size>& /* needs_adj */,
       const Eigen::VectorXd& adj) const {
     vector_d adj_times_jac(N_);
     Eigen::Map<vector_d> y(y_, N_);

--- a/stan/math/rev/fun/trunc.hpp
+++ b/stan/math/rev/fun/trunc.hpp
@@ -23,7 +23,7 @@ class trunc_vari : public op_v_vari {
 }  // namespace internal
 
 /**
- * Returns the truncatation of the specified variable (C99).
+ * Returns the truncation of the specified variable (C99).
  *
  * See ::trunc() for the double-based version.
  *

--- a/stan/math/rev/fun/variance.hpp
+++ b/stan/math/rev/fun/variance.hpp
@@ -46,7 +46,7 @@ inline var variance(const std::vector<var>& v) {
   return internal::calc_variance(v.size(), &v[0]);
 }
 
-/*
+/**
  * Return the sample variance of the specified vector, row vector,
  * or matrix.  Raise domain error if size is not greater than
  * zero.

--- a/stan/math/rev/functor/algebra_solver_fp.hpp
+++ b/stan/math/rev/functor/algebra_solver_fp.hpp
@@ -47,7 +47,7 @@ struct KinsolFixedPointEnv {
   const std::vector<double>& x_r_;
   /** integer data */
   const std::vector<int>& x_i_;
-  /** messege stream */
+  /** message stream */
   std::ostream* msgs_;
   /** KINSOL memory block */
   void* mem_;
@@ -129,7 +129,7 @@ struct KinsolFixedPointEnv {
 };
 
 /*
- * Calculate Jacobian Jxy(Jacobian of unkonwn x w.r.t. the * param y)
+ * Calculate Jacobian Jxy(Jacobian of unknown x w.r.t. the * param y)
  * given the solution. Specifically, for
  *
  *  x - f(x, y) = 0
@@ -152,7 +152,7 @@ struct FixedPointADJac {
    * @tparam F RHS functor type
    * @param x fixed point solution
    * @param y RHS parameters
-   * @param env KINSOL working envionment, see doc for @c KinsolFixedPointEnv.
+   * @param env KINSOL working environment, see doc for @c KinsolFixedPointEnv.
    */
   template <typename F>
   inline Eigen::Matrix<stan::math::var, -1, 1> operator()(
@@ -227,8 +227,8 @@ struct FixedPointSolver<KinsolFixedPointEnv<F>, fp_jac_type> {
    * Solve FP using KINSOL
    *
    * @param x initial point and final solution.
-   * @param env KINSOL solution envionment
-   * @param f_tol Function tolenrance
+   * @param env KINSOL solution environment
+   * @param f_tol Function tolerance
    * @param max_num_steps max nb. of iterations.
    */
   void kinsol_solve_fp(Eigen::VectorXd& x, KinsolFixedPointEnv<F>& env,
@@ -264,8 +264,8 @@ struct FixedPointSolver<KinsolFixedPointEnv<F>, fp_jac_type> {
    *
    * @param x initial point and final solution.
    * @param y RHS functor parameters
-   * @param env KINSOL solution envionment
-   * @param f_tol Function tolenrance
+   * @param env KINSOL solution environment
+   * @param f_tol Function tolerance
    * @param max_num_steps max nb. of iterations.
    */
   template <typename T1>
@@ -285,8 +285,8 @@ struct FixedPointSolver<KinsolFixedPointEnv<F>, fp_jac_type> {
    *
    * @param x initial point and final solution.
    * @param y RHS functor parameters
-   * @param env KINSOL solution envionment
-   * @param f_tol Function tolenrance
+   * @param env KINSOL solution environment
+   * @param f_tol Function tolerance
    * @param max_num_steps max nb. of iterations.
    */
   template <typename T1>
@@ -318,7 +318,7 @@ struct FixedPointSolver<KinsolFixedPointEnv<F>, fp_jac_type> {
  * tolerance, and the maximum number of steps.
  *
  * @tparam F type of equation system function.
- * @tparam T type of initial guess vector. The final soluton
+ * @tparam T type of initial guess vector. The final solution
  *           type doesn't depend on initial guess type,
  *           but we allow initial guess to be either data or param.
  * @tparam T_u type of scaling vector for unknowns. We allow

--- a/stan/math/rev/functor/algebra_solver_fp.hpp
+++ b/stan/math/rev/functor/algebra_solver_fp.hpp
@@ -58,7 +58,7 @@ struct KinsolFixedPointEnv {
   /** NVECTOR for scaling f */
   N_Vector nv_f_scal_;
 
-  /* Constructor when @y is data */
+  /** Constructor when y is data */
   template <typename T, typename T_u, typename T_f>
   KinsolFixedPointEnv(const F& f, const Eigen::Matrix<T, -1, 1>& x,
                       const Eigen::VectorXd& y, const std::vector<double>& x_r,
@@ -84,7 +84,7 @@ struct KinsolFixedPointEnv {
     }
   }
 
-  /* Constructor when @y is param */
+  /** Constructor when y is param */
   template <typename T, typename T_u, typename T_f>
   KinsolFixedPointEnv(const F& f, const Eigen::Matrix<T, -1, 1>& x,
                       const Eigen::Matrix<stan::math::var, -1, 1>& y,
@@ -118,7 +118,7 @@ struct KinsolFixedPointEnv {
     KINFree(&mem_);
   }
 
-  /* Implements the user-defined function passed to KINSOL. */
+  /** Implements the user-defined function passed to KINSOL. */
   static int kinsol_f_system(N_Vector x, N_Vector f, void* user_data) {
     auto g = static_cast<const KinsolFixedPointEnv<F>*>(user_data);
     Eigen::VectorXd x_eigen(Eigen::Map<Eigen::VectorXd>(NV_DATA_S(x), g->N_));
@@ -128,7 +128,7 @@ struct KinsolFixedPointEnv {
   }
 };
 
-/*
+/**
  * Calculate Jacobian Jxy(Jacobian of unknown x w.r.t. the * param y)
  * given the solution. Specifically, for
  *
@@ -146,7 +146,7 @@ struct KinsolFixedPointEnv {
  * w.r.t combined vector [x, y].
  */
 struct FixedPointADJac {
-  /*
+  /**
    * Calculate Jacobian Jxy.
    *
    * @tparam F RHS functor type
@@ -193,7 +193,7 @@ struct FixedPointADJac {
   }
 };
 
-/*
+/**
  * Fixed point solver for problem of form
  *
  * x = F(x; theta)
@@ -215,7 +215,7 @@ struct FixedPointADJac {
 template <typename fp_env_type, typename fp_jac_type>
 struct FixedPointSolver;
 
-/*
+/**
  * Specialization for fixed point solver when using KINSOL.
  *
  * @tparam F RHS functor for fixed point iteration.
@@ -223,7 +223,7 @@ struct FixedPointSolver;
  */
 template <typename F, typename fp_jac_type>
 struct FixedPointSolver<KinsolFixedPointEnv<F>, fp_jac_type> {
-  /*
+  /**
    * Solve FP using KINSOL
    *
    * @param x initial point and final solution.
@@ -257,7 +257,7 @@ struct FixedPointSolver<KinsolFixedPointEnv<F>, fp_jac_type> {
     }
   }
 
-  /*
+  /**
    * Solve data-only FP problem so no need to calculate jacobian.
    *
    * @tparam T1 type of init point of iterations
@@ -278,7 +278,7 @@ struct FixedPointSolver<KinsolFixedPointEnv<F>, fp_jac_type> {
     return xd;
   }
 
-  /*
+  /**
    * Solve FP problem and calculate jacobian.
    *
    * @tparam T1 type of init point of iterations

--- a/stan/math/rev/functor/algebra_system.hpp
+++ b/stan/math/rev/functor/algebra_system.hpp
@@ -140,7 +140,7 @@ struct hybrj_functor_solver : nlo_functor<double> {
    * Performs the same task as the operator(), but returns the
    * Jacobian, instead of saving it inside an argument
    * passed by reference.
-   * @param [in] iv indepdent variable.
+   * @param [in] iv independent variable.
    */
   Eigen::MatrixXd get_jacobian(const Eigen::VectorXd& iv) {
     Eigen::VectorXd fvec;

--- a/stan/math/rev/functor/coupled_ode_system.hpp
+++ b/stan/math/rev/functor/coupled_ode_system.hpp
@@ -146,7 +146,7 @@ struct coupled_ode_system<F, double, var> {
       nested.set_zero_all_adjoints();
       // Parameters stored on the outer (non-nested) nochain stack are not
       // reset to zero by the last call. This is done as a separate step here.
-      // See efficiency note above on template specalization for more details
+      // See efficiency note above on template specialization for more details
       // on this.
       for (size_t j = 0; j < M_; ++j) {
         theta_nochain_[j].vi_->set_zero_adjoint();
@@ -481,7 +481,7 @@ struct coupled_ode_system<F, var, var> {
       nested.set_zero_all_adjoints();
       // Parameters stored on the outer (non-nested) nochain stack are not
       // reset to zero by the last call. This is done as a separate step here.
-      // See efficiency note above on template specalization for more details
+      // See efficiency note above on template specialization for more details
       // on this.
       for (size_t j = 0; j < M_; ++j) {
         theta_nochain_[j].vi_->set_zero_adjoint();

--- a/stan/math/rev/functor/cvodes_integrator.hpp
+++ b/stan/math/rev/functor/cvodes_integrator.hpp
@@ -45,7 +45,7 @@ class cvodes_integrator {
    *
    * The solver used is based on the backward differentiation
    * formula which is an implicit numerical integration scheme
-   * appropiate for stiff ODE systems.
+   * appropriate for stiff ODE systems.
    *
    * @tparam F type of ODE system function.
    * @tparam T_initial type of scalars for initial values.

--- a/stan/math/rev/functor/cvodes_ode_data.hpp
+++ b/stan/math/rev/functor/cvodes_ode_data.hpp
@@ -54,7 +54,7 @@ class cvodes_ode_data {
    * RHS (<code>cv_rhs_sens</code>) and for the ODE Jacobian wrt
    * to the states (<code>cv_jacobian_states</code>).
    *
-   * The callbacks required by CVODES are detailled in
+   * The callbacks required by CVODES are detailed in
    * https://computation.llnl.gov/sites/default/files/public/cvs_guide.pdf
    *
    * Note: The supplied callbacks do always return 0 which flags to

--- a/stan/math/rev/functor/idas_integrator.hpp
+++ b/stan/math/rev/functor/idas_integrator.hpp
@@ -31,7 +31,7 @@ class idas_integrator {
   void init_sensitivity(Dae& dae);
 
   /**
-   * Placeholder for data-only idas_forward_system, no sensitivty
+   * Placeholder for data-only idas_forward_system, no sensitivity
    *
    * @tparam F DAE functor type.
    * @param[in] dae DAE system
@@ -199,7 +199,7 @@ void idas_integrator::init_sensitivity(Dae& dae) {
 
 /**
  *
- * Solve DAE system, no sensitivty
+ * Solve DAE system, no sensitivity
  *
  * @tparam F DAE functor type
  * @param[out] dae DAE system
@@ -226,7 +226,7 @@ void idas_integrator::solve(idas_forward_system<F, double, double, double>& dae,
 
 /**
  *
- * Solve Dae system with forward sensitivty, return a
+ * Solve Dae system with forward sensitivity, return a
  * vector of var with precomputed gradient as sensitivity value
  *
  * @tparam Dae DAE system type

--- a/stan/math/rev/functor/idas_system.hpp
+++ b/stan/math/rev/functor/idas_system.hpp
@@ -73,7 +73,7 @@ namespace stan {
 namespace math {
 
 /**
- * IDAS DAE system that contains informtion on residual
+ * IDAS DAE system that contains information on residual
  * equation functor, sensitivity residual equation functor,
  * as well as initial conditions. This is a base type that
  * is intended to contain common values used by forward

--- a/stan/math/rev/functor/integrate_dae.hpp
+++ b/stan/math/rev/functor/integrate_dae.hpp
@@ -27,7 +27,7 @@ namespace math {
  * @param[in] theta parameters
  * @param[in] x_r real data
  * @param[in] x_i int data
- * @param[in] rtol relative tolerance passed to IDAS, requred <10^-3
+ * @param[in] rtol relative tolerance passed to IDAS, required <10^-3
  * @param[in] atol absolute tolerance passed to IDAS, problem-dependent
  * @param[in] max_num_steps maximal number of admissable steps
  * between time-points

--- a/test/prob/beta/beta_ccdf_log_test.hpp
+++ b/test/prob/beta/beta_ccdf_log_test.hpp
@@ -13,7 +13,7 @@ class AgradCcdfLogBeta : public AgradCcdfLogTest {
 
     param[0] = 0.5;  // y
     param[1] = 2.0;  // alpha (Success Scale)
-    param[2] = 5.0;  // beta  (Faiulre Scale)
+    param[2] = 5.0;  // beta  (Failure Scale)
     parameters.push_back(param);
     log_ccdf.push_back(std::log(1.0 - 0.890625));  // expected Log_CCDF
   }

--- a/test/prob/beta/beta_cdf_log_test.hpp
+++ b/test/prob/beta/beta_cdf_log_test.hpp
@@ -13,7 +13,7 @@ class AgradCdfLogBeta : public AgradCdfLogTest {
 
     param[0] = 0.5;  // y
     param[1] = 2.0;  // alpha (Success Scale)
-    param[2] = 5.0;  // beta  (Faiulre Scale)
+    param[2] = 5.0;  // beta  (Failure Scale)
     parameters.push_back(param);
     log_cdf.push_back(std::log(0.890625));  // expected Log_CDF
   }

--- a/test/prob/beta/beta_cdf_test.hpp
+++ b/test/prob/beta/beta_cdf_test.hpp
@@ -12,7 +12,7 @@ class AgradCdfBeta : public AgradCdfTest {
 
     param[0] = 0.5;  // y
     param[1] = 2.0;  // alpha (Success Scale)
-    param[2] = 5.0;  // beta  (Faiulre Scale)
+    param[2] = 5.0;  // beta  (Failure Scale)
     parameters.push_back(param);
     cdf.push_back(0.890625);  // expected CDF
   }

--- a/test/unit/math/prim/meta/apply_template_permutations.hpp
+++ b/test/unit/math/prim/meta/apply_template_permutations.hpp
@@ -33,7 +33,7 @@ struct apply_template_permutations_helper {
 };
 
 /*
- * This edge case catches when the paramht-most argument has completed one
+ * This edge case catches when the right-most argument has completed one
  * iteration through all types. It computes func<types1[I], types2[J],
  * types3[0]>, carries from the second argument, and continues the recursion.
  *

--- a/test/unit/math/rev/fun/jacobian.hpp
+++ b/test/unit/math/rev/fun/jacobian.hpp
@@ -17,7 +17,7 @@ namespace math {
  * variables.
  *
  * A typical use case would be to take the Jacobian of a function
- * from independent variables to dependentant variables.  For instance,
+ * from independent variables to dependent variables.  For instance,
  *
  * <pre>
  * std::vector<var> f(std::vector<var>& x) { ... }
@@ -34,7 +34,7 @@ namespace math {
  * <code><i>d</i>y[m]/<i>d</i>x[n]</code>.
  *
  * @param[in] dependents Dependent (output) variables.
- * @param[in] independents Indepent (input) variables.
+ * @param[in] independents Independent (input) variables.
  * @param[out] jacobian Jacobian of the transform.
  */
 inline void jacobian(std::vector<var>& dependents,

--- a/test/unit/math/rev/functor/map_rect_mpi_prim_test.cpp
+++ b/test/unit/math/rev/functor/map_rect_mpi_prim_test.cpp
@@ -109,7 +109,7 @@ TEST_F(MpiJob, always_faulty_functor) {
                         shared_params_d, job_params_d, x_r, x_i)),
                    std::domain_error, "Error during MPI evaluation.");
 
-  // thorwing on the very first evaluation
+  // throwing on the very first evaluation
   EXPECT_THROW_MSG((result = stan::math::map_rect<3, faulty_functor>(
                         shared_params_d, job_params_d, x_r, x_i)),
                    std::domain_error, "MPI error on first evaluation.");

--- a/test/unit/math/serializer.hpp
+++ b/test/unit/math/serializer.hpp
@@ -12,7 +12,7 @@ namespace test {
 /**
  * A class to store a sequence of values which can be deserialized
  * back into structured objects such as scalars, vectors, and
- * matrixes.
+ * matrices.
  *
  * @tparam T type of scalars
  */
@@ -106,7 +106,7 @@ struct deserializer {
 };
 
 /**
- * A structure to serialize structures to an internall stored sequence
+ * A structure to serialize structures to an internal stored sequence
  * of scalars.
  *
  * @tparam T underlying scalar type

--- a/test/unit/math/test_ad.hpp
+++ b/test/unit/math/test_ad.hpp
@@ -389,7 +389,7 @@ void expect_all_throw(const F& f, double x1, double x2) {
 
 /**
  * Succeeds if the specified function applied to the specified
- * argument thorws an exception at every level of autodiff.
+ * argument throws an exception at every level of autodiff.
  *
  * @tparam F type of function
  * @param f function to evaluate

--- a/test/unit/math/util.hpp
+++ b/test/unit/math/util.hpp
@@ -10,7 +10,7 @@ namespace test {
 
 /**
  * Return the Eigen vector with the same size and elements as the
- * specified standard vector.  Elements are copied from the specifed
+ * specified standard vector.  Elements are copied from the specified
  * input vector.
  *
  * @tparam T type of scalars in containers


### PR DESCRIPTION
## Summary

Copypasta and typos. Document the third option in the boost_policy.

Shout out to this tool that I used to find the typos https://github.com/louis-langholtz/pyspellcode.

Closes #1755.

## Tests

None.

## Side Effects

Nope.

## Release Notes
Miscellaneous doxygen documentation cleanup.

I updated RELEASE_NOTES.md too. Probably we don't need a release notes entry for typos, but at release time its easier to delete an entry than reconstruct one. If we don't want it I can delete it from this PR without restarting the CI process.

## Checklist

- [X] Math issue #1755
- [X] Copyright holder: Peter Wicks Stringfield

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [X] the new changes are tested
