### PR TITLE
Do fewer distribution tests by default

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -303,6 +303,7 @@ pipeline {
                         script {
                             if (params.withRowVector || isBranch('develop') || isBranch('master')) {
                                 sh "echo CXXFLAGS+=-DSTAN_TEST_ROW_VECTORS >> make/local"
+                                sh "echo CXXFLAGS+=-DSTAN_PROB_TEST_ALL >> make/local"
                             }
                         }
                         sh "./runTests.py -j${env.PARALLEL} test/prob > dist.log 2>&1"

--- a/test/prob/generate_tests.cpp
+++ b/test/prob/generate_tests.cpp
@@ -444,12 +444,15 @@ int create_files(const int& argc, const char* argv[], const int& index,
  */
 int main(int argc, const char* argv[]) {
   int N_TESTS = atoi(argv[2]);
+
   create_files(argc, argv, 1, -1, N_TESTS);  // create var tests
+  create_files(argc, argv, 5, -1, N_TESTS);  // create ffv tests
+  create_files(argc, argv, 6, -1, N_TESTS);  // create varmat tests
+#ifdef STAN_PROB_TEST_ALL
   create_files(argc, argv, 2, -1, N_TESTS);  // create fd tests
   create_files(argc, argv, 3, -1, N_TESTS);  // create fv tests
   create_files(argc, argv, 4, -1, N_TESTS);  // create ffd tests
-  create_files(argc, argv, 5, -1, N_TESTS);  // create ffv tests
-  create_files(argc, argv, 6, -1, N_TESTS);  // create varmat tests
+#endif
 
   return 0;
 }


### PR DESCRIPTION
## Summary

By default lower the number of distribution tests done for open pull requests.

Specifically, only test `var`, `varmat`, and `fvar<fvar<var>>` autodiff types by default. The full tests also include `fvar<double>`, `fvar<var>`, and `fvar<fvar<double>>`.

The full distribution tests are still run after merge.

## Release notes

- Lower number of distribution tests run by default (still running them all after merge)

## Checklist

- [ ] Math issue #(issue number)

- [x] Copyright holder: Columbia University

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
