### PR TITLE
Added `var<mat>` implementations of `columns_dot_product` and `rows_dot_product`

### DIFF
--- a/stan/math/rev/fun/columns_dot_product.hpp
+++ b/stan/math/rev/fun/columns_dot_product.hpp
@@ -14,6 +14,20 @@
 namespace stan {
 namespace math {
 
+/**
+ * Returns the dot product of columns of the specified matrices.
+ *
+ * @tparam Mat1 type of the first matrix (must be derived from \c
+ * Eigen::MatrixBase)
+ * @tparam Mat2 type of the second matrix (must be derived from \c
+ * Eigen::MatrixBase)
+ *
+ * @param v1 Matrix of first vectors.
+ * @param v2 Matrix of second vectors.
+ * @return Dot product of the vectors.
+ * @throw std::domain_error If the vectors are not the same
+ * size or if they are both not vector dimensioned.
+ */
 template <typename Mat1, typename Mat2,
           require_all_eigen_t<Mat1, Mat2>* = nullptr,
           require_any_eigen_vt<is_var, Mat1, Mat2>* = nullptr>
@@ -27,6 +41,87 @@ columns_dot_product(const Mat1& v1, const Mat2& v2) {
   return ret;
 }
 
+/**
+ * Returns the dot product of columns of the specified matrices.
+ *
+ * This overload is used when at least one of Mat1 and Mat2 is
+ * a `var_value<T>` where `T` inherits from `EigenBase`. The other
+ * argument can be another `var_value` or a type that inherits from
+ * `EigenBase`.
+ *
+ * @tparam Mat1 type of the first matrix
+ * @tparam Mat2 type of the second matrix
+ *
+ * @param v1 Matrix of first vectors.
+ * @param v2 Matrix of second vectors.
+ * @return Dot product of the vectors.
+ * @throw std::domain_error If the vectors are not the same
+ * size or if they are both not vector dimensioned.
+ */
+template <typename Mat1, typename Mat2,
+          require_all_matrix_t<Mat1, Mat2>* = nullptr,
+          require_any_var_matrix_t<Mat1, Mat2>* = nullptr>
+inline auto columns_dot_product(const Mat1& v1, const Mat2& v2) {
+  check_matching_sizes("columns_dot_product", "v1", v1, "v2", v2);
+
+  using return_t
+      = promote_var_matrix_t<decltype((v1.val().array() *
+				       v2.val().array()).colwise().sum().matrix()),
+                             Mat1, Mat2>;
+
+  if (!is_constant<Mat1>::value && !is_constant<Mat2>::value) {
+    arena_t<promote_scalar_t<var, Mat1>> arena_v1 = v1;
+    arena_t<promote_scalar_t<var, Mat2>> arena_v2 = v2;
+
+    return_t res = (arena_v1.val().array() * arena_v2.val().array()).colwise().sum();
+
+    reverse_pass_callback([arena_v1, arena_v2, res]() mutable {
+      if (is_var_matrix<Mat1>::value) {
+	arena_v1.adj().noalias() += value_of(arena_v2) * res.adj().asDiagonal();
+      } else {
+	arena_v1.adj() += value_of(arena_v2) * res.adj().asDiagonal();
+      }
+      if (is_var_matrix<Mat2>::value) {
+	arena_v2.adj().noalias() += value_of(arena_v1) * res.adj().asDiagonal();
+      } else {
+	arena_v2.adj() += value_of(arena_v1) * res.adj().asDiagonal();
+      }
+    });
+
+    return res;
+  } else if (!is_constant<Mat2>::value) {
+    arena_t<promote_scalar_t<double, Mat1>> arena_v1 = value_of(v1);
+    arena_t<promote_scalar_t<var, Mat2>> arena_v2 = v2;
+
+    return_t res = (arena_v1.array() * arena_v2.val().array()).colwise().sum();
+
+    reverse_pass_callback([arena_v1, arena_v2, res]() mutable {
+      if (is_var_matrix<Mat2>::value) {
+	arena_v2.adj().noalias() += arena_v1 * res.adj().asDiagonal();
+      } else {
+	arena_v2.adj() += arena_v1 * res.adj().asDiagonal();
+      }
+    });
+
+    return res;
+  } else {
+    arena_t<promote_scalar_t<var, Mat1>> arena_v1 = v1;
+    arena_t<promote_scalar_t<double, Mat2>> arena_v2 = value_of(v2);
+
+    return_t res = (arena_v1.val().array() * arena_v2.array()).colwise().sum();
+
+    reverse_pass_callback([arena_v1, arena_v2, res]() mutable {
+      if (is_var_matrix<Mat2>::value) {
+	arena_v1.adj().noalias() += arena_v2 * res.adj().asDiagonal();
+      } else {
+	arena_v1.adj() += arena_v2 * res.adj().asDiagonal();
+      }
+    });
+
+    return res;
+  }
+}
+  
 }  // namespace math
 }  // namespace stan
 #endif

