### PR TITLE
Move size_zero() calls after other consistency checks (A-I)

### DIFF
--- a/stan/math/prim/err/check_bounded.hpp
+++ b/stan/math/prim/err/check_bounded.hpp
@@ -7,6 +7,7 @@
 #include <stan/math/prim/fun/get.hpp>
 #include <stan/math/prim/fun/max_size.hpp>
 #include <stan/math/prim/fun/size.hpp>
+#include <stan/math/prim/fun/size_zero.hpp>
 #include <string>
 
 namespace stan {
@@ -72,6 +73,9 @@ struct bounded<T_y, T_low, T_high, true> {
 template <typename T_y, typename T_low, typename T_high>
 inline void check_bounded(const char* function, const char* name, const T_y& y,
                           const T_low& low, const T_high& high) {
+  if (size_zero(y, low, high)) {
+    return;
+  }
   internal::bounded<T_y, T_low, T_high, is_vector_like<T_y>::value>::check(
       function, name, y, low, high);
 }

--- a/stan/math/prim/prob/bernoulli_cdf.hpp
+++ b/stan/math/prim/prob/bernoulli_cdf.hpp
@@ -26,25 +26,23 @@ namespace math {
  */
 template <typename T_n, typename T_prob>
 return_type_t<T_prob> bernoulli_cdf(const T_n& n, const T_prob& theta) {
-  static const char* function = "bernoulli_cdf";
   using T_partials_return = partials_return_t<T_n, T_prob>;
+  static const char* function = "bernoulli_cdf";
+  check_finite(function, "Probability parameter", theta);
+  check_bounded(function, "Probability parameter", theta, 0.0, 1.0);
+  check_consistent_sizes(function, "Random variable", n,
+                         "Probability parameter", theta);
 
   if (size_zero(n, theta)) {
     return 1.0;
   }
 
   T_partials_return P(1.0);
-
-  check_finite(function, "Probability parameter", theta);
-  check_bounded(function, "Probability parameter", theta, 0.0, 1.0);
-  check_consistent_sizes(function, "Random variable", n,
-                         "Probability parameter", theta);
+  operands_and_partials<T_prob> ops_partials(theta);
 
   scalar_seq_view<T_n> n_vec(n);
   scalar_seq_view<T_prob> theta_vec(theta);
   size_t max_size_seq_view = max_size(n, theta);
-
-  operands_and_partials<T_prob> ops_partials(theta);
 
   // Explicit return for extreme values
   // The gradients are technically ill-defined, but treated as zero

--- a/stan/math/prim/prob/bernoulli_lccdf.hpp
+++ b/stan/math/prim/prob/bernoulli_lccdf.hpp
@@ -29,26 +29,24 @@ namespace math {
  */
 template <typename T_n, typename T_prob>
 return_type_t<T_prob> bernoulli_lccdf(const T_n& n, const T_prob& theta) {
-  static const char* function = "bernoulli_lccdf";
   using T_partials_return = partials_return_t<T_n, T_prob>;
-
-  if (size_zero(n, theta)) {
-    return 0.0;
-  }
-
-  T_partials_return P(0.0);
-
+  static const char* function = "bernoulli_lccdf";
   check_finite(function, "Probability parameter", theta);
   check_bounded(function, "Probability parameter", theta, 0.0, 1.0);
   check_consistent_sizes(function, "Random variable", n,
                          "Probability parameter", theta);
 
+  if (size_zero(n, theta)) {
+    return 0.0;
+  }
+
+  using std::log;
+  T_partials_return P(0.0);
+  operands_and_partials<T_prob> ops_partials(theta);
+
   scalar_seq_view<T_n> n_vec(n);
   scalar_seq_view<T_prob> theta_vec(theta);
   size_t max_size_seq_view = max_size(n, theta);
-
-  using std::log;
-  operands_and_partials<T_prob> ops_partials(theta);
 
   // Explicit return for extreme values
   // The gradients are technically ill-defined, but treated as zero

--- a/stan/math/prim/prob/bernoulli_lcdf.hpp
+++ b/stan/math/prim/prob/bernoulli_lcdf.hpp
@@ -29,26 +29,24 @@ namespace math {
  */
 template <typename T_n, typename T_prob>
 return_type_t<T_prob> bernoulli_lcdf(const T_n& n, const T_prob& theta) {
-  static const char* function = "bernoulli_lcdf";
   using T_partials_return = partials_return_t<T_n, T_prob>;
-
-  if (size_zero(n, theta)) {
-    return 0.0;
-  }
-
-  T_partials_return P(0.0);
-
+  static const char* function = "bernoulli_lcdf";
   check_finite(function, "Probability parameter", theta);
   check_bounded(function, "Probability parameter", theta, 0.0, 1.0);
   check_consistent_sizes(function, "Random variable", n,
                          "Probability parameter", theta);
 
+  if (size_zero(n, theta)) {
+    return 0.0;
+  }
+
+  using std::log;
+  T_partials_return P(0.0);
+  operands_and_partials<T_prob> ops_partials(theta);
+
   scalar_seq_view<T_n> n_vec(n);
   scalar_seq_view<T_prob> theta_vec(theta);
   size_t max_size_seq_view = max_size(n, theta);
-
-  using std::log;
-  operands_and_partials<T_prob> ops_partials(theta);
 
   // Explicit return for extreme values
   // The gradients are technically ill-defined, but treated as zero

--- a/stan/math/prim/prob/bernoulli_logit_lpmf.hpp
+++ b/stan/math/prim/prob/bernoulli_logit_lpmf.hpp
@@ -27,30 +27,27 @@ namespace math {
  */
 template <bool propto, typename T_n, typename T_prob>
 return_type_t<T_prob> bernoulli_logit_lpmf(const T_n& n, const T_prob& theta) {
-  static const char* function = "bernoulli_logit_lpmf";
   using T_partials_return = partials_return_t<T_n, T_prob>;
-
-  using std::exp;
-
-  if (size_zero(n, theta)) {
-    return 0.0;
-  }
-
-  T_partials_return logp(0.0);
-
+  static const char* function = "bernoulli_logit_lpmf";
   check_bounded(function, "n", n, 0, 1);
   check_not_nan(function, "Logit transformed probability parameter", theta);
   check_consistent_sizes(function, "Random variable", n,
                          "Probability parameter", theta);
 
+  if (size_zero(n, theta)) {
+    return 0.0;
+  }
   if (!include_summand<propto, T_prob>::value) {
     return 0.0;
   }
 
+  using std::exp;
+  T_partials_return logp(0.0);
+  operands_and_partials<T_prob> ops_partials(theta);
+
   scalar_seq_view<T_n> n_vec(n);
   scalar_seq_view<T_prob> theta_vec(theta);
   size_t N = max_size(n, theta);
-  operands_and_partials<T_prob> ops_partials(theta);
 
   for (size_t n = 0; n < N; n++) {
     const T_partials_return theta_dbl = value_of(theta_vec[n]);

--- a/stan/math/prim/prob/bernoulli_lpmf.hpp
+++ b/stan/math/prim/prob/bernoulli_lpmf.hpp
@@ -28,31 +28,28 @@ namespace math {
  */
 template <bool propto, typename T_n, typename T_prob>
 return_type_t<T_prob> bernoulli_lpmf(const T_n& n, const T_prob& theta) {
-  static const char* function = "bernoulli_lpmf";
   using T_partials_return = partials_return_t<T_n, T_prob>;
-
-  using std::log;
-
-  if (size_zero(n, theta)) {
-    return 0.0;
-  }
-
-  T_partials_return logp(0.0);
-
+  static const char* function = "bernoulli_lpmf";
   check_bounded(function, "n", n, 0, 1);
   check_finite(function, "Probability parameter", theta);
   check_bounded(function, "Probability parameter", theta, 0.0, 1.0);
   check_consistent_sizes(function, "Random variable", n,
                          "Probability parameter", theta);
 
+  if (size_zero(n, theta)) {
+    return 0.0;
+  }
   if (!include_summand<propto, T_prob>::value) {
     return 0.0;
   }
 
+  using std::log;
+  T_partials_return logp(0.0);
+  operands_and_partials<T_prob> ops_partials(theta);
+
   scalar_seq_view<T_n> n_vec(n);
   scalar_seq_view<T_prob> theta_vec(theta);
   size_t N = max_size(n, theta);
-  operands_and_partials<T_prob> ops_partials(theta);
 
   if (size(theta) == 1) {
     size_t sum = 0;

--- a/stan/math/prim/prob/bernoulli_rng.hpp
+++ b/stan/math/prim/prob/bernoulli_rng.hpp
@@ -29,9 +29,7 @@ inline typename VectorBuilder<true, int, T_theta>::type bernoulli_rng(
     const T_theta& theta, RNG& rng) {
   using boost::bernoulli_distribution;
   using boost::variate_generator;
-
   static const char* function = "bernoulli_rng";
-
   check_finite(function, "Probability parameter", theta);
   check_bounded(function, "Probability parameter", theta, 0.0, 1.0);
 

--- a/stan/math/prim/prob/beta_binomial_cdf.hpp
+++ b/stan/math/prim/prob/beta_binomial_cdf.hpp
@@ -41,15 +41,8 @@ template <typename T_n, typename T_N, typename T_size1, typename T_size2>
 return_type_t<T_size1, T_size2> beta_binomial_cdf(const T_n& n, const T_N& N,
                                                   const T_size1& alpha,
                                                   const T_size2& beta) {
-  static const char* function = "beta_binomial_cdf";
   using T_partials_return = partials_return_t<T_n, T_N, T_size1, T_size2>;
-
-  if (size_zero(n, N, alpha, beta)) {
-    return 1.0;
-  }
-
-  T_partials_return P(1.0);
-
+  static const char* function = "beta_binomial_cdf";
   check_nonnegative(function, "Population size parameter", N);
   check_positive_finite(function, "First prior sample size parameter", alpha);
   check_positive_finite(function, "Second prior sample size parameter", beta);
@@ -58,15 +51,19 @@ return_type_t<T_size1, T_size2> beta_binomial_cdf(const T_n& n, const T_N& N,
                          "First prior sample size parameter", alpha,
                          "Second prior sample size parameter", beta);
 
+  if (size_zero(n, N, alpha, beta)) {
+    return 1.0;
+  }
+
+  using std::exp;
+  T_partials_return P(1.0);
+  operands_and_partials<T_size1, T_size2> ops_partials(alpha, beta);
+
   scalar_seq_view<T_n> n_vec(n);
   scalar_seq_view<T_N> N_vec(N);
   scalar_seq_view<T_size1> alpha_vec(alpha);
   scalar_seq_view<T_size2> beta_vec(beta);
   size_t max_size_seq_view = max_size(n, N, alpha, beta);
-
-  using std::exp;
-
-  operands_and_partials<T_size1, T_size2> ops_partials(alpha, beta);
 
   // Explicit return for extreme values
   // The gradients are technically ill-defined, but treated as zero

--- a/stan/math/prim/prob/beta_binomial_lccdf.hpp
+++ b/stan/math/prim/prob/beta_binomial_lccdf.hpp
@@ -42,15 +42,8 @@ template <typename T_n, typename T_N, typename T_size1, typename T_size2>
 return_type_t<T_size1, T_size2> beta_binomial_lccdf(const T_n& n, const T_N& N,
                                                     const T_size1& alpha,
                                                     const T_size2& beta) {
-  static const char* function = "beta_binomial_lccdf";
   using T_partials_return = partials_return_t<T_n, T_N, T_size1, T_size2>;
-
-  if (size_zero(n, N, alpha, beta)) {
-    return 0.0;
-  }
-
-  T_partials_return P(0.0);
-
+  static const char* function = "beta_binomial_lccdf";
   check_nonnegative(function, "Population size parameter", N);
   check_positive_finite(function, "First prior sample size parameter", alpha);
   check_positive_finite(function, "Second prior sample size parameter", beta);
@@ -59,16 +52,20 @@ return_type_t<T_size1, T_size2> beta_binomial_lccdf(const T_n& n, const T_N& N,
                          "First prior sample size parameter", alpha,
                          "Second prior sample size parameter", beta);
 
+  if (size_zero(n, N, alpha, beta)) {
+    return 0;
+  }
+
+  using std::exp;
+  using std::log;
+  T_partials_return P(0.0);
+  operands_and_partials<T_size1, T_size2> ops_partials(alpha, beta);
+
   scalar_seq_view<T_n> n_vec(n);
   scalar_seq_view<T_N> N_vec(N);
   scalar_seq_view<T_size1> alpha_vec(alpha);
   scalar_seq_view<T_size2> beta_vec(beta);
   size_t max_size_seq_view = max_size(n, N, alpha, beta);
-
-  using std::exp;
-  using std::log;
-
-  operands_and_partials<T_size1, T_size2> ops_partials(alpha, beta);
 
   // Explicit return for extreme values
   // The gradients are technically ill-defined, but treated as zero

--- a/stan/math/prim/prob/beta_binomial_lcdf.hpp
+++ b/stan/math/prim/prob/beta_binomial_lcdf.hpp
@@ -42,15 +42,8 @@ template <typename T_n, typename T_N, typename T_size1, typename T_size2>
 return_type_t<T_size1, T_size2> beta_binomial_lcdf(const T_n& n, const T_N& N,
                                                    const T_size1& alpha,
                                                    const T_size2& beta) {
-  static const char* function = "beta_binomial_lcdf";
   using T_partials_return = partials_return_t<T_n, T_N, T_size1, T_size2>;
-
-  if (size_zero(n, N, alpha, beta)) {
-    return 0.0;
-  }
-
-  T_partials_return P(0.0);
-
+  static const char* function = "beta_binomial_lcdf";
   check_nonnegative(function, "Population size parameter", N);
   check_positive_finite(function, "First prior sample size parameter", alpha);
   check_positive_finite(function, "Second prior sample size parameter", beta);
@@ -59,16 +52,20 @@ return_type_t<T_size1, T_size2> beta_binomial_lcdf(const T_n& n, const T_N& N,
                          "First prior sample size parameter", alpha,
                          "Second prior sample size parameter", beta);
 
+  if (size_zero(n, N, alpha, beta)) {
+    return 0;
+  }
+
+  using std::exp;
+  using std::log;
+  T_partials_return P(0.0);
+  operands_and_partials<T_size1, T_size2> ops_partials(alpha, beta);
+
   scalar_seq_view<T_n> n_vec(n);
   scalar_seq_view<T_N> N_vec(N);
   scalar_seq_view<T_size1> alpha_vec(alpha);
   scalar_seq_view<T_size2> beta_vec(beta);
   size_t max_size_seq_view = max_size(n, N, alpha, beta);
-
-  using std::exp;
-  using std::log;
-
-  operands_and_partials<T_size1, T_size2> ops_partials(alpha, beta);
 
   // Explicit return for extreme values
   // The gradients are technically ill-defined, but treated as neg infinity

--- a/stan/math/prim/prob/beta_binomial_lpmf.hpp
+++ b/stan/math/prim/prob/beta_binomial_lpmf.hpp
@@ -40,13 +40,8 @@ template <bool propto, typename T_n, typename T_N, typename T_size1,
 return_type_t<T_size1, T_size2> beta_binomial_lpmf(const T_n& n, const T_N& N,
                                                    const T_size1& alpha,
                                                    const T_size2& beta) {
-  static const char* function = "beta_binomial_lpmf";
   using T_partials_return = partials_return_t<T_size1, T_size2>;
-
-  if (size_zero(n, N, alpha, beta))
-    return 0.0;
-
-  T_partials_return logp(0.0);
+  static const char* function = "beta_binomial_lpmf";
   check_nonnegative(function, "Population size parameter", N);
   check_positive_finite(function, "First prior sample size parameter", alpha);
   check_positive_finite(function, "Second prior sample size parameter", beta);
@@ -55,9 +50,14 @@ return_type_t<T_size1, T_size2> beta_binomial_lpmf(const T_n& n, const T_N& N,
                          "First prior sample size parameter", alpha,
                          "Second prior sample size parameter", beta);
 
-  if (!include_summand<propto, T_size1, T_size2>::value)
+  if (size_zero(n, N, alpha, beta)) {
     return 0.0;
+  }
+  if (!include_summand<propto, T_size1, T_size2>::value) {
+    return 0.0;
+  }
 
+  T_partials_return logp(0.0);
   operands_and_partials<T_size1, T_size2> ops_partials(alpha, beta);
 
   scalar_seq_view<T_n> n_vec(n);

--- a/stan/math/prim/prob/beta_binomial_rng.hpp
+++ b/stan/math/prim/prob/beta_binomial_rng.hpp
@@ -33,7 +33,6 @@ inline typename VectorBuilder<true, int, T_N, T_shape1, T_shape2>::type
 beta_binomial_rng(const T_N &N, const T_shape1 &alpha, const T_shape2 &beta,
                   RNG &rng) {
   static const char *function = "beta_binomial_rng";
-
   check_nonnegative(function, "Population size parameter", N);
   check_positive_finite(function, "First prior sample size parameter", alpha);
   check_positive_finite(function, "Second prior sample size parameter", beta);

--- a/stan/math/prim/prob/beta_cdf.hpp
+++ b/stan/math/prim/prob/beta_cdf.hpp
@@ -34,15 +34,7 @@ template <typename T_y, typename T_scale_succ, typename T_scale_fail>
 return_type_t<T_y, T_scale_succ, T_scale_fail> beta_cdf(
     const T_y& y, const T_scale_succ& alpha, const T_scale_fail& beta) {
   using T_partials_return = partials_return_t<T_y, T_scale_succ, T_scale_fail>;
-
-  if (size_zero(y, alpha, beta)) {
-    return 1.0;
-  }
-
   static const char* function = "beta_cdf";
-
-  T_partials_return P(1.0);
-
   check_positive_finite(function, "First shape parameter", alpha);
   check_positive_finite(function, "Second shape parameter", beta);
   check_not_nan(function, "Random variable", y);
@@ -52,6 +44,13 @@ return_type_t<T_y, T_scale_succ, T_scale_fail> beta_cdf(
   check_nonnegative(function, "Random variable", y);
   check_less_or_equal(function, "Random variable", y, 1);
 
+  if (size_zero(y, alpha, beta)) {
+    return 1.0;
+  }
+
+  T_partials_return P(1.0);
+  operands_and_partials<T_y, T_scale_succ, T_scale_fail> ops_partials(y, alpha,
+                                                                      beta);
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_scale_succ> alpha_vec(alpha);
   scalar_seq_view<T_scale_fail> beta_vec(beta);
@@ -59,9 +58,6 @@ return_type_t<T_y, T_scale_succ, T_scale_fail> beta_cdf(
   size_t size_beta = stan::math::size(beta);
   size_t size_alpha_beta = max_size(alpha, beta);
   size_t N = max_size(y, alpha, beta);
-
-  operands_and_partials<T_y, T_scale_succ, T_scale_fail> ops_partials(y, alpha,
-                                                                      beta);
 
   // Explicit return for extreme values
   // The gradients are technically ill-defined, but treated as zero

--- a/stan/math/prim/prob/beta_lccdf.hpp
+++ b/stan/math/prim/prob/beta_lccdf.hpp
@@ -39,15 +39,7 @@ template <typename T_y, typename T_scale_succ, typename T_scale_fail>
 return_type_t<T_y, T_scale_succ, T_scale_fail> beta_lccdf(
     const T_y& y, const T_scale_succ& alpha, const T_scale_fail& beta) {
   using T_partials_return = partials_return_t<T_y, T_scale_succ, T_scale_fail>;
-
-  if (size_zero(y, alpha, beta)) {
-    return 0.0;
-  }
-
   static const char* function = "beta_lccdf";
-
-  T_partials_return ccdf_log(0.0);
-
   check_positive_finite(function, "First shape parameter", alpha);
   check_positive_finite(function, "Second shape parameter", beta);
   check_not_nan(function, "Random variable", y);
@@ -57,6 +49,16 @@ return_type_t<T_y, T_scale_succ, T_scale_fail> beta_lccdf(
                          "First shape parameter", alpha,
                          "Second shape parameter", beta);
 
+  if (size_zero(y, alpha, beta)) {
+    return 0;
+  }
+
+  using std::exp;
+  using std::log;
+  using std::pow;
+  T_partials_return ccdf_log(0.0);
+  operands_and_partials<T_y, T_scale_succ, T_scale_fail> ops_partials(y, alpha,
+                                                                      beta);
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_scale_succ> alpha_vec(alpha);
   scalar_seq_view<T_scale_fail> beta_vec(beta);
@@ -64,13 +66,6 @@ return_type_t<T_y, T_scale_succ, T_scale_fail> beta_lccdf(
   size_t size_beta = stan::math::size(beta);
   size_t size_alpha_beta = max_size(alpha, beta);
   size_t N = max_size(y, alpha, beta);
-
-  operands_and_partials<T_y, T_scale_succ, T_scale_fail> ops_partials(y, alpha,
-                                                                      beta);
-
-  using std::exp;
-  using std::log;
-  using std::pow;
 
   VectorBuilder<!is_constant_all<T_scale_succ, T_scale_fail>::value,
                 T_partials_return, T_scale_succ>

--- a/stan/math/prim/prob/beta_lcdf.hpp
+++ b/stan/math/prim/prob/beta_lcdf.hpp
@@ -39,15 +39,7 @@ template <typename T_y, typename T_scale_succ, typename T_scale_fail>
 return_type_t<T_y, T_scale_succ, T_scale_fail> beta_lcdf(
     const T_y& y, const T_scale_succ& alpha, const T_scale_fail& beta) {
   using T_partials_return = partials_return_t<T_y, T_scale_succ, T_scale_fail>;
-
-  if (size_zero(y, alpha, beta)) {
-    return 0.0;
-  }
-
   static const char* function = "beta_lcdf";
-
-  T_partials_return cdf_log(0.0);
-
   check_positive_finite(function, "First shape parameter", alpha);
   check_positive_finite(function, "Second shape parameter", beta);
   check_not_nan(function, "Random variable", y);
@@ -57,6 +49,16 @@ return_type_t<T_y, T_scale_succ, T_scale_fail> beta_lcdf(
                          "First shape parameter", alpha,
                          "Second shape parameter", beta);
 
+  if (size_zero(y, alpha, beta)) {
+    return 0;
+  }
+
+  using std::exp;
+  using std::log;
+  using std::pow;
+  T_partials_return cdf_log(0.0);
+  operands_and_partials<T_y, T_scale_succ, T_scale_fail> ops_partials(y, alpha,
+                                                                      beta);
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_scale_succ> alpha_vec(alpha);
   scalar_seq_view<T_scale_fail> beta_vec(beta);
@@ -64,13 +66,6 @@ return_type_t<T_y, T_scale_succ, T_scale_fail> beta_lcdf(
   size_t size_beta = stan::math::size(beta);
   size_t size_alpha_beta = max_size(alpha, beta);
   size_t N = max_size(y, alpha, beta);
-
-  operands_and_partials<T_y, T_scale_succ, T_scale_fail> ops_partials(y, alpha,
-                                                                      beta);
-
-  using std::exp;
-  using std::log;
-  using std::pow;
 
   VectorBuilder<!is_constant_all<T_scale_succ, T_scale_fail>::value,
                 T_partials_return, T_scale_succ>

--- a/stan/math/prim/prob/beta_lpdf.hpp
+++ b/stan/math/prim/prob/beta_lpdf.hpp
@@ -28,22 +28,20 @@ namespace math {
  *
  * Prior sample sizes, alpha and beta, must be greater than 0.
  *
+ * @tparam T_y type of scalar outcome
+ * @tparam T_scale_succ type of prior scale for successes
+ * @tparam T_scale_fail type of prior scale for failures
  * @param y (Sequence of) scalar(s).
  * @param alpha (Sequence of) prior sample stan::math::size(s).
  * @param beta (Sequence of) prior sample stan::math::size(s).
  * @return The log of the product of densities.
- * @tparam T_y Type of scalar outcome.
- * @tparam T_scale_succ Type of prior scale for successes.
- * @tparam T_scale_fail Type of prior scale for failures.
  */
 template <bool propto, typename T_y, typename T_scale_succ,
           typename T_scale_fail>
 return_type_t<T_y, T_scale_succ, T_scale_fail> beta_lpdf(
     const T_y& y, const T_scale_succ& alpha, const T_scale_fail& beta) {
-  static const char* function = "beta_lpdf";
-
   using T_partials_return = partials_return_t<T_y, T_scale_succ, T_scale_fail>;
-  using std::log;
+  static const char* function = "beta_lpdf";
   check_positive_finite(function, "First shape parameter", alpha);
   check_positive_finite(function, "Second shape parameter", beta);
   check_not_nan(function, "Random variable", y);
@@ -60,7 +58,10 @@ return_type_t<T_y, T_scale_succ, T_scale_fail> beta_lpdf(
     return 0;
   }
 
+  using std::log;
   T_partials_return logp(0);
+  operands_and_partials<T_y, T_scale_succ, T_scale_fail> ops_partials(y, alpha,
+                                                                      beta);
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_scale_succ> alpha_vec(alpha);
   scalar_seq_view<T_scale_fail> beta_vec(beta);
@@ -75,9 +76,6 @@ return_type_t<T_y, T_scale_succ, T_scale_fail> beta_lpdf(
       return LOG_ZERO;
     }
   }
-
-  operands_and_partials<T_y, T_scale_succ, T_scale_fail> ops_partials(y, alpha,
-                                                                      beta);
 
   VectorBuilder<include_summand<propto, T_y, T_scale_succ>::value,
                 T_partials_return, T_y>

--- a/stan/math/prim/prob/beta_proportion_lccdf.hpp
+++ b/stan/math/prim/prob/beta_proportion_lccdf.hpp
@@ -43,15 +43,7 @@ return_type_t<T_y, T_loc, T_prec> beta_proportion_lccdf(const T_y& y,
                                                         const T_loc& mu,
                                                         const T_prec& kappa) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_prec>;
-
   static const char* function = "beta_proportion_lccdf";
-
-  if (size_zero(y, mu, kappa)) {
-    return 0.0;
-  }
-
-  T_partials_return ccdf_log(0.0);
-
   check_positive(function, "Location parameter", mu);
   check_less(function, "Location parameter", mu, 1.0);
   check_positive_finite(function, "Precision parameter", kappa);
@@ -61,18 +53,22 @@ return_type_t<T_y, T_loc, T_prec> beta_proportion_lccdf(const T_y& y,
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Precision parameter", kappa);
 
+  if (size_zero(y, mu, kappa)) {
+    return 0;
+  }
+
+  using std::exp;
+  using std::log;
+  using std::pow;
+  T_partials_return ccdf_log(0.0);
+  operands_and_partials<T_y, T_loc, T_prec> ops_partials(y, mu, kappa);
+
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_loc> mu_vec(mu);
   scalar_seq_view<T_prec> kappa_vec(kappa);
   size_t size_kappa = stan::math::size(kappa);
   size_t size_mu_kappa = max_size(mu, kappa);
   size_t N = max_size(y, mu, kappa);
-
-  operands_and_partials<T_y, T_loc, T_prec> ops_partials(y, mu, kappa);
-
-  using std::exp;
-  using std::log;
-  using std::pow;
 
   VectorBuilder<!is_constant_all<T_loc, T_prec>::value, T_partials_return,
                 T_loc, T_prec>

--- a/stan/math/prim/prob/beta_proportion_lcdf.hpp
+++ b/stan/math/prim/prob/beta_proportion_lcdf.hpp
@@ -44,15 +44,7 @@ return_type_t<T_y, T_loc, T_prec> beta_proportion_lcdf(const T_y& y,
                                                        const T_loc& mu,
                                                        const T_prec& kappa) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_prec>;
-
-  if (size_zero(y, mu, kappa)) {
-    return 0.0;
-  }
-
   static const char* function = "beta_proportion_lcdf";
-
-  T_partials_return cdf_log(0.0);
-
   check_positive(function, "Location parameter", mu);
   check_less(function, "Location parameter", mu, 1.0);
   check_positive_finite(function, "Precision parameter", kappa);
@@ -62,18 +54,22 @@ return_type_t<T_y, T_loc, T_prec> beta_proportion_lcdf(const T_y& y,
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Precision parameter", kappa);
 
+  if (size_zero(y, mu, kappa)) {
+    return 0;
+  }
+
+  using std::exp;
+  using std::log;
+  using std::pow;
+  T_partials_return cdf_log(0.0);
+  operands_and_partials<T_y, T_loc, T_prec> ops_partials(y, mu, kappa);
+
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_loc> mu_vec(mu);
   scalar_seq_view<T_prec> kappa_vec(kappa);
   size_t size_kappa = stan::math::size(kappa);
   size_t size_mu_kappa = max_size(mu, kappa);
   size_t N = max_size(y, mu, kappa);
-
-  operands_and_partials<T_y, T_loc, T_prec> ops_partials(y, mu, kappa);
-
-  using std::exp;
-  using std::log;
-  using std::pow;
 
   VectorBuilder<!is_constant_all<T_loc, T_prec>::value, T_partials_return,
                 T_loc, T_prec>

--- a/stan/math/prim/prob/beta_proportion_rng.hpp
+++ b/stan/math/prim/prob/beta_proportion_rng.hpp
@@ -33,7 +33,6 @@ template <typename T_loc, typename T_prec, class RNG>
 inline typename VectorBuilder<true, double, T_loc, T_prec>::type
 beta_proportion_rng(const T_loc &mu, const T_prec &kappa, RNG &rng) {
   static const char *function = "beta_proportion_rng";
-
   check_positive(function, "Location parameter", mu);
   check_less(function, "Location parameter", mu, 1.0);
   check_positive_finite(function, "Precision parameter", kappa);

--- a/stan/math/prim/prob/beta_rng.hpp
+++ b/stan/math/prim/prob/beta_rng.hpp
@@ -20,8 +20,8 @@ namespace math {
  * alpha and beta can each be a scalar or a one-dimensional container. Any
  * non-scalar inputs must be the same size.
  *
- * @tparam T_shape1 Type of success parameter
- * @tparam T_shape2 Type of failure parameter
+ * @tparam T_shape1 type of success parameter
+ * @tparam T_shape2 type of failure parameter
  * @tparam RNG type of random number generator
  * @param alpha (Sequence of) positive finite success parameter(s)
  * @param beta (Sequence of) positive finite failure parameter(s)
@@ -38,7 +38,6 @@ inline typename VectorBuilder<true, double, T_shape1, T_shape2>::type beta_rng(
   using boost::random::uniform_real_distribution;
   using boost::variate_generator;
   static const char *function = "beta_rng";
-
   check_positive_finite(function, "First shape parameter", alpha);
   check_positive_finite(function, "Second shape parameter", beta);
   check_consistent_sizes(function, "First shape parameter", alpha,

--- a/stan/math/prim/prob/binomial_cdf.hpp
+++ b/stan/math/prim/prob/binomial_cdf.hpp
@@ -33,15 +33,8 @@ namespace math {
 template <typename T_n, typename T_N, typename T_prob>
 return_type_t<T_prob> binomial_cdf(const T_n& n, const T_N& N,
                                    const T_prob& theta) {
-  static const char* function = "binomial_cdf";
   using T_partials_return = partials_return_t<T_n, T_N, T_prob>;
-
-  if (size_zero(n, N, theta)) {
-    return 1.0;
-  }
-
-  T_partials_return P(1.0);
-
+  static const char* function = "binomial_cdf";
   check_nonnegative(function, "Population size parameter", N);
   check_finite(function, "Probability parameter", theta);
   check_bounded(function, "Probability parameter", theta, 0.0, 1.0);
@@ -49,15 +42,19 @@ return_type_t<T_prob> binomial_cdf(const T_n& n, const T_N& N,
                          "Population size parameter", N,
                          "Probability parameter", theta);
 
+  if (size_zero(n, N, theta)) {
+    return 1.0;
+  }
+
+  using std::exp;
+  using std::pow;
+  T_partials_return P(1.0);
+  operands_and_partials<T_prob> ops_partials(theta);
+
   scalar_seq_view<T_n> n_vec(n);
   scalar_seq_view<T_N> N_vec(N);
   scalar_seq_view<T_prob> theta_vec(theta);
   size_t max_size_seq_view = max_size(n, N, theta);
-
-  using std::exp;
-  using std::pow;
-
-  operands_and_partials<T_prob> ops_partials(theta);
 
   // Explicit return for extreme values
   // The gradients are technically ill-defined, but treated as zero

--- a/stan/math/prim/prob/binomial_lccdf.hpp
+++ b/stan/math/prim/prob/binomial_lccdf.hpp
@@ -35,15 +35,8 @@ namespace math {
 template <typename T_n, typename T_N, typename T_prob>
 return_type_t<T_prob> binomial_lccdf(const T_n& n, const T_N& N,
                                      const T_prob& theta) {
-  static const char* function = "binomial_lccdf";
   using T_partials_return = partials_return_t<T_n, T_N, T_prob>;
-
-  if (size_zero(n, N, theta)) {
-    return 0.0;
-  }
-
-  T_partials_return P(0.0);
-
+  static const char* function = "binomial_lccdf";
   check_nonnegative(function, "Population size parameter", N);
   check_finite(function, "Probability parameter", theta);
   check_bounded(function, "Probability parameter", theta, 0.0, 1.0);
@@ -51,16 +44,20 @@ return_type_t<T_prob> binomial_lccdf(const T_n& n, const T_N& N,
                          "Population size parameter", N,
                          "Probability parameter", theta);
 
-  scalar_seq_view<T_n> n_vec(n);
-  scalar_seq_view<T_N> N_vec(N);
-  scalar_seq_view<T_prob> theta_vec(theta);
-  size_t max_size_seq_view = max_size(n, N, theta);
+  if (size_zero(n, N, theta)) {
+    return 0;
+  }
 
   using std::exp;
   using std::log;
   using std::pow;
-
+  T_partials_return P(0.0);
   operands_and_partials<T_prob> ops_partials(theta);
+
+  scalar_seq_view<T_n> n_vec(n);
+  scalar_seq_view<T_N> N_vec(N);
+  scalar_seq_view<T_prob> theta_vec(theta);
+  size_t max_size_seq_view = max_size(n, N, theta);
 
   // Explicit return for extreme values
   // The gradients are technically ill-defined,

--- a/stan/math/prim/prob/binomial_lcdf.hpp
+++ b/stan/math/prim/prob/binomial_lcdf.hpp
@@ -35,15 +35,8 @@ namespace math {
 template <typename T_n, typename T_N, typename T_prob>
 return_type_t<T_prob> binomial_lcdf(const T_n& n, const T_N& N,
                                     const T_prob& theta) {
-  static const char* function = "binomial_lcdf";
   using T_partials_return = partials_return_t<T_n, T_N, T_prob>;
-
-  if (size_zero(n, N, theta)) {
-    return 0.0;
-  }
-
-  T_partials_return P(0.0);
-
+  static const char* function = "binomial_lcdf";
   check_nonnegative(function, "Population size parameter", N);
   check_finite(function, "Probability parameter", theta);
   check_bounded(function, "Probability parameter", theta, 0.0, 1.0);
@@ -51,16 +44,20 @@ return_type_t<T_prob> binomial_lcdf(const T_n& n, const T_N& N,
                          "Population size parameter", N,
                          "Probability parameter", theta);
 
-  scalar_seq_view<T_n> n_vec(n);
-  scalar_seq_view<T_N> N_vec(N);
-  scalar_seq_view<T_prob> theta_vec(theta);
-  size_t max_size_seq_view = max_size(n, N, theta);
+  if (size_zero(n, N, theta)) {
+    return 0;
+  }
 
   using std::exp;
   using std::log;
   using std::pow;
-
+  T_partials_return P(0.0);
   operands_and_partials<T_prob> ops_partials(theta);
+
+  scalar_seq_view<T_n> n_vec(n);
+  scalar_seq_view<T_N> N_vec(N);
+  scalar_seq_view<T_prob> theta_vec(theta);
+  size_t max_size_seq_view = max_size(n, N, theta);
 
   // Explicit return for extreme values
   // The gradients are technically ill-defined,

--- a/stan/math/prim/prob/binomial_logit_lpmf.hpp
+++ b/stan/math/prim/prob/binomial_logit_lpmf.hpp
@@ -33,14 +33,7 @@ template <bool propto, typename T_n, typename T_N, typename T_prob>
 return_type_t<T_prob> binomial_logit_lpmf(const T_n& n, const T_N& N,
                                           const T_prob& alpha) {
   using T_partials_return = partials_return_t<T_n, T_N, T_prob>;
-
   static const char* function = "binomial_logit_lpmf";
-
-  if (size_zero(n, N, alpha)) {
-    return 0.0;
-  }
-
-  T_partials_return logp = 0;
   check_bounded(function, "Successes variable", n, 0, N);
   check_nonnegative(function, "Population size parameter", N);
   check_finite(function, "Probability parameter", alpha);
@@ -48,19 +41,22 @@ return_type_t<T_prob> binomial_logit_lpmf(const T_n& n, const T_N& N,
                          "Population size parameter", N,
                          "Probability parameter", alpha);
 
+  if (size_zero(n, N, alpha)) {
+    return 0.0;
+  }
   if (!include_summand<propto, T_prob>::value) {
     return 0.0;
   }
 
   using std::log;
+  T_partials_return logp = 0;
+  operands_and_partials<T_prob> ops_partials(alpha);
 
   scalar_seq_view<T_n> n_vec(n);
   scalar_seq_view<T_N> N_vec(N);
   scalar_seq_view<T_prob> alpha_vec(alpha);
   size_t size_alpha = stan::math::size(alpha);
   size_t max_size_seq_view = max_size(n, N, alpha);
-
-  operands_and_partials<T_prob> ops_partials(alpha);
 
   if (include_summand<propto>::value) {
     for (size_t i = 0; i < max_size_seq_view; ++i) {

--- a/stan/math/prim/prob/binomial_lpmf.hpp
+++ b/stan/math/prim/prob/binomial_lpmf.hpp
@@ -35,14 +35,7 @@ template <bool propto, typename T_n, typename T_N, typename T_prob>
 return_type_t<T_prob> binomial_lpmf(const T_n& n, const T_N& N,
                                     const T_prob& theta) {
   using T_partials_return = partials_return_t<T_n, T_N, T_prob>;
-
   static const char* function = "binomial_lpmf";
-
-  if (size_zero(n, N, theta)) {
-    return 0.0;
-  }
-
-  T_partials_return logp = 0;
   check_bounded(function, "Successes variable", n, 0, N);
   check_nonnegative(function, "Population size parameter", N);
   check_finite(function, "Probability parameter", theta);
@@ -51,17 +44,21 @@ return_type_t<T_prob> binomial_lpmf(const T_n& n, const T_N& N,
                          "Population size parameter", N,
                          "Probability parameter", theta);
 
+  if (size_zero(n, N, theta)) {
+    return 0.0;
+  }
   if (!include_summand<propto, T_prob>::value) {
     return 0.0;
   }
+
+  T_partials_return logp = 0;
+  operands_and_partials<T_prob> ops_partials(theta);
 
   scalar_seq_view<T_n> n_vec(n);
   scalar_seq_view<T_N> N_vec(N);
   scalar_seq_view<T_prob> theta_vec(theta);
   size_t size_theta = stan::math::size(theta);
   size_t max_size_seq_view = max_size(n, N, theta);
-
-  operands_and_partials<T_prob> ops_partials(theta);
 
   if (include_summand<propto>::value) {
     for (size_t i = 0; i < max_size_seq_view; ++i) {

--- a/stan/math/prim/prob/binomial_rng.hpp
+++ b/stan/math/prim/prob/binomial_rng.hpp
@@ -32,9 +32,7 @@ inline typename VectorBuilder<true, int, T_N, T_theta>::type binomial_rng(
     const T_N& N, const T_theta& theta, RNG& rng) {
   using boost::binomial_distribution;
   using boost::variate_generator;
-
   static const char* function = "binomial_rng";
-
   check_nonnegative(function, "Population size parameter", N);
   check_bounded(function, "Probability parameter", theta, 0.0, 1.0);
   check_consistent_sizes(function, "Population size parameter", N,

--- a/stan/math/prim/prob/categorical_logit_lpmf.hpp
+++ b/stan/math/prim/prob/categorical_logit_lpmf.hpp
@@ -17,7 +17,6 @@ template <bool propto, typename T_prob>
 return_type_t<T_prob> categorical_logit_lpmf(
     int n, const Eigen::Matrix<T_prob, Eigen::Dynamic, 1>& beta) {
   static const char* function = "categorical_logit_lpmf";
-
   check_bounded(function, "categorical outcome out of support", n, 1,
                 beta.size());
   check_finite(function, "log odds parameter", beta);

--- a/stan/math/prim/prob/categorical_logit_rng.hpp
+++ b/stan/math/prim/prob/categorical_logit_rng.hpp
@@ -11,6 +11,7 @@
 
 namespace stan {
 namespace math {
+
 /** \ingroup multivar_dists
  * Return a draw from a Categorical distribution given a
  * a vector of unnormalized log probabilities and a psuedo-random
@@ -28,9 +29,7 @@ template <class RNG>
 inline int categorical_logit_rng(const Eigen::VectorXd& beta, RNG& rng) {
   using boost::uniform_01;
   using boost::variate_generator;
-
   static const char* function = "categorical_logit_rng";
-
   check_finite(function, "Log odds parameter", beta);
 
   variate_generator<RNG&, uniform_01<> > uniform01_rng(rng, uniform_01<>());

--- a/stan/math/prim/prob/categorical_lpmf.hpp
+++ b/stan/math/prim/prob/categorical_lpmf.hpp
@@ -16,11 +16,9 @@ template <bool propto, typename T_prob>
 return_type_t<T_prob> categorical_lpmf(
     int n, const Eigen::Matrix<T_prob, Eigen::Dynamic, 1>& theta) {
   static const char* function = "categorical_lpmf";
-
   using std::log;
 
   int lb = 1;
-
   check_bounded(function, "Number of categories", n, lb, theta.size());
   check_simplex(function, "Probabilities parameter", theta);
 

--- a/stan/math/prim/prob/categorical_rng.hpp
+++ b/stan/math/prim/prob/categorical_rng.hpp
@@ -15,9 +15,7 @@ inline int categorical_rng(
     const Eigen::Matrix<double, Eigen::Dynamic, 1>& theta, RNG& rng) {
   using boost::uniform_01;
   using boost::variate_generator;
-
   static const char* function = "categorical_rng";
-
   check_simplex(function, "Probabilities parameter", theta);
 
   variate_generator<RNG&, uniform_01<> > uniform01_rng(rng, uniform_01<>());

--- a/stan/math/prim/prob/cauchy_cdf.hpp
+++ b/stan/math/prim/prob/cauchy_cdf.hpp
@@ -31,27 +31,25 @@ template <typename T_y, typename T_loc, typename T_scale>
 return_type_t<T_y, T_loc, T_scale> cauchy_cdf(const T_y& y, const T_loc& mu,
                                               const T_scale& sigma) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale>;
-
-  if (size_zero(y, mu, sigma)) {
-    return 1.0;
-  }
-
   static const char* function = "cauchy_cdf";
-
-  T_partials_return P(1.0);
-
   check_not_nan(function, "Random variable", y);
   check_finite(function, "Location parameter", mu);
   check_positive_finite(function, "Scale parameter", sigma);
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Scale Parameter", sigma);
 
+  if (size_zero(y, mu, sigma)) {
+    return 1.0;
+  }
+
+  using std::atan;
+  T_partials_return P(1.0);
+  operands_and_partials<T_y, T_loc, T_scale> ops_partials(y, mu, sigma);
+
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_loc> mu_vec(mu);
   scalar_seq_view<T_scale> sigma_vec(sigma);
   size_t N = max_size(y, mu, sigma);
-
-  operands_and_partials<T_y, T_loc, T_scale> ops_partials(y, mu, sigma);
 
   // Explicit return for extreme values
   // The gradients are technically ill-defined, but treated as zero
@@ -60,8 +58,6 @@ return_type_t<T_y, T_loc, T_scale> cauchy_cdf(const T_y& y, const T_loc& mu,
       return ops_partials.build(0.0);
     }
   }
-
-  using std::atan;
 
   for (size_t n = 0; n < N; n++) {
     // Explicit results for extreme values

--- a/stan/math/prim/prob/cauchy_lccdf.hpp
+++ b/stan/math/prim/prob/cauchy_lccdf.hpp
@@ -32,30 +32,26 @@ template <typename T_y, typename T_loc, typename T_scale>
 return_type_t<T_y, T_loc, T_scale> cauchy_lccdf(const T_y& y, const T_loc& mu,
                                                 const T_scale& sigma) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale>;
-
-  if (size_zero(y, mu, sigma)) {
-    return 0.0;
-  }
-
   static const char* function = "cauchy_lccdf";
-
-  T_partials_return ccdf_log(0.0);
-
   check_not_nan(function, "Random variable", y);
   check_finite(function, "Location parameter", mu);
   check_positive_finite(function, "Scale parameter", sigma);
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Scale Parameter", sigma);
 
+  if (size_zero(y, mu, sigma)) {
+    return 0;
+  }
+
+  using std::atan;
+  using std::log;
+  T_partials_return ccdf_log(0.0);
+  operands_and_partials<T_y, T_loc, T_scale> ops_partials(y, mu, sigma);
+
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_loc> mu_vec(mu);
   scalar_seq_view<T_scale> sigma_vec(sigma);
   size_t N = max_size(y, mu, sigma);
-
-  operands_and_partials<T_y, T_loc, T_scale> ops_partials(y, mu, sigma);
-
-  using std::atan;
-  using std::log;
 
   for (size_t n = 0; n < N; n++) {
     const T_partials_return y_dbl = value_of(y_vec[n]);

--- a/stan/math/prim/prob/cauchy_lcdf.hpp
+++ b/stan/math/prim/prob/cauchy_lcdf.hpp
@@ -32,30 +32,26 @@ template <typename T_y, typename T_loc, typename T_scale>
 return_type_t<T_y, T_loc, T_scale> cauchy_lcdf(const T_y& y, const T_loc& mu,
                                                const T_scale& sigma) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale>;
-
-  if (size_zero(y, mu, sigma)) {
-    return 0.0;
-  }
-
   static const char* function = "cauchy_lcdf";
-
-  T_partials_return cdf_log(0.0);
-
   check_not_nan(function, "Random variable", y);
   check_finite(function, "Location parameter", mu);
   check_positive_finite(function, "Scale parameter", sigma);
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Scale Parameter", sigma);
 
+  if (size_zero(y, mu, sigma)) {
+    return 0;
+  }
+
+  using std::atan;
+  using std::log;
+  T_partials_return cdf_log(0.0);
+  operands_and_partials<T_y, T_loc, T_scale> ops_partials(y, mu, sigma);
+
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_loc> mu_vec(mu);
   scalar_seq_view<T_scale> sigma_vec(sigma);
   size_t N = max_size(y, mu, sigma);
-
-  operands_and_partials<T_y, T_loc, T_scale> ops_partials(y, mu, sigma);
-
-  using std::atan;
-  using std::log;
 
   for (size_t n = 0; n < N; n++) {
     const T_partials_return y_dbl = value_of(y_vec[n]);

--- a/stan/math/prim/prob/cauchy_log.hpp
+++ b/stan/math/prim/prob/cauchy_log.hpp
@@ -22,9 +22,9 @@ namespace math {
  * @param mu (Sequence of) location(s).
  * @param sigma (Sequence of) scale(s).
  * @return The log of the product of densities.
+ * @tparam T_scale Type of scale.
  * @tparam T_y Type of scalar outcome.
  * @tparam T_loc Type of location.
- * @tparam T_scale Type of scale.
  */
 template <bool propto, typename T_y, typename T_loc, typename T_scale>
 return_type_t<T_y, T_loc, T_scale> cauchy_log(const T_y& y, const T_loc& mu,

--- a/stan/math/prim/prob/cauchy_lpdf.hpp
+++ b/stan/math/prim/prob/cauchy_lpdf.hpp
@@ -24,37 +24,35 @@ namespace math {
  * <p> The result log probability is defined to be the sum of
  * the log probabilities for each observation/mu/sigma triple.
  *
+ * @tparam T_y type of scalar outcome
+ * @tparam T_loc type of location
+ * @tparam T_scale type of scale
  * @param y (Sequence of) scalar(s).
  * @param mu (Sequence of) location(s).
  * @param sigma (Sequence of) scale(s).
  * @return The log of the product of densities.
- * @tparam T_y Type of scalar outcome.
- * @tparam T_loc Type of location.
- * @tparam T_scale Type of scale.
  */
 template <bool propto, typename T_y, typename T_loc, typename T_scale>
 return_type_t<T_y, T_loc, T_scale> cauchy_lpdf(const T_y& y, const T_loc& mu,
                                                const T_scale& sigma) {
-  static const char* function = "cauchy_lpdf";
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale>;
-
-  if (size_zero(y, mu, sigma)) {
-    return 0.0;
-  }
-
-  T_partials_return logp(0.0);
-
+  static const char* function = "cauchy_lpdf";
   check_not_nan(function, "Random variable", y);
   check_finite(function, "Location parameter", mu);
   check_positive_finite(function, "Scale parameter", sigma);
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Scale parameter", sigma);
 
+  if (size_zero(y, mu, sigma)) {
+    return 0.0;
+  }
   if (!include_summand<propto, T_y, T_loc, T_scale>::value) {
     return 0.0;
   }
 
   using std::log;
+  T_partials_return logp(0.0);
+  operands_and_partials<T_y, T_loc, T_scale> ops_partials(y, mu, sigma);
 
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_loc> mu_vec(mu);
@@ -74,8 +72,6 @@ return_type_t<T_y, T_loc, T_scale> cauchy_lpdf(const T_y& y, const T_loc& mu,
       log_sigma[i] = log(sigma_dbl);
     }
   }
-
-  operands_and_partials<T_y, T_loc, T_scale> ops_partials(y, mu, sigma);
 
   for (size_t n = 0; n < N; n++) {
     const T_partials_return y_dbl = value_of(y_vec[n]);

--- a/stan/math/prim/prob/cauchy_rng.hpp
+++ b/stan/math/prim/prob/cauchy_rng.hpp
@@ -17,8 +17,8 @@ namespace math {
  * mu and sigma can each be a scalar or a vector. Any non-scalar
  * inputs must be the same length.
  *
- * @tparam T_loc Type of location parameter
- * @tparam T_scale Type of scale parameter
+ * @tparam T_loc type of location parameter
+ * @tparam T_scale type of scale parameter
  * @tparam RNG type of random number generator
  * @param mu (Sequence of) location parameter(s)
  * @param sigma (Sequence of) scale parameter(s)
@@ -34,7 +34,6 @@ inline typename VectorBuilder<true, double, T_loc, T_scale>::type cauchy_rng(
   using boost::random::cauchy_distribution;
   using boost::variate_generator;
   static const char* function = "cauchy_rng";
-
   check_finite(function, "Location parameter", mu);
   check_positive_finite(function, "Scale parameter", sigma);
   check_consistent_sizes(function, "Location parameter", mu, "Scale Parameter",

--- a/stan/math/prim/prob/chi_square_cdf.hpp
+++ b/stan/math/prim/prob/chi_square_cdf.hpp
@@ -33,26 +33,26 @@ namespace math {
  */
 template <typename T_y, typename T_dof>
 return_type_t<T_y, T_dof> chi_square_cdf(const T_y& y, const T_dof& nu) {
-  static const char* function = "chi_square_cdf";
   using T_partials_return = partials_return_t<T_y, T_dof>;
-
-  T_partials_return cdf(1.0);
-
-  if (size_zero(y, nu)) {
-    return cdf;
-  }
-
+  static const char* function = "chi_square_cdf";
   check_not_nan(function, "Random variable", y);
   check_nonnegative(function, "Random variable", y);
   check_positive_finite(function, "Degrees of freedom parameter", nu);
   check_consistent_sizes(function, "Random variable", y,
                          "Degrees of freedom parameter", nu);
 
+  if (size_zero(y, nu)) {
+    return 1.0;
+  }
+
+  using std::exp;
+  using std::pow;
+  T_partials_return cdf(1.0);
+  operands_and_partials<T_y, T_dof> ops_partials(y, nu);
+
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_dof> nu_vec(nu);
   size_t N = max_size(y, nu);
-
-  operands_and_partials<T_y, T_dof> ops_partials(y, nu);
 
   // Explicit return for extreme values
   // The gradients are technically ill-defined, but treated as zero
@@ -61,9 +61,6 @@ return_type_t<T_y, T_dof> chi_square_cdf(const T_y& y, const T_dof& nu) {
       return ops_partials.build(0.0);
     }
   }
-
-  using std::exp;
-  using std::pow;
 
   VectorBuilder<!is_constant_all<T_dof>::value, T_partials_return, T_dof>
       gamma_vec(size(nu));

--- a/stan/math/prim/prob/chi_square_lccdf.hpp
+++ b/stan/math/prim/prob/chi_square_lccdf.hpp
@@ -34,26 +34,27 @@ namespace math {
  */
 template <typename T_y, typename T_dof>
 return_type_t<T_y, T_dof> chi_square_lccdf(const T_y& y, const T_dof& nu) {
-  static const char* function = "chi_square_lccdf";
   using T_partials_return = partials_return_t<T_y, T_dof>;
-
-  T_partials_return ccdf_log(0.0);
-
-  if (size_zero(y, nu)) {
-    return ccdf_log;
-  }
-
+  static const char* function = "chi_square_lccdf";
   check_not_nan(function, "Random variable", y);
   check_nonnegative(function, "Random variable", y);
   check_positive_finite(function, "Degrees of freedom parameter", nu);
   check_consistent_sizes(function, "Random variable", y,
                          "Degrees of freedom parameter", nu);
 
+  if (size_zero(y, nu)) {
+    return 0;
+  }
+
+  using std::exp;
+  using std::log;
+  using std::pow;
+  T_partials_return ccdf_log(0.0);
+  operands_and_partials<T_y, T_dof> ops_partials(y, nu);
+
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_dof> nu_vec(nu);
   size_t N = max_size(y, nu);
-
-  operands_and_partials<T_y, T_dof> ops_partials(y, nu);
 
   // Explicit return for extreme values
   // The gradients are technically ill-defined, but treated as zero
@@ -62,10 +63,6 @@ return_type_t<T_y, T_dof> chi_square_lccdf(const T_y& y, const T_dof& nu) {
       return ops_partials.build(0.0);
     }
   }
-
-  using std::exp;
-  using std::log;
-  using std::pow;
 
   VectorBuilder<!is_constant_all<T_dof>::value, T_partials_return, T_dof>
       gamma_vec(size(nu));

--- a/stan/math/prim/prob/chi_square_lcdf.hpp
+++ b/stan/math/prim/prob/chi_square_lcdf.hpp
@@ -34,26 +34,27 @@ namespace math {
  */
 template <typename T_y, typename T_dof>
 return_type_t<T_y, T_dof> chi_square_lcdf(const T_y& y, const T_dof& nu) {
-  static const char* function = "chi_square_lcdf";
   using T_partials_return = partials_return_t<T_y, T_dof>;
-
-  T_partials_return cdf_log(0.0);
-
-  if (size_zero(y, nu)) {
-    return cdf_log;
-  }
-
+  static const char* function = "chi_square_lcdf";
   check_not_nan(function, "Random variable", y);
   check_nonnegative(function, "Random variable", y);
   check_positive_finite(function, "Degrees of freedom parameter", nu);
   check_consistent_sizes(function, "Random variable", y,
                          "Degrees of freedom parameter", nu);
 
+  if (size_zero(y, nu)) {
+    return 0;
+  }
+
+  using std::exp;
+  using std::log;
+  using std::pow;
+  T_partials_return cdf_log(0.0);
+  operands_and_partials<T_y, T_dof> ops_partials(y, nu);
+
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_dof> nu_vec(nu);
   size_t N = max_size(y, nu);
-
-  operands_and_partials<T_y, T_dof> ops_partials(y, nu);
 
   // Explicit return for extreme values
   // The gradients are technically ill-defined, but treated as zero
@@ -62,10 +63,6 @@ return_type_t<T_y, T_dof> chi_square_lcdf(const T_y& y, const T_dof& nu) {
       return ops_partials.build(negative_infinity());
     }
   }
-
-  using std::exp;
-  using std::log;
-  using std::pow;
 
   VectorBuilder<!is_constant_all<T_dof>::value, T_partials_return, T_dof>
       gamma_vec(size(nu));

--- a/stan/math/prim/prob/chi_square_lpdf.hpp
+++ b/stan/math/prim/prob/chi_square_lpdf.hpp
@@ -28,28 +28,34 @@ namespace math {
  y^{\nu / 2 - 1} \exp^{- y / 2} \right) \\
  &=& - \frac{\nu}{2} \log(2) - \log (\Gamma (\nu / 2)) + (\frac{\nu}{2} - 1)
  \log(y) - \frac{y}{2} \\ & & \mathrm{ where } \; y \ge 0 \f}
+ *
+ * @tparam T_y type of scalar
+ * @tparam T_dof type of degrees of freedom
  * @param y A scalar variable.
  * @param nu Degrees of freedom.
  * @throw std::domain_error if nu is not greater than or equal to 0
  * @throw std::domain_error if y is not greater than or equal to 0.
- * @tparam T_y Type of scalar.
- * @tparam T_dof Type of degrees of freedom.
  */
 template <bool propto, typename T_y, typename T_dof>
 return_type_t<T_y, T_dof> chi_square_lpdf(const T_y& y, const T_dof& nu) {
-  static const char* function = "chi_square_lpdf";
   using T_partials_return = partials_return_t<T_y, T_dof>;
-
+  static const char* function = "chi_square_lpdf";
   check_not_nan(function, "Random variable", y);
   check_nonnegative(function, "Random variable", y);
   check_positive_finite(function, "Degrees of freedom parameter", nu);
   check_consistent_sizes(function, "Random variable", y,
                          "Degrees of freedom parameter", nu);
+
   if (size_zero(y, nu)) {
     return 0;
   }
+  if (!include_summand<propto, T_y, T_dof>::value) {
+    return 0;
+  }
 
+  using std::log;
   T_partials_return logp(0);
+  operands_and_partials<T_y, T_dof> ops_partials(y, nu);
 
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_dof> nu_vec(nu);
@@ -60,12 +66,6 @@ return_type_t<T_y, T_dof> chi_square_lpdf(const T_y& y, const T_dof& nu) {
       return LOG_ZERO;
     }
   }
-
-  if (!include_summand<propto, T_y, T_dof>::value) {
-    return 0.0;
-  }
-
-  using std::log;
 
   VectorBuilder<include_summand<propto, T_y, T_dof>::value, T_partials_return,
                 T_y>
@@ -96,8 +96,6 @@ return_type_t<T_y, T_dof> chi_square_lpdf(const T_y& y, const T_dof& nu) {
       digamma_half_nu_over_two[i] = digamma(half_nu) * 0.5;
     }
   }
-
-  operands_and_partials<T_y, T_dof> ops_partials(y, nu);
 
   for (size_t n = 0; n < N; n++) {
     const T_partials_return y_dbl = value_of(y_vec[n]);

--- a/stan/math/prim/prob/chi_square_rng.hpp
+++ b/stan/math/prim/prob/chi_square_rng.hpp
@@ -16,7 +16,7 @@ namespace math {
  *
  * nu can be a scalar or a one-dimensional container.
  *
- * @tparam T_deg Type of degrees of freedom parameter
+ * @tparam T_deg type of degrees of freedom parameter
  * @tparam RNG class of random number generator
  * @param nu (Sequence of) positive degrees of freedom parameter(s)
  * @param rng random number generator
@@ -28,9 +28,7 @@ inline typename VectorBuilder<true, double, T_deg>::type chi_square_rng(
     const T_deg& nu, RNG& rng) {
   using boost::random::chi_squared_distribution;
   using boost::variate_generator;
-
   static const char* function = "chi_square_rng";
-
   check_positive_finite(function, "Degrees of freedom parameter", nu);
 
   scalar_seq_view<T_deg> nu_vec(nu);

--- a/stan/math/prim/prob/dirichlet_lpdf.hpp
+++ b/stan/math/prim/prob/dirichlet_lpdf.hpp
@@ -40,6 +40,8 @@ namespace math {
  * =\psi_{(0)}(\sum\alpha)-\psi_{(0)}(\alpha_x)+\log\theta_x
  * \f]
  *
+ * @tparam T_prob type of scalar
+ * @tparam T_prior_size type of prior sample sizes
  * @param theta A scalar vector.
  * @param alpha Prior sample sizes.
  * @return The log of the Dirichlet density.
@@ -47,17 +49,14 @@ namespace math {
  * or equal to 0.
  * @throw std::domain_error if any element of theta is less than 0.
  * @throw std::domain_error if the sum of theta is not 1.
- * @tparam T_prob Type of scalar.
- * @tparam T_prior_size Type of prior sample sizes.
  */
 template <bool propto, typename T_prob, typename T_prior_size>
 return_type_t<T_prob, T_prior_size> dirichlet_lpdf(const T_prob& theta,
                                                    const T_prior_size& alpha) {
-  static const char* function = "dirichlet_lpdf";
-
   using T_partials_return = partials_return_t<T_prob, T_prior_size>;
   using T_partials_vec = typename Eigen::Matrix<T_partials_return, -1, 1>;
   using T_partials_mat = typename Eigen::Matrix<T_partials_return, -1, -1>;
+  static const char* function = "dirichlet_lpdf";
 
   vector_seq_view<T_prob> theta_vec(theta);
   vector_seq_view<T_prior_size> alpha_vec(alpha);

--- a/stan/math/prim/prob/dirichlet_rng.hpp
+++ b/stan/math/prim/prob/dirichlet_rng.hpp
@@ -31,7 +31,7 @@ namespace math {
  * 26(3):363--372, 2000.
  * </blockquote>
  *
- * @tparam RNG Type of pseudo-random number generator.
+ * @tparam RNG type of pseudo-random number generator
  * @param alpha Prior count (plus 1) parameter for Dirichlet.
  * @param rng Pseudo-random number generator.
  */

--- a/stan/math/prim/prob/discrete_range_lpmf.hpp
+++ b/stan/math/prim/prob/discrete_range_lpmf.hpp
@@ -45,7 +45,6 @@ template <bool propto, typename T_y, typename T_lower, typename T_upper>
 double discrete_range_lpmf(const T_y& y, const T_lower& lower,
                            const T_upper& upper) {
   static const char* function = "discrete_range_lpmf";
-  using std::log;
   check_not_nan(function, "Random variable", y);
   check_consistent_sizes(function, "Lower bound parameter", lower,
                          "Upper bound parameter", upper);
@@ -57,6 +56,8 @@ double discrete_range_lpmf(const T_y& y, const T_lower& lower,
   if (!include_summand<propto>::value) {
     return 0.0;
   }
+
+  using std::log;
 
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_lower> lower_vec(lower);

--- a/stan/math/prim/prob/double_exponential_cdf.hpp
+++ b/stan/math/prim/prob/double_exponential_cdf.hpp
@@ -30,21 +30,18 @@ namespace math {
 template <typename T_y, typename T_loc, typename T_scale>
 return_type_t<T_y, T_loc, T_scale> double_exponential_cdf(
     const T_y& y, const T_loc& mu, const T_scale& sigma) {
-  static const char* function = "double_exponential_cdf";
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale>;
+  static const char* function = "double_exponential_cdf";
+  check_not_nan(function, "Random variable", y);
+  check_finite(function, "Location parameter", mu);
+  check_positive_finite(function, "Scale parameter", sigma);
 
   if (size_zero(y, mu, sigma)) {
     return 1.0;
   }
 
   using std::exp;
-
   T_partials_return cdf(1.0);
-
-  check_not_nan(function, "Random variable", y);
-  check_finite(function, "Location parameter", mu);
-  check_positive_finite(function, "Scale parameter", sigma);
-
   operands_and_partials<T_y, T_loc, T_scale> ops_partials(y, mu, sigma);
 
   scalar_seq_view<T_y> y_vec(y);

--- a/stan/math/prim/prob/double_exponential_lccdf.hpp
+++ b/stan/math/prim/prob/double_exponential_lccdf.hpp
@@ -33,24 +33,21 @@ namespace math {
 template <typename T_y, typename T_loc, typename T_scale>
 return_type_t<T_y, T_loc, T_scale> double_exponential_lccdf(
     const T_y& y, const T_loc& mu, const T_scale& sigma) {
-  static const char* function = "double_exponential_lccdf";
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale>;
-
-  T_partials_return ccdf_log(0.0);
-
-  if (size_zero(y, mu, sigma)) {
-    return ccdf_log;
-  }
-
+  static const char* function = "double_exponential_lccdf";
   check_not_nan(function, "Random variable", y);
   check_finite(function, "Location parameter", mu);
   check_positive_finite(function, "Scale parameter", sigma);
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Scale Parameter", sigma);
 
+  if (size_zero(y, mu, sigma)) {
+    return 0;
+  }
+
   using std::exp;
   using std::log;
-
+  T_partials_return ccdf_log(0.0);
   operands_and_partials<T_y, T_loc, T_scale> ops_partials(y, mu, sigma);
 
   scalar_seq_view<T_y> y_vec(y);

--- a/stan/math/prim/prob/double_exponential_lcdf.hpp
+++ b/stan/math/prim/prob/double_exponential_lcdf.hpp
@@ -32,24 +32,21 @@ namespace math {
 template <typename T_y, typename T_loc, typename T_scale>
 return_type_t<T_y, T_loc, T_scale> double_exponential_lcdf(
     const T_y& y, const T_loc& mu, const T_scale& sigma) {
-  static const char* function = "double_exponential_lcdf";
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale>;
-
-  T_partials_return cdf_log(0.0);
-
-  if (size_zero(y, mu, sigma)) {
-    return cdf_log;
-  }
-
+  static const char* function = "double_exponential_lcdf";
   check_not_nan(function, "Random variable", y);
   check_finite(function, "Location parameter", mu);
   check_positive_finite(function, "Scale parameter", sigma);
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Scale Parameter", sigma);
 
+  if (size_zero(y, mu, sigma)) {
+    return 0;
+  }
+
   using std::exp;
   using std::log;
-
+  T_partials_return cdf_log(0.0);
   operands_and_partials<T_y, T_loc, T_scale> ops_partials(y, mu, sigma);
 
   scalar_seq_view<T_y> y_vec(y);

--- a/stan/math/prim/prob/double_exponential_lpdf.hpp
+++ b/stan/math/prim/prob/double_exponential_lpdf.hpp
@@ -34,33 +34,31 @@ namespace math {
 template <bool propto, typename T_y, typename T_loc, typename T_scale>
 return_type_t<T_y, T_loc, T_scale> double_exponential_lpdf(
     const T_y& y, const T_loc& mu, const T_scale& sigma) {
-  static const char* function = "double_exponential_lpdf";
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale>;
-
-  using std::fabs;
-  using std::log;
-
-  if (size_zero(y, mu, sigma)) {
-    return 0.0;
-  }
-
-  T_partials_return logp(0.0);
+  static const char* function = "double_exponential_lpdf";
   check_finite(function, "Random variable", y);
   check_finite(function, "Location parameter", mu);
   check_positive_finite(function, "Scale parameter", sigma);
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Shape parameter", sigma);
 
+  if (size_zero(y, mu, sigma)) {
+    return 0.0;
+  }
   if (!include_summand<propto, T_y, T_loc, T_scale>::value) {
     return 0.0;
   }
+
+  using std::fabs;
+  using std::log;
+  T_partials_return logp(0.0);
+  operands_and_partials<T_y, T_loc, T_scale> ops_partials(y, mu, sigma);
 
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_loc> mu_vec(mu);
   scalar_seq_view<T_scale> sigma_vec(sigma);
   size_t size_sigma = stan::math::size(sigma);
   size_t N = max_size(y, mu, sigma);
-  operands_and_partials<T_y, T_loc, T_scale> ops_partials(y, mu, sigma);
 
   VectorBuilder<true, T_partials_return, T_scale> inv_sigma(size_sigma);
   VectorBuilder<include_summand<propto, T_scale>::value, T_partials_return,

--- a/stan/math/prim/prob/double_exponential_rng.hpp
+++ b/stan/math/prim/prob/double_exponential_rng.hpp
@@ -36,7 +36,6 @@ double_exponential_rng(const T_loc& mu, const T_scale& sigma, RNG& rng) {
   using boost::random::uniform_real_distribution;
   using boost::variate_generator;
   static const char* function = "double_exponential_rng";
-
   check_finite(function, "Location parameter", mu);
   check_positive_finite(function, "Scale parameter", sigma);
   check_consistent_sizes(function, "Location parameter", mu, "Scale Parameter",

--- a/stan/math/prim/prob/exp_mod_normal_cdf.hpp
+++ b/stan/math/prim/prob/exp_mod_normal_cdf.hpp
@@ -24,12 +24,6 @@ return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_cdf(
     const T_inv_scale& lambda) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale, T_inv_scale>;
   static const char* function = "exp_mod_normal_cdf";
-
-  T_partials_return cdf(1.0);
-  if (size_zero(y, mu, sigma, lambda)) {
-    return cdf;
-  }
-
   check_not_nan(function, "Random variable", y);
   check_finite(function, "Location parameter", mu);
   check_not_nan(function, "Scale parameter", sigma);
@@ -40,10 +34,14 @@ return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_cdf(
                          mu, "Scale parameter", sigma, "Inv_scale paramter",
                          lambda);
 
-  operands_and_partials<T_y, T_loc, T_scale, T_inv_scale> ops_partials(
-      y, mu, sigma, lambda);
+  if (size_zero(y, mu, sigma, lambda)) {
+    return 1.0;
+  }
 
   using std::exp;
+  T_partials_return cdf(1.0);
+  operands_and_partials<T_y, T_loc, T_scale, T_inv_scale> ops_partials(
+      y, mu, sigma, lambda);
 
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_loc> mu_vec(mu);

--- a/stan/math/prim/prob/exp_mod_normal_lccdf.hpp
+++ b/stan/math/prim/prob/exp_mod_normal_lccdf.hpp
@@ -23,14 +23,8 @@ template <typename T_y, typename T_loc, typename T_scale, typename T_inv_scale>
 return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_lccdf(
     const T_y& y, const T_loc& mu, const T_scale& sigma,
     const T_inv_scale& lambda) {
-  static const char* function = "exp_mod_normal_lccdf";
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale, T_inv_scale>;
-
-  T_partials_return ccdf_log(0.0);
-  if (size_zero(y, mu, sigma, lambda)) {
-    return ccdf_log;
-  }
-
+  static const char* function = "exp_mod_normal_lccdf";
   check_not_nan(function, "Random variable", y);
   check_finite(function, "Location parameter", mu);
   check_not_nan(function, "Scale parameter", sigma);
@@ -41,11 +35,15 @@ return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_lccdf(
                          mu, "Scale parameter", sigma, "Inv_scale paramter",
                          lambda);
 
-  operands_and_partials<T_y, T_loc, T_scale, T_inv_scale> ops_partials(
-      y, mu, sigma, lambda);
+  if (size_zero(y, mu, sigma, lambda)) {
+    return 0;
+  }
 
   using std::exp;
   using std::log;
+  T_partials_return ccdf_log(0.0);
+  operands_and_partials<T_y, T_loc, T_scale, T_inv_scale> ops_partials(
+      y, mu, sigma, lambda);
 
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_loc> mu_vec(mu);

--- a/stan/math/prim/prob/exp_mod_normal_lcdf.hpp
+++ b/stan/math/prim/prob/exp_mod_normal_lcdf.hpp
@@ -23,15 +23,8 @@ template <typename T_y, typename T_loc, typename T_scale, typename T_inv_scale>
 return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_lcdf(
     const T_y& y, const T_loc& mu, const T_scale& sigma,
     const T_inv_scale& lambda) {
-  using T_partials_return = partials_return_t<T_y, T_loc, T_scale, T_inv_scale>;
-
   static const char* function = "exp_mod_normal_lcdf";
-
-  T_partials_return cdf_log(0.0);
-  if (size_zero(y, mu, sigma, lambda)) {
-    return cdf_log;
-  }
-
+  using T_partials_return = partials_return_t<T_y, T_loc, T_scale, T_inv_scale>;
   check_not_nan(function, "Random variable", y);
   check_finite(function, "Location parameter", mu);
   check_not_nan(function, "Scale parameter", sigma);
@@ -42,11 +35,15 @@ return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_lcdf(
                          mu, "Scale parameter", sigma, "Inv_scale paramter",
                          lambda);
 
-  operands_and_partials<T_y, T_loc, T_scale, T_inv_scale> ops_partials(
-      y, mu, sigma, lambda);
+  if (size_zero(y, mu, sigma, lambda)) {
+    return 0;
+  }
 
   using std::exp;
   using std::log;
+  T_partials_return cdf_log(0.0);
+  operands_and_partials<T_y, T_loc, T_scale, T_inv_scale> ops_partials(
+      y, mu, sigma, lambda);
 
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_loc> mu_vec(mu);

--- a/stan/math/prim/prob/exp_mod_normal_lpdf.hpp
+++ b/stan/math/prim/prob/exp_mod_normal_lpdf.hpp
@@ -22,15 +22,8 @@ template <bool propto, typename T_y, typename T_loc, typename T_scale,
 return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_lpdf(
     const T_y& y, const T_loc& mu, const T_scale& sigma,
     const T_inv_scale& lambda) {
-  static const char* function = "exp_mod_normal_lpdf";
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale, T_inv_scale>;
-
-  if (size_zero(y, mu, sigma, lambda)) {
-    return 0.0;
-  }
-
-  T_partials_return logp(0.0);
-
+  static const char* function = "exp_mod_normal_lpdf";
   check_not_nan(function, "Random variable", y);
   check_finite(function, "Location parameter", mu);
   check_positive_finite(function, "Inv_scale parameter", lambda);
@@ -39,6 +32,9 @@ return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_lpdf(
                          mu, "Scale parameter", sigma, "Inv_scale paramter",
                          lambda);
 
+  if (size_zero(y, mu, sigma, lambda)) {
+    return 0.0;
+  }
   if (!include_summand<propto, T_y, T_loc, T_scale, T_inv_scale>::value) {
     return 0.0;
   }
@@ -46,7 +42,7 @@ return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_lpdf(
   using std::exp;
   using std::log;
   using std::sqrt;
-
+  T_partials_return logp(0.0);
   operands_and_partials<T_y, T_loc, T_scale, T_inv_scale> ops_partials(
       y, mu, sigma, lambda);
 

--- a/stan/math/prim/prob/exp_mod_normal_rng.hpp
+++ b/stan/math/prim/prob/exp_mod_normal_rng.hpp
@@ -39,7 +39,6 @@ inline typename VectorBuilder<true, double, T_loc, T_scale, T_inv_scale>::type
 exp_mod_normal_rng(const T_loc& mu, const T_scale& sigma,
                    const T_inv_scale& lambda, RNG& rng) {
   static const char* function = "exp_mod_normal_rng";
-
   check_finite(function, "Location parameter", mu);
   check_positive_finite(function, "Scale parameter", sigma);
   check_positive_finite(function, "Inv_scale parameter", lambda);

--- a/stan/math/prim/prob/exponential_cdf.hpp
+++ b/stan/math/prim/prob/exponential_cdf.hpp
@@ -28,20 +28,17 @@ template <typename T_y, typename T_inv_scale>
 return_type_t<T_y, T_inv_scale> exponential_cdf(const T_y& y,
                                                 const T_inv_scale& beta) {
   using T_partials_return = partials_return_t<T_y, T_inv_scale>;
-
   static const char* function = "exponential_cdf";
-
-  using std::exp;
-
-  T_partials_return cdf(1.0);
-  if (size_zero(y, beta)) {
-    return cdf;
-  }
-
   check_not_nan(function, "Random variable", y);
   check_nonnegative(function, "Random variable", y);
   check_positive_finite(function, "Inverse scale parameter", beta);
 
+  if (size_zero(y, beta)) {
+    return 1.0;
+  }
+
+  using std::exp;
+  T_partials_return cdf(1.0);
   operands_and_partials<T_y, T_inv_scale> ops_partials(y, beta);
 
   scalar_seq_view<T_y> y_vec(y);

--- a/stan/math/prim/prob/exponential_lccdf.hpp
+++ b/stan/math/prim/prob/exponential_lccdf.hpp
@@ -14,18 +14,16 @@ template <typename T_y, typename T_inv_scale>
 return_type_t<T_y, T_inv_scale> exponential_lccdf(const T_y& y,
                                                   const T_inv_scale& beta) {
   using T_partials_return = partials_return_t<T_y, T_inv_scale>;
-
   static const char* function = "exponential_lccdf";
-
-  T_partials_return ccdf_log(0.0);
-  if (size_zero(y, beta)) {
-    return ccdf_log;
-  }
-
   check_not_nan(function, "Random variable", y);
   check_nonnegative(function, "Random variable", y);
   check_positive_finite(function, "Inverse scale parameter", beta);
 
+  if (size_zero(y, beta)) {
+    return 0;
+  }
+
+  T_partials_return ccdf_log(0.0);
   operands_and_partials<T_y, T_inv_scale> ops_partials(y, beta);
 
   scalar_seq_view<T_y> y_vec(y);

--- a/stan/math/prim/prob/exponential_lcdf.hpp
+++ b/stan/math/prim/prob/exponential_lcdf.hpp
@@ -17,21 +17,18 @@ template <typename T_y, typename T_inv_scale>
 return_type_t<T_y, T_inv_scale> exponential_lcdf(const T_y& y,
                                                  const T_inv_scale& beta) {
   using T_partials_return = partials_return_t<T_y, T_inv_scale>;
-
   static const char* function = "exponential_lcdf";
-
-  using std::exp;
-  using std::log;
-
-  T_partials_return cdf_log(0.0);
-  if (size_zero(y, beta)) {
-    return cdf_log;
-  }
-
   check_not_nan(function, "Random variable", y);
   check_nonnegative(function, "Random variable", y);
   check_positive_finite(function, "Inverse scale parameter", beta);
 
+  if (size_zero(y, beta)) {
+    return 0;
+  }
+
+  using std::exp;
+  using std::log;
+  T_partials_return cdf_log(0.0);
   operands_and_partials<T_y, T_inv_scale> ops_partials(y, beta);
 
   scalar_seq_view<T_y> y_vec(y);

--- a/stan/math/prim/prob/exponential_lpdf.hpp
+++ b/stan/math/prim/prob/exponential_lpdf.hpp
@@ -34,30 +34,30 @@ namespace math {
  \mathrm{where} \; y > 0
  \f}
  *
+ * @tparam T_y type of scalar
+ * @tparam T_inv_scale type of inverse scale
  * @param y A scalar variable.
  * @param beta Inverse scale parameter.
  * @throw std::domain_error if beta is not greater than 0.
  * @throw std::domain_error if y is not greater than or equal to 0.
- * @tparam T_y Type of scalar.
- * @tparam T_inv_scale Type of inverse scale.
  */
 template <bool propto, typename T_y, typename T_inv_scale>
 return_type_t<T_y, T_inv_scale> exponential_lpdf(const T_y& y,
                                                  const T_inv_scale& beta) {
-  static const char* function = "exponential_lpdf";
   using T_partials_return = partials_return_t<T_y, T_inv_scale>;
+  static const char* function = "exponential_lpdf";
+  check_nonnegative(function, "Random variable", y);
+  check_positive_finite(function, "Inverse scale parameter", beta);
+  check_consistent_sizes(function, "Random variable", y,
+                         "Inverse scale parameter", beta);
 
   if (size_zero(y, beta)) {
     return 0.0;
   }
 
   using std::log;
-
   T_partials_return logp(0.0);
-  check_nonnegative(function, "Random variable", y);
-  check_positive_finite(function, "Inverse scale parameter", beta);
-  check_consistent_sizes(function, "Random variable", y,
-                         "Inverse scale parameter", beta);
+  operands_and_partials<T_y, T_inv_scale> ops_partials(y, beta);
 
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_inv_scale> beta_vec(beta);
@@ -72,8 +72,6 @@ return_type_t<T_y, T_inv_scale> exponential_lpdf(const T_y& y,
       log_beta[i] = log(value_of(beta_vec[i]));
     }
   }
-
-  operands_and_partials<T_y, T_inv_scale> ops_partials(y, beta);
 
   for (size_t n = 0; n < N; n++) {
     const T_partials_return beta_dbl = value_of(beta_vec[n]);

--- a/stan/math/prim/prob/exponential_rng.hpp
+++ b/stan/math/prim/prob/exponential_rng.hpp
@@ -28,9 +28,7 @@ inline typename VectorBuilder<true, double, T_inv>::type exponential_rng(
     const T_inv& beta, RNG& rng) {
   using boost::exponential_distribution;
   using boost::variate_generator;
-
   static const char* function = "exponential_rng";
-
   check_positive_finite(function, "Inverse scale parameter", beta);
 
   scalar_seq_view<T_inv> beta_vec(beta);

--- a/stan/math/prim/prob/frechet_cdf.hpp
+++ b/stan/math/prim/prob/frechet_cdf.hpp
@@ -24,22 +24,19 @@ return_type_t<T_y, T_shape, T_scale> frechet_cdf(const T_y& y,
                                                  const T_shape& alpha,
                                                  const T_scale& sigma) {
   using T_partials_return = partials_return_t<T_y, T_shape, T_scale>;
-
   static const char* function = "frechet_cdf";
-
-  using std::exp;
-  using std::log;
-  using std::pow;
+  check_positive(function, "Random variable", y);
+  check_positive_finite(function, "Shape parameter", alpha);
+  check_positive_finite(function, "Scale parameter", sigma);
 
   if (size_zero(y, alpha, sigma)) {
     return 1.0;
   }
 
+  using std::exp;
+  using std::log;
+  using std::pow;
   T_partials_return cdf(1.0);
-  check_positive(function, "Random variable", y);
-  check_positive_finite(function, "Shape parameter", alpha);
-  check_positive_finite(function, "Scale parameter", sigma);
-
   operands_and_partials<T_y, T_shape, T_scale> ops_partials(y, alpha, sigma);
 
   scalar_seq_view<T_y> y_vec(y);

--- a/stan/math/prim/prob/frechet_lccdf.hpp
+++ b/stan/math/prim/prob/frechet_lccdf.hpp
@@ -23,23 +23,20 @@ return_type_t<T_y, T_shape, T_scale> frechet_lccdf(const T_y& y,
                                                    const T_shape& alpha,
                                                    const T_scale& sigma) {
   using T_partials_return = partials_return_t<T_y, T_shape, T_scale>;
-
   static const char* function = "frechet_lccdf";
-
-  if (size_zero(y, alpha, sigma)) {
-    return 0.0;
-  }
-
-  T_partials_return ccdf_log(0.0);
   check_positive(function, "Random variable", y);
   check_positive_finite(function, "Shape parameter", alpha);
   check_positive_finite(function, "Scale parameter", sigma);
 
-  operands_and_partials<T_y, T_shape, T_scale> ops_partials(y, alpha, sigma);
+  if (size_zero(y, alpha, sigma)) {
+    return 0;
+  }
 
   using std::exp;
   using std::log;
   using std::pow;
+  T_partials_return ccdf_log(0.0);
+  operands_and_partials<T_y, T_shape, T_scale> ops_partials(y, alpha, sigma);
 
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_scale> sigma_vec(sigma);

--- a/stan/math/prim/prob/frechet_lcdf.hpp
+++ b/stan/math/prim/prob/frechet_lcdf.hpp
@@ -22,21 +22,18 @@ return_type_t<T_y, T_shape, T_scale> frechet_lcdf(const T_y& y,
                                                   const T_shape& alpha,
                                                   const T_scale& sigma) {
   using T_partials_return = partials_return_t<T_y, T_shape, T_scale>;
-
   static const char* function = "frechet_lcdf";
-
-  using std::log;
-  using std::pow;
+  check_positive(function, "Random variable", y);
+  check_positive_finite(function, "Shape parameter", alpha);
+  check_positive_finite(function, "Scale parameter", sigma);
 
   if (size_zero(y, alpha, sigma)) {
     return 0.0;
   }
 
+  using std::log;
+  using std::pow;
   T_partials_return cdf_log(0.0);
-  check_positive(function, "Random variable", y);
-  check_positive_finite(function, "Shape parameter", alpha);
-  check_positive_finite(function, "Scale parameter", sigma);
-
   operands_and_partials<T_y, T_shape, T_scale> ops_partials(y, alpha, sigma);
 
   scalar_seq_view<T_y> y_vec(y);

--- a/stan/math/prim/prob/frechet_lpdf.hpp
+++ b/stan/math/prim/prob/frechet_lpdf.hpp
@@ -24,9 +24,8 @@ template <bool propto, typename T_y, typename T_shape, typename T_scale>
 return_type_t<T_y, T_shape, T_scale> frechet_lpdf(const T_y& y,
                                                   const T_shape& alpha,
                                                   const T_scale& sigma) {
-  static const char* function = "frechet_lpdf";
   using T_partials_return = partials_return_t<T_y, T_shape, T_scale>;
-  using std::log;
+  static const char* function = "frechet_lpdf";
   check_positive(function, "Random variable", y);
   check_positive_finite(function, "Shape parameter", alpha);
   check_positive_finite(function, "Scale parameter", sigma);
@@ -40,9 +39,10 @@ return_type_t<T_y, T_shape, T_scale> frechet_lpdf(const T_y& y,
     return 0;
   }
 
+  using std::log;
   using std::pow;
-
   T_partials_return logp(0);
+  operands_and_partials<T_y, T_shape, T_scale> ops_partials(y, alpha, sigma);
 
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_shape> alpha_vec(alpha);
@@ -92,7 +92,6 @@ return_type_t<T_y, T_shape, T_scale> frechet_lpdf(const T_y& y,
         = pow(inv_y[i] * value_of(sigma_vec[i]), alpha_dbl);
   }
 
-  operands_and_partials<T_y, T_shape, T_scale> ops_partials(y, alpha, sigma);
   for (size_t n = 0; n < N; n++) {
     const T_partials_return alpha_dbl = value_of(alpha_vec[n]);
     if (include_summand<propto, T_shape>::value) {

--- a/stan/math/prim/prob/frechet_rng.hpp
+++ b/stan/math/prim/prob/frechet_rng.hpp
@@ -16,8 +16,8 @@ namespace math {
  * alpha and sigma can each be a scalar or a one-dimensional container. Any
  * non-scalar inputs must be the same size.
  *
- * @tparam T_shape Type of shape parameter
- * @tparam T_scale Type of scale parameter
+ * @tparam T_shape type of shape parameter
+ * @tparam T_scale type of scale parameter
  * @tparam RNG type of random number generator
  * @param alpha (Sequence of) positive shape parameter(s)
  * @param sigma (Sequence of) positive scale parameter(s)
@@ -32,9 +32,7 @@ inline typename VectorBuilder<true, double, T_shape, T_scale>::type frechet_rng(
     const T_shape& alpha, const T_scale& sigma, RNG& rng) {
   using boost::random::weibull_distribution;
   using boost::variate_generator;
-
   static const char* function = "frechet_rng";
-
   check_positive_finite(function, "Shape parameter", alpha);
   check_positive_finite(function, "Scale parameter", sigma);
   check_consistent_sizes(function, "Shape parameter", alpha, "Scale Parameter",

--- a/stan/math/prim/prob/gamma_cdf.hpp
+++ b/stan/math/prim/prob/gamma_cdf.hpp
@@ -25,31 +25,22 @@ namespace math {
  * The cumulative density function for a gamma distribution for y
  * with the specified shape and inverse scale parameters.
  *
+ * @tparam T_y type of scalar
+ * @tparam T_shape type of shape
+ * @tparam T_inv_scale type of inverse scale
  * @param y A scalar variable.
  * @param alpha Shape parameter.
  * @param beta Inverse scale parameter.
  * @throw std::domain_error if alpha is not greater than 0.
  * @throw std::domain_error if beta is not greater than 0.
  * @throw std::domain_error if y is not greater than or equal to 0.
- * @tparam T_y Type of scalar.
- * @tparam T_shape Type of shape.
- * @tparam T_inv_scale Type of inverse scale.
  */
 template <typename T_y, typename T_shape, typename T_inv_scale>
 return_type_t<T_y, T_shape, T_inv_scale> gamma_cdf(const T_y& y,
                                                    const T_shape& alpha,
                                                    const T_inv_scale& beta) {
-  if (size_zero(y, alpha, beta)) {
-    return 1.0;
-  }
   using T_partials_return = partials_return_t<T_y, T_shape, T_inv_scale>;
-
   static const char* function = "gamma_cdf";
-
-  using std::exp;
-
-  T_partials_return P(1.0);
-
   check_positive_finite(function, "Shape parameter", alpha);
   check_positive_finite(function, "Inverse scale parameter", beta);
   check_not_nan(function, "Random variable", y);
@@ -57,12 +48,18 @@ return_type_t<T_y, T_shape, T_inv_scale> gamma_cdf(const T_y& y,
   check_consistent_sizes(function, "Random variable", y, "Shape parameter",
                          alpha, "Inverse scale parameter", beta);
 
+  if (size_zero(y, alpha, beta)) {
+    return 1.0;
+  }
+
+  using std::exp;
+  T_partials_return P(1.0);
+  operands_and_partials<T_y, T_shape, T_inv_scale> ops_partials(y, alpha, beta);
+
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_shape> alpha_vec(alpha);
   scalar_seq_view<T_inv_scale> beta_vec(beta);
   size_t N = max_size(y, alpha, beta);
-
-  operands_and_partials<T_y, T_shape, T_inv_scale> ops_partials(y, alpha, beta);
 
   // Explicit return for extreme values
   // The gradients are technically ill-defined, but treated as zero

--- a/stan/math/prim/prob/gamma_lccdf.hpp
+++ b/stan/math/prim/prob/gamma_lccdf.hpp
@@ -23,16 +23,8 @@ template <typename T_y, typename T_shape, typename T_inv_scale>
 return_type_t<T_y, T_shape, T_inv_scale> gamma_lccdf(const T_y& y,
                                                      const T_shape& alpha,
                                                      const T_inv_scale& beta) {
-  if (size_zero(y, alpha, beta)) {
-    return 0.0;
-  }
-
   using T_partials_return = partials_return_t<T_y, T_shape, T_inv_scale>;
-
   static const char* function = "gamma_lccdf";
-
-  T_partials_return P(0.0);
-
   check_positive_finite(function, "Shape parameter", alpha);
   check_positive_finite(function, "Inverse scale parameter", beta);
   check_not_nan(function, "Random variable", y);
@@ -40,12 +32,20 @@ return_type_t<T_y, T_shape, T_inv_scale> gamma_lccdf(const T_y& y,
   check_consistent_sizes(function, "Random variable", y, "Shape parameter",
                          alpha, "Inverse scale parameter", beta);
 
+  if (size_zero(y, alpha, beta)) {
+    return 0;
+  }
+
+  using std::exp;
+  using std::log;
+  using std::pow;
+  T_partials_return P(0.0);
+  operands_and_partials<T_y, T_shape, T_inv_scale> ops_partials(y, alpha, beta);
+
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_shape> alpha_vec(alpha);
   scalar_seq_view<T_inv_scale> beta_vec(beta);
   size_t N = max_size(y, alpha, beta);
-
-  operands_and_partials<T_y, T_shape, T_inv_scale> ops_partials(y, alpha, beta);
 
   // Explicit return for extreme values
   // The gradients are technically ill-defined, but treated as zero
@@ -54,10 +54,6 @@ return_type_t<T_y, T_shape, T_inv_scale> gamma_lccdf(const T_y& y,
       return ops_partials.build(0.0);
     }
   }
-
-  using std::exp;
-  using std::log;
-  using std::pow;
 
   VectorBuilder<!is_constant_all<T_shape>::value, T_partials_return, T_shape>
       gamma_vec(size(alpha));

--- a/stan/math/prim/prob/gamma_lcdf.hpp
+++ b/stan/math/prim/prob/gamma_lcdf.hpp
@@ -23,15 +23,8 @@ template <typename T_y, typename T_shape, typename T_inv_scale>
 return_type_t<T_y, T_shape, T_inv_scale> gamma_lcdf(const T_y& y,
                                                     const T_shape& alpha,
                                                     const T_inv_scale& beta) {
-  if (size_zero(y, alpha, beta)) {
-    return 0.0;
-  }
   using T_partials_return = partials_return_t<T_y, T_shape, T_inv_scale>;
-
   static const char* function = "gamma_lcdf";
-
-  T_partials_return P(0.0);
-
   check_positive_finite(function, "Shape parameter", alpha);
   check_positive_finite(function, "Inverse scale parameter", beta);
   check_not_nan(function, "Random variable", y);
@@ -39,12 +32,20 @@ return_type_t<T_y, T_shape, T_inv_scale> gamma_lcdf(const T_y& y,
   check_consistent_sizes(function, "Random variable", y, "Shape parameter",
                          alpha, "Inverse scale parameter", beta);
 
+  if (size_zero(y, alpha, beta)) {
+    return 0;
+  }
+
+  using std::exp;
+  using std::log;
+  using std::pow;
+  T_partials_return P(0.0);
+  operands_and_partials<T_y, T_shape, T_inv_scale> ops_partials(y, alpha, beta);
+
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_shape> alpha_vec(alpha);
   scalar_seq_view<T_inv_scale> beta_vec(beta);
   size_t N = max_size(y, alpha, beta);
-
-  operands_and_partials<T_y, T_shape, T_inv_scale> ops_partials(y, alpha, beta);
 
   // Explicit return for extreme values
   // The gradients are technically ill-defined, but treated as zero
@@ -53,10 +54,6 @@ return_type_t<T_y, T_shape, T_inv_scale> gamma_lcdf(const T_y& y,
       return ops_partials.build(negative_infinity());
     }
   }
-
-  using std::exp;
-  using std::log;
-  using std::pow;
 
   VectorBuilder<!is_constant_all<T_shape>::value, T_partials_return, T_shape>
       gamma_vec(size(alpha));

--- a/stan/math/prim/prob/gamma_lpdf.hpp
+++ b/stan/math/prim/prob/gamma_lpdf.hpp
@@ -29,42 +29,44 @@ namespace math {
  \frac{\beta^\alpha}{\Gamma(\alpha)} y^{\alpha - 1} \exp^{- \beta y} \right) \\
  &=& \alpha \log(\beta) - \log(\Gamma(\alpha)) + (\alpha - 1) \log(y) - \beta
  y\\ & & \mathrm{where} \; y > 0 \f}
+ *
+ * @tparam T_y type of scalar
+ * @tparam T_shape type of shape
+ * @tparam T_inv_scale type of inverse scale
  * @param y A scalar variable.
  * @param alpha Shape parameter.
  * @param beta Inverse scale parameter.
  * @throw std::domain_error if alpha is not greater than 0.
  * @throw std::domain_error if beta is not greater than 0.
  * @throw std::domain_error if y is not greater than or equal to 0.
- * @tparam T_y Type of scalar.
- * @tparam T_shape Type of shape.
- * @tparam T_inv_scale Type of inverse scale.
  */
 template <bool propto, typename T_y, typename T_shape, typename T_inv_scale>
 return_type_t<T_y, T_shape, T_inv_scale> gamma_lpdf(const T_y& y,
                                                     const T_shape& alpha,
                                                     const T_inv_scale& beta) {
-  static const char* function = "gamma_lpdf";
   using T_partials_return = partials_return_t<T_y, T_shape, T_inv_scale>;
-
-  if (size_zero(y, alpha, beta)) {
-    return 0.0;
-  }
-
-  T_partials_return logp(0.0);
-
+  static const char* function = "gamma_lpdf";
   check_not_nan(function, "Random variable", y);
   check_positive_finite(function, "Shape parameter", alpha);
   check_positive_finite(function, "Inverse scale parameter", beta);
   check_consistent_sizes(function, "Random variable", y, "Shape parameter",
                          alpha, "Inverse scale parameter", beta);
 
+  if (size_zero(y, alpha, beta)) {
+    return 0.0;
+  }
   if (!include_summand<propto, T_y, T_shape, T_inv_scale>::value) {
     return 0.0;
   }
 
+  using std::log;
+  T_partials_return logp(0.0);
+  operands_and_partials<T_y, T_shape, T_inv_scale> ops_partials(y, alpha, beta);
+
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_shape> alpha_vec(alpha);
   scalar_seq_view<T_inv_scale> beta_vec(beta);
+  size_t N = max_size(y, alpha, beta);
 
   for (size_t n = 0; n < stan::math::size(y); n++) {
     const T_partials_return y_dbl = value_of(y_vec[n]);
@@ -72,11 +74,6 @@ return_type_t<T_y, T_shape, T_inv_scale> gamma_lpdf(const T_y& y,
       return LOG_ZERO;
     }
   }
-
-  size_t N = max_size(y, alpha, beta);
-  operands_and_partials<T_y, T_shape, T_inv_scale> ops_partials(y, alpha, beta);
-
-  using std::log;
 
   VectorBuilder<include_summand<propto, T_y, T_shape>::value, T_partials_return,
                 T_y>

--- a/stan/math/prim/prob/gamma_rng.hpp
+++ b/stan/math/prim/prob/gamma_rng.hpp
@@ -17,8 +17,8 @@ namespace math {
  * alpha and beta can each be a scalar or a one-dimensional container. Any
  * non-scalar inputs must be the same size.
  *
- * @tparam T_shape Type of shape parameter
- * @tparam T_inv Type of inverse scale parameter
+ * @tparam T_shape type of shape parameter
+ * @tparam T_inv type of inverse scale parameter
  * @tparam RNG type of random number generator
  * @param alpha (Sequence of) positive shape parameter(s)
  * @param beta (Sequence of) positive inverse scale parameter(s)
@@ -33,9 +33,7 @@ inline typename VectorBuilder<true, double, T_shape, T_inv>::type gamma_rng(
     const T_shape& alpha, const T_inv& beta, RNG& rng) {
   using boost::gamma_distribution;
   using boost::variate_generator;
-
   static const char* function = "gamma_rng";
-
   check_positive_finite(function, "Shape parameter", alpha);
   check_positive_finite(function, "Inverse scale parameter", beta);
   check_consistent_sizes(function, "Shape parameter", alpha,

--- a/stan/math/prim/prob/gaussian_dlm_obs_lpdf.hpp
+++ b/stan/math/prim/prob/gaussian_dlm_obs_lpdf.hpp
@@ -38,6 +38,14 @@ namespace math {
  * If V is a vector, then the Kalman filter is applied
  * sequentially.
  *
+ * @tparam T_y type of scalar
+ * @tparam T_F type of design matrix
+ * @tparam T_G type of transition matrix
+ * @tparam T_V type of observation covariance matrix
+ * @tparam T_W type of state covariance matrix
+ * @tparam T_m0 type of initial state mean vector
+ * @tparam T_C0 type of initial state covariance matrix
+ *
  * @param y A r x T matrix of observations. Rows are variables,
  * columns are observations.
  * @param F A n x r matrix. The design matrix.
@@ -51,13 +59,6 @@ namespace math {
  * @return The log of the joint density of the GDLM.
  * @throw std::domain_error if a matrix in the Kalman filter is
  * not positive semi-definite.
- * @tparam T_y Type of scalar.
- * @tparam T_F Type of design matrix.
- * @tparam T_G Type of transition matrix.
- * @tparam T_V Type of observation covariance matrix.
- * @tparam T_W Type of state covariance matrix.
- * @tparam T_m0 Type of initial state mean vector.
- * @tparam T_C0 Type of initial state covariance matrix.
  */
 template <bool propto, typename T_y, typename T_F, typename T_G, typename T_V,
           typename T_W, typename T_m0, typename T_C0>

--- a/stan/math/prim/prob/gaussian_dlm_obs_rng.hpp
+++ b/stan/math/prim/prob/gaussian_dlm_obs_rng.hpp
@@ -19,7 +19,7 @@ namespace internal {
  * No error checking or templating, takes the LDLT directly to avoid
  * recomputation. Can sample from semidefinite covariance matrices.
  *
- * @tparam RNG Type of pseudo-random number generator
+ * @tparam RNG type of pseudo-random number generator
  * @param mu location parameter
  * @param S_ldlt Eigen::LDLT of covariance matrix, semidefinite is okay
  * @param rng random number generator

--- a/stan/math/prim/prob/gumbel_cdf.hpp
+++ b/stan/math/prim/prob/gumbel_cdf.hpp
@@ -31,16 +31,8 @@ namespace math {
 template <typename T_y, typename T_loc, typename T_scale>
 return_type_t<T_y, T_loc, T_scale> gumbel_cdf(const T_y& y, const T_loc& mu,
                                               const T_scale& beta) {
-  static const char* function = "gumbel_cdf";
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale>;
-
-  using std::exp;
-
-  T_partials_return cdf(1.0);
-  if (size_zero(y, mu, beta)) {
-    return cdf;
-  }
-
+  static const char* function = "gumbel_cdf";
   check_not_nan(function, "Random variable", y);
   check_finite(function, "Location parameter", mu);
   check_not_nan(function, "Scale parameter", beta);
@@ -48,6 +40,12 @@ return_type_t<T_y, T_loc, T_scale> gumbel_cdf(const T_y& y, const T_loc& mu,
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Scale parameter", beta);
 
+  if (size_zero(y, mu, beta)) {
+    return 1.0;
+  }
+
+  using std::exp;
+  T_partials_return cdf(1.0);
   operands_and_partials<T_y, T_loc, T_scale> ops_partials(y, mu, beta);
 
   scalar_seq_view<T_y> y_vec(y);

--- a/stan/math/prim/prob/gumbel_lccdf.hpp
+++ b/stan/math/prim/prob/gumbel_lccdf.hpp
@@ -31,17 +31,8 @@ namespace math {
 template <typename T_y, typename T_loc, typename T_scale>
 return_type_t<T_y, T_loc, T_scale> gumbel_lccdf(const T_y& y, const T_loc& mu,
                                                 const T_scale& beta) {
-  static const char* function = "gumbel_lccdf";
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale>;
-
-  using std::exp;
-  using std::log;
-
-  T_partials_return ccdf_log(0.0);
-  if (size_zero(y, mu, beta)) {
-    return ccdf_log;
-  }
-
+  static const char* function = "gumbel_lccdf";
   check_not_nan(function, "Random variable", y);
   check_finite(function, "Location parameter", mu);
   check_not_nan(function, "Scale parameter", beta);
@@ -49,6 +40,13 @@ return_type_t<T_y, T_loc, T_scale> gumbel_lccdf(const T_y& y, const T_loc& mu,
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Scale parameter", beta);
 
+  if (size_zero(y, mu, beta)) {
+    return 0;
+  }
+
+  using std::exp;
+  using std::log;
+  T_partials_return ccdf_log(0.0);
   operands_and_partials<T_y, T_loc, T_scale> ops_partials(y, mu, beta);
 
   scalar_seq_view<T_y> y_vec(y);

--- a/stan/math/prim/prob/gumbel_lcdf.hpp
+++ b/stan/math/prim/prob/gumbel_lcdf.hpp
@@ -30,16 +30,8 @@ namespace math {
 template <typename T_y, typename T_loc, typename T_scale>
 return_type_t<T_y, T_loc, T_scale> gumbel_lcdf(const T_y& y, const T_loc& mu,
                                                const T_scale& beta) {
-  static const char* function = "gumbel_lcdf";
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale>;
-
-  using std::exp;
-
-  T_partials_return cdf_log(0.0);
-  if (size_zero(y, mu, beta)) {
-    return cdf_log;
-  }
-
+  static const char* function = "gumbel_lcdf";
   check_not_nan(function, "Random variable", y);
   check_finite(function, "Location parameter", mu);
   check_not_nan(function, "Scale parameter", beta);
@@ -47,6 +39,12 @@ return_type_t<T_y, T_loc, T_scale> gumbel_lcdf(const T_y& y, const T_loc& mu,
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Scale parameter", beta);
 
+  if (size_zero(y, mu, beta)) {
+    return 0;
+  }
+
+  using std::exp;
+  T_partials_return cdf_log(0.0);
   operands_and_partials<T_y, T_loc, T_scale> ops_partials(y, mu, beta);
 
   scalar_seq_view<T_y> y_vec(y);

--- a/stan/math/prim/prob/gumbel_lpdf.hpp
+++ b/stan/math/prim/prob/gumbel_lpdf.hpp
@@ -32,28 +32,24 @@ namespace math {
 template <bool propto, typename T_y, typename T_loc, typename T_scale>
 return_type_t<T_y, T_loc, T_scale> gumbel_lpdf(const T_y& y, const T_loc& mu,
                                                const T_scale& beta) {
-  static const char* function = "gumbel_lpdf";
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale>;
-
-  using std::exp;
-  using std::log;
-
-  if (size_zero(y, mu, beta)) {
-    return 0.0;
-  }
-
-  T_partials_return logp(0.0);
-
+  static const char* function = "gumbel_lpdf";
   check_not_nan(function, "Random variable", y);
   check_finite(function, "Location parameter", mu);
   check_positive(function, "Scale parameter", beta);
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Scale parameter", beta);
 
+  if (size_zero(y, mu, beta)) {
+    return 0.0;
+  }
   if (!include_summand<propto, T_y, T_loc, T_scale>::value) {
     return 0.0;
   }
 
+  using std::exp;
+  using std::log;
+  T_partials_return logp(0.0);
   operands_and_partials<T_y, T_loc, T_scale> ops_partials(y, mu, beta);
 
   scalar_seq_view<T_y> y_vec(y);

--- a/stan/math/prim/prob/gumbel_rng.hpp
+++ b/stan/math/prim/prob/gumbel_rng.hpp
@@ -18,8 +18,8 @@ namespace math {
  * mu and beta can each be a scalar or a vector. Any non-scalar inputs
  * must be the same length.
  *
- * @tparam T_loc Type of location parameter
- * @tparam T_scale Type of scale parameter
+ * @tparam T_loc type of location parameter
+ * @tparam T_scale type of scale parameter
  * @tparam RNG type of random number generator
  * @param mu (Sequence of) location parameter(s)
  * @param beta (Sequence of) scale parameter(s)
@@ -35,7 +35,6 @@ inline typename VectorBuilder<true, double, T_loc, T_scale>::type gumbel_rng(
   using boost::uniform_01;
   using boost::variate_generator;
   static const char* function = "gumbel_rng";
-
   check_finite(function, "Location parameter", mu);
   check_positive_finite(function, "Scale parameter", beta);
   check_consistent_sizes(function, "Location parameter", mu, "Scale Parameter",

--- a/stan/math/prim/prob/hypergeometric_lpmf.hpp
+++ b/stan/math/prim/prob/hypergeometric_lpmf.hpp
@@ -17,10 +17,17 @@ template <bool propto, typename T_n, typename T_N, typename T_a, typename T_b>
 double hypergeometric_lpmf(const T_n& n, const T_N& N, const T_a& a,
                            const T_b& b) {
   static const char* function = "hypergeometric_lpmf";
+  check_bounded(function, "Successes variable", n, 0, a);
+  check_consistent_sizes(function, "Successes variable", n, "Draws parameter",
+                         N, "Successes in population parameter", a,
+                         "Failures in population parameter", b);
+  check_greater_or_equal(function, "Draws parameter", N, n);
 
   if (size_zero(n, N, a, b)) {
     return 0.0;
   }
+
+  double logp(0.0);
 
   scalar_seq_view<T_n> n_vec(n);
   scalar_seq_view<T_N> N_vec(N);
@@ -28,12 +35,6 @@ double hypergeometric_lpmf(const T_n& n, const T_N& N, const T_a& a,
   scalar_seq_view<T_b> b_vec(b);
   size_t max_size_seq_view = max_size(n, N, a, b);
 
-  double logp(0.0);
-  check_bounded(function, "Successes variable", n, 0, a);
-  check_consistent_sizes(function, "Successes variable", n, "Draws parameter",
-                         N, "Successes in population parameter", a,
-                         "Failures in population parameter", b);
-  check_greater_or_equal(function, "Draws parameter", N, n);
   for (size_t i = 0; i < max_size_seq_view; i++) {
     check_bounded(function, "Draws parameter minus successes variable",
                   N_vec[i] - n_vec[i], 0, b_vec[i]);

--- a/stan/math/prim/prob/hypergeometric_rng.hpp
+++ b/stan/math/prim/prob/hypergeometric_rng.hpp
@@ -14,9 +14,7 @@ template <class RNG>
 inline int hypergeometric_rng(int N, int a, int b, RNG& rng) {
   using boost::math::hypergeometric_distribution;
   using boost::variate_generator;
-
   static const char* function = "hypergeometric_rng";
-
   check_bounded(function, "Draws parameter", N, 0, a + b);
   check_positive(function, "Draws parameter", N);
   check_positive(function, "Successes in population parameter", a);

--- a/stan/math/prim/prob/inv_chi_square_cdf.hpp
+++ b/stan/math/prim/prob/inv_chi_square_cdf.hpp
@@ -34,26 +34,25 @@ namespace math {
 template <typename T_y, typename T_dof>
 return_type_t<T_y, T_dof> inv_chi_square_cdf(const T_y& y, const T_dof& nu) {
   using T_partials_return = partials_return_t<T_y, T_dof>;
-
-  if (size_zero(y, nu)) {
-    return 1.0;
-  }
-
   static const char* function = "inv_chi_square_cdf";
-
-  T_partials_return P(1.0);
-
   check_positive_finite(function, "Degrees of freedom parameter", nu);
   check_not_nan(function, "Random variable", y);
   check_nonnegative(function, "Random variable", y);
   check_consistent_sizes(function, "Random variable", y,
                          "Degrees of freedom parameter", nu);
 
+  if (size_zero(y, nu)) {
+    return 1.0;
+  }
+
+  using std::exp;
+  using std::pow;
+  T_partials_return P(1.0);
+  operands_and_partials<T_y, T_dof> ops_partials(y, nu);
+
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_dof> nu_vec(nu);
   size_t N = max_size(y, nu);
-
-  operands_and_partials<T_y, T_dof> ops_partials(y, nu);
 
   // Explicit return for extreme values
   // The gradients are technically ill-defined, but treated as zero
@@ -62,9 +61,6 @@ return_type_t<T_y, T_dof> inv_chi_square_cdf(const T_y& y, const T_dof& nu) {
       return ops_partials.build(0.0);
     }
   }
-
-  using std::exp;
-  using std::pow;
 
   VectorBuilder<!is_constant_all<T_dof>::value, T_partials_return, T_dof>
       gamma_vec(size(nu));

--- a/stan/math/prim/prob/inv_chi_square_lccdf.hpp
+++ b/stan/math/prim/prob/inv_chi_square_lccdf.hpp
@@ -35,26 +35,26 @@ namespace math {
 template <typename T_y, typename T_dof>
 return_type_t<T_y, T_dof> inv_chi_square_lccdf(const T_y& y, const T_dof& nu) {
   using T_partials_return = partials_return_t<T_y, T_dof>;
-
-  if (size_zero(y, nu)) {
-    return 0.0;
-  }
-
   static const char* function = "inv_chi_square_lccdf";
-
-  T_partials_return P(0.0);
-
   check_positive_finite(function, "Degrees of freedom parameter", nu);
   check_not_nan(function, "Random variable", y);
   check_nonnegative(function, "Random variable", y);
   check_consistent_sizes(function, "Random variable", y,
                          "Degrees of freedom parameter", nu);
 
+  if (size_zero(y, nu)) {
+    return 0;
+  }
+
+  using std::exp;
+  using std::log;
+  using std::pow;
+  T_partials_return P(0.0);
+  operands_and_partials<T_y, T_dof> ops_partials(y, nu);
+
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_dof> nu_vec(nu);
   size_t N = max_size(y, nu);
-
-  operands_and_partials<T_y, T_dof> ops_partials(y, nu);
 
   // Explicit return for extreme values
   // The gradients are technically ill-defined, but treated as zero
@@ -63,10 +63,6 @@ return_type_t<T_y, T_dof> inv_chi_square_lccdf(const T_y& y, const T_dof& nu) {
       return ops_partials.build(0.0);
     }
   }
-
-  using std::exp;
-  using std::log;
-  using std::pow;
 
   VectorBuilder<!is_constant_all<T_dof>::value, T_partials_return, T_dof>
       gamma_vec(size(nu));

--- a/stan/math/prim/prob/inv_chi_square_lcdf.hpp
+++ b/stan/math/prim/prob/inv_chi_square_lcdf.hpp
@@ -35,26 +35,26 @@ namespace math {
 template <typename T_y, typename T_dof>
 return_type_t<T_y, T_dof> inv_chi_square_lcdf(const T_y& y, const T_dof& nu) {
   using T_partials_return = partials_return_t<T_y, T_dof>;
-
-  if (size_zero(y, nu)) {
-    return 0.0;
-  }
-
   static const char* function = "inv_chi_square_lcdf";
-
-  T_partials_return P(0.0);
-
   check_positive_finite(function, "Degrees of freedom parameter", nu);
   check_not_nan(function, "Random variable", y);
   check_nonnegative(function, "Random variable", y);
   check_consistent_sizes(function, "Random variable", y,
                          "Degrees of freedom parameter", nu);
 
+  if (size_zero(y, nu)) {
+    return 0;
+  }
+
+  using std::exp;
+  using std::log;
+  using std::pow;
+  T_partials_return P(0.0);
+  operands_and_partials<T_y, T_dof> ops_partials(y, nu);
+
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_dof> nu_vec(nu);
   size_t N = max_size(y, nu);
-
-  operands_and_partials<T_y, T_dof> ops_partials(y, nu);
 
   // Explicit return for extreme values
   // The gradients are technically ill-defined, but treated as zero
@@ -63,10 +63,6 @@ return_type_t<T_y, T_dof> inv_chi_square_lcdf(const T_y& y, const T_dof& nu) {
       return ops_partials.build(negative_infinity());
     }
   }
-
-  using std::exp;
-  using std::log;
-  using std::pow;
 
   VectorBuilder<!is_constant_all<T_dof>::value, T_partials_return, T_dof>
       gamma_vec(size(nu));

--- a/stan/math/prim/prob/inv_chi_square_lpdf.hpp
+++ b/stan/math/prim/prob/inv_chi_square_lpdf.hpp
@@ -29,27 +29,30 @@ namespace math {
  y^{- (\nu / 2 + 1)} \exp^{-1 / (2y)} \right) \\
  &=& - \frac{\nu}{2} \log(2) - \log (\Gamma (\nu / 2)) - (\frac{\nu}{2} + 1)
  \log(y) - \frac{1}{2y} \\ & & \mathrm{ where } \; y > 0 \f}
+ *
+ * @tparam T_y type of scalar
+ * @tparam T_dof type of degrees of freedom
  * @param y A scalar variable.
  * @param nu Degrees of freedom.
  * @throw std::domain_error if nu is not greater than or equal to 0
  * @throw std::domain_error if y is not greater than or equal to 0.
- * @tparam T_y Type of scalar.
- * @tparam T_dof Type of degrees of freedom.
  */
 template <bool propto, typename T_y, typename T_dof>
 return_type_t<T_y, T_dof> inv_chi_square_lpdf(const T_y& y, const T_dof& nu) {
   static const char* function = "inv_chi_square_lpdf";
   using T_partials_return = partials_return_t<T_y, T_dof>;
-
   check_positive_finite(function, "Degrees of freedom parameter", nu);
   check_not_nan(function, "Random variable", y);
   check_consistent_sizes(function, "Random variable", y,
                          "Degrees of freedom parameter", nu);
+
   if (size_zero(y, nu)) {
     return 0;
   }
 
+  using std::log;
   T_partials_return logp(0);
+  operands_and_partials<T_y, T_dof> ops_partials(y, nu);
 
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_dof> nu_vec(nu);
@@ -60,8 +63,6 @@ return_type_t<T_y, T_dof> inv_chi_square_lpdf(const T_y& y, const T_dof& nu) {
       return LOG_ZERO;
     }
   }
-
-  using std::log;
 
   VectorBuilder<include_summand<propto, T_y, T_dof>::value, T_partials_return,
                 T_y>
@@ -94,7 +95,6 @@ return_type_t<T_y, T_dof> inv_chi_square_lpdf(const T_y& y, const T_dof& nu) {
     }
   }
 
-  operands_and_partials<T_y, T_dof> ops_partials(y, nu);
   for (size_t n = 0; n < N; n++) {
     const T_partials_return nu_dbl = value_of(nu_vec[n]);
     const T_partials_return half_nu = 0.5 * nu_dbl;

--- a/stan/math/prim/prob/inv_chi_square_rng.hpp
+++ b/stan/math/prim/prob/inv_chi_square_rng.hpp
@@ -28,9 +28,7 @@ inline typename VectorBuilder<true, double, T_deg>::type inv_chi_square_rng(
     const T_deg& nu, RNG& rng) {
   using boost::random::chi_squared_distribution;
   using boost::variate_generator;
-
   static const char* function = "inv_chi_square_rng";
-
   check_positive_finite(function, "Degrees of freedom parameter", nu);
 
   scalar_seq_view<T_deg> nu_vec(nu);

--- a/stan/math/prim/prob/inv_gamma_cdf.hpp
+++ b/stan/math/prim/prob/inv_gamma_cdf.hpp
@@ -23,15 +23,15 @@ namespace math {
  * shape and scale parameters. y, shape, and scale parameters must
  * be greater than 0.
  *
+ * @tparam T_y type of scalar
+ * @tparam T_shape type of shape
+ * @tparam T_scale type of scale
  * @param y A scalar variable.
  * @param alpha Shape parameter.
  * @param beta Scale parameter.
  * @throw std::domain_error if alpha is not greater than 0.
  * @throw std::domain_error if beta is not greater than 0.
  * @throw std::domain_error if y is not greater than 0.
- * @tparam T_y Type of scalar.
- * @tparam T_shape Type of shape.
- * @tparam T_scale Type of scale.
  */
 
 template <typename T_y, typename T_shape, typename T_scale>
@@ -39,15 +39,7 @@ return_type_t<T_y, T_shape, T_scale> inv_gamma_cdf(const T_y& y,
                                                    const T_shape& alpha,
                                                    const T_scale& beta) {
   using T_partials_return = partials_return_t<T_y, T_shape, T_scale>;
-
-  if (size_zero(y, alpha, beta)) {
-    return 1.0;
-  }
-
   static const char* function = "inv_gamma_cdf";
-
-  T_partials_return P(1.0);
-
   check_positive_finite(function, "Shape parameter", alpha);
   check_positive_finite(function, "Scale parameter", beta);
   check_not_nan(function, "Random variable", y);
@@ -55,12 +47,19 @@ return_type_t<T_y, T_shape, T_scale> inv_gamma_cdf(const T_y& y,
   check_consistent_sizes(function, "Random variable", y, "Shape parameter",
                          alpha, "Scale Parameter", beta);
 
+  if (size_zero(y, alpha, beta)) {
+    return 1.0;
+  }
+
+  using std::exp;
+  using std::pow;
+  T_partials_return P(1.0);
+  operands_and_partials<T_y, T_shape, T_scale> ops_partials(y, alpha, beta);
+
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_shape> alpha_vec(alpha);
   scalar_seq_view<T_scale> beta_vec(beta);
   size_t N = max_size(y, alpha, beta);
-
-  operands_and_partials<T_y, T_shape, T_scale> ops_partials(y, alpha, beta);
 
   // Explicit return for extreme values
   // The gradients are technically ill-defined, but treated as zero
@@ -69,9 +68,6 @@ return_type_t<T_y, T_shape, T_scale> inv_gamma_cdf(const T_y& y,
       return ops_partials.build(0.0);
     }
   }
-
-  using std::exp;
-  using std::pow;
 
   VectorBuilder<!is_constant_all<T_shape>::value, T_partials_return, T_shape>
       gamma_vec(size(alpha));

--- a/stan/math/prim/prob/inv_gamma_lccdf.hpp
+++ b/stan/math/prim/prob/inv_gamma_lccdf.hpp
@@ -24,15 +24,7 @@ return_type_t<T_y, T_shape, T_scale> inv_gamma_lccdf(const T_y& y,
                                                      const T_shape& alpha,
                                                      const T_scale& beta) {
   using T_partials_return = partials_return_t<T_y, T_shape, T_scale>;
-
-  if (size_zero(y, alpha, beta)) {
-    return 0.0;
-  }
-
   static const char* function = "inv_gamma_lccdf";
-
-  T_partials_return P(0.0);
-
   check_positive_finite(function, "Shape parameter", alpha);
   check_positive_finite(function, "Scale parameter", beta);
   check_not_nan(function, "Random variable", y);
@@ -40,12 +32,20 @@ return_type_t<T_y, T_shape, T_scale> inv_gamma_lccdf(const T_y& y,
   check_consistent_sizes(function, "Random variable", y, "Shape parameter",
                          alpha, "Scale Parameter", beta);
 
+  if (size_zero(y, alpha, beta)) {
+    return 0;
+  }
+
+  using std::exp;
+  using std::log;
+  using std::pow;
+  T_partials_return P(0.0);
+  operands_and_partials<T_y, T_shape, T_scale> ops_partials(y, alpha, beta);
+
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_shape> alpha_vec(alpha);
   scalar_seq_view<T_scale> beta_vec(beta);
   size_t N = max_size(y, alpha, beta);
-
-  operands_and_partials<T_y, T_shape, T_scale> ops_partials(y, alpha, beta);
 
   // Explicit return for extreme values
   // The gradients are technically ill-defined, but treated as zero
@@ -54,10 +54,6 @@ return_type_t<T_y, T_shape, T_scale> inv_gamma_lccdf(const T_y& y,
       return ops_partials.build(0.0);
     }
   }
-
-  using std::exp;
-  using std::log;
-  using std::pow;
 
   VectorBuilder<!is_constant_all<T_shape>::value, T_partials_return, T_shape>
       gamma_vec(size(alpha));

--- a/stan/math/prim/prob/inv_gamma_lcdf.hpp
+++ b/stan/math/prim/prob/inv_gamma_lcdf.hpp
@@ -24,15 +24,7 @@ return_type_t<T_y, T_shape, T_scale> inv_gamma_lcdf(const T_y& y,
                                                     const T_shape& alpha,
                                                     const T_scale& beta) {
   using T_partials_return = partials_return_t<T_y, T_shape, T_scale>;
-
-  if (size_zero(y, alpha, beta)) {
-    return 0.0;
-  }
-
   static const char* function = "inv_gamma_lcdf";
-
-  T_partials_return P(0.0);
-
   check_positive_finite(function, "Shape parameter", alpha);
   check_positive_finite(function, "Scale parameter", beta);
   check_not_nan(function, "Random variable", y);
@@ -40,12 +32,20 @@ return_type_t<T_y, T_shape, T_scale> inv_gamma_lcdf(const T_y& y,
   check_consistent_sizes(function, "Random variable", y, "Shape parameter",
                          alpha, "Scale Parameter", beta);
 
+  if (size_zero(y, alpha, beta)) {
+    return 0;
+  }
+
+  using std::exp;
+  using std::log;
+  using std::pow;
+  T_partials_return P(0.0);
+  operands_and_partials<T_y, T_shape, T_scale> ops_partials(y, alpha, beta);
+
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_shape> alpha_vec(alpha);
   scalar_seq_view<T_scale> beta_vec(beta);
   size_t N = max_size(y, alpha, beta);
-
-  operands_and_partials<T_y, T_shape, T_scale> ops_partials(y, alpha, beta);
 
   // Explicit return for extreme values
   // The gradients are technically ill-defined, but treated as zero
@@ -54,10 +54,6 @@ return_type_t<T_y, T_shape, T_scale> inv_gamma_lcdf(const T_y& y,
       return ops_partials.build(negative_infinity());
     }
   }
-
-  using std::exp;
-  using std::log;
-  using std::pow;
 
   VectorBuilder<!is_constant_all<T_shape>::value, T_partials_return, T_shape>
       gamma_vec(size(alpha));

--- a/stan/math/prim/prob/inv_gamma_lpdf.hpp
+++ b/stan/math/prim/prob/inv_gamma_lpdf.hpp
@@ -36,26 +36,29 @@ template <bool propto, typename T_y, typename T_shape, typename T_scale>
 return_type_t<T_y, T_shape, T_scale> inv_gamma_lpdf(const T_y& y,
                                                     const T_shape& alpha,
                                                     const T_scale& beta) {
-  static const char* function = "inv_gamma_lpdf";
   using T_partials_return = partials_return_t<T_y, T_shape, T_scale>;
-
+  static const char* function = "inv_gamma_lpdf";
   check_not_nan(function, "Random variable", y);
   check_positive_finite(function, "Shape parameter", alpha);
   check_positive_finite(function, "Scale parameter", beta);
   check_consistent_sizes(function, "Random variable", y, "Shape parameter",
                          alpha, "Scale parameter", beta);
+
   if (size_zero(y, alpha, beta)) {
     return 0;
   }
-
   if (!include_summand<propto, T_y, T_shape, T_scale>::value) {
     return 0;
   }
 
+  using std::log;
   T_partials_return logp(0);
+  operands_and_partials<T_y, T_shape, T_scale> ops_partials(y, alpha, beta);
+
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_shape> alpha_vec(alpha);
   scalar_seq_view<T_scale> beta_vec(beta);
+  size_t N = max_size(y, alpha, beta);
 
   for (size_t n = 0; n < stan::math::size(y); n++) {
     const T_partials_return y_dbl = value_of(y_vec[n]);
@@ -63,11 +66,6 @@ return_type_t<T_y, T_shape, T_scale> inv_gamma_lpdf(const T_y& y,
       return LOG_ZERO;
     }
   }
-
-  size_t N = max_size(y, alpha, beta);
-  operands_and_partials<T_y, T_shape, T_scale> ops_partials(y, alpha, beta);
-
-  using std::log;
 
   VectorBuilder<include_summand<propto, T_y, T_shape>::value, T_partials_return,
                 T_y>

--- a/stan/math/prim/prob/inv_gamma_rng.hpp
+++ b/stan/math/prim/prob/inv_gamma_rng.hpp
@@ -33,9 +33,7 @@ inline typename VectorBuilder<true, double, T_shape, T_scale>::type
 inv_gamma_rng(const T_shape& alpha, const T_scale& beta, RNG& rng) {
   using boost::random::gamma_distribution;
   using boost::variate_generator;
-
   static const char* function = "inv_gamma_rng";
-
   check_positive_finite(function, "Shape parameter", alpha);
   check_positive_finite(function, "Scale parameter", beta);
   check_consistent_sizes(function, "Shape parameter", alpha, "Scale Parameter",

--- a/stan/math/prim/prob/inv_wishart_lpdf.hpp
+++ b/stan/math/prim/prob/inv_wishart_lpdf.hpp
@@ -30,6 +30,9 @@ namespace math {
  +\frac{\nu}{2} \log(\det(S)) - \frac{\nu+k+1}{2}\log (\det(W)) - \frac{1}{2}
  \mbox{tr}(S W^{-1}) \f}
  *
+ * @tparam T_y type of scalar
+ * @tparam T_dof type of degrees of freedom
+ * @tparam T_scale type of scale
  * @param W A scalar matrix
  * @param nu Degrees of freedom
  * @param S The scale matrix
@@ -37,23 +40,16 @@ namespace math {
  * @throw std::domain_error if nu is not greater than k-1
  * @throw std::domain_error if S is not square, not symmetric, or not
  * semi-positive definite.
- * @tparam T_y Type of scalar.
- * @tparam T_dof Type of degrees of freedom.
- * @tparam T_scale Type of scale.
  */
 template <bool propto, typename T_y, typename T_dof, typename T_scale>
 return_type_t<T_y, T_dof, T_scale> inv_wishart_lpdf(
     const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>& W,
     const T_dof& nu,
     const Eigen::Matrix<T_scale, Eigen::Dynamic, Eigen::Dynamic>& S) {
-  static const char* function = "inv_wishart_lpdf";
-
   using Eigen::Dynamic;
   using Eigen::Matrix;
-
+  static const char* function = "inv_wishart_lpdf";
   index_type_t<Matrix<T_scale, Dynamic, Dynamic>> k = S.rows();
-  return_type_t<T_y, T_dof, T_scale> lp(0.0);
-
   check_greater(function, "Degrees of freedom parameter", nu, k - 1);
   check_square(function, "random variable", W);
   check_square(function, "scale parameter", S);
@@ -64,6 +60,8 @@ return_type_t<T_y, T_dof, T_scale> inv_wishart_lpdf(
   check_ldlt_factor(function, "LDLT_Factor of random variable", ldlt_W);
   LDLT_factor<T_scale, Eigen::Dynamic, Eigen::Dynamic> ldlt_S(S);
   check_ldlt_factor(function, "LDLT_Factor of scale parameter", ldlt_S);
+
+  return_type_t<T_y, T_dof, T_scale> lp(0.0);
 
   if (include_summand<propto, T_dof>::value) {
     lp -= lmgamma(k, 0.5 * nu);

--- a/stan/math/prim/prob/inv_wishart_rng.hpp
+++ b/stan/math/prim/prob/inv_wishart_rng.hpp
@@ -12,11 +12,9 @@ namespace math {
 template <class RNG>
 inline Eigen::MatrixXd inv_wishart_rng(double nu, const Eigen::MatrixXd& S,
                                        RNG& rng) {
-  static const char* function = "inv_wishart_rng";
-
   using Eigen::MatrixXd;
+  static const char* function = "inv_wishart_rng";
   index_type_t<MatrixXd> k = S.rows();
-
   check_greater(function, "degrees of freedom > dims - 1", nu, k - 1);
   check_square(function, "scale parameter", S);
 

--- a/test/unit/math/prim/err/check_bounded_test.cpp
+++ b/test/unit/math/prim/err/check_bounded_test.cpp
@@ -121,3 +121,23 @@ TEST(ErrorHandlingScalar, CheckBounded_nan) {
   EXPECT_THROW(check_bounded(function, name, x, nan, nan), std::domain_error);
   EXPECT_THROW(check_bounded(function, name, nan, nan, nan), std::domain_error);
 }
+
+TEST(ErrorHandlingScalar, CheckBounded_size_zero_vector) {
+  const char* function = "check_bounded";
+  const char* name = "x";
+  double x = 0;
+  double low = -1;
+  double high = 1;
+
+  Eigen::VectorXd vx(0);
+  Eigen::VectorXd vlow(0);
+  Eigen::VectorXd vhigh(0);
+
+  EXPECT_NO_THROW(check_bounded(function, name, x, vlow, high));
+  EXPECT_NO_THROW(check_bounded(function, name, x, low, vhigh));
+  EXPECT_NO_THROW(check_bounded(function, name, x, vlow, vhigh));
+  EXPECT_NO_THROW(check_bounded(function, name, vx, low, high));
+  EXPECT_NO_THROW(check_bounded(function, name, vx, vlow, high));
+  EXPECT_NO_THROW(check_bounded(function, name, vx, low, vhigh));
+  EXPECT_NO_THROW(check_bounded(function, name, vx, vlow, vhigh));
+}


### PR DESCRIPTION
## Summary

This is the first of two PRs that deals with moving the `size_zero` calls after the other consistency checks on function arguments. This covers all distributions with names starting A-I.

This also improves the consistency of the placement of the `using std::` statements and the declaration of the `operands_and_partials` variable. This came about as in many cases these lines of code were in between the `size_zero` checks and the other consistency checks, so they had to be moved anyway. Now all distribution files look very similar in their first few chunks, which is a small added benefit, I think.

## Tests

No new tests. The distribution test framework already contains tests for input vectors of size zero (search for `test_length_0_vector`).

## Side Effects

None.

## Checklist

- [X] Math issue #1757

- [X] Copyright holder: Marco Colombo

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [X] the new changes are tested
