### PR TITLE
preventing boost mpi to be rebuilt when building tests again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,8 @@ lib/boost_*/project-config.jam.1
 lib/boost_*/stage/
 lib/boost_*/tools/build/*
 !lib/boost_*/tools/build/src*
+lib/boost_*/tools/build/src/engine/b2
+lib/boost_*/tools/build/src/engine/bjam
 lib/boost_*/user-config.jam
 
 # clang-tidy output

--- a/make/libraries
+++ b/make/libraries
@@ -186,19 +186,17 @@ $(BOOST)/user-config.jam:
 	echo "#using mpi : /path/to/mpicxx ;" >> $(BOOST)/user-config.jam
 	echo "using mpi ;" >> $(BOOST)/user-config.jam
 
-$(BOOST)/stage/lib/mpi.so: $(BOOST)/user-config.jam
+$(BOOST)/stage/lib/libboost_serialization.so $(BOOST)/stage/lib/libboost_mpi.so: $(BOOST)/user-config.jam
 	@mkdir -p $(dir $@)
 	cd $(BOOST); ./bootstrap.sh
 	cd $(BOOST); ./b2 --user-config=user-config.jam --layout=system --with-mpi --with-serialization -j$(BOOST_PARALLEL_JOBS) variant=release link=shared threading=multi runtime-link=shared hardcode-dll-paths=true dll-path="$(BOOST_LIBRARY_ABSOLUTE_PATH)" cxxstd=11
 
-$(BOOST)/stage/lib/libboost_serialization.so: $(BOOST)/stage/lib/mpi.so
-$(BOOST)/stage/lib/libboost_mpi.so: $(BOOST)/stage/lib/mpi.so
-
-
-$(BOOST)/stage/lib/libboost_serialization.dylib: $(BOOST)/stage/lib/mpi.so
+$(BOOST)/stage/lib/libboost_serialization.dylib $(BOOST)/stage/lib/libboost_mpi.dylib: $(BOOST)/user-config.jam
+	@mkdir -p $(dir $@)
+	cd $(BOOST); ./bootstrap.sh
+	cd $(BOOST); ./b2 --user-config=user-config.jam --layout=system --with-mpi --with-serialization -j$(BOOST_PARALLEL_JOBS) variant=release link=shared threading=multi runtime-link=shared hardcode-dll-paths=true dll-path="$(BOOST_LIBRARY_ABSOLUTE_PATH)" cxxstd=11
 	install_name_tool -add_rpath "$(BOOST_LIBRARY_ABSOLUTE_PATH)" "$(BOOST)/stage/lib/libboost_serialization.dylib"
 	install_name_tool -id @rpath/libboost_serialization.dylib "$(BOOST)/stage/lib/libboost_serialization.dylib"
-$(BOOST)/stage/lib/libboost_mpi.dylib: $(BOOST)/stage/lib/mpi.so $(BOOST)/stage/lib/libboost_serialization.dylib
 	install_name_tool -add_rpath "$(BOOST_LIBRARY_ABSOLUTE_PATH)" "$(BOOST)/stage/lib/libboost_mpi.dylib"
 	install_name_tool -change libboost_serialization.dylib @rpath/libboost_serialization.dylib "$(BOOST)/stage/lib/libboost_mpi.dylib"
 	install_name_tool -id @rpath/libboost_mpi.dylib "$(BOOST)/stage/lib/libboost_mpi.dylib"


### PR DESCRIPTION
## Summary

When building boost mpi, there are no `.so` targets that are built in the process. This may have been an update with a more recent boost. This causes boost to be rebuilt every time an mpi test is run.

This PR removes the intermediate libraries files and just has references to the `.dylib` files.

Note: I'm not certain if this patch is cross-platform compatible. I'm relying on Jenkins to give me an answer on that.

## Tests

No new tests. This is a build change, so there isn't code change.

I've run the steps outlined in #1999 multiple times and it works now. I've also build the targets directly to see that it behaves as expected.

## Side Effects

No.

## Release notes

N/A

## Checklist

- [x] Math issue #1999

- [x] Copyright holder: Generable

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
