### PR TITLE
Replace log(Phi(x)) with std_normal_lcdf(x) in ordered_probit_lpmf

### DIFF
--- a/stan/math/prim/prob/ordered_probit_lpmf.hpp
+++ b/stan/math/prim/prob/ordered_probit_lpmf.hpp
@@ -5,9 +5,11 @@
 #include <stan/math/prim/err.hpp>
 #include <stan/math/prim/fun/Eigen.hpp>
 #include <stan/math/prim/fun/log.hpp>
-#include <stan/math/prim/fun/Phi.hpp>
+#include <stan/math/prim/fun/log_diff_exp.hpp>
 #include <stan/math/prim/fun/size_mvt.hpp>
 #include <stan/math/prim/fun/to_ref.hpp>
+#include <stan/math/prim/prob/std_normal_lcdf.hpp>
+#include <stan/math/prim/prob/std_normal_lccdf.hpp>
 #include <vector>
 #include <cmath>
 
@@ -84,12 +86,14 @@ return_type_t<T_loc, T_cut> ordered_probit_lpmf(const T_y& y,
     int K = c_vec[i].size() + 1;
 
     if (y_vec[i] == 1) {
-      logp_n += log1m(Phi(lambda_vec[i] - c_vec[i].coeff(0)));
+      logp_n += std_normal_lccdf(lambda_vec[i] - c_vec[i].coeff(0));
     } else if (y_vec[i] == K) {
-      logp_n += log(Phi(lambda_vec[i] - c_vec[i].coeff(K - 2)));
+      logp_n += std_normal_lcdf(lambda_vec[i] - c_vec[i].coeff(K - 2));
     } else {
-      logp_n += log(Phi(lambda_vec[i] - c_vec[i].coeff(y_vec[i] - 2))
-                    - Phi(lambda_vec[i] - c_vec[i].coeff(y_vec[i] - 1)));
+      logp_n += log_diff_exp(
+                  std_normal_lcdf(lambda_vec[i] - c_vec[i].coeff(y_vec[i] - 2)),
+                  std_normal_lcdf(lambda_vec[i] - c_vec[i].coeff(y_vec[i] - 1))
+                );
     }
   }
   return logp_n;

--- a/stan/math/prim/prob/ordered_probit_lpmf.hpp
+++ b/stan/math/prim/prob/ordered_probit_lpmf.hpp
@@ -92,8 +92,7 @@ return_type_t<T_loc, T_cut> ordered_probit_lpmf(const T_y& y,
     } else {
       logp_n += log_diff_exp(
                   std_normal_lcdf(lambda_vec[i] - c_vec[i].coeff(y_vec[i] - 2)),
-                  std_normal_lcdf(lambda_vec[i] - c_vec[i].coeff(y_vec[i] - 1))
-                );
+                  std_normal_lcdf(lambda_vec[i] - c_vec[i].coeff(y_vec[i] - 1)));
     }
   }
   return logp_n;

--- a/stan/math/prim/prob/ordered_probit_lpmf.hpp
+++ b/stan/math/prim/prob/ordered_probit_lpmf.hpp
@@ -6,10 +6,10 @@
 #include <stan/math/prim/fun/Eigen.hpp>
 #include <stan/math/prim/fun/log.hpp>
 #include <stan/math/prim/fun/log_diff_exp.hpp>
+#include <stan/math/prim/fun/log1m_exp.hpp>
 #include <stan/math/prim/fun/size_mvt.hpp>
 #include <stan/math/prim/fun/to_ref.hpp>
 #include <stan/math/prim/prob/std_normal_lcdf.hpp>
-#include <stan/math/prim/prob/std_normal_lccdf.hpp>
 #include <vector>
 #include <cmath>
 
@@ -86,7 +86,7 @@ return_type_t<T_loc, T_cut> ordered_probit_lpmf(const T_y& y,
     int K = c_vec[i].size() + 1;
 
     if (y_vec[i] == 1) {
-      logp_n += std_normal_lccdf(lambda_vec[i] - c_vec[i].coeff(0));
+      logp_n += log1m_exp(std_normal_lcdf(lambda_vec[i] - c_vec[i].coeff(0)));
     } else if (y_vec[i] == K) {
       logp_n += std_normal_lcdf(lambda_vec[i] - c_vec[i].coeff(K - 2));
     } else {

--- a/stan/math/prim/prob/ordered_probit_lpmf.hpp
+++ b/stan/math/prim/prob/ordered_probit_lpmf.hpp
@@ -86,7 +86,7 @@ return_type_t<T_loc, T_cut> ordered_probit_lpmf(const T_y& y,
     int K = c_vec[i].size() + 1;
 
     if (y_vec[i] == 1) {
-      logp_n += log1m_exp(std_normal_lcdf(lambda_vec[i] - c_vec[i].coeff(0)));
+      logp_n += std_normal_lcdf(c_vec[i].coeff(0) - lambda_vec[i]);
     } else if (y_vec[i] == K) {
       logp_n += std_normal_lcdf(lambda_vec[i] - c_vec[i].coeff(K - 2));
     } else {

--- a/stan/math/prim/prob/ordered_probit_lpmf.hpp
+++ b/stan/math/prim/prob/ordered_probit_lpmf.hpp
@@ -91,8 +91,8 @@ return_type_t<T_loc, T_cut> ordered_probit_lpmf(const T_y& y,
       logp_n += std_normal_lcdf(lambda_vec[i] - c_vec[i].coeff(K - 2));
     } else {
       logp_n += log_diff_exp(
-                  std_normal_lcdf(lambda_vec[i] - c_vec[i].coeff(y_vec[i] - 2)),
-                  std_normal_lcdf(lambda_vec[i] - c_vec[i].coeff(y_vec[i] - 1)));
+          std_normal_lcdf(lambda_vec[i] - c_vec[i].coeff(y_vec[i] - 2)),
+          std_normal_lcdf(lambda_vec[i] - c_vec[i].coeff(y_vec[i] - 1)));
     }
   }
   return logp_n;

--- a/stan/math/prim/prob/ordered_probit_lpmf.hpp
+++ b/stan/math/prim/prob/ordered_probit_lpmf.hpp
@@ -91,8 +91,8 @@ return_type_t<T_loc, T_cut> ordered_probit_lpmf(const T_y& y,
       logp_n += std_normal_lcdf(lambda_vec[i] - c_vec[i].coeff(K - 2));
     } else {
       logp_n += log_diff_exp(
-          std_normal_lcdf(lambda_vec[i] - c_vec[i].coeff(y_vec[i] - 2)),
-          std_normal_lcdf(lambda_vec[i] - c_vec[i].coeff(y_vec[i] - 1)));
+          std_normal_lcdf(c_vec[i].coeff(y_vec[i] - 1) - lambda_vec[i]),
+          std_normal_lcdf(c_vec[i].coeff(y_vec[i] - 2) - lambda_vec[i]));
     }
   }
   return logp_n;

