### PR TITLE
Opencl double_exponential and exp_mod_normal (lc)cdf

### DIFF
--- a/stan/math/opencl/prim.hpp
+++ b/stan/math/opencl/prim.hpp
@@ -132,6 +132,9 @@
 #include <stan/math/opencl/prim/double_exponential_lccdf.hpp>
 #include <stan/math/opencl/prim/double_exponential_lcdf.hpp>
 #include <stan/math/opencl/prim/double_exponential_lpdf.hpp>
+#include <stan/math/opencl/prim/exp_mod_normal_cdf.hpp>
+#include <stan/math/opencl/prim/exp_mod_normal_lccdf.hpp>
+#include <stan/math/opencl/prim/exp_mod_normal_lcdf.hpp>
 #include <stan/math/opencl/prim/exp_mod_normal_lpdf.hpp>
 #include <stan/math/opencl/prim/exponential_lpdf.hpp>
 #include <stan/math/opencl/prim/frechet_lpdf.hpp>

--- a/stan/math/opencl/prim.hpp
+++ b/stan/math/opencl/prim.hpp
@@ -128,6 +128,9 @@
 #include <stan/math/opencl/prim/divide_columns.hpp>
 #include <stan/math/opencl/prim/dot_product.hpp>
 #include <stan/math/opencl/prim/dot_self.hpp>
+#include <stan/math/opencl/prim/double_exponential_cdf.hpp>
+#include <stan/math/opencl/prim/double_exponential_lccdf.hpp>
+#include <stan/math/opencl/prim/double_exponential_lcdf.hpp>
 #include <stan/math/opencl/prim/double_exponential_lpdf.hpp>
 #include <stan/math/opencl/prim/exp_mod_normal_lpdf.hpp>
 #include <stan/math/opencl/prim/exponential_lpdf.hpp>

--- a/stan/math/opencl/prim/double_exponential_cdf.hpp
+++ b/stan/math/opencl/prim/double_exponential_cdf.hpp
@@ -1,0 +1,118 @@
+#ifndef STAN_MATH_OPENCL_PRIM_DOUBLE_EXPONENTIAL_CDF_HPP
+#define STAN_MATH_OPENCL_PRIM_DOUBLE_EXPONENTIAL_CDF_HPP
+#ifdef STAN_OPENCL
+
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/err.hpp>
+#include <stan/math/prim/fun/constants.hpp>
+#include <stan/math/prim/fun/elt_divide.hpp>
+#include <stan/math/prim/fun/elt_multiply.hpp>
+#include <stan/math/opencl/kernel_generator.hpp>
+#include <stan/math/prim/functor/operands_and_partials.hpp>
+
+namespace stan {
+namespace math {
+
+/** \ingroup opencl
+ * Returns the double exponential cumulative density function. Given
+ * containers of matching sizes, returns the product of probabilities.
+ *
+ * @tparam T_y_cl type of scalar outcome
+ * @tparam T_loc_cl type of location
+ * @tparam T_scale_cl type of scale
+ * @param y (Sequence of) scalar(s).
+ * @param mu (Sequence of) location(s).
+ * @param sigma (Sequence of) scale(s).
+ * @return The log of the product of densities.
+ */
+template <
+    typename T_y_cl, typename T_loc_cl, typename T_scale_cl,
+    require_all_prim_or_rev_kernel_expression_t<T_y_cl, T_loc_cl,
+                                                T_scale_cl>* = nullptr,
+    require_any_not_stan_scalar_t<T_y_cl, T_loc_cl, T_scale_cl>* = nullptr>
+return_type_t<T_y_cl, T_loc_cl, T_scale_cl> double_exponential_cdf(
+    const T_y_cl& y, const T_loc_cl& mu, const T_scale_cl& sigma) {
+  static const char* function = "double_exponential_cdf(OpenCL)";
+  using T_partials_return = partials_return_t<T_y_cl, T_loc_cl, T_scale_cl>;
+  using std::isfinite;
+  using std::isnan;
+
+  check_consistent_sizes(function, "Random variable", y, "Location parameter",
+                         mu, "Scale parameter", sigma);
+  const size_t N = max_size(y, mu, sigma);
+  if (N == 0) {
+    return 1.0;
+  }
+
+  const auto& y_col = as_column_vector_or_scalar(y);
+  const auto& mu_col = as_column_vector_or_scalar(mu);
+  const auto& sigma_col = as_column_vector_or_scalar(sigma);
+
+  const auto& y_val = value_of(y_col);
+  const auto& mu_val = value_of(mu_col);
+  const auto& sigma_val = value_of(sigma_col);
+
+  auto check_y_not_nan
+      = check_cl(function, "Random variable", y_val, "not NaN");
+  auto y_not_nan_expr = !isnan(y_val);
+  auto check_mu_finite
+      = check_cl(function, "Location parameter", mu_val, "finite");
+  auto mu_finite_expr = isfinite(mu_val);
+  auto check_sigma_positive_finite
+      = check_cl(function, "Scale parameter", sigma_val, "positive finite");
+  auto sigma_positive_finite_expr = 0 < sigma_val && isfinite(sigma_val);
+
+  auto scaled_diff = elt_divide(y_val - mu_val, sigma_val);
+  auto exp_scaled_diff = exp(scaled_diff);
+  auto cond = y_val < mu_val;
+  auto cdf_expr = colwise_prod(select(cond, 0.5 * exp_scaled_diff,
+                                      1.0 - elt_divide(0.5, exp_scaled_diff)));
+
+  matrix_cl<double> cdf_cl;
+  matrix_cl<double> mu_deriv_cl;  // also temporarily stores exp_scaled_diff
+  matrix_cl<double> y_deriv_cl;
+  matrix_cl<double> sigma_deriv_cl;  // also temporarily stores scaled_diff
+
+  results(check_y_not_nan, check_mu_finite, check_sigma_positive_finite, cdf_cl,
+          mu_deriv_cl, sigma_deriv_cl)
+      = expressions(
+          y_not_nan_expr, mu_finite_expr, sigma_positive_finite_expr, cdf_expr,
+          calc_if<!is_constant_all<T_y_cl, T_loc_cl, T_scale_cl>::value>(
+              exp_scaled_diff),
+          calc_if<!is_constant<T_scale_cl>::value>(scaled_diff));
+
+  T_partials_return cdf = (from_matrix_cl(cdf_cl)).prod();
+
+  operands_and_partials<decltype(y_col), decltype(mu_col), decltype(sigma_col)>
+      ops_partials(y_col, mu_col, sigma_col);
+  if (!is_constant_all<T_y_cl, T_loc_cl, T_scale_cl>::value) {
+    auto cdf_div_sigma = elt_divide(cdf, sigma_val);
+    auto y_deriv = select(cond, cdf_div_sigma,
+                          elt_divide(cdf_div_sigma, (2.0 * mu_deriv_cl - 1.0)));
+    auto mu_deriv = -y_deriv;
+    auto sigma_deriv
+        = elt_multiply(mu_deriv, static_select<is_constant<T_scale_cl>::value>(
+                                     mu_deriv_cl, sigma_deriv_cl));
+
+    results(mu_deriv_cl, y_deriv_cl, sigma_deriv_cl)
+        = expressions(calc_if<!is_constant<T_loc_cl>::value>(mu_deriv),
+                      calc_if<!is_constant<T_y_cl>::value>(y_deriv),
+                      calc_if<!is_constant<T_scale_cl>::value>(sigma_deriv));
+
+    if (!is_constant<T_y_cl>::value) {
+      ops_partials.edge1_.partials_ = std::move(y_deriv_cl);
+    }
+    if (!is_constant<T_loc_cl>::value) {
+      ops_partials.edge2_.partials_ = std::move(mu_deriv_cl);
+    }
+    if (!is_constant<T_scale_cl>::value) {
+      ops_partials.edge3_.partials_ = std::move(sigma_deriv_cl);
+    }
+  }
+  return ops_partials.build(cdf);
+}
+
+}  // namespace math
+}  // namespace stan
+#endif
+#endif

--- a/stan/math/opencl/prim/double_exponential_lccdf.hpp
+++ b/stan/math/opencl/prim/double_exponential_lccdf.hpp
@@ -1,0 +1,109 @@
+#ifndef STAN_MATH_OPENCL_PRIM_DOUBLE_EXPONENTIAL_LCCDF_HPP
+#define STAN_MATH_OPENCL_PRIM_DOUBLE_EXPONENTIAL_LCCDF_HPP
+#ifdef STAN_OPENCL
+
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/err.hpp>
+#include <stan/math/prim/fun/constants.hpp>
+#include <stan/math/prim/fun/elt_divide.hpp>
+#include <stan/math/prim/fun/elt_multiply.hpp>
+#include <stan/math/opencl/kernel_generator.hpp>
+#include <stan/math/prim/functor/operands_and_partials.hpp>
+
+namespace stan {
+namespace math {
+
+/** \ingroup opencl
+ * Returns the double exponential log complementary cumulative density
+ * function. Given containers of matching sizes, returns the log sum of
+ * probabilities.
+ *
+ * @tparam T_y_cl type of scalar outcome
+ * @tparam T_loc_cl type of location
+ * @tparam T_scale_cl type of scale
+ * @param y (Sequence of) scalar(s).
+ * @param mu (Sequence of) location(s).
+ * @param sigma (Sequence of) scale(s).
+ * @return The log of the product of densities.
+ */
+template <
+    typename T_y_cl, typename T_loc_cl, typename T_scale_cl,
+    require_all_prim_or_rev_kernel_expression_t<T_y_cl, T_loc_cl,
+                                                T_scale_cl>* = nullptr,
+    require_any_not_stan_scalar_t<T_y_cl, T_loc_cl, T_scale_cl>* = nullptr>
+return_type_t<T_y_cl, T_loc_cl, T_scale_cl> double_exponential_lccdf(
+    const T_y_cl& y, const T_loc_cl& mu, const T_scale_cl& sigma) {
+  static const char* function = "double_exponential_lccdf(OpenCL)";
+  using T_partials_return = partials_return_t<T_y_cl, T_loc_cl, T_scale_cl>;
+  using std::isfinite;
+  using std::isnan;
+
+  check_consistent_sizes(function, "Random variable", y, "Location parameter",
+                         mu, "Scale parameter", sigma);
+  const size_t N = max_size(y, mu, sigma);
+  if (N == 0) {
+    return 0.0;
+  }
+
+  const auto& y_col = as_column_vector_or_scalar(y);
+  const auto& mu_col = as_column_vector_or_scalar(mu);
+  const auto& sigma_col = as_column_vector_or_scalar(sigma);
+
+  const auto& y_val = value_of(y_col);
+  const auto& mu_val = value_of(mu_col);
+  const auto& sigma_val = value_of(sigma_col);
+
+  auto check_y_not_nan
+      = check_cl(function, "Random variable", y_val, "not NaN");
+  auto y_not_nan_expr = !isnan(y_val);
+  auto check_mu_finite
+      = check_cl(function, "Location parameter", mu_val, "finite");
+  auto mu_finite_expr = isfinite(mu_val);
+  auto check_sigma_positive_finite
+      = check_cl(function, "Scale parameter", sigma_val, "positive finite");
+  auto sigma_positive_finite_expr = 0 < sigma_val && isfinite(sigma_val);
+
+  auto sigma_inv = elt_divide(1.0, sigma_val);
+  auto scaled_diff = elt_multiply(y_val - mu_val, sigma_inv);
+  auto cond = y_val < mu_val;
+  auto mu_deriv = select(
+      cond, elt_divide(sigma_inv, 2.0 * exp(-scaled_diff) - 1.0), sigma_inv);
+  auto ccdf_log_expr = colwise_sum(
+      select(cond, log1m(0.5 * exp(scaled_diff)), LOG_HALF - scaled_diff));
+  auto y_deriv = -mu_deriv;
+  auto sigma_deriv = elt_multiply(mu_deriv, scaled_diff);
+
+  matrix_cl<double> ccdf_log_cl;
+  matrix_cl<double> mu_deriv_cl;
+  matrix_cl<double> y_deriv_cl;
+  matrix_cl<double> sigma_deriv_cl;
+
+  results(check_y_not_nan, check_mu_finite, check_sigma_positive_finite,
+          ccdf_log_cl, y_deriv_cl, mu_deriv_cl, sigma_deriv_cl)
+      = expressions(y_not_nan_expr, mu_finite_expr, sigma_positive_finite_expr,
+                    ccdf_log_expr,
+                    calc_if<!is_constant<T_y_cl>::value>(y_deriv),
+                    calc_if<!is_constant<T_loc_cl>::value>(mu_deriv),
+                    calc_if<!is_constant<T_scale_cl>::value>(sigma_deriv));
+
+  T_partials_return ccdf_log = (from_matrix_cl(ccdf_log_cl)).sum();
+
+  operands_and_partials<decltype(y_col), decltype(mu_col), decltype(sigma_col)>
+      ops_partials(y_col, mu_col, sigma_col);
+
+  if (!is_constant<T_y_cl>::value) {
+    ops_partials.edge1_.partials_ = std::move(y_deriv_cl);
+  }
+  if (!is_constant<T_loc_cl>::value) {
+    ops_partials.edge2_.partials_ = std::move(mu_deriv_cl);
+  }
+  if (!is_constant<T_scale_cl>::value) {
+    ops_partials.edge3_.partials_ = std::move(sigma_deriv_cl);
+  }
+  return ops_partials.build(ccdf_log);
+}
+
+}  // namespace math
+}  // namespace stan
+#endif
+#endif

