### PR TITLE
Fix dirichlet_lpdf and multi_normal_cholesky_lpdf adjoints

### DIFF
--- a/stan/math/prim/prob/dirichlet_lpdf.hpp
+++ b/stan/math/prim/prob/dirichlet_lpdf.hpp
@@ -110,15 +110,16 @@ return_type_t<T_prob, T_prior_size> dirichlet_lpdf(const T_prob& theta,
   if (!is_constant_all<T_prob>::value) {
     for (size_t t = 0; t < t_length; t++) {
       ops_partials.edge1_.partials_vec_[t]
-          = alpha_m_1.col(t) / theta_dbl.col(t);
+          += (alpha_m_1.col(t) / theta_dbl.col(t)).matrix();
     }
   }
 
   if (!is_constant_all<T_prior_size>::value) {
     for (size_t t = 0; t < t_length; t++) {
-      ops_partials.edge2_.partials_vec_[t] = digamma(alpha_dbl.col(t).sum())
-                                             - digamma(alpha_dbl.col(t))
-                                             + theta_log.col(t);
+      ops_partials.edge2_.partials_vec_[t]
+          += (digamma(alpha_dbl.col(t).sum()) - digamma(alpha_dbl.col(t))
+              + theta_log.col(t))
+                 .matrix();
     }
   }
   return ops_partials.build(lp);

--- a/stan/math/prim/prob/multi_normal_cholesky_lpdf.hpp
+++ b/stan/math/prim/prob/multi_normal_cholesky_lpdf.hpp
@@ -129,8 +129,10 @@ return_type_t<T_y, T_loc, T_covar> multi_normal_cholesky_lpdf(
       const auto& mu_col = as_column_vector_or_scalar(mu_vec[i]);
 
       const row_vector_partials_t half
-          = (inv_L_dbl.template triangularView<Eigen::Lower>() *
-	     (value_of(y_col) - value_of(mu_col)).template cast<T_partials_return>()).transpose();
+          = (inv_L_dbl.template triangularView<Eigen::Lower>()
+             * (value_of(y_col) - value_of(mu_col))
+                   .template cast<T_partials_return>())
+                .transpose();
       const vector_partials_t scaled_diff
           = (half * inv_L_dbl.template triangularView<Eigen::Lower>())
                 .transpose();

--- a/stan/math/prim/prob/multi_normal_cholesky_lpdf.hpp
+++ b/stan/math/prim/prob/multi_normal_cholesky_lpdf.hpp
@@ -129,9 +129,8 @@ return_type_t<T_y, T_loc, T_covar> multi_normal_cholesky_lpdf(
       const auto& mu_col = as_column_vector_or_scalar(mu_vec[i]);
 
       const row_vector_partials_t half
-          = (inv_L_dbl.template triangularView<Eigen::Lower>()
-             * (value_of(y_col) - value_of(mu_col)))
-                .transpose();
+          = (inv_L_dbl.template triangularView<Eigen::Lower>() *
+	     (value_of(y_col) - value_of(mu_col)).template cast<T_partials_return>()).transpose();
       const vector_partials_t scaled_diff
           = (half * inv_L_dbl.template triangularView<Eigen::Lower>())
                 .transpose();

--- a/stan/math/prim/prob/multi_normal_cholesky_lpdf.hpp
+++ b/stan/math/prim/prob/multi_normal_cholesky_lpdf.hpp
@@ -139,10 +139,10 @@ return_type_t<T_y, T_loc, T_covar> multi_normal_cholesky_lpdf(
       logp -= 0.5 * dot_self(half);
 
       if (!is_constant_all<T_y>::value) {
-        ops_partials.edge1_.partials_vec_[i] = -scaled_diff;
+        ops_partials.edge1_.partials_vec_[i] -= scaled_diff;
       }
       if (!is_constant_all<T_loc>::value) {
-        ops_partials.edge2_.partials_vec_[i] = scaled_diff;
+        ops_partials.edge2_.partials_vec_[i] += scaled_diff;
       }
       if (!is_constant_all<T_covar>::value) {
         ops_partials.edge3_.partials_ += scaled_diff * half;

--- a/test/unit/math/mix/prob/dirichlet_test.cpp
+++ b/test/unit/math/mix/prob/dirichlet_test.cpp
@@ -1,21 +1,20 @@
 #include <test/unit/math/test_ad.hpp>
 
 namespace dirichlet_test {
-  template <typename T>
-  std::vector<T> vectorize_softmax(const std::vector<T>& y) {
-    std::vector<T> y_simplex;
-    for(size_t i = 0; i < y.size(); ++i) {
-      y_simplex.push_back(stan::math::softmax(y[i]));
-    }
-    return y_simplex;
+template <typename T>
+std::vector<T> vectorize_softmax(const std::vector<T>& y) {
+  std::vector<T> y_simplex;
+  for (size_t i = 0; i < y.size(); ++i) {
+    y_simplex.push_back(stan::math::softmax(y[i]));
   }
+  return y_simplex;
+}
 
-  template <typename T,
-	    stan::require_not_std_vector_t<T>* = nullptr>
-  T vectorize_softmax(const T& y) {
-    return stan::math::softmax(y);
-  }
-} 
+template <typename T, stan::require_not_std_vector_t<T>* = nullptr>
+T vectorize_softmax(const T& y) {
+  return stan::math::softmax(y);
+}
+}  // namespace dirichlet_test
 
 TEST(ProbDistributions, dirichlet) {
   auto f = [](const auto& y, const auto& alpha) {
@@ -29,7 +28,7 @@ TEST(ProbDistributions, dirichlet) {
   Eigen::VectorXd v2(2);
   v2 << 1.0, 0.5;
 
-  std::vector<Eigen::VectorXd> vs = { v1, v2 };
+  std::vector<Eigen::VectorXd> vs = {v1, v2};
 
   stan::test::expect_ad(f, v1, v2);
   stan::test::expect_ad(f, v1, vs);

--- a/test/unit/math/mix/prob/dirichlet_test.cpp
+++ b/test/unit/math/mix/prob/dirichlet_test.cpp
@@ -1,8 +1,41 @@
-#include <stan/math/mix.hpp>
-#include <gtest/gtest.h>
-#include <boost/random/mersenne_twister.hpp>
-#include <boost/math/distributions.hpp>
-#include <vector>
+#include <test/unit/math/test_ad.hpp>
+
+namespace dirichlet_test {
+  template <typename T>
+  std::vector<T> vectorize_softmax(const std::vector<T>& y) {
+    std::vector<T> y_simplex;
+    for(size_t i = 0; i < y.size(); ++i) {
+      y_simplex.push_back(stan::math::softmax(y[i]));
+    }
+    return y_simplex;
+  }
+
+  template <typename T,
+	    stan::require_not_std_vector_t<T>* = nullptr>
+  T vectorize_softmax(const T& y) {
+    return stan::math::softmax(y);
+  }
+} 
+
+TEST(ProbDistributions, dirichlet) {
+  auto f = [](const auto& y, const auto& alpha) {
+    auto y_simplex = dirichlet_test::vectorize_softmax(y);
+    auto lp = stan::math::dirichlet_lpdf(y_simplex, alpha);
+    return lp;
+  };
+
+  Eigen::VectorXd v1(2);
+  v1 << 1.0, 2.0;
+  Eigen::VectorXd v2(2);
+  v2 << 1.0, 0.5;
+
+  std::vector<Eigen::VectorXd> vs = { v1, v2 };
+
+  stan::test::expect_ad(f, v1, v2);
+  stan::test::expect_ad(f, v1, vs);
+  stan::test::expect_ad(f, vs, v1);
+  stan::test::expect_ad(f, vs, vs);
+}
 
 TEST(ProbDistributions, fvar_var) {
   using Eigen::Dynamic;

--- a/test/unit/math/mix/prob/multi_normal_cholesky_test.cpp
+++ b/test/unit/math/mix/prob/multi_normal_cholesky_test.cpp
@@ -32,8 +32,8 @@ TEST(ProbDistributionsMultiNormalCholesky, matvar) {
   y22 << 0.4, 0.3;
   Eigen::VectorXd mu22(2);
   mu22 << 2.1, 1.0;
-  std::vector<Eigen::VectorXd> y2s = { y2, y22 };
-  std::vector<Eigen::VectorXd> mu2s = { mu2, mu22 };
+  std::vector<Eigen::VectorXd> y2s = {y2, y22};
+  std::vector<Eigen::VectorXd> mu2s = {mu2, mu22};
   stan::test::expect_ad(f, y2, mu2s, Sigma22);
   stan::test::expect_ad(f, y2s, mu2, Sigma22);
   stan::test::expect_ad(f, y2s, mu2s, Sigma22);

--- a/test/unit/math/mix/prob/multi_normal_cholesky_test.cpp
+++ b/test/unit/math/mix/prob/multi_normal_cholesky_test.cpp
@@ -1,7 +1,49 @@
-#include <stan/math/mix.hpp>
-#include <gtest/gtest.h>
-#include <boost/random/mersenne_twister.hpp>
-#include <boost/math/distributions.hpp>
+#include <test/unit/math/test_ad.hpp>
+
+TEST(ProbDistributionsMultiNormalCholesky, matvar) {
+  auto f = [](const auto& y, const auto& mu, const auto& sigma) {
+    auto sigma_sym = stan::math::multiply(0.5, sigma + sigma.transpose());
+    auto L = stan::math::cholesky_decompose(sigma_sym);
+    return stan::math::multi_normal_cholesky_lpdf(y, mu, L);
+  };
+
+  Eigen::VectorXd y1(1);
+  y1 << 1;
+  Eigen::VectorXd mu1(1);
+  mu1 << 3.4;
+  Eigen::MatrixXd Sigma11(1, 1);
+  Sigma11 << 1;
+  stan::test::expect_ad(f, y1, mu1, Sigma11);
+
+  Eigen::VectorXd y0(0);
+  Eigen::VectorXd mu0(0);
+  Eigen::MatrixXd Sigma00(0, 0);
+  stan::test::expect_ad(f, y0, mu0, Sigma00);
+
+  Eigen::VectorXd y2(2);
+  y2 << 1.0, 0.1;
+  Eigen::VectorXd mu2(2);
+  mu2 << 0.1, 2.0;
+  Eigen::MatrixXd Sigma22(2, 2);
+  Sigma22 << 2.0, 0.5, 0.5, 1.1;
+  stan::test::expect_ad(f, y2, mu2, Sigma22);
+
+  Eigen::VectorXd y22(2);
+  y22 << 0.4, 0.3;
+  Eigen::VectorXd mu22(2);
+  mu22 << 2.1, 1.0;
+  std::vector<Eigen::VectorXd> y2s = { y2, y22 };
+  std::vector<Eigen::VectorXd> mu2s = { mu2, mu22 };
+  stan::test::expect_ad(f, y2, mu2s, Sigma22);
+  stan::test::expect_ad(f, y2s, mu2, Sigma22);
+  stan::test::expect_ad(f, y2s, mu2s, Sigma22);
+
+  // Error sizes
+  stan::test::expect_ad(f, y0, mu0, Sigma11);
+  stan::test::expect_ad(f, y1, mu1, Sigma00);
+  stan::test::expect_ad_matvar(f, y0, mu0, Sigma11);
+  stan::test::expect_ad_matvar(f, y1, mu1, Sigma00);
+}
 
 TEST(ProbDistributionsMultiNormalCholesky, fvar_var) {
   using Eigen::Dynamic;

--- a/test/unit/math/mix/prob/multi_normal_test.cpp
+++ b/test/unit/math/mix/prob/multi_normal_test.cpp
@@ -30,6 +30,16 @@ TEST(ProbDistributionsMultiNormal, matvar) {
   stan::test::expect_ad(f, y2, mu2, Sigma22);
   stan::test::expect_ad_matvar(f, y2, mu2, Sigma22);
 
+  Eigen::VectorXd y22(2);
+  y22 << 0.4, 0.3;
+  Eigen::VectorXd mu22(2);
+  mu22 << 2.1, 1.0;
+  std::vector<Eigen::VectorXd> y2s = { y2, y22 };
+  std::vector<Eigen::VectorXd> mu2s = { mu2, mu22 };
+  stan::test::expect_ad(f, y2, mu2s, Sigma22);
+  stan::test::expect_ad(f, y2s, mu2, Sigma22);
+  stan::test::expect_ad(f, y2s, mu2s, Sigma22);
+
   // Error sizes
   stan::test::expect_ad(f, y0, mu0, Sigma11);
   stan::test::expect_ad(f, y1, mu1, Sigma00);

--- a/test/unit/math/mix/prob/multi_normal_test.cpp
+++ b/test/unit/math/mix/prob/multi_normal_test.cpp
@@ -34,8 +34,8 @@ TEST(ProbDistributionsMultiNormal, matvar) {
   y22 << 0.4, 0.3;
   Eigen::VectorXd mu22(2);
   mu22 << 2.1, 1.0;
-  std::vector<Eigen::VectorXd> y2s = { y2, y22 };
-  std::vector<Eigen::VectorXd> mu2s = { mu2, mu22 };
+  std::vector<Eigen::VectorXd> y2s = {y2, y22};
+  std::vector<Eigen::VectorXd> mu2s = {mu2, mu22};
   stan::test::expect_ad(f, y2, mu2s, Sigma22);
   stan::test::expect_ad(f, y2s, mu2, Sigma22);
   stan::test::expect_ad(f, y2s, mu2s, Sigma22);


### PR DESCRIPTION
## Summary

Fixes a bug in `dirichlet_lpdf` and `multi_normal_cholesky_lpdf`, where some overloads (ones that do broadcasting) produced wrong derivatives. The bug appeared with generalizations of the functions, so it is also present in the last release.

## Tests
As far as I can see there is no test for `dirichlet_lpdf` that would check adjoints (ouch). Tests for `multi_normal_cholesky_lpdf` seem as if they should catch that, but they are quite complicated and I can't really make sense of them. 

@bbbales2 can I recruit you for writing appropriate tests for this?

## Side Effects
None.

## Release notes

Fixed a bug in `dirichlet_lpdf` and `multi_normal_cholesky_lpdf`, where some overloads (ones that do broadcasting) produced wrong derivatives.

## Checklist

- [x] Math issue #2332 

- [x] Copyright holder: Tadej Ciglarič

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [ ] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [ ] the new changes are tested
