### PR TITLE
Fixes bug in `reduce_sum` handling expressions with threading enabled

### DIFF
--- a/stan/math/prim/functor/reduce_sum.hpp
+++ b/stan/math/prim/functor/reduce_sum.hpp
@@ -204,9 +204,9 @@ inline auto reduce_sum(Vec&& vmapped, int grainsize, std::ostream* msgs,
 
 #ifdef STAN_THREADS
   return internal::reduce_sum_impl<ReduceFunction, void, return_type, Vec,
-                                   Args...>()(std::forward<Vec>(vmapped), true,
-                                              grainsize, msgs,
-                                              std::forward<Args>(args)...);
+                                   ref_type_t<Args&&>...>()(
+      std::forward<Vec>(vmapped), true, grainsize, msgs,
+      std::forward<Args>(args)...);
 #else
   if (vmapped.empty()) {
     return return_type(0.0);

--- a/stan/math/rev/core/deep_copy_vars.hpp
+++ b/stan/math/rev/core/deep_copy_vars.hpp
@@ -20,7 +20,7 @@ namespace math {
  *  Otherwise it will be moved.
  */
 template <typename Arith, typename = require_arithmetic_t<scalar_type_t<Arith>>>
-inline decltype(auto) deep_copy_vars(Arith&& arg) {
+inline Arith deep_copy_vars(Arith&& arg) {
   return std::forward<Arith>(arg);
 }
 


### PR DESCRIPTION
## Summary

Fixes two bugs in `reduce_sum` when `STAN_THREADS` is set. 
 - under some conditions `reduce_sum` did not compile (the original reported bug in the issue)
 - shared arguments could be evaluated multiple times (the reason for expression tests failing with `STAN_THREADS` set)

## Tests
None for now. @rok-cesnovar promised he will add tests for those after the bugfix release.

## Side Effects
None

## Release notes
Fixes two bugs in `reduce_sum` when `STAN_THREADS` is set. 

## Checklist

- [x] Math issue #2370

- [x] Copyright holder: Tadej Ciglarič

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [ ] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [ ] the code is written in idiomatic C++ and changes are documented in the doxygen

- [ ] the new changes are tested
