### PR TITLE
Add OpenCL append_row, append_col, matrix_power and multiply_lower_tri_self_transpose

### DIFF
--- a/stan/math/opencl/kernel_generator/operation_cl.hpp
+++ b/stan/math/opencl/kernel_generator/operation_cl.hpp
@@ -362,6 +362,15 @@ class operation_cl : public operation_cl_base {
   }
 
   /**
+   * Size of a matrix that would be the result of evaluating this
+   * expression.
+   * @return number of elements
+   */
+  inline int size() const {
+    return derived().rows() * derived().cols();
+  }
+
+  /**
    * Number of rows threads need to be launched for. For most expressions this
    * equals number of rows of the result.
    * @return number of rows

--- a/stan/math/opencl/prim.hpp
+++ b/stan/math/opencl/prim.hpp
@@ -140,6 +140,7 @@
 #include <stan/math/opencl/prim/inv_sqrt.hpp>
 #include <stan/math/opencl/prim/logistic_lpdf.hpp>
 #include <stan/math/opencl/prim/lognormal_lpdf.hpp>
+#include <stan/math/opencl/prim/matrix_power.hpp>
 #include <stan/math/opencl/prim/mdivide_left_tri_low.hpp>
 #include <stan/math/opencl/prim/mdivide_right_tri_low.hpp>
 #include <stan/math/opencl/prim/mean.hpp>

--- a/stan/math/opencl/prim.hpp
+++ b/stan/math/opencl/prim.hpp
@@ -144,6 +144,7 @@
 #include <stan/math/opencl/prim/mdivide_right_tri_low.hpp>
 #include <stan/math/opencl/prim/mean.hpp>
 #include <stan/math/opencl/prim/multi_normal_cholesky_lpdf.hpp>
+#include <stan/math/opencl/prim/multiply_lower_tri_self_transpose.hpp>
 #include <stan/math/opencl/prim/neg_binomial_lpmf.hpp>
 #include <stan/math/opencl/prim/neg_binomial_2_lpmf.hpp>
 #include <stan/math/opencl/prim/neg_binomial_2_log_lpmf.hpp>

--- a/stan/math/opencl/prim/matrix_power.hpp
+++ b/stan/math/opencl/prim/matrix_power.hpp
@@ -1,0 +1,49 @@
+#ifndef STAN_MATH_OPENCL_PRIM_MATRIX_POWER_HPP
+#define STAN_MATH_OPENCL_PRIM_MATRIX_POWER_HPP
+#ifdef STAN_OPENCL
+#include <stan/math/opencl/prim/size.hpp>
+#include <stan/math/opencl/kernel_generator.hpp>
+#include <stan/math/opencl/prim/diag_matrix.hpp>
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/err.hpp>
+
+namespace stan {
+namespace math {
+
+/**
+ * Returns the nth power of the specific matrix. M^n = M * M * ... * M.
+ *
+ * @tparam T type of the matrix
+ *
+ * @param[in] M a square matrix
+ * @param[in] n exponent
+ * @return nth power of M
+ * @throw std::domain_error if the matrix contains NaNs or infinities.
+ * @throw std::invalid_argument if the exponent is negative or the matrix is not
+ * square.
+ */
+template <typename T_m,
+          require_all_kernel_expressions_and_none_scalar_t<T_m>* = nullptr>
+inline plain_type_t<T_m> matrix_power(T_m&& M, const int n) {
+  const char* function = "matrix_power(OpenCL)";
+  check_square(function, "M", M);
+  check_nonnegative(function, "n", n);
+  plain_type_t<T_m> MM = std::forward<T_m>(M);
+  check_cl(function, "M", value_of(MM), "finite") = isfinite(value_of(MM));
+  if (n == 0)
+    return diag_matrix(constant(1.0, M.rows(), 1));
+  plain_type_t<T_m> result = MM;
+  for (int nn = n - 1; nn > 0; nn /= 2) {
+    if (nn % 2 == 1) {
+      result = result * MM;
+      --nn;
+    }
+    MM = MM * MM;
+  }
+  return result;
+}
+}  // namespace math
+}  // namespace stan
+
+#endif
+#endif

