### PR TITLE
Feature/elementwise check

### DIFF
--- a/stan/math/opencl/matrix_cl.hpp
+++ b/stan/math/opencl/matrix_cl.hpp
@@ -452,15 +452,15 @@ class matrix_cl<T, require_arithmetic_t<T>> {
   }
 
   /**
-   * Construct from a kernel generator expression. It evaluates the ixpression
+   * Construct from a kernel generator expression. It evaluates the expression
    * into \c this.
    * @tparam Expr type of the expression
    * @param expression expression
    */
   template <typename Expr,
             require_all_valid_expressions_and_none_scalar_t<Expr>* = nullptr>
-  matrix_cl(const Expr& expresion);  // NOLINT This constructor is intentionally
-                                     // implicit
+  matrix_cl(const Expr& expression);  // NOLINT This constructor is
+                                      // intentionally implicit
 
   /** \ingroup opencl
    * Move assignment operator.
@@ -492,14 +492,14 @@ class matrix_cl<T, require_arithmetic_t<T>> {
   }
 
   /**
-   * Assignment of a kernel generator expression evaluates the ixpression into
+   * Assignment of a kernel generator expression evaluates the expression into
    * \c this.
    * @tparam Expr type of the expression
    * @param expression expression
    */
   template <typename Expr,
             require_all_valid_expressions_and_none_scalar_t<Expr>* = nullptr>
-  matrix_cl<T>& operator=(const Expr& expresion);
+  matrix_cl<T>& operator=(const Expr& expression);
 
  private:
   /** \ingroup opencl

--- a/stan/math/opencl/matrix_cl.hpp
+++ b/stan/math/opencl/matrix_cl.hpp
@@ -459,8 +459,7 @@ class matrix_cl<T, require_arithmetic_t<T>> {
    */
   template <typename Expr,
             require_all_valid_expressions_and_none_scalar_t<Expr>* = nullptr>
