### PR TITLE
Bugfix exp_mod_normal_lpdf OpenCL test values

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -234,7 +234,7 @@ pipeline {
                         sh "echo OPENCL_PLATFORM_ID=0>> make/local"
                         sh "echo OPENCL_DEVICE_ID=${OPENCL_DEVICE_ID}>> make/local"
                         runTests("test/unit/math/opencl")
-						runTests("test/unit/multiple_translation_units_test.cpp")
+                        runTests("test/unit/multiple_translation_units_test.cpp")
                         runTests("test/unit/math/prim/fun/gp_exp_quad_cov_test.cpp")
                         runTests("test/unit/math/prim/fun/mdivide_left_tri_test.cpp")
                         runTests("test/unit/math/prim/fun/mdivide_right_tri_test.cpp")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,8 +36,6 @@ def deleteDirWin() {
 }
 
 def skipRemainingStages = false
-def runGpuAsync = false
-def openClGpuLabel = "gpu"
 
 def utils = new org.stan.Utils()
 
@@ -60,7 +58,6 @@ pipeline {
         string(defaultValue: '', name: 'cmdstan_pr', description: 'PR to test CmdStan upstream against e.g. PR-630')
         string(defaultValue: '', name: 'stan_pr', description: 'PR to test Stan upstream against e.g. PR-630')
         booleanParam(defaultValue: false, name: 'withRowVector', description: 'Run additional distribution tests on RowVectors (takes 5x as long)')
-        booleanParam(defaultValue: false, name: 'gpu_async', description: 'Run the OpenCL tests on both a sync (AMD) GPU and an async (NVIDIA) one.')
         booleanParam(defaultValue: false, name: 'run_win_tests', description: 'Run full unit tests on Windows.')
     }
     options {
@@ -167,14 +164,6 @@ pipeline {
 
                     def paths = ['stan', 'make', 'lib', 'test', 'runTests.py', 'runChecks.py', 'makefile', 'Jenkinsfile', '.clang-format'].join(" ")
                     skipRemainingStages = utils.verifyChanges(paths)
-
-                    if(!utils.verifyChanges(["stan/math/opencl", "test/unit/math/opencl"].join(" ")) || params.gpu_async){
-                        runGpuAsync = true
-                        openClGpuLabel = "gpu-no-async"
-                    }
-                    else{
-                        runGpuAsync = false
-                    }
                 }
             }
         }
