### PR TITLE
Clean up adj_jac_apply (static matrix design doc)

### DIFF
--- a/stan/math/rev/functor/adj_jac_apply.hpp
+++ b/stan/math/rev/functor/adj_jac_apply.hpp
@@ -231,8 +231,8 @@ struct adj_jac_vari : public vari {
   /**
    * Accumulate, if necessary, the values of y_adj_jac into the
    * adjoints of the varis pointed to by the appropriate elements
-   * of x_vis_. Recursively calls accumulate_adjoints_in_varis on the rest of the
-   * arguments.
+   * of x_vis_. Recursively calls accumulate_adjoints_in_varis on the rest of
+   * the arguments.
    *
    * @tparam R number of rows, can be Eigen::Dynamic
    * @tparam C number of columns, can be Eigen::Dynamic
@@ -243,9 +243,9 @@ struct adj_jac_vari : public vari {
    * recursively)
    */
   template <int R, int C, typename... Pargs>
-  inline void accumulate_adjoints_in_varis(vari** varis,
-					   const Eigen::Matrix<double, R, C>& y_adj_jac,
-					   const Pargs&... args) {
+  inline void accumulate_adjoints_in_varis(
+      vari** varis, const Eigen::Matrix<double, R, C>& y_adj_jac,
+      const Pargs&... args) {
     static constexpr int t = sizeof...(Targs) - sizeof...(Pargs) - 1;
     if (is_var_[t]) {
       for (int n = 0; n < y_adj_jac.size(); ++n) {
@@ -259,8 +259,8 @@ struct adj_jac_vari : public vari {
   /**
    * Accumulate, if necessary, the values of y_adj_jac into the
    * adjoints of the varis pointed to by the appropriate elements
-   * of x_vis_. Recursively calls accumulate_adjoints_in_varis on the rest of the
-   * arguments.
+   * of x_vis_. Recursively calls accumulate_adjoints_in_varis on the rest of
+   * the arguments.
    *
    * @tparam Pargs Types of the rest of adjoints to accumulate
    * @param y_adj_jac set of values to be accumulated in adjoints
@@ -269,8 +269,8 @@ struct adj_jac_vari : public vari {
    */
   template <typename... Pargs>
   inline void accumulate_adjoints_in_varis(vari** varis,
-					   const std::vector<double>& y_adj_jac,
-					   const Pargs&... args) {
+                                           const std::vector<double>& y_adj_jac,
+                                           const Pargs&... args) {
     static constexpr int t = sizeof...(Targs) - sizeof...(Pargs) - 1;
     if (is_var_[t]) {
       for (int n = 0; n < y_adj_jac.size(); ++n) {
@@ -283,8 +283,8 @@ struct adj_jac_vari : public vari {
   }
 
   /**
-   * Recursively call accumulate_adjoints_in_varis with args. There are no adjoints to
-   * accumulate for std::vector<int> arguments.
+   * Recursively call accumulate_adjoints_in_varis with args. There are no
+   * adjoints to accumulate for std::vector<int> arguments.
    *
    * @tparam Pargs Types of the rest of adjoints to accumulate
    * @param y_adj_jac ignored
@@ -293,16 +293,16 @@ struct adj_jac_vari : public vari {
    */
   template <typename... Pargs>
   inline void accumulate_adjoints_in_varis(vari** varis,
-				  const std::vector<int>& y_adj_jac,
-                                  const Pargs&... args) {
+                                           const std::vector<int>& y_adj_jac,
+                                           const Pargs&... args) {
     accumulate_adjoints_in_varis(varis, args...);
   }
 
   /**
    * Accumulate, if necessary, the value of y_adj_jac into the
    * adjoint of the vari pointed to by the appropriate element
-   * of x_vis_. Recursively calls accumulate_adjoints_in_varis on the rest of the
-   * arguments.
+   * of x_vis_. Recursively calls accumulate_adjoints_in_varis on the rest of
+   * the arguments.
    *
    * @tparam Pargs Types of the rest of adjoints to accumulate
    * @param y_adj_jac next set of adjoints to be accumulated
@@ -311,8 +311,8 @@ struct adj_jac_vari : public vari {
    */
   template <typename... Pargs>
   inline void accumulate_adjoints_in_varis(vari** varis,
-				  const double& y_adj_jac,
-                                  const Pargs&... args) {
+                                           const double& y_adj_jac,
+                                           const Pargs&... args) {
     static constexpr int t = sizeof...(Targs) - sizeof...(Pargs) - 1;
     if (is_var_[t]) {
       varis[0]->adj_ += y_adj_jac;
@@ -322,8 +322,8 @@ struct adj_jac_vari : public vari {
   }
 
   /**
-   * Recursively call accumulate_adjoints_in_varis with args. There are no adjoints to
-   * accumulate for int arguments.
+   * Recursively call accumulate_adjoints_in_varis with args. There are no
+   * adjoints to accumulate for int arguments.
    *
    * @tparam Pargs Types of the rest of adjoints to accumulate
    * @param y_adj_jac ignored
@@ -331,11 +331,12 @@ struct adj_jac_vari : public vari {
    * recursively)
    */
   template <typename... Pargs>
-  inline void accumulate_adjoints_in_varis(vari** varis, const int& y_adj_jac, const Pargs&... args) {
+  inline void accumulate_adjoints_in_varis(vari** varis, const int& y_adj_jac,
+                                           const Pargs&... args) {
     accumulate_adjoints_in_varis(varis, args...);
   }
 
-  inline void accumulate_adjoints_in_varis(vari **) {}
+  inline void accumulate_adjoints_in_varis(vari**) {}
 
   /**
    * Propagate the adjoints at the output varis (y_vi_) back to the input
@@ -354,8 +355,11 @@ struct adj_jac_vari : public vari {
     internal::build_y_adj(y_vi_, M_, y_adj);
     auto y_adj_jacs = f_.multiply_adjoint_jacobian(is_var_, y_adj);
 
-    apply([&, this](auto&&... args) { this->accumulate_adjoints_in_varis(x_vis_, args...); },
-          y_adj_jacs);
+    apply(
+        [&, this](auto&&... args) {
+          this->accumulate_adjoints_in_varis(x_vis_, args...);
+        },
+        y_adj_jacs);
   }
 };
 

--- a/test/unit/math/rev/functor/adj_jac_apply_test.cpp
+++ b/test/unit/math/rev/functor/adj_jac_apply_test.cpp
@@ -463,7 +463,7 @@ auto make_vari_for_test(const Targs&... args) {
 }
 
 TEST(AgradRev,
-     test_weird_argument_list_functor_compiles_and_sets_is_var_and_offsets_) {
+     test_weird_argument_list_functor_compiles_and_sets_is_var_) {
   int i;
   double d;
   stan::math::var v(5.0);
@@ -497,9 +497,6 @@ TEST(AgradRev,
                 {{false, false, false, false, false, false, false, false, false,
                   false, false, false, false, false, false, false}})));
 
-  EXPECT_EQ(vi1->offsets_, (std::array<int, 16>({{0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                                                  0, 0, 0, 0, 0, 0}})));
-
   stan::math::var(vi1).grad();
 
   auto vi2 = make_vari_for_test<WeirdArgumentListFunctor1>(
@@ -509,9 +506,6 @@ TEST(AgradRev,
             (std::array<bool, 16>(
                 {{true, false, false, false, true, false, false, false, true,
                   false, true, false, true, false, true, false}})));
-
-  EXPECT_EQ(vi2->offsets_, (std::array<int, 16>({{0, 1, 1, 1, 1, 3, 3, 3, 3, 6,
-                                                  6, 16, 16, 19, 19, 29}})));
 
   stan::math::var(vi2).grad();
 
@@ -523,9 +517,6 @@ TEST(AgradRev,
                 {{false, false, true, false, false, false, true, false, false,
                   true, false, true, false, true, false, true}})));
 
-  EXPECT_EQ(vi3->offsets_, (std::array<int, 16>({{0, 0, 0, 1, 1, 1, 1, 3, 3, 3,
-                                                  11, 11, 16, 16, 24, 24}})));
-
   stan::math::var(vi3).grad();
 
   auto vi4 = make_vari_for_test<WeirdArgumentListFunctor1>(
@@ -535,9 +526,6 @@ TEST(AgradRev,
             (std::array<bool, 16>(
                 {{true, false, false, false, false, false, true, false, true,
                   false, false, true, true, false, false, true}})));
-
-  EXPECT_EQ(vi4->offsets_, (std::array<int, 16>({{0, 1, 1, 1, 1, 1, 1, 3, 3, 6,
-                                                  6, 6, 11, 14, 14, 14}})));
 
   stan::math::var(vi4).grad();
 }

--- a/test/unit/math/rev/functor/adj_jac_apply_test.cpp
+++ b/test/unit/math/rev/functor/adj_jac_apply_test.cpp
@@ -462,8 +462,7 @@ auto make_vari_for_test(const Targs&... args) {
   return vi;
 }
 
-TEST(AgradRev,
-     test_weird_argument_list_functor_compiles_and_sets_is_var_) {
+TEST(AgradRev, test_weird_argument_list_functor_compiles_and_sets_is_var_) {
   int i;
   double d;
   stan::math::var v(5.0);


### PR DESCRIPTION
`count_vars` and `save_varis` dropped in directly. The `accumulate_adjoints` here was doing something different from the `accumulate_adjoints` we have.

In the one we have, we're taking adjoints from varis and saving them in an array of doubles.

In the one here, we're taking adjoints from data structures that use doubles and accumulating them in an array of varis.

## Checklist

- [ ] Math issue #(issue number)

- [x] Copyright holder: Columbia Unversity

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [ ] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [ ] the code is written in idiomatic C++ and changes are documented in the doxygen

- [ ] the new changes are tested
