### PR TITLE
update prob tests to use non-deprecated gtest macros

### DIFF
--- a/test/prob/test_fixture_ccdf_log.hpp
+++ b/test/prob/test_fixture_ccdf_log.hpp
@@ -801,7 +801,7 @@ class AgradCcdfLogTestFixture : public ::testing::Test {
   }
 };
 
-TYPED_TEST_CASE_P(AgradCcdfLogTestFixture);
+TYPED_TEST_SUITE_P(AgradCcdfLogTestFixture);
 
 TYPED_TEST_P(AgradCcdfLogTestFixture, CallAllVersions) {
   this->call_all_versions();
@@ -833,7 +833,7 @@ TYPED_TEST_P(AgradCcdfLogTestFixture, Length0Vector) {
   this->test_length_0_vector();
 }
 
-REGISTER_TYPED_TEST_CASE_P(AgradCcdfLogTestFixture, CallAllVersions,
+REGISTER_TYPED_TEST_SUITE_P(AgradCcdfLogTestFixture, CallAllVersions,
                            ValidValues, InvalidValues, FiniteDiff, Function,
                            RepeatAsVector, LowerBound, UpperBound,
                            Length0Vector);

--- a/test/prob/test_fixture_ccdf_log.hpp
+++ b/test/prob/test_fixture_ccdf_log.hpp
@@ -834,9 +834,9 @@ TYPED_TEST_P(AgradCcdfLogTestFixture, Length0Vector) {
 }
 
 REGISTER_TYPED_TEST_SUITE_P(AgradCcdfLogTestFixture, CallAllVersions,
-                           ValidValues, InvalidValues, FiniteDiff, Function,
-                           RepeatAsVector, LowerBound, UpperBound,
-                           Length0Vector);
+                            ValidValues, InvalidValues, FiniteDiff, Function,
+                            RepeatAsVector, LowerBound, UpperBound,
+                            Length0Vector);
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(AgradCcdfLogTestFixture);
 

--- a/test/prob/test_fixture_cdf.hpp
+++ b/test/prob/test_fixture_cdf.hpp
@@ -791,7 +791,7 @@ class AgradCdfTestFixture : public ::testing::Test {
   }
 };
 
-TYPED_TEST_CASE_P(AgradCdfTestFixture);
+TYPED_TEST_SUITE_P(AgradCdfTestFixture);
 
 TYPED_TEST_P(AgradCdfTestFixture, CallAllVersions) {
   this->call_all_versions();
@@ -819,7 +819,7 @@ TYPED_TEST_P(AgradCdfTestFixture, Length0Vector) {
   this->test_length_0_vector();
 }
 
-REGISTER_TYPED_TEST_CASE_P(AgradCdfTestFixture, CallAllVersions, ValidValues,
+REGISTER_TYPED_TEST_SUITE_P(AgradCdfTestFixture, CallAllVersions, ValidValues,
                            InvalidValues, FiniteDiff, Function, RepeatAsVector,
                            LowerBound, UpperBound, Length0Vector);
 

--- a/test/prob/test_fixture_cdf.hpp
+++ b/test/prob/test_fixture_cdf.hpp
@@ -820,8 +820,8 @@ TYPED_TEST_P(AgradCdfTestFixture, Length0Vector) {
 }
 
 REGISTER_TYPED_TEST_SUITE_P(AgradCdfTestFixture, CallAllVersions, ValidValues,
-                           InvalidValues, FiniteDiff, Function, RepeatAsVector,
-                           LowerBound, UpperBound, Length0Vector);
+                            InvalidValues, FiniteDiff, Function, RepeatAsVector,
+                            LowerBound, UpperBound, Length0Vector);
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(AgradCdfTestFixture);
 

--- a/test/prob/test_fixture_cdf_log.hpp
+++ b/test/prob/test_fixture_cdf_log.hpp
@@ -801,7 +801,7 @@ class AgradCdfLogTestFixture : public ::testing::Test {
   }
 };
 
