### PR TITLE
Opencl rayleigh_lpdf, scaled_inv_chi_square and skew_normal_lpdf

### DIFF
--- a/stan/math/opencl/opencl.hpp
+++ b/stan/math/opencl/opencl.hpp
@@ -143,6 +143,7 @@
 #include <stan/math/opencl/prim/rep_vector.hpp>
 #include <stan/math/opencl/prim/row.hpp>
 #include <stan/math/opencl/prim/rows.hpp>
+#include <stan/math/opencl/prim/scaled_inv_chi_square_lpdf.hpp>
 #include <stan/math/opencl/prim/sign.hpp>
 #include <stan/math/opencl/prim/size.hpp>
 #include <stan/math/opencl/prim/sum.hpp>

--- a/stan/math/opencl/opencl.hpp
+++ b/stan/math/opencl/opencl.hpp
@@ -146,6 +146,7 @@
 #include <stan/math/opencl/prim/scaled_inv_chi_square_lpdf.hpp>
 #include <stan/math/opencl/prim/sign.hpp>
 #include <stan/math/opencl/prim/size.hpp>
+#include <stan/math/opencl/prim/skew_normal_lpdf.hpp>
 #include <stan/math/opencl/prim/sum.hpp>
 #include <stan/math/opencl/prim/tcrossprod.hpp>
 

--- a/stan/math/opencl/opencl.hpp
+++ b/stan/math/opencl/opencl.hpp
@@ -137,6 +137,7 @@
 #include <stan/math/opencl/prim/ordered_logistic_glm_lpmf.hpp>
 #include <stan/math/opencl/prim/pareto_lpdf.hpp>
 #include <stan/math/opencl/prim/poisson_log_glm_lpmf.hpp>
+#include <stan/math/opencl/prim/rayleigh_lpdf.hpp>
 #include <stan/math/opencl/prim/rep_matrix.hpp>
 #include <stan/math/opencl/prim/rep_row_vector.hpp>
 #include <stan/math/opencl/prim/rep_vector.hpp>

--- a/stan/math/opencl/prim/rayleigh_lpdf.hpp
+++ b/stan/math/opencl/prim/rayleigh_lpdf.hpp
@@ -1,0 +1,97 @@
+#ifndef STAN_MATH_OPENCL_PRIM_RAYLEIGH_LPDF_HPP
+#define STAN_MATH_OPENCL_PRIM_RAYLEIGH_LPDF_HPP
+#ifdef STAN_OPENCL
+
+#include <stan/math/opencl/kernel_generator.hpp>
+#include <stan/math/opencl/prim/size.hpp>
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/err.hpp>
+#include <stan/math/prim/fun/max_size.hpp>
+#include <stan/math/prim/functor/operands_and_partials.hpp>
+
+namespace stan {
+namespace math {
+
+/** \ingroup opencl
+ * The log of an Rayleigh density for y with the specified
+ * scale parameter.
+ * y and scale parameter must be greater than 0.
+ *
+ * @tparam T_y_cl type of scalar
+ * @tparam T_scale_cl type of inverse scale
+ * @param y A scalar variable.
+ * @param sigma Inverse scale parameter.
+ * @throw std::domain_error if sigma is not greater than 0.
+ * @throw std::domain_error if y is not greater than or equal to 0.
+ */
+template <
+    bool propto, typename T_y_cl, typename T_scale_cl,
+    require_all_prim_or_rev_kernel_expression_t<T_y_cl, T_scale_cl>* = nullptr,
+    require_any_not_stan_scalar_t<T_y_cl, T_scale_cl>* = nullptr>
+return_type_t<T_y_cl, T_scale_cl> rayleigh_lpdf(const T_y_cl& y,
+                                                const T_scale_cl& sigma) {
+  static const char* function = "rayleigh_lpdf(OpenCL)";
+  using T_partials_return = partials_return_t<T_y_cl, T_scale_cl>;
+
+  check_consistent_sizes(function, "Random variable", y, "Scale parameter",
+                         sigma);
+  const size_t N = max_size(y, sigma);
+  if (N == 0) {
+    return 0.0;
+  }
+  if (!include_summand<propto, T_y_cl, T_scale_cl>::value) {
+    return 0.0;
+  }
+
+  const auto& y_val = value_of(y);
+  const auto& sigma_val = value_of(sigma);
+
+  operands_and_partials<T_y_cl, T_scale_cl> ops_partials(y, sigma);
+
+  auto check_y_positive
+      = check_cl(function, "Random variable", y_val, "positive");
+  auto y_positive = y_val > 0;
+  auto check_sigma_positive
+      = check_cl(function, "Scale parameter", sigma_val, "positive");
+  auto sigma_positive = sigma_val > 0;
+
+  auto inv_sigma = elt_divide(1.0, sigma_val);
+  auto y_over_sigma = elt_divide(y_val, sigma_val);
+
+  auto logp1 = -0.5 * elt_multiply(y_over_sigma, y_over_sigma);
+  auto logp2 = static_select<include_summand<propto, T_scale_cl>::value>(
+      logp1 - 2.0 * log(sigma_val), logp1);
+  auto logp_expr
+      = colwise_sum(static_select<include_summand<propto, T_y_cl>::value>(
+          logp2 + log(y_val), logp2));
+
+  auto scaled_diff = elt_multiply(inv_sigma, y_over_sigma);
+  auto y_deriv_expr = elt_divide(1.0, y_val) - scaled_diff;
+  auto sigma_deriv_expr = elt_multiply(y_over_sigma, scaled_diff) - 2.0 * inv_sigma;
+
+  matrix_cl<double> logp_cl;
+  matrix_cl<double> y_deriv_cl;
+  matrix_cl<double> sigma_deriv_cl;
+
+  results(check_y_positive, check_sigma_positive, logp_cl, y_deriv_cl,
+          sigma_deriv_cl)
+      = expressions(y_positive, sigma_positive, logp_expr,
+                    calc_if<!is_constant<T_y_cl>::value>(y_deriv_expr),
+                    calc_if<!is_constant<T_scale_cl>::value>(sigma_deriv_expr));
+
+  T_partials_return logp = sum(from_matrix_cl(logp_cl));
+
+  if (!is_constant<T_y_cl>::value) {
+    ops_partials.edge1_.partials_ = std::move(y_deriv_cl);
+  }
+  if (!is_constant<T_scale_cl>::value) {
+    ops_partials.edge2_.partials_ = std::move(sigma_deriv_cl);
+  }
+
+  return ops_partials.build(logp);
+}
+
+}  // namespace math
+}  // namespace stan
+#endif
+#endif

