### PR TITLE
Revert "Add tests for var_value<Matrix> for univariate distributions"

### DIFF
--- a/make/tests
+++ b/make/tests
@@ -121,15 +121,15 @@ test/prob/generate_tests$(EXE) : test/prob/generate_tests.cpp
 
 
 ## FIXME: think about how to do this generally using test_types
-# test_types := v fd fv ffd ffv vv
+# test_types := v fd fv ffd ffv
 
 test_name = $(shell echo $(1) | sed 's,_[0-9]\{5\},_test.hpp,g')
 
 .SECONDEXPANSION:
-test/prob/%_generated_v_test.cpp test/prob/%_generated_fd_test.cpp test/prob/%_generated_fv_test.cpp test/prob/%_generated_ffd_test.cpp test/prob/%_generated_ffv_test.cpp test/prob/%_generated_vv_test.cpp: test/prob/$$(call test_name,$$*) test/prob/generate_tests$(EXE)
+test/prob/%_generated_v_test.cpp test/prob/%_generated_fd_test.cpp test/prob/%_generated_fv_test.cpp test/prob/%_generated_ffd_test.cpp test/prob/%_generated_ffv_test.cpp: test/prob/$$(call test_name,$$*) test/prob/generate_tests$(EXE)
 	$(WINE) test/prob/generate_tests$(EXE) $< $(N_TESTS)
 
-LIST_OF_GENERATED_TESTS := $(shell find test/prob -type f -name '*_test.hpp' | sed 's,_test.hpp,_00000_generated_v_test.cpp,g') $(shell find test/prob -type f -name '*_test.hpp' | sed 's,_test.hpp,_00000_generated_fd_test.cpp,g') $(shell find test/prob -type f -name '*_test.hpp' | sed 's,_test.hpp,_00000_generated_fv_test.cpp,g') $(shell find test/prob -type f -name '*_test.hpp' | sed 's,_test.hpp,_00000_generated_ffd_test.cpp,g') $(shell find test/prob -type f -name '*_test.hpp' | sed 's,_test.hpp,_00000_generated_ffv_test.cpp,g') $(shell find test/prob -type f -name '*_test.hpp' | sed 's,_test.hpp,_00000_generated_vv_test.cpp,g')
+LIST_OF_GENERATED_TESTS := $(shell find test/prob -type f -name '*_test.hpp' | sed 's,_test.hpp,_00000_generated_v_test.cpp,g') $(shell find test/prob -type f -name '*_test.hpp' | sed 's,_test.hpp,_00000_generated_fd_test.cpp,g') $(shell find test/prob -type f -name '*_test.hpp' | sed 's,_test.hpp,_00000_generated_fv_test.cpp,g') $(shell find test/prob -type f -name '*_test.hpp' | sed 's,_test.hpp,_00000_generated_ffd_test.cpp,g') $(shell find test/prob -type f -name '*_test.hpp' | sed 's,_test.hpp,_00000_generated_ffv_test.cpp,g')
 
 .PHONY: generate-tests
 generate-tests: $(LIST_OF_GENERATED_TESTS)

