### PR TITLE
Reorder reduce sum args

### DIFF
--- a/stan/math/fwd/functor/reduce_sum.hpp
+++ b/stan/math/fwd/functor/reduce_sum.hpp
@@ -38,7 +38,7 @@ struct reduce_sum_impl {
    * This specialization is not parallelized and works for any autodiff types.
    *
    * An instance, f, of `ReduceFunction` should have the signature:
-   *   T f(int start, int end, Vec&& vmapped_subset, std::ostream* msgs,
+   *   T f(Vec&& vmapped_subset, int start, int end, std::ostream* msgs,
    * Args&&... args)
    *
    * `ReduceFunction` must be default constructible without any arguments
@@ -73,7 +73,8 @@ struct reduce_sum_impl {
     }
 
     if (auto_partitioning) {
-      return ReduceFunction()(0, vmapped.size() - 1, std::forward<Vec>(vmapped),
+      return ReduceFunction()(std::forward<Vec>(vmapped),
+                              0, vmapped.size() - 1,
                               msgs, std::forward<Args>(args)...);
     } else {
       return_type_t<Vec, Args...> sum = 0.0;
@@ -88,8 +89,8 @@ struct reduce_sum_impl {
           sub_slice.emplace_back(vmapped[i]);
         }
 
-        sum += ReduceFunction()(start, end, std::forward<Vec>(sub_slice), msgs,
-                                std::forward<Args>(args)...);
+        sum += ReduceFunction()(std::forward<Vec>(sub_slice), start, end, 
+                                msgs, std::forward<Args>(args)...);
       }
       return sum;
     }

--- a/stan/math/fwd/functor/reduce_sum.hpp
+++ b/stan/math/fwd/functor/reduce_sum.hpp
@@ -73,8 +73,7 @@ struct reduce_sum_impl {
     }
 
     if (auto_partitioning) {
-      return ReduceFunction()(std::forward<Vec>(vmapped),
-                              0, vmapped.size() - 1,
+      return ReduceFunction()(std::forward<Vec>(vmapped), 0, vmapped.size() - 1,
                               msgs, std::forward<Args>(args)...);
     } else {
       return_type_t<Vec, Args...> sum = 0.0;
@@ -89,8 +88,8 @@ struct reduce_sum_impl {
           sub_slice.emplace_back(vmapped[i]);
         }
 
-        sum += ReduceFunction()(std::forward<Vec>(sub_slice), start, end, 
-                                msgs, std::forward<Args>(args)...);
+        sum += ReduceFunction()(std::forward<Vec>(sub_slice), start, end, msgs,
+                                std::forward<Args>(args)...);
       }
       return sum;
     }

--- a/stan/math/prim/functor/reduce_sum.hpp
+++ b/stan/math/prim/functor/reduce_sum.hpp
@@ -85,7 +85,7 @@ struct reduce_sum_impl<ReduceFunction, require_arithmetic_t<ReturnType>,
 
       sum_ += apply(
           [&](auto&&... args) {
-            return ReduceFunction()(r.begin(), r.end() - 1, sub_slice, msgs_,
+            return ReduceFunction()(sub_slice, r.begin(), r.end() - 1, msgs_,
                                     args...);
           },
           args_tuple_);
@@ -107,7 +107,7 @@ struct reduce_sum_impl<ReduceFunction, require_arithmetic_t<ReturnType>,
    *   arithmetic types.
    *
    * ReduceFunction must define an operator() with the same signature as:
-   *   double f(int start, int end, Vec&& vmapped_subset, std::ostream* msgs,
+   *   double f(Vec&& vmapped_subset, int start, int end, std::ostream* msgs,
    * Args&&... args)
    *
    * `ReduceFunction` must be default constructible without any arguments
@@ -174,7 +174,7 @@ struct reduce_sum_impl<ReduceFunction, require_arithmetic_t<ReturnType>,
  * This defers to reduce_sum_impl for the appropriate implementation
  *
  * ReduceFunction must define an operator() with the same signature as:
- *   T f(int start, int end, Vec&& vmapped_subset, std::ostream* msgs, Args&&...
+ *   T f(Vec&& vmapped_subset, int start, int end, std::ostream* msgs, Args&&...
  * args)
  *
  * `ReduceFunction` must be default constructible without any arguments
@@ -209,7 +209,7 @@ inline auto reduce_sum(Vec&& vmapped, int grainsize, std::ostream* msgs,
     return return_type(0.0);
   }
 
-  return ReduceFunction()(0, vmapped.size() - 1, std::forward<Vec>(vmapped),
+  return ReduceFunction()(std::forward<Vec>(vmapped), 0, vmapped.size() - 1,
                           msgs, std::forward<Args>(args)...);
 #endif
 }

--- a/stan/math/prim/functor/reduce_sum_static.hpp
+++ b/stan/math/prim/functor/reduce_sum_static.hpp
@@ -58,7 +58,7 @@ auto reduce_sum_static(Vec&& vmapped, int grainsize, std::ostream* msgs,
     return return_type(0);
   }
 
-  return ReduceFunction()(0, vmapped.size() - 1, std::forward<Vec>(vmapped),
+  return ReduceFunction()(std::forward<Vec>(vmapped), 0, vmapped.size() - 1,
                           msgs, std::forward<Args>(args)...);
 #endif
 }

--- a/stan/math/prim/functor/reduce_sum_static.hpp
+++ b/stan/math/prim/functor/reduce_sum_static.hpp
@@ -21,7 +21,7 @@ namespace math {
  * This defers to reduce_sum_impl for the appropriate implementation
  *
  * ReduceFunction must define an operator() with the same signature as:
- *   T f(int start, int end, Vec&& vmapped_subset, std::ostream* msgs, Args&&...
+ *   T f(Vec&& vmapped_subset, int start, int end, std::ostream* msgs, Args&&...
  * args)
  *
  * `ReduceFunction` must be default constructible without any arguments

--- a/stan/math/rev/functor/reduce_sum.hpp
+++ b/stan/math/rev/functor/reduce_sum.hpp
@@ -116,7 +116,8 @@ struct reduce_sum_impl<ReduceFunction, require_var_t<ReturnType>, ReturnType,
       // Perform calculation
       var sub_sum_v = apply(
           [&](auto&&... args) {
-            return ReduceFunction()(r.begin(), r.end() - 1, local_sub_slice,
+            return ReduceFunction()(local_sub_slice,
+                                    r.begin(), r.end() - 1,
                                     msgs_, args...);
           },
           args_tuple_local_copy);
@@ -164,7 +165,7 @@ struct reduce_sum_impl<ReduceFunction, require_var_t<ReturnType>, ReturnType,
    *   mode autodiff.
    *
    * ReduceFunction must define an operator() with the same signature as:
-   *   var f(int start, int end, Vec&& vmapped_subset, std::ostream* msgs,
+   *   var f(Vec&& vmapped_subset, int start, int end, std::ostream* msgs,
    * Args&&... args)
    *
    * `ReduceFunction` must be default constructible without any arguments

--- a/stan/math/rev/functor/reduce_sum.hpp
+++ b/stan/math/rev/functor/reduce_sum.hpp
@@ -116,8 +116,7 @@ struct reduce_sum_impl<ReduceFunction, require_var_t<ReturnType>, ReturnType,
       // Perform calculation
       var sub_sum_v = apply(
           [&](auto&&... args) {
-            return ReduceFunction()(local_sub_slice,
-                                    r.begin(), r.end() - 1,
+            return ReduceFunction()(local_sub_slice, r.begin(), r.end() - 1,
                                     msgs_, args...);
           },
           args_tuple_local_copy);

--- a/test/unit/math/prim/functor/reduce_sum_test.cpp
+++ b/test/unit/math/prim/functor/reduce_sum_test.cpp
@@ -237,8 +237,8 @@ TEST(StanMathPrim_reduce_sum, sum) {
 std::vector<int> threading_test_global;
 struct threading_test_lpdf {
   template <typename T1>
-  inline auto operator()(std::size_t start, std::size_t end,
-                         const std::vector<T1>&, std::ostream* msgs) const {
+  inline auto operator()(const std::vector<T1>&, std::size_t start, std::size_t end,
+                         std::ostream* msgs) const {
     threading_test_global[start] = tbb::this_task_arena::current_thread_index();
 
     return stan::return_type_t<T1>(0);

--- a/test/unit/math/prim/functor/reduce_sum_test.cpp
+++ b/test/unit/math/prim/functor/reduce_sum_test.cpp
@@ -237,8 +237,8 @@ TEST(StanMathPrim_reduce_sum, sum) {
 std::vector<int> threading_test_global;
 struct threading_test_lpdf {
   template <typename T1>
-  inline auto operator()(const std::vector<T1>&, std::size_t start, std::size_t end,
-                         std::ostream* msgs) const {
+  inline auto operator()(const std::vector<T1>&, std::size_t start,
+                         std::size_t end, std::ostream* msgs) const {
     threading_test_global[start] = tbb::this_task_arena::current_thread_index();
 
     return stan::return_type_t<T1>(0);

--- a/test/unit/math/prim/functor/reduce_sum_util.hpp
+++ b/test/unit/math/prim/functor/reduce_sum_util.hpp
@@ -21,9 +21,8 @@ struct count_lpdf {
   count_lpdf() {}
 
   // does the reduction in the sub-slice start to end
-  inline T operator()(const std::vector<int>& sub_slice,
-                      std::size_t start, std::size_t end,
-                      std::ostream* msgs,
+  inline T operator()(const std::vector<int>& sub_slice, std::size_t start,
+                      std::size_t end, std::ostream* msgs,
                       const std::vector<T>& lambda,
                       const std::vector<int>& idata) const {
     return stan::math::poisson_lpmf(sub_slice, lambda[0]);
@@ -35,8 +34,8 @@ struct nesting_count_lpdf {
   nesting_count_lpdf() {}
 
   // does the reduction in the sub-slice start to end
-  inline T operator()(const std::vector<int>& sub_slice,
-                      std::size_t start, std::size_t end, std::ostream* msgs,
+  inline T operator()(const std::vector<int>& sub_slice, std::size_t start,
+                      std::size_t end, std::ostream* msgs,
                       const std::vector<T>& lambda,
                       const std::vector<int>& idata) const {
     return stan::math::reduce_sum<count_lpdf<T>>(sub_slice, 5, msgs, lambda,
@@ -98,9 +97,8 @@ struct slice_group_count_lpdf {
   slice_group_count_lpdf() {}
 
   // does the reduction in the sub-slice start to end
-  inline T operator()(const std::vector<T>& lambda_slice,
-                      std::size_t start, std::size_t end,
-                      std::ostream* msgs,
+  inline T operator()(const std::vector<T>& lambda_slice, std::size_t start,
+                      std::size_t end, std::ostream* msgs,
                       const std::vector<int>& y,
                       const std::vector<int>& gsidx) const {
     const std::size_t num_groups = end - start + 1;
@@ -170,8 +168,9 @@ auto reduce_sum_sum_lpdf = [](auto&& data, auto&&... args) {
 template <int grainsize>
 struct static_check_lpdf {
   template <typename T>
-  inline auto operator()(const std::vector<int>&, std::size_t start, std::size_t end,
-                         std::ostream* msgs, const std::vector<T>& data) const {
+  inline auto operator()(const std::vector<int>&, std::size_t start,
+                         std::size_t end, std::ostream* msgs,
+                         const std::vector<T>& data) const {
     T sum = 0;
     EXPECT_LE(end - start + 1, grainsize);
     for (size_t i = start; i <= end; i++) {

--- a/test/unit/math/rev/functor/reduce_sum_test.cpp
+++ b/test/unit/math/rev/functor/reduce_sum_test.cpp
@@ -394,8 +394,8 @@ TEST(StanMathRev_reduce_sum, slice_group_gradient) {
 std::vector<int> threading_test_global;
 struct threading_test_lpdf {
   template <typename T1>
-  inline auto operator()(std::size_t start, std::size_t end,
-                         const std::vector<T1>&, std::ostream* msgs) const {
+  inline auto operator()(const std::vector<T1>&, std::size_t start,
+                         std::size_t end, std::ostream* msgs) const {
     threading_test_global[start] = tbb::this_task_arena::current_thread_index();
 
     return stan::return_type_t<T1>(0);


### PR DESCRIPTION
## Summary

In https://discourse.mc-stan.org/t/can-we-have-unnormalised-densities-in-user-functions/14333/18 we discussed that the slice argument should come first. This PR does this change.

The release notes section is left empty because this is fixing a "bug" (its more of a prevention from a backwards compatibility nightmare) for a feature that has not been released yet.

## Tests

Changes are reflected in the tests utilities also.

## Side Effects

/

## Release notes

## Checklist

- [x] Math issue #(issue number)

- [x] Copyright holder: Rok Češnovar

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
