### PR TITLE
skip full unit when no source changes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -177,6 +177,11 @@ pipeline {
         }
         stage('Full Unit Tests') {
             agent any
+            when {
+                expression {
+                    !skipRemainingStages
+                }
+            }
             steps {
                 script {
                     if (isUnix()) {


### PR DESCRIPTION
## Summary

In #1881, I refactored the stages but the first stage (Full Unit Tests) will now run always, even to changes in /doxygen, /license, etc. 

This PR fixes that. No release notes as this is a CI change.

## Tests

/

## Side Effects

/

## Release notes

## Checklist

- [x] Math issue #1879

- [x] Copyright holder: Rok Češnovar, Faculty of Computer and Information Science, Uni. of Ljubljana

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
