### PR TITLE
Cleanup use of boost::

### DIFF
--- a/stan/math/prim/fun/LDLT_factor.hpp
+++ b/stan/math/prim/fun/LDLT_factor.hpp
@@ -6,7 +6,6 @@
 #include <stan/math/prim/fun/log.hpp>
 #include <stan/math/prim/fun/sum.hpp>
 #include <stan/math/prim/fun/is_nan.hpp>
-#include <boost/shared_ptr.hpp>
 
 namespace stan {
 namespace math {
@@ -17,7 +16,7 @@ namespace math {
  * log determinants and solutions to linear systems.
  *
  * Memory is allocated in the constructor and stored in a
- * <code>boost::shared_ptr</code>, which ensures that is freed
+ * <code>std::shared_ptr</code>, which ensures that is freed
  * when the object is released.
  *
  * After the constructor and/or compute() is called, users of
@@ -123,7 +122,7 @@ class LDLT_factor {
   inline size_t cols() const { return N_; }
 
   size_t N_;
-  boost::shared_ptr<ldlt_t> ldltP_;
+  std::shared_ptr<ldlt_t> ldltP_;
 };
 
 }  // namespace math

--- a/stan/math/prim/fun/LDLT_factor.hpp
+++ b/stan/math/prim/fun/LDLT_factor.hpp
@@ -6,6 +6,7 @@
 #include <stan/math/prim/fun/log.hpp>
 #include <stan/math/prim/fun/sum.hpp>
 #include <stan/math/prim/fun/is_nan.hpp>
+#include <memory>
 
 namespace stan {
 namespace math {

--- a/stan/math/prim/fun/boost_policy.hpp
+++ b/stan/math/prim/fun/boost_policy.hpp
@@ -3,7 +3,6 @@
 
 #include <stan/math/prim/meta.hpp>
 #include <boost/math/policies/policy.hpp>
-#include <boost/math/policies/error_handling.hpp>
 
 namespace stan {
 namespace math {

--- a/stan/math/rev/fun/mdivide_left_ldlt.hpp
+++ b/stan/math/rev/fun/mdivide_left_ldlt.hpp
@@ -8,6 +8,7 @@
 #include <stan/math/prim/err.hpp>
 #include <stan/math/prim/fun/Eigen.hpp>
 #include <stan/math/prim/fun/typedefs.hpp>
+#include <memory>
 
 namespace stan {
 namespace math {
@@ -23,7 +24,7 @@ class mdivide_left_ldlt_alloc : public chainable_alloc {
    * for mdivide_left_ldlt(ldltA, b) when ldltA is a LDLT_factor<double>.
    * The pointer is shared with the LDLT_factor<double> class.
    **/
-  boost::shared_ptr<Eigen::LDLT<Eigen::Matrix<double, R1, C1> > > ldltP_;
+  std::shared_ptr<Eigen::LDLT<Eigen::Matrix<double, R1, C1> > > ldltP_;
   Eigen::Matrix<double, R2, C2> C_;
 };
 


### PR DESCRIPTION
## Summary
Fixes #1850 

This is part of a wider cleanup to address https://github.com/stan-dev/cmdstan/issues/863

## Tests

/

## Side Effects

/

## Release notes

Cleaned up the use of Boost headers.

## Checklist

- [x] Math issue #(issue number)

- [x] Copyright holder: Rok Češnovar

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
