### PR TITLE
Move size_zero() calls after other consistency checks (L-Z) 

### DIFF
--- a/stan/math/prim/err/check_consistent_sizes.hpp
+++ b/stan/math/prim/err/check_consistent_sizes.hpp
@@ -13,6 +13,7 @@ namespace math {
  * Check if the dimension of x1 is consistent with x2.
  * Consistent size is defined as having the same size if vector-like or
  * being a scalar.
+ *
  * @tparam T1 Type of x1
  * @tparam T2 Type of x2
  * @param function Function name (for error messages)
@@ -36,6 +37,7 @@ inline void check_consistent_sizes(const char* function, const char* name1,
  * Check if the dimension of x1, x2, and x3 are consistent.
  * Consistent size is defined as having the same size if vector-like or
  * being a scalar.
+ *
  * @tparam T1 Type of x1
  * @tparam T2 Type of x2
  * @tparam T3 Type of x3
@@ -66,10 +68,12 @@ inline void check_consistent_sizes(const char* function, const char* name1,
  * Check if the dimension of x1, x2, x3, and x4 are consistent.
  * Consistent size is defined as having the same size if
  * vector-like or being a scalar.
+ *
  * @tparam T1 Type of x1
  * @tparam T2 Type of x2
  * @tparam T3 Type of x3
  * @tparam T4 Type of x4
+ *
  * @param function Function name (for error messages)
  * @param name1 Variable name (for error messages)
  * @param x1 Variable to check for consistent size
@@ -97,6 +101,31 @@ inline void check_consistent_sizes(const char* function, const char* name1,
   check_consistent_size(function, name3, x3, max_size);
   check_consistent_size(function, name4, x4, max_size);
 }
+
+/**
+ * Check if the dimension of x1, x2, x3, x4 and x5 are consistent.
+ * Consistent size is defined as having the same size if
+ * vector-like or being a scalar.
+ *
+ * @tparam T1 Type of x1
+ * @tparam T2 Type of x2
+ * @tparam T3 Type of x3
+ * @tparam T4 Type of x4
+ * @tparam T5 Type of x5
+ *
+ * @param function Function name (for error messages)
+ * @param name1 Variable name (for error messages)
+ * @param x1 Variable to check for consistent size
+ * @param name2 Variable name (for error messages)
+ * @param x2 Variable to check for consistent size
+ * @param name3 Variable name (for error messages)
+ * @param x3 Variable to check for consistent size
+ * @param name4 Variable name (for error messages)
+ * @param x4 Variable to check for consistent size
+ * @param name5 Variable name (for error messages)
+ * @param x5 Variable to check for consistent size
+ * @throw <code>invalid_argument</code> if sizes are inconsistent
+ */
 template <typename T1, typename T2, typename T3, typename T4, typename T5>
 inline void check_consistent_sizes(const char* function, const char* name1,
                                    const T1& x1, const char* name2,
@@ -105,10 +134,12 @@ inline void check_consistent_sizes(const char* function, const char* name1,
                                    const T4& x4, const char* name5,
                                    const T5& x5) {
   size_t max_size = std::max(
-      stan::math::size(x1),
-      std::max(stan::math::size(x2),
-               std::max(stan::math::size(x3),
-                        std::max(stan::math::size(x4), stan::math::size(x5)))));
+      is_vector<T1>::value * stan::math::size(x1),
+      std::max(
+          is_vector<T2>::value * stan::math::size(x2),
+          std::max(is_vector<T3>::value * stan::math::size(x3),
+                   std::max(is_vector<T4>::value * stan::math::size(x4),
+                            is_vector<T5>::value * stan::math::size(x5)))));
   check_consistent_size(function, name1, x1, max_size);
   check_consistent_size(function, name2, x2, max_size);
   check_consistent_size(function, name3, x3, max_size);

--- a/stan/math/prim/prob/bernoulli_lccdf.hpp
+++ b/stan/math/prim/prob/bernoulli_lccdf.hpp
@@ -30,6 +30,7 @@ namespace math {
 template <typename T_n, typename T_prob>
 return_type_t<T_prob> bernoulli_lccdf(const T_n& n, const T_prob& theta) {
   using T_partials_return = partials_return_t<T_n, T_prob>;
+  using std::log;
   static const char* function = "bernoulli_lccdf";
   check_finite(function, "Probability parameter", theta);
   check_bounded(function, "Probability parameter", theta, 0.0, 1.0);
@@ -40,7 +41,6 @@ return_type_t<T_prob> bernoulli_lccdf(const T_n& n, const T_prob& theta) {
     return 0.0;
   }
 
-  using std::log;
   T_partials_return P(0.0);
   operands_and_partials<T_prob> ops_partials(theta);
 

--- a/stan/math/prim/prob/bernoulli_lcdf.hpp
+++ b/stan/math/prim/prob/bernoulli_lcdf.hpp
@@ -30,6 +30,7 @@ namespace math {
 template <typename T_n, typename T_prob>
 return_type_t<T_prob> bernoulli_lcdf(const T_n& n, const T_prob& theta) {
   using T_partials_return = partials_return_t<T_n, T_prob>;
+  using std::log;
   static const char* function = "bernoulli_lcdf";
   check_finite(function, "Probability parameter", theta);
   check_bounded(function, "Probability parameter", theta, 0.0, 1.0);
@@ -40,7 +41,6 @@ return_type_t<T_prob> bernoulli_lcdf(const T_n& n, const T_prob& theta) {
     return 0.0;
   }
 
-  using std::log;
   T_partials_return P(0.0);
   operands_and_partials<T_prob> ops_partials(theta);
 

--- a/stan/math/prim/prob/bernoulli_logit_glm_lpmf.hpp
+++ b/stan/math/prim/prob/bernoulli_logit_glm_lpmf.hpp
@@ -49,14 +49,11 @@ template <bool propto, typename T_y, typename T_x_scalar, int T_x_rows,
 return_type_t<T_x_scalar, T_alpha, T_beta> bernoulli_logit_glm_lpmf(
     const T_y &y, const Eigen::Matrix<T_x_scalar, T_x_rows, Eigen::Dynamic> &x,
     const T_alpha &alpha, const T_beta &beta) {
-  static const char *function = "bernoulli_logit_glm_lpmf";
-
   using Eigen::Array;
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using Eigen::log1p;
   using std::exp;
-
   using T_partials_return = partials_return_t<T_y, T_x_scalar, T_alpha, T_beta>;
   using T_y_val =
       typename std::conditional_t<is_vector<T_y>::value,
@@ -69,6 +66,7 @@ return_type_t<T_x_scalar, T_alpha, T_beta> bernoulli_logit_glm_lpmf(
   const size_t N_instances = T_x_rows == 1 ? stan::math::size(y) : x.rows();
   const size_t N_attributes = x.cols();
 
+  static const char *function = "bernoulli_logit_glm_lpmf";
   check_consistent_size(function, "Vector of dependent variables", y,
                         N_instances);
   check_consistent_size(function, "Weight vector", beta, N_attributes);

--- a/stan/math/prim/prob/bernoulli_logit_glm_rng.hpp
+++ b/stan/math/prim/prob/bernoulli_logit_glm_rng.hpp
@@ -42,11 +42,10 @@ inline typename VectorBuilder<true, int, T_alpha>::type bernoulli_logit_glm_rng(
   using boost::bernoulli_distribution;
   using boost::variate_generator;
 
-  static const char *function = "bernoulli_logit_glm_rng";
-
   const size_t N = x.row(0).size();
   const size_t M = x.col(0).size();
 
+  static const char *function = "bernoulli_logit_glm_rng";
   check_finite(function, "Matrix of independent variables", x);
   check_finite(function, "Weight vector", beta);
   check_finite(function, "Intercept", alpha);

--- a/stan/math/prim/prob/bernoulli_logit_lpmf.hpp
+++ b/stan/math/prim/prob/bernoulli_logit_lpmf.hpp
@@ -28,6 +28,7 @@ namespace math {
 template <bool propto, typename T_n, typename T_prob>
 return_type_t<T_prob> bernoulli_logit_lpmf(const T_n& n, const T_prob& theta) {
   using T_partials_return = partials_return_t<T_n, T_prob>;
+  using std::exp;
   static const char* function = "bernoulli_logit_lpmf";
   check_bounded(function, "n", n, 0, 1);
   check_not_nan(function, "Logit transformed probability parameter", theta);
@@ -41,7 +42,6 @@ return_type_t<T_prob> bernoulli_logit_lpmf(const T_n& n, const T_prob& theta) {
     return 0.0;
   }
 
-  using std::exp;
   T_partials_return logp(0.0);
   operands_and_partials<T_prob> ops_partials(theta);
 

--- a/stan/math/prim/prob/bernoulli_logit_rng.hpp
+++ b/stan/math/prim/prob/bernoulli_logit_rng.hpp
@@ -30,7 +30,6 @@ inline typename VectorBuilder<true, int, T_t>::type bernoulli_logit_rng(
     const T_t& t, RNG& rng) {
   using boost::bernoulli_distribution;
   using boost::variate_generator;
-
   check_finite("bernoulli_logit_rng", "Logit transformed probability parameter",
                t);
 

--- a/stan/math/prim/prob/bernoulli_lpmf.hpp
+++ b/stan/math/prim/prob/bernoulli_lpmf.hpp
@@ -29,6 +29,7 @@ namespace math {
 template <bool propto, typename T_n, typename T_prob>
 return_type_t<T_prob> bernoulli_lpmf(const T_n& n, const T_prob& theta) {
   using T_partials_return = partials_return_t<T_n, T_prob>;
+  using std::log;
   static const char* function = "bernoulli_lpmf";
   check_bounded(function, "n", n, 0, 1);
   check_finite(function, "Probability parameter", theta);
@@ -43,7 +44,6 @@ return_type_t<T_prob> bernoulli_lpmf(const T_n& n, const T_prob& theta) {
     return 0.0;
   }
 
-  using std::log;
   T_partials_return logp(0.0);
   operands_and_partials<T_prob> ops_partials(theta);
 

--- a/stan/math/prim/prob/beta_binomial_cdf.hpp
+++ b/stan/math/prim/prob/beta_binomial_cdf.hpp
@@ -42,6 +42,7 @@ return_type_t<T_size1, T_size2> beta_binomial_cdf(const T_n& n, const T_N& N,
                                                   const T_size1& alpha,
                                                   const T_size2& beta) {
   using T_partials_return = partials_return_t<T_n, T_N, T_size1, T_size2>;
+  using std::exp;
   static const char* function = "beta_binomial_cdf";
   check_nonnegative(function, "Population size parameter", N);
   check_positive_finite(function, "First prior sample size parameter", alpha);
@@ -55,7 +56,6 @@ return_type_t<T_size1, T_size2> beta_binomial_cdf(const T_n& n, const T_N& N,
     return 1.0;
   }
 
-  using std::exp;
   T_partials_return P(1.0);
   operands_and_partials<T_size1, T_size2> ops_partials(alpha, beta);
 

--- a/stan/math/prim/prob/beta_binomial_lccdf.hpp
+++ b/stan/math/prim/prob/beta_binomial_lccdf.hpp
@@ -43,6 +43,8 @@ return_type_t<T_size1, T_size2> beta_binomial_lccdf(const T_n& n, const T_N& N,
                                                     const T_size1& alpha,
                                                     const T_size2& beta) {
   using T_partials_return = partials_return_t<T_n, T_N, T_size1, T_size2>;
+  using std::exp;
+  using std::log;
   static const char* function = "beta_binomial_lccdf";
   check_nonnegative(function, "Population size parameter", N);
   check_positive_finite(function, "First prior sample size parameter", alpha);
@@ -56,8 +58,6 @@ return_type_t<T_size1, T_size2> beta_binomial_lccdf(const T_n& n, const T_N& N,
     return 0;
   }
 
-  using std::exp;
-  using std::log;
   T_partials_return P(0.0);
   operands_and_partials<T_size1, T_size2> ops_partials(alpha, beta);
 

--- a/stan/math/prim/prob/beta_binomial_lcdf.hpp
+++ b/stan/math/prim/prob/beta_binomial_lcdf.hpp
@@ -43,6 +43,8 @@ return_type_t<T_size1, T_size2> beta_binomial_lcdf(const T_n& n, const T_N& N,
                                                    const T_size1& alpha,
                                                    const T_size2& beta) {
   using T_partials_return = partials_return_t<T_n, T_N, T_size1, T_size2>;
+  using std::exp;
+  using std::log;
   static const char* function = "beta_binomial_lcdf";
   check_nonnegative(function, "Population size parameter", N);
   check_positive_finite(function, "First prior sample size parameter", alpha);
@@ -56,8 +58,6 @@ return_type_t<T_size1, T_size2> beta_binomial_lcdf(const T_n& n, const T_N& N,
     return 0;
   }
 
-  using std::exp;
-  using std::log;
   T_partials_return P(0.0);
   operands_and_partials<T_size1, T_size2> ops_partials(alpha, beta);
 

--- a/stan/math/prim/prob/beta_lccdf.hpp
+++ b/stan/math/prim/prob/beta_lccdf.hpp
@@ -39,6 +39,9 @@ template <typename T_y, typename T_scale_succ, typename T_scale_fail>
 return_type_t<T_y, T_scale_succ, T_scale_fail> beta_lccdf(
     const T_y& y, const T_scale_succ& alpha, const T_scale_fail& beta) {
   using T_partials_return = partials_return_t<T_y, T_scale_succ, T_scale_fail>;
+  using std::exp;
+  using std::log;
+  using std::pow;
   static const char* function = "beta_lccdf";
   check_positive_finite(function, "First shape parameter", alpha);
   check_positive_finite(function, "Second shape parameter", beta);
@@ -53,9 +56,6 @@ return_type_t<T_y, T_scale_succ, T_scale_fail> beta_lccdf(
     return 0;
   }
 
-  using std::exp;
-  using std::log;
-  using std::pow;
   T_partials_return ccdf_log(0.0);
   operands_and_partials<T_y, T_scale_succ, T_scale_fail> ops_partials(y, alpha,
                                                                       beta);

--- a/stan/math/prim/prob/beta_lcdf.hpp
+++ b/stan/math/prim/prob/beta_lcdf.hpp
@@ -39,6 +39,9 @@ template <typename T_y, typename T_scale_succ, typename T_scale_fail>
 return_type_t<T_y, T_scale_succ, T_scale_fail> beta_lcdf(
     const T_y& y, const T_scale_succ& alpha, const T_scale_fail& beta) {
   using T_partials_return = partials_return_t<T_y, T_scale_succ, T_scale_fail>;
+  using std::exp;
+  using std::log;
+  using std::pow;
   static const char* function = "beta_lcdf";
   check_positive_finite(function, "First shape parameter", alpha);
   check_positive_finite(function, "Second shape parameter", beta);
@@ -53,9 +56,6 @@ return_type_t<T_y, T_scale_succ, T_scale_fail> beta_lcdf(
     return 0;
   }
 
-  using std::exp;
-  using std::log;
-  using std::pow;
   T_partials_return cdf_log(0.0);
   operands_and_partials<T_y, T_scale_succ, T_scale_fail> ops_partials(y, alpha,
                                                                       beta);

--- a/stan/math/prim/prob/beta_lpdf.hpp
+++ b/stan/math/prim/prob/beta_lpdf.hpp
@@ -41,6 +41,7 @@ template <bool propto, typename T_y, typename T_scale_succ,
 return_type_t<T_y, T_scale_succ, T_scale_fail> beta_lpdf(
     const T_y& y, const T_scale_succ& alpha, const T_scale_fail& beta) {
   using T_partials_return = partials_return_t<T_y, T_scale_succ, T_scale_fail>;
+  using std::log;
   static const char* function = "beta_lpdf";
   check_positive_finite(function, "First shape parameter", alpha);
   check_positive_finite(function, "Second shape parameter", beta);
@@ -58,7 +59,6 @@ return_type_t<T_y, T_scale_succ, T_scale_fail> beta_lpdf(
     return 0;
   }
 
-  using std::log;
   T_partials_return logp(0);
   operands_and_partials<T_y, T_scale_succ, T_scale_fail> ops_partials(y, alpha,
                                                                       beta);

--- a/stan/math/prim/prob/beta_proportion_lccdf.hpp
+++ b/stan/math/prim/prob/beta_proportion_lccdf.hpp
@@ -43,6 +43,9 @@ return_type_t<T_y, T_loc, T_prec> beta_proportion_lccdf(const T_y& y,
                                                         const T_loc& mu,
                                                         const T_prec& kappa) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_prec>;
+  using std::exp;
+  using std::log;
+  using std::pow;
   static const char* function = "beta_proportion_lccdf";
   check_positive(function, "Location parameter", mu);
   check_less(function, "Location parameter", mu, 1.0);
@@ -57,9 +60,6 @@ return_type_t<T_y, T_loc, T_prec> beta_proportion_lccdf(const T_y& y,
     return 0;
   }
 
-  using std::exp;
-  using std::log;
-  using std::pow;
   T_partials_return ccdf_log(0.0);
   operands_and_partials<T_y, T_loc, T_prec> ops_partials(y, mu, kappa);
 

--- a/stan/math/prim/prob/beta_proportion_lcdf.hpp
+++ b/stan/math/prim/prob/beta_proportion_lcdf.hpp
@@ -44,6 +44,9 @@ return_type_t<T_y, T_loc, T_prec> beta_proportion_lcdf(const T_y& y,
                                                        const T_loc& mu,
                                                        const T_prec& kappa) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_prec>;
+  using std::exp;
+  using std::log;
+  using std::pow;
   static const char* function = "beta_proportion_lcdf";
   check_positive(function, "Location parameter", mu);
   check_less(function, "Location parameter", mu, 1.0);
@@ -58,9 +61,6 @@ return_type_t<T_y, T_loc, T_prec> beta_proportion_lcdf(const T_y& y,
     return 0;
   }
 
-  using std::exp;
-  using std::log;
-  using std::pow;
   T_partials_return cdf_log(0.0);
   operands_and_partials<T_y, T_loc, T_prec> ops_partials(y, mu, kappa);
 

--- a/stan/math/prim/prob/beta_proportion_lpdf.hpp
+++ b/stan/math/prim/prob/beta_proportion_lpdf.hpp
@@ -43,10 +43,9 @@ template <bool propto, typename T_y, typename T_loc, typename T_prec>
 return_type_t<T_y, T_loc, T_prec> beta_proportion_lpdf(const T_y& y,
                                                        const T_loc& mu,
                                                        const T_prec& kappa) {
-  static const char* function = "beta_proportion_lpdf";
-
   using T_partials_return = partials_return_t<T_y, T_loc, T_prec>;
   using std::log;
+  static const char* function = "beta_proportion_lpdf";
   check_positive(function, "Location parameter", mu);
   check_less(function, "Location parameter", mu, 1.0);
   check_positive_finite(function, "Precision parameter", kappa);
@@ -55,13 +54,16 @@ return_type_t<T_y, T_loc, T_prec> beta_proportion_lpdf(const T_y& y,
   check_less_or_equal(function, "Random variable", y, 1.0);
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Precision parameter", kappa);
+
   if (size_zero(y, mu, kappa)) {
     return 0;
   }
   if (!include_summand<propto, T_y, T_loc, T_prec>::value) {
     return 0;
   }
+
   T_partials_return logp(0);
+  operands_and_partials<T_y, T_loc, T_prec> ops_partials(y, mu, kappa);
 
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_loc> mu_vec(mu);
@@ -77,8 +79,6 @@ return_type_t<T_y, T_loc, T_prec> beta_proportion_lpdf(const T_y& y,
       return LOG_ZERO;
     }
   }
-
-  operands_and_partials<T_y, T_loc, T_prec> ops_partials(y, mu, kappa);
 
   VectorBuilder<include_summand<propto, T_y, T_loc, T_prec>::value,
                 T_partials_return, T_y>

--- a/stan/math/prim/prob/binomial_cdf.hpp
+++ b/stan/math/prim/prob/binomial_cdf.hpp
@@ -34,6 +34,8 @@ template <typename T_n, typename T_N, typename T_prob>
 return_type_t<T_prob> binomial_cdf(const T_n& n, const T_N& N,
                                    const T_prob& theta) {
   using T_partials_return = partials_return_t<T_n, T_N, T_prob>;
+  using std::exp;
+  using std::pow;
   static const char* function = "binomial_cdf";
   check_nonnegative(function, "Population size parameter", N);
   check_finite(function, "Probability parameter", theta);
@@ -46,8 +48,6 @@ return_type_t<T_prob> binomial_cdf(const T_n& n, const T_N& N,
     return 1.0;
   }
 
-  using std::exp;
-  using std::pow;
   T_partials_return P(1.0);
   operands_and_partials<T_prob> ops_partials(theta);
 

--- a/stan/math/prim/prob/binomial_lccdf.hpp
+++ b/stan/math/prim/prob/binomial_lccdf.hpp
@@ -36,6 +36,9 @@ template <typename T_n, typename T_N, typename T_prob>
 return_type_t<T_prob> binomial_lccdf(const T_n& n, const T_N& N,
                                      const T_prob& theta) {
   using T_partials_return = partials_return_t<T_n, T_N, T_prob>;
+  using std::exp;
+  using std::log;
+  using std::pow;
   static const char* function = "binomial_lccdf";
   check_nonnegative(function, "Population size parameter", N);
   check_finite(function, "Probability parameter", theta);
@@ -48,9 +51,6 @@ return_type_t<T_prob> binomial_lccdf(const T_n& n, const T_N& N,
     return 0;
   }
 
-  using std::exp;
-  using std::log;
-  using std::pow;
   T_partials_return P(0.0);
   operands_and_partials<T_prob> ops_partials(theta);
 

--- a/stan/math/prim/prob/binomial_lcdf.hpp
+++ b/stan/math/prim/prob/binomial_lcdf.hpp
@@ -36,6 +36,9 @@ template <typename T_n, typename T_N, typename T_prob>
 return_type_t<T_prob> binomial_lcdf(const T_n& n, const T_N& N,
                                     const T_prob& theta) {
   using T_partials_return = partials_return_t<T_n, T_N, T_prob>;
+  using std::exp;
+  using std::log;
+  using std::pow;
   static const char* function = "binomial_lcdf";
   check_nonnegative(function, "Population size parameter", N);
   check_finite(function, "Probability parameter", theta);
@@ -48,9 +51,6 @@ return_type_t<T_prob> binomial_lcdf(const T_n& n, const T_N& N,
     return 0;
   }
 
-  using std::exp;
-  using std::log;
-  using std::pow;
   T_partials_return P(0.0);
   operands_and_partials<T_prob> ops_partials(theta);
 

--- a/stan/math/prim/prob/binomial_logit_lpmf.hpp
+++ b/stan/math/prim/prob/binomial_logit_lpmf.hpp
@@ -33,6 +33,7 @@ template <bool propto, typename T_n, typename T_N, typename T_prob>
 return_type_t<T_prob> binomial_logit_lpmf(const T_n& n, const T_N& N,
                                           const T_prob& alpha) {
   using T_partials_return = partials_return_t<T_n, T_N, T_prob>;
+  using std::log;
   static const char* function = "binomial_logit_lpmf";
   check_bounded(function, "Successes variable", n, 0, N);
   check_nonnegative(function, "Population size parameter", N);
@@ -48,7 +49,6 @@ return_type_t<T_prob> binomial_logit_lpmf(const T_n& n, const T_N& N,
     return 0.0;
   }
 
-  using std::log;
   T_partials_return logp = 0;
   operands_and_partials<T_prob> ops_partials(alpha);
 

--- a/stan/math/prim/prob/categorical_logit_glm_lpmf.hpp
+++ b/stan/math/prim/prob/categorical_logit_glm_lpmf.hpp
@@ -45,8 +45,6 @@ categorical_logit_glm_lpmf(
     const Eigen::Matrix<T_beta_scalar, Eigen::Dynamic, Eigen::Dynamic>& beta) {
   using T_partials_return
       = partials_return_t<T_x_scalar, T_alpha_scalar, T_beta_scalar>;
-  static const char* function = "categorical_logit_glm_lpmf";
-
   using Eigen::Array;
   using Eigen::Dynamic;
   using Eigen::Matrix;
@@ -57,6 +55,7 @@ categorical_logit_glm_lpmf(
   const size_t N_attributes = x.cols();
   const size_t N_classes = beta.cols();
 
+  static const char* function = "categorical_logit_glm_lpmf";
   check_consistent_size(function, "Vector of dependent variables", y,
                         N_instances);
   check_consistent_size(function, "Intercept vector", alpha, N_classes);

--- a/stan/math/prim/prob/cauchy_cdf.hpp
+++ b/stan/math/prim/prob/cauchy_cdf.hpp
@@ -31,6 +31,7 @@ template <typename T_y, typename T_loc, typename T_scale>
 return_type_t<T_y, T_loc, T_scale> cauchy_cdf(const T_y& y, const T_loc& mu,
                                               const T_scale& sigma) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale>;
+  using std::atan;
   static const char* function = "cauchy_cdf";
   check_not_nan(function, "Random variable", y);
   check_finite(function, "Location parameter", mu);
@@ -42,7 +43,6 @@ return_type_t<T_y, T_loc, T_scale> cauchy_cdf(const T_y& y, const T_loc& mu,
     return 1.0;
   }
 
-  using std::atan;
   T_partials_return P(1.0);
   operands_and_partials<T_y, T_loc, T_scale> ops_partials(y, mu, sigma);
 

--- a/stan/math/prim/prob/cauchy_lccdf.hpp
+++ b/stan/math/prim/prob/cauchy_lccdf.hpp
@@ -32,6 +32,8 @@ template <typename T_y, typename T_loc, typename T_scale>
 return_type_t<T_y, T_loc, T_scale> cauchy_lccdf(const T_y& y, const T_loc& mu,
                                                 const T_scale& sigma) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale>;
+  using std::atan;
+  using std::log;
   static const char* function = "cauchy_lccdf";
   check_not_nan(function, "Random variable", y);
   check_finite(function, "Location parameter", mu);
@@ -43,8 +45,6 @@ return_type_t<T_y, T_loc, T_scale> cauchy_lccdf(const T_y& y, const T_loc& mu,
     return 0;
   }
 
-  using std::atan;
-  using std::log;
   T_partials_return ccdf_log(0.0);
   operands_and_partials<T_y, T_loc, T_scale> ops_partials(y, mu, sigma);
 

--- a/stan/math/prim/prob/cauchy_lcdf.hpp
+++ b/stan/math/prim/prob/cauchy_lcdf.hpp
@@ -32,6 +32,8 @@ template <typename T_y, typename T_loc, typename T_scale>
 return_type_t<T_y, T_loc, T_scale> cauchy_lcdf(const T_y& y, const T_loc& mu,
                                                const T_scale& sigma) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale>;
+  using std::atan;
+  using std::log;
   static const char* function = "cauchy_lcdf";
   check_not_nan(function, "Random variable", y);
   check_finite(function, "Location parameter", mu);
@@ -43,8 +45,6 @@ return_type_t<T_y, T_loc, T_scale> cauchy_lcdf(const T_y& y, const T_loc& mu,
     return 0;
   }
 
-  using std::atan;
-  using std::log;
   T_partials_return cdf_log(0.0);
   operands_and_partials<T_y, T_loc, T_scale> ops_partials(y, mu, sigma);
 

--- a/stan/math/prim/prob/cauchy_lpdf.hpp
+++ b/stan/math/prim/prob/cauchy_lpdf.hpp
@@ -36,6 +36,7 @@ template <bool propto, typename T_y, typename T_loc, typename T_scale>
 return_type_t<T_y, T_loc, T_scale> cauchy_lpdf(const T_y& y, const T_loc& mu,
                                                const T_scale& sigma) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale>;
+  using std::log;
   static const char* function = "cauchy_lpdf";
   check_not_nan(function, "Random variable", y);
   check_finite(function, "Location parameter", mu);
@@ -50,7 +51,6 @@ return_type_t<T_y, T_loc, T_scale> cauchy_lpdf(const T_y& y, const T_loc& mu,
     return 0.0;
   }
 
-  using std::log;
   T_partials_return logp(0.0);
   operands_and_partials<T_y, T_loc, T_scale> ops_partials(y, mu, sigma);
 

--- a/stan/math/prim/prob/chi_square_cdf.hpp
+++ b/stan/math/prim/prob/chi_square_cdf.hpp
@@ -34,6 +34,8 @@ namespace math {
 template <typename T_y, typename T_dof>
 return_type_t<T_y, T_dof> chi_square_cdf(const T_y& y, const T_dof& nu) {
   using T_partials_return = partials_return_t<T_y, T_dof>;
+  using std::exp;
+  using std::pow;
   static const char* function = "chi_square_cdf";
   check_not_nan(function, "Random variable", y);
   check_nonnegative(function, "Random variable", y);
@@ -45,8 +47,6 @@ return_type_t<T_y, T_dof> chi_square_cdf(const T_y& y, const T_dof& nu) {
     return 1.0;
   }
 
-  using std::exp;
-  using std::pow;
   T_partials_return cdf(1.0);
   operands_and_partials<T_y, T_dof> ops_partials(y, nu);
 

--- a/stan/math/prim/prob/chi_square_lccdf.hpp
+++ b/stan/math/prim/prob/chi_square_lccdf.hpp
@@ -35,6 +35,9 @@ namespace math {
 template <typename T_y, typename T_dof>
 return_type_t<T_y, T_dof> chi_square_lccdf(const T_y& y, const T_dof& nu) {
   using T_partials_return = partials_return_t<T_y, T_dof>;
+  using std::exp;
+  using std::log;
+  using std::pow;
   static const char* function = "chi_square_lccdf";
   check_not_nan(function, "Random variable", y);
   check_nonnegative(function, "Random variable", y);
@@ -46,9 +49,6 @@ return_type_t<T_y, T_dof> chi_square_lccdf(const T_y& y, const T_dof& nu) {
     return 0;
   }
 
-  using std::exp;
-  using std::log;
-  using std::pow;
   T_partials_return ccdf_log(0.0);
   operands_and_partials<T_y, T_dof> ops_partials(y, nu);
 

--- a/stan/math/prim/prob/chi_square_lcdf.hpp
+++ b/stan/math/prim/prob/chi_square_lcdf.hpp
@@ -35,6 +35,9 @@ namespace math {
 template <typename T_y, typename T_dof>
 return_type_t<T_y, T_dof> chi_square_lcdf(const T_y& y, const T_dof& nu) {
   using T_partials_return = partials_return_t<T_y, T_dof>;
+  using std::exp;
+  using std::log;
+  using std::pow;
   static const char* function = "chi_square_lcdf";
   check_not_nan(function, "Random variable", y);
   check_nonnegative(function, "Random variable", y);
@@ -46,9 +49,6 @@ return_type_t<T_y, T_dof> chi_square_lcdf(const T_y& y, const T_dof& nu) {
     return 0;
   }
 
-  using std::exp;
-  using std::log;
-  using std::pow;
   T_partials_return cdf_log(0.0);
   operands_and_partials<T_y, T_dof> ops_partials(y, nu);
 

--- a/stan/math/prim/prob/chi_square_lpdf.hpp
+++ b/stan/math/prim/prob/chi_square_lpdf.hpp
@@ -39,6 +39,7 @@ namespace math {
 template <bool propto, typename T_y, typename T_dof>
 return_type_t<T_y, T_dof> chi_square_lpdf(const T_y& y, const T_dof& nu) {
   using T_partials_return = partials_return_t<T_y, T_dof>;
+  using std::log;
   static const char* function = "chi_square_lpdf";
   check_not_nan(function, "Random variable", y);
   check_nonnegative(function, "Random variable", y);
@@ -53,7 +54,6 @@ return_type_t<T_y, T_dof> chi_square_lpdf(const T_y& y, const T_dof& nu) {
     return 0;
   }
 
-  using std::log;
   T_partials_return logp(0);
   operands_and_partials<T_y, T_dof> ops_partials(y, nu);
 

--- a/stan/math/prim/prob/discrete_range_lpmf.hpp
+++ b/stan/math/prim/prob/discrete_range_lpmf.hpp
@@ -44,6 +44,7 @@ namespace math {
 template <bool propto, typename T_y, typename T_lower, typename T_upper>
 double discrete_range_lpmf(const T_y& y, const T_lower& lower,
                            const T_upper& upper) {
+  using std::log;
   static const char* function = "discrete_range_lpmf";
   check_not_nan(function, "Random variable", y);
   check_consistent_sizes(function, "Lower bound parameter", lower,
@@ -56,8 +57,6 @@ double discrete_range_lpmf(const T_y& y, const T_lower& lower,
   if (!include_summand<propto>::value) {
     return 0.0;
   }
-
-  using std::log;
 
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_lower> lower_vec(lower);

--- a/stan/math/prim/prob/double_exponential_cdf.hpp
+++ b/stan/math/prim/prob/double_exponential_cdf.hpp
@@ -31,6 +31,7 @@ template <typename T_y, typename T_loc, typename T_scale>
 return_type_t<T_y, T_loc, T_scale> double_exponential_cdf(
     const T_y& y, const T_loc& mu, const T_scale& sigma) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale>;
+  using std::exp;
   static const char* function = "double_exponential_cdf";
   check_not_nan(function, "Random variable", y);
   check_finite(function, "Location parameter", mu);
@@ -40,7 +41,6 @@ return_type_t<T_y, T_loc, T_scale> double_exponential_cdf(
     return 1.0;
   }
 
-  using std::exp;
   T_partials_return cdf(1.0);
   operands_and_partials<T_y, T_loc, T_scale> ops_partials(y, mu, sigma);
 

--- a/stan/math/prim/prob/double_exponential_lccdf.hpp
+++ b/stan/math/prim/prob/double_exponential_lccdf.hpp
@@ -34,6 +34,8 @@ template <typename T_y, typename T_loc, typename T_scale>
 return_type_t<T_y, T_loc, T_scale> double_exponential_lccdf(
     const T_y& y, const T_loc& mu, const T_scale& sigma) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale>;
+  using std::exp;
+  using std::log;
   static const char* function = "double_exponential_lccdf";
   check_not_nan(function, "Random variable", y);
   check_finite(function, "Location parameter", mu);
@@ -45,8 +47,6 @@ return_type_t<T_y, T_loc, T_scale> double_exponential_lccdf(
     return 0;
   }
 
-  using std::exp;
-  using std::log;
   T_partials_return ccdf_log(0.0);
   operands_and_partials<T_y, T_loc, T_scale> ops_partials(y, mu, sigma);
 

--- a/stan/math/prim/prob/double_exponential_lcdf.hpp
+++ b/stan/math/prim/prob/double_exponential_lcdf.hpp
@@ -33,6 +33,8 @@ template <typename T_y, typename T_loc, typename T_scale>
 return_type_t<T_y, T_loc, T_scale> double_exponential_lcdf(
     const T_y& y, const T_loc& mu, const T_scale& sigma) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale>;
+  using std::exp;
+  using std::log;
   static const char* function = "double_exponential_lcdf";
   check_not_nan(function, "Random variable", y);
   check_finite(function, "Location parameter", mu);
@@ -44,8 +46,6 @@ return_type_t<T_y, T_loc, T_scale> double_exponential_lcdf(
     return 0;
   }
 
-  using std::exp;
-  using std::log;
   T_partials_return cdf_log(0.0);
   operands_and_partials<T_y, T_loc, T_scale> ops_partials(y, mu, sigma);
 

--- a/stan/math/prim/prob/double_exponential_lpdf.hpp
+++ b/stan/math/prim/prob/double_exponential_lpdf.hpp
@@ -35,6 +35,8 @@ template <bool propto, typename T_y, typename T_loc, typename T_scale>
 return_type_t<T_y, T_loc, T_scale> double_exponential_lpdf(
     const T_y& y, const T_loc& mu, const T_scale& sigma) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale>;
+  using std::fabs;
+  using std::log;
   static const char* function = "double_exponential_lpdf";
   check_finite(function, "Random variable", y);
   check_finite(function, "Location parameter", mu);
@@ -49,8 +51,6 @@ return_type_t<T_y, T_loc, T_scale> double_exponential_lpdf(
     return 0.0;
   }
 
-  using std::fabs;
-  using std::log;
   T_partials_return logp(0.0);
   operands_and_partials<T_y, T_loc, T_scale> ops_partials(y, mu, sigma);
 

--- a/stan/math/prim/prob/exp_mod_normal_cdf.hpp
+++ b/stan/math/prim/prob/exp_mod_normal_cdf.hpp
@@ -23,6 +23,7 @@ return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_cdf(
     const T_y& y, const T_loc& mu, const T_scale& sigma,
     const T_inv_scale& lambda) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale, T_inv_scale>;
+  using std::exp;
   static const char* function = "exp_mod_normal_cdf";
   check_not_nan(function, "Random variable", y);
   check_finite(function, "Location parameter", mu);
@@ -38,7 +39,6 @@ return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_cdf(
     return 1.0;
   }
 
-  using std::exp;
   T_partials_return cdf(1.0);
   operands_and_partials<T_y, T_loc, T_scale, T_inv_scale> ops_partials(
       y, mu, sigma, lambda);

--- a/stan/math/prim/prob/exp_mod_normal_lccdf.hpp
+++ b/stan/math/prim/prob/exp_mod_normal_lccdf.hpp
@@ -24,6 +24,8 @@ return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_lccdf(
     const T_y& y, const T_loc& mu, const T_scale& sigma,
     const T_inv_scale& lambda) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale, T_inv_scale>;
+  using std::exp;
+  using std::log;
   static const char* function = "exp_mod_normal_lccdf";
   check_not_nan(function, "Random variable", y);
   check_finite(function, "Location parameter", mu);
@@ -39,8 +41,6 @@ return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_lccdf(
     return 0;
   }
 
-  using std::exp;
-  using std::log;
   T_partials_return ccdf_log(0.0);
   operands_and_partials<T_y, T_loc, T_scale, T_inv_scale> ops_partials(
       y, mu, sigma, lambda);

--- a/stan/math/prim/prob/exp_mod_normal_lcdf.hpp
+++ b/stan/math/prim/prob/exp_mod_normal_lcdf.hpp
@@ -24,6 +24,8 @@ return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_lcdf(
     const T_y& y, const T_loc& mu, const T_scale& sigma,
     const T_inv_scale& lambda) {
   static const char* function = "exp_mod_normal_lcdf";
+  using std::exp;
+  using std::log;
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale, T_inv_scale>;
   check_not_nan(function, "Random variable", y);
   check_finite(function, "Location parameter", mu);
@@ -39,8 +41,6 @@ return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_lcdf(
     return 0;
   }
 
-  using std::exp;
-  using std::log;
   T_partials_return cdf_log(0.0);
   operands_and_partials<T_y, T_loc, T_scale, T_inv_scale> ops_partials(
       y, mu, sigma, lambda);

--- a/stan/math/prim/prob/exp_mod_normal_lpdf.hpp
+++ b/stan/math/prim/prob/exp_mod_normal_lpdf.hpp
@@ -23,6 +23,9 @@ return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_lpdf(
     const T_y& y, const T_loc& mu, const T_scale& sigma,
     const T_inv_scale& lambda) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale, T_inv_scale>;
+  using std::exp;
+  using std::log;
+  using std::sqrt;
   static const char* function = "exp_mod_normal_lpdf";
   check_not_nan(function, "Random variable", y);
   check_finite(function, "Location parameter", mu);
@@ -39,9 +42,6 @@ return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_lpdf(
     return 0.0;
   }
 
-  using std::exp;
-  using std::log;
-  using std::sqrt;
   T_partials_return logp(0.0);
   operands_and_partials<T_y, T_loc, T_scale, T_inv_scale> ops_partials(
       y, mu, sigma, lambda);

--- a/stan/math/prim/prob/exponential_cdf.hpp
+++ b/stan/math/prim/prob/exponential_cdf.hpp
@@ -28,6 +28,7 @@ template <typename T_y, typename T_inv_scale>
 return_type_t<T_y, T_inv_scale> exponential_cdf(const T_y& y,
                                                 const T_inv_scale& beta) {
   using T_partials_return = partials_return_t<T_y, T_inv_scale>;
+  using std::exp;
   static const char* function = "exponential_cdf";
   check_not_nan(function, "Random variable", y);
   check_nonnegative(function, "Random variable", y);
@@ -37,7 +38,6 @@ return_type_t<T_y, T_inv_scale> exponential_cdf(const T_y& y,
     return 1.0;
   }
 
-  using std::exp;
   T_partials_return cdf(1.0);
   operands_and_partials<T_y, T_inv_scale> ops_partials(y, beta);
 

--- a/stan/math/prim/prob/exponential_lcdf.hpp
+++ b/stan/math/prim/prob/exponential_lcdf.hpp
@@ -17,6 +17,8 @@ template <typename T_y, typename T_inv_scale>
 return_type_t<T_y, T_inv_scale> exponential_lcdf(const T_y& y,
                                                  const T_inv_scale& beta) {
   using T_partials_return = partials_return_t<T_y, T_inv_scale>;
+  using std::exp;
+  using std::log;
   static const char* function = "exponential_lcdf";
   check_not_nan(function, "Random variable", y);
   check_nonnegative(function, "Random variable", y);
@@ -26,8 +28,6 @@ return_type_t<T_y, T_inv_scale> exponential_lcdf(const T_y& y,
     return 0;
   }
 
-  using std::exp;
-  using std::log;
   T_partials_return cdf_log(0.0);
   operands_and_partials<T_y, T_inv_scale> ops_partials(y, beta);
 

--- a/stan/math/prim/prob/exponential_lpdf.hpp
+++ b/stan/math/prim/prob/exponential_lpdf.hpp
@@ -45,6 +45,7 @@ template <bool propto, typename T_y, typename T_inv_scale>
 return_type_t<T_y, T_inv_scale> exponential_lpdf(const T_y& y,
                                                  const T_inv_scale& beta) {
   using T_partials_return = partials_return_t<T_y, T_inv_scale>;
+  using std::log;
   static const char* function = "exponential_lpdf";
   check_nonnegative(function, "Random variable", y);
   check_positive_finite(function, "Inverse scale parameter", beta);
@@ -55,7 +56,6 @@ return_type_t<T_y, T_inv_scale> exponential_lpdf(const T_y& y,
     return 0.0;
   }
 
-  using std::log;
   T_partials_return logp(0.0);
   operands_and_partials<T_y, T_inv_scale> ops_partials(y, beta);
 

--- a/stan/math/prim/prob/frechet_cdf.hpp
+++ b/stan/math/prim/prob/frechet_cdf.hpp
@@ -24,6 +24,9 @@ return_type_t<T_y, T_shape, T_scale> frechet_cdf(const T_y& y,
                                                  const T_shape& alpha,
                                                  const T_scale& sigma) {
   using T_partials_return = partials_return_t<T_y, T_shape, T_scale>;
+  using std::exp;
+  using std::log;
+  using std::pow;
   static const char* function = "frechet_cdf";
   check_positive(function, "Random variable", y);
   check_positive_finite(function, "Shape parameter", alpha);
@@ -33,9 +36,6 @@ return_type_t<T_y, T_shape, T_scale> frechet_cdf(const T_y& y,
     return 1.0;
   }
 
-  using std::exp;
-  using std::log;
-  using std::pow;
   T_partials_return cdf(1.0);
   operands_and_partials<T_y, T_shape, T_scale> ops_partials(y, alpha, sigma);
 

--- a/stan/math/prim/prob/frechet_lccdf.hpp
+++ b/stan/math/prim/prob/frechet_lccdf.hpp
@@ -23,6 +23,9 @@ return_type_t<T_y, T_shape, T_scale> frechet_lccdf(const T_y& y,
                                                    const T_shape& alpha,
                                                    const T_scale& sigma) {
   using T_partials_return = partials_return_t<T_y, T_shape, T_scale>;
+  using std::exp;
+  using std::log;
+  using std::pow;
   static const char* function = "frechet_lccdf";
   check_positive(function, "Random variable", y);
   check_positive_finite(function, "Shape parameter", alpha);
@@ -32,9 +35,6 @@ return_type_t<T_y, T_shape, T_scale> frechet_lccdf(const T_y& y,
     return 0;
   }
 
-  using std::exp;
-  using std::log;
-  using std::pow;
   T_partials_return ccdf_log(0.0);
   operands_and_partials<T_y, T_shape, T_scale> ops_partials(y, alpha, sigma);
 

--- a/stan/math/prim/prob/frechet_lcdf.hpp
+++ b/stan/math/prim/prob/frechet_lcdf.hpp
@@ -22,6 +22,8 @@ return_type_t<T_y, T_shape, T_scale> frechet_lcdf(const T_y& y,
                                                   const T_shape& alpha,
                                                   const T_scale& sigma) {
   using T_partials_return = partials_return_t<T_y, T_shape, T_scale>;
+  using std::log;
+  using std::pow;
   static const char* function = "frechet_lcdf";
   check_positive(function, "Random variable", y);
   check_positive_finite(function, "Shape parameter", alpha);
@@ -31,8 +33,6 @@ return_type_t<T_y, T_shape, T_scale> frechet_lcdf(const T_y& y,
     return 0.0;
   }
 
-  using std::log;
-  using std::pow;
   T_partials_return cdf_log(0.0);
   operands_and_partials<T_y, T_shape, T_scale> ops_partials(y, alpha, sigma);
 

--- a/stan/math/prim/prob/frechet_lpdf.hpp
+++ b/stan/math/prim/prob/frechet_lpdf.hpp
@@ -25,6 +25,8 @@ return_type_t<T_y, T_shape, T_scale> frechet_lpdf(const T_y& y,
                                                   const T_shape& alpha,
                                                   const T_scale& sigma) {
   using T_partials_return = partials_return_t<T_y, T_shape, T_scale>;
+  using std::log;
+  using std::pow;
   static const char* function = "frechet_lpdf";
   check_positive(function, "Random variable", y);
   check_positive_finite(function, "Shape parameter", alpha);
@@ -39,8 +41,6 @@ return_type_t<T_y, T_shape, T_scale> frechet_lpdf(const T_y& y,
     return 0;
   }
 
-  using std::log;
-  using std::pow;
   T_partials_return logp(0);
   operands_and_partials<T_y, T_shape, T_scale> ops_partials(y, alpha, sigma);
 

--- a/stan/math/prim/prob/gamma_cdf.hpp
+++ b/stan/math/prim/prob/gamma_cdf.hpp
@@ -40,6 +40,7 @@ return_type_t<T_y, T_shape, T_inv_scale> gamma_cdf(const T_y& y,
                                                    const T_shape& alpha,
                                                    const T_inv_scale& beta) {
   using T_partials_return = partials_return_t<T_y, T_shape, T_inv_scale>;
+  using std::exp;
   static const char* function = "gamma_cdf";
   check_positive_finite(function, "Shape parameter", alpha);
   check_positive_finite(function, "Inverse scale parameter", beta);
@@ -52,7 +53,6 @@ return_type_t<T_y, T_shape, T_inv_scale> gamma_cdf(const T_y& y,
     return 1.0;
   }
 
-  using std::exp;
   T_partials_return P(1.0);
   operands_and_partials<T_y, T_shape, T_inv_scale> ops_partials(y, alpha, beta);
 

--- a/stan/math/prim/prob/gamma_lccdf.hpp
+++ b/stan/math/prim/prob/gamma_lccdf.hpp
@@ -24,6 +24,9 @@ return_type_t<T_y, T_shape, T_inv_scale> gamma_lccdf(const T_y& y,
                                                      const T_shape& alpha,
                                                      const T_inv_scale& beta) {
   using T_partials_return = partials_return_t<T_y, T_shape, T_inv_scale>;
+  using std::exp;
+  using std::log;
+  using std::pow;
   static const char* function = "gamma_lccdf";
   check_positive_finite(function, "Shape parameter", alpha);
   check_positive_finite(function, "Inverse scale parameter", beta);
@@ -36,9 +39,6 @@ return_type_t<T_y, T_shape, T_inv_scale> gamma_lccdf(const T_y& y,
     return 0;
   }
 
-  using std::exp;
-  using std::log;
-  using std::pow;
   T_partials_return P(0.0);
   operands_and_partials<T_y, T_shape, T_inv_scale> ops_partials(y, alpha, beta);
 

--- a/stan/math/prim/prob/gamma_lcdf.hpp
+++ b/stan/math/prim/prob/gamma_lcdf.hpp
@@ -24,6 +24,9 @@ return_type_t<T_y, T_shape, T_inv_scale> gamma_lcdf(const T_y& y,
                                                     const T_shape& alpha,
                                                     const T_inv_scale& beta) {
   using T_partials_return = partials_return_t<T_y, T_shape, T_inv_scale>;
+  using std::exp;
+  using std::log;
+  using std::pow;
   static const char* function = "gamma_lcdf";
   check_positive_finite(function, "Shape parameter", alpha);
   check_positive_finite(function, "Inverse scale parameter", beta);
@@ -36,9 +39,6 @@ return_type_t<T_y, T_shape, T_inv_scale> gamma_lcdf(const T_y& y,
     return 0;
   }
 
-  using std::exp;
-  using std::log;
-  using std::pow;
   T_partials_return P(0.0);
   operands_and_partials<T_y, T_shape, T_inv_scale> ops_partials(y, alpha, beta);
 

--- a/stan/math/prim/prob/gamma_lpdf.hpp
+++ b/stan/math/prim/prob/gamma_lpdf.hpp
@@ -45,6 +45,7 @@ return_type_t<T_y, T_shape, T_inv_scale> gamma_lpdf(const T_y& y,
                                                     const T_shape& alpha,
                                                     const T_inv_scale& beta) {
   using T_partials_return = partials_return_t<T_y, T_shape, T_inv_scale>;
+  using std::log;
   static const char* function = "gamma_lpdf";
   check_not_nan(function, "Random variable", y);
   check_positive_finite(function, "Shape parameter", alpha);
@@ -59,7 +60,6 @@ return_type_t<T_y, T_shape, T_inv_scale> gamma_lpdf(const T_y& y,
     return 0.0;
   }
 
-  using std::log;
   T_partials_return logp(0.0);
   operands_and_partials<T_y, T_shape, T_inv_scale> ops_partials(y, alpha, beta);
 

--- a/stan/math/prim/prob/gaussian_dlm_obs_lpdf.hpp
+++ b/stan/math/prim/prob/gaussian_dlm_obs_lpdf.hpp
@@ -71,14 +71,14 @@ gaussian_dlm_obs_lpdf(
     const Eigen::Matrix<T_W, Eigen::Dynamic, Eigen::Dynamic>& W,
     const Eigen::Matrix<T_m0, Eigen::Dynamic, 1>& m0,
     const Eigen::Matrix<T_C0, Eigen::Dynamic, Eigen::Dynamic>& C0) {
-  static const char* function = "gaussian_dlm_obs_lpdf";
   using T_lp
       = return_type_t<T_y, return_type_t<T_F, T_G, T_V, T_W, T_m0, T_C0>>;
+  using std::pow;
   int r = y.rows();  // number of variables
   int T = y.cols();  // number of observations
   int n = G.rows();  // number of states
-  using std::pow;
 
+  static const char* function = "gaussian_dlm_obs_lpdf";
   check_finite(function, "y", y);
   check_not_nan(function, "y", y);
   check_size_match(function, "columns of F", F.cols(), "rows of y", y.rows());

--- a/stan/math/prim/prob/gumbel_cdf.hpp
+++ b/stan/math/prim/prob/gumbel_cdf.hpp
@@ -32,6 +32,7 @@ template <typename T_y, typename T_loc, typename T_scale>
 return_type_t<T_y, T_loc, T_scale> gumbel_cdf(const T_y& y, const T_loc& mu,
                                               const T_scale& beta) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale>;
+  using std::exp;
   static const char* function = "gumbel_cdf";
   check_not_nan(function, "Random variable", y);
   check_finite(function, "Location parameter", mu);
@@ -44,7 +45,6 @@ return_type_t<T_y, T_loc, T_scale> gumbel_cdf(const T_y& y, const T_loc& mu,
     return 1.0;
   }
 
-  using std::exp;
   T_partials_return cdf(1.0);
   operands_and_partials<T_y, T_loc, T_scale> ops_partials(y, mu, beta);
 

--- a/stan/math/prim/prob/gumbel_lccdf.hpp
+++ b/stan/math/prim/prob/gumbel_lccdf.hpp
@@ -32,6 +32,8 @@ template <typename T_y, typename T_loc, typename T_scale>
 return_type_t<T_y, T_loc, T_scale> gumbel_lccdf(const T_y& y, const T_loc& mu,
                                                 const T_scale& beta) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale>;
+  using std::exp;
+  using std::log;
   static const char* function = "gumbel_lccdf";
   check_not_nan(function, "Random variable", y);
   check_finite(function, "Location parameter", mu);
@@ -44,8 +46,6 @@ return_type_t<T_y, T_loc, T_scale> gumbel_lccdf(const T_y& y, const T_loc& mu,
     return 0;
   }
 
-  using std::exp;
-  using std::log;
   T_partials_return ccdf_log(0.0);
   operands_and_partials<T_y, T_loc, T_scale> ops_partials(y, mu, beta);
 

--- a/stan/math/prim/prob/gumbel_lcdf.hpp
+++ b/stan/math/prim/prob/gumbel_lcdf.hpp
@@ -31,6 +31,7 @@ template <typename T_y, typename T_loc, typename T_scale>
 return_type_t<T_y, T_loc, T_scale> gumbel_lcdf(const T_y& y, const T_loc& mu,
                                                const T_scale& beta) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale>;
+  using std::exp;
   static const char* function = "gumbel_lcdf";
   check_not_nan(function, "Random variable", y);
   check_finite(function, "Location parameter", mu);
@@ -43,7 +44,6 @@ return_type_t<T_y, T_loc, T_scale> gumbel_lcdf(const T_y& y, const T_loc& mu,
     return 0;
   }
 
-  using std::exp;
   T_partials_return cdf_log(0.0);
   operands_and_partials<T_y, T_loc, T_scale> ops_partials(y, mu, beta);
 

--- a/stan/math/prim/prob/gumbel_lpdf.hpp
+++ b/stan/math/prim/prob/gumbel_lpdf.hpp
@@ -33,6 +33,8 @@ template <bool propto, typename T_y, typename T_loc, typename T_scale>
 return_type_t<T_y, T_loc, T_scale> gumbel_lpdf(const T_y& y, const T_loc& mu,
                                                const T_scale& beta) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale>;
+  using std::exp;
+  using std::log;
   static const char* function = "gumbel_lpdf";
   check_not_nan(function, "Random variable", y);
   check_finite(function, "Location parameter", mu);
@@ -47,8 +49,6 @@ return_type_t<T_y, T_loc, T_scale> gumbel_lpdf(const T_y& y, const T_loc& mu,
     return 0.0;
   }
 
-  using std::exp;
-  using std::log;
   T_partials_return logp(0.0);
   operands_and_partials<T_y, T_loc, T_scale> ops_partials(y, mu, beta);
 

--- a/stan/math/prim/prob/inv_chi_square_cdf.hpp
+++ b/stan/math/prim/prob/inv_chi_square_cdf.hpp
@@ -34,6 +34,8 @@ namespace math {
 template <typename T_y, typename T_dof>
 return_type_t<T_y, T_dof> inv_chi_square_cdf(const T_y& y, const T_dof& nu) {
   using T_partials_return = partials_return_t<T_y, T_dof>;
+  using std::exp;
+  using std::pow;
   static const char* function = "inv_chi_square_cdf";
   check_positive_finite(function, "Degrees of freedom parameter", nu);
   check_not_nan(function, "Random variable", y);
@@ -45,8 +47,6 @@ return_type_t<T_y, T_dof> inv_chi_square_cdf(const T_y& y, const T_dof& nu) {
     return 1.0;
   }
 
-  using std::exp;
-  using std::pow;
   T_partials_return P(1.0);
   operands_and_partials<T_y, T_dof> ops_partials(y, nu);
 

--- a/stan/math/prim/prob/inv_chi_square_lccdf.hpp
+++ b/stan/math/prim/prob/inv_chi_square_lccdf.hpp
@@ -35,6 +35,9 @@ namespace math {
 template <typename T_y, typename T_dof>
 return_type_t<T_y, T_dof> inv_chi_square_lccdf(const T_y& y, const T_dof& nu) {
   using T_partials_return = partials_return_t<T_y, T_dof>;
+  using std::exp;
+  using std::log;
+  using std::pow;
   static const char* function = "inv_chi_square_lccdf";
   check_positive_finite(function, "Degrees of freedom parameter", nu);
   check_not_nan(function, "Random variable", y);
@@ -46,9 +49,6 @@ return_type_t<T_y, T_dof> inv_chi_square_lccdf(const T_y& y, const T_dof& nu) {
     return 0;
   }
 
-  using std::exp;
-  using std::log;
-  using std::pow;
   T_partials_return P(0.0);
   operands_and_partials<T_y, T_dof> ops_partials(y, nu);
 

--- a/stan/math/prim/prob/inv_chi_square_lcdf.hpp
+++ b/stan/math/prim/prob/inv_chi_square_lcdf.hpp
@@ -35,6 +35,9 @@ namespace math {
 template <typename T_y, typename T_dof>
 return_type_t<T_y, T_dof> inv_chi_square_lcdf(const T_y& y, const T_dof& nu) {
   using T_partials_return = partials_return_t<T_y, T_dof>;
+  using std::exp;
+  using std::log;
+  using std::pow;
   static const char* function = "inv_chi_square_lcdf";
   check_positive_finite(function, "Degrees of freedom parameter", nu);
   check_not_nan(function, "Random variable", y);
@@ -46,9 +49,6 @@ return_type_t<T_y, T_dof> inv_chi_square_lcdf(const T_y& y, const T_dof& nu) {
     return 0;
   }
 
-  using std::exp;
-  using std::log;
-  using std::pow;
   T_partials_return P(0.0);
   operands_and_partials<T_y, T_dof> ops_partials(y, nu);
 

--- a/stan/math/prim/prob/inv_chi_square_lpdf.hpp
+++ b/stan/math/prim/prob/inv_chi_square_lpdf.hpp
@@ -39,8 +39,9 @@ namespace math {
  */
 template <bool propto, typename T_y, typename T_dof>
 return_type_t<T_y, T_dof> inv_chi_square_lpdf(const T_y& y, const T_dof& nu) {
-  static const char* function = "inv_chi_square_lpdf";
+  using std::log;
   using T_partials_return = partials_return_t<T_y, T_dof>;
+  static const char* function = "inv_chi_square_lpdf";
   check_positive_finite(function, "Degrees of freedom parameter", nu);
   check_not_nan(function, "Random variable", y);
   check_consistent_sizes(function, "Random variable", y,
@@ -50,7 +51,6 @@ return_type_t<T_y, T_dof> inv_chi_square_lpdf(const T_y& y, const T_dof& nu) {
     return 0;
   }
 
-  using std::log;
   T_partials_return logp(0);
   operands_and_partials<T_y, T_dof> ops_partials(y, nu);
 

--- a/stan/math/prim/prob/inv_gamma_cdf.hpp
+++ b/stan/math/prim/prob/inv_gamma_cdf.hpp
@@ -39,6 +39,8 @@ return_type_t<T_y, T_shape, T_scale> inv_gamma_cdf(const T_y& y,
                                                    const T_shape& alpha,
                                                    const T_scale& beta) {
   using T_partials_return = partials_return_t<T_y, T_shape, T_scale>;
+  using std::exp;
+  using std::pow;
   static const char* function = "inv_gamma_cdf";
   check_positive_finite(function, "Shape parameter", alpha);
   check_positive_finite(function, "Scale parameter", beta);
@@ -51,8 +53,6 @@ return_type_t<T_y, T_shape, T_scale> inv_gamma_cdf(const T_y& y,
     return 1.0;
   }
 
-  using std::exp;
-  using std::pow;
   T_partials_return P(1.0);
   operands_and_partials<T_y, T_shape, T_scale> ops_partials(y, alpha, beta);
 

--- a/stan/math/prim/prob/inv_gamma_lccdf.hpp
+++ b/stan/math/prim/prob/inv_gamma_lccdf.hpp
@@ -24,6 +24,9 @@ return_type_t<T_y, T_shape, T_scale> inv_gamma_lccdf(const T_y& y,
                                                      const T_shape& alpha,
                                                      const T_scale& beta) {
   using T_partials_return = partials_return_t<T_y, T_shape, T_scale>;
+  using std::exp;
+  using std::log;
+  using std::pow;
   static const char* function = "inv_gamma_lccdf";
   check_positive_finite(function, "Shape parameter", alpha);
   check_positive_finite(function, "Scale parameter", beta);
@@ -36,9 +39,6 @@ return_type_t<T_y, T_shape, T_scale> inv_gamma_lccdf(const T_y& y,
     return 0;
   }
 
-  using std::exp;
-  using std::log;
-  using std::pow;
   T_partials_return P(0.0);
   operands_and_partials<T_y, T_shape, T_scale> ops_partials(y, alpha, beta);
 

--- a/stan/math/prim/prob/inv_gamma_lcdf.hpp
+++ b/stan/math/prim/prob/inv_gamma_lcdf.hpp
@@ -24,6 +24,9 @@ return_type_t<T_y, T_shape, T_scale> inv_gamma_lcdf(const T_y& y,
                                                     const T_shape& alpha,
                                                     const T_scale& beta) {
   using T_partials_return = partials_return_t<T_y, T_shape, T_scale>;
+  using std::exp;
+  using std::log;
+  using std::pow;
   static const char* function = "inv_gamma_lcdf";
   check_positive_finite(function, "Shape parameter", alpha);
   check_positive_finite(function, "Scale parameter", beta);
@@ -36,9 +39,6 @@ return_type_t<T_y, T_shape, T_scale> inv_gamma_lcdf(const T_y& y,
     return 0;
   }
 
-  using std::exp;
-  using std::log;
-  using std::pow;
   T_partials_return P(0.0);
   operands_and_partials<T_y, T_shape, T_scale> ops_partials(y, alpha, beta);
 

--- a/stan/math/prim/prob/inv_gamma_lpdf.hpp
+++ b/stan/math/prim/prob/inv_gamma_lpdf.hpp
@@ -37,6 +37,7 @@ return_type_t<T_y, T_shape, T_scale> inv_gamma_lpdf(const T_y& y,
                                                     const T_shape& alpha,
                                                     const T_scale& beta) {
   using T_partials_return = partials_return_t<T_y, T_shape, T_scale>;
+  using std::log;
   static const char* function = "inv_gamma_lpdf";
   check_not_nan(function, "Random variable", y);
   check_positive_finite(function, "Shape parameter", alpha);
@@ -51,7 +52,6 @@ return_type_t<T_y, T_shape, T_scale> inv_gamma_lpdf(const T_y& y,
     return 0;
   }
 
-  using std::log;
   T_partials_return logp(0);
   operands_and_partials<T_y, T_shape, T_scale> ops_partials(y, alpha, beta);
 

--- a/stan/math/prim/prob/lkj_corr_cholesky_lpdf.hpp
+++ b/stan/math/prim/prob/lkj_corr_cholesky_lpdf.hpp
@@ -17,10 +17,8 @@ template <bool propto, typename T_covar, typename T_shape>
 return_type_t<T_covar, T_shape> lkj_corr_cholesky_lpdf(
     const Eigen::Matrix<T_covar, Eigen::Dynamic, Eigen::Dynamic>& L,
     const T_shape& eta) {
-  static const char* function = "lkj_corr_cholesky_lpdf";
-
   using lp_ret = return_type_t<T_covar, T_shape>;
-  lp_ret lp(0.0);
+  static const char* function = "lkj_corr_cholesky_lpdf";
   check_positive(function, "Shape parameter", eta);
   check_lower_triangular(function, "Random variable", L);
 
@@ -28,6 +26,8 @@ return_type_t<T_covar, T_shape> lkj_corr_cholesky_lpdf(
   if (K == 0) {
     return 0.0;
   }
+
+  lp_ret lp(0.0);
 
   if (include_summand<propto, T_shape>::value) {
     lp += do_lkj_constant(eta, K);

--- a/stan/math/prim/prob/lkj_corr_cholesky_rng.hpp
+++ b/stan/math/prim/prob/lkj_corr_cholesky_rng.hpp
@@ -12,7 +12,6 @@ namespace math {
 template <class RNG>
 inline Eigen::MatrixXd lkj_corr_cholesky_rng(size_t K, double eta, RNG& rng) {
   static const char* function = "lkj_corr_cholesky_rng";
-
   check_positive(function, "Shape parameter", eta);
 
   Eigen::ArrayXd CPCs((K * (K - 1)) / 2);

--- a/stan/math/prim/prob/lkj_cov_lpdf.hpp
+++ b/stan/math/prim/prob/lkj_cov_lpdf.hpp
@@ -19,8 +19,6 @@ return_type_t<T_y, T_loc, T_scale, T_shape> lkj_cov_lpdf(
     const Eigen::Matrix<T_scale, Eigen::Dynamic, 1>& sigma,
     const T_shape& eta) {
   static const char* function = "lkj_cov_lpdf";
-
-  return_type_t<T_y, T_loc, T_scale, T_shape> lp(0.0);
   check_size_match(function, "Rows of location parameter", mu.rows(),
                    "columns of scale parameter", sigma.rows());
   check_square(function, "random variable", y);
@@ -30,6 +28,8 @@ return_type_t<T_y, T_loc, T_scale, T_shape> lkj_cov_lpdf(
   check_finite(function, "Location parameter", mu);
   check_finite(function, "Scale parameter", sigma);
   check_finite(function, "Covariance matrix", y);
+
+  return_type_t<T_y, T_loc, T_scale, T_shape> lp(0.0);
 
   const unsigned int K = y.rows();
   const Eigen::Array<T_y, Eigen::Dynamic, 1> sds = y.diagonal().array().sqrt();
@@ -65,12 +65,12 @@ return_type_t<T_y, T_loc, T_scale, T_shape> lkj_cov_lpdf(
     const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>& y,
     const T_loc& mu, const T_scale& sigma, const T_shape& eta) {
   static const char* function = "lkj_cov_lpdf";
-
-  return_type_t<T_y, T_loc, T_scale, T_shape> lp(0.0);
   check_positive(function, "Shape parameter", eta);
   check_finite(function, "Location parameter", mu);
   check_finite(function, "Scale parameter", sigma);
   check_finite(function, "Covariance matrix", y);
+
+  return_type_t<T_y, T_loc, T_scale, T_shape> lp(0.0);
 
   const unsigned int K = y.rows();
   const Eigen::Array<T_y, Eigen::Dynamic, 1> sds = y.diagonal().array().sqrt();

--- a/stan/math/prim/prob/logistic_cdf.hpp
+++ b/stan/math/prim/prob/logistic_cdf.hpp
@@ -20,29 +20,25 @@ template <typename T_y, typename T_loc, typename T_scale>
 return_type_t<T_y, T_loc, T_scale> logistic_cdf(const T_y& y, const T_loc& mu,
                                                 const T_scale& sigma) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale>;
-
-  if (size_zero(y, mu, sigma)) {
-    return 1.0;
-  }
-
-  static const char* function = "logistic_cdf";
-
   using std::exp;
-
-  T_partials_return P(1.0);
-
+  static const char* function = "logistic_cdf";
   check_not_nan(function, "Random variable", y);
   check_finite(function, "Location parameter", mu);
   check_positive_finite(function, "Scale parameter", sigma);
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Scale parameter", sigma);
 
+  if (size_zero(y, mu, sigma)) {
+    return 1.0;
+  }
+
+  T_partials_return P(1.0);
+  operands_and_partials<T_y, T_loc, T_scale> ops_partials(y, mu, sigma);
+
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_loc> mu_vec(mu);
   scalar_seq_view<T_scale> sigma_vec(sigma);
   size_t N = max_size(y, mu, sigma);
-
-  operands_and_partials<T_y, T_loc, T_scale> ops_partials(y, mu, sigma);
 
   // Explicit return for extreme values
   // The gradients are technically ill-defined, but treated as zero

--- a/stan/math/prim/prob/logistic_lccdf.hpp
+++ b/stan/math/prim/prob/logistic_lccdf.hpp
@@ -20,30 +20,26 @@ template <typename T_y, typename T_loc, typename T_scale>
 return_type_t<T_y, T_loc, T_scale> logistic_lccdf(const T_y& y, const T_loc& mu,
                                                   const T_scale& sigma) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale>;
-
-  if (size_zero(y, mu, sigma)) {
-    return 0.0;
-  }
-
-  static const char* function = "logistic_lccdf";
-
   using std::exp;
   using std::log;
-
-  T_partials_return P(0.0);
-
+  static const char* function = "logistic_lccdf";
   check_not_nan(function, "Random variable", y);
   check_finite(function, "Location parameter", mu);
   check_positive_finite(function, "Scale parameter", sigma);
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Scale parameter", sigma);
 
+  if (size_zero(y, mu, sigma)) {
+    return 0;
+  }
+
+  T_partials_return P(0.0);
+  operands_and_partials<T_y, T_loc, T_scale> ops_partials(y, mu, sigma);
+
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_loc> mu_vec(mu);
   scalar_seq_view<T_scale> sigma_vec(sigma);
   size_t N = max_size(y, mu, sigma);
-
-  operands_and_partials<T_y, T_loc, T_scale> ops_partials(y, mu, sigma);
 
   // Explicit return for extreme values
   // The gradients are technically ill-defined, but treated as zero

--- a/stan/math/prim/prob/logistic_lcdf.hpp
+++ b/stan/math/prim/prob/logistic_lcdf.hpp
@@ -20,30 +20,26 @@ template <typename T_y, typename T_loc, typename T_scale>
 return_type_t<T_y, T_loc, T_scale> logistic_lcdf(const T_y& y, const T_loc& mu,
                                                  const T_scale& sigma) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale>;
-
-  if (size_zero(y, mu, sigma)) {
-    return 0.0;
-  }
-
-  static const char* function = "logistic_lcdf";
-
   using std::exp;
   using std::log;
-
-  T_partials_return P(0.0);
-
+  static const char* function = "logistic_lcdf";
   check_not_nan(function, "Random variable", y);
   check_finite(function, "Location parameter", mu);
   check_positive_finite(function, "Scale parameter", sigma);
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Scale parameter", sigma);
 
+  if (size_zero(y, mu, sigma)) {
+    return 0;
+  }
+
+  T_partials_return P(0.0);
+  operands_and_partials<T_y, T_loc, T_scale> ops_partials(y, mu, sigma);
+
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_loc> mu_vec(mu);
   scalar_seq_view<T_scale> sigma_vec(sigma);
   size_t N = max_size(y, mu, sigma);
-
-  operands_and_partials<T_y, T_loc, T_scale> ops_partials(y, mu, sigma);
 
   // Explicit return for extreme values
   // The gradients are technically ill-defined, but treated as zero

--- a/stan/math/prim/prob/logistic_lpdf.hpp
+++ b/stan/math/prim/prob/logistic_lpdf.hpp
@@ -19,28 +19,24 @@ namespace math {
 template <bool propto, typename T_y, typename T_loc, typename T_scale>
 return_type_t<T_y, T_loc, T_scale> logistic_lpdf(const T_y& y, const T_loc& mu,
                                                  const T_scale& sigma) {
-  static const char* function = "logistic_lpdf";
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale>;
-
   using std::exp;
   using std::log;
-
-  if (size_zero(y, mu, sigma)) {
-    return 0.0;
-  }
-
-  T_partials_return logp(0.0);
-
+  static const char* function = "logistic_lpdf";
   check_finite(function, "Random variable", y);
   check_finite(function, "Location parameter", mu);
   check_positive_finite(function, "Scale parameter", sigma);
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Scale parameter", sigma);
 
+  if (size_zero(y, mu, sigma)) {
+    return 0.0;
+  }
   if (!include_summand<propto, T_y, T_loc, T_scale>::value) {
     return 0.0;
   }
 
+  T_partials_return logp(0.0);
   operands_and_partials<T_y, T_loc, T_scale> ops_partials(y, mu, sigma);
 
   scalar_seq_view<T_y> y_vec(y);

--- a/stan/math/prim/prob/logistic_rng.hpp
+++ b/stan/math/prim/prob/logistic_rng.hpp
@@ -18,8 +18,8 @@ namespace math {
  * mu and sigma can each be a scalar or a one-dimensional container. Any
  * non-scalar inputs must be the same size.
  *
- * @tparam T_loc Type of location parameter
- * @tparam T_scale Type of scale parameter
+ * @tparam T_loc type of location parameter
+ * @tparam T_scale type of scale parameter
  * @tparam RNG type of random number generator
  * @param mu (Sequence of) location parameter(s)
  * @param sigma (Sequence of) scale parameter(s)
@@ -35,7 +35,6 @@ inline typename VectorBuilder<true, double, T_loc, T_scale>::type logistic_rng(
   using boost::random::exponential_distribution;
   using boost::variate_generator;
   static const char* function = "logistic_rng";
-
   check_finite(function, "Location parameter", mu);
   check_positive_finite(function, "Scale parameter", sigma);
   check_consistent_sizes(function, "Location parameter", mu, "Scale Parameter",

--- a/stan/math/prim/prob/lognormal_cdf.hpp
+++ b/stan/math/prim/prob/lognormal_cdf.hpp
@@ -18,24 +18,20 @@ namespace math {
 template <typename T_y, typename T_loc, typename T_scale>
 return_type_t<T_y, T_loc, T_scale> lognormal_cdf(const T_y& y, const T_loc& mu,
                                                  const T_scale& sigma) {
-  static const char* function = "lognormal_cdf";
-
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale>;
-
-  T_partials_return cdf = 1.0;
-
   using std::exp;
   using std::log;
-
-  if (size_zero(y, mu, sigma)) {
-    return cdf;
-  }
-
+  static const char* function = "lognormal_cdf";
   check_not_nan(function, "Random variable", y);
   check_nonnegative(function, "Random variable", y);
   check_finite(function, "Location parameter", mu);
   check_positive_finite(function, "Scale parameter", sigma);
 
+  if (size_zero(y, mu, sigma)) {
+    return 1.0;
+  }
+
+  T_partials_return cdf = 1.0;
   operands_and_partials<T_y, T_loc, T_scale> ops_partials(y, mu, sigma);
 
   scalar_seq_view<T_y> y_vec(y);

--- a/stan/math/prim/prob/lognormal_lccdf.hpp
+++ b/stan/math/prim/prob/lognormal_lccdf.hpp
@@ -20,23 +20,20 @@ template <typename T_y, typename T_loc, typename T_scale>
 return_type_t<T_y, T_loc, T_scale> lognormal_lccdf(const T_y& y,
                                                    const T_loc& mu,
                                                    const T_scale& sigma) {
-  static const char* function = "lognormal_lccdf";
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale>;
-
-  T_partials_return ccdf_log = 0.0;
-
   using std::exp;
   using std::log;
-
-  if (size_zero(y, mu, sigma)) {
-    return ccdf_log;
-  }
-
+  static const char* function = "lognormal_lccdf";
   check_not_nan(function, "Random variable", y);
   check_nonnegative(function, "Random variable", y);
   check_finite(function, "Location parameter", mu);
   check_positive_finite(function, "Scale parameter", sigma);
 
+  if (size_zero(y, mu, sigma)) {
+    return 0;
+  }
+
+  T_partials_return ccdf_log = 0.0;
   operands_and_partials<T_y, T_loc, T_scale> ops_partials(y, mu, sigma);
 
   scalar_seq_view<T_y> y_vec(y);

--- a/stan/math/prim/prob/lognormal_lcdf.hpp
+++ b/stan/math/prim/prob/lognormal_lcdf.hpp
@@ -19,23 +19,20 @@ namespace math {
 template <typename T_y, typename T_loc, typename T_scale>
 return_type_t<T_y, T_loc, T_scale> lognormal_lcdf(const T_y& y, const T_loc& mu,
                                                   const T_scale& sigma) {
-  static const char* function = "lognormal_lcdf";
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale>;
-
-  T_partials_return cdf_log = 0.0;
-
   using std::exp;
   using std::log;
-
-  if (size_zero(y, mu, sigma)) {
-    return cdf_log;
-  }
-
+  static const char* function = "lognormal_lcdf";
   check_not_nan(function, "Random variable", y);
   check_nonnegative(function, "Random variable", y);
   check_finite(function, "Location parameter", mu);
   check_positive_finite(function, "Scale parameter", sigma);
 
+  if (size_zero(y, mu, sigma)) {
+    return 0;
+  }
+
+  T_partials_return cdf_log = 0.0;
   operands_and_partials<T_y, T_loc, T_scale> ops_partials(y, mu, sigma);
 
   scalar_seq_view<T_y> y_vec(y);

--- a/stan/math/prim/prob/lognormal_lpdf.hpp
+++ b/stan/math/prim/prob/lognormal_lpdf.hpp
@@ -18,20 +18,22 @@ namespace math {
 template <bool propto, typename T_y, typename T_loc, typename T_scale>
 return_type_t<T_y, T_loc, T_scale> lognormal_lpdf(const T_y& y, const T_loc& mu,
                                                   const T_scale& sigma) {
-  static const char* function = "lognormal_lpdf";
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale>;
-
+  using std::log;
+  static const char* function = "lognormal_lpdf";
   check_not_nan(function, "Random variable", y);
   check_nonnegative(function, "Random variable", y);
   check_finite(function, "Location parameter", mu);
   check_positive_finite(function, "Scale parameter", sigma);
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Scale parameter", sigma);
+
   if (size_zero(y, mu, sigma)) {
     return 0;
   }
 
   T_partials_return logp(0);
+  operands_and_partials<T_y, T_loc, T_scale> ops_partials(y, mu, sigma);
 
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_loc> mu_vec(mu);
@@ -43,10 +45,6 @@ return_type_t<T_y, T_loc, T_scale> lognormal_lpdf(const T_y& y, const T_loc& mu,
       return LOG_ZERO;
     }
   }
-
-  operands_and_partials<T_y, T_loc, T_scale> ops_partials(y, mu, sigma);
-
-  using std::log;
 
   VectorBuilder<include_summand<propto, T_scale>::value, T_partials_return,
                 T_scale>

--- a/stan/math/prim/prob/lognormal_rng.hpp
+++ b/stan/math/prim/prob/lognormal_rng.hpp
@@ -17,8 +17,8 @@ namespace math {
  * mu and sigma can each be a scalar or a one-dimensional container. Any
  * non-scalar inputs must be the same size.
  *
- * @tparam T_loc Type of location parameter
- * @tparam T_scale Type of scale parameter
+ * @tparam T_loc type of location parameter
+ * @tparam T_scale type of scale parameter
  * @tparam RNG type of random number generator
  * @param mu (Sequence of) location parameter(s)
  * @param sigma (Sequence of) positive scale parameter(s)
@@ -33,9 +33,7 @@ inline typename VectorBuilder<true, double, T_loc, T_scale>::type lognormal_rng(
     const T_loc& mu, const T_scale& sigma, RNG& rng) {
   using boost::random::lognormal_distribution;
   using boost::variate_generator;
-
   static const char* function = "lognormal_rng";
-
   check_finite(function, "Location parameter", mu);
   check_positive_finite(function, "Scale parameter", sigma);
   check_consistent_sizes(function, "Location parameter", mu, "Scale Parameter",

--- a/stan/math/prim/prob/matrix_normal_prec_lpdf.hpp
+++ b/stan/math/prim/prob/matrix_normal_prec_lpdf.hpp
@@ -10,9 +10,15 @@
 
 namespace stan {
 namespace math {
+
 /** \ingroup multivar_dists
  * The log of the matrix normal density for the given y, mu, Sigma and D
  * where Sigma and D are given as precision matrices, not covariance matrices.
+ *
+ * @tparam T_y type of scalar
+ * @tparam T_Mu type of location
+ * @tparam T_Sigma type of Sigma
+ * @tparam T_D type of D
  *
  * @param y An mxn matrix.
  * @param Mu The mean matrix.
@@ -23,10 +29,6 @@ namespace math {
  * @return The log of the matrix normal density.
  * @throw std::domain_error if Sigma or D are not square, not symmetric,
  * or not semi-positive definite.
- * @tparam T_y Type of scalar.
- * @tparam T_Mu Type of location.
- * @tparam T_Sigma Type of Sigma.
- * @tparam T_D Type of D.
  */
 template <bool propto, typename T_y, typename T_Mu, typename T_Sigma,
           typename T_D>
@@ -36,8 +38,6 @@ return_type_t<T_y, T_Mu, T_Sigma, T_D> matrix_normal_prec_lpdf(
     const Eigen::Matrix<T_Sigma, Eigen::Dynamic, Eigen::Dynamic>& Sigma,
     const Eigen::Matrix<T_D, Eigen::Dynamic, Eigen::Dynamic>& D) {
   static const char* function = "matrix_normal_prec_lpdf";
-  return_type_t<T_y, T_Mu, T_Sigma, T_D> lp(0.0);
-
   check_positive(function, "Sigma rows", Sigma.rows());
   check_finite(function, "Sigma", Sigma);
   check_symmetric(function, "Sigma", Sigma);
@@ -60,6 +60,8 @@ return_type_t<T_y, T_Mu, T_Sigma, T_D> matrix_normal_prec_lpdf(
                    "Rows of D", D.rows());
   check_finite(function, "Location parameter", Mu);
   check_finite(function, "Random variable", y);
+
+  return_type_t<T_y, T_Mu, T_Sigma, T_D> lp(0.0);
 
   if (include_summand<propto>::value) {
     lp += NEG_LOG_SQRT_TWO_PI * y.cols() * y.rows();

--- a/stan/math/prim/prob/matrix_normal_prec_rng.hpp
+++ b/stan/math/prim/prob/matrix_normal_prec_rng.hpp
@@ -35,22 +35,17 @@ inline Eigen::MatrixXd matrix_normal_prec_rng(const Eigen::MatrixXd &Mu,
                                               RNG &rng) {
   using boost::normal_distribution;
   using boost::variate_generator;
-
   static const char *function = "matrix_normal_prec_rng";
-
   check_positive(function, "Sigma rows", Sigma.rows());
   check_finite(function, "Sigma", Sigma);
   check_symmetric(function, "Sigma", Sigma);
-
   check_positive(function, "D rows", D.rows());
   check_finite(function, "D", D);
   check_symmetric(function, "D", D);
-
   check_size_match(function, "Rows of location parameter", Mu.rows(),
                    "Rows of Sigma", Sigma.rows());
   check_size_match(function, "Columns of location parameter", Mu.cols(),
                    "Rows of D", D.rows());
-
   check_finite(function, "Location parameter", Mu);
 
   Eigen::LDLT<Eigen::MatrixXd> Sigma_ldlt(Sigma);

--- a/stan/math/prim/prob/multi_gp_cholesky_lpdf.hpp
+++ b/stan/math/prim/prob/multi_gp_cholesky_lpdf.hpp
@@ -39,9 +39,8 @@ return_type_t<T_y, T_covar, T_w> multi_gp_cholesky_lpdf(
     const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>& y,
     const Eigen::Matrix<T_covar, Eigen::Dynamic, Eigen::Dynamic>& L,
     const Eigen::Matrix<T_w, Eigen::Dynamic, 1>& w) {
-  static const char* function = "multi_gp_cholesky_lpdf";
   using T_lp = return_type_t<T_y, T_covar, T_w>;
-
+  static const char* function = "multi_gp_cholesky_lpdf";
   check_size_match(function, "Size of random variable (rows y)", y.rows(),
                    "Size of kernel scales (w)", w.size());
   check_size_match(function, "Size of random variable", y.cols(),

--- a/stan/math/prim/prob/multi_gp_lpdf.hpp
+++ b/stan/math/prim/prob/multi_gp_lpdf.hpp
@@ -10,6 +10,7 @@
 
 namespace stan {
 namespace math {
+
 /** \ingroup multivar_dists
  * The log of a multivariate Gaussian Process for the given y, Sigma, and
  * w.  y is a dxN matrix, where each column is a different observation and each
@@ -18,6 +19,9 @@ namespace math {
  * This distribution is equivalent to:
  *    for (i in 1:d) row(y, i) ~ multi_normal(0, (1/w[i])*Sigma).
  *
+ * @tparam T_y type of scalar
+ * @tparam T_covar type of kernel
+ * @tparam T_w type of weight
  * @param y A dxN matrix
  * @param Sigma The NxN kernel matrix
  * @param w A d-dimensional vector of positive inverse scale parameters for each
@@ -25,19 +29,14 @@ namespace math {
  * @return The log of the multivariate GP density.
  * @throw std::domain_error if Sigma is not square, not symmetric,
  * or not semi-positive definite.
- * @tparam T_y Type of scalar.
- * @tparam T_covar Type of kernel.
- * @tparam T_w Type of weight.
  */
 template <bool propto, typename T_y, typename T_covar, typename T_w>
 return_type_t<T_y, T_covar, T_w> multi_gp_lpdf(
     const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>& y,
     const Eigen::Matrix<T_covar, Eigen::Dynamic, Eigen::Dynamic>& Sigma,
     const Eigen::Matrix<T_w, Eigen::Dynamic, 1>& w) {
-  static const char* function = "multi_gp_lpdf";
   using T_lp = return_type_t<T_y, T_covar, T_w>;
-  T_lp lp(0.0);
-
+  static const char* function = "multi_gp_lpdf";
   check_positive(function, "Kernel rows", Sigma.rows());
   check_finite(function, "Kernel", Sigma);
   check_symmetric(function, "Kernel", Sigma);
@@ -51,6 +50,8 @@ return_type_t<T_y, T_covar, T_w> multi_gp_lpdf(
                    "rows of covariance parameter", Sigma.rows());
   check_positive_finite(function, "Kernel scales", w);
   check_finite(function, "Random variable", y);
+
+  T_lp lp(0.0);
 
   if (y.rows() == 0) {
     return lp;

--- a/stan/math/prim/prob/multi_normal_lpdf.hpp
+++ b/stan/math/prim/prob/multi_normal_lpdf.hpp
@@ -16,12 +16,10 @@ template <bool propto, typename T_y, typename T_loc, typename T_covar>
 return_type_t<T_y, T_loc, T_covar> multi_normal_lpdf(const T_y& y,
                                                      const T_loc& mu,
                                                      const T_covar& Sigma) {
-  static const char* function = "multi_normal_lpdf";
   using T_covar_elem = typename scalar_type<T_covar>::type;
   using lp_type = return_type_t<T_y, T_loc, T_covar>;
-
   using Eigen::Dynamic;
-
+  static const char* function = "multi_normal_lpdf";
   check_positive(function, "Covariance matrix rows", Sigma.rows());
   check_symmetric(function, "Covariance matrix", Sigma);
 

--- a/stan/math/prim/prob/multi_normal_prec_lpdf.hpp
+++ b/stan/math/prim/prob/multi_normal_prec_lpdf.hpp
@@ -16,18 +16,16 @@ namespace math {
 template <bool propto, typename T_y, typename T_loc, typename T_covar>
 return_type_t<T_y, T_loc, T_covar> multi_normal_prec_lpdf(
     const T_y& y, const T_loc& mu, const T_covar& Sigma) {
-  static const char* function = "multi_normal_prec_lpdf";
   using T_covar_elem = typename scalar_type<T_covar>::type;
   using lp_type = return_type_t<T_y, T_loc, T_covar>;
-
+  using Eigen::Matrix;
+  using std::vector;
+  static const char* function = "multi_normal_prec_lpdf";
   check_positive(function, "Precision matrix rows", Sigma.rows());
   check_symmetric(function, "Precision matrix", Sigma);
 
   LDLT_factor<T_covar_elem, Eigen::Dynamic, Eigen::Dynamic> ldlt_Sigma(Sigma);
   check_ldlt_factor(function, "LDLT_Factor of precision parameter", ldlt_Sigma);
-
-  using Eigen::Matrix;
-  using std::vector;
 
   size_t number_of_y = size_mvt(y);
   size_t number_of_mu = size_mvt(mu);

--- a/stan/math/prim/prob/multi_normal_prec_rng.hpp
+++ b/stan/math/prim/prob/multi_normal_prec_rng.hpp
@@ -31,9 +31,7 @@ inline typename StdVectorBuilder<true, Eigen::VectorXd, T_loc>::type
 multi_normal_prec_rng(const T_loc &mu, const Eigen::MatrixXd &S, RNG &rng) {
   using boost::normal_distribution;
   using boost::variate_generator;
-
   static const char *function = "multi_normal_prec_rng";
-
   check_positive(function, "Precision matrix rows", S.rows());
   check_finite(function, "Precision matrix", S);
   check_symmetric(function, "Precision matrix", S);

--- a/stan/math/prim/prob/multi_normal_rng.hpp
+++ b/stan/math/prim/prob/multi_normal_rng.hpp
@@ -33,9 +33,7 @@ multi_normal_rng(const T_loc& mu,
                  RNG& rng) {
   using boost::normal_distribution;
   using boost::variate_generator;
-
   static const char* function = "multi_normal_rng";
-
   check_positive(function, "Covariance matrix rows", S.rows());
   check_not_nan(function, "Covariance matrix", S);
   check_symmetric(function, "Covariance matrix", S);

--- a/stan/math/prim/prob/multi_student_t_lpdf.hpp
+++ b/stan/math/prim/prob/multi_student_t_lpdf.hpp
@@ -30,8 +30,8 @@ return_type_t<T_y, T_dof, T_loc, T_scale> multi_student_t_lpdf(
   using T_scale_elem = typename scalar_type<T_scale>::type;
   using lp_type = return_type_t<T_y, T_dof, T_loc, T_scale>;
   using Eigen::Matrix;
-  using std::vector;
   using std::log;
+  using std::vector;
   static const char* function = "multi_student_t";
   check_not_nan(function, "Degrees of freedom parameter", nu);
   check_positive(function, "Degrees of freedom parameter", nu);

--- a/stan/math/prim/prob/multi_student_t_lpdf.hpp
+++ b/stan/math/prim/prob/multi_student_t_lpdf.hpp
@@ -27,20 +27,18 @@ template <bool propto, typename T_y, typename T_dof, typename T_loc,
           typename T_scale>
 return_type_t<T_y, T_dof, T_loc, T_scale> multi_student_t_lpdf(
     const T_y& y, const T_dof& nu, const T_loc& mu, const T_scale& Sigma) {
-  static const char* function = "multi_student_t";
-  using std::log;
   using T_scale_elem = typename scalar_type<T_scale>::type;
   using lp_type = return_type_t<T_y, T_dof, T_loc, T_scale>;
-
+  using Eigen::Matrix;
+  using std::vector;
+  using std::log;
+  static const char* function = "multi_student_t";
   check_not_nan(function, "Degrees of freedom parameter", nu);
   check_positive(function, "Degrees of freedom parameter", nu);
 
   if (is_inf(nu)) {
     return multi_normal_log(y, mu, Sigma);
   }
-
-  using Eigen::Matrix;
-  using std::vector;
 
   size_t number_of_y = size_mvt(y);
   size_t number_of_mu = size_mvt(mu);

--- a/stan/math/prim/prob/multi_student_t_rng.hpp
+++ b/stan/math/prim/prob/multi_student_t_rng.hpp
@@ -40,7 +40,6 @@ multi_student_t_rng(
   using boost::variate_generator;
 
   static const char* function = "multi_student_t_rng";
-
   check_not_nan(function, "Degrees of freedom parameter", nu);
   check_positive(function, "Degrees of freedom parameter", nu);
   check_positive(function, "Covariance matrix rows", S.rows());

--- a/stan/math/prim/prob/multinomial_lpmf.hpp
+++ b/stan/math/prim/prob/multinomial_lpmf.hpp
@@ -16,12 +16,12 @@ return_type_t<T_prob> multinomial_lpmf(
     const std::vector<int>& ns,
     const Eigen::Matrix<T_prob, Eigen::Dynamic, 1>& theta) {
   static const char* function = "multinomial_lpmf";
-
-  return_type_t<T_prob> lp(0.0);
   check_nonnegative(function, "Number of trials variable", ns);
   check_simplex(function, "Probabilities parameter", theta);
   check_size_match(function, "Size of number of trials variable", ns.size(),
                    "rows of probabilities parameter", theta.rows());
+
+  return_type_t<T_prob> lp(0.0);
 
   if (include_summand<propto>::value) {
     double sum = 1.0;

--- a/stan/math/prim/prob/multinomial_rng.hpp
+++ b/stan/math/prim/prob/multinomial_rng.hpp
@@ -13,7 +13,6 @@ template <class RNG>
 inline std::vector<int> multinomial_rng(
     const Eigen::Matrix<double, Eigen::Dynamic, 1>& theta, int N, RNG& rng) {
   static const char* function = "multinomial_rng";
-
   check_simplex(function, "Probabilities parameter", theta);
   check_positive(function, "number of trials variables", N);
 

--- a/stan/math/prim/prob/neg_binomial_2_cdf.hpp
+++ b/stan/math/prim/prob/neg_binomial_2_cdf.hpp
@@ -21,19 +21,20 @@ namespace math {
 template <typename T_n, typename T_location, typename T_precision>
 return_type_t<T_location, T_precision> neg_binomial_2_cdf(
     const T_n& n, const T_location& mu, const T_precision& phi) {
-  static const char* function = "neg_binomial_2_cdf";
   using T_partials_return = partials_return_t<T_n, T_location, T_precision>;
-
-  T_partials_return P(1.0);
-  if (size_zero(n, mu, phi)) {
-    return P;
-  }
-
+  static const char* function = "neg_binomial_2_cdf";
   check_positive_finite(function, "Location parameter", mu);
   check_positive_finite(function, "Precision parameter", phi);
   check_not_nan(function, "Random variable", n);
   check_consistent_sizes(function, "Random variable", n, "Location parameter",
                          mu, "Precision Parameter", phi);
+
+  if (size_zero(n, mu, phi)) {
+    return 1.0;
+  }
+
+  T_partials_return P(1.0);
+  operands_and_partials<T_location, T_precision> ops_partials(mu, phi);
 
   scalar_seq_view<T_n> n_vec(n);
   scalar_seq_view<T_location> mu_vec(mu);
@@ -41,8 +42,6 @@ return_type_t<T_location, T_precision> neg_binomial_2_cdf(
   size_t size_phi = stan::math::size(phi);
   size_t size_n_phi = max_size(n, phi);
   size_t max_size_seq_view = max_size(n, mu, phi);
-
-  operands_and_partials<T_location, T_precision> ops_partials(mu, phi);
 
   // Explicit return for extreme values
   // The gradients are technically ill-defined, but treated as zero

--- a/stan/math/prim/prob/neg_binomial_2_lccdf.hpp
+++ b/stan/math/prim/prob/neg_binomial_2_lccdf.hpp
@@ -15,16 +15,16 @@ namespace math {
 template <typename T_n, typename T_location, typename T_precision>
 return_type_t<T_location, T_precision> neg_binomial_2_lccdf(
     const T_n& n, const T_location& mu, const T_precision& phi) {
-  if (size_zero(n, mu, phi)) {
-    return 0.0;
-  }
-
   static const char* function = "neg_binomial_2_lccdf";
   check_positive_finite(function, "Location parameter", mu);
   check_positive_finite(function, "Precision parameter", phi);
   check_not_nan(function, "Random variable", n);
   check_consistent_sizes(function, "Random variable", n, "Location parameter",
                          mu, "Precision Parameter", phi);
+
+  if (size_zero(n, mu, phi)) {
+    return 0;
+  }
 
   scalar_seq_view<T_location> mu_vec(mu);
   scalar_seq_view<T_precision> phi_vec(phi);

--- a/stan/math/prim/prob/neg_binomial_2_lcdf.hpp
+++ b/stan/math/prim/prob/neg_binomial_2_lcdf.hpp
@@ -17,17 +17,16 @@ template <typename T_n, typename T_location, typename T_precision>
 return_type_t<T_location, T_precision> neg_binomial_2_lcdf(
     const T_n& n, const T_location& mu, const T_precision& phi) {
   using std::log;
-
-  if (size_zero(n, mu, phi)) {
-    return 0.0;
-  }
-
   static const char* function = "neg_binomial_2_lcdf";
   check_positive_finite(function, "Location parameter", mu);
   check_positive_finite(function, "Precision parameter", phi);
   check_not_nan(function, "Random variable", n);
   check_consistent_sizes(function, "Random variable", n, "Location parameter",
                          mu, "Precision Parameter", phi);
+
+  if (size_zero(n, mu, phi)) {
+    return 0;
+  }
 
   scalar_seq_view<T_n> n_vec(n);
   scalar_seq_view<T_location> mu_vec(mu);

--- a/stan/math/prim/prob/neg_binomial_2_log_glm_lpmf.hpp
+++ b/stan/math/prim/prob/neg_binomial_2_log_glm_lpmf.hpp
@@ -26,6 +26,7 @@ namespace math {
  * neg_binomial_2_log_lpmf(y, alpha + x * beta, phi) by using analytically
  * simplified gradients.
  * If containers are supplied, returns the log sum of the probabilities.
+ *
  * @tparam T_y type of positive int vector of variates (labels);
  * this can also be a single positive integer value;
  * @tparam T_x_scalar type of a scalar in the matrix of independent variables
@@ -40,6 +41,7 @@ namespace math {
  * @tparam T_precision type of the (positive) precision(s);
  * this can be a vector (of the same length as y, for heteroskedasticity)
  * or a scalar.
+ *
  * @param y failures count scalar or vector parameter. If it is a scalar it will
  * be broadcast - used for all instances.
  * @param x design matrix or row vector. If it is a row vector it will be
@@ -59,14 +61,11 @@ return_type_t<T_x_scalar, T_alpha, T_beta, T_precision>
 neg_binomial_2_log_glm_lpmf(
     const T_y& y, const Eigen::Matrix<T_x_scalar, T_x_rows, Eigen::Dynamic>& x,
     const T_alpha& alpha, const T_beta& beta, const T_precision& phi) {
-  static const char* function = "neg_binomial_2_log_glm_lpmf";
-
   using Eigen::Array;
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using Eigen::exp;
   using Eigen::log1p;
-
   using T_partials_return
       = partials_return_t<T_y, T_x_scalar, T_alpha, T_beta, T_precision>;
   using T_precision_val = typename std::conditional_t<
@@ -84,6 +83,7 @@ neg_binomial_2_log_glm_lpmf(
   const size_t N_instances = T_x_rows == 1 ? stan::math::size(y) : x.rows();
   const size_t N_attributes = x.cols();
 
+  static const char* function = "neg_binomial_2_log_glm_lpmf";
   check_consistent_size(function, "Vector of dependent variables", y,
                         N_instances);
   check_consistent_size(function, "Weight vector", beta, N_attributes);

--- a/stan/math/prim/prob/neg_binomial_2_log_lpmf.hpp
+++ b/stan/math/prim/prob/neg_binomial_2_log_lpmf.hpp
@@ -25,14 +25,9 @@ template <bool propto, typename T_n, typename T_log_location,
 return_type_t<T_log_location, T_precision> neg_binomial_2_log_lpmf(
     const T_n& n, const T_log_location& eta, const T_precision& phi) {
   using T_partials_return = partials_return_t<T_n, T_log_location, T_precision>;
-
+  using std::exp;
+  using std::log;
   static const char* function = "neg_binomial_2_log_lpmf";
-
-  if (size_zero(n, eta, phi)) {
-    return 0.0;
-  }
-
-  T_partials_return logp(0.0);
   check_nonnegative(function, "Failures variable", n);
   check_finite(function, "Log location parameter", eta);
   check_positive_finite(function, "Precision parameter", phi);
@@ -40,12 +35,15 @@ return_type_t<T_log_location, T_precision> neg_binomial_2_log_lpmf(
                          "Log location parameter", eta, "Precision parameter",
                          phi);
 
+  if (size_zero(n, eta, phi)) {
+    return 0.0;
+  }
   if (!include_summand<propto, T_log_location, T_precision>::value) {
     return 0.0;
   }
 
-  using std::exp;
-  using std::log;
+  T_partials_return logp(0.0);
+  operands_and_partials<T_log_location, T_precision> ops_partials(eta, phi);
 
   scalar_seq_view<T_n> n_vec(n);
   scalar_seq_view<T_log_location> eta_vec(eta);
@@ -55,8 +53,6 @@ return_type_t<T_log_location, T_precision> neg_binomial_2_log_lpmf(
   size_t size_eta_phi = max_size(eta, phi);
   size_t size_n_phi = max_size(n, phi);
   size_t max_size_seq_view = max_size(n, eta, phi);
-
-  operands_and_partials<T_log_location, T_precision> ops_partials(eta, phi);
 
   VectorBuilder<true, T_partials_return, T_log_location> eta_val(size_eta);
   for (size_t i = 0; i < size_eta; ++i) {

--- a/stan/math/prim/prob/neg_binomial_2_log_rng.hpp
+++ b/stan/math/prim/prob/neg_binomial_2_log_rng.hpp
@@ -37,9 +37,7 @@ neg_binomial_2_log_rng(const T_loc& eta, const T_inv& phi, RNG& rng) {
   using boost::gamma_distribution;
   using boost::random::poisson_distribution;
   using boost::variate_generator;
-
   static const char* function = "neg_binomial_2_log_rng";
-
   check_finite(function, "Log-location parameter", eta);
   check_positive_finite(function, "Inverse dispersion parameter", phi);
   check_consistent_sizes(function, "Log-location parameter", eta,

--- a/stan/math/prim/prob/neg_binomial_2_lpmf.hpp
+++ b/stan/math/prim/prob/neg_binomial_2_lpmf.hpp
@@ -22,25 +22,23 @@ template <bool propto, typename T_n, typename T_location, typename T_precision>
 return_type_t<T_location, T_precision> neg_binomial_2_lpmf(
     const T_n& n, const T_location& mu, const T_precision& phi) {
   using T_partials_return = partials_return_t<T_n, T_location, T_precision>;
-
+  using std::log;
   static const char* function = "neg_binomial_2_lpmf";
-
-  if (size_zero(n, mu, phi)) {
-    return 0.0;
-  }
-
-  T_partials_return logp(0.0);
   check_nonnegative(function, "Failures variable", n);
   check_positive_finite(function, "Location parameter", mu);
   check_positive_finite(function, "Precision parameter", phi);
   check_consistent_sizes(function, "Failures variable", n, "Location parameter",
                          mu, "Precision parameter", phi);
 
+  if (size_zero(n, mu, phi)) {
+    return 0.0;
+  }
   if (!include_summand<propto, T_location, T_precision>::value) {
     return 0.0;
   }
 
-  using std::log;
+  T_partials_return logp(0.0);
+  operands_and_partials<T_location, T_precision> ops_partials(mu, phi);
 
   scalar_seq_view<T_n> n_vec(n);
   scalar_seq_view<T_location> mu_vec(mu);
@@ -50,8 +48,6 @@ return_type_t<T_location, T_precision> neg_binomial_2_lpmf(
   size_t size_mu_phi = max_size(mu, phi);
   size_t size_n_phi = max_size(n, phi);
   size_t max_size_seq_view = max_size(n, mu, phi);
-
-  operands_and_partials<T_location, T_precision> ops_partials(mu, phi);
 
   VectorBuilder<true, T_partials_return, T_location> mu_val(size_mu);
   for (size_t i = 0; i < size_mu; ++i) {

--- a/stan/math/prim/prob/neg_binomial_2_rng.hpp
+++ b/stan/math/prim/prob/neg_binomial_2_rng.hpp
@@ -19,8 +19,8 @@ namespace math {
  * mu and phi can each be a scalar or a one-dimensional container. Any
  * non-scalar inputs must be the same size.
  *
- * @tparam T_loc Type of location parameter
- * @tparam T_prec Type of precision parameter
+ * @tparam T_loc type of location parameter
+ * @tparam T_prec type of precision parameter
  * @tparam RNG type of random number generator
  * @param mu (Sequence of) positive location parameter(s)
  * @param phi (Sequence of) positive precision parameter(s)
@@ -36,9 +36,7 @@ neg_binomial_2_rng(const T_loc& mu, const T_prec& phi, RNG& rng) {
   using boost::gamma_distribution;
   using boost::random::poisson_distribution;
   using boost::variate_generator;
-
   static const char* function = "neg_binomial_2_rng";
-
   check_positive_finite(function, "Location parameter", mu);
   check_positive_finite(function, "Precision parameter", phi);
   check_consistent_sizes(function, "Location parameter", mu,

--- a/stan/math/prim/prob/neg_binomial_cdf.hpp
+++ b/stan/math/prim/prob/neg_binomial_cdf.hpp
@@ -23,19 +23,19 @@ template <typename T_n, typename T_shape, typename T_inv_scale>
 return_type_t<T_shape, T_inv_scale> neg_binomial_cdf(const T_n& n,
                                                      const T_shape& alpha,
                                                      const T_inv_scale& beta) {
-  static const char* function = "neg_binomial_cdf";
   using T_partials_return = partials_return_t<T_n, T_shape, T_inv_scale>;
+  static const char* function = "neg_binomial_cdf";
+  check_positive_finite(function, "Shape parameter", alpha);
+  check_positive_finite(function, "Inverse scale parameter", beta);
+  check_consistent_sizes(function, "Failures variable", n, "Shape parameter",
+                         alpha, "Inverse scale parameter", beta);
 
   if (size_zero(n, alpha, beta)) {
     return 1.0;
   }
 
   T_partials_return P(1.0);
-
-  check_positive_finite(function, "Shape parameter", alpha);
-  check_positive_finite(function, "Inverse scale parameter", beta);
-  check_consistent_sizes(function, "Failures variable", n, "Shape parameter",
-                         alpha, "Inverse scale parameter", beta);
+  operands_and_partials<T_shape, T_inv_scale> ops_partials(alpha, beta);
 
   scalar_seq_view<T_n> n_vec(n);
   scalar_seq_view<T_shape> alpha_vec(alpha);
@@ -43,8 +43,6 @@ return_type_t<T_shape, T_inv_scale> neg_binomial_cdf(const T_n& n,
   size_t size_alpha = stan::math::size(alpha);
   size_t size_n_alpha = max_size(n, alpha);
   size_t max_size_seq_view = max_size(n, alpha, beta);
-
-  operands_and_partials<T_shape, T_inv_scale> ops_partials(alpha, beta);
 
   // Explicit return for extreme values
   // The gradients are technically ill-defined, but treated as zero

--- a/stan/math/prim/prob/neg_binomial_lccdf.hpp
+++ b/stan/math/prim/prob/neg_binomial_lccdf.hpp
@@ -24,24 +24,21 @@ namespace math {
 template <typename T_n, typename T_shape, typename T_inv_scale>
 return_type_t<T_shape, T_inv_scale> neg_binomial_lccdf(
     const T_n& n, const T_shape& alpha, const T_inv_scale& beta) {
-  static const char* function = "neg_binomial_lccdf";
   using T_partials_return = partials_return_t<T_n, T_shape, T_inv_scale>;
-
-  if (size_zero(n, alpha, beta)) {
-    return 0.0;
-  }
-
-  T_partials_return P(0.0);
-
+  using std::exp;
+  using std::log;
+  using std::pow;
+  static const char* function = "neg_binomial_lccdf";
   check_positive_finite(function, "Shape parameter", alpha);
   check_positive_finite(function, "Inverse scale parameter", beta);
   check_consistent_sizes(function, "Failures variable", n, "Shape parameter",
                          alpha, "Inverse scale parameter", beta);
 
-  using std::exp;
-  using std::log;
-  using std::pow;
+  if (size_zero(n, alpha, beta)) {
+    return 0;
+  }
 
+  T_partials_return P(0.0);
   operands_and_partials<T_shape, T_inv_scale> ops_partials(alpha, beta);
 
   scalar_seq_view<T_n> n_vec(n);

--- a/stan/math/prim/prob/neg_binomial_lcdf.hpp
+++ b/stan/math/prim/prob/neg_binomial_lcdf.hpp
@@ -25,24 +25,21 @@ template <typename T_n, typename T_shape, typename T_inv_scale>
 return_type_t<T_shape, T_inv_scale> neg_binomial_lcdf(const T_n& n,
                                                       const T_shape& alpha,
                                                       const T_inv_scale& beta) {
-  static const char* function = "neg_binomial_lcdf";
   using T_partials_return = partials_return_t<T_n, T_shape, T_inv_scale>;
-
-  if (size_zero(n, alpha, beta)) {
-    return 0.0;
-  }
-
-  T_partials_return P(0.0);
-
+  using std::exp;
+  using std::log;
+  using std::pow;
+  static const char* function = "neg_binomial_lcdf";
   check_positive_finite(function, "Shape parameter", alpha);
   check_positive_finite(function, "Inverse scale parameter", beta);
   check_consistent_sizes(function, "Failures variable", n, "Shape parameter",
                          alpha, "Inverse scale parameter", beta);
 
-  using std::exp;
-  using std::log;
-  using std::pow;
+  if (size_zero(n, alpha, beta)) {
+    return 0;
+  }
 
+  T_partials_return P(0.0);
   operands_and_partials<T_shape, T_inv_scale> ops_partials(alpha, beta);
 
   scalar_seq_view<T_n> n_vec(n);

--- a/stan/math/prim/prob/neg_binomial_lpmf.hpp
+++ b/stan/math/prim/prob/neg_binomial_lpmf.hpp
@@ -30,25 +30,23 @@ return_type_t<T_shape, T_inv_scale> neg_binomial_lpmf(const T_n& n,
                                                       const T_shape& alpha,
                                                       const T_inv_scale& beta) {
   using T_partials_return = partials_return_t<T_n, T_shape, T_inv_scale>;
-
+  using std::log;
   static const char* function = "neg_binomial_lpmf";
-
-  if (size_zero(n, alpha, beta)) {
-    return 0.0;
-  }
-
-  T_partials_return logp(0.0);
   check_nonnegative(function, "Failures variable", n);
   check_positive_finite(function, "Shape parameter", alpha);
   check_positive_finite(function, "Inverse scale parameter", beta);
   check_consistent_sizes(function, "Failures variable", n, "Shape parameter",
                          alpha, "Inverse scale parameter", beta);
 
+  if (size_zero(n, alpha, beta)) {
+    return 0.0;
+  }
   if (!include_summand<propto, T_shape, T_inv_scale>::value) {
     return 0.0;
   }
 
-  using std::log;
+  T_partials_return logp(0.0);
+  operands_and_partials<T_shape, T_inv_scale> ops_partials(alpha, beta);
 
   scalar_seq_view<T_n> n_vec(n);
   scalar_seq_view<T_shape> alpha_vec(alpha);
@@ -57,8 +55,6 @@ return_type_t<T_shape, T_inv_scale> neg_binomial_lpmf(const T_n& n,
   size_t size_beta = stan::math::size(beta);
   size_t size_alpha_beta = max_size(alpha, beta);
   size_t max_size_seq_view = max_size(n, alpha, beta);
-
-  operands_and_partials<T_shape, T_inv_scale> ops_partials(alpha, beta);
 
   VectorBuilder<!is_constant_all<T_shape>::value, T_partials_return, T_shape>
       digamma_alpha(size_alpha);

--- a/stan/math/prim/prob/neg_binomial_rng.hpp
+++ b/stan/math/prim/prob/neg_binomial_rng.hpp
@@ -19,8 +19,8 @@ namespace math {
  * alpha and beta can each be a scalar or a one-dimensional container. Any
  * non-scalar inputs must be the same size.
  *
- * @tparam T_shape Type of shape parameter
- * @tparam T_inv Type of inverse scale parameter
+ * @tparam T_shape type of shape parameter
+ * @tparam T_inv type of inverse scale parameter
  * @tparam RNG type of random number generator
  * @param alpha (Sequence of) positive shape parameter(s)
  * @param beta (Sequence of) positive inverse scale parameter(s)
@@ -36,10 +36,7 @@ inline typename VectorBuilder<true, int, T_shape, T_inv>::type neg_binomial_rng(
   using boost::gamma_distribution;
   using boost::random::poisson_distribution;
   using boost::variate_generator;
-
   static const char* function = "neg_binomial_rng";
-
-  // gamma_rng params must be positive and finite
   check_positive_finite(function, "Shape parameter", alpha);
   check_positive_finite(function, "Inverse scale parameter", beta);
   check_consistent_sizes(function, "Shape parameter", alpha,

--- a/stan/math/prim/prob/normal_cdf.hpp
+++ b/stan/math/prim/prob/normal_cdf.hpp
@@ -22,29 +22,21 @@ namespace math {
  *
  * \f$\Phi(x) = \frac{1}{\sqrt{2 \pi}} \int_{-\inf}^x e^{-t^2/2} dt\f$.
  *
+ * @tparam T_y type of y
+ * @tparam T_loc type of mean parameter
+ * @tparam T_scale type of standard deviation parameter
  * @param y A scalar variate.
  * @param mu The location of the normal distribution.
  * @param sigma The scale of the normal distribution
  * @return The unit normal cdf evaluated at the specified arguments.
- * @tparam T_y Type of y.
- * @tparam T_loc Type of mean parameter.
- * @tparam T_scale Type of standard deviation parameter.
  */
 template <typename T_y, typename T_loc, typename T_scale>
 inline return_type_t<T_y, T_loc, T_scale> normal_cdf(const T_y& y,
                                                      const T_loc& mu,
                                                      const T_scale& sigma) {
-  static const char* function = "normal_cdf";
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale>;
-
   using std::exp;
-
-  T_partials_return cdf(1.0);
-
-  if (size_zero(y, mu, sigma)) {
-    return cdf;
-  }
-
+  static const char* function = "normal_cdf";
   check_not_nan(function, "Random variable", y);
   check_finite(function, "Location parameter", mu);
   check_not_nan(function, "Scale parameter", sigma);
@@ -52,6 +44,11 @@ inline return_type_t<T_y, T_loc, T_scale> normal_cdf(const T_y& y,
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Scale parameter", sigma);
 
+  if (size_zero(y, mu, sigma)) {
+    return 1.0;
+  }
+
+  T_partials_return cdf(1.0);
   operands_and_partials<T_y, T_loc, T_scale> ops_partials(y, mu, sigma);
 
   scalar_seq_view<T_y> y_vec(y);

--- a/stan/math/prim/prob/normal_id_glm_lpdf.hpp
+++ b/stan/math/prim/prob/normal_id_glm_lpdf.hpp
@@ -21,6 +21,7 @@ namespace math {
  * The idea is that normal_id_glm_lpdf(y, x, alpha, beta, sigma) should
  * compute a more efficient version of normal_lpdf(y, alpha + x * beta, sigma)
  * by using analytically simplified gradients.
+ *
  * @tparam T_y type of vector of dependent variables (labels);
  * @tparam T_x_scalar type of a scalar in the matrix of independent variables
  * (features)
@@ -34,6 +35,7 @@ namespace math {
  * @tparam T_scale type of the (positive) scale(s);
  * this can be a vector (of the same length as y, for heteroskedasticity)
  * or a scalar.
+ *
  * @param y scalar or vector of dependent variables. If it is a scalar it will
  * be broadcast - used for all instances.
  * @param x design matrix or row vector. If it is a row vector it will be
@@ -56,7 +58,6 @@ return_type_t<T_y, T_x_scalar, T_alpha, T_beta, T_scale> normal_id_glm_lpdf(
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using Eigen::VectorXd;
-
   using T_partials_return
       = partials_return_t<T_y, T_x_scalar, T_alpha, T_beta, T_scale>;
   using T_scale_val = typename std::conditional_t<
@@ -67,11 +68,10 @@ return_type_t<T_y, T_x_scalar, T_alpha, T_beta, T_scale> normal_id_glm_lpdf(
       typename std::conditional_t<T_x_rows == 1, T_partials_return,
                                   Array<T_partials_return, Dynamic, 1>>;
 
-  static const char *function = "normal_id_glm_lpdf";
-
   const size_t N_instances = T_x_rows == 1 ? stan::math::size(y) : x.rows();
   const size_t N_attributes = x.cols();
 
+  static const char *function = "normal_id_glm_lpdf";
   check_consistent_size(function, "Vector of dependent variables", y,
                         N_instances);
   check_consistent_size(function, "Weight vector", beta, N_attributes);
@@ -83,7 +83,6 @@ return_type_t<T_y, T_x_scalar, T_alpha, T_beta, T_scale> normal_id_glm_lpdf(
   if (size_zero(y, sigma)) {
     return 0;
   }
-
   if (!include_summand<propto, T_y, T_x_scalar, T_alpha, T_beta,
                        T_scale>::value) {
     return 0;

--- a/stan/math/prim/prob/normal_lccdf.hpp
+++ b/stan/math/prim/prob/normal_lccdf.hpp
@@ -20,17 +20,10 @@ template <typename T_y, typename T_loc, typename T_scale>
 inline return_type_t<T_y, T_loc, T_scale> normal_lccdf(const T_y& y,
                                                        const T_loc& mu,
                                                        const T_scale& sigma) {
-  static const char* function = "normal_lccdf";
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale>;
-
   using std::exp;
   using std::log;
-
-  T_partials_return ccdf_log(0.0);
-  if (size_zero(y, mu, sigma)) {
-    return ccdf_log;
-  }
-
+  static const char* function = "normal_lccdf";
   check_not_nan(function, "Random variable", y);
   check_finite(function, "Location parameter", mu);
   check_not_nan(function, "Scale parameter", sigma);
@@ -38,6 +31,11 @@ inline return_type_t<T_y, T_loc, T_scale> normal_lccdf(const T_y& y,
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Scale parameter", sigma);
 
+  if (size_zero(y, mu, sigma)) {
+    return 0;
+  }
+
+  T_partials_return ccdf_log(0.0);
   operands_and_partials<T_y, T_loc, T_scale> ops_partials(y, mu, sigma);
 
   scalar_seq_view<T_y> y_vec(y);

--- a/stan/math/prim/prob/normal_lcdf.hpp
+++ b/stan/math/prim/prob/normal_lcdf.hpp
@@ -23,19 +23,13 @@ template <typename T_y, typename T_loc, typename T_scale>
 inline return_type_t<T_y, T_loc, T_scale> normal_lcdf(const T_y& y,
                                                       const T_loc& mu,
                                                       const T_scale& sigma) {
-  static const char* function = "normal_lcdf";
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale>;
   using std::exp;
   using std::fabs;
   using std::log;
   using std::pow;
   using std::sqrt;
-
-  T_partials_return cdf_log(0.0);
-  if (size_zero(y, mu, sigma)) {
-    return cdf_log;
-  }
-
+  static const char* function = "normal_lcdf";
   check_not_nan(function, "Random variable", y);
   check_finite(function, "Location parameter", mu);
   check_not_nan(function, "Scale parameter", sigma);
@@ -43,6 +37,11 @@ inline return_type_t<T_y, T_loc, T_scale> normal_lcdf(const T_y& y,
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Scale parameter", sigma);
 
+  if (size_zero(y, mu, sigma)) {
+    return 0;
+  }
+
+  T_partials_return cdf_log(0.0);
   operands_and_partials<T_y, T_loc, T_scale> ops_partials(y, mu, sigma);
 
   scalar_seq_view<T_y> y_vec(y);

--- a/stan/math/prim/prob/normal_lpdf.hpp
+++ b/stan/math/prim/prob/normal_lpdf.hpp
@@ -22,14 +22,14 @@ namespace math {
  *
  * <p>The result log probability is defined to be the sum of the
  * log probabilities for each observation/mean/deviation triple.
- * @tparam T_y Underlying type of scalar in sequence.
- * @tparam T_loc Type of location parameter.
- * @tparam T_scale Type of scale parameter.
+ *
+ * @tparam T_y type of scalar
+ * @tparam T_loc type of location parameter
+ * @tparam T_scale type of scale parameter
  * @param y (Sequence of) scalar(s).
  * @param mu (Sequence of) location parameter(s)
  * for the normal distribution.
- * @param sigma (Sequence of) scale parameters for the normal
- * distribution.
+ * @param sigma (Sequence of) scale parameters for the normal distribution.
  * @return The log of the product of the densities.
  * @throw std::domain_error if the scale is not positive.
  */
@@ -37,26 +37,23 @@ template <bool propto, typename T_y, typename T_loc, typename T_scale>
 inline return_type_t<T_y, T_loc, T_scale> normal_lpdf(const T_y& y,
                                                       const T_loc& mu,
                                                       const T_scale& sigma) {
-  static const char* function = "normal_lpdf";
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale>;
-
   using std::log;
-
-  if (size_zero(y, mu, sigma)) {
-    return 0.0;
-  }
-
-  T_partials_return logp(0.0);
-
+  static const char* function = "normal_lpdf";
   check_not_nan(function, "Random variable", y);
   check_finite(function, "Location parameter", mu);
   check_positive(function, "Scale parameter", sigma);
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Scale parameter", sigma);
+
+  if (size_zero(y, mu, sigma)) {
+    return 0.0;
+  }
   if (!include_summand<propto, T_y, T_loc, T_scale>::value) {
     return 0.0;
   }
 
+  T_partials_return logp(0.0);
   operands_and_partials<T_y, T_loc, T_scale> ops_partials(y, mu, sigma);
 
   scalar_seq_view<T_y> y_vec(y);

--- a/stan/math/prim/prob/normal_rng.hpp
+++ b/stan/math/prim/prob/normal_rng.hpp
@@ -17,8 +17,8 @@ namespace math {
  * mu and sigma can each be a scalar or a vector. Any non-scalar
  * inputs must be the same length.
  *
- * @tparam T_loc Type of location parameter
- * @tparam T_scale Type of scale parameter
+ * @tparam T_loc type of location parameter
+ * @tparam T_scale type of scale parameter
  * @tparam RNG type of random number generator
  * @param mu (Sequence of) location parameter(s)
  * @param sigma (Sequence of) positive scale parameter(s)
@@ -34,7 +34,6 @@ inline typename VectorBuilder<true, double, T_loc, T_scale>::type normal_rng(
   using boost::normal_distribution;
   using boost::variate_generator;
   static const char* function = "normal_rng";
-
   check_finite(function, "Location parameter", mu);
   check_positive_finite(function, "Scale parameter", sigma);
   check_consistent_sizes(function, "Location parameter", mu, "Scale Parameter",

--- a/stan/math/prim/prob/normal_sufficient_lpdf.hpp
+++ b/stan/math/prim/prob/normal_sufficient_lpdf.hpp
@@ -26,11 +26,12 @@ namespace math {
  * <p>The result log probability is defined to be the sum of the
  * log probabilities for each observation/mean/deviation triple.
  *
- * @tparam T_y Type of sample average parameter.
- * @tparam T_s Type of sample squared errors parameter.
- * @tparam T_n Type of sample size parameter.
- * @tparam T_loc Type of location parameter.
- * @tparam T_scale Type of scale parameter.
+ * @tparam T_y type of sample average parameter
+ * @tparam T_s type of sample squared errors parameter
+ * @tparam T_n type of sample size parameter
+ * @tparam T_loc type of location parameter
+ * @tparam T_scale type of scale parameter
+ *
  * @param y_bar (Sequence of) scalar(s) (sample average(s)).
  * @param s_squared (Sequence of) sum(s) of sample squared errors
  * @param n_obs (Sequence of) sample size(s)
@@ -47,21 +48,10 @@ template <bool propto, typename T_y, typename T_s, typename T_n, typename T_loc,
 return_type_t<T_y, T_s, T_loc, T_scale> normal_sufficient_lpdf(
     const T_y& y_bar, const T_s& s_squared, const T_n& n_obs, const T_loc& mu,
     const T_scale& sigma) {
-  static const char* function = "normal_sufficient_lpdf";
   using T_partials_return = partials_return_t<T_y, T_s, T_n, T_loc, T_scale>;
-
   using std::log;
   using std::pow;
-
-  // check if any vectors are zero length
-  if (size_zero(y_bar, s_squared, n_obs, mu, sigma)) {
-    return 0.0;
-  }
-
-  // set up return value accumulator
-  T_partials_return logp(0.0);
-
-  // validate args (here done over var, which should be OK)
+  static const char* function = "normal_sufficient_lpdf";
   check_finite(function, "Location parameter sufficient statistic", y_bar);
   check_finite(function, "Scale parameter sufficient statistic", s_squared);
   check_nonnegative(function, "Scale parameter sufficient statistic",
@@ -75,15 +65,17 @@ return_type_t<T_y, T_s, T_loc, T_scale> normal_sufficient_lpdf(
                          y_bar, "Scale parameter sufficient statistic",
                          s_squared, "Number of observations", n_obs,
                          "Location parameter", mu, "Scale parameter", sigma);
-  // check if no variables are involved and prop-to
+
+  if (size_zero(y_bar, s_squared, n_obs, mu, sigma)) {
+    return 0.0;
+  }
   if (!include_summand<propto, T_y, T_s, T_loc, T_scale>::value) {
     return 0.0;
   }
 
-  // set up template expressions wrapping scalars into vector views
+  T_partials_return logp(0.0);
   operands_and_partials<T_y, T_s, T_loc, T_scale> ops_partials(y_bar, s_squared,
                                                                mu, sigma);
-
   scalar_seq_view<const T_y> y_bar_vec(y_bar);
   scalar_seq_view<const T_s> s_squared_vec(s_squared);
   scalar_seq_view<const T_n> n_obs_vec(n_obs);

--- a/stan/math/prim/prob/ordered_logistic_glm_lpmf.hpp
+++ b/stan/math/prim/prob/ordered_logistic_glm_lpmf.hpp
@@ -26,6 +26,7 @@ namespace math {
  * `Eigen::Dynamic` or 1.
  * @tparam T_beta_scalar type of a scalar in the vector of weights
  * @tparam T_cuts_scalar type of a scalar in the vector of cutpoints
+ *
  * @param y a scalar or vector of classes. If it is a scalar it will be
  * broadcast - used for all instances. Values should be between 1 and number of
  * classes, including endpoints.
@@ -52,18 +53,16 @@ ordered_logistic_glm_lpmf(
   using Eigen::VectorXd;
   using std::exp;
   using std::isfinite;
-
   using T_partials_return
       = partials_return_t<T_y, T_x_scalar, T_beta_scalar, T_cuts_scalar>;
   typedef typename std::conditional_t<T_x_rows == 1, double, VectorXd>
       T_location;
 
-  static const char* function = "ordered_logistic_glm_lpmf";
-
   const size_t N_instances = T_x_rows == 1 ? stan::math::size(y) : x.rows();
   const size_t N_attributes = x.cols();
   const size_t N_classes = stan::math::size(cuts) + 1;
 
+  static const char* function = "ordered_logistic_glm_lpmf";
   check_consistent_size(function, "Vector of dependent variables", y,
                         N_instances);
   check_consistent_size(function, "Weight vector", beta, N_attributes);

--- a/stan/math/prim/prob/ordered_logistic_rng.hpp
+++ b/stan/math/prim/prob/ordered_logistic_rng.hpp
@@ -14,9 +14,7 @@ template <class RNG>
 inline int ordered_logistic_rng(
     double eta, const Eigen::Matrix<double, Eigen::Dynamic, 1>& c, RNG& rng) {
   using boost::variate_generator;
-
   static const char* function = "ordered_logistic";
-
   check_finite(function, "Location parameter", eta);
   check_greater(function, "Size of cut points parameter", c.size(), 0);
   check_ordered(function, "Cut points parameter", c);

--- a/stan/math/prim/prob/ordered_probit_lpmf.hpp
+++ b/stan/math/prim/prob/ordered_probit_lpmf.hpp
@@ -21,14 +21,12 @@ namespace math {
  * will be the dot product of a vector of regression coefficients
  * and a vector of predictors for the outcome.
  *
- * @tparam propto True if calculating up to a proportion.
- * @tparam T_loc Location type.
- * @tparam T_cut Cut-point type.
+ * @tparam T_loc location type
+ * @tparam T_cut cut-point type
  * @param y Outcome.
  * @param lambda Location.
  * @param c Positive increasing vector of cutpoints.
- * @return Log probability of outcome given location and
- * cutpoints.
+ * @return Log probability of outcome given location and cutpoints.
  * @throw std::domain_error If the outcome is not between 1 and
  * the number of cutpoints plus 2; if the cutpoint vector is
  * empty; if the cutpoint vector contains a non-positive,
@@ -41,11 +39,8 @@ return_type_t<T_loc, T_cut> ordered_probit_lpmf(
     const Eigen::Matrix<T_cut, Eigen::Dynamic, 1>& c) {
   using std::exp;
   using std::log;
-
   static const char* function = "ordered_probit";
-
   int K = c.size() + 1;
-
   check_bounded(function, "Random variable", y, 1, K);
   check_finite(function, "Location parameter", lambda);
   check_greater(function, "Size of cut points parameter", c.size(), 0);
@@ -98,9 +93,6 @@ return_type_t<T_loc, T_cut> ordered_probit_lpmf(
     const std::vector<int>& y,
     const Eigen::Matrix<T_loc, Eigen::Dynamic, 1>& lambda,
     const Eigen::Matrix<T_cut, Eigen::Dynamic, 1>& c) {
-  using std::exp;
-  using std::log;
-
   static const char* function = "ordered_probit";
 
   int N = lambda.size();
@@ -113,6 +105,8 @@ return_type_t<T_loc, T_cut> ordered_probit_lpmf(
   check_greater(function, "Size of cut points parameter", c.size(), 0);
   check_finite(function, "Cut-points", c);
 
+  using std::exp;
+  using std::log;
   return_type_t<T_loc, T_cut> logp_n(0.0);
 
   for (int i = 0; i < N; ++i) {
@@ -168,13 +162,8 @@ return_type_t<T_loc, T_cut> ordered_probit_lpmf(
     const std::vector<int>& y,
     const Eigen::Matrix<T_loc, Eigen::Dynamic, 1>& lambda,
     const std::vector<Eigen::Matrix<T_cut, Eigen::Dynamic, 1> >& c) {
-  using std::exp;
-  using std::log;
-
   static const char* function = "ordered_probit";
-
   int N = lambda.size();
-
   check_consistent_sizes(function, "Integers", y, "Locations", lambda);
   check_consistent_sizes(function, "Integers", y, "Cut-points", c);
 
@@ -188,6 +177,8 @@ return_type_t<T_loc, T_cut> ordered_probit_lpmf(
   check_finite(function, "Location parameter", lambda);
   check_finite(function, "Cut-points", c);
 
+  using std::exp;
+  using std::log;
   return_type_t<T_loc, T_cut> logp_n(0.0);
 
   for (int i = 0; i < N; ++i) {

--- a/stan/math/prim/prob/ordered_probit_rng.hpp
+++ b/stan/math/prim/prob/ordered_probit_rng.hpp
@@ -12,7 +12,6 @@ namespace math {
 template <class RNG>
 inline int ordered_probit_rng(double eta, const Eigen::VectorXd& c, RNG& rng) {
   static const char* function = "ordered_probit";
-
   check_finite(function, "Location parameter", eta);
   check_greater(function, "Size of cut points parameter", c.size(), 0);
   check_ordered(function, "Cut points vector", c);

--- a/stan/math/prim/prob/pareto_cdf.hpp
+++ b/stan/math/prim/prob/pareto_cdf.hpp
@@ -20,18 +20,9 @@ return_type_t<T_y, T_scale, T_shape> pareto_cdf(const T_y& y,
                                                 const T_scale& y_min,
                                                 const T_shape& alpha) {
   using T_partials_return = partials_return_t<T_y, T_scale, T_shape>;
-
-  if (size_zero(y, y_min, alpha)) {
-    return 1.0;
-  }
-
-  static const char* function = "pareto_cdf";
-
   using std::exp;
   using std::log;
-
-  T_partials_return P(1.0);
-
+  static const char* function = "pareto_cdf";
   check_not_nan(function, "Random variable", y);
   check_nonnegative(function, "Random variable", y);
   check_positive_finite(function, "Scale parameter", y_min);
@@ -39,12 +30,17 @@ return_type_t<T_y, T_scale, T_shape> pareto_cdf(const T_y& y,
   check_consistent_sizes(function, "Random variable", y, "Scale parameter",
                          y_min, "Shape parameter", alpha);
 
+  if (size_zero(y, y_min, alpha)) {
+    return 1.0;
+  }
+
+  T_partials_return P(1.0);
+  operands_and_partials<T_y, T_scale, T_shape> ops_partials(y, y_min, alpha);
+
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_scale> y_min_vec(y_min);
   scalar_seq_view<T_shape> alpha_vec(alpha);
   size_t N = max_size(y, y_min, alpha);
-
-  operands_and_partials<T_y, T_scale, T_shape> ops_partials(y, y_min, alpha);
 
   // Explicit return for extreme values
   // The gradients are technically ill-defined, but treated as zero

--- a/stan/math/prim/prob/pareto_lccdf.hpp
+++ b/stan/math/prim/prob/pareto_lccdf.hpp
@@ -20,18 +20,9 @@ return_type_t<T_y, T_scale, T_shape> pareto_lccdf(const T_y& y,
                                                   const T_scale& y_min,
                                                   const T_shape& alpha) {
   using T_partials_return = partials_return_t<T_y, T_scale, T_shape>;
-
-  if (size_zero(y, y_min, alpha)) {
-    return 0.0;
-  }
-
-  static const char* function = "pareto_lccdf";
-
   using std::exp;
   using std::log;
-
-  T_partials_return P(0.0);
-
+  static const char* function = "pareto_lccdf";
   check_not_nan(function, "Random variable", y);
   check_nonnegative(function, "Random variable", y);
   check_positive_finite(function, "Scale parameter", y_min);
@@ -39,12 +30,17 @@ return_type_t<T_y, T_scale, T_shape> pareto_lccdf(const T_y& y,
   check_consistent_sizes(function, "Random variable", y, "Scale parameter",
                          y_min, "Shape parameter", alpha);
 
+  if (size_zero(y, y_min, alpha)) {
+    return 0;
+  }
+
+  T_partials_return P(0.0);
+  operands_and_partials<T_y, T_scale, T_shape> ops_partials(y, y_min, alpha);
+
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_scale> y_min_vec(y_min);
   scalar_seq_view<T_shape> alpha_vec(alpha);
   size_t N = max_size(y, y_min, alpha);
-
-  operands_and_partials<T_y, T_scale, T_shape> ops_partials(y, y_min, alpha);
 
   // Explicit return for extreme values
   // The gradients are technically ill-defined, but treated as zero

--- a/stan/math/prim/prob/pareto_lcdf.hpp
+++ b/stan/math/prim/prob/pareto_lcdf.hpp
@@ -20,18 +20,9 @@ return_type_t<T_y, T_scale, T_shape> pareto_lcdf(const T_y& y,
                                                  const T_scale& y_min,
                                                  const T_shape& alpha) {
   using T_partials_return = partials_return_t<T_y, T_scale, T_shape>;
-
-  if (size_zero(y, y_min, alpha)) {
-    return 0.0;
-  }
-
-  static const char* function = "pareto_lcdf";
-
   using std::exp;
   using std::log;
-
-  T_partials_return P(0.0);
-
+  static const char* function = "pareto_lcdf";
   check_not_nan(function, "Random variable", y);
   check_nonnegative(function, "Random variable", y);
   check_positive_finite(function, "Scale parameter", y_min);
@@ -39,12 +30,17 @@ return_type_t<T_y, T_scale, T_shape> pareto_lcdf(const T_y& y,
   check_consistent_sizes(function, "Random variable", y, "Scale parameter",
                          y_min, "Shape parameter", alpha);
 
+  if (size_zero(y, y_min, alpha)) {
+    return 0;
+  }
+
+  T_partials_return P(0.0);
+  operands_and_partials<T_y, T_scale, T_shape> ops_partials(y, y_min, alpha);
+
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_scale> y_min_vec(y_min);
   scalar_seq_view<T_shape> alpha_vec(alpha);
   size_t N = max_size(y, y_min, alpha);
-
-  operands_and_partials<T_y, T_scale, T_shape> ops_partials(y, y_min, alpha);
 
   // Explicit return for extreme values
   // The gradients are technically ill-defined, but treated as zero

--- a/stan/math/prim/prob/pareto_lpdf.hpp
+++ b/stan/math/prim/prob/pareto_lpdf.hpp
@@ -19,23 +19,24 @@ template <bool propto, typename T_y, typename T_scale, typename T_shape>
 return_type_t<T_y, T_scale, T_shape> pareto_lpdf(const T_y& y,
                                                  const T_scale& y_min,
                                                  const T_shape& alpha) {
-  static const char* function = "pareto_lpdf";
   using T_partials_return = partials_return_t<T_y, T_scale, T_shape>;
   using std::log;
+  static const char* function = "pareto_lpdf";
   check_not_nan(function, "Random variable", y);
   check_positive_finite(function, "Scale parameter", y_min);
   check_positive_finite(function, "Shape parameter", alpha);
   check_consistent_sizes(function, "Random variable", y, "Scale parameter",
                          y_min, "Shape parameter", alpha);
+
   if (size_zero(y, y_min, alpha)) {
     return 0;
   }
-
   if (!include_summand<propto, T_y, T_scale, T_shape>::value) {
     return 0;
   }
 
   T_partials_return logp(0);
+  operands_and_partials<T_y, T_scale, T_shape> ops_partials(y, y_min, alpha);
 
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_scale> y_min_vec(y_min);
@@ -47,8 +48,6 @@ return_type_t<T_y, T_scale, T_shape> pareto_lpdf(const T_y& y,
       return LOG_ZERO;
     }
   }
-
-  operands_and_partials<T_y, T_scale, T_shape> ops_partials(y, y_min, alpha);
 
   VectorBuilder<include_summand<propto, T_y, T_shape>::value, T_partials_return,
                 T_y>

--- a/stan/math/prim/prob/pareto_rng.hpp
+++ b/stan/math/prim/prob/pareto_rng.hpp
@@ -18,8 +18,8 @@ namespace math {
  * y_min and alpha can each be a scalar or a one-dimensional container. Any
  * non-scalar inputs must be the same size.
  *
- * @tparam T_scale Type of scale parameter
- * @tparam T_shape Type of shape parameter
+ * @tparam T_scale type of scale parameter
+ * @tparam T_shape type of shape parameter
  * @tparam RNG type of random number generator
  * @param y_min (Sequence of) positive scale parameter(s)
  * @param alpha (Sequence of) positive shape parameter(s)
@@ -34,9 +34,7 @@ inline typename VectorBuilder<true, double, T_shape, T_scale>::type pareto_rng(
     const T_scale& y_min, const T_shape& alpha, RNG& rng) {
   using boost::exponential_distribution;
   using boost::variate_generator;
-
   static const char* function = "pareto_rng";
-
   check_positive_finite(function, "Scale parameter", y_min);
   check_positive_finite(function, "Shape parameter", alpha);
   check_consistent_sizes(function, "Scale Parameter", y_min, "Shape parameter",

--- a/stan/math/prim/prob/pareto_type_2_cdf.hpp
+++ b/stan/math/prim/prob/pareto_type_2_cdf.hpp
@@ -18,17 +18,9 @@ return_type_t<T_y, T_loc, T_scale, T_shape> pareto_type_2_cdf(
     const T_y& y, const T_loc& mu, const T_scale& lambda,
     const T_shape& alpha) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale, T_shape>;
-  static const char* function = "pareto_type_2_cdf";
-
-  if (size_zero(y, mu, lambda, alpha)) {
-    return 1.0;
-  }
-
   using std::log;
   using std::pow;
-
-  T_partials_return P(1.0);
-
+  static const char* function = "pareto_type_2_cdf";
   check_not_nan(function, "Random variable", y);
   check_nonnegative(function, "Random variable", y);
   check_positive_finite(function, "Scale parameter", lambda);
@@ -38,14 +30,19 @@ return_type_t<T_y, T_loc, T_scale, T_shape> pareto_type_2_cdf(
                          alpha);
   check_greater_or_equal(function, "Random variable", y, mu);
 
+  if (size_zero(y, mu, lambda, alpha)) {
+    return 1.0;
+  }
+
+  T_partials_return P(1.0);
+  operands_and_partials<T_y, T_loc, T_scale, T_shape> ops_partials(
+      y, mu, lambda, alpha);
+
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_loc> mu_vec(mu);
   scalar_seq_view<T_scale> lambda_vec(lambda);
   scalar_seq_view<T_shape> alpha_vec(alpha);
   size_t N = max_size(y, mu, lambda, alpha);
-
-  operands_and_partials<T_y, T_loc, T_scale, T_shape> ops_partials(
-      y, mu, lambda, alpha);
 
   for (size_t n = 0; n < N; n++) {
     const T_partials_return y_dbl = value_of(y_vec[n]);

--- a/stan/math/prim/prob/pareto_type_2_lccdf.hpp
+++ b/stan/math/prim/prob/pareto_type_2_lccdf.hpp
@@ -17,16 +17,8 @@ return_type_t<T_y, T_loc, T_scale, T_shape> pareto_type_2_lccdf(
     const T_y& y, const T_loc& mu, const T_scale& lambda,
     const T_shape& alpha) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale, T_shape>;
-  static const char* function = "pareto_type_2_lccdf";
-
-  if (size_zero(y, mu, lambda, alpha)) {
-    return 0.0;
-  }
-
   using std::log;
-
-  T_partials_return P(0.0);
-
+  static const char* function = "pareto_type_2_lccdf";
   check_not_nan(function, "Random variable", y);
   check_nonnegative(function, "Random variable", y);
   check_positive_finite(function, "Scale parameter", lambda);
@@ -36,14 +28,19 @@ return_type_t<T_y, T_loc, T_scale, T_shape> pareto_type_2_lccdf(
                          alpha);
   check_greater_or_equal(function, "Random variable", y, mu);
 
+  if (size_zero(y, mu, lambda, alpha)) {
+    return 0;
+  }
+
+  T_partials_return P(0.0);
+  operands_and_partials<T_y, T_loc, T_scale, T_shape> ops_partials(
+      y, mu, lambda, alpha);
+
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_loc> mu_vec(mu);
   scalar_seq_view<T_scale> lambda_vec(lambda);
   scalar_seq_view<T_shape> alpha_vec(alpha);
   size_t N = max_size(y, mu, lambda, alpha);
-
-  operands_and_partials<T_y, T_loc, T_scale, T_shape> ops_partials(
-      y, mu, lambda, alpha);
 
   for (size_t n = 0; n < N; n++) {
     const T_partials_return y_dbl = value_of(y_vec[n]);

--- a/stan/math/prim/prob/pareto_type_2_lcdf.hpp
+++ b/stan/math/prim/prob/pareto_type_2_lcdf.hpp
@@ -18,17 +18,9 @@ return_type_t<T_y, T_loc, T_scale, T_shape> pareto_type_2_lcdf(
     const T_y& y, const T_loc& mu, const T_scale& lambda,
     const T_shape& alpha) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale, T_shape>;
-  static const char* function = "pareto_type_2_lcdf";
-
-  if (size_zero(y, mu, lambda, alpha)) {
-    return 0.0;
-  }
-
   using std::log;
   using std::pow;
-
-  T_partials_return P(0.0);
-
+  static const char* function = "pareto_type_2_lcdf";
   check_not_nan(function, "Random variable", y);
   check_nonnegative(function, "Random variable", y);
   check_positive_finite(function, "Scale parameter", lambda);
@@ -38,14 +30,19 @@ return_type_t<T_y, T_loc, T_scale, T_shape> pareto_type_2_lcdf(
                          alpha);
   check_greater_or_equal(function, "Random variable", y, mu);
 
+  if (size_zero(y, mu, lambda, alpha)) {
+    return 0;
+  }
+
+  T_partials_return P(0.0);
+  operands_and_partials<T_y, T_loc, T_scale, T_shape> ops_partials(
+      y, mu, lambda, alpha);
+
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_loc> mu_vec(mu);
   scalar_seq_view<T_scale> lambda_vec(lambda);
   scalar_seq_view<T_shape> alpha_vec(alpha);
   size_t N = max_size(y, mu, lambda, alpha);
-
-  operands_and_partials<T_y, T_loc, T_scale, T_shape> ops_partials(
-      y, mu, lambda, alpha);
 
   for (size_t n = 0; n < N; n++) {
     const T_partials_return y_dbl = value_of(y_vec[n]);

--- a/stan/math/prim/prob/pareto_type_2_lpdf.hpp
+++ b/stan/math/prim/prob/pareto_type_2_lpdf.hpp
@@ -20,17 +20,9 @@ template <bool propto, typename T_y, typename T_loc, typename T_scale,
 return_type_t<T_y, T_loc, T_scale, T_shape> pareto_type_2_lpdf(
     const T_y& y, const T_loc& mu, const T_scale& lambda,
     const T_shape& alpha) {
-  static const char* function = "pareto_type_2_lpdf";
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale, T_shape>;
-
   using std::log;
-
-  if (size_zero(y, mu, lambda, alpha)) {
-    return 0.0;
-  }
-
-  T_partials_return logp(0.0);
-
+  static const char* function = "pareto_type_2_lpdf";
   check_not_nan(function, "Random variable", y);
   check_positive_finite(function, "Scale parameter", lambda);
   check_positive_finite(function, "Shape parameter", alpha);
@@ -39,18 +31,22 @@ return_type_t<T_y, T_loc, T_scale, T_shape> pareto_type_2_lpdf(
                          alpha);
   check_greater_or_equal(function, "Random variable", y, mu);
 
+  if (size_zero(y, mu, lambda, alpha)) {
+    return 0.0;
+  }
   if (!include_summand<propto, T_y, T_loc, T_scale, T_shape>::value) {
     return 0.0;
   }
+
+  T_partials_return logp(0.0);
+  operands_and_partials<T_y, T_loc, T_scale, T_shape> ops_partials(
+      y, mu, lambda, alpha);
 
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_loc> mu_vec(mu);
   scalar_seq_view<T_scale> lambda_vec(lambda);
   scalar_seq_view<T_shape> alpha_vec(alpha);
   size_t N = max_size(y, mu, lambda, alpha);
-
-  operands_and_partials<T_y, T_loc, T_scale, T_shape> ops_partials(
-      y, mu, lambda, alpha);
 
   VectorBuilder<include_summand<propto, T_scale>::value, T_partials_return,
                 T_scale>

--- a/stan/math/prim/prob/pareto_type_2_rng.hpp
+++ b/stan/math/prim/prob/pareto_type_2_rng.hpp
@@ -20,10 +20,11 @@ namespace math {
  * mu, lambda, and alpha can each be a scalar or a one-dimensional container.
  * Any non-scalar inputs must be the same size.
  *
- * @tparam T_loc Type of location parameter
- * @tparam T_scale Type of scale parameter
- * @tparam T_shape Type of shape parameter
+ * @tparam T_loc type of location parameter
+ * @tparam T_scale type of scale parameter
+ * @tparam T_shape type of shape parameter
  * @tparam RNG type of random number generator
+ *
  * @param mu (Sequence of) location parameter(s)
  * @param lambda (Sequence of) scale parameter(s)
  * @param alpha (Sequence of) shape parameter(s)
@@ -41,7 +42,6 @@ pareto_type_2_rng(const T_loc& mu, const T_scale& lambda, const T_shape& alpha,
   using boost::random::uniform_real_distribution;
   using boost::variate_generator;
   static const char* function = "pareto_type_2_rng";
-
   check_finite(function, "Location parameter", mu);
   check_positive_finite(function, "Scale parameter", lambda);
   check_positive_finite(function, "Shape parameter", alpha);

--- a/stan/math/prim/prob/poisson_cdf.hpp
+++ b/stan/math/prim/prob/poisson_cdf.hpp
@@ -19,23 +19,20 @@ namespace math {
 // Poisson CDF
 template <typename T_n, typename T_rate>
 return_type_t<T_rate> poisson_cdf(const T_n& n, const T_rate& lambda) {
-  static const char* function = "poisson_cdf";
   using T_partials_return = partials_return_t<T_n, T_rate>;
+  using std::exp;
+  using std::pow;
+  static const char* function = "poisson_cdf";
+  check_not_nan(function, "Rate parameter", lambda);
+  check_nonnegative(function, "Rate parameter", lambda);
+  check_consistent_sizes(function, "Random variable", n, "Rate parameter",
+                         lambda);
 
   if (size_zero(n, lambda)) {
     return 1.0;
   }
 
   T_partials_return P(1.0);
-
-  check_not_nan(function, "Rate parameter", lambda);
-  check_nonnegative(function, "Rate parameter", lambda);
-  check_consistent_sizes(function, "Random variable", n, "Rate parameter",
-                         lambda);
-
-  using std::exp;
-  using std::pow;
-
   operands_and_partials<T_rate> ops_partials(lambda);
 
   scalar_seq_view<T_n> n_vec(n);

--- a/stan/math/prim/prob/poisson_lccdf.hpp
+++ b/stan/math/prim/prob/poisson_lccdf.hpp
@@ -20,23 +20,20 @@ namespace math {
 
 template <typename T_n, typename T_rate>
 return_type_t<T_rate> poisson_lccdf(const T_n& n, const T_rate& lambda) {
-  static const char* function = "poisson_lccdf";
   using T_partials_return = partials_return_t<T_n, T_rate>;
-
-  if (size_zero(n, lambda)) {
-    return 0.0;
-  }
-
-  T_partials_return P(0.0);
-
+  using std::exp;
+  using std::log;
+  static const char* function = "poisson_lccdf";
   check_not_nan(function, "Rate parameter", lambda);
   check_nonnegative(function, "Rate parameter", lambda);
   check_consistent_sizes(function, "Random variable", n, "Rate parameter",
                          lambda);
 
-  using std::exp;
-  using std::log;
+  if (size_zero(n, lambda)) {
+    return 0;
+  }
 
+  T_partials_return P(0.0);
   operands_and_partials<T_rate> ops_partials(lambda);
 
   scalar_seq_view<T_n> n_vec(n);

--- a/stan/math/prim/prob/poisson_lcdf.hpp
+++ b/stan/math/prim/prob/poisson_lcdf.hpp
@@ -20,23 +20,20 @@ namespace math {
 
 template <typename T_n, typename T_rate>
 return_type_t<T_rate> poisson_lcdf(const T_n& n, const T_rate& lambda) {
-  static const char* function = "poisson_lcdf";
   using T_partials_return = partials_return_t<T_n, T_rate>;
-
-  if (size_zero(n, lambda)) {
-    return 0.0;
-  }
-
-  T_partials_return P(0.0);
-
+  using std::exp;
+  using std::log;
+  static const char* function = "poisson_lcdf";
   check_not_nan(function, "Rate parameter", lambda);
   check_nonnegative(function, "Rate parameter", lambda);
   check_consistent_sizes(function, "Random variable", n, "Rate parameter",
                          lambda);
 
-  using std::exp;
-  using std::log;
+  if (size_zero(n, lambda)) {
+    return 0;
+  }
 
+  T_partials_return P(0.0);
   operands_and_partials<T_rate> ops_partials(lambda);
 
   scalar_seq_view<T_n> n_vec(n);

--- a/stan/math/prim/prob/poisson_log_glm_lpmf.hpp
+++ b/stan/math/prim/prob/poisson_log_glm_lpmf.hpp
@@ -21,6 +21,7 @@ namespace math {
  * compute a more efficient version of poisson_log_lpmf(y, alpha + x * beta)
  * by using analytically simplified gradients.
  * If containers are supplied, returns the log sum of the probabilities.
+ *
  * @tparam T_y type of vector of variates (labels), integers >=0;
  * this can also be a single positive integer;
  * @tparam T_x_scalar type of a scalar in the matrix of independent variables
@@ -48,8 +49,6 @@ template <bool propto, typename T_y, typename T_x_scalar, int T_x_rows,
 return_type_t<T_x_scalar, T_alpha, T_beta> poisson_log_glm_lpmf(
     const T_y& y, const Eigen::Matrix<T_x_scalar, T_x_rows, Eigen::Dynamic>& x,
     const T_alpha& alpha, const T_beta& beta) {
-  static const char* function = "poisson_log_glm_lpmf";
-
   using Eigen::Array;
   using Eigen::Dynamic;
   using Eigen::Matrix;
@@ -66,6 +65,7 @@ return_type_t<T_x_scalar, T_alpha, T_beta> poisson_log_glm_lpmf(
   const size_t N_instances = T_x_rows == 1 ? stan::math::size(y) : x.rows();
   const size_t N_attributes = x.cols();
 
+  static const char* function = "poisson_log_glm_lpmf";
   check_consistent_size(function, "Vector of dependent variables", y,
                         N_instances);
   check_consistent_size(function, "Weight vector", beta, N_attributes);

--- a/stan/math/prim/prob/poisson_log_lpmf.hpp
+++ b/stan/math/prim/prob/poisson_log_lpmf.hpp
@@ -20,25 +20,22 @@ template <bool propto, typename T_n, typename T_log_rate>
 return_type_t<T_log_rate> poisson_log_lpmf(const T_n& n,
                                            const T_log_rate& alpha) {
   using T_partials_return = partials_return_t<T_n, T_log_rate>;
-
-  static const char* function = "poisson_log_lpmf";
-
   using std::exp;
-
-  if (size_zero(n, alpha)) {
-    return 0.0;
-  }
-
-  T_partials_return logp(0.0);
-
+  static const char* function = "poisson_log_lpmf";
   check_nonnegative(function, "Random variable", n);
   check_not_nan(function, "Log rate parameter", alpha);
   check_consistent_sizes(function, "Random variable", n, "Log rate parameter",
                          alpha);
 
+  if (size_zero(n, alpha)) {
+    return 0.0;
+  }
   if (!include_summand<propto, T_log_rate>::value) {
     return 0.0;
   }
+
+  T_partials_return logp(0.0);
+  operands_and_partials<T_log_rate> ops_partials(alpha);
 
   scalar_seq_view<T_n> n_vec(n);
   scalar_seq_view<T_log_rate> alpha_vec(alpha);
@@ -55,8 +52,6 @@ return_type_t<T_log_rate> poisson_log_lpmf(const T_n& n,
       return LOG_ZERO;
     }
   }
-
-  operands_and_partials<T_log_rate> ops_partials(alpha);
 
   VectorBuilder<include_summand<propto>::value, T_partials_return, T_n>
       lgamma_n_plus_one(size(n));

--- a/stan/math/prim/prob/poisson_log_rng.hpp
+++ b/stan/math/prim/prob/poisson_log_rng.hpp
@@ -30,10 +30,8 @@ inline typename VectorBuilder<true, int, T_rate>::type poisson_log_rng(
     const T_rate& alpha, RNG& rng) {
   using boost::random::poisson_distribution;
   using boost::variate_generator;
-
   static const char* function = "poisson_log_rng";
   static const double POISSON_MAX_LOG_RATE = 30 * LOG_TWO;
-
   check_finite(function, "Log rate parameter", alpha);
   check_less(function, "Log rate parameter", alpha, POISSON_MAX_LOG_RATE);
 

--- a/stan/math/prim/prob/poisson_lpmf.hpp
+++ b/stan/math/prim/prob/poisson_lpmf.hpp
@@ -19,24 +19,22 @@ namespace math {
 template <bool propto, typename T_n, typename T_rate>
 return_type_t<T_rate> poisson_lpmf(const T_n& n, const T_rate& lambda) {
   using T_partials_return = partials_return_t<T_n, T_rate>;
-
   static const char* function = "poisson_lpmf";
-
-  if (size_zero(n, lambda)) {
-    return 0.0;
-  }
-
-  T_partials_return logp(0.0);
-
   check_nonnegative(function, "Random variable", n);
   check_not_nan(function, "Rate parameter", lambda);
   check_nonnegative(function, "Rate parameter", lambda);
   check_consistent_sizes(function, "Random variable", n, "Rate parameter",
                          lambda);
 
+  if (size_zero(n, lambda)) {
+    return 0.0;
+  }
   if (!include_summand<propto, T_rate>::value) {
     return 0.0;
   }
+
+  T_partials_return logp(0.0);
+  operands_and_partials<T_rate> ops_partials(lambda);
 
   scalar_seq_view<T_n> n_vec(n);
   scalar_seq_view<T_rate> lambda_vec(lambda);
@@ -53,8 +51,6 @@ return_type_t<T_rate> poisson_lpmf(const T_n& n, const T_rate& lambda) {
       return LOG_ZERO;
     }
   }
-
-  operands_and_partials<T_rate> ops_partials(lambda);
 
   VectorBuilder<include_summand<propto>::value, T_partials_return, T_n>
       lgamma_n_plus_one(size(n));

--- a/stan/math/prim/prob/poisson_rng.hpp
+++ b/stan/math/prim/prob/poisson_rng.hpp
@@ -29,9 +29,7 @@ inline typename VectorBuilder<true, int, T_rate>::type poisson_rng(
     const T_rate& lambda, RNG& rng) {
   using boost::random::poisson_distribution;
   using boost::variate_generator;
-
   static const char* function = "poisson_rng";
-
   check_not_nan(function, "Rate parameter", lambda);
   check_positive(function, "Rate parameter", lambda);
   check_less(function, "Rate parameter", lambda, POISSON_MAX_RATE);

--- a/stan/math/prim/prob/rayleigh_cdf.hpp
+++ b/stan/math/prim/prob/rayleigh_cdf.hpp
@@ -16,17 +16,9 @@ namespace math {
 
 template <typename T_y, typename T_scale>
 return_type_t<T_y, T_scale> rayleigh_cdf(const T_y& y, const T_scale& sigma) {
-  static const char* function = "rayleigh_cdf";
   using T_partials_return = partials_return_t<T_y, T_scale>;
-
   using std::exp;
-
-  T_partials_return cdf(1.0);
-
-  if (size_zero(y, sigma)) {
-    return cdf;
-  }
-
+  static const char* function = "rayleigh_cdf";
   check_not_nan(function, "Random variable", y);
   check_nonnegative(function, "Random variable", y);
   check_not_nan(function, "Scale parameter", sigma);
@@ -34,6 +26,11 @@ return_type_t<T_y, T_scale> rayleigh_cdf(const T_y& y, const T_scale& sigma) {
   check_consistent_sizes(function, "Random variable", y, "Scale parameter",
                          sigma);
 
+  if (size_zero(y, sigma)) {
+    return 1.0;
+  }
+
+  T_partials_return cdf(1.0);
   operands_and_partials<T_y, T_scale> ops_partials(y, sigma);
 
   scalar_seq_view<T_y> y_vec(y);

--- a/stan/math/prim/prob/rayleigh_lccdf.hpp
+++ b/stan/math/prim/prob/rayleigh_lccdf.hpp
@@ -14,15 +14,8 @@ namespace math {
 
 template <typename T_y, typename T_scale>
 return_type_t<T_y, T_scale> rayleigh_lccdf(const T_y& y, const T_scale& sigma) {
-  static const char* function = "rayleigh_lccdf";
   using T_partials_return = partials_return_t<T_y, T_scale>;
-
-  T_partials_return ccdf_log(0.0);
-
-  if (size_zero(y, sigma)) {
-    return ccdf_log;
-  }
-
+  static const char* function = "rayleigh_lccdf";
   check_not_nan(function, "Random variable", y);
   check_nonnegative(function, "Random variable", y);
   check_not_nan(function, "Scale parameter", sigma);
@@ -30,6 +23,11 @@ return_type_t<T_y, T_scale> rayleigh_lccdf(const T_y& y, const T_scale& sigma) {
   check_consistent_sizes(function, "Random variable", y, "Scale parameter",
                          sigma);
 
+  if (size_zero(y, sigma)) {
+    return 0;
+  }
+
+  T_partials_return ccdf_log(0.0);
   operands_and_partials<T_y, T_scale> ops_partials(y, sigma);
 
   scalar_seq_view<T_y> y_vec(y);

--- a/stan/math/prim/prob/rayleigh_lcdf.hpp
+++ b/stan/math/prim/prob/rayleigh_lcdf.hpp
@@ -16,17 +16,9 @@ namespace math {
 
 template <typename T_y, typename T_scale>
 return_type_t<T_y, T_scale> rayleigh_lcdf(const T_y& y, const T_scale& sigma) {
-  static const char* function = "rayleigh_lcdf";
   using T_partials_return = partials_return_t<T_y, T_scale>;
-
   using std::exp;
-
-  T_partials_return cdf_log(0.0);
-
-  if (size_zero(y, sigma)) {
-    return cdf_log;
-  }
-
+  static const char* function = "rayleigh_lcdf";
   check_not_nan(function, "Random variable", y);
   check_nonnegative(function, "Random variable", y);
   check_not_nan(function, "Scale parameter", sigma);
@@ -34,6 +26,11 @@ return_type_t<T_y, T_scale> rayleigh_lcdf(const T_y& y, const T_scale& sigma) {
   check_consistent_sizes(function, "Random variable", y, "Scale parameter",
                          sigma);
 
+  if (size_zero(y, sigma)) {
+    return 0;
+  }
+
+  T_partials_return cdf_log(0.0);
   operands_and_partials<T_y, T_scale> ops_partials(y, sigma);
 
   scalar_seq_view<T_y> y_vec(y);

--- a/stan/math/prim/prob/rayleigh_lpdf.hpp
+++ b/stan/math/prim/prob/rayleigh_lpdf.hpp
@@ -16,27 +16,23 @@ namespace math {
 
 template <bool propto, typename T_y, typename T_scale>
 return_type_t<T_y, T_scale> rayleigh_lpdf(const T_y& y, const T_scale& sigma) {
-  static const char* function = "rayleigh_lpdf";
   using T_partials_return = partials_return_t<T_y, T_scale>;
-
   using std::log;
-
-  if (size_zero(y, sigma)) {
-    return 0.0;
-  }
-
-  T_partials_return logp(0.0);
-
+  static const char* function = "rayleigh_lpdf";
   check_not_nan(function, "Random variable", y);
   check_positive(function, "Scale parameter", sigma);
   check_positive(function, "Random variable", y);
   check_consistent_sizes(function, "Random variable", y, "Scale parameter",
                          sigma);
 
+  if (size_zero(y, sigma)) {
+    return 0.0;
+  }
   if (!include_summand<propto, T_y, T_scale>::value) {
     return 0.0;
   }
 
+  T_partials_return logp(0.0);
   operands_and_partials<T_y, T_scale> ops_partials(y, sigma);
 
   scalar_seq_view<T_y> y_vec(y);

--- a/stan/math/prim/prob/rayleigh_rng.hpp
+++ b/stan/math/prim/prob/rayleigh_rng.hpp
@@ -29,9 +29,7 @@ inline typename VectorBuilder<true, double, T_scale>::type rayleigh_rng(
     const T_scale& sigma, RNG& rng) {
   using boost::random::uniform_real_distribution;
   using boost::variate_generator;
-
   static const char* function = "rayleigh_rng";
-
   check_positive_finite(function, "Scale parameter", sigma);
 
   scalar_seq_view<T_scale> sigma_vec(sigma);

--- a/stan/math/prim/prob/scaled_inv_chi_square_lcdf.hpp
+++ b/stan/math/prim/prob/scaled_inv_chi_square_lcdf.hpp
@@ -23,15 +23,10 @@ template <typename T_y, typename T_dof, typename T_scale>
 return_type_t<T_y, T_dof, T_scale> scaled_inv_chi_square_lcdf(
     const T_y& y, const T_dof& nu, const T_scale& s) {
   using T_partials_return = partials_return_t<T_y, T_dof, T_scale>;
-
-  if (size_zero(y, nu, s)) {
-    return 0.0;
-  }
-
+  using std::exp;
+  using std::log;
+  using std::pow;
   static const char* function = "scaled_inv_chi_square_lcdf";
-
-  T_partials_return P(0.0);
-
   check_not_nan(function, "Random variable", y);
   check_nonnegative(function, "Random variable", y);
   check_positive_finite(function, "Degrees of freedom parameter", nu);
@@ -40,12 +35,17 @@ return_type_t<T_y, T_dof, T_scale> scaled_inv_chi_square_lcdf(
                          "Degrees of freedom parameter", nu, "Scale parameter",
                          s);
 
+  if (size_zero(y, nu, s)) {
+    return 0;
+  }
+
+  T_partials_return P(0.0);
+  operands_and_partials<T_y, T_dof, T_scale> ops_partials(y, nu, s);
+
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_dof> nu_vec(nu);
   scalar_seq_view<T_scale> s_vec(s);
   size_t N = max_size(y, nu, s);
-
-  operands_and_partials<T_y, T_dof, T_scale> ops_partials(y, nu, s);
 
   // Explicit return for extreme values
   // The gradients are technically ill-defined, but treated as zero
@@ -54,10 +54,6 @@ return_type_t<T_y, T_dof, T_scale> scaled_inv_chi_square_lcdf(
       return ops_partials.build(negative_infinity());
     }
   }
-
-  using std::exp;
-  using std::log;
-  using std::pow;
 
   VectorBuilder<!is_constant_all<T_dof>::value, T_partials_return, T_dof>
       gamma_vec(size(nu));

--- a/stan/math/prim/prob/scaled_inv_chi_square_lpdf.hpp
+++ b/stan/math/prim/prob/scaled_inv_chi_square_lpdf.hpp
@@ -28,34 +28,39 @@ namespace math {
  &=& \frac{\nu}{2} \log(\frac{\nu}{2}) - \log (\Gamma (\nu / 2)) + \nu \log(s) -
  (\frac{\nu}{2} + 1) \log(y) - \frac{\nu s^2}{2y} \\ & & \mathrm{ where } \; y >
  0 \f}
+ *
+ * @tparam T_y type of scalar
+ * @tparam T_dof type of degrees of freedom
  * @param y A scalar variable.
  * @param nu Degrees of freedom.
  * @param s Scale parameter.
  * @throw std::domain_error if nu is not greater than 0
  * @throw std::domain_error if s is not greater than 0.
  * @throw std::domain_error if y is not greater than 0.
- * @tparam T_y Type of scalar.
- * @tparam T_dof Type of degrees of freedom.
  */
 template <bool propto, typename T_y, typename T_dof, typename T_scale>
 return_type_t<T_y, T_dof, T_scale> scaled_inv_chi_square_lpdf(
     const T_y& y, const T_dof& nu, const T_scale& s) {
-  static const char* function = "scaled_inv_chi_square_lpdf";
   using T_partials_return = partials_return_t<T_y, T_dof, T_scale>;
-
+  using std::log;
+  static const char* function = "scaled_inv_chi_square_lpdf";
   check_not_nan(function, "Random variable", y);
   check_positive_finite(function, "Degrees of freedom parameter", nu);
   check_positive_finite(function, "Scale parameter", s);
   check_consistent_sizes(function, "Random variable", y,
                          "Degrees of freedom parameter", nu, "Scale parameter",
                          s);
+
   if (size_zero(y, nu, s)) {
     return 0;
   }
   if (!include_summand<propto, T_y, T_dof, T_scale>::value) {
     return 0;
   }
+
   T_partials_return logp(0);
+  operands_and_partials<T_y, T_dof, T_scale> ops_partials(y, nu, s);
+
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_dof> nu_vec(nu);
   scalar_seq_view<T_scale> s_vec(s);
@@ -66,8 +71,6 @@ return_type_t<T_y, T_dof, T_scale> scaled_inv_chi_square_lpdf(
       return LOG_ZERO;
     }
   }
-
-  using std::log;
 
   VectorBuilder<include_summand<propto, T_dof, T_y, T_scale>::value,
                 T_partials_return, T_dof>
@@ -123,7 +126,6 @@ return_type_t<T_y, T_dof, T_scale> scaled_inv_chi_square_lpdf(
     }
   }
 
-  operands_and_partials<T_y, T_dof, T_scale> ops_partials(y, nu, s);
   for (size_t n = 0; n < N; n++) {
     const T_partials_return s_dbl = value_of(s_vec[n]);
     const T_partials_return nu_dbl = value_of(nu_vec[n]);

--- a/stan/math/prim/prob/scaled_inv_chi_square_rng.hpp
+++ b/stan/math/prim/prob/scaled_inv_chi_square_rng.hpp
@@ -18,8 +18,8 @@ namespace math {
  * nu and sigma can each be a scalar or a one-dimensional container. Any
  * non-scalar inputs must be the same size.
  *
- * @tparam T_deg Type of degrees of freedom parameter
- * @tparam T_scale Type of scale parameter
+ * @tparam T_deg type of degrees of freedom parameter
+ * @tparam T_scale type of scale parameter
  * @tparam RNG type of random number generator
  * @param nu (Sequence of) positive degrees of freedom parameter(s)
  * @param s (Sequence of) positive scale parameter(s)
@@ -34,9 +34,7 @@ inline typename VectorBuilder<true, double, T_deg, T_scale>::type
 scaled_inv_chi_square_rng(const T_deg& nu, const T_scale& s, RNG& rng) {
   using boost::random::chi_squared_distribution;
   using boost::variate_generator;
-
   static const char* function = "scaled_inv_chi_square_rng";
-
   check_positive_finite(function, "Degrees of freedom parameter", nu);
   check_positive_finite(function, "Scale parameter", s);
   check_consistent_sizes(function, "Location parameter", nu, "Scale Parameter",

--- a/stan/math/prim/prob/skew_normal_cdf.hpp
+++ b/stan/math/prim/prob/skew_normal_cdf.hpp
@@ -20,15 +20,9 @@ namespace math {
 template <typename T_y, typename T_loc, typename T_scale, typename T_shape>
 return_type_t<T_y, T_loc, T_scale, T_shape> skew_normal_cdf(
     const T_y& y, const T_loc& mu, const T_scale& sigma, const T_shape& alpha) {
-  static const char* function = "skew_normal_cdf";
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale, T_shape>;
-
-  T_partials_return cdf(1.0);
-
-  if (size_zero(y, mu, sigma, alpha)) {
-    return cdf;
-  }
-
+  using std::exp;
+  static const char* function = "skew_normal_cdf";
   check_not_nan(function, "Random variable", y);
   check_finite(function, "Location parameter", mu);
   check_not_nan(function, "Scale parameter", sigma);
@@ -38,11 +32,13 @@ return_type_t<T_y, T_loc, T_scale, T_shape> skew_normal_cdf(
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Scale parameter", sigma, "Shape paramter", alpha);
 
+  if (size_zero(y, mu, sigma, alpha)) {
+    return 1.0;
+  }
+
+  T_partials_return cdf(1.0);
   operands_and_partials<T_y, T_loc, T_scale, T_shape> ops_partials(y, mu, sigma,
                                                                    alpha);
-
-  using std::exp;
-
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_loc> mu_vec(mu);
   scalar_seq_view<T_scale> sigma_vec(sigma);

--- a/stan/math/prim/prob/skew_normal_lccdf.hpp
+++ b/stan/math/prim/prob/skew_normal_lccdf.hpp
@@ -20,15 +20,10 @@ namespace math {
 template <typename T_y, typename T_loc, typename T_scale, typename T_shape>
 return_type_t<T_y, T_loc, T_scale, T_shape> skew_normal_lccdf(
     const T_y& y, const T_loc& mu, const T_scale& sigma, const T_shape& alpha) {
-  static const char* function = "skew_normal_lccdf";
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale, T_shape>;
-
-  T_partials_return ccdf_log(0.0);
-
-  if (size_zero(y, mu, sigma, alpha)) {
-    return ccdf_log;
-  }
-
+  using std::exp;
+  using std::log;
+  static const char* function = "skew_normal_lccdf";
   check_not_nan(function, "Random variable", y);
   check_finite(function, "Location parameter", mu);
   check_not_nan(function, "Scale parameter", sigma);
@@ -38,12 +33,13 @@ return_type_t<T_y, T_loc, T_scale, T_shape> skew_normal_lccdf(
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Scale parameter", sigma, "Shape paramter", alpha);
 
+  if (size_zero(y, mu, sigma, alpha)) {
+    return 0;
+  }
+
+  T_partials_return ccdf_log(0.0);
   operands_and_partials<T_y, T_loc, T_scale, T_shape> ops_partials(y, mu, sigma,
                                                                    alpha);
-
-  using std::exp;
-  using std::log;
-
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_loc> mu_vec(mu);
   scalar_seq_view<T_scale> sigma_vec(sigma);

--- a/stan/math/prim/prob/skew_normal_lcdf.hpp
+++ b/stan/math/prim/prob/skew_normal_lcdf.hpp
@@ -20,15 +20,10 @@ namespace math {
 template <typename T_y, typename T_loc, typename T_scale, typename T_shape>
 return_type_t<T_y, T_loc, T_scale, T_shape> skew_normal_lcdf(
     const T_y& y, const T_loc& mu, const T_scale& sigma, const T_shape& alpha) {
-  static const char* function = "skew_normal_lcdf";
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale, T_shape>;
-
-  T_partials_return cdf_log(0.0);
-
-  if (size_zero(y, mu, sigma, alpha)) {
-    return cdf_log;
-  }
-
+  using std::exp;
+  using std::log;
+  static const char* function = "skew_normal_lcdf";
   check_not_nan(function, "Random variable", y);
   check_finite(function, "Location parameter", mu);
   check_not_nan(function, "Scale parameter", sigma);
@@ -38,12 +33,13 @@ return_type_t<T_y, T_loc, T_scale, T_shape> skew_normal_lcdf(
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Scale parameter", sigma, "Shape paramter", alpha);
 
+  if (size_zero(y, mu, sigma, alpha)) {
+    return 0;
+  }
+
+  T_partials_return cdf_log(0.0);
   operands_and_partials<T_y, T_loc, T_scale, T_shape> ops_partials(y, mu, sigma,
                                                                    alpha);
-
-  using std::exp;
-  using std::log;
-
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_loc> mu_vec(mu);
   scalar_seq_view<T_scale> sigma_vec(sigma);

--- a/stan/math/prim/prob/skew_normal_lpdf.hpp
+++ b/stan/math/prim/prob/skew_normal_lpdf.hpp
@@ -21,18 +21,10 @@ template <bool propto, typename T_y, typename T_loc, typename T_scale,
           typename T_shape>
 return_type_t<T_y, T_loc, T_scale, T_shape> skew_normal_lpdf(
     const T_y& y, const T_loc& mu, const T_scale& sigma, const T_shape& alpha) {
-  static const char* function = "skew_normal_lpdf";
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale, T_shape>;
-
   using std::exp;
   using std::log;
-
-  if (size_zero(y, mu, sigma, alpha)) {
-    return 0.0;
-  }
-
-  T_partials_return logp(0.0);
-
+  static const char* function = "skew_normal_lpdf";
   check_not_nan(function, "Random variable", y);
   check_finite(function, "Location parameter", mu);
   check_finite(function, "Shape parameter", alpha);
@@ -40,13 +32,16 @@ return_type_t<T_y, T_loc, T_scale, T_shape> skew_normal_lpdf(
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Scale parameter", sigma, "Shape paramter", alpha);
 
+  if (size_zero(y, mu, sigma, alpha)) {
+    return 0.0;
+  }
   if (!include_summand<propto, T_y, T_loc, T_scale, T_shape>::value) {
     return 0.0;
   }
 
+  T_partials_return logp(0.0);
   operands_and_partials<T_y, T_loc, T_scale, T_shape> ops_partials(y, mu, sigma,
                                                                    alpha);
-
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_loc> mu_vec(mu);
   scalar_seq_view<T_scale> sigma_vec(sigma);

--- a/stan/math/prim/prob/skew_normal_rng.hpp
+++ b/stan/math/prim/prob/skew_normal_rng.hpp
@@ -18,10 +18,11 @@ namespace math {
  * mu, sigma, and alpha can each be a scalar or a one-dimensional container. Any
  * non-scalar inputs must be the same size.
  *
- * @tparam T_loc Type of location parameter
- * @tparam T_scale Type of scale parameter
- * @tparam T_shape Type of shape parameter
+ * @tparam T_loc type of location parameter
+ * @tparam T_scale type of scale parameter
+ * @tparam T_shape type of shape parameter
  * @tparam RNG type of random number generator
+ *
  * @param mu (Sequence of) location parameter(s)
  * @param sigma (Sequence of) scale parameter(s)
  * @param alpha (Sequence of) shape parameter(s)
@@ -39,7 +40,6 @@ skew_normal_rng(const T_loc& mu, const T_scale& sigma, const T_shape& alpha,
   using boost::random::normal_distribution;
   using boost::variate_generator;
   static const char* function = "skew_normal_rng";
-
   check_finite(function, "Location parameter", mu);
   check_positive_finite(function, "Scale parameter", sigma);
   check_finite(function, "Shape parameter", alpha);

--- a/stan/math/prim/prob/std_normal_cdf.hpp
+++ b/stan/math/prim/prob/std_normal_cdf.hpp
@@ -29,17 +29,14 @@ template <typename T_y>
 inline return_type_t<T_y> std_normal_cdf(const T_y& y) {
   using T_partials_return = partials_return_t<T_y>;
   using std::exp;
-
   static const char* function = "std_normal_cdf";
-
-  T_partials_return cdf(1.0);
-
-  if (size_zero(y)) {
-    return cdf;
-  }
-
   check_not_nan(function, "Random variable", y);
 
+  if (size_zero(y)) {
+    return 1.0;
+  }
+
+  T_partials_return cdf(1.0);
   operands_and_partials<T_y> ops_partials(y);
 
   scalar_seq_view<T_y> y_vec(y);

--- a/stan/math/prim/prob/std_normal_lccdf.hpp
+++ b/stan/math/prim/prob/std_normal_lccdf.hpp
@@ -21,17 +21,16 @@ inline return_type_t<T_y> std_normal_lccdf(const T_y& y) {
   using T_partials_return = partials_return_t<T_y>;
   using std::exp;
   using std::log;
-
   static const char* function = "std_normal_lccdf";
-
-  T_partials_return lccdf(0.0);
-  if (size_zero(y)) {
-    return lccdf;
-  }
-
   check_not_nan(function, "Random variable", y);
 
+  if (size_zero(y)) {
+    return 0;
+  }
+
+  T_partials_return lccdf(0.0);
   operands_and_partials<T_y> ops_partials(y);
+
   scalar_seq_view<T_y> y_vec(y);
   size_t N = stan::math::size(y);
 

--- a/stan/math/prim/prob/std_normal_lcdf.hpp
+++ b/stan/math/prim/prob/std_normal_lcdf.hpp
@@ -26,16 +26,14 @@ inline return_type_t<T_y> std_normal_lcdf(const T_y& y) {
   using std::fabs;
   using std::log;
   using std::pow;
-
   static const char* function = "std_normal_lcdf";
-
-  T_partials_return lcdf(0.0);
-  if (size_zero(y)) {
-    return lcdf;
-  }
-
   check_not_nan(function, "Random variable", y);
 
+  if (size_zero(y)) {
+    return 0;
+  }
+
+  T_partials_return lcdf(0.0);
   operands_and_partials<T_y> ops_partials(y);
 
   scalar_seq_view<T_y> y_vec(y);

--- a/stan/math/prim/prob/std_normal_lpdf.hpp
+++ b/stan/math/prim/prob/std_normal_lpdf.hpp
@@ -18,7 +18,8 @@ namespace math {
  *
  * <p>The result log probability is defined to be the sum of the
  * log probabilities for each observation.
- * @tparam T_y Underlying type of scalar in sequence.
+ *
+ * @tparam T_y type of scalar
  * @param y (Sequence of) scalar(s).
  * @return The log of the product of the densities.
  * @throw std::domain_error if any scalar is nan.
@@ -27,20 +28,18 @@ template <bool propto, typename T_y>
 return_type_t<T_y> std_normal_lpdf(const T_y& y) {
   static const char* function = "std_normal_lpdf";
   using T_partials_return = partials_return_t<T_y>;
+  check_not_nan(function, "Random variable", y);
 
   if (size_zero(y)) {
     return 0.0;
   }
-
-  check_not_nan(function, "Random variable", y);
-
   if (!include_summand<propto, T_y>::value) {
     return 0.0;
   }
 
+  T_partials_return logp(0.0);
   operands_and_partials<T_y> ops_partials(y);
 
-  T_partials_return logp(0.0);
   scalar_seq_view<T_y> y_vec(y);
   size_t N = stan::math::size(y);
 

--- a/stan/math/prim/prob/student_t_cdf.hpp
+++ b/stan/math/prim/prob/student_t_cdf.hpp
@@ -23,28 +23,26 @@ return_type_t<T_y, T_dof, T_loc, T_scale> student_t_cdf(const T_y& y,
                                                         const T_loc& mu,
                                                         const T_scale& sigma) {
   using T_partials_return = partials_return_t<T_y, T_dof, T_loc, T_scale>;
-
-  if (size_zero(y, nu, mu, sigma)) {
-    return 1.0;
-  }
-
+  using std::exp;
+  using std::pow;
   static const char* function = "student_t_cdf";
-
-  T_partials_return P(1.0);
-
   check_not_nan(function, "Random variable", y);
   check_positive_finite(function, "Degrees of freedom parameter", nu);
   check_finite(function, "Location parameter", mu);
   check_positive_finite(function, "Scale parameter", sigma);
 
+  if (size_zero(y, nu, mu, sigma)) {
+    return 1.0;
+  }
+
+  T_partials_return P(1.0);
+  operands_and_partials<T_y, T_dof, T_loc, T_scale> ops_partials(y, nu, mu,
+                                                                 sigma);
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_dof> nu_vec(nu);
   scalar_seq_view<T_loc> mu_vec(mu);
   scalar_seq_view<T_scale> sigma_vec(sigma);
   size_t N = max_size(y, nu, mu, sigma);
-
-  operands_and_partials<T_y, T_dof, T_loc, T_scale> ops_partials(y, nu, mu,
-                                                                 sigma);
 
   // Explicit return for extreme values
   // The gradients are technically ill-defined, but treated as zero
@@ -53,9 +51,6 @@ return_type_t<T_y, T_dof, T_loc, T_scale> student_t_cdf(const T_y& y,
       return ops_partials.build(0.0);
     }
   }
-
-  using std::exp;
-  using std::pow;
 
   T_partials_return digammaHalf = 0;
 

--- a/stan/math/prim/prob/student_t_lccdf.hpp
+++ b/stan/math/prim/prob/student_t_lccdf.hpp
@@ -22,28 +22,27 @@ template <typename T_y, typename T_dof, typename T_loc, typename T_scale>
 return_type_t<T_y, T_dof, T_loc, T_scale> student_t_lccdf(
     const T_y& y, const T_dof& nu, const T_loc& mu, const T_scale& sigma) {
   using T_partials_return = partials_return_t<T_y, T_dof, T_loc, T_scale>;
-
-  if (size_zero(y, nu, mu, sigma)) {
-    return 0.0;
-  }
-
+  using std::exp;
+  using std::log;
+  using std::pow;
   static const char* function = "student_t_lccdf";
-
-  T_partials_return P(0.0);
-
   check_not_nan(function, "Random variable", y);
   check_positive_finite(function, "Degrees of freedom parameter", nu);
   check_finite(function, "Location parameter", mu);
   check_positive_finite(function, "Scale parameter", sigma);
 
+  if (size_zero(y, nu, mu, sigma)) {
+    return 0;
+  }
+
+  T_partials_return P(0.0);
+  operands_and_partials<T_y, T_dof, T_loc, T_scale> ops_partials(y, nu, mu,
+                                                                 sigma);
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_dof> nu_vec(nu);
   scalar_seq_view<T_loc> mu_vec(mu);
   scalar_seq_view<T_scale> sigma_vec(sigma);
   size_t N = max_size(y, nu, mu, sigma);
-
-  operands_and_partials<T_y, T_dof, T_loc, T_scale> ops_partials(y, nu, mu,
-                                                                 sigma);
 
   // Explicit return for extreme values
   // The gradients are technically ill-defined, but treated as zero
@@ -52,10 +51,6 @@ return_type_t<T_y, T_dof, T_loc, T_scale> student_t_lccdf(
       return ops_partials.build(0.0);
     }
   }
-
-  using std::exp;
-  using std::log;
-  using std::pow;
 
   T_partials_return digammaHalf = 0;
 

--- a/stan/math/prim/prob/student_t_lcdf.hpp
+++ b/stan/math/prim/prob/student_t_lcdf.hpp
@@ -24,28 +24,27 @@ return_type_t<T_y, T_dof, T_loc, T_scale> student_t_lcdf(const T_y& y,
                                                          const T_loc& mu,
                                                          const T_scale& sigma) {
   using T_partials_return = partials_return_t<T_y, T_dof, T_loc, T_scale>;
-
-  if (size_zero(y, nu, mu, sigma)) {
-    return 0.0;
-  }
-
+  using std::exp;
+  using std::log;
+  using std::pow;
   static const char* function = "student_t_lcdf";
-
-  T_partials_return P(0.0);
-
   check_not_nan(function, "Random variable", y);
   check_positive_finite(function, "Degrees of freedom parameter", nu);
   check_finite(function, "Location parameter", mu);
   check_positive_finite(function, "Scale parameter", sigma);
 
+  if (size_zero(y, nu, mu, sigma)) {
+    return 0;
+  }
+
+  T_partials_return P(0.0);
+  operands_and_partials<T_y, T_dof, T_loc, T_scale> ops_partials(y, nu, mu,
+                                                                 sigma);
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_dof> nu_vec(nu);
   scalar_seq_view<T_loc> mu_vec(mu);
   scalar_seq_view<T_scale> sigma_vec(sigma);
   size_t N = max_size(y, nu, mu, sigma);
-
-  operands_and_partials<T_y, T_dof, T_loc, T_scale> ops_partials(y, nu, mu,
-                                                                 sigma);
 
   // Explicit return for extreme values
   // The gradients are technically ill-defined, but treated as zero
@@ -54,10 +53,6 @@ return_type_t<T_y, T_dof, T_loc, T_scale> student_t_lcdf(const T_y& y,
       return ops_partials.build(negative_infinity());
     }
   }
-
-  using std::exp;
-  using std::log;
-  using std::pow;
 
   T_partials_return digammaHalf = 0;
 

--- a/stan/math/prim/prob/student_t_rng.hpp
+++ b/stan/math/prim/prob/student_t_rng.hpp
@@ -17,10 +17,11 @@ namespace math {
  * nu, mu, and sigma can each be a scalar or a one-dimensional container. Any
  * non-scalar inputs must be the same size.
  *
- * @tparam T_deg Type of degrees of freedom parameter
- * @tparam T_loc Type of location parameter
- * @tparam T_scale Type of scale parameter
+ * @tparam T_deg type of degrees of freedom parameter
+ * @tparam T_loc type of location parameter
+ * @tparam T_scale type of scale parameter
  * @tparam RNG type of random number generator
+ *
  * @param nu (Sequence of) degrees of freedom parameter(s)
  * @param mu (Sequence of) location parameter(s)
  * @param sigma (Sequence of) scale parameter(s)
@@ -38,7 +39,6 @@ student_t_rng(const T_deg& nu, const T_loc& mu, const T_scale& sigma,
   using boost::random::student_t_distribution;
   using boost::variate_generator;
   static const char* function = "student_t_rng";
-
   check_positive_finite(function, "Degrees of freedom parameter", nu);
   check_finite(function, "Location parameter", mu);
   check_positive_finite(function, "Scale parameter", sigma);

--- a/stan/math/prim/prob/uniform_cdf.hpp
+++ b/stan/math/prim/prob/uniform_cdf.hpp
@@ -14,14 +14,8 @@ namespace math {
 template <typename T_y, typename T_low, typename T_high>
 return_type_t<T_y, T_low, T_high> uniform_cdf(const T_y& y, const T_low& alpha,
                                               const T_high& beta) {
-  static const char* function = "uniform_cdf";
   using T_partials_return = partials_return_t<T_y, T_low, T_high>;
-
-  if (size_zero(y, alpha, beta)) {
-    return 1.0;
-  }
-
-  T_partials_return cdf(1.0);
+  static const char* function = "uniform_cdf";
   check_not_nan(function, "Random variable", y);
   check_finite(function, "Lower bound parameter", alpha);
   check_finite(function, "Upper bound parameter", beta);
@@ -29,6 +23,13 @@ return_type_t<T_y, T_low, T_high> uniform_cdf(const T_y& y, const T_low& alpha,
   check_consistent_sizes(function, "Random variable", y,
                          "Lower bound parameter", alpha,
                          "Upper bound parameter", beta);
+
+  if (size_zero(y, alpha, beta)) {
+    return 1.0;
+  }
+
+  T_partials_return cdf(1.0);
+  operands_and_partials<T_y, T_low, T_high> ops_partials(y, alpha, beta);
 
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_low> alpha_vec(alpha);
@@ -42,7 +43,6 @@ return_type_t<T_y, T_low, T_high> uniform_cdf(const T_y& y, const T_low& alpha,
     }
   }
 
-  operands_and_partials<T_y, T_low, T_high> ops_partials(y, alpha, beta);
   for (size_t n = 0; n < N; n++) {
     const T_partials_return y_dbl = value_of(y_vec[n]);
     const T_partials_return alpha_dbl = value_of(alpha_vec[n]);

--- a/stan/math/prim/prob/uniform_lccdf.hpp
+++ b/stan/math/prim/prob/uniform_lccdf.hpp
@@ -17,16 +17,9 @@ template <typename T_y, typename T_low, typename T_high>
 return_type_t<T_y, T_low, T_high> uniform_lccdf(const T_y& y,
                                                 const T_low& alpha,
                                                 const T_high& beta) {
-  static const char* function = "uniform_lccdf";
   using T_partials_return = partials_return_t<T_y, T_low, T_high>;
-
   using std::log;
-
-  if (size_zero(y, alpha, beta)) {
-    return 0.0;
-  }
-
-  T_partials_return ccdf_log(0.0);
+  static const char* function = "uniform_lccdf";
   check_not_nan(function, "Random variable", y);
   check_finite(function, "Lower bound parameter", alpha);
   check_finite(function, "Upper bound parameter", beta);
@@ -34,6 +27,13 @@ return_type_t<T_y, T_low, T_high> uniform_lccdf(const T_y& y,
   check_consistent_sizes(function, "Random variable", y,
                          "Lower bound parameter", alpha,
                          "Upper bound parameter", beta);
+
+  if (size_zero(y, alpha, beta)) {
+    return 0;
+  }
+
+  T_partials_return ccdf_log(0.0);
+  operands_and_partials<T_y, T_low, T_high> ops_partials(y, alpha, beta);
 
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_low> alpha_vec(alpha);
@@ -50,7 +50,6 @@ return_type_t<T_y, T_low, T_high> uniform_lccdf(const T_y& y,
     }
   }
 
-  operands_and_partials<T_y, T_low, T_high> ops_partials(y, alpha, beta);
   for (size_t n = 0; n < N; n++) {
     const T_partials_return y_dbl = value_of(y_vec[n]);
     const T_partials_return alpha_dbl = value_of(alpha_vec[n]);

--- a/stan/math/prim/prob/uniform_lcdf.hpp
+++ b/stan/math/prim/prob/uniform_lcdf.hpp
@@ -16,16 +16,9 @@ namespace math {
 template <typename T_y, typename T_low, typename T_high>
 return_type_t<T_y, T_low, T_high> uniform_lcdf(const T_y& y, const T_low& alpha,
                                                const T_high& beta) {
-  static const char* function = "uniform_lcdf";
   using T_partials_return = partials_return_t<T_y, T_low, T_high>;
-
   using std::log;
-
-  if (size_zero(y, alpha, beta)) {
-    return 0.0;
-  }
-
-  T_partials_return cdf_log(0.0);
+  static const char* function = "uniform_lcdf";
   check_not_nan(function, "Random variable", y);
   check_finite(function, "Lower bound parameter", alpha);
   check_finite(function, "Upper bound parameter", beta);
@@ -34,12 +27,17 @@ return_type_t<T_y, T_low, T_high> uniform_lcdf(const T_y& y, const T_low& alpha,
                          "Lower bound parameter", alpha,
                          "Upper bound parameter", beta);
 
+  if (size_zero(y, alpha, beta)) {
+    return 0;
+  }
+
+  T_partials_return cdf_log(0.0);
+  operands_and_partials<T_y, T_low, T_high> ops_partials(y, alpha, beta);
+
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_low> alpha_vec(alpha);
   scalar_seq_view<T_high> beta_vec(beta);
   size_t N = max_size(y, alpha, beta);
-
-  operands_and_partials<T_y, T_low, T_high> ops_partials(y, alpha, beta);
 
   for (size_t n = 0; n < N; n++) {
     const T_partials_return y_dbl = value_of(y_vec[n]);

--- a/stan/math/prim/prob/uniform_lpdf.hpp
+++ b/stan/math/prim/prob/uniform_lpdf.hpp
@@ -26,28 +26,21 @@ namespace math {
  & & \mathrm{ where } \; y \in [\alpha, \beta], \log(0) \; \mathrm{otherwise}
  \f}
  *
+ * @tparam T_y type of scalar
+ * @tparam T_low type of lower bound
+ * @tparam T_high type of upper bound
  * @param y A scalar variable.
  * @param alpha Lower bound.
  * @param beta Upper bound.
  * @throw std::invalid_argument if the lower bound is greater than
  *    or equal to the lower bound
- * @tparam T_y Type of scalar.
- * @tparam T_low Type of lower bound.
- * @tparam T_high Type of upper bound.
  */
 template <bool propto, typename T_y, typename T_low, typename T_high>
 return_type_t<T_y, T_low, T_high> uniform_lpdf(const T_y& y, const T_low& alpha,
                                                const T_high& beta) {
-  static const char* function = "uniform_lpdf";
   using T_partials_return = partials_return_t<T_y, T_low, T_high>;
-
   using std::log;
-
-  if (size_zero(y, alpha, beta)) {
-    return 0.0;
-  }
-
-  T_partials_return logp(0.0);
+  static const char* function = "uniform_lpdf";
   check_not_nan(function, "Random variable", y);
   check_finite(function, "Lower bound parameter", alpha);
   check_finite(function, "Upper bound parameter", beta);
@@ -56,9 +49,15 @@ return_type_t<T_y, T_low, T_high> uniform_lpdf(const T_y& y, const T_low& alpha,
                          "Upper bound parameter", beta);
   check_greater(function, "Upper bound parameter", beta, alpha);
 
+  if (size_zero(y, alpha, beta)) {
+    return 0.0;
+  }
   if (!include_summand<propto, T_y, T_low, T_high>::value) {
     return 0.0;
   }
+
+  T_partials_return logp(0.0);
+  operands_and_partials<T_y, T_low, T_high> ops_partials(y, alpha, beta);
 
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_low> alpha_vec(alpha);
@@ -92,7 +91,6 @@ return_type_t<T_y, T_low, T_high> uniform_lpdf(const T_y& y, const T_low& alpha,
     }
   }
 
-  operands_and_partials<T_y, T_low, T_high> ops_partials(y, alpha, beta);
   for (size_t n = 0; n < N; n++) {
     if (include_summand<propto, T_low, T_high>::value) {
       logp -= log_beta_minus_alpha[n];

--- a/stan/math/prim/prob/uniform_rng.hpp
+++ b/stan/math/prim/prob/uniform_rng.hpp
@@ -19,8 +19,8 @@ namespace math {
  * alpha and beta can each be a scalar or a one-dimensional container. Any
  * non-scalar inputs must be the same size.
  *
- * @tparam T_alpha Type of shape parameter
- * @tparam T_beta Type of inverse scale parameter
+ * @tparam T_alpha type of shape parameter
+ * @tparam T_beta type of inverse scale parameter
  * @tparam RNG type of random number generator
  * @param alpha (Sequence of) lower bound parameter(s)
  * @param beta (Sequence of) upper bound parameter(s)
@@ -35,9 +35,7 @@ inline typename VectorBuilder<true, double, T_alpha, T_beta>::type uniform_rng(
     const T_alpha& alpha, const T_beta& beta, RNG& rng) {
   using boost::random::uniform_real_distribution;
   using boost::variate_generator;
-
   static const char* function = "uniform_rng";
-
   check_finite(function, "Lower bound parameter", alpha);
   check_finite(function, "Upper bound parameter", beta);
   check_consistent_sizes(function, "Lower bound parameter", alpha,

--- a/stan/math/prim/prob/von_mises_lpdf.hpp
+++ b/stan/math/prim/prob/von_mises_lpdf.hpp
@@ -20,20 +20,11 @@ namespace math {
 template <bool propto, typename T_y, typename T_loc, typename T_scale>
 return_type_t<T_y, T_loc, T_scale> von_mises_lpdf(T_y const& y, T_loc const& mu,
                                                   T_scale const& kappa) {
-  static char const* const function = "von_mises_lpdf";
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale>;
-
-  if (size_zero(y, mu, kappa)) {
-    return 0.0;
-  }
-
   using std::cos;
   using std::floor;
-  using std::log;
   using std::sin;
-
-  T_partials_return logp = 0.0;
-
+  static char const* const function = "von_mises_lpdf";
   check_finite(function, "Random variable", y);
   check_finite(function, "Location parameter", mu);
   check_nonnegative(function, "Scale parameter", kappa);
@@ -41,20 +32,26 @@ return_type_t<T_y, T_loc, T_scale> von_mises_lpdf(T_y const& y, T_loc const& mu,
   check_consistent_sizes(function, "Random variable", y, "Location parameter",
                          mu, "Scale parameter", kappa);
 
+  if (size_zero(y, mu, kappa)) {
+    return 0;
+  }
   if (!include_summand<propto, T_y, T_loc, T_scale>::value) {
-    return logp;
+    return 0;
   }
 
-  const bool y_const = is_constant_all<T_y>::value;
-  const bool mu_const = is_constant_all<T_loc>::value;
-  const bool kappa_const = is_constant_all<T_scale>::value;
-
-  const bool compute_bessel0 = include_summand<propto, T_scale>::value;
-  const bool compute_bessel1 = !kappa_const;
+  T_partials_return logp = 0.0;
+  operands_and_partials<T_y, T_loc, T_scale> ops_partials(y, mu, kappa);
 
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_loc> mu_vec(mu);
   scalar_seq_view<T_scale> kappa_vec(kappa);
+  size_t N = max_size(y, mu, kappa);
+
+  const bool y_const = is_constant_all<T_y>::value;
+  const bool mu_const = is_constant_all<T_loc>::value;
+  const bool kappa_const = is_constant_all<T_scale>::value;
+  const bool compute_bessel0 = include_summand<propto, T_scale>::value;
+  const bool compute_bessel1 = !kappa_const;
 
   VectorBuilder<true, T_partials_return, T_scale> kappa_dbl(size(kappa));
   VectorBuilder<include_summand<propto, T_scale>::value, T_partials_return,
@@ -67,10 +64,6 @@ return_type_t<T_y, T_loc, T_scale> von_mises_lpdf(T_y const& y, T_loc const& mu,
           = log_modified_bessel_first_kind(0, value_of(kappa_vec[i]));
     }
   }
-
-  operands_and_partials<T_y, T_loc, T_scale> ops_partials(y, mu, kappa);
-
-  size_t N = max_size(y, mu, kappa);
 
   for (size_t n = 0; n < N; n++) {
     const T_partials_return y_val = value_of(y_vec[n]);

--- a/stan/math/prim/prob/von_mises_rng.hpp
+++ b/stan/math/prim/prob/von_mises_rng.hpp
@@ -47,7 +47,6 @@ inline typename VectorBuilder<true, double, T_loc, T_conc>::type von_mises_rng(
   using boost::random::uniform_real_distribution;
   using boost::variate_generator;
   static const char* function = "von_mises_rng";
-
   check_finite(function, "Location parameter", mu);
   check_nonnegative(function, "Scale parameter", kappa);
   check_finite(function, "Scale parameter", kappa);

--- a/stan/math/prim/prob/weibull_cdf.hpp
+++ b/stan/math/prim/prob/weibull_cdf.hpp
@@ -33,22 +33,19 @@ return_type_t<T_y, T_shape, T_scale> weibull_cdf(const T_y& y,
                                                  const T_shape& alpha,
                                                  const T_scale& sigma) {
   using T_partials_return = partials_return_t<T_y, T_shape, T_scale>;
-
-  static const char* function = "weibull_cdf";
-
   using std::exp;
   using std::log;
   using std::pow;
+  static const char* function = "weibull_cdf";
+  check_nonnegative(function, "Random variable", y);
+  check_positive_finite(function, "Shape parameter", alpha);
+  check_positive_finite(function, "Scale parameter", sigma);
 
   if (size_zero(y, alpha, sigma)) {
     return 1.0;
   }
 
   T_partials_return cdf(1.0);
-  check_nonnegative(function, "Random variable", y);
-  check_positive_finite(function, "Shape parameter", alpha);
-  check_positive_finite(function, "Scale parameter", sigma);
-
   operands_and_partials<T_y, T_shape, T_scale> ops_partials(y, alpha, sigma);
 
   scalar_seq_view<T_y> y_vec(y);

--- a/stan/math/prim/prob/weibull_lccdf.hpp
+++ b/stan/math/prim/prob/weibull_lccdf.hpp
@@ -31,21 +31,18 @@ return_type_t<T_y, T_shape, T_scale> weibull_lccdf(const T_y& y,
                                                    const T_shape& alpha,
                                                    const T_scale& sigma) {
   using T_partials_return = partials_return_t<T_y, T_shape, T_scale>;
-
-  static const char* function = "weibull_lccdf";
-
   using std::log;
   using std::pow;
+  static const char* function = "weibull_lccdf";
+  check_nonnegative(function, "Random variable", y);
+  check_positive_finite(function, "Shape parameter", alpha);
+  check_positive_finite(function, "Scale parameter", sigma);
 
   if (size_zero(y, alpha, sigma)) {
     return 0.0;
   }
 
   T_partials_return ccdf_log(0.0);
-  check_nonnegative(function, "Random variable", y);
-  check_positive_finite(function, "Shape parameter", alpha);
-  check_positive_finite(function, "Scale parameter", sigma);
-
   operands_and_partials<T_y, T_shape, T_scale> ops_partials(y, alpha, sigma);
 
   scalar_seq_view<T_y> y_vec(y);

--- a/stan/math/prim/prob/weibull_lcdf.hpp
+++ b/stan/math/prim/prob/weibull_lcdf.hpp
@@ -32,22 +32,19 @@ return_type_t<T_y, T_shape, T_scale> weibull_lcdf(const T_y& y,
                                                   const T_shape& alpha,
                                                   const T_scale& sigma) {
   using T_partials_return = partials_return_t<T_y, T_shape, T_scale>;
-
-  static const char* function = "weibull_lcdf";
-
   using std::exp;
   using std::log;
   using std::pow;
+  static const char* function = "weibull_lcdf";
+  check_nonnegative(function, "Random variable", y);
+  check_positive_finite(function, "Shape parameter", alpha);
+  check_positive_finite(function, "Scale parameter", sigma);
 
   if (size_zero(y, alpha, sigma)) {
     return 0.0;
   }
 
   T_partials_return cdf_log(0.0);
-  check_nonnegative(function, "Random variable", y);
-  check_positive_finite(function, "Shape parameter", alpha);
-  check_positive_finite(function, "Scale parameter", sigma);
-
   operands_and_partials<T_y, T_shape, T_scale> ops_partials(y, alpha, sigma);
 
   scalar_seq_view<T_y> y_vec(y);

--- a/stan/math/prim/prob/weibull_lpdf.hpp
+++ b/stan/math/prim/prob/weibull_lpdf.hpp
@@ -32,17 +32,16 @@ template <bool propto, typename T_y, typename T_shape, typename T_scale>
 return_type_t<T_y, T_shape, T_scale> weibull_lpdf(const T_y& y,
                                                   const T_shape& alpha,
                                                   const T_scale& sigma) {
-  static const char* function = "weibull_lpdf";
   using T_partials_return = partials_return_t<T_y, T_shape, T_scale>;
-
   using std::log;
   using std::pow;
-
+  static const char* function = "weibull_lpdf";
   check_finite(function, "Random variable", y);
   check_positive_finite(function, "Shape parameter", alpha);
   check_positive_finite(function, "Scale parameter", sigma);
   check_consistent_sizes(function, "Random variable", y, "Shape parameter",
                          alpha, "Scale parameter", sigma);
+
   if (size_zero(y, alpha, sigma)) {
     return 0;
   }
@@ -51,6 +50,8 @@ return_type_t<T_y, T_shape, T_scale> weibull_lpdf(const T_y& y,
   }
 
   T_partials_return logp(0);
+  operands_and_partials<T_y, T_shape, T_scale> ops_partials(y, alpha, sigma);
+
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_shape> alpha_vec(alpha);
   scalar_seq_view<T_scale> sigma_vec(sigma);
@@ -106,7 +107,6 @@ return_type_t<T_y, T_shape, T_scale> weibull_lpdf(const T_y& y,
     y_div_sigma_pow_alpha[i] = pow(y_dbl * inv_sigma[i], alpha_dbl);
   }
 
-  operands_and_partials<T_y, T_shape, T_scale> ops_partials(y, alpha, sigma);
   for (size_t n = 0; n < N; n++) {
     const T_partials_return alpha_dbl = value_of(alpha_vec[n]);
     if (include_summand<propto, T_shape>::value) {

--- a/stan/math/prim/prob/weibull_rng.hpp
+++ b/stan/math/prim/prob/weibull_rng.hpp
@@ -17,8 +17,8 @@ namespace math {
  * alpha and sigma can each be a scalar or a one-dimensional container. Any
  * non-scalar inputs must be the same size.
  *
- * @tparam T_shape Type of shape parameter
- * @tparam T_scale Type of scale parameter
+ * @tparam T_shape type of shape parameter
+ * @tparam T_scale type of scale parameter
  * @tparam RNG type of random number generator
  * @param alpha (Sequence of) positive shape parameter(s)
  * @param sigma (Sequence of) positive scale parameter(s)
@@ -33,9 +33,7 @@ inline typename VectorBuilder<true, double, T_shape, T_scale>::type weibull_rng(
     const T_shape& alpha, const T_scale& sigma, RNG& rng) {
   using boost::random::weibull_distribution;
   using boost::variate_generator;
-
   static const char* function = "weibull_rng";
-
   check_positive_finite(function, "Shape parameter", alpha);
   check_positive_finite(function, "Scale parameter", sigma);
   check_consistent_sizes(function, "Shape parameter", alpha, "Scale Parameter",

--- a/stan/math/prim/prob/wiener_lpdf.hpp
+++ b/stan/math/prim/prob/wiener_lpdf.hpp
@@ -57,6 +57,12 @@ namespace math {
  * reaction times in seconds (strictly positive) with
  * upper-boundary responses.
  *
+ * @tparam T_y type of scalar
+ * @tparam T_alpha type of alpha parameter
+ * @tparam T_tau type of tau parameter
+ * @tparam T_beta type of beta parameter
+ * @tparam T_delta type of delta parameter
+ *
  * @param y A scalar variate.
  * @param alpha The boundary separation.
  * @param tau The nondecision time.
@@ -70,32 +76,14 @@ template <bool propto, typename T_y, typename T_alpha, typename T_tau,
 return_type_t<T_y, T_alpha, T_tau, T_beta, T_delta> wiener_lpdf(
     const T_y& y, const T_alpha& alpha, const T_tau& tau, const T_beta& beta,
     const T_delta& delta) {
-  static const char* function = "wiener_lpdf";
-
+  using T_return_type = return_type_t<T_y, T_alpha, T_tau, T_beta, T_delta>;
   using std::ceil;
   using std::exp;
   using std::floor;
   using std::log;
   using std::sin;
   using std::sqrt;
-
-  static const double WIENER_ERR = 0.000001;
-  static const double PI_TIMES_WIENER_ERR = pi() * WIENER_ERR;
-  static const double LOG_PI_LOG_WIENER_ERR = LOG_PI + log(WIENER_ERR);
-  static const double TWO_TIMES_SQRT_TWO_PI_TIMES_WIENER_ERR
-      = 2.0 * SQRT_TWO_PI * WIENER_ERR;
-  static const double LOG_TWO_OVER_TWO_PLUS_LOG_SQRT_PI
-      = LOG_TWO / 2 + LOG_SQRT_PI;
-  static const double SQUARE_PI_OVER_TWO = square(pi()) * 0.5;
-  static const double TWO_TIMES_LOG_SQRT_PI = 2.0 * LOG_SQRT_PI;
-
-  if (size_zero(y, alpha, beta, tau, delta)) {
-    return 0.0;
-  }
-
-  using T_return_type = return_type_t<T_y, T_alpha, T_tau, T_beta, T_delta>;
-  T_return_type lp(0.0);
-
+  static const char* function = "wiener_lpdf";
   check_not_nan(function, "Random variable", y);
   check_not_nan(function, "Boundary separation", alpha);
   check_not_nan(function, "A-priori bias", beta);
@@ -113,6 +101,12 @@ return_type_t<T_y, T_alpha, T_tau, T_beta, T_delta> wiener_lpdf(
                          alpha, "A-priori bias", beta, "Nondecision time", tau,
                          "Drift rate", delta);
 
+  if (size_zero(y, alpha, beta, tau, delta)) {
+    return 0;
+  }
+
+  T_return_type lp(0.0);
+
   size_t N = std::max(max_size(y, alpha, beta), max_size(tau, delta));
   if (!N) {
     return 0.0;
@@ -123,8 +117,8 @@ return_type_t<T_y, T_alpha, T_tau, T_beta, T_delta> wiener_lpdf(
   scalar_seq_view<T_beta> beta_vec(beta);
   scalar_seq_view<T_tau> tau_vec(tau);
   scalar_seq_view<T_delta> delta_vec(delta);
-
   size_t N_y_tau = max_size(y, tau);
+
   for (size_t i = 0; i < N_y_tau; ++i) {
     if (y_vec[i] <= tau_vec[i]) {
       std::stringstream msg;
@@ -138,6 +132,16 @@ return_type_t<T_y, T_alpha, T_tau, T_beta, T_delta> wiener_lpdf(
   if (!include_summand<propto, T_y, T_alpha, T_tau, T_beta, T_delta>::value) {
     return 0;
   }
+
+  static const double WIENER_ERR = 0.000001;
+  static const double PI_TIMES_WIENER_ERR = pi() * WIENER_ERR;
+  static const double LOG_PI_LOG_WIENER_ERR = LOG_PI + log(WIENER_ERR);
+  static const double TWO_TIMES_SQRT_TWO_PI_TIMES_WIENER_ERR
+      = 2.0 * SQRT_TWO_PI * WIENER_ERR;
+  static const double LOG_TWO_OVER_TWO_PLUS_LOG_SQRT_PI
+      = LOG_TWO / 2 + LOG_SQRT_PI;
+  static const double SQUARE_PI_OVER_TWO = square(pi()) * 0.5;
+  static const double TWO_TIMES_LOG_SQRT_PI = 2.0 * LOG_SQRT_PI;
 
   for (size_t i = 0; i < N; i++) {
     typename scalar_type<T_beta>::type one_minus_beta = 1.0 - beta_vec[i];

--- a/stan/math/prim/prob/wishart_lpdf.hpp
+++ b/stan/math/prim/prob/wishart_lpdf.hpp
@@ -31,30 +31,27 @@ namespace math {
  -\frac{\nu}{2} \log(\det(S)) + \frac{\nu-k-1}{2}\log (\det(W)) - \frac{1}{2}
  \mbox{tr} (S^{-1}W) \f}
  *
+ * @tparam T_y type of scalar
+ * @tparam T_dof type of degrees of freedom
+ * @tparam T_scale type of scale
  * @param W A scalar matrix
  * @param nu Degrees of freedom
  * @param S The scale matrix
  * @return The log of the Wishart density at W given nu and S.
  * @throw std::domain_error if nu is not greater than k-1
  * @throw std::domain_error if S is not square, not symmetric, or not
- semi-positive definite.
- * @tparam T_y Type of scalar.
- * @tparam T_dof Type of degrees of freedom.
- * @tparam T_scale Type of scale.
+ * semi-positive definite.
  */
 template <bool propto, typename T_y, typename T_dof, typename T_scale>
 return_type_t<T_y, T_dof, T_scale> wishart_lpdf(
     const Eigen::Matrix<T_y, Eigen::Dynamic, Eigen::Dynamic>& W,
     const T_dof& nu,
     const Eigen::Matrix<T_scale, Eigen::Dynamic, Eigen::Dynamic>& S) {
-  static const char* function = "wishart_lpdf";
-
   using Eigen::Dynamic;
   using Eigen::Lower;
   using Eigen::Matrix;
-
+  static const char* function = "wishart_lpdf";
   index_type_t<Matrix<T_scale, Dynamic, Dynamic>> k = W.rows();
-  return_type_t<T_y, T_dof, T_scale> lp(0.0);
   check_greater(function, "Degrees of freedom parameter", nu, k - 1);
   check_square(function, "random variable", W);
   check_square(function, "scale parameter", S);
@@ -66,6 +63,8 @@ return_type_t<T_y, T_dof, T_scale> wishart_lpdf(
 
   LDLT_factor<T_scale, Eigen::Dynamic, Eigen::Dynamic> ldlt_S(S);
   check_ldlt_factor(function, "LDLT_Factor of scale parameter", ldlt_S);
+
+  return_type_t<T_y, T_dof, T_scale> lp(0.0);
 
   if (include_summand<propto, T_dof>::value) {
     lp -= nu * k * HALF_LOG_TWO;

--- a/stan/math/prim/prob/wishart_rng.hpp
+++ b/stan/math/prim/prob/wishart_rng.hpp
@@ -14,11 +14,9 @@ namespace math {
 template <class RNG>
 inline Eigen::MatrixXd wishart_rng(double nu, const Eigen::MatrixXd& S,
                                    RNG& rng) {
-  static const char* function = "wishart_rng";
-
   using Eigen::MatrixXd;
+  static const char* function = "wishart_rng";
   index_type_t<MatrixXd> k = S.rows();
-
   check_square(function, "scale parameter", S);
   check_greater(function, "degrees of freedom > dims - 1", nu, k - 1);
 


### PR DESCRIPTION
## Summary

This is the second of two PRs that deals with moving the `size_zero` calls after the other consistency checks on function arguments. This covers all distributions with names starting L-Z. Closes #1757.

This also improves the consistency of the placement of the using std:: statements and the declaration of the operands_and_partials variable. Following @bob-carpenter's suggestion in https://github.com/stan-dev/math/pull/1758#discussion_r388379291, now all `using` statements are at the beginning of the function.

I went back and reordered those also for the distributions done in #1758: given that these appear alphabetically first, the relevant changes concerning this PR appear after after some scrolling. If you want to isolate them from the rest, they are contained in the first commit.

## Tests

No new tests.

## Side Effects

None.

## Checklist

- [X] Math issue #1757

- [X] Copyright holder: Marco Colombo

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [X] the new changes are tested
