### PR TITLE
Fix probability framework allocations (Issue #2036)

### DIFF
--- a/test/prob/test_fixture_ccdf_log.hpp
+++ b/test/prob/test_fixture_ccdf_log.hpp
@@ -257,8 +257,8 @@ class AgradCcdfLogTestFixture : public ::testing::Test {
   // works for <var>
   double calculate_gradients_1storder(vector<double>& grad, var& ccdf_log,
                                       vector<var>& x) {
+    stan::math::set_zero_all_adjoints();
     ccdf_log.grad(x, grad);
-    stan::math::recover_memory();
     return ccdf_log.val();
   }
   double calculate_gradients_2ndorder(vector<double>& grad, var& ccdf_log,
@@ -306,14 +306,14 @@ class AgradCcdfLogTestFixture : public ::testing::Test {
   // works for fvar<var>
   double calculate_gradients_1storder(vector<double>& grad, fvar<var>& ccdf_log,
                                       vector<var>& x) {
+    stan::math::set_zero_all_adjoints();
     ccdf_log.val_.grad(x, grad);
-    stan::math::recover_memory();
     return ccdf_log.val_.val();
   }
   double calculate_gradients_2ndorder(vector<double>& grad, fvar<var>& ccdf_log,
                                       vector<var>& x) {
+    stan::math::set_zero_all_adjoints();
     ccdf_log.d_.grad(x, grad);
-    stan::math::recover_memory();
     return ccdf_log.val_.val();
   }
   double calculate_gradients_3rdorder(vector<double>& grad, fvar<var>& ccdf_log,
@@ -325,22 +325,22 @@ class AgradCcdfLogTestFixture : public ::testing::Test {
   double calculate_gradients_1storder(vector<double>& grad,
                                       fvar<fvar<var>>& ccdf_log,
                                       vector<var>& x) {
+    stan::math::set_zero_all_adjoints();
     ccdf_log.val_.val_.grad(x, grad);
-    stan::math::recover_memory();
     return ccdf_log.val_.val_.val();
   }
   double calculate_gradients_2ndorder(vector<double>& grad,
                                       fvar<fvar<var>>& ccdf_log,
                                       vector<var>& x) {
+    stan::math::set_zero_all_adjoints();
     ccdf_log.d_.val_.grad(x, grad);
-    stan::math::recover_memory();
     return ccdf_log.val_.val_.val();
   }
   double calculate_gradients_3rdorder(vector<double>& grad,
                                       fvar<fvar<var>>& ccdf_log,
                                       vector<var>& x) {
+    stan::math::set_zero_all_adjoints();
     ccdf_log.d_.d_.grad(x, grad);
-    stan::math::recover_memory();
     return ccdf_log.val_.val_.val();
   }
 
@@ -408,6 +408,8 @@ class AgradCcdfLogTestFixture : public ::testing::Test {
         calculate_gradients_1storder(gradients, ccdf_log, x1);
 
         test_finite_diffs_equal(parameters[n], finite_diffs, gradients);
+
+	stan::math::recover_memory();
       }
     }
   }
@@ -484,6 +486,8 @@ class AgradCcdfLogTestFixture : public ::testing::Test {
       test_gradients_equal(expected_gradients1, gradients1);
       test_gradients_equal(expected_gradients2, gradients2);
       test_gradients_equal(expected_gradients3, gradients3);
+
+      stan::math::recover_memory();
     }
   }
 
@@ -574,6 +578,8 @@ class AgradCcdfLogTestFixture : public ::testing::Test {
       calculate_gradients_1storder(multiple_gradients1, multiple_ccdf_log, x1);
       calculate_gradients_1storder(multiple_gradients2, multiple_ccdf_log, x1);
       calculate_gradients_1storder(multiple_gradients3, multiple_ccdf_log, x1);
+
+      stan::math::recover_memory();
 
       EXPECT_NEAR(stan::math::value_of_rec(single_ccdf_log * N_REPEAT),
                   stan::math::value_of_rec(multiple_ccdf_log), 1e-8)

--- a/test/prob/test_fixture_ccdf_log.hpp
+++ b/test/prob/test_fixture_ccdf_log.hpp
@@ -409,7 +409,7 @@ class AgradCcdfLogTestFixture : public ::testing::Test {
 
         test_finite_diffs_equal(parameters[n], finite_diffs, gradients);
 
-	stan::math::recover_memory();
+        stan::math::recover_memory();
       }
     }
   }

--- a/test/prob/test_fixture_cdf.hpp
+++ b/test/prob/test_fixture_cdf.hpp
@@ -256,8 +256,8 @@ class AgradCdfTestFixture : public ::testing::Test {
   // works for <var>
   double calculate_gradients_1storder(vector<double>& grad, var& cdf,
                                       vector<var>& x) {
+    stan::math::set_zero_all_adjoints();
     cdf.grad(x, grad);
-    stan::math::recover_memory();
     return cdf.val();
   }
   double calculate_gradients_2ndorder(vector<double>& grad, var& cdf,
@@ -302,14 +302,14 @@ class AgradCdfTestFixture : public ::testing::Test {
   // works for fvar<var>
   double calculate_gradients_1storder(vector<double>& grad, fvar<var>& cdf,
                                       vector<var>& x) {
+    stan::math::set_zero_all_adjoints();
     cdf.val_.grad(x, grad);
-    stan::math::recover_memory();
     return cdf.val_.val();
   }
   double calculate_gradients_2ndorder(vector<double>& grad, fvar<var>& cdf,
                                       vector<var>& x) {
+    stan::math::set_zero_all_adjoints();
     cdf.d_.grad(x, grad);
-    stan::math::recover_memory();
     return cdf.val_.val();
   }
   double calculate_gradients_3rdorder(vector<double>& grad, fvar<var>& cdf,
@@ -320,20 +320,20 @@ class AgradCdfTestFixture : public ::testing::Test {
   // works for fvar<fvar<var> >
   double calculate_gradients_1storder(vector<double>& grad,
                                       fvar<fvar<var>>& cdf, vector<var>& x) {
+    stan::math::set_zero_all_adjoints();
     cdf.val_.val_.grad(x, grad);
-    stan::math::recover_memory();
     return cdf.val_.val_.val();
   }
   double calculate_gradients_2ndorder(vector<double>& grad,
                                       fvar<fvar<var>>& cdf, vector<var>& x) {
+    stan::math::set_zero_all_adjoints();
     cdf.d_.val_.grad(x, grad);
-    stan::math::recover_memory();
     return cdf.val_.val_.val();
   }
   double calculate_gradients_3rdorder(vector<double>& grad,
                                       fvar<fvar<var>>& cdf, vector<var>& x) {
+    stan::math::set_zero_all_adjoints();
     cdf.d_.d_.grad(x, grad);
-    stan::math::recover_memory();
     return cdf.val_.val_.val();
   }
 
@@ -399,6 +399,8 @@ class AgradCdfTestFixture : public ::testing::Test {
         calculate_gradients_1storder(gradients, cdf, x1);
 
         test_finite_diffs_equal(parameters[n], finite_diffs, gradients);
+
+	stan::math::recover_memory();
       }
     }
   }
@@ -474,6 +476,8 @@ class AgradCdfTestFixture : public ::testing::Test {
       test_gradients_equal(expected_gradients1, gradients1);
       test_gradients_equal(expected_gradients2, gradients2);
       test_gradients_equal(expected_gradients3, gradients3);
+
+      stan::math::recover_memory();
     }
   }
 
@@ -565,6 +569,8 @@ class AgradCdfTestFixture : public ::testing::Test {
       calculate_gradients_1storder(multiple_gradients1, multiple_cdf, x1);
       calculate_gradients_1storder(multiple_gradients2, multiple_cdf, x1);
       calculate_gradients_1storder(multiple_gradients3, multiple_cdf, x1);
+
+      stan::math::recover_memory();
 
       EXPECT_NEAR(stan::math::value_of_rec(pow(single_cdf, N_REPEAT)),
                   stan::math::value_of_rec(multiple_cdf), 1e-8)

--- a/test/prob/test_fixture_cdf.hpp
+++ b/test/prob/test_fixture_cdf.hpp
@@ -400,7 +400,7 @@ class AgradCdfTestFixture : public ::testing::Test {
 
         test_finite_diffs_equal(parameters[n], finite_diffs, gradients);
 
-	stan::math::recover_memory();
+        stan::math::recover_memory();
       }
     }
   }

--- a/test/prob/test_fixture_cdf_log.hpp
+++ b/test/prob/test_fixture_cdf_log.hpp
@@ -259,8 +259,8 @@ class AgradCdfLogTestFixture : public ::testing::Test {
   // works for <var>
   double calculate_gradients_1storder(vector<double>& grad, var& cdf_log,
                                       vector<var>& x) {
+    stan::math::set_zero_all_adjoints();
     cdf_log.grad(x, grad);
-    stan::math::recover_memory();
     return cdf_log.val();
   }
   double calculate_gradients_2ndorder(vector<double>& grad, var& cdf_log,
@@ -308,14 +308,14 @@ class AgradCdfLogTestFixture : public ::testing::Test {
   // works for fvar<var>
   double calculate_gradients_1storder(vector<double>& grad, fvar<var>& cdf_log,
                                       vector<var>& x) {
+    stan::math::set_zero_all_adjoints();
     cdf_log.val_.grad(x, grad);
-    stan::math::recover_memory();
     return cdf_log.val_.val();
   }
   double calculate_gradients_2ndorder(vector<double>& grad, fvar<var>& cdf_log,
                                       vector<var>& x) {
+    stan::math::set_zero_all_adjoints();
     cdf_log.d_.grad(x, grad);
-    stan::math::recover_memory();
     return cdf_log.val_.val();
   }
   double calculate_gradients_3rdorder(vector<double>& grad, fvar<var>& cdf_log,
@@ -327,22 +327,22 @@ class AgradCdfLogTestFixture : public ::testing::Test {
   double calculate_gradients_1storder(vector<double>& grad,
                                       fvar<fvar<var>>& cdf_log,
                                       vector<var>& x) {
+    stan::math::set_zero_all_adjoints();
     cdf_log.val_.val_.grad(x, grad);
-    stan::math::recover_memory();
     return cdf_log.val_.val_.val();
   }
   double calculate_gradients_2ndorder(vector<double>& grad,
                                       fvar<fvar<var>>& cdf_log,
                                       vector<var>& x) {
+    stan::math::set_zero_all_adjoints();
     cdf_log.d_.val_.grad(x, grad);
-    stan::math::recover_memory();
     return cdf_log.val_.val_.val();
   }
   double calculate_gradients_3rdorder(vector<double>& grad,
                                       fvar<fvar<var>>& cdf_log,
                                       vector<var>& x) {
+    stan::math::set_zero_all_adjoints();
     cdf_log.d_.d_.grad(x, grad);
-    stan::math::recover_memory();
     return cdf_log.val_.val_.val();
   }
 
@@ -409,6 +409,8 @@ class AgradCdfLogTestFixture : public ::testing::Test {
         calculate_gradients_1storder(gradients, cdf_log, x1);
 
         test_finite_diffs_equal(parameters[n], finite_diffs, gradients);
+
+        stan::math::recover_memory();
       }
     }
   }
@@ -485,6 +487,8 @@ class AgradCdfLogTestFixture : public ::testing::Test {
       test_gradients_equal(expected_gradients1, gradients1);
       test_gradients_equal(expected_gradients2, gradients2);
       test_gradients_equal(expected_gradients3, gradients3);
+
+      stan::math::recover_memory();
     }
   }
 
@@ -575,6 +579,8 @@ class AgradCdfLogTestFixture : public ::testing::Test {
       calculate_gradients_1storder(multiple_gradients1, multiple_cdf_log, x1);
       calculate_gradients_1storder(multiple_gradients2, multiple_cdf_log, x1);
       calculate_gradients_1storder(multiple_gradients3, multiple_cdf_log, x1);
+
+      stan::math::recover_memory();
 
       EXPECT_NEAR(stan::math::value_of_rec(N_REPEAT * single_cdf_log),
                   stan::math::value_of_rec(multiple_cdf_log), 1e-8)

--- a/test/prob/test_fixture_distr.hpp
+++ b/test/prob/test_fixture_distr.hpp
@@ -319,8 +319,8 @@ class AgradDistributionTestFixture : public ::testing::Test {
   // works for <var>
   double calculate_gradients_1storder(vector<double>& grad, var& logprob,
                                       vector<var>& x) {
+    stan::math::set_zero_all_adjoints();
     logprob.grad(x, grad);
-    stan::math::recover_memory();
     return logprob.val();
   }
   double calculate_gradients_2ndorder(vector<double>& grad, var& logprob,
@@ -368,14 +368,14 @@ class AgradDistributionTestFixture : public ::testing::Test {
   // works for fvar<var>
   double calculate_gradients_1storder(vector<double>& grad, fvar<var>& logprob,
                                       vector<var>& x) {
+    stan::math::set_zero_all_adjoints();
     logprob.val_.grad(x, grad);
-    stan::math::recover_memory();
     return logprob.val_.val();
   }
   double calculate_gradients_2ndorder(vector<double>& grad, fvar<var>& logprob,
                                       vector<var>& x) {
+    stan::math::set_zero_all_adjoints();
     logprob.d_.grad(x, grad);
-    stan::math::recover_memory();
     return logprob.val_.val();
   }
   double calculate_gradients_3rdorder(vector<double>& grad, fvar<var>& logprob,
@@ -387,22 +387,22 @@ class AgradDistributionTestFixture : public ::testing::Test {
   double calculate_gradients_1storder(vector<double>& grad,
                                       fvar<fvar<var>>& logprob,
                                       vector<var>& x) {
+    stan::math::set_zero_all_adjoints();
     logprob.val_.val_.grad(x, grad);
-    stan::math::recover_memory();
     return logprob.val_.val_.val();
   }
   double calculate_gradients_2ndorder(vector<double>& grad,
                                       fvar<fvar<var>>& logprob,
                                       vector<var>& x) {
+    stan::math::set_zero_all_adjoints();
     logprob.d_.val_.grad(x, grad);
-    stan::math::recover_memory();
     return logprob.val_.val_.val();
   }
   double calculate_gradients_3rdorder(vector<double>& grad,
                                       fvar<fvar<var>>& logprob,
                                       vector<var>& x) {
+    stan::math::set_zero_all_adjoints();
     logprob.d_.d_.grad(x, grad);
-    stan::math::recover_memory();
     return logprob.val_.val_.val();
   }
 
@@ -472,6 +472,8 @@ class AgradDistributionTestFixture : public ::testing::Test {
         test_finite_diffs_equal(parameters[n], finite_diffs, gradients);
       }
     }
+
+    stan::math::recover_memory();
   }
 
   void test_gradients_equal(const vector<double>& expected_gradients,
@@ -547,6 +549,8 @@ class AgradDistributionTestFixture : public ::testing::Test {
       test_gradients_equal(expected_gradients1, gradients1);
       test_gradients_equal(expected_gradients2, gradients2);
       test_gradients_equal(expected_gradients3, gradients3);
+
+      stan::math::recover_memory();
     }
   }
 
@@ -640,6 +644,8 @@ class AgradDistributionTestFixture : public ::testing::Test {
       calculate_gradients_1storder(multiple_gradients1, multiple_lp, x1);
       calculate_gradients_1storder(multiple_gradients2, multiple_lp, x1);
       calculate_gradients_1storder(multiple_gradients3, multiple_lp, x1);
+
+      stan::math::recover_memory();
 
       EXPECT_NEAR(stan::math::value_of_rec(N_REPEAT * single_lp),
                   stan::math::value_of_rec(multiple_lp), 1e-8)


### PR DESCRIPTION
Fixes #2036

## Release notes

Fixes some memory allocation problems with test framework

## Checklist

- [x] Math issue #2036 

- [x] Copyright holder: (fill in copyright holder information)

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [ ] the new changes are tested
