### PR TITLE
Opencl pareto_type_2_lpdf, poisson_log_plmf and poisson_log_lpmf

### DIFF
--- a/stan/math/opencl/kernel_generator/elt_function_cl.hpp
+++ b/stan/math/opencl/kernel_generator/elt_function_cl.hpp
@@ -332,8 +332,7 @@ ADD_BINARY_FUNCTION_WITH_INCLUDES(
     stan::math::opencl_kernels::lbeta_device_function,
     stan::math::opencl_kernels::binomial_coefficient_log_device_function)
 ADD_BINARY_FUNCTION_WITH_INCLUDES(
-    multiply_log,
-    stan::math::opencl_kernels::multiply_log_device_function)
+    multiply_log, stan::math::opencl_kernels::multiply_log_device_function)
 
 #undef ADD_BINARY_FUNCTION_WITH_INCLUDES
 #undef ADD_UNARY_FUNCTION_WITH_INCLUDES

--- a/stan/math/opencl/kernel_generator/elt_function_cl.hpp
+++ b/stan/math/opencl/kernel_generator/elt_function_cl.hpp
@@ -12,6 +12,7 @@
 #include <stan/math/opencl/kernels/device_functions/log1m_inv_logit.hpp>
 #include <stan/math/opencl/kernels/device_functions/log1p_exp.hpp>
 #include <stan/math/opencl/kernels/device_functions/logit.hpp>
+#include <stan/math/opencl/kernels/device_functions/multiply_log.hpp>
 #include <stan/math/opencl/kernels/device_functions/inv_logit.hpp>
 #include <stan/math/opencl/kernels/device_functions/inv_square.hpp>
 #include <stan/math/opencl/matrix_cl_view.hpp>
@@ -330,6 +331,9 @@ ADD_BINARY_FUNCTION_WITH_INCLUDES(
     stan::math::opencl_kernels::lgamma_stirling_diff_device_function,
     stan::math::opencl_kernels::lbeta_device_function,
     stan::math::opencl_kernels::binomial_coefficient_log_device_function)
+ADD_BINARY_FUNCTION_WITH_INCLUDES(
+    multiply_log,
+    stan::math::opencl_kernels::multiply_log_device_function)
 
 #undef ADD_BINARY_FUNCTION_WITH_INCLUDES
 #undef ADD_UNARY_FUNCTION_WITH_INCLUDES

--- a/stan/math/opencl/kernels/device_functions/multiply_log.hpp
+++ b/stan/math/opencl/kernels/device_functions/multiply_log.hpp
@@ -1,0 +1,72 @@
+#ifndef STAN_MATH_OPENCL_KERNELS_DEVICE_FUNCTIONS_MULTIPLY_LOG_HPP
+#define STAN_MATH_OPENCL_KERNELS_DEVICE_FUNCTIONS_MULTIPLY_LOG_HPP
+#ifdef STAN_OPENCL
+
+#include <stan/math/opencl/stringify.hpp>
+#include <string>
+
+namespace stan {
+namespace math {
+namespace opencl_kernels {
+
+// \cond
+static const char* multiply_log_device_function
+    = "\n"
+      "#ifndef STAN_MATH_OPENCL_KERNELS_DEVICE_FUNCTIONS_MULTIPLY_LOG\n"
+      "#define "
+      "STAN_MATH_OPENCL_KERNELS_DEVICE_FUNCTIONS_MULTIPLY_LOG\n" STRINGIFY(
+          // \endcond
+          /**
+           * Calculate the value of the first argument
+           * times log of the second argument while behaving
+           * properly with 0 inputs.
+           *
+           * \f$ a * \log b \f$.
+           *
+             \f[
+             \mbox{multiply\_log}(x, y) =
+             \begin{cases}
+               0 & \mbox{if } x=y=0\\
+               x\ln y & \mbox{if } x, y\neq0 \\[6pt]
+               \textrm{NaN} & \mbox{if } x = \textrm{NaN or } y = \textrm{NaN}
+             \end{cases}
+             \f]
+
+             \f[
+             \frac{\partial\, \mbox{multiply\_log}(x, y)}{\partial x} =
+             \begin{cases}
+               \infty & \mbox{if } x=y=0\\
+               \ln y & \mbox{if } x, y\neq 0 \\[6pt]
+               \textrm{NaN} & \mbox{if } x = \textrm{NaN or } y = \textrm{NaN}
+             \end{cases}
+             \f]
+
+             \f[
+             \frac{\partial\, \mbox{multiply\_log}(x, y)}{\partial y} =
+             \begin{cases}
+               \infty & \mbox{if } x=y=0\\
+               \frac{x}{y} & \mbox{if } x, y\neq 0 \\[6pt]
+               \textrm{NaN} & \mbox{if } x = \textrm{NaN or } y = \textrm{NaN}
+             \end{cases}
+             \f]
+           *
+           * @param a the first variable
+           * @param b the second variable
+           * @return a * log(b)
+           */
+          double multiply_log(double a, double b) {
+            if (b == 0.0 && a == 0.0) {
+              return 0.0;
+            }
+            return a * log(b);
+          }
+          // \cond
+          ) "\n#endif\n";  // NOLINT
+// \endcond
+
+}  // namespace opencl_kernels
+}  // namespace math
+}  // namespace stan
+
+#endif
+#endif

--- a/stan/math/opencl/opencl.hpp
+++ b/stan/math/opencl/opencl.hpp
@@ -133,6 +133,7 @@
 #include <stan/math/opencl/prim/ordered_logistic_glm_lpmf.hpp>
 #include <stan/math/opencl/prim/pareto_type_2_lpdf.hpp>
 #include <stan/math/opencl/prim/poisson_log_glm_lpmf.hpp>
+#include <stan/math/opencl/prim/poisson_log_lpmf.hpp>
 #include <stan/math/opencl/prim/rep_matrix.hpp>
 #include <stan/math/opencl/prim/rep_row_vector.hpp>
 #include <stan/math/opencl/prim/rep_vector.hpp>

--- a/stan/math/opencl/opencl.hpp
+++ b/stan/math/opencl/opencl.hpp
@@ -134,6 +134,7 @@
 #include <stan/math/opencl/prim/pareto_type_2_lpdf.hpp>
 #include <stan/math/opencl/prim/poisson_log_glm_lpmf.hpp>
 #include <stan/math/opencl/prim/poisson_log_lpmf.hpp>
+#include <stan/math/opencl/prim/poisson_lpmf.hpp>
 #include <stan/math/opencl/prim/rep_matrix.hpp>
 #include <stan/math/opencl/prim/rep_row_vector.hpp>
 #include <stan/math/opencl/prim/rep_vector.hpp>

--- a/stan/math/opencl/opencl.hpp
+++ b/stan/math/opencl/opencl.hpp
@@ -131,6 +131,7 @@
 #include <stan/math/opencl/prim/neg_binomial_2_log_glm_lpmf.hpp>
 #include <stan/math/opencl/prim/normal_id_glm_lpdf.hpp>
 #include <stan/math/opencl/prim/ordered_logistic_glm_lpmf.hpp>
+#include <stan/math/opencl/prim/pareto_type_2_lpdf.hpp>
 #include <stan/math/opencl/prim/poisson_log_glm_lpmf.hpp>
 #include <stan/math/opencl/prim/rep_matrix.hpp>
 #include <stan/math/opencl/prim/rep_row_vector.hpp>

