### PR TITLE
bugfix test_repeat_as_vector

### DIFF
--- a/test/prob/test_fixture_ccdf_log.hpp
+++ b/test/prob/test_fixture_ccdf_log.hpp
@@ -575,7 +575,8 @@ class AgradCcdfLogTestFixture : public ::testing::Test {
       calculate_gradients_1storder(multiple_gradients2, multiple_ccdf_log, x1);
       calculate_gradients_1storder(multiple_gradients3, multiple_ccdf_log, x1);
 
-      EXPECT_TRUE(single_ccdf_log * N_REPEAT - multiple_ccdf_log < 1e-8)
+      EXPECT_NEAR(stan::math::value_of_rec(single_ccdf_log * N_REPEAT),
+                  stan::math::value_of_rec(multiple_ccdf_log), 1e-8)
           << "ccdf_log with repeated vector input should match "
           << "a multiple of ccdf_log of single input";
 

--- a/test/prob/test_fixture_cdf.hpp
+++ b/test/prob/test_fixture_cdf.hpp
@@ -566,7 +566,8 @@ class AgradCdfTestFixture : public ::testing::Test {
       calculate_gradients_1storder(multiple_gradients2, multiple_cdf, x1);
       calculate_gradients_1storder(multiple_gradients3, multiple_cdf, x1);
 
-      EXPECT_TRUE(pow(single_cdf, N_REPEAT) - multiple_cdf < 1e-8)
+      EXPECT_NEAR(stan::math::value_of_rec(pow(single_cdf, N_REPEAT)),
+                  stan::math::value_of_rec(multiple_cdf), 1e-8)
           << "cdf with repeated vector input should match "
           << "a multiple of cdf of single input";
 

--- a/test/prob/test_fixture_cdf_log.hpp
+++ b/test/prob/test_fixture_cdf_log.hpp
@@ -576,7 +576,8 @@ class AgradCdfLogTestFixture : public ::testing::Test {
       calculate_gradients_1storder(multiple_gradients2, multiple_cdf_log, x1);
       calculate_gradients_1storder(multiple_gradients3, multiple_cdf_log, x1);
 
-      EXPECT_TRUE(single_cdf_log * N_REPEAT - multiple_cdf_log < 1e-8)
+      EXPECT_NEAR(stan::math::value_of_rec(N_REPEAT * single_cdf_log),
+                  stan::math::value_of_rec(multiple_cdf_log), 1e-8)
           << "cdf_log with repeated vector input should match "
           << "a multiple of cdf_log of single input";
 

--- a/test/prob/test_fixture_distr.hpp
+++ b/test/prob/test_fixture_distr.hpp
@@ -640,7 +640,8 @@ class AgradDistributionTestFixture : public ::testing::Test {
       calculate_gradients_1storder(multiple_gradients2, multiple_lp, x1);
       calculate_gradients_1storder(multiple_gradients3, multiple_lp, x1);
 
-      EXPECT_TRUE(N_REPEAT * single_lp - multiple_lp < 1e-8)
+      EXPECT_NEAR(stan::math::value_of_rec(N_REPEAT * single_lp),
+                  stan::math::value_of_rec(multiple_lp), 1e-8)
           << "log prob with repeated vector input should match "
           << "a multiple of log prob of single input";
 


### PR DESCRIPTION
## Summary

Fixes one sided checks in `test_repeat_as_vector` in distribution tests.

## Tests

## Side Effects
None.

## Release notes

Fixed one sided checks in `test_repeat_as_vector` in distribution tests.

## Checklist

- [x] Math issue #1932 

- [x] Copyright holder: Tadej Ciglarič

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [ ] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
