### PR TITLE
Bugfix: construction of matrix_cl from Eigen::Map

### DIFF
--- a/stan/math/opencl/matrix_cl.hpp
+++ b/stan/math/opencl/matrix_cl.hpp
@@ -313,26 +313,10 @@ class matrix_cl<T, require_arithmetic_t<T>> {
     if (size() == 0) {
       return;
     }
-    if (std::is_same<std::decay_t<Mat>, Mat_type>::value
+    initialize_buffer_no_heap_if<
+        std::is_same<std::decay_t<Mat>, Mat_type>::value
         && (std::is_lvalue_reference<Mat>::value
-            || is_eigen_contiguous_map<Mat>::value)) {
-      // .eval)= is here just in case other branch is selected and A does not
-      // have data directley accessible
-      initialize_buffer(A.eval().data());
-    } else {
-      auto* A_heap = new Mat_type(std::move(A));
-      try {
-        cl::Event e = initialize_buffer(A_heap->data());
-        // We set a callback that will delete the memory once copying is
-        // complete. This event object does not hold the information about
-        // callback. OpenCL implementation does. So nothing is lost as event
-        // goes out of scope.
-        e.setCallback(CL_COMPLETE, &delete_it<Mat_type>, A_heap);
-      } catch (...) {
-        delete A_heap;
-        throw;
-      }
-    }
+            || is_eigen_contiguous_map<Mat>::value)>(A);
   }
 
   /**
@@ -405,7 +389,7 @@ class matrix_cl<T, require_arithmetic_t<T>> {
   explicit matrix_cl(Vec&& A, const int& R, const int& C,
                      matrix_cl_view partial_view = matrix_cl_view::Entire)
       : rows_(R), cols_(C), view_(partial_view) {
-    initialize_buffer_optionally_from_heap(std::forward<Vec>(A));
+    initialize_buffer_no_heap_if<std::is_lvalue_reference<Vec>::value>(A);
   }
 
   /**
@@ -520,37 +504,43 @@ class matrix_cl<T, require_arithmetic_t<T>> {
   /**
    * Initializes the OpenCL buffer of this matrix by copying the data from given
    * object. Assumes that size of \c this is already set and matches the
-   * buffer size. If the object is rvalue (temporary) it is first moved to heap
+   * buffer size. If No_heap is false the object is first moved to heap
    * and callback is set to delete it after copying to OpenCL device is
-   * complete. If a lvalue is passed to this function the caller must make
-   * sure that input object does not go out of scope before copying is complete.
+   * complete. Otherwise the caller must make sure that input object does not go
+   * out of scope before copying is complete.
    *
    * That means `.wait()` must be called on the event associated on copying or
    * any other event that requires completion of this event. This can be done by
    * calling `.wait_for_write_events()` or `.wait_for_read_write_events()` on
    * this matrix or any matrix that is calculated from this one.
    *
+   * @tparam No_heap whether to move the object to heap first
    * @tparam U type of object
    * @param obj object
    * @return event for the copy
    */
-  template <typename U>
-  void initialize_buffer_optionally_from_heap(U&& obj) {
-    using U_val = std::decay_t<U>;
+  template <bool No_heap, typename U, std::enable_if_t<No_heap>* = nullptr>
+  void initialize_buffer_no_heap_if(U&& obj) {
     if (size() == 0) {
       return;
     }
-    if (std::is_lvalue_reference<U>::value) {
-      initialize_buffer(obj.data());
-    } else {
-      auto* obj_heap = new U_val(std::move(obj));
-      try {
-        cl::Event e = initialize_buffer(obj_heap->data());
-        e.setCallback(CL_COMPLETE, &delete_it<U_val>, obj_heap);
-      } catch (...) {
-        delete obj_heap;
-        throw;
-      }
+    initialize_buffer(obj.data());
+  }
+  // we need separate overloads as obj.data() might not be available when second
+  // overload is called.
+  template <bool No_heap, typename U, std::enable_if_t<!No_heap>* = nullptr>
+  void initialize_buffer_no_heap_if(U&& obj) {
+    using U_val = std::decay_t<ref_type_for_opencl_t<U>>;
+    if (size() == 0) {
+      return;
+    }
+    auto* obj_heap = new U_val(std::move(obj));
+    try {
+      cl::Event e = initialize_buffer(obj_heap->data());
+      e.setCallback(CL_COMPLETE, &delete_it<U_val>, obj_heap);
+    } catch (...) {
+      delete obj_heap;
+      throw;
     }
   }
 

--- a/test/unit/math/opencl/matrix_cl_test.cpp
+++ b/test/unit/math/opencl/matrix_cl_test.cpp
@@ -20,6 +20,7 @@ inline void test_matrix_creation() {
   EXPECT_NO_THROW(stan::math::matrix_cl<T> vec_1cl(vec_1, 2, 2));
   EXPECT_NO_THROW(stan::math::matrix_cl<T> mat_1cl(mat_1));
   EXPECT_NO_THROW(stan::math::matrix_cl<T> mat_2cl(mat_2));
+  EXPECT_NO_THROW(stan::math::matrix_cl<T> mat_2cl(mat_2 * 2));
 }
 
 TEST(MathMatrixCL, matrix_cl_types_creation) {
@@ -34,6 +35,11 @@ TEST(MathMatrixCL, matrix_cl_value) {
   col_major << 1, 2, 3, 4, 5, 6, 7, 8, 9;
   stan::math::matrix_cl<double> cl_from_col_major(col_major);
   Eigen::MatrixXd res = stan::math::from_matrix_cl(cl_from_col_major);
+  expect_matrix_eq(col_major, res);
+
+  Eigen::Map<Eigen::MatrixXd> map(col_major.data(),3,3);
+  stan::math::matrix_cl<double> cl_from_map(map);
+  res = stan::math::from_matrix_cl(cl_from_map);
   expect_matrix_eq(col_major, res);
 
   Eigen::Matrix<double, -1, -1, Eigen::RowMajor> row_major(3, 3);

--- a/test/unit/math/opencl/matrix_cl_test.cpp
+++ b/test/unit/math/opencl/matrix_cl_test.cpp
@@ -37,7 +37,7 @@ TEST(MathMatrixCL, matrix_cl_value) {
   Eigen::MatrixXd res = stan::math::from_matrix_cl(cl_from_col_major);
   expect_matrix_eq(col_major, res);
 
-  Eigen::Map<Eigen::MatrixXd> map(col_major.data(),3,3);
+  Eigen::Map<Eigen::MatrixXd> map(col_major.data(), 3, 3);
   stan::math::matrix_cl<double> cl_from_map(map);
   res = stan::math::from_matrix_cl(cl_from_map);
   expect_matrix_eq(col_major, res);


### PR DESCRIPTION
## Summary
Fixes the bug that caused wrong results when constructing a `matrix_cl` from `Eigen::Map`. The map was first evaluated into temporary (whoops) and this temporary was copied to opencl device. It was than deleted before copying completed.

This was introduced in #1919 and caused develop to fail tests today.

## Tests
Added a test for this case and another one for constructing `matrix_cl` from an expression.

## Side Effects

None.

## Checklist

- [ ] Math issue #(issue number)

- [x] Copyright holder: Tadej Ciglarič

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
