### PR TITLE
Add matrix concatenation operations to kernel generator

### DIFF
--- a/stan/math/opencl/kernel_generator.hpp
+++ b/stan/math/opencl/kernel_generator.hpp
@@ -115,6 +115,7 @@
 
 #include <stan/math/opencl/kernel_generator/load.hpp>
 #include <stan/math/opencl/kernel_generator/scalar.hpp>
+#include <stan/math/opencl/kernel_generator/append.hpp>
 #include <stan/math/opencl/kernel_generator/binary_operation.hpp>
 #include <stan/math/opencl/kernel_generator/unary_function_cl.hpp>
 #include <stan/math/opencl/kernel_generator/unary_operation_cl.hpp>

--- a/stan/math/opencl/kernel_generator/append.hpp
+++ b/stan/math/opencl/kernel_generator/append.hpp
@@ -1,0 +1,323 @@
+#ifndef STAN_MATH_OPENCL_KERNEL_GENERATOR_APPEND_HPP
+#define STAN_MATH_OPENCL_KERNEL_GENERATOR_APPEND_HPP
+#ifdef STAN_OPENCL
+
+#include <stan/math/opencl/matrix_cl_view.hpp>
+#include <stan/math/opencl/err.hpp>
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/opencl/kernel_generator/type_str.hpp>
+#include <stan/math/opencl/kernel_generator/name_generator.hpp>
+#include <stan/math/opencl/kernel_generator/operation_cl.hpp>
+#include <stan/math/opencl/kernel_generator/scalar.hpp>
+#include <stan/math/opencl/kernel_generator/as_operation_cl.hpp>
+#include <stan/math/opencl/kernel_generator/is_valid_expression.hpp>
+#include <stan/math/opencl/kernel_generator/common_return_scalar.hpp>
+#include <algorithm>
+#include <string>
+#include <tuple>
+#include <type_traits>
+#include <set>
+#include <utility>
+
+namespace stan {
+namespace math {
+
+/** \addtogroup opencl_kernel_generator
+ *  @{
+ */
+
+/**
+ * Represents appending of rows in kernel generator expressions.
+ * @tparam T_a type of first argument
+ * @tparam T_b type of second argument
+ */
+template <typename T_a, typename T_b>
+class append_row_ : public operation_cl<append_row_<T_a, T_b>,
+                                        common_scalar_t<T_a, T_b>, T_a, T_b> {
+ public:
+  using Scalar = common_scalar_t<T_a, T_b>;
+  using base = operation_cl<append_row_<T_a, T_b>, Scalar, T_a, T_b>;
+  using base::var_name;
+
+ protected:
+  using base::arguments_;
+
+ public:
+  /**
+   * Constructor
+   * @param a first argument
+   * @param b second argument
+   */
+  append_row_(T_a&& a, T_b&& b)  // NOLINT
+      : base(std::forward<T_a>(a), std::forward<T_b>(b)) {
+    if (a.cols() != base::dynamic && b.cols() != base::dynamic) {
+      check_size_match("append_row", "Columns of ", "a", a.cols(),
+                       "columns of ", "b", b.cols());
+    }
+    if (a.rows() < 0) {
+      invalid_argument("append_row", "Rows of a", a.rows(),
+                       "should be nonnegative!");
+    }
+    if (b.rows() < 0) {
+      invalid_argument("append_row", "Rows of b", b.rows(),
+                       "should be nonnegative!");
+    }
+  }
+
+  /**
+   * Creates a deep copy of this expression.
+   * @return copy of \c *this
+   */
+  inline auto deep_copy() const {
+    auto&& a_copy = this->template get_arg<0>().deep_copy();
+    auto&& b_copy = this->template get_arg<1>().deep_copy();
+    return append_row_<std::remove_reference_t<decltype(a_copy)>,
+                       std::remove_reference_t<decltype(b_copy)>>{
+        std::move(a_copy), std::move(b_copy)};
+  }
+
+  /**
+   * Generates kernel code for this and nested expressions.
+   * @param[in,out] generated set of (pointer to) already generated operations
+   * @param name_gen name generator for this kernel
+   * @param i row index variable name
+   * @param j column index variable name
+   * @param view_handled whether caller already handled matrix view
+   * @return part of kernel with code for this and nested expressions
+   */
+  inline kernel_parts get_kernel_parts(
+      std::set<const operation_cl_base*>& generated, name_generator& name_gen,
+      const std::string& i, const std::string& j, bool view_handled) const {
+    kernel_parts res{};
+    if (generated.count(this) == 0) {
+      var_name = name_gen.generate();
+      generated.insert(this);
+      std::string i_b = "(" + i + " - " + var_name + "_first_rows)";
+      kernel_parts parts_a = this->template get_arg<0>().get_kernel_parts(
+          generated, name_gen, i, j, true);
+      kernel_parts parts_b = this->template get_arg<1>().get_kernel_parts(
+          generated, name_gen, i_b, j, true);
+      res = parts_a + parts_b;
+      res.body = type_str<Scalar>() + " " + var_name + ";\n"
+          "if("+ i +" < " + var_name + "_first_rows){\n"
+          + parts_a.body +
+          var_name + " = " + this->template get_arg<0>().var_name + ";\n"
+          "} else{\n"
+          + parts_b.body +
+          var_name + " = " + this->template get_arg<1>().var_name + ";\n"
+          "}\n";
+      res.args += "int " + var_name + "_first_rows, ";
+    }
+    return res;
+  }
+
+  /**
+   * Sets kernel arguments for this and nested expressions.
+   * @param[in,out] generated set of expressions that already set their kernel
+   * arguments
+   * @param kernel kernel to set arguments on
+   * @param[in,out] arg_num consecutive number of the first argument to set.
+   * This is incremented for each argument set by this function.
+   */
+  inline void set_args(std::set<const operation_cl_base*>& generated,
+                       cl::Kernel& kernel, int& arg_num) const {
+    if (generated.count(this) == 0) {
+      generated.insert(this);
+      this->template get_arg<0>().set_args(generated, kernel, arg_num);
+      this->template get_arg<1>().set_args(generated, kernel, arg_num);
+      kernel.setArg(arg_num++, this->template get_arg<0>().rows());
+    }
+  }
+
+  /**
+   * Number of rows of a matrix that would be the result of evaluating this
+   * expression.
+   * @return number of rows
+   */
+  inline int rows() const {
+    return this->template get_arg<0>().rows()
+           + this->template get_arg<1>().rows();
+  }
+
+  /**
+   * Determine indices of extreme sub- and superdiagonals written.
+   * @return pair of indices - bottom and top diagonal
+   */
+  inline std::pair<int, int> extreme_diagonals() const {
+    std::pair<int, int> a_diags
+        = this->template get_arg<0>().extreme_diagonals();
+    std::pair<int, int> b_diags
+        = this->template get_arg<1>().extreme_diagonals();
+    return {b_diags.first - this->template get_arg<0>().rows(), a_diags.second};
+  }
+};
+
+/**
+ * Stack the rows of the first argument on top of the second argument.
+ *
+ * @tparam Ta type of first argument
+ * @tparam Ta type of second argument
+ * @param a First argument
+ * @param a Second argument
+ * @return Stacked arguments
+ */
+template <typename Ta, typename Tb,
+          typename = require_all_valid_expressions_and_none_scalar_t<Ta, Tb>>
+inline auto append_row(Ta&& a, Tb&& b) {
+  auto&& a_operation = as_operation_cl(std::forward<Ta>(a)).deep_copy();
+  auto&& b_operation = as_operation_cl(std::forward<Tb>(b)).deep_copy();
+  return append_row_<std::remove_reference_t<decltype(a_operation)>,
+                     std::remove_reference_t<decltype(b_operation)>>(
+      std::move(a_operation), std::move(b_operation));
+}
+
+/**
+ * Represents appending of cols in kernel generator expressions.
+ * @tparam T_a type of first argument
+ * @tparam T_b type of second argument
+ */
+template <typename T_a, typename T_b>
+class append_col_ : public operation_cl<append_col_<T_a, T_b>,
+                                        common_scalar_t<T_a, T_b>, T_a, T_b> {
+ public:
+  using Scalar = common_scalar_t<T_a, T_b>;
+  using base = operation_cl<append_col_<T_a, T_b>, Scalar, T_a, T_b>;
+  using base::var_name;
+
+ protected:
+  using base::arguments_;
+
+ public:
+  /**
+   * Constructor
+   * @param a first argument
+   * @param b second argument
+   */
+  append_col_(T_a&& a, T_b&& b)  // NOLINT
+      : base(std::forward<T_a>(a), std::forward<T_b>(b)) {
+    if (a.rows() != base::dynamic && b.rows() != base::dynamic) {
+      check_size_match("append_col", "Rows of ", "a", a.rows(), "rows of ", "b",
+                       b.rows());
+    }
+    if (a.cols() < 0) {
+      invalid_argument("append_col", "Columns of a", a.cols(),
+                       "should be nonnegative!");
+    }
+    if (b.cols() < 0) {
+      invalid_argument("append_col", "Columns of b", b.cols(),
+                       "should be nonnegative!");
+    }
+  }
+
+  /**
+   * Creates a deep copy of this expression.
+   * @return copy of \c *this
+   */
+  inline auto deep_copy() const {
+    auto&& a_copy = this->template get_arg<0>().deep_copy();
+    auto&& b_copy = this->template get_arg<1>().deep_copy();
+    return append_col_<std::remove_reference_t<decltype(a_copy)>,
+                       std::remove_reference_t<decltype(b_copy)>>{
+        std::move(a_copy), std::move(b_copy)};
+  }
+
+  /**
+   * Generates kernel code for this and nested expressions.
+   * @param[in,out] generated set of (pointer to) already generated operations
+   * @param name_gen name generator for this kernel
+   * @param i row index variable name
+   * @param j column index variable name
+   * @param view_handled whether caller already handled matrix view
+   * @return part of kernel with code for this and nested expressions
+   */
+  inline kernel_parts get_kernel_parts(
+      std::set<const operation_cl_base*>& generated, name_generator& name_gen,
+      const std::string& i, const std::string& j, bool view_handled) const {
+    kernel_parts res{};
+    if (generated.count(this) == 0) {
+      var_name = name_gen.generate();
+      generated.insert(this);
+      std::string j_b = "(" + j + " - " + var_name + "_first_cols)";
+      kernel_parts parts_a = this->template get_arg<0>().get_kernel_parts(
+          generated, name_gen, i, j, true);
+      kernel_parts parts_b = this->template get_arg<1>().get_kernel_parts(
+          generated, name_gen, i, j_b, true);
+      res = parts_a + parts_b;
+      res.body = type_str<Scalar>() + " " + var_name + ";\n"
+          "if("+ j +" < " + var_name + "_first_cols){\n"
+          + parts_a.body +
+          var_name + " = " + this->template get_arg<0>().var_name + ";\n"
+          "} else{\n"
+          + parts_b.body +
+          var_name + " = " + this->template get_arg<1>().var_name + ";\n"
+          "}\n";
+      res.args += "int " + var_name + "_first_cols, ";
+    }
+    return res;
+  }
+
+  /**
+   * Sets kernel arguments for this and nested expressions.
+   * @param[in,out] generated set of expressions that already set their kernel
+   * arguments
+   * @param kernel kernel to set arguments on
+   * @param[in,out] arg_num consecutive number of the first argument to set.
+   * This is incremented for each argument set by this function.
+   */
+  inline void set_args(std::set<const operation_cl_base*>& generated,
+                       cl::Kernel& kernel, int& arg_num) const {
+    if (generated.count(this) == 0) {
+      generated.insert(this);
+      this->template get_arg<0>().set_args(generated, kernel, arg_num);
+      this->template get_arg<1>().set_args(generated, kernel, arg_num);
+      kernel.setArg(arg_num++, this->template get_arg<0>().cols());
+    }
+  }
+
+  /**
+   * Number of rows of a matrix that would be the result of evaluating this
+   * expression.
+   * @return number of rows
+   */
+  inline int cols() const {
+    return this->template get_arg<0>().cols()
+           + this->template get_arg<1>().cols();
+  }
+
+  /**
+   * Determine indices of extreme sub- and superdiagonals written.
+   * @return pair of indices - bottom and top diagonal
+   */
+  inline std::pair<int, int> extreme_diagonals() const {
+    std::pair<int, int> a_diags
+        = this->template get_arg<0>().extreme_diagonals();
+    std::pair<int, int> b_diags
+        = this->template get_arg<1>().extreme_diagonals();
+    return {a_diags.first, b_diags.second - this->template get_arg<0>().cols()};
+  }
+};
+
+/**
+ * Stack the cols of the arguments.
+ *
+ * @tparam Ta type of first argument
+ * @tparam Ta type of second argument
+ * @param a First argument
+ * @param a Second argument
+ * @return Stacked arguments
+ */
+template <typename Ta, typename Tb,
+          typename = require_all_valid_expressions_and_none_scalar_t<Ta, Tb>>
+inline auto append_col(Ta&& a, Tb&& b) {
+  auto&& a_operation = as_operation_cl(std::forward<Ta>(a)).deep_copy();
+  auto&& b_operation = as_operation_cl(std::forward<Tb>(b)).deep_copy();
+  return append_col_<std::remove_reference_t<decltype(a_operation)>,
+                     std::remove_reference_t<decltype(b_operation)>>(
+      std::move(a_operation), std::move(b_operation));
+}
+
+}  // namespace math
+}  // namespace stan
+
+#endif
+#endif

