### PR TITLE
Move validate_*_index from generated code to Math

### DIFF
--- a/stan/math/prim/err.hpp
+++ b/stan/math/prim/err.hpp
@@ -75,5 +75,7 @@
 #include <stan/math/prim/err/throw_domain_error.hpp>
 #include <stan/math/prim/err/throw_domain_error_vec.hpp>
 #include <stan/math/prim/err/validate_non_negative_index.hpp>
+#include <stan/math/prim/err/validate_positive_index.hpp>
+#include <stan/math/prim/err/validate_unit_vector_index.hpp>
 
 #endif

--- a/stan/math/prim/err/validate_positive_index.hpp
+++ b/stan/math/prim/err/validate_positive_index.hpp
@@ -9,6 +9,14 @@
 namespace stan {
 namespace math {
 
+/**
+ * Check that simplex is at least size 1
+ *
+ * @param var_name Name of simplex variable
+ * @param expr Expression in which variable is declared
+ * @param val Size of simplex
+ * @throw std::invalid_argument if simplex size is less than 1
+ */
 inline void validate_positive_index(const char* var_name, const char* expr,
                                     int val) {
   if (val < 1) {

--- a/stan/math/prim/err/validate_positive_index.hpp
+++ b/stan/math/prim/err/validate_positive_index.hpp
@@ -1,0 +1,28 @@
+#ifndef STAN_MATH_PRIM_ERR_VALIDATE_POSITIVE_INDEX_HPP
+#define STAN_MATH_PRIM_ERR_VALIDATE_POSITIVE_INDEX_HPP
+
+#include <stan/math/prim/meta.hpp>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+
+namespace stan {
+namespace math {
+
+inline void validate_positive_index(const char* var_name, const char* expr,
+                                    int val) {
+  if (val < 1) {
+    [&]() STAN_COLD_PATH {
+      std::stringstream msg;
+      msg << "Found dimension size less than one in simplex declaration"
+          << "; variable=" << var_name << "; dimension size expression=" << expr
+          << "; expression value=" << val;
+      std::string msg_str(msg.str());
+      throw std::invalid_argument(msg_str.c_str());
+    }();
+  }
+}
+
+}  // namespace math
+}  // namespace stan
+#endif

--- a/stan/math/prim/err/validate_unit_vector_index.hpp
+++ b/stan/math/prim/err/validate_unit_vector_index.hpp
@@ -1,0 +1,35 @@
+#ifndef STAN_MATH_PRIM_ERR_VALIDATE_UNIT_VECTOR_INDEX_HPP
+#define STAN_MATH_PRIM_ERR_VALIDATE_UNIT_VECTOR_INDEX_HPP
+
+#include <stan/math/prim/meta.hpp>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+
+namespace stan {
+namespace math {
+
+inline void validate_unit_vector_index(const char* var_name, const char* expr,
+                                       int val) {
+  if (val <= 1) {
+    [&]() STAN_COLD_PATH {
+      std::stringstream msg;
+      if (val == 1) {
+        msg << "Found dimension size one in unit vector declaration."
+            << " One-dimensional unit vector is discrete"
+            << " but the target distribution must be continuous."
+            << " variable=" << var_name << "; dimension size expression=" << expr;
+      } else {
+        msg << "Found dimension size less than one in unit vector declaration"
+            << "; variable=" << var_name << "; dimension size expression=" << expr
+            << "; expression value=" << val;
+      }
+      std::string msg_str(msg.str());
+      throw std::invalid_argument(msg_str.c_str());
+    }();
+  }
+}
+
+}  // namespace math
+}  // namespace stan
+#endif

--- a/stan/math/prim/err/validate_unit_vector_index.hpp
+++ b/stan/math/prim/err/validate_unit_vector_index.hpp
@@ -18,10 +18,12 @@ inline void validate_unit_vector_index(const char* var_name, const char* expr,
         msg << "Found dimension size one in unit vector declaration."
             << " One-dimensional unit vector is discrete"
             << " but the target distribution must be continuous."
-            << " variable=" << var_name << "; dimension size expression=" << expr;
+            << " variable=" << var_name
+            << "; dimension size expression=" << expr;
       } else {
         msg << "Found dimension size less than one in unit vector declaration"
-            << "; variable=" << var_name << "; dimension size expression=" << expr
+            << "; variable=" << var_name
+            << "; dimension size expression=" << expr
             << "; expression value=" << val;
       }
       std::string msg_str(msg.str());

--- a/stan/math/prim/err/validate_unit_vector_index.hpp
+++ b/stan/math/prim/err/validate_unit_vector_index.hpp
@@ -9,6 +9,14 @@
 namespace stan {
 namespace math {
 
+/**
+ * Check that unit vector is at least size 2
+ *
+ * @param var_name Name of unit vector variable
+ * @param expr Expression in which variable is declared
+ * @param val Size of unit vector
+ * @throw std::invalid_argument if simplex size is less than 2
+ */
 inline void validate_unit_vector_index(const char* var_name, const char* expr,
                                        int val) {
   if (val <= 1) {

--- a/test/unit/math/prim/err/validate_non_negative_index_test.cpp
+++ b/test/unit/math/prim/err/validate_non_negative_index_test.cpp
@@ -1,0 +1,11 @@
+#include <stan/math/prim.hpp>
+#include <gtest/gtest.h>
+#include <limits>
+
+TEST(ErrorHandling, validate_unit_vector_index) {
+  EXPECT_THROW(stan::math::validate_non_negative_index("unit_vector", "x", -5),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::validate_non_negative_index("unit_vector", "x", -1),
+               std::invalid_argument);
+  EXPECT_NO_THROW(stan::math::validate_non_negative_index("unit_vector", "x", 0));
+}

--- a/test/unit/math/prim/err/validate_non_negative_index_test.cpp
+++ b/test/unit/math/prim/err/validate_non_negative_index_test.cpp
@@ -7,5 +7,6 @@ TEST(ErrorHandling, validate_unit_vector_index) {
                std::invalid_argument);
   EXPECT_THROW(stan::math::validate_non_negative_index("unit_vector", "x", -1),
                std::invalid_argument);
-  EXPECT_NO_THROW(stan::math::validate_non_negative_index("unit_vector", "x", 0));
+  EXPECT_NO_THROW(
+      stan::math::validate_non_negative_index("unit_vector", "x", 0));
 }

--- a/test/unit/math/prim/err/validate_positive_index_test.cpp
+++ b/test/unit/math/prim/err/validate_positive_index_test.cpp
@@ -1,0 +1,11 @@
+#include <stan/math/prim.hpp>
+#include <gtest/gtest.h>
+#include <limits>
+
+TEST(ErrorHandling, validate_unit_vector_index) {
+  EXPECT_THROW(stan::math::validate_positive_index("unit_vector", "x", -1),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::validate_positive_index("unit_vector", "x", 0),
+               std::invalid_argument);
+  EXPECT_NO_THROW(stan::math::validate_positive_index("unit_vector", "x", 5));
+}

--- a/test/unit/math/prim/err/validate_unit_vector_index_test.cpp
+++ b/test/unit/math/prim/err/validate_unit_vector_index_test.cpp
@@ -1,0 +1,11 @@
+#include <stan/math/prim.hpp>
+#include <gtest/gtest.h>
+#include <limits>
+
+TEST(ErrorHandling, validate_unit_vector_index) {
+  EXPECT_THROW(stan::math::validate_unit_vector_index("unit_vector", "x", 0),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::validate_unit_vector_index("unit_vector", "x", 1),
+               std::invalid_argument);
+  EXPECT_NO_THROW(stan::math::validate_unit_vector_index("unit_vector", "x", 5));
+}

--- a/test/unit/math/prim/err/validate_unit_vector_index_test.cpp
+++ b/test/unit/math/prim/err/validate_unit_vector_index_test.cpp
@@ -7,5 +7,6 @@ TEST(ErrorHandling, validate_unit_vector_index) {
                std::invalid_argument);
   EXPECT_THROW(stan::math::validate_unit_vector_index("unit_vector", "x", 1),
                std::invalid_argument);
-  EXPECT_NO_THROW(stan::math::validate_unit_vector_index("unit_vector", "x", 5));
+  EXPECT_NO_THROW(
+      stan::math::validate_unit_vector_index("unit_vector", "x", 5));
 }


### PR DESCRIPTION
## Summary

Adds validate_positive_index and validate_unit_vector_index that are now generated with each stanc3 code gen unnecessarily.
Also adds tests for validate_non_negative_index.

## Tests

New tests for all. Added missing for the validate_non_negative_index

## Side Effects

/

## Release notes

Added validate_positive_index and validate_unit_vector_index to clean up generated Stanc3 code.

## Checklist

- [x] Copyright holder: Rok Češnovar

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