-  matrix_cl(const Expr& expression);  // NOLINT This constructor is
-                                      // intentionally implicit
+  matrix_cl(const Expr& expression);  // NOLINT(runtime/explicit)
 
   /** \ingroup opencl
    * Move assignment operator.

--- a/stan/math/prim/err.hpp
+++ b/stan/math/prim/err.hpp
@@ -47,6 +47,7 @@
 #include <stan/math/prim/err/constraint_tolerance.hpp>
 #include <stan/math/prim/err/domain_error.hpp>
 #include <stan/math/prim/err/domain_error_vec.hpp>
+#include <stan/math/prim/err/elementwise_check.hpp>
 #include <stan/math/prim/err/invalid_argument.hpp>
 #include <stan/math/prim/err/invalid_argument_vec.hpp>
 #include <stan/math/prim/err/is_cholesky_factor.hpp>

--- a/stan/math/prim/err/elementwise_check.hpp
+++ b/stan/math/prim/err/elementwise_check.hpp
@@ -1,0 +1,135 @@
+#ifndef STAN_MATH_PRIM_ERR_ELEMENTWISE_ERROR_CHECKER_HPP
+#define STAN_MATH_PRIM_ERR_ELEMENTWISE_ERROR_CHECKER_HPP
+
+#include <stan/math/prim/err/throw_domain_error.hpp>
+#include <stan/math/prim/fun/get.hpp>
+#include <stan/math/prim/fun/size.hpp>
+#include <stan/math/prim/fun/value_of_rec.hpp>
+#include <string>
+#include <sstream>
+#include <vector>
+
+namespace stan {
+namespace math {
+namespace internal {
+
+template <typename T_is_good, typename T_exception>
+struct Checker {
+  const T_is_good& is_good;
+  const char* function;
+  const char* name;
+  const char* suffix;
+
+  void raise_error_impl(std::stringstream& ss) { throw T_exception{ss.str()}; }
+
+  template <typename... M>
+  void raise_error_impl(std::stringstream& ss, const char* message,
+                        const M&... messages) {
+    ss << message;
+    raise_error_impl(ss, messages...);
+  }
+
+  template <typename... M>
+  void raise_error_impl(std::stringstream& ss, double value_of_x,
+                        const M&... messages) {
+    ss << value_of_x;
+    raise_error_impl(ss, messages...);
+  }
+
+  template <typename... M>
+  void raise_error_impl(std::stringstream& ss, size_t index,
+                        const M&... messages) {
+    ss << index + 1;
+    raise_error_impl(ss, messages...);
+  }
+
+  template <typename... M>
+  void raise_error(const M&... messages) {
+    std::stringstream ss{};
+    raise_error_impl(ss, messages...);
+  }
+
+  template <typename T, typename = require_stan_scalar_t<T>,
+            typename... T_indices>
+  void check(const T& x, T_indices... indices) {
+    double xd = value_of_rec(x);
+    if (!is_good(xd))
+      raise_error(function, ": ", name, indices..., " is ", xd, suffix);
+  }
+
+  template <typename T, typename = require_eigen_vector_t<T>, typename = void,
+            typename... T_indices>
+  void check(const T& x, T_indices... indices) {
+    for (size_t i = 0; i < stan::math::size(x); ++i)
+      check(x(i), indices..., "[", i, "]");
+  }
+
+  template <typename T, typename... T_indices>
+  void check(const std::vector<T>& x, T_indices... indices) {
+    for (size_t i = 0; i < stan::math::size(x); ++i)
+      check(x[i], indices..., "[", i, "]");
+  }
+
+  template <typename T, typename... T_indices>
+  void check(const Eigen::DenseBase<T>& x, T_indices... indices) {
+    for (size_t n = 0; n < x.cols(); ++n)
+      for (size_t m = 0; m < x.rows(); ++m)
+        check(x(m, n), indices..., "[row=", m, ", col=", n, "]");
+  }
+};
+
+template <typename T_is_good>
+struct Iser {
+  const T_is_good& is_good;
+
+  template <typename T, typename = require_stan_scalar_t<T>>
+  bool is(const T& x) {
+    return is_good(value_of_rec(x));
+  }
+
+  template <typename T, typename = require_not_stan_scalar_t<T>,
+            typename = void>
+  bool is(const T& x) {
+    for (size_t i = 0; i < stan::math::size(x); ++i)
+      if (!is(stan::get(x, i)))
+        return false;
+    return true;
+  }
+};
+
+}  // namespace internal
+
+/**
+ * Check that the predicate holds for the value of x, working elementwise on
+ * containers. If x is a container, check each element inside x, recursively.
+ * @tparam T_is_good type of is_good predicate
+ * @tparam T_x type of x
+ * @param is_good predicate to check, must accept doubles and produce bools
+ * @param function function name (for error messages)
+ * @param name variable name (for error messages)
+ * @param x variable to check, can be a scalar, a container of scalars, a
+ * container of containers of scalars, etc
+ * @param suffix message to print at end of error message
+ * @throw <code>std::domain_error</code> if is_good returns false for the value
+ * of any element in x the predicate
+ */
+template <typename T_is_good, typename T_x>
+void elementwise_check(const T_is_good& is_good, const char* function,
+                       const char* name, const T_x& x, const char* suffix) {
+  internal::Checker<T_is_good, std::domain_error>{is_good, function, name,
+                                                  suffix}
+      .check(x);
+}
+
+/**
+ * Like elementwise_check, but indicate failure by returning false instead of
+ * by throwing.
+ */
+template <typename T_is_good, typename T_x>
+bool elementwise_is(const T_is_good& is_good, const T_x& x) {
+  return internal::Iser<T_is_good>{is_good}.is(x);
+}
+
+}  // namespace math
+}  // namespace stan
+#endif

