### PR TITLE
Add some tools to simplify code generation for stanc3

### DIFF
--- a/stan/math/rev/fun/from_var_value.hpp
+++ b/stan/math/rev/fun/from_var_value.hpp
@@ -26,7 +26,7 @@ Eigen::Matrix<var, T::RowsAtCompileTime, T::ColsAtCompileTime> from_var_value(
 }
 
 /**
- * This is a no-op for Eigen containers of vars or scalars or prim types.
+ * This is a no-op for Eigen containers of vars, scalars or prim types.
  *
  * @tparam T type of the input
  * @param a matrix to convert

--- a/stan/math/rev/fun/from_var_value.hpp
+++ b/stan/math/rev/fun/from_var_value.hpp
@@ -26,23 +26,17 @@ Eigen::Matrix<var, T::RowsAtCompileTime, T::ColsAtCompileTime> from_var_value(
 }
 
 /**
- * This is a no-op for Eigen containers of vars.
+ * This is a no-op for Eigen containers of vars or scalars or prim types.
  *
  * @tparam T type of the input
  * @param a matrix to convert
  */
-template <typename T, require_eigen_vt<is_var, T>* = nullptr>
-T from_var_value(T&& a) {
-  return std::forward<T>(a);
-}
-
-/**
- * This is a no-op for scalar vars.
- *
- * @tparam T type of the input
- * @param a matrix to convert
- */
-template <typename T, require_var_vt<std::is_arithmetic, T>* = nullptr>
+template <
+    typename T,
+    require_any_t<
+        conjunction<is_eigen<T>, is_var<scalar_type_t<T>>>,
+        std::is_same<std::decay_t<T>, var>,
+        bool_constant<!std::is_same<scalar_type_t<T>, var>::value>>* = nullptr>
 T from_var_value(T&& a) {
   return std::forward<T>(a);
 }

--- a/stan/math/rev/meta.hpp
+++ b/stan/math/rev/meta.hpp
@@ -3,6 +3,7 @@
 
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/rev/meta/arena_type.hpp>
+#include <stan/math/rev/meta/conditional_var_value.hpp>
 #include <stan/math/rev/meta/is_arena_matrix.hpp>
 #include <stan/math/rev/meta/is_var.hpp>
 #include <stan/math/rev/meta/is_rev_matrix.hpp>

--- a/stan/math/rev/meta/conditional_var_value.hpp
+++ b/stan/math/rev/meta/conditional_var_value.hpp
@@ -1,0 +1,34 @@
+#ifndef STAN_MATH_REV_META_CONDITIONAL_VAR_EIGEN_HPP
+#define STAN_MATH_REV_META_CONDITIONAL_VAR_EIGEN_HPP
+
+#include <stan/math/rev/core/var.hpp>
+#include <stan/math/rev/meta/plain_type.hpp>
+
+namespace stan {
+
+/**
+ * Constructs a prim type or var_value from a scalar and a container.
+ * @tparam T_scalar Determines the scalar (var/double) of the type.
+ * @tparam T_container Determines the container (matrix/vector/matrix_cl ...) of
+ * the type. This must be a prim type.
+ */
+template <typename T_scalar, typename T_container, typename = void>
+struct conditional_var_value {
+  using type = std::conditional_t<is_var<scalar_type_t<T_scalar>>::value,
+                                  math::var_value<plain_type_t<T_container>>,
+                                  plain_type_t<T_container>>;
+};
+template <typename T_scalar, typename T_container>
+struct conditional_var_value<T_scalar, T_container,
+                             require_std_vector_t<T_container>> {
+  using type = std::vector<typename conditional_var_value<
+      T_scalar, value_type_t<T_container>>::type>;
+};
+
+template <typename T_scalar, typename T_container>
+using conditional_var_value_t =
+    typename conditional_var_value<T_scalar, T_container>::type;
+
+}  // namespace stan
+
+#endif

