### PR TITLE
Use jumbo tests in prim

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,8 +3,7 @@
 import org.stan.Utils
 
 def runTests(String testPath) {
-    sh "./runTests.py -j${env.PARALLEL} ${testPath} --make-only"
-    try { sh "./runTests.py -j${env.PARALLEL} ${testPath}" }
+    try { sh "./runTests.py -j${env.PARALLEL} ${testPath} --jumbo" }
     finally { junit 'test/**/*.xml' }
 }
 
@@ -14,8 +13,7 @@ def runTestsWin(String testPath, boolean buildLibs = true) {
        if (buildLibs){
            bat "mingw32-make.exe -f make/standalone math-libs"
        }
-       bat "runTests.py -j${env.PARALLEL} ${testPath} --make-only"
-       try { bat "runTests.py -j${env.PARALLEL} ${testPath}" }
+       try { bat "runTests.py -j${env.PARALLEL} ${testPath} --jumbo" }
        finally { junit 'test/**/*.xml' }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,18 +2,30 @@
 @Library('StanUtils')
 import org.stan.Utils
 
-def runTests(String testPath) {
-    try { sh "./runTests.py -j${env.PARALLEL} ${testPath} --jumbo" }
-    finally { junit 'test/**/*.xml' }
+def runTests(String testPath, boolean jumbo = false) {
+    try {
+        if (jumbo) {
+            sh "./runTests.py -j${env.PARALLEL} ${testPath} --jumbo"
+        } else {
+            sh "./runTests.py -j${env.PARALLEL} ${testPath}"
+        }
+    }
+    finally { junit 'test/**/*.xml' }    
 }
 
-def runTestsWin(String testPath, boolean buildLibs = true) {
+def runTestsWin(String testPath, boolean buildLibs = true, boolean jumbo = false) {
     withEnv(['PATH+TBB=./lib/tbb']) {
        bat "echo $PATH"
        if (buildLibs){
            bat "mingw32-make.exe -f make/standalone math-libs"
        }
-       try { bat "runTests.py -j${env.PARALLEL} ${testPath} --jumbo" }
+       try { 
+           if (jumbo) {
+               bat "runTests.py -j${env.PARALLEL} ${testPath} --jumbo" 
+            } else {
+                bat "runTests.py -j${env.PARALLEL} ${testPath}" 
+            }
+       }
        finally { junit 'test/**/*.xml' }
     }
 }
@@ -192,15 +204,15 @@ pipeline {
                     if (isUnix()) {
                         deleteDir()
                         unstash 'MathSetup'
-                        runTests("test/unit/math/prim")
-                        runTests("test/unit/math/rev")
-                        runTests("test/unit")
+                        runTests("test/unit/math/prim", true)
+                        runTests("test/unit/math/rev", true)
+                        runTests("test/unit", true)
                     } else {
                         deleteDirWin()
                         unstash 'MathSetup'
-                        runTestsWin("test/unit/math/prim")
-                        runTestsWin("test/unit/math/rev")
-                        runTestsWin("test/unit")
+                        runTestsWin("test/unit/math/prim", true)
+                        runTestsWin("test/unit/math/rev", true)
+                        runTestsWin("test/unit", true)
                     }
                 }
             }
@@ -333,7 +345,7 @@ pipeline {
                         unstash 'MathSetup'
                         bat "mingw32-make.exe -f make/standalone math-libs"
                         bat "mingw32-make -j${env.PARALLEL} test-headers"
-                        runTestsWin("test/unit", false)
+                        runTestsWin("test/unit", false, true)
                     }
                 }
             }

