### PR TITLE
varmat implementation of `dot_product`

### DIFF
--- a/stan/math/prim/fun/dot_product.hpp
+++ b/stan/math/prim/fun/dot_product.hpp
@@ -26,40 +26,6 @@ inline return_type_t<Vec1, Vec2> dot_product(const Vec1 &v1, const Vec2 &v2) {
   return v1.dot(v2);
 }
 
-/**
- * Returns the dot product of the specified arrays.
- *
- * @param v1 First array.
- * @param v2 Second array.
- * @param length Length of both arrays.
- */
-template <typename Scalar1, typename Scalar2,
-          typename = require_all_stan_scalar_t<Scalar1, Scalar2>,
-          typename = require_all_not_var_t<Scalar1, Scalar2>>
-inline auto dot_product(const Scalar1 *v1, const Scalar2 *v2, size_t length) {
-  return_type_t<Scalar1, Scalar2> result = 0;
-  for (size_t i = 0; i < length; i++) {
-    result += v1[i] * v2[i];
-  }
-  return result;
-}
-
-/**
- * Returns the dot product of the specified arrays.
- *
- * @param v1 First array.
- * @param v2 Second array.
- * @throw std::domain_error if the vectors are not the same size.
- */
-template <typename Scalar1, typename Scalar2, typename Alloc1, typename Alloc2,
-          typename = require_all_stan_scalar_t<Scalar1, Scalar2>,
-          typename = require_all_not_var_t<Scalar1, Scalar2>>
-inline auto dot_product(const std::vector<Scalar1, Alloc1> &v1,
-                        const std::vector<Scalar2, Alloc2> &v2) {
-  check_matching_sizes("dot_product", "v1", v1, "v2", v2);
-  return dot_product(&v1[0], &v2[0], v1.size());
-}
-
 }  // namespace math
 }  // namespace stan
 