--- a/stan/math/prim/err/elementwise_check.hpp
+++ b/stan/math/prim/err/elementwise_check.hpp
@@ -114,8 +114,8 @@ struct Iser {
  * of any element in x the predicate
  */
 template <typename T_is_good, typename T_x>
-void elementwise_check(const T_is_good& is_good, const char* function,
-                       const char* name, const T_x& x, const char* suffix) {
+inline void elementwise_check(const T_is_good& is_good, const char* function,
+                              const char* name, const T_x& x, const char* suffix) {
   internal::Checker<T_is_good, std::domain_error>{is_good, function, name,
                                                   suffix}
       .check(x);
@@ -126,7 +126,7 @@ void elementwise_check(const T_is_good& is_good, const char* function,
  * by throwing.
  */
 template <typename T_is_good, typename T_x>
-bool elementwise_is(const T_is_good& is_good, const T_x& x) {
+inline bool elementwise_is(const T_is_good& is_good, const T_x& x) {
   return internal::Iser<T_is_good>{is_good}.is(x);
 }
 

--- a/stan/math/prim/err/elementwise_check.hpp
+++ b/stan/math/prim/err/elementwise_check.hpp
@@ -27,17 +27,6 @@ class Checker {
   const char* name;
   const char* suffix;
 
- public:
-  /**
-   * @param is_good predicate to check, must accept doubles and produce bools
-   * @param function function name (for error messages)
-   * @param name variable name (for error messages)
-   * @param suffix message to print at end of error message
-   */
-  Checker(const F& is_good, const char* function, const char* name,
-          const char* suffix)
-      : is_good(is_good), function(function), name(name), suffix(suffix) {}
-
   /**
    * Throw an exception of type `E`.
    * The error message is the string inside the provided stringstream.
@@ -76,6 +65,17 @@ class Checker {
     std::stringstream ss{};
     raise_error_ss(ss, messages...);
   }
+
+ public:
+  /**
+   * @param is_good predicate to check, must accept doubles and produce bools
+   * @param function function name (for error messages)
+   * @param name variable name (for error messages)
+   * @param suffix message to print at end of error message
+   */
+  Checker(const F& is_good, const char* function, const char* name,
+          const char* suffix)
+      : is_good(is_good), function(function), name(name), suffix(suffix) {}
 
   /**
    * Check the scalar.

--- a/stan/math/prim/err/elementwise_check.hpp
+++ b/stan/math/prim/err/elementwise_check.hpp
@@ -115,7 +115,8 @@ struct Iser {
  */
 template <typename T_is_good, typename T_x>
 inline void elementwise_check(const T_is_good& is_good, const char* function,
-                              const char* name, const T_x& x, const char* suffix) {
+                              const char* name, const T_x& x,
+                              const char* suffix) {
   internal::Checker<T_is_good, std::domain_error>{is_good, function, name,
                                                   suffix}
       .check(x);

--- a/stan/math/prim/err/elementwise_check.hpp
+++ b/stan/math/prim/err/elementwise_check.hpp
@@ -5,6 +5,7 @@
 #include <stan/math/prim/fun/get.hpp>
 #include <stan/math/prim/fun/size.hpp>
 #include <stan/math/prim/fun/value_of_rec.hpp>
+#include <stan/math/prim/meta/is_vector.hpp>
 #include <string>
 #include <sstream>
 #include <vector>
@@ -13,80 +14,148 @@ namespace stan {
 namespace math {
 namespace internal {
 
-template <typename T_is_good, typename T_exception>
-struct Checker {
-  const T_is_good& is_good;
+/** Apply an error check to a container, signal failure by throwing.
+ * Apply a predicate like is_positive to the double underlying every scalar in a
+ * container, throw an exception if the predicate fails for any double.
+ * @tparam F type of predicate
+ * @tparam E type of exception thrown
+ */
+template <typename F, typename E>
+class Checker {
+  const F& is_good;
   const char* function;
   const char* name;
   const char* suffix;
 
-  void raise_error_impl(std::stringstream& ss) { throw T_exception{ss.str()}; }
+ public:
+  /**
+   * @param is_good predicate to check, must accept doubles and produce bools
+   * @param function function name (for error messages)
+   * @param name variable name (for error messages)
+   * @param suffix message to print at end of error message
+   */
+  Checker(const F& is_good, const char* function, const char* name,
+          const char* suffix)
+      : is_good(is_good), function(function), name(name), suffix(suffix) {}
 
-  template <typename... M>
-  void raise_error_impl(std::stringstream& ss, const char* message,
-                        const M&... messages) {
+  /**
+   * Throw an exception of type `E`.
+   * The error message is the string inside the provided stringstream.
+   * @param ss stringstream containing error message
+   * @throws `E`
+   */
+  void raise_error_ss(std::stringstream& ss) { throw E{ss.str()}; }
+
+  /**
+   * Throw an exception of type `E`.
+   * The error message is the concatenation of the string inside the provided
+   * stringstream with all the provided messages.
+   * @tparam M types of first message
+   * @tparam Ms types of other messages
+   * @param ss stringstream to accumulate error message in.
+   * @param message a message to append to `ss`
+   * @param messages more messages to append
+   * @throws `E`
+   */
+  template <typename M, typename... Ms>
+  void raise_error_ss(std::stringstream& ss, const M& message,
+                      const Ms&... messages) {
     ss << message;
-    raise_error_impl(ss, messages...);
+    raise_error_ss(ss, messages...);
   }
 
-  template <typename... M>
-  void raise_error_impl(std::stringstream& ss, double value_of_x,
-                        const M&... messages) {
-    ss << value_of_x;
-    raise_error_impl(ss, messages...);
-  }
-
-  template <typename... M>
-  void raise_error_impl(std::stringstream& ss, size_t index,
-                        const M&... messages) {
-    ss << index + 1;
-    raise_error_impl(ss, messages...);
-  }
-
-  template <typename... M>
-  void raise_error(const M&... messages) {
+  /**
+   * Throw an exception of type `E`.
+   * The error message is the concatenation of the provided messages.
+   * @tparam Ms types of messages
+   * @param messages a list of messages
+   * @throws `E`
+   */
+  template <typename... Ms>
+  void raise_error(const Ms&... messages) {
     std::stringstream ss{};
-    raise_error_impl(ss, messages...);
+    raise_error_ss(ss, messages...);
   }
 
-  template <typename T, typename = require_stan_scalar_t<T>,
-            typename... T_indices>
-  void check(const T& x, T_indices... indices) {
+  /**
+   * Check the scalar.
+   * @tparam T type of scalar
+   * @tparam Ms types of messages
+   * @param x scalar
+   * @param messages a list of messages to append to the error message
+   * @throws `E` if  the scalar fails the error check
+   */
+  template <typename T, typename = require_stan_scalar_t<T>, typename... Ms>
+  void check(const T& x, Ms... messages) {
     double xd = value_of_rec(x);
     if (!is_good(xd))
-      raise_error(function, ": ", name, indices..., " is ", xd, suffix);
+      raise_error(function, ": ", name, messages..., " is ", xd, suffix);
   }
 
-  template <typename T, typename = require_eigen_vector_t<T>, typename = void,
-            typename... T_indices>
-  void check(const T& x, T_indices... indices) {
+  /**
+   * Check all the scalars inside the vector.
+   * @tparam T type of vector
+   * @tparam Ms types of messages
+   * @param x vector
+   * @param messages a list of messages to append to the error message
+   * @throws `E` if any of the scalars fail the error check
+   */
+  template <typename T, typename = require_vector_t<T>, typename = void,
+            typename... Ms>
+  void check(const T& x, Ms... messages) {
     for (size_t i = 0; i < stan::math::size(x); ++i)
-      check(x(i), indices..., "[", i, "]");
+      check(x[i], messages..., "[", i + 1, "]");
   }
 
-  template <typename T, typename... T_indices>
-  void check(const std::vector<T>& x, T_indices... indices) {
-    for (size_t i = 0; i < stan::math::size(x); ++i)
-      check(x[i], indices..., "[", i, "]");
-  }
-
-  template <typename T, typename... T_indices>
-  void check(const Eigen::DenseBase<T>& x, T_indices... indices) {
+  /**
+   * Check all the scalars inside the matrix.
+   * @tparam Derived type of matrix
+   * @tparam Ms types of messages
+   * @param x matrix
+   * @param messages a list of messages to append to the error message
+   * @throws `E` if any of the scalars fail the error check
+   */
+  template <typename Derived, typename... Ms>
+  void check(const Eigen::DenseBase<Derived>& x, Ms... messages) {
     for (size_t n = 0; n < x.cols(); ++n)
       for (size_t m = 0; m < x.rows(); ++m)
-        check(x(m, n), indices..., "[row=", m, ", col=", n, "]");
+        check(x(m, n), messages..., "[row=", m + 1, ", col=", n + 1, "]");
   }
-};
+};  // namespace internal
 
-template <typename T_is_good>
-struct Iser {
-  const T_is_good& is_good;
+/** Apply an error check to a container, signal failure with `false`.
+ * Apply a predicate like is_positive to the double underlying every scalar in a
+ * container, producing true if the predicate holds everywhere and `false` if it
+ * fails anywhere.
+ * @tparam F type of predicate
+ */
+template <typename F>
+class Iser {
+  const F& is_good;
 
+ public:
+  /**
+   * @param is_good predicate to check, must accept doubles and produce bools
+   */
+  explicit Iser(const F& is_good) : is_good(is_good) {}
+
+  /**
+   * Check the scalar.
+   * @tparam T type of scalar
+   * @param x scalar
+   * @return `false` if the scalar fails the error check
+   */
   template <typename T, typename = require_stan_scalar_t<T>>
   bool is(const T& x) {
     return is_good(value_of_rec(x));
   }
 
+  /**
+   * Check all the scalars inside the container.
+   * @tparam T type of scalar
+   * @param x container
+   * @return `false` if any of the scalars fail the error check
+   */
   template <typename T, typename = require_not_stan_scalar_t<T>,
             typename = void>
   bool is(const T& x) {
@@ -100,35 +169,42 @@ struct Iser {
 }  // namespace internal
 
 /**
- * Check that the predicate holds for the value of x, working elementwise on
- * containers. If x is a container, check each element inside x, recursively.
- * @tparam T_is_good type of is_good predicate
- * @tparam T_x type of x
+ * Check that the predicate holds for the value of `x`, working elementwise on
+ * containers. If `x` is a scalar, check the double underlying the scalar. If
+ * `x` is a container, check each element inside `x`, recursively.
+ * @tparam F type of predicate
+ * @tparam T type of `x`
  * @param is_good predicate to check, must accept doubles and produce bools
  * @param function function name (for error messages)
  * @param name variable name (for error messages)
  * @param x variable to check, can be a scalar, a container of scalars, a
  * container of containers of scalars, etc
  * @param suffix message to print at end of error message
- * @throw <code>std::domain_error</code> if is_good returns false for the value
- * of any element in x the predicate
+ * @throws `std::domain_error` if `is_good` returns `false` for the value
+ * of any element in `x`
  */
-template <typename T_is_good, typename T_x>
-inline void elementwise_check(const T_is_good& is_good, const char* function,
-                              const char* name, const T_x& x,
+template <typename F, typename T>
+inline void elementwise_check(const F& is_good, const char* function,
+                              const char* name, const T& x,
                               const char* suffix) {
-  internal::Checker<T_is_good, std::domain_error>{is_good, function, name,
-                                                  suffix}
+  internal::Checker<F, std::domain_error>{is_good, function, name, suffix}
       .check(x);
 }
 
 /**
- * Like elementwise_check, but indicate failure by returning false instead of
- * by throwing.
+ * Check that the predicate holds for the value of `x`, working elementwise on
+ * containers. If `x` is a scalar, check the double underlying the scalar. If
+ * `x` is a container, check each element inside `x`, recursively.
+ * @tparam F type of predicate
+ * @tparam T type of `x`
+ * @param is_good predicate to check, must accept doubles and produce bools
+ * @param x variable to check, can be a scalar, a container of scalars, a
+ * container of containers of scalars, etc
+ * @return `false` if any of the scalars fail the error check
  */
-template <typename T_is_good, typename T_x>
-inline bool elementwise_is(const T_is_good& is_good, const T_x& x) {
-  return internal::Iser<T_is_good>{is_good}.is(x);
+template <typename F, typename T>
+inline bool elementwise_is(const F& is_good, const T& x) {
+  return internal::Iser<F>{is_good}.is(x);
 }
 
 }  // namespace math

--- a/test/unit/math/prim/err/check_not_nan_test.cpp
+++ b/test/unit/math/prim/err/check_not_nan_test.cpp
@@ -52,6 +52,7 @@ TEST(ErrorHandlingArr, CheckNotNanVectorized_one_indexed_message) {
 TEST(ErrorHandlingMatrix, checkNotNanEigenRow) {
   stan::math::vector_d y;
   y.resize(3);
+  y << 1, 2, 3;
 
   EXPECT_NO_THROW(stan::math::check_not_nan("checkNotNanEigenRow(%1)", "y", y));
   EXPECT_NO_THROW(stan::math::check_not_nan("checkNotNanEigenRow(%1)", "y", y));

--- a/test/unit/math/prim/err/elementwise_check_test.cpp
+++ b/test/unit/math/prim/err/elementwise_check_test.cpp
@@ -5,22 +5,18 @@
 #include <limits>
 #include <vector>
 
-template <typename T>
-bool example_predicate(const T& x) {
-  return !stan::math::is_nan(x);
-}
+auto p = [](const auto& x) { return !stan::math::is_nan(x); };
 
 template <typename T>
 void do_check(const T& x) {
-  stan::math::elementwise_check(
-      [](const auto& x) { return example_predicate(x); },
-      "elementwise_check_tests", "x", x, ", but must not be nan!");
+  stan::math::elementwise_check([](const auto& x) { return p(x); },
+                                "elementwise_check_tests", "x", x,
+                                ", but must not be nan!");
 }
 
 template <typename T>
 bool do_is(const T& x) {
-  return stan::math::elementwise_is(
-      [](const auto& x) { return example_predicate(x); }, x);
+  return stan::math::elementwise_is([](const auto& x) { return p(x); }, x);
 }
 
 template <typename T>

--- a/test/unit/math/prim/err/elementwise_check_test.cpp
+++ b/test/unit/math/prim/err/elementwise_check_test.cpp
@@ -1,0 +1,149 @@
+#include <test/unit/util.hpp>
+#include <stan/math/prim.hpp>
+#include <stan/math/prim/fun/is_nan.hpp>
+#include <gtest/gtest.h>
+#include <limits>
+#include <vector>
+
+template <typename T>
+bool example_predicate(const T& x) {
+  return !stan::math::is_nan(x);
+}
+
+template <typename T>
+void do_check(const T& x) {
+  stan::math::elementwise_check(
+      [](const auto& x) { return example_predicate(x); },
+      "elementwise_check_tests", "x", x, ", but must not be nan!");
+}
+
+template <typename T>
+bool do_is(const T& x) {
+  return stan::math::elementwise_is(
+      [](const auto& x) { return example_predicate(x); }, x);
+}
+
+template <typename T>
+void expect_good(const T& x) {
+  EXPECT_NO_THROW(do_check(x));
+  EXPECT_TRUE(do_is(x));
+}
+
+template <typename T>
+void expect_bad(const T& x) {
+  EXPECT_THROW(do_check(x), std::domain_error);
+  EXPECT_FALSE(do_is(x));
+}
+
+TEST(elementwise_check, checks_scalars) {
+  expect_good(0);
+  expect_bad(stan::math::NOT_A_NUMBER);
+}
+
+TEST(elementwise_check, works_elementwise_on_arrays) {
+  const double good = 0;
+  const double bad = stan::math::NOT_A_NUMBER;
+  using v = std::vector<double>;
+  using vv = std::vector<v>;
+  using vvv = std::vector<vv>;
+  expect_good(v{});
+  expect_good(vv{});
+  expect_good(vvv{});
+  expect_good(v{good});
+  expect_good(v{good, good, good});
+  expect_good(
+      vv{v{good, good}, v{good, good}, v{}, v{good}, v{good, good, good}});
+  expect_good(
+      vvv{vv{v{good, good, good}, v{good, good}, v{}},
+          vv{v{good, good}, v{good, good, good, good}, v{good, good, good}},
+          vv{v{}, v{good}, v{good, good, good}}, vv{}, vv{}});
+  expect_bad(v{bad});
+  expect_bad(v{good, bad, good});
+  expect_bad(v{bad, bad, bad});
+  expect_bad(
+      vv{v{good, good}, v{good, good}, v{}, v{bad}, v{good, good, good}});
+  expect_bad(vvv{vv{v{good, good, good}, v{good, good, good}, v{}},
+                 vv{v{good, good}, v{good, good}, v{good, good, good}},
+                 vv{v{}, v{good}, v{good, good, good, good, bad}}, vv{}, vv{}});
+}
+
+TEST(elementwise_check, works_on_eigen_types) {
+  const double bad = stan::math::NOT_A_NUMBER;
+  using Eigen::MatrixXd;
+  using Eigen::RowVectorXd;
+  using Eigen::VectorXd;
+  expect_good(VectorXd{0});
+  expect_good(RowVectorXd{0});
+  expect_good(MatrixXd{3, 0});
+  expect_good(MatrixXd{0, 3});
+  expect_good(MatrixXd{0, 0});
+  for (int r = 1; r <= 3; ++r) {
+    for (int i = 0; i < r; ++i) {
+      const VectorXd good_ev = VectorXd::Zero(r);
+      VectorXd bad_ev{good_ev};
+      bad_ev[i] = bad;
+      expect_good(good_ev);
+      expect_bad(bad_ev);
+      expect_good(Eigen::RowVectorXd{good_ev});
+      expect_bad(Eigen::RowVectorXd{bad_ev});
+      for (int c = 1; c <= 3; ++c) {
+        for (int j = 0; j < c; ++j) {
+          const MatrixXd good_m = MatrixXd::Zero(r, c);
+          MatrixXd bad_m{good_m};
+          bad_m(i, j) = bad;
+          expect_good(good_m);
+          expect_bad(bad_m);
+        }
+      }
+    }
+  }
+}
+
+TEST(elementwise_check, works_on_weird_eigen_types) {
+  const double bad = stan::math::NOT_A_NUMBER;
+  // Static size and expression templates.
+  expect_good(Eigen::Matrix<double, 3, 3>::Zero());
+  expect_bad(Eigen::Matrix<double, 3, 3>::Constant(bad));
+  expect_good(Eigen::VectorXd::Zero(3) + Eigen::VectorXd::Zero(3));
+  expect_bad(Eigen::Matrix<double, 3, 3>::Constant(bad)
+             + Eigen::Matrix<double, 3, 3>::Constant(bad));
+  expect_good(Eigen::Vector3d::Zero() + Eigen::Vector3d::Zero());
+  expect_bad(Eigen::Vector3d::Zero() + Eigen::Vector3d::Constant(bad));
+}
+
+TEST(elementwise_check, works_on_a_ragged_mess_of_dynamic_matrices) {
+  const double bad = stan::math::NOT_A_NUMBER;
+  using m = Eigen::MatrixXd;
+  using v = std::vector<m>;
+  using vv = std::vector<v>;
+  using vvv = std::vector<vv>;
+  const m good00{0, 0};
+  const m good31 = Eigen::MatrixXd::Zero(3, 1);
+  const m good13 = Eigen::MatrixXd::Zero(1, 3);
+  m bad31{good31};
+  bad31(1, 0) = bad;
+  m bad13{good13};
+  bad13(0, 1) = bad;
+  expect_good(vvv{vv{v{}}, vv{v{}, v{good00, good31}},
+                  vv{v{good31}, v{good31, good31}}, vv{},
+                  vv{v{good00}, v{good00}, v{good13}}, vv{v{good13}}});
+  expect_bad(vvv{vv{v{}}, vv{v{}, v{good00, good31}},
+                 vv{v{bad31}, v{good31, good31}}, vv{},
+                 vv{v{good00}, v{good00}, v{good13}}, vv{v{good13}}});
+  expect_bad(vvv{vv{v{}}, vv{v{}, v{good00, good31}},
+                 vv{v{good31}, v{good31, good31}}, vv{},
+                 vv{v{good00}, v{good00}, v{good13}}, vv{v{bad13}}});
+}
+
+TEST(elementwise_check, error_messages_look_good) {
+  const double bad = stan::math::NOT_A_NUMBER;
+  Eigen::VectorXd bad_eigen_v = Eigen::VectorXd::Zero(3);
+  bad_eigen_v[1] = bad;
+  EXPECT_THROW_MSG(do_check(bad_eigen_v), std::domain_error, "[2]");
+  Eigen::MatrixXd bad_m = Eigen::MatrixXd::Zero(3, 3);
+  bad_m(1, 2) = bad;
+  EXPECT_THROW_MSG(do_check(bad_m), std::domain_error, "[row=2, col=3]");
+  std::vector<std::vector<double> > bad_vv{std::vector<double>{},
+                                           std::vector<double>{bad}};
+  EXPECT_THROW_MSG(do_check(bad_vv), std::domain_error, "[2][1]");
+}


### PR DESCRIPTION
## Summary

First part of a PR to address #1635 and #381. Thanks @bob-carpenter for the use the parameter pack in raise_error.

Implement elementwise_check / elementwise_is, which take a predicate and apply it to every scalar inside a (nested) container. If the predicate fails, they throw / return false.

Part two of this PR reimplements check_not_nan, check_positive, check_nonnegative, check_finite, is_scal_finite, is_positive, and is_not_nan in terms of these functions and eliminates a bunch of boilerplate loops.

We can do this: check_not_nan(..., some_double).
And this: check_not_nan(..., some_vector_of_doubles).
But we have to do this:
```
for (size_t i = ...)
  check_not_nan(..., some_vector_of_vector_of_doubles[i])
```
And we really want to just do this: check_not_nan(..., some_vector_of_vector_of_doubles).
And now we can.

The diff got kinda big, so I split it into two parts.

(Likewise .)

```
some_function: x[2][4][row=1, col=3] is nan, but must not be nan!
```

## Tests

Tests for new functions elementwise_check and elementwise_is.

## Side Effects

None.

## Checklist

- [X] Math issue #1635 (don't close)

- [X] Copyright holder: Peter Wicks Stringfield

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [X] the new changes are tested