--- a/stan/math/rev/fun/columns_dot_product.hpp
+++ b/stan/math/rev/fun/columns_dot_product.hpp
@@ -64,27 +64,27 @@ template <typename Mat1, typename Mat2,
 inline auto columns_dot_product(const Mat1& v1, const Mat2& v2) {
   check_matching_sizes("columns_dot_product", "v1", v1, "v2", v2);
 
-  using return_t
-      = promote_var_matrix_t<decltype((v1.val().array() *
-				       v2.val().array()).colwise().sum().matrix()),
-                             Mat1, Mat2>;
+  using return_t = promote_var_matrix_t<
+      decltype((v1.val().array() * v2.val().array()).colwise().sum().matrix()),
+      Mat1, Mat2>;
 
   if (!is_constant<Mat1>::value && !is_constant<Mat2>::value) {
     arena_t<promote_scalar_t<var, Mat1>> arena_v1 = v1;
     arena_t<promote_scalar_t<var, Mat2>> arena_v2 = v2;
 
-    return_t res = (arena_v1.val().array() * arena_v2.val().array()).colwise().sum();
+    return_t res
+        = (arena_v1.val().array() * arena_v2.val().array()).colwise().sum();
 
     reverse_pass_callback([arena_v1, arena_v2, res]() mutable {
       if (is_var_matrix<Mat1>::value) {
-	arena_v1.adj().noalias() += value_of(arena_v2) * res.adj().asDiagonal();
+        arena_v1.adj().noalias() += value_of(arena_v2) * res.adj().asDiagonal();
       } else {
-	arena_v1.adj() += value_of(arena_v2) * res.adj().asDiagonal();
+        arena_v1.adj() += value_of(arena_v2) * res.adj().asDiagonal();
       }
       if (is_var_matrix<Mat2>::value) {
-	arena_v2.adj().noalias() += value_of(arena_v1) * res.adj().asDiagonal();
+        arena_v2.adj().noalias() += value_of(arena_v1) * res.adj().asDiagonal();
       } else {
-	arena_v2.adj() += value_of(arena_v1) * res.adj().asDiagonal();
+        arena_v2.adj() += value_of(arena_v1) * res.adj().asDiagonal();
       }
     });
 
@@ -97,9 +97,9 @@ inline auto columns_dot_product(const Mat1& v1, const Mat2& v2) {
 
     reverse_pass_callback([arena_v1, arena_v2, res]() mutable {
       if (is_var_matrix<Mat2>::value) {
-	arena_v2.adj().noalias() += arena_v1 * res.adj().asDiagonal();
+        arena_v2.adj().noalias() += arena_v1 * res.adj().asDiagonal();
       } else {
-	arena_v2.adj() += arena_v1 * res.adj().asDiagonal();
+        arena_v2.adj() += arena_v1 * res.adj().asDiagonal();
       }
     });
 
@@ -112,16 +112,16 @@ inline auto columns_dot_product(const Mat1& v1, const Mat2& v2) {
 
     reverse_pass_callback([arena_v1, arena_v2, res]() mutable {
       if (is_var_matrix<Mat2>::value) {
-	arena_v1.adj().noalias() += arena_v2 * res.adj().asDiagonal();
+        arena_v1.adj().noalias() += arena_v2 * res.adj().asDiagonal();
       } else {
-	arena_v1.adj() += arena_v2 * res.adj().asDiagonal();
+        arena_v1.adj() += arena_v2 * res.adj().asDiagonal();
       }
     });
 
     return res;
   }
 }
-  
+
 }  // namespace math
 }  // namespace stan
 #endif

