### PR TITLE
Add a manually triggerable Github Action for generating release notes

### DIFF
--- a/.github/workflows/release_notes.yml
+++ b/.github/workflows/release_notes.yml
@@ -1,0 +1,21 @@
+name: Release scripts
+on:
+  workflow_dispatch
+
+jobs:
+  release_notes:
+    name: Generate release notes
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Get release notes
+      run: |
+        pip3 install urllib3
+        python3 scripts/release_notes.py > release_notes.txt
+
+    - name: Upload release notes
+      uses: actions/upload-artifact@v2
+      with:
+        name: release_notes.txt
+        path: './release_notes.txt'
+      

--- a/scripts/release_notes.py
+++ b/scripts/release_notes.py
@@ -1,0 +1,43 @@
+#!/usr/bin/python
+
+# Script for retrieving release notes from pull requests merged since the last release
+
+import urllib.request, json
+
+release_url = "https://api.github.com/repos/stan-dev/math/releases/latest"
+releases = json.loads(urllib.request.urlopen(release_url).read().decode())
+last_release_date = releases["published_at"]
+
+prs_url = "https://api.github.com/repos/stan-dev/math/pulls?state=closed&sort=created&per_page=100&sort=asc&page="
+
+
+num_of_prs = 0
+prs_on_page = 1
+current_page = 1
+# cycle through the pages until you hit a page with no PRs
+while prs_on_page > 0:
+    tmp_url = prs_url + str(current_page)
+    with urllib.request.urlopen(tmp_url) as url:
+        prs_info = json.loads(url.read().decode())
+        prs_on_page = len(prs_info)
+        for pr in prs_info:
+            # check if PR was merged
+            if pr["merged_at"]:
+                # if merged check date
+                if pr["merged_at"] > last_release_date:
+                    num_of_prs = num_of_prs + 1
+                    body = pr["body"]
+                    parsing_release_notes = False
+                    for line in body.split("\r\n"):
+                        if parsing_release_notes:
+                            if line.find("##") >= 0:
+                                parsing_release_notes = False
+                        if parsing_release_notes:
+                            line = line.strip()
+                            if len(line) > 0:
+                                print(" - " + line + "(#" + str(pr["number"]) + ")")
+                        if line.find("Release notes") >= 0:
+                            parsing_release_notes = True
+    current_page = current_page + 1
+
+print("\nNumber of merged PRs:" + str(num_of_prs))


### PR DESCRIPTION
## Summary

This PR adds a manually triggerable Github Action job to generate release notes. 

An example of how you can start it can be seen here: https://github.com/bstatcomp/math/actions?query=workflow%3A%22Release+notes%22

The result of the job can be seen here: https://github.com/bstatcomp/math/actions/runs/284867780 

This script lived on my computer, but I think its better if it lives in the repository so anyone can run it without actually having to do anythin locally.

## Tests
/
## Side Effects
/
## Release notes

## Checklist

- [x] Copyright holder: Rok Češnovar, Univ. of Ljubljana

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested