### PR TITLE
Binary function vectorisation framework

### DIFF
--- a/stan/math/fwd/fun/Eigen_NumTraits.hpp
+++ b/stan/math/fwd/fun/Eigen_NumTraits.hpp
@@ -53,6 +53,31 @@ struct NumTraits<stan::math::fvar<T>> : GenericNumTraits<stan::math::fvar<T>> {
    */
   static int digits10() { return std::numeric_limits<double>::digits10; }
 };
+/**
+ * Traits specialization for Eigen binary operations for autodiff and
+ * `int` arguments.
+ *
+ * @tparam T value and tangent type of autodiff variable
+ * @tparam BinaryOp type of binary operation for which traits are
+ * defined
+ */
+template <typename T, typename BinaryOp>
+struct ScalarBinaryOpTraits<stan::math::fvar<T>, int, BinaryOp> {
+  using ReturnType = stan::math::fvar<T>;
+};
+
+/**
+ * Traits specialization for Eigen binary operations for `int` and
+ * autodiff arguments.
+ *
+ * @tparam T value and tangent type of autodiff variable
+ * @tparam BinaryOp type of binary operation for which traits are
+ * defined
+ */
+template <typename T, typename BinaryOp>
+struct ScalarBinaryOpTraits<int, stan::math::fvar<T>, BinaryOp> {
+  using ReturnType = stan::math::fvar<T>;
+};
 
 /**
  * Traits specialization for Eigen binary operations for autodiff and

--- a/stan/math/fwd/fun/binary_log_loss.hpp
+++ b/stan/math/fwd/fun/binary_log_loss.hpp
@@ -8,14 +8,19 @@
 namespace stan {
 namespace math {
 
-template <typename T>
-inline fvar<T> binary_log_loss(int y, const fvar<T>& y_hat) {
-  if (y) {
-    return fvar<T>(binary_log_loss(y, y_hat.val_), -y_hat.d_ / y_hat.val_);
-  } else {
-    return fvar<T>(binary_log_loss(y, y_hat.val_),
-                   y_hat.d_ / (1.0 - y_hat.val_));
-  }
+template <typename T1, typename T2, require_st_integral<T1>* = nullptr,
+          require_st_fvar<T2>* = nullptr>
+inline auto binary_log_loss(T1 y, const T2& y_hat) {
+  return apply_scalar_binary<T1, T2>::apply(
+      y, y_hat, [&](const auto& v, const auto& v_hat) {
+        using T = typename scalar_type_t<T2>::Scalar;
+        if (v) {
+          return fvar<T>(binary_log_loss(v, v_hat.val_), -v_hat.d_ / v_hat.val_);
+        } else {
+          return fvar<T>(binary_log_loss(v, v_hat.val_),
+                       v_hat.d_ / (1.0 - v_hat.val_));
+        }
+      });
 }
 }  // namespace math
 }  // namespace stan

--- a/stan/math/fwd/fun/binary_log_loss.hpp
+++ b/stan/math/fwd/fun/binary_log_loss.hpp
@@ -15,10 +15,11 @@ inline auto binary_log_loss(T1 y, const T2& y_hat) {
       y, y_hat, [&](const auto& v, const auto& v_hat) {
         using T = typename scalar_type_t<T2>::Scalar;
         if (v) {
-          return fvar<T>(binary_log_loss(v, v_hat.val_), -v_hat.d_ / v_hat.val_);
+          return fvar<T>(binary_log_loss(v, v_hat.val_),
+                         -v_hat.d_ / v_hat.val_);
         } else {
           return fvar<T>(binary_log_loss(v, v_hat.val_),
-                       v_hat.d_ / (1.0 - v_hat.val_));
+                         v_hat.d_ / (1.0 - v_hat.val_));
         }
       });
 }

--- a/stan/math/prim/fun/Eigen.hpp
+++ b/stan/math/prim/fun/Eigen.hpp
@@ -24,4 +24,16 @@
 #include <Eigen/QR>
 #include <Eigen/src/Core/NumTraits.h>
 
+namespace Eigen {
+template <typename BinaryOp>
+struct ScalarBinaryOpTraits<int, double, BinaryOp> {
+  using ReturnType = double;
+};
+
+template <typename BinaryOp>
+struct ScalarBinaryOpTraits<double, int, BinaryOp> {
+  using ReturnType = double;
+};
+}  // namespace internal
+
 #endif

--- a/stan/math/prim/fun/Eigen.hpp
+++ b/stan/math/prim/fun/Eigen.hpp
@@ -34,6 +34,6 @@ template <typename BinaryOp>
 struct ScalarBinaryOpTraits<double, int, BinaryOp> {
   using ReturnType = double;
 };
-}  // namespace internal
+}  // namespace Eigen
 
 #endif

--- a/stan/math/prim/fun/Eigen.hpp
+++ b/stan/math/prim/fun/Eigen.hpp
@@ -24,16 +24,16 @@
 #include <Eigen/QR>
 #include <Eigen/src/Core/NumTraits.h>
 
-namespace Eigen {
-template <typename BinaryOp>
-struct ScalarBinaryOpTraits<int, double, BinaryOp> {
-  using ReturnType = double;
-};
+    namespace Eigen {
+  template <typename BinaryOp>
+  struct ScalarBinaryOpTraits<int, double, BinaryOp> {
+    using ReturnType = double;
+  };
 
-template <typename BinaryOp>
-struct ScalarBinaryOpTraits<double, int, BinaryOp> {
-  using ReturnType = double;
-};
+  template <typename BinaryOp>
+  struct ScalarBinaryOpTraits<double, int, BinaryOp> {
+    using ReturnType = double;
+  };
 }  // namespace Eigen
 
 #endif

--- a/stan/math/prim/fun/binary_log_loss.hpp
+++ b/stan/math/prim/fun/binary_log_loss.hpp
@@ -2,6 +2,7 @@
 #define STAN_MATH_PRIM_FUN_BINARY_LOG_LOSS_HPP
 
 #include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/meta/apply_scalar_binary.hpp>
 #include <stan/math/prim/fun/log.hpp>
 #include <stan/math/prim/fun/log1m.hpp>
 #include <cmath>
@@ -24,11 +25,19 @@ namespace math {
  * @param[in] y reference value, either 0 or 1
  * @param[in] y_hat response value in [0, 1]
  * @return Log loss for response given reference value
- */
+ *//*
 template <typename T>
 inline T binary_log_loss(int y, const T& y_hat) {
   using std::log;
   return y ? -log(y_hat) : -log1m(y_hat);
+}*/
+
+template <typename T1, typename T2>
+inline auto binary_log_loss(T1 y, const T2& y_hat) {
+  return apply_scalar_binary<T1, T2>::apply(
+      y, y_hat, [&](const auto& v, const auto& v_hat) {
+        return v ? -log(v_hat) : -log1m(v_hat);
+      });
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/binary_log_loss.hpp
+++ b/stan/math/prim/fun/binary_log_loss.hpp
@@ -25,14 +25,9 @@ namespace math {
  * @param[in] y reference value, either 0 or 1
  * @param[in] y_hat response value in [0, 1]
  * @return Log loss for response given reference value
- *//*
-template <typename T>
-inline T binary_log_loss(int y, const T& y_hat) {
-  using std::log;
-  return y ? -log(y_hat) : -log1m(y_hat);
-}*/
-
-template <typename T1, typename T2>
+ */
+template <typename T1, typename T2, require_st_integral<T1>* = nullptr,
+          require_st_arithmetic<T2>* = nullptr>
 inline auto binary_log_loss(T1 y, const T2& y_hat) {
   return apply_scalar_binary<T1, T2>::apply(
       y, y_hat, [&](const auto& v, const auto& v_hat) {

--- a/stan/math/prim/meta.hpp
+++ b/stan/math/prim/meta.hpp
@@ -168,6 +168,7 @@
 #include <stan/math/prim/meta/ad_promotable.hpp>
 #include <stan/math/prim/meta/append_return_type.hpp>
 #include <stan/math/prim/meta/apply_scalar_unary.hpp>
+#include <stan/math/prim/meta/apply_scalar_binary.hpp>
 #include <stan/math/prim/meta/apply_vector_unary.hpp>
 #include <stan/math/prim/meta/as_array_or_scalar.hpp>
 #include <stan/math/prim/meta/as_column_vector_or_scalar.hpp>

--- a/stan/math/prim/meta/apply_scalar_binary.hpp
+++ b/stan/math/prim/meta/apply_scalar_binary.hpp
@@ -30,7 +30,7 @@ template <typename T1, typename T2>
 struct apply_scalar_binary<T1, T2, require_all_stan_scalar_t<T1, T2>> {
   /**
    * Member function for applying a functor to two scalars and subsequently
-   * returning a scalar. 
+   * returning a scalar.
    *
    * @tparam T1 Type of first argument to which functor is applied.
    * @tparam T2 Type of second argument to which functor is applied.
@@ -55,7 +55,7 @@ template <typename T1, typename T2>
 struct apply_scalar_binary<T1, T2, require_all_eigen_t<T1, T2>> {
   /**
    * Member function for applying a functor to two Eigen objects and
-   * subsequently returning an Eigen object. 
+   * subsequently returning an Eigen object.
    *
    * @tparam T1 Type of first argument to which functor is applied.
    * @tparam T2 Type of second argument to which functor is applied.
@@ -82,7 +82,7 @@ struct apply_scalar_binary<T1, T2, require_eigen_t<T1>,
                            require_stan_scalar_t<T2>> {
   /**
    * Member function for applying a functor to an Eigen object and
-   * a scalar, and subsequently returning an Eigen object. 
+   * a scalar, and subsequently returning an Eigen object.
    *
    * @tparam T1 Type of Eigen object to which functor is applied.
    * @tparam T2 Type of scalar to which functor is applied.
@@ -94,7 +94,7 @@ struct apply_scalar_binary<T1, T2, require_eigen_t<T1>,
    */
   template <typename F>
   static inline auto apply(const T1& x, const T2& y, const F& f) {
-    return x.unaryExpr([&f, &y](const auto& v){ return f(v, y); }).eval();
+    return x.unaryExpr([&f, &y](const auto& v) { return f(v, y); }).eval();
   }
 };
 
@@ -109,7 +109,7 @@ struct apply_scalar_binary<T1, T2, require_stan_scalar_t<T1>,
                            require_eigen_t<T2>> {
   /**
    * Member function for applying a functor to a scalar and
-   * an Eigen object, and subsequently returning an Eigen object. 
+   * an Eigen object, and subsequently returning an Eigen object.
    *
    * @tparam T1 Type of scalar to which functor is applied.
    * @tparam T2 Type of Eigen object to which functor is applied.
@@ -121,7 +121,7 @@ struct apply_scalar_binary<T1, T2, require_stan_scalar_t<T1>,
    */
   template <typename F>
   static inline auto apply(const T1& x, const T2& y, const F& f) {
-    return y.unaryExpr([&f, &x](const auto& v){ return f(x, v); }).eval();
+    return y.unaryExpr([&f, &x](const auto& v) { return f(x, v); }).eval();
   }
 };
 
@@ -139,7 +139,7 @@ struct apply_scalar_binary<T1, T2,
                            require_all_std_vector_vt<is_stan_scalar, T1, T2>> {
   /**
    * Member function for applying a functor to two (non-nested) std::vectors,
-   * and subsequently returning an std::vector. 
+   * and subsequently returning an std::vector.
    *
    * @tparam T1 Type of first std::vector to which functor is applied.
    * @tparam T2 Type of second std::vector to which functor is applied.
@@ -163,7 +163,7 @@ struct apply_scalar_binary<T1, T2,
 
 /**
  * Specialisation for use with one (non-nested) std::vector and one scalar.
- * The std::vector input is mapped to an Eigen column vector and then the 
+ * The std::vector input is mapped to an Eigen column vector and then the
  * result is evaluated directly into the returned std::vector (via Eigen::Map).
  *
  * The returned scalar type is deduced to allow for cases where the input and
@@ -175,7 +175,7 @@ struct apply_scalar_binary<T1, T2, require_std_vector_vt<is_stan_scalar, T1>,
                            require_stan_scalar_t<T2>> {
   /**
    * Member function for applying a functor to one (non-nested) std::vector
-   * and one scalar, and subsequently returning an std::vector. 
+   * and one scalar, and subsequently returning an std::vector.
    *
    * @tparam T1 Type of std::vector to which functor is applied.
    * @tparam T2 Type of scalar to which functor is applied.
@@ -191,14 +191,14 @@ struct apply_scalar_binary<T1, T2, require_std_vector_vt<is_stan_scalar, T1>,
     using T_return = value_type_t<decltype(f(x[0], y))>;
     std::vector<T_return> result(x.size());
     Eigen::Map<Eigen::Matrix<T_return, -1, 1>>(result.data(), result.size())
-        = x_vec.unaryExpr([&f, &y](const auto& v){ return f(v, y); });
+        = x_vec.unaryExpr([&f, &y](const auto& v) { return f(v, y); });
     return result;
   }
 };
 
 /**
  * Specialisation for use with one scalar and one (non-nested) std::vector.
- * The std::vector input is mapped to an Eigen column vector and then the 
+ * The std::vector input is mapped to an Eigen column vector and then the
  * result is evaluated directly into the returned std::vector (via Eigen::Map).
  *
  * The returned scalar type is deduced to allow for cases where the input and
@@ -226,7 +226,7 @@ struct apply_scalar_binary<T1, T2, require_stan_scalar_t<T1>,
     using T_return = value_type_t<decltype(f(x, y[0]))>;
     std::vector<T_return> result(y.size());
     Eigen::Map<Eigen::Matrix<T_return, -1, 1>>(result.data(), result.size())
-        = y_vec.unaryExpr([&f, &x](const auto& v){ return f(x, v); });
+        = y_vec.unaryExpr([&f, &x](const auto& v) { return f(x, v); });
     return result;
   }
 };
@@ -245,7 +245,7 @@ struct apply_scalar_binary<T1, T2,
 
   /**
    * Member function for applying a functor to two std::vectors of containers,
-   * and subsequently returning an std::vector of containers. 
+   * and subsequently returning an std::vector of containers.
    *
    * @tparam T1 Type of first std::vector to which functor is applied.
    * @tparam T2 Type of second std::vector to which functor is applied.
@@ -258,7 +258,7 @@ struct apply_scalar_binary<T1, T2,
   template <typename F>
   static inline auto apply(const T1& x, const T2& y, const F& f) {
     using T_return
-           = decltype(apply_scalar_binary<T1_vt, T2_vt>::apply(x[0], y[0], f));
+        = decltype(apply_scalar_binary<T1_vt, T2_vt>::apply(x[0], y[0], f));
     size_t y_size = y.size();
     std::vector<T_return> result(y_size);
     for (size_t i = 0; i < y_size; ++i)
@@ -280,7 +280,7 @@ struct apply_scalar_binary<T1, T2, require_std_vector_vt<is_container, T1>,
 
   /**
    * Member function for applying a functor to an std::vector of containers
-   * and a scalar, and subsequently returning an std::vector of containers. 
+   * and a scalar, and subsequently returning an std::vector of containers.
    *
    * @tparam T1 Type of std::vector to which functor is applied.
    * @tparam T2 Type of scalar to which functor is applied.
@@ -293,7 +293,7 @@ struct apply_scalar_binary<T1, T2, require_std_vector_vt<is_container, T1>,
   template <typename F>
   static inline auto apply(const T1& x, const T2& y, const F& f) {
     using T_return
-            = decltype(apply_scalar_binary<T1_vt, T2>::apply(x[0], y, f));
+        = decltype(apply_scalar_binary<T1_vt, T2>::apply(x[0], y, f));
     size_t x_size = x.size();
     std::vector<T_return> result(x_size);
     for (size_t i = 0; i < x_size; ++i)
@@ -315,7 +315,7 @@ struct apply_scalar_binary<T1, T2, require_stan_scalar_t<T1>,
 
   /**
    * Member function for applying a functor to a scalar and an std::vector of
-   * containers, and subsequently returning an std::vector of containers. 
+   * containers, and subsequently returning an std::vector of containers.
    *
    * @tparam T1 Type of scalar to which functor is applied.
    * @tparam T2 Type of std::vector to which functor is applied.
@@ -328,7 +328,7 @@ struct apply_scalar_binary<T1, T2, require_stan_scalar_t<T1>,
   template <typename F>
   static inline auto apply(const T1& x, const T2& y, const F& f) {
     using T_return
-            = decltype(apply_scalar_binary<T1, T2_vt>::apply(x, y[0], f));
+        = decltype(apply_scalar_binary<T1, T2_vt>::apply(x, y[0], f));
     size_t y_size = y.size();
     std::vector<T_return> result(y_size);
     for (size_t i = 0; i < y_size; ++i)

--- a/stan/math/prim/meta/apply_scalar_binary.hpp
+++ b/stan/math/prim/meta/apply_scalar_binary.hpp
@@ -16,48 +16,124 @@ template <typename T1, typename T2, typename Enable = void,
           typename Enable2 = void>
 struct apply_scalar_binary {};
 
+/**
+ * Base template class for vectorization of binary scalar functions
+ * defined by applying a functor to a combination of scalars,
+ * containers of matching sizes, or a combination of a scclar and a container.
+ * These containers can be a standard library vector, Eigen dense
+ * matrix expression template, or container of these. For each specialisation,
+ * the same type as the largest (dimension) input is returned.
+ *
+ * This base template class takes (and returns) Eigen expression templates.
+ */
 template <typename T1, typename T2>
 struct apply_scalar_binary<T1, T2, require_all_stan_scalar_t<T1, T2>> {
-
+  /**
+   * Member function for applying a functor to two scalars and subsequently
+   * returning a scalar. 
+   *
+   * @tparam T1 Type of first argument to which functor is applied.
+   * @tparam T2 Type of second argument to which functor is applied.
+   * @tparam F Type of functor to apply.
+   * @param x First input to which operation is applied.
+   * @param y Second input to which operation is applied.
+   * @param f functor to apply to inputs.
+   * @return Scalar with result of applying functor to input.
+   */
   template <typename F>
   static inline auto apply(const T1& x, const T2& y, const F& f) {
     return f(x,y);
   }
-
 };
 
+/**
+ * Specialisation for use with two Eigen inputs. Eigen's binaryExpr framework
+ * is used for more efficient indexing of both row- and column-major inputs
+ * without separate loops.
+ */
 template <typename T1, typename T2>
 struct apply_scalar_binary<T1, T2, require_all_eigen_t<T1, T2>> {
-
+  /**
+   * Member function for applying a functor to two Eigen objects and
+   * subsequently returning an Eigen object. 
+   *
+   * @tparam T1 Type of first argument to which functor is applied.
+   * @tparam T2 Type of second argument to which functor is applied.
+   * @tparam F Type of functor to apply.
+   * @param x First Eigen input to which operation is applied.
+   * @param y Second Eigen input to which operation is applied.
+   * @param f functor to apply to Eigen input.
+   * @return Eigen object with result of applying functor to inputs.
+   */
   template <typename F>
   static inline auto apply(const T1& x, const T2& y, const F& f) {
     return x.binaryExpr(y, f).eval();
   }
-
 };
 
+/**
+ * Specialisation for use with one Eigen input and one scalar. Eigen's
+ * unaryExpr framework is used for more efficient indexing of both row-
+ * and column-major inputs. The unaryExpr framework also allows for the
+ * scalar to be captured and applied to each element in the Eigen object.
+ */
 template <typename T1, typename T2>
 struct apply_scalar_binary<T1, T2, require_eigen_t<T1>,
                            require_stan_scalar_t<T2>> {
-
+  /**
+   * Member function for applying a functor to an Eigen object and
+   * a scalar, and subsequently returning an Eigen object. 
+   *
+   * @tparam T1 Type of Eigen object to which functor is applied.
+   * @tparam T2 Type of scalar to which functor is applied.
+   * @tparam F Type of functor to apply.
+   * @param x Eigen input to which operation is applied.
+   * @param y Scalar input to which operation is applied.
+   * @param f functor to apply to Eigen and scalar inputs.
+   * @return Eigen object with result of applying functor to inputs.
+   */
   template <typename F>
   static inline auto apply(const T1& x, const T2& y, const F& f) {
     return x.unaryExpr([&f,&y](const auto& v){ return f(v, y); }).eval();
   }
-
 };
 
+/**
+ * Specialisation for use with one scalar and one Eigen input. Eigen's
+ * unaryExpr framework is used for more efficient indexing of both row-
+ * and column-major inputs. The unaryExpr framework also allows for the
+ * scalar to be captured and applied to each element in the Eigen object.
+ */
 template <typename T1, typename T2>
 struct apply_scalar_binary<T1, T2, require_stan_scalar_t<T1>,
                            require_eigen_t<T2>> {
-
+  /**
+   * Member function for applying a functor to a scalar and
+   * an Eigen object, and subsequently returning an Eigen object. 
+   *
+   * @tparam T1 Type of scalar to which functor is applied.
+   * @tparam T2 Type of Eigen object to which functor is applied.
+   * @tparam F Type of functor to apply.
+   * @param x Scalar input to which operation is applied.
+   * @param y Eigen input to which operation is applied.
+   * @param f functor to apply to scalar and Eigen inputs.
+   * @return Eigen object with result of applying functor to inputs.
+   */
   template <typename F>
   static inline auto apply(const T1& x, const T2& y, const F& f) {
     return y.unaryExpr([&f,&x](const auto& v){ return f(x, v); }).eval();
   }
-
 };
 
+/**
+ * Specialisation for use with (non-nested) std::vectors. Inputs are mapped
+ * to Eigen column vectors and then the result is evaluated directly into the
+ * returned std::vector (via Eigen::Map).
+ *
+ * The returned scalar type is deduced to allow for cases where the input and
+ * return scalar types differ (e.g., functions implicitly promoting
+ * integers).
+ */
 template <typename T1, typename T2>
 struct apply_scalar_binary<T1, T2,
                            require_all_std_vector_vt<is_stan_scalar, T1, T2>> {

--- a/stan/math/prim/meta/apply_scalar_binary.hpp
+++ b/stan/math/prim/meta/apply_scalar_binary.hpp
@@ -226,7 +226,7 @@ struct apply_scalar_binary<T1, T2, require_stan_scalar_t<T1>,
     using T_return = value_type_t<decltype(f(x, y[0]))>;
     std::vector<T_return> result(y.size());
     Eigen::Map<Eigen::Matrix<T_return, -1, 1>>(result.data(), result.size())
-        = y_vec.unaryExpr([&f,&x](const auto& v){ return f(x, v); });
+        = y_vec.unaryExpr([&f, &x](const auto& v){ return f(x, v); });
     return result;
   }
 };

--- a/stan/math/prim/meta/apply_scalar_binary.hpp
+++ b/stan/math/prim/meta/apply_scalar_binary.hpp
@@ -1,0 +1,167 @@
+#ifndef STAN_MATH_PRIM_META_APPLY_SCALAR_BINARY_HPP
+#define STAN_MATH_PRIM_META_APPLY_SCALAR_BINARY_HPP
+
+#include <stan/math/prim/meta/as_column_vector_or_scalar.hpp>
+#include <stan/math/prim/meta/is_stan_scalar.hpp>
+#include <stan/math/prim/meta/is_container.hpp>
+#include <stan/math/prim/meta/is_eigen.hpp>
+#include <stan/math/prim/meta/require_generics.hpp>
+#include <vector>
+
+namespace stan {
+namespace math {
+
+// Forward declaration to allow specialisations
+template <typename T1, typename T2, typename Enable = void,
+          typename Enable2 = void>
+struct apply_scalar_binary {};
+
+template <typename T1, typename T2>
+struct apply_scalar_binary<T1, T2, require_all_stan_scalar_t<T1, T2>> {
+
+  template <typename F>
+  static inline auto apply(const T1& x, const T2& y, const F& f) {
+    return f(x,y);
+  }
+
+};
+
+template <typename T1, typename T2>
+struct apply_scalar_binary<T1, T2, require_all_eigen_t<T1, T2>> {
+
+  template <typename F>
+  static inline auto apply(const T1& x, const T2& y, const F& f) {
+    return x.binaryExpr(y, f).eval();
+  }
+
+};
+
+template <typename T1, typename T2>
+struct apply_scalar_binary<T1, T2, require_eigen_t<T1>,
+                           require_stan_scalar_t<T2>> {
+
+  template <typename F>
+  static inline auto apply(const T1& x, const T2& y, const F& f) {
+    return x.unaryExpr([&f,&y](const auto& v){ return f(v, y); }).eval();
+  }
+
+};
+
+template <typename T1, typename T2>
+struct apply_scalar_binary<T1, T2, require_stan_scalar_t<T1>,
+                           require_eigen_t<T2>> {
+
+  template <typename F>
+  static inline auto apply(const T1& x, const T2& y, const F& f) {
+    return y.unaryExpr([&f,&x](const auto& v){ return f(x, v); }).eval();
+  }
+
+};
+
+template <typename T1, typename T2>
+struct apply_scalar_binary<T1, T2,
+                           require_all_std_vector_vt<is_stan_scalar, T1, T2>> {
+
+  template <typename F>
+  static inline auto apply(const T1& x, const T2& y, const F& f) {
+    decltype(auto) x_vec = as_column_vector_or_scalar(x);
+    decltype(auto) y_vec = as_column_vector_or_scalar(y);
+    using T_return = value_type_t<decltype(x_vec.binaryExpr(y_vec, f))>;
+    std::vector<T_return> result(x.size());
+    Eigen::Map<Eigen::Matrix<T_return, -1, 1>>(result.data(), result.size())
+        = x_vec.binaryExpr(y_vec, f);
+    return result;
+  }
+
+};
+
+template <typename T1, typename T2>
+struct apply_scalar_binary<T1, T2, require_std_vector_vt<is_stan_scalar, T1>,
+                           require_stan_scalar_t<T2>> {
+
+  template <typename F>
+  static inline auto apply(const T1& x, const T2& y, const F& f) {
+    decltype(auto) x_vec = as_column_vector_or_scalar(x);
+    using T_return = value_type_t<decltype(f(x[0], y))>;
+    std::vector<T_return> result(x.size());
+    Eigen::Map<Eigen::Matrix<T_return, -1, 1>>(result.data(), result.size())
+        = x_vec.unaryExpr([&f,&y](const auto& v){ return f(v, y); });
+    return result;
+  }
+
+};
+
+template <typename T1, typename T2>
+struct apply_scalar_binary<T1, T2, require_stan_scalar_t<T1>,
+                           require_std_vector_vt<is_stan_scalar, T2>> {
+
+  template <typename F>
+  static inline auto apply(const T1& x, const T2& y, const F& f) {
+    decltype(auto) y_vec = as_column_vector_or_scalar(y);
+    using T_return = value_type_t<decltype(f(x, y[0]))>;
+    std::vector<T_return> result(y.size());
+    Eigen::Map<Eigen::Matrix<T_return, -1, 1>>(result.data(), result.size())
+        = y_vec.unaryExpr([&f,&x](const auto& v){ return f(x, v); });
+    return result;
+  }
+
+};
+
+template <typename T1, typename T2>
+struct apply_scalar_binary<T1, T2,
+                           require_all_std_vector_vt<is_container, T1, T2>> {
+  using T1_vt = value_type_t<T1>;
+  using T2_vt = value_type_t<T2>;
+
+  template <typename F>
+  static inline auto apply(const T1& x, const T2& y, const F& f) {
+    using T_return
+           = decltype(apply_scalar_binary<T1_vt, T2_vt>::apply(x[0], y[0], f));
+    size_t y_size = y.size();
+    std::vector<T_return> result(y_size);
+    for (size_t i = 0; i < y_size; ++i)
+      result[i] = apply_scalar_binary<T1_vt, T2_vt>::apply(x[i], y[i], f);
+    return result;
+  }
+
+};
+
+template <typename T1, typename T2>
+struct apply_scalar_binary<T1, T2, require_std_vector_vt<is_container, T1>,
+                           require_stan_scalar_t<T2>> {
+  using T1_vt = value_type_t<T1>;
+
+  template <typename F>
+  static inline auto apply(const T1& x, const T2& y, const F& f) {
+    using T_return
+            = decltype(apply_scalar_binary<T1_vt, T2>::apply(x[0], y, f));
+    size_t x_size = x.size();
+    std::vector<T_return> result(x_size);
+    for (size_t i = 0; i < x_size; ++i)
+      result[i] = apply_scalar_binary<T1_vt, T2>::apply(x[i], y, f);
+    return result;
+  }
+
+};
+
+template <typename T1, typename T2>
+struct apply_scalar_binary<T1, T2, require_stan_scalar_t<T1>,
+                           require_std_vector_vt<is_container, T2>> {
+  using T2_vt = value_type_t<T2>;
+
+  template <typename F>
+  static inline auto apply(const T1& x, const T2& y, const F& f) {
+    using T_return
+            = decltype(apply_scalar_binary<T1, T2_vt>::apply(x, y[0], f));
+    size_t y_size = y.size();
+    std::vector<T_return> result(y_size);
+    for (size_t i = 0; i < y_size; ++i)
+      result[i] = apply_scalar_binary<T1, T2_vt>::apply(x, y[i], f);
+    return result;
+  }
+
+};
+
+}  // namespace math
+}  // namespace stan
+#endif

--- a/stan/math/rev/fun/Eigen_NumTraits.hpp
+++ b/stan/math/rev/fun/Eigen_NumTraits.hpp
@@ -83,6 +83,30 @@ struct NumTraits<stan::math::var> : GenericNumTraits<stan::math::var> {
 
 /**
  * Traits specialization for Eigen binary operations for reverse-mode
+ * autodiff and `int` arguments.
+ *
+ * @tparam BinaryOp type of binary operation for which traits are
+ * defined
+ */
+template <typename BinaryOp>
+struct ScalarBinaryOpTraits<stan::math::var, int, BinaryOp> {
+  using ReturnType = stan::math::var;
+};
+
+/**
+ * Traits specialization for Eigen binary operations for `int` and
+ * reverse-mode autodiff arguments.
+ *
+ * @tparam BinaryOp type of binary operation for which traits are
+ * defined
+ */
+template <typename BinaryOp>
+struct ScalarBinaryOpTraits<int, stan::math::var, BinaryOp> {
+  using ReturnType = stan::math::var;
+};
+
+/**
+ * Traits specialization for Eigen binary operations for reverse-mode
  * autodiff and `double` arguments.
  *
  * @tparam BinaryOp type of binary operation for which traits are

--- a/stan/math/rev/fun/binary_log_loss.hpp
+++ b/stan/math/rev/fun/binary_log_loss.hpp
@@ -59,12 +59,17 @@ class binary_log_loss_0_vari : public op_v_vari {
  * @param y_hat Response variable.
  * @return Log loss of response versus reference value.
  */
-inline var binary_log_loss(int y, const var& y_hat) {
-  if (y == 0) {
-    return var(new internal::binary_log_loss_0_vari(y_hat.vi_));
-  } else {
-    return var(new internal::binary_log_loss_1_vari(y_hat.vi_));
-  }
+template <typename T1, typename T2, require_st_integral<T1>* = nullptr,
+          require_st_var<T2>* = nullptr>
+inline auto binary_log_loss(T1 y, const T2& y_hat) {
+  return apply_scalar_binary<T1, T2>::apply(
+      y, y_hat, [&](const auto& v, const auto& v_hat) {
+        if (v == 0) {
+          return var(new internal::binary_log_loss_0_vari(v_hat.vi_));
+        } else {
+          return var(new internal::binary_log_loss_1_vari(v_hat.vi_));
+        }
+      });
 }
 
 }  // namespace math

--- a/test/unit/math/mix/fun/binary_log_loss_test.cpp
+++ b/test/unit/math/mix/fun/binary_log_loss_test.cpp
@@ -3,12 +3,28 @@
 
 TEST(mathMixScalFun, binaryLogLoss) {
   // bind integer arg because can't autodiff
-  auto f = [](int x1) {
+  auto f = [](const auto& x1) {
     return [=](const auto& x2) { return stan::math::binary_log_loss(x1, x2); };
   };
   for (int y = 0; y <= 1; ++y) {
     stan::test::expect_ad(f(y), std::numeric_limits<double>::quiet_NaN());
-    for (double y_hat = 0.05; y_hat < 1.0; y_hat += 0.05)
+    for (double y_hat = 0.05; y_hat < 1.0; y_hat += 0.05) {
+      std::vector<int> sti_y{y,y,y};
+      std::vector<std::vector<int>> ststi_y{sti_y,sti_y,sti_y};
+      Eigen::VectorXi ei_y = Eigen::VectorXi::Constant(3,y);
+      std::vector<Eigen::VectorXi> stei_y{ei_y,ei_y,ei_y};
+      Eigen::MatrixXd ed_yhat = Eigen::MatrixXd::Constant(3,3,y_hat);
+      std::vector<Eigen::VectorXd> sted_y{ed_yhat.diagonal(),ed_yhat.diagonal(),ed_yhat.diagonal()};
       stan::test::expect_ad(f(y), y_hat);
+      stan::test::expect_ad(f(ei_y), y_hat);
+      stan::test::expect_ad(f(ei_y), ed_yhat.diagonal().eval());
+      stan::test::expect_ad(f(Eigen::MatrixXi::Constant(3,3,y)), y_hat);
+      stan::test::expect_ad(f(y), ed_yhat);
+      stan::test::expect_ad(f(sti_y), y_hat);
+      stan::test::expect_ad(f(ststi_y), y_hat);
+      stan::test::expect_ad(f(stei_y), y_hat);
+      stan::test::expect_ad(f(y), sted_y);
+      stan::test::expect_ad(f(stei_y), sted_y);
+    }
   }
 }

--- a/test/unit/math/mix/fun/binary_log_loss_test.cpp
+++ b/test/unit/math/mix/fun/binary_log_loss_test.cpp
@@ -14,9 +14,8 @@ TEST(mathMixScalFun, binaryLogLoss) {
       Eigen::VectorXi ei_y = Eigen::VectorXi::Constant(3, y);
       std::vector<Eigen::VectorXi> stei_y{ei_y, ei_y, ei_y};
       Eigen::MatrixXd ed_yhat = Eigen::MatrixXd::Constant(3, 3, y_hat);
-      std::vector<Eigen::VectorXd> sted_y{ed_yhat.diagonal(),
-                                          ed_yhat.diagonal(),
-                                          ed_yhat.diagonal()};
+      std::vector<Eigen::VectorXd> sted_y{
+          ed_yhat.diagonal(), ed_yhat.diagonal(), ed_yhat.diagonal()};
       stan::test::expect_ad(f(y), y_hat);
       stan::test::expect_ad(f(ei_y), y_hat);
       stan::test::expect_ad(f(ei_y), ed_yhat.diagonal().eval());

--- a/test/unit/math/mix/fun/binary_log_loss_test.cpp
+++ b/test/unit/math/mix/fun/binary_log_loss_test.cpp
@@ -9,16 +9,18 @@ TEST(mathMixScalFun, binaryLogLoss) {
   for (int y = 0; y <= 1; ++y) {
     stan::test::expect_ad(f(y), std::numeric_limits<double>::quiet_NaN());
     for (double y_hat = 0.05; y_hat < 1.0; y_hat += 0.05) {
-      std::vector<int> sti_y{y,y,y};
-      std::vector<std::vector<int>> ststi_y{sti_y,sti_y,sti_y};
-      Eigen::VectorXi ei_y = Eigen::VectorXi::Constant(3,y);
-      std::vector<Eigen::VectorXi> stei_y{ei_y,ei_y,ei_y};
-      Eigen::MatrixXd ed_yhat = Eigen::MatrixXd::Constant(3,3,y_hat);
-      std::vector<Eigen::VectorXd> sted_y{ed_yhat.diagonal(),ed_yhat.diagonal(),ed_yhat.diagonal()};
+      std::vector<int> sti_y{y, y, y};
+      std::vector<std::vector<int>> ststi_y{sti_y, sti_y, sti_y};
+      Eigen::VectorXi ei_y = Eigen::VectorXi::Constant(3, y);
+      std::vector<Eigen::VectorXi> stei_y{ei_y, ei_y, ei_y};
+      Eigen::MatrixXd ed_yhat = Eigen::MatrixXd::Constant(3, 3, y_hat);
+      std::vector<Eigen::VectorXd> sted_y{ed_yhat.diagonal(),
+                                          ed_yhat.diagonal(),
+                                          ed_yhat.diagonal()};
       stan::test::expect_ad(f(y), y_hat);
       stan::test::expect_ad(f(ei_y), y_hat);
       stan::test::expect_ad(f(ei_y), ed_yhat.diagonal().eval());
-      stan::test::expect_ad(f(Eigen::MatrixXi::Constant(3,3,y)), y_hat);
+      stan::test::expect_ad(f(Eigen::MatrixXi::Constant(3, 3, y)), y_hat);
       stan::test::expect_ad(f(y), ed_yhat);
       stan::test::expect_ad(f(sti_y), y_hat);
       stan::test::expect_ad(f(ststi_y), y_hat);

--- a/test/unit/math/prim/fun/binary_log_loss_test.cpp
+++ b/test/unit/math/prim/fun/binary_log_loss_test.cpp
@@ -15,11 +15,14 @@ TEST(MathFunctions, binary_log_loss) {
   in1 << 0, 0, 0;
   Eigen::VectorXd in2(3);
   in2 << 0.5, 0.5, 0.5;
+  Eigen::MatrixXd in_mat(3,3);
+  in_mat.fill(0.5);
 
   Eigen::VectorXd out(3);
   out = stan::math::binary_log_loss(in1, 0.5);
   out = stan::math::binary_log_loss(0, in2);
   out = stan::math::binary_log_loss(in1, in2);
+  out = stan::math::binary_log_loss(in1, in_mat.diagonal());
 
   std::vector<int> st_in1{0, 0, 0};
   std::vector<std::vector<int>> stst_in1{st_in1, st_in1, st_in1};
@@ -40,6 +43,7 @@ TEST(MathFunctions, binary_log_loss) {
   st_eigout = stan::math::binary_log_loss(0, st_eig2);
   double res = -log(0.5);
   for(int i = 0; i < 3; ++i) {
+    EXPECT_FLOAT_EQ(res, out[i]);
     EXPECT_FLOAT_EQ(res, st_out[i]);
     EXPECT_FLOAT_EQ(res, stst_out[i][i]);
     EXPECT_FLOAT_EQ(res, st_eigout[i][i]);

--- a/test/unit/math/prim/fun/binary_log_loss_test.cpp
+++ b/test/unit/math/prim/fun/binary_log_loss_test.cpp
@@ -1,4 +1,5 @@
 #include <stan/math/prim.hpp>
+#include <test/unit/math/prim/fun/binary_scalar_tester.hpp>
 #include <gtest/gtest.h>
 #include <cmath>
 #include <limits>
@@ -10,44 +11,19 @@ TEST(MathFunctions, binary_log_loss) {
   EXPECT_FLOAT_EQ(-log(0.5), stan::math::binary_log_loss(1, 0.5));
   EXPECT_FLOAT_EQ(-log(0.75), stan::math::binary_log_loss(0, 0.25));
   EXPECT_FLOAT_EQ(-log(0.75), stan::math::binary_log_loss(1, 0.75));
+}
 
-  Eigen::VectorXi in1(3);
-  in1 << 0, 0, 0;
-  Eigen::VectorXd in2(3);
-  in2 << 0.5, 0.5, 0.5;
-  Eigen::MatrixXd in_mat(3,3);
-  in_mat.fill(0.5);
+TEST(MathFunctions, binary_log_loss_vec) {
+  auto f = [](const auto& x1, const auto& x2) {
+    return stan::math::binary_log_loss(x1, x2);
+  };
 
-  Eigen::VectorXd out(3);
-  out = stan::math::binary_log_loss(in1, 0.5);
-  out = stan::math::binary_log_loss(0, in2);
-  out = stan::math::binary_log_loss(in1, in2);
-  out = stan::math::binary_log_loss(in1, in_mat.diagonal());
+  Eigen::VectorXi in1(6);
+  in1 << 0, 1, 0, 1, 0, 1;
+  Eigen::VectorXd in2(6);
+  in2 << 0, 1, 0.5, 0.5, 0.25, 0.75;
 
-  std::vector<int> st_in1{0, 0, 0};
-  std::vector<std::vector<int>> stst_in1{st_in1, st_in1, st_in1};
-  std::vector<double> st_in2{0.5, 0.5, 0.5};
-  std::vector<std::vector<double>> stst_in2{st_in2, st_in2, st_in2};
-  std::vector<double> st_out(3);
-  std::vector<std::vector<double>> stst_out(3);
-  std::vector<Eigen::VectorXi> st_eig1{in1, in1, in1};
-  std::vector<Eigen::VectorXd> st_eig2{in2, in2, in2};
-  std::vector<Eigen::VectorXd> st_eigout(3);
-  st_out = stan::math::binary_log_loss(st_in1, 0.5);
-  stst_out = stan::math::binary_log_loss(stst_in1, 0.5);
-  st_out = stan::math::binary_log_loss(0, st_in2);
-  stst_out = stan::math::binary_log_loss(0, stst_in2);
-  stst_out = stan::math::binary_log_loss(stst_in1, stst_in2);
-  st_eigout = stan::math::binary_log_loss(st_eig1, 0.5);
-  st_eigout = stan::math::binary_log_loss(st_eig1, st_eig2);
-  st_eigout = stan::math::binary_log_loss(0, st_eig2);
-  double res = -log(0.5);
-  for(int i = 0; i < 3; ++i) {
-    EXPECT_FLOAT_EQ(res, out[i]);
-    EXPECT_FLOAT_EQ(res, st_out[i]);
-    EXPECT_FLOAT_EQ(res, stst_out[i][i]);
-    EXPECT_FLOAT_EQ(res, st_eigout[i][i]);
-  }
+  stan::test::binary_scalar_tester(f, in1, in2);
 }
 
 TEST(MathFunctions, binary_log_loss_nan) {

--- a/test/unit/math/prim/fun/binary_log_loss_test.cpp
+++ b/test/unit/math/prim/fun/binary_log_loss_test.cpp
@@ -10,6 +10,40 @@ TEST(MathFunctions, binary_log_loss) {
   EXPECT_FLOAT_EQ(-log(0.5), stan::math::binary_log_loss(1, 0.5));
   EXPECT_FLOAT_EQ(-log(0.75), stan::math::binary_log_loss(0, 0.25));
   EXPECT_FLOAT_EQ(-log(0.75), stan::math::binary_log_loss(1, 0.75));
+
+  Eigen::VectorXi in1(3);
+  in1 << 0, 0, 0;
+  Eigen::VectorXd in2(3);
+  in2 << 0.5, 0.5, 0.5;
+
+  Eigen::VectorXd out(3);
+  out = stan::math::binary_log_loss(in1, 0.5);
+  out = stan::math::binary_log_loss(0, in2);
+  out = stan::math::binary_log_loss(in1, in2);
+
+  std::vector<int> st_in1{0, 0, 0};
+  std::vector<std::vector<int>> stst_in1{st_in1, st_in1, st_in1};
+  std::vector<double> st_in2{0.5, 0.5, 0.5};
+  std::vector<std::vector<double>> stst_in2{st_in2, st_in2, st_in2};
+  std::vector<double> st_out(3);
+  std::vector<std::vector<double>> stst_out(3);
+  std::vector<Eigen::VectorXi> st_eig1{in1, in1, in1};
+  std::vector<Eigen::VectorXd> st_eig2{in2, in2, in2};
+  std::vector<Eigen::VectorXd> st_eigout(3);
+  st_out = stan::math::binary_log_loss(st_in1, 0.5);
+  stst_out = stan::math::binary_log_loss(stst_in1, 0.5);
+  st_out = stan::math::binary_log_loss(0, st_in2);
+  stst_out = stan::math::binary_log_loss(0, stst_in2);
+  stst_out = stan::math::binary_log_loss(stst_in1, stst_in2);
+  st_eigout = stan::math::binary_log_loss(st_eig1, 0.5);
+  st_eigout = stan::math::binary_log_loss(st_eig1, st_eig2);
+  st_eigout = stan::math::binary_log_loss(0, st_eig2);
+  double res = -log(0.5);
+  for(int i = 0; i < 3; ++i) {
+    EXPECT_FLOAT_EQ(res, st_out[i]);
+    EXPECT_FLOAT_EQ(res, stst_out[i][i]);
+    EXPECT_FLOAT_EQ(res, st_eigout[i][i]);
+  }
 }
 
 TEST(MathFunctions, binary_log_loss_nan) {

--- a/test/unit/math/prim/fun/binary_scalar_tester.hpp
+++ b/test/unit/math/prim/fun/binary_scalar_tester.hpp
@@ -33,8 +33,7 @@ void binary_scalar_tester_impl(const F& f, const T1& x, const T2& y) {
   auto scal_nestvec = f(x[1], nest_y);
   for (int i = 0; i < 3; ++i) {
     for (int j = 0; j < x.size(); ++j) {
-      EXPECT_FLOAT_EQ(f(nest_x[i][j], nest_y[i][j]),
-                      nestvec_nestvec[i][j]);
+      EXPECT_FLOAT_EQ(f(nest_x[i][j], nest_y[i][j]), nestvec_nestvec[i][j]);
       EXPECT_FLOAT_EQ(f(nest_x[i][j], y[1]), nestvec_scal[i][j]);
       EXPECT_FLOAT_EQ(f(x[1], nest_y[i][j]), scal_nestvec[i][j]);
     }
@@ -60,10 +59,9 @@ template <typename F, typename T1, typename T2,
 void binary_scalar_tester(const F& f, const T1& x, const T2& y) {
   binary_scalar_tester_impl(f, x, y);
   binary_scalar_tester_impl(f, x.transpose(), y.transpose());
-  binary_scalar_tester_impl(f, std::vector<typename T1::Scalar>(x.data(),
-                                                     x.data() + x.size()),
-                               std::vector<typename T2::Scalar>(y.data(),
-                                                     y.data() + y.size()));
+  binary_scalar_tester_impl(
+      f, std::vector<typename T1::Scalar>(x.data(), x.data() + x.size()),
+      std::vector<typename T2::Scalar>(y.data(), y.data() + y.size()));
 }
 
 }  // namespace test

--- a/test/unit/math/prim/fun/binary_scalar_tester.hpp
+++ b/test/unit/math/prim/fun/binary_scalar_tester.hpp
@@ -1,0 +1,70 @@
+#include <stan/math/prim.hpp>
+#include <gtest/gtest.h>
+
+namespace stan {
+namespace test {
+
+/**
+ * Implementation function which checks that the binary vectorisation
+ * framework returns the same value as the function with scalar inputs,
+ * for all valid combinations of scalar/vector/nested vector.
+ *
+ * @tparam F Type of functor to apply.
+ * @tparam T1 Type of first vector.
+ * @tparam T2 Type of second vector.
+ * @param x First vector input to which operation is applied.
+ * @param y Second vector input to which operation is applied.
+ * @param f functor to apply to inputs.
+ */
+template <typename F, typename T1, typename T2>
+void binary_scalar_tester_impl(const F& f, const T1& x, const T2& y) {
+  auto vec_vec = f(x, y);
+  auto vec_scal = f(x, y[1]);
+  auto scal_vec = f(x[1], y);
+  for (int i = 0; i < x.size(); ++i) {
+    EXPECT_FLOAT_EQ(f(x[i], y[i]), vec_vec[i]);
+    EXPECT_FLOAT_EQ(f(x[i], y[1]), vec_scal[i]);
+    EXPECT_FLOAT_EQ(f(x[1], y[i]), scal_vec[i]);
+  }
+  std::vector<T1> nest_x{x, x, x};
+  std::vector<T2> nest_y{y, y, y};
+  auto nestvec_nestvec = f(nest_x, nest_y);
+  auto nestvec_scal = f(nest_x, y[1]);
+  auto scal_nestvec = f(x[1], nest_y);
+  for (int i = 0; i < 3; ++i) {
+    for (int j = 0; j < x.size(); ++j) {
+      EXPECT_FLOAT_EQ(f(nest_x[i][j], nest_y[i][j]),
+                      nestvec_nestvec[i][j]);
+      EXPECT_FLOAT_EQ(f(nest_x[i][j], y[1]), nestvec_scal[i][j]);
+      EXPECT_FLOAT_EQ(f(x[1], nest_y[i][j]), scal_nestvec[i][j]);
+    }
+  }
+}
+
+/**
+ * Testing framework for checking that the vectorisation of binary
+ * functions returns the same results as the binary function with
+ * scalar inputs. This framework takes two Eigen column vectors of
+ * inputs which are tested, and then transformed to Eigen row vectors
+ * and std::vectors to also be tested.
+ *
+ * @tparam F Type of functor to apply.
+ * @tparam T1 Type of first Eigen column-vector.
+ * @tparam T2 Type of second Eigen column-vector.
+ * @param x First Eigen column-vector input to which operation is applied.
+ * @param y Second Eigen column-vector input to which operation is applied.
+ * @param f functor to apply to inputs.
+ */
+template <typename F, typename T1, typename T2,
+          require_all_eigen_col_vector_t<T1, T2>...>
+void binary_scalar_tester(const F& f, const T1& x, const T2& y) {
+  binary_scalar_tester_impl(f, x, y);
+  binary_scalar_tester_impl(f, x.transpose(), y.transpose());
+  binary_scalar_tester_impl(f, std::vector<typename T1::Scalar>(x.data(),
+                                                     x.data() + x.size()),
+                               std::vector<typename T2::Scalar>(y.data(),
+                                                     y.data() + y.size()));
+}
+
+}  // namespace test
+}  // namespace stan


### PR DESCRIPTION
## Summary

This PR introduces the ```apply_scalar_binary``` framework, which provides a simple means of extending binary scalar functions to work with eigen expressions, containers, and nested containers. The framework also supports broadcasting, so a function like ```f(double, std::vector<Eigen::VectorXd>``` will work.

The ```binary_log_loss``` function is reimplemented using this framework as an example.

This PR also introduces a function (```binary_scalar_tester```) to be used in the ```prim``` tests which checks that the vectorised function return the same values as the respective scalar function.

## Tests
New ```prim``` and ```mix``` tests for ```binary_log_loss```

## Side Effects

N/A

## Release notes

Introduced a framework for vectorising/broadcasting binary functions

## Checklist

- [x] Math issue #1890 

- [x] Copyright holder: Andrew Johnson

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