--- a/runTests.py
+++ b/runTests.py
@@ -21,9 +21,9 @@ testsfx = "_test.cpp"
 allowed_paths_with_jumbo = [	
     "test/unit/math/prim/",	
     "test/unit/math/",	
-    # "test/unit/math/rev/",	
-    # "test/unit/math/fwd/",	
-    # "test/unit/math/mix/"	
+    "test/unit/math/rev/",	
+    "test/unit/math/fwd/",	
+    "test/unit/math/mix/"	
 ]	
 
 jumbo_folders = [	

--- a/runTests.py
+++ b/runTests.py
@@ -20,10 +20,11 @@ testsfx = "_test.cpp"
 
 allowed_paths_with_jumbo = [	
     "test/unit/math/prim/",	
-    "test/unit/math/",	
+    "test/unit/math/",
     "test/unit/math/rev/",	
     "test/unit/math/fwd/",	
-    "test/unit/math/mix/"	
+    "test/unit/math/mix/",
+    "test/unit"
 ]	
 
 jumbo_folders = [	

--- a/runTests.py
+++ b/runTests.py
@@ -18,6 +18,38 @@ import time
 winsfx = ".exe"
 testsfx = "_test.cpp"
 
+allowed_paths_with_jumbo = [	
+    "test/unit/math/prim/",	
+    "test/unit/math/",	
+    # "test/unit/math/rev/",	
+    # "test/unit/math/fwd/",	
+    # "test/unit/math/mix/"	
+]	
+
+jumbo_folders = [	
+    "test/unit/math/prim/core",	
+    "test/unit/math/prim/err",	
+    "test/unit/math/prim/fun",	
+    "test/unit/math/prim/functor",	
+    "test/unit/math/prim/meta",	
+    "test/unit/math/prim/prob",	
+    # "test/unit/math/rev/core",	
+    # "test/unit/math/rev/err",	
+    # "test/unit/math/rev/fun",	
+    # "test/unit/math/rev/functor",	
+    # "test/unit/math/rev/meta",	
+    # "test/unit/math/rev/prob",	
+    # "test/unit/math/fwd/core",	
+    # "test/unit/math/fwd/fun",	
+    # "test/unit/math/fwd/functor",	
+    # "test/unit/math/fwd/meta",	
+    # "test/unit/math/fwd/prob",	
+    # "test/unit/math/mix/core",	
+    # "test/unit/math/mix/fun",	
+    # "test/unit/math/mix/functor",	
+    # "test/unit/math/mix/meta",	
+    # "test/unit/math/mix/prob"	
+]
 
 def processCLIArgs():
     """
@@ -49,7 +81,8 @@ def processCLIArgs():
                         action="store_true", help="Don't run tests, just try to make them.")
     parser.add_argument("--run-all", dest="run_all", action="store_true",
                         help="Don't stop at the first test failure, run all of them.")
-
+    parser.add_argument("--jumbo-test", dest="do_jumbo", action="store_true",	
+                            help="Build/run jumbo tests.")
     # And parse the command line against those rules
     return parser.parse_args()
 
@@ -97,6 +130,42 @@ def generateTests(j):
     else:
         doCommand('make -j%d generate-tests -s' % (j or 1))
 
+def divide_chunks(l, n): 	
+    # looping till length l 	
+    for i in range(0, len(l), n):  	
+        yield l[i:i + n] 	
+
+def generateJumboTests(paths):	
+    jumbo_files_to_create = []	
+    jumbo_files = []	
+    for p in paths:	
+        if not p.endswith(testsfx) and not p.endswith("/"):	
+            p = p + "/"	
+        if p in allowed_paths_with_jumbo:	
+            jumbo_files_to_create.extend(	
+                [x for x in jumbo_folders if x.startswith(p)]	
+            )	
+        else:	
+            stopErr('The --jumbo flag is only allowed with top level folders.', 10)	
+    for jf in jumbo_files_to_create:	
+        tests_in_subfolder = sorted([x for x in os.listdir(jf) if x.endswith(testsfx)])	
+        chunked_tests = divide_chunks(tests_in_subfolder, 30)	
+        i = 0	
+        for tests in chunked_tests:	
+            i = i + 1	
+            jumbo_file_path = jf + "_" + str(i) + testsfx	
+            jumbo_files.append(jumbo_file_path)	
+            f = open(jumbo_file_path, "w")	
+            for t in tests:	
+                f.write("#include <"+jf+"/"+t+">\n")	
+            f.close()	
+    return jumbo_files	
+
+def cleanupJumboTests(paths):	
+    for f in paths:	
+        if os.path.exists(f):	
+            os.remove(f)
+
 def makeTest(name, j):
     """Run the make command for a given single test."""
     if isWin():
@@ -127,7 +196,7 @@ def runTest(name, run_all=False, mpi=False, j=1):
         command = "mpirun -np {} {}".format(j, command)
     doCommand(command, not run_all)
 
-def findTests(base_path, filter_names):
+def findTests(base_path, filter_names, do_jumbo = False):
     folders = filter(os.path.isdir, base_path)
     nonfolders = list(set(base_path) - set(folders))
     tests = nonfolders + [os.path.join(root, n)
@@ -140,6 +209,18 @@ def findTests(base_path, filter_names):
             for test in tests
             if all(filter_name in test
                    for filter_name in filter_names)]
+    if do_jumbo:	
+        filtered_jumbo_tests = []	
+        for t in tests:	
+            add = True	
+            for k in jumbo_folders:	
+                k = k + "/"	
+                if t.startswith(k):	
+                    add = False	
+                    break	
+            if add:	
+                filtered_jumbo_tests.append(t)	
+        tests = filtered_jumbo_tests
     return tests
 
 def batched(tests):
@@ -159,7 +240,11 @@ def main():
     if any(['test/prob' in arg for arg in inputs.tests]):
         generateTests(inputs.j)
 
-    tests = findTests(inputs.tests, inputs.f)
+    if inputs.do_jumbo:	
+        jumboFiles = generateJumboTests(inputs.tests)	
+
+    jumboFiles = []
+    tests = findTests(inputs.tests, inputs.f, inputs.do_jumbo)
     if not tests:
         stopErr("No matching tests found.", -1)
     if inputs.debug:
@@ -178,6 +263,7 @@ def main():
                 print("run single test: %s" % testname)
             runTest(t, inputs.run_all, mpi = stan_mpi, j = inputs.j)
 
+    cleanupJumboTests(jumboFiles)
 
 if __name__ == "__main__":
     main()

--- a/runTests.py
+++ b/runTests.py
@@ -24,7 +24,7 @@ allowed_paths_with_jumbo = [
     "test/unit/math/rev/",	
     "test/unit/math/fwd/",	
     "test/unit/math/mix/",
-    "test/unit"
+    "test/unit/"
 ]	
 
 jumbo_folders = [	


### PR DESCRIPTION
## Summary

Advances #1948 by using jumbo test for /prim. See the issue for more details on what jumbo tests are. 

This is not a priority so feel free to ignore this until the release.

## Tests

This is only touching tests.

## Side Effects

/

## Checklist

- [x] Math issue #1948 

- [x] Copyright holder: Rok Češnovar, Univ. of Ljubljana

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
