### PR TITLE
Alternative bugfix for arena_matrix_cl

### DIFF
--- a/stan/math/opencl/kernel_generator/as_operation_cl.hpp
+++ b/stan/math/opencl/kernel_generator/as_operation_cl.hpp
@@ -59,7 +59,9 @@ inline scalar_<char> as_operation_cl(const bool a) { return scalar_<char>(a); }
  * @param a \c matrix_cl
  * @return \c load_ wrapping the input
  */
-template <typename T_matrix_cl, typename = require_matrix_cl_t<T_matrix_cl>>
+template <typename T_matrix_cl,
+          typename
+          = require_any_t<is_matrix_cl<T_matrix_cl>, is_arena_matrix_cl<T_matrix_cl>>>
 inline load_<T_matrix_cl> as_operation_cl(T_matrix_cl&& a) {
   return load_<T_matrix_cl>(std::forward<T_matrix_cl>(a));
 }

--- a/stan/math/opencl/kernel_generator/is_kernel_expression.hpp
+++ b/stan/math/opencl/kernel_generator/is_kernel_expression.hpp
@@ -38,6 +38,9 @@ struct is_kernel_expression_and_not_scalar
 template <typename T>
 struct is_kernel_expression_and_not_scalar<T, require_matrix_cl_t<T>>
     : std::true_type {};
+template <typename T>
+struct is_kernel_expression_and_not_scalar<T, require_arena_matrix_cl_t<T>>
+    : std::true_type {};
 
 /**
  * Determines whether a type is is a valid kernel generator expression. Valid

--- a/stan/math/opencl/kernel_generator/load.hpp
+++ b/stan/math/opencl/kernel_generator/load.hpp
@@ -35,8 +35,7 @@ class load_
   using Scalar = typename std::remove_reference_t<T>::type;
   using base = operation_cl<load_<T>, Scalar>;
   using base::var_name_;
-  static_assert(std::is_base_of<matrix_cl<Scalar>,
-                                typename std::remove_reference_t<T>>::value,
+  static_assert(disjunction<is_matrix_cl<T>, is_arena_matrix_cl<T>>::value,
                 "load_: argument a must be a matrix_cl<T>!");
   static_assert(
       std::is_arithmetic<Scalar>::value,

--- a/stan/math/opencl/matrix_cl.hpp
+++ b/stan/math/opencl/matrix_cl.hpp
@@ -469,6 +469,17 @@ class matrix_cl<T, require_arithmetic_t<T>> : public matrix_cl_base {
             require_all_kernel_expressions_and_none_scalar_t<Expr>* = nullptr>
   matrix_cl<T>& operator=(const Expr& expression);
 
+  /**
+    Evaluates `this`. This is a no-op.
+    @return `*this`
+    */
+  const matrix_cl<T>& eval() const& {
+    return *this;
+  }
+  matrix_cl<T> eval() && {
+    return std::move(*this);
+  }
+
  private:
   /**
    * Initializes the OpenCL buffer of this matrix by copying the data from given

--- a/stan/math/opencl/multiply.hpp
+++ b/stan/math/opencl/multiply.hpp
@@ -7,6 +7,7 @@
 #include <stan/math/opencl/kernel_generator.hpp>
 #include <stan/math/opencl/kernels/matrix_multiply.hpp>
 #include <stan/math/opencl/kernels/add.hpp>
+#include <stan/math/opencl/scalar_type.hpp>
 #include <stan/math/opencl/sub_block.hpp>
 #include <stan/math/opencl/zeros.hpp>
 #include <stan/math/prim/fun/Eigen.hpp>

--- a/stan/math/opencl/rev/arena_matrix_cl.hpp
+++ b/stan/math/opencl/rev/arena_matrix_cl.hpp
@@ -5,30 +5,51 @@
 #include <stan/math/rev/core/chainable_alloc.hpp>
 #include <stan/math/opencl/kernel_generator/is_kernel_expression.hpp>
 #include <stan/math/opencl/matrix_cl.hpp>
+#include <stan/math/opencl/matrix_cl_view.hpp>
 #include <utility>
 
 namespace stan {
 namespace math {
+namespace internal {
+template <typename T>
+class arena_matrix_cl_impl : public chainable_alloc, public matrix_cl<T> {
+ public:
+  using Scalar = typename matrix_cl<T>::Scalar;
+  using type = typename matrix_cl<T>::type;
+
+  template <typename... Args>
+  explicit arena_matrix_cl_impl(Args&&... args)
+      : chainable_alloc(), matrix_cl<T>(std::forward<Args>(args)...) {}
+
+  arena_matrix_cl_impl(const arena_matrix_cl_impl&) = default;
+  arena_matrix_cl_impl(arena_matrix_cl_impl&) = default;
+  arena_matrix_cl_impl(arena_matrix_cl_impl&&) = default;
+};
+
+}  // namespace internal
 
 /**
  * A variant of `matrix_cl` that schedules its destructor to be called, so it
  * can be used on the AD stack.
  */
 template <typename T>
