### PR TITLE
Remove direct includes of Eigen

### DIFF
--- a/stan/math/opencl/matrix_cl_view.hpp
+++ b/stan/math/opencl/matrix_cl_view.hpp
@@ -3,7 +3,7 @@
 #ifdef STAN_OPENCL
 
 #include <stan/math/opencl/stringify.hpp>
-#include <Eigen/Core>
+#include <stan/math/prim/fun/Eigen.hpp>
 #include <type_traits>
 
 namespace stan {

--- a/stan/math/opencl/prim/categorical_logit_glm_lpmf.hpp
+++ b/stan/math/opencl/prim/categorical_logit_glm_lpmf.hpp
@@ -7,7 +7,7 @@
 #include <stan/math/prim/fun/size_zero.hpp>
 #include <stan/math/prim/fun/sum.hpp>
 #include <stan/math/prim/fun/to_ref.hpp>
-#include <Eigen/Core>
+#include <stan/math/prim/fun/Eigen.hpp>
 
 #include <stan/math/opencl/matrix_cl.hpp>
 #include <stan/math/opencl/copy.hpp>

--- a/stan/math/prim/prob/categorical_logit_glm_lpmf.hpp
+++ b/stan/math/prim/prob/categorical_logit_glm_lpmf.hpp
@@ -10,7 +10,7 @@
 #include <stan/math/prim/fun/to_ref.hpp>
 #include <stan/math/prim/fun/value_of_rec.hpp>
 #include <stan/math/prim/functor/operands_and_partials.hpp>
-#include <Eigen/Core>
+#include <stan/math/prim/fun/Eigen.hpp>
 #include <cmath>
 
 namespace stan {

--- a/stan/math/prim/prob/hmm_hidden_state_prob.hpp
+++ b/stan/math/prim/prob/hmm_hidden_state_prob.hpp
@@ -4,7 +4,7 @@
 #include <stan/math/prim/core.hpp>
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/err/hmm_check.hpp>
-#include <Eigen/Core>
+#include <stan/math/prim/fun/Eigen.hpp>
 #include <boost/random.hpp>
 #include <vector>
 

--- a/stan/math/prim/prob/hmm_latent_rng.hpp
+++ b/stan/math/prim/prob/hmm_latent_rng.hpp
@@ -4,7 +4,7 @@
 #include <stan/math/prim/core.hpp>
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/err/hmm_check.hpp>
-#include <Eigen/Core>
+#include <stan/math/prim/fun/Eigen.hpp>
 #include <boost/random.hpp>
 #include <vector>
 

--- a/test/unit/math/mix/meta/eigen_utils.hpp
+++ b/test/unit/math/mix/meta/eigen_utils.hpp
@@ -2,7 +2,7 @@
 #define TEST_UNIT_MATH_MIX_EIGEN_UTILS_HPP
 #include <stan/math/mix.hpp>
 #include <test/unit/pretty_print_types.hpp>
-#include <Eigen/Sparse>
+#include <stan/math/prim/fun/Eigen.hpp>
 #include <gtest/gtest.h>
 #include <vector>
 


### PR DESCRIPTION
## Summary

In some places, we directly include `<Eigen/...>` files. That is discouraged due to our implementations of .val() and .adj(). This PR cleans that up. This popped up in the OpenCL GLM refactor.

## Tests

/

## Side Effects

/

## Release notes

Cleaned up the use of `<Eigen/*>` outside the main Eigen header file.

## Checklist


- [x] Copyright holder: Rok Češnovar

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
