### PR TITLE
Made it so that C0 in gaussian_dlm_obs_lpdf/rng can be positive semidefinite

### DIFF
--- a/stan/math/prim/prob/gaussian_dlm_obs_lpdf.hpp
+++ b/stan/math/prim/prob/gaussian_dlm_obs_lpdf.hpp
@@ -99,7 +99,7 @@ inline return_type_t<T_y, T_F, T_G, T_V, T_W, T_m0, T_C0> gaussian_dlm_obs_lpdf(
   check_finite(function, "W", W_ref);
   check_pos_semidefinite(function, "W", W_ref);
   check_finite(function, "m0", m0_ref);
-  check_pos_definite(function, "C0", C0_ref);
+  check_pos_semidefinite(function, "C0", C0_ref);
   check_finite(function, "C0", C0_ref);
 
   if (size_zero(y)) {
@@ -136,6 +136,8 @@ inline return_type_t<T_y, T_F, T_G, T_V, T_W, T_m0, T_C0> gaussian_dlm_obs_lpdf(
       f = multiply(transpose(F_ref), a);
       // Q_t = F'_t R_t F_t + V_t
       Q = quad_form_sym(R, F_ref) + V_ref;
+      if(i == 0)
+	check_pos_definite(function, "Q", Q);
       Q_inv = inverse_spd(Q);
       // // filtered state
       // e_t = y_t - f_t
@@ -224,7 +226,7 @@ inline return_type_t<T_y, T_F, T_G, T_V, T_W, T_m0, T_C0> gaussian_dlm_obs_lpdf(
   // TODO(anyone): support infinite W
   check_finite(function, "W", W_ref);
   check_finite(function, "m0", m0_ref);
-  check_pos_definite(function, "C0", C0_ref);
+  check_pos_semidefinite(function, "C0", C0_ref);
   check_finite(function, "C0", C0_ref);
 
   if (y.cols() == 0 || y.rows() == 0) {
@@ -261,6 +263,8 @@ inline return_type_t<T_y, T_F, T_G, T_V, T_W, T_m0, T_C0> gaussian_dlm_obs_lpdf(
         // f_{t, i} = F_{t, i}' m_{t, i-1}
         f = dot_product(Fj, m);
         Q = trace_quad_form(C, Fj) + V_ref.coeff(j);
+	if(i == 0)
+	  check_positive(function, "Q0", Q);
         Q_inv = 1.0 / Q;
         // filtered observation
         // e_{t, i} = y_{t, i} - f_{t, i}

--- a/stan/math/prim/prob/gaussian_dlm_obs_lpdf.hpp
+++ b/stan/math/prim/prob/gaussian_dlm_obs_lpdf.hpp
@@ -136,8 +136,6 @@ inline return_type_t<T_y, T_F, T_G, T_V, T_W, T_m0, T_C0> gaussian_dlm_obs_lpdf(
       f = multiply(transpose(F_ref), a);
       // Q_t = F'_t R_t F_t + V_t
       Q = quad_form_sym(R, F_ref) + V_ref;
-      if(i == 0)
-	check_pos_definite(function, "Q", Q);
       Q_inv = inverse_spd(Q);
       // // filtered state
       // e_t = y_t - f_t

--- a/test/unit/math/prim/prob/gaussian_dlm_obs_rng_test.cpp
+++ b/test/unit/math/prim/prob/gaussian_dlm_obs_rng_test.cpp
@@ -283,11 +283,10 @@ TEST_F(ProbDistributionsGaussianDLMInputsRng, PoliciesC0) {
                std::invalid_argument);
   EXPECT_THROW(gaussian_dlm_obs_rng(FF, GG, V_vec, W, m0, C0_notsq, T, rng),
                std::invalid_argument);
-  // not positive definite.
+  // positive semi-definite okay.
   MatrixXd C0_psd = MatrixXd::Zero(2, 2);
   C0_psd(0, 0) = 1.0;
-  EXPECT_THROW(gaussian_dlm_obs_rng(FF, GG, V, W, m0, C0_psd, T, rng),
-               std::domain_error);
+  EXPECT_NO_THROW(gaussian_dlm_obs_rng(FF, GG, V, W, m0, C0_psd, T, rng));
 }
 
 TEST_F(ProbDistributionsGaussianDLMInputsRng, PoliciesT) {

--- a/test/unit/math/prim/prob/gaussian_dlm_obs_test.cpp
+++ b/test/unit/math/prim/prob/gaussian_dlm_obs_test.cpp
@@ -413,4 +413,26 @@ TEST_F(ProbDistributionsGaussianDLMInputs, PoliciesC0) {
                std::invalid_argument);
   EXPECT_THROW(gaussian_dlm_obs_log(y, FF, GG, V_vec, W, m0, C0_notsq),
                std::invalid_argument);
+  // positive semi-definite is okay
+  Matrix<double, Dynamic, Dynamic> C0_psd = MatrixXd::Zero(2, 2);
+  C0_psd(0, 0) = 1.0;
+  EXPECT_NO_THROW(gaussian_dlm_obs_log(y, FF, GG, V, W, m0, C0_psd));
+  EXPECT_NO_THROW(gaussian_dlm_obs_log(y, FF, GG, V_vec, W, m0, C0_psd));
+}
+
+TEST_F(ProbDistributionsGaussianDLMInputs, PoliciesQ0) {
+  using Eigen::Dynamic;
+  using Eigen::Matrix;
+  using Eigen::MatrixXd;
+  using stan::math::gaussian_dlm_obs_log;
+
+  // Not positive definite
+  Matrix<double, Dynamic, Dynamic> W_0 = W * 0;
+  Matrix<double, Dynamic, Dynamic> V_0 = V * 0;
+  Matrix<double, Dynamic, 1> V_vec_0 = V_vec * 0;
+  Matrix<double, Dynamic, Dynamic> C0_0 = C0 * 0;
+  EXPECT_THROW(gaussian_dlm_obs_log(y, FF, GG, V_0, W_0, m0, C0_0),
+               std::domain_error);
+  EXPECT_THROW(gaussian_dlm_obs_log(y, FF, GG, V_vec_0, W_0, m0, C0_0),
+               std::domain_error);
 }


### PR DESCRIPTION
This is a follow up to Issue #2017 

## Summary

I changed it for both gaussian_dlm_obs_lpdf/gaussian_dlm_obs_rng

The covariance for the output is a matrix Q computed from input matrices F, G, C, W, V

Q = F^T G C G^T F + F^T W F + V

The easy way to guarantee Q is positive definite is to guarantee one of C, W, or V are positive definite. Previously, W and V could be positive semi-definite but C had to be positive definite.

I relaxed this to C being positive semi-definite, but check the first time Q is computed that it is positive definite.

## Release notes

C0 in gaussian_dlm_obs_lpdf and gaussian_dlp_obs_rng can now be positive semidefinite

## Checklist

- [x] Math issue #2017

- [x] Copyright holder: Columbia University

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
