### PR TITLE
Fix `cholesky_decompose` not updating adjoints correct (2.26)

### DIFF
--- a/stan/math/rev/fun/cholesky_decompose.hpp
+++ b/stan/math/rev/fun/cholesky_decompose.hpp
@@ -55,22 +55,24 @@ inline auto unblocked_cholesky_lambda(T1& L_A, T2& L, T3& A) {
     const size_t N = A.rows();
     // Algorithm is in rowmajor so we make the adjoint copy rowmajor
     Eigen::Matrix<double, -1, -1, Eigen::RowMajor> adjL(L.rows(), L.cols());
+    Eigen::MatrixXd adjA = Eigen::MatrixXd::Zero(L.rows(), L.cols());
     adjL.template triangularView<Eigen::Lower>() = L.adj();
     for (int i = N - 1; i >= 0; --i) {
       for (int j = i; j >= 0; --j) {
         if (i == j) {
-          A.adj()(i, j) = 0.5 * adjL.coeff(i, j) / L_A.coeff(i, j);
+          adjA.coeffRef(i, j) = 0.5 * adjL.coeff(i, j) / L_A.coeff(i, j);
         } else {
-          A.adj()(i, j) = adjL.coeff(i, j) / L_A.coeff(j, j);
+          adjA.coeffRef(i, j) = adjL.coeff(i, j) / L_A.coeff(j, j);
           adjL.coeffRef(j, j)
               -= adjL.coeff(i, j) * L_A.coeff(i, j) / L_A.coeff(j, j);
         }
         for (int k = j - 1; k >= 0; --k) {
-          adjL.coeffRef(i, k) -= A.adj().coeff(i, j) * L_A.coeff(j, k);
-          adjL.coeffRef(j, k) -= A.adj().coeff(i, j) * L_A.coeff(i, k);
+          adjL.coeffRef(i, k) -= adjA.coeff(i, j) * L_A.coeff(j, k);
+          adjL.coeffRef(j, k) -= adjA.coeff(i, j) * L_A.coeff(i, k);
         }
       }
     }
+    A.adj() += adjA;
   };
 }
 
@@ -87,7 +89,7 @@ inline auto cholesky_lambda(T1& L_A, T2& L, T3& A) {
     using Eigen::Lower;
     using Eigen::StrictlyUpper;
     using Eigen::Upper;
-    Eigen::MatrixXd L_adj(L.rows(), L.cols());
+    Eigen::MatrixXd L_adj = Eigen::MatrixXd::Zero(L.rows(), L.cols());
     L_adj.template triangularView<Eigen::Lower>() = L.adj();
     const int M_ = L_A.rows();
     int block_size_ = std::max(M_ / 8, 8);
@@ -119,7 +121,7 @@ inline auto cholesky_lambda(T1& L_A, T2& L, T3& A) {
       R_adj.noalias() -= D_adj.template selfadjointView<Lower>() * R;
       D_adj.diagonal() *= 0.5;
     }
-    A.adj().template triangularView<Eigen::Lower>() = L_adj;
+    A.adj().template triangularView<Eigen::Lower>() += L_adj;
   };
 }
 

--- a/test/unit/math/rev/fun/cholesky_decompose_test.cpp
+++ b/test/unit/math/rev/fun/cholesky_decompose_test.cpp
@@ -451,7 +451,7 @@ TEST(AgradRevMatrix, mat_cholesky_1st_deriv_large_gradients) {
 
 TEST(AgradRevMatrix, cholesky_replicated_input) {
   using stan::math::var;
-  
+
   auto f = [](int size, const auto& y) {
     auto m = stan::math::diag_matrix(stan::math::rep_vector(y, size));
     auto L = stan::math::cholesky_decompose(m);

--- a/test/unit/math/rev/fun/cholesky_decompose_test.cpp
+++ b/test/unit/math/rev/fun/cholesky_decompose_test.cpp
@@ -449,6 +449,34 @@ TEST(AgradRevMatrix, mat_cholesky_1st_deriv_large_gradients) {
   test_simple_vec_mult(45, 1e-08);
 }
 
+TEST(AgradRevMatrix, cholesky_replicated_input) {
+  using stan::math::var;
+  
+  auto f = [](int size, const auto& y) {
+    auto m = stan::math::diag_matrix(stan::math::rep_vector(y, size));
+    auto L = stan::math::cholesky_decompose(m);
+    return stan::math::sum(L);
+  };
+
+  double ydbl = 1.5;
+  double dx = 1e-5;
+  var y = ydbl;
+  int size = 4;
+  var s = f(size, y);
+  s.grad();
+
+  double fd_ref = (f(size, ydbl + dx) - f(size, ydbl - dx)) / (2.0 * dx);
+  EXPECT_FLOAT_EQ(y.adj(), fd_ref);
+
+  stan::math::set_zero_all_adjoints();
+  size = 40;
+  s = f(size, y);
+  s.grad();
+
+  fd_ref = (f(size, ydbl + dx) - f(size, ydbl - dx)) / (2.0 * dx);
+  EXPECT_FLOAT_EQ(y.adj(), fd_ref);
+}
+
 #ifdef STAN_OPENCL
 TEST(AgradRevMatrix, mat_cholesky_1st_deriv_large_gradients_opencl) {
   stan::math::opencl_context.tuning_opts().cholesky_size_worth_transfer = 25;


### PR DESCRIPTION
## Summary

Fixes #2364 . The problem was `cholesky_decompose` not updating the input adjoints correctly (but doing it in a way that it would pass generic autodiff tests).

## Tests

Added one!

## Release notes

 - Fixed issue with `cholesky_decompose` not propagating derivatives correctly

## Checklist

- [x] Math issue #2364 

- [x] Copyright holder: Columbia University

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
