### PR TITLE
added OpenCL ref_type

### DIFF
--- a/stan/math/opencl/prim.hpp
+++ b/stan/math/opencl/prim.hpp
@@ -93,6 +93,7 @@
 #include <stan/math/opencl/pinned_matrix.hpp>
 #include <stan/math/opencl/plain_type.hpp>
 #include <stan/math/opencl/ref_type_for_opencl.hpp>
+#include <stan/math/opencl/ref_type.hpp>
 #include <stan/math/opencl/to_ref_for_opencl.hpp>
 #include <stan/math/opencl/value_type.hpp>
 #include <stan/math/opencl/zeros_strict_tri.hpp>

--- a/stan/math/opencl/ref_type.hpp
+++ b/stan/math/opencl/ref_type.hpp
@@ -1,0 +1,71 @@
+#ifndef STAN_MATH_OPENCL_REF_TYPE_HPP
+#define STAN_MATH_OPENCL_REF_TYPE_HPP
+#ifdef STAN_OPENCL
+
+#include <stan/math/opencl/kernel_generator.hpp>
+#include <stan/math/opencl/plain_type.hpp>
+#include <stan/math/prim/meta/ref_type.hpp>
+#include <type_traits>
+
+namespace stan {
+
+namespace internal {
+
+template <typename T>
+struct is_trivial_kg_expression : public std::false_type {};
+
+template <>
+struct is_trivial_kg_expression<int> : public std::true_type {};
+template <>
+struct is_trivial_kg_expression<double> : public std::true_type {};
+template <typename T>
+struct is_trivial_kg_expression<math::matrix_cl<T>> : public std::true_type {};
+template <typename T>
+struct is_trivial_kg_expression<math::load_<T>> : public std::true_type {};
+template <typename T>
+struct is_trivial_kg_expression<math::scalar_<T>> : public std::true_type {};
+template <typename T>
+struct is_trivial_kg_expression<math::constant_<T>> : public std::true_type {};
+template <>
+struct is_trivial_kg_expression<math::row_index> : public std::true_type {};
+template <>
+struct is_trivial_kg_expression<math::col_index> : public std::true_type {};
+template <typename T>
+struct is_trivial_kg_expression<math::calc_if_<false, T>>
+    : public std::true_type {};
+
+template <typename T>
+struct is_trivial_kg_expression<math::as_column_vector_or_scalar_<T>>
+    : public is_trivial_kg_expression<std::decay_t<T>> {};
+template <typename T>
+struct is_trivial_kg_expression<math::block_<T>>
+    : public is_trivial_kg_expression<std::decay_t<T>> {};
+template <typename T, bool Colwise, bool Rowwise>
+struct is_trivial_kg_expression<math::broadcast_<T, Colwise, Rowwise>>
+    : public is_trivial_kg_expression<std::decay_t<T>> {};
+template <typename T>
+struct is_trivial_kg_expression<math::calc_if_<true, T>>
+    : public is_trivial_kg_expression<std::decay_t<T>> {};
+template <typename T>
+struct is_trivial_kg_expression<math::holder_cl_<T>>
+    : public is_trivial_kg_expression<std::decay_t<T>> {};
+template <typename T, bool Colwise, bool Rowwise>
+struct is_trivial_kg_expression<math::optional_broadcast_<T, Colwise, Rowwise>>
+    : public is_trivial_kg_expression<std::decay_t<T>> {};
+
+}  // namespace internal
+
+template <bool Condition, typename T>
+struct ref_type_if<Condition, T, require_all_kernel_expressions_t<T>> {
+  using T_plain = plain_type_t<T>;
+  using T_optionally_ref
+      = std::conditional_t<std::is_rvalue_reference<T>::value,
+                           std::remove_reference_t<T>, const T&>;
+  using type = std::conditional_t<
+      internal::is_trivial_kg_expression<std::decay_t<T>>::value || !Condition,
+      T_optionally_ref, T_plain>;
+};
+
+}  // namespace stan
+#endif
+#endif

