### PR TITLE
Adds diagonal to kernel generator

### DIFF
--- a/stan/math/opencl/kernel_generator.hpp
+++ b/stan/math/opencl/kernel_generator.hpp
@@ -125,6 +125,7 @@
 #include <stan/math/opencl/kernel_generator/transpose.hpp>
 #include <stan/math/opencl/kernel_generator/broadcast.hpp>
 #include <stan/math/opencl/kernel_generator/optional_broadcast.hpp>
+#include <stan/math/opencl/kernel_generator/diagonal.hpp>
 
 #include <stan/math/opencl/kernel_generator/multi_result_kernel.hpp>
 #include <stan/math/opencl/kernel_generator/get_kernel_source_for_evaluating_into.hpp>

--- a/stan/math/opencl/kernel_generator/block.hpp
+++ b/stan/math/opencl/kernel_generator/block.hpp
@@ -37,6 +37,7 @@ class block_
   using base = operation_cl_lhs<block_<T>, Scalar, T>;
   using base::var_name;
   using view_transitivity = std::tuple<std::true_type>;
+  using base::operator=;
 
  protected:
   int start_row_, start_col_, rows_, cols_;
@@ -179,23 +180,6 @@ class block_
         = this->template get_arg<0>().extreme_diagonals();
     return {arg_diags.first - start_col_ + start_row_,
             arg_diags.second - start_col_ + start_row_};
-  }
-
-  /**
-   * Evaluates an expression and assigns it to the block.
-   * @tparam T_expression type of expression
-   * @param rhs input expression
-   */
-  template <typename T_expression,
-            typename
-            = require_all_valid_expressions_and_none_scalar_t<T_expression>>
-  const block_<T>& operator=(T_expression&& rhs) const {
-    auto expression = as_operation_cl(std::forward<T_expression>(rhs));
-    if (rows_ * cols_ == 0) {
-      return *this;
-    }
-    expression.evaluate_into(*this);
-    return *this;
   }
 
   /**

--- a/stan/math/opencl/kernel_generator/diagonal.hpp
+++ b/stan/math/opencl/kernel_generator/diagonal.hpp
@@ -9,6 +9,7 @@
 #include <stan/math/opencl/kernel_generator/operation_cl_lhs.hpp>
 #include <stan/math/opencl/kernel_generator/as_operation_cl.hpp>
 #include <stan/math/opencl/kernel_generator/is_valid_expression.hpp>
+#include <algorithm>
 #include <set>
 #include <string>
 #include <tuple>
@@ -42,7 +43,7 @@ class diagonal_
    * Constructor
    * @param a expression
    */
