### PR TITLE
Minor GitHub Actions and runTests.py fixes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,8 +11,8 @@ on:
       - 'README.md'
       - 'RELEASE-NOTES.txt'
 jobs:
-  full:
-    name: Full unit tests
+  prim-rev:
+    name: prim and rev unit tests
     runs-on: windows-latest
 
     steps:
@@ -27,31 +27,71 @@ jobs:
       run: Start-Process -FilePath ./R35.exe -ArgumentList /VERYSILENT -NoNewWindow -Wait
     - name: PATH Setup
       shell: powershell
-      run: echo "::add-path::C:/Rtools/bin"
-    - name: PATH Setup
+      run: echo "C:/Rtools/bin;C:/Rtools/mingw_64/bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+    - name: Print g++ & make version and path
       shell: powershell
-      run: echo "::add-path::C:/Rtools/mingw_64/bin"
-    - name: Print g++ version
-      shell: powershell
-      run: g++ --version
-    - name: Print g++ path
-      shell: powershell
-      run: Get-Command g++ | Select-Object -ExpandProperty Definition
-    - name: Print mingw32-make version
-      shell: powershell
-      run: mingw32-make --version
-    - name: Print mingw32-make path
-      shell: powershell
-      run: Get-Command mingw32-make | Select-Object -ExpandProperty Definition
+      run: |
+        g++ --version
+        Get-Command g++ | Select-Object -ExpandProperty Definition
+        mingw32-make --version
+        Get-Command mingw32-make | Select-Object -ExpandProperty Definition
     - name: Build Math libs
       shell: powershell
       run: mingw32-make -f make/standalone math-libs
     - name: Add TBB to PATH
       shell: powershell
-      run: echo "::add-path::D:/a/math/math/lib/tbb"
-    - name: Run full unit tests
+      run: echo "D:/a/math/math/lib/tbb" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+    - name: Run prim and rev unit tests
       shell: powershell
-      run: python.exe runTests.py -j2 test/unit -f test/unit/
+      run: 
+        python.exe runTests.py -j2 test/unit/*_test.cpp
+        python.exe runTests.py -j2 test/unit/math/*_test.cpp
+        python.exe runTests.py -j2 test/unit/prim
+        python.exe runTests.py -j2 test/unit/rev
+        python.exe runTests.py -j2 test/unit/memory
+        
+    - name: Upload gtest_output xml
+      uses: actions/upload-artifact@v2
+      if: failure()
+      with:
+        name: gtest_outputs_xml
+        path: '**/*_test.xml'
+  fwd-mix:
+    name: fwd and mix unit tests
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '2.x'
+    - name: Download RTools
+      run: Invoke-WebRequest -Uri https://cran.rstudio.com/bin/windows/Rtools/Rtools35.exe -OutFile ./R35.exe
+    - name: Install RTools
+      shell: powershell
+      run: Start-Process -FilePath ./R35.exe -ArgumentList /VERYSILENT -NoNewWindow -Wait
+    - name: PATH Setup
+      shell: powershell
+      run: echo "C:/Rtools/bin;C:/Rtools/mingw_64/bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+    - name: Print g++ & make version and path
+      shell: powershell
+      run: |
+        g++ --version
+        Get-Command g++ | Select-Object -ExpandProperty Definition
+        mingw32-make --version
+        Get-Command mingw32-make | Select-Object -ExpandProperty Definition
+    - name: Build Math libs
+      shell: powershell
+      run: mingw32-make -f make/standalone math-libs
+    - name: Add TBB to PATH
+      shell: powershell
+      run: echo "D:/a/math/math/lib/tbb" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+    - name: Run prim and rev unit tests
+      shell: powershell
+      run: 
+        python.exe runTests.py -j2 test/unit/fwd
+        python.exe runTests.py -j2 test/unit/mix
+        
     - name: Upload gtest_output xml
       uses: actions/upload-artifact@v2
       if: failure()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -246,12 +246,12 @@ pipeline {
                         sh "echo OPENCL_DEVICE_ID=${OPENCL_DEVICE_ID}>> make/local"
                         runTests("test/unit/math/opencl")
 						runTests("test/unit/multiple_translation_units_test.cpp")
-                        runTests("test/unit/math/prim/fun/gp_exp_quad_cov_test")
-                        runTests("test/unit/math/prim/fun/mdivide_left_tri_test")
-                        runTests("test/unit/math/prim/fun/mdivide_right_tri_test")
-                        runTests("test/unit/math/prim/fun/multiply_test")
-                        runTests("test/unit/math/rev/fun/mdivide_left_tri_test")
-                        runTests("test/unit/math/rev/fun/multiply_test")
+                        runTests("test/unit/math/prim/fun/gp_exp_quad_cov_test.cpp")
+                        runTests("test/unit/math/prim/fun/mdivide_left_tri_test.cpp")
+                        runTests("test/unit/math/prim/fun/mdivide_right_tri_test.cpp")
+                        runTests("test/unit/math/prim/fun/multiply_test.cpp")
+                        runTests("test/unit/math/rev/fun/mdivide_left_tri_test.cpp")
+                        runTests("test/unit/math/rev/fun/multiply_test.cpp")
                     }
                     post { always { retry(3) { deleteDir() } } }
                 }
