### PR TITLE
Run OpenCL tests only when there are changes to its source

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -166,8 +166,8 @@ pipeline {
                     def paths = ['stan', 'make', 'lib', 'test', 'runTests.py', 'runChecks.py', 'makefile', 'Jenkinsfile', '.clang-format'].join(" ")
                     skipRemainingStages = utils.verifyChanges(paths)
 
-                    def paths = ['stan/math/opencl', 'test/unit/math/opencl'].join(" ")
-                    skipOpenCL = utils.verifyChanges(paths)
+                    def openCLPaths = ['stan/math/opencl', 'test/unit/math/opencl'].join(" ")
+                    skipOpenCL = utils.verifyChanges(openCLPaths)
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,6 +36,7 @@ def deleteDirWin() {
 }
 
 def skipRemainingStages = false
+def skipOpenCL = false
 
 def utils = new org.stan.Utils()
 
@@ -164,6 +165,9 @@ pipeline {
 
                     def paths = ['stan', 'make', 'lib', 'test', 'runTests.py', 'runChecks.py', 'makefile', 'Jenkinsfile', '.clang-format'].join(" ")
                     skipRemainingStages = utils.verifyChanges(paths)
+
+                    def paths = ['stan/math/opencl', 'test/unit/math/opencl'].join(" ")
+                    skipOpenCL = utils.verifyChanges(paths)
                 }
             }
         }
@@ -253,6 +257,11 @@ pipeline {
                     }
                 }
                 stage('OpenCL GPU tests') {
+                    when {
+                        expression {
+                            !skipOpenCL
+                        }
+                    }
                     agent { label "gelman-group-win2 || gg-linux" }
                     steps {
                         script {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -229,6 +229,11 @@ pipeline {
                     post { always { retry(3) { deleteDir() } } }
                 }
                 stage('OpenCL CPU tests') {
+                    when {
+                        expression {
+                            !skipOpenCL
+                        }
+                    }
                     agent { label "gelman-group-win2 || gg-linux" }
                     steps {
                         script {
@@ -257,11 +262,6 @@ pipeline {
                     }
                 }
                 stage('OpenCL GPU tests') {
-                    when {
-                        expression {
-                            !skipOpenCL
-                        }
-                    }
                     agent { label "gelman-group-win2 || gg-linux" }
                     steps {
                         script {


### PR DESCRIPTION
## Summary

Run `OpenCL CPU tests` in the pipeline only if there are changes to 'stan/math/opencl' or 'test/unit/math/opencl'.

## Tests

No new tests.

## Side Effects

No.

## Release notes

## Checklist

- [ ] Math issue #(issue number)

- [ ] Copyright holder: (fill in copyright holder information)

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [ ] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [ ] the code is written in idiomatic C++ and changes are documented in the doxygen

- [ ] the new changes are tested
