### PR TITLE
Generalize bernoulli distribution functions

### DIFF
--- a/stan/math/fwd/meta/operands_and_partials.hpp
+++ b/stan/math/fwd/meta/operands_and_partials.hpp
@@ -70,11 +70,11 @@ template <typename Op1, typename Op2, typename Op3, typename Op4, typename Op5,
           typename Dx>
 class operands_and_partials<Op1, Op2, Op3, Op4, Op5, fvar<Dx>> {
  public:
-  internal::ops_partials_edge<Dx, Op1> edge1_;
-  internal::ops_partials_edge<Dx, Op2> edge2_;
-  internal::ops_partials_edge<Dx, Op3> edge3_;
-  internal::ops_partials_edge<Dx, Op4> edge4_;
-  internal::ops_partials_edge<Dx, Op5> edge5_;
+  internal::ops_partials_edge<Dx, std::decay_t<Op1>> edge1_;
+  internal::ops_partials_edge<Dx, std::decay_t<Op2>> edge2_;
+  internal::ops_partials_edge<Dx, std::decay_t<Op3>> edge3_;
+  internal::ops_partials_edge<Dx, std::decay_t<Op4>> edge4_;
+  internal::ops_partials_edge<Dx, std::decay_t<Op5>> edge5_;
   using T_return_type = fvar<Dx>;
   explicit operands_and_partials(const Op1& o1) : edge1_(o1) {}
   operands_and_partials(const Op1& o1, const Op2& o2)

--- a/stan/math/prim/meta/as_array_or_scalar.hpp
+++ b/stan/math/prim/meta/as_array_or_scalar.hpp
@@ -17,8 +17,8 @@ namespace math {
  * @return Same value.
  */
 template <typename T, typename = require_stan_scalar_t<T>>
-inline const T& as_array_or_scalar(const T& v) {
-  return v;
+inline T as_array_or_scalar(T&& v) {
+  return std::forward<T>(v);
 }
 
 /** \ingroup type_trait

--- a/stan/math/prim/meta/broadcast_array.hpp
+++ b/stan/math/prim/meta/broadcast_array.hpp
@@ -3,6 +3,7 @@
 
 #include <stan/math/prim/meta/is_eigen.hpp>
 #include <stan/math/prim/meta/promote_scalar_type.hpp>
+#include <stan/math/prim/meta/ref_type.hpp>
 #include <stan/math/prim/fun/Eigen.hpp>
 #include <stdexcept>
 
@@ -28,7 +29,8 @@ class broadcast_array {
    */
   template <typename Y>
   void operator=(const Y& m) {
-    prim_ = m[0];
+    ref_type_t<Y> m_ref = m;
+    prim_ = m_ref[0];
   }
 };
 

--- a/stan/math/prim/prob/bernoulli_cdf.hpp
+++ b/stan/math/prim/prob/bernoulli_cdf.hpp
@@ -31,7 +31,7 @@ return_type_t<T_prob> bernoulli_cdf(const T_n& n, const T_prob& theta) {
   static const char* function = "bernoulli_cdf";
   check_consistent_sizes(function, "Random variable", n,
                          "Probability parameter", theta);
-  T_theta_ref theta_ref = to_ref(theta);
+  T_theta_ref theta_ref = theta;
   check_bounded(function, "Probability parameter", theta_ref, 0.0, 1.0);
 
   if (size_zero(n, theta)) {

--- a/stan/math/prim/prob/bernoulli_cdf.hpp
+++ b/stan/math/prim/prob/bernoulli_cdf.hpp
@@ -27,21 +27,22 @@ namespace math {
 template <typename T_n, typename T_prob>
 return_type_t<T_prob> bernoulli_cdf(const T_n& n, const T_prob& theta) {
   using T_partials_return = partials_return_t<T_n, T_prob>;
+  using T_theta_ref = ref_type_t<T_prob>;
   static const char* function = "bernoulli_cdf";
-  check_finite(function, "Probability parameter", theta);
-  check_bounded(function, "Probability parameter", theta, 0.0, 1.0);
   check_consistent_sizes(function, "Random variable", n,
                          "Probability parameter", theta);
+  T_theta_ref theta_ref = to_ref(theta);
+  check_bounded(function, "Probability parameter", theta_ref, 0.0, 1.0);
 
   if (size_zero(n, theta)) {
     return 1.0;
   }
 
   T_partials_return P(1.0);
-  operands_and_partials<T_prob> ops_partials(theta);
+  operands_and_partials<T_theta_ref> ops_partials(theta_ref);
 
   scalar_seq_view<T_n> n_vec(n);
-  scalar_seq_view<T_prob> theta_vec(theta);
+  scalar_seq_view<T_theta_ref> theta_vec(theta_ref);
   size_t max_size_seq_view = max_size(n, theta);
 
   // Explicit return for extreme values

--- a/stan/math/prim/prob/bernoulli_lccdf.hpp
+++ b/stan/math/prim/prob/bernoulli_lccdf.hpp
@@ -35,7 +35,7 @@ return_type_t<T_prob> bernoulli_lccdf(const T_n& n, const T_prob& theta) {
   static const char* function = "bernoulli_lccdf";
   check_consistent_sizes(function, "Random variable", n,
                          "Probability parameter", theta);
-  T_theta_ref theta_ref = to_ref(theta);
+  T_theta_ref theta_ref = theta;
   check_bounded(function, "Probability parameter", theta_ref, 0.0, 1.0);
 
   if (size_zero(n, theta)) {

--- a/stan/math/prim/prob/bernoulli_lccdf.hpp
+++ b/stan/math/prim/prob/bernoulli_lccdf.hpp
@@ -30,22 +30,23 @@ namespace math {
 template <typename T_n, typename T_prob>
 return_type_t<T_prob> bernoulli_lccdf(const T_n& n, const T_prob& theta) {
   using T_partials_return = partials_return_t<T_n, T_prob>;
+  using T_theta_ref = ref_type_t<T_prob>;
   using std::log;
   static const char* function = "bernoulli_lccdf";
-  check_finite(function, "Probability parameter", theta);
-  check_bounded(function, "Probability parameter", theta, 0.0, 1.0);
   check_consistent_sizes(function, "Random variable", n,
                          "Probability parameter", theta);
+  T_theta_ref theta_ref = to_ref(theta);
+  check_bounded(function, "Probability parameter", theta_ref, 0.0, 1.0);
 
   if (size_zero(n, theta)) {
     return 0.0;
   }
 
   T_partials_return P(0.0);
-  operands_and_partials<T_prob> ops_partials(theta);
+  operands_and_partials<T_theta_ref> ops_partials(theta_ref);
 
   scalar_seq_view<T_n> n_vec(n);
-  scalar_seq_view<T_prob> theta_vec(theta);
+  scalar_seq_view<T_theta_ref> theta_vec(theta_ref);
   size_t max_size_seq_view = max_size(n, theta);
 
   // Explicit return for extreme values

--- a/stan/math/prim/prob/bernoulli_lcdf.hpp
+++ b/stan/math/prim/prob/bernoulli_lcdf.hpp
@@ -30,22 +30,23 @@ namespace math {
 template <typename T_n, typename T_prob>
 return_type_t<T_prob> bernoulli_lcdf(const T_n& n, const T_prob& theta) {
   using T_partials_return = partials_return_t<T_n, T_prob>;
+  using T_theta_ref = ref_type_t<T_prob>;
   using std::log;
   static const char* function = "bernoulli_lcdf";
-  check_finite(function, "Probability parameter", theta);
-  check_bounded(function, "Probability parameter", theta, 0.0, 1.0);
   check_consistent_sizes(function, "Random variable", n,
                          "Probability parameter", theta);
+  T_theta_ref theta_ref = to_ref(theta);
+  check_bounded(function, "Probability parameter", theta, 0.0, 1.0);
 
   if (size_zero(n, theta)) {
     return 0.0;
   }
 
   T_partials_return P(0.0);
-  operands_and_partials<T_prob> ops_partials(theta);
+  operands_and_partials<T_theta_ref> ops_partials(theta_ref);
 
   scalar_seq_view<T_n> n_vec(n);
-  scalar_seq_view<T_prob> theta_vec(theta);
+  scalar_seq_view<T_theta_ref> theta_vec(theta);
   size_t max_size_seq_view = max_size(n, theta);
 
   // Explicit return for extreme values

--- a/stan/math/prim/prob/bernoulli_lcdf.hpp
+++ b/stan/math/prim/prob/bernoulli_lcdf.hpp
@@ -35,7 +35,7 @@ return_type_t<T_prob> bernoulli_lcdf(const T_n& n, const T_prob& theta) {
   static const char* function = "bernoulli_lcdf";
   check_consistent_sizes(function, "Random variable", n,
                          "Probability parameter", theta);
-  T_theta_ref theta_ref = to_ref(theta);
+  T_theta_ref theta_ref = theta;
   check_bounded(function, "Probability parameter", theta, 0.0, 1.0);
 
   if (size_zero(n, theta)) {
@@ -46,7 +46,7 @@ return_type_t<T_prob> bernoulli_lcdf(const T_n& n, const T_prob& theta) {
   operands_and_partials<T_theta_ref> ops_partials(theta_ref);
 
   scalar_seq_view<T_n> n_vec(n);
-  scalar_seq_view<T_theta_ref> theta_vec(theta);
+  scalar_seq_view<T_theta_ref> theta_vec(theta_ref);
   size_t max_size_seq_view = max_size(n, theta);
 
   // Explicit return for extreme values

--- a/stan/math/prim/prob/bernoulli_lcdf.hpp
+++ b/stan/math/prim/prob/bernoulli_lcdf.hpp
@@ -36,7 +36,7 @@ return_type_t<T_prob> bernoulli_lcdf(const T_n& n, const T_prob& theta) {
   check_consistent_sizes(function, "Random variable", n,
                          "Probability parameter", theta);
   T_theta_ref theta_ref = theta;
-  check_bounded(function, "Probability parameter", theta, 0.0, 1.0);
+  check_bounded(function, "Probability parameter", theta_ref, 0.0, 1.0);
 
   if (size_zero(n, theta)) {
     return 0.0;

--- a/stan/math/prim/prob/bernoulli_logit_lpmf.hpp
+++ b/stan/math/prim/prob/bernoulli_logit_lpmf.hpp
@@ -8,6 +8,7 @@
 #include <stan/math/prim/fun/max_size.hpp>
 #include <stan/math/prim/fun/size_zero.hpp>
 #include <stan/math/prim/fun/value_of.hpp>
+#include <stan/math/prim/fun/value_of_rec.hpp>
 #include <cmath>
 
 namespace stan {
@@ -28,12 +29,17 @@ namespace math {
 template <bool propto, typename T_n, typename T_prob>
 return_type_t<T_prob> bernoulli_logit_lpmf(const T_n& n, const T_prob& theta) {
   using T_partials_return = partials_return_t<T_n, T_prob>;
+  using T_partials_array = Eigen::Array<T_partials_return, Eigen::Dynamic, 1>;
   using std::exp;
+  using T_n_ref = ref_type_t<T_n>;
+  using T_theta_ref = ref_type_t<T_prob>;
   static const char* function = "bernoulli_logit_lpmf";
-  check_bounded(function, "n", n, 0, 1);
-  check_not_nan(function, "Logit transformed probability parameter", theta);
   check_consistent_sizes(function, "Random variable", n,
                          "Probability parameter", theta);
+  T_n_ref n_ref = n;
+  T_theta_ref theta_ref = theta;
+  check_bounded(function, "n", n_ref, 0, 1);
+  check_not_nan(function, "Logit transformed probability parameter", theta_ref);
 
   if (size_zero(n, theta)) {
     return 0.0;
@@ -43,39 +49,35 @@ return_type_t<T_prob> bernoulli_logit_lpmf(const T_n& n, const T_prob& theta) {
   }
 
   T_partials_return logp(0.0);
-  operands_and_partials<T_prob> ops_partials(theta);
+  operands_and_partials<T_theta_ref> ops_partials(theta_ref);
 
-  scalar_seq_view<T_n> n_vec(n);
-  scalar_seq_view<T_prob> theta_vec(theta);
-  size_t N = max_size(n, theta);
+  const auto& theta_val = as_array_or_scalar(value_of(theta_ref));
 
-  for (size_t n = 0; n < N; n++) {
-    const T_partials_return theta_dbl = value_of(theta_vec[n]);
+  auto signs = to_ref_if<!is_constant<T_prob>::value>(
+      (2 * as_array_or_scalar(value_of_rec(n_ref)) - 1));
+  T_partials_array ntheta;
+  if (is_vector<T_n>::value || is_vector<T_prob>::value) {
+    ntheta = forward_as<T_partials_array>(signs * theta_val);
+  } else {
+    T_partials_return theta_val2 = theta_val;
+    T_partials_return ntheta_s = forward_as<T_partials_return>(signs * theta_val);
+    ntheta = T_partials_array::Constant(1, 1,
+                                        ntheta_s);
+  }
+  T_partials_array exp_m_ntheta = exp(-ntheta);
+  static const double cutoff = 20.0;
+  logp += sum(
+      (ntheta > cutoff)
+          .select(-exp_m_ntheta,
+                  (ntheta < -cutoff).select(ntheta, -log1p(exp_m_ntheta))));
 
-    const int sign = 2 * n_vec[n] - 1;
-    const T_partials_return ntheta = sign * theta_dbl;
-    const T_partials_return exp_m_ntheta = exp(-ntheta);
-
-    // Handle extreme values gracefully using Taylor approximations.
-    static const double cutoff = 20.0;
-    if (ntheta > cutoff) {
-      logp -= exp_m_ntheta;
-    } else if (ntheta < -cutoff) {
-      logp += ntheta;
-    } else {
-      logp -= log1p(exp_m_ntheta);
-    }
-
-    if (!is_constant_all<T_prob>::value) {
-      if (ntheta > cutoff) {
-        ops_partials.edge1_.partials_[n] -= exp_m_ntheta;
-      } else if (ntheta < -cutoff) {
-        ops_partials.edge1_.partials_[n] += sign;
-      } else {
-        ops_partials.edge1_.partials_[n]
-            += sign * exp_m_ntheta / (exp_m_ntheta + 1);
-      }
-    }
+  if (!is_constant_all<T_prob>::value) {
+    ops_partials.edge1_.partials_
+        = (ntheta > cutoff)
+              .select(-exp_m_ntheta,
+                      (ntheta < -cutoff)
+                          .select(signs,
+                                  signs * exp_m_ntheta / (exp_m_ntheta + 1)));
   }
   return ops_partials.build(logp);
 }

--- a/stan/math/prim/prob/bernoulli_logit_lpmf.hpp
+++ b/stan/math/prim/prob/bernoulli_logit_lpmf.hpp
@@ -7,6 +7,7 @@
 #include <stan/math/prim/fun/log1p.hpp>
 #include <stan/math/prim/fun/max_size.hpp>
 #include <stan/math/prim/fun/size_zero.hpp>
+#include <stan/math/prim/fun/to_ref.hpp>
 #include <stan/math/prim/fun/value_of.hpp>
 #include <stan/math/prim/fun/value_of_rec.hpp>
 #include <cmath>

--- a/stan/math/prim/prob/bernoulli_logit_rng.hpp
+++ b/stan/math/prim/prob/bernoulli_logit_rng.hpp
@@ -30,10 +30,11 @@ inline typename VectorBuilder<true, int, T_t>::type bernoulli_logit_rng(
     const T_t& t, RNG& rng) {
   using boost::bernoulli_distribution;
   using boost::variate_generator;
+  ref_type_t<T_t> t_ref = t;
   check_finite("bernoulli_logit_rng", "Logit transformed probability parameter",
-               t);
+               t_ref);
 
-  scalar_seq_view<T_t> t_vec(t);
+  scalar_seq_view<T_t> t_vec(t_ref);
   size_t N = stan::math::size(t);
   VectorBuilder<true, int, T_t> output(N);
 

--- a/stan/math/prim/prob/bernoulli_lpmf.hpp
+++ b/stan/math/prim/prob/bernoulli_lpmf.hpp
@@ -29,12 +29,14 @@ namespace math {
 template <bool propto, typename T_n, typename T_prob>
 return_type_t<T_prob> bernoulli_lpmf(const T_n& n, const T_prob& theta) {
   using T_partials_return = partials_return_t<T_n, T_prob>;
+  using T_theta_ref = ref_type_t<T_prob>;
+  using T_n_ref = ref_type_t<T_n>;
   using std::log;
   static const char* function = "bernoulli_lpmf";
   check_consistent_sizes(function, "Random variable", n,
                          "Probability parameter", theta);
-  const auto& n_ref = to_ref(n);
-  const auto& theta_ref = to_ref(theta);
+  const T_n_ref n_ref = to_ref(n);
+  const T_theta_ref theta_ref = to_ref(theta);
   check_bounded(function, "n", n_ref, 0, 1);
   check_bounded(function, "Probability parameter", theta_ref, 0.0, 1.0);
 
@@ -46,13 +48,14 @@ return_type_t<T_prob> bernoulli_lpmf(const T_n& n, const T_prob& theta) {
   }
 
   T_partials_return logp(0.0);
-  operands_and_partials<decltype (theta_ref)> ops_partials(theta_ref);
+  operands_and_partials<T_theta_ref> ops_partials(theta_ref);
 
-  scalar_seq_view<T_n> n_vec(n_ref);
-  scalar_seq_view<T_prob> theta_vec(theta_ref);
+  scalar_seq_view<T_n_ref> n_vec(n_ref);
+  scalar_seq_view<T_theta_ref> theta_vec(theta_ref);
   size_t N = max_size(n, theta);
 
   if (size(theta) == 1) {
+    size_t sum = 0;
     for (size_t n = 0; n < N; n++) {
       sum += value_of(n_vec[n]);
     }

--- a/stan/math/prim/prob/bernoulli_lpmf.hpp
+++ b/stan/math/prim/prob/bernoulli_lpmf.hpp
@@ -31,11 +31,12 @@ return_type_t<T_prob> bernoulli_lpmf(const T_n& n, const T_prob& theta) {
   using T_partials_return = partials_return_t<T_n, T_prob>;
   using std::log;
   static const char* function = "bernoulli_lpmf";
-  check_bounded(function, "n", n, 0, 1);
-  check_finite(function, "Probability parameter", theta);
-  check_bounded(function, "Probability parameter", theta, 0.0, 1.0);
   check_consistent_sizes(function, "Random variable", n,
                          "Probability parameter", theta);
+  const auto& n_ref = to_ref(n);
+  const auto& theta_ref = to_ref(theta);
+  check_bounded(function, "n", n_ref, 0, 1);
+  check_bounded(function, "Probability parameter", theta_ref, 0.0, 1.0);
 
   if (size_zero(n, theta)) {
     return 0.0;
@@ -45,14 +46,13 @@ return_type_t<T_prob> bernoulli_lpmf(const T_n& n, const T_prob& theta) {
   }
 
   T_partials_return logp(0.0);
-  operands_and_partials<T_prob> ops_partials(theta);
+  operands_and_partials<decltype (theta_ref)> ops_partials(theta_ref);
 
-  scalar_seq_view<T_n> n_vec(n);
-  scalar_seq_view<T_prob> theta_vec(theta);
+  scalar_seq_view<T_n> n_vec(n_ref);
+  scalar_seq_view<T_prob> theta_vec(theta_ref);
   size_t N = max_size(n, theta);
 
   if (size(theta) == 1) {
-    size_t sum = 0;
     for (size_t n = 0; n < N; n++) {
       sum += value_of(n_vec[n]);
     }

--- a/stan/math/prim/prob/bernoulli_rng.hpp
+++ b/stan/math/prim/prob/bernoulli_rng.hpp
@@ -30,10 +30,10 @@ inline typename VectorBuilder<true, int, T_theta>::type bernoulli_rng(
   using boost::bernoulli_distribution;
   using boost::variate_generator;
   static const char* function = "bernoulli_rng";
-  check_finite(function, "Probability parameter", theta);
-  check_bounded(function, "Probability parameter", theta, 0.0, 1.0);
+  ref_type_t<T_theta> theta_ref = theta;
+  check_bounded(function, "Probability parameter", theta_ref, 0.0, 1.0);
 
-  scalar_seq_view<T_theta> theta_vec(theta);
+  scalar_seq_view<T_theta> theta_vec(theta_ref);
   size_t N = stan::math::size(theta);
   VectorBuilder<true, int, T_theta> output(N);
 


### PR DESCRIPTION
## Summary
Generalizes functions related to Bernoulli distribution to accept Eigen expressions. Some unnecesarry checks (check_finite together with check_bounded) were also removed from these functions. 

## Tests

No new tests. This is just a refactor.

## Side Effects

None.

## Release notes

Generalized functions related to Bernoulli distribution to accept Eigen expressions.

## Checklist

- [x] Math issue #1470

- [x] Copyright holder: Tadej Ciglarič

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
