### PR TITLE
Make fmin/fmax behaviour consistent between rev & fwd

### DIFF
--- a/stan/math/fwd/fun/fmax.hpp
+++ b/stan/math/fwd/fun/fmax.hpp
@@ -76,7 +76,7 @@ inline fvar<T> fmax(const fvar<T>& x1, double x2) {
   if (unlikely(is_nan(x2))) {
     return x1;
   }
-  return x1 > x2 ? x1 : fvar<T>(x2, 0);
+  return x1 >= x2 ? x1 : fvar<T>(x2, 0);
 }
 
 }  // namespace math

--- a/stan/math/fwd/fun/fmax.hpp
+++ b/stan/math/fwd/fun/fmax.hpp
@@ -21,21 +21,16 @@ namespace math {
  */
 template <typename T>
 inline fvar<T> fmax(const fvar<T>& x1, const fvar<T>& x2) {
-  if (unlikely(is_nan(x1.val_))) {
-    if (is_nan(x2.val_)) {
-      return fvar<T>(fmax(x1.val_, x2.val_), NOT_A_NUMBER);
-    } else {
-      return fvar<T>(x2.val_, x2.d_);
+  if (unlikely(is_nan(x1))) {
+    if (unlikely(is_nan(x2))) {
+      return fvar<T>(NOT_A_NUMBER, NOT_A_NUMBER);
     }
-  } else if (unlikely(is_nan(x2.val_))) {
-    return fvar<T>(x1.val_, x1.d_);
-  } else if (x1.val_ > x2.val_) {
-    return fvar<T>(x1.val_, x1.d_);
-  } else if (x1.val_ == x2.val_) {
-    return fvar<T>(x1.val_, NOT_A_NUMBER);
-  } else {
-    return fvar<T>(x2.val_, x2.d_);
+    return x2;
   }
+  if (unlikely(is_nan(x2))) {
+    return x1;
+  }
+  return x1 > x2 ? x1 : x2;
 }
 
 /**
@@ -50,20 +45,15 @@ inline fvar<T> fmax(const fvar<T>& x1, const fvar<T>& x2) {
 template <typename T>
 inline fvar<T> fmax(double x1, const fvar<T>& x2) {
   if (unlikely(is_nan(x1))) {
-    if (is_nan(x2.val_)) {
-      return fvar<T>(fmax(x1, x2.val_), NOT_A_NUMBER);
-    } else {
-      return fvar<T>(x2.val_, x2.d_);
+    if (unlikely(is_nan(x2))) {
+      return fvar<T>(NOT_A_NUMBER, NOT_A_NUMBER);
     }
-  } else if (unlikely(is_nan(x2.val_))) {
-    return fvar<T>(x1, 0.0);
-  } else if (x1 > x2.val_) {
-    return fvar<T>(x1, 0.0);
-  } else if (x1 == x2.val_) {
-    return fvar<T>(x2.val_, NOT_A_NUMBER);
-  } else {
-    return fvar<T>(x2.val_, x2.d_);
+    return x2;
   }
+  if (unlikely(is_nan(x2))) {
+    return fvar<T>(x1, 0);
+  }
+  return x1 > x2 ? fvar<T>(x1, 0) : x2;
 }
 
 /**
@@ -77,21 +67,16 @@ inline fvar<T> fmax(double x1, const fvar<T>& x2) {
  */
 template <typename T>
 inline fvar<T> fmax(const fvar<T>& x1, double x2) {
-  if (unlikely(is_nan(x1.val_))) {
-    if (is_nan(x2)) {
-      return fvar<T>(fmax(x1.val_, x2), NOT_A_NUMBER);
-    } else {
-      return fvar<T>(x2, 0.0);
+  if (unlikely(is_nan(x1))) {
+    if (unlikely(is_nan(x2))) {
+      return fvar<T>(NOT_A_NUMBER, NOT_A_NUMBER);
     }
-  } else if (unlikely(is_nan(x2))) {
-    return fvar<T>(x1.val_, x1.d_);
-  } else if (x1.val_ > x2) {
-    return fvar<T>(x1.val_, x1.d_);
-  } else if (x1.val_ == x2) {
-    return fvar<T>(x1.val_, NOT_A_NUMBER);
-  } else {
-    return fvar<T>(x2, 0.0);
+    return fvar<T>(x2, 0);
   }
+  if (unlikely(is_nan(x2))) {
+    return x1;
+  }
+  return x1 > x2 ? x1 : fvar<T>(x2, 0);
 }
 
 }  // namespace math

--- a/stan/math/fwd/fun/fmin.hpp
+++ b/stan/math/fwd/fun/fmin.hpp
@@ -12,59 +12,44 @@ namespace math {
 
 template <typename T>
 inline fvar<T> fmin(const fvar<T>& x1, const fvar<T>& x2) {
-  if (unlikely(is_nan(x1.val_))) {
-    if (is_nan(x2.val_)) {
-      return fvar<T>(fmin(x1.val_, x2.val_), NOT_A_NUMBER);
-    } else {
-      return fvar<T>(x2.val_, x2.d_);
+  if (unlikely(is_nan(x1))) {
+    if (unlikely(is_nan(x2))) {
+      return fvar<T>(NOT_A_NUMBER, NOT_A_NUMBER);
     }
-  } else if (unlikely(is_nan(x2.val_))) {
-    return fvar<T>(x1.val_, x1.d_);
-  } else if (x1.val_ < x2.val_) {
-    return fvar<T>(x1.val_, x1.d_);
-  } else if (x1.val_ == x2.val_) {
-    return fvar<T>(x1.val_, NOT_A_NUMBER);
-  } else {
-    return fvar<T>(x2.val_, x2.d_);
+    return x2;
   }
+  if (unlikely(is_nan(x2))) {
+    return x1;
+  }
+  return x1 < x2 ? x1 : x2;
 }
 
 template <typename T>
 inline fvar<T> fmin(double x1, const fvar<T>& x2) {
   if (unlikely(is_nan(x1))) {
-    if (is_nan(x2.val_)) {
-      return fvar<T>(fmin(x1, x2.val_), NOT_A_NUMBER);
-    } else {
-      return fvar<T>(x2.val_, x2.d_);
+    if (unlikely(is_nan(x2))) {
+      return fvar<T>(NOT_A_NUMBER, NOT_A_NUMBER);
     }
-  } else if (unlikely(is_nan(x2.val_))) {
-    return fvar<T>(x1, 0.0);
-  } else if (x1 < x2.val_) {
-    return fvar<T>(x1, 0.0);
-  } else if (x1 == x2.val_) {
-    return fvar<T>(x2.val_, NOT_A_NUMBER);
-  } else {
-    return fvar<T>(x2.val_, x2.d_);
+    return x2;
   }
+  if (unlikely(is_nan(x2))) {
+    return fvar<T>(x1, 0);
+  }
+  return x2 <= x1 ? x2 : fvar<T>(x1, 0);
 }
 
 template <typename T>
 inline fvar<T> fmin(const fvar<T>& x1, double x2) {
-  if (unlikely(is_nan(x1.val_))) {
-    if (is_nan(x2)) {
-      return fvar<T>(fmin(x1.val_, x2), NOT_A_NUMBER);
-    } else {
-      return fvar<T>(x2, 0.0);
+  if (unlikely(is_nan(x1))) {
+    if (unlikely(is_nan(x2))) {
+      return fvar<T>(NOT_A_NUMBER, NOT_A_NUMBER);
     }
-  } else if (unlikely(is_nan(x2))) {
-    return fvar<T>(x1.val_, x1.d_);
-  } else if (x1.val_ < x2) {
-    return fvar<T>(x1.val_, x1.d_);
-  } else if (x1.val_ == x2) {
-    return fvar<T>(x1.val_, NOT_A_NUMBER);
-  } else {
-    return fvar<T>(x2, 0.0);
+    return fvar<T>(x2, 0);
   }
+  if (unlikely(is_nan(x2))) {
+    return x1;
+  }
+  return x1 <= x2 ? x1 : fvar<T>(x2, 0);
 }
 
 }  // namespace math

--- a/test/unit/math/mix/fun/fmax_test.cpp
+++ b/test/unit/math/mix/fun/fmax_test.cpp
@@ -30,3 +30,15 @@ TEST(mathMixScalFun, fmax_vec) {
   in2 << 0.5, 3.4;
   stan::test::expect_ad_vectorized_binary(f, in1, in2);
 }
+
+TEST(mathMixScalFun, fmax_equal) {
+  using stan::math::fmax;
+  using stan::math::fvar;
+  using stan::math::var;
+
+  var a = 1, b = 1, c = fmax(a, b);
+  c.grad();
+
+  fvar<double> d = {1, 1}, e = {1, 1}, f = fmax(d, e);
+  EXPECT_FLOAT_EQ(a.adj() + b.adj(), f.d_);
+}

--- a/test/unit/math/mix/fun/fmin_test.cpp
+++ b/test/unit/math/mix/fun/fmin_test.cpp
@@ -31,3 +31,15 @@ TEST(mathMixScalFun, fmin_vec) {
   in2 << 0.5, 3.4;
   stan::test::expect_ad_vectorized_binary(f, in1, in2);
 }
+
+TEST(mathMixScalFun, fmin_equal) {
+  using stan::math::fmin;
+  using stan::math::fvar;
+  using stan::math::var;
+
+  var a = 1, b = 1, c = fmin(a, b);
+  c.grad();
+
+  fvar<double> d = {1, 1}, e = {1, 1}, f = fmin(d, e);
+  EXPECT_FLOAT_EQ(a.adj() + b.adj(), f.d_);
+}


### PR DESCRIPTION
## Summary

Currently, the rev & fwd definitions of ```fmin``` and ```fmax``` behave differently in the case of ```x == y```. This PR brings the fwd definition in line with the rev definition

## Tests

Added tests of gradient equality between var and fvar when calling ```fmin``` or ```fmax``` with equal numbers

## Side Effects

N/A

## Release notes

Made behaviour of ```fmin``` and ```fmax``` with equal inputs equivalent across reverse- and forward-mode

## Checklist

- [x] Math issue #2060

- [x] Copyright holder: Andrew Johnson

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
