### PR TITLE
Bugfix 1973: Add no-ignored-attributes to CXXFLAGS

### DIFF
--- a/make/compiler_flags
+++ b/make/compiler_flags
@@ -117,7 +117,7 @@ CXXFLAGS_SUNDIALS ?= -pipe
 # Update compiler flags with operating system specific modifications
 ##
 ifeq ($(OS),Windows_NT)
-  CXXFLAGS_WARNINGS ?= -Wall -Wno-unused-function -Wno-uninitialized -Wno-unused-but-set-variable -Wno-unused-variable -Wno-sign-compare -Wno-unused-local-typedefs
+  CXXFLAGS_WARNINGS ?= -Wall -Wno-unused-function -Wno-uninitialized -Wno-unused-but-set-variable -Wno-unused-variable -Wno-sign-compare -Wno-unused-local-typedefs -Wno-int-in-bool-context -Wno-attributes
   CPPFLAGS_GTEST ?= -DGTEST_HAS_PTHREAD=0
   CPPFLAGS_OS ?= -D_USE_MATH_DEFINES
   ## Detecting Process Bitness:
@@ -162,9 +162,8 @@ endif
 ## makes reentrant version lgamma_r available from cmath
 CXXFLAGS_OS += -D_REENTRANT
 
-ifeq (gcc,$(CXX_TYPE))
-CXXFLAGS_WARNINGS += -Wno-int-in-bool-context -Wno-attributes
-endif
+## silence warnings occuring due to the TBB and Eigen libraries
+CXXFLAGS_WARNINGS += -Wno-ignored-attributes
 
 ################################################################################
 # Setup OpenCL


### PR DESCRIPTION
## Summary

Fixes #1973 by adding `-Wno-ignored-attributes` to the CXXFLAGS. Also, moves the Windows-specific flags to the Windows section.

I checked that these flags cause no issues with Rtools 3.5 on Windows as well as g++ 5.0 and clang 6 on Ubuntu.

## Tests

/

## Side Effects

/

## Release notes

Added `-Wno-ignored-attributes` to the compile flags.

## Checklist

- [x] Math issue #1973

- [x] Copyright holder: (fill in copyright holder information)

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
