### PR TITLE
Generalize glms

### DIFF
--- a/stan/math/opencl/prim/bernoulli_logit_glm_lpmf.hpp
+++ b/stan/math/opencl/prim/bernoulli_logit_glm_lpmf.hpp
@@ -9,6 +9,7 @@
 #include <stan/math/prim/fun/size.hpp>
 #include <stan/math/prim/fun/size_zero.hpp>
 #include <stan/math/prim/fun/sum.hpp>
+#include <stan/math/prim/fun/to_ref.hpp>
 #include <stan/math/prim/fun/value_of.hpp>
 #include <stan/math/prim/fun/value_of_rec.hpp>
 #include <stan/math/opencl/copy.hpp>
@@ -45,9 +46,9 @@ namespace math {
 
 template <bool propto, typename T_alpha, typename T_beta>
 return_type_t<T_alpha, T_beta> bernoulli_logit_glm_lpmf(
-    const matrix_cl<int> &y_cl, const matrix_cl<double> &x_cl,
-    const T_alpha &alpha, const T_beta &beta) {
-  static const char *function = "bernoulli_logit_glm_lpmf(OpenCL)";
+    const matrix_cl<int>& y_cl, const matrix_cl<double>& x_cl,
+    const T_alpha& alpha, const T_beta& beta) {
+  static const char* function = "bernoulli_logit_glm_lpmf(OpenCL)";
   using T_partials_return = partials_return_t<T_alpha, T_beta>;
 
   using Eigen::Dynamic;
@@ -75,11 +76,15 @@ return_type_t<T_alpha, T_beta> bernoulli_logit_glm_lpmf(
   }
 
   T_partials_return logp(0);
-  const auto &beta_val = value_of_rec(beta);
-  const auto &alpha_val = value_of_rec(alpha);
 
-  const auto &beta_val_vec = as_column_vector_or_scalar(beta_val);
-  const auto &alpha_val_vec = as_column_vector_or_scalar(alpha_val);
+  const auto& beta_ref = to_ref_if<!is_constant<T_beta>::value>(beta);
+  const auto& alpha_ref = to_ref_if<!is_constant<T_alpha>::value>(alpha);
+
+  const auto& beta_val = value_of_rec(beta_ref);
+  const auto& alpha_val = value_of_rec(alpha_ref);
+
+  const auto& beta_val_vec = as_column_vector_or_scalar(beta_val);
+  const auto& alpha_val_vec = as_column_vector_or_scalar(alpha_val);
 
   const int local_size
       = opencl_kernels::bernoulli_logit_glm.get_option("LOCAL_SIZE_");
@@ -102,7 +107,7 @@ return_type_t<T_alpha, T_beta> bernoulli_logit_glm_lpmf(
         theta_derivative_cl, theta_derivative_sum_cl, y_cl, x_cl, alpha_cl,
         beta_cl, N, M, y_cl.size() != 1, stan::math::size(alpha) != 1,
         need_theta_derivative, need_theta_derivative_sum);
-  } catch (const cl::Error &e) {
+  } catch (const cl::Error& e) {
     check_opencl_error(function, e);
   }
 
@@ -119,7 +124,8 @@ return_type_t<T_alpha, T_beta> bernoulli_logit_glm_lpmf(
                  from_matrix_cl(x_cl));
   }
 
-  operands_and_partials<T_alpha, T_beta> ops_partials(alpha, beta);
+  operands_and_partials<decltype(alpha_ref), decltype(beta_ref)> ops_partials(
+      alpha_ref, beta_ref);
   // Compute the necessary derivatives.
   if (!is_constant_all<T_alpha>::value) {
     if (is_vector<T_alpha>::value) {

--- a/stan/math/opencl/prim/bernoulli_logit_glm_lpmf.hpp
+++ b/stan/math/opencl/prim/bernoulli_logit_glm_lpmf.hpp
@@ -141,13 +141,6 @@ return_type_t<T_alpha, T_beta> bernoulli_logit_glm_lpmf(
   return ops_partials.build(logp);
 }
 
-template <typename T_alpha, typename T_beta>
-inline return_type_t<T_beta, T_alpha> bernoulli_logit_glm_lpmf(
-    const matrix_cl<int> &y, const matrix_cl<double> &x, const T_alpha &alpha,
-    const T_beta &beta) {
-  return bernoulli_logit_glm_lpmf<false>(y, x, alpha, beta);
-}
-
 }  // namespace math
 }  // namespace stan
 