-class arena_matrix_cl : public chainable_alloc, public matrix_cl<T> {
+class arena_matrix_cl {
+ private:
+  internal::arena_matrix_cl_impl<T>* impl_;
+
  public:
   using Scalar = typename matrix_cl<T>::Scalar;
   using type = typename matrix_cl<T>::type;
 
   /**
-   * General constructoer forwards arguments to various `matrix_cl` constructors
-   * and schedules the destructor to be called.
+   * General constructor forwards arguments to various `matrix_cl` constructors.
    * @tparam Args argument types
    * @param args arguments
    */
   template <typename... Args>
   explicit arena_matrix_cl(Args&&... args)
-      : chainable_alloc(), matrix_cl<T>(std::forward<Args>(args)...) {}
+      : impl_(
+          new internal::arena_matrix_cl_impl<T>(std::forward<Args>(args)...)) {}
 
   arena_matrix_cl(const arena_matrix_cl&) = default;
   arena_matrix_cl(arena_matrix_cl&) = default;
@@ -39,10 +60,88 @@ class arena_matrix_cl : public chainable_alloc, public matrix_cl<T> {
    * @tparam Expr expression type
    * @param expression expression
    */
+  // we need this as a separate overload, because the general constructor is
+  // explicit
   template <typename Expr,
             require_all_kernel_expressions_and_none_scalar_t<Expr>* = nullptr>
-  arena_matrix_cl(const Expr& expression)  // NOLINT(runtime/explicit)
-      : chainable_alloc(), matrix_cl<T>(expression) {}
+  arena_matrix_cl(Expr&& expression)  // NOLINT(runtime/explicit)
+      : impl_(new internal::arena_matrix_cl_impl<T>(
+          std::forward<Expr>(expression))) {}
+
+  /**
+   * Implicit conversion operator to `matrix_cl`.
+   * @return `matrix_cl` equivalent to `*this`
+   */
+  operator matrix_cl<T>() const& { return *impl_; }  // NOLINT(runtime/explicit)
+  operator matrix_cl<T>() && {                       // NOLINT(runtime/explicit)
+    return std::move(*impl_);
+  }
+
+  /**
+   * Evaluates `this`.
+   * @return `matrix_cl` equivalent to `*this`
+   */
+  matrix_cl<T> eval() const& { return *impl_; }
+  matrix_cl<T> eval() && { return std::move(*impl_); }
+
+  // Wrapers to functions with explicit template parameters are implemented
+  // without macros.
+  template <matrix_cl_view matrix_view = matrix_cl_view::Entire>
+  inline void zeros() {
+    impl_->template zeros<matrix_view>();
+  }
+  template <matrix_cl_view matrix_view = matrix_cl_view::Entire>
+  inline void zeros_strict_tri() {
+    impl_->template zeros_strict_tri<matrix_view>();
+  }
+  template <TriangularMapCL triangular_map = TriangularMapCL::LowerToUpper>
+  inline void triangular_transpose() {
+    impl_->template triangular_transpose<triangular_map>();
+  }
+
+/**
+ * Implements a wrapper for a non-const function in `matrix_cl`.
+ * @param function_name name of the function to wrap
+ */
+#define ARENA_MATRIX_CL_FUNCTION_WRAPPER(function_name)       \
+  template <typename... Args>                                 \
+  inline decltype(auto) function_name(Args&&... args) {       \
+    return impl_->function_name(std::forward<Args>(args)...); \
+  }
+
+  /**
+   * Implements a wrapper for a const function in `matrix_cl`.
+   * @param function_name name of the function to wrap
+   */
+#define ARENA_MATRIX_CL_CONST_FUNCTION_WRAPPER(function_name) \
+  template <typename... Args>                                 \
+  inline decltype(auto) function_name(Args&&... args) const { \
+    return impl_->function_name(std::forward<Args>(args)...); \
+  }
+
+  ARENA_MATRIX_CL_CONST_FUNCTION_WRAPPER(rows)
+  ARENA_MATRIX_CL_CONST_FUNCTION_WRAPPER(cols)
+  ARENA_MATRIX_CL_CONST_FUNCTION_WRAPPER(size)
+  ARENA_MATRIX_CL_CONST_FUNCTION_WRAPPER(view)
+  ARENA_MATRIX_CL_CONST_FUNCTION_WRAPPER(clear_write_events)
+  ARENA_MATRIX_CL_CONST_FUNCTION_WRAPPER(clear_read_events)
+  ARENA_MATRIX_CL_CONST_FUNCTION_WRAPPER(clear_read_write_events)
+  ARENA_MATRIX_CL_CONST_FUNCTION_WRAPPER(write_events)
+  ARENA_MATRIX_CL_CONST_FUNCTION_WRAPPER(read_events)
+  ARENA_MATRIX_CL_CONST_FUNCTION_WRAPPER(read_write_events)
+  ARENA_MATRIX_CL_CONST_FUNCTION_WRAPPER(add_read_event)
+  ARENA_MATRIX_CL_CONST_FUNCTION_WRAPPER(add_write_event)
+  ARENA_MATRIX_CL_CONST_FUNCTION_WRAPPER(add_read_write_event)
+  ARENA_MATRIX_CL_CONST_FUNCTION_WRAPPER(wait_for_write_events)
+  ARENA_MATRIX_CL_CONST_FUNCTION_WRAPPER(wait_for_read_events)
+  ARENA_MATRIX_CL_CONST_FUNCTION_WRAPPER(wait_for_read_write_events)
+  ARENA_MATRIX_CL_CONST_FUNCTION_WRAPPER(buffer)
+  ARENA_MATRIX_CL_FUNCTION_WRAPPER(buffer)
+  ARENA_MATRIX_CL_FUNCTION_WRAPPER(sub_block)
+  ARENA_MATRIX_CL_FUNCTION_WRAPPER(operator=)
+
+#undef ARENA_MATRIX_CL_FUNCTION_WRAPPER
+#undef ARENA_MATRIX_CL_CONST_FUNCTION_WRAPPER
 };
 
 }  // namespace math

--- a/stan/math/opencl/rev/arena_matrix_cl.hpp
+++ b/stan/math/opencl/rev/arena_matrix_cl.hpp
@@ -21,9 +21,11 @@ class arena_matrix_cl_impl : public chainable_alloc, public matrix_cl<T> {
   explicit arena_matrix_cl_impl(Args&&... args)
       : chainable_alloc(), matrix_cl<T>(std::forward<Args>(args)...) {}
 
-  arena_matrix_cl_impl(const arena_matrix_cl_impl&) = default;
-  arena_matrix_cl_impl(arena_matrix_cl_impl&) = default;
-  arena_matrix_cl_impl(arena_matrix_cl_impl&&) = default;
+  arena_matrix_cl_impl(const arena_matrix_cl_impl<T>&) = default;
+  arena_matrix_cl_impl(arena_matrix_cl_impl<T>&) = default;
+  arena_matrix_cl_impl(arena_matrix_cl_impl<T>&&) = default;
+  arena_matrix_cl_impl<T>& operator=(const arena_matrix_cl_impl<T>&) = default;
+  arena_matrix_cl_impl<T>& operator=(arena_matrix_cl_impl<T>&&) = default;
 };
 
 }  // namespace internal
