### PR TITLE
Remove Windows g++ warnings

### DIFF
--- a/make/compiler_flags
+++ b/make/compiler_flags
@@ -161,6 +161,7 @@ endif
 
 ## makes reentrant version lgamma_r available from cmath
 CXXFLAGS_OS += -D_REENTRANT
+CXXFLAGS_WARNINGS += -Wno-int-in-bool-context -Wno-attributes
 
 ################################################################################
 # Setup OpenCL

--- a/make/compiler_flags
+++ b/make/compiler_flags
@@ -161,7 +161,10 @@ endif
 
 ## makes reentrant version lgamma_r available from cmath
 CXXFLAGS_OS += -D_REENTRANT
+
+ifeq (gcc,$(CXX_TYPE))
 CXXFLAGS_WARNINGS += -Wno-int-in-bool-context -Wno-attributes
+endif
 
 ################################################################################
 # Setup OpenCL


### PR DESCRIPTION
## Summary

Fixes #1864 by adding `-Wno-int-in-bool-context -Wno-attributes` to CXXFLAGS.

This 

## Tests

/

## Side Effects

/

## Release notes

Added -Wno-int-in-bool-context and -Wno-attributes compiler flags to silence warnings due to compiler bugs.

## Checklist

- [x] Math issue #1864 

- [x] Copyright holder: Rok Češnovar

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
