### PR TITLE
Add fp classification functions to kernel generator

### DIFF
--- a/runChecks.py
+++ b/runChecks.py
@@ -41,12 +41,13 @@ def check_non_unique_test_names():
                 # look for TEST() and TEST_F()
                 matches = re.findall(r"TEST(?:_F)?\((.*?)\)", test_file_content, re.DOTALL)
                 for x in matches:
-                    # strips for test names written in two lines
-                    x_stripped = x.replace("\n", "").replace(" ", "").replace(",",", ")
-                    if x_stripped in tests:                        
-                        duplicates[x_stripped].append(filepath)
-                    else:
-                        tests[x_stripped] = filepath
+                    if not ("#" in x):
+                        # strips for test names written in two lines
+                        x_stripped = x.replace("\n", "").replace(" ", "").replace(",",", ")
+                        if x_stripped in tests:                        
+                            duplicates[x_stripped].append(filepath)
+                        else:
+                            tests[x_stripped] = filepath
     errors = []
     if len(duplicates)>0:
         duplicates_error_msg = ""

--- a/test/unit/math/opencl/kernel_generator/unary_function_cl_test.cpp
+++ b/test/unit/math/opencl/kernel_generator/unary_function_cl_test.cpp
@@ -113,18 +113,18 @@ TEST(KernelGenerator, log1m_exp_test) {
   EXPECT_MATRIX_NEAR(correct, res, 1e-9);
 }
 