--- a/stan/math/opencl/prim/rayleigh_lpdf.hpp
+++ b/stan/math/opencl/prim/rayleigh_lpdf.hpp
@@ -67,7 +67,8 @@ return_type_t<T_y_cl, T_scale_cl> rayleigh_lpdf(const T_y_cl& y,
 
   auto scaled_diff = elt_multiply(inv_sigma, y_over_sigma);
   auto y_deriv_expr = elt_divide(1.0, y_val) - scaled_diff;
-  auto sigma_deriv_expr = elt_multiply(y_over_sigma, scaled_diff) - 2.0 * inv_sigma;
+  auto sigma_deriv_expr
+      = elt_multiply(y_over_sigma, scaled_diff) - 2.0 * inv_sigma;
 
   matrix_cl<double> logp_cl;
   matrix_cl<double> y_deriv_cl;

--- a/stan/math/opencl/prim/scaled_inv_chi_square_lpdf.hpp
+++ b/stan/math/opencl/prim/scaled_inv_chi_square_lpdf.hpp
@@ -1,0 +1,142 @@
+#ifndef STAN_MATH_OPENCL_PRIM_SCALED_INV_CHI_SQUARE_LPDF_HPP
+#define STAN_MATH_OPENCL_PRIM_SCALED_INV_CHI_SQUARE_LPDF_HPP
+#ifdef STAN_OPENCL
+
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/err.hpp>
+#include <stan/math/prim/fun/constants.hpp>
+#include <stan/math/prim/fun/elt_divide.hpp>
+#include <stan/math/prim/fun/elt_multiply.hpp>
+#include <stan/math/opencl/kernel_generator.hpp>
+#include <stan/math/prim/functor/operands_and_partials.hpp>
+
+namespace stan {
+namespace math {
+
+/** \ingroup opencl
+ * The log of a scaled inverse chi-squared density for y with the
+ * specified degrees of freedom parameter and scale parameter.
+ *
+ \f{eqnarray*}{
+ y &\sim& \mbox{\sf{Inv-}}\chi^2(\nu, s^2) \\
+ \log (p (y \, |\, \nu, s)) &=& \log \left( \frac{(\nu / 2)^{\nu / 2}}{\Gamma
+ (\nu / 2)} s^\nu y^{- (\nu / 2 + 1)} \exp^{-\nu s^2 / (2y)} \right) \\
+ &=& \frac{\nu}{2} \log(\frac{\nu}{2}) - \log (\Gamma (\nu / 2)) + \nu \log(s) -
+ (\frac{\nu}{2} + 1) \log(y) - \frac{\nu s^2}{2y} \\ & & \mathrm{ where } \; y >
+ 0 \f}
+ *
+ * @tparam T_y_cl type of random variable
+ * @tparam T_dof_cl type of degrees of freedom
+ * @tparam T_Scale_cl type of scale
+ * @param y random variable
+ * @param nu degrees of freedom
+ * @param s Scale parameter.
+ * @throw std::domain_error if nu is not greater than 0
+ * @throw std::domain_error if s is not greater than 0.
+ * @throw std::domain_error if y is not greater than 0.
+ */
+template <
+    bool propto, typename T_y_cl, typename T_dof_cl, typename T_scale_cl,
+    require_all_prim_or_rev_kernel_expression_t<T_y_cl, T_dof_cl,
+                                                T_scale_cl>* = nullptr,
+    require_any_not_stan_scalar_t<T_y_cl, T_dof_cl, T_scale_cl>* = nullptr>
+inline return_type_t<T_y_cl, T_dof_cl, T_scale_cl> scaled_inv_chi_square_lpdf(
+    const T_y_cl& y, const T_dof_cl& nu, const T_scale_cl& s) {
+  static const char* function = "scaled_inv_chi_square_lpdf(OpenCL)";
+  using T_partials_return = partials_return_t<T_y_cl, T_dof_cl, T_scale_cl>;
+  using std::isfinite;
+  using std::isnan;
+
+  check_consistent_sizes(function, "Random variable", y,
+                         "Degrees of freedom parameter", nu, "Scale parameter",
+                         s);
+  const size_t N = max_size(y, nu, s);
+  if (N == 0) {
+    return 0.0;
+  }
+  if (!include_summand<propto, T_y_cl, T_dof_cl, T_scale_cl>::value) {
+    return 0.0;
+  }
+
+  const auto& y_val = value_of(y);
+  const auto& nu_val = value_of(nu);
+  const auto& s_val = value_of(s);
+
+  auto check_y_not_nan
+      = check_cl(function, "Random variable", y_val, "not NaN");
+  auto y_not_nan = !isnan(y_val);
+  auto check_nu_positive_finite = check_cl(
+      function, "Degrees of freedom parameter", nu_val, "positive finite");
+  auto nu_positive_finite = isfinite(nu_val) && 0 < nu_val;
+  auto check_s_positive_finite
+      = check_cl(function, "Scale parameter", s_val, "positive finite");
+  auto s_positive_finite = isfinite(s_val) && 0 < s_val;
+
+  auto any_y_nonpositive = colwise_max(constant(0, N, 1) + (y_val <= 0.0));
+  auto half_nu = 0.5 * nu_val;
+  auto log_y = log(y_val);
+  auto inv_y = elt_divide(1.0, y_val);
+  auto log_s = log(s_val);
+  auto log_half_nu = log(half_nu);
+  auto s_square = elt_multiply(s_val, s_val);
+
+  auto logp1 = static_select<include_summand<propto, T_dof_cl>::value>(
+      elt_multiply(half_nu, log_half_nu) - lgamma(half_nu), constant(0, N, 1));
+  auto logp2
+      = static_select<include_summand<propto, T_dof_cl, T_scale_cl>::value>(
+          logp1 + elt_multiply(nu_val, log_s), logp1);
+  auto logp3 = static_select<include_summand<propto, T_dof_cl, T_y_cl>::value>(
+      logp2 - elt_multiply(half_nu + 1.0, log_y), logp2);
+  auto logp_expr = colwise_sum(
+      static_select<
+          include_summand<propto, T_dof_cl, T_y_cl, T_scale_cl>::value>(
+          logp3 - elt_multiply(elt_multiply(half_nu, s_square), inv_y), logp3));
+
+  auto y_deriv = -elt_multiply(half_nu + 1.0, inv_y)
+                 + elt_multiply(elt_multiply(half_nu, s_square),
+                                elt_multiply(inv_y, inv_y));
+  auto nu_deriv = 0.5
+                      * (log_half_nu - digamma(half_nu) - log_y
+                         - elt_multiply(s_square, inv_y))
+                  + log_s + 0.5;
+  auto s_deriv = elt_divide(nu_val, s_val)
+                 - elt_multiply(elt_multiply(nu_val, inv_y), s_val);
+
+  matrix_cl<int> any_y_nonpositive_cl;
+  matrix_cl<double> logp_cl;
+  matrix_cl<double> nu_deriv_cl;
+  matrix_cl<double> y_deriv_cl;
+  matrix_cl<double> s_deriv_cl;
+
+  results(check_y_not_nan, check_nu_positive_finite, check_s_positive_finite,
+          any_y_nonpositive_cl, logp_cl, y_deriv_cl, nu_deriv_cl, s_deriv_cl)
+      = expressions(y_not_nan, nu_positive_finite, s_positive_finite,
+                    any_y_nonpositive, logp_expr,
+                    calc_if<!is_constant<T_y_cl>::value>(y_deriv),
+                    calc_if<!is_constant<T_dof_cl>::value>(nu_deriv),
+                    calc_if<!is_constant<T_scale_cl>::value>(s_deriv));
+
+  if (from_matrix_cl(any_y_nonpositive_cl).any()) {
+    return LOG_ZERO;
+  }
+
+  T_partials_return logp = sum(from_matrix_cl(logp_cl));
+
+  operands_and_partials<T_y_cl, T_dof_cl, T_scale_cl> ops_partials(y, nu, s);
+
+  if (!is_constant<T_y_cl>::value) {
+    ops_partials.edge1_.partials_ = std::move(y_deriv_cl);
+  }
+  if (!is_constant<T_dof_cl>::value) {
+    ops_partials.edge2_.partials_ = std::move(nu_deriv_cl);
+  }
+  if (!is_constant<T_scale_cl>::value) {
+    ops_partials.edge3_.partials_ = std::move(s_deriv_cl);
+  }
+  return ops_partials.build(logp);
+}
+
+}  // namespace math
+}  // namespace stan
+#endif
+#endif

--- a/stan/math/opencl/prim/skew_normal_lpdf.hpp
+++ b/stan/math/opencl/prim/skew_normal_lpdf.hpp
@@ -25,10 +25,11 @@ namespace math {
  * @tparam T_y_cl type of scalar
  * @tparam T_loc_cl type of location parameter
  * @tparam T_scale_cl type of scale parameter
+ * @tparam T_shape_cl type of shape parameter
  * @param y (Sequence of) scalar(s).
  * @param mu (Sequence of) location parameter(s)
- * for the normal distribution.
- * @param sigma (Sequence of) scale parameters for the normal distribution.
+ * @param sigma (Sequence of) scale parameter(s)
+ * @param alpha (Sequence of) shape parameter(s)
  * @return The log of the product of the densities.
  * @throw std::domain_error if the scale is not positive.
  */

--- a/stan/math/opencl/prim/skew_normal_lpdf.hpp
+++ b/stan/math/opencl/prim/skew_normal_lpdf.hpp
@@ -1,0 +1,151 @@
+#ifndef STAN_MATH_OPENCL_PRIM_SKEW_NORMAL_LPDF_HPP
+#define STAN_MATH_OPENCL_PRIM_SKEW_NORMAL_LPDF_HPP
+#ifdef STAN_OPENCL
+
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/err.hpp>
+#include <stan/math/prim/fun/constants.hpp>
+#include <stan/math/prim/fun/elt_divide.hpp>
+#include <stan/math/prim/fun/elt_multiply.hpp>
+#include <stan/math/opencl/kernel_generator.hpp>
+#include <stan/math/prim/functor/operands_and_partials.hpp>
+
+namespace stan {
+namespace math {
+
+/** \ingroup opencl
+ * The log of the skew normal density for the specified scalar(s) given
+ * the specified mean(s), deviation(s) and shape(s). y, mu, sigma, or alpha can
+ * each be either a scalar or a vector matrix_cl. Any vector inputs
+ * must be the same length.
+ *
+ * <p>The result log probability is defined to be the sum of the
+ * log probabilities for each observation/mean/deviation quadruple.
+ *
+ * @tparam T_y_cl type of scalar
+ * @tparam T_loc_cl type of location parameter
+ * @tparam T_scale_cl type of scale parameter
+ * @param y (Sequence of) scalar(s).
+ * @param mu (Sequence of) location parameter(s)
+ * for the normal distribution.
+ * @param sigma (Sequence of) scale parameters for the normal distribution.
+ * @return The log of the product of the densities.
+ * @throw std::domain_error if the scale is not positive.
+ */
+template <bool propto, typename T_y_cl, typename T_loc_cl, typename T_scale_cl,
+          typename T_shape_cl,
+          require_all_prim_or_rev_kernel_expression_t<
+              T_y_cl, T_loc_cl, T_scale_cl, T_shape_cl>* = nullptr,
+          require_any_not_stan_scalar_t<T_y_cl, T_loc_cl, T_scale_cl,
+                                        T_shape_cl>* = nullptr>
+inline return_type_t<T_y_cl, T_loc_cl, T_scale_cl, T_shape_cl> skew_normal_lpdf(
+    const T_y_cl& y, const T_loc_cl& mu, const T_scale_cl& sigma,
+    const T_shape_cl& alpha) {
+  static const char* function = "skew_normal_lpdf(OpenCL)";
+  using T_partials_return
+      = partials_return_t<T_y_cl, T_loc_cl, T_scale_cl, T_shape_cl>;
+  using std::isfinite;
+  using std::isnan;
+
+  check_consistent_sizes(function, "Random variable", y, "Location parameter",
+                         mu, "Scale parameter", sigma, "Shape paramter", alpha);
+  const size_t N = max_size(y, mu, sigma, alpha);
+  if (N == 0) {
+    return 0.0;
+  }
+  if (!include_summand<propto, T_y_cl, T_loc_cl, T_scale_cl,
+                       T_shape_cl>::value) {
+    return 0.0;
+  }
+
+  const auto& y_val = value_of(y);
+  const auto& mu_val = value_of(mu);
+  const auto& sigma_val = value_of(sigma);
+  const auto& alpha_val = value_of(alpha);
+
+  auto check_y_not_nan
+      = check_cl(function, "Random variable", y_val, "not NaN");
+  auto y_not_nan = !isnan(y_val);
+  auto check_mu_finite
+      = check_cl(function, "Location parameter", mu_val, "finite");
+  auto mu_finite = isfinite(mu_val);
+  auto check_sigma_positive
+      = check_cl(function, "Scale parameter", sigma_val, "positive");
+  auto sigma_positive = 0 < sigma_val;
+  auto check_alpha_finite
+      = check_cl(function, "Shape parameter", alpha_val, "finite");
+  auto alpha_finite = isfinite(alpha_val);
+
+  auto inv_sigma = elt_divide(1., sigma_val);
+  auto y_minus_mu_over_sigma = elt_multiply((y_val - mu_val), inv_sigma);
+  auto log_erfc_alpha_z = log(
+      erfc(elt_multiply(alpha_val, y_minus_mu_over_sigma) * -INV_SQRT_TWO));
+
+  auto logp1 = log_erfc_alpha_z;
+  auto logp2 = static_select<include_summand<propto, T_scale_cl>::value>(
+      logp1 - log(sigma_val), logp1);
+  auto logp_expr = colwise_sum(
+      static_select<
+          include_summand<propto, T_y_cl, T_loc_cl, T_scale_cl>::value>(
+          logp2
+              - elt_multiply(y_minus_mu_over_sigma, y_minus_mu_over_sigma)
+                    * 0.5,
+          logp2));
+
+  auto scaled = elt_multiply(alpha_val, y_minus_mu_over_sigma) * INV_SQRT_TWO;
+  auto deriv_logerf = SQRT_TWO_OVER_SQRT_PI
+                      * exp(-elt_multiply(scaled, scaled) - log_erfc_alpha_z);
+  auto y_loc_deriv = elt_multiply(
+      y_minus_mu_over_sigma - elt_multiply(deriv_logerf, alpha_val), inv_sigma);
+  auto sigma_deriv
+      = elt_multiply(elt_multiply(y_minus_mu_over_sigma
+                                      - elt_multiply(deriv_logerf, alpha_val),
+                                  y_minus_mu_over_sigma)
+                         - 1,
+                     inv_sigma);
+  auto alpha_deriv = elt_multiply(deriv_logerf, y_minus_mu_over_sigma);
+
+  matrix_cl<double> logp_cl;
+  matrix_cl<double> mu_deriv_cl;
+  matrix_cl<double> y_deriv_cl;
+  matrix_cl<double> sigma_deriv_cl;
+  matrix_cl<double> alpha_deriv_cl;
+
+  results(check_y_not_nan, check_mu_finite, check_sigma_positive,
+          check_alpha_finite, logp_cl, y_deriv_cl, mu_deriv_cl, sigma_deriv_cl,
+          alpha_deriv_cl)
+      = expressions(y_not_nan, mu_finite, sigma_positive, alpha_finite,
+                    logp_expr,
+                    calc_if<!is_constant<T_y_cl>::value>(-y_loc_deriv),
+                    calc_if<!is_constant<T_loc_cl>::value>(y_loc_deriv),
+                    calc_if<!is_constant<T_scale_cl>::value>(sigma_deriv),
+                    calc_if<!is_constant<T_shape_cl>::value>(alpha_deriv));
+
+  T_partials_return logp = sum(from_matrix_cl(logp_cl));
+
+  if (include_summand<propto>::value) {
+    logp -= HALF_LOG_TWO_PI * N;
+  }
+
+  operands_and_partials<T_y_cl, T_loc_cl, T_scale_cl, T_shape_cl> ops_partials(
+      y, mu, sigma, alpha);
+
+  if (!is_constant<T_y_cl>::value) {
+    ops_partials.edge1_.partials_ = std::move(y_deriv_cl);
+  }
+  if (!is_constant<T_loc_cl>::value) {
+    ops_partials.edge2_.partials_ = std::move(mu_deriv_cl);
+  }
+  if (!is_constant<T_scale_cl>::value) {
+    ops_partials.edge3_.partials_ = std::move(sigma_deriv_cl);
+  }
+  if (!is_constant<T_shape_cl>::value) {
+    ops_partials.edge4_.partials_ = std::move(alpha_deriv_cl);
+  }
+  return ops_partials.build(logp);
+}
+
+}  // namespace math
+}  // namespace stan
+#endif
+#endif

--- a/stan/math/prim/fun/log.hpp
+++ b/stan/math/prim/fun/log.hpp
@@ -44,7 +44,7 @@ struct log_fun {
  */
 template <typename Container,
           require_not_container_st<std::is_arithmetic, Container>* = nullptr,
-          require_not_matrix_cl_t<Container>* = nullptr>
+          require_not_nonscalar_prim_or_rev_kernel_expression_t<Container>* = nullptr>
 inline auto log(const Container& x) {
   return apply_scalar_unary<log_fun, Container>::apply(x);
 }

--- a/stan/math/prim/fun/log.hpp
+++ b/stan/math/prim/fun/log.hpp
@@ -42,9 +42,10 @@ struct log_fun {
  * @param[in] x container
  * @return Elementwise application of natural log to the argument.
  */
-template <typename Container,
-          require_not_container_st<std::is_arithmetic, Container>* = nullptr,
-          require_not_nonscalar_prim_or_rev_kernel_expression_t<Container>* = nullptr>
+template <
+    typename Container,
+    require_not_container_st<std::is_arithmetic, Container>* = nullptr,
+    require_not_nonscalar_prim_or_rev_kernel_expression_t<Container>* = nullptr>
 inline auto log(const Container& x) {
   return apply_scalar_unary<log_fun, Container>::apply(x);
 }

--- a/stan/math/prim/prob/rayleigh_lpdf.hpp
+++ b/stan/math/prim/prob/rayleigh_lpdf.hpp
@@ -16,7 +16,9 @@
 namespace stan {
 namespace math {
 
-template <bool propto, typename T_y, typename T_scale>
+template <bool propto, typename T_y, typename T_scale,
+          require_all_not_nonscalar_prim_or_rev_kernel_expression_t<
+              T_y, T_scale>* = nullptr>
 return_type_t<T_y, T_scale> rayleigh_lpdf(const T_y& y, const T_scale& sigma) {
   using T_partials_return = partials_return_t<T_y, T_scale>;
   using T_y_ref = ref_type_if_t<!is_constant<T_y>::value, T_y>;

--- a/stan/math/prim/prob/scaled_inv_chi_square_lpdf.hpp
+++ b/stan/math/prim/prob/scaled_inv_chi_square_lpdf.hpp
@@ -32,6 +32,7 @@ namespace math {
  *
  * @tparam T_y type of scalar
  * @tparam T_dof type of degrees of freedom
+ * @tparam T_Scale type of scale
  * @param y A scalar variable.
  * @param nu Degrees of freedom.
  * @param s Scale parameter.
@@ -39,7 +40,9 @@ namespace math {
  * @throw std::domain_error if s is not greater than 0.
  * @throw std::domain_error if y is not greater than 0.
  */
-template <bool propto, typename T_y, typename T_dof, typename T_scale>
+template <bool propto, typename T_y, typename T_dof, typename T_scale,
+          require_all_not_nonscalar_prim_or_rev_kernel_expression_t<
+              T_y, T_dof, T_scale>* = nullptr>
 return_type_t<T_y, T_dof, T_scale> scaled_inv_chi_square_lpdf(
     const T_y& y, const T_dof& nu, const T_scale& s) {
   using T_partials_return = partials_return_t<T_y, T_dof, T_scale>;

--- a/stan/math/prim/prob/skew_normal_lpdf.hpp
+++ b/stan/math/prim/prob/skew_normal_lpdf.hpp
@@ -20,7 +20,9 @@ namespace stan {
 namespace math {
 
 template <bool propto, typename T_y, typename T_loc, typename T_scale,
-          typename T_shape>
+          typename T_shape,
+          require_all_not_nonscalar_prim_or_rev_kernel_expression_t<
+              T_y, T_loc, T_scale, T_shape>* = nullptr>
 return_type_t<T_y, T_loc, T_scale, T_shape> skew_normal_lpdf(
     const T_y& y, const T_loc& mu, const T_scale& sigma, const T_shape& alpha) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale, T_shape>;

--- a/test/unit/math/opencl/rev/rayleigh_lpdf_test.cpp
+++ b/test/unit/math/opencl/rev/rayleigh_lpdf_test.cpp
@@ -61,8 +61,8 @@ TEST(ProbDistributionsRayleigh, opencl_matches_cpu_small) {
 
   stan::math::test::compare_cpu_opencl_prim_rev(rayleigh_lpdf_functor, y,
                                                 sigma);
-  stan::math::test::compare_cpu_opencl_prim_rev(rayleigh_lpdf_functor_propto,
-                                                y, sigma);
+  stan::math::test::compare_cpu_opencl_prim_rev(rayleigh_lpdf_functor_propto, y,
+                                                sigma);
 }
 
 TEST(ProbDistributionsRayleigh, opencl_broadcast_y) {
@@ -72,8 +72,8 @@ TEST(ProbDistributionsRayleigh, opencl_broadcast_y) {
   Eigen::VectorXd sigma(N);
   sigma << 0.3, 0.8, 1.0;
 
-  stan::math::test::test_opencl_broadcasting_prim_rev<0>(
-      rayleigh_lpdf_functor, y, sigma);
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(rayleigh_lpdf_functor,
+                                                         y, sigma);
   stan::math::test::test_opencl_broadcasting_prim_rev<0>(
       rayleigh_lpdf_functor_propto, y, sigma);
 }
@@ -85,8 +85,8 @@ TEST(ProbDistributionsRayleigh, opencl_broadcast_sigma) {
   y << 0.3, 0.8, 1.0;
   double sigma = 9.3;
 
-  stan::math::test::test_opencl_broadcasting_prim_rev<1>(
-      rayleigh_lpdf_functor, y, sigma);
+  stan::math::test::test_opencl_broadcasting_prim_rev<1>(rayleigh_lpdf_functor,
+                                                         y, sigma);
   stan::math::test::test_opencl_broadcasting_prim_rev<1>(
       rayleigh_lpdf_functor_propto, y, sigma);
 }
@@ -101,8 +101,8 @@ TEST(ProbDistributionsRayleigh, opencl_matches_cpu_big) {
 
   stan::math::test::compare_cpu_opencl_prim_rev(rayleigh_lpdf_functor, y,
                                                 sigma);
-  stan::math::test::compare_cpu_opencl_prim_rev(rayleigh_lpdf_functor_propto,
-                                                y, sigma);
+  stan::math::test::compare_cpu_opencl_prim_rev(rayleigh_lpdf_functor_propto, y,
+                                                sigma);
 }
 
 #endif

--- a/test/unit/math/opencl/rev/rayleigh_lpdf_test.cpp
+++ b/test/unit/math/opencl/rev/rayleigh_lpdf_test.cpp
@@ -1,0 +1,108 @@
+#ifdef STAN_OPENCL
+#include <stan/math/opencl/rev/opencl.hpp>
+#include <stan/math.hpp>
+#include <gtest/gtest.h>
+#include <test/unit/math/opencl/util.hpp>
+#include <vector>
+
+TEST(ProbDistributionsRayleigh, error_checking) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.1, 0.5, 12.3;
+  Eigen::VectorXd y_size(N - 1);
+  y_size << 0.1, 0.5;
+  Eigen::VectorXd y_value(N);
+  y_value << -0.1, 0.5, 0.99;
+
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 12.4;
+  Eigen::VectorXd sigma_size(N - 1);
+  sigma_size << 0.3, 0.8;
+  Eigen::VectorXd sigma_value(N);
+  sigma_value << 0.3, -0.8, 0.5;
+
+  stan::math::matrix_cl<double> y_cl(y);
+  stan::math::matrix_cl<double> y_size_cl(y_size);
+  stan::math::matrix_cl<double> y_value_cl(y_value);
+
+  stan::math::matrix_cl<double> sigma_cl(sigma);
+  stan::math::matrix_cl<double> sigma_size_cl(sigma_size);
+  stan::math::matrix_cl<double> sigma_value_cl(sigma_value);
+
+  EXPECT_NO_THROW(stan::math::rayleigh_lpdf(y_cl, sigma_cl));
+
+  EXPECT_THROW(stan::math::rayleigh_lpdf(y_size_cl, sigma_cl),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::rayleigh_lpdf(y_cl, sigma_size_cl),
+               std::invalid_argument);
+
+  EXPECT_THROW(stan::math::rayleigh_lpdf(y_value_cl, sigma_cl),
+               std::domain_error);
+  EXPECT_THROW(stan::math::rayleigh_lpdf(y_cl, sigma_value_cl),
+               std::domain_error);
+}
+
+auto rayleigh_lpdf_functor = [](const auto& y, const auto& sigma) {
+  return stan::math::rayleigh_lpdf(y, sigma);
+};
+auto rayleigh_lpdf_functor_propto = [](const auto& y, const auto& sigma) {
+  return stan::math::rayleigh_lpdf<true>(y, sigma);
+};
+
+TEST(ProbDistributionsRayleigh, opencl_matches_cpu_small) {
+  int N = 3;
+  int M = 2;
+
+  Eigen::VectorXd y(N);
+  y << 0.1, 0.5, 12.3;
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 21.0;
+
+  stan::math::test::compare_cpu_opencl_prim_rev(rayleigh_lpdf_functor, y,
+                                                sigma);
+  stan::math::test::compare_cpu_opencl_prim_rev(rayleigh_lpdf_functor_propto,
+                                                y, sigma);
+}
+
+TEST(ProbDistributionsRayleigh, opencl_broadcast_y) {
+  int N = 3;
+
+  double y = 0.5;
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(
+      rayleigh_lpdf_functor, y, sigma);
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(
+      rayleigh_lpdf_functor_propto, y, sigma);
+}
+
+TEST(ProbDistributionsRayleigh, opencl_broadcast_sigma) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  double sigma = 9.3;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<1>(
+      rayleigh_lpdf_functor, y, sigma);
+  stan::math::test::test_opencl_broadcasting_prim_rev<1>(
+      rayleigh_lpdf_functor_propto, y, sigma);
+}
+
+TEST(ProbDistributionsRayleigh, opencl_matches_cpu_big) {
+  int N = 153;
+
+  Eigen::Matrix<double, Eigen::Dynamic, 1> y
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+  Eigen::Matrix<double, Eigen::Dynamic, 1> sigma
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+
+  stan::math::test::compare_cpu_opencl_prim_rev(rayleigh_lpdf_functor, y,
+                                                sigma);
+  stan::math::test::compare_cpu_opencl_prim_rev(rayleigh_lpdf_functor_propto,
+                                                y, sigma);
+}
+
+#endif

--- a/test/unit/math/opencl/rev/scaled_inv_chi_square_lpdf_test.cpp
+++ b/test/unit/math/opencl/rev/scaled_inv_chi_square_lpdf_test.cpp
@@ -86,10 +86,10 @@ TEST(ProbDistributionsScaledInvChiSquare, opencl_matches_cpu_small) {
   Eigen::VectorXd s(N);
   s << 0.3, 0.8, 1.0;
 
-  stan::math::test::compare_cpu_opencl_prim_rev(scaled_inv_chi_square_lpdf_functor_propto, y,
-                                                nu, s);
-  stan::math::test::compare_cpu_opencl_prim_rev(scaled_inv_chi_square_lpdf_functor, y, nu,
-                                                s);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      scaled_inv_chi_square_lpdf_functor_propto, y, nu, s);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      scaled_inv_chi_square_lpdf_functor, y, nu, s);
 }
 
 TEST(ProbDistributionsScaledInvChiSquare, opencl_matches_cpu_small_y_negative) {
@@ -103,10 +103,10 @@ TEST(ProbDistributionsScaledInvChiSquare, opencl_matches_cpu_small_y_negative) {
   Eigen::VectorXd s(N);
   s << 0.3, 0.8, 1.0;
 
-  stan::math::test::compare_cpu_opencl_prim_rev(scaled_inv_chi_square_lpdf_functor, y, nu,
-                                                s);
-  stan::math::test::compare_cpu_opencl_prim_rev(scaled_inv_chi_square_lpdf_functor_propto, y,
-                                                nu, s);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      scaled_inv_chi_square_lpdf_functor, y, nu, s);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      scaled_inv_chi_square_lpdf_functor_propto, y, nu, s);
 }
 
 TEST(ProbDistributionsScaledInvChiSquare, opencl_broadcast_y) {
@@ -118,8 +118,8 @@ TEST(ProbDistributionsScaledInvChiSquare, opencl_broadcast_y) {
   Eigen::VectorXd s(N);
   s << 0.3, 0.8, 1.0;
 
-  stan::math::test::test_opencl_broadcasting_prim_rev<0>(scaled_inv_chi_square_lpdf_functor,
-                                                         y_scal, nu, s);
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(
+      scaled_inv_chi_square_lpdf_functor, y_scal, nu, s);
   stan::math::test::test_opencl_broadcasting_prim_rev<0>(
       scaled_inv_chi_square_lpdf_functor_propto, y_scal, nu, s);
 }
@@ -133,8 +133,8 @@ TEST(ProbDistributionsScaledInvChiSquare, opencl_broadcast_nu) {
   Eigen::VectorXd s(N);
   s << 0.3, 0.8, 1.0;
 
-  stan::math::test::test_opencl_broadcasting_prim_rev<1>(scaled_inv_chi_square_lpdf_functor, y,
-                                                         nu_scal, s);
+  stan::math::test::test_opencl_broadcasting_prim_rev<1>(
+      scaled_inv_chi_square_lpdf_functor, y, nu_scal, s);
   stan::math::test::test_opencl_broadcasting_prim_rev<1>(
       scaled_inv_chi_square_lpdf_functor_propto, y, nu_scal, s);
 }
@@ -148,8 +148,8 @@ TEST(ProbDistributionsScaledInvChiSquare, opencl_broadcast_s) {
   nu << 0.3, 0.8, 1.0;
   double s_scal = 12.3;
 
-  stan::math::test::test_opencl_broadcasting_prim_rev<2>(scaled_inv_chi_square_lpdf_functor, y,
-                                                         nu, s_scal);
+  stan::math::test::test_opencl_broadcasting_prim_rev<2>(
+      scaled_inv_chi_square_lpdf_functor, y, nu, s_scal);
   stan::math::test::test_opencl_broadcasting_prim_rev<2>(
       scaled_inv_chi_square_lpdf_functor_propto, y, nu, s_scal);
 }
@@ -164,10 +164,10 @@ TEST(ProbDistributionsScaledInvChiSquare, opencl_matches_cpu_big) {
   Eigen::Matrix<double, Eigen::Dynamic, 1> s
       = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
 
-  stan::math::test::compare_cpu_opencl_prim_rev(scaled_inv_chi_square_lpdf_functor, y, nu,
-                                                s);
-  stan::math::test::compare_cpu_opencl_prim_rev(scaled_inv_chi_square_lpdf_functor_propto, y,
-                                                nu, s);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      scaled_inv_chi_square_lpdf_functor, y, nu, s);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      scaled_inv_chi_square_lpdf_functor_propto, y, nu, s);
 }
 
 #endif

--- a/test/unit/math/opencl/rev/scaled_inv_chi_square_lpdf_test.cpp
+++ b/test/unit/math/opencl/rev/scaled_inv_chi_square_lpdf_test.cpp
@@ -1,0 +1,173 @@
+#ifdef STAN_OPENCL
+#include <stan/math/opencl/rev/opencl.hpp>
+#include <stan/math.hpp>
+#include <gtest/gtest.h>
+#include <test/unit/math/opencl/util.hpp>
+#include <vector>
+
+TEST(ProbDistributionsScaledInvChiSquare, error_checking) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  Eigen::VectorXd y_size(N - 1);
+  y_size << 0.3, 0.8;
+  Eigen::VectorXd y_value(N);
+  y_value << 0.3, NAN, 0.5;
+
+  Eigen::VectorXd nu(N);
+  nu << 0.3, 0.8, 1.0;
+  Eigen::VectorXd nu_size(N - 1);
+  nu_size << 0.3, 0.8;
+  Eigen::VectorXd nu_value1(N);
+  nu_value1 << 0.3, 0, 0.5;
+  Eigen::VectorXd nu_value2(N);
+  nu_value2 << 0.3, INFINITY, 0.5;
+
+  Eigen::VectorXd s(N);
+  s << 0.3, 0.8, 1.0;
+  Eigen::VectorXd s_size(N - 1);
+  s_size << 0.3, 0.8;
+  Eigen::VectorXd s_value1(N);
+  s_value1 << 0.3, 0, 0.5;
+  Eigen::VectorXd s_value2(N);
+  s_value2 << 0.3, INFINITY, 0.5;
+
+  stan::math::matrix_cl<double> y_cl(y);
+  stan::math::matrix_cl<double> y_size_cl(y_size);
+  stan::math::matrix_cl<double> y_value_cl(y_value);
+  stan::math::matrix_cl<double> nu_cl(nu);
+  stan::math::matrix_cl<double> nu_size_cl(nu_size);
+  stan::math::matrix_cl<double> nu_value1_cl(nu_value1);
+  stan::math::matrix_cl<double> nu_value2_cl(nu_value2);
+  stan::math::matrix_cl<double> s_cl(s);
+  stan::math::matrix_cl<double> s_size_cl(s_size);
+  stan::math::matrix_cl<double> s_value1_cl(s_value1);
+  stan::math::matrix_cl<double> s_value2_cl(s_value2);
+
+  EXPECT_NO_THROW(stan::math::scaled_inv_chi_square_lpdf(y_cl, nu_cl, s_cl));
+
+  EXPECT_THROW(stan::math::scaled_inv_chi_square_lpdf(y_size_cl, nu_cl, s_cl),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::scaled_inv_chi_square_lpdf(y_cl, nu_size_cl, s_cl),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::scaled_inv_chi_square_lpdf(y_cl, nu_cl, s_size_cl),
+               std::invalid_argument);
+
+  EXPECT_THROW(stan::math::scaled_inv_chi_square_lpdf(y_value_cl, nu_cl, s_cl),
+               std::domain_error);
+  EXPECT_THROW(stan::math::scaled_inv_chi_square_lpdf(y_cl, nu_value1_cl, s_cl),
+               std::domain_error);
+  EXPECT_THROW(stan::math::scaled_inv_chi_square_lpdf(y_cl, nu_value2_cl, s_cl),
+               std::domain_error);
+  EXPECT_THROW(stan::math::scaled_inv_chi_square_lpdf(y_cl, nu_cl, s_value1_cl),
+               std::domain_error);
+  EXPECT_THROW(stan::math::scaled_inv_chi_square_lpdf(y_cl, nu_cl, s_value2_cl),
+               std::domain_error);
+}
+
+auto scaled_inv_chi_square_lpdf_functor
+    = [](const auto& y, const auto& nu, const auto& s) {
+        return stan::math::scaled_inv_chi_square_lpdf(y, nu, s);
+      };
+auto scaled_inv_chi_square_lpdf_functor_propto
+    = [](const auto& y, const auto& nu, const auto& s) {
+        return stan::math::scaled_inv_chi_square_lpdf<true>(y, nu, s);
+      };
+
+TEST(ProbDistributionsScaledInvChiSquare, opencl_matches_cpu_small) {
+  int N = 3;
+  int M = 2;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  Eigen::VectorXd nu(N);
+  nu << 0.3, 0.8, 1.0;
+  Eigen::VectorXd s(N);
+  s << 0.3, 0.8, 1.0;
+
+  stan::math::test::compare_cpu_opencl_prim_rev(scaled_inv_chi_square_lpdf_functor_propto, y,
+                                                nu, s);
+  stan::math::test::compare_cpu_opencl_prim_rev(scaled_inv_chi_square_lpdf_functor, y, nu,
+                                                s);
+}
+
+TEST(ProbDistributionsScaledInvChiSquare, opencl_matches_cpu_small_y_negative) {
+  int N = 3;
+  int M = 2;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, -0.8, 1.0;
+  Eigen::VectorXd nu(N);
+  nu << 0.3, 0.8, 1.0;
+  Eigen::VectorXd s(N);
+  s << 0.3, 0.8, 1.0;
+
+  stan::math::test::compare_cpu_opencl_prim_rev(scaled_inv_chi_square_lpdf_functor, y, nu,
+                                                s);
+  stan::math::test::compare_cpu_opencl_prim_rev(scaled_inv_chi_square_lpdf_functor_propto, y,
+                                                nu, s);
+}
+
+TEST(ProbDistributionsScaledInvChiSquare, opencl_broadcast_y) {
+  int N = 3;
+
+  double y_scal = 12.3;
+  Eigen::VectorXd nu(N);
+  nu << 0.5, 1.2, 1.0;
+  Eigen::VectorXd s(N);
+  s << 0.3, 0.8, 1.0;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(scaled_inv_chi_square_lpdf_functor,
+                                                         y_scal, nu, s);
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(
+      scaled_inv_chi_square_lpdf_functor_propto, y_scal, nu, s);
+}
+
+TEST(ProbDistributionsScaledInvChiSquare, opencl_broadcast_nu) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  double nu_scal = 12.3;
+  Eigen::VectorXd s(N);
+  s << 0.3, 0.8, 1.0;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<1>(scaled_inv_chi_square_lpdf_functor, y,
+                                                         nu_scal, s);
+  stan::math::test::test_opencl_broadcasting_prim_rev<1>(
+      scaled_inv_chi_square_lpdf_functor_propto, y, nu_scal, s);
+}
+
+TEST(ProbDistributionsScaledInvChiSquare, opencl_broadcast_s) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  Eigen::VectorXd nu(N);
+  nu << 0.3, 0.8, 1.0;
+  double s_scal = 12.3;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<2>(scaled_inv_chi_square_lpdf_functor, y,
+                                                         nu, s_scal);
+  stan::math::test::test_opencl_broadcasting_prim_rev<2>(
+      scaled_inv_chi_square_lpdf_functor_propto, y, nu, s_scal);
+}
+
+TEST(ProbDistributionsScaledInvChiSquare, opencl_matches_cpu_big) {
+  int N = 153;
+
+  Eigen::Matrix<double, Eigen::Dynamic, 1> y
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+  Eigen::Matrix<double, Eigen::Dynamic, 1> nu
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+  Eigen::Matrix<double, Eigen::Dynamic, 1> s
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+
+  stan::math::test::compare_cpu_opencl_prim_rev(scaled_inv_chi_square_lpdf_functor, y, nu,
+                                                s);
+  stan::math::test::compare_cpu_opencl_prim_rev(scaled_inv_chi_square_lpdf_functor_propto, y,
+                                                nu, s);
+}
+
+#endif

--- a/test/unit/math/opencl/rev/skew_normal_lpdf_test.cpp
+++ b/test/unit/math/opencl/rev/skew_normal_lpdf_test.cpp
@@ -1,0 +1,187 @@
+#ifdef STAN_OPENCL
+#include <stan/math/opencl/rev/opencl.hpp>
+#include <stan/math.hpp>
+#include <gtest/gtest.h>
+#include <test/unit/math/opencl/util.hpp>
+#include <vector>
+
+TEST(ProbDistributionsSkewNormal, error_checking) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  Eigen::VectorXd y_size(N - 1);
+  y_size << 0.3, 0.8;
+  Eigen::VectorXd y_value(N);
+  y_value << 0.3, NAN, 0.5;
+
+  Eigen::VectorXd mu(N);
+  mu << 0.3, 0.8, 1.0;
+  Eigen::VectorXd mu_size(N - 1);
+  mu_size << 0.3, 0.8;
+  Eigen::VectorXd mu_value(N);
+  mu_value << 0.3, -INFINITY, 0.5;
+
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+  Eigen::VectorXd sigma_size(N - 1);
+  sigma_size << 0.3, 0.8;
+  Eigen::VectorXd sigma_value(N);
+  sigma_value << 0.3, 0, 0.5;
+
+  Eigen::VectorXd alpha(N);
+  alpha << 0.3, -0.8, 1.0;
+  Eigen::VectorXd alpha_size(N - 1);
+  alpha_size << 0.3, 0.8;
+  Eigen::VectorXd alpha_value(N);
+  alpha_value << 0.3, INFINITY, 0.5;
+
+  stan::math::matrix_cl<double> y_cl(y);
+  stan::math::matrix_cl<double> y_size_cl(y_size);
+  stan::math::matrix_cl<double> y_value_cl(y_value);
+  stan::math::matrix_cl<double> mu_cl(mu);
+  stan::math::matrix_cl<double> mu_size_cl(mu_size);
+  stan::math::matrix_cl<double> mu_value_cl(mu_value);
+  stan::math::matrix_cl<double> sigma_cl(sigma);
+  stan::math::matrix_cl<double> sigma_size_cl(sigma_size);
+  stan::math::matrix_cl<double> sigma_value_cl(sigma_value);
+  stan::math::matrix_cl<double> alpha_cl(alpha);
+  stan::math::matrix_cl<double> alpha_size_cl(alpha_size);
+  stan::math::matrix_cl<double> alpha_value_cl(alpha_value);
+
+  EXPECT_NO_THROW(stan::math::skew_normal_lpdf(y_cl, mu_cl, sigma_cl, alpha_cl));
+
+  EXPECT_THROW(stan::math::skew_normal_lpdf(y_size_cl, mu_cl, sigma_cl, alpha_cl),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::skew_normal_lpdf(y_cl, mu_size_cl, sigma_cl, alpha_cl),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::skew_normal_lpdf(y_cl, mu_cl, sigma_size_cl, alpha_cl),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::skew_normal_lpdf(y_cl, mu_cl, sigma_cl, alpha_size_cl),
+               std::invalid_argument);
+
+  EXPECT_THROW(stan::math::skew_normal_lpdf(y_value_cl, mu_cl, sigma_cl, alpha_cl),
+               std::domain_error);
+  EXPECT_THROW(stan::math::skew_normal_lpdf(y_cl, mu_value_cl, sigma_cl, alpha_cl),
+               std::domain_error);
+  EXPECT_THROW(stan::math::skew_normal_lpdf(y_cl, mu_cl, sigma_value_cl, alpha_cl),
+               std::domain_error);
+  EXPECT_THROW(stan::math::skew_normal_lpdf(y_cl, mu_cl, sigma_cl, alpha_value_cl),
+               std::domain_error);
+}
+
+auto skew_normal_lpdf_functor
+    = [](const auto& y, const auto& mu, const auto& sigma, const auto& alpha) {
+        return stan::math::skew_normal_lpdf(y, mu, sigma, alpha);
+      };
+auto skew_normal_lpdf_functor_propto
+    = [](const auto& y, const auto& mu, const auto& sigma, const auto& alpha) {
+        return stan::math::skew_normal_lpdf<true>(y, mu, sigma, alpha);
+      };
+
+TEST(ProbDistributionsSkewNormal, opencl_matches_cpu_small) {
+  int N = 3;
+  int M = 2;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  Eigen::VectorXd mu(N);
+  mu << 0.3, 0.3, 1.5;
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+  Eigen::VectorXd alpha(N);
+  alpha << 0.3, -0.8, 1.0;
+
+  stan::math::test::compare_cpu_opencl_prim_rev(skew_normal_lpdf_functor, y, mu,
+                                                sigma, alpha);
+  stan::math::test::compare_cpu_opencl_prim_rev(skew_normal_lpdf_functor_propto, y,
+                                                mu, sigma, alpha);
+}
+
+TEST(ProbDistributionsSkewNormal, opencl_broadcast_y) {
+  int N = 3;
+
+  double y_scal = 12.3;
+  Eigen::VectorXd mu(N);
+  mu << 0.5, 1.2, 1.0;
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+  Eigen::VectorXd alpha(N);
+  alpha << 0.3, -0.8, 1.0;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(skew_normal_lpdf_functor,
+                                                         y_scal, mu, sigma, alpha);
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(
+      skew_normal_lpdf_functor_propto, y_scal, mu, sigma, alpha);
+}
+
+TEST(ProbDistributionsSkewNormal, opencl_broadcast_mu) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  double mu_scal = 12.3;
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+  Eigen::VectorXd alpha(N);
+  alpha << 0.3, -0.8, 1.0;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<1>(skew_normal_lpdf_functor, y,
+                                                         mu_scal, sigma, alpha);
+  stan::math::test::test_opencl_broadcasting_prim_rev<1>(
+      skew_normal_lpdf_functor_propto, y, mu_scal, sigma, alpha);
+}
+
+TEST(ProbDistributionsSkewNormal, opencl_broadcast_sigma) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  Eigen::VectorXd mu(N);
+  mu << 0.3, 0.3, 1.5;
+  double sigma_scal = 12.3;
+  Eigen::VectorXd alpha(N);
+  alpha << 0.3, -0.8, 1.0;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<2>(skew_normal_lpdf_functor, y,
+                                                         mu, sigma_scal, alpha);
+  stan::math::test::test_opencl_broadcasting_prim_rev<2>(
+      skew_normal_lpdf_functor_propto, y, mu, sigma_scal, alpha);
+}
+
+TEST(ProbDistributionsSkewNormal, opencl_broadcast_alpha) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  Eigen::VectorXd mu(N);
+  mu << 0.3, 0.3, 1.5;
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+  double alpha_scal = 12.3;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<3>(skew_normal_lpdf_functor, y,
+                                                         mu, sigma, alpha_scal);
+  stan::math::test::test_opencl_broadcasting_prim_rev<3>(
+      skew_normal_lpdf_functor_propto, y, mu, sigma, alpha_scal);
+}
+
+TEST(ProbDistributionsSkewNormal, opencl_matches_cpu_big) {
+  int N = 153;
+
+  Eigen::Matrix<double, Eigen::Dynamic, 1> y
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+  Eigen::Matrix<double, Eigen::Dynamic, 1> mu
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+  Eigen::Matrix<double, Eigen::Dynamic, 1> sigma
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+  Eigen::Matrix<double, Eigen::Dynamic, 1> alpha
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+
+  stan::math::test::compare_cpu_opencl_prim_rev(skew_normal_lpdf_functor, y, mu,
+                                                sigma, alpha);
+  stan::math::test::compare_cpu_opencl_prim_rev(skew_normal_lpdf_functor_propto, y,
+                                                mu, sigma, alpha);
+}
+
+#endif