--- a/stan/math/opencl/prim/double_exponential_lcdf.hpp
+++ b/stan/math/opencl/prim/double_exponential_lcdf.hpp
@@ -1,0 +1,107 @@
+#ifndef STAN_MATH_OPENCL_PRIM_DOUBLE_EXPONENTIAL_LCDF_HPP
+#define STAN_MATH_OPENCL_PRIM_DOUBLE_EXPONENTIAL_LCDF_HPP
+#ifdef STAN_OPENCL
+
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/err.hpp>
+#include <stan/math/prim/fun/constants.hpp>
+#include <stan/math/prim/fun/elt_divide.hpp>
+#include <stan/math/prim/fun/elt_multiply.hpp>
+#include <stan/math/opencl/kernel_generator.hpp>
+#include <stan/math/prim/functor/operands_and_partials.hpp>
+
+namespace stan {
+namespace math {
+
+/** \ingroup opencl
+ * Returns the double exponential log cumulative density function. Given
+ * containers of matching sizes, returns the log sum of probabilities.
+ *
+ * @tparam T_y_cl type of scalar outcome
+ * @tparam T_loc_cl type of location
+ * @tparam T_scale_cl type of scale
+ * @param y (Sequence of) scalar(s).
+ * @param mu (Sequence of) location(s).
+ * @param sigma (Sequence of) scale(s).
+ * @return The log of the product of densities.
+ */
+template <
+    typename T_y_cl, typename T_loc_cl, typename T_scale_cl,
+    require_all_prim_or_rev_kernel_expression_t<T_y_cl, T_loc_cl,
+                                                T_scale_cl>* = nullptr,
+    require_any_not_stan_scalar_t<T_y_cl, T_loc_cl, T_scale_cl>* = nullptr>
+return_type_t<T_y_cl, T_loc_cl, T_scale_cl> double_exponential_lcdf(
+    const T_y_cl& y, const T_loc_cl& mu, const T_scale_cl& sigma) {
+  static const char* function = "double_exponential_lcdf(OpenCL)";
+  using T_partials_return = partials_return_t<T_y_cl, T_loc_cl, T_scale_cl>;
+  using std::isfinite;
+  using std::isnan;
+
+  check_consistent_sizes(function, "Random variable", y, "Location parameter",
+                         mu, "Scale parameter", sigma);
+  const size_t N = max_size(y, mu, sigma);
+  if (N == 0) {
+    return 0.0;
+  }
+
+  const auto& y_col = as_column_vector_or_scalar(y);
+  const auto& mu_col = as_column_vector_or_scalar(mu);
+  const auto& sigma_col = as_column_vector_or_scalar(sigma);
+
+  const auto& y_val = value_of(y_col);
+  const auto& mu_val = value_of(mu_col);
+  const auto& sigma_val = value_of(sigma_col);
+
+  auto check_y_not_nan
+      = check_cl(function, "Random variable", y_val, "not NaN");
+  auto y_not_nan_expr = !isnan(y_val);
+  auto check_mu_finite
+      = check_cl(function, "Location parameter", mu_val, "finite");
+  auto mu_finite_expr = isfinite(mu_val);
+  auto check_sigma_positive_finite
+      = check_cl(function, "Scale parameter", sigma_val, "positive finite");
+  auto sigma_positive_finite_expr = 0 < sigma_val && isfinite(sigma_val);
+
+  auto sigma_inv = elt_divide(1.0, sigma_val);
+  auto scaled_diff = elt_multiply(y_val - mu_val, sigma_inv);
+  auto cond = y_val < mu_val;
+  auto y_deriv = select(cond, sigma_inv,
+                        elt_divide(sigma_inv, 2.0 * exp(scaled_diff) - 1.0));
+  auto cdf_log_expr = colwise_sum(
+      select(cond, LOG_HALF + scaled_diff, log1m(0.5 * exp(-scaled_diff))));
+  auto mu_deriv = -y_deriv;
+  auto sigma_deriv = elt_multiply(mu_deriv, scaled_diff);
+
+  matrix_cl<double> cdf_log_cl;
+  matrix_cl<double> mu_deriv_cl;
+  matrix_cl<double> y_deriv_cl;
+  matrix_cl<double> sigma_deriv_cl;
+
+  results(check_y_not_nan, check_mu_finite, check_sigma_positive_finite,
+          cdf_log_cl, y_deriv_cl, mu_deriv_cl, sigma_deriv_cl)
+      = expressions(y_not_nan_expr, mu_finite_expr, sigma_positive_finite_expr,
+                    cdf_log_expr, calc_if<!is_constant<T_y_cl>::value>(y_deriv),
+                    calc_if<!is_constant<T_loc_cl>::value>(mu_deriv),
+                    calc_if<!is_constant<T_scale_cl>::value>(sigma_deriv));
+
+  T_partials_return cdf_log = (from_matrix_cl(cdf_log_cl)).sum();
+
+  operands_and_partials<decltype(y_col), decltype(mu_col), decltype(sigma_col)>
+      ops_partials(y_col, mu_col, sigma_col);
+
+  if (!is_constant<T_y_cl>::value) {
+    ops_partials.edge1_.partials_ = std::move(y_deriv_cl);
+  }
+  if (!is_constant<T_loc_cl>::value) {
+    ops_partials.edge2_.partials_ = std::move(mu_deriv_cl);
+  }
+  if (!is_constant<T_scale_cl>::value) {
+    ops_partials.edge3_.partials_ = std::move(sigma_deriv_cl);
+  }
+  return ops_partials.build(cdf_log);
+}
+
+}  // namespace math
+}  // namespace stan
+#endif
+#endif

--- a/stan/math/opencl/prim/exp_mod_normal_cdf.hpp
+++ b/stan/math/opencl/prim/exp_mod_normal_cdf.hpp
@@ -1,0 +1,168 @@
+#ifndef STAN_MATH_OPENCL_PRIM_DOUBLE_EXP_MOD_NORMAL_CDF_HPP
+#define STAN_MATH_OPENCL_PRIM_DOUBLE_EXP_MOD_NORMAL_CDF_HPP
+#ifdef STAN_OPENCL
+
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/err.hpp>
+#include <stan/math/prim/fun/constants.hpp>
+#include <stan/math/prim/fun/elt_divide.hpp>
+#include <stan/math/prim/fun/elt_multiply.hpp>
+#include <stan/math/opencl/kernel_generator.hpp>
+#include <stan/math/prim/functor/operands_and_partials.hpp>
+
+namespace stan {
+namespace math {
+
+/** \ingroup opencl
+ * Returns the double exponential cumulative density function. Given
+ * containers of matching sizes, returns the product of probabilities.
+ *
+ * @tparam T_y_cl type of scalar outcome
+ * @tparam T_loc_cl type of location
+ * @tparam T_scale_cl type of scale
+ * @param y (Sequence of) scalar(s).
+ * @param mu (Sequence of) location(s).
+ * @param sigma (Sequence of) scale(s).
+ * @return The log of the product of densities.
+ */
+template <typename T_y_cl, typename T_loc_cl, typename T_scale_cl,
+          typename T_inv_scale_cl,
+          require_all_prim_or_rev_kernel_expression_t<
+              T_y_cl, T_loc_cl, T_scale_cl, T_inv_scale_cl>* = nullptr,
+          require_any_not_stan_scalar_t<T_y_cl, T_loc_cl, T_scale_cl,
+                                        T_inv_scale_cl>* = nullptr>
+return_type_t<T_y_cl, T_loc_cl, T_scale_cl, T_inv_scale_cl> exp_mod_normal_cdf(
+    const T_y_cl& y, const T_loc_cl& mu, const T_scale_cl& sigma,
+    const T_inv_scale_cl& lambda) {
+  static const char* function = "exp_mod_normal_cdf(OpenCL)";
+  using T_partials_return
+      = partials_return_t<T_y_cl, T_loc_cl, T_scale_cl, T_inv_scale_cl>;
+  using std::isfinite;
+  using std::isnan;
+
+  check_consistent_sizes(function, "Random variable", y, "Location parameter",
+                         mu, "Scale parameter", sigma);
+  const size_t N = max_size(y, mu, sigma);
+  if (N == 0) {
+    return 1.0;
+  }
+
+  const auto& y_col = as_column_vector_or_scalar(y);
+  const auto& mu_col = as_column_vector_or_scalar(mu);
+  const auto& sigma_col = as_column_vector_or_scalar(sigma);
+  const auto& lambda_col = as_column_vector_or_scalar(lambda);
+
+  const auto& y_val = value_of(y_col);
+  const auto& mu_val = value_of(mu_col);
+  const auto& sigma_val = value_of(sigma_col);
+  const auto& lambda_val = value_of(lambda_col);
+
+  auto check_y_not_nan
+      = check_cl(function, "Random variable", y_val, "not NaN");
+  auto y_not_nan_expr = !isnan(y_val);
+  auto check_mu_finite
+      = check_cl(function, "Location parameter", mu_val, "finite");
+  auto mu_finite_expr = isfinite(mu_val);
+  auto check_sigma_positive_finite
+      = check_cl(function, "Scale parameter", sigma_val, "positive finite");
+  auto sigma_positive_finite_expr = 0 < sigma_val && isfinite(sigma_val);
+  auto check_lambda_positive_finite
+      = check_cl(function, "Inv_cale parameter", lambda_val, "positive finite");
+  auto lambda_positive_finite_expr = 0 < lambda_val && isfinite(lambda_val);
+
+  auto any_y_neg_inf
+      = colwise_max(constant(0, N, 1) + (y_val == NEGATIVE_INFTY));
+  auto inv_sigma = elt_divide(1.0, sigma_val);
+  auto diff = y_val - mu_val;
+  auto v = elt_multiply(lambda_val, sigma_val);
+  auto scaled_diff = elt_multiply(diff, inv_sigma * INV_SQRT_TWO);
+  auto scaled_diff_diff = scaled_diff - v * INV_SQRT_TWO;
+  auto erf_calc = 0.5 * (1.0 + erf(scaled_diff_diff));
+  auto exp_term = exp(0.5 * square(v) - elt_multiply(lambda_val, diff));
+  auto cdf_n = 0.5 + 0.5 * erf(scaled_diff) - elt_multiply(exp_term, erf_calc);
+  auto cdf_expr = colwise_prod(cdf_n);
+
+  auto exp_term_2 = exp(-square(scaled_diff_diff));
+  auto deriv_1 = elt_multiply(elt_multiply(lambda_val, exp_term), erf_calc);
+  auto deriv_2 = INV_SQRT_TWO_PI
+                 * elt_multiply(elt_multiply(exp_term, exp_term_2), inv_sigma);
+  auto deriv_3
+      = INV_SQRT_TWO_PI * elt_multiply(exp(-square(scaled_diff)), inv_sigma);
+  auto mu_deriv1 = elt_divide(deriv_2 - deriv_1 - deriv_3, cdf_n);
+  auto sigma_deriv1 = elt_divide(
+      -elt_multiply(deriv_1 - deriv_2, v)
+          + elt_multiply(deriv_3 - deriv_2, scaled_diff) * SQRT_TWO,
+      cdf_n);
+  auto lambda_deriv1 = elt_divide(
+      elt_multiply(
+          exp_term,
+          INV_SQRT_TWO_PI * elt_multiply(sigma_val, exp_term_2)
+              - elt_multiply(elt_multiply(v, sigma_val) - diff, erf_calc)),
+      cdf_n);
+
+  matrix_cl<double> any_y_neg_inf_cl;
+  matrix_cl<double> cdf_cl;
+  matrix_cl<double> y_deriv_cl;
+  matrix_cl<double> mu_deriv_cl;
+  matrix_cl<double> sigma_deriv_cl;
+  matrix_cl<double> lambda_deriv_cl;
+
+  results(check_y_not_nan, check_mu_finite, check_sigma_positive_finite,
+          check_lambda_positive_finite, any_y_neg_inf_cl, cdf_cl, y_deriv_cl,
+          mu_deriv_cl, sigma_deriv_cl, lambda_deriv_cl)
+      = expressions(
+          y_not_nan_expr, mu_finite_expr, sigma_positive_finite_expr,
+          lambda_positive_finite_expr, any_y_neg_inf, cdf_expr,
+          calc_if<!is_constant_all<T_y_cl, T_loc_cl, T_scale_cl,
+                                   T_inv_scale_cl>::value>(cdf_n),
+          calc_if<!is_constant_all<T_y_cl, T_loc_cl>::value>(mu_deriv1),
+          calc_if<!is_constant<T_scale_cl>::value>(sigma_deriv1),
+          calc_if<!is_constant<T_inv_scale_cl>::value>(lambda_deriv1));
+
+  if(from_matrix_cl(any_y_neg_inf_cl).maxCoeff()){
+    return 0.0;
+  }
+
+  T_partials_return cdf = (from_matrix_cl(cdf_cl)).prod();
+
+  operands_and_partials<decltype(y_col), decltype(mu_col), decltype(sigma_col),
+                        decltype(lambda_col)>
+      ops_partials(y_col, mu_col, sigma_col, lambda_col);
+  if (!is_constant_all<T_y_cl, T_loc_cl, T_scale_cl, T_inv_scale_cl>::value) {
+    auto mu_deriv = elt_multiply(
+        static_select<is_constant_all<T_y_cl, T_loc_cl>::value>(0, mu_deriv_cl),
+        cdf);
+    auto y_deriv = -mu_deriv;
+    auto sigma_deriv = elt_multiply(
+        static_select<is_constant<T_scale_cl>::value>(0, sigma_deriv_cl), cdf);
+    auto lambda_deriv = elt_multiply(
+        static_select<is_constant<T_inv_scale_cl>::value>(0, lambda_deriv_cl),
+        cdf);
+
+    results(y_deriv_cl, mu_deriv_cl, sigma_deriv_cl, lambda_deriv_cl)
+        = expressions(
+            calc_if<!is_constant<T_y_cl>::value>(y_deriv),
+            calc_if<!is_constant<T_loc_cl>::value>(mu_deriv),
+            calc_if<!is_constant<T_scale_cl>::value>(sigma_deriv),
+            calc_if<!is_constant<T_inv_scale_cl>::value>(lambda_deriv));
+
+    if (!is_constant<T_y_cl>::value) {
+      ops_partials.edge1_.partials_ = std::move(y_deriv_cl);
+    }
+    if (!is_constant<T_loc_cl>::value) {
+      ops_partials.edge2_.partials_ = std::move(mu_deriv_cl);
+    }
+    if (!is_constant<T_scale_cl>::value) {
+      ops_partials.edge3_.partials_ = std::move(sigma_deriv_cl);
+    }
+    if (!is_constant<T_inv_scale_cl>::value) {
+      ops_partials.edge4_.partials_ = std::move(lambda_deriv_cl);
+    }
+  }
+  return ops_partials.build(cdf);
+}
+
+}  // namespace math
+}  // namespace stan
+#endif
+#endif

