### PR TITLE
Allow var_value<Matrix> to var_value<Block> Assignment

### DIFF
--- a/stan/math/prim/meta/require_generics.hpp
+++ b/stan/math/prim/meta/require_generics.hpp
@@ -11,6 +11,8 @@ STAN_ADD_REQUIRE_BINARY_INNER(same, std::is_same, require_std);
 
 STAN_ADD_REQUIRE_BINARY(convertible, std::is_convertible, require_std);
 STAN_ADD_REQUIRE_BINARY_INNER(convertible, std::is_convertible, require_std);
+STAN_ADD_REQUIRE_BINARY(assignable, std::is_assignable, require_std);
+STAN_ADD_REQUIRE_BINARY_INNER(assignable, std::is_assignable, require_std);
 
 STAN_ADD_REQUIRE_UNARY(arithmetic, std::is_arithmetic,
                        require_stan_scalar_real);

--- a/stan/math/rev/core/var.hpp
+++ b/stan/math/rev/core/var.hpp
@@ -359,7 +359,7 @@ class var_value<
    * @tparam S A type that is convertible to `value_type`.
    * @param x Value of the variable.
    */
-  template <typename S, require_convertible_t<S&, value_type>* = nullptr>
+  template <typename S, require_assignable_t<value_type, S>* = nullptr>
   var_value(S&& x) : vi_(new vari_type(std::forward<S>(x), false)) {}  // NOLINT
 
   /**
@@ -368,7 +368,7 @@ class var_value<
    * @param other the value to assign
    * @return this
    */
-  template <typename S, require_convertible_t<S&, value_type>* = nullptr,
+  template <typename S, require_assignable_t<value_type, S>* = nullptr,
             require_all_plain_type_t<T, S>* = nullptr>
   var_value(const var_value<S>& other) : vi_(other.vi_) {}
 
@@ -380,7 +380,7 @@ class var_value<
    * @return this
    */
   template <typename S, typename T_ = T,
