### PR TITLE
Add missing implementations for add/subtract for scalars

### DIFF
--- a/stan/math/prim/fun/add.hpp
+++ b/stan/math/prim/fun/add.hpp
@@ -11,11 +11,11 @@ namespace math {
 /**
  * Return the sum of the specified scalars.
  *
- * @tparam ScalarA Type of the first scalar.
- * @tparam ScalarB Type of the second scalar.
- * @param a First scalar.
- * @param b Second scalar.
- * @return The sum of the scalars.
+ * @tparam ScalarA type of the first scalar
+ * @tparam ScalarB type of the second scalar
+ * @param a first scalar
+ * @param b second scalar
+ * @return the sum of the scalars
  */
 template <typename ScalarA, typename ScalarB,
           typename = require_all_stan_scalar_t<ScalarA, ScalarB>>

--- a/stan/math/prim/fun/add.hpp
+++ b/stan/math/prim/fun/add.hpp
@@ -19,7 +19,7 @@ namespace math {
  */
 template <typename ScalarA, typename ScalarB,
           typename = require_all_stan_scalar_t<ScalarA, ScalarB>>
-inline return_type_t<ScalarA, ScalarB> add(const ScalarA a, const ScalarB b) {
+inline return_type_t<ScalarA, ScalarB> add(const ScalarA& a, const ScalarB& b) {
   return a + b;
 }
 

--- a/stan/math/prim/fun/add.hpp
+++ b/stan/math/prim/fun/add.hpp
@@ -9,6 +9,21 @@ namespace stan {
 namespace math {
 
 /**
+ * Return the sum of the specified scalars.
+ *
+ * @tparam ScalarA Type of the first scalar.
+ * @tparam ScalarB Type of the second scalar.
+ * @param a First scalar.
+ * @param b Second scalar.
+ * @return The sum of the scalars.
+ */
+template <typename ScalarA, typename ScalarB,
+          typename = require_all_stan_scalar_t<ScalarA, ScalarB>>
+inline return_type_t<ScalarA, ScalarB> add(const ScalarA a, const ScalarB b) {
+  return a + b;
+}
+
+/**
  * Return the sum of the specified matrices.  The two matrices
  * must have the same dimensions.
  *

--- a/stan/math/prim/fun/subtract.hpp
+++ b/stan/math/prim/fun/subtract.hpp
@@ -20,7 +20,8 @@ namespace math {
  */
 template <typename ScalarA, typename ScalarB,
           typename = require_all_stan_scalar_t<ScalarA, ScalarB>>
-inline return_type_t<ScalarA, ScalarB> subtract(const ScalarA a, const ScalarB b) {
+inline return_type_t<ScalarA, ScalarB> subtract(const ScalarA a,
+                                                const ScalarB b) {
   return a - b;
 }
 

--- a/stan/math/prim/fun/subtract.hpp
+++ b/stan/math/prim/fun/subtract.hpp
@@ -12,11 +12,11 @@ namespace math {
  * Return the result of subtracting the second scalar from the first
  * scalar.
  *
- * @tparam ScalarA Type of the first scalar.
- * @tparam ScalarB Type of the second scalar.
- * @param a First scalar.
- * @param b Second scalar.
- * @return Difference between first scalar and second scalar.
+ * @tparam ScalarA type of the first scalar
+ * @tparam ScalarB type of the second scalar
+ * @param a first scalar
+ * @param b second scalar
+ * @return difference between first scalar and second scalar
  */
 template <typename ScalarA, typename ScalarB,
           typename = require_all_stan_scalar_t<ScalarA, ScalarB>>

--- a/stan/math/prim/fun/subtract.hpp
+++ b/stan/math/prim/fun/subtract.hpp
@@ -20,8 +20,8 @@ namespace math {
  */
 template <typename ScalarA, typename ScalarB,
           typename = require_all_stan_scalar_t<ScalarA, ScalarB>>
-inline return_type_t<ScalarA, ScalarB> subtract(const ScalarA a,
-                                                const ScalarB b) {
+inline return_type_t<ScalarA, ScalarB> subtract(const ScalarA& a,
+                                                const ScalarB& b) {
   return a - b;
 }
 

--- a/stan/math/prim/fun/subtract.hpp
+++ b/stan/math/prim/fun/subtract.hpp
@@ -9,6 +9,22 @@ namespace stan {
 namespace math {
 
 /**
+ * Return the result of subtracting the second scalar from the first
+ * scalar.
+ *
+ * @tparam ScalarA Type of the first scalar.
+ * @tparam ScalarB Type of the second scalar.
+ * @param a First scalar.
+ * @param b Second scalar.
+ * @return Difference between first scalar and second scalar.
+ */
+template <typename ScalarA, typename ScalarB,
+          typename = require_all_stan_scalar_t<ScalarA, ScalarB>>
+inline return_type_t<ScalarA, ScalarB> subtract(const ScalarA a, const ScalarB b) {
+  return a - b;
+}
+
+/**
  * Return the result of subtracting the second specified matrix
  * from the first specified matrix.
  *

--- a/test/unit/math/mix/fun/add_test.cpp
+++ b/test/unit/math/mix/fun/add_test.cpp
@@ -109,9 +109,10 @@ TEST(MathMixMatFun, add_mat_mat) {
 TEST(MathMixMatFun, add_scal) {
   auto f = [](const auto& x, const auto& y) { return stan::math::add(x, y); };
 
-  double a = 2;
-  double b = 5;
-  stan::test::expect_ad(f, a, b);
+  expect_ad(f, 2, 5);
+  expect_ad(f, 2.0, 5);
+  expect_ad(f, 2, 5.0);
+  expect_ad(f, 2.0, 5.0);
 }
 
 // these will throw

--- a/test/unit/math/mix/fun/add_test.cpp
+++ b/test/unit/math/mix/fun/add_test.cpp
@@ -109,10 +109,10 @@ TEST(MathMixMatFun, add_mat_mat) {
 TEST(MathMixMatFun, add_scal) {
   auto f = [](const auto& x, const auto& y) { return stan::math::add(x, y); };
 
-  expect_ad(f, 2, 5);
-  expect_ad(f, 2.0, 5);
-  expect_ad(f, 2, 5.0);
-  expect_ad(f, 2.0, 5.0);
+  stan::test::expect_ad(f, 2, 5);
+  stan::test::expect_ad(f, 2.0, 5);
+  stan::test::expect_ad(f, 2, 5.0);
+  stan::test::expect_ad(f, 2.0, 5.0);
 }
 
 // these will throw

--- a/test/unit/math/mix/fun/add_test.cpp
+++ b/test/unit/math/mix/fun/add_test.cpp
@@ -106,6 +106,14 @@ TEST(MathMixMatFun, add_mat_mat) {
   stan::test::expect_ad(f, m23, m23b);
 }
 
+TEST(MathMixMatFun, add_scal) {
+  auto f = [](const auto& x, const auto& y) { return stan::math::add(x, y); };
+
+  double a = 2;
+  double b = 5;
+  stan::test::expect_ad(f, a, b);
+}
+
 // these will throw
 TEST(MathMixMatFun, add_throw) {
   auto f = [](const auto& x, const auto& y) { return stan::math::add(x, y); };

--- a/test/unit/math/mix/fun/subtract_test.cpp
+++ b/test/unit/math/mix/fun/subtract_test.cpp
@@ -32,9 +32,10 @@ TEST(MathMixMatFun, subtract_scal) {
   auto f
       = [](const auto& x, const auto& y) { return stan::math::subtract(x, y); };
 
-  double a = 2;
-  double b = 5;
-  stan::test::expect_ad(f, a, b);
+  expect_ad(f, 2, 5);
+  expect_ad(f, 2.0, 5);
+  expect_ad(f, 2, 5.0);
+  expect_ad(f, 2.0, 5.0);
 }
 
 TEST(MathMixMatFun, subtract_empty) {

--- a/test/unit/math/mix/fun/subtract_test.cpp
+++ b/test/unit/math/mix/fun/subtract_test.cpp
@@ -28,6 +28,14 @@ TEST(MathMixMatFun, subtract_1) {
   stan::test::expect_ad(f, m11, m11b);
 }
 
+TEST(MathMixMatFun, subtract_scal) {
+  auto f = [](const auto& x, const auto& y) { return stan::math::subtract(x, y); };
+
+  double a = 2;
+  double b = 5;
+  stan::test::expect_ad(f, a, b);
+}
+
 TEST(MathMixMatFun, subtract_empty) {
   auto f
       = [](const auto& x, const auto& y) { return stan::math::subtract(x, y); };

--- a/test/unit/math/mix/fun/subtract_test.cpp
+++ b/test/unit/math/mix/fun/subtract_test.cpp
@@ -29,7 +29,8 @@ TEST(MathMixMatFun, subtract_1) {
 }
 
 TEST(MathMixMatFun, subtract_scal) {
-  auto f = [](const auto& x, const auto& y) { return stan::math::subtract(x, y); };
+  auto f
+      = [](const auto& x, const auto& y) { return stan::math::subtract(x, y); };
 
   double a = 2;
   double b = 5;

--- a/test/unit/math/mix/fun/subtract_test.cpp
+++ b/test/unit/math/mix/fun/subtract_test.cpp
@@ -32,10 +32,10 @@ TEST(MathMixMatFun, subtract_scal) {
   auto f
       = [](const auto& x, const auto& y) { return stan::math::subtract(x, y); };
 
-  expect_ad(f, 2, 5);
-  expect_ad(f, 2.0, 5);
-  expect_ad(f, 2, 5.0);
-  expect_ad(f, 2.0, 5.0);
+  stan::test::expect_ad(f, 2, 5);
+  stan::test::expect_ad(f, 2.0, 5);
+  stan::test::expect_ad(f, 2, 5.0);
+  stan::test::expect_ad(f, 2.0, 5.0);
 }
 
 TEST(MathMixMatFun, subtract_empty) {

--- a/test/unit/math/prim/fun/add_test.cpp
+++ b/test/unit/math/prim/fun/add_test.cpp
@@ -2,9 +2,9 @@
 #include <gtest/gtest.h>
 
 TEST(MathMatrixPrimMat, add_scalar) {
-  EXPECT_EQ(1.5, stan::math::add(1, 0.5));
-  EXPECT_EQ(1.5, stan::math::add(0.5, 1));
-  EXPECT_EQ(2.7, stan::math::add(1.2, 1.5));
+  EXPECT_FLOAT_EQ(1.5, stan::math::add(1, 0.5));
+  EXPECT_FLOAT_EQ(1.5, stan::math::add(0.5, 1));
+  EXPECT_FLOAT_EQ(2.7, stan::math::add(1.2, 1.5));
   EXPECT_EQ(4, stan::math::add(1, 3));
 }
 TEST(MathMatrixPrimMat, add_v_exception) {

--- a/test/unit/math/prim/fun/add_test.cpp
+++ b/test/unit/math/prim/fun/add_test.cpp
@@ -1,6 +1,12 @@
 #include <stan/math/prim.hpp>
 #include <gtest/gtest.h>
 
+TEST(MathMatrixPrimMat, add_scalar) {
+  EXPECT_EQ(1.5, stan::math::add(1,0.5));
+  EXPECT_EQ(1.5, stan::math::add(0.5,1));
+  EXPECT_EQ(2.7, stan::math::add(1.2,1.5));
+  EXPECT_EQ(4, stan::math::add(1,3));
+}
 TEST(MathMatrixPrimMat, add_v_exception) {
   stan::math::vector_d d1, d2;
 

--- a/test/unit/math/prim/fun/add_test.cpp
+++ b/test/unit/math/prim/fun/add_test.cpp
@@ -2,10 +2,10 @@
 #include <gtest/gtest.h>
 
 TEST(MathMatrixPrimMat, add_scalar) {
-  EXPECT_EQ(1.5, stan::math::add(1,0.5));
-  EXPECT_EQ(1.5, stan::math::add(0.5,1));
-  EXPECT_EQ(2.7, stan::math::add(1.2,1.5));
-  EXPECT_EQ(4, stan::math::add(1,3));
+  EXPECT_EQ(1.5, stan::math::add(1, 0.5));
+  EXPECT_EQ(1.5, stan::math::add(0.5, 1));
+  EXPECT_EQ(2.7, stan::math::add(1.2, 1.5));
+  EXPECT_EQ(4, stan::math::add(1, 3));
 }
 TEST(MathMatrixPrimMat, add_v_exception) {
   stan::math::vector_d d1, d2;

--- a/test/unit/math/prim/fun/subtract_test.cpp
+++ b/test/unit/math/prim/fun/subtract_test.cpp
@@ -2,10 +2,10 @@
 #include <gtest/gtest.h>
 
 TEST(MathMatrixPrimMat, subtract_scalar) {
-  EXPECT_EQ(0.5, stan::math::subtract(1,0.5));
-  EXPECT_EQ(-0.5, stan::math::subtract(0.5,1));
-  EXPECT_EQ(-0.3, stan::math::subtract(1.2,1.5));
-  EXPECT_EQ(-2, stan::math::subtract(1,3));
+  EXPECT_EQ(0.5, stan::math::subtract(1, 0.5));
+  EXPECT_EQ(-0.5, stan::math::subtract(0.5, 1));
+  EXPECT_EQ(-0.3, stan::math::subtract(1.2, 1.5));
+  EXPECT_EQ(-2, stan::math::subtract(1, 3));
 }
 TEST(MathMatrixPrimMat, subtract_v_exception) {
   stan::math::vector_d d1, d2;

--- a/test/unit/math/prim/fun/subtract_test.cpp
+++ b/test/unit/math/prim/fun/subtract_test.cpp
@@ -2,9 +2,9 @@
 #include <gtest/gtest.h>
 
 TEST(MathMatrixPrimMat, subtract_scalar) {
-  EXPECT_EQ(0.5, stan::math::subtract(1, 0.5));
-  EXPECT_EQ(-0.5, stan::math::subtract(0.5, 1));
-  EXPECT_EQ(-0.3, stan::math::subtract(1.2, 1.5));
+  EXPECT_FLOAT_EQ(0.5, stan::math::subtract(1, 0.5));
+  EXPECT_FLOAT_EQ(-0.5, stan::math::subtract(0.5, 1));
+  EXPECT_FLOAT_EQ(-0.3, stan::math::subtract(1.2, 1.5));
   EXPECT_EQ(-2, stan::math::subtract(1, 3));
 }
 TEST(MathMatrixPrimMat, subtract_v_exception) {

--- a/test/unit/math/prim/fun/subtract_test.cpp
+++ b/test/unit/math/prim/fun/subtract_test.cpp
@@ -1,6 +1,12 @@
 #include <stan/math/prim.hpp>
 #include <gtest/gtest.h>
 
+TEST(MathMatrixPrimMat, subtract_scalar) {
+  EXPECT_EQ(0.5, stan::math::subtract(1,0.5));
+  EXPECT_EQ(-0.5, stan::math::subtract(0.5,1));
+  EXPECT_EQ(-0.3, stan::math::subtract(1.2,1.5));
+  EXPECT_EQ(-2, stan::math::subtract(1,3));
+}
 TEST(MathMatrixPrimMat, subtract_v_exception) {
   stan::math::vector_d d1, d2;
 


### PR DESCRIPTION
## Summary

Adds missing support for

int add(int,int) and real add(real,real). These are obviously supported by operators, but not with a named function.

## Tests

Added prim and mix tests.

## Side Effects

/

## Release notes

Added support for `int add(int,int)` and `real add(real,real)`.

## Checklist

- [x] Math issue #1857 

- [x] Copyright holder: Rok Češnovar

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses: 
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