--- a/stan/math/opencl/prim/exp_mod_normal_cdf.hpp
+++ b/stan/math/opencl/prim/exp_mod_normal_cdf.hpp
@@ -20,9 +20,11 @@ namespace math {
  * @tparam T_y_cl type of scalar outcome
  * @tparam T_loc_cl type of location
  * @tparam T_scale_cl type of scale
+ * @tparam T_inv_scale_cl type of inverse scale
  * @param y (Sequence of) scalar(s).
  * @param mu (Sequence of) location(s).
  * @param sigma (Sequence of) scale(s).
+ * @param lambda (Sequence of) inverse scale(s).
  * @return The log of the product of densities.
  */
 template <typename T_y_cl, typename T_loc_cl, typename T_scale_cl,

--- a/stan/math/opencl/prim/exp_mod_normal_cdf.hpp
+++ b/stan/math/opencl/prim/exp_mod_normal_cdf.hpp
@@ -119,7 +119,7 @@ return_type_t<T_y_cl, T_loc_cl, T_scale_cl, T_inv_scale_cl> exp_mod_normal_cdf(
           calc_if<!is_constant<T_scale_cl>::value>(sigma_deriv1),
           calc_if<!is_constant<T_inv_scale_cl>::value>(lambda_deriv1));
 
-  if(from_matrix_cl(any_y_neg_inf_cl).maxCoeff()){
+  if (from_matrix_cl(any_y_neg_inf_cl).maxCoeff()) {
     return 0.0;
   }
 

--- a/stan/math/opencl/prim/exp_mod_normal_lccdf.hpp
+++ b/stan/math/opencl/prim/exp_mod_normal_lccdf.hpp
@@ -25,7 +25,7 @@ namespace math {
  * @param y (Sequence of) scalar(s).
  * @param mu (Sequence of) location(s).
  * @param sigma (Sequence of) scale(s).
- * @param sigma (Sequence of) inverse scale(s).
+ * @param lambda (Sequence of) inverse scale(s).
  * @return The log of the product of densities.
  */
 template <typename T_y_cl, typename T_loc_cl, typename T_scale_cl,

--- a/stan/math/opencl/prim/exp_mod_normal_lccdf.hpp
+++ b/stan/math/opencl/prim/exp_mod_normal_lccdf.hpp
@@ -1,0 +1,158 @@
+#ifndef STAN_MATH_OPENCL_PRIM_DOUBLE_EXP_MOD_NORMAL_LCCDF_HPP
+#define STAN_MATH_OPENCL_PRIM_DOUBLE_EXP_MOD_NORMAL_LCCDF_HPP
+#ifdef STAN_OPENCL
+
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/err.hpp>
+#include <stan/math/prim/fun/constants.hpp>
+#include <stan/math/prim/fun/elt_divide.hpp>
+#include <stan/math/prim/fun/elt_multiply.hpp>
+#include <stan/math/opencl/kernel_generator.hpp>
+#include <stan/math/prim/functor/operands_and_partials.hpp>
+
+namespace stan {
+namespace math {
+
+/** \ingroup opencl
+ * Returns the exp mod normal log complementary cumulative density
+ * function. Given containers of matching sizes, returns the log sum of
+ * probabilities.
+ *
+ * @tparam T_y_cl type of scalar outcome
+ * @tparam T_loc_cl type of location
+ * @tparam T_scale_cl type of scale
+ * @tparam T_inv_scale_cl type of inverse scale
+ * @param y (Sequence of) scalar(s).
+ * @param mu (Sequence of) location(s).
+ * @param sigma (Sequence of) scale(s).
+ * @param sigma (Sequence of) inverse scale(s).
+ * @return The log of the product of densities.
+ */
+template <typename T_y_cl, typename T_loc_cl, typename T_scale_cl,
+          typename T_inv_scale_cl,
+          require_all_prim_or_rev_kernel_expression_t<
+              T_y_cl, T_loc_cl, T_scale_cl, T_inv_scale_cl>* = nullptr,
+          require_any_not_stan_scalar_t<T_y_cl, T_loc_cl, T_scale_cl,
+                                        T_inv_scale_cl>* = nullptr>
+return_type_t<T_y_cl, T_loc_cl, T_scale_cl, T_inv_scale_cl>
+exp_mod_normal_lccdf(const T_y_cl& y, const T_loc_cl& mu,
+                     const T_scale_cl& sigma, const T_inv_scale_cl& lambda) {
+  static const char* function = "exp_mod_normal_lccdf(OpenCL)";
+  using T_partials_return
+      = partials_return_t<T_y_cl, T_loc_cl, T_scale_cl, T_inv_scale_cl>;
+  using std::isfinite;
+  using std::isnan;
+
+  check_consistent_sizes(function, "Random variable", y, "Location parameter",
+                         mu, "Scale parameter", sigma);
+  const size_t N = max_size(y, mu, sigma);
+  if (N == 0) {
+    return 0.0;
+  }
+
+  const auto& y_col = as_column_vector_or_scalar(y);
+  const auto& mu_col = as_column_vector_or_scalar(mu);
+  const auto& sigma_col = as_column_vector_or_scalar(sigma);
+  const auto& lambda_col = as_column_vector_or_scalar(lambda);
+
+  const auto& y_val = value_of(y_col);
+  const auto& mu_val = value_of(mu_col);
+  const auto& sigma_val = value_of(sigma_col);
+  const auto& lambda_val = value_of(lambda_col);
+
+  auto check_y_not_nan
+      = check_cl(function, "Random variable", y_val, "not NaN");
+  auto y_not_nan_expr = !isnan(y_val);
+  auto check_mu_finite
+      = check_cl(function, "Location parameter", mu_val, "finite");
+  auto mu_finite_expr = isfinite(mu_val);
+  auto check_sigma_positive_finite
+      = check_cl(function, "Scale parameter", sigma_val, "positive finite");
+  auto sigma_positive_finite_expr = 0 < sigma_val && isfinite(sigma_val);
+  auto check_lambda_positive_finite
+      = check_cl(function, "Inv_cale parameter", lambda_val, "positive finite");
+  auto lambda_positive_finite_expr = 0 < lambda_val && isfinite(lambda_val);
+
+  auto any_y_neg_inf
+      = colwise_max(constant(0, N, 1) + (y_val == NEGATIVE_INFTY));
+  auto any_y_pos_inf = colwise_max(constant(0, N, 1) + (y_val == INFTY));
+  auto inv_sigma = elt_divide(1.0, sigma_val);
+  auto diff = y_val - mu_val;
+  auto scaled_diff = elt_multiply(diff, inv_sigma * INV_SQRT_TWO);
+  auto v = elt_multiply(lambda_val, sigma_val);
+  auto scaled_diff_diff = scaled_diff - v * INV_SQRT_TWO;
+  auto erf_calc = 0.5 * (1.0 + erf(scaled_diff_diff));
+  auto exp_term = exp(0.5 * square(v) - elt_multiply(lambda_val, diff));
+  auto ccdf_n = 0.5 - 0.5 * erf(scaled_diff) + elt_multiply(exp_term, erf_calc);
+  auto ccdf_log_expr = colwise_sum(log(ccdf_n));
+
+  auto exp_term_2 = exp(-square(scaled_diff_diff));
+  auto deriv_1 = elt_multiply(elt_multiply(lambda_val, exp_term), erf_calc);
+  auto deriv_2 = INV_SQRT_TWO_PI
+                 * elt_multiply(elt_multiply(exp_term, exp_term_2), inv_sigma);
+  auto deriv_3
+      = INV_SQRT_TWO_PI * elt_multiply(exp(-square(scaled_diff)), inv_sigma);
+  auto mu_deriv = elt_divide(deriv_1 - deriv_2 + deriv_3, ccdf_n);
+  auto y_deriv = -mu_deriv;
+  auto sigma_deriv = elt_divide(
+      elt_multiply(deriv_1 - deriv_2, v)
+          + elt_multiply(deriv_3 - deriv_2, scaled_diff) * SQRT_TWO,
+      ccdf_n);
+  auto lambda_deriv = elt_divide(
+      elt_multiply(exp_term,
+                   elt_multiply(elt_multiply(v, sigma_val) - diff, erf_calc)
+                       - INV_SQRT_TWO_PI * elt_multiply(sigma_val, exp_term_2)),
+      ccdf_n);
+
+  matrix_cl<double> any_y_neg_inf_cl;
+  matrix_cl<double> any_y_pos_inf_cl;
+  matrix_cl<double> ccdf_log_cl;
+  matrix_cl<double> mu_deriv_cl;
+  matrix_cl<double> y_deriv_cl;
+  matrix_cl<double> sigma_deriv_cl;
+  matrix_cl<double> lambda_deriv_cl;
+
+  results(check_y_not_nan, check_mu_finite, check_sigma_positive_finite,
+          check_lambda_positive_finite, any_y_neg_inf_cl, any_y_pos_inf_cl,
+          ccdf_log_cl, y_deriv_cl, mu_deriv_cl, sigma_deriv_cl, lambda_deriv_cl)
+      = expressions(y_not_nan_expr, mu_finite_expr, sigma_positive_finite_expr,
+                    lambda_positive_finite_expr, any_y_neg_inf, any_y_pos_inf,
+                    ccdf_log_expr,
+                    calc_if<!is_constant<T_y_cl>::value>(y_deriv),
+                    calc_if<!is_constant<T_loc_cl>::value>(mu_deriv),
+                    calc_if<!is_constant<T_scale_cl>::value>(sigma_deriv),
+                    calc_if<!is_constant<T_inv_scale_cl>::value>(lambda_deriv));
+
+  if (from_matrix_cl(any_y_pos_inf_cl).maxCoeff()) {
+    return NEGATIVE_INFTY;
+  }
+
+  if (from_matrix_cl(any_y_neg_inf_cl).maxCoeff()) {
+    return 0.0;
+  }
+
+  T_partials_return ccdf_log = (from_matrix_cl(ccdf_log_cl)).sum();
+
+  operands_and_partials<decltype(y_col), decltype(mu_col), decltype(sigma_col),
+                        decltype(lambda_col)>
+      ops_partials(y_col, mu_col, sigma_col, lambda_col);
+
+  if (!is_constant<T_y_cl>::value) {
+    ops_partials.edge1_.partials_ = std::move(y_deriv_cl);
+  }
+  if (!is_constant<T_loc_cl>::value) {
+    ops_partials.edge2_.partials_ = std::move(mu_deriv_cl);
+  }
+  if (!is_constant<T_scale_cl>::value) {
+    ops_partials.edge3_.partials_ = std::move(sigma_deriv_cl);
+  }
+  if (!is_constant<T_inv_scale_cl>::value) {
+    ops_partials.edge4_.partials_ = std::move(lambda_deriv_cl);
+  }
+  return ops_partials.build(ccdf_log);
+}
+
+}  // namespace math
+}  // namespace stan
+#endif
+#endif

--- a/stan/math/opencl/prim/exp_mod_normal_lcdf.hpp
+++ b/stan/math/opencl/prim/exp_mod_normal_lcdf.hpp
@@ -1,0 +1,158 @@
+#ifndef STAN_MATH_OPENCL_PRIM_DOUBLE_EXP_MOD_NORMAL_LCDF_HPP
+#define STAN_MATH_OPENCL_PRIM_DOUBLE_EXP_MOD_NORMAL_LCDF_HPP
+#ifdef STAN_OPENCL
+
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/err.hpp>
+#include <stan/math/prim/fun/constants.hpp>
+#include <stan/math/prim/fun/elt_divide.hpp>
+#include <stan/math/prim/fun/elt_multiply.hpp>
+#include <stan/math/opencl/kernel_generator.hpp>
+#include <stan/math/prim/functor/operands_and_partials.hpp>
+
+namespace stan {
+namespace math {
+
+/** \ingroup opencl
+ * Returns the exp mod normal log cumulative density
+ * function. Given containers of matching sizes, returns the log sum of
+ * probabilities.
+ *
+ * @tparam T_y_cl type of scalar outcome
+ * @tparam T_loc_cl type of location
+ * @tparam T_scale_cl type of scale
+ * @tparam T_inv_scale_cl type of inverse scale
+ * @param y (Sequence of) scalar(s).
+ * @param mu (Sequence of) location(s).
+ * @param sigma (Sequence of) scale(s).
+ * @param sigma (Sequence of) inverse scale(s).
+ * @return The log of the product of densities.
+ */
+template <typename T_y_cl, typename T_loc_cl, typename T_scale_cl,
+          typename T_inv_scale_cl,
+          require_all_prim_or_rev_kernel_expression_t<
+              T_y_cl, T_loc_cl, T_scale_cl, T_inv_scale_cl>* = nullptr,
+          require_any_not_stan_scalar_t<T_y_cl, T_loc_cl, T_scale_cl,
+                                        T_inv_scale_cl>* = nullptr>
+return_type_t<T_y_cl, T_loc_cl, T_scale_cl, T_inv_scale_cl> exp_mod_normal_lcdf(
+    const T_y_cl& y, const T_loc_cl& mu, const T_scale_cl& sigma,
+    const T_inv_scale_cl& lambda) {
+  static const char* function = "exp_mod_normal_lcdf(OpenCL)";
+  using T_partials_return
+      = partials_return_t<T_y_cl, T_loc_cl, T_scale_cl, T_inv_scale_cl>;
+  using std::isfinite;
+  using std::isnan;
+
+  check_consistent_sizes(function, "Random variable", y, "Location parameter",
+                         mu, "Scale parameter", sigma);
+  const size_t N = max_size(y, mu, sigma);
+  if (N == 0) {
+    return 0.0;
+  }
+
+  const auto& y_col = as_column_vector_or_scalar(y);
+  const auto& mu_col = as_column_vector_or_scalar(mu);
+  const auto& sigma_col = as_column_vector_or_scalar(sigma);
+  const auto& lambda_col = as_column_vector_or_scalar(lambda);
+
+  const auto& y_val = value_of(y_col);
+  const auto& mu_val = value_of(mu_col);
+  const auto& sigma_val = value_of(sigma_col);
+  const auto& lambda_val = value_of(lambda_col);
+
+  auto check_y_not_nan
+      = check_cl(function, "Random variable", y_val, "not NaN");
+  auto y_not_nan_expr = !isnan(y_val);
+  auto check_mu_finite
+      = check_cl(function, "Location parameter", mu_val, "finite");
+  auto mu_finite_expr = isfinite(mu_val);
+  auto check_sigma_positive_finite
+      = check_cl(function, "Scale parameter", sigma_val, "positive finite");
+  auto sigma_positive_finite_expr = 0 < sigma_val && isfinite(sigma_val);
+  auto check_lambda_positive_finite
+      = check_cl(function, "Inv_cale parameter", lambda_val, "positive finite");
+  auto lambda_positive_finite_expr = 0 < lambda_val && isfinite(lambda_val);
+
+  auto any_y_neg_inf
+      = colwise_max(constant(0, N, 1) + (y_val == NEGATIVE_INFTY));
+  auto any_y_pos_inf = colwise_max(constant(0, N, 1) + (y_val == INFTY));
+  auto sigma_inv = elt_divide(1.0, sigma_val);
+  auto diff = y_val - mu_val;
+  auto scaled_diff = elt_multiply(diff * INV_SQRT_TWO, sigma_inv);
+  auto v = elt_multiply(lambda_val, sigma_val);
+  auto scaled_diff_diff = scaled_diff - v * INV_SQRT_TWO;
+  auto erf_calc = 0.5 * (1.0 + erf(scaled_diff_diff));
+  auto exp_term = exp(0.5 * square(v) - elt_multiply(lambda_val, diff));
+  auto cdf_n = 0.5 + 0.5 * erf(scaled_diff) - elt_multiply(exp_term, erf_calc);
+  auto cdf_log_expr = colwise_sum(log(cdf_n));
+
+  auto exp_term_2 = exp(-square(scaled_diff_diff));
+  auto deriv_1 = elt_multiply(elt_multiply(lambda_val, exp_term), erf_calc);
+  auto deriv_2 = INV_SQRT_TWO_PI
+                 * elt_multiply(elt_multiply(exp_term, exp_term_2), sigma_inv);
+  auto deriv_3
+      = INV_SQRT_TWO_PI * elt_multiply(exp(-square(scaled_diff)), sigma_inv);
+  auto y_deriv = elt_divide(deriv_1 - deriv_2 + deriv_3, cdf_n);
+  auto mu_deriv = -y_deriv;
+  auto sigma_deriv = -elt_divide(
+      elt_multiply(deriv_1 - deriv_2, v)
+          + elt_multiply(deriv_3 - deriv_2, scaled_diff) * SQRT_TWO,
+      cdf_n);
+  auto lambda_deriv = elt_divide(
+      elt_multiply(
+          exp_term,
+          INV_SQRT_TWO_PI * elt_multiply(sigma_val, exp_term_2)
+              - elt_multiply(elt_multiply(v, sigma_val) - diff, erf_calc)),
+      cdf_n);
+
+  matrix_cl<double> any_y_neg_inf_cl;
+  matrix_cl<double> any_y_pos_inf_cl;
+  matrix_cl<double> cdf_log_cl;
+  matrix_cl<double> mu_deriv_cl;
+  matrix_cl<double> y_deriv_cl;
+  matrix_cl<double> sigma_deriv_cl;
+  matrix_cl<double> lambda_deriv_cl;
+
+  results(check_y_not_nan, check_mu_finite, check_sigma_positive_finite,
+          check_lambda_positive_finite, any_y_neg_inf_cl, any_y_pos_inf_cl,
+          cdf_log_cl, y_deriv_cl, mu_deriv_cl, sigma_deriv_cl, lambda_deriv_cl)
+      = expressions(y_not_nan_expr, mu_finite_expr, sigma_positive_finite_expr,
+                    lambda_positive_finite_expr, any_y_neg_inf, any_y_pos_inf,
+                    cdf_log_expr, calc_if<!is_constant<T_y_cl>::value>(y_deriv),
+                    calc_if<!is_constant<T_loc_cl>::value>(mu_deriv),
+                    calc_if<!is_constant<T_scale_cl>::value>(sigma_deriv),
+                    calc_if<!is_constant<T_inv_scale_cl>::value>(lambda_deriv));
+
+  if (from_matrix_cl(any_y_pos_inf_cl).maxCoeff()) {
+    return 0.0;
+  }
+
+  if (from_matrix_cl(any_y_neg_inf_cl).maxCoeff()) {
+    return NEGATIVE_INFTY;
+  }
+
+  T_partials_return cdf_log = (from_matrix_cl(cdf_log_cl)).sum();
+
+  operands_and_partials<decltype(y_col), decltype(mu_col), decltype(sigma_col),
+                        decltype(lambda_col)>
+      ops_partials(y_col, mu_col, sigma_col, lambda_col);
+
+  if (!is_constant<T_y_cl>::value) {
+    ops_partials.edge1_.partials_ = std::move(y_deriv_cl);
+  }
+  if (!is_constant<T_loc_cl>::value) {
+    ops_partials.edge2_.partials_ = std::move(mu_deriv_cl);
+  }
+  if (!is_constant<T_scale_cl>::value) {
+    ops_partials.edge3_.partials_ = std::move(sigma_deriv_cl);
+  }
+  if (!is_constant<T_inv_scale_cl>::value) {
+    ops_partials.edge4_.partials_ = std::move(lambda_deriv_cl);
+  }
+  return ops_partials.build(cdf_log);
+}
+
+}  // namespace math
+}  // namespace stan
+#endif
+#endif

--- a/stan/math/opencl/prim/exp_mod_normal_lcdf.hpp
+++ b/stan/math/opencl/prim/exp_mod_normal_lcdf.hpp
@@ -25,7 +25,7 @@ namespace math {
  * @param y (Sequence of) scalar(s).
  * @param mu (Sequence of) location(s).
  * @param sigma (Sequence of) scale(s).
- * @param sigma (Sequence of) inverse scale(s).
+ * @param lambda (Sequence of) inverse scale(s).
  * @return The log of the product of densities.
  */
 template <typename T_y_cl, typename T_loc_cl, typename T_scale_cl,

--- a/stan/math/prim/prob/double_exponential_cdf.hpp
+++ b/stan/math/prim/prob/double_exponential_cdf.hpp
@@ -33,7 +33,9 @@ namespace math {
  * @throw std::domain_error if y is nan, mu is infinite,
  *  or sigma is nonpositive
  */
-template <typename T_y, typename T_loc, typename T_scale>
+template <typename T_y, typename T_loc, typename T_scale,
+          require_all_not_nonscalar_prim_or_rev_kernel_expression_t<
+              T_y, T_loc, T_scale>* = nullptr>
 return_type_t<T_y, T_loc, T_scale> double_exponential_cdf(
     const T_y& y, const T_loc& mu, const T_scale& sigma) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale>;

--- a/stan/math/prim/prob/double_exponential_lccdf.hpp
+++ b/stan/math/prim/prob/double_exponential_lccdf.hpp
@@ -32,7 +32,9 @@ namespace math {
  * @throw std::domain_error if y is nan, mu is infinite, or sigma is nonpositive
  * @throw std::invalid_argument if container sizes mismatch
  */
-template <typename T_y, typename T_loc, typename T_scale>
+template <typename T_y, typename T_loc, typename T_scale,
+          require_all_not_nonscalar_prim_or_rev_kernel_expression_t<
+              T_y, T_loc, T_scale>* = nullptr>
 return_type_t<T_y, T_loc, T_scale> double_exponential_lccdf(
     const T_y& y, const T_loc& mu, const T_scale& sigma) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale>;

--- a/stan/math/prim/prob/double_exponential_lcdf.hpp
+++ b/stan/math/prim/prob/double_exponential_lcdf.hpp
@@ -31,7 +31,9 @@ namespace math {
  * @throw std::domain_error if y is nan, mu is infinite, or sigma is nonpositive
  * @throw std::invalid_argument if container sizes mismatch
  */
-template <typename T_y, typename T_loc, typename T_scale>
+template <typename T_y, typename T_loc, typename T_scale,
+          require_all_not_nonscalar_prim_or_rev_kernel_expression_t<
+              T_y, T_loc, T_scale>* = nullptr>
 return_type_t<T_y, T_loc, T_scale> double_exponential_lcdf(
     const T_y& y, const T_loc& mu, const T_scale& sigma) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale>;

--- a/stan/math/prim/prob/exp_mod_normal_cdf.hpp
+++ b/stan/math/prim/prob/exp_mod_normal_cdf.hpp
@@ -23,7 +23,9 @@
 namespace stan {
 namespace math {
 
-template <typename T_y, typename T_loc, typename T_scale, typename T_inv_scale>
+template <typename T_y, typename T_loc, typename T_scale, typename T_inv_scale,
+          require_all_not_nonscalar_prim_or_rev_kernel_expression_t<
+              T_y, T_loc, T_scale, T_inv_scale>* = nullptr>
 return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_cdf(
     const T_y& y, const T_loc& mu, const T_scale& sigma,
     const T_inv_scale& lambda) {

--- a/stan/math/prim/prob/exp_mod_normal_lccdf.hpp
+++ b/stan/math/prim/prob/exp_mod_normal_lccdf.hpp
@@ -25,7 +25,9 @@
 namespace stan {
 namespace math {
 
-template <typename T_y, typename T_loc, typename T_scale, typename T_inv_scale>
+template <typename T_y, typename T_loc, typename T_scale, typename T_inv_scale,
+          require_all_not_nonscalar_prim_or_rev_kernel_expression_t<
+              T_y, T_loc, T_scale, T_inv_scale>* = nullptr>
 return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_lccdf(
     const T_y& y, const T_loc& mu, const T_scale& sigma,
     const T_inv_scale& lambda) {

--- a/stan/math/prim/prob/exp_mod_normal_lcdf.hpp
+++ b/stan/math/prim/prob/exp_mod_normal_lcdf.hpp
@@ -25,7 +25,9 @@
 namespace stan {
 namespace math {
 
-template <typename T_y, typename T_loc, typename T_scale, typename T_inv_scale>
+template <typename T_y, typename T_loc, typename T_scale, typename T_inv_scale,
+          require_all_not_nonscalar_prim_or_rev_kernel_expression_t<
+              T_y, T_loc, T_scale, T_inv_scale>* = nullptr>
 return_type_t<T_y, T_loc, T_scale, T_inv_scale> exp_mod_normal_lcdf(
     const T_y& y, const T_loc& mu, const T_scale& sigma,
     const T_inv_scale& lambda) {

--- a/test/unit/math/opencl/rev/double_exponential_cdf_test.cpp
+++ b/test/unit/math/opencl/rev/double_exponential_cdf_test.cpp
@@ -56,9 +56,10 @@ TEST(ProbDistributionsDoubleExponentialCdf, error_checking) {
                std::domain_error);
 }
 
-auto double_exponential_cdf_functor = [](const auto& y, const auto& mu, const auto& sigma) {
-  return stan::math::double_exponential_cdf(y, mu, sigma);
-};
+auto double_exponential_cdf_functor
+    = [](const auto& y, const auto& mu, const auto& sigma) {
+        return stan::math::double_exponential_cdf(y, mu, sigma);
+      };
 
 TEST(ProbDistributionsDoubleExponentialCdf, opencl_matches_cpu_small) {
   int N = 3;
@@ -71,11 +72,11 @@ TEST(ProbDistributionsDoubleExponentialCdf, opencl_matches_cpu_small) {
   Eigen::VectorXd sigma(N);
   sigma << 0.3, 0.8, 1.0;
 
-  stan::math::test::compare_cpu_opencl_prim_rev(double_exponential_cdf_functor, y, mu,
-                                                sigma);
+  stan::math::test::compare_cpu_opencl_prim_rev(double_exponential_cdf_functor,
+                                                y, mu, sigma);
   stan::math::test::compare_cpu_opencl_prim_rev(
-      double_exponential_cdf_functor, y.transpose().eval(), mu.transpose().eval(),
-      sigma.transpose().eval());
+      double_exponential_cdf_functor, y.transpose().eval(),
+      mu.transpose().eval(), sigma.transpose().eval());
 }
 
 TEST(ProbDistributionsDoubleExponentialCdf, opencl_broadcast_y) {
@@ -87,8 +88,8 @@ TEST(ProbDistributionsDoubleExponentialCdf, opencl_broadcast_y) {
   Eigen::VectorXd sigma(N);
   sigma << 0.3, 0.8, 1.0;
 
-  stan::math::test::test_opencl_broadcasting_prim_rev<0>(double_exponential_cdf_functor,
-                                                         y_scal, mu, sigma);
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(
+      double_exponential_cdf_functor, y_scal, mu, sigma);
   stan::math::test::test_opencl_broadcasting_prim_rev<0>(
       double_exponential_cdf_functor, y_scal, mu.transpose().eval(), sigma);
 }
@@ -102,8 +103,8 @@ TEST(ProbDistributionsDoubleExponentialCdf, opencl_broadcast_mu) {
   Eigen::VectorXd sigma(N);
   sigma << 0.3, 0.8, 1.0;
 
-  stan::math::test::test_opencl_broadcasting_prim_rev<1>(double_exponential_cdf_functor, y,
-                                                         mu_scal, sigma);
+  stan::math::test::test_opencl_broadcasting_prim_rev<1>(
+      double_exponential_cdf_functor, y, mu_scal, sigma);
   stan::math::test::test_opencl_broadcasting_prim_rev<1>(
       double_exponential_cdf_functor, y.transpose().eval(), mu_scal, sigma);
 }
@@ -117,8 +118,8 @@ TEST(ProbDistributionsDoubleExponentialCdf, opencl_broadcast_sigma) {
   mu << 0.3, 0.8, 1.0;
   double sigma_scal = 12.3;
 
-  stan::math::test::test_opencl_broadcasting_prim_rev<2>(double_exponential_cdf_functor, y,
-                                                         mu, sigma_scal);
+  stan::math::test::test_opencl_broadcasting_prim_rev<2>(
+      double_exponential_cdf_functor, y, mu, sigma_scal);
   stan::math::test::test_opencl_broadcasting_prim_rev<2>(
       double_exponential_cdf_functor, y.transpose().eval(), mu, sigma_scal);
 }
@@ -133,11 +134,11 @@ TEST(ProbDistributionsDoubleExponentialCdf, opencl_matches_cpu_big) {
   Eigen::Matrix<double, Eigen::Dynamic, 1> sigma
       = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
 
-  stan::math::test::compare_cpu_opencl_prim_rev(double_exponential_cdf_functor, y, mu,
-                                                sigma);
+  stan::math::test::compare_cpu_opencl_prim_rev(double_exponential_cdf_functor,
+                                                y, mu, sigma);
   stan::math::test::compare_cpu_opencl_prim_rev(
-      double_exponential_cdf_functor, y.transpose().eval(), mu.transpose().eval(),
-      sigma.transpose().eval());
+      double_exponential_cdf_functor, y.transpose().eval(),
+      mu.transpose().eval(), sigma.transpose().eval());
 }
 
 #endif

--- a/test/unit/math/opencl/rev/double_exponential_cdf_test.cpp
+++ b/test/unit/math/opencl/rev/double_exponential_cdf_test.cpp
@@ -1,0 +1,143 @@
+#ifdef STAN_OPENCL
+#include <stan/math/opencl/rev.hpp>
+#include <stan/math.hpp>
+#include <gtest/gtest.h>
+#include <test/unit/math/opencl/util.hpp>
+#include <vector>
+
+TEST(ProbDistributionsDoubleExponentialCdf, error_checking) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  Eigen::VectorXd y_size(N - 1);
+  y_size << 0.3, 0.8;
+  Eigen::VectorXd y_value(N);
+  y_value << 0.3, NAN, 0.5;
+
+  Eigen::VectorXd mu(N);
+  mu << 0.3, 0.8, 1.0;
+  Eigen::VectorXd mu_size(N - 1);
+  mu_size << 0.3, 0.8;
+  Eigen::VectorXd mu_value(N);
+  mu_value << 0.3, -INFINITY, 0.5;
+
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+  Eigen::VectorXd sigma_size(N - 1);
+  sigma_size << 0.3, 0.8;
+  Eigen::VectorXd sigma_value(N);
+  sigma_value << 0.3, 0, 0.5;
+
+  stan::math::matrix_cl<double> y_cl(y);
+  stan::math::matrix_cl<double> y_size_cl(y_size);
+  stan::math::matrix_cl<double> y_value_cl(y_value);
+  stan::math::matrix_cl<double> mu_cl(mu);
+  stan::math::matrix_cl<double> mu_size_cl(mu_size);
+  stan::math::matrix_cl<double> mu_value_cl(mu_value);
+  stan::math::matrix_cl<double> sigma_cl(sigma);
+  stan::math::matrix_cl<double> sigma_size_cl(sigma_size);
+  stan::math::matrix_cl<double> sigma_value_cl(sigma_value);
+
+  EXPECT_NO_THROW(stan::math::double_exponential_cdf(y_cl, mu_cl, sigma_cl));
+
+  EXPECT_THROW(stan::math::double_exponential_cdf(y_size_cl, mu_cl, sigma_cl),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::double_exponential_cdf(y_cl, mu_size_cl, sigma_cl),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::double_exponential_cdf(y_cl, mu_cl, sigma_size_cl),
+               std::invalid_argument);
+
+  EXPECT_THROW(stan::math::double_exponential_cdf(y_value_cl, mu_cl, sigma_cl),
+               std::domain_error);
+  EXPECT_THROW(stan::math::double_exponential_cdf(y_cl, mu_value_cl, sigma_cl),
+               std::domain_error);
+  EXPECT_THROW(stan::math::double_exponential_cdf(y_cl, mu_cl, sigma_value_cl),
+               std::domain_error);
+}
+
+auto double_exponential_cdf_functor = [](const auto& y, const auto& mu, const auto& sigma) {
+  return stan::math::double_exponential_cdf(y, mu, sigma);
+};
+
+TEST(ProbDistributionsDoubleExponentialCdf, opencl_matches_cpu_small) {
+  int N = 3;
+  int M = 2;
+
+  Eigen::VectorXd y(N);
+  y << -0.3, 1.8, 1.4;
+  Eigen::VectorXd mu(N);
+  mu << 0.3, 0.8, 1.0;
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+
+  stan::math::test::compare_cpu_opencl_prim_rev(double_exponential_cdf_functor, y, mu,
+                                                sigma);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      double_exponential_cdf_functor, y.transpose().eval(), mu.transpose().eval(),
+      sigma.transpose().eval());
+}
+
+TEST(ProbDistributionsDoubleExponentialCdf, opencl_broadcast_y) {
+  int N = 3;
+
+  double y_scal = 12.3;
+  Eigen::VectorXd mu(N);
+  mu << 0.5, 1.2, 1.0;
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(double_exponential_cdf_functor,
+                                                         y_scal, mu, sigma);
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(
+      double_exponential_cdf_functor, y_scal, mu.transpose().eval(), sigma);
+}
+
+TEST(ProbDistributionsDoubleExponentialCdf, opencl_broadcast_mu) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  double mu_scal = 12.3;
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<1>(double_exponential_cdf_functor, y,
+                                                         mu_scal, sigma);
+  stan::math::test::test_opencl_broadcasting_prim_rev<1>(
+      double_exponential_cdf_functor, y.transpose().eval(), mu_scal, sigma);
+}
+
+TEST(ProbDistributionsDoubleExponentialCdf, opencl_broadcast_sigma) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  Eigen::VectorXd mu(N);
+  mu << 0.3, 0.8, 1.0;
+  double sigma_scal = 12.3;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<2>(double_exponential_cdf_functor, y,
+                                                         mu, sigma_scal);
+  stan::math::test::test_opencl_broadcasting_prim_rev<2>(
+      double_exponential_cdf_functor, y.transpose().eval(), mu, sigma_scal);
+}
+
+TEST(ProbDistributionsDoubleExponentialCdf, opencl_matches_cpu_big) {
+  int N = 153;
+
+  Eigen::Matrix<double, Eigen::Dynamic, 1> y
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+  Eigen::Matrix<double, Eigen::Dynamic, 1> mu
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+  Eigen::Matrix<double, Eigen::Dynamic, 1> sigma
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+
+  stan::math::test::compare_cpu_opencl_prim_rev(double_exponential_cdf_functor, y, mu,
+                                                sigma);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      double_exponential_cdf_functor, y.transpose().eval(), mu.transpose().eval(),
+      sigma.transpose().eval());
+}
+
+#endif

--- a/test/unit/math/opencl/rev/double_exponential_lccdf_test.cpp
+++ b/test/unit/math/opencl/rev/double_exponential_lccdf_test.cpp
@@ -1,0 +1,142 @@
+#ifdef STAN_OPENCL
+#include <stan/math/opencl/rev.hpp>
+#include <stan/math.hpp>
+#include <gtest/gtest.h>
+#include <test/unit/math/opencl/util.hpp>
+#include <vector>
+
+TEST(ProbDistributionsDoubleExponentialLccdf, error_checking) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  Eigen::VectorXd y_size(N - 1);
+  y_size << 0.3, 0.8;
+  Eigen::VectorXd y_value(N);
+  y_value << 0.3, NAN, 0.5;
+
+  Eigen::VectorXd mu(N);
+  mu << 0.3, 0.8, 1.0;
+  Eigen::VectorXd mu_size(N - 1);
+  mu_size << 0.3, 0.8;
+  Eigen::VectorXd mu_value(N);
+  mu_value << 0.3, -INFINITY, 0.5;
+
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+  Eigen::VectorXd sigma_size(N - 1);
+  sigma_size << 0.3, 0.8;
+  Eigen::VectorXd sigma_value(N);
+  sigma_value << 0.3, 0, 0.5;
+
+  stan::math::matrix_cl<double> y_cl(y);
+  stan::math::matrix_cl<double> y_size_cl(y_size);
+  stan::math::matrix_cl<double> y_value_cl(y_value);
+  stan::math::matrix_cl<double> mu_cl(mu);
+  stan::math::matrix_cl<double> mu_size_cl(mu_size);
+  stan::math::matrix_cl<double> mu_value_cl(mu_value);
+  stan::math::matrix_cl<double> sigma_cl(sigma);
+  stan::math::matrix_cl<double> sigma_size_cl(sigma_size);
+  stan::math::matrix_cl<double> sigma_value_cl(sigma_value);
+
+  EXPECT_NO_THROW(stan::math::double_exponential_lccdf(y_cl, mu_cl, sigma_cl));
+
+  EXPECT_THROW(stan::math::double_exponential_lccdf(y_size_cl, mu_cl, sigma_cl),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::double_exponential_lccdf(y_cl, mu_size_cl, sigma_cl),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::double_exponential_lccdf(y_cl, mu_cl, sigma_size_cl),
+               std::invalid_argument);
+
+  EXPECT_THROW(stan::math::double_exponential_lccdf(y_value_cl, mu_cl, sigma_cl),
+               std::domain_error);
+  EXPECT_THROW(stan::math::double_exponential_lccdf(y_cl, mu_value_cl, sigma_cl),
+               std::domain_error);
+  EXPECT_THROW(stan::math::double_exponential_lccdf(y_cl, mu_cl, sigma_value_cl),
+               std::domain_error);
+}
+
+auto double_exponential_lccdf_functor = [](const auto& y, const auto& mu, const auto& sigma) {
+  return stan::math::double_exponential_lccdf(y, mu, sigma);
+};
+
+TEST(ProbDistributionsDoubleExponentialLccdf, opencl_matches_cpu_small) {
+  int N = 3;
+  int M = 2;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 2.8, 1.0;
+  Eigen::VectorXd mu(N);
+  mu << -0.3, 0.8, 1.4;
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+
+  stan::math::test::compare_cpu_opencl_prim_rev(double_exponential_lccdf_functor, y, mu,
+                                                sigma);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      double_exponential_lccdf_functor, y.transpose().eval(), mu.transpose().eval(),
+      sigma.transpose().eval());
+}
+
+TEST(ProbDistributionsDoubleExponentialLccdf, opencl_broadcast_y) {
+  int N = 3;
+
+  double y_scal = 12.3;
+  Eigen::VectorXd mu(N);
+  mu << 0.5, 1.2, 1.0;
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(double_exponential_lccdf_functor,
+                                                         y_scal, mu, sigma);
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(
+      double_exponential_lccdf_functor, y_scal, mu.transpose().eval(), sigma);
+}
+
+TEST(ProbDistributionsDoubleExponentialLccdf, opencl_broadcast_mu) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  double mu_scal = 12.3;
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<1>(double_exponential_lccdf_functor, y,
+                                                         mu_scal, sigma);
+  stan::math::test::test_opencl_broadcasting_prim_rev<1>(
+      double_exponential_lccdf_functor, y.transpose().eval(), mu_scal, sigma);
+}
+
+TEST(ProbDistributionsDoubleExponentialLccdf, opencl_broadcast_sigma) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  Eigen::VectorXd mu(N);
+  mu << 0.3, 0.8, 1.0;
+  double sigma_scal = 12.3;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<2>(double_exponential_lccdf_functor, y,
+                                                         mu, sigma_scal);
+  stan::math::test::test_opencl_broadcasting_prim_rev<2>(
+      double_exponential_lccdf_functor, y.transpose().eval(), mu, sigma_scal);
+}
+
+TEST(ProbDistributionsDoubleExponentialLccdf, opencl_matches_cpu_big) {
+  int N = 153;
+
+  Eigen::Matrix<double, Eigen::Dynamic, 1> y
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+  Eigen::Matrix<double, Eigen::Dynamic, 1> mu
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+  Eigen::Matrix<double, Eigen::Dynamic, 1> sigma
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+
+  stan::math::test::compare_cpu_opencl_prim_rev(double_exponential_lccdf_functor, y, mu,
+                                                sigma);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      double_exponential_lccdf_functor, y.transpose().eval(), mu.transpose().eval(),
+      sigma.transpose().eval());
+}
+#endif

--- a/test/unit/math/opencl/rev/double_exponential_lccdf_test.cpp
+++ b/test/unit/math/opencl/rev/double_exponential_lccdf_test.cpp
@@ -48,17 +48,21 @@ TEST(ProbDistributionsDoubleExponentialLccdf, error_checking) {
   EXPECT_THROW(stan::math::double_exponential_lccdf(y_cl, mu_cl, sigma_size_cl),
                std::invalid_argument);
 
-  EXPECT_THROW(stan::math::double_exponential_lccdf(y_value_cl, mu_cl, sigma_cl),
-               std::domain_error);
-  EXPECT_THROW(stan::math::double_exponential_lccdf(y_cl, mu_value_cl, sigma_cl),
-               std::domain_error);
-  EXPECT_THROW(stan::math::double_exponential_lccdf(y_cl, mu_cl, sigma_value_cl),
-               std::domain_error);
+  EXPECT_THROW(
+      stan::math::double_exponential_lccdf(y_value_cl, mu_cl, sigma_cl),
+      std::domain_error);
+  EXPECT_THROW(
+      stan::math::double_exponential_lccdf(y_cl, mu_value_cl, sigma_cl),
+      std::domain_error);
+  EXPECT_THROW(
+      stan::math::double_exponential_lccdf(y_cl, mu_cl, sigma_value_cl),
+      std::domain_error);
 }
 
-auto double_exponential_lccdf_functor = [](const auto& y, const auto& mu, const auto& sigma) {
-  return stan::math::double_exponential_lccdf(y, mu, sigma);
-};
+auto double_exponential_lccdf_functor
+    = [](const auto& y, const auto& mu, const auto& sigma) {
+        return stan::math::double_exponential_lccdf(y, mu, sigma);
+      };
 
 TEST(ProbDistributionsDoubleExponentialLccdf, opencl_matches_cpu_small) {
   int N = 3;
@@ -71,11 +75,11 @@ TEST(ProbDistributionsDoubleExponentialLccdf, opencl_matches_cpu_small) {
   Eigen::VectorXd sigma(N);
   sigma << 0.3, 0.8, 1.0;
 
-  stan::math::test::compare_cpu_opencl_prim_rev(double_exponential_lccdf_functor, y, mu,
-                                                sigma);
   stan::math::test::compare_cpu_opencl_prim_rev(
-      double_exponential_lccdf_functor, y.transpose().eval(), mu.transpose().eval(),
-      sigma.transpose().eval());
+      double_exponential_lccdf_functor, y, mu, sigma);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      double_exponential_lccdf_functor, y.transpose().eval(),
+      mu.transpose().eval(), sigma.transpose().eval());
 }
 
 TEST(ProbDistributionsDoubleExponentialLccdf, opencl_broadcast_y) {
@@ -87,8 +91,8 @@ TEST(ProbDistributionsDoubleExponentialLccdf, opencl_broadcast_y) {
   Eigen::VectorXd sigma(N);
   sigma << 0.3, 0.8, 1.0;
 
-  stan::math::test::test_opencl_broadcasting_prim_rev<0>(double_exponential_lccdf_functor,
-                                                         y_scal, mu, sigma);
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(
+      double_exponential_lccdf_functor, y_scal, mu, sigma);
   stan::math::test::test_opencl_broadcasting_prim_rev<0>(
       double_exponential_lccdf_functor, y_scal, mu.transpose().eval(), sigma);
 }
@@ -102,8 +106,8 @@ TEST(ProbDistributionsDoubleExponentialLccdf, opencl_broadcast_mu) {
   Eigen::VectorXd sigma(N);
   sigma << 0.3, 0.8, 1.0;
 
-  stan::math::test::test_opencl_broadcasting_prim_rev<1>(double_exponential_lccdf_functor, y,
-                                                         mu_scal, sigma);
+  stan::math::test::test_opencl_broadcasting_prim_rev<1>(
+      double_exponential_lccdf_functor, y, mu_scal, sigma);
   stan::math::test::test_opencl_broadcasting_prim_rev<1>(
       double_exponential_lccdf_functor, y.transpose().eval(), mu_scal, sigma);
 }
@@ -117,8 +121,8 @@ TEST(ProbDistributionsDoubleExponentialLccdf, opencl_broadcast_sigma) {
   mu << 0.3, 0.8, 1.0;
   double sigma_scal = 12.3;
 
-  stan::math::test::test_opencl_broadcasting_prim_rev<2>(double_exponential_lccdf_functor, y,
-                                                         mu, sigma_scal);
+  stan::math::test::test_opencl_broadcasting_prim_rev<2>(
+      double_exponential_lccdf_functor, y, mu, sigma_scal);
   stan::math::test::test_opencl_broadcasting_prim_rev<2>(
       double_exponential_lccdf_functor, y.transpose().eval(), mu, sigma_scal);
 }
@@ -133,10 +137,10 @@ TEST(ProbDistributionsDoubleExponentialLccdf, opencl_matches_cpu_big) {
   Eigen::Matrix<double, Eigen::Dynamic, 1> sigma
       = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
 
-  stan::math::test::compare_cpu_opencl_prim_rev(double_exponential_lccdf_functor, y, mu,
-                                                sigma);
   stan::math::test::compare_cpu_opencl_prim_rev(
-      double_exponential_lccdf_functor, y.transpose().eval(), mu.transpose().eval(),
-      sigma.transpose().eval());
+      double_exponential_lccdf_functor, y, mu, sigma);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      double_exponential_lccdf_functor, y.transpose().eval(),
+      mu.transpose().eval(), sigma.transpose().eval());
 }
 #endif

--- a/test/unit/math/opencl/rev/double_exponential_lcdf_test.cpp
+++ b/test/unit/math/opencl/rev/double_exponential_lcdf_test.cpp
@@ -56,9 +56,10 @@ TEST(ProbDistributionsDoubleExponentialLcdf, error_checking) {
                std::domain_error);
 }
 
-auto double_exponential_lcdf_functor = [](const auto& y, const auto& mu, const auto& sigma) {
-  return stan::math::double_exponential_lcdf(y, mu, sigma);
-};
+auto double_exponential_lcdf_functor
+    = [](const auto& y, const auto& mu, const auto& sigma) {
+        return stan::math::double_exponential_lcdf(y, mu, sigma);
+      };
 
 TEST(ProbDistributionsDoubleExponentialLcdf, opencl_matches_cpu_small) {
   int N = 3;
@@ -71,11 +72,11 @@ TEST(ProbDistributionsDoubleExponentialLcdf, opencl_matches_cpu_small) {
   Eigen::VectorXd sigma(N);
   sigma << 0.3, 0.8, 1.0;
 
-  stan::math::test::compare_cpu_opencl_prim_rev(double_exponential_lcdf_functor, y, mu,
-                                                sigma);
+  stan::math::test::compare_cpu_opencl_prim_rev(double_exponential_lcdf_functor,
+                                                y, mu, sigma);
   stan::math::test::compare_cpu_opencl_prim_rev(
-      double_exponential_lcdf_functor, y.transpose().eval(), mu.transpose().eval(),
-      sigma.transpose().eval());
+      double_exponential_lcdf_functor, y.transpose().eval(),
+      mu.transpose().eval(), sigma.transpose().eval());
 }
 
 TEST(ProbDistributionsDoubleExponentialLcdf, opencl_broadcast_y) {
@@ -87,8 +88,8 @@ TEST(ProbDistributionsDoubleExponentialLcdf, opencl_broadcast_y) {
   Eigen::VectorXd sigma(N);
   sigma << 0.3, 0.8, 1.0;
 
-  stan::math::test::test_opencl_broadcasting_prim_rev<0>(double_exponential_lcdf_functor,
-                                                         y_scal, mu, sigma);
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(
+      double_exponential_lcdf_functor, y_scal, mu, sigma);
   stan::math::test::test_opencl_broadcasting_prim_rev<0>(
       double_exponential_lcdf_functor, y_scal, mu.transpose().eval(), sigma);
 }
@@ -102,8 +103,8 @@ TEST(ProbDistributionsDoubleExponentialLcdf, opencl_broadcast_mu) {
   Eigen::VectorXd sigma(N);
   sigma << 0.3, 0.8, 1.0;
 
-  stan::math::test::test_opencl_broadcasting_prim_rev<1>(double_exponential_lcdf_functor, y,
-                                                         mu_scal, sigma);
+  stan::math::test::test_opencl_broadcasting_prim_rev<1>(
+      double_exponential_lcdf_functor, y, mu_scal, sigma);
   stan::math::test::test_opencl_broadcasting_prim_rev<1>(
       double_exponential_lcdf_functor, y.transpose().eval(), mu_scal, sigma);
 }
@@ -117,8 +118,8 @@ TEST(ProbDistributionsDoubleExponentialLcdf, opencl_broadcast_sigma) {
   mu << 0.3, 0.8, 1.0;
   double sigma_scal = 12.3;
 
-  stan::math::test::test_opencl_broadcasting_prim_rev<2>(double_exponential_lcdf_functor, y,
-                                                         mu, sigma_scal);
+  stan::math::test::test_opencl_broadcasting_prim_rev<2>(
+      double_exponential_lcdf_functor, y, mu, sigma_scal);
   stan::math::test::test_opencl_broadcasting_prim_rev<2>(
       double_exponential_lcdf_functor, y.transpose().eval(), mu, sigma_scal);
 }
@@ -133,10 +134,10 @@ TEST(ProbDistributionsDoubleExponentialLcdf, opencl_matches_cpu_big) {
   Eigen::Matrix<double, Eigen::Dynamic, 1> sigma
       = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
 
-  stan::math::test::compare_cpu_opencl_prim_rev(double_exponential_lcdf_functor, y, mu,
-                                                sigma);
+  stan::math::test::compare_cpu_opencl_prim_rev(double_exponential_lcdf_functor,
+                                                y, mu, sigma);
   stan::math::test::compare_cpu_opencl_prim_rev(
-      double_exponential_lcdf_functor, y.transpose().eval(), mu.transpose().eval(),
-      sigma.transpose().eval());
+      double_exponential_lcdf_functor, y.transpose().eval(),
+      mu.transpose().eval(), sigma.transpose().eval());
 }
 #endif

--- a/test/unit/math/opencl/rev/double_exponential_lcdf_test.cpp
+++ b/test/unit/math/opencl/rev/double_exponential_lcdf_test.cpp
@@ -1,0 +1,142 @@
+#ifdef STAN_OPENCL
+#include <stan/math/opencl/rev.hpp>
+#include <stan/math.hpp>
+#include <gtest/gtest.h>
+#include <test/unit/math/opencl/util.hpp>
+#include <vector>
+
+TEST(ProbDistributionsDoubleExponentialLcdf, error_checking) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  Eigen::VectorXd y_size(N - 1);
+  y_size << 0.3, 0.8;
+  Eigen::VectorXd y_value(N);
+  y_value << 0.3, NAN, 0.5;
+
+  Eigen::VectorXd mu(N);
+  mu << 0.3, 0.8, 1.0;
+  Eigen::VectorXd mu_size(N - 1);
+  mu_size << 0.3, 0.8;
+  Eigen::VectorXd mu_value(N);
+  mu_value << 0.3, -INFINITY, 0.5;
+
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+  Eigen::VectorXd sigma_size(N - 1);
+  sigma_size << 0.3, 0.8;
+  Eigen::VectorXd sigma_value(N);
+  sigma_value << 0.3, 0, 0.5;
+
+  stan::math::matrix_cl<double> y_cl(y);
+  stan::math::matrix_cl<double> y_size_cl(y_size);
+  stan::math::matrix_cl<double> y_value_cl(y_value);
+  stan::math::matrix_cl<double> mu_cl(mu);
+  stan::math::matrix_cl<double> mu_size_cl(mu_size);
+  stan::math::matrix_cl<double> mu_value_cl(mu_value);
+  stan::math::matrix_cl<double> sigma_cl(sigma);
+  stan::math::matrix_cl<double> sigma_size_cl(sigma_size);
+  stan::math::matrix_cl<double> sigma_value_cl(sigma_value);
+
+  EXPECT_NO_THROW(stan::math::double_exponential_lcdf(y_cl, mu_cl, sigma_cl));
+
+  EXPECT_THROW(stan::math::double_exponential_lcdf(y_size_cl, mu_cl, sigma_cl),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::double_exponential_lcdf(y_cl, mu_size_cl, sigma_cl),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::double_exponential_lcdf(y_cl, mu_cl, sigma_size_cl),
+               std::invalid_argument);
+
+  EXPECT_THROW(stan::math::double_exponential_lcdf(y_value_cl, mu_cl, sigma_cl),
+               std::domain_error);
+  EXPECT_THROW(stan::math::double_exponential_lcdf(y_cl, mu_value_cl, sigma_cl),
+               std::domain_error);
+  EXPECT_THROW(stan::math::double_exponential_lcdf(y_cl, mu_cl, sigma_value_cl),
+               std::domain_error);
+}
+
+auto double_exponential_lcdf_functor = [](const auto& y, const auto& mu, const auto& sigma) {
+  return stan::math::double_exponential_lcdf(y, mu, sigma);
+};
+
+TEST(ProbDistributionsDoubleExponentialLcdf, opencl_matches_cpu_small) {
+  int N = 3;
+  int M = 2;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.7;
+  Eigen::VectorXd mu(N);
+  mu << 0.5, -0.8, 1.0;
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+
+  stan::math::test::compare_cpu_opencl_prim_rev(double_exponential_lcdf_functor, y, mu,
+                                                sigma);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      double_exponential_lcdf_functor, y.transpose().eval(), mu.transpose().eval(),
+      sigma.transpose().eval());
+}
+
+TEST(ProbDistributionsDoubleExponentialLcdf, opencl_broadcast_y) {
+  int N = 3;
+
+  double y_scal = 12.3;
+  Eigen::VectorXd mu(N);
+  mu << 0.5, 1.2, 1.0;
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(double_exponential_lcdf_functor,
+                                                         y_scal, mu, sigma);
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(
+      double_exponential_lcdf_functor, y_scal, mu.transpose().eval(), sigma);
+}
+
+TEST(ProbDistributionsDoubleExponentialLcdf, opencl_broadcast_mu) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  double mu_scal = 12.3;
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<1>(double_exponential_lcdf_functor, y,
+                                                         mu_scal, sigma);
+  stan::math::test::test_opencl_broadcasting_prim_rev<1>(
+      double_exponential_lcdf_functor, y.transpose().eval(), mu_scal, sigma);
+}
+
+TEST(ProbDistributionsDoubleExponentialLcdf, opencl_broadcast_sigma) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  Eigen::VectorXd mu(N);
+  mu << 0.3, 0.8, 1.0;
+  double sigma_scal = 12.3;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<2>(double_exponential_lcdf_functor, y,
+                                                         mu, sigma_scal);
+  stan::math::test::test_opencl_broadcasting_prim_rev<2>(
+      double_exponential_lcdf_functor, y.transpose().eval(), mu, sigma_scal);
+}
+
+TEST(ProbDistributionsDoubleExponentialLcdf, opencl_matches_cpu_big) {
+  int N = 153;
+
+  Eigen::Matrix<double, Eigen::Dynamic, 1> y
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+  Eigen::Matrix<double, Eigen::Dynamic, 1> mu
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+  Eigen::Matrix<double, Eigen::Dynamic, 1> sigma
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+
+  stan::math::test::compare_cpu_opencl_prim_rev(double_exponential_lcdf_functor, y, mu,
+                                                sigma);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      double_exponential_lcdf_functor, y.transpose().eval(), mu.transpose().eval(),
+      sigma.transpose().eval());
+}
+#endif

