### PR TITLE
Backport assign to Stan Math

### DIFF
--- a/stan/math/prim/fun.hpp
+++ b/stan/math/prim/fun.hpp
@@ -126,6 +126,7 @@
 #include <stan/math/prim/fun/if_else.hpp>
 #include <stan/math/prim/fun/imag.hpp>
 #include <stan/math/prim/fun/inc_beta.hpp>
+#include <stan/math/prim/fun/index_list.hpp>
 #include <stan/math/prim/fun/initialize.hpp>
 #include <stan/math/prim/fun/int_step.hpp>
 #include <stan/math/prim/fun/inv.hpp>
@@ -274,6 +275,8 @@
 #include <stan/math/prim/fun/rows.hpp>
 #include <stan/math/prim/fun/rows_dot_product.hpp>
 #include <stan/math/prim/fun/rows_dot_self.hpp>
+#include <stan/math/prim/fun/rvalue_at.hpp>
+#include <stan/math/prim/fun/rvalue_index_size.hpp>
 #include <stan/math/prim/fun/scalbn.hpp>
 #include <stan/math/prim/fun/scale_matrix_exp_multiply.hpp>
 #include <stan/math/prim/fun/scaled_add.hpp>

--- a/stan/math/prim/fun/assign.hpp
+++ b/stan/math/prim/fun/assign.hpp
@@ -415,7 +415,7 @@ inline void assign(Mat1&& x, const cons_index_list<Idx, nil_index_list>& idxs,
  * @tparam Mat2 Eigen type with dynamic rows and columns.
  * @param[in] x Matrix variable to be assigned.
  * @param[in] idxs An index list containing two min_max indices
- * @param[in] x Matrix variable to assign from.
+ * @param[in] y Matrix variable to assign from.
  * @param[in] name Name of variable (default "ANON").
  * @param[in] depth Indexing depth (default 0).
  * @throw std::out_of_range If any of the indices are out of bounds.

--- a/stan/math/prim/fun/assign.hpp
+++ b/stan/math/prim/fun/assign.hpp
@@ -1,8 +1,7 @@
-#ifndef STAN_MODEL_INDEXING_LVALUE_HPP
-#define STAN_MODEL_INDEXING_LVALUE_HPP
+#ifndef STAN_MATH_PRIM_FUN_ASSIGN_HPP
+#define STAN_MATH_PRIM_FUN_ASSIGN_HPP
 
-#include <stan/math/prim.hpp>
-#include <stan/math/prim/fun/indexing/index.hpp>
+#include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/fun/index_list.hpp>
 #include <stan/math/prim/fun/rvalue_at.hpp>
 #include <stan/math/prim/fun/rvalue_index_size.hpp>
@@ -11,7 +10,7 @@
 
 namespace stan {
 
-namespace model {
+namespace math {
 
 /**
  * Indexing Notes:
@@ -22,8 +21,8 @@ namespace model {
  * index_min - index from min:N
  * index_max - index from 1:max
  * index_min_max - index from min:max
+ * nil_index_list - no-op
  * The order of the overloads are
- * nil_index_list / no-op
  * vector:
  *  - full index overloads
  *  - general index overload
@@ -50,9 +49,7 @@ namespace model {
  * @param[in] name Name of lvalue variable (default "ANON"); ignored
  * @param[in] depth Indexing depth (default 0; ignored
  */
-template <
-    typename T, typename U,
-    require_t<std::is_assignable<std::decay_t<T>&, std::decay_t<U>>>* = nullptr>
+template <typename T, typename U, require_assignable_t<T&, U>* = nullptr>
 inline void assign(T&& x, const nil_index_list& /* idxs */, U&& y,
                    const char* name = "ANON", int depth = 0) {
   x = std::forward<U>(y);
@@ -78,7 +75,7 @@ template <typename Vec1, typename U, require_eigen_vector_t<Vec1>* = nullptr,
 inline void assign(Vec1&& x,
                    const cons_index_list<index_uni, nil_index_list>& idxs,
                    const U& y, const char* name = "ANON", int depth = 0) {
-  math::check_range("vector[uni] assign range", name, x.size(), idxs.head_.n_);
+  check_range("vector[uni] assign range", name, x.size(), idxs.head_.n_);
   x.coeffRef(idxs.head_.n_ - 1) = y;
 }
 
@@ -102,8 +99,8 @@ template <typename Vec1, typename Vec2,
 inline void assign(Vec1&& x,
                    const cons_index_list<index_uni, nil_index_list>& idxs,
                    const Vec2& y, const char* name = "ANON", int depth = 0) {
-  math::check_range("vector[uni] assign range", name, x.size(), idxs.head_.n_);
-  math::check_range("vector[uni] assign range", name, y.size(), idxs.head_.n_);
+  check_range("vector[uni] assign range", name, x.size(), idxs.head_.n_);
+  check_range("vector[uni] assign range", name, y.size(), idxs.head_.n_);
   x.coeffRef(idxs.head_.n_ - 1) = y.coeffRef(idxs.head_.n_ - 1);
 }
 
@@ -129,13 +126,12 @@ template <typename Vec1, typename Vec2,
 inline void assign(Vec1&& x,
                    const cons_index_list<index_multi, nil_index_list>& idxs,
                    const Vec2& y, const char* name = "ANON", int depth = 0) {
-  const auto& y_ref = stan::math::to_ref(y);
-  math::check_size_match("vector[multi] assign sizes", "lhs",
-                         idxs.head_.ns_.size(), name, y_ref.size());
+  const auto& y_ref = to_ref(y);
+  check_size_match("vector[multi] assign sizes", "lhs", idxs.head_.ns_.size(),
+                   name, y_ref.size());
   const auto x_size = x.size();
   for (int n = 0; n < y_ref.size(); ++n) {
-    math::check_range("vector[multi] assign range", name, x_size,
-                      idxs.head_.ns_[n]);
+    check_range("vector[multi] assign range", name, x_size, idxs.head_.ns_[n]);
     x.coeffRef(idxs.head_.ns_[n] - 1) = y_ref.coeffRef(n);
   }
 }
@@ -162,22 +158,20 @@ template <typename Vec1, typename Vec2,
 inline void assign(Vec1&& x,
                    const cons_index_list<index_min_max, nil_index_list>& idxs,
                    const Vec2& y, const char* name = "ANON", int depth = 0) {
-  math::check_range("vector[min_max] min assign", name, x.size(),
-                    idxs.head_.min_);
-  math::check_range("vector[min_max] max assign", name, x.size(),
-                    idxs.head_.max_);
-  if (idxs.head_.positive_idx_) {
+  check_range("vector[min_max] min assign", name, x.size(), idxs.head_.min_);
+  check_range("vector[min_max] max assign", name, x.size(), idxs.head_.max_);
+  if (idxs.head_.is_positive_idx()) {
     const auto slice_start = idxs.head_.min_ - 1;
     const auto slice_size = idxs.head_.max_ - slice_start;
-    math::check_size_match("vector[min_max] assign sizes", "lhs and rhs",
-                           slice_size, name, y.size());
+    check_size_match("vector[min_max] assign sizes", "lhs and rhs", slice_size,
+                     name, y.size());
     x.segment(slice_start, slice_size) = y;
     return;
   } else {
     const auto slice_start = idxs.head_.max_ - 1;
     const auto slice_size = idxs.head_.min_ - slice_start;
-    math::check_size_match("vector[reverse_min_max] assign sizes",
-                           "lhs and rhs", slice_size, name, y.size());
+    check_size_match("vector[reverse_min_max] assign sizes", "lhs and rhs",
+                     slice_size, name, y.size());
     x.segment(slice_start, slice_size) = y.reverse();
     return;
   }
@@ -189,7 +183,7 @@ inline void assign(Vec1&& x,
  * Types:  vec[general] <- vec
  *
  * @tparam Vec1 Eigen type with either dynamic rows or columns, but not both.
- * @tparam I Type of multiple index.
+ * @tparam Idx Type of multiple index.
  * @tparam Vec2 Eigen type with either dynamic rows or columns, but not both.
  * @param[in] x Row vector variable to be assigned.
  * @param[in] idxs An index.
@@ -200,17 +194,16 @@ inline void assign(Vec1&& x,
  * @throw std::invalid_argument If the value size isn't the same as
  * the indexed size.
  */
-template <typename Vec1, typename Vec2, typename I,
+template <typename Vec1, typename Vec2, typename Idx,
           require_all_eigen_vector_t<Vec1, Vec2>* = nullptr>
-inline void assign(Vec1&& x, const cons_index_list<I, nil_index_list>& idxs,
+inline void assign(Vec1&& x, const cons_index_list<Idx, nil_index_list>& idxs,
                    const Vec2& y, const char* name = "ANON", int depth = 0) {
-  const auto& y_ref = stan::math::to_ref(y);
-  math::check_size_match("vector[...] assign sizes", "lhs",
-                         rvalue_index_size(idxs.head_, x.size()), name,
-                         y_ref.size());
+  const auto& y_ref = to_ref(y);
+  check_size_match("vector[...] assign sizes", "lhs",
+                   rvalue_index_size(idxs.head_, x.size()), name, y_ref.size());
   for (int n = 0; n < y.size(); ++n) {
     int i = rvalue_at(n, idxs.head_);
-    math::check_range("vector[...] assign range", name, x.size(), i);
+    check_range("vector[...] assign range", name, x.size(), i);
     x.coeffRef(i - 1) = y_ref.coeffRef(n);
   }
 }
@@ -233,14 +226,13 @@ inline void assign(Vec1&& x, const cons_index_list<I, nil_index_list>& idxs,
  * vector and matrix do not match.
  */
 template <typename Mat, typename RowVec,
-          stan::internal::require_eigen_dense_dynamic_t<Mat>* = nullptr,
+          require_eigen_dense_dynamic_t<Mat>* = nullptr,
           require_eigen_row_vector_t<RowVec>* = nullptr>
 inline void assign(Mat&& x,
                    const cons_index_list<index_uni, nil_index_list>& idxs,
                    const RowVec& y, const char* name = "ANON", int depth = 0) {
-  math::check_size_match("matrix[uni] assign sizes", "lhs", x.cols(), name,
-                         y.size());
-  math::check_range("matrix[uni] assign range", name, x.rows(), idxs.head_.n_);
+  check_size_match("matrix[uni] assign sizes", "lhs", x.cols(), name, y.size());
+  check_range("matrix[uni] assign range", name, x.rows(), idxs.head_.n_);
   x.row(idxs.head_.n_ - 1) = y;
 }
 
@@ -262,20 +254,19 @@ inline void assign(Mat&& x,
  * @throw std::invalid_argument If the dimensions of the indexed
  * matrix and right-hand side matrix do not match.
  */
-template <
-    typename Mat1, typename Mat2,
-    stan::internal::require_all_eigen_dense_dynamic_t<Mat1, Mat2>* = nullptr,
-    require_eigen_t<Mat2>* = nullptr>
+template <typename Mat1, typename Mat2,
+          require_all_eigen_dense_dynamic_t<Mat1, Mat2>* = nullptr,
+          require_eigen_t<Mat2>* = nullptr>
 inline void assign(Mat1&& x,
                    const cons_index_list<index_min, nil_index_list>& idxs,
                    const Mat2& y, const char* name = "ANON", int depth = 0) {
   const auto start_row = idxs.head_.min_ - 1;
   const auto row_size = x.rows() - start_row;
-  math::check_range("matrix[min] assign range", name, x.rows(), row_size);
-  math::check_size_match("matrix[min] assign row sizes", "lhs", row_size, name,
-                         y.rows());
-  math::check_size_match("matrix[min] assign col sizes", "lhs", x.cols(), name,
-                         y.cols());
+  check_range("matrix[min] assign range", name, x.rows(), row_size);
+  check_size_match("matrix[min] assign row sizes", "lhs", row_size, name,
+                   y.rows());
+  check_size_match("matrix[min] assign col sizes", "lhs", x.cols(), name,
+                   y.cols());
   x.block(start_row, 0, row_size, x.cols()) = y;
 }
 
@@ -297,16 +288,14 @@ inline void assign(Mat1&& x,
  * @throw std::invalid_argument If the dimensions of the indexed
  * matrix and right-hand side matrix do not match.
  */
-template <
-    typename Mat1, typename Mat2,
-    stan::internal::require_all_eigen_dense_dynamic_t<Mat1, Mat2>* = nullptr>
+template <typename Mat1, typename Mat2,
+          require_all_eigen_dense_dynamic_t<Mat1, Mat2>* = nullptr>
 inline void assign(Mat1&& x,
                    const cons_index_list<index_max, nil_index_list>& idxs,
                    const Mat2& y, const char* name = "ANON", int depth = 0) {
-  math::check_range("matrix[max] assign range", name, x.cols(),
-                    idxs.head_.max_);
-  math::check_size_match("matrix[max] assign row sizes", "lhs", idxs.head_.max_,
-                         name, y.rows());
+  check_range("matrix[max] assign range", name, x.cols(), idxs.head_.max_);
+  check_size_match("matrix[max] assign row sizes", "lhs", idxs.head_.max_, name,
+                   y.rows());
   x.block(0, 0, idxs.head_.max_, x.cols()) = y;
 }
 
@@ -328,23 +317,22 @@ inline void assign(Mat1&& x,
  * matrix and right-hand side matrix do not match.
  */
 template <typename EigMat1, typename EigMat2,
-          stan::internal::require_all_eigen_dense_dynamic_t<EigMat1,
-                                                            EigMat2>* = nullptr>
+          require_all_eigen_dense_dynamic_t<EigMat1, EigMat2>* = nullptr>
 inline void assign(EigMat1&& x,
                    const cons_index_list<index_min_max, nil_index_list>& idxs,
                    const EigMat2& y, const char* name = "ANON", int depth = 0) {
-  math::check_range("matrix[min_max] max row indexing", name, x.rows(),
-                    idxs.head_.max_);
-  math::check_range("matrix[min_max] min row indexing", name, x.rows(),
-                    idxs.head_.min_);
-  if (idxs.head_.positive_idx_) {
-    math::check_size_match("matrix[min_max] assign row sizes", "lhs",
-                           idxs.head_.min_, name, y.rows());
+  check_range("matrix[min_max] max row indexing", name, x.rows(),
+              idxs.head_.max_);
+  check_range("matrix[min_max] min row indexing", name, x.rows(),
+              idxs.head_.min_);
+  if (idxs.head_.is_positive_idx()) {
+    check_size_match("matrix[min_max] assign row sizes", "lhs", idxs.head_.min_,
+                     name, y.rows());
     x.block(idxs.head_.min_ - 1, 0, idxs.head_.max_ - 1, x.cols()) = y;
     return;
   } else {
-    math::check_size_match("matrix[reverse_min_max] assign row sizes", "lhs",
-                           idxs.head_.max_, name, y.rows());
+    check_size_match("matrix[reverse_min_max] assign row sizes", "lhs",
+                     idxs.head_.max_, name, y.rows());
     x.block(idxs.head_.max_ - 1, 0, idxs.head_.min_ - 1, x.cols())
         = y.colwise().reverse();
     return;
@@ -370,17 +358,16 @@ inline void assign(EigMat1&& x,
  * matrix and right-hand side matrix do not match.
  */
 template <typename EigMat1, typename EigMat2,
-          stan::internal::require_all_eigen_dense_dynamic_t<EigMat1,
-                                                            EigMat2>* = nullptr>
+          require_all_eigen_dense_dynamic_t<EigMat1, EigMat2>* = nullptr>
 inline void rvalue(EigMat1&& x,
                    const cons_index_list<index_multi, nil_index_list>& idxs,
                    const EigMat2& y, const char* name = "ANON", int depth = 0) {
-  const auto& y_ref = stan::math::to_ref(y);
-  math::check_size_match("matrix[multi] assign row sizes", "lhs",
-                         idxs.head_.ns_.size(), name, y.rows());
+  const auto& y_ref = to_ref(y);
+  check_size_match("matrix[multi] assign row sizes", "lhs",
+                   idxs.head_.ns_.size(), name, y.rows());
   for (int i = 0; i < idxs.head_.ns_.size(); ++i) {
     const int n = idxs.head_.ns_[i];
-    math::check_range("matrix[multi] subset range", name, x.rows(), n);
+    check_range("matrix[multi] subset range", name, x.rows(), n);
     x.row(n - 1) = y_ref.row(i);
   }
 }
@@ -391,7 +378,7 @@ inline void rvalue(EigMat1&& x,
  * Types:  mat[general] = mat
  *
  * @tparam Mat1 Eigen type with dynamic rows and columns.
- * @tparam L Multiple index type.
+ * @tparam Idx Multiple index type.
  * @tparam Mat2 Eigen type with dynamic rows and columns.
  * @param[in] x Matrix variable to be assigned.
  * @param[in] idxs Any of the index types.
@@ -402,20 +389,19 @@ inline void rvalue(EigMat1&& x,
  * @throw std::invalid_argument If the dimensions of the indexed
  * matrix and right-hand side matrix do not match.
  */
-template <
-    typename Mat1, typename L, typename Mat2,
-    stan::internal::require_all_eigen_dense_dynamic_t<Mat1, Mat2>* = nullptr>
-inline void assign(Mat1&& x, const cons_index_list<L, nil_index_list>& idxs,
+template <typename Mat1, typename Idx, typename Mat2,
+          require_all_eigen_dense_dynamic_t<Mat1, Mat2>* = nullptr>
+inline void assign(Mat1&& x, const cons_index_list<Idx, nil_index_list>& idxs,
                    const Mat2& y, const char* name = "ANON", int depth = 0) {
   const int x_idx_rows = rvalue_index_size(idxs.head_, x.rows());
-  const auto& y_ref = stan::math::to_ref(y);
-  math::check_size_match("matrix[...] assign row sizes", "lhs", x_idx_rows,
-                         name, y_ref.rows());
-  math::check_size_match("matrix[...] assign col sizes", "lhs", x.cols(), name,
-                         y_ref.cols());
+  const auto& y_ref = to_ref(y);
+  check_size_match("matrix[...] assign row sizes", "lhs", x_idx_rows, name,
+                   y_ref.rows());
+  check_size_match("matrix[...] assign col sizes", "lhs", x.cols(), name,
+                   y_ref.cols());
   for (int i = 0; i < y_ref.rows(); ++i) {
     const int m = rvalue_at(i, idxs.head_);
-    math::check_range("matrix[...] assign range", name, x.rows(), m);
+    check_range("matrix[...] assign range", name, x.rows(), m);
     x.row(m - 1) = y_ref.row(i);
   }
 }
@@ -437,25 +423,25 @@ inline void assign(Mat1&& x, const cons_index_list<L, nil_index_list>& idxs,
  * matrix and right-hand side matrix do not match.
  */
 template <typename Mat1, typename Mat2,
-          stan::internal::require_eigen_dense_dynamic_t<Mat1>* = nullptr,
+          require_eigen_dense_dynamic_t<Mat1>* = nullptr,
           require_eigen_t<Mat2>* = nullptr>
 inline void assign(
     Mat1&& x,
     const cons_index_list<index_min_max,
                           cons_index_list<index_min_max, nil_index_list>>& idxs,
     const Mat2& y, const char* name = "ANON", int depth = 0) {
-  if (idxs.head_.positive_idx_) {
-    if (idxs.tail_.head_.positive_idx_) {
+  if (idxs.head_.is_positive_idx()) {
+    if (idxs.tail_.head_.is_positive_idx()) {
       auto row_size = idxs.head_.max_ - (idxs.head_.min_ - 1);
       auto col_size = idxs.tail_.head_.max_ - (idxs.tail_.head_.min_ - 1);
-      math::check_range("matrix[min_max, min_max] assign col range", name,
-                        x.cols(), idxs.head_.min_);
-      math::check_range("matrix[min_max, min_max] assign row range", name,
-                        x.rows(), idxs.tail_.head_.min_);
-      math::check_size_match("matrix[min_max, min_max] assign row sizes", "lhs",
-                             row_size, name, y.rows());
-      math::check_size_match("matrix[min_max, min_max] assign col sizes", "lhs",
-                             col_size, name, y.cols());
+      check_range("matrix[min_max, min_max] assign col range", name, x.cols(),
+                  idxs.head_.min_);
+      check_range("matrix[min_max, min_max] assign row range", name, x.rows(),
+                  idxs.tail_.head_.min_);
+      check_size_match("matrix[min_max, min_max] assign row sizes", "lhs",
+                       row_size, name, y.rows());
+      check_size_match("matrix[min_max, min_max] assign col sizes", "lhs",
+                       col_size, name, y.cols());
       x.block(idxs.head_.min_ - 1, idxs.tail_.head_.min_ - 1, row_size,
               col_size)
           = y;
@@ -463,35 +449,31 @@ inline void assign(
     } else {
       auto row_size = idxs.head_.max_ - (idxs.head_.min_ - 1);
       auto col_size = idxs.tail_.head_.min_ - (idxs.tail_.head_.max_ - 1);
-      math::check_range("matrix[min_max, reverse_min_max] assign col range",
-                        name, x.cols(), idxs.head_.min_);
-      math::check_range("matrix[min_max, reverse_min_max] assign row range",
-                        name, x.rows(), idxs.tail_.head_.max_);
-      math::check_size_match(
-          "matrix[min_max, reverse_min_max] assign row sizes", "lhs", row_size,
-          name, y.rows());
-      math::check_size_match(
-          "matrix[min_max, reverse_min_max] assign col sizes", "lhs", col_size,
-          name, y.cols());
+      check_range("matrix[min_max, reverse_min_max] assign col range", name,
+                  x.cols(), idxs.head_.min_);
+      check_range("matrix[min_max, reverse_min_max] assign row range", name,
+                  x.rows(), idxs.tail_.head_.max_);
+      check_size_match("matrix[min_max, reverse_min_max] assign row sizes",
+                       "lhs", row_size, name, y.rows());
+      check_size_match("matrix[min_max, reverse_min_max] assign col sizes",
+                       "lhs", col_size, name, y.cols());
       x.block(idxs.head_.min_ - 1, idxs.tail_.head_.max_ - 1, row_size,
               col_size)
           = y.rowwise().reverse();
       return;
     }
   } else {
-    if (idxs.tail_.head_.positive_idx_) {
+    if (idxs.tail_.head_.is_positive_idx()) {
       auto row_size = idxs.head_.min_ - (idxs.head_.max_ - 1);
       auto col_size = idxs.tail_.head_.max_ - (idxs.tail_.head_.min_ - 1);
-      math::check_range("matrix[reverse_min_max, min_max] assign col range",
-                        name, x.cols(), idxs.head_.max_);
-      math::check_range("matrix[reverse_min_max, min_max] assign row range",
-                        name, x.rows(), idxs.tail_.head_.min_);
-      math::check_size_match(
-          "matrix[reverse_min_max, min_max] assign row sizes", "lhs", row_size,
-          name, y.rows());
-      math::check_size_match(
-          "matrix[reverse_min_max, min_max] assign col sizes", "lhs", col_size,
-          name, y.cols());
+      check_range("matrix[reverse_min_max, min_max] assign col range", name,
+                  x.cols(), idxs.head_.max_);
+      check_range("matrix[reverse_min_max, min_max] assign row range", name,
+                  x.rows(), idxs.tail_.head_.min_);
+      check_size_match("matrix[reverse_min_max, min_max] assign row sizes",
+                       "lhs", row_size, name, y.rows());
+      check_size_match("matrix[reverse_min_max, min_max] assign col sizes",
+                       "lhs", col_size, name, y.cols());
       x.block(idxs.head_.max_ - 1, idxs.tail_.head_.min_ - 1, row_size,
               col_size)
           = y.colwise().reverse();
@@ -499,16 +481,14 @@ inline void assign(
     } else {
       auto row_size = idxs.head_.min_ - (idxs.head_.max_ - 1);
       auto col_size = idxs.tail_.head_.min_ - (idxs.tail_.head_.max_ - 1);
-      math::check_range(
-          "matrix[reverse_min_max, reverse_min_max] assign col range", name,
-          x.cols(), idxs.head_.max_);
-      math::check_range(
-          "matrix[reverse_min_max, reverse_min_max] assign row range", name,
-          x.rows(), idxs.tail_.head_.max_);
-      math::check_size_match(
+      check_range("matrix[reverse_min_max, reverse_min_max] assign col range",
+                  name, x.cols(), idxs.head_.max_);
+      check_range("matrix[reverse_min_max, reverse_min_max] assign row range",
+                  name, x.rows(), idxs.tail_.head_.max_);
+      check_size_match(
           "matrix[reverse_min_max, reverse_min_max] assign row sizes", "lhs",
           row_size, name, y.rows());
-      math::check_size_match(
+      check_size_match(
           "matrix[reverse_min_max, reverse_min_max] assign col sizes", "lhs",
           col_size, name, y.cols());
       x.block(idxs.head_.max_ - 1, idxs.tail_.head_.max_ - 1, row_size,
@@ -535,7 +515,7 @@ inline void assign(
  * @throw std::out_of_range If either of the indices are out of bounds.
  */
 template <typename Mat, typename U,
-          stan::internal::require_eigen_dense_dynamic_t<Mat>* = nullptr>
+          require_eigen_dense_dynamic_t<Mat>* = nullptr>
 inline void assign(
     Mat&& x,
     const cons_index_list<index_uni,
@@ -543,9 +523,9 @@ inline void assign(
     const U& y, const char* name = "ANON", int depth = 0) {
   const int m = idxs.head_.n_;
   const int n = idxs.tail_.head_.n_;
-  math::check_range("matrix[uni,uni] assign range", name, x.rows(), m);
-  math::check_range("matrix[uni,uni] assign range", name, x.cols(), n);
-  stan::math::to_ref(x).coeffRef(m - 1, n - 1) = y;
+  check_range("matrix[uni,uni] assign range", name, x.rows(), m);
+  check_range("matrix[uni,uni] assign range", name, x.cols(), n);
+  to_ref(x).coeffRef(m - 1, n - 1) = y;
 }
 
 /**
@@ -565,21 +545,20 @@ inline void assign(
  * matrix and value matrix do not match.
  */
 template <typename Mat1, typename Vec,
-          stan::internal::require_eigen_dense_dynamic_t<Mat1>* = nullptr,
+          require_eigen_dense_dynamic_t<Mat1>* = nullptr,
           require_eigen_vector_t<Vec>* = nullptr>
 inline void assign(
     Mat1&& x,
     const cons_index_list<index_uni,
                           cons_index_list<index_multi, nil_index_list>>& idxs,
     const Vec& y, const char* name = "ANON", int depth = 0) {
-  const auto& y_ref = stan::math::to_ref(y);
-  math::check_range("matrix[uni, multi] assign range", name, x.cols(),
-                    idxs.head_.n_);
-  math::check_size_match("matrix[uni, multi] assign sizes", "lhs",
-                         idxs.tail_.head_.ns_.size(), name, y_ref.size());
+  const auto& y_ref = to_ref(y);
+  check_range("matrix[uni, multi] assign range", name, x.cols(), idxs.head_.n_);
+  check_size_match("matrix[uni, multi] assign sizes", "lhs",
+                   idxs.tail_.head_.ns_.size(), name, y_ref.size());
   for (int i = 0; i < idxs.tail_.head_.ns_.size(); ++i) {
-    math::check_range("matrix[uni, multi] assign range", name, x.cols(),
-                      idxs.tail_.head_.ns_[i]);
+    check_range("matrix[uni, multi] assign range", name, x.cols(),
+                idxs.tail_.head_.ns_[i]);
     x.coeffRef(idxs.head_.n_ - 1, idxs.tail_.head_.ns_[i] - 1)
         = y_ref.coeffRef(i);
   }
@@ -602,25 +581,24 @@ inline void assign(
  * @throw std::invalid_argument If the dimensions of the indexed
  * matrix and value matrix do not match.
  */
-template <
-    typename Mat1, typename Mat2,
-    stan::internal::require_all_eigen_dense_dynamic_t<Mat1, Mat2>* = nullptr>
+template <typename Mat1, typename Mat2,
+          require_all_eigen_dense_dynamic_t<Mat1, Mat2>* = nullptr>
 inline void assign(
     Mat1&& x,
     const cons_index_list<index_multi,
                           cons_index_list<index_multi, nil_index_list>>& idxs,
     const Mat2& y, const char* name = "ANON", int depth = 0) {
-  const auto& y_ref = stan::math::to_ref(y);
-  math::check_size_match("matrix[multi,multi] assign sizes", "lhs",
-                         idxs.head_.ns_.size(), name, y_ref.rows());
-  math::check_size_match("matrix[multi,multi] assign sizes", "lhs",
-                         idxs.tail_.head_.ns_.size(), name, y_ref.cols());
+  const auto& y_ref = to_ref(y);
+  check_size_match("matrix[multi,multi] assign sizes", "lhs",
+                   idxs.head_.ns_.size(), name, y_ref.rows());
+  check_size_match("matrix[multi,multi] assign sizes", "lhs",
+                   idxs.tail_.head_.ns_.size(), name, y_ref.cols());
   for (int j = 0; j < y_ref.cols(); ++j) {
     const int n = idxs.tail_.head_.ns_[j];
-    math::check_range("matrix[multi,multi] assign range", name, x.cols(), n);
+    check_range("matrix[multi,multi] assign range", name, x.cols(), n);
     for (int i = 0; i < y_ref.rows(); ++i) {
       const int m = idxs.head_.ns_[i];
-      math::check_range("matrix[multi,multi] assign range", name, x.rows(), m);
+      check_range("matrix[multi,multi] assign range", name, x.rows(), m);
       x.coeffRef(m - 1, n - 1) = y_ref.coeffRef(i, j);
     }
   }
@@ -629,11 +607,11 @@ inline void assign(
 /**
  * Assign the specified Eigen matrix at the min_max indice for the assignee.
  *
- * Types:  mat[L, uni] = mat
+ * Types:  mat[Idx, uni] = mat
  *
  * @tparam Mat1 Eigen type with dynamic rows and columns.
  * @tparam Mat2 Eigen type with dynamic rows and columns.
- * @tparam L The row index type
+ * @tparam Idx The row index type
  * @param[in] x Matrix variable to be assigned.
  * @param[in] idxs Container holding row index and a min_max index.
  * @param[in] y Matrix variable to assign from.
@@ -643,14 +621,15 @@ inline void assign(
  * @throw std::invalid_argument If the dimensions of the indexed
  * matrix and right-hand side matrix do not match.
  */
-template <typename Mat1, typename Mat2, typename L,
-          stan::internal::require_eigen_dense_dynamic_t<Mat1>* = nullptr>
+template <typename Mat1, typename Mat2, typename Idx,
+          require_eigen_dense_dynamic_t<Mat1>* = nullptr>
 inline void assign(
     Mat1&& x,
-    const cons_index_list<L, cons_index_list<index_uni, nil_index_list>>& idxs,
+    const cons_index_list<Idx, cons_index_list<index_uni, nil_index_list>>&
+        idxs,
     const Mat2& y, const char* name = "ANON", int depth = 0) {
-  math::check_range("matrix[..., uni] assign range", name, x.cols(),
-                    idxs.tail_.head_.n_);
+  check_range("matrix[..., uni] assign range", name, x.cols(),
+              idxs.tail_.head_.n_);
   assign(x.col(idxs.tail_.head_.n_ - 1), index_list(idxs.head_), y, name,
          depth + 1);
   return;
@@ -660,11 +639,11 @@ inline void assign(
  * Assign the specified Eigen matrix at the specified pair of
  * multiple indexes to the specified matrix.
  *
- * Types:  mat[L, multi] = mat
+ * Types:  mat[Idx, multi] = mat
  *
  * @tparam Mat1 Eigen type with dynamic rows and columns.
  * @tparam Mat2 Eigen type with dynamic rows and columns.
- * @tparam L The row index type
+ * @tparam Idx The row index type
  * @param[in] x Matrix variable to be assigned.
  * @param[in] idxs Pair of multiple indexes (from 1).
  * @param[in] y Value matrix.
@@ -674,19 +653,19 @@ inline void assign(
  * @throw std::invalid_argument If the dimensions of the indexed
  * matrix and value matrix do not match.
  */
-template <typename Mat1, typename Mat2, typename L,
-          stan::internal::require_eigen_dense_dynamic_t<Mat1>* = nullptr>
+template <typename Mat1, typename Mat2, typename Idx,
+          require_eigen_dense_dynamic_t<Mat1>* = nullptr>
 inline void assign(
     Mat1&& x,
-    const cons_index_list<L, cons_index_list<index_multi, nil_index_list>>&
+    const cons_index_list<Idx, cons_index_list<index_multi, nil_index_list>>&
         idxs,
     const Mat2& y, const char* name = "ANON", int depth = 0) {
-  const auto& y_ref = stan::math::to_ref(y);
-  math::check_size_match("matrix[..., multi] assign sizes", "lhs",
-                         idxs.tail_.head_.ns_.size(), name, y_ref.cols());
+  const auto& y_ref = to_ref(y);
+  check_size_match("matrix[..., multi] assign sizes", "lhs",
+                   idxs.tail_.head_.ns_.size(), name, y_ref.cols());
   for (int j = 0; j < y_ref.cols(); ++j) {
     const int n = idxs.tail_.head_.ns_[j];
-    math::check_range("matrix[..., multi] assign range", name, x.cols(), n);
+    check_range("matrix[..., multi] assign range", name, x.cols(), n);
     assign(x.col(n - 1), index_list(idxs.head_), y_ref.col(j), name, depth + 1);
   }
 }
@@ -695,11 +674,11 @@ inline void assign(
  * Assign an Eigen matrix at the pair of multiple indexes to the specified
  * matrix.
  *
- * Types:  mat[L, omni] = mat
+ * Types:  mat[Idx, omni] = mat
  *
  * @tparam Mat1 Eigen type with dynamic rows and columns.
  * @tparam Mat2 Eigen type with dynamic rows and columns.
- * @tparam L The row index type
+ * @tparam Idx The row index type
  * @param[in] x Matrix variable to be assigned.
  * @param[in] idxs Pair of multiple indexes (from 1).
  * @param[in] y Value matrix.
@@ -709,11 +688,12 @@ inline void assign(
  * @throw std::invalid_argument If the dimensions of the indexed
  * matrix and value matrix do not match.
  */
-template <typename Mat1, typename Mat2, typename L,
-          stan::internal::require_eigen_dense_dynamic_t<Mat1>* = nullptr>
+template <typename Mat1, typename Mat2, typename Idx,
+          require_eigen_dense_dynamic_t<Mat1>* = nullptr>
 inline void assign(
     Mat1&& x,
-    const cons_index_list<L, cons_index_list<index_omni, nil_index_list>>& idxs,
+    const cons_index_list<Idx, cons_index_list<index_omni, nil_index_list>>&
+        idxs,
     const Mat2& y, const char* name = "ANON", int depth = 0) {
   assign(x, index_list(idxs.head_), y, name, depth + 1);
 }
@@ -721,11 +701,11 @@ inline void assign(
 /**
  * Assign to an Eigen matrix using a min_index for the columns.
  *
- * Types:  mat[L, min] = mat
+ * Types:  mat[Idx, min] = mat
  *
  * @tparam Mat1 Eigen type with dynamic rows and columns.
  * @tparam Mat2 Eigen type with dynamic rows and columns.
- * @tparam L The row index type
+ * @tparam Idx The row index type
  * @param[in] x Matrix variable to be assigned.
  * @param[in] idxs Container holding a row index and an index from a minimum
  * index (inclusive) to the end of a container.
@@ -736,16 +716,17 @@ inline void assign(
  * @throw std::invalid_argument If the dimensions of the indexed
  * matrix and right-hand side matrix do not match.
  */
-template <typename Mat1, typename Mat2, typename L,
-          stan::internal::require_eigen_dense_dynamic_t<Mat1>* = nullptr>
+template <typename Mat1, typename Mat2, typename Idx,
+          require_eigen_dense_dynamic_t<Mat1>* = nullptr>
 inline void assign(
     Mat1&& x,
-    const cons_index_list<L, cons_index_list<index_min, nil_index_list>>& idxs,
+    const cons_index_list<Idx, cons_index_list<index_min, nil_index_list>>&
+        idxs,
     const Mat2& y, const char* name = "ANON", int depth = 0) {
   const auto start_col = idxs.tail_.head_.min_ - 1;
   const auto col_size = x.cols() - start_col;
-  math::check_size_match("matrix[..., min] assign col sizes", "lhs", col_size,
-                         name, y.cols());
+  check_size_match("matrix[..., min] assign col sizes", "lhs", col_size, name,
+                   y.cols());
   assign(x.block(0, start_col, x.rows(), col_size), index_list(idxs.head_), y,
          name, depth + 1);
 }
@@ -753,11 +734,11 @@ inline void assign(
 /**
  * Assign to an Eigen matrix using a max_index.
  *
- * Types:  mat[L, max] = mat
+ * Types:  mat[Idx, max] = mat
  *
  * @tparam Mat1 Eigen type with dynamic rows and columns.
  * @tparam Mat2 Eigen type with dynamic rows and columns.
- * @tparam L The row index type
+ * @tparam Idx The row index type
  * @param[in] x Matrix variable to be assigned.
  * @param[in] idxs Index holding a row index and an index from the start of the
  * container up to the specified maximum index (inclusive).
@@ -768,14 +749,15 @@ inline void assign(
  * @throw std::invalid_argument If the dimensions of the indexed
  * matrix and right-hand side matrix do not match.
  */
-template <typename Mat1, typename Mat2, typename L,
-          stan::internal::require_eigen_dense_dynamic_t<Mat1>* = nullptr>
+template <typename Mat1, typename Mat2, typename Idx,
+          require_eigen_dense_dynamic_t<Mat1>* = nullptr>
 inline void assign(
     Mat1&& x,
-    const cons_index_list<L, cons_index_list<index_max, nil_index_list>>& idxs,
+    const cons_index_list<Idx, cons_index_list<index_max, nil_index_list>>&
+        idxs,
     const Mat2& y, const char* name = "ANON", int depth = 0) {
-  math::check_size_match("matrix[..., max] assign col size", "lhs",
-                         idxs.tail_.head_.max_, name, y.cols());
+  check_size_match("matrix[..., max] assign col size", "lhs",
+                   idxs.tail_.head_.max_, name, y.cols());
   assign(x.block(0, 0, x.rows(), idxs.tail_.head_.max_ - 1),
          index_list(idxs.head_), y, name, depth + 1);
 }
@@ -783,11 +765,11 @@ inline void assign(
 /**
  * Assign the specified Eigen matrix at the min_max indice for the assignee.
  *
- * Types:  mat[L, min_max] = mat
+ * Types:  mat[Idx, min_max] = mat
  *
  * @tparam Mat1 Eigen type with dynamic rows and columns.
  * @tparam Mat2 Eigen type with dynamic rows and columns.
- * @tparam L The row index type
+ * @tparam Idx The row index type
  * @param[in] x Matrix variable to be assigned.
  * @param[in] idxs Container holding row index and a min_max index.
  * @param[in] y Matrix variable to assign from.
@@ -797,34 +779,34 @@ inline void assign(
  * @throw std::invalid_argument If the dimensions of the indexed
  * matrix and right-hand side matrix do not match.
  */
-template <typename Mat1, typename Mat2, typename L,
-          stan::internal::require_eigen_dense_dynamic_t<Mat1>* = nullptr>
+template <typename Mat1, typename Mat2, typename Idx,
+          require_eigen_dense_dynamic_t<Mat1>* = nullptr>
 inline void assign(
     Mat1&& x,
-    const cons_index_list<L, cons_index_list<index_min_max, nil_index_list>>&
+    const cons_index_list<Idx, cons_index_list<index_min_max, nil_index_list>>&
         idxs,
     const Mat2& y, const char* name = "ANON", int depth = 0) {
-  if (idxs.tail_.head_.positive_idx_) {
+  if (idxs.tail_.head_.is_positive_idx()) {
     const auto col_start = idxs.tail_.head_.min_ - 1;
     const auto col_size = idxs.tail_.head_.max_ - col_start;
-    math::check_range("matrix[..., min_max] assign range", name, x.cols(),
-                      idxs.tail_.head_.min_);
-    math::check_range("matrix[..., min_max] assign range", name,
-                      idxs.tail_.head_.max_, x.cols());
-    math::check_size_match("matrix[..., min_max] assign col size", "lhs",
-                           idxs.tail_.head_.max_, name, x.cols());
+    check_range("matrix[..., min_max] assign range", name, x.cols(),
+                idxs.tail_.head_.min_);
+    check_range("matrix[..., min_max] assign range", name,
+                idxs.tail_.head_.max_, x.cols());
+    check_size_match("matrix[..., min_max] assign col size", "lhs",
+                     idxs.tail_.head_.max_, name, x.cols());
     assign(x.block(0, col_start, x.rows(), col_size), index_list(idxs.head_), y,
            name, depth + 1);
     return;
   } else {
     const auto col_start = idxs.tail_.head_.max_ - 1;
     const auto col_size = idxs.tail_.head_.min_ - col_start;
-    math::check_range("matrix[..., reverse_min_max] assign range", name,
-                      x.cols(), idxs.tail_.head_.max_);
-    math::check_range("matrix[..., reverse_min_max] assign range", name,
-                      idxs.tail_.head_.min_, x.cols());
-    math::check_size_match("matrix[..., min_max] assign col size", "lhs",
-                           idxs.tail_.head_.min_, name, x.cols());
+    check_range("matrix[..., reverse_min_max] assign range", name, x.cols(),
+                idxs.tail_.head_.max_);
+    check_range("matrix[..., reverse_min_max] assign range", name,
+                idxs.tail_.head_.min_, x.cols());
+    check_size_match("matrix[..., min_max] assign col size", "lhs",
+                     idxs.tail_.head_.min_, name, x.cols());
     assign(x.block(0, col_start, x.rows(), col_size), index_list(idxs.head_),
            y.rowwise().reverse(), name, depth + 1);
     return;
@@ -847,21 +829,21 @@ inline void assign(
  * matrix and value matrix do not match.
  */
 template <typename Mat1, typename Vec,
-          stan::internal::require_eigen_dense_dynamic_t<Mat1>* = nullptr,
+          require_eigen_dense_dynamic_t<Mat1>* = nullptr,
           require_eigen_vector_t<Vec>* = nullptr>
 inline void assign(
     Mat1&& x,
     const cons_index_list<index_multi,
                           cons_index_list<index_uni, nil_index_list>>& idxs,
     const Vec& y, const char* name = "ANON", int depth = 0) {
-  const auto& y_ref = stan::math::to_ref(y);
-  math::check_range("matrix[multi, uni] assign range", name, x.cols(),
-                    idxs.tail_.head_.n_);
-  math::check_size_match("matrix[multi, uni] assign sizes", "lhs",
-                         idxs.head_.ns_.size(), name, y_ref.size());
+  const auto& y_ref = to_ref(y);
+  check_range("matrix[multi, uni] assign range", name, x.cols(),
+              idxs.tail_.head_.n_);
+  check_size_match("matrix[multi, uni] assign sizes", "lhs",
+                   idxs.head_.ns_.size(), name, y_ref.size());
   for (int i = 0; i < idxs.head_.ns_.size(); ++i) {
-    math::check_range("matrix[multi, uni] assign range", name, x.rows(),
-                      idxs.head_.ns_[i]);
+    check_range("matrix[multi, uni] assign range", name, x.rows(),
+                idxs.head_.ns_[i]);
     x.coeffRef(idxs.head_.ns_[i] - 1, idxs.tail_.head_.n_ - 1)
         = y_ref.coeffRef(i);
   }
@@ -885,26 +867,25 @@ inline void assign(
  * @throw std::invalid_argument If the dimensions of the indexed
  * matrix and value matrix do not match.
  */
-template <
-    typename Mat1, typename I1, typename I2, typename Mat2,
-    stan::internal::require_all_eigen_dense_dynamic_t<Mat1, Mat2>* = nullptr>
+template <typename Mat1, typename I1, typename I2, typename Mat2,
+          require_all_eigen_dense_dynamic_t<Mat1, Mat2>* = nullptr>
 inline void assign(
     Mat1&& x,
     const cons_index_list<I1, cons_index_list<I2, nil_index_list>>& idxs,
     const Mat2& y, const char* name = "ANON", int depth = 0) {
   const int x_idxs_rows = rvalue_index_size(idxs.head_, x.rows());
   const int x_idxs_cols = rvalue_index_size(idxs.tail_.head_, x.cols());
-  const auto& y_ref = stan::math::to_ref(y);
-  math::check_size_match("matrix[..., ...] assign sizes", "lhs", x_idxs_rows,
-                         name, y_ref.rows());
-  math::check_size_match("matrix[..., ...] assign sizes", "lhs", x_idxs_cols,
-                         name, y_ref.cols());
+  const auto& y_ref = to_ref(y);
+  check_size_match("matrix[..., ...] assign sizes", "lhs", x_idxs_rows, name,
+                   y_ref.rows());
+  check_size_match("matrix[..., ...] assign sizes", "lhs", x_idxs_cols, name,
+                   y_ref.cols());
   for (int j = 0; j < y_ref.cols(); ++j) {
     const int n = rvalue_at(j, idxs.tail_.head_);
-    math::check_range("matrix[..., ...] assign range", name, x.cols(), n);
+    check_range("matrix[..., ...] assign range", name, x.cols(), n);
     for (int i = 0; i < y_ref.rows(); ++i) {
       const int m = rvalue_at(i, idxs.head_);
-      math::check_range("matrix[..., ...] assign range", name, x.rows(), m);
+      check_range("matrix[..., ...] assign range", name, x.rows(), m);
       x.coeffRef(m - 1, n - 1) = y_ref.coeffRef(i, j);
     }
   }
@@ -922,8 +903,7 @@ inline void assign(
  * @param[in] depth indexing depth (default 0).
  */
 template <typename T, typename U, require_all_std_vector_t<T, U>* = nullptr,
-          require_not_t<
-              std::is_assignable<std::decay_t<T>&, std::decay_t<U>>>* = nullptr>
+          require_not_assignable_t<T&, U>* = nullptr>
 inline void assign(T&& x, const nil_index_list& /* idxs */, U&& y,
                    const char* name = "ANON", int depth = 0) {
   x.resize(y.size());
@@ -939,10 +919,10 @@ inline void assign(T&& x, const nil_index_list& /* idxs */, U&& y,
  * This function operates recursively to carry out the tail
  * indexing.
  *
- * Types:  x[uni | L] = y
+ * Types:  x[uni | Idx] = y
  *
  * @tparam StdVec A standard vector
- * @tparam L Type of tail of index list.
+ * @tparam Idx Type of tail of index list.
  * @tparam U A type assignable to the value type of `StdVec`
  * @param[in] x Array variable to be assigned.
  * @param[in] idxs List of indexes beginning with single index
@@ -954,12 +934,11 @@ inline void assign(T&& x, const nil_index_list& /* idxs */, U&& y,
  * @throw std::invalid_argument If the dimensions do not match in the
  * tail assignment.
  */
-template <typename StdVec, typename L, typename U,
+template <typename StdVec, typename Idx, typename U,
           require_std_vector_t<StdVec>* = nullptr>
-inline void assign(StdVec&& x, const cons_index_list<index_uni, L>& idxs, U&& y,
-                   const char* name = "ANON", int depth = 0) {
-  math::check_range("vector[uni,...] assign range", name, x.size(),
-                    idxs.head_.n_);
+inline void assign(StdVec&& x, const cons_index_list<index_uni, Idx>& idxs,
+                   U&& y, const char* name = "ANON", int depth = 0) {
+  check_range("vector[uni,...] assign range", name, x.size(), idxs.head_.n_);
   assign(x[idxs.head_.n_ - 1], idxs.tail_, y, name, depth + 1);
 }
 
@@ -970,10 +949,10 @@ inline void assign(StdVec&& x, const cons_index_list<index_uni, L>& idxs, U&& y,
  * This function operates recursively to carry out the tail
  * indexing.
  *
- * Types:  x[uni | L] = y
+ * Types:  x[uni | Idx] = y
  *
  * @tparam StdVec A standard vector
- * @tparam L Type of tail of index list.
+ * @tparam Idx Type of tail of index list.
  * @tparam U A type assignable to the value type of `StdVec`
  * @param[in] x Array variable to be assigned.
  * @param[in] idxs List of indexes beginning with single index
@@ -985,13 +964,12 @@ inline void assign(StdVec&& x, const cons_index_list<index_uni, L>& idxs, U&& y,
  * @throw std::invalid_argument If the dimensions do not match in the
  * tail assignment.
  */
-template <typename StdVec, typename L, typename U,
+template <typename StdVec, typename Idx, typename U,
           require_std_vector_t<StdVec>* = nullptr>
 inline void assign(StdVec&& x,
                    const cons_index_list<index_uni, nil_index_list>& idxs,
                    U&& y, const char* name = "ANON", int depth = 0) {
-  math::check_range("vector[uni,...] assign range", name, x.size(),
-                    idxs.head_.n_);
+  check_range("vector[uni,...] assign range", name, x.size(), idxs.head_.n_);
   x[idxs.head_.n_ - 1] = y;
 }
 
@@ -1002,11 +980,11 @@ inline void assign(StdVec&& x,
  * This function operates recursively to carry out the tail
  * indexing.
  *
- * Types:  x[general | L] = y
+ * Types:  x[Idx1 | Idx2] = y
  *
  * @tparam T A standard vector.
- * @tparam I Type of multiple index heading index list.
- * @tparam L Type of tail of index list.
+ * @tparam Idx1 Type of multiple index heading index list.
+ * @tparam Idx2 Type of tail of index list.
  * @tparam U A standard vector
  * @param[in] x Array variable to be assigned.
  * @param[in] idxs List of indexes beginning with multiple index
@@ -1019,16 +997,16 @@ inline void assign(StdVec&& x,
  * and size of first dimension of value do not match, or any of
  * the recursive tail assignment dimensions do not match.
  */
-template <typename T, typename I, typename L, typename U,
+template <typename T, typename Idx1, typename Idx2, typename U,
           require_all_std_vector_t<T, U>* = nullptr>
-inline void assign(T&& x, const cons_index_list<I, L>& idxs, U&& y,
+inline void assign(T&& x, const cons_index_list<Idx1, Idx2>& idxs, U&& y,
                    const char* name = "ANON", int depth = 0) {
   int x_idx_size = rvalue_index_size(idxs.head_, x.size());
-  math::check_size_match("vector[multi,...] assign sizes", "lhs", x_idx_size,
-                         name, y.size());
+  check_size_match("vector[multi,...] assign sizes", "lhs", x_idx_size, name,
+                   y.size());
   for (size_t n = 0; n < y.size(); ++n) {
     int i = rvalue_at(n, idxs.head_);
-    math::check_range("vector[multi,...] assign range", name, x.size(), i);
+    check_range("vector[multi,...] assign range", name, x.size(), i);
     assign(x[i - 1], idxs.tail_, y[n], name, depth + 1);
   }
 }

--- a/stan/math/prim/fun/assign.hpp
+++ b/stan/math/prim/fun/assign.hpp
@@ -1,102 +1,1038 @@
-#ifndef STAN_MATH_PRIM_FUN_ASSIGN_HPP
-#define STAN_MATH_PRIM_FUN_ASSIGN_HPP
+#ifndef STAN_MODEL_INDEXING_LVALUE_HPP
+#define STAN_MODEL_INDEXING_LVALUE_HPP
 
-#include <stan/math/prim/err.hpp>
-#include <stan/math/prim/fun/Eigen.hpp>
-#include <iostream>
-#include <sstream>
-#include <stdexcept>
-#include <string>
+#include <stan/math/prim.hpp>
+#include <stan/math/prim/fun/indexing/index.hpp>
+#include <stan/math/prim/fun/index_list.hpp>
+#include <stan/math/prim/fun/rvalue_at.hpp>
+#include <stan/math/prim/fun/rvalue_index_size.hpp>
+#include <type_traits>
 #include <vector>
 
 namespace stan {
-namespace math {
+
+namespace model {
 
 /**
- * Helper function to return the matrix size as either "dynamic" or "1".
- *
- * @tparam N Eigen matrix size specification
- * @param o output stream
+ * Indexing Notes:
+ * The different index types:
+ * index_uni - A single cell.
+ * index_multi - Random access index.
+ * index_omni - A no-op for all indices along a dimension.
+ * index_min - index from min:N
+ * index_max - index from 1:max
+ * index_min_max - index from min:max
+ * The order of the overloads are
+ * nil_index_list / no-op
+ * vector:
+ *  - full index overloads
+ *  - general index overload
+ * matrix:
+ *  - row subset full index overloads
+ *  - general row indexing overload
+ *  - column subset partial overloads
+ *    - These take a subset of columns and then call the row slice assignment
+ *       over the column subset.
+ *  - general indexing overload
+ *    - This covers any slices that were missed by the overloads.
+ * Std vector general overloads
  */
-template <int N>
-inline void print_mat_size(std::ostream& o) {
-  if (N == Eigen::Dynamic) {
-    o << "dynamically sized";
-  } else {
-    o << N;
+
+/**
+ * Assign the specified rvalue to the specified lvalue.  The index
+ * list's type must be `nil_index_list`, but its value will be
+ * ignored.  The last two arguments are also ignored.
+ *
+ * @tparam T lvalue variable type
+ * @tparam U rvalue variable type, which must be assignable to `T`
+ * @param[in,out] x lvalue
+ * @param[in] y rvalue
+ * @param[in] name Name of lvalue variable (default "ANON"); ignored
+ * @param[in] depth Indexing depth (default 0; ignored
+ */
+template <
+    typename T, typename U,
+    require_t<std::is_assignable<std::decay_t<T>&, std::decay_t<U>>>* = nullptr>
+inline void assign(T&& x, const nil_index_list& /* idxs */, U&& y,
+                   const char* name = "ANON", int depth = 0) {
+  x = std::forward<U>(y);
+}
+
+/**
+ * Assign the specified Eigen vector at the specified single index
+ * to the specified value.
+ *
+ * Types: vec[uni] <- scalar
+ *
+ * @tparam Vec1 Eigen type with either dynamic rows or columns, but not both.
+ * @tparam U Type of value (must be assignable to T).
+ * @param[in] x Vector variable to be assigned.
+ * @param[in] idxs Sequence of one single index (from 1).
+ * @param[in] y Value scalar.
+ * @param[in] name Name of variable (default "ANON").
+ * @param[in] depth Indexing depth (default 0).
+ * @throw std::out_of_range If the index is out of bounds.
+ */
+template <typename Vec1, typename U, require_eigen_vector_t<Vec1>* = nullptr,
+          require_stan_scalar_t<U>* = nullptr>
+inline void assign(Vec1&& x,
+                   const cons_index_list<index_uni, nil_index_list>& idxs,
+                   const U& y, const char* name = "ANON", int depth = 0) {
+  math::check_range("vector[uni] assign range", name, x.size(), idxs.head_.n_);
+  x.coeffRef(idxs.head_.n_ - 1) = y;
+}
+
+/**
+ * Assign a coefficient of an eigen vector to a coefficient of another
+ * eigen vector.
+ *
+ * Types: vec[uni] <- vec[uni]
+ *
+ * @tparam Vec1 Eigen type with either dynamic rows or columns, but not both.
+ * @tparam U Type of value (must be assignable to T).
+ * @param[in] x Vector variable to be assigned.
+ * @param[in] idxs Sequence of one single index (from 1).
+ * @param[in] y Value scalar.
+ * @param[in] name Name of variable (default "ANON").
+ * @param[in] depth Indexing depth (default 0).
+ * @throw std::out_of_range If the index is out of bounds.
+ */
+template <typename Vec1, typename Vec2,
+          require_all_eigen_vector_t<Vec1, Vec2>* = nullptr>
+inline void assign(Vec1&& x,
+                   const cons_index_list<index_uni, nil_index_list>& idxs,
+                   const Vec2& y, const char* name = "ANON", int depth = 0) {
+  math::check_range("vector[uni] assign range", name, x.size(), idxs.head_.n_);
+  math::check_range("vector[uni] assign range", name, y.size(), idxs.head_.n_);
+  x.coeffRef(idxs.head_.n_ - 1) = y.coeffRef(idxs.head_.n_ - 1);
+}
+
+/**
+ * Assign the specified Eigen vector at the specified multiple
+ * index to the specified value.
+ *
+ * Types:  vec[multi] <- vec
+ *
+ * @tparam Vec1 Eigen type with either dynamic rows or columns, but not both.
+ * @tparam Vec2 Eigen type with either dynamic rows or columns, but not both.
+ * @param[in] x Row vector variable to be assigned.
+ * @param[in] idxs Sequnce of cells to assign to.
+ * @param[in] y Value vector.
+ * @param[in] name Name of variable (default "ANON").
+ * @param[in] depth Indexing depth (default 0).
+ * @throw std::out_of_range If any of the indices are out of bounds.
+ * @throw std::invalid_argument If the value size isn't the same as
+ * the indexed size.
+ */
+template <typename Vec1, typename Vec2,
+          require_all_eigen_vector_t<Vec1, Vec2>* = nullptr>
+inline void assign(Vec1&& x,
+                   const cons_index_list<index_multi, nil_index_list>& idxs,
+                   const Vec2& y, const char* name = "ANON", int depth = 0) {
+  const auto& y_ref = stan::math::to_ref(y);
+  math::check_size_match("vector[multi] assign sizes", "lhs",
+                         idxs.head_.ns_.size(), name, y_ref.size());
+  const auto x_size = x.size();
+  for (int n = 0; n < y_ref.size(); ++n) {
+    math::check_range("vector[multi] assign range", name, x_size,
+                      idxs.head_.ns_[n]);
+    x.coeffRef(idxs.head_.ns_[n] - 1) = y_ref.coeffRef(n);
   }
 }
 
 /**
- * Copy the right-hand side's value to the left-hand side
- * variable.
+ * Assign the specified Eigen vector at the specified min_max
+ * index to the specified value.
  *
- * The <code>assign()</code> function is overloaded.  This
- * instance will match arguments where the right-hand side is
- * assignable to the left and they are not both
- * <code>std::vector</code> or <code>Eigen::Matrix</code> types.
+ * Types:  vec[min_max] <- vec
  *
- * @tparam T_lhs Type of left-hand side.
- * @tparam T_rhs Type of right-hand side.
- * @param x Left-hand side.
- * @param y Right-hand side.
+ * @tparam Vec1 Eigen type with either dynamic rows or columns, but not both.
+ * @tparam Vec2 Eigen type with either dynamic rows or columns, but not both.
+ * @param[in] x vector variable to be assigned.
+ * @param[in] idxs An `index_min_max`
+ * @param[in] y Value vector.
+ * @param[in] name Name of variable (default "ANON").
+ * @param[in] depth Indexing depth (default 0).
+ * @throw std::out_of_range If any of the indices are out of bounds.
+ * @throw std::invalid_argument If the value size isn't the same as
+ * the indexed size.
  */
-template <typename T_lhs, typename T_rhs,
-          require_all_stan_scalar_t<T_lhs, T_rhs>* = nullptr>
-inline void assign(T_lhs& x, const T_rhs& y) {
-  x = y;
+template <typename Vec1, typename Vec2,
+          require_all_eigen_vector_t<Vec1, Vec2>* = nullptr>
+inline void assign(Vec1&& x,
+                   const cons_index_list<index_min_max, nil_index_list>& idxs,
+                   const Vec2& y, const char* name = "ANON", int depth = 0) {
+  math::check_range("vector[min_max] min assign", name, x.size(),
+                    idxs.head_.min_);
+  math::check_range("vector[min_max] max assign", name, x.size(),
+                    idxs.head_.max_);
+  if (idxs.head_.positive_idx_) {
+    const auto slice_start = idxs.head_.min_ - 1;
+    const auto slice_size = idxs.head_.max_ - slice_start;
+    math::check_size_match("vector[min_max] assign sizes", "lhs and rhs",
+                           slice_size, name, y.size());
+    x.segment(slice_start, slice_size) = y;
+    return;
+  } else {
+    const auto slice_start = idxs.head_.max_ - 1;
+    const auto slice_size = idxs.head_.min_ - slice_start;
+    math::check_size_match("vector[reverse_min_max] assign sizes",
+                           "lhs and rhs", slice_size, name, y.size());
+    x.segment(slice_start, slice_size) = y.reverse();
+    return;
+  }
 }
 
 /**
- * Copy the right-hand side's value to the left-hand side
- * variable.
+ * Assign an
  *
- * The <code>assign()</code> function is overloaded.  This
- * instance will be called for arguments that are both
- * <code>Eigen::Matrix</code> types.
+ * Types:  vec[general] <- vec
  *
- * @tparam T_lhs type of the left-hand side matrix
- * @tparam T_rhs type of the right-hand side matrix
- *
- * @param x Left-hand side matrix.
- * @param y Right-hand side matrix.
- * @throw std::invalid_argument if sizes do not match.
+ * @tparam Vec1 Eigen type with either dynamic rows or columns, but not both.
+ * @tparam I Type of multiple index.
+ * @tparam Vec2 Eigen type with either dynamic rows or columns, but not both.
+ * @param[in] x Row vector variable to be assigned.
+ * @param[in] idxs An index.
+ * @param[in] y Value vector.
+ * @param[in] name Name of variable (default "ANON").
+ * @param[in] depth Indexing depth (default 0).
+ * @throw std::out_of_range If any of the indices are out of bounds.
+ * @throw std::invalid_argument If the value size isn't the same as
+ * the indexed size.
  */
-template <typename T_lhs, typename T_rhs,
-          require_all_eigen_t<T_lhs, T_rhs>* = nullptr>
-inline void assign(T_lhs&& x, const T_rhs& y) {
-  check_matching_dims("assign", "left-hand-side", x, "right-hand-side", y);
-  x = y.template cast<value_type_t<T_lhs>>();
+template <typename Vec1, typename Vec2, typename I,
+          require_all_eigen_vector_t<Vec1, Vec2>* = nullptr>
+inline void assign(Vec1&& x, const cons_index_list<I, nil_index_list>& idxs,
+                   const Vec2& y, const char* name = "ANON", int depth = 0) {
+  const auto& y_ref = stan::math::to_ref(y);
+  math::check_size_match("vector[...] assign sizes", "lhs",
+                         rvalue_index_size(idxs.head_, x.size()), name,
+                         y_ref.size());
+  for (int n = 0; n < y.size(); ++n) {
+    int i = rvalue_at(n, idxs.head_);
+    math::check_range("vector[...] assign range", name, x.size(), i);
+    x.coeffRef(i - 1) = y_ref.coeffRef(n);
+  }
 }
 
 /**
- * Copy the right-hand side's value to the left-hand side
- * variable.
+ * Assign a row vector to a row of an eigen matrix.
  *
- * The <code>assign()</code> function is overloaded.  This
- * instance will be called for arguments that are both
- * <code>std::vector</code>, and will call <code>assign()</code>
- * element-by element.
+ * Types:  mat[uni] = rowvec
  *
- * For example, a <code>std::vector&lt;int&gt;</code> can be
- * assigned to a <code>std::vector&lt;double&gt;</code> using this
- * function.
- *
- * @tparam T_lhs type of elements in the left-hand side vector
- * @tparam T_rhs type of elements in the right-hand side vector
- * @param x Left-hand side vector.
- * @param y Right-hand side vector.
- * @throw std::invalid_argument if sizes do not match.
+ * @tparam Mat Eigen type with dynamic rows and columns.
+ * @tparam RowVec Eigen type with dynamic columns and a compile time rows equal
+ * to 1.
+ * @param[in] x Matrix variable to be assigned.
+ * @param[in] idxs An index holding the row to be assigned to.
+ * @param[in] y Value row vector.
+ * @param[in] name Name of variable (default "ANON").
+ * @param[in] depth Indexing depth (default 0).
+ * @throw std::out_of_range If any of the indices are out of bounds.
+ * @throw std::invalid_argument If the number of columns in the row
+ * vector and matrix do not match.
  */
-template <typename T_lhs, typename T_rhs>
-inline void assign(std::vector<T_lhs>& x, const std::vector<T_rhs>& y) {
-  check_matching_sizes("assign", "left-hand side", x, "right-hand side", y);
-  for (size_t i = 0; i < x.size(); ++i) {
-    assign(x[i], y[i]);
+template <typename Mat, typename RowVec,
+          stan::internal::require_eigen_dense_dynamic_t<Mat>* = nullptr,
+          require_eigen_row_vector_t<RowVec>* = nullptr>
+inline void assign(Mat&& x,
+                   const cons_index_list<index_uni, nil_index_list>& idxs,
+                   const RowVec& y, const char* name = "ANON", int depth = 0) {
+  math::check_size_match("matrix[uni] assign sizes", "lhs", x.cols(), name,
+                         y.size());
+  math::check_range("matrix[uni] assign range", name, x.rows(), idxs.head_.n_);
+  x.row(idxs.head_.n_ - 1) = y;
+}
+
+/**
+ * Assign the specified Eigen matrix at the specified min
+ * index to the specified matrix value.
+ *
+ * Types:  mat[min] = mat
+ *
+ * @tparam Mat1 Eigen type with dynamic rows and columns.
+ * @tparam Mat2 Eigen type with dynamic rows and columns.
+ * @param[in] x Matrix variable to be assigned.
+ * @param[in] idxs An indexing from a minimum index (inclusive) to
+ * the end of a container.
+ * @param[in] y Value matrix.
+ * @param[in] name Name of variable (default "ANON").
+ * @param[in] depth Indexing depth (default 0).
+ * @throw std::out_of_range If any of the indices are out of bounds.
+ * @throw std::invalid_argument If the dimensions of the indexed
+ * matrix and right-hand side matrix do not match.
+ */
+template <
+    typename Mat1, typename Mat2,
+    stan::internal::require_all_eigen_dense_dynamic_t<Mat1, Mat2>* = nullptr,
+    require_eigen_t<Mat2>* = nullptr>
+inline void assign(Mat1&& x,
+                   const cons_index_list<index_min, nil_index_list>& idxs,
+                   const Mat2& y, const char* name = "ANON", int depth = 0) {
+  const auto start_row = idxs.head_.min_ - 1;
+  const auto row_size = x.rows() - start_row;
+  math::check_range("matrix[min] assign range", name, x.rows(), row_size);
+  math::check_size_match("matrix[min] assign row sizes", "lhs", row_size, name,
+                         y.rows());
+  math::check_size_match("matrix[min] assign col sizes", "lhs", x.cols(), name,
+                         y.cols());
+  x.block(start_row, 0, row_size, x.cols()) = y;
+}
+
+/**
+ * Assign the specified Eigen matrix at the specified max
+ * index to the specified matrix value.
+ *
+ * Types:  mat[max] = mat
+ *
+ * @tparam Mat1 Eigen type with dynamic rows and columns.
+ * @tparam Mat2 Eigen type with dynamic rows and columns.
+ * @param[in] x Matrix variable to be assigned.
+ * @param[in] idxs An indexing from the start of the container up to
+ * the specified maximum index (inclusive).
+ * @param[in] y Value matrix.
+ * @param[in] name Name of variable (default "ANON").
+ * @param[in] depth Indexing depth (default 0).
+ * @throw std::out_of_range If any of the indices are out of bounds.
+ * @throw std::invalid_argument If the dimensions of the indexed
+ * matrix and right-hand side matrix do not match.
+ */
+template <
+    typename Mat1, typename Mat2,
+    stan::internal::require_all_eigen_dense_dynamic_t<Mat1, Mat2>* = nullptr>
+inline void assign(Mat1&& x,
+                   const cons_index_list<index_max, nil_index_list>& idxs,
+                   const Mat2& y, const char* name = "ANON", int depth = 0) {
+  math::check_range("matrix[max] assign range", name, x.cols(),
+                    idxs.head_.max_);
+  math::check_size_match("matrix[max] assign row sizes", "lhs", idxs.head_.max_,
+                         name, y.rows());
+  x.block(0, 0, idxs.head_.max_, x.cols()) = y;
+}
+
+/**
+ * Assign the specified Eigen matrix at the specified min_Max
+ * index to the specified matrix value.
+ *
+ * Types:  mat[min_max] = mat
+ *
+ * @tparam Mat Eigen type with dynamic rows and columns.
+ * @tparam Mat2 Eigen type with dynamic rows and columns.
+ * @param[in] x Matrix variable to be assigned.
+ * @param[in] idxs An index for a min_max slice of rows
+ * @param[in] y Value matrix.
+ * @param[in] name Name of variable (default "ANON").
+ * @param[in] depth Indexing depth (default 0).
+ * @throw std::out_of_range If any of the indices are out of bounds.
+ * @throw std::invalid_argument If the dimensions of the indexed
+ * matrix and right-hand side matrix do not match.
+ */
+template <typename EigMat1, typename EigMat2,
+          stan::internal::require_all_eigen_dense_dynamic_t<EigMat1,
+                                                            EigMat2>* = nullptr>
+inline void assign(EigMat1&& x,
+                   const cons_index_list<index_min_max, nil_index_list>& idxs,
+                   const EigMat2& y, const char* name = "ANON", int depth = 0) {
+  math::check_range("matrix[min_max] max row indexing", name, x.rows(),
+                    idxs.head_.max_);
+  math::check_range("matrix[min_max] min row indexing", name, x.rows(),
+                    idxs.head_.min_);
+  if (idxs.head_.positive_idx_) {
+    math::check_size_match("matrix[min_max] assign row sizes", "lhs",
+                           idxs.head_.min_, name, y.rows());
+    x.block(idxs.head_.min_ - 1, 0, idxs.head_.max_ - 1, x.cols()) = y;
+    return;
+  } else {
+    math::check_size_match("matrix[reverse_min_max] assign row sizes", "lhs",
+                           idxs.head_.max_, name, y.rows());
+    x.block(idxs.head_.max_ - 1, 0, idxs.head_.min_ - 1, x.cols())
+        = y.colwise().reverse();
+    return;
+  }
+}
+
+/**
+ * Assign the specified Eigen matrix at the specified multi
+ * index to the specified matrix value.
+ *
+ * Types:  mat[multi] = mat
+ *
+ * @tparam Mat Eigen type with dynamic rows and columns.
+ * @tparam Mat2 Eigen type with dynamic rows and columns.
+ * @param[in] x Matrix variable to be assigned.
+ * @param[in] idxs An indexing from the start of the container up to
+ * the specified maximum index (inclusive).
+ * @param[in] y Value matrix.
+ * @param[in] name Name of variable (default "ANON").
+ * @param[in] depth Indexing depth (default 0).
+ * @throw std::out_of_range If any of the indices are out of bounds.
+ * @throw std::invalid_argument If the dimensions of the indexed
+ * matrix and right-hand side matrix do not match.
+ */
+template <typename EigMat1, typename EigMat2,
+          stan::internal::require_all_eigen_dense_dynamic_t<EigMat1,
+                                                            EigMat2>* = nullptr>
+inline void rvalue(EigMat1&& x,
+                   const cons_index_list<index_multi, nil_index_list>& idxs,
+                   const EigMat2& y, const char* name = "ANON", int depth = 0) {
+  const auto& y_ref = stan::math::to_ref(y);
+  math::check_size_match("matrix[multi] assign row sizes", "lhs",
+                         idxs.head_.ns_.size(), name, y.rows());
+  for (int i = 0; i < idxs.head_.ns_.size(); ++i) {
+    const int n = idxs.head_.ns_[i];
+    math::check_range("matrix[multi] subset range", name, x.rows(), n);
+    x.row(n - 1) = y_ref.row(i);
+  }
+}
+
+/**
+ * Random access assignment to an eigen matrix.
+ *
+ * Types:  mat[general] = mat
+ *
+ * @tparam Mat1 Eigen type with dynamic rows and columns.
+ * @tparam L Multiple index type.
+ * @tparam Mat2 Eigen type with dynamic rows and columns.
+ * @param[in] x Matrix variable to be assigned.
+ * @param[in] idxs Any of the index types.
+ * @param[in] y Value matrix.
+ * @param[in] name Name of variable (default "ANON").
+ * @param[in] depth Indexing depth (default 0).
+ * @throw std::out_of_range If any of the indices are out of bounds.
+ * @throw std::invalid_argument If the dimensions of the indexed
+ * matrix and right-hand side matrix do not match.
+ */
+template <
+    typename Mat1, typename L, typename Mat2,
+    stan::internal::require_all_eigen_dense_dynamic_t<Mat1, Mat2>* = nullptr>
+inline void assign(Mat1&& x, const cons_index_list<L, nil_index_list>& idxs,
+                   const Mat2& y, const char* name = "ANON", int depth = 0) {
+  const int x_idx_rows = rvalue_index_size(idxs.head_, x.rows());
+  const auto& y_ref = stan::math::to_ref(y);
+  math::check_size_match("matrix[...] assign row sizes", "lhs", x_idx_rows,
+                         name, y_ref.rows());
+  math::check_size_match("matrix[...] assign col sizes", "lhs", x.cols(), name,
+                         y_ref.cols());
+  for (int i = 0; i < y_ref.rows(); ++i) {
+    const int m = rvalue_at(i, idxs.head_);
+    math::check_range("matrix[...] assign range", name, x.rows(), m);
+    x.row(m - 1) = y_ref.row(i);
+  }
+}
+
+/**
+ * Assign the specified Eigen matrix at the min_max indices for the assignee.
+ *
+ * Types:  mat[min_max, min_max] = mat
+ *
+ * @tparam Mat1 Eigen type with dynamic rows and columns.
+ * @tparam Mat2 Eigen type with dynamic rows and columns.
+ * @param[in] x Matrix variable to be assigned.
+ * @param[in] idxs An index list containing two min_max indices
+ * @param[in] x Matrix variable to assign from.
+ * @param[in] name Name of variable (default "ANON").
+ * @param[in] depth Indexing depth (default 0).
+ * @throw std::out_of_range If any of the indices are out of bounds.
+ * @throw std::invalid_argument If the dimensions of the indexed
+ * matrix and right-hand side matrix do not match.
+ */
+template <typename Mat1, typename Mat2,
+          stan::internal::require_eigen_dense_dynamic_t<Mat1>* = nullptr,
+          require_eigen_t<Mat2>* = nullptr>
+inline void assign(
+    Mat1&& x,
+    const cons_index_list<index_min_max,
+                          cons_index_list<index_min_max, nil_index_list>>& idxs,
+    const Mat2& y, const char* name = "ANON", int depth = 0) {
+  if (idxs.head_.positive_idx_) {
+    if (idxs.tail_.head_.positive_idx_) {
+      auto row_size = idxs.head_.max_ - (idxs.head_.min_ - 1);
+      auto col_size = idxs.tail_.head_.max_ - (idxs.tail_.head_.min_ - 1);
+      math::check_range("matrix[min_max, min_max] assign col range", name,
+                        x.cols(), idxs.head_.min_);
+      math::check_range("matrix[min_max, min_max] assign row range", name,
+                        x.rows(), idxs.tail_.head_.min_);
+      math::check_size_match("matrix[min_max, min_max] assign row sizes", "lhs",
+                             row_size, name, y.rows());
+      math::check_size_match("matrix[min_max, min_max] assign col sizes", "lhs",
+                             col_size, name, y.cols());
+      x.block(idxs.head_.min_ - 1, idxs.tail_.head_.min_ - 1, row_size,
+              col_size)
+          = y;
+      return;
+    } else {
+      auto row_size = idxs.head_.max_ - (idxs.head_.min_ - 1);
+      auto col_size = idxs.tail_.head_.min_ - (idxs.tail_.head_.max_ - 1);
+      math::check_range("matrix[min_max, reverse_min_max] assign col range",
+                        name, x.cols(), idxs.head_.min_);
+      math::check_range("matrix[min_max, reverse_min_max] assign row range",
+                        name, x.rows(), idxs.tail_.head_.max_);
+      math::check_size_match(
+          "matrix[min_max, reverse_min_max] assign row sizes", "lhs", row_size,
+          name, y.rows());
+      math::check_size_match(
+          "matrix[min_max, reverse_min_max] assign col sizes", "lhs", col_size,
+          name, y.cols());
+      x.block(idxs.head_.min_ - 1, idxs.tail_.head_.max_ - 1, row_size,
+              col_size)
+          = y.rowwise().reverse();
+      return;
+    }
+  } else {
+    if (idxs.tail_.head_.positive_idx_) {
+      auto row_size = idxs.head_.min_ - (idxs.head_.max_ - 1);
+      auto col_size = idxs.tail_.head_.max_ - (idxs.tail_.head_.min_ - 1);
+      math::check_range("matrix[reverse_min_max, min_max] assign col range",
+                        name, x.cols(), idxs.head_.max_);
+      math::check_range("matrix[reverse_min_max, min_max] assign row range",
+                        name, x.rows(), idxs.tail_.head_.min_);
+      math::check_size_match(
+          "matrix[reverse_min_max, min_max] assign row sizes", "lhs", row_size,
+          name, y.rows());
+      math::check_size_match(
+          "matrix[reverse_min_max, min_max] assign col sizes", "lhs", col_size,
+          name, y.cols());
+      x.block(idxs.head_.max_ - 1, idxs.tail_.head_.min_ - 1, row_size,
+              col_size)
+          = y.colwise().reverse();
+      return;
+    } else {
+      auto row_size = idxs.head_.min_ - (idxs.head_.max_ - 1);
+      auto col_size = idxs.tail_.head_.min_ - (idxs.tail_.head_.max_ - 1);
+      math::check_range(
+          "matrix[reverse_min_max, reverse_min_max] assign col range", name,
+          x.cols(), idxs.head_.max_);
+      math::check_range(
+          "matrix[reverse_min_max, reverse_min_max] assign row range", name,
+          x.rows(), idxs.tail_.head_.max_);
+      math::check_size_match(
+          "matrix[reverse_min_max, reverse_min_max] assign row sizes", "lhs",
+          row_size, name, y.rows());
+      math::check_size_match(
+          "matrix[reverse_min_max, reverse_min_max] assign col sizes", "lhs",
+          col_size, name, y.cols());
+      x.block(idxs.head_.max_ - 1, idxs.tail_.head_.max_ - 1, row_size,
+              col_size)
+          = y.reverse();
+      return;
+    }
+  }
+}
+
+/**
+ * Assign the specified Eigen matrix at the specified pair of
+ * single indexes to the specified scalar value.
+ *
+ * Types:  mat[single, single] = scalar
+ *
+ * @tparam Mat Eigen type with dynamic rows and columns.
+ * @tparam U Scalar type.
+ * @param[in] x Matrix variable to be assigned.
+ * @param[in] idxs Sequence of two single indexes (from 1).
+ * @param[in] y Value scalar.
+ * @param[in] name Name of variable (default "ANON").
+ * @param[in] depth Indexing depth (default 0).
+ * @throw std::out_of_range If either of the indices are out of bounds.
+ */
+template <typename Mat, typename U,
+          stan::internal::require_eigen_dense_dynamic_t<Mat>* = nullptr>
+inline void assign(
+    Mat&& x,
+    const cons_index_list<index_uni,
+                          cons_index_list<index_uni, nil_index_list>>& idxs,
+    const U& y, const char* name = "ANON", int depth = 0) {
+  const int m = idxs.head_.n_;
+  const int n = idxs.tail_.head_.n_;
+  math::check_range("matrix[uni,uni] assign range", name, x.rows(), m);
+  math::check_range("matrix[uni,uni] assign range", name, x.cols(), n);
+  stan::math::to_ref(x).coeffRef(m - 1, n - 1) = y;
+}
+
+/**
+ * Random access assign of a vector's cells to a row of an eigen matrix.
+ *
+ * Types:  mat[uni, multi] = vector
+ *
+ * @tparam Mat1 Eigen type with dynamic rows and columns.
+ * @tparam Vec Eigen type with dynamic rows and columns.
+ * @param[in] x Matrix variable to be assigned.
+ * @param[in] idxs Pair of multiple indexes (from 1).
+ * @param[in] y Vector
+ * @param[in] name Name of variable (default "ANON").
+ * @param[in] depth Indexing depth (default 0).
+ * @throw std::out_of_range If any of the indices are out of bounds.
+ * @throw std::invalid_argument If the dimensions of the indexed
+ * matrix and value matrix do not match.
+ */
+template <typename Mat1, typename Vec,
+          stan::internal::require_eigen_dense_dynamic_t<Mat1>* = nullptr,
+          require_eigen_vector_t<Vec>* = nullptr>
+inline void assign(
+    Mat1&& x,
+    const cons_index_list<index_uni,
+                          cons_index_list<index_multi, nil_index_list>>& idxs,
+    const Vec& y, const char* name = "ANON", int depth = 0) {
+  const auto& y_ref = stan::math::to_ref(y);
+  math::check_range("matrix[uni, multi] assign range", name, x.cols(),
+                    idxs.head_.n_);
+  math::check_size_match("matrix[uni, multi] assign sizes", "lhs",
+                         idxs.tail_.head_.ns_.size(), name, y_ref.size());
+  for (int i = 0; i < idxs.tail_.head_.ns_.size(); ++i) {
+    math::check_range("matrix[uni, multi] assign range", name, x.cols(),
+                      idxs.tail_.head_.ns_[i]);
+    x.coeffRef(idxs.head_.n_ - 1, idxs.tail_.head_.ns_[i] - 1)
+        = y_ref.coeffRef(i);
+  }
+}
+
+/**
+ * Assign the specified Eigen matrix at the specified pair of
+ * multiple indexes to the specified matrix.
+ *
+ * Types:  mat[multi, multi] = mat
+ *
+ * @tparam Mat1 Eigen type with dynamic rows and columns.
+ * @tparam Mat2 Eigen type with dynamic rows and columns.
+ * @param[in] x Matrix variable to be assigned.
+ * @param[in] idxs Pair of multiple indexes (from 1).
+ * @param[in] y Value matrix.
+ * @param[in] name Name of variable (default "ANON").
+ * @param[in] depth Indexing depth (default 0).
+ * @throw std::out_of_range If any of the indices are out of bounds.
+ * @throw std::invalid_argument If the dimensions of the indexed
+ * matrix and value matrix do not match.
+ */
+template <
+    typename Mat1, typename Mat2,
+    stan::internal::require_all_eigen_dense_dynamic_t<Mat1, Mat2>* = nullptr>
+inline void assign(
+    Mat1&& x,
+    const cons_index_list<index_multi,
+                          cons_index_list<index_multi, nil_index_list>>& idxs,
+    const Mat2& y, const char* name = "ANON", int depth = 0) {
+  const auto& y_ref = stan::math::to_ref(y);
+  math::check_size_match("matrix[multi,multi] assign sizes", "lhs",
+                         idxs.head_.ns_.size(), name, y_ref.rows());
+  math::check_size_match("matrix[multi,multi] assign sizes", "lhs",
+                         idxs.tail_.head_.ns_.size(), name, y_ref.cols());
+  for (int j = 0; j < y_ref.cols(); ++j) {
+    const int n = idxs.tail_.head_.ns_[j];
+    math::check_range("matrix[multi,multi] assign range", name, x.cols(), n);
+    for (int i = 0; i < y_ref.rows(); ++i) {
+      const int m = idxs.head_.ns_[i];
+      math::check_range("matrix[multi,multi] assign range", name, x.rows(), m);
+      x.coeffRef(m - 1, n - 1) = y_ref.coeffRef(i, j);
+    }
+  }
+}
+
+/**
+ * Assign the specified Eigen matrix at the min_max indice for the assignee.
+ *
+ * Types:  mat[L, uni] = mat
+ *
+ * @tparam Mat1 Eigen type with dynamic rows and columns.
+ * @tparam Mat2 Eigen type with dynamic rows and columns.
+ * @tparam L The row index type
+ * @param[in] x Matrix variable to be assigned.
+ * @param[in] idxs Container holding row index and a min_max index.
+ * @param[in] y Matrix variable to assign from.
+ * @param[in] name Name of variable (default "ANON").
+ * @param[in] depth Indexing depth (default 0).
+ * @throw std::out_of_range If any of the indices are out of bounds.
+ * @throw std::invalid_argument If the dimensions of the indexed
+ * matrix and right-hand side matrix do not match.
+ */
+template <typename Mat1, typename Mat2, typename L,
+          stan::internal::require_eigen_dense_dynamic_t<Mat1>* = nullptr>
+inline void assign(
+    Mat1&& x,
+    const cons_index_list<L, cons_index_list<index_uni, nil_index_list>>& idxs,
+    const Mat2& y, const char* name = "ANON", int depth = 0) {
+  math::check_range("matrix[..., uni] assign range", name, x.cols(),
+                    idxs.tail_.head_.n_);
+  assign(x.col(idxs.tail_.head_.n_ - 1), index_list(idxs.head_), y, name,
+         depth + 1);
+  return;
+}
+
+/**
+ * Assign the specified Eigen matrix at the specified pair of
+ * multiple indexes to the specified matrix.
+ *
+ * Types:  mat[L, multi] = mat
+ *
+ * @tparam Mat1 Eigen type with dynamic rows and columns.
+ * @tparam Mat2 Eigen type with dynamic rows and columns.
+ * @tparam L The row index type
+ * @param[in] x Matrix variable to be assigned.
+ * @param[in] idxs Pair of multiple indexes (from 1).
+ * @param[in] y Value matrix.
+ * @param[in] name Name of variable (default "ANON").
+ * @param[in] depth Indexing depth (default 0).
+ * @throw std::out_of_range If any of the indices are out of bounds.
+ * @throw std::invalid_argument If the dimensions of the indexed
+ * matrix and value matrix do not match.
+ */
+template <typename Mat1, typename Mat2, typename L,
+          stan::internal::require_eigen_dense_dynamic_t<Mat1>* = nullptr>
+inline void assign(
+    Mat1&& x,
+    const cons_index_list<L, cons_index_list<index_multi, nil_index_list>>&
+        idxs,
+    const Mat2& y, const char* name = "ANON", int depth = 0) {
+  const auto& y_ref = stan::math::to_ref(y);
+  math::check_size_match("matrix[..., multi] assign sizes", "lhs",
+                         idxs.tail_.head_.ns_.size(), name, y_ref.cols());
+  for (int j = 0; j < y_ref.cols(); ++j) {
+    const int n = idxs.tail_.head_.ns_[j];
+    math::check_range("matrix[..., multi] assign range", name, x.cols(), n);
+    assign(x.col(n - 1), index_list(idxs.head_), y_ref.col(j), name, depth + 1);
+  }
+}
+
+/**
+ * Assign an Eigen matrix at the pair of multiple indexes to the specified
+ * matrix.
+ *
+ * Types:  mat[L, omni] = mat
+ *
+ * @tparam Mat1 Eigen type with dynamic rows and columns.
+ * @tparam Mat2 Eigen type with dynamic rows and columns.
+ * @tparam L The row index type
+ * @param[in] x Matrix variable to be assigned.
+ * @param[in] idxs Pair of multiple indexes (from 1).
+ * @param[in] y Value matrix.
+ * @param[in] name Name of variable (default "ANON").
+ * @param[in] depth Indexing depth (default 0).
+ * @throw std::out_of_range If any of the indices are out of bounds.
+ * @throw std::invalid_argument If the dimensions of the indexed
+ * matrix and value matrix do not match.
+ */
+template <typename Mat1, typename Mat2, typename L,
+          stan::internal::require_eigen_dense_dynamic_t<Mat1>* = nullptr>
+inline void assign(
+    Mat1&& x,
+    const cons_index_list<L, cons_index_list<index_omni, nil_index_list>>& idxs,
+    const Mat2& y, const char* name = "ANON", int depth = 0) {
+  assign(x, index_list(idxs.head_), y, name, depth + 1);
+}
+
+/**
+ * Assign to an Eigen matrix using a min_index for the columns.
+ *
+ * Types:  mat[L, min] = mat
+ *
+ * @tparam Mat1 Eigen type with dynamic rows and columns.
+ * @tparam Mat2 Eigen type with dynamic rows and columns.
+ * @tparam L The row index type
+ * @param[in] x Matrix variable to be assigned.
+ * @param[in] idxs Container holding a row index and an index from a minimum
+ * index (inclusive) to the end of a container.
+ * @param[in] y Value matrix.
+ * @param[in] name Name of variable (default "ANON").
+ * @param[in] depth Indexing depth (default 0).
+ * @throw std::out_of_range If any of the indices are out of bounds.
+ * @throw std::invalid_argument If the dimensions of the indexed
+ * matrix and right-hand side matrix do not match.
+ */
+template <typename Mat1, typename Mat2, typename L,
+          stan::internal::require_eigen_dense_dynamic_t<Mat1>* = nullptr>
+inline void assign(
+    Mat1&& x,
+    const cons_index_list<L, cons_index_list<index_min, nil_index_list>>& idxs,
+    const Mat2& y, const char* name = "ANON", int depth = 0) {
+  const auto start_col = idxs.tail_.head_.min_ - 1;
+  const auto col_size = x.cols() - start_col;
+  math::check_size_match("matrix[..., min] assign col sizes", "lhs", col_size,
+                         name, y.cols());
+  assign(x.block(0, start_col, x.rows(), col_size), index_list(idxs.head_), y,
+         name, depth + 1);
+}
+
+/**
+ * Assign to an Eigen matrix using a max_index.
+ *
+ * Types:  mat[L, max] = mat
+ *
+ * @tparam Mat1 Eigen type with dynamic rows and columns.
+ * @tparam Mat2 Eigen type with dynamic rows and columns.
+ * @tparam L The row index type
+ * @param[in] x Matrix variable to be assigned.
+ * @param[in] idxs Index holding a row index and an index from the start of the
+ * container up to the specified maximum index (inclusive).
+ * @param[in] y Value matrix.
+ * @param[in] name Name of variable (default "ANON").
+ * @param[in] depth Indexing depth (default 0).
+ * @throw std::out_of_range If any of the indices are out of bounds.
+ * @throw std::invalid_argument If the dimensions of the indexed
+ * matrix and right-hand side matrix do not match.
+ */
+template <typename Mat1, typename Mat2, typename L,
+          stan::internal::require_eigen_dense_dynamic_t<Mat1>* = nullptr>
+inline void assign(
+    Mat1&& x,
+    const cons_index_list<L, cons_index_list<index_max, nil_index_list>>& idxs,
+    const Mat2& y, const char* name = "ANON", int depth = 0) {
+  math::check_size_match("matrix[..., max] assign col size", "lhs",
+                         idxs.tail_.head_.max_, name, y.cols());
+  assign(x.block(0, 0, x.rows(), idxs.tail_.head_.max_ - 1),
+         index_list(idxs.head_), y, name, depth + 1);
+}
+
+/**
+ * Assign the specified Eigen matrix at the min_max indice for the assignee.
+ *
+ * Types:  mat[L, min_max] = mat
+ *
+ * @tparam Mat1 Eigen type with dynamic rows and columns.
+ * @tparam Mat2 Eigen type with dynamic rows and columns.
+ * @tparam L The row index type
+ * @param[in] x Matrix variable to be assigned.
+ * @param[in] idxs Container holding row index and a min_max index.
+ * @param[in] y Matrix variable to assign from.
+ * @param[in] name Name of variable (default "ANON").
+ * @param[in] depth Indexing depth (default 0).
+ * @throw std::out_of_range If any of the indices are out of bounds.
+ * @throw std::invalid_argument If the dimensions of the indexed
+ * matrix and right-hand side matrix do not match.
+ */
+template <typename Mat1, typename Mat2, typename L,
+          stan::internal::require_eigen_dense_dynamic_t<Mat1>* = nullptr>
+inline void assign(
+    Mat1&& x,
+    const cons_index_list<L, cons_index_list<index_min_max, nil_index_list>>&
+        idxs,
+    const Mat2& y, const char* name = "ANON", int depth = 0) {
+  if (idxs.tail_.head_.positive_idx_) {
+    const auto col_start = idxs.tail_.head_.min_ - 1;
+    const auto col_size = idxs.tail_.head_.max_ - col_start;
+    math::check_range("matrix[..., min_max] assign range", name, x.cols(),
+                      idxs.tail_.head_.min_);
+    math::check_range("matrix[..., min_max] assign range", name,
+                      idxs.tail_.head_.max_, x.cols());
+    math::check_size_match("matrix[..., min_max] assign col size", "lhs",
+                           idxs.tail_.head_.max_, name, x.cols());
+    assign(x.block(0, col_start, x.rows(), col_size), index_list(idxs.head_), y,
+           name, depth + 1);
+    return;
+  } else {
+    const auto col_start = idxs.tail_.head_.max_ - 1;
+    const auto col_size = idxs.tail_.head_.min_ - col_start;
+    math::check_range("matrix[..., reverse_min_max] assign range", name,
+                      x.cols(), idxs.tail_.head_.max_);
+    math::check_range("matrix[..., reverse_min_max] assign range", name,
+                      idxs.tail_.head_.min_, x.cols());
+    math::check_size_match("matrix[..., min_max] assign col size", "lhs",
+                           idxs.tail_.head_.min_, name, x.cols());
+    assign(x.block(0, col_start, x.rows(), col_size), index_list(idxs.head_),
+           y.rowwise().reverse(), name, depth + 1);
+    return;
+  }
+}
+
+/**
+ * Random access assign of a vector's cells to a column of an eigen matrix.
+ * Types:  mat[multi, uni] = vector
+ *
+ * @tparam Mat1 Eigen type with dynamic rows and columns.
+ * @tparam Vec Eigen type with dynamic rows and columns.
+ * @param[in] x Matrix variable to be assigned.
+ * @param[in] idxs Pair of multiple indexes (from 1).
+ * @param[in] y Vector
+ * @param[in] name Name of variable (default "ANON").
+ * @param[in] depth Indexing depth (default 0).
+ * @throw std::out_of_range If any of the indices are out of bounds.
+ * @throw std::invalid_argument If the dimensions of the indexed
+ * matrix and value matrix do not match.
+ */
+template <typename Mat1, typename Vec,
+          stan::internal::require_eigen_dense_dynamic_t<Mat1>* = nullptr,
+          require_eigen_vector_t<Vec>* = nullptr>
+inline void assign(
+    Mat1&& x,
+    const cons_index_list<index_multi,
+                          cons_index_list<index_uni, nil_index_list>>& idxs,
+    const Vec& y, const char* name = "ANON", int depth = 0) {
+  const auto& y_ref = stan::math::to_ref(y);
+  math::check_range("matrix[multi, uni] assign range", name, x.cols(),
+                    idxs.tail_.head_.n_);
+  math::check_size_match("matrix[multi, uni] assign sizes", "lhs",
+                         idxs.head_.ns_.size(), name, y_ref.size());
+  for (int i = 0; i < idxs.head_.ns_.size(); ++i) {
+    math::check_range("matrix[multi, uni] assign range", name, x.rows(),
+                      idxs.head_.ns_[i]);
+    x.coeffRef(idxs.head_.ns_[i] - 1, idxs.tail_.head_.n_ - 1)
+        = y_ref.coeffRef(i);
+  }
+}
+
+/**
+ * Assign an eigen matrix with two indices without a specialization.
+ *
+ * Types:  mat[general, general] = mat
+ *
+ * @tparam Mat1 Eigen type with dynamic rows and columns.
+ * @tparam I1 First index
+ * @tparam I2 Second index
+ * @tparam Mat2 Eigen type with dynamic rows and columns.
+ * @param[in] x Matrix variable to be assigned.
+ * @param[in] idxs Pair of general indexes (from 1).
+ * @param[in] y Value matrix.
+ * @param[in] name Name of variable (default "ANON").
+ * @param[in] depth Indexing depth (default 0).
+ * @throw std::out_of_range If any of the indices are out of bounds.
+ * @throw std::invalid_argument If the dimensions of the indexed
+ * matrix and value matrix do not match.
+ */
+template <
+    typename Mat1, typename I1, typename I2, typename Mat2,
+    stan::internal::require_all_eigen_dense_dynamic_t<Mat1, Mat2>* = nullptr>
+inline void assign(
+    Mat1&& x,
+    const cons_index_list<I1, cons_index_list<I2, nil_index_list>>& idxs,
+    const Mat2& y, const char* name = "ANON", int depth = 0) {
+  const int x_idxs_rows = rvalue_index_size(idxs.head_, x.rows());
+  const int x_idxs_cols = rvalue_index_size(idxs.tail_.head_, x.cols());
+  const auto& y_ref = stan::math::to_ref(y);
+  math::check_size_match("matrix[..., ...] assign sizes", "lhs", x_idxs_rows,
+                         name, y_ref.rows());
+  math::check_size_match("matrix[..., ...] assign sizes", "lhs", x_idxs_cols,
+                         name, y_ref.cols());
+  for (int j = 0; j < y_ref.cols(); ++j) {
+    const int n = rvalue_at(j, idxs.tail_.head_);
+    math::check_range("matrix[..., ...] assign range", name, x.cols(), n);
+    for (int i = 0; i < y_ref.rows(); ++i) {
+      const int m = rvalue_at(i, idxs.head_);
+      math::check_range("matrix[..., ...] assign range", name, x.rows(), m);
+      x.coeffRef(m - 1, n - 1) = y_ref.coeffRef(i, j);
+    }
+  }
+}
+
+/**
+ * Assign the specified standard vector rvalue to the specified
+ * standard vector lvalue.
+ *
+ * @tparam T lvalue container element type
+ * @tparam U rvalue container element type, which must be assignable to `T`
+ * @param[in] x lvalue variable
+ * @param[in] y rvalue variable
+ * @param[in] name name of lvalue variable (default "ANON").
+ * @param[in] depth indexing depth (default 0).
+ */
+template <typename T, typename U, require_all_std_vector_t<T, U>* = nullptr,
+          require_not_t<
+              std::is_assignable<std::decay_t<T>&, std::decay_t<U>>>* = nullptr>
+inline void assign(T&& x, const nil_index_list& /* idxs */, U&& y,
+                   const char* name = "ANON", int depth = 0) {
+  x.resize(y.size());
+  for (size_t i = 0; i < y.size(); ++i) {
+    assign(x[i], nil_index_list(), y[i], name, depth + 1);
+  }
+}
+
+/**
+ * Assign the specified array (standard vector) at the specified
+ * index list beginning with a single index to the specified value.
+ *
+ * This function operates recursively to carry out the tail
+ * indexing.
+ *
+ * Types:  x[uni | L] = y
+ *
+ * @tparam StdVec A standard vector
+ * @tparam L Type of tail of index list.
+ * @tparam U A type assignable to the value type of `StdVec`
+ * @param[in] x Array variable to be assigned.
+ * @param[in] idxs List of indexes beginning with single index
+ * (from 1).
+ * @param[in] y Value.
+ * @param[in] name Name of variable (default "ANON").
+ * @param[in] depth Indexing depth (default 0).
+ * @throw std::out_of_range If any of the indices are out of bounds.
+ * @throw std::invalid_argument If the dimensions do not match in the
+ * tail assignment.
+ */
+template <typename StdVec, typename L, typename U,
+          require_std_vector_t<StdVec>* = nullptr>
+inline void assign(StdVec&& x, const cons_index_list<index_uni, L>& idxs, U&& y,
+                   const char* name = "ANON", int depth = 0) {
+  math::check_range("vector[uni,...] assign range", name, x.size(),
+                    idxs.head_.n_);
+  assign(x[idxs.head_.n_ - 1], idxs.tail_, y, name, depth + 1);
+}
+
+/**
+ * Assign the specified array (standard vector) at the specified
+ * index list beginning with a single index to the specified value.
+ *
+ * This function operates recursively to carry out the tail
+ * indexing.
+ *
+ * Types:  x[uni | L] = y
+ *
+ * @tparam StdVec A standard vector
+ * @tparam L Type of tail of index list.
+ * @tparam U A type assignable to the value type of `StdVec`
+ * @param[in] x Array variable to be assigned.
+ * @param[in] idxs List of indexes beginning with single index
+ * (from 1).
+ * @param[in] y Value.
+ * @param[in] name Name of variable (default "ANON").
+ * @param[in] depth Indexing depth (default 0).
+ * @throw std::out_of_range If any of the indices are out of bounds.
+ * @throw std::invalid_argument If the dimensions do not match in the
+ * tail assignment.
+ */
+template <typename StdVec, typename L, typename U,
+          require_std_vector_t<StdVec>* = nullptr>
+inline void assign(StdVec&& x,
+                   const cons_index_list<index_uni, nil_index_list>& idxs,
+                   U&& y, const char* name = "ANON", int depth = 0) {
+  math::check_range("vector[uni,...] assign range", name, x.size(),
+                    idxs.head_.n_);
+  x[idxs.head_.n_ - 1] = y;
+}
+
+/**
+ * Assign the specified array (standard vector) at the specified
+ * index list beginning with a multiple index to the specified value.
+ *
+ * This function operates recursively to carry out the tail
+ * indexing.
+ *
+ * Types:  x[general | L] = y
+ *
+ * @tparam T A standard vector.
+ * @tparam I Type of multiple index heading index list.
+ * @tparam L Type of tail of index list.
+ * @tparam U A standard vector
+ * @param[in] x Array variable to be assigned.
+ * @param[in] idxs List of indexes beginning with multiple index
+ * (from 1).
+ * @param[in] y Value.
+ * @param[in] name Name of variable (default "ANON").
+ * @param[in] depth Indexing depth (default 0).
+ * @throw std::out_of_range If any of the indices are out of bounds.
+ * @throw std::invalid_argument If the size of the multiple indexing
+ * and size of first dimension of value do not match, or any of
+ * the recursive tail assignment dimensions do not match.
+ */
+template <typename T, typename I, typename L, typename U,
+          require_all_std_vector_t<T, U>* = nullptr>
+inline void assign(T&& x, const cons_index_list<I, L>& idxs, U&& y,
+                   const char* name = "ANON", int depth = 0) {
+  int x_idx_size = rvalue_index_size(idxs.head_, x.size());
+  math::check_size_match("vector[multi,...] assign sizes", "lhs", x_idx_size,
+                         name, y.size());
+  for (size_t n = 0; n < y.size(); ++n) {
+    int i = rvalue_at(n, idxs.head_);
+    math::check_range("vector[multi,...] assign range", name, x.size(), i);
+    assign(x[i - 1], idxs.tail_, y[n], name, depth + 1);
   }
 }
 
 }  // namespace math
 }  // namespace stan
-
 #endif

--- a/stan/math/prim/fun/deep_copy.hpp
+++ b/stan/math/prim/fun/deep_copy.hpp
@@ -1,7 +1,6 @@
 #ifndef STAN_MATH_PRIM_FUN_DEEP_COPY_HPP
 #define STAN_MATH_PRIM_FUN_DEEP_COPY_HPP
 
-
 #include <stan/math/prim/fun/Eigen.hpp>
 #include <stan/math/prim/meta.hpp>
 #include <vector>
@@ -27,6 +26,6 @@ inline plain_type_t<T> deep_copy(T&& x) {
   return std::forward<T>(x);
 }
 
-}  // namespace model
+}  // namespace math
 }  // namespace stan
 #endif

--- a/stan/math/prim/fun/deep_copy.hpp
+++ b/stan/math/prim/fun/deep_copy.hpp
@@ -1,0 +1,32 @@
+#ifndef STAN_MATH_PRIM_FUN_DEEP_COPY_HPP
+#define STAN_MATH_PRIM_FUN_DEEP_COPY_HPP
+
+
+#include <stan/math/prim/fun/Eigen.hpp>
+#include <stan/math/prim/meta.hpp>
+#include <vector>
+
+namespace stan {
+
+namespace math {
+
+/**
+ * Return the specified argument as a constant reference.
+ *
+ * <p>Warning: because of the usage pattern of this class, this
+ * function only needs to return value references, not actual
+ * copies.  The functions that call this overload recursively will
+ * be doing the actual copies with assignment.
+ *
+ * @tparam T Any type.
+ * @param x Input value.
+ * @return Copy of input.
+ */
+template <typename T>
+inline plain_type_t<T> deep_copy(T&& x) {
+  return std::forward<T>(x);
+}
+
+}  // namespace model
+}  // namespace stan
+#endif

--- a/stan/math/prim/fun/index.hpp
+++ b/stan/math/prim/fun/index.hpp
@@ -1,0 +1,104 @@
+#ifndef STAN_MODEL_INDEXING_INDEX_HPP
+#define STAN_MODEL_INDEXING_INDEX_HPP
+
+#include <vector>
+#include <stan/math/prim/meta.hpp>
+namespace stan {
+
+namespace model {
+
+// SINGLE INDEXING (reduces dimensionality)
+
+/**
+ * Structure for an indexing consisting of a single index.
+ * Applying this index reduces the dimensionality of the container
+ * to which it is applied by one.
+ */
+struct index_uni {
+  int n_;
+
+  /**
+   * Construct a single indexing from the specified index.
+   *
+   * @param n single index.
+   */
+  explicit constexpr index_uni(int n) : n_(n) {}
+};
+
+// MULTIPLE INDEXING (does not reduce dimensionality)
+
+/**
+ * Structure for an indexing consisting of multiple indexes.  The
+ * indexes do not need to be unique or in order.
+ */
+struct index_multi {
+  std::vector<int> ns_;
+
+  /**
+   * Construct a multiple indexing from the specified indexes.
+   *
+   * @param ns multiple indexes.
+   */
+  template <typename T, require_std_vector_vt<std::is_integral, T>* = nullptr>
+  explicit constexpr index_multi(T&& ns) : ns_(std::forward<T>(ns)) {}
+};
+
+/**
+ * Structure for an indexing that consists of all indexes for a
+ * container.  Applying this index is a no-op.
+ */
+struct index_omni {};
+
+/**
+ * Structure for an indexing from a minimum index (inclusive) to
+ * the end of a container.
+ */
+struct index_min {
+  int min_;
+
+  /**
+   * Construct an indexing from the specified minimum index (inclusive).
+   *
+   * @param min minimum index (inclusive).
+   */
+  explicit constexpr index_min(int min) : min_(min) {}
+};
+
+/**
+ * Structure for an indexing from the start of a container to a
+ * specified maximum index (inclusive).
+ */
+struct index_max {
+  int max_;
+
+  /**
+   * Construct an indexing from the start of the container up to
+   * the specified maximum index (inclusive).
+   *
+   * @param max maximum index (inclusive).
+   */
+  explicit constexpr index_max(int max) : max_(max) {}
+};
+
+/**
+ * Structure for an indexing from a minimum index (inclusive) to a
+ * maximum index (inclusive).
+ */
+struct index_min_max {
+  int min_;
+  int max_;
+  bool positive_idx_{true};  // If true min <= max
+  /**
+   * Construct an indexing from the specified minimum index
+   * (inclusive) and maximum index (inclusive).
+   *
+   * @param min minimum index (inclusive).
+   * @param max maximum index (inclusive).
+   */
+  explicit constexpr index_min_max(int min, int max)
+      : min_(min), max_(max), positive_idx_(min <= max) {}
+};
+
+}  // namespace model
+}  // namespace stan
+#endif

--- a/stan/math/prim/fun/index_list.hpp
+++ b/stan/math/prim/fun/index_list.hpp
@@ -16,9 +16,9 @@ namespace math {
  * @param idx2 second index placed in `tail_`
  */
 template <typename T1, typename T2>
-inline constexpr auto cons_list(T1&& idx1, T2&& t) {
+inline constexpr auto cons_list(T1&& idx1, T2&& idx2) {
   return cons_index_list<std::decay_t<T1>, std::decay_t<T2>>(
-      std::forward<T1>(idx1), std::forward<T2>(t));
+      std::forward<T1>(idx1), std::forward<T2>(idx2));
 }
 
 /**

--- a/stan/math/prim/fun/index_list.hpp
+++ b/stan/math/prim/fun/index_list.hpp
@@ -1,46 +1,25 @@
-#ifndef STAN_MODEL_INDEXING_INDEX_LIST_HPP
-#define STAN_MODEL_INDEXING_INDEX_LIST_HPP
+#ifndef STAN_MATH_PRIM_FUN_INDEX_LIST_HPP
+#define STAN_MATH_PRIM_FUN_INDEX_LIST_HPP
 
+#include <stan/math/prim/meta.hpp>
 #include <utility>
 #include <type_traits>
 
 namespace stan {
-namespace model {
+namespace math {
+
 
 /**
- * Structure for an empty (size zero) index list.
+ * Construct a pack of indices.
+ * @tparam T1 The first index type.
+ * @tparam T2 The second index type.
+ * @param idx1 first index placed in `head_`
+ * @param idx2 second index placed in `tail_`
  */
-struct nil_index_list {};
-
-/**
- * Template structure for an index list consisting of a head and
- * tail index.
- *
- * @tparam H type of index stored as the head of the list.
- * @tparam T type of index list stored as the tail of the list.
- */
-template <typename H, typename T>
-struct cons_index_list {
-  std::decay_t<H> head_;
-  std::decay_t<T> tail_;
-
-  /**
-   * Construct a non-empty index list with the specified index for
-   * a head and specified index list for a tail.
-   *
-   * @param head Index for head.
-   * @param tail Index list for tail.
-   */
-  template <typename Head, typename Tail>
-  explicit constexpr cons_index_list(Head&& head, Tail&& tail)
-      : head_(std::forward<Head>(head)), tail_(std::forward<Tail>(tail)) {}
-};
-
-// factory-like function does type inference for I and T
-template <typename I, typename T>
-inline constexpr auto cons_list(I&& idx1, T&& t) {
-  return cons_index_list<std::decay_t<I>, std::decay_t<T>>(
-      std::forward<I>(idx1), std::forward<T>(t));
+template <typename T1, typename T2>
+inline constexpr auto cons_list(T1&& idx1, T2&& t) {
+  return cons_index_list<std::decay_t<T1>, std::decay_t<T2>>(
+      std::forward<T1>(idx1), std::forward<T2>(t));
 }
 
 /**
@@ -56,10 +35,10 @@ inline constexpr auto index_list() { return nil_index_list(); }
  * @param idx2 A parameter pack expanded and recursivly called into
  *  `index_list()`
  */
-template <typename I1, typename... I2>
-inline constexpr auto index_list(I1&& idx1, I2&&... idx2) {
-  return cons_list(std::forward<I1>(idx1),
-                   index_list(std::forward<I2>(idx2)...));
+template <typename T, typename... Types>
+inline constexpr auto index_list(T&& idx1, Types&&... idx2) {
+  return cons_list(std::forward<T>(idx1),
+                   index_list(std::forward<Types>(idx2)...));
 }
 
 }  // namespace model

--- a/stan/math/prim/fun/index_list.hpp
+++ b/stan/math/prim/fun/index_list.hpp
@@ -8,7 +8,6 @@
 namespace stan {
 namespace math {
 
-
 /**
  * Construct a pack of indices.
  * @tparam T1 The first index type.
@@ -41,6 +40,6 @@ inline constexpr auto index_list(T&& idx1, Types&&... idx2) {
                    index_list(std::forward<Types>(idx2)...));
 }
 
-}  // namespace model
+}  // namespace math
 }  // namespace stan
 #endif

--- a/stan/math/prim/fun/index_list.hpp
+++ b/stan/math/prim/fun/index_list.hpp
@@ -1,0 +1,67 @@
+#ifndef STAN_MODEL_INDEXING_INDEX_LIST_HPP
+#define STAN_MODEL_INDEXING_INDEX_LIST_HPP
+
+#include <utility>
+#include <type_traits>
+
+namespace stan {
+namespace model {
+
+/**
+ * Structure for an empty (size zero) index list.
+ */
+struct nil_index_list {};
+
+/**
+ * Template structure for an index list consisting of a head and
+ * tail index.
+ *
+ * @tparam H type of index stored as the head of the list.
+ * @tparam T type of index list stored as the tail of the list.
+ */
+template <typename H, typename T>
+struct cons_index_list {
+  std::decay_t<H> head_;
+  std::decay_t<T> tail_;
+
+  /**
+   * Construct a non-empty index list with the specified index for
+   * a head and specified index list for a tail.
+   *
+   * @param head Index for head.
+   * @param tail Index list for tail.
+   */
+  template <typename Head, typename Tail>
+  explicit constexpr cons_index_list(Head&& head, Tail&& tail)
+      : head_(std::forward<Head>(head)), tail_(std::forward<Tail>(tail)) {}
+};
+
+// factory-like function does type inference for I and T
+template <typename I, typename T>
+inline constexpr auto cons_list(I&& idx1, T&& t) {
+  return cons_index_list<std::decay_t<I>, std::decay_t<T>>(
+      std::forward<I>(idx1), std::forward<T>(t));
+}
+
+/**
+ * Expansion stop for index_list returning back a `nul_index_list`
+ */
+inline constexpr auto index_list() { return nil_index_list(); }
+
+/**
+ * Factory-like function to construct a `cons_index_list` of `cons_index_list`s
+ * @tparam I1 First index type
+ * @tparam I2 Parameter pack of index types.
+ * @param idx1 First index to construct the cons_index_list.
+ * @param idx2 A parameter pack expanded and recursivly called into
+ *  `index_list()`
+ */
+template <typename I1, typename... I2>
+inline constexpr auto index_list(I1&& idx1, I2&&... idx2) {
+  return cons_list(std::forward<I1>(idx1),
+                   index_list(std::forward<I2>(idx2)...));
+}
+
+}  // namespace model
+}  // namespace stan
+#endif

--- a/stan/math/prim/fun/rvalue_at.hpp
+++ b/stan/math/prim/fun/rvalue_at.hpp
@@ -1,0 +1,91 @@
+#ifndef STAN_MODEL_INDEXING_RVALUE_AT_HPP
+#define STAN_MODEL_INDEXING_RVALUE_AT_HPP
+
+#include <stan/model/indexing/index.hpp>
+
+namespace stan {
+
+namespace internal {
+
+template <typename T>
+using is_eigen_dense_dynamic = stan::internal::is_eigen_matrix_dynamic_impl<
+    std::decay_t<T>,
+    stan::is_eigen_dense_base<T>::value && stan::is_eigen<T>::value>;
+
+template <typename T>
+using require_eigen_dense_dynamic_t = require_t<is_eigen_dense_dynamic<T>>;
+
+template <typename... Types>
+using require_all_eigen_dense_dynamic_t
+    = require_all_t<is_eigen_dense_dynamic<Types>...>;
+
+}  // namespace internal
+
+namespace model {
+
+// relative indexing from 0; multi-indexing and return from 1
+// no error checking from these methods, just indexing
+
+/**
+ * Return the index in the underlying array corresponding to the
+ * specified position in the specified multi-index.
+ *
+ * @param[in] n Relative index position (from 0).
+ * @param[in] idx Index (from 1).
+ * @return Underlying index position (from 1).
+ */
+inline int rvalue_at(int n, const index_multi& idx) { return idx.ns_[n]; }
+
+/**
+ * Return the index in the underlying array corresponding to the
+ * specified position in the specified omni-index.
+ *
+ * @param[in] n Relative index position (from 0).
+ * @param[in] idx Index (from 1).
+ * @return Underlying index position (from 1).
+ */
+inline constexpr int rvalue_at(int n, const index_omni& idx) { return n + 1; }
+
+/**
+ * Return the index in the underlying array corresponding to the
+ * specified position in the specified min-index.
+ *
+ * All indexing begins from 1.
+ *
+ * @param[in] n Relative index position (from 0).
+ * @param[in] idx Index (from 1)
+ * @return Underlying index position (from 1).
+ */
+inline constexpr int rvalue_at(int n, const index_min& idx) {
+  return idx.min_ + n;
+}
+
+/**
+ * Return the index in the underlying array corresponding to the
+ * specified position in the specified max-index.
+ *
+ * All indexing begins from 1.
+ *
+ * @param[in] n Relative index position (from 0).
+ * @param[in] idx Index (from 1).
+ * @return Underlying index position (from 1).
+ */
+inline constexpr int rvalue_at(int n, const index_max& idx) { return n + 1; }
+
+/**
+ * Return the index in the underlying array corresponding to the
+ * specified position in the specified min-max-index.
+ *
+ * All indexing begins from 1.
+ *
+ * @param[in] n Relative index position (from 0).
+ * @param[in] idx Index (from 1).
+ * @return Underlying index position (from 1).
+ */
+inline constexpr int rvalue_at(int n, const index_min_max& idx) {
+  return idx.min_ + n;
+}
+
+}  // namespace model
+}  // namespace stan
+#endif

--- a/stan/math/prim/fun/rvalue_at.hpp
+++ b/stan/math/prim/fun/rvalue_at.hpp
@@ -70,6 +70,6 @@ inline constexpr int rvalue_at(int n, const index_min_max& idx) {
   return idx.min_ + n;
 }
 
-}  // namespace model
+}  // namespace math
 }  // namespace stan
 #endif

--- a/stan/math/prim/fun/rvalue_at.hpp
+++ b/stan/math/prim/fun/rvalue_at.hpp
@@ -1,27 +1,11 @@
 #ifndef STAN_MODEL_INDEXING_RVALUE_AT_HPP
 #define STAN_MODEL_INDEXING_RVALUE_AT_HPP
 
-#include <stan/model/indexing/index.hpp>
+#include <stan/math/prim/meta.hpp>
 
 namespace stan {
 
-namespace internal {
-
-template <typename T>
-using is_eigen_dense_dynamic = stan::internal::is_eigen_matrix_dynamic_impl<
-    std::decay_t<T>,
-    stan::is_eigen_dense_base<T>::value && stan::is_eigen<T>::value>;
-
-template <typename T>
-using require_eigen_dense_dynamic_t = require_t<is_eigen_dense_dynamic<T>>;
-
-template <typename... Types>
-using require_all_eigen_dense_dynamic_t
-    = require_all_t<is_eigen_dense_dynamic<Types>...>;
-
-}  // namespace internal
-
-namespace model {
+namespace math {
 
 // relative indexing from 0; multi-indexing and return from 1
 // no error checking from these methods, just indexing

--- a/stan/math/prim/fun/rvalue_index_size.hpp
+++ b/stan/math/prim/fun/rvalue_index_size.hpp
@@ -67,6 +67,6 @@ inline constexpr int rvalue_index_size(const index_min_max& idx, int size) {
   return (idx.max_ < idx.min_) ? 0 : (idx.max_ - idx.min_ + 1);
 }
 
-}  // namespace model
+}  // namespace math
 }  // namespace stan
 #endif

--- a/stan/math/prim/fun/rvalue_index_size.hpp
+++ b/stan/math/prim/fun/rvalue_index_size.hpp
@@ -1,0 +1,72 @@
+#ifndef STAN_MODEL_INDEXING_RVALUE_INDEX_SIZE_HPP
+#define STAN_MODEL_INDEXING_RVALUE_INDEX_SIZE_HPP
+
+#include <stan/model/indexing/index.hpp>
+
+namespace stan {
+
+namespace model {
+
+// no error checking
+
+/**
+ * Return size of specified multi-index.
+ *
+ * @param[in] idx Input index (from 1).
+ * @param[in] size Size of container (ignored here).
+ * @return Size of result.
+ */
+inline int rvalue_index_size(const index_multi& idx, int size) {
+  return idx.ns_.size();
+}
+
+/**
+ * Return size of specified omni-index for specified size of
+ * input.
+ *
+ * @param[in] idx Input index (from 1).
+ * @param[in] size Size of container.
+ * @return Size of result.
+ */
+inline constexpr int rvalue_index_size(const index_omni& idx, int size) {
+  return size;
+}
+
+/**
+ * Return size of specified min index for specified size of
+ * input.
+ *
+ * @param[in] idx Input index (from 1).
+ * @param[in] size Size of container.
+ * @return Size of result.
+ */
+inline constexpr int rvalue_index_size(const index_min& idx, int size) {
+  return size - idx.min_ + 1;
+}
+
+/**
+ * Return size of specified max index.
+ *
+ * @param[in] idx Input index (from 1).
+ * @param[in] size Size of container (ignored).
+ * @return Size of result.
+ */
+inline constexpr int rvalue_index_size(const index_max& idx, int size) {
+  return idx.max_;
+}
+
+/**
+ * Return size of specified min - max index.  If the maximum value
+ * index is less than the minimum index, the size will be zero.
+ *
+ * @param[in] idx Input index (from 1).
+ * @param[in] size Size of container (ignored).
+ * @return Size of result.
+ */
+inline constexpr int rvalue_index_size(const index_min_max& idx, int size) {
+  return (idx.max_ < idx.min_) ? 0 : (idx.max_ - idx.min_ + 1);
+}
+
+}  // namespace model
+}  // namespace stan
+#endif

--- a/stan/math/prim/fun/rvalue_index_size.hpp
+++ b/stan/math/prim/fun/rvalue_index_size.hpp
@@ -1,11 +1,11 @@
 #ifndef STAN_MODEL_INDEXING_RVALUE_INDEX_SIZE_HPP
 #define STAN_MODEL_INDEXING_RVALUE_INDEX_SIZE_HPP
 
-#include <stan/model/indexing/index.hpp>
+#include <stan/math/prim/meta.hpp>
 
 namespace stan {
 
-namespace model {
+namespace math {
 
 // no error checking
 

--- a/stan/math/prim/meta.hpp
+++ b/stan/math/prim/meta.hpp
@@ -184,6 +184,7 @@
 #include <stan/math/prim/meta/forward_as.hpp>
 #include <stan/math/prim/meta/holder.hpp>
 #include <stan/math/prim/meta/include_summand.hpp>
+#include <stan/math/prim/meta/index.hpp>
 #include <stan/math/prim/meta/index_type.hpp>
 #include <stan/math/prim/meta/index_apply.hpp>
 #include <stan/math/prim/meta/is_autodiff.hpp>
@@ -195,6 +196,7 @@
 #include <stan/math/prim/meta/is_container.hpp>
 #include <stan/math/prim/meta/is_eigen.hpp>
 #include <stan/math/prim/meta/is_eigen_dense_base.hpp>
+#include <stan/math/prim/meta/is_eigen_dense_dynamic.hpp>
 #include <stan/math/prim/meta/is_eigen_matrix.hpp>
 #include <stan/math/prim/meta/is_eigen_matrix_base.hpp>
 #include <stan/math/prim/meta/is_eigen_sparse_base.hpp>

--- a/stan/math/prim/meta/index.hpp
+++ b/stan/math/prim/meta/index.hpp
@@ -36,7 +36,6 @@ struct cons_index_list {
       : head_(std::forward<Head>(head)), tail_(std::forward<Tail>(tail)) {}
 };
 
-
 /**
  * Structure for an indexing consisting of a single index.
  * Applying this index reduces the dimensionality of the container
@@ -118,9 +117,7 @@ struct index_min_max {
   /**
    * Return whether the index is positive or negative
    */
-  bool is_positive_idx() const {
-    return min_ <= max_;
-  }
+  bool is_positive_idx() const { return min_ <= max_; }
   /**
    * Construct an indexing from the specified minimum index
    * (inclusive) and maximum index (inclusive).
@@ -128,10 +125,9 @@ struct index_min_max {
    * @param min minimum index (inclusive).
    * @param max maximum index (inclusive).
    */
-  constexpr index_min_max(int min, int max) noexcept
-      : min_(min), max_(max) {}
+  constexpr index_min_max(int min, int max) noexcept : min_(min), max_(max) {}
 };
 
-}  // namespace model
+}  // namespace math
 }  // namespace stan
 #endif

--- a/stan/math/prim/meta/index.hpp
+++ b/stan/math/prim/meta/index.hpp
@@ -1,13 +1,41 @@
-#ifndef STAN_MODEL_INDEXING_INDEX_HPP
-#define STAN_MODEL_INDEXING_INDEX_HPP
+#ifndef STAN_MATH_PRIM_META_INDEX_HPP
+#define STAN_MATH_PRIM_META_INDEX_HPP
 
+#include <stan/math/prim/meta/is_vector.hpp>
 #include <vector>
-#include <stan/math/prim/meta.hpp>
+
 namespace stan {
+namespace math {
 
-namespace model {
+/**
+ * Structure for an empty (size zero) index list.
+ */
+struct nil_index_list {};
 
-// SINGLE INDEXING (reduces dimensionality)
+/**
+ * Template structure for an index list consisting of a head and
+ * tail index.
+ *
+ * @tparam H type of index stored as the head of the list.
+ * @tparam T type of index list stored as the tail of the list.
+ */
+template <typename H, typename T>
+struct cons_index_list {
+  std::decay_t<H> head_;
+  std::decay_t<T> tail_;
+
+  /**
+   * Construct a non-empty index list with the specified index for
+   * a head and specified index list for a tail.
+   *
+   * @param head Index for head.
+   * @param tail Index list for tail.
+   */
+  template <typename Head, typename Tail>
+  explicit constexpr cons_index_list(Head&& head, Tail&& tail) noexcept
+      : head_(std::forward<Head>(head)), tail_(std::forward<Tail>(tail)) {}
+};
+
 
 /**
  * Structure for an indexing consisting of a single index.
@@ -22,7 +50,7 @@ struct index_uni {
    *
    * @param n single index.
    */
-  explicit constexpr index_uni(int n) : n_(n) {}
+  explicit constexpr index_uni(int n) noexcept : n_(n) {}
 };
 
 // MULTIPLE INDEXING (does not reduce dimensionality)
@@ -40,7 +68,7 @@ struct index_multi {
    * @param ns multiple indexes.
    */
   template <typename T, require_std_vector_vt<std::is_integral, T>* = nullptr>
-  explicit constexpr index_multi(T&& ns) : ns_(std::forward<T>(ns)) {}
+  explicit constexpr index_multi(T&& ns) noexcept : ns_(std::forward<T>(ns)) {}
 };
 
 /**
@@ -61,7 +89,7 @@ struct index_min {
    *
    * @param min minimum index (inclusive).
    */
-  explicit constexpr index_min(int min) : min_(min) {}
+  explicit constexpr index_min(int min) noexcept : min_(min) {}
 };
 
 /**
@@ -77,7 +105,7 @@ struct index_max {
    *
    * @param max maximum index (inclusive).
    */
-  explicit constexpr index_max(int max) : max_(max) {}
+  explicit constexpr index_max(int max) noexcept : max_(max) {}
 };
 
 /**
@@ -87,7 +115,12 @@ struct index_max {
 struct index_min_max {
   int min_;
   int max_;
-  bool positive_idx_{true};  // If true min <= max
+  /**
+   * Return whether the index is positive or negative
+   */
+  bool is_positive_idx() const {
+    return min_ <= max_;
+  }
   /**
    * Construct an indexing from the specified minimum index
    * (inclusive) and maximum index (inclusive).
@@ -95,8 +128,8 @@ struct index_min_max {
    * @param min minimum index (inclusive).
    * @param max maximum index (inclusive).
    */
-  explicit constexpr index_min_max(int min, int max)
-      : min_(min), max_(max), positive_idx_(min <= max) {}
+  constexpr index_min_max(int min, int max) noexcept
+      : min_(min), max_(max) {}
 };
 
 }  // namespace model

--- a/stan/math/prim/meta/is_eigen_dense_dynamic.hpp
+++ b/stan/math/prim/meta/is_eigen_dense_dynamic.hpp
@@ -1,0 +1,34 @@
+#ifndef STAN_MATH_PRIM_META_IS_EIGEN_DENSE_DYNAMIC_HPP
+#define STAN_MATH_PRIM_META_IS_EIGEN_DENSE_DYNAMIC_HPP
+
+#include <stan/math/prim/fun/Eigen.hpp>
+#include <stan/math/prim/meta/bool_constant.hpp>
+#include <stan/math/prim/meta/is_eigen_matrix.hpp>
+#include <stan/math/prim/meta/is_eigen_dense_base.hpp>
+#include <stan/math/prim/meta/is_base_pointer_convertible.hpp>
+#include <stan/math/prim/meta/require_helpers.hpp>
+#include <type_traits>
+
+namespace stan {
+
+/**
+ * Checks whether type T is derived from Eigen::DenseBase and has dynamic rows
+ * and columns. If true this will have a static member function named value with
+ * a type of true, else value is false.
+ * @tparam T Type to check
+ * @tparam Enable used for SFINAE deduction.
+ * @ingroup type_trait
+ */
+template <typename T>
+using is_eigen_dense_dynamic = stan::internal::is_eigen_matrix_dynamic_impl<
+    std::decay_t<std::decay_t<T>>,
+    stan::is_eigen_dense_base<std::decay_t<T>>::value>;
+
+STAN_ADD_REQUIRE_UNARY(eigen_dense_dynamic, is_eigen_dense_dynamic,
+                       require_eigens_types);
+STAN_ADD_REQUIRE_CONTAINER(eigen_dense_dynamic, is_eigen_dense_dynamic,
+                           require_eigens_types);
+
+}  // namespace stan
+
+#endif

--- a/stan/math/prim/meta/require_generics.hpp
+++ b/stan/math/prim/meta/require_generics.hpp
@@ -12,30 +12,25 @@ STAN_ADD_REQUIRE_BINARY_INNER(same, std::is_same, require_std);
 STAN_ADD_REQUIRE_BINARY(convertible, std::is_convertible, require_std);
 STAN_ADD_REQUIRE_BINARY_INNER(convertible, std::is_convertible, require_std);
 
-
 /*! ingroup require_std */
 /*! defgroup assignable_types check_type  */
 /*! addtogroup assignable_types */
 /*! @{ */
 /*! brief Require types `T` and `S` satisfies `std::is_assignable` */
 template <typename T, typename S>
-using require_assignable_t
-    = require_t<std::is_assignable<T, S>>;
+using require_assignable_t = require_t<std::is_assignable<T, S>>;
 
 /*! brief Require types `T` and `S` does not satisfy `std::is_assignable` */
 template <typename T, typename S>
-using require_not_assignable_t
-    = require_not_t<std::is_assignable<T, S>>;
+using require_not_assignable_t = require_not_t<std::is_assignable<T, S>>;
 
 /*! brief Require `T` and all of the `Types` satisfy `std::is_assignable` */
 template <typename T, typename... Types>
-using require_all_assignable_t
-    = require_all_t<std::is_assignable<T, Types>...>;
+using require_all_assignable_t = require_all_t<std::is_assignable<T, Types>...>;
 
 /*! brief Require any of the `Types` and `T` satisfy `std::is_assignable` */
 template <typename T, typename... Types>
-using require_any_assignable_t
-    = require_any_t<std::is_assignable<T, Types>...>;
+using require_any_assignable_t = require_any_t<std::is_assignable<T, Types>...>;
 
 /*! brief Require none of the `Types` and `T` satisfy `std::is_assignable` */
 template <typename T, typename... Types>

--- a/stan/math/prim/meta/require_generics.hpp
+++ b/stan/math/prim/meta/require_generics.hpp
@@ -12,6 +12,42 @@ STAN_ADD_REQUIRE_BINARY_INNER(same, std::is_same, require_std);
 STAN_ADD_REQUIRE_BINARY(convertible, std::is_convertible, require_std);
 STAN_ADD_REQUIRE_BINARY_INNER(convertible, std::is_convertible, require_std);
 
+
+/*! ingroup require_std */
+/*! defgroup assignable_types check_type  */
+/*! addtogroup assignable_types */
+/*! @{ */
+/*! brief Require types `T` and `S` satisfies `std::is_assignable` */
+template <typename T, typename S>
+using require_assignable_t
+    = require_t<std::is_assignable<T, S>>;
+
+/*! brief Require types `T` and `S` does not satisfy `std::is_assignable` */
+template <typename T, typename S>
+using require_not_assignable_t
+    = require_not_t<std::is_assignable<T, S>>;
+
+/*! brief Require `T` and all of the `Types` satisfy `std::is_assignable` */
+template <typename T, typename... Types>
+using require_all_assignable_t
+    = require_all_t<std::is_assignable<T, Types>...>;
+
+/*! brief Require any of the `Types` and `T` satisfy `std::is_assignable` */
+template <typename T, typename... Types>
+using require_any_assignable_t
+    = require_any_t<std::is_assignable<T, Types>...>;
+
+/*! brief Require none of the `Types` and `T` satisfy `std::is_assignable` */
+template <typename T, typename... Types>
+using require_all_not_assignable_t
+    = require_all_not_t<std::is_assignable<T, Types>...>;
+
+/*! brief Any one of the `Types` and `T` do not satisfy `std::is_assignable` */
+template <typename T, typename... Types>
+using require_any_not_assignable_t
+    = require_any_not_t<std::is_assignable<T, Types>...>;
+/*! @} */
+
 STAN_ADD_REQUIRE_UNARY(arithmetic, std::is_arithmetic,
                        require_stan_scalar_real);
 STAN_ADD_REQUIRE_UNARY_INNER(arithmetic, std::is_arithmetic,

--- a/test/unit/math/mix/meta/is_eigen_dense_dynamic_test.cpp
+++ b/test/unit/math/mix/meta/is_eigen_dense_dynamic_test.cpp
@@ -1,0 +1,58 @@
+#include <stan/math/mix.hpp>
+#include <test/unit/math/mix/meta/eigen_utils.hpp>
+#include <Eigen/Sparse>
+#include <gtest/gtest.h>
+
+TEST(MathMetaPrim, is_eigen_dense_dynamic_hierarchy_tests) {
+  using Eigen::Array;
+  using Eigen::Matrix;
+  using stan::is_eigen_dense_dynamic;
+  using stan::math::test::all_eigen_dense;
+  all_eigen_dense<false, true, true, true, true, is_eigen_dense_dynamic, Matrix,
+                  -1, -1>();
+  all_eigen_dense<false, false, false, false, false, is_eigen_dense_dynamic,
+                  Matrix, 1, -1>();
+  all_eigen_dense<false, false, false, false, false, is_eigen_dense_dynamic,
+                  Matrix, -1, 1>();
+  all_eigen_dense<false, true, true, true, true, is_eigen_dense_dynamic, Array,
+                  -1, -1>();
+  all_eigen_dense<false, false, false, false, false, is_eigen_dense_dynamic,
+                  Array, 1, -1>();
+  all_eigen_dense<false, false, false, false, false, is_eigen_dense_dynamic,
+                  Array, -1, 1>();
+}
+
+TEST(MathMetaPrim, is_eigen_dense_dynamic_sparse_tests) {
+  using Eigen::Array;
+  using Eigen::Matrix;
+  using stan::is_eigen_dense_dynamic;
+  using stan::math::test::all_eigen_sparse;
+  all_eigen_sparse<false, false, false, false, is_eigen_dense_dynamic>();
+}
+
+TEST(MathMetaPrim, is_eigen_dense_dynamic_decomp_tests) {
+  using Eigen::Array;
+  using Eigen::Matrix;
+  using stan::is_eigen_dense_dynamic;
+  using stan::math::test::all_eigen_dense_decomp;
+  all_eigen_dense_decomp<false, is_eigen_dense_dynamic>();
+}
+
+TEST(MathMetaPrim, is_eigen_dense_dynamic_expr_tests) {
+  using Eigen::Array;
+  using Eigen::Matrix;
+  using stan::is_eigen_dense_dynamic;
+  using stan::math::test::all_eigen_dense_exprs;
+  all_eigen_dense_exprs<true, true, false, true, is_eigen_dense_dynamic, Matrix,
+                        -1, -1>();
+  all_eigen_dense_exprs<false, false, false, true, is_eigen_dense_dynamic,
+                        Matrix, 1, -1>();
+  all_eigen_dense_exprs<false, false, false, true, is_eigen_dense_dynamic,
+                        Matrix, -1, 1>();
+  all_eigen_dense_exprs<true, true, false, true, is_eigen_dense_dynamic, Array,
+                        -1, -1>();
+  all_eigen_dense_exprs<false, false, false, true, is_eigen_dense_dynamic,
+                        Array, 1, -1>();
+  all_eigen_dense_exprs<false, false, false, true, is_eigen_dense_dynamic,
+                        Array, -1, 1>();
+}

--- a/test/unit/math/prim/fun/assign_test.cpp
+++ b/test/unit/math/prim/fun/assign_test.cpp
@@ -2,22 +2,20 @@
 #include <gtest/gtest.h>
 
 namespace stan {
-    namespace test {
-      namespace indexing {
-        template <typename T1, typename I, typename T2>
-        void test_throw(T1& lhs, const I& idxs, const T2& rhs) {
-          EXPECT_THROW(stan::math::assign(lhs, idxs, rhs), std::out_of_range);
-        }
-
-        template <typename T1, typename I, typename T2>
-        void test_throw_ia(T1& lhs, const I& idxs, const T2& rhs) {
-          EXPECT_THROW(stan::math::assign(lhs, idxs, rhs), std::invalid_argument);
-        }
-      }
-  }
+namespace test {
+namespace indexing {
+template <typename T1, typename I, typename T2>
+void test_throw(T1& lhs, const I& idxs, const T2& rhs) {
+  EXPECT_THROW(stan::math::assign(lhs, idxs, rhs), std::out_of_range);
 }
 
-
+template <typename T1, typename I, typename T2>
+void test_throw_ia(T1& lhs, const I& idxs, const T2& rhs) {
+  EXPECT_THROW(stan::math::assign(lhs, idxs, rhs), std::invalid_argument);
+}
+}  // namespace indexing
+}  // namespace test
+}  // namespace stan
 
 TEST(ModelIndexing, lvalueNil) {
   using stan::math::assign;
@@ -127,10 +125,14 @@ TEST(ModelIndexing, lvalueUniUni) {
   assign(xs, index_list(index_uni(2), index_uni(3)), y);
   EXPECT_FLOAT_EQ(y, xs[1][2]);
 
-  stan::test::indexing::test_throw(xs, index_list(index_uni(0), index_uni(3)), y);
-  stan::test::indexing::test_throw(xs, index_list(index_uni(2), index_uni(0)), y);
-  stan::test::indexing::test_throw(xs, index_list(index_uni(10), index_uni(3)), y);
-  stan::test::indexing::test_throw(xs, index_list(index_uni(2), index_uni(10)), y);
+  stan::test::indexing::test_throw(xs, index_list(index_uni(0), index_uni(3)),
+                                   y);
+  stan::test::indexing::test_throw(xs, index_list(index_uni(2), index_uni(0)),
+                                   y);
+  stan::test::indexing::test_throw(xs, index_list(index_uni(10), index_uni(3)),
+                                   y);
+  stan::test::indexing::test_throw(xs, index_list(index_uni(2), index_uni(10)),
+                                   y);
 }
 
 TEST(ModelIndexing, lvalueUniUniEigen) {
@@ -151,10 +153,14 @@ TEST(ModelIndexing, lvalueUniUniEigen) {
   assign(xs, index_list(index_uni(2), index_uni(3)), y);
   EXPECT_FLOAT_EQ(y, xs[1][2]);
 
-  stan::test::indexing::test_throw(xs, index_list(index_uni(0), index_uni(3)), y);
-  stan::test::indexing::test_throw(xs, index_list(index_uni(2), index_uni(0)), y);
-  stan::test::indexing::test_throw(xs, index_list(index_uni(10), index_uni(3)), y);
-  stan::test::indexing::test_throw(xs, index_list(index_uni(2), index_uni(10)), y);
+  stan::test::indexing::test_throw(xs, index_list(index_uni(0), index_uni(3)),
+                                   y);
+  stan::test::indexing::test_throw(xs, index_list(index_uni(2), index_uni(0)),
+                                   y);
+  stan::test::indexing::test_throw(xs, index_list(index_uni(10), index_uni(3)),
+                                   y);
+  stan::test::indexing::test_throw(xs, index_list(index_uni(2), index_uni(10)),
+                                   y);
 }
 
 TEST(ModelIndexing, lvalueMulti) {
@@ -268,8 +274,10 @@ TEST(ModelIndexing, lvalueMultiMulti) {
     for (int j = 0; j < 3; ++j)
       EXPECT_FLOAT_EQ(ys[i][j], xs[8 + i][j]);
 
-  stan::test::indexing::test_throw_ia(xs, index_list(index_min(7), index_max(3)), ys);
-  stan::test::indexing::test_throw_ia(xs, index_list(index_min(9), index_max(2)), ys);
+  stan::test::indexing::test_throw_ia(
+      xs, index_list(index_min(7), index_max(3)), ys);
+  stan::test::indexing::test_throw_ia(
+      xs, index_list(index_min(9), index_max(2)), ys);
 }
 
 TEST(ModelIndexing, lvalueMultiMultiEigen) {
@@ -301,8 +309,10 @@ TEST(ModelIndexing, lvalueMultiMultiEigen) {
     for (int j = 0; j < 3; ++j)
       EXPECT_FLOAT_EQ(ys[i][j], xs[8 + i][j]);
 
-  stan::test::indexing::test_throw_ia(xs, index_list(index_min(7), index_max(3)), ys);
-  stan::test::indexing::test_throw_ia(xs, index_list(index_min(9), index_max(2)), ys);
+  stan::test::indexing::test_throw_ia(
+      xs, index_list(index_min(7), index_max(3)), ys);
+  stan::test::indexing::test_throw_ia(
+      xs, index_list(index_min(9), index_max(2)), ys);
 }
 
 TEST(ModelIndexing, lvalueUniMulti) {
@@ -327,9 +337,12 @@ TEST(ModelIndexing, lvalueUniMulti) {
   for (int j = 0; j < 3; ++j)
     EXPECT_FLOAT_EQ(ys[j], xs[3][j + 2]);
 
-  stan::test::indexing::test_throw(xs, index_list(index_uni(0), index_min_max(3, 5)), ys);
-  stan::test::indexing::test_throw(xs, index_list(index_uni(11), index_min_max(3, 5)), ys);
-  stan::test::indexing::test_throw_ia(xs, index_list(index_uni(4), index_min_max(2, 5)), ys);
+  stan::test::indexing::test_throw(
+      xs, index_list(index_uni(0), index_min_max(3, 5)), ys);
+  stan::test::indexing::test_throw(
+      xs, index_list(index_uni(11), index_min_max(3, 5)), ys);
+  stan::test::indexing::test_throw_ia(
+      xs, index_list(index_uni(4), index_min_max(2, 5)), ys);
 }
 
 TEST(ModelIndexing, lvalueMultiUni) {
@@ -354,9 +367,12 @@ TEST(ModelIndexing, lvalueMultiUni) {
   for (int j = 0; j < 3; ++j)
     EXPECT_FLOAT_EQ(ys[j], xs[j + 4][7]);
 
-  stan::test::indexing::test_throw_ia(xs, index_list(index_min_max(3, 6), index_uni(7)), ys);
-  stan::test::indexing::test_throw(xs, index_list(index_min_max(4, 6), index_uni(0)), ys);
-  stan::test::indexing::test_throw(xs, index_list(index_min_max(4, 6), index_uni(30)), ys);
+  stan::test::indexing::test_throw_ia(
+      xs, index_list(index_min_max(3, 6), index_uni(7)), ys);
+  stan::test::indexing::test_throw(
+      xs, index_list(index_min_max(4, 6), index_uni(0)), ys);
+  stan::test::indexing::test_throw(
+      xs, index_list(index_min_max(4, 6), index_uni(30)), ys);
 }
 
 TEST(ModelIndexing, lvalueVecUni) {
@@ -511,17 +527,21 @@ TEST(ModelIndexing, lvalueMatrixUniUni) {
   assign(x, index_list(index_uni(2), index_uni(3)), y);
   EXPECT_FLOAT_EQ(y, x(1, 2));
 
-  stan::test::indexing::test_throw(x, index_list(index_uni(0), index_uni(3)), y);
-  stan::test::indexing::test_throw(x, index_list(index_uni(2), index_uni(0)), y);
-  stan::test::indexing::test_throw(x, index_list(index_uni(4), index_uni(3)), y);
-  stan::test::indexing::test_throw(x, index_list(index_uni(2), index_uni(5)), y);
+  stan::test::indexing::test_throw(x, index_list(index_uni(0), index_uni(3)),
+                                   y);
+  stan::test::indexing::test_throw(x, index_list(index_uni(2), index_uni(0)),
+                                   y);
+  stan::test::indexing::test_throw(x, index_list(index_uni(4), index_uni(3)),
+                                   y);
+  stan::test::indexing::test_throw(x, index_list(index_uni(2), index_uni(5)),
+                                   y);
 }
 
 TEST(ModelIndexing, lvalueMatrixUniMulti) {
   using stan::math::assign;
   using stan::math::index_list;
-  using stan::math::index_multi;
   using stan::math::index_min_max;
+  using stan::math::index_multi;
   using stan::math::index_uni;
   Eigen::MatrixXd x(3, 4);
   x << 0.0, 0.1, 0.2, 0.3, 1.0, 1.1, 1.2, 1.3, 2.0, 2.1, 2.2, 2.3;
@@ -535,13 +555,17 @@ TEST(ModelIndexing, lvalueMatrixUniMulti) {
   EXPECT_FLOAT_EQ(y(2), x(1, 3));
 
   puts("2");
-  stan::test::indexing::test_throw(x, index_list(index_uni(0), index_min_max(2, 4)), y);
+  stan::test::indexing::test_throw(
+      x, index_list(index_uni(0), index_min_max(2, 4)), y);
   puts("3");
-  stan::test::indexing::test_throw(x, index_list(index_uni(5), index_min_max(2, 4)), y);
+  stan::test::indexing::test_throw(
+      x, index_list(index_uni(5), index_min_max(2, 4)), y);
   puts("4");
-  stan::test::indexing::test_throw(x, index_list(index_uni(2), index_min_max(0, 2)), y);
+  stan::test::indexing::test_throw(
+      x, index_list(index_uni(2), index_min_max(0, 2)), y);
   puts("5");
-  stan::test::indexing::test_throw_ia(x, index_list(index_uni(2), index_min_max(2, 5)), y);
+  stan::test::indexing::test_throw_ia(
+      x, index_list(index_uni(2), index_min_max(2, 5)), y);
 
   std::vector<int> ns;
   ns.push_back(4);
@@ -557,21 +581,24 @@ TEST(ModelIndexing, lvalueMatrixUniMulti) {
   EXPECT_FLOAT_EQ(y(2), x(2, 2));
 
   ns[ns.size() - 1] = 0;
-  stan::test::indexing::test_throw(x, index_list(index_uni(3), index_multi(ns)), y);
+  stan::test::indexing::test_throw(x, index_list(index_uni(3), index_multi(ns)),
+                                   y);
 
   ns[ns.size() - 1] = 20;
-  stan::test::indexing::test_throw(x, index_list(index_uni(3), index_multi(ns)), y);
+  stan::test::indexing::test_throw(x, index_list(index_uni(3), index_multi(ns)),
+                                   y);
 
   ns.push_back(2);
-  stan::test::indexing::test_throw_ia(x, index_list(index_uni(3), index_multi(ns)), y);
+  stan::test::indexing::test_throw_ia(
+      x, index_list(index_uni(3), index_multi(ns)), y);
 }
 
 TEST(ModelIndexing, lvalueMatrixMultiUni) {
   using stan::math::assign;
   using stan::math::index_list;
   using stan::math::index_min_max;
-  using stan::math::index_uni;
   using stan::math::index_multi;
+  using stan::math::index_uni;
   Eigen::MatrixXd x(3, 4);
   x << 0.0, 0.1, 0.2, 0.3, 1.0, 1.1, 1.2, 1.3, 2.0, 2.1, 2.2, 2.3;
 
@@ -582,10 +609,14 @@ TEST(ModelIndexing, lvalueMatrixMultiUni) {
   EXPECT_FLOAT_EQ(y(0), x(1, 3));
   EXPECT_FLOAT_EQ(y(1), x(2, 3));
 
-  stan::test::indexing::test_throw(x, index_list(index_min_max(2, 3), index_uni(0)), y);
-  stan::test::indexing::test_throw(x, index_list(index_min_max(2, 3), index_uni(5)), y);
-  stan::test::indexing::test_throw(x, index_list(index_min_max(0, 1), index_uni(4)), y);
-  stan::test::indexing::test_throw_ia(x, index_list(index_min_max(1, 3), index_uni(4)), y);
+  stan::test::indexing::test_throw(
+      x, index_list(index_min_max(2, 3), index_uni(0)), y);
+  stan::test::indexing::test_throw(
+      x, index_list(index_min_max(2, 3), index_uni(5)), y);
+  stan::test::indexing::test_throw(
+      x, index_list(index_min_max(0, 1), index_uni(4)), y);
+  stan::test::indexing::test_throw_ia(
+      x, index_list(index_min_max(1, 3), index_uni(4)), y);
 
   std::vector<int> ns;
   ns.push_back(3);
@@ -596,20 +627,23 @@ TEST(ModelIndexing, lvalueMatrixMultiUni) {
   EXPECT_FLOAT_EQ(y(1), x(0, 2));
 
   ns[ns.size() - 1] = 0;
-  stan::test::indexing::test_throw(x, index_list(index_multi(ns), index_uni(3)), y);
+  stan::test::indexing::test_throw(x, index_list(index_multi(ns), index_uni(3)),
+                                   y);
 
   ns[ns.size() - 1] = 20;
-  stan::test::indexing::test_throw(x, index_list(index_multi(ns), index_uni(3)), y);
+  stan::test::indexing::test_throw(x, index_list(index_multi(ns), index_uni(3)),
+                                   y);
 
   ns.push_back(2);
-  stan::test::indexing::test_throw_ia(x, index_list(index_multi(ns), index_uni(3)), y);
+  stan::test::indexing::test_throw_ia(
+      x, index_list(index_multi(ns), index_uni(3)), y);
 }
 
 TEST(ModelIndexing, lvalueMatrixMultiMulti) {
   using stan::math::assign;
   using stan::math::index_list;
-  using stan::math::index_min_max;
   using stan::math::index_min;
+  using stan::math::index_min_max;
   using stan::math::index_multi;
   Eigen::MatrixXd x(3, 4);
   x << 0.0, 0.1, 0.2, 0.3, 1.0, 1.1, 1.2, 1.3, 2.0, 2.1, 2.2, 2.3;
@@ -624,9 +658,12 @@ TEST(ModelIndexing, lvalueMatrixMultiMulti) {
   EXPECT_FLOAT_EQ(y(1, 1), x(2, 2));
   EXPECT_FLOAT_EQ(y(1, 2), x(2, 3));
 
-  stan::test::indexing::test_throw_ia(x, index_list(index_min_max(2, 3), index_min(0)), y);
-  stan::test::indexing::test_throw_ia(x, index_list(index_min_max(2, 3), index_min(10)), y);
-  stan::test::indexing::test_throw_ia(x, index_list(index_min_max(1, 3), index_min(2)), y);
+  stan::test::indexing::test_throw_ia(
+      x, index_list(index_min_max(2, 3), index_min(0)), y);
+  stan::test::indexing::test_throw_ia(
+      x, index_list(index_min_max(2, 3), index_min(10)), y);
+  stan::test::indexing::test_throw_ia(
+      x, index_list(index_min_max(1, 3), index_min(2)), y);
 
   x << 0.0, 0.1, 0.2, 0.3, 1.0, 1.1, 1.2, 1.3, 2.0, 2.1, 2.2, 2.3;
   std::vector<int> ms;
@@ -646,28 +683,32 @@ TEST(ModelIndexing, lvalueMatrixMultiMulti) {
   EXPECT_FLOAT_EQ(y(1, 2), x(0, 0));
 
   ms[ms.size() - 1] = 0;
-  stan::test::indexing::test_throw(x, index_list(index_multi(ms), index_multi(ns)), y);
+  stan::test::indexing::test_throw(
+      x, index_list(index_multi(ms), index_multi(ns)), y);
 
   ms[ms.size() - 1] = 10;
-  stan::test::indexing::test_throw(x, index_list(index_multi(ms), index_multi(ns)), y);
+  stan::test::indexing::test_throw(
+      x, index_list(index_multi(ms), index_multi(ns)), y);
 
   ms[ms.size() - 1] = 1;  // back to original valid value
   ns[ns.size() - 1] = 0;
-  stan::test::indexing::test_throw(x, index_list(index_multi(ms), index_multi(ns)), y);
+  stan::test::indexing::test_throw(
+      x, index_list(index_multi(ms), index_multi(ns)), y);
 
   ns[ns.size() - 1] = 10;
-  stan::test::indexing::test_throw(x, index_list(index_multi(ms), index_multi(ns)), y);
+  stan::test::indexing::test_throw(
+      x, index_list(index_multi(ms), index_multi(ns)), y);
 }
 
 TEST(ModelIndexing, doubleToVar) {
+  using Eigen::Dynamic;
   using stan::math::assign;
   using stan::math::index_list;
-  using stan::math::index_uni;
   using stan::math::index_multi;
   using stan::math::index_omni;
+  using stan::math::index_uni;
   using stan::math::nil_index_list;
   using stan::math::var;
-  using Eigen::Dynamic;
   std::vector<double> xs;
   xs.push_back(1);
   xs.push_back(2);
@@ -869,8 +910,8 @@ TEST(ModelIndexing, resultSizeNegMinMaxNegMinMaxEigenMatrix) {
 
 TEST(modelIndexing, doubleToVarSimple) {
   using stan::math::assign;
-  using stan::math::var;
   using stan::math::nil_index_list;
+  using stan::math::var;
 
   Eigen::MatrixXd a(2, 2);
   a << 1, 2, 3, 4;
@@ -931,7 +972,8 @@ TEST(model_indexing, assign_eigvec_eigvec_index_multi) {
 
   ns[ns.size() - 1] = 3;
   ns.push_back(1);
-  stan::test::indexing::test_throw_ia(lhs_x, index_list(index_multi(ns)), rhs_y);
+  stan::test::indexing::test_throw_ia(lhs_x, index_list(index_multi(ns)),
+                                      rhs_y);
 }
 
 TEST(model_indexing, assign_eigrowvec_eigrowvec_index_min) {
@@ -985,7 +1027,8 @@ TEST(model_indexing, assign_eigrowvec_eigrowvec_index_multi) {
 
   ns[ns.size() - 1] = 3;
   ns.push_back(1);
-  stan::test::indexing::test_throw_ia(lhs_x, index_list(index_multi(ns)), rhs_y);
+  stan::test::indexing::test_throw_ia(lhs_x, index_list(index_multi(ns)),
+                                      rhs_y);
 }
 
 TEST(model_indexing, assign_densemat_rowvec_uni_index) {
@@ -1047,18 +1090,22 @@ TEST(model_indexing, assign_densemat_scalar_index_uni) {
   assign(x, index_list(index_uni(2), index_uni(3)), y);
   EXPECT_FLOAT_EQ(y, x(1, 2));
 
-  stan::test::indexing::test_throw(x, index_list(index_uni(0), index_uni(3)), y);
-  stan::test::indexing::test_throw(x, index_list(index_uni(2), index_uni(0)), y);
-  stan::test::indexing::test_throw(x, index_list(index_uni(4), index_uni(3)), y);
-  stan::test::indexing::test_throw(x, index_list(index_uni(2), index_uni(5)), y);
+  stan::test::indexing::test_throw(x, index_list(index_uni(0), index_uni(3)),
+                                   y);
+  stan::test::indexing::test_throw(x, index_list(index_uni(2), index_uni(0)),
+                                   y);
+  stan::test::indexing::test_throw(x, index_list(index_uni(4), index_uni(3)),
+                                   y);
+  stan::test::indexing::test_throw(x, index_list(index_uni(2), index_uni(5)),
+                                   y);
 }
 
 TEST(model_indexing, assign_densemat_eigrowvec_uni_index_min_max_index) {
   using stan::math::assign;
   using stan::math::index_list;
-  using stan::math::index_uni;
   using stan::math::index_min_max;
   using stan::math::index_multi;
+  using stan::math::index_uni;
   Eigen::MatrixXd x(3, 4);
   x << 0.0, 0.1, 0.2, 0.3, 1.0, 1.1, 1.2, 1.3, 2.0, 2.1, 2.2, 2.3;
 
@@ -1074,10 +1121,14 @@ TEST(model_indexing, assign_densemat_eigrowvec_uni_index_min_max_index) {
   EXPECT_FLOAT_EQ(y(1) + 2, x(1, 2));
   EXPECT_FLOAT_EQ(y(2) + 2, x(1, 3));
 
-  stan::test::indexing::test_throw(x, index_list(index_uni(0), index_min_max(2, 4)), y);
-  stan::test::indexing::test_throw(x, index_list(index_uni(5), index_min_max(2, 4)), y);
-  stan::test::indexing::test_throw(x, index_list(index_uni(2), index_min_max(0, 2)), y);
-  stan::test::indexing::test_throw_ia(x, index_list(index_uni(2), index_min_max(2, 5)), y);
+  stan::test::indexing::test_throw(
+      x, index_list(index_uni(0), index_min_max(2, 4)), y);
+  stan::test::indexing::test_throw(
+      x, index_list(index_uni(5), index_min_max(2, 4)), y);
+  stan::test::indexing::test_throw(
+      x, index_list(index_uni(2), index_min_max(0, 2)), y);
+  stan::test::indexing::test_throw_ia(
+      x, index_list(index_uni(2), index_min_max(2, 5)), y);
 
   std::vector<int> ns;
   ns.push_back(4);
@@ -1094,21 +1145,24 @@ TEST(model_indexing, assign_densemat_eigrowvec_uni_index_min_max_index) {
   EXPECT_FLOAT_EQ(y(2) + 2, x(2, 2));
 
   ns[ns.size() - 1] = 0;
-  stan::test::indexing::test_throw(x, index_list(index_uni(3), index_multi(ns)), y);
+  stan::test::indexing::test_throw(x, index_list(index_uni(3), index_multi(ns)),
+                                   y);
 
   ns[ns.size() - 1] = 20;
-  stan::test::indexing::test_throw(x, index_list(index_uni(3), index_multi(ns)), y);
+  stan::test::indexing::test_throw(x, index_list(index_uni(3), index_multi(ns)),
+                                   y);
 
   ns.push_back(2);
-  stan::test::indexing::test_throw_ia(x, index_list(index_uni(3), index_multi(ns)), y);
+  stan::test::indexing::test_throw_ia(
+      x, index_list(index_uni(3), index_multi(ns)), y);
 }
 
 TEST(model_indexing, assign_densemat_eigvec_min_max_index_uni_index) {
   using stan::math::assign;
   using stan::math::index_list;
-  using stan::math::index_uni;
   using stan::math::index_min_max;
   using stan::math::index_multi;
+  using stan::math::index_uni;
   Eigen::MatrixXd x(3, 4);
   x << 0.0, 0.1, 0.2, 0.3, 1.0, 1.1, 1.2, 1.3, 2.0, 2.1, 2.2, 2.3;
 
@@ -1123,10 +1177,14 @@ TEST(model_indexing, assign_densemat_eigvec_min_max_index_uni_index) {
   EXPECT_FLOAT_EQ(y(0) + 2, x(1, 3));
   EXPECT_FLOAT_EQ(y(1) + 2, x(2, 3));
 
-  stan::test::indexing::test_throw(x, index_list(index_min_max(2, 3), index_uni(0)), y);
-  stan::test::indexing::test_throw(x, index_list(index_min_max(2, 3), index_uni(5)), y);
-  stan::test::indexing::test_throw(x, index_list(index_min_max(0, 1), index_uni(4)), y);
-  stan::test::indexing::test_throw_ia(x, index_list(index_min_max(1, 3), index_uni(4)), y);
+  stan::test::indexing::test_throw(
+      x, index_list(index_min_max(2, 3), index_uni(0)), y);
+  stan::test::indexing::test_throw(
+      x, index_list(index_min_max(2, 3), index_uni(5)), y);
+  stan::test::indexing::test_throw(
+      x, index_list(index_min_max(0, 1), index_uni(4)), y);
+  stan::test::indexing::test_throw_ia(
+      x, index_list(index_min_max(1, 3), index_uni(4)), y);
 
   std::vector<int> ns;
   ns.push_back(3);
@@ -1141,13 +1199,16 @@ TEST(model_indexing, assign_densemat_eigvec_min_max_index_uni_index) {
   EXPECT_FLOAT_EQ(y(1) + 2, x(0, 2));
 
   ns[ns.size() - 1] = 0;
-  stan::test::indexing::test_throw(x, index_list(index_multi(ns), index_uni(3)), y);
+  stan::test::indexing::test_throw(x, index_list(index_multi(ns), index_uni(3)),
+                                   y);
 
   ns[ns.size() - 1] = 20;
-  stan::test::indexing::test_throw(x, index_list(index_multi(ns), index_uni(3)), y);
+  stan::test::indexing::test_throw(x, index_list(index_multi(ns), index_uni(3)),
+                                   y);
 
   ns.push_back(2);
-  stan::test::indexing::test_throw_ia(x, index_list(index_multi(ns), index_uni(3)), y);
+  stan::test::indexing::test_throw_ia(
+      x, index_list(index_multi(ns), index_uni(3)), y);
 }
 
 TEST(model_indexing, assign_densemat_densemat_min_max_index_min_index) {
@@ -1178,9 +1239,12 @@ TEST(model_indexing, assign_densemat_densemat_min_max_index_min_index) {
   EXPECT_FLOAT_EQ(y(1, 1), x(2, 2));
   EXPECT_FLOAT_EQ(y(1, 2), x(2, 3));
 
-  stan::test::indexing::test_throw_ia(x, index_list(index_min_max(2, 3), index_min(0)), y);
-  stan::test::indexing::test_throw_ia(x, index_list(index_min_max(2, 3), index_min(10)), y);
-  stan::test::indexing::test_throw_ia(x, index_list(index_min_max(1, 3), index_min(2)), y);
+  stan::test::indexing::test_throw_ia(
+      x, index_list(index_min_max(2, 3), index_min(0)), y);
+  stan::test::indexing::test_throw_ia(
+      x, index_list(index_min_max(2, 3), index_min(10)), y);
+  stan::test::indexing::test_throw_ia(
+      x, index_list(index_min_max(1, 3), index_min(2)), y);
 }
 
 TEST(model_indexing, assign_densemat_densemat_multi_index_multi_index) {
@@ -1219,15 +1283,19 @@ TEST(model_indexing, assign_densemat_densemat_multi_index_multi_index) {
   EXPECT_FLOAT_EQ(y2(1, 2), x(0, 0));
 
   ms[ms.size() - 1] = 0;
-  stan::test::indexing::test_throw(x, index_list(index_multi(ms), index_multi(ns)), y);
+  stan::test::indexing::test_throw(
+      x, index_list(index_multi(ms), index_multi(ns)), y);
 
   ms[ms.size() - 1] = 10;
-  stan::test::indexing::test_throw(x, index_list(index_multi(ms), index_multi(ns)), y);
+  stan::test::indexing::test_throw(
+      x, index_list(index_multi(ms), index_multi(ns)), y);
 
   ms[ms.size() - 1] = 1;  // back to original valid value
   ns[ns.size() - 1] = 0;
-  stan::test::indexing::test_throw(x, index_list(index_multi(ms), index_multi(ns)), y);
+  stan::test::indexing::test_throw(
+      x, index_list(index_multi(ms), index_multi(ns)), y);
 
   ns[ns.size() - 1] = 10;
-  stan::test::indexing::test_throw(x, index_list(index_multi(ms), index_multi(ns)), y);
+  stan::test::indexing::test_throw(
+      x, index_list(index_multi(ms), index_multi(ns)), y);
 }

--- a/test/unit/math/prim/fun/assign_test.cpp
+++ b/test/unit/math/prim/fun/assign_test.cpp
@@ -1,363 +1,1233 @@
-#include <stan/math/prim.hpp>
-#include <test/unit/util.hpp>
+#include <stan/math.hpp>
 #include <gtest/gtest.h>
-#include <sstream>
-#include <stdexcept>
-#include <vector>
-#include <string>
 
-template <int N>
-void test_print_mat_size(const std::string& expected) {
-  using stan::math::print_mat_size;
-  std::stringstream ss;
-  stan::math::print_mat_size<N>(ss);
-  EXPECT_EQ(expected, ss.str());
+namespace stan {
+    namespace test {
+      namespace indexing {
+        template <typename T1, typename I, typename T2>
+        void test_throw(T1& lhs, const I& idxs, const T2& rhs) {
+          EXPECT_THROW(stan::math::assign(lhs, idxs, rhs), std::out_of_range);
+        }
+
+        template <typename T1, typename I, typename T2>
+        void test_throw_ia(T1& lhs, const I& idxs, const T2& rhs) {
+          EXPECT_THROW(stan::math::assign(lhs, idxs, rhs), std::invalid_argument);
+        }
+      }
+  }
 }
 
-TEST(MathMatrixAssign, print_mat_size) {
-  test_print_mat_size<-1>("dynamically sized");
-  test_print_mat_size<0>("0");
-  test_print_mat_size<1>("1");
-  test_print_mat_size<10>("10");
-}
 
-TEST(MathMatrixAssign, intToDouble) {
-  double a = 2.7;
-  int b = 0;
-  EXPECT_NO_THROW(stan::math::assign(b, a));
-  EXPECT_NO_THROW(stan::math::assign(a, b));
-}
 
-TEST(MathMatrixAssign, matSizeMismatch) {
-  using Eigen::Matrix;
+TEST(ModelIndexing, lvalueNil) {
   using stan::math::assign;
-  Matrix<double, 1, -1> x(3);
-  Matrix<double, 1, -1> y(3);
-  EXPECT_NO_THROW(assign(x, y));
-  Matrix<double, 1, -1> z(10);
-  EXPECT_THROW(assign(x, z), std::invalid_argument);
+  using stan::math::nil_index_list;
+  double x = 3;
+  double y = 5;
+  assign(x, nil_index_list(), y);
+  EXPECT_FLOAT_EQ(5, x);
 
-  Matrix<double, -1, 1> a(5);
-  Matrix<double, -1, 1> b(6);
-  EXPECT_THROW(assign(a, b), std::invalid_argument);
-
-  std::vector<double> u(5);
-  std::vector<double> v(7);
-  EXPECT_THROW(assign(u, v), std::invalid_argument);
-
-  Matrix<double, -1, -1> m1(4, 5);
-  Matrix<double, -1, -1> m2(5, 4);
-  EXPECT_THROW(assign(m1, m2), std::invalid_argument);
-
-  Matrix<double, -1, -1> m3(10, 10);
-  Matrix<double, -1, -1> m4(2, 3);
-  EXPECT_THROW(assign(m3.block(1, 1, 7, 3), m4), std::invalid_argument);
-
-  EXPECT_THROW(assign(m3.block(1, 1, 2, 5), m4), std::invalid_argument);
+  std::vector<double> xs;
+  xs.push_back(3);
+  xs.push_back(5);
+  std::vector<double> ys;
+  ys.push_back(13);
+  ys.push_back(15);
+  assign(xs, nil_index_list(), ys);
+  EXPECT_FLOAT_EQ(ys[0], xs[0]);
+  EXPECT_FLOAT_EQ(ys[1], xs[1]);
 }
 
-TEST(MathMatrixAssign, test_int) {
+TEST(ModelIndexing, lvalueUni) {
   using stan::math::assign;
-  int a;
-  int b = 5;
-  assign(a, b);
-  EXPECT_EQ(5, a);
-  EXPECT_EQ(5, b);
+  using stan::math::index_list;
+  using stan::math::index_uni;
+  std::vector<double> xs;
+  xs.push_back(3);
+  xs.push_back(5);
+  xs.push_back(7);
+  double y = 15;
+  assign(xs, index_list(index_uni(2)), y);
+  EXPECT_FLOAT_EQ(y, xs[1]);
 
-  assign(a, 12);
-  EXPECT_EQ(a, 12);
-}
-TEST(MathMatrixAssign, test_double) {
-  using stan::math::assign;
-
-  double a;
-  int b = 5;
-  double c = 5.0;
-  assign(a, b);
-  EXPECT_FLOAT_EQ(5.0, a);
-  EXPECT_FLOAT_EQ(5.0, b);
-
-  assign(a, c);
-  EXPECT_FLOAT_EQ(5.0, a);
-  EXPECT_FLOAT_EQ(5.0, b);
-
-  assign(a, 5.2);
-  EXPECT_FLOAT_EQ(5.2, a);
-}
-TEST(MathMatrixAssign, vectorDouble) {
-  using stan::math::assign;
-  using std::vector;
-
-  vector<double> y(3);
-  y[0] = 1.2;
-  y[1] = 100;
-  y[2] = -5.1;
-
-  vector<double> x(3);
-  assign(x, y);
-  EXPECT_EQ(3U, x.size());
-  EXPECT_EQ(3U, y.size());
-  for (size_t i = 0; i < 3; ++i)
-    EXPECT_FLOAT_EQ(y[i], x[i]);
-
-  vector<double> z(2);
-  EXPECT_THROW(assign(x, z), std::invalid_argument);
-
-  vector<int> ns(3);
-  ns[0] = 1;
-  ns[1] = -10;
-  ns[2] = 500;
-
-  assign(x, ns);
-  EXPECT_EQ(3U, x.size());
-  EXPECT_EQ(3U, ns.size());
-  for (size_t i = 0; i < 3; ++i)
-    EXPECT_FLOAT_EQ(ns[i], x[i]);
+  stan::test::indexing::test_throw(xs, index_list(index_uni(0)), y);
+  stan::test::indexing::test_throw(xs, index_list(index_uni(4)), y);
 }
 
-TEST(MathMatrixAssign, eigenRowVectorDoubleToDouble) {
-  using Eigen::Dynamic;
-  using Eigen::Matrix;
+TEST(ModelIndexing, lvalueUniEigen) {
   using stan::math::assign;
+  using stan::math::index_list;
+  using stan::math::index_uni;
+  Eigen::VectorXd xs(3);
+  xs << 3, 5, 7;
+  double y = 15;
+  assign(xs, index_list(index_uni(2)), y);
+  EXPECT_FLOAT_EQ(y, xs[1]);
+  double z = 10;
+  assign(xs.segment(0, 3), index_list(index_uni(2)), z);
+  EXPECT_FLOAT_EQ(z, xs[1]);
 
-  Matrix<double, 1, Dynamic> y(3);
-  y[0] = 1.2;
-  y[1] = 100;
-  y[2] = -5.1;
-
-  Matrix<double, 1, Dynamic> x(3);
-  assign(x, y);
-  EXPECT_EQ(3, x.size());
-  EXPECT_EQ(3, y.size());
-  for (int i = 0; i < 3; ++i)
-    EXPECT_FLOAT_EQ(y[i], x[i]);
-}
-TEST(MathMatrixAssign, eigenRowVectorIntToDouble) {
-  using Eigen::Dynamic;
-  using Eigen::Matrix;
-  using stan::math::assign;
-
-  Matrix<double, 1, Dynamic> x(3);
-  x[0] = 1.2;
-  x[1] = 100;
-  x[2] = -5.1;
-
-  Matrix<int, 1, Dynamic> ns(3);
-  ns[0] = 1;
-  ns[1] = -10;
-  ns[2] = 500;
-
-  assign(x, ns);
-  EXPECT_EQ(3, x.size());
-  EXPECT_EQ(3, ns.size());
-  for (int i = 0; i < 3; ++i)
-    EXPECT_FLOAT_EQ(ns[i], x[i]);
-}
-TEST(MathMatrixAssign, eigenRowVectorShapeMismatch) {
-  using Eigen::Dynamic;
-  using Eigen::Matrix;
-  using stan::math::assign;
-
-  Matrix<double, 1, Dynamic> x(3);
-  x[0] = 1.2;
-  x[1] = 100;
-  x[2] = -5.1;
-
-  Matrix<double, 1, Dynamic> z(2);
-  EXPECT_THROW(assign(x, z), std::invalid_argument);
-
-  Matrix<double, Dynamic, 1> zz(3);
-  zz << 1, 2, 3;
-  EXPECT_THROW(assign(x, zz), std::invalid_argument);
-
-  Matrix<double, Dynamic, Dynamic> zzz(3, 1);
-  zzz << 1, 2, 3;
-  EXPECT_THROW(assign(x, zzz), std::invalid_argument);
+  stan::test::indexing::test_throw(xs, index_list(index_uni(0)), y);
+  stan::test::indexing::test_throw(xs, index_list(index_uni(4)), y);
 }
 
-TEST(MathMatrixAssign, eigenMatrixDoubleToDouble) {
-  using Eigen::Dynamic;
-  using Eigen::Matrix;
+TEST(model_indexing, assign_eigvec_scalar_uni_index_segment) {
   using stan::math::assign;
+  using stan::math::index_list;
+  using stan::math::index_uni;
+  Eigen::VectorXd lhs_x(5);
+  lhs_x << 0, 1, 2, 3, 4;
+  double y = 13;
+  assign(lhs_x.segment(0, 5), index_list(index_uni(3)), y);
+  EXPECT_FLOAT_EQ(y, lhs_x(2));
 
-  Matrix<double, Dynamic, Dynamic> y(3, 2);
-  y << 1.2, 100, -5.1, 12, 1000, -5100;
-
-  Matrix<double, Dynamic, Dynamic> x(3, 2);
-  assign(x, y);
-  EXPECT_EQ(6, x.size());
-  EXPECT_EQ(6, y.size());
-  EXPECT_EQ(3, x.rows());
-  EXPECT_EQ(3, y.rows());
-  EXPECT_EQ(2, x.cols());
-  EXPECT_EQ(2, y.cols());
-  for (size_t i = 0; i < 6; ++i)
-    EXPECT_FLOAT_EQ(y(i), x(i));
-}
-TEST(MathMatrixAssign, eigenMatrixIntToDouble) {
-  using Eigen::Dynamic;
-  using Eigen::Matrix;
-  using stan::math::assign;
-
-  Matrix<int, Dynamic, Dynamic> y(3, 2);
-  y << 1, 2, 3, 4, 5, 6;
-
-  Matrix<double, Dynamic, Dynamic> x(3, 2);
-  assign(x, y);
-  EXPECT_EQ(6, x.size());
-  EXPECT_EQ(6, y.size());
-  EXPECT_EQ(3, x.rows());
-  EXPECT_EQ(3, y.rows());
-  EXPECT_EQ(2, x.cols());
-  EXPECT_EQ(2, y.cols());
-  for (size_t i = 0; i < 6; ++i)
-    EXPECT_FLOAT_EQ(y(i), x(i));
-}
-TEST(MathMatrixAssign, eigenMatrixShapeMismatch) {
-  using Eigen::Dynamic;
-  using Eigen::Matrix;
-  using stan::math::assign;
-
-  Matrix<double, Dynamic, Dynamic> x(2, 3);
-  x << 1, 2, 3, 4, 5, 6;
-
-  Matrix<double, 1, Dynamic> z(6);
-  z << 1, 2, 3, 4, 5, 6;
-  EXPECT_THROW(assign(x, z), std::invalid_argument);
-  EXPECT_THROW(assign(z, x), std::invalid_argument);
-
-  Matrix<double, Dynamic, 1> zz(6);
-  zz << 1, 2, 3, 4, 5, 6;
-  EXPECT_THROW(assign(x, zz), std::invalid_argument);
-  EXPECT_THROW(assign(zz, x), std::invalid_argument);
-
-  Matrix<double, Dynamic, Dynamic> zzz(6, 1);
-  zzz << 1, 2, 3, 4, 5, 6;
-  EXPECT_THROW(assign(x, zzz), std::invalid_argument);
-  EXPECT_THROW(assign(zzz, x), std::invalid_argument);
+  stan::test::indexing::test_throw(lhs_x, index_list(index_uni(0)), y);
+  stan::test::indexing::test_throw(lhs_x, index_list(index_uni(6)), y);
 }
 
-TEST(MathMatrixPrimMat, block) {
-  using Eigen::Dynamic;
-  using Eigen::Matrix;
+TEST(model_indexing, assign_eigrowvec_scalar_uni_index_segment) {
   using stan::math::assign;
-  using stan::math::get_base1_lhs;
+  using stan::math::index_list;
+  using stan::math::index_uni;
 
-  Matrix<double, Dynamic, Dynamic> m(2, 3);
-  m << 1, 2, 3, 4, 5, 6;
-
-  Matrix<double, 1, Dynamic> rv(3);
-  rv << 10, 100, 1000;
-
-  assign(get_base1_lhs(m, 1, "m", 1), rv);
-  EXPECT_FLOAT_EQ(10.0, m(0, 0));
-  EXPECT_FLOAT_EQ(100.0, m(0, 1));
-  EXPECT_FLOAT_EQ(1000.0, m(0, 2));
+  Eigen::RowVectorXd lhs_x(5);
+  lhs_x << 0, 1, 2, 3, 4;
+  double y = 13;
+  assign(lhs_x.segment(0, 5), index_list(index_uni(3)), y);
+  EXPECT_FLOAT_EQ(y, lhs_x(2));
+  stan::test::indexing::test_throw(lhs_x, index_list(index_uni(0)), y);
+  stan::test::indexing::test_throw(lhs_x, index_list(index_uni(6)), y);
 }
 
-TEST(MathMatrixPrimMat, block2) {
-  using Eigen::MatrixXd;
+TEST(ModelIndexing, lvalueUniUni) {
   using stan::math::assign;
+  using stan::math::index_list;
+  using stan::math::index_max;
+  using stan::math::index_min;
+  using stan::math::index_min_max;
+  using stan::math::index_multi;
+  using stan::math::index_omni;
+  using stan::math::index_uni;
+  using stan::math::nil_index_list;
+  std::vector<double> xs0;
+  xs0.push_back(0.0);
+  xs0.push_back(0.1);
+  xs0.push_back(0.2);
 
-  MatrixXd a(2, 3);
-  a << 1, 2, 3, 4, 5, 6;
+  std::vector<double> xs1;
+  xs1.push_back(1.0);
+  xs1.push_back(1.1);
+  xs1.push_back(1.2);
 
-  MatrixXd b(2, 2);
-  b << 10, 20, 30, 40;
+  std::vector<std::vector<double> > xs;
+  xs.push_back(xs0);
+  xs.push_back(xs1);
 
-  assign(a.block(0, 0, 2, 2), b);
+  double y = 15;
+  assign(xs, index_list(index_uni(2), index_uni(3)), y);
+  EXPECT_FLOAT_EQ(y, xs[1][2]);
+
+  stan::test::indexing::test_throw(xs, index_list(index_uni(0), index_uni(3)), y);
+  stan::test::indexing::test_throw(xs, index_list(index_uni(2), index_uni(0)), y);
+  stan::test::indexing::test_throw(xs, index_list(index_uni(10), index_uni(3)), y);
+  stan::test::indexing::test_throw(xs, index_list(index_uni(2), index_uni(10)), y);
+}
+
+TEST(ModelIndexing, lvalueUniUniEigen) {
+  using stan::math::assign;
+  using stan::math::index_list;
+  using stan::math::index_uni;
+  Eigen::VectorXd xs0(3);
+  xs0 << 0.0, 0.1, 0.2;
+
+  Eigen::VectorXd xs1(3);
+  xs1 << 1.0, 1.1, 1.2;
+
+  std::vector<Eigen::VectorXd> xs;
+  xs.push_back(xs0);
+  xs.push_back(xs1);
+
+  double y = 15;
+  assign(xs, index_list(index_uni(2), index_uni(3)), y);
+  EXPECT_FLOAT_EQ(y, xs[1][2]);
+
+  stan::test::indexing::test_throw(xs, index_list(index_uni(0), index_uni(3)), y);
+  stan::test::indexing::test_throw(xs, index_list(index_uni(2), index_uni(0)), y);
+  stan::test::indexing::test_throw(xs, index_list(index_uni(10), index_uni(3)), y);
+  stan::test::indexing::test_throw(xs, index_list(index_uni(2), index_uni(10)), y);
+}
+
+TEST(ModelIndexing, lvalueMulti) {
+  using stan::math::assign;
+  using stan::math::index_list;
+  using stan::math::index_max;
+  using stan::math::index_min;
+  using stan::math::index_multi;
+  std::vector<double> x;
+  for (int i = 0; i < 10; ++i)
+    x.push_back(i);
+
+  std::vector<double> y;
+  y.push_back(8.1);
+  y.push_back(9.1);
+
+  assign(x, index_list(index_min(9)), y);
+  EXPECT_FLOAT_EQ(y[0], x[8]);
+  EXPECT_FLOAT_EQ(y[1], x[9]);
+  stan::test::indexing::test_throw_ia(x, index_list(index_min(0)), y);
+
+  assign(x, index_list(index_max(2)), y);
+  EXPECT_FLOAT_EQ(y[0], x[0]);
+  EXPECT_FLOAT_EQ(y[1], x[1]);
+  EXPECT_FLOAT_EQ(2, x[2]);
+  stan::test::indexing::test_throw_ia(x, index_list(index_max(10)), y);
+
+  std::vector<int> ns;
+  ns.push_back(4);
+  ns.push_back(6);
+  assign(x, index_list(index_multi(ns)), y);
+  EXPECT_FLOAT_EQ(y[0], x[3]);
+  EXPECT_FLOAT_EQ(y[1], x[5]);
+
+  ns[0] = 0;
+  stan::test::indexing::test_throw(x, index_list(index_multi(ns)), y);
+
+  ns[0] = 11;
+  stan::test::indexing::test_throw(x, index_list(index_multi(ns)), y);
+
+  ns.push_back(3);
+  stan::test::indexing::test_throw_ia(x, index_list(index_multi(ns)), y);
+}
+
+TEST(ModelIndexing, lvalueMultiEigen) {
+  using stan::math::assign;
+  using stan::math::index_list;
+  using stan::math::index_max;
+  using stan::math::index_min;
+  using stan::math::index_multi;
+  Eigen::VectorXd x(10);
+  for (int i = 0; i < 10; ++i) {
+    x(i) = i;
+  }
+
+  Eigen::VectorXd y(2);
+  y << 8.1, 9.1;
+
+  assign(x, index_list(index_min(9)), y);
+  EXPECT_FLOAT_EQ(y[0], x[8]);
+  EXPECT_FLOAT_EQ(y[1], x[9]);
+  stan::test::indexing::test_throw_ia(x, index_list(index_min(0)), y);
+
+  assign(x, index_list(index_max(2)), y);
+  EXPECT_FLOAT_EQ(y[0], x[0]);
+  EXPECT_FLOAT_EQ(y[1], x[1]);
+  EXPECT_FLOAT_EQ(2, x[2]);
+  stan::test::indexing::test_throw_ia(x, index_list(index_max(10)), y);
+
+  std::vector<int> ns;
+  ns.push_back(4);
+  ns.push_back(6);
+  assign(x, index_list(index_multi(ns)), y);
+  EXPECT_FLOAT_EQ(y[0], x[3]);
+  EXPECT_FLOAT_EQ(y[1], x[5]);
+
+  ns[0] = 0;
+  stan::test::indexing::test_throw(x, index_list(index_multi(ns)), y);
+
+  ns[0] = 11;
+  stan::test::indexing::test_throw(x, index_list(index_multi(ns)), y);
+
+  ns.push_back(3);
+  stan::test::indexing::test_throw_ia(x, index_list(index_multi(ns)), y);
+}
+
+TEST(ModelIndexing, lvalueMultiMulti) {
+  using stan::math::assign;
+  using stan::math::index_list;
+  using stan::math::index_max;
+  using stan::math::index_min;
+  std::vector<std::vector<double> > xs;
+  for (int i = 0; i < 10; ++i) {
+    std::vector<double> xsi;
+    for (int j = 0; j < 20; ++j)
+      xsi.push_back(i + j / 10.0);
+    xs.push_back(xsi);
+  }
+
+  std::vector<std::vector<double> > ys;
+  for (int i = 0; i < 2; ++i) {
+    std::vector<double> ysi;
+    for (int j = 0; j < 3; ++j)
+      ysi.push_back(10 + i + j / 10.0);
+    ys.push_back(ysi);
+  }
+
+  assign(xs, index_list(index_min(9), index_max(3)), ys);
 
   for (int i = 0; i < 2; ++i)
-    for (int j = 0; j < 2; ++j)
-      EXPECT_FLOAT_EQ(a(i, j), b(i, j));
+    for (int j = 0; j < 3; ++j)
+      EXPECT_FLOAT_EQ(ys[i][j], xs[8 + i][j]);
 
-  EXPECT_FLOAT_EQ(a(0, 2), 3.0);
-  EXPECT_FLOAT_EQ(a(1, 2), 6.0);
+  stan::test::indexing::test_throw_ia(xs, index_list(index_min(7), index_max(3)), ys);
+  stan::test::indexing::test_throw_ia(xs, index_list(index_min(9), index_max(2)), ys);
 }
 
-TEST(MathMatrixPrimMat, vectorVector) {
+TEST(ModelIndexing, lvalueMultiMultiEigen) {
   using stan::math::assign;
-  using std::vector;
-  vector<vector<double> > x(3, vector<double>(2));
-  for (size_t i = 0; i < 3; ++i)
-    for (size_t j = 0; j < 2; ++j)
-      x[i][j] = (i + 1) * (j - 10);
-
-  vector<vector<double> > y(3, vector<double>(2));
-
-  assign(y, x);
-  EXPECT_EQ(3U, y.size());
-  for (size_t i = 0; i < 3U; ++i) {
-    EXPECT_EQ(2U, y[i].size());
-    for (size_t j = 0; j < 2U; ++j) {
-      EXPECT_FLOAT_EQ(x[i][j], y[i][j]);
+  using stan::math::index_list;
+  using stan::math::index_max;
+  using stan::math::index_min;
+  std::vector<Eigen::VectorXd> xs;
+  for (int i = 0; i < 10; ++i) {
+    Eigen::VectorXd xsi(20);
+    for (int j = 0; j < 20; ++j) {
+      xsi(j) = (i + j / 10.0);
     }
+    xs.push_back(xsi);
   }
+
+  std::vector<Eigen::VectorXd> ys;
+  for (int i = 0; i < 2; ++i) {
+    Eigen::VectorXd ysi(3);
+    for (int j = 0; j < 3; ++j) {
+      ysi(j) = (10 + i + j / 10.0);
+    }
+    ys.push_back(ysi);
+  }
+
+  assign(xs, index_list(index_min(9), index_max(3)), ys);
+
+  for (int i = 0; i < 2; ++i)
+    for (int j = 0; j < 3; ++j)
+      EXPECT_FLOAT_EQ(ys[i][j], xs[8 + i][j]);
+
+  stan::test::indexing::test_throw_ia(xs, index_list(index_min(7), index_max(3)), ys);
+  stan::test::indexing::test_throw_ia(xs, index_list(index_min(9), index_max(2)), ys);
 }
 
-TEST(MathMatrixPrimMat, vectorVectorVector) {
+TEST(ModelIndexing, lvalueUniMulti) {
   using stan::math::assign;
+  using stan::math::index_list;
+  using stan::math::index_min_max;
+  using stan::math::index_uni;
+  std::vector<std::vector<double> > xs;
+  for (int i = 0; i < 10; ++i) {
+    std::vector<double> xsi;
+    for (int j = 0; j < 20; ++j)
+      xsi.push_back(i + j / 10.0);
+    xs.push_back(xsi);
+  }
+
+  std::vector<double> ys;
+  for (int i = 0; i < 3; ++i)
+    ys.push_back(10 + i);
+
+  assign(xs, index_list(index_uni(4), index_min_max(3, 5)), ys);
+
+  for (int j = 0; j < 3; ++j)
+    EXPECT_FLOAT_EQ(ys[j], xs[3][j + 2]);
+
+  stan::test::indexing::test_throw(xs, index_list(index_uni(0), index_min_max(3, 5)), ys);
+  stan::test::indexing::test_throw(xs, index_list(index_uni(11), index_min_max(3, 5)), ys);
+  stan::test::indexing::test_throw_ia(xs, index_list(index_uni(4), index_min_max(2, 5)), ys);
+}
+
+TEST(ModelIndexing, lvalueMultiUni) {
+  using stan::math::assign;
+  using stan::math::index_list;
+  using stan::math::index_min_max;
+  using stan::math::index_uni;
+  std::vector<std::vector<double> > xs;
+  for (int i = 0; i < 10; ++i) {
+    std::vector<double> xsi;
+    for (int j = 0; j < 20; ++j)
+      xsi.push_back(i + j / 10.0);
+    xs.push_back(xsi);
+  }
+
+  std::vector<double> ys;
+  for (int i = 0; i < 3; ++i)
+    ys.push_back(10 + i);
+
+  assign(xs, index_list(index_min_max(5, 7), index_uni(8)), ys);
+
+  for (int j = 0; j < 3; ++j)
+    EXPECT_FLOAT_EQ(ys[j], xs[j + 4][7]);
+
+  stan::test::indexing::test_throw_ia(xs, index_list(index_min_max(3, 6), index_uni(7)), ys);
+  stan::test::indexing::test_throw(xs, index_list(index_min_max(4, 6), index_uni(0)), ys);
+  stan::test::indexing::test_throw(xs, index_list(index_min_max(4, 6), index_uni(30)), ys);
+}
+
+TEST(ModelIndexing, lvalueVecUni) {
+  using stan::math::assign;
+  using stan::math::index_list;
+  using stan::math::index_uni;
+  Eigen::VectorXd xs(5);
+  xs << 0, 1, 2, 3, 4;
+  double y = 13;
+  assign(xs, index_list(index_uni(3)), y);
+  EXPECT_FLOAT_EQ(y, xs(2));
+
+  stan::test::indexing::test_throw(xs, index_list(index_uni(0)), y);
+  stan::test::indexing::test_throw(xs, index_list(index_uni(6)), y);
+}
+
+TEST(ModelIndexing, lvalueRowVecUni) {
+  using stan::math::assign;
+  using stan::math::index_list;
+  using stan::math::index_uni;
+  using stan::math::nil_index_list;
+  Eigen::RowVectorXd xs(5);
+  xs << 0, 1, 2, 3, 4;
+  double y = 13;
+  assign(xs, index_list(index_uni(3)), y);
+  EXPECT_FLOAT_EQ(y, xs(2));
+  stan::test::indexing::test_throw(xs, index_list(index_uni(0)), y);
+  stan::test::indexing::test_throw(xs, index_list(index_uni(6)), y);
+}
+
+TEST(ModelIndexing, lvalueVecMulti) {
+  using stan::math::assign;
+  using stan::math::index_list;
+  using stan::math::index_min;
+  using stan::math::index_multi;
+  Eigen::VectorXd xs(5);
+  xs << 0, 1, 2, 3, 4;
+  Eigen::VectorXd ys(3);
+  ys << 10, 11, 12;
+  assign(xs, index_list(index_min(3)), ys);
+  EXPECT_FLOAT_EQ(ys(0), xs(2));
+  EXPECT_FLOAT_EQ(ys(1), xs(3));
+  EXPECT_FLOAT_EQ(ys(2), xs(4));
+  stan::test::indexing::test_throw_ia(xs, index_list(index_min(0)), ys);
+
+  xs << 0, 1, 2, 3, 4;
+  std::vector<int> ns;
+  ns.push_back(4);
+  ns.push_back(1);
+  ns.push_back(3);
+  assign(xs, index_list(index_multi(ns)), ys);
+  EXPECT_FLOAT_EQ(ys(0), xs(3));
+  EXPECT_FLOAT_EQ(ys(1), xs(0));
+  EXPECT_FLOAT_EQ(ys(2), xs(2));
+
+  ns[ns.size() - 1] = 0;
+  stan::test::indexing::test_throw(xs, index_list(index_multi(ns)), ys);
+
+  ns[ns.size() - 1] = 10;
+  stan::test::indexing::test_throw(xs, index_list(index_multi(ns)), ys);
+
+  ns[ns.size() - 1] = 3;
+  ns.push_back(1);
+  stan::test::indexing::test_throw_ia(xs, index_list(index_multi(ns)), ys);
+}
+
+TEST(ModelIndexing, lvalueRowVecMulti) {
+  using stan::math::assign;
+  using stan::math::index_list;
+  using stan::math::index_min;
+  using stan::math::index_multi;
+  Eigen::RowVectorXd xs(5);
+  xs << 0, 1, 2, 3, 4;
+  Eigen::RowVectorXd ys(3);
+  ys << 10, 11, 12;
+  assign(xs, index_list(index_min(3)), ys);
+  EXPECT_FLOAT_EQ(ys(0), xs(2));
+  EXPECT_FLOAT_EQ(ys(1), xs(3));
+  EXPECT_FLOAT_EQ(ys(2), xs(4));
+  stan::test::indexing::test_throw_ia(xs, index_list(index_min(2)), ys);
+  stan::test::indexing::test_throw_ia(xs, index_list(index_min(0)), ys);
+
+  xs << 0, 1, 2, 3, 4;
+  std::vector<int> ns;
+  ns.push_back(4);
+  ns.push_back(1);
+  ns.push_back(3);
+  assign(xs, index_list(index_multi(ns)), ys);
+  EXPECT_FLOAT_EQ(ys(0), xs(3));
+  EXPECT_FLOAT_EQ(ys(1), xs(0));
+  EXPECT_FLOAT_EQ(ys(2), xs(2));
+
+  ns[ns.size() - 1] = 0;
+  stan::test::indexing::test_throw(xs, index_list(index_multi(ns)), ys);
+
+  ns[ns.size() - 1] = 10;
+  stan::test::indexing::test_throw(xs, index_list(index_multi(ns)), ys);
+
+  ns[ns.size() - 1] = 3;
+  ns.push_back(1);
+  stan::test::indexing::test_throw_ia(xs, index_list(index_multi(ns)), ys);
+}
+
+TEST(ModelIndexing, lvalueMatrixUni) {
+  using stan::math::assign;
+  using stan::math::index_list;
+  using stan::math::index_uni;
+  Eigen::MatrixXd x(3, 4);
+  x << 0.0, 0.1, 0.2, 0.3, 1.0, 1.1, 1.2, 1.3, 2.0, 2.1, 2.2, 2.3;
+
+  Eigen::RowVectorXd y(4);
+  y << 10.0, 10.1, 10.2, 10.3;
+
+  assign(x, index_list(index_uni(3)), y);
+  for (int j = 0; j < 4; ++j)
+    EXPECT_FLOAT_EQ(x(2, j), y(j));
+
+  stan::test::indexing::test_throw(x, index_list(index_uni(0)), y);
+  stan::test::indexing::test_throw(x, index_list(index_uni(5)), y);
+}
+
+TEST(ModelIndexing, lvalueMatrixMulti) {
+  using stan::math::assign;
+  using stan::math::index_list;
+  using stan::math::index_min;
+  Eigen::MatrixXd x(3, 4);
+  x << 0.0, 0.1, 0.2, 0.3, 1.0, 1.1, 1.2, 1.3, 2.0, 2.1, 2.2, 2.3;
+
+  Eigen::MatrixXd y(2, 4);
+  y << 10.0, 10.1, 10.2, 10.3, 11.0, 11.1, 11.2, 11.3;
+
+  assign(x, index_list(index_min(2)), y);
+  for (int i = 0; i < 2; ++i)
+    for (int j = 0; j < 4; ++j)
+      EXPECT_FLOAT_EQ(y(i, j), x(i + 1, j));
+  stan::test::indexing::test_throw_ia(x, index_list(index_min(1)), y);
+
+  Eigen::MatrixXd z(1, 2);
+  z << 10, 20;
+  stan::test::indexing::test_throw_ia(x, index_list(index_min(1)), z);
+  stan::test::indexing::test_throw_ia(x, index_list(index_min(2)), z);
+}
+
+TEST(ModelIndexing, lvalueMatrixUniUni) {
+  using stan::math::assign;
+  using stan::math::index_list;
+  using stan::math::index_uni;
+  Eigen::MatrixXd x(3, 4);
+  x << 0.0, 0.1, 0.2, 0.3, 1.0, 1.1, 1.2, 1.3, 2.0, 2.1, 2.2, 2.3;
+
+  double y = 10.12;
+  assign(x, index_list(index_uni(2), index_uni(3)), y);
+  EXPECT_FLOAT_EQ(y, x(1, 2));
+
+  stan::test::indexing::test_throw(x, index_list(index_uni(0), index_uni(3)), y);
+  stan::test::indexing::test_throw(x, index_list(index_uni(2), index_uni(0)), y);
+  stan::test::indexing::test_throw(x, index_list(index_uni(4), index_uni(3)), y);
+  stan::test::indexing::test_throw(x, index_list(index_uni(2), index_uni(5)), y);
+}
+
+TEST(ModelIndexing, lvalueMatrixUniMulti) {
+  using stan::math::assign;
+  using stan::math::index_list;
+  using stan::math::index_multi;
+  using stan::math::index_min_max;
+  using stan::math::index_uni;
+  Eigen::MatrixXd x(3, 4);
+  x << 0.0, 0.1, 0.2, 0.3, 1.0, 1.1, 1.2, 1.3, 2.0, 2.1, 2.2, 2.3;
+
+  Eigen::RowVectorXd y(3);
+  y << 10, 11, 12;
+  puts("1");
+  assign(x, index_list(index_uni(2), index_min_max(2, 4)), y);
+  EXPECT_FLOAT_EQ(y(0), x(1, 1));
+  EXPECT_FLOAT_EQ(y(1), x(1, 2));
+  EXPECT_FLOAT_EQ(y(2), x(1, 3));
+
+  puts("2");
+  stan::test::indexing::test_throw(x, index_list(index_uni(0), index_min_max(2, 4)), y);
+  puts("3");
+  stan::test::indexing::test_throw(x, index_list(index_uni(5), index_min_max(2, 4)), y);
+  puts("4");
+  stan::test::indexing::test_throw(x, index_list(index_uni(2), index_min_max(0, 2)), y);
+  puts("5");
+  stan::test::indexing::test_throw_ia(x, index_list(index_uni(2), index_min_max(2, 5)), y);
+
+  std::vector<int> ns;
+  ns.push_back(4);
+  ns.push_back(1);
+  ns.push_back(3);
+  puts("6");
+  std::cout << "\nx: \n" << x << "\n";
+  assign(x, index_list(index_uni(3), index_multi(ns)), y);
+  std::cout << "\nnewx: \n" << x << "\n";
+  std::cout << "\ny: \n" << y << "\n";
+  EXPECT_FLOAT_EQ(y(0), x(2, 3));
+  EXPECT_FLOAT_EQ(y(1), x(2, 0));
+  EXPECT_FLOAT_EQ(y(2), x(2, 2));
+
+  ns[ns.size() - 1] = 0;
+  stan::test::indexing::test_throw(x, index_list(index_uni(3), index_multi(ns)), y);
+
+  ns[ns.size() - 1] = 20;
+  stan::test::indexing::test_throw(x, index_list(index_uni(3), index_multi(ns)), y);
+
+  ns.push_back(2);
+  stan::test::indexing::test_throw_ia(x, index_list(index_uni(3), index_multi(ns)), y);
+}
+
+TEST(ModelIndexing, lvalueMatrixMultiUni) {
+  using stan::math::assign;
+  using stan::math::index_list;
+  using stan::math::index_min_max;
+  using stan::math::index_uni;
+  using stan::math::index_multi;
+  Eigen::MatrixXd x(3, 4);
+  x << 0.0, 0.1, 0.2, 0.3, 1.0, 1.1, 1.2, 1.3, 2.0, 2.1, 2.2, 2.3;
+
+  Eigen::VectorXd y(2);
+  y << 10, 11;
+  puts("get1");
+  assign(x, index_list(index_min_max(2, 3), index_uni(4)), y);
+  EXPECT_FLOAT_EQ(y(0), x(1, 3));
+  EXPECT_FLOAT_EQ(y(1), x(2, 3));
+
+  stan::test::indexing::test_throw(x, index_list(index_min_max(2, 3), index_uni(0)), y);
+  stan::test::indexing::test_throw(x, index_list(index_min_max(2, 3), index_uni(5)), y);
+  stan::test::indexing::test_throw(x, index_list(index_min_max(0, 1), index_uni(4)), y);
+  stan::test::indexing::test_throw_ia(x, index_list(index_min_max(1, 3), index_uni(4)), y);
+
+  std::vector<int> ns;
+  ns.push_back(3);
+  ns.push_back(1);
+  puts("get2");
+  assign(x, index_list(index_multi(ns), index_uni(3)), y);
+  EXPECT_FLOAT_EQ(y(0), x(2, 2));
+  EXPECT_FLOAT_EQ(y(1), x(0, 2));
+
+  ns[ns.size() - 1] = 0;
+  stan::test::indexing::test_throw(x, index_list(index_multi(ns), index_uni(3)), y);
+
+  ns[ns.size() - 1] = 20;
+  stan::test::indexing::test_throw(x, index_list(index_multi(ns), index_uni(3)), y);
+
+  ns.push_back(2);
+  stan::test::indexing::test_throw_ia(x, index_list(index_multi(ns), index_uni(3)), y);
+}
+
+TEST(ModelIndexing, lvalueMatrixMultiMulti) {
+  using stan::math::assign;
+  using stan::math::index_list;
+  using stan::math::index_min_max;
+  using stan::math::index_min;
+  using stan::math::index_multi;
+  Eigen::MatrixXd x(3, 4);
+  x << 0.0, 0.1, 0.2, 0.3, 1.0, 1.1, 1.2, 1.3, 2.0, 2.1, 2.2, 2.3;
+
+  Eigen::MatrixXd y(2, 3);
+  y << 10, 11, 12, 20, 21, 22;
+  assign(x, index_list(index_min_max(2, 3), index_min(2)), y);
+  EXPECT_FLOAT_EQ(y(0, 0), x(1, 1));
+  EXPECT_FLOAT_EQ(y(0, 1), x(1, 2));
+  EXPECT_FLOAT_EQ(y(0, 2), x(1, 3));
+  EXPECT_FLOAT_EQ(y(1, 0), x(2, 1));
+  EXPECT_FLOAT_EQ(y(1, 1), x(2, 2));
+  EXPECT_FLOAT_EQ(y(1, 2), x(2, 3));
+
+  stan::test::indexing::test_throw_ia(x, index_list(index_min_max(2, 3), index_min(0)), y);
+  stan::test::indexing::test_throw_ia(x, index_list(index_min_max(2, 3), index_min(10)), y);
+  stan::test::indexing::test_throw_ia(x, index_list(index_min_max(1, 3), index_min(2)), y);
+
+  x << 0.0, 0.1, 0.2, 0.3, 1.0, 1.1, 1.2, 1.3, 2.0, 2.1, 2.2, 2.3;
+  std::vector<int> ms;
+  ms.push_back(3);
+  ms.push_back(1);
+
+  std::vector<int> ns;
+  ns.push_back(2);
+  ns.push_back(3);
+  ns.push_back(1);
+  assign(x, index_list(index_multi(ms), index_multi(ns)), y);
+  EXPECT_FLOAT_EQ(y(0, 0), x(2, 1));
+  EXPECT_FLOAT_EQ(y(0, 1), x(2, 2));
+  EXPECT_FLOAT_EQ(y(0, 2), x(2, 0));
+  EXPECT_FLOAT_EQ(y(1, 0), x(0, 1));
+  EXPECT_FLOAT_EQ(y(1, 1), x(0, 2));
+  EXPECT_FLOAT_EQ(y(1, 2), x(0, 0));
+
+  ms[ms.size() - 1] = 0;
+  stan::test::indexing::test_throw(x, index_list(index_multi(ms), index_multi(ns)), y);
+
+  ms[ms.size() - 1] = 10;
+  stan::test::indexing::test_throw(x, index_list(index_multi(ms), index_multi(ns)), y);
+
+  ms[ms.size() - 1] = 1;  // back to original valid value
+  ns[ns.size() - 1] = 0;
+  stan::test::indexing::test_throw(x, index_list(index_multi(ms), index_multi(ns)), y);
+
+  ns[ns.size() - 1] = 10;
+  stan::test::indexing::test_throw(x, index_list(index_multi(ms), index_multi(ns)), y);
+}
+
+TEST(ModelIndexing, doubleToVar) {
+  using stan::math::assign;
+  using stan::math::index_list;
+  using stan::math::index_uni;
+  using stan::math::index_multi;
+  using stan::math::index_omni;
+  using stan::math::nil_index_list;
+  using stan::math::var;
+  using Eigen::Dynamic;
+  std::vector<double> xs;
+  xs.push_back(1);
+  xs.push_back(2);
+  xs.push_back(3);
+  std::vector<std::vector<double> > xss;
+  xss.push_back(xs);
+
+  std::vector<var> ys(3);
+  std::vector<std::vector<var> > yss;
+  yss.push_back(ys);
+
+  assign(yss, index_list(index_omni()), xss, "foo");
+
+  // test both cases where matrix indexed by rows
+  // case 1: double matrix with single multi-index on LHS, var matrix on RHS
+  Eigen::Matrix<var, Dynamic, Dynamic> a(4, 3);
+  for (int i = 0; i < 12; ++i)
+    a(i) = -(i + 1);
+
+  Eigen::Matrix<double, Dynamic, Dynamic> b(2, 3);
+  b << 1, 2, 3, 4, 5, 6;
+
+  std::vector<int> is;
+  is.push_back(2);
+  is.push_back(3);
+  assign(a, index_list(index_multi(is)), b);
+  for (int i = 0; i < 2; ++i)
+    for (int j = 0; j < 3; ++j)
+      EXPECT_FLOAT_EQ(a(i + 1, j).val(), b(i, j));
+
+  // case 2: double matrix with single multi-index on LHS, row vector
+  // on RHS
+  Eigen::Matrix<var, Dynamic, Dynamic> c(4, 3);
+  for (int i = 0; i < 12; ++i)
+    c(i) = -(i + 1);
+  Eigen::Matrix<double, 1, Dynamic> d(3);
+  d << 100, 101, 102;
+  assign(c, index_list(index_uni(2)), d);
+  for (int j = 0; j < 3; ++j)
+    EXPECT_FLOAT_EQ(c(1, j).val(), d(j));
+}
+TEST(ModelIndexing, resultSizeNegIndexing) {
+  using stan::math::assign;
+  using stan::math::index_list;
+  using stan::math::index_min_max;
+
+  std::vector<double> rhs;
+  rhs.push_back(2);
+  rhs.push_back(5);
+  rhs.push_back(-125);
+
+  std::vector<double> lhs;
+  assign(rhs, index_list(index_min_max(1, 0)), lhs);
+  EXPECT_EQ(0, lhs.size());
+}
+
+TEST(ModelIndexing, resultSizeIndexingEigen) {
+  using stan::math::assign;
+  using stan::math::index_list;
+  using stan::math::index_min_max;
+  Eigen::VectorXd lhs(5);
+  lhs << 1, 2, 3, 4, 5;
+  Eigen::VectorXd rhs(4);
+  rhs << 4, 3, 2, 1;
+  assign(lhs, index_list(index_min_max(1, 4)), rhs);
+  EXPECT_FLOAT_EQ(lhs(0), 4);
+  EXPECT_FLOAT_EQ(lhs(1), 3);
+  EXPECT_FLOAT_EQ(lhs(2), 2);
+  EXPECT_FLOAT_EQ(lhs(3), 1);
+  EXPECT_FLOAT_EQ(lhs(4), 5);
+}
+
+TEST(ModelIndexing, resultSizeNegIndexingEigen) {
+  using stan::math::assign;
+  using stan::math::index_list;
+  using stan::math::index_min_max;
+  Eigen::VectorXd lhs(5);
+  lhs << 1, 2, 3, 4, 5;
+  Eigen::VectorXd rhs(4);
+  rhs << 1, 2, 3, 4;
+  assign(lhs, index_list(index_min_max(4, 1)), rhs);
+  EXPECT_FLOAT_EQ(lhs(0), 4);
+  EXPECT_FLOAT_EQ(lhs(1), 3);
+  EXPECT_FLOAT_EQ(lhs(2), 2);
+  EXPECT_FLOAT_EQ(lhs(3), 1);
+  EXPECT_FLOAT_EQ(lhs(4), 5);
+}
+
+TEST(ModelIndexing, resultSizePosMinMaxPosMinMaxEigenMatrix) {
+  using stan::math::assign;
+  using stan::math::cons_list;
+  using stan::math::index_list;
+  using stan::math::index_min_max;
   using std::vector;
-  vector<vector<vector<double> > > x(
-      4, vector<vector<double> >(3, vector<double>(2)));
-  for (size_t k = 0; k < 4; ++k)
-    for (size_t i = 0; i < 3; ++i)
-      for (size_t j = 0; j < 2; ++j)
-        x[k][i][j] = (i + 1) * (j - 10) * (20 * k + 100);
+  Eigen::Matrix<double, -1, -1> x(5, 5);
+  Eigen::Matrix<double, -1, -1> x_rev(5, 5);
+  for (int i = 0; i < x.size(); ++i) {
+    x(i) = i;
+    x_rev(i) = x.size() - i - 1;
+  }
 
-  vector<vector<vector<double> > > y(
-      4, vector<vector<double> >(3, vector<double>(2)));
-
-  assign(y, x);
-  EXPECT_EQ(4U, y.size());
-  for (size_t k = 0; k < 4U; ++k) {
-    EXPECT_EQ(3U, y[k].size());
-    for (size_t i = 0; i < 3U; ++i) {
-      EXPECT_EQ(2U, y[k][i].size());
-      for (size_t j = 0; j < 2U; ++j) {
-        EXPECT_FLOAT_EQ(x[k][i][j], y[k][i][j]);
+  for (int i = 0; i < x.rows(); ++i) {
+    Eigen::MatrixXd x_colwise_rev = x_rev.block(0, 0, i + 1, i + 1);
+    assign(x, index_list(index_min_max(1, i + 1), index_min_max(1, i + 1)),
+           x_rev.block(0, 0, i + 1, i + 1));
+    for (int kk = 0; kk < i; ++kk) {
+      for (int jj = 0; jj < i; ++jj) {
+        EXPECT_FLOAT_EQ(x(kk, jj), x_rev(kk, jj));
       }
     }
-  }
-}
-
-TEST(MathMatrixPrimMat, vectorEigenVector) {
-  using Eigen::Dynamic;
-  using Eigen::Matrix;
-  using stan::math::assign;
-  using std::vector;
-
-  vector<Matrix<double, Dynamic, 1> > x(2, Matrix<double, Dynamic, 1>(3));
-  for (size_t i = 0; i < 2; ++i)
-    for (int j = 0; j < 3; ++j)
-      x[i](j) = (i + 1) * (10 * j + 2);
-  vector<Matrix<double, Dynamic, 1> > y(2, Matrix<double, Dynamic, 1>(3));
-
-  assign(y, x);
-
-  EXPECT_EQ(2U, y.size());
-  for (size_t i = 0; i < 2U; ++i) {
-    EXPECT_EQ(3U, y[i].size());
-    for (size_t j = 0; j < 3U; ++j) {
-      EXPECT_FLOAT_EQ(x[i](j), y[i](j));
+    for (int j = 0; j < x.size(); ++j) {
+      x(j) = j;
     }
   }
 }
 
-TEST(MathMatrixPrimMat, getAssignRow) {
-  using Eigen::Dynamic;
-  using Eigen::Matrix;
+TEST(ModelIndexing, resultSizePosMinMaxNegMinMaxEigenMatrix) {
   using stan::math::assign;
-  using stan::math::get_base1_lhs;
+  using stan::math::cons_list;
+  using stan::math::index_list;
+  using stan::math::index_min_max;
+  Eigen::Matrix<double, -1, -1> x(5, 5);
+  Eigen::Matrix<double, -1, -1> x_rev(5, 5);
+  for (int i = 0; i < x.size(); ++i) {
+    x(i) = i;
+    x_rev(i) = x.size() - i - 1;
+  }
 
-  Matrix<double, Dynamic, Dynamic> m(2, 3);
-  m << 1, 2, 3, 4, 5, 6;
+  for (int i = 0; i < x.rows(); ++i) {
+    Eigen::MatrixXd x_rowwise_reverse
+        = x_rev.block(0, 0, i + 1, i + 1).rowwise().reverse();
+    assign(x, index_list(index_min_max(1, i + 1), index_min_max(i + 1, 1)),
+           x_rev.block(0, 0, i + 1, i + 1));
+    for (int kk = 0; kk < i; ++kk) {
+      for (int jj = 0; jj < i; ++jj) {
+        EXPECT_FLOAT_EQ(x(kk, jj), x_rowwise_reverse(kk, jj));
+      }
+    }
+    for (int j = 0; j < x.size(); ++j) {
+      x(j) = j;
+    }
+  }
+}
 
-  Matrix<double, 1, Dynamic> rv(3);
-  rv << 10, 100, 1000;
+TEST(ModelIndexing, resultSizeNigMinMaxPosMinMaxEigenMatrix) {
+  using stan::math::assign;
+  using stan::math::cons_list;
+  using stan::math::index_list;
+  using stan::math::index_min_max;
+  Eigen::Matrix<double, -1, -1> x(5, 5);
+  Eigen::Matrix<double, -1, -1> x_rev(5, 5);
+  for (int i = 0; i < x.size(); ++i) {
+    x(i) = i;
+    x_rev(i) = x.size() - i - 1;
+  }
 
-  assign(get_base1_lhs(m, 1, "m", 1), rv);
-  EXPECT_FLOAT_EQ(10.0, m(0, 0));
-  EXPECT_FLOAT_EQ(100.0, m(0, 1));
-  EXPECT_FLOAT_EQ(1000.0, m(0, 2));
+  for (int i = 0; i < x.rows(); ++i) {
+    Eigen::MatrixXd x_colwise_reverse
+        = x_rev.block(0, 0, i + 1, i + 1).colwise().reverse();
+    assign(x, index_list(index_min_max(i + 1, 1), index_min_max(1, i + 1)),
+           x_rev.block(0, 0, i + 1, i + 1));
+    for (int kk = 0; kk < i; ++kk) {
+      for (int jj = 0; jj < i; ++jj) {
+        EXPECT_FLOAT_EQ(x(kk, jj), x_colwise_reverse(kk, jj));
+      }
+    }
+    for (int j = 0; j < x.size(); ++j) {
+      x(j) = j;
+    }
+  }
+}
+
+TEST(ModelIndexing, resultSizeNegMinMaxNegMinMaxEigenMatrix) {
+  using stan::math::assign;
+  using stan::math::cons_list;
+  using stan::math::index_list;
+  using stan::math::index_min_max;
+  Eigen::Matrix<double, -1, -1> x(5, 5);
+  Eigen::Matrix<double, -1, -1> x_rev(5, 5);
+  for (int i = 0; i < x.size(); ++i) {
+    x(i) = i;
+    x_rev(i) = x.size() - i - 1;
+  }
+
+  for (int i = 0; i < x.rows(); ++i) {
+    Eigen::MatrixXd x_reverse = x_rev.block(0, 0, i + 1, i + 1).reverse();
+    assign(x, index_list(index_min_max(i + 1, 1), index_min_max(i + 1, 1)),
+           x_rev.block(0, 0, i + 1, i + 1));
+    for (int kk = 0; kk < i; ++kk) {
+      for (int jj = 0; jj < i; ++jj) {
+        EXPECT_FLOAT_EQ(x(kk, jj), x_reverse(kk, jj));
+      }
+    }
+    for (int j = 0; j < x.size(); ++j) {
+      x(j) = j;
+    }
+  }
+}
+
+TEST(modelIndexing, doubleToVarSimple) {
+  using stan::math::assign;
+  using stan::math::var;
+  using stan::math::nil_index_list;
+
+  Eigen::MatrixXd a(2, 2);
+  a << 1, 2, 3, 4;
+  Eigen::Matrix<var, -1, -1> b;
+  assign(b, nil_index_list(), a);
+  for (int i = 0; i < a.size(); ++i)
+    EXPECT_FLOAT_EQ(a(i), b(i).val());
+}
+
+TEST(model_indexing, assign_eigvec_eigvec_index_min) {
+  using stan::math::assign;
+  using stan::math::index_list;
+  using stan::math::index_min;
+  Eigen::VectorXd lhs_x(5);
+  lhs_x << 0, 1, 2, 3, 4;
+  Eigen::VectorXd rhs_y(3);
+  rhs_y << 10, 11, 12;
+  assign(lhs_x, index_list(index_min(3)), rhs_y);
+  EXPECT_FLOAT_EQ(rhs_y(0), lhs_x(2));
+  EXPECT_FLOAT_EQ(rhs_y(1), lhs_x(3));
+  EXPECT_FLOAT_EQ(rhs_y(2), lhs_x(4));
+  stan::test::indexing::test_throw_ia(lhs_x, index_list(index_min(0)), rhs_y);
+
+  assign(lhs_x, index_list(index_min(3)), rhs_y.array() + 1.0);
+  EXPECT_FLOAT_EQ(rhs_y(0) + 1.0, lhs_x(2));
+  EXPECT_FLOAT_EQ(rhs_y(1) + 1.0, lhs_x(3));
+  EXPECT_FLOAT_EQ(rhs_y(2) + 1.0, lhs_x(4));
+}
+
+TEST(model_indexing, assign_eigvec_eigvec_index_multi) {
+  using stan::math::assign;
+  using stan::math::index_list;
+  using stan::math::index_multi;
+  Eigen::VectorXd lhs_x(5);
+  lhs_x << 0, 1, 2, 3, 4;
+  Eigen::VectorXd rhs_y(3);
+  rhs_y << 10, 11, 12;
+
+  std::vector<int> ns;
+  ns.push_back(4);
+  ns.push_back(1);
+  ns.push_back(3);
+  assign(lhs_x, index_list(index_multi(ns)), rhs_y);
+  EXPECT_FLOAT_EQ(rhs_y(0), lhs_x(3));
+  EXPECT_FLOAT_EQ(rhs_y(1), lhs_x(0));
+  EXPECT_FLOAT_EQ(rhs_y(2), lhs_x(2));
+
+  assign(lhs_x, index_list(index_multi(ns)), rhs_y.array() + 4);
+  EXPECT_FLOAT_EQ(rhs_y(0) + 4, lhs_x(3));
+  EXPECT_FLOAT_EQ(rhs_y(1) + 4, lhs_x(0));
+  EXPECT_FLOAT_EQ(rhs_y(2) + 4, lhs_x(2));
+
+  ns[ns.size() - 1] = 0;
+  stan::test::indexing::test_throw(lhs_x, index_list(index_multi(ns)), rhs_y);
+
+  ns[ns.size() - 1] = 10;
+  stan::test::indexing::test_throw(lhs_x, index_list(index_multi(ns)), rhs_y);
+
+  ns[ns.size() - 1] = 3;
+  ns.push_back(1);
+  stan::test::indexing::test_throw_ia(lhs_x, index_list(index_multi(ns)), rhs_y);
+}
+
+TEST(model_indexing, assign_eigrowvec_eigrowvec_index_min) {
+  using stan::math::assign;
+  using stan::math::index_list;
+  using stan::math::index_min;
+  Eigen::RowVectorXd lhs_x(5);
+  lhs_x << 0, 1, 2, 3, 4;
+  Eigen::RowVectorXd rhs_y(3);
+  rhs_y << 10, 11, 12;
+  assign(lhs_x, index_list(index_min(3)), rhs_y);
+  EXPECT_FLOAT_EQ(rhs_y(0), lhs_x(2));
+  EXPECT_FLOAT_EQ(rhs_y(1), lhs_x(3));
+  EXPECT_FLOAT_EQ(rhs_y(2), lhs_x(4));
+  stan::test::indexing::test_throw_ia(lhs_x, index_list(index_min(0)), rhs_y);
+
+  assign(lhs_x, index_list(index_min(3)), rhs_y.array() + 1.0);
+  EXPECT_FLOAT_EQ(rhs_y(0) + 1.0, lhs_x(2));
+  EXPECT_FLOAT_EQ(rhs_y(1) + 1.0, lhs_x(3));
+  EXPECT_FLOAT_EQ(rhs_y(2) + 1.0, lhs_x(4));
+}
+
+TEST(model_indexing, assign_eigrowvec_eigrowvec_index_multi) {
+  using stan::math::assign;
+  using stan::math::index_list;
+  using stan::math::index_multi;
+  Eigen::RowVectorXd lhs_x(5);
+  lhs_x << 0, 1, 2, 3, 4;
+  Eigen::RowVectorXd rhs_y(3);
+  rhs_y << 10, 11, 12;
+
+  std::vector<int> ns;
+  ns.push_back(4);
+  ns.push_back(1);
+  ns.push_back(3);
+  assign(lhs_x, index_list(index_multi(ns)), rhs_y);
+  EXPECT_FLOAT_EQ(rhs_y(0), lhs_x(3));
+  EXPECT_FLOAT_EQ(rhs_y(1), lhs_x(0));
+  EXPECT_FLOAT_EQ(rhs_y(2), lhs_x(2));
+
+  assign(lhs_x, index_list(index_multi(ns)), rhs_y.array() + 4);
+  EXPECT_FLOAT_EQ(rhs_y(0) + 4, lhs_x(3));
+  EXPECT_FLOAT_EQ(rhs_y(1) + 4, lhs_x(0));
+  EXPECT_FLOAT_EQ(rhs_y(2) + 4, lhs_x(2));
+
+  ns[ns.size() - 1] = 0;
+  stan::test::indexing::test_throw(lhs_x, index_list(index_multi(ns)), rhs_y);
+
+  ns[ns.size() - 1] = 10;
+  stan::test::indexing::test_throw(lhs_x, index_list(index_multi(ns)), rhs_y);
+
+  ns[ns.size() - 1] = 3;
+  ns.push_back(1);
+  stan::test::indexing::test_throw_ia(lhs_x, index_list(index_multi(ns)), rhs_y);
+}
+
+TEST(model_indexing, assign_densemat_rowvec_uni_index) {
+  using stan::math::assign;
+  using stan::math::index_list;
+  using stan::math::index_uni;
+  Eigen::MatrixXd x(3, 4);
+  x << 0.0, 0.1, 0.2, 0.3, 1.0, 1.1, 1.2, 1.3, 2.0, 2.1, 2.2, 2.3;
+
+  Eigen::RowVectorXd y(4);
+  y << 10.0, 10.1, 10.2, 10.3;
+
+  assign(x, index_list(index_uni(3)), y.array() + 3);
+  for (int j = 0; j < 4; ++j)
+    EXPECT_FLOAT_EQ(x(2, j), y(j) + 3);
+
+  stan::test::indexing::test_throw(x, index_list(index_uni(0)), y);
+  stan::test::indexing::test_throw(x, index_list(index_uni(5)), y);
+}
+
+TEST(model_indexing, assign_densemat_densemat_index_min) {
+  using stan::math::assign;
+  using stan::math::index_list;
+  using stan::math::index_min;
+  Eigen::MatrixXd x(3, 4);
+  x << 0.0, 0.1, 0.2, 0.3, 1.0, 1.1, 1.2, 1.3, 2.0, 2.1, 2.2, 2.3;
+
+  Eigen::MatrixXd y(2, 4);
+  y << 10.0, 10.1, 10.2, 10.3, 11.0, 11.1, 11.2, 11.3;
+
+  assign(x, index_list(index_min(2)), y);
+  for (int i = 0; i < 2; ++i) {
+    for (int j = 0; j < 4; ++j) {
+      EXPECT_FLOAT_EQ(y(i, j), x(i + 1, j));
+    }
+  }
+  assign(x, index_list(index_min(2)), y.transpose().transpose());
+  for (int i = 0; i < 2; ++i) {
+    for (int j = 0; j < 4; ++j) {
+      EXPECT_FLOAT_EQ(y(i, j), x(i + 1, j));
+    }
+  }
+  stan::test::indexing::test_throw_ia(x, index_list(index_min(1)), y);
+
+  Eigen::MatrixXd z(1, 2);
+  z << 10, 20;
+  stan::test::indexing::test_throw_ia(x, index_list(index_min(1)), z);
+  stan::test::indexing::test_throw_ia(x, index_list(index_min(2)), z);
+}
+
+TEST(model_indexing, assign_densemat_scalar_index_uni) {
+  using stan::math::assign;
+  using stan::math::index_list;
+  using stan::math::index_uni;
+  Eigen::MatrixXd x(3, 4);
+  x << 0.0, 0.1, 0.2, 0.3, 1.0, 1.1, 1.2, 1.3, 2.0, 2.1, 2.2, 2.3;
+
+  double y = 10.12;
+  assign(x, index_list(index_uni(2), index_uni(3)), y);
+  EXPECT_FLOAT_EQ(y, x(1, 2));
+
+  stan::test::indexing::test_throw(x, index_list(index_uni(0), index_uni(3)), y);
+  stan::test::indexing::test_throw(x, index_list(index_uni(2), index_uni(0)), y);
+  stan::test::indexing::test_throw(x, index_list(index_uni(4), index_uni(3)), y);
+  stan::test::indexing::test_throw(x, index_list(index_uni(2), index_uni(5)), y);
+}
+
+TEST(model_indexing, assign_densemat_eigrowvec_uni_index_min_max_index) {
+  using stan::math::assign;
+  using stan::math::index_list;
+  using stan::math::index_uni;
+  using stan::math::index_min_max;
+  using stan::math::index_multi;
+  Eigen::MatrixXd x(3, 4);
+  x << 0.0, 0.1, 0.2, 0.3, 1.0, 1.1, 1.2, 1.3, 2.0, 2.1, 2.2, 2.3;
+
+  Eigen::RowVectorXd y(3);
+  y << 10, 11, 12;
+  assign(x, index_list(index_uni(2), index_min_max(2, 4)), y);
+  EXPECT_FLOAT_EQ(y(0), x(1, 1));
+  EXPECT_FLOAT_EQ(y(1), x(1, 2));
+  EXPECT_FLOAT_EQ(y(2), x(1, 3));
+
+  assign(x, index_list(index_uni(2), index_min_max(2, 4)), y.array() + 2);
+  EXPECT_FLOAT_EQ(y(0) + 2, x(1, 1));
+  EXPECT_FLOAT_EQ(y(1) + 2, x(1, 2));
+  EXPECT_FLOAT_EQ(y(2) + 2, x(1, 3));
+
+  stan::test::indexing::test_throw(x, index_list(index_uni(0), index_min_max(2, 4)), y);
+  stan::test::indexing::test_throw(x, index_list(index_uni(5), index_min_max(2, 4)), y);
+  stan::test::indexing::test_throw(x, index_list(index_uni(2), index_min_max(0, 2)), y);
+  stan::test::indexing::test_throw_ia(x, index_list(index_uni(2), index_min_max(2, 5)), y);
+
+  std::vector<int> ns;
+  ns.push_back(4);
+  ns.push_back(1);
+  ns.push_back(3);
+  assign(x, index_list(index_uni(3), index_multi(ns)), y);
+  EXPECT_FLOAT_EQ(y(0), x(2, 3));
+  EXPECT_FLOAT_EQ(y(1), x(2, 0));
+  EXPECT_FLOAT_EQ(y(2), x(2, 2));
+
+  assign(x, index_list(index_uni(3), index_multi(ns)), y.array() + 2);
+  EXPECT_FLOAT_EQ(y(0) + 2, x(2, 3));
+  EXPECT_FLOAT_EQ(y(1) + 2, x(2, 0));
+  EXPECT_FLOAT_EQ(y(2) + 2, x(2, 2));
+
+  ns[ns.size() - 1] = 0;
+  stan::test::indexing::test_throw(x, index_list(index_uni(3), index_multi(ns)), y);
+
+  ns[ns.size() - 1] = 20;
+  stan::test::indexing::test_throw(x, index_list(index_uni(3), index_multi(ns)), y);
+
+  ns.push_back(2);
+  stan::test::indexing::test_throw_ia(x, index_list(index_uni(3), index_multi(ns)), y);
+}
+
+TEST(model_indexing, assign_densemat_eigvec_min_max_index_uni_index) {
+  using stan::math::assign;
+  using stan::math::index_list;
+  using stan::math::index_uni;
+  using stan::math::index_min_max;
+  using stan::math::index_multi;
+  Eigen::MatrixXd x(3, 4);
+  x << 0.0, 0.1, 0.2, 0.3, 1.0, 1.1, 1.2, 1.3, 2.0, 2.1, 2.2, 2.3;
+
+  Eigen::VectorXd y(2);
+  y << 10, 11;
+
+  assign(x, index_list(index_min_max(2, 3), index_uni(4)), y);
+  EXPECT_FLOAT_EQ(y(0), x(1, 3));
+  EXPECT_FLOAT_EQ(y(1), x(2, 3));
+
+  assign(x, index_list(index_min_max(2, 3), index_uni(4)), y.array() + 2);
+  EXPECT_FLOAT_EQ(y(0) + 2, x(1, 3));
+  EXPECT_FLOAT_EQ(y(1) + 2, x(2, 3));
+
+  stan::test::indexing::test_throw(x, index_list(index_min_max(2, 3), index_uni(0)), y);
+  stan::test::indexing::test_throw(x, index_list(index_min_max(2, 3), index_uni(5)), y);
+  stan::test::indexing::test_throw(x, index_list(index_min_max(0, 1), index_uni(4)), y);
+  stan::test::indexing::test_throw_ia(x, index_list(index_min_max(1, 3), index_uni(4)), y);
+
+  std::vector<int> ns;
+  ns.push_back(3);
+  ns.push_back(1);
+  assign(x, index_list(index_multi(ns), index_uni(3)), y);
+  EXPECT_FLOAT_EQ(y(0), x(2, 2));
+  EXPECT_FLOAT_EQ(y(1), x(0, 2));
+
+  assign(x.block(0, 0, 3, 3), index_list(index_multi(ns), index_uni(3)),
+         y.array() + 2);
+  EXPECT_FLOAT_EQ(y(0) + 2, x(2, 2));
+  EXPECT_FLOAT_EQ(y(1) + 2, x(0, 2));
+
+  ns[ns.size() - 1] = 0;
+  stan::test::indexing::test_throw(x, index_list(index_multi(ns), index_uni(3)), y);
+
+  ns[ns.size() - 1] = 20;
+  stan::test::indexing::test_throw(x, index_list(index_multi(ns), index_uni(3)), y);
+
+  ns.push_back(2);
+  stan::test::indexing::test_throw_ia(x, index_list(index_multi(ns), index_uni(3)), y);
+}
+
+TEST(model_indexing, assign_densemat_densemat_min_max_index_min_index) {
+  using stan::math::assign;
+  using stan::math::index_list;
+  using stan::math::index_min;
+  using stan::math::index_min_max;
+  Eigen::MatrixXd x(3, 4);
+  x << 0.0, 0.1, 0.2, 0.3, 1.0, 1.1, 1.2, 1.3, 2.0, 2.1, 2.2, 2.3;
+
+  Eigen::MatrixXd y(2, 3);
+  y << 10, 11, 12, 20, 21, 22;
+
+  assign(x, index_list(index_min_max(2, 3), index_min(2)), y);
+  EXPECT_FLOAT_EQ(y(0, 0), x(1, 1));
+  EXPECT_FLOAT_EQ(y(0, 1), x(1, 2));
+  EXPECT_FLOAT_EQ(y(0, 2), x(1, 3));
+  EXPECT_FLOAT_EQ(y(1, 0), x(2, 1));
+  EXPECT_FLOAT_EQ(y(1, 1), x(2, 2));
+  EXPECT_FLOAT_EQ(y(1, 2), x(2, 3));
+
+  assign(x.block(0, 0, 3, 3), index_list(index_min_max(2, 3), index_min(2)),
+         y.block(0, 0, 2, 2));
+  EXPECT_FLOAT_EQ(y(0, 0), x(1, 1));
+  EXPECT_FLOAT_EQ(y(0, 1), x(1, 2));
+  EXPECT_FLOAT_EQ(y(0, 2), x(1, 3));
+  EXPECT_FLOAT_EQ(y(1, 0), x(2, 1));
+  EXPECT_FLOAT_EQ(y(1, 1), x(2, 2));
+  EXPECT_FLOAT_EQ(y(1, 2), x(2, 3));
+
+  stan::test::indexing::test_throw_ia(x, index_list(index_min_max(2, 3), index_min(0)), y);
+  stan::test::indexing::test_throw_ia(x, index_list(index_min_max(2, 3), index_min(10)), y);
+  stan::test::indexing::test_throw_ia(x, index_list(index_min_max(1, 3), index_min(2)), y);
+}
+
+TEST(model_indexing, assign_densemat_densemat_multi_index_multi_index) {
+  using stan::math::assign;
+  using stan::math::index_list;
+  using stan::math::index_multi;
+  Eigen::MatrixXd x(3, 4);
+  x << 0.0, 0.1, 0.2, 0.3, 1.0, 1.1, 1.2, 1.3, 2.0, 2.1, 2.2, 2.3;
+
+  Eigen::MatrixXd y(2, 3);
+  y << 10, 11, 12, 20, 21, 22;
+  std::vector<int> ms;
+  ms.push_back(3);
+  ms.push_back(1);
+
+  std::vector<int> ns;
+  ns.push_back(2);
+  ns.push_back(3);
+  ns.push_back(1);
+  assign(x, index_list(index_multi(ms), index_multi(ns)), y);
+  EXPECT_FLOAT_EQ(y(0, 0), x(2, 1));
+  EXPECT_FLOAT_EQ(y(0, 1), x(2, 2));
+  EXPECT_FLOAT_EQ(y(0, 2), x(2, 0));
+  EXPECT_FLOAT_EQ(y(1, 0), x(0, 1));
+  EXPECT_FLOAT_EQ(y(1, 1), x(0, 2));
+  EXPECT_FLOAT_EQ(y(1, 2), x(0, 0));
+
+  Eigen::MatrixXd y2 = y.array() + 2;
+  assign(x.block(0, 0, 3, 4), index_list(index_multi(ms), index_multi(ns)),
+         y.array() + 2);
+  EXPECT_FLOAT_EQ(y2(0, 0), x(2, 1));
+  EXPECT_FLOAT_EQ(y2(0, 1), x(2, 2));
+  EXPECT_FLOAT_EQ(y2(0, 2), x(2, 0));
+  EXPECT_FLOAT_EQ(y2(1, 0), x(0, 1));
+  EXPECT_FLOAT_EQ(y2(1, 1), x(0, 2));
+  EXPECT_FLOAT_EQ(y2(1, 2), x(0, 0));
+
+  ms[ms.size() - 1] = 0;
+  stan::test::indexing::test_throw(x, index_list(index_multi(ms), index_multi(ns)), y);
+
+  ms[ms.size() - 1] = 10;
+  stan::test::indexing::test_throw(x, index_list(index_multi(ms), index_multi(ns)), y);
+
+  ms[ms.size() - 1] = 1;  // back to original valid value
+  ns[ns.size() - 1] = 0;
+  stan::test::indexing::test_throw(x, index_list(index_multi(ms), index_multi(ns)), y);
+
+  ns[ns.size() - 1] = 10;
+  stan::test::indexing::test_throw(x, index_list(index_multi(ms), index_multi(ns)), y);
 }

--- a/test/unit/math/prim/fun/deep_copy_test.cpp
+++ b/test/unit/math/prim/fun/deep_copy_test.cpp
@@ -1,0 +1,100 @@
+#include <stan/math.hpp>
+#include <gtest/gtest.h>
+#include <vector>
+
+TEST(modelIndexingDeepCopy, scalar) {
+  using stan::math::deep_copy;
+  EXPECT_FLOAT_EQ(2.3, deep_copy(2.3));
+  EXPECT_EQ(3, deep_copy(3));
+}
+
+template <typename C>
+void test_vec() {
+  using stan::math::deep_copy;
+
+  // first test size 0
+  C a;
+  C ac = deep_copy(a);
+  EXPECT_EQ(0, ac.size());
+
+  // something bigger than size 0
+  C v(3);
+  v[0] = 1;
+  v[1] = 2;
+  v[2] = 3.5;
+
+  C vc = deep_copy(v);
+
+  // test that copies properly (no loop to avoid signed/unsigned)
+  EXPECT_EQ(v.size(), vc.size());
+  EXPECT_FLOAT_EQ(v[0], vc[0]);
+  EXPECT_FLOAT_EQ(v[1], vc[1]);
+  EXPECT_FLOAT_EQ(v[2], vc[2]);
+
+  // modifying copy should not affect original
+  vc[1] = 10;
+  EXPECT_FLOAT_EQ(10, vc[1]);
+  EXPECT_FLOAT_EQ(2, v[1]);
+}
+
+TEST(modelIndexingDeepCopy, vectorDouble) { test_vec<Eigen::VectorXd>(); }
+TEST(modelIndexingDeepCopy, rowVectorDouble) { test_vec<Eigen::RowVectorXd>(); }
+TEST(modelIndexingDeepCopy, stdVectorDouble) {
+  test_vec<std::vector<double> >();
+}
+
+TEST(modelIndexingDeepCopy, matrixDouble) {
+  using Eigen::MatrixXd;
+  using stan::math::deep_copy;
+
+  // first test size 0
+  MatrixXd a(0, 0);
+  MatrixXd ac = deep_copy(a);
+  EXPECT_EQ(0, ac.size());
+
+  // something bigger than size 0
+  MatrixXd b(2, 3);
+  b << 1, 2, 3, 4, 5, 6;
+
+  MatrixXd bc = deep_copy(b);
+  EXPECT_EQ(b.rows(), bc.rows());
+  EXPECT_EQ(b.cols(), bc.cols());
+  for (int j = 0; j < b.cols(); ++j)
+    for (int i = 0; i < b.rows(); ++i)
+      EXPECT_FLOAT_EQ(b(i, j), bc(i, j));
+
+  // modifying copy should not affect original
+  bc(0, 1) = 110;
+  EXPECT_FLOAT_EQ(110, bc(0, 1));
+  EXPECT_FLOAT_EQ(2, b(0, 1));
+}
+
+TEST(modelIndexingDeepCopy, stdVectorStdVectorDouble) {
+  using stan::math::deep_copy;
+  using std::vector;
+  typedef vector<double> doubles_t;
+  typedef vector<doubles_t> doubless_t;
+
+  doubles_t a1;
+  doubles_t a2;
+  for (size_t i = 0; i < 3; ++i) {
+    a1.push_back(i);
+    a2.push_back(i + 10);
+  }
+  doubless_t a;
+  a.push_back(a1);
+  a.push_back(a2);
+
+  doubless_t ac = deep_copy(a);
+  EXPECT_EQ(a.size(), ac.size());
+  for (size_t i = 0; i < a.size(); ++i)
+    EXPECT_EQ(a[i].size(), ac[i].size());
+
+  for (size_t i = 0; i < a.size(); ++i)
+    for (size_t j = 0; j < a[i].size(); ++j)
+      EXPECT_FLOAT_EQ(a[i][j], ac[i][j]);
+
+  ac[1][1] = 20;
+  EXPECT_FLOAT_EQ(20, ac[1][1]);
+  EXPECT_FLOAT_EQ(11, a[1][1]);
+}

--- a/test/unit/math/prim/fun/index_list_test.cpp
+++ b/test/unit/math/prim/fun/index_list_test.cpp
@@ -1,0 +1,28 @@
+#include <stan/math.hpp>
+#include <gtest/gtest.h>
+#include <vector>
+
+
+TEST(MathIndexingIndexList, cons_index_list) {
+  using stan::math::nil_index_list;
+  using stan::math::index_uni;
+  using stan::math::cons_index_list;
+  using stan::math::index_multi;
+  nil_index_list empty;  // ()
+
+  index_uni idx_u(7);
+
+  cons_index_list<index_uni, nil_index_list> cil(idx_u, empty);
+  EXPECT_EQ(index_uni(7).n_, cil.head_.n_);
+
+  std::vector<int> ns;
+  ns.push_back(3);
+  ns.push_back(17);
+  index_multi idx_m(ns);
+
+  cons_index_list<index_multi, cons_index_list<index_uni, nil_index_list> >
+      cil2(idx_m, cil);
+  EXPECT_EQ(2, cil2.head_.ns_.size());
+  EXPECT_EQ(17, cil2.head_.ns_[1]);
+  EXPECT_EQ(7, cil2.tail_.head_.n_);
+}

--- a/test/unit/math/prim/fun/index_list_test.cpp
+++ b/test/unit/math/prim/fun/index_list_test.cpp
@@ -2,12 +2,11 @@
 #include <gtest/gtest.h>
 #include <vector>
 
-
 TEST(MathIndexingIndexList, cons_index_list) {
-  using stan::math::nil_index_list;
-  using stan::math::index_uni;
   using stan::math::cons_index_list;
   using stan::math::index_multi;
+  using stan::math::index_uni;
+  using stan::math::nil_index_list;
   nil_index_list empty;  // ()
 
   index_uni idx_u(7);

--- a/test/unit/math/prim/fun/rvalue_index_size_test.cpp
+++ b/test/unit/math/prim/fun/rvalue_index_size_test.cpp
@@ -1,0 +1,58 @@
+#include <stan/math.hpp>
+#include <gtest/gtest.h>
+#include <vector>
+
+// error checking is during indexing, not during index construction
+// so no tests here for out of bounds
+
+TEST(modelIndexingRvalueIndexSize, multi) {
+  using stan::math::index_multi;
+  using stan::math::rvalue_index_size;
+
+  std::vector<int> ns;
+  ns.push_back(1);
+  ns.push_back(2);
+
+  index_multi idx(ns);
+  EXPECT_EQ(2, rvalue_index_size(idx, 10));
+}
+
+TEST(modelIndexingRvalueIndexSize, omni) {
+  using stan::math::index_omni;
+  using stan::math::rvalue_index_size;
+
+  index_omni idx;
+  EXPECT_EQ(10, rvalue_index_size(idx, 10));
+}
+
+TEST(modelIndexingRvalueIndexSize, min) {
+  using stan::math::index_min;
+  using stan::math::rvalue_index_size;
+
+  index_min idx(3);
+  EXPECT_EQ(8, rvalue_index_size(idx, 10));
+}
+
+TEST(modelIndexingRvalueIndexSize, max) {
+  using stan::math::index_max;
+  using stan::math::rvalue_index_size;
+
+  index_max idx(5);
+  EXPECT_EQ(5, rvalue_index_size(idx, 10));
+}
+
+TEST(modelIndexingRvalueIndexSize, minMax) {
+  using stan::math::index_min_max;
+  using stan::math::rvalue_index_size;
+  index_min_max mm(1, 3);
+  EXPECT_EQ(3, rvalue_index_size(mm, 10));
+
+  index_min_max mm2(3, 3);
+  EXPECT_EQ(1, rvalue_index_size(mm2, 10));
+
+  index_min_max mm3(3, 1);
+  EXPECT_EQ(0, rvalue_index_size(mm3, 10));
+
+  index_min_max mm4(1, 0);
+  EXPECT_EQ(0, rvalue_index_size(mm3, 10));
+}

--- a/test/unit/math/prim/meta/index_test.cpp
+++ b/test/unit/math/prim/meta/index_test.cpp
@@ -1,0 +1,47 @@
+#include <type_traits>
+#include <vector>
+#include <stan/math.hpp>
+#include <gtest/gtest.h>
+
+TEST(MathIndexingIndex, index_uni) {
+  using stan::math::index_uni;
+  index_uni idx(17);
+  EXPECT_EQ(17, idx.n_);
+}
+
+TEST(MathIndexingIndex, index_multi) {
+  using stan::math::index_multi;
+  std::vector<int> ns;
+  ns.push_back(3);
+  ns.push_back(23);
+
+  index_multi idx(ns);
+  EXPECT_EQ(2, idx.ns_.size());
+  for (size_t i = 0; i < ns.size(); ++i)
+    EXPECT_EQ(ns[i], idx.ns_[i]);
+}
+
+TEST(MathIndexingIndex, index_omni) {
+  using stan::math::index_omni;
+  index_omni idx;
+  (void)idx;  // just to silence compiler griping about idx being unused
+}
+
+TEST(MathIndexingIndex, index_min) {
+  using stan::math::index_min;
+  index_min idx(3);
+  EXPECT_EQ(3, idx.min_);
+}
+
+TEST(MathIndexingIndex, index_max) {
+  using stan::math::index_max;
+  index_max idx(912);
+  EXPECT_EQ(912, idx.max_);
+}
+
+TEST(MathIndexingIndex, index_min_max) {
+  using stan::math::index_min_max;
+  index_min_max idx(401, 912);
+  EXPECT_EQ(401, idx.min_);
+  EXPECT_EQ(912, idx.max_);
+}


### PR DESCRIPTION
## Summary

This backports (up-ports?) the assign functions from the Stan repo into this repo and refactors the `assign()` function to allow for better slice indexing

The scheme here is that for slicing like `A[2:5, 1:10]` `Vector[1:10]` we want to translate that directly into Eigen's `block()` or `.segment()`  functions. For functions that slice over rows and columns like `A[, {1, 3, 8}]` and `A[1:N, :N]` So that Eigen knows what columns it's slicing by first and then the slice of rows.

## Tests

Tests were added for the new overloads and can be run with

```
./runTests.py ./test/unit/math/prim/fun/assign_test.cpp
./runTests.py ./test/unit/math/prim/ -f index
./runTests.py ./test/unit/math/prim/ -f rvalue
```

@t4c1 would you have time to help me add the `assign()` functions here to the expression testing framework? It's not clear to me how to add all the combinations of index types

## Side Effects

This should have no side effects until we change the compiler to use the `assign` function in the `stan::math` namespace instead of the ones defined in the `stan::model` namespace

## Release notes

Assign statements in Stan have better support for slice indexing

## Checklist

- [ ] Math issue #(issue number)

- [x] Copyright holder: Steve Bronder

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
