### PR TITLE
fixed arena_matrix_cl

### DIFF
--- a/stan/math/opencl/rev/arena_matrix_cl.hpp
+++ b/stan/math/opencl/rev/arena_matrix_cl.hpp
@@ -2,7 +2,7 @@
 #define STAN_MATH_OPENCL_REV_ARENA_MATRIX_CL_HPP
 #ifdef STAN_OPENCL
 
-#include <stan/math/rev/core/chainable_alloc.hpp>
+#include <stan/math/rev/core/needs_destructor.hpp>
 #include <stan/math/opencl/kernel_generator/is_kernel_expression.hpp>
 #include <stan/math/opencl/matrix_cl.hpp>
 #include <utility>
@@ -15,7 +15,7 @@ namespace math {
  * can be used on the AD stack.
  */
 template <typename T>
-class arena_matrix_cl : public chainable_alloc, public matrix_cl<T> {
+class arena_matrix_cl : public needs_destructor, public matrix_cl<T> {
  public:
   using Scalar = typename matrix_cl<T>::Scalar;
   using type = typename matrix_cl<T>::type;
@@ -28,10 +28,13 @@ class arena_matrix_cl : public chainable_alloc, public matrix_cl<T> {
    */
   template <typename... Args>
   explicit arena_matrix_cl(Args&&... args)
-      : chainable_alloc(), matrix_cl<T>(std::forward<Args>(args)...) {}
+      : needs_destructor(), matrix_cl<T>(std::forward<Args>(args)...) {}
 
-  arena_matrix_cl(const arena_matrix_cl&) = default;
-  arena_matrix_cl(arena_matrix_cl&) = default;
+  arena_matrix_cl(const arena_matrix_cl& other) = default;
+//      : matrix_cl<T>(other.buffer(), other.rows(), other.cols(), other.view()) {
+//    read_events_ = other.read_events();
+//    write_events_ = other.write_events();
+//  }
   arena_matrix_cl(arena_matrix_cl&&) = default;
 
   /**
@@ -42,7 +45,13 @@ class arena_matrix_cl : public chainable_alloc, public matrix_cl<T> {
   template <typename Expr,
             require_all_kernel_expressions_and_none_scalar_t<Expr>* = nullptr>
   arena_matrix_cl(const Expr& expression)  // NOLINT(runtime/explicit)
-      : chainable_alloc(), matrix_cl<T>(expression) {}
+      : needs_destructor(), matrix_cl<T>(expression) {}
+
+//  void destroy() { ~matrix_cl<T>(); }
+//  ~arena_matrix_cl() {
+//    read_events_.~vector();
+//    write_events_.~vector();
+//  }
 };
 
 }  // namespace math

--- a/stan/math/opencl/rev/arena_matrix_cl.hpp
+++ b/stan/math/opencl/rev/arena_matrix_cl.hpp
@@ -31,10 +31,6 @@ class arena_matrix_cl : public needs_destructor, public matrix_cl<T> {
       : needs_destructor(), matrix_cl<T>(std::forward<Args>(args)...) {}
 
   arena_matrix_cl(const arena_matrix_cl& other) = default;
-//      : matrix_cl<T>(other.buffer(), other.rows(), other.cols(), other.view()) {
-//    read_events_ = other.read_events();
-//    write_events_ = other.write_events();
-//  }
   arena_matrix_cl(arena_matrix_cl&&) = default;
 
   /**
@@ -46,12 +42,6 @@ class arena_matrix_cl : public needs_destructor, public matrix_cl<T> {
             require_all_kernel_expressions_and_none_scalar_t<Expr>* = nullptr>
   arena_matrix_cl(const Expr& expression)  // NOLINT(runtime/explicit)
       : needs_destructor(), matrix_cl<T>(expression) {}
-
-//  void destroy() { ~matrix_cl<T>(); }
-//  ~arena_matrix_cl() {
-//    read_events_.~vector();
-//    write_events_.~vector();
-//  }
 };
 
 }  // namespace math

--- a/stan/math/rev/core/autodiffstackstorage.hpp
+++ b/stan/math/rev/core/autodiffstackstorage.hpp
@@ -114,6 +114,7 @@ struct AutodiffStackSingleton {
     std::vector<size_t> nested_var_stack_sizes_;
     std::vector<size_t> nested_var_nochain_stack_sizes_;
     std::vector<size_t> nested_var_alloc_stack_starts_;
+    std::vector<size_t> nested_destructor_stack_starts_;
   };
 
   explicit AutodiffStackSingleton(AutodiffStackSingleton_t const &) = delete;

--- a/stan/math/rev/core/autodiffstackstorage.hpp
+++ b/stan/math/rev/core/autodiffstackstorage.hpp
@@ -24,6 +24,9 @@ namespace math {
 #define STAN_THREADS_DEF
 #endif
 
+//forward declaration
+class needs_destructor;
+
 /**
  * This struct always provides access to the autodiff stack using
  * the singleton pattern. Read warnings below!
@@ -104,6 +107,7 @@ struct AutodiffStackSingleton {
     std::vector<ChainableT *> var_stack_;
     std::vector<ChainableT *> var_nochain_stack_;
     std::vector<ChainableAllocT *> var_alloc_stack_;
+    std::vector<needs_destructor *> destructor_stack_;
     stack_alloc memalloc_;
 
     // nested positions

--- a/stan/math/rev/core/needs_destructor.hpp
+++ b/stan/math/rev/core/needs_destructor.hpp
@@ -1,0 +1,56 @@
+#ifndef STAN_MATH_REV_CORE_NEEDS_DESTRUCTOR_HPP
+#define STAN_MATH_REV_CORE_NEEDS_DESTRUCTOR_HPP
+
+namespace stan {
+namespace math {
+
+/**
+ * A base for any type that can be allocated in arena that is not default
+ * destructible. This ensures the destructor is actually called when the arena
+ * memory is recovered. Different than `chainable_alloc` this does not require
+ * objects to be directly allocated by `new`. They can for example also be just
+ * members of a larger object.
+ */
+class needs_destructor {
+  needs_destructor** stack_location_;
+
+ public:
+  /**
+   * Default constructor. Needs to be called by constructors of derived types
+   */
+  needs_destructor() {
+    if (ChainableStack::instance_->memalloc_.in_stack(this)) {
+      ChainableStack::instance_->destructor_stack_.push_back(this);
+      stack_location_ = &ChainableStack::instance_->destructor_stack_.back();
+    } else {
+      stack_location_ = nullptr;
+    }
+  }
+
+  /**
+   * Copy constructor.
+   * @param other Object to copy
+   */
+  needs_destructor(const needs_destructor& other) {
+    if (ChainableStack::instance_->memalloc_.in_stack(this)) {
+      ChainableStack::instance_->destructor_stack_.push_back(this);
+      stack_location_ = &ChainableStack::instance_->destructor_stack_.back();
+    } else {
+      stack_location_ = nullptr;
+    }
+  }
+
+  /**
+   * Destructor. Unschedules the destructor call that would happen when the
+   * arena memory is recoverd.
+   */
+  virtual ~needs_destructor() {
+    if (stack_location_ != nullptr) {
+      *stack_location_ = nullptr;
+    }
+  }
+};
+
+}  // namespace math
+}  // namespace stan
+#endif

--- a/stan/math/rev/core/needs_destructor.hpp
+++ b/stan/math/rev/core/needs_destructor.hpp
@@ -1,6 +1,8 @@
 #ifndef STAN_MATH_REV_CORE_NEEDS_DESTRUCTOR_HPP
 #define STAN_MATH_REV_CORE_NEEDS_DESTRUCTOR_HPP
 
+#include <stan/math/rev/core/chainablestack.hpp>
+
 namespace stan {
 namespace math {
 

--- a/stan/math/rev/core/recover_memory.hpp
+++ b/stan/math/rev/core/recover_memory.hpp
@@ -4,6 +4,7 @@
 #include <stan/math/rev/core/vari.hpp>
 #include <stan/math/rev/core/chainablestack.hpp>
 #include <stan/math/rev/core/empty_nested.hpp>
+#include <stan/math/rev/core/needs_destructor.hpp>
 #include <stdexcept>
 
 namespace stan {
@@ -25,6 +26,11 @@ static inline void recover_memory() {
   ChainableStack::instance_->var_nochain_stack_.clear();
   for (auto &x : ChainableStack::instance_->var_alloc_stack_) {
     delete x;
+  }
+  for (auto x : ChainableStack::instance_->destructor_stack_) {
+    if(x!=nullptr){
+      x->~needs_destructor();
+    }
   }
   ChainableStack::instance_->var_alloc_stack_.clear();
   ChainableStack::instance_->memalloc_.recover_all();

--- a/stan/math/rev/core/recover_memory_nested.hpp
+++ b/stan/math/rev/core/recover_memory_nested.hpp
@@ -44,6 +44,17 @@ static inline void recover_memory_nested() {
       ChainableStack::instance_->nested_var_alloc_stack_starts_.back());
   ChainableStack::instance_->nested_var_alloc_stack_starts_.pop_back();
 
+  for (size_t i
+       = ChainableStack::instance_->nested_destructor_stack_starts_.back();
+       i < ChainableStack::instance_->destructor_stack_.size(); ++i) {
+    if (ChainableStack::instance_->destructor_stack_[i] != nullptr) {
+      ChainableStack::instance_->destructor_stack_[i]->~needs_destructor();
+    }
+  }
+  ChainableStack::instance_->destructor_stack_.resize(
+      ChainableStack::instance_->nested_destructor_stack_starts_.back());
+  ChainableStack::instance_->nested_destructor_stack_starts_.pop_back();
+
   ChainableStack::instance_->memalloc_.recover_nested();
 }
 

--- a/stan/math/rev/core/recover_memory_nested.hpp
+++ b/stan/math/rev/core/recover_memory_nested.hpp
@@ -4,6 +4,7 @@
 #include <stan/math/rev/core/chainable_alloc.hpp>
 #include <stan/math/rev/core/chainablestack.hpp>
 #include <stan/math/rev/core/empty_nested.hpp>
+#include <stan/math/rev/core/needs_destructor.hpp>
 #include <stdexcept>
 
 namespace stan {

--- a/stan/math/rev/core/start_nested.hpp
+++ b/stan/math/rev/core/start_nested.hpp
@@ -20,6 +20,8 @@ static inline void start_nested() {
       ChainableStack::instance_->var_nochain_stack_.size());
   ChainableStack::instance_->nested_var_alloc_stack_starts_.push_back(
       ChainableStack::instance_->var_alloc_stack_.size());
+  ChainableStack::instance_->nested_destructor_stack_starts_.push_back(
+      ChainableStack::instance_->destructor_stack_.size());
   ChainableStack::instance_->memalloc_.start_nested();
 }
 

--- a/test/unit/math/opencl/rev/to_arena_test.cpp
+++ b/test/unit/math/opencl/rev/to_arena_test.cpp
@@ -18,6 +18,7 @@ TEST(AgradRev, to_arena_matrix_cl_test) {
   EXPECT_EQ(b.rows(), c.rows());
   EXPECT_EQ(b.cols(), c.cols());
   EXPECT_EQ(b.buffer()(), c.buffer()());
+  stan::math::recover_memory();
 }
 
 TEST(AgradRev, to_arena_kg_expression_test) {
@@ -35,6 +36,7 @@ TEST(AgradRev, to_arena_kg_expression_test) {
   EXPECT_EQ(b.cols(), c.cols());
   EXPECT_EQ(b.buffer()(), c.buffer()());
   EXPECT_TRUE((std::is_same<decltype(b), decltype(c)>::value));
+  stan::math::recover_memory();
 }
 
 TEST(AgradRev, to_arena_var_value_matrix_cl_test) {
@@ -60,6 +62,7 @@ TEST(AgradRev, to_arena_var_value_matrix_cl_test) {
   EXPECT_EQ(b.val().buffer()(), c.val().buffer()());
   EXPECT_EQ(b.adj().buffer()(), c.adj().buffer()());
   EXPECT_TRUE((std::is_same<decltype(b), decltype(c)>::value));
+  stan::math::recover_memory();
 }
 
 #endif

--- a/test/unit/math/rev/core/arena_matrix_test.cpp
+++ b/test/unit/math/rev/core/arena_matrix_test.cpp
@@ -26,6 +26,7 @@ TEST(AgradRev, arena_matrix_matrix_test) {
   a = MatrixXd::Ones(3, 2);
 
   EXPECT_MATRIX_EQ(a + a2 + a3 + b + b2 + e, MatrixXd::Ones(3, 2) * 9);
+  stan::math::recover_memory();
 }
 
 TEST(AgradRev, arena_matrix_vector_test) {
@@ -52,6 +53,7 @@ TEST(AgradRev, arena_matrix_vector_test) {
   a = VectorXd::Ones(3);
 
   EXPECT_MATRIX_EQ(a + a2 + a3 + b + b2 + e, VectorXd::Ones(3) * 9);
+  stan::math::recover_memory();
 }
 
 TEST(AgradRev, arena_matrix_row_vector_test) {
@@ -78,4 +80,5 @@ TEST(AgradRev, arena_matrix_row_vector_test) {
   a = RowVectorXd::Ones(3);
 
   EXPECT_MATRIX_EQ(a + a2 + a3 + b + b2 + e, RowVectorXd::Ones(3) * 9);
+  stan::math::recover_memory();
 }


### PR DESCRIPTION
## Summary

Fixes a crash that happens when calling `recover_memory` after using `arena_matrix_cl` (used internally in all rev OpenCL functions).

## Tests
Added `recover_memory()` to `arena_matrix` and `to_arena` tests.

## Side Effects
This is not the most elegant solution, but it is what I could came up with before the release. We should probably rethink the design of `arena_matrix_cl`.

## Checklist

- [ ] Math issue #2161

- [ ] Copyright holder: Tadej Ciglarič

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [ ] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [ ] the code is written in idiomatic C++ and changes are documented in the doxygen

- [ ] the new changes are tested
