### PR TITLE
Fix ode gradients with respect to t0 (Issue #1833)

### DIFF
--- a/stan/math/prim/functor/coupled_ode_observer.hpp
+++ b/stan/math/prim/functor/coupled_ode_observer.hpp
@@ -44,6 +44,7 @@ struct coupled_ode_observer {
   const std::size_t N_;
   const std::size_t M_;
   const std::size_t index_offset_theta_;
+  std::vector<double> f_y0_t0_;
   int next_ts_index_;
 
   /**
@@ -84,7 +85,12 @@ struct coupled_ode_observer {
         N_(y0.size()),
         M_(theta.size()),
         index_offset_theta_(is_constant_all<T1>::value ? 0 : N_ * N_),
-        next_ts_index_(0) {}
+        next_ts_index_(0) {
+    if (!is_constant_all<T_t0>::value) {
+      f_y0_t0_ = f(value_of(t0), value_of(y0), value_of(theta_), x_, x_int_, msgs_);
+      check_size_match("coupled_ode_observer", "dy_dt", f_y0_t0_.size(), "states", N_);
+    }
+  }
 
   /**
    * Callback function for ODE solvers to record values. The coupled
@@ -131,6 +137,10 @@ struct coupled_ode_observer {
           ops_partials.edge2_.partials_[k]
               = coupled_state[N_ + index_offset_theta_ + N_ * k + j];
         }
+      }
+
+      if (!is_constant_all<T_t0>::value) {
+	ops_partials.edge3_.partials_[0] = -f_y0_t0_[j];
       }
 
       if (!is_constant_all<T_ts>::value) {

--- a/stan/math/prim/functor/coupled_ode_observer.hpp
+++ b/stan/math/prim/functor/coupled_ode_observer.hpp
@@ -44,7 +44,7 @@ struct coupled_ode_observer {
   const std::size_t N_;
   const std::size_t M_;
   const std::size_t index_offset_theta_;
-  std::vector<double> f_y0_t0_;
+  std::vector<double> initial_dy_dt_;
   int next_ts_index_;
 
   /**
@@ -87,9 +87,9 @@ struct coupled_ode_observer {
         index_offset_theta_(is_constant_all<T1>::value ? 0 : N_ * N_),
         next_ts_index_(0) {
     if (!is_constant_all<T_t0>::value) {
-      f_y0_t0_
+      initial_dy_dt_
           = f(value_of(t0), value_of(y0), value_of(theta_), x_, x_int_, msgs_);
-      check_size_match("coupled_ode_observer", "dy_dt", f_y0_t0_.size(),
+      check_size_match("coupled_ode_observer", "dy_dt", initial_dy_dt_.size(),
                        "states", N_);
     }
   }
@@ -142,7 +142,7 @@ struct coupled_ode_observer {
       }
 
       if (!is_constant_all<T_t0>::value) {
-        ops_partials.edge3_.partials_[0] = -f_y0_t0_[j];
+        ops_partials.edge3_.partials_[0] = -initial_dy_dt_[j];
       }
 
       if (!is_constant_all<T_ts>::value) {

--- a/stan/math/prim/functor/coupled_ode_observer.hpp
+++ b/stan/math/prim/functor/coupled_ode_observer.hpp
@@ -87,8 +87,10 @@ struct coupled_ode_observer {
         index_offset_theta_(is_constant_all<T1>::value ? 0 : N_ * N_),
         next_ts_index_(0) {
     if (!is_constant_all<T_t0>::value) {
-      f_y0_t0_ = f(value_of(t0), value_of(y0), value_of(theta_), x_, x_int_, msgs_);
-      check_size_match("coupled_ode_observer", "dy_dt", f_y0_t0_.size(), "states", N_);
+      f_y0_t0_
+          = f(value_of(t0), value_of(y0), value_of(theta_), x_, x_int_, msgs_);
+      check_size_match("coupled_ode_observer", "dy_dt", f_y0_t0_.size(),
+                       "states", N_);
     }
   }
 
@@ -140,7 +142,7 @@ struct coupled_ode_observer {
       }
 
       if (!is_constant_all<T_t0>::value) {
-	ops_partials.edge3_.partials_[0] = -f_y0_t0_[j];
+        ops_partials.edge3_.partials_[0] = -f_y0_t0_[j];
       }
 
       if (!is_constant_all<T_ts>::value) {

--- a/test/unit/math/rev/functor/coupled_ode_observer_test.cpp
+++ b/test/unit/math/rev/functor/coupled_ode_observer_test.cpp
@@ -221,7 +221,7 @@ TEST_F(StanRevOde, observe_states_ddvd) {
       EXPECT_FLOAT_EQ(ys_coupled[t][n], y[t][n].val());
     for (size_t n = 0; n < 2; n++) {
       y[t][n].grad();
-      EXPECT_FLOAT_EQ(0.0, t0.adj());
+      EXPECT_FLOAT_EQ(-y0[n], t0.adj());
       stan::math::set_zero_all_adjoints();
     }
   }

--- a/test/unit/math/rev/functor/coupled_ode_observer_test.cpp
+++ b/test/unit/math/rev/functor/coupled_ode_observer_test.cpp
@@ -320,12 +320,17 @@ TEST_F(StanRevOde, observe_states_ddvd_error) {
     tsd[t] = t;
   }
 
-  EXPECT_THROW_MSG((stan::math::coupled_ode_observer<harm_osc_ode_wrong_size_1_fun, double, double, var,
-		    double>(harm_osc1, y0, theta, t0v, tsd, x, x_int, &msgs, y)), std::invalid_argument,
-		   std::string("coupled_ode_observer: dy_dt (3) and states (2) must match in size"));
+  EXPECT_THROW_MSG(
+      (stan::math::coupled_ode_observer<harm_osc_ode_wrong_size_1_fun, double,
+                                        double, var, double>(
+          harm_osc1, y0, theta, t0v, tsd, x, x_int, &msgs, y)),
+      std::invalid_argument,
+      std::string(
+          "coupled_ode_observer: dy_dt (3) and states (2) must match in size"));
 
-  EXPECT_NO_THROW((stan::math::coupled_ode_observer<harm_osc_ode_fun, double, double, var,
-		    double>(harm_osc2, y0, theta, t0v, tsd, x, x_int, &msgs, y)));
+  EXPECT_NO_THROW((stan::math::coupled_ode_observer<harm_osc_ode_fun, double,
+                                                    double, var, double>(
+      harm_osc2, y0, theta, t0v, tsd, x, x_int, &msgs, y)));
 }
 
 TEST_F(StanRevOde, observe_states_dddv_error) {
@@ -350,13 +355,17 @@ TEST_F(StanRevOde, observe_states_dddv_error) {
     tsv[t] = t;
   }
 
-  stan::math::coupled_ode_observer<harm_osc_ode_wrong_size_1_fun, double, double, double, var>
-    throwing_observer(harm_osc1, y0, theta, t0d, tsv, x, x_int, &msgs, y);
+  stan::math::coupled_ode_observer<harm_osc_ode_wrong_size_1_fun, double,
+                                   double, double, var>
+      throwing_observer(harm_osc1, y0, theta, t0d, tsv, x, x_int, &msgs, y);
 
-  stan::math::coupled_ode_observer<harm_osc_ode_fun, double, double, double, var>
-    observer(harm_osc2, y0, theta, t0d, tsv, x, x_int, &msgs, y);
+  stan::math::coupled_ode_observer<harm_osc_ode_fun, double, double, double,
+                                   var>
+      observer(harm_osc2, y0, theta, t0d, tsv, x, x_int, &msgs, y);
 
-  EXPECT_THROW_MSG((throwing_observer(std::vector<double>(2), 0)), std::invalid_argument,
-		   std::string("coupled_ode_observer: dy_dt (3) and states (2) must match in size"));
+  EXPECT_THROW_MSG(
+      (throwing_observer(std::vector<double>(2), 0)), std::invalid_argument,
+      std::string(
+          "coupled_ode_observer: dy_dt (3) and states (2) must match in size"));
   EXPECT_NO_THROW((observer(std::vector<double>(2), 0)));
 }

--- a/test/unit/math/rev/functor/coupled_ode_observer_test.cpp
+++ b/test/unit/math/rev/functor/coupled_ode_observer_test.cpp
@@ -297,3 +297,66 @@ TEST_F(StanRevOde, observe_states_dddv) {
       (throwing_observer(std::vector<double>(coupled_system.size(), 0.0), 0)),
       std::logic_error, message);
 }
+
+TEST_F(StanRevOde, observe_states_ddvd_error) {
+  using stan::math::coupled_ode_system;
+  using stan::math::var;
+
+  harm_osc_ode_wrong_size_1_fun harm_osc1;
+  harm_osc_ode_fun harm_osc2;
+
+  std::vector<double> y0(2);
+  std::vector<double> theta(1);
+
+  y0[0] = 1.0;
+  y0[1] = 0.5;
+  theta[0] = 0.15;
+
+  std::vector<std::vector<var>> y;
+  var t0v = 0;
+  int T = 10;
+  std::vector<double> tsd(T);
+  for (int t = 0; t < T; t++) {
+    tsd[t] = t;
+  }
+
+  EXPECT_THROW_MSG((stan::math::coupled_ode_observer<harm_osc_ode_wrong_size_1_fun, double, double, var,
+		    double>(harm_osc1, y0, theta, t0v, tsd, x, x_int, &msgs, y)), std::invalid_argument,
+		   std::string("coupled_ode_observer: dy_dt (3) and states (2) must match in size"));
+
+  EXPECT_NO_THROW((stan::math::coupled_ode_observer<harm_osc_ode_fun, double, double, var,
+		    double>(harm_osc2, y0, theta, t0v, tsd, x, x_int, &msgs, y)));
+}
+
+TEST_F(StanRevOde, observe_states_dddv_error) {
+  using stan::math::coupled_ode_system;
+  using stan::math::var;
+
+  harm_osc_ode_wrong_size_1_fun harm_osc1;
+  harm_osc_ode_fun harm_osc2;
+
+  std::vector<double> y0(2);
+  std::vector<double> theta(1);
+
+  y0[0] = 1.0;
+  y0[1] = 0.5;
+  theta[0] = 0.15;
+
+  std::vector<std::vector<var>> y;
+  double t0d = 0;
+  int T = 10;
+  std::vector<var> tsv(T);
+  for (int t = 0; t < T; t++) {
+    tsv[t] = t;
+  }
+
+  stan::math::coupled_ode_observer<harm_osc_ode_wrong_size_1_fun, double, double, double, var>
+    throwing_observer(harm_osc1, y0, theta, t0d, tsv, x, x_int, &msgs, y);
+
+  stan::math::coupled_ode_observer<harm_osc_ode_fun, double, double, double, var>
+    observer(harm_osc2, y0, theta, t0d, tsv, x, x_int, &msgs, y);
+
+  EXPECT_THROW_MSG((throwing_observer(std::vector<double>(2), 0)), std::invalid_argument,
+		   std::string("coupled_ode_observer: dy_dt (3) and states (2) must match in size"));
+  EXPECT_NO_THROW((observer(std::vector<double>(2), 0)));
+}

--- a/test/unit/math/rev/functor/integrate_ode_adams_rev_test.cpp
+++ b/test/unit/math/rev/functor/integrate_ode_adams_rev_test.cpp
@@ -242,7 +242,7 @@ TEST(StanAgradRevOde_integrate_ode_adams, t0_as_param_AD) {
   const int ns = 2;    // nb. of states
   std::ostream* msgs = NULL;
 
-  forced_harm_osc_ode_fun ode;
+  harm_osc_ode_fun ode;
 
   std::vector<double> theta{0.15, 0.25};
   std::vector<double> y0{1.0, 0.0};
@@ -260,13 +260,12 @@ TEST(StanAgradRevOde_integrate_ode_adams, t0_as_param_AD) {
   auto test_ad = [&res, &t0v, &ode, &nt, &ns, &theta, &x, &x_int, &msgs]() {
     for (auto i = 0; i < nt; ++i) {
       std::vector<double> res_d = value_of(res[i]);
-      for (auto j = 0; j < ns; ++j) {
-        res[i][j].grad();
-        for (auto k = 0; k < nt; ++k) {
-          EXPECT_FLOAT_EQ(t0v.adj(), 0.0);
-        }
-        stan::math::set_zero_all_adjoints();
-      }
+      res[i][0].grad();
+      EXPECT_FLOAT_EQ(t0v.adj(), 0.0);
+      stan::math::set_zero_all_adjoints();
+      res[i][1].grad();
+      EXPECT_FLOAT_EQ(t0v.adj(), 1.0);
+      stan::math::set_zero_all_adjoints();
     }
   };
   res = integrate_ode_adams(ode, y0, t0v, ts, theta, x, x_int);

--- a/test/unit/math/rev/functor/integrate_ode_bdf_rev_test.cpp
+++ b/test/unit/math/rev/functor/integrate_ode_bdf_rev_test.cpp
@@ -268,7 +268,7 @@ TEST(StanAgradRevOde_integrate_ode_bdf, t0_as_param_AD) {
   const int ns = 2;    // nb. of states
   std::ostream* msgs = NULL;
 
-  forced_harm_osc_ode_fun ode;
+  harm_osc_ode_fun ode;
 
   std::vector<double> theta{0.15, 0.25};
   std::vector<double> y0{1.0, 0.0};
@@ -286,13 +286,12 @@ TEST(StanAgradRevOde_integrate_ode_bdf, t0_as_param_AD) {
   auto test_ad = [&res, &t0v, &ode, &nt, &ns, &theta, &x, &x_int, &msgs]() {
     for (auto i = 0; i < nt; ++i) {
       std::vector<double> res_d = value_of(res[i]);
-      for (auto j = 0; j < ns; ++j) {
-        res[i][j].grad();
-        for (auto k = 0; k < nt; ++k) {
-          EXPECT_FLOAT_EQ(t0v.adj(), 0.0);
-        }
-        stan::math::set_zero_all_adjoints();
-      }
+      res[i][0].grad();
+      EXPECT_FLOAT_EQ(t0v.adj(), 0.0);
+      stan::math::set_zero_all_adjoints();
+      res[i][1].grad();
+      EXPECT_FLOAT_EQ(t0v.adj(), 1.0);
+      stan::math::set_zero_all_adjoints();
     }
   };
   res = integrate_ode_bdf(ode, y0, t0v, ts, theta, x, x_int);

--- a/test/unit/math/rev/functor/integrate_ode_rk45_test.cpp
+++ b/test/unit/math/rev/functor/integrate_ode_rk45_test.cpp
@@ -251,11 +251,12 @@ TEST(StanAgradRevOde_integrate_ode_rk45, t0_as_param_AD) {
   auto test_ad = [&res, &t0v, &ode, &nt, &ns, &theta, &x, &x_int, &msgs]() {
     for (auto i = 0; i < nt; ++i) {
       std::vector<double> res_d = value_of(res[i]);
-      for (auto j = 0; j < ns; ++j) {
-        res[i][j].grad();
-        EXPECT_FLOAT_EQ(t0v.adj(), 0.0);
-        stan::math::set_zero_all_adjoints();
-      }
+      res[i][0].grad();
+      EXPECT_FLOAT_EQ(t0v.adj(), 0.0);
+      stan::math::set_zero_all_adjoints();
+      res[i][1].grad();
+      EXPECT_FLOAT_EQ(t0v.adj(), 1.0);
+      stan::math::set_zero_all_adjoints();
     }
   };
   res = integrate_ode_rk45(ode, y0, t0v, ts, theta, x, x_int);


### PR DESCRIPTION
Fixes #1833 

## Tests

There were tests in place, but either:
1. They were testing against ```forced_harm_osc_ode_fun``` which actually had zero gradients
2. Or they were testing that the gradients were zero

So not setting the gradients was accidentally making these things pass. I changed the tests to use ```harm_osc_ode_fun``` where one of the gradients isn't zero, and I updated the checks to look for that.

## Release notes

Fixed problem where ode solvers were not computing the gradients of the output with respect to the initial integration time. This affected the rk45, adams, and bdf solvers.

## Checklist

- [x] Math issue #1833
- [x] Copyright holder: Columbia University

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [ ] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
