### PR TITLE
Feature/lb constrain matvar varmat tests

### DIFF
--- a/stan/math/prim/fun/lb_constrain.hpp
+++ b/stan/math/prim/fun/lb_constrain.hpp
@@ -115,6 +115,7 @@ inline auto lb_constrain(const T& x, const L& lb, return_type_t<T, L>& lp) {
 template <typename T, typename L, require_all_eigen_t<T, L>* = nullptr,
           require_all_not_st_var<T, L>* = nullptr>
 inline auto lb_constrain(T&& x, L&& lb) {
+  check_matching_dims("lb_constrain", "x", x, "lb", lb);
   return eval(x.binaryExpr(
       lb, [](auto&& x, auto&& lb) { return lb_constrain(x, lb); }));
 }
@@ -133,6 +134,7 @@ inline auto lb_constrain(T&& x, L&& lb) {
 template <typename T, typename L, require_all_eigen_t<T, L>* = nullptr,
           require_all_not_st_var<T, L>* = nullptr>
 inline auto lb_constrain(const T& x, const L& lb, return_type_t<T, L>& lp) {
+  check_matching_dims("lb_constrain", "x", x, "lb", lb);
   return eval(x.binaryExpr(
       lb, [&lp](auto&& xx, auto&& lbb) { return lb_constrain(xx, lbb, lp); }));
 }
@@ -191,6 +193,7 @@ inline auto lb_constrain(const std::vector<T>& x, const L& lb,
  */
 template <typename T, typename L>
 inline auto lb_constrain(const std::vector<T>& x, const std::vector<L>& lb) {
+  check_matching_dims("lb_constrain", "x", x, "lb", lb);
   std::vector<plain_type_t<decltype(lb_constrain(x[0], lb[0]))>> ret(x.size());
   for (size_t i = 0; i < x.size(); ++i) {
     ret[i] = lb_constrain(x[i], lb[i]);
@@ -212,6 +215,7 @@ inline auto lb_constrain(const std::vector<T>& x, const std::vector<L>& lb) {
 template <typename T, typename L>
 inline auto lb_constrain(const std::vector<T>& x, const std::vector<L>& lb,
                          return_type_t<T, L>& lp) {
+  check_matching_dims("lb_constrain", "x", x, "lb", lb);
   std::vector<plain_type_t<decltype(lb_constrain(x[0], lb[0]))>> ret(x.size());
   for (size_t i = 0; i < x.size(); ++i) {
     ret[i] = lb_constrain(x[i], lb[i], lp);

--- a/stan/math/rev/fun/lb_constrain.hpp
+++ b/stan/math/rev/fun/lb_constrain.hpp
@@ -234,6 +234,7 @@ inline auto lb_constrain(const T& x, const L& lb, return_type_t<T, L>& lp) {
 template <typename T, typename L, require_all_matrix_t<T, L>* = nullptr,
           require_any_st_var<T, L>* = nullptr>
 inline auto lb_constrain(const T& x, const L& lb) {
+  check_matching_dims("lb_constrain", "x", x, "lb", lb);
   using ret_type = return_var_matrix_t<T, T, L>;
   if (!is_constant<T>::value && !is_constant<L>::value) {
     arena_t<promote_scalar_t<var, T>> arena_x = x;
@@ -297,6 +298,7 @@ inline auto lb_constrain(const T& x, const L& lb) {
 template <typename T, typename L, require_all_matrix_t<T, L>* = nullptr,
           require_any_st_var<T, L>* = nullptr>
 inline auto lb_constrain(const T& x, const L& lb, return_type_t<T, L>& lp) {
+  check_matching_dims("lb_constrain", "x", x, "lb", lb);
   using ret_type = return_var_matrix_t<T, T, L>;
   if (!is_constant<T>::value && !is_constant<L>::value) {
     arena_t<promote_scalar_t<var, T>> arena_x = x;

--- a/test/unit/math/mix/fun/lb_constrain_matvar_test.cpp
+++ b/test/unit/math/mix/fun/lb_constrain_matvar_test.cpp
@@ -66,7 +66,10 @@ TEST(mathMixMatFun, lb_matvar_constrain) {
   A << 5.0, 2.0, 0.0, 0.005;
   Eigen::MatrixXd lbm(2, 2);
   lbm << 7.0, 5.0, 0.0, 0.0005;
+  Eigen::MatrixXd lbm_bad(2, 1);
+  lbm << 7.0, 5.0;
   lb_constrain_test::expect_matvar(A, lbm);
+  lb_constrain_test::expect_matvar(A, lbm_bad);
   double lbd = 6.0;
   lb_constrain_test::expect_matvar(A, lbd);
 }
@@ -87,11 +90,14 @@ TEST(mathMixMatFun, lb_stdvec_mat_mat_constrain_matvar) {
   A_inner << 5.0, 2.0, 4.0, -2.0, 0.0, 0.005;
   Eigen::MatrixXd lbm_inner(2, 3);
   lbm_inner << 7.0, 5.0, 6.0, 100.0, 0.0, 0.0005;
+  Eigen::MatrixXd lbm_inner_bad(2, 2);
+  lbm_inner << 7.0, 5.0, 6.0, 100.0;
   Eigen::MatrixXd A_inner2 = 2.0 * A_inner;
   std::vector<Eigen::MatrixXd> A;
   A.push_back(A_inner);
   A.push_back(A_inner2);
   lb_constrain_test::expect_vec_matvar(A, lbm_inner);
+  lb_constrain_test::expect_vec(A, lbm_inner_bad);
   double lbd = 6.0;
   lb_constrain_test::expect_vec_matvar(A, lbd);
 }
@@ -124,7 +130,15 @@ TEST(mathMixMatFun, lb_stdvec_mat_constrain_matvar) {
   std::vector<Eigen::MatrixXd> lbm;
   lbm.push_back(lbm_inner);
   lbm.push_back(lbm_inner2);
+  std::vector<Eigen::MatrixXd> lbm_bad1;
+  lbm_bad1.push_back(lbm_inner);
+  Eigen::MatrixXd lbm_inner_bad(2, 2);
+  lbm_inner_bad << 7.0, 5.0, 6.0, 100.0;
+  std::vector<Eigen::MatrixXd> lbm_bad2;
+  lbm_bad2.push_back(lbm_inner_bad);
   lb_constrain_test::expect_vec_matvar(A, lbm);
+  lb_constrain_test::expect_vec_matvar(A, lbm_bad1);
+  lb_constrain_test::expect_vec_matvar(A, lbm_bad2);
 }
 
 TEST(mathMixMatFun, lb_stdvec_mat_constrain_matvar_neg_inf) {

--- a/test/unit/math/mix/fun/lb_constrain_matvar_test.cpp
+++ b/test/unit/math/mix/fun/lb_constrain_matvar_test.cpp
@@ -67,7 +67,7 @@ TEST(mathMixMatFun, lb_matvar_constrain) {
   Eigen::MatrixXd lbm(2, 2);
   lbm << 7.0, 5.0, 0.0, 0.0005;
   Eigen::MatrixXd lbm_bad(2, 1);
-  lbm << 7.0, 5.0;
+  lbm_bad << 7.0, 5.0;
   lb_constrain_test::expect_matvar(A, lbm);
   lb_constrain_test::expect_matvar(A, lbm_bad);
   double lbd = 6.0;
@@ -91,13 +91,13 @@ TEST(mathMixMatFun, lb_stdvec_mat_mat_constrain_matvar) {
   Eigen::MatrixXd lbm_inner(2, 3);
   lbm_inner << 7.0, 5.0, 6.0, 100.0, 0.0, 0.0005;
   Eigen::MatrixXd lbm_inner_bad(2, 2);
-  lbm_inner << 7.0, 5.0, 6.0, 100.0;
+  lbm_inner_bad << 7.0, 5.0, 6.0, 100.0;
   Eigen::MatrixXd A_inner2 = 2.0 * A_inner;
   std::vector<Eigen::MatrixXd> A;
   A.push_back(A_inner);
   A.push_back(A_inner2);
   lb_constrain_test::expect_vec_matvar(A, lbm_inner);
-  lb_constrain_test::expect_vec(A, lbm_inner_bad);
+  lb_constrain_test::expect_vec_matvar(A, lbm_inner_bad);
   double lbd = 6.0;
   lb_constrain_test::expect_vec_matvar(A, lbd);
 }

--- a/test/unit/math/mix/fun/lb_constrain_matvar_test.cpp
+++ b/test/unit/math/mix/fun/lb_constrain_matvar_test.cpp
@@ -27,6 +27,35 @@ void expect_matvar(const T1& x, const T2& lb) {
   stan::test::expect_ad_matvar(f3, x, lb);
   stan::test::expect_ad_matvar(f4, x, lb);
 }
+
+template <typename T1, typename T2>
+void expect_vec_matvar(const T1& x, const T2& lb) {
+  auto f1 = [](const auto& x, const auto& lb) {
+    return stan::math::lb_constrain(x, lb);
+  };
+  auto f2 = [](const auto& x, const auto& lb) {
+    stan::return_type_t<decltype(x), decltype(lb)> lp = 0;
+    return stan::math::lb_constrain(x, lb, lp);
+  };
+  auto f3 = [](const auto& x, const auto& lb) {
+    stan::return_type_t<decltype(x), decltype(lb)> lp = 0;
+    stan::math::lb_constrain(x, lb, lp);
+    return lp;
+  };
+  auto f4 = [](const auto& x, const auto& lb) {
+    stan::return_type_t<decltype(x), decltype(lb)> lp = 0;
+    auto xx = stan::math::eval(stan::math::lb_constrain(x, lb, lp));
+    stan::return_type_t<decltype(x), decltype(lb)> xx_acc = 0;
+    for (size_t i = 0; i < xx.size(); ++i) {
+      xx_acc += stan::math::sum(xx[i]);
+    }
+    return stan::math::add(lp, xx_acc);
+  };
+  stan::test::expect_ad_matvar(f1, x, lb);
+  stan::test::expect_ad_matvar(f2, x, lb);
+  stan::test::expect_ad_matvar(f3, x, lb);
+  stan::test::expect_ad_matvar(f4, x, lb);
+}
 }  // namespace lb_constrain_test
 
 TEST(mathMixMatFun, lb_matvar_constrain) {
@@ -50,3 +79,66 @@ TEST(mathMixMatFun, lb_matvar_constrain_neg_inf) {
   lb_constrain_test::expect_matvar(A, lbm);
   lb_constrain_test::expect_matvar(A, stan::math::NEGATIVE_INFTY);
 }
+
+// matrix[], matrix
+// matrix[], real
+TEST(mathMixMatFun, lb_stdvec_mat_mat_constrain_matvar) {
+  Eigen::MatrixXd A_inner(2, 3);
+  A_inner << 5.0, 2.0, 4.0, -2.0, 0.0, 0.005;
+  Eigen::MatrixXd lbm_inner(2, 3);
+  lbm_inner << 7.0, 5.0, 6.0, 100.0, 0.0, 0.0005;
+  Eigen::MatrixXd A_inner2 = 2.0 * A_inner;
+  std::vector<Eigen::MatrixXd> A;
+  A.push_back(A_inner);
+  A.push_back(A_inner2);
+  lb_constrain_test::expect_vec_matvar(A, lbm_inner);
+  double lbd = 6.0;
+  lb_constrain_test::expect_vec_matvar(A, lbd);
+}
+
+TEST(mathMixMatFun, lb_stdvec_mat_mat_constrain_matvar_neg_inf) {
+  Eigen::MatrixXd A_inner(2, 3);
+  A_inner << 5.0, 2.0, 4.0, -2.0, 0.0, 0.005;
+  Eigen::MatrixXd lbm_inner(2, 3);
+  lbm_inner << 7.0, 5.0, 6.0, stan::math::NEGATIVE_INFTY, 0.0, 0.0005;
+  Eigen::MatrixXd A_inner2 = 2.0 * A_inner;
+  std::vector<Eigen::MatrixXd> A;
+  A.push_back(A_inner);
+  A.push_back(A_inner2);
+  lb_constrain_test::expect_vec_matvar(A, lbm_inner);
+  double lbi = stan::math::NEGATIVE_INFTY;
+  lb_constrain_test::expect_vec_matvar(A, lbi);
+}
+
+// matrix[], matrix[]
+TEST(mathMixMatFun, lb_stdvec_mat_constrain_matvar) {
+  Eigen::MatrixXd A_inner(2, 3);
+  A_inner << 5.0, 2.0, 4.0, -2.0, 0.0, 0.005;
+  Eigen::MatrixXd lbm_inner(2, 3);
+  lbm_inner << 7.0, 5.0, 6.0, 100.0, 0.0, 0.0005;
+  Eigen::MatrixXd A_inner2 = 2.0 * A_inner;
+  Eigen::MatrixXd lbm_inner2 = 3.0 * lbm_inner;
+  std::vector<Eigen::MatrixXd> A;
+  A.push_back(A_inner);
+  A.push_back(A_inner2);
+  std::vector<Eigen::MatrixXd> lbm;
+  lbm.push_back(lbm_inner);
+  lbm.push_back(lbm_inner2);
+  lb_constrain_test::expect_vec_matvar(A, lbm);
+}
+
+TEST(mathMixMatFun, lb_stdvec_mat_constrain_matvar_neg_inf) {
+  Eigen::MatrixXd A_inner(2, 2);
+  A_inner << 5.0, 2.0, 4.0, -2.0;
+  Eigen::MatrixXd lbm_inner(2, 2);
+  lbm_inner << 7.0, 5.0, stan::math::NEGATIVE_INFTY, 100.0;
+  Eigen::MatrixXd A_inner2 = 2 * A_inner;
+  Eigen::MatrixXd lbm_inner2(2, 2);
+  lbm_inner << 7.0, stan::math::NEGATIVE_INFTY, 5.0, 100.0;
+  std::vector<Eigen::MatrixXd> A{A_inner, A_inner2};
+  std::vector<Eigen::MatrixXd> lbm{lbm_inner, lbm_inner2};
+  lb_constrain_test::expect_vec_matvar(A, lbm);
+  lb_constrain_test::expect_vec_matvar(A, A_inner);
+  lb_constrain_test::expect_vec_matvar(A, stan::math::NEGATIVE_INFTY);
+}
+

--- a/test/unit/math/mix/fun/lb_constrain_test.cpp
+++ b/test/unit/math/mix/fun/lb_constrain_test.cpp
@@ -78,7 +78,7 @@ TEST(mathMixMatFun, lb_mat_constrain) {
   Eigen::MatrixXd lbm(2, 3);
   lbm << 7.0, 5.0, 6.0, 100.0, 0.0, 0.0005;
   Eigen::MatrixXd lbm_bad(2, 2);
-  lbm << 7.0, 5.0, 6.0, 100.0;
+  lbm_bad << 7.0, 5.0, 6.0, 100.0;
   lb_constrain_test::expect(A, lbm);
   lb_constrain_test::expect(A, lbm_bad);
   double lbd = 6.0;
@@ -120,8 +120,8 @@ TEST(mathMixMatFun, lb_stdvec_mat_mat_constrain) {
   A_inner << 5.0, 2.0, 4.0, -2.0, 0.0, 0.005;
   Eigen::MatrixXd lbm_inner(2, 3);
   lbm_inner << 7.0, 5.0, 6.0, 100.0, 0.0, 0.0005;
-  Eigen::MatrixXd lbm_inner_bad(2);
-  lbm_inner << 7.0, 5.0, 6.0, 100.0;
+  Eigen::MatrixXd lbm_inner_bad(2, 1);
+  lbm_inner_bad << 7.0, 5.0;
   Eigen::MatrixXd A_inner2 = 2.0 * A_inner;
   std::vector<Eigen::MatrixXd> A;
   A.push_back(A_inner);

--- a/test/unit/math/mix/fun/lb_constrain_test.cpp
+++ b/test/unit/math/mix/fun/lb_constrain_test.cpp
@@ -77,7 +77,10 @@ TEST(mathMixMatFun, lb_mat_constrain) {
   A << 5.0, 2.0, 4.0, -2.0, 0.0, 0.005;
   Eigen::MatrixXd lbm(2, 3);
   lbm << 7.0, 5.0, 6.0, 100.0, 0.0, 0.0005;
+  Eigen::MatrixXd lbm_bad(2, 2);
+  lbm << 7.0, 5.0, 6.0, 100.0;
   lb_constrain_test::expect(A, lbm);
+  lb_constrain_test::expect(A, lbm_bad);
   double lbd = 6.0;
   lb_constrain_test::expect(A, lbd);
 }
@@ -96,7 +99,9 @@ TEST(mathMixMatFun, lb_mat_constrain_neg_inf) {
 TEST(mathMixMatFun, lb_stdvec_constrain) {
   std::vector<double> A{5.0, 2.0, 4.0, -2.0};
   std::vector<double> lbm{7.0, 5.0, 6.0, 100.0};
+  std::vector<double> lbm_bad{7.0, 5.0, 6.0};
   lb_constrain_test::expect(A, lbm);
+  lb_constrain_test::expect(A, lbm_bad);
   double lbd = 6.0;
   lb_constrain_test::expect(A, lbd);
 }
@@ -115,11 +120,14 @@ TEST(mathMixMatFun, lb_stdvec_mat_mat_constrain) {
   A_inner << 5.0, 2.0, 4.0, -2.0, 0.0, 0.005;
   Eigen::MatrixXd lbm_inner(2, 3);
   lbm_inner << 7.0, 5.0, 6.0, 100.0, 0.0, 0.0005;
+  Eigen::MatrixXd lbm_inner_bad(2);
+  lbm_inner << 7.0, 5.0, 6.0, 100.0;
   Eigen::MatrixXd A_inner2 = 2.0 * A_inner;
   std::vector<Eigen::MatrixXd> A;
   A.push_back(A_inner);
   A.push_back(A_inner2);
   lb_constrain_test::expect_vec(A, lbm_inner);
+  lb_constrain_test::expect_vec(A, lbm_inner_bad);
   double lbd = 6.0;
   lb_constrain_test::expect_vec(A, lbd);
 }
@@ -152,7 +160,15 @@ TEST(mathMixMatFun, lb_stdvec_mat_constrain) {
   std::vector<Eigen::MatrixXd> lbm;
   lbm.push_back(lbm_inner);
   lbm.push_back(lbm_inner2);
+  std::vector<Eigen::MatrixXd> lbm_bad1;
+  lbm_bad1.push_back(lbm_inner);
+  Eigen::MatrixXd lbm_inner_bad(2, 2);
+  lbm_inner_bad << 7.0, 5.0, 6.0, 100.0;
+  std::vector<Eigen::MatrixXd> lbm_bad2;
+  lbm_bad2.push_back(lbm_inner_bad);
   lb_constrain_test::expect_vec(A, lbm);
+  lb_constrain_test::expect_vec(A, lbm_bad1);
+  lb_constrain_test::expect_vec(A, lbm_bad2);
 }
 
 TEST(mathMixMatFun, lb_stdvec_mat_constrain_neg_inf) {

--- a/test/unit/math/prim/fun/lb_transform_test.cpp
+++ b/test/unit/math/prim/fun/lb_transform_test.cpp
@@ -44,7 +44,7 @@ TEST(prob_transform, lb_constrain_matrix) {
     for(size_t i = 0; i < result.size(); ++i) {
       EXPECT_FLOAT_EQ(result(i), stan::math::lb_constrain(x(i), lbd));
     }
-    EXPECT_MATRIX_EQ(x, stan::math::lb_free(result, lbd));
+    //EXPECT_MATRIX_EQ(x, stan::math::lb_free(result, lbd));
   }
 
   // matrix, matrix
@@ -53,7 +53,7 @@ TEST(prob_transform, lb_constrain_matrix) {
     for(size_t i = 0; i < result.size(); ++i) {
       EXPECT_FLOAT_EQ(result(i), stan::math::lb_constrain(x(i), lb(i)));
     }
-    EXPECT_MATRIX_EQ(x, stan::math::lb_free(result, lb));
+    //EXPECT_MATRIX_EQ(x, stan::math::lb_free(result, lb));
     EXPECT_THROW(stan::math::lb_constrain(x, lb_bad), std::invalid_argument);
   }
 
@@ -104,10 +104,10 @@ TEST(prob_transform, lb_constrain_std_vector) {
     for(size_t i = 0; i < result.size(); ++i) {
       EXPECT_MATRIX_EQ(result[i], stan::math::lb_constrain(x_vec[i], lbd));
     }
-    auto free_x = stan::math::lb_free(result, lbd);
+    /*auto free_x = stan::math::lb_free(result, lbd);
     for(size_t i = 0; i < result.size(); ++i) {
       EXPECT_MATRIX_EQ(x[i], free_x[i]);
-    }
+      }*/
   }
 
   // matrix[], matrix
@@ -116,10 +116,10 @@ TEST(prob_transform, lb_constrain_std_vector) {
     for(size_t i = 0; i < result.size(); ++i) {
       EXPECT_MATRIX_EQ(result[i], stan::math::lb_constrain(x_vec[i], lb));
     }
-    auto free_x = stan::math::lb_free(result, lb);
+    /*auto free_x = stan::math::lb_free(result, lb);
     for(size_t i = 0; i < result.size(); ++i) {
       EXPECT_MATRIX_EQ(x[i], free_x[i]);
-    }
+      }*/
     EXPECT_THROW(stan::math::lb_constrain(x_vec, lb_bad), std::invalid_argument);
   }
 
@@ -129,10 +129,10 @@ TEST(prob_transform, lb_constrain_std_vector) {
     for(size_t i = 0; i < result.size(); ++i) {
       EXPECT_MATRIX_EQ(result[i], stan::math::lb_constrain(x_vec[i], lb_vec[i]));
     }
-    auto free_x = stan::math::lb_free(result, lb_vec);
+    /*auto free_x = stan::math::lb_free(result, lb_vec);
     for(size_t i = 0; i < result.size(); ++i) {
       EXPECT_MATRIX_EQ(x[i], free_x[i]);
-    }
+      }*/
     EXPECT_THROW(stan::math::lb_constrain(x_vec, lb_vec_bad1), std::invalid_argument);
     EXPECT_THROW(stan::math::lb_constrain(x_vec, lb_vec_bad2), std::invalid_argument);
   }
@@ -191,10 +191,10 @@ TEST(prob_transform, lb_free_exception) {
 
   EXPECT_THROW(stan::math::lb_free(xd_bad, lbd), std::domain_error);
 
-  EXPECT_THROW(stan::math::lb_free(x_bad, lbd), std::domain_error);
+  /*EXPECT_THROW(stan::math::lb_free(x_bad, lbd), std::domain_error);
   EXPECT_THROW(stan::math::lb_free(x_bad, lb), std::domain_error);
 
   EXPECT_THROW(stan::math::lb_free(x_bad_vec, lbd), std::domain_error);
   EXPECT_THROW(stan::math::lb_free(x_bad_vec, lb), std::domain_error);
-  EXPECT_THROW(stan::math::lb_free(x_bad_vec, lb_vec), std::domain_error);
+  EXPECT_THROW(stan::math::lb_free(x_bad_vec, lb_vec), std::domain_error);*/
 }

--- a/test/unit/math/prim/fun/lb_transform_test.cpp
+++ b/test/unit/math/prim/fun/lb_transform_test.cpp
@@ -44,7 +44,7 @@ TEST(prob_transform, lb_constrain_matrix) {
     for(size_t i = 0; i < result.size(); ++i) {
       EXPECT_FLOAT_EQ(result(i), stan::math::lb_constrain(x(i), lbd));
     }
-    //EXPECT_MATRIX_EQ(x, stan::math::lb_free(result, lbd));
+    EXPECT_MATRIX_EQ(x, stan::math::lb_free(result, lbd));
   }
 
   // matrix, matrix
@@ -53,7 +53,7 @@ TEST(prob_transform, lb_constrain_matrix) {
     for(size_t i = 0; i < result.size(); ++i) {
       EXPECT_FLOAT_EQ(result(i), stan::math::lb_constrain(x(i), lb(i)));
     }
-    //EXPECT_MATRIX_EQ(x, stan::math::lb_free(result, lb));
+    EXPECT_MATRIX_EQ(x, stan::math::lb_free(result, lb));
     EXPECT_THROW(stan::math::lb_constrain(x, lb_bad), std::invalid_argument);
   }
 
@@ -104,10 +104,10 @@ TEST(prob_transform, lb_constrain_std_vector) {
     for(size_t i = 0; i < result.size(); ++i) {
       EXPECT_MATRIX_EQ(result[i], stan::math::lb_constrain(x_vec[i], lbd));
     }
-    /*auto free_x = stan::math::lb_free(result, lbd);
+    auto free_x = stan::math::lb_free(result, lbd);
     for(size_t i = 0; i < result.size(); ++i) {
       EXPECT_MATRIX_EQ(x[i], free_x[i]);
-      }*/
+    }
   }
 
   // matrix[], matrix
@@ -116,10 +116,10 @@ TEST(prob_transform, lb_constrain_std_vector) {
     for(size_t i = 0; i < result.size(); ++i) {
       EXPECT_MATRIX_EQ(result[i], stan::math::lb_constrain(x_vec[i], lb));
     }
-    /*auto free_x = stan::math::lb_free(result, lb);
+    auto free_x = stan::math::lb_free(result, lb);
     for(size_t i = 0; i < result.size(); ++i) {
       EXPECT_MATRIX_EQ(x[i], free_x[i]);
-      }*/
+    }
     EXPECT_THROW(stan::math::lb_constrain(x_vec, lb_bad), std::invalid_argument);
   }
 
@@ -129,10 +129,10 @@ TEST(prob_transform, lb_constrain_std_vector) {
     for(size_t i = 0; i < result.size(); ++i) {
       EXPECT_MATRIX_EQ(result[i], stan::math::lb_constrain(x_vec[i], lb_vec[i]));
     }
-    /*auto free_x = stan::math::lb_free(result, lb_vec);
+    auto free_x = stan::math::lb_free(result, lb_vec);
     for(size_t i = 0; i < result.size(); ++i) {
       EXPECT_MATRIX_EQ(x[i], free_x[i]);
-      }*/
+    }
     EXPECT_THROW(stan::math::lb_constrain(x_vec, lb_vec_bad1), std::invalid_argument);
     EXPECT_THROW(stan::math::lb_constrain(x_vec, lb_vec_bad2), std::invalid_argument);
   }
@@ -191,10 +191,10 @@ TEST(prob_transform, lb_free_exception) {
 
   EXPECT_THROW(stan::math::lb_free(xd_bad, lbd), std::domain_error);
 
-  /*EXPECT_THROW(stan::math::lb_free(x_bad, lbd), std::domain_error);
+  EXPECT_THROW(stan::math::lb_free(x_bad, lbd), std::domain_error);
   EXPECT_THROW(stan::math::lb_free(x_bad, lb), std::domain_error);
 
   EXPECT_THROW(stan::math::lb_free(x_bad_vec, lbd), std::domain_error);
   EXPECT_THROW(stan::math::lb_free(x_bad_vec, lb), std::domain_error);
-  EXPECT_THROW(stan::math::lb_free(x_bad_vec, lb_vec), std::domain_error);*/
+  EXPECT_THROW(stan::math::lb_free(x_bad_vec, lb_vec), std::domain_error);
 }

--- a/test/unit/math/test_ad_matvar.hpp
+++ b/test/unit/math/test_ad_matvar.hpp
@@ -408,7 +408,8 @@ void expect_ad_matvar_impl(const ad_tolerances& tols, const F& f,
   auto A_vm_tuple = std::make_tuple(convert_to_varmat<Types>(x)...);
 
   bool any_varmat = stan::math::apply([](const auto&... args) {
-      return stan::math::disjunction<is_var_matrix<decltype(args)>...>::value;
+      return stan::math::disjunction<is_var_matrix<decltype(args)>...>::value ||
+      stan::math::disjunction<stan::math::conjunction<is_std_vector<decltype(args)>, is_var_matrix<value_type_t<decltype(args)>>>...>::value;
     }, A_vm_tuple);
 
   if(!any_varmat) {

--- a/test/unit/math/test_ad_matvar.hpp
+++ b/test/unit/math/test_ad_matvar.hpp
@@ -429,8 +429,6 @@ void expect_ad_matvar_impl(const ad_tolerances& tols, const F& f,
 
   if(is_eigen<T_vm_ret>::value ||
      (is_std_vector<T_vm_ret>::value && is_eigen<value_type_t<T_vm_ret>>::value)) {
-    std::cout << type_name<decltype(std::get<0>(A_vm_tuple))>() << std::endl;
-    std::cout << type_name<decltype(std::get<1>(A_vm_tuple))>() << std::endl;
     FAIL() << "A function with varmat inputs should not return " << type_name<T_vm_ret>() << std::endl;
   }
 


### PR DESCRIPTION
## Summary

@SteveBronder I was gonna do this directly on the lb_constrain-matvar branch but it ended up being big enough to be separate.

This:
1. Updates the matvar tests to support `std::vector<Eigen::Matrix<T, R, C>>` types. This does not support `std::vector<std::vector<...>>` recursive types.
2. Enables matvar tests for lb_constrain
3. Add dimensionality checks to lb_constrain (since Math is doing all the work now)
4. Tests everything

`lb_free` is failing to compile now though. I'm sending this back to you to implement. Merge this in the other `lb_constrain` branch when you're happy.

```
./runTests.py test/unit/math/prim/fun/lb_transform_test.cpp
```

## Tests

I had to update the matvar test of tests quite a bit to make sure they were triggering in the right place

## Release notes

Replace this text with a short note on what will change if this pull request is merged in which case this will be included in the release notes.

## Checklist

- [x] Math issue #2333

- [x] Copyright holder: Columbia University

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