--- a/stan/math/opencl/prim/pareto_type_2_lpdf.hpp
+++ b/stan/math/opencl/prim/pareto_type_2_lpdf.hpp
@@ -1,0 +1,136 @@
+#ifndef STAN_MATH_OPENCL_PRIM_PARETO_TYPE_2_LPDF_HPP
+#define STAN_MATH_OPENCL_PRIM_PARETO_TYPE_2_LPDF_HPP
+#ifdef STAN_OPENCL
+
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/err.hpp>
+#include <stan/math/prim/fun/constants.hpp>
+#include <stan/math/prim/fun/elt_divide.hpp>
+#include <stan/math/prim/fun/elt_multiply.hpp>
+#include <stan/math/opencl/kernel_generator.hpp>
+#include <stan/math/prim/functor/operands_and_partials.hpp>
+
+namespace stan {
+namespace math {
+
+/** \ingroup opencl
+ * Returns the log PMF of the Pareto type 2 distribution. If
+ * containers are supplied, returns the log sum of the probabilities.
+ *
+ * @tparam T_y_cl type of dependent variable
+ * @tparam T_loc_cl type of location parameter
+ * @tparam T_scale_cl type of scale parameter
+ * @tparam T_shape_cl type of inverse scale parameter
+ * @param y dependent variable
+ * @param mu location
+ * @param lambda scale
+ * @param alpha inverse scale
+ * @return log probability or log sum of probabilities
+ * @throw std::domain_error if y is NaN, mu is infinite, lambda is negative or
+ * infinite or alpha is negative or infinite.
+ * @throw std::invalid_argument if container sizes mismatch.
+ */
+template <bool propto, typename T_y_cl, typename T_loc_cl, typename T_scale_cl,
+          typename T_shape_cl,
+          require_all_prim_or_rev_kernel_expression_t<
+              T_y_cl, T_loc_cl, T_scale_cl, T_shape_cl>* = nullptr,
+          require_any_not_stan_scalar_t<T_y_cl, T_loc_cl, T_scale_cl,
+                                        T_shape_cl>* = nullptr>
+return_type_t<T_y_cl, T_loc_cl, T_scale_cl, T_shape_cl> pareto_type_2_lpdf(
+    const T_y_cl& y, const T_loc_cl& mu, const T_scale_cl& lambda,
+    const T_shape_cl& alpha) {
+  static const char* function = "pareto_type_2_lpdf(OpenCL)";
+  using T_partials_return
+      = partials_return_t<T_y_cl, T_loc_cl, T_scale_cl, T_shape_cl>;
+  using std::isfinite;
+  using std::isnan;
+
+  check_consistent_sizes(function, "Random variable", y, "Location parameter",
+                         mu, "Scale parameter", alpha, "Shape parameter",
+                         alpha);
+  const size_t N = max_size(y, mu, lambda, alpha);
+  if (N == 0) {
+    return 0.0;
+  }
+  if (!include_summand<propto, T_y_cl, T_loc_cl, T_scale_cl,
+                       T_shape_cl>::value) {
+    return 0.0;
+  }
+
+  const auto& y_val = value_of(y);
+  const auto& mu_val = value_of(mu);
+  const auto& lambda_val = value_of(lambda);
+  const auto& alpha_val = value_of(alpha);
+
+  auto y_minus_mu = y_val - mu_val;
+  auto check_y_ge_mu
+      = check_cl(function, "Random variable minus location parameter",
+                 y_minus_mu, "greater or equal than zero");
+  auto y_ge_mu = y_minus_mu >= 0;
+  auto check_lambda_positive_finite
+      = check_cl(function, "Scale parameter", lambda_val, "positive finite");
+  auto lambda_positive_finite = isfinite(lambda_val) && lambda_val > 0;
+  auto check_alpha_positive_finite
+      = check_cl(function, "Shape parameter", alpha_val, "positive finite");
+  auto alpha_positive_finite = isfinite(alpha_val) && alpha_val > 0;
+
+  auto log1p_scaled_diff = log1p(elt_divide(y_minus_mu, lambda_val));
+
+  auto logp1 = static_select<include_summand<propto, T_shape_cl>::value>(
+      log(alpha_val), constant(0, N, 1));
+  auto logp2 = static_select<include_summand<propto, T_scale_cl>::value>(
+      logp1 - log(lambda_val), logp1);
+  auto logp_expr = colwise_sum(
+      static_select<include_summand<propto, T_y_cl, T_loc_cl, T_scale_cl,
+                                    T_shape_cl>::value>(
+          logp2 - elt_multiply(alpha_val + 1.0, log1p_scaled_diff), logp2));
+
+  auto inv_sum = elt_divide(1.0, lambda_val + y_minus_mu);
+  auto alpha_div_sum = elt_multiply(alpha_val, inv_sum);
+
+  auto deriv_y_mu = inv_sum + alpha_div_sum;
+  auto deriv_lambda
+      = elt_divide(elt_multiply(alpha_div_sum, y_minus_mu), lambda_val)
+        - inv_sum;
+  auto deriv_alpha = elt_divide(1.0, alpha_val) - log1p_scaled_diff;
+
+  matrix_cl<double> logp_cl;
+  matrix_cl<double> y_deriv_cl;
+  matrix_cl<double> mu_deriv_cl;
+  matrix_cl<double> lambda_deriv_cl;
+  matrix_cl<double> alpha_deriv_cl;
+
+  results(check_y_ge_mu, check_lambda_positive_finite,
+          check_alpha_positive_finite, logp_cl, y_deriv_cl, mu_deriv_cl,
+          lambda_deriv_cl, alpha_deriv_cl)
+      = expressions(y_ge_mu, lambda_positive_finite, alpha_positive_finite,
+                    logp_expr,
+                    calc_if<!is_constant<T_y_cl>::value>(-deriv_y_mu),
+                    calc_if<!is_constant<T_loc_cl>::value>(deriv_y_mu),
+                    calc_if<!is_constant<T_scale_cl>::value>(deriv_lambda),
+                    calc_if<!is_constant<T_shape_cl>::value>(deriv_alpha));
+
+  T_partials_return logp = sum(from_matrix_cl(logp_cl));
+
+  operands_and_partials<T_y_cl, T_loc_cl, T_scale_cl, T_shape_cl> ops_partials(
+      y, mu, lambda, alpha);
+  if (!is_constant<T_y_cl>::value) {
+    ops_partials.edge1_.partials_ = std::move(y_deriv_cl);
+  }
+  if (!is_constant<T_loc_cl>::value) {
+    ops_partials.edge2_.partials_ = std::move(mu_deriv_cl);
+  }
+  if (!is_constant<T_scale_cl>::value) {
+    ops_partials.edge3_.partials_ = std::move(lambda_deriv_cl);
+  }
+  if (!is_constant<T_shape_cl>::value) {
+    ops_partials.edge4_.partials_ = std::move(alpha_deriv_cl);
+  }
+  return ops_partials.build(logp);
+}
+
+}  // namespace math
+}  // namespace stan
+
+#endif
+#endif

