### PR TITLE
fixed normal_id_glm for const sigma

### DIFF
--- a/stan/math/prim/prob/normal_id_glm_lpdf.hpp
+++ b/stan/math/prim/prob/normal_id_glm_lpdf.hpp
@@ -167,6 +167,8 @@ return_type_t<T_y, T_x_scalar, T_alpha, T_beta, T_scale> normal_id_glm_lpdf(
         ops_partials.edge5_.partials_[0]
             = (y_scaled_sq_sum - N_instances) * forward_as<double>(inv_sigma);
       }
+    } else {
+      y_scaled_sq_sum = sum(y_scaled * y_scaled);
     }
   } else {
     y_scaled_sq_sum = sum(y_scaled * y_scaled);

--- a/test/unit/math/opencl/rev/normal_id_glm_lpdf_test.cpp
+++ b/test/unit/math/opencl/rev/normal_id_glm_lpdf_test.cpp
@@ -126,12 +126,28 @@ TEST(ProbDistributionsNormalIdGLM, gpu_matches_cpu_small_simple) {
   Matrix<var, Dynamic, 1> beta_var2 = beta;
   var alpha_var1 = alpha;
   var alpha_var2 = alpha;
+
+  var res1 = stan::math::normal_id_glm_lpdf(y_cl, x_cl, alpha_var1, beta_var1,
+                                            sigma);
+  var res2 = stan::math::normal_id_glm_lpdf(y, x, alpha_var2, beta_var2, sigma);
+
+  (res1 + res2).grad();
+
+  expect_near_rel("normal_id_glm_lpdf (OpenCL)", res1.val(), res2.val());
+
+  expect_near_rel("normal_id_glm_lpdf (OpenCL)", alpha_var1.adj(),
+                  alpha_var2.adj());
+  expect_near_rel("normal_id_glm_lpdf (OpenCL)", beta_var1.adj().eval(),
+                  beta_var2.adj().eval());
+
+  stan::math::set_zero_all_adjoints();
+
   var sigma_var1 = sigma;
   var sigma_var2 = sigma;
 
-  var res1 = stan::math::normal_id_glm_lpdf(y_cl, x_cl, alpha_var1, beta_var1,
-                                            sigma_var1);
-  var res2
+  res1 = stan::math::normal_id_glm_lpdf(y_cl, x_cl, alpha_var1, beta_var1,
+                                        sigma_var1);
+  res2
       = stan::math::normal_id_glm_lpdf(y, x, alpha_var2, beta_var2, sigma_var2);
 
   (res1 + res2).grad();

--- a/test/unit/math/rev/prob/normal_id_glm_lpdf_test.cpp
+++ b/test/unit/math/rev/prob/normal_id_glm_lpdf_test.cpp
@@ -130,7 +130,8 @@ TEST(ProbDistributionsNormalIdGLM, glm_matches_normal_id_simple) {
   double sigma = 10;
 
   var lp1 = stan::math::normal_id_glm_lpdf(y, x, alpha1, beta1, sigma);
-  var lp2 = stan::math::normal_lpdf(y, ((x * beta2).array() +  alpha2).matrix().eval(), sigma);
+  var lp2 = stan::math::normal_lpdf(
+      y, ((x * beta2).array() + alpha2).matrix().eval(), sigma);
 
   EXPECT_NEAR(lp1.val(), lp2.val(), eps);
 

--- a/test/unit/math/rev/prob/normal_id_glm_lpdf_test.cpp
+++ b/test/unit/math/rev/prob/normal_id_glm_lpdf_test.cpp
@@ -115,6 +115,33 @@ TEST(ProbDistributionsNormalIdGLM, glm_matches_normal_id_vars) {
   }
 }
 
+TEST(ProbDistributionsNormalIdGLM, glm_matches_normal_id_simple) {
+  double eps = 1e-9;
+  Matrix<double, Dynamic, 1> y(3, 1);
+  y << 14, 32, 21;
+  Matrix<double, Dynamic, Dynamic> x(3, 2);
+  x << -12, 46, -42, 24, 25, 27;
+  Matrix<double, Dynamic, 1> beta(2, 1);
+  beta << 0.3, 2;
+  Matrix<var, Dynamic, 1> beta1 = beta;
+  Matrix<var, Dynamic, 1> beta2 = beta;
+  var alpha1 = 0.3;
+  var alpha2 = 0.3;
+  double sigma = 10;
+
+  var lp1 = stan::math::normal_id_glm_lpdf(y, x, alpha1, beta1, sigma);
+  var lp2 = stan::math::normal_lpdf(y, ((x * beta2).array() +  alpha2).matrix().eval(), sigma);
+
+  EXPECT_NEAR(lp1.val(), lp2.val(), eps);
+
+  (lp1 + lp2).grad();
+
+  for (int i = 0; i < 2; i++) {
+    EXPECT_NEAR(beta1[i].adj(), beta2[i].adj(), eps);
+  }
+  EXPECT_NEAR(alpha1.adj(), alpha2.adj(), eps);
+}
+
 TEST(ProbDistributionsNormalIdGLM, broadcast_x) {
   Matrix<double, Dynamic, 1> y(3, 1);
   y << 14, 32, 21;


### PR DESCRIPTION
## Summary

Fixed `normal_id_glm_lpdf` for const (not `var`) sigma.

## Tests

Added a test that fails without the fix. A similar test is added for OpenCL implementation (even if it works fine).

## Side Effects
None.

## Release notes

Fixed `normal_id_glm_lpdf` for const (not `var`) sigma.

## Checklist

- [x] Math issue #1806 

- [x] Copyright holder: Tadej Ciglarič

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
