### PR TITLE
Fix/frechet perf

### DIFF
--- a/stan/math/prim/prob/frechet_cdf.hpp
+++ b/stan/math/prim/prob/frechet_cdf.hpp
@@ -75,7 +75,7 @@ return_type_t<T_y, T_shape, T_scale> frechet_cdf(const T_y& y,
     ops_partials.edge1_.partials_ = cdf * pow_n * alpha_val / y_val;
   }
   if (!is_constant_all<T_shape>::value) {
-    ops_partials.edge2_.partials_ = cdf * pow_n * (log(y_val) - log(sigma_val));
+    ops_partials.edge2_.partials_ = cdf * pow_n * log(y_val / sigma_val);
   }
   if (!is_constant_all<T_scale>::value) {
     ops_partials.edge3_.partials_ = -cdf * pow_n * alpha_val / sigma_val;

--- a/stan/math/prim/prob/frechet_cdf.hpp
+++ b/stan/math/prim/prob/frechet_cdf.hpp
@@ -36,49 +36,57 @@ return_type_t<T_y, T_shape, T_scale> frechet_cdf(const T_y& y,
   T_alpha_ref alpha_ref = alpha;
   T_sigma_ref sigma_ref = sigma;
 
-  const auto& y_col = as_column_vector_or_scalar(y_ref);
-  const auto& alpha_col = as_column_vector_or_scalar(alpha_ref);
-  const auto& sigma_col = as_column_vector_or_scalar(sigma_ref);
+  check_positive(function, "Random variable", y_ref);
+  check_positive_finite(function, "Shape parameter", alpha_ref);
+  check_positive_finite(function, "Scale parameter", sigma_ref);
 
-  const auto& y_arr = as_array_or_scalar(y_col);
-  const auto& alpha_arr = as_array_or_scalar(alpha_col);
-  const auto& sigma_arr = as_array_or_scalar(sigma_col);
-
-  ref_type_t<decltype(value_of(y_arr))> y_val = value_of(y_arr);
-  ref_type_t<decltype(value_of(alpha_arr))> alpha_val = value_of(alpha_arr);
-  ref_type_t<decltype(value_of(sigma_arr))> sigma_val = value_of(sigma_arr);
-
-  check_positive(function, "Random variable", y_val);
-  check_positive_finite(function, "Shape parameter", alpha_val);
-  check_positive_finite(function, "Scale parameter", sigma_val);
-
-  if (size_zero(y, alpha, sigma)) {
+  if (size_zero(y_ref, alpha_ref, sigma_ref)) {
     return 1.0;
   }
 
-  operands_and_partials<T_y_ref, T_alpha_ref, T_sigma_ref> ops_partials(
-      y_ref, alpha_ref, sigma_ref);
-
-  const auto& pow_n = to_ref_if<!is_constant_all<T_y, T_shape, T_scale>::value>(
-      pow(sigma_val / y_val, alpha_val));
-
-  const auto& cdf_n = exp(-pow_n);
   T_partials_return cdf(1.0);
-  if (is_vector<T_y>::value || is_vector<T_shape>::value
-      || is_vector<T_scale>::value) {
-    cdf = forward_as<T_partials_array>(cdf_n).prod();
-  } else {
-    cdf = forward_as<T_partials_return>(cdf_n);
+  operands_and_partials<T_y_ref, T_alpha_ref, T_sigma_ref>
+    ops_partials(y_ref, alpha_ref, sigma_ref);
+
+  scalar_seq_view<T_y> y_vec(y_ref);
+  scalar_seq_view<T_scale> sigma_vec(sigma_ref);
+  scalar_seq_view<T_shape> alpha_vec(alpha_ref);
+  size_t N = max_size(y_ref, sigma_ref, alpha_ref);
+
+  for (size_t n = 0; n < N; n++) {
+    const T_partials_return y_dbl = value_of(y_vec[n]);
+    const T_partials_return sigma_dbl = value_of(sigma_vec[n]);
+    const T_partials_return alpha_dbl = value_of(alpha_vec[n]);
+    const T_partials_return pow_n = pow(sigma_dbl / y_dbl, alpha_dbl);
+    const T_partials_return cdf_n = exp(-pow_n);
+
+    cdf *= cdf_n;
+
+    if (!is_constant_all<T_y>::value) {
+      ops_partials.edge1_.partials_[n] += pow_n * alpha_dbl / y_dbl;
+    }
+    if (!is_constant_all<T_shape>::value) {
+      ops_partials.edge2_.partials_[n] += pow_n * log(y_dbl / sigma_dbl);
+    }
+    if (!is_constant_all<T_scale>::value) {
+      ops_partials.edge3_.partials_[n] -= pow_n * alpha_dbl / sigma_dbl;
+    }
   }
 
   if (!is_constant_all<T_y>::value) {
-    ops_partials.edge1_.partials_ = cdf * pow_n * alpha_val / y_val;
+    for (size_t n = 0; n < stan::math::size(y); ++n) {
+      ops_partials.edge1_.partials_[n] *= cdf;
+    }
   }
   if (!is_constant_all<T_shape>::value) {
-    ops_partials.edge2_.partials_ = cdf * pow_n * log(y_val / sigma_val);
+    for (size_t n = 0; n < stan::math::size(alpha); ++n) {
+      ops_partials.edge2_.partials_[n] *= cdf;
+    }
   }
   if (!is_constant_all<T_scale>::value) {
-    ops_partials.edge3_.partials_ = -cdf * pow_n * alpha_val / sigma_val;
+    for (size_t n = 0; n < stan::math::size(sigma); ++n) {
+      ops_partials.edge3_.partials_[n] *= cdf;
+    }
   }
   return ops_partials.build(cdf);
 }

--- a/stan/math/prim/prob/frechet_cdf.hpp
+++ b/stan/math/prim/prob/frechet_cdf.hpp
@@ -45,8 +45,8 @@ return_type_t<T_y, T_shape, T_scale> frechet_cdf(const T_y& y,
   }
 
   T_partials_return cdf(1.0);
-  operands_and_partials<T_y_ref, T_alpha_ref, T_sigma_ref>
-    ops_partials(y_ref, alpha_ref, sigma_ref);
+  operands_and_partials<T_y_ref, T_alpha_ref, T_sigma_ref> ops_partials(
+      y_ref, alpha_ref, sigma_ref);
 
   scalar_seq_view<T_y> y_vec(y_ref);
   scalar_seq_view<T_scale> sigma_vec(sigma_ref);

--- a/stan/math/prim/prob/frechet_lccdf.hpp
+++ b/stan/math/prim/prob/frechet_lccdf.hpp
@@ -43,8 +43,8 @@ return_type_t<T_y, T_shape, T_scale> frechet_lccdf(const T_y& y,
   }
 
   T_partials_return ccdf_log(0.0);
-  operands_and_partials<T_y_ref, T_alpha_ref, T_sigma_ref>
-    ops_partials(y_ref, alpha_ref, sigma_ref);
+  operands_and_partials<T_y_ref, T_alpha_ref, T_sigma_ref> ops_partials(
+      y_ref, alpha_ref, sigma_ref);
 
   scalar_seq_view<T_y> y_vec(y_ref);
   scalar_seq_view<T_scale> sigma_vec(sigma_ref);

--- a/stan/math/prim/prob/frechet_lccdf.hpp
+++ b/stan/math/prim/prob/frechet_lccdf.hpp
@@ -34,49 +34,41 @@ return_type_t<T_y, T_shape, T_scale> frechet_lccdf(const T_y& y,
   T_alpha_ref alpha_ref = alpha;
   T_sigma_ref sigma_ref = sigma;
   using std::pow;
+  check_positive(function, "Random variable", y_ref);
+  check_positive_finite(function, "Shape parameter", alpha_ref);
+  check_positive_finite(function, "Scale parameter", sigma_ref);
 
-  const auto& y_col = as_column_vector_or_scalar(y_ref);
-  const auto& alpha_col = as_column_vector_or_scalar(alpha_ref);
-  const auto& sigma_col = as_column_vector_or_scalar(sigma_ref);
-
-  const auto& y_arr = as_array_or_scalar(y_col);
-  const auto& alpha_arr = as_array_or_scalar(alpha_col);
-  const auto& sigma_arr = as_array_or_scalar(sigma_col);
-
-  ref_type_t<decltype(value_of(y_arr))> y_val = value_of(y_arr);
-  ref_type_t<decltype(value_of(alpha_arr))> alpha_val = value_of(alpha_arr);
-  ref_type_t<decltype(value_of(sigma_arr))> sigma_val = value_of(sigma_arr);
-
-  check_positive(function, "Random variable", y_val);
-  check_positive_finite(function, "Shape parameter", alpha_val);
-  check_positive_finite(function, "Scale parameter", sigma_val);
-
-  if (size_zero(y, alpha, sigma)) {
+  if (size_zero(y_ref, alpha_ref, sigma_ref)) {
     return 0;
   }
 
-  operands_and_partials<T_y_ref, T_alpha_ref, T_sigma_ref> ops_partials(
-      y_ref, alpha_ref, sigma_ref);
+  T_partials_return ccdf_log(0.0);
+  operands_and_partials<T_y_ref, T_alpha_ref, T_sigma_ref>
+    ops_partials(y_ref, alpha_ref, sigma_ref);
 
-  const auto& pow_n = to_ref_if<!is_constant_all<T_y, T_shape, T_scale>::value>(
-      pow(sigma_val / y_val, alpha_val));
-  const auto& exp_n
-      = to_ref_if<!is_constant_all<T_y, T_shape, T_scale>::value>(exp(-pow_n));
+  scalar_seq_view<T_y> y_vec(y_ref);
+  scalar_seq_view<T_scale> sigma_vec(sigma_ref);
+  scalar_seq_view<T_shape> alpha_vec(alpha_ref);
+  size_t N = max_size(y_ref, sigma_ref, alpha_ref);
 
-  T_partials_return ccdf_log = sum(log1m(exp_n));
-  if (!is_constant_all<T_y, T_shape, T_scale>::value) {
-    const auto& rep_deriv = to_ref_if<!is_constant_all<T_y>::value
-                                          + !is_constant_all<T_shape>::value
-                                          + !is_constant_all<T_scale>::value
-                                      >= 2>(pow_n / (1.0 / exp_n - 1));
+  for (size_t n = 0; n < N; n++) {
+    const T_partials_return y_dbl = value_of(y_vec[n]);
+    const T_partials_return sigma_dbl = value_of(sigma_vec[n]);
+    const T_partials_return alpha_dbl = value_of(alpha_vec[n]);
+    const T_partials_return pow_n = pow(sigma_dbl / y_dbl, alpha_dbl);
+    const T_partials_return exp_n = exp(-pow_n);
+
+    ccdf_log += log1m(exp_n);
+
+    const T_partials_return rep_deriv = pow_n / (1.0 / exp_n - 1);
     if (!is_constant_all<T_y>::value) {
-      ops_partials.edge1_.partials_ = -alpha_val / y_val * rep_deriv;
+      ops_partials.edge1_.partials_[n] -= alpha_dbl / y_dbl * rep_deriv;
     }
     if (!is_constant_all<T_shape>::value) {
-      ops_partials.edge2_.partials_ = (log(sigma_val / y_val)) * rep_deriv;
+      ops_partials.edge2_.partials_[n] -= log(y_dbl / sigma_dbl) * rep_deriv;
     }
     if (!is_constant_all<T_scale>::value) {
-      ops_partials.edge3_.partials_ = alpha_val / sigma_val * rep_deriv;
+      ops_partials.edge3_.partials_[n] += alpha_dbl / sigma_dbl * rep_deriv;
     }
   }
   return ops_partials.build(ccdf_log);

--- a/stan/math/prim/prob/frechet_lccdf.hpp
+++ b/stan/math/prim/prob/frechet_lccdf.hpp
@@ -73,7 +73,7 @@ return_type_t<T_y, T_shape, T_scale> frechet_lccdf(const T_y& y,
       ops_partials.edge1_.partials_ = -alpha_val / y_val * rep_deriv;
     }
     if (!is_constant_all<T_shape>::value) {
-      ops_partials.edge2_.partials_ = (log(sigma_val) - log(y_val)) * rep_deriv;
+      ops_partials.edge2_.partials_ = (log(sigma_val / y_val)) * rep_deriv;
     }
     if (!is_constant_all<T_scale>::value) {
       ops_partials.edge3_.partials_ = alpha_val / sigma_val * rep_deriv;

--- a/stan/math/prim/prob/frechet_lcdf.hpp
+++ b/stan/math/prim/prob/frechet_lcdf.hpp
@@ -32,42 +32,41 @@ return_type_t<T_y, T_shape, T_scale> frechet_lcdf(const T_y& y,
   T_alpha_ref alpha_ref = alpha;
   T_sigma_ref sigma_ref = sigma;
   using std::pow;
+  using std::exp;
 
-  const auto& y_col = as_column_vector_or_scalar(y_ref);
-  const auto& alpha_col = as_column_vector_or_scalar(alpha_ref);
-  const auto& sigma_col = as_column_vector_or_scalar(sigma_ref);
+  check_positive(function, "Random variable", y_ref);
+  check_positive_finite(function, "Shape parameter", alpha_ref);
+  check_positive_finite(function, "Scale parameter", sigma_ref);
 
-  const auto& y_arr = as_array_or_scalar(y_col);
-  const auto& alpha_arr = as_array_or_scalar(alpha_col);
-  const auto& sigma_arr = as_array_or_scalar(sigma_col);
-
-  ref_type_t<decltype(value_of(y_arr))> y_val = value_of(y_arr);
-  ref_type_t<decltype(value_of(alpha_arr))> alpha_val = value_of(alpha_arr);
-  ref_type_t<decltype(value_of(sigma_arr))> sigma_val = value_of(sigma_arr);
-
-  check_positive(function, "Random variable", y_val);
-  check_positive_finite(function, "Shape parameter", alpha_val);
-  check_positive_finite(function, "Scale parameter", sigma_val);
-
-  if (size_zero(y, alpha, sigma)) {
+  if (size_zero(y_ref, alpha_ref, sigma_ref)) {
     return 0.0;
   }
 
-  operands_and_partials<T_y_ref, T_alpha_ref, T_sigma_ref> ops_partials(
-      y_ref, alpha_ref, sigma_ref);
+  T_partials_return cdf_log(0.0);
+  operands_and_partials<T_y_ref, T_alpha_ref, T_sigma_ref>
+    ops_partials(y_ref, alpha_ref, sigma_ref);
 
-  const auto& pow_n = to_ref_if<!is_constant_all<T_y, T_shape, T_scale>::value>(
-      pow(sigma_val / y_val, alpha_val));
-  T_partials_return cdf_log = -sum(pow_n);
+  scalar_seq_view<T_y> y_vec(y_ref);
+  scalar_seq_view<T_scale> sigma_vec(sigma_ref);
+  scalar_seq_view<T_shape> alpha_vec(alpha_ref);
+  size_t N = max_size(y_ref, sigma_ref, alpha_ref);
+  for (size_t n = 0; n < N; n++) {
+    const T_partials_return y_dbl = value_of(y_vec[n]);
+    const T_partials_return sigma_dbl = value_of(sigma_vec[n]);
+    const T_partials_return alpha_dbl = value_of(alpha_vec[n]);
+    const T_partials_return pow_n = pow(sigma_dbl / y_dbl, alpha_dbl);
 
-  if (!is_constant_all<T_y>::value) {
-    ops_partials.edge1_.partials_ = pow_n * alpha_val / y_val;
-  }
-  if (!is_constant_all<T_shape>::value) {
-    ops_partials.edge2_.partials_ = pow_n * log(y_val / sigma_val);
-  }
-  if (!is_constant_all<T_scale>::value) {
-    ops_partials.edge3_.partials_ = -pow_n * alpha_val / sigma_val;
+    cdf_log -= pow_n;
+
+    if (!is_constant_all<T_y>::value) {
+      ops_partials.edge1_.partials_[n] += pow_n * alpha_dbl / y_dbl;
+    }
+    if (!is_constant_all<T_shape>::value) {
+      ops_partials.edge2_.partials_[n] += pow_n * log(y_dbl / sigma_dbl);
+    }
+    if (!is_constant_all<T_scale>::value) {
+      ops_partials.edge3_.partials_[n] -= pow_n * alpha_dbl / sigma_dbl;
+    }
   }
   return ops_partials.build(cdf_log);
 }

--- a/stan/math/prim/prob/frechet_lcdf.hpp
+++ b/stan/math/prim/prob/frechet_lcdf.hpp
@@ -31,8 +31,8 @@ return_type_t<T_y, T_shape, T_scale> frechet_lcdf(const T_y& y,
   T_y_ref y_ref = y;
   T_alpha_ref alpha_ref = alpha;
   T_sigma_ref sigma_ref = sigma;
-  using std::pow;
   using std::exp;
+  using std::pow;
 
   check_positive(function, "Random variable", y_ref);
   check_positive_finite(function, "Shape parameter", alpha_ref);
@@ -43,8 +43,8 @@ return_type_t<T_y, T_shape, T_scale> frechet_lcdf(const T_y& y,
   }
 
   T_partials_return cdf_log(0.0);
-  operands_and_partials<T_y_ref, T_alpha_ref, T_sigma_ref>
-    ops_partials(y_ref, alpha_ref, sigma_ref);
+  operands_and_partials<T_y_ref, T_alpha_ref, T_sigma_ref> ops_partials(
+      y_ref, alpha_ref, sigma_ref);
 
   scalar_seq_view<T_y> y_vec(y_ref);
   scalar_seq_view<T_scale> sigma_vec(sigma_ref);

--- a/stan/math/prim/prob/frechet_lcdf.hpp
+++ b/stan/math/prim/prob/frechet_lcdf.hpp
@@ -64,7 +64,7 @@ return_type_t<T_y, T_shape, T_scale> frechet_lcdf(const T_y& y,
     ops_partials.edge1_.partials_ = pow_n * alpha_val / y_val;
   }
   if (!is_constant_all<T_shape>::value) {
-    ops_partials.edge2_.partials_ = pow_n * (log(y_val) - log(sigma_val));
+    ops_partials.edge2_.partials_ = pow_n * log(y_val / sigma_val);
   }
   if (!is_constant_all<T_scale>::value) {
     ops_partials.edge3_.partials_ = -pow_n * alpha_val / sigma_val;


### PR DESCRIPTION
## Summary

This reverts the recent Frechet cdf, lcdf, and lccdf rewrites, but keeps them working with expressions

## Release notes

Reverted Frechet generalization

## Checklist

- [x] Math issue #2135 

- [x] Copyright holder: Columbia University

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
