### PR TITLE
simplify GLM code

### DIFF
--- a/stan/math/opencl/prim/categorical_logit_glm_lpmf.hpp
+++ b/stan/math/opencl/prim/categorical_logit_glm_lpmf.hpp
@@ -118,8 +118,8 @@ return_type_t<T_alpha, T_beta> categorical_logit_glm_lpmf(
                  from_matrix_cl(x_cl));
   }
 
-  operands_and_partials<T_alpha_ref, T_beta_ref> ops_partials(
-      alpha_ref, beta_ref);
+  operands_and_partials<T_alpha_ref, T_beta_ref> ops_partials(alpha_ref,
+                                                              beta_ref);
   if (!is_constant_all<T_alpha>::value) {
     ops_partials.edge1_.partials_
         = from_matrix_cl(alpha_derivative_cl).colwise().sum();

--- a/stan/math/opencl/prim/categorical_logit_glm_lpmf.hpp
+++ b/stan/math/opencl/prim/categorical_logit_glm_lpmf.hpp
@@ -45,8 +45,8 @@ return_type_t<T_alpha, T_beta> categorical_logit_glm_lpmf(
     const matrix_cl<int>& y_cl, const matrix_cl<double>& x_cl,
     const T_alpha& alpha, const T_beta& beta) {
   using T_partials_return = partials_return_t<T_alpha, T_beta>;
-  static const char* function = "categorical_logit_glm_lpmf";
-
+  using T_alpha_ref = ref_type_if_t<!is_constant<T_alpha>::value, T_alpha>;
+  using T_beta_ref = ref_type_if_t<!is_constant<T_beta>::value, T_beta>;
   using Eigen::Array;
   using Eigen::Dynamic;
   using Eigen::Matrix;
@@ -55,6 +55,7 @@ return_type_t<T_alpha, T_beta> categorical_logit_glm_lpmf(
   const size_t N_attributes = x_cl.cols();
   const size_t N_classes = beta.cols();
 
+  static const char* function = "categorical_logit_glm_lpmf";
   if (y_cl.size() != 1) {
     check_size_match(function, "x.rows()", N_instances, "y.size()",
                      y_cl.size());
@@ -66,13 +67,12 @@ return_type_t<T_alpha, T_beta> categorical_logit_glm_lpmf(
   if (N_instances == 0 || N_classes <= 1) {
     return 0;
   }
-
   if (!include_summand<propto, T_alpha, T_beta>::value) {
     return 0;
   }
 
-  const auto& alpha_ref = to_ref_if<!is_constant<T_alpha>::value>(alpha);
-  const auto& beta_ref = to_ref_if<!is_constant<T_beta>::value>(beta);
+  T_alpha_ref alpha_ref = alpha;
+  T_beta_ref beta_ref = beta;
 
   const auto& alpha_val = value_of_rec(alpha_ref);
   const auto& beta_val = value_of_rec(beta_ref);
@@ -118,7 +118,7 @@ return_type_t<T_alpha, T_beta> categorical_logit_glm_lpmf(
                  from_matrix_cl(x_cl));
   }
 
-  operands_and_partials<decltype(alpha_ref), decltype(beta_ref)> ops_partials(
+  operands_and_partials<T_alpha_ref, T_beta_ref> ops_partials(
       alpha_ref, beta_ref);
   if (!is_constant_all<T_alpha>::value) {
     ops_partials.edge1_.partials_

--- a/stan/math/opencl/prim/neg_binomial_2_log_glm_lpmf.hpp
+++ b/stan/math/opencl/prim/neg_binomial_2_log_glm_lpmf.hpp
@@ -61,7 +61,8 @@ return_type_t<T_alpha, T_beta, T_precision> neg_binomial_2_log_glm_lpmf(
   using T_partials_return = partials_return_t<T_alpha, T_beta, T_precision>;
   using T_alpha_ref = ref_type_if_t<!is_constant<T_alpha>::value, T_alpha>;
   using T_beta_ref = ref_type_if_t<!is_constant<T_beta>::value, T_beta>;
-  using T_phi_ref = ref_type_if_t<!is_constant<T_precision>::value, T_precision>;
+  using T_phi_ref
+      = ref_type_if_t<!is_constant<T_precision>::value, T_precision>;
   using Eigen::Array;
   using Eigen::Dynamic;
   using Eigen::Matrix;

--- a/stan/math/opencl/prim/neg_binomial_2_log_glm_lpmf.hpp
+++ b/stan/math/opencl/prim/neg_binomial_2_log_glm_lpmf.hpp
@@ -61,7 +61,7 @@ return_type_t<T_alpha, T_beta, T_precision> neg_binomial_2_log_glm_lpmf(
   using T_partials_return = partials_return_t<T_alpha, T_beta, T_precision>;
   using T_alpha_ref = ref_type_if_t<!is_constant<T_alpha>::value, T_alpha>;
   using T_beta_ref = ref_type_if_t<!is_constant<T_beta>::value, T_beta>;
-  using T_phi_ref = ref_type_t<!is_constant<T_precision>::value, T_precision>;
+  using T_phi_ref = ref_type_if_t<!is_constant<T_precision>::value, T_precision>;
   using Eigen::Array;
   using Eigen::Dynamic;
   using Eigen::Matrix;

--- a/stan/math/opencl/prim/neg_binomial_2_log_glm_lpmf.hpp
+++ b/stan/math/opencl/prim/neg_binomial_2_log_glm_lpmf.hpp
@@ -90,7 +90,8 @@ return_type_t<T_alpha, T_beta, T_precision> neg_binomial_2_log_glm_lpmf(
   }
   T_phi_ref phi_ref = phi;
   const auto& phi_val = value_of_rec(phi_ref);
-  const auto& phi_val_vec = to_ref_for_opencl(as_column_vector_or_scalar(phi_val));
+  const auto& phi_val_vec
+      = to_ref_for_opencl(as_column_vector_or_scalar(phi_val));
   check_positive_finite(function, "Precision parameter", phi_val_vec);
 
   if (!include_summand<propto, T_alpha, T_beta, T_precision>::value) {
@@ -168,8 +169,8 @@ return_type_t<T_alpha, T_beta, T_precision> neg_binomial_2_log_glm_lpmf(
                - lgamma(forward_as<double>(phi_val)));
   }
 
-  operands_and_partials<T_alpha_ref, T_beta_ref, T_phi_ref> ops_partials(alpha, beta,
-                                                                   phi);
+  operands_and_partials<T_alpha_ref, T_beta_ref, T_phi_ref> ops_partials(
+      alpha, beta, phi);
   // Compute the necessary derivatives.
   if (!is_constant_all<T_alpha>::value) {
     if (is_vector<T_alpha>::value) {

--- a/stan/math/opencl/prim/neg_binomial_2_log_glm_lpmf.hpp
+++ b/stan/math/opencl/prim/neg_binomial_2_log_glm_lpmf.hpp
@@ -59,7 +59,9 @@ return_type_t<T_alpha, T_beta, T_precision> neg_binomial_2_log_glm_lpmf(
     const T_alpha& alpha, const T_beta& beta, const T_precision& phi) {
   static const char* function = "neg_binomial_2_log_glm_lpmf(OpenCL)";
   using T_partials_return = partials_return_t<T_alpha, T_beta, T_precision>;
-
+  using T_alpha_ref = ref_type_if_t<!is_constant<T_alpha>::value, T_alpha>;
+  using T_beta_ref = ref_type_if_t<!is_constant<T_beta>::value, T_beta>;
+  using T_phi_ref = ref_type_t<!is_constant<T_precision>::value, T_precision>;
   using Eigen::Array;
   using Eigen::Dynamic;
   using Eigen::Matrix;
@@ -83,26 +85,26 @@ return_type_t<T_alpha, T_beta, T_precision> neg_binomial_2_log_glm_lpmf(
     check_size_match(function, "Rows of ", "x_cl", N, "size of ", "alpha",
                      stan::math::size(alpha));
   }
-  const auto& phi_ref = to_ref(phi);
-  check_positive_finite(function, "Precision parameter", phi_ref);
-
   if (N == 0) {
     return 0;
   }
+  T_phi_ref phi_ref = phi;
+  const auto& phi_val = value_of_rec(phi_ref);
+  const auto& phi_val_vec = to_ref_for_opencl(as_column_vector_or_scalar(phi_val));
+  check_positive_finite(function, "Precision parameter", phi_val_vec);
+
   if (!include_summand<propto, T_alpha, T_beta, T_precision>::value) {
     return 0;
   }
 
-  const auto& alpha_ref = to_ref_if<!is_constant<T_alpha>::value>(alpha);
-  const auto& beta_ref = to_ref_if<!is_constant<T_beta>::value>(beta);
+  T_alpha_ref alpha_ref = alpha;
+  T_beta_ref beta_ref = beta;
 
   const auto& beta_val = value_of_rec(beta_ref);
   const auto& alpha_val = value_of_rec(alpha_ref);
-  const auto& phi_val = value_of_rec(phi_ref);
 
   const auto& beta_val_vec = as_column_vector_or_scalar(beta_val);
   const auto& alpha_val_vec = as_column_vector_or_scalar(alpha_val);
-  const auto& phi_val_vec = as_column_vector_or_scalar(phi_val);
 
   const int local_size
       = opencl_kernels::neg_binomial_2_log_glm.get_option("LOCAL_SIZE_");
@@ -166,7 +168,7 @@ return_type_t<T_alpha, T_beta, T_precision> neg_binomial_2_log_glm_lpmf(
                - lgamma(forward_as<double>(phi_val)));
   }
 
-  operands_and_partials<T_alpha, T_beta, T_precision> ops_partials(alpha, beta,
+  operands_and_partials<T_alpha_ref, T_beta_ref, T_phi_ref> ops_partials(alpha, beta,
                                                                    phi);
   // Compute the necessary derivatives.
   if (!is_constant_all<T_alpha>::value) {

--- a/stan/math/opencl/prim/ordered_logistic_glm_lpmf.hpp
+++ b/stan/math/opencl/prim/ordered_logistic_glm_lpmf.hpp
@@ -123,8 +123,8 @@ return_type_t<T_beta, T_cuts> ordered_logistic_glm_lpmf(
                  from_matrix_cl(x_cl));
   }
 
-  operands_and_partials<T_beta_ref, T_cuts_ref> ops_partials(
-      beta_ref, cuts_ref);
+  operands_and_partials<T_beta_ref, T_cuts_ref> ops_partials(beta_ref,
+                                                             cuts_ref);
   if (!is_constant_all<T_beta>::value) {
     ops_partials.edge1_.partials_
         = from_matrix_cl<1, Dynamic>(location_derivative_cl * x_cl);

--- a/stan/math/opencl/prim/ordered_logistic_glm_lpmf.hpp
+++ b/stan/math/opencl/prim/ordered_logistic_glm_lpmf.hpp
@@ -53,6 +53,8 @@ return_type_t<T_beta, T_cuts> ordered_logistic_glm_lpmf(
   using Eigen::VectorXd;
   using std::isfinite;
   using T_partials_return = partials_return_t<T_beta, T_cuts>;
+  using T_beta_ref = ref_type_if_t<!is_constant<T_beta>::value, T_beta>;
+  using T_cuts_ref = ref_type_if_t<!is_constant<T_cuts>::value, T_cuts>;
 
   static const char* function = "ordered_logistic_glm_lpmf";
 
@@ -65,13 +67,14 @@ return_type_t<T_beta, T_cuts> ordered_logistic_glm_lpmf(
                      "y_cl", y_cl.size());
   }
   check_consistent_size(function, "Weight vector", beta, N_attributes);
-  const auto& cuts_ref = to_ref(cuts);
-  check_ordered(function, "Cut-points", cuts_ref);
+  T_cuts_ref cuts_ref = cuts;
+  const auto& cuts_val = to_ref_for_opencl(value_of_rec(cuts_ref));
+  check_ordered(function, "Cut-points", cuts_val);
   if (N_classes > 1) {
     if (N_classes > 2) {
-      check_finite(function, "Final cut-point", cuts_ref[N_classes - 2]);
+      check_finite(function, "Final cut-point", cuts_val[N_classes - 2]);
     }
-    check_finite(function, "First cut-point", cuts_ref[0]);
+    check_finite(function, "First cut-point", cuts_val[0]);
   }
 
   if (N_instances == 0 || N_classes == 1) {
@@ -81,13 +84,9 @@ return_type_t<T_beta, T_cuts> ordered_logistic_glm_lpmf(
     return 0;
   }
 
-  const auto& beta_ref = to_ref_if<!is_constant<T_beta>::value>(beta);
-
+  T_beta_ref beta_ref = beta;
   const auto& beta_val = value_of_rec(beta_ref);
-  const auto& cuts_val = value_of_rec(cuts_ref);
 
-  operands_and_partials<decltype(beta_ref), decltype(cuts_ref)> ops_partials(
-      beta_ref, cuts_ref);
   const int local_size
       = opencl_kernels::ordered_logistic_glm.get_option("LOCAL_SIZE_");
   const int wgs = (N_instances + local_size - 1) / local_size;
@@ -124,6 +123,8 @@ return_type_t<T_beta, T_cuts> ordered_logistic_glm_lpmf(
                  from_matrix_cl(x_cl));
   }
 
+  operands_and_partials<T_beta_ref, T_cuts_ref> ops_partials(
+      beta_ref, cuts_ref);
   if (!is_constant_all<T_beta>::value) {
     ops_partials.edge1_.partials_
         = from_matrix_cl<1, Dynamic>(location_derivative_cl * x_cl);

--- a/stan/math/opencl/prim/poisson_log_glm_lpmf.hpp
+++ b/stan/math/opencl/prim/poisson_log_glm_lpmf.hpp
@@ -47,7 +47,8 @@ return_type_t<T_alpha, T_beta> poisson_log_glm_lpmf(
     const T_alpha& alpha, const T_beta& beta) {
   static const char* function = "poisson_log_glm_lpmf(OpenCL)";
   using T_partials_return = partials_return_t<T_alpha, T_beta>;
-
+  using T_alpha_ref = ref_type_if_t<!is_constant<T_alpha>::value, T_alpha>;
+  using T_beta_ref = ref_type_if_t<!is_constant<T_beta>::value, T_beta>;
   using Eigen::Dynamic;
   using Eigen::Matrix;
   using std::exp;
@@ -76,8 +77,8 @@ return_type_t<T_alpha, T_beta> poisson_log_glm_lpmf(
 
   T_partials_return logp(0);
 
-  const auto& alpha_ref = to_ref_if<!is_constant<T_alpha>::value>(alpha);
-  const auto& beta_ref = to_ref_if<!is_constant<T_beta>::value>(beta);
+  T_alpha_ref alpha_ref = alpha;
+  T_beta_ref beta_ref = beta;
 
   const auto& alpha_val = value_of_rec(alpha_ref);
   const auto& beta_val = value_of_rec(beta_ref);
@@ -121,8 +122,8 @@ return_type_t<T_alpha, T_beta> poisson_log_glm_lpmf(
                  from_matrix_cl(x_cl));
   }
 
-  operands_and_partials<decltype(alpha_ref), decltype(beta_ref)> ops_partials(
-      alpha_ref, beta_ref);
+  operands_and_partials<T_alpha_ref, T_beta_ref> ops_partials(alpha_ref,
+                                                              beta_ref);
   // Compute the necessary derivatives.
   if (!is_constant_all<T_alpha>::value) {
     if (is_vector<T_alpha>::value)

--- a/stan/math/prim/prob/bernoulli_logit_glm_lpmf.hpp
+++ b/stan/math/prim/prob/bernoulli_logit_glm_lpmf.hpp
@@ -60,6 +60,9 @@ return_type_t<T_x, T_alpha, T_beta> bernoulli_logit_glm_lpmf(
   using T_ytheta_tmp =
       typename std::conditional_t<T_x_rows == 1, T_partials_return,
                                   Array<T_partials_return, Dynamic, 1>>;
+  using T_x_ref = ref_type_if_t<!is_constant<T_x>::value, T_x>;
+  using T_alpha_ref = ref_type_if_t<!is_constant<T_alpha>::value, T_alpha>;
+  using T_beta_ref = ref_type_if_t<!is_constant<T_beta>::value, T_beta>;
 
   const size_t N_instances = T_x_rows == 1 ? stan::math::size(y) : x.rows();
   const size_t N_attributes = x.cols();
@@ -69,22 +72,20 @@ return_type_t<T_x, T_alpha, T_beta> bernoulli_logit_glm_lpmf(
                         N_instances);
   check_consistent_size(function, "Weight vector", beta, N_attributes);
   check_consistent_size(function, "Vector of intercepts", alpha, N_instances);
-  const auto& y_ref = to_ref(y);
-  check_bounded(function, "Vector of dependent variables", y_ref, 0, 1);
-
   if (size_zero(y)) {
     return 0;
   }
+
+  const auto& y_ref = to_ref(y);
+  check_bounded(function, "Vector of dependent variables", y_ref, 0, 1);
 
   if (!include_summand<propto, T_x, T_alpha, T_beta>::value) {
     return 0;
   }
 
-  T_partials_return logp(0);
-
-  const auto& x_ref = to_ref_if<!is_constant<T_x>::value>(x);
-  const auto& alpha_ref = to_ref_if<!is_constant<T_alpha>::value>(alpha);
-  const auto& beta_ref = to_ref_if<!is_constant<T_beta>::value>(beta);
+  T_x_ref x_ref = x;
+  T_alpha_ref alpha_ref = alpha;
+  T_beta_ref beta_ref = beta;
 
   const auto& y_val = value_of_rec(y_ref);
   const auto& x_val
@@ -115,7 +116,7 @@ return_type_t<T_x, T_alpha, T_beta> bernoulli_logit_glm_lpmf(
   // And compute the derivatives wrt theta.
   static const double cutoff = 20.0;
   Eigen::Array<T_partials_return, Dynamic, 1> exp_m_ytheta = exp(-ytheta);
-  logp += sum(
+  T_partials_return logp = sum(
       (ytheta > cutoff)
           .select(-exp_m_ytheta,
                   (ytheta < -cutoff).select(ytheta, -log1p(exp_m_ytheta))));
@@ -126,9 +127,8 @@ return_type_t<T_x, T_alpha, T_beta> bernoulli_logit_glm_lpmf(
     check_finite(function, "Matrix of independent variables", ytheta);
   }
 
-  operands_and_partials<decltype(x_ref), decltype(alpha_ref),
-                        decltype(beta_ref)>
-      ops_partials(x_ref, alpha_ref, beta_ref);
+  operands_and_partials<T_x_ref, T_alpha_ref, T_beta_ref> ops_partials(
+      x_ref, alpha_ref, beta_ref);
   // Compute the necessary derivatives.
   if (!is_constant_all<T_beta, T_x, T_alpha>::value) {
     Matrix<T_partials_return, Dynamic, 1> theta_derivative

--- a/stan/math/prim/prob/categorical_logit_glm_lpmf.hpp
+++ b/stan/math/prim/prob/categorical_logit_glm_lpmf.hpp
@@ -47,6 +47,10 @@ return_type_t<T_x, T_alpha, T_beta> categorical_logit_glm_lpmf(
   using Eigen::Matrix;
   using std::exp;
   using std::log;
+  using T_y_ref = ref_type_t<T_y>;
+  using T_x_ref = ref_type_if_t<!is_constant<T_x>::value, T_x>;
+  using T_alpha_ref = ref_type_if_t<!is_constant<T_alpha>::value, T_alpha>;
+  using T_beta_ref = ref_type_if_t<!is_constant<T_beta>::value, T_beta>;
   constexpr int T_x_rows = T_x::RowsAtCompileTime;
 
   const size_t N_instances = T_x_rows == 1 ? stan::math::size(y) : x.rows();
@@ -59,20 +63,20 @@ return_type_t<T_x, T_alpha, T_beta> categorical_logit_glm_lpmf(
   check_consistent_size(function, "Intercept vector", alpha, N_classes);
   check_size_match(function, "x.cols()", N_attributes, "beta.rows()",
                    beta.rows());
-  const auto& y_ref = to_ref(y);
-  check_bounded(function, "categorical outcome out of support", y_ref, 1,
-                N_classes);
-
   if (size_zero(y) || N_classes == 1) {
     return 0;
   }
+  T_y_ref y_ref = y;
+  check_bounded(function, "categorical outcome out of support", y_ref, 1,
+                N_classes);
+
   if (!include_summand<propto, T_x, T_alpha, T_beta>::value) {
     return 0;
   }
 
-  const auto& x_ref = to_ref_if<!is_constant<T_x>::value>(x);
-  const auto& alpha_ref = to_ref_if<!is_constant<T_alpha>::value>(alpha);
-  const auto& beta_ref = to_ref_if<!is_constant<T_beta>::value>(beta);
+  T_x_ref x_ref = x;
+  T_alpha_ref alpha_ref = alpha;
+  T_beta_ref beta_ref = beta;
 
   const auto& x_val
       = to_ref_if<!is_constant<T_beta>::value>(value_of_rec(x_ref));
@@ -97,7 +101,7 @@ return_type_t<T_x, T_alpha, T_beta> categorical_logit_glm_lpmf(
   if (T_x_rows == 1) {
     logp *= N_instances;
   }
-  scalar_seq_view<T_y> y_seq(y_ref);
+  scalar_seq_view<T_y_ref> y_seq(y_ref);
   for (int i = 0; i < N_instances; i++) {
     if (T_x_rows == 1) {
       logp += lin(0, y_seq[i] - 1);
@@ -116,9 +120,8 @@ return_type_t<T_x, T_alpha, T_beta> categorical_logit_glm_lpmf(
   }
 
   // Compute the derivatives.
-  operands_and_partials<decltype(x_ref), decltype(alpha_ref),
-                        decltype(beta_ref)>
-      ops_partials(x_ref, alpha_ref, beta_ref);
+  operands_and_partials<T_x_ref, T_alpha_ref, T_beta_ref> ops_partials(
+      x_ref, alpha_ref, beta_ref);
 
   if (!is_constant_all<T_x>::value) {
     if (T_x_rows == 1) {

--- a/stan/math/prim/prob/neg_binomial_2_log_glm_lpmf.hpp
+++ b/stan/math/prim/prob/neg_binomial_2_log_glm_lpmf.hpp
@@ -82,9 +82,9 @@ return_type_t<T_x, T_alpha, T_beta, T_precision> neg_binomial_2_log_glm_lpmf(
       typename std::conditional_t<T_x_rows == 1, T_partials_return,
                                   Array<T_partials_return, Dynamic, 1>>;
   using T_x_ref = ref_type_if_t<!is_constant<T_x>::value, T_x>;
-  using T_alpha_ref = ref_type_t<!is_constant<T_alpha>::value, T_alpha>;
-  using T_beta_ref = ref_type_t<!is_constant<T_beta>::value, T_beta>;
-  using T_phi_ref = ref_type_t<!is_constant<T_precision>::value, T_precision>;
+  using T_alpha_ref = ref_type_if_t<!is_constant<T_alpha>::value, T_alpha>;
+  using T_beta_ref = ref_type_if_t<!is_constant<T_beta>::value, T_beta>;
+  using T_phi_ref = ref_type_if_t<!is_constant<T_precision>::value, T_precision>;
 
   const size_t N_instances = T_x_rows == 1 ? stan::math::size(y) : x.rows();
   const size_t N_attributes = x.cols();

--- a/stan/math/prim/prob/neg_binomial_2_log_glm_lpmf.hpp
+++ b/stan/math/prim/prob/neg_binomial_2_log_glm_lpmf.hpp
@@ -84,7 +84,8 @@ return_type_t<T_x, T_alpha, T_beta, T_precision> neg_binomial_2_log_glm_lpmf(
   using T_x_ref = ref_type_if_t<!is_constant<T_x>::value, T_x>;
   using T_alpha_ref = ref_type_if_t<!is_constant<T_alpha>::value, T_alpha>;
   using T_beta_ref = ref_type_if_t<!is_constant<T_beta>::value, T_beta>;
-  using T_phi_ref = ref_type_if_t<!is_constant<T_precision>::value, T_precision>;
+  using T_phi_ref
+      = ref_type_if_t<!is_constant<T_precision>::value, T_precision>;
 
   const size_t N_instances = T_x_rows == 1 ? stan::math::size(y) : x.rows();
   const size_t N_attributes = x.cols();

--- a/stan/math/prim/prob/neg_binomial_2_log_glm_lpmf.hpp
+++ b/stan/math/prim/prob/neg_binomial_2_log_glm_lpmf.hpp
@@ -81,6 +81,10 @@ return_type_t<T_x, T_alpha, T_beta, T_precision> neg_binomial_2_log_glm_lpmf(
   using T_theta_tmp =
       typename std::conditional_t<T_x_rows == 1, T_partials_return,
                                   Array<T_partials_return, Dynamic, 1>>;
+  using T_x_ref = ref_type_if_t<!is_constant<T_x>::value, T_x>;
+  using T_alpha_ref = ref_type_t<!is_constant<T_alpha>::value, T_alpha>;
+  using T_beta_ref = ref_type_t<!is_constant<T_beta>::value, T_beta>;
+  using T_phi_ref = ref_type_t<!is_constant<T_precision>::value, T_precision>;
 
   const size_t N_instances = T_x_rows == 1 ? stan::math::size(y) : x.rows();
   const size_t N_attributes = x.cols();
@@ -92,38 +96,38 @@ return_type_t<T_x, T_alpha, T_beta, T_precision> neg_binomial_2_log_glm_lpmf(
   check_consistent_size(function, "Vector of precision parameters", phi,
                         N_instances);
   check_consistent_size(function, "Vector of intercepts", alpha, N_instances);
-  const auto& y_ref = to_ref(y);
-  const auto& alpha_ref = to_ref(alpha);
-  const auto& beta_ref = to_ref(beta);
-  const auto& phi_ref = to_ref(phi);
-  check_nonnegative(function, "Failures variables", y_ref);
+  T_alpha_ref alpha_ref = alpha;
+  T_beta_ref beta_ref = beta;
+  const auto& beta_val = value_of_rec(beta_ref);
+  const auto& alpha_val = value_of_rec(alpha_ref);
+  const auto& beta_val_vec = to_ref(as_column_vector_or_scalar(beta_val));
+  const auto& alpha_val_vec = to_ref(as_column_vector_or_scalar(alpha_val));
   check_finite(function, "Weight vector", beta_ref);
   check_finite(function, "Intercept", alpha_ref);
-  check_positive_finite(function, "Precision parameter", phi_ref);
 
   if (size_zero(y, phi)) {
     return 0;
   }
+
+  const auto& y_ref = to_ref(y);
+  T_phi_ref phi_ref = phi;
+
+  const auto& y_val = value_of_rec(y_ref);
+  const auto& phi_val = value_of_rec(phi_ref);
+
+  const auto& y_val_vec = to_ref(as_column_vector_or_scalar(y_val));
+  const auto& phi_val_vec = to_ref(as_column_vector_or_scalar(phi_val));
+  check_nonnegative(function, "Failures variables", y_val_vec);
+  check_positive_finite(function, "Precision parameter", phi_val_vec);
+
   if (!include_summand<propto, T_x, T_alpha, T_beta, T_precision>::value) {
     return 0;
   }
 
-  const auto& x_ref = to_ref_if<!is_constant<T_x>::value>(x);
+  T_x_ref x_ref = x;
 
-  T_partials_return logp(0);
-
-  const auto& y_val = value_of_rec(y_ref);
   const auto& x_val
       = to_ref_if<!is_constant<T_beta>::value>(value_of_rec(x_ref));
-  const auto& beta_val = value_of_rec(beta_ref);
-  const auto& alpha_val = value_of_rec(alpha_ref);
-  const auto& phi_val = value_of_rec(phi_ref);
-
-  const auto& y_val_vec = to_ref(as_column_vector_or_scalar(y_val));
-  const auto& beta_val_vec = to_ref_if<!is_constant<T_x>::value>(
-      as_column_vector_or_scalar(beta_val));
-  const auto& alpha_val_vec = as_column_vector_or_scalar(alpha_val);
-  const auto& phi_val_vec = to_ref(as_column_vector_or_scalar(phi_val));
 
   const auto& y_arr = as_array_or_scalar(y_val_vec);
   const auto& phi_arr = as_array_or_scalar(phi_val_vec);
@@ -147,6 +151,7 @@ return_type_t<T_x, T_alpha, T_beta, T_precision> neg_binomial_2_log_glm_lpmf(
   T_sum_val y_plus_phi = y_arr + phi_arr;
 
   // Compute the log-density.
+  T_partials_return logp(0);
   if (include_summand<propto>::value) {
     if (is_vector<T_y>::value) {
       logp -= sum(lgamma(y_arr + 1));
@@ -181,8 +186,7 @@ return_type_t<T_x, T_alpha, T_beta, T_precision> neg_binomial_2_log_glm_lpmf(
   }
 
   // Compute the necessary derivatives.
-  operands_and_partials<decltype(x_ref), decltype(alpha_ref),
-                        decltype(beta_ref), decltype(phi_ref)>
+  operands_and_partials<T_x_ref, T_alpha_ref, T_beta_ref, T_phi_ref>
       ops_partials(x_ref, alpha_ref, beta_ref, phi_ref);
   if (!is_constant_all<T_x, T_beta, T_alpha, T_precision>::value) {
     Array<T_partials_return, Dynamic, 1> theta_exp = theta.exp();

--- a/stan/math/prim/prob/normal_id_glm_lpdf.hpp
+++ b/stan/math/prim/prob/normal_id_glm_lpdf.hpp
@@ -66,6 +66,11 @@ return_type_t<T_y, T_x, T_alpha, T_beta, T_scale> normal_id_glm_lpdf(
   using T_y_scaled_tmp =
       typename std::conditional_t<T_x_rows == 1, T_partials_return,
                                   Array<T_partials_return, Dynamic, 1>>;
+  using T_y_ref = ref_type_if_t<!is_constant<T_y>::value, T_y>;
+  using T_x_ref = ref_type_if_t<!is_constant<T_x>::value, T_x>;
+  using T_alpha_ref = ref_type_if_t<!is_constant<T_alpha>::value, T_alpha>;
+  using T_beta_ref = ref_type_if_t<!is_constant<T_beta>::value, T_beta>;
+  using T_sigma_ref = ref_type_if_t<!is_constant<T_scale>::value, T_scale>;
 
   const size_t N_instances = T_x_rows == 1 ? stan::math::size(y) : x.rows();
   const size_t N_attributes = x.cols();
@@ -77,8 +82,10 @@ return_type_t<T_y, T_x, T_alpha, T_beta, T_scale> normal_id_glm_lpdf(
   check_consistent_size(function, "Vector of scale parameters", sigma,
                         N_instances);
   check_consistent_size(function, "Vector of intercepts", alpha, N_instances);
-  const auto& sigma_ref = to_ref(sigma);
-  check_positive_finite(function, "Scale vector", sigma_ref);
+  T_sigma_ref sigma_ref = sigma;
+  const auto& sigma_val = value_of_rec(sigma_ref);
+  const auto& sigma_val_vec = to_ref(as_column_vector_or_scalar(sigma_val));
+  check_positive_finite(function, "Scale vector", sigma_val_vec);
 
   if (size_zero(y, sigma)) {
     return 0;
@@ -87,25 +94,21 @@ return_type_t<T_y, T_x, T_alpha, T_beta, T_scale> normal_id_glm_lpdf(
     return 0;
   }
 
-  const auto& y_ref = to_ref_if<!is_constant<T_y>::value>(y);
-  const auto& x_ref = to_ref_if<!is_constant<T_x>::value>(x);
-  const auto& alpha_ref = to_ref_if<!is_constant<T_alpha>::value>(alpha);
-  const auto& beta_ref = to_ref_if<!is_constant<T_beta>::value>(beta);
+  T_y_ref y_ref = y;
+  T_x_ref x_ref = x;
+  T_alpha_ref alpha_ref = alpha;
+  T_beta_ref beta_ref = beta;
 
   const auto& y_val = value_of_rec(y_ref);
   const auto& x_val
       = to_ref_if<!is_constant<T_beta>::value>(value_of_rec(x_ref));
   const auto& alpha_val = value_of_rec(alpha_ref);
   const auto& beta_val = value_of_rec(beta_ref);
-  const auto& sigma_val = value_of_rec(sigma_ref);
 
   const auto& y_val_vec = as_column_vector_or_scalar(y_val);
   const auto& alpha_val_vec = as_column_vector_or_scalar(alpha_val);
   const auto& beta_val_vec = to_ref_if<!is_constant<T_x>::value>(
       as_column_vector_or_scalar(beta_val));
-  const auto& sigma_val_vec
-      = to_ref_if<include_summand<propto, T_scale>::value>(
-          as_column_vector_or_scalar(sigma_val));
 
   T_scale_val inv_sigma = 1 / as_array_or_scalar(sigma_val_vec);
 
@@ -126,8 +129,7 @@ return_type_t<T_y, T_x, T_alpha, T_beta, T_scale> normal_id_glm_lpdf(
                * inv_sigma;
   }
 
-  operands_and_partials<decltype(y_ref), decltype(x_ref), decltype(alpha_ref),
-                        decltype(beta_ref), decltype(sigma_ref)>
+  operands_and_partials<T_y_ref, T_x_ref, T_alpha_ref, T_beta_ref, T_sigma_ref>
       ops_partials(y_ref, x_ref, alpha_ref, beta_ref, sigma_ref);
 
   if (!(is_constant_all<T_y, T_x, T_beta, T_alpha>::value)) {

--- a/stan/math/prim/prob/ordered_logistic_glm_lpmf.hpp
+++ b/stan/math/prim/prob/ordered_logistic_glm_lpmf.hpp
@@ -150,8 +150,8 @@ return_type_t<T_x, T_beta, T_cuts> ordered_logistic_glm_lpmf(
     }
   }
 
-  operands_and_partials<T_x_ref, T_beta_ref, T_cuts_ref>
-      ops_partials(x_ref, beta_ref, cuts_ref);
+  operands_and_partials<T_x_ref, T_beta_ref, T_cuts_ref> ops_partials(
+      x_ref, beta_ref, cuts_ref);
   if (!is_constant_all<T_x, T_beta, T_cuts>::value) {
     Array<double, Dynamic, 1> exp_m_cut1 = exp(-cut1);
     Array<double, Dynamic, 1> exp_m_cut2 = exp(-cut2);

--- a/stan/math/prim/prob/ordered_logistic_glm_lpmf.hpp
+++ b/stan/math/prim/prob/ordered_logistic_glm_lpmf.hpp
@@ -53,6 +53,10 @@ return_type_t<T_x, T_beta, T_cuts> ordered_logistic_glm_lpmf(
   using T_partials_return = partials_return_t<T_y, T_x, T_beta, T_cuts>;
   typedef typename std::conditional_t<T_x_rows == 1, double, VectorXd>
       T_location;
+  using T_y_ref = ref_type_t<T_y>;
+  using T_x_ref = ref_type_if_t<!is_constant<T_x>::value, T_x>;
+  using T_beta_ref = ref_type_if_t<!is_constant<T_beta>::value, T_beta>;
+  using T_cuts_ref = ref_type_if_t<!is_constant<T_cuts>::value, T_cuts>;
 
   const size_t N_instances = T_x_rows == 1 ? stan::math::size(y) : x.rows();
   const size_t N_attributes = x.cols();
@@ -62,15 +66,17 @@ return_type_t<T_x, T_beta, T_cuts> ordered_logistic_glm_lpmf(
   check_consistent_size(function, "Vector of dependent variables", y,
                         N_instances);
   check_consistent_size(function, "Weight vector", beta, N_attributes);
-  const auto& y_ref = to_ref(y);
-  const auto& cuts_ref = to_ref(cuts);
+  T_y_ref y_ref = y;
+  T_cuts_ref cuts_ref = cuts;
+  const auto& cuts_val = value_of_rec(cuts_ref);
+  const auto& cuts_val_vec = to_ref(as_column_vector_or_scalar(cuts_val));
   check_bounded(function, "Vector of dependent variables", y_ref, 1, N_classes);
-  check_ordered(function, "Cut-points", cuts_ref);
+  check_ordered(function, "Cut-points", cuts_val_vec);
   if (N_classes > 1) {
     if (N_classes > 2) {
-      check_finite(function, "Final cut-point", cuts_ref[N_classes - 2]);
+      check_finite(function, "Final cut-point", cuts_val_vec[N_classes - 2]);
     }
-    check_finite(function, "First cut-point", cuts_ref[0]);
+    check_finite(function, "First cut-point", cuts_val_vec[0]);
   }
 
   if (size_zero(y, cuts)) {
@@ -80,19 +86,17 @@ return_type_t<T_x, T_beta, T_cuts> ordered_logistic_glm_lpmf(
     return 0;
   }
 
-  const auto& x_ref = to_ref_if<!is_constant<T_x>::value>(x);
-  const auto& beta_ref = to_ref_if<!is_constant<T_beta>::value>(beta);
+  T_x_ref x_ref = x;
+  T_beta_ref beta_ref = beta;
 
   const auto& x_val
       = to_ref_if<!is_constant<T_beta>::value>(value_of_rec(x_ref));
   const auto& beta_val = value_of_rec(beta_ref);
-  const auto& cuts_val = value_of_rec(cuts_ref);
 
   const auto& beta_val_vec = to_ref_if<!is_constant<T_x>::value>(
       as_column_vector_or_scalar(beta_val));
-  const auto& cuts_val_vec = to_ref(as_column_vector_or_scalar(cuts_val));
 
-  scalar_seq_view<T_y> y_seq(y_ref);
+  scalar_seq_view<T_y_ref> y_seq(y_ref);
   Array<double, Dynamic, 1> cuts_y1(N_instances), cuts_y2(N_instances);
   for (int i = 0; i < N_instances; i++) {
     int c = y_seq[i];
@@ -146,7 +150,7 @@ return_type_t<T_x, T_beta, T_cuts> ordered_logistic_glm_lpmf(
     }
   }
 
-  operands_and_partials<decltype(x_ref), decltype(beta_ref), decltype(cuts_ref)>
+  operands_and_partials<T_x_ref, T_beta_ref, T_cuts_ref>
       ops_partials(x_ref, beta_ref, cuts_ref);
   if (!is_constant_all<T_x, T_beta, T_cuts>::value) {
     Array<double, Dynamic, 1> exp_m_cut1 = exp(-cut1);


### PR DESCRIPTION

## Summary
in #1930 I added `ref_type_if_t`, whch can also be used in GLMs to avoid some `decltype`s. I also moved some checks so they are executed after we extract values from autodiff inputs - iterating over values is faster than over autodiff.

## Tests
Just a refactor - no new tests.

## Side Effects
None


## Checklist

- [x] Math issue #1470

- [x] Copyright holder: Tadej Ciglarič

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