@@ -236,32 +225,7 @@ pipeline {
                     post { always { retry(3) { deleteDir() } } }
                 }
                 stage('OpenCL tests') {
-                    agent { label openClGpuLabel }
-                    steps {
-                        deleteDir()
-                        unstash 'MathSetup'
-                        sh "echo CXX=${env.CXX} -Werror > make/local"
-                        sh "echo STAN_OPENCL=true>> make/local"
-                        sh "echo OPENCL_PLATFORM_ID=0>> make/local"
-                        sh "echo OPENCL_DEVICE_ID=${OPENCL_DEVICE_ID}>> make/local"
-                        runTests("test/unit/math/opencl")
-						runTests("test/unit/multiple_translation_units_test.cpp")
-                        runTests("test/unit/math/prim/fun/gp_exp_quad_cov_test.cpp")
-                        runTests("test/unit/math/prim/fun/mdivide_left_tri_test.cpp")
-                        runTests("test/unit/math/prim/fun/mdivide_right_tri_test.cpp")
-                        runTests("test/unit/math/prim/fun/multiply_test.cpp")
-                        runTests("test/unit/math/rev/fun/mdivide_left_tri_test.cpp")
-                        runTests("test/unit/math/rev/fun/multiply_test.cpp")
-                    }
-                    post { always { retry(3) { deleteDir() } } }
-                }
-                stage('OpenCL tests async') {
-                    agent { label "gpu-async" }
-                    when {
-                        expression {
-                            runGpuAsync
-                        }
-                    }
+                    agent { label "gg-linux" }
                     steps {
                         deleteDir()
                         unstash 'MathSetup'

--- a/test/unit/math/opencl/rev/exp_mod_normal_lpdf_test.cpp
+++ b/test/unit/math/opencl/rev/exp_mod_normal_lpdf_test.cpp
@@ -197,7 +197,8 @@ TEST(ProbDistributionsExpModNormal, opencl_matches_cpu_big) {
   Eigen::Matrix<double, Eigen::Dynamic, 1> mu
       = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
   Eigen::Matrix<double, Eigen::Dynamic, 1> sigma
-      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs().array() + 0.1;
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs().array()
+        + 0.1;
   Eigen::Matrix<double, Eigen::Dynamic, 1> lambda
       = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
 

--- a/test/unit/math/opencl/rev/exp_mod_normal_lpdf_test.cpp
+++ b/test/unit/math/opencl/rev/exp_mod_normal_lpdf_test.cpp
@@ -16,7 +16,7 @@ TEST(ProbDistributionsExpModNormal, error_checking) {
   y_value << NAN, 0.5, 0.99;
 
   Eigen::VectorXd mu(N);
-  mu << -10.3, 0.8, 21.0;
+  mu << -10.3, 0.8, 2.1;
   Eigen::VectorXd mu_size(N - 1);
   mu_size << 0.3, 0.8;
   Eigen::VectorXd mu_value(N);
@@ -32,7 +32,7 @@ TEST(ProbDistributionsExpModNormal, error_checking) {
   sigma_value2 << 0.3, INFINITY, 0.5;
 
   Eigen::VectorXd lambda(N);
-  lambda << 0.3, 0.8, 13.0;
+  lambda << 0.3, 0.8, 1.3;
   Eigen::VectorXd lambda_size(N - 1);
   lambda_size << 0.3, 0.8;
   Eigen::VectorXd lambda_value1(N);
@@ -109,11 +109,11 @@ TEST(ProbDistributionsExpModNormal, opencl_matches_cpu_small) {
   Eigen::VectorXd y(N);
   y << 0, 0.5, 1;
   Eigen::VectorXd mu(N);
-  mu << -10.3, 0.8, 21.0;
+  mu << -10.3, 0.8, 2.1;
   Eigen::VectorXd sigma(N);
   sigma << 0.3, 0.8, 11.0;
   Eigen::VectorXd lambda(N);
-  lambda << 0.3, 0.8, 13.0;
+  lambda << 0.3, 0.8, 1.30;
 
   stan::math::test::compare_cpu_opencl_prim_rev(exp_mod_normal_lpdf_functor, y,
                                                 mu, sigma, lambda);
@@ -126,11 +126,11 @@ TEST(ProbDistributionsExpModNormal, opencl_broadcast_y) {
 
   double y = 0.3;
   Eigen::VectorXd mu(N);
-  mu << -10.3, 0.8, 21.0;
+  mu << -10.3, 0.8, 2.1;
   Eigen::VectorXd sigma(N);
   sigma << 0.3, 0.8, 11.0;
   Eigen::VectorXd lambda(N);
-  lambda << 0.3, 0.8, 13.0;
+  lambda << 0.3, 0.8, 1.3;
 
   stan::math::test::test_opencl_broadcasting_prim_rev<0>(
       exp_mod_normal_lpdf_functor, y, mu, sigma, lambda);
@@ -147,7 +147,7 @@ TEST(ProbDistributionsExpModNormal, opencl_broadcast_mu) {
   Eigen::VectorXd sigma(N);
   sigma << 0.3, 0.8, 11.0;
   Eigen::VectorXd lambda(N);
-  lambda << 0.3, 0.8, 13.0;
+  lambda << 0.3, 0.8, 1.3;
 
   stan::math::test::test_opencl_broadcasting_prim_rev<1>(
       exp_mod_normal_lpdf_functor, y, mu, sigma, lambda);
@@ -161,10 +161,10 @@ TEST(ProbDistributionsExpModNormal, opencl_broadcast_sigma) {
   Eigen::VectorXd y(N);
   y << 0, 0.5, 1;
   Eigen::VectorXd mu(N);
-  mu << -10.3, 0.8, 21.0;
+  mu << -10.3, 0.8, 2.1;
   double sigma = 0.8;
   Eigen::VectorXd lambda(N);
-  lambda << 0.3, 0.8, 13.0;
+  lambda << 0.3, 0.8, 1.3;
 
   stan::math::test::test_opencl_broadcasting_prim_rev<2>(
       exp_mod_normal_lpdf_functor, y, mu, sigma, lambda);
@@ -178,7 +178,7 @@ TEST(ProbDistributionsExpModNormal, opencl_broadcast_lambda) {
   Eigen::VectorXd y(N);
   y << 0, 0.5, 1;
   Eigen::VectorXd mu(N);
-  mu << -10.3, 0.8, 21.0;
+  mu << -10.3, 0.8, 2.1;
   Eigen::VectorXd sigma(N);
   sigma << 0.3, 0.8, 11.0;
   double lambda = 1.2;
@@ -197,7 +197,7 @@ TEST(ProbDistributionsExpModNormal, opencl_matches_cpu_big) {
   Eigen::Matrix<double, Eigen::Dynamic, 1> mu
       = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
   Eigen::Matrix<double, Eigen::Dynamic, 1> sigma
-      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs().array() + 0.1;
   Eigen::Matrix<double, Eigen::Dynamic, 1> lambda
       = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
 


### PR DESCRIPTION
## Summary

Due to poorly chosen values in OpenCL tests for `exp_mod_normal_lpdf` we were getting division by zero. Standard says this is undefined operation and we were getting different results on some OpenCL devices. This PR fixes test values so this does not happen.

## Tests
This whole thing.

## Side Effects
None.


## Checklist

- [ ] Math issue #2152

- [ ] Copyright holder: Tadej Ciglarič

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [ ] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [ ] the code is written in idiomatic C++ and changes are documented in the doxygen

- [ ] the new changes are tested
