### PR TITLE
Added transpose to `var<mat>` (Issue #2101)

### DIFF
--- a/stan/math/rev/core/var.hpp
+++ b/stan/math/rev/core/var.hpp
@@ -575,6 +575,20 @@ class var_value<
   }
 
   /**
+   * View transpose of eigen matrix.
+   */
+  inline auto transpose() const {
+    using vari_sub = decltype(vi_->transpose());
+    using var_sub = var_value<value_type_t<vari_sub>>;
+    return var_sub(new vari_sub(vi_->transpose()));
+  }
+  inline auto transpose() {
+    using vari_sub = decltype(vi_->transpose());
+    using var_sub = var_value<value_type_t<vari_sub>>;
+    return var_sub(new vari_sub(vi_->transpose()));
+  }
+
+  /**
    * View of the head of Eigen vector types.
    * @param n Number of elements to return from top of vector.
    */

--- a/stan/math/rev/core/vari.hpp
+++ b/stan/math/rev/core/vari.hpp
@@ -286,12 +286,12 @@ class vari_view_eigen {
   inline auto transpose() const {
     using inner_type = decltype(derived().val_.transpose());
     return vari_view<inner_type>(derived().val_.transpose(),
-				 derived().adj_.transpose());
+                                 derived().adj_.transpose());
   }
   inline auto transpose() {
     using inner_type = decltype(derived().val_.transpose());
     return vari_view<inner_type>(derived().val_.transpose(),
-				 derived().adj_.transpose());
+                                 derived().adj_.transpose());
   }
 
   /**

--- a/stan/math/rev/core/vari.hpp
+++ b/stan/math/rev/core/vari.hpp
@@ -281,6 +281,20 @@ class vari_view_eigen {
   }
 
   /**
+   * View transpose of eigen matrix.
+   */
+  inline auto transpose() const {
+    using inner_type = decltype(derived().val_.transpose());
+    return vari_view<inner_type>(derived().val_.transpose(),
+				 derived().adj_.transpose());
+  }
+  inline auto transpose() {
+    using inner_type = decltype(derived().val_.transpose());
+    return vari_view<inner_type>(derived().val_.transpose(),
+				 derived().adj_.transpose());
+  }
+
+  /**
    * View row of eigen matrices.
    * @param i Row index to slice.
    */

