### PR TITLE
Add indexing to kernel generator

### DIFF
--- a/stan/math/opencl/kernel_generator.hpp
+++ b/stan/math/opencl/kernel_generator.hpp
@@ -130,6 +130,7 @@
 #include <stan/math/opencl/kernel_generator/holder_cl.hpp>
 #include <stan/math/opencl/kernel_generator/check_cl.hpp>
 #include <stan/math/opencl/kernel_generator/index.hpp>
+#include <stan/math/opencl/kernel_generator/indexing.hpp>
 
 #include <stan/math/opencl/kernel_generator/multi_result_kernel.hpp>
 #include <stan/math/opencl/kernel_generator/get_kernel_source_for_evaluating_into.hpp>

--- a/stan/math/opencl/kernel_generator/indexing.hpp
+++ b/stan/math/opencl/kernel_generator/indexing.hpp
@@ -22,8 +22,8 @@ namespace math {
  * Represents indexing of a matrix with two matrices of indices. `indexing(mat,
  * col_index, row_index)[i,j] = mat[col_index[i,j], row_index[i,j]]`
  * @tparam T_mat expression type of the matrix to index
- * @tparam T_col_index expression type of the column index
  * @tparam T_row_index expression type of the row index
+ * @tparam T_col_index expression type of the column index
  */
 template <typename T_mat, typename T_row_index, typename T_col_index>
 class indexing_
@@ -45,8 +45,8 @@ class indexing_
   /**
    * Constructor
    * @param mat expression to index
-   * @param col_index column index expression
    * @param row_index row index expression
+   * @param col_index column index expression
    */
   indexing_(T_mat&& mat, T_row_index&& row_index, T_col_index&& col_index)
       : base(std::forward<T_mat>(mat), std::forward<T_row_index>(row_index),
@@ -243,11 +243,11 @@ class indexing_
  * type as indexed expression. `indexing(mat, col_index, row_index)[i,j] =
  * mat[col_index[i,j], row_index[i,j]]`
  *
- * If a matrix is both indexed and a the result of the kernel (such as in
+ * If a matrix is both indexed and the result of the kernel (such as in
  * `indexing(a, b, c) = indexing(a, d, e);`), the result can be wrong due to
- * aliasing. In such case the expression should be evaluated in a temporary by
- * doing <indexing(a, b, c) = indexing(a, d, e).eval();`. This is not necessary
- * if both indexings use same indices or index no common elements of the marix.
+ * aliasing. In this case the expression should be evaluated in a temporary by
+ * doing `indexing(a, b, c) = indexing(a, d, e).eval();`. This is not necessary
+ * if both indexings use the same indices or index no common elements of the matrix.
  *
  * If indexing is assigned to and some element is indexed multiple times it can
  * end with either of the assigned values due to a data race.

--- a/stan/math/opencl/kernel_generator/indexing.hpp
+++ b/stan/math/opencl/kernel_generator/indexing.hpp
@@ -1,0 +1,282 @@
+#ifndef STAN_MATH_OPENCL_KERNEL_GENERATOR_indexing_HPP
+#define STAN_MATH_OPENCL_KERNEL_GENERATOR_indexing_HPP
+#ifdef STAN_OPENCL
+
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/opencl/kernel_generator/type_str.hpp>
+#include <stan/math/opencl/kernel_generator/name_generator.hpp>
+#include <stan/math/opencl/kernel_generator/operation_cl.hpp>
+#include <stan/math/opencl/kernel_generator/as_operation_cl.hpp>
+#include <stan/math/opencl/kernel_generator/is_kernel_expression.hpp>
+#include <string>
+#include <utility>
+
+namespace stan {
+namespace math {
+
+/** \addtogroup opencl_kernel_generator
+ *  @{
+ */
+
+/**
+ * Represents indexing of a matrix with two matrices of indices. `indexing(mat,
+ * col_index, row_index)[i,j] = mat[col_index[i,j], row_index[i,j]]`
+ * @tparam T_mat expression type of the matrix to index
+ * @tparam T_col_index expression type of the column index
+ * @tparam T_row_index expression type of the row index
+ */
+template <typename T_mat, typename T_row_index, typename T_col_index>
+class indexing_
+    : public operation_cl_lhs<indexing_<T_mat, T_row_index, T_col_index>,
+                              typename std::remove_reference_t<T_mat>::Scalar,
+                              T_mat, T_row_index, T_col_index> {
+  static_assert(std::is_integral<value_type_t<T_row_index>>::value,
+                "indexing: Row index scalar type must be an integer!");
+  static_assert(std::is_integral<value_type_t<T_col_index>>::value,
+                "indexing: Column index scalar type must be an integer!");
+
+ public:
+  using Scalar = typename std::remove_reference_t<T_mat>::Scalar;
+  using base = operation_cl_lhs<indexing_<T_mat, T_row_index, T_col_index>,
+                                Scalar, T_mat, T_row_index, T_col_index>;
+  using base::var_name_;
+  using base::operator=;
+
+  /**
+   * Constructor
+   * @param mat expression to index
+   * @param col_index column index expression
+   * @param row_index row index expression
+   */
+  indexing_(T_mat&& mat, T_row_index&& row_index, T_col_index&& col_index)
+      : base(std::forward<T_mat>(mat), std::forward<T_row_index>(row_index),
+             std::forward<T_col_index>(col_index)) {
+    const char* function = "indexing";
+    if (col_index.rows() != base::dynamic
+        && row_index.rows() != base::dynamic) {
+      check_size_match(function, "Rows of ", "col_index", col_index.rows(),
+                       "rows of ", "row_index", row_index.rows());
+    }
+    if (col_index.cols() != base::dynamic
+        && row_index.cols() != base::dynamic) {
+      check_size_match(function, "Columns of ", "col_index", col_index.cols(),
+                       "columns of ", "row_index", row_index.cols());
+    }
+  }
+
+  /**
+   * Creates a deep copy of this expression.
+   * @return copy of \c *this
+   */
+  inline auto deep_copy() const {
+    auto&& mat_copy = this->template get_arg<0>().deep_copy();
+    auto&& row_index_copy = this->template get_arg<1>().deep_copy();
+    auto&& col_index_copy = this->template get_arg<2>().deep_copy();
+    return indexing_<std::remove_reference_t<decltype(mat_copy)>,
+                     std::remove_reference_t<decltype(row_index_copy)>,
+                     std::remove_reference_t<decltype(col_index_copy)>>{
+        std::move(mat_copy), std::move(row_index_copy),
+        std::move(col_index_copy)};
+  }
+
+  /**
+   * Generates kernel code for this and nested expressions.
+   * @param[in,out] generated set of (pointer to) already generated operations
+   * @param name_gen name generator for this kernel
+   * @param row_index_name row index variable name
+   * @param col_index_name column index variable name
+   * @param view_handled whether caller already handled matrix view
+   * @return part of kernel with code for this and nested expressions
+   */
+  inline kernel_parts get_kernel_parts(
+      std::set<const operation_cl_base*>& generated, name_generator& name_gen,
+      const std::string& row_index_name, const std::string& col_index_name,
+      bool view_handled) const {
+    kernel_parts res{};
+    if (generated.count(this) == 0) {
+      generated.insert(this);
+
+      const auto& mat = this->template get_arg<0>();
+      const auto& row_index = this->template get_arg<1>();
+      const auto& col_index = this->template get_arg<2>();
+
+      kernel_parts parts_row_idx = row_index.get_kernel_parts(
+          generated, name_gen, row_index_name, col_index_name, view_handled);
+      kernel_parts parts_col_idx = col_index.get_kernel_parts(
+          generated, name_gen, row_index_name, col_index_name, view_handled);
+      kernel_parts parts_mat = mat.get_kernel_parts(
+          generated, name_gen, row_index.var_name_, col_index.var_name_, false);
+
+      res = parts_row_idx + parts_col_idx + parts_mat;
+      var_name_ = mat.var_name_;
+    }
+    return res;
+  }
+
+  /**
+   * Generates kernel code for this expression if it appears on the left hand
+   * side of an assignment.
+   * @param[in,out] generated set of (pointer to) already generated operations
+   * @param name_gen name generator for this kernel
+   * @param row_index_name row index variable name
+   * @param col_index_name column index variable name
+   * @return part of kernel with code for this expressions
+   */
+  inline kernel_parts get_kernel_parts_lhs(
+      std::set<const operation_cl_base*>& generated, name_generator& name_gen,
+      const std::string& row_index_name,
+      const std::string& col_index_name) const {
+    if (generated.count(this) == 0) {
+      generated.insert(this);
+    }
+    const auto& mat = this->template get_arg<0>();
+    const auto& row_index = this->template get_arg<1>();
+    const auto& col_index = this->template get_arg<2>();
+
+    kernel_parts parts_row_idx = row_index.get_kernel_parts(
+        generated, name_gen, row_index_name, col_index_name, false);
+    kernel_parts parts_col_idx = col_index.get_kernel_parts(
+        generated, name_gen, row_index_name, col_index_name, false);
+    kernel_parts parts_mat = mat.get_kernel_parts_lhs(
+        generated, name_gen, row_index.var_name_, col_index.var_name_);
+
+    kernel_parts res = parts_row_idx + parts_col_idx + parts_mat;
+    var_name_ = mat.var_name_;
+    return res;
+  }
+
+  /**
+   * Sets kernel arguments for this expression.
+   * @param[in,out] generated set of expressions that already set their kernel
+   * arguments
+   * @param kernel kernel to set arguments on
+   * @param[in,out] arg_num consecutive number of the first argument to set.
+   * This is incremented for each argument set by this function.
+   */
+  inline void set_args(std::set<const operation_cl_base*>& generated,
+                       cl::Kernel& kernel, int& arg_num) const {
+    if (generated.count(this) == 0) {
+      generated.insert(this);
+      this->template get_arg<1>().set_args(generated, kernel, arg_num);
+      this->template get_arg<2>().set_args(generated, kernel, arg_num);
+      this->template get_arg<0>().set_args(generated, kernel, arg_num);
+    }
+  }
+
+  /**
+   * Number of rows of a matrix that would be the result of evaluating this
+   * expression.
+   * @return number of rows
+   */
+  inline int rows() const {
+    return std::max(this->template get_arg<1>().rows(),
+                    this->template get_arg<2>().rows());
+  }
+
+  /**
+   * Number of columns of a matrix that would be the result of evaluating this
+   * expression.
+   * @return number of columns
+   */
+  inline int cols() const {
+    return std::max(this->template get_arg<1>().cols(),
+                    this->template get_arg<2>().cols());
+  }
+
+  /**
+   * Sets view of the underlying matrix depending on which part is written.
+   * @param bottom_diagonal Index of the top sub- or super- diagonal written
+   * with nonzero elements.
+   * @param top_diagonal Index of the top sub- or super- diagonal written with
+   * nonzero elements.
+   * @param bottom_zero_diagonal Index of the top sub- or super- diagonal
+   * written with zeros if it ie more extreme than \c bottom_diagonal. Otherwise
+   * it should be set to equal value as \c bottom_diagonal.
+   * @param top_zero_diagonal Index of the top sub- or super- diagonal written
+   * with zeros if it ie more extreme than \c top_diagonal. Otherwise it should
+   * be set to equal value as \c top_diagonal.
+   */
+  inline void set_view(int bottom_diagonal, int top_diagonal,
+                       int bottom_zero_diagonal, int top_zero_diagonal) const {
+    this->template get_arg<0>().set_view(
+        std::numeric_limits<int>::min(), std::numeric_limits<int>::max(),
+        std::numeric_limits<int>::min(), std::numeric_limits<int>::max());
+  }
+
+  /**
+   * Determine indices of extreme sub- and superdiagonals written.
+   * @return pair of indices - bottom and top diagonal
+   */
+  inline std::pair<int, int> extreme_diagonals() const {
+    return {std::numeric_limits<int>::min(), std::numeric_limits<int>::max()};
+  }
+
+  /**
+   * Checks if desired dimensions match dimensions of the indexing.
+   * @param rows desired number of rows
+   * @param cols desired number of columns
+   * @throws std::invalid_argument desired dimensions do not match dimensions
+   * of the indexing.
+   */
+  inline void check_assign_dimensions(int rows, int cols) const {
+    check_size_match("indexing_.check_assign_dimensions", "Rows of ",
+                     "indexing", this->rows(), "rows of ", "expression", rows);
+    check_size_match("indexing_.check_assign_dimensions", "Columns of ",
+                     "indexing", this->cols(), "columns of ", "expression",
+                     cols);
+  }
+
+  /**
+   * Adds write event to indexed matrix and read event to indices.
+   * @param e the event to add
+   */
+  inline void add_write_event(cl::Event& e) const {
+    this->template get_arg<1>().add_read_event(e);
+    this->template get_arg<2>().add_read_event(e);
+    this->template get_arg<0>().add_write_event(e);
+  }
+};
+
+/**
+ * Index a kernel generator expression using two expressions for indices. The
+ * result is a matrix of the same size as index matrices and with same scalar
+ * type as indexed expression. `indexing(mat, col_index, row_index)[i,j] =
+ * mat[col_index[i,j], row_index[i,j]]`
+ *
+ * If a matrix is both indexed and a the result of the kernel (such as in
+ * `indexing(a, b, c) = indexing(a, d, e);`), the result can be wrong due to
+ * aliasing. In such case the expression should be evaluated in a temporary by
+ * doing <indexing(a, b, c) = indexing(a, d, e).eval();`. This is not necessary
+ * if both indexings use same indices or index no common elements of the marix.
+ *
+ * If indexing is assigned to and some element is indexed multiple times it can
+ * end with either of the assigned values due to a data race.
+ *
+ * @tparam T_mat type of indexed expression
+ * @tparam T_row_index type of row index
+ * @tparam T_col_index type of column index
+ * @param mat indexed matrix
+ * @param row_index row index
+ * @param col_index column index
+ * @return indexing expression
+ */
+template <typename T_mat, typename T_row_index, typename T_col_index,
+          require_all_kernel_expressions_and_none_scalar_t<
+              T_mat, T_row_index, T_col_index>* = nullptr>
+inline auto indexing(T_mat&& mat, T_row_index&& row_index,
+                     T_col_index&& col_index) {
+  auto&& mat_operation = as_operation_cl(std::forward<T_mat>(mat)).deep_copy();
+  return indexing_<std::remove_reference_t<decltype(mat_operation)>,
+                   as_operation_cl_t<T_row_index>,
+                   as_operation_cl_t<T_col_index>>(
+      std::move(mat_operation),
+      as_operation_cl(std::forward<T_row_index>(row_index)),
+      as_operation_cl(std::forward<T_col_index>(col_index)));
+}
+
+/** @}*/
+}  // namespace math
+}  // namespace stan
+
+#endif
+#endif

--- a/stan/math/opencl/kernel_generator/indexing.hpp
+++ b/stan/math/opencl/kernel_generator/indexing.hpp
@@ -247,7 +247,8 @@ class indexing_
  * `indexing(a, b, c) = indexing(a, d, e);`), the result can be wrong due to
  * aliasing. In this case the expression should be evaluated in a temporary by
  * doing `indexing(a, b, c) = indexing(a, d, e).eval();`. This is not necessary
