### PR TITLE
add a list of functions with no math implementations

### DIFF
--- a/test/expressions/generateExpressionTests.py
+++ b/test/expressions/generateExpressionTests.py
@@ -11,9 +11,7 @@ else:
 
 src_folder = "./test/expressions/"
 build_folder = "./test/expressions/"
-exceptions_list_location = (
-    "./test/expressions/stan_math_sigs_exceptions.expected"
-)
+exceptions_list_location = "./test/expressions/stan_math_sigs_exceptions.expected"
 
 eigen_types = ["matrix", "vector", "row_vector"]
 arg_types = {
@@ -128,18 +126,21 @@ def parse_signature(signature):
 # list of function arguments that need special scalar values.
 # None means to use the default argument value.
 special_arg_values = {
-	"acosh" : [1.4],
-	"log1m_exp" : [-0.6],
-	"categorical_log" : [None, 1],
-	"categorical_rng" : [1, None],
-	"categorical_lpmf" : [None, 1],
-	"hmm_hidden_state_prob" : [None, 1, 1],
-	"hmm_latent_rng" : [None, 1, 1, None],
-	"hmm_marginal" : [None, 1, 1],
-	"lkj_corr_lpdf" : [1, None],
-	"lkj_corr_log" : [1, None],
-  "log_diff_exp" : [3, None],
+    "acosh": [1.4],
+    "log1m_exp": [-0.6],
+    "categorical_log": [None, 1],
+    "categorical_rng": [1, None],
+    "categorical_lpmf": [None, 1],
+    "hmm_hidden_state_prob": [None, 1, 1],
+    "hmm_latent_rng": [None, 1, 1, None],
+    "hmm_marginal": [None, 1, 1],
+    "lkj_corr_lpdf": [1, None],
+    "lkj_corr_log": [1, None],
+    "log_diff_exp": [3, None],
+    "log_inv_logit_diff": [1.2, 0.4],
 }
+
+
 def make_arg_code(arg, scalar, var_name, var_number, function_name):
     """
     Makes code for declaration and initialization of an argument to function.
@@ -161,17 +162,18 @@ def make_arg_code(arg, scalar, var_name, var_number, function_name):
             "  %s %s = [](const auto& a, const auto&, const auto&, const auto&){return a;}"
             % (arg_type, var_name)
         )
-    elif function_name in special_arg_values and special_arg_values[function_name][var_number] is not None:
-        return (
-            "  %s %s = stan::test::make_arg<%s>(%f)"
-            % (arg_type, var_name, arg_type, special_arg_values[function_name][var_number])
-        )
-    else:
-        return "  %s %s = stan::test::make_arg<%s>()" % (
+    elif (
+        function_name in special_arg_values
+        and special_arg_values[function_name][var_number] is not None
+    ):
+        return "  %s %s = stan::test::make_arg<%s>(%f)" % (
             arg_type,
             var_name,
             arg_type,
+            special_arg_values[function_name][var_number],
         )
+    else:
+        return "  %s %s = stan::test::make_arg<%s>()" % (arg_type, var_name, arg_type,)
 
 
 def save_tests_in_files(N_files, tests):
@@ -210,13 +212,11 @@ def handle_function_list(functions_input, signatures):
             function_names.append(f)
     return function_names, function_signatures
 
+
 # lists of functions that do not support fwd or rev autodiff
-no_rev_overload = [
-    "hmm_hidden_state_prob"
-]
-no_fwd_overload = [
-    "hmm_hidden_state_prob"
-]
+no_rev_overload = ["hmm_hidden_state_prob"]
+no_fwd_overload = ["hmm_hidden_state_prob"]
+
 
 def main(functions=(), j=1):
     """
@@ -248,9 +248,11 @@ def main(functions=(), j=1):
         if signature in ignored and not functions and signature not in extra_signatures:
             continue
         # skip default if we have list of function names/signatures to test
-        if ((functions or extra_signatures) and
-                function_name not in functions and
-                signature not in extra_signatures):
+        if (
+            (functions or extra_signatures)
+            and function_name not in functions
+            and signature not in extra_signatures
+        ):
             continue
         # skip signatures without eigen inputs
         for arg2test in eigen_types:
@@ -281,13 +283,19 @@ def main(functions=(), j=1):
 
             mat_declarations = ""
             for n, arg in enumerate(function_args):
-                mat_declarations += make_arg_code(arg, scalar, "arg_mat%d" % n, n, function_name) + ";\n"
+                mat_declarations += (
+                    make_arg_code(arg, scalar, "arg_mat%d" % n, n, function_name)
+                    + ";\n"
+                )
 
             mat_arg_list = ", ".join("arg_mat%d" % n for n in range(len(function_args)))
 
             expression_declarations = ""
             for n, arg in enumerate(function_args):
-                expression_declarations += make_arg_code(arg, scalar, "arg_expr%d" % n, n, function_name) + ";\n"
+                expression_declarations += (
+                    make_arg_code(arg, scalar, "arg_expr%d" % n, n, function_name)
+                    + ";\n"
+                )
                 if arg in eigen_types:
                     expression_declarations += "  int counter%d = 0;\n" % n
                     expression_declarations += (
@@ -298,7 +306,10 @@ def main(functions=(), j=1):
             expression_arg_list = ""
             for n, arg in enumerate(function_args[:-1]):
                 if arg in eigen_types:
-                    expression_arg_list += "arg_expr%d.unaryExpr(counter_op%d), " % (n, n)
+                    expression_arg_list += "arg_expr%d.unaryExpr(counter_op%d), " % (
+                        n,
+                        n,
+                    )
                 else:
                     expression_arg_list += "arg_expr%d, " % n
             if function_args[-1] in eigen_types:
@@ -329,19 +340,19 @@ def main(functions=(), j=1):
                     # functors don't have adjoints to check
                     if arg == "(vector, vector, data real[], data int[]) => vector":
                         continue
-                    checks += "  EXPECT_STAN_ADJ_EQ(arg_expr%d,arg_mat%d);\n" % (
-                        n,
-                        n,
-                    )
-            tests.append(test_code_template.format(overload=overload,
-                                                   function_name=function_name,
-                                                   signature_number=func_test_n,
-                                                   matrix_argument_declarations=mat_declarations,
-                                                   matrix_argument_list=mat_arg_list,
-                                                   expression_argument_declarations=expression_declarations,
-                                                   expression_argument_list=expression_arg_list,
-                                                   checks=checks,
-                                                   ))
+                    checks += "  EXPECT_STAN_ADJ_EQ(arg_expr%d,arg_mat%d);\n" % (n, n,)
+            tests.append(
+                test_code_template.format(
+                    overload=overload,
+                    function_name=function_name,
+                    signature_number=func_test_n,
+                    matrix_argument_declarations=mat_declarations,
+                    matrix_argument_list=mat_arg_list,
+                    expression_argument_declarations=expression_declarations,
+                    expression_argument_list=expression_arg_list,
+                    checks=checks,
+                )
+            )
     if remaining_functions:
         raise NameError("Functions not found: " + ", ".join(remaining_functions))
     save_tests_in_files(j, tests)

--- a/test/expressions/generateExpressionTests.py
+++ b/test/expressions/generateExpressionTests.py
@@ -14,10 +14,6 @@ build_folder = "./test/expressions/"
 exceptions_list_location = (
     "./test/expressions/stan_math_sigs_exceptions.expected"
 )
-exception_functions_list = (
-    "lmultiply",
-    "lchoose"
-)
 
 eigen_types = ["matrix", "vector", "row_vector"]
 arg_types = {
@@ -250,9 +246,6 @@ def main(functions=(), j=1):
         return_type, function_name, function_args = parse_signature(signature)
         # skip ignored signatures
         if signature in ignored and not functions and signature not in extra_signatures:
-            continue
-        # skip ignored functions
-        if function_name in exception_functions_list:
             continue
         # skip default if we have list of function names/signatures to test
         if ((functions or extra_signatures) and

--- a/test/expressions/generateExpressionTests.py
+++ b/test/expressions/generateExpressionTests.py
@@ -14,6 +14,10 @@ build_folder = "./test/expressions/"
 exceptions_list_location = (
     "./test/expressions/stan_math_sigs_exceptions.expected"
 )
+exception_functions_list = (
+    "lmultiply",
+    "lchoose"
+)
 
 eigen_types = ["matrix", "vector", "row_vector"]
 arg_types = {
@@ -246,6 +250,9 @@ def main(functions=(), j=1):
         return_type, function_name, function_args = parse_signature(signature)
         # skip ignored signatures
         if signature in ignored and not functions and signature not in extra_signatures:
+            continue
+        # skip ignored functions
+        if function_name in exception_functions_list:
             continue
         # skip default if we have list of function names/signatures to test
         if ((functions or extra_signatures) and

--- a/test/expressions/stan_math_sigs_exceptions.expected
+++ b/test/expressions/stan_math_sigs_exceptions.expected
@@ -1,3 +1,18 @@
+vector lmultiply(int, vector)
+vector lmultiply(real, vector)
+vector lmultiply(vector, int)
+vector lmultiply(vector, real)
+vector lmultiply(vector, vector)
+row_vector lmultiply(int, row_vector)
+row_vector lmultiply(real, row_vector)
+row_vector lmultiply(row_vector, int)
+row_vector lmultiply(row_vector, real)
+row_vector lmultiply(row_vector, row_vector)
+matrix lmultiply(int, matrix)
+matrix lmultiply(real, matrix)
+matrix lmultiply(matrix, int)
+matrix lmultiply(matrix, real)
+matrix lmultiply(matrix, matrix)
 vector algebra_solver((vector, vector, data real[], data int[]) => vector,
                         vector, vector, real[], int[])
 vector algebra_solver((vector, vector, data real[], data int[]) => vector,


### PR DESCRIPTION
Fixes #2079 

## Summary

This PR fixes expression tests for the `lmultiply` function. The issue is that stanc3 supports lmultiply but there is no Math implementation of it as stanc3 transpiles lmultiply as multiply_log. We need to cover these exceptions in the expression tests.

## Tests

This is fixing tests.

## Side Effects

/

## Release notes

## Checklist

- [x] Math issue #2079

- [x] Copyright holder: Rok Češnovar, Univ. of Ljubljana

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
