### PR TITLE
Replace map with matrix in vari_value

### DIFF
--- a/test/unit/math/rev/core/vari_test.cpp
+++ b/test/unit/math/rev/core/vari_test.cpp
@@ -1,4 +1,5 @@
 #include <stan/math/rev/core.hpp>
+#include <test/unit/util.hpp>
 #include <gtest/gtest.h>
 #include <sstream>
 
@@ -19,4 +20,16 @@ TEST(AgradRev, long_double_test) {
 TEST(AgradRev, dense_matrix_vari) {
   using stan::math::vari_value;
   stan::math::vari_value<Eigen::MatrixXd> A(Eigen::MatrixXd::Random(3, 3));
+}
+
+TEST(AgradRev, dense_matrix_vari_block) {
+  using stan::math::vari_value;
+  Eigen::MatrixXd a = Eigen::MatrixXd::Random(3, 3);
+  Eigen::MatrixXd b = Eigen::MatrixXd::Random(3, 3);
+
+  vari_value<Eigen::MatrixXd> A(a);
+  EXPECT_MATRIX_EQ(a.block(0,1,2,2), A.block(0,1,2,2).val_);
+  vari_value<Eigen::MatrixXd> B(a,b);
+  EXPECT_MATRIX_EQ(a.block(0,1,2,2), B.block(0,1,2,2).val_);
+  EXPECT_MATRIX_EQ(b.block(0,1,2,2), B.block(0,1,2,2).adj_);
 }


### PR DESCRIPTION
## Summary
Replaced map with matrix in vari_vase. Separate templates for value and adjoint made adding block very simple.

@SteveBronder You did sme benchmarking when adding vari_value. Can you also check how this compares with your version with maps?
