### PR TITLE
Issue 1908 - Fwd definition of beta function not always called

### DIFF
--- a/stan/math/prim/fun/beta.hpp
+++ b/stan/math/prim/fun/beta.hpp
@@ -48,7 +48,8 @@ namespace math {
  * @param b Second value
  * @return Beta function applied to the two values.
  */
-template <typename T1, typename T2>
+template <typename T1, typename T2,
+          require_all_arithmetic_t<T1, T2>* = nullptr>
 inline return_type_t<T1, T2> beta(const T1 a, const T2 b) {
   using std::exp;
   return exp(lgamma(a) + lgamma(b) - lgamma(a + b));

--- a/stan/math/prim/fun/beta.hpp
+++ b/stan/math/prim/fun/beta.hpp
@@ -48,8 +48,7 @@ namespace math {
  * @param b Second value
  * @return Beta function applied to the two values.
  */
-template <typename T1, typename T2,
-          require_all_arithmetic_t<T1, T2>* = nullptr>
+template <typename T1, typename T2, require_all_arithmetic_t<T1, T2>* = nullptr>
 inline return_type_t<T1, T2> beta(const T1 a, const T2 b) {
   using std::exp;
   return exp(lgamma(a) + lgamma(b) - lgamma(a + b));

--- a/stan/math/prim/prob/beta_lccdf.hpp
+++ b/stan/math/prim/prob/beta_lccdf.hpp
@@ -29,7 +29,7 @@ namespace math {
  * @tparam T_scale_fail type of failure parameter
  * @param y (Sequence of) scalar(s) between zero and one
  * @param alpha (Sequence of) success parameter(s)
- * @param beta (Sequence of) failure parameter(s)
+ * @param beta_param (Sequence of) failure parameter(s)
  * @return log probability or sum of log of probabilities
  * @throw std::domain_error if alpha or beta is negative
  * @throw std::domain_error if y is not a valid probability
@@ -37,35 +37,35 @@ namespace math {
  */
 template <typename T_y, typename T_scale_succ, typename T_scale_fail>
 return_type_t<T_y, T_scale_succ, T_scale_fail> beta_lccdf(
-    const T_y& y, const T_scale_succ& alpha, const T_scale_fail& beta) {
+    const T_y& y, const T_scale_succ& alpha, const T_scale_fail& beta_param) {
   using T_partials_return = partials_return_t<T_y, T_scale_succ, T_scale_fail>;
   using std::exp;
   using std::log;
   using std::pow;
   static const char* function = "beta_lccdf";
   check_positive_finite(function, "First shape parameter", alpha);
-  check_positive_finite(function, "Second shape parameter", beta);
+  check_positive_finite(function, "Second shape parameter", beta_param);
   check_not_nan(function, "Random variable", y);
   check_nonnegative(function, "Random variable", y);
   check_less_or_equal(function, "Random variable", y, 1);
   check_consistent_sizes(function, "Random variable", y,
                          "First shape parameter", alpha,
-                         "Second shape parameter", beta);
+                         "Second shape parameter", beta_param);
 
-  if (size_zero(y, alpha, beta)) {
+  if (size_zero(y, alpha, beta_param)) {
     return 0;
   }
 
   T_partials_return ccdf_log(0.0);
-  operands_and_partials<T_y, T_scale_succ, T_scale_fail> ops_partials(y, alpha,
-                                                                      beta);
+  operands_and_partials<T_y, T_scale_succ, T_scale_fail>
+    ops_partials(y, alpha, beta_param);
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_scale_succ> alpha_vec(alpha);
-  scalar_seq_view<T_scale_fail> beta_vec(beta);
+  scalar_seq_view<T_scale_fail> beta_vec(beta_param);
   size_t size_alpha = stan::math::size(alpha);
-  size_t size_beta = stan::math::size(beta);
-  size_t size_alpha_beta = max_size(alpha, beta);
-  size_t N = max_size(y, alpha, beta);
+  size_t size_beta = stan::math::size(beta_param);
+  size_t size_alpha_beta = max_size(alpha, beta_param);
+  size_t N = max_size(y, alpha, beta_param);
 
   VectorBuilder<!is_constant_all<T_scale_succ, T_scale_fail>::value,
                 T_partials_return, T_scale_succ>
@@ -93,8 +93,7 @@ return_type_t<T_y, T_scale_succ, T_scale_fail> beta_lccdf(
     const T_partials_return y_dbl = value_of(y_vec[n]);
     const T_partials_return alpha_dbl = value_of(alpha_vec[n]);
     const T_partials_return beta_dbl = value_of(beta_vec[n]);
-    const T_partials_return betafunc_dbl
-        = stan::math::beta(alpha_dbl, beta_dbl);
+    const T_partials_return betafunc_dbl = beta(alpha_dbl, beta_dbl);
     const T_partials_return Pn = 1.0 - inc_beta(alpha_dbl, beta_dbl, y_dbl);
     const T_partials_return inv_Pn
         = is_constant_all<T_y, T_scale_succ, T_scale_fail>::value ? 0 : inv(Pn);

--- a/stan/math/prim/prob/beta_lccdf.hpp
+++ b/stan/math/prim/prob/beta_lccdf.hpp
@@ -57,8 +57,8 @@ return_type_t<T_y, T_scale_succ, T_scale_fail> beta_lccdf(
   }
 
   T_partials_return ccdf_log(0.0);
-  operands_and_partials<T_y, T_scale_succ, T_scale_fail>
-    ops_partials(y, alpha, beta_param);
+  operands_and_partials<T_y, T_scale_succ, T_scale_fail> ops_partials(
+      y, alpha, beta_param);
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_scale_succ> alpha_vec(alpha);
   scalar_seq_view<T_scale_fail> beta_vec(beta_param);

--- a/stan/math/prim/prob/beta_lcdf.hpp
+++ b/stan/math/prim/prob/beta_lcdf.hpp
@@ -29,7 +29,7 @@ namespace math {
  * @tparam T_scale_fail type of failure parameter
  * @param y (Sequence of) scalar(s) between zero and one
  * @param alpha (Sequence of) success parameter(s)
- * @param beta (Sequence of) failure parameter(s)
+ * @param beta_param (Sequence of) failure parameter(s)
  * @return log probability or sum of log of probabilities
  * @throw std::domain_error if alpha or beta is negative
  * @throw std::domain_error if y is not a valid probability
@@ -37,35 +37,35 @@ namespace math {
  */
 template <typename T_y, typename T_scale_succ, typename T_scale_fail>
 return_type_t<T_y, T_scale_succ, T_scale_fail> beta_lcdf(
-    const T_y& y, const T_scale_succ& alpha, const T_scale_fail& beta) {
+    const T_y& y, const T_scale_succ& alpha, const T_scale_fail& beta_param) {
   using T_partials_return = partials_return_t<T_y, T_scale_succ, T_scale_fail>;
   using std::exp;
   using std::log;
   using std::pow;
   static const char* function = "beta_lcdf";
   check_positive_finite(function, "First shape parameter", alpha);
-  check_positive_finite(function, "Second shape parameter", beta);
+  check_positive_finite(function, "Second shape parameter", beta_param);
   check_not_nan(function, "Random variable", y);
   check_nonnegative(function, "Random variable", y);
   check_less_or_equal(function, "Random variable", y, 1);
   check_consistent_sizes(function, "Random variable", y,
                          "First shape parameter", alpha,
-                         "Second shape parameter", beta);
+                         "Second shape parameter", beta_param);
 
-  if (size_zero(y, alpha, beta)) {
+  if (size_zero(y, alpha, beta_param)) {
     return 0;
   }
 
   T_partials_return cdf_log(0.0);
-  operands_and_partials<T_y, T_scale_succ, T_scale_fail> ops_partials(y, alpha,
-                                                                      beta);
+  operands_and_partials<T_y, T_scale_succ, T_scale_fail>
+    ops_partials(y, alpha, beta_param);
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_scale_succ> alpha_vec(alpha);
-  scalar_seq_view<T_scale_fail> beta_vec(beta);
+  scalar_seq_view<T_scale_fail> beta_vec(beta_param);
   size_t size_alpha = stan::math::size(alpha);
-  size_t size_beta = stan::math::size(beta);
-  size_t size_alpha_beta = max_size(alpha, beta);
-  size_t N = max_size(y, alpha, beta);
+  size_t size_beta = stan::math::size(beta_param);
+  size_t size_alpha_beta = max_size(alpha, beta_param);
+  size_t N = max_size(y, alpha, beta_param);
 
   VectorBuilder<!is_constant_all<T_scale_succ, T_scale_fail>::value,
                 T_partials_return, T_scale_succ>
@@ -94,7 +94,7 @@ return_type_t<T_y, T_scale_succ, T_scale_fail> beta_lcdf(
     const T_partials_return alpha_dbl = value_of(alpha_vec[n]);
     const T_partials_return beta_dbl = value_of(beta_vec[n]);
     const T_partials_return betafunc_dbl
-        = stan::math::beta(alpha_dbl, beta_dbl);
+        = beta(alpha_dbl, beta_dbl);
     const T_partials_return Pn = inc_beta(alpha_dbl, beta_dbl, y_dbl);
     const T_partials_return inv_Pn
         = is_constant_all<T_y, T_scale_succ, T_scale_fail>::value ? 0 : inv(Pn);

--- a/stan/math/prim/prob/beta_lcdf.hpp
+++ b/stan/math/prim/prob/beta_lcdf.hpp
@@ -57,8 +57,8 @@ return_type_t<T_y, T_scale_succ, T_scale_fail> beta_lcdf(
   }
 
   T_partials_return cdf_log(0.0);
-  operands_and_partials<T_y, T_scale_succ, T_scale_fail>
-    ops_partials(y, alpha, beta_param);
+  operands_and_partials<T_y, T_scale_succ, T_scale_fail> ops_partials(
+      y, alpha, beta_param);
   scalar_seq_view<T_y> y_vec(y);
   scalar_seq_view<T_scale_succ> alpha_vec(alpha);
   scalar_seq_view<T_scale_fail> beta_vec(beta_param);
@@ -93,8 +93,7 @@ return_type_t<T_y, T_scale_succ, T_scale_fail> beta_lcdf(
     const T_partials_return y_dbl = value_of(y_vec[n]);
     const T_partials_return alpha_dbl = value_of(alpha_vec[n]);
     const T_partials_return beta_dbl = value_of(beta_vec[n]);
-    const T_partials_return betafunc_dbl
-        = beta(alpha_dbl, beta_dbl);
+    const T_partials_return betafunc_dbl = beta(alpha_dbl, beta_dbl);
     const T_partials_return Pn = inc_beta(alpha_dbl, beta_dbl, y_dbl);
     const T_partials_return inv_Pn
         = is_constant_all<T_y, T_scale_succ, T_scale_fail>::value ? 0 : inv(Pn);

--- a/stan/math/prim/prob/neg_binomial_lccdf.hpp
+++ b/stan/math/prim/prob/neg_binomial_lccdf.hpp
@@ -23,31 +23,31 @@ namespace math {
 
 template <typename T_n, typename T_shape, typename T_inv_scale>
 return_type_t<T_shape, T_inv_scale> neg_binomial_lccdf(
-    const T_n& n, const T_shape& alpha, const T_inv_scale& beta) {
+    const T_n& n, const T_shape& alpha, const T_inv_scale& beta_param) {
   using T_partials_return = partials_return_t<T_n, T_shape, T_inv_scale>;
   using std::exp;
   using std::log;
   using std::pow;
   static const char* function = "neg_binomial_lccdf";
   check_positive_finite(function, "Shape parameter", alpha);
-  check_positive_finite(function, "Inverse scale parameter", beta);
+  check_positive_finite(function, "Inverse scale parameter", beta_param);
   check_consistent_sizes(function, "Failures variable", n, "Shape parameter",
-                         alpha, "Inverse scale parameter", beta);
+                         alpha, "Inverse scale parameter", beta_param);
 
-  if (size_zero(n, alpha, beta)) {
+  if (size_zero(n, alpha, beta_param)) {
     return 0;
   }
 
   T_partials_return P(0.0);
-  operands_and_partials<T_shape, T_inv_scale> ops_partials(alpha, beta);
+  operands_and_partials<T_shape, T_inv_scale> ops_partials(alpha, beta_param);
 
   scalar_seq_view<T_n> n_vec(n);
   scalar_seq_view<T_shape> alpha_vec(alpha);
-  scalar_seq_view<T_inv_scale> beta_vec(beta);
+  scalar_seq_view<T_inv_scale> beta_vec(beta_param);
   size_t size_n = stan::math::size(n);
   size_t size_alpha = stan::math::size(alpha);
   size_t size_n_alpha = max_size(n, alpha);
-  size_t max_size_seq_view = max_size(n, alpha, beta);
+  size_t max_size_seq_view = max_size(n, alpha, beta_param);
 
   // Explicit return for extreme values
   // The gradients are technically ill-defined, but treated as zero
@@ -93,7 +93,7 @@ return_type_t<T_shape, T_inv_scale> neg_binomial_lccdf(
     const T_partials_return p_dbl = beta_dbl * inv_beta_p1;
     const T_partials_return d_dbl = square(inv_beta_p1);
     const T_partials_return Pi = 1.0 - inc_beta(alpha_dbl, n_dbl + 1.0, p_dbl);
-    const T_partials_return beta_func = stan::math::beta(n_dbl + 1, alpha_dbl);
+    const T_partials_return beta_func = beta(n_dbl + 1, alpha_dbl);
 
     P += log(Pi);
 

--- a/stan/math/prim/prob/neg_binomial_lcdf.hpp
+++ b/stan/math/prim/prob/neg_binomial_lcdf.hpp
@@ -22,9 +22,8 @@ namespace stan {
 namespace math {
 
 template <typename T_n, typename T_shape, typename T_inv_scale>
-return_type_t<T_shape, T_inv_scale>
-  neg_binomial_lcdf(const T_n& n, const T_shape& alpha,
-                    const T_inv_scale& beta_param) {
+return_type_t<T_shape, T_inv_scale> neg_binomial_lcdf(
+    const T_n& n, const T_shape& alpha, const T_inv_scale& beta_param) {
   using T_partials_return = partials_return_t<T_n, T_shape, T_inv_scale>;
   using std::exp;
   using std::log;

--- a/stan/math/prim/prob/neg_binomial_lcdf.hpp
+++ b/stan/math/prim/prob/neg_binomial_lcdf.hpp
@@ -22,33 +22,33 @@ namespace stan {
 namespace math {
 
 template <typename T_n, typename T_shape, typename T_inv_scale>
-return_type_t<T_shape, T_inv_scale> neg_binomial_lcdf(const T_n& n,
-                                                      const T_shape& alpha,
-                                                      const T_inv_scale& beta) {
+return_type_t<T_shape, T_inv_scale>
+  neg_binomial_lcdf(const T_n& n, const T_shape& alpha,
+                    const T_inv_scale& beta_param) {
   using T_partials_return = partials_return_t<T_n, T_shape, T_inv_scale>;
   using std::exp;
   using std::log;
   using std::pow;
   static const char* function = "neg_binomial_lcdf";
   check_positive_finite(function, "Shape parameter", alpha);
-  check_positive_finite(function, "Inverse scale parameter", beta);
+  check_positive_finite(function, "Inverse scale parameter", beta_param);
   check_consistent_sizes(function, "Failures variable", n, "Shape parameter",
-                         alpha, "Inverse scale parameter", beta);
+                         alpha, "Inverse scale parameter", beta_param);
 
-  if (size_zero(n, alpha, beta)) {
+  if (size_zero(n, alpha, beta_param)) {
     return 0;
   }
 
   T_partials_return P(0.0);
-  operands_and_partials<T_shape, T_inv_scale> ops_partials(alpha, beta);
+  operands_and_partials<T_shape, T_inv_scale> ops_partials(alpha, beta_param);
 
   scalar_seq_view<T_n> n_vec(n);
   scalar_seq_view<T_shape> alpha_vec(alpha);
-  scalar_seq_view<T_inv_scale> beta_vec(beta);
+  scalar_seq_view<T_inv_scale> beta_vec(beta_param);
   size_t size_n = stan::math::size(n);
   size_t size_alpha = stan::math::size(alpha);
   size_t size_n_alpha = max_size(n, alpha);
-  size_t max_size_seq_view = max_size(n, alpha, beta);
+  size_t max_size_seq_view = max_size(n, alpha, beta_param);
 
   // Explicit return for extreme values
   // The gradients are technically ill-defined, but treated as zero
@@ -94,7 +94,7 @@ return_type_t<T_shape, T_inv_scale> neg_binomial_lcdf(const T_n& n,
     const T_partials_return p_dbl = beta_dbl * inv_beta_p1;
     const T_partials_return d_dbl = square(inv_beta_p1);
     const T_partials_return Pi = inc_beta(alpha_dbl, n_dbl + 1.0, p_dbl);
-    const T_partials_return beta_func = stan::math::beta(n_dbl + 1, alpha_dbl);
+    const T_partials_return beta_func = beta(n_dbl + 1, alpha_dbl);
 
     P += log(Pi);
 

--- a/stan/math/rev/fun/grad_inc_beta.hpp
+++ b/stan/math/rev/fun/grad_inc_beta.hpp
@@ -3,6 +3,7 @@
 
 #include <stan/math/rev/meta.hpp>
 #include <stan/math/rev/core.hpp>
+#include <stan/math/rev/fun/beta.hpp>
 #include <stan/math/rev/fun/exp.hpp>
 #include <stan/math/rev/fun/fabs.hpp>
 #include <stan/math/rev/fun/floor.hpp>
@@ -12,7 +13,6 @@
 #include <stan/math/rev/fun/log.hpp>
 #include <stan/math/rev/fun/log1m.hpp>
 #include <stan/math/rev/fun/value_of.hpp>
-#include <stan/math/prim/fun/beta.hpp>
 #include <stan/math/prim/fun/grad_2F1.hpp>
 #include <stan/math/prim/fun/value_of.hpp>
 #include <cmath>


### PR DESCRIPTION
## Summary

This PR fixes the issue where distributions that call the beta function with a namespace qualifier (i.e., ```stan::math::beta(a,b)```) don't delegate to the ```fwd``` definition for ```fvar``` inputs, rather relying on autodiff-ing the ```prim``` function.

By removing the namespace qualifier from the call to beta, the correct (```fwd```) definition is called.

## Tests
No tests added, as this PR fixes existing failures.

As shown in #1908, current tests will fail when the ```prim``` definition of ```beta``` is restricted to only take arithmetic inputs. This PR introduces that restriction, and tests pass with the added changes.

## Side Effects

N/A

## Release notes

Fixed a bug where the appropriate specialization for the beta function was not called for forward-mode autodiff variables

## Checklist

- [x] Math issue #1908

- [x] Copyright holder: Andrew Johnson

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