@@ -270,12 +270,13 @@ pipeline {
                         sh "echo OPENCL_PLATFORM_ID=0>> make/local"
                         sh "echo OPENCL_DEVICE_ID=${OPENCL_DEVICE_ID}>> make/local"
                         runTests("test/unit/math/opencl")
-                        runTests("test/unit/math/prim/fun/gp_exp_quad_cov_test")
-                        runTests("test/unit/math/prim/fun/mdivide_left_tri_test")
-                        runTests("test/unit/math/prim/fun/mdivide_right_tri_test")
-                        runTests("test/unit/math/prim/fun/multiply_test")
-                        runTests("test/unit/math/rev/fun/mdivide_left_tri_test")
-                        runTests("test/unit/math/rev/fun/multiply_test")
+						runTests("test/unit/multiple_translation_units_test.cpp")
+                        runTests("test/unit/math/prim/fun/gp_exp_quad_cov_test.cpp")
+                        runTests("test/unit/math/prim/fun/mdivide_left_tri_test.cpp")
+                        runTests("test/unit/math/prim/fun/mdivide_right_tri_test.cpp")
+                        runTests("test/unit/math/prim/fun/multiply_test.cpp")
+                        runTests("test/unit/math/rev/fun/mdivide_left_tri_test.cpp")
+                        runTests("test/unit/math/rev/fun/multiply_test.cpp")
                     }
                     post { always { retry(3) { deleteDir() } } }
                 }

--- a/runTests.py
+++ b/runTests.py
@@ -237,23 +237,24 @@ def runTest(name, run_all=False, mpi=False, j=1):
         command = "mpirun -np {} {}".format(j, command)
     doCommand(command, not run_all)
 
-def files_in_folder(folder):
-    """Returns a list of files in the folder and all
-    its subfolders recursively. The folder can be
-    written with wildcards as with the Unix find command.
+def test_files_in_folder(folder):
+    """Returns a list of test files (*_test.cpp) in the folder and all
+    its subfolders recursively. The folder can be written with
+    wildcards as with the Unix find command.
     """
     files = []
     for f in glob.glob(folder):
         if os.path.isdir(f):
-            files.extend(files_in_folder(f + os.sep + "**"))
+            files.extend(test_files_in_folder(f + os.sep + "**"))
         else:
-            files.append(f)
+            if f.endswith(testsfx):
+                files.append(f)
     return files
 
 def findTests(base_path, filter_names, do_jumbo=False):
     tests = []
     for path in base_path:
-        tests.extend(files_in_folder(path))
+        tests.extend(test_files_in_folder(path))
     tests = map(mungeName, tests)
     tests = [
         test

--- a/runTests.py
+++ b/runTests.py
@@ -254,7 +254,10 @@ def test_files_in_folder(folder):
 def findTests(base_path, filter_names, do_jumbo=False):
     tests = []
     for path in base_path:
-        tests.extend(test_files_in_folder(path))
+        if (not os.path.isdir(path)) and path.endswith("_test"):
+            tests.append(path+".cpp")
+        else:
+            tests.extend(test_files_in_folder(path))
     tests = map(mungeName, tests)
     tests = [
         test

--- a/runTests.py
+++ b/runTests.py
@@ -14,6 +14,7 @@ import platform
 import subprocess
 import sys
 import time
+import glob
 import re
 
 winsfx = ".exe"
@@ -236,17 +237,23 @@ def runTest(name, run_all=False, mpi=False, j=1):
         command = "mpirun -np {} {}".format(j, command)
     doCommand(command, not run_all)
 
+def files_in_folder(folder):
+    """Returns a list of files in the folder and all
+    its subfolders recursively. The folder can be
+    written with wildcards as with the Unix find command.
+    """
+    files = []
+    for f in glob.glob(folder):
+        if os.path.isdir(f):
+            files.extend(files_in_folder(f + os.sep + "**"))
+        else:
+            files.append(f)
+    return files
 
 def findTests(base_path, filter_names, do_jumbo=False):
-    folders = filter(os.path.isdir, base_path)
-    nonfolders = list(set(base_path) - set(folders))
-    tests = nonfolders + [
-        os.path.join(root, n)
-        for f in folders
-        for root, _, names in os.walk(f)
-        for n in names
-        if n.endswith(testsfx)
-    ]
+    tests = []
+    for path in base_path:
+        tests.extend(files_in_folder(path))
     tests = map(mungeName, tests)
     tests = [
         test


### PR DESCRIPTION
## Summary

This PR fixes three separate problems: 
  - splits Github Actions Windows 3.5 tests in two parts (fwd&mix and everything else). We have been hitting the 6 hour limit occasionally with the full test.
 - replaces the use of `::add-path::` that was disabled on Github Actions (see https://github.com/stan-dev/math/runs/1418393578)
 - fixes a problem for running test on Windows. Commands like `./runTests.py test/unit/*_test.cpp` did not work on Windows. On Unix the cmd line resolves `test/unit/*_test.cpp` to all the files that match it, so the call there is actually `./runTests.py test/unit/math_c11_test.cpp test/unit/math_include_test.cpp test/unit/multiple_translation_units_test.cpp`. On windows this doesnt resolve beforehand. We now do it in the runTests script.
## Tests

/

## Side Effects

/

## Checklist

- [x] Copyright holder: Rok Češnovar

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
