### PR TITLE
makefile cleanup: replace "if [[" syntax with make ifs

### DIFF
--- a/make/libraries
+++ b/make/libraries
@@ -125,11 +125,11 @@ endif
 
 $(TBB_BIN)/tbb-make-check:
 ifeq (Windows_NT,$(OS))
-ifneq (mingw32,$(MAKE))
+		if ! [[ $(MAKE) =~ mingw32 ]]; then \
 			echo "ERROR: Please use mingw32-make on Windows to build the Intel TBB library."; \
 			echo "This is packaged with RTools, for example."; \
-			exit 1;
-endif
+			exit 1; \
+		fi
 endif
 	@mkdir -p $(TBB_BIN)
 	touch $(TBB_BIN)/tbb-make-check

--- a/make/libraries
+++ b/make/libraries
@@ -124,13 +124,13 @@ ifeq (,$(TBB_CC))
 endif
 
 $(TBB_BIN)/tbb-make-check:
-	@if [[ $(OS) == Windows_NT ]]; then \
-		if ! [[ $(MAKE) =~ mingw32 ]]; then \
+ifeq (Windows_NT,$(OS))
+ifneq (mingw32,$(MAKE))
 			echo "ERROR: Please use mingw32-make on Windows to build the Intel TBB library."; \
 			echo "This is packaged with RTools, for example."; \
-			exit 1; \
-		fi \
-	fi
+			exit 1;
+endif
+endif
 	@mkdir -p $(TBB_BIN)
 	touch $(TBB_BIN)/tbb-make-check
 


### PR DESCRIPTION
## Summary

Fixes #1839 by replacing the "if [[ " syntax that uses shell with make ifeq and ifneq syntax.

## Tests

/

## Side Effects

/

## Release notes

Removed the "/bin/sh: 1: [[: not found" warning on Linux.

## Checklist

- [x] Math issue #1836 

- [x] Copyright holder: Rok Češnovar

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
