### PR TITLE
Add linspaced_int_array()

### DIFF
--- a/stan/math/prim/fun.hpp
+++ b/stan/math/prim/fun.hpp
@@ -160,6 +160,7 @@
 #include <stan/math/prim/fun/LDLT_factor.hpp>
 #include <stan/math/prim/fun/lgamma.hpp>
 #include <stan/math/prim/fun/linspaced_array.hpp>
+#include <stan/math/prim/fun/linspaced_int_array.hpp>
 #include <stan/math/prim/fun/linspaced_row_vector.hpp>
 #include <stan/math/prim/fun/linspaced_vector.hpp>
 #include <stan/math/prim/fun/lmgamma.hpp>

--- a/stan/math/prim/fun/linspaced_array.hpp
+++ b/stan/math/prim/fun/linspaced_array.hpp
@@ -11,7 +11,7 @@ namespace math {
 /**
  * Return an array of linearly spaced elements.
  *
- * This produces an array from low to high (included) with elements spaced
+ * This produces an array from low to high (inclusive) with elements spaced
  * as (high - low) / (K - 1). For K=1, the array will contain the high value;
  * for K=0 it returns an empty array.
  *
@@ -23,7 +23,7 @@ namespace math {
  * @throw std::domain_error if K is negative, if low is nan or infinite,
  * if high is nan or infinite, or if high is less than low.
  */
-inline std::vector<double> linspaced_array(int K, double low, double high) {
+inline std::vector<int> linspaced_array(int K, double low, double high) {
   static const char* function = "linspaced_array";
   check_nonnegative(function, "size", K);
   check_finite(function, "low", low);

--- a/stan/math/prim/fun/linspaced_int_array.hpp
+++ b/stan/math/prim/fun/linspaced_int_array.hpp
@@ -11,7 +11,7 @@ namespace math {
 /**
  * Return an array of linearly spaced integers.
  *
- * This produces an array from low to high (included) with integers spaced
+ * This produces an array from low to high (inclusive) with integers spaced
  * as (high - low) / (K - 1). For K=1, the array will contain the high value;
  * for K=0 it returns an empty array.
  *
@@ -20,8 +20,7 @@ namespace math {
  * @param high largest value
  * @return An array of size K with elements linearly spaced between
  * low and high.
- * @throw std::domain_error if K is negative, if high is less than low
- * or if ().
+ * @throw std::domain_error if K is negative or high is less than low.
  */
 inline std::vector<double> linspaced_int_array(int K, int low, int high) {
   static const char* function = "linspaced_int_array";

--- a/stan/math/prim/fun/linspaced_int_array.hpp
+++ b/stan/math/prim/fun/linspaced_int_array.hpp
@@ -13,8 +13,8 @@ namespace math {
  *
  * This produces an array from `low` to `high` (inclusive). If `high - low` is
  * greater or equal to `K - 1`, then the integers are evenly spaced. If it is
- * not possible to get from `low` to `high` with a multiple of an integer, `high`
- * is lowered until this is possible.
+ * not possible to get from `low` to `high` with a multiple of an integer,
+ * `high` is lowered until this is possible.
  *
  * If `K - 1` is greater than `high - low`, then integers are repeated. For
  * instance, `low, low, low + 1, low + 1, ...`. `high` is lowered until `K - 1`

--- a/stan/math/prim/fun/linspaced_int_array.hpp
+++ b/stan/math/prim/fun/linspaced_int_array.hpp
@@ -13,7 +13,8 @@ namespace math {
  *
  * This produces an array from low to high (inclusive) with integers spaced
  * as (high - low) / (K - 1). For K=1, the array will contain the high value;
- * for K=0 it returns an empty array.
+ * for K=0 it returns an empty array. If there are less integers between
+ * high and low than K, there will be duplicate integers.
  *
  * @param K size of the array
  * @param low smallest value
@@ -32,7 +33,6 @@ inline std::vector<int> linspaced_int_array(int K, int low, int high) {
 
   Eigen::VectorXi v = Eigen::VectorXi::LinSpaced(K, low, high);
   return {v.data(), v.data() + K};
-  ;
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/linspaced_int_array.hpp
+++ b/stan/math/prim/fun/linspaced_int_array.hpp
@@ -1,0 +1,41 @@
+#ifndef STAN_MATH_PRIM_FUN_LINSPACED_INT_ARRAY_HPP
+#define STAN_MATH_PRIM_FUN_LINSPACED_INT_ARRAY_HPP
+
+#include <stan/math/prim/err.hpp>
+#include <stan/math/prim/fun/Eigen.hpp>
+#include <vector>
+
+namespace stan {
+namespace math {
+
+/**
+ * Return an array of linearly spaced integers.
+ *
+ * This produces an array from low to high (included) with integers spaced
+ * as (high - low) / (K - 1). For K=1, the array will contain the high value;
+ * for K=0 it returns an empty array.
+ *
+ * @param K size of the array
+ * @param low smallest value
+ * @param high largest value
+ * @return An array of size K with elements linearly spaced between
+ * low and high.
+ * @throw std::domain_error if K is negative, if high is less than low
+ * or if ().
+ */
+inline std::vector<double> linspaced_int_array(int K, int low, int high) {
+  static const char* function = "linspaced_int_array";
+  check_nonnegative(function, "size", K);
+  check_greater_or_equal(function, "high", high, low);
+  if (K == 0) {
+    return {};
+  }
+
+  Eigen::VectorXi v = Eigen::VectorXi::LinSpaced(K, low, high);
+  return {&v[0], &v[0] + K};
+}
+
+}  // namespace math
+}  // namespace stan
+
+#endif

--- a/stan/math/prim/fun/linspaced_int_array.hpp
+++ b/stan/math/prim/fun/linspaced_int_array.hpp
@@ -11,10 +11,17 @@ namespace math {
 /**
  * Return an array of linearly spaced integers.
  *
- * This produces an array from low to high (inclusive) with integers spaced
- * as (high - low) / (K - 1). For K=1, the array will contain the high value;
- * for K=0 it returns an empty array. If there are less integers between
- * high and low than K, there will be duplicate integers.
+ * This produces an array from `low` to `high` (inclusive). If `high - low` is
+ * greater or equal to `K - 1`, then the integers are evenly spaced. If it is
+ * not possible to get from `low` to `high` with a multiple of an integer, `high`
+ * is lowered until this is possible.
+ *
+ * If `K - 1` is greater than `high - low`, then integers are repeated. For
+ * instance, `low, low, low + 1, low + 1, ...`. `high` is lowered until `K - 1`
+ * is a multiple of `high - low`
+ *
+ * For `K = 1`, the array will contain the `high` value. For `K = 0` it returns
+ * an empty array.
  *
  * @param K size of the array
  * @param low smallest value

--- a/stan/math/prim/fun/linspaced_int_array.hpp
+++ b/stan/math/prim/fun/linspaced_int_array.hpp
@@ -31,7 +31,8 @@ inline std::vector<int> linspaced_int_array(int K, int low, int high) {
   }
 
   Eigen::VectorXi v = Eigen::VectorXi::LinSpaced(K, low, high);
-  return {v.data(), v.data() + K};;
+  return {v.data(), v.data() + K};
+  ;
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/linspaced_int_array.hpp
+++ b/stan/math/prim/fun/linspaced_int_array.hpp
@@ -22,7 +22,7 @@ namespace math {
  * low and high.
  * @throw std::domain_error if K is negative or high is less than low.
  */
-inline std::vector<double> linspaced_int_array(int K, int low, int high) {
+inline std::vector<int> linspaced_int_array(int K, int low, int high) {
   static const char* function = "linspaced_int_array";
   check_nonnegative(function, "size", K);
   check_greater_or_equal(function, "high", high, low);
@@ -31,7 +31,7 @@ inline std::vector<double> linspaced_int_array(int K, int low, int high) {
   }
 
   Eigen::VectorXi v = Eigen::VectorXi::LinSpaced(K, low, high);
-  return {&v[0], &v[0] + K};
+  return {v.data(), v.data() + K};;
 }
 
 }  // namespace math

--- a/stan/math/prim/fun/linspaced_row_vector.hpp
+++ b/stan/math/prim/fun/linspaced_row_vector.hpp
@@ -10,7 +10,7 @@ namespace math {
 /**
  * Return a row vector of linearly spaced elements.
  *
- * This produces a row vector from low to high (included) with elements spaced
+ * This produces a row vector from low to high (inclusive) with elements spaced
  * as (high - low) / (K - 1). For K=1, the vector will contain the high value;
  * for K=0 it returns an empty vector.
  *

--- a/stan/math/prim/fun/linspaced_vector.hpp
+++ b/stan/math/prim/fun/linspaced_vector.hpp
@@ -10,7 +10,7 @@ namespace math {
 /**
  * Return a vector of linearly spaced elements.
  *
- * This produces a vector from low to high (included) with elements spaced
+ * This produces a vector from low to high (inclusive) with elements spaced
  * as (high - low) / (K - 1). For K=1, the vector will contain the high value;
  * for K=0 it returns an empty vector.
  *

--- a/test/unit/math/prim/fun/linspaced_int_array_test.cpp
+++ b/test/unit/math/prim/fun/linspaced_int_array_test.cpp
@@ -22,7 +22,7 @@ TEST(MathFunctions, linspaced_int_array) {
                        std::vector<int>({0, 3, 6, 9, 12}));
 }
 
-TEST(MathFunctions, linspaced_array_throw) {
+TEST(MathFunctions, linspaced_int_array_throw) {
   using stan::math::linspaced_int_array;
   int low = -2;
   int high = 5;

--- a/test/unit/math/prim/fun/linspaced_int_array_test.cpp
+++ b/test/unit/math/prim/fun/linspaced_int_array_test.cpp
@@ -1,0 +1,31 @@
+#include <stan/math/prim.hpp>
+#include <test/unit/util.hpp>
+#include <gtest/gtest.h>
+#include <limits>
+#include <vector>
+
+TEST(MathFunctions, linspaced_int_array) {
+  using stan::math::linspaced_int_array;
+  EXPECT_STD_VECTOR_EQ(linspaced_int_array(0, 1, 5), std::vector<int>({}));
+  EXPECT_STD_VECTOR_EQ(linspaced_int_array(1, 1, 5), std::vector<int>({5}));
+  EXPECT_STD_VECTOR_EQ(linspaced_int_array(5, 1, 5),
+                             std::vector<int>({1, 2, 3, 4, 5}));
+  EXPECT_STD_VECTOR_EQ(linspaced_int_array(5, -2, 2),
+                             std::vector<int>({-2, -1, 0, 1, 2}));
+  EXPECT_STD_VECTOR_EQ(linspaced_int_array(5, 0, 8),
+                             std::vector<int>({0, 2, 4, 6, 8}));
+  EXPECT_STD_VECTOR_EQ(linspaced_int_array(5, 0, 8),
+                             std::vector<int>({0, 2, 4, 6, 8}));
+  EXPECT_STD_VECTOR_EQ(linspaced_int_array(5, 0, 11),
+                             std::vector<int>({0, 2, 4, 6, 8}));
+  EXPECT_STD_VECTOR_EQ(linspaced_int_array(5, 0, 12),
+                             std::vector<int>({0, 3, 6, 9, 12}));
+}
+
+TEST(MathFunctions, linspaced_array_throw) {
+  using stan::math::linspaced_int_array;
+  int low = -2;
+  int high = 5;
+  EXPECT_THROW(linspaced_int_array(-1, low, high), std::domain_error);
+  EXPECT_THROW(linspaced_int_array(5, low, low - 1), std::domain_error);
+}

--- a/test/unit/math/prim/fun/linspaced_int_array_test.cpp
+++ b/test/unit/math/prim/fun/linspaced_int_array_test.cpp
@@ -9,17 +9,17 @@ TEST(MathFunctions, linspaced_int_array) {
   EXPECT_STD_VECTOR_EQ(linspaced_int_array(0, 1, 5), std::vector<int>({}));
   EXPECT_STD_VECTOR_EQ(linspaced_int_array(1, 1, 5), std::vector<int>({5}));
   EXPECT_STD_VECTOR_EQ(linspaced_int_array(5, 1, 5),
-                             std::vector<int>({1, 2, 3, 4, 5}));
+                       std::vector<int>({1, 2, 3, 4, 5}));
   EXPECT_STD_VECTOR_EQ(linspaced_int_array(5, -2, 2),
-                             std::vector<int>({-2, -1, 0, 1, 2}));
+                       std::vector<int>({-2, -1, 0, 1, 2}));
   EXPECT_STD_VECTOR_EQ(linspaced_int_array(5, 0, 8),
-                             std::vector<int>({0, 2, 4, 6, 8}));
+                       std::vector<int>({0, 2, 4, 6, 8}));
   EXPECT_STD_VECTOR_EQ(linspaced_int_array(5, 0, 8),
-                             std::vector<int>({0, 2, 4, 6, 8}));
+                       std::vector<int>({0, 2, 4, 6, 8}));
   EXPECT_STD_VECTOR_EQ(linspaced_int_array(5, 0, 11),
-                             std::vector<int>({0, 2, 4, 6, 8}));
+                       std::vector<int>({0, 2, 4, 6, 8}));
   EXPECT_STD_VECTOR_EQ(linspaced_int_array(5, 0, 12),
-                             std::vector<int>({0, 3, 6, 9, 12}));
+                       std::vector<int>({0, 3, 6, 9, 12}));
 }
 
 TEST(MathFunctions, linspaced_array_throw) {

--- a/test/unit/util.hpp
+++ b/test/unit/util.hpp
@@ -88,9 +88,9 @@
  * @param A first input vector of integers to compare
  * @param B second input vector of integers to compare
  */
-#define EXPECT_STD_VECTOR_EQ(A, B) \
-  EXPECT_EQ(A.size(), B.size());         \
-  for (int i = 0; i < A.size(); ++i)     \
+#define EXPECT_STD_VECTOR_EQ(A, B)   \
+  EXPECT_EQ(A.size(), B.size());     \
+  for (int i = 0; i < A.size(); ++i) \
     EXPECT_EQ(A[i], B[i]);
 
 /**

--- a/test/unit/util.hpp
+++ b/test/unit/util.hpp
@@ -82,6 +82,18 @@
     EXPECT_FLOAT_EQ(A[i], B[i]);
 
 /**
+ * Tests for elementwise equality of the input std::vectors
+ * of any type with the EXPECT_EQ macro from GTest.
+ *
+ * @param A first input vector of integers to compare
+ * @param B second input vector of integers to compare
+ */
+#define EXPECT_STD_VECTOR_EQ(A, B) \
+  EXPECT_EQ(A.size(), B.size());         \
+  for (int i = 0; i < A.size(); ++i)     \
+    EXPECT_EQ(A[i], B[i]);
+
+/**
  * Tests if any elementwise difference of the input matrices
  * of doubles is greater than DELTA. This uses the
  * EXPECT_NEAR macro from GTest.


### PR DESCRIPTION
## Summary

Adds support for `ìnt[] linspaced_int_array(int, int, int)` as a complement to `real[] linspaced_int_array(int, real, real)`. This was proposed by @avehtari in a discussion and I agree it would be useful.

`linspaced_int_array(5,0,8)` returns 0,2,4,6,8
`linspaced_int_array(5,0,9)` returns 0,2,4,6,8
`linspaced_int_array(5,0,11)` returns 0,2,4,6,8
`linspaced_int_array(5,0,12)` returns 0,3,6,9,12

So the behaviour is the same as for `Eigen::VectorXi v = Eigen::VectorXi::LinSpaced(K, low, high)`

## Tests

/

## Side Effects

/

## Release notes

Added linspaced_int_array.

## Checklist

- [x] Copyright holder: Rok Češnovar

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