--- a/stan/math/opencl/prim/multiply_lower_tri_self_transpose.hpp
+++ b/stan/math/opencl/prim/multiply_lower_tri_self_transpose.hpp
@@ -1,0 +1,38 @@
+#ifndef STAN_MATH_OPENCL_PRIM_MULTIPLY_LOWER_TRI_SELF_TRANSPOSE_HPP
+#define STAN_MATH_OPENCL_PRIM_MULTIPLY_LOWER_TRI_SELF_TRANSPOSE_HPP
+#ifdef STAN_OPENCL
+
+#include <stan/math/opencl/kernel_generator.hpp>
+#include <stan/math/opencl/prim/multiply.hpp>
+
+namespace stan {
+namespace math {
+
+/**
+ * Returns the result of multiplying the lower triangular
+ * portion of the input matrix by its own transpose.
+ *
+ * @param x Matrix to multiply.
+ * @return The lower triangular values in x times their own
+ * transpose.
+ */
+template <typename T_x,
+          require_all_kernel_expressions_and_none_scalar_t<T_x>* = nullptr>
+inline auto multiply_lower_tri_self_transpose(T_x&& x) {
+  matrix_cl<double> x_eval = std::forward<T_x>(x);
+  if(x_eval.size()==0){
+    return matrix_cl<double>(0,0);
+  }
+  matrix_cl<double> x_lower(x_eval.buffer(), x_eval.rows(), x_eval.cols(),
+                            matrix_cl_view::Lower);
+  for (auto e : x_eval.write_events()) {
+    x_lower.add_write_event(e);
+  }
+  matrix_cl<double> res = x_lower * transpose(x_lower);
+  x_eval.add_read_event(x_lower.read_events().back());
+  return res;
+}
+}  // namespace math
+}  // namespace stan
+#endif
+#endif

--- a/stan/math/opencl/rev.hpp
+++ b/stan/math/opencl/rev.hpp
@@ -64,6 +64,7 @@
 #include <stan/math/opencl/rev/log1m_inv_logit.hpp>
 #include <stan/math/opencl/rev/log_inv_logit_diff.hpp>
 #include <stan/math/opencl/rev/log_diff_exp.hpp>
+#include <stan/math/opencl/rev/matrix_power.hpp>
 #include <stan/math/opencl/rev/mdivide_left_tri_low.hpp>
 #include <stan/math/opencl/rev/mdivide_right_tri_low.hpp>
 #include <stan/math/opencl/rev/multiply.hpp>

--- a/stan/math/opencl/rev.hpp
+++ b/stan/math/opencl/rev.hpp
@@ -3,6 +3,8 @@
 #ifdef STAN_OPENCL
 
 #include <stan/math/opencl/prim.hpp>
+#include <stan/math/opencl/rev/append_col.hpp>
+#include <stan/math/opencl/rev/append_row.hpp>
 #include <stan/math/opencl/rev/acos.hpp>
 #include <stan/math/opencl/rev/acosh.hpp>
 #include <stan/math/opencl/rev/add.hpp>

--- a/stan/math/opencl/rev.hpp
+++ b/stan/math/opencl/rev.hpp
@@ -68,6 +68,7 @@
 #include <stan/math/opencl/rev/mdivide_right_tri_low.hpp>
 #include <stan/math/opencl/rev/multiply.hpp>
 #include <stan/math/opencl/rev/multiply_log.hpp>
+#include <stan/math/opencl/rev/multiply_lower_tri_self_transpose.hpp>
 #include <stan/math/opencl/rev/operands_and_partials.hpp>
 #include <stan/math/opencl/rev/operator_unary_minus.hpp>
 #include <stan/math/opencl/rev/operator_unary_plus.hpp>