--- a/test/unit/math/opencl/rev/exp_mod_normal_cdf2_test.cpp
+++ b/test/unit/math/opencl/rev/exp_mod_normal_cdf2_test.cpp
@@ -1,0 +1,49 @@
+#ifdef STAN_OPENCL
+#include <stan/math/opencl/rev.hpp>
+#include <stan/math.hpp>
+#include <gtest/gtest.h>
+#include <test/unit/math/opencl/util.hpp>
+#include <vector>
+
+auto exp_mod_normal_cdf_functor
+    = [](const auto& y, const auto& mu, const auto& sigma, const auto& lambda) {
+        return stan::math::exp_mod_normal_cdf(y, mu, sigma, lambda);
+      };
+
+TEST(ProbDistributionsDoubleExpModNormalCdf, opencl_broadcast_sigma) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  Eigen::VectorXd mu(N);
+  mu << 0.3, 0.8, 1.0;
+  double sigma_scal = 12.3;
+  Eigen::VectorXd lambda(N);
+  lambda << 0.3, 0.4, 1.1;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<2>(
+      exp_mod_normal_cdf_functor, y, mu, sigma_scal, lambda);
+  stan::math::test::test_opencl_broadcasting_prim_rev<2>(
+      exp_mod_normal_cdf_functor, y.transpose().eval(), mu, sigma_scal,
+      lambda.transpose().eval());
+}
+
+TEST(ProbDistributionsDoubleExpModNormalCdf, opencl_broadcast_lambda) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  Eigen::VectorXd mu(N);
+  mu << 0.3, 0.8, 1.0;
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.4, 1.1;
+  double lambda_scal = 12.3;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<3>(
+      exp_mod_normal_cdf_functor, y, mu, sigma, lambda_scal);
+  stan::math::test::test_opencl_broadcasting_prim_rev<3>(
+      exp_mod_normal_cdf_functor, y.transpose().eval(), mu,
+      sigma.transpose().eval(), lambda_scal);
+}
+
+#endif

