### PR TITLE
Added STAN_NO_RANGE_CHECKS helper

### DIFF
--- a/.github/workflows/header_checks.yml
+++ b/.github/workflows/header_checks.yml
@@ -78,5 +78,5 @@ jobs:
 
     - name: Run header tests
       run: |
-        echo "CXXFLAGS+=-DSTAN_NO_RANGE_CHECKS" > make/local
+        echo "STAN_NO_RANGE_CHECKS=true" > make/local
         ./runTests.py -j2 ./test/unit/math/prim/err/

--- a/make/compiler_flags
+++ b/make/compiler_flags
@@ -90,6 +90,10 @@ CXX_MINOR := $(word 2,$(subst ., ,$(CXX_VERSION)))
 # LDFLAGS_MPI_FLTO: For adding flto options to MPI build
 ##
 
+ifdef STAN_NO_RANGE_CHECKS
+  CXXFLAGS_THREADS ?= -DSTAN_NO_RANGE_CHECKS
+endif
+
 ################################################################################
 # Set default compiler flags
 #


### PR DESCRIPTION
## Summary

Added a makefile helper so:

```
STAN_NO_RANGE_CHECKS=true
```

is shorthand for

```
CXXFLAGS += -DSTAN_NO_RANGE_CHECKS
```

## Tests

None

## Release notes

- Allow `STAN_NO_RANGE_CHECKS=true` in `make/local` to turn off range/size checks

## Checklist

- [x] Math issue #2420

- [x] Copyright holder: Columbia University

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