--- a/stan/math/opencl/rev/append_col.hpp
+++ b/stan/math/opencl/rev/append_col.hpp
@@ -1,0 +1,64 @@
+#ifndef STAN_MATH_OPENCL_REV_APPEND_COL_HPP
+#define STAN_MATH_OPENCL_REV_APPEND_COL_HPP
+#ifdef STAN_OPENCL
+
+#include <stan/math/opencl/rev/adjoint_results.hpp>
+#include <stan/math/opencl/matrix_cl.hpp>
+#include <stan/math/opencl/kernel_generator.hpp>
+#include <stan/math/opencl/prim/sum.hpp>
+#include <stan/math/rev/core.hpp>
+#include <stan/math/rev/fun/value_of.hpp>
+#include <stan/math/rev/core/reverse_pass_callback.hpp>
+#include <stan/math/prim/fun/value_of.hpp>
+#include <stan/math/prim/meta/is_kernel_expression.hpp>
+
+namespace stan {
+namespace math {
+
+/**
+ * Return the result of appending the second argument matrix after the
+ * first argument matrix, that is, putting them side by side, with
+ * the first matrix followed by the second matrix.
+ *
+ * Given input types result in following outputs:
+ * (matrix, matrix) -> matrix,
+ * (matrix, vector) -> matrix,
+ * (vector, matrix) -> matrix,
+ * (vector, vector) -> matrix,
+ * (row vector, row vector) -> row_vector.
+ *
+ * @tparam T_a type of the first matrix
+ * @tparam T_b type of the second matrix
+ *
+ * @param a First matrix.
+ * @param b Second matrix.
+ * @return Result of appending the first matrix followed by the
+ * second matrix side by side.
+ */
+template <typename T_a, typename T_b,
+          require_all_prim_or_rev_kernel_expression_t<T_a, T_b>* = nullptr,
+          require_any_var_t<T_a, T_b>* = nullptr,
+          require_any_not_stan_scalar_t<T_a, T_b>* = nullptr>
+inline var_value<matrix_cl<double>> append_col(T_a&& a, T_b&& b) {
+  arena_t<T_a> a_arena = std::forward<T_a>(a);
+  arena_t<T_b> b_arena = std::forward<T_b>(b);
+
+  return make_callback_var(
+      append_col(value_of(a_arena), value_of(b_arena)),
+      [a_arena, b_arena](const vari_value<matrix_cl<double>>& res) mutable {
+        if (!is_constant<T_a>::value) {
+          adjoint_of(a_arena) += block_zero_based(
+              res.adj(), 0, 0, a_arena.rows(), a_arena.cols());
+        }
+        if (!is_constant<T_b>::value) {
+          adjoint_of(b_arena) += block_zero_based(
+              res.adj(), 0, a_arena.cols(), b_arena.rows(), b_arena.cols());
+        }
+      });
+}
+
+}  // namespace math
+}  // namespace stan
+
+#endif
+#endif

--- a/stan/math/opencl/rev/append_row.hpp
+++ b/stan/math/opencl/rev/append_row.hpp
@@ -1,0 +1,62 @@
+#ifndef STAN_MATH_OPENCL_REV_APPEND_ROW_HPP
+#define STAN_MATH_OPENCL_REV_APPEND_ROW_HPP
+#ifdef STAN_OPENCL
+
+#include <stan/math/opencl/rev/adjoint_results.hpp>
+#include <stan/math/opencl/matrix_cl.hpp>
+#include <stan/math/opencl/kernel_generator.hpp>
+#include <stan/math/opencl/prim/sum.hpp>
+#include <stan/math/rev/core.hpp>
+#include <stan/math/rev/fun/value_of.hpp>
+#include <stan/math/rev/core/reverse_pass_callback.hpp>
+#include <stan/math/prim/fun/value_of.hpp>
+#include <stan/math/prim/meta/is_kernel_expression.hpp>
+
+namespace stan {
+namespace math {
+
+/**
+ * Return the result of stacking the rows of the first argument
+ * matrix on top of the second argument matrix.
+ *
+ * Given input types result in following outputs:
+ * (matrix, matrix) -> matrix,
+ * (matrix, row_vector) -> matrix,
+ * (row_vector, matrix) -> matrix,
+ * (row_vector, row_vector) -> matrix,
+ * (vector, vector) -> vector.
+ *
+ * @tparam T_a type of the first matrix
+ * @tparam T_b type of the second matrix
+ *
+ * @param a First matrix.
+ * @param b Second matrix.
+ * @return Result of stacking first matrix on top of second.
+ */
+template <typename T_a, typename T_b,
+          require_all_prim_or_rev_kernel_expression_t<T_a, T_b>* = nullptr,
+          require_any_var_t<T_a, T_b>* = nullptr,
+          require_any_not_stan_scalar_t<T_a, T_b>* = nullptr>
+inline var_value<matrix_cl<double>> append_row(T_a&& a, T_b&& b) {
+  arena_t<T_a> a_arena = std::forward<T_a>(a);
+  arena_t<T_b> b_arena = std::forward<T_b>(b);
+
+  return make_callback_var(
+      append_row(value_of(a_arena), value_of(b_arena)),
+      [a_arena, b_arena](const vari_value<matrix_cl<double>>& res) mutable {
+        if (!is_constant<T_a>::value) {
+          adjoint_of(a_arena) += block_zero_based(
+              res.adj(), 0, 0, a_arena.rows(), a_arena.cols());
+        }
+        if (!is_constant<T_b>::value) {
+          adjoint_of(b_arena) += block_zero_based(
+              res.adj(), a_arena.rows(), 0, b_arena.rows(), b_arena.cols());
+        }
+      });
+}
+
+}  // namespace math
+}  // namespace stan
+
+#endif
+#endif

