### PR TITLE
remove boost dependency from dist tests

### DIFF
--- a/test/prob/generate_tests.cpp
+++ b/test/prob/generate_tests.cpp
@@ -269,8 +269,7 @@ void write_types_typedef(vector<std::ostream*>& outs, string base, size_t& N,
         N++;
       } else {
         if (check_all_double(base, args[n]) == false) {
-          *out << "typedef std::tuple<" << base << args[n]
-               << extra_args;
+          *out << "typedef std::tuple<" << base << args[n] << extra_args;
           if (extra_args.size() == 0)
             *out << " ";
           else if (index == 2)
@@ -307,23 +306,23 @@ void write_test(vector<std::ostream*>& outs, const string& test_name,
   for (size_t n = 0; n < N; n++) {
     std::ostream* out = outs[int(n / N_TESTS)];
     if (index == 1)
-      *out << "typedef std::tuple<" << test_name << ", type_v_" << n
-           << "> " << test_name << "_v_" << n << ";" << endl;
+      *out << "typedef std::tuple<" << test_name << ", type_v_" << n << "> "
+           << test_name << "_v_" << n << ";" << endl;
     else if (index == 2)
-      *out << "typedef std::tuple<" << test_name << ", type_fd_" << n
-           << "> " << test_name << "_fd_" << n << ";" << endl;
+      *out << "typedef std::tuple<" << test_name << ", type_fd_" << n << "> "
+           << test_name << "_fd_" << n << ";" << endl;
     else if (index == 3)
-      *out << "typedef std::tuple<" << test_name << ", type_fv_" << n
-           << "> " << test_name << "_fv_" << n << ";" << endl;
+      *out << "typedef std::tuple<" << test_name << ", type_fv_" << n << "> "
+           << test_name << "_fv_" << n << ";" << endl;
     else if (index == 4)
-      *out << "typedef std::tuple<" << test_name << ", type_ffd_" << n
-           << "> " << test_name << "_ffd_" << n << ";" << endl;
+      *out << "typedef std::tuple<" << test_name << ", type_ffd_" << n << "> "
+           << test_name << "_ffd_" << n << ";" << endl;
     else if (index == 5)
-      *out << "typedef std::tuple<" << test_name << ", type_ffv_" << n
-           << "> " << test_name << "_ffv_" << n << ";" << endl;
+      *out << "typedef std::tuple<" << test_name << ", type_ffv_" << n << "> "
+           << test_name << "_ffv_" << n << ";" << endl;
     else if (index == 6)
-      *out << "typedef std::tuple<" << test_name << ", type_vv_" << n
-           << "> " << test_name << "_vv_" << n << ";" << endl;
+      *out << "typedef std::tuple<" << test_name << ", type_vv_" << n << "> "
+           << test_name << "_vv_" << n << ";" << endl;
   }
   for (size_t i = 0; i < outs.size(); i++) {
     *outs[i] << endl;

--- a/test/prob/generate_tests.cpp
+++ b/test/prob/generate_tests.cpp
@@ -87,7 +87,7 @@ void write_includes(vector<std::ostream*>& outs, const string& include) {
   for (size_t n = 0; n < outs.size(); n++) {
     std::ostream* out = outs[n];
     *out << "#include <gtest/gtest.h>" << endl;
-    *out << "#include <boost/mpl/vector.hpp>" << endl;
+    *out << "#include <tuple>" << endl;
     *out << "#include <test/prob/test_fixture_distr.hpp>" << endl;
     *out << "#include <test/prob/test_fixture_cdf.hpp>" << endl;
     *out << "#include <test/prob/test_fixture_cdf_log.hpp>" << endl;
@@ -262,14 +262,14 @@ void write_types_typedef(vector<std::ostream*>& outs, string base, size_t& N,
     for (size_t n = 0; n < args.size(); n++) {
       std::ostream* out = outs[int(N / N_TESTS)];
       if (index == 1) {
-        *out << "typedef boost::mpl::vector<" << base << args[n] << extra_args;
+        *out << "typedef std::tuple<" << base << args[n] << extra_args;
         if (extra_args.size() == 0)
           *out << " ";
         *out << "> type_v_" << N << ";" << endl;
         N++;
       } else {
         if (check_all_double(base, args[n]) == false) {
-          *out << "typedef boost::mpl::vector<" << base << args[n]
+          *out << "typedef std::tuple<" << base << args[n]
                << extra_args;
           if (extra_args.size() == 0)
             *out << " ";
@@ -307,22 +307,22 @@ void write_test(vector<std::ostream*>& outs, const string& test_name,
   for (size_t n = 0; n < N; n++) {
     std::ostream* out = outs[int(n / N_TESTS)];
     if (index == 1)
-      *out << "typedef boost::mpl::vector<" << test_name << ", type_v_" << n
+      *out << "typedef std::tuple<" << test_name << ", type_v_" << n
            << "> " << test_name << "_v_" << n << ";" << endl;
     else if (index == 2)
-      *out << "typedef boost::mpl::vector<" << test_name << ", type_fd_" << n
+      *out << "typedef std::tuple<" << test_name << ", type_fd_" << n
            << "> " << test_name << "_fd_" << n << ";" << endl;
     else if (index == 3)
-      *out << "typedef boost::mpl::vector<" << test_name << ", type_fv_" << n
+      *out << "typedef std::tuple<" << test_name << ", type_fv_" << n
            << "> " << test_name << "_fv_" << n << ";" << endl;
     else if (index == 4)
-      *out << "typedef boost::mpl::vector<" << test_name << ", type_ffd_" << n
+      *out << "typedef std::tuple<" << test_name << ", type_ffd_" << n
            << "> " << test_name << "_ffd_" << n << ";" << endl;
     else if (index == 5)
-      *out << "typedef boost::mpl::vector<" << test_name << ", type_ffv_" << n
+      *out << "typedef std::tuple<" << test_name << ", type_ffv_" << n
            << "> " << test_name << "_ffv_" << n << ";" << endl;
     else if (index == 6)
-      *out << "typedef boost::mpl::vector<" << test_name << ", type_vv_" << n
+      *out << "typedef std::tuple<" << test_name << ", type_vv_" << n
            << "> " << test_name << "_vv_" << n << ";" << endl;
   }
   for (size_t i = 0; i < outs.size(); i++) {

--- a/test/prob/test_fixture_ccdf_log.hpp
+++ b/test/prob/test_fixture_ccdf_log.hpp
@@ -4,6 +4,7 @@
 #include <stan/math/rev.hpp>
 #include <test/prob/utility.hpp>
 #include <type_traits>
+#include <tuple>
 
 using Eigen::Dynamic;
 using Eigen::Matrix;
@@ -67,13 +68,15 @@ class AgradCcdfLogTest {
 template <class T>
 class AgradCcdfLogTestFixture : public ::testing::Test {
  public:
-  typename at_c<T, 0>::type TestClass;
-  typedef typename at_c<typename at_c<T, 1>::type, 0>::type T0;
-  typedef typename at_c<typename at_c<T, 1>::type, 1>::type T1;
-  typedef typename at_c<typename at_c<T, 1>::type, 2>::type T2;
-  typedef typename at_c<typename at_c<T, 1>::type, 3>::type T3;
-  typedef typename at_c<typename at_c<T, 1>::type, 4>::type T4;
-  typedef typename at_c<typename at_c<T, 1>::type, 5>::type T5;
+  std::tuple_element_t<0, T> TestClass;
+  typedef std::tuple_element_t<1, T> ArgClass;
+  typedef std::tuple_element_t<0, ArgClass> T0;
+  typedef std::tuple_element_t<1, ArgClass> T1;
+  typedef std::tuple_element_t<2, ArgClass> T2;
+  typedef std::tuple_element_t<3, ArgClass> T3;
+  typedef std::tuple_element_t<4, ArgClass> T4;
+  typedef std::tuple_element_t<5, ArgClass> T5;
+
 
   typedef typename scalar_type<T0>::type Scalar0;
   typedef typename scalar_type<T1>::type Scalar1;

--- a/test/prob/test_fixture_ccdf_log.hpp
+++ b/test/prob/test_fixture_ccdf_log.hpp
@@ -77,7 +77,6 @@ class AgradCcdfLogTestFixture : public ::testing::Test {
   typedef std::tuple_element_t<4, ArgClass> T4;
   typedef std::tuple_element_t<5, ArgClass> T5;
 
-
   typedef typename scalar_type<T0>::type Scalar0;
   typedef typename scalar_type<T1>::type Scalar1;
   typedef typename scalar_type<T2>::type Scalar2;

--- a/test/prob/test_fixture_cdf.hpp
+++ b/test/prob/test_fixture_cdf.hpp
@@ -67,13 +67,15 @@ class AgradCdfTest {
 template <class T>
 class AgradCdfTestFixture : public ::testing::Test {
  public:
-  typename at_c<T, 0>::type TestClass;
-  typedef typename at_c<typename at_c<T, 1>::type, 0>::type T0;
-  typedef typename at_c<typename at_c<T, 1>::type, 1>::type T1;
-  typedef typename at_c<typename at_c<T, 1>::type, 2>::type T2;
-  typedef typename at_c<typename at_c<T, 1>::type, 3>::type T3;
-  typedef typename at_c<typename at_c<T, 1>::type, 4>::type T4;
-  typedef typename at_c<typename at_c<T, 1>::type, 5>::type T5;
+   std::tuple_element_t<0, T> TestClass;
+   typedef std::tuple_element_t<1, T> ArgClass;
+   typedef std::tuple_element_t<0, ArgClass> T0;
+   typedef std::tuple_element_t<1, ArgClass> T1;
+   typedef std::tuple_element_t<2, ArgClass> T2;
+   typedef std::tuple_element_t<3, ArgClass> T3;
+   typedef std::tuple_element_t<4, ArgClass> T4;
+   typedef std::tuple_element_t<5, ArgClass> T5;
+
 
   typedef typename scalar_type<T0>::type Scalar0;
   typedef typename scalar_type<T1>::type Scalar1;

--- a/test/prob/test_fixture_cdf.hpp
+++ b/test/prob/test_fixture_cdf.hpp
@@ -67,15 +67,14 @@ class AgradCdfTest {
 template <class T>
 class AgradCdfTestFixture : public ::testing::Test {
  public:
-   std::tuple_element_t<0, T> TestClass;
-   typedef std::tuple_element_t<1, T> ArgClass;
-   typedef std::tuple_element_t<0, ArgClass> T0;
-   typedef std::tuple_element_t<1, ArgClass> T1;
-   typedef std::tuple_element_t<2, ArgClass> T2;
-   typedef std::tuple_element_t<3, ArgClass> T3;
-   typedef std::tuple_element_t<4, ArgClass> T4;
-   typedef std::tuple_element_t<5, ArgClass> T5;
-
+  std::tuple_element_t<0, T> TestClass;
+  typedef std::tuple_element_t<1, T> ArgClass;
+  typedef std::tuple_element_t<0, ArgClass> T0;
+  typedef std::tuple_element_t<1, ArgClass> T1;
+  typedef std::tuple_element_t<2, ArgClass> T2;
+  typedef std::tuple_element_t<3, ArgClass> T3;
+  typedef std::tuple_element_t<4, ArgClass> T4;
+  typedef std::tuple_element_t<5, ArgClass> T5;
 
   typedef typename scalar_type<T0>::type Scalar0;
   typedef typename scalar_type<T1>::type Scalar1;

--- a/test/prob/test_fixture_cdf_log.hpp
+++ b/test/prob/test_fixture_cdf_log.hpp
@@ -67,15 +67,14 @@ class AgradCdfLogTest {
 template <class T>
 class AgradCdfLogTestFixture : public ::testing::Test {
  public:
-   std::tuple_element_t<0, T> TestClass;
-   typedef std::tuple_element_t<1, T> ArgClass;
-   typedef std::tuple_element_t<0, ArgClass> T0;
-   typedef std::tuple_element_t<1, ArgClass> T1;
-   typedef std::tuple_element_t<2, ArgClass> T2;
-   typedef std::tuple_element_t<3, ArgClass> T3;
-   typedef std::tuple_element_t<4, ArgClass> T4;
-   typedef std::tuple_element_t<5, ArgClass> T5;
-
+  std::tuple_element_t<0, T> TestClass;
+  typedef std::tuple_element_t<1, T> ArgClass;
+  typedef std::tuple_element_t<0, ArgClass> T0;
+  typedef std::tuple_element_t<1, ArgClass> T1;
+  typedef std::tuple_element_t<2, ArgClass> T2;
+  typedef std::tuple_element_t<3, ArgClass> T3;
+  typedef std::tuple_element_t<4, ArgClass> T4;
+  typedef std::tuple_element_t<5, ArgClass> T5;
 
   typedef typename scalar_type<T0>::type Scalar0;
   typedef typename scalar_type<T1>::type Scalar1;

--- a/test/prob/test_fixture_cdf_log.hpp
+++ b/test/prob/test_fixture_cdf_log.hpp
@@ -67,13 +67,15 @@ class AgradCdfLogTest {
 template <class T>
 class AgradCdfLogTestFixture : public ::testing::Test {
  public:
-  typename at_c<T, 0>::type TestClass;
-  typedef typename at_c<typename at_c<T, 1>::type, 0>::type T0;
-  typedef typename at_c<typename at_c<T, 1>::type, 1>::type T1;
-  typedef typename at_c<typename at_c<T, 1>::type, 2>::type T2;
-  typedef typename at_c<typename at_c<T, 1>::type, 3>::type T3;
-  typedef typename at_c<typename at_c<T, 1>::type, 4>::type T4;
-  typedef typename at_c<typename at_c<T, 1>::type, 5>::type T5;
+   std::tuple_element_t<0, T> TestClass;
+   typedef std::tuple_element_t<1, T> ArgClass;
+   typedef std::tuple_element_t<0, ArgClass> T0;
+   typedef std::tuple_element_t<1, ArgClass> T1;
+   typedef std::tuple_element_t<2, ArgClass> T2;
+   typedef std::tuple_element_t<3, ArgClass> T3;
+   typedef std::tuple_element_t<4, ArgClass> T4;
+   typedef std::tuple_element_t<5, ArgClass> T5;
+
 
   typedef typename scalar_type<T0>::type Scalar0;
   typedef typename scalar_type<T1>::type Scalar1;

--- a/test/prob/test_fixture_distr.hpp
+++ b/test/prob/test_fixture_distr.hpp
@@ -41,15 +41,14 @@ using boost::mpl::at_c;
 template <class T>
 class AgradDistributionTestFixture : public ::testing::Test {
  public:
-   std::tuple_element_t<0, T> TestClass;
-   typedef std::tuple_element_t<1, T> ArgClass;
-   typedef std::tuple_element_t<0, ArgClass> T0;
-   typedef std::tuple_element_t<1, ArgClass> T1;
-   typedef std::tuple_element_t<2, ArgClass> T2;
-   typedef std::tuple_element_t<3, ArgClass> T3;
-   typedef std::tuple_element_t<4, ArgClass> T4;
-   typedef std::tuple_element_t<5, ArgClass> T5;
-
+  std::tuple_element_t<0, T> TestClass;
+  typedef std::tuple_element_t<1, T> ArgClass;
+  typedef std::tuple_element_t<0, ArgClass> T0;
+  typedef std::tuple_element_t<1, ArgClass> T1;
+  typedef std::tuple_element_t<2, ArgClass> T2;
+  typedef std::tuple_element_t<3, ArgClass> T3;
+  typedef std::tuple_element_t<4, ArgClass> T4;
+  typedef std::tuple_element_t<5, ArgClass> T5;
 
   typedef typename scalar_type<T0>::type Scalar0;
   typedef typename scalar_type<T1>::type Scalar1;

--- a/test/prob/test_fixture_distr.hpp
+++ b/test/prob/test_fixture_distr.hpp
@@ -41,13 +41,15 @@ using boost::mpl::at_c;
 template <class T>
 class AgradDistributionTestFixture : public ::testing::Test {
  public:
-  typename at_c<T, 0>::type TestClass;
-  typedef typename at_c<typename at_c<T, 1>::type, 0>::type T0;
-  typedef typename at_c<typename at_c<T, 1>::type, 1>::type T1;
-  typedef typename at_c<typename at_c<T, 1>::type, 2>::type T2;
-  typedef typename at_c<typename at_c<T, 1>::type, 3>::type T3;
-  typedef typename at_c<typename at_c<T, 1>::type, 4>::type T4;
-  typedef typename at_c<typename at_c<T, 1>::type, 5>::type T5;
+   std::tuple_element_t<0, T> TestClass;
+   typedef std::tuple_element_t<1, T> ArgClass;
+   typedef std::tuple_element_t<0, ArgClass> T0;
+   typedef std::tuple_element_t<1, ArgClass> T1;
+   typedef std::tuple_element_t<2, ArgClass> T2;
+   typedef std::tuple_element_t<3, ArgClass> T3;
+   typedef std::tuple_element_t<4, ArgClass> T4;
+   typedef std::tuple_element_t<5, ArgClass> T5;
+
 
   typedef typename scalar_type<T0>::type Scalar0;
   typedef typename scalar_type<T1>::type Scalar1;


### PR DESCRIPTION

## Summary

This is just a small cleanup. Dist tests should compile a hair faster by not having to include `mpl_vector`

## Tests

No new tests

## Side Effects

Should hopefully compile distributions a little faster

## Release notes

## Checklist

- [ ] Math issue #(issue number)

- [x] Copyright holder: Steve Bronder

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
