### PR TITLE
flip indexes in hmm_marginal doc

### DIFF
--- a/stan/math/prim/prob/hmm_marginal.hpp
+++ b/stan/math/prim/prob/hmm_marginal.hpp
@@ -53,8 +53,8 @@ inline auto hmm_marginal_val(
  * the derivative is calculated with an adjoint method,
  * e.g (Betancourt, Margossian, & Leos-Barajas, 2020).
  * log_omegas is a matrix of observational densities, where
- * the (i, j)th entry corresponds to the density of the ith observation, y_i,
- * given x_i = j.
+ * the (i, j)th entry corresponds to the density of the jth observation, y_j,
+ * given x_j = i.
  * The transition matrix Gamma is such that the (i, j)th entry is the
  * probability that x_n = j given x_{n - 1} = i. The rows of Gamma are
  * simplexes.


### PR DESCRIPTION
## Summary

Fixes the doxygen documentation for `hmm_marginal` according to @charlesm93 in #1979. I walked through the code and I believe the indexing is correct after the patch.

## Tests

No new tests. Doc only.

## Side Effects

No side effects.

## Release notes

fixed doxygen documentation of `hmm_marginal`

## Checklist

- [x] Math issue #1979

- [x] Copyright holder: Generable

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