--- a/stan/math/opencl/prim/poisson_log_lpmf.hpp
+++ b/stan/math/opencl/prim/poisson_log_lpmf.hpp
@@ -75,11 +75,12 @@ return_type_t<T_log_rate_cl> poisson_log_lpmf(const T_n_cl& n,
   matrix_cl<double> logp_cl;
   matrix_cl<double> deriv_cl;
 
-  results(check_n_nonnegative, check_alpha_not_nan, return_log_zero_cl, logp_cl, deriv_cl)
+  results(check_n_nonnegative, check_alpha_not_nan, return_log_zero_cl, logp_cl,
+          deriv_cl)
       = expressions(n_nonnegativer, alpha_not_nan, return_log_zero, logp_expr,
                     calc_if<!is_constant_all<T_log_rate_cl>::value>(deriv));
 
-  if(from_matrix_cl(return_log_zero_cl).any()){
+  if (from_matrix_cl(return_log_zero_cl).any()) {
     return LOG_ZERO;
   }
 

--- a/stan/math/opencl/prim/poisson_log_lpmf.hpp
+++ b/stan/math/opencl/prim/poisson_log_lpmf.hpp
@@ -13,13 +13,13 @@ namespace stan {
 namespace math {
 
 /** \ingroup opencl
- * Returns the log PMF of the Poisson distribution. If containers are
+ * Returns the log PMF of the Poisson log distribution. If containers are
  * supplied, returns the log sum of the probabilities.
  *
  * @tparam T_n_cl type of integer parameters
  * @tparam T_log_rate_cl type of chance of success parameters
  * @param n integer parameter
- * @param alpha chance of success parameter
+ * @param alpha log rate parameter
  * @return log probability or log sum of probabilities
  * @throw std::domain_error if alpha is not a valid probability
  * @throw std::invalid_argument if container sizes mismatch.

--- a/stan/math/opencl/prim/poisson_log_lpmf.hpp
+++ b/stan/math/opencl/prim/poisson_log_lpmf.hpp
@@ -1,0 +1,96 @@
+#ifndef STAN_MATH_OPENCL_PRIM_POISSON_LOG_LPMF_HPP
+#define STAN_MATH_OPENCL_PRIM_POISSON_LOG_LPMF_HPP
+#ifdef STAN_OPENCL
+
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/err.hpp>
+#include <stan/math/prim/fun/constants.hpp>
+#include <stan/math/prim/fun/log.hpp>
+#include <stan/math/opencl/kernel_generator.hpp>
+#include <stan/math/prim/functor/operands_and_partials.hpp>
+
+namespace stan {
+namespace math {
+
+/** \ingroup opencl
+ * Returns the log PMF of the Poisson distribution. If containers are
+ * supplied, returns the log sum of the probabilities.
+ *
+ * @tparam T_n_cl type of integer parameters
+ * @tparam T_log_rate_cl type of chance of success parameters
+ * @param n integer parameter
+ * @param alpha chance of success parameter
+ * @return log probability or log sum of probabilities
+ * @throw std::domain_error if alpha is not a valid probability
+ * @throw std::invalid_argument if container sizes mismatch.
+ */
+template <bool propto, typename T_n_cl, typename T_log_rate_cl,
+          require_all_prim_or_rev_kernel_expression_t<T_n_cl,
+                                                      T_log_rate_cl>* = nullptr,
+          require_any_not_stan_scalar_t<T_n_cl, T_log_rate_cl>* = nullptr>
+return_type_t<T_log_rate_cl> poisson_log_lpmf(const T_n_cl& n,
+                                              const T_log_rate_cl& alpha) {
+  static const char* function = "poisson_log_lpmf(OpenCL)";
+  using T_partials_return = partials_return_t<T_log_rate_cl>;
+  constexpr bool is_n_vector = !is_stan_scalar<T_n_cl>::value;
+  constexpr bool is_alpha_vector = !is_stan_scalar<T_log_rate_cl>::value;
+
+  check_consistent_sizes(function, "Random variable", n, "Log rate parameter",
+                         alpha);
+  const size_t N = is_n_vector ? size(n) : size(alpha);
+  if (N == 0) {
+    return 0.0;
+  }
+  if (!include_summand<propto, T_log_rate_cl>::value) {
+    return 0.0;
+  }
+
+  const auto& alpha_val = value_of(alpha);
+
+  T_partials_return logp(0.0);
+  operands_and_partials<T_log_rate_cl> ops_partials(alpha);
+
+  auto check_n_nonnegative
+      = check_cl(function, "Random variable", n, "nonnegative");
+  auto n_nonnegativer = 0 <= n;
+  auto check_alpha_not_nan
+      = check_cl(function, "Log rate parameter", alpha_val, "not nan");
+  auto alpha_not_nan = !isnan(alpha_val);
+
+  auto return_log_zero = colwise_max(
+      constant(0, N, 1) + (isinf(alpha_val) && (alpha_val > 0 || n != 0)));
+  auto exp_alpha = exp(alpha_val);
+
+  auto logp1 = elt_multiply(n, alpha_val);
+  auto logp2 = static_select<include_summand<propto, T_log_rate_cl>::value>(
+      logp1 - exp_alpha, logp1);
+  auto logp_expr = colwise_sum(static_select<include_summand<propto>::value>(
+      logp2 - lgamma(n + 1.0), logp2));
+
+  auto deriv = n - exp_alpha;
+
+  matrix_cl<int> return_log_zero_cl;
+  matrix_cl<double> logp_cl;
+  matrix_cl<double> deriv_cl;
+
+  results(check_n_nonnegative, check_alpha_not_nan, return_log_zero_cl, logp_cl, deriv_cl)
+      = expressions(n_nonnegativer, alpha_not_nan, return_log_zero, logp_expr,
+                    calc_if<!is_constant_all<T_log_rate_cl>::value>(deriv));
+
+  if(from_matrix_cl(return_log_zero_cl).any()){
+    return LOG_ZERO;
+  }
+
+  logp = sum(from_matrix_cl(logp_cl));
+
+  if (!is_constant_all<T_log_rate_cl>::value) {
+    ops_partials.edge1_.partials_ = deriv_cl;
+  }
+
+  return ops_partials.build(logp);
+}
+
+}  // namespace math
+}  // namespace stan
+#endif
+#endif

--- a/stan/math/opencl/prim/poisson_log_lpmf.hpp
+++ b/stan/math/opencl/prim/poisson_log_lpmf.hpp
@@ -32,6 +32,8 @@ return_type_t<T_log_rate_cl> poisson_log_lpmf(const T_n_cl& n,
                                               const T_log_rate_cl& alpha) {
   static const char* function = "poisson_log_lpmf(OpenCL)";
   using T_partials_return = partials_return_t<T_log_rate_cl>;
+  using std::isinf;
+  using std::isnan;
   constexpr bool is_n_vector = !is_stan_scalar<T_n_cl>::value;
   constexpr bool is_alpha_vector = !is_stan_scalar<T_log_rate_cl>::value;
 

--- a/stan/math/opencl/prim/poisson_lpmf.hpp
+++ b/stan/math/opencl/prim/poisson_lpmf.hpp
@@ -24,12 +24,12 @@ namespace math {
  * @throw std::domain_error if lambda is not a valid probability
  * @throw std::invalid_argument if container sizes mismatch.
  */
-template <bool propto, typename T_n_cl, typename T_rate_cl,
-          require_all_prim_or_rev_kernel_expression_t<T_n_cl,
-                                                      T_rate_cl>* = nullptr,
-          require_any_not_stan_scalar_t<T_n_cl, T_rate_cl>* = nullptr>
+template <
+    bool propto, typename T_n_cl, typename T_rate_cl,
+    require_all_prim_or_rev_kernel_expression_t<T_n_cl, T_rate_cl>* = nullptr,
+    require_any_not_stan_scalar_t<T_n_cl, T_rate_cl>* = nullptr>
 return_type_t<T_rate_cl> poisson_lpmf(const T_n_cl& n,
-                                              const T_rate_cl& lambda) {
+                                      const T_rate_cl& lambda) {
   static const char* function = "poisson_lpmf(OpenCL)";
   using T_partials_return = partials_return_t<T_rate_cl>;
   using std::isinf;
@@ -73,11 +73,13 @@ return_type_t<T_rate_cl> poisson_lpmf(const T_n_cl& n,
   matrix_cl<double> logp_cl;
   matrix_cl<double> deriv_cl;
 
-  results(check_n_nonnegative, check_lambda_nonnegative, return_log_zero_cl, logp_cl, deriv_cl)
-      = expressions(n_nonnegative, lambda_nonnegative, return_log_zero, logp_expr,
+  results(check_n_nonnegative, check_lambda_nonnegative, return_log_zero_cl,
+          logp_cl, deriv_cl)
+      = expressions(n_nonnegative, lambda_nonnegative, return_log_zero,
+                    logp_expr,
                     calc_if<!is_constant_all<T_rate_cl>::value>(deriv));
 
-  if(from_matrix_cl(return_log_zero_cl).any()){
+  if (from_matrix_cl(return_log_zero_cl).any()) {
     return LOG_ZERO;
   }
 

--- a/stan/math/opencl/prim/poisson_lpmf.hpp
+++ b/stan/math/opencl/prim/poisson_lpmf.hpp
@@ -1,0 +1,95 @@
+#ifndef STAN_MATH_OPENCL_PRIM_POISSON_LPMF_HPP
+#define STAN_MATH_OPENCL_PRIM_POISSON_LPMF_HPP
+#ifdef STAN_OPENCL
+
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/err.hpp>
+#include <stan/math/prim/fun/constants.hpp>
+#include <stan/math/prim/fun/log.hpp>
+#include <stan/math/opencl/kernel_generator.hpp>
+#include <stan/math/prim/functor/operands_and_partials.hpp>
+
+namespace stan {
+namespace math {
+
+/** \ingroup opencl
+ * Returns the log PMF of the Poisson distribution. If containers are
+ * supplied, returns the log sum of the probabilities.
+ *
+ * @tparam T_n_cl type of integer parameters
+ * @tparam T_rate_cl type of chance of success parameters
+ * @param n integer parameter
+ * @param lambda rate parameter
+ * @return log probability or log sum of probabilities
+ * @throw std::domain_error if lambda is not a valid probability
+ * @throw std::invalid_argument if container sizes mismatch.
+ */
+template <bool propto, typename T_n_cl, typename T_rate_cl,
+          require_all_prim_or_rev_kernel_expression_t<T_n_cl,
+                                                      T_rate_cl>* = nullptr,
+          require_any_not_stan_scalar_t<T_n_cl, T_rate_cl>* = nullptr>
+return_type_t<T_rate_cl> poisson_lpmf(const T_n_cl& n,
+                                              const T_rate_cl& lambda) {
+  static const char* function = "poisson_lpmf(OpenCL)";
+  using T_partials_return = partials_return_t<T_rate_cl>;
+  constexpr bool is_n_vector = !is_stan_scalar<T_n_cl>::value;
+  constexpr bool is_lambda_vector = !is_stan_scalar<T_rate_cl>::value;
+
+  check_consistent_sizes(function, "Random variable", n, "Rate parameter",
+                         lambda);
+  const size_t N = is_n_vector ? size(n) : size(lambda);
+  if (N == 0) {
+    return 0.0;
+  }
+  if (!include_summand<propto, T_rate_cl>::value) {
+    return 0.0;
+  }
+
+  const auto& lambda_val = value_of(lambda);
+
+  T_partials_return logp(0.0);
+  operands_and_partials<T_rate_cl> ops_partials(lambda);
+
+  auto check_n_nonnegative
+      = check_cl(function, "Random variable", n, "nonnegative");
+  auto n_nonnegativer = 0 <= n;
+  auto check_lambda_nonnegative
+      = check_cl(function, "Log rate parameter", lambda_val, "nonnegative");
+  auto lambda_nonnegative = 0 <= lambda;
+
+  auto return_log_zero = colwise_max(
+      constant(0, N, 1) + (isinf(lambda_val) || (lambda_val == 0 && n != 0)));
+
+  auto logp1 = elt_multiply(n, lambda_val);
+  auto logp2 = static_select<include_summand<propto, T_rate_cl>::value>(
+      logp1 - exp_lambda, logp1);
+  auto logp_expr = colwise_sum(static_select<include_summand<propto>::value>(
+      logp2 - lgamma(n + 1.0), logp2));
+
+  auto deriv = n - exp_lambda;
+
+  matrix_cl<int> return_log_zero_cl;
+  matrix_cl<double> logp_cl;
+  matrix_cl<double> deriv_cl;
+
+  results(check_n_nonnegative, check_lambda_not_nan, return_log_zero_cl, logp_cl, deriv_cl)
+      = expressions(n_nonnegativer, lambda_not_nan, return_log_zero, logp_expr,
+                    calc_if<!is_constant_all<T_rate_cl>::value>(deriv));
+
+  if(from_matrix_cl(return_log_zero_cl).any()){
+    return LOG_ZERO;
+  }
+
+  logp = sum(from_matrix_cl(logp_cl));
+
+  if (!is_constant_all<T_rate_cl>::value) {
+    ops_partials.edge1_.partials_ = deriv_cl;
+  }
+
+  return ops_partials.build(logp);
+}
+
+}  // namespace math
+}  // namespace stan
+#endif
+#endif

--- a/stan/math/opencl/prim/poisson_lpmf.hpp
+++ b/stan/math/opencl/prim/poisson_lpmf.hpp
@@ -32,6 +32,7 @@ return_type_t<T_rate_cl> poisson_lpmf(const T_n_cl& n,
                                               const T_rate_cl& lambda) {
   static const char* function = "poisson_lpmf(OpenCL)";
   using T_partials_return = partials_return_t<T_rate_cl>;
+  using std::isinf;
   constexpr bool is_n_vector = !is_stan_scalar<T_n_cl>::value;
   constexpr bool is_lambda_vector = !is_stan_scalar<T_rate_cl>::value;
 
@@ -52,28 +53,28 @@ return_type_t<T_rate_cl> poisson_lpmf(const T_n_cl& n,
 
   auto check_n_nonnegative
       = check_cl(function, "Random variable", n, "nonnegative");
-  auto n_nonnegativer = 0 <= n;
+  auto n_nonnegative = 0 <= n;
   auto check_lambda_nonnegative
       = check_cl(function, "Log rate parameter", lambda_val, "nonnegative");
-  auto lambda_nonnegative = 0 <= lambda;
+  auto lambda_nonnegative = 0.0 <= lambda_val;
 
   auto return_log_zero = colwise_max(
       constant(0, N, 1) + (isinf(lambda_val) || (lambda_val == 0 && n != 0)));
 
-  auto logp1 = elt_multiply(n, lambda_val);
+  auto logp1 = multiply_log(n, lambda_val);
   auto logp2 = static_select<include_summand<propto, T_rate_cl>::value>(
-      logp1 - exp_lambda, logp1);
+      logp1 - lambda_val, logp1);
   auto logp_expr = colwise_sum(static_select<include_summand<propto>::value>(
       logp2 - lgamma(n + 1.0), logp2));
 
-  auto deriv = n - exp_lambda;
+  auto deriv = elt_divide(n, lambda_val) - 1.0;
 
   matrix_cl<int> return_log_zero_cl;
   matrix_cl<double> logp_cl;
   matrix_cl<double> deriv_cl;
 
-  results(check_n_nonnegative, check_lambda_not_nan, return_log_zero_cl, logp_cl, deriv_cl)
-      = expressions(n_nonnegativer, lambda_not_nan, return_log_zero, logp_expr,
+  results(check_n_nonnegative, check_lambda_nonnegative, return_log_zero_cl, logp_cl, deriv_cl)
+      = expressions(n_nonnegative, lambda_nonnegative, return_log_zero, logp_expr,
                     calc_if<!is_constant_all<T_rate_cl>::value>(deriv));
 
   if(from_matrix_cl(return_log_zero_cl).any()){

--- a/stan/math/prim/fun/exp.hpp
+++ b/stan/math/prim/fun/exp.hpp
@@ -39,8 +39,10 @@ struct exp_fun {
  * @param[in] x container
  * @return Elementwise application of exponentiation to the argument.
  */
-template <typename Container,
-          require_not_container_st<std::is_arithmetic, Container>* = nullptr>
+template <
+    typename Container,
+    require_not_container_st<std::is_arithmetic, Container>* = nullptr,
+    require_not_nonscalar_prim_or_rev_kernel_expression_t<Container>* = nullptr>
 inline auto exp(const Container& x) {
   return apply_scalar_unary<exp_fun, Container>::apply(x);
 }

--- a/stan/math/prim/prob/pareto_type_2_lpdf.hpp
+++ b/stan/math/prim/prob/pareto_type_2_lpdf.hpp
@@ -18,7 +18,9 @@ namespace math {
 
 // pareto_type_2(y|lambda, alpha)  [y >= 0;  lambda > 0;  alpha > 0]
 template <bool propto, typename T_y, typename T_loc, typename T_scale,
-          typename T_shape>
+          typename T_shape,
+          require_all_not_nonscalar_prim_or_rev_kernel_expression_t<
+              T_y, T_loc, T_scale, T_shape>* = nullptr>
 return_type_t<T_y, T_loc, T_scale, T_shape> pareto_type_2_lpdf(
     const T_y& y, const T_loc& mu, const T_scale& lambda,
     const T_shape& alpha) {
@@ -56,10 +58,9 @@ return_type_t<T_y, T_loc, T_scale, T_shape> pareto_type_2_lpdf(
   ref_type_t<decltype(value_of(lambda_arr))> lambda_val = value_of(lambda_arr);
   ref_type_t<decltype(value_of(alpha_arr))> alpha_val = value_of(alpha_arr);
 
-  check_not_nan(function, "Random variable", y_val);
+  check_greater_or_equal(function, "Random variable", y_val, mu_val);
   check_positive_finite(function, "Scale parameter", lambda_val);
   check_positive_finite(function, "Shape parameter", alpha_val);
-  check_greater_or_equal(function, "Random variable", y_val, mu_val);
 
   if (!include_summand<propto, T_y, T_loc, T_scale, T_shape>::value) {
     return 0.0;

--- a/stan/math/prim/prob/poisson_log_lpmf.hpp
+++ b/stan/math/prim/prob/poisson_log_lpmf.hpp
@@ -19,7 +19,9 @@ namespace stan {
 namespace math {
 
 // PoissonLog(n|alpha)  [n >= 0]   = Poisson(n|exp(alpha))
-template <bool propto, typename T_n, typename T_log_rate>
+template <bool propto, typename T_n, typename T_log_rate,
+          require_all_not_nonscalar_prim_or_rev_kernel_expression_t<
+              T_n, T_log_rate>* = nullptr>
 return_type_t<T_log_rate> poisson_log_lpmf(const T_n& n,
                                            const T_log_rate& alpha) {
   using T_partials_return = partials_return_t<T_n, T_log_rate>;

--- a/stan/math/prim/prob/poisson_lpmf.hpp
+++ b/stan/math/prim/prob/poisson_lpmf.hpp
@@ -18,7 +18,9 @@ namespace stan {
 namespace math {
 
 // Poisson(n|lambda)  [lambda > 0;  n >= 0]
-template <bool propto, typename T_n, typename T_rate>
+template <bool propto, typename T_n, typename T_rate,
+          require_all_not_nonscalar_prim_or_rev_kernel_expression_t<
+              T_n, T_rate>* = nullptr>
 return_type_t<T_rate> poisson_lpmf(const T_n& n, const T_rate& lambda) {
   using T_partials_return = partials_return_t<T_n, T_rate>;
   using T_n_ref = ref_type_if_t<!is_constant<T_n>::value, T_n>;

--- a/test/unit/math/opencl/device_functions/multiply_log_test.cpp
+++ b/test/unit/math/opencl/device_functions/multiply_log_test.cpp
@@ -22,8 +22,7 @@ const stan::math::opencl_kernels::kernel_cl<
 
 TEST(MathMatrixCL, multiply_log) {
   Eigen::VectorXd a = Eigen::VectorXd::Random(1000).array() * 5;
-  Eigen::VectorXd b
-      = Eigen::VectorXd::Random(1000).array().abs();
+  Eigen::VectorXd b = Eigen::VectorXd::Random(1000).array().abs();
 
   stan::math::matrix_cl<double> a_cl(a);
   stan::math::matrix_cl<double> b_cl(b);

--- a/test/unit/math/opencl/device_functions/multiply_log_test.cpp
+++ b/test/unit/math/opencl/device_functions/multiply_log_test.cpp
@@ -1,0 +1,53 @@
+#ifdef STAN_OPENCL
+#include <stan/math.hpp>
+#include <stan/math/opencl/kernels/device_functions/multiply_log.hpp>
+#include <stan/math/opencl/kernel_cl.hpp>
+#include <gtest/gtest.h>
+#include <test/unit/math/expect_near_rel.hpp>
+#include <string>
+
+static const std::string test_kernel_code = STRINGIFY(__kernel void test(
+    __global double *C, __global double *A, __global double *B) {
+  const int i = get_global_id(0);
+  C[i] = multiply_log(A[i], B[i]);
+});
+
+const stan::math::opencl_kernels::kernel_cl<
+    stan::math::opencl_kernels::out_buffer,
+    stan::math::opencl_kernels::in_buffer,
+    stan::math::opencl_kernels::in_buffer>
+    multiply_log("test",
+                 {stan::math::opencl_kernels::multiply_log_device_function,
+                  test_kernel_code});
+
+TEST(MathMatrixCL, multiply_log) {
+  Eigen::VectorXd a = Eigen::VectorXd::Random(1000).array() * 5;
+  Eigen::VectorXd b
+      = Eigen::VectorXd::Random(1000).array().abs();
+
+  stan::math::matrix_cl<double> a_cl(a);
+  stan::math::matrix_cl<double> b_cl(b);
+  stan::math::matrix_cl<double> res_cl(1000, 1);
+  multiply_log(cl::NDRange(1000), res_cl, a_cl, b_cl);
+  Eigen::VectorXd res = stan::math::from_matrix_cl<-1, 1>(res_cl);
+
+  EXPECT_NEAR_REL(res, stan::math::multiply_log(a, b));
+}
+
+TEST(MathMatrixCL, multiply_log_edge_cases) {
+  Eigen::VectorXd a(7);
+  a << NAN, INFINITY, 1.0E50, 0, 1, 1, 1;
+
+  Eigen::VectorXd b(7);
+  b << 1, 1, 1, 0, NAN, INFINITY, 1.0E50;
+
+  stan::math::matrix_cl<double> a_cl(a);
+  stan::math::matrix_cl<double> b_cl(b);
+  stan::math::matrix_cl<double> res_cl(7, 1);
+  multiply_log(cl::NDRange(7), res_cl, a_cl, b_cl);
+  Eigen::VectorXd res = stan::math::from_matrix_cl<-1, 1>(res_cl);
+
+  EXPECT_NEAR_REL(res, stan::math::multiply_log(a, b));
+}
+
+#endif

--- a/test/unit/math/opencl/kernel_generator/elt_function_cl_test.cpp
+++ b/test/unit/math/opencl/kernel_generator/elt_function_cl_test.cpp
@@ -217,5 +217,6 @@ TEST(KernelGenerator, multiple_operations_with_includes_test) {
 TEST_BINARY_FUNCTION(pow)
 TEST_BINARY_FUNCTION(lbeta)
 TEST_BINARY_FUNCTION(binomial_coefficient_log)
+TEST_BINARY_FUNCTION(multiply_log)
 
 #endif

--- a/test/unit/math/opencl/rev/pareto_type_2_lpdf_test.cpp
+++ b/test/unit/math/opencl/rev/pareto_type_2_lpdf_test.cpp
@@ -1,0 +1,210 @@
+#ifdef STAN_OPENCL
+#include <stan/math/opencl/rev/opencl.hpp>
+#include <stan/math.hpp>
+#include <gtest/gtest.h>
+#include <test/unit/math/opencl/util.hpp>
+#include <vector>
+
+TEST(ProbDistributionsParetoType2, error_checking) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << -10, INFINITY, 11.3;
+  Eigen::VectorXd y_size(N - 1);
+  y_size << 0.1, 0.5;
+  Eigen::VectorXd y_value(N);
+  y_value << 10, 0.5, 9.99;
+
+  Eigen::VectorXd mu(N);
+  mu << -10.3, 0.8, 2.1;
+  Eigen::VectorXd mu_size(N - 1);
+  mu_size << 0.3, 0.8;
+  Eigen::VectorXd mu_value(N);
+  mu_value << -20.3, NAN, 0.5;
+
+  Eigen::VectorXd lambda(N);
+  lambda << 0.3, 0.8, 11.0;
+  Eigen::VectorXd lambda_size(N - 1);
+  lambda_size << 0.3, 0.8;
+  Eigen::VectorXd lambda_value1(N);
+  lambda_value1 << 0.3, -0.8, 0.5;
+  Eigen::VectorXd lambda_value2(N);
+  lambda_value2 << 0.3, INFINITY, 0.5;
+
+  Eigen::VectorXd alpha(N);
+  alpha << 0.3, 0.8, 13.0;
+  Eigen::VectorXd alpha_size(N - 1);
+  alpha_size << 0.3, 0.8;
+  Eigen::VectorXd alpha_value1(N);
+  alpha_value1 << 0.3, -0.8, 0.5;
+  Eigen::VectorXd alpha_value2(N);
+  alpha_value2 << 0.3, INFINITY, 0.5;
+
+  stan::math::matrix_cl<double> y_cl(y);
+  stan::math::matrix_cl<double> y_size_cl(y_size);
+  stan::math::matrix_cl<double> y_value_cl(y_value);
+
+  stan::math::matrix_cl<double> mu_cl(mu);
+  stan::math::matrix_cl<double> mu_size_cl(mu_size);
+  stan::math::matrix_cl<double> mu_value_cl(mu_value);
+
+  stan::math::matrix_cl<double> lambda_cl(lambda);
+  stan::math::matrix_cl<double> lambda_size_cl(lambda_size);
+  stan::math::matrix_cl<double> lambda_value1_cl(lambda_value1);
+  stan::math::matrix_cl<double> lambda_value2_cl(lambda_value2);
+
+  stan::math::matrix_cl<double> alpha_cl(alpha);
+  stan::math::matrix_cl<double> alpha_size_cl(alpha_size);
+  stan::math::matrix_cl<double> alpha_value1_cl(alpha_value1);
+  stan::math::matrix_cl<double> alpha_value2_cl(alpha_value2);
+
+  EXPECT_NO_THROW(
+      stan::math::pareto_type_2_lpdf(y_cl, mu_cl, lambda_cl, alpha_cl));
+
+  EXPECT_THROW(
+      stan::math::pareto_type_2_lpdf(y_size_cl, mu_cl, lambda_cl, alpha_cl),
+      std::invalid_argument);
+  EXPECT_THROW(
+      stan::math::pareto_type_2_lpdf(y_cl, mu_size_cl, lambda_cl, alpha_cl),
+      std::invalid_argument);
+  EXPECT_THROW(
+      stan::math::pareto_type_2_lpdf(y_cl, mu_cl, lambda_size_cl, alpha_cl),
+      std::invalid_argument);
+  EXPECT_THROW(
+      stan::math::pareto_type_2_lpdf(y_cl, mu_cl, lambda_cl, alpha_size_cl),
+      std::invalid_argument);
+
+  EXPECT_THROW(
+      stan::math::pareto_type_2_lpdf(y_value_cl, mu_cl, lambda_cl, alpha_cl),
+      std::domain_error);
+  EXPECT_THROW(
+      stan::math::pareto_type_2_lpdf(y_cl, mu_value_cl, lambda_cl, alpha_cl),
+      std::domain_error);
+  EXPECT_THROW(
+      stan::math::pareto_type_2_lpdf(y_cl, mu_cl, lambda_value1_cl, alpha_cl),
+      std::domain_error);
+  EXPECT_THROW(
+      stan::math::pareto_type_2_lpdf(y_cl, mu_cl, lambda_cl, alpha_value1_cl),
+      std::domain_error);
+  EXPECT_THROW(
+      stan::math::pareto_type_2_lpdf(y_cl, mu_cl, lambda_value2_cl, alpha_cl),
+      std::domain_error);
+  EXPECT_THROW(
+      stan::math::pareto_type_2_lpdf(y_cl, mu_cl, lambda_cl, alpha_value2_cl),
+      std::domain_error);
+}
+
+auto pareto_type_2_lpdf_functor
+    = [](const auto& y, const auto& mu, const auto& lambda, const auto& alpha) {
+        return stan::math::pareto_type_2_lpdf(y, mu, lambda, alpha);
+      };
+auto pareto_type_2_lpdf_functor_propto
+    = [](const auto& y, const auto& mu, const auto& lambda, const auto& alpha) {
+        return stan::math::pareto_type_2_lpdf<true>(y, mu, lambda, alpha);
+      };
+
+TEST(ProbDistributionsParetoType2, opencl_matches_cpu_small) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0, 0.9, 31;
+  Eigen::VectorXd mu(N);
+  mu << -10.3, 0.8, 21.0;
+  Eigen::VectorXd lambda(N);
+  lambda << 0.3, 0.8, 11.0;
+  Eigen::VectorXd alpha(N);
+  alpha << 0.3, 0.8, 13.0;
+
+  stan::math::test::compare_cpu_opencl_prim_rev(pareto_type_2_lpdf_functor, y,
+                                                mu, lambda, alpha);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      pareto_type_2_lpdf_functor_propto, y, mu, lambda, alpha);
+}
+
+TEST(ProbDistributionsParetoType2, opencl_broadcast_y) {
+  int N = 3;
+
+  double y = 30.3;
+  Eigen::VectorXd mu(N);
+  mu << -10.3, 0.8, 21.0;
+  Eigen::VectorXd lambda(N);
+  lambda << 0.3, 0.8, 11.0;
+  Eigen::VectorXd alpha(N);
+  alpha << 0.3, 0.8, 13.0;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(
+      pareto_type_2_lpdf_functor, y, mu, lambda, alpha);
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(
+      pareto_type_2_lpdf_functor_propto, y, mu, lambda, alpha);
+}
+
+TEST(ProbDistributionsParetoType2, opencl_broadcast_mu) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0, 0.5, 1;
+  double mu = -1.1;
+  Eigen::VectorXd lambda(N);
+  lambda << 0.3, 0.8, 11.0;
+  Eigen::VectorXd alpha(N);
+  alpha << 0.3, 0.8, 13.0;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<1>(
+      pareto_type_2_lpdf_functor, y, mu, lambda, alpha);
+  stan::math::test::test_opencl_broadcasting_prim_rev<1>(
+      pareto_type_2_lpdf_functor_propto, y, mu, lambda, alpha);
+}
+
+TEST(ProbDistributionsParetoType2, opencl_broadcast_lambda) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0, 0.9, 31;
+  Eigen::VectorXd mu(N);
+  mu << -10.3, 0.8, 21.0;
+  double lambda = 0.8;
+  Eigen::VectorXd alpha(N);
+  alpha << 0.3, 0.8, 13.0;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<2>(
+      pareto_type_2_lpdf_functor, y, mu, lambda, alpha);
+  stan::math::test::test_opencl_broadcasting_prim_rev<2>(
+      pareto_type_2_lpdf_functor_propto, y, mu, lambda, alpha);
+}
+
+TEST(ProbDistributionsParetoType2, opencl_broadcast_alpha) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0, 0.9, 31;
+  Eigen::VectorXd mu(N);
+  mu << -10.3, 0.8, 21.0;
+  Eigen::VectorXd lambda(N);
+  lambda << 0.3, 0.8, 11.0;
+  double alpha = 1.2;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<3>(
+      pareto_type_2_lpdf_functor, y, mu, lambda, alpha);
+  stan::math::test::test_opencl_broadcasting_prim_rev<3>(
+      pareto_type_2_lpdf_functor_propto, y, mu, lambda, alpha);
+}
+
+TEST(ProbDistributionsParetoType2, opencl_matches_cpu_big) {
+  int N = 153;
+
+  Eigen::Matrix<double, Eigen::Dynamic, 1> y
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1);
+  Eigen::Matrix<double, Eigen::Dynamic, 1> mu
+      = -Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs() + y.array();
+  Eigen::Matrix<double, Eigen::Dynamic, 1> lambda
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+  Eigen::Matrix<double, Eigen::Dynamic, 1> alpha
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+
+  stan::math::test::compare_cpu_opencl_prim_rev(pareto_type_2_lpdf_functor, y,
+                                                mu, lambda, alpha);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      pareto_type_2_lpdf_functor_propto, y, mu, lambda, alpha);
+}
+
+#endif

--- a/test/unit/math/opencl/rev/pareto_type_2_lpdf_test.cpp
+++ b/test/unit/math/opencl/rev/pareto_type_2_lpdf_test.cpp
@@ -195,7 +195,8 @@ TEST(ProbDistributionsParetoType2, opencl_matches_cpu_big) {
   Eigen::Matrix<double, Eigen::Dynamic, 1> y
       = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1);
   Eigen::Matrix<double, Eigen::Dynamic, 1> mu
-      = -Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs() + y.array();
+      = -Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs()
+        + y.array();
   Eigen::Matrix<double, Eigen::Dynamic, 1> lambda
       = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
   Eigen::Matrix<double, Eigen::Dynamic, 1> alpha

--- a/test/unit/math/opencl/rev/poisson_log_lpmf_test.cpp
+++ b/test/unit/math/opencl/rev/poisson_log_lpmf_test.cpp
@@ -66,8 +66,8 @@ TEST(ProbDistributionsPoissonLog, opencl_broadcast_n) {
   Eigen::VectorXd alpha(N);
   alpha << 0.3, 0.8, 1.0;
 
-  stan::math::test::test_opencl_broadcasting_prim_rev<0>(poisson_log_lpmf_functor,
-                                                         n_scal, alpha);
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(
+      poisson_log_lpmf_functor, n_scal, alpha);
   stan::math::test::test_opencl_broadcasting_prim_rev<0>(
       poisson_log_lpmf_functor_propto, n_scal, alpha);
 }
@@ -78,8 +78,8 @@ TEST(ProbDistributionsPoissonLog, opencl_broadcast_alpha) {
   std::vector<int> n{0, 1, 5};
   double alpha_scal = 0.4;
 
-  stan::math::test::test_opencl_broadcasting_prim_rev<1>(poisson_log_lpmf_functor,
-                                                         n, alpha_scal);
+  stan::math::test::test_opencl_broadcasting_prim_rev<1>(
+      poisson_log_lpmf_functor, n, alpha_scal);
   stan::math::test::test_opencl_broadcasting_prim_rev<1>(
       poisson_log_lpmf_functor_propto, n, alpha_scal);
 }

--- a/test/unit/math/opencl/rev/poisson_log_lpmf_test.cpp
+++ b/test/unit/math/opencl/rev/poisson_log_lpmf_test.cpp
@@ -1,0 +1,103 @@
+#ifdef STAN_OPENCL
+#include <stan/math/opencl/rev/opencl.hpp>
+#include <stan/math.hpp>
+#include <gtest/gtest.h>
+#include <test/unit/math/opencl/util.hpp>
+#include <vector>
+
+TEST(ProbDistributionsPoissonLog, error_checking) {
+  int N = 3;
+
+  std::vector<int> n{1, 0, 5};
+  std::vector<int> n_size{1, 6, 1, 0};
+  std::vector<int> n_value{0, -1, 23};
+  Eigen::VectorXd alpha(N);
+  alpha << 0.3, 0.8, 1.5;
+  Eigen::VectorXd alpha_size(N - 1);
+  alpha_size << 0.3, 0.8;
+  Eigen::VectorXd alpha_value(N);
+  alpha_value << 0.3, NAN, 0.5;
+
+  stan::math::matrix_cl<int> n_cl(n);
+  stan::math::matrix_cl<int> n_size_cl(n_size);
+  stan::math::matrix_cl<int> n_value_cl(n_value);
+  stan::math::matrix_cl<double> alpha_cl(alpha);
+  stan::math::matrix_cl<double> alpha_size_cl(alpha_size);
+  stan::math::matrix_cl<double> alpha_value_cl(alpha_value);
+
+  EXPECT_NO_THROW(stan::math::poisson_lpmf(n_cl, alpha_cl));
+
+  EXPECT_THROW(stan::math::poisson_lpmf(n_size_cl, alpha_cl),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::poisson_lpmf(n_cl, alpha_size_cl),
+               std::invalid_argument);
+
+  EXPECT_THROW(stan::math::poisson_lpmf(n_value_cl, alpha_cl),
+               std::domain_error);
+  EXPECT_THROW(stan::math::poisson_lpmf(n_cl, alpha_value_cl),
+               std::domain_error);
+}
+
+auto poisson_lpmf_functor = [](const auto& n, const auto& alpha) {
+  return stan::math::poisson_lpmf(n, alpha);
+};
+auto poisson_lpmf_functor_propto = [](const auto& n, const auto& alpha) {
+  return stan::math::poisson_lpmf<true>(n, alpha);
+};
+
+TEST(ProbDistributionsPoissonLog, opencl_matches_cpu_small) {
+  int N = 3;
+  int M = 2;
+
+  std::vector<int> n{0, 1, 6};
+  Eigen::VectorXd alpha(N);
+  alpha << 0.3, 0.8, 2.0;
+
+  stan::math::test::compare_cpu_opencl_prim_rev(poisson_lpmf_functor, n,
+                                                alpha);
+  stan::math::test::compare_cpu_opencl_prim_rev(poisson_lpmf_functor_propto,
+                                                n, alpha);
+}
+
+TEST(ProbDistributionsPoissonLog, opencl_broadcast_n) {
+  int N = 3;
+
+  int n_scal = 1;
+  Eigen::VectorXd alpha(N);
+  alpha << 0.3, 0.8, 1.0;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(poisson_lpmf_functor,
+                                                         n_scal, alpha);
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(
+      poisson_lpmf_functor_propto, n_scal, alpha);
+}
+
+TEST(ProbDistributionsPoissonLog, opencl_broadcast_alpha) {
+  int N = 3;
+
+  std::vector<int> n{0, 1, 5};
+  double alpha_scal = 0.4;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<1>(poisson_lpmf_functor,
+                                                         n, alpha_scal);
+  stan::math::test::test_opencl_broadcasting_prim_rev<1>(
+      poisson_lpmf_functor_propto, n, alpha_scal);
+}
+
+TEST(ProbDistributionsPoissonLog, opencl_matches_cpu_big) {
+  int N = 153;
+
+  std::vector<int> n(N);
+  for (int i = 0; i < N; i++) {
+    n[i] = Eigen::Array<int, Eigen::Dynamic, 1>::Random(1, 1).abs()(0);
+  }
+  Eigen::Matrix<double, Eigen::Dynamic, 1> alpha
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1);
+
+  stan::math::test::compare_cpu_opencl_prim_rev(poisson_lpmf_functor, n,
+                                                alpha);
+  stan::math::test::compare_cpu_opencl_prim_rev(poisson_lpmf_functor_propto,
+                                                n, alpha);
+}
+
+#endif

--- a/test/unit/math/opencl/rev/poisson_lpmf_test.cpp
+++ b/test/unit/math/opencl/rev/poisson_lpmf_test.cpp
@@ -53,10 +53,9 @@ TEST(ProbDistributionsPoisson, opencl_matches_cpu_small) {
   Eigen::VectorXd alpha(N);
   alpha << 0.3, 0.8, 2.0;
 
-  stan::math::test::compare_cpu_opencl_prim_rev(poisson_lpmf_functor, n,
+  stan::math::test::compare_cpu_opencl_prim_rev(poisson_lpmf_functor, n, alpha);
+  stan::math::test::compare_cpu_opencl_prim_rev(poisson_lpmf_functor_propto, n,
                                                 alpha);
-  stan::math::test::compare_cpu_opencl_prim_rev(poisson_lpmf_functor_propto,
-                                                n, alpha);
 }
 
 TEST(ProbDistributionsPoisson, opencl_broadcast_n) {
@@ -94,10 +93,9 @@ TEST(ProbDistributionsPoisson, opencl_matches_cpu_big) {
   Eigen::Matrix<double, Eigen::Dynamic, 1> alpha
       = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
 
-  stan::math::test::compare_cpu_opencl_prim_rev(poisson_lpmf_functor, n,
+  stan::math::test::compare_cpu_opencl_prim_rev(poisson_lpmf_functor, n, alpha);
+  stan::math::test::compare_cpu_opencl_prim_rev(poisson_lpmf_functor_propto, n,
                                                 alpha);
-  stan::math::test::compare_cpu_opencl_prim_rev(poisson_lpmf_functor_propto,
-                                                n, alpha);
 }
 
 #endif

--- a/test/unit/math/opencl/rev/poisson_lpmf_test.cpp
+++ b/test/unit/math/opencl/rev/poisson_lpmf_test.cpp
@@ -5,7 +5,7 @@
 #include <test/unit/math/opencl/util.hpp>
 #include <vector>
 
-TEST(ProbDistributionsPoissonLog, error_checking) {
+TEST(ProbDistributionsPoisson, error_checking) {
   int N = 3;
 
   std::vector<int> n{1, 0, 5};
@@ -25,27 +25,27 @@ TEST(ProbDistributionsPoissonLog, error_checking) {
   stan::math::matrix_cl<double> alpha_size_cl(alpha_size);
   stan::math::matrix_cl<double> alpha_value_cl(alpha_value);
 
-  EXPECT_NO_THROW(stan::math::poisson_log_lpmf(n_cl, alpha_cl));
+  EXPECT_NO_THROW(stan::math::poisson_lpmf(n_cl, alpha_cl));
 
-  EXPECT_THROW(stan::math::poisson_log_lpmf(n_size_cl, alpha_cl),
+  EXPECT_THROW(stan::math::poisson_lpmf(n_size_cl, alpha_cl),
                std::invalid_argument);
-  EXPECT_THROW(stan::math::poisson_log_lpmf(n_cl, alpha_size_cl),
+  EXPECT_THROW(stan::math::poisson_lpmf(n_cl, alpha_size_cl),
                std::invalid_argument);
 
-  EXPECT_THROW(stan::math::poisson_log_lpmf(n_value_cl, alpha_cl),
+  EXPECT_THROW(stan::math::poisson_lpmf(n_value_cl, alpha_cl),
                std::domain_error);
-  EXPECT_THROW(stan::math::poisson_log_lpmf(n_cl, alpha_value_cl),
+  EXPECT_THROW(stan::math::poisson_lpmf(n_cl, alpha_value_cl),
                std::domain_error);
 }
 
-auto poisson_log_lpmf_functor = [](const auto& n, const auto& alpha) {
-  return stan::math::poisson_log_lpmf(n, alpha);
+auto poisson_lpmf_functor = [](const auto& n, const auto& alpha) {
+  return stan::math::poisson_lpmf(n, alpha);
 };
-auto poisson_log_lpmf_functor_propto = [](const auto& n, const auto& alpha) {
-  return stan::math::poisson_log_lpmf<true>(n, alpha);
+auto poisson_lpmf_functor_propto = [](const auto& n, const auto& alpha) {
+  return stan::math::poisson_lpmf<true>(n, alpha);
 };
 
-TEST(ProbDistributionsPoissonLog, opencl_matches_cpu_small) {
+TEST(ProbDistributionsPoisson, opencl_matches_cpu_small) {
   int N = 3;
   int M = 2;
 
@@ -53,38 +53,38 @@ TEST(ProbDistributionsPoissonLog, opencl_matches_cpu_small) {
   Eigen::VectorXd alpha(N);
   alpha << 0.3, 0.8, 2.0;
 
-  stan::math::test::compare_cpu_opencl_prim_rev(poisson_log_lpmf_functor, n,
+  stan::math::test::compare_cpu_opencl_prim_rev(poisson_lpmf_functor, n,
                                                 alpha);
-  stan::math::test::compare_cpu_opencl_prim_rev(poisson_log_lpmf_functor_propto,
+  stan::math::test::compare_cpu_opencl_prim_rev(poisson_lpmf_functor_propto,
                                                 n, alpha);
 }
 
-TEST(ProbDistributionsPoissonLog, opencl_broadcast_n) {
+TEST(ProbDistributionsPoisson, opencl_broadcast_n) {
   int N = 3;
 
   int n_scal = 1;
   Eigen::VectorXd alpha(N);
   alpha << 0.3, 0.8, 1.0;
 
-  stan::math::test::test_opencl_broadcasting_prim_rev<0>(poisson_log_lpmf_functor,
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(poisson_lpmf_functor,
                                                          n_scal, alpha);
   stan::math::test::test_opencl_broadcasting_prim_rev<0>(
-      poisson_log_lpmf_functor_propto, n_scal, alpha);
+      poisson_lpmf_functor_propto, n_scal, alpha);
 }
 
-TEST(ProbDistributionsPoissonLog, opencl_broadcast_alpha) {
+TEST(ProbDistributionsPoisson, opencl_broadcast_alpha) {
   int N = 3;
 
   std::vector<int> n{0, 1, 5};
   double alpha_scal = 0.4;
 
-  stan::math::test::test_opencl_broadcasting_prim_rev<1>(poisson_log_lpmf_functor,
+  stan::math::test::test_opencl_broadcasting_prim_rev<1>(poisson_lpmf_functor,
                                                          n, alpha_scal);
   stan::math::test::test_opencl_broadcasting_prim_rev<1>(
-      poisson_log_lpmf_functor_propto, n, alpha_scal);
+      poisson_lpmf_functor_propto, n, alpha_scal);
 }
 
-TEST(ProbDistributionsPoissonLog, opencl_matches_cpu_big) {
+TEST(ProbDistributionsPoisson, opencl_matches_cpu_big) {
   int N = 153;
 
   std::vector<int> n(N);
@@ -92,11 +92,11 @@ TEST(ProbDistributionsPoissonLog, opencl_matches_cpu_big) {
     n[i] = Eigen::Array<int, Eigen::Dynamic, 1>::Random(1, 1).abs()(0);
   }
   Eigen::Matrix<double, Eigen::Dynamic, 1> alpha
-      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1);
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
 
-  stan::math::test::compare_cpu_opencl_prim_rev(poisson_log_lpmf_functor, n,
+  stan::math::test::compare_cpu_opencl_prim_rev(poisson_lpmf_functor, n,
                                                 alpha);
-  stan::math::test::compare_cpu_opencl_prim_rev(poisson_log_lpmf_functor_propto,
+  stan::math::test::compare_cpu_opencl_prim_rev(poisson_lpmf_functor_propto,
                                                 n, alpha);
 }
 


### PR DESCRIPTION
## Summary

Added OpenCL implementations for functions `pareto_type_2_lpdf`, `poisson_log_plmf` and `poisson_log_lpmf`.

Also added support  for function `multiply_log` to kernel generator.

## Tests

New functions are tested.

## Side Effects

None.

## Release notes

Added OpenCL implementations for functions `pareto_type_2_lpdf`, `poisson_log_plmf` and `poisson_log_lpmf`.

Also added support  for function `multiply_log` to kernel generator.

## Checklist

- [ ] Math issue #2152

- [ ] Copyright holder: Tadej Ciglarič

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [ ] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [ ] the code is written in idiomatic C++ and changes are documented in the doxygen

- [ ] the new changes are tested