--- a/stan/math/fwd/core/operator_division.hpp
+++ b/stan/math/fwd/core/operator_division.hpp
@@ -33,8 +33,7 @@ inline fvar<T> operator/(const fvar<T>& x1, const fvar<T>& x2) {
  */
 template <typename T, typename U, require_arithmetic_t<U>* = nullptr>
 inline fvar<T> operator/(const fvar<T>& x1, U x2) {
-  return fvar<T>(x1.val_ / static_cast<double>(x2),
-                 x1.d_ / static_cast<double>(x2));
+  return fvar<T>(x1.val_ / x2, x1.d_ / x2);
 }
 
 /**
@@ -47,8 +46,7 @@ inline fvar<T> operator/(const fvar<T>& x1, U x2) {
  */
 template <typename T, typename U, require_arithmetic_t<U>* = nullptr>
 inline fvar<T> operator/(U x1, const fvar<T>& x2) {
-  return fvar<T>(static_cast<double>(x1) / x2.val_,
-                 -static_cast<double>(x1) * x2.d_ / (x2.val_ * x2.val_));
+  return fvar<T>(x1 / x2.val_, -x1 * x2.d_ / (x2.val_ * x2.val_));
 }
 
 template <typename T>

--- a/stan/math/prim/fun/scalar_seq_view.hpp
+++ b/stan/math/prim/fun/scalar_seq_view.hpp
@@ -62,7 +62,7 @@ class scalar_seq_view<C, require_var_matrix_t<C>> {
    * @param i index
    * @return the element at the specified position in the container
    */
-  inline auto operator[](size_t i) const { return c_.coeff(i); }
+  inline auto operator[](size_t i) const { return c_.val().coeffRef(i); }
   inline const auto* data() const noexcept { return c_.vi_; }
   inline auto* data() noexcept { return c_.vi_; }
 
@@ -70,7 +70,7 @@ class scalar_seq_view<C, require_var_matrix_t<C>> {
 
   template <typename T = C, require_st_autodiff<T>* = nullptr>
   inline auto val(size_t i) const {
-    return c_.val().coeff(i);
+    return c_.val().coeffRef(i);
   }
 
   template <typename T = C, require_st_autodiff<T>* = nullptr>

--- a/stan/math/prim/meta.hpp
+++ b/stan/math/prim/meta.hpp
@@ -178,6 +178,7 @@
 #include <stan/math/prim/meta/compiler_attributes.hpp>
 #include <stan/math/prim/meta/contains_fvar.hpp>
 #include <stan/math/prim/meta/contains_std_vector.hpp>
+#include <stan/math/prim/meta/contains_vector.hpp>
 #include <stan/math/prim/meta/error_index.hpp>
 #include <stan/math/prim/meta/forward_as.hpp>
 #include <stan/math/prim/meta/holder.hpp>

--- a/stan/math/prim/meta/VectorBuilder.hpp
+++ b/stan/math/prim/meta/VectorBuilder.hpp
@@ -2,8 +2,7 @@
 #define STAN_MATH_PRIM_META_VECTORBUILDER_HPP
 
 #include <stan/math/prim/meta/VectorBuilderHelper.hpp>
-#include <stan/math/prim/meta/disjunction.hpp>
-#include <stan/math/prim/meta/is_vector.hpp>
+#include <stan/math/prim/meta/contains_vector.hpp>
 
 namespace stan {
 
@@ -26,9 +25,7 @@ namespace stan {
 template <bool used, typename T1, typename... Args>
 class VectorBuilder {
  private:
-  using helper
-      = VectorBuilderHelper<T1, used,
-                            math::disjunction<is_vector<Args>...>::value>;
+  using helper = VectorBuilderHelper<T1, used, contains_vector<Args...>::value>;
 
  public:
   using type = typename helper::type;

--- a/stan/math/prim/meta/contains_vector.hpp
+++ b/stan/math/prim/meta/contains_vector.hpp
@@ -1,0 +1,19 @@
+#ifndef STAN_MATH_PRIM_META_CONTAINS_VECTOR_HPP
+#define STAN_MATH_PRIM_META_CONTAINS_VECTOR_HPP
+
+#include <stan/math/prim/meta/is_vector.hpp>
+#include <stan/math/prim/meta/bool_constant.hpp>
+#include <stan/math/prim/meta/disjunction.hpp>
+
+namespace stan {
+/** \ingroup type_trait
+ * Metaprogram to determine if any of the
+ * provided types is a std or eigen vector.
+ * @tparam T Types to test
+ */
+template <typename... T>
+using contains_vector = math::disjunction<
+    bool_constant<is_eigen_vector<T>::value || is_std_vector<T>::value>...>;
+
+}  // namespace stan
+#endif

--- a/stan/math/prim/prob/bernoulli_cdf.hpp
+++ b/stan/math/prim/prob/bernoulli_cdf.hpp
@@ -34,8 +34,7 @@ return_type_t<T_prob> bernoulli_cdf(const T_n& n, const T_prob& theta) {
   check_consistent_sizes(function, "Random variable", n,
                          "Probability parameter", theta);
   T_theta_ref theta_ref = theta;
-  check_bounded(function, "Probability parameter", value_of(theta_ref), 0.0,
-                1.0);
+  check_bounded(function, "Probability parameter", theta_ref, 0.0, 1.0);
 
   if (size_zero(n, theta)) {
     return 1.0;

--- a/stan/math/prim/prob/bernoulli_lccdf.hpp
+++ b/stan/math/prim/prob/bernoulli_lccdf.hpp
@@ -38,8 +38,7 @@ return_type_t<T_prob> bernoulli_lccdf(const T_n& n, const T_prob& theta) {
   check_consistent_sizes(function, "Random variable", n,
                          "Probability parameter", theta);
   T_theta_ref theta_ref = theta;
-  check_bounded(function, "Probability parameter", value_of(theta_ref), 0.0,
-                1.0);
+  check_bounded(function, "Probability parameter", theta_ref, 0.0, 1.0);
 
   if (size_zero(n, theta)) {
     return 0.0;

--- a/stan/math/prim/prob/bernoulli_lcdf.hpp
+++ b/stan/math/prim/prob/bernoulli_lcdf.hpp
@@ -38,8 +38,7 @@ return_type_t<T_prob> bernoulli_lcdf(const T_n& n, const T_prob& theta) {
   check_consistent_sizes(function, "Random variable", n,
                          "Probability parameter", theta);
   T_theta_ref theta_ref = theta;
-  check_bounded(function, "Probability parameter", value_of(theta_ref), 0.0,
-                1.0);
+  check_bounded(function, "Probability parameter", theta_ref, 0.0, 1.0);
 
   if (size_zero(n, theta)) {
     return 0.0;

--- a/stan/math/prim/prob/bernoulli_lpmf.hpp
+++ b/stan/math/prim/prob/bernoulli_lpmf.hpp
@@ -42,8 +42,7 @@ return_type_t<T_prob> bernoulli_lpmf(const T_n& n, const T_prob& theta) {
   const T_n_ref n_ref = to_ref(n);
   const T_theta_ref theta_ref = to_ref(theta);
   check_bounded(function, "n", n_ref, 0, 1);
-  check_bounded(function, "Probability parameter", value_of(theta_ref), 0.0,
-                1.0);
+  check_bounded(function, "Probability parameter", theta_ref, 0.0, 1.0);
 
   if (size_zero(n, theta)) {
     return 0.0;
@@ -84,8 +83,8 @@ return_type_t<T_prob> bernoulli_lpmf(const T_n& n, const T_prob& theta) {
       logp += (N - sum) * log1m_theta;
 
       if (!is_constant_all<T_prob>::value) {
-        ops_partials.edge1_.partials_[0] += sum * inv(theta_dbl);
-        ops_partials.edge1_.partials_[0] += (N - sum) * inv(theta_dbl - 1);
+        ops_partials.edge1_.partials_[0] += sum / theta_dbl;
+        ops_partials.edge1_.partials_[0] += (N - sum) / (theta_dbl - 1);
       }
     }
   } else {

--- a/stan/math/prim/prob/bernoulli_rng.hpp
+++ b/stan/math/prim/prob/bernoulli_rng.hpp
@@ -32,8 +32,7 @@ inline typename VectorBuilder<true, int, T_theta>::type bernoulli_rng(
   using boost::variate_generator;
   static const char* function = "bernoulli_rng";
   ref_type_t<T_theta> theta_ref = theta;
-  check_bounded(function, "Probability parameter", value_of(theta_ref), 0.0,
-                1.0);
+  check_bounded(function, "Probability parameter", theta_ref, 0.0, 1.0);
 
   scalar_seq_view<T_theta> theta_vec(theta_ref);
   size_t N = stan::math::size(theta);

--- a/stan/math/prim/prob/beta_cdf.hpp
+++ b/stan/math/prim/prob/beta_cdf.hpp
@@ -52,7 +52,7 @@ return_type_t<T_y, T_scale_succ, T_scale_fail> beta_cdf(
   T_beta_ref beta_ref = beta;
   check_positive_finite(function, "First shape parameter", alpha_ref);
   check_positive_finite(function, "Second shape parameter", beta_ref);
-  check_bounded(function, "Random variable", value_of(y_ref), 0, 1);
+  check_bounded(function, "Random variable", y_ref, 0, 1);
 
   T_partials_return P(1.0);
   operands_and_partials<T_y_ref, T_alpha_ref, T_beta_ref> ops_partials(

--- a/stan/math/prim/prob/beta_lccdf.hpp
+++ b/stan/math/prim/prob/beta_lccdf.hpp
@@ -60,7 +60,7 @@ return_type_t<T_y, T_scale_succ, T_scale_fail> beta_lccdf(
   T_beta_ref beta_ref = beta_param;
   check_positive_finite(function, "First shape parameter", alpha_ref);
   check_positive_finite(function, "Second shape parameter", beta_ref);
-  check_bounded(function, "Random variable", value_of(y_ref), 0, 1);
+  check_bounded(function, "Random variable", y_ref, 0, 1);
 
   T_partials_return ccdf_log(0.0);
   operands_and_partials<T_y_ref, T_alpha_ref, T_beta_ref> ops_partials(

--- a/stan/math/prim/prob/beta_lcdf.hpp
+++ b/stan/math/prim/prob/beta_lcdf.hpp
@@ -60,7 +60,7 @@ return_type_t<T_y, T_scale_succ, T_scale_fail> beta_lcdf(
   T_beta_ref beta_ref = beta_param;
   check_positive_finite(function, "First shape parameter", alpha_ref);
   check_positive_finite(function, "Second shape parameter", beta_ref);
-  check_bounded(function, "Random variable", value_of(y_ref), 0, 1);
+  check_bounded(function, "Random variable", y_ref, 0, 1);
 
   T_partials_return cdf_log(0.0);
   operands_and_partials<T_y_ref, T_alpha_ref, T_beta_ref> ops_partials(

--- a/stan/math/prim/prob/beta_lpdf.hpp
+++ b/stan/math/prim/prob/beta_lpdf.hpp
@@ -79,7 +79,7 @@ return_type_t<T_y, T_scale_succ, T_scale_fail> beta_lpdf(
 
   check_positive_finite(function, "First shape parameter", alpha_val);
   check_positive_finite(function, "Second shape parameter", beta_val);
-  check_bounded(function, "Random variable", value_of(y_val), 0, 1);
+  check_bounded(function, "Random variable", y_val, 0, 1);
   if (!include_summand<propto, T_y, T_scale_succ, T_scale_fail>::value) {
     return 0;
   }

--- a/stan/math/prim/prob/beta_proportion_lccdf.hpp
+++ b/stan/math/prim/prob/beta_proportion_lccdf.hpp
@@ -61,10 +61,10 @@ return_type_t<T_y, T_loc, T_prec> beta_proportion_lccdf(const T_y& y,
   T_y_ref y_ref = y;
   T_mu_ref mu_ref = mu;
   T_kappa_ref kappa_ref = kappa;
-  check_positive(function, "Location parameter", value_of(mu_ref));
-  check_less(function, "Location parameter", value_of(mu_ref), 1.0);
-  check_positive_finite(function, "Precision parameter", value_of(kappa_ref));
-  check_bounded(function, "Random variable", value_of(y_ref), 0.0, 1.0);
+  check_positive(function, "Location parameter", mu_ref);
+  check_less(function, "Location parameter", mu_ref, 1.0);
+  check_positive_finite(function, "Precision parameter", kappa_ref);
+  check_bounded(function, "Random variable", y_ref, 0.0, 1.0);
 
   T_partials_return ccdf_log(0.0);
   operands_and_partials<T_y_ref, T_mu_ref, T_kappa_ref> ops_partials(

--- a/stan/math/prim/prob/beta_proportion_lcdf.hpp
+++ b/stan/math/prim/prob/beta_proportion_lcdf.hpp
@@ -62,10 +62,10 @@ return_type_t<T_y, T_loc, T_prec> beta_proportion_lcdf(const T_y& y,
   T_y_ref y_ref = y;
   T_mu_ref mu_ref = mu;
   T_kappa_ref kappa_ref = kappa;
-  check_positive(function, "Location parameter", value_of(mu_ref));
-  check_less(function, "Location parameter", value_of(mu_ref), 1.0);
-  check_positive_finite(function, "Precision parameter", value_of(kappa_ref));
-  check_bounded(function, "Random variable", value_of(y_ref), 0.0, 1.0);
+  check_positive(function, "Location parameter", mu_ref);
+  check_less(function, "Location parameter", mu_ref, 1.0);
+  check_positive_finite(function, "Precision parameter", kappa_ref);
+  check_bounded(function, "Random variable", y_ref, 0.0, 1.0);
 
   T_partials_return cdf_log(0.0);
   operands_and_partials<T_y_ref, T_mu_ref, T_kappa_ref> ops_partials(

--- a/stan/math/prim/prob/beta_proportion_lpdf.hpp
+++ b/stan/math/prim/prob/beta_proportion_lpdf.hpp
@@ -74,7 +74,8 @@ return_type_t<T_y, T_loc, T_prec> beta_proportion_lpdf(const T_y& y,
 
   const auto& y_arr = as_array_or_scalar(y_col);
   const auto& mu_arr = as_array_or_scalar(mu_col);
-  const auto& kappa_arr = as_array_or_scalar(kappa_col);
+  const auto& kappa_arr
+      = promote_scalar<T_partials_return_kappa>(as_array_or_scalar(kappa_col));
 
   ref_type_t<decltype(value_of(y_arr))> y_val = value_of(y_arr);
   ref_type_t<decltype(value_of(mu_arr))> mu_val = value_of(mu_arr);
@@ -83,7 +84,7 @@ return_type_t<T_y, T_loc, T_prec> beta_proportion_lpdf(const T_y& y,
   check_positive(function, "Location parameter", mu_val);
   check_less(function, "Location parameter", mu_val, 1.0);
   check_positive_finite(function, "Precision parameter", kappa_val);
-  check_bounded(function, "Random variable", value_of(y_val), 0, 1);
+  check_bounded(function, "Random variable", y_val, 0, 1);
 
   if (!include_summand<propto, T_y, T_loc, T_prec>::value) {
     return 0;

--- a/stan/math/prim/prob/binomial_cdf.hpp
+++ b/stan/math/prim/prob/binomial_cdf.hpp
@@ -51,8 +51,7 @@ return_type_t<T_prob> binomial_cdf(const T_n& n, const T_N& N,
   T_theta_ref theta_ref = theta;
 
   check_nonnegative(function, "Population size parameter", N_ref);
-  check_bounded(function, "Probability parameter", value_of(theta_ref), 0.0,
-                1.0);
+  check_bounded(function, "Probability parameter", theta_ref, 0.0, 1.0);
 
   if (size_zero(n, N, theta)) {
     return 1.0;

--- a/stan/math/prim/prob/binomial_lccdf.hpp
+++ b/stan/math/prim/prob/binomial_lccdf.hpp
@@ -54,8 +54,7 @@ return_type_t<T_prob> binomial_lccdf(const T_n& n, const T_N& N,
   T_theta_ref theta_ref = theta;
 
   check_nonnegative(function, "Population size parameter", N_ref);
-  check_bounded(function, "Probability parameter", value_of(theta_ref), 0.0,
-                1.0);
+  check_bounded(function, "Probability parameter", theta_ref, 0.0, 1.0);
 
   if (size_zero(n, N, theta)) {
     return 0;

--- a/stan/math/prim/prob/binomial_lcdf.hpp
+++ b/stan/math/prim/prob/binomial_lcdf.hpp
@@ -54,8 +54,7 @@ return_type_t<T_prob> binomial_lcdf(const T_n& n, const T_N& N,
   T_theta_ref theta_ref = theta;
 
   check_nonnegative(function, "Population size parameter", N_ref);
-  check_bounded(function, "Probability parameter", value_of(theta_ref), 0.0,
-                1.0);
+  check_bounded(function, "Probability parameter", theta_ref, 0.0, 1.0);
 
   if (size_zero(n, N, theta)) {
     return 0;

--- a/stan/math/prim/prob/binomial_logit_lpmf.hpp
+++ b/stan/math/prim/prob/binomial_logit_lpmf.hpp
@@ -63,7 +63,7 @@ return_type_t<T_prob> binomial_logit_lpmf(const T_n& n, const T_N& N,
   ref_type_t<decltype(value_of(N_arr))> N_val = value_of(N_arr);
   ref_type_t<decltype(value_of(alpha_arr))> alpha_val = value_of(alpha_arr);
 
-  check_bounded(function, "Successes variable", value_of(n_val), 0, N_val);
+  check_bounded(function, "Successes variable", n_val, 0, N_val);
   check_nonnegative(function, "Population size parameter", N_val);
   check_finite(function, "Probability parameter", alpha_val);
 

--- a/stan/math/prim/prob/binomial_lpmf.hpp
+++ b/stan/math/prim/prob/binomial_lpmf.hpp
@@ -51,10 +51,9 @@ return_type_t<T_prob> binomial_lpmf(const T_n& n, const T_N& N,
   T_N_ref N_ref = N;
   T_theta_ref theta_ref = theta;
 
-  check_bounded(function, "Successes variable", value_of(n_ref), 0, N_ref);
+  check_bounded(function, "Successes variable", n_ref, 0, N_ref);
   check_nonnegative(function, "Population size parameter", N_ref);
-  check_bounded(function, "Probability parameter", value_of(theta_ref), 0.0,
-                1.0);
+  check_bounded(function, "Probability parameter", theta_ref, 0.0, 1.0);
 
   if (size_zero(n, N, theta)) {
     return 0.0;

--- a/stan/math/prim/prob/binomial_rng.hpp
+++ b/stan/math/prim/prob/binomial_rng.hpp
@@ -41,8 +41,7 @@ inline typename VectorBuilder<true, int, T_N, T_theta>::type binomial_rng(
   T_N_ref N_ref = N;
   T_theta_ref theta_ref = theta;
   check_nonnegative(function, "Population size parameter", N_ref);
-  check_bounded(function, "Probability parameter", value_of(theta_ref), 0.0,
-                1.0);
+  check_bounded(function, "Probability parameter", theta_ref, 0.0, 1.0);
 
   scalar_seq_view<T_N_ref> N_vec(N_ref);
   scalar_seq_view<T_theta_ref> theta_vec(theta_ref);

--- a/stan/math/prim/prob/categorical_lpmf.hpp
+++ b/stan/math/prim/prob/categorical_lpmf.hpp
@@ -20,7 +20,7 @@ return_type_t<T_prob> categorical_lpmf(int n, const T_prob& theta) {
 
   check_bounded(function, "Number of categories", n, 1, theta.size());
   ref_type_t<T_prob> theta_ref = theta;
-  check_simplex(function, "Probabilities parameter", value_of(theta_ref));
+  check_simplex(function, "Probabilities parameter", theta_ref);
 
   if (include_summand<propto, T_prob>::value) {
     return log(theta_ref.coeff(n - 1));
@@ -36,7 +36,7 @@ return_type_t<T_prob> categorical_lpmf(const std::vector<int>& ns,
 
   check_bounded(function, "element of outcome array", ns, 1, theta.size());
   ref_type_t<T_prob> theta_ref = theta;
-  check_simplex(function, "Probabilities parameter", value_of(theta_ref));
+  check_simplex(function, "Probabilities parameter", theta_ref);
 
   if (!include_summand<propto, T_prob>::value) {
     return 0.0;

--- a/stan/math/prim/prob/hypergeometric_lpmf.hpp
+++ b/stan/math/prim/prob/hypergeometric_lpmf.hpp
@@ -18,7 +18,7 @@ template <bool propto, typename T_n, typename T_N, typename T_a, typename T_b>
 double hypergeometric_lpmf(const T_n& n, const T_N& N, const T_a& a,
                            const T_b& b) {
   static const char* function = "hypergeometric_lpmf";
-  check_bounded(function, "Successes variable", value_of(n), 0, a);
+  check_bounded(function, "Successes variable", n, 0, a);
   check_consistent_sizes(function, "Successes variable", n, "Draws parameter",
                          N, "Successes in population parameter", a,
                          "Failures in population parameter", b);

--- a/stan/math/prim/prob/hypergeometric_rng.hpp
+++ b/stan/math/prim/prob/hypergeometric_rng.hpp
@@ -15,7 +15,7 @@ inline int hypergeometric_rng(int N, int a, int b, RNG& rng) {
   using boost::variate_generator;
   using boost::math::hypergeometric_distribution;
   static const char* function = "hypergeometric_rng";
-  check_bounded(function, "Draws parameter", value_of(N), 0, a + b);
+  check_bounded(function, "Draws parameter", N, 0, a + b);
   check_positive(function, "Draws parameter", N);
   check_positive(function, "Successes in population parameter", a);
   check_positive(function, "Failures in population parameter", b);

--- a/stan/math/prim/prob/poisson_binomial_lccdf.hpp
+++ b/stan/math/prim/prob/poisson_binomial_lccdf.hpp
@@ -51,9 +51,8 @@ return_type_t<T_theta> poisson_binomial_lccdf(const T_y& y,
   for (size_t i = 0; i < max_sz; ++i) {
     check_bounded(function, "Successes variable", y_vec[i], 0,
                   theta_vec[i].size());
-    check_finite(function, "Probability parameters", theta_vec.val(i));
-    check_bounded(function, "Probability parameters", theta_vec.val(i), 0.0,
-                  1.0);
+    check_finite(function, "Probability parameters", theta_vec[i]);
+    check_bounded(function, "Probability parameters", theta_vec[i], 0.0, 1.0);
   }
 
   return sum(log1m_exp(log_sum_exp(poisson_binomial_log_probs(y, theta))));

--- a/stan/math/prim/prob/poisson_binomial_lcdf.hpp
+++ b/stan/math/prim/prob/poisson_binomial_lcdf.hpp
@@ -50,9 +50,8 @@ return_type_t<T_theta> poisson_binomial_lcdf(const T_y& y,
   for (size_t i = 0; i < max_sz; ++i) {
     check_bounded(function, "Successes variable", y_vec[i], 0,
                   theta_vec[i].size());
-    check_finite(function, "Probability parameters", theta_vec.val(i));
-    check_bounded(function, "Probability parameters", theta_vec.val(i), 0.0,
-                  1.0);
+    check_finite(function, "Probability parameters", theta_vec[i]);
+    check_bounded(function, "Probability parameters", theta_vec[i], 0.0, 1.0);
   }
 
   return sum(log_sum_exp(poisson_binomial_log_probs(y, theta)));

--- a/stan/math/prim/prob/poisson_binomial_lpmf.hpp
+++ b/stan/math/prim/prob/poisson_binomial_lpmf.hpp
@@ -42,9 +42,8 @@ return_type_t<T_theta> poisson_binomial_lpmf(const T_y& y,
   for (size_t i = 0; i < max_sz; ++i) {
     check_bounded(function, "Successes variable", y_vec[i], 0,
                   theta_vec[i].size());
-    check_finite(function, "Probability parameters", theta_vec.val(i));
-    check_bounded(function, "Probability parameters", theta_vec.val(i), 0.0,
-                  1.0);
+    check_finite(function, "Probability parameters", theta_vec[i]);
+    check_bounded(function, "Probability parameters", theta_vec[i], 0.0, 1.0);
   }
 
   return_type_t<T_theta> log_prob = 0.0;

--- a/stan/math/prim/prob/poisson_binomial_rng.hpp
+++ b/stan/math/prim/prob/poisson_binomial_rng.hpp
@@ -27,7 +27,7 @@ inline int poisson_binomial_rng(
     const Eigen::Matrix<T_theta, Eigen::Dynamic, 1>& theta, RNG& rng) {
   static const char* function = "poisson_binomial_rng";
   check_finite(function, "Probability parameters", theta);
-  check_bounded(function, "Probability parameters", value_of(theta), 0.0, 1.0);
+  check_bounded(function, "Probability parameters", theta, 0.0, 1.0);
 
   int y = 0;
   for (size_t i = 0; i < theta.size(); ++i) {

--- a/stan/math/prim/prob/skew_double_exponential_cdf.hpp
+++ b/stan/math/prim/prob/skew_double_exponential_cdf.hpp
@@ -55,10 +55,10 @@ return_type_t<T_y, T_loc, T_scale, T_skewness> skew_double_exponential_cdf(
   T_sigma_ref sigma_ref = sigma;
   T_tau_ref tau_ref = tau;
 
-  check_not_nan(function, "Random variable", value_of(y_ref));
-  check_finite(function, "Location parameter", value_of(mu_ref));
-  check_positive_finite(function, "Scale parameter", value_of(sigma_ref));
-  check_bounded(function, "Skewness parameter", value_of(tau_ref), 0.0, 1.0);
+  check_not_nan(function, "Random variable", y_ref);
+  check_finite(function, "Location parameter", mu_ref);
+  check_positive_finite(function, "Scale parameter", sigma_ref);
+  check_bounded(function, "Skewness parameter", tau_ref, 0.0, 1.0);
 
   if (size_zero(y, mu, sigma, tau)) {
     return 1.0;
@@ -82,10 +82,10 @@ return_type_t<T_y, T_loc, T_scale, T_skewness> skew_double_exponential_cdf(
   }
 
   for (int i = 0; i < N; ++i) {
-    const T_partials_return y_dbl = y_vec.val(i);
-    const T_partials_return mu_dbl = mu_vec.val(i);
-    const T_partials_return sigma_dbl = sigma_vec.val(i);
-    const T_partials_return tau_dbl = tau_vec.val(i);
+    const T_partials_return y_dbl = value_of(y_vec[i]);
+    const T_partials_return mu_dbl = value_of(mu_vec[i]);
+    const T_partials_return sigma_dbl = value_of(sigma_vec[i]);
+    const T_partials_return tau_dbl = value_of(tau_vec[i]);
 
     const T_partials_return y_m_mu = y_dbl - mu_dbl;
     const T_partials_return diff_sign = sign(y_m_mu);

--- a/stan/math/prim/prob/skew_double_exponential_lccdf.hpp
+++ b/stan/math/prim/prob/skew_double_exponential_lccdf.hpp
@@ -54,10 +54,10 @@ return_type_t<T_y, T_loc, T_scale, T_skewness> skew_double_exponential_lccdf(
   T_sigma_ref sigma_ref = sigma;
   T_tau_ref tau_ref = tau;
 
-  check_not_nan(function, "Random variable", value_of(y_ref));
-  check_finite(function, "Location parameter", value_of(mu_ref));
-  check_positive_finite(function, "Scale parameter", value_of(sigma_ref));
-  check_bounded(function, "Skewness parameter", value_of(tau_ref), 0.0, 1.0);
+  check_not_nan(function, "Random variable", y_ref);
+  check_finite(function, "Location parameter", mu_ref);
+  check_positive_finite(function, "Scale parameter", sigma_ref);
+  check_bounded(function, "Skewness parameter", tau_ref, 0.0, 1.0);
 
   if (size_zero(y, mu, sigma, tau)) {
     return 0.0;
@@ -81,10 +81,10 @@ return_type_t<T_y, T_loc, T_scale, T_skewness> skew_double_exponential_lccdf(
   }
 
   for (int i = 0; i < N; ++i) {
-    const T_partials_return y_dbl = y_vec.val(i);
-    const T_partials_return mu_dbl = mu_vec.val(i);
-    const T_partials_return sigma_dbl = sigma_vec.val(i);
-    const T_partials_return tau_dbl = tau_vec.val(i);
+    const T_partials_return y_dbl = value_of(y_vec[i]);
+    const T_partials_return mu_dbl = value_of(mu_vec[i]);
+    const T_partials_return sigma_dbl = value_of(sigma_vec[i]);
+    const T_partials_return tau_dbl = value_of(tau_vec[i]);
 
     const T_partials_return y_m_mu = y_dbl - mu_dbl;
     const T_partials_return diff_sign = sign(y_m_mu);

--- a/stan/math/prim/prob/skew_double_exponential_lcdf.hpp
+++ b/stan/math/prim/prob/skew_double_exponential_lcdf.hpp
@@ -55,10 +55,10 @@ return_type_t<T_y, T_loc, T_scale, T_skewness> skew_double_exponential_lcdf(
   T_sigma_ref sigma_ref = sigma;
   T_tau_ref tau_ref = tau;
 
-  check_not_nan(function, "Random variable", value_of(y_ref));
-  check_finite(function, "Location parameter", value_of(mu_ref));
-  check_positive_finite(function, "Scale parameter", value_of(sigma_ref));
-  check_bounded(function, "Skewness parameter", value_of(tau_ref), 0.0, 1.0);
+  check_not_nan(function, "Random variable", y_ref);
+  check_finite(function, "Location parameter", mu_ref);
+  check_positive_finite(function, "Scale parameter", sigma_ref);
+  check_bounded(function, "Skewness parameter", tau_ref, 0.0, 1.0);
 
   if (size_zero(y, mu, sigma, tau)) {
     return 0.0;
@@ -82,10 +82,10 @@ return_type_t<T_y, T_loc, T_scale, T_skewness> skew_double_exponential_lcdf(
   }
 
   for (int i = 0; i < N; ++i) {
-    const T_partials_return y_dbl = y_vec.val(i);
-    const T_partials_return mu_dbl = mu_vec.val(i);
-    const T_partials_return sigma_dbl = sigma_vec.val(i);
-    const T_partials_return tau_dbl = tau_vec.val(i);
+    const T_partials_return y_dbl = value_of(y_vec[i]);
+    const T_partials_return mu_dbl = value_of(mu_vec[i]);
+    const T_partials_return sigma_dbl = value_of(sigma_vec[i]);
+    const T_partials_return tau_dbl = value_of(tau_vec[i]);
 
     const T_partials_return y_m_mu = y_dbl - mu_dbl;
     const T_partials_return diff_sign = sign(y_m_mu);

--- a/stan/math/prim/prob/skew_double_exponential_lpdf.hpp
+++ b/stan/math/prim/prob/skew_double_exponential_lpdf.hpp
@@ -81,10 +81,10 @@ return_type_t<T_y, T_loc, T_scale, T_skewness> skew_double_exponential_lpdf(
   ref_type_t<decltype(value_of(sigma_arr))> sigma_val = value_of(sigma_arr);
   ref_type_t<decltype(value_of(tau_arr))> tau_val = value_of(tau_arr);
 
-  check_not_nan(function, "Random variable", y_val);
-  check_finite(function, "Location parameter", mu_val);
-  check_positive_finite(function, "Scale parameter", sigma_val);
-  check_bounded(function, "Skewness parameter", tau_val, 0.0, 1.0);
+  check_not_nan(function, "Random variable", y_ref);
+  check_finite(function, "Location parameter", mu_ref);
+  check_positive_finite(function, "Scale parameter", sigma_ref);
+  check_bounded(function, "Skewness parameter", tau_ref, 0.0, 1.0);
 
   const auto& inv_sigma
       = to_ref_if<!is_constant_all<T_scale>::value>(inv(sigma_val));

--- a/stan/math/prim/prob/von_mises_cdf.hpp
+++ b/stan/math/prim/prob/von_mises_cdf.hpp
@@ -133,9 +133,9 @@ inline return_type_t<T_x, T_mu, T_k> von_mises_cdf(const T_x& x, const T_mu& mu,
   T_mu_ref mu_ref = mu;
   T_k_ref k_ref = k;
 
-  check_bounded(function, "Random variable", value_of(x_ref), -pi, pi);
-  check_finite(function, "Location parameter", value_of(mu_ref));
-  check_positive(function, "Scale parameter", value_of(k_ref));
+  check_bounded(function, "Random variable", x_ref, -pi, pi);
+  check_finite(function, "Location parameter", mu_ref);
+  check_positive(function, "Scale parameter", k_ref);
 
   if (size_zero(x, mu, k)) {
     return 1.0;

--- a/stan/math/prim/prob/von_mises_lccdf.hpp
+++ b/stan/math/prim/prob/von_mises_lccdf.hpp
@@ -47,9 +47,9 @@ inline return_type_t<T_x, T_mu, T_k> von_mises_lccdf(const T_x& x,
   T_mu_ref mu_ref = mu;
   T_k_ref k_ref = k;
 
-  check_bounded(function, "Random variable", value_of(x_ref), -pi, pi);
-  check_finite(function, "Location parameter", value_of(mu_ref));
-  check_positive(function, "Scale parameter", value_of(k_ref));
+  check_bounded(function, "Random variable", x_ref, -pi, pi);
+  check_finite(function, "Location parameter", mu_ref);
+  check_positive(function, "Scale parameter", k_ref);
 
   if (size_zero(x, mu, k)) {
     return 0.0;

--- a/stan/math/prim/prob/von_mises_lcdf.hpp
+++ b/stan/math/prim/prob/von_mises_lcdf.hpp
@@ -48,9 +48,9 @@ inline return_type_t<T_x, T_mu, T_k> von_mises_lcdf(const T_x& x,
   T_mu_ref mu_ref = mu;
   T_k_ref k_ref = k;
 
-  check_bounded(function, "Random variable", value_of(x_ref), -pi, pi);
-  check_finite(function, "Location parameter", value_of(mu_ref));
-  check_positive(function, "Scale parameter", value_of(k_ref));
+  check_bounded(function, "Random variable", x_ref, -pi, pi);
+  check_finite(function, "Location parameter", mu_ref);
+  check_positive(function, "Scale parameter", k_ref);
 
   if (size_zero(x, mu, k)) {
     return 0.0;

--- a/stan/math/prim/prob/von_mises_lpdf.hpp
+++ b/stan/math/prim/prob/von_mises_lpdf.hpp
@@ -86,10 +86,9 @@ return_type_t<T_y, T_loc, T_scale> von_mises_lpdf(T_y const& y, T_loc const& mu,
     }
   }
   if (!is_constant_all<T_scale>::value) {
-    ops_partials.edge3_.partials_
-        = cos_mu_minus_y
-          - modified_bessel_first_kind(-1, kappa_val)
-                / modified_bessel_first_kind(0, kappa_val);
+    const auto& bessel0 = modified_bessel_first_kind(0, kappa_val);
+    const auto& bessel1 = modified_bessel_first_kind(-1, kappa_val);
+    ops_partials.edge3_.partials_ = cos_mu_minus_y - bessel1 / bessel0;
   }
 
   return ops_partials.build(logp);

--- a/stan/math/prim/prob/wiener_lpdf.hpp
+++ b/stan/math/prim/prob/wiener_lpdf.hpp
@@ -100,11 +100,11 @@ return_type_t<T_y, T_alpha, T_tau, T_beta, T_delta> wiener_lpdf(
   T_beta_ref beta_ref = beta;
   T_delta_ref delta_ref = delta;
 
-  check_positive(function, "Random variable", value_of(y_ref));
-  check_positive_finite(function, "Boundary separation", value_of(alpha_ref));
-  check_positive_finite(function, "Nondecision time", value_of(tau_ref));
-  check_bounded(function, "A-priori bias", value_of(beta_ref), 0, 1);
-  check_finite(function, "Drift rate", value_of(delta_ref));
+  check_positive(function, "Random variable", y_ref);
+  check_positive_finite(function, "Boundary separation", alpha_ref);
+  check_positive_finite(function, "Nondecision time", tau_ref);
+  check_bounded(function, "A-priori bias", beta_ref, 0, 1);
+  check_finite(function, "Drift rate", delta_ref);
 
   if (size_zero(y, alpha, beta, tau, delta)) {
     return 0;

--- a/test/prob/generate_tests.cpp
+++ b/test/prob/generate_tests.cpp
@@ -23,21 +23,11 @@ int ROW_VECTORS = 0;
 #endif
 
 void push_args(vector<string>& args, const string& type) {
-  if (type.compare("varmat") == 0) {
-    args.push_back("var");
-    args.push_back("std::vector<var>");
-    args.push_back(
-        "stan::math::var_value<Eigen::Matrix<double, Eigen::Dynamic, 1>>");
-    if (ROW_VECTORS == 1)
-      args.push_back(
-          "stan::math::var_value<Eigen::Matrix<double, 1, Eigen::Dynamic>>");
-  } else {
-    args.push_back(type);
-    args.push_back("std::vector<" + type + ">");
-    args.push_back("Eigen::Matrix<" + type + ", Eigen::Dynamic, 1>");
-    if (ROW_VECTORS == 1)
-      args.push_back("Eigen::Matrix<" + type + ", 1, Eigen::Dynamic>");
-  }
+  args.push_back(type);
+  args.push_back("std::vector<" + type + ">");
+  args.push_back("Eigen::Matrix<" + type + ", Eigen::Dynamic, 1>");
+  if (ROW_VECTORS == 1)
+    args.push_back("Eigen::Matrix<" + type + ", 1, Eigen::Dynamic>");
 }
 
 vector<string> lookup_argument(const string& argument, const int& ind) {
@@ -62,8 +52,6 @@ vector<string> lookup_argument(const string& argument, const int& ind) {
       push_args(args, "fvar<fvar<double> >");
     } else if (ind == 5) {
       push_args(args, "fvar<fvar<var> >");
-    } else if (ind == 6) {
-      push_args(args, "varmat");
     }
   }
   return args;
@@ -281,8 +269,6 @@ void write_types_typedef(vector<std::ostream*>& outs, string base, size_t& N,
             *out << "> type_ffd_" << N << ";" << endl;
           else if (index == 5)
             *out << "> type_ffv_" << N << ";" << endl;
-          else if (index == 6)
-            *out << "> type_vv_" << N << ";" << endl;
           N++;
         }
       }
@@ -321,9 +307,6 @@ void write_test(vector<std::ostream*>& outs, const string& test_name,
     else if (index == 5)
       *out << "typedef boost::mpl::vector<" << test_name << ", type_ffv_" << n
            << "> " << test_name << "_ffv_" << n << ";" << endl;
-    else if (index == 6)
-      *out << "typedef boost::mpl::vector<" << test_name << ", type_vv_" << n
-           << "> " << test_name << "_vv_" << n << ";" << endl;
   }
   for (size_t i = 0; i < outs.size(); i++) {
     *outs[i] << endl;
@@ -349,10 +332,6 @@ void write_test(vector<std::ostream*>& outs, const string& test_name,
     else if (index == 5)
       *out << "INSTANTIATE_TYPED_TEST_SUITE_P(" << test_name << "_ffv_" << n
            << ", " << fixture_name << ", " << test_name << "_ffv_" << n << ");"
-           << endl;
-    else if (index == 6)
-      *out << "INSTANTIATE_TYPED_TEST_SUITE_P(" << test_name << "_vv_" << n
-           << ", " << fixture_name << ", " << test_name << "_vv_" << n << ");"
            << endl;
   }
   for (size_t i = 0; i < outs.size(); i++) {
@@ -413,8 +392,6 @@ int create_files(const int& argc, const char* argv[], const int& index,
       out_name << "_generated_ffd_test.cpp";
     else if (index == 5)
       out_name << "_generated_ffv_test.cpp";
-    else if (index == 6)
-      out_name << "_generated_vv_test.cpp";
     std::string tmp(out_name.str());
     outs.push_back(new std::ofstream(tmp.c_str()));
   }
@@ -431,6 +408,7 @@ int create_files(const int& argc, const char* argv[], const int& index,
     delete (outs[n]);
   }
   outs.clear();
+
   return start + BATCHES;
 }
 
@@ -450,7 +428,6 @@ int main(int argc, const char* argv[]) {
   create_files(argc, argv, 3, -1, N_TESTS);  // create fv tests
   create_files(argc, argv, 4, -1, N_TESTS);  // create ffd tests
   create_files(argc, argv, 5, -1, N_TESTS);  // create ffv tests
-  create_files(argc, argv, 6, -1, N_TESTS);  // create varmat tests
 
   return 0;
 }

--- a/test/prob/test_fixture_ccdf_log.hpp
+++ b/test/prob/test_fixture_ccdf_log.hpp
@@ -240,133 +240,109 @@ class AgradCcdfLogTestFixture : public ::testing::Test {
     if (!is_constant_all<Scalar5>::value && !is_empty<Scalar5>::value)
       add_finite_diff_1storder(params, finite_diff, 5);
   }
-
   // works for <double>
-  template <typename... Args>
-  double calculate_gradients_1storder(vector<double>& grad, double& logprob,
-                                      Args&... args) {
-    return logprob;
+  double calculate_gradients_1storder(vector<double>& grad, double& ccdf_log,
+                                      vector<var>& x) {
+    return ccdf_log;
   }
-  template <typename... Args>
-  double calculate_gradients_2ndorder(vector<double>& grad, double& logprob,
-                                      Args&... x) {
-    return logprob;
+  double calculate_gradients_2ndorder(vector<double>& grad, double& ccdf_log,
+                                      vector<var>& x) {
+    return ccdf_log;
   }
-  template <typename... Args>
-  double calculate_gradients_3rdorder(vector<double>& grad, double& logprob,
-                                      Args&... x) {
-    return logprob;
+  double calculate_gradients_3rdorder(vector<double>& grad, double& ccdf_log,
+                                      vector<var>& x) {
+    return ccdf_log;
   }
 
   // works for <var>
-  template <typename... Args>
-  double calculate_gradients_1storder(vector<double>& grad, var& logprob,
-                                      Args&... args) {
+  double calculate_gradients_1storder(vector<double>& grad, var& ccdf_log,
+                                      vector<var>& x) {
     stan::math::set_zero_all_adjoints();
-    logprob.grad();
-    add_adjoints(grad, args...);
-    return logprob.val();
+    ccdf_log.grad(x, grad);
+    return ccdf_log.val();
   }
-  template <typename... Args>
-  double calculate_gradients_2ndorder(vector<double>& grad, var& logprob,
-                                      Args&... args) {
-    return logprob.val();
+  double calculate_gradients_2ndorder(vector<double>& grad, var& ccdf_log,
+                                      vector<var>& x) {
+    return ccdf_log.val();
   }
-  template <typename... Args>
-  double calculate_gradients_3rdorder(vector<double>& grad, var& logprob,
-                                      Args&... args) {
-    return logprob.val();
+  double calculate_gradients_3rdorder(vector<double>& grad, var& ccdf_log,
+                                      vector<var>& x) {
+    return ccdf_log.val();
   }
 
   // works for fvar<double>
-  template <typename... Args>
   double calculate_gradients_1storder(vector<double>& grad,
-                                      fvar<double>& logprob, Args&... args) {
-    grad.push_back(logprob.d_);
-    return logprob.val();
+                                      fvar<double>& ccdf_log, vector<var>& x) {
+    grad.push_back(ccdf_log.d_);
+    return ccdf_log.val();
   }
-  template <typename... Args>
   double calculate_gradients_2ndorder(vector<double>& grad,
-                                      fvar<double>& logprob, Args&... args) {
-    return logprob.val();
+                                      fvar<double>& ccdf_log, vector<var>& x) {
+    return ccdf_log.val();
   }
-  template <typename... Args>
   double calculate_gradients_3rdorder(vector<double>& grad,
-                                      fvar<double>& logprob, Args&... args) {
-    return logprob.val();
+                                      fvar<double>& ccdf_log, vector<var>& x) {
+    return ccdf_log.val();
   }
 
   // works for fvar<fvar<double> >
-  template <typename... Args>
   double calculate_gradients_1storder(vector<double>& grad,
-                                      fvar<fvar<double>>& logprob,
-                                      Args&... args) {
-    grad.push_back(logprob.d_.val_);
-
-    return logprob.val().val();
+                                      fvar<fvar<double>>& ccdf_log,
+                                      vector<var>& x) {
+    grad.push_back(ccdf_log.d_.val_);
+    return ccdf_log.val().val();
   }
-  template <typename... Args>
   double calculate_gradients_2ndorder(vector<double>& grad,
-                                      fvar<fvar<double>>& logprob,
-                                      Args&... args) {
-    grad.push_back(logprob.d_.d_);
-    return logprob.val().val();
+                                      fvar<fvar<double>>& ccdf_log,
+                                      vector<var>& x) {
+    grad.push_back(ccdf_log.d_.d_);
+    return ccdf_log.val().val();
   }
-  template <typename... Args>
   double calculate_gradients_3rdorder(vector<double>& grad,
-                                      fvar<fvar<double>>& logprob,
-                                      Args&... args) {
-    return logprob.val().val();
+                                      fvar<fvar<double>>& ccdf_log,
+                                      vector<var>& x) {
+    return ccdf_log.val().val();
   }
 
   // works for fvar<var>
-  template <typename... Args>
-  double calculate_gradients_1storder(vector<double>& grad, fvar<var>& logprob,
-                                      Args&... args) {
+  double calculate_gradients_1storder(vector<double>& grad, fvar<var>& ccdf_log,
+                                      vector<var>& x) {
     stan::math::set_zero_all_adjoints();
-    logprob.val_.grad();
-    add_adjoints(grad, args...);
-    return logprob.val_.val();
+    ccdf_log.val_.grad(x, grad);
+    return ccdf_log.val_.val();
   }
-  template <typename... Args>
-  double calculate_gradients_2ndorder(vector<double>& grad, fvar<var>& logprob,
-                                      Args&... args) {
+  double calculate_gradients_2ndorder(vector<double>& grad, fvar<var>& ccdf_log,
+                                      vector<var>& x) {
     stan::math::set_zero_all_adjoints();
-    logprob.d_.grad();
-    add_adjoints(grad, args...);
-    return logprob.val_.val();
+    ccdf_log.d_.grad(x, grad);
+    return ccdf_log.val_.val();
   }
-  template <typename... Args>
-  double calculate_gradients_3rdorder(vector<double>& grad, fvar<var>& logprob,
-                                      Args&... args) {
-    return logprob.val_.val();
+  double calculate_gradients_3rdorder(vector<double>& grad, fvar<var>& ccdf_log,
+                                      vector<var>& x) {
+    return ccdf_log.val_.val();
   }
 
   // works for fvar<fvar<var> >
-  template <typename... Args>
   double calculate_gradients_1storder(vector<double>& grad,
-                                      fvar<fvar<var>>& logprob, Args&... args) {
+                                      fvar<fvar<var>>& ccdf_log,
+                                      vector<var>& x) {
     stan::math::set_zero_all_adjoints();
-    logprob.val_.val_.grad();
-    add_adjoints(grad, args...);
-    return logprob.val_.val_.val();
+    ccdf_log.val_.val_.grad(x, grad);
+    return ccdf_log.val_.val_.val();
   }
-  template <typename... Args>
   double calculate_gradients_2ndorder(vector<double>& grad,
-                                      fvar<fvar<var>>& logprob, Args&... args) {
+                                      fvar<fvar<var>>& ccdf_log,
+                                      vector<var>& x) {
     stan::math::set_zero_all_adjoints();
-    logprob.d_.val_.grad();
-    add_adjoints(grad, args...);
-
-    return logprob.val_.val_.val();
+    ccdf_log.d_.val_.grad(x, grad);
+    return ccdf_log.val_.val_.val();
   }
-  template <typename... Args>
   double calculate_gradients_3rdorder(vector<double>& grad,
-                                      fvar<fvar<var>>& logprob, Args&... args) {
+                                      fvar<fvar<var>>& ccdf_log,
+                                      vector<var>& x) {
     stan::math::set_zero_all_adjoints();
-    logprob.d_.d_.grad();
-    add_adjoints(grad, args...);
-    return logprob.val_.val_.val();
+    ccdf_log.d_.d_.grad(x, grad);
+    return ccdf_log.val_.val_.val();
   }
 
   void test_finite_diffs_equal(const vector<double>& parameters,
@@ -422,13 +398,15 @@ class AgradCcdfLogTestFixture : public ::testing::Test {
         Scalar4 p4 = get_param<Scalar4>(parameters[n], 4);
         Scalar5 p5 = get_param<Scalar5>(parameters[n], 5);
 
+        vector<var> x1;
+        add_vars(x1, p0, p1, p2, p3, p4, p5);
+
         T_return_type ccdf_log
             = TestClass.template ccdf_log<Scalar0, Scalar1, Scalar2, Scalar3,
                                           Scalar4, Scalar5>(p0, p1, p2, p3, p4,
                                                             p5);
 
-        calculate_gradients_1storder(gradients, ccdf_log, p0, p1, p2, p3, p4,
-                                     p5);
+        calculate_gradients_1storder(gradients, ccdf_log, x1);
 
         test_finite_diffs_equal(parameters[n], finite_diffs, gradients);
 
@@ -476,6 +454,19 @@ class AgradCcdfLogTestFixture : public ::testing::Test {
       Scalar4 p4 = get_param<Scalar4>(parameters[n], 4);
       Scalar5 p5 = get_param<Scalar5>(parameters[n], 5);
 
+      vector<var> x1;
+      vector<var> x2;
+      vector<var> x3;
+      vector<var> y1;
+      vector<var> y2;
+      vector<var> y3;
+      add_vars(x1, p0, p1, p2, p3, p4, p5);
+      add_vars(x2, p0, p1, p2, p3, p4, p5);
+      add_vars(x3, p0, p1, p2, p3, p4, p5);
+      add_vars(y1, p0, p1, p2, p3, p4, p5);
+      add_vars(y2, p0, p1, p2, p3, p4, p5);
+      add_vars(y3, p0, p1, p2, p3, p4, p5);
+
       T_return_type ccdf_log
           = TestClass.template ccdf_log<Scalar0, Scalar1, Scalar2, Scalar3,
                                         Scalar4, Scalar5>(p0, p1, p2, p3, p4,
@@ -486,18 +477,12 @@ class AgradCcdfLogTestFixture : public ::testing::Test {
                                                  Scalar3, Scalar4, Scalar5>(
               p0, p1, p2, p3, p4, p5);
 
-      calculate_gradients_1storder(expected_gradients1, ccdf_log_funct, p0, p1,
-                                   p2, p3, p4, p5);
-      calculate_gradients_1storder(gradients1, ccdf_log, p0, p1, p2, p3, p4,
-                                   p5);
-      calculate_gradients_2ndorder(expected_gradients2, ccdf_log_funct, p0, p1,
-                                   p2, p3, p4, p5);
-      calculate_gradients_2ndorder(gradients2, ccdf_log, p0, p1, p2, p3, p4,
-                                   p5);
-      calculate_gradients_3rdorder(expected_gradients3, ccdf_log_funct, p0, p1,
-                                   p2, p3, p4, p5);
-      calculate_gradients_3rdorder(gradients3, ccdf_log, p0, p1, p2, p3, p4,
-                                   p5);
+      calculate_gradients_1storder(expected_gradients1, ccdf_log_funct, x1);
+      calculate_gradients_1storder(gradients1, ccdf_log, y1);
+      calculate_gradients_2ndorder(expected_gradients2, ccdf_log_funct, x2);
+      calculate_gradients_2ndorder(gradients2, ccdf_log, y2);
+      calculate_gradients_3rdorder(expected_gradients3, ccdf_log_funct, x3);
+      calculate_gradients_3rdorder(gradients3, ccdf_log, y3);
 
       test_gradients_equal(expected_gradients1, gradients1);
       test_gradients_equal(expected_gradients2, gradients2);
@@ -514,17 +499,6 @@ class AgradCcdfLogTestFixture : public ::testing::Test {
    * For log ccdf this means lccdf([a, a, a]) == lccdf(a) + lccdf(a) + lccdf(a)
    */
   void test_repeat_as_vector() {
-    if (stan::is_any_var_matrix<T0, T1, T2, T3, T4, T5>::value) {
-      // There is no way to do this test for a `var_value` matrix
-      // because this is testing what happens when all elements of
-      // the vector are the same thing. This works the PIMP var types
-      // stored in other containers because every var can point at the
-      // same vari. However, when a var_value of length N is allocated
-      // there are N values and N adjoints and they are all separate.
-
-      SUCCEED() << "No test for var_value<Eigen::Matrix<T, R, C>> arguments";
-      return;
-    }
     if (!any_vector<T0, T1, T2, T3, T4, T5>::value) {
       SUCCEED() << "No test for non-vector arguments";
       return;
@@ -545,22 +519,26 @@ class AgradCcdfLogTestFixture : public ::testing::Test {
       Scalar3 p3_ = get_param<Scalar3>(parameters[n], 3);
       Scalar4 p4_ = get_param<Scalar4>(parameters[n], 4);
       Scalar5 p5_ = get_param<Scalar5>(parameters[n], 5);
+      vector<var> s1;
+      vector<var> s2;
+      vector<var> s3;
       std::vector<Scalar0> p0s_((is_vector<T0>::value) ? N_REPEAT : 1, p0_);
       std::vector<Scalar1> p1s_((is_vector<T1>::value) ? N_REPEAT : 1, p1_);
       std::vector<Scalar2> p2s_((is_vector<T2>::value) ? N_REPEAT : 1, p2_);
       std::vector<Scalar3> p3s_((is_vector<T3>::value) ? N_REPEAT : 1, p3_);
       std::vector<Scalar4> p4s_((is_vector<T4>::value) ? N_REPEAT : 1, p4_);
       std::vector<Scalar5> p5s_((is_vector<T5>::value) ? N_REPEAT : 1, p5_);
+      add_vars(s1, p0s_, p1s_, p2s_, p3s_, p4s_, p5s_);
+      add_vars(s2, p0s_, p1s_, p2s_, p3s_, p4s_, p5s_);
+      add_vars(s3, p0s_, p1s_, p2s_, p3s_, p4s_, p5s_);
 
       T_return_type ccdf_log
           = N_REPEAT * TestClass.ccdf_log(p0_, p1_, p2_, p3_, p4_, p5_);
 
-      double single_ccdf_log = calculate_gradients_1storder(
-          single_gradients1, ccdf_log, p0s_, p1s_, p2s_, p3s_, p4s_, p5s_);
-      calculate_gradients_2ndorder(single_gradients2, ccdf_log, p0s_, p1s_,
-                                   p2s_, p3s_, p4s_, p5s_);
-      calculate_gradients_3rdorder(single_gradients3, ccdf_log, p0s_, p1s_,
-                                   p2s_, p3s_, p4s_, p5s_);
+      double single_ccdf_log
+          = calculate_gradients_1storder(single_gradients1, ccdf_log, s1);
+      calculate_gradients_2ndorder(single_gradients2, ccdf_log, s2);
+      calculate_gradients_3rdorder(single_gradients3, ccdf_log, s3);
 
       T0 p0 = get_repeated_params<T0>(parameters[n], 0, N_REPEAT);
       T1 p1 = get_repeated_params<T1>(parameters[n], 1, N_REPEAT);
@@ -574,13 +552,16 @@ class AgradCcdfLogTestFixture : public ::testing::Test {
       vector<double> multiple_gradients1;
       vector<double> multiple_gradients2;
       vector<double> multiple_gradients3;
+      vector<var> x1;
+      vector<var> x2;
+      vector<var> x3;
+      add_vars(x1, p0, p1, p2, p3, p4, p5);
+      add_vars(x2, p0, p1, p2, p3, p4, p5);
+      add_vars(x3, p0, p1, p2, p3, p4, p5);
 
-      calculate_gradients_1storder(multiple_gradients1, multiple_ccdf_log, p0,
-                                   p1, p2, p3, p4, p5);
-      calculate_gradients_2ndorder(multiple_gradients2, multiple_ccdf_log, p0,
-                                   p1, p2, p3, p4, p5);
-      calculate_gradients_3rdorder(multiple_gradients3, multiple_ccdf_log, p0,
-                                   p1, p2, p3, p4, p5);
+      calculate_gradients_1storder(multiple_gradients1, multiple_ccdf_log, x1);
+      calculate_gradients_2ndorder(multiple_gradients2, multiple_ccdf_log, x2);
+      calculate_gradients_3rdorder(multiple_gradients3, multiple_ccdf_log, x3);
 
       stan::math::recover_memory();
 
@@ -623,10 +604,12 @@ class AgradCcdfLogTestFixture : public ::testing::Test {
     vector<double> single_gradients1;
     vector<double> single_gradients2;
     vector<double> single_gradients3;
+    vector<var> scalar_vars;
 
     vector<double> multiple_gradients1;
     vector<double> multiple_gradients2;
     vector<double> multiple_gradients3;
+    vector<var> vector_vars;
 
     T0 p0 = get_params<T0>(parameters, 0);
     T1 p1 = get_params<T1>(parameters, 1);
@@ -668,22 +651,40 @@ class AgradCcdfLogTestFixture : public ::testing::Test {
                                             p3s.back(), p4s.back(), p5s.back());
     }
 
-    calculate_gradients_1storder(single_gradients1, single_ccdf_log, p0s, p1s,
-                                 p2s, p3s, p4s, p5s);
-    calculate_gradients_2ndorder(single_gradients2, single_ccdf_log, p0s, p1s,
-                                 p2s, p3s, p4s, p5s);
-    calculate_gradients_3rdorder(single_gradients3, single_ccdf_log, p0s, p1s,
-                                 p2s, p3s, p4s, p5s);
+    add_var(vector_vars, p0);
+    add_var(scalar_vars, p0s);
+
+    add_var(vector_vars, p1);
+    add_var(scalar_vars, p1s);
+
+    add_var(vector_vars, p2);
+    add_var(scalar_vars, p2s);
+
+    add_var(vector_vars, p3);
+    add_var(scalar_vars, p3s);
+
+    add_var(vector_vars, p4);
+    add_var(scalar_vars, p4s);
+
+    add_var(vector_vars, p5);
+    add_var(scalar_vars, p5s);
+
+    calculate_gradients_1storder(single_gradients1, single_ccdf_log,
+                                 scalar_vars);
+    calculate_gradients_2ndorder(single_gradients2, single_ccdf_log,
+                                 scalar_vars);
+    calculate_gradients_3rdorder(single_gradients3, single_ccdf_log,
+                                 scalar_vars);
 
     T_return_type multiple_ccdf_log
         = TestClass.ccdf_log(p0, p1, p2, p3, p4, p5);
 
-    calculate_gradients_1storder(multiple_gradients1, multiple_ccdf_log, p0, p1,
-                                 p2, p3, p4, p5);
-    calculate_gradients_2ndorder(multiple_gradients2, multiple_ccdf_log, p0, p1,
-                                 p2, p3, p4, p5);
-    calculate_gradients_3rdorder(multiple_gradients3, multiple_ccdf_log, p0, p1,
-                                 p2, p3, p4, p5);
+    calculate_gradients_1storder(multiple_gradients1, multiple_ccdf_log,
+                                 vector_vars);
+    calculate_gradients_2ndorder(multiple_gradients2, multiple_ccdf_log,
+                                 vector_vars);
+    calculate_gradients_3rdorder(multiple_gradients3, multiple_ccdf_log,
+                                 vector_vars);
 
     stan::math::recover_memory();
 

--- a/test/prob/test_fixture_cdf.hpp
+++ b/test/prob/test_fixture_cdf.hpp
@@ -240,131 +240,102 @@ class AgradCdfTestFixture : public ::testing::Test {
   }
 
   // works for <double>
-  template <typename... Args>
-  double calculate_gradients_1storder(vector<double>& grad, double& logprob,
-                                      Args&... args) {
-    return logprob;
+  double calculate_gradients_1storder(vector<double>& grad, double& cdf,
+                                      vector<var>& x) {
+    return cdf;
   }
-  template <typename... Args>
-  double calculate_gradients_2ndorder(vector<double>& grad, double& logprob,
-                                      Args&... x) {
-    return logprob;
+  double calculate_gradients_2ndorder(vector<double>& grad, double& cdf,
+                                      vector<var>& x) {
+    return cdf;
   }
-  template <typename... Args>
-  double calculate_gradients_3rdorder(vector<double>& grad, double& logprob,
-                                      Args&... x) {
-    return logprob;
+  double calculate_gradients_3rdorder(vector<double>& grad, double& cdf,
+                                      vector<var>& x) {
+    return cdf;
   }
 
   // works for <var>
-  template <typename... Args>
-  double calculate_gradients_1storder(vector<double>& grad, var& logprob,
-                                      Args&... args) {
+  double calculate_gradients_1storder(vector<double>& grad, var& cdf,
+                                      vector<var>& x) {
     stan::math::set_zero_all_adjoints();
-    logprob.grad();
-    add_adjoints(grad, args...);
-    return logprob.val();
+    cdf.grad(x, grad);
+    return cdf.val();
   }
-  template <typename... Args>
-  double calculate_gradients_2ndorder(vector<double>& grad, var& logprob,
-                                      Args&... args) {
-    return logprob.val();
+  double calculate_gradients_2ndorder(vector<double>& grad, var& cdf,
+                                      vector<var>& x) {
+    return cdf.val();
   }
-  template <typename... Args>
-  double calculate_gradients_3rdorder(vector<double>& grad, var& logprob,
-                                      Args&... args) {
-    return logprob.val();
+  double calculate_gradients_3rdorder(vector<double>& grad, var& cdf,
+                                      vector<var>& x) {
+    return cdf.val();
   }
 
   // works for fvar<double>
-  template <typename... Args>
-  double calculate_gradients_1storder(vector<double>& grad,
-                                      fvar<double>& logprob, Args&... args) {
-    grad.push_back(logprob.d_);
-    return logprob.val();
+  double calculate_gradients_1storder(vector<double>& grad, fvar<double>& cdf,
+                                      vector<var>& x) {
+    grad.push_back(cdf.d_);
+    return cdf.val();
   }
-  template <typename... Args>
-  double calculate_gradients_2ndorder(vector<double>& grad,
-                                      fvar<double>& logprob, Args&... args) {
-    return logprob.val();
+  double calculate_gradients_2ndorder(vector<double>& grad, fvar<double>& cdf,
+                                      vector<var>& x) {
+    return cdf.val();
   }
-  template <typename... Args>
-  double calculate_gradients_3rdorder(vector<double>& grad,
-                                      fvar<double>& logprob, Args&... args) {
-    return logprob.val();
+  double calculate_gradients_3rdorder(vector<double>& grad, fvar<double>& cdf,
+                                      vector<var>& x) {
+    return cdf.val();
   }
 
   // works for fvar<fvar<double> >
-  template <typename... Args>
   double calculate_gradients_1storder(vector<double>& grad,
-                                      fvar<fvar<double>>& logprob,
-                                      Args&... args) {
-    grad.push_back(logprob.d_.val_);
-
-    return logprob.val().val();
+                                      fvar<fvar<double>>& cdf, vector<var>& x) {
+    grad.push_back(cdf.d_.val_);
+    return cdf.val().val();
   }
-  template <typename... Args>
   double calculate_gradients_2ndorder(vector<double>& grad,
-                                      fvar<fvar<double>>& logprob,
-                                      Args&... args) {
-    grad.push_back(logprob.d_.d_);
-    return logprob.val().val();
+                                      fvar<fvar<double>>& cdf, vector<var>& x) {
+    grad.push_back(cdf.d_.d_);
+    return cdf.val().val();
   }
-  template <typename... Args>
   double calculate_gradients_3rdorder(vector<double>& grad,
-                                      fvar<fvar<double>>& logprob,
-                                      Args&... args) {
-    return logprob.val().val();
+                                      fvar<fvar<double>>& cdf, vector<var>& x) {
+    return cdf.val().val();
   }
 
   // works for fvar<var>
-  template <typename... Args>
-  double calculate_gradients_1storder(vector<double>& grad, fvar<var>& logprob,
-                                      Args&... args) {
+  double calculate_gradients_1storder(vector<double>& grad, fvar<var>& cdf,
+                                      vector<var>& x) {
     stan::math::set_zero_all_adjoints();
-    logprob.val_.grad();
-    add_adjoints(grad, args...);
-    return logprob.val_.val();
+    cdf.val_.grad(x, grad);
+    return cdf.val_.val();
   }
-  template <typename... Args>
-  double calculate_gradients_2ndorder(vector<double>& grad, fvar<var>& logprob,
-                                      Args&... args) {
+  double calculate_gradients_2ndorder(vector<double>& grad, fvar<var>& cdf,
+                                      vector<var>& x) {
     stan::math::set_zero_all_adjoints();
-    logprob.d_.grad();
-    add_adjoints(grad, args...);
-    return logprob.val_.val();
+    cdf.d_.grad(x, grad);
+    return cdf.val_.val();
   }
-  template <typename... Args>
-  double calculate_gradients_3rdorder(vector<double>& grad, fvar<var>& logprob,
-                                      Args&... args) {
-    return logprob.val_.val();
+  double calculate_gradients_3rdorder(vector<double>& grad, fvar<var>& cdf,
+                                      vector<var>& x) {
+    return cdf.val_.val();
   }
 
   // works for fvar<fvar<var> >
-  template <typename... Args>
   double calculate_gradients_1storder(vector<double>& grad,
-                                      fvar<fvar<var>>& logprob, Args&... args) {
+                                      fvar<fvar<var>>& cdf, vector<var>& x) {
     stan::math::set_zero_all_adjoints();
-    logprob.val_.val_.grad();
-    add_adjoints(grad, args...);
-    return logprob.val_.val_.val();
+    cdf.val_.val_.grad(x, grad);
+    return cdf.val_.val_.val();
   }
-  template <typename... Args>
   double calculate_gradients_2ndorder(vector<double>& grad,
-                                      fvar<fvar<var>>& logprob, Args&... args) {
+                                      fvar<fvar<var>>& cdf, vector<var>& x) {
     stan::math::set_zero_all_adjoints();
-    logprob.d_.val_.grad();
-    add_adjoints(grad, args...);
-
-    return logprob.val_.val_.val();
+    cdf.d_.val_.grad(x, grad);
+    return cdf.val_.val_.val();
   }
-  template <typename... Args>
   double calculate_gradients_3rdorder(vector<double>& grad,
-                                      fvar<fvar<var>>& logprob, Args&... args) {
+                                      fvar<fvar<var>>& cdf, vector<var>& x) {
     stan::math::set_zero_all_adjoints();
-    logprob.d_.d_.grad();
-    add_adjoints(grad, args...);
-    return logprob.val_.val_.val();
+    cdf.d_.d_.grad(x, grad);
+    return cdf.val_.val_.val();
   }
 
   void test_finite_diffs_equal(const vector<double>& parameters,
@@ -419,11 +390,14 @@ class AgradCdfTestFixture : public ::testing::Test {
         Scalar4 p4 = get_param<Scalar4>(parameters[n], 4);
         Scalar5 p5 = get_param<Scalar5>(parameters[n], 5);
 
+        vector<var> x1;
+        add_vars(x1, p0, p1, p2, p3, p4, p5);
+
         T_return_type cdf
             = TestClass.template cdf<Scalar0, Scalar1, Scalar2, Scalar3,
                                      Scalar4, Scalar5>(p0, p1, p2, p3, p4, p5);
 
-        calculate_gradients_1storder(gradients, cdf, p0, p1, p2, p3, p4, p5);
+        calculate_gradients_1storder(gradients, cdf, x1);
 
         test_finite_diffs_equal(parameters[n], finite_diffs, gradients);
 
@@ -471,6 +445,19 @@ class AgradCdfTestFixture : public ::testing::Test {
       Scalar4 p4 = get_param<Scalar4>(parameters[n], 4);
       Scalar5 p5 = get_param<Scalar5>(parameters[n], 5);
 
+      vector<var> x1;
+      vector<var> x2;
+      vector<var> x3;
+      vector<var> y1;
+      vector<var> y2;
+      vector<var> y3;
+      add_vars(x1, p0, p1, p2, p3, p4, p5);
+      add_vars(x2, p0, p1, p2, p3, p4, p5);
+      add_vars(x3, p0, p1, p2, p3, p4, p5);
+      add_vars(y1, p0, p1, p2, p3, p4, p5);
+      add_vars(y2, p0, p1, p2, p3, p4, p5);
+      add_vars(y3, p0, p1, p2, p3, p4, p5);
+
       T_return_type cdf
           = TestClass.template cdf<Scalar0, Scalar1, Scalar2, Scalar3, Scalar4,
                                    Scalar5>(p0, p1, p2, p3, p4, p5);
@@ -480,15 +467,12 @@ class AgradCdfTestFixture : public ::testing::Test {
                                             Scalar4, Scalar5>(p0, p1, p2, p3,
                                                               p4, p5);
 
-      calculate_gradients_1storder(expected_gradients1, cdf_funct, p0, p1, p2,
-                                   p3, p4, p5);
-      calculate_gradients_1storder(gradients1, cdf, p0, p1, p2, p3, p4, p5);
-      calculate_gradients_2ndorder(expected_gradients2, cdf_funct, p0, p1, p2,
-                                   p3, p4, p5);
-      calculate_gradients_2ndorder(gradients2, cdf, p0, p1, p2, p3, p4, p5);
-      calculate_gradients_3rdorder(expected_gradients3, cdf_funct, p0, p1, p2,
-                                   p3, p4, p5);
-      calculate_gradients_3rdorder(gradients3, cdf, p0, p1, p2, p3, p4, p5);
+      calculate_gradients_1storder(expected_gradients1, cdf_funct, x1);
+      calculate_gradients_1storder(gradients1, cdf, y1);
+      calculate_gradients_2ndorder(expected_gradients2, cdf_funct, x2);
+      calculate_gradients_2ndorder(gradients2, cdf, y2);
+      calculate_gradients_3rdorder(expected_gradients3, cdf_funct, x3);
+      calculate_gradients_3rdorder(gradients3, cdf, y3);
 
       test_gradients_equal(expected_gradients1, gradients1);
       test_gradients_equal(expected_gradients2, gradients2);
@@ -508,17 +492,6 @@ class AgradCdfTestFixture : public ::testing::Test {
     using stan::math::pow;
     using std::pow;
 
-    if (stan::is_any_var_matrix<T0, T1, T2, T3, T4, T5>::value) {
-      // There is no way to do this test for a `var_value` matrix
-      // because this is testing what happens when all elements of
-      // the vector are the same thing. This works the PIMP var types
-      // stored in other containers because every var can point at the
-      // same vari. However, when a var_value of length N is allocated
-      // there are N values and N adjoints and they are all separate.
-
-      SUCCEED() << "No test for var_value<Eigen::Matrix<T, R, C>> arguments";
-      return;
-    }
     if (!any_vector<T0, T1, T2, T3, T4, T5>::value) {
       SUCCEED() << "No test for non-vector arguments";
       return;
@@ -540,22 +513,26 @@ class AgradCdfTestFixture : public ::testing::Test {
       Scalar3 p3_ = get_param<Scalar3>(parameters[n], 3);
       Scalar4 p4_ = get_param<Scalar4>(parameters[n], 4);
       Scalar5 p5_ = get_param<Scalar5>(parameters[n], 5);
+      vector<var> s1;
+      vector<var> s2;
+      vector<var> s3;
       std::vector<Scalar0> p0s_((is_vector<T0>::value) ? N_REPEAT : 1, p0_);
       std::vector<Scalar1> p1s_((is_vector<T1>::value) ? N_REPEAT : 1, p1_);
       std::vector<Scalar2> p2s_((is_vector<T2>::value) ? N_REPEAT : 1, p2_);
       std::vector<Scalar3> p3s_((is_vector<T3>::value) ? N_REPEAT : 1, p3_);
       std::vector<Scalar4> p4s_((is_vector<T4>::value) ? N_REPEAT : 1, p4_);
       std::vector<Scalar5> p5s_((is_vector<T5>::value) ? N_REPEAT : 1, p5_);
+      add_vars(s1, p0s_, p1s_, p2s_, p3s_, p4s_, p5s_);
+      add_vars(s2, p0s_, p1s_, p2s_, p3s_, p4s_, p5s_);
+      add_vars(s3, p0s_, p1s_, p2s_, p3s_, p4s_, p5s_);
 
       T_return_type cdf
           = pow(TestClass.cdf(p0_, p1_, p2_, p3_, p4_, p5_), N_REPEAT);
 
-      double single_cdf = calculate_gradients_1storder(
-          single_gradients1, cdf, p0s_, p1s_, p2s_, p3s_, p4s_, p5s_);
-      calculate_gradients_2ndorder(single_gradients2, cdf, p0s_, p1s_, p2s_,
-                                   p3s_, p4s_, p5s_);
-      calculate_gradients_3rdorder(single_gradients3, cdf, p0s_, p1s_, p2s_,
-                                   p3s_, p4s_, p5s_);
+      double single_cdf
+          = calculate_gradients_1storder(single_gradients1, cdf, s1);
+      calculate_gradients_2ndorder(single_gradients2, cdf, s2);
+      calculate_gradients_3rdorder(single_gradients3, cdf, s3);
 
       T0 p0 = get_repeated_params<T0>(parameters[n], 0, N_REPEAT);
       T1 p1 = get_repeated_params<T1>(parameters[n], 1, N_REPEAT);
@@ -568,13 +545,16 @@ class AgradCdfTestFixture : public ::testing::Test {
       vector<double> multiple_gradients1;
       vector<double> multiple_gradients2;
       vector<double> multiple_gradients3;
+      vector<var> x1;
+      vector<var> x2;
+      vector<var> x3;
+      add_vars(x1, p0, p1, p2, p3, p4, p5);
+      add_vars(x2, p0, p1, p2, p3, p4, p5);
+      add_vars(x3, p0, p1, p2, p3, p4, p5);
 
-      calculate_gradients_1storder(multiple_gradients1, multiple_cdf, p0, p1,
-                                   p2, p3, p4, p5);
-      calculate_gradients_2ndorder(multiple_gradients2, multiple_cdf, p0, p1,
-                                   p2, p3, p4, p5);
-      calculate_gradients_3rdorder(multiple_gradients3, multiple_cdf, p0, p1,
-                                   p2, p3, p4, p5);
+      calculate_gradients_1storder(multiple_gradients1, multiple_cdf, x1);
+      calculate_gradients_2ndorder(multiple_gradients2, multiple_cdf, x2);
+      calculate_gradients_3rdorder(multiple_gradients3, multiple_cdf, x3);
 
       stan::math::recover_memory();
 
@@ -617,10 +597,12 @@ class AgradCdfTestFixture : public ::testing::Test {
     vector<double> single_gradients1;
     vector<double> single_gradients2;
     vector<double> single_gradients3;
+    vector<var> scalar_vars;
 
     vector<double> multiple_gradients1;
     vector<double> multiple_gradients2;
     vector<double> multiple_gradients3;
+    vector<var> vector_vars;
 
     T0 p0 = get_params<T0>(parameters, 0);
     T1 p1 = get_params<T1>(parameters, 1);
@@ -662,21 +644,36 @@ class AgradCdfTestFixture : public ::testing::Test {
                                   p3s.back(), p4s.back(), p5s.back());
     }
 
-    calculate_gradients_1storder(single_gradients1, single_cdf, p0s, p1s, p2s,
-                                 p3s, p4s, p5s);
-    calculate_gradients_2ndorder(single_gradients2, single_cdf, p0s, p1s, p2s,
-                                 p3s, p4s, p5s);
-    calculate_gradients_3rdorder(single_gradients3, single_cdf, p0s, p1s, p2s,
-                                 p3s, p4s, p5s);
+    add_var(vector_vars, p0);
+    add_var(scalar_vars, p0s);
+
+    add_var(vector_vars, p1);
+    add_var(scalar_vars, p1s);
+
+    add_var(vector_vars, p2);
+    add_var(scalar_vars, p2s);
+
+    add_var(vector_vars, p3);
+    add_var(scalar_vars, p3s);
+
+    add_var(vector_vars, p4);
+    add_var(scalar_vars, p4s);
+
+    add_var(vector_vars, p5);
+    add_var(scalar_vars, p5s);
+
+    calculate_gradients_1storder(single_gradients1, single_cdf, scalar_vars);
+    calculate_gradients_2ndorder(single_gradients2, single_cdf, scalar_vars);
+    calculate_gradients_3rdorder(single_gradients3, single_cdf, scalar_vars);
 
     T_return_type multiple_cdf = TestClass.cdf(p0, p1, p2, p3, p4, p5);
 
-    calculate_gradients_1storder(multiple_gradients1, multiple_cdf, p0, p1, p2,
-                                 p3, p4, p5);
-    calculate_gradients_2ndorder(multiple_gradients2, multiple_cdf, p0, p1, p2,
-                                 p3, p4, p5);
-    calculate_gradients_3rdorder(multiple_gradients3, multiple_cdf, p0, p1, p2,
-                                 p3, p4, p5);
+    calculate_gradients_1storder(multiple_gradients1, multiple_cdf,
+                                 vector_vars);
+    calculate_gradients_2ndorder(multiple_gradients2, multiple_cdf,
+                                 vector_vars);
+    calculate_gradients_3rdorder(multiple_gradients3, multiple_cdf,
+                                 vector_vars);
 
     stan::math::recover_memory();
 

--- a/test/prob/test_fixture_cdf_log.hpp
+++ b/test/prob/test_fixture_cdf_log.hpp
@@ -243,131 +243,108 @@ class AgradCdfLogTestFixture : public ::testing::Test {
   }
 
   // works for <double>
-  template <typename... Args>
-  double calculate_gradients_1storder(vector<double>& grad, double& logprob,
-                                      Args&... args) {
-    return logprob;
+  double calculate_gradients_1storder(vector<double>& grad, double& cdf_log,
+                                      vector<var>& x) {
+    return cdf_log;
   }
-  template <typename... Args>
-  double calculate_gradients_2ndorder(vector<double>& grad, double& logprob,
-                                      Args&... x) {
-    return logprob;
+  double calculate_gradients_2ndorder(vector<double>& grad, double& cdf_log,
+                                      vector<var>& x) {
+    return cdf_log;
   }
-  template <typename... Args>
-  double calculate_gradients_3rdorder(vector<double>& grad, double& logprob,
-                                      Args&... x) {
-    return logprob;
+  double calculate_gradients_3rdorder(vector<double>& grad, double& cdf_log,
+                                      vector<var>& x) {
+    return cdf_log;
   }
 
   // works for <var>
-  template <typename... Args>
-  double calculate_gradients_1storder(vector<double>& grad, var& logprob,
-                                      Args&... args) {
+  double calculate_gradients_1storder(vector<double>& grad, var& cdf_log,
+                                      vector<var>& x) {
     stan::math::set_zero_all_adjoints();
-    logprob.grad();
-    add_adjoints(grad, args...);
-    return logprob.val();
+    cdf_log.grad(x, grad);
+    return cdf_log.val();
   }
-  template <typename... Args>
-  double calculate_gradients_2ndorder(vector<double>& grad, var& logprob,
-                                      Args&... args) {
-    return logprob.val();
+  double calculate_gradients_2ndorder(vector<double>& grad, var& cdf_log,
+                                      vector<var>& x) {
+    return cdf_log.val();
   }
-  template <typename... Args>
-  double calculate_gradients_3rdorder(vector<double>& grad, var& logprob,
-                                      Args&... args) {
-    return logprob.val();
+  double calculate_gradients_3rdorder(vector<double>& grad, var& cdf_log,
+                                      vector<var>& x) {
+    return cdf_log.val();
   }
 
   // works for fvar<double>
-  template <typename... Args>
   double calculate_gradients_1storder(vector<double>& grad,
-                                      fvar<double>& logprob, Args&... args) {
-    grad.push_back(logprob.d_);
-    return logprob.val();
+                                      fvar<double>& cdf_log, vector<var>& x) {
+    grad.push_back(cdf_log.d_);
+    return cdf_log.val();
   }
-  template <typename... Args>
   double calculate_gradients_2ndorder(vector<double>& grad,
-                                      fvar<double>& logprob, Args&... args) {
-    return logprob.val();
+                                      fvar<double>& cdf_log, vector<var>& x) {
+    return cdf_log.val();
   }
-  template <typename... Args>
   double calculate_gradients_3rdorder(vector<double>& grad,
-                                      fvar<double>& logprob, Args&... args) {
-    return logprob.val();
+                                      fvar<double>& cdf_log, vector<var>& x) {
+    return cdf_log.val();
   }
 
   // works for fvar<fvar<double> >
-  template <typename... Args>
   double calculate_gradients_1storder(vector<double>& grad,
-                                      fvar<fvar<double>>& logprob,
-                                      Args&... args) {
-    grad.push_back(logprob.d_.val_);
-
-    return logprob.val().val();
+                                      fvar<fvar<double>>& cdf_log,
+                                      vector<var>& x) {
+    grad.push_back(cdf_log.d_.val_);
+    return cdf_log.val().val();
   }
-  template <typename... Args>
   double calculate_gradients_2ndorder(vector<double>& grad,
-                                      fvar<fvar<double>>& logprob,
-                                      Args&... args) {
-    grad.push_back(logprob.d_.d_);
-    return logprob.val().val();
+                                      fvar<fvar<double>>& cdf_log,
+                                      vector<var>& x) {
+    grad.push_back(cdf_log.d_.d_);
+    return cdf_log.val().val();
   }
-  template <typename... Args>
   double calculate_gradients_3rdorder(vector<double>& grad,
-                                      fvar<fvar<double>>& logprob,
-                                      Args&... args) {
-    return logprob.val().val();
+                                      fvar<fvar<double>>& cdf_log,
+                                      vector<var>& x) {
+    return cdf_log.val().val();
   }
 
   // works for fvar<var>
-  template <typename... Args>
-  double calculate_gradients_1storder(vector<double>& grad, fvar<var>& logprob,
-                                      Args&... args) {
+  double calculate_gradients_1storder(vector<double>& grad, fvar<var>& cdf_log,
+                                      vector<var>& x) {
     stan::math::set_zero_all_adjoints();
-    logprob.val_.grad();
-    add_adjoints(grad, args...);
-    return logprob.val_.val();
+    cdf_log.val_.grad(x, grad);
+    return cdf_log.val_.val();
   }
-  template <typename... Args>
-  double calculate_gradients_2ndorder(vector<double>& grad, fvar<var>& logprob,
-                                      Args&... args) {
+  double calculate_gradients_2ndorder(vector<double>& grad, fvar<var>& cdf_log,
+                                      vector<var>& x) {
     stan::math::set_zero_all_adjoints();
-    logprob.d_.grad();
-    add_adjoints(grad, args...);
-    return logprob.val_.val();
+    cdf_log.d_.grad(x, grad);
+    return cdf_log.val_.val();
   }
-  template <typename... Args>
-  double calculate_gradients_3rdorder(vector<double>& grad, fvar<var>& logprob,
-                                      Args&... args) {
-    return logprob.val_.val();
+  double calculate_gradients_3rdorder(vector<double>& grad, fvar<var>& cdf_log,
+                                      vector<var>& x) {
+    return cdf_log.val_.val();
   }
 
   // works for fvar<fvar<var> >
-  template <typename... Args>
   double calculate_gradients_1storder(vector<double>& grad,
-                                      fvar<fvar<var>>& logprob, Args&... args) {
+                                      fvar<fvar<var>>& cdf_log,
+                                      vector<var>& x) {
     stan::math::set_zero_all_adjoints();
-    logprob.val_.val_.grad();
-    add_adjoints(grad, args...);
-    return logprob.val_.val_.val();
+    cdf_log.val_.val_.grad(x, grad);
+    return cdf_log.val_.val_.val();
   }
-  template <typename... Args>
   double calculate_gradients_2ndorder(vector<double>& grad,
-                                      fvar<fvar<var>>& logprob, Args&... args) {
+                                      fvar<fvar<var>>& cdf_log,
+                                      vector<var>& x) {
     stan::math::set_zero_all_adjoints();
-    logprob.d_.val_.grad();
-    add_adjoints(grad, args...);
-
-    return logprob.val_.val_.val();
+    cdf_log.d_.val_.grad(x, grad);
+    return cdf_log.val_.val_.val();
   }
-  template <typename... Args>
   double calculate_gradients_3rdorder(vector<double>& grad,
-                                      fvar<fvar<var>>& logprob, Args&... args) {
+                                      fvar<fvar<var>>& cdf_log,
+                                      vector<var>& x) {
     stan::math::set_zero_all_adjoints();
-    logprob.d_.d_.grad();
-    add_adjoints(grad, args...);
-    return logprob.val_.val_.val();
+    cdf_log.d_.d_.grad(x, grad);
+    return cdf_log.val_.val_.val();
   }
 
   void test_finite_diffs_equal(const vector<double>& parameters,
@@ -422,13 +399,15 @@ class AgradCdfLogTestFixture : public ::testing::Test {
         Scalar4 p4 = get_param<Scalar4>(parameters[n], 4);
         Scalar5 p5 = get_param<Scalar5>(parameters[n], 5);
 
+        vector<var> x1;
+        add_vars(x1, p0, p1, p2, p3, p4, p5);
+
         T_return_type cdf_log
             = TestClass.template cdf_log<Scalar0, Scalar1, Scalar2, Scalar3,
                                          Scalar4, Scalar5>(p0, p1, p2, p3, p4,
                                                            p5);
 
-        calculate_gradients_1storder(gradients, cdf_log, p0, p1, p2, p3, p4,
-                                     p5);
+        calculate_gradients_1storder(gradients, cdf_log, x1);
 
         test_finite_diffs_equal(parameters[n], finite_diffs, gradients);
 
@@ -476,6 +455,19 @@ class AgradCdfLogTestFixture : public ::testing::Test {
       Scalar4 p4 = get_param<Scalar4>(parameters[n], 4);
       Scalar5 p5 = get_param<Scalar5>(parameters[n], 5);
 
+      vector<var> x1;
+      vector<var> x2;
+      vector<var> x3;
+      vector<var> y1;
+      vector<var> y2;
+      vector<var> y3;
+      add_vars(x1, p0, p1, p2, p3, p4, p5);
+      add_vars(x2, p0, p1, p2, p3, p4, p5);
+      add_vars(x3, p0, p1, p2, p3, p4, p5);
+      add_vars(y1, p0, p1, p2, p3, p4, p5);
+      add_vars(y2, p0, p1, p2, p3, p4, p5);
+      add_vars(y3, p0, p1, p2, p3, p4, p5);
+
       T_return_type cdf_log
           = TestClass.template cdf_log<Scalar0, Scalar1, Scalar2, Scalar3,
                                        Scalar4, Scalar5>(p0, p1, p2, p3, p4,
@@ -486,15 +478,12 @@ class AgradCdfLogTestFixture : public ::testing::Test {
                                                 Scalar3, Scalar4, Scalar5>(
               p0, p1, p2, p3, p4, p5);
 
-      calculate_gradients_1storder(expected_gradients1, cdf_log_funct, p0, p1,
-                                   p2, p3, p4, p5);
-      calculate_gradients_1storder(gradients1, cdf_log, p0, p1, p2, p3, p4, p5);
-      calculate_gradients_2ndorder(expected_gradients2, cdf_log_funct, p0, p1,
-                                   p2, p3, p4, p5);
-      calculate_gradients_2ndorder(gradients2, cdf_log, p0, p1, p2, p3, p4, p5);
-      calculate_gradients_3rdorder(expected_gradients3, cdf_log_funct, p0, p1,
-                                   p2, p3, p4, p5);
-      calculate_gradients_3rdorder(gradients3, cdf_log, p0, p1, p2, p3, p4, p5);
+      calculate_gradients_1storder(expected_gradients1, cdf_log_funct, x1);
+      calculate_gradients_1storder(gradients1, cdf_log, y1);
+      calculate_gradients_2ndorder(expected_gradients2, cdf_log_funct, x2);
+      calculate_gradients_2ndorder(gradients2, cdf_log, y2);
+      calculate_gradients_3rdorder(expected_gradients3, cdf_log_funct, x3);
+      calculate_gradients_3rdorder(gradients3, cdf_log, y3);
 
       test_gradients_equal(expected_gradients1, gradients1);
       test_gradients_equal(expected_gradients2, gradients2);
@@ -511,17 +500,6 @@ class AgradCdfLogTestFixture : public ::testing::Test {
    * For log cdf this means lcdf([a, a, a]) == lcdf(a) + lcdf(a) + lcdf(a)
    */
   void test_repeat_as_vector() {
-    if (stan::is_any_var_matrix<T0, T1, T2, T3, T4, T5>::value) {
-      // There is no way to do this test for a `var_value` matrix
-      // because this is testing what happens when all elements of
-      // the vector are the same thing. This works the PIMP var types
-      // stored in other containers because every var can point at the
-      // same vari. However, when a var_value of length N is allocated
-      // there are N values and N adjoints and they are all separate.
-
-      SUCCEED() << "No test for var_value<Eigen::Matrix<T, R, C>> arguments";
-      return;
-    }
     if (!any_vector<T0, T1, T2, T3, T4, T5>::value) {
       SUCCEED() << "No test for non-vector arguments";
       return;
@@ -542,22 +520,26 @@ class AgradCdfLogTestFixture : public ::testing::Test {
       Scalar3 p3_ = get_param<Scalar3>(parameters[n], 3);
       Scalar4 p4_ = get_param<Scalar4>(parameters[n], 4);
       Scalar5 p5_ = get_param<Scalar5>(parameters[n], 5);
+      vector<var> s1;
+      vector<var> s2;
+      vector<var> s3;
       std::vector<Scalar0> p0s_((is_vector<T0>::value) ? N_REPEAT : 1, p0_);
       std::vector<Scalar1> p1s_((is_vector<T1>::value) ? N_REPEAT : 1, p1_);
       std::vector<Scalar2> p2s_((is_vector<T2>::value) ? N_REPEAT : 1, p2_);
       std::vector<Scalar3> p3s_((is_vector<T3>::value) ? N_REPEAT : 1, p3_);
       std::vector<Scalar4> p4s_((is_vector<T4>::value) ? N_REPEAT : 1, p4_);
       std::vector<Scalar5> p5s_((is_vector<T5>::value) ? N_REPEAT : 1, p5_);
+      add_vars(s1, p0s_, p1s_, p2s_, p3s_, p4s_, p5s_);
+      add_vars(s2, p0s_, p1s_, p2s_, p3s_, p4s_, p5s_);
+      add_vars(s3, p0s_, p1s_, p2s_, p3s_, p4s_, p5s_);
 
       T_return_type cdf_log
           = N_REPEAT * TestClass.cdf_log(p0_, p1_, p2_, p3_, p4_, p5_);
 
-      double single_cdf_log = calculate_gradients_1storder(
-          single_gradients1, cdf_log, p0s_, p1s_, p2s_, p3s_, p4s_, p5s_);
-      calculate_gradients_2ndorder(single_gradients2, cdf_log, p0s_, p1s_, p2s_,
-                                   p3s_, p4s_, p5s_);
-      calculate_gradients_3rdorder(single_gradients3, cdf_log, p0s_, p1s_, p2s_,
-                                   p3s_, p4s_, p5s_);
+      double single_cdf_log
+          = calculate_gradients_1storder(single_gradients1, cdf_log, s1);
+      calculate_gradients_2ndorder(single_gradients2, cdf_log, s2);
+      calculate_gradients_3rdorder(single_gradients3, cdf_log, s3);
 
       T0 p0 = get_repeated_params<T0>(parameters[n], 0, N_REPEAT);
       T1 p1 = get_repeated_params<T1>(parameters[n], 1, N_REPEAT);
@@ -571,13 +553,16 @@ class AgradCdfLogTestFixture : public ::testing::Test {
       vector<double> multiple_gradients1;
       vector<double> multiple_gradients2;
       vector<double> multiple_gradients3;
+      vector<var> x1;
+      vector<var> x2;
+      vector<var> x3;
+      add_vars(x1, p0, p1, p2, p3, p4, p5);
+      add_vars(x2, p0, p1, p2, p3, p4, p5);
+      add_vars(x3, p0, p1, p2, p3, p4, p5);
 
-      calculate_gradients_1storder(multiple_gradients1, multiple_cdf_log, p0,
-                                   p1, p2, p3, p4, p5);
-      calculate_gradients_2ndorder(multiple_gradients2, multiple_cdf_log, p0,
-                                   p1, p2, p3, p4, p5);
-      calculate_gradients_3rdorder(multiple_gradients3, multiple_cdf_log, p0,
-                                   p1, p2, p3, p4, p5);
+      calculate_gradients_1storder(multiple_gradients1, multiple_cdf_log, x1);
+      calculate_gradients_2ndorder(multiple_gradients2, multiple_cdf_log, x2);
+      calculate_gradients_3rdorder(multiple_gradients3, multiple_cdf_log, x3);
 
       stan::math::recover_memory();
 
@@ -620,10 +605,12 @@ class AgradCdfLogTestFixture : public ::testing::Test {
     vector<double> single_gradients1;
     vector<double> single_gradients2;
     vector<double> single_gradients3;
+    vector<var> scalar_vars;
 
     vector<double> multiple_gradients1;
     vector<double> multiple_gradients2;
     vector<double> multiple_gradients3;
+    vector<var> vector_vars;
 
     T0 p0 = get_params<T0>(parameters, 0);
     T1 p1 = get_params<T1>(parameters, 1);
@@ -665,21 +652,39 @@ class AgradCdfLogTestFixture : public ::testing::Test {
                                           p3s.back(), p4s.back(), p5s.back());
     }
 
-    calculate_gradients_1storder(single_gradients1, single_cdf_log, p0s, p1s,
-                                 p2s, p3s, p4s, p5s);
-    calculate_gradients_2ndorder(single_gradients2, single_cdf_log, p0s, p1s,
-                                 p2s, p3s, p4s, p5s);
-    calculate_gradients_3rdorder(single_gradients3, single_cdf_log, p0s, p1s,
-                                 p2s, p3s, p4s, p5s);
+    add_var(vector_vars, p0);
+    add_var(scalar_vars, p0s);
+
+    add_var(vector_vars, p1);
+    add_var(scalar_vars, p1s);
+
+    add_var(vector_vars, p2);
+    add_var(scalar_vars, p2s);
+
+    add_var(vector_vars, p3);
+    add_var(scalar_vars, p3s);
+
+    add_var(vector_vars, p4);
+    add_var(scalar_vars, p4s);
+
+    add_var(vector_vars, p5);
+    add_var(scalar_vars, p5s);
+
+    calculate_gradients_1storder(single_gradients1, single_cdf_log,
+                                 scalar_vars);
+    calculate_gradients_2ndorder(single_gradients2, single_cdf_log,
+                                 scalar_vars);
+    calculate_gradients_3rdorder(single_gradients3, single_cdf_log,
+                                 scalar_vars);
 
     T_return_type multiple_cdf_log = TestClass.cdf_log(p0, p1, p2, p3, p4, p5);
 
-    calculate_gradients_1storder(multiple_gradients1, multiple_cdf_log, p0, p1,
-                                 p2, p3, p4, p5);
-    calculate_gradients_2ndorder(multiple_gradients2, multiple_cdf_log, p0, p1,
-                                 p2, p3, p4, p5);
-    calculate_gradients_3rdorder(multiple_gradients3, multiple_cdf_log, p0, p1,
-                                 p2, p3, p4, p5);
+    calculate_gradients_1storder(multiple_gradients1, multiple_cdf_log,
+                                 vector_vars);
+    calculate_gradients_2ndorder(multiple_gradients2, multiple_cdf_log,
+                                 vector_vars);
+    calculate_gradients_3rdorder(multiple_gradients3, multiple_cdf_log,
+                                 vector_vars);
 
     stan::math::recover_memory();
 

--- a/test/prob/test_fixture_distr.hpp
+++ b/test/prob/test_fixture_distr.hpp
@@ -304,130 +304,107 @@ class AgradDistributionTestFixture : public ::testing::Test {
   }
 
   // works for <double>
-  template <typename... Args>
   double calculate_gradients_1storder(vector<double>& grad, double& logprob,
-                                      Args&... args) {
+                                      vector<var>& x) {
     return logprob;
   }
-  template <typename... Args>
   double calculate_gradients_2ndorder(vector<double>& grad, double& logprob,
-                                      Args&... x) {
+                                      vector<var>& x) {
     return logprob;
   }
-  template <typename... Args>
   double calculate_gradients_3rdorder(vector<double>& grad, double& logprob,
-                                      Args&... x) {
+                                      vector<var>& x) {
     return logprob;
   }
 
   // works for <var>
-  template <typename... Args>
   double calculate_gradients_1storder(vector<double>& grad, var& logprob,
-                                      Args&... args) {
+                                      vector<var>& x) {
     stan::math::set_zero_all_adjoints();
-    logprob.grad();
-    add_adjoints(grad, args...);
+    logprob.grad(x, grad);
     return logprob.val();
   }
-  template <typename... Args>
   double calculate_gradients_2ndorder(vector<double>& grad, var& logprob,
-                                      Args&... args) {
+                                      vector<var>& x) {
     return logprob.val();
   }
-  template <typename... Args>
   double calculate_gradients_3rdorder(vector<double>& grad, var& logprob,
-                                      Args&... args) {
+                                      vector<var>& x) {
     return logprob.val();
   }
 
   // works for fvar<double>
-  template <typename... Args>
   double calculate_gradients_1storder(vector<double>& grad,
-                                      fvar<double>& logprob, Args&... args) {
+                                      fvar<double>& logprob, vector<var>& x) {
     grad.push_back(logprob.d_);
     return logprob.val();
   }
-  template <typename... Args>
   double calculate_gradients_2ndorder(vector<double>& grad,
-                                      fvar<double>& logprob, Args&... args) {
+                                      fvar<double>& logprob, vector<var>& x) {
     return logprob.val();
   }
-  template <typename... Args>
   double calculate_gradients_3rdorder(vector<double>& grad,
-                                      fvar<double>& logprob, Args&... args) {
+                                      fvar<double>& logprob, vector<var>& x) {
     return logprob.val();
   }
 
   // works for fvar<fvar<double> >
-  template <typename... Args>
   double calculate_gradients_1storder(vector<double>& grad,
                                       fvar<fvar<double>>& logprob,
-                                      Args&... args) {
+                                      vector<var>& x) {
     grad.push_back(logprob.d_.val_);
-
     return logprob.val().val();
   }
-  template <typename... Args>
   double calculate_gradients_2ndorder(vector<double>& grad,
                                       fvar<fvar<double>>& logprob,
-                                      Args&... args) {
+                                      vector<var>& x) {
     grad.push_back(logprob.d_.d_);
     return logprob.val().val();
   }
-  template <typename... Args>
   double calculate_gradients_3rdorder(vector<double>& grad,
                                       fvar<fvar<double>>& logprob,
-                                      Args&... args) {
+                                      vector<var>& x) {
     return logprob.val().val();
   }
 
   // works for fvar<var>
-  template <typename... Args>
   double calculate_gradients_1storder(vector<double>& grad, fvar<var>& logprob,
-                                      Args&... args) {
+                                      vector<var>& x) {
     stan::math::set_zero_all_adjoints();
-    logprob.val_.grad();
-    add_adjoints(grad, args...);
+    logprob.val_.grad(x, grad);
     return logprob.val_.val();
   }
-  template <typename... Args>
   double calculate_gradients_2ndorder(vector<double>& grad, fvar<var>& logprob,
-                                      Args&... args) {
+                                      vector<var>& x) {
     stan::math::set_zero_all_adjoints();
-    logprob.d_.grad();
-    add_adjoints(grad, args...);
+    logprob.d_.grad(x, grad);
     return logprob.val_.val();
   }
-  template <typename... Args>
   double calculate_gradients_3rdorder(vector<double>& grad, fvar<var>& logprob,
-                                      Args&... args) {
+                                      vector<var>& x) {
     return logprob.val_.val();
   }
 
   // works for fvar<fvar<var> >
-  template <typename... Args>
   double calculate_gradients_1storder(vector<double>& grad,
-                                      fvar<fvar<var>>& logprob, Args&... args) {
+                                      fvar<fvar<var>>& logprob,
+                                      vector<var>& x) {
     stan::math::set_zero_all_adjoints();
-    logprob.val_.val_.grad();
-    add_adjoints(grad, args...);
+    logprob.val_.val_.grad(x, grad);
     return logprob.val_.val_.val();
   }
-  template <typename... Args>
   double calculate_gradients_2ndorder(vector<double>& grad,
-                                      fvar<fvar<var>>& logprob, Args&... args) {
+                                      fvar<fvar<var>>& logprob,
+                                      vector<var>& x) {
     stan::math::set_zero_all_adjoints();
-    logprob.d_.val_.grad();
-    add_adjoints(grad, args...);
-
+    logprob.d_.val_.grad(x, grad);
     return logprob.val_.val_.val();
   }
-  template <typename... Args>
   double calculate_gradients_3rdorder(vector<double>& grad,
-                                      fvar<fvar<var>>& logprob, Args&... args) {
+                                      fvar<fvar<var>>& logprob,
+                                      vector<var>& x) {
     stan::math::set_zero_all_adjoints();
-    logprob.d_.d_.grad();
-    add_adjoints(grad, args...);
+    logprob.d_.d_.grad(x, grad);
     return logprob.val_.val_.val();
   }
 
@@ -485,13 +462,14 @@ class AgradDistributionTestFixture : public ::testing::Test {
         Scalar3 p3_ = get_param<Scalar3>(parameters[n], 3);
         Scalar4 p4_ = get_param<Scalar4>(parameters[n], 4);
         Scalar5 p5_ = get_param<Scalar5>(parameters[n], 5);
+        vector<var> x;
+        add_vars(x, p0_, p1_, p2_, p3_, p4_, p5_);
 
         T_return_type logprob
             = TestClass.template log_prob<false, Scalar0, Scalar1, Scalar2,
                                           Scalar3, Scalar4, Scalar5>(
                 p0_, p1_, p2_, p3_, p4_, p5_);
-        calculate_gradients_1storder(gradients, logprob, p0_, p1_, p2_, p3_,
-                                     p4_, p5_);
+        calculate_gradients_1storder(gradients, logprob, x);
 
         test_finite_diffs_equal(parameters[n], finite_diffs, gradients);
       }
@@ -540,6 +518,19 @@ class AgradDistributionTestFixture : public ::testing::Test {
       Scalar4 p4 = get_param<Scalar4>(parameters[n], 4);
       Scalar5 p5 = get_param<Scalar5>(parameters[n], 5);
 
+      vector<var> x1;
+      vector<var> x2;
+      vector<var> x3;
+      vector<var> y1;
+      vector<var> y2;
+      vector<var> y3;
+      add_vars(x1, p0, p1, p2, p3, p4, p5);
+      add_vars(x2, p0, p1, p2, p3, p4, p5);
+      add_vars(x3, p0, p1, p2, p3, p4, p5);
+      add_vars(y1, p0, p1, p2, p3, p4, p5);
+      add_vars(y2, p0, p1, p2, p3, p4, p5);
+      add_vars(y3, p0, p1, p2, p3, p4, p5);
+
       T_return_type logprob
           = TestClass.template log_prob<Scalar0, Scalar1, Scalar2, Scalar3,
                                         Scalar4, Scalar5>(p0, p1, p2, p3, p4,
@@ -550,15 +541,12 @@ class AgradDistributionTestFixture : public ::testing::Test {
                                                  Scalar3, Scalar4, Scalar5>(
               p0, p1, p2, p3, p4, p5);
 
-      calculate_gradients_1storder(expected_gradients1, logprob_funct, p0, p1,
-                                   p2, p3, p4, p5);
-      calculate_gradients_1storder(gradients1, logprob, p0, p1, p2, p3, p4, p5);
-      calculate_gradients_2ndorder(expected_gradients2, logprob_funct, p0, p1,
-                                   p2, p3, p4, p5);
-      calculate_gradients_2ndorder(gradients2, logprob, p0, p1, p2, p3, p4, p5);
-      calculate_gradients_3rdorder(expected_gradients3, logprob_funct, p0, p1,
-                                   p2, p3, p4, p5);
-      calculate_gradients_3rdorder(gradients3, logprob, p0, p1, p2, p3, p4, p5);
+      calculate_gradients_1storder(expected_gradients1, logprob_funct, x1);
+      calculate_gradients_1storder(gradients1, logprob, y1);
+      calculate_gradients_2ndorder(expected_gradients2, logprob_funct, x2);
+      calculate_gradients_2ndorder(gradients2, logprob, y2);
+      calculate_gradients_3rdorder(expected_gradients3, logprob_funct, x3);
+      calculate_gradients_3rdorder(gradients3, logprob, y3);
 
       test_gradients_equal(expected_gradients1, gradients1);
       test_gradients_equal(expected_gradients2, gradients2);
@@ -583,17 +571,6 @@ class AgradDistributionTestFixture : public ::testing::Test {
       SUCCEED() << "No test for all double arguments";
       return;
     }
-    if (stan::is_any_var_matrix<T0, T1, T2, T3, T4, T5>::value) {
-      // There is no way to do this test for a `var_value` matrix
-      // because this is testing what happens when all elements of
-      // the vector are the same thing. This works the PIMP var types
-      // stored in other containers because every var can point at the
-      // same vari. However, when a var_value of length N is allocated
-      // there are N values and N adjoints and they are all separate.
-
-      SUCCEED() << "No test for var_value<Eigen::Matrix<T, R, C>> arguments";
-      return;
-    }
     if (!any_vector<T0, T1, T2, T3, T4, T5>::value) {
       SUCCEED() << "No test for non-vector arguments";
       return;
@@ -614,22 +591,26 @@ class AgradDistributionTestFixture : public ::testing::Test {
       Scalar3 p3_ = get_param<Scalar3>(parameters[n], 3);
       Scalar4 p4_ = get_param<Scalar4>(parameters[n], 4);
       Scalar5 p5_ = get_param<Scalar5>(parameters[n], 5);
+      vector<var> s1;
+      vector<var> s2;
+      vector<var> s3;
       std::vector<Scalar0> p0s_((is_vector<T0>::value) ? N_REPEAT : 1, p0_);
       std::vector<Scalar1> p1s_((is_vector<T1>::value) ? N_REPEAT : 1, p1_);
       std::vector<Scalar2> p2s_((is_vector<T2>::value) ? N_REPEAT : 1, p2_);
       std::vector<Scalar3> p3s_((is_vector<T3>::value) ? N_REPEAT : 1, p3_);
       std::vector<Scalar4> p4s_((is_vector<T4>::value) ? N_REPEAT : 1, p4_);
       std::vector<Scalar5> p5s_((is_vector<T5>::value) ? N_REPEAT : 1, p5_);
+      add_vars(s1, p0s_, p1s_, p2s_, p3s_, p4s_, p5s_);
+      add_vars(s2, p0s_, p1s_, p2s_, p3s_, p4s_, p5s_);
+      add_vars(s3, p0s_, p1s_, p2s_, p3s_, p4s_, p5s_);
 
       T_return_type logprob
           = N_REPEAT * TestClass.log_prob(p0_, p1_, p2_, p3_, p4_, p5_);
 
-      double single_lp = calculate_gradients_1storder(
-          single_gradients1, logprob, p0s_, p1s_, p2s_, p3s_, p4s_, p5s_);
-      calculate_gradients_2ndorder(single_gradients2, logprob, p0s_, p1s_, p2s_,
-                                   p3s_, p4s_, p5s_);
-      calculate_gradients_3rdorder(single_gradients3, logprob, p0s_, p1s_, p2s_,
-                                   p3s_, p4s_, p5s_);
+      double single_lp
+          = calculate_gradients_1storder(single_gradients1, logprob, s1);
+      calculate_gradients_2ndorder(single_gradients2, logprob, s2);
+      calculate_gradients_3rdorder(single_gradients3, logprob, s3);
 
       T0 p0 = get_repeated_params<T0>(parameters[n], 0, N_REPEAT);
       T1 p1 = get_repeated_params<T1>(parameters[n], 1, N_REPEAT);
@@ -642,13 +623,16 @@ class AgradDistributionTestFixture : public ::testing::Test {
       vector<double> multiple_gradients1;
       vector<double> multiple_gradients2;
       vector<double> multiple_gradients3;
+      vector<var> x1;
+      vector<var> x2;
+      vector<var> x3;
+      add_vars(x1, p0, p1, p2, p3, p4, p5);
+      add_vars(x2, p0, p1, p2, p3, p4, p5);
+      add_vars(x3, p0, p1, p2, p3, p4, p5);
 
-      calculate_gradients_1storder(multiple_gradients1, multiple_lp, p0, p1, p2,
-                                   p3, p4, p5);
-      calculate_gradients_2ndorder(multiple_gradients2, multiple_lp, p0, p1, p2,
-                                   p3, p4, p5);
-      calculate_gradients_3rdorder(multiple_gradients3, multiple_lp, p0, p1, p2,
-                                   p3, p4, p5);
+      calculate_gradients_1storder(multiple_gradients1, multiple_lp, x1);
+      calculate_gradients_2ndorder(multiple_gradients2, multiple_lp, x2);
+      calculate_gradients_3rdorder(multiple_gradients3, multiple_lp, x3);
 
       stan::math::recover_memory();
 
@@ -699,10 +683,12 @@ class AgradDistributionTestFixture : public ::testing::Test {
     vector<double> single_gradients1;
     vector<double> single_gradients2;
     vector<double> single_gradients3;
+    vector<var> scalar_vars;
 
     vector<double> multiple_gradients1;
     vector<double> multiple_gradients2;
     vector<double> multiple_gradients3;
+    vector<var> vector_vars;
 
     T0 p0 = get_params<T0>(parameters, 0);
     T1 p1 = get_params<T1>(parameters, 1);
@@ -744,21 +730,33 @@ class AgradDistributionTestFixture : public ::testing::Test {
                                       p3s.back(), p4s.back(), p5s.back());
     }
 
-    calculate_gradients_1storder(single_gradients1, single_lp, p0s, p1s, p2s,
-                                 p3s, p4s, p5s);
-    calculate_gradients_2ndorder(single_gradients2, single_lp, p0s, p1s, p2s,
-                                 p3s, p4s, p5s);
-    calculate_gradients_3rdorder(single_gradients3, single_lp, p0s, p1s, p2s,
-                                 p3s, p4s, p5s);
+    add_var(vector_vars, p0);
+    add_var(scalar_vars, p0s);
+
+    add_var(vector_vars, p1);
+    add_var(scalar_vars, p1s);
+
+    add_var(vector_vars, p2);
+    add_var(scalar_vars, p2s);
+
+    add_var(vector_vars, p3);
+    add_var(scalar_vars, p3s);
+
+    add_var(vector_vars, p4);
+    add_var(scalar_vars, p4s);
+
+    add_var(vector_vars, p5);
+    add_var(scalar_vars, p5s);
+
+    calculate_gradients_1storder(single_gradients1, single_lp, scalar_vars);
+    calculate_gradients_2ndorder(single_gradients2, single_lp, scalar_vars);
+    calculate_gradients_3rdorder(single_gradients3, single_lp, scalar_vars);
 
     T_return_type multiple_lp = TestClass.log_prob(p0, p1, p2, p3, p4, p5);
 
-    calculate_gradients_1storder(multiple_gradients1, multiple_lp, p0, p1, p2,
-                                 p3, p4, p5);
-    calculate_gradients_2ndorder(multiple_gradients2, multiple_lp, p0, p1, p2,
-                                 p3, p4, p5);
-    calculate_gradients_3rdorder(multiple_gradients3, multiple_lp, p0, p1, p2,
-                                 p3, p4, p5);
+    calculate_gradients_1storder(multiple_gradients1, multiple_lp, vector_vars);
+    calculate_gradients_2ndorder(multiple_gradients2, multiple_lp, vector_vars);
+    calculate_gradients_3rdorder(multiple_gradients3, multiple_lp, vector_vars);
 
     stan::math::recover_memory();
 

--- a/test/prob/utility.hpp
+++ b/test/prob/utility.hpp
@@ -93,7 +93,7 @@ fvar<fvar<double>> get_param<fvar<fvar<double>>>(const vector<double>& params,
   fvar<fvar<double>> param = 0;
   if (n < params.size()) {
     param = params[n];
-    param.d_.val_ = 1.0;
+    param.d_ = 1.0;
   }
   return param;
 }
@@ -103,7 +103,7 @@ fvar<fvar<var>> get_param<fvar<fvar<var>>>(const vector<double>& params,
   fvar<fvar<var>> param = 0;
   if (n < params.size()) {
     param = params[n];
-    param.d_.val_ = 1.0;
+    param.d_ = 1.0;
   }
   return param;
 }
@@ -111,22 +111,12 @@ fvar<fvar<var>> get_param<fvar<fvar<var>>>(const vector<double>& params,
 // ------------------------------------------------------------
 
 // default template handles Eigen::Matrix
-template <typename T, stan::require_not_var_matrix_t<T>* = nullptr>
+template <typename T>
 T get_params(const vector<vector<double>>& parameters, const size_t p) {
   T param(parameters.size());
   for (size_t n = 0; n < parameters.size(); n++)
     if (p < parameters[0].size())
       param(n) = get_param<stan::scalar_type_t<T>>(parameters[n], p);
-  return param;
-}
-
-// handle `var_value<T>` where T is an Eigen type
-template <typename T, stan::require_var_matrix_t<T>* = nullptr>
-T get_params(const vector<vector<double>>& parameters, const size_t p) {
-  typename T::value_type param(parameters.size());
-  for (size_t n = 0; n < parameters.size(); n++)
-    if (p < parameters[0].size())
-      param(n) = get_param<double>(parameters[n], p);
   return param;
 }
 
@@ -178,7 +168,7 @@ fvar<fvar<double>> get_params<fvar<fvar<double>>>(
   fvar<fvar<double>> param(0);
   if (p < parameters[0].size()) {
     param = parameters[0][p];
-    param.d_.val_ = 1.0;
+    param.d_ = 1.0;
   }
   return param;
 }
@@ -188,7 +178,7 @@ fvar<fvar<var>> get_params<fvar<fvar<var>>>(
   fvar<fvar<var>> param(0);
   if (p < parameters[0].size()) {
     param = parameters[0][p];
-    param.d_.val_ = 1.0;
+    param.d_ = 1.0;
   }
   return param;
 }
@@ -256,7 +246,7 @@ vector<fvar<fvar<double>>> get_params<vector<fvar<fvar<double>>>>(
   for (size_t n = 0; n < parameters.size(); n++)
     if (p < parameters[0].size()) {
       param[n] = parameters[n][p];
-      param[n].d_.val_ = 1.0;
+      param[n].d_ = 1.0;
     }
   return param;
 }
@@ -267,7 +257,7 @@ vector<fvar<fvar<var>>> get_params<vector<fvar<fvar<var>>>>(
   for (size_t n = 0; n < parameters.size(); n++)
     if (p < parameters[0].size()) {
       param[n] = parameters[n][p];
-      param[n].d_.val_ = 1.0;
+      param[n].d_ = 1.0;
     }
   return param;
 }
@@ -275,24 +265,13 @@ vector<fvar<fvar<var>>> get_params<vector<fvar<fvar<var>>>>(
 // ------------------------------------------------------------
 
 // default template handles Eigen::Matrix
-template <typename T, stan::require_not_var_matrix_t<T>* = nullptr>
+template <typename T>
 T get_params(const vector<vector<double>>& parameters, const size_t /*n*/,
              const size_t p) {
   T param(parameters.size());
   for (size_t i = 0; i < parameters.size(); i++)
     if (p < parameters[0].size())
       param(i) = get_param<stan::scalar_type_t<T>>(parameters[i], p);
-  return param;
-}
-
-// handle `var_value<T>` where T is an Eigen type
-template <typename T, stan::require_var_matrix_t<T>* = nullptr>
-T get_params(const vector<vector<double>>& parameters, const size_t /*n*/,
-             const size_t p) {
-  typename T::value_type param(parameters.size());
-  for (size_t i = 0; i < parameters.size(); i++)
-    if (p < parameters[0].size())
-      param(i) = get_param<double>(parameters[i], p);
   return param;
 }
 
@@ -345,7 +324,7 @@ fvar<fvar<double>> get_params<fvar<fvar<double>>>(
   fvar<fvar<double>> param(0);
   if (p < parameters[0].size()) {
     param = parameters[n][p];
-    param.d_.val_ = 1.0;
+    param.d_ = 1.0;
   }
   return param;
 }
@@ -355,7 +334,7 @@ fvar<fvar<var>> get_params<fvar<fvar<var>>>(
   fvar<fvar<var>> param(0);
   if (p < parameters[0].size()) {
     param = parameters[n][p];
-    param.d_.val_ = 1.0;
+    param.d_ = 1.0;
   }
   return param;
 }
@@ -428,7 +407,7 @@ vector<fvar<fvar<double>>> get_params<vector<fvar<fvar<double>>>>(
   for (size_t i = 0; i < parameters.size(); i++)
     if (p < parameters[0].size()) {
       param[i] = parameters[i][p];
-      param[i].d_.val_ = 1.0;
+      param[i].d_ = 1.0;
     }
   return param;
 }
@@ -440,7 +419,7 @@ vector<fvar<fvar<var>>> get_params<vector<fvar<fvar<var>>>>(
   for (size_t i = 0; i < parameters.size(); i++)
     if (p < parameters[0].size()) {
       param[i] = parameters[i][p];
-      param[i].d_.val_ = 1.0;
+      param[i].d_ = 1.0;
     }
   return param;
 }
@@ -465,26 +444,6 @@ T get_repeated_params(const vector<double>& parameters, const size_t p,
   return params;
 }
 
-// handle `var_value<T>` where T is an Eigen type
-template <typename T, stan::require_var_matrix_t<T>* = nullptr>
-T get_repeated_params(const vector<double>& parameters, const size_t p,
-                      const size_t N_REPEAT) {
-  typename T::value_type params(N_REPEAT);
-  double param;
-
-  if (p < parameters.size())
-    param = get_param<double>(parameters, p);
-  else
-    param = 0;
-
-  for (size_t n = 0; n < N_REPEAT; n++) {
-    params(n) = param;
-  }
-
-  return params;
-}
-
-// handle `std::vector`
 template <typename T, stan::require_std_vector_t<T>* = nullptr>
 T get_repeated_params(const vector<double>& parameters, const size_t p,
                       const size_t N_REPEAT) {
@@ -592,108 +551,99 @@ struct any_vector {
 };
 
 // ------------------------------------------------------------
-template <typename T, stan::require_not_var_matrix_t<T>* = nullptr>
-void add_adjoints(vector<double>& /*x*/, T& /*p*/) {}
+template <typename T>
+void add_var(vector<var>& /*x*/, T& /*p*/) {}
 
 template <>
-void add_adjoints<var>(vector<double>& x, var& p) {
-  x.push_back(p.adj());
-}
-
-template <typename T, stan::require_var_matrix_t<T>* = nullptr>
-void add_adjoints(vector<double>& x, T& p) {
-  for (size_type n = 0; n < p.size(); n++) {
-    x.push_back(p.adj().coeff(n));
-  }
+void add_var<var>(vector<var>& x, var& p) {
+  x.push_back(p);
 }
 
 template <>
-void add_adjoints<vector<var>>(vector<double>& x, vector<var>& p) {
+void add_var<vector<var>>(vector<var>& x, vector<var>& p) {
+  x.insert(x.end(), p.begin(), p.end());
+}
+
+template <>
+void add_var<Eigen::Matrix<var, 1, Eigen::Dynamic>>(
+    vector<var>& x, Eigen::Matrix<var, 1, Eigen::Dynamic>& p) {
   for (size_type n = 0; n < p.size(); n++)
-    x.push_back(p[n].adj());
+    x.push_back(p(n));
 }
 
 template <>
-void add_adjoints<Eigen::Matrix<var, 1, Eigen::Dynamic>>(
-    vector<double>& x, Eigen::Matrix<var, 1, Eigen::Dynamic>& p) {
+void add_var<Eigen::Matrix<var, Eigen::Dynamic, 1>>(
+    vector<var>& x, Eigen::Matrix<var, Eigen::Dynamic, 1>& p) {
   for (size_type n = 0; n < p.size(); n++)
-    x.push_back(p(n).adj());
+    x.push_back(p(n));
 }
 
 template <>
-void add_adjoints<Eigen::Matrix<var, Eigen::Dynamic, 1>>(
-    vector<double>& x, Eigen::Matrix<var, Eigen::Dynamic, 1>& p) {
-  for (size_type n = 0; n < p.size(); n++)
-    x.push_back(p(n).adj());
+void add_var<fvar<var>>(vector<var>& x, fvar<var>& p) {
+  x.push_back(p.val_);
 }
 
 template <>
-void add_adjoints<fvar<var>>(vector<double>& x, fvar<var>& p) {
-  x.push_back(p.val_.adj());
-}
-
-template <>
-void add_adjoints<vector<fvar<var>>>(vector<double>& x, vector<fvar<var>>& p) {
+void add_var<vector<fvar<var>>>(vector<var>& x, vector<fvar<var>>& p) {
   for (size_t n = 0; n < p.size(); n++)
-    x.push_back(p[n].val_.adj());
+    x.push_back(p[n].val_);
 }
 
 template <>
-void add_adjoints<Eigen::Matrix<fvar<var>, 1, Eigen::Dynamic>>(
-    vector<double>& x, Eigen::Matrix<fvar<var>, 1, Eigen::Dynamic>& p) {
+void add_var<Eigen::Matrix<fvar<var>, 1, Eigen::Dynamic>>(
+    vector<var>& x, Eigen::Matrix<fvar<var>, 1, Eigen::Dynamic>& p) {
   for (size_type n = 0; n < p.size(); n++)
-    x.push_back(p(n).val_.adj());
+    x.push_back(p(n).val_);
 }
 
 template <>
-void add_adjoints<Eigen::Matrix<fvar<var>, Eigen::Dynamic, 1>>(
-    vector<double>& x, Eigen::Matrix<fvar<var>, Eigen::Dynamic, 1>& p) {
+void add_var<Eigen::Matrix<fvar<var>, Eigen::Dynamic, 1>>(
+    vector<var>& x, Eigen::Matrix<fvar<var>, Eigen::Dynamic, 1>& p) {
   for (size_type n = 0; n < p.size(); n++)
-    x.push_back(p(n).val_.adj());
+    x.push_back(p(n).val_);
 }
 
 template <>
-void add_adjoints<fvar<fvar<var>>>(vector<double>& x, fvar<fvar<var>>& p) {
-  x.push_back(p.val_.val_.adj());
+void add_var<fvar<fvar<var>>>(vector<var>& x, fvar<fvar<var>>& p) {
+  x.push_back(p.val_.val_);
 }
 
 template <>
-void add_adjoints<vector<fvar<fvar<var>>>>(vector<double>& x,
-                                           vector<fvar<fvar<var>>>& p) {
+void add_var<vector<fvar<fvar<var>>>>(vector<var>& x,
+                                      vector<fvar<fvar<var>>>& p) {
   for (size_t n = 0; n < p.size(); n++)
-    x.push_back(p[n].val_.val_.adj());
+    x.push_back(p[n].val_.val_);
 }
 
 template <>
-void add_adjoints<Eigen::Matrix<fvar<fvar<var>>, 1, Eigen::Dynamic>>(
-    vector<double>& x, Eigen::Matrix<fvar<fvar<var>>, 1, Eigen::Dynamic>& p) {
+void add_var<Eigen::Matrix<fvar<fvar<var>>, 1, Eigen::Dynamic>>(
+    vector<var>& x, Eigen::Matrix<fvar<fvar<var>>, 1, Eigen::Dynamic>& p) {
   for (size_type n = 0; n < p.size(); n++)
-    x.push_back(p(n).val_.val_.adj());
+    x.push_back(p(n).val_.val_);
 }
 
 template <>
-void add_adjoints<Eigen::Matrix<fvar<fvar<var>>, Eigen::Dynamic, 1>>(
-    vector<double>& x, Eigen::Matrix<fvar<fvar<var>>, Eigen::Dynamic, 1>& p) {
+void add_var<Eigen::Matrix<fvar<fvar<var>>, Eigen::Dynamic, 1>>(
+    vector<var>& x, Eigen::Matrix<fvar<fvar<var>>, Eigen::Dynamic, 1>& p) {
   for (size_type n = 0; n < p.size(); n++)
-    x.push_back(p(n).val_.val_.adj());
+    x.push_back(p(n).val_.val_);
 }
 
 template <typename T0, typename T1, typename T2, typename T3, typename T4,
           typename T5>
-void add_adjoints(vector<double>& x, T0& p0, T1& p1, T2& p2, T3& p3, T4& p4,
-                  T5& p5) {
+void add_vars(vector<var>& x, T0& p0, T1& p1, T2& p2, T3& p3, T4& p4, T5& p5) {
   if (!is_constant_all<T0>::value)
-    add_adjoints(x, p0);
+    add_var(x, p0);
   if (!is_constant_all<T1>::value)
-    add_adjoints(x, p1);
+    add_var(x, p1);
   if (!is_constant_all<T2>::value)
-    add_adjoints(x, p2);
+    add_var(x, p2);
   if (!is_constant_all<T3>::value)
-    add_adjoints(x, p3);
+    add_var(x, p3);
   if (!is_constant_all<T4>::value)
-    add_adjoints(x, p4);
+    add_var(x, p4);
   if (!is_constant_all<T5>::value)
-    add_adjoints(x, p5);
+    add_var(x, p5);
 }
 
 #endif

--- a/test/unit/math/mix/prob/von_mises_test.cpp
+++ b/test/unit/math/mix/prob/von_mises_test.cpp
@@ -88,16 +88,3 @@ TEST(ProbAgradDistributionsVonMises, FvarVar_2ndDeriv2) {
   // Fails: g[0] is -nan
   // EXPECT_FLOAT_EQ(0, g[0]);
 }
-
-// This test once failed sanitizer checks -- nothing explicitly tested in the
-// code itself
-TEST(ProbAgradDistributionsVonMises, sanitizer_error_fixed) {
-  using stan::math::var;
-  double y = boost::math::constants::third_pi<double>();
-  double mu = boost::math::constants::sixth_pi<double>();
-  std::vector<var> kappa = {0.5};
-
-  auto lp = stan::math::von_mises_lpdf(y, mu, kappa);
-
-  lp.grad();
-}

--- a/test/unit/math/prim/meta/contains_vector_test.cpp
+++ b/test/unit/math/prim/meta/contains_vector_test.cpp
@@ -1,0 +1,57 @@
+#include <stan/math/prim/meta.hpp>
+#include <gtest/gtest.h>
+#include <vector>
+
+TEST(MathMetaPrim, contains_vector_std_vector) {
+  using stan::contains_vector;
+  using std::vector;
+
+  EXPECT_TRUE(contains_vector<std::vector<double> >::value);
+  EXPECT_TRUE(contains_vector<std::vector<int> >::value);
+  EXPECT_TRUE(contains_vector<const std::vector<double> >::value);
+  EXPECT_TRUE(contains_vector<const std::vector<int> >::value);
+}
+
+TEST(MathMetaPrim, contains_vector_scalars) {
+  using stan::contains_vector;
+  EXPECT_FALSE(contains_vector<double>::value);
+  EXPECT_FALSE(contains_vector<int>::value);
+  EXPECT_FALSE(contains_vector<size_t>::value);
+
+  EXPECT_FALSE(contains_vector<const double>::value);
+  EXPECT_FALSE(contains_vector<const int>::value);
+  EXPECT_FALSE(contains_vector<const size_t>::value);
+}
+
+TEST(MathMetaPrim, contains_vector_matrices) {
+  using Eigen::Dynamic;
+  using Eigen::Matrix;
+  using stan::contains_vector;
+
+  typedef Matrix<double, Dynamic, 1> temp_vec_d;
+  EXPECT_TRUE(contains_vector<temp_vec_d>::value);
+  EXPECT_TRUE(contains_vector<const temp_vec_d>::value);
+
+  typedef Matrix<double, 1, Dynamic> temp_rowvec_d;
+  EXPECT_TRUE(contains_vector<temp_rowvec_d>::value);
+  EXPECT_TRUE(contains_vector<const temp_rowvec_d>::value);
+
+  typedef Matrix<double, Dynamic, Dynamic> temp_matrix_d;
+  EXPECT_FALSE(contains_vector<temp_matrix_d>::value);
+  EXPECT_FALSE(contains_vector<const temp_matrix_d>::value);
+
+  bool temp
+      = contains_vector<temp_vec_d, temp_vec_d, double, temp_matrix_d>::value;
+  EXPECT_TRUE(temp);
+
+  temp = contains_vector<double, temp_matrix_d, temp_matrix_d>::value;
+  EXPECT_FALSE(temp);
+
+  temp = contains_vector<double, double, temp_matrix_d, double, temp_matrix_d,
+                         double, double>::value;
+  EXPECT_FALSE(temp);
+
+  temp = contains_vector<double, double, temp_matrix_d, double, temp_matrix_d,
+                         double, temp_vec_d>::value;
+  EXPECT_TRUE(temp);
+}

--- a/test/unit/math/rev/fun/scalar_seq_view_test.cpp
+++ b/test/unit/math/rev/fun/scalar_seq_view_test.cpp
@@ -59,51 +59,26 @@ void expect_scalar_seq_view_value(const C& v) {
   EXPECT_EQ(v.size(), sv.size());
 }
 
-template <typename C>
-void expect_scalar_seq_view_adjoints(const C& v) {
-  using stan::scalar_seq_view;
-  scalar_seq_view<C> sv(v);
-  std::vector<stan::math::var> stdv(sv.size());
-  for (size_t i = 0; i < sv.size(); ++i) {
-    stdv[i] = sv[i];
-  }
-
-  for (size_t i = 0; i < sv.size(); ++i) {
-    stan::math::set_zero_all_adjoints();
-    stdv[i].grad();
-    EXPECT_EQ(1.0, v.adj()(i));
-    for (size_t j = 0; j < sv.size(); ++j) {
-      if (j != i) {
-        EXPECT_EQ(0.0, v.adj()(j));
-      }
-    }
-  }
-}
-
 TEST(MathMetaRev, ScalarSeqViewVectorVar) {
   using stan::math::var;
   Eigen::Matrix<var, -1, 1> A = Eigen::VectorXd(4);
   expect_scalar_seq_view_value(A);
-  expect_scalar_seq_view_adjoints(A);
 }
 
 TEST(MathMetaRev, ScalarSeqViewRowVectorVar) {
   using stan::math::var;
   Eigen::Matrix<var, 1, -1> A = Eigen::RowVectorXd(4);
   expect_scalar_seq_view_value(A);
-  expect_scalar_seq_view_adjoints(A);
 }
 
 TEST(MathMetaRev, VarScalarSeqViewVector) {
   using stan::math::var_value;
   var_value<Eigen::Matrix<double, -1, 1>> A = Eigen::VectorXd(4);
   expect_scalar_seq_view_value(A);
-  expect_scalar_seq_view_adjoints(A);
 }
 
 TEST(MathMetaRev, VarScalarSeqViewRowVector) {
   using stan::math::var_value;
   var_value<Eigen::Matrix<double, 1, -1>> A = Eigen::RowVectorXd(4);
   expect_scalar_seq_view_value(A);
-  expect_scalar_seq_view_adjoints(A);
 }


### PR DESCRIPTION
Reverts stan-dev/math#2304

@bbbales2 @SteveBronder merging #2304 has broken develop distribution tests. Not sure why exactly it is failing, but either the branch for #2304 has not been updated to recent master before merging or its an issue with row_vector tests that only run on merges. 

I am going to merge the revert and then we can re-do the PR but make sure to run row vector tests as well (we can do that manually on Jenkins)

edit: Jenkins is running distribution tests with row vector to make sure the revert fixes this problem.

