### PR TITLE
Simplify gpu glm testing

### DIFF
--- a/test/unit/math/opencl/rev/bernoulli_logit_glm_lpmf_test.cpp
+++ b/test/unit/math/opencl/rev/bernoulli_logit_glm_lpmf_test.cpp
@@ -2,7 +2,7 @@
 #include <stan/math/opencl/rev/opencl.hpp>
 #include <stan/math.hpp>
 #include <gtest/gtest.h>
-#include <test/unit/math/expect_near_rel.hpp>
+#include <test/unit/math/opencl/util.hpp>
 #include <vector>
 
 using Eigen::Array;
@@ -14,7 +14,6 @@ using stan::test::expect_near_rel;
 using std::vector;
 
 TEST(ProbDistributionsBernoulliLogitGLM, error_checking) {
-  double eps = 1e-9;
   int N = 3;
   int M = 2;
 
@@ -92,8 +91,16 @@ TEST(ProbDistributionsBernoulliLogitGLM, error_checking) {
       std::domain_error);
 }
 
+auto bernoulli_logit_glm_lpmf_functor
+    = [](const auto& y, const auto& x, const auto& alpha, const auto& beta) {
+        return stan::math::bernoulli_logit_glm_lpmf(y, x, alpha, beta);
+      };
+auto bernoulli_logit_glm_lpmf_functor_propto
+    = [](const auto& y, const auto& x, const auto& alpha, const auto& beta) {
+        return stan::math::bernoulli_logit_glm_lpmf<true>(y, x, alpha, beta);
+      };
+
 TEST(ProbDistributionsBernoulliLogitGLM, gpu_matches_cpu_small_simple) {
-  double eps = 1e-9;
   int N = 3;
   int M = 2;
 
@@ -104,47 +111,13 @@ TEST(ProbDistributionsBernoulliLogitGLM, gpu_matches_cpu_small_simple) {
   beta << 0.3, 2;
   double alpha = 0.3;
 
-  matrix_cl<double> x_cl(x);
-  matrix_cl<int> y_cl(y);
-  matrix_cl<double> beta_cl(beta);
-
-  expect_near_rel(
-      "bernoulli_logit_glm_lpmf (OpenCL)",
-      stan::math::bernoulli_logit_glm_lpmf(y_cl, x_cl, alpha, beta_cl),
-      stan::math::bernoulli_logit_glm_lpmf(y, x, alpha, beta));
-  expect_near_rel(
-      "bernoulli_logit_glm_lpmf (OpenCL)",
-      stan::math::bernoulli_logit_glm_lpmf<true>(y_cl, x_cl, alpha, beta_cl),
-      stan::math::bernoulli_logit_glm_lpmf<true>(y, x, alpha, beta));
-
-  Matrix<var, Dynamic, Dynamic> x_var1 = x;
-  Matrix<var, Dynamic, Dynamic> x_var2 = x;
-  Matrix<var, Dynamic, 1> beta_var1 = beta;
-  Matrix<var, Dynamic, 1> beta_var2 = beta;
-  auto x_var1_cl = to_matrix_cl(x_var1);
-  auto beta_var1_cl = stan::math::to_matrix_cl(beta_var1);
-  var alpha_var1 = alpha;
-  var alpha_var2 = alpha;
-
-  var res1 = stan::math::bernoulli_logit_glm_lpmf(y_cl, x_var1_cl, alpha_var1,
-                                                  beta_var1_cl);
-  var res2
-      = stan::math::bernoulli_logit_glm_lpmf(y, x_var2, alpha_var2, beta_var2);
-
-  (res1 + res2).grad();
-
-  expect_near_rel("bernoulli_logit_glm_lpmf (OpenCL)", res1.val(), res2.val());
-
-  expect_near_rel("bernoulli_logit_glm_lpmf (OpenCL)", x_var1.adj().eval(),
-                  x_var2.adj().eval());
-  expect_near_rel("bernoulli_logit_glm_lpmf (OpenCL)", alpha_var1.adj(),
-                  alpha_var2.adj());
-  expect_near_rel("bernoulli_logit_glm_lpmf (OpenCL)", beta_var1.adj().eval(),
-                  beta_var2.adj().eval());
+  stan::math::test::compare_cpu_gpu_prim_rev(bernoulli_logit_glm_lpmf_functor,
+                                             y, x, alpha, beta);
+  stan::math::test::compare_cpu_gpu_prim_rev(
+      bernoulli_logit_glm_lpmf_functor_propto, y, x, alpha, beta);
 }
 
 TEST(ProbDistributionsBernoulliLogitGLM, gpu_broadcast_y) {
-  double eps = 1e-9;
   int N = 3;
   int M = 2;
 
@@ -199,7 +172,6 @@ TEST(ProbDistributionsBernoulliLogitGLM, gpu_broadcast_y) {
 }
 
 TEST(ProbDistributionsBernoulliLogitGLM, gpu_matches_cpu_zero_instances) {
-  double eps = 1e-9;
   int N = 0;
   int M = 2;
 
@@ -209,47 +181,13 @@ TEST(ProbDistributionsBernoulliLogitGLM, gpu_matches_cpu_zero_instances) {
   beta << 0.3, 2;
   double alpha = 0.3;
 
-  matrix_cl<double> x_cl(x);
-  matrix_cl<int> y_cl(y);
-  matrix_cl<double> beta_cl(beta);
-
-  expect_near_rel(
-      "bernoulli_logit_glm_lpmf (OpenCL)",
-      stan::math::bernoulli_logit_glm_lpmf(y_cl, x_cl, alpha, beta_cl),
-      stan::math::bernoulli_logit_glm_lpmf(y, x, alpha, beta));
-  expect_near_rel(
-      "bernoulli_logit_glm_lpmf (OpenCL)",
-      stan::math::bernoulli_logit_glm_lpmf<true>(y_cl, x_cl, alpha, beta_cl),
-      stan::math::bernoulli_logit_glm_lpmf<true>(y, x, alpha, beta));
-
-  Matrix<var, Dynamic, Dynamic> x_var1 = x;
-  Matrix<var, Dynamic, Dynamic> x_var2 = x;
-  Matrix<var, Dynamic, 1> beta_var1 = beta;
-  Matrix<var, Dynamic, 1> beta_var2 = beta;
-  auto x_var1_cl = to_matrix_cl(x_var1);
-  auto beta_var1_cl = stan::math::to_matrix_cl(beta_var1);
-  var alpha_var1 = alpha;
-  var alpha_var2 = alpha;
-
-  var res1 = stan::math::bernoulli_logit_glm_lpmf(y_cl, x_var1_cl, alpha_var1,
-                                                  beta_var1_cl);
-  var res2
-      = stan::math::bernoulli_logit_glm_lpmf(y, x_var2, alpha_var2, beta_var2);
-
-  (res1 + res2).grad();
-
-  expect_near_rel("bernoulli_logit_glm_lpmf (OpenCL)", res1.val(), res2.val());
-
-  expect_near_rel("bernoulli_logit_glm_lpmf (OpenCL)", x_var1.adj().eval(),
-                  x_var2.adj().eval());
-  expect_near_rel("bernoulli_logit_glm_lpmf (OpenCL)", alpha_var1.adj(),
-                  alpha_var2.adj());
-  expect_near_rel("bernoulli_logit_glm_lpmf (OpenCL)", beta_var1.adj().eval(),
-                  beta_var2.adj().eval());
+  stan::math::test::compare_cpu_gpu_prim_rev(bernoulli_logit_glm_lpmf_functor,
+                                             y, x, alpha, beta);
+  stan::math::test::compare_cpu_gpu_prim_rev(
+      bernoulli_logit_glm_lpmf_functor_propto, y, x, alpha, beta);
 }
 
 TEST(ProbDistributionsBernoulliLogitGLM, gpu_matches_cpu_zero_attributes) {
-  double eps = 1e-9;
   int N = 3;
   int M = 0;
 
@@ -258,47 +196,13 @@ TEST(ProbDistributionsBernoulliLogitGLM, gpu_matches_cpu_zero_attributes) {
   Matrix<double, Dynamic, 1> beta(M, 1);
   double alpha = 0.3;
 
-  matrix_cl<double> x_cl(x);
-  matrix_cl<int> y_cl(y);
-  matrix_cl<double> beta_cl(beta);
-
-  expect_near_rel(
-      "bernoulli_logit_glm_lpmf (OpenCL)",
-      stan::math::bernoulli_logit_glm_lpmf(y_cl, x_cl, alpha, beta_cl),
-      stan::math::bernoulli_logit_glm_lpmf(y, x, alpha, beta));
-  expect_near_rel(
-      "bernoulli_logit_glm_lpmf (OpenCL)",
-      stan::math::bernoulli_logit_glm_lpmf<true>(y_cl, x_cl, alpha, beta_cl),
-      stan::math::bernoulli_logit_glm_lpmf<true>(y, x, alpha, beta));
-
-  Matrix<var, Dynamic, Dynamic> x_var1 = x;
-  Matrix<var, Dynamic, Dynamic> x_var2 = x;
-  Matrix<var, Dynamic, 1> beta_var1 = beta;
-  Matrix<var, Dynamic, 1> beta_var2 = beta;
-  auto x_var1_cl = to_matrix_cl(x_var1);
-  auto beta_var1_cl = stan::math::to_matrix_cl(beta_var1);
-  var alpha_var1 = alpha;
-  var alpha_var2 = alpha;
-
-  var res1 = stan::math::bernoulli_logit_glm_lpmf(y_cl, x_var1_cl, alpha_var1,
-                                                  beta_var1_cl);
-  var res2
-      = stan::math::bernoulli_logit_glm_lpmf(y, x_var2, alpha_var2, beta_var2);
-
-  (res1 + res2).grad();
-
-  expect_near_rel("bernoulli_logit_glm_lpmf (OpenCL)", res1.val(), res2.val());
-
-  expect_near_rel("bernoulli_logit_glm_lpmf (OpenCL)", x_var1.adj().eval(),
-                  x_var2.adj().eval());
-  expect_near_rel("bernoulli_logit_glm_lpmf (OpenCL)", alpha_var1.adj(),
-                  alpha_var2.adj());
-  expect_near_rel("bernoulli_logit_glm_lpmf (OpenCL)", beta_var1.adj().eval(),
-                  beta_var2.adj().eval());
+  stan::math::test::compare_cpu_gpu_prim_rev(bernoulli_logit_glm_lpmf_functor,
+                                             y, x, alpha, beta);
+  stan::math::test::compare_cpu_gpu_prim_rev(
+      bernoulli_logit_glm_lpmf_functor_propto, y, x, alpha, beta);
 }
 
 TEST(ProbDistributionsBernoulliLogitGLM, gpu_matches_cpu_small_vector_alpha) {
-  double eps = 1e-9;
   int N = 3;
   int M = 2;
 
@@ -310,49 +214,13 @@ TEST(ProbDistributionsBernoulliLogitGLM, gpu_matches_cpu_small_vector_alpha) {
   Matrix<double, Dynamic, 1> alpha(N, 1);
   alpha << 0.3, -0.8, 1.8;
 
-  matrix_cl<double> x_cl(x);
-  matrix_cl<int> y_cl(y);
-  matrix_cl<double> alpha_cl(alpha);
-  matrix_cl<double> beta_cl(beta);
-
-  expect_near_rel(
-      "bernoulli_logit_glm_lpmf (OpenCL)",
-      stan::math::bernoulli_logit_glm_lpmf(y_cl, x_cl, alpha_cl, beta_cl),
-      stan::math::bernoulli_logit_glm_lpmf(y, x, alpha, beta));
-  expect_near_rel(
-      "bernoulli_logit_glm_lpmf (OpenCL)",
-      stan::math::bernoulli_logit_glm_lpmf<true>(y_cl, x_cl, alpha_cl, beta_cl),
-      stan::math::bernoulli_logit_glm_lpmf<true>(y, x, alpha, beta));
-
-  Matrix<var, Dynamic, Dynamic> x_var1 = x;
-  Matrix<var, Dynamic, Dynamic> x_var2 = x;
-  Matrix<var, Dynamic, 1> beta_var1 = beta;
-  Matrix<var, Dynamic, 1> beta_var2 = beta;
-  Matrix<var, Dynamic, 1> alpha_var1 = alpha;
-  Matrix<var, Dynamic, 1> alpha_var2 = alpha;
-  auto x_var1_cl = to_matrix_cl(x_var1);
-  auto alpha_var1_cl = to_matrix_cl(alpha_var1);
-  auto beta_var1_cl = to_matrix_cl(beta_var1);
-
-  var res1 = stan::math::bernoulli_logit_glm_lpmf(y_cl, x_var1_cl,
-                                                  alpha_var1_cl, beta_var1_cl);
-  var res2
-      = stan::math::bernoulli_logit_glm_lpmf(y, x_var2, alpha_var2, beta_var2);
-
-  (res1 + res2).grad();
-
-  expect_near_rel("bernoulli_logit_glm_lpmf (OpenCL)", res1.val(), res2.val());
-
-  expect_near_rel("bernoulli_logit_glm_lpmf (OpenCL)", x_var1.adj().eval(),
-                  x_var2.adj().eval());
-  expect_near_rel("bernoulli_logit_glm_lpmf (OpenCL)", beta_var1.adj().eval(),
-                  beta_var2.adj().eval());
-  expect_near_rel("bernoulli_logit_glm_lpmf (OpenCL)", alpha_var1.adj().eval(),
-                  alpha_var2.adj().eval());
+  stan::math::test::compare_cpu_gpu_prim_rev(bernoulli_logit_glm_lpmf_functor,
+                                             y, x, alpha, beta);
+  stan::math::test::compare_cpu_gpu_prim_rev(
+      bernoulli_logit_glm_lpmf_functor_propto, y, x, alpha, beta);
 }
 
 TEST(ProbDistributionsBernoulliLogitGLM, gpu_matches_cpu_big) {
-  double eps = 1e-9;
   int N = 153;
   int M = 71;
 
@@ -365,45 +233,10 @@ TEST(ProbDistributionsBernoulliLogitGLM, gpu_matches_cpu_big) {
   Matrix<double, Dynamic, 1> beta = Matrix<double, Dynamic, 1>::Random(M, 1);
   Matrix<double, Dynamic, 1> alpha = Matrix<double, Dynamic, 1>::Random(N, 1);
 
-  matrix_cl<double> x_cl(x);
-  matrix_cl<int> y_cl(y);
-  matrix_cl<double> alpha_cl(alpha);
-  matrix_cl<double> beta_cl(beta);
-
-  expect_near_rel(
-      "bernoulli_logit_glm_lpmf (OpenCL)",
-      stan::math::bernoulli_logit_glm_lpmf(y_cl, x_cl, alpha_cl, beta_cl),
-      stan::math::bernoulli_logit_glm_lpmf(y, x, alpha, beta));
-  expect_near_rel(
-      "bernoulli_logit_glm_lpmf (OpenCL)",
-      stan::math::bernoulli_logit_glm_lpmf(y_cl, x_cl, alpha_cl, beta_cl),
-      stan::math::bernoulli_logit_glm_lpmf(y, x, alpha, beta));
-
-  Matrix<var, Dynamic, Dynamic> x_var1 = x;
-  Matrix<var, Dynamic, Dynamic> x_var2 = x;
-  Matrix<var, Dynamic, 1> beta_var1 = beta;
-  Matrix<var, Dynamic, 1> beta_var2 = beta;
-  Matrix<var, Dynamic, 1> alpha_var1 = alpha;
-  Matrix<var, Dynamic, 1> alpha_var2 = alpha;
-  auto x_var1_cl = to_matrix_cl(x_var1);
-  auto alpha_var1_cl = to_matrix_cl(alpha_var1);
-  auto beta_var1_cl = to_matrix_cl(beta_var1);
-
-  var res1 = stan::math::bernoulli_logit_glm_lpmf<true>(
-      y_cl, x_var1_cl, alpha_var1_cl, beta_var1_cl);
-  var res2 = stan::math::bernoulli_logit_glm_lpmf<true>(y, x_var2, alpha_var2,
-                                                        beta_var2);
-
-  (res1 + res2).grad();
-
-  expect_near_rel("bernoulli_logit_glm_lpmf (OpenCL)", res1.val(), res2.val());
-
-  expect_near_rel("bernoulli_logit_glm_lpmf (OpenCL)", x_var1.adj().eval(),
-                  x_var2.adj().eval());
-  expect_near_rel("bernoulli_logit_glm_lpmf (OpenCL)", beta_var1.adj().eval(),
-                  beta_var2.adj().eval());
-  expect_near_rel("bernoulli_logit_glm_lpmf (OpenCL)", alpha_var1.adj().eval(),
-                  alpha_var2.adj().eval());
+  stan::math::test::compare_cpu_gpu_prim_rev(bernoulli_logit_glm_lpmf_functor,
+                                             y, x, alpha, beta);
+  stan::math::test::compare_cpu_gpu_prim_rev(
+      bernoulli_logit_glm_lpmf_functor_propto, y, x, alpha, beta);
 }
 
 #endif

--- a/test/unit/math/opencl/rev/bernoulli_logit_glm_lpmf_test.cpp
+++ b/test/unit/math/opencl/rev/bernoulli_logit_glm_lpmf_test.cpp
@@ -111,8 +111,8 @@ TEST(ProbDistributionsBernoulliLogitGLM, opencl_matches_cpu_small_simple) {
   beta << 0.3, 2;
   double alpha = 0.3;
 
-  stan::math::test::compare_cpu_opencl_prim_rev(bernoulli_logit_glm_lpmf_functor,
-                                             y, x, alpha, beta);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      bernoulli_logit_glm_lpmf_functor, y, x, alpha, beta);
   stan::math::test::compare_cpu_opencl_prim_rev(
       bernoulli_logit_glm_lpmf_functor_propto, y, x, alpha, beta);
 }
@@ -181,8 +181,8 @@ TEST(ProbDistributionsBernoulliLogitGLM, opencl_matches_cpu_zero_instances) {
   beta << 0.3, 2;
   double alpha = 0.3;
 
-  stan::math::test::compare_cpu_opencl_prim_rev(bernoulli_logit_glm_lpmf_functor,
-                                             y, x, alpha, beta);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      bernoulli_logit_glm_lpmf_functor, y, x, alpha, beta);
   stan::math::test::compare_cpu_opencl_prim_rev(
       bernoulli_logit_glm_lpmf_functor_propto, y, x, alpha, beta);
 }
@@ -196,13 +196,14 @@ TEST(ProbDistributionsBernoulliLogitGLM, opencl_matches_cpu_zero_attributes) {
   Matrix<double, Dynamic, 1> beta(M, 1);
   double alpha = 0.3;
 
-  stan::math::test::compare_cpu_opencl_prim_rev(bernoulli_logit_glm_lpmf_functor,
-                                             y, x, alpha, beta);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      bernoulli_logit_glm_lpmf_functor, y, x, alpha, beta);
   stan::math::test::compare_cpu_opencl_prim_rev(
       bernoulli_logit_glm_lpmf_functor_propto, y, x, alpha, beta);
 }
 
-TEST(ProbDistributionsBernoulliLogitGLM, opencl_matches_cpu_small_vector_alpha) {
+TEST(ProbDistributionsBernoulliLogitGLM,
+     opencl_matches_cpu_small_vector_alpha) {
   int N = 3;
   int M = 2;
 
@@ -214,8 +215,8 @@ TEST(ProbDistributionsBernoulliLogitGLM, opencl_matches_cpu_small_vector_alpha) 
   Matrix<double, Dynamic, 1> alpha(N, 1);
   alpha << 0.3, -0.8, 1.8;
 
-  stan::math::test::compare_cpu_opencl_prim_rev(bernoulli_logit_glm_lpmf_functor,
-                                             y, x, alpha, beta);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      bernoulli_logit_glm_lpmf_functor, y, x, alpha, beta);
   stan::math::test::compare_cpu_opencl_prim_rev(
       bernoulli_logit_glm_lpmf_functor_propto, y, x, alpha, beta);
 }
@@ -233,8 +234,8 @@ TEST(ProbDistributionsBernoulliLogitGLM, opencl_matches_cpu_big) {
   Matrix<double, Dynamic, 1> beta = Matrix<double, Dynamic, 1>::Random(M, 1);
   Matrix<double, Dynamic, 1> alpha = Matrix<double, Dynamic, 1>::Random(N, 1);
 
-  stan::math::test::compare_cpu_opencl_prim_rev(bernoulli_logit_glm_lpmf_functor,
-                                             y, x, alpha, beta);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      bernoulli_logit_glm_lpmf_functor, y, x, alpha, beta);
   stan::math::test::compare_cpu_opencl_prim_rev(
       bernoulli_logit_glm_lpmf_functor_propto, y, x, alpha, beta);
 }

--- a/test/unit/math/opencl/rev/bernoulli_logit_glm_lpmf_test.cpp
+++ b/test/unit/math/opencl/rev/bernoulli_logit_glm_lpmf_test.cpp
@@ -100,7 +100,7 @@ auto bernoulli_logit_glm_lpmf_functor_propto
         return stan::math::bernoulli_logit_glm_lpmf<true>(y, x, alpha, beta);
       };
 
-TEST(ProbDistributionsBernoulliLogitGLM, gpu_matches_cpu_small_simple) {
+TEST(ProbDistributionsBernoulliLogitGLM, opencl_matches_cpu_small_simple) {
   int N = 3;
   int M = 2;
 
@@ -111,13 +111,13 @@ TEST(ProbDistributionsBernoulliLogitGLM, gpu_matches_cpu_small_simple) {
   beta << 0.3, 2;
   double alpha = 0.3;
 
-  stan::math::test::compare_cpu_gpu_prim_rev(bernoulli_logit_glm_lpmf_functor,
+  stan::math::test::compare_cpu_opencl_prim_rev(bernoulli_logit_glm_lpmf_functor,
                                              y, x, alpha, beta);
-  stan::math::test::compare_cpu_gpu_prim_rev(
+  stan::math::test::compare_cpu_opencl_prim_rev(
       bernoulli_logit_glm_lpmf_functor_propto, y, x, alpha, beta);
 }
 
-TEST(ProbDistributionsBernoulliLogitGLM, gpu_broadcast_y) {
+TEST(ProbDistributionsBernoulliLogitGLM, opencl_broadcast_y) {
   int N = 3;
   int M = 2;
 
@@ -171,7 +171,7 @@ TEST(ProbDistributionsBernoulliLogitGLM, gpu_broadcast_y) {
                   beta_var2.adj().eval());
 }
 
-TEST(ProbDistributionsBernoulliLogitGLM, gpu_matches_cpu_zero_instances) {
+TEST(ProbDistributionsBernoulliLogitGLM, opencl_matches_cpu_zero_instances) {
   int N = 0;
   int M = 2;
 
@@ -181,13 +181,13 @@ TEST(ProbDistributionsBernoulliLogitGLM, gpu_matches_cpu_zero_instances) {
   beta << 0.3, 2;
   double alpha = 0.3;
 
-  stan::math::test::compare_cpu_gpu_prim_rev(bernoulli_logit_glm_lpmf_functor,
+  stan::math::test::compare_cpu_opencl_prim_rev(bernoulli_logit_glm_lpmf_functor,
                                              y, x, alpha, beta);
-  stan::math::test::compare_cpu_gpu_prim_rev(
+  stan::math::test::compare_cpu_opencl_prim_rev(
       bernoulli_logit_glm_lpmf_functor_propto, y, x, alpha, beta);
 }
 
-TEST(ProbDistributionsBernoulliLogitGLM, gpu_matches_cpu_zero_attributes) {
+TEST(ProbDistributionsBernoulliLogitGLM, opencl_matches_cpu_zero_attributes) {
   int N = 3;
   int M = 0;
 
@@ -196,13 +196,13 @@ TEST(ProbDistributionsBernoulliLogitGLM, gpu_matches_cpu_zero_attributes) {
   Matrix<double, Dynamic, 1> beta(M, 1);
   double alpha = 0.3;
 
-  stan::math::test::compare_cpu_gpu_prim_rev(bernoulli_logit_glm_lpmf_functor,
+  stan::math::test::compare_cpu_opencl_prim_rev(bernoulli_logit_glm_lpmf_functor,
                                              y, x, alpha, beta);
-  stan::math::test::compare_cpu_gpu_prim_rev(
+  stan::math::test::compare_cpu_opencl_prim_rev(
       bernoulli_logit_glm_lpmf_functor_propto, y, x, alpha, beta);
 }
 
-TEST(ProbDistributionsBernoulliLogitGLM, gpu_matches_cpu_small_vector_alpha) {
+TEST(ProbDistributionsBernoulliLogitGLM, opencl_matches_cpu_small_vector_alpha) {
   int N = 3;
   int M = 2;
 
@@ -214,13 +214,13 @@ TEST(ProbDistributionsBernoulliLogitGLM, gpu_matches_cpu_small_vector_alpha) {
   Matrix<double, Dynamic, 1> alpha(N, 1);
   alpha << 0.3, -0.8, 1.8;
 
-  stan::math::test::compare_cpu_gpu_prim_rev(bernoulli_logit_glm_lpmf_functor,
+  stan::math::test::compare_cpu_opencl_prim_rev(bernoulli_logit_glm_lpmf_functor,
                                              y, x, alpha, beta);
-  stan::math::test::compare_cpu_gpu_prim_rev(
+  stan::math::test::compare_cpu_opencl_prim_rev(
       bernoulli_logit_glm_lpmf_functor_propto, y, x, alpha, beta);
 }
 
-TEST(ProbDistributionsBernoulliLogitGLM, gpu_matches_cpu_big) {
+TEST(ProbDistributionsBernoulliLogitGLM, opencl_matches_cpu_big) {
   int N = 153;
   int M = 71;
 
@@ -233,9 +233,9 @@ TEST(ProbDistributionsBernoulliLogitGLM, gpu_matches_cpu_big) {
   Matrix<double, Dynamic, 1> beta = Matrix<double, Dynamic, 1>::Random(M, 1);
   Matrix<double, Dynamic, 1> alpha = Matrix<double, Dynamic, 1>::Random(N, 1);
 
-  stan::math::test::compare_cpu_gpu_prim_rev(bernoulli_logit_glm_lpmf_functor,
+  stan::math::test::compare_cpu_opencl_prim_rev(bernoulli_logit_glm_lpmf_functor,
                                              y, x, alpha, beta);
-  stan::math::test::compare_cpu_gpu_prim_rev(
+  stan::math::test::compare_cpu_opencl_prim_rev(
       bernoulli_logit_glm_lpmf_functor_propto, y, x, alpha, beta);
 }
 

--- a/test/unit/math/opencl/rev/categorical_logit_glm_lpmf_test.cpp
+++ b/test/unit/math/opencl/rev/categorical_logit_glm_lpmf_test.cpp
@@ -103,7 +103,7 @@ auto categorical_logit_glm_lpmf_functor_propto
         return stan::math::categorical_logit_glm_lpmf<true>(y, x, alpha, beta);
       };
 
-TEST(ProbDistributionsCategoricalLogitGLM, gpu_matches_cpu_small_simple) {
+TEST(ProbDistributionsCategoricalLogitGLM, opencl_matches_cpu_small_simple) {
   int N = 3;
   int M = 2;
   int C = 3;
@@ -116,13 +116,13 @@ TEST(ProbDistributionsCategoricalLogitGLM, gpu_matches_cpu_small_simple) {
   Matrix<double, Dynamic, 1> alpha(C);
   alpha << 0.3, -2, 0.8;
 
-  stan::math::test::compare_cpu_gpu_prim_rev(categorical_logit_glm_lpmf_functor,
+  stan::math::test::compare_cpu_opencl_prim_rev(categorical_logit_glm_lpmf_functor,
                                              y, x, alpha, beta);
-  stan::math::test::compare_cpu_gpu_prim_rev(
+  stan::math::test::compare_cpu_opencl_prim_rev(
       categorical_logit_glm_lpmf_functor_propto, y, x, alpha, beta);
 }
 
-TEST(ProbDistributionsCategoricalLogitGLM, gpu_broadcast_y) {
+TEST(ProbDistributionsCategoricalLogitGLM, opencl_broadcast_y) {
   int N = 3;
   int M = 2;
   int C = 3;
@@ -176,7 +176,7 @@ TEST(ProbDistributionsCategoricalLogitGLM, gpu_broadcast_y) {
   EXPECT_NEAR_REL(beta_var1.adj().eval(), beta_var2.adj().eval());
 }
 
-TEST(ProbDistributionsCategoricalLogitGLM, gpu_matches_cpu_zero_instances) {
+TEST(ProbDistributionsCategoricalLogitGLM, opencl_matches_cpu_zero_instances) {
   int N = 0;
   int M = 2;
   int C = 3;
@@ -188,13 +188,13 @@ TEST(ProbDistributionsCategoricalLogitGLM, gpu_matches_cpu_zero_instances) {
   Matrix<double, Dynamic, 1> alpha(C);
   alpha << 0.3, -2, 0.8;
 
-  stan::math::test::compare_cpu_gpu_prim_rev(categorical_logit_glm_lpmf_functor,
+  stan::math::test::compare_cpu_opencl_prim_rev(categorical_logit_glm_lpmf_functor,
                                              y, x, alpha, beta);
-  stan::math::test::compare_cpu_gpu_prim_rev(
+  stan::math::test::compare_cpu_opencl_prim_rev(
       categorical_logit_glm_lpmf_functor_propto, y, x, alpha, beta);
 }
 
-TEST(ProbDistributionsCategoricalLogitGLM, gpu_matches_cpu_zero_attributes) {
+TEST(ProbDistributionsCategoricalLogitGLM, opencl_matches_cpu_zero_attributes) {
   int N = 3;
   int M = 0;
   int C = 3;
@@ -205,13 +205,13 @@ TEST(ProbDistributionsCategoricalLogitGLM, gpu_matches_cpu_zero_attributes) {
   Matrix<double, Dynamic, 1> alpha(C);
   alpha << 0.3, -2, 0.8;
 
-  stan::math::test::compare_cpu_gpu_prim_rev(categorical_logit_glm_lpmf_functor,
+  stan::math::test::compare_cpu_opencl_prim_rev(categorical_logit_glm_lpmf_functor,
                                              y, x, alpha, beta);
-  stan::math::test::compare_cpu_gpu_prim_rev(
+  stan::math::test::compare_cpu_opencl_prim_rev(
       categorical_logit_glm_lpmf_functor_propto, y, x, alpha, beta);
 }
 
-TEST(ProbDistributionsCategoricalLogitGLM, gpu_matches_cpu_single_class) {
+TEST(ProbDistributionsCategoricalLogitGLM, opencl_matches_cpu_single_class) {
   int N = 3;
   int M = 2;
   int C = 1;
@@ -224,13 +224,13 @@ TEST(ProbDistributionsCategoricalLogitGLM, gpu_matches_cpu_single_class) {
   Matrix<double, Dynamic, 1> alpha(C);
   alpha << 100000.3;
 
-  stan::math::test::compare_cpu_gpu_prim_rev(categorical_logit_glm_lpmf_functor,
+  stan::math::test::compare_cpu_opencl_prim_rev(categorical_logit_glm_lpmf_functor,
                                              y, x, alpha, beta);
-  stan::math::test::compare_cpu_gpu_prim_rev(
+  stan::math::test::compare_cpu_opencl_prim_rev(
       categorical_logit_glm_lpmf_functor_propto, y, x, alpha, beta);
 }
 
-TEST(ProbDistributionsCategoricalLogitGLM, gpu_matches_cpu_all_vars) {
+TEST(ProbDistributionsCategoricalLogitGLM, opencl_matches_cpu_all_vars) {
   int N = 5;
   int M = 3;
   int C = 2;
@@ -245,13 +245,13 @@ TEST(ProbDistributionsCategoricalLogitGLM, gpu_matches_cpu_all_vars) {
       = Matrix<double, Dynamic, Dynamic>::Random(M, C);
   Matrix<double, Dynamic, 1> alpha = Matrix<double, Dynamic, 1>::Random(C, 1);
 
-  stan::math::test::compare_cpu_gpu_prim_rev(categorical_logit_glm_lpmf_functor,
+  stan::math::test::compare_cpu_opencl_prim_rev(categorical_logit_glm_lpmf_functor,
                                              y, x, alpha, beta);
-  stan::math::test::compare_cpu_gpu_prim_rev(
+  stan::math::test::compare_cpu_opencl_prim_rev(
       categorical_logit_glm_lpmf_functor_propto, y, x, alpha, beta);
 }
 
-TEST(ProbDistributionsCategoricalLogitGLM, gpu_matches_cpu_big) {
+TEST(ProbDistributionsCategoricalLogitGLM, opencl_matches_cpu_big) {
   int N = 153;
   int M = 71;
   int C = 43;
@@ -266,9 +266,9 @@ TEST(ProbDistributionsCategoricalLogitGLM, gpu_matches_cpu_big) {
       = Matrix<double, Dynamic, Dynamic>::Random(M, C);
   Matrix<double, Dynamic, 1> alpha = Matrix<double, Dynamic, 1>::Random(C, 1);
 
-  stan::math::test::compare_cpu_gpu_prim_rev(categorical_logit_glm_lpmf_functor,
+  stan::math::test::compare_cpu_opencl_prim_rev(categorical_logit_glm_lpmf_functor,
                                              y, x, alpha, beta);
-  stan::math::test::compare_cpu_gpu_prim_rev(
+  stan::math::test::compare_cpu_opencl_prim_rev(
       categorical_logit_glm_lpmf_functor_propto, y, x, alpha, beta);
 }
 

--- a/test/unit/math/opencl/rev/categorical_logit_glm_lpmf_test.cpp
+++ b/test/unit/math/opencl/rev/categorical_logit_glm_lpmf_test.cpp
@@ -116,8 +116,8 @@ TEST(ProbDistributionsCategoricalLogitGLM, opencl_matches_cpu_small_simple) {
   Matrix<double, Dynamic, 1> alpha(C);
   alpha << 0.3, -2, 0.8;
 
-  stan::math::test::compare_cpu_opencl_prim_rev(categorical_logit_glm_lpmf_functor,
-                                             y, x, alpha, beta);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      categorical_logit_glm_lpmf_functor, y, x, alpha, beta);
   stan::math::test::compare_cpu_opencl_prim_rev(
       categorical_logit_glm_lpmf_functor_propto, y, x, alpha, beta);
 }
@@ -188,8 +188,8 @@ TEST(ProbDistributionsCategoricalLogitGLM, opencl_matches_cpu_zero_instances) {
   Matrix<double, Dynamic, 1> alpha(C);
   alpha << 0.3, -2, 0.8;
 
-  stan::math::test::compare_cpu_opencl_prim_rev(categorical_logit_glm_lpmf_functor,
-                                             y, x, alpha, beta);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      categorical_logit_glm_lpmf_functor, y, x, alpha, beta);
   stan::math::test::compare_cpu_opencl_prim_rev(
       categorical_logit_glm_lpmf_functor_propto, y, x, alpha, beta);
 }
@@ -205,8 +205,8 @@ TEST(ProbDistributionsCategoricalLogitGLM, opencl_matches_cpu_zero_attributes) {
   Matrix<double, Dynamic, 1> alpha(C);
   alpha << 0.3, -2, 0.8;
 
-  stan::math::test::compare_cpu_opencl_prim_rev(categorical_logit_glm_lpmf_functor,
-                                             y, x, alpha, beta);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      categorical_logit_glm_lpmf_functor, y, x, alpha, beta);
   stan::math::test::compare_cpu_opencl_prim_rev(
       categorical_logit_glm_lpmf_functor_propto, y, x, alpha, beta);
 }
@@ -224,8 +224,8 @@ TEST(ProbDistributionsCategoricalLogitGLM, opencl_matches_cpu_single_class) {
   Matrix<double, Dynamic, 1> alpha(C);
   alpha << 100000.3;
 
-  stan::math::test::compare_cpu_opencl_prim_rev(categorical_logit_glm_lpmf_functor,
-                                             y, x, alpha, beta);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      categorical_logit_glm_lpmf_functor, y, x, alpha, beta);
   stan::math::test::compare_cpu_opencl_prim_rev(
       categorical_logit_glm_lpmf_functor_propto, y, x, alpha, beta);
 }
@@ -245,8 +245,8 @@ TEST(ProbDistributionsCategoricalLogitGLM, opencl_matches_cpu_all_vars) {
       = Matrix<double, Dynamic, Dynamic>::Random(M, C);
   Matrix<double, Dynamic, 1> alpha = Matrix<double, Dynamic, 1>::Random(C, 1);
 
-  stan::math::test::compare_cpu_opencl_prim_rev(categorical_logit_glm_lpmf_functor,
-                                             y, x, alpha, beta);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      categorical_logit_glm_lpmf_functor, y, x, alpha, beta);
   stan::math::test::compare_cpu_opencl_prim_rev(
       categorical_logit_glm_lpmf_functor_propto, y, x, alpha, beta);
 }
@@ -266,8 +266,8 @@ TEST(ProbDistributionsCategoricalLogitGLM, opencl_matches_cpu_big) {
       = Matrix<double, Dynamic, Dynamic>::Random(M, C);
   Matrix<double, Dynamic, 1> alpha = Matrix<double, Dynamic, 1>::Random(C, 1);
 
-  stan::math::test::compare_cpu_opencl_prim_rev(categorical_logit_glm_lpmf_functor,
-                                             y, x, alpha, beta);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      categorical_logit_glm_lpmf_functor, y, x, alpha, beta);
   stan::math::test::compare_cpu_opencl_prim_rev(
       categorical_logit_glm_lpmf_functor_propto, y, x, alpha, beta);
 }

--- a/test/unit/math/opencl/rev/categorical_logit_glm_lpmf_test.cpp
+++ b/test/unit/math/opencl/rev/categorical_logit_glm_lpmf_test.cpp
@@ -2,7 +2,7 @@
 #include <stan/math.hpp>
 #include <stan/math/opencl/opencl.hpp>
 #include <gtest/gtest.h>
-#include <test/unit/math/expect_near_rel.hpp>
+#include <test/unit/math/opencl/util.hpp>
 #include <vector>
 
 using Eigen::Array;
@@ -13,7 +13,6 @@ using stan::math::var;
 using std::vector;
 
 TEST(ProbDistributionsCategoricalLogitGLM, error_checking) {
-  double eps = 1e-9;
   int N = 3;
   int M = 2;
   int C = 3;
@@ -95,8 +94,16 @@ TEST(ProbDistributionsCategoricalLogitGLM, error_checking) {
                std::domain_error);
 }
 
+auto categorical_logit_glm_lpmf_functor
+    = [](const auto& y, const auto& x, const auto& alpha, const auto& beta) {
+        return stan::math::categorical_logit_glm_lpmf(y, x, alpha, beta);
+      };
+auto categorical_logit_glm_lpmf_functor_propto
+    = [](const auto& y, const auto& x, const auto& alpha, const auto& beta) {
+        return stan::math::categorical_logit_glm_lpmf<true>(y, x, alpha, beta);
+      };
+
 TEST(ProbDistributionsCategoricalLogitGLM, gpu_matches_cpu_small_simple) {
-  double eps = 1e-9;
   int N = 3;
   int M = 2;
   int C = 3;
@@ -109,45 +116,13 @@ TEST(ProbDistributionsCategoricalLogitGLM, gpu_matches_cpu_small_simple) {
   Matrix<double, Dynamic, 1> alpha(C);
   alpha << 0.3, -2, 0.8;
 
-  matrix_cl<double> x_cl(x);
-  matrix_cl<int> y_cl(y);
-  matrix_cl<double> beta_cl(beta);
-  matrix_cl<double> alpha_cl(alpha);
-
-  EXPECT_NEAR_REL(
-      stan::math::categorical_logit_glm_lpmf(y_cl, x_cl, alpha_cl, beta_cl),
-      stan::math::categorical_logit_glm_lpmf(y, x, alpha, beta));
-  EXPECT_NEAR_REL(
-      stan::math::categorical_logit_glm_lpmf<true>(y_cl, x_cl, alpha_cl,
-                                                   beta_cl),
-      stan::math::categorical_logit_glm_lpmf<true>(y, x, alpha, beta));
-
-  Matrix<var, Dynamic, Dynamic> x_var1 = x;
-  Matrix<var, Dynamic, Dynamic> x_var2 = x;
-  Matrix<var, Dynamic, Dynamic> beta_var1 = beta;
-  Matrix<var, Dynamic, Dynamic> beta_var2 = beta;
-  Matrix<var, Dynamic, 1> alpha_var1 = alpha;
-  Matrix<var, Dynamic, 1> alpha_var2 = alpha;
-  auto x_var1_cl = to_matrix_cl(x_var1);
-  auto beta_var1_cl = stan::math::to_matrix_cl(beta_var1);
-  auto alpha_var1_cl = stan::math::to_matrix_cl(alpha_var1);
-
-  var res1 = stan::math::categorical_logit_glm_lpmf(
-      y_cl, x_var1_cl, alpha_var1_cl, beta_var1_cl);
-  var res2 = stan::math::categorical_logit_glm_lpmf(y, x_var2, alpha_var2,
-                                                    beta_var2);
-
-  (res1 + res2).grad();
-
-  EXPECT_NEAR_REL(res1.val(), res2.val());
-
-  EXPECT_NEAR_REL(x_var1.adj().eval(), x_var2.adj().eval());
-  EXPECT_NEAR_REL(alpha_var1.adj().eval(), alpha_var2.adj().eval());
-  EXPECT_NEAR_REL(beta_var1.adj().eval(), beta_var2.adj().eval());
+  stan::math::test::compare_cpu_gpu_prim_rev(categorical_logit_glm_lpmf_functor,
+                                             y, x, alpha, beta);
+  stan::math::test::compare_cpu_gpu_prim_rev(
+      categorical_logit_glm_lpmf_functor_propto, y, x, alpha, beta);
 }
 
 TEST(ProbDistributionsCategoricalLogitGLM, gpu_broadcast_y) {
-  double eps = 1e-9;
   int N = 3;
   int M = 2;
   int C = 3;
@@ -202,7 +177,6 @@ TEST(ProbDistributionsCategoricalLogitGLM, gpu_broadcast_y) {
 }
 
 TEST(ProbDistributionsCategoricalLogitGLM, gpu_matches_cpu_zero_instances) {
-  double eps = 1e-9;
   int N = 0;
   int M = 2;
   int C = 3;
@@ -214,46 +188,13 @@ TEST(ProbDistributionsCategoricalLogitGLM, gpu_matches_cpu_zero_instances) {
   Matrix<double, Dynamic, 1> alpha(C);
   alpha << 0.3, -2, 0.8;
 
-  matrix_cl<double> x_cl(x);
-  matrix_cl<int> y_cl(y);
-  matrix_cl<double> beta_cl(beta);
-  matrix_cl<double> alpha_cl(alpha);
-
-  EXPECT_NEAR_REL(
-      stan::math::categorical_logit_glm_lpmf(y_cl, x_cl, alpha_cl, beta_cl),
-      stan::math::categorical_logit_glm_lpmf(y, x, alpha, beta));
-  EXPECT_NEAR_REL(
-
-      stan::math::categorical_logit_glm_lpmf<true>(y_cl, x_cl, alpha_cl,
-                                                   beta_cl),
-      stan::math::categorical_logit_glm_lpmf<true>(y, x, alpha, beta));
-
-  Matrix<var, Dynamic, Dynamic> x_var1 = x;
-  Matrix<var, Dynamic, Dynamic> x_var2 = x;
-  Matrix<var, Dynamic, Dynamic> beta_var1 = beta;
-  Matrix<var, Dynamic, Dynamic> beta_var2 = beta;
-  Matrix<var, Dynamic, 1> alpha_var1 = alpha;
-  Matrix<var, Dynamic, 1> alpha_var2 = alpha;
-  auto x_var1_cl = to_matrix_cl(x_var1);
-  auto beta_var1_cl = stan::math::to_matrix_cl(beta_var1);
-  auto alpha_var1_cl = stan::math::to_matrix_cl(alpha_var1);
-
-  var res1 = stan::math::categorical_logit_glm_lpmf(
-      y_cl, x_var1_cl, alpha_var1_cl, beta_var1_cl);
-  var res2 = stan::math::categorical_logit_glm_lpmf(y, x_var2, alpha_var2,
-                                                    beta_var2);
-
-  (res1 + res2).grad();
-
-  EXPECT_NEAR_REL(res1.val(), res2.val());
-
-  EXPECT_NEAR_REL(x_var1.adj().eval(), x_var2.adj().eval());
-  EXPECT_NEAR_REL(alpha_var1.adj().eval(), alpha_var2.adj().eval());
-  EXPECT_NEAR_REL(beta_var1.adj().eval(), beta_var2.adj().eval());
+  stan::math::test::compare_cpu_gpu_prim_rev(categorical_logit_glm_lpmf_functor,
+                                             y, x, alpha, beta);
+  stan::math::test::compare_cpu_gpu_prim_rev(
+      categorical_logit_glm_lpmf_functor_propto, y, x, alpha, beta);
 }
 
 TEST(ProbDistributionsCategoricalLogitGLM, gpu_matches_cpu_zero_attributes) {
-  double eps = 1e-9;
   int N = 3;
   int M = 0;
   int C = 3;
@@ -264,46 +205,13 @@ TEST(ProbDistributionsCategoricalLogitGLM, gpu_matches_cpu_zero_attributes) {
   Matrix<double, Dynamic, 1> alpha(C);
   alpha << 0.3, -2, 0.8;
 
-  matrix_cl<double> x_cl(x);
-  matrix_cl<int> y_cl(y);
-  matrix_cl<double> beta_cl(beta);
-  matrix_cl<double> alpha_cl(alpha);
-
-  EXPECT_NEAR_REL(
-      stan::math::categorical_logit_glm_lpmf(y_cl, x_cl, alpha_cl, beta_cl),
-      stan::math::categorical_logit_glm_lpmf(y, x, alpha, beta));
-  EXPECT_NEAR_REL(
-
-      stan::math::categorical_logit_glm_lpmf<true>(y_cl, x_cl, alpha_cl,
-                                                   beta_cl),
-      stan::math::categorical_logit_glm_lpmf<true>(y, x, alpha, beta));
-
-  Matrix<var, Dynamic, Dynamic> x_var1 = x;
-  Matrix<var, Dynamic, Dynamic> x_var2 = x;
-  Matrix<var, Dynamic, Dynamic> beta_var1 = beta;
-  Matrix<var, Dynamic, Dynamic> beta_var2 = beta;
-  Matrix<var, Dynamic, 1> alpha_var1 = alpha;
-  Matrix<var, Dynamic, 1> alpha_var2 = alpha;
-  auto x_var1_cl = to_matrix_cl(x_var1);
-  auto beta_var1_cl = stan::math::to_matrix_cl(beta_var1);
-  auto alpha_var1_cl = stan::math::to_matrix_cl(alpha_var1);
-
-  var res1 = stan::math::categorical_logit_glm_lpmf(
-      y_cl, x_var1_cl, alpha_var1_cl, beta_var1_cl);
-  var res2 = stan::math::categorical_logit_glm_lpmf(y, x_var2, alpha_var2,
-                                                    beta_var2);
-
-  (res1 + res2).grad();
-
-  EXPECT_NEAR_REL(res1.val(), res2.val());
-
-  EXPECT_NEAR_REL(x_var1.adj().eval(), x_var2.adj().eval());
-  EXPECT_NEAR_REL(alpha_var1.adj().eval(), alpha_var2.adj().eval());
-  EXPECT_NEAR_REL(beta_var1.adj().eval(), beta_var2.adj().eval());
+  stan::math::test::compare_cpu_gpu_prim_rev(categorical_logit_glm_lpmf_functor,
+                                             y, x, alpha, beta);
+  stan::math::test::compare_cpu_gpu_prim_rev(
+      categorical_logit_glm_lpmf_functor_propto, y, x, alpha, beta);
 }
 
 TEST(ProbDistributionsCategoricalLogitGLM, gpu_matches_cpu_single_class) {
-  double eps = 1e-9;
   int N = 3;
   int M = 2;
   int C = 1;
@@ -316,45 +224,13 @@ TEST(ProbDistributionsCategoricalLogitGLM, gpu_matches_cpu_single_class) {
   Matrix<double, Dynamic, 1> alpha(C);
   alpha << 100000.3;
 
-  matrix_cl<double> x_cl(x);
-  matrix_cl<int> y_cl(y);
-  matrix_cl<double> beta_cl(beta);
-  matrix_cl<double> alpha_cl(alpha);
-
-  EXPECT_NEAR_REL(
-      stan::math::categorical_logit_glm_lpmf(y_cl, x_cl, alpha_cl, beta_cl),
-      stan::math::categorical_logit_glm_lpmf(y, x, alpha, beta));
-  EXPECT_NEAR_REL(
-      stan::math::categorical_logit_glm_lpmf<true>(y_cl, x_cl, alpha_cl,
-                                                   beta_cl),
-      stan::math::categorical_logit_glm_lpmf<true>(y, x, alpha, beta));
-
-  Matrix<var, Dynamic, Dynamic> x_var1 = x;
-  Matrix<var, Dynamic, Dynamic> x_var2 = x;
-  Matrix<var, Dynamic, Dynamic> beta_var1 = beta;
-  Matrix<var, Dynamic, Dynamic> beta_var2 = beta;
-  Matrix<var, Dynamic, 1> alpha_var1 = alpha;
-  Matrix<var, Dynamic, 1> alpha_var2 = alpha;
-  auto x_var1_cl = to_matrix_cl(x_var1);
-  auto beta_var1_cl = stan::math::to_matrix_cl(beta_var1);
-  auto alpha_var1_cl = stan::math::to_matrix_cl(alpha_var1);
-
-  var res1 = stan::math::categorical_logit_glm_lpmf(
-      y_cl, x_var1_cl, alpha_var1_cl, beta_var1_cl);
-  var res2 = stan::math::categorical_logit_glm_lpmf(y, x_var2, alpha_var2,
-                                                    beta_var2);
-
-  (res1 + res2).grad();
-
-  EXPECT_NEAR_REL(res1.val(), res2.val());
-
-  EXPECT_NEAR_REL(x_var1.adj().eval(), x_var2.adj().eval());
-  EXPECT_NEAR_REL(alpha_var1.adj().eval(), alpha_var2.adj().eval());
-  EXPECT_NEAR_REL(beta_var1.adj().eval(), beta_var2.adj().eval());
+  stan::math::test::compare_cpu_gpu_prim_rev(categorical_logit_glm_lpmf_functor,
+                                             y, x, alpha, beta);
+  stan::math::test::compare_cpu_gpu_prim_rev(
+      categorical_logit_glm_lpmf_functor_propto, y, x, alpha, beta);
 }
 
 TEST(ProbDistributionsCategoricalLogitGLM, gpu_matches_cpu_all_vars) {
-  double eps = 1e-9;
   int N = 5;
   int M = 3;
   int C = 2;
@@ -369,44 +245,13 @@ TEST(ProbDistributionsCategoricalLogitGLM, gpu_matches_cpu_all_vars) {
       = Matrix<double, Dynamic, Dynamic>::Random(M, C);
   Matrix<double, Dynamic, 1> alpha = Matrix<double, Dynamic, 1>::Random(C, 1);
 
-  matrix_cl<double> x_cl(x);
-  matrix_cl<int> y_cl(y);
-  matrix_cl<double> beta_cl(beta);
-  matrix_cl<double> alpha_cl(alpha);
-
-  EXPECT_NEAR_REL(
-      stan::math::categorical_logit_glm_lpmf(y_cl, x_cl, alpha_cl, beta_cl),
-      stan::math::categorical_logit_glm_lpmf(y, x, alpha, beta));
-  EXPECT_NEAR_REL(
-      stan::math::categorical_logit_glm_lpmf(y_cl, x_cl, alpha_cl, beta_cl),
-      stan::math::categorical_logit_glm_lpmf(y, x, alpha, beta));
-
-  Matrix<var, Dynamic, Dynamic> x_var1 = x;
-  Matrix<var, Dynamic, Dynamic> x_var2 = x;
-  Matrix<var, Dynamic, Dynamic> beta_var1 = beta;
-  Matrix<var, Dynamic, Dynamic> beta_var2 = beta;
-  Matrix<var, Dynamic, 1> alpha_var1 = alpha;
-  Matrix<var, Dynamic, 1> alpha_var2 = alpha;
-  auto x_var1_cl = to_matrix_cl(x_var1);
-  auto alpha_var1_cl = to_matrix_cl(alpha_var1);
-  auto beta_var1_cl = to_matrix_cl(beta_var1);
-
-  var res1 = stan::math::categorical_logit_glm_lpmf<true>(
-      y_cl, x_var1_cl, alpha_var1_cl, beta_var1_cl);
-  var res2 = stan::math::categorical_logit_glm_lpmf<true>(y, x_var2, alpha_var2,
-                                                          beta_var2);
-
-  (res1 + res2).grad();
-
-  EXPECT_NEAR_REL(res1.val(), res2.val());
-
-  EXPECT_NEAR_REL(x_var1.adj().eval(), x_var2.adj().eval());
-  EXPECT_NEAR_REL(beta_var1.adj().eval(), beta_var2.adj().eval());
-  EXPECT_NEAR_REL(alpha_var1.adj().eval(), alpha_var2.adj().eval());
+  stan::math::test::compare_cpu_gpu_prim_rev(categorical_logit_glm_lpmf_functor,
+                                             y, x, alpha, beta);
+  stan::math::test::compare_cpu_gpu_prim_rev(
+      categorical_logit_glm_lpmf_functor_propto, y, x, alpha, beta);
 }
 
 TEST(ProbDistributionsCategoricalLogitGLM, gpu_matches_cpu_big) {
-  double eps = 1e-9;
   int N = 153;
   int M = 71;
   int C = 43;
@@ -421,40 +266,10 @@ TEST(ProbDistributionsCategoricalLogitGLM, gpu_matches_cpu_big) {
       = Matrix<double, Dynamic, Dynamic>::Random(M, C);
   Matrix<double, Dynamic, 1> alpha = Matrix<double, Dynamic, 1>::Random(C, 1);
 
-  matrix_cl<double> x_cl(x);
-  matrix_cl<int> y_cl(y);
-  matrix_cl<double> beta_cl(beta);
-  matrix_cl<double> alpha_cl(alpha);
-
-  EXPECT_NEAR_REL(
-      stan::math::categorical_logit_glm_lpmf(y_cl, x_cl, alpha_cl, beta_cl),
-      stan::math::categorical_logit_glm_lpmf(y, x, alpha, beta));
-  EXPECT_NEAR_REL(
-      stan::math::categorical_logit_glm_lpmf(y_cl, x_cl, alpha_cl, beta_cl),
-      stan::math::categorical_logit_glm_lpmf(y, x, alpha, beta));
-
-  Matrix<var, Dynamic, Dynamic> x_var1 = x;
-  Matrix<var, Dynamic, Dynamic> x_var2 = x;
-  Matrix<var, Dynamic, Dynamic> beta_var1 = beta;
-  Matrix<var, Dynamic, Dynamic> beta_var2 = beta;
-  Matrix<var, Dynamic, 1> alpha_var1 = alpha;
-  Matrix<var, Dynamic, 1> alpha_var2 = alpha;
-  auto x_var1_cl = to_matrix_cl(x_var1);
-  auto alpha_var1_cl = to_matrix_cl(alpha_var1);
-  auto beta_var1_cl = to_matrix_cl(beta_var1);
-
-  var res1 = stan::math::categorical_logit_glm_lpmf<true>(
-      y_cl, x_var1_cl, alpha_var1_cl, beta_var1_cl);
-  var res2 = stan::math::categorical_logit_glm_lpmf<true>(y, x_var2, alpha_var2,
-                                                          beta_var2);
-
-  (res1 + res2).grad();
-
-  EXPECT_NEAR_REL(res1.val(), res2.val());
-
-  EXPECT_NEAR_REL(x_var1.adj().eval(), x_var2.adj().eval());
-  EXPECT_NEAR_REL(beta_var1.adj().eval(), beta_var2.adj().eval());
-  EXPECT_NEAR_REL(alpha_var1.adj().eval(), alpha_var2.adj().eval());
+  stan::math::test::compare_cpu_gpu_prim_rev(categorical_logit_glm_lpmf_functor,
+                                             y, x, alpha, beta);
+  stan::math::test::compare_cpu_gpu_prim_rev(
+      categorical_logit_glm_lpmf_functor_propto, y, x, alpha, beta);
 }
 
 #endif

--- a/test/unit/math/opencl/rev/neg_binomial_2_log_glm_lpmf_test.cpp
+++ b/test/unit/math/opencl/rev/neg_binomial_2_log_glm_lpmf_test.cpp
@@ -124,7 +124,7 @@ auto neg_binomial_2_log_glm_lpmf_functor_propto
         return stan::math::neg_binomial_2_log_glm_lpmf<true>(y, x, alpha, beta, phi);
       };
 
-TEST(ProbDistributionsNegBinomial2LogGLM, gpu_matches_cpu_small_simple) {
+TEST(ProbDistributionsNegBinomial2LogGLM, opencl_matches_cpu_small_simple) {
   int N = 3;
   int M = 2;
 
@@ -136,13 +136,13 @@ TEST(ProbDistributionsNegBinomial2LogGLM, gpu_matches_cpu_small_simple) {
   double alpha = 0.3;
   double phi = 13.2;
 
-  stan::math::test::compare_cpu_gpu_prim_rev(neg_binomial_2_log_glm_lpmf_functor,
+  stan::math::test::compare_cpu_opencl_prim_rev(neg_binomial_2_log_glm_lpmf_functor,
                                              y, x, alpha, beta, phi);
-  stan::math::test::compare_cpu_gpu_prim_rev(
+  stan::math::test::compare_cpu_opencl_prim_rev(
       neg_binomial_2_log_glm_lpmf_functor_propto, y, x, alpha, beta, phi);
 }
 
-TEST(ProbDistributionsNegBinomial2LogGLM, gpu_broadcast_y) {
+TEST(ProbDistributionsNegBinomial2LogGLM, opencl_broadcast_y) {
   int N = 3;
   int M = 2;
 
@@ -203,7 +203,7 @@ TEST(ProbDistributionsNegBinomial2LogGLM, gpu_broadcast_y) {
                   phi_var2.adj());
 }
 
-TEST(ProbDistributionsNegBinomial2LogGLM, gpu_matches_cpu_zero_instances) {
+TEST(ProbDistributionsNegBinomial2LogGLM, opencl_matches_cpu_zero_instances) {
   int N = 0;
   int M = 2;
 
@@ -214,13 +214,13 @@ TEST(ProbDistributionsNegBinomial2LogGLM, gpu_matches_cpu_zero_instances) {
   double alpha = 0.3;
   double phi = 13.2;
 
-  stan::math::test::compare_cpu_gpu_prim_rev(neg_binomial_2_log_glm_lpmf_functor,
+  stan::math::test::compare_cpu_opencl_prim_rev(neg_binomial_2_log_glm_lpmf_functor,
                                              y, x, alpha, beta, phi);
-  stan::math::test::compare_cpu_gpu_prim_rev(
+  stan::math::test::compare_cpu_opencl_prim_rev(
       neg_binomial_2_log_glm_lpmf_functor_propto, y, x, alpha, beta, phi);
 }
 
-TEST(ProbDistributionsNegBinomial2LogGLM, gpu_matches_cpu_zero_attributes) {
+TEST(ProbDistributionsNegBinomial2LogGLM, opencl_matches_cpu_zero_attributes) {
   int N = 3;
   int M = 0;
 
@@ -230,14 +230,14 @@ TEST(ProbDistributionsNegBinomial2LogGLM, gpu_matches_cpu_zero_attributes) {
   double alpha = 0.3;
   double phi = 13.2;
 
-  stan::math::test::compare_cpu_gpu_prim_rev(neg_binomial_2_log_glm_lpmf_functor,
+  stan::math::test::compare_cpu_opencl_prim_rev(neg_binomial_2_log_glm_lpmf_functor,
                                              y, x, alpha, beta, phi);
-  stan::math::test::compare_cpu_gpu_prim_rev(
+  stan::math::test::compare_cpu_opencl_prim_rev(
       neg_binomial_2_log_glm_lpmf_functor_propto, y, x, alpha, beta, phi);
 }
 
 TEST(ProbDistributionsNegBinomial2LogGLM,
-     gpu_matches_cpu_small_vector_alpha_phi) {
+     opencl_matches_cpu_small_vector_alpha_phi) {
   int N = 3;
   int M = 2;
 
@@ -251,13 +251,13 @@ TEST(ProbDistributionsNegBinomial2LogGLM,
   Matrix<double, Dynamic, 1> phi(N, 1);
   phi << 0.1, 0.5, 1.2;
 
-  stan::math::test::compare_cpu_gpu_prim_rev(neg_binomial_2_log_glm_lpmf_functor,
+  stan::math::test::compare_cpu_opencl_prim_rev(neg_binomial_2_log_glm_lpmf_functor,
                                              y, x, alpha, beta, phi);
-  stan::math::test::compare_cpu_gpu_prim_rev(
+  stan::math::test::compare_cpu_opencl_prim_rev(
       neg_binomial_2_log_glm_lpmf_functor_propto, y, x, alpha, beta, phi);
 }
 
-TEST(ProbDistributionsNegBinomial2LogGLM, gpu_matches_cpu_big) {
+TEST(ProbDistributionsNegBinomial2LogGLM, opencl_matches_cpu_big) {
   int N = 153;
   int M = 71;
 
@@ -272,9 +272,9 @@ TEST(ProbDistributionsNegBinomial2LogGLM, gpu_matches_cpu_big) {
   Matrix<double, Dynamic, 1> phi
       = Array<double, Dynamic, 1>::Random(N, 1).abs();
 
-  stan::math::test::compare_cpu_gpu_prim_rev(neg_binomial_2_log_glm_lpmf_functor,
+  stan::math::test::compare_cpu_opencl_prim_rev(neg_binomial_2_log_glm_lpmf_functor,
                                              y, x, alpha, beta, phi);
-  stan::math::test::compare_cpu_gpu_prim_rev(
+  stan::math::test::compare_cpu_opencl_prim_rev(
       neg_binomial_2_log_glm_lpmf_functor_propto, y, x, alpha, beta, phi);
 }
 #endif

--- a/test/unit/math/opencl/rev/neg_binomial_2_log_glm_lpmf_test.cpp
+++ b/test/unit/math/opencl/rev/neg_binomial_2_log_glm_lpmf_test.cpp
@@ -2,7 +2,7 @@
 #include <stan/math/opencl/rev/opencl.hpp>
 #include <stan/math.hpp>
 #include <gtest/gtest.h>
-#include <test/unit/math/expect_near_rel.hpp>
+#include <test/unit/math/opencl/util.hpp>
 #include <vector>
 
 using Eigen::Array;
@@ -14,7 +14,6 @@ using stan::test::expect_near_rel;
 using std::vector;
 
 TEST(ProbDistributionsNegBinomial2LogGLM, error_checking) {
-  double eps = 1e-9;
   int N = 3;
   int M = 2;
 
@@ -116,8 +115,16 @@ TEST(ProbDistributionsNegBinomial2LogGLM, error_checking) {
                std::domain_error);
 }
 
+auto neg_binomial_2_log_glm_lpmf_functor
+    = [](const auto& y, const auto& x, const auto& alpha, const auto& beta, const auto& phi) {
+        return stan::math::neg_binomial_2_log_glm_lpmf(y, x, alpha, beta, phi);
+      };
+auto neg_binomial_2_log_glm_lpmf_functor_propto
+    = [](const auto& y, const auto& x, const auto& alpha, const auto& beta, const auto& phi) {
+        return stan::math::neg_binomial_2_log_glm_lpmf<true>(y, x, alpha, beta, phi);
+      };
+
 TEST(ProbDistributionsNegBinomial2LogGLM, gpu_matches_cpu_small_simple) {
-  double eps = 1e-9;
   int N = 3;
   int M = 2;
 
@@ -129,53 +136,13 @@ TEST(ProbDistributionsNegBinomial2LogGLM, gpu_matches_cpu_small_simple) {
   double alpha = 0.3;
   double phi = 13.2;
 
-  matrix_cl<double> x_cl(x);
-  matrix_cl<int> y_cl(y);
-  matrix_cl<double> beta_cl(beta);
-
-  expect_near_rel(
-      "neg_binomial_2_log_glm_lpmf (OpenCL)",
-      stan::math::neg_binomial_2_log_glm_lpmf(y_cl, x_cl, alpha, beta_cl, phi),
-      stan::math::neg_binomial_2_log_glm_lpmf(y, x, alpha, beta, phi));
-  expect_near_rel(
-      "neg_binomial_2_log_glm_lpmf (OpenCL)",
-      stan::math::neg_binomial_2_log_glm_lpmf<true>(y_cl, x_cl, alpha, beta_cl,
-                                                    phi),
-      stan::math::neg_binomial_2_log_glm_lpmf<true>(y, x, alpha, beta, phi));
-
-  Matrix<var, Dynamic, Dynamic> x_var1 = x;
-  Matrix<var, Dynamic, Dynamic> x_var2 = x;
-  Matrix<var, Dynamic, 1> beta_var1 = beta;
-  Matrix<var, Dynamic, 1> beta_var2 = beta;
-  auto x_var1_cl = to_matrix_cl(x_var1);
-  auto beta_var1_cl = stan::math::to_matrix_cl(beta_var1);
-  var alpha_var1 = alpha;
-  var alpha_var2 = alpha;
-  var phi_var1 = phi;
-  var phi_var2 = phi;
-
-  var res1 = stan::math::neg_binomial_2_log_glm_lpmf(
-      y_cl, x_var1_cl, alpha_var1, beta_var1_cl, phi_var1);
-  var res2 = stan::math::neg_binomial_2_log_glm_lpmf(y, x_var2, alpha_var2,
-                                                     beta_var2, phi_var2);
-
-  (res1 + res2).grad();
-
-  expect_near_rel("neg_binomial_2_log_glm_lpmf (OpenCL)", res1.val(),
-                  res2.val());
-
-  expect_near_rel("neg_binomial_2_log_glm_lpmf (OpenCL)", x_var1.adj().eval(),
-                  x_var2.adj().eval());
-  expect_near_rel("neg_binomial_2_log_glm_lpmf (OpenCL)", alpha_var1.adj(),
-                  alpha_var2.adj());
-  expect_near_rel("neg_binomial_2_log_glm_lpmf (OpenCL)",
-                  beta_var1.adj().eval(), beta_var2.adj().eval());
-  expect_near_rel("neg_binomial_2_log_glm_lpmf (OpenCL)", phi_var1.adj(),
-                  phi_var2.adj());
+  stan::math::test::compare_cpu_gpu_prim_rev(neg_binomial_2_log_glm_lpmf_functor,
+                                             y, x, alpha, beta, phi);
+  stan::math::test::compare_cpu_gpu_prim_rev(
+      neg_binomial_2_log_glm_lpmf_functor_propto, y, x, alpha, beta, phi);
 }
 
 TEST(ProbDistributionsNegBinomial2LogGLM, gpu_broadcast_y) {
-  double eps = 1e-9;
   int N = 3;
   int M = 2;
 
@@ -237,7 +204,6 @@ TEST(ProbDistributionsNegBinomial2LogGLM, gpu_broadcast_y) {
 }
 
 TEST(ProbDistributionsNegBinomial2LogGLM, gpu_matches_cpu_zero_instances) {
-  double eps = 1e-9;
   int N = 0;
   int M = 2;
 
@@ -248,53 +214,13 @@ TEST(ProbDistributionsNegBinomial2LogGLM, gpu_matches_cpu_zero_instances) {
   double alpha = 0.3;
   double phi = 13.2;
 
-  matrix_cl<double> x_cl(x);
-  matrix_cl<int> y_cl(y);
-  matrix_cl<double> beta_cl(beta);
-
-  expect_near_rel(
-      "neg_binomial_2_log_glm_lpmf (OpenCL)",
-      stan::math::neg_binomial_2_log_glm_lpmf(y_cl, x_cl, alpha, beta_cl, phi),
-      stan::math::neg_binomial_2_log_glm_lpmf(y, x, alpha, beta, phi));
-  expect_near_rel(
-      "neg_binomial_2_log_glm_lpmf (OpenCL)",
-      stan::math::neg_binomial_2_log_glm_lpmf<true>(y_cl, x_cl, alpha, beta_cl,
-                                                    phi),
-      stan::math::neg_binomial_2_log_glm_lpmf<true>(y, x, alpha, beta, phi));
-
-  Matrix<var, Dynamic, Dynamic> x_var1 = x;
-  Matrix<var, Dynamic, Dynamic> x_var2 = x;
-  Matrix<var, Dynamic, 1> beta_var1 = beta;
-  Matrix<var, Dynamic, 1> beta_var2 = beta;
-  auto x_var1_cl = to_matrix_cl(x_var1);
-  auto beta_var1_cl = to_matrix_cl(beta_var1);
-  var alpha_var1 = alpha;
-  var alpha_var2 = alpha;
-  var phi_var1 = phi;
-  var phi_var2 = phi;
-
-  var res1 = stan::math::neg_binomial_2_log_glm_lpmf(
-      y_cl, x_var1_cl, alpha_var1, beta_var1_cl, phi_var1);
-  var res2 = stan::math::neg_binomial_2_log_glm_lpmf(y, x_var2, alpha_var2,
-                                                     beta_var2, phi_var2);
-
-  (res1 + res2).grad();
-
-  expect_near_rel("neg_binomial_2_log_glm_lpmf (OpenCL)", res1.val(),
-                  res2.val());
-
-  expect_near_rel("neg_binomial_2_log_glm_lpmf (OpenCL)", x_var1.adj().eval(),
-                  x_var2.adj().eval());
-  expect_near_rel("neg_binomial_2_log_glm_lpmf (OpenCL)", alpha_var1.adj(),
-                  alpha_var2.adj());
-  expect_near_rel("neg_binomial_2_log_glm_lpmf (OpenCL)",
-                  beta_var1.adj().eval(), beta_var2.adj().eval());
-  expect_near_rel("neg_binomial_2_log_glm_lpmf (OpenCL)", phi_var1.adj(),
-                  phi_var2.adj());
+  stan::math::test::compare_cpu_gpu_prim_rev(neg_binomial_2_log_glm_lpmf_functor,
+                                             y, x, alpha, beta, phi);
+  stan::math::test::compare_cpu_gpu_prim_rev(
+      neg_binomial_2_log_glm_lpmf_functor_propto, y, x, alpha, beta, phi);
 }
 
 TEST(ProbDistributionsNegBinomial2LogGLM, gpu_matches_cpu_zero_attributes) {
-  double eps = 1e-9;
   int N = 3;
   int M = 0;
 
@@ -304,54 +230,14 @@ TEST(ProbDistributionsNegBinomial2LogGLM, gpu_matches_cpu_zero_attributes) {
   double alpha = 0.3;
   double phi = 13.2;
 
-  matrix_cl<double> x_cl(x);
-  matrix_cl<int> y_cl(y);
-  matrix_cl<double> beta_cl(beta);
-
-  expect_near_rel(
-      "neg_binomial_2_log_glm_lpmf (OpenCL)",
-      stan::math::neg_binomial_2_log_glm_lpmf(y_cl, x_cl, alpha, beta_cl, phi),
-      stan::math::neg_binomial_2_log_glm_lpmf(y, x, alpha, beta, phi));
-  expect_near_rel(
-      "neg_binomial_2_log_glm_lpmf (OpenCL)",
-      stan::math::neg_binomial_2_log_glm_lpmf<true>(y_cl, x_cl, alpha, beta_cl,
-                                                    phi),
-      stan::math::neg_binomial_2_log_glm_lpmf<true>(y, x, alpha, beta, phi));
-
-  Matrix<var, Dynamic, Dynamic> x_var1 = x;
-  Matrix<var, Dynamic, Dynamic> x_var2 = x;
-  Matrix<var, Dynamic, 1> beta_var1 = beta;
-  Matrix<var, Dynamic, 1> beta_var2 = beta;
-  auto x_var1_cl = to_matrix_cl(x_var1);
-  auto beta_var1_cl = to_matrix_cl(beta_var1);
-  var alpha_var1 = alpha;
-  var alpha_var2 = alpha;
-  var phi_var1 = phi;
-  var phi_var2 = phi;
-
-  var res1 = stan::math::neg_binomial_2_log_glm_lpmf(
-      y_cl, x_var1_cl, alpha_var1, beta_var1_cl, phi_var1);
-  var res2 = stan::math::neg_binomial_2_log_glm_lpmf(y, x_var2, alpha_var2,
-                                                     beta_var2, phi_var2);
-
-  (res1 + res2).grad();
-
-  expect_near_rel("neg_binomial_2_log_glm_lpmf (OpenCL)", res1.val(),
-                  res2.val());
-
-  expect_near_rel("neg_binomial_2_log_glm_lpmf (OpenCL)", x_var1.adj().eval(),
-                  x_var2.adj().eval());
-  expect_near_rel("neg_binomial_2_log_glm_lpmf (OpenCL)", alpha_var1.adj(),
-                  alpha_var2.adj());
-  expect_near_rel("neg_binomial_2_log_glm_lpmf (OpenCL)",
-                  beta_var1.adj().eval(), beta_var2.adj().eval());
-  expect_near_rel("neg_binomial_2_log_glm_lpmf (OpenCL)", phi_var1.adj(),
-                  phi_var2.adj());
+  stan::math::test::compare_cpu_gpu_prim_rev(neg_binomial_2_log_glm_lpmf_functor,
+                                             y, x, alpha, beta, phi);
+  stan::math::test::compare_cpu_gpu_prim_rev(
+      neg_binomial_2_log_glm_lpmf_functor_propto, y, x, alpha, beta, phi);
 }
 
 TEST(ProbDistributionsNegBinomial2LogGLM,
      gpu_matches_cpu_small_vector_alpha_phi) {
-  double eps = 1e-9;
   int N = 3;
   int M = 2;
 
@@ -365,57 +251,13 @@ TEST(ProbDistributionsNegBinomial2LogGLM,
   Matrix<double, Dynamic, 1> phi(N, 1);
   phi << 0.1, 0.5, 1.2;
 
-  matrix_cl<double> x_cl(x);
-  matrix_cl<int> y_cl(y);
-  matrix_cl<double> alpha_cl(alpha);
-  matrix_cl<double> beta_cl(beta);
-  matrix_cl<double> phi_cl(phi);
-
-  expect_near_rel(
-      "neg_binomial_2_log_glm_lpmf (OpenCL)",
-      stan::math::neg_binomial_2_log_glm_lpmf(y_cl, x_cl, alpha_cl, beta_cl,
-                                              phi_cl),
-      stan::math::neg_binomial_2_log_glm_lpmf(y, x, alpha, beta, phi));
-  expect_near_rel(
-      "neg_binomial_2_log_glm_lpmf (OpenCL)",
-      stan::math::neg_binomial_2_log_glm_lpmf<true>(y_cl, x_cl, alpha_cl,
-                                                    beta_cl, phi_cl),
-      stan::math::neg_binomial_2_log_glm_lpmf<true>(y, x, alpha, beta, phi));
-
-  Matrix<var, Dynamic, Dynamic> x_var1 = x;
-  Matrix<var, Dynamic, Dynamic> x_var2 = x;
-  Matrix<var, Dynamic, 1> beta_var1 = beta;
-  Matrix<var, Dynamic, 1> beta_var2 = beta;
-  Matrix<var, Dynamic, 1> alpha_var1 = alpha;
-  Matrix<var, Dynamic, 1> alpha_var2 = alpha;
-  Matrix<var, Dynamic, 1> phi_var1 = phi;
-  Matrix<var, Dynamic, 1> phi_var2 = phi;
-  auto x_var1_cl = to_matrix_cl(x_var1);
-  auto alpha_var1_cl = to_matrix_cl(alpha_var1);
-  auto beta_var1_cl = to_matrix_cl(beta_var1);
-  auto phi_var1_cl = to_matrix_cl(phi_var1);
-
-  var res1 = stan::math::neg_binomial_2_log_glm_lpmf(
-      y_cl, x_var1_cl, alpha_var1_cl, beta_var1_cl, phi_var1_cl);
-  var res2 = stan::math::neg_binomial_2_log_glm_lpmf(y, x_var2, alpha_var2,
-                                                     beta_var2, phi_var2);
-
-  (res1 + res2).grad();
-
-  expect_near_rel("neg_binomial_2_log_glm_lpmf (OpenCL)", x_var1.adj().eval(),
-                  x_var2.adj().eval());
-  expect_near_rel("neg_binomial_2_log_glm_lpmf (OpenCL)", res1.val(),
-                  res2.val());
-  expect_near_rel("neg_binomial_2_log_glm_lpmf (OpenCL)",
-                  beta_var1.adj().eval(), beta_var2.adj().eval());
-  expect_near_rel("neg_binomial_2_log_glm_lpmf (OpenCL)",
-                  alpha_var1.adj().eval(), alpha_var2.adj().eval());
-  expect_near_rel("neg_binomial_2_log_glm_lpmf (OpenCL)", phi_var1.adj().eval(),
-                  phi_var2.adj().eval());
+  stan::math::test::compare_cpu_gpu_prim_rev(neg_binomial_2_log_glm_lpmf_functor,
+                                             y, x, alpha, beta, phi);
+  stan::math::test::compare_cpu_gpu_prim_rev(
+      neg_binomial_2_log_glm_lpmf_functor_propto, y, x, alpha, beta, phi);
 }
 
 TEST(ProbDistributionsNegBinomial2LogGLM, gpu_matches_cpu_big) {
-  double eps = 1e-9;
   int N = 153;
   int M = 71;
 
@@ -430,53 +272,9 @@ TEST(ProbDistributionsNegBinomial2LogGLM, gpu_matches_cpu_big) {
   Matrix<double, Dynamic, 1> phi
       = Array<double, Dynamic, 1>::Random(N, 1).abs();
 
-  matrix_cl<double> x_cl(x);
-  matrix_cl<int> y_cl(y);
-  matrix_cl<double> alpha_cl(alpha);
-  matrix_cl<double> beta_cl(beta);
-  matrix_cl<double> phi_cl(phi);
-
-  expect_near_rel(
-      "neg_binomial_2_log_glm_lpmf (OpenCL)",
-      stan::math::neg_binomial_2_log_glm_lpmf(y_cl, x_cl, alpha_cl, beta_cl,
-                                              phi_cl),
-      stan::math::neg_binomial_2_log_glm_lpmf(y, x, alpha, beta, phi));
-  expect_near_rel(
-      "neg_binomial_2_log_glm_lpmf (OpenCL)",
-      stan::math::neg_binomial_2_log_glm_lpmf(y_cl, x_cl, alpha_cl, beta_cl,
-                                              phi_cl),
-      stan::math::neg_binomial_2_log_glm_lpmf(y, x, alpha, beta, phi));
-
-  Matrix<var, Dynamic, Dynamic> x_var1 = x;
-  Matrix<var, Dynamic, Dynamic> x_var2 = x;
-  Matrix<var, Dynamic, 1> beta_var1 = beta;
-  Matrix<var, Dynamic, 1> beta_var2 = beta;
-  Matrix<var, Dynamic, 1> alpha_var1 = alpha;
-  Matrix<var, Dynamic, 1> alpha_var2 = alpha;
-  Matrix<var, Dynamic, 1> phi_var1 = phi;
-  Matrix<var, Dynamic, 1> phi_var2 = phi;
-  auto x_var1_cl = to_matrix_cl(x_var1);
-  auto alpha_var1_cl = to_matrix_cl(alpha_var1);
-  auto beta_var1_cl = to_matrix_cl(beta_var1);
-  auto phi_var1_cl = to_matrix_cl(phi_var1);
-
-  var res1 = stan::math::neg_binomial_2_log_glm_lpmf<true>(
-      y_cl, x_var1_cl, alpha_var1_cl, beta_var1_cl, phi_var1_cl);
-  var res2 = stan::math::neg_binomial_2_log_glm_lpmf<true>(
-      y, x_var2, alpha_var2, beta_var2, phi_var2);
-
-  (res1 + res2).grad();
-
-  expect_near_rel("neg_binomial_2_log_glm_lpmf (OpenCL)", res1.val(),
-                  res2.val());
-
-  expect_near_rel("neg_binomial_2_log_glm_lpmf (OpenCL)", x_var1.adj().eval(),
-                  x_var2.adj().eval());
-  expect_near_rel("neg_binomial_2_log_glm_lpmf (OpenCL)",
-                  beta_var1.adj().eval(), beta_var2.adj().eval());
-  expect_near_rel("neg_binomial_2_log_glm_lpmf (OpenCL)",
-                  alpha_var1.adj().eval(), alpha_var2.adj().eval());
-  expect_near_rel("neg_binomial_2_log_glm_lpmf (OpenCL)", phi_var1.adj().eval(),
-                  phi_var2.adj().eval());
+  stan::math::test::compare_cpu_gpu_prim_rev(neg_binomial_2_log_glm_lpmf_functor,
+                                             y, x, alpha, beta, phi);
+  stan::math::test::compare_cpu_gpu_prim_rev(
+      neg_binomial_2_log_glm_lpmf_functor_propto, y, x, alpha, beta, phi);
 }
 #endif

--- a/test/unit/math/opencl/rev/neg_binomial_2_log_glm_lpmf_test.cpp
+++ b/test/unit/math/opencl/rev/neg_binomial_2_log_glm_lpmf_test.cpp
@@ -116,12 +116,15 @@ TEST(ProbDistributionsNegBinomial2LogGLM, error_checking) {
 }
 
 auto neg_binomial_2_log_glm_lpmf_functor
-    = [](const auto& y, const auto& x, const auto& alpha, const auto& beta, const auto& phi) {
+    = [](const auto& y, const auto& x, const auto& alpha, const auto& beta,
+         const auto& phi) {
         return stan::math::neg_binomial_2_log_glm_lpmf(y, x, alpha, beta, phi);
       };
 auto neg_binomial_2_log_glm_lpmf_functor_propto
-    = [](const auto& y, const auto& x, const auto& alpha, const auto& beta, const auto& phi) {
-        return stan::math::neg_binomial_2_log_glm_lpmf<true>(y, x, alpha, beta, phi);
+    = [](const auto& y, const auto& x, const auto& alpha, const auto& beta,
+         const auto& phi) {
+        return stan::math::neg_binomial_2_log_glm_lpmf<true>(y, x, alpha, beta,
+                                                             phi);
       };
 
 TEST(ProbDistributionsNegBinomial2LogGLM, opencl_matches_cpu_small_simple) {
@@ -136,8 +139,8 @@ TEST(ProbDistributionsNegBinomial2LogGLM, opencl_matches_cpu_small_simple) {
   double alpha = 0.3;
   double phi = 13.2;
 
-  stan::math::test::compare_cpu_opencl_prim_rev(neg_binomial_2_log_glm_lpmf_functor,
-                                             y, x, alpha, beta, phi);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      neg_binomial_2_log_glm_lpmf_functor, y, x, alpha, beta, phi);
   stan::math::test::compare_cpu_opencl_prim_rev(
       neg_binomial_2_log_glm_lpmf_functor_propto, y, x, alpha, beta, phi);
 }
@@ -214,8 +217,8 @@ TEST(ProbDistributionsNegBinomial2LogGLM, opencl_matches_cpu_zero_instances) {
   double alpha = 0.3;
   double phi = 13.2;
 
-  stan::math::test::compare_cpu_opencl_prim_rev(neg_binomial_2_log_glm_lpmf_functor,
-                                             y, x, alpha, beta, phi);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      neg_binomial_2_log_glm_lpmf_functor, y, x, alpha, beta, phi);
   stan::math::test::compare_cpu_opencl_prim_rev(
       neg_binomial_2_log_glm_lpmf_functor_propto, y, x, alpha, beta, phi);
 }
@@ -230,8 +233,8 @@ TEST(ProbDistributionsNegBinomial2LogGLM, opencl_matches_cpu_zero_attributes) {
   double alpha = 0.3;
   double phi = 13.2;
 
-  stan::math::test::compare_cpu_opencl_prim_rev(neg_binomial_2_log_glm_lpmf_functor,
-                                             y, x, alpha, beta, phi);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      neg_binomial_2_log_glm_lpmf_functor, y, x, alpha, beta, phi);
   stan::math::test::compare_cpu_opencl_prim_rev(
       neg_binomial_2_log_glm_lpmf_functor_propto, y, x, alpha, beta, phi);
 }
@@ -251,8 +254,8 @@ TEST(ProbDistributionsNegBinomial2LogGLM,
   Matrix<double, Dynamic, 1> phi(N, 1);
   phi << 0.1, 0.5, 1.2;
 
-  stan::math::test::compare_cpu_opencl_prim_rev(neg_binomial_2_log_glm_lpmf_functor,
-                                             y, x, alpha, beta, phi);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      neg_binomial_2_log_glm_lpmf_functor, y, x, alpha, beta, phi);
   stan::math::test::compare_cpu_opencl_prim_rev(
       neg_binomial_2_log_glm_lpmf_functor_propto, y, x, alpha, beta, phi);
 }
@@ -272,8 +275,8 @@ TEST(ProbDistributionsNegBinomial2LogGLM, opencl_matches_cpu_big) {
   Matrix<double, Dynamic, 1> phi
       = Array<double, Dynamic, 1>::Random(N, 1).abs();
 
-  stan::math::test::compare_cpu_opencl_prim_rev(neg_binomial_2_log_glm_lpmf_functor,
-                                             y, x, alpha, beta, phi);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      neg_binomial_2_log_glm_lpmf_functor, y, x, alpha, beta, phi);
   stan::math::test::compare_cpu_opencl_prim_rev(
       neg_binomial_2_log_glm_lpmf_functor_propto, y, x, alpha, beta, phi);
 }

--- a/test/unit/math/opencl/rev/normal_id_glm_lpdf_test.cpp
+++ b/test/unit/math/opencl/rev/normal_id_glm_lpdf_test.cpp
@@ -128,10 +128,10 @@ TEST(ProbDistributionsNormalIdGLM, opencl_matches_cpu_small_simple) {
   double alpha = 0.3;
   double sigma = 11;
 
-  stan::math::test::compare_cpu_opencl_prim_rev(normal_id_glm_lpdf_functor, y, x,
-                                             alpha, beta, sigma);
-  stan::math::test::compare_cpu_opencl_prim_rev(normal_id_glm_lpdf_functor_propto,
-                                             y, x, alpha, beta, sigma);
+  stan::math::test::compare_cpu_opencl_prim_rev(normal_id_glm_lpdf_functor, y,
+                                                x, alpha, beta, sigma);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      normal_id_glm_lpdf_functor_propto, y, x, alpha, beta, sigma);
 }
 
 TEST(ProbDistributionsNormalIdGLM, opencl_broadcast_y) {
@@ -208,10 +208,10 @@ TEST(ProbDistributionsNormalIdGLM, opencl_matches_cpu_zero_instances) {
   double alpha = 0.3;
   double sigma = 11;
 
-  stan::math::test::compare_cpu_opencl_prim_rev(normal_id_glm_lpdf_functor, y, x,
-                                             alpha, beta, sigma);
-  stan::math::test::compare_cpu_opencl_prim_rev(normal_id_glm_lpdf_functor_propto,
-                                             y, x, alpha, beta, sigma);
+  stan::math::test::compare_cpu_opencl_prim_rev(normal_id_glm_lpdf_functor, y,
+                                                x, alpha, beta, sigma);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      normal_id_glm_lpdf_functor_propto, y, x, alpha, beta, sigma);
 }
 
 TEST(ProbDistributionsNormalIdGLM, opencl_matches_cpu_zero_attributes) {
@@ -225,13 +225,14 @@ TEST(ProbDistributionsNormalIdGLM, opencl_matches_cpu_zero_attributes) {
   double alpha = 0.3;
   double sigma = 11;
 
-  stan::math::test::compare_cpu_opencl_prim_rev(normal_id_glm_lpdf_functor, y, x,
-                                             alpha, beta, sigma);
-  stan::math::test::compare_cpu_opencl_prim_rev(normal_id_glm_lpdf_functor_propto,
-                                             y, x, alpha, beta, sigma);
+  stan::math::test::compare_cpu_opencl_prim_rev(normal_id_glm_lpdf_functor, y,
+                                                x, alpha, beta, sigma);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      normal_id_glm_lpdf_functor_propto, y, x, alpha, beta, sigma);
 }
 
-TEST(ProbDistributionsNormalIdGLM, opencl_matches_cpu_small_vector_alpha_sigma) {
+TEST(ProbDistributionsNormalIdGLM,
+     opencl_matches_cpu_small_vector_alpha_sigma) {
   int N = 3;
   int M = 2;
 
@@ -246,10 +247,10 @@ TEST(ProbDistributionsNormalIdGLM, opencl_matches_cpu_small_vector_alpha_sigma) 
   Matrix<double, Dynamic, 1> sigma(N, 1);
   sigma << 5, 2, 3.4;
 
-  stan::math::test::compare_cpu_opencl_prim_rev(normal_id_glm_lpdf_functor, y, x,
-                                             alpha, beta, sigma);
-  stan::math::test::compare_cpu_opencl_prim_rev(normal_id_glm_lpdf_functor_propto,
-                                             y, x, alpha, beta, sigma);
+  stan::math::test::compare_cpu_opencl_prim_rev(normal_id_glm_lpdf_functor, y,
+                                                x, alpha, beta, sigma);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      normal_id_glm_lpdf_functor_propto, y, x, alpha, beta, sigma);
 }
 
 TEST(ProbDistributionsNormalIdGLM, opencl_matches_cpu_big) {
@@ -264,10 +265,10 @@ TEST(ProbDistributionsNormalIdGLM, opencl_matches_cpu_big) {
   Matrix<double, Dynamic, 1> sigma
       = Array<double, Dynamic, 1>::Random(N, 1) + 1.1;
 
-  stan::math::test::compare_cpu_opencl_prim_rev(normal_id_glm_lpdf_functor, y, x,
-                                             alpha, beta, sigma);
-  stan::math::test::compare_cpu_opencl_prim_rev(normal_id_glm_lpdf_functor_propto,
-                                             y, x, alpha, beta, sigma);
+  stan::math::test::compare_cpu_opencl_prim_rev(normal_id_glm_lpdf_functor, y,
+                                                x, alpha, beta, sigma);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      normal_id_glm_lpdf_functor_propto, y, x, alpha, beta, sigma);
 }
 
 #endif

--- a/test/unit/math/opencl/rev/normal_id_glm_lpdf_test.cpp
+++ b/test/unit/math/opencl/rev/normal_id_glm_lpdf_test.cpp
@@ -115,7 +115,7 @@ auto normal_id_glm_lpdf_functor_propto
         return stan::math::normal_id_glm_lpdf<true>(y, x, alpha, beta, sigma);
       };
 
-TEST(ProbDistributionsNormalIdGLM, gpu_matches_cpu_small_simple) {
+TEST(ProbDistributionsNormalIdGLM, opencl_matches_cpu_small_simple) {
   int N = 3;
   int M = 2;
 
@@ -128,13 +128,13 @@ TEST(ProbDistributionsNormalIdGLM, gpu_matches_cpu_small_simple) {
   double alpha = 0.3;
   double sigma = 11;
 
-  stan::math::test::compare_cpu_gpu_prim_rev(normal_id_glm_lpdf_functor, y, x,
+  stan::math::test::compare_cpu_opencl_prim_rev(normal_id_glm_lpdf_functor, y, x,
                                              alpha, beta, sigma);
-  stan::math::test::compare_cpu_gpu_prim_rev(normal_id_glm_lpdf_functor_propto,
+  stan::math::test::compare_cpu_opencl_prim_rev(normal_id_glm_lpdf_functor_propto,
                                              y, x, alpha, beta, sigma);
 }
 
-TEST(ProbDistributionsNormalIdGLM, gpu_broadcast_y) {
+TEST(ProbDistributionsNormalIdGLM, opencl_broadcast_y) {
   int N = 3;
   int M = 2;
 
@@ -197,7 +197,7 @@ TEST(ProbDistributionsNormalIdGLM, gpu_broadcast_y) {
                   beta_var2.adj().eval());
 }
 
-TEST(ProbDistributionsNormalIdGLM, gpu_matches_cpu_zero_instances) {
+TEST(ProbDistributionsNormalIdGLM, opencl_matches_cpu_zero_instances) {
   int N = 0;
   int M = 2;
 
@@ -208,13 +208,13 @@ TEST(ProbDistributionsNormalIdGLM, gpu_matches_cpu_zero_instances) {
   double alpha = 0.3;
   double sigma = 11;
 
-  stan::math::test::compare_cpu_gpu_prim_rev(normal_id_glm_lpdf_functor, y, x,
+  stan::math::test::compare_cpu_opencl_prim_rev(normal_id_glm_lpdf_functor, y, x,
                                              alpha, beta, sigma);
-  stan::math::test::compare_cpu_gpu_prim_rev(normal_id_glm_lpdf_functor_propto,
+  stan::math::test::compare_cpu_opencl_prim_rev(normal_id_glm_lpdf_functor_propto,
                                              y, x, alpha, beta, sigma);
 }
 
-TEST(ProbDistributionsNormalIdGLM, gpu_matches_cpu_zero_attributes) {
+TEST(ProbDistributionsNormalIdGLM, opencl_matches_cpu_zero_attributes) {
   int N = 3;
   int M = 0;
 
@@ -225,13 +225,13 @@ TEST(ProbDistributionsNormalIdGLM, gpu_matches_cpu_zero_attributes) {
   double alpha = 0.3;
   double sigma = 11;
 
-  stan::math::test::compare_cpu_gpu_prim_rev(normal_id_glm_lpdf_functor, y, x,
+  stan::math::test::compare_cpu_opencl_prim_rev(normal_id_glm_lpdf_functor, y, x,
                                              alpha, beta, sigma);
-  stan::math::test::compare_cpu_gpu_prim_rev(normal_id_glm_lpdf_functor_propto,
+  stan::math::test::compare_cpu_opencl_prim_rev(normal_id_glm_lpdf_functor_propto,
                                              y, x, alpha, beta, sigma);
 }
 
-TEST(ProbDistributionsNormalIdGLM, gpu_matches_cpu_small_vector_alpha_sigma) {
+TEST(ProbDistributionsNormalIdGLM, opencl_matches_cpu_small_vector_alpha_sigma) {
   int N = 3;
   int M = 2;
 
@@ -246,13 +246,13 @@ TEST(ProbDistributionsNormalIdGLM, gpu_matches_cpu_small_vector_alpha_sigma) {
   Matrix<double, Dynamic, 1> sigma(N, 1);
   sigma << 5, 2, 3.4;
 
-  stan::math::test::compare_cpu_gpu_prim_rev(normal_id_glm_lpdf_functor, y, x,
+  stan::math::test::compare_cpu_opencl_prim_rev(normal_id_glm_lpdf_functor, y, x,
                                              alpha, beta, sigma);
-  stan::math::test::compare_cpu_gpu_prim_rev(normal_id_glm_lpdf_functor_propto,
+  stan::math::test::compare_cpu_opencl_prim_rev(normal_id_glm_lpdf_functor_propto,
                                              y, x, alpha, beta, sigma);
 }
 
-TEST(ProbDistributionsNormalIdGLM, gpu_matches_cpu_big) {
+TEST(ProbDistributionsNormalIdGLM, opencl_matches_cpu_big) {
   int N = 153;
   int M = 71;
 
@@ -264,9 +264,9 @@ TEST(ProbDistributionsNormalIdGLM, gpu_matches_cpu_big) {
   Matrix<double, Dynamic, 1> sigma
       = Array<double, Dynamic, 1>::Random(N, 1) + 1.1;
 
-  stan::math::test::compare_cpu_gpu_prim_rev(normal_id_glm_lpdf_functor, y, x,
+  stan::math::test::compare_cpu_opencl_prim_rev(normal_id_glm_lpdf_functor, y, x,
                                              alpha, beta, sigma);
-  stan::math::test::compare_cpu_gpu_prim_rev(normal_id_glm_lpdf_functor_propto,
+  stan::math::test::compare_cpu_opencl_prim_rev(normal_id_glm_lpdf_functor_propto,
                                              y, x, alpha, beta, sigma);
 }
 

--- a/test/unit/math/opencl/rev/ordered_logistic_glm_lpmf_test.cpp
+++ b/test/unit/math/opencl/rev/ordered_logistic_glm_lpmf_test.cpp
@@ -102,7 +102,7 @@ auto ordered_logistic_glm_lpmf_functor_propto
         return stan::math::ordered_logistic_glm_lpmf<true>(y, x, beta, cuts);
       };
 
-TEST(ProbDistributionsOrderedLogisitcGLM, gpu_matches_cpu_small_simple) {
+TEST(ProbDistributionsOrderedLogisitcGLM, opencl_matches_cpu_small_simple) {
   int N = 3;
   int M = 2;
   int C = 5;
@@ -115,13 +115,13 @@ TEST(ProbDistributionsOrderedLogisitcGLM, gpu_matches_cpu_small_simple) {
   Matrix<double, Dynamic, 1> cuts(C - 1, 1);
   cuts << -0.4, 0.1, 0.3, 4.5;
 
-  stan::math::test::compare_cpu_gpu_prim_rev(ordered_logistic_glm_lpmf_functor,
+  stan::math::test::compare_cpu_opencl_prim_rev(ordered_logistic_glm_lpmf_functor,
                                              y, x, beta, cuts);
-  stan::math::test::compare_cpu_gpu_prim_rev(
+  stan::math::test::compare_cpu_opencl_prim_rev(
       ordered_logistic_glm_lpmf_functor_propto, y, x, beta, cuts);
 }
 
-TEST(ProbDistributionsOrderedLogisitcGLM, gpu_matches_cpu_broadcast_y) {
+TEST(ProbDistributionsOrderedLogisitcGLM, opencl_matches_cpu_broadcast_y) {
   int N = 3;
   int M = 2;
   int C = 5;
@@ -169,7 +169,7 @@ TEST(ProbDistributionsOrderedLogisitcGLM, gpu_matches_cpu_broadcast_y) {
   EXPECT_NEAR_REL(cuts_var1.adj().eval(), cuts_var2.adj().eval());
 }
 
-TEST(ProbDistributionsOrderedLogisitcGLM, gpu_matches_cpu_zero_instances) {
+TEST(ProbDistributionsOrderedLogisitcGLM, opencl_matches_cpu_zero_instances) {
   int N = 0;
   int M = 2;
   int C = 5;
@@ -186,13 +186,13 @@ TEST(ProbDistributionsOrderedLogisitcGLM, gpu_matches_cpu_zero_instances) {
   matrix_cl<double> beta_cl(beta);
   matrix_cl<double> cuts_cl(cuts);
 
-  stan::math::test::compare_cpu_gpu_prim_rev(ordered_logistic_glm_lpmf_functor,
+  stan::math::test::compare_cpu_opencl_prim_rev(ordered_logistic_glm_lpmf_functor,
                                              y, x, beta, cuts);
-  stan::math::test::compare_cpu_gpu_prim_rev(
+  stan::math::test::compare_cpu_opencl_prim_rev(
       ordered_logistic_glm_lpmf_functor_propto, y, x, beta, cuts);
 }
 
-TEST(ProbDistributionsOrderedLogisitcGLM, gpu_matches_cpu_zero_attributes) {
+TEST(ProbDistributionsOrderedLogisitcGLM, opencl_matches_cpu_zero_attributes) {
   int N = 3;
   int M = 0;
   int C = 5;
@@ -203,13 +203,13 @@ TEST(ProbDistributionsOrderedLogisitcGLM, gpu_matches_cpu_zero_attributes) {
   Matrix<double, Dynamic, 1> cuts(C - 1, 1);
   cuts << -0.4, 0.1, 0.3, 4.5;
 
-  stan::math::test::compare_cpu_gpu_prim_rev(ordered_logistic_glm_lpmf_functor,
+  stan::math::test::compare_cpu_opencl_prim_rev(ordered_logistic_glm_lpmf_functor,
                                              y, x, beta, cuts);
-  stan::math::test::compare_cpu_gpu_prim_rev(
+  stan::math::test::compare_cpu_opencl_prim_rev(
       ordered_logistic_glm_lpmf_functor_propto, y, x, beta, cuts);
 }
 
-TEST(ProbDistributionsOrderedLogisitcGLM, gpu_matches_cpu_single_class) {
+TEST(ProbDistributionsOrderedLogisitcGLM, opencl_matches_cpu_single_class) {
   int N = 3;
   int M = 2;
   int C = 1;
@@ -221,13 +221,13 @@ TEST(ProbDistributionsOrderedLogisitcGLM, gpu_matches_cpu_single_class) {
   beta << 0.3, 2;
   Matrix<double, Dynamic, 1> cuts(C - 1, 1);
 
-  stan::math::test::compare_cpu_gpu_prim_rev(ordered_logistic_glm_lpmf_functor,
+  stan::math::test::compare_cpu_opencl_prim_rev(ordered_logistic_glm_lpmf_functor,
                                              y, x, beta, cuts);
-  stan::math::test::compare_cpu_gpu_prim_rev(
+  stan::math::test::compare_cpu_opencl_prim_rev(
       ordered_logistic_glm_lpmf_functor_propto, y, x, beta, cuts);
 }
 
-TEST(ProbDistributionsOrderedLogisitcGLM, gpu_matches_cpu_big) {
+TEST(ProbDistributionsOrderedLogisitcGLM, opencl_matches_cpu_big) {
   int N = 153;
   int M = 71;
   int C = 43;
@@ -245,9 +245,9 @@ TEST(ProbDistributionsOrderedLogisitcGLM, gpu_matches_cpu_big) {
     cuts[i] += cuts[i - 1];
   }
 
-  stan::math::test::compare_cpu_gpu_prim_rev(ordered_logistic_glm_lpmf_functor,
+  stan::math::test::compare_cpu_opencl_prim_rev(ordered_logistic_glm_lpmf_functor,
                                              y, x, beta, cuts);
-  stan::math::test::compare_cpu_gpu_prim_rev(
+  stan::math::test::compare_cpu_opencl_prim_rev(
       ordered_logistic_glm_lpmf_functor_propto, y, x, beta, cuts);
 }
 

--- a/test/unit/math/opencl/rev/ordered_logistic_glm_lpmf_test.cpp
+++ b/test/unit/math/opencl/rev/ordered_logistic_glm_lpmf_test.cpp
@@ -115,8 +115,8 @@ TEST(ProbDistributionsOrderedLogisitcGLM, opencl_matches_cpu_small_simple) {
   Matrix<double, Dynamic, 1> cuts(C - 1, 1);
   cuts << -0.4, 0.1, 0.3, 4.5;
 
-  stan::math::test::compare_cpu_opencl_prim_rev(ordered_logistic_glm_lpmf_functor,
-                                             y, x, beta, cuts);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      ordered_logistic_glm_lpmf_functor, y, x, beta, cuts);
   stan::math::test::compare_cpu_opencl_prim_rev(
       ordered_logistic_glm_lpmf_functor_propto, y, x, beta, cuts);
 }
@@ -186,8 +186,8 @@ TEST(ProbDistributionsOrderedLogisitcGLM, opencl_matches_cpu_zero_instances) {
   matrix_cl<double> beta_cl(beta);
   matrix_cl<double> cuts_cl(cuts);
 
-  stan::math::test::compare_cpu_opencl_prim_rev(ordered_logistic_glm_lpmf_functor,
-                                             y, x, beta, cuts);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      ordered_logistic_glm_lpmf_functor, y, x, beta, cuts);
   stan::math::test::compare_cpu_opencl_prim_rev(
       ordered_logistic_glm_lpmf_functor_propto, y, x, beta, cuts);
 }
@@ -203,8 +203,8 @@ TEST(ProbDistributionsOrderedLogisitcGLM, opencl_matches_cpu_zero_attributes) {
   Matrix<double, Dynamic, 1> cuts(C - 1, 1);
   cuts << -0.4, 0.1, 0.3, 4.5;
 
-  stan::math::test::compare_cpu_opencl_prim_rev(ordered_logistic_glm_lpmf_functor,
-                                             y, x, beta, cuts);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      ordered_logistic_glm_lpmf_functor, y, x, beta, cuts);
   stan::math::test::compare_cpu_opencl_prim_rev(
       ordered_logistic_glm_lpmf_functor_propto, y, x, beta, cuts);
 }
@@ -221,8 +221,8 @@ TEST(ProbDistributionsOrderedLogisitcGLM, opencl_matches_cpu_single_class) {
   beta << 0.3, 2;
   Matrix<double, Dynamic, 1> cuts(C - 1, 1);
 
-  stan::math::test::compare_cpu_opencl_prim_rev(ordered_logistic_glm_lpmf_functor,
-                                             y, x, beta, cuts);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      ordered_logistic_glm_lpmf_functor, y, x, beta, cuts);
   stan::math::test::compare_cpu_opencl_prim_rev(
       ordered_logistic_glm_lpmf_functor_propto, y, x, beta, cuts);
 }
@@ -245,8 +245,8 @@ TEST(ProbDistributionsOrderedLogisitcGLM, opencl_matches_cpu_big) {
     cuts[i] += cuts[i - 1];
   }
 
-  stan::math::test::compare_cpu_opencl_prim_rev(ordered_logistic_glm_lpmf_functor,
-                                             y, x, beta, cuts);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      ordered_logistic_glm_lpmf_functor, y, x, beta, cuts);
   stan::math::test::compare_cpu_opencl_prim_rev(
       ordered_logistic_glm_lpmf_functor_propto, y, x, beta, cuts);
 }

--- a/test/unit/math/opencl/rev/poisson_log_glm_lpmf_test.cpp
+++ b/test/unit/math/opencl/rev/poisson_log_glm_lpmf_test.cpp
@@ -2,7 +2,7 @@
 #include <stan/math/opencl/rev/opencl.hpp>
 #include <stan/math.hpp>
 #include <gtest/gtest.h>
-#include <test/unit/math/expect_near_rel.hpp>
+#include <test/unit/math/opencl/util.hpp>
 #include <vector>
 
 using Eigen::Array;
@@ -14,7 +14,6 @@ using stan::test::expect_near_rel;
 using std::vector;
 
 TEST(ProbDistributionsPoissonLogGLM, error_checking) {
-  double eps = 1e-9;
   int N = 3;
   int M = 2;
 
@@ -92,8 +91,16 @@ TEST(ProbDistributionsPoissonLogGLM, error_checking) {
       std::domain_error);
 }
 
+auto poisson_log_glm_lpmf_functor
+    = [](const auto& y, const auto& x, const auto& alpha, const auto& beta) {
+        return stan::math::poisson_log_glm_lpmf(y, x, alpha, beta);
+      };
+auto poisson_log_glm_lpmf_functor_propto
+    = [](const auto& y, const auto& x, const auto& alpha, const auto& beta) {
+        return stan::math::poisson_log_glm_lpmf<true>(y, x, alpha, beta);
+      };
+
 TEST(ProbDistributionsPoissonLogGLM, gpu_matches_cpu_small_simple) {
-  double eps = 1e-9;
   int N = 3;
   int M = 2;
 
@@ -104,45 +111,13 @@ TEST(ProbDistributionsPoissonLogGLM, gpu_matches_cpu_small_simple) {
   beta << 0.3, 2;
   double alpha = 0.3;
 
-  matrix_cl<double> x_cl(x);
-  matrix_cl<int> y_cl(y);
-  matrix_cl<double> beta_cl(beta);
-
-  expect_near_rel("poisson_log_glm_lpmf (OpenCL)",
-                  stan::math::poisson_log_glm_lpmf(y_cl, x_cl, alpha, beta_cl),
-                  stan::math::poisson_log_glm_lpmf(y, x, alpha, beta));
-  expect_near_rel(
-      "poisson_log_glm_lpmf (OpenCL)",
-      stan::math::poisson_log_glm_lpmf<true>(y_cl, x_cl, alpha, beta_cl),
-      stan::math::poisson_log_glm_lpmf<true>(y, x, alpha, beta));
-
-  Matrix<var, Dynamic, Dynamic> x_var1 = x;
-  Matrix<var, Dynamic, Dynamic> x_var2 = x;
-  Matrix<var, Dynamic, 1> beta_var1 = beta;
-  Matrix<var, Dynamic, 1> beta_var2 = beta;
-  auto x_var1_cl = to_matrix_cl(x_var1);
-  auto beta_var1_cl = stan::math::to_matrix_cl(beta_var1);
-  var alpha_var1 = alpha;
-  var alpha_var2 = alpha;
-
-  var res1 = stan::math::poisson_log_glm_lpmf(y_cl, x_var1_cl, alpha_var1,
-                                              beta_var1_cl);
-  var res2 = stan::math::poisson_log_glm_lpmf(y, x_var2, alpha_var2, beta_var2);
-
-  (res1 + res2).grad();
-
-  expect_near_rel("poisson_log_glm_lpmf (OpenCL)", res1.val(), res2.val());
-
-  expect_near_rel("bernoulli_logit_glm_lpmf (OpenCL)", x_var1.adj().eval(),
-                  x_var2.adj().eval());
-  expect_near_rel("poisson_log_glm_lpmf (OpenCL)", alpha_var1.adj(),
-                  alpha_var2.adj());
-  expect_near_rel("poisson_log_glm_lpmf (OpenCL)", beta_var1.adj().eval(),
-                  beta_var2.adj().eval());
+  stan::math::test::compare_cpu_gpu_prim_rev(poisson_log_glm_lpmf_functor,
+                                             y, x, alpha, beta);
+  stan::math::test::compare_cpu_gpu_prim_rev(
+      poisson_log_glm_lpmf_functor_propto, y, x, alpha, beta);
 }
 
 TEST(ProbDistributionsPoissonLogGLM, gpu_broadcast_y) {
-  double eps = 1e-9;
   int N = 3;
   int M = 2;
 
@@ -196,7 +171,6 @@ TEST(ProbDistributionsPoissonLogGLM, gpu_broadcast_y) {
 }
 
 TEST(ProbDistributionsPoissonLogGLM, gpu_matches_cpu_zero_instances) {
-  double eps = 1e-9;
   int N = 0;
   int M = 2;
 
@@ -206,45 +180,13 @@ TEST(ProbDistributionsPoissonLogGLM, gpu_matches_cpu_zero_instances) {
   beta << 0.3, 2;
   double alpha = 0.3;
 
-  matrix_cl<double> x_cl(x);
-  matrix_cl<int> y_cl(y);
-  matrix_cl<double> beta_cl(beta);
-
-  expect_near_rel("poisson_log_glm_lpmf (OpenCL)",
-                  stan::math::poisson_log_glm_lpmf(y_cl, x_cl, alpha, beta_cl),
-                  stan::math::poisson_log_glm_lpmf(y, x, alpha, beta));
-  expect_near_rel(
-      "poisson_log_glm_lpmf (OpenCL)",
-      stan::math::poisson_log_glm_lpmf<true>(y_cl, x_cl, alpha, beta_cl),
-      stan::math::poisson_log_glm_lpmf<true>(y, x, alpha, beta));
-
-  Matrix<var, Dynamic, Dynamic> x_var1 = x;
-  Matrix<var, Dynamic, Dynamic> x_var2 = x;
-  Matrix<var, Dynamic, 1> beta_var1 = beta;
-  Matrix<var, Dynamic, 1> beta_var2 = beta;
-  auto x_var1_cl = to_matrix_cl(x_var1);
-  auto beta_var1_cl = stan::math::to_matrix_cl(beta_var1);
-  var alpha_var1 = alpha;
-  var alpha_var2 = alpha;
-
-  var res1 = stan::math::poisson_log_glm_lpmf(y_cl, x_var1_cl, alpha_var1,
-                                              beta_var1_cl);
-  var res2 = stan::math::poisson_log_glm_lpmf(y, x_var2, alpha_var2, beta_var2);
-
-  (res1 + res2).grad();
-
-  expect_near_rel("poisson_log_glm_lpmf (OpenCL)", res1.val(), res2.val());
-
-  expect_near_rel("bernoulli_logit_glm_lpmf (OpenCL)", x_var1.adj().eval(),
-                  x_var2.adj().eval());
-  expect_near_rel("poisson_log_glm_lpmf (OpenCL)", alpha_var1.adj(),
-                  alpha_var2.adj());
-  expect_near_rel("poisson_log_glm_lpmf (OpenCL)", beta_var1.adj().eval(),
-                  beta_var2.adj().eval());
+  stan::math::test::compare_cpu_gpu_prim_rev(poisson_log_glm_lpmf_functor,
+                                             y, x, alpha, beta);
+  stan::math::test::compare_cpu_gpu_prim_rev(
+      poisson_log_glm_lpmf_functor_propto, y, x, alpha, beta);
 }
 
 TEST(ProbDistributionsPoissonLogGLM, gpu_matches_cpu_zero_attributes) {
-  double eps = 1e-9;
   int N = 3;
   int M = 0;
 
@@ -253,45 +195,13 @@ TEST(ProbDistributionsPoissonLogGLM, gpu_matches_cpu_zero_attributes) {
   Matrix<double, Dynamic, 1> beta(M, 1);
   double alpha = 0.3;
 
-  matrix_cl<double> x_cl(x);
-  matrix_cl<int> y_cl(y);
-  matrix_cl<double> beta_cl(beta);
-
-  expect_near_rel("poisson_log_glm_lpmf (OpenCL)",
-                  stan::math::poisson_log_glm_lpmf(y_cl, x_cl, alpha, beta_cl),
-                  stan::math::poisson_log_glm_lpmf(y, x, alpha, beta));
-  expect_near_rel(
-      "poisson_log_glm_lpmf (OpenCL)",
-      stan::math::poisson_log_glm_lpmf<true>(y_cl, x_cl, alpha, beta_cl),
-      stan::math::poisson_log_glm_lpmf<true>(y, x, alpha, beta));
-
-  Matrix<var, Dynamic, Dynamic> x_var1 = x;
-  Matrix<var, Dynamic, Dynamic> x_var2 = x;
-  Matrix<var, Dynamic, 1> beta_var1 = beta;
-  Matrix<var, Dynamic, 1> beta_var2 = beta;
-  auto x_var1_cl = to_matrix_cl(x_var1);
-  auto beta_var1_cl = stan::math::to_matrix_cl(beta_var1);
-  var alpha_var1 = alpha;
-  var alpha_var2 = alpha;
-
-  var res1 = stan::math::poisson_log_glm_lpmf(y_cl, x_var1_cl, alpha_var1,
-                                              beta_var1_cl);
-  var res2 = stan::math::poisson_log_glm_lpmf(y, x_var2, alpha_var2, beta_var2);
-
-  (res1 + res2).grad();
-
-  expect_near_rel("poisson_log_glm_lpmf (OpenCL)", res1.val(), res2.val());
-
-  expect_near_rel("bernoulli_logit_glm_lpmf (OpenCL)", x_var1.adj().eval(),
-                  x_var2.adj().eval());
-  expect_near_rel("poisson_log_glm_lpmf (OpenCL)", alpha_var1.adj(),
-                  alpha_var2.adj());
-  expect_near_rel("poisson_log_glm_lpmf (OpenCL)", beta_var1.adj().eval(),
-                  beta_var2.adj().eval());
+  stan::math::test::compare_cpu_gpu_prim_rev(poisson_log_glm_lpmf_functor,
+                                             y, x, alpha, beta);
+  stan::math::test::compare_cpu_gpu_prim_rev(
+      poisson_log_glm_lpmf_functor_propto, y, x, alpha, beta);
 }
 
 TEST(ProbDistributionsPoissonLogGLM, gpu_matches_cpu_small_vector_alpha) {
-  double eps = 1e-9;
   int N = 3;
   int M = 2;
 
@@ -303,48 +213,13 @@ TEST(ProbDistributionsPoissonLogGLM, gpu_matches_cpu_small_vector_alpha) {
   Matrix<double, Dynamic, 1> alpha(N, 1);
   alpha << 0.3, -0.8, 1.8;
 
-  matrix_cl<double> x_cl(x);
-  matrix_cl<int> y_cl(y);
-  matrix_cl<double> alpha_cl(alpha);
-  matrix_cl<double> beta_cl(beta);
-
-  expect_near_rel(
-      "poisson_log_glm_lpmf (OpenCL)",
-      stan::math::poisson_log_glm_lpmf(y_cl, x_cl, alpha_cl, beta_cl),
-      stan::math::poisson_log_glm_lpmf(y, x, alpha, beta));
-  expect_near_rel(
-      "poisson_log_glm_lpmf (OpenCL)",
-      stan::math::poisson_log_glm_lpmf<true>(y_cl, x_cl, alpha_cl, beta_cl),
-      stan::math::poisson_log_glm_lpmf<true>(y, x, alpha, beta));
-
-  Matrix<var, Dynamic, Dynamic> x_var1 = x;
-  Matrix<var, Dynamic, Dynamic> x_var2 = x;
-  Matrix<var, Dynamic, 1> beta_var1 = beta;
-  Matrix<var, Dynamic, 1> beta_var2 = beta;
-  Matrix<var, Dynamic, 1> alpha_var1 = alpha;
-  Matrix<var, Dynamic, 1> alpha_var2 = alpha;
-  auto x_var1_cl = to_matrix_cl(x_var1);
-  auto alpha_var1_cl = to_matrix_cl(alpha_var1);
-  auto beta_var1_cl = to_matrix_cl(beta_var1);
-
-  var res1 = stan::math::poisson_log_glm_lpmf(y_cl, x_var1_cl, alpha_var1_cl,
-                                              beta_var1_cl);
-  var res2 = stan::math::poisson_log_glm_lpmf(y, x_var2, alpha_var2, beta_var2);
-
-  (res1 + res2).grad();
-
-  expect_near_rel("poisson_log_glm_lpmf (OpenCL)", res1.val(), res2.val());
-
-  expect_near_rel("bernoulli_logit_glm_lpmf (OpenCL)", x_var1.adj().eval(),
-                  x_var2.adj().eval());
-  expect_near_rel("poisson_log_glm_lpmf (OpenCL)", beta_var1.adj().eval(),
-                  beta_var2.adj().eval());
-  expect_near_rel("poisson_log_glm_lpmf (OpenCL)", alpha_var1.adj().eval(),
-                  alpha_var2.adj().eval());
+  stan::math::test::compare_cpu_gpu_prim_rev(poisson_log_glm_lpmf_functor,
+                                             y, x, alpha, beta);
+  stan::math::test::compare_cpu_gpu_prim_rev(
+      poisson_log_glm_lpmf_functor_propto, y, x, alpha, beta);
 }
 
 TEST(ProbDistributionsPoissonLogGLM, gpu_matches_cpu_big) {
-  double eps = 1e-9;
   int N = 153;
   int M = 71;
 
@@ -357,45 +232,10 @@ TEST(ProbDistributionsPoissonLogGLM, gpu_matches_cpu_big) {
   Matrix<double, Dynamic, 1> beta = Matrix<double, Dynamic, 1>::Random(M, 1);
   Matrix<double, Dynamic, 1> alpha = Matrix<double, Dynamic, 1>::Random(N, 1);
 
-  matrix_cl<double> x_cl(x);
-  matrix_cl<int> y_cl(y);
-  matrix_cl<double> alpha_cl(alpha);
-  matrix_cl<double> beta_cl(beta);
-
-  expect_near_rel(
-      "poisson_log_glm_lpmf (OpenCL)",
-      stan::math::poisson_log_glm_lpmf(y_cl, x_cl, alpha_cl, beta_cl),
-      stan::math::poisson_log_glm_lpmf(y, x, alpha, beta));
-  expect_near_rel(
-      "poisson_log_glm_lpmf (OpenCL)",
-      stan::math::poisson_log_glm_lpmf(y_cl, x_cl, alpha_cl, beta_cl),
-      stan::math::poisson_log_glm_lpmf(y, x, alpha, beta));
-
-  Matrix<var, Dynamic, Dynamic> x_var1 = x;
-  Matrix<var, Dynamic, Dynamic> x_var2 = x;
-  Matrix<var, Dynamic, 1> beta_var1 = beta;
-  Matrix<var, Dynamic, 1> beta_var2 = beta;
-  Matrix<var, Dynamic, 1> alpha_var1 = alpha;
-  Matrix<var, Dynamic, 1> alpha_var2 = alpha;
-  auto x_var1_cl = to_matrix_cl(x_var1);
-  auto alpha_var1_cl = to_matrix_cl(alpha_var1);
-  auto beta_var1_cl = to_matrix_cl(beta_var1);
-
-  var res1 = stan::math::poisson_log_glm_lpmf<true>(
-      y_cl, x_var1_cl, alpha_var1_cl, beta_var1_cl);
-  var res2 = stan::math::poisson_log_glm_lpmf<true>(y, x_var2, alpha_var2,
-                                                    beta_var2);
-
-  (res1 + res2).grad();
-
-  expect_near_rel("poisson_log_glm_lpmf (OpenCL)", res1.val(), res2.val());
-
-  expect_near_rel("bernoulli_logit_glm_lpmf (OpenCL)", x_var1.adj().eval(),
-                  x_var2.adj().eval());
-  expect_near_rel("poisson_log_glm_lpmf (OpenCL)", beta_var1.adj().eval(),
-                  beta_var2.adj().eval());
-  expect_near_rel("poisson_log_glm_lpmf (OpenCL)", alpha_var1.adj().eval(),
-                  alpha_var2.adj().eval());
+  stan::math::test::compare_cpu_gpu_prim_rev(poisson_log_glm_lpmf_functor,
+                                             y, x, alpha, beta);
+  stan::math::test::compare_cpu_gpu_prim_rev(
+      poisson_log_glm_lpmf_functor_propto, y, x, alpha, beta);
 }
 
 #endif

--- a/test/unit/math/opencl/rev/poisson_log_glm_lpmf_test.cpp
+++ b/test/unit/math/opencl/rev/poisson_log_glm_lpmf_test.cpp
@@ -100,7 +100,7 @@ auto poisson_log_glm_lpmf_functor_propto
         return stan::math::poisson_log_glm_lpmf<true>(y, x, alpha, beta);
       };
 
-TEST(ProbDistributionsPoissonLogGLM, gpu_matches_cpu_small_simple) {
+TEST(ProbDistributionsPoissonLogGLM, opencl_matches_cpu_small_simple) {
   int N = 3;
   int M = 2;
 
@@ -111,13 +111,13 @@ TEST(ProbDistributionsPoissonLogGLM, gpu_matches_cpu_small_simple) {
   beta << 0.3, 2;
   double alpha = 0.3;
 
-  stan::math::test::compare_cpu_gpu_prim_rev(poisson_log_glm_lpmf_functor,
+  stan::math::test::compare_cpu_opencl_prim_rev(poisson_log_glm_lpmf_functor,
                                              y, x, alpha, beta);
-  stan::math::test::compare_cpu_gpu_prim_rev(
+  stan::math::test::compare_cpu_opencl_prim_rev(
       poisson_log_glm_lpmf_functor_propto, y, x, alpha, beta);
 }
 
-TEST(ProbDistributionsPoissonLogGLM, gpu_broadcast_y) {
+TEST(ProbDistributionsPoissonLogGLM, opencl_broadcast_y) {
   int N = 3;
   int M = 2;
 
@@ -170,7 +170,7 @@ TEST(ProbDistributionsPoissonLogGLM, gpu_broadcast_y) {
                   beta_var2.adj().eval());
 }
 
-TEST(ProbDistributionsPoissonLogGLM, gpu_matches_cpu_zero_instances) {
+TEST(ProbDistributionsPoissonLogGLM, opencl_matches_cpu_zero_instances) {
   int N = 0;
   int M = 2;
 
@@ -180,13 +180,13 @@ TEST(ProbDistributionsPoissonLogGLM, gpu_matches_cpu_zero_instances) {
   beta << 0.3, 2;
   double alpha = 0.3;
 
-  stan::math::test::compare_cpu_gpu_prim_rev(poisson_log_glm_lpmf_functor,
+  stan::math::test::compare_cpu_opencl_prim_rev(poisson_log_glm_lpmf_functor,
                                              y, x, alpha, beta);
-  stan::math::test::compare_cpu_gpu_prim_rev(
+  stan::math::test::compare_cpu_opencl_prim_rev(
       poisson_log_glm_lpmf_functor_propto, y, x, alpha, beta);
 }
 
-TEST(ProbDistributionsPoissonLogGLM, gpu_matches_cpu_zero_attributes) {
+TEST(ProbDistributionsPoissonLogGLM, opencl_matches_cpu_zero_attributes) {
   int N = 3;
   int M = 0;
 
@@ -195,13 +195,13 @@ TEST(ProbDistributionsPoissonLogGLM, gpu_matches_cpu_zero_attributes) {
   Matrix<double, Dynamic, 1> beta(M, 1);
   double alpha = 0.3;
 
-  stan::math::test::compare_cpu_gpu_prim_rev(poisson_log_glm_lpmf_functor,
+  stan::math::test::compare_cpu_opencl_prim_rev(poisson_log_glm_lpmf_functor,
                                              y, x, alpha, beta);
-  stan::math::test::compare_cpu_gpu_prim_rev(
+  stan::math::test::compare_cpu_opencl_prim_rev(
       poisson_log_glm_lpmf_functor_propto, y, x, alpha, beta);
 }
 
-TEST(ProbDistributionsPoissonLogGLM, gpu_matches_cpu_small_vector_alpha) {
+TEST(ProbDistributionsPoissonLogGLM, opencl_matches_cpu_small_vector_alpha) {
   int N = 3;
   int M = 2;
 
@@ -213,13 +213,13 @@ TEST(ProbDistributionsPoissonLogGLM, gpu_matches_cpu_small_vector_alpha) {
   Matrix<double, Dynamic, 1> alpha(N, 1);
   alpha << 0.3, -0.8, 1.8;
 
-  stan::math::test::compare_cpu_gpu_prim_rev(poisson_log_glm_lpmf_functor,
+  stan::math::test::compare_cpu_opencl_prim_rev(poisson_log_glm_lpmf_functor,
                                              y, x, alpha, beta);
-  stan::math::test::compare_cpu_gpu_prim_rev(
+  stan::math::test::compare_cpu_opencl_prim_rev(
       poisson_log_glm_lpmf_functor_propto, y, x, alpha, beta);
 }
 
-TEST(ProbDistributionsPoissonLogGLM, gpu_matches_cpu_big) {
+TEST(ProbDistributionsPoissonLogGLM, opencl_matches_cpu_big) {
   int N = 153;
   int M = 71;
 
@@ -232,9 +232,9 @@ TEST(ProbDistributionsPoissonLogGLM, gpu_matches_cpu_big) {
   Matrix<double, Dynamic, 1> beta = Matrix<double, Dynamic, 1>::Random(M, 1);
   Matrix<double, Dynamic, 1> alpha = Matrix<double, Dynamic, 1>::Random(N, 1);
 
-  stan::math::test::compare_cpu_gpu_prim_rev(poisson_log_glm_lpmf_functor,
+  stan::math::test::compare_cpu_opencl_prim_rev(poisson_log_glm_lpmf_functor,
                                              y, x, alpha, beta);
-  stan::math::test::compare_cpu_gpu_prim_rev(
+  stan::math::test::compare_cpu_opencl_prim_rev(
       poisson_log_glm_lpmf_functor_propto, y, x, alpha, beta);
 }
 

--- a/test/unit/math/opencl/rev/poisson_log_glm_lpmf_test.cpp
+++ b/test/unit/math/opencl/rev/poisson_log_glm_lpmf_test.cpp
@@ -111,8 +111,8 @@ TEST(ProbDistributionsPoissonLogGLM, opencl_matches_cpu_small_simple) {
   beta << 0.3, 2;
   double alpha = 0.3;
 
-  stan::math::test::compare_cpu_opencl_prim_rev(poisson_log_glm_lpmf_functor,
-                                             y, x, alpha, beta);
+  stan::math::test::compare_cpu_opencl_prim_rev(poisson_log_glm_lpmf_functor, y,
+                                                x, alpha, beta);
   stan::math::test::compare_cpu_opencl_prim_rev(
       poisson_log_glm_lpmf_functor_propto, y, x, alpha, beta);
 }
@@ -180,8 +180,8 @@ TEST(ProbDistributionsPoissonLogGLM, opencl_matches_cpu_zero_instances) {
   beta << 0.3, 2;
   double alpha = 0.3;
 
-  stan::math::test::compare_cpu_opencl_prim_rev(poisson_log_glm_lpmf_functor,
-                                             y, x, alpha, beta);
+  stan::math::test::compare_cpu_opencl_prim_rev(poisson_log_glm_lpmf_functor, y,
+                                                x, alpha, beta);
   stan::math::test::compare_cpu_opencl_prim_rev(
       poisson_log_glm_lpmf_functor_propto, y, x, alpha, beta);
 }
@@ -195,8 +195,8 @@ TEST(ProbDistributionsPoissonLogGLM, opencl_matches_cpu_zero_attributes) {
   Matrix<double, Dynamic, 1> beta(M, 1);
   double alpha = 0.3;
 
-  stan::math::test::compare_cpu_opencl_prim_rev(poisson_log_glm_lpmf_functor,
-                                             y, x, alpha, beta);
+  stan::math::test::compare_cpu_opencl_prim_rev(poisson_log_glm_lpmf_functor, y,
+                                                x, alpha, beta);
   stan::math::test::compare_cpu_opencl_prim_rev(
       poisson_log_glm_lpmf_functor_propto, y, x, alpha, beta);
 }
@@ -213,8 +213,8 @@ TEST(ProbDistributionsPoissonLogGLM, opencl_matches_cpu_small_vector_alpha) {
   Matrix<double, Dynamic, 1> alpha(N, 1);
   alpha << 0.3, -0.8, 1.8;
 
-  stan::math::test::compare_cpu_opencl_prim_rev(poisson_log_glm_lpmf_functor,
-                                             y, x, alpha, beta);
+  stan::math::test::compare_cpu_opencl_prim_rev(poisson_log_glm_lpmf_functor, y,
+                                                x, alpha, beta);
   stan::math::test::compare_cpu_opencl_prim_rev(
       poisson_log_glm_lpmf_functor_propto, y, x, alpha, beta);
 }
@@ -232,8 +232,8 @@ TEST(ProbDistributionsPoissonLogGLM, opencl_matches_cpu_big) {
   Matrix<double, Dynamic, 1> beta = Matrix<double, Dynamic, 1>::Random(M, 1);
   Matrix<double, Dynamic, 1> alpha = Matrix<double, Dynamic, 1>::Random(N, 1);
 
-  stan::math::test::compare_cpu_opencl_prim_rev(poisson_log_glm_lpmf_functor,
-                                             y, x, alpha, beta);
+  stan::math::test::compare_cpu_opencl_prim_rev(poisson_log_glm_lpmf_functor, y,
+                                                x, alpha, beta);
   stan::math::test::compare_cpu_opencl_prim_rev(
       poisson_log_glm_lpmf_functor_propto, y, x, alpha, beta);
 }

--- a/test/unit/math/opencl/util.hpp
+++ b/test/unit/math/opencl/util.hpp
@@ -1,0 +1,152 @@
+#ifndef STAN_TEST_OPENCL_UTIL_HPP
+#define STAN_TEST_OPENCL_UTIL_HPP
+
+#include <stan/math.hpp>
+#include <stan/math/opencl/rev/opencl.hpp>
+#include <test/unit/math/expect_near_rel.hpp>
+#include <gtest/gtest.h>
+#include <utility>
+#include <tuple>
+
+namespace stan {
+namespace math {
+namespace test {
+
+namespace internal {
+
+template <typename T, require_stan_scalar_t<T>* = nullptr>
+T gpu_argument(T&& x) {
+  return x;
+}
+
+template <typename T, require_not_stan_scalar_t<T>* = nullptr>
+auto gpu_argument(const T& x) {
+  return to_matrix_cl(x);
+}
+
+template <typename T, require_st_same<T, int>* = nullptr>
+T var_argument(T&& x) {
+  return x;
+}
+
+template <typename T, require_not_st_same<T, int>* = nullptr>
+auto var_argument(T&& x) {
+  return to_var(x);
+}
+
+template <typename T, require_arithmetic_t<T>* = nullptr>
+void expect_eq(T a, T b, const char* msg) {
+  stan::test::expect_near_rel(msg, a, b);
+}
+
+void expect_eq(math::var a, math::var b, const char* msg) {
+  stan::test::expect_near_rel(msg, a.val(), b.val());
+}
+
+template <typename T1, typename T2, require_all_eigen_t<T1, T2>* = nullptr,
+          require_vt_same<T1, T2>* = nullptr>
+void expect_eq(const T1& a, const T2& b, const char* msg) {
+  EXPECT_EQ(a.rows(), b.rows()) << msg;
+  EXPECT_EQ(a.cols(), b.cols()) << msg;
+  const auto& a_ref = math::to_ref(a);
+  const auto& b_ref = math::to_ref(b);
+  for (int i = 0; i < a.rows(); i++) {
+    for (int j = 0; j < a.cols(); j++) {
+      expect_eq(a_ref(i, j), b_ref(i, j), msg);
+    }
+  }
+}
+
+template <typename T>
+void expect_eq(const std::vector<T>& a, const std::vector<T>& b,
+               const char* msg) {
+  EXPECT_EQ(a.size(), b.size());
+  for (int i = 0; i < a.size(); i++) {
+    expect_eq(a[i], b[i], msg);
+  }
+}
+
+template <typename T>
+auto recursive_sum(const T& a) {
+  return math::sum(a);
+}
+
+template <typename T>
+auto recursive_sum(const std::vector<T>& a) {
+  scalar_type_t<T> res = recursive_sum(a[0]);
+  for (int i = 0; i < a.size(); i++) {
+    res += recursive_sum(a[i]);
+  }
+  return res;
+}
+
+template <typename T, require_not_st_var<T>* = nullptr>
+void expect_adj_near(const T& a, const T& b, const char* msg) {}
+
+void expect_adj_near(var a, var b, const char* msg) {
+  stan::test::expect_near_rel(msg, a.adj(), b.adj());
+}
+
+template <typename T1, typename T2, require_all_eigen_t<T1, T2>* = nullptr,
+          require_vt_same<T1, T2>* = nullptr>
+void expect_adj_near(const T1& a, const T2& b, const char* msg) {
+  EXPECT_EQ(a.rows(), b.rows()) << msg;
+  EXPECT_EQ(a.cols(), b.cols()) << msg;
+  const auto& a_ref = math::to_ref(a);
+  const auto& b_ref = math::to_ref(b);
+  stan::test::expect_near_rel(msg, a_ref.adj(), b_ref.adj());
+}
+
+template <typename T>
+void expect_adj_near(const std::vector<T>& a, const std::vector<T>& b,
+                     const char* msg) {
+  EXPECT_EQ(a.size(), b.size()) << msg;
+  for (int i = 0; i < a.size(); i++) {
+    expect_adj_near(a[i], b[i], msg);
+  }
+}
+
+template <typename Functor, std::size_t... Is, typename... Args>
+void compare_cpu_gpu_prim_rev_impl(Functor functor, std::index_sequence<Is...>,
+                                   Args... args) {
+  expect_eq(functor(gpu_argument(args)...), functor(args...),
+            "Wrong prim return value!");
+
+  auto var_args_for_cpu = std::make_tuple(var_argument(args)...);
+  auto var_args_for_gpu = std::make_tuple(var_argument(args)...);
+  auto res_cpu = functor(std::get<Is>(var_args_for_cpu)...);
+  auto res_gpu = functor(gpu_argument(std::get<Is>(var_args_for_gpu))...);
+  expect_eq(res_gpu, res_cpu, "Wrong rev return value!");
+
+  (recursive_sum(res_cpu) + recursive_sum(res_gpu)).grad();
+
+  static_cast<void>(std::initializer_list<int>{
+      (expect_adj_near(std::get<Is>(var_args_for_gpu),
+                       std::get<Is>(var_args_for_cpu),
+                       "Wrong adjoint for argument " TO_STRING(Is) "!"),
+       0)...});
+}
+
+}  // namespace internal
+
+/**
+ * Tests that given functor calculates same values and adjoints when given
+ * arguments on CPU and GPU.
+ *
+ * @tparam Functor type of the functor
+ * @tparam Args types of the arguments
+ * @param fucntor functor to test
+ * @param args arguments to test the functor with. These should be just values
+ * on CPU (no vars, no arguments on GPU).
+ */
+template <typename Functor, typename... Args>
+void compare_cpu_gpu_prim_rev(Functor functor, Args... args) {
+  internal::compare_cpu_gpu_prim_rev_impl(
+      functor, std::make_index_sequence<sizeof...(args)>{}, args...);
+}
+
+}  // namespace test
+}  // namespace math
+}  // namespace stan
+
+#endif

--- a/test/unit/math/opencl/util.hpp
+++ b/test/unit/math/opencl/util.hpp
@@ -107,23 +107,27 @@ void expect_adj_near(const std::vector<T>& a, const std::vector<T>& b,
 }
 
 template <typename Functor, std::size_t... Is, typename... Args>
-void compare_cpu_opencl_prim_rev_impl(Functor functor, std::index_sequence<Is...>,
-                                   Args... args) {
+void compare_cpu_opencl_prim_rev_impl(Functor functor,
+                                      std::index_sequence<Is...>,
+                                      Args... args) {
   expect_eq(functor(opencl_argument(args)...), functor(args...),
             "CPU and OpenCL return values for prim do not match!");
 
   auto var_args_for_cpu = std::make_tuple(var_argument(args)...);
   auto var_args_for_opencl = std::make_tuple(var_argument(args)...);
   auto res_cpu = functor(std::get<Is>(var_args_for_cpu)...);
-  auto res_opencl = functor(opencl_argument(std::get<Is>(var_args_for_opencl))...);
-  expect_eq(res_opencl, res_cpu, "CPU and OpenCL return values for rev do not match!");
+  auto res_opencl
+      = functor(opencl_argument(std::get<Is>(var_args_for_opencl))...);
+  expect_eq(res_opencl, res_cpu,
+            "CPU and OpenCL return values for rev do not match!");
 
   (recursive_sum(res_cpu) + recursive_sum(res_opencl)).grad();
 
   static_cast<void>(std::initializer_list<int>{
-      (expect_adj_near(std::get<Is>(var_args_for_opencl),
-                       std::get<Is>(var_args_for_cpu),
-                       "CPU and OpenCL adjoints do not match for argument " TO_STRING(Is) "!"),
+      (expect_adj_near(
+           std::get<Is>(var_args_for_opencl), std::get<Is>(var_args_for_cpu),
+           "CPU and OpenCL adjoints do not match for argument " TO_STRING(
+               Is) "!"),
        0)...});
 }
 

--- a/test/unit/math/opencl/util.hpp
+++ b/test/unit/math/opencl/util.hpp
@@ -110,20 +110,20 @@ template <typename Functor, std::size_t... Is, typename... Args>
 void compare_cpu_opencl_prim_rev_impl(Functor functor, std::index_sequence<Is...>,
                                    Args... args) {
   expect_eq(functor(opencl_argument(args)...), functor(args...),
-            "Wrong prim return value!");
+            "CPU and OpenCL return values for prim do not match!");
 
   auto var_args_for_cpu = std::make_tuple(var_argument(args)...);
   auto var_args_for_opencl = std::make_tuple(var_argument(args)...);
   auto res_cpu = functor(std::get<Is>(var_args_for_cpu)...);
   auto res_opencl = functor(opencl_argument(std::get<Is>(var_args_for_opencl))...);
-  expect_eq(res_opencl, res_cpu, "Wrong rev return value!");
+  expect_eq(res_opencl, res_cpu, "CPU and OpenCL return values for rev do not match!");
 
   (recursive_sum(res_cpu) + recursive_sum(res_opencl)).grad();
 
   static_cast<void>(std::initializer_list<int>{
       (expect_adj_near(std::get<Is>(var_args_for_opencl),
                        std::get<Is>(var_args_for_cpu),
-                       "Wrong adjoint for argument " TO_STRING(Is) "!"),
+                       "CPU and OpenCL adjoints do not match for argument " TO_STRING(Is) "!"),
        0)...});
 }
 
@@ -131,13 +131,13 @@ void compare_cpu_opencl_prim_rev_impl(Functor functor, std::index_sequence<Is...
 
 /**
  * Tests that given functor calculates same values and adjoints when given
- * arguments on CPU and opencl.
+ * arguments on CPU and OpenCL device.
  *
  * @tparam Functor type of the functor
  * @tparam Args types of the arguments
  * @param fucntor functor to test
  * @param args arguments to test the functor with. These should be just values
- * on CPU (no vars, no arguments on opencl).
+ * in CPU memory (no vars, no arguments on the OpenCL device).
  */
 template <typename Functor, typename... Args>
 void compare_cpu_opencl_prim_rev(Functor functor, Args... args) {


### PR DESCRIPTION
##  Summary
Simplifies tests of GPU GLMs by moving repeated code into a common utility header.

## Tests
Only touches tests.

## Side Effects
None.

## Release notes
Simplified tests of GPU GLMs by moving repeated code into a common utility header.

## Checklist

- [ ] Math issue #(issue number)

- [x] Copyright holder: Tadej Ciglarič

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
