### PR TITLE
Feature/issue 2444 nested paralellism

### DIFF
--- a/stan/math/fwd/functor/reduce_sum.hpp
+++ b/stan/math/fwd/functor/reduce_sum.hpp
@@ -4,10 +4,6 @@
 #include <stan/math/prim/meta.hpp>
 #include <stan/math/prim/err.hpp>
 
-#include <tbb/task_arena.h>
-#include <tbb/parallel_reduce.h>
-#include <tbb/blocked_range.h>
-
 #include <algorithm>
 #include <tuple>
 #include <vector>

--- a/stan/math/rev/core/init_chainablestack.hpp
+++ b/stan/math/rev/core/init_chainablestack.hpp
@@ -20,7 +20,9 @@ namespace math {
  * hook ensures that each worker thread has an initialized AD tape
  * ready for use.
  *
- * Refer to https://software.intel.com/content/www/us/en/develop/documentation/tbb-documentation/top/intel-threading-building-blocks-developer-reference/task-scheduler/taskschedulerobserver.html for details on the observer concept.
+ * Refer to
+ * https://software.intel.com/content/www/us/en/develop/documentation/tbb-documentation/top/intel-threading-building-blocks-developer-reference/task-scheduler/taskschedulerobserver.html
+ * for details on the observer concept.
  */
 class ad_tape_observer final : public tbb::task_scheduler_observer {
   using stack_ptr = std::unique_ptr<ChainableStack>;

--- a/stan/math/rev/core/init_chainablestack.hpp
+++ b/stan/math/rev/core/init_chainablestack.hpp
@@ -20,8 +20,7 @@ namespace math {
  * hook ensures that each worker thread has an initialized AD tape
  * ready for use.
  *
- * Refer to https://software.intel.com/en-us/node/506314 for details
- * on the observer concept.
+ * Refer to https://software.intel.com/content/www/us/en/develop/documentation/tbb-documentation/top/intel-threading-building-blocks-developer-reference/task-scheduler/taskschedulerobserver.html for details on the observer concept.
  */
 class ad_tape_observer final : public tbb::task_scheduler_observer {
   using stack_ptr = std::unique_ptr<ChainableStack>;

--- a/stan/math/rev/functor/map_rect_concurrent.hpp
+++ b/stan/math/rev/functor/map_rect_concurrent.hpp
@@ -51,7 +51,7 @@ map_rect_concurrent(
   // not being modified from a different task which may happen
   // whenever this function is being used itself in a parallel
   // context (like running multiple chains for Stan)
-  tbb::this_task_arena::isolate( [&]{
+  tbb::this_task_arena::isolate([&] {
     tbb::parallel_for(tbb::blocked_range<std::size_t>(0, num_jobs),
                       [&](const tbb::blocked_range<size_t>& r) {
                         execute_chunk(r.begin(), r.end());

--- a/stan/math/rev/functor/map_rect_concurrent.hpp
+++ b/stan/math/rev/functor/map_rect_concurrent.hpp
@@ -45,10 +45,12 @@ map_rect_concurrent(
   };
 
 #ifdef STAN_THREADS
-  tbb::parallel_for(tbb::blocked_range<std::size_t>(0, num_jobs),
-                    [&](const tbb::blocked_range<size_t>& r) {
-                      execute_chunk(r.begin(), r.end());
-                    });
+  tbb::this_task_arena::isolate( [&]{
+    tbb::parallel_for(tbb::blocked_range<std::size_t>(0, num_jobs),
+                      [&](const tbb::blocked_range<size_t>& r) {
+                        execute_chunk(r.begin(), r.end());
+                      });
+  });
 #else
   execute_chunk(0, num_jobs);
 #endif

--- a/stan/math/rev/functor/map_rect_concurrent.hpp
+++ b/stan/math/rev/functor/map_rect_concurrent.hpp
@@ -45,6 +45,12 @@ map_rect_concurrent(
   };
 
 #ifdef STAN_THREADS
+  // we must use task isolation as described here:
+  // https://software.intel.com/content/www/us/en/develop/documentation/tbb-documentation/top/intel-threading-building-blocks-developer-guide/task-isolation.html
+  // this is to ensure that the thread local AD tape ressource is
+  // not being modified from a different task which may happen
+  // whenever this function is being used itself in a parallel
+  // context (like running multiple chains for Stan)
   tbb::this_task_arena::isolate( [&]{
     tbb::parallel_for(tbb::blocked_range<std::size_t>(0, num_jobs),
                       [&](const tbb::blocked_range<size_t>& r) {

--- a/stan/math/rev/functor/reduce_sum.hpp
+++ b/stan/math/rev/functor/reduce_sum.hpp
@@ -256,7 +256,7 @@ struct reduce_sum_impl<ReduceFunction, require_var_t<ReturnType>, ReturnType,
     // not being modified from a different task which may happen
     // whenever this function is being used itself in a parallel
     // context (like running multiple chains for Stan)
-    tbb::this_task_arena::isolate( [&]{
+    tbb::this_task_arena::isolate([&] {
       if (auto_partitioning) {
         tbb::parallel_reduce(
             tbb::blocked_range<std::size_t>(0, num_terms, grainsize), worker);

--- a/stan/math/rev/functor/reduce_sum.hpp
+++ b/stan/math/rev/functor/reduce_sum.hpp
@@ -250,6 +250,12 @@ struct reduce_sum_impl<ReduceFunction, require_var_t<ReturnType>, ReturnType,
                              std::forward<Vec>(vmapped),
                              std::forward<Args>(args)...);
 
+    // we must use task isolation as described here:
+    // https://software.intel.com/content/www/us/en/develop/documentation/tbb-documentation/top/intel-threading-building-blocks-developer-guide/task-isolation.html
+    // this is to ensure that the thread local AD tape ressource is
+    // not being modified from a different task which may happen
+    // whenever this function is being used itself in a parallel
+    // context (like running multiple chains for Stan)
     tbb::this_task_arena::isolate( [&]{
       if (auto_partitioning) {
         tbb::parallel_reduce(


### PR DESCRIPTION
## Summary

Stan math programs may run potentially within a nested parallel environment. In that case we need to use task isolation to avoid that the calling thread gets to do work from other contexts not related to the AD task being processed in the current thread.

## Tests

NA

## Side Effects

NA

## Release notes

Make stan math safe for nested paralellism.

## Checklist

- [X] Math issue #2444 

- [X] Copyright holder: Sebastian Weber

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [X] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [X] the new changes are tested
