### PR TITLE
generalize */fun q-r

### DIFF
--- a/stan/math/fwd/fun/quad_form.hpp
+++ b/stan/math/fwd/fun/quad_form.hpp
@@ -14,12 +14,8 @@ namespace math {
  * Symmetry of the resulting matrix is not guaranteed due to numerical
  * precision.
  *
- * @tparam Ta type of elements in the square matrix
- * @tparam Ra number of rows in the square matrix, can be Eigen::Dynamic
- * @tparam Ca number of columns in the square matrix, can be Eigen::Dynamic
- * @tparam Tb type of elements in the second matrix
- * @tparam Rb number of rows in the second matrix, can be Eigen::Dynamic
- * @tparam Cb number of columns in the second matrix, can be Eigen::Dynamic
+ * @tparam EigMat1 type of the first (square) matrix
+ * @tparam EigMat2 type of the second matrix
  *
  * @param A square matrix
  * @param B second matrix
@@ -27,10 +23,12 @@ namespace math {
  * @throws std::invalid_argument if A is not square, or if A cannot be
  * multiplied by B
  */
-template <typename Ta, int Ra, int Ca, typename Tb, int Rb, int Cb,
-          require_any_fvar_t<Ta, Tb>...>
-inline Eigen::Matrix<return_type_t<Ta, Tb>, Cb, Cb> quad_form(
-    const Eigen::Matrix<Ta, Ra, Ca>& A, const Eigen::Matrix<Tb, Rb, Cb>& B) {
+template <typename EigMat1, typename EigMat2,
+          require_all_eigen_t<EigMat1, EigMat2>* = nullptr,
+          require_not_eigen_col_vector_t<EigMat2>* = nullptr,
+          require_any_vt_fvar<EigMat1, EigMat2>* = nullptr>
+inline promote_scalar_t<return_type_t<EigMat1, EigMat2>, EigMat2> quad_form(
+    const EigMat1& A, const EigMat2& B) {
   check_square("quad_form", "A", A);
   check_multiplicable("quad_form", "A", A, "B", B);
   return multiply(transpose(B), multiply(A, B));
@@ -39,11 +37,8 @@ inline Eigen::Matrix<return_type_t<Ta, Tb>, Cb, Cb> quad_form(
 /**
  * Return the quadratic form \f$ B^T A B \f$.
  *
- * @tparam Ta type of elements in the square matrix
- * @tparam Ra number of rows in the square matrix, can be Eigen::Dynamic
- * @tparam Ca number of columns in the square matrix, can be Eigen::Dynamic
- * @tparam Tb type of elements in the vector
- * @tparam Rb number of rows in the vector, can be Eigen::Dynamic
+ * @tparam EigMat type of the matrix
+ * @tparam ColVec type of the vector
  *
  * @param A square matrix
  * @param B vector
@@ -51,10 +46,11 @@ inline Eigen::Matrix<return_type_t<Ta, Tb>, Cb, Cb> quad_form(
  * @throws std::invalid_argument if A is not square, or if A cannot be
  * multiplied by B
  */
-template <typename Ta, int Ra, int Ca, typename Tb, int Rb,
-          require_any_fvar_t<Ta, Tb>...>
-inline return_type_t<Ta, Tb> quad_form(const Eigen::Matrix<Ta, Ra, Ca>& A,
-                                       const Eigen::Matrix<Tb, Rb, 1>& B) {
+template <typename EigMat, typename ColVec, require_eigen_t<EigMat>* = nullptr,
+         require_eigen_col_vector_t<ColVec>* = nullptr,
+         require_any_vt_fvar<EigMat, ColVec>* = nullptr>
+inline return_type_t<EigMat, ColVec> quad_form(const EigMat& A,
+                                       const ColVec& B) {
   check_square("quad_form", "A", A);
   check_multiplicable("quad_form", "A", A, "B", B);
   return dot_product(B, multiply(A, B));

--- a/stan/math/fwd/fun/quad_form.hpp
+++ b/stan/math/fwd/fun/quad_form.hpp
@@ -47,10 +47,10 @@ inline promote_scalar_t<return_type_t<EigMat1, EigMat2>, EigMat2> quad_form(
  * multiplied by B
  */
 template <typename EigMat, typename ColVec, require_eigen_t<EigMat>* = nullptr,
-         require_eigen_col_vector_t<ColVec>* = nullptr,
-         require_any_vt_fvar<EigMat, ColVec>* = nullptr>
+          require_eigen_col_vector_t<ColVec>* = nullptr,
+          require_any_vt_fvar<EigMat, ColVec>* = nullptr>
 inline return_type_t<EigMat, ColVec> quad_form(const EigMat& A,
-                                       const ColVec& B) {
+                                               const ColVec& B) {
   check_square("quad_form", "A", A);
   check_multiplicable("quad_form", "A", A, "B", B);
   return dot_product(B, multiply(A, B));

--- a/stan/math/fwd/fun/quad_form.hpp
+++ b/stan/math/fwd/fun/quad_form.hpp
@@ -31,7 +31,7 @@ inline promote_scalar_t<return_type_t<EigMat1, EigMat2>, EigMat2> quad_form(
     const EigMat1& A, const EigMat2& B) {
   check_square("quad_form", "A", A);
   check_multiplicable("quad_form", "A", A, "B", B);
-  return multiply(transpose(B), multiply(A, B));
+  return multiply(B.transpose(), multiply(A, B));
 }
 
 /**

--- a/stan/math/fwd/fun/quad_form_sym.hpp
+++ b/stan/math/fwd/fun/quad_form_sym.hpp
@@ -31,8 +31,7 @@ inline promote_scalar_t<return_type_t<EigMat1, EigMat2>, EigMat2> quad_form_sym(
   using T_ret = return_type_t<EigMat1, EigMat2>;
   check_multiplicable("quad_form_sym", "A", A, "B", B);
   check_symmetric("quad_form_sym", "A", A);
-  promote_scalar_t<T_ret, EigMat2> ret(
-      multiply(B.transpose(), multiply(A, B)));
+  promote_scalar_t<T_ret, EigMat2> ret(multiply(B.transpose(), multiply(A, B)));
   return T_ret(0.5) * (ret + ret.transpose());
 }
 

--- a/stan/math/prim/fun/qr_Q.hpp
+++ b/stan/math/prim/fun/qr_Q.hpp
@@ -1,6 +1,7 @@
 #ifndef STAN_MATH_PRIM_FUN_QR_Q_HPP
 #define STAN_MATH_PRIM_FUN_QR_Q_HPP
 
+#include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/err.hpp>
 #include <stan/math/prim/fun/Eigen.hpp>
 #include <algorithm>
@@ -11,14 +12,14 @@ namespace math {
 /**
  * Returns the orthogonal factor of the fat QR decomposition
  *
- * @tparam T type of elements in the matrix
+ * @tparam EigMat type of the matrix
  * @param m Matrix.
  * @return Orthogonal matrix with maximal columns
  */
-template <typename T>
-Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> qr_Q(
-    const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& m) {
-  using matrix_t = Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>;
+template <typename EigMat, require_eigen_t<EigMat>* = nullptr>
+Eigen::Matrix<value_type_t<EigMat>, Eigen::Dynamic, Eigen::Dynamic> qr_Q(
+    const EigMat& m) {
+  using matrix_t = Eigen::Matrix<value_type_t<EigMat>, Eigen::Dynamic, Eigen::Dynamic>;
   check_nonzero_size("qr_Q", "m", m);
   Eigen::HouseholderQR<matrix_t> qr(m.rows(), m.cols());
   qr.compute(m);

--- a/stan/math/prim/fun/qr_Q.hpp
+++ b/stan/math/prim/fun/qr_Q.hpp
@@ -19,7 +19,8 @@ namespace math {
 template <typename EigMat, require_eigen_t<EigMat>* = nullptr>
 Eigen::Matrix<value_type_t<EigMat>, Eigen::Dynamic, Eigen::Dynamic> qr_Q(
     const EigMat& m) {
-  using matrix_t = Eigen::Matrix<value_type_t<EigMat>, Eigen::Dynamic, Eigen::Dynamic>;
+  using matrix_t
+      = Eigen::Matrix<value_type_t<EigMat>, Eigen::Dynamic, Eigen::Dynamic>;
   check_nonzero_size("qr_Q", "m", m);
   Eigen::HouseholderQR<matrix_t> qr(m.rows(), m.cols());
   qr.compute(m);

--- a/stan/math/prim/fun/qr_R.hpp
+++ b/stan/math/prim/fun/qr_R.hpp
@@ -18,7 +18,8 @@ namespace math {
 template <typename EigMat, require_eigen_t<EigMat>* = nullptr>
 Eigen::Matrix<value_type_t<EigMat>, Eigen::Dynamic, Eigen::Dynamic> qr_R(
     const EigMat& m) {
-  using matrix_t = Eigen::Matrix<value_type_t<EigMat>, Eigen::Dynamic, Eigen::Dynamic>;
+  using matrix_t
+      = Eigen::Matrix<value_type_t<EigMat>, Eigen::Dynamic, Eigen::Dynamic>;
   check_nonzero_size("qr_R", "m", m);
   Eigen::HouseholderQR<matrix_t> qr(m.rows(), m.cols());
   qr.compute(m);

--- a/stan/math/prim/fun/qr_R.hpp
+++ b/stan/math/prim/fun/qr_R.hpp
@@ -11,14 +11,14 @@ namespace math {
 /**
  * Returns the upper triangular factor of the fat QR decomposition
  *
- * @tparam T type of elements in the matrix
+ * @tparam EigMat type of the matrix
  * @param m Matrix.
  * @return Upper triangular matrix with maximal rows
  */
-template <typename T>
-Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> qr_R(
-    const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& m) {
-  using matrix_t = Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>;
+template <typename EigMat, require_eigen_t<EigMat>* = nullptr>
+Eigen::Matrix<value_type_t<EigMat>, Eigen::Dynamic, Eigen::Dynamic> qr_R(
+    const EigMat& m) {
+  using matrix_t = Eigen::Matrix<value_type_t<EigMat>, Eigen::Dynamic, Eigen::Dynamic>;
   check_nonzero_size("qr_R", "m", m);
   Eigen::HouseholderQR<matrix_t> qr(m.rows(), m.cols());
   qr.compute(m);

--- a/stan/math/prim/fun/qr_thin_Q.hpp
+++ b/stan/math/prim/fun/qr_thin_Q.hpp
@@ -18,7 +18,8 @@ namespace math {
 template <typename EigMat, require_eigen_t<EigMat>* = nullptr>
 Eigen::Matrix<value_type_t<EigMat>, Eigen::Dynamic, Eigen::Dynamic> qr_thin_Q(
     const EigMat& m) {
-  using matrix_t = Eigen::Matrix<value_type_t<EigMat>, Eigen::Dynamic, Eigen::Dynamic>;
+  using matrix_t
+      = Eigen::Matrix<value_type_t<EigMat>, Eigen::Dynamic, Eigen::Dynamic>;
   check_nonzero_size("qr_thin_Q", "m", m);
   Eigen::HouseholderQR<matrix_t> qr(m.rows(), m.cols());
   qr.compute(m);

--- a/stan/math/prim/fun/qr_thin_Q.hpp
+++ b/stan/math/prim/fun/qr_thin_Q.hpp
@@ -11,14 +11,14 @@ namespace math {
 /**
  * Returns the orthogonal factor of the thin QR decomposition
  *
- * @tparam T type of elements in the matrix
+ * @tparam EigMat type of the matrix
  * @param m Matrix.
  * @return Orthogonal matrix with minimal columns
  */
-template <typename T>
-Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> qr_thin_Q(
-    const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& m) {
-  using matrix_t = Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>;
+template <typename EigMat, require_eigen_t<EigMat>* = nullptr>
+Eigen::Matrix<value_type_t<EigMat>, Eigen::Dynamic, Eigen::Dynamic> qr_thin_Q(
+    const EigMat& m) {
+  using matrix_t = Eigen::Matrix<value_type_t<EigMat>, Eigen::Dynamic, Eigen::Dynamic>;
   check_nonzero_size("qr_thin_Q", "m", m);
   Eigen::HouseholderQR<matrix_t> qr(m.rows(), m.cols());
   qr.compute(m);

--- a/stan/math/prim/fun/qr_thin_R.hpp
+++ b/stan/math/prim/fun/qr_thin_R.hpp
@@ -18,7 +18,8 @@ namespace math {
 template <typename EigMat, require_eigen_t<EigMat>* = nullptr>
 Eigen::Matrix<value_type_t<EigMat>, Eigen::Dynamic, Eigen::Dynamic> qr_thin_R(
     const EigMat& m) {
-  using matrix_t = Eigen::Matrix<value_type_t<EigMat>, Eigen::Dynamic, Eigen::Dynamic>;
+  using matrix_t
+      = Eigen::Matrix<value_type_t<EigMat>, Eigen::Dynamic, Eigen::Dynamic>;
   check_nonzero_size("qr_thin_R", "m", m);
   Eigen::HouseholderQR<matrix_t> qr(m.rows(), m.cols());
   qr.compute(m);

--- a/stan/math/prim/fun/qr_thin_R.hpp
+++ b/stan/math/prim/fun/qr_thin_R.hpp
@@ -11,14 +11,14 @@ namespace math {
 /**
  * Returns the upper triangular factor of the thin QR decomposition
  *
- * @tparam T type of elements in the matrix
+ * @tparam EigMat type of the matrix
  * @param m Matrix.
  * @return Upper triangular matrix with minimal rows
  */
-template <typename T>
-Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> qr_thin_R(
-    const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& m) {
-  using matrix_t = Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>;
+template <typename EigMat, require_eigen_t<EigMat>* = nullptr>
+Eigen::Matrix<value_type_t<EigMat>, Eigen::Dynamic, Eigen::Dynamic> qr_thin_R(
+    const EigMat& m) {
+  using matrix_t = Eigen::Matrix<value_type_t<EigMat>, Eigen::Dynamic, Eigen::Dynamic>;
   check_nonzero_size("qr_thin_R", "m", m);
   Eigen::HouseholderQR<matrix_t> qr(m.rows(), m.cols());
   qr.compute(m);

--- a/stan/math/prim/fun/quad_form.hpp
+++ b/stan/math/prim/fun/quad_form.hpp
@@ -13,11 +13,8 @@ namespace math {
  * Symmetry of the resulting matrix is not guaranteed due to numerical
  * precision.
  *
- * @tparam RA number of rows in the square matrix, can be Eigen::Dynamic
- * @tparam CA number of columns in the square matrix, can be Eigen::Dynamic
- * @tparam RB number of rows in the second matrix, can be Eigen::Dynamic
- * @tparam CB number of columns in the second matrix, can be Eigen::Dynamic
- * @tparam T type of elements
+ * @tparam EigMat1 type of the first (square) matrix
+ * @tparam EigMat2 type of the second matrix
  *
  * @param A square matrix
  * @param B second matrix
@@ -25,9 +22,12 @@ namespace math {
  * @throws std::invalid_argument if A is not square, or if A cannot be
  * multiplied by B
  */
-template <int RA, int CA, int RB, int CB, typename T>
-inline Eigen::Matrix<T, CB, CB> quad_form(const Eigen::Matrix<T, RA, CA>& A,
-                                          const Eigen::Matrix<T, RB, CB>& B) {
+template <typename EigMat1, typename EigMat2,
+          require_all_eigen_t<EigMat1, EigMat2>* = nullptr,
+          require_not_eigen_col_vector_t<EigMat2>* = nullptr,
+          require_vt_same<EigMat1, EigMat2>* = nullptr,
+          require_all_vt_arithmetic<EigMat1, EigMat2>* = nullptr>
+inline plain_type_t<EigMat2> quad_form(const EigMat1& A, const EigMat2& B) {
   check_square("quad_form", "A", A);
   check_multiplicable("quad_form", "A", A, "B", B);
   return B.transpose() * A * B;
@@ -36,10 +36,8 @@ inline Eigen::Matrix<T, CB, CB> quad_form(const Eigen::Matrix<T, RA, CA>& A,
 /**
  * Return the quadratic form \f$ B^T A B \f$.
  *
- * @tparam RA number of rows in the square matrix, can be Eigen::Dynamic
- * @tparam CA number of columns in the square matrix, can be Eigen::Dynamic
- * @tparam RB number of rows in the vector, can be Eigen::Dynamic
- * @tparam T type of elements
+ * @tparam EigMat type of the matrix
+ * @tparam ColVec type of the vector
  *
  * @param A square matrix
  * @param B vector
@@ -47,9 +45,11 @@ inline Eigen::Matrix<T, CB, CB> quad_form(const Eigen::Matrix<T, RA, CA>& A,
  * @throws std::invalid_argument if A is not square, or if A cannot be
  * multiplied by B
  */
-template <int RA, int CA, int RB, typename T>
-inline T quad_form(const Eigen::Matrix<T, RA, CA>& A,
-                   const Eigen::Matrix<T, RB, 1>& B) {
+template <typename EigMat, typename ColVec, require_eigen_t<EigMat>* = nullptr,
+          require_eigen_col_vector_t<ColVec>* = nullptr,
+          require_vt_same<EigMat, ColVec>* = nullptr,
+          require_all_vt_arithmetic<EigMat, ColVec>* = nullptr>
+inline value_type_t<EigMat> quad_form(const EigMat& A, const ColVec& B) {
   check_square("quad_form", "A", A);
   check_multiplicable("quad_form", "A", A, "B", B);
   return B.dot(A * B);

--- a/stan/math/prim/fun/quad_form.hpp
+++ b/stan/math/prim/fun/quad_form.hpp
@@ -18,7 +18,7 @@ namespace math {
  *
  * @param A square matrix
  * @param B second matrix
- * @return The quadratic form, which is a symmetric matrix of size CB.
+ * @return The quadratic form, which is a symmetric matrix.
  * @throws std::invalid_argument if A is not square, or if A cannot be
  * multiplied by B
  */
@@ -27,7 +27,9 @@ template <typename EigMat1, typename EigMat2,
           require_not_eigen_col_vector_t<EigMat2>* = nullptr,
           require_vt_same<EigMat1, EigMat2>* = nullptr,
           require_all_vt_arithmetic<EigMat1, EigMat2>* = nullptr>
-inline plain_type_t<EigMat2> quad_form(const EigMat1& A, const EigMat2& B) {
+inline Eigen::Matrix<value_type_t<EigMat2>, EigMat2::ColsAtCompileTime,
+                     EigMat2::ColsAtCompileTime>
+quad_form(const EigMat1& A, const EigMat2& B) {
   check_square("quad_form", "A", A);
   check_multiplicable("quad_form", "A", A, "B", B);
   return B.transpose() * A * B;

--- a/stan/math/prim/fun/quad_form_diag.hpp
+++ b/stan/math/prim/fun/quad_form_diag.hpp
@@ -7,11 +7,11 @@
 namespace stan {
 namespace math {
 
-template <typename T1, typename T2, int R, int C>
-inline Eigen::Matrix<return_type_t<T1, T2>, Eigen::Dynamic, Eigen::Dynamic>
-quad_form_diag(const Eigen::Matrix<T1, Eigen::Dynamic, Eigen::Dynamic>& mat,
-               const Eigen::Matrix<T2, R, C>& vec) {
-  check_vector("quad_form_diag", "vec", vec);
+template <typename EigMat, typename EigVec, require_eigen_t<EigMat>* = nullptr,
+          require_eigen_vector_t<EigVec>* = nullptr>
+inline Eigen::Matrix<return_type_t<EigMat, EigVec>, Eigen::Dynamic,
+                     Eigen::Dynamic>
+quad_form_diag(const EigMat& mat, const EigVec& vec) {
   check_square("quad_form_diag", "mat", mat);
   check_size_match("quad_form_diag", "rows of mat", mat.rows(), "size of vec",
                    vec.size());

--- a/stan/math/prim/fun/quad_form_sym.hpp
+++ b/stan/math/prim/fun/quad_form_sym.hpp
@@ -17,7 +17,7 @@ namespace math {
  *
  * @param A symmetric matrix
  * @param B second matrix
- * @return The quadratic form, which is a symmetric matrix of size CB.
+ * @return The quadratic form, which is a symmetric matrix.
  * @throws std::invalid_argument if A is not symmetric, or if A cannot be
  * multiplied by B
  */

--- a/stan/math/prim/fun/quad_form_sym.hpp
+++ b/stan/math/prim/fun/quad_form_sym.hpp
@@ -12,11 +12,8 @@ namespace math {
  *
  * Symmetry of the resulting matrix is guaranteed.
  *
- * @tparam RA number of rows in the symmetric matrix, can be Eigen::Dynamic
- * @tparam CA number of columns in the symmetric matrix, can be Eigen::Dynamic
- * @tparam RB number of rows in the second matrix, can be Eigen::Dynamic
- * @tparam CB number of columns in the second matrix, can be Eigen::Dynamic
- * @tparam TA type of elements
+ * @tparam EigMat1 type of the first (symmetric) matrix
+ * @tparam EigMat2 type of the second matrix
  *
  * @param A symmetric matrix
  * @param B second matrix
@@ -24,22 +21,23 @@ namespace math {
  * @throws std::invalid_argument if A is not symmetric, or if A cannot be
  * multiplied by B
  */
-template <int RA, int CA, int RB, int CB, typename T>
-inline Eigen::Matrix<T, CB, CB> quad_form_sym(
-    const Eigen::Matrix<T, RA, CA>& A, const Eigen::Matrix<T, RB, CB>& B) {
+template <typename EigMat1, typename EigMat2,
+          require_all_eigen_t<EigMat1, EigMat2>* = nullptr,
+          require_not_eigen_col_vector_t<EigMat2>* = nullptr,
+          require_vt_same<EigMat1, EigMat2>* = nullptr,
+          require_all_vt_arithmetic<EigMat1, EigMat2>* = nullptr>
+inline plain_type_t<EigMat2> quad_form_sym(const EigMat1& A, const EigMat2& B) {
   check_multiplicable("quad_form_sym", "A", A, "B", B);
   check_symmetric("quad_form_sym", "A", A);
-  Eigen::Matrix<T, CB, CB> ret(B.transpose() * A * B);
-  return T(0.5) * (ret + ret.transpose());
+  plain_type_t<EigMat2> ret(B.transpose() * A * B);
+  return value_type_t<EigMat2>(0.5) * (ret + ret.transpose());
 }
 
 /**
  * Return the quadratic form \f$ B^T A B \f$ of a symmetric matrix.
  *
- * @tparam RA number of rows in the symmetric matrix, can be Eigen::Dynamic
- * @tparam CA number of columns in the symmetric matrix, can be Eigen::Dynamic
- * @tparam RB number of rows in the vector, can be Eigen::Dynamic
- * @tparam T type of elements
+ * @tparam EigMat type of the (symmetric) matrix
+ * @tparam ColVec type of the vector
  *
  * @param A symmetric matrix
  * @param B vector
@@ -47,9 +45,11 @@ inline Eigen::Matrix<T, CB, CB> quad_form_sym(
  * @throws std::invalid_argument if A is not symmetric, or if A cannot be
  * multiplied by B
  */
-template <int RA, int CA, int RB, typename T>
-inline T quad_form_sym(const Eigen::Matrix<T, RA, CA>& A,
-                       const Eigen::Matrix<T, RB, 1>& B) {
+template <typename EigMat, typename ColVec, require_eigen_t<EigMat>* = nullptr,
+          require_eigen_col_vector_t<ColVec>* = nullptr,
+          require_vt_same<EigMat, ColVec>* = nullptr,
+          require_all_vt_arithmetic<EigMat, ColVec>* = nullptr>
+inline value_type_t<EigMat> quad_form_sym(const EigMat& A, const ColVec& B) {
   check_multiplicable("quad_form_sym", "A", A, "B", B);
   check_symmetric("quad_form_sym", "A", A);
   return B.dot(A * B);

--- a/stan/math/prim/fun/rank.hpp
+++ b/stan/math/prim/fun/rank.hpp
@@ -16,17 +16,13 @@ namespace math {
  * @return number of components of v less than v[s].
  * @throw std::out_of_range if s is out of range.
  */
-template <typename C>
+template <typename C, require_container_t<C>* = nullptr>
 inline int rank(const C& v, int s) {
   check_range("rank", "v", v.size(), s);
   --s;  // adjust for indexing by one
-  int count = 0;
-  for (index_type_t<C> i = 0; i < v.size(); ++i) {
-    if (v[i] < v[s]) {
-      ++count;
-    }
-  }
-  return count;
+  return apply_vector_unary<C>::reduce(v, [s](const auto& vec){
+    return (vec.array()<vec.coeff(s)).template cast<int>().sum();
+  });
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/rank.hpp
+++ b/stan/math/prim/fun/rank.hpp
@@ -20,8 +20,8 @@ template <typename C, require_container_t<C>* = nullptr>
 inline int rank(const C& v, int s) {
   check_range("rank", "v", v.size(), s);
   --s;  // adjust for indexing by one
-  return apply_vector_unary<C>::reduce(v, [s](const auto& vec){
-    return (vec.array()<vec.coeff(s)).template cast<int>().sum();
+  return apply_vector_unary<C>::reduce(v, [s](const auto& vec) {
+    return (vec.array() < vec.coeff(s)).template cast<int>().sum();
   });
 }
 

--- a/stan/math/prim/fun/rep_array.hpp
+++ b/stan/math/prim/fun/rep_array.hpp
@@ -8,28 +8,32 @@
 namespace stan {
 namespace math {
 
-template <typename T>
-inline std::vector<T> rep_array(const T& x, int n) {
+template <typename In>
+inline std::vector<plain_type_t<In>> rep_array(const In& x, int n) {
+  using T = plain_type_t<In>;
   check_nonnegative("rep_array", "n", n);
   return std::vector<T>(n, x);
 }
 
-template <typename T>
-inline std::vector<std::vector<T> > rep_array(const T& x, int m, int n) {
+template <typename In>
+inline std::vector<std::vector<plain_type_t<In>>> rep_array(const In& x, int m,
+                                                            int n) {
   using std::vector;
+  using T = plain_type_t<In>;
   check_nonnegative("rep_array", "rows", m);
   check_nonnegative("rep_array", "cols", n);
-  return vector<vector<T> >(m, vector<T>(n, x));
+  return vector<vector<T>>(m, vector<T>(n, x));
 }
 
-template <typename T>
-inline std::vector<std::vector<std::vector<T> > > rep_array(const T& x, int k,
-                                                            int m, int n) {
+template <typename In>
+inline std::vector<std::vector<std::vector<plain_type_t<In>>>> rep_array(
+    const In& x, int k, int m, int n) {
   using std::vector;
+  using T = plain_type_t<In>;
   check_nonnegative("rep_array", "shelfs", k);
   check_nonnegative("rep_array", "rows", m);
   check_nonnegative("rep_array", "cols", n);
-  return vector<vector<vector<T> > >(k, vector<vector<T> >(m, vector<T>(n, x)));
+  return vector<vector<vector<T>>>(k, vector<vector<T>>(m, vector<T>(n, x)));
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/rep_matrix.hpp
+++ b/stan/math/prim/fun/rep_matrix.hpp
@@ -21,20 +21,14 @@ template <typename ColVec, require_eigen_col_vector_t<ColVec>* = nullptr>
 inline Eigen::Matrix<value_type_t<ColVec>, Eigen::Dynamic, Eigen::Dynamic>
 rep_matrix(const ColVec& v, int n) {
   check_nonnegative("rep_matrix", "rows", n);
-  Eigen::Matrix<value_type_t<ColVec>, Eigen::Dynamic, Eigen::Dynamic> result(
-      v.size(), n);
-  result.colwise() = v;
-  return result;
+  return v.replicate(1, n);
 }
 
 template <typename RowVec, require_eigen_row_vector_t<RowVec>* = nullptr>
 inline Eigen::Matrix<value_type_t<RowVec>, Eigen::Dynamic, Eigen::Dynamic>
 rep_matrix(const RowVec& rv, int m) {
   check_nonnegative("rep_matrix", "cols", m);
-  Eigen::Matrix<value_type_t<RowVec>, Eigen::Dynamic, Eigen::Dynamic> result(
-      m, rv.size());
-  result.rowwise() = rv;
-  return result;
+  return rv.replicate(m, 1);
 }
 }  // namespace math
 }  // namespace stan

--- a/stan/math/prim/fun/rep_matrix.hpp
+++ b/stan/math/prim/fun/rep_matrix.hpp
@@ -1,13 +1,14 @@
 #ifndef STAN_MATH_PRIM_FUN_REP_MATRIX_HPP
 #define STAN_MATH_PRIM_FUN_REP_MATRIX_HPP
 
+#include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/err.hpp>
 #include <stan/math/prim/fun/Eigen.hpp>
 
 namespace stan {
 namespace math {
 
-template <typename T>
+template <typename T, require_stan_scalar_t<T>* = nullptr>
 inline Eigen::Matrix<return_type_t<T>, Eigen::Dynamic, Eigen::Dynamic>
 rep_matrix(const T& x, int m, int n) {
   check_nonnegative("rep_matrix", "rows", m);
@@ -16,20 +17,22 @@ rep_matrix(const T& x, int m, int n) {
                        Eigen::Dynamic>::Constant(m, n, x);
 }
 
-template <typename T>
-inline Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> rep_matrix(
-    const Eigen::Matrix<T, Eigen::Dynamic, 1>& v, int n) {
+template <typename ColVec, require_eigen_col_vector_t<ColVec>* = nullptr>
+inline Eigen::Matrix<value_type_t<ColVec>, Eigen::Dynamic, Eigen::Dynamic>
+rep_matrix(const ColVec& v, int n) {
   check_nonnegative("rep_matrix", "rows", n);
-  Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> result(v.size(), n);
+  Eigen::Matrix<value_type_t<ColVec>, Eigen::Dynamic, Eigen::Dynamic> result(
+      v.size(), n);
   result.colwise() = v;
   return result;
 }
 
-template <typename T>
-inline Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> rep_matrix(
-    const Eigen::Matrix<T, 1, Eigen::Dynamic>& rv, int m) {
+template <typename RowVec, require_eigen_row_vector_t<RowVec>* = nullptr>
+inline Eigen::Matrix<value_type_t<RowVec>, Eigen::Dynamic, Eigen::Dynamic>
+rep_matrix(const RowVec& rv, int m) {
   check_nonnegative("rep_matrix", "cols", m);
-  Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> result(m, rv.size());
+  Eigen::Matrix<value_type_t<RowVec>, Eigen::Dynamic, Eigen::Dynamic> result(
+      m, rv.size());
   result.rowwise() = rv;
   return result;
 }

--- a/stan/math/rev/fun/quad_form.hpp
+++ b/stan/math/rev/fun/quad_form.hpp
@@ -106,7 +106,7 @@ class quad_form_vari : public vari {
  *
  * @param A square matrix
  * @param B second matrix
- * @return The quadratic form, which is a symmetric matrix of size Cb.
+ * @return The quadratic form, which is a symmetric matrix.
  * @throws std::invalid_argument if A is not square, or if A cannot be
  * multiplied by B
  */

--- a/stan/math/rev/fun/quad_form.hpp
+++ b/stan/math/rev/fun/quad_form.hpp
@@ -101,12 +101,8 @@ class quad_form_vari : public vari {
  * Symmetry of the resulting matrix is not guaranteed due to numerical
  * precision.
  *
- * @tparam Ta type of elements in the square matrix
- * @tparam Ra number of rows in the square matrix, can be Eigen::Dynamic
- * @tparam Ca number of columns in the square matrix, can be Eigen::Dynamic
- * @tparam Tb type of elements in the second matrix
- * @tparam Rb number of rows in the second matrix, can be Eigen::Dynamic
- * @tparam Cb number of columns in the second matrix, can be Eigen::Dynamic
+ * @tparam EigMat1 type of the first (square) matrix
+ * @tparam EigMat2 type of the second matrix
  *
  * @param A square matrix
  * @param B second matrix
@@ -114,15 +110,19 @@ class quad_form_vari : public vari {
  * @throws std::invalid_argument if A is not square, or if A cannot be
  * multiplied by B
  */
-template <typename Ta, int Ra, int Ca, typename Tb, int Rb, int Cb,
-          require_any_var_t<Ta, Tb>...>
-inline Eigen::Matrix<var, Cb, Cb> quad_form(
-    const Eigen::Matrix<Ta, Ra, Ca>& A, const Eigen::Matrix<Tb, Rb, Cb>& B) {
+template <typename EigMat1, typename EigMat2,
+          require_all_eigen_t<EigMat1, EigMat2>* = nullptr,
+          require_not_eigen_col_vector_t<EigMat2>* = nullptr,
+          require_any_vt_var<EigMat1, EigMat2>* = nullptr>
+inline promote_scalar_t<var, EigMat2> quad_form(const EigMat1& A,
+                                                const EigMat2& B) {
   check_square("quad_form", "A", A);
   check_multiplicable("quad_form", "A", A, "B", B);
 
-  internal::quad_form_vari<Ta, Ra, Ca, Tb, Rb, Cb>* baseVari
-      = new internal::quad_form_vari<Ta, Ra, Ca, Tb, Rb, Cb>(A, B);
+  auto* baseVari = new internal::quad_form_vari<
+      value_type_t<EigMat1>, EigMat1::RowsAtCompileTime,
+      EigMat1::ColsAtCompileTime, value_type_t<EigMat2>,
+      EigMat2::RowsAtCompileTime, EigMat2::ColsAtCompileTime>(A, B);
 
   return baseVari->impl_->C_;
 }
@@ -130,11 +130,8 @@ inline Eigen::Matrix<var, Cb, Cb> quad_form(
 /**
  * Return the quadratic form \f$ B^T A B \f$.
  *
- * @tparam Ta type of elements in the square matrix
- * @tparam Ra number of rows in the square matrix, can be Eigen::Dynamic
- * @tparam Ca number of columns in the square matrix, can be Eigen::Dynamic
- * @tparam Tb type of elements in the vector
- * @tparam Rb number of rows in the vector, can be Eigen::Dynamic
+ * @tparam EigMat type of the matrix
+ * @tparam ColVec type of the vector
  *
  * @param A square matrix
  * @param B vector
@@ -142,15 +139,17 @@ inline Eigen::Matrix<var, Cb, Cb> quad_form(
  * @throws std::invalid_argument if A is not square, or if A cannot be
  * multiplied by B
  */
-template <typename Ta, int Ra, int Ca, typename Tb, int Rb,
-          require_any_var_t<Ta, Tb>...>
-inline var quad_form(const Eigen::Matrix<Ta, Ra, Ca>& A,
-                     const Eigen::Matrix<Tb, Rb, 1>& B) {
+template <typename EigMat, typename ColVec, require_eigen_t<EigMat>* = nullptr,
+          require_eigen_col_vector_t<ColVec>* = nullptr,
+          require_any_vt_var<EigMat, ColVec>* = nullptr>
+inline var quad_form(const EigMat& A, const ColVec& B) {
   check_square("quad_form", "A", A);
   check_multiplicable("quad_form", "A", A, "B", B);
 
-  internal::quad_form_vari<Ta, Ra, Ca, Tb, Rb, 1>* baseVari
-      = new internal::quad_form_vari<Ta, Ra, Ca, Tb, Rb, 1>(A, B);
+  auto* baseVari = new internal::quad_form_vari<
+      value_type_t<EigMat>, EigMat::RowsAtCompileTime,
+      EigMat::ColsAtCompileTime, value_type_t<ColVec>,
+      ColVec::RowsAtCompileTime, 1>(A, B);
 
   return baseVari->impl_->C_(0, 0);
 }

--- a/stan/math/rev/fun/quad_form_sym.hpp
+++ b/stan/math/rev/fun/quad_form_sym.hpp
@@ -16,58 +16,23 @@ namespace math {
  *
  * Symmetry of the resulting matrix is guaranteed.
  *
- * @tparam Ta type of elements in the symmetric matrix
- * @tparam Ra number of rows in the symmetric matrix, can be Eigen::Dynamic
- * @tparam Ca number of columns in the symmetric matrix, can be Eigen::Dynamic
- * @tparam Tb type of elements in the second matrix
- * @tparam Rb number of rows in the second matrix, can be Eigen::Dynamic
- * @tparam Cb number of columns in the second matrix, can be Eigen::Dynamic
+ * @tparam EigMat1 type of the first (symmetric) matrix
+ * @tparam EigMat2 type of the second matrix
  *
  * @param A symmetric matrix
  * @param B second matrix
  * @return The quadratic form, which is a symmetric matrix of size Cb.
+ * If \c B is a column vector returns a scalar.
  * @throws std::invalid_argument if A is not symmetric, or if A cannot be
  * multiplied by B
  */
-template <typename Ta, int Ra, int Ca, typename Tb, int Rb, int Cb,
-          require_any_var_t<Ta, Tb>...>
-inline Eigen::Matrix<var, Cb, Cb> quad_form_sym(
-    const Eigen::Matrix<Ta, Ra, Ca>& A, const Eigen::Matrix<Tb, Rb, Cb>& B) {
+template <typename EigMat1, typename EigMat2,
+          require_all_eigen_t<EigMat1, EigMat2>* = nullptr,
+          require_any_vt_var<EigMat1, EigMat2>* = nullptr>
+inline auto quad_form_sym(const EigMat1& A, const EigMat2& B) {
   check_multiplicable("quad_form_sym", "A", A, "B", B);
   check_symmetric("quad_form_sym", "A", A);
-
-  internal::quad_form_vari<Ta, Ra, Ca, Tb, Rb, Cb>* baseVari
-      = new internal::quad_form_vari<Ta, Ra, Ca, Tb, Rb, Cb>(A, B, true);
-
-  return baseVari->impl_->C_;
-}
-
-/**
- * Return the quadratic form \f$ B^T A B \f$ of a symmetric matrix.
- *
- * @tparam Ta type of elements in the symmetric matrix
- * @tparam Ra number of rows in the symmetric matrix, can be Eigen::Dynamic
- * @tparam Ca number of columns in the symmetric matrix, can be Eigen::Dynamic
- * @tparam Tb type of elements in the vector
- * @tparam Rb number of rows in the vector, can be Eigen::Dynamic
- *
- * @param A symmetric matrix
- * @param B vector
- * @return The quadratic form (a scalar).
- * @throws std::invalid_argument if A is not symmetric, or if A cannot be
- * multiplied by B
- */
-template <typename Ta, int Ra, int Ca, typename Tb, int Rb,
-          require_any_var_t<Ta, Tb>...>
-inline var quad_form_sym(const Eigen::Matrix<Ta, Ra, Ca>& A,
-                         const Eigen::Matrix<Tb, Rb, 1>& B) {
-  check_multiplicable("quad_form_sym", "A", A, "B", B);
-  check_symmetric("quad_form_sym", "A", A);
-
-  internal::quad_form_vari<Ta, Ra, Ca, Tb, Rb, 1>* baseVari
-      = new internal::quad_form_vari<Ta, Ra, Ca, Tb, Rb, 1>(A, B, true);
-
-  return baseVari->impl_->C_(0, 0);
+  return quad_form(A, B);
 }
 
 }  // namespace math

--- a/test/unit/math/prim/fun/quad_form_diag_test.cpp
+++ b/test/unit/math/prim/fun/quad_form_diag_test.cpp
@@ -35,8 +35,6 @@ TEST(MathMatrixPrim, quadFormDiag2) {
 TEST(MathMatrixPrim, quadFormDiagException) {
   Eigen::MatrixXd m(2, 2);
   m << 2, 3, 4, 5;
-  EXPECT_THROW(quad_form_diag(m, m), std::invalid_argument);
-
   Eigen::VectorXd v(3);
   v << 1, 2, 3;
   EXPECT_THROW(quad_form_diag(m, v), std::invalid_argument);


### PR DESCRIPTION
## Summary

Generalizes functions with names starting with q and r.

## Tests
This is refactor, so no new tests. In `quad_form_diag` the second argument not being vector is now a compile time error so the test for this case was removed.

## Side Effects

None.

## Release notes

Generalized functions with names starting with q and r.

## Checklist

- [x] Math issue #1470 

- [x] Copyright holder: Tadej Ciglarič

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
