### PR TITLE
Switched ode solvers and algebra solvers to use domain_errors

### DIFF
--- a/stan/math/prim/err/check_flag_sundials.hpp
+++ b/stan/math/prim/err/check_flag_sundials.hpp
@@ -8,8 +8,12 @@ namespace stan {
 namespace math {
 
 /**
- * Throws an exception when a Sundial function fails
+ * Throws a std::runtime_error exception when a Sundial function fails
  * (i.e. returns a negative flag)
+ *
+ * @param flag Error flag
+ * @param func_name Name of the function that returned the flag
+ * @throw <code>std::runtime_error</code> if the flag is negative
  */
 inline void check_flag_sundials(int flag, const char* func_name) {
   if (flag < 0) {
@@ -24,6 +28,13 @@ inline void check_flag_sundials(int flag, const char* func_name) {
  * (call to the solver) fails. When the exception is caused
  * by a tuning parameter the user controls, gives a specific
  * error.
+ *
+ * @param flag Error flag
+ * @param func_name Name of the function that returned the flag
+ * @throw <code>std::domain_error</code> if flag means maximum number of
+ *   iterations exceeded in the algebra solver.
+ * @throw <code>std::runtime_error</code> if the flag is negative for
+ *   any other reason.
  */
 inline void check_flag_kinsol(int flag,
                               long int max_num_steps) {  // NOLINT(runtime/int)

--- a/stan/math/prim/err/check_flag_sundials.hpp
+++ b/stan/math/prim/err/check_flag_sundials.hpp
@@ -30,7 +30,7 @@ inline void check_flag_kinsol(int flag,
   if (flag == -6) {
     ss << "algebra_solver: max number of iterations: " << max_num_steps
        << " exceeded.";
-    throw std::runtime_error(ss.str());
+    throw std::domain_error(ss.str());
   } else if (flag < 0) {
     ss << "algebra_solver failed with error flag " << flag << ".";
     throw std::runtime_error(ss.str());

--- a/stan/math/prim/err/check_flag_sundials.hpp
+++ b/stan/math/prim/err/check_flag_sundials.hpp
@@ -30,7 +30,8 @@ inline void check_flag_sundials(int flag, const char* func_name) {
  * error.
  *
  * @param flag Error flag
- * @param func_name Name of the function that returned the flag
+ * @param max_num_steps Maximum number of iterations the algebra solver
+ *   should take before throwing an error
  * @throw <code>std::domain_error</code> if flag means maximum number of
  *   iterations exceeded in the algebra solver.
  * @throw <code>std::runtime_error</code> if the flag is negative for

--- a/stan/math/prim/err/check_flag_sundials.hpp
+++ b/stan/math/prim/err/check_flag_sundials.hpp
@@ -28,9 +28,7 @@ inline void check_flag_kinsol(int flag,
                               long int max_num_steps) {  // NOLINT(runtime/int)
   std::ostringstream ss;
   if (flag == -6) {
-    ss << "algebra_solver: max number of iterations: " << max_num_steps
-       << " exceeded.";
-    throw std::domain_error(ss.str());
+    throw_domain_error("algebra_solver", "maximum number of iterations", max_num_steps, "(", ") was exceeded in the solve.");
   } else if (flag < 0) {
     ss << "algebra_solver failed with error flag " << flag << ".";
     throw std::runtime_error(ss.str());

--- a/stan/math/prim/err/check_flag_sundials.hpp
+++ b/stan/math/prim/err/check_flag_sundials.hpp
@@ -2,6 +2,7 @@
 #define STAN_MATH_PRIM_ERR_CHECK_FLAG_SUNDIALS_HPP
 
 #include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/err/throw_domain_error.hpp>
 
 namespace stan {
 namespace math {

--- a/stan/math/prim/functor/integrate_ode_rk45.hpp
+++ b/stan/math/prim/functor/integrate_ode_rk45.hpp
@@ -76,8 +76,8 @@ std::vector<std::vector<return_type_t<T1, T2, T_t0, T_ts>>> integrate_ode_rk45(
   using boost::numeric::odeint::integrate_times;
   using boost::numeric::odeint::make_dense_output;
   using boost::numeric::odeint::max_step_checker;
-  using boost::numeric::odeint::runge_kutta_dopri5;
   using boost::numeric::odeint::no_progress_error;
+  using boost::numeric::odeint::runge_kutta_dopri5;
 
   const double t0_dbl = value_of(t0);
   const std::vector<double> ts_dbl = value_of(ts);
@@ -138,14 +138,16 @@ std::vector<std::vector<return_type_t<T1, T2, T_t0, T_ts>>> integrate_ode_rk45(
   const double step_size = 0.1;
   try {
     integrate_times(
-		    make_dense_output(absolute_tolerance, relative_tolerance,
-				      runge_kutta_dopri5<std::vector<double>, double,
-				      std::vector<double>, double>()),
-		    std::ref(coupled_system), initial_coupled_state, std::begin(ts_vec),
-		    std::end(ts_vec), step_size, filtered_observer,
-		    max_step_checker(max_num_steps));
-  } catch(no_progress_error &e) {
-    throw_domain_error("integrate_ode_rk45", "", ts_vec[timestep + 1], "Failed to integrate to next output time (", ") in less than max_num_steps steps");
+        make_dense_output(absolute_tolerance, relative_tolerance,
+                          runge_kutta_dopri5<std::vector<double>, double,
+                                             std::vector<double>, double>()),
+        std::ref(coupled_system), initial_coupled_state, std::begin(ts_vec),
+        std::end(ts_vec), step_size, filtered_observer,
+        max_step_checker(max_num_steps));
+  } catch (no_progress_error& e) {
+    throw_domain_error("integrate_ode_rk45", "", ts_vec[timestep + 1],
+                       "Failed to integrate to next output time (",
+                       ") in less than max_num_steps steps");
   }
 
   return y;

--- a/stan/math/prim/functor/integrate_ode_rk45.hpp
+++ b/stan/math/prim/functor/integrate_ode_rk45.hpp
@@ -77,6 +77,7 @@ std::vector<std::vector<return_type_t<T1, T2, T_t0, T_ts>>> integrate_ode_rk45(
   using boost::numeric::odeint::make_dense_output;
   using boost::numeric::odeint::max_step_checker;
   using boost::numeric::odeint::runge_kutta_dopri5;
+  using boost::numeric::odeint::no_progress_error;
 
   const double t0_dbl = value_of(t0);
   const std::vector<double> ts_dbl = value_of(ts);
@@ -120,6 +121,7 @@ std::vector<std::vector<return_type_t<T1, T2, T_t0, T_ts>>> integrate_ode_rk45(
 
   // avoid recording of the initial state which is included by the
   // conventions of odeint in the output
+  size_t timestep = 0;
   auto filtered_observer
       = [&](const std::vector<double>& coupled_state, double t) -> void {
     if (!observer_initial_recorded) {
@@ -127,19 +129,24 @@ std::vector<std::vector<return_type_t<T1, T2, T_t0, T_ts>>> integrate_ode_rk45(
       return;
     }
     observer(coupled_state, t);
+    timestep++;
   };
 
   // the coupled system creates the coupled initial state
   std::vector<double> initial_coupled_state = coupled_system.initial_state();
 
   const double step_size = 0.1;
-  integrate_times(
-      make_dense_output(absolute_tolerance, relative_tolerance,
-                        runge_kutta_dopri5<std::vector<double>, double,
-                                           std::vector<double>, double>()),
-      std::ref(coupled_system), initial_coupled_state, std::begin(ts_vec),
-      std::end(ts_vec), step_size, filtered_observer,
-      max_step_checker(max_num_steps));
+  try {
+    integrate_times(
+		    make_dense_output(absolute_tolerance, relative_tolerance,
+				      runge_kutta_dopri5<std::vector<double>, double,
+				      std::vector<double>, double>()),
+		    std::ref(coupled_system), initial_coupled_state, std::begin(ts_vec),
+		    std::end(ts_vec), step_size, filtered_observer,
+		    max_step_checker(max_num_steps));
+  } catch(no_progress_error &e) {
+    throw_domain_error("integrate_ode_rk45", "", ts_vec[timestep + 1], "Failed to integrate to next output time (", ") in less than max_num_steps steps");
+  }
 
   return y;
 }

--- a/stan/math/prim/functor/integrate_ode_rk45.hpp
+++ b/stan/math/prim/functor/integrate_ode_rk45.hpp
@@ -144,7 +144,7 @@ std::vector<std::vector<return_type_t<T1, T2, T_t0, T_ts>>> integrate_ode_rk45(
         std::ref(coupled_system), initial_coupled_state, std::begin(ts_vec),
         std::end(ts_vec), step_size, filtered_observer,
         max_step_checker(max_num_steps));
-  } catch (no_progress_error& e) {
+  } catch (const no_progress_error& e) {
     throw_domain_error("integrate_ode_rk45", "", ts_vec[timestep + 1],
                        "Failed to integrate to next output time (",
                        ") in less than max_num_steps steps");

--- a/stan/math/rev/functor/algebra_solver_newton.hpp
+++ b/stan/math/rev/functor/algebra_solver_newton.hpp
@@ -52,8 +52,7 @@ namespace math {
  * @throw <code>std::invalid_argument</code> if function_tolerance is strictly
  * negative.
  * @throw <code>std::invalid_argument</code> if max_num_steps is not positive.
- * @throw <code>boost::math::evaluation_error</code> (which is a subclass of
- * <code>std::runtime_error</code>) if solver exceeds max_num_steps.
+ * @throw <code>std::domain_error</code> if solver exceeds max_num_steps.
  */
 template <typename F, typename T>
 Eigen::VectorXd algebra_solver_newton(
@@ -115,8 +114,7 @@ Eigen::VectorXd algebra_solver_newton(
  * @throw <code>std::invalid_argument</code> if function_tolerance is strictly
  * negative.
  * @throw <code>std::invalid_argument</code> if max_num_steps is not positive.
- * @throw <code>boost::math::evaluation_error</code> (which is a subclass of
- * <code>std::runtime_error</code>) if solver exceeds max_num_steps.
+ * @throw <code>std::domain_error if solver exceeds max_num_steps.
  */
 template <typename F, typename T1, typename T2>
 Eigen::Matrix<T2, Eigen::Dynamic, 1> algebra_solver_newton(

--- a/stan/math/rev/functor/algebra_solver_powell.hpp
+++ b/stan/math/rev/functor/algebra_solver_powell.hpp
@@ -118,11 +118,9 @@ struct algebra_solver_vari : public vari {
  * @throw <code>std::invalid_argument</code> if function_tolerance is strictly
  * negative.
  * @throw <code>std::invalid_argument</code> if max_num_steps is not positive.
- * @throw <code>boost::math::evaluation_error</code> (which is a subclass of
- * <code>std::runtime_error</code>) if solver exceeds max_num_steps.
- * @throw <code>boost::math::evaluation_error</code> (which is a subclass of
- * <code>std::runtime_error</code>) if the norm of the solution exceeds the
- * function tolerance.
+ * @throw <code>std::domain_error</code> solver exceeds max_num_steps.
+ * @throw <code>std::domain_error</code> if the norm of the solution exceeds
+ * the function tolerance.
  */
 template <typename F, typename T>
 Eigen::VectorXd algebra_solver_powell(
@@ -157,22 +155,17 @@ Eigen::VectorXd algebra_solver_powell(
 
   // Check if the max number of steps has been exceeded
   if (solver.nfev >= max_num_steps) {
-    std::ostringstream message;
-    message << "algebra_solver: max number of iterations: " << max_num_steps
-            << " exceeded.";
-    throw std::domain_error(message.str());
+    throw_domain_error("algebra_solver", "maximum number of iterations", max_num_steps, "(", ") was exceeded in the solve.");
   }
 
   // Check solution is a root
   double system_norm = fx.get_value(theta_dbl).stableNorm();
   if (system_norm > function_tolerance) {
-    std::ostringstream message2;
-    message2 << "algebra_solver: the norm of the algebraic function is: "
-             << system_norm << " but should be lower than the function "
-             << "tolerance: " << function_tolerance << ". Consider "
-             << "decreasing the relative tolerance and increasing the "
-             << "max_num_steps.";
-    throw std::domain_error(message2.str());
+    std::ostringstream message;
+    message << "the norm of the algebraic function is "
+	    << system_norm << " but should be lower than the function "
+	    << "tolerance:";
+    throw_domain_error("algebra_solver",  message.str().c_str(), function_tolerance, "", ". Consider decreasing the relative tolerance and increasing max_num_steps.");
   }
 
   return theta_dbl;
@@ -219,11 +212,9 @@ Eigen::VectorXd algebra_solver_powell(
  * @throw <code>std::invalid_argument</code> if function_tolerance is strictly
  * negative.
  * @throw <code>std::invalid_argument</code> if max_num_steps is not positive.
- * @throw <code>boost::math::evaluation_error</code> (which is a subclass of
- * <code>std::runtime_error</code>) if solver exceeds max_num_steps.
- * @throw <code>boost::math::evaluation_error</code> (which is a subclass of
- * <code>std::runtime_error</code>) if the norm of the solution exceeds the
- * function tolerance.
+ * @throw <code>std::domain_error</code> solver exceeds max_num_steps.
+ * @throw <code>std::domain_error</code> if the norm of the solution exceeds
+ * the function tolerance.
  */
 template <typename F, typename T1, typename T2>
 Eigen::Matrix<T2, Eigen::Dynamic, 1> algebra_solver_powell(
@@ -299,9 +290,9 @@ Eigen::Matrix<T2, Eigen::Dynamic, 1> algebra_solver_powell(
  * negative.
  * @throw <code>std::invalid_argument</code> if max_num_steps is not positive.
  * @throw <code>boost::math::evaluation_error</code> (which is a subclass of
- * <code>std::runtime_error</code>) if solver exceeds max_num_steps.
+ * <code>std::domain_error</code>) if solver exceeds max_num_steps.
  * @throw <code>boost::math::evaluation_error</code> (which is a subclass of
- * <code>std::runtime_error</code>) if the norm of the solution exceeds the
+ * <code>std::domain_error</code>) if the norm of the solution exceeds the
  * function tolerance.
  */
 template <typename F, typename T1, typename T2>

--- a/stan/math/rev/functor/algebra_solver_powell.hpp
+++ b/stan/math/rev/functor/algebra_solver_powell.hpp
@@ -160,7 +160,7 @@ Eigen::VectorXd algebra_solver_powell(
     std::ostringstream message;
     message << "algebra_solver: max number of iterations: " << max_num_steps
             << " exceeded.";
-    throw boost::math::evaluation_error(message.str());
+    throw std::domain_error(message.str());
   }
 
   // Check solution is a root
@@ -172,7 +172,7 @@ Eigen::VectorXd algebra_solver_powell(
              << "tolerance: " << function_tolerance << ". Consider "
              << "decreasing the relative tolerance and increasing the "
              << "max_num_steps.";
-    throw boost::math::evaluation_error(message2.str());
+    throw std::domain_error(message2.str());
   }
 
   return theta_dbl;

--- a/stan/math/rev/functor/cvodes_integrator.hpp
+++ b/stan/math/rev/functor/cvodes_integrator.hpp
@@ -83,7 +83,7 @@ class cvodes_integrator {
 
     const char* fun;
 
-    if(Lmm == CV_BDF) {
+    if (Lmm == CV_BDF) {
       fun = "integrate_ode_bdf";
     } else {
       fun = "integrate_ode_adams";
@@ -102,16 +102,16 @@ class cvodes_integrator {
     check_ordered(fun, "times", ts_dbl);
     check_less(fun, "initial time", t0_dbl, ts_dbl[0]);
     if (relative_tolerance <= 0) {
-      invalid_argument(fun, "relative_tolerance,",
-                       relative_tolerance, "", ", must be greater than 0");
+      invalid_argument(fun, "relative_tolerance,", relative_tolerance, "",
+                       ", must be greater than 0");
     }
     if (absolute_tolerance <= 0) {
-      invalid_argument(fun, "absolute_tolerance,",
-                       absolute_tolerance, "", ", must be greater than 0");
+      invalid_argument(fun, "absolute_tolerance,", absolute_tolerance, "",
+                       ", must be greater than 0");
     }
     if (max_num_steps <= 0) {
-      invalid_argument(fun, "max_num_steps,", max_num_steps,
-                       "", ", must be greater than 0");
+      invalid_argument(fun, "max_num_steps,", max_num_steps, "",
+                       ", must be greater than 0");
     }
 
     const size_t N = y0.size();
@@ -171,12 +171,14 @@ class cvodes_integrator {
       for (size_t n = 0; n < ts.size(); ++n) {
         double t_final = ts_dbl[n];
         if (t_final != t_init) {
-          int ret = CVode(cvodes_mem, t_final, cvodes_data.nv_state_,
-			      &t_init, CV_NORMAL);
+          int ret = CVode(cvodes_mem, t_final, cvodes_data.nv_state_, &t_init,
+                          CV_NORMAL);
 
-	  if(ret == CV_TOO_MUCH_WORK) {
-	    throw_domain_error(fun, "", t_final, "Failed to integrate to next output time (" ,") in less than max_num_steps steps");
-	  }
+          if (ret == CV_TOO_MUCH_WORK) {
+            throw_domain_error(fun, "", t_final,
+                               "Failed to integrate to next output time (",
+                               ") in less than max_num_steps steps");
+          }
         }
         if (S > 0) {
           check_flag_sundials(

--- a/stan/math/rev/functor/cvodes_integrator.hpp
+++ b/stan/math/rev/functor/cvodes_integrator.hpp
@@ -72,7 +72,7 @@ class cvodes_integrator {
   template <typename F, typename T_initial, typename T_param, typename T_t0,
             typename T_ts>
   std::vector<std::vector<return_type_t<T_initial, T_param, T_t0, T_ts>>>
-  integrate(const F& f, const std::vector<T_initial>& y0, const T_t0& t0,
+  integrate(const char* fun, const F& f, const std::vector<T_initial>& y0, const T_t0& t0,
             const std::vector<T_ts>& ts, const std::vector<T_param>& theta,
             const std::vector<double>& x, const std::vector<int>& x_int,
             std::ostream* msgs, double relative_tolerance,
@@ -80,14 +80,6 @@ class cvodes_integrator {
             long int max_num_steps) {  // NOLINT(runtime/int)
     using initial_var = stan::is_var<T_initial>;
     using param_var = stan::is_var<T_param>;
-
-    const char* fun;
-
-    if (Lmm == CV_BDF) {
-      fun = "integrate_ode_bdf";
-    } else {
-      fun = "integrate_ode_adams";
-    }
 
     const double t0_dbl = value_of(t0);
     const std::vector<double> ts_dbl = value_of(ts);

--- a/stan/math/rev/functor/cvodes_integrator.hpp
+++ b/stan/math/rev/functor/cvodes_integrator.hpp
@@ -68,7 +68,12 @@ class cvodes_integrator {
    * @param[in] max_num_steps maximal number of admissable steps
    * between time-points
    * @return a vector of states, each state being a vector of the
-   * same size as the state variable, corresponding to a time in ts.
+   *   same size as the state variable, corresponding to a time in ts.
+   * @throw <code>std::domain_error</code> if y0, t0, ts, theta, x are not
+   *   finite, all elements of ts are not greater than t0, or ts is not
+   *   sorted in strictly increasing order.
+   * @throw <code>std::invalid_argument</code> if arguments are the wrong
+   *   size or tolerances or max_num_steps are out of range.
    */
   template <typename F, typename T_initial, typename T_param, typename T_t0,
             typename T_ts>

--- a/stan/math/rev/functor/cvodes_integrator.hpp
+++ b/stan/math/rev/functor/cvodes_integrator.hpp
@@ -53,6 +53,7 @@ class cvodes_integrator {
    * @tparam T_t0 type of scalar of initial time point.
    * @tparam T_ts type of time-points where ODE solution is returned.
    *
+   * @param[in] function_name name of function for error messages
    * @param[in] f functor for the base ordinary differential equation.
    * @param[in] y0 initial state.
    * @param[in] t0 initial time.
@@ -72,7 +73,7 @@ class cvodes_integrator {
   template <typename F, typename T_initial, typename T_param, typename T_t0,
             typename T_ts>
   std::vector<std::vector<return_type_t<T_initial, T_param, T_t0, T_ts>>>
-  integrate(const char* fun, const F& f, const std::vector<T_initial>& y0, const T_t0& t0,
+  integrate(const char* function_name, const F& f, const std::vector<T_initial>& y0, const T_t0& t0,
             const std::vector<T_ts>& ts, const std::vector<T_param>& theta,
             const std::vector<double>& x, const std::vector<int>& x_int,
             std::ostream* msgs, double relative_tolerance,
@@ -84,25 +85,25 @@ class cvodes_integrator {
     const double t0_dbl = value_of(t0);
     const std::vector<double> ts_dbl = value_of(ts);
 
-    check_finite(fun, "initial state", y0);
-    check_finite(fun, "initial time", t0_dbl);
-    check_finite(fun, "times", ts_dbl);
-    check_finite(fun, "parameter vector", theta);
-    check_finite(fun, "continuous data", x);
-    check_nonzero_size(fun, "times", ts);
-    check_nonzero_size(fun, "initial state", y0);
-    check_ordered(fun, "times", ts_dbl);
-    check_less(fun, "initial time", t0_dbl, ts_dbl[0]);
+    check_finite(function_name, "initial state", y0);
+    check_finite(function_name, "initial time", t0_dbl);
+    check_finite(function_name, "times", ts_dbl);
+    check_finite(function_name, "parameter vector", theta);
+    check_finite(function_name, "continuous data", x);
+    check_nonzero_size(function_name, "times", ts);
+    check_nonzero_size(function_name, "initial state", y0);
+    check_ordered(function_name, "times", ts_dbl);
+    check_less(function_name, "initial time", t0_dbl, ts_dbl[0]);
     if (relative_tolerance <= 0) {
-      invalid_argument(fun, "relative_tolerance,", relative_tolerance, "",
+      invalid_argument(function_name, "relative_tolerance,", relative_tolerance, "",
                        ", must be greater than 0");
     }
     if (absolute_tolerance <= 0) {
-      invalid_argument(fun, "absolute_tolerance,", absolute_tolerance, "",
+      invalid_argument(function_name, "absolute_tolerance,", absolute_tolerance, "",
                        ", must be greater than 0");
     }
     if (max_num_steps <= 0) {
-      invalid_argument(fun, "max_num_steps,", max_num_steps, "",
+      invalid_argument(function_name, "max_num_steps,", max_num_steps, "",
                        ", must be greater than 0");
     }
 
@@ -167,7 +168,7 @@ class cvodes_integrator {
                           CV_NORMAL);
 
           if (ret == CV_TOO_MUCH_WORK) {
-            throw_domain_error(fun, "", t_final,
+            throw_domain_error(function_name, "", t_final,
                                "Failed to integrate to next output time (",
                                ") in less than max_num_steps steps");
           }

--- a/stan/math/rev/functor/integrate_ode_adams.hpp
+++ b/stan/math/rev/functor/integrate_ode_adams.hpp
@@ -21,7 +21,7 @@ integrate_ode_adams(const F& f, const std::vector<T_initial>& y0,
                     double absolute_tolerance = 1e-10,
                     long int max_num_steps = 1e8) {  // NOLINT(runtime/int)
   stan::math::cvodes_integrator<CV_ADAMS> integrator;
-  return integrator.integrate(f, y0, t0, ts, theta, x, x_int, msgs,
+  return integrator.integrate("integrate_ode_adams", f, y0, t0, ts, theta, x, x_int, msgs,
                               relative_tolerance, absolute_tolerance,
                               max_num_steps);
 }

--- a/stan/math/rev/functor/integrate_ode_bdf.hpp
+++ b/stan/math/rev/functor/integrate_ode_bdf.hpp
@@ -21,7 +21,7 @@ integrate_ode_bdf(const F& f, const std::vector<T_initial>& y0, const T_t0& t0,
                   double absolute_tolerance = 1e-10,
                   long int max_num_steps = 1e8) {  // NOLINT(runtime/int)
   stan::math::cvodes_integrator<CV_BDF> integrator;
-  return integrator.integrate(f, y0, t0, ts, theta, x, x_int, msgs,
+  return integrator.integrate("integrate_ode_bdf", f, y0, t0, ts, theta, x, x_int, msgs,
                               relative_tolerance, absolute_tolerance,
                               max_num_steps);
 }

--- a/stan/math/rev/functor/kinsol_solve.hpp
+++ b/stan/math/rev/functor/kinsol_solve.hpp
@@ -50,8 +50,10 @@ namespace math {
  * @return x_solution Vector of solutions to the system of equations.
  * @throw <code>std::invalid_argument</code> if Kinsol returns a negative
  *        flag when setting up the solver.
- * @throw <code>boost::math::evaluation_error</code> if Kinsol returns a
- *        negative flag after attempting to solve the equation.
+ * @throw <code>std::domain_error</code> if Kinsol fails to solve
+ *        equation in max_num_steps iterations.
+ * @throw <code>std::runtime_error</code> if Kinsol returns a
+ *        negative flag that is not due to hitting max_num_steps.
  */
 template <typename F1, typename F2 = kinsol_J_f>
 Eigen::VectorXd kinsol_solve(

--- a/test/unit/math/rev/functor/algebra_solver_fp_test.cpp
+++ b/test/unit/math/rev/functor/algebra_solver_fp_test.cpp
@@ -527,7 +527,7 @@ TEST_F(FP_2d_func_test, exception_handling) {
     std::string msg = err_msg.str();
     EXPECT_THROW_MSG(algebra_solver_fp(f, x, y, x_r, x_i, u_scale, f_scale, 0,
                                        f_tol, max_num_steps),  // NOLINT
-                     std::runtime_error, msg);
+                     std::domain_error, msg);
   }
 
   {

--- a/test/unit/math/rev/functor/algebra_solver_fp_test.cpp
+++ b/test/unit/math/rev/functor/algebra_solver_fp_test.cpp
@@ -523,7 +523,8 @@ TEST_F(FP_2d_func_test, exception_handling) {
 
   {
     std::stringstream err_msg;
-    err_msg << "algebra_solver: maximum number of iterations (4) was exceeded in the solve.";
+    err_msg << "algebra_solver: maximum number of iterations (4) was exceeded "
+               "in the solve.";
     std::string msg = err_msg.str();
     EXPECT_THROW_MSG(algebra_solver_fp(f, x, y, x_r, x_i, u_scale, f_scale, 0,
                                        f_tol, max_num_steps),  // NOLINT

--- a/test/unit/math/rev/functor/algebra_solver_fp_test.cpp
+++ b/test/unit/math/rev/functor/algebra_solver_fp_test.cpp
@@ -523,7 +523,7 @@ TEST_F(FP_2d_func_test, exception_handling) {
 
   {
     std::stringstream err_msg;
-    err_msg << "algebra_solver: max number of iterations: 4 exceeded.";
+    err_msg << "algebra_solver: maximum number of iterations (4) was exceeded in the solve.";
     std::string msg = err_msg.str();
     EXPECT_THROW_MSG(algebra_solver_fp(f, x, y, x_r, x_i, u_scale, f_scale, 0,
                                        f_tol, max_num_steps),  // NOLINT

--- a/test/unit/math/rev/functor/integrate_ode_adams_prim_test.cpp
+++ b/test/unit/math/rev/functor/integrate_ode_adams_prim_test.cpp
@@ -393,10 +393,11 @@ TEST(StanMathOde_integrate_ode_bdf, too_much_work) {
 
   EXPECT_THROW_MSG(
       stan::math::integrate_ode_adams(f_, y0, t0, ts_long, theta, data,
-				      data_int, 0, 1E-6, 1E-6, 100),
+                                      data_int, 0, 1E-6, 1E-6, 100),
       std::domain_error,
-      "integrate_ode_adams:  Failed to integrate to next output time (1e+10) in less than max_num_steps steps");
+      "integrate_ode_adams:  Failed to integrate to next output time (1e+10) "
+      "in less than max_num_steps steps");
 
   EXPECT_NO_THROW(stan::math::integrate_ode_bdf(
-    f_, y0, t0, ts_short, theta, data, data_int, 0, 1E-6, 1E-6, 100));
+      f_, y0, t0, ts_short, theta, data, data_int, 0, 1E-6, 1E-6, 100));
 }

--- a/test/unit/math/rev/functor/integrate_ode_adams_prim_test.cpp
+++ b/test/unit/math/rev/functor/integrate_ode_adams_prim_test.cpp
@@ -395,8 +395,7 @@ TEST(StanMathOde_integrate_ode_adams, too_much_work) {
       stan::math::integrate_ode_adams(f_, y0, t0, ts_long, theta, data,
                                       data_int, 0, 1E-6, 1E-6, 100),
       std::domain_error,
-      "integrate_ode_adams:  Failed to integrate to next output time (1e+10) "
-      "in less than max_num_steps steps");
+      "integrate_ode_adams:  Failed to integrate to next output time");
 
   EXPECT_NO_THROW(stan::math::integrate_ode_bdf(
       f_, y0, t0, ts_short, theta, data, data_int, 0, 1E-6, 1E-6, 100));

--- a/test/unit/math/rev/functor/integrate_ode_adams_prim_test.cpp
+++ b/test/unit/math/rev/functor/integrate_ode_adams_prim_test.cpp
@@ -2,6 +2,7 @@
 #include <boost/numeric/odeint.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/math/prim/functor/harmonic_oscillator.hpp>
+#include <test/unit/math/rev/functor/coupled_mm.hpp>
 #include <test/unit/util.hpp>
 #include <iostream>
 #include <sstream>
@@ -361,4 +362,41 @@ TEST(StanMathOde_integrate_ode_adams, error_conditions_bad_ode) {
   EXPECT_THROW_MSG(integrate_ode_adams(harm_osc, y0, t0, ts, theta, x, x_int, 0,
                                        1e-8, 1e-10, 1e6),
                    std::invalid_argument, error_msg);
+}
+
+TEST(StanMathOde_integrate_ode_bdf, too_much_work) {
+  coupled_mm_ode_fun f_;
+
+  // initial value and parameters from model definition
+  std::vector<double> y0(2);
+  y0[0] = 1E5;
+  y0[1] = 1E-1;
+
+  double t0 = 0;
+
+  std::vector<double> ts_long;
+  ts_long.push_back(1E10);
+
+  std::vector<double> ts_short;
+  ts_short.push_back(1);
+
+  std::vector<double> theta(4);
+
+  theta[0] = 1.0;
+  theta[1] = 0.5;
+  theta[2] = 0.5;
+  theta[3] = 0.1;
+
+  std::vector<double> data;
+
+  std::vector<int> data_int;
+
+  EXPECT_THROW_MSG(
+      stan::math::integrate_ode_adams(f_, y0, t0, ts_long, theta, data,
+				      data_int, 0, 1E-6, 1E-6, 100),
+      std::domain_error,
+      "integrate_ode_adams:  Failed to integrate to next output time (1e+10) in less than max_num_steps steps");
+
+  EXPECT_NO_THROW(stan::math::integrate_ode_bdf(
+    f_, y0, t0, ts_short, theta, data, data_int, 0, 1E-6, 1E-6, 100));
 }

--- a/test/unit/math/rev/functor/integrate_ode_adams_prim_test.cpp
+++ b/test/unit/math/rev/functor/integrate_ode_adams_prim_test.cpp
@@ -364,7 +364,7 @@ TEST(StanMathOde_integrate_ode_adams, error_conditions_bad_ode) {
                    std::invalid_argument, error_msg);
 }
 
-TEST(StanMathOde_integrate_ode_bdf, too_much_work) {
+TEST(StanMathOde_integrate_ode_adams, too_much_work) {
   coupled_mm_ode_fun f_;
 
   // initial value and parameters from model definition

--- a/test/unit/math/rev/functor/integrate_ode_bdf_prim_test.cpp
+++ b/test/unit/math/rev/functor/integrate_ode_bdf_prim_test.cpp
@@ -391,11 +391,12 @@ TEST(StanMathOde_integrate_ode_bdf, too_much_work) {
   std::vector<int> data_int;
 
   EXPECT_THROW_MSG(
-      stan::math::integrate_ode_bdf(f_, y0, t0, ts_long, theta, data,
-                                     data_int, 0, 1E-6, 1E-6, 100),
+      stan::math::integrate_ode_bdf(f_, y0, t0, ts_long, theta, data, data_int,
+                                    0, 1E-6, 1E-6, 100),
       std::domain_error,
-      "integrate_ode_bdf:  Failed to integrate to next output time (1e+10) in less than max_num_steps steps");
+      "integrate_ode_bdf:  Failed to integrate to next output time (1e+10) in "
+      "less than max_num_steps steps");
 
   EXPECT_NO_THROW(stan::math::integrate_ode_bdf(
-    f_, y0, t0, ts_short, theta, data, data_int, 0, 1E-6, 1E-6, 100));
+      f_, y0, t0, ts_short, theta, data, data_int, 0, 1E-6, 1E-6, 100));
 }

--- a/test/unit/math/rev/functor/integrate_ode_bdf_prim_test.cpp
+++ b/test/unit/math/rev/functor/integrate_ode_bdf_prim_test.cpp
@@ -2,6 +2,7 @@
 #include <boost/numeric/odeint.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/math/prim/functor/harmonic_oscillator.hpp>
+#include <test/unit/math/rev/functor/coupled_mm.hpp>
 #include <test/unit/util.hpp>
 #include <iostream>
 #include <sstream>
@@ -360,4 +361,41 @@ TEST(StanMathOde_integrate_ode_bdf, error_conditions_bad_ode) {
   EXPECT_THROW_MSG(integrate_ode_bdf(harm_osc, y0, t0, ts, theta, x, x_int, 0,
                                      1e-8, 1e-10, 1e6),
                    std::invalid_argument, error_msg);
+}
+
+TEST(StanMathOde_integrate_ode_bdf, too_much_work) {
+  coupled_mm_ode_fun f_;
+
+  // initial value and parameters from model definition
+  std::vector<double> y0(2);
+  y0[0] = 1E5;
+  y0[1] = 1E-1;
+
+  double t0 = 0;
+
+  std::vector<double> ts_long;
+  ts_long.push_back(1E10);
+
+  std::vector<double> ts_short;
+  ts_short.push_back(1);
+
+  std::vector<double> theta(4);
+
+  theta[0] = 1.0;
+  theta[1] = 0.5;
+  theta[2] = 0.5;
+  theta[3] = 0.1;
+
+  std::vector<double> data;
+
+  std::vector<int> data_int;
+
+  EXPECT_THROW_MSG(
+      stan::math::integrate_ode_bdf(f_, y0, t0, ts_long, theta, data,
+                                     data_int, 0, 1E-6, 1E-6, 100),
+      std::domain_error,
+      "integrate_ode_bdf:  Failed to integrate to next output time (1e+10) in less than max_num_steps steps");
+
+  EXPECT_NO_THROW(stan::math::integrate_ode_bdf(
+    f_, y0, t0, ts_short, theta, data, data_int, 0, 1E-6, 1E-6, 100));
 }

--- a/test/unit/math/rev/functor/integrate_ode_bdf_prim_test.cpp
+++ b/test/unit/math/rev/functor/integrate_ode_bdf_prim_test.cpp
@@ -394,8 +394,7 @@ TEST(StanMathOde_integrate_ode_bdf, too_much_work) {
       stan::math::integrate_ode_bdf(f_, y0, t0, ts_long, theta, data, data_int,
                                     0, 1E-6, 1E-6, 100),
       std::domain_error,
-      "integrate_ode_bdf:  Failed to integrate to next output time (1e+10) in "
-      "less than max_num_steps steps");
+      "integrate_ode_bdf:  Failed to integrate to next output time");
 
   EXPECT_NO_THROW(stan::math::integrate_ode_bdf(
       f_, y0, t0, ts_short, theta, data, data_int, 0, 1E-6, 1E-6, 100));

--- a/test/unit/math/rev/functor/integrate_ode_rk45_tooMuchWork_test.cpp
+++ b/test/unit/math/rev/functor/integrate_ode_rk45_tooMuchWork_test.cpp
@@ -37,9 +37,9 @@ TEST(StanOde_tooMuchWork_test, odeint_coupled_mm) {
   EXPECT_THROW_MSG(
       stan::math::integrate_ode_rk45(f_, y0_v, t0, ts_long, theta_v, data,
                                      data_int, 0, 1E-6, 1E-6, 100),
-      boost::numeric::odeint::no_progress_error,
-      "Max number of iterations exceeded (100).");
+      std::domain_error,
+      "Failed to integrate to next output time (1e+10) in less than max_num_steps steps");
 
   EXPECT_NO_THROW(stan::math::integrate_ode_rk45(
-      f_, y0_v, t0, ts_short, theta_v, data, data_int, 0, 1E-6, 1E-6, 100));
+    f_, y0_v, t0, ts_short, theta_v, data, data_int, 0, 1E-6, 1E-6, 100));
 }

--- a/test/unit/math/rev/functor/integrate_ode_rk45_tooMuchWork_test.cpp
+++ b/test/unit/math/rev/functor/integrate_ode_rk45_tooMuchWork_test.cpp
@@ -38,8 +38,9 @@ TEST(StanOde_tooMuchWork_test, odeint_coupled_mm) {
       stan::math::integrate_ode_rk45(f_, y0_v, t0, ts_long, theta_v, data,
                                      data_int, 0, 1E-6, 1E-6, 100),
       std::domain_error,
-      "Failed to integrate to next output time (1e+10) in less than max_num_steps steps");
+      "Failed to integrate to next output time (1e+10) in less than "
+      "max_num_steps steps");
 
   EXPECT_NO_THROW(stan::math::integrate_ode_rk45(
-    f_, y0_v, t0, ts_short, theta_v, data, data_int, 0, 1E-6, 1E-6, 100));
+      f_, y0_v, t0, ts_short, theta_v, data, data_int, 0, 1E-6, 1E-6, 100));
 }

--- a/test/unit/math/rev/functor/integrate_ode_rk45_tooMuchWork_test.cpp
+++ b/test/unit/math/rev/functor/integrate_ode_rk45_tooMuchWork_test.cpp
@@ -38,8 +38,7 @@ TEST(StanOde_tooMuchWork_test, odeint_coupled_mm) {
       stan::math::integrate_ode_rk45(f_, y0_v, t0, ts_long, theta_v, data,
                                      data_int, 0, 1E-6, 1E-6, 100),
       std::domain_error,
-      "Failed to integrate to next output time (1e+10) in less than "
-      "max_num_steps steps");
+      "integrate_ode_rk45:  Failed to integrate to next output time");
 
   EXPECT_NO_THROW(stan::math::integrate_ode_rk45(
       f_, y0_v, t0, ts_short, theta_v, data, data_int, 0, 1E-6, 1E-6, 100));

--- a/test/unit/math/rev/functor/util_algebra_solver.hpp
+++ b/test/unit/math/rev/functor/util_algebra_solver.hpp
@@ -251,12 +251,12 @@ void inline unsolvable_test(Eigen::Matrix<T, Eigen::Dynamic, 1>& y,
   int max_num_steps = 1e+3;
 
   std::stringstream err_msg;
-  err_msg << "algebra_solver: the norm of the algebraic function is: "
+  err_msg << "algebra_solver: the norm of the algebraic function is "
           << 1.41421  // sqrt(2)
           << " but should be lower than the function tolerance: "
           << function_tolerance
           << ". Consider decreasing the relative tolerance and increasing"
-          << " the max_num_steps.";
+          << " max_num_steps.";
   std::string msg = err_msg.str();
   EXPECT_THROW_MSG(
       general_algebra_solver(is_newton, unsolvable_eq_functor(), x, y, dat,
@@ -293,8 +293,8 @@ inline void max_num_steps_test(Eigen::Matrix<T, Eigen::Dynamic, 1>& y,
   int max_num_steps = 2;  // very low for test
 
   std::stringstream err_msg;
-  err_msg << "algebra_solver: max number of iterations: " << max_num_steps
-          << " exceeded.";
+  err_msg << "algebra_solver: maximum number of iterations (" << max_num_steps
+          << ") was exceeded in the solve.";
   std::string msg = err_msg.str();
   EXPECT_THROW_MSG(
       general_algebra_solver(is_newton, non_linear_eq_functor(), x, y, dat,

--- a/test/unit/math/rev/functor/util_algebra_solver.hpp
+++ b/test/unit/math/rev/functor/util_algebra_solver.hpp
@@ -262,7 +262,7 @@ void inline unsolvable_test(Eigen::Matrix<T, Eigen::Dynamic, 1>& y,
       general_algebra_solver(is_newton, unsolvable_eq_functor(), x, y, dat,
                              dat_int, 0, relative_tolerance, scaling_step_size,
                              function_tolerance, max_num_steps),
-      std::runtime_error, msg);
+      std::domain_error, msg);
 }
 
 template <typename T>
@@ -300,5 +300,5 @@ inline void max_num_steps_test(Eigen::Matrix<T, Eigen::Dynamic, 1>& y,
       general_algebra_solver(is_newton, non_linear_eq_functor(), x, y, dat,
                              dat_int, 0, scaling_step, relative_tolerance,
                              function_tolerance, max_num_steps),
-      std::runtime_error, msg);
+      std::domain_error, msg);
 }


### PR DESCRIPTION
When hitting numeric problems, we want to throw domain_errors instead of runtime_errors cause runtime_errors will stop the chain but domain_errors will allow the chain to retry at different parameters.

This can cause problems at initialization.

I made the changes for the ode solvers and the algebra solvers (even though the issue was just for the ode solvers).

Closes #1887.

## Checklist

- [x] Math issue #1887 

- [x] Copyright holder: Columbia University

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
