### PR TITLE
Fix doxygen errors on develop

### DIFF
--- a/stan/math/opencl/kernel_generator/optional_broadcast.hpp
+++ b/stan/math/opencl/kernel_generator/optional_broadcast.hpp
@@ -55,7 +55,8 @@ class optional_broadcast_
    * generates kernel code for this and nested expressions.
    * @param row_idx_name  row index variable name
    * @param col_idx_name  column index variable name
-   * @param var_name_arg name generator for this kernel
+   * @param var_name_arg name of the variable in kernel that holds argument to
+   * this expression
    * @return part of kernel with code for this and nested expressions
    */
   inline kernel_parts generate(const std::string& row_idx_name,

--- a/stan/math/opencl/kernel_generator/optional_broadcast.hpp
+++ b/stan/math/opencl/kernel_generator/optional_broadcast.hpp
@@ -53,10 +53,9 @@ class optional_broadcast_
 
   /**
    * generates kernel code for this and nested expressions.
-   * @param[in,out] generated set of already generated operations
-   * @param ng name generator for this kernel
    * @param row_idx_name  row index variable name
    * @param col_idx_name  column index variable name
+   * @param var_name_arg name generator for this kernel
    * @return part of kernel with code for this and nested expressions
    */
   inline kernel_parts generate(const std::string& row_idx_name,

--- a/stan/math/prim/fun/isnan.hpp
+++ b/stan/math/prim/fun/isnan.hpp
@@ -14,7 +14,7 @@ namespace math {
  * lookup.
  *
  * @tparam ADType type of argument
- * @param[in] v argument
+ * @param[in] x argument
  * @return true if argument is not-a-number
  */
 template <typename T, typename = require_autodiff_t<T>>


### PR DESCRIPTION
## Summary

After the freeze I merged 3 PRs one of which refactored a ton of doxygen. Somehow there are now 2 doxygen errors on develop. This PR is fixing those. 

## Tests

/
## Side Effects

/
## Release notes

## Checklist

- [x] Math issue No issue, fixing develop

- [x] Copyright holder: (fill in copyright holder information)

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses: Rok Češnovar
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
