### PR TITLE
Add expression testing values for log_diff_exp

### DIFF
--- a/test/expressions/generateExpressionTests.py
+++ b/test/expressions/generateExpressionTests.py
@@ -136,6 +136,7 @@ special_arg_values = {
 	"hmm_hidden_state_prob" : [None, 1, 1],
 	"hmm_latent_rng" : [None, 1, 1, None],
 	"hmm_marginal" : [None, 1, 1],
+    "log_diff_exp" : [3, None],
 }
 def make_arg_code(arg, scalar, var_name, var_number, function_name):
     """


### PR DESCRIPTION
## Summary

The ```log_diff_exp``` function will fail in expression tests with the default values as ```nan``` values are returned, this PR specifies values to test so that a valid result is returned 

## Tests

N/A

## Side Effects

N/A

## Release notes

N/A

## Checklist

- [x] Math issue #(issue number)

- [x] Copyright holder: Andrew Johnson

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
