### PR TITLE
added size match checks to kg binary functions

### DIFF
--- a/stan/math/opencl/kernel_generator/elt_function_cl.hpp
+++ b/stan/math/opencl/kernel_generator/elt_function_cl.hpp
@@ -102,7 +102,16 @@ class elt_function_cl : public operation_cl<Derived, Scal, T...> {
     using base::cols;                                                       \
     static const std::vector<const char*> includes;                         \
     explicit fun##_(T1&& a, T2&& b)                                         \
-        : base(#fun, std::forward<T1>(a), std::forward<T2>(b)) {}           \
+        : base(#fun, std::forward<T1>(a), std::forward<T2>(b)) {            \
+      if (a.rows() != base::dynamic && b.rows() != base::dynamic) {         \
+        check_size_match(#fun, "Rows of ", "a", a.rows(), "rows of ", "b",  \
+                         b.rows());                                         \
+      }                                                                     \
+      if (a.cols() != base::dynamic && b.cols() != base::dynamic) {         \
+        check_size_match(#fun, "Columns of ", "a", a.cols(), "columns of ", \
+                         "b", b.cols());                                    \
+      }                                                                     \
+    }                                                                       \
     inline auto deep_copy() const {                                         \
       auto&& arg1_copy = this->template get_arg<0>().deep_copy();           \
       auto&& arg2_copy = this->template get_arg<1>().deep_copy();           \

--- a/test/unit/math/opencl/kernel_generator/binary_operation_test.cpp
+++ b/test/unit/math/opencl/kernel_generator/binary_operation_test.cpp
@@ -48,9 +48,14 @@ TEST(KernelGenerator, addition_test) {
     m1 << 1, 2.5, 3, 4, 5, 6.3, 7, -8, -9.5;                           \
     MatrixXi m2(3, 3);                                                 \
     m2 << 1, 100, 1000, 0, -10, -12, 2, -8, 8;                         \
+    MatrixXd m_size(3, 2);                                             \
+    m_size << 1, 100, 1000, 0, -10, -12;                               \
                                                                        \
     matrix_cl<double> m1_cl(m1);                                       \
     matrix_cl<int> m2_cl(m2);                                          \
+    matrix_cl<double> m_size_cl(m_size);                               \
+                                                                       \
+    EXPECT_THROW(m1_cl operation m_size_cl, std::invalid_argument);    \
                                                                        \
     auto tmp = m1_cl operation m2_cl;                                  \
     matrix_cl<res_type> res_cl = tmp;                                  \

--- a/test/unit/math/opencl/kernel_generator/binary_operation_test.cpp
+++ b/test/unit/math/opencl/kernel_generator/binary_operation_test.cpp
@@ -54,8 +54,10 @@ TEST(KernelGenerator, addition_test) {
     matrix_cl<double> m1_cl(m1);                                       \
     matrix_cl<int> m2_cl(m2);                                          \
     matrix_cl<double> m_size_cl(m_size);                               \
+    matrix_cl<res_type> unused_res;                                    \
                                                                        \
-    EXPECT_THROW(m1_cl operation m_size_cl, std::invalid_argument);    \
+    EXPECT_THROW(unused_res = m1_cl operation m_size_cl,               \
+                 std::invalid_argument);                               \
                                                                        \
     auto tmp = m1_cl operation m2_cl;                                  \
     matrix_cl<res_type> res_cl = tmp;                                  \

--- a/test/unit/math/opencl/kernel_generator/elt_function_cl_test.cpp
+++ b/test/unit/math/opencl/kernel_generator/elt_function_cl_test.cpp
@@ -176,51 +176,56 @@ TEST(KernelGenerator, multiple_operations_with_includes_test) {
   EXPECT_NEAR_REL(correct, res);
 }
 
-#define TEST_BINARY_FUNCTION(fun)                              \
-  TEST(KernelGenerator, fun##_test) {                          \
-    MatrixXd m1(3, 3);                                         \
-    m1 << 10.1, 11.2, 12.3, 13.4, 9.5, 24.6, 214.7, 12.8, 3.9; \
-    MatrixXd m2(3, 3);                                         \
-    m2 << 1.1, 2.2, 1.3, 3.4, 4.5, 2.6, 117.2, 11.8, 2.1;      \
-    MatrixXi m3(3, 3);                                         \
-    m3 << 2, 1, 3, 1, 2, 3, 4, 5, 3;                           \
-    MatrixXi m4(3, 3);                                         \
-    m4 << 4, 2, 5, 8, 3, 4, 12, 17, 5;                         \
-                                                               \
-    matrix_cl<double> m1_cl(m1);                               \
-    matrix_cl<double> m2_cl(m2);                               \
-    matrix_cl<int> m3_cl(m3);                                  \
-    matrix_cl<int> m4_cl(m4);                                  \
-                                                               \
-    matrix_cl<double> res1_cl = fun(m1_cl, m2_cl);             \
-                                                               \
-    MatrixXd res1 = stan::math::from_matrix_cl(res1_cl);       \
-    MatrixXd correct1 = stan::math::fun(m1, m2);               \
-    EXPECT_NEAR_REL(correct1, res1);                           \
-                                                               \
-    matrix_cl<double> res2_cl = fun(m1_cl, m3_cl);             \
-                                                               \
-    MatrixXd res2 = stan::math::from_matrix_cl(res2_cl);       \
-    MatrixXd correct2 = stan::math::fun(m1, m3);               \
-    EXPECT_NEAR_REL(correct2, res2);                           \
-                                                               \
-    matrix_cl<double> res3_cl = fun(m1_cl, 2.2);               \
-                                                               \
-    MatrixXd res3 = stan::math::from_matrix_cl(res3_cl);       \
-    MatrixXd correct3 = stan::math::fun(m1, 2.2);              \
-    EXPECT_NEAR_REL(correct3, res3);                           \
-                                                               \
-    matrix_cl<double> res4_cl = fun(1000.1, m2_cl);            \
-                                                               \
-    MatrixXd res4 = stan::math::from_matrix_cl(res4_cl);       \
-    MatrixXd correct4 = stan::math::fun(1000.1, m2);           \
-    EXPECT_NEAR_REL(correct4, res4);                           \
-                                                               \
-    matrix_cl<double> res5_cl = fun(m4_cl, m3_cl);             \
-                                                               \
-    MatrixXd res5 = stan::math::from_matrix_cl(res5_cl);       \
-    MatrixXd correct5 = stan::math::fun(m4, m3);               \
-    EXPECT_NEAR_REL(correct5, res5);                           \
+#define TEST_BINARY_FUNCTION(fun)                                           \
+  TEST(KernelGenerator, fun##_test) {                                       \
+    MatrixXd m1(3, 3);                                                      \
+    m1 << 10.1, 11.2, 12.3, 13.4, 9.5, 24.6, 214.7, 12.8, 3.9;              \
+    MatrixXd m2(3, 3);                                                      \
+    m2 << 1.1, 2.2, 1.3, 3.4, 4.5, 2.6, 117.2, 11.8, 2.1;                   \
+    MatrixXi m3(3, 3);                                                      \
+    m3 << 2, 1, 3, 1, 2, 3, 4, 5, 3;                                        \
+    MatrixXi m4(3, 3);                                                      \
+    m4 << 4, 2, 5, 8, 3, 4, 12, 17, 5;                                      \
+    MatrixXi m_size1(3, 2);                                                 \
+    m_size1 << 4, 2, 5, 8, 3, 4;                                            \
+                                                                            \
+    matrix_cl<double> m1_cl(m1);                                            \
+    matrix_cl<double> m2_cl(m2);                                            \
+    matrix_cl<int> m3_cl(m3);                                               \
+    matrix_cl<int> m4_cl(m4);                                               \
+    matrix_cl<int> m_size_cl(m_size1);                                      \
+                                                                            \
+    EXPECT_THROW(stan::math::fun(m1_cl, m_size_cl), std::invalid_argument); \
+                                                                            \
+    matrix_cl<double> res1_cl = fun(m1_cl, m2_cl);                          \
+                                                                            \
+    MatrixXd res1 = stan::math::from_matrix_cl(res1_cl);                    \
+    MatrixXd correct1 = stan::math::fun(m1, m2);                            \
+    EXPECT_NEAR_REL(correct1, res1);                                        \
+                                                                            \
+    matrix_cl<double> res2_cl = fun(m1_cl, m3_cl);                          \
+                                                                            \
+    MatrixXd res2 = stan::math::from_matrix_cl(res2_cl);                    \
+    MatrixXd correct2 = stan::math::fun(m1, m3);                            \
+    EXPECT_NEAR_REL(correct2, res2);                                        \
+                                                                            \
+    matrix_cl<double> res3_cl = fun(m1_cl, 2.2);                            \
+                                                                            \
+    MatrixXd res3 = stan::math::from_matrix_cl(res3_cl);                    \
+    MatrixXd correct3 = stan::math::fun(m1, 2.2);                           \
+    EXPECT_NEAR_REL(correct3, res3);                                        \
+                                                                            \
+    matrix_cl<double> res4_cl = fun(1000.1, m2_cl);                         \
+                                                                            \
+    MatrixXd res4 = stan::math::from_matrix_cl(res4_cl);                    \
+    MatrixXd correct4 = stan::math::fun(1000.1, m2);                        \
+    EXPECT_NEAR_REL(correct4, res4);                                        \
+                                                                            \
+    matrix_cl<double> res5_cl = fun(m4_cl, m3_cl);                          \
+                                                                            \
+    MatrixXd res5 = stan::math::from_matrix_cl(res5_cl);                    \
+    MatrixXd correct5 = stan::math::fun(m4, m3);                            \
+    EXPECT_NEAR_REL(correct5, res5);                                        \
   }
 
 TEST_BINARY_FUNCTION(pow)


### PR DESCRIPTION
## Summary

Added check_matching_sizes to kernel generator binary functions so they actually throw, if the sizes do not match.

## Tests

Added tests that check the throwing. Similar tests are also added for kernel generator binary operations.

## Side Effects
None.

## Release notes

Added check_matching_sizes to kernel generator binary functions so they actually throw, if the sizes do not match.

## Checklist

- [ ] Math issue #(issue number)

- [ ] Copyright holder: Tadej Ciglarič

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [ ] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [ ] the code is written in idiomatic C++ and changes are documented in the doxygen

- [ ] the new changes are tested