--- a/stan/math/opencl/rev/matrix_power.hpp
+++ b/stan/math/opencl/rev/matrix_power.hpp
@@ -2,6 +2,7 @@
 #define STAN_MATH_OPENCL_REV_MATRIX_POWER_HPP
 #ifdef STAN_OPENCL
 #include <stan/math/opencl/rev/arena_type.hpp>
+#include <stan/math/opencl/prim/multiply.hpp>
 #include <stan/math/opencl/kernel_generator.hpp>
 #include <stan/math/opencl/prim/diag_matrix.hpp>
 #include <stan/math/rev/core.hpp>

--- a/stan/math/opencl/rev/matrix_power.hpp
+++ b/stan/math/opencl/rev/matrix_power.hpp
@@ -1,6 +1,7 @@
 #ifndef STAN_MATH_OPENCL_REV_MATRIX_POWER_HPP
 #define STAN_MATH_OPENCL_REV_MATRIX_POWER_HPP
 #ifdef STAN_OPENCL
+#include <stan/math/opencl/rev/arena_type.hpp>
 #include <stan/math/opencl/kernel_generator.hpp>
 #include <stan/math/opencl/prim/diag_matrix.hpp>
 #include <stan/math/rev/core.hpp>
@@ -11,16 +12,16 @@ namespace stan {
 namespace math {
 
 /**
- * Returns a Matrix with values added along the main diagonal
+ * Returns the nth power of the specific matrix. M^n = M * M * ... * M.
  *
- * @tparam T_m type of input kernel generator expression for the input matrix
- * @tparam T_a type of input kernel generator expression to add along the
- * diagonal
+ * @tparam T type of the matrix
  *
- * @param mat input kernel generator expression
- * @param to_add scalar value or input kernel generator expression to add along
- * the diagonal
- * @return a kernel generator expressio with to_add added along main diagonal
+ * @param[in] M a square matrix
+ * @param[in] n exponent
+ * @return nth power of M
+ * @throw std::domain_error if the matrix contains NaNs or infinities.
+ * @throw std::invalid_argument if the exponent is negative or the matrix is not
+ * square.
  */
 template <typename T,
           require_all_kernel_expressions_and_none_scalar_t<T>* = nullptr>

--- a/stan/math/opencl/rev/matrix_power.hpp
+++ b/stan/math/opencl/rev/matrix_power.hpp
@@ -1,0 +1,67 @@
+#ifndef STAN_MATH_OPENCL_REV_MATRIX_POWER_HPP
+#define STAN_MATH_OPENCL_REV_MATRIX_POWER_HPP
+#ifdef STAN_OPENCL
+#include <stan/math/opencl/kernel_generator.hpp>
+#include <stan/math/opencl/prim/diag_matrix.hpp>
+#include <stan/math/rev/core.hpp>
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/err.hpp>
+
+namespace stan {
+namespace math {
+
+/**
+ * Returns a Matrix with values added along the main diagonal
+ *
+ * @tparam T_m type of input kernel generator expression for the input matrix
+ * @tparam T_a type of input kernel generator expression to add along the
+ * diagonal
+ *
+ * @param mat input kernel generator expression
+ * @param to_add scalar value or input kernel generator expression to add along
+ * the diagonal
+ * @return a kernel generator expressio with to_add added along main diagonal
+ */
+template <typename T,
+          require_all_kernel_expressions_and_none_scalar_t<T>* = nullptr>
+inline var_value<matrix_cl<double>> matrix_power(const var_value<T>& M,
+                                                 const int n) {
+  check_square("matrix_power", "M", M);
+  check_nonnegative("matrix_power", "n", n);
+
+  if (M.size() == 0)
+    return M;
+
+  size_t N = M.rows();
+  if (n == 0) {
+    return diag_matrix(constant(1.0, M.rows(), 1));
+  }
+  if (n == 1) {
+    return M;
+  }
+
+  arena_t<std::vector<matrix_cl<double>>> arena_powers(n + 1);
+  arena_powers[0] = diag_matrix(constant(1.0, M.rows(), 1));
+  arena_powers[1] = M.val();
+  for (size_t i = 2; i <= n; ++i) {
+    arena_powers[i] = arena_powers[1] * arena_powers[i - 1];
+  }
+
+ return make_callback_var(
+      arena_powers.back(),
+      [M, n, arena_powers](vari_value<matrix_cl<double>> res) mutable {
+        const auto& M_val = arena_powers[1];
+        matrix_cl<double> adj_C = res.adj();
+        matrix_cl<double> adj_M = constant(0.0, M_val.rows(), M_val.cols());
+        for (size_t i = n; i > 1; --i) {
+          adj_M += adj_C * transpose(arena_powers[i - 1]);
+          adj_C = transpose(M_val) * adj_C;
+        }
+        M.adj() += adj_M + adj_C;
+      });
+}
+}  // namespace math
+}  // namespace stan
+
+#endif
+#endif

--- a/stan/math/opencl/rev/multiply_lower_tri_self_transpose.hpp
+++ b/stan/math/opencl/rev/multiply_lower_tri_self_transpose.hpp
@@ -1,0 +1,46 @@
+#ifndef STAN_MATH_OPENCL_REV_MULTIPLY_LOWER_TRI_SELF_TRANSPOSE_HPP
+#define STAN_MATH_OPENCL_REV_MULTIPLY_LOWER_TRI_SELF_TRANSPOSE_HPP
+#ifdef STAN_OPENCL
+
+#include <stan/math/opencl/kernel_generator.hpp>
+#include <stan/math/opencl/prim/multiply_lower_tri_self_transpose.hpp>
+#include <stan/math/rev/core.hpp>
+#include <stan/math/rev/fun/value_of.hpp>
+
+namespace stan {
+namespace math {
+
+/**
+ * Returns the result of multiplying the lower triangular
+ * portion of the input matrix by its own transpose.
+ *
+ * @param L Matrix to multiply.
+ * @return The lower triangular values in L times their own
+ * transpose.
+ */
+template <typename T,
+          require_all_kernel_expressions_and_none_scalar_t<T>* = nullptr>
+inline var_value<matrix_cl<double>> multiply_lower_tri_self_transpose(
+    const var_value<T>& A) {
+  return make_callback_var(
+      multiply_lower_tri_self_transpose(A.val()),
+      [A](vari_value<matrix_cl<double>>& res) mutable {
+        if (A.size() != 0) {
+          matrix_cl<double> A_val_lower(A.val().buffer(), A.val().rows(),
+                                        A.val().cols(), matrix_cl_view::Lower);
+          for (auto e : A.val().write_events()) {
+            A_val_lower.add_write_event(e);
+          }
+          matrix_cl<double> prod
+              = (res.adj() + transpose(res.adj())) * A_val_lower;
+          prod.view(matrix_cl_view::Lower);
+          A.adj() += prod;
+        }
+      });
+}
+
+}  // namespace math
+}  // namespace stan
+
+#endif
+#endif

--- a/stan/math/opencl/rev/multiply_lower_tri_self_transpose.hpp
+++ b/stan/math/opencl/rev/multiply_lower_tri_self_transpose.hpp
@@ -14,7 +14,7 @@ namespace math {
  * Returns the result of multiplying the lower triangular
  * portion of the input matrix by its own transpose.
  *
- * @param L Matrix to multiply.
+ * @param A Matrix to multiply.
  * @return The lower triangular values in L times their own
  * transpose.
  */

--- a/stan/math/prim/fun/multiply_lower_tri_self_transpose.hpp
+++ b/stan/math/prim/fun/multiply_lower_tri_self_transpose.hpp
@@ -14,7 +14,6 @@ namespace math {
  * @param L Matrix to multiply.
  * @return The lower triangular values in L times their own
  * transpose.
- * @throw std::domain_error If the input matrix is not square.
  */
 template <typename EigMat, require_eigen_matrix_dynamic_t<EigMat>* = nullptr,
           require_not_st_autodiff<EigMat>* = nullptr>

--- a/test/unit/math/opencl/rev/append_col_test.cpp
+++ b/test/unit/math/opencl/rev/append_col_test.cpp
@@ -1,0 +1,45 @@
+#ifdef STAN_OPENCL
+#include <stan/math.hpp>
+#include <test/unit/math/opencl/util.hpp>
+#include <test/unit/util.hpp>
+#include <gtest/gtest.h>
+
+auto append_col_functor
+    = [](const auto& a, const auto& b) { return stan::math::append_col(a, b); };
+
+TEST(OpenCLAppendCol, prim_rev_values_small) {
+  int N = 2;
+  int M1 = 3;
+  int M2 = 2;
+
+  Eigen::MatrixXd a(N, M1);
+  a << 1, 2, 3, 4, 5, 6;
+  Eigen::MatrixXd b(N, M2);
+  b << 12, 11, 10, 9;
+  stan::math::test::compare_cpu_opencl_prim_rev(append_col_functor, a, b);
+}
+
+TEST(OpenCLAppendCol, prim_rev_values_M_0) {
+  int N = 2;
+  int M = 0;
+
+  Eigen::MatrixXd a(N, M);
+  Eigen::MatrixXd b(N, M);
+  stan::math::test::compare_cpu_opencl_prim_rev(append_col_functor, a, b);
+
+  Eigen::MatrixXd c(M, N);
+  Eigen::MatrixXd d(M, N);
+  stan::math::test::compare_cpu_opencl_prim_rev(append_col_functor, c, d);
+}
+
+TEST(OpenCLAppendCol, prim_rev_values_large) {
+  int N = 71;
+  int M1 = 83;
+  int M2 = 93;
+
+  Eigen::MatrixXd a = Eigen::MatrixXd::Random(N, M1);
+  Eigen::MatrixXd b = Eigen::MatrixXd::Random(N, M2);
+  stan::math::test::compare_cpu_opencl_prim_rev(append_col_functor, a, b);
+}
+
+#endif

--- a/test/unit/math/opencl/rev/append_row_test.cpp
+++ b/test/unit/math/opencl/rev/append_row_test.cpp
@@ -1,0 +1,46 @@
+#ifdef STAN_OPENCL
+#include <stan/math.hpp>
+#include <test/unit/math/opencl/util.hpp>
+#include <test/unit/util.hpp>
+#include <gtest/gtest.h>
+
+auto append_row_functor
+    = [](const auto& a, const auto& b) { return stan::math::append_row(a, b); };
+
+TEST(OpenCLMatrix_append_row, prim_rev_values_small) {
+  int N1 = 2;
+  int N2 = 3;
+  int M = 3;
+
+  Eigen::MatrixXd a(N1, M);
+  a << 1, 2, 3, 4, 5, 6;
+  Eigen::MatrixXd b(N2, M);
+  b << 12, 11, 10, 9, 8, 7,6,5,4;
+  stan::math::test::compare_cpu_opencl_prim_rev(append_row_functor, a, b);
+}
+
+TEST(OpenCLAppendRow, prim_rev_values_M_0) {
+  int N1 = 2;
+  int N2 = 3;
+  int M = 0;
+
+  Eigen::MatrixXd a(N1, M);
+  Eigen::MatrixXd b(N2, M);
+  stan::math::test::compare_cpu_opencl_prim_rev(append_row_functor, a, b);
+
+  Eigen::MatrixXd c(M, N1);
+  Eigen::MatrixXd d(M, N1);
+  stan::math::test::compare_cpu_opencl_prim_rev(append_row_functor, c, d);
+}
+
+TEST(OpenCLAppendRow, prim_rev_values_large) {
+  int N1 = 71;
+  int N2 = 95;
+  int M = 83;
+
+  Eigen::MatrixXd a = Eigen::MatrixXd::Random(N1, M);
+  Eigen::MatrixXd b = Eigen::MatrixXd::Random(N2, M);
+  stan::math::test::compare_cpu_opencl_prim_rev(append_row_functor, a, b);
+}
+
+#endif

--- a/test/unit/math/opencl/rev/matrix_power_test.cpp
+++ b/test/unit/math/opencl/rev/matrix_power_test.cpp
@@ -1,0 +1,30 @@
+#ifdef STAN_OPENCL
+#include <stan/math/opencl/rev.hpp>
+#include <stan/math.hpp>
+#include <gtest/gtest.h>
+#include <test/unit/math/opencl/util.hpp>
+
+auto matrix_power_functor = [](const auto& a, int b) { return stan::math::matrix_power(a, b); };
+
+TEST(OpenCLMatrixPower, prim_rev_values_small) {
+  Eigen::MatrixXd a(3,3);
+  a << -2.2, -0.8, 0.5, 1, 1.5, 3, 3.4,
+      4, 0.4;
+  stan::math::test::compare_cpu_opencl_prim_rev(matrix_power_functor, a, 7);
+}
+
+TEST(OpenCLMatrixPower, prim_rev_size_0) {
+  int N = 0;
+
+  Eigen::MatrixXd a(N, N);
+  stan::math::test::compare_cpu_opencl_prim_rev(matrix_power_functor, a, 3);
+}
+
+TEST(OpenCLMatrixPower, prim_rev_values_large) {
+  int N = 71;
+
+  Eigen::MatrixXd a = Eigen::MatrixXd::Random(N, N);
+  stan::math::test::compare_cpu_opencl_prim_rev(matrix_power_functor, a, 17);
+}
+
+#endif

--- a/test/unit/math/opencl/rev/multiply_lower_tri_self_transpose_test.cpp
+++ b/test/unit/math/opencl/rev/multiply_lower_tri_self_transpose_test.cpp
@@ -1,0 +1,35 @@
+#ifdef STAN_OPENCL
+#include <stan/math/opencl/rev.hpp>
+#include <stan/math.hpp>
+#include <gtest/gtest.h>
+#include <test/unit/math/opencl/util.hpp>
+
+auto multiply_lower_tri_self_transpose_functor = [](const auto& a) {
+  return stan::math::multiply_lower_tri_self_transpose(a);
+};
+
+TEST(OpenCLMultiplyLowerTriSelfTranspose, prim_rev_values_small) {
+  Eigen::MatrixXd a(4, 2);
+  a << -2.2, -0.8, 0.5, 1, 1.5, 3, 3.4, 4;
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      multiply_lower_tri_self_transpose_functor, a);
+}
+
+TEST(OpenCLMultiplyLowerTriSelfTranspose, prim_rev_size_0) {
+  int N = 0;
+
+  Eigen::MatrixXd a(N, N);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      multiply_lower_tri_self_transpose_functor, a);
+}
+
+TEST(OpenCLMultiplyLowerTriSelfTranspose, prim_rev_values_large) {
+  int N = 71;
+  int M = 87;
+
+  Eigen::MatrixXd a = Eigen::MatrixXd::Random(N, M);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      multiply_lower_tri_self_transpose_functor, a);
+}
+
+#endif


### PR DESCRIPTION
## Summary

Adds OpenCL prim and rev implementations of `append_row`, `append_col`, `matrix_power` and `multiply_lower_tri_self_transpose`.

## Tests

New functions are tested.

## Side Effects
None.

## Release notes

Added OpenCL prim and rev implementations of `append_row`, `append_col`, `matrix_power` and `multiply_lower_tri_self_transpose`.

## Checklist

- [ ] Math issue #1854 

- [ ] Copyright holder: Tadej Ciglarič

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [ ] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [ ] the code is written in idiomatic C++ and changes are documented in the doxygen

- [ ] the new changes are tested