--- a/test/unit/math/rev/core/var_test.cpp
+++ b/test/unit/math/rev/core/var_test.cpp
@@ -180,6 +180,8 @@ TEST_F(AgradRev, var_matrix_views) {
   stan::math::var_value<dense_mat> A_v(A);
   auto A_block = A_v.block(1, 1, 3, 3);
   EXPECT_MATRIX_FLOAT_EQ(A_block.val(), A.block(1, 1, 3, 3));
+  auto A_transpose = A_v.transpose();
+  EXPECT_MATRIX_FLOAT_EQ(A_transpose.val(), A.transpose());
   auto A_row = A_v.row(3);
   EXPECT_MATRIX_FLOAT_EQ(A_row.val(), A.row(3));
   auto A_col = A_v.col(3);
@@ -202,6 +204,7 @@ TEST_F(AgradRev, var_matrix_views) {
     A_v.vi_->adj_(i) = i;
   }
   EXPECT_MATRIX_FLOAT_EQ(A_block.adj(), A_v.adj().block(1, 1, 3, 3));
+  EXPECT_MATRIX_FLOAT_EQ(A_transpose.adj(), A_v.adj().transpose());
   EXPECT_MATRIX_FLOAT_EQ(A_row.adj(), A_v.adj().row(3));
   EXPECT_MATRIX_FLOAT_EQ(A_col.adj(), A_v.adj().col(3));
   EXPECT_MATRIX_FLOAT_EQ(A_block_row.adj(), A_v.adj().block(1, 1, 3, 3).row(1));
@@ -231,6 +234,8 @@ TEST_F(AgradRev, var_matrix_views_const) {
   const auto& A_v = A_vv;
   auto A_block = A_v.block(1, 1, 3, 3);
   EXPECT_MATRIX_FLOAT_EQ(A_block.val(), A.block(1, 1, 3, 3));
+  auto A_transpose = A_v.transpose();
+  EXPECT_MATRIX_FLOAT_EQ(A_transpose.val(), A.transpose());
   auto A_row = A_v.row(3);
   EXPECT_MATRIX_FLOAT_EQ(A_row.val(), A.row(3));
   auto A_col = A_v.col(3);
@@ -253,6 +258,7 @@ TEST_F(AgradRev, var_matrix_views_const) {
     A_v.vi_->adj_(i) = i;
   }
   EXPECT_MATRIX_FLOAT_EQ(A_block.adj(), A_v.adj().block(1, 1, 3, 3));
+  EXPECT_MATRIX_FLOAT_EQ(A_transpose.adj(), A_v.adj().transpose());
   EXPECT_MATRIX_FLOAT_EQ(A_row.adj(), A_v.adj().row(3));
   EXPECT_MATRIX_FLOAT_EQ(A_col.adj(), A_v.adj().col(3));
   EXPECT_MATRIX_FLOAT_EQ(A_block_row.adj(), A_v.adj().block(1, 1, 3, 3).row(1));
@@ -272,8 +278,8 @@ TEST_F(AgradRev, var_matrix_views_const) {
   EXPECT_FLOAT_EQ(A_v.adj()(3, 3) - prev_adj_val2, A_coeff2.adj());
 }
 
-TEST_F(AgradRev, var_vector_views) {
-  using dense_vec = Eigen::Matrix<double, -1, 1>;
+template <typename dense_vec>
+void var_vector_views_test() {
   using stan::math::var_value;
   dense_vec A(10);
   for (Eigen::Index i = 0; i < A.size(); ++i) {
@@ -282,6 +288,8 @@ TEST_F(AgradRev, var_vector_views) {
   var_value<dense_vec> A_v(A);
   auto A_head = A_v.head(3);
   EXPECT_MATRIX_FLOAT_EQ(A.head(3), A_head.val());
+  auto A_transpose = A_v.transpose();
+  EXPECT_MATRIX_FLOAT_EQ(A.transpose(), A_transpose.val());
   auto A_tail = A_v.tail(3);
   EXPECT_MATRIX_FLOAT_EQ(A.tail(3), A_tail.val());
   auto A_segment = A_v.segment(3, 5);
@@ -293,6 +301,46 @@ TEST_F(AgradRev, var_vector_views) {
     A_v.vi_->adj_(i) = i;
   }
   EXPECT_MATRIX_FLOAT_EQ(A_v.adj().head(3), A_head.adj());
+  EXPECT_MATRIX_FLOAT_EQ(A_v.adj().transpose(), A_transpose.adj());
+  EXPECT_MATRIX_FLOAT_EQ(A_v.adj().tail(3), A_tail.adj());
+  EXPECT_MATRIX_FLOAT_EQ(A_v.adj().segment(3, 5), A_segment.adj());
+  // since new var is made and values propogate back
+  A_coeff1.vi_->adj_ = 1;
+  auto prev_adj_val = A_v.adj()(3);
+  stan::math::grad();
+  EXPECT_FLOAT_EQ(A_v.adj()(3) - prev_adj_val, A_coeff1.adj());
+}
+
+TEST_F(AgradRev, var_vector_views) {
+  var_vector_views_test<Eigen::VectorXd>();
+  var_vector_views_test<Eigen::RowVectorXd>();
+}
+
+template <typename dense_vec>
+void var_vector_views_const_test() {
+  using stan::math::var_value;
+  dense_vec A(10);
+  for (Eigen::Index i = 0; i < A.size(); ++i) {
+    A(i) = i;
+  }
+  var_value<dense_vec> A_vv(A);
+  const auto& A_v = A_vv;
+  auto A_head = A_v.head(3);
+  EXPECT_MATRIX_FLOAT_EQ(A.head(3), A_head.val());
+  auto A_transpose = A_v.transpose();
+  EXPECT_MATRIX_FLOAT_EQ(A.transpose(), A_transpose.val());
+  auto A_tail = A_v.tail(3);
+  EXPECT_MATRIX_FLOAT_EQ(A.tail(3), A_tail.val());
+  auto A_segment = A_v.segment(3, 5);
+  EXPECT_MATRIX_FLOAT_EQ(A.segment(3, 5), A_segment.val());
+  auto A_coeff1 = A_v(3);
+  EXPECT_FLOAT_EQ(A(3), A_coeff1.val());
+  EXPECT_MATRIX_FLOAT_EQ(A, A_v.val());
+  for (Eigen::Index i = 0; i < A.size(); ++i) {
+    A_v.vi_->adj_(i) = i;
+  }
+  EXPECT_MATRIX_FLOAT_EQ(A_v.adj().head(3), A_head.adj());
+  EXPECT_MATRIX_FLOAT_EQ(A_v.adj().transpose(), A_transpose.adj());
   EXPECT_MATRIX_FLOAT_EQ(A_v.adj().tail(3), A_tail.adj());
   EXPECT_MATRIX_FLOAT_EQ(A_v.adj().segment(3, 5), A_segment.adj());
   // since new var is made and values propogate back
@@ -303,34 +351,8 @@ TEST_F(AgradRev, var_vector_views) {
 }
 
 TEST_F(AgradRev, var_vector_views_const) {
-  using dense_vec = Eigen::Matrix<double, -1, 1>;
-  using stan::math::var_value;
-  dense_vec A(10);
-  for (Eigen::Index i = 0; i < A.size(); ++i) {
-    A(i) = i;
-  }
-  var_value<dense_vec> A_vv(A);
-  const auto& A_v = A_vv;
-  auto A_head = A_v.head(3);
-  EXPECT_MATRIX_FLOAT_EQ(A.head(3), A_head.val());
-  auto A_tail = A_v.tail(3);
-  EXPECT_MATRIX_FLOAT_EQ(A.tail(3), A_tail.val());
-  auto A_segment = A_v.segment(3, 5);
-  EXPECT_MATRIX_FLOAT_EQ(A.segment(3, 5), A_segment.val());
-  auto A_coeff1 = A_v(3);
-  EXPECT_FLOAT_EQ(A(3), A_coeff1.val());
-  EXPECT_MATRIX_FLOAT_EQ(A, A_v.val());
-  for (Eigen::Index i = 0; i < A.size(); ++i) {
-    A_v.vi_->adj_(i) = i;
-  }
-  EXPECT_MATRIX_FLOAT_EQ(A_v.adj().head(3), A_head.adj());
-  EXPECT_MATRIX_FLOAT_EQ(A_v.adj().tail(3), A_tail.adj());
-  EXPECT_MATRIX_FLOAT_EQ(A_v.adj().segment(3, 5), A_segment.adj());
-  // since new var is made and values propogate back
-  A_coeff1.vi_->adj_ = 1;
-  auto prev_adj_val = A_v.adj()(3);
-  stan::math::grad();
-  EXPECT_FLOAT_EQ(A_v.adj()(3) - prev_adj_val, A_coeff1.adj());
+  var_vector_views_const_test<Eigen::VectorXd>();
+  var_vector_views_const_test<Eigen::RowVectorXd>();
 }
 
 /**
@@ -344,6 +366,7 @@ TEST_F(AgradRev, var_matrix_view) {
   A << 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15;
   var_value<Eigen::MatrixXd> A_v(A);
   auto A_v_block = A_v.block(1, 1, 3, 3);
+  auto A_v_transpose = A_v.transpose();
   auto A_v_row = A_v.row(3);
   auto A_v_col = A_v.col(3);
   auto A_v_block_row = A_v.block(1, 1, 3, 3).row(1);
@@ -361,6 +384,9 @@ TEST_F(AgradRev, var_matrix_view) {
   EXPECT_MATRIX_FLOAT_EQ(A_v.adj(), deriv);
   EXPECT_MATRIX_FLOAT_EQ(A_v_block.val(), A_v.val().block(1, 1, 3, 3));
   EXPECT_MATRIX_FLOAT_EQ(A_v_block.adj(), A_v.adj().block(1, 1, 3, 3));
+
+  EXPECT_MATRIX_FLOAT_EQ(A_v_transpose.val(), A_v.val().transpose());
+  EXPECT_MATRIX_FLOAT_EQ(A_v_transpose.adj(), A_v.adj().transpose());
 
   EXPECT_MATRIX_FLOAT_EQ(A_v_row.val(), A_v.val().row(3));
   EXPECT_MATRIX_FLOAT_EQ(A_v_row.adj(), A_v.adj().row(3));
@@ -403,6 +429,7 @@ TEST_F(AgradRev, var_matrix_view_const) {
   var_value<Eigen::MatrixXd> A_vv(A);
   const auto& A_v = A_vv;
   auto A_v_block = A_v.block(1, 1, 3, 3);
+  auto A_v_transpose = A_v.transpose();
   auto A_v_row = A_v.row(3);
   auto A_v_col = A_v.col(3);
   auto A_v_block_row = A_v.block(1, 1, 3, 3).row(1);
@@ -420,6 +447,9 @@ TEST_F(AgradRev, var_matrix_view_const) {
   EXPECT_MATRIX_FLOAT_EQ(A_v.adj(), deriv);
   EXPECT_MATRIX_FLOAT_EQ(A_v_block.val(), A_v.val().block(1, 1, 3, 3));
   EXPECT_MATRIX_FLOAT_EQ(A_v_block.adj(), A_v.adj().block(1, 1, 3, 3));
+
+  EXPECT_MATRIX_FLOAT_EQ(A_v_transpose.val(), A_v.val().transpose());
+  EXPECT_MATRIX_FLOAT_EQ(A_v_transpose.adj(), A_v.adj().transpose());
 
   EXPECT_MATRIX_FLOAT_EQ(A_v_row.val(), A_v.val().row(3));
   EXPECT_MATRIX_FLOAT_EQ(A_v_row.adj(), A_v.adj().row(3));
@@ -462,6 +492,7 @@ TEST_F(AgradRev, var_matrix_view_assignment) {
   A << 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15;
   var_value<Eigen::MatrixXd> A_v(A);
   var_value<Eigen::MatrixXd> A_v_block = A_v.block(1, 1, 3, 3);
+  var_value<Eigen::MatrixXd> A_v_transpose = A_v.transpose();
   var_value<Eigen::RowVectorXd> A_v_row = A_v.row(3);
   var_value<Eigen::VectorXd> A_v_col = A_v.col(3);
   var_value<Eigen::RowVectorXd> A_v_block_row = A_v.block(1, 1, 3, 3).row(1);
@@ -473,14 +504,15 @@ TEST_F(AgradRev, var_matrix_view_assignment) {
   var A_v_coeff2 = A_v.coeff(1, 2);
   A_v.block(0, 0, 3, 3) = A_v.block(1, 1, 3, 3);
   // Checks adjoints from all assigned slices are propogated upwards
-  var b_v = stan::math::sum(A_v_block) + stan::math::sum(A_v_row)
-            + stan::math::sum(A_v_col) + stan::math::sum(A_v_block_row)
-            + stan::math::sum(A_v_rowwise_reverse)
-            + stan::math::sum(A_v_colwise_reverse)
-            + stan::math::sum(A_v_rowwise_colwise_reverse);
+  var b_v = stan::math::sum(A_v_block) + stan::math::sum(A_v_transpose)
+    + stan::math::sum(A_v_row)
+    + stan::math::sum(A_v_col) + stan::math::sum(A_v_block_row)
+    + stan::math::sum(A_v_rowwise_reverse)
+    + stan::math::sum(A_v_colwise_reverse)
+    + stan::math::sum(A_v_rowwise_colwise_reverse);
   b_v.grad();
   Eigen::MatrixXd deriv(4, 4);
-  deriv << 3, 3, 3, 4, 3, 4, 4, 5, 3, 5, 5, 6, 4, 5, 5, 6;
+  deriv << 4, 4, 4, 5, 4, 5, 5, 6, 4, 6, 6, 7, 5, 6, 6, 7;
   EXPECT_MATRIX_FLOAT_EQ(A_v.adj(), deriv);
 }
 
@@ -493,6 +525,7 @@ TEST_F(AgradRev, var_matrix_view_assignment_const) {
   var_value<Eigen::MatrixXd> A_vv(A);
   const auto& A_v = A_vv;
   var_value<Eigen::MatrixXd> A_v_block = A_v.block(1, 1, 3, 3);
+  var_value<Eigen::MatrixXd> A_v_transpose = A_v.transpose();
   var_value<Eigen::RowVectorXd> A_v_row = A_v.row(3);
   var_value<Eigen::VectorXd> A_v_col = A_v.col(3);
   var_value<Eigen::RowVectorXd> A_v_block_row = A_v.block(1, 1, 3, 3).row(1);
@@ -504,14 +537,15 @@ TEST_F(AgradRev, var_matrix_view_assignment_const) {
   var A_v_coeff2 = A_v.coeff(1, 2);
   A_v.block(0, 0, 3, 3) = A_v.block(1, 1, 3, 3);
   // Checks adjoints from all assigned slices are propogated upwards
-  var b_v = stan::math::sum(A_v_block) + stan::math::sum(A_v_row)
-            + stan::math::sum(A_v_col) + stan::math::sum(A_v_block_row)
-            + stan::math::sum(A_v_rowwise_reverse)
-            + stan::math::sum(A_v_colwise_reverse)
-            + stan::math::sum(A_v_rowwise_colwise_reverse);
+  var b_v = stan::math::sum(A_v_block) + stan::math::sum(A_v_transpose)
+    + stan::math::sum(A_v_row)
+    + stan::math::sum(A_v_col) + stan::math::sum(A_v_block_row)
+    + stan::math::sum(A_v_rowwise_reverse)
+    + stan::math::sum(A_v_colwise_reverse)
+    + stan::math::sum(A_v_rowwise_colwise_reverse);
   b_v.grad();
   Eigen::MatrixXd deriv(4, 4);
-  deriv << 3, 3, 3, 4, 3, 4, 4, 5, 3, 5, 5, 6, 4, 5, 5, 6;
+  deriv << 4, 4, 4, 5, 4, 5, 5, 6, 4, 6, 6, 7, 5, 6, 6, 7;
   EXPECT_MATRIX_FLOAT_EQ(A_v.adj(), deriv);
 }
 
@@ -523,6 +557,7 @@ TEST_F(AgradRev, var_matrix_view_eval) {
   A << 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15;
   var_value<Eigen::MatrixXd> A_v(A);
   auto A_v_block = A_v.block(1, 1, 3, 3).eval();
+  auto A_v_transpose = A_v.transpose().eval();
   auto A_v_row = A_v.row(3).eval();
   auto A_v_col = A_v.col(3).eval();
   auto A_v_block_row = A_v.block(1, 1, 3, 3).row(1).eval();
@@ -535,14 +570,15 @@ TEST_F(AgradRev, var_matrix_view_eval) {
   auto A_v_coeff2 = A_v.coeff(1, 2);
   A_v.block(0, 0, 3, 3) = A_v.block(1, 1, 3, 3);
   // Checks adjoints from all assigned slices are propogated upwards
-  var b_v = stan::math::sum(A_v_block) + stan::math::sum(A_v_row)
-            + stan::math::sum(A_v_col) + stan::math::sum(A_v_block_row)
-            + stan::math::sum(A_v_rowwise_reverse)
-            + stan::math::sum(A_v_colwise_reverse)
-            + stan::math::sum(A_v_rowwise_colwise_reverse);
+  var b_v = stan::math::sum(A_v_block) + stan::math::sum(A_v_transpose)
+    + stan::math::sum(A_v_row)
+    + stan::math::sum(A_v_col) + stan::math::sum(A_v_block_row)
+    + stan::math::sum(A_v_rowwise_reverse)
+    + stan::math::sum(A_v_colwise_reverse)
+    + stan::math::sum(A_v_rowwise_colwise_reverse);
   b_v.grad();
   Eigen::MatrixXd deriv(4, 4);
-  deriv << 3, 3, 3, 4, 3, 4, 4, 5, 3, 5, 5, 6, 4, 5, 5, 6;
+  deriv << 4, 4, 4, 5, 4, 5, 5, 6, 4, 6, 6, 7, 5, 6, 6, 7;
   EXPECT_MATRIX_FLOAT_EQ(A_v.adj(), deriv);
 }
 
@@ -554,6 +590,17 @@ TEST_F(AgradRev, var_matrix_view_block_plain_assignment) {
   stan::math::sum(B_v).grad();
   Eigen::MatrixXd deriv(4, 4);
   deriv << 0, 0, 0, 0, 0, 1, 1, 1, 0, 1, 1, 1, 0, 1, 1, 1;
+  EXPECT_MATRIX_FLOAT_EQ(A_v.adj(), deriv);
+}
+
+TEST_F(AgradRev, var_matrix_view_transpose_plain_assignment) {
+  Eigen::MatrixXd A(4, 4);
+  A << 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15;
+  stan::math::var_value<Eigen::MatrixXd> A_v(A);
+  stan::math::var_value<Eigen::MatrixXd> B_v = A_v.transpose();
+  stan::math::sum(B_v).grad();
+  Eigen::MatrixXd deriv(4, 4);
+  deriv << 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1;
   EXPECT_MATRIX_FLOAT_EQ(A_v.adj(), deriv);
 }
 

--- a/test/unit/math/rev/core/var_test.cpp
+++ b/test/unit/math/rev/core/var_test.cpp
@@ -505,11 +505,11 @@ TEST_F(AgradRev, var_matrix_view_assignment) {
   A_v.block(0, 0, 3, 3) = A_v.block(1, 1, 3, 3);
   // Checks adjoints from all assigned slices are propogated upwards
   var b_v = stan::math::sum(A_v_block) + stan::math::sum(A_v_transpose)
-    + stan::math::sum(A_v_row)
-    + stan::math::sum(A_v_col) + stan::math::sum(A_v_block_row)
-    + stan::math::sum(A_v_rowwise_reverse)
-    + stan::math::sum(A_v_colwise_reverse)
-    + stan::math::sum(A_v_rowwise_colwise_reverse);
+            + stan::math::sum(A_v_row) + stan::math::sum(A_v_col)
+            + stan::math::sum(A_v_block_row)
+            + stan::math::sum(A_v_rowwise_reverse)
+            + stan::math::sum(A_v_colwise_reverse)
+            + stan::math::sum(A_v_rowwise_colwise_reverse);
   b_v.grad();
   Eigen::MatrixXd deriv(4, 4);
   deriv << 4, 4, 4, 5, 4, 5, 5, 6, 4, 6, 6, 7, 5, 6, 6, 7;
@@ -538,11 +538,11 @@ TEST_F(AgradRev, var_matrix_view_assignment_const) {
   A_v.block(0, 0, 3, 3) = A_v.block(1, 1, 3, 3);
   // Checks adjoints from all assigned slices are propogated upwards
   var b_v = stan::math::sum(A_v_block) + stan::math::sum(A_v_transpose)
-    + stan::math::sum(A_v_row)
-    + stan::math::sum(A_v_col) + stan::math::sum(A_v_block_row)
-    + stan::math::sum(A_v_rowwise_reverse)
-    + stan::math::sum(A_v_colwise_reverse)
-    + stan::math::sum(A_v_rowwise_colwise_reverse);
+            + stan::math::sum(A_v_row) + stan::math::sum(A_v_col)
+            + stan::math::sum(A_v_block_row)
+            + stan::math::sum(A_v_rowwise_reverse)
+            + stan::math::sum(A_v_colwise_reverse)
+            + stan::math::sum(A_v_rowwise_colwise_reverse);
   b_v.grad();
   Eigen::MatrixXd deriv(4, 4);
   deriv << 4, 4, 4, 5, 4, 5, 5, 6, 4, 6, 6, 7, 5, 6, 6, 7;
@@ -571,11 +571,11 @@ TEST_F(AgradRev, var_matrix_view_eval) {
   A_v.block(0, 0, 3, 3) = A_v.block(1, 1, 3, 3);
   // Checks adjoints from all assigned slices are propogated upwards
   var b_v = stan::math::sum(A_v_block) + stan::math::sum(A_v_transpose)
-    + stan::math::sum(A_v_row)
-    + stan::math::sum(A_v_col) + stan::math::sum(A_v_block_row)
-    + stan::math::sum(A_v_rowwise_reverse)
-    + stan::math::sum(A_v_colwise_reverse)
-    + stan::math::sum(A_v_rowwise_colwise_reverse);
+            + stan::math::sum(A_v_row) + stan::math::sum(A_v_col)
+            + stan::math::sum(A_v_block_row)
+            + stan::math::sum(A_v_rowwise_reverse)
+            + stan::math::sum(A_v_colwise_reverse)
+            + stan::math::sum(A_v_rowwise_colwise_reverse);
   b_v.grad();
   Eigen::MatrixXd deriv(4, 4);
   deriv << 4, 4, 4, 5, 4, 5, 5, 6, 4, 6, 6, 7, 5, 6, 6, 7;

--- a/test/unit/math/rev/core/vari_test.cpp
+++ b/test/unit/math/rev/core/vari_test.cpp
@@ -84,14 +84,26 @@ TEST(AgradRev, dense_vari_matrix_views) {
   auto A_head = A_v.block(1, 1, 3, 3);
   EXPECT_MATRIX_FLOAT_EQ(A_head.val_, A_v.val_.block(1, 1, 3, 3));
   EXPECT_MATRIX_FLOAT_EQ(A, A_v.val_);
+  A_head.adj_ = eig_mat::Random(3, 3);
+  EXPECT_MATRIX_FLOAT_EQ(A_head.adj_, A_v.adj_.block(1, 1, 3, 3));
+
+  auto A_transpose = A_v.transpose();
+  EXPECT_MATRIX_FLOAT_EQ(A_transpose.val_, A_v.val_.transpose());
+  EXPECT_MATRIX_FLOAT_EQ(A, A_v.val_);
+  A_transpose.adj_ = eig_mat::Random(5, 5);
+  EXPECT_MATRIX_FLOAT_EQ(A_transpose.adj_, A_v.adj_.transpose());
 
   auto A_row = A_v.row(3);
   EXPECT_MATRIX_FLOAT_EQ(A_row.val_, A_v.val_.row(3));
   EXPECT_MATRIX_FLOAT_EQ(A, A_v.val_);
+  A_row.adj_ = Eigen::RowVectorXd::Random(5);
+  EXPECT_MATRIX_FLOAT_EQ(A_row.adj_, A_v.adj_.row(3));
 
   auto A_col = A_v.col(3);
   EXPECT_MATRIX_FLOAT_EQ(A_col.val_, A_v.val_.col(3));
   EXPECT_MATRIX_FLOAT_EQ(A, A_v.val_);
+  A_col.adj_ = Eigen::VectorXd::Random(5);
+  EXPECT_MATRIX_FLOAT_EQ(A_col.adj_, A_v.adj_.col(3));
 
   auto A_op_par = A_v(3);
   EXPECT_FLOAT_EQ(A_op_par.val_, A_v.val_(3));
@@ -102,7 +114,7 @@ TEST(AgradRev, dense_vari_matrix_views) {
   EXPECT_MATRIX_FLOAT_EQ(A, A_v.val_);
 
   auto A_op_coeff = A_v.coeff(3, 3);
-  EXPECT_FLOAT_EQ(A_op_par2.val_, A_v.val_.coeff(3, 3));
+  EXPECT_FLOAT_EQ(A_op_coeff.val_, A_v.val_.coeff(3, 3));
   EXPECT_MATRIX_FLOAT_EQ(A, A_v.val_);
 }
 
@@ -117,12 +129,57 @@ TEST(AgradRev, dense_vari_vector_views) {
   auto A_sub = A_v.head(3);
   EXPECT_MATRIX_FLOAT_EQ(A_sub.val_, A_v.val_.head(3));
   EXPECT_MATRIX_FLOAT_EQ(A, A_v.val_);
+  A_sub.adj_ = Eigen::VectorXd::Random(3);
+  EXPECT_MATRIX_FLOAT_EQ(A_sub.adj_, A_v.adj_.head(3));
+
+  auto A_transpose = A_v.transpose();
+  EXPECT_MATRIX_FLOAT_EQ(A_transpose.val_, A_v.val_.transpose());
+  EXPECT_MATRIX_FLOAT_EQ(A, A_v.val_);
+  A_transpose.adj_ = Eigen::RowVectorXd::Random(10);
+  EXPECT_MATRIX_FLOAT_EQ(A_transpose.adj_, A_v.adj_.transpose());
 
   auto A_sub_tail = A_v.tail(3);
   EXPECT_MATRIX_FLOAT_EQ(A_sub_tail.val_, A_v.val_.tail(3));
   EXPECT_MATRIX_FLOAT_EQ(A, A_v.val_);
+  A_sub_tail.adj_ = Eigen::VectorXd::Random(3);
+  EXPECT_MATRIX_FLOAT_EQ(A_sub_tail.adj_, A_v.adj_.tail(3));
 
   auto A_segment = A_v.segment(3, 5);
   EXPECT_MATRIX_FLOAT_EQ(A_segment.val_, A_v.val_.segment(3, 5));
   EXPECT_MATRIX_FLOAT_EQ(A, A_v.val_);
+  A_segment.adj_ = Eigen::VectorXd::Random(5);
+  EXPECT_MATRIX_FLOAT_EQ(A_segment.adj_, A_v.adj_.segment(3, 5));
+}
+
+TEST(AgradRev, dense_vari_row_vector_views) {
+  using stan::math::vari_value;
+  using eig_vec = Eigen::RowVectorXd;
+  eig_vec A(10);
+  for (int i = 0; i < A.size(); ++i) {
+    A(i) = i;
+  }
+  stan::math::vari_value<eig_vec> A_v(A);
+  auto A_sub = A_v.head(3);
+  EXPECT_MATRIX_FLOAT_EQ(A_sub.val_, A_v.val_.head(3));
+  EXPECT_MATRIX_FLOAT_EQ(A, A_v.val_);
+  A_sub.adj_ = Eigen::RowVectorXd::Random(3);
+  EXPECT_MATRIX_FLOAT_EQ(A_sub.adj_, A_v.adj_.head(3));
+
+  auto A_transpose = A_v.transpose();
+  EXPECT_MATRIX_FLOAT_EQ(A_transpose.val_, A_v.val_.transpose());
+  EXPECT_MATRIX_FLOAT_EQ(A, A_v.val_);
+  A_transpose.adj_ = Eigen::VectorXd::Random(10);
+  EXPECT_MATRIX_FLOAT_EQ(A_transpose.adj_, A_v.adj_.transpose());
+
+  auto A_sub_tail = A_v.tail(3);
+  EXPECT_MATRIX_FLOAT_EQ(A_sub_tail.val_, A_v.val_.tail(3));
+  EXPECT_MATRIX_FLOAT_EQ(A, A_v.val_);
+  A_sub_tail.adj_ = Eigen::RowVectorXd::Random(3);
+  EXPECT_MATRIX_FLOAT_EQ(A_sub_tail.adj_, A_v.adj_.tail(3));
+
+  auto A_segment = A_v.segment(3, 5);
+  EXPECT_MATRIX_FLOAT_EQ(A_segment.val_, A_v.val_.segment(3, 5));
+  EXPECT_MATRIX_FLOAT_EQ(A, A_v.val_);
+  A_segment.adj_ = Eigen::RowVectorXd::Random(5);
+  EXPECT_MATRIX_FLOAT_EQ(A_segment.adj_, A_v.adj_.segment(3, 5));
 }


### PR DESCRIPTION
## Summary

This is `transpose` for `var<mat>`.

## Tests

It's all a lot of copy-paste of all the Eigen view things that were there.

## Side Effects

No

## Release notes

Added transpose for `var<mat>`

## Checklist

- [x] Math issue #2101 

- [x] Copyright holder: Columbia University

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