--- a/stan/math/prim/fun/dot_product.hpp
+++ b/stan/math/prim/fun/dot_product.hpp
@@ -19,11 +19,50 @@ namespace math {
  * size or if they are both not vector dimensioned.
  */
 template <typename Vec1, typename Vec2,
-          typename = require_all_eigen_vector_t<Vec1, Vec2>,
-          typename = require_all_not_eigen_vt<is_var, Vec1, Vec2>>
+          require_all_eigen_vector_t<Vec1, Vec2>* = nullptr,
+          require_all_not_eigen_vt<is_var, Vec1, Vec2>* = nullptr>
 inline return_type_t<Vec1, Vec2> dot_product(const Vec1 &v1, const Vec2 &v2) {
   check_matching_sizes("dot_product", "v1", v1, "v2", v2);
   return v1.dot(v2);
+}
+
+/**
+ * Returns the dot product of the specified arrays.
+ *
+ * @param v1 First array.
+ * @param v2 Second array.
+ * @param length Length of both arrays.
+ */
+template <typename Scalar1, typename Scalar2,
+          typename = require_all_stan_scalar_t<Scalar1, Scalar2>,
+          typename = require_all_not_var_t<Scalar1, Scalar2>>
+inline auto dot_product(const Scalar1 *v1, const Scalar2 *v2, size_t length) {
+  return_type_t<Scalar1, Scalar2> result = 0;
+  for (size_t i = 0; i < length; i++) {
+    result += v1[i] * v2[i];
+  }
+  return result;
+}
+
+/**
+ * Returns the dot product of the specified arrays.
+ *
+ * @param v1 First array.
+ * @param v2 Second array.
+ * @throw std::domain_error if the vectors are not the same size.
+ */
+template <typename Scalar1, typename Scalar2, typename Alloc1, typename Alloc2,
+          require_all_stan_scalar_t<Scalar1, Scalar2>* = nullptr>
+inline return_type_t<Scalar1, Scalar2> dot_product(const std::vector<Scalar1, Alloc1> &v1,
+                        const std::vector<Scalar2, Alloc2> &v2) {
+  check_matching_sizes("dot_product", "v1", v1, "v2", v2);
+
+  if(v1.size() == 0) {
+    return 0.0;
+  }
+  
+  return dot_product(as_column_vector_or_scalar(v1),
+		     as_column_vector_or_scalar(v2));
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/dot_product.hpp
+++ b/stan/math/prim/fun/dot_product.hpp
@@ -19,8 +19,8 @@ namespace math {
  * size or if they are both not vector dimensioned.
  */
 template <typename Vec1, typename Vec2,
-          require_all_eigen_vector_t<Vec1, Vec2>* = nullptr,
-          require_all_not_eigen_vt<is_var, Vec1, Vec2>* = nullptr>
+          require_all_eigen_vector_t<Vec1, Vec2> * = nullptr,
+          require_all_not_eigen_vt<is_var, Vec1, Vec2> * = nullptr>
 inline return_type_t<Vec1, Vec2> dot_product(const Vec1 &v1, const Vec2 &v2) {
   check_matching_sizes("dot_product", "v1", v1, "v2", v2);
   return v1.dot(v2);
@@ -52,17 +52,18 @@ inline auto dot_product(const Scalar1 *v1, const Scalar2 *v2, size_t length) {
  * @throw std::domain_error if the vectors are not the same size.
  */
 template <typename Scalar1, typename Scalar2, typename Alloc1, typename Alloc2,
-          require_all_stan_scalar_t<Scalar1, Scalar2>* = nullptr>
-inline return_type_t<Scalar1, Scalar2> dot_product(const std::vector<Scalar1, Alloc1> &v1,
-                        const std::vector<Scalar2, Alloc2> &v2) {
+          require_all_stan_scalar_t<Scalar1, Scalar2> * = nullptr>
+inline return_type_t<Scalar1, Scalar2> dot_product(
+    const std::vector<Scalar1, Alloc1> &v1,
+    const std::vector<Scalar2, Alloc2> &v2) {
   check_matching_sizes("dot_product", "v1", v1, "v2", v2);
 
-  if(v1.size() == 0) {
+  if (v1.size() == 0) {
     return 0.0;
   }
-  
+
   return dot_product(as_column_vector_or_scalar(v1),
-		     as_column_vector_or_scalar(v2));
+                     as_column_vector_or_scalar(v2));
 }
 
 }  // namespace math

--- a/stan/math/rev/fun/dot_product.hpp
+++ b/stan/math/rev/fun/dot_product.hpp
@@ -46,8 +46,8 @@ inline var dot_product(const T1& v1, const T2& v2) {
     arena_t<promote_scalar_t<var, T2>> v2_arena = v2;
     return make_callback_var(v1_arena.val().dot(v2_arena.val()),
 			     [v1_arena, v2_arena](const auto& vi) mutable {
+			       const auto res_adj = vi.adj();
 			       for (Eigen::Index i = 0; i < v1_arena.size(); ++i) {
-				 const auto res_adj = vi.adj();
 				 v1_arena.adj().coeffRef(i) += res_adj * v2_arena.val().coeff(i);
 				 v2_arena.adj().coeffRef(i) += res_adj * v1_arena.val().coeff(i);
 			       }

--- a/stan/math/rev/fun/dot_product.hpp
+++ b/stan/math/rev/fun/dot_product.hpp
@@ -31,40 +31,41 @@ namespace math {
  * @return Dot product of the vectors.
  * @throw std::domain_error if sizes of v1 and v2 do not match.
  */
-template <typename T1, typename T2, require_all_container_t<T1, T2>* = nullptr,
-          require_any_vt_var<T1, T2>* = nullptr>
+template <typename T1, typename T2, require_all_vector_t<T1, T2>* = nullptr,
+	  require_all_not_std_vector_t<T1, T2>* = nullptr,
+          require_any_st_var<T1, T2>* = nullptr>
 inline var dot_product(const T1& v1, const T2& v2) {
   check_matching_sizes("dot_product", "v1", v1, "v2", v2);
+
+  if(v1.size() == 0) {
+    return 0.0;
+  }
+  
   if (!is_constant<T1>::value && !is_constant<T2>::value) {
-    arena_t<vector_v> v1_arena = as_column_vector_or_scalar(v1);
-    arena_t<vector_v> v2_arena = as_column_vector_or_scalar(v2);
-    var res(v1_arena.val().dot(v2_arena.val()));
-    reverse_pass_callback([v1_arena, v2_arena, res]() mutable {
-      for (Eigen::Index i = 0; i < v1_arena.size(); ++i) {
-        const auto res_adj = res.adj();
-        v1_arena.coeffRef(i).adj() += res_adj * v2_arena.coeffRef(i).val();
-        v2_arena.coeffRef(i).adj() += res_adj * v1_arena.coeffRef(i).val();
-      }
-    });
-    return res;
+    arena_t<promote_scalar_t<var, T1>> v1_arena = v1;
+    arena_t<promote_scalar_t<var, T2>> v2_arena = v2;
+    return make_callback_var(v1_arena.val().dot(v2_arena.val()),
+			     [v1_arena, v2_arena](const auto& vi) mutable {
+			       for (Eigen::Index i = 0; i < v1_arena.size(); ++i) {
+				 const auto res_adj = vi.adj();
+				 v1_arena.adj().coeffRef(i) += res_adj * v2_arena.val().coeff(i);
+				 v2_arena.adj().coeffRef(i) += res_adj * v1_arena.val().coeff(i);
+			       }
+			     });
   } else if (!is_constant<T2>::value) {
-    arena_t<vector_v> v2_arena = as_column_vector_or_scalar(v2);
-    arena_t<Eigen::VectorXd> v1_val_arena
-        = value_of(as_column_vector_or_scalar(v1));
-    var res(v1_val_arena.dot(v2_arena.val()));
-    reverse_pass_callback([v1_val_arena, v2_arena, res]() mutable {
-      v2_arena.adj() += res.adj() * v1_val_arena;
-    });
-    return res;
+    arena_t<promote_scalar_t<var, T2>> v2_arena = v2;
+    arena_t<promote_scalar_t<double, T1>> v1_val_arena = value_of(v1);
+    return make_callback_var(v1_val_arena.dot(v2_arena.val()),
+			     [v1_val_arena, v2_arena](const auto& vi) mutable {
+			       v2_arena.adj().array() += vi.adj() * v1_val_arena.array();
+			     });
   } else {
-    arena_t<vector_v> v1_arena = as_column_vector_or_scalar(v1);
-    arena_t<Eigen::VectorXd> v2_val_arena
-        = value_of(as_column_vector_or_scalar(v2));
-    var res(v1_arena.val().dot(v2_val_arena));
-    reverse_pass_callback([v1_arena, v2_val_arena, res]() mutable {
-      v1_arena.adj() += res.adj() * v2_val_arena;
-    });
-    return res;
+    arena_t<promote_scalar_t<var, T1>> v1_arena = v1;
+    arena_t<promote_scalar_t<double, T2>> v2_val_arena = value_of(v2);
+    return make_callback_var(v1_arena.val().dot(v2_val_arena),
+			     [v1_arena, v2_val_arena](const auto& vi) mutable {
+			       v1_arena.adj().array() += vi.adj() * v2_val_arena.array();
+			     });
   }
 }
 

--- a/stan/math/rev/fun/dot_product.hpp
+++ b/stan/math/rev/fun/dot_product.hpp
@@ -44,14 +44,15 @@ inline var dot_product(const T1& v1, const T2& v2) {
   if (!is_constant<T1>::value && !is_constant<T2>::value) {
     arena_t<promote_scalar_t<var, T1>> v1_arena = v1;
     arena_t<promote_scalar_t<var, T2>> v2_arena = v2;
-    return make_callback_var(v1_arena.val().dot(v2_arena.val()),
-			     [v1_arena, v2_arena](const auto& vi) mutable {
-			       const auto res_adj = vi.adj();
-			       for (Eigen::Index i = 0; i < v1_arena.size(); ++i) {
-				 v1_arena.adj().coeffRef(i) += res_adj * v2_arena.val().coeff(i);
-				 v2_arena.adj().coeffRef(i) += res_adj * v1_arena.val().coeff(i);
-			       }
-			     });
+    return make_callback_var(
+        v1_arena.val().dot(v2_arena.val()),
+        [v1_arena, v2_arena](const auto& vi) mutable {
+          const auto res_adj = vi.adj();
+          for (Eigen::Index i = 0; i < v1_arena.size(); ++i) {
+            v1_arena.adj().coeffRef(i) += res_adj * v2_arena.val().coeff(i);
+            v2_arena.adj().coeffRef(i) += res_adj * v1_arena.val().coeff(i);
+          }
+        });
   } else if (!is_constant<T2>::value) {
     arena_t<promote_scalar_t<var, T2>> v2_arena = v2;
     arena_t<promote_scalar_t<double, T1>> v1_val_arena = value_of(v1);

--- a/test/unit/math/mix/fun/dot_product_test.cpp
+++ b/test/unit/math/mix/fun/dot_product_test.cpp
@@ -49,12 +49,12 @@ TEST(mathMixMatFun, dotProduct) {
   v2 << 1, 2;
   Eigen::RowVectorXd rv2(2);
   rv2 << 1, 2;
-  std::vector<double> sv2 = { 1.0, 2.0 };
+  std::vector<double> sv2 = {1.0, 2.0};
   Eigen::VectorXd v2b(2);
   v2b << 10, 100;
   Eigen::RowVectorXd rv2b(2);
   rv2b << 10, 100;
-  std::vector<double> sv2b = { 10.0, 100.0 };
+  std::vector<double> sv2b = {10.0, 100.0};
   stan::test::expect_ad(f, v2, v2b);
   stan::test::expect_ad(f, rv2, v2b);
   stan::test::expect_ad(f, v2, rv2b);
@@ -71,12 +71,12 @@ TEST(mathMixMatFun, dotProduct) {
   v3 << 1, 3, -5;
   Eigen::RowVectorXd rv3(3);
   rv3 << 1, 3, -5;
-  std::vector<double> sv3 = { 1.0, 2.0, 3.0 };
+  std::vector<double> sv3 = {1.0, 2.0, 3.0};
   Eigen::VectorXd v3b(3);
   v3b << 4, -2, -1;
   Eigen::RowVectorXd rv3b(3);
   rv3b << 4, -2, -1;
-  std::vector<double> sv3b = { 4.0, -2.0, -1.0 };
+  std::vector<double> sv3b = {4.0, -2.0, -1.0};
   stan::test::expect_ad(f, v3, v3b);
   stan::test::expect_ad(f, v3, rv3b);
   stan::test::expect_ad(f, rv3, v3b);
@@ -91,10 +91,10 @@ TEST(mathMixMatFun, dotProduct) {
   // size 3, another case (originally from rev)
   v3 << -1, 0, 1;
   rv3 << -1, 0, 1;
-  sv3 = { -1.0, 0.0, 1.0 };
+  sv3 = {-1.0, 0.0, 1.0};
   v3b << 1, 2, 3;
   rv3b << 1, 2, 3;
-  sv3b = { 1.0, 2.0, 3.0 };
+  sv3b = {1.0, 2.0, 3.0};
   stan::test::expect_ad(f, v3, v3b);
   stan::test::expect_ad(f, v3, rv3b);
   stan::test::expect_ad(f, rv3, v3b);

--- a/test/unit/math/mix/fun/dot_product_test.cpp
+++ b/test/unit/math/mix/fun/dot_product_test.cpp
@@ -2,26 +2,24 @@
 #include <limits>
 #include <vector>
 
-template <class F>
-void test_dot_product(const F& f) {
-  using stan::test::relative_tolerance;
-  stan::test::ad_tolerances tols;
-  tols.hessian_hessian_ = relative_tolerance(1e-3, 1e-3);
-  tols.hessian_fvar_hessian_ = relative_tolerance(1e-3, 1e-3);
+TEST(mathMixMatFun, dotProduct) {
+  auto f = [](const auto& x, const auto& y) {
+    return stan::math::dot_product(x, y);
+  };
 
   // size 0
   Eigen::VectorXd v0;
   Eigen::RowVectorXd rv0;
   std::vector<double> sv0;
-  stan::test::expect_ad(tols, f, v0, v0);
-  stan::test::expect_ad(tols, f, v0, rv0);
-  stan::test::expect_ad(tols, f, rv0, v0);
-  stan::test::expect_ad(tols, f, rv0, rv0);
+  stan::test::expect_ad(f, v0, v0);
+  stan::test::expect_ad(f, v0, rv0);
+  stan::test::expect_ad(f, rv0, v0);
+  stan::test::expect_ad(f, rv0, rv0);
 
-  stan::test::expect_ad_matvar(tols, f, v0, v0);
-  stan::test::expect_ad_matvar(tols, f, v0, rv0);
-  stan::test::expect_ad_matvar(tols, f, rv0, v0);
-  stan::test::expect_ad_matvar(tols, f, rv0, rv0);
+  stan::test::expect_ad_matvar(f, v0, v0);
+  stan::test::expect_ad_matvar(f, v0, rv0);
+  stan::test::expect_ad_matvar(f, rv0, v0);
+  stan::test::expect_ad_matvar(f, rv0, rv0);
 
   // size 1
   Eigen::VectorXd v1(1);
@@ -32,10 +30,15 @@ void test_dot_product(const F& f) {
   v1b << 2;
   Eigen::RowVectorXd rv1b(1);
   rv1b << 2;
-  stan::test::expect_ad(tols, f, v1, v1b);
-  stan::test::expect_ad(tols, f, rv1, v1b);
-  stan::test::expect_ad(tols, f, v1, rv1b);
-  stan::test::expect_ad(tols, f, rv1, rv1b);
+  stan::test::expect_ad(f, v1, v1b);
+  stan::test::expect_ad(f, rv1, v1b);
+  stan::test::expect_ad(f, v1, rv1b);
+  stan::test::expect_ad(f, rv1, rv1b);
+
+  stan::test::expect_ad_matvar(f, v1, v1b);
+  stan::test::expect_ad_matvar(f, rv1, v1b);
+  stan::test::expect_ad_matvar(f, v1, rv1b);
+  stan::test::expect_ad_matvar(f, rv1, rv1b);
 
   // size 2
   Eigen::VectorXd v2(2);
@@ -46,10 +49,15 @@ void test_dot_product(const F& f) {
   v2b << 10, 100;
   Eigen::RowVectorXd rv2b(2);
   rv2b << 10, 100;
-  stan::test::expect_ad(tols, f, v2, v2b);
-  stan::test::expect_ad(tols, f, rv2, v2b);
-  stan::test::expect_ad(tols, f, v2, rv2b);
-  stan::test::expect_ad(tols, f, rv2, rv2b);
+  stan::test::expect_ad(f, v2, v2b);
+  stan::test::expect_ad(f, rv2, v2b);
+  stan::test::expect_ad(f, v2, rv2b);
+  stan::test::expect_ad(f, rv2, rv2b);
+
+  stan::test::expect_ad_matvar(f, v2, v2b);
+  stan::test::expect_ad_matvar(f, rv2, v2b);
+  stan::test::expect_ad_matvar(f, v2, rv2b);
+  stan::test::expect_ad_matvar(f, rv2, rv2b);
 
   // size 3
   Eigen::VectorXd v3(3);
@@ -60,20 +68,30 @@ void test_dot_product(const F& f) {
   v3b << 4, -2, -1;
   Eigen::RowVectorXd rv3b(3);
   rv3b << 4, -2, -1;
-  stan::test::expect_ad(tols, f, v3, v3b);
-  stan::test::expect_ad(tols, f, v3, rv3b);
-  stan::test::expect_ad(tols, f, rv3, v3b);
-  stan::test::expect_ad(tols, f, rv3, rv3b);
+  stan::test::expect_ad(f, v3, v3b);
+  stan::test::expect_ad(f, v3, rv3b);
+  stan::test::expect_ad(f, rv3, v3b);
+  stan::test::expect_ad(f, rv3, rv3b);
+
+  stan::test::expect_ad_matvar(f, v3, v3b);
+  stan::test::expect_ad_matvar(f, v3, rv3b);
+  stan::test::expect_ad_matvar(f, rv3, v3b);
+  stan::test::expect_ad_matvar(f, rv3, rv3b);
 
   // size 3, another case (originally from rev)
   v3 << -1, 0, 1;
   rv3 << -1, 0, 1;
   v3b << 1, 2, 3;
   rv3b << 1, 2, 3;
-  stan::test::expect_ad(tols, f, v3, v3b);
-  stan::test::expect_ad(tols, f, v3, rv3b);
-  stan::test::expect_ad(tols, f, rv3, v3b);
-  stan::test::expect_ad(tols, f, rv3, rv3b);
+  stan::test::expect_ad(f, v3, v3b);
+  stan::test::expect_ad(f, v3, rv3b);
+  stan::test::expect_ad(f, rv3, v3b);
+  stan::test::expect_ad(f, rv3, rv3b);
+
+  stan::test::expect_ad_matvar(f, v3, v3b);
+  stan::test::expect_ad_matvar(f, v3, rv3b);
+  stan::test::expect_ad_matvar(f, rv3, v3b);
+  stan::test::expect_ad_matvar(f, rv3, rv3b);
 
   // following throw due to mismatched size
   stan::test::expect_ad(f, v1, v3);
@@ -81,13 +99,11 @@ void test_dot_product(const F& f) {
   stan::test::expect_ad(f, rv1, v3);
   stan::test::expect_ad(f, rv1, rv3);
 
+  stan::test::expect_ad_matvar(f, v1, v3);
+  stan::test::expect_ad_matvar(f, v1, rv3);
+  stan::test::expect_ad_matvar(f, rv1, v3);
+  stan::test::expect_ad_matvar(f, rv1, rv3);
+
   // eliminated tests that matrix args throw in ad because
   // they don't compile in prim;  they shouldn't compile in ad, either
-}
-
-TEST(mathMixMatFun, dotProduct) {
-  auto g = [](const auto& x, const auto& y) {
-    return stan::math::dot_product(x, y);
-  };
-  test_dot_product(g);  // standard data type args
 }

--- a/test/unit/math/mix/fun/dot_product_test.cpp
+++ b/test/unit/math/mix/fun/dot_product_test.cpp
@@ -15,6 +15,7 @@ TEST(mathMixMatFun, dotProduct) {
   stan::test::expect_ad(f, v0, rv0);
   stan::test::expect_ad(f, rv0, v0);
   stan::test::expect_ad(f, rv0, rv0);
+  stan::test::expect_ad(f, sv0, sv0);
 
   stan::test::expect_ad_matvar(f, v0, v0);
   stan::test::expect_ad_matvar(f, v0, rv0);
@@ -26,14 +27,17 @@ TEST(mathMixMatFun, dotProduct) {
   v1 << 1;
   Eigen::RowVectorXd rv1(1);
   rv1 << 1;
+  std::vector<double> sv1{1};
   Eigen::VectorXd v1b(1);
   v1b << 2;
   Eigen::RowVectorXd rv1b(1);
   rv1b << 2;
+  std::vector<double> sv1b{2};
   stan::test::expect_ad(f, v1, v1b);
   stan::test::expect_ad(f, rv1, v1b);
   stan::test::expect_ad(f, v1, rv1b);
   stan::test::expect_ad(f, rv1, rv1b);
+  stan::test::expect_ad(f, sv1, sv1b);
 
   stan::test::expect_ad_matvar(f, v1, v1b);
   stan::test::expect_ad_matvar(f, rv1, v1b);
@@ -45,14 +49,17 @@ TEST(mathMixMatFun, dotProduct) {
   v2 << 1, 2;
   Eigen::RowVectorXd rv2(2);
   rv2 << 1, 2;
+  std::vector<double> sv2 = { 1.0, 2.0 };
   Eigen::VectorXd v2b(2);
   v2b << 10, 100;
   Eigen::RowVectorXd rv2b(2);
   rv2b << 10, 100;
+  std::vector<double> sv2b = { 10.0, 100.0 };
   stan::test::expect_ad(f, v2, v2b);
   stan::test::expect_ad(f, rv2, v2b);
   stan::test::expect_ad(f, v2, rv2b);
   stan::test::expect_ad(f, rv2, rv2b);
+  stan::test::expect_ad(f, sv2, sv2b);
 
   stan::test::expect_ad_matvar(f, v2, v2b);
   stan::test::expect_ad_matvar(f, rv2, v2b);
@@ -64,14 +71,17 @@ TEST(mathMixMatFun, dotProduct) {
   v3 << 1, 3, -5;
   Eigen::RowVectorXd rv3(3);
   rv3 << 1, 3, -5;
+  std::vector<double> sv3 = { 1.0, 2.0, 3.0 };
   Eigen::VectorXd v3b(3);
   v3b << 4, -2, -1;
   Eigen::RowVectorXd rv3b(3);
   rv3b << 4, -2, -1;
+  std::vector<double> sv3b = { 4.0, -2.0, -1.0 };
   stan::test::expect_ad(f, v3, v3b);
   stan::test::expect_ad(f, v3, rv3b);
   stan::test::expect_ad(f, rv3, v3b);
   stan::test::expect_ad(f, rv3, rv3b);
+  stan::test::expect_ad(f, sv3, sv3b);
 
   stan::test::expect_ad_matvar(f, v3, v3b);
   stan::test::expect_ad_matvar(f, v3, rv3b);
@@ -81,12 +91,15 @@ TEST(mathMixMatFun, dotProduct) {
   // size 3, another case (originally from rev)
   v3 << -1, 0, 1;
   rv3 << -1, 0, 1;
+  sv3 = { -1.0, 0.0, 1.0 };
   v3b << 1, 2, 3;
   rv3b << 1, 2, 3;
+  sv3b = { 1.0, 2.0, 3.0 };
   stan::test::expect_ad(f, v3, v3b);
   stan::test::expect_ad(f, v3, rv3b);
   stan::test::expect_ad(f, rv3, v3b);
   stan::test::expect_ad(f, rv3, rv3b);
+  stan::test::expect_ad(f, sv3, sv3b);
 
   stan::test::expect_ad_matvar(f, v3, v3b);
   stan::test::expect_ad_matvar(f, v3, rv3b);
@@ -98,6 +111,7 @@ TEST(mathMixMatFun, dotProduct) {
   stan::test::expect_ad(f, v1, rv3);
   stan::test::expect_ad(f, rv1, v3);
   stan::test::expect_ad(f, rv1, rv3);
+  stan::test::expect_ad(f, sv1, sv3);
 
   stan::test::expect_ad_matvar(f, v1, v3);
   stan::test::expect_ad_matvar(f, v1, rv3);

--- a/test/unit/math/mix/fun/dot_product_test.cpp
+++ b/test/unit/math/mix/fun/dot_product_test.cpp
@@ -10,85 +10,76 @@ void test_dot_product(const F& f) {
   tols.hessian_fvar_hessian_ = relative_tolerance(1e-3, 1e-3);
 
   // size 0
-  Eigen::VectorXd v0(0);
-  Eigen::RowVectorXd rv0(0);
+  Eigen::VectorXd v0;
+  Eigen::RowVectorXd rv0;
   std::vector<double> sv0;
   stan::test::expect_ad(tols, f, v0, v0);
   stan::test::expect_ad(tols, f, v0, rv0);
   stan::test::expect_ad(tols, f, rv0, v0);
   stan::test::expect_ad(tols, f, rv0, rv0);
-  stan::test::expect_ad(tols, f, sv0, sv0);
+
+  stan::test::expect_ad_matvar(tols, f, v0, v0);
+  stan::test::expect_ad_matvar(tols, f, v0, rv0);
+  stan::test::expect_ad_matvar(tols, f, rv0, v0);
+  stan::test::expect_ad_matvar(tols, f, rv0, rv0);
 
   // size 1
   Eigen::VectorXd v1(1);
   v1 << 1;
   Eigen::RowVectorXd rv1(1);
   rv1 << 1;
-  std::vector<double> sv1{1};
   Eigen::VectorXd v1b(1);
   v1b << 2;
   Eigen::RowVectorXd rv1b(1);
   rv1b << 2;
-  std::vector<double> sv1b{2};
   stan::test::expect_ad(tols, f, v1, v1b);
   stan::test::expect_ad(tols, f, rv1, v1b);
   stan::test::expect_ad(tols, f, v1, rv1b);
   stan::test::expect_ad(tols, f, rv1, rv1b);
-  stan::test::expect_ad(tols, f, sv1, sv1b);
 
   // size 2
   Eigen::VectorXd v2(2);
   v2 << 1, 2;
   Eigen::RowVectorXd rv2(2);
   rv2 << 1, 2;
-  std::vector<double> sv2{1, 2};
   Eigen::VectorXd v2b(2);
   v2b << 10, 100;
   Eigen::RowVectorXd rv2b(2);
   rv2b << 10, 100;
-  std::vector<double> sv2b{10, 100};
   stan::test::expect_ad(tols, f, v2, v2b);
   stan::test::expect_ad(tols, f, rv2, v2b);
   stan::test::expect_ad(tols, f, v2, rv2b);
   stan::test::expect_ad(tols, f, rv2, rv2b);
-  stan::test::expect_ad(tols, f, sv2, sv2b);
 
   // size 3
   Eigen::VectorXd v3(3);
   v3 << 1, 3, -5;
   Eigen::RowVectorXd rv3(3);
   rv3 << 1, 3, -5;
-  std::vector<double> sv3{1, 3, -5};
   Eigen::VectorXd v3b(3);
   v3b << 4, -2, -1;
   Eigen::RowVectorXd rv3b(3);
   rv3b << 4, -2, -1;
-  std::vector<double> sv3b{4, -2, -1};
   stan::test::expect_ad(tols, f, v3, v3b);
   stan::test::expect_ad(tols, f, v3, rv3b);
   stan::test::expect_ad(tols, f, rv3, v3b);
   stan::test::expect_ad(tols, f, rv3, rv3b);
-  stan::test::expect_ad(tols, f, sv3, sv3b);
 
   // size 3, another case (originally from rev)
   v3 << -1, 0, 1;
   rv3 << -1, 0, 1;
-  sv3 = {-1, 0, 1};
   v3b << 1, 2, 3;
   rv3b << 1, 2, 3;
-  sv3b = {1, 2, 3};
   stan::test::expect_ad(tols, f, v3, v3b);
   stan::test::expect_ad(tols, f, v3, rv3b);
   stan::test::expect_ad(tols, f, rv3, v3b);
   stan::test::expect_ad(tols, f, rv3, rv3b);
-  stan::test::expect_ad(tols, f, sv3, sv3b);
 
   // following throw due to mismatched size
   stan::test::expect_ad(f, v1, v3);
   stan::test::expect_ad(f, v1, rv3);
   stan::test::expect_ad(f, rv1, v3);
   stan::test::expect_ad(f, rv1, rv3);
-  stan::test::expect_ad(f, sv1, sv3);
 
   // eliminated tests that matrix args throw in ad because
   // they don't compile in prim;  they shouldn't compile in ad, either

--- a/test/unit/math/prim/fun/dot_product_test.cpp
+++ b/test/unit/math/prim/fun/dot_product_test.cpp
@@ -1,0 +1,43 @@
+#include <stan/math/prim.hpp>
+#include <gtest/gtest.h>
+#include <cmath>
+#include <limits>
+#include <vector>
+
+TEST(MathMatrixPrimMat, dot_product) {
+  using stan::math::dot_self;
+
+  Eigen::VectorXd v1(3);
+  Eigen::RowVectorXd rv1(3);
+  v1 << 1.0, 2.0, 3.0;
+  rv1 = v1.transpose();
+  
+  Eigen::VectorXd v2(3);
+  Eigen::RowVectorXd rv2(3);
+  v2 << -2.0, -1.0, 3.0;
+  rv2 = v2.transpose();
+
+  EXPECT_FLOAT_EQ(5.0, stan::math::dot_product(v1, v2));
+  EXPECT_FLOAT_EQ(5.0, stan::math::dot_product(v1, rv2));
+  EXPECT_FLOAT_EQ(5.0, stan::math::dot_product(rv1, v2));
+  EXPECT_FLOAT_EQ(5.0, stan::math::dot_product(rv1, rv2));
+}
+
+TEST(MathMatrixPrimMat, dot_product_error) {
+  using stan::math::dot_self;
+
+  Eigen::VectorXd v1(3);
+  Eigen::RowVectorXd rv1(3);
+  v1 << 1.0, 2.0, 3.0;
+  rv1 = v1.transpose();
+  
+  Eigen::VectorXd v2(2);
+  Eigen::RowVectorXd rv2(2);
+  v2 << -2.0, -1.0;
+  rv2 = v2.transpose();
+
+  EXPECT_THROW(stan::math::dot_product(v1, v2), std::invalid_argument);
+  EXPECT_THROW(stan::math::dot_product(v1, rv2), std::invalid_argument);
+  EXPECT_THROW(stan::math::dot_product(rv1, v2), std::invalid_argument);
+  EXPECT_THROW(stan::math::dot_product(rv1, rv2), std::invalid_argument);
+}

--- a/test/unit/math/prim/fun/dot_product_test.cpp
+++ b/test/unit/math/prim/fun/dot_product_test.cpp
@@ -9,13 +9,13 @@ TEST(MathMatrixPrimMat, dot_product) {
 
   Eigen::VectorXd v1(3);
   Eigen::RowVectorXd rv1(3);
-  std::vector<double> sv1 = { 1.0, 2.0, 3.0 };
+  std::vector<double> sv1 = {1.0, 2.0, 3.0};
   v1 << 1.0, 2.0, 3.0;
   rv1 = v1.transpose();
 
   Eigen::VectorXd v2(3);
   Eigen::RowVectorXd rv2(3);
-  std::vector<double> sv2 = { -2.0, -1.0, 3.0 };
+  std::vector<double> sv2 = {-2.0, -1.0, 3.0};
   v2 << -2.0, -1.0, 3.0;
   rv2 = v2.transpose();
 
@@ -31,13 +31,13 @@ TEST(MathMatrixPrimMat, dot_product_error) {
 
   Eigen::VectorXd v1(3);
   Eigen::RowVectorXd rv1(3);
-  std::vector<double> sv1 = { 1.0, 2.0, 3.0 };
+  std::vector<double> sv1 = {1.0, 2.0, 3.0};
   v1 << 1.0, 2.0, 3.0;
   rv1 = v1.transpose();
 
   Eigen::VectorXd v2(2);
   Eigen::RowVectorXd rv2(2);
-  std::vector<double> sv2 = { -2.0, -1.0 };
+  std::vector<double> sv2 = {-2.0, -1.0};
   v2 << -2.0, -1.0;
   rv2 = v2.transpose();
 

--- a/test/unit/math/prim/fun/dot_product_test.cpp
+++ b/test/unit/math/prim/fun/dot_product_test.cpp
@@ -9,11 +9,13 @@ TEST(MathMatrixPrimMat, dot_product) {
 
   Eigen::VectorXd v1(3);
   Eigen::RowVectorXd rv1(3);
+  std::vector<double> sv1 = { 1.0, 2.0, 3.0 };
   v1 << 1.0, 2.0, 3.0;
   rv1 = v1.transpose();
   
   Eigen::VectorXd v2(3);
   Eigen::RowVectorXd rv2(3);
+  std::vector<double> sv2 = { -2.0, -1.0, 3.0 };
   v2 << -2.0, -1.0, 3.0;
   rv2 = v2.transpose();
 
@@ -21,6 +23,7 @@ TEST(MathMatrixPrimMat, dot_product) {
   EXPECT_FLOAT_EQ(5.0, stan::math::dot_product(v1, rv2));
   EXPECT_FLOAT_EQ(5.0, stan::math::dot_product(rv1, v2));
   EXPECT_FLOAT_EQ(5.0, stan::math::dot_product(rv1, rv2));
+  EXPECT_FLOAT_EQ(5.0, stan::math::dot_product(sv1, sv2));
 }
 
 TEST(MathMatrixPrimMat, dot_product_error) {
@@ -28,11 +31,13 @@ TEST(MathMatrixPrimMat, dot_product_error) {
 
   Eigen::VectorXd v1(3);
   Eigen::RowVectorXd rv1(3);
+  std::vector<double> sv1 = { 1.0, 2.0, 3.0 };
   v1 << 1.0, 2.0, 3.0;
   rv1 = v1.transpose();
   
   Eigen::VectorXd v2(2);
   Eigen::RowVectorXd rv2(2);
+  std::vector<double> sv2 = { -2.0, -1.0 };
   v2 << -2.0, -1.0;
   rv2 = v2.transpose();
 
@@ -40,4 +45,5 @@ TEST(MathMatrixPrimMat, dot_product_error) {
   EXPECT_THROW(stan::math::dot_product(v1, rv2), std::invalid_argument);
   EXPECT_THROW(stan::math::dot_product(rv1, v2), std::invalid_argument);
   EXPECT_THROW(stan::math::dot_product(rv1, rv2), std::invalid_argument);
+  EXPECT_THROW(stan::math::dot_product(sv1, sv2), std::invalid_argument);
 }


### PR DESCRIPTION
## Summary

This is a varmat implementation of `dot_product`.

~~I got rid of the `std::vector` implementation in the process. I don't think it's used anywhere and we only expose `dot_product` at the Stan level for `vector` and `row_vector` ([docs](https://mc-stan.org/docs/2_25/functions-reference/dot-products-and-specialized-products.html)).~~

~~I could add the `std::vector` version back pretty easily if there's a need for it.~~

I added back the `std::vector` version cause it's simple.

## Side Effects

~~I got rid of the `std::vector` signatures for `dot_product`~~

## Release notes

- varmat implementation of `dot_product`

## Checklist

- [x] Math issue #2101

- [x] Copyright holder: Columbia University

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