--- a/test/unit/math/opencl/rev/exp_mod_normal_cdf_test.cpp
+++ b/test/unit/math/opencl/rev/exp_mod_normal_cdf_test.cpp
@@ -1,0 +1,182 @@
+#ifdef STAN_OPENCL
+#include <stan/math/opencl/rev.hpp>
+#include <stan/math.hpp>
+#include <gtest/gtest.h>
+#include <test/unit/math/opencl/util.hpp>
+#include <vector>
+
+TEST(ProbDistributionsDoubleExpModNormalCdf, error_checking) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  Eigen::VectorXd y_size(N - 1);
+  y_size << 0.3, 0.8;
+  Eigen::VectorXd y_value(N);
+  y_value << 0.3, NAN, 0.5;
+
+  Eigen::VectorXd mu(N);
+  mu << 0.3, 0.8, 1.0;
+  Eigen::VectorXd mu_size(N - 1);
+  mu_size << 0.3, 0.8;
+  Eigen::VectorXd mu_value(N);
+  mu_value << 0.3, -INFINITY, 0.5;
+
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+  Eigen::VectorXd sigma_size(N - 1);
+  sigma_size << 0.3, 0.8;
+  Eigen::VectorXd sigma_value(N);
+  sigma_value << 0.3, 0, 0.5;
+
+  Eigen::VectorXd lambda(N);
+  lambda << 0.4, 0.4, 1.4;
+  Eigen::VectorXd lambda_size(N - 1);
+  lambda_size << 0.3, 0.8;
+  Eigen::VectorXd lambda_value(N);
+  lambda_value << 0.3, 0, 0.5;
+
+  stan::math::matrix_cl<double> y_cl(y);
+  stan::math::matrix_cl<double> y_size_cl(y_size);
+  stan::math::matrix_cl<double> y_value_cl(y_value);
+  stan::math::matrix_cl<double> mu_cl(mu);
+  stan::math::matrix_cl<double> mu_size_cl(mu_size);
+  stan::math::matrix_cl<double> mu_value_cl(mu_value);
+  stan::math::matrix_cl<double> sigma_cl(sigma);
+  stan::math::matrix_cl<double> sigma_size_cl(sigma_size);
+  stan::math::matrix_cl<double> sigma_value_cl(sigma_value);
+  stan::math::matrix_cl<double> lambda_cl(lambda);
+  stan::math::matrix_cl<double> lambda_size_cl(lambda_size);
+  stan::math::matrix_cl<double> lambda_value_cl(lambda_value);
+
+  EXPECT_NO_THROW(
+      stan::math::exp_mod_normal_cdf(y_cl, mu_cl, sigma_cl, lambda_cl));
+
+  EXPECT_THROW(
+      stan::math::exp_mod_normal_cdf(y_size_cl, mu_cl, sigma_cl, lambda_cl),
+      std::invalid_argument);
+  EXPECT_THROW(
+      stan::math::exp_mod_normal_cdf(y_cl, mu_size_cl, sigma_cl, lambda_cl),
+      std::invalid_argument);
+  EXPECT_THROW(
+      stan::math::exp_mod_normal_cdf(y_cl, mu_cl, sigma_size_cl, lambda_cl),
+      std::invalid_argument);
+  EXPECT_THROW(
+      stan::math::exp_mod_normal_cdf(y_cl, mu_cl, sigma_cl, lambda_size_cl),
+      std::invalid_argument);
+
+  EXPECT_THROW(
+      stan::math::exp_mod_normal_cdf(y_value_cl, mu_cl, sigma_cl, lambda_cl),
+      std::domain_error);
+  EXPECT_THROW(
+      stan::math::exp_mod_normal_cdf(y_cl, mu_value_cl, sigma_cl, lambda_cl),
+      std::domain_error);
+  EXPECT_THROW(
+      stan::math::exp_mod_normal_cdf(y_cl, mu_cl, sigma_value_cl, lambda_cl),
+      std::domain_error);
+  EXPECT_THROW(
+      stan::math::exp_mod_normal_cdf(y_cl, mu_cl, sigma_cl, lambda_value_cl),
+      std::domain_error);
+}
+
+auto exp_mod_normal_cdf_functor
+    = [](const auto& y, const auto& mu, const auto& sigma, const auto& lambda) {
+        return stan::math::exp_mod_normal_cdf(y, mu, sigma, lambda);
+      };
+
+TEST(ProbDistributionsDoubleExpModNormalCdf, opencl_matches_cpu_small) {
+  int N = 3;
+  int M = 2;
+
+  Eigen::VectorXd y(N);
+  y << -0.3, 1.8, 1.4;
+  Eigen::VectorXd mu(N);
+  mu << 0.3, 0.8, 1.0;
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+  Eigen::VectorXd lambda(N);
+  lambda << 0.3, 0.4, 1.1;
+
+  stan::math::test::compare_cpu_opencl_prim_rev(exp_mod_normal_cdf_functor, y,
+                                                mu, sigma, lambda);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      exp_mod_normal_cdf_functor, y.transpose().eval(), mu.transpose().eval(),
+      sigma.transpose().eval(), lambda.transpose().eval());
+}
+
+TEST(ProbDistributionsDoubleExpModNormalCdf, opencl_matches_cpu_small_y_neg_inf) {
+  int N = 3;
+  int M = 2;
+
+  Eigen::VectorXd y(N);
+  y << -INFINITY, 1.8, 1.4;
+  Eigen::VectorXd mu(N);
+  mu << 0.3, 0.8, 1.0;
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+  Eigen::VectorXd lambda(N);
+  lambda << 0.3, 0.4, 1.1;
+
+  stan::math::test::compare_cpu_opencl_prim_rev(exp_mod_normal_cdf_functor, y,
+                                                mu, sigma, lambda);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      exp_mod_normal_cdf_functor, y.transpose().eval(), mu.transpose().eval(),
+      sigma.transpose().eval(), lambda.transpose().eval());
+}
+
+TEST(ProbDistributionsDoubleExpModNormalCdf, opencl_broadcast_y) {
+  int N = 3;
+
+  double y_scal = 12.3;
+  Eigen::VectorXd mu(N);
+  mu << 0.5, 1.2, 1.0;
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+  Eigen::VectorXd lambda(N);
+  lambda << 0.3, 0.4, 1.1;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(
+      exp_mod_normal_cdf_functor, y_scal, mu, sigma, lambda);
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(
+      exp_mod_normal_cdf_functor, y_scal, mu.transpose().eval(), sigma,
+      lambda.transpose().eval());
+}
+
+TEST(ProbDistributionsDoubleExpModNormalCdf, opencl_broadcast_mu) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  double mu_scal = 12.3;
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+  Eigen::VectorXd lambda(N);
+  lambda << 0.3, 0.4, 1.1;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<1>(
+      exp_mod_normal_cdf_functor, y, mu_scal, sigma, lambda);
+  stan::math::test::test_opencl_broadcasting_prim_rev<1>(
+      exp_mod_normal_cdf_functor, y.transpose().eval(), mu_scal, sigma,
+      lambda.transpose().eval());
+}
+
+TEST(ProbDistributionsDoubleExpModNormalCdf, opencl_matches_cpu_big) {
+  int N = 153;
+
+  Eigen::Matrix<double, Eigen::Dynamic, 1> y
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+  Eigen::Matrix<double, Eigen::Dynamic, 1> mu
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+  Eigen::Matrix<double, Eigen::Dynamic, 1> sigma
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+  Eigen::Matrix<double, Eigen::Dynamic, 1> lambda
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+
+  stan::math::test::compare_cpu_opencl_prim_rev(exp_mod_normal_cdf_functor, y,
+                                                mu, sigma, lambda);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      exp_mod_normal_cdf_functor, y.transpose().eval(), mu.transpose().eval(),
+      sigma.transpose().eval(), lambda.transpose().eval());
+}
+
+#endif

