### PR TITLE
Cleanup duplicated overloads of scalar std:: functions

### DIFF
--- a/stan/math/prim/fun/acos.hpp
+++ b/stan/math/prim/fun/acos.hpp
@@ -9,7 +9,7 @@ namespace stan {
 namespace math {
 
 /**
- * Structure to wrap acos() so it can be vectorized.
+ * Structure to wrap <code>acos()</code> so it can be vectorized.
  *
  * @tparam T type of variable
  * @param x variable
@@ -24,7 +24,8 @@ struct acos_fun {
 };
 
 /**
- * Vectorized version of acos().
+ * Returns the elementwise <code>acos()</code> of the input,
+ * which may be a scalar or any Stan container of numeric scalars.
  *
  * @tparam T type of container
  * @param x container

--- a/stan/math/prim/fun/acos.hpp
+++ b/stan/math/prim/fun/acos.hpp
@@ -9,7 +9,7 @@ namespace stan {
 namespace math {
 
 /**
- * Structure to wrap <code>acos()</code> so it can be vectorized.
+ * Structure to wrap \c acos() so it can be vectorized.
  *
  * @tparam T type of variable
  * @param x variable
@@ -24,7 +24,7 @@ struct acos_fun {
 };
 
 /**
- * Returns the elementwise <code>acos()</code> of the input,
+ * Returns the elementwise \c acos() of the input,
  * which may be a scalar or any Stan container of numeric scalars.
  *
  * @tparam T type of container

--- a/stan/math/prim/fun/acos.hpp
+++ b/stan/math/prim/fun/acos.hpp
@@ -9,7 +9,7 @@ namespace stan {
 namespace math {
 
 /**
- * Structure to wrap \c acos() so it can be vectorized.
+ * Structure to wrap `acos()` so it can be vectorized.
  *
  * @tparam T type of variable
  * @param x variable
@@ -24,7 +24,7 @@ struct acos_fun {
 };
 
 /**
- * Returns the elementwise \c acos() of the input,
+ * Returns the elementwise `acos()` of the input,
  * which may be a scalar or any Stan container of numeric scalars.
  *
  * @tparam T type of container
@@ -37,7 +37,7 @@ inline auto acos(const T& x) {
 }
 
 /**
- * Version of acos() that accepts Eigen Matrix or matrix expressions.
+ * Version of `acos()` that accepts Eigen Matrix or matrix expressions.
  * @tparam Derived derived type of x
  * @param x Matrix or matrix expression
  * @return Arc cosine of each variable in the container, in radians.

--- a/stan/math/prim/fun/asin.hpp
+++ b/stan/math/prim/fun/asin.hpp
@@ -9,7 +9,7 @@ namespace stan {
 namespace math {
 
 /**
- * Structure to wrap <code>asin()</code> so it can be vectorized.
+ * Structure to wrap \c asin() so it can be vectorized.
  *
  * @tparam T type of argument
  * @param x argument
@@ -24,7 +24,7 @@ struct asin_fun {
 };
 
 /**
- * Returns the elementwise <code>asin()</code> of the input,
+ * Returns the elementwise \c asin() of the input,
  * which may be a scalar or any Stan container of numeric scalars.
  *
  * @tparam T type of container

--- a/stan/math/prim/fun/asin.hpp
+++ b/stan/math/prim/fun/asin.hpp
@@ -9,7 +9,7 @@ namespace stan {
 namespace math {
 
 /**
- * Structure to wrap asin() so it can be vectorized.
+ * Structure to wrap <code>asin()</code> so it can be vectorized.
  *
  * @tparam T type of argument
  * @param x argument
@@ -24,7 +24,8 @@ struct asin_fun {
 };
 
 /**
- * Vectorized version of asin().
+ * Returns the elementwise <code>asin()</code> of the input,
+ * which may be a scalar or any Stan container of numeric scalars.
  *
  * @tparam T type of container
  * @param x container

--- a/stan/math/prim/fun/asin.hpp
+++ b/stan/math/prim/fun/asin.hpp
@@ -9,7 +9,7 @@ namespace stan {
 namespace math {
 
 /**
- * Structure to wrap \c asin() so it can be vectorized.
+ * Structure to wrap `asin()` so it can be vectorized.
  *
  * @tparam T type of argument
  * @param x argument
@@ -24,7 +24,7 @@ struct asin_fun {
 };
 
 /**
- * Returns the elementwise \c asin() of the input,
+ * Returns the elementwise `asin()` of the input,
  * which may be a scalar or any Stan container of numeric scalars.
  *
  * @tparam T type of container
@@ -37,7 +37,7 @@ inline auto asin(const T& x) {
 }
 
 /**
- * Version of asin() that accepts Eigen Matrix or matrix expressions.
+ * Version of `asin()` that accepts Eigen Matrix or matrix expressions.
  *
  * @tparam Derived derived type of x
  * @param x Matrix or matrix expression

--- a/stan/math/prim/fun/asinh.hpp
+++ b/stan/math/prim/fun/asinh.hpp
@@ -25,7 +25,7 @@ struct asinh_fun {
 /**
  * Returns the elementwise <code>asinh()</code> of the input,
  * which may be a scalar or any Stan container of numeric scalars.
- * 
+ *
  * @tparam T type of container
  * @param x container
  * @return Inverse hyperbolic sine of each value in the container.

--- a/stan/math/prim/fun/asinh.hpp
+++ b/stan/math/prim/fun/asinh.hpp
@@ -8,7 +8,7 @@ namespace stan {
 namespace math {
 
 /**
- * Structure to wrap <code>asinh()</code> so it can be vectorized.
+ * Structure to wrap \c asinh() so it can be vectorized.
  *
  * @tparam T argument scalar type
  * @param x argument
@@ -23,7 +23,7 @@ struct asinh_fun {
 };
 
 /**
- * Returns the elementwise <code>asinh()</code> of the input,
+ * Returns the elementwise \c asinh() of the input,
  * which may be a scalar or any Stan container of numeric scalars.
  *
  * @tparam T type of container

--- a/stan/math/prim/fun/asinh.hpp
+++ b/stan/math/prim/fun/asinh.hpp
@@ -8,26 +8,7 @@ namespace stan {
 namespace math {
 
 /**
- * Return the inverse hyperbolic sine of the specified value.
- * Returns infinity for infinity argument and -infinity for
- * -infinity argument.
- * Returns nan for nan argument.
- *
- * @param[in] x Argument.
- * @return Inverse hyperbolic sine of the argument.
- */
-inline double asinh(double x) { return std::asinh(x); }
-
-/**
- * Integer version of asinh.
- *
- * @param[in] x Argument.
- * @return Inverse hyperbolic sine of the argument.
- */
-inline double asinh(int x) { return std::asinh(x); }
-
-/**
- * Structure to wrap asinh() so it can be vectorized.
+ * Structure to wrap <code>asinh()</code> so it can be vectorized.
  *
  * @tparam T argument scalar type
  * @param x argument
@@ -36,13 +17,15 @@ inline double asinh(int x) { return std::asinh(x); }
 struct asinh_fun {
   template <typename T>
   static inline T fun(const T& x) {
+    using std::asinh;
     return asinh(x);
   }
 };
 
 /**
- * Vectorized version of asinh().
- *
+ * Returns the elementwise <code>asinh()</code> of the input,
+ * which may be a scalar or any Stan container of numeric scalars.
+ * 
  * @tparam T type of container
  * @param x container
  * @return Inverse hyperbolic sine of each value in the container.

--- a/stan/math/prim/fun/asinh.hpp
+++ b/stan/math/prim/fun/asinh.hpp
@@ -8,7 +8,7 @@ namespace stan {
 namespace math {
 
 /**
- * Structure to wrap \c asinh() so it can be vectorized.
+ * Structure to wrap `asinh()` so it can be vectorized.
  *
  * @tparam T argument scalar type
  * @param x argument
@@ -23,7 +23,7 @@ struct asinh_fun {
 };
 
 /**
- * Returns the elementwise \c asinh() of the input,
+ * Returns the elementwise `asinh()` of the input,
  * which may be a scalar or any Stan container of numeric scalars.
  *
  * @tparam T type of container

--- a/stan/math/prim/fun/atan.hpp
+++ b/stan/math/prim/fun/atan.hpp
@@ -9,7 +9,7 @@ namespace stan {
 namespace math {
 
 /**
- * Structure to wrap atan() so it can be vectorized.
+ * Structure to wrap <code>atan()</code> so it can be vectorized.
  *
  * @tparam T type of variable
  * @param x variable
@@ -24,7 +24,8 @@ struct atan_fun {
 };
 
 /**
- * Vectorized version of atan().
+ * Returns the elementwise <code>atan()</code>of the input,
+ * which may be a scalar or any Stan container of numeric scalars.
  *
  * @tparam T type of container
  * @param x container

--- a/stan/math/prim/fun/atan.hpp
+++ b/stan/math/prim/fun/atan.hpp
@@ -9,7 +9,7 @@ namespace stan {
 namespace math {
 
 /**
- * Structure to wrap <code>atan()</code> so it can be vectorized.
+ * Structure to wrap \c atan() so it can be vectorized.
  *
  * @tparam T type of variable
  * @param x variable
@@ -24,7 +24,7 @@ struct atan_fun {
 };
 
 /**
- * Returns the elementwise <code>atan()</code>of the input,
+ * Returns the elementwise \c atan() of the input,
  * which may be a scalar or any Stan container of numeric scalars.
  *
  * @tparam T type of container

--- a/stan/math/prim/fun/atanh.hpp
+++ b/stan/math/prim/fun/atanh.hpp
@@ -36,12 +36,8 @@ inline double atanh(double x) {
  * @throw std::domain_error If argument is less than 1.
  */
 inline double atanh(int x) {
-  if (is_nan(x)) {
-    return x;
-  } else {
-    check_bounded("atanh", "x", x, -1, 1);
-    return std::atanh(x);
-  }
+  check_bounded("atanh", "x", x, -1, 1);
+  return std::atanh(x);
 }
 
 /**

--- a/stan/math/prim/fun/cbrt.hpp
+++ b/stan/math/prim/fun/cbrt.hpp
@@ -8,7 +8,7 @@ namespace stan {
 namespace math {
 
 /**
- * Structure to wrap \c cbrt() so it can be vectorized.
+ * Structure to wrap `cbrt()` so it can be vectorized.
  *
  * @tparam T type of variable
  * @param x variable
@@ -23,7 +23,7 @@ struct cbrt_fun {
 };
 
 /**
- * Returns the elementwise \c cbrt() of the input,
+ * Returns the elementwise `cbrt()` of the input,
  * which may be a scalar or any Stan container of numeric scalars.
  *
  * @tparam T type of container

--- a/stan/math/prim/fun/cbrt.hpp
+++ b/stan/math/prim/fun/cbrt.hpp
@@ -8,7 +8,7 @@ namespace stan {
 namespace math {
 
 /**
- * Structure to wrap <code>cbrt()</code> so it can be vectorized.
+ * Structure to wrap \c cbrt() so it can be vectorized.
  *
  * @tparam T type of variable
  * @param x variable
@@ -23,7 +23,7 @@ struct cbrt_fun {
 };
 
 /**
- * Returns the elementwise <code>cbrt()</code> of the input,
+ * Returns the elementwise \c cbrt() of the input,
  * which may be a scalar or any Stan container of numeric scalars.
  *
  * @tparam T type of container

--- a/stan/math/prim/fun/cbrt.hpp
+++ b/stan/math/prim/fun/cbrt.hpp
@@ -8,25 +8,7 @@ namespace stan {
 namespace math {
 
 /**
- * Return the cube root of the specified value
- *
- * @param[in] x Argument.
- * @return Cube root of the argument.
- * @throw std::domain_error If argument is negative.
- */
-inline double cbrt(double x) { return std::cbrt(x); }
-
-/**
- * Integer version of cbrt.
- *
- * @param[in] x Argument.
- * @return Cube root of the argument.
- * @throw std::domain_error If argument is less than 1.
- */
-inline double cbrt(int x) { return std::cbrt(x); }
-
-/**
- * Structure to wrap cbrt() so it can be vectorized.
+ * Structure to wrap <code>cbrt()</code> so it can be vectorized.
  *
  * @tparam T type of variable
  * @param x variable
@@ -35,12 +17,14 @@ inline double cbrt(int x) { return std::cbrt(x); }
 struct cbrt_fun {
   template <typename T>
   static inline T fun(const T& x) {
+    using std::cbrt;
     return cbrt(x);
   }
 };
 
 /**
- * Vectorized version of cbrt().
+ * Returns the elementwise <code>cbrt()</code> of the input,
+ * which may be a scalar or any Stan container of numeric scalars.
  *
  * @tparam T type of container
  * @param x container

--- a/stan/math/prim/fun/ceil.hpp
+++ b/stan/math/prim/fun/ceil.hpp
@@ -9,7 +9,7 @@ namespace stan {
 namespace math {
 
 /**
- * Structure to wrap ceil() so it can be vectorized.
+ * Structure to wrap <code>ceil()</code> so it can be vectorized.
  *
  * @tparam T type of variable
  * @param x variable
@@ -24,7 +24,8 @@ struct ceil_fun {
 };
 
 /**
- * Vectorized version of ceil().
+ * Returns the elementwise <code>ceil()</code> of the input,
+ * which may be a scalar or any Stan container of numeric scalars.
  *
  * @tparam T type of container
  * @param x container

--- a/stan/math/prim/fun/ceil.hpp
+++ b/stan/math/prim/fun/ceil.hpp
@@ -9,7 +9,7 @@ namespace stan {
 namespace math {
 
 /**
- * Structure to wrap \c ceil() so it can be vectorized.
+ * Structure to wrap `ceil()` so it can be vectorized.
  *
  * @tparam T type of variable
  * @param x variable
@@ -24,7 +24,7 @@ struct ceil_fun {
 };
 
 /**
- * Returns the elementwise \c ceil() of the input,
+ * Returns the elementwise `ceil()` of the input,
  * which may be a scalar or any Stan container of numeric scalars.
  *
  * @tparam T type of container
@@ -37,7 +37,7 @@ inline auto ceil(const T& x) {
 }
 
 /**
- * Version of \c ceil() that accepts Eigen Matrix or matrix expressions.
+ * Version of `ceil()` that accepts Eigen Matrix or matrix expressions.
  *
  * @tparam Derived derived type of x
  * @param x Matrix or matrix expression

--- a/stan/math/prim/fun/ceil.hpp
+++ b/stan/math/prim/fun/ceil.hpp
@@ -9,7 +9,7 @@ namespace stan {
 namespace math {
 
 /**
- * Structure to wrap <code>ceil()</code> so it can be vectorized.
+ * Structure to wrap \c ceil() so it can be vectorized.
  *
  * @tparam T type of variable
  * @param x variable
@@ -24,7 +24,7 @@ struct ceil_fun {
 };
 
 /**
- * Returns the elementwise <code>ceil()</code> of the input,
+ * Returns the elementwise \c ceil() of the input,
  * which may be a scalar or any Stan container of numeric scalars.
  *
  * @tparam T type of container
@@ -37,7 +37,7 @@ inline auto ceil(const T& x) {
 }
 
 /**
- * Version of ceil() that accepts Eigen Matrix or matrix expressions.
+ * Version of \c ceil() that accepts Eigen Matrix or matrix expressions.
  *
  * @tparam Derived derived type of x
  * @param x Matrix or matrix expression

--- a/stan/math/prim/fun/cos.hpp
+++ b/stan/math/prim/fun/cos.hpp
@@ -9,7 +9,7 @@ namespace stan {
 namespace math {
 
 /**
- * Structure to wrap cos() so it can be vectorized.
+ * Structure to wrap <code>cos()</code> so it can be vectorized.
  *
  * @tparam T type of variable
  * @param x angle in radians
@@ -24,7 +24,8 @@ struct cos_fun {
 };
 
 /**
- * Vectorized version of cos().
+ * Returns the elementwise <code>cos()</code> of the input,
+ * which may be a scalar or any Stan container of numeric scalars.
  *
  * @tparam T type of container
  * @param x angles in radians

--- a/stan/math/prim/fun/cos.hpp
+++ b/stan/math/prim/fun/cos.hpp
@@ -9,7 +9,7 @@ namespace stan {
 namespace math {
 
 /**
- * Structure to wrap <code>cos()</code> so it can be vectorized.
+ * Structure to wrap \c cos() so it can be vectorized.
  *
  * @tparam T type of variable
  * @param x angle in radians
@@ -24,7 +24,7 @@ struct cos_fun {
 };
 
 /**
- * Returns the elementwise <code>cos()</code> of the input,
+ * Returns the elementwise \c cos() of the input,
  * which may be a scalar or any Stan container of numeric scalars.
  *
  * @tparam T type of container
@@ -37,7 +37,7 @@ inline auto cos(const T& x) {
 }
 
 /**
- * Version of cos() that accepts Eigen Matrix or matrix expressions.
+ * Version of \c cos() that accepts Eigen Matrix or matrix expressions.
  *
  * @tparam Derived derived type of x
  * @param x Matrix or matrix expression

--- a/stan/math/prim/fun/cos.hpp
+++ b/stan/math/prim/fun/cos.hpp
@@ -9,7 +9,7 @@ namespace stan {
 namespace math {
 
 /**
- * Structure to wrap \c cos() so it can be vectorized.
+ * Structure to wrap `cos()` so it can be vectorized.
  *
  * @tparam T type of variable
  * @param x angle in radians
@@ -24,7 +24,7 @@ struct cos_fun {
 };
 
 /**
- * Returns the elementwise \c cos() of the input,
+ * Returns the elementwise `cos()` of the input,
  * which may be a scalar or any Stan container of numeric scalars.
  *
  * @tparam T type of container
@@ -37,7 +37,7 @@ inline auto cos(const T& x) {
 }
 
 /**
- * Version of \c cos() that accepts Eigen Matrix or matrix expressions.
+ * Version of `cos()` that accepts Eigen Matrix or matrix expressions.
  *
  * @tparam Derived derived type of x
  * @param x Matrix or matrix expression

--- a/stan/math/prim/fun/cosh.hpp
+++ b/stan/math/prim/fun/cosh.hpp
@@ -9,7 +9,7 @@ namespace stan {
 namespace math {
 
 /**
- * Structure to wrap cosh() so it can be vectorized.
+ * Structure to wrap <code>cosh()</code> so it can be vectorized.
  *
  * @tparam T type of argument
  * @param x angle in radians
@@ -24,7 +24,8 @@ struct cosh_fun {
 };
 
 /**
- * Vectorized version of cosh().
+ * Returns the elementwise <code>cosh()</code> of the input,
+ * which may be a scalar or any Stan container of numeric scalars.
  *
  * @tparam T type of container
  * @param x angles in radians

--- a/stan/math/prim/fun/cosh.hpp
+++ b/stan/math/prim/fun/cosh.hpp
@@ -9,7 +9,7 @@ namespace stan {
 namespace math {
 
 /**
- * Structure to wrap \c cosh() so it can be vectorized.
+ * Structure to wrap `cosh()` so it can be vectorized.
  *
  * @tparam T type of argument
  * @param x angle in radians
@@ -24,7 +24,7 @@ struct cosh_fun {
 };
 
 /**
- * Returns the elementwise \c cosh() of the input,
+ * Returns the elementwise `cosh()` of the input,
  * which may be a scalar or any Stan container of numeric scalars.
  *
  * @tparam T type of container
@@ -37,7 +37,7 @@ inline typename apply_scalar_unary<cosh_fun, T>::return_t cosh(const T& x) {
 }
 
 /**
- * Version of \c cosh() that accepts Eigen Matrix or matrix expressions.
+ * Version of `cosh()` that accepts Eigen Matrix or matrix expressions.
  *
  * @tparam Derived derived type of x
  * @param x Matrix or matrix expression

--- a/stan/math/prim/fun/cosh.hpp
+++ b/stan/math/prim/fun/cosh.hpp
@@ -9,7 +9,7 @@ namespace stan {
 namespace math {
 
 /**
- * Structure to wrap <code>cosh()</code> so it can be vectorized.
+ * Structure to wrap \c cosh() so it can be vectorized.
  *
  * @tparam T type of argument
  * @param x angle in radians
@@ -24,7 +24,7 @@ struct cosh_fun {
 };
 
 /**
- * Returns the elementwise <code>cosh()</code> of the input,
+ * Returns the elementwise \c cosh() of the input,
  * which may be a scalar or any Stan container of numeric scalars.
  *
  * @tparam T type of container
@@ -37,7 +37,7 @@ inline typename apply_scalar_unary<cosh_fun, T>::return_t cosh(const T& x) {
 }
 
 /**
- * Version of cosh() that accepts Eigen Matrix or matrix expressions.
+ * Version of \c cosh() that accepts Eigen Matrix or matrix expressions.
  *
  * @tparam Derived derived type of x
  * @param x Matrix or matrix expression

--- a/stan/math/prim/fun/erf.hpp
+++ b/stan/math/prim/fun/erf.hpp
@@ -8,28 +8,7 @@ namespace stan {
 namespace math {
 
 /**
- * Return the error function of the specified value.
- *
- * \f[
- * \mbox{erf}(x) = \frac{2}{\sqrt{\pi}} \int_0^x e^{-t^2} dt
- * \f]
- *
- * @param[in] x Argument.
- * @return Error function of the argument.
- */
-inline double erf(double x) { return std::erf(x); }
-
-/**
- * Return the error function of the specified argument.  This
- * version is required to disambiguate <code>erf(int)</code>.
- *
- * @param[in] x Argument.
- * @return Error function of the argument.
- */
-inline double erf(int x) { return std::erf(x); }
-
-/**
- * Structure to wrap erf() so it can be vectorized.
+ * Structure to wrap <code>erf()</code> so it can be vectorized.
  *
  * @tparam T type of variable
  * @param x variable
@@ -38,12 +17,14 @@ inline double erf(int x) { return std::erf(x); }
 struct erf_fun {
   template <typename T>
   static inline T fun(const T& x) {
+    using std::erf;
     return erf(x);
   }
 };
 
 /**
- * Vectorized version of erf().
+ * Returns the elementwise <code>erf()</code> of the input,
+ * which may be a scalar or any Stan container of numeric scalars.
  *
  * @tparam T type of container
  * @param x container

--- a/stan/math/prim/fun/erf.hpp
+++ b/stan/math/prim/fun/erf.hpp
@@ -8,7 +8,7 @@ namespace stan {
 namespace math {
 
 /**
- * Structure to wrap \c erf() so it can be vectorized.
+ * Structure to wrap `erf()` so it can be vectorized.
  *
  * @tparam T type of variable
  * @param x variable
@@ -23,7 +23,7 @@ struct erf_fun {
 };
 
 /**
- * Returns the elementwise \c erf() of the input,
+ * Returns the elementwise `erf()` of the input,
  * which may be a scalar or any Stan container of numeric scalars.
  *
  * @tparam T type of container

--- a/stan/math/prim/fun/erf.hpp
+++ b/stan/math/prim/fun/erf.hpp
@@ -8,7 +8,7 @@ namespace stan {
 namespace math {
 
 /**
- * Structure to wrap <code>erf()</code> so it can be vectorized.
+ * Structure to wrap \c erf() so it can be vectorized.
  *
  * @tparam T type of variable
  * @param x variable
@@ -23,7 +23,7 @@ struct erf_fun {
 };
 
 /**
- * Returns the elementwise <code>erf()</code> of the input,
+ * Returns the elementwise \c erf() of the input,
  * which may be a scalar or any Stan container of numeric scalars.
  *
  * @tparam T type of container

--- a/stan/math/prim/fun/erfc.hpp
+++ b/stan/math/prim/fun/erfc.hpp
@@ -8,7 +8,7 @@ namespace stan {
 namespace math {
 
 /**
- * Structure to wrap the \c erfc()
+ * Structure to wrap the `erfc()`
  * so that it can be vectorized.
  *
  * @tparam T type of variable
@@ -24,7 +24,7 @@ struct erfc_fun {
 };
 
 /**
- * Returns the elementwise \c erfc() of the input,
+ * Returns the elementwise `erfc()` of the input,
  * which may be a scalar or any Stan container of numeric scalars.
  *
  * @tparam T type of container

--- a/stan/math/prim/fun/erfc.hpp
+++ b/stan/math/prim/fun/erfc.hpp
@@ -8,7 +8,7 @@ namespace stan {
 namespace math {
 
 /**
- * Structure to wrap the <code>erfc()</code>
+ * Structure to wrap the \c erfc()
  * so that it can be vectorized.
  *
  * @tparam T type of variable
@@ -24,7 +24,7 @@ struct erfc_fun {
 };
 
 /**
- * Returns the elementwise <code>erfc()</code> of the input,
+ * Returns the elementwise \c erfc() of the input,
  * which may be a scalar or any Stan container of numeric scalars.
  *
  * @tparam T type of container

--- a/stan/math/prim/fun/erfc.hpp
+++ b/stan/math/prim/fun/erfc.hpp
@@ -8,28 +8,8 @@ namespace stan {
 namespace math {
 
 /**
- * Return the complementary error function of the specified value.
- *
- * \f[
- * \mbox{erfc}(x) = 1 - \frac{2}{\sqrt{\pi}} \int_0^x e^{-t^2} dt
- * \f]
- *
- * @param[in] x Argument.
- * @return Complementary error function of the argument.
- */
-inline double erfc(double x) { return std::erfc(x); }
-
-/**
- * Return the error function of the specified argument.  This
- * version is required to disambiguate <code>erfc(int)</code>.
- *
- * @param[in] x Argument.
- * @return Complementary error function value of the argument.
- */
-inline double erfc(int x) { return std::erfc(x); }
-
-/**
- * Structure to wrap erfc() so that it can be vectorized.
+ * Structure to wrap the <code>erfc()</code>
+ * so that it can be vectorized.
  *
  * @tparam T type of variable
  * @param x variable
@@ -38,12 +18,14 @@ inline double erfc(int x) { return std::erfc(x); }
 struct erfc_fun {
   template <typename T>
   static inline T fun(const T& x) {
+    using std::erfc;
     return erfc(x);
   }
 };
 
 /**
- * Vectorized version of erfc().
+ * Returns the elementwise <code>erfc()</code> of the input,
+ * which may be a scalar or any Stan container of numeric scalars.
  *
  * @tparam T type of container
  * @param x container

--- a/stan/math/prim/fun/exp.hpp
+++ b/stan/math/prim/fun/exp.hpp
@@ -9,7 +9,7 @@ namespace stan {
 namespace math {
 
 /**
- * Structure to wrap <code>exp()</code> so that it can be
+ * Structure to wrap \c exp() so that it can be
  * vectorized.
  */
 struct exp_fun {
@@ -28,7 +28,7 @@ struct exp_fun {
 };
 
 /**
- * Return the elementwise <code>exp()</code> of the specified argument,
+ * Return the elementwise \c exp() of the specified argument,
  * which may be a scalar or any Stan container of numeric scalars.
  * The return type is the same as the argument type.
  *
@@ -42,7 +42,7 @@ inline auto exp(const T& x) {
 }
 
 /**
- * Version of exp() that accepts Eigen Matrix or matrix expressions.
+ * Version of \c exp() that accepts Eigen Matrix or matrix expressions.
  * @tparam Derived derived type of x
  * @param x Matrix or matrix expression
  * @return Elementwise application of exponentiation to the argument.

--- a/stan/math/prim/fun/exp.hpp
+++ b/stan/math/prim/fun/exp.hpp
@@ -9,15 +9,6 @@ namespace stan {
 namespace math {
 
 /**
- * Return the natural exponential of the specified argument.  This
- * version is required to disambiguate <code>exp(int)</code>.
- *
- * @param[in] x Argument.
- * @return Natural exponential of argument.
- */
-inline double exp(int x) { return std::exp(x); }
-
-/**
  * Structure to wrap <code>exp()</code> so that it can be
  * vectorized.
  */
@@ -37,7 +28,7 @@ struct exp_fun {
 };
 
 /**
- * Return the elementwise exponentiation of the specified argument,
+ * Return the elementwise <code>exp()</code> of the specified argument,
  * which may be a scalar or any Stan container of numeric scalars.
  * The return type is the same as the argument type.
  *

--- a/stan/math/prim/fun/exp.hpp
+++ b/stan/math/prim/fun/exp.hpp
@@ -9,7 +9,7 @@ namespace stan {
 namespace math {
 
 /**
- * Structure to wrap \c exp() so that it can be
+ * Structure to wrap `exp()` so that it can be
  * vectorized.
  */
 struct exp_fun {
@@ -28,7 +28,7 @@ struct exp_fun {
 };
 
 /**
- * Return the elementwise \c exp() of the specified argument,
+ * Return the elementwise `exp()` of the specified argument,
  * which may be a scalar or any Stan container of numeric scalars.
  * The return type is the same as the argument type.
  *
@@ -42,7 +42,7 @@ inline auto exp(const T& x) {
 }
 
 /**
- * Version of \c exp() that accepts Eigen Matrix or matrix expressions.
+ * Version of `exp()` that accepts Eigen Matrix or matrix expressions.
  * @tparam Derived derived type of x
  * @param x Matrix or matrix expression
  * @return Elementwise application of exponentiation to the argument.

--- a/stan/math/prim/fun/exp2.hpp
+++ b/stan/math/prim/fun/exp2.hpp
@@ -8,7 +8,7 @@ namespace stan {
 namespace math {
 
 /**
- * Structure to wrap <code>exp2()</code> so it can be vectorized.
+ * Structure to wrap \c exp2() so it can be vectorized.
  */
 struct exp2_fun {
   /**
@@ -26,7 +26,7 @@ struct exp2_fun {
 };
 
 /**
- * Return the elementwise <code>exp2()</code> of the specified argument,
+ * Return the elementwise \c exp2() of the specified argument,
  * which may be a scalar or any Stan container of numeric scalars.
  * The return type is the same as the argument type.
  *

--- a/stan/math/prim/fun/exp2.hpp
+++ b/stan/math/prim/fun/exp2.hpp
@@ -8,24 +8,7 @@ namespace stan {
 namespace math {
 
 /**
- * Return the exponent base 2 of the specified argument (C99,
- * C++11).
- *
- * The exponent base 2 function is defined by
- *
- * <code>exp2(y) = pow(2.0, y)</code>.
- *
- * @param y argument.
- * @return exponent base 2 of argument.
- */
-template <typename T, typename = require_arithmetic_t<T>>
-inline double exp2(T y) {
-  using std::exp2;
-  return exp2(y);
-}
-
-/**
- * Structure to wrap exp2() so it can be vectorized.
+ * Structure to wrap <code>exp2()</code> so it can be vectorized.
  */
 struct exp2_fun {
   /**
@@ -37,21 +20,21 @@ struct exp2_fun {
    */
   template <typename T>
   static inline T fun(const T& x) {
+    using std::exp2;
     return exp2(x);
   }
 };
 
 /**
- * Return the elementwise application of <code>exp2()</code> to
- * specified argument container.  The return type promotes the
- * underlying scalar argument type to double if it is an integer,
- * and otherwise is the argument type.
+ * Return the elementwise <code>exp2()</code> of the specified argument,
+ * which may be a scalar or any Stan container of numeric scalars.
+ * The return type is the same as the argument type.
  *
  * @tparam T type of container
  * @param x container
  * @return Elementwise exp2 of members of container.
  */
-template <typename T, typename = require_vector_like_t<T>>
+template <typename T>
 inline auto exp2(const T& x) {
   return apply_scalar_unary<exp2_fun, T>::apply(x);
 }

--- a/stan/math/prim/fun/exp2.hpp
+++ b/stan/math/prim/fun/exp2.hpp
@@ -8,7 +8,7 @@ namespace stan {
 namespace math {
 
 /**
- * Structure to wrap \c exp2() so it can be vectorized.
+ * Structure to wrap `exp2()` so it can be vectorized.
  */
 struct exp2_fun {
   /**
@@ -26,7 +26,7 @@ struct exp2_fun {
 };
 
 /**
- * Return the elementwise \c exp2() of the specified argument,
+ * Return the elementwise `exp2()` of the specified argument,
  * which may be a scalar or any Stan container of numeric scalars.
  * The return type is the same as the argument type.
  *

--- a/stan/math/prim/fun/expm1.hpp
+++ b/stan/math/prim/fun/expm1.hpp
@@ -8,7 +8,7 @@ namespace stan {
 namespace math {
 
 /**
- * Structure to wrap \c expm1() so that it can be vectorized.
+ * Structure to wrap `expm1()` so that it can be vectorized.
  *
  * @tparam T type of variable
  * @param x variable
@@ -23,7 +23,7 @@ struct expm1_fun {
 };
 
 /**
- * Return the elementwise \c expm1() of the specified argument,
+ * Return the elementwise `expm1()` of the specified argument,
  * which may be a scalar or any Stan container of numeric scalars.
  * The return type is the same as the argument type.
  *

--- a/stan/math/prim/fun/expm1.hpp
+++ b/stan/math/prim/fun/expm1.hpp
@@ -8,7 +8,7 @@ namespace stan {
 namespace math {
 
 /**
- * Structure to wrap expm1() so that it can be vectorized.
+ * Structure to wrap \c expm1() so that it can be vectorized.
  *
  * @tparam T type of variable
  * @param x variable
@@ -23,7 +23,7 @@ struct expm1_fun {
 };
 
 /**
- * Return the elementwise expm1() of the specified argument,
+ * Return the elementwise \c expm1() of the specified argument,
  * which may be a scalar or any Stan container of numeric scalars.
  * The return type is the same as the argument type.
  *

--- a/stan/math/prim/fun/expm1.hpp
+++ b/stan/math/prim/fun/expm1.hpp
@@ -8,24 +8,6 @@ namespace stan {
 namespace math {
 
 /**
- * Return the natural exponentiation of x minus one.
- * Returns infinity for infinity argument and -infinity for
- * -infinity argument.
- *
- * @param[in] x Argument.
- * @return Natural exponentiation of argument minus one.
- */
-inline double expm1(double x) { return std::expm1(x); }
-
-/**
- * Integer version of expm1.
- *
- * @param[in] x Argument.
- * @return Natural exponentiation of argument minus one.
- */
-inline double expm1(int x) { return std::expm1(x); }
-
-/**
  * Structure to wrap expm1() so that it can be vectorized.
  *
  * @tparam T type of variable
@@ -35,12 +17,15 @@ inline double expm1(int x) { return std::expm1(x); }
 struct expm1_fun {
   template <typename T>
   static inline T fun(const T& x) {
+    using std::expm1;
     return expm1(x);
   }
 };
 
 /**
- * Vectorized version of expm1().
+ * Return the elementwise expm1() of the specified argument,
+ * which may be a scalar or any Stan container of numeric scalars.
+ * The return type is the same as the argument type.
  *
  * @tparam T type of container
  * @param x container

--- a/stan/math/prim/fun/fabs.hpp
+++ b/stan/math/prim/fun/fabs.hpp
@@ -9,7 +9,7 @@ namespace stan {
 namespace math {
 
 /**
- * Structure to wrap fabs() so that it can be vectorized.
+ * Structure to wrap <code>fabs()</code> so that it can be vectorized.
  *
  * @tparam T type of variable
  * @param x variable
@@ -24,7 +24,8 @@ struct fabs_fun {
 };
 
 /**
- * Vectorized version of fabs().
+ * Returns the elementwise <code>fabs()</code> of the input,
+ * which may be a scalar or any Stan container of numeric scalars.
  *
  * @tparam T type of container
  * @param x container

--- a/stan/math/prim/fun/fabs.hpp
+++ b/stan/math/prim/fun/fabs.hpp
@@ -9,7 +9,7 @@ namespace stan {
 namespace math {
 
 /**
- * Structure to wrap <code>fabs()</code> so that it can be vectorized.
+ * Structure to wrap \c fabs() so that it can be vectorized.
  *
  * @tparam T type of variable
  * @param x variable
@@ -24,7 +24,7 @@ struct fabs_fun {
 };
 
 /**
- * Returns the elementwise <code>fabs()</code> of the input,
+ * Returns the elementwise \c fabs() of the input,
  * which may be a scalar or any Stan container of numeric scalars.
  *
  * @tparam T type of container
@@ -37,7 +37,7 @@ inline typename apply_scalar_unary<fabs_fun, T>::return_t fabs(const T& x) {
 }
 
 /**
- * Version of fabs() that accepts Eigen Matrix or matrix expressions.
+ * Version of \c fabs() that accepts Eigen Matrix or matrix expressions.
  *
  * @tparam Derived derived type of x
  * @param x Matrix or matrix expression
@@ -50,7 +50,7 @@ inline auto fabs(const Eigen::MatrixBase<Derived>& x) {
 }
 
 /**
- * Version of fabs() that accepts Eigen Array or array expressions.
+ * Version of \c fabs() that accepts Eigen Array or array expressions.
  *
  * @tparam Derived derived type of x
  * @param x Matrix or matrix expression

--- a/stan/math/prim/fun/fabs.hpp
+++ b/stan/math/prim/fun/fabs.hpp
@@ -9,7 +9,7 @@ namespace stan {
 namespace math {
 
 /**
- * Structure to wrap \c fabs() so that it can be vectorized.
+ * Structure to wrap `fabs()` so that it can be vectorized.
  *
  * @tparam T type of variable
  * @param x variable
@@ -24,7 +24,7 @@ struct fabs_fun {
 };
 
 /**
- * Returns the elementwise \c fabs() of the input,
+ * Returns the elementwise `fabs()` of the input,
  * which may be a scalar or any Stan container of numeric scalars.
  *
  * @tparam T type of container
@@ -37,7 +37,7 @@ inline typename apply_scalar_unary<fabs_fun, T>::return_t fabs(const T& x) {
 }
 
 /**
- * Version of \c fabs() that accepts Eigen Matrix or matrix expressions.
+ * Version of `fabs()` that accepts Eigen Matrix or matrix expressions.
  *
  * @tparam Derived derived type of x
  * @param x Matrix or matrix expression

--- a/stan/math/prim/fun/floor.hpp
+++ b/stan/math/prim/fun/floor.hpp
@@ -9,7 +9,7 @@ namespace stan {
 namespace math {
 
 /**
- * Structure to wrap floor() so that it can be vectorized.
+ * Structure to wrap <code>floor()</code> so that it can be vectorized.
  *
  * @tparam T type of variable
  * @param x variable
@@ -24,7 +24,8 @@ struct floor_fun {
 };
 
 /**
- * Vectorized version of floor().
+ * Returns the elementwise <code>floor()</code> of the input,
+ * which may be a scalar or any Stan container of numeric scalars.
  *
  * @tparam T type of container
  * @param x container

--- a/stan/math/prim/fun/floor.hpp
+++ b/stan/math/prim/fun/floor.hpp
@@ -9,7 +9,7 @@ namespace stan {
 namespace math {
 
 /**
- * Structure to wrap \c floor() so that it can be vectorized.
+ * Structure to wrap `floor()` so that it can be vectorized.
  *
  * @tparam T type of variable
  * @param x variable
@@ -24,7 +24,7 @@ struct floor_fun {
 };
 
 /**
- * Returns the elementwise \c floor() of the input,
+ * Returns the elementwise `floor()` of the input,
  * which may be a scalar or any Stan container of numeric scalars.
  *
  * @tparam T type of container
@@ -37,7 +37,7 @@ inline auto floor(const T& x) {
 }
 
 /**
- * Version of \c floor() that accepts Eigen Matrix or matrix expressions.
+ * Version of `floor()` that accepts Eigen Matrix or matrix expressions.
  *
  * @tparam Derived derived type of x
  * @param x Matrix or matrix expression

--- a/stan/math/prim/fun/floor.hpp
+++ b/stan/math/prim/fun/floor.hpp
@@ -9,7 +9,7 @@ namespace stan {
 namespace math {
 
 /**
- * Structure to wrap <code>floor()</code> so that it can be vectorized.
+ * Structure to wrap \c floor() so that it can be vectorized.
  *
  * @tparam T type of variable
  * @param x variable
@@ -24,7 +24,7 @@ struct floor_fun {
 };
 
 /**
- * Returns the elementwise <code>floor()</code> of the input,
+ * Returns the elementwise \c floor() of the input,
  * which may be a scalar or any Stan container of numeric scalars.
  *
  * @tparam T type of container
@@ -37,7 +37,7 @@ inline auto floor(const T& x) {
 }
 
 /**
- * Version of floor() that accepts Eigen Matrix or matrix expressions.
+ * Version of \c floor() that accepts Eigen Matrix or matrix expressions.
  *
  * @tparam Derived derived type of x
  * @param x Matrix or matrix expression

--- a/stan/math/prim/fun/inv.hpp
+++ b/stan/math/prim/fun/inv.hpp
@@ -18,7 +18,6 @@ struct inv_fun {
   template <typename T>
   static inline T fun(const T& x) {
     return 1.0 / x;
-    ;
   }
 };
 

--- a/stan/math/prim/fun/inv.hpp
+++ b/stan/math/prim/fun/inv.hpp
@@ -17,7 +17,8 @@ namespace math {
 struct inv_fun {
   template <typename T>
   static inline T fun(const T& x) {
-    return 1.0 / x;;
+    return 1.0 / x;
+    ;
   }
 };
 

--- a/stan/math/prim/fun/inv.hpp
+++ b/stan/math/prim/fun/inv.hpp
@@ -48,7 +48,7 @@ inline auto inv(const Eigen::MatrixBase<Derived>& x) {
 }
 
 /**
- * Version of \c inv() that accepts Eigen Array or array expressions.
+ * Version of `inv()` that accepts Eigen Array or array expressions.
  *
  * @tparam Derived derived type of x
  * @param x Matrix or matrix expression

--- a/stan/math/prim/fun/inv.hpp
+++ b/stan/math/prim/fun/inv.hpp
@@ -7,10 +7,8 @@
 namespace stan {
 namespace math {
 
-inline double inv(double x) { return 1.0 / x; }
-
 /**
- * Structure to wrap inv() so that it can be vectorized.
+ * Structure to wrap 1.0 / x so that it can be vectorized.
  *
  * @tparam T type of variable
  * @param x variable
@@ -19,12 +17,13 @@ inline double inv(double x) { return 1.0 / x; }
 struct inv_fun {
   template <typename T>
   static inline T fun(const T& x) {
-    return inv(x);
+    return 1.0 / x;;
   }
 };
 
 /**
- * Vectorized version of inv().
+ * Return the elementwise 1.0 / x of the specified argument,
+ * which may be a scalar or any Stan container of numeric scalars.
  *
  * @tparam T type of container
  * @param x container

--- a/stan/math/prim/fun/inv.hpp
+++ b/stan/math/prim/fun/inv.hpp
@@ -35,7 +35,7 @@ inline auto inv(const T& x) {
 }
 
 /**
- * Version of inv() that accepts Eigen Matrix or matrix expressions.
+ * Version of \c inv() that accepts Eigen Matrix or matrix expressions.
  *
  * @tparam Derived derived type of x
  * @param x Matrix or matrix expression
@@ -48,7 +48,7 @@ inline auto inv(const Eigen::MatrixBase<Derived>& x) {
 }
 
 /**
- * Version of inv() that accepts Eigen Array or array expressions.
+ * Version of \c inv() that accepts Eigen Array or array expressions.
  *
  * @tparam Derived derived type of x
  * @param x Matrix or matrix expression

--- a/stan/math/prim/fun/inv_sqrt.hpp
+++ b/stan/math/prim/fun/inv_sqrt.hpp
@@ -10,13 +10,8 @@
 namespace stan {
 namespace math {
 
-inline double inv_sqrt(double x) {
-  using std::sqrt;
-  return inv(sqrt(x));
-}
-
 /**
- * Structure to wrap inv_sqrt() so that it can be vectorized.
+ * Structure to wrap 1 / sqrt(x) so that it can be vectorized.
  *
  * @tparam T type of variable
  * @param x variable
@@ -25,12 +20,14 @@ inline double inv_sqrt(double x) {
 struct inv_sqrt_fun {
   template <typename T>
   static inline T fun(const T& x) {
-    return inv_sqrt(x);
+    using std::sqrt;
+    return inv(sqrt(x));
   }
 };
 
 /**
- * Vectorized version of inv_sqrt().
+ * Return the elementwise 1 / sqrt(x) of the specified argument,
+ * which may be a scalar or any Stan container of numeric scalars.
  *
  * @tparam T type of container
  * @param x container

--- a/stan/math/prim/fun/inv_sqrt.hpp
+++ b/stan/math/prim/fun/inv_sqrt.hpp
@@ -11,7 +11,7 @@ namespace stan {
 namespace math {
 
 /**
- * Structure to wrap 1 / sqrt(x) so that it can be vectorized.
+ * Structure to wrap \code{1 / sqrt(x)} so that it can be vectorized.
  *
  * @tparam T type of variable
  * @param x variable
@@ -26,7 +26,7 @@ struct inv_sqrt_fun {
 };
 
 /**
- * Return the elementwise 1 / sqrt(x) of the specified argument,
+ * Return the elementwise \code{1 / sqrt(x)} of the specified argument,
  * which may be a scalar or any Stan container of numeric scalars.
  *
  * @tparam T type of container
@@ -39,7 +39,7 @@ inline auto inv_sqrt(const T& x) {
 }
 
 /**
- * Version of inv_sqrt() that accepts Eigen Matrix or matrix expressions.
+ * Version of \c inv_sqrt() that accepts Eigen Matrix or matrix expressions.
  *
  * @tparam Derived derived type of x
  * @param x Matrix or matrix expression
@@ -52,7 +52,7 @@ inline auto inv_sqrt(const Eigen::MatrixBase<Derived>& x) {
 }
 
 /**
- * Version of inv_sqrt() that accepts Eigen Array or array expressions.
+ * Version of \c inv_sqrt() that accepts Eigen Array or array expressions.
  *
  * @tparam Derived derived type of x
  * @param x Matrix or matrix expression

--- a/stan/math/prim/fun/inv_sqrt.hpp
+++ b/stan/math/prim/fun/inv_sqrt.hpp
@@ -11,7 +11,7 @@ namespace stan {
 namespace math {
 
 /**
- * Structure to wrap \code{1 / sqrt(x)} so that it can be vectorized.
+ * Structure to wrap `1 / sqrt(x)}` so that it can be vectorized.
  *
  * @tparam T type of variable
  * @param x variable
@@ -26,7 +26,7 @@ struct inv_sqrt_fun {
 };
 
 /**
- * Return the elementwise \code{1 / sqrt(x)} of the specified argument,
+ * Return the elementwise `1 / sqrt(x)}` of the specified argument,
  * which may be a scalar or any Stan container of numeric scalars.
  *
  * @tparam T type of container
@@ -39,7 +39,7 @@ inline auto inv_sqrt(const T& x) {
 }
 
 /**
- * Version of \c inv_sqrt() that accepts Eigen Matrix or matrix expressions.
+ * Version of `inv_sqrt()` that accepts Eigen Matrix or matrix expressions.
  *
  * @tparam Derived derived type of x
  * @param x Matrix or matrix expression

--- a/stan/math/prim/fun/inv_square.hpp
+++ b/stan/math/prim/fun/inv_square.hpp
@@ -9,14 +9,12 @@
 namespace stan {
 namespace math {
 
-inline double inv_square(double x) { return inv(square(x)); }
-
 /**
- * Vectorized version of inv_square().
+ * Returns 1 / square(x).
  *
  * @tparam T type of container
  * @param x container
- * @return 1 / the square of each value in x.
+ * @return 1 / square(x) of each value in x.
  */
 template <typename T>
 inline auto inv_square(const T& x) {

--- a/stan/math/prim/fun/inv_square.hpp
+++ b/stan/math/prim/fun/inv_square.hpp
@@ -10,11 +10,11 @@ namespace stan {
 namespace math {
 
 /**
- * Returns 1 / square(x).
+ * Returns \code{1 / square(x)}.
  *
  * @tparam T type of container
  * @param x container
- * @return 1 / square(x) of each value in x.
+ * @return \code{1 / square(x)} of each value in x.
  */
 template <typename T>
 inline auto inv_square(const T& x) {

--- a/stan/math/prim/fun/inv_square.hpp
+++ b/stan/math/prim/fun/inv_square.hpp
@@ -10,11 +10,11 @@ namespace stan {
 namespace math {
 
 /**
- * Returns \code{1 / square(x)}.
+ * Returns `1 / square(x)`.
  *
  * @tparam T type of container
  * @param x container
- * @return \code{1 / square(x)} of each value in x.
+ * @return `1 / square(x)` of each value in x.
  */
 template <typename T>
 inline auto inv_square(const T& x) {

--- a/stan/math/prim/fun/log.hpp
+++ b/stan/math/prim/fun/log.hpp
@@ -9,16 +9,7 @@ namespace stan {
 namespace math {
 
 /**
- * Return the natural log of the specified argument.  This version
- * is required to disambiguate <code>log(int)</code>.
- *
- * @param[in] x Argument.
- * @return Natural log of argument.
- */
-inline double log(int x) { return std::log(x); }
-
-/**
- * Structure to wrap log() so that it can be vectorized.
+ * Structure to wrap <code>log()</code> so that it can be vectorized.
  */
 struct log_fun {
   /**

--- a/stan/math/prim/fun/log.hpp
+++ b/stan/math/prim/fun/log.hpp
@@ -9,7 +9,7 @@ namespace stan {
 namespace math {
 
 /**
- * Structure to wrap <code>log()</code> so that it can be vectorized.
+ * Structure to wrap \c log() so that it can be vectorized.
  */
 struct log_fun {
   /**
@@ -41,7 +41,7 @@ inline auto log(const T& x) {
 }
 
 /**
- * Version of log() that accepts Eigen Matrix or matrix expressions.
+ * Version of \c log() that accepts Eigen Matrix or matrix expressions.
  *
  * @tparam Derived derived type of x
  * @param x Matrix or matrix expression

--- a/stan/math/prim/fun/log.hpp
+++ b/stan/math/prim/fun/log.hpp
@@ -9,7 +9,7 @@ namespace stan {
 namespace math {
 
 /**
- * Structure to wrap \c log() so that it can be vectorized.
+ * Structure to wrap `log()` so that it can be vectorized.
  */
 struct log_fun {
   /**
@@ -41,7 +41,7 @@ inline auto log(const T& x) {
 }
 
 /**
- * Version of \c log() that accepts Eigen Matrix or matrix expressions.
+ * Version of `log()` that accepts Eigen Matrix or matrix expressions.
  *
  * @tparam Derived derived type of x
  * @param x Matrix or matrix expression

--- a/stan/math/prim/fun/log1p.hpp
+++ b/stan/math/prim/fun/log1p.hpp
@@ -45,12 +45,8 @@ inline double log1p(double x) {
  * @throw std::domain_error If argument is less than -1.
  */
 inline double log1p(int x) {
-  if (is_nan(x)) {
-    return x;
-  } else {
-    check_greater_or_equal("log1p", "x", x, -1);
-    return std::log1p(x);
-  }
+  check_greater_or_equal("log1p", "x", x, -1);
+  return std::log1p(x);
 }
 
 /**

--- a/stan/math/prim/fun/log2.hpp
+++ b/stan/math/prim/fun/log2.hpp
@@ -3,27 +3,10 @@
 
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/fun/constants.hpp>
-#include <stan/math/prim/fun/log.hpp>
 #include <cmath>
 
 namespace stan {
 namespace math {
-
-/**
- * Returns the base two logarithm of the argument (C99, C++11).
- *
- * The function is defined by:
- *
- * <code>log2(a) = log(a) / std::log(2.0)</code>.
- *
- * @param[in] u argument
- * @return base two logarithm of argument
- */
-template <typename T, typename = require_arithmetic_t<T>>
-inline double log2(T u) {
-  using std::log2;
-  return log2(u);
-}
 
 /**
  * Return natural logarithm of two.
@@ -45,6 +28,7 @@ struct log2_fun {
    */
   template <typename T>
   static inline T fun(const T& x) {
+    using std::log2;
     return log2(x);
   }
 };
@@ -59,7 +43,7 @@ struct log2_fun {
  * @param x container
  * @return elementwise log2 of container elements
  */
-template <typename T, typename = require_vector_like_t<T>>
+template <typename T>
 inline auto log2(const T& x) {
   return apply_scalar_unary<log2_fun, T>::apply(x);
 }

--- a/stan/math/prim/fun/log2.hpp
+++ b/stan/math/prim/fun/log2.hpp
@@ -16,7 +16,7 @@ namespace math {
 inline double log2() { return LOG_TWO; }
 
 /**
- * Structure to wrap log2() so it can be vectorized.
+ * Structure to wrap \c log2() so it can be vectorized.
  */
 struct log2_fun {
   /**
@@ -34,7 +34,7 @@ struct log2_fun {
 };
 
 /**
- * Return the elementwise application of <code>log2()</code> to
+ * Return the elementwise application of \c log2() to
  * specified argument container.  The return type promotes the
  * underlying scalar argument type to double if it is an integer,
  * and otherwise is the argument type.

--- a/stan/math/prim/fun/log2.hpp
+++ b/stan/math/prim/fun/log2.hpp
@@ -16,7 +16,7 @@ namespace math {
 inline double log2() { return LOG_TWO; }
 
 /**
- * Structure to wrap \c log2() so it can be vectorized.
+ * Structure to wrap `log2()` so it can be vectorized.
  */
 struct log2_fun {
   /**
@@ -34,7 +34,7 @@ struct log2_fun {
 };
 
 /**
- * Return the elementwise application of \c log2() to
+ * Return the elementwise application of `log2()` to
  * specified argument container.  The return type promotes the
  * underlying scalar argument type to double if it is an integer,
  * and otherwise is the argument type.

--- a/stan/math/prim/fun/round.hpp
+++ b/stan/math/prim/fun/round.hpp
@@ -9,7 +9,7 @@ namespace stan {
 namespace math {
 
 /**
- * Structure to wrap \c round() so it can be vectorized.
+ * Structure to wrap `round()` so it can be vectorized.
  *
  * @tparam T type of argument
  * @param x argument variable
@@ -24,7 +24,7 @@ struct round_fun {
 };
 
 /**
- * Vectorized version of \c round().
+ * Vectorized version of `round()`.
  *
  * @tparam T type of container
  * @param x container
@@ -36,7 +36,7 @@ inline auto round(const T& x) {
 }
 
 /**
- * Version of \c round() that accepts Eigen Matrix or matrix expressions.
+ * Version of `round()` that accepts Eigen Matrix or matrix expressions.
  *
  * @tparam Derived derived type of x
  * @param x Matrix or matrix expression

--- a/stan/math/prim/fun/round.hpp
+++ b/stan/math/prim/fun/round.hpp
@@ -9,24 +9,6 @@ namespace stan {
 namespace math {
 
 /**
- * Return the closest integer to the specified argument, with
- * halfway cases rounded away from zero.
- *
- * @param x Argument.
- * @return The rounded value of the argument.
- */
-inline double round(double x) { return std::round(x); }
-
-/**
- * Return the closest integer to the specified argument, with
- * halfway cases rounded away from zero.
- *
- * @param x Argument.
- * @return The rounded value of the argument.
- */
-inline double round(int x) { return std::round(x); }
-
-/**
  * Structure to wrap round() so it can be vectorized.
  *
  * @tparam T type of argument
@@ -36,6 +18,7 @@ inline double round(int x) { return std::round(x); }
 struct round_fun {
   template <typename T>
   static inline T fun(const T& x) {
+    using std::round;
     return round(x);
   }
 };

--- a/stan/math/prim/fun/round.hpp
+++ b/stan/math/prim/fun/round.hpp
@@ -9,7 +9,7 @@ namespace stan {
 namespace math {
 
 /**
- * Structure to wrap round() so it can be vectorized.
+ * Structure to wrap \c round() so it can be vectorized.
  *
  * @tparam T type of argument
  * @param x argument variable
@@ -24,7 +24,7 @@ struct round_fun {
 };
 
 /**
- * Vectorized version of round.
+ * Vectorized version of \c round().
  *
  * @tparam T type of container
  * @param x container
@@ -36,7 +36,7 @@ inline auto round(const T& x) {
 }
 
 /**
- * Version of round() that accepts Eigen Matrix or matrix expressions.
+ * Version of \c round() that accepts Eigen Matrix or matrix expressions.
  *
  * @tparam Derived derived type of x
  * @param x Matrix or matrix expression

--- a/stan/math/prim/fun/sqrt.hpp
+++ b/stan/math/prim/fun/sqrt.hpp
@@ -9,7 +9,7 @@ namespace stan {
 namespace math {
 
 /**
- * Structure to wrap \c sqrt() so that it can be vectorized.
+ * Structure to wrap `sqrt()` so that it can be vectorized.
  *
  * @tparam T type of variable
  * @param x variable
@@ -24,7 +24,7 @@ struct sqrt_fun {
 };
 
 /**
- * Vectorized version of \c sqrt().
+ * Vectorized version of `sqrt()`.
  *
  * @tparam T type of container
  * @param x container
@@ -36,7 +36,7 @@ inline auto sqrt(const T& x) {
 }
 
 /**
- * Version of \c sqrt() that accepts Eigen Matrix or matrix expressions.
+ * Version of `sqrt()` that accepts Eigen Matrix or matrix expressions.
  *
  * @tparam Derived derived type of x
  * @param x Matrix or matrix expression

--- a/stan/math/prim/fun/sqrt.hpp
+++ b/stan/math/prim/fun/sqrt.hpp
@@ -9,15 +9,6 @@ namespace stan {
 namespace math {
 
 /**
- * Return the square root of the specified argument.  This
- * version is required to disambiguate <code>sqrt(int)</code>.
- *
- * @param[in] x Argument.
- * @return Square root of x.
- */
-inline double sqrt(int x) { return std::sqrt(x); }
-
-/**
  * Structure to wrap sqrt() so that it can be vectorized.
  *
  * @tparam T type of variable

--- a/stan/math/prim/fun/sqrt.hpp
+++ b/stan/math/prim/fun/sqrt.hpp
@@ -9,7 +9,7 @@ namespace stan {
 namespace math {
 
 /**
- * Structure to wrap sqrt() so that it can be vectorized.
+ * Structure to wrap \c sqrt() so that it can be vectorized.
  *
  * @tparam T type of variable
  * @param x variable
@@ -24,7 +24,7 @@ struct sqrt_fun {
 };
 
 /**
- * Vectorized version of sqrt().
+ * Vectorized version of \c sqrt().
  *
  * @tparam T type of container
  * @param x container
@@ -36,7 +36,7 @@ inline auto sqrt(const T& x) {
 }
 
 /**
- * Version of sqrt() that accepts Eigen Matrix or matrix expressions.
+ * Version of \c sqrt() that accepts Eigen Matrix or matrix expressions.
  *
  * @tparam Derived derived type of x
  * @param x Matrix or matrix expression

--- a/stan/math/prim/fun/tan.hpp
+++ b/stan/math/prim/fun/tan.hpp
@@ -9,7 +9,7 @@ namespace stan {
 namespace math {
 
 /**
- * Structure to wrap tan() so that it can be vectorized.
+ * Structure to wrap `tan()` so that it can be vectorized.
  *
  * @tparam T type of argument
  * @param x angle in radians
@@ -24,7 +24,7 @@ struct tan_fun {
 };
 
 /**
- * Vectorized version of tan().
+ * Vectorized version of `tan()`.
  *
  * @tparam T type of container
  * @param x angles in radians
@@ -36,7 +36,7 @@ inline auto tan(const T& x) {
 }
 
 /**
- * Version of tan() that accepts Eigen Matrix or matrix expressions.
+ * Version of `tan()` that accepts Eigen Matrix or matrix expressions.
  *
  * @tparam Derived derived type of x
  * @param x Matrix or matrix expression

--- a/stan/math/prim/fun/tanh.hpp
+++ b/stan/math/prim/fun/tanh.hpp
@@ -9,7 +9,7 @@ namespace stan {
 namespace math {
 
 /**
- * Structure to wrap tanh() so that it can be vectorized.
+ * Structure to wrap `tanh()` so that it can be vectorized.
  *
  * @tparam T type of argument
  * @param x angle in radians
@@ -24,7 +24,7 @@ struct tanh_fun {
 };
 
 /**
- * Vectorized version of tanh().
+ * Vectorized version of `tanh()`.
  *
  * @tparam T type of container
  * @param x angles in radians
@@ -36,7 +36,7 @@ inline auto tanh(const T& x) {
 }
 
 /**
- * Version of tanh() that accepts Eigen Matrix or matrix expressions.
+ * Version of `tanh()` that accepts Eigen Matrix or matrix expressions.
  *
  * @tparam Derived derived type of x
  * @param x Matrix or matrix expression

--- a/stan/math/prim/fun/trigamma.hpp
+++ b/stan/math/prim/fun/trigamma.hpp
@@ -128,7 +128,7 @@ inline double trigamma(double u) { return trigamma_impl(u); }
 inline double trigamma(int u) { return trigamma(static_cast<double>(u)); }
 
 /**
- * Structure to wrap trigamma() so it can be vectorized.
+ * Structure to wrap `trigamma()` so it can be vectorized.
  */
 struct trigamma_fun {
   /**
@@ -146,7 +146,7 @@ struct trigamma_fun {
 };
 
 /**
- * Return the elementwise application of <code>trigamma()</code> to
+ * Return the elementwise application of `trigamma()` to
  * specified argument container.  The return type promotes the
  * underlying scalar argument type to double if it is an integer,
  * and otherwise is the argument type.

--- a/stan/math/prim/fun/trunc.hpp
+++ b/stan/math/prim/fun/trunc.hpp
@@ -8,7 +8,7 @@ namespace stan {
 namespace math {
 
 /**
- * Structure to wrap <code>trunc()</code> so it can be vectorized.
+ * Structure to wrap \c trunc() so it can be vectorized.
  */
 struct trunc_fun {
   /**
@@ -27,7 +27,7 @@ struct trunc_fun {
 };
 
 /**
- * Return the elementwise application of <code>trunc()</code> to
+ * Return the elementwise application of \c trunc() to
  * specified argument container.  The return type promotes the
  * underlying scalar argument type to double if it is an integer,
  * and otherwise is the argument type.

--- a/stan/math/prim/fun/trunc.hpp
+++ b/stan/math/prim/fun/trunc.hpp
@@ -8,7 +8,7 @@ namespace stan {
 namespace math {
 
 /**
- * Structure to wrap \c trunc() so it can be vectorized.
+ * Structure to wrap `trunc()` so it can be vectorized.
  */
 struct trunc_fun {
   /**
@@ -27,7 +27,7 @@ struct trunc_fun {
 };
 
 /**
- * Return the elementwise application of \c trunc() to
+ * Return the elementwise application of `trunc()` to
  * specified argument container.  The return type promotes the
  * underlying scalar argument type to double if it is an integer,
  * and otherwise is the argument type.

--- a/stan/math/prim/fun/trunc.hpp
+++ b/stan/math/prim/fun/trunc.hpp
@@ -8,25 +8,7 @@ namespace stan {
 namespace math {
 
 /**
- * Return the nearest integral value that is not larger in
- * magnitude than the specified argument.
- *
- * @param[in] x Argument.
- * @return The truncated argument.
- */
-inline double trunc(double x) { return std::trunc(x); }
-
-/**
- * Return the nearest integral value that is not larger in
- * magnitude than the specified argument.
- *
- * @param[in] x Argument.
- * @return The truncated argument.
- */
-inline double trunc(int x) { return std::trunc(x); }
-
-/**
- * Structure to wrap trunc() so it can be vectorized.
+ * Structure to wrap <code>trunc()</code> so it can be vectorized.
  */
 struct trunc_fun {
   /**
@@ -39,6 +21,7 @@ struct trunc_fun {
    */
   template <typename T>
   static inline T fun(const T& x) {
+    using std::trunc;
     return trunc(x);
   }
 };

--- a/test/unit/math/prim/fun/exp_test.cpp
+++ b/test/unit/math/prim/fun/exp_test.cpp
@@ -3,8 +3,8 @@
 
 TEST(MathFunctions, expInt) {
   using stan::math::exp;
-  using std::exp;
   EXPECT_FLOAT_EQ(std::exp(3), exp(3));
+  EXPECT_FLOAT_EQ(std::exp(3.1), exp(3.1));
   EXPECT_FLOAT_EQ(std::exp(3.0), exp(3.0));
 }
 

--- a/test/unit/math/prim/fun/log_test.cpp
+++ b/test/unit/math/prim/fun/log_test.cpp
@@ -3,8 +3,8 @@
 
 TEST(MathFunctions, logInt) {
   using stan::math::log;
-  using std::log;
   EXPECT_FLOAT_EQ(std::log(3), log(3));
+  EXPECT_FLOAT_EQ(std::log(3.1), log(3.1));
   EXPECT_FLOAT_EQ(std::log(3.0), log(3.0));
 }
 

--- a/test/unit/math/prim/fun/sqrt_test.cpp
+++ b/test/unit/math/prim/fun/sqrt_test.cpp
@@ -3,8 +3,8 @@
 
 TEST(MathFunctions, sqrtInt) {
   using stan::math::sqrt;
-  using std::sqrt;
   EXPECT_FLOAT_EQ(std::sqrt(3.0), sqrt(3));
+  EXPECT_FLOAT_EQ(std::sqrt(3.1), sqrt(3.1));
   EXPECT_TRUE(stan::math::is_nan(sqrt(-2)));
 }
 


### PR DESCRIPTION
## Summary

Closes #1692 by cleaning up unnecessary int overloads. 
This PR also fixes a few comments and removes functions where the only code is a call to a std function. Example: 

```
inline double asinh(double x) { return std::asinh(x); }

inline double asinh(int x) { return std::asinh(x); }
```
These 2 can be removed because they are covered by 

```
struct asinh_fun {
  template <typename T>
  static inline T fun(const T& x) {
    using std::asinh;
    return asinh(x);
  }
};

template <typename T>
inline auto asinh(const T& x) {
  return apply_scalar_unary<asinh_fun, T>::apply(x);
}
```
We could do this for a lot more functions, for now this just removes these simple ones.

## Tests

No new tests.

## Side Effects

/

## Checklist

- [x] Math issue #1692 

- [x] Copyright holder: Rok Češnovar

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
