### PR TITLE
Simplifiy OpenCL broadcasting tests

### DIFF
--- a/test/unit/math/opencl/rev/bernoulli_logit_glm_lpmf_test.cpp
+++ b/test/unit/math/opencl/rev/bernoulli_logit_glm_lpmf_test.cpp
@@ -121,54 +121,17 @@ TEST(ProbDistributionsBernoulliLogitGLM, opencl_broadcast_y) {
   int N = 3;
   int M = 2;
 
-  int y = 1;
-  vector<int> y_vec{y, y, y};
+  int y_scal = 1;
   Matrix<double, Dynamic, Dynamic> x(N, M);
   x << -12, 46, -42, 24, 25, 27;
   Matrix<double, Dynamic, 1> beta(M, 1);
   beta << 0.3, 2;
   double alpha = 0.3;
 
-  matrix_cl<double> x_cl(x);
-  matrix_cl<int> y_vec_cl(y_vec);
-  matrix_cl<double> beta_cl(beta);
-
-  expect_near_rel(
-      "bernoulli_logit_glm_lpmf (OpenCL)",
-      stan::math::bernoulli_logit_glm_lpmf(y, x_cl, alpha, beta_cl),
-      stan::math::bernoulli_logit_glm_lpmf(y_vec_cl, x_cl, alpha, beta_cl));
-  expect_near_rel(
-      "bernoulli_logit_glm_lpmf (OpenCL)",
-      stan::math::bernoulli_logit_glm_lpmf<true>(y, x_cl, alpha, beta_cl),
-      stan::math::bernoulli_logit_glm_lpmf<true>(y_vec_cl, x_cl, alpha,
-                                                 beta_cl));
-
-  Matrix<var, Dynamic, Dynamic> x_var1 = x;
-  Matrix<var, Dynamic, Dynamic> x_var2 = x;
-  Matrix<var, Dynamic, 1> beta_var1 = beta;
-  Matrix<var, Dynamic, 1> beta_var2 = beta;
-  auto x_var1_cl = to_matrix_cl(x_var1);
-  auto x_var2_cl = to_matrix_cl(x_var2);
-  auto beta_var1_cl = stan::math::to_matrix_cl(beta_var1);
-  auto beta_var2_cl = stan::math::to_matrix_cl(beta_var2);
-  var alpha_var1 = alpha;
-  var alpha_var2 = alpha;
-
-  var res1 = stan::math::bernoulli_logit_glm_lpmf(y, x_var1_cl, alpha_var1,
-                                                  beta_var1_cl);
-  var res2 = stan::math::bernoulli_logit_glm_lpmf(y_vec_cl, x_var2_cl,
-                                                  alpha_var2, beta_var2_cl);
-
-  (res1 + res2).grad();
-
-  expect_near_rel("bernoulli_logit_glm_lpmf (OpenCL)", res1.val(), res2.val());
-
-  expect_near_rel("bernoulli_logit_glm_lpmf (OpenCL)", x_var1.adj().eval(),
-                  x_var2.adj().eval());
-  expect_near_rel("bernoulli_logit_glm_lpmf (OpenCL)", alpha_var1.adj(),
-                  alpha_var2.adj());
-  expect_near_rel("bernoulli_logit_glm_lpmf (OpenCL)", beta_var1.adj().eval(),
-                  beta_var2.adj().eval());
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(bernoulli_logit_glm_lpmf_functor,
+                                                         y_scal, x, alpha, beta);
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(
+      bernoulli_logit_glm_lpmf_functor_propto, y_scal, x, alpha, beta);
 }
 
 TEST(ProbDistributionsBernoulliLogitGLM, opencl_matches_cpu_zero_instances) {

--- a/test/unit/math/opencl/rev/bernoulli_logit_glm_lpmf_test.cpp
+++ b/test/unit/math/opencl/rev/bernoulli_logit_glm_lpmf_test.cpp
@@ -128,8 +128,8 @@ TEST(ProbDistributionsBernoulliLogitGLM, opencl_broadcast_y) {
   beta << 0.3, 2;
   double alpha = 0.3;
 
-  stan::math::test::test_opencl_broadcasting_prim_rev<0>(bernoulli_logit_glm_lpmf_functor,
-                                                         y_scal, x, alpha, beta);
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(
+      bernoulli_logit_glm_lpmf_functor, y_scal, x, alpha, beta);
   stan::math::test::test_opencl_broadcasting_prim_rev<0>(
       bernoulli_logit_glm_lpmf_functor_propto, y_scal, x, alpha, beta);
 }

--- a/test/unit/math/opencl/rev/bernoulli_lpmf_test.cpp
+++ b/test/unit/math/opencl/rev/bernoulli_lpmf_test.cpp
@@ -62,64 +62,26 @@ TEST(ProbDistributionsBernoulli, opencl_matches_cpu_small) {
 TEST(ProbDistributionsBernoulli, opencl_broadcast_n) {
   int N = 3;
 
-  int n = 1;
-  std::vector<int> n_vec{n, n, n};
+  int n_scal = 1;
   Eigen::VectorXd theta(N);
   theta << 0.3, 0.8, 1.0;
 
-  stan::math::matrix_cl<int> n_vec_cl(n_vec);
-  stan::math::matrix_cl<double> theta_cl(theta);
-
-  EXPECT_NEAR_REL(stan::math::bernoulli_lpmf(n, theta_cl),
-                  stan::math::bernoulli_lpmf(n_vec_cl, theta_cl));
-  EXPECT_NEAR_REL(stan::math::bernoulli_lpmf<true>(n, theta_cl),
-                  stan::math::bernoulli_lpmf<true>(n_vec_cl, theta_cl));
-
-  Eigen::Matrix<stan::math::var, Eigen::Dynamic, 1> theta_var1 = theta;
-  Eigen::Matrix<stan::math::var, Eigen::Dynamic, 1> theta_var2 = theta;
-  auto theta_var1_cl = stan::math::to_matrix_cl(theta_var1);
-  auto theta_var2_cl = stan::math::to_matrix_cl(theta_var2);
-
-  stan::math::var res1 = stan::math::bernoulli_lpmf(n, theta_var1_cl);
-  stan::math::var res2 = stan::math::bernoulli_lpmf(n_vec_cl, theta_var2_cl);
-
-  (res1 + res2).grad();
-
-  EXPECT_NEAR_REL(res1.val(), res2.val());
-
-  EXPECT_NEAR_REL(theta_var1.adj().eval(), theta_var2.adj().eval());
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(bernoulli_lpmf_functor,
+                                                         n_scal, theta);
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(
+      bernoulli_lpmf_functor_propto, n_scal, theta);
 }
 
 TEST(ProbDistributionsBernoulli, opencl_broadcast_theta) {
   int N = 3;
 
   std::vector<int> n{0, 1, 0};
-  double theta = 0.4;
-  Eigen::VectorXd theta_vec(N);
-  theta_vec << theta, theta, theta;
+  double theta_scal = 0.4;
 
-  stan::math::matrix_cl<int> n_cl(n);
-  stan::math::matrix_cl<double> theta_vec_cl(theta_vec);
-
-  EXPECT_NEAR_REL(stan::math::bernoulli_lpmf(n_cl, theta),
-                  stan::math::bernoulli_lpmf(n_cl, theta_vec_cl));
-  EXPECT_NEAR_REL(stan::math::bernoulli_lpmf<true>(n_cl, theta),
-                  stan::math::bernoulli_lpmf<true>(n_cl, theta_vec_cl));
-
-  stan::math::var theta_var1 = theta;
-  stan::math::var theta_var2 = theta;
-  Eigen::Matrix<stan::math::var, Eigen::Dynamic, 1> theta_var2_vec(N);
-  theta_var2_vec << theta_var2, theta_var2, theta_var2;
-  auto theta_var2_cl = stan::math::to_matrix_cl(theta_var2_vec);
-
-  stan::math::var res1 = stan::math::bernoulli_lpmf(n_cl, theta_var1);
-  stan::math::var res2 = stan::math::bernoulli_lpmf(n_cl, theta_var2_cl);
-
-  (res1 + res2).grad();
-
-  EXPECT_NEAR_REL(res1.val(), res2.val());
-
-  EXPECT_NEAR_REL(theta_var1.adj(), theta_var2.adj());
+  stan::math::test::test_opencl_broadcasting_prim_rev<1>(bernoulli_lpmf_functor,
+                                                         n, theta_scal);
+  stan::math::test::test_opencl_broadcasting_prim_rev<1>(
+      bernoulli_lpmf_functor_propto, n, theta_scal);
 }
 
 TEST(ProbDistributionsBernoulli, opencl_matches_cpu_big) {

--- a/test/unit/math/opencl/rev/categorical_logit_glm_lpmf_test.cpp
+++ b/test/unit/math/opencl/rev/categorical_logit_glm_lpmf_test.cpp
@@ -135,9 +135,8 @@ TEST(ProbDistributionsCategoricalLogitGLM, opencl_broadcast_y) {
   Matrix<double, Dynamic, 1> alpha(C);
   alpha << 0.3, -2, 0.8;
 
-
-  stan::math::test::test_opencl_broadcasting_prim_rev<0>(categorical_logit_glm_lpmf_functor,
-                                                         y_scal, x, alpha, beta);
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(
+      categorical_logit_glm_lpmf_functor, y_scal, x, alpha, beta);
   stan::math::test::test_opencl_broadcasting_prim_rev<0>(
       categorical_logit_glm_lpmf_functor_propto, y_scal, x, alpha, beta);
 }

--- a/test/unit/math/opencl/rev/categorical_logit_glm_lpmf_test.cpp
+++ b/test/unit/math/opencl/rev/categorical_logit_glm_lpmf_test.cpp
@@ -127,8 +127,7 @@ TEST(ProbDistributionsCategoricalLogitGLM, opencl_broadcast_y) {
   int M = 2;
   int C = 3;
 
-  int y_scalar = 1;
-  vector<int> y_vec{1, 1, 1};
+  int y_scal = 1;
   Matrix<double, Dynamic, Dynamic> x(N, M);
   x << -12, 46, -42, 24, 25, 27;
   Matrix<double, Dynamic, Dynamic> beta(M, C);
@@ -136,44 +135,11 @@ TEST(ProbDistributionsCategoricalLogitGLM, opencl_broadcast_y) {
   Matrix<double, Dynamic, 1> alpha(C);
   alpha << 0.3, -2, 0.8;
 
-  matrix_cl<double> x_cl(x);
-  matrix_cl<int> y_vec_cl(y_vec);
-  matrix_cl<double> beta_cl(beta);
-  matrix_cl<double> alpha_cl(alpha);
 
-  EXPECT_NEAR_REL(
-      stan::math::categorical_logit_glm_lpmf(y_scalar, x_cl, alpha_cl, beta_cl),
-      stan::math::categorical_logit_glm_lpmf(y_vec_cl, x_cl, alpha_cl, beta_cl))
-  EXPECT_NEAR_REL(stan::math::categorical_logit_glm_lpmf<true>(
-                      y_scalar, x_cl, alpha_cl, beta_cl),
-                  stan::math::categorical_logit_glm_lpmf<true>(
-                      y_vec_cl, x_cl, alpha_cl, beta_cl));
-
-  Matrix<var, Dynamic, Dynamic> x_var1 = x;
-  Matrix<var, Dynamic, Dynamic> x_var2 = x;
-  Matrix<var, Dynamic, Dynamic> beta_var1 = beta;
-  Matrix<var, Dynamic, Dynamic> beta_var2 = beta;
-  Matrix<var, Dynamic, 1> alpha_var1 = alpha;
-  Matrix<var, Dynamic, 1> alpha_var2 = alpha;
-  auto x_var1_cl = to_matrix_cl(x_var1);
-  auto x_var2_cl = to_matrix_cl(x_var2);
-  auto beta_var1_cl = stan::math::to_matrix_cl(beta_var1);
-  auto beta_var2_cl = stan::math::to_matrix_cl(beta_var2);
-  auto alpha_var1_cl = stan::math::to_matrix_cl(alpha_var1);
-  auto alpha_var2_cl = stan::math::to_matrix_cl(alpha_var2);
-
-  var res1 = stan::math::categorical_logit_glm_lpmf(
-      y_scalar, x_var1_cl, alpha_var1_cl, beta_var1_cl);
-  var res2 = stan::math::categorical_logit_glm_lpmf(
-      y_vec_cl, x_var2_cl, alpha_var2_cl, beta_var2_cl);
-
-  (res1 + res2).grad();
-
-  EXPECT_NEAR_REL(res1.val(), res2.val());
-
-  EXPECT_NEAR_REL(x_var1.adj().eval(), x_var2.adj().eval());
-  EXPECT_NEAR_REL(alpha_var1.adj().eval(), alpha_var2.adj().eval());
-  EXPECT_NEAR_REL(beta_var1.adj().eval(), beta_var2.adj().eval());
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(categorical_logit_glm_lpmf_functor,
+                                                         y_scal, x, alpha, beta);
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(
+      categorical_logit_glm_lpmf_functor_propto, y_scal, x, alpha, beta);
 }
 
 TEST(ProbDistributionsCategoricalLogitGLM, opencl_matches_cpu_zero_instances) {

--- a/test/unit/math/opencl/rev/neg_binomial_2_log_glm_lpmf_test.cpp
+++ b/test/unit/math/opencl/rev/neg_binomial_2_log_glm_lpmf_test.cpp
@@ -157,8 +157,8 @@ TEST(ProbDistributionsNegBinomial2LogGLM, opencl_broadcast_y) {
   double alpha = 0.3;
   double phi = 13.2;
 
-  stan::math::test::test_opencl_broadcasting_prim_rev<0>(neg_binomial_2_log_glm_lpmf_functor,
-                                                         y_scal, x, alpha, beta, phi);
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(
+      neg_binomial_2_log_glm_lpmf_functor, y_scal, x, alpha, beta, phi);
   stan::math::test::test_opencl_broadcasting_prim_rev<0>(
       neg_binomial_2_log_glm_lpmf_functor_propto, y_scal, x, alpha, beta, phi);
 }

--- a/test/unit/math/opencl/rev/neg_binomial_2_log_glm_lpmf_test.cpp
+++ b/test/unit/math/opencl/rev/neg_binomial_2_log_glm_lpmf_test.cpp
@@ -149,8 +149,7 @@ TEST(ProbDistributionsNegBinomial2LogGLM, opencl_broadcast_y) {
   int N = 3;
   int M = 2;
 
-  int y = 1;
-  vector<int> y_vec{y, y, y};
+  int y_scal = 1;
   Matrix<double, Dynamic, Dynamic> x(N, M);
   x << -12, 46, -42, 24, 25, 27;
   Matrix<double, Dynamic, 1> beta(M, 1);
@@ -158,52 +157,10 @@ TEST(ProbDistributionsNegBinomial2LogGLM, opencl_broadcast_y) {
   double alpha = 0.3;
   double phi = 13.2;
 
-  matrix_cl<double> x_cl(x);
-  matrix_cl<int> y_vec_cl(y_vec);
-  matrix_cl<double> beta_cl(beta);
-
-  expect_near_rel(
-      "neg_binomial_2_log_glm_lpmf (OpenCL)",
-      stan::math::neg_binomial_2_log_glm_lpmf(y, x_cl, alpha, beta_cl, phi),
-      stan::math::neg_binomial_2_log_glm_lpmf(y_vec_cl, x_cl, alpha, beta_cl,
-                                              phi));
-  expect_near_rel("neg_binomial_2_log_glm_lpmf (OpenCL)",
-                  stan::math::neg_binomial_2_log_glm_lpmf<true>(y, x_cl, alpha,
-                                                                beta_cl, phi),
-                  stan::math::neg_binomial_2_log_glm_lpmf<true>(
-                      y_vec_cl, x_cl, alpha, beta_cl, phi));
-
-  Matrix<var, Dynamic, Dynamic> x_var1 = x;
-  Matrix<var, Dynamic, Dynamic> x_var2 = x;
-  Matrix<var, Dynamic, 1> beta_var1 = beta;
-  Matrix<var, Dynamic, 1> beta_var2 = beta;
-  auto x_var1_cl = to_matrix_cl(x_var1);
-  auto x_var2_cl = to_matrix_cl(x_var2);
-  auto beta_var1_cl = to_matrix_cl(beta_var1);
-  auto beta_var2_cl = to_matrix_cl(beta_var2);
-  var alpha_var1 = alpha;
-  var alpha_var2 = alpha;
-  var phi_var1 = phi;
-  var phi_var2 = phi;
-
-  var res1 = stan::math::neg_binomial_2_log_glm_lpmf(y, x_var1_cl, alpha_var1,
-                                                     beta_var1_cl, phi_var1);
-  var res2 = stan::math::neg_binomial_2_log_glm_lpmf(
-      y_vec_cl, x_var2_cl, alpha_var2, beta_var2_cl, phi_var2);
-
-  (res1 + res2).grad();
-
-  expect_near_rel("neg_binomial_2_log_glm_lpmf (OpenCL)", res1.val(),
-                  res2.val());
-
-  expect_near_rel("neg_binomial_2_log_glm_lpmf (OpenCL)", x_var1.adj().eval(),
-                  x_var2.adj().eval());
-  expect_near_rel("neg_binomial_2_log_glm_lpmf (OpenCL)", alpha_var1.adj(),
-                  alpha_var2.adj());
-  expect_near_rel("neg_binomial_2_log_glm_lpmf (OpenCL)",
-                  beta_var1.adj().eval(), beta_var2.adj().eval());
-  expect_near_rel("neg_binomial_2_log_glm_lpmf (OpenCL)", phi_var1.adj(),
-                  phi_var2.adj());
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(neg_binomial_2_log_glm_lpmf_functor,
+                                                         y_scal, x, alpha, beta, phi);
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(
+      neg_binomial_2_log_glm_lpmf_functor_propto, y_scal, x, alpha, beta, phi);
 }
 
 TEST(ProbDistributionsNegBinomial2LogGLM, opencl_matches_cpu_zero_instances) {

--- a/test/unit/math/opencl/rev/normal_id_glm_lpdf_test.cpp
+++ b/test/unit/math/opencl/rev/normal_id_glm_lpdf_test.cpp
@@ -138,9 +138,7 @@ TEST(ProbDistributionsNormalIdGLM, opencl_broadcast_y) {
   int N = 3;
   int M = 2;
 
-  double y = 13;
-  Matrix<double, Dynamic, 1> y_vec
-      = Matrix<double, Dynamic, 1>::Constant(N, 1, y);
+  double y_scal = 13;
   Matrix<double, Dynamic, Dynamic> x(N, M);
   x << -12, 46, -42, 24, 25, 27;
   Matrix<double, Dynamic, 1> beta(M, 1);
@@ -148,53 +146,10 @@ TEST(ProbDistributionsNormalIdGLM, opencl_broadcast_y) {
   double alpha = 0.3;
   double sigma = 11;
 
-  matrix_cl<double> x_cl(x);
-  matrix_cl<double> y_vec_cl(y_vec);
-  matrix_cl<double> beta_cl(beta);
-
-  expect_near_rel(
-      "normal_id_glm_lpdf (OpenCL)",
-      stan::math::normal_id_glm_lpdf(y, x_cl, alpha, beta_cl, sigma),
-      stan::math::normal_id_glm_lpdf(y_vec_cl, x_cl, alpha, beta_cl, sigma));
-  expect_near_rel(
-      "normal_id_glm_lpdf (OpenCL)",
-      stan::math::normal_id_glm_lpdf<true>(y, x_cl, alpha, beta_cl, sigma),
-      stan::math::normal_id_glm_lpdf<true>(y_vec_cl, x_cl, alpha, beta_cl,
-                                           sigma));
-
-  var y_var1 = y;
-  Matrix<var, Dynamic, 1> y_var2 = y_vec;
-  Matrix<var, Dynamic, Dynamic> x_var1 = x;
-  Matrix<var, Dynamic, Dynamic> x_var2 = x;
-  Matrix<var, Dynamic, 1> beta_var1 = beta;
-  Matrix<var, Dynamic, 1> beta_var2 = beta;
-  auto x_var1_cl = to_matrix_cl(x_var1);
-  auto x_var2_cl = to_matrix_cl(x_var2);
-  auto y_var2_cl = to_matrix_cl(y_var2);
-  auto beta_var1_cl = to_matrix_cl(beta_var1);
-  auto beta_var2_cl = to_matrix_cl(beta_var2);
-  var alpha_var1 = alpha;
-  var alpha_var2 = alpha;
-  var sigma_var1 = sigma;
-  var sigma_var2 = sigma;
-
-  var res1 = stan::math::normal_id_glm_lpdf(y_var1, x_var1_cl, alpha_var1,
-                                            beta_var1_cl, sigma_var1);
-  var res2 = stan::math::normal_id_glm_lpdf(y_var2_cl, x_var2_cl, alpha_var2,
-                                            beta_var2_cl, sigma_var2);
-
-  (res1 + res2).grad();
-
-  expect_near_rel("normal_id_glm_lpdf (OpenCL)", res1.val(), res2.val());
-
-  expect_near_rel("normal_id_glm_lpdf (OpenCL)", x_var1.adj().eval(),
-                  x_var2.adj().eval());
-  expect_near_rel("normal_id_glm_lpdf (OpenCL)", alpha_var1.adj(),
-                  alpha_var2.adj());
-  expect_near_rel("normal_id_glm_lpdf (OpenCL)", sigma_var1.adj(),
-                  sigma_var2.adj());
-  expect_near_rel("normal_id_glm_lpdf (OpenCL)", beta_var1.adj().eval(),
-                  beta_var2.adj().eval());
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(normal_id_glm_lpdf_functor,
+                                                         y_scal, x, alpha, beta, sigma);
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(
+      normal_id_glm_lpdf_functor_propto, y_scal, x, alpha, beta, sigma);
 }
 
 TEST(ProbDistributionsNormalIdGLM, opencl_matches_cpu_zero_instances) {

--- a/test/unit/math/opencl/rev/normal_id_glm_lpdf_test.cpp
+++ b/test/unit/math/opencl/rev/normal_id_glm_lpdf_test.cpp
@@ -146,8 +146,8 @@ TEST(ProbDistributionsNormalIdGLM, opencl_broadcast_y) {
   double alpha = 0.3;
   double sigma = 11;
 
-  stan::math::test::test_opencl_broadcasting_prim_rev<0>(normal_id_glm_lpdf_functor,
-                                                         y_scal, x, alpha, beta, sigma);
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(
+      normal_id_glm_lpdf_functor, y_scal, x, alpha, beta, sigma);
   stan::math::test::test_opencl_broadcasting_prim_rev<0>(
       normal_id_glm_lpdf_functor_propto, y_scal, x, alpha, beta, sigma);
 }

--- a/test/unit/math/opencl/rev/ordered_logistic_glm_lpmf_test.cpp
+++ b/test/unit/math/opencl/rev/ordered_logistic_glm_lpmf_test.cpp
@@ -124,49 +124,20 @@ TEST(ProbDistributionsOrderedLogisitcGLM, opencl_matches_cpu_small_simple) {
 TEST(ProbDistributionsOrderedLogisitcGLM, opencl_matches_cpu_broadcast_y) {
   int N = 3;
   int M = 2;
-  int C = 5;
+  int C = 3;
 
-  int y = 1;
+  int y_scal = 1;
   Matrix<double, Dynamic, Dynamic> x(N, M);
   x << -12, 46, -42, 24, 25, 27;
   Matrix<double, Dynamic, 1> beta(M, 1);
   beta << 0.3, 2;
   Matrix<double, Dynamic, 1> cuts(C - 1, 1);
-  cuts << -0.4, 0.1, 0.3, 4.5;
+  cuts << -0.4, 0.1;
 
-  matrix_cl<double> x_cl(x);
-  matrix_cl<double> beta_cl(beta);
-  matrix_cl<double> cuts_cl(cuts);
-
-  EXPECT_NEAR_REL(
-      stan::math::ordered_logistic_glm_lpmf(y, x_cl, beta_cl, cuts_cl),
-      stan::math::ordered_logistic_glm_lpmf(y, x, beta, cuts));
-  EXPECT_NEAR_REL(
-      stan::math::ordered_logistic_glm_lpmf<true>(y, x_cl, beta_cl, cuts_cl),
-      stan::math::ordered_logistic_glm_lpmf<true>(y, x, beta, cuts));
-
-  Matrix<var, Dynamic, Dynamic> x_var1 = x;
-  Matrix<var, Dynamic, Dynamic> x_var2 = x;
-  Matrix<var, Dynamic, 1> beta_var1 = beta;
-  Matrix<var, Dynamic, 1> beta_var2 = beta;
-  Matrix<var, Dynamic, 1> cuts_var1 = cuts;
-  Matrix<var, Dynamic, 1> cuts_var2 = cuts;
-  auto x_var1_cl = stan::math::to_matrix_cl(x_var1);
-  auto beta_var1_cl = stan::math::to_matrix_cl(beta_var1);
-  auto cuts_var1_cl = stan::math::to_matrix_cl(cuts_var1);
-
-  var res1 = stan::math::ordered_logistic_glm_lpmf(y, x_var1_cl, beta_var1_cl,
-                                                   cuts_var1_cl);
-  var res2
-      = stan::math::ordered_logistic_glm_lpmf(y, x_var2, beta_var2, cuts_var2);
-
-  (res1 + res2).grad();
-
-  EXPECT_NEAR_REL(res1.val(), res2.val());
-
-  EXPECT_NEAR_REL(x_var1.adj().eval(), x_var2.adj().eval());
-  EXPECT_NEAR_REL(beta_var1.adj().eval(), beta_var2.adj().eval());
-  EXPECT_NEAR_REL(cuts_var1.adj().eval(), cuts_var2.adj().eval());
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(ordered_logistic_glm_lpmf_functor,
+                                                         y_scal, x, beta, cuts);
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(
+      ordered_logistic_glm_lpmf_functor_propto, y_scal, x, beta, cuts);
 }
 
 TEST(ProbDistributionsOrderedLogisitcGLM, opencl_matches_cpu_zero_instances) {

--- a/test/unit/math/opencl/rev/ordered_logistic_glm_lpmf_test.cpp
+++ b/test/unit/math/opencl/rev/ordered_logistic_glm_lpmf_test.cpp
@@ -134,8 +134,8 @@ TEST(ProbDistributionsOrderedLogisitcGLM, opencl_matches_cpu_broadcast_y) {
   Matrix<double, Dynamic, 1> cuts(C - 1, 1);
   cuts << -0.4, 0.1;
 
-  stan::math::test::test_opencl_broadcasting_prim_rev<0>(ordered_logistic_glm_lpmf_functor,
-                                                         y_scal, x, beta, cuts);
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(
+      ordered_logistic_glm_lpmf_functor, y_scal, x, beta, cuts);
   stan::math::test::test_opencl_broadcasting_prim_rev<0>(
       ordered_logistic_glm_lpmf_functor_propto, y_scal, x, beta, cuts);
 }

--- a/test/unit/math/opencl/rev/poisson_log_glm_lpmf_test.cpp
+++ b/test/unit/math/opencl/rev/poisson_log_glm_lpmf_test.cpp
@@ -121,53 +121,18 @@ TEST(ProbDistributionsPoissonLogGLM, opencl_broadcast_y) {
   int N = 3;
   int M = 2;
 
-  int y = 4;
-  vector<int> y_vec{y, y, y};
+  int y_scal = 4;
   Matrix<double, Dynamic, Dynamic> x(N, M);
   x << -12, 46, -42, 24, 25, 27;
   Matrix<double, Dynamic, 1> beta(M, 1);
   beta << 0.3, 2;
   double alpha = 0.3;
 
-  matrix_cl<double> x_cl(x);
-  matrix_cl<int> y_vec_cl(y_vec);
-  matrix_cl<double> beta_cl(beta);
 
-  expect_near_rel(
-      "poisson_log_glm_lpmf (OpenCL)",
-      stan::math::poisson_log_glm_lpmf(y, x_cl, alpha, beta_cl),
-      stan::math::poisson_log_glm_lpmf(y_vec_cl, x_cl, alpha, beta_cl));
-  expect_near_rel(
-      "poisson_log_glm_lpmf (OpenCL)",
-      stan::math::poisson_log_glm_lpmf<true>(y, x_cl, alpha, beta_cl),
-      stan::math::poisson_log_glm_lpmf<true>(y_vec_cl, x_cl, alpha, beta_cl));
-
-  Matrix<var, Dynamic, Dynamic> x_var1 = x;
-  Matrix<var, Dynamic, Dynamic> x_var2 = x;
-  Matrix<var, Dynamic, 1> beta_var1 = beta;
-  Matrix<var, Dynamic, 1> beta_var2 = beta;
-  auto x_var1_cl = to_matrix_cl(x_var1);
-  auto x_var2_cl = to_matrix_cl(x_var2);
-  auto beta_var1_cl = stan::math::to_matrix_cl(beta_var1);
-  auto beta_var2_cl = stan::math::to_matrix_cl(beta_var2);
-  var alpha_var1 = alpha;
-  var alpha_var2 = alpha;
-
-  var res1 = stan::math::poisson_log_glm_lpmf(y, x_var1_cl, alpha_var1,
-                                              beta_var1_cl);
-  var res2 = stan::math::poisson_log_glm_lpmf(y_vec_cl, x_var2_cl, alpha_var2,
-                                              beta_var2_cl);
-
-  (res1 + res2).grad();
-
-  expect_near_rel("poisson_log_glm_lpmf (OpenCL)", res1.val(), res2.val());
-
-  expect_near_rel("bernoulli_logit_glm_lpmf (OpenCL)", x_var1.adj().eval(),
-                  x_var2.adj().eval());
-  expect_near_rel("poisson_log_glm_lpmf (OpenCL)", alpha_var1.adj(),
-                  alpha_var2.adj());
-  expect_near_rel("poisson_log_glm_lpmf (OpenCL)", beta_var1.adj().eval(),
-                  beta_var2.adj().eval());
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(poisson_log_glm_lpmf_functor,
+                                                         y_scal, x, alpha, beta);
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(
+      poisson_log_glm_lpmf_functor_propto, y_scal, x, alpha, beta);
 }
 
 TEST(ProbDistributionsPoissonLogGLM, opencl_matches_cpu_zero_instances) {

--- a/test/unit/math/opencl/rev/poisson_log_glm_lpmf_test.cpp
+++ b/test/unit/math/opencl/rev/poisson_log_glm_lpmf_test.cpp
@@ -128,9 +128,8 @@ TEST(ProbDistributionsPoissonLogGLM, opencl_broadcast_y) {
   beta << 0.3, 2;
   double alpha = 0.3;
 
-
-  stan::math::test::test_opencl_broadcasting_prim_rev<0>(poisson_log_glm_lpmf_functor,
-                                                         y_scal, x, alpha, beta);
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(
+      poisson_log_glm_lpmf_functor, y_scal, x, alpha, beta);
   stan::math::test::test_opencl_broadcasting_prim_rev<0>(
       poisson_log_glm_lpmf_functor_propto, y_scal, x, alpha, beta);
 }

--- a/test/unit/math/opencl/util.hpp
+++ b/test/unit/math/opencl/util.hpp
@@ -258,9 +258,8 @@ void compare_cpu_opencl_prim_rev(const Functor& functor, const Args&... args) {
  * converting scalars to `double` in containers, `var_value<matrix_cl<double>>`
  * is used instead.
  *
- * Warning: Row vector arguments are not fully supported (if there is not at
- * least one std or col vector or matrix, the size to which scalar shoould be
- * broadcast to will not be correctly determined)!
+ * Warning: The scalar is broadcast to size equal to number of rows (or size in
+ * case of `std::vector`) of the argument with the most rows
  *
  * @tparam Functor type of the functor
  * @tparam Args types of the arguments; `I`-th argument must be a scalar

--- a/test/unit/math/opencl/util.hpp
+++ b/test/unit/math/opencl/util.hpp
@@ -121,25 +121,22 @@ template <typename Functor, typename Arg0, typename... Args>
 void prim_rev_argument_combinations(const Functor& f, const Arg0& arg0,
                                     const Args&... args) {
   prim_rev_argument_combinations(
-      [&f, &arg0](auto args_for_cpu, auto args_for_opencl) {
+      [&f, &arg0](auto args1, auto args2) {
         constexpr size_t Size
-            = std::tuple_size<std::decay_t<decltype(args_for_cpu)>>::value;
+            = std::tuple_size<std::decay_t<decltype(args1)>>::value;
         return index_apply<Size>([&](auto... Is) {
-          return f(
-              std::forward_as_tuple(arg0, std::get<Is>(args_for_cpu)...),
-              std::forward_as_tuple(arg0, std::get<Is>(args_for_opencl)...));
+          return f(std::forward_as_tuple(arg0, std::get<Is>(args1)...),
+                   std::forward_as_tuple(arg0, std::get<Is>(args2)...));
         });
       },
       args...);
   prim_rev_argument_combinations(
-      [&](const auto& args_for_cpu, const auto& args_for_opencl) {
+      [&](const auto& args1, const auto& args2) {
         constexpr size_t Size
-            = std::tuple_size<std::decay_t<decltype(args_for_cpu)>>::value;
+            = std::tuple_size<std::decay_t<decltype(args1)>>::value;
         return index_apply<Size>([&](auto... Is) {
-          return f(std::make_tuple(var_argument(arg0),
-                                   std::get<Is>(args_for_cpu)...),
-                   std::make_tuple(var_argument(arg0),
-                                   std::get<Is>(args_for_opencl)...));
+          return f(std::make_tuple(var_argument(arg0), std::get<Is>(args1)...),
+                   std::make_tuple(var_argument(arg0), std::get<Is>(args2)...));
         });
       },
       args...);
@@ -173,11 +170,70 @@ void compare_cpu_opencl_prim_rev_impl(const Functor& functor,
       },
       args...);
 }
+
+template <bool Condition, typename T, std::enable_if_t<Condition>* = nullptr>
+auto to_vector_if(const T& x, std::size_t N) {
+  return Eigen::Matrix<T, Eigen::Dynamic, 1>::Constant(N, x);
+}
+template <bool Condition, typename T, std::enable_if_t<!Condition>* = nullptr>
+T to_vector_if(const T& x, std::size_t N) {
+  return x;
+}
+
+using stan::math::rows;
+template <typename T, require_not_container_t<T>* = nullptr>
+int rows(const T&) {
+  return 1;
+}
+template <typename T, require_std_vector_t<T>* = nullptr>
+int rows(const T& x) {
+  return x.size();
+}
+
+template <std::size_t I, typename Functor, std::size_t... Is, typename... Args>
+void test_opencl_broadcasting_prim_rev_impl(const Functor& functor,
+                                            std::index_sequence<Is...>,
+                                            const Args&... args) {
+  prim_rev_argument_combinations(
+      [&functor, N = std::max({rows(args)...})](auto args_broadcast,
+                                                auto args_vector) {
+        auto res_scalar
+            = functor(opencl_argument(std::get<Is>(args_broadcast))...);
+        auto res_vec = functor(opencl_argument(
+            to_vector_if<Is == I>(std::get<Is>(args_vector), N))...);
+        std::string signature = type_name<decltype(args_broadcast)>().data();
+        expect_eq(res_vec, res_scalar,
+                  ("return values of broadcast and vector arguments do not "
+                   "match for signature "
+                   + signature + "!")
+                      .c_str());
+        var(recursive_sum(res_scalar) + recursive_sum(res_vec)).grad();
+
+        static_cast<void>(std::initializer_list<int>{
+            (expect_adj_near(
+                 std::get<Is>(args_vector), std::get<Is>(args_broadcast),
+                 ("adjoints of broadcast and vector arguments do not match for "
+                  "argument "
+                  + std::to_string(Is) + " for signature " + signature + "!")
+                     .c_str()),
+             0)...});
+
+        set_zero_all_adjoints();
+      },
+      args...);
+}
+
 }  // namespace internal
 
 /**
  * Tests that given functor calculates same values and adjoints when given
  * arguments on CPU and OpenCL device.
+ *
+ * The functor must accept all possible combinations of converted `args`.
+ * All std/row/col vectors and matrices are converted to `matrix_cl`. `double`
+ * scalars can be converted to `var`s or left as `double`s. When converting
+ * scalars to `double` in containers, `var_value<matrix_cl<double>>` is used
+ * instead.
  *
  * @tparam Functor type of the functor
  * @tparam Args types of the arguments
@@ -188,6 +244,37 @@ void compare_cpu_opencl_prim_rev_impl(const Functor& functor,
 template <typename Functor, typename... Args>
 void compare_cpu_opencl_prim_rev(const Functor& functor, const Args&... args) {
   internal::compare_cpu_opencl_prim_rev_impl(
+      functor, std::make_index_sequence<sizeof...(args)>{}, args...);
+  recover_memory();
+}
+
+/**
+ * Tests that given functor can broadcast the `I`-th argument by comparing a
+ * call with scalar and a call with column vector for that argument.
+ *
+ * The functor must accept all possible combinations of converted `args`.
+ * All std/col vectors and matrices are converted to `matrix_cl`.
+ * `double` scalars can be converted to `var`s or left as `double`s. When
+ * converting scalars to `double` in containers, `var_value<matrix_cl<double>>`
+ * is used instead.
+ *
+ * Warning: Row vector arguments are not fully supported (if there is not at
+ * least one std or col vector or matrix, the size to which scalar shoould be
+ * broadcast to will not be correctly determined)!
+ *
+ * @tparam Functor type of the functor
+ * @tparam Args types of the arguments; `I`-th argument must be a scalar
+ * @param fucntor functor to test
+ * @param args arguments to test the functor with. These should be just values
+ * in CPU memory (no vars, no arguments on the OpenCL device).
+ */
+template <std::size_t I, typename Functor, typename... Args,
+          std::enable_if_t<I<sizeof...(Args)>* = nullptr,
+                           require_stan_scalar_t<std::tuple_element_t<
+                               I, std::tuple<Args...>>>* = nullptr> void
+              test_opencl_broadcasting_prim_rev(const Functor& functor,
+                                                const Args&... args) {
+  internal::test_opencl_broadcasting_prim_rev_impl<I>(
       functor, std::make_index_sequence<sizeof...(args)>{}, args...);
   recover_memory();
 }


### PR DESCRIPTION
## Summary

Simplifies writing of OpenCL broadcasting tests by adding a helper function `test_opencl_broadcasting_prim_rev_impl` that does most of the work. All existing tests that can use this have been rewritten.

## Tests
This is a refactor of tests.

## Side Effects
None.

## Release notes
Simplified writing of OpenCL broadcasting tests.

## Checklist

- [ ] Math issue #(issue number)

- [ ] Copyright holder: Tadej Ciglarič

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [ ] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [ ] the code is written in idiomatic C++ and changes are documented in the doxygen

- [ ] the new changes are tested
