### PR TITLE
Feature/one core GitHub mix tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,8 +63,8 @@ jobs:
       with:
         name: gtest_outputs_xml
         path: '**/*_test.xml'
-  fwd-mix:
-    name: fwd and mix tests
+  fwd:
+    name: fwd tests
     runs-on: windows-latest
 
     steps:
@@ -93,10 +93,50 @@ jobs:
     - name: Add TBB to PATH
       shell: powershell
       run: echo "D:/a/math/math/lib/tbb" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
-    - name: Run fwd and mix unit tests
+    - name: Run fwd unit tests
       shell: powershell
       run: |
         python.exe runTests.py test/unit/math/fwd        
+        
+    - name: Upload gtest_output xml
+      uses: actions/upload-artifact@v2
+      if: failure()
+      with:
+        name: gtest_outputs_xml
+        path: '**/*_test.xml'
+  mix:
+    name: mix tests
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '2.x'
+    - name: Download RTools
+      run: Invoke-WebRequest -Uri https://cran.rstudio.com/bin/windows/Rtools/Rtools35.exe -OutFile ./R35.exe
+    - name: Install RTools
+      shell: powershell
+      run: Start-Process -FilePath ./R35.exe -ArgumentList /VERYSILENT -NoNewWindow -Wait
+    - name: PATH Setup
+      shell: powershell
+      run: echo "C:/Rtools/bin;C:/Rtools/mingw_64/bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+    - name: Print g++ & make version and path
+      shell: powershell
+      run: |
+        g++ --version
+        Get-Command g++ | Select-Object -ExpandProperty Definition
+        mingw32-make --version
+        Get-Command mingw32-make | Select-Object -ExpandProperty Definition
+    - name: Build Math libs
+      shell: powershell
+      run: mingw32-make -f make/standalone math-libs
+    - name: Add TBB to PATH
+      shell: powershell
+      run: echo "D:/a/math/math/lib/tbb" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+    - name: Run mix unit tests
+      shell: powershell
+      run: |
         python.exe runTests.py test/unit/math/mix
         
     - name: Upload gtest_output xml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -96,8 +96,8 @@ jobs:
     - name: Run fwd and mix unit tests
       shell: powershell
       run: |
-        python.exe runTests.py -j2 test/unit/math/fwd
-        python.exe runTests.py -j2 test/unit/math/mix
+        python.exe runTests.py test/unit/math/mix
+        python.exe runTests.py test/unit/math/fwd        
         
     - name: Upload gtest_output xml
       uses: actions/upload-artifact@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -96,8 +96,8 @@ jobs:
     - name: Run fwd and mix unit tests
       shell: powershell
       run: |
+        python.exe runTests.py -j2 test/unit/math/fwd        
         python.exe runTests.py test/unit/math/mix
-        python.exe runTests.py test/unit/math/fwd        
         
     - name: Upload gtest_output xml
       uses: actions/upload-artifact@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,8 +63,8 @@ jobs:
       with:
         name: gtest_outputs_xml
         path: '**/*_test.xml'
-  fwd:
-    name: fwd tests
+  fwd-non-fun-mix:
+    name: fwd tests and non-fun mix tests
     runs-on: windows-latest
 
     steps:
@@ -93,19 +93,24 @@ jobs:
     - name: Add TBB to PATH
       shell: powershell
       run: echo "D:/a/math/math/lib/tbb" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
-    - name: Run fwd unit tests
+    - name: Run fwd unit tests and all the mix tests except those in mix/fun
       shell: powershell
       run: |
-        python.exe runTests.py test/unit/math/fwd        
-        
+        python.exe runTests.py test/unit/math/fwd
+        python.exe runTests.py test/unit/math/mix/core
+        python.exe runTests.py test/unit/math/mix/functor
+        python.exe runTests.py test/unit/math/mix/meta
+        python.exe runTests.py test/unit/math/mix/prob
+        python.exe runTests.py test/unit/math/mix/*_test.cpp
+
     - name: Upload gtest_output xml
       uses: actions/upload-artifact@v2
       if: failure()
       with:
         name: gtest_outputs_xml
         path: '**/*_test.xml'
-  mix:
-    name: mix tests
+  mix-fun:
+    name: mix/fun tests
     runs-on: windows-latest
 
     steps:
@@ -134,10 +139,10 @@ jobs:
     - name: Add TBB to PATH
       shell: powershell
       run: echo "D:/a/math/math/lib/tbb" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
-    - name: Run mix unit tests
+    - name: Run mix/fun unit tests
       shell: powershell
       run: |
-        python.exe runTests.py test/unit/math/mix
+        python.exe runTests.py test/unit/math/mix/fun
         
     - name: Upload gtest_output xml
       uses: actions/upload-artifact@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -96,7 +96,7 @@ jobs:
     - name: Run fwd and mix unit tests
       shell: powershell
       run: |
-        python.exe runTests.py -j2 test/unit/math/fwd        
+        python.exe runTests.py test/unit/math/fwd        
         python.exe runTests.py test/unit/math/mix
         
     - name: Upload gtest_output xml


### PR DESCRIPTION
## Summary

This switches the mix mode Rtools 3.5 tests to only use one core on Github actions!

## Checklist

- [x] Math issue #2930

- [x] Copyright holder: Columbia University

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
