### PR TITLE
Function for constructing integer sequences

### DIFF
--- a/stan/math/prim/fun.hpp
+++ b/stan/math/prim/fun.hpp
@@ -327,6 +327,7 @@
 #include <stan/math/prim/fun/ub_constrain.hpp>
 #include <stan/math/prim/fun/ub_free.hpp>
 #include <stan/math/prim/fun/uniform_simplex.hpp>
+#include <stan/math/prim/fun/unitspaced_array.hpp>
 #include <stan/math/prim/fun/unit_vector_constrain.hpp>
 #include <stan/math/prim/fun/unit_vector_free.hpp>
 #include <stan/math/prim/fun/value_of.hpp>

--- a/stan/math/prim/fun/unitspaced_array.hpp
+++ b/stan/math/prim/fun/unitspaced_array.hpp
@@ -12,7 +12,7 @@ namespace math {
 /**
  * Return an array of integers in an ordered sequence.
  *
- * This produces an array from low to high (included). 
+ * This produces an array from low to high (included).
  *
  * @param low smallest integer
  * @param high largest integer

--- a/stan/math/prim/fun/unitspaced_array.hpp
+++ b/stan/math/prim/fun/unitspaced_array.hpp
@@ -26,10 +26,6 @@ inline std::vector<int> unitspaced_array(int low, int high) {
 
   int K = fabs(high - low + 1);
 
-  if (K == 0) {
-    return {};
-  }
-
   Eigen::VectorXi v = Eigen::VectorXi::LinSpaced(K, low, high);
   return {&v[0], &v[0] + K};
 }

--- a/stan/math/prim/fun/unitspaced_array.hpp
+++ b/stan/math/prim/fun/unitspaced_array.hpp
@@ -1,0 +1,40 @@
+#ifndef STAN_MATH_PRIM_FUN_UNITSPACED_ARRAY_HPP
+#define STAN_MATH_PRIM_FUN_UNITSPACED_ARRAY_HPP
+
+#include <stan/math/prim/err.hpp>
+#include <stan/math/prim/fun/Eigen.hpp>
+#include <stan/math/prim/fun/fabs.hpp>
+#include <vector>
+
+namespace stan {
+namespace math {
+
+/**
+ * Return an array of integers in an ordered sequence.
+ *
+ * This produces an array from low to high (included). 
+ *
+ * @param low smallest integer
+ * @param high largest integer
+ * @return An array of size (high - low + 1) with elements linearly spaced
+ * between low and high.
+ * @throw std::domain_error if high is less than low.
+ */
+inline std::vector<int> unitspaced_array(int low, int high) {
+  static const char* function = "unitspaced_array";
+  check_greater_or_equal(function, "high", high, low);
+
+  int K = fabs(high - low + 1);
+
+  if (K == 0) {
+    return {};
+  }
+
+  Eigen::VectorXi v = Eigen::VectorXi::LinSpaced(K, low, high);
+  return {&v[0], &v[0] + K};
+}
+
+}  // namespace math
+}  // namespace stan
+
+#endif

--- a/test/unit/math/prim/fun/unitspaced_array_test.cpp
+++ b/test/unit/math/prim/fun/unitspaced_array_test.cpp
@@ -1,0 +1,23 @@
+#include <stan/math/prim.hpp>
+#include <test/unit/util.hpp>
+#include <gtest/gtest.h>
+#include <limits>
+#include <vector>
+
+TEST(MathFunctions, unitspaced_array) {
+  using stan::math::unitspaced_array;
+  EXPECT_STD_VECTOR_FLOAT_EQ(unitspaced_array(1, 5),
+                             std::vector<int>({1, 2, 3, 4, 5}));
+  EXPECT_STD_VECTOR_FLOAT_EQ(unitspaced_array(-2, 0),
+                             std::vector<int>({-2, -1, 0}));
+  EXPECT_STD_VECTOR_FLOAT_EQ(unitspaced_array(-5, -5),
+                             std::vector<int>({-5}));
+}
+
+TEST(MathFunctions, unitspaced_array_throw) {
+  using stan::math::unitspaced_array;
+
+  EXPECT_THROW(unitspaced_array(0, -1), std::domain_error);
+  EXPECT_THROW(unitspaced_array(-5, -20), std::domain_error);
+  EXPECT_THROW(unitspaced_array(50, 49), std::domain_error);
+}

--- a/test/unit/math/prim/fun/unitspaced_array_test.cpp
+++ b/test/unit/math/prim/fun/unitspaced_array_test.cpp
@@ -10,8 +10,7 @@ TEST(MathFunctions, unitspaced_array) {
                              std::vector<int>({1, 2, 3, 4, 5}));
   EXPECT_STD_VECTOR_FLOAT_EQ(unitspaced_array(-2, 0),
                              std::vector<int>({-2, -1, 0}));
-  EXPECT_STD_VECTOR_FLOAT_EQ(unitspaced_array(-5, -5),
-                             std::vector<int>({-5}));
+  EXPECT_STD_VECTOR_FLOAT_EQ(unitspaced_array(-5, -5), std::vector<int>({-5}));
 }
 
 TEST(MathFunctions, unitspaced_array_throw) {


### PR DESCRIPTION
## Summary

This PR adds the math function necessary for constructing a sequence of integers given just the lower and upper bounds, so that the convenience function (```1:N```) can be added to the Stan language

## Tests

```prim``` tests added.

## Side Effects

N/A

## Release notes
Added function for creating an ordered integer sequence

## Checklist

- [x] Math issue #2107 

- [x] Copyright holder: Andrew Johnson

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