--- a/stan/math/rev/fun/columns_dot_product.hpp
+++ b/stan/math/rev/fun/columns_dot_product.hpp
@@ -77,14 +77,14 @@ inline auto columns_dot_product(const Mat1& v1, const Mat2& v2) {
 
     reverse_pass_callback([arena_v1, arena_v2, res]() mutable {
       if (is_var_matrix<Mat1>::value) {
-        arena_v1.adj().noalias() += value_of(arena_v2) * res.adj().asDiagonal();
+        arena_v1.adj().noalias() += arena_v2.val() * res.adj().asDiagonal();
       } else {
-        arena_v1.adj() += value_of(arena_v2) * res.adj().asDiagonal();
+        arena_v1.adj() += arena_v2.val() * res.adj().asDiagonal();
       }
       if (is_var_matrix<Mat2>::value) {
-        arena_v2.adj().noalias() += value_of(arena_v1) * res.adj().asDiagonal();
+        arena_v2.adj().noalias() += arena_v1.val() * res.adj().asDiagonal();
       } else {
-        arena_v2.adj() += value_of(arena_v1) * res.adj().asDiagonal();
+        arena_v2.adj() += arena_v1.val() * res.adj().asDiagonal();
       }
     });
 

--- a/stan/math/rev/fun/rows_dot_product.hpp
+++ b/stan/math/rev/fun/rows_dot_product.hpp
@@ -12,6 +12,20 @@
 namespace stan {
 namespace math {
 
+/**
+ * Returns the dot product of rows of the specified matrices.
+ *
+ * @tparam Mat1 type of the first matrix (must be derived from \c
+ * Eigen::MatrixBase)
+ * @tparam Mat2 type of the second matrix (must be derived from \c
+ * Eigen::MatrixBase)
+ *
+ * @param v1 Matrix of first vectors.
+ * @param v2 Matrix of second vectors.
+ * @return Dot product of the vectors.
+ * @throw std::domain_error If the vectors are not the same
+ * size or if they are both not vector dimensioned.
+ */
 template <typename Mat1, typename Mat2,
           require_all_eigen_t<Mat1, Mat2>* = nullptr,
           require_any_eigen_vt<is_var, Mat1, Mat2>* = nullptr>
@@ -23,6 +37,87 @@ inline Eigen::Matrix<var, Mat1::RowsAtCompileTime, 1> rows_dot_product(
     ret.coeffRef(j) = dot_product(v1.row(j), v2.row(j));
   }
   return ret;
+}
+
+/**
+ * Returns the dot product of rows of the specified matrices.
+ *
+ * This overload is used when at least one of Mat1 and Mat2 is
+ * a `var_value<T>` where `T` inherits from `EigenBase`. The other
+ * argument can be another `var_value` or a type that inherits from
+ * `EigenBase`.
+ *
+ * @tparam Mat1 type of the first matrix
+ * @tparam Mat2 type of the second matrix
+ *
+ * @param v1 Matrix of first vectors.
+ * @param v2 Matrix of second vectors.
+ * @return Dot product of the vectors.
+ * @throw std::domain_error If the vectors are not the same
+ * size or if they are both not vector dimensioned.
+ */
+template <typename Mat1, typename Mat2,
+          require_all_matrix_t<Mat1, Mat2>* = nullptr,
+          require_any_var_matrix_t<Mat1, Mat2>* = nullptr>
+inline auto rows_dot_product(const Mat1& v1, const Mat2& v2) {
+  check_matching_sizes("rows_dot_product", "v1", v1, "v2", v2);
+
+  using return_t
+      = promote_var_matrix_t<decltype((v1.val().array() *
+				       v2.val().array()).rowwise().sum().matrix()),
+                             Mat1, Mat2>;
+
+  if (!is_constant<Mat1>::value && !is_constant<Mat2>::value) {
+    arena_t<promote_scalar_t<var, Mat1>> arena_v1 = v1;
+    arena_t<promote_scalar_t<var, Mat2>> arena_v2 = v2;
+
+    return_t res = (arena_v1.val().array() * arena_v2.val().array()).rowwise().sum();
+
+    reverse_pass_callback([arena_v1, arena_v2, res]() mutable {
+      if (is_var_matrix<Mat1>::value) {
+	arena_v1.adj().noalias() += res.adj().asDiagonal() * value_of(arena_v2);
+      } else {
+	arena_v1.adj() += res.adj().asDiagonal() * value_of(arena_v2);
+      }
+      if (is_var_matrix<Mat2>::value) {
+	arena_v2.adj().noalias() += res.adj().asDiagonal() * value_of(arena_v1);
+      } else {
+	arena_v2.adj() += res.adj().asDiagonal() * value_of(arena_v1);
+      }
+    });
+
+    return res;
+  } else if (!is_constant<Mat2>::value) {
+    arena_t<promote_scalar_t<double, Mat1>> arena_v1 = value_of(v1);
+    arena_t<promote_scalar_t<var, Mat2>> arena_v2 = v2;
+
+    return_t res = (arena_v1.array() * arena_v2.val().array()).rowwise().sum();
+
+    reverse_pass_callback([arena_v1, arena_v2, res]() mutable {
+      if (is_var_matrix<Mat2>::value) {
+	arena_v2.adj().noalias() += res.adj().asDiagonal() * arena_v1;
+      } else {
+	arena_v2.adj() += res.adj().asDiagonal() * arena_v1;
+      }
+    });
+
+    return res;
+  } else {
+    arena_t<promote_scalar_t<var, Mat1>> arena_v1 = v1;
+    arena_t<promote_scalar_t<double, Mat2>> arena_v2 = value_of(v2);
+
+    return_t res = (arena_v1.val().array() * arena_v2.array()).rowwise().sum();
+
+    reverse_pass_callback([arena_v1, arena_v2, res]() mutable {
+      if (is_var_matrix<Mat2>::value) {
+	arena_v1.adj().noalias() += res.adj().asDiagonal() * arena_v2;
+      } else {
+	arena_v1.adj() += res.adj().asDiagonal() * arena_v2;
+      }
+    });
+
+    return res;
+  }
 }
 
 }  // namespace math

--- a/stan/math/rev/fun/rows_dot_product.hpp
+++ b/stan/math/rev/fun/rows_dot_product.hpp
@@ -75,14 +75,14 @@ inline auto rows_dot_product(const Mat1& v1, const Mat2& v2) {
 
     reverse_pass_callback([arena_v1, arena_v2, res]() mutable {
       if (is_var_matrix<Mat1>::value) {
-        arena_v1.adj().noalias() += res.adj().asDiagonal() * value_of(arena_v2);
+        arena_v1.adj().noalias() += res.adj().asDiagonal() * arena_v2.val();
       } else {
-        arena_v1.adj() += res.adj().asDiagonal() * value_of(arena_v2);
+        arena_v1.adj() += res.adj().asDiagonal() * arena_v2.val();
       }
       if (is_var_matrix<Mat2>::value) {
-        arena_v2.adj().noalias() += res.adj().asDiagonal() * value_of(arena_v1);
+        arena_v2.adj().noalias() += res.adj().asDiagonal() * arena_v1.val();
       } else {
-        arena_v2.adj() += res.adj().asDiagonal() * value_of(arena_v1);
+        arena_v2.adj() += res.adj().asDiagonal() * arena_v1.val();
       }
     });
 

--- a/stan/math/rev/fun/rows_dot_product.hpp
+++ b/stan/math/rev/fun/rows_dot_product.hpp
@@ -62,27 +62,27 @@ template <typename Mat1, typename Mat2,
 inline auto rows_dot_product(const Mat1& v1, const Mat2& v2) {
   check_matching_sizes("rows_dot_product", "v1", v1, "v2", v2);
 
-  using return_t
-      = promote_var_matrix_t<decltype((v1.val().array() *
-				       v2.val().array()).rowwise().sum().matrix()),
-                             Mat1, Mat2>;
+  using return_t = promote_var_matrix_t<
+      decltype((v1.val().array() * v2.val().array()).rowwise().sum().matrix()),
+      Mat1, Mat2>;
 
   if (!is_constant<Mat1>::value && !is_constant<Mat2>::value) {
     arena_t<promote_scalar_t<var, Mat1>> arena_v1 = v1;
     arena_t<promote_scalar_t<var, Mat2>> arena_v2 = v2;
 
-    return_t res = (arena_v1.val().array() * arena_v2.val().array()).rowwise().sum();
+    return_t res
+        = (arena_v1.val().array() * arena_v2.val().array()).rowwise().sum();
 
     reverse_pass_callback([arena_v1, arena_v2, res]() mutable {
       if (is_var_matrix<Mat1>::value) {
-	arena_v1.adj().noalias() += res.adj().asDiagonal() * value_of(arena_v2);
+        arena_v1.adj().noalias() += res.adj().asDiagonal() * value_of(arena_v2);
       } else {
-	arena_v1.adj() += res.adj().asDiagonal() * value_of(arena_v2);
+        arena_v1.adj() += res.adj().asDiagonal() * value_of(arena_v2);
       }
       if (is_var_matrix<Mat2>::value) {
-	arena_v2.adj().noalias() += res.adj().asDiagonal() * value_of(arena_v1);
+        arena_v2.adj().noalias() += res.adj().asDiagonal() * value_of(arena_v1);
       } else {
-	arena_v2.adj() += res.adj().asDiagonal() * value_of(arena_v1);
+        arena_v2.adj() += res.adj().asDiagonal() * value_of(arena_v1);
       }
     });
 
@@ -95,9 +95,9 @@ inline auto rows_dot_product(const Mat1& v1, const Mat2& v2) {
 
     reverse_pass_callback([arena_v1, arena_v2, res]() mutable {
       if (is_var_matrix<Mat2>::value) {
-	arena_v2.adj().noalias() += res.adj().asDiagonal() * arena_v1;
+        arena_v2.adj().noalias() += res.adj().asDiagonal() * arena_v1;
       } else {
-	arena_v2.adj() += res.adj().asDiagonal() * arena_v1;
+        arena_v2.adj() += res.adj().asDiagonal() * arena_v1;
       }
     });
 
@@ -110,9 +110,9 @@ inline auto rows_dot_product(const Mat1& v1, const Mat2& v2) {
 
     reverse_pass_callback([arena_v1, arena_v2, res]() mutable {
       if (is_var_matrix<Mat2>::value) {
-	arena_v1.adj().noalias() += res.adj().asDiagonal() * arena_v2;
+        arena_v1.adj().noalias() += res.adj().asDiagonal() * arena_v2;
       } else {
-	arena_v1.adj() += res.adj().asDiagonal() * arena_v2;
+        arena_v1.adj() += res.adj().asDiagonal() * arena_v2;
       }
     });
 

--- a/test/unit/math/mix/fun/columns_dot_product_test.cpp
+++ b/test/unit/math/mix/fun/columns_dot_product_test.cpp
@@ -9,26 +9,31 @@ TEST(MathMixMatFun, columnsDotProduct) {
   Eigen::VectorXd v3(3);
   v3 << 4, -2, -1;
   stan::test::expect_ad(f, u3, v3);
+  stan::test::expect_ad_matvar(f, u3, v3);
 
   Eigen::RowVectorXd ru3 = u3;
   Eigen::RowVectorXd rv3 = v3;
   stan::test::expect_ad(f, ru3, rv3);
+  stan::test::expect_ad_matvar(f, ru3, rv3);
 
   Eigen::MatrixXd a33(3, 3);
   a33 << 1, 1, 1, 3, 3, 3, -5, -5, -5;
   Eigen::MatrixXd b33(3, 3);
   b33 << 4, 4, 4, -2, -2, -2, -1, -1, -1;
   stan::test::expect_ad(f, a33, b33);
+  stan::test::expect_ad_matvar(f, a33, b33);
 
   Eigen::MatrixXd c32(3, 2);
   c32 << 1, 2, 3, 4, 5, 6;
   Eigen::MatrixXd d32(3, 2);
   d32 << -1, -2, -3, -4, -5, -6;
   stan::test::expect_ad(f, c32, d32);
+  stan::test::expect_ad_matvar(f, c32, d32);
 
   Eigen::MatrixXd c23 = c32.transpose();
   Eigen::MatrixXd d23 = d32.transpose();
   stan::test::expect_ad(f, c23, d23);
+  stan::test::expect_ad_matvar(f, c23, d23);
 
   // size zero boundary
   Eigen::VectorXd v0(0);
@@ -37,6 +42,9 @@ TEST(MathMixMatFun, columnsDotProduct) {
   stan::test::expect_ad(f, v0, v0);
   stan::test::expect_ad(f, rv0, rv0);
   stan::test::expect_ad(f, a00, a00);
+  stan::test::expect_ad_matvar(f, v0, v0);
+  stan::test::expect_ad_matvar(f, rv0, rv0);
+  stan::test::expect_ad_matvar(f, a00, a00);
 
   // exceptions---sizes
   Eigen::MatrixXd em33 = Eigen::MatrixXd::Zero(3, 3);
@@ -53,4 +61,8 @@ TEST(MathMixMatFun, columnsDotProduct) {
   stan::test::expect_ad(f, erv2, erv3);
   stan::test::expect_ad(f, em33, em23);
   stan::test::expect_ad(f, em23, em33);
+  stan::test::expect_ad_matvar(f, ev2, ev3);
+  stan::test::expect_ad_matvar(f, erv2, erv3);
+  stan::test::expect_ad_matvar(f, em33, em23);
+  stan::test::expect_ad_matvar(f, em23, em33);
 }

--- a/test/unit/math/mix/fun/rows_dot_product_test.cpp
+++ b/test/unit/math/mix/fun/rows_dot_product_test.cpp
@@ -11,32 +11,40 @@ TEST(MathMixMatFun, rowsDotProduct) {
   stan::test::expect_ad(f, v0, v0);
   stan::test::expect_ad(f, rv0, rv0);
   stan::test::expect_ad(f, m00, m00);
+  stan::test::expect_ad_matvar(f, v0, v0);
+  stan::test::expect_ad_matvar(f, rv0, rv0);
+  stan::test::expect_ad_matvar(f, m00, m00);
 
   Eigen::VectorXd u3(3);
   u3 << 1, 3, -5;
   Eigen::VectorXd v3(3);
   v3 << 4, -2, -1;
   stan::test::expect_ad(f, u3, v3);
+  stan::test::expect_ad_matvar(f, u3, v3);
 
   Eigen::RowVectorXd ru3 = u3;
   Eigen::RowVectorXd rv3 = v3;
   stan::test::expect_ad(f, ru3, rv3);
+  stan::test::expect_ad_matvar(f, ru3, rv3);
 
   Eigen::MatrixXd a33(3, 3);
   a33 << 1, 1, 1, 3, 3, 3, -5, -5, -5;
   Eigen::MatrixXd b33(3, 3);
   b33 << 4, 4, 4, -2, -2, -2, -1, -1, -1;
   stan::test::expect_ad(f, a33, b33);
+  stan::test::expect_ad_matvar(f, a33, b33);
 
   Eigen::MatrixXd c32(3, 2);
   c32 << 1, 2, 3, 4, 5, 6;
   Eigen::MatrixXd d32(3, 2);
   d32 << -1, -2, -3, -4, -5, -6;
   stan::test::expect_ad(f, c32, d32);
+  stan::test::expect_ad_matvar(f, c32, d32);
 
   Eigen::MatrixXd c23 = c32.transpose();
   Eigen::MatrixXd d23 = d32.transpose();
   stan::test::expect_ad(f, c23, d23);
+  stan::test::expect_ad_matvar(f, c23, d23);
 
   // exceptions---sizes
   Eigen::MatrixXd em33 = Eigen::MatrixXd::Zero(3, 3);
@@ -53,4 +61,8 @@ TEST(MathMixMatFun, rowsDotProduct) {
   stan::test::expect_ad(f, erv2, erv3);
   stan::test::expect_ad(f, em33, em23);
   stan::test::expect_ad(f, em23, em33);
+  stan::test::expect_ad_matvar(f, ev2, ev3);
+  stan::test::expect_ad_matvar(f, erv2, erv3);
+  stan::test::expect_ad_matvar(f, em33, em23);
+  stan::test::expect_ad_matvar(f, em23, em33);
 }


### PR DESCRIPTION
## Summary

Added `var<mat>` versions of `columns_dot_product` and `rows_dot_product`

## Release notes

Added `var<mat>` versions of `columns_dot_product` and `rows_dot_product`

## Checklist

- [x] Math issue #2101

- [x] Copyright holder: Columbia University

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
