### PR TITLE
[Fix] add to_arena() when only the first argument is a matrix<var> for elt_multiply

### DIFF
--- a/stan/math/rev/fun/elt_multiply.hpp
+++ b/stan/math/rev/fun/elt_multiply.hpp
@@ -67,7 +67,7 @@ auto elt_multiply(const Mat1& m1, const Mat2& m2) {
     return ret_type(ret);
   } else if (!is_constant<Mat2>::value) {
     arena_t<Mat2> arena_m2 = m2_ref;
-    auto arena_m1 = value_of(m1_ref);
+    auto arena_m1 = to_arena(value_of(m1_ref));
     arena_t<ret_type> ret(arena_m1.cwiseProduct(value_of(arena_m2)));
     reverse_pass_callback([ret, arena_m2, arena_m1]() mutable {
       using var_m2 = arena_t<promote_scalar_t<var, Mat2>>;


### PR DESCRIPTION

## Summary

Just a quick bug fix, I forgot to wrap the non-var matrix in `to_arena()` in `elt_multiply`

## Tests

No new tests, would there be some way to auto catch these sort of things? 

## Side Effects


## Release notes


## Checklist

- [ ] Math issue #(issue number)

- [x] Copyright holder: Steve Bronder

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