--- a/test/unit/math/prim/prob/ordered_probit_test.cpp
+++ b/test/unit/math/prim/prob/ordered_probit_test.cpp
@@ -18,9 +18,9 @@ stan::math::vector_d get_simplex_Phi(double lambda,
 }
 
 double old_ordered_probit(int y, double lambda, stan::math::vector_d c) {
-  using stan::math::Phi;
-  using stan::math::log1m;
   using stan::math::log;
+  using stan::math::log1m;
+  using stan::math::Phi;
 
   int K = c.size() + 1;
 

--- a/test/unit/math/prim/prob/ordered_probit_test.cpp
+++ b/test/unit/math/prim/prob/ordered_probit_test.cpp
@@ -48,8 +48,8 @@ TEST(ProbDistributions, ordered_probit_stability) {
   EXPECT_TRUE(is_inf(old_ordered_probit(2, -38, c)));
   EXPECT_TRUE(is_inf(old_ordered_probit(4, -38, c)));
 
-  EXPECT_FALSE(is_inf(ordered_probit_log(1, 9, c)));
-  EXPECT_FALSE(is_inf(ordered_probit_log(2, 9, c)));
+  EXPECT_FALSE(is_inf(ordered_probit_log(1, 10, c)));
+  EXPECT_FALSE(is_inf(ordered_probit_log(2, 10, c)));
   EXPECT_NE(ordered_probit_log(4, 10, c), 0);
 
   EXPECT_NE(ordered_probit_log(1, -38, c), 0);

--- a/test/unit/math/prim/prob/ordered_probit_test.cpp
+++ b/test/unit/math/prim/prob/ordered_probit_test.cpp
@@ -17,36 +17,12 @@ stan::math::vector_d get_simplex_Phi(double lambda,
   return theta;
 }
 
-double old_ordered_probit(int y, double lambda, stan::math::vector_d c) {
-  using stan::math::log;
-  using stan::math::log1m;
-  using stan::math::Phi;
-
-  int K = c.size() + 1;
-
-  if (y == 1) {
-    return log1m(Phi(lambda - c(0)));
-  } else if (y == K) {
-    return log(Phi(lambda - c(K - 2)));
-  } else {
-    return log(Phi(lambda - c(y - 2)) - Phi(lambda - c(y - 1)));
-  }
-}
-
 TEST(ProbDistributions, ordered_probit_stability) {
   using stan::math::is_inf;
   using stan::math::ordered_probit_log;
 
   Eigen::VectorXd c(3);
   c << -0.3, 0.1, 1.2;
-
-  EXPECT_TRUE(is_inf(old_ordered_probit(1, 10, c)));
-  EXPECT_TRUE(is_inf(old_ordered_probit(2, 10, c)));
-  EXPECT_EQ(old_ordered_probit(4, 10, c), 0);
-
-  EXPECT_EQ(old_ordered_probit(1, -38, c), 0);
-  EXPECT_TRUE(is_inf(old_ordered_probit(2, -38, c)));
-  EXPECT_TRUE(is_inf(old_ordered_probit(4, -38, c)));
 
   EXPECT_FALSE(is_inf(ordered_probit_log(1, 10, c)));
   EXPECT_FALSE(is_inf(ordered_probit_log(2, 10, c)));


### PR DESCRIPTION
## Summary

This PR replaces the use of ```log(Phi(x))``` with ```std_normal_lcdf(x)``` in ```ordered_probit_lpmf``` for increased numerical stability

## Tests

No new tests, as (minor) refactoring should produce the same results

## Side Effects

N/A

## Release notes

Updated log-likelihood calculation for ```ordered_probit_lpmf``` for increased numerical stability

## Checklist

- [x] Math issue #2228

- [x] Copyright holder: Andrew Johnson

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
