### PR TITLE
Fixed OpenCL multiple translation units

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -244,6 +244,7 @@ pipeline {
                         sh "echo OPENCL_DEVICE_ID=${OPENCL_DEVICE_ID}>> make/local"
                         sh "make -j${env.PARALLEL} test-headers"
                         runTests("test/unit/math/opencl")
+						runTests("test/unit/multiple_translation_units_test.cpp")
                         runTests("test/unit/math/prim/fun/gp_exp_quad_cov_test")
                         runTests("test/unit/math/prim/fun/mdivide_left_tri_test")
                         runTests("test/unit/math/prim/fun/mdivide_right_tri_test")

--- a/stan/math/opencl/opencl_context.hpp
+++ b/stan/math/opencl/opencl_context.hpp
@@ -194,7 +194,6 @@ class opencl_context_base {
     int tri_inverse_size_worth_transfer = 100;
   } tuning_opts_;
 
-
  protected:
   static opencl_context_base& getInstance() {
     static opencl_context_base instance_;

--- a/stan/math/opencl/opencl_context.hpp
+++ b/stan/math/opencl/opencl_context.hpp
@@ -194,17 +194,17 @@ class opencl_context_base {
     int tri_inverse_size_worth_transfer = 100;
   } tuning_opts_;
 
- private:
-  static opencl_context_base instance_;
 
  protected:
-  static opencl_context_base& getInstance() { return instance_; }
+  static opencl_context_base& getInstance() {
+    static opencl_context_base instance_;
+    return instance_;
+  }
 
   static void select_device(int platform_id, int device_id) {
-    instance_ = opencl_context_base(platform_id, device_id);
+    getInstance() = opencl_context_base(platform_id, device_id);
   }
 };
-opencl_context_base opencl_context_base::instance_;
 
 /** \ingroup opencl_context_group
  * The API to access the methods and values in opencl_context_base


### PR DESCRIPTION
## Summary

Fixes linking failure when compiling math in multiple translation units (introduced in #2067).

## Tests

Also runs multiple_translation_units.cpp test (which fails for this bug) with `STAN_OPENCL` defined.

## Side Effects
None.

## Checklist

- [ ] Math issue #(issue number)

- [x] Copyright holder: Tadej Ciglarič

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
