### PR TITLE
adds full impl for std allocator conformance

### DIFF
--- a/stan/math/rev/core/arena_allocator.hpp
+++ b/stan/math/rev/core/arena_allocator.hpp
@@ -13,6 +13,25 @@ namespace math {
 template <typename T>
 struct arena_allocator {
   using value_type = T;
+  using pointer = T*;
+  using const_pointer = const T*;
+  using reference = T&;
+  using const_reference = const T&;
+  using size_type = size_t;
+  using difference_type = ptrdiff_t;
+  using propagate_on_container_move_assignment = std::true_type;
+
+  constexpr arena_allocator() noexcept {};
+
+  template <class U>
+  constexpr arena_allocator(const arena_allocator<U>&) noexcept {}
+
+  template <class U>
+  constexpr arena_allocator<T>& operator=(const arena_allocator<U>&) noexcept { return *this; }
+
+  static constexpr size_type max_size() noexcept {
+    return std::numeric_limits<size_type>::max() / sizeof(T);
+  }
 
   /**
    * Allocates space for `n` items of type `T`.
@@ -20,26 +39,42 @@ struct arena_allocator {
    * @param n number of items to allocate space for
    * @return pointer to allocated space
    */
-  T* allocate(std::size_t n) {
+  static inline T* allocate(std::size_t n) noexcept {
     return ChainableStack::instance_->memalloc_.alloc_array<T>(n);
   }
 
   /**
    * No-op. Memory is dealocated by caling `recover_memory()`.
    */
-  void deallocate(T* /*p*/, std::size_t /*n*/) noexcept {}
+  inline void deallocate(T* /*p*/, std::size_t /*n*/) const noexcept {}
+
+  static inline void construct(pointer p, const_reference val ) {
+    new(static_cast<void*>(p)) T(val);
+  }
+
+  static inline void destroy(pointer p ) {
+    (static_cast<T*>(p))->~T();
+  }
+
+  inline pointer address(reference x) const noexcept {
+    return &x;
+  }
+
+  inline const_pointer address(const_reference x) const noexcept {
+    return &x;
+  }
 
   /**
    * Equality comparison operator.
    * @return true
    */
-  bool operator==(const arena_allocator&) { return true; }
+  constexpr bool operator==(const arena_allocator&) const noexcept { return true; }
 
   /**
    * Inequality comparison operator.
    * @return false
    */
-  bool operator!=(const arena_allocator&) { return false; }
+  constexpr bool operator!=(const arena_allocator&) const noexcept { return false; }
 };
 
 }  // namespace math

--- a/stan/math/rev/core/arena_allocator.hpp
+++ b/stan/math/rev/core/arena_allocator.hpp
@@ -27,7 +27,9 @@ struct arena_allocator {
   constexpr arena_allocator(const arena_allocator<U>&) noexcept {}
 
   template <class U>
-  constexpr arena_allocator<T>& operator=(const arena_allocator<U>&) noexcept { return *this; }
+  constexpr arena_allocator<T>& operator=(const arena_allocator<U>&) noexcept {
+    return *this;
+  }
 
   static constexpr size_type max_size() noexcept {
     return std::numeric_limits<size_type>::max() / sizeof(T);
@@ -48,33 +50,31 @@ struct arena_allocator {
    */
   inline void deallocate(T* /*p*/, std::size_t /*n*/) const noexcept {}
 
-  static inline void construct(pointer p, const_reference val ) {
-    new(static_cast<void*>(p)) T(val);
+  static inline void construct(pointer p, const_reference val) {
+    new (static_cast<void*>(p)) T(val);
   }
 
-  static inline void destroy(pointer p ) {
-    (static_cast<T*>(p))->~T();
-  }
+  static inline void destroy(pointer p) { (static_cast<T*>(p))->~T(); }
 
-  inline pointer address(reference x) const noexcept {
-    return &x;
-  }
+  inline pointer address(reference x) const noexcept { return &x; }
 
-  inline const_pointer address(const_reference x) const noexcept {
-    return &x;
-  }
+  inline const_pointer address(const_reference x) const noexcept { return &x; }
 
   /**
    * Equality comparison operator.
    * @return true
    */
-  constexpr bool operator==(const arena_allocator&) const noexcept { return true; }
+  constexpr bool operator==(const arena_allocator&) const noexcept {
+    return true;
+  }
 
   /**
    * Inequality comparison operator.
    * @return false
    */
-  constexpr bool operator!=(const arena_allocator&) const noexcept { return false; }
+  constexpr bool operator!=(const arena_allocator&) const noexcept {
+    return false;
+  }
 };
 
 }  // namespace math

--- a/test/unit/math/rev/core/arena_allocator_test.cpp
+++ b/test/unit/math/rev/core/arena_allocator_test.cpp
@@ -1,6 +1,7 @@
 #include <stan/math/rev/core.hpp>
 #include <gtest/gtest.h>
 #include <vector>
+#include <unordered_set>
 
 void arena_allocator_test() {
   std::vector<int, stan::math::arena_allocator<int>> v;
@@ -34,4 +35,26 @@ void arena_allocator_test() {
 
 TEST(AgradRev, arena_allocator_test) {
   EXPECT_NO_THROW(arena_allocator_test());
+}
+
+TEST(AgradRev, arena_allocator_unorderedset_test) {
+  std::unordered_set<int, std::hash<int>, std::equal_to<int>, stan::math::arena_allocator<int>> x_test;
+  x_test.reserve(10);
+  for (int i = 0; i < 5; i++) {
+    x_test.insert(i);
+    x_test.insert(i);
+  }
+  auto x_iter = x_test.begin();
+  while (x_iter != x_test.end()) {
+    EXPECT_TRUE(stan::math::ChainableStack::instance_->memalloc_.in_stack(
+        &(*x_iter)));
+    x_iter++;
+  }
+  auto x_test2 = x_test;
+  auto x_iter2 = x_test2.begin();
+  while (x_iter2 != x_test2.end()) {
+    EXPECT_TRUE(stan::math::ChainableStack::instance_->memalloc_.in_stack(
+        &(*x_iter2)));
+    x_iter2++;
+  }
 }

--- a/test/unit/math/rev/core/arena_allocator_test.cpp
+++ b/test/unit/math/rev/core/arena_allocator_test.cpp
@@ -38,7 +38,9 @@ TEST(AgradRev, arena_allocator_test) {
 }
 
 TEST(AgradRev, arena_allocator_unorderedset_test) {
-  std::unordered_set<int, std::hash<int>, std::equal_to<int>, stan::math::arena_allocator<int>> x_test;
+  std::unordered_set<int, std::hash<int>, std::equal_to<int>,
+                     stan::math::arena_allocator<int>>
+      x_test;
   x_test.reserve(10);
   for (int i = 0; i < 5; i++) {
     x_test.insert(i);
@@ -46,15 +48,15 @@ TEST(AgradRev, arena_allocator_unorderedset_test) {
   }
   auto x_iter = x_test.begin();
   while (x_iter != x_test.end()) {
-    EXPECT_TRUE(stan::math::ChainableStack::instance_->memalloc_.in_stack(
-        &(*x_iter)));
+    EXPECT_TRUE(
+        stan::math::ChainableStack::instance_->memalloc_.in_stack(&(*x_iter)));
     x_iter++;
   }
   auto x_test2 = x_test;
   auto x_iter2 = x_test2.begin();
   while (x_iter2 != x_test2.end()) {
-    EXPECT_TRUE(stan::math::ChainableStack::instance_->memalloc_.in_stack(
-        &(*x_iter2)));
+    EXPECT_TRUE(
+        stan::math::ChainableStack::instance_->memalloc_.in_stack(&(*x_iter2)));
     x_iter2++;
   }
 }


### PR DESCRIPTION
## Summary

Adds full conformance for `arena_allocator`. For multi indexing on `var<matrix>` types I need `std::unordered_set` which requires some additional member functions that `std::vector<>` does not. 

## Tests

Tests we added to make sure std::unordered_set compiles and handles mem correctly.

## Side Effects

We should be able to use `arena_allocator<>` with the other allocator aware classes in the standard library.

## Release notes

Makes `arena_allocator` standard compliant

## Checklist

- [ ] Math issue #(issue number)

- [x] Copyright holder: Steve Bronder

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
