### PR TITLE
Decrease jumbo size for windows

### DIFF
--- a/runTests.py
+++ b/runTests.py
@@ -139,7 +139,7 @@ def isWin():
 
 
 batchSize = 20 if isWin() else 200
-
+jumboSize = 5 if isWin() else 15
 
 def mungeName(name):
     """Set up the makefile target name"""
@@ -188,7 +188,7 @@ def generateJumboTests(paths):
             stopErr("The --jumbo flag is only allowed with top level folders.", 10)
     for jf in jumbo_files_to_create:
         tests_in_subfolder = sorted([x for x in os.listdir(jf) if x.endswith(testsfx)])
-        chunked_tests = divide_chunks(tests_in_subfolder, 15)
+        chunked_tests = divide_chunks(tests_in_subfolder, jumboSize)
         i = 0
         for tests in chunked_tests:
             i = i + 1


### PR DESCRIPTION
## Summary

Decreases jumbo size for Windows tests to fix the issue with too big tests files: 

```

C:/rtools40/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/8.3.0/../../../../x86_64-w64-mingw32/bin/as.exe: test/unit/math/mix/fun_10_test.o: section .pdata$_ZN4stan4math8internal24finite_diff_hessian_autoIZZNS_4test8internal16expect_ad_helperIZN19lub_constrain_tests10expect_vecISt6vectorIN5Eigen6MatrixIdLin1ELin1ELi0ELin1ELin1EEESaISB_EESB_SD_EEvRKT_RKT0_RKT1_EUlSG_SJ_SM_E0_ZNS4_13expect_ad_vvvISN_SD_SB_SD_EEvRKNS3_13ad_tolerancesESG_SJ_SM_RKT2_EUlSG_E0_JSD_SB_SD_EEEvSR_SG_SJ_RKNSA_IdLin1ELi1ELi0ELin1ELi1EEEDpT1_ENKUliE_clEiEUlSG_E_EEvSG_SY_RdRSW_RSB_: string table overflow at offset 10000158

C:\Users\Administrator\AppData\Local\Temp\ccY4ffr6.s: Assembler messages:

C:\Users\Administrator\AppData\Local\Temp\ccY4ffr6.s: Fatal error: can't close test/unit/math/mix/fun_10_test.o: file too big

mingw32-make: *** [<builtin>: test/unit/math/mix/fun_10_test.o] Error 1

mingw32-make: *** Waiting for unfinished jobs....
```

## Tests

/

## Side Effects

/

## Checklist

- [x] Math issue #(issue number)

- [x] Copyright holder: Rok Češnovar
