### PR TITLE
return an arena_t type from promote_var_matrix_t

### DIFF
--- a/stan/math/prim/meta/promote_scalar_type.hpp
+++ b/stan/math/prim/meta/promote_scalar_type.hpp
@@ -81,7 +81,10 @@ struct promote_scalar_type<T, S,
  * @tparam S input matrix type
  */
 template <typename T, typename S>
-struct promote_scalar_type<T, S, require_t<bool_constant<is_eigen<S>::value && !is_arena_matrix<S>::value>>> {
+struct promote_scalar_type<
+    T, S,
+    require_t<
+        bool_constant<is_eigen<S>::value && !is_arena_matrix<S>::value>>> {
   /**
    * The promoted type.
    */
@@ -98,11 +101,14 @@ template <typename MatrixType>
 class arena_matrix;
 
 template <typename T, typename S>
-struct promote_scalar_type<T, S, require_t<bool_constant<is_eigen<S>::value && is_arena_matrix<S>::value>>> {
+struct promote_scalar_type<
+    T, S,
+    require_t<bool_constant<is_eigen<S>::value && is_arena_matrix<S>::value>>> {
   /**
    * The promoted type.
    */
-  using type = arena_matrix<typename promote_scalar_type<T, typename S::PlainObject>::type>;
+  using type = arena_matrix<
+      typename promote_scalar_type<T, typename S::PlainObject>::type>;
 };
 template <typename T, typename S>
 using promote_scalar_t = typename promote_scalar_type<T, S>::type;

--- a/stan/math/prim/meta/promote_scalar_type.hpp
+++ b/stan/math/prim/meta/promote_scalar_type.hpp
@@ -3,6 +3,7 @@
 
 #include <stan/math/prim/fun/Eigen.hpp>
 #include <stan/math/prim/meta/is_eigen.hpp>
+#include <stan/math/prim/meta/is_arena_matrix.hpp>
 #include <stan/math/prim/meta/is_var.hpp>
 #include <vector>
 
@@ -80,7 +81,7 @@ struct promote_scalar_type<T, S,
  * @tparam S input matrix type
  */
 template <typename T, typename S>
-struct promote_scalar_type<T, S, require_eigen_t<S>> {
+struct promote_scalar_type<T, S, require_t<bool_constant<is_eigen<S>::value && !is_arena_matrix<S>::value>>> {
   /**
    * The promoted type.
    */
@@ -93,6 +94,16 @@ struct promote_scalar_type<T, S, require_eigen_t<S>> {
                    S::RowsAtCompileTime, S::ColsAtCompileTime>>::type;
 };
 
+template <typename MatrixType>
+class arena_matrix;
+
+template <typename T, typename S>
+struct promote_scalar_type<T, S, require_t<bool_constant<is_eigen<S>::value && is_arena_matrix<S>::value>>> {
+  /**
+   * The promoted type.
+   */
+  using type = arena_matrix<typename promote_scalar_type<T, typename S::PlainObject>::type>;
+};
 template <typename T, typename S>
 using promote_scalar_t = typename promote_scalar_type<T, S>::type;
 

--- a/stan/math/prim/meta/ref_type.hpp
+++ b/stan/math/prim/meta/ref_type.hpp
@@ -1,6 +1,7 @@
 #ifndef STAN_MATH_PRIM_META_REF_TYPE_HPP
 #define STAN_MATH_PRIM_META_REF_TYPE_HPP
 
+#include <stan/math/prim/meta/is_arena_matrix.hpp>
 #include <stan/math/prim/meta/is_eigen.hpp>
 #include <stan/math/prim/meta/is_vector.hpp>
 #include <stan/math/prim/meta/plain_type.hpp>
@@ -35,7 +36,7 @@ struct ref_type_if {
 };
 
 template <bool Condition, typename T>
-struct ref_type_if<Condition, T, require_not_eigen_t<T>> {
+struct ref_type_if<Condition, T, require_t<bool_constant<!is_eigen<T>::value || is_arena_matrix<T>::value>>> {
   using type = std::conditional_t<std::is_rvalue_reference<T>::value,
                                   std::remove_reference_t<T>, const T&>;
 };

--- a/stan/math/prim/meta/ref_type.hpp
+++ b/stan/math/prim/meta/ref_type.hpp
@@ -36,7 +36,9 @@ struct ref_type_if {
 };
 
 template <bool Condition, typename T>
-struct ref_type_if<Condition, T, require_t<bool_constant<!is_eigen<T>::value || is_arena_matrix<T>::value>>> {
+struct ref_type_if<Condition, T,
+                   require_t<bool_constant<!is_eigen<T>::value
+                                           || is_arena_matrix<T>::value>>> {
   using type = std::conditional_t<std::is_rvalue_reference<T>::value,
                                   std::remove_reference_t<T>, const T&>;
 };

--- a/stan/math/rev/meta/promote_var_matrix.hpp
+++ b/stan/math/rev/meta/promote_var_matrix.hpp
@@ -21,7 +21,7 @@ using promote_var_matrix_t = std::conditional_t<
     is_any_var_matrix<Types...>::value,
     stan::math::var_value<
         stan::math::promote_scalar_t<double, plain_type_t<ReturnType>>>,
-    stan::math::promote_scalar_t<stan::math::var, plain_type_t<ReturnType>>>;
+    arena_t<stan::math::promote_scalar_t<stan::math::var, plain_type_t<ReturnType>>>>;
 }  // namespace stan
 
 #endif

--- a/test/unit/math/rev/meta/promote_var_matrix_test.cpp
+++ b/test/unit/math/rev/meta/promote_var_matrix_test.cpp
@@ -6,6 +6,7 @@ TEST(MathFunctionsPromoteVarMatrix, VarMatrix) {
   using stan::promote_var_matrix_t;
   using stan::math::var;
   using stan::math::var_value;
+  using stan::math::arena_matrix;
   using std::is_same;
   using var_matrix = var_value<Eigen::MatrixXd>;
   using var_vector = var_value<Eigen::VectorXd>;
@@ -43,10 +44,10 @@ TEST(MathFunctionsPromoteVarMatrix, VarMatrix) {
                        promote_var_matrix_t<Eigen::RowVectorXd, var_vector,
                                             row_vector_var, double>>::value));
 
-  EXPECT_TRUE((is_same<Eigen::Matrix<var, -1, -1>,
+  EXPECT_TRUE((is_same<arena_matrix<Eigen::Matrix<var, -1, -1>>,
                        promote_var_matrix_t<Eigen::MatrixXd, vector_var,
                                             vector_var, double>>::value));
-  EXPECT_TRUE((is_same<Eigen::Matrix<var, 1, -1>,
+  EXPECT_TRUE((is_same<arena_matrix<Eigen::Matrix<var, 1, -1>>,
                        promote_var_matrix_t<Eigen::RowVectorXd, vector_var,
                                             row_vector_var, double>>::value));
 }

--- a/test/unit/math/rev/meta/promote_var_matrix_test.cpp
+++ b/test/unit/math/rev/meta/promote_var_matrix_test.cpp
@@ -4,9 +4,9 @@
 
 TEST(MathFunctionsPromoteVarMatrix, VarMatrix) {
   using stan::promote_var_matrix_t;
+  using stan::math::arena_matrix;
   using stan::math::var;
   using stan::math::var_value;
-  using stan::math::arena_matrix;
   using std::is_same;
   using var_matrix = var_value<Eigen::MatrixXd>;
   using var_vector = var_value<Eigen::VectorXd>;


### PR DESCRIPTION
## Summary

little potential bug fix. We should return an arena matrix from promote_var_matrix_t so people don't have to wrap it's result in an `arena_t<>`

## Tests


## Side Effects


## Release notes

## Checklist

- [ ] Copyright holder: Steve Bronder

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
