### PR TITLE
Added test to avoid reverting bug in `integrate_1d`

### DIFF
--- a/test/unit/math/prim/functor/integrate_1d_test.cpp
+++ b/test/unit/math/prim/functor/integrate_1d_test.cpp
@@ -203,13 +203,14 @@ struct f16 {
 
 struct f17 {
   inline double operator()(const double &x, const double &xc,
-			   const std::vector<double> &theta,
-			   const std::vector<double> &x_r,
-			   const std::vector<int> &x_i,
-			   std::ostream *msgs) const {
+                           const std::vector<double> &theta,
+                           const std::vector<double> &x_r,
+                           const std::vector<int> &x_i,
+                           std::ostream *msgs) const {
     double mu = theta[0];
     double sigma = theta[1];
-    return 1.0 / (sqrt(2.0 * stan::math::pi()) * sigma) * std::exp(-0.5 * ((x - mu) / sigma) * ((x - mu) / sigma));
+    return 1.0 / (sqrt(2.0 * stan::math::pi()) * sigma)
+           * std::exp(-0.5 * ((x - mu) / sigma) * ((x - mu) / sigma));
   }
 };
 
@@ -479,7 +480,9 @@ TEST(StanMath_integrate_1d_prim, test1) {
                    stan::math::square(stan::math::pi()) / 4);
 
   // Make sure bounds working right
-  test_integration(integrate_1d_test::f17{}, -std::numeric_limits<double>::infinity(), -1.5, { 0.0, 1.0 }, {}, {}, 0.066807201268858071);
+  test_integration(integrate_1d_test::f17{},
+                   -std::numeric_limits<double>::infinity(), -1.5, {0.0, 1.0},
+                   {}, {}, 0.066807201268858071);
 }
 
 TEST(StanMath_integrate_1d_prim, TestTolerance) {

--- a/test/unit/math/prim/functor/integrate_1d_test.cpp
+++ b/test/unit/math/prim/functor/integrate_1d_test.cpp
@@ -201,6 +201,18 @@ struct f16 {
   }
 };
 
+struct f17 {
+  inline double operator()(const double &x, const double &xc,
+			   const std::vector<double> &theta,
+			   const std::vector<double> &x_r,
+			   const std::vector<int> &x_i,
+			   std::ostream *msgs) const {
+    double mu = theta[0];
+    double sigma = theta[1];
+    return 1.0 / (sqrt(2.0 * stan::math::pi()) * sigma) * std::exp(-0.5 * ((x - mu) / sigma) * ((x - mu) / sigma));
+  }
+};
+
 double lbaX_pdf(double X, double t, double A, double v, double s,
                 std::ostream *pstream__) {
   double b_A_tv_ts;
@@ -465,6 +477,9 @@ TEST(StanMath_integrate_1d_prim, test1) {
   //                   32);
   test_integration(integrate_1d_test::f16{}, 0.0, stan::math::pi(), {}, {}, {},
                    stan::math::square(stan::math::pi()) / 4);
+
+  // Make sure bounds working right
+  test_integration(integrate_1d_test::f17{}, -std::numeric_limits<double>::infinity(), -1.5, { 0.0, 1.0 }, {}, {}, 0.066807201268858071);
 }
 
 TEST(StanMath_integrate_1d_prim, TestTolerance) {


### PR DESCRIPTION
## Summary

This is a test to make sure we don't reintroduce the bug leading to the issue here: https://github.com/stan-dev/stan/issues/2926

## Release notes

- Added test to prevent revert of `integrate_1d` fix

## Checklist

- [x] Stan issue https://github.com/stan-dev/stan/issues/2926

- [x] Copyright holder: Columbia University

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