-TYPED_TEST_CASE_P(AgradCdfLogTestFixture);
+TYPED_TEST_SUITE_P(AgradCdfLogTestFixture);
 
 TYPED_TEST_P(AgradCdfLogTestFixture, CallAllVersions) {
   this->call_all_versions();
@@ -831,7 +831,7 @@ TYPED_TEST_P(AgradCdfLogTestFixture, Length0Vector) {
   this->test_length_0_vector();
 }
 
-REGISTER_TYPED_TEST_CASE_P(AgradCdfLogTestFixture, CallAllVersions, ValidValues,
+REGISTER_TYPED_TEST_SUITE_P(AgradCdfLogTestFixture, CallAllVersions, ValidValues,
                            InvalidValues, FiniteDiff, Function, RepeatAsVector,
                            LowerBound, UpperBound, Length0Vector);
 

--- a/test/prob/test_fixture_cdf_log.hpp
+++ b/test/prob/test_fixture_cdf_log.hpp
@@ -831,9 +831,10 @@ TYPED_TEST_P(AgradCdfLogTestFixture, Length0Vector) {
   this->test_length_0_vector();
 }
 
-REGISTER_TYPED_TEST_SUITE_P(AgradCdfLogTestFixture, CallAllVersions, ValidValues,
-                           InvalidValues, FiniteDiff, Function, RepeatAsVector,
-                           LowerBound, UpperBound, Length0Vector);
+REGISTER_TYPED_TEST_SUITE_P(AgradCdfLogTestFixture, CallAllVersions,
+                            ValidValues, InvalidValues, FiniteDiff, Function,
+                            RepeatAsVector, LowerBound, UpperBound,
+                            Length0Vector);
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(AgradCdfLogTestFixture);
 

--- a/test/prob/test_fixture_distr.hpp
+++ b/test/prob/test_fixture_distr.hpp
@@ -790,7 +790,7 @@ class AgradDistributionTestFixture : public ::testing::Test {
     return params[0];
   }
 };
-TYPED_TEST_CASE_P(AgradDistributionTestFixture);
+TYPED_TEST_SUITE_P(AgradDistributionTestFixture);
 
 TYPED_TEST_P(AgradDistributionTestFixture, CallAllVersions) {
   this->call_all_versions();
@@ -820,7 +820,7 @@ TYPED_TEST_P(AgradDistributionTestFixture, Length0Vector) {
   this->test_length_0_vector();
 }
 
-REGISTER_TYPED_TEST_CASE_P(AgradDistributionTestFixture, CallAllVersions,
+REGISTER_TYPED_TEST_SUITE_P(AgradDistributionTestFixture, CallAllVersions,
                            ValidValues, InvalidValues, Propto, FiniteDiff,
                            Function, RepeatAsVector, Length0Vector);
 

--- a/test/prob/test_fixture_distr.hpp
+++ b/test/prob/test_fixture_distr.hpp
@@ -821,8 +821,8 @@ TYPED_TEST_P(AgradDistributionTestFixture, Length0Vector) {
 }
 
 REGISTER_TYPED_TEST_SUITE_P(AgradDistributionTestFixture, CallAllVersions,
-                           ValidValues, InvalidValues, Propto, FiniteDiff,
-                           Function, RepeatAsVector, Length0Vector);
+                            ValidValues, InvalidValues, Propto, FiniteDiff,
+                            Function, RepeatAsVector, Length0Vector);
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(AgradDistributionTestFixture);
 


### PR DESCRIPTION

## Summary

Fixes the prob tests to use `TYPED_TEST_SUITE_P` instead of `TYPED_TEST_CASE_P ` since the latter is deprecated

```
./test/prob/test_fixture_cdf.hpp:794:1: warning: 'TypedTestCase_P_IsDeprecated' is deprecated: TYPED_TEST_CASE_P is deprecated, please use TYPED_TEST_SUITE_P
```
## Tests

No new tests

## Side Effects

Nope

## Release notes

## Checklist

- [x] Copyright holder: Steve Bronder

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
