### PR TITLE
use a loop when elt_multiply has two var inputs

### DIFF
--- a/stan/math/rev/fun/elt_multiply.hpp
+++ b/stan/math/rev/fun/elt_multiply.hpp
@@ -25,54 +25,36 @@ template <typename Mat1, typename Mat2,
           require_all_matrix_t<Mat1, Mat2>* = nullptr,
           require_any_rev_matrix_t<Mat1, Mat2>* = nullptr>
 auto elt_multiply(const Mat1& m1, const Mat2& m2) {
-  const auto& m1_ref = to_ref(m1);
-  const auto& m2_ref = to_ref(m2);
-  check_matching_dims("elt_multiply", "m1", m1_ref, "m2", m2_ref);
-  using inner_ret_type
-      = decltype(value_of(m1_ref).cwiseProduct(value_of(m2_ref)));
+  check_matching_dims("elt_multiply", "m1", m1, "m2", m2);
+  using inner_ret_type = decltype(value_of(m1).cwiseProduct(value_of(m2)));
   using ret_type = promote_var_matrix_t<inner_ret_type, Mat1, Mat2>;
   if (!is_constant<Mat1>::value && !is_constant<Mat2>::value) {
-    arena_t<Mat1> arena_m1 = m1_ref;
-    arena_t<Mat2> arena_m2 = m2_ref;
-    arena_t<ret_type> ret(value_of(arena_m1).cwiseProduct(value_of(arena_m2)));
+    arena_t<promote_scalar_t<var, Mat1>> arena_m1 = m1;
+    arena_t<promote_scalar_t<var, Mat2>> arena_m2 = m2;
+    arena_t<ret_type> ret(arena_m1.val().cwiseProduct(arena_m2.val()));
     reverse_pass_callback([ret, arena_m1, arena_m2]() mutable {
-      using var_m1 = arena_t<promote_scalar_t<var, Mat1>>;
-      using var_m2 = arena_t<promote_scalar_t<var, Mat2>>;
-      if (is_var_matrix<Mat1>::value || is_var_matrix<Mat2>::value) {
-        forward_as<var_m1>(arena_m1).adj()
-            += value_of(arena_m2).cwiseProduct(ret.adj());
-        forward_as<var_m2>(arena_m2).adj()
-            += value_of(arena_m1).cwiseProduct(ret.adj());
-      } else {
-        for (Eigen::Index i = 0; i < arena_m2.size(); ++i) {
-          forward_as<var_m1>(arena_m1).coeffRef(i).adj()
-              += forward_as<var_m2>(arena_m2).coeffRef(i).val()
-                 * ret.coeffRef(i).adj();
-          forward_as<var_m2>(arena_m2).coeffRef(i).adj()
-              += forward_as<var_m1>(arena_m1).coeffRef(i).val()
-                 * ret.coeffRef(i).adj();
-        }
+      for (Eigen::Index i = 0; i < arena_m2.size(); ++i) {
+        const auto ret_adj = ret.adj().coeffRef(i);
+        arena_m1.adj().coeffRef(i) += arena_m2.val().coeff(i) * ret_adj;
+        arena_m2.adj().coeffRef(i) += arena_m1.val().coeff(i) * ret_adj;
       }
     });
     return ret_type(ret);
   } else if (!is_constant<Mat1>::value) {
-    arena_t<Mat1> arena_m1 = m1_ref;
-    auto arena_m2 = to_arena(value_of(m2_ref));
-    arena_t<ret_type> ret(value_of(arena_m1).cwiseProduct(arena_m2));
+    arena_t<promote_scalar_t<var, Mat1>> arena_m1 = m1;
+    arena_t<promote_scalar_t<double, Mat2>> arena_m2 = value_of(m2);
+    arena_t<ret_type> ret(arena_m1.val().cwiseProduct(arena_m2));
     reverse_pass_callback([ret, arena_m1, arena_m2]() mutable {
       using var_m1 = arena_t<promote_scalar_t<var, Mat1>>;
-      forward_as<var_m1>(arena_m1).adj().array()
-          += arena_m2.array() * ret.adj().array();
+      arena_m1.adj().array() += arena_m2.array() * ret.adj().array();
     });
     return ret_type(ret);
   } else if (!is_constant<Mat2>::value) {
-    arena_t<Mat2> arena_m2 = m2_ref;
-    auto arena_m1 = to_arena(value_of(m1_ref));
-    arena_t<ret_type> ret(arena_m1.cwiseProduct(value_of(arena_m2)));
+    arena_t<promote_scalar_t<double, Mat1>> arena_m1 = value_of(m1);
+    arena_t<promote_scalar_t<var, Mat2>> arena_m2 = m2;
+    arena_t<ret_type> ret(arena_m1.cwiseProduct(arena_m2.val()));
     reverse_pass_callback([ret, arena_m2, arena_m1]() mutable {
-      using var_m2 = arena_t<promote_scalar_t<var, Mat2>>;
-      forward_as<var_m2>(arena_m2).adj().array()
-          += arena_m1.array() * ret.adj().array();
+      arena_m2.adj().array() += arena_m1.array() * ret.adj().array();
     });
     return ret_type(ret);
   }


### PR DESCRIPTION

## Summary

This uses a loop in `elt_multiply` in the case of two vars instead of two eigen calls for the var<mat> case and a loop for the mat<var> case that pulls out the result's adjoint. I found this to be a bit faster when comparing against an `scalar_binary_apply()` version

![image](https://user-images.githubusercontent.com/5857231/96942164-564bd580-14a2-11eb-80bb-b0a3f0586c29.png)


![image](https://user-images.githubusercontent.com/5857231/96941644-f4d73700-14a0-11eb-97b2-2b746a0728b3.png)

So apply is still better at the small N case but compared to the top right graph from [here](https://github.com/stan-dev/math/pull/2115#issuecomment-704318139) the loop version is much nicer
 
## Tests

No new tests

## Side Effects

Nope

## Release notes


## Checklist

- [ ] Math issue #(issue number)

- [x] Copyright holder: Steve Bronder

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