--- a/test/unit/math/opencl/rev/skew_normal_lpdf_test.cpp
+++ b/test/unit/math/opencl/rev/skew_normal_lpdf_test.cpp
@@ -49,25 +49,34 @@ TEST(ProbDistributionsSkewNormal, error_checking) {
   stan::math::matrix_cl<double> alpha_size_cl(alpha_size);
   stan::math::matrix_cl<double> alpha_value_cl(alpha_value);
 
-  EXPECT_NO_THROW(stan::math::skew_normal_lpdf(y_cl, mu_cl, sigma_cl, alpha_cl));
+  EXPECT_NO_THROW(
+      stan::math::skew_normal_lpdf(y_cl, mu_cl, sigma_cl, alpha_cl));
 
-  EXPECT_THROW(stan::math::skew_normal_lpdf(y_size_cl, mu_cl, sigma_cl, alpha_cl),
-               std::invalid_argument);
-  EXPECT_THROW(stan::math::skew_normal_lpdf(y_cl, mu_size_cl, sigma_cl, alpha_cl),
-               std::invalid_argument);
-  EXPECT_THROW(stan::math::skew_normal_lpdf(y_cl, mu_cl, sigma_size_cl, alpha_cl),
-               std::invalid_argument);
-  EXPECT_THROW(stan::math::skew_normal_lpdf(y_cl, mu_cl, sigma_cl, alpha_size_cl),
-               std::invalid_argument);
+  EXPECT_THROW(
+      stan::math::skew_normal_lpdf(y_size_cl, mu_cl, sigma_cl, alpha_cl),
+      std::invalid_argument);
+  EXPECT_THROW(
+      stan::math::skew_normal_lpdf(y_cl, mu_size_cl, sigma_cl, alpha_cl),
+      std::invalid_argument);
+  EXPECT_THROW(
+      stan::math::skew_normal_lpdf(y_cl, mu_cl, sigma_size_cl, alpha_cl),
+      std::invalid_argument);
+  EXPECT_THROW(
+      stan::math::skew_normal_lpdf(y_cl, mu_cl, sigma_cl, alpha_size_cl),
+      std::invalid_argument);
 
-  EXPECT_THROW(stan::math::skew_normal_lpdf(y_value_cl, mu_cl, sigma_cl, alpha_cl),
-               std::domain_error);
-  EXPECT_THROW(stan::math::skew_normal_lpdf(y_cl, mu_value_cl, sigma_cl, alpha_cl),
-               std::domain_error);
-  EXPECT_THROW(stan::math::skew_normal_lpdf(y_cl, mu_cl, sigma_value_cl, alpha_cl),
-               std::domain_error);
-  EXPECT_THROW(stan::math::skew_normal_lpdf(y_cl, mu_cl, sigma_cl, alpha_value_cl),
-               std::domain_error);
+  EXPECT_THROW(
+      stan::math::skew_normal_lpdf(y_value_cl, mu_cl, sigma_cl, alpha_cl),
+      std::domain_error);
+  EXPECT_THROW(
+      stan::math::skew_normal_lpdf(y_cl, mu_value_cl, sigma_cl, alpha_cl),
+      std::domain_error);
+  EXPECT_THROW(
+      stan::math::skew_normal_lpdf(y_cl, mu_cl, sigma_value_cl, alpha_cl),
+      std::domain_error);
+  EXPECT_THROW(
+      stan::math::skew_normal_lpdf(y_cl, mu_cl, sigma_cl, alpha_value_cl),
+      std::domain_error);
 }
 
 auto skew_normal_lpdf_functor