-  diagonal_(T&& a) : base(std::forward<T>(a)) {}
+  explicit diagonal_(T&& a) : base(std::forward<T>(a)) {}
 
   /**
    * Creates a deep copy of this expression.

--- a/stan/math/opencl/kernel_generator/diagonal.hpp
+++ b/stan/math/opencl/kernel_generator/diagonal.hpp
@@ -1,0 +1,179 @@
+#ifndef STAN_MATH_OPENCL_KERNEL_GENERATOR_DIAGONAL_HPP
+#define STAN_MATH_OPENCL_KERNEL_GENERATOR_DIAGONAL_HPP
+#ifdef STAN_OPENCL
+
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/opencl/matrix_cl_view.hpp>
+#include <stan/math/opencl/kernel_generator/type_str.hpp>
+#include <stan/math/opencl/kernel_generator/name_generator.hpp>
+#include <stan/math/opencl/kernel_generator/operation_cl_lhs.hpp>
+#include <stan/math/opencl/kernel_generator/as_operation_cl.hpp>
+#include <stan/math/opencl/kernel_generator/is_valid_expression.hpp>
+#include <set>
+#include <string>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+
+namespace stan {
+namespace math {
+
+/** \addtogroup opencl_kernel_generator
+ *  @{
+ */
+
+/**
+ * Represents diagonal of a matrix (as column vector) in kernel generator
+ * expressions.
+ * @tparam Derived derived type
+ * @tparam T type of argument
+ */
+template <typename T>
+class diagonal_
+    : public operation_cl_lhs<diagonal_<T>,
+                              typename std::remove_reference_t<T>::Scalar, T> {
+ public:
+  using Scalar = typename std::remove_reference_t<T>::Scalar;
+  using base = operation_cl_lhs<diagonal_<T>, Scalar, T>;
+  using base::var_name;
+  using base::operator=;
+
+  /**
+   * Constructor
+   * @param a expression
+   */
+  diagonal_(T&& a) : base(std::forward<T>(a)) {}
+
+  /**
+   * Creates a deep copy of this expression.
+   * @return copy of \c *this
+   */
+  inline auto deep_copy() const {
+    auto&& arg_copy = this->template get_arg<0>().deep_copy();
+    return diagonal_<std::remove_reference_t<decltype(arg_copy)>>{
+        std::move(arg_copy)};
+  }
+
+  /**
+   * Generates kernel code for this and nested expressions.
+   * @param[in,out] generated set of (pointer to) already generated operations
+   * @param name_gen name generator for this kernel
+   * @param i row index variable name
+   * @param j column index variable name
+   * @param view_handled whether caller already handled matrix view
+   * @return part of kernel with code for this and nested expressions
+   */
+  inline kernel_parts get_kernel_parts(
+      std::set<const operation_cl_base*>& generated, name_generator& name_gen,
+      const std::string& i, const std::string& j, bool view_handled) const {
+    kernel_parts res{};
+    if (generated.count(this) == 0) {
+      generated.insert(this);
+      res = this->template get_arg<0>().get_kernel_parts(generated, name_gen, i,
+                                                         i, true);
+      var_name = this->template get_arg<0>().var_name;
+    }
+    return res;
+  }
+
+  /**
+   * Sets j to value of i. This is only used when diagonal is assigned to.
+   * @param[in, out] i row index
+   * @param[in, out] j column index
+   */
+  inline void modify_argument_indices(std::string& i, std::string& j) const {
+    j=i;
+  }
+
+  /**
+   * Generates kernel code for this and nested expressions if this expression
+   * appears on the left hand side of an assignment.
+   * @param i row index variable name
+   * @param j column index variable name
+   * @param var_name_arg name of the variable in kernel that holds argument to
+   * this expression
+   * @return part of kernel with code for this expression
+   */
+  inline kernel_parts generate_lhs(const std::string& i, const std::string& j,
+                                   const std::string& var_name_arg) const {
+    return {};
+  }
+
+  /**
+   * Number of rows of a matrix that would be the result of evaluating this
+   * expression.
+   * @return number of rows
+   */
+  inline int rows() const {
+    return std::min(this->template get_arg<0>().rows(),
+                    this->template get_arg<0>().cols());
+  }
+
+  /**
+   * Number of columns of a matrix that would be the result of evaluating this
+   * expression.
+   * @return 1
+   */
+  inline int cols() const { return 1; }
+
+  /**
+   * Sets view of the underlying matrix depending on which part is written.
+   * Setting view to diagonal never changes view of the underlying matrix.
+   * @param bottom_diagonal Index of the top sub- or super- diagonal written
+   * with nonzero elements.
+   * @param top_diagonal Index of the top sub- or super- diagonal written with
+   * nonzero elements.
+   * @param bottom_zero_diagonal Index of the top sub- or super- diagonal
+   * written with zeros if it ie more extreme than \c bottom_diagonal. Otherwise
+   * it should be set to equal value as \c bottom_diagonal.
+   * @param top_zero_diagonal Index of the top sub- or super- diagonal written
+   * with zeros if it ie more extreme than \c top_diagonal. Otherwise it should
+   * be set to equal value as \c top_diagonal.
+   */
+  inline void set_view(int bottom_diagonal, int top_diagonal,
+                       int bottom_zero_diagonal, int top_zero_diagonal) const {}
+
+  /**
+   * Determine indices of extreme sub- and superdiagonals written.
+   * @return pair of indices - bottom and top diagonal
+   */
+  inline std::pair<int, int> extreme_diagonals() const {
+    return {1 - rows(), 1};
+  }
+
+  /**
+   * Checks if desired dimensions match dimensions of the block.
+   * @param rows desired number of rows
+   * @param cols desired number of columns
+   * @throws std::invalid_argument desired dimensions do not match dimensions
+   * of the block.
+   */
+  inline void check_assign_dimensions(int rows, int cols) const {
+    check_size_match("diagonal_.check_assign_dimensions", "Rows of ",
+                     "diagonal", this->rows(), "rows of ", "expression", rows);
+    check_size_match("diagonal_.check_assign_dimensions", "Columns of ",
+                     "diagonal", 1, "columns of ", "expression", cols);
+  }
+};
+
+/**
+ * Diagonal of a kernel generator expression. Diagonal is represented as a
+ * column vector.
+ *
+ * @tparam T type of argument
+ * @param a input argument
+ * @return Diagonal of given expression
+ */
+template <typename T,
+          typename = require_all_valid_expressions_and_none_scalar_t<T>>
+inline auto diagonal(T&& a) {
+  auto&& a_operation = as_operation_cl(std::forward<T>(a)).deep_copy();
+  return diagonal_<std::remove_reference_t<decltype(a_operation)>>(
+      std::move(a_operation));
+}
+/** @}*/
+}  // namespace math
+}  // namespace stan
+
+#endif
+#endif

