### PR TITLE
Vectorise binary functions g-l

### DIFF
--- a/stan/math/fwd/fun/log_diff_exp.hpp
+++ b/stan/math/fwd/fun/log_diff_exp.hpp
@@ -23,7 +23,7 @@ inline fvar<T> log_diff_exp(const fvar<T>& x1, const fvar<T>& x2) {
       -(x1.d_ / expm1(x2.val_ - x1.val_) + x2.d_ / expm1(x1.val_ - x2.val_)));
 }
 
-template <typename T1, typename T2>
+template <typename T1, typename T2, require_arithmetic_t<T1>* = nullptr>
 inline fvar<T2> log_diff_exp(const T1& x1, const fvar<T2>& x2) {
   if (x1 <= x2.val_) {
     if (x1 < INFTY && x1 == x2.val_) {
@@ -34,7 +34,7 @@ inline fvar<T2> log_diff_exp(const T1& x1, const fvar<T2>& x2) {
   return fvar<T2>(log_diff_exp(x1, x2.val_), -x2.d_ / expm1(x1 - x2.val_));
 }
 
-template <typename T1, typename T2>
+template <typename T1, typename T2, require_arithmetic_t<T2>* = nullptr>
 inline fvar<T1> log_diff_exp(const fvar<T1>& x1, const T2& x2) {
   if (x1.val_ <= x2) {
     if (x1.val_ < INFTY && x1.val_ == x2) {

--- a/stan/math/prim/fun/gamma_p.hpp
+++ b/stan/math/prim/fun/gamma_p.hpp
@@ -64,8 +64,7 @@ namespace math {
    * @throws std::domain_error if either argument is not positive or
    * if z is at a pole of the function
  */
-template <typename T1, typename T2, require_all_arithmetic_t<T1, T2>* = nullptr>
-inline double gamma_p(T1 z, T2 a) {
+inline double gamma_p(double z, double a) {
   if (is_nan(z)) {
     return not_a_number();
   }

--- a/stan/math/prim/fun/gamma_p.hpp
+++ b/stan/math/prim/fun/gamma_p.hpp
@@ -5,6 +5,7 @@
 #include <stan/math/prim/fun/boost_policy.hpp>
 #include <stan/math/prim/fun/constants.hpp>
 #include <stan/math/prim/fun/is_nan.hpp>
+#include <stan/math/prim/functor/apply_scalar_binary.hpp>
 #include <boost/math/special_functions/gamma.hpp>
 
 namespace stan {
@@ -63,7 +64,8 @@ namespace math {
    * @throws std::domain_error if either argument is not positive or
    * if z is at a pole of the function
  */
-inline double gamma_p(double z, double a) {
+template <typename T1, typename T2, require_all_arithmetic_t<T1, T2>* = nullptr>
+inline double gamma_p(T1 z, T2 a) {
   if (is_nan(z)) {
     return not_a_number();
   }
@@ -73,6 +75,22 @@ inline double gamma_p(double z, double a) {
   check_positive("gamma_p", "first argument (z)", z);
   check_nonnegative("gamma_p", "second argument (a)", a);
   return boost::math::gamma_p(z, a, boost_policy_t<>());
+}
+
+/**
+ * Enables the vectorised application of the gamma_p function,
+ * when the first and/or second arguments are containers.
+ *
+ * @tparam T1 type of first input
+ * @tparam T2 type of second input
+ * @param a First input
+ * @param b Second input
+ * @return gamma_p function applied to the two inputs.
+ */
+template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
+inline auto gamma_p(const T1& a, const T2& b) {
+  return apply_scalar_binary(
+      a, b, [&](const auto& c, const auto& d) { return gamma_p(c, d); });
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/gamma_q.hpp
+++ b/stan/math/prim/fun/gamma_q.hpp
@@ -2,6 +2,7 @@
 #define STAN_MATH_PRIM_FUN_GAMMA_Q_HPP
 
 #include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/functor/apply_scalar_binary.hpp>
 #include <boost/math/special_functions/gamma.hpp>
 
 namespace stan {
@@ -51,7 +52,24 @@ namespace math {
    \f]
    * @throws domain_error if x is at pole
  */
-inline double gamma_q(double x, double a) { return boost::math::gamma_q(x, a); }
+template <typename T1, typename T2, require_all_arithmetic_t<T1, T2>* = nullptr>
+inline double gamma_q(T1 x, T2 a) { return boost::math::gamma_q(x, a); }
+
+/**
+ * Enables the vectorised application of the gamma_q function,
+ * when the first and/or second arguments are containers.
+ *
+ * @tparam T1 type of first input
+ * @tparam T2 type of second input
+ * @param a First input
+ * @param b Second input
+ * @return gamma_q function applied to the two inputs.
+ */
+template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
+inline auto gamma_q(const T1& a, const T2& b) {
+  return apply_scalar_binary(
+      a, b, [&](const auto& c, const auto& d) { return gamma_q(c, d); });
+}
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/prim/fun/gamma_q.hpp
+++ b/stan/math/prim/fun/gamma_q.hpp
@@ -53,7 +53,9 @@ namespace math {
    * @throws domain_error if x is at pole
  */
 template <typename T1, typename T2, require_all_arithmetic_t<T1, T2>* = nullptr>
-inline double gamma_q(T1 x, T2 a) { return boost::math::gamma_q(x, a); }
+inline double gamma_q(T1 x, T2 a) {
+  return boost::math::gamma_q(x, a);
+}
 
 /**
  * Enables the vectorised application of the gamma_q function,

--- a/stan/math/prim/fun/gamma_q.hpp
+++ b/stan/math/prim/fun/gamma_q.hpp
@@ -52,10 +52,7 @@ namespace math {
    \f]
    * @throws domain_error if x is at pole
  */
-template <typename T1, typename T2, require_all_arithmetic_t<T1, T2>* = nullptr>
-inline double gamma_q(T1 x, T2 a) {
-  return boost::math::gamma_q(x, a);
-}
+inline double gamma_q(double x, double a) { return boost::math::gamma_q(x, a); }
 
 /**
  * Enables the vectorised application of the gamma_q function,

--- a/stan/math/prim/fun/hypot.hpp
+++ b/stan/math/prim/fun/hypot.hpp
@@ -2,6 +2,7 @@
 #define STAN_MATH_PRIM_FUN_HYPOT_HPP
 
 #include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/functor/apply_scalar_binary.hpp>
 #include <cmath>
 
 namespace stan {
@@ -19,10 +20,26 @@ namespace math {
  * @return Length of hypotenuse of right triangle with opposite
  * and adjacent side lengths x and y.
  */
-template <typename T1, typename T2, typename = require_all_arithmetic_t<T1, T2>>
+template <typename T1, typename T2, require_all_arithmetic_t<T1, T2>* = nullptr>
 inline double hypot(T1 x, T2 y) {
   using std::hypot;
   return hypot(x, y);
+}
+
+/**
+ * Enables the vectorised application of the hypot function,
+ * when the first and/or second arguments are containers.
+ *
+ * @tparam T1 type of first input
+ * @tparam T2 type of second input
+ * @param a First input
+ * @param b Second input
+ * @return hypot function applied to the two inputs.
+ */
+template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
+inline auto hypot(const T1& a, const T2& b) {
+  return apply_scalar_binary(
+      a, b, [&](const auto& c, const auto& d) { return hypot(c, d); });
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/lbeta.hpp
+++ b/stan/math/prim/fun/lbeta.hpp
@@ -10,6 +10,7 @@
 #include <stan/math/prim/fun/lgamma_stirling_diff.hpp>
 #include <stan/math/prim/fun/log.hpp>
 #include <stan/math/prim/fun/log1m.hpp>
+#include <stan/math/prim/functor/apply_scalar_binary.hpp>
 
 namespace stan {
 namespace math {
@@ -60,7 +61,7 @@ namespace math {
  * @param b Second value
  * @return Log of the beta function applied to the two values.
  */
-template <typename T1, typename T2>
+template <typename T1, typename T2, require_all_arithmetic_t<T1, T2>* = nullptr>
 return_type_t<T1, T2> lbeta(const T1 a, const T2 b) {
   using T_ret = return_type_t<T1, T2>;
 
@@ -113,6 +114,22 @@ return_type_t<T1, T2> lbeta(const T1 a, const T2 b) {
   T_ret stirling = (x - 0.5) * log(x_over_xy) + y * log1m(x_over_xy)
                    + HALF_LOG_TWO_PI - 0.5 * log(y);
   return stirling + stirling_diff;
+}
+
+/**
+ * Enables the vectorised application of the lbeta function,
+ * when the first and/or second arguments are containers.
+ *
+ * @tparam T1 type of first input
+ * @tparam T2 type of second input
+ * @param a First input
+ * @param b Second input
+ * @return lbeta function applied to the two inputs.
+ */
+template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
+inline auto lbeta(const T1& a, const T2& b) {
+  return apply_scalar_binary(
+      a, b, [&](const auto& c, const auto& d) { return lbeta(c, d); });
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/ldexp.hpp
+++ b/stan/math/prim/fun/ldexp.hpp
@@ -2,6 +2,7 @@
 #define STAN_MATH_PRIM_FUN_LDEXP_HPP
 
 #include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/functor/apply_scalar_binary.hpp>
 #include <cmath>
 
 namespace stan {
@@ -16,10 +17,26 @@ namespace math {
  * @param[in] b an integer that is the exponent
  * @return product of a times 2 to the power b
  */
-template <typename T1, typename = require_arithmetic_t<T1>>
+template <typename T1, require_arithmetic_t<T1>* = nullptr>
 inline double ldexp(T1 a, int b) {
   using std::ldexp;
   return ldexp(a, b);
+}
+
+/**
+ * Enables the vectorised application of the ldexp function,
+ * when the first and/or second arguments are containers.
+ *
+ * @tparam T1 type of first input
+ * @tparam T2 type of second input
+ * @param a First input
+ * @param b Second input
+ * @return ldexp function applied to the two inputs.
+ */
+template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
+inline auto ldexp(const T1& a, const T2& b) {
+  return apply_scalar_binary(
+      a, b, [&](const auto& c, const auto& d) { return ldexp(c, d); });
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/lmgamma.hpp
+++ b/stan/math/prim/fun/lmgamma.hpp
@@ -59,20 +59,20 @@ inline return_type_t<T> lmgamma(int k, T x) {
 }
 
 /**
- * Enables the vectorised application of the natural log of the multivariate gamma
- * function, when the first and/or second arguments are containers.
+ * Enables the vectorised application of the natural log of the multivariate
+ * gamma function, when the first and/or second arguments are containers.
  *
  * @tparam T1 type of first input
  * @tparam T2 type of second input
  * @param a First input
  * @param b Second input
- * @return Natural log of the multivariate gamma function applied to the two inputs.
+ * @return Natural log of the multivariate gamma function applied to the two
+ * inputs.
  */
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
 inline auto lmgamma(const T1& a, const T2& b) {
-  return apply_scalar_binary(a, b, [&](const auto& c, const auto& d) {
-    return lmgamma(c, d);
-  });
+  return apply_scalar_binary(
+      a, b, [&](const auto& c, const auto& d) { return lmgamma(c, d); });
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/log_diff_exp.hpp
+++ b/stan/math/prim/fun/log_diff_exp.hpp
@@ -4,6 +4,7 @@
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/fun/log1m_exp.hpp>
 #include <stan/math/prim/fun/constants.hpp>
+#include <stan/math/prim/functor/apply_scalar_binary.hpp>
 
 namespace stan {
 namespace math {
@@ -46,12 +47,28 @@ namespace math {
  * @param x first argument
  * @param y second argument
  */
-template <typename T1, typename T2>
+template <typename T1, typename T2, require_all_arithmetic_t<T1, T2>* = nullptr>
 inline return_type_t<T1, T2> log_diff_exp(const T1 x, const T2 y) {
   if (x <= y) {
     return (x < INFTY && x == y) ? NEGATIVE_INFTY : NOT_A_NUMBER;
   }
   return x + log1m_exp(y - x);
+}
+
+/**
+ * Enables the vectorised application of the log_diff_exp function,
+ * when the first and/or second arguments are containers.
+ *
+ * @tparam T1 type of first input
+ * @tparam T2 type of second input
+ * @param a First input
+ * @param b Second input
+ * @return log_diff_exp function applied to the two inputs.
+ */
+template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
+inline auto log_diff_exp(const T1& a, const T2& b) {
+  return apply_scalar_binary(
+      a, b, [&](const auto& c, const auto& d) { return log_diff_exp(c, d); });
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/log_falling_factorial.hpp
+++ b/stan/math/prim/fun/log_falling_factorial.hpp
@@ -73,9 +73,9 @@ inline return_type_t<T1, T2> log_falling_factorial(const T1 x, const T2 n) {
  */
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
 inline auto log_falling_factorial(const T1& a, const T2& b) {
-  return apply_scalar_binary(
-      a, b, [&](const auto& c, const auto& d) {
-        return log_falling_factorial(c, d); });
+  return apply_scalar_binary(a, b, [&](const auto& c, const auto& d) {
+    return log_falling_factorial(c, d);
+  });
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/log_falling_factorial.hpp
+++ b/stan/math/prim/fun/log_falling_factorial.hpp
@@ -6,6 +6,7 @@
 #include <stan/math/prim/fun/is_any_nan.hpp>
 #include <stan/math/prim/fun/lgamma.hpp>
 #include <stan/math/prim/fun/constants.hpp>
+#include <stan/math/prim/functor/apply_scalar_binary.hpp>
 
 namespace stan {
 namespace math {
@@ -50,7 +51,7 @@ namespace math {
  * @throw std::domain_error if the first argument is not
  * positive
  */
-template <typename T1, typename T2>
+template <typename T1, typename T2, require_all_arithmetic_t<T1, T2>* = nullptr>
 inline return_type_t<T1, T2> log_falling_factorial(const T1 x, const T2 n) {
   if (is_any_nan(x, n)) {
     return NOT_A_NUMBER;
@@ -58,6 +59,23 @@ inline return_type_t<T1, T2> log_falling_factorial(const T1 x, const T2 n) {
   static const char* function = "log_falling_factorial";
   check_positive(function, "first argument", x);
   return lgamma(x + 1) - lgamma(x - n + 1);
+}
+
+/**
+ * Enables the vectorised application of the log_falling_factorial function,
+ * when the first and/or second arguments are containers.
+ *
+ * @tparam T1 type of first input
+ * @tparam T2 type of second input
+ * @param a First input
+ * @param b Second input
+ * @return log_falling_factorial function applied to the two inputs.
+ */
+template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
+inline auto log_falling_factorial(const T1& a, const T2& b) {
+  return apply_scalar_binary(
+      a, b, [&](const auto& c, const auto& d) {
+        return log_falling_factorial(c, d); });
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/log_inv_logit_diff.hpp
+++ b/stan/math/prim/fun/log_inv_logit_diff.hpp
@@ -49,9 +49,9 @@ inline return_type_t<T1, T2> log_inv_logit_diff(const T1& x, const T2& y) {
  */
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
 inline auto log_inv_logit_diff(const T1& a, const T2& b) {
-  return apply_scalar_binary(
-      a, b, [&](const auto& c, const auto& d) {
-        return log_inv_logit_diff(c, d); });
+  return apply_scalar_binary(a, b, [&](const auto& c, const auto& d) {
+    return log_inv_logit_diff(c, d);
+  });
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/log_inv_logit_diff.hpp
+++ b/stan/math/prim/fun/log_inv_logit_diff.hpp
@@ -4,6 +4,7 @@
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/fun/log1m_exp.hpp>
 #include <stan/math/prim/fun/log1p_exp.hpp>
+#include <stan/math/prim/functor/apply_scalar_binary.hpp>
 
 namespace stan {
 namespace math {
@@ -31,9 +32,26 @@ namespace math {
  * @param y second argument
  * @return Result of log difference of inverse logits of arguments.
  */
-template <typename T1, typename T2>
+template <typename T1, typename T2, require_all_arithmetic_t<T1, T2>* = nullptr>
 inline return_type_t<T1, T2> log_inv_logit_diff(const T1& x, const T2& y) {
   return x - log1p_exp(x) + log1m_exp(y - x) - log1p_exp(y);
+}
+
+/**
+ * Enables the vectorised application of the log_inv_logit_diff function,
+ * when the first and/or second arguments are containers.
+ *
+ * @tparam T1 type of first input
+ * @tparam T2 type of second input
+ * @param a First input
+ * @param b Second input
+ * @return log_inv_logit_diff function applied to the two inputs.
+ */
+template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
+inline auto log_inv_logit_diff(const T1& a, const T2& b) {
+  return apply_scalar_binary(
+      a, b, [&](const auto& c, const auto& d) {
+        return log_inv_logit_diff(c, d); });
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/log_modified_bessel_first_kind.hpp
+++ b/stan/math/prim/fun/log_modified_bessel_first_kind.hpp
@@ -20,6 +20,7 @@
 #include <stan/math/prim/fun/log1p_exp.hpp>
 #include <stan/math/prim/fun/sqrt.hpp>
 #include <stan/math/prim/fun/square.hpp>
+#include <stan/math/prim/functor/apply_scalar_binary.hpp>
 #include <boost/math/tools/rational.hpp>
 #include <cmath>
 
@@ -40,7 +41,8 @@ namespace math {
  * negative, or v is less than -1
  * @return log of Bessel I function
  */
-template <typename T1, typename T2>
+template <typename T1, typename T2,
+          require_all_stan_scalar_t<T1, T2>* = nullptr>
 inline return_type_t<T1, T2, double> log_modified_bessel_first_kind(
     const T1 v, const T2 z) {
   check_not_nan("log_modified_bessel_first_kind", "first argument (order)", v);
@@ -215,6 +217,23 @@ inline return_type_t<T1, T2, double> log_modified_bessel_first_kind(
     m++;
   } while (out > old_out || out < old_out);
   return out;
+}
+
+/**
+ * Enables the vectorised application of the log_modified_bessel_first_kind
+ * function, when the first and/or second arguments are containers.
+ *
+ * @tparam T1 type of first input
+ * @tparam T2 type of second input
+ * @param a First input
+ * @param b Second input
+ * @return log_modified_bessel_first_kind function applied to the two inputs.
+ */
+template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
+inline auto log_modified_bessel_first_kind(const T1& a, const T2& b) {
+  return apply_scalar_binary(
+      a, b, [&](const auto& c, const auto& d) {
+        return log_modified_bessel_first_kind(c, d); });
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/log_modified_bessel_first_kind.hpp
+++ b/stan/math/prim/fun/log_modified_bessel_first_kind.hpp
@@ -231,9 +231,9 @@ inline return_type_t<T1, T2, double> log_modified_bessel_first_kind(
  */
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
 inline auto log_modified_bessel_first_kind(const T1& a, const T2& b) {
-  return apply_scalar_binary(
-      a, b, [&](const auto& c, const auto& d) {
-        return log_modified_bessel_first_kind(c, d); });
+  return apply_scalar_binary(a, b, [&](const auto& c, const auto& d) {
+    return log_modified_bessel_first_kind(c, d);
+  });
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/log_rising_factorial.hpp
+++ b/stan/math/prim/fun/log_rising_factorial.hpp
@@ -71,9 +71,9 @@ inline return_type_t<T1, T2> log_rising_factorial(const T1& x, const T2& n) {
  */
 template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
 inline auto log_rising_factorial(const T1& a, const T2& b) {
-  return apply_scalar_binary(
-      a, b, [&](const auto& c, const auto& d) {
-        return log_rising_factorial(c, d); });
+  return apply_scalar_binary(a, b, [&](const auto& c, const auto& d) {
+    return log_rising_factorial(c, d);
+  });
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/log_rising_factorial.hpp
+++ b/stan/math/prim/fun/log_rising_factorial.hpp
@@ -6,6 +6,7 @@
 #include <stan/math/prim/fun/constants.hpp>
 #include <stan/math/prim/fun/is_any_nan.hpp>
 #include <stan/math/prim/fun/lgamma.hpp>
+#include <stan/math/prim/functor/apply_scalar_binary.hpp>
 
 namespace stan {
 namespace math {
@@ -48,7 +49,7 @@ namespace math {
  * @return natural logarithm of the rising factorial from x to n
  * @throw std::domain_error if the first argument is not positive
  */
-template <typename T1, typename T2>
+template <typename T1, typename T2, require_all_arithmetic_t<T1, T2>* = nullptr>
 inline return_type_t<T1, T2> log_rising_factorial(const T1& x, const T2& n) {
   if (is_any_nan(x, n)) {
     return NOT_A_NUMBER;
@@ -56,6 +57,23 @@ inline return_type_t<T1, T2> log_rising_factorial(const T1& x, const T2& n) {
   static const char* function = "log_rising_factorial";
   check_positive(function, "first argument", x);
   return lgamma(x + n) - lgamma(x);
+}
+
+/**
+ * Enables the vectorised application of the log_rising_factorial
+ * function, when the first and/or second arguments are containers.
+ *
+ * @tparam T1 type of first input
+ * @tparam T2 type of second input
+ * @param a First input
+ * @param b Second input
+ * @return log_rising_factorial function applied to the two inputs.
+ */
+template <typename T1, typename T2, require_any_container_t<T1, T2>* = nullptr>
+inline auto log_rising_factorial(const T1& a, const T2& b) {
+  return apply_scalar_binary(
+      a, b, [&](const auto& c, const auto& d) {
+        return log_rising_factorial(c, d); });
 }
 
 }  // namespace math

--- a/stan/math/prim/functor/apply_scalar_binary.hpp
+++ b/stan/math/prim/functor/apply_scalar_binary.hpp
@@ -6,6 +6,8 @@
 #include <stan/math/prim/meta/is_container.hpp>
 #include <stan/math/prim/meta/is_eigen.hpp>
 #include <stan/math/prim/meta/require_generics.hpp>
+#include <stan/math/prim/err/check_matching_dims.hpp>
+#include <stan/math/prim/err/check_matching_sizes.hpp>
 #include <stan/math/prim/fun/num_elements.hpp>
 #include <vector>
 

--- a/test/unit/math/mix/fun/gamma_p_test.cpp
+++ b/test/unit/math/mix/fun/gamma_p_test.cpp
@@ -92,3 +92,16 @@ TEST(mathMixScalFun, gammaP_pos_inf) {
     }
   }
 }
+
+TEST(mathMixScalFun, gammaP_vec) {
+  auto f = [](const auto& x1, const auto& x2) {
+    using stan::math::gamma_p;
+    return gamma_p(x1, x2);
+  };
+
+  Eigen::VectorXd in1(2);
+  in1 << 3, 1;
+  Eigen::VectorXd in2(2);
+  in2 << 0.5, 3.4;
+  stan::test::expect_ad_vectorized_binary(f, in1, in2);
+}

--- a/test/unit/math/mix/fun/gamma_q_test.cpp
+++ b/test/unit/math/mix/fun/gamma_q_test.cpp
@@ -17,3 +17,16 @@ TEST(mathMixScalFun, gammaQ) {
   // this still fails forward mode; left regression test in rev/fun
   // stan::test::expect_value(f, 8.01006, 2.47579e+215);
 }
+
+TEST(MathFunctions, gammaQ_vec) {
+  auto f = [](const auto& x1, const auto& x2) {
+    using stan::math::gamma_q;
+    return gamma_q(x1, x2);
+  };
+
+  Eigen::VectorXd in1(2);
+  in1 << 3, 1;
+  Eigen::VectorXd in2(2);
+  in2 << 0.5, 3.4;
+  stan::test::expect_ad_vectorized_binary(f, in1, in2);
+}

--- a/test/unit/math/mix/fun/hypot_test.cpp
+++ b/test/unit/math/mix/fun/hypot_test.cpp
@@ -11,3 +11,16 @@ TEST(mathMixScalFun, hypot) {
   stan::test::expect_ad(f, 3.0, 4.0);
   stan::test::expect_ad(f, 3.0, 6.0);
 }
+
+TEST(mathMixScalFun, hypot_vec) {
+  auto f = [](const auto& x1, const auto& x2) {
+    using stan::math::hypot;
+    return hypot(x1, x2);
+  };
+
+  Eigen::VectorXd in1(2);
+  in1 << 3, 1;
+  Eigen::VectorXd in2(2);
+  in2 << 0.5, 3.4;
+  stan::test::expect_ad_vectorized_binary(f, in1, in2);
+}

--- a/test/unit/math/mix/fun/lbeta_test.cpp
+++ b/test/unit/math/mix/fun/lbeta_test.cpp
@@ -16,3 +16,16 @@ TEST(mathMixScalFun, lbeta) {
   stan::test::expect_ad(f, 7.5, 1.8);
   stan::test::expect_ad(f, 12.3, 4.8);
 }
+
+TEST(mathMixScalFun, lbeta_vec) {
+  auto f = [](const auto& x1, const auto& x2) {
+    using stan::math::lbeta;
+    return lbeta(x1, x2);
+  };
+
+  Eigen::VectorXd in1(2);
+  in1 << 3, 1;
+  Eigen::VectorXd in2(2);
+  in2 << 0.5, 3.4;
+  stan::test::expect_ad_vectorized_binary(f, in1, in2);
+}

--- a/test/unit/math/mix/fun/ldexp_test.cpp
+++ b/test/unit/math/mix/fun/ldexp_test.cpp
@@ -10,3 +10,19 @@ TEST(mathMixScalFun, ldexp) {
   stan::test::expect_ad(f, stan::math::INFTY);
   stan::test::expect_ad(f, stan::math::NOT_A_NUMBER);
 }
+
+TEST(mathMixScalFun, ldexp_vec) {
+  auto f = [](const auto& x1, const auto& x2) {
+    using stan::math::ldexp;
+    return ldexp(x1, x2);
+  };
+
+  Eigen::VectorXd in1(2);
+  in1 << 0.5, 3.4;
+  std::vector<int> std_in2{3, 1};
+  stan::test::expect_ad_vectorized_binary(f, in1, std_in2);
+
+  Eigen::MatrixXd mat_in1 = in1.replicate(1, 2);
+  std::vector<std::vector<int>> std_std_in2{std_in2, std_in2};
+  stan::test::expect_ad_vectorized_binary(f, mat_in1, std_std_in2);
+}

--- a/test/unit/math/mix/fun/lmgamma_test.cpp
+++ b/test/unit/math/mix/fun/lmgamma_test.cpp
@@ -8,3 +8,19 @@ TEST(mathMixScalFun, lmgamma) {
   stan::test::expect_ad(f(3), 3.2);
   stan::test::expect_ad(f(3), std::numeric_limits<double>::quiet_NaN());
 }
+
+TEST(mathMixScalFun, lmgamma_vec) {
+  auto f = [](const auto& x1, const auto& x2) {
+    using stan::math::lmgamma;
+    return lmgamma(x1, x2);
+  };
+
+  std::vector<int> std_in1{3, 1};
+  Eigen::VectorXd in2(2);
+  in2 << 3.2, 3.4;
+  stan::test::expect_ad_vectorized_binary(f, std_in1, in2);
+
+  std::vector<std::vector<int>> std_std_in1{std_in1, std_in1};
+  Eigen::MatrixXd mat_in2 = in2.replicate(1, 2);
+  stan::test::expect_ad_vectorized_binary(f, std_std_in1, mat_in2);
+}

--- a/test/unit/math/mix/fun/log_diff_exp_test.cpp
+++ b/test/unit/math/mix/fun/log_diff_exp_test.cpp
@@ -27,3 +27,16 @@ TEST(mathMixScalFun, logDiffExp) {
   stan::test::expect_ad(f, nan, 1.0);
   stan::test::expect_ad(f, nan, nan);
 }
+
+TEST(mathMixScalFun, logDiffExp_vec) {
+  auto f = [](const auto& x1, const auto& x2) {
+    using stan::math::log_diff_exp;
+    return log_diff_exp(x1, x2);
+  };
+
+  Eigen::VectorXd in1(2);
+  in1 << 3, 1;
+  Eigen::VectorXd in2(2);
+  in2 << 0.5, 3.4;
+  stan::test::expect_ad_vectorized_binary(f, in1, in2);
+}

--- a/test/unit/math/mix/fun/log_falling_factorial_test.cpp
+++ b/test/unit/math/mix/fun/log_falling_factorial_test.cpp
@@ -26,3 +26,16 @@ TEST(mathMixScalFun, logFallingFactorial) {
   stan::test::expect_ad(f, nan, 4.0);
   stan::test::expect_ad(f, nan, nan);
 }
+
+TEST(mathMixScalFun, logFallingFactorial_vec) {
+  auto f = [](const auto& x1, const auto& x2) {
+    using stan::math::log_falling_factorial;
+    return log_falling_factorial(x1, x2);
+  };
+
+  Eigen::VectorXd in1(2);
+  in1 << 3, 1;
+  Eigen::VectorXd in2(2);
+  in2 << 0.5, 3.4;
+  stan::test::expect_ad_vectorized_binary(f, in1, in2);
+}

--- a/test/unit/math/mix/fun/log_inv_logit_diff_test.cpp
+++ b/test/unit/math/mix/fun/log_inv_logit_diff_test.cpp
@@ -15,3 +15,16 @@ TEST(mathMixScalFun, logInvLogitDiff) {
   stan::test::expect_ad(f, nan, 1.0);
   stan::test::expect_ad(f, nan, nan);
 }
+
+TEST(mathMixScalFun, logInvLogitDiff_vec) {
+  auto f = [](const auto& x1, const auto& x2) {
+    using stan::math::log_inv_logit_diff;
+    return log_inv_logit_diff(x1, x2);
+  };
+
+  Eigen::VectorXd in1(2);
+  in1 << 3, 1;
+  Eigen::VectorXd in2(2);
+  in2 << 0.5, -3.4;
+  stan::test::expect_ad_vectorized_binary(f, in1, in2);
+}

--- a/test/unit/math/mix/fun/log_modified_bessel_first_kind_test.cpp
+++ b/test/unit/math/mix/fun/log_modified_bessel_first_kind_test.cpp
@@ -14,3 +14,16 @@ TEST(mathMixScalFun, logModifiedBesselFirstKind) {
     for (double x2 : xs)
       stan::test::expect_ad(f, x1, x2);
 }
+
+TEST(mathMixScalFun, logModifiedBesselFirstKind_vec) {
+  auto f = [](const auto& x1, const auto& x2) {
+    using stan::math::log_modified_bessel_first_kind;
+    return log_modified_bessel_first_kind(x1, x2);
+  };
+
+  Eigen::VectorXd in1(2);
+  in1 << -1.3, 0.5;
+  Eigen::VectorXd in2(2);
+  in2 << 0.5, 3.4;
+  stan::test::expect_ad_vectorized_binary(f, in1, in2);
+}

--- a/test/unit/math/mix/fun/log_rising_factorial_test.cpp
+++ b/test/unit/math/mix/fun/log_rising_factorial_test.cpp
@@ -25,3 +25,16 @@ TEST(mathMixScalFun, logRisingFactorial) {
   stan::test::expect_ad(f, nan, 4.0);
   stan::test::expect_ad(f, nan, nan);
 }
+
+TEST(mathMixScalFun, logRisingFactorial_vec) {
+  auto f = [](const auto& x1, const auto& x2) {
+    using stan::math::log_rising_factorial;
+    return log_rising_factorial(x1, x2);
+  };
+
+  Eigen::VectorXd in1(2);
+  in1 << 3, 1;
+  Eigen::VectorXd in2(2);
+  in2 << 0.5, 3.4;
+  stan::test::expect_ad_vectorized_binary(f, in1, in2);
+}

--- a/test/unit/math/prim/fun/gamma_p_test.cpp
+++ b/test/unit/math/prim/fun/gamma_p_test.cpp
@@ -1,4 +1,5 @@
 #include <stan/math/prim.hpp>
+#include <test/unit/math/prim/fun/binary_scalar_tester.hpp>
 #include <gtest/gtest.h>
 #include <cmath>
 #include <limits>
@@ -25,4 +26,17 @@ TEST(MathFunctions, gamma_p_nan) {
   EXPECT_TRUE(std::isnan(stan::math::gamma_p(nan, 1.0)));
 
   EXPECT_TRUE(std::isnan(stan::math::gamma_p(nan, nan)));
+}
+
+TEST(MathFunctions, gamma_p_vec) {
+  auto f = [](const auto& x1, const auto& x2) {
+    using stan::math::gamma_p;
+    return gamma_p(x1, x2);
+  };
+
+  Eigen::VectorXd in1(3);
+  in1 << 1.8, 3.24, 1.8;
+  Eigen::VectorXd in2(3);
+  in2 << 1.3, 0.7, 2.8;
+  stan::test::binary_scalar_tester(f, in1, in2);
 }

--- a/test/unit/math/prim/fun/gamma_q_test.cpp
+++ b/test/unit/math/prim/fun/gamma_q_test.cpp
@@ -1,4 +1,5 @@
 #include <stan/math/prim.hpp>
+#include <test/unit/math/prim/fun/binary_scalar_tester.hpp>
 #include <gtest/gtest.h>
 #include <cmath>
 #include <limits>
@@ -22,4 +23,17 @@ TEST(MathFunctions, gamma_q_nan) {
   EXPECT_TRUE(std::isnan(stan::math::gamma_q(nan, 1.0)));
 
   EXPECT_TRUE(std::isnan(stan::math::gamma_q(nan, nan)));
+}
+
+TEST(MathFunctions, gamma_q_vec) {
+  auto f = [](const auto& x1, const auto& x2) {
+    using stan::math::gamma_q;
+    return gamma_q(x1, x2);
+  };
+
+  Eigen::VectorXd in1(3);
+  in1 << 1.8, 3.24, 1.8;
+  Eigen::VectorXd in2(3);
+  in2 << 1.3, 0.7, 2.8;
+  stan::test::binary_scalar_tester(f, in1, in2);
 }

--- a/test/unit/math/prim/fun/hypot_test.cpp
+++ b/test/unit/math/prim/fun/hypot_test.cpp
@@ -1,4 +1,5 @@
 #include <stan/math/prim.hpp>
+#include <test/unit/math/prim/fun/binary_scalar_tester.hpp>
 #include <gtest/gtest.h>
 #include <cmath>
 #include <limits>
@@ -41,4 +42,17 @@ TEST(MathFunctions, hypotNaN) {
   EXPECT_TRUE(std::isnan(stan::math::hypot(nan, 3.0)));
 
   EXPECT_TRUE(std::isnan(stan::math::hypot(nan, nan)));
+}
+
+TEST(MathFunctions, hypot_vec) {
+  auto f = [](const auto& x1, const auto& x2) {
+    using stan::math::hypot;
+    return hypot(x1, x2);
+  };
+
+  Eigen::VectorXd in1(3);
+  in1 << 1.8, 3.24, 1.8;
+  Eigen::VectorXd in2(3);
+  in2 << -1.3, 0.7, 2.8;
+  stan::test::binary_scalar_tester(f, in1, in2);
 }

--- a/test/unit/math/prim/fun/lbeta_test.cpp
+++ b/test/unit/math/prim/fun/lbeta_test.cpp
@@ -1,4 +1,5 @@
 #include <stan/math/prim.hpp>
+#include <test/unit/math/prim/fun/binary_scalar_tester.hpp>
 #include <gtest/gtest.h>
 #include <cmath>
 #include <limits>
@@ -109,4 +110,17 @@ TEST(MathFunctions, lbeta_stirling_cutoff) {
         << "diff before and after cutoff: x = " << x << "; before = " << before
         << "; at = " << at << "; after = " << after;
   }
+}
+
+TEST(MathFunctions, lbeta_vec) {
+  auto f = [](const auto& x1, const auto& x2) {
+    using stan::math::lbeta;
+    return lbeta(x1, x2);
+  };
+
+  Eigen::VectorXd in1(3);
+  in1 << 1.8, 3.24, 1.8;
+  Eigen::VectorXd in2(3);
+  in2 << 1.3, 0.7, 2.8;
+  stan::test::binary_scalar_tester(f, in1, in2);
 }

--- a/test/unit/math/prim/fun/ldexp_test.cpp
+++ b/test/unit/math/prim/fun/ldexp_test.cpp
@@ -1,4 +1,5 @@
 #include <stan/math/prim.hpp>
+#include <test/unit/math/prim/fun/binary_scalar_tester.hpp>
 #include <gtest/gtest.h>
 #include <cmath>
 #include <limits>
@@ -33,4 +34,20 @@ TEST(MathFunctions, ldexp_nan) {
   double nan = std::numeric_limits<double>::quiet_NaN();
 
   EXPECT_TRUE(std::isnan(stan::math::ldexp(nan, 5)));
+}
+
+TEST(MathFunctions, ldexp_vec) {
+  auto f = [](const auto& x1, const auto& x2) {
+    using stan::math::ldexp;
+    return ldexp(x1, x2);
+  };
+
+  Eigen::VectorXd in1(3);
+  in1 << -1.3, 0.7, 2.8;
+  std::vector<int> std_in2{1, 3, 1};
+  stan::test::binary_scalar_tester(f, in1, std_in2);
+
+  Eigen::MatrixXd mat_in1 = in1.replicate(1, 3);
+  std::vector<std::vector<int>> std_std_in2{std_in2, std_in2, std_in2};
+  stan::test::binary_scalar_tester(f, mat_in1, std_std_in2);
 }

--- a/test/unit/math/prim/fun/lmgamma_test.cpp
+++ b/test/unit/math/prim/fun/lmgamma_test.cpp
@@ -1,4 +1,5 @@
 #include <stan/math/prim.hpp>
+#include <test/unit/math/prim/fun/binary_scalar_tester.hpp>
 #include <gtest/gtest.h>
 #include <cmath>
 #include <limits>
@@ -25,4 +26,20 @@ TEST(MathFunctions, lmgamma_nan) {
   double nan = std::numeric_limits<double>::quiet_NaN();
 
   EXPECT_TRUE(std::isnan(stan::math::lmgamma(2, nan)));
+}
+
+TEST(MathFunctions, lmgamma_vec) {
+  auto f = [](const auto& x1, const auto& x2) {
+    using stan::math::lmgamma;
+    return lmgamma(x1, x2);
+  };
+
+  std::vector<int> std_in1{1, 3, 1};
+  Eigen::VectorXd in2(3);
+  in2 << -1.3, 0.7, 2.8;
+  stan::test::binary_scalar_tester(f, std_in1, in2);
+
+  std::vector<std::vector<int>> std_std_in1{std_in1, std_in1, std_in1};
+  Eigen::MatrixXd mat_in2 = in2.replicate(1, 3);
+  stan::test::binary_scalar_tester(f, std_std_in1, mat_in2);
 }

--- a/test/unit/math/prim/fun/log_diff_exp_test.cpp
+++ b/test/unit/math/prim/fun/log_diff_exp_test.cpp
@@ -1,4 +1,5 @@
 #include <stan/math/prim.hpp>
+#include <test/unit/math/prim/fun/binary_scalar_tester.hpp>
 #include <gtest/gtest.h>
 #include <cmath>
 #include <limits>
@@ -50,4 +51,17 @@ TEST(MathFunctions, log_diff_exp_nan) {
   EXPECT_TRUE(std::isnan(stan::math::log_diff_exp(nan, 2.0)));
 
   EXPECT_TRUE(std::isnan(stan::math::log_diff_exp(nan, nan)));
+}
+
+TEST(MathFunctions, log_diff_exp_vec) {
+  auto f = [](const auto& x1, const auto& x2) {
+    using stan::math::log_diff_exp;
+    return log_diff_exp(x1, x2);
+  };
+
+  Eigen::VectorXd in1(3);
+  in1 << 4.1, 3.24, 6.8;
+  Eigen::VectorXd in2(3);
+  in2 << 2.8, 1.7, 3.1;
+  stan::test::binary_scalar_tester(f, in1, in2);
 }

--- a/test/unit/math/prim/fun/log_falling_factorial_test.cpp
+++ b/test/unit/math/prim/fun/log_falling_factorial_test.cpp
@@ -1,4 +1,5 @@
 #include <stan/math/prim.hpp>
+#include <test/unit/math/prim/fun/binary_scalar_tester.hpp>
 #include <gtest/gtest.h>
 #include <cmath>
 #include <limits>
@@ -16,4 +17,17 @@ TEST(MathFunctions, log_falling_factorial_nan) {
   double nan = std::numeric_limits<double>::quiet_NaN();
 
   EXPECT_TRUE(std::isnan(stan::math::log_falling_factorial(nan, 3)));
+}
+
+TEST(MathFunctions, log_falling_factorial_vec) {
+  auto f = [](const auto& x1, const auto& x2) {
+    using stan::math::log_falling_factorial;
+    return log_falling_factorial(x1, x2);
+  };
+
+  Eigen::VectorXd in1(3);
+  in1 << 1.8, 3.24, 1.8;
+  Eigen::VectorXd in2(3);
+  in2 << 5.3, 0.7, 2.8;
+  stan::test::binary_scalar_tester(f, in1, in2);
 }

--- a/test/unit/math/prim/fun/log_inv_logit_diff_test.cpp
+++ b/test/unit/math/prim/fun/log_inv_logit_diff_test.cpp
@@ -1,4 +1,5 @@
 #include <stan/math/prim.hpp>
+#include <test/unit/math/prim/fun/binary_scalar_tester.hpp>
 #include <gtest/gtest.h>
 #include <cmath>
 
@@ -14,4 +15,17 @@ TEST(MathFunctions, log_inv_logit_diff_nan) {
   using stan::math::NOT_A_NUMBER;
 
   EXPECT_TRUE(std::isnan(log_inv_logit_diff(NOT_A_NUMBER, 2.16)));
+}
+
+TEST(MathFunctions, log_inv_logit_diff_vec) {
+  auto f = [](const auto& x1, const auto& x2) {
+    using stan::math::log_inv_logit_diff;
+    return log_inv_logit_diff(x1, x2);
+  };
+
+  Eigen::VectorXd in1(3);
+  in1 << 1.8, 3.24, 4.2;
+  Eigen::VectorXd in2(3);
+  in2 << 0.3, 0.7, -2.8;
+  stan::test::binary_scalar_tester(f, in1, in2);
 }

--- a/test/unit/math/prim/fun/log_modified_bessel_first_kind_test.cpp
+++ b/test/unit/math/prim/fun/log_modified_bessel_first_kind_test.cpp
@@ -1,4 +1,5 @@
 #include <stan/math/prim.hpp>
+#include <test/unit/math/prim/fun/binary_scalar_tester.hpp>
 #include <boost/math/special_functions/bessel.hpp>
 #include <gtest/gtest.h>
 #include <limits>
@@ -76,4 +77,17 @@ TEST(MathFunctions, log_modified_bessel_first_kind_throw) {
   EXPECT_THROW(log_modified_bessel_first_kind(nan, 1), std::domain_error);
   EXPECT_THROW(log_modified_bessel_first_kind(.5, -2), std::domain_error);
   EXPECT_THROW(log_modified_bessel_first_kind(-2, 1), std::domain_error);
+}
+
+TEST(MathFunctions, log_modified_bessel_first_kind_vec) {
+  auto f = [](const auto& x1, const auto& x2) {
+    using stan::math::log_modified_bessel_first_kind;
+    return log_modified_bessel_first_kind(x1, x2);
+  };
+
+  Eigen::VectorXd in1(3);
+  in1 << 1.8, 3.24, 1.8;
+  Eigen::VectorXd in2(3);
+  in2 << 7.3, 0.7, 2.8;
+  stan::test::binary_scalar_tester(f, in1, in2);
 }

--- a/test/unit/math/prim/fun/log_rising_factorial_test.cpp
+++ b/test/unit/math/prim/fun/log_rising_factorial_test.cpp
@@ -1,4 +1,5 @@
 #include <stan/math/prim.hpp>
+#include <test/unit/math/prim/fun/binary_scalar_tester.hpp>
 #include <gtest/gtest.h>
 #include <cmath>
 #include <limits>
@@ -15,4 +16,17 @@ TEST(MathFunctions, log_rising_factorial_nan) {
   double nan = std::numeric_limits<double>::quiet_NaN();
 
   EXPECT_TRUE(std::isnan(stan::math::log_rising_factorial(nan, 3)));
+}
+
+TEST(MathFunctions, log_rising_factorial_vec) {
+  auto f = [](const auto& x1, const auto& x2) {
+    using stan::math::log_rising_factorial;
+    return log_rising_factorial(x1, x2);
+  };
+
+  Eigen::VectorXd in1(3);
+  in1 << 1.8, 3.24, 1.8;
+  Eigen::VectorXd in2(3);
+  in2 << 7.3, 0.7, 2.8;
+  stan::test::binary_scalar_tester(f, in1, in2);
 }


### PR DESCRIPTION
## Summary

This pull continues the vectorisation of binary functions (first PR was #1987) by vectorising:

- ```gamma_p```
- ```gamma_q```
- ```hypot```
- ```lbeta```
- ```ldexp```
- ```lmgamma```
- ```log_diff_exp```
- ```log_falling_factorial```
- ```log_inv_logit_diff```
- ```log_modified_bessel_first_kind```
- ```log_rising_factorial```

## Tests

Vectorisation is tested using the ```binary_scalar_tester``` framework in ```prim```, and the ```expect_ad_vectorized_binary``` in ```mix```

## Side Effects

N/A

## Release notes

Vectorised binary scalar functions beginning with g-l

## Checklist

- [x] Math issue #1890 

- [x] Copyright holder: Andrew Johnson

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