--- a/stan/math/opencl/prim/categorical_logit_glm_lpmf.hpp
+++ b/stan/math/opencl/prim/categorical_logit_glm_lpmf.hpp
@@ -23,8 +23,8 @@ namespace math {
  * This is an overload of the GLM in
  * prim/prob/categorical_logit_glm_lpmf.hpp that is implemented in OpenCL.
  *
- * @tparam T_alpha_scalar type of scalar in the intercept vector
- * @tparam T_beta_scalar type of a scalar in the matrix of weights
+ * @tparam T_alpha type of the intercept vector
+ * @tparam T_beta type of a scalar in the matrix of weights
  * @param y_cl a scalar or vector of classes. If it is a scalar it will be
  * broadcast - used for all instances. Values should be between 1 and number of
  * classes, including endpoints.
@@ -37,12 +37,13 @@ namespace math {
  * bounds
  * @throw std::invalid_argument if container sizes mismatch.
  */
-template <bool propto, typename T_alpha_scalar, typename T_beta_scalar>
-return_type_t<T_alpha_scalar, T_beta_scalar> categorical_logit_glm_lpmf(
+template <bool propto, typename T_alpha, typename T_beta,
+          require_eigen_col_vector_t<T_alpha>* = nullptr,
+          require_eigen_matrix_t<T_beta>* = nullptr>
+return_type_t<T_alpha, T_beta> categorical_logit_glm_lpmf(
     const matrix_cl<int>& y_cl, const matrix_cl<double>& x_cl,
-    const Eigen::Matrix<T_alpha_scalar, Eigen::Dynamic, 1>& alpha,
-    const Eigen::Matrix<T_beta_scalar, Eigen::Dynamic, Eigen::Dynamic>& beta) {
-  using T_partials_return = partials_return_t<T_alpha_scalar, T_beta_scalar>;
+    const T_alpha& alpha, const T_beta& beta) {
+  using T_partials_return = partials_return_t<T_alpha, T_beta>;
   static const char* function = "categorical_logit_glm_lpmf";
 
   using Eigen::Array;
@@ -65,7 +66,7 @@ return_type_t<T_alpha_scalar, T_beta_scalar> categorical_logit_glm_lpmf(
     return 0;
   }
 
-  if (!include_summand<propto, T_alpha_scalar, T_beta_scalar>::value) {
+  if (!include_summand<propto, T_alpha, T_beta>::value) {
     return 0;
   }
 
@@ -83,8 +84,8 @@ return_type_t<T_alpha_scalar, T_beta_scalar> categorical_logit_glm_lpmf(
 
   matrix_cl<double> x_beta_cl = x_cl * beta_cl;
 
-  bool need_alpha_derivative = !is_constant_all<T_alpha_scalar>::value;
-  bool need_beta_derivative = !is_constant_all<T_beta_scalar>::value;
+  bool need_alpha_derivative = !is_constant_all<T_alpha>::value;
+  bool need_beta_derivative = !is_constant_all<T_beta>::value;
 
   matrix_cl<double> logp_cl(wgs, 1);
   matrix_cl<double> exp_lin_cl(N_instances, N_classes);
@@ -115,14 +116,12 @@ return_type_t<T_alpha_scalar, T_beta_scalar> categorical_logit_glm_lpmf(
                  from_matrix_cl(x_cl));
   }
 
-  operands_and_partials<Matrix<T_alpha_scalar, Dynamic, 1>,
-                        Matrix<T_beta_scalar, Dynamic, Dynamic>>
-      ops_partials(alpha, beta);
-  if (!is_constant_all<T_alpha_scalar>::value) {
+  operands_and_partials<T_alpha, T_beta> ops_partials(alpha, beta);
+  if (!is_constant_all<T_alpha>::value) {
     ops_partials.edge1_.partials_
         = from_matrix_cl(alpha_derivative_cl).colwise().sum();
   }
-  if (!is_constant_all<T_beta_scalar>::value && N_attributes != 0) {
+  if (!is_constant_all<T_beta>::value && N_attributes != 0) {
     matrix_cl<double> beta_derivative_cl = transpose(x_cl) * neg_softmax_lin_cl;
     matrix_cl<double> temp(N_classes, local_size * N_attributes);
     try {
@@ -136,14 +135,6 @@ return_type_t<T_alpha_scalar, T_beta_scalar> categorical_logit_glm_lpmf(
     ops_partials.edge2_.partials_ = from_matrix_cl(beta_derivative_cl);
   }
   return ops_partials.build(logp);
-}
-
-template <typename T_alpha_scalar, typename T_beta_scalar>
-return_type_t<T_alpha_scalar, T_beta_scalar> categorical_logit_glm_lpmf(
-    const matrix_cl<int>& y, const matrix_cl<double>& x,
-    const Eigen::Matrix<T_alpha_scalar, Eigen::Dynamic, 1>& alpha,
-    const Eigen::Matrix<T_beta_scalar, Eigen::Dynamic, Eigen::Dynamic>& beta) {
-  return categorical_logit_glm_lpmf<false>(y, x, alpha, beta);
 }
 
 }  // namespace math

--- a/stan/math/opencl/prim/categorical_logit_glm_lpmf.hpp
+++ b/stan/math/opencl/prim/categorical_logit_glm_lpmf.hpp
@@ -70,8 +70,11 @@ return_type_t<T_alpha, T_beta> categorical_logit_glm_lpmf(
     return 0;
   }
 
-  const auto& beta_val = value_of_rec(beta);
-  const auto& alpha_val = value_of_rec(alpha);
+  const auto& alpha_ref = to_ref_if<!is_constant<T_alpha>::value>(alpha);
+  const auto& beta_ref = to_ref_if<!is_constant<T_beta>::value>(beta);
+
+  const auto& alpha_val = value_of_rec(alpha_ref);
+  const auto& beta_val = value_of_rec(beta_ref);
 
   const int local_size
       = opencl_kernels::categorical_logit_glm.get_option("LOCAL_SIZE_");
@@ -114,7 +117,8 @@ return_type_t<T_alpha, T_beta> categorical_logit_glm_lpmf(
                  from_matrix_cl(x_cl));
   }
 
-  operands_and_partials<T_alpha, T_beta> ops_partials(alpha, beta);
+  operands_and_partials<decltype(alpha_ref), decltype(beta_ref)> ops_partials(
+      alpha_ref, beta_ref);
   if (!is_constant_all<T_alpha>::value) {
     ops_partials.edge1_.partials_
         = from_matrix_cl(alpha_derivative_cl).colwise().sum();

--- a/stan/math/opencl/prim/categorical_logit_glm_lpmf.hpp
+++ b/stan/math/opencl/prim/categorical_logit_glm_lpmf.hpp
@@ -6,6 +6,7 @@
 #include <stan/math/prim/err.hpp>
 #include <stan/math/prim/fun/size_zero.hpp>
 #include <stan/math/prim/fun/sum.hpp>
+#include <stan/math/prim/fun/to_ref.hpp>
 #include <Eigen/Core>
 
 #include <stan/math/opencl/matrix_cl.hpp>

--- a/stan/math/opencl/prim/neg_binomial_2_log_glm_lpmf.hpp
+++ b/stan/math/opencl/prim/neg_binomial_2_log_glm_lpmf.hpp
@@ -82,19 +82,22 @@ return_type_t<T_alpha, T_beta, T_precision> neg_binomial_2_log_glm_lpmf(
     check_size_match(function, "Rows of ", "x_cl", N, "size of ", "alpha",
                      stan::math::size(alpha));
   }
-  check_positive_finite(function, "Precision parameter", phi);
+  const auto& phi_ref = to_ref(phi);
+  check_positive_finite(function, "Precision parameter", phi_ref);
 
   if (N == 0) {
     return 0;
   }
-
   if (!include_summand<propto, T_alpha, T_beta, T_precision>::value) {
     return 0;
   }
 
-  const auto& beta_val = value_of_rec(beta);
-  const auto& alpha_val = value_of_rec(alpha);
-  const auto& phi_val = value_of_rec(phi);
+  const auto& alpha_ref = to_ref_if<!is_constant<T_alpha>::value>(alpha);
+  const auto& beta_ref = to_ref_if<!is_constant<T_beta>::value>(beta);
+
+  const auto& beta_val = value_of_rec(beta_ref);
+  const auto& alpha_val = value_of_rec(alpha_ref);
+  const auto& phi_val = value_of_rec(phi_ref);
 
   const auto& beta_val_vec = as_column_vector_or_scalar(beta_val);
   const auto& alpha_val_vec = as_column_vector_or_scalar(alpha_val);

--- a/stan/math/opencl/prim/neg_binomial_2_log_glm_lpmf.hpp
+++ b/stan/math/opencl/prim/neg_binomial_2_log_glm_lpmf.hpp
@@ -83,7 +83,7 @@ return_type_t<T_alpha, T_beta, T_precision> neg_binomial_2_log_glm_lpmf(
     check_size_match(function, "Rows of ", "x_cl", N, "size of ", "alpha",
                      stan::math::size(alpha));
   }
-  const auto& phi_ref = to_ref<Eigen::Stride<0,0>>(phi);
+  const auto& phi_ref = to_ref<Eigen::Stride<0, 0>>(phi);
   check_positive_finite(function, "Precision parameter", phi_ref);
 
   if (N == 0) {

--- a/stan/math/opencl/prim/neg_binomial_2_log_glm_lpmf.hpp
+++ b/stan/math/opencl/prim/neg_binomial_2_log_glm_lpmf.hpp
@@ -83,7 +83,7 @@ return_type_t<T_alpha, T_beta, T_precision> neg_binomial_2_log_glm_lpmf(
     check_size_match(function, "Rows of ", "x_cl", N, "size of ", "alpha",
                      stan::math::size(alpha));
   }
-  const auto& phi_ref = to_ref<Eigen::Stride<0, 0>>(phi);
+  const auto& phi_ref = to_ref(phi);
   check_positive_finite(function, "Precision parameter", phi_ref);
 
   if (N == 0) {

--- a/stan/math/opencl/prim/neg_binomial_2_log_glm_lpmf.hpp
+++ b/stan/math/opencl/prim/neg_binomial_2_log_glm_lpmf.hpp
@@ -196,13 +196,6 @@ return_type_t<T_alpha, T_beta, T_precision> neg_binomial_2_log_glm_lpmf(
   return ops_partials.build(logp);
 }
 
-template <typename T_alpha, typename T_beta, typename T_precision>
-inline return_type_t<T_alpha, T_beta, T_precision> neg_binomial_2_log_glm_lpmf(
-    const matrix_cl<int>& y, const matrix_cl<double>& x, const T_alpha& alpha,
-    const T_beta& beta, const T_precision& phi) {
-  return neg_binomial_2_log_glm_lpmf<false>(y, x, alpha, beta, phi);
-}
-
 }  // namespace math
 }  // namespace stan
 

--- a/stan/math/opencl/prim/neg_binomial_2_log_glm_lpmf.hpp
+++ b/stan/math/opencl/prim/neg_binomial_2_log_glm_lpmf.hpp
@@ -83,7 +83,7 @@ return_type_t<T_alpha, T_beta, T_precision> neg_binomial_2_log_glm_lpmf(
     check_size_match(function, "Rows of ", "x_cl", N, "size of ", "alpha",
                      stan::math::size(alpha));
   }
-  const auto& phi_ref = to_ref(phi);
+  const auto& phi_ref = to_ref<Eigen::Stride<0,0>>(phi);
   check_positive_finite(function, "Precision parameter", phi_ref);
 
   if (N == 0) {

--- a/stan/math/opencl/prim/neg_binomial_2_log_glm_lpmf.hpp
+++ b/stan/math/opencl/prim/neg_binomial_2_log_glm_lpmf.hpp
@@ -10,6 +10,7 @@
 #include <stan/math/prim/fun/multiply_log.hpp>
 #include <stan/math/prim/fun/size.hpp>
 #include <stan/math/prim/fun/sum.hpp>
+#include <stan/math/prim/fun/to_ref.hpp>
 #include <stan/math/prim/fun/value_of_rec.hpp>
 #include <stan/math/opencl/copy.hpp>
 #include <stan/math/opencl/multiply.hpp>

--- a/stan/math/opencl/prim/normal_id_glm_lpdf.hpp
+++ b/stan/math/opencl/prim/normal_id_glm_lpdf.hpp
@@ -101,7 +101,7 @@ return_type_t<T_alpha, T_beta, T_scale> normal_id_glm_lpdf(
 
   const auto& beta_val_vec = as_column_vector_or_scalar(beta_val);
   const auto& alpha_val_vec = as_column_vector_or_scalar(alpha_val);
-  const auto& sigma_val_vec = to_ref(as_column_vector_or_scalar(sigma_val));
+  const auto& sigma_val_vec = to_ref<Eigen::Stride<0,0>>(as_column_vector_or_scalar(sigma_val));
 
   T_scale_val inv_sigma = 1 / as_array_or_scalar(sigma_val_vec);
   Matrix<T_partials_return, Dynamic, 1> y_minus_mu_over_sigma_mat(N);

--- a/stan/math/opencl/prim/normal_id_glm_lpdf.hpp
+++ b/stan/math/opencl/prim/normal_id_glm_lpdf.hpp
@@ -50,9 +50,9 @@ namespace math {
  */
 template <bool propto, typename T_alpha, typename T_beta, typename T_scale>
 return_type_t<T_alpha, T_beta, T_scale> normal_id_glm_lpdf(
-    const matrix_cl<double> &y_cl, const matrix_cl<double> &x_cl,
-    const T_alpha &alpha, const T_beta &beta, const T_scale &sigma) {
-  static const char *function = "normal_id_glm_lpdf(OpenCL)";
+    const matrix_cl<double>& y_cl, const matrix_cl<double>& x_cl,
+    const T_alpha& alpha, const T_beta& beta, const T_scale& sigma) {
+  static const char* function = "normal_id_glm_lpdf(OpenCL)";
   using T_partials_return = partials_return_t<T_alpha, T_beta, T_scale>;
   using T_scale_val = typename std::conditional_t<
       is_vector<T_scale>::value,
@@ -68,7 +68,6 @@ return_type_t<T_alpha, T_beta, T_scale> normal_id_glm_lpdf(
   const size_t N = x_cl.rows();
   const size_t M = x_cl.cols();
 
-  check_positive_finite(function, "Scale vector", sigma);
   if (y_cl.size() != 1) {
     check_size_match(function, "Rows of ", "x_cl", N, "rows of ", "y_cl",
                      y_cl.size());
@@ -82,6 +81,8 @@ return_type_t<T_alpha, T_beta, T_scale> normal_id_glm_lpdf(
     check_size_match(function, "Rows of ", "x_cl", N, "size of ", "alpha",
                      stan::math::size(alpha));
   }
+  const auto& sigma_ref = to_ref(sigma);
+  check_positive_finite(function, "Scale vector", sigma_ref);
 
   if (!include_summand<propto, T_alpha, T_beta, T_scale>::value) {
     return 0;
@@ -91,13 +92,17 @@ return_type_t<T_alpha, T_beta, T_scale> normal_id_glm_lpdf(
     return 0;
   }
 
-  const auto &beta_val = value_of_rec(beta);
-  const auto &alpha_val = value_of_rec(alpha);
-  const auto &sigma_val = value_of_rec(sigma);
+  const auto& beta_ref = to_ref_if<!is_constant<T_beta>::value>(beta);
+  const auto& alpha_ref = to_ref_if<!is_constant<T_alpha>::value>(alpha);
 
-  const auto &beta_val_vec = as_column_vector_or_scalar(beta_val);
-  const auto &alpha_val_vec = as_column_vector_or_scalar(alpha_val);
-  const auto &sigma_val_vec = to_ref(as_column_vector_or_scalar(sigma_val));
+  const auto &beta_val = value_of_rec(beta_ref);
+  const auto &alpha_val = value_of_rec(alpha_ref);
+  const auto &sigma_val = value_of_rec(sigma_ref);
+
+  const auto& beta_val_vec = as_column_vector_or_scalar(beta_val);
+  const auto& alpha_val_vec = as_column_vector_or_scalar(alpha_val);
+  const auto& sigma_val_vec
+      = to_ref(as_column_vector_or_scalar(sigma_val));
 
   T_scale_val inv_sigma = 1 / as_array_or_scalar(sigma_val_vec);
   Matrix<T_partials_return, Dynamic, 1> y_minus_mu_over_sigma_mat(N);
@@ -133,14 +138,15 @@ return_type_t<T_alpha, T_beta, T_scale> normal_id_glm_lpdf(
         y_cl.size() != 1, stan::math::size(alpha) != 1,
         stan::math::size(sigma) != 1, need_mu_derivative,
         need_mu_derivative_sum, need_sigma_derivative, need_log_sigma_sum);
-  } catch (const cl::Error &e) {
+  } catch (const cl::Error& e) {
     check_opencl_error(function, e);
   }
   double y_scaled_sq_sum
       = sum(from_matrix_cl(y_minus_mu_over_sigma_squared_sum_cl));
 
-  operands_and_partials<T_alpha, T_beta, T_scale> ops_partials(alpha, beta,
-                                                               sigma);
+  operands_and_partials<decltype(alpha_ref), decltype(beta_ref),
+                        decltype(sigma_ref)>
+      ops_partials(alpha_ref, beta_ref, sigma_ref);
 
   if (!is_constant_all<T_alpha>::value && is_vector<T_alpha>::value) {
     ops_partials.edge1_.partials_
@@ -186,7 +192,7 @@ return_type_t<T_alpha, T_beta, T_scale> normal_id_glm_lpdf(
     if (is_vector<T_scale>::value) {
       logp -= sum(from_matrix_cl(log_sigma_sum_cl));
     } else {
-      logp -= N * log(forward_as<double>(sigma_val));
+      logp -= N * log(forward_as<double>(sigma_val_vec));
     }
   }
   logp -= 0.5 * y_scaled_sq_sum;

--- a/stan/math/opencl/prim/normal_id_glm_lpdf.hpp
+++ b/stan/math/opencl/prim/normal_id_glm_lpdf.hpp
@@ -193,13 +193,6 @@ return_type_t<T_alpha, T_beta, T_scale> normal_id_glm_lpdf(
   return ops_partials.build(logp);
 }
 
-template <typename T_alpha, typename T_beta, typename T_scale>
-inline return_type_t<T_alpha, T_beta, T_scale> normal_id_glm_lpdf(
-    const matrix_cl<double> &y, const matrix_cl<double> &x,
-    const T_alpha &alpha, const T_beta &beta, const T_scale &sigma) {
-  return normal_id_glm_lpdf<false>(y, x, alpha, beta, sigma);
-}
-
 }  // namespace math
 }  // namespace stan
 

--- a/stan/math/opencl/prim/normal_id_glm_lpdf.hpp
+++ b/stan/math/opencl/prim/normal_id_glm_lpdf.hpp
@@ -101,8 +101,7 @@ return_type_t<T_alpha, T_beta, T_scale> normal_id_glm_lpdf(
 
   const auto& beta_val_vec = as_column_vector_or_scalar(beta_val);
   const auto& alpha_val_vec = as_column_vector_or_scalar(alpha_val);
-  const auto& sigma_val_vec
-      = to_ref(as_column_vector_or_scalar(sigma_val));
+  const auto& sigma_val_vec = to_ref(as_column_vector_or_scalar(sigma_val));
 
   T_scale_val inv_sigma = 1 / as_array_or_scalar(sigma_val_vec);
   Matrix<T_partials_return, Dynamic, 1> y_minus_mu_over_sigma_mat(N);

--- a/stan/math/opencl/prim/normal_id_glm_lpdf.hpp
+++ b/stan/math/opencl/prim/normal_id_glm_lpdf.hpp
@@ -101,7 +101,8 @@ return_type_t<T_alpha, T_beta, T_scale> normal_id_glm_lpdf(
 
   const auto& beta_val_vec = as_column_vector_or_scalar(beta_val);
   const auto& alpha_val_vec = as_column_vector_or_scalar(alpha_val);
-  const auto& sigma_val_vec = to_ref<Eigen::Stride<0,0>>(as_column_vector_or_scalar(sigma_val));
+  const auto& sigma_val_vec
+      = to_ref<Eigen::Stride<0, 0>>(as_column_vector_or_scalar(sigma_val));
 
   T_scale_val inv_sigma = 1 / as_array_or_scalar(sigma_val_vec);
   Matrix<T_partials_return, Dynamic, 1> y_minus_mu_over_sigma_mat(N);

--- a/stan/math/opencl/prim/normal_id_glm_lpdf.hpp
+++ b/stan/math/opencl/prim/normal_id_glm_lpdf.hpp
@@ -95,14 +95,13 @@ return_type_t<T_alpha, T_beta, T_scale> normal_id_glm_lpdf(
   const auto& beta_ref = to_ref_if<!is_constant<T_beta>::value>(beta);
   const auto& alpha_ref = to_ref_if<!is_constant<T_alpha>::value>(alpha);
 
-  const auto &beta_val = value_of_rec(beta_ref);
-  const auto &alpha_val = value_of_rec(alpha_ref);
-  const auto &sigma_val = value_of_rec(sigma_ref);
+  const auto& beta_val = value_of_rec(beta_ref);
+  const auto& alpha_val = value_of_rec(alpha_ref);
+  const auto& sigma_val = value_of_rec(sigma_ref);
 
   const auto& beta_val_vec = as_column_vector_or_scalar(beta_val);
   const auto& alpha_val_vec = as_column_vector_or_scalar(alpha_val);
-  const auto& sigma_val_vec
-      = to_ref(as_column_vector_or_scalar(sigma_val));
+  const auto& sigma_val_vec = to_ref(as_column_vector_or_scalar(sigma_val));
 
   T_scale_val inv_sigma = 1 / as_array_or_scalar(sigma_val_vec);
   Matrix<T_partials_return, Dynamic, 1> y_minus_mu_over_sigma_mat(N);

--- a/stan/math/opencl/prim/normal_id_glm_lpdf.hpp
+++ b/stan/math/opencl/prim/normal_id_glm_lpdf.hpp
@@ -102,7 +102,7 @@ return_type_t<T_alpha, T_beta, T_scale> normal_id_glm_lpdf(
   const auto& beta_val_vec = as_column_vector_or_scalar(beta_val);
   const auto& alpha_val_vec = as_column_vector_or_scalar(alpha_val);
   const auto& sigma_val_vec
-      = to_ref<Eigen::Stride<0, 0>>(as_column_vector_or_scalar(sigma_val));
+      = to_ref(as_column_vector_or_scalar(sigma_val));
 
   T_scale_val inv_sigma = 1 / as_array_or_scalar(sigma_val_vec);
   Matrix<T_partials_return, Dynamic, 1> y_minus_mu_over_sigma_mat(N);

--- a/stan/math/opencl/prim/ordered_logistic_glm_lpmf.hpp
+++ b/stan/math/opencl/prim/ordered_logistic_glm_lpmf.hpp
@@ -65,7 +65,7 @@ return_type_t<T_beta, T_cuts> ordered_logistic_glm_lpmf(
                      "y_cl", y_cl.size());
   }
   check_consistent_size(function, "Weight vector", beta, N_attributes);
-  const auto& cuts_ref = to_ref<Eigen::Stride<0, 0>>(cuts);
+  const auto& cuts_ref = to_ref(cuts);
   check_ordered(function, "Cut-points", cuts_ref);
   if (N_classes > 1) {
     if (N_classes > 2) {

--- a/stan/math/opencl/prim/ordered_logistic_glm_lpmf.hpp
+++ b/stan/math/opencl/prim/ordered_logistic_glm_lpmf.hpp
@@ -8,6 +8,7 @@
 #include <stan/math/prim/fun/size.hpp>
 #include <stan/math/prim/fun/size_zero.hpp>
 #include <stan/math/prim/fun/sum.hpp>
+#include <stan/math/prim/fun/to_ref.hpp>
 #include <stan/math/prim/fun/value_of_rec.hpp>
 #include <stan/math/opencl/copy.hpp>
 #include <stan/math/opencl/kernel_generator.hpp>

--- a/stan/math/opencl/prim/ordered_logistic_glm_lpmf.hpp
+++ b/stan/math/opencl/prim/ordered_logistic_glm_lpmf.hpp
@@ -26,8 +26,8 @@ namespace math {
  * This is an overload of the GLM in
  * prim/prob/ordered_logistic_glm_lpmf.hpp that is implemented in OpenCL.
  *
- * @tparam T_beta_scalar type of a scalar in the vector of weights
- * @tparam T_cuts_scalar type of a scalar in the vector of cutpoints
+ * @tparam T_beta type the vector of weights
+ * @tparam T_cuts type the vector of cutpoints
  * @param y_cl a scalar or vector of classes on OpenCL device. If it is a scalar
  * it will be broadcast - used for all instances. Values should be between 1 and
  * number of classes, including endpoints.
@@ -41,17 +41,17 @@ namespace math {
  * ascending order or any input is not finite
  * @throw std::invalid_argument if container sizes mismatch.
  */
-template <bool propto, typename T_beta_scalar, typename T_cuts_scalar>
-return_type_t<T_beta_scalar, T_cuts_scalar> ordered_logistic_glm_lpmf(
+template <bool propto, typename T_beta, typename T_cuts,
+          require_all_eigen_col_vector_t<T_beta, T_cuts>* = nullptr>
+return_type_t<T_beta, T_cuts> ordered_logistic_glm_lpmf(
     const matrix_cl<int>& y_cl, const matrix_cl<double>& x_cl,
-    const Eigen::Matrix<T_beta_scalar, Eigen::Dynamic, 1>& beta,
-    const Eigen::Matrix<T_cuts_scalar, Eigen::Dynamic, 1>& cuts) {
+    const T_beta& beta, const T_cuts& cuts) {
   using Eigen::Array;
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using Eigen::VectorXd;
   using std::isfinite;
-  using T_partials_return = partials_return_t<T_beta_scalar, T_cuts_scalar>;
+  using T_partials_return = partials_return_t<T_beta, T_cuts>;
 
   static const char* function = "ordered_logistic_glm_lpmf";
 
@@ -76,7 +76,7 @@ return_type_t<T_beta_scalar, T_cuts_scalar> ordered_logistic_glm_lpmf(
     return 0;
   }
 
-  if (!include_summand<propto, T_beta_scalar, T_cuts_scalar>::value) {
+  if (!include_summand<propto, T_beta, T_cuts>::value) {
     return 0;
   }
 
@@ -86,9 +86,7 @@ return_type_t<T_beta_scalar, T_cuts_scalar> ordered_logistic_glm_lpmf(
   const auto& beta_val_vec = as_column_vector_or_scalar(beta_val);
   const auto& cuts_val_vec = as_column_vector_or_scalar(cuts_val);
 
-  operands_and_partials<Eigen::Matrix<T_beta_scalar, Eigen::Dynamic, 1>,
-                        Eigen::Matrix<T_cuts_scalar, Eigen::Dynamic, 1>>
-      ops_partials(beta, cuts);
+  operands_and_partials<T_beta, T_cuts> ops_partials(beta, cuts);
   const int local_size
       = opencl_kernels::ordered_logistic_glm.get_option("LOCAL_SIZE_");
   const int wgs = (N_instances + local_size - 1) / local_size;
@@ -96,8 +94,8 @@ return_type_t<T_beta_scalar, T_cuts_scalar> ordered_logistic_glm_lpmf(
   const matrix_cl<double> beta_cl(beta_val);
   const matrix_cl<double> cuts_cl(cuts_val);
 
-  bool need_location_derivative = !is_constant_all<T_beta_scalar>::value;
-  bool need_cuts_derivative = !is_constant_all<T_cuts_scalar>::value;
+  bool need_location_derivative = !is_constant_all<T_beta>::value;
+  bool need_cuts_derivative = !is_constant_all<T_cuts>::value;
   matrix_cl<double> logp_cl(wgs, 1);
   matrix_cl<double> location_sum_cl(wgs, 1);
   matrix_cl<double> location_derivative_cl(need_location_derivative ? 1 : 0,
@@ -125,23 +123,15 @@ return_type_t<T_beta_scalar, T_cuts_scalar> ordered_logistic_glm_lpmf(
                  from_matrix_cl(x_cl));
   }
 
-  if (!is_constant_all<T_beta_scalar>::value) {
+  if (!is_constant_all<T_beta>::value) {
     ops_partials.edge1_.partials_
         = from_matrix_cl<1, Dynamic>(location_derivative_cl * x_cl);
   }
-  if (!is_constant_all<T_cuts_scalar>::value) {
+  if (!is_constant_all<T_cuts>::value) {
     ops_partials.edge2_.partials_
         = from_matrix_cl(cuts_derivative_cl).colwise().sum();
   }
   return ops_partials.build(logp);
-}
-
-template <typename T_beta_scalar, typename T_cuts_scalar>
-return_type_t<T_beta_scalar, T_cuts_scalar> ordered_logistic_glm_lpmf(
-    const matrix_cl<int>& y, const matrix_cl<double>& x,
-    const Eigen::Matrix<T_beta_scalar, Eigen::Dynamic, 1>& beta,
-    const Eigen::Matrix<T_cuts_scalar, Eigen::Dynamic, 1>& cuts) {
-  return ordered_logistic_glm_lpmf<false>(y, x, beta, cuts);
 }
 
 }  // namespace math

--- a/stan/math/opencl/prim/ordered_logistic_glm_lpmf.hpp
+++ b/stan/math/opencl/prim/ordered_logistic_glm_lpmf.hpp
@@ -65,7 +65,7 @@ return_type_t<T_beta, T_cuts> ordered_logistic_glm_lpmf(
                      "y_cl", y_cl.size());
   }
   check_consistent_size(function, "Weight vector", beta, N_attributes);
-  const auto& cuts_ref = to_ref<Eigen::Stride<0,0>>(cuts);
+  const auto& cuts_ref = to_ref<Eigen::Stride<0, 0>>(cuts);
   check_ordered(function, "Cut-points", cuts_ref);
   if (N_classes > 1) {
     if (N_classes > 2) {

--- a/stan/math/opencl/prim/ordered_logistic_glm_lpmf.hpp
+++ b/stan/math/opencl/prim/ordered_logistic_glm_lpmf.hpp
@@ -65,7 +65,7 @@ return_type_t<T_beta, T_cuts> ordered_logistic_glm_lpmf(
                      "y_cl", y_cl.size());
   }
   check_consistent_size(function, "Weight vector", beta, N_attributes);
-  const auto& cuts_ref = to_ref(cuts);
+  const auto& cuts_ref = to_ref<Eigen::Stride<0,0>>(cuts);
   check_ordered(function, "Cut-points", cuts_ref);
   if (N_classes > 1) {
     if (N_classes > 2) {

--- a/stan/math/opencl/prim/poisson_log_glm_lpmf.hpp
+++ b/stan/math/opencl/prim/poisson_log_glm_lpmf.hpp
@@ -136,12 +136,6 @@ return_type_t<T_alpha, T_beta> poisson_log_glm_lpmf(
   return ops_partials.build(logp);
 }
 
-template <typename T_alpha, typename T_beta>
-inline return_type_t<T_alpha, T_beta> poisson_log_glm_lpmf(
-    const matrix_cl<int>& y, const matrix_cl<double>& x, const T_alpha& alpha,
-    const T_beta& beta) {
-  return poisson_log_glm_lpmf<false>(y, x, alpha, beta);
-}
 }  // namespace math
 }  // namespace stan
 

--- a/stan/math/opencl/prim/poisson_log_glm_lpmf.hpp
+++ b/stan/math/opencl/prim/poisson_log_glm_lpmf.hpp
@@ -8,6 +8,7 @@
 #include <stan/math/prim/fun/size.hpp>
 #include <stan/math/prim/fun/size_zero.hpp>
 #include <stan/math/prim/fun/sum.hpp>
+#include <stan/math/prim/fun/to_ref.hpp>
 #include <stan/math/prim/fun/value_of.hpp>
 #include <stan/math/prim/fun/value_of_rec.hpp>
 #include <stan/math/opencl/copy.hpp>

--- a/stan/math/prim/err/check_ordered.hpp
+++ b/stan/math/prim/err/check_ordered.hpp
@@ -21,12 +21,10 @@ namespace math {
  *   not ordered, if there are duplicated
  *   values, or if any element is <code>NaN</code>.
  */
-template <typename T_y>
+template <typename T_y, require_eigen_vector_t<T_y>* = nullptr>
 void check_ordered(const char* function, const char* name,
-                   const Eigen::Matrix<T_y, Eigen::Dynamic, 1>& y) {
-  using size_type = index_type_t<Eigen::Matrix<T_y, Eigen::Dynamic, 1>>;
-
-  for (size_type n = 1; n < y.size(); n++) {
+                   const T_y& y) {
+  for (Eigen::Index n = 1; n < y.size(); n++) {
     if (!(y[n] > y[n - 1])) {
       std::ostringstream msg1;
       msg1 << "is not a valid ordered vector."

--- a/stan/math/prim/err/check_ordered.hpp
+++ b/stan/math/prim/err/check_ordered.hpp
@@ -22,8 +22,7 @@ namespace math {
  *   values, or if any element is <code>NaN</code>.
  */
 template <typename T_y, require_eigen_vector_t<T_y>* = nullptr>
-void check_ordered(const char* function, const char* name,
-                   const T_y& y) {
+void check_ordered(const char* function, const char* name, const T_y& y) {
   for (Eigen::Index n = 1; n < y.size(); n++) {
     if (!(y[n] > y[n - 1])) {
       std::ostringstream msg1;

--- a/stan/math/prim/fun/to_ref.hpp
+++ b/stan/math/prim/fun/to_ref.hpp
@@ -12,13 +12,7 @@ namespace math {
  * @tparam T argument type
  * @param a argument
  * @return optionally evaluated argument
- * @tparam Ref_stride Stride type (see the documentation for `Eigen::Ref`).
- * Default is same as in `Eigen::Ref`.
  */
-template <typename Ref_stride, typename T>
-inline ref_type_t<T&&, Ref_stride> to_ref(T&& a) {
-  return std::forward<T>(a);
-}
 template <typename T>
 inline ref_type_t<T&&> to_ref(T&& a) {
   return std::forward<T>(a);
@@ -31,9 +25,8 @@ inline ref_type_t<T&&> to_ref(T&& a) {
  * @param a argument
  * @return argument
  */
-template <bool Cond, typename T,
-          require_not_t<conjunction<is_eigen<T>, is_var<value_type_t<T>>,
-                                    bool_constant<Cond>>>* = nullptr>
+template <
+    bool Cond, typename T, std::enable_if_t<!Cond>* = nullptr>
 inline T to_ref_if(T&& a) {
   return std::forward<T>(a);
 }
@@ -46,8 +39,7 @@ inline T to_ref_if(T&& a) {
  * @param a argument
  * @return argument converted to `Eigen::Ref`
  */
-template <bool Cond, typename T, require_eigen_vt<is_var, T>* = nullptr,
-          std::enable_if_t<Cond>* = nullptr>
+template <bool Cond, typename T, std::enable_if_t<Cond>* = nullptr>
 inline ref_type_t<T&&> to_ref_if(T&& a) {
   return std::forward<T>(a);
 }

--- a/stan/math/prim/fun/to_ref.hpp
+++ b/stan/math/prim/fun/to_ref.hpp
@@ -25,8 +25,7 @@ inline ref_type_t<T&&> to_ref(T&& a) {
  * @param a argument
  * @return argument
  */
-template <
-    bool Cond, typename T, std::enable_if_t<!Cond>* = nullptr>
+template <bool Cond, typename T, std::enable_if_t<!Cond>* = nullptr>
 inline T to_ref_if(T&& a) {
   return std::forward<T>(a);
 }

--- a/stan/math/prim/fun/to_ref.hpp
+++ b/stan/math/prim/fun/to_ref.hpp
@@ -7,25 +7,14 @@ namespace stan {
 namespace math {
 
 /**
- * No-op that should be optimized away.
- * @tparam T non-Eigen argument type
+ * This evaluates expensive Eigen expressions. If given expression involves no
+ * calculations this is a no-op that should be optimized away.
+ * @tparam T argument type
  * @param a argument
- * @return argument
+ * @return optionally evaluated argument
  */
-template <typename T, require_not_eigen_t<T>* = nullptr>
-inline T to_ref(T&& a) {
-  return std::forward<T>(a);
-}
-
-/**
- * Converts Eigen argument into `Eigen::Ref`. This evaluates expensive
- * expressions.
- * @tparam T argument type (Eigen expression)
- * @param a argument
- * @return argument converted to `Eigen::Ref`
- */
-template <typename T, require_eigen_t<T>* = nullptr>
-inline Eigen::Ref<const plain_type_t<T>> to_ref(T&& a) {
+template <typename T>
+inline ref_type_t<T> to_ref(T&& a) {
   return std::forward<T>(a);
 }
 
@@ -53,7 +42,7 @@ inline T to_ref_if(T&& a) {
  */
 template <bool Cond, typename T, require_eigen_vt<is_var, T>* = nullptr,
           std::enable_if_t<Cond>* = nullptr>
-inline Eigen::Ref<const plain_type_t<T>> to_ref_if(T&& a) {
+inline ref_type_t<T> to_ref_if(T&& a) {
   return std::forward<T>(a);
 }
 

--- a/stan/math/prim/fun/to_ref.hpp
+++ b/stan/math/prim/fun/to_ref.hpp
@@ -44,8 +44,8 @@ inline T to_ref_if(T&& a) {
 }
 
 /**
- * If the condition is true, converts Eigen argument into `Eigen::Ref`. This evaluates expensive
- * expressions.
+ * If the condition is true, converts Eigen argument into `Eigen::Ref`. This
+ * evaluates expensive expressions.
  * @tparam Cond condition
  * @tparam T argument type (Eigen expression)
  * @param a argument

--- a/stan/math/prim/fun/to_ref.hpp
+++ b/stan/math/prim/fun/to_ref.hpp
@@ -14,7 +14,7 @@ namespace math {
  * @return optionally evaluated argument
  */
 template <typename T>
-inline ref_type_t<T> to_ref(T&& a) {
+inline ref_type_t<T&&> to_ref(T&& a) {
   return std::forward<T>(a);
 }
 
@@ -42,7 +42,7 @@ inline T to_ref_if(T&& a) {
  */
 template <bool Cond, typename T, require_eigen_vt<is_var, T>* = nullptr,
           std::enable_if_t<Cond>* = nullptr>
-inline ref_type_t<T> to_ref_if(T&& a) {
+inline ref_type_t<T&&> to_ref_if(T&& a) {
   return std::forward<T>(a);
 }
 

--- a/stan/math/prim/fun/to_ref.hpp
+++ b/stan/math/prim/fun/to_ref.hpp
@@ -18,7 +18,7 @@ inline T to_ref(T&& a) {
 }
 
 /**
- * Converts Eigen argument into `Eigen::Ref`. This evaluate expensive
+ * Converts Eigen argument into `Eigen::Ref`. This evaluates expensive
  * expressions.
  * @tparam T argument type (Eigen expression)
  * @param a argument
@@ -26,6 +26,34 @@ inline T to_ref(T&& a) {
  */
 template <typename T, require_eigen_t<T>* = nullptr>
 inline Eigen::Ref<const plain_type_t<T>> to_ref(T&& a) {
+  return std::forward<T>(a);
+}
+
+/**
+ * No-op that should be optimized away.
+ * @tparam Cond condition
+ * @tparam T argument type
+ * @param a argument
+ * @return argument
+ */
+template <bool Cond, typename T,
+          require_not_t<conjunction<is_eigen<T>, is_var<value_type_t<T>>,
+                                    bool_constant<Cond>>>* = nullptr>
+inline T to_ref_if(T&& a) {
+  return std::forward<T>(a);
+}
+
+/**
+ * If the condition is true, converts Eigen argument into `Eigen::Ref`. This evaluates expensive
+ * expressions.
+ * @tparam Cond condition
+ * @tparam T argument type (Eigen expression)
+ * @param a argument
+ * @return argument converted to `Eigen::Ref`
+ */
+template <bool Cond, typename T, require_eigen_vt<is_var, T>* = nullptr,
+          std::enable_if_t<Cond>* = nullptr>
+inline Eigen::Ref<const plain_type_t<T>> to_ref_if(T&& a) {
   return std::forward<T>(a);
 }
 

--- a/stan/math/prim/fun/to_ref.hpp
+++ b/stan/math/prim/fun/to_ref.hpp
@@ -12,7 +12,13 @@ namespace math {
  * @tparam T argument type
  * @param a argument
  * @return optionally evaluated argument
+ * @tparam Ref_stride Stride type (see the documentation for `Eigen::Ref`).
+ * Default is same as in `Eigen::Ref`.
  */
+template <typename Ref_stride, typename T>
+inline ref_type_t<T&&, Ref_stride> to_ref(T&& a) {
+  return std::forward<T>(a);
+}
 template <typename T>
 inline ref_type_t<T&&> to_ref(T&& a) {
   return std::forward<T>(a);

--- a/stan/math/prim/meta.hpp
+++ b/stan/math/prim/meta.hpp
@@ -204,6 +204,7 @@
 #include <stan/math/prim/meta/plain_type.hpp>
 #include <stan/math/prim/meta/promote_args.hpp>
 #include <stan/math/prim/meta/promote_scalar_type.hpp>
+#include <stan/math/prim/meta/ref_type.hpp>
 #include <stan/math/prim/meta/require_generics.hpp>
 #include <stan/math/prim/meta/return_type.hpp>
 #include <stan/math/prim/meta/scalar_seq_view.hpp>

--- a/stan/math/prim/meta/operands_and_partials.hpp
+++ b/stan/math/prim/meta/operands_and_partials.hpp
@@ -120,11 +120,11 @@ class operands_and_partials {
   T_return_type build(double value) { return value; }
 
   // These will always be 0 size base template instantiations (above).
-  internal::ops_partials_edge<double, Op1> edge1_;
-  internal::ops_partials_edge<double, Op2> edge2_;
-  internal::ops_partials_edge<double, Op3> edge3_;
-  internal::ops_partials_edge<double, Op4> edge4_;
-  internal::ops_partials_edge<double, Op5> edge5_;
+  internal::ops_partials_edge<double, std::decay_t<Op1>> edge1_;
+  internal::ops_partials_edge<double, std::decay_t<Op2>> edge2_;
+  internal::ops_partials_edge<double, std::decay_t<Op3>> edge3_;
+  internal::ops_partials_edge<double, std::decay_t<Op4>> edge4_;
+  internal::ops_partials_edge<double, std::decay_t<Op5>> edge5_;
 };
 
 namespace internal {

--- a/stan/math/prim/meta/ref_type.hpp
+++ b/stan/math/prim/meta/ref_type.hpp
@@ -1,6 +1,11 @@
 #ifndef STAN_MATH_PRIM_META_REF_TYPE_HPP
 #define STAN_MATH_PRIM_META_REF_TYPE_HPP
 
+#include <stan/math/prim/meta/is_eigen.hpp>
+#include <stan/math/prim/meta/is_vector.hpp>
+#include <stan/math/prim/meta/plain_type.hpp>
+#include <stan/math/prim/fun/Eigen.hpp>
+
 #include <type_traits>
 
 namespace stan {

--- a/stan/math/prim/meta/ref_type.hpp
+++ b/stan/math/prim/meta/ref_type.hpp
@@ -1,0 +1,40 @@
+#ifndef STAN_MATH_PRIM_META_REF_TYPE_HPP
+#define STAN_MATH_PRIM_META_REF_TYPE_HPP
+
+namespace stan {
+
+/**
+ * Determines appropriate type for assigning expression of given type to,
+ * to evaluate expensive expressions, but not make a copy if T involves no
+ * calculations. This works similarly as `Eigen::Ref`. It also handles
+ * rvalue references, so it can be used with perfect forwarding.
+ * @tparam T type to determine reference for
+ * @tparam Ref_stride Stride type (see the documentation for `Eigen::Ref`)
+ */
+template <typename T,
+          typename Ref_stride
+          = std::conditional_t<is_eigen_vector<T>::value, Eigen::InnerStride<1>,
+                               Eigen::OuterStride<>>,
+          typename = void>
+struct ref_type {
+  using T_plain = plain_type_t<T>;
+  using T_optionally_ref
+      = std::conditional_t<std::is_rvalue_reference<T>::value, std::remove_reference_t<T>, const T&>;
+  using type = std::conditional_t<
+      Eigen::internal::traits<Eigen::Ref<std::decay_t<T_plain>, 0, Ref_stride>>::
+          template match<std::decay_t<T>>::MatchAtCompileTime,
+      T_optionally_ref, T_plain>;
+};
+
+template <typename T, typename Ref_stride>
+struct ref_type<T, Ref_stride, require_not_eigen_t<T>> {
+  using type
+      = std::conditional_t<std::is_rvalue_reference<T>::value, T, const T&>;
+};
+
+template <typename T>
+using ref_type_t = typename ref_type<T>::type;
+
+}  // namespace stan
+
+#endif

--- a/stan/math/prim/meta/ref_type.hpp
+++ b/stan/math/prim/meta/ref_type.hpp
@@ -20,16 +20,14 @@ namespace stan {
  * template parameter `T` is of correct reference type (rvalue).
  * @tparam T type to determine reference for
  */
-template <typename T,
-          typename = void>
+template <typename T, typename = void>
 struct ref_type {
   using T_plain = plain_type_t<T>;
   using T_optionally_ref
       = std::conditional_t<std::is_rvalue_reference<T>::value,
                            std::remove_reference_t<T>, const T&>;
   using type = std::conditional_t<
-      Eigen::internal::traits<
-          Eigen::Ref<std::decay_t<T_plain>>>::
+      Eigen::internal::traits<Eigen::Ref<std::decay_t<T_plain>>>::
           template match<std::decay_t<T>>::MatchAtCompileTime,
       T_optionally_ref, T_plain>;
 };

--- a/stan/math/prim/meta/ref_type.hpp
+++ b/stan/math/prim/meta/ref_type.hpp
@@ -19,13 +19,8 @@ namespace stan {
  * Warning: if a variable of this type could be assigned a rvalue, make sure
  * template parameter `T` is of correct reference type (rvalue).
  * @tparam T type to determine reference for
- * @tparam Ref_stride Stride type (see the documentation for `Eigen::Ref`).
- * Default is same as in `Eigen::Ref`.
  */
 template <typename T,
-          typename Ref_stride
-          = std::conditional_t<is_eigen_vector<T>::value, Eigen::InnerStride<1>,
-                               Eigen::OuterStride<>>,
           typename = void>
 struct ref_type {
   using T_plain = plain_type_t<T>;
@@ -34,21 +29,18 @@ struct ref_type {
                            std::remove_reference_t<T>, const T&>;
   using type = std::conditional_t<
       Eigen::internal::traits<
-          Eigen::Ref<std::decay_t<T_plain>, 0, Ref_stride>>::
+          Eigen::Ref<std::decay_t<T_plain>>>::
           template match<std::decay_t<T>>::MatchAtCompileTime,
       T_optionally_ref, T_plain>;
 };
 
-template <typename T, typename Ref_stride>
-struct ref_type<T, Ref_stride, require_not_eigen_t<T>> {
+template <typename T>
+struct ref_type<T, require_not_eigen_t<T>> {
   using type
       = std::conditional_t<std::is_rvalue_reference<T>::value, T, const T&>;
 };
 
-template <typename T,
-          typename Ref_stride
-          = std::conditional_t<is_eigen_vector<T>::value, Eigen::InnerStride<1>,
-                               Eigen::OuterStride<>>>
+template <typename T>
 using ref_type_t = typename ref_type<T>::type;
 
 }  // namespace stan

--- a/stan/math/prim/meta/ref_type.hpp
+++ b/stan/math/prim/meta/ref_type.hpp
@@ -19,7 +19,8 @@ namespace stan {
  * Warning: if a variable of this type could be assigned a rvalue, make sure
  * template parameter `T` is of correct reference type (rvalue).
  * @tparam T type to determine reference for
- * @tparam Ref_stride Stride type (see the documentation for `Eigen::Ref`)
+ * @tparam Ref_stride Stride type (see the documentation for `Eigen::Ref`).
+ * Default is same as in `Eigen::Ref`.
  */
 template <typename T,
           typename Ref_stride
@@ -44,7 +45,10 @@ struct ref_type<T, Ref_stride, require_not_eigen_t<T>> {
       = std::conditional_t<std::is_rvalue_reference<T>::value, T, const T&>;
 };
 
-template <typename T>
+template <typename T,
+          typename Ref_stride
+          = std::conditional_t<is_eigen_vector<T>::value, Eigen::InnerStride<1>,
+                               Eigen::OuterStride<>>>
 using ref_type_t = typename ref_type<T>::type;
 
 }  // namespace stan

--- a/stan/math/prim/meta/ref_type.hpp
+++ b/stan/math/prim/meta/ref_type.hpp
@@ -15,6 +15,9 @@ namespace stan {
  * to evaluate expensive expressions, but not make a copy if T involves no
  * calculations. This works similarly as `Eigen::Ref`. It also handles
  * rvalue references, so it can be used with perfect forwarding.
+ *
+ * Warning: if a variable of this type could be assigned a rvalue, make sure
+ * template parameter `T` is of correct reference type (rvalue).
  * @tparam T type to determine reference for
  * @tparam Ref_stride Stride type (see the documentation for `Eigen::Ref`)
  */

--- a/stan/math/prim/meta/ref_type.hpp
+++ b/stan/math/prim/meta/ref_type.hpp
@@ -19,9 +19,11 @@ template <typename T,
 struct ref_type {
   using T_plain = plain_type_t<T>;
   using T_optionally_ref
-      = std::conditional_t<std::is_rvalue_reference<T>::value, std::remove_reference_t<T>, const T&>;
+      = std::conditional_t<std::is_rvalue_reference<T>::value,
+                           std::remove_reference_t<T>, const T&>;
   using type = std::conditional_t<
-      Eigen::internal::traits<Eigen::Ref<std::decay_t<T_plain>, 0, Ref_stride>>::
+      Eigen::internal::traits<
+          Eigen::Ref<std::decay_t<T_plain>, 0, Ref_stride>>::
           template match<std::decay_t<T>>::MatchAtCompileTime,
       T_optionally_ref, T_plain>;
 };

--- a/stan/math/prim/meta/ref_type.hpp
+++ b/stan/math/prim/meta/ref_type.hpp
@@ -1,6 +1,8 @@
 #ifndef STAN_MATH_PRIM_META_REF_TYPE_HPP
 #define STAN_MATH_PRIM_META_REF_TYPE_HPP
 
+#include <type_traits>
+
 namespace stan {
 
 /**

--- a/stan/math/prim/meta/scalar_seq_view.hpp
+++ b/stan/math/prim/meta/scalar_seq_view.hpp
@@ -4,6 +4,7 @@
 #include <stan/math/prim/meta/plain_type.hpp>
 #include <stan/math/prim/meta/require_generics.hpp>
 #include <stan/math/prim/meta/scalar_type.hpp>
+#include <stan/math/prim/meta/ref_type.hpp>
 #include <stan/math/prim/meta/is_vector_like.hpp>
 #include <type_traits>
 #include <utility>

--- a/stan/math/prim/meta/scalar_seq_view.hpp
+++ b/stan/math/prim/meta/scalar_seq_view.hpp
@@ -33,8 +33,8 @@ class scalar_seq_view<
    * @param i index
    * @return the element at the specified position in the container
    */
-  auto& operator[](int i) const { return c_[i]; }
-  auto& operator[](int i) { return c_[i]; }
+  decltype(auto) operator[](int i) const { return c_[i]; }
+  decltype(auto) operator[](int i) { return c_[i]; }
 
   int size() const { return c_.size(); }
 

--- a/stan/math/prim/meta/scalar_seq_view.hpp
+++ b/stan/math/prim/meta/scalar_seq_view.hpp
@@ -38,7 +38,7 @@ class scalar_seq_view<
   int size() const { return c_.size(); }
 
  private:
-  eval_return_type_t<C> c_;
+  ref_type_t<C> c_;
 };
 
 /** \ingroup type_trait

--- a/stan/math/prim/prob/bernoulli_logit_glm_lpmf.hpp
+++ b/stan/math/prim/prob/bernoulli_logit_glm_lpmf.hpp
@@ -45,7 +45,7 @@ namespace math {
 template <bool propto, typename T_y, typename T_x, typename T_alpha,
           typename T_beta, require_eigen_t<T_x>* = nullptr>
 return_type_t<T_x, T_alpha, T_beta> bernoulli_logit_glm_lpmf(
-    const T_y &y, const T_x &x, const T_alpha &alpha, const T_beta &beta) {
+    const T_y& y, const T_x& x, const T_alpha& alpha, const T_beta& beta) {
   using Eigen::Array;
   using Eigen::Dynamic;
   using Eigen::log1p;
@@ -64,12 +64,13 @@ return_type_t<T_x, T_alpha, T_beta> bernoulli_logit_glm_lpmf(
   const size_t N_instances = T_x_rows == 1 ? stan::math::size(y) : x.rows();
   const size_t N_attributes = x.cols();
 
-  static const char *function = "bernoulli_logit_glm_lpmf";
+  static const char* function = "bernoulli_logit_glm_lpmf";
   check_consistent_size(function, "Vector of dependent variables", y,
                         N_instances);
   check_consistent_size(function, "Weight vector", beta, N_attributes);
   check_consistent_size(function, "Vector of intercepts", alpha, N_instances);
-  check_bounded(function, "Vector of dependent variables", y, 0, 1);
+  const auto& y_ref = to_ref(y);
+  check_bounded(function, "Vector of dependent variables", y_ref, 0, 1);
 
   if (size_zero(y)) {
     return 0;
@@ -80,27 +81,33 @@ return_type_t<T_x, T_alpha, T_beta> bernoulli_logit_glm_lpmf(
   }
 
   T_partials_return logp(0);
-  const auto &x_val = to_ref(value_of_rec(x));
-  const auto &y_val = value_of_rec(y);
-  const auto &beta_val = value_of_rec(beta);
-  const auto &alpha_val = value_of_rec(alpha);
 
-  const auto &y_val_vec = as_column_vector_or_scalar(y_val);
-  const auto &beta_val_vec = to_ref(as_column_vector_or_scalar(beta_val));
-  const auto &alpha_val_vec = as_column_vector_or_scalar(alpha_val);
+  const auto& x_ref = to_ref_if<!is_constant<T_x>::value>(x);
+  const auto& alpha_ref = to_ref_if<!is_constant<T_alpha>::value>(alpha);
+  const auto& beta_ref = to_ref_if<!is_constant<T_beta>::value>(beta);
 
-  T_y_val signs = 2 * as_array_or_scalar(y_val_vec) - 1;
+  const auto& y_val = value_of_rec(y_ref);
+  const auto& x_val
+      = to_ref_if<!is_constant<T_beta>::value>(value_of_rec(x_ref));
+  const auto& alpha_val = value_of_rec(alpha_ref);
+  const auto& beta_val = value_of_rec(beta_ref);
+
+  const auto& y_val_vec = as_column_vector_or_scalar(y_val);
+  const auto& alpha_val_vec = as_column_vector_or_scalar(alpha_val);
+  const auto& beta_val_vec = to_ref_if<!is_constant<T_x>::value>(
+      as_column_vector_or_scalar(beta_val));
+
+  auto signs = to_ref_if<!is_constant_all<T_beta, T_x, T_alpha>::value>(
+      2 * as_array_or_scalar(y_val_vec) - 1);
 
   Array<T_partials_return, Dynamic, 1> ytheta(N_instances);
   if (T_x_rows == 1) {
     T_ytheta_tmp ytheta_tmp
         = forward_as<T_ytheta_tmp>((x_val * beta_val_vec)(0, 0));
-    ytheta = as_array_or_scalar(signs)
-             * (ytheta_tmp + as_array_or_scalar(alpha_val_vec));
+    ytheta = signs * (ytheta_tmp + as_array_or_scalar(alpha_val_vec));
   } else {
     ytheta = (x_val * beta_val_vec).array();
-    ytheta = as_array_or_scalar(signs)
-             * (ytheta + as_array_or_scalar(alpha_val_vec));
+    ytheta = signs * (ytheta + as_array_or_scalar(alpha_val_vec));
   }
 
   // Compute the log-density and handle extreme values gracefully
@@ -119,16 +126,17 @@ return_type_t<T_x, T_alpha, T_beta> bernoulli_logit_glm_lpmf(
     check_finite(function, "Matrix of independent variables", ytheta);
   }
 
-  operands_and_partials<T_x, T_alpha, T_beta> ops_partials(x, alpha, beta);
+  operands_and_partials<decltype(x_ref), decltype(alpha_ref),
+                        decltype(beta_ref)>
+      ops_partials(x_ref, alpha_ref, beta_ref);
   // Compute the necessary derivatives.
   if (!is_constant_all<T_beta, T_x, T_alpha>::value) {
     Matrix<T_partials_return, Dynamic, 1> theta_derivative
         = (ytheta > cutoff)
               .select(-exp_m_ytheta,
                       (ytheta < -cutoff)
-                          .select(as_array_or_scalar(signs),
-                                  as_array_or_scalar(signs) * exp_m_ytheta
-                                      / (exp_m_ytheta + 1)));
+                          .select(signs,
+                                  signs * exp_m_ytheta / (exp_m_ytheta + 1)));
     if (!is_constant_all<T_beta>::value) {
       if (T_x_rows == 1) {
         ops_partials.edge3_.partials_
@@ -161,7 +169,7 @@ return_type_t<T_x, T_alpha, T_beta> bernoulli_logit_glm_lpmf(
 
 template <typename T_y, typename T_x, typename T_alpha, typename T_beta>
 inline return_type_t<T_x, T_beta, T_alpha> bernoulli_logit_glm_lpmf(
-    const T_y &y, const T_x &x, const T_alpha &alpha, const T_beta &beta) {
+    const T_y& y, const T_x& x, const T_alpha& alpha, const T_beta& beta) {
   return bernoulli_logit_glm_lpmf<false>(y, x, alpha, beta);
 }
 }  // namespace math

--- a/stan/math/prim/prob/bernoulli_logit_glm_lpmf.hpp
+++ b/stan/math/prim/prob/bernoulli_logit_glm_lpmf.hpp
@@ -24,10 +24,7 @@ namespace math {
  *
  * @tparam T_y type of binary vector of dependent variables (labels);
  * this can also be a single binary value;
- * @tparam T_x_scalar type of a scalar in the matrix of independent variables
- * (features)
- * @tparam T_x_rows compile-time number of rows of `x`. It can be either
- * `Eigen::Dynamic` or 1.
+ * @tparam T_x type of the matrix of independent variables (features)
  * @tparam T_alpha type of the intercept(s);
  * this can be a vector (of the same length as y) of intercepts or a single
  * value (for models with constant intercept);
@@ -44,17 +41,17 @@ namespace math {
  * @throw std::domain_error if y is not binary.
  * @throw std::invalid_argument if container sizes mismatch.
  */
-template <bool propto, typename T_y, typename T_x_scalar, int T_x_rows,
-          typename T_alpha, typename T_beta>
-return_type_t<T_x_scalar, T_alpha, T_beta> bernoulli_logit_glm_lpmf(
-    const T_y &y, const Eigen::Matrix<T_x_scalar, T_x_rows, Eigen::Dynamic> &x,
-    const T_alpha &alpha, const T_beta &beta) {
+template <bool propto, typename T_y, typename T_x, typename T_alpha,
+          typename T_beta, require_eigen_t<T_x>* = nullptr>
+return_type_t<T_x, T_alpha, T_beta> bernoulli_logit_glm_lpmf(
+    const T_y &y, const T_x &x, const T_alpha &alpha, const T_beta &beta) {
   using Eigen::Array;
   using Eigen::Dynamic;
   using Eigen::log1p;
   using Eigen::Matrix;
   using std::exp;
-  using T_partials_return = partials_return_t<T_y, T_x_scalar, T_alpha, T_beta>;
+  constexpr int T_x_rows = T_x::RowsAtCompileTime;
+  using T_partials_return = partials_return_t<T_y, T_x, T_alpha, T_beta>;
   using T_y_val =
       typename std::conditional_t<is_vector<T_y>::value,
                                   Eigen::Matrix<partials_return_t<T_y>, -1, 1>,
@@ -77,7 +74,7 @@ return_type_t<T_x_scalar, T_alpha, T_beta> bernoulli_logit_glm_lpmf(
     return 0;
   }
 
-  if (!include_summand<propto, T_x_scalar, T_alpha, T_beta>::value) {
+  if (!include_summand<propto, T_x, T_alpha, T_beta>::value) {
     return 0;
   }
 
@@ -121,11 +118,9 @@ return_type_t<T_x_scalar, T_alpha, T_beta> bernoulli_logit_glm_lpmf(
     check_finite(function, "Matrix of independent variables", ytheta);
   }
 
-  operands_and_partials<Eigen::Matrix<T_x_scalar, T_x_rows, Eigen::Dynamic>,
-                        T_alpha, T_beta>
-      ops_partials(x, alpha, beta);
+  operands_and_partials<T_x, T_alpha, T_beta> ops_partials(x, alpha, beta);
   // Compute the necessary derivatives.
-  if (!is_constant_all<T_beta, T_x_scalar, T_alpha>::value) {
+  if (!is_constant_all<T_beta, T_x, T_alpha>::value) {
     Matrix<T_partials_return, Dynamic, 1> theta_derivative
         = (ytheta > cutoff)
               .select(-exp_m_ytheta,
@@ -142,7 +137,7 @@ return_type_t<T_x_scalar, T_alpha, T_beta> bernoulli_logit_glm_lpmf(
         ops_partials.edge3_.partials_ = x_val.transpose() * theta_derivative;
       }
     }
-    if (!is_constant_all<T_x_scalar>::value) {
+    if (!is_constant_all<T_x>::value) {
       if (T_x_rows == 1) {
         ops_partials.edge1_.partials_
             = forward_as<Array<T_partials_return, Dynamic, T_x_rows>>(

--- a/stan/math/prim/prob/normal_id_glm_lpdf.hpp
+++ b/stan/math/prim/prob/normal_id_glm_lpdf.hpp
@@ -47,11 +47,11 @@ namespace math {
  * @throw std::domain_error if the scale is not positive.
  * @throw std::invalid_argument if container sizes mismatch.
  */
-template <bool propto, typename T_y, typename T_x,
-          typename T_alpha, typename T_beta, typename T_scale, require_eigen_t<T_x>* = nullptr>
+template <bool propto, typename T_y, typename T_x, typename T_alpha,
+          typename T_beta, typename T_scale, require_eigen_t<T_x>* = nullptr>
 return_type_t<T_y, T_x, T_alpha, T_beta, T_scale> normal_id_glm_lpdf(
-    const T_y &y, const T_x& x,
-    const T_alpha &alpha, const T_beta &beta, const T_scale &sigma) {
+    const T_y& y, const T_x& x, const T_alpha& alpha, const T_beta& beta,
+    const T_scale& sigma) {
   using Eigen::Array;
   using Eigen::Dynamic;
   using Eigen::Matrix;
@@ -70,33 +70,42 @@ return_type_t<T_y, T_x, T_alpha, T_beta, T_scale> normal_id_glm_lpdf(
   const size_t N_instances = T_x_rows == 1 ? stan::math::size(y) : x.rows();
   const size_t N_attributes = x.cols();
 
-  static const char *function = "normal_id_glm_lpdf";
+  static const char* function = "normal_id_glm_lpdf";
   check_consistent_size(function, "Vector of dependent variables", y,
                         N_instances);
   check_consistent_size(function, "Weight vector", beta, N_attributes);
   check_consistent_size(function, "Vector of scale parameters", sigma,
                         N_instances);
   check_consistent_size(function, "Vector of intercepts", alpha, N_instances);
-  check_positive_finite(function, "Scale vector", sigma);
+  const auto& sigma_ref = to_ref(sigma);
+  check_positive_finite(function, "Scale vector", sigma_ref);
 
   if (size_zero(y, sigma)) {
     return 0;
   }
-  if (!include_summand<propto, T_y, T_x, T_alpha, T_beta,
-                       T_scale>::value) {
+  if (!include_summand<propto, T_y, T_x, T_alpha, T_beta, T_scale>::value) {
     return 0;
   }
 
-  const auto &x_val = to_ref(value_of_rec(x));
-  const auto &beta_val = value_of_rec(beta);
-  const auto &alpha_val = value_of_rec(alpha);
-  const auto &sigma_val = value_of_rec(sigma);
-  const auto &y_val = value_of_rec(y);
+  const auto& y_ref = to_ref_if<!is_constant<T_y>::value>(y);
+  const auto& x_ref = to_ref_if<!is_constant<T_x>::value>(x);
+  const auto& alpha_ref = to_ref_if<!is_constant<T_alpha>::value>(alpha);
+  const auto& beta_ref = to_ref_if<!is_constant<T_beta>::value>(beta);
 
-  const auto &beta_val_vec = to_ref(as_column_vector_or_scalar(beta_val));
-  const auto &alpha_val_vec = as_column_vector_or_scalar(alpha_val);
-  const auto &sigma_val_vec = to_ref(as_column_vector_or_scalar(sigma_val));
-  const auto &y_val_vec = as_column_vector_or_scalar(y_val);
+  const auto& y_val = value_of_rec(y_ref);
+  const auto& x_val
+      = to_ref_if<!is_constant<T_beta>::value>(value_of_rec(x_ref));
+  const auto& alpha_val = value_of_rec(alpha_ref);
+  const auto& beta_val = value_of_rec(beta_ref);
+  const auto& sigma_val = value_of_rec(sigma_ref);
+
+  const auto& y_val_vec = as_column_vector_or_scalar(y_val);
+  const auto& alpha_val_vec = as_column_vector_or_scalar(alpha_val);
+  const auto& beta_val_vec = to_ref_if<!is_constant<T_x>::value>(
+      as_column_vector_or_scalar(beta_val));
+  const auto& sigma_val_vec
+      = to_ref_if<include_summand<propto, T_scale>::value>(
+          as_column_vector_or_scalar(sigma_val));
 
   T_scale_val inv_sigma = 1 / as_array_or_scalar(sigma_val_vec);
 
@@ -106,7 +115,7 @@ return_type_t<T_y, T_x, T_alpha, T_beta, T_scale> normal_id_glm_lpdf(
   Array<T_partials_return, Dynamic, 1> y_scaled(N_instances);
   if (T_x_rows == 1) {
     T_y_scaled_tmp y_scaled_tmp
-        = forward_as<T_y_scaled_tmp>((x_val * beta_val_vec)(0, 0));
+        = forward_as<T_y_scaled_tmp>((x_val * beta_val_vec).coeff(0, 0));
     y_scaled = (as_array_or_scalar(y_val_vec) - y_scaled_tmp
                 - as_array_or_scalar(alpha_val_vec))
                * inv_sigma;
@@ -117,9 +126,9 @@ return_type_t<T_y, T_x, T_alpha, T_beta, T_scale> normal_id_glm_lpdf(
                * inv_sigma;
   }
 
-  operands_and_partials<T_y, T_x, T_alpha,
-                        T_beta, T_scale>
-      ops_partials(y, x_val, alpha, beta, sigma);
+  operands_and_partials<decltype(y_ref), decltype(x_ref), decltype(alpha_ref),
+                        decltype(beta_ref), decltype(sigma_ref)>
+      ops_partials(y_ref, x_ref, alpha_ref, beta_ref, sigma_ref);
 
   if (!(is_constant_all<T_y, T_x, T_beta, T_alpha>::value)) {
     Matrix<T_partials_return, Dynamic, 1> mu_derivative = inv_sigma * y_scaled;
@@ -174,9 +183,9 @@ return_type_t<T_y, T_x, T_alpha, T_beta, T_scale> normal_id_glm_lpdf(
   }
 
   if (!std::isfinite(y_scaled_sq_sum)) {
-    check_finite(function, "Vector of dependent variables", y);
-    check_finite(function, "Weight vector", beta);
-    check_finite(function, "Intercept", alpha);
+    check_finite(function, "Vector of dependent variables", y_val_vec);
+    check_finite(function, "Weight vector", beta_val_vec);
+    check_finite(function, "Intercept", alpha_val_vec);
     // if all other checks passed, next will only fail if x is not finite
     check_finite(function, "Matrix of independent variables", y_scaled_sq_sum);
   }
@@ -190,7 +199,7 @@ return_type_t<T_y, T_x, T_alpha, T_beta, T_scale> normal_id_glm_lpdf(
     if (is_vector<T_scale>::value) {
       logp -= sum(log(sigma_val_vec));
     } else {
-      logp -= N_instances * log(forward_as<double>(sigma_val));
+      logp -= N_instances * log(forward_as<double>(sigma_val_vec));
     }
   }
   logp -= 0.5 * y_scaled_sq_sum;
@@ -201,8 +210,8 @@ return_type_t<T_y, T_x, T_alpha, T_beta, T_scale> normal_id_glm_lpdf(
 template <typename T_y, typename T_x, typename T_alpha, typename T_beta,
           typename T_scale>
 inline return_type_t<T_y, T_x, T_alpha, T_beta, T_scale> normal_id_glm_lpdf(
-    const T_y &y, const T_x &x, const T_alpha &alpha, const T_beta &beta,
-    const T_scale &sigma) {
+    const T_y& y, const T_x& x, const T_alpha& alpha, const T_beta& beta,
+    const T_scale& sigma) {
   return normal_id_glm_lpdf<false>(y, x, alpha, beta, sigma);
 }
 }  // namespace math

--- a/stan/math/prim/prob/normal_id_glm_lpdf.hpp
+++ b/stan/math/prim/prob/normal_id_glm_lpdf.hpp
@@ -23,10 +23,7 @@ namespace math {
  * by using analytically simplified gradients.
  *
  * @tparam T_y type of vector of dependent variables (labels);
- * @tparam T_x_scalar type of a scalar in the matrix of independent variables
- * (features)
- * @tparam T_x_rows compile-time number of rows of `x`. It can be either
- * `Eigen::Dynamic` or 1.
+ * @tparam T_x type of the matrix of independent variables (features)
  * @tparam T_alpha type of the intercept(s);
  * this can be a vector (of the same length as y) of intercepts or a single
  * value (for models with constant intercept);
@@ -49,17 +46,18 @@ namespace math {
  * @throw std::domain_error if the scale is not positive.
  * @throw std::invalid_argument if container sizes mismatch.
  */
-template <bool propto, typename T_y, typename T_x_scalar, int T_x_rows,
-          typename T_alpha, typename T_beta, typename T_scale>
-return_type_t<T_y, T_x_scalar, T_alpha, T_beta, T_scale> normal_id_glm_lpdf(
-    const T_y &y, const Eigen::Matrix<T_x_scalar, T_x_rows, Eigen::Dynamic> &x,
+template <bool propto, typename T_y, typename T_x,
+          typename T_alpha, typename T_beta, typename T_scale, require_eigen_t<T_x>* = nullptr>
+return_type_t<T_y, T_x, T_alpha, T_beta, T_scale> normal_id_glm_lpdf(
+    const T_y &y, const T_x& x,
     const T_alpha &alpha, const T_beta &beta, const T_scale &sigma) {
   using Eigen::Array;
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using Eigen::VectorXd;
+  constexpr int T_x_rows = T_x::RowsAtCompileTime;
   using T_partials_return
-      = partials_return_t<T_y, T_x_scalar, T_alpha, T_beta, T_scale>;
+      = partials_return_t<T_y, T_x, T_alpha, T_beta, T_scale>;
   using T_scale_val = typename std::conditional_t<
       is_vector<T_scale>::value,
       Eigen::Array<partials_return_t<T_scale>, -1, 1>,
@@ -83,12 +81,12 @@ return_type_t<T_y, T_x_scalar, T_alpha, T_beta, T_scale> normal_id_glm_lpdf(
   if (size_zero(y, sigma)) {
     return 0;
   }
-  if (!include_summand<propto, T_y, T_x_scalar, T_alpha, T_beta,
+  if (!include_summand<propto, T_y, T_x, T_alpha, T_beta,
                        T_scale>::value) {
     return 0;
   }
 
-  const auto &x_val = value_of_rec(x);
+  const auto &x_val = to_ref(value_of_rec(x));
   const auto &beta_val = value_of_rec(beta);
   const auto &alpha_val = value_of_rec(alpha);
   const auto &sigma_val = value_of_rec(sigma);
@@ -118,11 +116,11 @@ return_type_t<T_y, T_x_scalar, T_alpha, T_beta, T_scale> normal_id_glm_lpdf(
                * inv_sigma;
   }
 
-  operands_and_partials<T_y, Matrix<T_x_scalar, T_x_rows, Dynamic>, T_alpha,
+  operands_and_partials<T_y, T_x, T_alpha,
                         T_beta, T_scale>
-      ops_partials(y, x, alpha, beta, sigma);
+      ops_partials(y, x_val, alpha, beta, sigma);
 
-  if (!(is_constant_all<T_y, T_x_scalar, T_beta, T_alpha>::value)) {
+  if (!(is_constant_all<T_y, T_x, T_beta, T_alpha>::value)) {
     Matrix<T_partials_return, Dynamic, 1> mu_derivative = inv_sigma * y_scaled;
     if (!is_constant_all<T_y>::value) {
       if (is_vector<T_y>::value) {
@@ -131,7 +129,7 @@ return_type_t<T_y, T_x_scalar, T_alpha, T_beta, T_scale> normal_id_glm_lpdf(
         ops_partials.edge1_.partials_[0] = -mu_derivative.sum();
       }
     }
-    if (!is_constant_all<T_x_scalar>::value) {
+    if (!is_constant_all<T_x>::value) {
       if (T_x_rows == 1) {
         ops_partials.edge2_.partials_
             = forward_as<Array<T_partials_return, Dynamic, T_x_rows>>(

--- a/stan/math/prim/prob/ordered_logistic_glm_lpmf.hpp
+++ b/stan/math/prim/prob/ordered_logistic_glm_lpmf.hpp
@@ -73,21 +73,23 @@ return_type_t<T_x, T_beta, T_cuts> ordered_logistic_glm_lpmf(
     check_finite(function, "First cut-point", cuts_ref[0]);
   }
 
-  if (size_zero(y, cuts)){
+  if (size_zero(y, cuts)) {
     return 0;
   }
-  if (!include_summand<propto, T_x, T_beta, T_cuts>::value){
+  if (!include_summand<propto, T_x, T_beta, T_cuts>::value) {
     return 0;
   }
 
   const auto& x_ref = to_ref_if<!is_constant<T_x>::value>(x);
   const auto& beta_ref = to_ref_if<!is_constant<T_beta>::value>(beta);
 
-  const auto& x_val = to_ref_if<!is_constant<T_beta>::value>(value_of_rec(x_ref));
+  const auto& x_val
+      = to_ref_if<!is_constant<T_beta>::value>(value_of_rec(x_ref));
   const auto& beta_val = value_of_rec(beta_ref);
   const auto& cuts_val = value_of_rec(cuts_ref);
 
-  const auto& beta_val_vec = to_ref_if<!is_constant<T_x>::value>(as_column_vector_or_scalar(beta_val));
+  const auto& beta_val_vec = to_ref_if<!is_constant<T_x>::value>(
+      as_column_vector_or_scalar(beta_val));
   const auto& cuts_val_vec = to_ref(as_column_vector_or_scalar(cuts_val));
 
   scalar_seq_view<T_y> y_seq(y_ref);

--- a/stan/math/prim/prob/poisson_log_glm_lpmf.hpp
+++ b/stan/math/prim/prob/poisson_log_glm_lpmf.hpp
@@ -44,11 +44,12 @@ namespace math {
  * @throw std::domain_error if y is negative.
  * @throw std::invalid_argument if container sizes mismatch.
  */
-template <bool propto, typename T_y, typename T_x,
-          typename T_alpha, typename T_beta, require_eigen_t<T_x>* = nullptr>
-return_type_t<T_x, T_alpha, T_beta> poisson_log_glm_lpmf(
-    const T_y& y, const T_x& x,
-    const T_alpha& alpha, const T_beta& beta) {
+template <bool propto, typename T_y, typename T_x, typename T_alpha,
+          typename T_beta, require_eigen_t<T_x>* = nullptr>
+return_type_t<T_x, T_alpha, T_beta> poisson_log_glm_lpmf(const T_y& y,
+                                                         const T_x& x,
+                                                         const T_alpha& alpha,
+                                                         const T_beta& beta) {
   using Eigen::Array;
   using Eigen::Dynamic;
   using Eigen::Matrix;
@@ -71,7 +72,8 @@ return_type_t<T_x, T_alpha, T_beta> poisson_log_glm_lpmf(
                         N_instances);
   check_consistent_size(function, "Weight vector", beta, N_attributes);
   check_consistent_size(function, "Vector of intercepts", alpha, N_instances);
-  check_nonnegative(function, "Vector of dependent variables", y);
+  const auto& y_ref = to_ref(y);
+  check_nonnegative(function, "Vector of dependent variables", y_ref);
 
   if (size_zero(y)) {
     return 0;
@@ -83,19 +85,25 @@ return_type_t<T_x, T_alpha, T_beta> poisson_log_glm_lpmf(
 
   T_partials_return logp(0);
 
-  const auto& x_val = to_ref(value_of_rec(x));
-  const auto& y_val = value_of_rec(y);
-  const auto& beta_val = value_of_rec(beta);
-  const auto& alpha_val = value_of_rec(alpha);
+  const auto& x_ref = to_ref_if<!is_constant<T_x>::value>(x);
+  const auto& alpha_ref = to_ref_if<!is_constant<T_alpha>::value>(alpha);
+  const auto& beta_ref = to_ref_if<!is_constant<T_beta>::value>(beta);
+
+  const auto& y_val = value_of_rec(y_ref);
+  const auto& x_val
+      = to_ref_if<!is_constant<T_beta>::value>(value_of_rec(x_ref));
+  const auto& alpha_val = value_of_rec(alpha_ref);
+  const auto& beta_val = value_of_rec(beta_ref);
 
   const auto& y_val_vec = to_ref(as_column_vector_or_scalar(y_val));
-  const auto& beta_val_vec = to_ref(as_column_vector_or_scalar(beta_val));
   const auto& alpha_val_vec = as_column_vector_or_scalar(alpha_val);
+  const auto& beta_val_vec = to_ref_if<!is_constant<T_x>::value>(
+      as_column_vector_or_scalar(beta_val));
 
   Array<T_partials_return, Dynamic, 1> theta(N_instances);
   if (T_x_rows == 1) {
     T_theta_tmp theta_tmp
-        = forward_as<T_theta_tmp>((x_val * beta_val_vec)(0, 0));
+        = forward_as<T_theta_tmp>((x_val * beta_val_vec).coeff(0, 0));
     theta = theta_tmp + as_array_or_scalar(alpha_val_vec);
   } else {
     theta = x_val * beta_val_vec;
@@ -121,9 +129,9 @@ return_type_t<T_x, T_alpha, T_beta> poisson_log_glm_lpmf(
   logp += sum(as_array_or_scalar(y_val_vec) * theta.array()
               - exp(theta.array()));
 
-  operands_and_partials<T_x,
-                        T_alpha, T_beta>
-      ops_partials(x, alpha, beta);
+  operands_and_partials<decltype(x_ref), decltype(alpha_ref),
+                        decltype(beta_ref)>
+      ops_partials(x_ref, alpha_ref, beta_ref);
   // Compute the necessary derivatives.
   if (!is_constant_all<T_beta>::value) {
     if (T_x_rows == 1) {

--- a/stan/math/rev/meta/operands_and_partials.hpp
+++ b/stan/math/rev/meta/operands_and_partials.hpp
@@ -80,11 +80,11 @@ class ops_partials_edge<double, var> {
 template <typename Op1, typename Op2, typename Op3, typename Op4, typename Op5>
 class operands_and_partials<Op1, Op2, Op3, Op4, Op5, var> {
  public:
-  internal::ops_partials_edge<double, Op1> edge1_;
-  internal::ops_partials_edge<double, Op2> edge2_;
-  internal::ops_partials_edge<double, Op3> edge3_;
-  internal::ops_partials_edge<double, Op4> edge4_;
-  internal::ops_partials_edge<double, Op5> edge5_;
+  internal::ops_partials_edge<double, std::decay_t<Op1>> edge1_;
+  internal::ops_partials_edge<double, std::decay_t<Op2>> edge2_;
+  internal::ops_partials_edge<double, std::decay_t<Op3>> edge3_;
+  internal::ops_partials_edge<double, std::decay_t<Op4>> edge4_;
+  internal::ops_partials_edge<double, std::decay_t<Op5>> edge5_;
 
   explicit operands_and_partials(const Op1& o1) : edge1_(o1) {}
   operands_and_partials(const Op1& o1, const Op2& o2)
@@ -184,14 +184,14 @@ class ops_partials_edge<double, Op, require_eigen_st<is_var, Op>> {
   const Op& operands_;
 
   void dump_operands(vari** varis) {
-    for (int i = 0; i < this->operands_.size(); ++i) {
-      varis[i] = this->operands_(i).vi_;
-    }
+    Eigen::Map<promote_scalar_t<vari*, Op>>(varis, this->operands_.rows(),
+                                            this->operands_.cols())
+        = this->operands_.vi();
   }
   void dump_partials(double* partials) {
-    for (int i = 0; i < this->partials_.size(); ++i) {
-      partials[i] = this->partials_(i);
-    }
+    Eigen::Map<partials_t>(partials, this->partials_.rows(),
+                           this->partials_.cols())
+        = this->partials_;
   }
   int size() { return this->operands_.size(); }
 };

--- a/test/unit/math/prim/meta/ref_type_test.cpp
+++ b/test/unit/math/prim/meta/ref_type_test.cpp
@@ -1,0 +1,81 @@
+#include <stan/math/prim/meta.hpp>
+#include <test/unit/math/prim/fun/expect_matrix_eq.hpp>
+#include <gtest/gtest.h>
+
+TEST(MathMetaPrim, ref_type_non_eigen) {
+  using stan::ref_type_t;
+  std::vector<int> a{1, 2, 3};
+  ref_type_t<std::vector<int>> a_ref1 = a;
+  ref_type_t<std::vector<int>&> a_ref2 = a;
+  ref_type_t<std::vector<int>&&> a_ref3 = std::vector<int>{1, 2, 3};
+
+  double b = 3;
+  ref_type_t<double> b_ref1 = b;
+  ref_type_t<double&> b_ref2 = b;
+  ref_type_t<double&&> b_ref3 = 3;
+
+  const std::vector<double> c{0.5, 4, 0.7};
+  ref_type_t<const std::vector<double>> c_ref1 = c;
+  ref_type_t<const std::vector<double>&> c_ref2 = c;
+
+  expect_std_vector_eq(a_ref1, a);
+  expect_std_vector_eq(a_ref2, a);
+  expect_std_vector_eq(a_ref3, a);
+  EXPECT_EQ(b_ref1, b);
+  EXPECT_EQ(b_ref2, b);
+  EXPECT_EQ(b_ref3, b);
+  expect_std_vector_eq(c_ref1, c);
+  expect_std_vector_eq(c_ref2, c);
+}
+
+TEST(MathMetaPrim, ref_type_eigen_directly_accessible) {
+  using stan::ref_type_t;
+  Eigen::MatrixXd a(3, 3);
+  a << 1, 2, 3, 4, 5, 6, 7, 8, 9;
+  Eigen::MatrixXd a2 = a;
+  ref_type_t<Eigen::MatrixXd> a_ref1 = a;
+  ref_type_t<Eigen::MatrixXd&> a_ref2 = a;
+  ref_type_t<Eigen::MatrixXd&&> a_ref3 = std::move(a2);
+
+  auto b = a.block(1, 0, 2, 2);
+  ref_type_t<decltype(b)> b_ref1 = b;
+  ref_type_t<decltype(b)&> b_ref2 = b;
+  ref_type_t<decltype(b)&&> b_ref3 = a.block(1, 0, 2, 2);
+
+  Eigen::Ref<Eigen::MatrixXd> c = a;
+  Eigen::Ref<Eigen::MatrixXd> c2 = a;
+  ref_type_t<Eigen::Ref<Eigen::MatrixXd>> c_ref1 = c;
+  ref_type_t<Eigen::Ref<Eigen::MatrixXd>&> c_ref2 = c;
+  ref_type_t<Eigen::Ref<Eigen::MatrixXd>&&> c_ref3 = std::move(c2);
+
+  expect_matrix_eq(a_ref1, a);
+  expect_matrix_eq(a_ref2, a);
+  expect_matrix_eq(a_ref3, a);
+
+  expect_matrix_eq(b_ref1, b);
+  expect_matrix_eq(b_ref2, b);
+  expect_matrix_eq(b_ref3, b);
+
+  expect_matrix_eq(c_ref1, c);
+  expect_matrix_eq(c_ref2, c);
+  expect_matrix_eq(c_ref3, c);
+  EXPECT_TRUE((std::is_same<decltype(b), ref_type_t<decltype(b)&&>>::value));
+}
+
+TEST(MathMetaPrim, ref_type_eigen_expression) {
+  using stan::plain_type_t;
+  using stan::ref_type_t;
+  Eigen::MatrixXd m(3, 3);
+  m << 1, 2, 3, 4, 5, 6, 7, 8, 9;
+  auto a = m*3;
+  ref_type_t<decltype(a)> a_ref1 = a;
+  ref_type_t<decltype(a)&> a_ref2 = a;
+  ref_type_t<decltype(a)&&> a_ref3 = m*3;
+
+  Eigen::MatrixXd a_eval = a;
+  expect_matrix_eq(a_ref1, a_eval);
+  expect_matrix_eq(a_ref2, a_eval);
+  expect_matrix_eq(a_ref3, a_eval);
+
+  EXPECT_TRUE((std::is_same<plain_type_t<decltype(a)>, std::decay_t<ref_type_t<decltype(a)&&>>>::value));
+}

--- a/test/unit/math/prim/meta/ref_type_test.cpp
+++ b/test/unit/math/prim/meta/ref_type_test.cpp
@@ -67,15 +67,16 @@ TEST(MathMetaPrim, ref_type_eigen_expression) {
   using stan::ref_type_t;
   Eigen::MatrixXd m(3, 3);
   m << 1, 2, 3, 4, 5, 6, 7, 8, 9;
-  auto a = m*3;
+  auto a = m * 3;
   ref_type_t<decltype(a)> a_ref1 = a;
   ref_type_t<decltype(a)&> a_ref2 = a;
-  ref_type_t<decltype(a)&&> a_ref3 = m*3;
+  ref_type_t<decltype(a)&&> a_ref3 = m * 3;
 
   Eigen::MatrixXd a_eval = a;
   expect_matrix_eq(a_ref1, a_eval);
   expect_matrix_eq(a_ref2, a_eval);
   expect_matrix_eq(a_ref3, a_eval);
 
-  EXPECT_TRUE((std::is_same<plain_type_t<decltype(a)>, std::decay_t<ref_type_t<decltype(a)&&>>>::value));
+  EXPECT_TRUE((std::is_same<plain_type_t<decltype(a)>,
+                            std::decay_t<ref_type_t<decltype(a)&&>>>::value));
 }


### PR DESCRIPTION
## Summary

Generalizes GLM functions so they accept arbitrary Eigen expressions.

A new helper trait metaprogram `ref_type` has been added that detemines appropriate type, assigning to which will evaluate expensive expressions, but not make a copy for other types. In other works it works similarly to the way we have been using `Eigen::Ref` so far, except it also understands rvalue references and therefore works with perfect forwarding.

A new helper function `to_ref_if` has been added that evaluates expensive expressions if given condition is true.

## Tests
This is just a refactor - no new tests for glms. `ref_type` is tested.

## Side Effects
None.

## Release notes

Generalized GLM functions so they accept arbitrary Eigen expressions.

## Checklist

- [x] Math issue #1470

- [x] Copyright holder: Tadej Ciglarič

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
