### PR TITLE
Fix develop CI issue

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,8 +1,6 @@
 name: Windows RTools 3.5
 
 on:
-  pull_request:
-    branches: [ develop ]
   push:
     branches: [ develop ]
     paths-ignore:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,8 @@
 name: Windows RTools 3.5
 
 on:
+  pull_request:
+    branches: [ develop ]
   push:
     branches: [ develop ]
     paths-ignore:
@@ -43,7 +45,7 @@ jobs:
       run: echo "D:/a/math/math/lib/tbb" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
     - name: Run prim and rev unit tests
       shell: powershell
-      run: 
+      run: |
         python.exe runTests.py -j2 test/unit/*_test.cpp
         python.exe runTests.py -j2 test/unit/math/*_test.cpp
         python.exe runTests.py -j2 test/unit/prim
@@ -88,7 +90,7 @@ jobs:
       run: echo "D:/a/math/math/lib/tbb" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
     - name: Run prim and rev unit tests
       shell: powershell
-      run: 
+      run: |
         python.exe runTests.py -j2 test/unit/fwd
         python.exe runTests.py -j2 test/unit/mix
         

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,9 +48,9 @@ jobs:
       run: |
         python.exe runTests.py -j2 test/unit/*_test.cpp
         python.exe runTests.py -j2 test/unit/math/*_test.cpp
-        python.exe runTests.py -j2 test/unit/prim
-        python.exe runTests.py -j2 test/unit/rev
-        python.exe runTests.py -j2 test/unit/memory
+        python.exe runTests.py -j2 test/unit/math/prim
+        python.exe runTests.py -j2 test/unit/math/rev
+        python.exe runTests.py -j2 test/unit/math/memory
         
     - name: Upload gtest_output xml
       uses: actions/upload-artifact@v2
@@ -88,11 +88,11 @@ jobs:
     - name: Add TBB to PATH
       shell: powershell
       run: echo "D:/a/math/math/lib/tbb" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
-    - name: Run prim and rev unit tests
+    - name: Run fwd and mix unit tests
       shell: powershell
       run: |
-        python.exe runTests.py -j2 test/unit/fwd
-        python.exe runTests.py -j2 test/unit/mix
+        python.exe runTests.py -j2 test/unit/math/fwd
+        python.exe runTests.py -j2 test/unit/math/mix
         
     - name: Upload gtest_output xml
       uses: actions/upload-artifact@v2


### PR DESCRIPTION
## Summary

There was a bug in #2202 (missing | and wrong paths) that makes the job fail. This PR fixes that.

First trying to run the job on PR to make sure. See succesful run here: https://github.com/stan-dev/math/runs/1439204763

## Checklist


- [x] Copyright holder: Rok Češnovar

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
