### PR TITLE
Fix 2435

### DIFF
--- a/stan/math/prim/fun/stan_print.hpp
+++ b/stan/math/prim/fun/stan_print.hpp
@@ -16,12 +16,14 @@ void stan_print(std::ostream* o, const T& x) {
 
 template <typename EigVec, require_eigen_vector_t<EigVec>* = nullptr>
 void stan_print(std::ostream* o, const EigVec& x) {
+  const auto& x_ref = to_ref(x);
+
   *o << '[';
-  for (int i = 0; i < x.size(); ++i) {
+  for (int i = 0; i < x_ref.size(); ++i) {
     if (i > 0) {
       *o << ',';
     }
-    stan_print(o, x(i));
+    stan_print(o, x_ref.coeff(i));
   }
   *o << ']';
 }
@@ -29,17 +31,19 @@ void stan_print(std::ostream* o, const EigVec& x) {
 template <typename EigMat, require_eigen_t<EigMat>* = nullptr,
           require_not_eigen_vector_t<EigMat>* = nullptr>
 void stan_print(std::ostream* o, const EigMat& x) {
+  const auto& x_ref = to_ref(x);
+
   *o << '[';
-  for (int i = 0; i < x.rows(); ++i) {
+  for (int i = 0; i < x_ref.rows(); ++i) {
     if (i > 0) {
       *o << ',';
     }
     *o << '[';
-    for (int j = 0; j < x.cols(); ++j) {
+    for (int j = 0; j < x_ref.cols(); ++j) {
       if (j > 0) {
         *o << ',';
       }
-      stan_print(o, x.coeff(i, j));
+      stan_print(o, x_ref.coeff(i, j));
     }
     *o << ']';
   }

--- a/test/unit/math/prim/fun/stan_print_test.cpp
+++ b/test/unit/math/prim/fun/stan_print_test.cpp
@@ -62,7 +62,7 @@ TEST(MathPrim, basic_expressions) {
     stan::math::stan_print(&s, rv * m);
     EXPECT_TRUE(s.str().find("[2,2]") != std::string::npos);
   }
-  
+
   {
     std::stringstream s;
     stan::math::stan_print(&s, m * m);

--- a/test/unit/math/prim/fun/stan_print_test.cpp
+++ b/test/unit/math/prim/fun/stan_print_test.cpp
@@ -1,0 +1,71 @@
+#include <stan/math/prim.hpp>
+#include <gtest/gtest.h>
+
+TEST(MathPrim, basic_print) {
+  int i = 1;
+  double d = 1.0;
+  Eigen::VectorXd v = Eigen::VectorXd::Ones(1);
+  Eigen::RowVectorXd rv = Eigen::RowVectorXd::Ones(1);
+  Eigen::MatrixXd m = Eigen::MatrixXd::Ones(1, 1);
+  std::vector<double> a(1, 1);
+
+  {
+    std::stringstream s;
+    stan::math::stan_print(&s, i);
+    EXPECT_TRUE(s.str().find("1") != std::string::npos);
+  }
+
+  {
+    std::stringstream s;
+    stan::math::stan_print(&s, d);
+    EXPECT_TRUE(s.str().find("1") != std::string::npos);
+  }
+
+  {
+    std::stringstream s;
+    stan::math::stan_print(&s, v);
+    EXPECT_TRUE(s.str().find("[1]") != std::string::npos);
+  }
+
+  {
+    std::stringstream s;
+    stan::math::stan_print(&s, rv);
+    EXPECT_TRUE(s.str().find("[1]") != std::string::npos);
+  }
+
+  {
+    std::stringstream s;
+    stan::math::stan_print(&s, m);
+    EXPECT_TRUE(s.str().find("[[1]]") != std::string::npos);
+  }
+
+  {
+    std::stringstream s;
+    stan::math::stan_print(&s, a);
+    EXPECT_TRUE(s.str().find("[1]") != std::string::npos);
+  }
+}
+
+TEST(MathPrim, basic_expressions) {
+  Eigen::VectorXd v = Eigen::VectorXd::Ones(2);
+  Eigen::RowVectorXd rv = Eigen::RowVectorXd::Ones(2);
+  Eigen::MatrixXd m = Eigen::MatrixXd::Ones(2, 2);
+
+  {
+    std::stringstream s;
+    stan::math::stan_print(&s, v * v.transpose());
+    EXPECT_TRUE(s.str().find("[[1,1],[1,1]]") != std::string::npos);
+  }
+
+  {
+    std::stringstream s;
+    stan::math::stan_print(&s, rv * m);
+    EXPECT_TRUE(s.str().find("[2,2]") != std::string::npos);
+  }
+  
+  {
+    std::stringstream s;
+    stan::math::stan_print(&s, m * m);
+    EXPECT_TRUE(s.str().find("[[2,2],[2,2]]") != std::string::npos);
+  }
+}

--- a/test/unit/math/rev/fun/stan_print_test.cpp
+++ b/test/unit/math/rev/fun/stan_print_test.cpp
@@ -3,7 +3,7 @@
 #include <test/unit/util.hpp>
 #include <gtest/gtest.h>
 
-TEST(AgradRev, print) {
+TEST(AgradRev, stan_print) {
   using stan::math::var;
 
   var a = 5.0;

--- a/test/unit/math/rev/fun/stan_print_test.cpp
+++ b/test/unit/math/rev/fun/stan_print_test.cpp
@@ -1,0 +1,16 @@
+#include <stan/math/rev.hpp>
+#include <test/unit/math/rev/fun/util.hpp>
+#include <test/unit/util.hpp>
+#include <gtest/gtest.h>
+
+TEST(AgradRev, print) {
+  using stan::math::var;
+
+  var a = 5.0;
+
+  {
+    std::stringstream s;
+    stan::math::stan_print(&s, a);
+    EXPECT_TRUE(s.str().find("5") != std::string::npos);
+  }
+}


### PR DESCRIPTION
## Summary

This adds a test to make sure `stan_print` works with expressions.

I did the expression tests manually because:

1. There's no stanc3 notation for a function that returns void
2. Our current expression tests didn't catch this bug

To catch this bug the matrix expression needs to be at least a 2x2 product (1x1 product passes).

## Release notes

- Fix bug where printing Eigen expressions failed

## Checklist

- [x] Math issue #2435

- [x] Copyright holder: Columbia University

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