- * if both indexings use the same indices or index no common elements of the matrix.
+ * if both indexings use the same indices or index no common elements of the
+ * matrix.
  *
  * If indexing is assigned to and some element is indexed multiple times it can
  * end with either of the assigned values due to a data race.

--- a/test/unit/math/opencl/kernel_generator/indexing_test.cpp
+++ b/test/unit/math/opencl/kernel_generator/indexing_test.cpp
@@ -1,0 +1,159 @@
+#ifdef STAN_OPENCL
+
+#include <stan/math/opencl/kernel_generator.hpp>
+#include <stan/math/opencl/matrix_cl.hpp>
+#include <stan/math/opencl/copy.hpp>
+#include <test/unit/math/opencl/kernel_generator/reference_kernel.hpp>
+#include <test/unit/util.hpp>
+#include <Eigen/Dense>
+#include <gtest/gtest.h>
+#include <string>
+
+TEST(KernelGenerator, indexing_test) {
+  using Eigen::MatrixXd;
+  using stan::math::matrix_cl;
+
+  std::string kernel_filename = "indexing.cl";
+  MatrixXd m = MatrixXd::Random(7, 9);
+
+  Eigen::MatrixXi col_idx(3, 2);
+  col_idx << 2, 5, 0, 1, 6, 3;
+  Eigen::MatrixXi row_idx(3, 2);
+  row_idx << 1, 2, 3, 4, 2, 0;
+
+  matrix_cl<double> m_cl(m);
+  matrix_cl<int> row_idx_cl(row_idx);
+  matrix_cl<int> col_idx_cl(col_idx);
+
+  auto tmp = stan::math::indexing(m_cl, row_idx_cl, col_idx_cl);
+
+  matrix_cl<double> res_cl;
+  std::string kernel_src = tmp.get_kernel_source_for_evaluating_into(res_cl);
+  stan::test::store_reference_kernel_if_needed(kernel_filename, kernel_src);
+  std::string expected_kernel_src
+      = stan::test::load_reference_kernel(kernel_filename);
+  EXPECT_EQ(expected_kernel_src, kernel_src);
+
+  res_cl = tmp;
+
+  MatrixXd res = stan::math::from_matrix_cl(res_cl);
+
+  MatrixXd correct(3, 2);
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 2; j++) {
+      correct(i, j) = m(row_idx(i, j), col_idx(i, j));
+    }
+  }
+  EXPECT_MATRIX_EQ(res, correct);
+}
+
+TEST(KernelGenerator, indexing_multiple_operations_test) {
+  using Eigen::MatrixXd;
+  using Eigen::MatrixXi;
+  using stan::math::matrix_cl;
+
+  MatrixXd m = MatrixXd::Random(7, 9);
+
+  Eigen::MatrixXi col_idx(3, 2);
+  col_idx << 2, 5, 0, 1, 6, 3;
+  Eigen::MatrixXi row_idx(3, 2);
+  row_idx << 1, 2, 3, 4, 2, 0;
+
+  Eigen::MatrixXi col_idx2(2, 2);
+  col_idx2 << 0, 0, 1, 1;
+  Eigen::MatrixXi row_idx2(2, 2);
+  row_idx2 << 0, 1, 1, 2;
+
+  matrix_cl<double> m_cl(m);
+  matrix_cl<int> row_idx_cl(row_idx);
+  matrix_cl<int> col_idx_cl(col_idx);
+  matrix_cl<int> row_idx2_cl(row_idx2);
+  matrix_cl<int> col_idx2_cl(col_idx2);
+
+  matrix_cl<double> res_cl = stan::math::indexing(
+      stan::math::indexing(m_cl, row_idx_cl, col_idx_cl),
+      stan::math::indexing(row_idx2_cl, col_idx2_cl, col_idx2_cl), col_idx2_cl);
+
+  MatrixXd res = stan::math::from_matrix_cl(res_cl);
+
+  MatrixXd tmp(3, 2);
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 2; j++) {
+      tmp(i, j) = m(row_idx(i, j), col_idx(i, j));
+    }
+  }
+
+  MatrixXd correct(2, 2);
+  for (int i = 0; i < 2; i++) {
+    for (int j = 0; j < 2; j++) {
+      int a = col_idx2(i, j);
+      correct(i, j) = tmp(row_idx2(a, a), a);
+    }
+  }
+  EXPECT_MATRIX_EQ(res, correct);
+}
+
+TEST(KernelGenerator, indexing_lhs_test) {
+  using Eigen::MatrixXd;
+  using Eigen::MatrixXi;
+  using stan::math::matrix_cl;
+
+  MatrixXd m = MatrixXd::Zero(7, 9);
+  MatrixXd m2 = MatrixXd::Random(3, 2);
+
+  Eigen::MatrixXi col_idx(3, 2);
+  col_idx << 2, 5, 0, 1, 6, 3;
+  Eigen::MatrixXi row_idx(3, 2);
+  row_idx << 1, 2, 3, 4, 2, 0;
+
+  matrix_cl<double> m_cl(m);
+  matrix_cl<double> m2_cl(m2);
+  matrix_cl<int> row_idx_cl(row_idx);
+  matrix_cl<int> col_idx_cl(col_idx);
+
+  stan::math::indexing(m_cl, row_idx_cl, col_idx_cl) = m2_cl;
+
+  MatrixXd res = stan::math::from_matrix_cl(m_cl);
+
+  MatrixXd correct = m;
+
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 2; j++) {
+      correct(row_idx(i, j), col_idx(i, j)) = m2(i, j);
+    }
+  }
+  EXPECT_MATRIX_EQ(res, correct);
+}
+
+TEST(KernelGenerator, indexing_repeat_lhs_rhs_test) {
+  using Eigen::MatrixXd;
+  using Eigen::MatrixXi;
+  using stan::math::matrix_cl;
+
+  MatrixXd m = MatrixXd::Zero(7, 9);
+
+  Eigen::MatrixXi col_idx(3, 2);
+  col_idx << 2, 5, 0, 1, 6, 3;
+  Eigen::MatrixXi row_idx(3, 2);
+  row_idx << 1, 2, 3, 4, 2, 0;
+
+  matrix_cl<double> m_cl(m);
+  matrix_cl<int> row_idx_cl(row_idx);
+  matrix_cl<int> col_idx_cl(col_idx);
+
+  auto b = stan::math::indexing(m_cl, row_idx_cl, col_idx_cl);
+
+  b = b + 1;
+  MatrixXd res = stan::math::from_matrix_cl(m_cl);
+
+  MatrixXd correct = m;
+
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 2; j++) {
+      correct(row_idx(i, j), col_idx(i, j)) += 1;
+    }
+  }
+  EXPECT_MATRIX_EQ(res, correct);
+}
+
+#endif

