### PR TITLE
Reimplement holder without dynamic allocations

### DIFF
--- a/stan/math/prim/fun/scalar_seq_view.hpp
+++ b/stan/math/prim/fun/scalar_seq_view.hpp
@@ -29,7 +29,7 @@ class scalar_seq_view<C, require_eigen_vector_t<C>> {
    * @param i index
    * @return the element at the specified position in the container
    */
-  inline auto operator[](size_t i) const { return c_.coeffRef(i); }
+  inline auto operator[](size_t i) const { return c_.coeff(i); }
 
   inline auto size() const noexcept { return c_.size(); }
 

--- a/stan/math/prim/meta/holder.hpp
+++ b/stan/math/prim/meta/holder.hpp
@@ -251,10 +251,11 @@ namespace math {
  * @param args Args for the functor
  * @return `holder` referencing expression constructed by given functor
  */
-template <typename F, typename... Args,
-          require_t<disjunction<conjunction<std::is_lvalue_reference<Args&&>...>,
-                                is_plain_type<decltype(std::declval<F>()(
-                                    std::declval<Args&>()...))>>>* = nullptr>
+template <
+    typename F, typename... Args,
+    require_t<disjunction<conjunction<std::is_lvalue_reference<Args&&>...>,
+                          is_plain_type<decltype(std::declval<F>()(
+                              std::declval<Args&>()...))>>>* = nullptr>
 auto make_holder(const F& func, Args&&... args) {
   return func(std::forward<Args>(args)...);
 }

--- a/stan/math/prim/meta/holder.hpp
+++ b/stan/math/prim/meta/holder.hpp
@@ -127,7 +127,7 @@ class Holder
   typedef
       typename Eigen::internal::ref_selector<Holder<BaseExpr, Args...>>::type
           Nested;
-  typename Eigen::internal::ref_selector<BaseExpr>::non_const_type m_arg;
+  BaseExpr m_arg;
 
   template <typename Functor, require_same_t<decltype(std::declval<Functor>()(
                                                  std::declval<Args&>()...)),

--- a/test/unit/math/opencl/kernel_generator/holder_cl_test.cpp
+++ b/test/unit/math/opencl/kernel_generator/holder_cl_test.cpp
@@ -14,7 +14,7 @@ using stan::math::matrix_cl;
 template <typename T>
 auto f2(T&& a) {
   return stan::math::make_holder_cl([](const auto& a) { return a + a; },
-                                 std::forward<T>(a));
+                                    std::forward<T>(a));
 }
 
 TEST(KernelGenerator, make_holder_cl_lvalue_test) {

--- a/test/unit/math/opencl/kernel_generator/holder_cl_test.cpp
+++ b/test/unit/math/opencl/kernel_generator/holder_cl_test.cpp
@@ -12,41 +12,9 @@ using Eigen::MatrixXi;
 using stan::math::matrix_cl;
 
 template <typename T>
-auto f(T&& a) {
-  auto* a_heap = new std::remove_reference_t<T>(std::forward<T>(a));
-  return stan::math::holder_cl(*a_heap + *a_heap, a_heap);
-}
-
-TEST(KernelGenerator, holder_cl_lvalue_test) {
-  MatrixXd m(3, 3);
-  m << 1, 2, 3, 4, 5, 6, 7, 8, 9;
-
-  matrix_cl<double> m_cl(m);
-  matrix_cl<double> res_cl = f(m_cl);
-
-  MatrixXd res = stan::math::from_matrix_cl(res_cl);
-
-  MatrixXd correct = m + m;
-  EXPECT_MATRIX_NEAR(res, correct, 1e-9);
-}
-
-TEST(KernelGenerator, holder_cl_rvalue_test) {
-  MatrixXd m(3, 3);
-  m << 1, 2, 3, 4, 5, 6, 7, 8, 9;
-
-  matrix_cl<double> m_cl(m);
-  matrix_cl<double> res_cl = f(std::move(m_cl));
-
-  MatrixXd res = stan::math::from_matrix_cl(res_cl);
-
-  MatrixXd correct = m + m;
-  EXPECT_MATRIX_NEAR(res, correct, 1e-9);
-}
-
-template <typename T>
 auto f2(T&& a) {
   return stan::math::make_holder_cl([](const auto& a) { return a + a; },
-                                    std::forward<T>(a));
+                                 std::forward<T>(a));
 }
 
 TEST(KernelGenerator, make_holder_cl_lvalue_test) {

--- a/test/unit/math/prim/meta/holder_test.cpp
+++ b/test/unit/math/prim/meta/holder_test.cpp
@@ -3,17 +3,6 @@
 #include <gtest/gtest.h>
 
 namespace holder_test {
-template <typename T>
-auto f(T&& a) {
-  auto* a_heap = new std::remove_reference_t<T>(std::forward<T>(a));
-  return stan::math::holder(*a_heap + *a_heap, a_heap);
-}
-
-template <typename T>
-auto f2(T&& a) {
-  auto* a_heap = new std::remove_reference_t<T>(std::forward<T>(a));
-  return stan::math::holder(a_heap->array(), a_heap);
-}
 
 template <typename T>
 auto f3(T&& a) {
@@ -27,36 +16,6 @@ auto f4(T&& a) {
                                  std::forward<T>(a));
 }
 }  // namespace holder_test
-
-TEST(MathFunctions, holder_lvalue) {
-  using Eigen::MatrixXd;
-  MatrixXd m(3, 3);
-  m << 1, 2, 3, 4, 5, 6, 7, 8, 9;
-  MatrixXd res = holder_test::f(m);
-  MatrixXd correct = m + m;
-  EXPECT_MATRIX_EQ(res, correct);
-}
-
-TEST(MathFunctions, holder_rvalue) {
-  using Eigen::MatrixXd;
-  MatrixXd m(3, 3);
-  m << 1, 2, 3, 4, 5, 6, 7, 8, 9;
-  MatrixXd m2 = m;
-  MatrixXd res = holder_test::f(std::move(m2));
-  MatrixXd correct = m + m;
-  EXPECT_MATRIX_EQ(res, correct);
-}
-
-TEST(MathFunctions, holder_lvalue_assign) {
-  using Eigen::MatrixXd;
-  MatrixXd m = MatrixXd::Identity(3, 3);
-  MatrixXd m2(3, 3);
-  m2 << 1, 2, 3, 4, 5, 6, 7, 8, 9;
-  auto array_holder = holder_test::f2(m);
-  array_holder = m2;
-  MatrixXd res = array_holder;
-  EXPECT_MATRIX_EQ(res, m2);
-}
 
 TEST(MathFunctions, make_holder_lvalue) {
   using Eigen::MatrixXd;
@@ -112,15 +71,6 @@ TEST(MathFunctions, make_holder_assign_holder) {
   MatrixXd res = array_holder;
   EXPECT_MATRIX_EQ(res, m2);
   EXPECT_MATRIX_EQ(m, m2);
-}
-
-TEST(MathFunctions, block_of_holder) {
-  using Eigen::MatrixXd;
-  MatrixXd m(3, 3);
-  m << 1, 2, 3, 4, 5, 6, 7, 8, 9;
-  MatrixXd res = holder_test::f(m).block(1, 0, 2, 2);
-  MatrixXd correct = (m + m).block(1, 0, 2, 2);
-  EXPECT_MATRIX_EQ(res, correct);
 }
 
 TEST(MathFunctions, block_of_make_holder_assign) {


### PR DESCRIPTION
## Summary

Reimplements `Holder`, so that it does not need dynamic memory allocations. New implementation also happens to be simpler and work for kernel generator expressions. The (unused) option for constructing holder from expression and pointers to arguments on heap now does not make any sense, so it is removed.

This is the second attempt at this. The first one (not working) is here: #2415

## Tests

Removed tests for the removed option of how holder is constructed.

## Side Effects
Not really.

## Release notes

Reimplemented `Holder`, so that it does not need dynamic memory allocations.

## Checklist

- [ ] Math issue #(issue number)

- [ ] Copyright holder: Tadej Ciglarič

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [ ] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [ ] the code is written in idiomatic C++ and changes are documented in the doxygen

- [ ] the new changes are tested
