### PR TITLE
Opencl exponential and frechet (lc)cdf

### DIFF
--- a/stan/math/opencl/prim.hpp
+++ b/stan/math/opencl/prim.hpp
@@ -140,6 +140,9 @@
 #include <stan/math/opencl/prim/exponential_lccdf.hpp>
 #include <stan/math/opencl/prim/exponential_lcdf.hpp>
 #include <stan/math/opencl/prim/exponential_lpdf.hpp>
+#include <stan/math/opencl/prim/frechet_cdf.hpp>
+#include <stan/math/opencl/prim/frechet_lccdf.hpp>
+#include <stan/math/opencl/prim/frechet_lcdf.hpp>
 #include <stan/math/opencl/prim/frechet_lpdf.hpp>
 #include <stan/math/opencl/prim/gamma_lpdf.hpp>
 #include <stan/math/opencl/prim/gp_exp_quad_cov.hpp>

--- a/stan/math/opencl/prim.hpp
+++ b/stan/math/opencl/prim.hpp
@@ -136,6 +136,9 @@
 #include <stan/math/opencl/prim/dot_self.hpp>
 #include <stan/math/opencl/prim/double_exponential_lpdf.hpp>
 #include <stan/math/opencl/prim/exp_mod_normal_lpdf.hpp>
+#include <stan/math/opencl/prim/exponential_cdf.hpp>
+#include <stan/math/opencl/prim/exponential_lccdf.hpp>
+#include <stan/math/opencl/prim/exponential_lcdf.hpp>
 #include <stan/math/opencl/prim/exponential_lpdf.hpp>
 #include <stan/math/opencl/prim/frechet_lpdf.hpp>
 #include <stan/math/opencl/prim/gamma_lpdf.hpp>

--- a/stan/math/opencl/prim/exponential_cdf.hpp
+++ b/stan/math/opencl/prim/exponential_cdf.hpp
@@ -1,0 +1,102 @@
+#ifndef STAN_MATH_OPENCL_PRIM_EXPONENTIAL_CDF_HPP
+#define STAN_MATH_OPENCL_PRIM_EXPONENTIAL_CDF_HPP
+#ifdef STAN_OPENCL
+
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/err.hpp>
+#include <stan/math/prim/fun/constants.hpp>
+#include <stan/math/prim/fun/elt_divide.hpp>
+#include <stan/math/prim/fun/elt_multiply.hpp>
+#include <stan/math/opencl/kernel_generator.hpp>
+#include <stan/math/prim/functor/operands_and_partials.hpp>
+
+namespace stan {
+namespace math {
+
+/** \ingroup opencl
+ * Calculates the exponential cumulative distribution function for
+ * the given y and beta.
+ *
+ * Inverse scale parameter must be greater than 0.
+ * y must be greater than or equal to 0.
+ *
+ * @tparam T_y_cl type of scalar
+ * @tparam T_inv_scale_cl type of inverse scale
+ * @param y a scalar variable
+ * @param beta inverse scale parameter
+ * @return The product of densities
+ */
+template <typename T_y_cl, typename T_inv_scale_cl,
+          require_all_prim_or_rev_kernel_expression_t<
+              T_y_cl, T_inv_scale_cl>* = nullptr,
+          require_any_not_stan_scalar_t<T_y_cl, T_inv_scale_cl>* = nullptr>
+return_type_t<T_y_cl, T_inv_scale_cl> exponential_cdf(
+    const T_y_cl& y, const T_inv_scale_cl& beta) {
+  static const char* function = "exponential_cdf(OpenCL)";
+  using T_partials_return = partials_return_t<T_y_cl, T_inv_scale_cl>;
+  using std::isfinite;
+  using std::isnan;
+
+  check_consistent_sizes(function, "Random variable", y,
+                         "Inverse scale parameter", beta);
+  const size_t N = max_size(y, beta);
+  if (N == 0) {
+    return 1.0;
+  }
+
+  const auto& y_col = as_column_vector_or_scalar(y);
+  const auto& beta_col = as_column_vector_or_scalar(beta);
+
+  const auto& y_val = value_of(y_col);
+  const auto& beta_val = value_of(beta_col);
+
+  auto check_y_nonnegative
+      = check_cl(function, "Random variable", y_val, "nonnegative");
+  auto y_nonnegative_expr = y_val >= 0.0;
+  auto check_beta_positive_finite = check_cl(
+      function, "Inverse scale parameter", beta_val, "positive finite");
+  auto beta_positive_finite_expr = 0.0 < beta_val && isfinite(beta_val);
+
+  auto exp_val = exp(elt_multiply(-beta_val, y_val));
+  auto one_m_exp = 1.0 - exp_val;
+  auto cdf_expr = colwise_prod(one_m_exp);
+  auto rep_deriv1 = elt_divide(exp_val, one_m_exp);
+
+  matrix_cl<double> cdf_cl;
+  matrix_cl<double> y_deriv_cl;
+  matrix_cl<double> beta_deriv_cl;
+
+  results(check_y_nonnegative, check_beta_positive_finite, cdf_cl,
+          beta_deriv_cl)
+      = expressions(
+          y_nonnegative_expr, beta_positive_finite_expr, cdf_expr,
+          calc_if<!is_constant_all<T_y_cl, T_inv_scale_cl>::value>(rep_deriv1));
+
+  T_partials_return cdf = (from_matrix_cl(cdf_cl)).prod();
+
+  auto rep_deriv2 = beta_deriv_cl * cdf;
+  auto y_deriv = elt_multiply(
+      static_select<is_constant<T_y_cl>::value>(0, beta_val), rep_deriv2);
+  auto beta_deriv = elt_multiply(
+      static_select<is_constant<T_inv_scale_cl>::value>(0, y_val), rep_deriv2);
+
+  results(y_deriv_cl, beta_deriv_cl)
+      = expressions(calc_if<!is_constant<T_y_cl>::value>(y_deriv),
+                    calc_if<!is_constant<T_inv_scale_cl>::value>(beta_deriv));
+
+  operands_and_partials<decltype(y_col), decltype(beta_col)> ops_partials(
+      y_col, beta_col);
+
+  if (!is_constant<T_y_cl>::value) {
+    ops_partials.edge1_.partials_ = std::move(y_deriv_cl);
+  }
+  if (!is_constant<T_inv_scale_cl>::value) {
+    ops_partials.edge2_.partials_ = std::move(beta_deriv_cl);
+  }
+  return ops_partials.build(cdf);
+}
+
+}  // namespace math
+}  // namespace stan
+#endif
+#endif

--- a/stan/math/opencl/prim/exponential_lccdf.hpp
+++ b/stan/math/opencl/prim/exponential_lccdf.hpp
@@ -1,0 +1,84 @@
+#ifndef STAN_MATH_OPENCL_PRIM_EXPONENTIAL_LCCDF_HPP
+#define STAN_MATH_OPENCL_PRIM_EXPONENTIAL_LCCDF_HPP
+#ifdef STAN_OPENCL
+
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/err.hpp>
+#include <stan/math/prim/fun/constants.hpp>
+#include <stan/math/prim/fun/elt_divide.hpp>
+#include <stan/math/prim/fun/elt_multiply.hpp>
+#include <stan/math/opencl/kernel_generator.hpp>
+#include <stan/math/prim/functor/operands_and_partials.hpp>
+
+namespace stan {
+namespace math {
+
+/** \ingroup opencl
+ * Calculates the log exponential cumulative distribution function for
+ * the given y and beta.
+ *
+ * Inverse scale parameter must be greater than 0.
+ * y must be greater than or equal to 0.
+ *
+ * @tparam T_y_cl type of scalar
+ * @tparam T_inv_scale_cl type of inverse scale
+ * @param y a scalar variable
+ * @param beta inverse scale parameter
+ * @return The log of the product of densities
+ */
+template <typename T_y_cl, typename T_inv_scale_cl,
+          require_all_prim_or_rev_kernel_expression_t<
+              T_y_cl, T_inv_scale_cl>* = nullptr,
+          require_any_not_stan_scalar_t<T_y_cl, T_inv_scale_cl>* = nullptr>
+return_type_t<T_y_cl, T_inv_scale_cl> exponential_lccdf(
+    const T_y_cl& y, const T_inv_scale_cl& beta) {
+  static const char* function = "exponential_lccdf(OpenCL)";
+  using T_partials_return = partials_return_t<T_y_cl, T_inv_scale_cl>;
+  using std::isfinite;
+  using std::isnan;
+
+  check_consistent_sizes(function, "Random variable", y,
+                         "Inverse scale parameter", beta);
+  const size_t N = max_size(y, beta);
+  if (N == 0) {
+    return 0.0;
+  }
+
+  const auto& y_col = as_column_vector_or_scalar(y);
+  const auto& beta_col = as_column_vector_or_scalar(beta);
+
+  const auto& y_val = value_of(y_col);
+  const auto& beta_val = value_of(beta_col);
+
+  auto check_y_nonnegative
+      = check_cl(function, "Random variable", y_val, "nonnegative");
+  auto y_nonnegative_expr = y_val >= 0.0;
+  auto check_beta_positive_finite = check_cl(
+      function, "Inverse scale parameter", beta_val, "positive finite");
+  auto beta_positive_finite_expr = 0.0 < beta_val && isfinite(beta_val);
+
+  auto lccdf_expr = colwise_sum(elt_multiply(-beta_val, y_val));
+
+  matrix_cl<double> lccdf_cl;
+
+  results(check_y_nonnegative, check_beta_positive_finite, lccdf_cl)
+      = expressions(y_nonnegative_expr, beta_positive_finite_expr, lccdf_expr);
+
+  T_partials_return lccdf = (from_matrix_cl(lccdf_cl)).sum();
+
+  operands_and_partials<decltype(y_col), decltype(beta_col)> ops_partials(
+      y_col, beta_col);
+
+  if (!is_constant<T_y_cl>::value) {
+    ops_partials.edge1_.partials_ = constant(0.0, N, 1) - beta_val;
+  }
+  if (!is_constant<T_inv_scale_cl>::value) {
+    ops_partials.edge2_.partials_ = constant(0.0, N, 1) - y_val;
+  }
+  return ops_partials.build(lccdf);
+}
+
+}  // namespace math
+}  // namespace stan
+#endif
+#endif