--- a/stan/math/opencl/kernel_generator/append.hpp
+++ b/stan/math/opencl/kernel_generator/append.hpp
@@ -158,7 +158,7 @@ class append_row_ : public operation_cl<append_row_<T_a, T_b>,
  * @tparam Ta type of first argument
  * @tparam Ta type of second argument
  * @param a First argument
- * @param a Second argument
+ * @param b Second argument
  * @return Stacked arguments
  */
 template <typename Ta, typename Tb,
@@ -303,7 +303,7 @@ class append_col_ : public operation_cl<append_col_<T_a, T_b>,
  * @tparam Ta type of first argument
  * @tparam Ta type of second argument
  * @param a First argument
- * @param a Second argument
+ * @param b Second argument
  * @return Stacked arguments
  */
 template <typename Ta, typename Tb,

--- a/test/unit/math/opencl/kernel_generator/append_test.cpp
+++ b/test/unit/math/opencl/kernel_generator/append_test.cpp
@@ -1,0 +1,192 @@
+#ifdef STAN_OPENCL
+
+#include <stan/math/opencl/kernel_generator.hpp>
+#include <stan/math/opencl/matrix_cl.hpp>
+#include <stan/math/opencl/copy.hpp>
+#include <stan/math/prim/fun.hpp>
+#include <Eigen/Dense>
+#include <gtest/gtest.h>
+
+#define EXPECT_MATRIX_NEAR(A, B, DELTA) \
+  for (int i = 0; i < A.size(); i++)    \
+    EXPECT_NEAR(A(i), B(i), DELTA);
+
+TEST(KernelGenerator, append_row_errors) {
+  using Eigen::MatrixXd;
+  using stan::math::append_row;
+  using stan::math::matrix_cl;
+
+  MatrixXd m1(1, 1);
+  m1 << 1;
+  MatrixXd rv(1, 3);
+  rv << 1, 2.5, 3;
+  MatrixXd m2(2, 2);
+  m2 << 1, 2.5, 3, 4;
+  MatrixXd m3(3, 3);
+  m3 << 1, 2.5, 3, 4, 5, 6.3, 7, -8, -9.5;
+
+  matrix_cl<double> m1_cl(m1);
+  matrix_cl<double> m2_cl(m2);
+  matrix_cl<double> m3_cl(m3);
+  matrix_cl<double> rv_cl(rv);
+
+  EXPECT_NO_THROW(append_row(m3_cl, rv_cl));
+  EXPECT_NO_THROW(append_row(m3_cl, stan::math::rowwise_broadcast(m1_cl)));
+  EXPECT_NO_THROW(append_row(stan::math::rowwise_broadcast(m1_cl), m3_cl));
+  EXPECT_THROW(append_row(m3_cl, stan::math::colwise_broadcast(rv_cl)),
+               std::invalid_argument);
+  EXPECT_THROW(append_row(stan::math::colwise_broadcast(rv_cl), m3_cl),
+               std::invalid_argument);
+  EXPECT_THROW(append_row(m2_cl, m3_cl), std::invalid_argument);
+}
+
+TEST(KernelGenerator, append_row_test) {
+  using Eigen::MatrixXd;
+  using stan::math::append_row;
+  using stan::math::matrix_cl;
+  MatrixXd m1(2, 3);
+  m1 << 1, 2.5, 3, 4, 5, 6.3;
+  MatrixXd m2(1, 3);
+  m2 << 2, 4, 8;
+
+  matrix_cl<double> m1_cl(m1);
+  matrix_cl<double> m2_cl(m2);
+
+  matrix_cl<double> res_cl = append_row(m1_cl, m2_cl);
+  MatrixXd res = stan::math::from_matrix_cl(res_cl);
+
+  MatrixXd correct = append_row(m1, m2);
+  EXPECT_MATRIX_NEAR(res, correct, 1e-9);
+}
+
+TEST(KernelGenerator, append_row_multiple_operations_test) {
+  using Eigen::MatrixXd;
+  using stan::math::append_row;
+  using stan::math::matrix_cl;
+  MatrixXd m1(2, 3);
+  m1 << 1, 2.5, 3, 4, 5, 6.3;
+  MatrixXd m2(1, 3);
+  m2 << 2, 4, 8;
+
+  matrix_cl<double> m1_cl(m1);
+  matrix_cl<double> m2_cl(m2);
+
+  matrix_cl<double> res_cl
+      = append_row(append_row(m1_cl, m1_cl), append_row(m2_cl, m2_cl));
+  MatrixXd res = stan::math::from_matrix_cl(res_cl);
+
+  MatrixXd correct = append_row(append_row(m1, m1), append_row(m2, m2));
+  EXPECT_MATRIX_NEAR(res, correct, 1e-9);
+}
+
+TEST(KernelGenerator, append_row_multiple_operations_accept_lvalue_test) {
+  using Eigen::MatrixXd;
+  using stan::math::append_row;
+  using stan::math::matrix_cl;
+  MatrixXd m1(2, 3);
+  m1 << 1, 2.5, 3, 4, 5, 6.3;
+  MatrixXd m2(1, 3);
+  m2 << 2, 4, 8;
+
+  matrix_cl<double> m1_cl(m1);
+  matrix_cl<double> m2_cl(m2);
+
+  auto a = append_row(m1_cl, m1_cl);
+  auto b = append_row(m2_cl, m2_cl);
+  matrix_cl<double> res_cl = append_row(a, b);
+  MatrixXd res = stan::math::from_matrix_cl(res_cl);
+
+  MatrixXd correct = append_row(append_row(m1, m1), append_row(m2, m2));
+  EXPECT_MATRIX_NEAR(res, correct, 1e-9);
+}
+
+TEST(KernelGenerator, append_col_errors) {
+  using Eigen::MatrixXd;
+  using stan::math::append_col;
+  using stan::math::matrix_cl;
+
+  MatrixXd m1(1, 1);
+  m1 << 1;
+  MatrixXd v(3, 1);
+  v << 1, 2.5, 3;
+  MatrixXd m2(2, 2);
+  m2 << 1, 2.5, 3, 4;
+  MatrixXd m3(3, 3);
+  m3 << 1, 2.5, 3, 4, 5, 6.3, 7, -8, -9.5;
+
+  matrix_cl<double> m1_cl(m1);
+  matrix_cl<double> m2_cl(m2);
+  matrix_cl<double> m3_cl(m3);
+  matrix_cl<double> v_cl(v);
+
+  EXPECT_NO_THROW(append_col(m3_cl, v_cl));
+  EXPECT_NO_THROW(append_col(m3_cl, stan::math::colwise_broadcast(m1_cl)));
+  EXPECT_NO_THROW(append_col(stan::math::colwise_broadcast(m1_cl), m3_cl));
+  EXPECT_THROW(append_col(m3_cl, stan::math::rowwise_broadcast(v_cl)),
+               std::invalid_argument);
+  EXPECT_THROW(append_col(stan::math::rowwise_broadcast(v_cl), m3_cl),
+               std::invalid_argument);
+  EXPECT_THROW(append_col(m2_cl, m3_cl), std::invalid_argument);
+}
+
+TEST(KernelGenerator, append_col_test) {
+  using Eigen::MatrixXd;
+  using stan::math::append_col;
+  using stan::math::matrix_cl;
+  MatrixXd m1(3, 2);
+  m1 << 1, 2.5, 3, 4, 5, 6.3;
+  MatrixXd m2(3, 1);
+  m2 << 2, 4, 8;
+
+  matrix_cl<double> m1_cl(m1);
+  matrix_cl<double> m2_cl(m2);
+
+  matrix_cl<double> res_cl = append_col(m1_cl, m2_cl);
+  MatrixXd res = stan::math::from_matrix_cl(res_cl);
+
+  MatrixXd correct = append_col(m1, m2);
+  EXPECT_MATRIX_NEAR(res, correct, 1e-9);
+}
+
+TEST(KernelGenerator, append_col_multiple_operations_test) {
+  using Eigen::MatrixXd;
+  using stan::math::append_col;
+  using stan::math::matrix_cl;
+  MatrixXd m1(3, 2);
+  m1 << 1, 2.5, 3, 4, 5, 6.3;
+  MatrixXd m2(3, 1);
+  m2 << 2, 4, 8;
+
+  matrix_cl<double> m1_cl(m1);
+  matrix_cl<double> m2_cl(m2);
+
+  matrix_cl<double> res_cl
+      = append_col(append_col(m1_cl, m1_cl), append_col(m2_cl, m2_cl));
+  MatrixXd res = stan::math::from_matrix_cl(res_cl);
+
+  MatrixXd correct = append_col(append_col(m1, m1), append_col(m2, m2));
+  EXPECT_MATRIX_NEAR(res, correct, 1e-9);
+}
+
+TEST(KernelGenerator, append_col_multiple_operations_accept_lvalue_test) {
+  using Eigen::MatrixXd;
+  using stan::math::append_col;
+  using stan::math::matrix_cl;
+  MatrixXd m1(3, 2);
+  m1 << 1, 2.5, 3, 4, 5, 6.3;
+  MatrixXd m2(3, 1);
+  m2 << 2, 4, 8;
+
+  matrix_cl<double> m1_cl(m1);
+  matrix_cl<double> m2_cl(m2);
+
+  auto a = append_col(m1_cl, m1_cl);
+  auto b = append_col(m2_cl, m2_cl);
+  matrix_cl<double> res_cl = append_col(a, b);
+  MatrixXd res = stan::math::from_matrix_cl(res_cl);
+
+  MatrixXd correct = append_col(append_col(m1, m1), append_col(m2, m2));
+  EXPECT_MATRIX_NEAR(res, correct, 1e-9);
+}
+
+#endif


### PR DESCRIPTION
## Summary

Adds matrix concatenation oprations (`append_row` and `append_col`) to kernel generator.

## Tests

New operations are tested.

## Side Effects

None.

## Release notes

Added matrix concatenation oprations (`append_row` and `append_col`) to kernel generator.

## Checklist

- [x] Math issue #1342

- [x] Copyright holder: Tadej Ciglarič

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