-            require_convertible_t<S&, value_type>* = nullptr,
+            require_assignable_t<value_type, S>* = nullptr,
             require_not_plain_type_t<S>* = nullptr,
             require_plain_type_t<T_>* = nullptr>
   var_value(const var_value<S>& other) : vi_(new vari_type(other.vi_->val_)) {
@@ -848,7 +848,7 @@ class var_value<
    * @param other the value to assign
    * @return this
    */
-  template <typename S, require_convertible_t<S&, value_type>* = nullptr,
+  template <typename S, require_assignable_t<value_type, S>* = nullptr,
             require_all_plain_type_t<T, S>* = nullptr>
   inline var_value<T>& operator=(const var_value<S>& other) {
     vi_ = other.vi_;
@@ -862,8 +862,8 @@ class var_value<
    * @param other the value to assign
    * @return this
    */
-  template <typename S, require_convertible_t<S&, value_type>* = nullptr,
-            require_any_not_plain_type_t<T, S>* = nullptr>
+  template <typename S, typename T_ = T, require_assignable_t<value_type, S>* = nullptr,
+            require_any_not_plain_type_t<T_, S>* = nullptr>
   inline var_value<T>& operator=(const var_value<S>& other) {
     arena_t<plain_type_t<T>> prev_val = vi_->val_;
     vi_->val_ = other.val();

--- a/stan/math/rev/core/var.hpp
+++ b/stan/math/rev/core/var.hpp
@@ -862,7 +862,8 @@ class var_value<
    * @param other the value to assign
    * @return this
    */
-  template <typename S, typename T_ = T, require_assignable_t<value_type, S>* = nullptr,
+  template <typename S, typename T_ = T,
+            require_assignable_t<value_type, S>* = nullptr,
             require_any_not_plain_type_t<T_, S>* = nullptr>
   inline var_value<T>& operator=(const var_value<S>& other) {
     arena_t<plain_type_t<T>> prev_val = vi_->val_;

--- a/stan/math/rev/core/vari.hpp
+++ b/stan/math/rev/core/vari.hpp
@@ -442,8 +442,8 @@ class vari_view<T, require_not_plain_type_t<T>> final
   T val_;
   T adj_;
   template <typename S, typename K,
-            require_convertible_t<S&, value_type>* = nullptr,
-            require_convertible_t<K&, value_type>* = nullptr>
+            require_assignable_t<value_type, S>* = nullptr,
+            require_assignable_t<value_type, K>* = nullptr>
   vari_view(const S& val, const K& adj) noexcept : val_(val), adj_(adj) {}
 
   void set_zero_adjoint() {}
@@ -507,7 +507,7 @@ class vari_value<T, require_all_t<is_plain_type<T>, is_eigen_dense_base<T>>>
    * @tparam S A dense Eigen type that is convertible to `value_type`
    * @param x Value of the constructed variable.
    */
-  template <typename S, require_convertible_t<S&, T>* = nullptr>
+  template <typename S, require_assignable_t<T, S>* = nullptr>
   explicit vari_value(const S& x) : val_(x), adj_(x.rows(), x.cols()) {
     adj_.setZero();
     ChainableStack::instance_->var_stack_.push_back(this);
@@ -528,7 +528,7 @@ class vari_value<T, require_all_t<is_plain_type<T>, is_eigen_dense_base<T>>>
    * @param stacked If false will put this this vari on the nochain stack so
    * that its `chain()` method is not called.
    */
-  template <typename S, require_convertible_t<S&, T>* = nullptr>
+  template <typename S, require_assignable_t<T, S>* = nullptr>
   vari_value(const S& x, bool stacked) : val_(x), adj_(x.rows(), x.cols()) {
     adj_.setZero();
     if (stacked) {

--- a/test/unit/math/rev/core/var_test.cpp
+++ b/test/unit/math/rev/core/var_test.cpp
@@ -375,7 +375,6 @@ TEST_F(AgradRev, var_matrix_view_block_from_plain) {
   EXPECT_FLOAT_EQ(B_v.adj()(3), 5);
 }
 
-
 /**
  * Tests that views of a var<Matrix> receive the adjoints of the original
  * matrix.

--- a/test/unit/math/rev/core/var_test.cpp
+++ b/test/unit/math/rev/core/var_test.cpp
@@ -355,6 +355,27 @@ TEST_F(AgradRev, var_vector_views_const) {
   var_vector_views_const_test<Eigen::RowVectorXd>();
 }
 
+TEST_F(AgradRev, var_matrix_view_block_from_plain) {
+  using stan::math::sum;
+  using stan::math::var_value;
+  Eigen::MatrixXd A(4, 4);
+  A << 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15;
+  var_value<Eigen::MatrixXd> A_v(A);
+  Eigen::MatrixXd B(2, 2);
+  B << 2, 3, 4, 5;
+  var_value<Eigen::MatrixXd> B_v(B);
+  for (Eigen::Index i = 0; i < A_v.size(); ++i) {
+    A_v.adj().coeffRef(i) = i;
+  }
+  A_v.block(0, 0, 2, 2) = B_v;
+  stan::math::grad();
+  EXPECT_FLOAT_EQ(B_v.adj()(0), 0);
+  EXPECT_FLOAT_EQ(B_v.adj()(1), 1);
+  EXPECT_FLOAT_EQ(B_v.adj()(2), 4);
+  EXPECT_FLOAT_EQ(B_v.adj()(3), 5);
+}
+
+
 /**
  * Tests that views of a var<Matrix> receive the adjoints of the original
  * matrix.

--- a/test/unit/math/rev/core/var_test.cpp
+++ b/test/unit/math/rev/core/var_test.cpp
@@ -355,7 +355,7 @@ TEST_F(AgradRev, var_vector_views_const) {
   var_vector_views_const_test<Eigen::RowVectorXd>();
 }
 
-TEST_F(AgradRev, var_matrix_view_block_from_plain) {
+TEST_F(AgradRev, var_matrix_view_block_from_plain_test) {
   using stan::math::sum;
   using stan::math::var_value;
   Eigen::MatrixXd A(4, 4);

--- a/test/unit/math/rev/core/var_test.cpp
+++ b/test/unit/math/rev/core/var_test.cpp
@@ -360,20 +360,21 @@ TEST_F(AgradRev, var_matrix_view_block_from_plain) {
   using stan::math::var_value;
   Eigen::MatrixXd A(4, 4);
   A << 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15;
-  var_value<Eigen::MatrixXd> A_v(A);
   Eigen::MatrixXd B(2, 2);
   B << 2, 3, 4, 5;
+  var_value<Eigen::MatrixXd> A_v(A);
   var_value<Eigen::MatrixXd> B_v(B);
+  A_v.block(0, 0, 2, 2) = B_v;
   for (Eigen::Index i = 0; i < A_v.size(); ++i) {
     A_v.adj().coeffRef(i) = i;
   }
-  A_v.block(0, 0, 2, 2) = B_v;
   stan::math::grad();
   EXPECT_FLOAT_EQ(B_v.adj()(0), 0);
   EXPECT_FLOAT_EQ(B_v.adj()(1), 1);
   EXPECT_FLOAT_EQ(B_v.adj()(2), 4);
   EXPECT_FLOAT_EQ(B_v.adj()(3), 5);
 }
+
 
 /**
  * Tests that views of a var<Matrix> receive the adjoints of the original


### PR DESCRIPTION
## Summary

Quick bug fix, for doing 

```cpp
  var_value<Eigen::MatrixXd> A_v(A);
  var_value<Eigen::MatrixXd> B_v(B);
  A_v.block(0, 0, 2, 2) = B_v;
```

We need the constructors for `var<mat>` to require that the input is assignable and not convertible. This just changes the requires on the constructors for `var<mat>` to allow that

## Tests

Test added to `var_test` that checks adjoints are propogated correctly

## Side Effects

Nope

## Release notes

Bug fix for assignment to blocks of a `var<matrix>`

## Checklist

- [ ] Math issue #(issue number)

- [x] Copyright holder: Steve Bronder

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
