### PR TITLE
Bugfix kg caching

### DIFF
--- a/stan/math/opencl/kernel_generator.hpp
+++ b/stan/math/opencl/kernel_generator.hpp
@@ -75,17 +75,6 @@
  * operations that are broadcast so their exact size is not known.
  *     - Default: Bottom diagonal equals to min of bottom diagonals of
  * arguments. Top diagonal equals to max of top diagonals of arguments.
- * - `void get_unique_matrix_accesses(std::vector<int>& uids, std::map<const
- * void*, int>& id_map, int& next_id)`:
- *     - Determines unique accesses to `matrix_cl`'s. On return `uids` contain
- * one number per matrix access, different numbers meaning accesses to different
- * matrices. `id_map` is used internally to determine whether a matrix is
- * unique. It maps from pointerers to matrices to their unique ids. `next_id`
- * reference to next unused index that can be used for new unique matrix. Once a
- * new unique access is added `next_id` is inremented.
- *     - Default: calls `get_unique_matrix_accesses` on expression arguments. If
- * this expression overrides the default `modify_argument_indices` new set of
- * ids is used even if accesses are made to same matrices.
  *
  * If an operation should support being assigned to it should also define the
  * following:

--- a/stan/math/opencl/kernel_generator.hpp
+++ b/stan/math/opencl/kernel_generator.hpp
@@ -24,8 +24,8 @@
  *
  * ## Defining a new kernel generator operation
  *
- * Unary functions can be added using one of the macros in
- * `unary_functions.hpp`.
+ * Element-wise functions can be added using one of the macros in
+ * `elt_functions.hpp`.
  *
  * New kernel generator classes must satsify the conditions below:
  *
@@ -75,6 +75,17 @@
  * operations that are broadcast so their exact size is not known.
  *     - Default: Bottom diagonal equals to min of bottom diagonals of
  * arguments. Top diagonal equals to max of top diagonals of arguments.
+ * - `void get_unique_matrix_accesses(std::vector<int>& uids, std::map<const
+ * void*, int>& id_map, int& next_id)`:
+ *     - Determines unique accesses to `matrix_cl`'s. On return `uids` contain
+ * one number per matrix access, different numbers meaning accesses to different
+ * matrices. `id_map` is used internally to determine whether a matrix is
+ * unique. It maps from pointerers to matrices to their unique ids. `next_id`
+ * reference to next unused index that can be used for new unique matrix. Once a
+ * new unique access is added `next_id` is inremented.
+ *     - Default: calls `get_unique_matrix_accesses` on expression arguments. If
+ * this expression overrides the default `modify_argument_indices` new set of
+ * ids is used even if accesses are made to same matrices.
  *
  * If an operation should support being assigned to it should also define the
  * following:

--- a/stan/math/opencl/kernel_generator/append.hpp
+++ b/stan/math/opencl/kernel_generator/append.hpp
@@ -15,7 +15,7 @@
 #include <string>
 #include <tuple>
 #include <type_traits>
