### PR TITLE
Add support for expression tests to specify new signatures

### DIFF
--- a/test/expressions/test_expression_testing_framework.py
+++ b/test/expressions/test_expression_testing_framework.py
@@ -24,25 +24,25 @@ class TestExpressionTestingFramework(unittest.TestCase):
         self.assertTrue(content in stdout, msg = error_template.format(content, stdout, stderr))
 
     def testExpressionNotAcceptedFailure(self):
-        return_code, stdout, stderr = self.runCommand((sys.executable, "./runTests.py", "./test/expressions", "--make-only", "--only-functions", "bad_no_expressions"))
+        return_code, stdout, stderr = self.runCommand((sys.executable, "./runTests.py", "./test/expressions", "--make-only", "--only-functions", "matrix bad_no_expressions(matrix)"))
         self.assertNotEqual(return_code, 0)
 
     def testMultipleEvaluationsFailure(self):
-        return_code, stdout, stderr = self.runCommand((sys.executable, "./runTests.py", "./test/expressions", "--only-functions", "bad_multiple_evaluations"))
+        return_code, stdout, stderr = self.runCommand((sys.executable, "./runTests.py", "./test/expressions", "--only-functions", "matrix bad_multiple_evaluations(matrix)"))
         self.assertNotEqual(return_code, 0)
         self.assertStdoutContains("[  FAILED  ] ExpressionTestPrim.bad_multiple_evaluations0", stdout, stderr)
         self.assertStdoutContains("[  FAILED  ] ExpressionTestRev.bad_multiple_evaluations0", stdout, stderr)
         self.assertStdoutContains("[  FAILED  ] ExpressionTestFwd.bad_multiple_evaluations0", stdout, stderr)
 
     def testWrongResultFailure(self):
-        return_code, stdout, stderr = self.runCommand((sys.executable, "./runTests.py", "./test/expressions", "--only-functions", "bad_wrong_value"))
+        return_code, stdout, stderr = self.runCommand((sys.executable, "./runTests.py", "./test/expressions", "--only-functions", "real bad_wrong_value(matrix)"))
         self.assertNotEqual(return_code, 0)
         self.assertStdoutContains("[  FAILED  ] ExpressionTestPrim.bad_wrong_value0", stdout, stderr)
         self.assertStdoutContains("[  FAILED  ] ExpressionTestRev.bad_wrong_value0", stdout, stderr)
         self.assertStdoutContains("[  FAILED  ] ExpressionTestFwd.bad_wrong_value0", stdout, stderr)
 
     def testWrongDerivativeFailure(self):
-        return_code, stdout, stderr = self.runCommand((sys.executable, "./runTests.py", "./test/expressions", "--only-functions", "bad_wrong_derivatives"))
+        return_code, stdout, stderr = self.runCommand((sys.executable, "./runTests.py", "./test/expressions", "--only-functions", "real bad_wrong_derivatives(vector)"))
         self.assertNotEqual(return_code, 0)
         self.assertStdoutContains("[       OK ] ExpressionTestPrim.bad_wrong_derivatives0", stdout, stderr)
         self.assertStdoutContains("[  FAILED  ] ExpressionTestRev.bad_wrong_derivatives0", stdout, stderr)


### PR DESCRIPTION
## Summary
THis PR contain some changes that simplify running expression tests for new functions. `--only-functions` argument now also supports listing function signatures or files. By listing function signatures it is possible to run tests for functions that are not yet supported in stanc3. If testing a function that supports many signatures it might be more conveniant to put the list of signatures in a file, instead of listing them in terminal.

## Tests
This whole PR.

Nothing is changed about how testing is done on Jenkins. This is just conveniance for running tests locally.

## Side Effects

None.

## Release notes

Add support for new signatures to be specified in expression tests.

## Checklist

- [ ] Math issue #(issue number)

- [ ] Copyright holder: Tadej Ciglarič

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [ ] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [ ] the code is written in idiomatic C++ and changes are documented in the doxygen

- [ ] the new changes are tested