--- a/stan/math/opencl/prim/exponential_lcdf.hpp
+++ b/stan/math/opencl/prim/exponential_lcdf.hpp
@@ -1,0 +1,94 @@
+#ifndef STAN_MATH_OPENCL_PRIM_EXPONENTIAL_LCDF_HPP
+#define STAN_MATH_OPENCL_PRIM_EXPONENTIAL_LCDF_HPP
+#ifdef STAN_OPENCL
+
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/err.hpp>
+#include <stan/math/prim/fun/constants.hpp>
+#include <stan/math/prim/fun/elt_divide.hpp>
+#include <stan/math/prim/fun/elt_multiply.hpp>
+#include <stan/math/opencl/kernel_generator.hpp>
+#include <stan/math/prim/functor/operands_and_partials.hpp>
+
+namespace stan {
+namespace math {
+
+/** \ingroup opencl
+ * Calculates the log exponential cumulative distribution function for
+ * the given y and beta.
+ *
+ * Inverse scale parameter must be greater than 0.
+ * y must be greater than or equal to 0.
+ *
+ * @tparam T_y_cl type of scalar
+ * @tparam T_inv_scale_cl type of inverse scale
+ * @param y a scalar variable
+ * @param beta inverse scale parameter
+ * @return The log of the product of densities
+ */
+template <typename T_y_cl, typename T_inv_scale_cl,
+          require_all_prim_or_rev_kernel_expression_t<
+              T_y_cl, T_inv_scale_cl>* = nullptr,
+          require_any_not_stan_scalar_t<T_y_cl, T_inv_scale_cl>* = nullptr>
+return_type_t<T_y_cl, T_inv_scale_cl> exponential_lcdf(
+    const T_y_cl& y, const T_inv_scale_cl& beta) {
+  static const char* function = "exponential_lcdf(OpenCL)";
+  using T_partials_return = partials_return_t<T_y_cl, T_inv_scale_cl>;
+  using std::isfinite;
+  using std::isnan;
+
+  check_consistent_sizes(function, "Random variable", y,
+                         "Inverse scale parameter", beta);
+  const size_t N = max_size(y, beta);
+  if (N == 0) {
+    return 0.0;
+  }
+
+  const auto& y_col = as_column_vector_or_scalar(y);
+  const auto& beta_col = as_column_vector_or_scalar(beta);
+
+  const auto& y_val = value_of(y_col);
+  const auto& beta_val = value_of(beta_col);
+
+  auto check_y_nonnegative
+      = check_cl(function, "Random variable", y_val, "nonnegative");
+  auto y_nonnegative_expr = y_val >= 0.0;
+  auto check_beta_positive_finite = check_cl(
+      function, "Inverse scale parameter", beta_val, "positive finite");
+  auto beta_positive_finite_expr = 0.0 < beta_val && isfinite(beta_val);
+
+  auto exp_val = exp(elt_multiply(-beta_val, y_val));
+  auto lcdf_expr = colwise_sum(log1m(exp_val));
+
+  auto rep_deriv = elt_divide(exp_val, 1.0 - exp_val);
+  auto y_deriv = elt_multiply(beta_val, rep_deriv);
+  auto beta_deriv = elt_multiply(y_val, rep_deriv);
+
+  matrix_cl<double> lcdf_cl;
+  matrix_cl<double> y_deriv_cl;
+  matrix_cl<double> beta_deriv_cl;
+
+  results(check_y_nonnegative, check_beta_positive_finite, lcdf_cl, y_deriv_cl,
+          beta_deriv_cl)
+      = expressions(y_nonnegative_expr, beta_positive_finite_expr, lcdf_expr,
+                    calc_if<!is_constant<T_y_cl>::value>(y_deriv),
+                    calc_if<!is_constant<T_inv_scale_cl>::value>(beta_deriv));
+
+  T_partials_return lcdf = (from_matrix_cl(lcdf_cl)).sum();
+
+  operands_and_partials<decltype(y_col), decltype(beta_col)> ops_partials(
+      y_col, beta_col);
+
+  if (!is_constant<T_y_cl>::value) {
+    ops_partials.edge1_.partials_ = std::move(y_deriv);
+  }
+  if (!is_constant<T_inv_scale_cl>::value) {
+    ops_partials.edge2_.partials_ = std::move(beta_deriv);
+  }
+  return ops_partials.build(lcdf);
+}
+
+}  // namespace math
+}  // namespace stan
+#endif
+#endif

