### PR TITLE
Add lbeta and binomial_coefficient_log to kernel generator

### DIFF
--- a/stan/math/opencl/kernel_generator/elt_function_cl.hpp
+++ b/stan/math/opencl/kernel_generator/elt_function_cl.hpp
@@ -3,7 +3,11 @@
 #ifdef STAN_OPENCL
 
 #include <stan/math/prim/meta.hpp>
+#include <stan/math/opencl/kernels/device_functions/binomial_coefficient_log.hpp>
 #include <stan/math/opencl/kernels/device_functions/digamma.hpp>
+#include <stan/math/opencl/kernels/device_functions/lbeta.hpp>
+#include <stan/math/opencl/kernels/device_functions/lgamma_stirling.hpp>
+#include <stan/math/opencl/kernels/device_functions/lgamma_stirling_diff.hpp>
 #include <stan/math/opencl/kernels/device_functions/log1m_exp.hpp>
 #include <stan/math/opencl/kernels/device_functions/log1m_inv_logit.hpp>
 #include <stan/math/opencl/kernels/device_functions/log1p_exp.hpp>
@@ -63,7 +67,10 @@ class elt_function_cl : public operation_cl<Derived, Scal, T...> {
       const bool view_handled,
       std::conditional_t<false, T, const std::string&>... var_names_arg) const {
     kernel_parts res{};
-    res.includes = base::derived().include;
+
+    for (const char* incl : base::derived().includes) {
+      res.includes += incl;
+    }
     std::array<std::string, sizeof...(T)> var_names_arg_arr
         = {(var_names_arg + ", ")...};
     std::string var_names_list = std::accumulate(
@@ -81,9 +88,9 @@ class elt_function_cl : public operation_cl<Derived, Scal, T...> {
  * Generates a class and function for a general binary function that is defined
  * by OpenCL or in the included code.
  * @param fun function
- * @param incl function source to include into kernel
+ * @param ... function sources to include into kernel
  */
-#define ADD_BINARY_FUNCTION_WITH_INCLUDE(fun, incl)                         \
+#define ADD_BINARY_FUNCTION_WITH_INCLUDES(fun, ...)                         \
   template <typename T1, typename T2>                                       \
   class fun##_ : public elt_function_cl<fun##_<T1, T2>,                     \
                                         common_scalar_t<T1, T2>, T1, T2> {  \
@@ -94,7 +101,7 @@ class elt_function_cl : public operation_cl<Derived, Scal, T...> {
    public:                                                                  \
     using base::rows;                                                       \
     using base::cols;                                                       \
-    static const char* include;                                             \
+    static const std::vector<const char*> includes;                         \
     explicit fun##_(T1&& a, T2&& b)                                         \
         : base(#fun, std::forward<T1>(a), std::forward<T2>(b)) {}           \
     inline auto deep_copy() const {                                         \
@@ -119,15 +126,15 @@ class elt_function_cl : public operation_cl<Derived, Scal, T...> {
         as_operation_cl(std::forward<T2>(b)));                              \
   }                                                                         \
   template <typename T1, typename T2>                                       \
-  const char* fun##_<T1, T2>::include(incl);
+  const std::vector<const char*> fun##_<T1, T2>::includes{__VA_ARGS__};
 
 /**
  * Generates a class and function for a general unary function that is defined
  * by OpenCL or in the included code.
  * @param fun function
- * @param incl function source to include into kernel
+ * @param ... function sources to include into kernel
  */
-#define ADD_UNARY_FUNCTION_WITH_INCLUDE(fun, incl)                             \
+#define ADD_UNARY_FUNCTION_WITH_INCLUDES(fun, ...)                             \
   template <typename T>                                                        \
   class fun##_                                                                 \
       : public elt_function_cl<                                                \
@@ -145,7 +152,7 @@ class elt_function_cl : public operation_cl<Derived, Scal, T...> {
    public:                                                                     \
     using base::rows;                                                          \
     using base::cols;                                                          \
-    static const char* include;                                                \
+    static const std::vector<const char*> includes;                            \
     explicit fun##_(T&& a) : base(#fun, std::forward<T>(a)) {}                 \
     inline auto deep_copy() const {                                            \
       auto&& arg_copy = this->template get_arg<0>().deep_copy();               \
@@ -163,14 +170,14 @@ class elt_function_cl : public operation_cl<Derived, Scal, T...> {
     return fun##_<as_operation_cl_t<T>>(as_operation_cl(std::forward<T>(a)));  \
   }                                                                            \
   template <typename T>                                                        \
-  const char* fun##_<T>::include(incl);
+  const std::vector<const char*> fun##_<T>::includes{__VA_ARGS__};
 
 /**
  * Generates a class and function for a general unary function that is defined
  * by OpenCL.
  * @param fun function
  */
-#define ADD_UNARY_FUNCTION(fun) ADD_UNARY_FUNCTION_WITH_INCLUDE(fun, "")
+#define ADD_UNARY_FUNCTION(fun) ADD_UNARY_FUNCTION_WITH_INCLUDES(fun)
 
 /**
  * Generates a class and function for an unary function, defined by OpenCL with
@@ -197,7 +204,7 @@ class elt_function_cl : public operation_cl<Derived, Scal, T...> {
     using base::rows;                                                          \
     using base::cols;                                                          \
     static constexpr auto view_transitivness = std::make_tuple(true);          \
-    static const char* include;                                                \
+    static const std::vector<const char*> includes;                            \
     explicit fun##_(T&& a) : base(#fun, std::forward<T>(a)) {}                 \
     inline auto deep_copy() const {                                            \
       auto&& arg_copy = this->template get_arg<0>().deep_copy();               \
@@ -212,7 +219,7 @@ class elt_function_cl : public operation_cl<Derived, Scal, T...> {
     return fun##_<as_operation_cl_t<T>>(as_operation_cl(std::forward<T>(a)));  \
   }                                                                            \
   template <typename T>                                                        \
-  const char* fun##_<T>::include = "";
+  const std::vector<const char*> fun##_<T>::includes{};
 
 /**
  * Generates a class and function for a classification function, defined by
@@ -235,7 +242,7 @@ class elt_function_cl : public operation_cl<Derived, Scal, T...> {
     using base::rows;                                                          \
     using base::cols;                                                          \
     static constexpr auto view_transitivness = std::make_tuple(true);          \
-    static const char* include;                                                \
+    static const std::vector<const char*> includes;                            \
     explicit fun##_(T&& a) : base(#fun, std::forward<T>(a)) {}                 \
     inline auto deep_copy() const {                                            \
       auto&& arg_copy = this->template get_arg<0>().deep_copy();               \
@@ -253,7 +260,7 @@ class elt_function_cl : public operation_cl<Derived, Scal, T...> {
     return fun##_<as_operation_cl_t<T>>(as_operation_cl(std::forward<T>(a)));  \
   }                                                                            \
   template <typename T>                                                        \
-  const char* fun##_<T>::include = "";
+  const std::vector<const char*> fun##_<T>::includes{};
 
 ADD_UNARY_FUNCTION(rsqrt)
 ADD_UNARY_FUNCTION_PASS_ZERO(sqrt)
@@ -292,19 +299,19 @@ ADD_UNARY_FUNCTION_PASS_ZERO(ceil)
 ADD_UNARY_FUNCTION_PASS_ZERO(fabs)
 ADD_UNARY_FUNCTION_PASS_ZERO(trunc)
 
-ADD_UNARY_FUNCTION_WITH_INCLUDE(digamma,
-                                opencl_kernels::digamma_device_function)
-ADD_UNARY_FUNCTION_WITH_INCLUDE(log1m_exp,
-                                opencl_kernels::log1m_exp_device_function)
-ADD_UNARY_FUNCTION_WITH_INCLUDE(log1p_exp,
-                                opencl_kernels::log1p_exp_device_function)
-ADD_UNARY_FUNCTION_WITH_INCLUDE(inv_square,
-                                opencl_kernels::inv_square_device_function)
-ADD_UNARY_FUNCTION_WITH_INCLUDE(inv_logit,
-                                opencl_kernels::inv_logit_device_function)
-ADD_UNARY_FUNCTION_WITH_INCLUDE(logit, opencl_kernels::logit_device_function)
-ADD_UNARY_FUNCTION_WITH_INCLUDE(log1m_inv_logit,
-                                opencl_kernels::log1m_inv_logit_device_function)
+ADD_UNARY_FUNCTION_WITH_INCLUDES(digamma,
+                                 opencl_kernels::digamma_device_function)
+ADD_UNARY_FUNCTION_WITH_INCLUDES(log1m_exp,
+                                 opencl_kernels::log1m_exp_device_function)
+ADD_UNARY_FUNCTION_WITH_INCLUDES(log1p_exp,
+                                 opencl_kernels::log1p_exp_device_function)
+ADD_UNARY_FUNCTION_WITH_INCLUDES(inv_square,
+                                 opencl_kernels::inv_square_device_function)
+ADD_UNARY_FUNCTION_WITH_INCLUDES(inv_logit,
+                                 opencl_kernels::inv_logit_device_function)
+ADD_UNARY_FUNCTION_WITH_INCLUDES(logit, opencl_kernels::logit_device_function)
+ADD_UNARY_FUNCTION_WITH_INCLUDES(
+    log1m_inv_logit, opencl_kernels::log1m_inv_logit_device_function)
 
 ADD_CLASSIFICATION_FUNCTION(isfinite, {-rows() + 1, cols() - 1})
 ADD_CLASSIFICATION_FUNCTION(isinf,
@@ -312,10 +319,20 @@ ADD_CLASSIFICATION_FUNCTION(isinf,
 ADD_CLASSIFICATION_FUNCTION(isnan,
                             this->template get_arg<0>().extreme_diagonals())
 
-ADD_BINARY_FUNCTION_WITH_INCLUDE(pow, "")
+ADD_BINARY_FUNCTION_WITH_INCLUDES(pow)
+ADD_BINARY_FUNCTION_WITH_INCLUDES(
+    lbeta, stan::math::opencl_kernels::lgamma_stirling_device_function,
+    stan::math::opencl_kernels::lgamma_stirling_diff_device_function,
+    stan::math::opencl_kernels::lbeta_device_function)
+ADD_BINARY_FUNCTION_WITH_INCLUDES(
+    binomial_coefficient_log,
+    stan::math::opencl_kernels::lgamma_stirling_device_function,
+    stan::math::opencl_kernels::lgamma_stirling_diff_device_function,
+    stan::math::opencl_kernels::lbeta_device_function,
+    stan::math::opencl_kernels::binomial_coefficient_log_device_function)
 
-#undef ADD_BINARY_FUNCTION_WITH_INCLUDE
-#undef ADD_UNARY_FUNCTION_WITH_INCLUDE
+#undef ADD_BINARY_FUNCTION_WITH_INCLUDES
+#undef ADD_UNARY_FUNCTION_WITH_INCLUDES
 #undef ADD_UNARY_FUNCTION
 #undef ADD_UNARY_FUNCTION_PASS_ZERO
 #undef ADD_CLASSIFICATION_FUNCTION

--- a/test/unit/math/opencl/kernel_generator/elt_function_cl_test.cpp
+++ b/test/unit/math/opencl/kernel_generator/elt_function_cl_test.cpp
@@ -24,7 +24,7 @@ MatrixXd rsqrt(const MatrixXd& a) { return stan::math::inv_sqrt(a); }
 }  // namespace math
 }  // namespace stan
 
-#define TEST_FUNCTION(fun)                             \
+#define TEST_UNARY_FUNCTION(fun)                       \
   TEST(KernelGenerator, fun##_test) {                  \
     using stan::math::fun;                             \
     MatrixXd m1(3, 3);                                 \
@@ -39,28 +39,28 @@ MatrixXd rsqrt(const MatrixXd& a) { return stan::math::inv_sqrt(a); }
     EXPECT_NEAR_REL(correct, res);                     \
   }
 
-TEST_FUNCTION(rsqrt)
-TEST_FUNCTION(sqrt)
-TEST_FUNCTION(cbrt)
+TEST_UNARY_FUNCTION(rsqrt)
+TEST_UNARY_FUNCTION(sqrt)
+TEST_UNARY_FUNCTION(cbrt)
 
-TEST_FUNCTION(exp)
-TEST_FUNCTION(exp2)
-TEST_FUNCTION(expm1)
-TEST_FUNCTION(log)
-TEST_FUNCTION(log2)
-TEST_FUNCTION(log10)
-TEST_FUNCTION(log1p)
+TEST_UNARY_FUNCTION(exp)
+TEST_UNARY_FUNCTION(exp2)
+TEST_UNARY_FUNCTION(expm1)
+TEST_UNARY_FUNCTION(log)
+TEST_UNARY_FUNCTION(log2)
+TEST_UNARY_FUNCTION(log10)
+TEST_UNARY_FUNCTION(log1p)
 
-TEST_FUNCTION(sin)
-TEST_FUNCTION(sinh)
-TEST_FUNCTION(cos)
-TEST_FUNCTION(cosh)
-TEST_FUNCTION(tan)
-TEST_FUNCTION(tanh)
+TEST_UNARY_FUNCTION(sin)
+TEST_UNARY_FUNCTION(sinh)
+TEST_UNARY_FUNCTION(cos)
+TEST_UNARY_FUNCTION(cosh)
+TEST_UNARY_FUNCTION(tan)
+TEST_UNARY_FUNCTION(tanh)
 
-TEST_FUNCTION(asin)
-TEST_FUNCTION(asinh)
-TEST_FUNCTION(acos)
+TEST_UNARY_FUNCTION(asin)
+TEST_UNARY_FUNCTION(asinh)
+TEST_UNARY_FUNCTION(acos)
 
 TEST(KernelGenerator, acosh_test) {
   std::string kernel_filename = "unary_function_acosh.cl";
@@ -84,22 +84,21 @@ TEST(KernelGenerator, acosh_test) {
   EXPECT_NEAR_REL(correct, res);
 }
 
-TEST_FUNCTION(atan)
-TEST_FUNCTION(atanh)
+TEST_UNARY_FUNCTION(atan)
+TEST_UNARY_FUNCTION(atanh)
 
-TEST_FUNCTION(tgamma)
-TEST_FUNCTION(lgamma)
-TEST_FUNCTION(erf)
-TEST_FUNCTION(erfc)
+TEST_UNARY_FUNCTION(tgamma)
+TEST_UNARY_FUNCTION(lgamma)
+TEST_UNARY_FUNCTION(erf)
+TEST_UNARY_FUNCTION(erfc)
 
-TEST_FUNCTION(floor)
-TEST_FUNCTION(round)
-TEST_FUNCTION(ceil)
-TEST_FUNCTION(fabs)
-TEST_FUNCTION(trunc)
+TEST_UNARY_FUNCTION(floor)
+TEST_UNARY_FUNCTION(round)
+TEST_UNARY_FUNCTION(ceil)
+TEST_UNARY_FUNCTION(fabs)
+TEST_UNARY_FUNCTION(trunc)
 
-TEST_FUNCTION(digamma)
-TEST_FUNCTION(log1p_exp)
+TEST_UNARY_FUNCTION(digamma)
 TEST(KernelGenerator, log1m_exp_test) {
   MatrixXd m1(3, 3);
   m1 << -0.1, -0.2, -0.3, -0.4, -0.5, -0.6, -0.7, -0.8, -0.9;
@@ -112,6 +111,11 @@ TEST(KernelGenerator, log1m_exp_test) {
   MatrixXd correct = stan::math::log1m_exp(m1);
   EXPECT_NEAR_REL(correct, res);
 }
+TEST_UNARY_FUNCTION(log1p_exp)
+TEST_UNARY_FUNCTION(inv_square)
+TEST_UNARY_FUNCTION(inv_logit)
+TEST_UNARY_FUNCTION(logit)
+TEST_UNARY_FUNCTION(log1m_inv_logit)
 
 #define TEST_CLASSIFICATION_FUNCTION(fun)                                 \
   TEST(KernelGenerator, fun##_test) {                                     \
@@ -172,29 +176,46 @@ TEST(KernelGenerator, multiple_operations_with_includes_test) {
   EXPECT_NEAR_REL(correct, res);
 }
 
-TEST(KernelGenerator, pow_test) {
-  MatrixXd m1(3, 3);
-  m1 << -0.1, -0.2, -0.3, -0.4, -0.5, -0.6, -0.7, -0.8, -0.9;
-  MatrixXd m2(3, 3);
-  m1 << 1.1, 2.2, 1.3, 3.4, 4.5, 2.6, 117.2, 11.8, 0;
-  MatrixXi m3(3, 3);
-  m3 << -2, -1, 0, 1, 2, 3, 4, 5, 6;
+#define TEST_BINARY_FUNCTION(fun)                              \
+  TEST(KernelGenerator, fun##_test) {                          \
+    MatrixXd m1(3, 3);                                         \
+    m1 << 10.1, 11.2, 12.3, 13.4, 9.5, 24.6, 214.7, 12.8, 3.9; \
+    MatrixXd m2(3, 3);                                         \
+    m2 << 1.1, 2.2, 1.3, 3.4, 4.5, 2.6, 117.2, 11.8, 2.1;      \
+    MatrixXi m3(3, 3);                                         \
+    m3 << 2, 1, 3, 1, 2, 3, 4, 5, 3;                           \
+                                                               \
+    matrix_cl<double> m1_cl(m1);                               \
+    matrix_cl<double> m2_cl(m2);                               \
+    matrix_cl<int> m3_cl(m3);                                  \
+                                                               \
+    matrix_cl<double> res1_cl = fun(m1_cl, m2_cl);             \
+                                                               \
+    MatrixXd res1 = stan::math::from_matrix_cl(res1_cl);       \
+    MatrixXd correct1 = stan::math::fun(m1, m2);               \
+    EXPECT_NEAR_REL(correct1, res1);                           \
+                                                               \
+    matrix_cl<double> res2_cl = fun(m1_cl, m3_cl);             \
+                                                               \
+    MatrixXd res2 = stan::math::from_matrix_cl(res2_cl);       \
+    MatrixXd correct2 = stan::math::fun(m1, m3);               \
+    EXPECT_NEAR_REL(correct2, res2);                           \
+                                                               \
+    matrix_cl<double> res3_cl = fun(m1_cl, 2.2);               \
+                                                               \
+    MatrixXd res3 = stan::math::from_matrix_cl(res3_cl);       \
+    MatrixXd correct3 = stan::math::fun(m1, 2.2);              \
+    EXPECT_NEAR_REL(correct3, res3);                           \
+                                                               \
+    matrix_cl<double> res4_cl = fun(1000.1, m2_cl);            \
+                                                               \
+    MatrixXd res4 = stan::math::from_matrix_cl(res4_cl);       \
+    MatrixXd correct4 = stan::math::fun(1000.1, m2);           \
+    EXPECT_NEAR_REL(correct4, res4);                           \
+  }
 
-  matrix_cl<double> m1_cl(m1);
-  matrix_cl<double> m2_cl(m2);
-  matrix_cl<int> m3_cl(m3);
-
-  matrix_cl<double> res1_cl = pow(m1_cl, m2_cl);
-
-  MatrixXd res1 = stan::math::from_matrix_cl(res1_cl);
-  MatrixXd correct1 = stan::math::pow(m1, m2);
-  EXPECT_NEAR_REL(correct1, res1);
-
-  matrix_cl<double> res2_cl = pow(m1_cl, m3_cl);
-
-  MatrixXd res2 = stan::math::from_matrix_cl(res2_cl);
-  MatrixXd correct2 = stan::math::pow(m1, m3);
-  EXPECT_NEAR_REL(correct2, res2);
-}
+TEST_BINARY_FUNCTION(pow)
+TEST_BINARY_FUNCTION(lbeta)
+TEST_BINARY_FUNCTION(binomial_coefficient_log)
 
 #endif


### PR DESCRIPTION

## Summary

Added support for device functions with multiple includes to kernel generator. Added functions `lbeta` and `binomial_coefficient_log`.

## Tests

New functions are tested.

## Side Effects

None.

## Release notes

Added support for device functions with multiple includes to kernel generator. Added functions `lbeta` and `binomial_coefficient_log`.

## Checklist

- [ ] Math issue #2152 

- [ ] Copyright holder: Tadej Ciglarič

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [ ] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [ ] the code is written in idiomatic C++ and changes are documented in the doxygen

- [ ] the new changes are tested