@@ -94,8 +103,8 @@ TEST(ProbDistributionsSkewNormal, opencl_matches_cpu_small) {
 
   stan::math::test::compare_cpu_opencl_prim_rev(skew_normal_lpdf_functor, y, mu,
                                                 sigma, alpha);
-  stan::math::test::compare_cpu_opencl_prim_rev(skew_normal_lpdf_functor_propto, y,
-                                                mu, sigma, alpha);
+  stan::math::test::compare_cpu_opencl_prim_rev(skew_normal_lpdf_functor_propto,
+                                                y, mu, sigma, alpha);
 }
 
 TEST(ProbDistributionsSkewNormal, opencl_broadcast_y) {
@@ -109,8 +118,8 @@ TEST(ProbDistributionsSkewNormal, opencl_broadcast_y) {
   Eigen::VectorXd alpha(N);
   alpha << 0.3, -0.8, 1.0;
 
-  stan::math::test::test_opencl_broadcasting_prim_rev<0>(skew_normal_lpdf_functor,
-                                                         y_scal, mu, sigma, alpha);
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(
+      skew_normal_lpdf_functor, y_scal, mu, sigma, alpha);
   stan::math::test::test_opencl_broadcasting_prim_rev<0>(
       skew_normal_lpdf_functor_propto, y_scal, mu, sigma, alpha);
 }
@@ -126,8 +135,8 @@ TEST(ProbDistributionsSkewNormal, opencl_broadcast_mu) {
   Eigen::VectorXd alpha(N);
   alpha << 0.3, -0.8, 1.0;
 
-  stan::math::test::test_opencl_broadcasting_prim_rev<1>(skew_normal_lpdf_functor, y,
-                                                         mu_scal, sigma, alpha);
+  stan::math::test::test_opencl_broadcasting_prim_rev<1>(
+      skew_normal_lpdf_functor, y, mu_scal, sigma, alpha);
   stan::math::test::test_opencl_broadcasting_prim_rev<1>(
       skew_normal_lpdf_functor_propto, y, mu_scal, sigma, alpha);
 }
@@ -143,8 +152,8 @@ TEST(ProbDistributionsSkewNormal, opencl_broadcast_sigma) {
   Eigen::VectorXd alpha(N);
   alpha << 0.3, -0.8, 1.0;
 
-  stan::math::test::test_opencl_broadcasting_prim_rev<2>(skew_normal_lpdf_functor, y,
-                                                         mu, sigma_scal, alpha);
+  stan::math::test::test_opencl_broadcasting_prim_rev<2>(
+      skew_normal_lpdf_functor, y, mu, sigma_scal, alpha);
   stan::math::test::test_opencl_broadcasting_prim_rev<2>(
       skew_normal_lpdf_functor_propto, y, mu, sigma_scal, alpha);
 }
@@ -160,8 +169,8 @@ TEST(ProbDistributionsSkewNormal, opencl_broadcast_alpha) {
   sigma << 0.3, 0.8, 1.0;
   double alpha_scal = 12.3;
 
-  stan::math::test::test_opencl_broadcasting_prim_rev<3>(skew_normal_lpdf_functor, y,
-                                                         mu, sigma, alpha_scal);
+  stan::math::test::test_opencl_broadcasting_prim_rev<3>(
+      skew_normal_lpdf_functor, y, mu, sigma, alpha_scal);
   stan::math::test::test_opencl_broadcasting_prim_rev<3>(
       skew_normal_lpdf_functor_propto, y, mu, sigma, alpha_scal);
 }
@@ -180,8 +189,8 @@ TEST(ProbDistributionsSkewNormal, opencl_matches_cpu_big) {
 
   stan::math::test::compare_cpu_opencl_prim_rev(skew_normal_lpdf_functor, y, mu,
                                                 sigma, alpha);
-  stan::math::test::compare_cpu_opencl_prim_rev(skew_normal_lpdf_functor_propto, y,
-                                                mu, sigma, alpha);
+  stan::math::test::compare_cpu_opencl_prim_rev(skew_normal_lpdf_functor_propto,
+                                                y, mu, sigma, alpha);
 }
 
 #endif


### PR DESCRIPTION
## Summary

Added OpenCL implementations for functions `rayleigh_lpdf`, `scaled_inv_chi_square` and `skew_normal_lpdf`.

## Tests

New functions are tested.

## Side Effects
None.

## Release notes

Added OpenCL implementations for functions `rayleigh_lpdf`, `scaled_inv_chi_square` and `skew_normal_lpdf`.

## Checklist

- [ ] Math issue #2152 

- [ ] Copyright holder: Tadej Ciglarič

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [ ] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [ ] the code is written in idiomatic C++ and changes are documented in the doxygen

- [ ] the new changes are tested
