### PR TITLE
[WIP] Reworked the multiplication operator to use adj_jac_apply

### DIFF
--- a/stan/math/prim/err/check_matching_sizes.hpp
+++ b/stan/math/prim/err/check_matching_sizes.hpp
@@ -24,8 +24,8 @@ template <typename T_y1, typename T_y2>
 inline void check_matching_sizes(const char* function, const char* name1,
                                  const T_y1& y1, const char* name2,
                                  const T_y2& y2) {
-  check_size_match(function, "size of ", name1, y1.size(), "size of ", name2,
-                   y2.size());
+  check_size_match(function, "size of ", name1, size(y1), "size of ", name2,
+                   size(y2));
 }
 
 }  // namespace math

--- a/stan/math/rev/core/operator_multiplication.hpp
+++ b/stan/math/rev/core/operator_multiplication.hpp
@@ -216,11 +216,7 @@ struct OpMultiplyMatrixScalar {
   template <std::size_t size, typename Derived>
   auto multiply_adjoint_jacobian(const std::array<bool, size>& needs_adj,
                                  const Eigen::MatrixBase<Derived>& adj) {
-<<<<<<< HEAD
-    Eigen::MatrixXd adja;
-=======
     Eigen::Map<Eigen::MatrixXd> adja(work_mem_, N_, M_);
->>>>>>> 04fa972ce410a5ad16ecfe1d994541eed58e2c79
     double adjb = 0.0;
 
     if(needs_adj[0]) {
@@ -230,11 +226,7 @@ struct OpMultiplyMatrixScalar {
 
     if(needs_adj[1]) {
       Eigen::Map<Eigen::MatrixXd> x(x_mem_, N_, M_);
-<<<<<<< HEAD
-      for(size_t i = 0; i < N_ * M_; ++i)
-=======
       for(size_t i = 0; i < x.size(); ++i)
->>>>>>> 04fa972ce410a5ad16ecfe1d994541eed58e2c79
 	adjb += x(i) * adj(i);
     }
     

--- a/stan/math/rev/core/propogate_static_matrix.hpp
+++ b/stan/math/rev/core/propogate_static_matrix.hpp
@@ -20,6 +20,10 @@ class from_static_vari : public vari_base {
                    vari** output_vis)
       : N_(N), input_vi_(input_vi), output_vis_(output_vis) {}
   void chain() {
+    /*input_vi_->adj_ +=
+      Eigen::Map<Eigen::Matrix<vari*, R, C>>(output_vis_,
+					     input_vi_->adj_.rows(),
+					     input_vi_->adj_.cols()).adj_();*/
     for (size_t n = 0; n < N_; ++n) {
       input_vi_->adj_(n) += output_vis_[n]->adj_;
     }
@@ -37,6 +41,10 @@ class to_static_vari : public vari_base {
                  vari_value<Eigen::Matrix<double, R, C>>* output_vi)
       : N_(N), input_vis_(input_vis), output_vi_(output_vi) {}
   void chain() {
+    /*Eigen::Map<Eigen::Matrix<vari*, R, C>>(input_vis_,
+					   output_vi_->adj_.rows(),
+					   output_vi_->adj_.cols()).adj_() +=
+					   output_vi_->adj_;*/
     for (size_t n = 0; n < N_; ++n) {
       input_vis_[n]->adj_ += output_vi_->adj_(n);
     }

--- a/stan/math/rev/core/var.hpp
+++ b/stan/math/rev/core/var.hpp
@@ -114,7 +114,7 @@ class var_value<T, require_vt_floating_point<T>> {
             var_value(EigenT x) : vi_(new vari_type(x, false)) {}  // NOLINT*/
 
   template <int R, int C>
-  var_value(const Eigen::Matrix<var_value<double>, R, C>& x); // NOLINT
+  var_value(const Eigen::Matrix<var_value<double>, R, C>& x);  // NOLINT
 
   /**
    * Return the value of this variable.

--- a/stan/math/rev/core/var.hpp
+++ b/stan/math/rev/core/var.hpp
@@ -114,7 +114,7 @@ class var_value<T, require_vt_floating_point<T>> {
             var_value(EigenT x) : vi_(new vari_type(x, false)) {}  // NOLINT*/
 
   template <int R, int C>
-  var_value(const Eigen::Matrix<var_value<double>, R, C>& x);
+  var_value(const Eigen::Matrix<var_value<double>, R, C>& x); // NOLINT
 
   /**
    * Return the value of this variable.

--- a/stan/math/rev/fun.hpp
+++ b/stan/math/rev/fun.hpp
@@ -126,6 +126,7 @@
 #include <stan/math/rev/fun/simplex_constrain.hpp>
 #include <stan/math/rev/fun/sin.hpp>
 #include <stan/math/rev/fun/sinh.hpp>
+#include <stan/math/rev/fun/size.hpp>
 #include <stan/math/rev/fun/softmax.hpp>
 #include <stan/math/rev/fun/sqrt.hpp>
 #include <stan/math/rev/fun/square.hpp>

--- a/stan/math/rev/fun/dot_product.hpp
+++ b/stan/math/rev/fun/dot_product.hpp
@@ -1,183 +1,87 @@
 #ifndef STAN_MATH_REV_FUN_DOT_PRODUCT_HPP
 #define STAN_MATH_REV_FUN_DOT_PRODUCT_HPP
 
-#include <stan/math/rev/meta.hpp>
-#include <stan/math/rev/core.hpp>
-#include <stan/math/rev/fun/value_of.hpp>
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/err.hpp>
+#include <stan/math/rev/core/var.hpp>
+#include <stan/math/rev/core/op_vari.hpp>
+#include <stan/math/rev/functor/adj_jac_apply.hpp>
+#include <stan/math/rev/meta/is_vari.hpp>
+#include <stan/math/prim/fun/constants.hpp>
+#include <stan/math/prim/fun/is_any_nan.hpp>
+#include <stan/math/prim/fun/isinf.hpp>
+#include <stan/math/prim/fun/isnan.hpp>
+
+
+
+#include <stan/math/rev/core.hpp>
 #include <stan/math/prim/fun/Eigen.hpp>
 #include <stan/math/prim/fun/typedefs.hpp>
 #include <stan/math/prim/fun/value_of.hpp>
-#include <type_traits>
 #include <vector>
 
 namespace stan {
 namespace math {
 namespace internal {
 
-template <typename T>
-struct dot_product_store_type;
+struct OpDotProductEigen {
+  int N_;
+  double* a_mem_;
+  double* b_mem_;
 
-template <>
-struct dot_product_store_type<var> {
-  using type = vari**;
+  template <std::size_t size,
+	    typename Derived1,
+	    typename Derived2>
+  double operator()(const std::array<bool, size>& needs_adj,
+		    const Eigen::MatrixBase<Derived1>& a,
+		    const Eigen::MatrixBase<Derived2>& b) {
+    N_ = a.size();
+
+    double ret = 0.0;
+
+    if(needs_adj[0])
+      b_mem_
+        = stan::math::ChainableStack::instance_->memalloc_.alloc_array<double>(N_);
+    
+    if(needs_adj[1])
+      a_mem_
+        = stan::math::ChainableStack::instance_->memalloc_.alloc_array<double>(N_);
+
+    for (int n = 0; n < N_; ++n) {
+      ret += a(n) * b(n);
+
+      if(needs_adj[0])
+	b_mem_[n] = b(n);
+
+      if(needs_adj[1])
+	a_mem_[n] = a(n);
+    }
+
+    return ret;
+  }
+
+  template <std::size_t size>
+  auto multiply_adjoint_jacobian(const std::array<bool, size>& needs_adj,
+                                 const double& adj) {
+    Eigen::VectorXd adja;
+    Eigen::VectorXd adjb;
+
+    if(needs_adj[0]) {
+      Eigen::Map<Eigen::VectorXd> b(b_mem_, N_);
+      adja.resize(N_);
+      adja = adj * b;
+    }
+    
+    if(needs_adj[1]) {
+      Eigen::Map<Eigen::VectorXd> a(a_mem_, N_);
+      adjb.resize(N_);
+      adjb = adj * a;
+    }
+
+    return std::make_tuple(adja, adjb);
+  }
 };
 
-template <>
-struct dot_product_store_type<double> {
-  using type = double*;
-};
-
-template <typename T1, typename T2>
-class dot_product_vari : public vari {
- protected:
-  typename dot_product_store_type<T1>::type v1_;
-  typename dot_product_store_type<T2>::type v2_;
-  size_t length_;
-
-  inline static double var_dot(vari** v1, vari** v2, size_t length) {
-    Eigen::Map<vector_vi> vd1(v1, length);
-    Eigen::Map<vector_vi> vd2(v2, length);
-
-    return vd1.val().dot(vd2.val());
-  }
-
-  inline static double var_dot(const T1* v1, const T2* v2, size_t length) {
-    Eigen::Map<const Eigen::Matrix<T1, -1, 1>> vd1(v1, length);
-    Eigen::Map<const Eigen::Matrix<T2, -1, 1>> vd2(v2, length);
-    return vd1.val().dot(vd2.val());
-  }
-
-  template <typename Derived1, typename Derived2>
-  inline static double var_dot(const Eigen::DenseBase<Derived1>& v1,
-                               const Eigen::DenseBase<Derived2>& v2) {
-    vector_d vd1
-        = Eigen::Ref<const Eigen::Matrix<typename Derived1::Scalar, -1, 1>>(v1)
-              .val();
-    vector_d vd2
-        = Eigen::Ref<const Eigen::Matrix<typename Derived2::Scalar, -1, 1>>(v2)
-              .val();
-    return vd1.dot(vd2);
-  }
-  inline void chain(vari** v1, vari** v2) {
-    Eigen::Map<vector_vi> vd1(v1, length_);
-    Eigen::Map<vector_vi> vd2(v2, length_);
-    vd1.adj() += adj_ * vd2.val();
-    vd2.adj() += adj_ * vd1.val();
-  }
-  inline void chain(double* v1, vari** v2) {
-    Eigen::Map<vector_vi>(v2, length_).adj()
-        += adj_ * Eigen::Map<vector_d>(v1, length_);
-  }
-  inline void chain(vari** v1, double* v2) {
-    Eigen::Map<vector_vi>(v1, length_).adj()
-        += adj_ * Eigen::Map<vector_d>(v2, length_);
-  }
-  inline void initialize(vari**& mem_v, const var* inv,
-                         vari** shared = nullptr) {
-    if (shared == nullptr) {
-      mem_v = reinterpret_cast<vari**>(
-          ChainableStack::instance_->memalloc_.alloc(length_ * sizeof(vari*)));
-      Eigen::Map<vector_vi>(mem_v, length_)
-          = Eigen::Map<const vector_v>(inv, length_).vi();
-    } else {
-      mem_v = shared;
-    }
-  }
-  template <typename Derived>
-  inline void initialize(vari**& mem_v, const Eigen::DenseBase<Derived>& inv,
-                         vari** shared = nullptr) {
-    if (shared == nullptr) {
-      mem_v = reinterpret_cast<vari**>(
-          ChainableStack::instance_->memalloc_.alloc(length_ * sizeof(vari*)));
-      Eigen::Map<vector_vi>(mem_v, length_)
-          = Eigen::Ref<const vector_v>(inv).vi();
-    } else {
-      mem_v = shared;
-    }
-  }
-
-  inline void initialize(double*& mem_d, const double* ind,
-                         double* shared = nullptr) {
-    if (shared == nullptr) {
-      mem_d = reinterpret_cast<double*>(
-          ChainableStack::instance_->memalloc_.alloc(length_ * sizeof(double)));
-      for (size_t i = 0; i < length_; i++) {
-        mem_d[i] = ind[i];
-      }
-    } else {
-      mem_d = shared;
-    }
-  }
-  template <typename Derived>
-  inline void initialize(double*& mem_d, const Eigen::DenseBase<Derived>& ind,
-                         double* shared = nullptr) {
-    if (shared == nullptr) {
-      mem_d = reinterpret_cast<double*>(
-          ChainableStack::instance_->memalloc_.alloc(length_ * sizeof(double)));
-      Eigen::Map<vector_d>(mem_d, length_) = Eigen::Ref<const vector_d>(ind);
-    } else {
-      mem_d = shared;
-    }
-  }
-
- public:
-  dot_product_vari(typename dot_product_store_type<T1>::type v1,
-                   typename dot_product_store_type<T2>::type v2, size_t length)
-      : vari(var_dot(v1, v2, length)), v1_(v1), v2_(v2), length_(length) {}
-
-  dot_product_vari(const T1* v1, const T2* v2, size_t length,
-                   dot_product_vari<T1, T2>* shared_v1 = NULL,
-                   dot_product_vari<T1, T2>* shared_v2 = NULL)
-      : vari(var_dot(v1, v2, length)), length_(length) {
-    if (shared_v1 == NULL) {
-      initialize(v1_, v1);
-    } else {
-      initialize(v1_, v1, shared_v1->v1_);
-    }
-    if (shared_v2 == NULL) {
-      initialize(v2_, v2);
-    } else {
-      initialize(v2_, v2, shared_v2->v2_);
-    }
-  }
-  template <typename Derived1, typename Derived2>
-  dot_product_vari(const Eigen::DenseBase<Derived1>& v1,
-                   const Eigen::DenseBase<Derived2>& v2,
-                   dot_product_vari<T1, T2>* shared_v1 = NULL,
-                   dot_product_vari<T1, T2>* shared_v2 = NULL)
-      : vari(var_dot(v1, v2)), length_(v1.size()) {
-    if (shared_v1 == NULL) {
-      initialize(v1_, v1);
-    } else {
-      initialize(v1_, v1, shared_v1->v1_);
-    }
-    if (shared_v2 == NULL) {
-      initialize(v2_, v2);
-    } else {
-      initialize(v2_, v2, shared_v2->v2_);
-    }
-  }
-  template <int R1, int C1, int R2, int C2>
-  dot_product_vari(const Eigen::Matrix<T1, R1, C1>& v1,
-                   const Eigen::Matrix<T2, R2, C2>& v2,
-                   dot_product_vari<T1, T2>* shared_v1 = NULL,
-                   dot_product_vari<T1, T2>* shared_v2 = NULL)
-      : vari(var_dot(v1, v2)), length_(v1.size()) {
-    if (shared_v1 == NULL) {
-      initialize(v1_, v1);
-    } else {
-      initialize(v1_, v1, shared_v1->v1_);
-    }
-    if (shared_v2 == NULL) {
-      initialize(v2_, v2);
-    } else {
-      initialize(v2_, v2, shared_v2->v2_);
-    }
-  }
-  virtual void chain() { chain(v1_, v2_); }
-};
 }  // namespace internal
 
 /**
@@ -192,13 +96,17 @@ class dot_product_vari : public vari {
  * @throw std::domain_error if length of v1 is not equal to length of v2.
  */
 template <typename Vec1, typename Vec2,
-          typename = require_all_eigen_vector_t<Vec1, Vec2>,
-          typename = require_any_eigen_vt<is_var, Vec1, Vec2>, typename = void>
-inline auto dot_product(const Vec1& v1, const Vec2& v2) {
+	  require_t<
+	    disjunction<conjunction<
+			  require_vector2<Vec1>,
+			  require_vector2<Vec2>>,
+			conjunction<
+			  require_row_vector2<Vec1>,
+			  require_row_vector2<Vec2>>>>* = nullptr,
+          require_any_var2_t<Vec1, Vec2>* = nullptr>
+inline var dot_product(const Vec1& v1, const Vec2& v2) {
   check_matching_sizes("dot_product", "v1", v1, "v2", v2);
-  return var(
-      new internal::dot_product_vari<value_type_t<Vec1>, value_type_t<Vec2>>(
-          v1, v2));
+  return adj_jac_apply<internal::OpDotProductEigen>(v1, v2);
 }
 
 /**
@@ -212,12 +120,15 @@ inline auto dot_product(const Vec1& v1, const Vec2& v2) {
  * @param[in] length Length of both arrays.
  * @return Dot product of the arrays.
  */
-template <typename T1, typename T2, typename = require_any_var_t<T1, T2>>
+template <typename T1, typename T2,
+	  require_any_var_t<T1, T2>* = nullptr>
 inline return_type_t<T1, T2> dot_product(const T1* v1, const T2* v2,
                                          size_t length) {
-  return var(new internal::dot_product_vari<T1, T2>(v1, v2, length));
+  return adj_jac_apply<internal::OpDotProductEigen>
+    (Eigen::Map<Eigen::VectorXd>(v1, length),
+     Eigen::Map<Eigen::VectorXd>(v2, length));
 }
-
+  
 /**
  * Returns the dot product.
  *
@@ -229,11 +140,15 @@ inline return_type_t<T1, T2> dot_product(const T1* v1, const T2* v2,
  * @return Dot product of the vectors.
  * @throw std::domain_error if sizes of v1 and v2 do not match.
  */
-template <typename T1, typename T2, typename = require_any_var_t<T1, T2>>
+template <typename T1,
+	  typename T2,
+	  require_any_var_t<T1, T2>* = nullptr>
 inline return_type_t<T1, T2> dot_product(const std::vector<T1>& v1,
                                          const std::vector<T2>& v2) {
   check_matching_sizes("dot_product", "v1", v1, "v2", v2);
-  return var(new internal::dot_product_vari<T1, T2>(&v1[0], &v2[0], v1.size()));
+  return adj_jac_apply<internal::OpDotProductEigen>
+    (Eigen::Map<Eigen::VectorXd>(v1.data(), v1.size()),
+     Eigen::Map<Eigen::VectorXd>(v2.data(), v2.size()));
 }
 
 }  // namespace math

--- a/stan/math/rev/fun/multiply_lower_tri_self_transpose.hpp
+++ b/stan/math/rev/fun/multiply_lower_tri_self_transpose.hpp
@@ -41,7 +41,7 @@ struct OpLLT : public AdjJacOp {
     Eigen::MatrixXd adjL = (adj.transpose() + adj) * L;
 
     for(size_t j = 1; j < adjL.cols(); ++j)
-      for(size_t i = 0; i < j; ++i)
+      for(size_t i = 0; i < std::min(static_cast<size_t>(adjL.rows()), j); ++i)
 	adjL(i, j) = 0.0;
 
     return std::make_tuple(adjL);

--- a/stan/math/rev/fun/rows_dot_product.hpp
+++ b/stan/math/rev/fun/rows_dot_product.hpp
@@ -24,19 +24,18 @@ struct RowsDotProductOp : public AdjJacOp {
 	    typename Derived1,
 	    typename Derived2>
   Eigen::VectorXd operator()(const std::array<bool, size>& needs_adj,
-			     const Eigen::MatrixBase<Derived1>& a_arg,
-			     const Eigen::MatrixBase<Derived2>& b_arg) {
-    const auto& a = a_arg.eval();
-    const auto& b = b_arg.eval();
-    
+			     const Eigen::MatrixBase<Derived1>& a,
+			     const Eigen::MatrixBase<Derived2>& b) {
     N_ = a.rows();
     M_ = a.cols();
 
-    if(needs_adj[0])
+    if(needs_adj[0]) {
       b_mem_ = allocate_and_save(b);
+    }
 
-    if(needs_adj[1])
+    if(needs_adj[1]) {
       a_mem_ = allocate_and_save(a);
+    }
 
     Eigen::VectorXd out(N_);
     for(size_t n = 0; n < N_; ++n)
@@ -48,26 +47,11 @@ struct RowsDotProductOp : public AdjJacOp {
   template <std::size_t size, typename Derived>
   auto multiply_adjoint_jacobian(const std::array<bool, size>& needs_adj,
                                  const Eigen::MatrixBase<Derived>& adj) {
-    Eigen::MatrixXd adja;
-    Eigen::MatrixXd adjb;
+    auto a = map_matrix(a_mem_, N_, (needs_adj[1]) ? M_ : 0);
+    auto b = map_matrix(b_mem_, N_, (needs_adj[0]) ? M_ : 0);
 
-    if(needs_adj[0]) {
-      auto b = map_matrix(b_mem_, N_, M_);
-      adja.resize(N_, M_);
-
-      for(size_t n = 0; n < N_; ++n)
-	adja.row(n) = adj(n) * b.row(n);
-    }
-
-    if(needs_adj[1]) {
-      auto a = map_matrix(a_mem_, N_, M_);
-      adjb.resize(N_, M_);
-
-      for(size_t n = 0; n < N_; ++n)
-	adjb.row(n) = adj(n) * a.row(n);
-    }
-
-    return std::make_tuple(adja, adjb);
+    return std::make_tuple(adj.asDiagonal() * b,
+			   adj.asDiagonal() * a);
   }
 };
 

--- a/stan/math/rev/fun/size.hpp
+++ b/stan/math/rev/fun/size.hpp
@@ -1,0 +1,33 @@
+#ifndef STAN_MATH_REV_FUN_SIZE_HPP
+#define STAN_MATH_REV_FUN_SIZE_HPP
+
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/fun/Eigen.hpp>
+#include <stan/math/rev/core/var.hpp>
+#include <cstdlib>
+#include <vector>
+
+namespace stan {
+namespace math {
+
+/** \ingroup type_trait
+ * Returns the length of var_value<double> (always of length 1)
+ */
+inline size_t size(const var_value<double>& /*x*/) {
+  return 1U;
+}
+
+/** \ingroup type_trait
+ * Returns the size of the provided var_value<Eigen::Matrix<T, R, C>>
+ *
+ * @param m var_value
+ * @tparam T type of m
+ */
+template<int R, int C>
+inline size_t size(const var_value<Eigen::Matrix<double, R, C>>& m) {
+  return m.val().size();
+}
+
+}  // namespace math
+}  // namespace stan
+#endif

--- a/stan/math/rev/fun/sum.hpp
+++ b/stan/math/rev/fun/sum.hpp
@@ -88,12 +88,13 @@ class sum_eigen_v_vari : public sum_v_vari {
  * @param m Specified matrix or vector.
  * @return Sum of coefficients of matrix.
  */
-template <int R, int C>
-inline var sum(const Eigen::Matrix<var, R, C>& m) {
+template <typename T,
+	  require_eigen_vt<is_var, T>* = nullptr>
+inline var sum(const T& m) {
   if (m.size() == 0) {
     return 0.0;
   }
-  return var(new sum_eigen_v_vari(m));
+  return var(new sum_eigen_v_vari(m.eval()));
 }
 
 template <int R, int C>

--- a/stan/math/rev/fun/sum.hpp
+++ b/stan/math/rev/fun/sum.hpp
@@ -109,7 +109,7 @@ class sum_vari : public vari {
 
 template <int R, int C>
 inline var sum(const var_value<Eigen::Matrix<double, R, C>>& x) {
-  return {new sum_vari<R, C>(x.vi_)};
+  return { new sum_vari<R, C>(x.vi_) };
 }
 
 inline var sum(var_value<double> x) { return x; }

--- a/stan/math/rev/fun/value_of.hpp
+++ b/stan/math/rev/fun/value_of.hpp
@@ -21,7 +21,7 @@ namespace math {
  * @return Value of variable.
  */
 template <typename T>
-inline auto value_of(const var_value<T>& v) {
+inline const auto& value_of(const var_value<T>& v) {
   return v.vi_->val_;
 }
 

--- a/stan/math/rev/meta/is_var.hpp
+++ b/stan/math/rev/meta/is_var.hpp
@@ -101,6 +101,42 @@ template <typename T>
 struct scalar_type<T, std::enable_if_t<is_var_value<T>::value>> {
   using type = math::var_value<double>;
 };
+
+template <typename... Targs>
+using require_any_var2 = math::disjunction<
+  is_var<value_type_t<Targs>>...,
+  std::is_same<std::decay_t<Targs>, math::var_value<Eigen::MatrixXd>>...,
+  std::is_same<std::decay_t<Targs>, math::var_value<Eigen::VectorXd>>...,
+  std::is_same<std::decay_t<Targs>, math::var_value<Eigen::RowVectorXd>>...>;
+
+template <typename... Targs>
+using require_any_var2_t = require_t<require_any_var2<Targs...>>;
+
+template <typename T> 
+using require_scalar2_t = require_t<std::is_same<std::decay_t<T>, scalar_type_t<std::decay_t<T>>>>;
+
+template <typename T>
+using require_matrix2 = math::disjunction<is_eigen<T>,
+					  std::is_same<std::decay_t<T>, math::var_value<Eigen::MatrixXd>>,
+					  std::is_same<std::decay_t<T>, math::var_value<Eigen::VectorXd>>,
+					  std::is_same<std::decay_t<T>, math::var_value<Eigen::RowVectorXd>>>;
+
+template <typename T>
+using require_matrix2_t = require_t<require_matrix2<T>>;
+
+template <typename T>
+using require_vector2 = math::disjunction<is_eigen_col_vector<T>,
+					 std::is_same<std::decay_t<T>, math::var_value<Eigen::VectorXd>>>;
+  
+template <typename T>
+using require_vector2_t = require_t<require_vector2<T>>;
+
+template <typename T>
+using require_row_vector2 = math::disjunction<is_eigen_row_vector<T>,
+					     std::is_same<std::decay_t<T>, math::var_value<Eigen::RowVectorXd>>>;
+
+template <typename T>
+using require_row_vector2_t = require_t<require_row_vector2<T>>;
   
 }  // namespace stan
 #endif

--- a/stan/math/rev/meta/is_var.hpp
+++ b/stan/math/rev/meta/is_var.hpp
@@ -97,5 +97,10 @@ struct get_var_scalar<T, require_var_value_t<T>> {
 template <typename T>
 using get_var_scalar_t = typename get_var_scalar<std::decay_t<T>>::type;
 
+template <typename T>
+struct scalar_type<T, std::enable_if_t<is_var_value<T>::value>> {
+  using type = math::var_value<double>;
+};
+  
 }  // namespace stan
 #endif

--- a/stan/math/rev/meta/var_tuple_filter.hpp
+++ b/stan/math/rev/meta/var_tuple_filter.hpp
@@ -17,7 +17,7 @@ template <template <typename...> class Pred,
           template <typename...> class Filter, typename T>
 using var_filter_helper
     = std::conditional_t<Pred<std::decay_t<T>>::value, std::tuple<Filter<T>>,
-                         std::tuple<>>;
+                         std::tuple<std::nullptr_t>>;
 
 template <typename T>
 using var_vari_value_t = get_var_vari_value_t<scalar_type_t<T>>;

--- a/test/unit/math/rev/core/operator_multiplication_test.cpp
+++ b/test/unit/math/rev/core/operator_multiplication_test.cpp
@@ -1,6 +1,6 @@
 #include <stan/math/rev/core.hpp>
 #include <test/unit/math/expect_near_rel.hpp>
-#include <test/unit/math/rev/fun/util.hpp>
+#include <test/unit/math/rev/test_var_value_helper.hpp>
 #include <gtest/gtest.h>
 #include <vector>
 #include <limits>
@@ -34,48 +34,6 @@ auto make_var_matrix(size_t N = 3, size_t M = 3) {
     out(n) = n + 1;
   }
   return out;
-}
-
-template <typename F, int R, int C>
-void expect_ad2(const F& f, const Eigen::Matrix<double, R, C>& x) {
-  Eigen::Matrix<var, R, C> xv = x;
-  var_value<Eigen::Matrix<double, R, C>> vx = x;
-
-  auto o = f(x).eval();
-  auto ov = f(xv);
-  auto vo = f(vx);
-
-  stan::math::set_zero_all_adjoints();
-  sum(ov).grad();
-  auto xv_adj = xv.adj().eval();
-  stan::math::set_zero_all_adjoints();
-  sum(vo).grad();
-  auto vx_adj = vx.adj().eval();
-
-  auto g = [&](const Eigen::VectorXd& flat_x) {
-    Eigen::Matrix<double, R, C> x_shaped_variable(x.rows(), x.cols());
-    for(size_t i = 0; i < flat_x.size(); ++i)
-      x_shaped_variable(i) = flat_x(i);
-
-    auto o = f(x_shaped_variable);
-
-    return sum(o);
-  };
-
-  double tmp;
-  Eigen::VectorXd flat_x(x.size());
-  Eigen::VectorXd grad_x;
-  for(size_t i = 0; i < flat_x.size(); ++i)
-    flat_x(i) = x(i);
-  stan::math::finite_diff_gradient_auto(g, flat_x, tmp, grad_x);
-  Eigen::Matrix<double, R, C> x_shaped_grad(x.rows(), x.cols());
-  for(size_t i = 0; i < grad_x.size(); ++i)
-    x_shaped_grad(i) = grad_x(i);
-
-  stan::test::expect_near_rel("matrix of vars function output", o, value_of(ov));
-  stan::test::expect_near_rel("var matrix function output", o, value_of(vo));
-  stan::test::expect_near_rel("matrix of vars argument adjoints", x_shaped_grad, xv_adj);
-  stan::test::expect_near_rel("var matrix argument adjoints", x_shaped_grad, vx_adj);
 }
 
 /*TEST(MathRev, cast_vector) {

--- a/test/unit/math/rev/fun/columns_dot_product_test.cpp
+++ b/test/unit/math/rev/fun/columns_dot_product_test.cpp
@@ -1,0 +1,19 @@
+#include <stan/math/rev/core.hpp>
+#include <test/unit/math/expect_near_rel.hpp>
+#include <test/unit/math/rev/test_var_value_helper.hpp>
+#include <stan/math/rev/fun/columns_dot_product.hpp>
+#include <gtest/gtest.h>
+#include <vector>
+#include <limits>
+
+TEST(MathRev, var_value_tests) {
+  Eigen::MatrixXd mat1 = Eigen::MatrixXd::Random(3, 3);
+  Eigen::MatrixXd mat2 = Eigen::MatrixXd::Random(3, 3);
+
+  auto f = [&](const auto& arg) {
+    return (stan::math::columns_dot_product(mat1, arg) +
+    stan::math::columns_dot_product(arg, mat1)).eval();
+  };
+
+  expect_ad2(f, mat2);
+}

--- a/test/unit/math/rev/fun/dot_product_test.cpp
+++ b/test/unit/math/rev/fun/dot_product_test.cpp
@@ -1,0 +1,22 @@
+#include <stan/math/rev/core.hpp>
+#include <test/unit/math/expect_near_rel.hpp>
+#include <test/unit/math/rev/test_var_value_helper.hpp>
+#include <gtest/gtest.h>
+#include <vector>
+#include <limits>
+
+TEST(MathRev, scalar_vector) {
+  Eigen::VectorXd vec = Eigen::VectorXd::Random(3);
+  Eigen::RowVectorXd rvec = Eigen::RowVectorXd::Random(3);
+
+  auto f1 = [&](const auto& arg) {
+    return stan::math::dot_product(vec, arg) + stan::math::dot_product(arg, vec);
+  };
+
+  auto f2 = [&](const auto& arg) {
+    return stan::math::dot_product(rvec, arg) + stan::math::dot_product(arg, rvec);
+  };
+
+  expect_ad2(f1, vec);
+  expect_ad2(f2, rvec);
+}

--- a/test/unit/math/rev/fun/multiply_lower_tri_self_transpose_test.cpp
+++ b/test/unit/math/rev/fun/multiply_lower_tri_self_transpose_test.cpp
@@ -1,0 +1,17 @@
+#include <stan/math/rev/core.hpp>
+#include <test/unit/math/expect_near_rel.hpp>
+#include <test/unit/math/rev/test_var_value_helper.hpp>
+#include <stan/math/rev/fun/multiply_lower_tri_self_transpose.hpp>
+#include <gtest/gtest.h>
+#include <vector>
+#include <limits>
+
+TEST(MathRev, var_value_tests) {
+  Eigen::MatrixXd mat = Eigen::MatrixXd::Random(3, 3);
+
+  auto f = [&](const auto& arg) {
+    return stan::math::multiply_lower_tri_self_transpose(arg);
+  };
+
+  expect_ad2(f, mat);
+}

--- a/test/unit/math/rev/fun/rows_dot_product_test.cpp
+++ b/test/unit/math/rev/fun/rows_dot_product_test.cpp
@@ -1,0 +1,19 @@
+#include <stan/math/rev/core.hpp>
+#include <test/unit/math/expect_near_rel.hpp>
+#include <test/unit/math/rev/test_var_value_helper.hpp>
+#include <stan/math/rev/fun/rows_dot_product.hpp>
+#include <gtest/gtest.h>
+#include <vector>
+#include <limits>
+
+TEST(MathRev, var_value_tests) {
+  Eigen::MatrixXd mat1 = Eigen::MatrixXd::Random(3, 3);
+  Eigen::MatrixXd mat2 = Eigen::MatrixXd::Random(3, 3);
+
+  auto f = [&](const auto& arg) {
+    return (stan::math::rows_dot_product(mat1, arg) +
+    stan::math::rows_dot_product(arg, mat1)).eval();
+  };
+
+  expect_ad2(f, mat2);
+}

--- a/test/unit/math/rev/fun/tcrossprod_test.cpp
+++ b/test/unit/math/rev/fun/tcrossprod_test.cpp
@@ -1,0 +1,17 @@
+#include <stan/math/rev/core.hpp>
+#include <test/unit/math/expect_near_rel.hpp>
+#include <test/unit/math/rev/test_var_value_helper.hpp>
+#include <stan/math/rev/fun/tcrossprod.hpp>
+#include <gtest/gtest.h>
+#include <vector>
+#include <limits>
+
+TEST(MathRev, var_value_tests) {
+  Eigen::MatrixXd mat = Eigen::MatrixXd::Random(3, 3);
+
+  auto f = [&](const auto& arg) {
+    return stan::math::tcrossprod(arg);
+  };
+
+  expect_ad2(f, mat);
+}

--- a/test/unit/math/rev/functor/adj_jac_apply_test.cpp
+++ b/test/unit/math/rev/functor/adj_jac_apply_test.cpp
@@ -454,14 +454,17 @@ struct WeirdArgumentListFunctor1 {
 };
 
 template <typename F, typename... Targs>
-auto make_vari_for_test(const Targs&... args) {
+auto make_vari_for_test_impl(const Targs&... args) {
   using stan::math::adj_jac_vari;
-  using stan::math::x_vis_alloc;
-  auto* x_alloc = new x_vis_alloc<Targs...>(args...);
-  auto vi = new adj_jac_vari<F, Targs...>(x_alloc);
+  auto vi = new adj_jac_vari<F, Targs...>(args...);
   (*vi)(args...);
 
   return vi;
+}
+
+template <typename F, typename... Targs>
+auto make_vari_for_test(const Targs&... args) {
+  return make_vari_for_test_impl<F>(stan::math::convert_to_whole_matrix(args)...);
 }
 
 TEST(AgradRev, test_weird_argument_list_functor_compiles_and_sets_is_var_) {

--- a/test/unit/math/rev/meta/var_tuple_filter_test.cpp
+++ b/test/unit/math/rev/meta/var_tuple_filter_test.cpp
@@ -8,17 +8,20 @@ TEST(MetaTraitsRevScal, var_tuple_filter) {
   using stan::math::var_value;
   using stan::math::test::type_name;
 
+  std::cout << type_name<stan::scalar_type_t<var_value<Eigen::MatrixXd>>>() << std::endl << std::endl;
+  
   std::cout << type_name<stan::value_type_t<Eigen::Matrix<var, -1, -1>>>()
             << std::endl
             << std::endl;
 
   std::cout
-      << type_name<stan::get_var_vari_value_t<Eigen::Matrix<var, -1, -1>>>()
+      << type_name<stan::get_var_vari_value_t<Eigen::Matrix<double, -1, -1>>>()
       << std::endl;
 
   using checker
-      = var_to_vari_filter_t<var, double, double, Eigen::Matrix<var, -1, -1>,
-                             var_value<Eigen::MatrixXd>, std::vector<var>>;
+    = var_to_vari_filter_t<var, double, double, Eigen::Matrix<double, -1, -1>,
+			   Eigen::Matrix<var, -1, -1>,
+			   var_value<Eigen::MatrixXd>, std::vector<var>>;
 
   std::cout << "\n" << type_name<checker>() << "\n";
 }

--- a/test/unit/math/rev/test_var_value_helper.hpp
+++ b/test/unit/math/rev/test_var_value_helper.hpp
@@ -1,0 +1,56 @@
+#include <stan/math/rev/core.hpp>
+#include <test/unit/math/expect_near_rel.hpp>
+#include <test/unit/math/rev/fun/util.hpp>
+#include <gtest/gtest.h>
+#include <vector>
+#include <limits>
+
+template <typename F, int R, int C>
+void expect_ad2(const F& f, const Eigen::Matrix<double, R, C>& x) {
+  using stan::math::var;
+  using stan::math::var_value;
+  using stan::math::sum;
+  
+  Eigen::Matrix<var, R, C> xv = x;
+  var_value<Eigen::Matrix<double, R, C>> vx = x;
+
+  auto o = f(x);
+  auto ov = f(xv);
+  auto vo = f(vx);
+
+  stan::math::set_zero_all_adjoints();
+  sum(ov).grad();
+  auto xv_adj = xv.adj().eval();
+  stan::math::set_zero_all_adjoints();
+  sum(vo).grad();
+  auto vx_adj = vx.adj().eval();
+
+  auto g = [&](const Eigen::VectorXd& flat_x) {
+    Eigen::Matrix<double, R, C> x_shaped_variable(x.rows(), x.cols());
+    for(size_t i = 0; i < flat_x.size(); ++i)
+      x_shaped_variable(i) = flat_x(i);
+
+    auto o = f(x_shaped_variable);
+
+    return sum(o);
+  };
+
+  double tmp;
+  Eigen::VectorXd flat_x(x.size());
+  Eigen::VectorXd grad_x;
+  for(size_t i = 0; i < flat_x.size(); ++i)
+    flat_x(i) = x(i);
+  stan::math::finite_diff_gradient_auto(g, flat_x, tmp, grad_x);
+  Eigen::Matrix<double, R, C> x_shaped_grad(x.rows(), x.cols());
+  for(size_t i = 0; i < grad_x.size(); ++i)
+    x_shaped_grad(i) = grad_x(i);
+
+  /*std::cout << x_shaped_grad << std::endl;
+  std::cout << "-----" << std::endl;
+  std::cout << vx_adj << std::endl;*/
+   
+  stan::test::expect_near_rel("matrix of vars function output", o, value_of(ov));
+  stan::test::expect_near_rel("var matrix function output", o, value_of(vo));
+  stan::test::expect_near_rel("matrix of vars argument adjoints", x_shaped_grad, xv_adj);
+  stan::test::expect_near_rel("var matrix argument adjoints", x_shaped_grad, vx_adj);
+}


### PR DESCRIPTION
Alright here's a version of the multiplication that I like better.

After writing this I'm not convinced we'd actually do multiplication with it. There might be some overheads especially with scalar * scalar multiplication that means we should stick with the previous varis, but it works for illustration and will be appropriate for a lot of the functions we do have to tackle (https://gist.github.com/bbbales2/a1b2bcc1f616820ce5db59b9be46c49c)

In this implementation there are `adj_jac_apply` functions to handle the implementations of the multiplication operator between different combinations of scalar and matrix types.

Type traits are used to make sure `adj_jac_apply` gets called for the right combination of scalar/matrix arguments. There are four combinations we gotta worry about:

```
operator*(scalar, scalar)
operator*(matrix, scalar)
operator*(scalar, matrix)
operator*(matrix, matrix)
```

The outside-facing function ended up looking like:
```
template <typename T1, typename T2,
	  require_scalar_t<T1>...,
	  require_scalar_t<T2>...,
	  require_any_var_value_t<T1, T2>...>
inline auto operator*(const T1& a, const T2& b) {
  return adj_jac_apply<OpMultiplyScalarScalar>(a, b);
}
```

The type traits I needed were:
* ```require_scalar_t``` which accepts only mathematical scalar objects,
* ```require_matrix_t``` which only accepts objects that are matrices (this includes vectors/row_vectors) and then
* ```require_any_var_value_t``` to make sure at least one thing was a var (and avoid conflicting with prim implementations)

Implementations of ```require_scalar_t``` and ```require_matrix_t``` are [here](https://github.com/stan-dev/math/pull/1928/files#diff-4d75dd68c0cf62489e92b7584c06fde3R159)

So for the most part now, ```adj_jac_apply``` is doing all the juggling with autodiff types and whatnot, and so for implementing functions I don't really need to deal with lots of type_traits.

I'm not sure how much this would balloon if it supported things with complex number specializations or what those would look like. It's probably worth thinking about though.

The implementation starts around like [159](https://github.com/stan-dev/math/blob/4ab15812179e40fe6c26c25e5552d26e649430b6/stan/math/rev/core/operator_multiplication.hpp)

## Checklist

- [ ] Math issue #(issue number)

- [x] Copyright holder: Columbia University

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [ ] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [ ] the code is written in idiomatic C++ and changes are documented in the doxygen

- [ ] the new changes are tested