--- a/stan/math/prim/meta/ref_type.hpp
+++ b/stan/math/prim/meta/ref_type.hpp
@@ -23,6 +23,14 @@ namespace stan {
  */
 template <bool Condition, typename T, typename = void>
 struct ref_type_if {
+  using type = std::conditional_t<std::is_rvalue_reference<T>::value,
+                                  std::remove_reference_t<T>, const T&>;
+};
+
+template <bool Condition, typename T>
+struct ref_type_if<
+    Condition, T,
+    require_all_t<is_eigen<T>, bool_constant<!is_arena_matrix<T>::value>>> {
   using T_plain = plain_type_t<T>;
   using T_optionally_ref
       = std::conditional_t<std::is_rvalue_reference<T>::value,
@@ -34,12 +42,6 @@ struct ref_type_if {
               template match<T_dec>::MatchAtCompileTime
           || !Condition,
       T_optionally_ref, T_plain>;
-};
-
-template <bool Condition, typename T>
-struct ref_type_if<Condition, T, require_not_eigen_t<T>> {
-  using type = std::conditional_t<std::is_rvalue_reference<T>::value,
-                                  std::remove_reference_t<T>, const T&>;
 };
 
 template <bool Condition, typename T>

--- a/test/unit/math/opencl/ref_type_for_opencl_test.cpp
+++ b/test/unit/math/opencl/ref_type_for_opencl_test.cpp
@@ -1,0 +1,158 @@
+#ifdef STAN_OPENCL
+#include <stan/math/opencl/prim.hpp>
+#include <stan/math/prim.hpp>
+
+#include <test/unit/util.hpp>
+#include <gtest/gtest.h>
+#include <stan/math/opencl/pinned_matrix.hpp>
+
+TEST(MathMetaPrim, ref_type_for_opencl_for_opencl_non_eigen) {
+  using stan::math::ref_type_for_opencl_t;
+  std::vector<int> a{1, 2, 3};
+  ref_type_for_opencl_t<std::vector<int>> a_ref1 = a;
+  ref_type_for_opencl_t<std::vector<int>&> a_ref2 = a;
+  ref_type_for_opencl_t<std::vector<int>&&> a_ref3 = std::vector<int>{1, 2, 3};
+
+  double b = 3;
+  ref_type_for_opencl_t<double> b_ref1 = b;
+  ref_type_for_opencl_t<double&> b_ref2 = b;
+  ref_type_for_opencl_t<double&&> b_ref3 = 3;
+
+  const std::vector<double> c{0.5, 4, 0.7};
+  ref_type_for_opencl_t<const std::vector<double>> c_ref1 = c;
+  ref_type_for_opencl_t<const std::vector<double>&> c_ref2 = c;
+
+  EXPECT_STD_VECTOR_FLOAT_EQ(a_ref1, a);
+  EXPECT_STD_VECTOR_FLOAT_EQ(a_ref2, a);
+  EXPECT_STD_VECTOR_FLOAT_EQ(a_ref3, a);
+  EXPECT_EQ(b_ref1, b);
+  EXPECT_EQ(b_ref2, b);
+  EXPECT_EQ(b_ref3, b);
+  EXPECT_STD_VECTOR_FLOAT_EQ(c_ref1, c);
+  EXPECT_STD_VECTOR_FLOAT_EQ(c_ref2, c);
+  EXPECT_TRUE(std::is_lvalue_reference<ref_type_for_opencl_t<double>>::value);
+  EXPECT_TRUE(std::is_lvalue_reference<ref_type_for_opencl_t<double&>>::value);
+  EXPECT_FALSE(std::is_reference<ref_type_for_opencl_t<double&&>>::value);
+  EXPECT_TRUE(std::is_lvalue_reference<
+              ref_type_for_opencl_t<const std::vector<double>>>::value);
+  EXPECT_TRUE(std::is_lvalue_reference<
+              ref_type_for_opencl_t<const std::vector<double>&>>::value);
+  EXPECT_FALSE(std::is_reference<
+               ref_type_for_opencl_t<const std::vector<double>&&>>::value);
+}
+
+TEST(MathMetaPrim, ref_type_for_opencl_eigen_contiguous) {
+  using stan::math::ref_type_for_opencl_t;
+  Eigen::MatrixXd a(3, 3);
+  a << 1, 2, 3, 4, 5, 6, 7, 8, 9;
+  Eigen::MatrixXd a2 = a;
+  ref_type_for_opencl_t<Eigen::MatrixXd> a_ref1 = a;
+  ref_type_for_opencl_t<Eigen::MatrixXd&> a_ref2 = a;
+  ref_type_for_opencl_t<Eigen::MatrixXd&&> a_ref3 = std::move(a2);
+
+  auto b = a.leftCols(2);
+  ref_type_for_opencl_t<decltype(b)> b_ref1 = b;
+  ref_type_for_opencl_t<decltype(b)&> b_ref2 = b;
+  ref_type_for_opencl_t<decltype(b)&&> b_ref3 = a.leftCols(2);
+
+  using ContiguousMap = Eigen::Map<Eigen::MatrixXd, 0, Eigen::Stride<0, 0>>;
+  ContiguousMap c(a.data(), 3, 3);
+  ContiguousMap c2(a.data(), 3, 3);
+  ref_type_for_opencl_t<ContiguousMap> c_ref1 = c;
+  ref_type_for_opencl_t<ContiguousMap&> c_ref2 = c;
+  ref_type_for_opencl_t<ContiguousMap&&> c_ref3 = std::move(c2);
+
+  EXPECT_MATRIX_EQ(a_ref1, a);
+  EXPECT_MATRIX_EQ(a_ref2, a);
+  EXPECT_MATRIX_EQ(a_ref3, a);
+
+  EXPECT_MATRIX_EQ(b_ref1, b);
+  EXPECT_MATRIX_EQ(b_ref2, b);
+  EXPECT_MATRIX_EQ(b_ref3, b);
+
+  EXPECT_MATRIX_EQ(c_ref1, c);
+  EXPECT_MATRIX_EQ(c_ref2, c);
+  EXPECT_MATRIX_EQ(c_ref3, c);
+  EXPECT_TRUE(
+      (std::is_same<decltype(a), ref_type_for_opencl_t<decltype(a)&&>>::value));
+  EXPECT_TRUE(
+      (std::is_same<decltype(b), ref_type_for_opencl_t<decltype(b)&&>>::value));
+  EXPECT_TRUE(
+      (std::is_same<decltype(c), ref_type_for_opencl_t<decltype(c)&&>>::value));
+  EXPECT_TRUE(
+      std::is_lvalue_reference<ref_type_for_opencl_t<Eigen::MatrixXd>>::value);
+  EXPECT_TRUE(
+      std::is_lvalue_reference<ref_type_for_opencl_t<Eigen::MatrixXd&>>::value);
+  EXPECT_FALSE(
+      std::is_reference<ref_type_for_opencl_t<Eigen::MatrixXd&&>>::value);
+}
+
+TEST(MathMetaPrim, ref_type_for_opencl_eigen_non_contiguous) {
+  using stan::math::ref_type_for_opencl_t;
+  Eigen::MatrixXd m(3, 3);
+  m << 1, 2, 3, 4, 5, 6, 7, 8, 9;
+  using RowMajorMatrixXd
+      = Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>;
+  RowMajorMatrixXd a = m;
+  RowMajorMatrixXd a2 = m;
+  ref_type_for_opencl_t<RowMajorMatrixXd> a_ref1 = a;
+  ref_type_for_opencl_t<RowMajorMatrixXd&> a_ref2 = a;
+  ref_type_for_opencl_t<RowMajorMatrixXd&&> a_ref3 = std::move(a2);
+
+  auto b = m.block(1, 0, 2, 2);
+  ref_type_for_opencl_t<decltype(b)> b_ref1 = b;
+  ref_type_for_opencl_t<decltype(b)&> b_ref2 = b;
+  ref_type_for_opencl_t<decltype(b)&&> b_ref3 = a.block(1, 0, 2, 2);
+
+  Eigen::Ref<Eigen::MatrixXd> c = m;
+  Eigen::Ref<Eigen::MatrixXd> c2 = m;
+  ref_type_for_opencl_t<Eigen::Ref<Eigen::MatrixXd>> c_ref1 = c;
+  ref_type_for_opencl_t<Eigen::Ref<Eigen::MatrixXd>&> c_ref2 = c;
+  ref_type_for_opencl_t<Eigen::Ref<Eigen::MatrixXd>&&> c_ref3 = std::move(c2);
+
+  EXPECT_MATRIX_EQ(a_ref1, a);
+  EXPECT_MATRIX_EQ(a_ref2, a);
+  EXPECT_MATRIX_EQ(a_ref3, a);
+
+  EXPECT_MATRIX_EQ(b_ref1, b);
+  EXPECT_MATRIX_EQ(b_ref2, b);
+  EXPECT_MATRIX_EQ(b_ref3, b);
+
+  EXPECT_MATRIX_EQ(c_ref1, c);
+  EXPECT_MATRIX_EQ(c_ref2, c);
+  EXPECT_MATRIX_EQ(c_ref3, c);
+  EXPECT_TRUE((std::is_same<stan::math::pinned_matrix<Eigen::MatrixXd>,
+                            ref_type_for_opencl_t<decltype(a)&&>>::value));
+  EXPECT_TRUE((std::is_same<stan::math::pinned_matrix<Eigen::MatrixXd>,
+                            ref_type_for_opencl_t<decltype(b)&&>>::value));
+  EXPECT_TRUE((std::is_same<stan::math::pinned_matrix<Eigen::MatrixXd>,
+                            ref_type_for_opencl_t<decltype(c)&&>>::value));
+}
+
+TEST(MathMetaPrim, ref_type_for_opencl_eigen_expression) {
+  using stan::plain_type_t;
+  using stan::math::ref_type_for_opencl_t;
+  Eigen::MatrixXd m(3, 3);
+  m << 1, 2, 3, 4, 5, 6, 7, 8, 9;
+  auto a = m * 3;
+  ref_type_for_opencl_t<decltype(a)> a_ref1 = a;
+  ref_type_for_opencl_t<decltype(a)&> a_ref2 = a;
+  ref_type_for_opencl_t<decltype(a)&&> a_ref3 = m * 3;
+
+  Eigen::MatrixXd a_eval = a;
+  EXPECT_MATRIX_EQ(a_ref1, a_eval);
+  EXPECT_MATRIX_EQ(a_ref2, a_eval);
+  EXPECT_MATRIX_EQ(a_ref3, a_eval);
+
+  EXPECT_TRUE(
+      (std::is_same<stan::math::pinned_matrix<plain_type_t<decltype(a)>>,
+                    ref_type_for_opencl_t<decltype(a)>>::value));
+  EXPECT_TRUE(
+      (std::is_same<stan::math::pinned_matrix<plain_type_t<decltype(a)>>,
+                    ref_type_for_opencl_t<decltype(a)&>>::value));
+  EXPECT_TRUE(
+      (std::is_same<stan::math::pinned_matrix<plain_type_t<decltype(a)>>,
+                    ref_type_for_opencl_t<decltype(a)&&>>::value));
+}
+
+#endif

--- a/test/unit/math/opencl/ref_type_test.cpp
+++ b/test/unit/math/opencl/ref_type_test.cpp
@@ -5,8 +5,8 @@
 #include <gtest/gtest.h>
 
 TEST(MathMetaPrim, ref_type_matrix_cl) {
-  using stan::math::matrix_cl;
   using stan::ref_type_t;
+  using stan::math::matrix_cl;
   Eigen::MatrixXd a_eig(3, 3);
   a_eig << 1, 2, 3, 4, 5, 6, 7, 8, 9;
   matrix_cl<double> a(a_eig);
@@ -19,19 +19,15 @@ TEST(MathMetaPrim, ref_type_matrix_cl) {
   EXPECT_MATRIX_EQ(from_matrix_cl(a_ref2), from_matrix_cl(a));
   EXPECT_MATRIX_EQ(from_matrix_cl(a_ref3), from_matrix_cl(a));
 
-  EXPECT_TRUE(
-      (std::is_same<decltype(a), ref_type_t<decltype(a)&&>>::value));
-  EXPECT_TRUE(std::is_lvalue_reference<
-              ref_type_t<matrix_cl<double>>>::value);
-  EXPECT_TRUE(std::is_lvalue_reference<
-              ref_type_t<matrix_cl<double>&>>::value);
-  EXPECT_FALSE(
-      std::is_reference<ref_type_t<matrix_cl<double>&&>>::value);
+  EXPECT_TRUE((std::is_same<decltype(a), ref_type_t<decltype(a)&&>>::value));
+  EXPECT_TRUE(std::is_lvalue_reference<ref_type_t<matrix_cl<double>>>::value);
+  EXPECT_TRUE(std::is_lvalue_reference<ref_type_t<matrix_cl<double>&>>::value);
+  EXPECT_FALSE(std::is_reference<ref_type_t<matrix_cl<double>&&>>::value);
 }
 
 TEST(MathMetaPrim, ref_type_kg_light_expression) {
-  using stan::math::matrix_cl;
   using stan::ref_type_t;
+  using stan::math::matrix_cl;
   Eigen::MatrixXd m_eig(3, 3);
   m_eig << 1, 2, 3, 4, 5, 6, 7, 8, 9;
   matrix_cl<double> m(m_eig);
@@ -47,15 +43,13 @@ TEST(MathMetaPrim, ref_type_kg_light_expression) {
   EXPECT_MATRIX_EQ(from_matrix_cl(a_ref3), from_matrix_cl(a_eval));
 
   EXPECT_FALSE((stan::is_matrix_cl<ref_type_t<decltype(a)>>::value));
-  EXPECT_FALSE(
-      (stan::is_matrix_cl<ref_type_t<decltype(a)&>>::value));
-  EXPECT_FALSE(
-      (stan::is_matrix_cl<ref_type_t<decltype(a)&&>>::value));
+  EXPECT_FALSE((stan::is_matrix_cl<ref_type_t<decltype(a)&>>::value));
+  EXPECT_FALSE((stan::is_matrix_cl<ref_type_t<decltype(a)&&>>::value));
 }
 
 TEST(MathMetaPrim, ref_type_kg_heavy_expression) {
-  using stan::math::matrix_cl;
   using stan::ref_type_t;
+  using stan::math::matrix_cl;
   Eigen::MatrixXd m_eig(3, 3);
   m_eig << 1, 2, 3, 4, 5, 6, 7, 8, 9;
   matrix_cl<double> m(m_eig);

--- a/test/unit/math/opencl/ref_type_test.cpp
+++ b/test/unit/math/opencl/ref_type_test.cpp
@@ -1,158 +1,80 @@
 #ifdef STAN_OPENCL
 #include <stan/math/opencl/prim.hpp>
 #include <stan/math/prim.hpp>
-
 #include <test/unit/util.hpp>
 #include <gtest/gtest.h>
-#include <stan/math/opencl/pinned_matrix.hpp>
 
-TEST(MathMetaPrim, ref_type_for_opencl_for_opencl_non_eigen) {
-  using stan::math::ref_type_for_opencl_t;
-  std::vector<int> a{1, 2, 3};
-  ref_type_for_opencl_t<std::vector<int>> a_ref1 = a;
-  ref_type_for_opencl_t<std::vector<int>&> a_ref2 = a;
-  ref_type_for_opencl_t<std::vector<int>&&> a_ref3 = std::vector<int>{1, 2, 3};
+TEST(MathMetaPrim, ref_type_matrix_cl) {
+  using stan::math::matrix_cl;
+  using stan::ref_type_t;
+  Eigen::MatrixXd a_eig(3, 3);
+  a_eig << 1, 2, 3, 4, 5, 6, 7, 8, 9;
+  matrix_cl<double> a(a_eig);
+  matrix_cl<double> a2 = a;
+  ref_type_t<matrix_cl<double>> a_ref1 = a;
+  ref_type_t<matrix_cl<double>&> a_ref2 = a;
+  ref_type_t<matrix_cl<double>&&> a_ref3 = std::move(a2);
 
-  double b = 3;
-  ref_type_for_opencl_t<double> b_ref1 = b;
-  ref_type_for_opencl_t<double&> b_ref2 = b;
-  ref_type_for_opencl_t<double&&> b_ref3 = 3;
+  EXPECT_MATRIX_EQ(from_matrix_cl(a_ref1), from_matrix_cl(a));
+  EXPECT_MATRIX_EQ(from_matrix_cl(a_ref2), from_matrix_cl(a));
+  EXPECT_MATRIX_EQ(from_matrix_cl(a_ref3), from_matrix_cl(a));
 
-  const std::vector<double> c{0.5, 4, 0.7};
-  ref_type_for_opencl_t<const std::vector<double>> c_ref1 = c;
-  ref_type_for_opencl_t<const std::vector<double>&> c_ref2 = c;
-
-  EXPECT_STD_VECTOR_FLOAT_EQ(a_ref1, a);
-  EXPECT_STD_VECTOR_FLOAT_EQ(a_ref2, a);
-  EXPECT_STD_VECTOR_FLOAT_EQ(a_ref3, a);
-  EXPECT_EQ(b_ref1, b);
-  EXPECT_EQ(b_ref2, b);
-  EXPECT_EQ(b_ref3, b);
-  EXPECT_STD_VECTOR_FLOAT_EQ(c_ref1, c);
-  EXPECT_STD_VECTOR_FLOAT_EQ(c_ref2, c);
-  EXPECT_TRUE(std::is_lvalue_reference<ref_type_for_opencl_t<double>>::value);
-  EXPECT_TRUE(std::is_lvalue_reference<ref_type_for_opencl_t<double&>>::value);
-  EXPECT_FALSE(std::is_reference<ref_type_for_opencl_t<double&&>>::value);
+  EXPECT_TRUE(
+      (std::is_same<decltype(a), ref_type_t<decltype(a)&&>>::value));
   EXPECT_TRUE(std::is_lvalue_reference<
-              ref_type_for_opencl_t<const std::vector<double>>>::value);
+              ref_type_t<matrix_cl<double>>>::value);
   EXPECT_TRUE(std::is_lvalue_reference<
-              ref_type_for_opencl_t<const std::vector<double>&>>::value);
-  EXPECT_FALSE(std::is_reference<
-               ref_type_for_opencl_t<const std::vector<double>&&>>::value);
-}
-
-TEST(MathMetaPrim, ref_type_for_opencl_eigen_contiguous) {
-  using stan::math::ref_type_for_opencl_t;
-  Eigen::MatrixXd a(3, 3);
-  a << 1, 2, 3, 4, 5, 6, 7, 8, 9;
-  Eigen::MatrixXd a2 = a;
-  ref_type_for_opencl_t<Eigen::MatrixXd> a_ref1 = a;
-  ref_type_for_opencl_t<Eigen::MatrixXd&> a_ref2 = a;
-  ref_type_for_opencl_t<Eigen::MatrixXd&&> a_ref3 = std::move(a2);
-
-  auto b = a.leftCols(2);
-  ref_type_for_opencl_t<decltype(b)> b_ref1 = b;
-  ref_type_for_opencl_t<decltype(b)&> b_ref2 = b;
-  ref_type_for_opencl_t<decltype(b)&&> b_ref3 = a.leftCols(2);
-
-  using ContiguousMap = Eigen::Map<Eigen::MatrixXd, 0, Eigen::Stride<0, 0>>;
-  ContiguousMap c(a.data(), 3, 3);
-  ContiguousMap c2(a.data(), 3, 3);
-  ref_type_for_opencl_t<ContiguousMap> c_ref1 = c;
-  ref_type_for_opencl_t<ContiguousMap&> c_ref2 = c;
-  ref_type_for_opencl_t<ContiguousMap&&> c_ref3 = std::move(c2);
-
-  EXPECT_MATRIX_EQ(a_ref1, a);
-  EXPECT_MATRIX_EQ(a_ref2, a);
-  EXPECT_MATRIX_EQ(a_ref3, a);
-
-  EXPECT_MATRIX_EQ(b_ref1, b);
-  EXPECT_MATRIX_EQ(b_ref2, b);
-  EXPECT_MATRIX_EQ(b_ref3, b);
-
-  EXPECT_MATRIX_EQ(c_ref1, c);
-  EXPECT_MATRIX_EQ(c_ref2, c);
-  EXPECT_MATRIX_EQ(c_ref3, c);
-  EXPECT_TRUE(
-      (std::is_same<decltype(a), ref_type_for_opencl_t<decltype(a)&&>>::value));
-  EXPECT_TRUE(
-      (std::is_same<decltype(b), ref_type_for_opencl_t<decltype(b)&&>>::value));
-  EXPECT_TRUE(
-      (std::is_same<decltype(c), ref_type_for_opencl_t<decltype(c)&&>>::value));
-  EXPECT_TRUE(
-      std::is_lvalue_reference<ref_type_for_opencl_t<Eigen::MatrixXd>>::value);
-  EXPECT_TRUE(
-      std::is_lvalue_reference<ref_type_for_opencl_t<Eigen::MatrixXd&>>::value);
+              ref_type_t<matrix_cl<double>&>>::value);
   EXPECT_FALSE(
-      std::is_reference<ref_type_for_opencl_t<Eigen::MatrixXd&&>>::value);
+      std::is_reference<ref_type_t<matrix_cl<double>&&>>::value);
 }
 
-TEST(MathMetaPrim, ref_type_for_opencl_eigen_non_contiguous) {
-  using stan::math::ref_type_for_opencl_t;
-  Eigen::MatrixXd m(3, 3);
-  m << 1, 2, 3, 4, 5, 6, 7, 8, 9;
-  using RowMajorMatrixXd
-      = Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>;
-  RowMajorMatrixXd a = m;
-  RowMajorMatrixXd a2 = m;
-  ref_type_for_opencl_t<RowMajorMatrixXd> a_ref1 = a;
-  ref_type_for_opencl_t<RowMajorMatrixXd&> a_ref2 = a;
-  ref_type_for_opencl_t<RowMajorMatrixXd&&> a_ref3 = std::move(a2);
+TEST(MathMetaPrim, ref_type_kg_light_expression) {
+  using stan::math::matrix_cl;
+  using stan::ref_type_t;
+  Eigen::MatrixXd m_eig(3, 3);
+  m_eig << 1, 2, 3, 4, 5, 6, 7, 8, 9;
+  matrix_cl<double> m(m_eig);
+  auto a = stan::math::block_zero_based(m, 0, 1, 2, 2);
+  ref_type_t<decltype(a)> a_ref1 = a;
+  ref_type_t<decltype(a)&> a_ref2 = a;
+  ref_type_t<decltype(a)&&> a_ref3
+      = stan::math::block_zero_based(m, 0, 1, 2, 2);
 
-  auto b = m.block(1, 0, 2, 2);
-  ref_type_for_opencl_t<decltype(b)> b_ref1 = b;
-  ref_type_for_opencl_t<decltype(b)&> b_ref2 = b;
-  ref_type_for_opencl_t<decltype(b)&&> b_ref3 = a.block(1, 0, 2, 2);
+  matrix_cl<double> a_eval = a;
+  EXPECT_MATRIX_EQ(from_matrix_cl(a_ref1), from_matrix_cl(a_eval));
+  EXPECT_MATRIX_EQ(from_matrix_cl(a_ref2), from_matrix_cl(a_eval));
+  EXPECT_MATRIX_EQ(from_matrix_cl(a_ref3), from_matrix_cl(a_eval));
 
-  Eigen::Ref<Eigen::MatrixXd> c = m;
-  Eigen::Ref<Eigen::MatrixXd> c2 = m;
-  ref_type_for_opencl_t<Eigen::Ref<Eigen::MatrixXd>> c_ref1 = c;
-  ref_type_for_opencl_t<Eigen::Ref<Eigen::MatrixXd>&> c_ref2 = c;
-  ref_type_for_opencl_t<Eigen::Ref<Eigen::MatrixXd>&&> c_ref3 = std::move(c2);
-
-  EXPECT_MATRIX_EQ(a_ref1, a);
-  EXPECT_MATRIX_EQ(a_ref2, a);
-  EXPECT_MATRIX_EQ(a_ref3, a);
-
-  EXPECT_MATRIX_EQ(b_ref1, b);
-  EXPECT_MATRIX_EQ(b_ref2, b);
-  EXPECT_MATRIX_EQ(b_ref3, b);
-
-  EXPECT_MATRIX_EQ(c_ref1, c);
-  EXPECT_MATRIX_EQ(c_ref2, c);
-  EXPECT_MATRIX_EQ(c_ref3, c);
-  EXPECT_TRUE((std::is_same<stan::math::pinned_matrix<Eigen::MatrixXd>,
-                            ref_type_for_opencl_t<decltype(a)&&>>::value));
-  EXPECT_TRUE((std::is_same<stan::math::pinned_matrix<Eigen::MatrixXd>,
-                            ref_type_for_opencl_t<decltype(b)&&>>::value));
-  EXPECT_TRUE((std::is_same<stan::math::pinned_matrix<Eigen::MatrixXd>,
-                            ref_type_for_opencl_t<decltype(c)&&>>::value));
+  EXPECT_FALSE((stan::is_matrix_cl<ref_type_t<decltype(a)>>::value));
+  EXPECT_FALSE(
+      (stan::is_matrix_cl<ref_type_t<decltype(a)&>>::value));
+  EXPECT_FALSE(
+      (stan::is_matrix_cl<ref_type_t<decltype(a)&&>>::value));
 }
 
-TEST(MathMetaPrim, ref_type_for_opencl_eigen_expression) {
-  using stan::plain_type_t;
-  using stan::math::ref_type_for_opencl_t;
-  Eigen::MatrixXd m(3, 3);
-  m << 1, 2, 3, 4, 5, 6, 7, 8, 9;
+TEST(MathMetaPrim, ref_type_kg_heavy_expression) {
+  using stan::math::matrix_cl;
+  using stan::ref_type_t;
+  Eigen::MatrixXd m_eig(3, 3);
+  m_eig << 1, 2, 3, 4, 5, 6, 7, 8, 9;
+  matrix_cl<double> m(m_eig);
   auto a = m * 3;
-  ref_type_for_opencl_t<decltype(a)> a_ref1 = a;
-  ref_type_for_opencl_t<decltype(a)&> a_ref2 = a;
-  ref_type_for_opencl_t<decltype(a)&&> a_ref3 = m * 3;
+  ref_type_t<decltype(a)> a_ref1 = a;
+  ref_type_t<decltype(a)&> a_ref2 = a;
+  ref_type_t<decltype(a)&&> a_ref3 = m * 3;
 
-  Eigen::MatrixXd a_eval = a;
-  EXPECT_MATRIX_EQ(a_ref1, a_eval);
-  EXPECT_MATRIX_EQ(a_ref2, a_eval);
-  EXPECT_MATRIX_EQ(a_ref3, a_eval);
+  matrix_cl<double> a_eval = a;
+  EXPECT_MATRIX_EQ(from_matrix_cl(a_ref1), from_matrix_cl(a_eval));
+  EXPECT_MATRIX_EQ(from_matrix_cl(a_ref2), from_matrix_cl(a_eval));
+  EXPECT_MATRIX_EQ(from_matrix_cl(a_ref3), from_matrix_cl(a_eval));
 
-  EXPECT_TRUE(
-      (std::is_same<stan::math::pinned_matrix<plain_type_t<decltype(a)>>,
-                    ref_type_for_opencl_t<decltype(a)>>::value));
-  EXPECT_TRUE(
-      (std::is_same<stan::math::pinned_matrix<plain_type_t<decltype(a)>>,
-                    ref_type_for_opencl_t<decltype(a)&>>::value));
-  EXPECT_TRUE(
-      (std::is_same<stan::math::pinned_matrix<plain_type_t<decltype(a)>>,
-                    ref_type_for_opencl_t<decltype(a)&&>>::value));
+  EXPECT_TRUE((std::is_same<stan::math::matrix_cl<double>,
+                            ref_type_t<decltype(a)>>::value));
+  EXPECT_TRUE((std::is_same<stan::math::matrix_cl<double>,
+                            ref_type_t<decltype(a)&>>::value));
+  EXPECT_TRUE((std::is_same<stan::math::matrix_cl<double>,
+                            ref_type_t<decltype(a)&&>>::value));
 }
 
 #endif


### PR DESCRIPTION
## Summary

Added reference (`ref_type`) for kernel generator expressions. 

`ref_type_for_opencl_test.cpp` is not a new file; it has been renamed from `ref_type_test.cpp`.

## Tests
Added tests for OpenCL `ref_type`.

## Side Effects
None.

## Release notes
Added reference (`ref_type`) for kernel generator expressions. 

## Checklist

- [ ] Math issue #(issue number)

- [ ] Copyright holder: Tadej Ciglarič

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [ ] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [ ] the code is written in idiomatic C++ and changes are documented in the doxygen

- [ ] the new changes are tested