--- a/stan/math/opencl/prim/frechet_cdf.hpp
+++ b/stan/math/opencl/prim/frechet_cdf.hpp
@@ -55,10 +55,10 @@ return_type_t<T_y_cl, T_shape_cl, T_scale_cl> frechet_cdf(
 
   auto check_y_positive
       = check_cl(function, "Random variable", y_val, "positive");
-  auto y_positive = y_val>0;
+  auto y_positive = y_val > 0;
   auto check_alpha_positive_finite
       = check_cl(function, "Shape parameter", alpha_val, "positive finite");
-  auto alpha_positive_finite_expr = alpha_val>0 && isfinite(alpha_val);
+  auto alpha_positive_finite_expr = alpha_val > 0 && isfinite(alpha_val);
   auto check_sigma_positive_finite
       = check_cl(function, "Scale parameter", sigma_val, "positive finite");
   auto sigma_positive_finite_expr = 0 < sigma_val && isfinite(sigma_val);
@@ -67,8 +67,8 @@ return_type_t<T_y_cl, T_shape_cl, T_scale_cl> frechet_cdf(
   auto cdf_n = exp(-pow_n);
   auto cdf_expr = colwise_prod(cdf_n);
 
-  auto pow_n_alpha =elt_multiply(pow_n, alpha_val);
-  auto y_deriv_tmp =elt_divide(pow_n_alpha, y_val);
+  auto pow_n_alpha = elt_multiply(pow_n, alpha_val);
+  auto y_deriv_tmp = elt_divide(pow_n_alpha, y_val);
   auto alpha_deriv_tmp = elt_multiply(pow_n, log(elt_divide(y_val, sigma_val)));
   auto sigma_deriv_tmp = elt_divide(pow_n_alpha, -sigma_val);
 
@@ -77,14 +77,14 @@ return_type_t<T_y_cl, T_shape_cl, T_scale_cl> frechet_cdf(
   matrix_cl<double> alpha_deriv_cl;
   matrix_cl<double> sigma_deriv_cl;
 
-  results(check_y_positive, check_alpha_positive_finite, check_sigma_positive_finite,
-          cdf_cl, y_deriv_cl, alpha_deriv_cl, sigma_deriv_cl)
-      = expressions(
-          y_positive, alpha_positive_finite_expr, sigma_positive_finite_expr,
-          cdf_expr,
-        calc_if<!is_constant<T_y_cl>::value>(y_deriv_tmp),
-        calc_if<!is_constant<T_shape_cl>::value>(alpha_deriv_tmp),
-          calc_if<!is_constant<T_scale_cl>::value>(sigma_deriv_tmp));
+  results(check_y_positive, check_alpha_positive_finite,
+          check_sigma_positive_finite, cdf_cl, y_deriv_cl, alpha_deriv_cl,
+          sigma_deriv_cl)
+      = expressions(y_positive, alpha_positive_finite_expr,
+                    sigma_positive_finite_expr, cdf_expr,
+                    calc_if<!is_constant<T_y_cl>::value>(y_deriv_tmp),
+                    calc_if<!is_constant<T_shape_cl>::value>(alpha_deriv_tmp),
+                    calc_if<!is_constant<T_scale_cl>::value>(sigma_deriv_tmp));
 
   T_partials_return cdf = (from_matrix_cl(cdf_cl)).prod();
 
@@ -97,7 +97,8 @@ return_type_t<T_y_cl, T_shape_cl, T_scale_cl> frechet_cdf(
                     calc_if<!is_constant<T_y_cl>::value>(y_deriv),
                     calc_if<!is_constant<T_scale_cl>::value>(sigma_deriv));
 
-  operands_and_partials<decltype(y_col), decltype(alpha_col), decltype(sigma_col)>
+  operands_and_partials<decltype(y_col), decltype(alpha_col),
+                        decltype(sigma_col)>
       ops_partials(y_col, alpha_col, sigma_col);
 
   if (!is_constant<T_y_cl>::value) {

--- a/stan/math/opencl/prim/frechet_cdf.hpp
+++ b/stan/math/opencl/prim/frechet_cdf.hpp
@@ -1,0 +1,118 @@
+#ifndef STAN_MATH_OPENCL_PRIM_FRECHET_CDF_HPP
+#define STAN_MATH_OPENCL_PRIM_FRECHET_CDF_HPP
+#ifdef STAN_OPENCL
+
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/err.hpp>
+#include <stan/math/prim/fun/constants.hpp>
+#include <stan/math/prim/fun/elt_divide.hpp>
+#include <stan/math/prim/fun/elt_multiply.hpp>
+#include <stan/math/opencl/kernel_generator.hpp>
+#include <stan/math/prim/functor/operands_and_partials.hpp>
+
+namespace stan {
+namespace math {
+
+/** \ingroup opencl
+ * Returns the frechet cumulative distribution function for the given
+ * location, and scale. If given containers of matching sizes
+ * returns the product of probabilities.
+ *
+ * @tparam T_y_cl type of scalar outcome
+ * @tparam T_shape_cl type of location
+ * @tparam T_scale_cl type of scale
+ * @param y (Sequence of) scalar(s).
+ * @param alpha (Sequence of) location(s).
+ * @param sigma (Sequence of) scale(s).
+ * @return The log of the product of densities.
+ */
+template <
+    typename T_y_cl, typename T_shape_cl, typename T_scale_cl,
+    require_all_prim_or_rev_kernel_expression_t<T_y_cl, T_shape_cl,
+                                                T_scale_cl>* = nullptr,
+    require_any_not_stan_scalar_t<T_y_cl, T_shape_cl, T_scale_cl>* = nullptr>
+return_type_t<T_y_cl, T_shape_cl, T_scale_cl> frechet_cdf(
+    const T_y_cl& y, const T_shape_cl& alpha, const T_scale_cl& sigma) {
+  static const char* function = "frechet_cdf(OpenCL)";
+  using T_partials_return = partials_return_t<T_y_cl, T_shape_cl, T_scale_cl>;
+  using std::isfinite;
+  using std::isnan;
+
+  check_consistent_sizes(function, "Random variable", y, "Shape parameter",
+                         alpha, "Scale parameter", sigma);
+  const size_t N = max_size(y, alpha, sigma);
+  if (N == 0) {
+    return 1.0;
+  }
+
+  const auto& y_col = as_column_vector_or_scalar(y);
+  const auto& alpha_col = as_column_vector_or_scalar(alpha);
+  const auto& sigma_col = as_column_vector_or_scalar(sigma);
+
+  const auto& y_val = value_of(y_col);
+  const auto& alpha_val = value_of(alpha_col);
+  const auto& sigma_val = value_of(sigma_col);
+
+  auto check_y_positive
+      = check_cl(function, "Random variable", y_val, "positive");
+  auto y_positive = y_val>0;
+  auto check_alpha_positive_finite
+      = check_cl(function, "Shape parameter", alpha_val, "positive finite");
+  auto alpha_positive_finite_expr = alpha_val>0 && isfinite(alpha_val);
+  auto check_sigma_positive_finite
+      = check_cl(function, "Scale parameter", sigma_val, "positive finite");
+  auto sigma_positive_finite_expr = 0 < sigma_val && isfinite(sigma_val);
+
+  auto pow_n = pow(elt_divide(sigma_val, y_val), alpha_val);
+  auto cdf_n = exp(-pow_n);
+  auto cdf_expr = colwise_prod(cdf_n);
+
+  auto pow_n_alpha =elt_multiply(pow_n, alpha_val);
+  auto y_deriv_tmp =elt_divide(pow_n_alpha, y_val);
+  auto alpha_deriv_tmp = elt_multiply(pow_n, log(elt_divide(y_val, sigma_val)));
+  auto sigma_deriv_tmp = elt_divide(pow_n_alpha, -sigma_val);
+
+  matrix_cl<double> cdf_cl;
+  matrix_cl<double> y_deriv_cl;
+  matrix_cl<double> alpha_deriv_cl;
+  matrix_cl<double> sigma_deriv_cl;
+
+  results(check_y_positive, check_alpha_positive_finite, check_sigma_positive_finite,
+          cdf_cl, y_deriv_cl, alpha_deriv_cl, sigma_deriv_cl)
+      = expressions(
+          y_positive, alpha_positive_finite_expr, sigma_positive_finite_expr,
+          cdf_expr,
+        calc_if<!is_constant<T_y_cl>::value>(y_deriv_tmp),
+        calc_if<!is_constant<T_shape_cl>::value>(alpha_deriv_tmp),
+          calc_if<!is_constant<T_scale_cl>::value>(sigma_deriv_tmp));
+
+  T_partials_return cdf = (from_matrix_cl(cdf_cl)).prod();
+
+  auto alpha_deriv = alpha_deriv_cl * cdf;
+  auto y_deriv = y_deriv_cl * cdf;
+  auto sigma_deriv = sigma_deriv_cl * cdf;
+
+  results(alpha_deriv_cl, y_deriv_cl, sigma_deriv_cl)
+      = expressions(calc_if<!is_constant<T_shape_cl>::value>(alpha_deriv),
+                    calc_if<!is_constant<T_y_cl>::value>(y_deriv),
+                    calc_if<!is_constant<T_scale_cl>::value>(sigma_deriv));
+
+  operands_and_partials<decltype(y_col), decltype(alpha_col), decltype(sigma_col)>
+      ops_partials(y_col, alpha_col, sigma_col);
+
+  if (!is_constant<T_y_cl>::value) {
+    ops_partials.edge1_.partials_ = std::move(y_deriv_cl);
+  }
+  if (!is_constant<T_shape_cl>::value) {
+    ops_partials.edge2_.partials_ = std::move(alpha_deriv_cl);
+  }
+  if (!is_constant<T_scale_cl>::value) {
+    ops_partials.edge3_.partials_ = std::move(sigma_deriv_cl);
+  }
+  return ops_partials.build(cdf);
+}
+
+}  // namespace math
+}  // namespace stan
+#endif
+#endif

--- a/stan/math/opencl/prim/frechet_lccdf.hpp
+++ b/stan/math/opencl/prim/frechet_lccdf.hpp
@@ -69,7 +69,8 @@ return_type_t<T_y_cl, T_shape_cl, T_scale_cl> frechet_lccdf(
 
   auto rep_deriv = elt_divide(pow_n, elt_divide(1.0, exp_n - 1.0));
   auto y_deriv = elt_multiply(elt_divide(-alpha_val, y_val), rep_deriv);
-  auto alpha_deriv = elt_multiply(-log(elt_divide(y_val, sigma_val)), rep_deriv);
+  auto alpha_deriv
+      = elt_multiply(-log(elt_divide(y_val, sigma_val)), rep_deriv);
   auto sigma_deriv = elt_multiply(elt_divide(alpha_val, sigma_val), rep_deriv);
 
   matrix_cl<double> lccdf_cl;

--- a/stan/math/opencl/prim/frechet_lccdf.hpp
+++ b/stan/math/opencl/prim/frechet_lccdf.hpp
@@ -67,7 +67,7 @@ return_type_t<T_y_cl, T_shape_cl, T_scale_cl> frechet_lccdf(
   auto exp_n = exp(-pow_n);
   auto lccdf_expr = colwise_sum(log1m(exp_n));
 
-  auto rep_deriv = elt_divide(pow_n, elt_divide(1.0, exp_n - 1.0));
+  auto rep_deriv = elt_divide(pow_n, elt_divide(1.0, exp_n) - 1.0);
   auto y_deriv = elt_multiply(elt_divide(-alpha_val, y_val), rep_deriv);
   auto alpha_deriv
       = elt_multiply(-log(elt_divide(y_val, sigma_val)), rep_deriv);

--- a/stan/math/opencl/prim/frechet_lccdf.hpp
+++ b/stan/math/opencl/prim/frechet_lccdf.hpp
@@ -1,0 +1,110 @@
+#ifndef STAN_MATH_OPENCL_PRIM_FRECHET_LCCDF_HPP
+#define STAN_MATH_OPENCL_PRIM_FRECHET_LCCDF_HPP
+#ifdef STAN_OPENCL
+
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/err.hpp>
+#include <stan/math/prim/fun/constants.hpp>
+#include <stan/math/prim/fun/elt_divide.hpp>
+#include <stan/math/prim/fun/elt_multiply.hpp>
+#include <stan/math/opencl/kernel_generator.hpp>
+#include <stan/math/prim/functor/operands_and_partials.hpp>
+
+namespace stan {
+namespace math {
+
+/** \ingroup opencl
+ * Returns the frechet log complementary cumulative distribution function for
+ * the given location, and scale. If given containers of matching sizes returns
+ * the product of probabilities.
+ *
+ * @tparam T_y_cl type of scalar outcome
+ * @tparam T_shape_cl type of location
+ * @tparam T_scale_cl type of scale
+ * @param y (Sequence of) scalar(s).
+ * @param alpha (Sequence of) location(s).
+ * @param sigma (Sequence of) scale(s).
+ * @return The log of the product of densities.
+ */
+template <
+    typename T_y_cl, typename T_shape_cl, typename T_scale_cl,
+    require_all_prim_or_rev_kernel_expression_t<T_y_cl, T_shape_cl,
+                                                T_scale_cl>* = nullptr,
+    require_any_not_stan_scalar_t<T_y_cl, T_shape_cl, T_scale_cl>* = nullptr>
+return_type_t<T_y_cl, T_shape_cl, T_scale_cl> frechet_lccdf(
+    const T_y_cl& y, const T_shape_cl& alpha, const T_scale_cl& sigma) {
+  static const char* function = "frechet_lccdf(OpenCL)";
+  using T_partials_return = partials_return_t<T_y_cl, T_shape_cl, T_scale_cl>;
+  using std::isfinite;
+  using std::isnan;
+
+  check_consistent_sizes(function, "Random variable", y, "Shape parameter",
+                         alpha, "Scale parameter", sigma);
+  const size_t N = max_size(y, alpha, sigma);
+  if (N == 0) {
+    return 1.0;
+  }
+
+  const auto& y_col = as_column_vector_or_scalar(y);
+  const auto& alpha_col = as_column_vector_or_scalar(alpha);
+  const auto& sigma_col = as_column_vector_or_scalar(sigma);
+
+  const auto& y_val = value_of(y_col);
+  const auto& alpha_val = value_of(alpha_col);
+  const auto& sigma_val = value_of(sigma_col);
+
+  auto check_y_positive
+      = check_cl(function, "Random variable", y_val, "positive");
+  auto y_positive = y_val > 0;
+  auto check_alpha_positive_finite
+      = check_cl(function, "Shape parameter", alpha_val, "positive finite");
+  auto alpha_positive_finite_expr = alpha_val > 0 && isfinite(alpha_val);
+  auto check_sigma_positive_finite
+      = check_cl(function, "Scale parameter", sigma_val, "positive finite");
+  auto sigma_positive_finite_expr = 0 < sigma_val && isfinite(sigma_val);
+
+  auto pow_n = pow(elt_divide(sigma_val, y_val), alpha_val);
+  auto exp_n = exp(-pow_n);
+  auto lccdf_expr = colwise_sum(log1m(exp_n));
+
+  auto rep_deriv = elt_divide(pow_n, elt_divide(1.0, exp_n - 1.0));
+  auto y_deriv = elt_multiply(elt_divide(-alpha_val, y_val), rep_deriv);
+  auto alpha_deriv = elt_multiply(-log(elt_divide(y_val, sigma_val)), rep_deriv);
+  auto sigma_deriv = elt_multiply(elt_divide(alpha_val, sigma_val), rep_deriv);
+
+  matrix_cl<double> lccdf_cl;
+  matrix_cl<double> y_deriv_cl;
+  matrix_cl<double> alpha_deriv_cl;
+  matrix_cl<double> sigma_deriv_cl;
+
+  results(check_y_positive, check_alpha_positive_finite,
+          check_sigma_positive_finite, lccdf_cl, y_deriv_cl, alpha_deriv_cl,
+          sigma_deriv_cl)
+      = expressions(y_positive, alpha_positive_finite_expr,
+                    sigma_positive_finite_expr, lccdf_expr,
+                    calc_if<!is_constant<T_y_cl>::value>(y_deriv),
+                    calc_if<!is_constant<T_shape_cl>::value>(alpha_deriv),
+                    calc_if<!is_constant<T_scale_cl>::value>(sigma_deriv));
+
+  T_partials_return lccdf = (from_matrix_cl(lccdf_cl)).sum();
+
+  operands_and_partials<decltype(y_col), decltype(alpha_col),
+                        decltype(sigma_col)>
+      ops_partials(y_col, alpha_col, sigma_col);
+
+  if (!is_constant<T_y_cl>::value) {
+    ops_partials.edge1_.partials_ = std::move(y_deriv_cl);
+  }
+  if (!is_constant<T_shape_cl>::value) {
+    ops_partials.edge2_.partials_ = std::move(alpha_deriv_cl);
+  }
+  if (!is_constant<T_scale_cl>::value) {
+    ops_partials.edge3_.partials_ = std::move(sigma_deriv_cl);
+  }
+  return ops_partials.build(lccdf);
+}
+
+}  // namespace math
+}  // namespace stan
+#endif
+#endif

--- a/stan/math/opencl/prim/frechet_lcdf.hpp
+++ b/stan/math/opencl/prim/frechet_lcdf.hpp
@@ -1,0 +1,108 @@
+#ifndef STAN_MATH_OPENCL_PRIM_FRECHET_LCDF_HPP
+#define STAN_MATH_OPENCL_PRIM_FRECHET_LCDF_HPP
+#ifdef STAN_OPENCL
+
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/err.hpp>
+#include <stan/math/prim/fun/constants.hpp>
+#include <stan/math/prim/fun/elt_divide.hpp>
+#include <stan/math/prim/fun/elt_multiply.hpp>
+#include <stan/math/opencl/kernel_generator.hpp>
+#include <stan/math/prim/functor/operands_and_partials.hpp>
+
+namespace stan {
+namespace math {
+
+/** \ingroup opencl
+ * Returns the frechet log cumulative distribution function for
+ * the given location, and scale. If given containers of matching sizes returns
+ * the product of probabilities.
+ *
+ * @tparam T_y_cl type of scalar outcome
+ * @tparam T_shape_cl type of location
+ * @tparam T_scale_cl type of scale
+ * @param y (Sequence of) scalar(s).
+ * @param alpha (Sequence of) location(s).
+ * @param sigma (Sequence of) scale(s).
+ * @return The log of the product of densities.
+ */
+template <
+    typename T_y_cl, typename T_shape_cl, typename T_scale_cl,
+    require_all_prim_or_rev_kernel_expression_t<T_y_cl, T_shape_cl,
+                                                T_scale_cl>* = nullptr,
+    require_any_not_stan_scalar_t<T_y_cl, T_shape_cl, T_scale_cl>* = nullptr>
+return_type_t<T_y_cl, T_shape_cl, T_scale_cl> frechet_lcdf(
+    const T_y_cl& y, const T_shape_cl& alpha, const T_scale_cl& sigma) {
+  static const char* function = "frechet_lcdf(OpenCL)";
+  using T_partials_return = partials_return_t<T_y_cl, T_shape_cl, T_scale_cl>;
+  using std::isfinite;
+  using std::isnan;
+
+  check_consistent_sizes(function, "Random variable", y, "Shape parameter",
+                         alpha, "Scale parameter", sigma);
+  const size_t N = max_size(y, alpha, sigma);
+  if (N == 0) {
+    return 1.0;
+  }
+
+  const auto& y_col = as_column_vector_or_scalar(y);
+  const auto& alpha_col = as_column_vector_or_scalar(alpha);
+  const auto& sigma_col = as_column_vector_or_scalar(sigma);
+
+  const auto& y_val = value_of(y_col);
+  const auto& alpha_val = value_of(alpha_col);
+  const auto& sigma_val = value_of(sigma_col);
+
+  auto check_y_positive
+      = check_cl(function, "Random variable", y_val, "positive");
+  auto y_positive = y_val > 0;
+  auto check_alpha_positive_finite
+      = check_cl(function, "Shape parameter", alpha_val, "positive finite");
+  auto alpha_positive_finite_expr = alpha_val > 0 && isfinite(alpha_val);
+  auto check_sigma_positive_finite
+      = check_cl(function, "Scale parameter", sigma_val, "positive finite");
+  auto sigma_positive_finite_expr = 0 < sigma_val && isfinite(sigma_val);
+
+  auto pow_n = pow(elt_divide(sigma_val, y_val), alpha_val);
+  auto lcdf_expr = colwise_sum(pow_n);
+
+  auto y_deriv = elt_multiply(elt_divide(alpha_val, y_val), pow_n);
+  auto alpha_deriv = elt_multiply(log(elt_divide(y_val, sigma_val)), pow_n);
+  auto sigma_deriv = elt_multiply(elt_divide(alpha_val, -sigma_val), pow_n);
+
+  matrix_cl<double> lcdf_cl;
+  matrix_cl<double> y_deriv_cl;
+  matrix_cl<double> alpha_deriv_cl;
+  matrix_cl<double> sigma_deriv_cl;
+
+  results(check_y_positive, check_alpha_positive_finite,
+          check_sigma_positive_finite, lcdf_cl, y_deriv_cl, alpha_deriv_cl,
+          sigma_deriv_cl)
+      = expressions(y_positive, alpha_positive_finite_expr,
+                    sigma_positive_finite_expr, lcdf_expr,
+                    calc_if<!is_constant<T_y_cl>::value>(y_deriv),
+                    calc_if<!is_constant<T_shape_cl>::value>(alpha_deriv),
+                    calc_if<!is_constant<T_scale_cl>::value>(sigma_deriv));
+
+  T_partials_return lcdf = -(from_matrix_cl(lcdf_cl)).sum();
+
+  operands_and_partials<decltype(y_col), decltype(alpha_col),
+                        decltype(sigma_col)>
+      ops_partials(y_col, alpha_col, sigma_col);
+
+  if (!is_constant<T_y_cl>::value) {
+    ops_partials.edge1_.partials_ = std::move(y_deriv_cl);
+  }
+  if (!is_constant<T_shape_cl>::value) {
+    ops_partials.edge2_.partials_ = std::move(alpha_deriv_cl);
+  }
+  if (!is_constant<T_scale_cl>::value) {
+    ops_partials.edge3_.partials_ = std::move(sigma_deriv_cl);
+  }
+  return ops_partials.build(lcdf);
+}
+
+}  // namespace math
+}  // namespace stan
+#endif
+#endif

--- a/stan/math/prim/prob/exponential_cdf.hpp
+++ b/stan/math/prim/prob/exponential_cdf.hpp
@@ -29,7 +29,9 @@ namespace math {
  * @param y A scalar variable.
  * @param beta Inverse scale parameter.
  */
-template <typename T_y, typename T_inv_scale>
+template <typename T_y, typename T_inv_scale,
+          require_all_not_nonscalar_prim_or_rev_kernel_expression_t<
+              T_y, T_inv_scale>* = nullptr>
 return_type_t<T_y, T_inv_scale> exponential_cdf(const T_y& y,
                                                 const T_inv_scale& beta) {
   using T_partials_return = partials_return_t<T_y, T_inv_scale>;

--- a/stan/math/prim/prob/exponential_lccdf.hpp
+++ b/stan/math/prim/prob/exponential_lccdf.hpp
@@ -14,7 +14,9 @@
 namespace stan {
 namespace math {
 
-template <typename T_y, typename T_inv_scale>
+template <typename T_y, typename T_inv_scale,
+          require_all_not_nonscalar_prim_or_rev_kernel_expression_t<
+              T_y, T_inv_scale>* = nullptr>
 return_type_t<T_y, T_inv_scale> exponential_lccdf(const T_y& y,
                                                   const T_inv_scale& beta) {
   using T_partials_return = partials_return_t<T_y, T_inv_scale>;

--- a/stan/math/prim/prob/exponential_lcdf.hpp
+++ b/stan/math/prim/prob/exponential_lcdf.hpp
@@ -18,7 +18,9 @@
 namespace stan {
 namespace math {
 
-template <typename T_y, typename T_inv_scale>
+template <typename T_y, typename T_inv_scale,
+          require_all_not_nonscalar_prim_or_rev_kernel_expression_t<
+              T_y, T_inv_scale>* = nullptr>
 return_type_t<T_y, T_inv_scale> exponential_lcdf(const T_y& y,
                                                  const T_inv_scale& beta) {
   using T_partials_return = partials_return_t<T_y, T_inv_scale>;

--- a/stan/math/prim/prob/frechet_cdf.hpp
+++ b/stan/math/prim/prob/frechet_cdf.hpp
@@ -22,7 +22,9 @@
 namespace stan {
 namespace math {
 
-template <typename T_y, typename T_shape, typename T_scale>
+template <typename T_y, typename T_shape, typename T_scale,
+          require_all_not_nonscalar_prim_or_rev_kernel_expression_t<
+              T_y, T_shape, T_scale>* = nullptr>
 return_type_t<T_y, T_shape, T_scale> frechet_cdf(const T_y& y,
                                                  const T_shape& alpha,
                                                  const T_scale& sigma) {

--- a/stan/math/prim/prob/frechet_lccdf.hpp
+++ b/stan/math/prim/prob/frechet_lccdf.hpp
@@ -22,7 +22,9 @@
 namespace stan {
 namespace math {
 
-template <typename T_y, typename T_shape, typename T_scale>
+template <typename T_y, typename T_shape, typename T_scale,
+          require_all_not_nonscalar_prim_or_rev_kernel_expression_t<
+              T_y, T_shape, T_scale>* = nullptr>
 return_type_t<T_y, T_shape, T_scale> frechet_lccdf(const T_y& y,
                                                    const T_shape& alpha,
                                                    const T_scale& sigma) {

--- a/stan/math/prim/prob/frechet_lcdf.hpp
+++ b/stan/math/prim/prob/frechet_lcdf.hpp
@@ -20,7 +20,9 @@
 namespace stan {
 namespace math {
 
-template <typename T_y, typename T_shape, typename T_scale>
+template <typename T_y, typename T_shape, typename T_scale,
+          require_all_not_nonscalar_prim_or_rev_kernel_expression_t<
+              T_y, T_shape, T_scale>* = nullptr>
 return_type_t<T_y, T_shape, T_scale> frechet_lcdf(const T_y& y,
                                                   const T_shape& alpha,
                                                   const T_scale& sigma) {

--- a/test/unit/math/opencl/rev/exponential_cdf_test.cpp
+++ b/test/unit/math/opencl/rev/exponential_cdf_test.cpp
@@ -1,0 +1,99 @@
+#ifdef STAN_OPENCL
+#include <stan/math/opencl/rev.hpp>
+#include <stan/math.hpp>
+#include <gtest/gtest.h>
+#include <test/unit/math/opencl/util.hpp>
+#include <vector>
+
+TEST(ProbDistributionsExponentialCdf, error_checking) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  Eigen::VectorXd y_size(N - 1);
+  y_size << 0.3, 0.8;
+  Eigen::VectorXd y_value(N);
+  y_value << 0.3, -0.9, 0.5;
+
+  Eigen::VectorXd beta(N);
+  beta << 0.3, 0.8, 1.0;
+  Eigen::VectorXd beta_size(N - 1);
+  beta_size << 0.3, 0.8;
+  Eigen::VectorXd beta_value(N);
+  beta_value << 0.3, 0, -0.5;
+
+  stan::math::matrix_cl<double> y_cl(y);
+  stan::math::matrix_cl<double> y_size_cl(y_size);
+  stan::math::matrix_cl<double> y_value_cl(y_value);
+  stan::math::matrix_cl<double> beta_cl(beta);
+  stan::math::matrix_cl<double> beta_size_cl(beta_size);
+  stan::math::matrix_cl<double> beta_value_cl(beta_value);
+
+  EXPECT_NO_THROW(stan::math::exponential_cdf(y_cl, beta_cl));
+
+  EXPECT_THROW(stan::math::exponential_cdf(y_size_cl, beta_cl),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::exponential_cdf(y_cl, beta_size_cl),
+               std::invalid_argument);
+
+  EXPECT_THROW(stan::math::exponential_cdf(y_value_cl, beta_cl),
+               std::domain_error);
+  EXPECT_THROW(stan::math::exponential_cdf(y_cl, beta_value_cl),
+               std::domain_error);
+}
+
+auto exponential_cdf_functor = [](const auto& y, const auto& beta) {
+  return stan::math::exponential_cdf(y, beta);
+};
+
+TEST(ProbDistributionsExponentialCdf, opencl_matches_cpu_small) {
+  int N = 3;
+  int M = 2;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  Eigen::VectorXd beta(N);
+  beta << 0.3, 0.8, 1.0;
+
+  stan::math::test::compare_cpu_opencl_prim_rev(exponential_cdf_functor, y,
+                                                beta);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      exponential_cdf_functor, y.transpose().eval(), beta.transpose().eval());
+}
+
+TEST(ProbDistributionsExponentialCdf, opencl_broadcast_y) {
+  int N = 3;
+
+  double y_scal = 12.3;
+  Eigen::VectorXd beta(N);
+  beta << 0.3, 0.8, 1.0;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(
+      exponential_cdf_functor, y_scal, beta);
+}
+
+TEST(ProbDistributionsExponentialCdf, opencl_broadcast_beta) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  double beta_scal = 12.3;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<1>(
+      exponential_cdf_functor, y, beta_scal);
+}
+
+TEST(ProbDistributionsExponentialCdf, opencl_matches_cpu_big) {
+  int N = 153;
+
+  Eigen::Matrix<double, Eigen::Dynamic, 1> y
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+  Eigen::Matrix<double, Eigen::Dynamic, 1> beta
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+
+  stan::math::test::compare_cpu_opencl_prim_rev(exponential_cdf_functor,
+                                                y.transpose().eval(), beta);
+  stan::math::test::compare_cpu_opencl_prim_rev(exponential_cdf_functor, y,
+                                                beta.transpose().eval());
+}
+#endif

--- a/test/unit/math/opencl/rev/exponential_lccdf_test.cpp
+++ b/test/unit/math/opencl/rev/exponential_lccdf_test.cpp
@@ -1,0 +1,99 @@
+#ifdef STAN_OPENCL
+#include <stan/math/opencl/rev.hpp>
+#include <stan/math.hpp>
+#include <gtest/gtest.h>
+#include <test/unit/math/opencl/util.hpp>
+#include <vector>
+
+TEST(ProbDistributionsExponentialLccdf, error_checking) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  Eigen::VectorXd y_size(N - 1);
+  y_size << 0.3, 0.8;
+  Eigen::VectorXd y_value(N);
+  y_value << 0.3, -0.9, 0.5;
+
+  Eigen::VectorXd beta(N);
+  beta << 0.3, 0.8, 1.0;
+  Eigen::VectorXd beta_size(N - 1);
+  beta_size << 0.3, 0.8;
+  Eigen::VectorXd beta_value(N);
+  beta_value << 0.3, 0, -0.5;
+
+  stan::math::matrix_cl<double> y_cl(y);
+  stan::math::matrix_cl<double> y_size_cl(y_size);
+  stan::math::matrix_cl<double> y_value_cl(y_value);
+  stan::math::matrix_cl<double> beta_cl(beta);
+  stan::math::matrix_cl<double> beta_size_cl(beta_size);
+  stan::math::matrix_cl<double> beta_value_cl(beta_value);
+
+  EXPECT_NO_THROW(stan::math::exponential_lccdf(y_cl, beta_cl));
+
+  EXPECT_THROW(stan::math::exponential_lccdf(y_size_cl, beta_cl),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::exponential_lccdf(y_cl, beta_size_cl),
+               std::invalid_argument);
+
+  EXPECT_THROW(stan::math::exponential_lccdf(y_value_cl, beta_cl),
+               std::domain_error);
+  EXPECT_THROW(stan::math::exponential_lccdf(y_cl, beta_value_cl),
+               std::domain_error);
+}
+
+auto exponential_lccdf_functor = [](const auto& y, const auto& beta) {
+  return stan::math::exponential_lccdf(y, beta);
+};
+
+TEST(ProbDistributionsExponentialLccdf, opencl_matches_cpu_small) {
+  int N = 3;
+  int M = 2;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  Eigen::VectorXd beta(N);
+  beta << 0.3, 0.8, 1.0;
+
+  stan::math::test::compare_cpu_opencl_prim_rev(exponential_lccdf_functor, y,
+                                                beta);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      exponential_lccdf_functor, y.transpose().eval(), beta.transpose().eval());
+}
+
+TEST(ProbDistributionsExponentialLccdf, opencl_broadcast_y) {
+  int N = 3;
+
+  double y_scal = 12.3;
+  Eigen::VectorXd beta(N);
+  beta << 0.3, 0.8, 1.0;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(
+      exponential_lccdf_functor, y_scal, beta);
+}
+
+TEST(ProbDistributionsExponentialLccdf, opencl_broadcast_beta) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  double beta_scal = 12.3;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<1>(
+      exponential_lccdf_functor, y, beta_scal);
+}
+
+TEST(ProbDistributionsExponentialLccdf, opencl_matches_cpu_big) {
+  int N = 153;
+
+  Eigen::Matrix<double, Eigen::Dynamic, 1> y
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+  Eigen::Matrix<double, Eigen::Dynamic, 1> beta
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+
+  stan::math::test::compare_cpu_opencl_prim_rev(exponential_lccdf_functor,
+                                                y.transpose().eval(), beta);
+  stan::math::test::compare_cpu_opencl_prim_rev(exponential_lccdf_functor, y,
+                                                beta.transpose().eval());
+}
+#endif

--- a/test/unit/math/opencl/rev/exponential_lcdf_test.cpp
+++ b/test/unit/math/opencl/rev/exponential_lcdf_test.cpp
@@ -1,0 +1,99 @@
+#ifdef STAN_OPENCL
+#include <stan/math/opencl/rev.hpp>
+#include <stan/math.hpp>
+#include <gtest/gtest.h>
+#include <test/unit/math/opencl/util.hpp>
+#include <vector>
+
+TEST(ProbDistributionsExponentialLcdf, error_checking) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  Eigen::VectorXd y_size(N - 1);
+  y_size << 0.3, 0.8;
+  Eigen::VectorXd y_value(N);
+  y_value << 0.3, -0.9, 0.5;
+
+  Eigen::VectorXd beta(N);
+  beta << 0.3, 0.8, 1.0;
+  Eigen::VectorXd beta_size(N - 1);
+  beta_size << 0.3, 0.8;
+  Eigen::VectorXd beta_value(N);
+  beta_value << 0.3, 0, -0.5;
+
+  stan::math::matrix_cl<double> y_cl(y);
+  stan::math::matrix_cl<double> y_size_cl(y_size);
+  stan::math::matrix_cl<double> y_value_cl(y_value);
+  stan::math::matrix_cl<double> beta_cl(beta);
+  stan::math::matrix_cl<double> beta_size_cl(beta_size);
+  stan::math::matrix_cl<double> beta_value_cl(beta_value);
+
+  EXPECT_NO_THROW(stan::math::exponential_lcdf(y_cl, beta_cl));
+
+  EXPECT_THROW(stan::math::exponential_lcdf(y_size_cl, beta_cl),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::exponential_lcdf(y_cl, beta_size_cl),
+               std::invalid_argument);
+
+  EXPECT_THROW(stan::math::exponential_lcdf(y_value_cl, beta_cl),
+               std::domain_error);
+  EXPECT_THROW(stan::math::exponential_lcdf(y_cl, beta_value_cl),
+               std::domain_error);
+}
+
+auto exponential_lcdf_functor = [](const auto& y, const auto& beta) {
+  return stan::math::exponential_lcdf(y, beta);
+};
+
+TEST(ProbDistributionsExponentialLcdf, opencl_matches_cpu_small) {
+  int N = 3;
+  int M = 2;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  Eigen::VectorXd beta(N);
+  beta << 0.3, 0.8, 1.0;
+
+  stan::math::test::compare_cpu_opencl_prim_rev(exponential_lcdf_functor, y,
+                                                beta);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      exponential_lcdf_functor, y.transpose().eval(), beta.transpose().eval());
+}
+
+TEST(ProbDistributionsExponentialLcdf, opencl_broadcast_y) {
+  int N = 3;
+
+  double y_scal = 12.3;
+  Eigen::VectorXd beta(N);
+  beta << 0.3, 0.8, 1.0;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(
+      exponential_lcdf_functor, y_scal, beta);
+}
+
+TEST(ProbDistributionsExponentialLcdf, opencl_broadcast_beta) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  double beta_scal = 12.3;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<1>(
+      exponential_lcdf_functor, y, beta_scal);
+}
+
+TEST(ProbDistributionsExponentialLcdf, opencl_matches_cpu_big) {
+  int N = 153;
+
+  Eigen::Matrix<double, Eigen::Dynamic, 1> y
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+  Eigen::Matrix<double, Eigen::Dynamic, 1> beta
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+
+  stan::math::test::compare_cpu_opencl_prim_rev(exponential_lcdf_functor,
+                                                y.transpose().eval(), beta);
+  stan::math::test::compare_cpu_opencl_prim_rev(exponential_lcdf_functor, y,
+                                                beta.transpose().eval());
+}
+#endif

--- a/test/unit/math/opencl/rev/frechet_cdf_test.cpp
+++ b/test/unit/math/opencl/rev/frechet_cdf_test.cpp
@@ -56,9 +56,10 @@ TEST(ProbDistributionsFrechetCdf, error_checking) {
                std::domain_error);
 }
 
-auto frechet_cdf_functor = [](const auto& y, const auto& alpha, const auto& sigma) {
-  return stan::math::frechet_cdf(y, alpha, sigma);
-};
+auto frechet_cdf_functor
+    = [](const auto& y, const auto& alpha, const auto& sigma) {
+        return stan::math::frechet_cdf(y, alpha, sigma);
+      };
 
 TEST(ProbDistributionsFrechetCdf, opencl_matches_cpu_small) {
   int N = 3;

--- a/test/unit/math/opencl/rev/frechet_cdf_test.cpp
+++ b/test/unit/math/opencl/rev/frechet_cdf_test.cpp
@@ -1,0 +1,142 @@
+#ifdef STAN_OPENCL
+#include <stan/math/opencl/rev.hpp>
+#include <stan/math.hpp>
+#include <gtest/gtest.h>
+#include <test/unit/math/opencl/util.hpp>
+#include <vector>
+
+TEST(ProbDistributionsFrechetCdf, error_checking) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  Eigen::VectorXd y_size(N - 1);
+  y_size << 0.3, 0.8;
+  Eigen::VectorXd y_value(N);
+  y_value << 0.3, NAN, 0.5;
+
+  Eigen::VectorXd alpha(N);
+  alpha << 0.3, 0.8, 1.0;
+  Eigen::VectorXd alpha_size(N - 1);
+  alpha_size << 0.3, 0.8;
+  Eigen::VectorXd alpha_value(N);
+  alpha_value << 0.3, -0.6, 0.5;
+
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+  Eigen::VectorXd sigma_size(N - 1);
+  sigma_size << 0.3, 0.8;
+  Eigen::VectorXd sigma_value(N);
+  sigma_value << 0.3, 0, 0.5;
+
+  stan::math::matrix_cl<double> y_cl(y);
+  stan::math::matrix_cl<double> y_size_cl(y_size);
+  stan::math::matrix_cl<double> y_value_cl(y_value);
+  stan::math::matrix_cl<double> alpha_cl(alpha);
+  stan::math::matrix_cl<double> alpha_size_cl(alpha_size);
+  stan::math::matrix_cl<double> alpha_value_cl(alpha_value);
+  stan::math::matrix_cl<double> sigma_cl(sigma);
+  stan::math::matrix_cl<double> sigma_size_cl(sigma_size);
+  stan::math::matrix_cl<double> sigma_value_cl(sigma_value);
+
+  EXPECT_NO_THROW(stan::math::frechet_cdf(y_cl, alpha_cl, sigma_cl));
+
+  EXPECT_THROW(stan::math::frechet_cdf(y_size_cl, alpha_cl, sigma_cl),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::frechet_cdf(y_cl, alpha_size_cl, sigma_cl),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::frechet_cdf(y_cl, alpha_cl, sigma_size_cl),
+               std::invalid_argument);
+
+  EXPECT_THROW(stan::math::frechet_cdf(y_value_cl, alpha_cl, sigma_cl),
+               std::domain_error);
+  EXPECT_THROW(stan::math::frechet_cdf(y_cl, alpha_value_cl, sigma_cl),
+               std::domain_error);
+  EXPECT_THROW(stan::math::frechet_cdf(y_cl, alpha_cl, sigma_value_cl),
+               std::domain_error);
+}
+
+auto frechet_cdf_functor = [](const auto& y, const auto& alpha, const auto& sigma) {
+  return stan::math::frechet_cdf(y, alpha, sigma);
+};
+
+TEST(ProbDistributionsFrechetCdf, opencl_matches_cpu_small) {
+  int N = 3;
+  int M = 2;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  Eigen::VectorXd alpha(N);
+  alpha << 0.3, 0.8, 1.0;
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+
+  stan::math::test::compare_cpu_opencl_prim_rev(frechet_cdf_functor, y, alpha,
+                                                sigma);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      frechet_cdf_functor, y.transpose().eval(), alpha.transpose().eval(),
+      sigma.transpose().eval());
+}
+
+TEST(ProbDistributionsFrechetCdf, opencl_broadcast_y) {
+  int N = 3;
+
+  double y_scal = 12.3;
+  Eigen::VectorXd alpha(N);
+  alpha << 0.5, 1.2, 1.0;
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(frechet_cdf_functor,
+                                                         y_scal, alpha, sigma);
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(
+      frechet_cdf_functor, y_scal, alpha.transpose().eval(), sigma);
+}
+
+TEST(ProbDistributionsFrechetCdf, opencl_broadcast_alpha) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  double alpha_scal = 12.3;
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<1>(frechet_cdf_functor, y,
+                                                         alpha_scal, sigma);
+  stan::math::test::test_opencl_broadcasting_prim_rev<1>(
+      frechet_cdf_functor, y.transpose().eval(), alpha_scal, sigma);
+}
+
+TEST(ProbDistributionsFrechetCdf, opencl_broadcast_sigma) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  Eigen::VectorXd alpha(N);
+  alpha << 0.3, 0.8, 1.0;
+  double sigma_scal = 12.3;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<2>(frechet_cdf_functor, y,
+                                                         alpha, sigma_scal);
+  stan::math::test::test_opencl_broadcasting_prim_rev<2>(
+      frechet_cdf_functor, y.transpose().eval(), alpha, sigma_scal);
+}
+
+TEST(ProbDistributionsFrechetCdf, opencl_matches_cpu_big) {
+  int N = 153;
+
+  Eigen::Matrix<double, Eigen::Dynamic, 1> y
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+  Eigen::Matrix<double, Eigen::Dynamic, 1> alpha
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+  Eigen::Matrix<double, Eigen::Dynamic, 1> sigma
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+
+  stan::math::test::compare_cpu_opencl_prim_rev(frechet_cdf_functor, y, alpha,
+                                                sigma);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      frechet_cdf_functor, y.transpose().eval(), alpha.transpose().eval(),
+      sigma.transpose().eval());
+}
+#endif

--- a/test/unit/math/opencl/rev/frechet_lccdf_test.cpp
+++ b/test/unit/math/opencl/rev/frechet_lccdf_test.cpp
@@ -1,0 +1,142 @@
+#ifdef STAN_OPENCL
+#include <stan/math/opencl/rev.hpp>
+#include <stan/math.hpp>
+#include <gtest/gtest.h>
+#include <test/unit/math/opencl/util.hpp>
+#include <vector>
+
+TEST(ProbDistributionsFrechetLccdf, error_checking) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  Eigen::VectorXd y_size(N - 1);
+  y_size << 0.3, 0.8;
+  Eigen::VectorXd y_value(N);
+  y_value << 0.3, NAN, 0.5;
+
+  Eigen::VectorXd alpha(N);
+  alpha << 0.3, 0.8, 1.0;
+  Eigen::VectorXd alpha_size(N - 1);
+  alpha_size << 0.3, 0.8;
+  Eigen::VectorXd alpha_value(N);
+  alpha_value << 0.3, -0.6, 0.5;
+
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+  Eigen::VectorXd sigma_size(N - 1);
+  sigma_size << 0.3, 0.8;
+  Eigen::VectorXd sigma_value(N);
+  sigma_value << 0.3, 0, 0.5;
+
+  stan::math::matrix_cl<double> y_cl(y);
+  stan::math::matrix_cl<double> y_size_cl(y_size);
+  stan::math::matrix_cl<double> y_value_cl(y_value);
+  stan::math::matrix_cl<double> alpha_cl(alpha);
+  stan::math::matrix_cl<double> alpha_size_cl(alpha_size);
+  stan::math::matrix_cl<double> alpha_value_cl(alpha_value);
+  stan::math::matrix_cl<double> sigma_cl(sigma);
+  stan::math::matrix_cl<double> sigma_size_cl(sigma_size);
+  stan::math::matrix_cl<double> sigma_value_cl(sigma_value);
+
+  EXPECT_NO_THROW(stan::math::frechet_lccdf(y_cl, alpha_cl, sigma_cl));
+
+  EXPECT_THROW(stan::math::frechet_lccdf(y_size_cl, alpha_cl, sigma_cl),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::frechet_lccdf(y_cl, alpha_size_cl, sigma_cl),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::frechet_lccdf(y_cl, alpha_cl, sigma_size_cl),
+               std::invalid_argument);
+
+  EXPECT_THROW(stan::math::frechet_lccdf(y_value_cl, alpha_cl, sigma_cl),
+               std::domain_error);
+  EXPECT_THROW(stan::math::frechet_lccdf(y_cl, alpha_value_cl, sigma_cl),
+               std::domain_error);
+  EXPECT_THROW(stan::math::frechet_lccdf(y_cl, alpha_cl, sigma_value_cl),
+               std::domain_error);
+}
+
+auto frechet_lccdf_functor = [](const auto& y, const auto& alpha, const auto& sigma) {
+  return stan::math::frechet_lccdf(y, alpha, sigma);
+};
+
+TEST(ProbDistributionsFrechetLccdf, opencl_matches_cpu_small) {
+  int N = 3;
+  int M = 2;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  Eigen::VectorXd alpha(N);
+  alpha << 0.3, 0.8, 1.0;
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+
+  stan::math::test::compare_cpu_opencl_prim_rev(frechet_lccdf_functor, y, alpha,
+                                                sigma);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      frechet_lccdf_functor, y.transpose().eval(), alpha.transpose().eval(),
+      sigma.transpose().eval());
+}
+
+TEST(ProbDistributionsFrechetLccdf, opencl_broadcast_y) {
+  int N = 3;
+
+  double y_scal = 12.3;
+  Eigen::VectorXd alpha(N);
+  alpha << 0.5, 1.2, 1.0;
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(frechet_lccdf_functor,
+                                                         y_scal, alpha, sigma);
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(
+      frechet_lccdf_functor, y_scal, alpha.transpose().eval(), sigma);
+}
+
+TEST(ProbDistributionsFrechetLccdf, opencl_broadcast_alpha) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  double alpha_scal = 12.3;
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<1>(frechet_lccdf_functor, y,
+                                                         alpha_scal, sigma);
+  stan::math::test::test_opencl_broadcasting_prim_rev<1>(
+      frechet_lccdf_functor, y.transpose().eval(), alpha_scal, sigma);
+}
+
+TEST(ProbDistributionsFrechetLccdf, opencl_broadcast_sigma) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  Eigen::VectorXd alpha(N);
+  alpha << 0.3, 0.8, 1.0;
+  double sigma_scal = 12.3;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<2>(frechet_lccdf_functor, y,
+                                                         alpha, sigma_scal);
+  stan::math::test::test_opencl_broadcasting_prim_rev<2>(
+      frechet_lccdf_functor, y.transpose().eval(), alpha, sigma_scal);
+}
+
+TEST(ProbDistributionsFrechetLccdf, opencl_matches_cpu_big) {
+  int N = 153;
+
+  Eigen::Matrix<double, Eigen::Dynamic, 1> y
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+  Eigen::Matrix<double, Eigen::Dynamic, 1> alpha
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+  Eigen::Matrix<double, Eigen::Dynamic, 1> sigma
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+
+  stan::math::test::compare_cpu_opencl_prim_rev(frechet_lccdf_functor, y, alpha,
+                                                sigma);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      frechet_lccdf_functor, y.transpose().eval(), alpha.transpose().eval(),
+      sigma.transpose().eval());
+}
+#endif

--- a/test/unit/math/opencl/rev/frechet_lccdf_test.cpp
+++ b/test/unit/math/opencl/rev/frechet_lccdf_test.cpp
@@ -56,9 +56,10 @@ TEST(ProbDistributionsFrechetLccdf, error_checking) {
                std::domain_error);
 }
 
-auto frechet_lccdf_functor = [](const auto& y, const auto& alpha, const auto& sigma) {
-  return stan::math::frechet_lccdf(y, alpha, sigma);
-};
+auto frechet_lccdf_functor
+    = [](const auto& y, const auto& alpha, const auto& sigma) {
+        return stan::math::frechet_lccdf(y, alpha, sigma);
+      };
 
 TEST(ProbDistributionsFrechetLccdf, opencl_matches_cpu_small) {
   int N = 3;
@@ -102,8 +103,8 @@ TEST(ProbDistributionsFrechetLccdf, opencl_broadcast_alpha) {
   Eigen::VectorXd sigma(N);
   sigma << 0.3, 0.8, 1.0;
 
-  stan::math::test::test_opencl_broadcasting_prim_rev<1>(frechet_lccdf_functor, y,
-                                                         alpha_scal, sigma);
+  stan::math::test::test_opencl_broadcasting_prim_rev<1>(frechet_lccdf_functor,
+                                                         y, alpha_scal, sigma);
   stan::math::test::test_opencl_broadcasting_prim_rev<1>(
       frechet_lccdf_functor, y.transpose().eval(), alpha_scal, sigma);
 }
@@ -117,8 +118,8 @@ TEST(ProbDistributionsFrechetLccdf, opencl_broadcast_sigma) {
   alpha << 0.3, 0.8, 1.0;
   double sigma_scal = 12.3;
 
-  stan::math::test::test_opencl_broadcasting_prim_rev<2>(frechet_lccdf_functor, y,
-                                                         alpha, sigma_scal);
+  stan::math::test::test_opencl_broadcasting_prim_rev<2>(frechet_lccdf_functor,
+                                                         y, alpha, sigma_scal);
   stan::math::test::test_opencl_broadcasting_prim_rev<2>(
       frechet_lccdf_functor, y.transpose().eval(), alpha, sigma_scal);
 }

--- a/test/unit/math/opencl/rev/frechet_lcdf_test.cpp
+++ b/test/unit/math/opencl/rev/frechet_lcdf_test.cpp
@@ -56,9 +56,10 @@ TEST(ProbDistributionsFrechetLcdf, error_checking) {
                std::domain_error);
 }
 
-auto frechet_lcdf_functor = [](const auto& y, const auto& alpha, const auto& sigma) {
-  return stan::math::frechet_lcdf(y, alpha, sigma);
-};
+auto frechet_lcdf_functor
+    = [](const auto& y, const auto& alpha, const auto& sigma) {
+        return stan::math::frechet_lcdf(y, alpha, sigma);
+      };
 
 TEST(ProbDistributionsFrechetLcdf, opencl_matches_cpu_small) {
   int N = 3;
@@ -102,8 +103,8 @@ TEST(ProbDistributionsFrechetLcdf, opencl_broadcast_alpha) {
   Eigen::VectorXd sigma(N);
   sigma << 0.3, 0.8, 1.0;
 
-  stan::math::test::test_opencl_broadcasting_prim_rev<1>(frechet_lcdf_functor, y,
-                                                         alpha_scal, sigma);
+  stan::math::test::test_opencl_broadcasting_prim_rev<1>(frechet_lcdf_functor,
+                                                         y, alpha_scal, sigma);
   stan::math::test::test_opencl_broadcasting_prim_rev<1>(
       frechet_lcdf_functor, y.transpose().eval(), alpha_scal, sigma);
 }
@@ -117,8 +118,8 @@ TEST(ProbDistributionsFrechetLcdf, opencl_broadcast_sigma) {
   alpha << 0.3, 0.8, 1.0;
   double sigma_scal = 12.3;
 
-  stan::math::test::test_opencl_broadcasting_prim_rev<2>(frechet_lcdf_functor, y,
-                                                         alpha, sigma_scal);
+  stan::math::test::test_opencl_broadcasting_prim_rev<2>(frechet_lcdf_functor,
+                                                         y, alpha, sigma_scal);
   stan::math::test::test_opencl_broadcasting_prim_rev<2>(
       frechet_lcdf_functor, y.transpose().eval(), alpha, sigma_scal);
 }

--- a/test/unit/math/opencl/rev/frechet_lcdf_test.cpp
+++ b/test/unit/math/opencl/rev/frechet_lcdf_test.cpp
@@ -1,0 +1,142 @@
+#ifdef STAN_OPENCL
+#include <stan/math/opencl/rev.hpp>
+#include <stan/math.hpp>
+#include <gtest/gtest.h>
+#include <test/unit/math/opencl/util.hpp>
+#include <vector>
+
+TEST(ProbDistributionsFrechetLcdf, error_checking) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  Eigen::VectorXd y_size(N - 1);
+  y_size << 0.3, 0.8;
+  Eigen::VectorXd y_value(N);
+  y_value << 0.3, NAN, 0.5;
+
+  Eigen::VectorXd alpha(N);
+  alpha << 0.3, 0.8, 1.0;
+  Eigen::VectorXd alpha_size(N - 1);
+  alpha_size << 0.3, 0.8;
+  Eigen::VectorXd alpha_value(N);
+  alpha_value << 0.3, -0.6, 0.5;
+
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+  Eigen::VectorXd sigma_size(N - 1);
+  sigma_size << 0.3, 0.8;
+  Eigen::VectorXd sigma_value(N);
+  sigma_value << 0.3, 0, 0.5;
+
+  stan::math::matrix_cl<double> y_cl(y);
+  stan::math::matrix_cl<double> y_size_cl(y_size);
+  stan::math::matrix_cl<double> y_value_cl(y_value);
+  stan::math::matrix_cl<double> alpha_cl(alpha);
+  stan::math::matrix_cl<double> alpha_size_cl(alpha_size);
+  stan::math::matrix_cl<double> alpha_value_cl(alpha_value);
+  stan::math::matrix_cl<double> sigma_cl(sigma);
+  stan::math::matrix_cl<double> sigma_size_cl(sigma_size);
+  stan::math::matrix_cl<double> sigma_value_cl(sigma_value);
+
+  EXPECT_NO_THROW(stan::math::frechet_lcdf(y_cl, alpha_cl, sigma_cl));
+
+  EXPECT_THROW(stan::math::frechet_lcdf(y_size_cl, alpha_cl, sigma_cl),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::frechet_lcdf(y_cl, alpha_size_cl, sigma_cl),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::frechet_lcdf(y_cl, alpha_cl, sigma_size_cl),
+               std::invalid_argument);
+
+  EXPECT_THROW(stan::math::frechet_lcdf(y_value_cl, alpha_cl, sigma_cl),
+               std::domain_error);
+  EXPECT_THROW(stan::math::frechet_lcdf(y_cl, alpha_value_cl, sigma_cl),
+               std::domain_error);
+  EXPECT_THROW(stan::math::frechet_lcdf(y_cl, alpha_cl, sigma_value_cl),
+               std::domain_error);
+}
+
+auto frechet_lcdf_functor = [](const auto& y, const auto& alpha, const auto& sigma) {
+  return stan::math::frechet_lcdf(y, alpha, sigma);
+};
+
+TEST(ProbDistributionsFrechetLcdf, opencl_matches_cpu_small) {
+  int N = 3;
+  int M = 2;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  Eigen::VectorXd alpha(N);
+  alpha << 0.3, 0.8, 1.0;
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+
+  stan::math::test::compare_cpu_opencl_prim_rev(frechet_lcdf_functor, y, alpha,
+                                                sigma);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      frechet_lcdf_functor, y.transpose().eval(), alpha.transpose().eval(),
+      sigma.transpose().eval());
+}
+
+TEST(ProbDistributionsFrechetLcdf, opencl_broadcast_y) {
+  int N = 3;
+
+  double y_scal = 12.3;
+  Eigen::VectorXd alpha(N);
+  alpha << 0.5, 1.2, 1.0;
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(frechet_lcdf_functor,
+                                                         y_scal, alpha, sigma);
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(
+      frechet_lcdf_functor, y_scal, alpha.transpose().eval(), sigma);
+}
+
+TEST(ProbDistributionsFrechetLcdf, opencl_broadcast_alpha) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  double alpha_scal = 12.3;
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<1>(frechet_lcdf_functor, y,
+                                                         alpha_scal, sigma);
+  stan::math::test::test_opencl_broadcasting_prim_rev<1>(
+      frechet_lcdf_functor, y.transpose().eval(), alpha_scal, sigma);
+}
+
+TEST(ProbDistributionsFrechetLcdf, opencl_broadcast_sigma) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  Eigen::VectorXd alpha(N);
+  alpha << 0.3, 0.8, 1.0;
+  double sigma_scal = 12.3;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<2>(frechet_lcdf_functor, y,
+                                                         alpha, sigma_scal);
+  stan::math::test::test_opencl_broadcasting_prim_rev<2>(
+      frechet_lcdf_functor, y.transpose().eval(), alpha, sigma_scal);
+}
+
+TEST(ProbDistributionsFrechetLcdf, opencl_matches_cpu_big) {
+  int N = 153;
+
+  Eigen::Matrix<double, Eigen::Dynamic, 1> y
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+  Eigen::Matrix<double, Eigen::Dynamic, 1> alpha
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+  Eigen::Matrix<double, Eigen::Dynamic, 1> sigma
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+
+  stan::math::test::compare_cpu_opencl_prim_rev(frechet_lcdf_functor, y, alpha,
+                                                sigma);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      frechet_lcdf_functor, y.transpose().eval(), alpha.transpose().eval(),
+      sigma.transpose().eval());
+}
+#endif


### PR DESCRIPTION
## Summary

Added OpenCL implementations for functions `exponential_cdf`, `exponential_lcdf`, `exponential_lccdf`, `frechet_cdf`, `frechet_lcdf` and `frechet_lccdf`.

## Tests

New functions are tested.

## Side Effects
None

## Release notes

OpenCL: Added OpenCL implementations for functions `exponential_cdf`, `exponential_lcdf`, `exponential_lccdf`, `frechet_cdf`, `frechet_lcdf` and `frechet_lccdf`.

## Checklist

- [ ] Math issue #2152 

- [ ] Copyright holder: Tadej Ciglarič

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [ ] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [ ] the code is written in idiomatic C++ and changes are documented in the doxygen

- [ ] the new changes are tested