--- a/test/unit/math/opencl/rev/exp_mod_normal_cdf_test.cpp
+++ b/test/unit/math/opencl/rev/exp_mod_normal_cdf_test.cpp
@@ -169,7 +169,7 @@ TEST(ProbDistributionsDoubleExpModNormalCdf, opencl_matches_cpu_big) {
   Eigen::Matrix<double, Eigen::Dynamic, 1> mu
       = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
   Eigen::Matrix<double, Eigen::Dynamic, 1> sigma
-      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs().array() + 0.1;
   Eigen::Matrix<double, Eigen::Dynamic, 1> lambda
       = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
 

--- a/test/unit/math/opencl/rev/exp_mod_normal_cdf_test.cpp
+++ b/test/unit/math/opencl/rev/exp_mod_normal_cdf_test.cpp
@@ -104,7 +104,8 @@ TEST(ProbDistributionsDoubleExpModNormalCdf, opencl_matches_cpu_small) {
       sigma.transpose().eval(), lambda.transpose().eval());
 }
 
-TEST(ProbDistributionsDoubleExpModNormalCdf, opencl_matches_cpu_small_y_neg_inf) {
+TEST(ProbDistributionsDoubleExpModNormalCdf,
+     opencl_matches_cpu_small_y_neg_inf) {
   int N = 3;
   int M = 2;
 

--- a/test/unit/math/opencl/rev/exp_mod_normal_cdf_test.cpp
+++ b/test/unit/math/opencl/rev/exp_mod_normal_cdf_test.cpp
@@ -169,7 +169,8 @@ TEST(ProbDistributionsDoubleExpModNormalCdf, opencl_matches_cpu_big) {
   Eigen::Matrix<double, Eigen::Dynamic, 1> mu
       = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
   Eigen::Matrix<double, Eigen::Dynamic, 1> sigma
-      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs().array() + 0.1;
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs().array()
+        + 0.1;
   Eigen::Matrix<double, Eigen::Dynamic, 1> lambda
       = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
 

--- a/test/unit/math/opencl/rev/exp_mod_normal_lccdf2_test.cpp
+++ b/test/unit/math/opencl/rev/exp_mod_normal_lccdf2_test.cpp
@@ -1,0 +1,31 @@
+#ifdef STAN_OPENCL
+#include <stan/math/opencl/rev.hpp>
+#include <stan/math.hpp>
+#include <gtest/gtest.h>
+#include <test/unit/math/opencl/util.hpp>
+#include <vector>
+
+auto exp_mod_normal_lccdf_functor
+    = [](const auto& y, const auto& mu, const auto& sigma, const auto& lambda) {
+        return stan::math::exp_mod_normal_lccdf(y, mu, sigma, lambda);
+      };
+
+TEST(ProbDistributionsDoubleExpModNormalLccdf, opencl_broadcast_mu) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  double mu_scal = 12.3;
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+  Eigen::VectorXd lambda(N);
+  lambda << 0.3, 0.4, 1.1;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<1>(
+      exp_mod_normal_lccdf_functor, y, mu_scal, sigma, lambda);
+  stan::math::test::test_opencl_broadcasting_prim_rev<1>(
+      exp_mod_normal_lccdf_functor, y.transpose().eval(), mu_scal, sigma,
+      lambda.transpose().eval());
+}
+
+#endif

--- a/test/unit/math/opencl/rev/exp_mod_normal_lccdf3_test.cpp
+++ b/test/unit/math/opencl/rev/exp_mod_normal_lccdf3_test.cpp
@@ -1,0 +1,31 @@
+#ifdef STAN_OPENCL
+#include <stan/math/opencl/rev.hpp>
+#include <stan/math.hpp>
+#include <gtest/gtest.h>
+#include <test/unit/math/opencl/util.hpp>
+#include <vector>
+
+auto exp_mod_normal_lccdf_functor
+    = [](const auto& y, const auto& mu, const auto& sigma, const auto& lambda) {
+        return stan::math::exp_mod_normal_lccdf(y, mu, sigma, lambda);
+      };
+
+TEST(ProbDistributionsDoubleExpModNormalLccdf, opencl_broadcast_sigma) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  Eigen::VectorXd mu(N);
+  mu << 0.3, 0.8, 1.0;
+  double sigma_scal = 12.3;
+  Eigen::VectorXd lambda(N);
+  lambda << 0.3, 0.4, 1.1;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<2>(
+      exp_mod_normal_lccdf_functor, y, mu, sigma_scal, lambda);
+  stan::math::test::test_opencl_broadcasting_prim_rev<2>(
+      exp_mod_normal_lccdf_functor, y.transpose().eval(), mu, sigma_scal,
+      lambda.transpose().eval());
+}
+
+#endif

--- a/test/unit/math/opencl/rev/exp_mod_normal_lccdf4_test.cpp
+++ b/test/unit/math/opencl/rev/exp_mod_normal_lccdf4_test.cpp
@@ -1,0 +1,31 @@
+#ifdef STAN_OPENCL
+#include <stan/math/opencl/rev.hpp>
+#include <stan/math.hpp>
+#include <gtest/gtest.h>
+#include <test/unit/math/opencl/util.hpp>
+#include <vector>
+
+auto exp_mod_normal_lccdf_functor
+    = [](const auto& y, const auto& mu, const auto& sigma, const auto& lambda) {
+        return stan::math::exp_mod_normal_lccdf(y, mu, sigma, lambda);
+      };
+
+TEST(ProbDistributionsDoubleExpModNormalLccdf, opencl_broadcast_lambda) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  Eigen::VectorXd mu(N);
+  mu << 0.3, 0.8, 1.0;
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.4, 1.1;
+  double lambda_scal = 12.3;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<3>(
+      exp_mod_normal_lccdf_functor, y, mu, sigma, lambda_scal);
+  stan::math::test::test_opencl_broadcasting_prim_rev<3>(
+      exp_mod_normal_lccdf_functor, y.transpose().eval(), mu,
+      sigma.transpose().eval(), lambda_scal);
+}
+
+#endif

