### PR TITLE
Template from matrix cl

### DIFF
--- a/stan/math/opencl/err/check_diagonal_zeros.hpp
+++ b/stan/math/opencl/err/check_diagonal_zeros.hpp
@@ -37,7 +37,7 @@ inline void check_diagonal_zeros(const char* function, const char* name,
     matrix_cl<int> zeros_flag = constant(0, 1, 1);
     opencl_kernels::check_diagonal_zeros(cl::NDRange(y.rows(), y.cols()), y,
                                          zeros_flag, y.rows(), y.cols());
-    zero_on_diagonal_flag = from_matrix_cl_error_code(zeros_flag);
+    zero_on_diagonal_flag = from_matrix_cl<int>(zeros_flag);
     //  if zeros were found on the diagonal
     if (zero_on_diagonal_flag) {
       throw_domain_error(function, name, "has zeros on the diagonal.", "");

--- a/stan/math/opencl/err/check_nan.hpp
+++ b/stan/math/opencl/err/check_nan.hpp
@@ -34,7 +34,7 @@ inline void check_nan(const char* function, const char* name,
     nan_chk = to_matrix_cl(nan_flag);
     opencl_kernels::check_nan(cl::NDRange(y.rows(), y.cols()), y, nan_chk,
                               y.rows(), y.cols());
-    nan_flag = from_matrix_cl_error_code(nan_chk);
+    nan_flag = from_matrix_cl<int>(nan_chk);
     if (nan_flag) {
       throw_domain_error(function, name, "has NaN values", "");
     }

--- a/stan/math/opencl/err/check_symmetric.hpp
+++ b/stan/math/opencl/err/check_symmetric.hpp
@@ -37,7 +37,7 @@ inline void check_symmetric(const char* function, const char* name,
     opencl_kernels::check_symmetric(cl::NDRange(y.rows(), y.cols()), y,
                                     symm_flag, y.rows(), y.cols(),
                                     math::CONSTRAINT_TOLERANCE);
-    symmetric_flag = from_matrix_cl_error_code(symm_flag);
+    symmetric_flag = from_matrix_cl<int>(symm_flag);
     if (!symmetric_flag) {
       throw_domain_error(function, name, "is not symmetric", "");
     }

--- a/stan/math/opencl/kernel_generator/check_cl.hpp
+++ b/stan/math/opencl/kernel_generator/check_cl.hpp
@@ -160,12 +160,12 @@ class check_cl_ : public operation_cl_lhs<check_cl_<T>, bool> {
    */
   inline void add_write_event(cl::Event& e) const {
     e.wait();
-    Eigen::VectorXi res = from_matrix_cl<Eigen::Dynamic, 1>(buffer_);
+    Eigen::VectorXi res = from_matrix_cl<Eigen::VectorXi>(buffer_);
     if (res.coeff(0)) {
-      Eigen::VectorXd value = from_matrix_cl<Eigen::Dynamic, 1>(value_);
+      double value = from_matrix_cl<double>(value_);
       std::stringstream s;
       s << function_ << ": " << err_variable_ << "[" << res[1] << ", " << res[2]
-        << "] = " << value[0] << ", but it must be " << must_be_ << "!";
+        << "] = " << value << ", but it must be " << must_be_ << "!";
       throw std::domain_error(s.str());
     }
   }

--- a/stan/math/opencl/kernel_generator/check_cl.hpp
+++ b/stan/math/opencl/kernel_generator/check_cl.hpp
@@ -163,7 +163,7 @@ class check_cl_ : public operation_cl_lhs<check_cl_<T>, bool> {
     e.wait();
     Eigen::VectorXi res = from_matrix_cl<Eigen::VectorXi>(buffer_);
     if (res.coeff(0)) {
-      double value = from_matrix_cl<double>(value_);
+      double value = from_matrix_cl<scalar_type_t<T>>(value_);
       std::stringstream s;
       s << function_ << ": " << err_variable_ << "[" << res[1] << ", " << res[2]
         << "] = " << value << ", but it must be " << must_be_ << "!";

--- a/stan/math/opencl/prim/bernoulli_logit_glm_lpmf.hpp
+++ b/stan/math/opencl/prim/bernoulli_logit_glm_lpmf.hpp
@@ -120,7 +120,7 @@ return_type_t<T_x_cl, T_alpha_cl, T_beta_cl> bernoulli_logit_glm_lpmf(
       logp_expr, calc_if<need_theta_derivative>(theta_derivative_expr),
       calc_if<need_theta_derivative_sum>(colwise_sum(theta_derivative_expr)));
 
-  T_partials_return logp = sum(from_matrix_cl<Eigen::Dynamic, 1>(logp_cl));
+  T_partials_return logp = sum(from_matrix_cl(logp_cl));
   if (!std::isfinite(logp)) {
     results(check_cl(function, "Vector of dependent variables", y_val,
                      "in the interval [0, 1]"),

--- a/stan/math/opencl/prim/neg_binomial_2_log_glm_lpmf.hpp
+++ b/stan/math/opencl/prim/neg_binomial_2_log_glm_lpmf.hpp
@@ -149,7 +149,7 @@ neg_binomial_2_log_glm_lpmf(const T_y_cl& y, const T_x_cl& x,
     check_opencl_error(function, e);
   }
 
-  T_partials_return logp = sum(from_matrix_cl<Dynamic, 1>(logp_cl));
+  T_partials_return logp = sum(from_matrix_cl(logp_cl));
   if (!std::isfinite(logp)) {
     results(
         check_cl(function, "Vector of dependent variables", y_val,
@@ -205,7 +205,7 @@ neg_binomial_2_log_glm_lpmf(const T_y_cl& y, const T_x_cl& x,
     } else {
       forward_as<internal::broadcast_array<double>>(
           ops_partials.edge2_.partials_)[0]
-          = sum(from_matrix_cl<Dynamic, 1>(theta_derivative_sum_cl));
+          = sum(from_matrix_cl(theta_derivative_sum_cl));
     }
   }
   if (!is_constant_all<T_phi_cl>::value) {
@@ -214,7 +214,7 @@ neg_binomial_2_log_glm_lpmf(const T_y_cl& y, const T_x_cl& x,
     } else {
       forward_as<internal::broadcast_array<double>>(
           ops_partials.edge4_.partials_)[0]
-          = sum(from_matrix_cl<Dynamic, 1>(phi_derivative_cl));
+          = sum(from_matrix_cl(phi_derivative_cl));
     }
   }
   return ops_partials.build(logp);

--- a/stan/math/opencl/prim/poisson_log_glm_lpmf.hpp
+++ b/stan/math/opencl/prim/poisson_log_glm_lpmf.hpp
@@ -108,9 +108,8 @@ return_type_t<T_x_cl, T_alpha_cl, T_beta_cl> poisson_log_glm_lpmf(
   results(theta_derivative_cl, theta_derivative_sum_cl, logp_cl) = expressions(
       theta_derivative_expr, colwise_sum(theta_derivative_expr), logp_expr);
 
-  double theta_derivative_sum
-      = sum(from_matrix_cl<Dynamic, 1>(theta_derivative_sum_cl));
-  logp += sum(from_matrix_cl<Dynamic, 1>(logp_cl));
+  double theta_derivative_sum = sum(from_matrix_cl(theta_derivative_sum_cl));
+  logp += sum(from_matrix_cl(logp_cl));
   if (!std::isfinite(theta_derivative_sum)) {
     results(check_cl(function, "Vector of dependent variables", y_val,
                      "nonnegative"),

--- a/stan/math/opencl/prim/sum.hpp
+++ b/stan/math/opencl/prim/sum.hpp
@@ -28,7 +28,7 @@ value_type_t<T> sum(const T& m) {
   } else {
     res = colwise_sum(rowwise_sum(m));
   }
-  return sum(from_matrix_cl<Eigen::Dynamic, 1>(res));
+  return sum(from_matrix_cl(res));
 }
 
 }  // namespace math

--- a/stan/math/opencl/rev/copy.hpp
+++ b/stan/math/opencl/rev/copy.hpp
@@ -124,6 +124,18 @@ inline T_dst from_matrix_cl(const var_value<T>& a) {
       [a](auto& res_vari) mutable { a.adj() += to_matrix_cl(res_vari.adj()); });
 }
 
+template <typename T_dst, typename T,
+          require_eigen_vt<is_var, T_dst>* = nullptr,
+          require_all_kernel_expressions_t<T>* = nullptr>
+inline T_dst from_matrix_cl(const var_value<T>& a) {
+  arena_t<T_dst> res = from_matrix_cl<
+      Eigen::Matrix<double, T_dst::RowsAtCompileTime, T_dst::ColsAtCompileTime>>(
+      a.val());
+  reverse_pass_callback(
+        [a, res]() mutable { a.adj() += to_matrix_cl(res.adj()); });
+  return res;
+}
+
 template <typename T, require_all_kernel_expressions_t<T>* = nullptr>
 auto from_matrix_cl(const var_value<T>& src) {
   return from_matrix_cl<var_value<Eigen::MatrixXd>>(src);

--- a/stan/math/prim/fun/multiply.hpp
+++ b/stan/math/prim/fun/multiply.hpp
@@ -5,9 +5,6 @@
 #include <stan/math/prim/err.hpp>
 #include <stan/math/prim/fun/Eigen.hpp>
 #include <stan/math/prim/fun/dot_product.hpp>
-#ifdef STAN_OPENCL
-#include <stan/math/opencl/prim.hpp>
-#endif
 #include <type_traits>
 
 namespace stan {
@@ -63,53 +60,11 @@ inline auto multiply(Scal c, const Mat& m) {
  */
 template <typename Mat1, typename Mat2,
           require_all_eigen_vt<std::is_arithmetic, Mat1, Mat2>* = nullptr,
-          require_any_not_same_t<double, value_type_t<Mat1>,
-                                 value_type_t<Mat2>>* = nullptr,
           require_not_eigen_row_and_col_t<Mat1, Mat2>* = nullptr>
 inline auto multiply(const Mat1& m1, const Mat2& m2) {
   check_size_match("multiply", "Columns of m1", m1.cols(), "Rows of m2",
                    m2.rows());
   return m1 * m2;
-}
-
-/**
- * Return the product of the specified matrices. The number of
- * columns in the first matrix must be the same as the number of rows
- * in the second matrix. If scalar of matrices is \c double OpenCL
- * implementation can be used.
- *
- * @tparam Mat1 type of the first matrix or expression
- * @tparam Mat2 type of the second matrix or expression
- *
- * @param m1 first matrix or expression
- * @param m2 second matrix or expression
- * @return the product of the first and second matrices
- * @throw <code>std::invalid_argument</code> if the number of columns of m1 does
- * not match the number of rows of m2.
- */
-template <typename Mat1, typename Mat2,
-          require_all_eigen_t<Mat1, Mat2>* = nullptr,
-          require_all_same_t<double, value_type_t<Mat1>,
-                             value_type_t<Mat2>>* = nullptr,
-          require_not_eigen_row_and_col_t<Mat1, Mat2>* = nullptr>
-inline auto multiply(const Mat1& m1, const Mat2& m2)
-    -> decltype((m1 * m2).eval()) {
-  check_multiplicable("multiply", "m1", m1, "m2", m2);
-
-#ifdef STAN_OPENCL
-  if (m1.rows() * m1.cols() * m2.cols()
-      > opencl_context.tuning_opts().multiply_dim_prod_worth_transfer) {
-    matrix_cl<double> m1_cl(m1);
-    matrix_cl<double> m2_cl(m2);
-    matrix_cl<double> m3_cl = m1_cl * m2_cl;
-    return from_matrix_cl<Mat1::RowsAtCompileTime, Mat2::ColsAtCompileTime>(
-        m3_cl);
-  } else {
-    return (m1 * m2).eval();
-  }
-#else
-  return (m1 * m2).eval();
-#endif
 }
 
 /**

--- a/stan/math/rev/core/var.hpp
+++ b/stan/math/rev/core/var.hpp
@@ -311,14 +311,9 @@ class var_value<T, require_floating_point_t<T>> {
  */
 template <typename T>
 class var_value<
-    T,
-    require_t<bool_constant<
-        is_eigen<T>::value || is_kernel_expression_and_not_scalar<T>::value>>> {
-  static_assert(
-      std::is_floating_point<value_type_t<T>>::value,
-      "The template for must be a floating point or a container holding"
-      " floating point types");
-
+    T, require_t<bool_constant<
+           (is_eigen<T>::value || is_kernel_expression_and_not_scalar<T>::value)
+           && std::is_floating_point<value_type_t<T>>::value>>> {
  public:
   using value_type = T;  // type in vari_value.
   using vari_type = std::conditional_t<is_plain_type<value_type>::value,

--- a/test/unit/math/opencl/copy_test.cpp
+++ b/test/unit/math/opencl/copy_test.cpp
@@ -4,6 +4,7 @@
 #include <stan/math/opencl/matrix_cl.hpp>
 #include <stan/math/opencl/copy.hpp>
 #include <gtest/gtest.h>
+#include <test/unit/util.hpp>
 #include <CL/cl2.hpp>
 #include <algorithm>
 #include <vector>
@@ -244,9 +245,22 @@ TEST(MathMatrixGPU, matrix_cl_std_vector_copy) {
   EXPECT_NO_THROW(d_empty_cl = stan::math::to_matrix_cl(d_empty));
   EXPECT_NO_THROW(d1_cpu_ret
                   = stan::math::from_matrix_cl<std::vector<double>>(d11_cl));
-  EXPECT_EQ(10.0, d1_cpu_ret[0]);
-  EXPECT_EQ(20.0, d1_cpu_ret[1]);
-  EXPECT_EQ(30.0, d1_cpu_ret[2]);
+  EXPECT_STD_VECTOR_EQ(d1_cpu_ret, d1_cpu);
+}
+
+TEST(MathMatrixGPU, matrix_cl_std_vector_eigen_copy) {
+  Eigen::VectorXd v1(3);
+  v1 << 1, 2, 3;
+  Eigen::VectorXd v2(3);
+  v2 << 4, 5, 6;
+  std::vector<Eigen::VectorXd> v{v1, v2};
+  stan::math::matrix_cl<double> v_cl;
+  EXPECT_NO_THROW(v_cl = stan::math::to_matrix_cl(v));
+  std::vector<Eigen::VectorXd> v_ret;
+  EXPECT_NO_THROW(
+      v_ret = stan::math::from_matrix_cl<std::vector<Eigen::VectorXd>>(v_cl));
+  EXPECT_MATRIX_EQ(v_ret[0], v1);
+  EXPECT_MATRIX_EQ(v_ret[1], v2);
 }
 
 TEST(MathMatrixGPU, matrix_cl_packed_std_vector_copy_rvalue) {

--- a/test/unit/math/opencl/copy_test.cpp
+++ b/test/unit/math/opencl/copy_test.cpp
@@ -237,15 +237,16 @@ TEST(MathMatrixGPU, matrix_cl_vector_copy) {
 TEST(MathMatrixGPU, matrix_cl_std_vector_copy) {
   std::vector<double> d1_cpu{10.0, 20.0, 30.0};
   std::vector<double> d_empty;
-  stan::math::matrix_d d1_cpu_ret;
+  std::vector<double> d1_cpu_ret;
 
   stan::math::matrix_cl<double> d11_cl = stan::math::to_matrix_cl(d1_cpu);
   stan::math::matrix_cl<double> d_empty_cl;
   EXPECT_NO_THROW(d_empty_cl = stan::math::to_matrix_cl(d_empty));
-  EXPECT_NO_THROW(d1_cpu_ret = stan::math::from_matrix_cl(d11_cl));
-  EXPECT_EQ(10.0, d1_cpu_ret(0));
-  EXPECT_EQ(20.0, d1_cpu_ret(1));
-  EXPECT_EQ(30.0, d1_cpu_ret(2));
+  EXPECT_NO_THROW(d1_cpu_ret
+                  = stan::math::from_matrix_cl<std::vector<double>>(d11_cl));
+  EXPECT_EQ(10.0, d1_cpu_ret[0]);
+  EXPECT_EQ(20.0, d1_cpu_ret[1]);
+  EXPECT_EQ(30.0, d1_cpu_ret[2]);
 }
 
 TEST(MathMatrixGPU, matrix_cl_packed_std_vector_copy_rvalue) {

--- a/test/unit/math/opencl/copy_test.cpp
+++ b/test/unit/math/opencl/copy_test.cpp
@@ -301,7 +301,7 @@ TEST(MathMatrixCL, matrix_cl_matrix_copy_arithmetic) {
   // Use this for successful copy
   stan::math::matrix_cl<double> d22_cl(1, 1);
   EXPECT_NO_THROW(d22_cl = stan::math::to_matrix_cl(test_val));
-  EXPECT_NO_THROW(test_val = stan::math::from_matrix_cl_error_code(d22_cl));
+  EXPECT_NO_THROW(test_val = stan::math::from_matrix_cl<double>(d22_cl));
 }
 
 TEST(MathMatrixCL, matrix_cl_pack_unpack_copy_lower) {

--- a/test/unit/math/opencl/device_functions/binomial_coefficient_log_test.cpp
+++ b/test/unit/math/opencl/device_functions/binomial_coefficient_log_test.cpp
@@ -36,7 +36,7 @@ TEST(MathMatrixCL, binomial_coefficient_log) {
   stan::math::matrix_cl<double> b_cl(b);
   stan::math::matrix_cl<double> res_cl(1000, 1);
   binomial_coefficient_log(cl::NDRange(1000), res_cl, a_cl, b_cl);
-  Eigen::VectorXd res = stan::math::from_matrix_cl<-1, 1>(res_cl);
+  Eigen::VectorXd res = stan::math::from_matrix_cl<Eigen::VectorXd>(res_cl);
 
   EXPECT_NEAR_REL(res, stan::math::binomial_coefficient_log(a, b));
 }
@@ -52,7 +52,7 @@ TEST(MathMatrixCL, binomial_coefficient_log_edge_cases) {
   stan::math::matrix_cl<double> b_cl(b);
   stan::math::matrix_cl<double> res_cl(5, 1);
   binomial_coefficient_log(cl::NDRange(5), res_cl, a_cl, b_cl);
-  Eigen::VectorXd res = stan::math::from_matrix_cl<-1, 1>(res_cl);
+  Eigen::VectorXd res = stan::math::from_matrix_cl<Eigen::VectorXd>(res_cl);
 
   EXPECT_NEAR_REL(res, stan::math::binomial_coefficient_log(a, b));
 }

--- a/test/unit/math/opencl/device_functions/digamma_test.cpp
+++ b/test/unit/math/opencl/device_functions/digamma_test.cpp
@@ -24,7 +24,7 @@ TEST(MathMatrixCL, digamma) {
   stan::math::matrix_cl<double> a_cl(a);
   stan::math::matrix_cl<double> res_cl(1000, 1);
   digamma(cl::NDRange(1000), res_cl, a_cl);
-  Eigen::VectorXd res = stan::math::from_matrix_cl<-1, 1>(res_cl);
+  Eigen::VectorXd res = stan::math::from_matrix_cl<Eigen::VectorXd>(res_cl);
 
   stan::test::expect_near_rel("digamma (OpenCL)", res, stan::math::digamma(a));
 }
@@ -36,7 +36,7 @@ TEST(MathMatrixCL, digamma_edge_cases) {
   stan::math::matrix_cl<double> a_cl(a);
   stan::math::matrix_cl<double> res_cl(3, 1);
   digamma(cl::NDRange(3), res_cl, a_cl);
-  Eigen::VectorXd res = stan::math::from_matrix_cl<-1, 1>(res_cl);
+  Eigen::VectorXd res = stan::math::from_matrix_cl<Eigen::VectorXd>(res_cl);
 
   stan::test::expect_near_rel("digamma (OpenCL)", res, stan::math::digamma(a));
 }

--- a/test/unit/math/opencl/device_functions/lbeta_test.cpp
+++ b/test/unit/math/opencl/device_functions/lbeta_test.cpp
@@ -32,7 +32,7 @@ TEST(MathMatrixCL, lbeta) {
   stan::math::matrix_cl<double> b_cl(b);
   stan::math::matrix_cl<double> res_cl(1000, 1);
   lbeta(cl::NDRange(1000), res_cl, a_cl, b_cl);
-  Eigen::VectorXd res = stan::math::from_matrix_cl<-1, 1>(res_cl);
+  Eigen::VectorXd res = stan::math::from_matrix_cl<Eigen::VectorXd>(res_cl);
 
   EXPECT_NEAR_REL(res, stan::math::lbeta(a, b));
 }
@@ -48,7 +48,7 @@ TEST(MathMatrixCL, lbeta_edge_cases) {
   stan::math::matrix_cl<double> b_cl(b);
   stan::math::matrix_cl<double> res_cl(3, 1);
   lbeta(cl::NDRange(3), res_cl, a_cl, b_cl);
-  Eigen::VectorXd res = stan::math::from_matrix_cl<-1, 1>(res_cl);
+  Eigen::VectorXd res = stan::math::from_matrix_cl<Eigen::VectorXd>(res_cl);
 
   EXPECT_NEAR_REL(res, stan::math::lbeta(a, b));
 }

--- a/test/unit/math/opencl/device_functions/lgamma_stirling_diff_test.cpp
+++ b/test/unit/math/opencl/device_functions/lgamma_stirling_diff_test.cpp
@@ -28,7 +28,7 @@ TEST(MathMatrixCL, lgamma_stirling_diff) {
   stan::math::matrix_cl<double> a_cl(a);
   stan::math::matrix_cl<double> res_cl(1000, 1);
   lgamma_stirling_diff(cl::NDRange(1000), res_cl, a_cl);
-  Eigen::VectorXd res = stan::math::from_matrix_cl<-1, 1>(res_cl);
+  Eigen::VectorXd res = stan::math::from_matrix_cl<Eigen::VectorXd>(res_cl);
 
   EXPECT_NEAR_REL(res, a.unaryExpr([](double x) {
     return stan::math::lgamma_stirling_diff(x);
@@ -42,7 +42,7 @@ TEST(MathMatrixCL, lgamma_stirling_diff_edge_cases) {
   stan::math::matrix_cl<double> a_cl(a);
   stan::math::matrix_cl<double> res_cl(4, 1);
   lgamma_stirling_diff(cl::NDRange(4), res_cl, a_cl);
-  Eigen::VectorXd res = stan::math::from_matrix_cl<-1, 1>(res_cl);
+  Eigen::VectorXd res = stan::math::from_matrix_cl<Eigen::VectorXd>(res_cl);
 
   EXPECT_NEAR_REL(res, a.unaryExpr([](double x) {
     return stan::math::lgamma_stirling_diff(x);

--- a/test/unit/math/opencl/device_functions/lgamma_stirling_test.cpp
+++ b/test/unit/math/opencl/device_functions/lgamma_stirling_test.cpp
@@ -25,7 +25,7 @@ TEST(MathMatrixCL, lgamma_stirling) {
   stan::math::matrix_cl<double> a_cl(a);
   stan::math::matrix_cl<double> res_cl(1000, 1);
   lgamma_stirling(cl::NDRange(1000), res_cl, a_cl);
-  Eigen::VectorXd res = stan::math::from_matrix_cl<-1, 1>(res_cl);
+  Eigen::VectorXd res = stan::math::from_matrix_cl<Eigen::VectorXd>(res_cl);
 
   EXPECT_NEAR_REL(res, a.unaryExpr([](double x) {
     return stan::math::lgamma_stirling(x);
@@ -39,7 +39,7 @@ TEST(MathMatrixCL, lgamma_stirling_edge_cases) {
   stan::math::matrix_cl<double> a_cl(a);
   stan::math::matrix_cl<double> res_cl(3, 1);
   lgamma_stirling(cl::NDRange(3), res_cl, a_cl);
-  Eigen::VectorXd res = stan::math::from_matrix_cl<-1, 1>(res_cl);
+  Eigen::VectorXd res = stan::math::from_matrix_cl<Eigen::VectorXd>(res_cl);
 
   EXPECT_NEAR_REL(res, a.unaryExpr([](double x) {
     return stan::math::lgamma_stirling(x);

--- a/test/unit/math/opencl/device_functions/log1m_exp_test.cpp
+++ b/test/unit/math/opencl/device_functions/log1m_exp_test.cpp
@@ -24,7 +24,7 @@ TEST(MathMatrixCL, log1m_exp) {
   stan::math::matrix_cl<double> a_cl(a);
   stan::math::matrix_cl<double> res_cl(1000, 1);
   log1m_exp(cl::NDRange(1000), res_cl, a_cl);
-  Eigen::VectorXd res = stan::math::from_matrix_cl<-1, 1>(res_cl);
+  Eigen::VectorXd res = stan::math::from_matrix_cl<Eigen::VectorXd>(res_cl);
 
   stan::test::expect_near_rel("log1m_exp (OpenCL)", res,
                               stan::math::log1m_exp(a));
@@ -37,7 +37,7 @@ TEST(MathMatrixCL, log1m_exp_edge_cases) {
   stan::math::matrix_cl<double> a_cl(a);
   stan::math::matrix_cl<double> res_cl(11, 1);
   log1m_exp(cl::NDRange(11), res_cl, a_cl);
-  Eigen::VectorXd res = stan::math::from_matrix_cl<-1, 1>(res_cl);
+  Eigen::VectorXd res = stan::math::from_matrix_cl<Eigen::VectorXd>(res_cl);
 
   stan::test::expect_near_rel("log1m_exp (OpenCL)", res,
                               stan::math::log1m_exp(a));

--- a/test/unit/math/opencl/device_functions/log1p_exp_test.cpp
+++ b/test/unit/math/opencl/device_functions/log1p_exp_test.cpp
@@ -24,7 +24,7 @@ TEST(MathMatrixCL, log1p_exp) {
   stan::math::matrix_cl<double> a_cl(a);
   stan::math::matrix_cl<double> res_cl(1000, 1);
   log1p_exp(cl::NDRange(1000), res_cl, a_cl);
-  Eigen::VectorXd res = stan::math::from_matrix_cl<-1, 1>(res_cl);
+  Eigen::VectorXd res = stan::math::from_matrix_cl<Eigen::VectorXd>(res_cl);
 
   stan::test::expect_near_rel("log1p_exp (OpenCL)", res,
                               stan::math::log1p_exp(a));
@@ -37,7 +37,7 @@ TEST(MathMatrixCL, log1p_exp_edge_cases) {
   stan::math::matrix_cl<double> a_cl(a);
   stan::math::matrix_cl<double> res_cl(3, 1);
   log1p_exp(cl::NDRange(3), res_cl, a_cl);
-  Eigen::VectorXd res = stan::math::from_matrix_cl<-1, 1>(res_cl);
+  Eigen::VectorXd res = stan::math::from_matrix_cl<Eigen::VectorXd>(res_cl);
 
   stan::test::expect_near_rel("log1p_exp (OpenCL)", res,
                               stan::math::log1p_exp(a));

--- a/test/unit/math/opencl/device_functions/multiply_log_test.cpp
+++ b/test/unit/math/opencl/device_functions/multiply_log_test.cpp
@@ -28,7 +28,7 @@ TEST(MathMatrixCL, multiply_log) {
   stan::math::matrix_cl<double> b_cl(b);
   stan::math::matrix_cl<double> res_cl(1000, 1);
   multiply_log(cl::NDRange(1000), res_cl, a_cl, b_cl);
-  Eigen::VectorXd res = stan::math::from_matrix_cl<-1, 1>(res_cl);
+  Eigen::VectorXd res = stan::math::from_matrix_cl<Eigen::VectorXd>(res_cl);
 
   EXPECT_NEAR_REL(res, stan::math::multiply_log(a, b));
 }
@@ -44,7 +44,7 @@ TEST(MathMatrixCL, multiply_log_edge_cases) {
   stan::math::matrix_cl<double> b_cl(b);
   stan::math::matrix_cl<double> res_cl(7, 1);
   multiply_log(cl::NDRange(7), res_cl, a_cl, b_cl);
-  Eigen::VectorXd res = stan::math::from_matrix_cl<-1, 1>(res_cl);
+  Eigen::VectorXd res = stan::math::from_matrix_cl<Eigen::VectorXd>(res_cl);
 
   EXPECT_NEAR_REL(res, stan::math::multiply_log(a, b));
 }

--- a/test/unit/math/opencl/pinned_matrix_test.cpp
+++ b/test/unit/math/opencl/pinned_matrix_test.cpp
@@ -10,24 +10,38 @@ TEST(AgradRev, pinned_matrix_matrix_test) {
 
   // construction
   pinned_matrix<MatrixXd> a;
-  pinned_matrix<MatrixXd> a2;
-  pinned_matrix<MatrixXd> a3;
-  pinned_matrix<MatrixXd> b(3, 2);
+  pinned_matrix<MatrixXd> a2(a);
+  pinned_matrix<MatrixXd> a3(std::move(a));
+  pinned_matrix<MatrixXd> b(4, 5);
   pinned_matrix<MatrixXd> b2(4, 5);
+  pinned_matrix<MatrixXd> b3(4, 5);
   pinned_matrix<MatrixXd> c(MatrixXd::Ones(3, 2));
   pinned_matrix<MatrixXd> d(c);
-  pinned_matrix<MatrixXd> e(2 * d);
+  pinned_matrix<MatrixXd> e(std::move(c));
+  pinned_matrix<MatrixXd> f(2 * d);
+  pinned_matrix<MatrixXd> g(0, 0);
 
   // assignment
-  a = c;
+  a = e;
   a2 = std::move(d);
   a3 = 2 * a;
-  b = d;
-  b2 = std::move(c);
-  e = e + a;
-  a = MatrixXd::Ones(3, 2);
+  b = a;
+  b2 = std::move(a);
+  b3 = 2 * a2;
+  e = e + a2;
+  e += a2;
 
-  EXPECT_MATRIX_EQ(a + a2 + a3 + b + b2 + e, MatrixXd::Ones(3, 2) * 9);
+  EXPECT_MATRIX_EQ(a, MatrixXd(0, 0));
+  EXPECT_MATRIX_EQ(a2, MatrixXd::Ones(3, 2));
+  EXPECT_MATRIX_EQ(a3, MatrixXd::Ones(3, 2) * 2);
+  EXPECT_MATRIX_EQ(b, MatrixXd::Ones(3, 2));
+  EXPECT_MATRIX_EQ(b2, MatrixXd::Ones(3, 2));
+  EXPECT_MATRIX_EQ(b3, MatrixXd::Ones(3, 2) * 2);
+  EXPECT_MATRIX_EQ(c, MatrixXd(0, 0));
+  EXPECT_MATRIX_EQ(d, MatrixXd(0, 0));
+  EXPECT_MATRIX_EQ(e, MatrixXd::Ones(3, 2) * 3);
+  EXPECT_MATRIX_EQ(f, MatrixXd::Ones(3, 2) * 2);
+
   stan::math::recover_memory();
 }
 
@@ -37,24 +51,38 @@ TEST(AgradRev, pinned_matrix_vector_test) {
 
   // construction
   pinned_matrix<VectorXd> a;
-  pinned_matrix<VectorXd> a2;
-  pinned_matrix<VectorXd> a3;
-  pinned_matrix<VectorXd> b(3);
+  pinned_matrix<VectorXd> a2(a);
+  pinned_matrix<VectorXd> a3(std::move(a));
+  pinned_matrix<VectorXd> b(4);
   pinned_matrix<VectorXd> b2(4);
+  pinned_matrix<VectorXd> b3(4);
   pinned_matrix<VectorXd> c(VectorXd::Ones(3));
   pinned_matrix<VectorXd> d(c);
-  pinned_matrix<VectorXd> e(2 * d);
+  pinned_matrix<VectorXd> e(std::move(c));
+  pinned_matrix<VectorXd> f(2 * d);
+  pinned_matrix<VectorXd> g(0);
 
   // assignment
-  a = c;
+  a = e;
   a2 = std::move(d);
   a3 = 2 * a;
-  b = d;
-  b2 = std::move(c);
-  e = e + a;
-  a = VectorXd::Ones(3);
+  b = a;
+  b2 = std::move(a);
+  b3 = 2 * a2;
+  e = e + a2;
+  e += a2;
 
-  EXPECT_MATRIX_EQ(a + a2 + a3 + b + b2 + e, VectorXd::Ones(3) * 9);
+  EXPECT_MATRIX_EQ(a, VectorXd(0));
+  EXPECT_MATRIX_EQ(a2, VectorXd::Ones(3));
+  EXPECT_MATRIX_EQ(a3, VectorXd::Ones(3) * 2);
+  EXPECT_MATRIX_EQ(b, VectorXd::Ones(3));
+  EXPECT_MATRIX_EQ(b2, VectorXd::Ones(3));
+  EXPECT_MATRIX_EQ(b3, VectorXd::Ones(3) * 2);
+  EXPECT_MATRIX_EQ(c, VectorXd(0));
+  EXPECT_MATRIX_EQ(d, VectorXd(0));
+  EXPECT_MATRIX_EQ(e, VectorXd::Ones(3) * 3);
+  EXPECT_MATRIX_EQ(f, VectorXd::Ones(3) * 2);
+
   stan::math::recover_memory();
 }
 
@@ -64,24 +92,37 @@ TEST(AgradRev, pinned_matrix_row_vector_test) {
 
   // construction
   pinned_matrix<RowVectorXd> a;
-  pinned_matrix<RowVectorXd> a2;
-  pinned_matrix<RowVectorXd> a3;
-  pinned_matrix<RowVectorXd> b(3);
+  pinned_matrix<RowVectorXd> a2(a);
+  pinned_matrix<RowVectorXd> a3(std::move(a));
+  pinned_matrix<RowVectorXd> b(4);
   pinned_matrix<RowVectorXd> b2(4);
+  pinned_matrix<RowVectorXd> b3(4);
   pinned_matrix<RowVectorXd> c(RowVectorXd::Ones(3));
   pinned_matrix<RowVectorXd> d(c);
-  pinned_matrix<RowVectorXd> e(2 * d);
+  pinned_matrix<RowVectorXd> e(std::move(c));
+  pinned_matrix<RowVectorXd> f(2 * d);
+  pinned_matrix<RowVectorXd> g(0);
 
   // assignment
-  a = c;
+  a = e;
   a2 = std::move(d);
   a3 = 2 * a;
-  b = d;
-  b2 = std::move(c);
-  e = e + a;
-  a = RowVectorXd::Ones(3);
+  b = a;
+  b2 = std::move(a);
+  b3 = 2 * a2;
+  e = e + a2;
+  e += a2;
 
-  EXPECT_MATRIX_EQ(a + a2 + a3 + b + b2 + e, RowVectorXd::Ones(3) * 9);
+  EXPECT_MATRIX_EQ(a, RowVectorXd(0));
+  EXPECT_MATRIX_EQ(a2, RowVectorXd::Ones(3));
+  EXPECT_MATRIX_EQ(a3, RowVectorXd::Ones(3) * 2);
+  EXPECT_MATRIX_EQ(b, RowVectorXd::Ones(3));
+  EXPECT_MATRIX_EQ(b2, RowVectorXd::Ones(3));
+  EXPECT_MATRIX_EQ(b3, RowVectorXd::Ones(3) * 2);
+  EXPECT_MATRIX_EQ(c, RowVectorXd(0));
+  EXPECT_MATRIX_EQ(d, RowVectorXd(0));
+  EXPECT_MATRIX_EQ(e, RowVectorXd::Ones(3) * 3);
+
   stan::math::recover_memory();
 }
 

--- a/test/unit/math/opencl/rev/copy_test.cpp
+++ b/test/unit/math/opencl/rev/copy_test.cpp
@@ -74,7 +74,7 @@ TEST(MathMatrixGPU, std_vector_matrix_var_to_matrix_cl) {
   }
 }
 
-TEST(VariCL, from_matrix_cl) {
+TEST(VariCL, var_matrix_from_matrix_cl) {
   using stan::math::var_value;
   Eigen::MatrixXd vals(2, 3);
   vals << 1, 2, 3, 4, 5, 6;
@@ -84,6 +84,21 @@ TEST(VariCL, from_matrix_cl) {
   EXPECT_MATRIX_EQ(a.val(), vals);
   a.adj() = Eigen::MatrixXd::Constant(2, 3, 1);
   a.vi_->chain();
+  EXPECT_MATRIX_EQ(from_matrix_cl(a_cl.adj()),
+                   Eigen::MatrixXd::Constant(2, 3, 1));
+}
+
+TEST(VariCL, eigen_var_from_matrix_cl) {
+  using stan::math::var_value;
+  Eigen::MatrixXd vals(2, 3);
+  vals << 1, 2, 3, 4, 5, 6;
+  stan::math::matrix_cl<double> vals_cl(vals);
+  var_value<stan::math::matrix_cl<double>> a_cl(vals_cl);
+  stan::math::matrix_v a
+      = stan::math::from_matrix_cl<stan::math::matrix_v>(a_cl);
+  EXPECT_MATRIX_EQ(a.val(), vals);
+  a.adj() = Eigen::MatrixXd::Constant(2, 3, 1);
+  stan::math::grad();
   EXPECT_MATRIX_EQ(from_matrix_cl(a_cl.adj()),
                    Eigen::MatrixXd::Constant(2, 3, 1));
 }

--- a/test/unit/math/opencl/rev/copy_test.cpp
+++ b/test/unit/math/opencl/rev/copy_test.cpp
@@ -129,7 +129,8 @@ TEST(VariCL, std_vector_var_eigen_from_matrix_cl) {
   stan::math::matrix_cl<double> vals_cl(vals);
   var_value<stan::math::matrix_cl<double>> a_cl(vals_cl);
   std::vector<var_value<Eigen::VectorXd>> a
-      = stan::math::from_matrix_cl<std::vector<var_value<Eigen::VectorXd>>>(a_cl);
+      = stan::math::from_matrix_cl<std::vector<var_value<Eigen::VectorXd>>>(
+          a_cl);
   EXPECT_MATRIX_EQ(stan::math::value_of(a[0]), vals.col(0));
   EXPECT_MATRIX_EQ(stan::math::value_of(a[1]), vals.col(1));
   EXPECT_MATRIX_EQ(stan::math::value_of(a[2]), vals.col(2));

--- a/test/unit/math/opencl/rev/copy_test.cpp
+++ b/test/unit/math/opencl/rev/copy_test.cpp
@@ -103,4 +103,65 @@ TEST(VariCL, eigen_var_from_matrix_cl) {
                    Eigen::MatrixXd::Constant(2, 3, 1));
 }
 
+TEST(VariCL, std_vector_var_from_matrix_cl) {
+  using stan::math::var;
+  using stan::math::var_value;
+  std::vector<double> vals{1, 2, 3, 4, 5, 6};
+  stan::math::matrix_cl<double> vals_cl(vals);
+  var_value<stan::math::matrix_cl<double>> a_cl(vals_cl);
+  std::vector<var> a = stan::math::from_matrix_cl<std::vector<var>>(a_cl);
+  EXPECT_STD_VECTOR_EQ(stan::math::value_of(a), vals);
+  stan::math::as_column_vector_or_scalar(a).adj()
+      = Eigen::VectorXd::Constant(6, 1.0);
+  stan::math::grad();
+  EXPECT_MATRIX_EQ(from_matrix_cl(a_cl.adj()),
+                   Eigen::VectorXd::Constant(6, 1.0));
+}
+
+TEST(VariCL, std_vector_var_eigen_from_matrix_cl) {
+  using stan::math::var;
+  using stan::math::var_value;
+  using stan::math::vector_v;
+
+  Eigen::MatrixXd vals(2, 3);
+  vals << 1, 2, 3, 4, 5, 6;
+
+  stan::math::matrix_cl<double> vals_cl(vals);
+  var_value<stan::math::matrix_cl<double>> a_cl(vals_cl);
+  std::vector<var_value<Eigen::VectorXd>> a
+      = stan::math::from_matrix_cl<std::vector<var_value<Eigen::VectorXd>>>(a_cl);
+  EXPECT_MATRIX_EQ(stan::math::value_of(a[0]), vals.col(0));
+  EXPECT_MATRIX_EQ(stan::math::value_of(a[1]), vals.col(1));
+  EXPECT_MATRIX_EQ(stan::math::value_of(a[2]), vals.col(2));
+  a[0].adj() = Eigen::VectorXd::Constant(2, 2.0);
+  a[1].adj() = Eigen::VectorXd::Constant(2, 2.0);
+  a[2].adj() = Eigen::VectorXd::Constant(2, 2.0);
+  stan::math::grad();
+  EXPECT_MATRIX_EQ(from_matrix_cl(a_cl.adj()),
+                   Eigen::MatrixXd::Constant(2, 3, 2.0));
+}
+
+TEST(VariCL, std_vector_eigen_var_from_matrix_cl) {
+  using stan::math::var;
+  using stan::math::var_value;
+  using stan::math::vector_v;
+
+  Eigen::MatrixXd vals(2, 3);
+  vals << 1, 2, 3, 4, 5, 6;
+
+  stan::math::matrix_cl<double> vals_cl(vals);
+  var_value<stan::math::matrix_cl<double>> a_cl(vals_cl);
+  std::vector<vector_v> a
+      = stan::math::from_matrix_cl<std::vector<vector_v>>(a_cl);
+  EXPECT_MATRIX_EQ(stan::math::value_of(a[0]), vals.col(0));
+  EXPECT_MATRIX_EQ(stan::math::value_of(a[1]), vals.col(1));
+  EXPECT_MATRIX_EQ(stan::math::value_of(a[2]), vals.col(2));
+  a[0].adj() = Eigen::VectorXd::Constant(2, 2.0);
+  a[1].adj() = Eigen::VectorXd::Constant(2, 2.0);
+  a[2].adj() = Eigen::VectorXd::Constant(2, 2.0);
+  stan::math::grad();
+  EXPECT_MATRIX_EQ(from_matrix_cl(a_cl.adj()),
+                   Eigen::MatrixXd::Constant(2, 3, 2.0));
+}
+
 #endif


### PR DESCRIPTION
## Summary
`from_matrix_cl` can now accept an explicit template parameter specifying desired return type. It the parameter is not specified it defaults to `var_value<Eiggen::MatrixXd>` for `var_value<matrix_cl<double>>` and `Eigen::Matrix` otherwise (same as before). Supported types are: arithmetic types, Eigen matrices and vectors of arithmetic types or vars, vars containing Eigen types, std vectors containing arithmetic types or vars or Eigen vectors. 

For returning a scalar the input `matrix_cl` must be of size 1x1. For returning a std vector the input `matrix_cl` must have a single column.

This replaces `from_matrix_cl_error_code`.

This PR also contains a fix for an issue in `pinned_matrix`, which caused memory leaks on some OpenCL platforms.

## Tests
New overloads of `from_matrix_cl` are tested.

## Side Effects
Explicitly specifying dimensions of returned Eigen type is not supported anymore. Whole return type must be specified instead.

## Release notes
`from_matrix_cl` can now accept an explicit template parameter specifying desired return type. Supported types are: arithmetic types, Eigen matrices and vectors of arithmetic types or vars, vars containing Eigen types, std vectors containing arithmetic types or vars or Eigen vectors. 

## Checklist

- [ ] Math issue #(issue number)

- [ ] Copyright holder: Tadej Ciglarič

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [ ] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [ ] the code is written in idiomatic C++ and changes are documented in the doxygen

- [ ] the new changes are tested
