### PR TITLE
Use /usr/bin/env bash instead of /bin/bash

### DIFF
--- a/make/libraries
+++ b/make/libraries
@@ -125,7 +125,7 @@ endif
 
 # Set shell in order to use string matching for tbb-make-check
 ifeq (Linux, $(OS))
-  SHELL = /bin/bash
+  SHELL = /usr/bin/env bash
 endif
 
 $(TBB_BIN)/tbb-make-check:


### PR DESCRIPTION
Fix for [Unable to build cmdstan if bash is not at /bin/bash](https://github.com/stan-dev/math/issues/1997)

Thanks for submitting a pull request! Please remove this text when submitting.

Start by filling in the Summary, Tests, and Side Effects sections of this pull request and then work through the handy checklist at the bottom. If anything significant is missing, the pull request may be closed until it's ready. The full guidebook on how pull requests are reviewed is here: [Code Review Guidelines](https://github.com/stan-dev/math/wiki/Developer-Doc#code-review-guidelines).

## Summary

This pull request removes the hardcoding of `/bin/bash` as the path to the bash shell and replaces it with `/usr/bin/env bash` which should be compatible with systems where bash is installed but not located at /bin/bash. NixOS is one environment where this is the case.

This fixes https://github.com/stan-dev/math/issues/1997

## Tests

None

## Side Effects

I guess that if a user has /bin/bash but not /usr/bin/env then this will not work. But I believe that to be unusual

## Release notes

Switched `/bin/bash` with `/usr/bin/env bash` in the makefiles.

## Checklist

- [X ] Math issue #1997 

- [X] Copyright holder: Richard Fergie

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [ ] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [ ] the code is written in idiomatic C++ and changes are documented in the doxygen

- [ ] the new changes are tested
