### PR TITLE
Added decay to scalar_type_t (Issue #2262)

### DIFF
--- a/stan/math/rev/core/var.hpp
+++ b/stan/math/rev/core/var.hpp
@@ -1029,8 +1029,8 @@ using var = var_value<double>;
  * @ingroup type_trait
  */
 template <typename T>
-struct scalar_type<math::var_value<T>> {
-  using type = math::var_value<scalar_type_t<T>>;
+struct scalar_type<T, std::enable_if_t<is_var<T>::value>> {
+  using type = math::var_value<scalar_type_t<typename std::decay_t<T>::value_type>>;
 };
 
 }  // namespace stan

--- a/stan/math/rev/core/var.hpp
+++ b/stan/math/rev/core/var.hpp
@@ -1030,7 +1030,8 @@ using var = var_value<double>;
  */
 template <typename T>
 struct scalar_type<T, std::enable_if_t<is_var<T>::value>> {
-  using type = math::var_value<scalar_type_t<typename std::decay_t<T>::value_type>>;
+  using type
+      = math::var_value<scalar_type_t<typename std::decay_t<T>::value_type>>;
 };
 
 }  // namespace stan

--- a/test/unit/math/rev/core/scalar_type_t_test.cpp
+++ b/test/unit/math/rev/core/scalar_type_t_test.cpp
@@ -4,9 +4,13 @@
 #include <vector>
 
 TEST(AgradRev, scalar_type_t_var_value) {
-  EXPECT_TRUE((std::is_same<stan::math::var,
-                            stan::scalar_type_t<stan::math::var_value<Eigen::MatrixXd>>>::value));
+  EXPECT_TRUE(
+      (std::is_same<
+          stan::math::var,
+          stan::scalar_type_t<stan::math::var_value<Eigen::MatrixXd>>>::value));
 
-  EXPECT_TRUE((std::is_same<stan::scalar_type_t<stan::math::var_value<Eigen::MatrixXd>>,
-                            stan::scalar_type_t<const stan::math::var_value<Eigen::MatrixXd>&>>::value));
+  EXPECT_TRUE((
+      std::is_same<stan::scalar_type_t<stan::math::var_value<Eigen::MatrixXd>>,
+                   stan::scalar_type_t<
+                       const stan::math::var_value<Eigen::MatrixXd>&>>::value));
 }

--- a/test/unit/math/rev/core/scalar_type_t_test.cpp
+++ b/test/unit/math/rev/core/scalar_type_t_test.cpp
@@ -1,0 +1,12 @@
+#include <stan/math/rev.hpp>
+#include <gtest/gtest.h>
+#include <string>
+#include <vector>
+
+TEST(AgradRev, scalar_type_t_var_value) {
+  EXPECT_TRUE((std::is_same<stan::math::var,
+                            stan::scalar_type_t<stan::math::var_value<Eigen::MatrixXd>>>::value));
+
+  EXPECT_TRUE((std::is_same<stan::scalar_type_t<stan::math::var_value<Eigen::MatrixXd>>,
+                            stan::scalar_type_t<const stan::math::var_value<Eigen::MatrixXd>&>>::value));
+}


### PR DESCRIPTION
## Summary

Make `scalar_type_t` decay references for `var_value<T>` types

## Release notes

- `scalar_type_t` now decays references for `var_value<T>` types

## Checklist

- [x] Math issue #2262

- [x] Copyright holder: Columbia University

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