--- a/test/unit/math/rev/fun/from_var_value_test.cpp
+++ b/test/unit/math/rev/fun/from_var_value_test.cpp
@@ -4,7 +4,7 @@
 #include <test/unit/pretty_print_types.hpp>
 
 TEST(AgradRevMatrix, from_var_value_types) {
-  using stan::math::to_var_value;
+  using stan::math::from_var_value;
   using stan::math::var;
   using stan::math::var_value;
 
@@ -25,6 +25,10 @@ TEST(AgradRevMatrix, from_var_value_types) {
   var_vec f = Eigen::VectorXd(2);
   var_row_vec g = Eigen::RowVectorXd(2);
 
+  Eigen::MatrixXd h;
+  Eigen::VectorXd i;
+  Eigen::RowVectorXd j;
+
   auto av = from_var_value(a);
   auto bv = from_var_value(b);
   auto cv = from_var_value(c);
@@ -34,6 +38,10 @@ TEST(AgradRevMatrix, from_var_value_types) {
   auto fv = from_var_value(f);
   auto gv = from_var_value(g);
 
+  auto hv = from_var_value(h);
+  auto iv = from_var_value(i);
+  auto jv = from_var_value(j);
+
   test::expect_same_type<var, decltype(av)>();
   test::expect_same_type<mat_var, decltype(bv)>();
   test::expect_same_type<vec_var, decltype(cv)>();
@@ -42,6 +50,10 @@ TEST(AgradRevMatrix, from_var_value_types) {
   test::expect_same_type<mat_var, decltype(ev)>();
   test::expect_same_type<vec_var, decltype(fv)>();
   test::expect_same_type<row_vec_var, decltype(gv)>();
+
+  test::expect_same_type<Eigen::MatrixXd, decltype(hv)>();
+  test::expect_same_type<Eigen::VectorXd, decltype(iv)>();
+  test::expect_same_type<Eigen::RowVectorXd, decltype(jv)>();
 
   stan::math::recover_memory();
 }
@@ -189,4 +201,16 @@ TEST(AgradRevMatrix, from_var_value_row_vector_svec_test) {
     stan::math::grad();
     EXPECT_MATRIX_EQ(varmats[i].adj(), matvars[i].adj());
   }
+}
+
+TEST(AgradRevMatrix, from_var_value_prim_test) {
+  Eigen::MatrixXd a(3, 2);
+  a << 1, 2, 3, 4, 5, 6;
+  Eigen::VectorXd b(3);
+  b << 1, 2, 3;
+  Eigen::RowVectorXd c(3);
+  c << 4, 5, 6;
+  EXPECT_MATRIX_EQ(stan::math::from_var_value(a), a);
+  EXPECT_MATRIX_EQ(stan::math::from_var_value(b), b);
+  EXPECT_MATRIX_EQ(stan::math::from_var_value(c), c);
 }

--- a/test/unit/math/rev/meta/conditional_var_value_test.cpp
+++ b/test/unit/math/rev/meta/conditional_var_value_test.cpp
@@ -1,0 +1,75 @@
+#include <stan/math/rev/meta.hpp>
+#include <test/unit/util.hpp>
+#include <gtest/gtest.h>
+
+TEST(MathMetaRev, conditional_var_value_scalar) {
+  using stan::conditional_var_value_t;
+  using stan::math::var;
+  EXPECT_SAME_TYPE(double, conditional_var_value_t<double, double>);
+  EXPECT_SAME_TYPE(var, conditional_var_value_t<var, double>);
+}
+
+TEST(MathMetaRev, conditional_var_value_reference) {
+  using stan::conditional_var_value_t;
+  EXPECT_SAME_TYPE(double, conditional_var_value_t<double, double>);
+  EXPECT_SAME_TYPE(double, conditional_var_value_t<double&, double&>);
+  EXPECT_SAME_TYPE(double, conditional_var_value_t<double&&, double&&>);
+}
+
+TEST(MathMetaRev, conditional_var_value_vector) {
+  using stan::conditional_var_value_t;
+  using stan::math::var;
+  using stan::math::var_value;
+  EXPECT_SAME_TYPE(Eigen::VectorXd,
+                   conditional_var_value_t<double, Eigen::VectorXd>);
+  EXPECT_SAME_TYPE(var_value<Eigen::VectorXd>,
+                   conditional_var_value_t<var, Eigen::VectorXd>);
+}
+
+TEST(MathMetaRev, conditional_var_value_row_vector) {
+  using stan::conditional_var_value_t;
+  using stan::math::var;
+  using stan::math::var_value;
+  EXPECT_SAME_TYPE(Eigen::RowVectorXd,
+                   conditional_var_value_t<double, Eigen::RowVectorXd>);
+  EXPECT_SAME_TYPE(var_value<Eigen::RowVectorXd>,
+                   conditional_var_value_t<var, Eigen::RowVectorXd>);
+}
+
+TEST(MathMetaRev, conditional_var_value_matrix) {
+  using stan::conditional_var_value_t;
+  using stan::math::var;
+  using stan::math::var_value;
+  EXPECT_SAME_TYPE(Eigen::MatrixXd,
+                   conditional_var_value_t<double, Eigen::MatrixXd>);
+  EXPECT_SAME_TYPE(var_value<Eigen::MatrixXd>,
+                   conditional_var_value_t<var, Eigen::MatrixXd>);
+}
+
+TEST(MathMetaRev, conditional_var_value_expression) {
+  using stan::conditional_var_value_t;
+  using stan::math::var;
+  using stan::math::var_value;
+  Eigen::MatrixXd a;
+  Eigen::MatrixXd b;
+  EXPECT_SAME_TYPE(
+      Eigen::MatrixXd,
+      conditional_var_value_t<double, decltype(a + b.block(1, 1, 2, 2))>);
+  EXPECT_SAME_TYPE(
+      var_value<Eigen::MatrixXd>,
+      conditional_var_value_t<var, decltype(a + b.block(1, 1, 2, 2))>);
+}
+
+TEST(MathMetaRev, conditional_var_value_container_T_scalar) {
+  using stan::conditional_var_value_t;
+  using stan::math::var;
+  using stan::math::var_value;
+  Eigen::MatrixXd a;
+  Eigen::MatrixXd b;
+  EXPECT_SAME_TYPE(Eigen::MatrixXd,
+                   conditional_var_value_t<Eigen::VectorXd, Eigen::MatrixXd>);
+  EXPECT_SAME_TYPE(
+      var_value<Eigen::MatrixXd>,
+      conditional_var_value_t<Eigen::Matrix<var, 1, Eigen::Dynamic>,
+                              Eigen::MatrixXd>);
+}

--- a/test/unit/util.hpp
+++ b/test/unit/util.hpp
@@ -168,12 +168,12 @@
  * Tests if given types are the same type.
  *
  * @param a first type
- * @param b second type
+ * @param b second type (code for this one can contain commas)
  **/
-#define EXPECT_SAME_TYPE(a, b)                                             \
-  EXPECT_TRUE((std::is_same<a, b>::value))                                 \
+#define EXPECT_SAME_TYPE(a, ...)                                             \
+  EXPECT_TRUE((std::is_same<a, __VA_ARGS__>::value))                                 \
       << "Type a is" << stan::math::test::type_name<a>() << ". Type b is " \
-      << stan::math::test::type_name<b>();
+      << stan::math::test::type_name<__VA_ARGS__>();
 
 /**
  * Count the number of times a substring is found in

--- a/test/unit/util.hpp
+++ b/test/unit/util.hpp
@@ -170,8 +170,8 @@
  * @param a first type
  * @param b second type (code for this one can contain commas)
  **/
-#define EXPECT_SAME_TYPE(a, ...)                                             \
-  EXPECT_TRUE((std::is_same<a, __VA_ARGS__>::value))                                 \
+#define EXPECT_SAME_TYPE(a, ...)                                           \
+  EXPECT_TRUE((std::is_same<a, __VA_ARGS__>::value))                       \
       << "Type a is" << stan::math::test::type_name<a>() << ". Type b is " \
       << stan::math::test::type_name<__VA_ARGS__>();
 


### PR DESCRIPTION
## Summary
Adds some tools to simplify conde generation for stanc3:
- makes `from_var_value` work on prim types, returning the argument
- adds `conditional_var_value` metaprogram that constructs a type from a scalar and a container.

Closes #2325. Closes #2298.

## Tests
New changes are tested. `EXPECT_TYPE_EQ` macro has been extended so that the code for the second type can contain commas.

## Side Effects
None.

## Release notes
- makes `from_var_value` work on prim types
- adds `conditional_var_value` metaprogram

## Checklist

- [ ] Math issue #2325, #2298

- [ ] Copyright holder: Tadej Ciglarič

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [ ] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [ ] the code is written in idiomatic C++ and changes are documented in the doxygen

- [ ] the new changes are tested