-#define TEST_CLASSIFICATION_FUNCTION(fun)                                 \
-  TEST(KernelGenerator, fun##_test) {                                     \
-    using stan::math::fun;                                                \
+#define TEST_CLASSIFICATION_FUNCTION(func)                                 \
+  TEST(KernelGenerator, func##_test) {                                     \
+    using stan::math::func;                                                \
     MatrixXd m1(3, 3);                                                    \
     m1 << 0.0, 0.2, 0.3, 0.4, 0.5, 0.6, -INFINITY, INFINITY, NAN;         \
                                                                           \
     matrix_cl<double> m1_cl(m1);                                          \
-    auto tmp = fun(m1_cl);                                                \
+    auto tmp = func(m1_cl);                                                \
     matrix_cl<bool> res_cl = tmp;                                         \
                                                                           \
     Eigen::Matrix<bool, -1, -1> res = stan::math::from_matrix_cl(res_cl); \
-    Eigen::Matrix<bool, -1, -1> correct = fun(m1.array());                \
+    Eigen::Matrix<bool, -1, -1> correct = func(m1.array());                \
     EXPECT_MATRIX_NEAR(correct, res, 1e-9);                               \
   }
 

--- a/test/unit/math/opencl/kernel_generator/unary_function_cl_test.cpp
+++ b/test/unit/math/opencl/kernel_generator/unary_function_cl_test.cpp
@@ -113,18 +113,18 @@ TEST(KernelGenerator, log1m_exp_test) {
   EXPECT_MATRIX_NEAR(correct, res, 1e-9);
 }
 
-#define TEST_CLASSIFICATION_FUNCTION(func)                                \
-  TEST(KernelGenerator, func##_test) {                                    \
-    using stan::math::func;                                               \
+#define TEST_CLASSIFICATION_FUNCTION(fun)                                \
+  TEST(KernelGenerator, fun##_test) {                                    \
+    using stan::math::fun;                                               \
     MatrixXd m1(3, 3);                                                    \
     m1 << 0.0, 0.2, 0.3, 0.4, 0.5, 0.6, -INFINITY, INFINITY, NAN;         \
                                                                           \
     matrix_cl<double> m1_cl(m1);                                          \
-    auto tmp = func(m1_cl);                                               \
+    auto tmp = fun(m1_cl);                                               \
     matrix_cl<bool> res_cl = tmp;                                         \
                                                                           \
     Eigen::Matrix<bool, -1, -1> res = stan::math::from_matrix_cl(res_cl); \
-    Eigen::Matrix<bool, -1, -1> correct = func(m1.array());               \
+    Eigen::Matrix<bool, -1, -1> correct = fun(m1.array());               \
     EXPECT_MATRIX_NEAR(correct, res, 1e-9);                               \
   }
 

--- a/test/unit/math/opencl/kernel_generator/unary_function_cl_test.cpp
+++ b/test/unit/math/opencl/kernel_generator/unary_function_cl_test.cpp
@@ -113,18 +113,18 @@ TEST(KernelGenerator, log1m_exp_test) {
   EXPECT_MATRIX_NEAR(correct, res, 1e-9);
 }
 
-#define TEST_CLASSIFICATION_FUNCTION(func)                                 \
-  TEST(KernelGenerator, func##_test) {                                     \
-    using stan::math::func;                                                \
+#define TEST_CLASSIFICATION_FUNCTION(func)                                \
+  TEST(KernelGenerator, func##_test) {                                    \
+    using stan::math::func;                                               \
     MatrixXd m1(3, 3);                                                    \
     m1 << 0.0, 0.2, 0.3, 0.4, 0.5, 0.6, -INFINITY, INFINITY, NAN;         \
                                                                           \
     matrix_cl<double> m1_cl(m1);                                          \
-    auto tmp = func(m1_cl);                                                \
+    auto tmp = func(m1_cl);                                               \
     matrix_cl<bool> res_cl = tmp;                                         \
                                                                           \
     Eigen::Matrix<bool, -1, -1> res = stan::math::from_matrix_cl(res_cl); \
-    Eigen::Matrix<bool, -1, -1> correct = func(m1.array());                \
+    Eigen::Matrix<bool, -1, -1> correct = func(m1.array());               \
     EXPECT_MATRIX_NEAR(correct, res, 1e-9);                               \
   }
 

--- a/test/unit/math/opencl/kernel_generator/unary_function_cl_test.cpp
+++ b/test/unit/math/opencl/kernel_generator/unary_function_cl_test.cpp
@@ -100,7 +100,7 @@ TEST_FUNCTION(ceil)
 
 TEST_FUNCTION(digamma)
 TEST_FUNCTION(log1p_exp)
-TEST(KernelGenerator, log1m_exp) {
+TEST(KernelGenerator, log1m_exp_test) {
   MatrixXd m1(3, 3);
   m1 << -0.1, -0.2, -0.3, -0.4, -0.5, -0.6, -0.7, -0.8, -0.9;
 
@@ -112,6 +112,25 @@ TEST(KernelGenerator, log1m_exp) {
   MatrixXd correct = stan::math::log1m_exp(m1);
   EXPECT_MATRIX_NEAR(correct, res, 1e-9);
 }
+
+#define TEST_CLASSIFICATION_FUNCTION(fun)                                 \
+  TEST(KernelGenerator, fun##_test) {                                     \
+    using stan::math::fun;                                                \
+    MatrixXd m1(3, 3);                                                    \
+    m1 << 0.0, 0.2, 0.3, 0.4, 0.5, 0.6, -INFINITY, INFINITY, NAN;         \
+                                                                          \
+    matrix_cl<double> m1_cl(m1);                                          \
+    auto tmp = fun(m1_cl);                                                \
+    matrix_cl<bool> res_cl = tmp;                                         \
+                                                                          \
+    Eigen::Matrix<bool, -1, -1> res = stan::math::from_matrix_cl(res_cl); \
+    Eigen::Matrix<bool, -1, -1> correct = fun(m1.array());                \
+    EXPECT_MATRIX_NEAR(correct, res, 1e-9);                               \
+  }
+
+TEST_CLASSIFICATION_FUNCTION(isfinite)
+TEST_CLASSIFICATION_FUNCTION(isinf)
+TEST_CLASSIFICATION_FUNCTION(isnan)
 
 TEST(KernelGenerator, multiple_operations_test) {
   MatrixXd m1(3, 3);

--- a/test/unit/math/opencl/kernel_generator/unary_function_cl_test.cpp
+++ b/test/unit/math/opencl/kernel_generator/unary_function_cl_test.cpp
@@ -113,18 +113,18 @@ TEST(KernelGenerator, log1m_exp_test) {
   EXPECT_MATRIX_NEAR(correct, res, 1e-9);
 }
 
-#define TEST_CLASSIFICATION_FUNCTION(fun)                                \
-  TEST(KernelGenerator, fun##_test) {                                    \
-    using stan::math::fun;                                               \
+#define TEST_CLASSIFICATION_FUNCTION(fun)                                 \
+  TEST(KernelGenerator, fun##_test) {                                     \
+    using stan::math::fun;                                                \
     MatrixXd m1(3, 3);                                                    \
     m1 << 0.0, 0.2, 0.3, 0.4, 0.5, 0.6, -INFINITY, INFINITY, NAN;         \
                                                                           \
     matrix_cl<double> m1_cl(m1);                                          \
-    auto tmp = fun(m1_cl);                                               \
+    auto tmp = fun(m1_cl);                                                \
     matrix_cl<bool> res_cl = tmp;                                         \
                                                                           \
     Eigen::Matrix<bool, -1, -1> res = stan::math::from_matrix_cl(res_cl); \
-    Eigen::Matrix<bool, -1, -1> correct = fun(m1.array());               \
+    Eigen::Matrix<bool, -1, -1> correct = fun(m1.array());                \
     EXPECT_MATRIX_NEAR(correct, res, 1e-9);                               \
   }
 


### PR DESCRIPTION
## Summary

Adds floating point classification functions (`isfinite`, `isnan`, `isinf`) to kernel generator by extending unary function macros.

## Tests

New functions are tested.

## Side Effects

None.

## Release notes
Added floating point classification functions (`isfinite`, `isnan`, `isinf`) to kernel generator.

## Checklist

- [x] Math issue #1342 

- [x] Copyright holder: Tadej Ciglarič

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
