### PR TITLE
Remove threading test that cause false positives

### DIFF
--- a/test/unit/math/prim/functor/reduce_sum_test.cpp
+++ b/test/unit/math/prim/functor/reduce_sum_test.cpp
@@ -232,37 +232,3 @@ TEST(StanMathPrim_reduce_sum, sum) {
       std::vector<std::vector<double>>(2, std::vector<double>(5, 1.0)),
       std::vector<Eigen::VectorXd>(2, Eigen::VectorXd::Ones(5)));
 }
-
-#ifdef STAN_THREADS
-std::vector<int> threading_test_global;
-struct threading_test_lpdf {
-  template <typename T1>
-  inline auto operator()(const std::vector<T1>&, std::size_t start,
-                         std::size_t end, std::ostream* msgs) const {
-    threading_test_global[start] = tbb::this_task_arena::current_thread_index();
-
-    return stan::return_type_t<T1>(0);
-  }
-};
-
-TEST(StanMathPrim_reduce_sum, threading) {
-  threading_test_global = std::vector<int>(10000, 0);
-  stan::math::reduce_sum_static<threading_test_lpdf>(threading_test_global, 1,
-                                                     nullptr);
-
-  auto uniques = std::set<int>(threading_test_global.begin(),
-                               threading_test_global.end());
-
-  EXPECT_GT(uniques.size(), 1);
-
-  threading_test_global = std::vector<int>(10000, 0);
-
-  stan::math::reduce_sum<threading_test_lpdf>(threading_test_global, 1,
-                                              nullptr);
-
-  uniques = std::set<int>(threading_test_global.begin(),
-                          threading_test_global.end());
-
-  EXPECT_GT(uniques.size(), 1);
-}
-#endif

--- a/test/unit/math/rev/functor/reduce_sum_test.cpp
+++ b/test/unit/math/rev/functor/reduce_sum_test.cpp
@@ -389,38 +389,3 @@ TEST(StanMathRev_reduce_sum, slice_group_gradient) {
 
   stan::math::recover_memory();
 }
-
-#ifdef STAN_THREADS
-std::vector<int> threading_test_global;
-struct threading_test_lpdf {
-  template <typename T1>
-  inline auto operator()(const std::vector<T1>&, std::size_t start,
-                         std::size_t end, std::ostream* msgs) const {
-    threading_test_global[start] = tbb::this_task_arena::current_thread_index();
-
-    return stan::return_type_t<T1>(0);
-  }
-};
-
-TEST(StanMathRev_reduce_sum, threading) {
-  threading_test_global = std::vector<int>(10000, 0);
-  std::vector<stan::math::var> data(threading_test_global.size(), 0);
-  stan::math::reduce_sum_static<threading_test_lpdf>(data, 1, nullptr);
-
-  auto uniques = std::set<int>(threading_test_global.begin(),
-                               threading_test_global.end());
-
-  EXPECT_GT(uniques.size(), 1);
-
-  threading_test_global = std::vector<int>(10000, 0);
-
-  stan::math::reduce_sum<threading_test_lpdf>(data, 1, nullptr);
-
-  uniques = std::set<int>(threading_test_global.begin(),
-                          threading_test_global.end());
-
-  EXPECT_GT(uniques.size(), 1);
-
-  stan::math::recover_memory();
-}
-#endif


### PR DESCRIPTION
## Summary

Fixes #1996 

The test can cause false positives and are thus a bit annoying. I think they would be better suited as a part of performance tests or something like that

## Tests

Yes, removed two tests

## Side Effects

A side effect of this is that we no longer test if reduce_sum uses more than 1 thread with STAN_THREADS is on. I think this either has to be a separate test in test/unit/ or as part of /stan. That test needs to be run separately on a multi core system with no other tests running at the same time.

## Release notes

Remove unit tests for reduce_sum threading that caused false positives.

## Checklist

- [x] Math issue #1996 

- [x] Copyright holder: Rok Češnovar, Univ. of Ljubljana

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
