### PR TITLE
Revert 1798 feature/elementwise checks part 2

### DIFF
--- a/stan/math/prim/err/check_finite.hpp
+++ b/stan/math/prim/err/check_finite.hpp
@@ -15,11 +15,25 @@
 namespace stan {
 namespace math {
 namespace internal {
+/**
+ * Return true if y is finite
+ *
+ * @tparam T_y type of y
+ * @param y parameter to check
+ * @return boolean
+ */
 template <typename T_y>
 bool is_finite(const T_y& y) {
   return is_scal_finite(y);
 }
 
+/**
+ * Return true if every element of the matrix y is finite
+ *
+ * @tparam T_y type of elements y
+ * @param y matrix to check
+ * @return boolean
+ */
 template <typename T_y, int R, int C>
 bool is_finite(const Eigen::Matrix<T_y, R, C>& y) {
   bool all = true;
@@ -29,6 +43,13 @@ bool is_finite(const Eigen::Matrix<T_y, R, C>& y) {
   return all;
 }
 
+/**
+ * Return true if every element of the vector y is finite
+ *
+ * @tparam T_y type of elements y
+ * @param y vector to check
+ * @return boolean
+ */
 template <typename T_y>
 bool is_finite(const std::vector<T_y>& y) {
   bool all = true;

--- a/test/unit/math/prim/err/check_finite_test.cpp
+++ b/test/unit/math/prim/err/check_finite_test.cpp
@@ -24,6 +24,31 @@ TEST(ErrorHandlingArr, CheckFinite_Vector) {
       << "check_finite should throw exception on NaN";
 }
 
+
+TEST(ErrorHandlingArr, CheckFinite_std_vector_std_vector) {
+  using stan::math::check_finite;
+  const char* function = "check_finite";
+  std::vector<double> x = {-1, 0, 1};
+  std::vector<std::vector<double>> xx = { x };
+  ASSERT_NO_THROW(check_finite(function, "x", xx))
+      << "check_finite should be true with finite x";
+
+  x = {-1, 0, std::numeric_limits<double>::infinity()};
+  xx = { x };
+  EXPECT_THROW(check_finite(function, "x", xx), std::domain_error)
+      << "check_finite should throw exception on Inf";
+
+  x = {-1, 0, -std::numeric_limits<double>::infinity()};
+  xx = { x };
+  EXPECT_THROW(check_finite(function, "x", xx), std::domain_error)
+      << "check_finite should throw exception on -Inf";
+
+  x = {-1, 0, std::numeric_limits<double>::quiet_NaN()};
+  xx = { x };
+  EXPECT_THROW(check_finite(function, "x", xx), std::domain_error)
+      << "check_finite should throw exception on NaN";
+}
+
 TEST(ErrorHandlingArr, CheckFinite_nan) {
   using stan::math::check_finite;
   const char* function = "check_finite";
@@ -94,26 +119,20 @@ TEST(ErrorHandlingMat, CheckFinite_std_vector_Matrix) {
 
   x.resize(3);
   x << -1, 0, std::numeric_limits<double>::infinity();
-
-  std::vector<Eigen::Matrix<double, Eigen::Dynamic, 1>> xvi = { x };
-
-  EXPECT_THROW(check_finite(function, "x", xvi), std::domain_error)
+  xv = { x };
+  EXPECT_THROW(check_finite(function, "x", xv), std::domain_error)
       << "check_finite should throw exception on Inf";
 
   x.resize(3);
   x << -1, 0, -std::numeric_limits<double>::infinity();
-
-  std::vector<Eigen::Matrix<double, Eigen::Dynamic, 1>> nxvi = { x };
-
-  EXPECT_THROW(check_finite(function, "x", nxvi), std::domain_error)
+  xv = { x };
+  EXPECT_THROW(check_finite(function, "x", xv), std::domain_error)
       << "check_finite should throw exception on -Inf";
 
   x.resize(3);
   x << -1, 0, std::numeric_limits<double>::quiet_NaN();
-
-  std::vector<Eigen::Matrix<double, Eigen::Dynamic, 1>> xvn = { x };
-
-  EXPECT_THROW(check_finite(function, "x", xvn), std::domain_error)
+  xv = { x };
+  EXPECT_THROW(check_finite(function, "x", xv), std::domain_error)
   << "check_finite should throw exception on NaN";
 }
 

--- a/test/unit/math/prim/err/check_finite_test.cpp
+++ b/test/unit/math/prim/err/check_finite_test.cpp
@@ -24,27 +24,26 @@ TEST(ErrorHandlingArr, CheckFinite_Vector) {
       << "check_finite should throw exception on NaN";
 }
 
-
 TEST(ErrorHandlingArr, CheckFinite_std_vector_std_vector) {
   using stan::math::check_finite;
   const char* function = "check_finite";
   std::vector<double> x = {-1, 0, 1};
-  std::vector<std::vector<double>> xx = { x };
+  std::vector<std::vector<double>> xx = {x};
   ASSERT_NO_THROW(check_finite(function, "x", xx))
       << "check_finite should be true with finite x";
 
   x = {-1, 0, std::numeric_limits<double>::infinity()};
-  xx = { x };
+  xx = {x};
   EXPECT_THROW(check_finite(function, "x", xx), std::domain_error)
       << "check_finite should throw exception on Inf";
 
   x = {-1, 0, -std::numeric_limits<double>::infinity()};
-  xx = { x };
+  xx = {x};
   EXPECT_THROW(check_finite(function, "x", xx), std::domain_error)
       << "check_finite should throw exception on -Inf";
 
   x = {-1, 0, std::numeric_limits<double>::quiet_NaN()};
-  xx = { x };
+  xx = {x};
   EXPECT_THROW(check_finite(function, "x", xx), std::domain_error)
       << "check_finite should throw exception on NaN";
 }
@@ -119,21 +118,21 @@ TEST(ErrorHandlingMat, CheckFinite_std_vector_Matrix) {
 
   x.resize(3);
   x << -1, 0, std::numeric_limits<double>::infinity();
-  xv = { x };
+  xv = {x};
   EXPECT_THROW(check_finite(function, "x", xv), std::domain_error)
       << "check_finite should throw exception on Inf";
 
   x.resize(3);
   x << -1, 0, -std::numeric_limits<double>::infinity();
-  xv = { x };
+  xv = {x};
   EXPECT_THROW(check_finite(function, "x", xv), std::domain_error)
       << "check_finite should throw exception on -Inf";
 
   x.resize(3);
   x << -1, 0, std::numeric_limits<double>::quiet_NaN();
-  xv = { x };
+  xv = {x};
   EXPECT_THROW(check_finite(function, "x", xv), std::domain_error)
-  << "check_finite should throw exception on NaN";
+      << "check_finite should throw exception on NaN";
 }
 
 TEST(ErrorHandlingMat, CheckFinite_Matrix_one_indexed_message) {


### PR DESCRIPTION
## Summary

Adding some missing tests

Fixes #1983 

## Tests

The check_finite tests were missing tests for `std::vector<std::vector<T>>` which is why https://github.com/stan-dev/math/pull/1641

## Release notes

Added missing tests to check_finite

## Checklist

- [x] Math issue #1983

- [x] Copyright holder: Columbia University

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