--- a/test/unit/math/opencl/kernel_generator/reference_kernels/indexing.cl
+++ b/test/unit/math/opencl/kernel_generator/reference_kernels/indexing.cl
@@ -1,0 +1,8 @@
+kernel void calculate(__global int* var1_global, int var1_rows, int var1_view, __global int* var2_global, int var2_rows, int var2_view, __global double* var3_global, int var3_rows, int var3_view, __global double* var4_global, int var4_rows, int var4_view){
+int i = get_global_id(0);
+int j = get_global_id(1);
+int var1 = 0; if (!((!contains_nonzero(var1_view, LOWER) && j < i) || (!contains_nonzero(var1_view, UPPER) && j > i))) {var1 = var1_global[i + var1_rows * j];}
+int var2 = 0; if (!((!contains_nonzero(var2_view, LOWER) && j < i) || (!contains_nonzero(var2_view, UPPER) && j > i))) {var2 = var2_global[i + var2_rows * j];}
+double var3 = 0; if (!((!contains_nonzero(var3_view, LOWER) && var2 < var1) || (!contains_nonzero(var3_view, UPPER) && var2 > var1))) {var3 = var3_global[var1 + var3_rows * var2];}
+var4_global[i + var4_rows * j] = var3;
+}


### PR DESCRIPTION
## Summary
Implements indexing for kernel generator expressions. A matrix can be indexed using two index expressions (of the same size that have int scalars) resuling in a matrix with size of indices and scalar of the indexed matrix. 

`indexing(mat, col_index, row_index)[i,j] = mat[col_index[i,j], row_index[i,j]]`

## Tests

Added tests for indexing.

## Side Effects
None.

## Release notes

Implements indexing for kernel generator expressions.

## Checklist

- [x] Math issue #1342 

- [x] Copyright holder: Tadej Ciglarič

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
