### PR TITLE
Makefiles: strip newlines in findiles and fix runChecks call

### DIFF
--- a/make/compiler_flags
+++ b/make/compiler_flags
@@ -1,6 +1,6 @@
 # Find files subroutine for different operating system
 # This is recursive version of the makefiles wildcard function
-findfiles = $(foreach d,$(wildcard $(addsuffix *,$(1))),$(call findfiles,$(d)/,$(2)) $(wildcard $(d)/$(2)))
+findfiles = $(strip $(foreach d,$(wildcard $(addsuffix *,$(1))),$(call findfiles,$(d)/,$(2))$(wildcard $(d)/$(2))))
 
 ifneq ($(OS),Windows_NT)
 GENERATE_DISTRIBUTION_TESTS=true

--- a/make/compiler_flags
+++ b/make/compiler_flags
@@ -1,10 +1,6 @@
 # Find files subroutine for different operating system
 # This is recursive version of the makefiles wildcard function
-ifeq ($(OS),Windows_NT)
 findfiles = $(subst \n,,$(foreach d,$(wildcard $(addsuffix *,$(1))),$(call findfiles,$(d)/,$(2)) $(wildcard $(d)/$(2))))
-else
-findfiles = $(subst \n,,$(foreach d,$(wildcard $(addsuffix *,$(1))),$(call findfiles,$(d)/,$(2)) $(wildcard $(d)/$(2))))
-endif
 
 ifneq ($(OS),Windows_NT)
 GENERATE_DISTRIBUTION_TESTS=true

--- a/make/compiler_flags
+++ b/make/compiler_flags
@@ -1,9 +1,9 @@
 # Find files subroutine for different operating system
 # This is recursive version of the makefiles wildcard function
 ifeq ($(OS),Windows_NT)
-findfiles = $(subst \n, ,$(foreach d,$(wildcard $(addsuffix *,$(1))),$(call findfiles,$(d)/,$(2))$(wildcard $(d)/$(2))))
+findfiles = $(subst \n,,$(foreach d,$(wildcard $(addsuffix *,$(1))),$(call findfiles,$(d)/,$(2)) $(wildcard $(d)/$(2))))
 else
-findfiles = $(subst \n,,$(foreach d,$(wildcard $(addsuffix *,$(1))),$(call findfiles,$(d)/,$(2))$(wildcard $(d)/$(2))))
+findfiles = $(subst \n,,$(foreach d,$(wildcard $(addsuffix *,$(1))),$(call findfiles,$(d)/,$(2)) $(wildcard $(d)/$(2))))
 endif
 
 ifneq ($(OS),Windows_NT)

--- a/make/compiler_flags
+++ b/make/compiler_flags
@@ -1,6 +1,6 @@
 # Find files subroutine for different operating system
 # This is recursive version of the makefiles wildcard function
-ifneq ($(OS),Windows_NT)
+ifeq ($(OS),Windows_NT)
 findfiles = $(subst \n, ,$(foreach d,$(wildcard $(addsuffix *,$(1))),$(call findfiles,$(d)/,$(2))$(wildcard $(d)/$(2))))
 else
 findfiles = $(subst \n,,$(foreach d,$(wildcard $(addsuffix *,$(1))),$(call findfiles,$(d)/,$(2))$(wildcard $(d)/$(2))))

--- a/make/compiler_flags
+++ b/make/compiler_flags
@@ -1,6 +1,10 @@
 # Find files subroutine for different operating system
 # This is recursive version of the makefiles wildcard function
+ifneq ($(OS),Windows_NT)
+findfiles = $(subst \n, ,$(foreach d,$(wildcard $(addsuffix *,$(1))),$(call findfiles,$(d)/,$(2))$(wildcard $(d)/$(2))))
+else
 findfiles = $(subst \n,,$(foreach d,$(wildcard $(addsuffix *,$(1))),$(call findfiles,$(d)/,$(2))$(wildcard $(d)/$(2))))
+endif
 
 ifneq ($(OS),Windows_NT)
 GENERATE_DISTRIBUTION_TESTS=true

--- a/make/compiler_flags
+++ b/make/compiler_flags
@@ -1,6 +1,6 @@
 # Find files subroutine for different operating system
 # This is recursive version of the makefiles wildcard function
-findfiles = $(strip $(foreach d,$(wildcard $(addsuffix *,$(1))),$(call findfiles,$(d)/,$(2))$(wildcard $(d)/$(2))))
+findfiles = $(subst \n,,$(foreach d,$(wildcard $(addsuffix *,$(1))),$(call findfiles,$(d)/,$(2))$(wildcard $(d)/$(2))))
 
 ifneq ($(OS),Windows_NT)
 GENERATE_DISTRIBUTION_TESTS=true

--- a/make/tests
+++ b/make/tests
@@ -67,7 +67,7 @@ $(ALGEBRA_SOLVER_TESTS) : $(LIBSUNDIALS)
 # Target to verify header files within Stan has
 # enough include calls
 ##
-HEADER_TESTS := $(addsuffix -test ,$(call findfiles,stan,*.hpp))
+HEADER_TESTS := $(addsuffix -test,$(call findfiles,stan,*.hpp))
 
 ifeq ($(OS),Windows_NT)
   DEV_NULL = nul

--- a/make/tests
+++ b/make/tests
@@ -67,7 +67,7 @@ $(ALGEBRA_SOLVER_TESTS) : $(LIBSUNDIALS)
 # Target to verify header files within Stan has
 # enough include calls
 ##
-HEADER_TESTS := $(addsuffix -test,$(call findfiles,stan,*.hpp))
+HEADER_TESTS := $(addsuffix -test ,$(call findfiles,stan,*.hpp))
 
 ifeq ($(OS),Windows_NT)
   DEV_NULL = nul

--- a/makefile
+++ b/makefile
@@ -126,7 +126,7 @@ clean-all: clean clean-doxygen clean-deps clean-libraries
 
 .PHONY: test-math-dependencies
 test-math-dependencies:
-	@python runChecks.py
+	@./runChecks.py
 ##
 # Debug target that allows you to print a variable
 ##


### PR DESCRIPTION
## Summary

Strips whitespace in findiles. The whitespaces created a lot of empty lines. See https://github.com/stan-dev/cmdstan/pull/844

Also changes how we call runChecks.py 
Reasons for the change are given here https://github.com/stan-dev/math/pull/1774#issuecomment-597914743

## Tests

/

## Side Effects

/
## Checklist

- [x] Math issue No math issue - see https://github.com/stan-dev/cmdstan/issues/786

- [x] Copyright holder: (fill in copyright holder information)

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses: Rok Češnovar
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
