### PR TITLE
cleanup OpenCL rev

### DIFF
--- a/stan/math/opencl/kernel_generator/elt_function_cl.hpp
+++ b/stan/math/opencl/kernel_generator/elt_function_cl.hpp
@@ -318,7 +318,12 @@ ADD_UNARY_FUNCTION_WITH_INCLUDES(
     log1m_inv_logit, opencl_kernels::log1m_inv_logit_device_function)
 ADD_UNARY_FUNCTION_WITH_INCLUDES(trigamma,
                                  opencl_kernels::trigamma_device_function)
-ADD_UNARY_FUNCTION_WITH_INCLUDES(square, "double square(double x){return x*x;}")
+ADD_UNARY_FUNCTION_WITH_INCLUDES(
+    square,
+    "\n#ifndef STAN_MATH_OPENCL_KERNELS_DEVICE_FUNCTIONS_SQUARE\n"
+    "#define STAN_MATH_OPENCL_KERNELS_DEVICE_FUNCTIONS_SQUARE\n"
+    "double square(double x){return x*x;}\n"
+    "#endif\n")
 
 ADD_CLASSIFICATION_FUNCTION(isfinite, {-rows() + 1, cols() - 1})
 ADD_CLASSIFICATION_FUNCTION(isinf,

--- a/stan/math/opencl/rev/Phi.hpp
+++ b/stan/math/opencl/rev/Phi.hpp
@@ -20,13 +20,9 @@ template <typename T,
 inline var_value<matrix_cl<double>> Phi(const var_value<T>& A) {
   return make_callback_var(
       Phi(A.val()), [A](vari_value<matrix_cl<double>>& res) mutable {
-        A.adj()
-            = A.adj()
-              + elt_multiply(
-                    res.adj(),
-                    elt_multiply(INV_SQRT_TWO_PI,
-                                 exp(elt_multiply(
-                                     -0.5, elt_multiply(A.val(), A.val())))));
+        A.adj() += elt_multiply(
+            res.adj(), elt_multiply(INV_SQRT_TWO_PI,
+                                    exp(elt_multiply(-0.5, square(A.val())))));
       });
 }
 

--- a/stan/math/opencl/rev/Phi_approx.hpp
+++ b/stan/math/opencl/rev/Phi_approx.hpp
@@ -20,15 +20,9 @@ template <typename T,
 inline var_value<matrix_cl<double>> Phi_approx(const var_value<T>& A) {
   return make_callback_var(
       Phi_approx(A.val()), [A](vari_value<matrix_cl<double>>& res) mutable {
-        A.adj() = A.adj()
-                  + elt_multiply(
-                        res.adj(),
-                        elt_multiply(
-                            res.val(),
-                            elt_multiply(
-                                (1 - res.val()),
-                                (3.0 * 0.07056 * elt_multiply(A.val(), A.val())
-                                 + 1.5976))));
+        A.adj() += elt_multiply(
+            elt_multiply(elt_multiply(res.adj(), res.val()), 1 - res.val()),
+            3.0 * 0.07056 * square(A.val()) + 1.5976);
       });
 }
 

--- a/stan/math/opencl/rev/acos.hpp
+++ b/stan/math/opencl/rev/acos.hpp
@@ -21,9 +21,7 @@ template <typename T,
 inline var_value<matrix_cl<double>> acos(const var_value<T>& A) {
   return make_callback_var(
       acos(A.val()), [A](vari_value<matrix_cl<double>>& res) mutable {
-        A.adj() = A.adj()
-                  - elt_divide(res.adj(),
-                               sqrt(1.0 - elt_multiply(A.val(), A.val())));
+        A.adj() -= elt_divide(res.adj(), sqrt(1.0 - square(A.val())));
       });
 }
 

--- a/stan/math/opencl/rev/acosh.hpp
+++ b/stan/math/opencl/rev/acosh.hpp
@@ -21,9 +21,7 @@ template <typename T,
 inline var_value<matrix_cl<double>> acosh(const var_value<T>& A) {
   return make_callback_var(
       acosh(A.val()), [A](vari_value<matrix_cl<double>>& res) mutable {
-        A.adj() = A.adj()
-                  + elt_divide(res.adj(),
-                               sqrt(elt_multiply(A.val(), A.val()) - 1.0));
+        A.adj() += elt_divide(res.adj(), sqrt(square(A.val()) - 1.0));
       });
 }
 

--- a/stan/math/opencl/rev/add.hpp
+++ b/stan/math/opencl/rev/add.hpp
@@ -2,7 +2,7 @@
 #define STAN_MATH_OPENCL_REV_ADD_HPP
 #ifdef STAN_OPENCL
 
-#include <stan/math/prim/meta/is_kernel_expression.hpp>
+#include <stan/math/opencl/rev/adjoint_results.hpp>
 #include <stan/math/opencl/matrix_cl.hpp>
 #include <stan/math/opencl/kernel_generator.hpp>
 #include <stan/math/opencl/prim/sum.hpp>
@@ -10,6 +10,7 @@
 #include <stan/math/rev/fun/value_of.hpp>
 #include <stan/math/rev/core/reverse_pass_callback.hpp>
 #include <stan/math/prim/fun/value_of.hpp>
+#include <stan/math/prim/meta/is_kernel_expression.hpp>
 
 namespace stan {
 namespace math {
@@ -25,31 +26,18 @@ namespace math {
  */
 template <
     typename T_a, typename T_b,
-    require_all_nonscalar_prim_or_rev_kernel_expression_t<T_a, T_b>* = nullptr,
-    require_any_var_t<T_a, T_b>* = nullptr>
-inline auto add(const T_a& a, const T_b& b) {
-  check_size_match("add (OpenCL)", "A.cols()", a.cols(), "B.cols()", b.cols());
-  check_size_match("add (OpenCL)", "A.rows()", a.rows(), "B.rows()", b.rows());
-  const arena_t<T_a>& a_arena = a;
-  const arena_t<T_b>& b_arena = b;
+    require_all_prim_or_rev_kernel_expression_t<T_a, T_b>* = nullptr,
+    require_any_var_t<T_a, T_b>* = nullptr,
+    require_any_not_stan_scalar_t<T_a, T_b>* = nullptr>
+inline auto add(T_a&& a, T_b&& b) {
+  arena_t<T_a> a_arena = std::forward<T_a>(a);
+  arena_t<T_b> b_arena = std::forward<T_b>(b);
 
-  var_value<matrix_cl<double>> res = value_of(a_arena) + value_of(b_arena);
-
-  reverse_pass_callback([a_arena, b_arena, res]() mutable {
-    if (!is_constant<T_a>::value && !is_constant<T_b>::value) {
-      auto& a_adj = forward_as<var_value<matrix_cl<double>>>(a_arena).adj();
-      auto& b_adj = forward_as<var_value<matrix_cl<double>>>(b_arena).adj();
-      results(a_adj, b_adj)
-          = expressions((a_adj + res.adj()), (b_adj + res.adj()));
-    } else if (!is_constant<T_a>::value) {
-      auto& a_adj = forward_as<var_value<matrix_cl<double>>>(a_arena).adj();
-      a_adj = a_adj + res.adj();
-    } else {
-      auto& b_adj = forward_as<var_value<matrix_cl<double>>>(b_arena).adj();
-      b_adj = b_adj + res.adj();
-    }
-  });
-  return res;
+  return make_callback_var(
+      value_of(a_arena) + value_of(b_arena),
+      [a_arena, b_arena](vari_value<matrix_cl<double>>& res) mutable {
+        adjoint_results(a_arena, b_arena) += expressions(res.adj(), res.adj());
+      });
 }
 
 /**
@@ -67,55 +55,6 @@ template <
     require_any_var_t<T_a, T_b>* = nullptr>
 inline auto operator+(const T_a& a, const T_b& b) {
   return add(a, b);
-}
-
-/**
- * Addition of a kernel generator expression and a scalar.
- *
- * @tparam T1 type of the scalar
- * @tparam T2 type of the matrix or expression
- *
- * @param a scalar
- * @param b matrix
- * @return sum of a matrix and scalar
- */
-template <typename T1, typename T2, require_stan_scalar_t<T1>* = nullptr,
-          require_all_nonscalar_prim_or_rev_kernel_expression_t<T2>* = nullptr,
-          require_any_var_t<T1, T2>* = nullptr>
-inline auto add(const T1& a, const T2& b) {
-  const arena_t<T1>& a_arena = a;
-  const arena_t<T2>& b_arena = b;
-
-  var_value<matrix_cl<double>> res = value_of(a_arena) + value_of(b_arena);
-
-  reverse_pass_callback([a_arena, b_arena, res]() mutable {
-    if (!is_constant<T1>::value) {
-      auto& a_adj = forward_as<var_value<double>>(a_arena).adj();
-      a_adj = a_adj + sum(res.adj());
-    }
-    if (!is_constant<T2>::value) {
-      auto& b_adj = forward_as<var_value<matrix_cl<double>>>(b_arena).adj();
-      b_adj = b_adj + res.adj();
-    }
-  });
-  return res;
-}
-
-/**
- * Addition of a kernel generator expression and a scalar.
- *
- * @tparam T1 type of the matrix or expression
- * @tparam T2 type of the scalar
- *
- * @param a matrix
- * @param b scalar
- * @return sum of matrix and scalar
- */
-template <typename T1, typename T2, require_stan_scalar_t<T2>* = nullptr,
-          require_all_nonscalar_prim_or_rev_kernel_expression_t<T1>* = nullptr,
-          require_any_var_t<T1, T2>* = nullptr>
-inline auto add(const T1& a, const T2& b) {
-  return add(b, a);
 }
 
 }  // namespace math

--- a/stan/math/opencl/rev/add.hpp
+++ b/stan/math/opencl/rev/add.hpp
@@ -24,11 +24,10 @@ namespace math {
  * @param b second expression
  * @return The sum of the given arguments
  */
-template <
-    typename T_a, typename T_b,
-    require_all_prim_or_rev_kernel_expression_t<T_a, T_b>* = nullptr,
-    require_any_var_t<T_a, T_b>* = nullptr,
-    require_any_not_stan_scalar_t<T_a, T_b>* = nullptr>
+template <typename T_a, typename T_b,
+          require_all_prim_or_rev_kernel_expression_t<T_a, T_b>* = nullptr,
+          require_any_var_t<T_a, T_b>* = nullptr,
+          require_any_not_stan_scalar_t<T_a, T_b>* = nullptr>
 inline auto add(T_a&& a, T_b&& b) {
   arena_t<T_a> a_arena = std::forward<T_a>(a);
   arena_t<T_b> b_arena = std::forward<T_b>(b);

--- a/stan/math/opencl/rev/add_diag.hpp
+++ b/stan/math/opencl/rev/add_diag.hpp
@@ -4,9 +4,10 @@
 #include <stan/math/opencl/kernel_generator.hpp>
 #include <stan/math/opencl/prim/add_diag.hpp>
 #include <stan/math/opencl/prim/sum.hpp>
+#include <stan/math/rev/core.hpp>
+#include <stan/math/rev/fun/adjoint_of.hpp>
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/err.hpp>
-#include <stan/math/rev/core.hpp>
 
 namespace stan {
 namespace math {
@@ -35,17 +36,16 @@ inline auto add_diag(const T_m& mat, const T_a& to_add) {
 
   reverse_pass_callback([mat_arena, to_add_arena, res]() mutable {
     if (!is_constant<T_m>::value) {
-      auto& mat_adj = forward_as<var_value<matrix_cl<double>>>(mat_arena).adj();
-      mat_adj = mat_adj + res.adj();
+      adjoint_of(mat_arena) += res.adj();
     }
     if (!is_constant<T_a>::value) {
       if (!is_stan_scalar<T_a>::value) {
         auto& to_add_adj
             = forward_as<var_value<matrix_cl<double>>>(to_add_arena).adj();
-        to_add_adj = to_add_adj + diagonal(res.adj());
+        to_add_adj += diagonal(res.adj());
       } else {
         auto& to_add_adj = forward_as<var_value<double>>(to_add_arena).adj();
-        to_add_adj = to_add_adj + sum(diagonal(res.adj()));
+        to_add_adj += to_add_adj + sum(diagonal(res.adj()));
       }
     }
   });

--- a/stan/math/opencl/rev/asin.hpp
+++ b/stan/math/opencl/rev/asin.hpp
@@ -21,8 +21,7 @@ template <typename T,
 inline var_value<matrix_cl<double>> asin(const var_value<T>& A) {
   return make_callback_var(
       asin(A.val()), [A](vari_value<matrix_cl<double>>& res) mutable {
-        A.adj() += elt_divide(res.adj(),
-                               sqrt(1.0 - square(A.val())));
+        A.adj() += elt_divide(res.adj(), sqrt(1.0 - square(A.val())));
       });
 }
 

--- a/stan/math/opencl/rev/asin.hpp
+++ b/stan/math/opencl/rev/asin.hpp
@@ -21,9 +21,8 @@ template <typename T,
 inline var_value<matrix_cl<double>> asin(const var_value<T>& A) {
   return make_callback_var(
       asin(A.val()), [A](vari_value<matrix_cl<double>>& res) mutable {
-        A.adj() = A.adj()
-                  + elt_divide(res.adj(),
-                               sqrt(1.0 - elt_multiply(A.val(), A.val())));
+        A.adj() += elt_divide(res.adj(),
+                               sqrt(1.0 - square(A.val())));
       });
 }
 

--- a/stan/math/opencl/rev/asinh.hpp
+++ b/stan/math/opencl/rev/asinh.hpp
@@ -21,9 +21,7 @@ template <typename T,
 inline var_value<matrix_cl<double>> asinh(const var_value<T>& A) {
   return make_callback_var(
       asinh(A.val()), [A](vari_value<matrix_cl<double>>& res) mutable {
-        A.adj() = A.adj()
-                  + elt_divide(res.adj(),
-                               sqrt(elt_multiply(A.val(), A.val()) + 1.0));
+        A.adj() += elt_divide(res.adj(), sqrt(square(A.val()) + 1.0));
       });
 }
 

--- a/stan/math/opencl/rev/atan.hpp
+++ b/stan/math/opencl/rev/atan.hpp
@@ -21,9 +21,7 @@ template <typename T,
 inline var_value<matrix_cl<double>> atan(const var_value<T>& A) {
   return make_callback_var(
       atan(A.val()), [A](vari_value<matrix_cl<double>>& res) mutable {
-        A.adj()
-            = A.adj()
-              + elt_divide(res.adj(), (1.0 + elt_multiply(A.val(), A.val())));
+        A.adj() += elt_divide(res.adj(), (1.0 + square(A.val())));
       });
 }
 

--- a/stan/math/opencl/rev/atanh.hpp
+++ b/stan/math/opencl/rev/atanh.hpp
@@ -21,8 +21,7 @@ template <typename T,
 inline var_value<matrix_cl<double>> atanh(const var_value<T>& A) {
   return make_callback_var(
       atanh(A.val()), [A](vari_value<matrix_cl<double>>& res) mutable {
-        A.adj()
-            += elt_divide(res.adj(), (1.0 - square(A.val())));
+        A.adj() += elt_divide(res.adj(), (1.0 - square(A.val())));
       });
 }
 

--- a/stan/math/opencl/rev/atanh.hpp
+++ b/stan/math/opencl/rev/atanh.hpp
@@ -22,8 +22,7 @@ inline var_value<matrix_cl<double>> atanh(const var_value<T>& A) {
   return make_callback_var(
       atanh(A.val()), [A](vari_value<matrix_cl<double>>& res) mutable {
         A.adj()
-            = A.adj()
-              + elt_divide(res.adj(), (1.0 - elt_multiply(A.val(), A.val())));
+            += elt_divide(res.adj(), (1.0 - square(A.val())));
       });
 }
 

--- a/stan/math/opencl/rev/beta.hpp
+++ b/stan/math/opencl/rev/beta.hpp
@@ -2,14 +2,14 @@
 #define STAN_MATH_OPENCL_REV_BETA_HPP
 #ifdef STAN_OPENCL
 
-#include <stan/math/prim/meta/is_kernel_expression.hpp>
+#include <stan/math/opencl/rev/adjoint_results.hpp>
 #include <stan/math/opencl/matrix_cl.hpp>
 #include <stan/math/opencl/kernel_generator.hpp>
 #include <stan/math/rev/core.hpp>
-#include <stan/math/rev/fun/adjoint_of.hpp>
 #include <stan/math/rev/fun/value_of.hpp>
 #include <stan/math/rev/core/reverse_pass_callback.hpp>
 #include <stan/math/prim/fun/value_of.hpp>
+#include <stan/math/prim/meta/is_kernel_expression.hpp>
 
 namespace stan {
 namespace math {

--- a/stan/math/opencl/rev/cbrt.hpp
+++ b/stan/math/opencl/rev/cbrt.hpp
@@ -21,10 +21,9 @@ template <typename T,
 inline var_value<matrix_cl<double>> cbrt(const var_value<T>& A) {
   return make_callback_var(
       cbrt(A.val()), [A](vari_value<matrix_cl<double>>& res) mutable {
-        A.adj() = A.adj()
-                  + elt_divide(
+        A.adj() += elt_divide(
                         res.adj(),
-                        elt_multiply(3.0, elt_multiply(res.val(), res.val())));
+                        elt_multiply(3.0, square(res.val())));
       });
 }
 

--- a/stan/math/opencl/rev/cbrt.hpp
+++ b/stan/math/opencl/rev/cbrt.hpp
@@ -21,9 +21,7 @@ template <typename T,
 inline var_value<matrix_cl<double>> cbrt(const var_value<T>& A) {
   return make_callback_var(
       cbrt(A.val()), [A](vari_value<matrix_cl<double>>& res) mutable {
-        A.adj() += elt_divide(
-                        res.adj(),
-                        elt_multiply(3.0, square(res.val())));
+        A.adj() += elt_divide(res.adj(), elt_multiply(3.0, square(res.val())));
       });
 }
 

--- a/stan/math/opencl/rev/ceil.hpp
+++ b/stan/math/opencl/rev/ceil.hpp
@@ -20,8 +20,7 @@ template <typename T,
 inline var_value<matrix_cl<double>> ceil(const var_value<T>& A) {
   return make_callback_var(
       ceil(A.val()), [A](vari_value<matrix_cl<double>>& res) mutable {
-        A.adj() = select(isnan(A.val()),
-                         constant(NOT_A_NUMBER, A.rows(), A.cols()), A.adj());
+        A.adj() = select(isnan(A.val()), NOT_A_NUMBER, A.adj());
       });
 }
 

--- a/stan/math/opencl/rev/cholesky_decompose.hpp
+++ b/stan/math/opencl/rev/cholesky_decompose.hpp
@@ -25,51 +25,52 @@ template <typename T,
           require_all_kernel_expressions_and_none_scalar_t<T>* = nullptr>
 inline var_value<matrix_cl<double>> cholesky_decompose(const var_value<T>& A) {
   check_nan("cholesky_decompose", "A", A.val());
-  var_value<matrix_cl<double>> L_A = cholesky_decompose(A.val());
 
-  reverse_pass_callback([A, L_A]() mutable {
-    int M_ = A.rows();
-    int block_size
-        = M_ / opencl_context.tuning_opts().cholesky_rev_block_partition;
-    block_size = std::max(block_size, 8);
-    block_size = std::min(
-        block_size, opencl_context.tuning_opts().cholesky_rev_min_block_size);
-    matrix_cl<double> A_adj = L_A.adj();
-    for (int k = M_; k > 0; k -= block_size) {
-      const int j = std::max(0, k - block_size);
-      const int k_j_ind = k - j;
-      const int m_k_ind = M_ - k;
+  return make_callback_var(
+      cholesky_decompose(A.val()),
+      [A](vari_value<matrix_cl<double>>& L_A) mutable {
+        int M_ = A.rows();
+        int block_size
+            = M_ / opencl_context.tuning_opts().cholesky_rev_block_partition;
+        block_size = std::max(block_size, 8);
+        block_size = std::min(
+            block_size,
+            opencl_context.tuning_opts().cholesky_rev_min_block_size);
+        matrix_cl<double> A_adj = L_A.adj();
+        for (int k = M_; k > 0; k -= block_size) {
+          const int j = std::max(0, k - block_size);
+          const int k_j_ind = k - j;
+          const int m_k_ind = M_ - k;
 
-      auto&& R_val = block_zero_based(L_A.val(), j, 0, k_j_ind, j);
-      auto&& R_adj = block_zero_based(A_adj, j, 0, k_j_ind, j);
-      matrix_cl<double> D_val
-          = block_zero_based(L_A.val(), j, j, k_j_ind, k_j_ind);
-      matrix_cl<double> D_adj = block_zero_based(A_adj, j, j, k_j_ind, k_j_ind);
-      auto&& B_val = block_zero_based(L_A.val(), k, 0, m_k_ind, j);
-      auto&& B_adj = block_zero_based(A_adj, k, 0, m_k_ind, j);
-      auto&& C_val = block_zero_based(L_A.val(), k, j, m_k_ind, k_j_ind);
-      auto&& C_adj = block_zero_based(A_adj, k, j, m_k_ind, k_j_ind);
+          auto&& R_val = block_zero_based(L_A.val(), j, 0, k_j_ind, j);
+          auto&& R_adj = block_zero_based(A_adj, j, 0, k_j_ind, j);
+          matrix_cl<double> D_val
+              = block_zero_based(L_A.val(), j, j, k_j_ind, k_j_ind);
+          matrix_cl<double> D_adj
+              = block_zero_based(A_adj, j, j, k_j_ind, k_j_ind);
+          auto&& B_val = block_zero_based(L_A.val(), k, 0, m_k_ind, j);
+          auto&& B_adj = block_zero_based(A_adj, k, 0, m_k_ind, j);
+          auto&& C_val = block_zero_based(L_A.val(), k, j, m_k_ind, k_j_ind);
+          auto&& C_adj = block_zero_based(A_adj, k, j, m_k_ind, k_j_ind);
 
-      C_adj = C_adj * tri_inverse(D_val);
-      B_adj = B_adj - C_adj * R_val;
-      D_adj = D_adj - transpose(C_adj) * C_val;
+          C_adj = C_adj * tri_inverse(D_val);
+          B_adj = B_adj - C_adj * R_val;
+          D_adj = D_adj - transpose(C_adj) * C_val;
 
-      D_adj = transpose(D_val) * D_adj;
-      D_adj.triangular_transpose<TriangularMapCL::LowerToUpper>();
-      D_val = transpose(tri_inverse(D_val));
-      D_adj = D_val * transpose(D_val * D_adj);
-      D_adj.triangular_transpose<TriangularMapCL::LowerToUpper>();
+          D_adj = transpose(D_val) * D_adj;
+          D_adj.triangular_transpose<TriangularMapCL::LowerToUpper>();
+          D_val = transpose(tri_inverse(D_val));
+          D_adj = D_val * transpose(D_val * D_adj);
+          D_adj.triangular_transpose<TriangularMapCL::LowerToUpper>();
 
-      R_adj = R_adj - transpose(C_adj) * B_val - D_adj * R_val;
-      diagonal(D_adj) = diagonal(D_adj) * 0.5;
+          R_adj = R_adj - transpose(C_adj) * B_val - D_adj * R_val;
+          diagonal(D_adj) = diagonal(D_adj) * 0.5;
 
-      block_zero_based(A_adj, j, j, k_j_ind, k_j_ind) = D_adj;
-    }
-    A_adj.view(matrix_cl_view::Lower);
-    A.adj() = A.adj() + A_adj;
-  });
-
-  return L_A;
+          block_zero_based(A_adj, j, j, k_j_ind, k_j_ind) = D_adj;
+        }
+        A_adj.view(matrix_cl_view::Lower);
+        A.adj() += A_adj;
+      });
 }
 
 }  // namespace math

--- a/stan/math/opencl/rev/columns_dot_product.hpp
+++ b/stan/math/opencl/rev/columns_dot_product.hpp
@@ -2,6 +2,7 @@
 #define STAN_MATH_OPENCL_REV_COLUMNS_DOT_PRODUCT_HPP
 #ifdef STAN_OPENCL
 
+#include <stan/math/opencl/rev/adjoint_results.hpp>
 #include <stan/math/opencl/kernel_generator.hpp>
 #include <stan/math/rev/core.hpp>
 #include <stan/math/rev/fun/adjoint_of.hpp>
@@ -62,9 +63,7 @@ inline var_value<matrix_cl<double>> columns_dot_product(T1&& v1, T2&& v2) {
             = elt_multiply(colwise_broadcast(res.adj()), value_of(v2_arena));
         auto v2_deriv
             = elt_multiply(colwise_broadcast(res.adj()), value_of(v1_arena));
-        results(adjoint_of(v1_arena), adjoint_of(v2_arena))
-            += expressions(calc_if<is_var<T1>::value>(v1_deriv),
-                           calc_if<is_var<T2>::value>(v2_deriv));
+        adjoint_results(v1_arena, v2_arena) += expressions(v1_deriv, v2_deriv);
       });
 }
 

--- a/stan/math/opencl/rev/columns_dot_self.hpp
+++ b/stan/math/opencl/rev/columns_dot_self.hpp
@@ -18,32 +18,16 @@ namespace math {
  * @param v Matrix.
  */
 template <typename T,
-          require_var_vt<is_kernel_expression_and_not_scalar, T>* = nullptr>
-inline var_value<matrix_cl<double>> columns_dot_self(T&& v) {
+          require_all_kernel_expressions_and_none_scalar_t<T>* = nullptr>
+inline var_value<matrix_cl<double>> columns_dot_self(const var_value<T>& v) {
   if (size_zero(v)) {
     return var_value<matrix_cl<double>>(constant(0.0, 1, v.cols()));
   }
 
-  arena_t<T> v_arena;
-  if ((std::is_rvalue_reference<T&&>::value && is_matrix_cl<T>::value)
-      || is_var<T>::value) {
-    v_arena = std::forward<T>(v);
-  }
-
-  matrix_cl<double> res_val;
-  results(v_arena, res_val) = expressions(
-      calc_if<((std::is_lvalue_reference<T>::value || !is_matrix_cl<T>::value)
-               && !is_var<T>::value)>(value_of(v)),
-      colwise_sum(square(value_of(v))));
-  while (res_val.rows() > 1) {
-    res_val = colwise_sum(res_val).eval();
-  }
-
   return make_callback_var(
-      res_val, [v_arena](const vari_value<matrix_cl<double>>& res) mutable {
-        v_arena.adj() = v_arena.adj()
-                        + elt_multiply(colwise_broadcast(res.adj() * 2),
-                                       value_of(v_arena));
+      columns_dot_self(v.val()), [v](const vari_value<matrix_cl<double>>& res) mutable {
+        v.adj() += elt_multiply(colwise_broadcast(res.adj() * 2.0),
+                                       value_of(v));
       });
 }
 

--- a/stan/math/opencl/rev/columns_dot_self.hpp
+++ b/stan/math/opencl/rev/columns_dot_self.hpp
@@ -25,9 +25,10 @@ inline var_value<matrix_cl<double>> columns_dot_self(const var_value<T>& v) {
   }
 
   return make_callback_var(
-      columns_dot_self(v.val()), [v](const vari_value<matrix_cl<double>>& res) mutable {
-        v.adj() += elt_multiply(colwise_broadcast(res.adj() * 2.0),
-                                       value_of(v));
+      columns_dot_self(v.val()),
+      [v](const vari_value<matrix_cl<double>>& res) mutable {
+        v.adj()
+            += elt_multiply(colwise_broadcast(res.adj() * 2.0), value_of(v));
       });
 }
 

--- a/stan/math/opencl/rev/copy.hpp
+++ b/stan/math/opencl/rev/copy.hpp
@@ -3,6 +3,7 @@
 #ifdef STAN_OPENCL
 
 #include <stan/math/opencl/rev/vari.hpp>
+#include <stan/math/opencl/rev/arena_type.hpp>
 #include <stan/math/opencl/copy.hpp>
 #include <stan/math/rev/core.hpp>
 #include <stan/math/prim/err.hpp>
@@ -84,12 +85,7 @@ inline var_value<Eigen::Matrix<value_type_t<T>, Rows, Cols>> from_matrix_cl(
 template <typename T, require_eigen_vt<is_var, T>* = nullptr>
 inline var_value<matrix_cl<value_type_t<value_type_t<T>>>> to_matrix_cl(
     const T& src) {
-  // the matrix can go out of scope before chain() is called. So we store a map
-  // to the data
-  var* src_array
-      = ChainableStack::instance_->memalloc_.alloc_array<var>(src.size());
-  Eigen::Map<plain_type_t<T>> src_stacked(src_array, src.rows(), src.cols());
-  src_stacked = src;
+  arena_t<T> src_stacked = src;
 
   return make_callback_var(
       to_matrix_cl(src_stacked.val()), [src_stacked](auto& res_vari) mutable {

--- a/stan/math/opencl/rev/cos.hpp
+++ b/stan/math/opencl/rev/cos.hpp
@@ -21,7 +21,7 @@ template <typename T,
 inline var_value<matrix_cl<double>> cos(const var_value<T>& A) {
   return make_callback_var(
       cos(A.val()), [A](vari_value<matrix_cl<double>>& res) mutable {
-        A.adj() = A.adj() - elt_multiply(res.adj(), sin(A.val()));
+        A.adj() -= elt_multiply(res.adj(), sin(A.val()));
       });
 }
 

--- a/stan/math/opencl/rev/cos.hpp
+++ b/stan/math/opencl/rev/cos.hpp
@@ -19,10 +19,10 @@ namespace math {
 template <typename T,
           require_all_kernel_expressions_and_none_scalar_t<T>* = nullptr>
 inline var_value<matrix_cl<double>> cos(const var_value<T>& A) {
-  return make_callback_var(
-      cos(A.val()), [A](vari_value<matrix_cl<double>>& res) mutable {
-        A.adj() -= elt_multiply(res.adj(), sin(A.val()));
-      });
+  return make_callback_var(cos(A.val()),
+                           [A](vari_value<matrix_cl<double>>& res) mutable {
+                             A.adj() -= elt_multiply(res.adj(), sin(A.val()));
+                           });
 }
 
 }  // namespace math

--- a/stan/math/opencl/rev/cosh.hpp
+++ b/stan/math/opencl/rev/cosh.hpp
@@ -21,7 +21,7 @@ template <typename T,
 inline var_value<matrix_cl<double>> cosh(const var_value<T>& A) {
   return make_callback_var(
       cosh(A.val()), [A](vari_value<matrix_cl<double>>& res) mutable {
-        A.adj() = A.adj() + elt_multiply(res.adj(), sinh(A.val()));
+        A.adj() += elt_multiply(res.adj(), sinh(A.val()));
       });
 }
 

--- a/stan/math/opencl/rev/cosh.hpp
+++ b/stan/math/opencl/rev/cosh.hpp
@@ -19,10 +19,10 @@ namespace math {
 template <typename T,
           require_all_kernel_expressions_and_none_scalar_t<T>* = nullptr>
 inline var_value<matrix_cl<double>> cosh(const var_value<T>& A) {
-  return make_callback_var(
-      cosh(A.val()), [A](vari_value<matrix_cl<double>>& res) mutable {
-        A.adj() += elt_multiply(res.adj(), sinh(A.val()));
-      });
+  return make_callback_var(cosh(A.val()),
+                           [A](vari_value<matrix_cl<double>>& res) mutable {
+                             A.adj() += elt_multiply(res.adj(), sinh(A.val()));
+                           });
 }
 
 }  // namespace math

--- a/stan/math/opencl/rev/crossprod.hpp
+++ b/stan/math/opencl/rev/crossprod.hpp
@@ -23,7 +23,7 @@ inline var_value<matrix_cl<double>> crossprod(const var_value<T>& M) {
   return make_callback_var(
       transpose(M.val()) * M.val(),
       [M](vari_value<matrix_cl<double>>& res) mutable {
-        M.adj() = M.adj() + M.val() * (res.adj() + transpose(res.adj()));
+        M.adj() += M.val() * (res.adj() + transpose(res.adj()));
       });
 }
 

--- a/stan/math/opencl/rev/crossprod.hpp
+++ b/stan/math/opencl/rev/crossprod.hpp
@@ -20,11 +20,11 @@ namespace math {
 template <typename T,
           require_all_kernel_expressions_and_none_scalar_t<T>* = nullptr>
 inline var_value<matrix_cl<double>> crossprod(const var_value<T>& M) {
-  return make_callback_var(
-      transpose(M.val()) * M.val(),
-      [M](vari_value<matrix_cl<double>>& res) mutable {
-        M.adj() += M.val() * (res.adj() + transpose(res.adj()));
-      });
+  return make_callback_var(transpose(M.val()) * M.val(),
+                           [M](vari_value<matrix_cl<double>>& res) mutable {
+                             M.adj() += M.val()
+                                        * (res.adj() + transpose(res.adj()));
+                           });
 }
 
 }  // namespace math

--- a/stan/math/opencl/rev/diag_matrix.hpp
+++ b/stan/math/opencl/rev/diag_matrix.hpp
@@ -21,7 +21,7 @@ template <typename T,
 inline var_value<matrix_cl<double>> diag_matrix(const var_value<T>& v) {
   return make_callback_var(diag_matrix(v.val()),
                            [v](vari_value<matrix_cl<double>>& res) mutable {
-                             v.adj() = v.adj() + diagonal(res.adj());
+                             v.adj() += diagonal(res.adj());
                            });
 }
 

--- a/stan/math/opencl/rev/diag_post_multiply.hpp
+++ b/stan/math/opencl/rev/diag_post_multiply.hpp
@@ -52,8 +52,7 @@ inline var_value<matrix_cl<double>> diag_post_multiply(T1&& v1, T2&& v2) {
         while (tmp.rows() > 1) {
           tmp = eval(colwise_sum(tmp));
         }
-        auto& v2_adj = forward_as<var_value<matrix_cl<double>>>(v2_arena).adj();
-        v2_adj = v2_adj + tmp;
+        adjoint_of(v2_arena) += tmp;
       }
     } else {
       auto v1_adj_inc = elt_multiply(
@@ -69,8 +68,7 @@ inline var_value<matrix_cl<double>> diag_post_multiply(T1&& v1, T2&& v2) {
         while (tmp.rows() > 1) {
           tmp = eval(colwise_sum(tmp));
         }
-        auto& v2_adj = forward_as<var_value<matrix_cl<double>>>(v2_arena).adj();
-        v2_adj = v2_adj + transpose(tmp);
+        adjoint_of(v2_arena) += transpose(tmp);
       }
     }
   });

--- a/stan/math/opencl/rev/diag_post_multiply.hpp
+++ b/stan/math/opencl/rev/diag_post_multiply.hpp
@@ -34,44 +34,46 @@ inline var_value<matrix_cl<double>> diag_post_multiply(T1&& v1, T2&& v2) {
   matrix_cl<double> res_val
       = diag_post_multiply(value_of(v1_arena), value_of(v2_arena));
 
-  return make_callback_var(res_val, [v1_arena, v2_arena](
-                                        const vari_value<matrix_cl<double>>&
-                                            res) mutable {
-    if (v2_arena.rows() == 1) {
-      auto v1_adj_inc
-          = elt_multiply(res.adj(), colwise_broadcast(value_of(v2_arena)));
-      auto v2_adj_inc
-          = colwise_sum(elt_multiply(res.adj(), value_of(v1_arena)));
-      matrix_cl<double> tmp;
-      auto&& v1_adj = adjoint_of(v1_arena);
-      results(v1_adj, tmp) = expressions(
-          calc_if<!is_constant<std::decay_t<T1>>::value>(v1_adj + v1_adj_inc),
-          calc_if<!is_constant<std::decay_t<T2>>::value>(v2_adj_inc));
+  return make_callback_var(
+      res_val,
+      [v1_arena, v2_arena](const vari_value<matrix_cl<double>>& res) mutable {
+        if (v2_arena.rows() == 1) {
+          auto v1_adj_inc
+              = elt_multiply(res.adj(), colwise_broadcast(value_of(v2_arena)));
+          auto v2_adj_inc
+              = colwise_sum(elt_multiply(res.adj(), value_of(v1_arena)));
+          matrix_cl<double> tmp;
+          auto&& v1_adj = adjoint_of(v1_arena);
+          results(v1_adj, tmp) = expressions(
+              calc_if<!is_constant<std::decay_t<T1>>::value>(v1_adj
+                                                             + v1_adj_inc),
+              calc_if<!is_constant<std::decay_t<T2>>::value>(v2_adj_inc));
 
-      if (!is_constant<std::decay_t<T2>>::value) {
-        while (tmp.rows() > 1) {
-          tmp = eval(colwise_sum(tmp));
+          if (!is_constant<std::decay_t<T2>>::value) {
+            while (tmp.rows() > 1) {
+              tmp = eval(colwise_sum(tmp));
+            }
+            adjoint_of(v2_arena) += tmp;
+          }
+        } else {
+          auto v1_adj_inc = elt_multiply(
+              res.adj(), colwise_broadcast(transpose(value_of(v2_arena))));
+          auto v2_adj_inc
+              = colwise_sum(elt_multiply(res.adj(), value_of(v1_arena)));
+          matrix_cl<double> tmp;
+          auto&& v1_adj = adjoint_of(v1_arena);
+          results(v1_adj, tmp) = expressions(
+              calc_if<!is_constant<std::decay_t<T1>>::value>(v1_adj
+                                                             + v1_adj_inc),
+              calc_if<!is_constant<std::decay_t<T2>>::value>(v2_adj_inc));
+          if (!is_constant<std::decay_t<T2>>::value) {
+            while (tmp.rows() > 1) {
+              tmp = eval(colwise_sum(tmp));
+            }
+            adjoint_of(v2_arena) += transpose(tmp);
+          }
         }
-        adjoint_of(v2_arena) += tmp;
-      }
-    } else {
-      auto v1_adj_inc = elt_multiply(
-          res.adj(), colwise_broadcast(transpose(value_of(v2_arena))));
-      auto v2_adj_inc
-          = colwise_sum(elt_multiply(res.adj(), value_of(v1_arena)));
-      matrix_cl<double> tmp;
-      auto&& v1_adj = adjoint_of(v1_arena);
-      results(v1_adj, tmp) = expressions(
-          calc_if<!is_constant<std::decay_t<T1>>::value>(v1_adj + v1_adj_inc),
-          calc_if<!is_constant<std::decay_t<T2>>::value>(v2_adj_inc));
-      if (!is_constant<std::decay_t<T2>>::value) {
-        while (tmp.rows() > 1) {
-          tmp = eval(colwise_sum(tmp));
-        }
-        adjoint_of(v2_arena) += transpose(tmp);
-      }
-    }
-  });
+      });
 }
 
 }  // namespace math

--- a/stan/math/opencl/rev/diag_pre_multiply.hpp
+++ b/stan/math/opencl/rev/diag_pre_multiply.hpp
@@ -39,33 +39,21 @@ inline var_value<matrix_cl<double>> diag_pre_multiply(T1&& v1, T2&& v2) {
       [v1_arena, v2_arena](const vari_value<matrix_cl<double>>& res) mutable {
         if (v1_arena.cols() == 1) {
           if (!is_constant<std::decay_t<T1>>::value) {
-            auto& v1_adj
-                = forward_as<var_value<matrix_cl<double>>>(v1_arena).adj();
-            v1_adj = v1_adj
-                     + rowwise_sum(elt_multiply(res.adj(), value_of(v2_arena)));
+            adjoint_of(v1_arena)
+                += rowwise_sum(elt_multiply(res.adj(), value_of(v2_arena)));
           }
           if (!is_constant<std::decay_t<T2>>::value) {
-            auto& v2_adj
-                = forward_as<var_value<matrix_cl<double>>>(v2_arena).adj();
-            v2_adj = v2_adj
-                     + elt_multiply(res.adj(),
-                                    rowwise_broadcast(value_of(v1_arena)));
+            adjoint_of(v2_arena) += elt_multiply(
+                res.adj(), rowwise_broadcast(value_of(v1_arena)));
           }
         } else {
           if (!is_constant<std::decay_t<T1>>::value) {
-            auto v1_adj_transpose = transpose(
-                forward_as<var_value<matrix_cl<double>>>(v1_arena).adj());
-            v1_adj_transpose
-                = v1_adj_transpose
-                  + rowwise_sum(elt_multiply(res.adj(), value_of(v2_arena)));
+            adjoint_of(transpose(v1_arena))
+                += rowwise_sum(elt_multiply(res.adj(), value_of(v2_arena)));
           }
           if (!is_constant<std::decay_t<T2>>::value) {
-            auto& v2_adj
-                = forward_as<var_value<matrix_cl<double>>>(v2_arena).adj();
-            v2_adj = v2_adj
-                     + elt_multiply(
-                           res.adj(),
-                           rowwise_broadcast(transpose(value_of(v1_arena))));
+            adjoint_of(v2_arena) += elt_multiply(
+                res.adj(), rowwise_broadcast(transpose(value_of(v1_arena))));
           }
         }
       });

--- a/stan/math/opencl/rev/diagonal.hpp
+++ b/stan/math/opencl/rev/diagonal.hpp
@@ -21,7 +21,7 @@ template <typename T,
 inline var_value<matrix_cl<double>> diagonal(const var_value<T>& M) {
   return make_callback_var(diagonal(M.val()),
                            [M](vari_value<matrix_cl<double>>& res) mutable {
-                             diagonal(M.adj()) = diagonal(M.adj()) + res.adj();
+                             diagonal(M.adj()) += res.adj();
                            });
 }
 

--- a/stan/math/opencl/rev/digamma.hpp
+++ b/stan/math/opencl/rev/digamma.hpp
@@ -19,7 +19,7 @@ inline var_value<matrix_cl<double>> digamma(
     const var_value<matrix_cl<double>>& A) {
   return make_callback_var(
       digamma(A.val()), [A](const vari_value<matrix_cl<double>> res) mutable {
-        A.adj() = A.adj() + elt_multiply(res.adj(), trigamma(A.val()));
+        A.adj() += elt_multiply(res.adj(), trigamma(A.val()));
       });
 }
 

--- a/stan/math/opencl/rev/divide.hpp
+++ b/stan/math/opencl/rev/divide.hpp
@@ -2,7 +2,7 @@
 #define STAN_MATH_OPENCL_REV_DIVIDE_HPP
 #ifdef STAN_OPENCL
 
-#include <stan/math/prim/meta/is_kernel_expression.hpp>
+#include <stan/math/opencl/rev/adjoint_results.hpp>
 #include <stan/math/opencl/matrix_cl.hpp>
 #include <stan/math/opencl/kernel_generator.hpp>
 #include <stan/math/opencl/prim/sum.hpp>
@@ -10,6 +10,7 @@
 #include <stan/math/rev/fun/value_of.hpp>
 #include <stan/math/rev/core/reverse_pass_callback.hpp>
 #include <stan/math/prim/fun/value_of.hpp>
+#include <stan/math/prim/meta/is_kernel_expression.hpp>
 
 namespace stan {
 namespace math {
@@ -32,19 +33,12 @@ inline var_value<matrix_cl<double>> divide(T_a&& a, T_b&& b) {
   arena_t<T_a> a_arena = std::forward<T_a>(a);
   arena_t<T_b> b_arena = std::forward<T_b>(b);
 
-  matrix_cl<double> res_val = elt_divide(value_of(a_arena), value_of(b_arena));
-
   return make_callback_var(
-      res_val,
+      elt_divide(value_of(a_arena), value_of(b_arena)),
       [a_arena, b_arena](const vari_value<matrix_cl<double>>& res) mutable {
-        if (!is_constant<T_a>::value) {
-          auto& a_adj = forward_as<var_value<matrix_cl<double>>>(a_arena).adj();
-          a_adj = a_adj + elt_divide(res.adj(), value_of(b_arena));
-        }
-        if (!is_constant<T_b>::value) {
-          auto& b_adj = forward_as<var_value<double>>(b_arena).adj();
-          b_adj = b_adj - sum(elt_divide(res.val(), value_of(b_arena)));
-        }
+        adjoint_results(a_arena, b_arena)
+            += expressions(elt_divide(res.adj(), value_of(b_arena)),
+                           -elt_divide(res.val(), value_of(b_arena)));
       });
 }
 

--- a/stan/math/opencl/rev/dot_product.hpp
+++ b/stan/math/opencl/rev/dot_product.hpp
@@ -2,6 +2,7 @@
 #define STAN_MATH_OPENCL_REV_DOT_PRODUCT_HPP
 #ifdef STAN_OPENCL
 
+#include <stan/math/opencl/rev/adjoint_results.hpp>
 #include <stan/math/opencl/kernel_generator.hpp>
 #include <stan/math/rev/core.hpp>
 #include <stan/math/rev/fun/adjoint_of.hpp>
@@ -30,12 +31,9 @@ inline var dot_product(T1&& v1, T2&& v2) {
 
   return make_callback_var(dot_product(value_of(v1_arena), value_of(v2_arena)),
                            [v1_arena, v2_arena](vari& res) mutable {
-                             auto v1_deriv = res.adj() * value_of(v2_arena);
-                             auto v2_deriv = res.adj() * value_of(v1_arena);
-                             results(adjoint_of(v1_arena), adjoint_of(v2_arena))
-                                 += expressions(
-                                     calc_if<is_var<T1>::value>(v1_deriv),
-                                     calc_if<is_var<T2>::value>(v2_deriv));
+                             adjoint_results(v1_arena, v2_arena)
+                                 += expressions(res.adj() * value_of(v2_arena),
+                                                res.adj() * value_of(v1_arena));
                            });
 }
 

--- a/stan/math/opencl/rev/dot_self.hpp
+++ b/stan/math/opencl/rev/dot_self.hpp
@@ -16,12 +16,11 @@ namespace math {
  * @param[in] v Vector.
  * @return Dot product of the vector with itself.
  */
-template <typename T, require_var_vt<is_matrix_cl, T>* = nullptr>
-inline var dot_self(T&& v) {
-  arena_t<T> v_arena = std::forward<T>(v);
-
-  return make_callback_var(dot_self(v.val()), [v_arena](vari& res) mutable {
-    v_arena.adj() = v_arena.adj() + 2.0 * res.adj() * v_arena.val();
+template <typename T,
+          require_all_kernel_expressions_and_none_scalar_t<T>* = nullptr>
+inline var dot_self(const var_value<T>& v) {
+  return make_callback_var(dot_self(v.val()), [v](vari& res) mutable {
+    v.adj() += 2.0 * res.adj() * v.val();
   });
 }
 

--- a/stan/math/opencl/rev/elt_divide.hpp
+++ b/stan/math/opencl/rev/elt_divide.hpp
@@ -2,15 +2,15 @@
 #define STAN_MATH_OPENCL_REV_ELT_DIVIDE_HPP
 #ifdef STAN_OPENCL
 
-#include <stan/math/prim/meta/is_kernel_expression.hpp>
+#include <stan/math/opencl/rev/adjoint_results.hpp>
 #include <stan/math/opencl/matrix_cl.hpp>
 #include <stan/math/opencl/kernel_generator.hpp>
 #include <stan/math/opencl/prim/sum.hpp>
 #include <stan/math/rev/core.hpp>
-#include <stan/math/rev/fun/adjoint_of.hpp>
 #include <stan/math/rev/fun/value_of.hpp>
 #include <stan/math/rev/core/reverse_pass_callback.hpp>
 #include <stan/math/prim/fun/value_of.hpp>
+#include <stan/math/prim/meta/is_kernel_expression.hpp>
 
 namespace stan {
 namespace math {
@@ -26,79 +26,19 @@ namespace math {
  */
 template <
     typename T_a, typename T_b,
-    require_all_nonscalar_prim_or_rev_kernel_expression_t<T_a, T_b>* = nullptr,
-    require_any_var_t<T_a, T_b>* = nullptr>
+    require_all_prim_or_rev_kernel_expression_t<T_a, T_b>* = nullptr,
+    require_any_var_t<T_a, T_b>* = nullptr,
+    require_any_not_stan_scalar_t<T_a, T_b>* = nullptr>
 inline var_value<matrix_cl<double>> elt_divide(T_a&& a, T_b&& b) {
-  const arena_t<T_a>& a_arena = std::forward<T_a>(a);
-  const arena_t<T_b>& b_arena = std::forward<T_b>(b);
-
-  matrix_cl<double> res_val = elt_divide(value_of(a_arena), value_of(b_arena));
+  arena_t<T_a> a_arena = std::forward<T_a>(a);
+  arena_t<T_b> b_arena = std::forward<T_b>(b);
 
   return make_callback_var(
-      res_val,
+      elt_divide(value_of(a_arena), value_of(b_arena)),
       [a_arena, b_arena](const vari_value<matrix_cl<double>>& res) mutable {
-        auto a_deriv = elt_divide(res.adj(), value_of(b_arena));
-        auto b_deriv = -elt_divide(res.val(), value_of(b_arena));
-        results(adjoint_of(a_arena), adjoint_of(b_arena))
-            += expressions(calc_if<is_var<T_a>::value>(a_deriv),
-                           calc_if<is_var<T_b>::value>(b_deriv));
-      });
-}
-/**
- * Elementwise division of a reverse mode matrices and a scalar.
- * @tparam T_a type of kernel generator expression
- * @tparam T_b type of scalar
- * @param a kernel generator expression
- * @param b scalar
- * @return Elementwise division of the input arguments
- */
-template <typename T_a, typename T_b,
-          require_nonscalar_prim_or_rev_kernel_expression_t<T_a>* = nullptr,
-          require_stan_scalar_t<T_b>* = nullptr,
-          require_any_var_t<T_a, T_b>* = nullptr>
-inline var_value<matrix_cl<double>> elt_divide(T_a&& a, const T_b& b) {
-  const arena_t<T_a>& a_arena = std::forward<T_a>(a);
-
-  matrix_cl<double> res_val = elt_divide(value_of(a_arena), value_of(b));
-
-  return make_callback_var(
-      res_val, [a_arena, b](const vari_value<matrix_cl<double>>& res) mutable {
-        if (!is_constant<T_a>::value) {
-          auto& a_adj = forward_as<var_value<matrix_cl<double>>>(a_arena).adj();
-          a_adj = a_adj + elt_divide(res.adj(), value_of(b));
-        }
-        if (!is_constant<T_b>::value) {
-          adjoint_of(b) -= sum(elt_divide(res.val(), value_of(b)));
-        }
-      });
-}
-
-/**
- * Elementwise division of a scalar and a reverse mode matrix.
- * @tparam T_a type of scalar
- * @tparam T_b type of kernel generator expression
- * @param a scalar
- * @param b kernel generator expression
- * @return Elementwise division of the input arguments
- */
-template <typename T_a, typename T_b,
-          require_nonscalar_prim_or_rev_kernel_expression_t<T_b>* = nullptr,
-          require_stan_scalar_t<T_a>* = nullptr,
-          require_any_var_t<T_a, T_b>* = nullptr>
-inline var_value<matrix_cl<double>> elt_divide(const T_a& a, T_b&& b) {
-  const arena_t<T_b>& b_arena = std::forward<T_b>(b);
-
-  matrix_cl<double> res_val = elt_divide(value_of(a), value_of(b_arena));
-
-  return make_callback_var(
-      res_val, [a, b_arena](const vari_value<matrix_cl<double>>& res) mutable {
-        if (!is_constant<T_a>::value) {
-          adjoint_of(a) += sum(elt_divide(res.adj(), value_of(b_arena)));
-        }
-        if (!is_constant<T_b>::value) {
-          auto& b_adj = forward_as<var_value<matrix_cl<double>>>(b_arena).adj();
-          b_adj = b_adj - elt_divide(res.val(), value_of(b_arena));
-        }
+        adjoint_results(a_arena, b_arena)
+            += expressions(elt_divide(res.adj(), value_of(b_arena)),
+                           -elt_divide(res.val(), value_of(b_arena)));
       });
 }
 

--- a/stan/math/opencl/rev/elt_divide.hpp
+++ b/stan/math/opencl/rev/elt_divide.hpp
@@ -24,11 +24,10 @@ namespace math {
  * @param b second expression
  * @return Elementwise division of the input arguments
  */
-template <
-    typename T_a, typename T_b,
-    require_all_prim_or_rev_kernel_expression_t<T_a, T_b>* = nullptr,
-    require_any_var_t<T_a, T_b>* = nullptr,
-    require_any_not_stan_scalar_t<T_a, T_b>* = nullptr>
+template <typename T_a, typename T_b,
+          require_all_prim_or_rev_kernel_expression_t<T_a, T_b>* = nullptr,
+          require_any_var_t<T_a, T_b>* = nullptr,
+          require_any_not_stan_scalar_t<T_a, T_b>* = nullptr>
 inline var_value<matrix_cl<double>> elt_divide(T_a&& a, T_b&& b) {
   arena_t<T_a> a_arena = std::forward<T_a>(a);
   arena_t<T_b> b_arena = std::forward<T_b>(b);

--- a/stan/math/opencl/rev/erf.hpp
+++ b/stan/math/opencl/rev/erf.hpp
@@ -20,11 +20,10 @@ template <typename T,
 inline var_value<matrix_cl<double>> erf(const var_value<T>& A) {
   return make_callback_var(
       erf(A.val()), [A](vari_value<matrix_cl<double>>& res) mutable {
-        A.adj() = A.adj()
-                  + elt_multiply(
+        A.adj() += elt_multiply(
                         res.adj(),
                         elt_multiply(TWO_OVER_SQRT_PI,
-                                     exp(-elt_multiply(A.val(), A.val()))));
+                                     exp(-square(A.val()))));
       });
 }
 

--- a/stan/math/opencl/rev/erf.hpp
+++ b/stan/math/opencl/rev/erf.hpp
@@ -21,9 +21,7 @@ inline var_value<matrix_cl<double>> erf(const var_value<T>& A) {
   return make_callback_var(
       erf(A.val()), [A](vari_value<matrix_cl<double>>& res) mutable {
         A.adj() += elt_multiply(
-                        res.adj(),
-                        elt_multiply(TWO_OVER_SQRT_PI,
-                                     exp(-square(A.val()))));
+            res.adj(), elt_multiply(TWO_OVER_SQRT_PI, exp(-square(A.val()))));
       });
 }
 

--- a/stan/math/opencl/rev/erfc.hpp
+++ b/stan/math/opencl/rev/erfc.hpp
@@ -20,11 +20,8 @@ template <typename T,
 inline var_value<matrix_cl<double>> erfc(const var_value<T>& A) {
   return make_callback_var(
       erfc(A.val()), [A](vari_value<matrix_cl<double>>& res) mutable {
-        A.adj() = A.adj()
-                  - elt_multiply(
-                        res.adj(),
-                        elt_multiply(TWO_OVER_SQRT_PI,
-                                     exp(-elt_multiply(A.val(), A.val()))));
+        A.adj() -= elt_multiply(
+            res.adj(), elt_multiply(TWO_OVER_SQRT_PI, exp(-square(A.val()))));
       });
 }
 

--- a/stan/math/opencl/rev/exp.hpp
+++ b/stan/math/opencl/rev/exp.hpp
@@ -20,7 +20,7 @@ template <typename T,
 inline var_value<matrix_cl<double>> exp(const var_value<T>& A) {
   return make_callback_var(
       exp(A.val()), [A](vari_value<matrix_cl<double>>& res) mutable {
-        A.adj() = A.adj() + elt_multiply(res.adj(), res.val());
+        A.adj() += elt_multiply(res.adj(), res.val());
       });
 }
 

--- a/stan/math/opencl/rev/exp.hpp
+++ b/stan/math/opencl/rev/exp.hpp
@@ -18,10 +18,10 @@ namespace math {
 template <typename T,
           require_all_kernel_expressions_and_none_scalar_t<T>* = nullptr>
 inline var_value<matrix_cl<double>> exp(const var_value<T>& A) {
-  return make_callback_var(
-      exp(A.val()), [A](vari_value<matrix_cl<double>>& res) mutable {
-        A.adj() += elt_multiply(res.adj(), res.val());
-      });
+  return make_callback_var(exp(A.val()),
+                           [A](vari_value<matrix_cl<double>>& res) mutable {
+                             A.adj() += elt_multiply(res.adj(), res.val());
+                           });
 }
 
 }  // namespace math

--- a/stan/math/opencl/rev/exp2.hpp
+++ b/stan/math/opencl/rev/exp2.hpp
@@ -20,8 +20,7 @@ template <typename T,
 inline var_value<matrix_cl<double>> exp2(const var_value<T>& A) {
   return make_callback_var(
       exp2(A.val()), [A](vari_value<matrix_cl<double>>& res) mutable {
-        A.adj() = A.adj()
-                  + elt_multiply(elt_multiply(res.adj(), res.val()), LOG_TWO);
+        A.adj() += elt_multiply(elt_multiply(res.adj(), res.val()), LOG_TWO);
       });
 }
 

--- a/stan/math/opencl/rev/expm1.hpp
+++ b/stan/math/opencl/rev/expm1.hpp
@@ -20,7 +20,7 @@ template <typename T,
 inline var_value<matrix_cl<double>> expm1(const var_value<T>& A) {
   return make_callback_var(
       expm1(A.val()), [A](vari_value<matrix_cl<double>>& res) mutable {
-        A.adj() = A.adj() + elt_multiply(res.adj(), res.val() + 1.0);
+        A.adj() += elt_multiply(res.adj(), res.val() + 1.0);
       });
 }
 

--- a/stan/math/opencl/rev/fabs.hpp
+++ b/stan/math/opencl/rev/fabs.hpp
@@ -22,7 +22,7 @@ inline var_value<matrix_cl<double>> fabs(const var_value<T>& A) {
   return make_callback_var(
       fabs(A.val()), [A](vari_value<matrix_cl<double>>& res) mutable {
         A.adj() = select(
-            isnan(A.val()), constant(NOT_A_NUMBER, A.rows(), A.cols()),
+            isnan(A.val()), NOT_A_NUMBER,
             select(A.val() < 0.0, A.adj() - res.adj(), A.adj() + res.adj()));
       });
 }

--- a/stan/math/opencl/rev/floor.hpp
+++ b/stan/math/opencl/rev/floor.hpp
@@ -21,8 +21,7 @@ template <typename T,
 inline var_value<matrix_cl<double>> floor(const var_value<T>& A) {
   return make_callback_var(
       floor(A.val()), [A](vari_value<matrix_cl<double>>& res) mutable {
-        A.adj() = select(isnan(A.val()),
-                         constant(NOT_A_NUMBER, A.rows(), A.cols()), A.adj());
+        A.adj() = select(isnan(A.val()), NOT_A_NUMBER, A.adj());
       });
 }
 

--- a/stan/math/opencl/rev/hypot.hpp
+++ b/stan/math/opencl/rev/hypot.hpp
@@ -21,11 +21,10 @@ namespace math {
  *
  * @return Elementwise `hypot()` of the input.
  */
-template <
-    typename T_a, typename T_b,
-    require_all_prim_or_rev_kernel_expression_t<T_a, T_b>* = nullptr,
-    require_any_var_t<T_a, T_b>* = nullptr,
-    require_any_not_stan_scalar_t<T_a, T_b>* = nullptr>
+template <typename T_a, typename T_b,
+          require_all_prim_or_rev_kernel_expression_t<T_a, T_b>* = nullptr,
+          require_any_var_t<T_a, T_b>* = nullptr,
+          require_any_not_stan_scalar_t<T_a, T_b>* = nullptr>
 inline var_value<matrix_cl<double>> hypot(T_a&& a, T_b&& b) {
   arena_t<T_a> a_arena = std::forward<T_a>(a);
   arena_t<T_b> b_arena = std::forward<T_b>(b);

--- a/stan/math/opencl/rev/hypot.hpp
+++ b/stan/math/opencl/rev/hypot.hpp
@@ -2,6 +2,7 @@
 #define STAN_MATH_OPENCL_REV_HYPOT_HPP
 #ifdef STAN_OPENCL
 
+#include <stan/math/opencl/rev/adjoint_results.hpp>
 #include <stan/math/opencl/kernel_generator.hpp>
 #include <stan/math/rev/core.hpp>
 #include <stan/math/rev/fun/adjoint_of.hpp>
@@ -22,94 +23,20 @@ namespace math {
  */
 template <
     typename T_a, typename T_b,
-    require_all_nonscalar_prim_or_rev_kernel_expression_t<T_a, T_b>* = nullptr,
-    require_any_var_t<T_a, T_b>* = nullptr>
+    require_all_prim_or_rev_kernel_expression_t<T_a, T_b>* = nullptr,
+    require_any_var_t<T_a, T_b>* = nullptr,
+    require_any_not_stan_scalar_t<T_a, T_b>* = nullptr>
 inline var_value<matrix_cl<double>> hypot(T_a&& a, T_b&& b) {
-  const arena_t<T_a>& a_arena = std::forward<T_a>(a);
-  const arena_t<T_b>& b_arena = std::forward<T_b>(b);
-
-  matrix_cl<double> res_val = hypot(value_of(a_arena), value_of(b_arena));
+  arena_t<T_a> a_arena = std::forward<T_a>(a);
+  arena_t<T_b> b_arena = std::forward<T_b>(b);
 
   return make_callback_var(
-      res_val,
+      hypot(value_of(a_arena), value_of(b_arena)),
       [a_arena, b_arena](const vari_value<matrix_cl<double>>& res) mutable {
-        auto a_deriv
-            = elt_multiply(res.adj(), elt_divide(value_of(a_arena), res.val()));
-        auto b_deriv
-            = elt_multiply(res.adj(), elt_divide(value_of(b_arena), res.val()));
-        results(adjoint_of(a_arena), adjoint_of(b_arena))
-            += expressions(calc_if<is_var<T_a>::value>(a_deriv),
-                           calc_if<is_var<T_b>::value>(b_deriv));
-      });
-}
-
-/**
- * Returns the elementwise `hypot()` of the input, where the first input
- * is a nonscalar kernel generator expression and the second input is
- * a scalar.
- *
- * @tparam T_a type of kernel generator expression
- * @tparam T_b type of scalar
- * @param a kernel generator expression
- * @param b scalar
- * @return Elementwise `hypot()` of the input arguments
- */
-template <typename T_a, typename T_b,
-          require_nonscalar_prim_or_rev_kernel_expression_t<T_a>* = nullptr,
-          require_stan_scalar_t<T_b>* = nullptr,
-          require_any_var_t<T_a, T_b>* = nullptr>
-inline var_value<matrix_cl<double>> hypot(T_a&& a, const T_b& b) {
-  const arena_t<T_a>& a_arena = std::forward<T_a>(a);
-
-  matrix_cl<double> res_val = hypot(value_of(a_arena), value_of(b));
-
-  return make_callback_var(
-      res_val, [a_arena, b](const vari_value<matrix_cl<double>>& res) mutable {
-        if (!is_constant<T_a>::value) {
-          auto& a_adj = forward_as<var_value<matrix_cl<double>>>(a_arena).adj();
-          a_adj = a_adj
-                  + elt_multiply(res.adj(),
-                                 elt_divide(value_of(a_arena), res.val()));
-        }
-        if (!is_constant<T_b>::value) {
-          adjoint_of(b) += sum(
-              elt_multiply(res.adj(), elt_divide(value_of(b), res.val())));
-        }
-      });
-}
-
-/**
- * Returns the elementwise `hypot()` of the input, where the first input
- * is a scalar and the second input is a nonscalar kernel generator
- * expression.
- *
- * @tparam T_a type of scalar
- * @tparam T_b type of kernel generator expression
- * @param a scalar
- * @param b kernel generator expression
- * @return Elementwise division of the input arguments
- */
-template <typename T_a, typename T_b,
-          require_nonscalar_prim_or_rev_kernel_expression_t<T_b>* = nullptr,
-          require_stan_scalar_t<T_a>* = nullptr,
-          require_any_var_t<T_a, T_b>* = nullptr>
-inline var_value<matrix_cl<double>> hypot(const T_a& a, T_b&& b) {
-  const arena_t<T_b>& b_arena = std::forward<T_b>(b);
-
-  matrix_cl<double> res_val = hypot(value_of(a), value_of(b_arena));
-
-  return make_callback_var(
-      res_val, [a, b_arena](const vari_value<matrix_cl<double>>& res) mutable {
-        if (!is_constant<T_a>::value) {
-          adjoint_of(a) += sum(
-              elt_multiply(res.adj(), elt_divide(value_of(a), res.val())));
-        }
-        if (!is_constant<T_b>::value) {
-          auto& b_adj = forward_as<var_value<matrix_cl<double>>>(b_arena).adj();
-          b_adj = b_adj
-                  + elt_multiply(res.adj(),
-                                 elt_divide(value_of(b_arena), res.val()));
-        }
+        auto res_adj_div_val = elt_divide(res.adj(), res.val());
+        adjoint_results(a_arena, b_arena)
+            += expressions(elt_multiply(value_of(a_arena), res_adj_div_val),
+                           elt_multiply(value_of(b_arena), res_adj_div_val));
       });
 }
 

--- a/stan/math/opencl/rev/inv.hpp
+++ b/stan/math/opencl/rev/inv.hpp
@@ -18,10 +18,10 @@ namespace math {
 template <typename T,
           require_all_kernel_expressions_and_none_scalar_t<T>* = nullptr>
 inline var_value<matrix_cl<double>> inv(const var_value<T>& A) {
-  return make_callback_var(
-      inv(A.val()), [A](vari_value<matrix_cl<double>>& res) mutable {
-        A.adj() -= elt_divide(res.adj(), square(A.val()));
-      });
+  return make_callback_var(inv(A.val()),
+                           [A](vari_value<matrix_cl<double>>& res) mutable {
+                             A.adj() -= elt_divide(res.adj(), square(A.val()));
+                           });
 }
 
 }  // namespace math

--- a/stan/math/opencl/rev/inv.hpp
+++ b/stan/math/opencl/rev/inv.hpp
@@ -20,8 +20,7 @@ template <typename T,
 inline var_value<matrix_cl<double>> inv(const var_value<T>& A) {
   return make_callback_var(
       inv(A.val()), [A](vari_value<matrix_cl<double>>& res) mutable {
-        A.adj()
-            = A.adj() - elt_divide(res.adj(), elt_multiply(A.val(), A.val()));
+        A.adj() -= elt_divide(res.adj(), square(A.val()));
       });
 }
 

--- a/stan/math/opencl/rev/inv_Phi.hpp
+++ b/stan/math/opencl/rev/inv_Phi.hpp
@@ -20,12 +20,8 @@ template <typename T,
 inline var_value<matrix_cl<double>> inv_Phi(const var_value<T>& A) {
   return make_callback_var(
       inv_Phi(A.val()), [A](vari_value<matrix_cl<double>>& res) mutable {
-        A.adj()
-            = A.adj()
-              + elt_multiply(
-                    res.adj(),
-                    elt_divide(SQRT_TWO_PI,
-                               exp(-0.5 * elt_multiply(res.val(), res.val()))));
+        A.adj() += elt_multiply(
+            res.adj(), elt_divide(SQRT_TWO_PI, exp(-0.5 * square(res.val()))));
       });
 }
 

--- a/stan/math/opencl/rev/inv_cloglog.hpp
+++ b/stan/math/opencl/rev/inv_cloglog.hpp
@@ -20,8 +20,7 @@ template <typename T,
 inline var_value<matrix_cl<double>> inv_cloglog(const var_value<T>& A) {
   return make_callback_var(
       inv_cloglog(A.val()), [A](vari_value<matrix_cl<double>>& res) mutable {
-        A.adj()
-            = A.adj() + elt_multiply(res.adj(), exp(A.val() - exp(A.val())));
+        A.adj() += elt_multiply(res.adj(), exp(A.val() - exp(A.val())));
       });
 }
 

--- a/stan/math/opencl/rev/inv_logit.hpp
+++ b/stan/math/opencl/rev/inv_logit.hpp
@@ -20,9 +20,8 @@ template <typename T,
 inline var_value<matrix_cl<double>> inv_logit(const var_value<T>& A) {
   return make_callback_var(
       inv_logit(A.val()), [A](vari_value<matrix_cl<double>>& res) mutable {
-        A.adj() = A.adj()
-                  + elt_multiply(res.adj(),
-                                 elt_multiply(res.val(), 1.0 - res.val()));
+        A.adj() += elt_multiply(res.adj(),
+                                elt_multiply(res.val(), 1.0 - res.val()));
       });
 }
 

--- a/stan/math/opencl/rev/inv_sqrt.hpp
+++ b/stan/math/opencl/rev/inv_sqrt.hpp
@@ -20,10 +20,9 @@ template <typename T,
 inline var_value<matrix_cl<double>> inv_sqrt(const var_value<T>& A) {
   return make_callback_var(
       inv_sqrt(A.val()), [A](vari_value<matrix_cl<double>>& res) mutable {
-        A.adj() = A.adj()
-                  - 0.5
-                        * elt_divide(res.adj(),
-                                     elt_multiply(sqrt(A.val()), A.val()));
+        A.adj()
+            -= 0.5
+               * elt_divide(res.adj(), elt_multiply(sqrt(A.val()), A.val()));
       });
 }
 

--- a/stan/math/opencl/rev/inv_square.hpp
+++ b/stan/math/opencl/rev/inv_square.hpp
@@ -20,12 +20,8 @@ template <typename T,
 inline var_value<matrix_cl<double>> inv_square(const var_value<T>& A) {
   return make_callback_var(
       inv_square(A.val()), [A](vari_value<matrix_cl<double>>& res) mutable {
-        A.adj()
-            = A.adj()
-              - 2.0
-                    * elt_divide(res.adj(),
-                                 elt_multiply(elt_multiply(A.val(), A.val()),
-                                              A.val()));
+        A.adj() -= elt_divide(2.0 * res.adj(),
+                              elt_multiply(square(A.val()), A.val()));
       });
 }
 

--- a/stan/math/opencl/rev/lbeta.hpp
+++ b/stan/math/opencl/rev/lbeta.hpp
@@ -25,11 +25,10 @@ namespace math {
  * @param b second expression
  * @return elementwise `lbeta()`
  */
-template <
-    typename T_a, typename T_b,
-    require_all_prim_or_rev_kernel_expression_t<T_a, T_b>* = nullptr,
-    require_any_var_t<T_a, T_b>* = nullptr,
-    require_any_not_stan_scalar_t<T_a, T_b>* = nullptr>
+template <typename T_a, typename T_b,
+          require_all_prim_or_rev_kernel_expression_t<T_a, T_b>* = nullptr,
+          require_any_var_t<T_a, T_b>* = nullptr,
+          require_any_not_stan_scalar_t<T_a, T_b>* = nullptr>
 inline auto lbeta(T_a&& a, T_b&& b) {
   arena_t<T_a> a_arena = std::forward<T_a>(a);
   arena_t<T_b> b_arena = std::forward<T_b>(b);

--- a/stan/math/opencl/rev/lbeta.hpp
+++ b/stan/math/opencl/rev/lbeta.hpp
@@ -2,6 +2,7 @@
 #define STAN_MATH_OPENCL_REV_LBETA_HPP
 #ifdef STAN_OPENCL
 
+#include <stan/math/opencl/rev/adjoint_results.hpp>
 #include <stan/math/prim/meta/is_kernel_expression.hpp>
 #include <stan/math/opencl/matrix_cl.hpp>
 #include <stan/math/opencl/kernel_generator.hpp>
@@ -26,111 +27,21 @@ namespace math {
  */
 template <
     typename T_a, typename T_b,
-    require_all_nonscalar_prim_or_rev_kernel_expression_t<T_a, T_b>* = nullptr,
-    require_any_var_t<T_a, T_b>* = nullptr>
+    require_all_prim_or_rev_kernel_expression_t<T_a, T_b>* = nullptr,
+    require_any_var_t<T_a, T_b>* = nullptr,
+    require_any_not_stan_scalar_t<T_a, T_b>* = nullptr>
 inline auto lbeta(T_a&& a, T_b&& b) {
-  const arena_t<T_a>& a_arena = std::forward<T_a>(a);
-  const arena_t<T_b>& b_arena = std::forward<T_b>(b);
+  arena_t<T_a> a_arena = std::forward<T_a>(a);
+  arena_t<T_b> b_arena = std::forward<T_b>(b);
 
-  var_value<matrix_cl<double>> res
-      = lbeta(value_of(a_arena), value_of(b_arena));
-  reverse_pass_callback([a_arena, b_arena, res]() mutable {
-    auto digamma_ab = digamma(value_of(a_arena) + value_of(b_arena));
-    if (!is_constant<T_a>::value && !is_constant<T_b>::value) {
-      auto& a_adj = forward_as<var_value<matrix_cl<double>>>(a_arena).adj();
-      auto& b_adj = forward_as<var_value<matrix_cl<double>>>(b_arena).adj();
-      results(a_adj, b_adj) = expressions(
-          a_adj
-              + elt_multiply(res.adj(),
-                             (digamma(value_of(a_arena)) - digamma_ab)),
-          b_adj
-              + elt_multiply(res.adj(),
-                             (digamma(value_of(b_arena)) - digamma_ab)));
-    } else if (!is_constant<T_a>::value) {
-      auto& a_adj = forward_as<var_value<matrix_cl<double>>>(a_arena).adj();
-      a_adj = a_adj
-              + elt_multiply(res.adj(),
-                             (digamma(value_of(a_arena)) - digamma_ab));
-    } else {
-      auto& b_adj = forward_as<var_value<matrix_cl<double>>>(b_arena).adj();
-      b_adj = b_adj
-              + elt_multiply(res.adj(),
-                             (digamma(value_of(b_arena)) - digamma_ab));
-    }
-  });
-  return res;
-}
-
-/**
- * Return the elementwise `lbeta()` on an input kernel
- * generator expression and scalar.
- *
- * @tparam T_a type of first expression
- * @tparam T_b type of scalar
- * @param a kernel generator expression
- * @param b scalar
- * @return elementwise `lbeta()`
- */
-template <typename T_a, typename T_b,
-          require_nonscalar_prim_or_rev_kernel_expression_t<T_a>* = nullptr,
-          require_stan_scalar_t<T_b>* = nullptr,
-          require_any_var_t<T_a, T_b>* = nullptr>
-inline auto lbeta(T_a&& a, const T_b& b) {
-  const arena_t<T_a>& a_arena = std::forward<T_a>(a);
-
-  var_value<matrix_cl<double>> res = lbeta(value_of(a_arena), value_of(b));
-
-  reverse_pass_callback([a_arena, b, res]() mutable {
-    auto adj_val = elt_multiply(res.adj(), res.val());
-    auto digamma_ab = digamma(value_of(a_arena) + value_of(b));
-    if (!is_constant<T_a>::value) {
-      auto& a_adj = forward_as<var_value<matrix_cl<double>>>(a_arena).adj();
-      a_adj = a_adj
-              + elt_multiply(res.adj(),
-                             (digamma(value_of(a_arena)) - digamma_ab));
-    }
-    if (!is_constant<T_b>::value) {
-      adjoint_of(b)
-          += sum(elt_multiply(res.adj(), (digamma(value_of(b)) - digamma_ab)));
-    }
-  });
-  return res;
-}
-
-/**
- * Return the elementwise `lbeta()` on an input kernel
- * generator expression and scalar.
- *
- * @tparam T_a type of scalar
- * @tparam T_b type of first expression
- * @param a scalar
- * @param b kernel generator expression
- * @return elementwise `lbeta()`
- */
-template <typename T_a, typename T_b,
-          require_nonscalar_prim_or_rev_kernel_expression_t<T_b>* = nullptr,
-          require_stan_scalar_t<T_a>* = nullptr,
-          require_any_var_t<T_a, T_b>* = nullptr>
-inline auto lbeta(const T_a& a, T_b&& b) {
-  const arena_t<T_b>& b_arena = std::forward<T_b>(b);
-
-  var_value<matrix_cl<double>> res = lbeta(value_of(a), value_of(b_arena));
-
-  reverse_pass_callback([a, b_arena, res]() mutable {
-    auto adj_val = elt_multiply(res.adj(), res.val());
-    auto digamma_ab = digamma(value_of(a) + value_of(b_arena));
-    if (!is_constant<T_a>::value) {
-      adjoint_of(a)
-          += sum(elt_multiply(res.adj(), (digamma(value_of(a)) - digamma_ab)));
-    }
-    if (!is_constant<T_b>::value) {
-      auto& b_adj = forward_as<var_value<matrix_cl<double>>>(b_arena).adj();
-      b_adj = b_adj
-              + elt_multiply(res.adj(),
-                             (digamma(value_of(b_arena)) - digamma_ab));
-    }
-  });
-  return res;
+  return make_callback_var(
+      lbeta(value_of(a_arena), value_of(b_arena)),
+      [a_arena, b_arena](vari_value<matrix_cl<double>>& res) mutable {
+        auto digamma_ab = digamma(value_of(a_arena) + value_of(b_arena));
+        adjoint_results(a_arena, b_arena) += expressions(
+            elt_multiply(res.adj(), digamma(value_of(a_arena)) - digamma_ab),
+            elt_multiply(res.adj(), digamma(value_of(b_arena)) - digamma_ab));
+      });
 }
 
 }  // namespace math

--- a/stan/math/opencl/rev/ldexp.hpp
+++ b/stan/math/opencl/rev/ldexp.hpp
@@ -2,6 +2,7 @@
 #define STAN_MATH_OPENCL_REV_LDEXP_HPP
 #ifdef STAN_OPENCL
 
+#include <stan/math/opencl/rev/adjoint_results.hpp>
 #include <stan/math/opencl/kernel_generator.hpp>
 #include <stan/math/rev/core.hpp>
 #include <stan/math/rev/fun/value_of.hpp>
@@ -20,42 +21,16 @@ namespace math {
  * @return Elementwise `ldexp()` of the input argument.
  */
 template <typename T_a, typename T_b,
-          require_all_kernel_expressions_and_none_scalar_t<T_a>* = nullptr,
-          require_all_kernel_expressions_t<T_b>* = nullptr>
+          require_all_kernel_expressions_t<T_a, T_b>* = nullptr,
+          require_st_integral<T_b>* = nullptr>
 inline var_value<matrix_cl<double>> ldexp(const var_value<T_a>& a, T_b&& b) {
-  const arena_t<T_b>& b_arena = std::forward<T_b>(b);
+  arena_t<T_b> b_arena = std::forward<T_b>(b);
 
-  var_value<matrix_cl<double>> res = ldexp(a.val(), b);
-
-  reverse_pass_callback([a, b_arena, res]() mutable {
-    a.adj() = a.adj() + ldexp(res.adj(), value_of(b_arena));
-  });
-
-  return res;
-}
-
-/**
- * Returns the elementwise `ldexp()` of the input
- * `var_value<double>` and kernel generator expression.
- *
- * @param a input rev kernel generator expression representing
- * significands
- * @param b input kernel generator expression representing
- * the integer exponents.
- * @return Elementwise `ldexp()` of the input argument.
- */
-template <typename T_b,
-          require_all_kernel_expressions_and_none_scalar_t<T_b>* = nullptr>
-inline var_value<matrix_cl<double>> ldexp(const var_value<double>& a, T_b&& b) {
-  const arena_t<T_b>& b_arena = std::forward<T_b>(b);
-
-  var_value<matrix_cl<double>> res = ldexp(a.val(), b);
-
-  reverse_pass_callback([a, b_arena, res]() mutable {
-    a.adj() = a.adj() + sum(ldexp(res.adj(), value_of(b_arena)));
-  });
-
-  return res;
+  return make_callback_var(
+      ldexp(a.val(), b),
+      [a, b_arena](vari_value<matrix_cl<double>>& res) mutable {
+        adjoint_results(a) += expressions(ldexp(res.adj(), b_arena));
+      });
 }
 
 }  // namespace math

--- a/stan/math/opencl/rev/lgamma.hpp
+++ b/stan/math/opencl/rev/lgamma.hpp
@@ -20,7 +20,7 @@ template <typename T,
 inline var_value<matrix_cl<double>> lgamma(const var_value<T>& A) {
   return make_callback_var(
       lgamma(A.val()), [A](vari_value<matrix_cl<double>>& res) mutable {
-        A.adj() = A.adj() + elt_multiply(res.adj(), digamma(A.val()));
+        A.adj() += elt_multiply(res.adj(), digamma(A.val()));
       });
 }
 

--- a/stan/math/opencl/rev/log.hpp
+++ b/stan/math/opencl/rev/log.hpp
@@ -20,7 +20,7 @@ template <typename T,
 inline var_value<matrix_cl<double>> log(const var_value<T>& A) {
   return make_callback_var(log(A.val()),
                            [A](vari_value<matrix_cl<double>>& res) mutable {
-                             A.adj() = A.adj() + elt_divide(res.adj(), A.val());
+                             A.adj() += elt_divide(res.adj(), A.val());
                            });
 }
 

--- a/stan/math/opencl/rev/log10.hpp
+++ b/stan/math/opencl/rev/log10.hpp
@@ -20,7 +20,7 @@ template <typename T,
 inline var_value<matrix_cl<double>> log10(const var_value<T>& A) {
   return make_callback_var(
       log10(A.val()), [A](vari_value<matrix_cl<double>>& res) mutable {
-        A.adj() = A.adj() + elt_divide(res.adj(), A.val() * LOG_TEN);
+        A.adj() += elt_divide(res.adj(), A.val() * LOG_TEN);
       });
 }
 

--- a/stan/math/opencl/rev/log1m.hpp
+++ b/stan/math/opencl/rev/log1m.hpp
@@ -18,10 +18,10 @@ namespace math {
 template <typename T,
           require_all_kernel_expressions_and_none_scalar_t<T>* = nullptr>
 inline var_value<matrix_cl<double>> log1m(const var_value<T>& A) {
-  return make_callback_var(
-      log1m(A.val()), [A](vari_value<matrix_cl<double>>& res) mutable {
-        A.adj() += elt_divide(res.adj(), A.val() - 1.0);
-      });
+  return make_callback_var(log1m(A.val()),
+                           [A](vari_value<matrix_cl<double>>& res) mutable {
+                             A.adj() += elt_divide(res.adj(), A.val() - 1.0);
+                           });
 }
 
 }  // namespace math

--- a/stan/math/opencl/rev/log1m.hpp
+++ b/stan/math/opencl/rev/log1m.hpp
@@ -20,7 +20,7 @@ template <typename T,
 inline var_value<matrix_cl<double>> log1m(const var_value<T>& A) {
   return make_callback_var(
       log1m(A.val()), [A](vari_value<matrix_cl<double>>& res) mutable {
-        A.adj() = A.adj() + elt_divide(res.adj(), A.val() - 1.0);
+        A.adj() += elt_divide(res.adj(), A.val() - 1.0);
       });
 }
 

--- a/stan/math/opencl/rev/log1m_exp.hpp
+++ b/stan/math/opencl/rev/log1m_exp.hpp
@@ -18,10 +18,10 @@ namespace math {
 template <typename T,
           require_all_kernel_expressions_and_none_scalar_t<T>* = nullptr>
 inline var_value<matrix_cl<double>> log1m_exp(const var_value<T>& A) {
-  return make_callback_var(
-      log1m_exp(A.val()), [A](vari_value<matrix_cl<double>>& res) mutable {
-        A.adj() -= elt_divide(res.adj(), expm1(-A.val()));
-      });
+  return make_callback_var(log1m_exp(A.val()),
+                           [A](vari_value<matrix_cl<double>>& res) mutable {
+                             A.adj() -= elt_divide(res.adj(), expm1(-A.val()));
+                           });
 }
 
 }  // namespace math

--- a/stan/math/opencl/rev/log1m_exp.hpp
+++ b/stan/math/opencl/rev/log1m_exp.hpp
@@ -20,7 +20,7 @@ template <typename T,
 inline var_value<matrix_cl<double>> log1m_exp(const var_value<T>& A) {
   return make_callback_var(
       log1m_exp(A.val()), [A](vari_value<matrix_cl<double>>& res) mutable {
-        A.adj() = A.adj() - elt_divide(res.adj(), expm1(-A.val()));
+        A.adj() -= elt_divide(res.adj(), expm1(-A.val()));
       });
 }
 

--- a/stan/math/opencl/rev/log1m_inv_logit.hpp
+++ b/stan/math/opencl/rev/log1m_inv_logit.hpp
@@ -21,7 +21,7 @@ template <typename T,
 inline var_value<matrix_cl<double>> log1m_inv_logit(const var_value<T>& A) {
   return make_callback_var(log1m_inv_logit(A.val()),
                            [A](vari_value<matrix_cl<double>>& res) mutable {
-                             A.adj() = A.adj() - inv_logit(A.val());
+                             A.adj() -= inv_logit(A.val());
                            });
 }
 

--- a/stan/math/opencl/rev/log1p.hpp
+++ b/stan/math/opencl/rev/log1p.hpp
@@ -18,10 +18,10 @@ namespace math {
 template <typename T,
           require_all_kernel_expressions_and_none_scalar_t<T>* = nullptr>
 inline var_value<matrix_cl<double>> log1p(const var_value<T>& A) {
-  return make_callback_var(
-      log1p(A.val()), [A](vari_value<matrix_cl<double>>& res) mutable {
-        A.adj() += elt_divide(res.adj(), 1.0 + A.val());
-      });
+  return make_callback_var(log1p(A.val()),
+                           [A](vari_value<matrix_cl<double>>& res) mutable {
+                             A.adj() += elt_divide(res.adj(), 1.0 + A.val());
+                           });
 }
 
 }  // namespace math

--- a/stan/math/opencl/rev/log1p.hpp
+++ b/stan/math/opencl/rev/log1p.hpp
@@ -20,7 +20,7 @@ template <typename T,
 inline var_value<matrix_cl<double>> log1p(const var_value<T>& A) {
   return make_callback_var(
       log1p(A.val()), [A](vari_value<matrix_cl<double>>& res) mutable {
-        A.adj() = A.adj() + elt_divide(res.adj(), 1.0 + A.val());
+        A.adj() += elt_divide(res.adj(), 1.0 + A.val());
       });
 }
 

--- a/stan/math/opencl/rev/log1p_exp.hpp
+++ b/stan/math/opencl/rev/log1p_exp.hpp
@@ -20,7 +20,7 @@ template <typename T,
 inline var_value<matrix_cl<double>> log1p_exp(const var_value<T>& A) {
   return make_callback_var(
       log1p_exp(A.val()), [A](vari_value<matrix_cl<double>>& res) mutable {
-        A.adj() = A.adj() + elt_multiply(res.adj(), inv_logit(A.val()));
+        A.adj() += elt_multiply(res.adj(), inv_logit(A.val()));
       });
 }
 

--- a/stan/math/opencl/rev/log2.hpp
+++ b/stan/math/opencl/rev/log2.hpp
@@ -20,7 +20,7 @@ template <typename T,
 inline var_value<matrix_cl<double>> log2(const var_value<T>& A) {
   return make_callback_var(
       log2(A.val()), [A](vari_value<matrix_cl<double>>& res) mutable {
-        A.adj() = A.adj() + elt_divide(res.adj(), A.val() * LOG_TWO);
+        A.adj() += elt_divide(res.adj(), A.val() * LOG_TWO);
       });
 }
 

--- a/stan/math/opencl/rev/log_diff_exp.hpp
+++ b/stan/math/opencl/rev/log_diff_exp.hpp
@@ -2,7 +2,7 @@
 #define STAN_MATH_OPENCL_REV_LOG_DIFF_EXP_HPP
 #ifdef STAN_OPENCL
 
-#include <stan/math/prim/meta/is_kernel_expression.hpp>
+#include <stan/math/opencl/rev/adjoint_results.hpp>
 #include <stan/math/opencl/matrix_cl.hpp>
 #include <stan/math/opencl/kernel_generator.hpp>
 #include <stan/math/opencl/prim/sum.hpp>
@@ -11,6 +11,7 @@
 #include <stan/math/rev/fun/value_of.hpp>
 #include <stan/math/rev/core/reverse_pass_callback.hpp>
 #include <stan/math/prim/fun/value_of.hpp>
+#include <stan/math/prim/meta/is_kernel_expression.hpp>
 
 namespace stan {
 namespace math {
@@ -28,120 +29,25 @@ namespace math {
  * of the natural exponentiation of x and
  * the natural exponentiation of y.
  */
-template <
-    typename T_x, typename T_y,
-    require_all_nonscalar_prim_or_rev_kernel_expression_t<T_x, T_y>* = nullptr,
-    require_any_var_t<T_x, T_y>* = nullptr>
+template <typename T_x, typename T_y,
+          require_all_prim_or_rev_kernel_expression_t<T_x, T_y>* = nullptr,
+          require_any_var_t<T_x, T_y>* = nullptr,
+          require_any_not_stan_scalar_t<T_x, T_y>* = nullptr>
 inline var_value<matrix_cl<double>> log_diff_exp(T_x&& x, T_y&& y) {
   arena_t<T_x> x_arena = std::forward<T_x>(x);
   arena_t<T_y> y_arena = std::forward<T_y>(y);
 
-  matrix_cl<double> res_val
-      = log_diff_exp(value_of(x_arena), value_of(y_arena));
-
   return make_callback_var(
-      res_val,
+      log_diff_exp(value_of(x_arena), value_of(y_arena)),
       [x_arena, y_arena](const vari_value<matrix_cl<double>>& res) mutable {
-        if (!is_constant<T_x>::value && !is_constant<T_y>::value) {
-          auto x_deriv = -elt_divide(
-              res.adj(), expm1(value_of(y_arena) - value_of(x_arena)));
-          auto y_deriv = -elt_divide(
-              res.adj(), expm1(value_of(x_arena) - value_of(y_arena)));
-
-          results(adjoint_of(x_arena), adjoint_of(y_arena))
-              += expressions(calc_if<is_var<T_x>::value>(x_deriv),
-                             calc_if<is_var<T_y>::value>(y_deriv));
-        } else if (!is_constant<T_x>::value) {
-          auto& x_adj = forward_as<var_value<matrix_cl<double>>>(x_arena).adj();
-          x_adj = x_adj
-                  + select(res.val() == NEGATIVE_INFTY,
-                           select(value_of(y_arena) == NEGATIVE_INFTY,
-                                  res.adj(), INFTY * res.adj()),
-                           -elt_divide(res.adj(), expm1(value_of(y_arena)
-                                                        - value_of(x_arena))));
-        } else {
-          auto& y_adj = forward_as<var_value<matrix_cl<double>>>(y_arena).adj();
-          y_adj = y_adj
-                  + select(res.val() == NEGATIVE_INFTY, -(res.adj() * INFTY),
-                           -elt_divide(res.adj(), expm1(value_of(y_arena)
-                                                        - value_of(x_arena))));
-        }
+        adjoint_results(x_arena, y_arena) += expressions(
+            -elt_divide(res.adj(),
+                        expm1(value_of(y_arena) - value_of(x_arena))),
+            -elt_divide(res.adj(),
+                        expm1(value_of(x_arena) - value_of(y_arena))));
       });
 }
 
-/**
- * Returns  the natural logarithm of the difference
- * of the natural exponentiation of x and
- * the natural exponentiation of y.
- *
- * @tparam T_x type of kernel generator expression for x
- * @tparam T_y type of scalar y argument
- * @param x kernel generator expression
- * @param y scalar
- * @return Result the natural logarithm of the difference
- * of the natural exponentiation of x and
- * the natural exponentiation of y.
- */
-template <typename T_x, typename T_y,
-          require_nonscalar_prim_or_rev_kernel_expression_t<T_x>* = nullptr,
-          require_stan_scalar_t<T_y>* = nullptr,
-          require_any_var_t<T_x, T_y>* = nullptr>
-inline var_value<matrix_cl<double>> log_diff_exp(T_x&& x, const T_y& y) {
-  arena_t<T_x> x_arena = std::forward<T_x>(x);
-
-  matrix_cl<double> res_val = log_diff_exp(value_of(x_arena), value_of(y));
-
-  return make_callback_var(
-      res_val, [x_arena, y](const vari_value<matrix_cl<double>>& res) mutable {
-        if (!is_constant<T_x>::value) {
-          auto& x_adj = forward_as<var_value<matrix_cl<double>>>(x_arena).adj();
-          x_adj
-              = x_adj
-                - elt_divide(res.adj(), expm1(value_of(y) - value_of(x_arena)));
-        }
-        if (!is_constant<T_y>::value) {
-          adjoint_of(y) -= sum(
-              elt_divide(res.adj(), expm1(value_of(x_arena) - value_of(y))));
-        }
-      });
-}
-
-/**
- * Returns the natural logarithm of the difference
- * of the natural exponentiation of x and
- * the natural exponentiation of y.
- *
- * @tparam T_x type of scalar x argument
- * @tparam T_y type of kernel generator expression for y
- * @param x kernel generator expression
- * @param y scalar
- * @return Result the natural logarithm of the difference
- * of the natural exponentiation of x and
- * the natural exponentiation of y.
- */
-template <typename T_x, typename T_y,
-          require_nonscalar_prim_or_rev_kernel_expression_t<T_y>* = nullptr,
-          require_stan_scalar_t<T_x>* = nullptr,
-          require_any_var_t<T_x, T_y>* = nullptr>
-inline var_value<matrix_cl<double>> log_diff_exp(const T_x& x, T_y&& y) {
-  arena_t<T_y> y_arena = std::forward<T_y>(y);
-
-  matrix_cl<double> res_val = log_diff_exp(value_of(x), value_of(y_arena));
-
-  return make_callback_var(
-      res_val, [x, y_arena](const vari_value<matrix_cl<double>>& res) mutable {
-        if (!is_constant<T_x>::value) {
-          adjoint_of(x) -= sum(
-              elt_divide(res.adj(), expm1(value_of(y_arena) - value_of(x))));
-        }
-        if (!is_constant<T_y>::value) {
-          auto& y_adj = forward_as<var_value<matrix_cl<double>>>(y_arena).adj();
-          y_adj
-              = y_adj
-                - elt_divide(res.adj(), expm1(value_of(x) - value_of(y_arena)));
-        }
-      });
-}
 }  // namespace math
 }  // namespace stan
 

--- a/stan/math/opencl/rev/log_inv_logit.hpp
+++ b/stan/math/opencl/rev/log_inv_logit.hpp
@@ -20,7 +20,7 @@ template <typename T,
 inline var_value<matrix_cl<double>> log_inv_logit(const var_value<T>& A) {
   return make_callback_var(log_inv_logit(A.val()),
                            [A](vari_value<matrix_cl<double>>& res) mutable {
-                             A.adj() = A.adj() + inv_logit(-A.val());
+                             A.adj() += inv_logit(-A.val());
                            });
 }
 

--- a/stan/math/opencl/rev/log_inv_logit_diff.hpp
+++ b/stan/math/opencl/rev/log_inv_logit_diff.hpp
@@ -2,7 +2,7 @@
 #define STAN_MATH_OPENCL_REV_LOG_INV_LOGIT_DIFF_HPP
 #ifdef STAN_OPENCL
 
-#include <stan/math/prim/meta/is_kernel_expression.hpp>
+#include <stan/math/opencl/rev/adjoint_results.hpp>
 #include <stan/math/opencl/matrix_cl.hpp>
 #include <stan/math/opencl/kernel_generator.hpp>
 #include <stan/math/opencl/prim/sum.hpp>
@@ -12,6 +12,7 @@
 #include <stan/math/rev/core/reverse_pass_callback.hpp>
 #include <stan/math/prim/fun/value_of.hpp>
 #include <stan/math/prim/fun/inv_logit.hpp>
+#include <stan/math/prim/meta/is_kernel_expression.hpp>
 
 namespace stan {
 namespace math {
@@ -28,102 +29,23 @@ namespace math {
  */
 template <
     typename T_x, typename T_y,
-    require_all_nonscalar_prim_or_rev_kernel_expression_t<T_x, T_y>* = nullptr,
-    require_any_var_t<T_x, T_y>* = nullptr>
+    require_all_prim_or_rev_kernel_expression_t<T_x, T_y>* = nullptr,
+    require_any_var_t<T_x, T_y>* = nullptr,
+    require_any_not_stan_scalar_t<T_x, T_y>* = nullptr>
 inline var_value<matrix_cl<double>> log_inv_logit_diff(T_x&& x, T_y&& y) {
-  const arena_t<T_x>& x_arena = std::forward<T_x>(x);
-  const arena_t<T_y>& y_arena = std::forward<T_y>(y);
-
-  matrix_cl<double> res_val
-      = log_inv_logit_diff(value_of(x_arena), value_of(y_arena));
+  arena_t<T_x> x_arena = std::forward<T_x>(x);
+  arena_t<T_y> y_arena = std::forward<T_y>(y);
 
   return make_callback_var(
-      res_val,
+      log_inv_logit_diff(value_of(x_arena), value_of(y_arena)),
       [x_arena, y_arena](const vari_value<matrix_cl<double>>& res) mutable {
-        auto x_deriv = -elt_multiply(
-            res.adj(), inv(expm1(value_of(y_arena) - value_of(x_arena)))
-                           + inv_logit(value_of(x_arena)));
-        auto y_deriv = -elt_multiply(
-            res.adj(), inv(expm1(value_of(x_arena) - value_of(y_arena)))
-                           + inv_logit(value_of(y_arena)));
-
-        results(adjoint_of(x_arena), adjoint_of(y_arena))
-            += expressions(calc_if<is_var<T_x>::value>(x_deriv),
-                           calc_if<is_var<T_y>::value>(y_deriv));
-      });
-}
-
-/**
- * Returns the natural logarithm of the difference of the
- * inverse logits of the specified arguments.
- *
- * @tparam T_x type of kernel generator expression for x
- * @tparam T_y type of scalar y argument
- * @param x kernel generator expression
- * @param y scalar
- * @return Result of log difference of inverse logits of arguments.
- */
-template <typename T_x, typename T_y,
-          require_nonscalar_prim_or_rev_kernel_expression_t<T_x>* = nullptr,
-          require_stan_scalar_t<T_y>* = nullptr,
-          require_any_var_t<T_x, T_y>* = nullptr>
-inline var_value<matrix_cl<double>> log_inv_logit_diff(T_x&& x, const T_y& y) {
-  const arena_t<T_x>& x_arena = std::forward<T_x>(x);
-
-  matrix_cl<double> res_val
-      = log_inv_logit_diff(value_of(x_arena), value_of(y));
-
-  return make_callback_var(
-      res_val, [x_arena, y](const vari_value<matrix_cl<double>>& res) mutable {
-        if (!is_constant<T_x>::value) {
-          auto& x_adj = forward_as<var_value<matrix_cl<double>>>(x_arena).adj();
-          x_adj = x_adj
-                  - elt_multiply(res.adj(),
-                                 inv(expm1(value_of(y) - value_of(x_arena)))
-                                     + inv_logit(value_of(x_arena)));
-        }
-        if (!is_constant<T_y>::value) {
-          adjoint_of(y) -= sum(elt_multiply(
-              res.adj(), inv(expm1(value_of(x_arena) - value_of(y)))
-                             + inv_logit(value_of(y))));
-        }
-      });
-}
-
-/**
- * Returns the natural logarithm of the difference of the
- * inverse logits of the specified arguments.
- *
- * @tparam T_x type of scalar x argument
- * @tparam T_y type of kernel generator expression for y
- * @param x kernel generator expression
- * @param y scalar
- * @return Result of log difference of inverse logits of arguments.
- */
-template <typename T_x, typename T_y,
-          require_nonscalar_prim_or_rev_kernel_expression_t<T_y>* = nullptr,
-          require_stan_scalar_t<T_x>* = nullptr,
-          require_any_var_t<T_x, T_y>* = nullptr>
-inline var_value<matrix_cl<double>> log_inv_logit_diff(const T_x& x, T_y&& y) {
-  const arena_t<T_y>& y_arena = std::forward<T_y>(y);
-
-  matrix_cl<double> res_val
-      = log_inv_logit_diff(value_of(x), value_of(y_arena));
-
-  return make_callback_var(
-      res_val, [x, y_arena](const vari_value<matrix_cl<double>>& res) mutable {
-        if (!is_constant<T_x>::value) {
-          adjoint_of(x) -= sum(elt_multiply(
-              res.adj(), inv(expm1(value_of(y_arena) - value_of(x)))
-                             + inv_logit(value_of(x))));
-        }
-        if (!is_constant<T_y>::value) {
-          auto& y_adj = forward_as<var_value<matrix_cl<double>>>(y_arena).adj();
-          y_adj = y_adj
-                  - elt_multiply(res.adj(),
-                                 inv(expm1(value_of(x) - value_of(y_arena)))
-                                     + inv_logit(value_of(y_arena)));
-        }
+        adjoint_results(x_arena, y_arena) += expressions(
+            -elt_multiply(res.adj(),
+                          inv(expm1(value_of(y_arena) - value_of(x_arena)))
+                              + inv_logit(value_of(x_arena))),
+            -elt_multiply(res.adj(),
+                          inv(expm1(value_of(x_arena) - value_of(y_arena)))
+                              + inv_logit(value_of(y_arena))));
       });
 }
 

--- a/stan/math/opencl/rev/log_inv_logit_diff.hpp
+++ b/stan/math/opencl/rev/log_inv_logit_diff.hpp
@@ -27,11 +27,10 @@ namespace math {
  * @param y second argument
  * @return Result of log difference of inverse logits of arguments.
  */
-template <
-    typename T_x, typename T_y,
-    require_all_prim_or_rev_kernel_expression_t<T_x, T_y>* = nullptr,
-    require_any_var_t<T_x, T_y>* = nullptr,
-    require_any_not_stan_scalar_t<T_x, T_y>* = nullptr>
+template <typename T_x, typename T_y,
+          require_all_prim_or_rev_kernel_expression_t<T_x, T_y>* = nullptr,
+          require_any_var_t<T_x, T_y>* = nullptr,
+          require_any_not_stan_scalar_t<T_x, T_y>* = nullptr>
 inline var_value<matrix_cl<double>> log_inv_logit_diff(T_x&& x, T_y&& y) {
   arena_t<T_x> x_arena = std::forward<T_x>(x);
   arena_t<T_y> y_arena = std::forward<T_y>(y);

--- a/stan/math/opencl/rev/logit.hpp
+++ b/stan/math/opencl/rev/logit.hpp
@@ -20,7 +20,7 @@ template <typename T,
 inline var_value<matrix_cl<double>> logit(const var_value<T>& A) {
   return make_callback_var(
       logit(A.val()), [A](vari_value<matrix_cl<double>>& res) mutable {
-        A.adj() = A.adj() + elt_divide(res.adj(), A.val() * LOG_TEN);
+        A.adj() += elt_divide(res.adj(), A.val() * LOG_TEN);
       });
 }
 

--- a/stan/math/opencl/rev/mdivide_left_tri_low.hpp
+++ b/stan/math/opencl/rev/mdivide_left_tri_low.hpp
@@ -62,7 +62,8 @@ inline var_value<matrix_cl<double>> mdivide_left_tri_low(T1&& A, T2&& b) {
  */
 template <typename T,
           require_all_kernel_expressions_and_none_scalar_t<T>* = nullptr>
-inline var_value<matrix_cl<double>> mdivide_left_tri_low(const var_value<T>& A) {
+inline var_value<matrix_cl<double>> mdivide_left_tri_low(
+    const var_value<T>& A) {
   check_square("mdivide_left_tri_low", "A", A);
   if (A.size() == 0) {
     return A;

--- a/stan/math/opencl/rev/mdivide_left_tri_low.hpp
+++ b/stan/math/opencl/rev/mdivide_left_tri_low.hpp
@@ -60,23 +60,21 @@ inline var_value<matrix_cl<double>> mdivide_left_tri_low(T1&& A, T2&& b) {
  * @return x = A^-1 .
  * @throws std::domain_error if A is not square
  */
-template <typename T1,
-          require_all_nonscalar_prim_or_rev_kernel_expression_t<T1>* = nullptr,
-          require_any_var_t<T1>* = nullptr>
-inline var_value<matrix_cl<double>> mdivide_left_tri_low(T1&& A) {
+template <typename T,
+          require_all_kernel_expressions_and_none_scalar_t<T>* = nullptr>
+inline var_value<matrix_cl<double>> mdivide_left_tri_low(const var_value<T>& A) {
   check_square("mdivide_left_tri_low", "A", A);
   if (A.size() == 0) {
     return A;
   }
-  arena_t<T1> A_arena = std::forward<T1>(A);
   return make_callback_var(
-      mdivide_left_tri_low(value_of(A_arena)),
-      [A_arena](const vari_value<matrix_cl<double>>& res) {
+      mdivide_left_tri_low(value_of(A)),
+      [A](const vari_value<matrix_cl<double>>& res) {
         matrix_cl<double> res_val_transpose = transpose(res.val());
         matrix_cl<double> adjA
             = res_val_transpose * res.adj() * res_val_transpose;
         adjA.view(matrix_cl_view::Lower);
-        adjoint_of(A_arena) -= adjA;
+        adjoint_of(A) -= adjA;
       });
 }
 

--- a/stan/math/opencl/rev/multiply_log.hpp
+++ b/stan/math/opencl/rev/multiply_log.hpp
@@ -2,6 +2,7 @@
 #define STAN_MATH_OPENCL_REV_MULTIPLY_LOG_HPP
 #ifdef STAN_OPENCL
 
+#include <stan/math/opencl/rev/adjoint_results.hpp>
 #include <stan/math/opencl/kernel_generator.hpp>
 #include <stan/math/rev/core.hpp>
 #include <stan/math/rev/fun/adjoint_of.hpp>
@@ -20,90 +21,21 @@ namespace math {
  *
  * @return Elementwise `multiply_log()` of the input.
  */
-template <
-    typename T_a, typename T_b,
-    require_all_nonscalar_prim_or_rev_kernel_expression_t<T_a, T_b>* = nullptr,
-    require_any_var_t<T_a, T_b>* = nullptr>
+template <typename T_a, typename T_b,
+          require_all_prim_or_rev_kernel_expression_t<T_a, T_b>* = nullptr,
+          require_any_var_t<T_a, T_b>* = nullptr,
+          require_any_not_stan_scalar_t<T_a, T_b>* = nullptr>
 inline var_value<matrix_cl<double>> multiply_log(T_a&& a, T_b&& b) {
-  const arena_t<T_a>& a_arena = std::forward<T_a>(a);
-  const arena_t<T_b>& b_arena = std::forward<T_b>(b);
-
-  matrix_cl<double> res_val
-      = multiply_log(value_of(a_arena), value_of(b_arena));
+  arena_t<T_a> a_arena = std::forward<T_a>(a);
+  arena_t<T_b> b_arena = std::forward<T_b>(b);
 
   return make_callback_var(
-      res_val,
+      multiply_log(value_of(a_arena), value_of(b_arena)),
       [a_arena, b_arena](const vari_value<matrix_cl<double>>& res) mutable {
-        auto a_deriv = elt_multiply(res.adj(), log(value_of(b_arena)));
-        auto b_deriv = elt_multiply(
-            res.adj(), elt_divide(value_of(a_arena), value_of(b_arena)));
-        results(adjoint_of(a_arena), adjoint_of(b_arena))
-            += expressions(calc_if<is_var<T_a>::value>(a_deriv),
-                           calc_if<is_var<T_b>::value>(b_deriv));
-      });
-}
-
-/**
- * Returns the elementwise `multiply_log()` of the input.
- *
- * @tparam T_a type of first expression
- * @tparam T_b type of second expression
- * @param a first expression
- * @param b second expression
- *
- * @return Elementwise `multiply_log()` of the input.
- */
-template <typename T_a, typename T_b,
-          require_nonscalar_prim_or_rev_kernel_expression_t<T_a>* = nullptr,
-          require_stan_scalar_t<T_b>* = nullptr,
-          require_any_var_t<T_a, T_b>* = nullptr>
-inline var_value<matrix_cl<double>> multiply_log(T_a&& a, const T_b& b) {
-  const arena_t<T_a>& a_arena = std::forward<T_a>(a);
-
-  matrix_cl<double> res_val = multiply_log(value_of(a_arena), value_of(b));
-
-  return make_callback_var(
-      res_val, [a_arena, b](const vari_value<matrix_cl<double>>& res) mutable {
-        if (!is_constant<T_a>::value) {
-          auto& a_adj = forward_as<var_value<matrix_cl<double>>>(a_arena).adj();
-          a_adj = a_adj + elt_multiply(res.adj(), log(value_of(b)));
-        }
-        if (!is_constant<T_b>::value) {
-          adjoint_of(b) += sum(elt_multiply(
-              res.adj(), elt_divide(value_of(a_arena), value_of(b))));
-        }
-      });
-}
-/**
- * Returns the elementwise `multiply_log()` of the input.
- *
- * @tparam T_a type of first expression
- * @tparam T_b type of second expression
- * @param a first expression
- * @param b second expression
- *
- * @return Elementwise `multiply_log()` of the input.
- */
-template <typename T_a, typename T_b,
-          require_nonscalar_prim_or_rev_kernel_expression_t<T_b>* = nullptr,
-          require_stan_scalar_t<T_a>* = nullptr,
-          require_any_var_t<T_a, T_b>* = nullptr>
-inline var_value<matrix_cl<double>> multiply_log(const T_a& a, T_b&& b) {
-  const arena_t<T_b>& b_arena = std::forward<T_b>(b);
-
-  matrix_cl<double> res_val = multiply_log(value_of(a), value_of(b_arena));
-
-  return make_callback_var(
-      res_val, [a, b_arena](const vari_value<matrix_cl<double>>& res) mutable {
-        if (!is_constant<T_a>::value) {
-          adjoint_of(a) += sum(elt_multiply(res.adj(), log(value_of(b_arena))));
-        }
-        if (!is_constant<T_b>::value) {
-          auto& b_adj = forward_as<var_value<matrix_cl<double>>>(b_arena).adj();
-          b_adj = b_adj
-                  + elt_multiply(res.adj(),
-                                 elt_divide(value_of(a), value_of(b_arena)));
-        }
+        adjoint_results(a_arena, b_arena) += expressions(
+            elt_multiply(res.adj(), log(value_of(b_arena))),
+            elt_multiply(res.adj(),
+                         elt_divide(value_of(a_arena), value_of(b_arena))));
       });
 }
 

--- a/stan/math/opencl/rev/operator_unary_minus.hpp
+++ b/stan/math/opencl/rev/operator_unary_minus.hpp
@@ -19,7 +19,7 @@ template <typename T,
 inline var_value<matrix_cl<double>> operator-(const var_value<T>& M) {
   return make_callback_var(-M.val(),
                            [M](vari_value<matrix_cl<double>>& res) mutable {
-                             M.adj() = M.adj() - res.adj();
+                             M.adj() -= res.adj();
                            });
 }
 

--- a/stan/math/opencl/rev/pow.hpp
+++ b/stan/math/opencl/rev/pow.hpp
@@ -26,11 +26,10 @@ namespace math {
  * @param b second expression of exponent
  * @return base raised to the power of the exponent
  */
-template <
-    typename T_a, typename T_b,
-    require_all_prim_or_rev_kernel_expression_t<T_a, T_b>* = nullptr,
-    require_any_var_t<T_a, T_b>* = nullptr,
-    require_any_not_stan_scalar_t<T_a, T_b>* = nullptr>
+template <typename T_a, typename T_b,
+          require_all_prim_or_rev_kernel_expression_t<T_a, T_b>* = nullptr,
+          require_any_var_t<T_a, T_b>* = nullptr,
+          require_any_not_stan_scalar_t<T_a, T_b>* = nullptr>
 inline var_value<matrix_cl<double>> pow(T_a&& a, T_b&& b) {
   const arena_t<T_a>& a_arena = std::forward<T_a>(a);
   const arena_t<T_b>& b_arena = std::forward<T_b>(b);

--- a/stan/math/opencl/rev/pow.hpp
+++ b/stan/math/opencl/rev/pow.hpp
@@ -2,7 +2,7 @@
 #define STAN_MATH_OPENCL_REV_POW_HPP
 #ifdef STAN_OPENCL
 
-#include <stan/math/prim/meta/is_kernel_expression.hpp>
+#include <stan/math/opencl/rev/adjoint_results.hpp>
 #include <stan/math/opencl/matrix_cl.hpp>
 #include <stan/math/opencl/kernel_generator.hpp>
 #include <stan/math/opencl/prim/sum.hpp>
@@ -11,6 +11,7 @@
 #include <stan/math/rev/fun/value_of.hpp>
 #include <stan/math/rev/core/reverse_pass_callback.hpp>
 #include <stan/math/prim/fun/value_of.hpp>
+#include <stan/math/prim/meta/is_kernel_expression.hpp>
 
 namespace stan {
 namespace math {
@@ -27,8 +28,9 @@ namespace math {
  */
 template <
     typename T_a, typename T_b,
-    require_all_nonscalar_prim_or_rev_kernel_expression_t<T_a, T_b>* = nullptr,
-    require_any_var_t<T_a, T_b>* = nullptr>
+    require_all_prim_or_rev_kernel_expression_t<T_a, T_b>* = nullptr,
+    require_any_var_t<T_a, T_b>* = nullptr,
+    require_any_not_stan_scalar_t<T_a, T_b>* = nullptr>
 inline var_value<matrix_cl<double>> pow(T_a&& a, T_b&& b) {
   const arena_t<T_a>& a_arena = std::forward<T_a>(a);
   const arena_t<T_b>& b_arena = std::forward<T_b>(b);
@@ -39,120 +41,20 @@ inline var_value<matrix_cl<double>> pow(T_a&& a, T_b&& b) {
       res_val,
       [a_arena, b_arena](const vari_value<matrix_cl<double>>& res) mutable {
         auto isnan_res = isnan(res.val());
-        auto constant_nan = constant(NOT_A_NUMBER, res.rows(), res.cols());
         auto zero_a_arena = value_of(a_arena) == 0.0;
-        auto zeros = constant(0, res.rows(), res.cols());
+        auto res_adj_times_val = elt_multiply(res.adj(), res.val());
         auto a_deriv = select(
-            isnan_res, constant_nan,
-            select(zero_a_arena, zeros,
-                   elt_multiply(res.adj(),
-                                elt_multiply(value_of(b_arena),
-                                             elt_divide(res.val(),
-                                                        value_of(a_arena))))));
+            isnan_res, NOT_A_NUMBER,
+            select(zero_a_arena, 0.0,
+                   elt_multiply(
+                       res_adj_times_val,
+                       elt_divide(value_of(b_arena), value_of(a_arena)))));
         auto b_deriv = select(
-            isnan_res, constant_nan,
-            select(zero_a_arena, zeros,
-                   elt_multiply(res.adj(), elt_multiply(log(value_of(a_arena)),
-                                                        res.val()))));
+            isnan_res, NOT_A_NUMBER,
+            select(zero_a_arena, 0.0,
+                   elt_multiply(res_adj_times_val, log(value_of(a_arena)))));
 
-        results(adjoint_of(a_arena), adjoint_of(b_arena))
-            += expressions(calc_if<is_var<T_a>::value>(a_deriv),
-                           calc_if<is_var<T_b>::value>(b_deriv));
-      });
-}
-
-/**
- * Return the first argument raised to the power of the second
- * argument.
- *
- * @tparam T_a type of first expression of the base
- * @tparam T_b type of scalar exponent
- * @param a first expression of base
- * @param b scalar exponent
- * @return base raised to the power of the exponent
- */
-template <typename T_a, typename T_b,
-          require_nonscalar_prim_or_rev_kernel_expression_t<T_a>* = nullptr,
-          require_stan_scalar_t<T_b>* = nullptr,
-          require_any_var_t<T_a, T_b>* = nullptr>
-inline var_value<matrix_cl<double>> pow(T_a&& a, const T_b& b) {
-  const arena_t<T_a>& a_arena = std::forward<T_a>(a);
-
-  matrix_cl<double> res_val = pow(value_of(a_arena), value_of(b));
-
-  return make_callback_var(
-      res_val, [a_arena, b](const vari_value<matrix_cl<double>>& res) mutable {
-        auto isnan_res = isnan(res.val());
-        auto constant_nan = constant(NOT_A_NUMBER, res.rows(), res.cols());
-        auto zero_a_arena = value_of(a_arena) == 0.0;
-        auto zeros = constant(0, res.rows(), res.cols());
-        if (!is_constant<T_a>::value) {
-          auto& a_adj = forward_as<var_value<matrix_cl<double>>>(a_arena).adj();
-          a_adj
-              = a_adj
-                + select(
-                      isnan_res, constant_nan,
-                      select(zero_a_arena, zeros,
-                             elt_multiply(
-                                 res.adj(),
-                                 elt_multiply(value_of(b),
-                                              elt_divide(res.val(),
-                                                         value_of(a_arena))))));
-        }
-        if (!is_constant<T_b>::value) {
-          adjoint_of(b) += sum(select(
-              isnan_res, constant_nan,
-              select(
-                  zero_a_arena, zeros,
-                  elt_multiply(res.adj(), elt_multiply(log(value_of(a_arena)),
-                                                       res.val())))));
-        }
-      });
-}
-
-/**
- * Return the first argument raised to the power of the second
- * argument.
- *
- * @tparam T_a type of scalar exponent
- * @tparam T_b type of first expression of the base
- * @param a scalar base
- * @param b first expression of exponent
- * @return base raised to the power of the exponent
- */
-template <typename T_a, typename T_b,
-          require_nonscalar_prim_or_rev_kernel_expression_t<T_b>* = nullptr,
-          require_stan_scalar_t<T_a>* = nullptr,
-          require_any_var_t<T_a, T_b>* = nullptr>
-inline var_value<matrix_cl<double>> pow(const T_a& a, T_b&& b) {
-  const arena_t<T_b>& b_arena = std::forward<T_b>(b);
-
-  matrix_cl<double> res_val = pow(value_of(a), value_of(b_arena));
-
-  return make_callback_var(
-      res_val, [a, b_arena](const vari_value<matrix_cl<double>>& res) mutable {
-        auto isnan_res = isnan(res.val());
-        auto constant_nan = constant(NOT_A_NUMBER, res.rows(), res.cols());
-        auto zero_a_arena = value_of(a) == 0.0;
-        auto zeros = constant(0, res.rows(), res.cols());
-        if (!is_constant<T_a>::value) {
-          adjoint_of(a) += sum(select(
-              isnan_res, constant_nan,
-              select(zero_a_arena, zeros,
-                     elt_multiply(
-                         res.adj(),
-                         elt_multiply(value_of(b_arena),
-                                      elt_divide(res.val(), value_of(a)))))));
-        }
-        if (!is_constant<T_b>::value) {
-          auto& b_adj = forward_as<var_value<matrix_cl<double>>>(b_arena).adj();
-          b_adj = b_adj
-                  + select(isnan_res, constant_nan,
-                           select(zero_a_arena, zeros,
-                                  elt_multiply(res.adj(),
-                                               elt_multiply(log(value_of(a)),
-                                                            res.val()))));
-        }
+        adjoint_results(a_arena, b_arena) += expressions(a_deriv, b_deriv);
       });
 }
 

--- a/stan/math/opencl/rev/round.hpp
+++ b/stan/math/opencl/rev/round.hpp
@@ -22,8 +22,7 @@ template <typename T,
 inline var_value<matrix_cl<double>> round(const var_value<T>& A) {
   return make_callback_var(
       round(A.val()), [A](vari_value<matrix_cl<double>>& res) mutable {
-        A.adj() = select(isnan(A.val()),
-                         constant(NOT_A_NUMBER, A.rows(), A.cols()), A.adj());
+        A.adj() = select(isnan(A.val()), NOT_A_NUMBER, A.adj());
       });
 }
 

--- a/stan/math/opencl/rev/rows_dot_self.hpp
+++ b/stan/math/opencl/rev/rows_dot_self.hpp
@@ -5,7 +5,6 @@
 #include <stan/math/opencl/kernel_generator.hpp>
 #include <stan/math/opencl/prim/rows_dot_self.hpp>
 #include <stan/math/rev/core.hpp>
-#include <stan/math/rev/fun/adjoint_of.hpp>
 #include <stan/math/rev/fun/value_of.hpp>
 #include <stan/math/prim/fun/size_zero.hpp>
 
@@ -19,17 +18,12 @@ namespace math {
  * @param v Matrix.
  */
 template <typename T,
-          require_var_vt<is_kernel_expression_and_not_scalar, T>* = nullptr>
-inline var_value<matrix_cl<double>> rows_dot_self(T&& v) {
-  arena_t<T> v_arena = std::forward<T>(v);
-
-  matrix_cl<double> res_val = rows_dot_self(value_of(v));
-
+          require_all_kernel_expressions_and_none_scalar_t<T>* = nullptr>
+inline var_value<matrix_cl<double>> rows_dot_self(const var_value<T>& v) {
   return make_callback_var(
-      res_val, [v_arena](const vari_value<matrix_cl<double>>& res) mutable {
-        v_arena.adj() = v_arena.adj()
-                        + elt_multiply(rowwise_broadcast(res.adj() * 2),
-                                       value_of(v_arena));
+      rows_dot_self(value_of(v)),
+      [v](const vari_value<matrix_cl<double>>& res) mutable {
+        v.adj() += elt_multiply(rowwise_broadcast(res.adj() * 2), value_of(v));
       });
 }
 

--- a/stan/math/opencl/rev/sin.hpp
+++ b/stan/math/opencl/rev/sin.hpp
@@ -21,7 +21,7 @@ template <typename T,
 inline var_value<matrix_cl<double>> sin(const var_value<T>& A) {
   return make_callback_var(
       sin(A.val()), [A](vari_value<matrix_cl<double>>& res) mutable {
-        A.adj() = A.adj() + elt_multiply(res.adj(), cos(A.val()));
+        A.adj() += elt_multiply(res.adj(), cos(A.val()));
       });
 }
 

--- a/stan/math/opencl/rev/sin.hpp
+++ b/stan/math/opencl/rev/sin.hpp
@@ -19,10 +19,10 @@ namespace math {
 template <typename T,
           require_all_kernel_expressions_and_none_scalar_t<T>* = nullptr>
 inline var_value<matrix_cl<double>> sin(const var_value<T>& A) {
-  return make_callback_var(
-      sin(A.val()), [A](vari_value<matrix_cl<double>>& res) mutable {
-        A.adj() += elt_multiply(res.adj(), cos(A.val()));
-      });
+  return make_callback_var(sin(A.val()),
+                           [A](vari_value<matrix_cl<double>>& res) mutable {
+                             A.adj() += elt_multiply(res.adj(), cos(A.val()));
+                           });
 }
 
 }  // namespace math

--- a/stan/math/opencl/rev/sinh.hpp
+++ b/stan/math/opencl/rev/sinh.hpp
@@ -21,7 +21,7 @@ template <typename T,
 inline var_value<matrix_cl<double>> sinh(const var_value<T>& A) {
   return make_callback_var(
       sinh(A.val()), [A](vari_value<matrix_cl<double>>& res) mutable {
-        A.adj() = A.adj() + elt_multiply(res.adj(), cosh(A.val()));
+        A.adj() += elt_multiply(res.adj(), cosh(A.val()));
       });
 }
 

--- a/stan/math/opencl/rev/sinh.hpp
+++ b/stan/math/opencl/rev/sinh.hpp
@@ -19,10 +19,10 @@ namespace math {
 template <typename T,
           require_all_kernel_expressions_and_none_scalar_t<T>* = nullptr>
 inline var_value<matrix_cl<double>> sinh(const var_value<T>& A) {
-  return make_callback_var(
-      sinh(A.val()), [A](vari_value<matrix_cl<double>>& res) mutable {
-        A.adj() += elt_multiply(res.adj(), cosh(A.val()));
-      });
+  return make_callback_var(sinh(A.val()),
+                           [A](vari_value<matrix_cl<double>>& res) mutable {
+                             A.adj() += elt_multiply(res.adj(), cosh(A.val()));
+                           });
 }
 
 }  // namespace math

--- a/stan/math/opencl/rev/sqrt.hpp
+++ b/stan/math/opencl/rev/sqrt.hpp
@@ -20,7 +20,7 @@ template <typename T,
 inline var_value<matrix_cl<double>> sqrt(const var_value<T>& A) {
   return make_callback_var(
       sqrt(A.val()), [A](vari_value<matrix_cl<double>>& res) mutable {
-        A.adj() = A.adj() + elt_divide(res.adj(), 2.0 * res.val());
+        A.adj() += elt_divide(res.adj(), 2.0 * res.val());
       });
 }
 

--- a/stan/math/opencl/rev/sqrt.hpp
+++ b/stan/math/opencl/rev/sqrt.hpp
@@ -18,10 +18,10 @@ namespace math {
 template <typename T,
           require_all_kernel_expressions_and_none_scalar_t<T>* = nullptr>
 inline var_value<matrix_cl<double>> sqrt(const var_value<T>& A) {
-  return make_callback_var(
-      sqrt(A.val()), [A](vari_value<matrix_cl<double>>& res) mutable {
-        A.adj() += elt_divide(res.adj(), 2.0 * res.val());
-      });
+  return make_callback_var(sqrt(A.val()),
+                           [A](vari_value<matrix_cl<double>>& res) mutable {
+                             A.adj() += elt_divide(res.adj(), 2.0 * res.val());
+                           });
 }
 
 }  // namespace math

--- a/stan/math/opencl/rev/square.hpp
+++ b/stan/math/opencl/rev/square.hpp
@@ -18,10 +18,10 @@ namespace math {
 template <typename T,
           require_all_kernel_expressions_and_none_scalar_t<T>* = nullptr>
 inline var_value<matrix_cl<double>> square(const var_value<T>& A) {
-  return make_callback_var(
-      square(A.val()), [A](vari_value<matrix_cl<double>>& res) mutable {
-        A.adj() += 2.0 * elt_multiply(res.adj(), A.val());
-      });
+  return make_callback_var(square(A.val()),
+                           [A](vari_value<matrix_cl<double>>& res) mutable {
+                             A.adj() += 2.0 * elt_multiply(res.adj(), A.val());
+                           });
 }
 
 }  // namespace math

--- a/stan/math/opencl/rev/square.hpp
+++ b/stan/math/opencl/rev/square.hpp
@@ -20,7 +20,7 @@ template <typename T,
 inline var_value<matrix_cl<double>> square(const var_value<T>& A) {
   return make_callback_var(
       square(A.val()), [A](vari_value<matrix_cl<double>>& res) mutable {
-        A.adj() = A.adj() + 2.0 * elt_multiply(res.adj(), A.val());
+        A.adj() += 2.0 * elt_multiply(res.adj(), A.val());
       });
 }
 

--- a/stan/math/opencl/rev/subtract.hpp
+++ b/stan/math/opencl/rev/subtract.hpp
@@ -24,11 +24,10 @@ namespace math {
  * @param b second expression
  * @return The subtraction of the the second argument from the first
  */
-template <
-    typename T_a, typename T_b,
-    require_all_prim_or_rev_kernel_expression_t<T_a, T_b>* = nullptr,
-    require_any_var_t<T_a, T_b>* = nullptr,
-    require_any_not_stan_scalar_t<T_a, T_b>* = nullptr>
+template <typename T_a, typename T_b,
+          require_all_prim_or_rev_kernel_expression_t<T_a, T_b>* = nullptr,
+          require_any_var_t<T_a, T_b>* = nullptr,
+          require_any_not_stan_scalar_t<T_a, T_b>* = nullptr>
 inline auto subtract(T_a&& a, T_b&& b) {
   arena_t<T_a> a_arena = a;
   arena_t<T_b> b_arena = b;

--- a/stan/math/opencl/rev/subtract.hpp
+++ b/stan/math/opencl/rev/subtract.hpp
@@ -2,7 +2,7 @@
 #define STAN_MATH_OPENCL_REV_SUBTRACT_HPP
 #ifdef STAN_OPENCL
 
-#include <stan/math/prim/meta/is_kernel_expression.hpp>
+#include <stan/math/opencl/rev/adjoint_results.hpp>
 #include <stan/math/opencl/matrix_cl.hpp>
 #include <stan/math/opencl/kernel_generator.hpp>
 #include <stan/math/opencl/prim/sum.hpp>
@@ -10,6 +10,7 @@
 #include <stan/math/rev/fun/value_of.hpp>
 #include <stan/math/rev/core/reverse_pass_callback.hpp>
 #include <stan/math/prim/fun/value_of.hpp>
+#include <stan/math/prim/meta/is_kernel_expression.hpp>
 
 namespace stan {
 namespace math {
@@ -25,33 +26,18 @@ namespace math {
  */
 template <
     typename T_a, typename T_b,
-    require_all_nonscalar_prim_or_rev_kernel_expression_t<T_a, T_b>* = nullptr,
-    require_any_var_t<T_a, T_b>* = nullptr>
-inline auto subtract(const T_a& a, const T_b& b) {
-  check_size_match("subtract (OpenCL)", "A.cols()", a.cols(), "B.cols()",
-                   b.cols());
-  check_size_match("subtract (OpenCL)", "A.rows()", a.rows(), "B.rows()",
-                   b.rows());
-  const arena_t<T_a>& a_arena = a;
-  const arena_t<T_b>& b_arena = b;
+    require_all_prim_or_rev_kernel_expression_t<T_a, T_b>* = nullptr,
+    require_any_var_t<T_a, T_b>* = nullptr,
+    require_any_not_stan_scalar_t<T_a, T_b>* = nullptr>
+inline auto subtract(T_a&& a, T_b&& b) {
+  arena_t<T_a> a_arena = a;
+  arena_t<T_b> b_arena = b;
 
-  var_value<matrix_cl<double>> res = value_of(a_arena) - value_of(b_arena);
-
-  reverse_pass_callback([a_arena, b_arena, res]() mutable {
-    if (!is_constant<T_a>::value && !is_constant<T_b>::value) {
-      auto& a_adj = forward_as<var_value<matrix_cl<double>>>(a_arena).adj();
-      auto& b_adj = forward_as<var_value<matrix_cl<double>>>(b_arena).adj();
-      results(a_adj, b_adj)
-          = expressions((a_adj + res.adj()), (b_adj - res.adj()));
-    } else if (!is_constant<T_a>::value) {
-      auto& a_adj = forward_as<var_value<matrix_cl<double>>>(a_arena).adj();
-      a_adj = a_adj + res.adj();
-    } else {
-      auto& b_adj = forward_as<var_value<matrix_cl<double>>>(b_arena).adj();
-      b_adj = b_adj - res.adj();
-    }
-  });
-  return res;
+  return make_callback_var(
+      value_of(a_arena) - value_of(b_arena),
+      [a_arena, b_arena](vari_value<matrix_cl<double>>& res) mutable {
+        adjoint_results(a_arena, b_arena) += expressions(res.adj(), -res.adj());
+      });
 }
 
 /**
@@ -69,70 +55,6 @@ template <
     require_any_var_t<T_a, T_b>* = nullptr>
 inline auto operator-(const T_a& a, const T_b& b) {
   return subtract(a, b);
-}
-
-/**
- * Subtraction of a kernel generator expression and a scalar.
- *
- * @tparam T1 type of the scalar
- * @tparam T2 type of the matrix or expression
- *
- * @param a scalar
- * @param b matrix
- * @return The subtraction of the the second argument from the first
- */
-template <typename T1, typename T2, require_stan_scalar_t<T1>* = nullptr,
-          require_all_nonscalar_prim_or_rev_kernel_expression_t<T2>* = nullptr,
-          require_any_var_t<T1, T2>* = nullptr>
-inline auto subtract(const T1& a, const T2& b) {
-  const arena_t<T1>& a_arena = a;
-  const arena_t<T2>& b_arena = b;
-
-  var_value<matrix_cl<double>> res = value_of(a_arena) - value_of(b_arena);
-
-  reverse_pass_callback([a_arena, b_arena, res]() mutable {
-    if (!is_constant<T1>::value) {
-      auto& a_adj = forward_as<var_value<double>>(a_arena).adj();
-      a_adj = a_adj + sum(res.adj());
-    }
-    if (!is_constant<T2>::value) {
-      auto& b_adj = forward_as<var_value<matrix_cl<double>>>(b_arena).adj();
-      b_adj = b_adj - res.adj();
-    }
-  });
-  return res;
-}
-
-/**
- * Subtraction of a kernel generator expression and a scalar.
- *
- * @tparam T1 type of the matrix or expression
- * @tparam T2 type of the scalar
- *
- * @param a matrix
- * @param b scalar
- * @return The subtraction of the the second argument from the first
- */
-template <typename T1, typename T2, require_stan_scalar_t<T2>* = nullptr,
-          require_all_nonscalar_prim_or_rev_kernel_expression_t<T1>* = nullptr,
-          require_any_var_t<T1, T2>* = nullptr>
-inline auto subtract(const T1& a, const T2& b) {
-  const arena_t<T1>& a_arena = a;
-  const arena_t<T2>& b_arena = b;
-
-  var_value<matrix_cl<double>> res = value_of(a_arena) - value_of(b_arena);
-
-  reverse_pass_callback([a_arena, b_arena, res]() mutable {
-    if (!is_constant<T1>::value) {
-      auto& a_adj = forward_as<var_value<matrix_cl<double>>>(a_arena).adj();
-      a_adj = a_adj + res.adj();
-    }
-    if (!is_constant<T2>::value) {
-      auto& b_adj = forward_as<var_value<double>>(b_arena).adj();
-      b_adj = b_adj - sum(res.adj());
-    }
-  });
-  return res;
 }
 
 }  // namespace math

--- a/stan/math/opencl/rev/sum.hpp
+++ b/stan/math/opencl/rev/sum.hpp
@@ -21,7 +21,7 @@ template <typename T,
           require_all_kernel_expressions_and_none_scalar_t<T>* = nullptr>
 inline var sum(const var_value<T>& x) {
   return make_callback_var(sum(value_of(x)), [x](vari& res) mutable {
-    x.adj() = x.adj() + res.adj();
+    x.adj() += res.adj();
   });
 }
 

--- a/stan/math/opencl/rev/sum.hpp
+++ b/stan/math/opencl/rev/sum.hpp
@@ -20,9 +20,8 @@ namespace math {
 template <typename T,
           require_all_kernel_expressions_and_none_scalar_t<T>* = nullptr>
 inline var sum(const var_value<T>& x) {
-  return make_callback_var(sum(value_of(x)), [x](vari& res) mutable {
-    x.adj() += res.adj();
-  });
+  return make_callback_var(sum(value_of(x)),
+                           [x](vari& res) mutable { x.adj() += res.adj(); });
 }
 
 }  // namespace math

--- a/stan/math/opencl/rev/tan.hpp
+++ b/stan/math/opencl/rev/tan.hpp
@@ -21,9 +21,7 @@ template <typename T,
 inline var_value<matrix_cl<double>> tan(const var_value<T>& A) {
   return make_callback_var(
       tan(A.val()), [A](vari_value<matrix_cl<double>>& res) mutable {
-        A.adj() = A.adj()
-                  + elt_multiply(res.adj(),
-                                 (1.0 + elt_multiply(res.val(), res.val())));
+        A.adj() += elt_multiply(res.adj(), (1.0 + square(res.val())));
       });
 }
 

--- a/stan/math/opencl/rev/tanh.hpp
+++ b/stan/math/opencl/rev/tanh.hpp
@@ -21,9 +21,7 @@ template <typename T,
 inline var_value<matrix_cl<double>> tanh(const var_value<T>& A) {
   return make_callback_var(
       tanh(A.val()), [A](vari_value<matrix_cl<double>>& res) mutable {
-        auto cosh_A_val = cosh(A.val());
-        A.adj() = A.adj()
-                  + elt_divide(res.adj(), elt_multiply(cosh_A_val, cosh_A_val));
+        A.adj() += elt_divide(res.adj(), square(cosh(A.val())));
       });
 }
 

--- a/stan/math/opencl/rev/tcrossprod.hpp
+++ b/stan/math/opencl/rev/tcrossprod.hpp
@@ -23,7 +23,7 @@ inline var_value<matrix_cl<double>> tcrossprod(const var_value<T>& M) {
   return make_callback_var(
       M.val() * transpose(M.val()),
       [M](vari_value<matrix_cl<double>>& res) mutable {
-        M.adj() = M.adj() + (res.adj() + transpose(res.adj())) * M.val();
+        M.adj() += (res.adj() + transpose(res.adj())) * M.val();
       });
 }
 

--- a/stan/math/opencl/rev/tcrossprod.hpp
+++ b/stan/math/opencl/rev/tcrossprod.hpp
@@ -20,11 +20,11 @@ namespace math {
 template <typename T,
           require_all_kernel_expressions_and_none_scalar_t<T>* = nullptr>
 inline var_value<matrix_cl<double>> tcrossprod(const var_value<T>& M) {
-  return make_callback_var(
-      M.val() * transpose(M.val()),
-      [M](vari_value<matrix_cl<double>>& res) mutable {
-        M.adj() += (res.adj() + transpose(res.adj())) * M.val();
-      });
+  return make_callback_var(M.val() * transpose(M.val()),
+                           [M](vari_value<matrix_cl<double>>& res) mutable {
+                             M.adj() += (res.adj() + transpose(res.adj()))
+                                        * M.val();
+                           });
 }
 
 }  // namespace math

--- a/stan/math/opencl/rev/tgamma.hpp
+++ b/stan/math/opencl/rev/tgamma.hpp
@@ -20,9 +20,8 @@ template <typename T,
 inline var_value<matrix_cl<double>> tgamma(const var_value<T>& A) {
   return make_callback_var(
       tgamma(A.val()), [A](vari_value<matrix_cl<double>>& res) mutable {
-        A.adj() = A.adj()
-                  + elt_multiply(res.adj(),
-                                 elt_multiply(res.val(), digamma(A.val())));
+        A.adj() += elt_multiply(elt_multiply(res.adj(), res.val()),
+                                digamma(A.val()));
       });
 }
 

--- a/stan/math/opencl/rev/trunc.hpp
+++ b/stan/math/opencl/rev/trunc.hpp
@@ -21,8 +21,7 @@ template <typename T,
 inline var_value<matrix_cl<double>> trunc(const var_value<T>& A) {
   return make_callback_var(
       trunc(A.val()), [A](vari_value<matrix_cl<double>>& res) mutable {
-        A.adj() = select(isnan(A.val()),
-                         constant(NOT_A_NUMBER, A.rows(), A.cols()), A.adj());
+        A.adj() = select(isnan(A.val()), NOT_A_NUMBER, A.adj());
       });
 }
 


### PR DESCRIPTION
## Summary

Lately we have added many tools that make rev OpenCL simpler. They were used inconsistently. This PR cleans that up.

It also fixes missing include for square device function.

## Tests
No changes to tests. This is just a refactor.

## Side Effects
None.

## Checklist

- [ ] Math issue #(issue number)

- [ ] Copyright holder: Tadej Ciglarič

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [ ] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [ ] the code is written in idiomatic C++ and changes are documented in the doxygen

- [ ] the new changes are tested