--- a/test/unit/math/opencl/rev/exp_mod_normal_lccdf_test.cpp
+++ b/test/unit/math/opencl/rev/exp_mod_normal_lccdf_test.cpp
@@ -104,7 +104,8 @@ TEST(ProbDistributionsDoubleExpModNormalLccdf, opencl_matches_cpu_small) {
       sigma.transpose().eval(), lambda.transpose().eval());
 }
 
-TEST(ProbDistributionsDoubleExpModNormalLccdf, opencl_matches_cpu_small_y_pos_inf) {
+TEST(ProbDistributionsDoubleExpModNormalLccdf,
+     opencl_matches_cpu_small_y_pos_inf) {
   int N = 3;
   int M = 2;
 
@@ -124,7 +125,8 @@ TEST(ProbDistributionsDoubleExpModNormalLccdf, opencl_matches_cpu_small_y_pos_in
       sigma.transpose().eval(), lambda.transpose().eval());
 }
 
-TEST(ProbDistributionsDoubleExpModNormalLccdf, opencl_matches_cpu_small_y_neg_inf) {
+TEST(ProbDistributionsDoubleExpModNormalLccdf,
+     opencl_matches_cpu_small_y_neg_inf) {
   int N = 3;
   int M = 2;
 

--- a/test/unit/math/opencl/rev/exp_mod_normal_lccdf_test.cpp
+++ b/test/unit/math/opencl/rev/exp_mod_normal_lccdf_test.cpp
@@ -172,7 +172,7 @@ TEST(ProbDistributionsDoubleExpModNormalLccdf, opencl_matches_cpu_big) {
   Eigen::Matrix<double, Eigen::Dynamic, 1> mu
       = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
   Eigen::Matrix<double, Eigen::Dynamic, 1> sigma
-      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs().array() + 0.1;
   Eigen::Matrix<double, Eigen::Dynamic, 1> lambda
       = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
 

--- a/test/unit/math/opencl/rev/exp_mod_normal_lccdf_test.cpp
+++ b/test/unit/math/opencl/rev/exp_mod_normal_lccdf_test.cpp
@@ -1,0 +1,184 @@
+#ifdef STAN_OPENCL
+#include <stan/math/opencl/rev.hpp>
+#include <stan/math.hpp>
+#include <gtest/gtest.h>
+#include <test/unit/math/opencl/util.hpp>
+#include <vector>
+
+TEST(ProbDistributionsDoubleExpModNormalLccdf, error_checking) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  Eigen::VectorXd y_size(N - 1);
+  y_size << 0.3, 0.8;
+  Eigen::VectorXd y_value(N);
+  y_value << 0.3, NAN, 0.5;
+
+  Eigen::VectorXd mu(N);
+  mu << 0.3, 0.8, 1.0;
+  Eigen::VectorXd mu_size(N - 1);
+  mu_size << 0.3, 0.8;
+  Eigen::VectorXd mu_value(N);
+  mu_value << 0.3, -INFINITY, 0.5;
+
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+  Eigen::VectorXd sigma_size(N - 1);
+  sigma_size << 0.3, 0.8;
+  Eigen::VectorXd sigma_value(N);
+  sigma_value << 0.3, 0, 0.5;
+
+  Eigen::VectorXd lambda(N);
+  lambda << 0.4, 0.4, 1.4;
+  Eigen::VectorXd lambda_size(N - 1);
+  lambda_size << 0.3, 0.8;
+  Eigen::VectorXd lambda_value(N);
+  lambda_value << 0.3, 0, 0.5;
+
+  stan::math::matrix_cl<double> y_cl(y);
+  stan::math::matrix_cl<double> y_size_cl(y_size);
+  stan::math::matrix_cl<double> y_value_cl(y_value);
+  stan::math::matrix_cl<double> mu_cl(mu);
+  stan::math::matrix_cl<double> mu_size_cl(mu_size);
+  stan::math::matrix_cl<double> mu_value_cl(mu_value);
+  stan::math::matrix_cl<double> sigma_cl(sigma);
+  stan::math::matrix_cl<double> sigma_size_cl(sigma_size);
+  stan::math::matrix_cl<double> sigma_value_cl(sigma_value);
+  stan::math::matrix_cl<double> lambda_cl(lambda);
+  stan::math::matrix_cl<double> lambda_size_cl(lambda_size);
+  stan::math::matrix_cl<double> lambda_value_cl(lambda_value);
+
+  EXPECT_NO_THROW(
+      stan::math::exp_mod_normal_lccdf(y_cl, mu_cl, sigma_cl, lambda_cl));
+
+  EXPECT_THROW(
+      stan::math::exp_mod_normal_lccdf(y_size_cl, mu_cl, sigma_cl, lambda_cl),
+      std::invalid_argument);
+  EXPECT_THROW(
+      stan::math::exp_mod_normal_lccdf(y_cl, mu_size_cl, sigma_cl, lambda_cl),
+      std::invalid_argument);
+  EXPECT_THROW(
+      stan::math::exp_mod_normal_lccdf(y_cl, mu_cl, sigma_size_cl, lambda_cl),
+      std::invalid_argument);
+  EXPECT_THROW(
+      stan::math::exp_mod_normal_lccdf(y_cl, mu_cl, sigma_cl, lambda_size_cl),
+      std::invalid_argument);
+
+  EXPECT_THROW(
+      stan::math::exp_mod_normal_lccdf(y_value_cl, mu_cl, sigma_cl, lambda_cl),
+      std::domain_error);
+  EXPECT_THROW(
+      stan::math::exp_mod_normal_lccdf(y_cl, mu_value_cl, sigma_cl, lambda_cl),
+      std::domain_error);
+  EXPECT_THROW(
+      stan::math::exp_mod_normal_lccdf(y_cl, mu_cl, sigma_value_cl, lambda_cl),
+      std::domain_error);
+  EXPECT_THROW(
+      stan::math::exp_mod_normal_lccdf(y_cl, mu_cl, sigma_cl, lambda_value_cl),
+      std::domain_error);
+}
+
+auto exp_mod_normal_lccdf_functor
+    = [](const auto& y, const auto& mu, const auto& sigma, const auto& lambda) {
+        return stan::math::exp_mod_normal_lccdf(y, mu, sigma, lambda);
+      };
+
+TEST(ProbDistributionsDoubleExpModNormalLccdf, opencl_matches_cpu_small) {
+  int N = 3;
+  int M = 2;
+
+  Eigen::VectorXd y(N);
+  y << -0.3, 1.8, 1.4;
+  Eigen::VectorXd mu(N);
+  mu << 0.3, 0.8, 1.0;
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+  Eigen::VectorXd lambda(N);
+  lambda << 0.3, 0.4, 1.1;
+
+  stan::math::test::compare_cpu_opencl_prim_rev(exp_mod_normal_lccdf_functor, y,
+                                                mu, sigma, lambda);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      exp_mod_normal_lccdf_functor, y.transpose().eval(), mu.transpose().eval(),
+      sigma.transpose().eval(), lambda.transpose().eval());
+}
+
+TEST(ProbDistributionsDoubleExpModNormalLccdf, opencl_matches_cpu_small_y_pos_inf) {
+  int N = 3;
+  int M = 2;
+
+  Eigen::VectorXd y(N);
+  y << -0.3, 1.8, INFINITY;
+  Eigen::VectorXd mu(N);
+  mu << 0.3, 0.8, 1.0;
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+  Eigen::VectorXd lambda(N);
+  lambda << 0.3, 0.4, 1.1;
+
+  stan::math::test::compare_cpu_opencl_prim_rev(exp_mod_normal_lccdf_functor, y,
+                                                mu, sigma, lambda);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      exp_mod_normal_lccdf_functor, y.transpose().eval(), mu.transpose().eval(),
+      sigma.transpose().eval(), lambda.transpose().eval());
+}
+
+TEST(ProbDistributionsDoubleExpModNormalLccdf, opencl_matches_cpu_small_y_neg_inf) {
+  int N = 3;
+  int M = 2;
+
+  Eigen::VectorXd y(N);
+  y << -0.3, 1.8, -INFINITY;
+  Eigen::VectorXd mu(N);
+  mu << 0.3, 0.8, 1.0;
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+  Eigen::VectorXd lambda(N);
+  lambda << 0.3, 0.4, 1.1;
+
+  stan::math::test::compare_cpu_opencl_prim_rev(exp_mod_normal_lccdf_functor, y,
+                                                mu, sigma, lambda);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      exp_mod_normal_lccdf_functor, y.transpose().eval(), mu.transpose().eval(),
+      sigma.transpose().eval(), lambda.transpose().eval());
+}
+
+TEST(ProbDistributionsDoubleExpModNormalLccdf, opencl_broadcast_y) {
+  int N = 3;
+
+  double y_scal = 12.3;
+  Eigen::VectorXd mu(N);
+  mu << 0.5, 1.2, 1.0;
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+  Eigen::VectorXd lambda(N);
+  lambda << 0.3, 0.4, 1.1;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(
+      exp_mod_normal_lccdf_functor, y_scal, mu, sigma, lambda);
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(
+      exp_mod_normal_lccdf_functor, y_scal, mu.transpose().eval(), sigma,
+      lambda.transpose().eval());
+}
+
+TEST(ProbDistributionsDoubleExpModNormalLccdf, opencl_matches_cpu_big) {
+  int N = 153;
+
+  Eigen::Matrix<double, Eigen::Dynamic, 1> y
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+  Eigen::Matrix<double, Eigen::Dynamic, 1> mu
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+  Eigen::Matrix<double, Eigen::Dynamic, 1> sigma
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+  Eigen::Matrix<double, Eigen::Dynamic, 1> lambda
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+
+  stan::math::test::compare_cpu_opencl_prim_rev(exp_mod_normal_lccdf_functor, y,
+                                                mu, sigma, lambda);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      exp_mod_normal_lccdf_functor, y.transpose().eval(), mu.transpose().eval(),
+      sigma.transpose().eval(), lambda.transpose().eval());
+}
+
+#endif