-#include <set>
+#include <map>
 #include <utility>
 
 namespace stan {
@@ -85,19 +85,20 @@ class append_row_ : public operation_cl<append_row_<T_a, T_b>,
    * @return part of kernel with code for this and nested expressions
    */
   inline kernel_parts get_kernel_parts(
-      std::set<const operation_cl_base*>& generated, name_generator& name_gen,
+      std::map<const void*, const char*>& generated, name_generator& name_gen,
       const std::string& row_index_name, const std::string& col_index_name,
       bool view_handled) const {
     kernel_parts res{};
     if (generated.count(this) == 0) {
       var_name_ = name_gen.generate();
-      generated.insert(this);
-      std::string row_index_name_b
-          = "(" + row_index_name + " - " + var_name_ + "_first_rows)";
+      generated[this] = "";
       kernel_parts parts_a = this->template get_arg<0>().get_kernel_parts(
           generated, name_gen, row_index_name, col_index_name, true);
+      std::string row_index_name_b
+          = "(" + row_index_name + " - " + var_name_ + "_first_rows)";
+      std::map<const void*, const char*> generated_b;
       kernel_parts parts_b = this->template get_arg<1>().get_kernel_parts(
-          generated, name_gen, row_index_name_b, col_index_name, true);
+          generated_b, name_gen, row_index_name_b, col_index_name, true);
       res = parts_a + parts_b;
       res.body = type_str<Scalar>() + " " + var_name_ + ";\n"
           "if("+ row_index_name +" < " + var_name_ + "_first_rows){\n"
@@ -120,12 +121,13 @@ class append_row_ : public operation_cl<append_row_<T_a, T_b>,
    * @param[in,out] arg_num consecutive number of the first argument to set.
    * This is incremented for each argument set by this function.
    */
-  inline void set_args(std::set<const operation_cl_base*>& generated,
+  inline void set_args(std::map<const void*, const char*>& generated,
                        cl::Kernel& kernel, int& arg_num) const {
     if (generated.count(this) == 0) {
-      generated.insert(this);
+      generated[this] = "";
       this->template get_arg<0>().set_args(generated, kernel, arg_num);
-      this->template get_arg<1>().set_args(generated, kernel, arg_num);
+      std::map<const void*, const char*> generated_b;
+      this->template get_arg<1>().set_args(generated_b, kernel, arg_num);
       kernel.setArg(arg_num++, this->template get_arg<0>().rows());
     }
   }
@@ -234,19 +236,20 @@ class append_col_ : public operation_cl<append_col_<T_a, T_b>,
    * @return part of kernel with code for this and nested expressions
    */
   inline kernel_parts get_kernel_parts(
-      std::set<const operation_cl_base*>& generated, name_generator& name_gen,
+      std::map<const void*, const char*>& generated, name_generator& name_gen,
       const std::string& row_index_name, const std::string& col_index_name,
       bool view_handled) const {
     kernel_parts res{};
     if (generated.count(this) == 0) {
       var_name_ = name_gen.generate();
-      generated.insert(this);
-      std::string col_index_name_b
-          = "(" + col_index_name + " - " + var_name_ + "_first_cols)";
+      generated[this] = "";
       kernel_parts parts_a = this->template get_arg<0>().get_kernel_parts(
           generated, name_gen, row_index_name, col_index_name, true);
+      std::string col_index_name_b
+          = "(" + col_index_name + " - " + var_name_ + "_first_cols)";
+      std::map<const void*, const char*> generated_b;
       kernel_parts parts_b = this->template get_arg<1>().get_kernel_parts(
-          generated, name_gen, row_index_name, col_index_name_b, true);
+          generated_b, name_gen, row_index_name, col_index_name_b, true);
       res = parts_a + parts_b;
       res.body = type_str<Scalar>() + " " + var_name_ + ";\n"
           "if("+ col_index_name +" < " + var_name_ + "_first_cols){\n"
@@ -269,12 +272,13 @@ class append_col_ : public operation_cl<append_col_<T_a, T_b>,
    * @param[in,out] arg_num consecutive number of the first argument to set.
    * This is incremented for each argument set by this function.
    */
-  inline void set_args(std::set<const operation_cl_base*>& generated,
+  inline void set_args(std::map<const void*, const char*>& generated,
                        cl::Kernel& kernel, int& arg_num) const {
     if (generated.count(this) == 0) {
-      generated.insert(this);
+      generated[this] = "";
       this->template get_arg<0>().set_args(generated, kernel, arg_num);
-      this->template get_arg<1>().set_args(generated, kernel, arg_num);
+      std::map<const void*, const char*> generated_b;
+      this->template get_arg<1>().set_args(generated_b, kernel, arg_num);
       kernel.setArg(arg_num++, this->template get_arg<0>().cols());
     }
   }

--- a/stan/math/opencl/kernel_generator/append.hpp
+++ b/stan/math/opencl/kernel_generator/append.hpp
@@ -77,7 +77,8 @@ class append_row_ : public operation_cl<append_row_<T_a, T_b>,
 
   /**
    * Generates kernel code for this and nested expressions.
-   * @param[in,out] generated set of (pointer to) already generated operations
+   * @param[in,out] generated map from (pointer to) already generated operations
+   * to variable names
    * @param name_gen name generator for this kernel
    * @param row_index_name row index variable name
    * @param col_index_name column index variable name
@@ -115,7 +116,7 @@ class append_row_ : public operation_cl<append_row_<T_a, T_b>,
 
   /**
    * Sets kernel arguments for this and nested expressions.
-   * @param[in,out] generated set of expressions that already set their kernel
+   * @param[in,out] generated map of expressions that already set their kernel
    * arguments
    * @param kernel kernel to set arguments on
    * @param[in,out] arg_num consecutive number of the first argument to set.
@@ -228,7 +229,8 @@ class append_col_ : public operation_cl<append_col_<T_a, T_b>,
 
   /**
    * Generates kernel code for this and nested expressions.
-   * @param[in,out] generated set of (pointer to) already generated operations
+   * @param[in,out] generated map from (pointer to) already generated operations
+   * to variable names
    * @param name_gen name generator for this kernel
    * @param row_index_name row index variable name
    * @param col_index_name column index variable name
@@ -266,7 +268,7 @@ class append_col_ : public operation_cl<append_col_<T_a, T_b>,
 
   /**
    * Sets kernel arguments for this and nested expressions.
-   * @param[in,out] generated set of expressions that already set their kernel
+   * @param[in,out] generated map of expressions that already set their kernel
    * arguments
    * @param kernel kernel to set arguments on
    * @param[in,out] arg_num consecutive number of the first argument to set.

--- a/stan/math/opencl/kernel_generator/binary_operation.hpp
+++ b/stan/math/opencl/kernel_generator/binary_operation.hpp
@@ -15,7 +15,6 @@
 #include <string>
 #include <tuple>
 #include <type_traits>
-#include <set>
 #include <utility>
 
 namespace stan {

--- a/stan/math/opencl/kernel_generator/block.hpp
+++ b/stan/math/opencl/kernel_generator/block.hpp
@@ -156,7 +156,8 @@ class block_
   /**
    * Generates kernel code for this expression if it appears on the left hand
    * side of an assignment.
-   * @param[in,out] generated set of (pointer to) already generated operations
+   * @param[in,out] generated map from (pointer to) already generated operations
+   * to variable names
    * @param name_gen name generator for this kernel
    * @param row_index_name row index variable name
    * @param col_index_name column index variable name
@@ -203,7 +204,7 @@ class block_
 
   /**
    * Sets kernel arguments for this and nested expressions.
-   * @param[in,out] generated set of expressions that already set their kernel
+   * @param[in,out] generated map of expressions that already set their kernel
    * arguments
    * @param kernel kernel to set arguments on
    * @param[in,out] arg_num consecutive number of the first argument to set.

--- a/stan/math/opencl/kernel_generator/block.hpp
+++ b/stan/math/opencl/kernel_generator/block.hpp
@@ -9,7 +9,7 @@
 #include <stan/math/opencl/kernel_generator/name_generator.hpp>
 #include <stan/math/opencl/kernel_generator/operation_cl_lhs.hpp>
 #include <stan/math/opencl/kernel_generator/as_operation_cl.hpp>
-#include <set>
+#include <map>
 #include <string>
 #include <tuple>
 #include <type_traits>
@@ -143,10 +143,10 @@ class block_
    * @param[in,out] arg_num consecutive number of the first argument to set.
    * This is incremented for each argument set by this function.
    */
-  inline void set_args(std::set<const operation_cl_base*>& generated,
+  inline void set_args(std::map<const void*, const char*>& generated,
                        cl::Kernel& kernel, int& arg_num) const {
     if (generated.count(this) == 0) {
-      generated.insert(this);
+      generated[this] = "";
       this->template get_arg<0>().set_args(generated, kernel, arg_num);
       kernel.setArg(arg_num++, start_row_);
       kernel.setArg(arg_num++, start_col_);

--- a/stan/math/opencl/kernel_generator/block.hpp
+++ b/stan/math/opencl/kernel_generator/block.hpp
@@ -40,6 +40,7 @@ class block_
 
  protected:
   int start_row_, start_col_, rows_, cols_;
+  mutable std::map<const void*, const char*> generated_;
 
  public:
   /**
@@ -89,6 +90,39 @@ class block_
   }
 
   /**
+   * Generates kernel code for this and nested expressions.
+   * @param[in,out] generated map from (pointer to) already generated operations
+   * to variable names
+   * @param name_gen name generator for this kernel
+   * @param row_index_name row index variable name
+   * @param col_index_name column index variable name
+   * @param view_handled whether caller already handled matrix view
+   * @return part of kernel with code for this and nested expressions
+   */
+  inline kernel_parts get_kernel_parts(
+      std::map<const void*, const char*>& generated, name_generator& name_gen,
+      const std::string& row_index_name, const std::string& col_index_name,
+      bool view_handled) const {
+    kernel_parts res{};
+    if (generated.count(this) == 0) {
+      this->var_name_ = name_gen.generate();
+      generated[this] = "";
+      generated_.clear();
+      std::string row_index_name_arg = row_index_name;
+      std::string col_index_name_arg = col_index_name;
+      modify_argument_indices(row_index_name_arg, col_index_name_arg);
+      res = this->template get_arg<0>().get_kernel_parts(
+          generated_, name_gen, row_index_name_arg, col_index_name_arg,
+          view_handled);
+      res += this->generate(row_index_name, col_index_name, view_handled,
+                            this->template get_arg<0>().var_name_);
+      res.body = res.body_prefix + res.body;
+      res.body_prefix = "";
+    }
+    return res;
+  }
+
+  /**
    * Generates kernel code for this expression.
    * @param row_index_name row index variable name
    * @param col_index_name column index variable name
@@ -120,6 +154,38 @@ class block_
   }
 
   /**
+   * Generates kernel code for this expression if it appears on the left hand
+   * side of an assignment.
+   * @param[in,out] generated set of (pointer to) already generated operations
+   * @param name_gen name generator for this kernel
+   * @param row_index_name row index variable name
+   * @param col_index_name column index variable name
+   * @return part of kernel with code for this expressions
+   */
+  inline kernel_parts get_kernel_parts_lhs(
+      std::map<const void*, const char*>& generated, name_generator& name_gen,
+      const std::string& row_index_name,
+      const std::string& col_index_name) const {
+    if (generated.count(this) == 0) {
+      this->var_name_ = name_gen.generate();
+      generated_.clear();
+    }
+    std::string row_index_name_arg = row_index_name;
+    std::string col_index_name_arg = col_index_name;
+    modify_argument_indices(row_index_name_arg, col_index_name_arg);
+    kernel_parts res = this->template get_arg<0>().get_kernel_parts_lhs(
+        generated_, name_gen, row_index_name_arg, col_index_name_arg);
+    res += this->derived().generate_lhs(row_index_name, col_index_name,
+                                        this->template get_arg<0>().var_name_);
+    if (generated.count(this) == 0) {
+      generated[this] = "";
+    } else {
+      res.args = "";
+    }
+    return res;
+  }
+
+  /**
    * Generates kernel code for this and nested expressions if this expression
    * appears on the left hand side of an assignment.
    * @param i row index variable name
@@ -147,7 +213,8 @@ class block_
                        cl::Kernel& kernel, int& arg_num) const {
     if (generated.count(this) == 0) {
       generated[this] = "";
-      this->template get_arg<0>().set_args(generated, kernel, arg_num);
+      std::map<const void*, const char*> generated2;
+      this->template get_arg<0>().set_args(generated2, kernel, arg_num);
       kernel.setArg(arg_num++, start_row_);
       kernel.setArg(arg_num++, start_col_);
     }
@@ -214,7 +281,7 @@ class block_
   }
 };
 
-/**
+  /**
  * Block of a kernel generator expression.
  *
  * Block operation modifies how its argument is indexed. If a matrix is both an

--- a/stan/math/opencl/kernel_generator/block.hpp
+++ b/stan/math/opencl/kernel_generator/block.hpp
@@ -282,7 +282,7 @@ class block_
   }
 };
 
-  /**
+/**
  * Block of a kernel generator expression.
  *
  * Block operation modifies how its argument is indexed. If a matrix is both an

--- a/stan/math/opencl/kernel_generator/calc_if.hpp
+++ b/stan/math/opencl/kernel_generator/calc_if.hpp
@@ -10,7 +10,7 @@
 #include <stan/math/opencl/kernel_generator/as_operation_cl.hpp>
 #include <string>
 #include <type_traits>
-#include <set>
+#include <map>
 #include <utility>
 
 namespace stan {
@@ -63,7 +63,7 @@ class calc_if_
    */
   template <typename T_result>
   kernel_parts get_whole_kernel_parts(
-      std::set<const operation_cl_base*>& generated, name_generator& ng,
+      std::map<const void*, const char*>& generated, name_generator& ng,
       const std::string& row_index_name, const std::string& col_index_name,
       const T_result& result) const {
     if (Do_Calculate) {
@@ -82,7 +82,7 @@ class calc_if_
    * @param[in,out] arg_num consecutive number of the first argument to set.
    * This is incremented for each argument set by this function.
    */
-  inline void set_args(std::set<const operation_cl_base*>& generated,
+  inline void set_args(std::map<const void*, const char*>& generated,
                        cl::Kernel& kernel, int& arg_num) const {
     if (Do_Calculate) {
       this->template get_arg<0>().set_args(generated, kernel, arg_num);

--- a/stan/math/opencl/kernel_generator/calc_if.hpp
+++ b/stan/math/opencl/kernel_generator/calc_if.hpp
@@ -52,7 +52,8 @@ class calc_if_
 
   /**
    * Generates kernel code for assigning this expression into result expression.
-   * @param[in,out] generated set of (pointer to) already generated operations
+   * @param[in,out] generated map from (pointer to) already generated operations
+   * to variable names
    * @param ng name generator for this kernel
    * @param row_index_name row index variable name
    * @param col_index_name column index variable name
@@ -76,7 +77,7 @@ class calc_if_
 
   /**
    * Sets kernel arguments for nested expressions.
-   * @param[in,out] generated set of expressions that already set their kernel
+   * @param[in,out] generated map of expressions that already set their kernel
    * arguments
    * @param kernel kernel to set arguments on
    * @param[in,out] arg_num consecutive number of the first argument to set.

--- a/stan/math/opencl/kernel_generator/check_cl.hpp
+++ b/stan/math/opencl/kernel_generator/check_cl.hpp
@@ -67,7 +67,8 @@ class check_cl_ : public operation_cl_lhs<check_cl_<T>, bool> {
 
   /**
    * Generates kernel code for this and nested expressions.
-   * @param[in,out] generated set of (pointer to) already generated operations
+   * @param[in,out] generated map from (pointer to) already generated operations
+   * to variable names
    * @param name_gen name generator for this kernel
    * @param row_index_name row index variable name
    * @param col_index_name column index variable name
@@ -99,7 +100,7 @@ class check_cl_ : public operation_cl_lhs<check_cl_<T>, bool> {
 
   /**
    * Sets kernel arguments for this expression.
-   * @param[in,out] generated set of expressions that already set their kernel
+   * @param[in,out] generated map of expressions that already set their kernel
    * arguments
    * @param kernel kernel to set arguments on
    * @param[in,out] arg_num consecutive number of the first argument to set.

--- a/stan/math/opencl/kernel_generator/check_cl.hpp
+++ b/stan/math/opencl/kernel_generator/check_cl.hpp
@@ -87,7 +87,7 @@ class check_cl_ : public operation_cl_lhs<check_cl_<T>, bool> {
     res.args += "__global int* " + var_name_ + "_buffer, __global "
                 + type_str<value_type_t<T>>() + "* " + var_name_ + "_value, ";
     res.body += "bool " + var_name_;
-      res.body_suffix += "if(!" + var_name_ +
+    res.body_suffix += "if(!" + var_name_ +
             " && atomic_xchg(" + var_name_ + "_buffer, 1) == 0){\n"
           + var_name_ + "_buffer[1] = " + row_index_name + ";\n"
           + var_name_ + "_buffer[2] = " + col_index_name + ";\n"

--- a/stan/math/opencl/kernel_generator/check_cl.hpp
+++ b/stan/math/opencl/kernel_generator/check_cl.hpp
@@ -8,6 +8,7 @@
 #include <stan/math/opencl/kernel_generator/as_operation_cl.hpp>
 #include <stan/math/opencl/kernel_generator/operation_cl_lhs.hpp>
 #include <stan/math/opencl/kernel_generator/scalar.hpp>
+#include <map>
 
 namespace stan {
 namespace math {
@@ -73,13 +74,13 @@ class check_cl_ : public operation_cl_lhs<check_cl_<T>, bool> {
    * @return part of kernel with code for this and nested expressions
    */
   inline kernel_parts get_kernel_parts_lhs(
-      std::set<const operation_cl_base*>& generated, name_generator& name_gen,
+      std::map<const void*, const char*>& generated, name_generator& name_gen,
       const std::string& row_index_name,
       const std::string& col_index_name) const {
     kernel_parts res;
     if (generated.count(this) == 0) {
       this->var_name_ = name_gen.generate();
-      generated.insert(this);
+      generated[this] = "";
       res = arg_.get_kernel_parts(generated, name_gen, row_index_name,
                                   col_index_name, false);
 
@@ -104,10 +105,10 @@ class check_cl_ : public operation_cl_lhs<check_cl_<T>, bool> {
    * @param[in,out] arg_num consecutive number of the first argument to set.
    * This is incremented for each argument set by this function.
    */
-  inline void set_args(std::set<const operation_cl_base*>& generated,
+  inline void set_args(std::map<const void*, const char*>& generated,
                        cl::Kernel& kernel, int& arg_num) const {
     if (generated.count(this) == 0) {
-      generated.insert(this);
+      generated[this] = "";
       arg_.set_args(generated, kernel, arg_num);
       kernel.setArg(arg_num++, buffer_.buffer());
       kernel.setArg(arg_num++, value_.buffer());

--- a/stan/math/opencl/kernel_generator/check_cl.hpp
+++ b/stan/math/opencl/kernel_generator/check_cl.hpp
@@ -79,22 +79,20 @@ class check_cl_ : public operation_cl_lhs<check_cl_<T>, bool> {
       const std::string& row_index_name,
       const std::string& col_index_name) const {
     kernel_parts res;
-    if (generated.count(this) == 0) {
-      this->var_name_ = name_gen.generate();
-      generated[this] = "";
-      res = arg_.get_kernel_parts(generated, name_gen, row_index_name,
-                                  col_index_name, false);
+    this->var_name_ = name_gen.generate();
+    generated[this] = "";
+    res = arg_.get_kernel_parts(generated, name_gen, row_index_name,
+                                col_index_name, false);
 
-      res.args += "__global int* " + var_name_ + "_buffer, __global "
-                  + type_str<value_type_t<T>>() + "* " + var_name_ + "_value, ";
-      res.body += "bool " + var_name_;
+    res.args += "__global int* " + var_name_ + "_buffer, __global "
+                + type_str<value_type_t<T>>() + "* " + var_name_ + "_value, ";
+    res.body += "bool " + var_name_;
       res.body_suffix += "if(!" + var_name_ +
             " && atomic_xchg(" + var_name_ + "_buffer, 1) == 0){\n"
           + var_name_ + "_buffer[1] = " + row_index_name + ";\n"
           + var_name_ + "_buffer[2] = " + col_index_name + ";\n"
           + var_name_ + "_value[0] = " + arg_.var_name_ + ";\n"
           "}";
-    }
     return res;
   }
 
@@ -108,12 +106,10 @@ class check_cl_ : public operation_cl_lhs<check_cl_<T>, bool> {
    */
   inline void set_args(std::map<const void*, const char*>& generated,
                        cl::Kernel& kernel, int& arg_num) const {
-    if (generated.count(this) == 0) {
-      generated[this] = "";
-      arg_.set_args(generated, kernel, arg_num);
-      kernel.setArg(arg_num++, buffer_.buffer());
-      kernel.setArg(arg_num++, value_.buffer());
-    }
+    generated[this] = "";
+    arg_.set_args(generated, kernel, arg_num);
+    kernel.setArg(arg_num++, buffer_.buffer());
+    kernel.setArg(arg_num++, value_.buffer());
   }
 
   /**

--- a/stan/math/opencl/kernel_generator/colwise_reduction.hpp
+++ b/stan/math/opencl/kernel_generator/colwise_reduction.hpp
@@ -10,7 +10,7 @@
 #include <stan/math/opencl/kernel_generator/operation_cl.hpp>
 #include <stan/math/opencl/kernel_generator/as_operation_cl.hpp>
 #include <stan/math/opencl/kernel_generator/rowwise_reduction.hpp>
-#include <set>
+#include <map>
 #include <string>
 #include <type_traits>
 #include <utility>
@@ -69,7 +69,7 @@ class colwise_reduction
    */
   template <typename T_result>
   kernel_parts get_whole_kernel_parts(
-      std::set<const operation_cl_base*>& generated, name_generator& ng,
+      std::map<const void*, const char*>& generated, name_generator& ng,
       const std::string& row_index_name, const std::string& col_index_name,
       const T_result& result) const {
     kernel_parts parts = derived().get_kernel_parts(

--- a/stan/math/opencl/kernel_generator/colwise_reduction.hpp
+++ b/stan/math/opencl/kernel_generator/colwise_reduction.hpp
@@ -60,7 +60,8 @@ class colwise_reduction
 
   /**
    * Generates kernel code for assigning this expression into result expression.
-   * @param[in,out] generated set of (pointer to) already generated operations
+   * @param[in,out] generated map from (pointer to) already generated operations
+   * to variable names
    * @param ng name generator for this kernel
    * @param row_index_name row index variable name
    * @param col_index_name column index variable name

--- a/stan/math/opencl/kernel_generator/colwise_reduction.hpp
+++ b/stan/math/opencl/kernel_generator/colwise_reduction.hpp
@@ -185,11 +185,11 @@ class colwise_sum_ : public colwise_reduction<colwise_sum_<T>, T, sum_op> {
  * @param a expression to reduce
  * @return sum
  */
-template <typename T, typename = require_all_kernel_expressions_t<T>>
+template <typename T, require_all_kernel_expressions_t<T>* = nullptr>
 inline auto colwise_sum(T&& a) {
   auto&& arg_copy = as_operation_cl(std::forward<T>(a)).deep_copy();
-  return colwise_sum_<std::remove_reference_t<decltype(arg_copy)>>(
-      std::move(arg_copy));
+  return colwise_sum_<as_operation_cl_t<T>>(
+      as_operation_cl(std::forward<T>(a)));
 }
 
 /**
@@ -232,11 +232,11 @@ class colwise_max_ : public colwise_reduction<
  * @param a expression to reduce
  * @return max
  */
-template <typename T, typename = require_all_kernel_expressions_t<T>>
+template <typename T, require_all_kernel_expressions_t<T>* = nullptr>
 inline auto colwise_max(T&& a) {
   auto&& arg_copy = as_operation_cl(std::forward<T>(a)).deep_copy();
-  return colwise_max_<std::remove_reference_t<decltype(arg_copy)>>(
-      std::move(arg_copy));
+  return colwise_max_<as_operation_cl_t<T>>(
+      as_operation_cl(std::forward<T>(a)));
 }
 
 /**
@@ -279,11 +279,10 @@ class colwise_min_ : public colwise_reduction<
  * @param a expression to reduce
  * @return min
  */
-template <typename T, typename = require_all_kernel_expressions_t<T>>
+template <typename T, require_all_kernel_expressions_t<T>* = nullptr>
 inline auto colwise_min(T&& a) {
-  auto&& arg_copy = as_operation_cl(std::forward<T>(a)).deep_copy();
-  return colwise_min_<std::remove_reference_t<decltype(arg_copy)>>(
-      std::move(arg_copy));
+  return colwise_min_<as_operation_cl_t<T>>(
+      as_operation_cl(std::forward<T>(a)));
 }
 /** @}*/
 }  // namespace math

--- a/stan/math/opencl/kernel_generator/constant.hpp
+++ b/stan/math/opencl/kernel_generator/constant.hpp
@@ -8,7 +8,7 @@
 #include <stan/math/opencl/kernel_generator/name_generator.hpp>
 #include <stan/math/opencl/kernel_generator/operation_cl.hpp>
 #include <limits>
-#include <set>
+#include <map>
 #include <string>
 #include <tuple>
 #include <type_traits>
@@ -78,9 +78,12 @@ class constant_ : public operation_cl<constant_<T>, T> {
    * @param[in,out] arg_num consecutive number of the first argument to set.
    * This is incremented for each argument set by this function.
    */
-  inline void set_args(std::set<const operation_cl_base*>& generated,
+  inline void set_args(std::map<const void*, const char*>& generated,
                        cl::Kernel& kernel, int& arg_num) const {
-    kernel.setArg(arg_num++, a_);
+    if (generated.count(this) == 0) {
+      generated[this] = "";
+      kernel.setArg(arg_num++, a_);
+    }
   }
 
   /**

--- a/stan/math/opencl/kernel_generator/constant.hpp
+++ b/stan/math/opencl/kernel_generator/constant.hpp
@@ -72,8 +72,8 @@ class constant_ : public operation_cl<constant_<T>, T> {
 
   /**
    * Sets kernel arguments for this and nested expressions.
-   * @param[in,out] generated set of expressions that already set their kernel
-   * arguments
+   * @param[in,out] generated map from (pointer to) already generated operations
+   * to variable names
    * @param kernel kernel to set arguments on
    * @param[in,out] arg_num consecutive number of the first argument to set.
    * This is incremented for each argument set by this function.

--- a/stan/math/opencl/kernel_generator/diagonal.hpp
+++ b/stan/math/opencl/kernel_generator/diagonal.hpp
@@ -56,7 +56,8 @@ class diagonal_
 
   /**
    * Generates kernel code for this and nested expressions.
-   * @param[in,out] generated set of (pointer to) already generated operations
+   * @param[in,out] generated map from (pointer to) already generated operations
+   * to variable names
    * @param name_gen name generator for this kernel
    * @param row_index_name row index variable name
    * @param col_index_name column index variable name

--- a/stan/math/opencl/kernel_generator/diagonal.hpp
+++ b/stan/math/opencl/kernel_generator/diagonal.hpp
@@ -9,7 +9,7 @@
 #include <stan/math/opencl/kernel_generator/operation_cl_lhs.hpp>
 #include <stan/math/opencl/kernel_generator/as_operation_cl.hpp>
 #include <algorithm>
-#include <set>
+#include <map>
 #include <string>
 #include <tuple>
 #include <type_traits>
@@ -64,12 +64,12 @@ class diagonal_
    * @return part of kernel with code for this and nested expressions
    */
   inline kernel_parts get_kernel_parts(
-      std::set<const operation_cl_base*>& generated, name_generator& name_gen,
+      std::map<const void*, const char*>& generated, name_generator& name_gen,
       const std::string& row_index_name, const std::string& col_index_name,
       bool view_handled) const {
     kernel_parts res{};
     if (generated.count(this) == 0) {
-      generated.insert(this);
+      generated[this] = "";
       res = this->template get_arg<0>().get_kernel_parts(
           generated, name_gen, row_index_name, row_index_name, true);
       var_name_ = this->template get_arg<0>().var_name_;

--- a/stan/math/opencl/kernel_generator/diagonal.hpp
+++ b/stan/math/opencl/kernel_generator/diagonal.hpp
@@ -70,8 +70,9 @@ class diagonal_
     kernel_parts res{};
     if (generated.count(this) == 0) {
       generated[this] = "";
+      std::map<const void*, const char*> generated2;
       res = this->template get_arg<0>().get_kernel_parts(
-          generated, name_gen, row_index_name, row_index_name, true);
+          generated2, name_gen, row_index_name, row_index_name, true);
       var_name_ = this->template get_arg<0>().var_name_;
     }
     return res;

--- a/stan/math/opencl/kernel_generator/indexing.hpp
+++ b/stan/math/opencl/kernel_generator/indexing.hpp
@@ -241,28 +241,6 @@ class indexing_
     this->template get_arg<2>().add_read_event(e);
     this->template get_arg<0>().add_write_event(e);
   }
-
-  /**
-   * Collects data that is needed beside types to uniqly identify a kernel
-   * generator expression.
-   * @param[out] uid ids of unique matrix accesses
-   * @param[in,out] id_map map from memory addresses to unique ids
-   * @param[in,out] next_id neqt unique id to use
-   */
-  inline void get_unique_matrix_accesses(std::vector<int>& uids,
-                                         std::map<const void*, int>& id_map,
-                                         int& next_id) const {
-    std::vector<int> uids2;
-    std::map<const void*, int> id_map2;
-    int next_id2 = 0;
-    this->template get_arg<0>().get_unique_matrix_accesses(uids2, id_map2, next_id2);
-    for (int i : uids2) {
-      uids.push_back(i + next_id);
-    }
-    next_id += next_id2;
-    this->template get_arg<1>().get_unique_matrix_accesses(uids, id_map, next_id);
-    this->template get_arg<2>().get_unique_matrix_accesses(uids, id_map, next_id);
-  }
 };
 
 /**

--- a/stan/math/opencl/kernel_generator/indexing.hpp
+++ b/stan/math/opencl/kernel_generator/indexing.hpp
@@ -36,6 +36,7 @@ class indexing_
                 "indexing: Column index scalar type must be an integer!");
 
   mutable std::map<const void*, const char*> generated_;
+
  public:
   using Scalar = typename std::remove_reference_t<T_mat>::Scalar;
   using base = operation_cl_lhs<indexing_<T_mat, T_row_index, T_col_index>,
@@ -107,8 +108,9 @@ class indexing_
           generated, name_gen, row_index_name, col_index_name, view_handled);
       kernel_parts parts_col_idx = col_index.get_kernel_parts(
           generated, name_gen, row_index_name, col_index_name, view_handled);
-      kernel_parts parts_mat = mat.get_kernel_parts(
-          generated_, name_gen, row_index.var_name_, col_index.var_name_, false);
+      kernel_parts parts_mat
+          = mat.get_kernel_parts(generated_, name_gen, row_index.var_name_,
+                                 col_index.var_name_, false);
 
       res = parts_row_idx + parts_col_idx + parts_mat;
       var_name_ = mat.var_name_;

--- a/stan/math/opencl/kernel_generator/indexing.hpp
+++ b/stan/math/opencl/kernel_generator/indexing.hpp
@@ -82,7 +82,8 @@ class indexing_
 
   /**
    * Generates kernel code for this and nested expressions.
-   * @param[in,out] generated set of (pointer to) already generated operations
+   * @param[in,out] generated map from (pointer to) already generated operations
+   * to variable names
    * @param name_gen name generator for this kernel
    * @param row_index_name row index variable name
    * @param col_index_name column index variable name
@@ -118,7 +119,8 @@ class indexing_
   /**
    * Generates kernel code for this expression if it appears on the left hand
    * side of an assignment.
-   * @param[in,out] generated set of (pointer to) already generated operations
+   * @param[in,out] generated map from (pointer to) already generated operations
+   * to variable names
    * @param name_gen name generator for this kernel
    * @param row_index_name row index variable name
    * @param col_index_name column index variable name
@@ -150,7 +152,7 @@ class indexing_
 
   /**
    * Sets kernel arguments for this expression.
-   * @param[in,out] generated set of expressions that already set their kernel
+   * @param[in,out] generated map of expressions that already set their kernel
    * arguments
    * @param kernel kernel to set arguments on
    * @param[in,out] arg_num consecutive number of the first argument to set.

--- a/stan/math/opencl/kernel_generator/indexing.hpp
+++ b/stan/math/opencl/kernel_generator/indexing.hpp
@@ -7,6 +7,7 @@
 #include <stan/math/opencl/kernel_generator/name_generator.hpp>
 #include <stan/math/opencl/kernel_generator/operation_cl.hpp>
 #include <stan/math/opencl/kernel_generator/as_operation_cl.hpp>
+#include <map>
 #include <string>
 #include <utility>
 
@@ -88,12 +89,12 @@ class indexing_
    * @return part of kernel with code for this and nested expressions
    */
   inline kernel_parts get_kernel_parts(
-      std::set<const operation_cl_base*>& generated, name_generator& name_gen,
+      std::map<const void*, const char*>& generated, name_generator& name_gen,
       const std::string& row_index_name, const std::string& col_index_name,
       bool view_handled) const {
     kernel_parts res{};
     if (generated.count(this) == 0) {
-      generated.insert(this);
+      generated[this] = "";
 
       const auto& mat = this->template get_arg<0>();
       const auto& row_index = this->template get_arg<1>();
@@ -122,11 +123,11 @@ class indexing_
    * @return part of kernel with code for this expressions
    */
   inline kernel_parts get_kernel_parts_lhs(
-      std::set<const operation_cl_base*>& generated, name_generator& name_gen,
+      std::map<const void*, const char*>& generated, name_generator& name_gen,
       const std::string& row_index_name,
       const std::string& col_index_name) const {
     if (generated.count(this) == 0) {
-      generated.insert(this);
+      generated[this] = "";
     }
     const auto& mat = this->template get_arg<0>();
     const auto& row_index = this->template get_arg<1>();
@@ -152,10 +153,10 @@ class indexing_
    * @param[in,out] arg_num consecutive number of the first argument to set.
    * This is incremented for each argument set by this function.
    */
-  inline void set_args(std::set<const operation_cl_base*>& generated,
+  inline void set_args(std::map<const void*, const char*>& generated,
                        cl::Kernel& kernel, int& arg_num) const {
     if (generated.count(this) == 0) {
-      generated.insert(this);
+      generated[this] = "";
       this->template get_arg<1>().set_args(generated, kernel, arg_num);
       this->template get_arg<2>().set_args(generated, kernel, arg_num);
       this->template get_arg<0>().set_args(generated, kernel, arg_num);

--- a/stan/math/opencl/kernel_generator/load.hpp
+++ b/stan/math/opencl/kernel_generator/load.hpp
@@ -288,11 +288,21 @@ class load_
 
   /**
    * Collects data that is needed beside types to uniqly identify a kernel
-   * generator expression. Pushes a pointer to underlying `matrix_cl` to data.
-   * @param[out] data collected data
+   * generator expression.
+   * @param[out] uid ids of unique matrix accesses
+   * @param[in,out] id_map map from memory addresses to unique ids
+   * @param[in,out] next_id neqt unique id to use
    */
-  inline void get_unique_data(std::vector<const void*>& data) const {
-    data.push_back(&a_);
+  inline void get_unique_matrix_accesses(std::vector<int>& uids,
+                                         std::map<const void*, int>& id_map,
+                                         int& next_id) const {
+    if (id_map.count(&a_) == 0) {
+      id_map[&a_] = next_id;
+      uids.push_back(next_id);
+      next_id++;
+    } else {
+      uids.push_back(id_map[&a_]);
+    }
   }
 };
 /** @}*/

--- a/stan/math/opencl/kernel_generator/load.hpp
+++ b/stan/math/opencl/kernel_generator/load.hpp
@@ -57,7 +57,8 @@ class load_
 
   /**
    * Generates kernel code for this expression.
-   * @param[in,out] generated set of (pointer to) already generated operations
+   * @param[in,out] generated map from (pointer to) already generated operations
+   * to variable names
    * @param name_gen name generator for this kernel
    * @param row_index_name row index variable name
    * @param col_index_name column index variable name
@@ -112,7 +113,8 @@ class load_
   /**
    * Generates kernel code for this expression if it appears on the left hand
    * side of an assignment.
-   * @param[in,out] generated set of (pointer to) already generated operations
+   * @param[in,out] generated map from (pointer to) already generated operations
+   * to variable names
    * @param name_gen name generator for this kernel
    * @param row_index_name row index variable name
    * @param col_index_name column index variable name
@@ -157,7 +159,7 @@ class load_
 
   /**
    * Sets kernel arguments for this expression.
-   * @param[in,out] generated set of expressions that already set their kernel
+   * @param[in,out] generated map of expressions that already set their kernel
    * arguments
    * @param kernel kernel to set arguments on
    * @param[in,out] arg_num consecutive number of the first argument to set.

--- a/stan/math/opencl/kernel_generator/load.hpp
+++ b/stan/math/opencl/kernel_generator/load.hpp
@@ -291,7 +291,7 @@ class load_
   /**
    * Collects data that is needed beside types to uniqly identify a kernel
    * generator expression.
-   * @param[out] uid ids of unique matrix accesses
+   * @param[out] uids ids of unique matrix accesses
    * @param[in,out] id_map map from memory addresses to unique ids
    * @param[in,out] next_id neqt unique id to use
    */

--- a/stan/math/opencl/kernel_generator/load.hpp
+++ b/stan/math/opencl/kernel_generator/load.hpp
@@ -233,6 +233,16 @@ class load_
       a_ = matrix_cl<Scalar>(rows, cols);
     }
   }
+
+  /**
+   * Collects data that is needed beside types to uniqly identify a kernel
+   * generator expression. Pushes the handle to underlying `matrix_cl`'s memory
+   * to `mems`.
+   * @param[out] mems data of type `cl_mem`
+   */
+  inline void get_unique_data(std::vector<cl_mem>& mems) const {
+    mems.push_back(a_.buffer()());
+  }
 };
 /** @}*/
 }  // namespace math

--- a/stan/math/opencl/kernel_generator/multi_result_kernel.hpp
+++ b/stan/math/opencl/kernel_generator/multi_result_kernel.hpp
@@ -148,10 +148,10 @@ struct multi_result_kernel_internal {
     static void add_event(
         cl::Event e, const std::tuple<std::pair<T_results, T_expressions>...>&
                          assignment_pairs) {
+      next::add_event(e, assignment_pairs);
       if (is_without_output<T_current_expression>::value) {
         return;
       }
-      next::add_event(e, assignment_pairs);
       std::get<N>(assignment_pairs).second.add_read_event(e);
       std::get<N>(assignment_pairs).first.add_write_event(e);
     }

--- a/stan/math/opencl/kernel_generator/multi_result_kernel.hpp
+++ b/stan/math/opencl/kernel_generator/multi_result_kernel.hpp
@@ -241,7 +241,7 @@ class expressions_cl {
    */
   explicit expressions_cl(T_expressions&&... expressions)
       : expressions_(
-          T_expressions(std::forward<T_expressions>(expressions))...) {}
+            T_expressions(std::forward<T_expressions>(expressions))...) {}
 
  private:
   std::tuple<T_expressions...> expressions_;

--- a/stan/math/opencl/kernel_generator/multi_result_kernel.hpp
+++ b/stan/math/opencl/kernel_generator/multi_result_kernel.hpp
@@ -91,7 +91,8 @@ struct multi_result_kernel_internal {
 
     /**
      * Generates kernel source for assignment of expressions to results.
-     * @param generated set of already generated expressions
+     * @param[in,out] generated map from (pointer to) already generated operations
+     * to variable names
      * @param ng name generator
      * @param row_index_name variable name of the row index
      * @param col_index_name variable name of the column index
@@ -119,7 +120,8 @@ struct multi_result_kernel_internal {
 
     /**
      * Sets kernel arguments.
-     * @param generated Set of operations that already set their arguments
+     * @param[in,out] generated map from (pointer to) already generated operations
+     * to variable names
      * @param kernel kernel to set arguments to
      * @param arg_num number of the next argument to set
      * @param assignment_pairs pairs of result and expression

--- a/stan/math/opencl/kernel_generator/multi_result_kernel.hpp
+++ b/stan/math/opencl/kernel_generator/multi_result_kernel.hpp
@@ -158,7 +158,9 @@ struct multi_result_kernel_internal {
 
     /**
      * Collects data that is needed beside types to uniqly identify a kernel.
-     * @param[out] mems data of type `cl_mem`
+     * @param[out] uids ids of unique matrix accesses
+     * @param[in,out] id_map map from memory addresses to unique ids
+     * @param[in,out] next_id neqt unique id to use
      * @param assignment_pairs pairs of result and expression
      */
     static void get_unique_matrix_accesses(
@@ -239,7 +241,7 @@ class expressions_cl {
    */
   explicit expressions_cl(T_expressions&&... expressions)
       : expressions_(
-            T_expressions(std::forward<T_expressions>(expressions))...) {}
+          T_expressions(std::forward<T_expressions>(expressions))...) {}
 
  private:
   std::tuple<T_expressions...> expressions_;

--- a/stan/math/opencl/kernel_generator/multi_result_kernel.hpp
+++ b/stan/math/opencl/kernel_generator/multi_result_kernel.hpp
@@ -91,8 +91,8 @@ struct multi_result_kernel_internal {
 
     /**
      * Generates kernel source for assignment of expressions to results.
-     * @param[in,out] generated map from (pointer to) already generated operations
-     * to variable names
+     * @param[in,out] generated map from (pointer to) already generated
+     * operations to variable names
      * @param ng name generator
      * @param row_index_name variable name of the row index
      * @param col_index_name variable name of the column index
@@ -120,8 +120,8 @@ struct multi_result_kernel_internal {
 
     /**
      * Sets kernel arguments.
-     * @param[in,out] generated map from (pointer to) already generated operations
-     * to variable names
+     * @param[in,out] generated map from (pointer to) already generated
+     * operations to variable names
      * @param kernel kernel to set arguments to
      * @param arg_num number of the next argument to set
      * @param assignment_pairs pairs of result and expression
@@ -162,7 +162,8 @@ struct multi_result_kernel_internal {
      * @param assignment_pairs pairs of result and expression
      */
     static void get_unique_matrix_accesses(
-        std::vector<int>& uids, std::map<const void*, int>& id_map, int& next_id,
+        std::vector<int>& uids, std::map<const void*, int>& id_map,
+        int& next_id,
         const std::tuple<std::pair<T_results, T_expressions>...>&
             assignment_pairs) {
       if (is_without_output<T_current_expression>::value) {
@@ -211,7 +212,8 @@ struct multi_result_kernel_internal<-1, T_results...> {
                          assignment_pairs) {}
 
     static void get_unique_matrix_accesses(
-        std::vector<int>& uids, std::map<const void*, int>& id_map, int& next_id,
+        std::vector<int>& uids, std::map<const void*, int>& id_map,
+        int& next_id,
         const std::tuple<std::pair<T_results, T_expressions>...>&
             assignment_pairs) {}
   };
@@ -237,7 +239,7 @@ class expressions_cl {
    */
   explicit expressions_cl(T_expressions&&... expressions)
       : expressions_(
-          T_expressions(std::forward<T_expressions>(expressions))...) {}
+            T_expressions(std::forward<T_expressions>(expressions))...) {}
 
  private:
   std::tuple<T_expressions...> expressions_;

--- a/stan/math/opencl/kernel_generator/operation_cl.hpp
+++ b/stan/math/opencl/kernel_generator/operation_cl.hpp
@@ -414,29 +414,12 @@ class operation_cl : public operation_cl_base {
   inline void get_unique_matrix_accesses(std::vector<int>& uids,
                                          std::map<const void*, int>& id_map,
                                          int& next_id) const {
-    if (&Derived::modify_argument_indices
-        == &operation_cl::modify_argument_indices) {
       index_apply<N>([&](auto... Is) {
         static_cast<void>(std::initializer_list<int>{
             (this->get_arg<Is>().get_unique_matrix_accesses(uids, id_map,
                                                             next_id),
              0)...});
       });
-    } else {
-      std::vector<int> uids2;
-      std::map<const void*, int> id_map2;
-      int next_id2 = 0;
-      index_apply<N>([&](auto... Is) {
-        static_cast<void>(std::initializer_list<int>{
-            (this->get_arg<Is>().get_unique_matrix_accesses(uids2, id_map2,
-                                                            next_id2),
-             0)...});
-      });
-      for (int i : uids2) {
-        uids.push_back(i + next_id);
-      }
-      next_id += next_id2;
-    }
   }
 };
 

--- a/stan/math/opencl/kernel_generator/operation_cl.hpp
+++ b/stan/math/opencl/kernel_generator/operation_cl.hpp
@@ -407,7 +407,7 @@ class operation_cl : public operation_cl_base {
   /**
    * Collects data that is needed beside types to uniqly identify a kernel
    * generator expression.
-   * @param[out] uid ids of unique matrix accesses
+   * @param[out] uids ids of unique matrix accesses
    * @param[in,out] id_map map from memory addresses to unique ids
    * @param[in,out] next_id neqt unique id to use
    */

--- a/stan/math/opencl/kernel_generator/operation_cl.hpp
+++ b/stan/math/opencl/kernel_generator/operation_cl.hpp
@@ -175,7 +175,8 @@ class operation_cl : public operation_cl_base {
 
   /**
    * Generates kernel code for assigning this expression into result expression.
-   * @param[in,out] generated set of (pointer to) already generated operations
+   * @param[in,out] generated map from (pointer to) already generated operations
+   * to variable names
    * @param ng name generator for this kernel
    * @param row_index_name row index variable name
    * @param col_index_name column index variable name
@@ -272,7 +273,7 @@ class operation_cl : public operation_cl_base {
 
   /**
    * Sets kernel arguments for nested expressions.
-   * @param[in,out] generated set of expressions that already set their kernel
+   * @param[in,out] generated map of expressions that already set their kernel
    * arguments
    * @param kernel kernel to set arguments on
    * @param[in,out] arg_num consecutive number of the first argument to set.

--- a/stan/math/opencl/kernel_generator/operation_cl.hpp
+++ b/stan/math/opencl/kernel_generator/operation_cl.hpp
@@ -228,7 +228,7 @@ class operation_cl : public operation_cl_base {
             name_gen, row_index_name_arg, col_index_name_arg,
             view_handled
                 && std::tuple_element_t<
-                    Is, typename Deriv::view_transitivity>::value)...};
+                       Is, typename Deriv::view_transitivity>::value)...};
       });
       res = std::accumulate(args_parts.begin(), args_parts.end(),
                             kernel_parts{});
@@ -414,12 +414,11 @@ class operation_cl : public operation_cl_base {
   inline void get_unique_matrix_accesses(std::vector<int>& uids,
                                          std::map<const void*, int>& id_map,
                                          int& next_id) const {
-      index_apply<N>([&](auto... Is) {
-        static_cast<void>(std::initializer_list<int>{
-            (this->get_arg<Is>().get_unique_matrix_accesses(uids, id_map,
-                                                            next_id),
-             0)...});
-      });
+    index_apply<N>([&](auto... Is) {
+      static_cast<void>(std::initializer_list<int>{(
+          this->get_arg<Is>().get_unique_matrix_accesses(uids, id_map, next_id),
+          0)...});
+    });
   }
 };
 

--- a/stan/math/opencl/kernel_generator/operation_cl_lhs.hpp
+++ b/stan/math/opencl/kernel_generator/operation_cl_lhs.hpp
@@ -5,7 +5,7 @@
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/opencl/kernel_generator/operation_cl.hpp>
 #include <string>
-#include <set>
+#include <map>
 #include <array>
 #include <numeric>
 #include <vector>
@@ -44,7 +44,7 @@ class operation_cl_lhs : public operation_cl<Derived, Scalar, Args...>,
    * @return part of kernel with code for this expressions
    */
   inline kernel_parts get_kernel_parts_lhs(
-      std::set<const operation_cl_base*>& generated, name_generator& name_gen,
+      std::map<const void*, const char*>& generated, name_generator& name_gen,
       const std::string& row_index_name,
       const std::string& col_index_name) const {
     if (generated.count(this) == 0) {
@@ -67,7 +67,7 @@ class operation_cl_lhs : public operation_cl<Derived, Scalar, Args...>,
     });
     res += my_part;
     if (generated.count(this) == 0) {
-      generated.insert(this);
+      generated[this] = "";
     } else {
       res.args = "";
     }

--- a/stan/math/opencl/kernel_generator/operation_cl_lhs.hpp
+++ b/stan/math/opencl/kernel_generator/operation_cl_lhs.hpp
@@ -37,7 +37,8 @@ class operation_cl_lhs : public operation_cl<Derived, Scalar, Args...>,
   /**
    * Generates kernel code for this expression if it appears on the left hand
    * side of an assignment.
-   * @param[in,out] generated set of (pointer to) already generated operations
+   * @param[in,out] generated map from (pointer to) already generated operations
+   * to variable names
    * @param name_gen name generator for this kernel
    * @param row_index_name row index variable name
    * @param col_index_name column index variable name

--- a/stan/math/opencl/kernel_generator/operation_cl_lhs.hpp
+++ b/stan/math/opencl/kernel_generator/operation_cl_lhs.hpp
@@ -54,9 +54,15 @@ class operation_cl_lhs : public operation_cl<Derived, Scalar, Args...>,
     std::string col_index_name_arg = col_index_name;
     derived().modify_argument_indices(row_index_name_arg, col_index_name_arg);
     std::array<kernel_parts, N> args_parts = index_apply<N>([&](auto... Is) {
+      std::map<const void*, const char*> generated2;
       return std::array<kernel_parts, N>{
           this->template get_arg<Is>().get_kernel_parts_lhs(
-              generated, name_gen, row_index_name_arg, col_index_name_arg)...};
+              &Derived::modify_argument_indices
+                      == &operation_cl<Derived, Scalar,
+                                       Args...>::modify_argument_indices
+                  ? generated
+                  : generated2,
+              name_gen, row_index_name_arg, col_index_name_arg)...};
     });
     kernel_parts res
         = std::accumulate(args_parts.begin(), args_parts.end(), kernel_parts{});

--- a/stan/math/opencl/kernel_generator/optional_broadcast.hpp
+++ b/stan/math/opencl/kernel_generator/optional_broadcast.hpp
@@ -11,7 +11,7 @@
 #include <limits>
 #include <string>
 #include <type_traits>
-#include <set>
+#include <map>
 #include <utility>
 
 namespace stan {
@@ -98,10 +98,10 @@ class optional_broadcast_
    * @param[in,out] arg_num consecutive number of the first argument to set.
    * This is incremented for each argument set by this function.
    */
-  inline void set_args(std::set<const operation_cl_base*>& generated,
+  inline void set_args(std::map<const void*, const char*>& generated,
                        cl::Kernel& kernel, int& arg_num) const {
     if (generated.count(this) == 0) {
-      generated.insert(this);
+      generated[this] = "";
       this->template get_arg<0>().set_args(generated, kernel, arg_num);
       if (Colwise) {
         kernel.setArg(arg_num++, static_cast<int>(

--- a/stan/math/opencl/kernel_generator/optional_broadcast.hpp
+++ b/stan/math/opencl/kernel_generator/optional_broadcast.hpp
@@ -92,8 +92,8 @@ class optional_broadcast_
 
   /**
    * Sets kernel arguments for this and nested expressions.
-   * @param[in,out] generated set of expressions that already set their kernel
-   * arguments
+   * @param[in,out] generated map from (pointer to) already generated operations
+   * to variable names
    * @param kernel kernel to set arguments on
    * @param[in,out] arg_num consecutive number of the first argument to set.
    * This is incremented for each argument set by this function.

--- a/stan/math/opencl/kernel_generator/optional_broadcast.hpp
+++ b/stan/math/opencl/kernel_generator/optional_broadcast.hpp
@@ -102,7 +102,8 @@ class optional_broadcast_
                        cl::Kernel& kernel, int& arg_num) const {
     if (generated.count(this) == 0) {
       generated[this] = "";
-      this->template get_arg<0>().set_args(generated, kernel, arg_num);
+      std::map<const void*, const char*> generated2;
+      this->template get_arg<0>().set_args(generated2, kernel, arg_num);
       if (Colwise) {
         kernel.setArg(arg_num++, static_cast<int>(
                                      this->template get_arg<0>().rows() != 1));

--- a/stan/math/opencl/kernel_generator/rowwise_reduction.hpp
+++ b/stan/math/opencl/kernel_generator/rowwise_reduction.hpp
@@ -60,7 +60,8 @@ struct matvec_mul_opt<elt_multiply_<Mat, broadcast_<VecT, true, false>>> {
    * optimization - ignoring the triangular view of the vector, as it is already
    * handeled by rowwise reduction.
    * @param mul argument of the rowwise reduction
-   * @param[in,out] generated set of (pointer to) already generated operations
+   * @param[in,out] generated map from (pointer to) already generated operations
+   * to variable names
    * @param name_gen name generator for this kernel
    * @param row_index_name row index variable name
    * @param col_index_name column index variable name
@@ -138,7 +139,8 @@ class rowwise_reduction
 
   /**
    * Generates kernel code for this and nested expressions.
-   * @param[in,out] generated set of (pointer to) already generated operations
+   * @param[in,out] generated map from (pointer to) already generated operations
+   * to variable names
    * @param name_gen name generator for this kernel
    * @param row_index_name row index variable name
    * @param col_index_name column index variable name
@@ -228,7 +230,7 @@ class rowwise_reduction
 
   /**
    * Sets kernel arguments for this and nested expressions.
-   * @param[in,out] generated set of expressions that already set their kernel
+   * @param[in,out] generated map of expressions that already set their kernel
    * arguments
    * @param kernel kernel to set arguments on
    * @param[in,out] arg_num consecutive number of the first argument to set.

--- a/stan/math/opencl/kernel_generator/rowwise_reduction.hpp
+++ b/stan/math/opencl/kernel_generator/rowwise_reduction.hpp
@@ -74,7 +74,7 @@ struct matvec_mul_opt<elt_multiply_<Mat, broadcast_<VecT, true, false>>> {
     kernel_parts res{};
     if (generated.count(&mul) == 0) {
       mul.var_name_ = name_gen.generate();
-      generated[&mul]="";
+      generated[&mul] = "";
 
       const auto& matrix = mul.template get_arg<0>();
       const auto& broadcast = mul.template get_arg<1>();
@@ -82,7 +82,7 @@ struct matvec_mul_opt<elt_multiply_<Mat, broadcast_<VecT, true, false>>> {
                                     col_index_name, true);
       if (generated.count(&broadcast) == 0) {
         broadcast.var_name_ = name_gen.generate();
-        generated[&broadcast]="";
+        generated[&broadcast] = "";
 
         const auto& vec = broadcast.template get_arg<0>();
         std::string row_index_name_bc = row_index_name;
@@ -267,7 +267,7 @@ class rowwise_reduction
   }
 };
 
-  /**
+/**
  * Operation for sum reduction.
  */
 struct sum_op {

--- a/stan/math/opencl/kernel_generator/rowwise_reduction.hpp
+++ b/stan/math/opencl/kernel_generator/rowwise_reduction.hpp
@@ -154,13 +154,14 @@ class rowwise_reduction
       this->var_name_ = name_gen.generate();
       generated[this] = "";
 
+      std::map<const void*, const char*> generated2;
       if (PassZero && internal::matvec_mul_opt<T_no_ref>::is_possible) {
         res = internal::matvec_mul_opt<T_no_ref>::get_kernel_parts(
-            this->template get_arg<0>(), generated, name_gen, row_index_name,
+            this->template get_arg<0>(), generated2, name_gen, row_index_name,
             var_name_ + "_j");
       } else {
         res = this->template get_arg<0>().get_kernel_parts(
-            generated, name_gen, row_index_name, var_name_ + "_j",
+            generated2, name_gen, row_index_name, var_name_ + "_j",
             view_handled || PassZero);
       }
       kernel_parts my_part
@@ -237,7 +238,8 @@ class rowwise_reduction
                        cl::Kernel& kernel, int& arg_num) const {
     if (generated.count(this) == 0) {
       generated[this] = "";
-      this->template get_arg<0>().set_args(generated, kernel, arg_num);
+      std::map<const void*, const char*> generated2;
+      this->template get_arg<0>().set_args(generated2, kernel, arg_num);
       kernel.setArg(arg_num++, this->template get_arg<0>().view());
       kernel.setArg(arg_num++, this->template get_arg<0>().cols());
       if (PassZero && internal::matvec_mul_opt<T>::is_possible) {
@@ -261,9 +263,9 @@ class rowwise_reduction
   inline std::pair<int, int> extreme_diagonals() const {
     return {-rows() + 1, cols() - 1};
   }
-};  // namespace math
+};
 
-/**
+  /**
  * Operation for sum reduction.
  */
 struct sum_op {

--- a/stan/math/opencl/kernel_generator/scalar.hpp
+++ b/stan/math/opencl/kernel_generator/scalar.hpp
@@ -64,8 +64,8 @@ class scalar_ : public operation_cl<scalar_<T>, T> {
 
   /**
    * Sets kernel arguments for this and nested expressions.
-   * @param[in,out] generated set of expressions that already set their kernel
-   * arguments
+   * @param[in,out] generated map from (pointer to) already generated operations
+   * to variable names
    * @param kernel kernel to set arguments on
    * @param[in,out] arg_num consecutive number of the first argument to set.
    * This is incremented for each argument set by this function.

--- a/stan/math/opencl/kernel_generator/scalar.hpp
+++ b/stan/math/opencl/kernel_generator/scalar.hpp
@@ -8,7 +8,7 @@
 #include <stan/math/opencl/kernel_generator/name_generator.hpp>
 #include <stan/math/opencl/kernel_generator/operation_cl.hpp>
 #include <limits>
-#include <set>
+#include <map>
 #include <string>
 #include <tuple>
 #include <type_traits>
@@ -70,9 +70,12 @@ class scalar_ : public operation_cl<scalar_<T>, T> {
    * @param[in,out] arg_num consecutive number of the first argument to set.
    * This is incremented for each argument set by this function.
    */
-  inline void set_args(std::set<const operation_cl_base*>& generated,
+  inline void set_args(std::map<const void*, const char*>& generated,
                        cl::Kernel& kernel, int& arg_num) const {
-    kernel.setArg(arg_num++, a_);
+    if (generated.count(this) == 0) {
+      generated[this] = "";
+      kernel.setArg(arg_num++, a_);
+    }
   }
 
   /**

--- a/test/unit/math/opencl/kernel_generator/operation_test.cpp
+++ b/test/unit/math/opencl/kernel_generator/operation_test.cpp
@@ -29,23 +29,32 @@ TEST(KernelGenerator, kernel_caching) {
   matrix_cl<double> m1_cl(m1);
   matrix_cl<double> m2_cl(m2);
   auto tmp = m1_cl + 0.1234 * m2_cl;
+
   using cache = stan::math::internal::multi_result_kernel_internal<
       0, stan::math::load_<matrix_cl<double>&>&&>::inner<const decltype(tmp)&>;
   using unused_cache = stan::math::internal::multi_result_kernel_internal<
       0, stan::math::load_<matrix_cl<int>&>&&>::inner<const decltype(tmp)&>;
-  EXPECT_EQ(cache::kernel_(), nullptr);
+  size_t cache_size = cache::kernel_cache_.size();
+  size_t unused_cache_size = unused_cache::kernel_cache_.size();
+  std::vector<int> uid = {0, 1, 2};
+
+  EXPECT_EQ(cache::kernel_cache_.count(uid), 0);
+  EXPECT_EQ(cache::kernel_cache_.size(), cache_size);
   matrix_cl<double> res_cl = tmp;
-  cl_kernel cached_kernel = cache::kernel_();
+  EXPECT_EQ(cache::kernel_cache_.size(), cache_size + 1);
+  cl_kernel cached_kernel = cache::kernel_cache_.at(uid)();
   EXPECT_NE(cached_kernel, nullptr);
 
   auto tmp2 = m1_cl + 0.1234 * m2_cl;
   matrix_cl<double> res2_cl = tmp2;
-  EXPECT_EQ(cache::kernel_(), cached_kernel);
+  EXPECT_EQ(cache::kernel_cache_.at(uid)(), cached_kernel);
+  EXPECT_EQ(cache::kernel_cache_.size(), cache_size + 1);
 
   matrix_cl<double> res3_cl = res_cl + 0.1234 * res2_cl;
-  EXPECT_EQ(cache::kernel_(), cached_kernel);
+  EXPECT_EQ(cache::kernel_cache_.at(uid)(), cached_kernel);
+  EXPECT_EQ(cache::kernel_cache_.size(), cache_size + 1);
 
-  EXPECT_EQ(unused_cache::kernel_(), nullptr);
+  EXPECT_EQ(unused_cache::kernel_cache_.size(), unused_cache_size);
 }
 
 TEST(MathMatrixCL, events_write_after_write) {
@@ -84,6 +93,25 @@ TEST(MathMatrixCL, events_read_after_write_and_write_after_read) {
   Eigen::MatrixXd correct = Eigen::MatrixXd::Constant(3, 3, 2 * iters);
 
   EXPECT_MATRIX_NEAR(res, correct, 1e-13);
+}
+
+TEST(MathMatrixCL, same_operations_different_inputs) {
+  MatrixXd m1(3, 3);
+  m1 << 1, 2, 3, 4, 5, 6, 7, 8, 9;
+  MatrixXd m2(3, 3);
+  m2 << 10, 100, 1000, 0, -10, -12, 2, 4, 8;
+
+  matrix_cl<double> m1_cl(m1);
+  matrix_cl<double> m2_cl(m2);
+
+  auto m1_op = stan::math::as_operation_cl(m1_cl);
+  auto m2_op = stan::math::as_operation_cl(m2_cl);
+
+  matrix_cl<double> res1_cl = m1_op + m1_op;
+  matrix_cl<double> res2_cl = m2_op + m1_op;
+
+  EXPECT_MATRIX_EQ(stan::math::from_matrix_cl(res1_cl), m1 + m1);
+  EXPECT_MATRIX_EQ(stan::math::from_matrix_cl(res2_cl), m2 + m1);
 }
 
 #endif

--- a/test/unit/math/opencl/kernel_generator/reference_kernels/binary_operation_reuse_expression.cl
+++ b/test/unit/math/opencl/kernel_generator/reference_kernels/binary_operation_reuse_expression.cl
@@ -1,13 +1,12 @@
-kernel void calculate(__global double* var4_global, int var4_rows, int var4_view, __global double* var5_global, int var5_rows, int var5_view, __global double* var8_global, int var8_rows, int var8_view, __global double* var9_global, int var9_rows, int var9_view){
+kernel void calculate(__global double* var4_global, int var4_rows, int var4_view, __global double* var5_global, int var5_rows, int var5_view, __global double* var8_global, int var8_rows, int var8_view){
 int i = get_global_id(0);
 int j = get_global_id(1);
 double var4 = 0; if (!((!contains_nonzero(var4_view, LOWER) && j < i) || (!contains_nonzero(var4_view, UPPER) && j > i))) {var4 = var4_global[i + var4_rows * j];}
 double var5 = 0; if (!((!contains_nonzero(var5_view, LOWER) && j < i) || (!contains_nonzero(var5_view, UPPER) && j > i))) {var5 = var5_global[i + var5_rows * j];}
 double var3 = var4 + var5;
 double var7 = var3 * var3;
-double var8 = 0; if (!((!contains_nonzero(var8_view, LOWER) && j < i) || (!contains_nonzero(var8_view, UPPER) && j > i))) {var8 = var8_global[i + var8_rows * j];}
-double var6 = var7 / var8;
+double var6 = var7 / var4;
 double var2 = var3 / var6;
 double var1 = var2 * var6;
-var9_global[i + var9_rows * j] = var1;
+var8_global[i + var8_rows * j] = var1;
 }

--- a/test/unit/math/opencl/kernel_generator/reference_kernels/check_cl_positive.cl
+++ b/test/unit/math/opencl/kernel_generator/reference_kernels/check_cl_positive.cl
@@ -1,12 +1,11 @@
-kernel void calculate(__global double* var2_global, int var2_rows, int var2_view, int var3, __global double* var5_global, int var5_rows, int var5_view, __global int* var4_buffer, __global double* var4_value){
+kernel void calculate(__global double* var2_global, int var2_rows, int var2_view, int var3, __global int* var4_buffer, __global double* var4_value){
 int i = get_global_id(0);
 int j = get_global_id(1);
 double var2 = 0; if (!((!contains_nonzero(var2_view, LOWER) && j < i) || (!contains_nonzero(var2_view, UPPER) && j > i))) {var2 = var2_global[i + var2_rows * j];}
 bool var1 = var2 > var3;
-double var5 = 0; if (!((!contains_nonzero(var5_view, LOWER) && j < i) || (!contains_nonzero(var5_view, UPPER) && j > i))) {var5 = var5_global[i + var5_rows * j];}
 bool var4 = var1;
 if(!var4 && atomic_xchg(var4_buffer, 1) == 0){
 var4_buffer[1] = i;
 var4_buffer[2] = j;
-var4_value[0] = var5;
+var4_value[0] = var2;
 }}

--- a/test/unit/math/opencl/kernel_generator/reference_kernels/sum_dif.cl
+++ b/test/unit/math/opencl/kernel_generator/reference_kernels/sum_dif.cl
@@ -1,12 +1,10 @@
-kernel void calculate(__global double* var2_global, int var2_rows, int var2_view, __global double* var3_global, int var3_rows, int var3_view, __global double* var4_global, int var4_rows, int var4_view, __global double* var6_global, int var6_rows, int var6_view, __global double* var7_global, int var7_rows, int var7_view, __global double* var8_global, int var8_rows, int var8_view){
+kernel void calculate(__global double* var2_global, int var2_rows, int var2_view, __global double* var3_global, int var3_rows, int var3_view, __global double* var4_global, int var4_rows, int var4_view, __global double* var6_global, int var6_rows, int var6_view){
 int i = get_global_id(0);
 int j = get_global_id(1);
 double var2 = 0; if (!((!contains_nonzero(var2_view, LOWER) && j < i) || (!contains_nonzero(var2_view, UPPER) && j > i))) {var2 = var2_global[i + var2_rows * j];}
 double var3 = 0; if (!((!contains_nonzero(var3_view, LOWER) && j < i) || (!contains_nonzero(var3_view, UPPER) && j > i))) {var3 = var3_global[i + var3_rows * j];}
 double var1 = var2 + var3;
 var4_global[i + var4_rows * j] = var1;
-double var6 = 0; if (!((!contains_nonzero(var6_view, LOWER) && j < i) || (!contains_nonzero(var6_view, UPPER) && j > i))) {var6 = var6_global[i + var6_rows * j];}
-double var7 = 0; if (!((!contains_nonzero(var7_view, LOWER) && j < i) || (!contains_nonzero(var7_view, UPPER) && j > i))) {var7 = var7_global[i + var7_rows * j];}
-double var5 = var6 - var7;
-var8_global[i + var8_rows * j] = var5;
+double var5 = var2 - var3;
+var6_global[i + var6_rows * j] = var5;
 }


### PR DESCRIPTION
## Summary

Fixes a bug in kernel generator's caching for OpenCL kernels. KG uses only types of expressions for determining uniqueness of a kernel. Two kernels consisting of same operations working on different combination of unique matrices (for example `c = a + b` and `˙c = a + a`) would be cached as the same kernel. If two such kernels were used in same program it would crash or produce wrong results.

This PR changes caching to also consider uniqueness of accessed matrices. That allows not to duplicate accesses to a matrix when it is used in one kernel multiple times, hopefully also working around the issue in #2200.

## Tests

Added a test with two kernels using same operations but different unique matrix accesses that would crash before this bugfix.

## Side Effects
None.

## Release notes
Fixed a bug that would crash a program if two kernels using same operations are run on different set of unique matrices (for example `c = a + b` and `˙c = a + a`).

## Checklist

- [ ] Math issue #(issue number)

- [ ] Copyright holder: Tadej Ciglarič

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [ ] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [ ] the code is written in idiomatic C++ and changes are documented in the doxygen

- [ ] the new changes are tested
