### PR TITLE
Fixed matrix_cl construction from row major matrices or expressions

### DIFF
--- a/stan/math/opencl/matrix_cl.hpp
+++ b/stan/math/opencl/matrix_cl.hpp
@@ -316,8 +316,8 @@ class matrix_cl<T, require_arithmetic_t<T>> {
     if (std::is_same<std::decay_t<Mat>, Mat_type>::value
         && (std::is_lvalue_reference<Mat>::value
             || is_eigen_contiguous_map<Mat>::value)) {
-      // .eval)= is here just in case other branch is selected and A does not have
-      // data directley accessible
+      // .eval)= is here just in case other branch is selected and A does not
+      // have data directley accessible
       initialize_buffer(A.eval().data());
     } else {
       auto* A_heap = new Mat_type(std::move(A));

--- a/stan/math/opencl/matrix_cl.hpp
+++ b/stan/math/opencl/matrix_cl.hpp
@@ -305,20 +305,22 @@ class matrix_cl<T, require_arithmetic_t<T>> {
    * @throw <code>std::system_error</code> if the memory on the device could not
    * be allocated
    */
-  template <typename Mat, require_eigen_t<Mat>..., require_vt_same<Mat, T>...,
-            require_not_t<is_eigen_contiguous_map<Mat>>...>
+  template <typename Mat, require_eigen_t<Mat>..., require_vt_same<Mat, T>...>
   explicit matrix_cl(Mat&& A,
                      matrix_cl_view partial_view = matrix_cl_view::Entire)
       : rows_(A.rows()), cols_(A.cols()), view_(partial_view) {
-    using Mat_type = std::decay_t<decltype(A.eval())>;
+    using Mat_type = std::decay_t<ref_type_for_opencl_t<Mat>>;
     if (size() == 0) {
       return;
     }
-    if (is_eigen_matrix_or_array<Mat>::value
-        && std::is_lvalue_reference<Mat>::value) {
+    if (std::is_same<std::decay_t<Mat>, Mat_type>::value
+        && (std::is_lvalue_reference<Mat>::value
+            || is_eigen_contiguous_map<Mat>::value)) {
+      // .eval)= is here just in case other branch is selected and A does not have
+      // data directley accessible
       initialize_buffer(A.eval().data());
     } else {
-      auto* A_heap = new Mat_type(std::move(A.eval()));
+      auto* A_heap = new Mat_type(std::move(A));
       try {
         cl::Event e = initialize_buffer(A_heap->data());
         // We set a callback that will delete the memory once copying is
@@ -331,32 +333,6 @@ class matrix_cl<T, require_arithmetic_t<T>> {
         throw;
       }
     }
-  }
-
-  /**
-   * Constructor for the matrix_cl that creates a copy of the Eigen Map on the
-   * OpenCL device. Regardless of `partial_view`, whole matrix is stored. The
-   * caller must make sure that the memory referenced by map is not deleted
-   * before copying is complete.
-   *
-   * That means `.wait()` must be called on the event associated on copying or
-   * any other event that requires completion of this event. This can be done by
-   * calling `.wait_for_write_events()` or `.wait_for_read_write_events()` on
-   * this matrix or any matrix that is calculated from this one.
-   *
-   * @tparam T type of data in the \c Eigen \c Matrix
-   * @param A the \c Eigen \c Map
-   * @param partial_view which part of the matrix is used
-   *
-   * @throw <code>std::system_error</code> if the memory on the device could not
-   * be allocated
-   */
-  template <typename Map, require_t<is_eigen_contiguous_map<Map>>...,
-            require_vt_same<Map, T>...>
-  explicit matrix_cl(Map&& A,
-                     matrix_cl_view partial_view = matrix_cl_view::Entire)
-      : rows_(A.rows()), cols_(A.cols()), view_(partial_view) {
-    initialize_buffer(A.data());
   }
 
   /**

--- a/stan/math/prim/fun/to_ref.hpp
+++ b/stan/math/prim/fun/to_ref.hpp
@@ -31,8 +31,9 @@ inline T to_ref_if(T&& a) {
 }
 
 /**
- * If the condition is true, converts Eigen argument into `Eigen::Ref`. This
- * evaluates expensive expressions.
+ * If the condition is true, evaluates expensive Eigen expressions. If given
+ * expression involves no calculations this is a no-op that should be optimized
+ * away.
  * @tparam Cond condition
  * @tparam T argument type (Eigen expression)
  * @param a argument
@@ -40,6 +41,19 @@ inline T to_ref_if(T&& a) {
  */
 template <bool Cond, typename T, std::enable_if_t<Cond>* = nullptr>
 inline ref_type_t<T&&> to_ref_if(T&& a) {
+  return std::forward<T>(a);
+}
+
+/**
+ * Converts given Eigen expression into one that can be directly copied to an
+ * OpenCL device to create `matrix_cl`. If given expression can be directly
+ * copied, this is a no-op that should be optimized away.
+ * @tparam T argument type
+ * @param a argument
+ * @return optionally evaluated argument
+ */
+template <typename T>
+inline ref_type_for_opencl_t<T&&> to_ref_for_opencl(T&& a) {
   return std::forward<T>(a);
 }
 

--- a/stan/math/prim/meta/ref_type.hpp
+++ b/stan/math/prim/meta/ref_type.hpp
@@ -80,7 +80,7 @@ struct ref_type_for_opencl {
 template <typename T>
 struct ref_type_for_opencl<T, require_not_eigen_t<T>> {
   using type
-      = std::conditional_t<std::is_rvalue_reference<T>::value, T, const T&>;
+      = std::conditional_t<std::is_rvalue_reference<T>::value, std::remove_reference_t<T>, const T&>;
 };
 
 template <typename T>

--- a/stan/math/prim/meta/ref_type.hpp
+++ b/stan/math/prim/meta/ref_type.hpp
@@ -79,8 +79,8 @@ struct ref_type_for_opencl {
 
 template <typename T>
 struct ref_type_for_opencl<T, require_not_eigen_t<T>> {
-  using type
-      = std::conditional_t<std::is_rvalue_reference<T>::value, std::remove_reference_t<T>, const T&>;
+  using type = std::conditional_t<std::is_rvalue_reference<T>::value,
+                                  std::remove_reference_t<T>, const T&>;
 };
 
 template <typename T>

--- a/stan/math/prim/meta/ref_type.hpp
+++ b/stan/math/prim/meta/ref_type.hpp
@@ -41,6 +41,51 @@ struct ref_type<T, require_not_eigen_t<T>> {
 template <typename T>
 using ref_type_t = typename ref_type<T>::type;
 
+/**
+ * Determines appropriate type for assigning expression of given type to, so
+ * that the resulting type has directly accessible contiguous colum-major data,
+ * which is needed to copy to OpenCL device for construction of matrix_cl.
+ *
+ * THis is similar to `ref_type` except this also copies expressions, which do
+ * not have contiguous data (in both dimensions) or have row major storage
+ * order.
+ *
+ * Warning: if a variable of this type could be assigned a rvalue, make sure
+ * template parameter `T` is of correct reference type (rvalue).
+ * @tparam T type to determine reference for
+ */
+template <typename T, typename = void>
+struct ref_type_for_opencl {
+  using T_val = std::remove_reference_t<T>;
+  using T_plain_col_major = std::conditional_t<
+      std::is_same<typename Eigen::internal::traits<T_val>::XprKind,
+                   Eigen::MatrixXpr>::value,
+      Eigen::Matrix<value_type_t<T>, T_val::RowsAtCompileTime,
+                    T_val::ColsAtCompileTime>,
+      Eigen::Array<value_type_t<T>, T_val::RowsAtCompileTime,
+                   T_val::ColsAtCompileTime>>;
+  using T_optionally_ref
+      = std::conditional_t<std::is_rvalue_reference<T>::value, T_val, const T&>;
+  // Setting Outer stride of Ref to 0 (default) won't actually check that
+  // expression has contiguous outer stride. Instead we need to check that
+  // evaluator flags contain LinearAccessBit.
+  using type = std::conditional_t<
+      Eigen::internal::traits<Eigen::Ref<std::decay_t<T_plain_col_major>>>::
+              template match<T_val>::MatchAtCompileTime
+          && (Eigen::internal::evaluator<T_val>::Flags
+              & Eigen::LinearAccessBit),
+      T_optionally_ref, T_plain_col_major>;
+};
+
+template <typename T>
+struct ref_type_for_opencl<T, require_not_eigen_t<T>> {
+  using type
+      = std::conditional_t<std::is_rvalue_reference<T>::value, T, const T&>;
+};
+
+template <typename T>
+using ref_type_for_opencl_t = typename ref_type_for_opencl<T>::type;
+
 }  // namespace stan
 
 #endif

--- a/test/unit/math/opencl/matrix_cl_test.cpp
+++ b/test/unit/math/opencl/matrix_cl_test.cpp
@@ -5,6 +5,7 @@
 #include <stan/math/opencl/copy.hpp>
 #include <stan/math/opencl/zeros.hpp>
 #include <stan/math/opencl/sub_block.hpp>
+#include <test/unit/math/prim/fun/expect_matrix_eq.hpp>
 #include <gtest/gtest.h>
 #include <algorithm>
 #include <vector>
@@ -26,6 +27,20 @@ TEST(MathMatrixCL, matrix_cl_types_creation) {
   test_matrix_creation<float>();
   test_matrix_creation<int>();
   test_matrix_creation<long double>();
+}
+
+TEST(MathMatrixCL, matrix_cl_value) {
+  Eigen::Matrix<double, -1, -1> col_major(3, 3);
+  col_major << 1, 2, 3, 4, 5, 6, 7, 8, 9;
+  stan::math::matrix_cl<double> cl_from_col_major(col_major);
+  Eigen::MatrixXd res = stan::math::from_matrix_cl(cl_from_col_major);
+  expect_matrix_eq(col_major, res);
+
+  Eigen::Matrix<double, -1, -1, Eigen::RowMajor> row_major(3, 3);
+  row_major << 1, 2, 3, 4, 5, 6, 7, 8, 9;
+  stan::math::matrix_cl<double> cl_from_row_major(row_major);
+  res = stan::math::from_matrix_cl(cl_from_row_major);
+  expect_matrix_eq(row_major, res);
 }
 
 TEST(MathMatrixCL, assignment) {

--- a/test/unit/math/prim/meta/ref_type_test.cpp
+++ b/test/unit/math/prim/meta/ref_type_test.cpp
@@ -105,6 +105,15 @@ TEST(MathMetaPrim, ref_type_for_opencl_for_opencl_non_eigen) {
   EXPECT_EQ(b_ref3, b);
   expect_std_vector_eq(c_ref1, c);
   expect_std_vector_eq(c_ref2, c);
+  EXPECT_TRUE(std::is_lvalue_reference<ref_type_for_opencl_t<double>>::value);
+  EXPECT_TRUE(std::is_lvalue_reference<ref_type_for_opencl_t<double&>>::value);
+  EXPECT_FALSE(std::is_reference<ref_type_for_opencl_t<double&&>>::value);
+  EXPECT_TRUE(std::is_lvalue_reference<
+              ref_type_for_opencl_t<const std::vector<double>>>::value);
+  EXPECT_TRUE(std::is_lvalue_reference<
+              ref_type_for_opencl_t<const std::vector<double>&>>::value);
+  EXPECT_FALSE(std::is_reference<
+               ref_type_for_opencl_t<const std::vector<double>&&>>::value);
 }
 
 TEST(MathMetaPrim, ref_type_for_opencl_eigen_contiguous) {
@@ -145,6 +154,9 @@ TEST(MathMetaPrim, ref_type_for_opencl_eigen_contiguous) {
       (std::is_same<decltype(b), ref_type_for_opencl_t<decltype(b)&&>>::value));
   EXPECT_TRUE(
       (std::is_same<decltype(c), ref_type_for_opencl_t<decltype(c)&&>>::value));
+  EXPECT_TRUE(std::is_lvalue_reference<ref_type_for_opencl_t<Eigen::MatrixXd>>::value);
+  EXPECT_TRUE(std::is_lvalue_reference<ref_type_for_opencl_t<Eigen::MatrixXd&>>::value);
+  EXPECT_FALSE(std::is_reference<ref_type_for_opencl_t<Eigen::MatrixXd&&>>::value);
 }
 
 TEST(MathMetaPrim, ref_type_for_opencl_eigen_non_contiguous) {
@@ -204,7 +216,10 @@ TEST(MathMetaPrim, ref_type_for_opencl_eigen_expression) {
   expect_matrix_eq(a_ref2, a_eval);
   expect_matrix_eq(a_ref3, a_eval);
 
-  EXPECT_TRUE((
-      std::is_same<plain_type_t<decltype(a)>,
-                   std::decay_t<ref_type_for_opencl_t<decltype(a)&&>>>::value));
+  EXPECT_TRUE((std::is_same<plain_type_t<decltype(a)>,
+                            ref_type_for_opencl_t<decltype(a)>>::value));
+  EXPECT_TRUE((std::is_same<plain_type_t<decltype(a)>,
+                            ref_type_for_opencl_t<decltype(a)&>>::value));
+  EXPECT_TRUE((std::is_same<plain_type_t<decltype(a)>,
+                            ref_type_for_opencl_t<decltype(a)&&>>::value));
 }

--- a/test/unit/math/prim/meta/ref_type_test.cpp
+++ b/test/unit/math/prim/meta/ref_type_test.cpp
@@ -80,3 +80,131 @@ TEST(MathMetaPrim, ref_type_eigen_expression) {
   EXPECT_TRUE((std::is_same<plain_type_t<decltype(a)>,
                             std::decay_t<ref_type_t<decltype(a)&&>>>::value));
 }
+
+TEST(MathMetaPrim, ref_type_for_opencl_for_opencl_non_eigen) {
+  using stan::ref_type_for_opencl_t;
+  std::vector<int> a{1, 2, 3};
+  ref_type_for_opencl_t<std::vector<int>> a_ref1 = a;
+  ref_type_for_opencl_t<std::vector<int>&> a_ref2 = a;
+  ref_type_for_opencl_t<std::vector<int>&&> a_ref3 = std::vector<int>{1, 2, 3};
+
+  double b = 3;
+  ref_type_for_opencl_t<double> b_ref1 = b;
+  ref_type_for_opencl_t<double&> b_ref2 = b;
+  ref_type_for_opencl_t<double&&> b_ref3 = 3;
+
+  const std::vector<double> c{0.5, 4, 0.7};
+  ref_type_for_opencl_t<const std::vector<double>> c_ref1 = c;
+  ref_type_for_opencl_t<const std::vector<double>&> c_ref2 = c;
+
+  expect_std_vector_eq(a_ref1, a);
+  expect_std_vector_eq(a_ref2, a);
+  expect_std_vector_eq(a_ref3, a);
+  EXPECT_EQ(b_ref1, b);
+  EXPECT_EQ(b_ref2, b);
+  EXPECT_EQ(b_ref3, b);
+  expect_std_vector_eq(c_ref1, c);
+  expect_std_vector_eq(c_ref2, c);
+}
+
+TEST(MathMetaPrim, ref_type_for_opencl_eigen_contiguous) {
+  using stan::ref_type_for_opencl_t;
+  Eigen::MatrixXd a(3, 3);
+  a << 1, 2, 3, 4, 5, 6, 7, 8, 9;
+  Eigen::MatrixXd a2 = a;
+  ref_type_for_opencl_t<Eigen::MatrixXd> a_ref1 = a;
+  ref_type_for_opencl_t<Eigen::MatrixXd&> a_ref2 = a;
+  ref_type_for_opencl_t<Eigen::MatrixXd&&> a_ref3 = std::move(a2);
+
+  auto b = a.leftCols(2);
+  ref_type_for_opencl_t<decltype(b)> b_ref1 = b;
+  ref_type_for_opencl_t<decltype(b)&> b_ref2 = b;
+  ref_type_for_opencl_t<decltype(b)&&> b_ref3 = a.leftCols(2);
+
+  using ContiguousMap = Eigen::Map<Eigen::MatrixXd, 0, Eigen::Stride<0, 0>>;
+  ContiguousMap c(a.data(), 3, 3);
+  ContiguousMap c2(a.data(), 3, 3);
+  ref_type_for_opencl_t<ContiguousMap> c_ref1 = c;
+  ref_type_for_opencl_t<ContiguousMap&> c_ref2 = c;
+  ref_type_for_opencl_t<ContiguousMap&&> c_ref3 = std::move(c2);
+
+  expect_matrix_eq(a_ref1, a);
+  expect_matrix_eq(a_ref2, a);
+  expect_matrix_eq(a_ref3, a);
+
+  expect_matrix_eq(b_ref1, b);
+  expect_matrix_eq(b_ref2, b);
+  expect_matrix_eq(b_ref3, b);
+
+  expect_matrix_eq(c_ref1, c);
+  expect_matrix_eq(c_ref2, c);
+  expect_matrix_eq(c_ref3, c);
+  EXPECT_TRUE(
+      (std::is_same<decltype(a), ref_type_for_opencl_t<decltype(a)&&>>::value));
+  EXPECT_TRUE(
+      (std::is_same<decltype(b), ref_type_for_opencl_t<decltype(b)&&>>::value));
+  EXPECT_TRUE(
+      (std::is_same<decltype(c), ref_type_for_opencl_t<decltype(c)&&>>::value));
+}
+
+TEST(MathMetaPrim, ref_type_for_opencl_eigen_non_contiguous) {
+  using stan::ref_type_for_opencl_t;
+  Eigen::MatrixXd m(3, 3);
+  m << 1, 2, 3, 4, 5, 6, 7, 8, 9;
+  using RowMajorMatrixXd
+      = Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>;
+  RowMajorMatrixXd a = m;
+  RowMajorMatrixXd a2 = m;
+  ref_type_for_opencl_t<RowMajorMatrixXd> a_ref1 = a;
+  ref_type_for_opencl_t<RowMajorMatrixXd&> a_ref2 = a;
+  ref_type_for_opencl_t<RowMajorMatrixXd&&> a_ref3 = std::move(a2);
+
+  auto b = m.block(1, 0, 2, 2);
+  ref_type_for_opencl_t<decltype(b)> b_ref1 = b;
+  ref_type_for_opencl_t<decltype(b)&> b_ref2 = b;
+  ref_type_for_opencl_t<decltype(b)&&> b_ref3 = a.block(1, 0, 2, 2);
+
+  Eigen::Ref<Eigen::MatrixXd> c = m;
+  Eigen::Ref<Eigen::MatrixXd> c2 = m;
+  ref_type_for_opencl_t<Eigen::Ref<Eigen::MatrixXd>> c_ref1 = c;
+  ref_type_for_opencl_t<Eigen::Ref<Eigen::MatrixXd>&> c_ref2 = c;
+  ref_type_for_opencl_t<Eigen::Ref<Eigen::MatrixXd>&&> c_ref3 = std::move(c2);
+
+  expect_matrix_eq(a_ref1, a);
+  expect_matrix_eq(a_ref2, a);
+  expect_matrix_eq(a_ref3, a);
+
+  expect_matrix_eq(b_ref1, b);
+  expect_matrix_eq(b_ref2, b);
+  expect_matrix_eq(b_ref3, b);
+
+  expect_matrix_eq(c_ref1, c);
+  expect_matrix_eq(c_ref2, c);
+  expect_matrix_eq(c_ref3, c);
+  EXPECT_TRUE((std::is_same<Eigen::MatrixXd,
+                            ref_type_for_opencl_t<decltype(a)&&>>::value));
+  EXPECT_TRUE((std::is_same<Eigen::MatrixXd,
+                            ref_type_for_opencl_t<decltype(b)&&>>::value));
+  EXPECT_TRUE((std::is_same<Eigen::MatrixXd,
+                            ref_type_for_opencl_t<decltype(c)&&>>::value));
+}
+
+TEST(MathMetaPrim, ref_type_for_opencl_eigen_expression) {
+  using stan::plain_type_t;
+  using stan::ref_type_for_opencl_t;
+  Eigen::MatrixXd m(3, 3);
+  m << 1, 2, 3, 4, 5, 6, 7, 8, 9;
+  auto a = m * 3;
+  ref_type_for_opencl_t<decltype(a)> a_ref1 = a;
+  ref_type_for_opencl_t<decltype(a)&> a_ref2 = a;
+  ref_type_for_opencl_t<decltype(a)&&> a_ref3 = m * 3;
+
+  Eigen::MatrixXd a_eval = a;
+  expect_matrix_eq(a_ref1, a_eval);
+  expect_matrix_eq(a_ref2, a_eval);
+  expect_matrix_eq(a_ref3, a_eval);
+
+  EXPECT_TRUE((
+      std::is_same<plain_type_t<decltype(a)>,
+                   std::decay_t<ref_type_for_opencl_t<decltype(a)&&>>>::value));
+}

--- a/test/unit/math/prim/meta/ref_type_test.cpp
+++ b/test/unit/math/prim/meta/ref_type_test.cpp
@@ -154,9 +154,12 @@ TEST(MathMetaPrim, ref_type_for_opencl_eigen_contiguous) {
       (std::is_same<decltype(b), ref_type_for_opencl_t<decltype(b)&&>>::value));
   EXPECT_TRUE(
       (std::is_same<decltype(c), ref_type_for_opencl_t<decltype(c)&&>>::value));
-  EXPECT_TRUE(std::is_lvalue_reference<ref_type_for_opencl_t<Eigen::MatrixXd>>::value);
-  EXPECT_TRUE(std::is_lvalue_reference<ref_type_for_opencl_t<Eigen::MatrixXd&>>::value);
-  EXPECT_FALSE(std::is_reference<ref_type_for_opencl_t<Eigen::MatrixXd&&>>::value);
+  EXPECT_TRUE(
+      std::is_lvalue_reference<ref_type_for_opencl_t<Eigen::MatrixXd>>::value);
+  EXPECT_TRUE(
+      std::is_lvalue_reference<ref_type_for_opencl_t<Eigen::MatrixXd&>>::value);
+  EXPECT_FALSE(
+      std::is_reference<ref_type_for_opencl_t<Eigen::MatrixXd&&>>::value);
 }
 
 TEST(MathMetaPrim, ref_type_for_opencl_eigen_non_contiguous) {


### PR DESCRIPTION
## Summary

To completely generalize OpenCL implementations of GLMs we need to support constructing `matrix_cl` from row major matrices and expressions. Currently this is bugged - the values in `matrix_cl` will be in incorrectly ordered.

This also adds `ref_type_for_opencl` type metaprogram and `to_ref_for_opencl` function. These two work similarly to `ref_type` and `to_ref`, except their results are guaranteed to be column-major and fully contiguous, so they can be directly copied into `matrix_cl` buffer.

## Tests
Added a test for constructing `matrix_cl` from row major matrix and tests for `ref_type_for_opencl`.

## Side Effects
None.

## Release notes

Fixed a bug that resulted in wrong result when constructing `matrix_cl` from row-major matrix or expression.

## Checklist

- [x] Math issue #1470

- [x] Copyright holder: Tadej Ciglarič

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