--- a/test/unit/math/opencl/rev/exp_mod_normal_lccdf_test.cpp
+++ b/test/unit/math/opencl/rev/exp_mod_normal_lccdf_test.cpp
@@ -172,7 +172,8 @@ TEST(ProbDistributionsDoubleExpModNormalLccdf, opencl_matches_cpu_big) {
   Eigen::Matrix<double, Eigen::Dynamic, 1> mu
       = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
   Eigen::Matrix<double, Eigen::Dynamic, 1> sigma
-      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs().array() + 0.1;
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs().array()
+        + 0.1;
   Eigen::Matrix<double, Eigen::Dynamic, 1> lambda
       = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
 

--- a/test/unit/math/opencl/rev/exp_mod_normal_lcdf2_test.cpp
+++ b/test/unit/math/opencl/rev/exp_mod_normal_lcdf2_test.cpp
@@ -1,0 +1,31 @@
+#ifdef STAN_OPENCL
+#include <stan/math/opencl/rev.hpp>
+#include <stan/math.hpp>
+#include <gtest/gtest.h>
+#include <test/unit/math/opencl/util.hpp>
+#include <vector>
+
+auto exp_mod_normal_lcdf_functor
+    = [](const auto& y, const auto& mu, const auto& sigma, const auto& lambda) {
+        return stan::math::exp_mod_normal_lcdf(y, mu, sigma, lambda);
+      };
+
+TEST(ProbDistributionsDoubleExpModNormalLcdf, opencl_broadcast_mu) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  double mu_scal = 12.3;
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+  Eigen::VectorXd lambda(N);
+  lambda << 0.3, 0.4, 1.1;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<1>(
+      exp_mod_normal_lcdf_functor, y, mu_scal, sigma, lambda);
+  stan::math::test::test_opencl_broadcasting_prim_rev<1>(
+      exp_mod_normal_lcdf_functor, y.transpose().eval(), mu_scal, sigma,
+      lambda.transpose().eval());
+}
+
+#endif

--- a/test/unit/math/opencl/rev/exp_mod_normal_lcdf3_test.cpp
+++ b/test/unit/math/opencl/rev/exp_mod_normal_lcdf3_test.cpp
@@ -1,0 +1,31 @@
+#ifdef STAN_OPENCL
+#include <stan/math/opencl/rev.hpp>
+#include <stan/math.hpp>
+#include <gtest/gtest.h>
+#include <test/unit/math/opencl/util.hpp>
+#include <vector>
+
+auto exp_mod_normal_lcdf_functor
+    = [](const auto& y, const auto& mu, const auto& sigma, const auto& lambda) {
+        return stan::math::exp_mod_normal_lcdf(y, mu, sigma, lambda);
+      };
+
+TEST(ProbDistributionsDoubleExpModNormalLcdf, opencl_broadcast_sigma) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  Eigen::VectorXd mu(N);
+  mu << 0.3, 0.8, 1.0;
+  double sigma_scal = 12.3;
+  Eigen::VectorXd lambda(N);
+  lambda << 0.3, 0.4, 1.1;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<2>(
+      exp_mod_normal_lcdf_functor, y, mu, sigma_scal, lambda);
+  stan::math::test::test_opencl_broadcasting_prim_rev<2>(
+      exp_mod_normal_lcdf_functor, y.transpose().eval(), mu, sigma_scal,
+      lambda.transpose().eval());
+}
+
+#endif

--- a/test/unit/math/opencl/rev/exp_mod_normal_lcdf4_test.cpp
+++ b/test/unit/math/opencl/rev/exp_mod_normal_lcdf4_test.cpp
@@ -1,0 +1,31 @@
+#ifdef STAN_OPENCL
+#include <stan/math/opencl/rev.hpp>
+#include <stan/math.hpp>
+#include <gtest/gtest.h>
+#include <test/unit/math/opencl/util.hpp>
+#include <vector>
+
+auto exp_mod_normal_lcdf_functor
+    = [](const auto& y, const auto& mu, const auto& sigma, const auto& lambda) {
+        return stan::math::exp_mod_normal_lcdf(y, mu, sigma, lambda);
+      };
+
+TEST(ProbDistributionsDoubleExpModNormalLcdf, opencl_broadcast_lambda) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  Eigen::VectorXd mu(N);
+  mu << 0.3, 0.8, 1.0;
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.4, 1.1;
+  double lambda_scal = 12.3;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<3>(
+      exp_mod_normal_lcdf_functor, y, mu, sigma, lambda_scal);
+  stan::math::test::test_opencl_broadcasting_prim_rev<3>(
+      exp_mod_normal_lcdf_functor, y.transpose().eval(), mu,
+      sigma.transpose().eval(), lambda_scal);
+}
+
+#endif

--- a/test/unit/math/opencl/rev/exp_mod_normal_lcdf_test.cpp
+++ b/test/unit/math/opencl/rev/exp_mod_normal_lcdf_test.cpp
@@ -1,0 +1,184 @@
+#ifdef STAN_OPENCL
+#include <stan/math/opencl/rev.hpp>
+#include <stan/math.hpp>
+#include <gtest/gtest.h>
+#include <test/unit/math/opencl/util.hpp>
+#include <vector>
+
+TEST(ProbDistributionsDoubleExpModNormalLcdf, error_checking) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  Eigen::VectorXd y_size(N - 1);
+  y_size << 0.3, 0.8;
+  Eigen::VectorXd y_value(N);
+  y_value << 0.3, NAN, 0.5;
+
+  Eigen::VectorXd mu(N);
+  mu << 0.3, 0.8, 1.0;
+  Eigen::VectorXd mu_size(N - 1);
+  mu_size << 0.3, 0.8;
+  Eigen::VectorXd mu_value(N);
+  mu_value << 0.3, -INFINITY, 0.5;
+
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+  Eigen::VectorXd sigma_size(N - 1);
+  sigma_size << 0.3, 0.8;
+  Eigen::VectorXd sigma_value(N);
+  sigma_value << 0.3, 0, 0.5;
+
+  Eigen::VectorXd lambda(N);
+  lambda << 0.4, 0.4, 1.4;
+  Eigen::VectorXd lambda_size(N - 1);
+  lambda_size << 0.3, 0.8;
+  Eigen::VectorXd lambda_value(N);
+  lambda_value << 0.3, 0, 0.5;
+
+  stan::math::matrix_cl<double> y_cl(y);
+  stan::math::matrix_cl<double> y_size_cl(y_size);
+  stan::math::matrix_cl<double> y_value_cl(y_value);
+  stan::math::matrix_cl<double> mu_cl(mu);
+  stan::math::matrix_cl<double> mu_size_cl(mu_size);
+  stan::math::matrix_cl<double> mu_value_cl(mu_value);
+  stan::math::matrix_cl<double> sigma_cl(sigma);
+  stan::math::matrix_cl<double> sigma_size_cl(sigma_size);
+  stan::math::matrix_cl<double> sigma_value_cl(sigma_value);
+  stan::math::matrix_cl<double> lambda_cl(lambda);
+  stan::math::matrix_cl<double> lambda_size_cl(lambda_size);
+  stan::math::matrix_cl<double> lambda_value_cl(lambda_value);
+
+  EXPECT_NO_THROW(
+      stan::math::exp_mod_normal_lcdf(y_cl, mu_cl, sigma_cl, lambda_cl));
+
+  EXPECT_THROW(
+      stan::math::exp_mod_normal_lcdf(y_size_cl, mu_cl, sigma_cl, lambda_cl),
+      std::invalid_argument);
+  EXPECT_THROW(
+      stan::math::exp_mod_normal_lcdf(y_cl, mu_size_cl, sigma_cl, lambda_cl),
+      std::invalid_argument);
+  EXPECT_THROW(
+      stan::math::exp_mod_normal_lcdf(y_cl, mu_cl, sigma_size_cl, lambda_cl),
+      std::invalid_argument);
+  EXPECT_THROW(
+      stan::math::exp_mod_normal_lcdf(y_cl, mu_cl, sigma_cl, lambda_size_cl),
+      std::invalid_argument);
+
+  EXPECT_THROW(
+      stan::math::exp_mod_normal_lcdf(y_value_cl, mu_cl, sigma_cl, lambda_cl),
+      std::domain_error);
+  EXPECT_THROW(
+      stan::math::exp_mod_normal_lcdf(y_cl, mu_value_cl, sigma_cl, lambda_cl),
+      std::domain_error);
+  EXPECT_THROW(
+      stan::math::exp_mod_normal_lcdf(y_cl, mu_cl, sigma_value_cl, lambda_cl),
+      std::domain_error);
+  EXPECT_THROW(
+      stan::math::exp_mod_normal_lcdf(y_cl, mu_cl, sigma_cl, lambda_value_cl),
+      std::domain_error);
+}
+
+auto exp_mod_normal_lcdf_functor
+    = [](const auto& y, const auto& mu, const auto& sigma, const auto& lambda) {
+        return stan::math::exp_mod_normal_lcdf(y, mu, sigma, lambda);
+      };
+
+TEST(ProbDistributionsDoubleExpModNormalLcdf, opencl_matches_cpu_small) {
+  int N = 3;
+  int M = 2;
+
+  Eigen::VectorXd y(N);
+  y << -0.3, 1.8, 1.4;
+  Eigen::VectorXd mu(N);
+  mu << 0.3, 0.8, 1.0;
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+  Eigen::VectorXd lambda(N);
+  lambda << 0.3, 0.4, 1.1;
+
+  stan::math::test::compare_cpu_opencl_prim_rev(exp_mod_normal_lcdf_functor, y,
+                                                mu, sigma, lambda);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      exp_mod_normal_lcdf_functor, y.transpose().eval(), mu.transpose().eval(),
+      sigma.transpose().eval(), lambda.transpose().eval());
+}
+
+TEST(ProbDistributionsDoubleExpModNormalLcdf, opencl_matches_cpu_small_y_pos_inf) {
+  int N = 3;
+  int M = 2;
+
+  Eigen::VectorXd y(N);
+  y << -0.3, 1.8, INFINITY;
+  Eigen::VectorXd mu(N);
+  mu << 0.3, 0.8, 1.0;
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+  Eigen::VectorXd lambda(N);
+  lambda << 0.3, 0.4, 1.1;
+
+  stan::math::test::compare_cpu_opencl_prim_rev(exp_mod_normal_lcdf_functor, y,
+                                                mu, sigma, lambda);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      exp_mod_normal_lcdf_functor, y.transpose().eval(), mu.transpose().eval(),
+      sigma.transpose().eval(), lambda.transpose().eval());
+}
+
+TEST(ProbDistributionsDoubleExpModNormalLcdf, opencl_matches_cpu_small_y_neg_inf) {
+  int N = 3;
+  int M = 2;
+
+  Eigen::VectorXd y(N);
+  y << -0.3, 1.8, -INFINITY;
+  Eigen::VectorXd mu(N);
+  mu << 0.3, 0.8, 1.0;
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+  Eigen::VectorXd lambda(N);
+  lambda << 0.3, 0.4, 1.1;
+
+  stan::math::test::compare_cpu_opencl_prim_rev(exp_mod_normal_lcdf_functor, y,
+                                                mu, sigma, lambda);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      exp_mod_normal_lcdf_functor, y.transpose().eval(), mu.transpose().eval(),
+      sigma.transpose().eval(), lambda.transpose().eval());
+}
+
+TEST(ProbDistributionsDoubleExpModNormalLcdf, opencl_broadcast_y) {
+  int N = 3;
+
+  double y_scal = 12.3;
+  Eigen::VectorXd mu(N);
+  mu << 0.5, 1.2, 1.0;
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+  Eigen::VectorXd lambda(N);
+  lambda << 0.3, 0.4, 1.1;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(
+      exp_mod_normal_lcdf_functor, y_scal, mu, sigma, lambda);
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(
+      exp_mod_normal_lcdf_functor, y_scal, mu.transpose().eval(), sigma,
+      lambda.transpose().eval());
+}
+
+TEST(ProbDistributionsDoubleExpModNormalLcdf, opencl_matches_cpu_big) {
+  int N = 153;
+
+  Eigen::Matrix<double, Eigen::Dynamic, 1> y
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+  Eigen::Matrix<double, Eigen::Dynamic, 1> mu
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+  Eigen::Matrix<double, Eigen::Dynamic, 1> sigma
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+  Eigen::Matrix<double, Eigen::Dynamic, 1> lambda
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+
+  stan::math::test::compare_cpu_opencl_prim_rev(exp_mod_normal_lcdf_functor, y,
+                                                mu, sigma, lambda);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      exp_mod_normal_lcdf_functor, y.transpose().eval(), mu.transpose().eval(),
+      sigma.transpose().eval(), lambda.transpose().eval());
+}
+
+#endif

--- a/test/unit/math/opencl/rev/exp_mod_normal_lcdf_test.cpp
+++ b/test/unit/math/opencl/rev/exp_mod_normal_lcdf_test.cpp
@@ -172,7 +172,7 @@ TEST(ProbDistributionsDoubleExpModNormalLcdf, opencl_matches_cpu_big) {
   Eigen::Matrix<double, Eigen::Dynamic, 1> mu
       = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
   Eigen::Matrix<double, Eigen::Dynamic, 1> sigma
-      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs().array() + 0.1;
   Eigen::Matrix<double, Eigen::Dynamic, 1> lambda
       = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
 

--- a/test/unit/math/opencl/rev/exp_mod_normal_lcdf_test.cpp
+++ b/test/unit/math/opencl/rev/exp_mod_normal_lcdf_test.cpp
@@ -104,7 +104,8 @@ TEST(ProbDistributionsDoubleExpModNormalLcdf, opencl_matches_cpu_small) {
       sigma.transpose().eval(), lambda.transpose().eval());
 }
 
-TEST(ProbDistributionsDoubleExpModNormalLcdf, opencl_matches_cpu_small_y_pos_inf) {
+TEST(ProbDistributionsDoubleExpModNormalLcdf,
+     opencl_matches_cpu_small_y_pos_inf) {
   int N = 3;
   int M = 2;
 
@@ -124,7 +125,8 @@ TEST(ProbDistributionsDoubleExpModNormalLcdf, opencl_matches_cpu_small_y_pos_inf
       sigma.transpose().eval(), lambda.transpose().eval());
 }
 
-TEST(ProbDistributionsDoubleExpModNormalLcdf, opencl_matches_cpu_small_y_neg_inf) {
+TEST(ProbDistributionsDoubleExpModNormalLcdf,
+     opencl_matches_cpu_small_y_neg_inf) {
   int N = 3;
   int M = 2;
 

--- a/test/unit/math/opencl/rev/exp_mod_normal_lcdf_test.cpp
+++ b/test/unit/math/opencl/rev/exp_mod_normal_lcdf_test.cpp
@@ -172,7 +172,8 @@ TEST(ProbDistributionsDoubleExpModNormalLcdf, opencl_matches_cpu_big) {
   Eigen::Matrix<double, Eigen::Dynamic, 1> mu
       = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
   Eigen::Matrix<double, Eigen::Dynamic, 1> sigma
-      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs().array() + 0.1;
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs().array()
+        + 0.1;
   Eigen::Matrix<double, Eigen::Dynamic, 1> lambda
       = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
 


### PR DESCRIPTION
## Summary

Added OpenCL implementations for functions `double_exponential_cdf`, `double exponential_lcd`, `double_exponential_lccdf`˙, `exp_mod_normal_cdf`, `exp_mod_normal_lcdf` and `exp_mod_normal_lccdf`.

## Tests
Added tests for new functions. `exp_mod_normal` is quite complicated distribution, so I had to split tests into multiple files or they would not compile.

## Side Effects
None.

## Release notes

OpenCL: Added OpenCL implementations for functions `double_exponential_cdf`, `double exponential_lcd`, `double_exponential_lccdf`˙, `exp_mod_normal_cdf`, `exp_mod_normal_lcdf` and `exp_mod_normal_lccdf`.

## Checklist

- [ ] Math issue #2152

- [ ] Copyright holder: Tadej Ciglarič

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [ ] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [ ] the code is written in idiomatic C++ and changes are documented in the doxygen

- [ ] the new changes are tested
