### PR TITLE
Makefiles: Add $(strip) to findfiles function

### DIFF
--- a/make/compiler_flags
+++ b/make/compiler_flags
@@ -1,6 +1,6 @@
 # Find files subroutine for different operating system
 # This is recursive version of the makefiles wildcard function
-findfiles = $(subst \n,,$(foreach d,$(wildcard $(addsuffix *,$(1))),$(call findfiles,$(d)/,$(2)) $(wildcard $(d)/$(2))))
+findfiles = $(strip $(subst \n,,$(foreach d,$(wildcard $(addsuffix *,$(1))),$(call findfiles,$(d)/,$(2)) $(wildcard $(d)/$(2)))))
 
 ifneq ($(OS),Windows_NT)
 GENERATE_DISTRIBUTION_TESTS=true


### PR DESCRIPTION
## Summary

The work in https://github.com/stan-dev/math/pull/1784 needs an additional patch. This adds $(strip to remove whitespaces that occur on unix systems.

## Tests

/

## Side Effects

/

## Release notes

Replace this text with a short note on what will change if this pull request is merged in which case this will be included in the release notes.

## Checklist

- [ ] Math issue #(issue number)

- [ ] Copyright holder: Rok Češnovar

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [ ] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [ ] the code is written in idiomatic C++ and changes are documented in the doxygen

- [ ] the new changes are tested
