### PR TITLE
operator- for var<matrix>

### DIFF
--- a/stan/math/prim/fun/size.hpp
+++ b/stan/math/prim/fun/size.hpp
@@ -34,7 +34,6 @@ inline size_t size(const T& m) {
   return m.size();
 }
 
-
 }  // namespace math
 }  // namespace stan
 #endif

--- a/stan/math/prim/fun/size.hpp
+++ b/stan/math/prim/fun/size.hpp
@@ -29,6 +29,12 @@ inline size_t size(const T& m) {
   return m.size();
 }
 
+template <typename T, require_var_matrix_t<T>* = nullptr>
+inline size_t size(const T& m) {
+  return m.size();
+}
+
+
 }  // namespace math
 }  // namespace stan
 #endif

--- a/stan/math/prim/fun/subtract.hpp
+++ b/stan/math/prim/fun/subtract.hpp
@@ -19,7 +19,8 @@ namespace math {
  * @return difference between first scalar and second scalar
  */
 template <typename ScalarA, typename ScalarB,
-          typename = require_all_stan_scalar_t<ScalarA, ScalarB>>
+          require_all_stan_scalar_t<ScalarA, ScalarB>* = nullptr,
+          require_all_not_var_t<ScalarA, ScalarB>* = nullptr>
 inline return_type_t<ScalarA, ScalarB> subtract(const ScalarA& a,
                                                 const ScalarB& b) {
   return a - b;
@@ -37,7 +38,8 @@ inline return_type_t<ScalarA, ScalarB> subtract(const ScalarA& a,
  * @return Difference between first matrix and second matrix.
  */
 template <typename Mat1, typename Mat2,
-          typename = require_all_eigen_t<Mat1, Mat2>>
+          require_all_eigen_t<Mat1, Mat2>* = nullptr,
+          require_all_not_st_var<Mat1, Mat2>* = nullptr>
 inline auto subtract(const Mat1& m1, const Mat2& m2) {
   check_matching_dims("subtract", "m1", m1, "m2", m2);
   return (m1 - m2).eval();
@@ -54,7 +56,8 @@ inline auto subtract(const Mat1& m1, const Mat2& m2) {
  * @return The scalar minus the matrix.
  */
 template <typename Scal, typename Mat, typename = require_stan_scalar_t<Scal>,
-          typename = require_eigen_t<Mat>>
+          require_eigen_t<Mat>* = nullptr,
+          require_all_not_st_var<Mat, Scal>* = nullptr>
 inline auto subtract(const Scal c, const Mat& m) {
   return (c - m.array()).matrix().eval();
 }
@@ -70,7 +73,8 @@ inline auto subtract(const Scal c, const Mat& m) {
  * @return The matrix minus the scalar.
  */
 template <typename Mat, typename Scal, typename = require_eigen_t<Mat>,
-          typename = require_stan_scalar_t<Scal>>
+          require_stan_scalar_t<Scal>* = nullptr,
+          require_all_not_st_var<Scal, Mat>* = nullptr>
 inline auto subtract(const Mat& m, const Scal c) {
   return (m.array() - c).matrix().eval();
 }

--- a/stan/math/rev/core/operator_minus_equal.hpp
+++ b/stan/math/rev/core/operator_minus_equal.hpp
@@ -4,24 +4,24 @@
 #include <stan/math/rev/core/var.hpp>
 #include <stan/math/rev/core/operator_subtraction.hpp>
 #include <stan/math/prim/meta.hpp>
-
+#include <stan/math/prim/fun/size.hpp>
 namespace stan {
 namespace math {
 
 template <typename T>
 inline var_value<T>& var_value<T, require_floating_point_t<T>>::operator-=(
     const var_value<T>& b) {
-  vi_ = new internal::subtract_vv_vari(vi_, b.vi_);
+  vi_ = (*this - b).vi_;
   return *this;
 }
 
 template <typename T>
 inline var_value<T>& var_value<T, require_floating_point_t<T>>::operator-=(
     T b) {
-  if (b == 0.0) {
+  if (unlikely(b == 0.0)) {
     return *this;
   }
-  vi_ = new internal::subtract_vd_vari(vi_, b);
+  vi_ = (*this - b).vi_;
   return *this;
 }
 

--- a/stan/math/rev/core/operator_subtraction.hpp
+++ b/stan/math/rev/core/operator_subtraction.hpp
@@ -94,7 +94,16 @@ class subtract_dv_vari final : public op_dv_vari {
  * the first.
  */
 inline var operator-(const var& a, const var& b) {
-  return {new internal::subtract_vv_vari(a.vi_, b.vi_)};
+  return make_callback_vari(a.vi_->val_ - b.vi_->val_,
+    [avi = a.vi_, bvi = b.vi_](const auto& vi) mutable {
+      if (unlikely(is_any_nan(avi->val_, bvi->val_))) {
+        avi->adj_ = NOT_A_NUMBER;
+        bvi->adj_ = NOT_A_NUMBER;
+      } else {
+        avi->adj_ += vi.adj_;
+        bvi->adj_ -= vi.adj_;
+      }
+    });
 }
 
 /**
@@ -112,10 +121,17 @@ inline var operator-(const var& a, const var& b) {
  */
 template <typename Arith, require_arithmetic_t<Arith>* = nullptr>
 inline var operator-(const var& a, Arith b) {
-  if (b == 0.0) {
+  if (unlikely(b == 0.0)) {
     return a;
   }
-  return {new internal::subtract_vd_vari(a.vi_, b)};
+  return make_callback_vari(a.vi_->val_ - b,
+    [avi = a.vi_, b](const auto& vi) mutable {
+        if (unlikely(is_any_nan(avi->val_, b))) {
+          avi->adj_ = NOT_A_NUMBER;
+        } else {
+          avi->adj_ += vi.adj_;
+        }
+    });
 }
 
 /**
@@ -133,8 +149,214 @@ inline var operator-(const var& a, Arith b) {
  */
 template <typename Arith, require_arithmetic_t<Arith>* = nullptr>
 inline var operator-(Arith a, const var& b) {
-  return {new internal::subtract_dv_vari(a, b.vi_)};
+  return make_callback_vari(a - b.vi_->val_,
+    [bvi = b.vi_, a](const auto& vi) mutable {
+      if (unlikely(is_any_nan(a, bvi->val_))) {
+        bvi->adj_ = NOT_A_NUMBER;
+      } else {
+        bvi->adj_ -= vi.adj_;
+      }
+    });
 }
+
+/**
+ * Subtraction operator for matrix variables (C++).
+ *
+ * @tparam VarMat1 A matrix of vars or a var with an underlying matrix type.
+ * @tparam VarMat2 A matrix of vars or a var with an underlying matrix type.
+ * @param a First variable operand.
+ * @param b Second variable operand.
+ * @return Variable result of subtracting two variables.
+ */
+template <typename VarMat1, typename VarMat2, require_all_rev_matrix_t<VarMat1, VarMat2>* = nullptr>
+inline auto subtract(const VarMat1& a, const VarMat2& b) {
+  check_matching_dims("subtract", "a", a, "b", b);
+  using op_ret_type = decltype(a.val() - b.val());
+  using ret_type = promote_var_matrix_t<op_ret_type, VarMat1, VarMat2>;
+  arena_t<ret_type> ret((a.val() - b.val()));
+  arena_t<VarMat1> arena_a = a;
+  arena_t<VarMat2> arena_b = b;
+  reverse_pass_callback([ret, arena_a, arena_b]() mutable {
+    for (Eigen::Index i = 0; i < ret.size(); ++i) {
+      const auto ret_adj = ret.adj().coeffRef(i);
+      arena_a.adj().coeffRef(i) += ret_adj;
+      arena_b.adj().coeffRef(i) -= ret_adj;
+    }
+    });
+  return ret_type(ret);
+}
+
+/**
+ * Subtraction operator for a matrix variable and arithmetic (C++).
+ *
+ * @tparam VarMat A matrix of vars or a var with an underlying matrix type.
+ * @tparam Arith A type with an arithmetic Scalar type.
+ * @param a First variable operand.
+ * @param b Second variable operand.
+ * @return Variable result of subtracting two variables.
+ */
+template <typename Arith, typename VarMat, require_st_arithmetic<Arith>* = nullptr,
+ require_rev_matrix_t<VarMat>* = nullptr>
+inline auto subtract(const VarMat& a, const Arith& b) {
+  if (is_eigen<Arith>::value) {
+    check_matching_dims("subtract", "a", a, "b", b);
+  }
+  using op_ret_type = plain_type_t<decltype((a.val().array() - as_array_or_scalar(b)).matrix())>;
+  using ret_type = promote_var_matrix_t<op_ret_type, VarMat>;
+  arena_t<VarMat> arena_a = a;
+  arena_t<ret_type> ret(a.val().array() - as_array_or_scalar(b));
+  reverse_pass_callback([ret, arena_a]() mutable {
+    arena_a.adj() += ret.adj();
+  });
+  return ret_type(ret);
+}
+
+/**
+ * Subtraction operator for an arithmetic type and matrix variable (C++).
+ *
+ * @tparam VarMat A matrix of vars or a var with an underlying matrix type.
+ * @tparam Arith A type with an arithmetic Scalar type.
+ * @param a First variable operand.
+ * @param b Second variable operand.
+ * @return Variable result of subtracting two variables.
+ */
+ template <typename Arith, typename VarMat, require_st_arithmetic<Arith>* = nullptr,
+  require_rev_matrix_t<VarMat>* = nullptr>
+inline auto subtract(const Arith& a, const VarMat& b) {
+  if (is_eigen<Arith>::value) {
+    check_matching_dims("subtract", "a", a, "b", b);
+  }
+  using op_ret_type = plain_type_t<decltype((as_array_or_scalar(a) - b.val().array()).matrix())>;
+  using ret_type = promote_var_matrix_t<op_ret_type, VarMat>;
+  arena_t<VarMat> arena_b = b;
+  arena_t<ret_type> ret(as_array_or_scalar(a) - b.val().array());
+  reverse_pass_callback([ret, arena_b]() mutable {
+    arena_b.adj() -= ret.adj_op();
+  });
+  return ret_type(ret);
+}
+
+/**
+ * Subtraction operator for an arithmetic matrix and variable (C++).
+ *
+ * @tparam Var A `var_value` with an underlying arithmetic type.
+ * @tparam EigMat An Eigen Matrix type with an arithmetic Scalar type.
+ * @param a First variable operand.
+ * @param b Second variable operand.
+ * @return Variable result of subtracting two variables.
+ */
+template <typename Var, typename EigMat,
+       require_var_vt<std::is_arithmetic, Var>* = nullptr,
+       require_eigen_vt<std::is_arithmetic, EigMat>* = nullptr>
+inline auto subtract(const Var& a, const EigMat& b) {
+  using ret_type = promote_scalar_t<var, EigMat>;
+  arena_t<ret_type>  ret(a.val() - b.array());
+  reverse_pass_callback([ret, a]() mutable {
+    a.adj() += ret.adj().sum();
+  });
+  return ret_type(ret);
+}
+
+
+/**
+ * Subtraction operator for a variable and arithmetic matrix (C++).
+ *
+ * @tparam EigMat An Eigen Matrix type with an arithmetic Scalar type.
+ * @tparam Var A `var_value` with an underlying arithmetic type.
+ * @param a First variable operand.
+ * @param b Second variable operand.
+ * @return Variable result of subtracting two variables.
+ */
+template <typename EigMat, typename Var,
+     require_eigen_vt<std::is_arithmetic, EigMat>* = nullptr,
+     require_var_vt<std::is_arithmetic, Var>* = nullptr>
+inline auto subtract(const EigMat& a, const Var& b) {
+  using ret_type = promote_scalar_t<var, EigMat>;
+  arena_t<ret_type>  ret(a.array() - b.val());
+  reverse_pass_callback([ret, b]() mutable {
+    b.adj() -= ret.adj().sum();
+  });
+  return ret_type(ret);
+}
+
+/**
+ * Subtraction operator for a variable and variable matrix (C++).
+ *
+ * @tparam VarMat An Eigen Matrix type with a variable Scalar type or a `var_value` with an underlying matrix type.
+ * @tparam Var A `var_value` with an underlying arithmetic type.
+ * @param a First variable operand.
+ * @param b Second variable operand.
+ * @return Variable result of subtracting two variables.
+ */
+template <typename Var, typename VarMat,
+   require_var_vt<std::is_arithmetic, Var>* = nullptr,
+   require_rev_matrix_t<VarMat>* = nullptr>
+inline auto subtract(const Var& a, const VarMat& b) {
+  arena_t<VarMat> arena_b(b);
+  arena_t<VarMat> ret(a.val() - b.val().array());
+  reverse_pass_callback([ret, a, arena_b]() mutable {
+    for (Eigen::Index i = 0; i < ret.size(); ++i) {
+      auto ret_adj = ret.adj().coeff(i);
+      a.adj() += ret_adj;
+      arena_b.adj().coeffRef(i) -= ret_adj;
+    }
+  });
+  return plain_type_t<VarMat>(ret);
+}
+
+
+/**
+ * Subtraction operator for a variable matrix and variable (C++).
+ *
+ * @tparam VarMat An Eigen Matrix type with a variable Scalar type or a `var_value` with an underlying matrix type.
+ * @tparam Var A `var_value` with an underlying arithmetic type.
+ * @param a First variable operand.
+ * @param b Second variable operand.
+ * @return Variable result of subtracting two variables.
+ */
+ template <typename Var, typename VarMat,
+  require_rev_matrix_t<VarMat>* = nullptr,
+  require_var_vt<std::is_arithmetic, Var>* = nullptr>
+ inline auto subtract(const VarMat& a, const Var& b) {
+   arena_t<VarMat> arena_a(a);
+   arena_t<VarMat> ret(a.val().array() - b.val());
+   reverse_pass_callback([ret, b, arena_a]() mutable {
+     for (Eigen::Index i = 0; i < ret.size(); ++i) {
+       const auto ret_adj = ret.adj().coeff(i);
+       arena_a.adj().coeffRef(i) += ret_adj;
+       b.adj() -= ret_adj;
+     }
+   });
+   return plain_type_t<VarMat>(ret);
+ }
+
+ template <typename T1, typename T2,
+           require_any_var_vt<std::is_arithmetic, T1, T2>* = nullptr,
+           require_any_arithmetic_t<T1, T2>* = nullptr>
+ inline auto subtract(const T1& a, const T2& b) {
+   return a - b;
+ }
+
+ template <typename T1, typename T2,
+           require_all_var_vt<std::is_arithmetic, T1, T2>* = nullptr>
+ inline auto subtract(const T1& a, const T2& b) {
+   return a - b;
+ }
+
+ /**
+  * Addition operator for matrix variables (C++).
+  *
+  * @tparam VarMat1 A matrix of vars or a var with an underlying matrix type.
+  * @tparam VarMat2 A matrix of vars or a var with an underlying matrix type.
+  * @param a First variable operand.
+  * @param b Second variable operand.
+  * @return Variable result of adding two variables.
+  */
+ template <typename VarMat1, typename VarMat2,
+           require_any_var_matrix_t<VarMat1, VarMat2>* = nullptr>
+ inline auto operator-(const VarMat1& a, const VarMat2& b) {
+   return subtract(a, b);
+ }
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/rev/core/operator_subtraction.hpp
+++ b/stan/math/rev/core/operator_subtraction.hpp
@@ -12,7 +12,7 @@ namespace stan {
 namespace math {
 
 /**
- * Subtraction operator for variables (C++).
+ * Subtraction operator for variables.
  *
  * The partial derivatives are defined by
  *
@@ -54,7 +54,7 @@ namespace math {
 inline var operator-(const var& a, const var& b) {
   return make_callback_vari(a.vi_->val_ - b.vi_->val_,
                             [avi = a.vi_, bvi = b.vi_](const auto& vi) mutable {
-                              if (unlikely(is_any_nan(avi->val_, bvi->val_))) {
+                              if (unlikely(is_nan(vi.val_))) {
                                 avi->adj_ = NOT_A_NUMBER;
                                 bvi->adj_ = NOT_A_NUMBER;
                               } else {
@@ -65,7 +65,7 @@ inline var operator-(const var& a, const var& b) {
 }
 
 /**
- * Subtraction operator for variable and scalar (C++).
+ * Subtraction operator for variable and scalar.
  *
  * The derivative for the variable is
  *
@@ -84,7 +84,7 @@ inline var operator-(const var& a, Arith b) {
   }
   return make_callback_vari(a.vi_->val_ - b,
                             [avi = a.vi_, b](const auto& vi) mutable {
-                              if (unlikely(is_any_nan(avi->val_, b))) {
+                              if (unlikely(is_nan(vi.val_))) {
                                 avi->adj_ = NOT_A_NUMBER;
                               } else {
                                 avi->adj_ += vi.adj_;
@@ -93,7 +93,7 @@ inline var operator-(const var& a, Arith b) {
 }
 
 /**
- * Subtraction operator for scalar and variable (C++).
+ * Subtraction operator for scalar and variable.
  *
  * The derivative for the variable is
  *
@@ -109,7 +109,7 @@ template <typename Arith, require_arithmetic_t<Arith>* = nullptr>
 inline var operator-(Arith a, const var& b) {
   return make_callback_vari(a - b.vi_->val_,
                             [bvi = b.vi_, a](const auto& vi) mutable {
-                              if (unlikely(is_any_nan(a, bvi->val_))) {
+                              if (unlikely(is_nan(vi.val_))) {
                                 bvi->adj_ = NOT_A_NUMBER;
                               } else {
                                 bvi->adj_ -= vi.adj_;
@@ -118,7 +118,7 @@ inline var operator-(Arith a, const var& b) {
 }
 
 /**
- * Subtraction operator for matrix variables (C++).
+ * Subtraction operator for matrix variables.
  *
  * @tparam VarMat1 A matrix of vars or a var with an underlying matrix type.
  * @tparam VarMat2 A matrix of vars or a var with an underlying matrix type.
@@ -146,7 +146,7 @@ inline auto subtract(const VarMat1& a, const VarMat2& b) {
 }
 
 /**
- * Subtraction operator for a matrix variable and arithmetic (C++).
+ * Subtraction operator for a matrix variable and arithmetic.
  *
  * @tparam VarMat A matrix of vars or a var with an underlying matrix type.
  * @tparam Arith A type with an arithmetic Scalar type.
@@ -172,7 +172,7 @@ inline auto subtract(const VarMat& a, const Arith& b) {
 }
 
 /**
- * Subtraction operator for an arithmetic type and matrix variable (C++).
+ * Subtraction operator for an arithmetic type and matrix variable.
  *
  * @tparam VarMat A matrix of vars or a var with an underlying matrix type.
  * @tparam Arith A type with an arithmetic Scalar type.
@@ -198,7 +198,7 @@ inline auto subtract(const Arith& a, const VarMat& b) {
 }
 
 /**
- * Subtraction operator for an arithmetic matrix and variable (C++).
+ * Subtraction operator for an arithmetic matrix and variable.
  *
  * @tparam Var A `var_value` with an underlying arithmetic type.
  * @tparam EigMat An Eigen Matrix type with an arithmetic Scalar type.
@@ -217,7 +217,7 @@ inline auto subtract(const Var& a, const EigMat& b) {
 }
 
 /**
- * Subtraction operator for a variable and arithmetic matrix (C++).
+ * Subtraction operator for a variable and arithmetic matrix.
  *
  * @tparam EigMat An Eigen Matrix type with an arithmetic Scalar type.
  * @tparam Var A `var_value` with an underlying arithmetic type.
@@ -236,7 +236,7 @@ inline auto subtract(const EigMat& a, const Var& b) {
 }
 
 /**
- * Subtraction operator for a variable and variable matrix (C++).
+ * Subtraction operator for a variable and variable matrix.
  *
  * @tparam VarMat An Eigen Matrix type with a variable Scalar type or a
  * `var_value` with an underlying matrix type.
@@ -262,7 +262,7 @@ inline auto subtract(const Var& a, const VarMat& b) {
 }
 
 /**
- * Subtraction operator for a variable matrix and variable (C++).
+ * Subtraction operator for a variable matrix and variable.
  *
  * @tparam VarMat An Eigen Matrix type with a variable Scalar type or a
  * `var_value` with an underlying matrix type.
@@ -301,7 +301,7 @@ inline auto subtract(const T1& a, const T2& b) {
 }
 
 /**
- * Addition operator for matrix variables (C++).
+ * Addition operator for matrix variables.
  *
  * @tparam VarMat1 A matrix of vars or a var with an underlying matrix type.
  * @tparam VarMat2 A matrix of vars or a var with an underlying matrix type.

--- a/stan/math/rev/core/operator_subtraction.hpp
+++ b/stan/math/rev/core/operator_subtraction.hpp
@@ -1,57 +1,15 @@
 #ifndef STAN_MATH_REV_CORE_OPERATOR_SUBTRACTION_HPP
 #define STAN_MATH_REV_CORE_OPERATOR_SUBTRACTION_HPP
 
-#include <stan/math/prim/meta.hpp>
+#include <stan/math/rev/meta.hpp>
 #include <stan/math/rev/core/var.hpp>
-#include <stan/math/rev/core/vv_vari.hpp>
-#include <stan/math/rev/core/vd_vari.hpp>
-#include <stan/math/rev/core/dv_vari.hpp>
+#include <stan/math/rev/core/arena_matrix.hpp>
+#include <stan/math/rev/core/callback_vari.hpp>
 #include <stan/math/prim/fun/constants.hpp>
 #include <stan/math/prim/fun/is_any_nan.hpp>
 
 namespace stan {
 namespace math {
-
-namespace internal {
-class subtract_vv_vari final : public op_vv_vari {
- public:
-  subtract_vv_vari(vari* avi, vari* bvi)
-      : op_vv_vari(avi->val_ - bvi->val_, avi, bvi) {}
-  void chain() {
-    if (unlikely(is_any_nan(avi_->val_, bvi_->val_))) {
-      avi_->adj_ = NOT_A_NUMBER;
-      bvi_->adj_ = NOT_A_NUMBER;
-    } else {
-      avi_->adj_ += adj_;
-      bvi_->adj_ -= adj_;
-    }
-  }
-};
-
-class subtract_vd_vari final : public op_vd_vari {
- public:
-  subtract_vd_vari(vari* avi, double b) : op_vd_vari(avi->val_ - b, avi, b) {}
-  void chain() {
-    if (unlikely(is_any_nan(avi_->val_, bd_))) {
-      avi_->adj_ = NOT_A_NUMBER;
-    } else {
-      avi_->adj_ += adj_;
-    }
-  }
-};
-
-class subtract_dv_vari final : public op_dv_vari {
- public:
-  subtract_dv_vari(double a, vari* bvi) : op_dv_vari(a - bvi->val_, a, bvi) {}
-  void chain() {
-    if (unlikely(is_any_nan(ad_, bvi_->val_))) {
-      bvi_->adj_ = NOT_A_NUMBER;
-    } else {
-      bvi_->adj_ -= adj_;
-    }
-  }
-};
-}  // namespace internal
 
 /**
  * Subtraction operator for variables (C++).

--- a/stan/math/rev/core/operator_subtraction.hpp
+++ b/stan/math/rev/core/operator_subtraction.hpp
@@ -132,9 +132,9 @@ inline auto subtract(const VarMat1& a, const VarMat2& b) {
   check_matching_dims("subtract", "a", a, "b", b);
   using op_ret_type = decltype(a.val() - b.val());
   using ret_type = promote_var_matrix_t<op_ret_type, VarMat1, VarMat2>;
-  arena_t<ret_type> ret((a.val() - b.val()));
   arena_t<VarMat1> arena_a = a;
   arena_t<VarMat2> arena_b = b;
+  arena_t<ret_type> ret((arena_a.val() - arena_b.val()));
   reverse_pass_callback([ret, arena_a, arena_b]() mutable {
     for (Eigen::Index i = 0; i < ret.size(); ++i) {
       const auto ret_adj = ret.adj().coeffRef(i);
@@ -165,7 +165,7 @@ inline auto subtract(const VarMat& a, const Arith& b) {
       (a.val().array() - as_array_or_scalar(b)).matrix())>;
   using ret_type = promote_var_matrix_t<op_ret_type, VarMat>;
   arena_t<VarMat> arena_a = a;
-  arena_t<ret_type> ret(a.val().array() - as_array_or_scalar(b));
+  arena_t<ret_type> ret(arena_a.val().array() - as_array_or_scalar(b));
   reverse_pass_callback(
       [ret, arena_a]() mutable { arena_a.adj() += ret.adj(); });
   return ret_type(ret);
@@ -191,7 +191,7 @@ inline auto subtract(const Arith& a, const VarMat& b) {
       (as_array_or_scalar(a) - b.val().array()).matrix())>;
   using ret_type = promote_var_matrix_t<op_ret_type, VarMat>;
   arena_t<VarMat> arena_b = b;
-  arena_t<ret_type> ret(as_array_or_scalar(a) - b.val().array());
+  arena_t<ret_type> ret(as_array_or_scalar(a) - arena_b.val().array());
   reverse_pass_callback(
       [ret, arena_b]() mutable { arena_b.adj() -= ret.adj_op(); });
   return ret_type(ret);
@@ -250,7 +250,7 @@ template <typename Var, typename VarMat,
           require_rev_matrix_t<VarMat>* = nullptr>
 inline auto subtract(const Var& a, const VarMat& b) {
   arena_t<VarMat> arena_b(b);
-  arena_t<VarMat> ret(a.val() - b.val().array());
+  arena_t<VarMat> ret(a.val() - arena_b.val().array());
   reverse_pass_callback([ret, a, arena_b]() mutable {
     for (Eigen::Index i = 0; i < ret.size(); ++i) {
       auto ret_adj = ret.adj().coeff(i);
@@ -276,7 +276,7 @@ template <typename Var, typename VarMat,
           require_var_vt<std::is_arithmetic, Var>* = nullptr>
 inline auto subtract(const VarMat& a, const Var& b) {
   arena_t<VarMat> arena_a(a);
-  arena_t<VarMat> ret(a.val().array() - b.val());
+  arena_t<VarMat> ret(arena_a.val().array() - b.val());
   reverse_pass_callback([ret, b, arena_a]() mutable {
     for (Eigen::Index i = 0; i < ret.size(); ++i) {
       const auto ret_adj = ret.adj().coeff(i);

--- a/stan/math/rev/core/operator_subtraction.hpp
+++ b/stan/math/rev/core/operator_subtraction.hpp
@@ -53,15 +53,15 @@ namespace math {
  */
 inline var operator-(const var& a, const var& b) {
   return make_callback_vari(a.vi_->val_ - b.vi_->val_,
-    [avi = a.vi_, bvi = b.vi_](const auto& vi) mutable {
-      if (unlikely(is_any_nan(avi->val_, bvi->val_))) {
-        avi->adj_ = NOT_A_NUMBER;
-        bvi->adj_ = NOT_A_NUMBER;
-      } else {
-        avi->adj_ += vi.adj_;
-        bvi->adj_ -= vi.adj_;
-      }
-    });
+                            [avi = a.vi_, bvi = b.vi_](const auto& vi) mutable {
+                              if (unlikely(is_any_nan(avi->val_, bvi->val_))) {
+                                avi->adj_ = NOT_A_NUMBER;
+                                bvi->adj_ = NOT_A_NUMBER;
+                              } else {
+                                avi->adj_ += vi.adj_;
+                                bvi->adj_ -= vi.adj_;
+                              }
+                            });
 }
 
 /**
@@ -83,13 +83,13 @@ inline var operator-(const var& a, Arith b) {
     return a;
   }
   return make_callback_vari(a.vi_->val_ - b,
-    [avi = a.vi_, b](const auto& vi) mutable {
-        if (unlikely(is_any_nan(avi->val_, b))) {
-          avi->adj_ = NOT_A_NUMBER;
-        } else {
-          avi->adj_ += vi.adj_;
-        }
-    });
+                            [avi = a.vi_, b](const auto& vi) mutable {
+                              if (unlikely(is_any_nan(avi->val_, b))) {
+                                avi->adj_ = NOT_A_NUMBER;
+                              } else {
+                                avi->adj_ += vi.adj_;
+                              }
+                            });
 }
 
 /**
@@ -108,13 +108,13 @@ inline var operator-(const var& a, Arith b) {
 template <typename Arith, require_arithmetic_t<Arith>* = nullptr>
 inline var operator-(Arith a, const var& b) {
   return make_callback_vari(a - b.vi_->val_,
-    [bvi = b.vi_, a](const auto& vi) mutable {
-      if (unlikely(is_any_nan(a, bvi->val_))) {
-        bvi->adj_ = NOT_A_NUMBER;
-      } else {
-        bvi->adj_ -= vi.adj_;
-      }
-    });
+                            [bvi = b.vi_, a](const auto& vi) mutable {
+                              if (unlikely(is_any_nan(a, bvi->val_))) {
+                                bvi->adj_ = NOT_A_NUMBER;
+                              } else {
+                                bvi->adj_ -= vi.adj_;
+                              }
+                            });
 }
 
 /**
@@ -126,7 +126,8 @@ inline var operator-(Arith a, const var& b) {
  * @param b Second variable operand.
  * @return Variable result of subtracting two variables.
  */
-template <typename VarMat1, typename VarMat2, require_all_rev_matrix_t<VarMat1, VarMat2>* = nullptr>
+template <typename VarMat1, typename VarMat2,
+          require_all_rev_matrix_t<VarMat1, VarMat2>* = nullptr>
 inline auto subtract(const VarMat1& a, const VarMat2& b) {
   check_matching_dims("subtract", "a", a, "b", b);
   using op_ret_type = decltype(a.val() - b.val());
@@ -140,7 +141,7 @@ inline auto subtract(const VarMat1& a, const VarMat2& b) {
       arena_a.adj().coeffRef(i) += ret_adj;
       arena_b.adj().coeffRef(i) -= ret_adj;
     }
-    });
+  });
   return ret_type(ret);
 }
 
@@ -153,19 +154,20 @@ inline auto subtract(const VarMat1& a, const VarMat2& b) {
  * @param b Second variable operand.
  * @return Variable result of subtracting two variables.
  */
-template <typename Arith, typename VarMat, require_st_arithmetic<Arith>* = nullptr,
- require_rev_matrix_t<VarMat>* = nullptr>
+template <typename Arith, typename VarMat,
+          require_st_arithmetic<Arith>* = nullptr,
+          require_rev_matrix_t<VarMat>* = nullptr>
 inline auto subtract(const VarMat& a, const Arith& b) {
   if (is_eigen<Arith>::value) {
     check_matching_dims("subtract", "a", a, "b", b);
   }
-  using op_ret_type = plain_type_t<decltype((a.val().array() - as_array_or_scalar(b)).matrix())>;
+  using op_ret_type = plain_type_t<decltype(
+      (a.val().array() - as_array_or_scalar(b)).matrix())>;
   using ret_type = promote_var_matrix_t<op_ret_type, VarMat>;
   arena_t<VarMat> arena_a = a;
   arena_t<ret_type> ret(a.val().array() - as_array_or_scalar(b));
-  reverse_pass_callback([ret, arena_a]() mutable {
-    arena_a.adj() += ret.adj();
-  });
+  reverse_pass_callback(
+      [ret, arena_a]() mutable { arena_a.adj() += ret.adj(); });
   return ret_type(ret);
 }
 
@@ -178,19 +180,20 @@ inline auto subtract(const VarMat& a, const Arith& b) {
  * @param b Second variable operand.
  * @return Variable result of subtracting two variables.
  */
- template <typename Arith, typename VarMat, require_st_arithmetic<Arith>* = nullptr,
-  require_rev_matrix_t<VarMat>* = nullptr>
+template <typename Arith, typename VarMat,
+          require_st_arithmetic<Arith>* = nullptr,
+          require_rev_matrix_t<VarMat>* = nullptr>
 inline auto subtract(const Arith& a, const VarMat& b) {
   if (is_eigen<Arith>::value) {
     check_matching_dims("subtract", "a", a, "b", b);
   }
-  using op_ret_type = plain_type_t<decltype((as_array_or_scalar(a) - b.val().array()).matrix())>;
+  using op_ret_type = plain_type_t<decltype(
+      (as_array_or_scalar(a) - b.val().array()).matrix())>;
   using ret_type = promote_var_matrix_t<op_ret_type, VarMat>;
   arena_t<VarMat> arena_b = b;
   arena_t<ret_type> ret(as_array_or_scalar(a) - b.val().array());
-  reverse_pass_callback([ret, arena_b]() mutable {
-    arena_b.adj() -= ret.adj_op();
-  });
+  reverse_pass_callback(
+      [ret, arena_b]() mutable { arena_b.adj() -= ret.adj_op(); });
   return ret_type(ret);
 }
 
@@ -204,17 +207,14 @@ inline auto subtract(const Arith& a, const VarMat& b) {
  * @return Variable result of subtracting two variables.
  */
 template <typename Var, typename EigMat,
-       require_var_vt<std::is_arithmetic, Var>* = nullptr,
-       require_eigen_vt<std::is_arithmetic, EigMat>* = nullptr>
+          require_var_vt<std::is_arithmetic, Var>* = nullptr,
+          require_eigen_vt<std::is_arithmetic, EigMat>* = nullptr>
 inline auto subtract(const Var& a, const EigMat& b) {
   using ret_type = promote_scalar_t<var, EigMat>;
-  arena_t<ret_type>  ret(a.val() - b.array());
-  reverse_pass_callback([ret, a]() mutable {
-    a.adj() += ret.adj().sum();
-  });
+  arena_t<ret_type> ret(a.val() - b.array());
+  reverse_pass_callback([ret, a]() mutable { a.adj() += ret.adj().sum(); });
   return ret_type(ret);
 }
-
 
 /**
  * Subtraction operator for a variable and arithmetic matrix (C++).
@@ -226,29 +226,28 @@ inline auto subtract(const Var& a, const EigMat& b) {
  * @return Variable result of subtracting two variables.
  */
 template <typename EigMat, typename Var,
-     require_eigen_vt<std::is_arithmetic, EigMat>* = nullptr,
-     require_var_vt<std::is_arithmetic, Var>* = nullptr>
+          require_eigen_vt<std::is_arithmetic, EigMat>* = nullptr,
+          require_var_vt<std::is_arithmetic, Var>* = nullptr>
 inline auto subtract(const EigMat& a, const Var& b) {
   using ret_type = promote_scalar_t<var, EigMat>;
-  arena_t<ret_type>  ret(a.array() - b.val());
-  reverse_pass_callback([ret, b]() mutable {
-    b.adj() -= ret.adj().sum();
-  });
+  arena_t<ret_type> ret(a.array() - b.val());
+  reverse_pass_callback([ret, b]() mutable { b.adj() -= ret.adj().sum(); });
   return ret_type(ret);
 }
 
 /**
  * Subtraction operator for a variable and variable matrix (C++).
  *
- * @tparam VarMat An Eigen Matrix type with a variable Scalar type or a `var_value` with an underlying matrix type.
+ * @tparam VarMat An Eigen Matrix type with a variable Scalar type or a
+ * `var_value` with an underlying matrix type.
  * @tparam Var A `var_value` with an underlying arithmetic type.
  * @param a First variable operand.
  * @param b Second variable operand.
  * @return Variable result of subtracting two variables.
  */
 template <typename Var, typename VarMat,
-   require_var_vt<std::is_arithmetic, Var>* = nullptr,
-   require_rev_matrix_t<VarMat>* = nullptr>
+          require_var_vt<std::is_arithmetic, Var>* = nullptr,
+          require_rev_matrix_t<VarMat>* = nullptr>
 inline auto subtract(const Var& a, const VarMat& b) {
   arena_t<VarMat> arena_b(b);
   arena_t<VarMat> ret(a.val() - b.val().array());
@@ -262,59 +261,59 @@ inline auto subtract(const Var& a, const VarMat& b) {
   return plain_type_t<VarMat>(ret);
 }
 
-
 /**
  * Subtraction operator for a variable matrix and variable (C++).
  *
- * @tparam VarMat An Eigen Matrix type with a variable Scalar type or a `var_value` with an underlying matrix type.
+ * @tparam VarMat An Eigen Matrix type with a variable Scalar type or a
+ * `var_value` with an underlying matrix type.
  * @tparam Var A `var_value` with an underlying arithmetic type.
  * @param a First variable operand.
  * @param b Second variable operand.
  * @return Variable result of subtracting two variables.
  */
- template <typename Var, typename VarMat,
-  require_rev_matrix_t<VarMat>* = nullptr,
-  require_var_vt<std::is_arithmetic, Var>* = nullptr>
- inline auto subtract(const VarMat& a, const Var& b) {
-   arena_t<VarMat> arena_a(a);
-   arena_t<VarMat> ret(a.val().array() - b.val());
-   reverse_pass_callback([ret, b, arena_a]() mutable {
-     for (Eigen::Index i = 0; i < ret.size(); ++i) {
-       const auto ret_adj = ret.adj().coeff(i);
-       arena_a.adj().coeffRef(i) += ret_adj;
-       b.adj() -= ret_adj;
-     }
-   });
-   return plain_type_t<VarMat>(ret);
- }
+template <typename Var, typename VarMat,
+          require_rev_matrix_t<VarMat>* = nullptr,
+          require_var_vt<std::is_arithmetic, Var>* = nullptr>
+inline auto subtract(const VarMat& a, const Var& b) {
+  arena_t<VarMat> arena_a(a);
+  arena_t<VarMat> ret(a.val().array() - b.val());
+  reverse_pass_callback([ret, b, arena_a]() mutable {
+    for (Eigen::Index i = 0; i < ret.size(); ++i) {
+      const auto ret_adj = ret.adj().coeff(i);
+      arena_a.adj().coeffRef(i) += ret_adj;
+      b.adj() -= ret_adj;
+    }
+  });
+  return plain_type_t<VarMat>(ret);
+}
 
- template <typename T1, typename T2,
-           require_any_var_vt<std::is_arithmetic, T1, T2>* = nullptr,
-           require_any_arithmetic_t<T1, T2>* = nullptr>
- inline auto subtract(const T1& a, const T2& b) {
-   return a - b;
- }
+template <typename T1, typename T2,
+          require_any_var_vt<std::is_arithmetic, T1, T2>* = nullptr,
+          require_any_arithmetic_t<T1, T2>* = nullptr>
+inline auto subtract(const T1& a, const T2& b) {
+  return a - b;
+}
 
- template <typename T1, typename T2,
-           require_all_var_vt<std::is_arithmetic, T1, T2>* = nullptr>
- inline auto subtract(const T1& a, const T2& b) {
-   return a - b;
- }
+template <typename T1, typename T2,
+          require_all_var_vt<std::is_arithmetic, T1, T2>* = nullptr>
+inline auto subtract(const T1& a, const T2& b) {
+  return a - b;
+}
 
- /**
-  * Addition operator for matrix variables (C++).
-  *
-  * @tparam VarMat1 A matrix of vars or a var with an underlying matrix type.
-  * @tparam VarMat2 A matrix of vars or a var with an underlying matrix type.
-  * @param a First variable operand.
-  * @param b Second variable operand.
-  * @return Variable result of adding two variables.
-  */
- template <typename VarMat1, typename VarMat2,
-           require_any_var_matrix_t<VarMat1, VarMat2>* = nullptr>
- inline auto operator-(const VarMat1& a, const VarMat2& b) {
-   return subtract(a, b);
- }
+/**
+ * Addition operator for matrix variables (C++).
+ *
+ * @tparam VarMat1 A matrix of vars or a var with an underlying matrix type.
+ * @tparam VarMat2 A matrix of vars or a var with an underlying matrix type.
+ * @param a First variable operand.
+ * @param b Second variable operand.
+ * @return Variable result of adding two variables.
+ */
+template <typename VarMat1, typename VarMat2,
+          require_any_var_matrix_t<VarMat1, VarMat2>* = nullptr>
+inline auto operator-(const VarMat1& a, const VarMat2& b) {
+  return subtract(a, b);
+}
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/rev/core/var.hpp
+++ b/stan/math/rev/core/var.hpp
@@ -474,6 +474,7 @@ class var_value<
    */
   inline var_value<T>& operator+=(T b);
 
+
   /**
    * The compound subtract/assignment operator for variables (C++).
    *
@@ -485,7 +486,8 @@ class var_value<
    * @return The result of subtracting the specified variable from
    * this variable.
    */
-  inline var_value<T>& operator-=(const var_value<T>& b);
+  template<typename S, require_st_var<S>* = nullptr>
+  inline var_value<T>& operator-=(const S& b);
 
   /**
    * The compound subtract/assignment operator for scalars (C++).
@@ -498,7 +500,8 @@ class var_value<
    * @return The result of subtracting the specified variable from this
    * variable.
    */
-  inline var_value<T>& operator-=(T b);
+  template<typename S, require_st_arithmetic<S>* = nullptr>
+  inline var_value<T>& operator-=(const S& b);
 
   /**
    * The compound multiply/assignment operator for variables (C++).

--- a/stan/math/rev/core/var.hpp
+++ b/stan/math/rev/core/var.hpp
@@ -474,7 +474,6 @@ class var_value<
    */
   inline var_value<T>& operator+=(T b);
 
-
   /**
    * The compound subtract/assignment operator for variables (C++).
    *
@@ -486,7 +485,7 @@ class var_value<
    * @return The result of subtracting the specified variable from
    * this variable.
    */
-  template<typename S, require_st_var<S>* = nullptr>
+  template <typename S, require_st_var<S>* = nullptr>
   inline var_value<T>& operator-=(const S& b);
 
   /**
@@ -500,7 +499,7 @@ class var_value<
    * @return The result of subtracting the specified variable from this
    * variable.
    */
-  template<typename S, require_st_arithmetic<S>* = nullptr>
+  template <typename S, require_st_arithmetic<S>* = nullptr>
   inline var_value<T>& operator-=(const S& b);
 
   /**

--- a/test/unit/math/mix/core/operator_subtraction_test.cpp
+++ b/test/unit/math/mix/core/operator_subtraction_test.cpp
@@ -9,7 +9,7 @@ TEST(mathMixCore, operatorSubtraction) {
 
 
 TEST(mathMixCore, operatorSubtractionMatrixSmall) {
-  // This calls operator+ under the hood
+  // This calls operator- under the hood
   auto f
       = [](const auto& x1, const auto& x2) { return stan::math::subtract(x1, x2); };
   stan::test::ad_tolerances tols;

--- a/test/unit/math/mix/core/operator_subtraction_test.cpp
+++ b/test/unit/math/mix/core/operator_subtraction_test.cpp
@@ -6,3 +6,133 @@ TEST(mathMixCore, operatorSubtraction) {
   stan::test::expect_common_binary(f, disable_lhs_int);
   stan::test::expect_complex_common_binary(f);
 }
+
+
+TEST(mathMixCore, operatorSubtractionMatrixSmall) {
+  // This calls operator+ under the hood
+  auto f
+      = [](const auto& x1, const auto& x2) { return stan::math::subtract(x1, x2); };
+  stan::test::ad_tolerances tols;
+  tols.hessian_hessian_ = 1e-1;
+  tols.hessian_fvar_hessian_ = 1e-1;
+
+  double scalar_a = 10;
+  Eigen::VectorXd vector_v1(1);
+  vector_v1 << 3;
+  Eigen::RowVectorXd row_vector_rv1(1);
+  row_vector_rv1 << -2;
+  Eigen::MatrixXd matrix_m11(1, 1);
+  matrix_m11 << 1.5;
+  stan::test::expect_ad(tols, f, scalar_a, scalar_a);
+  stan::test::expect_ad(tols, f, scalar_a, vector_v1);
+  stan::test::expect_ad(tols, f, vector_v1, scalar_a);
+  stan::test::expect_ad(tols, f, scalar_a, row_vector_rv1);
+  stan::test::expect_ad(tols, f, row_vector_rv1, scalar_a);
+  stan::test::expect_ad(tols, f, scalar_a, matrix_m11);
+  stan::test::expect_ad(tols, f, matrix_m11, scalar_a);
+  stan::test::expect_ad(tols, f, matrix_m11, matrix_m11);
+
+  stan::test::expect_ad_matvar(tols, f, scalar_a, vector_v1);
+  stan::test::expect_ad_matvar(tols, f, vector_v1, scalar_a);
+  stan::test::expect_ad_matvar(tols, f, scalar_a, row_vector_rv1);
+  stan::test::expect_ad_matvar(tols, f, row_vector_rv1, scalar_a);
+  stan::test::expect_ad_matvar(tols, f, row_vector_rv1, vector_v1);
+  stan::test::expect_ad_matvar(tols, f, vector_v1, row_vector_rv1);
+  stan::test::expect_ad_matvar(tols, f, scalar_a, matrix_m11);
+  stan::test::expect_ad_matvar(tols, f, matrix_m11, scalar_a);
+  stan::test::expect_ad_matvar(tols, f, matrix_m11, vector_v1);
+  stan::test::expect_ad_matvar(tols, f, row_vector_rv1, matrix_m11);
+  stan::test::expect_ad_matvar(tols, f, matrix_m11, matrix_m11);
+}
+
+TEST(mathMixCore, operatorSubtractionMatrixZeroSize) {
+  auto f
+      = [](const auto& x1, const auto& x2) { return stan::math::subtract(x1, x2); };
+  stan::test::ad_tolerances tols;
+  tols.hessian_hessian_ = 1e-1;
+  tols.hessian_fvar_hessian_ = 1e-1;
+  double scalar_a = 10;
+  Eigen::VectorXd vector_v0(0);
+  Eigen::RowVectorXd rowvector_rv0(0);
+  Eigen::MatrixXd matrix_m00(0, 0);
+  stan::test::expect_ad(f, scalar_a, vector_v0);
+  stan::test::expect_ad(f, vector_v0, scalar_a);
+  stan::test::expect_ad(f, scalar_a, rowvector_rv0);
+  stan::test::expect_ad(f, rowvector_rv0, scalar_a);
+  stan::test::expect_ad(f, scalar_a, matrix_m00);
+  stan::test::expect_ad(f, matrix_m00, scalar_a);
+  stan::test::expect_ad(f, matrix_m00, matrix_m00);
+
+  stan::test::expect_ad_matvar(f, scalar_a, vector_v0);
+  stan::test::expect_ad_matvar(f, vector_v0, scalar_a);
+  stan::test::expect_ad_matvar(f, scalar_a, rowvector_rv0);
+  stan::test::expect_ad_matvar(f, rowvector_rv0, scalar_a);
+  stan::test::expect_ad_matvar(f, scalar_a, matrix_m00);
+  stan::test::expect_ad_matvar(f, matrix_m00, scalar_a);
+  stan::test::expect_ad_matvar(f, matrix_m00, vector_v0);
+  stan::test::expect_ad_matvar(f, rowvector_rv0, vector_v0);
+  stan::test::expect_ad_matvar(f, vector_v0, rowvector_rv0);
+  stan::test::expect_ad_matvar(f, rowvector_rv0, matrix_m00);
+  stan::test::expect_ad_matvar(f, matrix_m00, matrix_m00);
+}
+
+TEST(mathMixCore, operatorSubtractionMatrixNormal) {
+  auto f
+      = [](const auto& x1, const auto& x2) { return stan::math::subtract(x1, x2); };
+  stan::test::ad_tolerances tols;
+  tols.hessian_hessian_ = 1e-1;
+  tols.hessian_fvar_hessian_ = 1e-1;
+  double scalar_a = 10;
+  Eigen::VectorXd vector_v(2);
+  vector_v << 100, -3;
+  Eigen::RowVectorXd rowvector_rv(2);
+  rowvector_rv << 100, -3;
+  Eigen::MatrixXd matrix_m(2, 2);
+  matrix_m << 100, 0, -3, 4;
+  stan::test::expect_ad(tols, f, scalar_a, vector_v);
+  stan::test::expect_ad(tols, f, vector_v, scalar_a);
+  stan::test::expect_ad(tols, f, scalar_a, rowvector_rv);
+  stan::test::expect_ad(tols, f, rowvector_rv, scalar_a);
+  stan::test::expect_ad(tols, f, scalar_a, matrix_m);
+  stan::test::expect_ad(tols, f, matrix_m, matrix_m);
+  stan::test::expect_ad(tols, f, matrix_m, scalar_a);
+
+  stan::test::expect_ad_matvar(tols, f, scalar_a, vector_v);
+  stan::test::expect_ad_matvar(tols, f, vector_v, scalar_a);
+  stan::test::expect_ad_matvar(tols, f, scalar_a, rowvector_rv);
+  stan::test::expect_ad_matvar(tols, f, rowvector_rv, scalar_a);
+  stan::test::expect_ad_matvar(tols, f, rowvector_rv, vector_v);
+  stan::test::expect_ad_matvar(tols, f, vector_v, rowvector_rv);
+  stan::test::expect_ad_matvar(tols, f, scalar_a, matrix_m);
+  stan::test::expect_ad_matvar(tols, f, matrix_m, scalar_a);
+  stan::test::expect_ad_matvar(tols, f, matrix_m, vector_v);
+  stan::test::expect_ad_matvar(tols, f, rowvector_rv, matrix_m);
+  stan::test::expect_ad_matvar(tols, f, matrix_m, matrix_m);
+}
+
+TEST(mathMixCore, operatorSubtractionMatrixFailures) {
+  auto f
+      = [](const auto& x1, const auto& x2) { return stan::math::subtract(x1, x2); };
+  stan::test::ad_tolerances tols;
+  tols.hessian_hessian_ = 1e-1;
+  tols.hessian_fvar_hessian_ = 1e-1;
+  // These two tests below are just to make sure both fail correctly.
+  Eigen::RowVectorXd d1(3);
+  d1 << 1, 3, -5;
+  Eigen::VectorXd d2(3);
+  d2 << 4, -2, -1;
+  stan::test::expect_ad_matvar(tols, f, d1, d2);
+  stan::test::expect_ad_matvar(tols, f, d2, d1);
+
+  Eigen::MatrixXd u(3, 2);
+  u << 1, 3, -5, 4, -2, -1;
+  Eigen::MatrixXd u_tr = u.transpose();
+  Eigen::VectorXd vv(2);
+  vv << -2, 4;
+  Eigen::RowVectorXd rvv(3);
+  rvv << -2, 4, 1;
+  stan::test::expect_ad_matvar(tols, f, u, u_tr);
+  stan::test::expect_ad_matvar(tols, f, u_tr, u);
+  stan::test::expect_ad_matvar(tols, f, u, vv);
+  stan::test::expect_ad_matvar(tols, f, rvv, u);
+}

--- a/test/unit/math/mix/core/operator_subtraction_test.cpp
+++ b/test/unit/math/mix/core/operator_subtraction_test.cpp
@@ -70,11 +70,12 @@ TEST(mathMixCore, operatorSubtractionMatrixZeroSize) {
   stan::test::expect_ad_matvar(f, rowvector_rv0, scalar_a);
   stan::test::expect_ad_matvar(f, scalar_a, matrix_m00);
   stan::test::expect_ad_matvar(f, matrix_m00, scalar_a);
-  stan::test::expect_ad_matvar(f, matrix_m00, vector_v0);
   stan::test::expect_ad_matvar(f, rowvector_rv0, vector_v0);
   stan::test::expect_ad_matvar(f, vector_v0, rowvector_rv0);
-  stan::test::expect_ad_matvar(f, rowvector_rv0, matrix_m00);
   stan::test::expect_ad_matvar(f, matrix_m00, matrix_m00);
+
+  stan::test::expect_ad_matvar(f, rowvector_rv0, matrix_m00);
+  stan::test::expect_ad_matvar(f, matrix_m00, vector_v0);
 }
 
 TEST(mathMixCore, operatorSubtractionMatrixNormal) {
@@ -107,9 +108,10 @@ TEST(mathMixCore, operatorSubtractionMatrixNormal) {
   stan::test::expect_ad_matvar(tols, f, vector_v, rowvector_rv);
   stan::test::expect_ad_matvar(tols, f, scalar_a, matrix_m);
   stan::test::expect_ad_matvar(tols, f, matrix_m, scalar_a);
+  stan::test::expect_ad_matvar(tols, f, matrix_m, matrix_m);
+
   stan::test::expect_ad_matvar(tols, f, matrix_m, vector_v);
   stan::test::expect_ad_matvar(tols, f, rowvector_rv, matrix_m);
-  stan::test::expect_ad_matvar(tols, f, matrix_m, matrix_m);
 }
 
 TEST(mathMixCore, operatorSubtractionMatrixFailures) {

--- a/test/unit/math/mix/core/operator_subtraction_test.cpp
+++ b/test/unit/math/mix/core/operator_subtraction_test.cpp
@@ -7,11 +7,11 @@ TEST(mathMixCore, operatorSubtraction) {
   stan::test::expect_complex_common_binary(f);
 }
 
-
 TEST(mathMixCore, operatorSubtractionMatrixSmall) {
   // This calls operator- under the hood
-  auto f
-      = [](const auto& x1, const auto& x2) { return stan::math::subtract(x1, x2); };
+  auto f = [](const auto& x1, const auto& x2) {
+    return stan::math::subtract(x1, x2);
+  };
   stan::test::ad_tolerances tols;
   tols.hessian_hessian_ = 1e-1;
   tols.hessian_fvar_hessian_ = 1e-1;
@@ -46,8 +46,9 @@ TEST(mathMixCore, operatorSubtractionMatrixSmall) {
 }
 
 TEST(mathMixCore, operatorSubtractionMatrixZeroSize) {
-  auto f
-      = [](const auto& x1, const auto& x2) { return stan::math::subtract(x1, x2); };
+  auto f = [](const auto& x1, const auto& x2) {
+    return stan::math::subtract(x1, x2);
+  };
   stan::test::ad_tolerances tols;
   tols.hessian_hessian_ = 1e-1;
   tols.hessian_fvar_hessian_ = 1e-1;
@@ -77,8 +78,9 @@ TEST(mathMixCore, operatorSubtractionMatrixZeroSize) {
 }
 
 TEST(mathMixCore, operatorSubtractionMatrixNormal) {
-  auto f
-      = [](const auto& x1, const auto& x2) { return stan::math::subtract(x1, x2); };
+  auto f = [](const auto& x1, const auto& x2) {
+    return stan::math::subtract(x1, x2);
+  };
   stan::test::ad_tolerances tols;
   tols.hessian_hessian_ = 1e-1;
   tols.hessian_fvar_hessian_ = 1e-1;
@@ -111,8 +113,9 @@ TEST(mathMixCore, operatorSubtractionMatrixNormal) {
 }
 
 TEST(mathMixCore, operatorSubtractionMatrixFailures) {
-  auto f
-      = [](const auto& x1, const auto& x2) { return stan::math::subtract(x1, x2); };
+  auto f = [](const auto& x1, const auto& x2) {
+    return stan::math::subtract(x1, x2);
+  };
   stan::test::ad_tolerances tols;
   tols.hessian_hessian_ = 1e-1;
   tols.hessian_fvar_hessian_ = 1e-1;


### PR DESCRIPTION

## Summary

Adds `operator-` for `var<matrix>` types

## Tests

Adds the same tests for `operator+` for `var<matrix>`

## Side Effects

Nope!

## Release notes

Adds `operator-` for `var<matrix>` types

## Checklist

- [x] Math issue #1805 

- [x] Copyright holder: Steve Bronder

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
