### PR TITLE
Replace ... with * = nullptr for requires

### DIFF
--- a/stan/math/fwd/core/operator_division.hpp
+++ b/stan/math/fwd/core/operator_division.hpp
@@ -31,7 +31,7 @@ inline fvar<T> operator/(const fvar<T>& x1, const fvar<T>& x2) {
  * @param x2 second argument
  * @return first argument divided by second argument
  */
-template <typename T, typename U, require_arithmetic_t<U>...>
+template <typename T, typename U, require_arithmetic_t<U>* = nullptr>
 inline fvar<T> operator/(const fvar<T>& x1, U x2) {
   return fvar<T>(x1.val_ / x2, x1.d_ / x2);
 }
@@ -44,7 +44,7 @@ inline fvar<T> operator/(const fvar<T>& x1, U x2) {
  * @param x2 second argument
  * @return first argument divided by second argument
  */
-template <typename T, typename U, require_arithmetic_t<U>...>
+template <typename T, typename U, require_arithmetic_t<U>* = nullptr>
 inline fvar<T> operator/(U x1, const fvar<T>& x2) {
   return fvar<T>(x1 / x2.val_, -x1 * x2.d_ / (x2.val_ * x2.val_));
 }
@@ -54,7 +54,7 @@ inline std::complex<fvar<T>> operator/(const std::complex<fvar<T>>& x1,
                                        const std::complex<fvar<T>>& x2) {
   return internal::complex_divide(x1, x2);
 }
-template <typename T, typename U, require_arithmetic_t<U>...>
+template <typename T, typename U, require_arithmetic_t<U>* = nullptr>
 inline std::complex<fvar<T>> operator/(const std::complex<fvar<T>>& x1,
                                        const std::complex<U>& x2) {
   return internal::complex_divide(x1, x2);
@@ -64,17 +64,17 @@ inline std::complex<fvar<T>> operator/(const std::complex<fvar<T>>& x1,
                                        const fvar<T>& x2) {
   return internal::complex_divide(x1, x2);
 }
-template <typename T, typename U, require_arithmetic_t<U>...>
+template <typename T, typename U, require_arithmetic_t<U>* = nullptr>
 inline std::complex<fvar<T>> operator/(const std::complex<fvar<T>>& x1, U x2) {
   return internal::complex_divide(x1, x2);
 }
 
-template <typename T, typename U, require_arithmetic_t<U>...>
+template <typename T, typename U, require_arithmetic_t<U>* = nullptr>
 inline std::complex<fvar<T>> operator/(const std::complex<U>& x1,
                                        const std::complex<fvar<T>>& x2) {
   return internal::complex_divide(x1, x2);
 }
-template <typename T, typename U, require_arithmetic_t<U>...>
+template <typename T, typename U, require_arithmetic_t<U>* = nullptr>
 inline std::complex<fvar<T>> operator/(const std::complex<U>& x1,
                                        const fvar<T>& x2) {
   return internal::complex_divide(x1, x2);
@@ -92,7 +92,7 @@ inline std::complex<fvar<T>> operator/(const fvar<T>& x1,
   return internal::complex_divide(x1, x2);
 }
 
-template <typename T, typename U, require_arithmetic_t<U>...>
+template <typename T, typename U, require_arithmetic_t<U>* = nullptr>
 inline std::complex<fvar<T>> operator/(U x1, const std::complex<fvar<T>>& x2) {
   return internal::complex_divide(x1, x2);
 }

--- a/stan/math/fwd/fun/is_nan.hpp
+++ b/stan/math/fwd/fun/is_nan.hpp
@@ -18,7 +18,7 @@ namespace math {
  * @param x Value to test.
  * @return <code>1</code> if the value is NaN and <code>0</code> otherwise.
  */
-template <typename T, require_fvar_t<T>...>
+template <typename T, require_fvar_t<T>* = nullptr>
 inline bool is_nan(T&& x) {
   return is_nan(std::forward<decltype(x.val())>(x.val()));
 }

--- a/stan/math/fwd/fun/log_mix.hpp
+++ b/stan/math/fwd/fun/log_mix.hpp
@@ -114,7 +114,7 @@ inline fvar<T> log_mix(const fvar<T>& theta, const fvar<T>& lambda1,
   }
 }
 
-template <typename T, typename P, require_all_arithmetic_t<P>...>
+template <typename T, typename P, require_all_arithmetic_t<P>* = nullptr>
 inline fvar<T> log_mix(const fvar<T>& theta, const fvar<T>& lambda1,
                        P lambda2) {
   if (lambda1.val_ > lambda2) {
@@ -132,7 +132,7 @@ inline fvar<T> log_mix(const fvar<T>& theta, const fvar<T>& lambda1,
   }
 }
 
-template <typename T, typename P, require_all_arithmetic_t<P>...>
+template <typename T, typename P, require_all_arithmetic_t<P>* = nullptr>
 inline fvar<T> log_mix(const fvar<T>& theta, P lambda1,
                        const fvar<T>& lambda2) {
   if (lambda1 > lambda2.val_) {
@@ -150,7 +150,7 @@ inline fvar<T> log_mix(const fvar<T>& theta, P lambda1,
   }
 }
 
-template <typename T, typename P, require_all_arithmetic_t<P>...>
+template <typename T, typename P, require_all_arithmetic_t<P>* = nullptr>
 inline fvar<T> log_mix(P theta, const fvar<T>& lambda1,
                        const fvar<T>& lambda2) {
   if (lambda1.val_ > lambda2.val_) {
@@ -169,7 +169,7 @@ inline fvar<T> log_mix(P theta, const fvar<T>& lambda1,
 }
 
 template <typename T, typename P1, typename P2,
-          require_all_arithmetic_t<P1, P2>...>
+          require_all_arithmetic_t<P1, P2>* = nullptr>
 inline fvar<T> log_mix(const fvar<T>& theta, P1 lambda1, P2 lambda2) {
   if (lambda1 > lambda2) {
     fvar<T> partial_deriv_array[1];
@@ -185,7 +185,7 @@ inline fvar<T> log_mix(const fvar<T>& theta, P1 lambda1, P2 lambda2) {
 }
 
 template <typename T, typename P1, typename P2,
-          require_all_arithmetic_t<P1, P2>...>
+          require_all_arithmetic_t<P1, P2>* = nullptr>
 inline fvar<T> log_mix(P1 theta, const fvar<T>& lambda1, P2 lambda2) {
   if (lambda1.val_ > lambda2) {
     fvar<T> partial_deriv_array[1];
@@ -201,7 +201,7 @@ inline fvar<T> log_mix(P1 theta, const fvar<T>& lambda1, P2 lambda2) {
 }
 
 template <typename T, typename P1, typename P2,
-          require_all_arithmetic_t<P1, P2>...>
+          require_all_arithmetic_t<P1, P2>* = nullptr>
 inline fvar<T> log_mix(P1 theta, P2 lambda1, const fvar<T>& lambda2) {
   if (lambda1 > lambda2.val_) {
     fvar<T> partial_deriv_array[1];

--- a/stan/math/fwd/fun/log_sum_exp.hpp
+++ b/stan/math/fwd/fun/log_sum_exp.hpp
@@ -50,7 +50,7 @@ inline fvar<T> log_sum_exp(const fvar<T>& x1, double x2) {
  * @param[in] x Matrix of specified values.
  * @return The log of the sum of the exponentiated vector values.
  */
-template <typename T, require_container_st<is_fvar, T>...>
+template <typename T, require_container_st<is_fvar, T>* = nullptr>
 inline auto log_sum_exp(const T& x) {
   return apply_vector_unary<T>::reduce(x, [&](const auto& v) {
     using T_fvar_inner = typename value_type_t<decltype(v)>::Scalar;

--- a/stan/math/opencl/copy.hpp
+++ b/stan/math/opencl/copy.hpp
@@ -41,7 +41,7 @@ namespace math {
  * @return matrix_cl with a copy of the data in the source matrix
  */
 template <typename Mat, typename Mat_scalar = scalar_type_t<Mat>,
-          require_eigen_vt<std::is_arithmetic, Mat>...>
+          require_eigen_vt<std::is_arithmetic, Mat>* = nullptr>
 inline matrix_cl<Mat_scalar> to_matrix_cl(Mat&& src) {
   return matrix_cl<Mat_scalar>(std::forward<Mat>(src));
 }
@@ -60,7 +60,7 @@ inline matrix_cl<Mat_scalar> to_matrix_cl(Mat&& src) {
  * @return matrix_cl with a copy of the data in the source matrix
  */
 template <typename Vec, typename Vec_scalar = scalar_type_t<Vec>,
-          require_std_vector_vt<std::is_arithmetic, Vec>...>
+          require_std_vector_vt<std::is_arithmetic, Vec>* = nullptr>
 inline matrix_cl<Vec_scalar> to_matrix_cl(Vec&& src) {
   return matrix_cl<Vec_scalar>(std::forward<Vec>(src));
 }
@@ -158,7 +158,7 @@ inline std::vector<T> packed_copy(const matrix_cl<T>& src) {
  */
 template <matrix_cl_view matrix_view, typename Vec,
           typename Vec_scalar = scalar_type_t<Vec>,
-          require_vector_vt<std::is_arithmetic, Vec>...>
+          require_vector_vt<std::is_arithmetic, Vec>* = nullptr>
 inline matrix_cl<Vec_scalar> packed_copy(Vec&& src, int rows) {
   const int packed_size = rows * (rows + 1) / 2;
   check_size_match("copy (packed std::vector -> OpenCL)", "src.size()",

--- a/stan/math/opencl/kernel_cl.hpp
+++ b/stan/math/opencl/kernel_cl.hpp
@@ -112,7 +112,7 @@ inline void assign_event(const cl::Event& e,
   helper.set(e, m);
 }
 
-template <typename T, require_same_t<T, cl::Event>...>
+template <typename T, require_same_t<T, cl::Event>* = nullptr>
 inline void assign_events(const T&) {}
 
 /** \ingroup kernel_executor_opencl

--- a/stan/math/opencl/matrix_cl.hpp
+++ b/stan/math/opencl/matrix_cl.hpp
@@ -233,8 +233,8 @@ class matrix_cl<T, require_arithmetic_t<T>> {
    * @throw <code>std::system_error</code> if the memory on the device could not
    * be allocated
    */
-  template <typename Vec, require_std_vector_vt<is_eigen, Vec>...,
-            require_st_same<Vec, T>...>
+  template <typename Vec, require_std_vector_vt<is_eigen, Vec>* = nullptr,
+            require_st_same<Vec, T>* = nullptr>
   explicit matrix_cl(Vec&& A) try : rows_(A.empty() ? 0 : A[0].size()),
                                     cols_(A.size()) {
     if (this->size() == 0) {
@@ -305,7 +305,7 @@ class matrix_cl<T, require_arithmetic_t<T>> {
    * @throw <code>std::system_error</code> if the memory on the device could not
    * be allocated
    */
-  template <typename Mat, require_eigen_t<Mat>..., require_vt_same<Mat, T>...>
+  template <typename Mat, require_eigen_t<Mat>* = nullptr, require_vt_same<Mat, T>* = nullptr>
   explicit matrix_cl(Mat&& A,
                      matrix_cl_view partial_view = matrix_cl_view::Entire)
       : rows_(A.rows()), cols_(A.cols()), view_(partial_view) {
@@ -360,8 +360,8 @@ class matrix_cl<T, require_arithmetic_t<T>> {
    * @throw <code>std::system_error</code> if the memory on the device could not
    * be allocated
    */
-  template <typename Vec, require_std_vector_t<Vec>...,
-            require_vt_same<Vec, T>...>
+  template <typename Vec, require_std_vector_t<Vec>* = nullptr,
+            require_vt_same<Vec, T>* = nullptr>
   explicit matrix_cl(Vec&& A,
                      matrix_cl_view partial_view = matrix_cl_view::Entire)
       : matrix_cl(std::forward<Vec>(A), A.size(), 1) {}
@@ -384,8 +384,8 @@ class matrix_cl<T, require_arithmetic_t<T>> {
    * @throw <code>std::system_error</code> if the memory on the device could not
    * be allocated
    */
-  template <typename Vec, require_std_vector_t<Vec>...,
-            require_vt_same<Vec, T>...>
+  template <typename Vec, require_std_vector_t<Vec>* = nullptr,
+            require_vt_same<Vec, T>* = nullptr>
   explicit matrix_cl(Vec&& A, const int& R, const int& C,
                      matrix_cl_view partial_view = matrix_cl_view::Entire)
       : rows_(R), cols_(C), view_(partial_view) {
@@ -409,7 +409,7 @@ class matrix_cl<T, require_arithmetic_t<T>> {
    * @throw <code>std::system_error</code> if the memory on the device could not
    * be allocated
    */
-  template <typename U, require_same_t<T, U>...>
+  template <typename U, require_same_t<T, U>* = nullptr>
   explicit matrix_cl(const U* A, const int& R, const int& C,
                      matrix_cl_view partial_view = matrix_cl_view::Entire)
       : rows_(R), cols_(C), view_(partial_view) {

--- a/stan/math/opencl/matrix_cl.hpp
+++ b/stan/math/opencl/matrix_cl.hpp
@@ -305,7 +305,8 @@ class matrix_cl<T, require_arithmetic_t<T>> {
    * @throw <code>std::system_error</code> if the memory on the device could not
    * be allocated
    */
-  template <typename Mat, require_eigen_t<Mat>* = nullptr, require_vt_same<Mat, T>* = nullptr>
+  template <typename Mat, require_eigen_t<Mat>* = nullptr,
+            require_vt_same<Mat, T>* = nullptr>
   explicit matrix_cl(Mat&& A,
                      matrix_cl_view partial_view = matrix_cl_view::Entire)
       : rows_(A.rows()), cols_(A.cols()), view_(partial_view) {

--- a/stan/math/opencl/rev/copy.hpp
+++ b/stan/math/opencl/rev/copy.hpp
@@ -26,7 +26,7 @@ namespace math {
  * @param src source Eigen matrix
  * @return matrix_cl with a copy of the data in the source matrix
  */
-template <typename T, int R, int C, require_var_t<T>...>
+template <typename T, int R, int C, require_var_t<T>* = nullptr>
 inline matrix_cl<T> to_matrix_cl(const Eigen::Matrix<T, R, C>& src) try {
   matrix_cl<T> dst(src.rows(), src.cols());
   if (src.size() == 0) {
@@ -50,7 +50,7 @@ inline matrix_cl<T> to_matrix_cl(const Eigen::Matrix<T, R, C>& src) try {
  * @return Eigen matrix with a copy of the adjoints in the source matrix
  */
 template <int R = Eigen::Dynamic, int C = Eigen::Dynamic, typename T,
-          require_var_t<T>...>
+          require_var_t<T>* = nullptr>
 inline Eigen::Matrix<double, R, C> from_matrix_cl(const matrix_cl<T>& src) try {
   Eigen::Matrix<double, R, C> dst(src.rows(), src.cols());
   if (src.size() == 0) {
@@ -130,7 +130,7 @@ inline matrix_cl<var> packed_copy(vari** src, int rows) try {
  * @throw <code>std::invalid_argument</code> if the
  * matrices do not have matching dimensions
  */
-template <typename T, require_var_t<T>...>
+template <typename T, require_var_t<T>* = nullptr>
 inline matrix_cl<T> copy_cl(const matrix_cl<T>& src) {
   matrix_cl<T> dst(src.rows(), src.cols(), src.view());
   if (src.size() == 0) {

--- a/stan/math/opencl/rev/matrix_cl.hpp
+++ b/stan/math/opencl/rev/matrix_cl.hpp
@@ -107,7 +107,7 @@ class matrix_cl<T, require_var_t<T>> {
    * @param A an object derived from `Eigen::EigenBase`
    * @param partial_view `matrix_cl_view` for declaring special type.
    */
-  template <typename Mat, require_eigen_st<is_var, Mat>...>
+  template <typename Mat, require_eigen_st<is_var, Mat>* = nullptr>
   explicit matrix_cl(Mat&& A,
                      matrix_cl_view partial_view = matrix_cl_view::Entire)
       : rows_(A.rows()),

--- a/stan/math/prim/fun/isfinite.hpp
+++ b/stan/math/prim/fun/isfinite.hpp
@@ -17,7 +17,7 @@ namespace math {
  * @param[in] v argument
  * @return true if argument is finite
  */
-template <typename ADType, require_autodiff_t<ADType>...>
+template <typename ADType, require_autodiff_t<ADType>* = nullptr>
 inline bool isfinite(ADType&& v) {
   using std::isfinite;
   return isfinite(v.val());

--- a/stan/math/prim/fun/isnormal.hpp
+++ b/stan/math/prim/fun/isnormal.hpp
@@ -17,7 +17,7 @@ namespace math {
  * @param[in] v argument
  * @return true if argument is normal
  */
-template <typename ADType, require_autodiff_t<ADType>...>
+template <typename ADType, require_autodiff_t<ADType>* = nullptr>
 inline bool isnormal(ADType&& v) {
   using std::isnormal;
   return isnormal(v.val());

--- a/stan/math/prim/fun/log_softmax.hpp
+++ b/stan/math/prim/fun/log_softmax.hpp
@@ -40,7 +40,8 @@ namespace math {
  * Note: The return must be evaluated otherwise the Ref object falls out
  * of scope
  */
-template <typename Container, require_arithmetic_t<scalar_type_t<Container>>* = nullptr>
+template <typename Container,
+          require_arithmetic_t<scalar_type_t<Container>>* = nullptr>
 inline auto log_softmax(const Container& x) {
   return apply_vector_unary<Container>::apply(x, [](const auto& v) {
     const Eigen::Ref<const plain_type_t<decltype(v)>>& v_ref = v;

--- a/stan/math/prim/fun/log_softmax.hpp
+++ b/stan/math/prim/fun/log_softmax.hpp
@@ -40,7 +40,7 @@ namespace math {
  * Note: The return must be evaluated otherwise the Ref object falls out
  * of scope
  */
-template <typename Container, require_arithmetic_t<scalar_type_t<Container>>...>
+template <typename Container, require_arithmetic_t<scalar_type_t<Container>>* = nullptr>
 inline auto log_softmax(const Container& x) {
   return apply_vector_unary<Container>::apply(x, [](const auto& v) {
     const Eigen::Ref<const plain_type_t<decltype(v)>>& v_ref = v;

--- a/stan/math/prim/fun/log_sum_exp.hpp
+++ b/stan/math/prim/fun/log_sum_exp.hpp
@@ -76,7 +76,7 @@ inline return_type_t<T1, T2> log_sum_exp(const T2& a, const T1& b) {
  * @param[in] x matrix of specified values
  * @return The log of the sum of the exponentiated vector values.
  */
-template <typename T, require_container_st<std::is_arithmetic, T>...>
+template <typename T, require_container_st<std::is_arithmetic, T>* = nullptr>
 inline auto log_sum_exp(const T& x) {
   return apply_vector_unary<T>::reduce(x, [&](const auto& v) {
     if (v.size() == 0) {

--- a/stan/math/prim/fun/signbit.hpp
+++ b/stan/math/prim/fun/signbit.hpp
@@ -17,7 +17,7 @@ namespace math {
  * @param[in] v argument
  * @return `true` if the argument is negative
  */
-template <typename ADType, require_autodiff_t<ADType>...>
+template <typename ADType, require_autodiff_t<ADType>* = nullptr>
 inline bool signbit(ADType&& v) {
   using std::signbit;
   return signbit(v.val());

--- a/stan/math/prim/meta/apply_vector_unary.hpp
+++ b/stan/math/prim/meta/apply_vector_unary.hpp
@@ -46,13 +46,13 @@ struct apply_vector_unary<T, require_eigen_t<T>> {
    * @return Eigen object with result of applying functor to input
    */
   template <typename F, typename T2 = T,
-            require_t<is_eigen_matrix_base<plain_type_t<T2>>>...>
+            require_t<is_eigen_matrix_base<plain_type_t<T2>>>* = nullptr>
   static inline auto apply(const T& x, const F& f) {
     return f(x).matrix().eval();
   }
 
   template <typename F, typename T2 = T,
-            require_t<is_eigen_array<plain_type_t<T2>>>...>
+            require_t<is_eigen_array<plain_type_t<T2>>>* = nullptr>
   static inline auto apply(const T& x, const F& f) {
     return f(x).array().eval();
   }

--- a/stan/math/rev/core/matrix_vari.hpp
+++ b/stan/math/rev/core/matrix_vari.hpp
@@ -17,7 +17,7 @@ class op_matrix_vari : public vari {
   vari** vis_;
 
  public:
-  template <typename T, require_eigen_vt<is_var, T>...>
+  template <typename T, require_eigen_vt<is_var, T>* = nullptr>
   op_matrix_vari(double f, const T& vs) : vari(f), size_(vs.size()) {
     vis_ = ChainableStack::instance_->memalloc_.alloc_array<vari*>(size_);
     Eigen::Map<Eigen::Matrix<vari*, -1, -1>>(vis_, vs.rows(), vs.cols())

--- a/stan/math/rev/core/operator_addition.hpp
+++ b/stan/math/rev/core/operator_addition.hpp
@@ -94,7 +94,7 @@ inline var operator+(var a, var b) {
  * @param b Second scalar operand.
  * @return Result of adding variable and scalar.
  */
-template <typename Arith, require_arithmetic_t<Arith>...>
+template <typename Arith, require_arithmetic_t<Arith>* = nullptr>
 inline var operator+(var a, Arith b) {
   if (b == 0.0) {
     return a;
@@ -114,7 +114,7 @@ inline var operator+(var a, Arith b) {
  * @param b Second variable operand.
  * @return Result of adding variable and scalar.
  */
-template <typename Arith, require_arithmetic_t<Arith>...>
+template <typename Arith, require_arithmetic_t<Arith>* = nullptr>
 inline var operator+(Arith a, var b) {
   if (a == 0.0) {
     return b;

--- a/stan/math/rev/core/operator_divide_equal.hpp
+++ b/stan/math/rev/core/operator_divide_equal.hpp
@@ -12,7 +12,7 @@ inline var& var::operator/=(var b) {
   return *this;
 }
 
-template <typename Arith, require_arithmetic_t<Arith>...>
+template <typename Arith, require_arithmetic_t<Arith>* = nullptr>
 inline var& var::operator/=(Arith b) {
   if (b == 1.0) {
     return *this;

--- a/stan/math/rev/core/operator_divide_equal.hpp
+++ b/stan/math/rev/core/operator_divide_equal.hpp
@@ -12,7 +12,7 @@ inline var& var::operator/=(var b) {
   return *this;
 }
 
-template <typename Arith, require_arithmetic_t<Arith>* = nullptr>
+template <typename Arith, require_arithmetic_t<Arith>*>
 inline var& var::operator/=(Arith b) {
   if (b == 1.0) {
     return *this;

--- a/stan/math/rev/core/operator_division.hpp
+++ b/stan/math/rev/core/operator_division.hpp
@@ -115,7 +115,7 @@ inline var operator/(var dividend, var divisor) {
  * @param divisor Scalar operand.
  * @return Variable result of dividing the variable by the scalar.
  */
-template <typename Arith, require_arithmetic_t<Arith>...>
+template <typename Arith, require_arithmetic_t<Arith>* = nullptr>
 inline var operator/(var dividend, Arith divisor) {
   if (divisor == 1.0) {
     return dividend;
@@ -135,7 +135,7 @@ inline var operator/(var dividend, Arith divisor) {
  * @param divisor Variable operand.
  * @return Quotient of the dividend and divisor.
  */
-template <typename Arith, require_arithmetic_t<Arith>...>
+template <typename Arith, require_arithmetic_t<Arith>* = nullptr>
 inline var operator/(Arith dividend, var divisor) {
   return {new internal::divide_dv_vari(dividend, divisor.vi_)};
 }

--- a/stan/math/rev/core/operator_equal.hpp
+++ b/stan/math/rev/core/operator_equal.hpp
@@ -36,7 +36,7 @@ inline bool operator==(var a, var b) { return a.val() == b.val(); }
  * @return True if the first variable's value is the same as the
  * second value.
  */
-template <typename Arith, require_arithmetic_t<Arith>...>
+template <typename Arith, require_arithmetic_t<Arith>* = nullptr>
 inline bool operator==(var a, Arith b) {
   return a.val() == b;
 }
@@ -50,7 +50,7 @@ inline bool operator==(var a, Arith b) {
  * @param b Second variable.
  * @return True if the variable's value is equal to the scalar.
  */
-template <typename Arith, require_arithmetic_t<Arith>...>
+template <typename Arith, require_arithmetic_t<Arith>* = nullptr>
 inline bool operator==(Arith a, var b) {
   return a == b.val();
 }

--- a/stan/math/rev/core/operator_greater_than.hpp
+++ b/stan/math/rev/core/operator_greater_than.hpp
@@ -34,7 +34,7 @@ inline bool operator>(var a, var b) { return a.val() > b.val(); }
  * @param b Second value.
  * @return True if first variable's value is greater than second value.
  */
-template <typename Arith, require_arithmetic_t<Arith>...>
+template <typename Arith, require_arithmetic_t<Arith>* = nullptr>
 inline bool operator>(var a, Arith b) {
   return a.val() > b;
 }
@@ -48,7 +48,7 @@ inline bool operator>(var a, Arith b) {
  * @param b Second variable.
  * @return True if first value is greater than second variable's value.
  */
-template <typename Arith, require_arithmetic_t<Arith>...>
+template <typename Arith, require_arithmetic_t<Arith>* = nullptr>
 inline bool operator>(Arith a, var b) {
   return a > b.val();
 }

--- a/stan/math/rev/core/operator_greater_than_or_equal.hpp
+++ b/stan/math/rev/core/operator_greater_than_or_equal.hpp
@@ -37,7 +37,7 @@ inline bool operator>=(var a, var b) { return a.val() >= b.val(); }
  * @return True if first variable's value is greater than or equal
  * to second value.
  */
-template <typename Arith, require_arithmetic_t<Arith>...>
+template <typename Arith, require_arithmetic_t<Arith>* = nullptr>
 inline bool operator>=(var a, Arith b) {
   return a.val() >= b;
 }
@@ -52,7 +52,7 @@ inline bool operator>=(var a, Arith b) {
  * @return True if the first value is greater than or equal to the
  * second variable's value.
  */
-template <typename Arith, typename Var, require_arithmetic_t<Arith>...>
+template <typename Arith, typename Var, require_arithmetic_t<Arith>* = nullptr>
 inline bool operator>=(Arith a, var b) {
   return a >= b.val();
 }

--- a/stan/math/rev/core/operator_less_than.hpp
+++ b/stan/math/rev/core/operator_less_than.hpp
@@ -33,7 +33,7 @@ inline bool operator<(var a, var b) { return a.val() < b.val(); }
  * @param b Second value.
  * @return True if first variable's value is less than second value.
  */
-template <typename Arith, require_arithmetic_t<Arith>...>
+template <typename Arith, require_arithmetic_t<Arith>* = nullptr>
 inline bool operator<(var a, Arith b) {
   return a.val() < b;
 }
@@ -47,7 +47,7 @@ inline bool operator<(var a, Arith b) {
  * @param b Second variable.
  * @return True if first value is less than second variable's value.
  */
-template <typename Arith, require_arithmetic_t<Arith>...>
+template <typename Arith, require_arithmetic_t<Arith>* = nullptr>
 inline bool operator<(Arith a, var b) {
   return a < b.val();
 }

--- a/stan/math/rev/core/operator_less_than_or_equal.hpp
+++ b/stan/math/rev/core/operator_less_than_or_equal.hpp
@@ -36,7 +36,7 @@ inline bool operator<=(var a, var b) { return a.val() <= b.val(); }
  * @return True if first variable's value is less than or equal to
  * the second value.
  */
-template <typename Arith, require_arithmetic_t<Arith>...>
+template <typename Arith, require_arithmetic_t<Arith>* = nullptr>
 inline bool operator<=(var a, Arith b) {
   return a.val() <= b;
 }
@@ -51,7 +51,7 @@ inline bool operator<=(var a, Arith b) {
  * @return True if first value is less than or equal to the second
  * variable's value.
  */
-template <typename Arith, require_arithmetic_t<Arith>...>
+template <typename Arith, require_arithmetic_t<Arith>* = nullptr>
 inline bool operator<=(Arith a, var b) {
   return a <= b.val();
 }

--- a/stan/math/rev/core/operator_logical_and.hpp
+++ b/stan/math/rev/core/operator_logical_and.hpp
@@ -28,7 +28,7 @@ inline bool operator&&(var x, var y) { return x.val() && y.val(); }
  * @return conjunction of first argument's value and second
  * argument
  */
-template <typename Arith, require_arithmetic_t<Arith>...>
+template <typename Arith, require_arithmetic_t<Arith>* = nullptr>
 inline bool operator&&(var x, Arith y) {
   return x.val() && y;
 }
@@ -44,7 +44,7 @@ inline bool operator&&(var x, Arith y) {
  * @return conjunction of first argument and second argument's
  * value
  */
-template <typename Arith, require_arithmetic_t<Arith>...>
+template <typename Arith, require_arithmetic_t<Arith>* = nullptr>
 inline bool operator&&(Arith x, var y) {
   return x && y.val();
 }

--- a/stan/math/rev/core/operator_logical_or.hpp
+++ b/stan/math/rev/core/operator_logical_or.hpp
@@ -27,7 +27,7 @@ inline bool operator||(var x, var y) { return x.val() || y.val(); }
  * @return disjunction of first argument's value and second
  * argument
  */
-template <typename Arith, require_arithmetic_t<Arith>...>
+template <typename Arith, require_arithmetic_t<Arith>* = nullptr>
 inline bool operator||(var x, Arith y) {
   return x.val() || y;
 }
@@ -42,7 +42,7 @@ inline bool operator||(var x, Arith y) {
  * @return disjunction of first argument and the second
  * argument's value
  */
-template <typename Arith, require_arithmetic_t<Arith>...>
+template <typename Arith, require_arithmetic_t<Arith>* = nullptr>
 inline bool operator||(Arith x, var y) {
   return x || y.val();
 }

--- a/stan/math/rev/core/operator_minus_equal.hpp
+++ b/stan/math/rev/core/operator_minus_equal.hpp
@@ -13,7 +13,7 @@ inline var& var::operator-=(var b) {
   return *this;
 }
 
-template <typename Arith, require_arithmetic_t<Arith>...>
+template <typename Arith, require_arithmetic_t<Arith>* = nullptr>
 inline var& var::operator-=(Arith b) {
   if (b == 0.0) {
     return *this;

--- a/stan/math/rev/core/operator_minus_equal.hpp
+++ b/stan/math/rev/core/operator_minus_equal.hpp
@@ -13,7 +13,7 @@ inline var& var::operator-=(var b) {
   return *this;
 }
 
-template <typename Arith, require_arithmetic_t<Arith>* = nullptr>
+template <typename Arith, require_arithmetic_t<Arith>*>
 inline var& var::operator-=(Arith b) {
   if (b == 0.0) {
     return *this;

--- a/stan/math/rev/core/operator_multiplication.hpp
+++ b/stan/math/rev/core/operator_multiplication.hpp
@@ -95,7 +95,7 @@ inline var operator*(var a, var b) {
  * @param b Scalar operand.
  * @return Variable result of multiplying operands.
  */
-template <typename Arith, require_arithmetic_t<Arith>...>
+template <typename Arith, require_arithmetic_t<Arith>* = nullptr>
 inline var operator*(var a, Arith b) {
   if (b == 1.0) {
     return a;
@@ -115,7 +115,7 @@ inline var operator*(var a, Arith b) {
  * @param b Variable operand.
  * @return Variable result of multiplying the operands.
  */
-template <typename Arith, require_arithmetic_t<Arith>...>
+template <typename Arith, require_arithmetic_t<Arith>* = nullptr>
 inline var operator*(Arith a, var b) {
   if (a == 1.0) {
     return b;

--- a/stan/math/rev/core/operator_multiply_equal.hpp
+++ b/stan/math/rev/core/operator_multiply_equal.hpp
@@ -13,7 +13,7 @@ inline var& var::operator*=(var b) {
   return *this;
 }
 
-template <typename Arith, require_arithmetic_t<Arith>...>
+template <typename Arith, require_arithmetic_t<Arith>* = nullptr>
 inline var& var::operator*=(Arith b) {
   if (b == 1.0) {
     return *this;

--- a/stan/math/rev/core/operator_multiply_equal.hpp
+++ b/stan/math/rev/core/operator_multiply_equal.hpp
@@ -13,7 +13,7 @@ inline var& var::operator*=(var b) {
   return *this;
 }
 
-template <typename Arith, require_arithmetic_t<Arith>* = nullptr>
+template <typename Arith, require_arithmetic_t<Arith>*>
 inline var& var::operator*=(Arith b) {
   if (b == 1.0) {
     return *this;

--- a/stan/math/rev/core/operator_not_equal.hpp
+++ b/stan/math/rev/core/operator_not_equal.hpp
@@ -39,7 +39,7 @@ inline bool operator!=(var a, var b) { return a.val() != b.val(); }
  * @return True if the first variable's value is not the same as the
  * second value.
  */
-template <typename Arith, require_arithmetic_t<Arith>...>
+template <typename Arith, require_arithmetic_t<Arith>* = nullptr>
 inline bool operator!=(var a, Arith b) {
   return a.val() != b;
 }
@@ -54,7 +54,7 @@ inline bool operator!=(var a, Arith b) {
  * @return True if the first value is not the same as the
  * second variable's value.
  */
-template <typename Arith, require_arithmetic_t<Arith>...>
+template <typename Arith, require_arithmetic_t<Arith>* = nullptr>
 inline bool operator!=(Arith a, var b) {
   return a != b.val();
 }

--- a/stan/math/rev/core/operator_plus_equal.hpp
+++ b/stan/math/rev/core/operator_plus_equal.hpp
@@ -13,7 +13,7 @@ inline var& var::operator+=(var b) {
   return *this;
 }
 
-template <typename Arith, require_arithmetic_t<Arith>...>
+template <typename Arith, require_arithmetic_t<Arith>* = nullptr>
 inline var& var::operator+=(Arith b) {
   if (b == 0.0) {
     return *this;

--- a/stan/math/rev/core/operator_plus_equal.hpp
+++ b/stan/math/rev/core/operator_plus_equal.hpp
@@ -13,7 +13,7 @@ inline var& var::operator+=(var b) {
   return *this;
 }
 
-template <typename Arith, require_arithmetic_t<Arith>* = nullptr>
+template <typename Arith, require_arithmetic_t<Arith>*>
 inline var& var::operator+=(Arith b) {
   if (b == 0.0) {
     return *this;

--- a/stan/math/rev/core/operator_subtraction.hpp
+++ b/stan/math/rev/core/operator_subtraction.hpp
@@ -110,7 +110,7 @@ inline var operator-(var a, var b) {
  * @param b Second scalar operand.
  * @return Result of subtracting the scalar from the variable.
  */
-template <typename Arith, require_arithmetic_t<Arith>...>
+template <typename Arith, require_arithmetic_t<Arith>* = nullptr>
 inline var operator-(var a, Arith b) {
   if (b == 0.0) {
     return a;
@@ -131,7 +131,7 @@ inline var operator-(var a, Arith b) {
  * @param b Second variable operand.
  * @return Result of subtracting a variable from a scalar.
  */
-template <typename Arith, require_arithmetic_t<Arith>...>
+template <typename Arith, require_arithmetic_t<Arith>* = nullptr>
 inline var operator-(Arith a, var b) {
   return {new internal::subtract_dv_vari(a, b.vi_)};
 }

--- a/stan/math/rev/core/var.hpp
+++ b/stan/math/rev/core/var.hpp
@@ -323,7 +323,7 @@ class var {
    * @param b The scalar to add to this variable.
    * @return The result of adding the specified variable to this variable.
    */
-  template <typename Arith, require_arithmetic_t<Arith>...>
+  template <typename Arith, require_arithmetic_t<Arith>* = nullptr>
   inline var& operator+=(Arith b);
 
   /**
@@ -350,7 +350,7 @@ class var {
    * @return The result of subtracting the specified variable from this
    * variable.
    */
-  template <typename Arith, require_arithmetic_t<Arith>...>
+  template <typename Arith, require_arithmetic_t<Arith>* = nullptr>
   inline var& operator-=(Arith b);
 
   /**
@@ -377,7 +377,7 @@ class var {
    * @return The result of multiplying this variable by the specified
    * variable.
    */
-  template <typename Arith, require_arithmetic_t<Arith>...>
+  template <typename Arith, require_arithmetic_t<Arith>* = nullptr>
   inline var& operator*=(Arith b);
 
   /**
@@ -403,7 +403,7 @@ class var {
    * @return The result of dividing this variable by the specified
    * variable.
    */
-  template <typename Arith, require_arithmetic_t<Arith>...>
+  template <typename Arith, require_arithmetic_t<Arith>* = nullptr>
   inline var& operator/=(Arith b);
 
   /**

--- a/stan/math/rev/core/vector_vari.hpp
+++ b/stan/math/rev/core/vector_vari.hpp
@@ -15,7 +15,8 @@ class op_vector_vari : public vari {
   vari** vis_;
 
  public:
-  template <typename Arith, typename VecVar, require_arithmetic_t<Arith>* = nullptr,
+  template <typename Arith, typename VecVar,
+            require_arithmetic_t<Arith>* = nullptr,
             require_vector_like_vt<is_var, VecVar>* = nullptr>
   op_vector_vari(Arith f, VecVar&& vs) : vari(f), size_(vs.size()) {
     vis_ = reinterpret_cast<vari**>(operator new(sizeof(vari*) * vs.size()));

--- a/stan/math/rev/core/vector_vari.hpp
+++ b/stan/math/rev/core/vector_vari.hpp
@@ -15,8 +15,8 @@ class op_vector_vari : public vari {
   vari** vis_;
 
  public:
-  template <typename Arith, typename VecVar, require_arithmetic_t<Arith>...,
-            require_vector_like_vt<is_var, VecVar>...>
+  template <typename Arith, typename VecVar, require_arithmetic_t<Arith>* = nullptr,
+            require_vector_like_vt<is_var, VecVar>* = nullptr>
   op_vector_vari(Arith f, VecVar&& vs) : vari(f), size_(vs.size()) {
     vis_ = reinterpret_cast<vari**>(operator new(sizeof(vari*) * vs.size()));
     for (size_t i = 0; i < vs.size(); ++i) {


### PR DESCRIPTION

## Summary

Closes #1941 . Not sure if it's a compiler bug or UB but the clang-7 version on the darwin mac doesn't seem to accept the `requires` with `...` afterwards. This just removes all of those

## Tests

No new tests

## Side Effects


## Release notes

Bugfix for require style templates

## Checklist

- [x] Math issue #1941

- [x] Copyright holder: Steve Bronder

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
