### PR TITLE
adding arm64 architecture to build parameters for macos

### DIFF
--- a/lib/tbb_2019_U8/build/macos.inc
+++ b/lib/tbb_2019_U8/build/macos.inc
@@ -36,11 +36,15 @@ ifndef arch
      export arch:=ppc32
    endif
  else
+  ifeq ($(shell /usr/sbin/sysctl -n hw.machine),arm64)
+   export arch:=arm64
+  else
    ifeq ($(shell /usr/sbin/sysctl -n hw.optional.x86_64 2>/dev/null),1)
      export arch:=intel64
    else
      export arch:=ia32
    endif
+  endif
  endif
 endif
 


### PR DESCRIPTION
## Summary

This commit adds arm64 specific definitions to TBB necessary for building on M1 Macs. It was taken from https://github.com/oneapi-src/oneTBB/pull/294

I've been able to run arm64-compiled Stan models from within a Rosetta2 RStudio/R environment using cmdstanr as follows:

model=cmdstanr::cmdstan_model('test.stan', cpp_options=list(CXX="arch -arch arm64e clang++"))

This should provide a speed up while we wait for the rest of the R ecosystem to update.

## Tests

Compilation fails on ARM Macs when this pull request is not in place.

## Side Effects

None as far as I know.

## Release notes

Compiles on M1 Macs.

## Checklist

- [ ] Math issue #(issue number)
None yet.
- [√] Copyright holder:
@jsbache , https://github.com/oneapi-src/oneTBB/pull/294
- [] the basic tests are passing

These are running now, but this pull request addresses a compilation error.

- [NA] the code is written in idiomatic C++ and changes are documented in the doxygen

- [√] the new changes are tested
