### PR TITLE
Add OpenCL prod

### DIFF
--- a/stan/math/opencl/kernel_generator/colwise_reduction.hpp
+++ b/stan/math/opencl/kernel_generator/colwise_reduction.hpp
@@ -217,7 +217,7 @@ class colwise_sum_ : public colwise_reduction<colwise_sum_<T>, T, sum_op> {
  * reductions can not be used as arguments to other operations - they can only
  * be evaluated.
  * @tparam T type of input expression
- * @param an expression to reduce
+ * @param a the expression to reduce
  * @return sum
  */
 template <typename T, require_all_kernel_expressions_t<T>* = nullptr>
@@ -261,7 +261,7 @@ class colwise_prod_ : public colwise_reduction<colwise_prod_<T>, T, prod_op> {
  * reductions can not be used as arguments to other operations - they can only
  * be evaluated.
  * @tparam T type of input expression
- * @param an expression to reduce
+ * @param a the expression to reduce
  * @return prod
  */
 template <typename T, require_all_kernel_expressions_t<T>* = nullptr>
@@ -310,7 +310,7 @@ class colwise_max_ : public colwise_reduction<
  * reductions can not be used as arguments to other operations - they can only
  * be evaluated.
  * @tparam T type of input expression
- * @param a an expression to reduce
+ * @param a the expression to reduce
  * @return max
  */
 template <typename T, require_all_kernel_expressions_t<T>* = nullptr>
@@ -359,7 +359,7 @@ class colwise_min_ : public colwise_reduction<
  * reductions can not be used as arguments to other operations - they can only
  * be evaluated.
  * @tparam T type of input expression
- * @param a an expression to reduce
+ * @param a the expression to reduce
  * @return min
  */
 template <typename T, require_all_kernel_expressions_t<T>* = nullptr>

--- a/stan/math/opencl/kernel_generator/colwise_reduction.hpp
+++ b/stan/math/opencl/kernel_generator/colwise_reduction.hpp
@@ -211,10 +211,11 @@ class colwise_sum_ : public colwise_reduction<colwise_sum_<T>, T, sum_op> {
  * Column wise sum - reduction of a kernel generator expression. So as to
  * be efficient column wise reductions are only done partially. That means
  * instead of 1 row kernel output will have a few rows that need to be reduced
- * to obtain the final result (actually it is 1 result per work group run - roughly
- * 16 times the number of compute units on the OpenCL device). This can be done
- * in a separate kernel or after copying to CPU. Also column wise reductions can
- * not be used as arguments to other operations - they can only be evaluated.
+ * to obtain the final result (actually it is 1 result per work group run -
+ * roughly 16 times the number of compute units on the OpenCL device). This can
+ * be done in a separate kernel or after copying to CPU. Also column wise
+ * reductions can not be used as arguments to other operations - they can only
+ * be evaluated.
  * @tparam T type of input expression
  * @param an expression to reduce
  * @return sum
@@ -254,10 +255,11 @@ class colwise_prod_ : public colwise_reduction<colwise_prod_<T>, T, prod_op> {
  * Column wise product - reduction of a kernel generator expression. So as to
  * be efficient column wise reductions are only done partially. That means
  * instead of 1 row kernel output will have a few rows that need to be reduced
- * to obtain the final result (actually it is 1 result per work group run - roughly
- * 16 times the number of compute units on the OpenCL device). This can be done
- * in a separate kernel or after copying to CPU. Also column wise reductions can
- * not be used as arguments to other operations - they can only be evaluated.
+ * to obtain the final result (actually it is 1 result per work group run -
+ * roughly 16 times the number of compute units on the OpenCL device). This can
+ * be done in a separate kernel or after copying to CPU. Also column wise
+ * reductions can not be used as arguments to other operations - they can only
+ * be evaluated.
  * @tparam T type of input expression
  * @param an expression to reduce
  * @return prod
@@ -302,10 +304,11 @@ class colwise_max_ : public colwise_reduction<
  * Column wise max - reduction of a kernel generator expression. So as to
  * be efficient column wise reductions are only done partially. That means
  * instead of 1 row kernel output will have a few rows that need to be reduced
- * to obtain the final result (actually it is 1 result per work group run - roughly
- * 16 times the number of compute units on the OpenCL device). This can be done
- * in a separate kernel or after copying to CPU. Also column wise reductions can
- * not be used as arguments to other operations - they can only be evaluated.
+ * to obtain the final result (actually it is 1 result per work group run -
+ * roughly 16 times the number of compute units on the OpenCL device). This can
+ * be done in a separate kernel or after copying to CPU. Also column wise
+ * reductions can not be used as arguments to other operations - they can only
+ * be evaluated.
  * @tparam T type of input expression
  * @param an expression to reduce
  * @return max
@@ -350,10 +353,11 @@ class colwise_min_ : public colwise_reduction<
  * Column wise min - reduction of a kernel generator expression.  So as to
  * be efficient column wise reductions are only done partially. That means
  * instead of 1 row kernel output will have a few rows that need to be reduced
- * to obtain the final result (actually it is 1 result per work group run - roughly
- * 16 times the number of compute units on the OpenCL device). This can be done
- * in a separate kernel or after copying to CPU. Also column wise reductions can
- * not be used as arguments to other operations - they can only be evaluated.
+ * to obtain the final result (actually it is 1 result per work group run -
+ * roughly 16 times the number of compute units on the OpenCL device). This can
+ * be done in a separate kernel or after copying to CPU. Also column wise
+ * reductions can not be used as arguments to other operations - they can only
+ * be evaluated.
  * @tparam T type of input expression
  * @param an expression to reduce
  * @return min

--- a/stan/math/opencl/kernel_generator/colwise_reduction.hpp
+++ b/stan/math/opencl/kernel_generator/colwise_reduction.hpp
@@ -310,7 +310,7 @@ class colwise_max_ : public colwise_reduction<
  * reductions can not be used as arguments to other operations - they can only
  * be evaluated.
  * @tparam T type of input expression
- * @param a expression to reduce
+ * @param a an expression to reduce
  * @return max
  */
 template <typename T, require_all_kernel_expressions_t<T>* = nullptr>
@@ -359,7 +359,7 @@ class colwise_min_ : public colwise_reduction<
  * reductions can not be used as arguments to other operations - they can only
  * be evaluated.
  * @tparam T type of input expression
- * @param an expression to reduce
+ * @param a an expression to reduce
  * @return min
  */
 template <typename T, require_all_kernel_expressions_t<T>* = nullptr>

--- a/stan/math/opencl/kernel_generator/colwise_reduction.hpp
+++ b/stan/math/opencl/kernel_generator/colwise_reduction.hpp
@@ -48,7 +48,7 @@ inline int colwise_reduction_wgs_rows(int n_rows, int n_cols) {
  * be efficient column wise reductions are only done partially. That means
  * instead of 1 row kernel output will have a few rows that need to be reduced
  * to obtain final result (actually it is 1
- * reslut per work group run - roughly 16 times the number of compute units on
+ * result per work group run - roughly 16 times the number of compute units on
  * the OpenCL device). This can be done in a separate kernel or after
  * copying to CPU. Also column wise reductions can not be used as arguments to
  * other operations - they can only be evaluated.
@@ -211,12 +211,12 @@ class colwise_sum_ : public colwise_reduction<colwise_sum_<T>, T, sum_op> {
  * Column wise sum - reduction of a kernel generator expression. So as to
  * be efficient column wise reductions are only done partially. That means
  * instead of 1 row kernel output will have a few rows that need to be reduced
- * to obtain final result (actually it is 1 reslut per work group run - roughly
+ * to obtain the final result (actually it is 1 result per work group run - roughly
  * 16 times the number of compute units on the OpenCL device). This can be done
  * in a separate kernel or after copying to CPU. Also column wise reductions can
  * not be used as arguments to other operations - they can only be evaluated.
  * @tparam T type of input expression
- * @param a expression to reduce
+ * @param an expression to reduce
  * @return sum
  */
 template <typename T, require_all_kernel_expressions_t<T>* = nullptr>
@@ -254,12 +254,12 @@ class colwise_prod_ : public colwise_reduction<colwise_prod_<T>, T, prod_op> {
  * Column wise product - reduction of a kernel generator expression. So as to
  * be efficient column wise reductions are only done partially. That means
  * instead of 1 row kernel output will have a few rows that need to be reduced
- * to obtain final result (actually it is 1 reslut per work group run - roughly
+ * to obtain the final result (actually it is 1 result per work group run - roughly
  * 16 times the number of compute units on the OpenCL device). This can be done
  * in a separate kernel or after copying to CPU. Also column wise reductions can
  * not be used as arguments to other operations - they can only be evaluated.
  * @tparam T type of input expression
- * @param a expression to reduce
+ * @param an expression to reduce
  * @return prod
  */
 template <typename T, require_all_kernel_expressions_t<T>* = nullptr>
@@ -302,12 +302,12 @@ class colwise_max_ : public colwise_reduction<
  * Column wise max - reduction of a kernel generator expression. So as to
  * be efficient column wise reductions are only done partially. That means
  * instead of 1 row kernel output will have a few rows that need to be reduced
- * to obtain final result (actually it is 1 reslut per work group run - roughly
+ * to obtain the final result (actually it is 1 result per work group run - roughly
  * 16 times the number of compute units on the OpenCL device). This can be done
  * in a separate kernel or after copying to CPU. Also column wise reductions can
  * not be used as arguments to other operations - they can only be evaluated.
  * @tparam T type of input expression
- * @param a expression to reduce
+ * @param an expression to reduce
  * @return max
  */
 template <typename T, require_all_kernel_expressions_t<T>* = nullptr>
@@ -350,12 +350,12 @@ class colwise_min_ : public colwise_reduction<
  * Column wise min - reduction of a kernel generator expression.  So as to
  * be efficient column wise reductions are only done partially. That means
  * instead of 1 row kernel output will have a few rows that need to be reduced
- * to obtain final result (actually it is 1 reslut per work group run - roughly
+ * to obtain the final result (actually it is 1 result per work group run - roughly
  * 16 times the number of compute units on the OpenCL device). This can be done
  * in a separate kernel or after copying to CPU. Also column wise reductions can
  * not be used as arguments to other operations - they can only be evaluated.
  * @tparam T type of input expression
- * @param a expression to reduce
+ * @param an expression to reduce
  * @return min
  */
 template <typename T, require_all_kernel_expressions_t<T>* = nullptr>

--- a/stan/math/opencl/kernel_generator/colwise_reduction.hpp
+++ b/stan/math/opencl/kernel_generator/colwise_reduction.hpp
@@ -227,6 +227,49 @@ inline auto colwise_sum(T&& a) {
 }
 
 /**
+ * Represents column wise product - reduction in kernel generator expressions.
+ * @tparam T type of expression
+ */
+template <typename T>
+class colwise_prod_ : public colwise_reduction<colwise_prod_<T>, T, prod_op> {
+  using base = colwise_reduction<colwise_prod_<T>, T, prod_op>;
+  using base::arguments_;
+
+ public:
+  explicit colwise_prod_(T&& a)
+      : colwise_reduction<colwise_prod_<T>, T, prod_op>(std::forward<T>(a), "1") {
+  }
+  /**
+   * Creates a deep copy of this expression.
+   * @return copy of \c *this
+   */
+  inline auto deep_copy() const {
+    auto&& arg_copy = this->template get_arg<0>().deep_copy();
+    return colwise_prod_<std::remove_reference_t<decltype(arg_copy)>>(
+        std::move(arg_copy));
+  }
+};
+
+/**
+ * Column wise product - reduction of a kernel generator expression. So as to
+ * be efficient column wise reductions are only done partially. That means
+ * instead of 1 row kernel output will have a few rows that need to be reduced
+ * to obtain final result (actually it is 1 reslut per work group run - roughly
+ * 16 times the number of compute units on the OpenCL device). This can be done
+ * in a separate kernel or after copying to CPU. Also column wise reductions can
+ * not be used as arguments to other operations - they can only be evaluated.
+ * @tparam T type of input expression
+ * @param a expression to reduce
+ * @return prod
+ */
+template <typename T, require_all_kernel_expressions_t<T>* = nullptr>
+inline auto colwise_prod(T&& a) {
+  auto&& arg_copy = as_operation_cl(std::forward<T>(a)).deep_copy();
+  return colwise_prod_<as_operation_cl_t<T>>(
+      as_operation_cl(std::forward<T>(a)));
+}
+
+/**
  * Represents column wise max - reduction in kernel generator expressions.
  * @tparam T type of expression
  */

--- a/stan/math/opencl/kernel_generator/colwise_reduction.hpp
+++ b/stan/math/opencl/kernel_generator/colwise_reduction.hpp
@@ -310,7 +310,7 @@ class colwise_max_ : public colwise_reduction<
  * reductions can not be used as arguments to other operations - they can only
  * be evaluated.
  * @tparam T type of input expression
- * @param an expression to reduce
+ * @param a expression to reduce
  * @return max
  */
 template <typename T, require_all_kernel_expressions_t<T>* = nullptr>

--- a/stan/math/opencl/kernel_generator/reduction_2d.hpp
+++ b/stan/math/opencl/kernel_generator/reduction_2d.hpp
@@ -32,7 +32,7 @@ class reduction_2d_base {};
  * to be efficient two dimensional reductions are only done partially. That
  * means instead of 1 element kernel output can have a few rows and a few
  * columns that need to be reduced to obtain final result (actually it is 1
- * reslut per work group run - roughly 16 times the number of compute units on
+ * result per work group run - roughly 16 times the number of compute units on
  * the OpenCL device). This can be done in a separate kernel or after copying to
  * CPU. Also two dimensional reductions can not be used as arguments to other
  * operations - they can only be evaluated.
@@ -217,16 +217,16 @@ class sum_2d_ : public reduction_2d<sum_2d_<T>, T, sum_op> {
 };
 
 /**
- * two dimensional sum - reduction of a kernel generator expression. So as to
+ * Two dimensional sum - reduction of a kernel generator expression. So as to
  * be efficient two dimensional reductions are only done partially. That means
  * instead of 1 element kernel output can have a few rows and a few columns
- * that need to be reduced to obtain final result (actually it is 1 reslut per
+ * that need to be reduced to obtain final result (actually it is 1 result per
  * work group run - roughly 16 times the number of compute units on the OpenCL
  * device). This can be done in a separate kernel or after copying to CPU. Also
  * two dimensional reductions can not be used as arguments to other operations -
  * they can only be evaluated.
  * @tparam T type of input expression
- * @param a expression to reduce
+ * @param an expression to reduce
  * @return sum
  */
 template <typename T, require_all_kernel_expressions_t<T>* = nullptr>
@@ -259,16 +259,16 @@ class prod_2d_ : public reduction_2d<prod_2d_<T>, T, prod_op> {
 };
 
 /**
- * two dimensional product - reduction of a kernel generator expression. So as to
+ * Two dimensional product - reduction of a kernel generator expression. So as to
  * be efficient two dimensional reductions are only done partially. That means
  * instead of 1 element kernel output can have a few rows and a few columns
- * that need to be reduced to obtain final result (actually it is 1 reslut per
+ * that need to be reduced to obtain final result (actually it is 1 result per
  * work group run - roughly 16 times the number of compute units on the OpenCL
  * device). This can be done in a separate kernel or after copying to CPU. Also
  * two dimensional reductions can not be used as arguments to other operations -
  * they can only be evaluated.
  * @tparam T type of input expression
- * @param a expression to reduce
+ * @param an expression to reduce
  * @return prod
  */
 template <typename T, require_all_kernel_expressions_t<T>* = nullptr>
@@ -306,16 +306,16 @@ class max_2d_
 };
 
 /**
- * two dimensional max - reduction of a kernel generator expression. So as to
+ * Two dimensional max - reduction of a kernel generator expression. So as to
  * be efficient two dimensional reductions are only done partially. That means
  * instead of 1 element kernel output can have a few rows and a few columns that
- * need to be reduced to obtain final result (actually it is 1 reslut per work
+ * need to be reduced to obtain final result (actually it is 1 result per work
  * group run - roughly 16 times the number of compute units on the OpenCL
  * device). This can be done in a separate kernel or after copying to CPU. Also
  * two dimensional reductions can not be used as arguments to other operations -
  * they can only be evaluated.
  * @tparam T type of input expression
- * @param a expression to reduce
+ * @param an expression to reduce
  * @return max
  */
 template <typename T, require_all_kernel_expressions_t<T>* = nullptr>
@@ -353,16 +353,16 @@ class min_2d_
 };
 
 /**
- * two dimensional min - reduction of a kernel generator expression.  So as to
+ * Two dimensional min - reduction of a kernel generator expression.  So as to
  * be efficient two dimensional reductions are only done partially. That means
  * instead of 1 row kernel output will have a few rows that need to be reduced
- * to obtain final result (actually it is 1 reslut per work group run - roughly
+ * to obtain final result (actually it is 1 result per work group run - roughly
  * 16 times the number of compute units on the OpenCL device). This can be done
  * in a separate kernel or after copying to CPU. Also two dimensional reductions
  * can not be used as arguments to other operations - they can only be
  * evaluated.
  * @tparam T type of input expression
- * @param a expression to reduce
+ * @param an expression to reduce
  * @return min
  */
 template <typename T, require_all_kernel_expressions_t<T>* = nullptr>

--- a/stan/math/opencl/kernel_generator/reduction_2d.hpp
+++ b/stan/math/opencl/kernel_generator/reduction_2d.hpp
@@ -260,14 +260,14 @@ class prod_2d_ : public reduction_2d<prod_2d_<T>, T, prod_op> {
 };
 
 /**
- * Two dimensional product - reduction of a kernel generator expression. So as to
- * be efficient two dimensional reductions are only done partially. That means
- * instead of 1 element kernel output can have a few rows and a few columns
- * that need to be reduced to obtain final result (actually it is 1 result per
- * work group run - roughly 16 times the number of compute units on the OpenCL
- * device). This can be done in a separate kernel or after copying to CPU. Also
- * two dimensional reductions can not be used as arguments to other operations -
- * they can only be evaluated.
+ * Two dimensional product - reduction of a kernel generator expression. So as
+ * to be efficient two dimensional reductions are only done partially. That
+ * means instead of 1 element kernel output can have a few rows and a few
+ * columns that need to be reduced to obtain final result (actually it is 1
+ * result per work group run - roughly 16 times the number of compute units on
+ * the OpenCL device). This can be done in a separate kernel or after copying to
+ * CPU. Also two dimensional reductions can not be used as arguments to other
+ * operations - they can only be evaluated.
  * @tparam T type of input expression
  * @param an expression to reduce
  * @return prod

--- a/stan/math/opencl/kernel_generator/reduction_2d.hpp
+++ b/stan/math/opencl/kernel_generator/reduction_2d.hpp
@@ -226,7 +226,7 @@ class sum_2d_ : public reduction_2d<sum_2d_<T>, T, sum_op> {
  * two dimensional reductions can not be used as arguments to other operations -
  * they can only be evaluated.
  * @tparam T type of input expression
- * @param an expression to reduce
+ * @param a the expression to reduce
  * @return sum
  */
 template <typename T, require_all_kernel_expressions_t<T>* = nullptr>
@@ -269,7 +269,7 @@ class prod_2d_ : public reduction_2d<prod_2d_<T>, T, prod_op> {
  * CPU. Also two dimensional reductions can not be used as arguments to other
  * operations - they can only be evaluated.
  * @tparam T type of input expression
- * @param an expression to reduce
+ * @param a the expression to reduce
  * @return prod
  */
 template <typename T, require_all_kernel_expressions_t<T>* = nullptr>
@@ -316,7 +316,7 @@ class max_2d_
  * two dimensional reductions can not be used as arguments to other operations -
  * they can only be evaluated.
  * @tparam T type of input expression
- * @param an expression to reduce
+ * @param a the expression to reduce
  * @return max
  */
 template <typename T, require_all_kernel_expressions_t<T>* = nullptr>
@@ -363,7 +363,7 @@ class min_2d_
  * can not be used as arguments to other operations - they can only be
  * evaluated.
  * @tparam T type of input expression
- * @param an expression to reduce
+ * @param a the expression to reduce
  * @return min
  */
 template <typename T, require_all_kernel_expressions_t<T>* = nullptr>

--- a/stan/math/opencl/kernel_generator/reduction_2d.hpp
+++ b/stan/math/opencl/kernel_generator/reduction_2d.hpp
@@ -236,6 +236,48 @@ inline auto sum_2d(T&& a) {
 }
 
 /**
+ * Represents two dimensional product - reduction in kernel generator expressions.
+ * @tparam T type of expression
+ */
+template <typename T>
+class prod_2d_ : public reduction_2d<prod_2d_<T>, T, prod_op> {
+  using base = reduction_2d<prod_2d_<T>, T, prod_op>;
+  using base::arguments_;
+
+ public:
+  explicit prod_2d_(T&& a)
+      : reduction_2d<prod_2d_<T>, T, prod_op>(std::forward<T>(a), "1") {}
+  /**
+   * Creates a deep copy of this expression.
+   * @return copy of \c *this
+   */
+  inline auto deep_copy() const {
+    auto&& arg_copy = this->template get_arg<0>().deep_copy();
+    return prod_2d_<std::remove_reference_t<decltype(arg_copy)>>(
+        std::move(arg_copy));
+  }
+};
+
+/**
+ * two dimensional product - reduction of a kernel generator expression. So as to
+ * be efficient two dimensional reductions are only done partially. That means
+ * instead of 1 element kernel output can have a few rows and a few columns
+ * that need to be reduced to obtain final result (actually it is 1 reslut per
+ * work group run - roughly 16 times the number of compute units on the OpenCL
+ * device). This can be done in a separate kernel or after copying to CPU. Also
+ * two dimensional reductions can not be used as arguments to other operations -
+ * they can only be evaluated.
+ * @tparam T type of input expression
+ * @param a expression to reduce
+ * @return prod
+ */
+template <typename T, require_all_kernel_expressions_t<T>* = nullptr>
+inline auto prod_2d(T&& a) {
+  auto&& arg_copy = as_operation_cl(std::forward<T>(a)).deep_copy();
+  return prod_2d_<as_operation_cl_t<T>>(as_operation_cl(std::forward<T>(a)));
+}
+
+/**
  * Represents two dimensional max - reduction in kernel generator expressions.
  * @tparam T type of expression
  */

--- a/stan/math/opencl/kernel_generator/rowwise_reduction.hpp
+++ b/stan/math/opencl/kernel_generator/rowwise_reduction.hpp
@@ -333,6 +333,60 @@ inline auto rowwise_sum(T&& a) {
 }
 
 /**
+ * Operation for product reduction.
+ */
+struct prod_op {
+  /**
+   * Generates prod reduction kernel code.
+   * @param a first variable
+   * @param b second variable
+   * @return reduction code
+   */
+  inline static std::string generate(const std::string& a,
+                                     const std::string& b) {
+    return a + " * " + b;
+  }
+};
+
+/**
+ * Represents rowwise product reduction in kernel generator expressions.
+ * @tparam T type of expression
+ */
+template <typename T>
+class rowwise_prod_
+    : public rowwise_reduction<rowwise_prod_<T>, T, prod_op, false> {
+  using base = rowwise_reduction<rowwise_prod_<T>, T, prod_op, false>;
+  using base::arguments_;
+
+ public:
+  explicit rowwise_prod_(T&& a) : base(std::forward<T>(a), "1") {}
+
+  /**
+   * Creates a deep copy of this expression.
+   * @return copy of \c *this
+   */
+  inline auto deep_copy() const {
+    auto&& arg_copy = this->template get_arg<0>().deep_copy();
+    return rowwise_prod_<std::remove_reference_t<decltype(arg_copy)>>(
+        std::move(arg_copy));
+  }
+};
+
+/**
+ * Rowwise product reduction of a kernel generator expression.
+ * @tparam T type of input expression
+ * @param a expression to reduce
+ * @return prod
+ */
+template <typename T,
+          typename = require_all_kernel_expressions_and_none_scalar_t<T>>
+inline auto rowwise_prod(T&& a) {
+  auto&& arg_copy = as_operation_cl(std::forward<T>(a)).deep_copy();
+  return rowwise_prod_<std::remove_reference_t<decltype(arg_copy)>>(
+      std::move(arg_copy));
+}
+
+/**
  * Operation for max reduction.
  * @tparam T type to reduce
  */

--- a/stan/math/opencl/kernel_generator/rowwise_reduction.hpp
+++ b/stan/math/opencl/kernel_generator/rowwise_reduction.hpp
@@ -321,7 +321,7 @@ class rowwise_sum_
 /**
  * Rowwise sum reduction of a kernel generator expression.
  * @tparam T type of input expression
- * @param an expression to reduce
+ * @param a the expression to reduce
  * @return sum
  */
 template <typename T,
@@ -375,7 +375,7 @@ class rowwise_prod_
 /**
  * Rowwise product reduction of a kernel generator expression.
  * @tparam T type of input expression
- * @param an expression to reduce
+ * @param a the expression to reduce
  * @return prod
  */
 template <typename T,
@@ -443,7 +443,7 @@ class rowwise_max_
 /**
  * Rowwise max reduction of a kernel generator expression.
  * @tparam T type of input expression
- * @param an expression to reduce
+ * @param a the expression to reduce
  * @return max
  */
 template <typename T,
@@ -510,7 +510,7 @@ class rowwise_min_
 /**
  * Min reduction of a kernel generator expression.
  * @tparam T type of input expression
- * @param an expression to reduce
+ * @param a the expression to reduce
  * @return min
  */
 template <typename T,

--- a/stan/math/opencl/kernel_generator/rowwise_reduction.hpp
+++ b/stan/math/opencl/kernel_generator/rowwise_reduction.hpp
@@ -321,7 +321,7 @@ class rowwise_sum_
 /**
  * Rowwise sum reduction of a kernel generator expression.
  * @tparam T type of input expression
- * @param a expression to reduce
+ * @param an expression to reduce
  * @return sum
  */
 template <typename T,
@@ -375,7 +375,7 @@ class rowwise_prod_
 /**
  * Rowwise product reduction of a kernel generator expression.
  * @tparam T type of input expression
- * @param a expression to reduce
+ * @param an expression to reduce
  * @return prod
  */
 template <typename T,
@@ -443,7 +443,7 @@ class rowwise_max_
 /**
  * Rowwise max reduction of a kernel generator expression.
  * @tparam T type of input expression
- * @param a expression to reduce
+ * @param an expression to reduce
  * @return max
  */
 template <typename T,
@@ -510,7 +510,7 @@ class rowwise_min_
 /**
  * Min reduction of a kernel generator expression.
  * @tparam T type of input expression
- * @param a expression to reduce
+ * @param an expression to reduce
  * @return min
  */
 template <typename T,

--- a/stan/math/opencl/prim.hpp
+++ b/stan/math/opencl/prim.hpp
@@ -166,6 +166,7 @@
 #include <stan/math/opencl/prim/poisson_log_glm_lpmf.hpp>
 #include <stan/math/opencl/prim/poisson_log_lpmf.hpp>
 #include <stan/math/opencl/prim/poisson_lpmf.hpp>
+#include <stan/math/opencl/prim/prod.hpp>
 #include <stan/math/opencl/prim/rayleigh_lpdf.hpp>
 #include <stan/math/opencl/prim/rep_array.hpp>
 #include <stan/math/opencl/prim/rep_matrix.hpp>

--- a/stan/math/opencl/prim/prod.hpp
+++ b/stan/math/opencl/prim/prod.hpp
@@ -1,0 +1,40 @@
+#ifndef STAN_MATH_OPENCL_PRIM_PROD_HPP
+#define STAN_MATH_OPENCL_PRIM_PROD_HPP
+#ifdef STAN_OPENCL
+
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/fun/prod.hpp>
+#include <stan/math/opencl/matrix_cl.hpp>
+#include <stan/math/opencl/kernel_generator.hpp>
+
+namespace stan {
+namespace math {
+
+/**
+ * Calculates product of given kernel generator expression elements.
+ * @tparam T type of the expression
+ * @param m expression to calcualte product of
+ * @return product of given expression
+ */
+template <typename T,
+          require_all_kernel_expressions_and_none_scalar_t<T>* = nullptr>
+value_type_t<T> prod(const T& m) {
+  if (is_matrix_cl<T>::value && m.size() < 1000) {
+    // for small matrices running another kernel is not worth it
+    return prod(from_matrix_cl(m));
+  }
+  matrix_cl<value_type_t<T>> res;
+  if (m.rows() <= 8) {
+    // without transpose we would use just a few threads in a work group
+    res = prod_2d(transpose(m));
+  } else {
+    res = prod_2d(m);
+  }
+  return prod(from_matrix_cl(res));
+}
+
+}  // namespace math
+}  // namespace stan
+
+#endif
+#endif

--- a/stan/math/opencl/rev.hpp
+++ b/stan/math/opencl/rev.hpp
@@ -86,6 +86,7 @@
 #include <stan/math/opencl/rev/Phi.hpp>
 #include <stan/math/opencl/rev/Phi_approx.hpp>
 #include <stan/math/opencl/rev/pow.hpp>
+#include <stan/math/opencl/rev/prod.hpp>
 #include <stan/math/opencl/rev/rep_matrix.hpp>
 #include <stan/math/opencl/rev/reverse.hpp>
 #include <stan/math/opencl/rev/round.hpp>

--- a/stan/math/opencl/rev/prod.hpp
+++ b/stan/math/opencl/rev/prod.hpp
@@ -1,0 +1,32 @@
+#ifndef STAN_MATH_OPENCL_REV_PROD_HPP
+#define STAN_MATH_OPENCL_REV_PROD_HPP
+#ifdef STAN_OPENCL
+
+#include <stan/math/opencl/prim/prod.hpp>
+#include <stan/math/rev/core.hpp>
+#include <stan/math/rev/fun/value_of.hpp>
+#include <stan/math/rev/core/reverse_pass_callback.hpp>
+
+namespace stan {
+namespace math {
+
+/**
+ * Returns the prod of the coefficients of the specified
+ * matrix on the OpenCL device.
+ *
+ * @param x Specified var_value containing a matrix.
+ * @return prod of coefficients of matrix.
+ */
+template <typename T,
+          require_all_kernel_expressions_and_none_scalar_t<T>* = nullptr>
+inline var prod(const var_value<T>& x) {
+  return make_callback_var(prod(value_of(x)), [x](vari& res) mutable {
+    x.adj() += elt_divide(res.adj() * res.val(), x.val());
+  });
+}
+
+}  // namespace math
+}  // namespace stan
+
+#endif
+#endif

--- a/test/unit/math/opencl/kernel_generator/colwise_reduction_test.cpp
+++ b/test/unit/math/opencl/kernel_generator/colwise_reduction_test.cpp
@@ -43,6 +43,22 @@ TEST(KernelGenerator, colwise_sum_test) {
   EXPECT_MATRIX_NEAR(correct, res, 1e-9);
 }
 
+TEST(KernelGenerator, colwise_prod_test) {
+  MatrixXd m(3, 2);
+  m << 1.1, 1.2, 1.3, 1.4, 1.5, 1.6;
+
+  matrix_cl<double> m_cl(m);
+
+  matrix_cl<double> res_cl = stan::math::colwise_prod(m_cl);
+  MatrixXd raw_res = stan::math::from_matrix_cl(res_cl);
+  EXPECT_GE(m.rows(), raw_res.rows());
+  MatrixXd res = raw_res.colwise().prod();
+  MatrixXd correct = m.colwise().prod();
+  EXPECT_EQ(correct.rows(), res.rows());
+  EXPECT_EQ(correct.cols(), res.cols());
+  EXPECT_MATRIX_NEAR(correct, res, 1e-9);
+}
+
 TEST(KernelGenerator, colwise_min_test) {
   MatrixXd m(3, 2);
   m << 1.1, 1.2, 1.3, 1.4, 1.5, 1.6;

--- a/test/unit/math/opencl/kernel_generator/reduction_2d_test.cpp
+++ b/test/unit/math/opencl/kernel_generator/reduction_2d_test.cpp
@@ -42,6 +42,21 @@ TEST(KernelGenerator, sum_2d_test) {
   EXPECT_NEAR(correct, res, 1e-9);
 }
 
+TEST(KernelGenerator, prod_2d_test) {
+  MatrixXd m(3, 2);
+  m << 1.1, 1.2, 1.3, 1.4, 1.5, 1.6;
+
+  matrix_cl<double> m_cl(m);
+
+  matrix_cl<double> res_cl = stan::math::prod_2d(m_cl);
+  MatrixXd raw_res = stan::math::from_matrix_cl(res_cl);
+  EXPECT_GE(m.rows(), raw_res.rows());
+  EXPECT_GE(m.cols(), raw_res.cols());
+  double res = raw_res.prod();
+  double correct = m.prod();
+  EXPECT_NEAR(correct, res, 1e-9);
+}
+
 TEST(KernelGenerator, min_2d_test) {
   MatrixXd m(3, 2);
   m << 1.1, 1.2, 1.3, 1.4, 1.5, 1.6;

--- a/test/unit/math/opencl/kernel_generator/rowwise_reduction_test.cpp
+++ b/test/unit/math/opencl/kernel_generator/rowwise_reduction_test.cpp
@@ -25,6 +25,20 @@ TEST(KernelGenerator, rowwise_sum_test) {
   EXPECT_MATRIX_NEAR(correct1, res1, 1e-9);
 }
 
+TEST(KernelGenerator, rowwise_prod_test) {
+  MatrixXd m(3, 2);
+  m << 1.1, 1.2, 1.3, 1.4, 1.5, 1.6;
+
+  matrix_cl<double> m_cl(m);
+
+  matrix_cl<double> res1_cl = stan::math::rowwise_prod(m_cl);
+  MatrixXd res1 = stan::math::from_matrix_cl(res1_cl);
+  MatrixXd correct1 = m.rowwise().prod();
+  EXPECT_EQ(correct1.rows(), res1.rows());
+  EXPECT_EQ(correct1.cols(), res1.cols());
+  EXPECT_MATRIX_NEAR(correct1, res1, 1e-9);
+}
+
 TEST(KernelGenerator, rowwise_min_test) {
   MatrixXd m(3, 2);
   m << 1.1, 1.2, 1.3, 1.4, 1.5, 1.6;

--- a/test/unit/math/opencl/rev/prod_test.cpp
+++ b/test/unit/math/opencl/rev/prod_test.cpp
@@ -1,0 +1,42 @@
+#ifdef STAN_OPENCL
+#include <stan/math/opencl/rev.hpp>
+#include <stan/math.hpp>
+#include <gtest/gtest.h>
+#include <test/unit/math/opencl/util.hpp>
+
+auto prod_functor = [](const auto& a) { return stan::math::prod(a); };
+
+TEST(OpenCLProd, prim_rev_values_small) {
+  int N = 2;
+  int M = 3;
+
+  Eigen::MatrixXd a(N, M);
+  a << 1, 2, 3, 4, 5, 6;
+  stan::math::test::compare_cpu_opencl_prim_rev(prod_functor, a);
+}
+
+TEST(OpenCLProd, prim_rev_values_zero_rows) {
+  int N = 0;
+  int M = 3;
+
+  Eigen::MatrixXd a(N, M);
+  stan::math::test::compare_cpu_opencl_prim_rev(prod_functor, a);
+}
+
+TEST(OpenCLProd, prim_rev_values_zero_cols) {
+  int N = 2;
+  int M = 0;
+
+  Eigen::MatrixXd a(N, M);
+  stan::math::test::compare_cpu_opencl_prim_rev(prod_functor, a);
+}
+
+TEST(OpenCLProd, prim_rev_values_large) {
+  int N = 71;
+  int M = 83;
+
+  Eigen::MatrixXd a = Eigen::MatrixXd::Random(N, M);
+  stan::math::test::compare_cpu_opencl_prim_rev(prod_functor, a);
+}
+
+#endif


### PR DESCRIPTION
## Summary

Added OpenCL implementation for `prod` function and kernel generator operation for rowwise, colwise and 2d product.

## Tests

New functions are tested.

## Side Effects
None.

## Release notes

Added OpenCL implementation for `prod` function and kernel generator operation for rowwise, colwise and 2d product.

## Checklist

- [ ] Math issue #1854

- [ ] Copyright holder: Tadej Ciglarič

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [ ] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [ ] the code is written in idiomatic C++ and changes are documented in the doxygen

- [ ] the new changes are tested
