### PR TITLE
Extract forward declaration of stan::math::var_value into its own header

### DIFF
--- a/stan/math/rev/core/var_value_fwd_declare.hpp
+++ b/stan/math/rev/core/var_value_fwd_declare.hpp
@@ -1,0 +1,11 @@
+#ifndef STAN_MATH_REV_CORE_VAR_VALUE_FWD_DECLARE_HPP
+#define STAN_MATH_REV_CORE_VAR_VALUE_FWD_DECLARE_HPP
+
+namespace stan {
+namespace math {
+// forward declaration of var
+template <typename T, typename = void>
+class var_value;
+}
+}
+#endif

--- a/stan/math/rev/core/var_value_fwd_declare.hpp
+++ b/stan/math/rev/core/var_value_fwd_declare.hpp
@@ -6,6 +6,6 @@ namespace math {
 // forward declaration of var
 template <typename T, typename = void>
 class var_value;
-}
-}
+}  // namespace math
+}  // namespace stan
 #endif

--- a/stan/math/rev/core/vari.hpp
+++ b/stan/math/rev/core/vari.hpp
@@ -1,6 +1,7 @@
 #ifndef STAN_MATH_REV_CORE_VARI_HPP
 #define STAN_MATH_REV_CORE_VARI_HPP
 
+#include <stan/math/rev/core/var_value_fwd_declare.hpp>
 #include <stan/math/rev/core/chainable_alloc.hpp>
 #include <stan/math/rev/core/chainablestack.hpp>
 #include <stan/math/rev/core/arena_matrix.hpp>
@@ -14,10 +15,6 @@ namespace math {
 // forward decleration of vari_value
 template <typename T, typename = void>
 class vari_value;
-
-// forward declaration of var
-template <typename T, typename = void>
-class var_value;
 
 /**
  * Abstract base class that all `vari_value` and it's derived classes inherit.


### PR DESCRIPTION
See #2430 for context.

This pull request would enable external code to also take advantage of forward declarations of the templated `var_value` by extracting the relevant forward declaration lines from `vari.hpp` into their own header, `var_values_fwd_declare.hpp`.  It then `#include`s this new header in `vari.hpp`.

It may make sense to do something similar with other forward declarations (I saw another for `vari_value` in that same file, and a few others when grepping around in other places).  But I don't know how externally-facing those other instances are meant to be, whereas `var` (==`var_value<double>`) is definitely user-facing.

I don't expect this to have any side effects.