### PR TITLE
Added bugfix for #2233

### DIFF
--- a/stan/math/rev/core/set_zero_all_adjoints_nested.hpp
+++ b/stan/math/rev/core/set_zero_all_adjoints_nested.hpp
@@ -26,8 +26,8 @@ static void set_zero_all_adjoints_nested() {
   const size_t start1
       = ChainableStack::instance_->nested_var_stack_sizes_.back();
   // avoid wrap with unsigned when start1 == 0
-  for (size_t i = start1;
-       i < ChainableStack::instance_->var_stack_.size(); ++i) {
+  for (size_t i = start1; i < ChainableStack::instance_->var_stack_.size();
+       ++i) {
     ChainableStack::instance_->var_stack_[i]->set_zero_adjoint();
   }
 

--- a/stan/math/rev/core/set_zero_all_adjoints_nested.hpp
+++ b/stan/math/rev/core/set_zero_all_adjoints_nested.hpp
@@ -26,14 +26,14 @@ static void set_zero_all_adjoints_nested() {
   const size_t start1
       = ChainableStack::instance_->nested_var_stack_sizes_.back();
   // avoid wrap with unsigned when start1 == 0
-  for (size_t i = (start1 == 0U) ? 0U : (start1 - 1);
+  for (size_t i = start1;
        i < ChainableStack::instance_->var_stack_.size(); ++i) {
     ChainableStack::instance_->var_stack_[i]->set_zero_adjoint();
   }
 
   const size_t start2
       = ChainableStack::instance_->nested_var_nochain_stack_sizes_.back();
-  for (size_t i = (start2 == 0U) ? 0U : (start2 - 1);
+  for (size_t i = start2;
        i < ChainableStack::instance_->var_nochain_stack_.size(); ++i) {
     ChainableStack::instance_->var_nochain_stack_[i]->set_zero_adjoint();
   }

--- a/test/unit/math/rev/core/set_zero_all_adjoints_nested_test.cpp
+++ b/test/unit/math/rev/core/set_zero_all_adjoints_nested_test.cpp
@@ -12,7 +12,7 @@ TEST(AgradRev, set_zero_all_adjoints_nested_outside) {
   EXPECT_FLOAT_EQ(chaining.adj(), 2.0);
 
   stan::math::recover_memory_nested();
-  
+
   stan::math::var non_chaining = new stan::math::vari(1.0, false);
   non_chaining.adj() = 2.0;
 

--- a/test/unit/math/rev/core/set_zero_all_adjoints_nested_test.cpp
+++ b/test/unit/math/rev/core/set_zero_all_adjoints_nested_test.cpp
@@ -1,0 +1,23 @@
+#include <stan/math.hpp>
+#include <test/unit/util.hpp>
+#include <gtest/gtest.h>
+
+TEST(AgradRev, set_zero_all_adjoints_nested_outside) {
+  stan::math::var chaining = new stan::math::vari(1.0, true);
+  chaining.adj() = 2.0;
+
+  stan::math::start_nested();
+  EXPECT_FLOAT_EQ(chaining.adj(), 2.0);
+  stan::math::set_zero_all_adjoints_nested();
+  EXPECT_FLOAT_EQ(chaining.adj(), 2.0);
+
+  stan::math::recover_memory_nested();
+  
+  stan::math::var non_chaining = new stan::math::vari(1.0, false);
+  non_chaining.adj() = 2.0;
+
+  stan::math::start_nested();
+  EXPECT_FLOAT_EQ(non_chaining.adj(), 2.0);
+  stan::math::set_zero_all_adjoints_nested();
+  EXPECT_FLOAT_EQ(non_chaining.adj(), 2.0);
+}


### PR DESCRIPTION
## Summary

This fixes an off by one error in set_zero_all_adjoints_nested (where a vari right before the nested chainable/non-chainable varis would get zeroed). I think this never caused problems because we so far always do nested autodiff in forward mode (where the adjoints are already zero) and not in reverse mode.

## Tests

There's a new test to make sure this is fixed

## Release notes

- Fix off by one error in set_zero_all_adjoints_nested

## Checklist

- [x] Math issue #2233

- [x] Copyright holder: Columbia University

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
