### PR TITLE
Added `var<mat>` implementation of divide (Issue #2101)

### DIFF
--- a/stan/math/prim/fun/elt_divide.hpp
+++ b/stan/math/prim/fun/elt_divide.hpp
@@ -20,7 +20,7 @@ namespace math {
  */
 template <typename Mat1, typename Mat2,
           require_all_eigen_t<Mat1, Mat2>* = nullptr,
-	  require_all_not_st_var<Mat1, Mat2>* = nullptr>
+          require_all_not_st_var<Mat1, Mat2>* = nullptr>
 auto elt_divide(const Mat1& m1, const Mat2& m2) {
   check_matching_dims("elt_divide", "m1", m1, "m2", m2);
   return (m1.array() / m2.array()).matrix().eval();
@@ -37,8 +37,7 @@ auto elt_divide(const Mat1& m1, const Mat2& m2) {
  * @param s scalar
  * @return Elementwise division of a scalar by matrix.
  */
-template <typename Mat, typename Scal,
-	  typename = require_matrix_t<Mat>,
+template <typename Mat, typename Scal, typename = require_matrix_t<Mat>,
           typename = require_stan_scalar_t<Scal>>
 auto elt_divide(const Mat& m, Scal s) {
   return divide(m, s);

--- a/stan/math/prim/fun/elt_divide.hpp
+++ b/stan/math/prim/fun/elt_divide.hpp
@@ -19,7 +19,8 @@ namespace math {
  * @return Elementwise division of matrices.
  */
 template <typename Mat1, typename Mat2,
-          typename = require_all_eigen_t<Mat1, Mat2>>
+          require_all_eigen_t<Mat1, Mat2>* = nullptr,
+	  require_all_not_st_var<Mat1, Mat2>* = nullptr>
 auto elt_divide(const Mat1& m1, const Mat2& m2) {
   check_matching_dims("elt_divide", "m1", m1, "m2", m2);
   return (m1.array() / m2.array()).matrix().eval();
@@ -36,10 +37,11 @@ auto elt_divide(const Mat1& m1, const Mat2& m2) {
  * @param s scalar
  * @return Elementwise division of a scalar by matrix.
  */
-template <typename Mat, typename Scal, typename = require_eigen_t<Mat>,
+template <typename Mat, typename Scal,
+	  typename = require_matrix_t<Mat>,
           typename = require_stan_scalar_t<Scal>>
 auto elt_divide(const Mat& m, Scal s) {
-  return (m.array() / s).matrix().eval();
+  return divide(m, s);
 }
 
 /**

--- a/stan/math/rev/fun.hpp
+++ b/stan/math/rev/fun.hpp
@@ -41,6 +41,7 @@
 #include <stan/math/rev/fun/dot_self.hpp>
 #include <stan/math/rev/fun/eigenvalues_sym.hpp>
 #include <stan/math/rev/fun/eigenvectors_sym.hpp>
+#include <stan/math/rev/fun/elt_divide.hpp>
 #include <stan/math/rev/fun/elt_multiply.hpp>
 #include <stan/math/rev/fun/erf.hpp>
 #include <stan/math/rev/fun/erfc.hpp>

--- a/stan/math/rev/fun/divide.hpp
+++ b/stan/math/rev/fun/divide.hpp
@@ -186,8 +186,7 @@ inline auto divide(const Mat& m, const var& c) {
  * @param[in] c input scalar
  * @return matrix divided by the scalar
  */
-template <typename Mat, typename Scal,
-	  require_var_matrix_t<Mat>* = nullptr,
+template <typename Mat, typename Scal, require_var_matrix_t<Mat>* = nullptr,
           require_stan_scalar_t<Scal>* = nullptr>
 inline auto divide(const Mat& m, const Scal& c) {
   double invc = 1.0 / value_of(c);
@@ -198,7 +197,7 @@ inline auto divide(const Mat& m, const Scal& c) {
     m.adj() += invc * res.adj();
     if (!is_constant<Scal>::value)
       forward_as<var>(c).adj()
-	-= invc * (res.adj().array() * res.val().array()).sum();
+          -= invc * (res.adj().array() * res.val().array()).sum();
   });
 
   return res;

--- a/stan/math/rev/fun/elt_divide.hpp
+++ b/stan/math/rev/fun/elt_divide.hpp
@@ -11,15 +11,15 @@ namespace stan {
 namespace math {
 
 /**
- * Return the elementwise multiplication of the specified
+ * Return the elementwise division of the specified
  * matrices.
  *
- * @tparam Mat1 type of the first matrix or expression
- * @tparam Mat2 type of the second matrix or expression
+ * @tparam Mat1 type of the first matrix
+ * @tparam Mat2 type of the second matrix
  *
- * @param m1 First matrix or expression
- * @param m2 Second matrix or expression
- * @return Elementwise product of matrices.
+ * @param m1 First matrix
+ * @param m2 Second matrix
+ * @return Elementwise division of matrices.
  */
 template <typename Mat1, typename Mat2,
           require_all_matrix_t<Mat1, Mat2>* = nullptr,
@@ -65,7 +65,7 @@ auto elt_divide(const Mat1& m1, const Mat2& m2) {
  * by the specified matrix.
  *
  * @tparam Scal type of the scalar
- * @tparam Mat type of the matrix or expression
+ * @tparam Mat type of the matrix
  *
  * @param s scalar
  * @param m matrix or expression

--- a/stan/math/rev/fun/elt_divide.hpp
+++ b/stan/math/rev/fun/elt_divide.hpp
@@ -26,7 +26,7 @@ template <typename Mat1, typename Mat2,
           require_any_rev_matrix_t<Mat1, Mat2>* = nullptr>
 auto elt_divide(const Mat1& m1, const Mat2& m2) {
   check_matching_dims("elt_divide", "m1", m1, "m2", m2);
-  using inner_ret_type = decltype(value_of(m1).cwiseProduct(value_of(m2)));
+  using inner_ret_type = decltype((value_of(m1).array() / value_of(m2).array()).matrix());
   using ret_type = promote_var_matrix_t<inner_ret_type, Mat1, Mat2>;
   if (!is_constant<Mat1>::value && !is_constant<Mat2>::value) {
     arena_t<promote_scalar_t<var, Mat1>> arena_m1 = m1;
@@ -46,7 +46,6 @@ auto elt_divide(const Mat1& m1, const Mat2& m2) {
     arena_t<promote_scalar_t<double, Mat2>> arena_m2 = value_of(m2);
     arena_t<ret_type> ret(arena_m1.val().array() / arena_m2.array());
     reverse_pass_callback([ret, arena_m1, arena_m2]() mutable {
-      using var_m1 = arena_t<promote_scalar_t<var, Mat1>>;
       arena_m1.adj().array() += ret.adj().array() / arena_m2.array();
     });
     return ret_type(ret);

--- a/stan/math/rev/fun/elt_divide.hpp
+++ b/stan/math/rev/fun/elt_divide.hpp
@@ -26,7 +26,8 @@ template <typename Mat1, typename Mat2,
           require_any_rev_matrix_t<Mat1, Mat2>* = nullptr>
 auto elt_divide(const Mat1& m1, const Mat2& m2) {
   check_matching_dims("elt_divide", "m1", m1, "m2", m2);
-  using inner_ret_type = decltype((value_of(m1).array() / value_of(m2).array()).matrix());
+  using inner_ret_type
+      = decltype((value_of(m1).array() / value_of(m2).array()).matrix());
   using ret_type = promote_var_matrix_t<inner_ret_type, Mat1, Mat2>;
   if (!is_constant<Mat1>::value && !is_constant<Mat2>::value) {
     arena_t<promote_scalar_t<var, Mat1>> arena_m1 = m1;

--- a/stan/math/rev/fun/elt_divide.hpp
+++ b/stan/math/rev/fun/elt_divide.hpp
@@ -1,0 +1,93 @@
+#ifndef STAN_MATH_REV_FUN_ELT_DIVIDE_HPP
+#define STAN_MATH_REV_FUN_ELT_DIVIDE_HPP
+
+#include <stan/math/prim/fun/Eigen.hpp>
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/err.hpp>
+#include <stan/math/prim/fun/eval.hpp>
+#include <stan/math/rev/core.hpp>
+
+namespace stan {
+namespace math {
+
+/**
+ * Return the elementwise multiplication of the specified
+ * matrices.
+ *
+ * @tparam Mat1 type of the first matrix or expression
+ * @tparam Mat2 type of the second matrix or expression
+ *
+ * @param m1 First matrix or expression
+ * @param m2 Second matrix or expression
+ * @return Elementwise product of matrices.
+ */
+template <typename Mat1, typename Mat2,
+          require_all_matrix_t<Mat1, Mat2>* = nullptr,
+          require_any_rev_matrix_t<Mat1, Mat2>* = nullptr>
+auto elt_divide(const Mat1& m1, const Mat2& m2) {
+  check_matching_dims("elt_divide", "m1", m1, "m2", m2);
+  using inner_ret_type = decltype(value_of(m1).cwiseProduct(value_of(m2)));
+  using ret_type = promote_var_matrix_t<inner_ret_type, Mat1, Mat2>;
+  if (!is_constant<Mat1>::value && !is_constant<Mat2>::value) {
+    arena_t<promote_scalar_t<var, Mat1>> arena_m1 = m1;
+    arena_t<promote_scalar_t<var, Mat2>> arena_m2 = m2;
+    arena_t<ret_type> ret(arena_m1.val().array() / arena_m2.val().array());
+    reverse_pass_callback([ret, arena_m1, arena_m2]() mutable {
+      for (Eigen::Index i = 0; i < arena_m2.size(); ++i) {
+        const auto ret_adj = ret.adj().coeffRef(i);
+        arena_m1.adj().coeffRef(i) += ret_adj / arena_m2.val().coeff(i);
+        arena_m2.adj().coeffRef(i) -= ret.val().coeff(i) * ret_adj / arena_m2.val().coeff(i);
+      }
+    });
+    return ret_type(ret);
+  } else if (!is_constant<Mat1>::value) {
+    arena_t<promote_scalar_t<var, Mat1>> arena_m1 = m1;
+    arena_t<promote_scalar_t<double, Mat2>> arena_m2 = value_of(m2);
+    arena_t<ret_type> ret(arena_m1.val().array() / arena_m2.array());
+    reverse_pass_callback([ret, arena_m1, arena_m2]() mutable {
+      using var_m1 = arena_t<promote_scalar_t<var, Mat1>>;
+      arena_m1.adj().array() += ret.adj().array() / arena_m2.array();
+    });
+    return ret_type(ret);
+  } else if (!is_constant<Mat2>::value) {
+    arena_t<promote_scalar_t<double, Mat1>> arena_m1 = value_of(m1);
+    arena_t<promote_scalar_t<var, Mat2>> arena_m2 = m2;
+    arena_t<ret_type> ret(arena_m1.array() / arena_m2.val().array());
+    reverse_pass_callback([ret, arena_m2, arena_m1]() mutable {
+      arena_m2.adj().array() -= ret.val().array() * ret.adj().array() / arena_m2.val().array();
+    });
+    return ret_type(ret);
+  }
+}
+
+/**
+ * Return the elementwise division of the specified scalar
+ * by the specified matrix.
+ *
+ * @tparam Scal type of the scalar
+ * @tparam Mat type of the matrix or expression
+ *
+ * @param s scalar
+ * @param m matrix or expression
+ * @return Elementwise division of a scalar by matrix.
+ */
+template <typename Scal, typename Mat,
+	  require_stan_scalar_t<Scal>* = nullptr,
+          require_var_matrix_t<Mat> * = nullptr>
+auto elt_divide(Scal s, const Mat& m) {
+  Mat res = value_of(s) / m.val().array();
+
+  reverse_pass_callback([m, s, res]() mutable {
+    m.adj().array() -= res.val().array() * res.adj().array() / m.val().array();
+    if (!is_constant<Scal>::value)
+      forward_as<var>(s).adj()
+	+= (res.adj().array() / m.val().array()).sum();
+  });
+
+  return res;
+}
+
+}  // namespace math
+}  // namespace stan
+
+#endif

--- a/stan/math/rev/fun/elt_divide.hpp
+++ b/stan/math/rev/fun/elt_divide.hpp
@@ -36,7 +36,8 @@ auto elt_divide(const Mat1& m1, const Mat2& m2) {
       for (Eigen::Index i = 0; i < arena_m2.size(); ++i) {
         const auto ret_adj = ret.adj().coeffRef(i);
         arena_m1.adj().coeffRef(i) += ret_adj / arena_m2.val().coeff(i);
-        arena_m2.adj().coeffRef(i) -= ret.val().coeff(i) * ret_adj / arena_m2.val().coeff(i);
+        arena_m2.adj().coeffRef(i)
+            -= ret.val().coeff(i) * ret_adj / arena_m2.val().coeff(i);
       }
     });
     return ret_type(ret);
@@ -54,7 +55,8 @@ auto elt_divide(const Mat1& m1, const Mat2& m2) {
     arena_t<promote_scalar_t<var, Mat2>> arena_m2 = m2;
     arena_t<ret_type> ret(arena_m1.array() / arena_m2.val().array());
     reverse_pass_callback([ret, arena_m2, arena_m1]() mutable {
-      arena_m2.adj().array() -= ret.val().array() * ret.adj().array() / arena_m2.val().array();
+      arena_m2.adj().array()
+          -= ret.val().array() * ret.adj().array() / arena_m2.val().array();
     });
     return ret_type(ret);
   }
@@ -71,17 +73,15 @@ auto elt_divide(const Mat1& m1, const Mat2& m2) {
  * @param m matrix or expression
  * @return Elementwise division of a scalar by matrix.
  */
-template <typename Scal, typename Mat,
-	  require_stan_scalar_t<Scal>* = nullptr,
-          require_var_matrix_t<Mat> * = nullptr>
+template <typename Scal, typename Mat, require_stan_scalar_t<Scal>* = nullptr,
+          require_var_matrix_t<Mat>* = nullptr>
 auto elt_divide(Scal s, const Mat& m) {
   Mat res = value_of(s) / m.val().array();
 
   reverse_pass_callback([m, s, res]() mutable {
     m.adj().array() -= res.val().array() * res.adj().array() / m.val().array();
     if (!is_constant<Scal>::value)
-      forward_as<var>(s).adj()
-	+= (res.adj().array() / m.val().array()).sum();
+      forward_as<var>(s).adj() += (res.adj().array() / m.val().array()).sum();
   });
 
   return res;

--- a/stan/math/rev/fun/elt_multiply.hpp
+++ b/stan/math/rev/fun/elt_multiply.hpp
@@ -45,7 +45,6 @@ auto elt_multiply(const Mat1& m1, const Mat2& m2) {
     arena_t<promote_scalar_t<double, Mat2>> arena_m2 = value_of(m2);
     arena_t<ret_type> ret(arena_m1.val().cwiseProduct(arena_m2));
     reverse_pass_callback([ret, arena_m1, arena_m2]() mutable {
-      using var_m1 = arena_t<promote_scalar_t<var, Mat1>>;
       arena_m1.adj().array() += arena_m2.array() * ret.adj().array();
     });
     return ret_type(ret);

--- a/test/unit/math/mix/fun/divide_test.cpp
+++ b/test/unit/math/mix/fun/divide_test.cpp
@@ -8,29 +8,36 @@ TEST(MathMixMatFun, divide) {
   double x1 = 10;
   double x2 = -2;
   stan::test::expect_ad(f, x1, x2);
+  stan::test::expect_ad_matvar(f, x1, x2);
 
   Eigen::VectorXd v(1);
   v << 10;
   stan::test::expect_ad(f, v, x2);
+  stan::test::expect_ad_matvar(f, v, x2);
 
   Eigen::RowVectorXd rv = v;
   stan::test::expect_ad(f, rv, x2);
+  stan::test::expect_ad_matvar(f, rv, x2);
 
   Eigen::MatrixXd m(1, 1);
   m << 10;
   stan::test::expect_ad(f, m, x2);
+  stan::test::expect_ad_matvar(f, m, x2);
 
   Eigen::MatrixXd p(3, 2);
   p << 1, 2, 3, 4, 5, 6;
   stan::test::expect_ad(f, p, x2);
+  stan::test::expect_ad_matvar(f, m, x2);
 
   Eigen::VectorXd w(3);
   w << 100, 0, -3;
   stan::test::expect_ad(f, w, x2);
+  stan::test::expect_ad_matvar(f, m, x2);
 
   Eigen::VectorXd u(4);
   u << 100, 0, -3, 4;
   stan::test::expect_ad(f, u, x2);
+  stan::test::expect_ad_matvar(f, m, x2);
 
   Eigen::VectorXd v0(0);
   Eigen::RowVectorXd rv0(0);
@@ -39,13 +46,22 @@ TEST(MathMixMatFun, divide) {
   stan::test::expect_ad(f, rv0, x1);
   stan::test::expect_ad(f, m00, x1);
 
+  stan::test::expect_ad_matvar(f, v0, x1);
+  stan::test::expect_ad_matvar(f, rv0, x1);
+  stan::test::expect_ad_matvar(f, m00, x1);
+
   stan::test::expect_ad(f, u, 0.0);
   stan::test::expect_ad(f, rv, 0.0);
   stan::test::expect_ad(f, p, 0.0);
 
+  stan::test::expect_ad_matvar(f, u, 0.0);
+  stan::test::expect_ad_matvar(f, rv, 0.0);
+  stan::test::expect_ad_matvar(f, p, 0.0);
+
   Eigen::RowVectorXd rv4(4);
   rv4 << -5, 10, 7, 8.2;
   stan::test::expect_ad(f, rv4, x2);
+  stan::test::expect_ad_matvar(f, rv4, x2);
 
   double inf = std::numeric_limits<double>::infinity();
   double nan = std::numeric_limits<double>::quiet_NaN();
@@ -53,5 +69,9 @@ TEST(MathMixMatFun, divide) {
     stan::test::expect_ad(f, u, value);
     stan::test::expect_ad(f, rv4, value);
     stan::test::expect_ad(f, p, value);
+
+    stan::test::expect_ad_matvar(f, u, value);
+    stan::test::expect_ad_matvar(f, rv4, value);
+    stan::test::expect_ad_matvar(f, p, value);
   }
 }

--- a/test/unit/math/mix/fun/elt_divide_test.cpp
+++ b/test/unit/math/mix/fun/elt_divide_test.cpp
@@ -10,27 +10,38 @@ TEST(MathMixMatFun, eltDivide) {
   Eigen::VectorXd b2(2);
   b2 << 10, 100;
   stan::test::expect_ad(f, a2, b2);
+  stan::test::expect_ad_matvar(f, a2, b2);
 
   Eigen::RowVectorXd c2(2);
   c2 << 2, 5;
   Eigen::RowVectorXd d2(2);
   d2 << 10, 100;
   stan::test::expect_ad(f, c2, d2);
+  stan::test::expect_ad_matvar(f, c2, d2);
 
   Eigen::MatrixXd e23(2, 3);
   e23 << 2, 5, 7, 13, 29, 112;
   Eigen::MatrixXd f23(2, 3);
   f23 << 1e1, 1e2, 1e3, 1e4, 1e5, 1e6;
   stan::test::expect_ad(f, e23, f23);
+  stan::test::expect_ad_matvar(f, e23, f23);
 
   double z = 10;
   stan::test::expect_ad(f, a2, z);
   stan::test::expect_ad(f, c2, z);
   stan::test::expect_ad(f, e23, z);
 
+  stan::test::expect_ad_matvar(f, a2, z);
+  stan::test::expect_ad_matvar(f, c2, z);
+  stan::test::expect_ad_matvar(f, e23, z);
+
   stan::test::expect_ad(f, z, a2);
   stan::test::expect_ad(f, z, c2);
   stan::test::expect_ad(f, z, e23);
+
+  stan::test::expect_ad_matvar(f, z, a2);
+  stan::test::expect_ad_matvar(f, z, c2);
+  stan::test::expect_ad_matvar(f, z, e23);
 
   Eigen::VectorXd v0(0);
   Eigen::RowVectorXd rv0(0);
@@ -41,4 +52,11 @@ TEST(MathMixMatFun, eltDivide) {
   stan::test::expect_ad(f, v0, z);
   stan::test::expect_ad(f, rv0, z);
   stan::test::expect_ad(f, m00, z);
+
+  stan::test::expect_ad_matvar(f, v0, v0);
+  stan::test::expect_ad_matvar(f, rv0, rv0);
+  stan::test::expect_ad_matvar(f, m00, m00);
+  stan::test::expect_ad_matvar(f, v0, z);
+  stan::test::expect_ad_matvar(f, rv0, z);
+  stan::test::expect_ad_matvar(f, m00, z);
 }


### PR DESCRIPTION
## Summary

`var<mat>` version of divide. I didn't realize that the tests already supported combos of matrix and scalar types! Neat!

## Release notes

Added `var<mat>` support to `divide`

## Checklist

- [x] Math issue #2101 

- [x] Copyright holder: Columbia University

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