--- a/stan/math/opencl/kernel_generator/operation_cl.hpp
+++ b/stan/math/opencl/kernel_generator/operation_cl.hpp
@@ -78,6 +78,7 @@ class operation_cl : public operation_cl_base {
   mutable std::string var_name;  // name of the variable that holds result of
                                  // this operation in the kernel
 
+public:
   /**
    * Casts the instance into its derived type.
    * @return \c this cast into derived type
@@ -92,7 +93,6 @@ class operation_cl : public operation_cl_base {
     return *static_cast<const Derived*>(this);
   }
 
- public:
   using Deriv = Derived;
   using ArgsTuple = std::tuple<Args...>;
   static const bool require_specific_local_size;

--- a/stan/math/opencl/kernel_generator/operation_cl.hpp
+++ b/stan/math/opencl/kernel_generator/operation_cl.hpp
@@ -78,7 +78,7 @@ class operation_cl : public operation_cl_base {
   mutable std::string var_name;  // name of the variable that holds result of
                                  // this operation in the kernel
 
-public:
+ public:
   /**
    * Casts the instance into its derived type.
    * @return \c this cast into derived type

--- a/stan/math/opencl/kernel_generator/operation_cl_lhs.hpp
+++ b/stan/math/opencl/kernel_generator/operation_cl_lhs.hpp
@@ -28,13 +28,13 @@ class operation_cl_lhs : public operation_cl<Derived, Scalar, Args...> {
  protected:
   using base = operation_cl<Derived, Scalar, Args...>;
   static constexpr int N = sizeof...(Args);
-  using base::derived;
 
  public:
+  using base::derived;
   using base::operation_cl;
 
   /**
-   * generates kernel code for this expression if it appears on the left hand
+   * Generates kernel code for this expression if it appears on the left hand
    * side of an assignment.
    * @param[in,out] generated set of (pointer to) already generated operations
    * @param name_gen name generator for this kernel
@@ -74,6 +74,34 @@ class operation_cl_lhs : public operation_cl<Derived, Scalar, Args...> {
       res += my_part;
     }
     return res;
+  }
+
+  /**
+   * Evaluates an expression and assigns it to this.
+   * @tparam T_expression type of expression
+   * @param rhs input expression
+   */
+  template <typename T_expression,
+            typename
+            = require_all_valid_expressions_and_none_scalar_t<T_expression>>
+  const operation_cl_lhs<Derived, Scalar, Args...>& operator=(
+      T_expression&& rhs) const {
+    auto expression = as_operation_cl(std::forward<T_expression>(rhs)).derived();
+    int this_rows = derived().rows();
+    int this_cols = derived().cols();
+    if (this_rows == expression.rows() && this_cols == expression.cols()
+        && this_rows * this_cols == 0) {
+      return *this;
+    }
+    expression.evaluate_into(derived());
+    return *this;
+  }
+  // Copy assignment delegates to general assignment operator. If we didn't
+  // implement this, we would get ambiguities in overload resolution with
+  // implicitly generated one
+  inline const operation_cl_lhs<Derived, Scalar, Args...>& operator=(
+      const operation_cl_lhs<Derived, Scalar, Args...>& rhs) const {
+    return operator=<const operation_cl_lhs<Derived, Scalar, Args...>&>(rhs);
   }
 
   /**

--- a/test/unit/math/opencl/kernel_generator/block_test.cpp
+++ b/test/unit/math/opencl/kernel_generator/block_test.cpp
@@ -108,6 +108,24 @@ TEST(KernelGenerator, lhs_block_test) {
   EXPECT_MATRIX_NEAR(res, correct, 1e-9);
 }
 
+TEST(KernelGenerator, block_to_lhs_block_test) {
+  using stan::math::block;
+  MatrixXd m1(2, 3);
+  m1 << 1, 2, 3, 4, 5, 6;
+  MatrixXd m2 = MatrixXd::Constant(5, 7, 9);
+
+  matrix_cl<double> m1_cl(m1);
+  matrix_cl<double> m2_cl(m2);
+
+  block(m2_cl, 1, 1, 2, 3) = block(m1_cl, 0, 0, 2, 3);
+
+  MatrixXd res = stan::math::from_matrix_cl(m2_cl);
+
+  MatrixXd correct = m2;
+  correct.block(1, 1, 2, 3) = m1;
+  EXPECT_MATRIX_NEAR(res, correct, 1e-9);
+}
+
 TEST(KernelGenerator, two_blocks_of_same_expression) {
   using stan::math::block;
   MatrixXd m(2, 3);

--- a/test/unit/math/opencl/kernel_generator/diagonal_test.cpp
+++ b/test/unit/math/opencl/kernel_generator/diagonal_test.cpp
@@ -1,0 +1,87 @@
+#ifdef STAN_OPENCL
+
+#include <stan/math/opencl/kernel_generator.hpp>
+#include <test/unit/math/opencl/kernel_generator/reference_kernel.hpp>
+#include <stan/math/opencl/matrix_cl.hpp>
+#include <stan/math/opencl/copy.hpp>
+#include <Eigen/Dense>
+#include <gtest/gtest.h>
+#include <string>
+
+using Eigen::MatrixXd;
+using Eigen::VectorXd;
+using stan::math::diagonal;
+using stan::math::matrix_cl;
+
+#define EXPECT_MATRIX_NEAR(A, B, DELTA) \
+  EXPECT_EQ(A.rows(), B.rows());        \
+  EXPECT_EQ(A.cols(), B.cols());        \
+  for (int i = 0; i < A.size(); i++)    \
+    EXPECT_NEAR(A(i), B(i), DELTA);
+
+TEST(KernelGenerator, diagonal_test) {
+  MatrixXd m = MatrixXd::Random(3, 4);
+
+  matrix_cl<double> m_cl(m);
+
+  matrix_cl<double> res_cl = diagonal(m_cl);
+  MatrixXd res = stan::math::from_matrix_cl(res_cl);
+
+  MatrixXd correct = m.diagonal();
+  EXPECT_MATRIX_NEAR(res, correct, 1e-9);
+}
+
+TEST(KernelGenerator, diagonal_multiple_operations_test) {
+  MatrixXd m = MatrixXd::Random(4, 3);
+
+  matrix_cl<double> m_cl(m);
+
+  matrix_cl<double> res_cl = diagonal(m_cl * 2);
+  MatrixXd res = stan::math::from_matrix_cl(res_cl);
+
+  MatrixXd correct = (2 * m).diagonal();
+  EXPECT_MATRIX_NEAR(res, correct, 1e-9);
+}
+
+TEST(KernelGenerator, diagonal_multiple_operations_accept_lvalue_test) {
+  MatrixXd m = MatrixXd::Random(3, 4);
+
+  matrix_cl<double> m_cl(m);
+
+  auto tmp = m_cl * 2;
+  matrix_cl<double> res_cl = diagonal(tmp);
+  MatrixXd res = stan::math::from_matrix_cl(res_cl);
+
+  MatrixXd correct = (2 * m).diagonal();
+  EXPECT_MATRIX_NEAR(res, correct, 1e-9);
+}
+
+TEST(KernelGenerator, diagonal_lhs_test) {
+  MatrixXd m = MatrixXd::Random(3, 4);
+  VectorXd v = VectorXd::Random(3);
+
+  matrix_cl<double> m_cl(m);
+  matrix_cl<double> v_cl(v);
+
+  diagonal(m_cl) = v_cl;
+  MatrixXd res = stan::math::from_matrix_cl(m_cl);
+
+  MatrixXd correct = m;
+  correct.diagonal() = v;
+  EXPECT_MATRIX_NEAR(res, correct, 1e-9);
+}
+
+TEST(KernelGenerator, diagonal_of_a_block_test) {
+  MatrixXd m = MatrixXd::Random(4, 4);
+
+  matrix_cl<double> m_cl(m);
+
+  diagonal(block(m_cl, 0, 1, 3, 3)) = diagonal(block(m_cl, 1, 0, 3, 3));
+  MatrixXd res = stan::math::from_matrix_cl(m_cl);
+
+  MatrixXd correct = m;
+  correct.diagonal(1) = correct.diagonal(-1);
+  EXPECT_MATRIX_NEAR(res, correct, 1e-9);
+}
+
+#endif


### PR DESCRIPTION
## Summary
Adds diagonal operation to kernel generator. `operator=` has been moved from `block_` to `operation_cl_lhs` so the same function can also be used by `diagonal_`.

## Tests
Diagonal is tested. Added aditional test for block.

## Side Effects

None.

## Release notes

Added diagonal operation to kernel generator. 

## Checklist

- [x] Math issue #1342 

- [x] Copyright holder: Tadej Ciglarič

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