@@ -51,9 +53,11 @@ class arena_matrix_cl {
       : impl_(new internal::arena_matrix_cl_impl<T>(
             std::forward<Args>(args)...)) {}
 
-  arena_matrix_cl(const arena_matrix_cl&) = default;
-  arena_matrix_cl(arena_matrix_cl&) = default;
-  arena_matrix_cl(arena_matrix_cl&&) = default;
+  arena_matrix_cl(const arena_matrix_cl<T>&) = default;
+  arena_matrix_cl(arena_matrix_cl<T>&) = default;
+  arena_matrix_cl(arena_matrix_cl<T>&&) = default;
+  arena_matrix_cl<T>& operator=(const arena_matrix_cl<T>&) = default;
+  arena_matrix_cl<T>& operator=(arena_matrix_cl<T>&&) = default;
 
   /**
    * Constructor from a kernel generator expression.

--- a/stan/math/opencl/rev/arena_type.hpp
+++ b/stan/math/opencl/rev/arena_type.hpp
@@ -16,9 +16,10 @@ struct arena_type_impl<stan::math::matrix_cl<T>> {
 };
 
 template <typename T>
-struct arena_type_impl<T,
-                       require_all_t<is_kernel_expression_and_not_scalar<T>,
-                                     bool_constant<!is_matrix_cl<T>::value>>> {
+struct arena_type_impl<
+    T, require_all_t<is_kernel_expression_and_not_scalar<T>,
+                     bool_constant<!is_matrix_cl<T>::value>,
+                     bool_constant<!is_arena_matrix_cl<T>::value>>> {
   using type =
       typename arena_type_impl<stan::math::matrix_cl<value_type_t<T>>>::type;
 };

--- a/stan/math/opencl/scalar_type.hpp
+++ b/stan/math/opencl/scalar_type.hpp
@@ -3,6 +3,7 @@
 #ifdef STAN_OPENCL
 
 #include <stan/math/prim/meta.hpp>
+#include <stan/math/opencl/kernel_generator/is_kernel_expression.hpp>
 #include <type_traits>
 
 namespace stan {

--- a/stan/math/opencl/scalar_type.hpp
+++ b/stan/math/opencl/scalar_type.hpp
@@ -11,7 +11,7 @@ namespace stan {
  * Return the scalar type of an OpenCL matrix.
  */
 template <typename T>
-struct scalar_type<T, require_matrix_cl_t<T>> {
+struct scalar_type<T, require_all_kernel_expressions_and_none_scalar_t<T>> {
   using type = typename scalar_type<typename std::decay_t<T>::Scalar>::type;
 };
 }  // namespace stan

--- a/stan/math/prim/meta/is_matrix_cl.hpp
+++ b/stan/math/prim/meta/is_matrix_cl.hpp
@@ -7,6 +7,9 @@
 namespace stan {
 namespace math {
 
+template <typename T>
+class arena_matrix_cl;
+
 /**
  * Non-templated base class for `matrix_cl` simplifies checking if something is
  * matrix_cl.
@@ -24,6 +27,24 @@ struct is_matrix_cl
 
 STAN_ADD_REQUIRE_UNARY(matrix_cl, is_matrix_cl, matrix_cl_group);
 STAN_ADD_REQUIRE_CONTAINER(matrix_cl, is_matrix_cl, matrix_cl_group);
+
+namespace internal {
+
+template <typename T>
+struct is_arena_matrix_cl_impl : public std::false_type {};
+
+template <typename T>
+struct is_arena_matrix_cl_impl<math::arena_matrix_cl<T>>
+    : public std::true_type {};
+
+}  // namespace internal
+
+template <typename T>
+struct is_arena_matrix_cl
+    : public internal::is_arena_matrix_cl_impl<std::decay_t<T>> {};
+
+STAN_ADD_REQUIRE_UNARY(arena_matrix_cl, is_arena_matrix_cl, matrix_cl_group);
+STAN_ADD_REQUIRE_CONTAINER(arena_matrix_cl, is_arena_matrix_cl, matrix_cl_group);
 
 }  // namespace stan
 #endif

--- a/test/unit/math/opencl/rev/to_arena_test.cpp
+++ b/test/unit/math/opencl/rev/to_arena_test.cpp
@@ -18,6 +18,7 @@ TEST(AgradRev, to_arena_matrix_cl_test) {
   EXPECT_EQ(b.rows(), c.rows());
   EXPECT_EQ(b.cols(), c.cols());
   EXPECT_EQ(b.buffer()(), c.buffer()());
+  stan::math::recover_memory();
 }
 
 TEST(AgradRev, to_arena_kg_expression_test) {
@@ -35,6 +36,7 @@ TEST(AgradRev, to_arena_kg_expression_test) {
   EXPECT_EQ(b.cols(), c.cols());
   EXPECT_EQ(b.buffer()(), c.buffer()());
   EXPECT_TRUE((std::is_same<decltype(b), decltype(c)>::value));
+  stan::math::recover_memory();
 }
 
 TEST(AgradRev, to_arena_var_value_matrix_cl_test) {
@@ -60,6 +62,7 @@ TEST(AgradRev, to_arena_var_value_matrix_cl_test) {
   EXPECT_EQ(b.val().buffer()(), c.val().buffer()());
   EXPECT_EQ(b.adj().buffer()(), c.adj().buffer()());
   EXPECT_TRUE((std::is_same<decltype(b), decltype(c)>::value));
+  stan::math::recover_memory();
 }
 
 #endif

--- a/test/unit/math/opencl/util.hpp
+++ b/test/unit/math/opencl/util.hpp
@@ -189,6 +189,7 @@ template <typename Functor, typename... Args>
 void compare_cpu_opencl_prim_rev(const Functor& functor, const Args&... args) {
   internal::compare_cpu_opencl_prim_rev_impl(
       functor, std::make_index_sequence<sizeof...(args)>{}, args...);
+  recover_memory();
 }
 
 }  // namespace test

--- a/test/unit/math/rev/core/arena_matrix_test.cpp
+++ b/test/unit/math/rev/core/arena_matrix_test.cpp
@@ -26,6 +26,7 @@ TEST(AgradRev, arena_matrix_matrix_test) {
   a = MatrixXd::Ones(3, 2);
 
   EXPECT_MATRIX_EQ(a + a2 + a3 + b + b2 + e, MatrixXd::Ones(3, 2) * 9);
+  stan::math::recover_memory();
 }
 
 TEST(AgradRev, arena_matrix_vector_test) {
@@ -52,6 +53,7 @@ TEST(AgradRev, arena_matrix_vector_test) {
   a = VectorXd::Ones(3);
 
   EXPECT_MATRIX_EQ(a + a2 + a3 + b + b2 + e, VectorXd::Ones(3) * 9);
+  stan::math::recover_memory();
 }
 
 TEST(AgradRev, arena_matrix_row_vector_test) {
@@ -78,4 +80,5 @@ TEST(AgradRev, arena_matrix_row_vector_test) {
   a = RowVectorXd::Ones(3);
 
   EXPECT_MATRIX_EQ(a + a2 + a3 + b + b2 + e, RowVectorXd::Ones(3) * 9);
+  stan::math::recover_memory();
 }


### PR DESCRIPTION
## Summary

Fixes a crash that happens when calling `recover_memory` after using `arena_matrix_cl` (used internally in all rev OpenCL functions). (This fixes the same bug as #2156, but in different, less dangerous way)

## Tests
Added `recover_memory()` to `arena_matrix` and `to_arena` tests and to `compare_cpu_opencl_prim_rev` function, which is used in rev OpenCL tests.

## Side Effects
A number of functions and metaprograms had to be modified to also work with `arena_matrix_cl`.

## Checklist

- [x] Math issue #2161

- [x] Copyright holder: Tadej Ciglarič

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [ ] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [ ] the code is written in idiomatic C++ and changes are documented in the doxygen

- [ ] the new changes are tested
