### PR TITLE
Fix pow tests with RTools 3.5

### DIFF
--- a/test/unit/math/mix/fun/pow_part1_test.cpp
+++ b/test/unit/math/mix/fun/pow_part1_test.cpp
@@ -1,0 +1,63 @@
+#include <test/unit/math/test_ad.hpp>
+#include <cmath>
+#include <limits>
+#include <vector>
+
+template <typename T>
+void expect_arith_instantiate() {
+  using stan::math::pow;
+  using std::pow;
+  auto a1 = pow(T(1.0), 1);
+  auto b1 = pow(T(1.0), 1.0);
+  auto c1 = pow(1, T(1.0));
+  auto d1 = pow(1.0, T(1.0));
+  auto e1 = pow(T(1.0), T(1.0));
+
+  auto a2 = pow(std::complex<T>(1.0), 1);
+  auto b2 = pow(std::complex<T>(1.0), 1.0);
+  auto c2 = pow(1, std::complex<T>(1.0));
+  auto d2 = pow(1.0, std::complex<T>(1.0));
+  auto e2 = pow(std::complex<T>(1.0), std::complex<T>(1.0));
+  auto f2 = pow(std::complex<double>(1.0), std::complex<T>(1.0));
+  auto g2 = pow(std::complex<T>(1.0), std::complex<double>(1.0));
+}
+
+// this one's been tricky to instantiate, so test all instances
+TEST(mathMixScalFun, powInstantiations) {
+  using stan::math::fvar;
+  using stan::math::var;
+  expect_arith_instantiate<double>();
+  expect_arith_instantiate<var>();
+  expect_arith_instantiate<fvar<double>>();
+  expect_arith_instantiate<fvar<fvar<double>>>();
+  expect_arith_instantiate<fvar<var>>();
+  expect_arith_instantiate<fvar<fvar<var>>>();
+}
+
+TEST(mathMixScalFun, pow) {
+  auto f = [](const auto& x1, const auto& x2) {
+    using stan::math::pow;
+    using std::pow;
+    return pow(x1, x2);
+  };
+  stan::test::expect_ad(f, -0.4, 0.5);
+  stan::test::expect_ad(f, 0.5, 0.5);
+  stan::test::expect_ad(f, 0.5, 1.0);
+  stan::test::expect_ad(f, 0.5, 1.2);
+  stan::test::expect_ad(f, 0.5, 5.0);
+  stan::test::expect_ad(f, 1.0, 2.0);
+  stan::test::expect_ad(f, 3.0, 4.0);
+  for (double y = -2; y <= 4; y += 0.5)
+    stan::test::expect_ad(f, 4.0, y);
+
+  double nan = std::numeric_limits<double>::quiet_NaN();
+  stan::test::expect_ad(f, 1.0, nan);
+  stan::test::expect_ad(f, nan, 1.0);
+  stan::test::expect_ad(f, nan, nan);
+
+  Eigen::VectorXd in1(3);
+  in1 << 0.5, 3.4, 5.2;
+  Eigen::VectorXd in2(3);
+  in2 << 3.3, 0.9, 6.7;
+  stan::test::expect_ad_vectorized_binary(f, in1, in2);
+}

--- a/test/unit/math/mix/fun/pow_part2_test.cpp
+++ b/test/unit/math/mix/fun/pow_part2_test.cpp
@@ -3,64 +3,6 @@
 #include <limits>
 #include <vector>
 
-template <typename T>
-void expect_arith_instantiate() {
-  using stan::math::pow;
-  using std::pow;
-  auto a1 = pow(T(1.0), 1);
-  auto b1 = pow(T(1.0), 1.0);
-  auto c1 = pow(1, T(1.0));
-  auto d1 = pow(1.0, T(1.0));
-  auto e1 = pow(T(1.0), T(1.0));
-
-  auto a2 = pow(std::complex<T>(1.0), 1);
-  auto b2 = pow(std::complex<T>(1.0), 1.0);
-  auto c2 = pow(1, std::complex<T>(1.0));
-  auto d2 = pow(1.0, std::complex<T>(1.0));
-  auto e2 = pow(std::complex<T>(1.0), std::complex<T>(1.0));
-  auto f2 = pow(std::complex<double>(1.0), std::complex<T>(1.0));
-  auto g2 = pow(std::complex<T>(1.0), std::complex<double>(1.0));
-}
-
-// this one's been tricky to instantiate, so test all instances
-TEST(mathMixScalFun, powInstantiations) {
-  using stan::math::fvar;
-  using stan::math::var;
-  expect_arith_instantiate<double>();
-  expect_arith_instantiate<var>();
-  expect_arith_instantiate<fvar<double>>();
-  expect_arith_instantiate<fvar<fvar<double>>>();
-  expect_arith_instantiate<fvar<var>>();
-  expect_arith_instantiate<fvar<fvar<var>>>();
-}
-
-TEST(mathMixScalFun, pow) {
-  auto f = [](const auto& x1, const auto& x2) {
-    using stan::math::pow;
-    using std::pow;
-    return pow(x1, x2);
-  };
-  stan::test::expect_ad(f, -0.4, 0.5);
-  stan::test::expect_ad(f, 0.5, 0.5);
-  stan::test::expect_ad(f, 0.5, 1.0);
-  stan::test::expect_ad(f, 0.5, 1.2);
-  stan::test::expect_ad(f, 0.5, 5.0);
-  stan::test::expect_ad(f, 1.0, 2.0);
-  stan::test::expect_ad(f, 3.0, 4.0);
-  for (double y = -2; y <= 4; y += 0.5)
-    stan::test::expect_ad(f, 4.0, y);
-
-  double nan = std::numeric_limits<double>::quiet_NaN();
-  stan::test::expect_ad(f, 1.0, nan);
-  stan::test::expect_ad(f, nan, 1.0);
-  stan::test::expect_ad(f, nan, nan);
-
-  Eigen::VectorXd in1(3);
-  in1 << 0.5, 3.4, 5.2;
-  Eigen::VectorXd in2(3);
-  in2 << 3.3, 0.9, 6.7;
-  stan::test::expect_ad_vectorized_binary(f, in1, in2);
-}
 TEST(mathMixFun, complexPow) {
   auto f = [](const auto& x1, const auto& x2) {
     using stan::math::pow;


### PR DESCRIPTION
## Summary

This pull fixes the compilation failures for the ```mix``` tests for ```pow``` under RTools 3.5, by splitting the tests into two files

## Tests

No new tests, just the separation of the single existing test into two parts.

## Side Effects

N/A

## Release notes

Fix segfaults when compiling ```mix``` tests for ```pow``` on Windows with g++ 4.9.3

## Checklist

- [x] Math issue #1890 

- [x] Copyright holder: Andrew Johnson

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
