### PR TITLE
Opencl gumbel and logistic (lc)cdf

### DIFF
--- a/stan/math/opencl/prim.hpp
+++ b/stan/math/opencl/prim.hpp
@@ -153,6 +153,9 @@
 #include <stan/math/opencl/prim/lb_constrain.hpp>
 #include <stan/math/opencl/prim/log_mix.hpp>
 #include <stan/math/opencl/prim/log_softmax.hpp>
+#include <stan/math/opencl/prim/logistic_cdf.hpp>
+#include <stan/math/opencl/prim/logistic_lccdf.hpp>
+#include <stan/math/opencl/prim/logistic_lcdf.hpp>
 #include <stan/math/opencl/prim/logistic_lpdf.hpp>
 #include <stan/math/opencl/prim/log_sum_exp.hpp>
 #include <stan/math/opencl/prim/lognormal_lpdf.hpp>

--- a/stan/math/opencl/prim.hpp
+++ b/stan/math/opencl/prim.hpp
@@ -140,6 +140,9 @@
 #include <stan/math/opencl/prim/frechet_lpdf.hpp>
 #include <stan/math/opencl/prim/gamma_lpdf.hpp>
 #include <stan/math/opencl/prim/gp_exp_quad_cov.hpp>
+#include <stan/math/opencl/prim/gumbel_cdf.hpp>
+#include <stan/math/opencl/prim/gumbel_lccdf.hpp>
+#include <stan/math/opencl/prim/gumbel_lcdf.hpp>
 #include <stan/math/opencl/prim/gumbel_lpdf.hpp>
 #include <stan/math/opencl/prim/head.hpp>
 #include <stan/math/opencl/prim/inv.hpp>

--- a/stan/math/opencl/prim/gumbel_cdf.hpp
+++ b/stan/math/opencl/prim/gumbel_cdf.hpp
@@ -84,7 +84,7 @@ return_type_t<T_y_cl, T_loc_cl, T_scale_cl> gumbel_cdf(const T_y_cl& y,
               rep_deriv),
           calc_if<!is_constant<T_scale_cl>::value>(scaled_diff));
 
-  T_partials_return cdf = sum(from_matrix_cl(cdf_cl));
+  T_partials_return cdf = (from_matrix_cl(cdf_cl)).prod();
 
   auto y_deriv = elt_multiply(cdf, mu_deriv_cl);
   auto mu_deriv = -y_deriv;

--- a/stan/math/opencl/prim/gumbel_cdf.hpp
+++ b/stan/math/opencl/prim/gumbel_cdf.hpp
@@ -1,0 +1,118 @@
+#ifndef STAN_MATH_OPENCL_PRIM_GUMBEL_CDF_HPP
+#define STAN_MATH_OPENCL_PRIM_GUMBEL_CDF_HPP
+#ifdef STAN_OPENCL
+
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/err.hpp>
+#include <stan/math/prim/fun/constants.hpp>
+#include <stan/math/prim/fun/elt_divide.hpp>
+#include <stan/math/prim/fun/elt_multiply.hpp>
+#include <stan/math/opencl/kernel_generator.hpp>
+#include <stan/math/prim/functor/operands_and_partials.hpp>
+
+namespace stan {
+namespace math {
+
+/** \ingroup opencl
+ * Returns the gumbel cumulative distribution function for the given
+ * location, and scale. If given containers of matching sizes
+ * returns the product of probabilities.
+ *
+ * @tparam T_y_cl type of scalar outcome
+ * @tparam T_loc_cl type of location
+ * @tparam T_scale_cl type of scale
+ * @param y (Sequence of) scalar(s).
+ * @param mu (Sequence of) location(s).
+ * @param beta (Sequence of) scale(s).
+ * @return The product of densities.
+ */
+template <
+    typename T_y_cl, typename T_loc_cl, typename T_scale_cl,
+    require_all_prim_or_rev_kernel_expression_t<T_y_cl, T_loc_cl,
+                                                T_scale_cl>* = nullptr,
+    require_any_not_stan_scalar_t<T_y_cl, T_loc_cl, T_scale_cl>* = nullptr>
+return_type_t<T_y_cl, T_loc_cl, T_scale_cl> gumbel_cdf(const T_y_cl& y,
+                                                       const T_loc_cl& mu,
+                                                       const T_scale_cl& beta) {
+  static const char* function = "gumbel_cdf(OpenCL)";
+  using T_partials_return = partials_return_t<T_y_cl, T_loc_cl, T_scale_cl>;
+  using std::isfinite;
+  using std::isnan;
+
+  check_consistent_sizes(function, "Random variable", y, "Location parameter",
+                         mu, "Scale parameter", beta);
+  const size_t N = max_size(y, mu, beta);
+  if (N == 0) {
+    return 1.0;
+  }
+
+  const auto& y_col = as_column_vector_or_scalar(y);
+  const auto& mu_col = as_column_vector_or_scalar(mu);
+  const auto& beta_col = as_column_vector_or_scalar(beta);
+
+  const auto& y_val = value_of(y_col);
+  const auto& mu_val = value_of(mu_col);
+  const auto& beta_val = value_of(beta_col);
+
+  auto check_y_not_nan
+      = check_cl(function, "Random variable", y_val, "not NaN");
+  auto y_not_nan_expr = !isnan(y_val);
+  auto check_mu_finite
+      = check_cl(function, "Location parameter", mu_val, "finite");
+  auto mu_finite_expr = isfinite(mu_val);
+  auto check_beta_positive
+      = check_cl(function, "Scale parameter", beta_val, "positive");
+  auto beta_positive_expr = 0.0 < beta_val;
+
+  auto scaled_diff = elt_divide(y_val - mu_val, beta_val);
+  auto exp_m_scaled_diff = exp(-scaled_diff);
+  auto cdf_n = exp(-exp_m_scaled_diff);
+  auto cdf_expr = colwise_prod(cdf_n);
+  auto rep_deriv = elt_divide(exp(-scaled_diff - exp_m_scaled_diff),
+                              elt_multiply(beta_val, cdf_n));
+
+  matrix_cl<double> cdf_cl;
+  matrix_cl<double> y_deriv_cl;
+  matrix_cl<double> mu_deriv_cl;
+  matrix_cl<double> beta_deriv_cl;
+
+  results(check_y_not_nan, check_mu_finite, check_beta_positive, cdf_cl,
+          mu_deriv_cl, beta_deriv_cl)
+      = expressions(
+          y_not_nan_expr, mu_finite_expr, beta_positive_expr, cdf_expr,
+          calc_if<!is_constant_all<T_y_cl, T_loc_cl, T_scale_cl>::value>(
+              rep_deriv),
+          calc_if<!is_constant<T_scale_cl>::value>(scaled_diff));
+
+  T_partials_return cdf = sum(from_matrix_cl(cdf_cl));
+
+  auto y_deriv = elt_multiply(cdf, mu_deriv_cl);
+  auto mu_deriv = -y_deriv;
+  auto beta_deriv
+      = elt_multiply(static_select<is_constant<T_scale_cl>::value>(0, mu_deriv),
+                     beta_deriv_cl);
+
+  results(y_deriv_cl, mu_deriv_cl, beta_deriv_cl)
+      = expressions(calc_if<!is_constant<T_y_cl>::value>(y_deriv),
+                    calc_if<!is_constant<T_loc_cl>::value>(mu_deriv),
+                    calc_if<!is_constant<T_scale_cl>::value>(beta_deriv));
+
+  operands_and_partials<decltype(y_col), decltype(mu_col), decltype(beta_col)>
+      ops_partials(y_col, mu_col, beta_col);
+
+  if (!is_constant<T_y_cl>::value) {
+    ops_partials.edge1_.partials_ = std::move(y_deriv_cl);
+  }
+  if (!is_constant<T_loc_cl>::value) {
+    ops_partials.edge2_.partials_ = std::move(mu_deriv_cl);
+  }
+  if (!is_constant<T_scale_cl>::value) {
+    ops_partials.edge3_.partials_ = std::move(beta_deriv_cl);
+  }
+  return ops_partials.build(cdf);
+}
+
+}  // namespace math
+}  // namespace stan
+#endif
+#endif

--- a/stan/math/opencl/prim/gumbel_lccdf.hpp
+++ b/stan/math/opencl/prim/gumbel_lccdf.hpp
@@ -1,0 +1,107 @@
+#ifndef STAN_MATH_OPENCL_PRIM_GUMBEL_LCCDF_HPP
+#define STAN_MATH_OPENCL_PRIM_GUMBEL_LCCDF_HPP
+#ifdef STAN_OPENCL
+
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/err.hpp>
+#include <stan/math/prim/fun/constants.hpp>
+#include <stan/math/prim/fun/elt_divide.hpp>
+#include <stan/math/prim/fun/elt_multiply.hpp>
+#include <stan/math/opencl/kernel_generator.hpp>
+#include <stan/math/prim/functor/operands_and_partials.hpp>
+
+namespace stan {
+namespace math {
+
+/** \ingroup opencl
+ * Returns the Gumbel log complementary cumulative distribution function for the
+ * given location, and scale. If given containers of matching sizes returns the
+ * product of probabilities.
+ *
+ * @tparam T_y_cl type of scalar outcome
+ * @tparam T_loc_cl type of location
+ * @tparam T_scale_cl type of scale
+ * @param y (Sequence of) scalar(s).
+ * @param mu (Sequence of) location(s).
+ * @param beta (Sequence of) scale(s).
+ * @return The sum of log complementary cumulative probabilities.
+ */
+template <
+    typename T_y_cl, typename T_loc_cl, typename T_scale_cl,
+    require_all_prim_or_rev_kernel_expression_t<T_y_cl, T_loc_cl,
+                                                T_scale_cl>* = nullptr,
+    require_any_not_stan_scalar_t<T_y_cl, T_loc_cl, T_scale_cl>* = nullptr>
+return_type_t<T_y_cl, T_loc_cl, T_scale_cl> gumbel_lccdf(
+    const T_y_cl& y, const T_loc_cl& mu, const T_scale_cl& beta) {
+  static const char* function = "gumbel_lccdf(OpenCL)";
+  using T_partials_return = partials_return_t<T_y_cl, T_loc_cl, T_scale_cl>;
+  using std::isfinite;
+  using std::isnan;
+
+  check_consistent_sizes(function, "Random variable", y, "Location parameter",
+                         mu, "Scale parameter", beta);
+  const size_t N = max_size(y, mu, beta);
+  if (N == 0) {
+    return 1.0;
+  }
+
+  const auto& y_col = as_column_vector_or_scalar(y);
+  const auto& mu_col = as_column_vector_or_scalar(mu);
+  const auto& beta_col = as_column_vector_or_scalar(beta);
+
+  const auto& y_val = value_of(y_col);
+  const auto& mu_val = value_of(mu_col);
+  const auto& beta_val = value_of(beta_col);
+
+  auto check_y_not_nan
+      = check_cl(function, "Random variable", y_val, "not NaN");
+  auto y_not_nan_expr = !isnan(y_val);
+  auto check_mu_finite
+      = check_cl(function, "Location parameter", mu_val, "finite");
+  auto mu_finite_expr = isfinite(mu_val);
+  auto check_beta_positive
+      = check_cl(function, "Scale parameter", beta_val, "positive");
+  auto beta_positive_expr = 0.0 < beta_val;
+
+  auto scaled_diff = elt_divide(y_val - mu_val, beta_val);
+  auto exp_m_scaled_diff = exp(-scaled_diff);
+  auto ccdf_n = 1.0 - exp(-exp_m_scaled_diff);
+  auto lccdf_expr = colwise_sum(log(ccdf_n));
+  auto mu_deriv = elt_divide(exp(-scaled_diff - exp_m_scaled_diff),
+                              elt_multiply(beta_val, ccdf_n));
+  auto y_deriv = -mu_deriv;
+  auto beta_deriv = elt_multiply(mu_deriv, scaled_diff);
+
+  matrix_cl<double> lccdf_cl;
+  matrix_cl<double> y_deriv_cl;
+  matrix_cl<double> mu_deriv_cl;
+  matrix_cl<double> beta_deriv_cl;
+
+  results(check_y_not_nan, check_mu_finite, check_beta_positive, lccdf_cl,
+          y_deriv_cl, mu_deriv_cl, beta_deriv_cl)
+      = expressions(y_not_nan_expr, mu_finite_expr, beta_positive_expr,
+                    lccdf_expr, calc_if<!is_constant<T_y_cl>::value>(y_deriv),
+                    calc_if<!is_constant<T_loc_cl>::value>(mu_deriv),
+                    calc_if<!is_constant<T_scale_cl>::value>(beta_deriv));
+
+  T_partials_return lccdf = sum(from_matrix_cl(lccdf_cl));
+
+  operands_and_partials<decltype(y_col), decltype(mu_col), decltype(beta_col)>
+      ops_partials(y_col, mu_col, beta_col);
+
+  if (!is_constant<T_y_cl>::value) {
+    ops_partials.edge1_.partials_ = std::move(y_deriv_cl);
+  }
+  if (!is_constant<T_loc_cl>::value) {
+    ops_partials.edge2_.partials_ = std::move(mu_deriv_cl);
+  }
+  if (!is_constant<T_scale_cl>::value) {
+    ops_partials.edge3_.partials_ = std::move(beta_deriv_cl);
+  }
+  return ops_partials.build(lccdf);
+}
+
+}  // namespace math
+}  // namespace stan
+#endif
+#endif

--- a/stan/math/opencl/prim/gumbel_lccdf.hpp
+++ b/stan/math/opencl/prim/gumbel_lccdf.hpp
@@ -68,7 +68,7 @@ return_type_t<T_y_cl, T_loc_cl, T_scale_cl> gumbel_lccdf(
   auto ccdf_n = 1.0 - exp(-exp_m_scaled_diff);
   auto lccdf_expr = colwise_sum(log(ccdf_n));
   auto mu_deriv = elt_divide(exp(-scaled_diff - exp_m_scaled_diff),
-                              elt_multiply(beta_val, ccdf_n));
+                             elt_multiply(beta_val, ccdf_n));
   auto y_deriv = -mu_deriv;
   auto beta_deriv = elt_multiply(mu_deriv, scaled_diff);
 

--- a/stan/math/opencl/prim/gumbel_lcdf.hpp
+++ b/stan/math/opencl/prim/gumbel_lcdf.hpp
@@ -1,0 +1,106 @@
+#ifndef STAN_MATH_OPENCL_PRIM_GUMBEL_LCDF_HPP
+#define STAN_MATH_OPENCL_PRIM_GUMBEL_LCDF_HPP
+#ifdef STAN_OPENCL
+
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/err.hpp>
+#include <stan/math/prim/fun/constants.hpp>
+#include <stan/math/prim/fun/elt_divide.hpp>
+#include <stan/math/prim/fun/elt_multiply.hpp>
+#include <stan/math/opencl/kernel_generator.hpp>
+#include <stan/math/prim/functor/operands_and_partials.hpp>
+
+namespace stan {
+namespace math {
+
+/** \ingroup opencl
+ * Returns the Gumbel log complementary cumulative distribution function for the
+ * given location, and scale. If given containers of matching sizes returns the
+ * product of probabilities.
+ *
+ * @tparam T_y_cl type of scalar outcome
+ * @tparam T_loc_cl type of location
+ * @tparam T_scale_cl type of scale
+ * @param y (Sequence of) scalar(s).
+ * @param mu (Sequence of) location(s).
+ * @param beta (Sequence of) scale(s).
+ * @return The sum of log complementary cumulative probabilities.
+ */
+template <
+    typename T_y_cl, typename T_loc_cl, typename T_scale_cl,
+    require_all_prim_or_rev_kernel_expression_t<T_y_cl, T_loc_cl,
+                                                T_scale_cl>* = nullptr,
+    require_any_not_stan_scalar_t<T_y_cl, T_loc_cl, T_scale_cl>* = nullptr>
+return_type_t<T_y_cl, T_loc_cl, T_scale_cl> gumbel_lcdf(
+    const T_y_cl& y, const T_loc_cl& mu, const T_scale_cl& beta) {
+  static const char* function = "gumbel_lcdf(OpenCL)";
+  using T_partials_return = partials_return_t<T_y_cl, T_loc_cl, T_scale_cl>;
+  using std::isfinite;
+  using std::isnan;
+
+  check_consistent_sizes(function, "Random variable", y, "Location parameter",
+                         mu, "Scale parameter", beta);
+  const size_t N = max_size(y, mu, beta);
+  if (N == 0) {
+    return 1.0;
+  }
+
+  const auto& y_col = as_column_vector_or_scalar(y);
+  const auto& mu_col = as_column_vector_or_scalar(mu);
+  const auto& beta_col = as_column_vector_or_scalar(beta);
+
+  const auto& y_val = value_of(y_col);
+  const auto& mu_val = value_of(mu_col);
+  const auto& beta_val = value_of(beta_col);
+
+  auto check_y_not_nan
+      = check_cl(function, "Random variable", y_val, "not NaN");
+  auto y_not_nan_expr = !isnan(y_val);
+  auto check_mu_finite
+      = check_cl(function, "Location parameter", mu_val, "finite");
+  auto mu_finite_expr = isfinite(mu_val);
+  auto check_beta_positive
+      = check_cl(function, "Scale parameter", beta_val, "positive");
+  auto beta_positive_expr = 0.0 < beta_val;
+
+  auto scaled_diff = elt_divide(mu_val - y_val, beta_val);
+  auto exp_scaled_diff = exp(scaled_diff);
+  auto lcdf_expr = colwise_sum(exp_scaled_diff);
+  auto y_deriv = elt_divide(exp_scaled_diff, beta_val);
+  auto mu_deriv = -y_deriv;
+  auto beta_deriv = elt_multiply(y_deriv, scaled_diff);
+
+  matrix_cl<double> lcdf_cl;
+  matrix_cl<double> y_deriv_cl;
+  matrix_cl<double> mu_deriv_cl;
+  matrix_cl<double> beta_deriv_cl;
+
+  results(check_y_not_nan, check_mu_finite, check_beta_positive, lcdf_cl,
+          y_deriv_cl, mu_deriv_cl, beta_deriv_cl)
+      = expressions(y_not_nan_expr, mu_finite_expr, beta_positive_expr,
+                    lcdf_expr,
+                    calc_if<!is_constant<T_y_cl>::value>(y_deriv),
+                    calc_if<!is_constant<T_loc_cl>::value>(mu_deriv),
+                    calc_if<!is_constant<T_scale_cl>::value>(beta_deriv));
+
+  T_partials_return lcdf = -sum(from_matrix_cl(lcdf_cl));
+
+  operands_and_partials<decltype(y_col), decltype(mu_col), decltype(beta_col)>
+      ops_partials(y_col, mu_col, beta_col);
+
+  if (!is_constant<T_y_cl>::value) {
+    ops_partials.edge1_.partials_ = std::move(y_deriv_cl);
+  }
+  if (!is_constant<T_loc_cl>::value) {
+    ops_partials.edge2_.partials_ = std::move(mu_deriv_cl);
+  }
+  if (!is_constant<T_scale_cl>::value) {
+    ops_partials.edge3_.partials_ = std::move(beta_deriv_cl);
+  }
+  return ops_partials.build(lcdf);
+}
+
+}  // namespace math
+}  // namespace stan
+#endif
+#endif

--- a/stan/math/opencl/prim/gumbel_lcdf.hpp
+++ b/stan/math/opencl/prim/gumbel_lcdf.hpp
@@ -78,8 +78,7 @@ return_type_t<T_y_cl, T_loc_cl, T_scale_cl> gumbel_lcdf(
   results(check_y_not_nan, check_mu_finite, check_beta_positive, lcdf_cl,
           y_deriv_cl, mu_deriv_cl, beta_deriv_cl)
       = expressions(y_not_nan_expr, mu_finite_expr, beta_positive_expr,
-                    lcdf_expr,
-                    calc_if<!is_constant<T_y_cl>::value>(y_deriv),
+                    lcdf_expr, calc_if<!is_constant<T_y_cl>::value>(y_deriv),
                     calc_if<!is_constant<T_loc_cl>::value>(mu_deriv),
                     calc_if<!is_constant<T_scale_cl>::value>(beta_deriv));
 

--- a/stan/math/opencl/prim/logistic_cdf.hpp
+++ b/stan/math/opencl/prim/logistic_cdf.hpp
@@ -67,11 +67,9 @@ return_type_t<T_y_cl, T_loc_cl, T_scale_cl> logistic_cdf(
       = colwise_max(constant(0, N, 1) + (y_val == NEGATIVE_INFTY));
   auto cond = y_val == INFTY;
   auto inv_sigma = elt_divide(1.0, sigma_val);
-  auto mu_minus_y_div_sigma
-      = elt_multiply(mu_val - y_val, inv_sigma);
+  auto mu_minus_y_div_sigma = elt_multiply(mu_val - y_val, inv_sigma);
   auto exp_scaled_diff = exp(mu_minus_y_div_sigma);
-  auto Pn
-      = elt_divide(1.0, 1.0 + exp_scaled_diff);
+  auto Pn = elt_divide(1.0, 1.0 + exp_scaled_diff);
   auto P_expr = colwise_prod(select(cond, 1.0, Pn));
 
   auto y_deriv_tmp = select(cond, 0.0,

--- a/stan/math/opencl/prim/logistic_cdf.hpp
+++ b/stan/math/opencl/prim/logistic_cdf.hpp
@@ -1,0 +1,130 @@
+#ifndef STAN_MATH_OPENCL_PRIM_LOGISTIC_CDF_HPP
+#define STAN_MATH_OPENCL_PRIM_LOGISTIC_CDF_HPP
+#ifdef STAN_OPENCL
+
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/err.hpp>
+#include <stan/math/prim/fun/constants.hpp>
+#include <stan/math/prim/fun/elt_divide.hpp>
+#include <stan/math/prim/fun/elt_multiply.hpp>
+#include <stan/math/opencl/kernel_generator.hpp>
+#include <stan/math/prim/functor/operands_and_partials.hpp>
+
+namespace stan {
+namespace math {
+
+/** \ingroup opencl
+ * Returns the logistic cumulative distribution function for the given
+ * location, and scale. If given containers of matching sizes
+ * returns the product of probabilities.
+ *
+ * @tparam T_y_cl type of scalar outcome
+ * @tparam T_loc_cl type of location
+ * @tparam T_scale_cl type of scale
+ * @param y (Sequence of) scalar(s).
+ * @param mu (Sequence of) location(s).
+ * @param sigma (Sequence of) scale(s).
+ * @return The log of the product of densities.
+ */
+template <
+    typename T_y_cl, typename T_loc_cl, typename T_scale_cl,
+    require_all_prim_or_rev_kernel_expression_t<T_y_cl, T_loc_cl,
+                                                T_scale_cl>* = nullptr,
+    require_any_not_stan_scalar_t<T_y_cl, T_loc_cl, T_scale_cl>* = nullptr>
+return_type_t<T_y_cl, T_loc_cl, T_scale_cl> logistic_cdf(
+    const T_y_cl& y, const T_loc_cl& mu, const T_scale_cl& sigma) {
+  static const char* function = "logistic_cdf(OpenCL)";
+  using T_partials_return = partials_return_t<T_y_cl, T_loc_cl, T_scale_cl>;
+  using std::isfinite;
+  using std::isnan;
+
+  check_consistent_sizes(function, "Random variable", y, "Location parameter",
+                         mu, "Scale parameter", sigma);
+  const size_t N = max_size(y, mu, sigma);
+  if (N == 0) {
+    return 1.0;
+  }
+
+  const auto& y_col = as_column_vector_or_scalar(y);
+  const auto& mu_col = as_column_vector_or_scalar(mu);
+  const auto& sigma_col = as_column_vector_or_scalar(sigma);
+
+  const auto& y_val = value_of(y_col);
+  const auto& mu_val = value_of(mu_col);
+  const auto& sigma_val = value_of(sigma_col);
+
+  auto check_y_not_nan
+      = check_cl(function, "Random variable", y_val, "not NaN");
+  auto y_not_nan_expr = !isnan(y_val);
+  auto check_mu_finite
+      = check_cl(function, "Location parameter", mu_val, "finite");
+  auto mu_finite_expr = isfinite(mu_val);
+  auto check_sigma_positive_finite
+      = check_cl(function, "Scale parameter", sigma_val, "positive finite");
+  auto sigma_positive_finite_expr = 0 < sigma_val && isfinite(sigma_val);
+
+  auto any_y_neg_inf
+      = colwise_max(constant(0, N, 1) + (y_val == NEGATIVE_INFTY));
+  auto cond = y_val == INFTY;
+  auto inv_sigma = elt_divide(1.0, sigma_val);
+  auto mu_minus_y_div_sigma
+      = elt_multiply(mu_val - y_val, inv_sigma);
+  auto exp_scaled_diff = exp(mu_minus_y_div_sigma);
+  auto Pn
+      = elt_divide(1.0, 1.0 + exp_scaled_diff);
+  auto P_expr = colwise_prod(select(cond, 1.0, Pn));
+
+  auto y_deriv_tmp = select(cond, 0.0,
+                            elt_divide(exp(mu_minus_y_div_sigma - log(sigma_val)
+                                           - 2.0 * log1p(exp_scaled_diff)),
+                                       Pn));
+  auto sigma_deriv_tmp = elt_multiply(y_deriv_tmp, mu_minus_y_div_sigma);
+
+  matrix_cl<double> any_y_neg_inf_cl;
+  matrix_cl<double> P_cl;
+  matrix_cl<double> mu_deriv_cl;
+  matrix_cl<double> y_deriv_cl;
+  matrix_cl<double> sigma_deriv_cl;
+
+  results(check_y_not_nan, check_mu_finite, check_sigma_positive_finite,
+          any_y_neg_inf_cl, P_cl, mu_deriv_cl, sigma_deriv_cl)
+      = expressions(
+          y_not_nan_expr, mu_finite_expr, sigma_positive_finite_expr,
+          any_y_neg_inf, P_expr,
+          calc_if<!is_constant_all<T_y_cl, T_loc_cl>::value>(y_deriv_tmp),
+          calc_if<!is_constant<T_scale_cl>::value>(sigma_deriv_tmp));
+
+  if (from_matrix_cl(any_y_neg_inf_cl).maxCoeff()) {
+    return 0.0;
+  }
+
+  T_partials_return P = (from_matrix_cl(P_cl)).prod();
+
+  auto y_deriv = mu_deriv_cl * P;
+  auto mu_deriv = -y_deriv;
+  auto sigma_deriv = sigma_deriv_cl * P;
+
+  results(mu_deriv_cl, y_deriv_cl, sigma_deriv_cl)
+      = expressions(calc_if<!is_constant<T_loc_cl>::value>(mu_deriv),
+                    calc_if<!is_constant<T_y_cl>::value>(y_deriv),
+                    calc_if<!is_constant<T_scale_cl>::value>(sigma_deriv));
+
+  operands_and_partials<decltype(y_col), decltype(mu_col), decltype(sigma_col)>
+      ops_partials(y_col, mu_col, sigma_col);
+
+  if (!is_constant<T_y_cl>::value) {
+    ops_partials.edge1_.partials_ = std::move(y_deriv_cl);
+  }
+  if (!is_constant<T_loc_cl>::value) {
+    ops_partials.edge2_.partials_ = std::move(mu_deriv_cl);
+  }
+  if (!is_constant<T_scale_cl>::value) {
+    ops_partials.edge3_.partials_ = std::move(sigma_deriv_cl);
+  }
+  return ops_partials.build(P);
+}
+
+}  // namespace math
+}  // namespace stan
+#endif
+#endif

--- a/stan/math/opencl/prim/logistic_lccdf.hpp
+++ b/stan/math/opencl/prim/logistic_lccdf.hpp
@@ -1,0 +1,124 @@
+#ifndef STAN_MATH_OPENCL_PRIM_LOGISTIC_LCCDF_HPP
+#define STAN_MATH_OPENCL_PRIM_LOGISTIC_LCCDF_HPP
+#ifdef STAN_OPENCL
+
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/err.hpp>
+#include <stan/math/prim/fun/constants.hpp>
+#include <stan/math/prim/fun/elt_divide.hpp>
+#include <stan/math/prim/fun/elt_multiply.hpp>
+#include <stan/math/opencl/kernel_generator.hpp>
+#include <stan/math/prim/functor/operands_and_partials.hpp>
+
+namespace stan {
+namespace math {
+
+/** \ingroup opencl
+ * Returns the logistic cumulative distribution function for the given
+ * location, and scale. If given containers of matching sizes
+ * returns the product of probabilities.
+ *
+ * @tparam T_y_cl type of scalar outcome
+ * @tparam T_loc_cl type of location
+ * @tparam T_scale_cl type of scale
+ * @param y (Sequence of) scalar(s).
+ * @param mu (Sequence of) location(s).
+ * @param sigma (Sequence of) scale(s).
+ * @return The log of the product of densities.
+ */
+template <
+    typename T_y_cl, typename T_loc_cl, typename T_scale_cl,
+    require_all_prim_or_rev_kernel_expression_t<T_y_cl, T_loc_cl,
+                                                T_scale_cl>* = nullptr,
+    require_any_not_stan_scalar_t<T_y_cl, T_loc_cl, T_scale_cl>* = nullptr>
+return_type_t<T_y_cl, T_loc_cl, T_scale_cl> logistic_lccdf(
+    const T_y_cl& y, const T_loc_cl& mu, const T_scale_cl& sigma) {
+  static const char* function = "logistic_lccdf(OpenCL)";
+  using T_partials_return = partials_return_t<T_y_cl, T_loc_cl, T_scale_cl>;
+  using std::isfinite;
+  using std::isnan;
+
+  check_consistent_sizes(function, "Random variable", y, "Location parameter",
+                         mu, "Scale parameter", sigma);
+  const size_t N = max_size(y, mu, sigma);
+  if (N == 0) {
+    return 0.0;
+  }
+
+  const auto& y_col = as_column_vector_or_scalar(y);
+  const auto& mu_col = as_column_vector_or_scalar(mu);
+  const auto& sigma_col = as_column_vector_or_scalar(sigma);
+
+  const auto& y_val = value_of(y_col);
+  const auto& mu_val = value_of(mu_col);
+  const auto& sigma_val = value_of(sigma_col);
+
+  auto check_y_not_nan
+      = check_cl(function, "Random variable", y_val, "not NaN");
+  auto y_not_nan_expr = !isnan(y_val);
+  auto check_mu_finite
+      = check_cl(function, "Location parameter", mu_val, "finite");
+  auto mu_finite_expr = isfinite(mu_val);
+  auto check_sigma_positive_finite
+      = check_cl(function, "Scale parameter", sigma_val, "positive finite");
+  auto sigma_positive_finite_expr = 0 < sigma_val && isfinite(sigma_val);
+
+  auto any_y_neg_inf
+      = colwise_max(constant(0, N, 1) + (y_val == NEGATIVE_INFTY));
+  auto any_y_pos_inf = colwise_max(constant(0, N, 1) + (y_val == INFTY));
+  auto inv_sigma = elt_divide(1.0, sigma_val);
+  auto mu_minus_y_div_sigma = elt_multiply(mu_val - y_val, inv_sigma);
+  auto exp_scaled_diff = exp(mu_minus_y_div_sigma);
+  auto Pn = 1.0 - elt_divide(1.0, 1.0 + exp_scaled_diff);
+  auto P_expr = colwise_sum(log(Pn));
+
+  auto mu_deriv = elt_divide(
+      exp(mu_minus_y_div_sigma - log(sigma_val) - 2.0 * log1p(exp_scaled_diff)),
+      Pn);
+  auto y_deriv = -mu_deriv;
+  auto sigma_deriv = elt_multiply(-mu_deriv, mu_minus_y_div_sigma);
+
+  matrix_cl<double> any_y_neg_inf_cl;
+  matrix_cl<double> any_y_pos_inf_cl;
+  matrix_cl<double> P_cl;
+  matrix_cl<double> mu_deriv_cl;
+  matrix_cl<double> y_deriv_cl;
+  matrix_cl<double> sigma_deriv_cl;
+
+  results(check_y_not_nan, check_mu_finite, check_sigma_positive_finite,
+          any_y_neg_inf_cl, any_y_pos_inf_cl, P_cl, y_deriv_cl, mu_deriv_cl,
+          sigma_deriv_cl)
+      = expressions(y_not_nan_expr, mu_finite_expr, sigma_positive_finite_expr,
+                    any_y_neg_inf, any_y_pos_inf, P_expr,
+                    calc_if<!is_constant<T_y_cl>::value>(y_deriv),
+                    calc_if<!is_constant<T_loc_cl>::value>(mu_deriv),
+                    calc_if<!is_constant<T_scale_cl>::value>(sigma_deriv));
+
+  if (from_matrix_cl(any_y_neg_inf_cl).maxCoeff()) {
+    return 0.0;
+  }
+  if (from_matrix_cl(any_y_pos_inf_cl).maxCoeff()) {
+    return NEGATIVE_INFTY;
+  }
+
+  T_partials_return P = (from_matrix_cl(P_cl)).sum();
+
+  operands_and_partials<decltype(y_col), decltype(mu_col), decltype(sigma_col)>
+      ops_partials(y_col, mu_col, sigma_col);
+
+  if (!is_constant<T_y_cl>::value) {
+    ops_partials.edge1_.partials_ = std::move(y_deriv_cl);
+  }
+  if (!is_constant<T_loc_cl>::value) {
+    ops_partials.edge2_.partials_ = std::move(mu_deriv_cl);
+  }
+  if (!is_constant<T_scale_cl>::value) {
+    ops_partials.edge3_.partials_ = std::move(sigma_deriv_cl);
+  }
+  return ops_partials.build(P);
+}
+
+}  // namespace math
+}  // namespace stan
+#endif
+#endif

--- a/stan/math/opencl/prim/logistic_lcdf.hpp
+++ b/stan/math/opencl/prim/logistic_lcdf.hpp
@@ -1,0 +1,120 @@
+#ifndef STAN_MATH_OPENCL_PRIM_LOGISTIC_LCDF_HPP
+#define STAN_MATH_OPENCL_PRIM_LOGISTIC_LCDF_HPP
+#ifdef STAN_OPENCL
+
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/err.hpp>
+#include <stan/math/prim/fun/constants.hpp>
+#include <stan/math/prim/fun/elt_divide.hpp>
+#include <stan/math/prim/fun/elt_multiply.hpp>
+#include <stan/math/opencl/kernel_generator.hpp>
+#include <stan/math/prim/functor/operands_and_partials.hpp>
+
+namespace stan {
+namespace math {
+
+/** \ingroup opencl
+ * Returns the logistic cumulative distribution function for the given
+ * location, and scale. If given containers of matching sizes
+ * returns the product of probabilities.
+ *
+ * @tparam T_y_cl type of scalar outcome
+ * @tparam T_loc_cl type of location
+ * @tparam T_scale_cl type of scale
+ * @param y (Sequence of) scalar(s).
+ * @param mu (Sequence of) location(s).
+ * @param sigma (Sequence of) scale(s).
+ * @return The log of the product of densities.
+ */
+template <
+    typename T_y_cl, typename T_loc_cl, typename T_scale_cl,
+    require_all_prim_or_rev_kernel_expression_t<T_y_cl, T_loc_cl,
+                                                T_scale_cl>* = nullptr,
+    require_any_not_stan_scalar_t<T_y_cl, T_loc_cl, T_scale_cl>* = nullptr>
+return_type_t<T_y_cl, T_loc_cl, T_scale_cl> logistic_lcdf(
+    const T_y_cl& y, const T_loc_cl& mu, const T_scale_cl& sigma) {
+  static const char* function = "logistic_lcdf(OpenCL)";
+  using T_partials_return = partials_return_t<T_y_cl, T_loc_cl, T_scale_cl>;
+  using std::isfinite;
+  using std::isnan;
+
+  check_consistent_sizes(function, "Random variable", y, "Location parameter",
+                         mu, "Scale parameter", sigma);
+  const size_t N = max_size(y, mu, sigma);
+  if (N == 0) {
+    return 0.0;
+  }
+
+  const auto& y_col = as_column_vector_or_scalar(y);
+  const auto& mu_col = as_column_vector_or_scalar(mu);
+  const auto& sigma_col = as_column_vector_or_scalar(sigma);
+
+  const auto& y_val = value_of(y_col);
+  const auto& mu_val = value_of(mu_col);
+  const auto& sigma_val = value_of(sigma_col);
+
+  auto check_y_not_nan
+      = check_cl(function, "Random variable", y_val, "not NaN");
+  auto y_not_nan_expr = !isnan(y_val);
+  auto check_mu_finite
+      = check_cl(function, "Location parameter", mu_val, "finite");
+  auto mu_finite_expr = isfinite(mu_val);
+  auto check_sigma_positive_finite
+      = check_cl(function, "Scale parameter", sigma_val, "positive finite");
+  auto sigma_positive_finite_expr = 0 < sigma_val && isfinite(sigma_val);
+
+  auto any_y_neg_inf
+      = colwise_max(constant(0, N, 1) + (y_val == NEGATIVE_INFTY));
+  auto cond = y_val == INFTY;
+  auto inv_sigma = elt_divide(1.0, sigma_val);
+  auto mu_minus_y_div_sigma = elt_multiply(mu_val - y_val, inv_sigma);
+  auto exp_scaled_diff = exp(mu_minus_y_div_sigma);
+  auto Pn = elt_divide(1.0, 1.0 + exp_scaled_diff);
+  auto P_expr = colwise_sum(log(Pn));
+
+  auto y_deriv = elt_divide(
+      exp(mu_minus_y_div_sigma - log(sigma_val) - 2.0 * log1p(exp_scaled_diff)),
+      Pn);
+  auto mu_deriv = -y_deriv;
+  auto sigma_deriv = elt_multiply(y_deriv, mu_minus_y_div_sigma);
+
+  matrix_cl<double> any_y_neg_inf_cl;
+  matrix_cl<double> P_cl;
+  matrix_cl<double> mu_deriv_cl;
+  matrix_cl<double> y_deriv_cl;
+  matrix_cl<double> sigma_deriv_cl;
+
+  results(check_y_not_nan, check_mu_finite, check_sigma_positive_finite,
+          any_y_neg_inf_cl, P_cl, y_deriv_cl, mu_deriv_cl,
+          sigma_deriv_cl)
+      = expressions(y_not_nan_expr, mu_finite_expr, sigma_positive_finite_expr,
+                    any_y_neg_inf, P_expr,
+                    calc_if<!is_constant<T_y_cl>::value>(y_deriv),
+                    calc_if<!is_constant<T_loc_cl>::value>(mu_deriv),
+                    calc_if<!is_constant<T_scale_cl>::value>(sigma_deriv));
+
+  if (from_matrix_cl(any_y_neg_inf_cl).maxCoeff()) {
+    return NEGATIVE_INFTY;
+  }
+
+  T_partials_return P = (from_matrix_cl(P_cl)).sum();
+
+  operands_and_partials<decltype(y_col), decltype(mu_col), decltype(sigma_col)>
+      ops_partials(y_col, mu_col, sigma_col);
+
+  if (!is_constant<T_y_cl>::value) {
+    ops_partials.edge1_.partials_ = std::move(y_deriv_cl);
+  }
+  if (!is_constant<T_loc_cl>::value) {
+    ops_partials.edge2_.partials_ = std::move(mu_deriv_cl);
+  }
+  if (!is_constant<T_scale_cl>::value) {
+    ops_partials.edge3_.partials_ = std::move(sigma_deriv_cl);
+  }
+  return ops_partials.build(P);
+}
+
+}  // namespace math
+}  // namespace stan
+#endif
+#endif

--- a/stan/math/opencl/prim/logistic_lcdf.hpp
+++ b/stan/math/opencl/prim/logistic_lcdf.hpp
@@ -85,8 +85,7 @@ return_type_t<T_y_cl, T_loc_cl, T_scale_cl> logistic_lcdf(
   matrix_cl<double> sigma_deriv_cl;
 
   results(check_y_not_nan, check_mu_finite, check_sigma_positive_finite,
-          any_y_neg_inf_cl, P_cl, y_deriv_cl, mu_deriv_cl,
-          sigma_deriv_cl)
+          any_y_neg_inf_cl, P_cl, y_deriv_cl, mu_deriv_cl, sigma_deriv_cl)
       = expressions(y_not_nan_expr, mu_finite_expr, sigma_positive_finite_expr,
                     any_y_neg_inf, P_expr,
                     calc_if<!is_constant<T_y_cl>::value>(y_deriv),

--- a/stan/math/prim/prob/gumbel_cdf.hpp
+++ b/stan/math/prim/prob/gumbel_cdf.hpp
@@ -33,7 +33,9 @@ namespace math {
  * @throw std::domain_error if y is nan, mu is infinite, or beta is nonpositive
  * @throw std::invalid_argument if container sizes mismatch
  */
-template <typename T_y, typename T_loc, typename T_scale>
+template <typename T_y, typename T_loc, typename T_scale,
+          require_all_not_nonscalar_prim_or_rev_kernel_expression_t<
+              T_y, T_loc, T_scale>* = nullptr>
 return_type_t<T_y, T_loc, T_scale> gumbel_cdf(const T_y& y, const T_loc& mu,
                                               const T_scale& beta) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale>;
@@ -54,7 +56,6 @@ return_type_t<T_y, T_loc, T_scale> gumbel_cdf(const T_y& y, const T_loc& mu,
 
   check_not_nan(function, "Random variable", y_val);
   check_finite(function, "Location parameter", mu_val);
-  check_not_nan(function, "Scale parameter", beta_val);
   check_positive(function, "Scale parameter", beta_val);
 
   if (size_zero(y, mu, beta)) {

--- a/stan/math/prim/prob/gumbel_lccdf.hpp
+++ b/stan/math/prim/prob/gumbel_lccdf.hpp
@@ -69,9 +69,8 @@ return_type_t<T_y, T_loc, T_scale> gumbel_lccdf(const T_y& y, const T_loc& mu,
       = to_ref_if<!is_constant_all<T_y, T_loc, T_scale>::value>(
           exp(-scaled_diff));
   const auto& cdf_log_n_tmp = exp(-exp_m_scaled_diff);
-  const auto& ccdf_n
-      = to_ref_if<!is_constant_all<T_y, T_loc, T_scale>::value>(
-          1.0 - cdf_log_n_tmp);
+  const auto& ccdf_n = to_ref_if<!is_constant_all<T_y, T_loc, T_scale>::value>(
+      1.0 - cdf_log_n_tmp);
   T_partials_return ccdf_log = sum(log(ccdf_n));
 
   if (!is_constant_all<T_y, T_loc, T_scale>::value) {

--- a/stan/math/prim/prob/gumbel_lcdf.hpp
+++ b/stan/math/prim/prob/gumbel_lcdf.hpp
@@ -32,7 +32,9 @@ namespace math {
  * @throw std::domain_error if y is nan, mu is infinite, or beta is nonpositive
  * @throw std::invalid_argument if container sizes mismatch
  */
-template <typename T_y, typename T_loc, typename T_scale>
+template <typename T_y, typename T_loc, typename T_scale,
+          require_all_not_nonscalar_prim_or_rev_kernel_expression_t<
+              T_y, T_loc, T_scale>* = nullptr>
 return_type_t<T_y, T_loc, T_scale> gumbel_lcdf(const T_y& y, const T_loc& mu,
                                                const T_scale& beta) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale>;
@@ -52,7 +54,6 @@ return_type_t<T_y, T_loc, T_scale> gumbel_lcdf(const T_y& y, const T_loc& mu,
 
   check_not_nan(function, "Random variable", y_val);
   check_finite(function, "Location parameter", mu_val);
-  check_not_nan(function, "Scale parameter", beta_val);
   check_positive(function, "Scale parameter", beta_val);
 
   if (size_zero(y, mu, beta)) {

--- a/stan/math/prim/prob/logistic_cdf.hpp
+++ b/stan/math/prim/prob/logistic_cdf.hpp
@@ -18,7 +18,9 @@ namespace stan {
 namespace math {
 
 // Logistic(y|mu, sigma) [sigma > 0]
-template <typename T_y, typename T_loc, typename T_scale>
+template <typename T_y, typename T_loc, typename T_scale,
+          require_all_not_nonscalar_prim_or_rev_kernel_expression_t<
+              T_y, T_loc, T_scale>* = nullptr>
 return_type_t<T_y, T_loc, T_scale> logistic_cdf(const T_y& y, const T_loc& mu,
                                                 const T_scale& sigma) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale>;

--- a/stan/math/prim/prob/logistic_lccdf.hpp
+++ b/stan/math/prim/prob/logistic_lccdf.hpp
@@ -18,7 +18,9 @@
 namespace stan {
 namespace math {
 
-template <typename T_y, typename T_loc, typename T_scale>
+template <typename T_y, typename T_loc, typename T_scale,
+          require_all_not_nonscalar_prim_or_rev_kernel_expression_t<
+              T_y, T_loc, T_scale>* = nullptr>
 return_type_t<T_y, T_loc, T_scale> logistic_lccdf(const T_y& y, const T_loc& mu,
                                                   const T_scale& sigma) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale>;

--- a/stan/math/prim/prob/logistic_lcdf.hpp
+++ b/stan/math/prim/prob/logistic_lcdf.hpp
@@ -18,7 +18,9 @@
 namespace stan {
 namespace math {
 
-template <typename T_y, typename T_loc, typename T_scale>
+template <typename T_y, typename T_loc, typename T_scale,
+          require_all_not_nonscalar_prim_or_rev_kernel_expression_t<
+              T_y, T_loc, T_scale>* = nullptr>
 return_type_t<T_y, T_loc, T_scale> logistic_lcdf(const T_y& y, const T_loc& mu,
                                                  const T_scale& sigma) {
   using T_partials_return = partials_return_t<T_y, T_loc, T_scale>;

--- a/test/unit/math/opencl/rev/gumbel_cdf_test.cpp
+++ b/test/unit/math/opencl/rev/gumbel_cdf_test.cpp
@@ -1,0 +1,142 @@
+#ifdef STAN_OPENCL
+#include <stan/math/opencl/rev.hpp>
+#include <stan/math.hpp>
+#include <gtest/gtest.h>
+#include <test/unit/math/opencl/util.hpp>
+#include <vector>
+
+TEST(ProbDistributionsGumbelCdf, error_checking) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  Eigen::VectorXd y_size(N - 1);
+  y_size << 0.3, 0.8;
+  Eigen::VectorXd y_value(N);
+  y_value << 0.3, NAN, 0.5;
+
+  Eigen::VectorXd mu(N);
+  mu << 0.3, 0.8, 1.0;
+  Eigen::VectorXd mu_size(N - 1);
+  mu_size << 0.3, 0.8;
+  Eigen::VectorXd mu_value(N);
+  mu_value << 0.3, -INFINITY, 0.5;
+
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+  Eigen::VectorXd sigma_size(N - 1);
+  sigma_size << 0.3, 0.8;
+  Eigen::VectorXd sigma_value(N);
+  sigma_value << 0.3, 0, 0.5;
+
+  stan::math::matrix_cl<double> y_cl(y);
+  stan::math::matrix_cl<double> y_size_cl(y_size);
+  stan::math::matrix_cl<double> y_value_cl(y_value);
+  stan::math::matrix_cl<double> mu_cl(mu);
+  stan::math::matrix_cl<double> mu_size_cl(mu_size);
+  stan::math::matrix_cl<double> mu_value_cl(mu_value);
+  stan::math::matrix_cl<double> sigma_cl(sigma);
+  stan::math::matrix_cl<double> sigma_size_cl(sigma_size);
+  stan::math::matrix_cl<double> sigma_value_cl(sigma_value);
+
+  EXPECT_NO_THROW(stan::math::gumbel_cdf(y_cl, mu_cl, sigma_cl));
+
+  EXPECT_THROW(stan::math::gumbel_cdf(y_size_cl, mu_cl, sigma_cl),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::gumbel_cdf(y_cl, mu_size_cl, sigma_cl),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::gumbel_cdf(y_cl, mu_cl, sigma_size_cl),
+               std::invalid_argument);
+
+  EXPECT_THROW(stan::math::gumbel_cdf(y_value_cl, mu_cl, sigma_cl),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gumbel_cdf(y_cl, mu_value_cl, sigma_cl),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gumbel_cdf(y_cl, mu_cl, sigma_value_cl),
+               std::domain_error);
+}
+
+auto gumbel_cdf_functor = [](const auto& y, const auto& mu, const auto& sigma) {
+  return stan::math::gumbel_cdf(y, mu, sigma);
+};
+
+TEST(ProbDistributionsGumbelCdf, opencl_matches_cpu_small) {
+  int N = 3;
+  int M = 2;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  Eigen::VectorXd mu(N);
+  mu << 0.3, 0.8, 1.0;
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+
+  stan::math::test::compare_cpu_opencl_prim_rev(gumbel_cdf_functor, y, mu,
+                                                sigma);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      gumbel_cdf_functor, y.transpose().eval(), mu.transpose().eval(),
+      sigma.transpose().eval());
+}
+
+TEST(ProbDistributionsGumbelCdf, opencl_broadcast_y) {
+  int N = 3;
+
+  double y_scal = 12.3;
+  Eigen::VectorXd mu(N);
+  mu << 0.5, 1.2, 1.0;
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(gumbel_cdf_functor,
+                                                         y_scal, mu, sigma);
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(
+      gumbel_cdf_functor, y_scal, mu.transpose().eval(), sigma);
+}
+
+TEST(ProbDistributionsGumbelCdf, opencl_broadcast_mu) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  double mu_scal = 12.3;
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<1>(gumbel_cdf_functor, y,
+                                                         mu_scal, sigma);
+  stan::math::test::test_opencl_broadcasting_prim_rev<1>(
+      gumbel_cdf_functor, y.transpose().eval(), mu_scal, sigma);
+}
+
+TEST(ProbDistributionsGumbelCdf, opencl_broadcast_sigma) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  Eigen::VectorXd mu(N);
+  mu << 0.3, 0.8, 1.0;
+  double sigma_scal = 12.3;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<2>(gumbel_cdf_functor, y,
+                                                         mu, sigma_scal);
+  stan::math::test::test_opencl_broadcasting_prim_rev<2>(
+      gumbel_cdf_functor, y.transpose().eval(), mu, sigma_scal);
+}
+
+TEST(ProbDistributionsGumbelCdf, opencl_matches_cpu_big) {
+  int N = 153;
+
+  Eigen::Matrix<double, Eigen::Dynamic, 1> y
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+  Eigen::Matrix<double, Eigen::Dynamic, 1> mu
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+  Eigen::Matrix<double, Eigen::Dynamic, 1> sigma
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+
+  stan::math::test::compare_cpu_opencl_prim_rev(gumbel_cdf_functor, y, mu,
+                                                sigma);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      gumbel_cdf_functor, y.transpose().eval(), mu.transpose().eval(),
+      sigma.transpose().eval());
+}
+#endif

--- a/test/unit/math/opencl/rev/gumbel_cdf_test.cpp
+++ b/test/unit/math/opencl/rev/gumbel_cdf_test.cpp
@@ -131,7 +131,7 @@ TEST(ProbDistributionsGumbelCdf, opencl_matches_cpu_big) {
   Eigen::Matrix<double, Eigen::Dynamic, 1> mu
       = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
   Eigen::Matrix<double, Eigen::Dynamic, 1> sigma
-      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs() + 0.1;
 
   stan::math::test::compare_cpu_opencl_prim_rev(gumbel_cdf_functor, y, mu,
                                                 sigma);

--- a/test/unit/math/opencl/rev/gumbel_cdf_test.cpp
+++ b/test/unit/math/opencl/rev/gumbel_cdf_test.cpp
@@ -67,7 +67,7 @@ TEST(ProbDistributionsGumbelCdf, opencl_matches_cpu_small) {
   Eigen::VectorXd y(N);
   y << 0.3, 0.8, 1.0;
   Eigen::VectorXd mu(N);
-  mu << 0.3, 0.8, 1.0;
+  mu << 0.4, -0.8, 1.4;
   Eigen::VectorXd sigma(N);
   sigma << 0.3, 0.8, 1.0;
 

--- a/test/unit/math/opencl/rev/gumbel_lccdf_test.cpp
+++ b/test/unit/math/opencl/rev/gumbel_lccdf_test.cpp
@@ -56,9 +56,10 @@ TEST(ProbDistributionsGumbelLccdf, error_checking) {
                std::domain_error);
 }
 
-auto gumbel_lccdf_functor = [](const auto& y, const auto& mu, const auto& sigma) {
-  return stan::math::gumbel_lccdf(y, mu, sigma);
-};
+auto gumbel_lccdf_functor
+    = [](const auto& y, const auto& mu, const auto& sigma) {
+        return stan::math::gumbel_lccdf(y, mu, sigma);
+      };
 
 TEST(ProbDistributionsGumbelLccdf, opencl_matches_cpu_small) {
   int N = 3;
@@ -102,8 +103,8 @@ TEST(ProbDistributionsGumbelLccdf, opencl_broadcast_mu) {
   Eigen::VectorXd sigma(N);
   sigma << 0.3, 0.8, 1.0;
 
-  stan::math::test::test_opencl_broadcasting_prim_rev<1>(gumbel_lccdf_functor, y,
-                                                         mu_scal, sigma);
+  stan::math::test::test_opencl_broadcasting_prim_rev<1>(gumbel_lccdf_functor,
+                                                         y, mu_scal, sigma);
   stan::math::test::test_opencl_broadcasting_prim_rev<1>(
       gumbel_lccdf_functor, y.transpose().eval(), mu_scal, sigma);
 }
@@ -117,8 +118,8 @@ TEST(ProbDistributionsGumbelLccdf, opencl_broadcast_sigma) {
   mu << 0.3, 0.8, 1.0;
   double sigma_scal = 12.3;
 
-  stan::math::test::test_opencl_broadcasting_prim_rev<2>(gumbel_lccdf_functor, y,
-                                                         mu, sigma_scal);
+  stan::math::test::test_opencl_broadcasting_prim_rev<2>(gumbel_lccdf_functor,
+                                                         y, mu, sigma_scal);
   stan::math::test::test_opencl_broadcasting_prim_rev<2>(
       gumbel_lccdf_functor, y.transpose().eval(), mu, sigma_scal);
 }

--- a/test/unit/math/opencl/rev/gumbel_lccdf_test.cpp
+++ b/test/unit/math/opencl/rev/gumbel_lccdf_test.cpp
@@ -1,0 +1,142 @@
+#ifdef STAN_OPENCL
+#include <stan/math/opencl/rev.hpp>
+#include <stan/math.hpp>
+#include <gtest/gtest.h>
+#include <test/unit/math/opencl/util.hpp>
+#include <vector>
+
+TEST(ProbDistributionsGumbelLccdf, error_checking) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  Eigen::VectorXd y_size(N - 1);
+  y_size << 0.3, 0.8;
+  Eigen::VectorXd y_value(N);
+  y_value << 0.3, NAN, 0.5;
+
+  Eigen::VectorXd mu(N);
+  mu << 0.3, 0.8, 1.0;
+  Eigen::VectorXd mu_size(N - 1);
+  mu_size << 0.3, 0.8;
+  Eigen::VectorXd mu_value(N);
+  mu_value << 0.3, -INFINITY, 0.5;
+
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+  Eigen::VectorXd sigma_size(N - 1);
+  sigma_size << 0.3, 0.8;
+  Eigen::VectorXd sigma_value(N);
+  sigma_value << 0.3, 0, 0.5;
+
+  stan::math::matrix_cl<double> y_cl(y);
+  stan::math::matrix_cl<double> y_size_cl(y_size);
+  stan::math::matrix_cl<double> y_value_cl(y_value);
+  stan::math::matrix_cl<double> mu_cl(mu);
+  stan::math::matrix_cl<double> mu_size_cl(mu_size);
+  stan::math::matrix_cl<double> mu_value_cl(mu_value);
+  stan::math::matrix_cl<double> sigma_cl(sigma);
+  stan::math::matrix_cl<double> sigma_size_cl(sigma_size);
+  stan::math::matrix_cl<double> sigma_value_cl(sigma_value);
+
+  EXPECT_NO_THROW(stan::math::gumbel_lccdf(y_cl, mu_cl, sigma_cl));
+
+  EXPECT_THROW(stan::math::gumbel_lccdf(y_size_cl, mu_cl, sigma_cl),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::gumbel_lccdf(y_cl, mu_size_cl, sigma_cl),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::gumbel_lccdf(y_cl, mu_cl, sigma_size_cl),
+               std::invalid_argument);
+
+  EXPECT_THROW(stan::math::gumbel_lccdf(y_value_cl, mu_cl, sigma_cl),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gumbel_lccdf(y_cl, mu_value_cl, sigma_cl),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gumbel_lccdf(y_cl, mu_cl, sigma_value_cl),
+               std::domain_error);
+}
+
+auto gumbel_lccdf_functor = [](const auto& y, const auto& mu, const auto& sigma) {
+  return stan::math::gumbel_lccdf(y, mu, sigma);
+};
+
+TEST(ProbDistributionsGumbelLccdf, opencl_matches_cpu_small) {
+  int N = 3;
+  int M = 2;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  Eigen::VectorXd mu(N);
+  mu << 0.3, 0.8, 1.0;
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+
+  stan::math::test::compare_cpu_opencl_prim_rev(gumbel_lccdf_functor, y, mu,
+                                                sigma);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      gumbel_lccdf_functor, y.transpose().eval(), mu.transpose().eval(),
+      sigma.transpose().eval());
+}
+
+TEST(ProbDistributionsGumbelLccdf, opencl_broadcast_y) {
+  int N = 3;
+
+  double y_scal = 12.3;
+  Eigen::VectorXd mu(N);
+  mu << 0.5, 1.2, 1.0;
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(gumbel_lccdf_functor,
+                                                         y_scal, mu, sigma);
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(
+      gumbel_lccdf_functor, y_scal, mu.transpose().eval(), sigma);
+}
+
+TEST(ProbDistributionsGumbelLccdf, opencl_broadcast_mu) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  double mu_scal = 12.3;
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<1>(gumbel_lccdf_functor, y,
+                                                         mu_scal, sigma);
+  stan::math::test::test_opencl_broadcasting_prim_rev<1>(
+      gumbel_lccdf_functor, y.transpose().eval(), mu_scal, sigma);
+}
+
+TEST(ProbDistributionsGumbelLccdf, opencl_broadcast_sigma) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  Eigen::VectorXd mu(N);
+  mu << 0.3, 0.8, 1.0;
+  double sigma_scal = 12.3;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<2>(gumbel_lccdf_functor, y,
+                                                         mu, sigma_scal);
+  stan::math::test::test_opencl_broadcasting_prim_rev<2>(
+      gumbel_lccdf_functor, y.transpose().eval(), mu, sigma_scal);
+}
+
+TEST(ProbDistributionsGumbelLccdf, opencl_matches_cpu_big) {
+  int N = 153;
+
+  Eigen::Matrix<double, Eigen::Dynamic, 1> y
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+  Eigen::Matrix<double, Eigen::Dynamic, 1> mu
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+  Eigen::Matrix<double, Eigen::Dynamic, 1> sigma
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+
+  stan::math::test::compare_cpu_opencl_prim_rev(gumbel_lccdf_functor, y, mu,
+                                                sigma);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      gumbel_lccdf_functor, y.transpose().eval(), mu.transpose().eval(),
+      sigma.transpose().eval());
+}
+#endif

--- a/test/unit/math/opencl/rev/gumbel_lcdf_test.cpp
+++ b/test/unit/math/opencl/rev/gumbel_lcdf_test.cpp
@@ -56,9 +56,10 @@ TEST(ProbDistributionsGumbelLcdf, error_checking) {
                std::domain_error);
 }
 
-auto gumbel_lcdf_functor = [](const auto& y, const auto& mu, const auto& sigma) {
-  return stan::math::gumbel_lcdf(y, mu, sigma);
-};
+auto gumbel_lcdf_functor
+    = [](const auto& y, const auto& mu, const auto& sigma) {
+        return stan::math::gumbel_lcdf(y, mu, sigma);
+      };
 
 TEST(ProbDistributionsGumbelLcdf, opencl_matches_cpu_small) {
   int N = 3;

--- a/test/unit/math/opencl/rev/gumbel_lcdf_test.cpp
+++ b/test/unit/math/opencl/rev/gumbel_lcdf_test.cpp
@@ -1,0 +1,142 @@
+#ifdef STAN_OPENCL
+#include <stan/math/opencl/rev.hpp>
+#include <stan/math.hpp>
+#include <gtest/gtest.h>
+#include <test/unit/math/opencl/util.hpp>
+#include <vector>
+
+TEST(ProbDistributionsGumbelLcdf, error_checking) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  Eigen::VectorXd y_size(N - 1);
+  y_size << 0.3, 0.8;
+  Eigen::VectorXd y_value(N);
+  y_value << 0.3, NAN, 0.5;
+
+  Eigen::VectorXd mu(N);
+  mu << 0.3, 0.8, 1.0;
+  Eigen::VectorXd mu_size(N - 1);
+  mu_size << 0.3, 0.8;
+  Eigen::VectorXd mu_value(N);
+  mu_value << 0.3, -INFINITY, 0.5;
+
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+  Eigen::VectorXd sigma_size(N - 1);
+  sigma_size << 0.3, 0.8;
+  Eigen::VectorXd sigma_value(N);
+  sigma_value << 0.3, 0, 0.5;
+
+  stan::math::matrix_cl<double> y_cl(y);
+  stan::math::matrix_cl<double> y_size_cl(y_size);
+  stan::math::matrix_cl<double> y_value_cl(y_value);
+  stan::math::matrix_cl<double> mu_cl(mu);
+  stan::math::matrix_cl<double> mu_size_cl(mu_size);
+  stan::math::matrix_cl<double> mu_value_cl(mu_value);
+  stan::math::matrix_cl<double> sigma_cl(sigma);
+  stan::math::matrix_cl<double> sigma_size_cl(sigma_size);
+  stan::math::matrix_cl<double> sigma_value_cl(sigma_value);
+
+  EXPECT_NO_THROW(stan::math::gumbel_lcdf(y_cl, mu_cl, sigma_cl));
+
+  EXPECT_THROW(stan::math::gumbel_lcdf(y_size_cl, mu_cl, sigma_cl),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::gumbel_lcdf(y_cl, mu_size_cl, sigma_cl),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::gumbel_lcdf(y_cl, mu_cl, sigma_size_cl),
+               std::invalid_argument);
+
+  EXPECT_THROW(stan::math::gumbel_lcdf(y_value_cl, mu_cl, sigma_cl),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gumbel_lcdf(y_cl, mu_value_cl, sigma_cl),
+               std::domain_error);
+  EXPECT_THROW(stan::math::gumbel_lcdf(y_cl, mu_cl, sigma_value_cl),
+               std::domain_error);
+}
+
+auto gumbel_lcdf_functor = [](const auto& y, const auto& mu, const auto& sigma) {
+  return stan::math::gumbel_lcdf(y, mu, sigma);
+};
+
+TEST(ProbDistributionsGumbelLcdf, opencl_matches_cpu_small) {
+  int N = 3;
+  int M = 2;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  Eigen::VectorXd mu(N);
+  mu << 0.3, 0.8, 1.0;
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+
+  stan::math::test::compare_cpu_opencl_prim_rev(gumbel_lcdf_functor, y, mu,
+                                                sigma);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      gumbel_lcdf_functor, y.transpose().eval(), mu.transpose().eval(),
+      sigma.transpose().eval());
+}
+
+TEST(ProbDistributionsGumbelLcdf, opencl_broadcast_y) {
+  int N = 3;
+
+  double y_scal = 12.3;
+  Eigen::VectorXd mu(N);
+  mu << 0.5, 1.2, 1.0;
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(gumbel_lcdf_functor,
+                                                         y_scal, mu, sigma);
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(
+      gumbel_lcdf_functor, y_scal, mu.transpose().eval(), sigma);
+}
+
+TEST(ProbDistributionsGumbelLcdf, opencl_broadcast_mu) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  double mu_scal = 12.3;
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<1>(gumbel_lcdf_functor, y,
+                                                         mu_scal, sigma);
+  stan::math::test::test_opencl_broadcasting_prim_rev<1>(
+      gumbel_lcdf_functor, y.transpose().eval(), mu_scal, sigma);
+}
+
+TEST(ProbDistributionsGumbelLcdf, opencl_broadcast_sigma) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  Eigen::VectorXd mu(N);
+  mu << 0.3, 0.8, 1.0;
+  double sigma_scal = 12.3;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<2>(gumbel_lcdf_functor, y,
+                                                         mu, sigma_scal);
+  stan::math::test::test_opencl_broadcasting_prim_rev<2>(
+      gumbel_lcdf_functor, y.transpose().eval(), mu, sigma_scal);
+}
+
+TEST(ProbDistributionsGumbelLcdf, opencl_matches_cpu_big) {
+  int N = 153;
+
+  Eigen::Matrix<double, Eigen::Dynamic, 1> y
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+  Eigen::Matrix<double, Eigen::Dynamic, 1> mu
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+  Eigen::Matrix<double, Eigen::Dynamic, 1> sigma
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+
+  stan::math::test::compare_cpu_opencl_prim_rev(gumbel_lcdf_functor, y, mu,
+                                                sigma);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      gumbel_lcdf_functor, y.transpose().eval(), mu.transpose().eval(),
+      sigma.transpose().eval());
+}
+#endif

--- a/test/unit/math/opencl/rev/logistic_cdf_test.cpp
+++ b/test/unit/math/opencl/rev/logistic_cdf_test.cpp
@@ -1,0 +1,160 @@
+#ifdef STAN_OPENCL
+#include <stan/math/opencl/rev.hpp>
+#include <stan/math.hpp>
+#include <gtest/gtest.h>
+#include <test/unit/math/opencl/util.hpp>
+#include <vector>
+
+TEST(ProbDistributionsLogisticCdf, error_checking) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  Eigen::VectorXd y_size(N - 1);
+  y_size << 0.3, 0.8;
+  Eigen::VectorXd y_value(N);
+  y_value << 0.3, NAN, 0.5;
+
+  Eigen::VectorXd mu(N);
+  mu << 0.3, 0.8, 1.0;
+  Eigen::VectorXd mu_size(N - 1);
+  mu_size << 0.3, 0.8;
+  Eigen::VectorXd mu_value(N);
+  mu_value << 0.3, -INFINITY, 0.5;
+
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+  Eigen::VectorXd sigma_size(N - 1);
+  sigma_size << 0.3, 0.8;
+  Eigen::VectorXd sigma_value(N);
+  sigma_value << 0.3, 0, 0.5;
+
+  stan::math::matrix_cl<double> y_cl(y);
+  stan::math::matrix_cl<double> y_size_cl(y_size);
+  stan::math::matrix_cl<double> y_value_cl(y_value);
+  stan::math::matrix_cl<double> mu_cl(mu);
+  stan::math::matrix_cl<double> mu_size_cl(mu_size);
+  stan::math::matrix_cl<double> mu_value_cl(mu_value);
+  stan::math::matrix_cl<double> sigma_cl(sigma);
+  stan::math::matrix_cl<double> sigma_size_cl(sigma_size);
+  stan::math::matrix_cl<double> sigma_value_cl(sigma_value);
+
+  EXPECT_NO_THROW(stan::math::logistic_cdf(y_cl, mu_cl, sigma_cl));
+
+  EXPECT_THROW(stan::math::logistic_cdf(y_size_cl, mu_cl, sigma_cl),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::logistic_cdf(y_cl, mu_size_cl, sigma_cl),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::logistic_cdf(y_cl, mu_cl, sigma_size_cl),
+               std::invalid_argument);
+
+  EXPECT_THROW(stan::math::logistic_cdf(y_value_cl, mu_cl, sigma_cl),
+               std::domain_error);
+  EXPECT_THROW(stan::math::logistic_cdf(y_cl, mu_value_cl, sigma_cl),
+               std::domain_error);
+  EXPECT_THROW(stan::math::logistic_cdf(y_cl, mu_cl, sigma_value_cl),
+               std::domain_error);
+}
+
+auto logistic_cdf_functor = [](const auto& y, const auto& mu, const auto& sigma) {
+  return stan::math::logistic_cdf(y, mu, sigma);
+};
+
+TEST(ProbDistributionsLogisticCdf, opencl_matches_cpu_small) {
+  int N = 3;
+  int M = 2;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  Eigen::VectorXd mu(N);
+  mu << 0.3, 0.8, 1.0;
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+
+  stan::math::test::compare_cpu_opencl_prim_rev(logistic_cdf_functor, y, mu,
+                                                sigma);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      logistic_cdf_functor, y.transpose().eval(), mu.transpose().eval(),
+      sigma.transpose().eval());
+}
+
+TEST(ProbDistributionsLogisticCdf, opencl_matches_cpu_small_y_neg_inf) {
+  int N = 3;
+  int M = 2;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, -INFINITY, 1.0;
+  Eigen::VectorXd mu(N);
+  mu << 0.3, 0.8, 1.0;
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+
+  stan::math::test::compare_cpu_opencl_prim_rev(logistic_cdf_functor, y, mu,
+                                                sigma);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      logistic_cdf_functor, y.transpose().eval(), mu.transpose().eval(),
+      sigma.transpose().eval());
+}
+
+TEST(ProbDistributionsLogisticCdf, opencl_broadcast_y) {
+  int N = 3;
+
+  double y_scal = 12.3;
+  Eigen::VectorXd mu(N);
+  mu << 0.5, 1.2, 1.0;
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(logistic_cdf_functor,
+                                                         y_scal, mu, sigma);
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(
+      logistic_cdf_functor, y_scal, mu.transpose().eval(), sigma);
+}
+
+TEST(ProbDistributionsLogisticCdf, opencl_broadcast_mu) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  double mu_scal = 12.3;
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<1>(logistic_cdf_functor, y,
+                                                         mu_scal, sigma);
+  stan::math::test::test_opencl_broadcasting_prim_rev<1>(
+      logistic_cdf_functor, y.transpose().eval(), mu_scal, sigma);
+}
+
+TEST(ProbDistributionsLogisticCdf, opencl_broadcast_sigma) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  Eigen::VectorXd mu(N);
+  mu << 0.3, 0.8, 1.0;
+  double sigma_scal = 12.3;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<2>(logistic_cdf_functor, y,
+                                                         mu, sigma_scal);
+  stan::math::test::test_opencl_broadcasting_prim_rev<2>(
+      logistic_cdf_functor, y.transpose().eval(), mu, sigma_scal);
+}
+
+TEST(ProbDistributionsLogisticCdf, opencl_matches_cpu_big) {
+  int N = 153;
+
+  Eigen::Matrix<double, Eigen::Dynamic, 1> y
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+  Eigen::Matrix<double, Eigen::Dynamic, 1> mu
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+  Eigen::Matrix<double, Eigen::Dynamic, 1> sigma
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+
+  stan::math::test::compare_cpu_opencl_prim_rev(logistic_cdf_functor, y, mu,
+                                                sigma);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      logistic_cdf_functor, y.transpose().eval(), mu.transpose().eval(),
+      sigma.transpose().eval());
+}
+#endif

--- a/test/unit/math/opencl/rev/logistic_cdf_test.cpp
+++ b/test/unit/math/opencl/rev/logistic_cdf_test.cpp
@@ -56,9 +56,10 @@ TEST(ProbDistributionsLogisticCdf, error_checking) {
                std::domain_error);
 }
 
-auto logistic_cdf_functor = [](const auto& y, const auto& mu, const auto& sigma) {
-  return stan::math::logistic_cdf(y, mu, sigma);
-};
+auto logistic_cdf_functor
+    = [](const auto& y, const auto& mu, const auto& sigma) {
+        return stan::math::logistic_cdf(y, mu, sigma);
+      };
 
 TEST(ProbDistributionsLogisticCdf, opencl_matches_cpu_small) {
   int N = 3;
@@ -120,8 +121,8 @@ TEST(ProbDistributionsLogisticCdf, opencl_broadcast_mu) {
   Eigen::VectorXd sigma(N);
   sigma << 0.3, 0.8, 1.0;
 
-  stan::math::test::test_opencl_broadcasting_prim_rev<1>(logistic_cdf_functor, y,
-                                                         mu_scal, sigma);
+  stan::math::test::test_opencl_broadcasting_prim_rev<1>(logistic_cdf_functor,
+                                                         y, mu_scal, sigma);
   stan::math::test::test_opencl_broadcasting_prim_rev<1>(
       logistic_cdf_functor, y.transpose().eval(), mu_scal, sigma);
 }
@@ -135,8 +136,8 @@ TEST(ProbDistributionsLogisticCdf, opencl_broadcast_sigma) {
   mu << 0.3, 0.8, 1.0;
   double sigma_scal = 12.3;
 
-  stan::math::test::test_opencl_broadcasting_prim_rev<2>(logistic_cdf_functor, y,
-                                                         mu, sigma_scal);
+  stan::math::test::test_opencl_broadcasting_prim_rev<2>(logistic_cdf_functor,
+                                                         y, mu, sigma_scal);
   stan::math::test::test_opencl_broadcasting_prim_rev<2>(
       logistic_cdf_functor, y.transpose().eval(), mu, sigma_scal);
 }

--- a/test/unit/math/opencl/rev/logistic_lccdf_test.cpp
+++ b/test/unit/math/opencl/rev/logistic_lccdf_test.cpp
@@ -1,0 +1,160 @@
+#ifdef STAN_OPENCL
+#include <stan/math/opencl/rev.hpp>
+#include <stan/math.hpp>
+#include <gtest/gtest.h>
+#include <test/unit/math/opencl/util.hpp>
+#include <vector>
+
+TEST(ProbDistributionsLogisticLccdf, error_checking) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  Eigen::VectorXd y_size(N - 1);
+  y_size << 0.3, 0.8;
+  Eigen::VectorXd y_value(N);
+  y_value << 0.3, NAN, 0.5;
+
+  Eigen::VectorXd mu(N);
+  mu << 0.3, 0.8, 1.0;
+  Eigen::VectorXd mu_size(N - 1);
+  mu_size << 0.3, 0.8;
+  Eigen::VectorXd mu_value(N);
+  mu_value << 0.3, -INFINITY, 0.5;
+
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+  Eigen::VectorXd sigma_size(N - 1);
+  sigma_size << 0.3, 0.8;
+  Eigen::VectorXd sigma_value(N);
+  sigma_value << 0.3, 0, 0.5;
+
+  stan::math::matrix_cl<double> y_cl(y);
+  stan::math::matrix_cl<double> y_size_cl(y_size);
+  stan::math::matrix_cl<double> y_value_cl(y_value);
+  stan::math::matrix_cl<double> mu_cl(mu);
+  stan::math::matrix_cl<double> mu_size_cl(mu_size);
+  stan::math::matrix_cl<double> mu_value_cl(mu_value);
+  stan::math::matrix_cl<double> sigma_cl(sigma);
+  stan::math::matrix_cl<double> sigma_size_cl(sigma_size);
+  stan::math::matrix_cl<double> sigma_value_cl(sigma_value);
+
+  EXPECT_NO_THROW(stan::math::logistic_lccdf(y_cl, mu_cl, sigma_cl));
+
+  EXPECT_THROW(stan::math::logistic_lccdf(y_size_cl, mu_cl, sigma_cl),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::logistic_lccdf(y_cl, mu_size_cl, sigma_cl),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::logistic_lccdf(y_cl, mu_cl, sigma_size_cl),
+               std::invalid_argument);
+
+  EXPECT_THROW(stan::math::logistic_lccdf(y_value_cl, mu_cl, sigma_cl),
+               std::domain_error);
+  EXPECT_THROW(stan::math::logistic_lccdf(y_cl, mu_value_cl, sigma_cl),
+               std::domain_error);
+  EXPECT_THROW(stan::math::logistic_lccdf(y_cl, mu_cl, sigma_value_cl),
+               std::domain_error);
+}
+
+auto logistic_lccdf_functor = [](const auto& y, const auto& mu, const auto& sigma) {
+  return stan::math::logistic_lccdf(y, mu, sigma);
+};
+
+TEST(ProbDistributionsLogisticLccdf, opencl_matches_cpu_small) {
+  int N = 3;
+  int M = 2;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  Eigen::VectorXd mu(N);
+  mu << 0.3, 0.8, 1.0;
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+
+  stan::math::test::compare_cpu_opencl_prim_rev(logistic_lccdf_functor, y, mu,
+                                                sigma);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      logistic_lccdf_functor, y.transpose().eval(), mu.transpose().eval(),
+      sigma.transpose().eval());
+}
+
+TEST(ProbDistributionsLogisticLccdf, opencl_matches_cpu_small_y_neg_inf) {
+  int N = 3;
+  int M = 2;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, -INFINITY, 1.0;
+  Eigen::VectorXd mu(N);
+  mu << 0.3, 0.8, 1.0;
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+
+  stan::math::test::compare_cpu_opencl_prim_rev(logistic_lccdf_functor, y, mu,
+                                                sigma);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      logistic_lccdf_functor, y.transpose().eval(), mu.transpose().eval(),
+      sigma.transpose().eval());
+}
+
+TEST(ProbDistributionsLogisticLccdf, opencl_broadcast_y) {
+  int N = 3;
+
+  double y_scal = 12.3;
+  Eigen::VectorXd mu(N);
+  mu << 0.5, 1.2, 1.0;
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(logistic_lccdf_functor,
+                                                         y_scal, mu, sigma);
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(
+      logistic_lccdf_functor, y_scal, mu.transpose().eval(), sigma);
+}
+
+TEST(ProbDistributionsLogisticLccdf, opencl_broadcast_mu) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  double mu_scal = 12.3;
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<1>(logistic_lccdf_functor, y,
+                                                         mu_scal, sigma);
+  stan::math::test::test_opencl_broadcasting_prim_rev<1>(
+      logistic_lccdf_functor, y.transpose().eval(), mu_scal, sigma);
+}
+
+TEST(ProbDistributionsLogisticLccdf, opencl_broadcast_sigma) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  Eigen::VectorXd mu(N);
+  mu << 0.3, 0.8, 1.0;
+  double sigma_scal = 12.3;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<2>(logistic_lccdf_functor, y,
+                                                         mu, sigma_scal);
+  stan::math::test::test_opencl_broadcasting_prim_rev<2>(
+      logistic_lccdf_functor, y.transpose().eval(), mu, sigma_scal);
+}
+
+TEST(ProbDistributionsLogisticLccdf, opencl_matches_cpu_big) {
+  int N = 153;
+
+  Eigen::Matrix<double, Eigen::Dynamic, 1> y
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+  Eigen::Matrix<double, Eigen::Dynamic, 1> mu
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+  Eigen::Matrix<double, Eigen::Dynamic, 1> sigma
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+
+  stan::math::test::compare_cpu_opencl_prim_rev(logistic_lccdf_functor, y, mu,
+                                                sigma);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      logistic_lccdf_functor, y.transpose().eval(), mu.transpose().eval(),
+      sigma.transpose().eval());
+}
+#endif

--- a/test/unit/math/opencl/rev/logistic_lccdf_test.cpp
+++ b/test/unit/math/opencl/rev/logistic_lccdf_test.cpp
@@ -56,9 +56,10 @@ TEST(ProbDistributionsLogisticLccdf, error_checking) {
                std::domain_error);
 }
 
-auto logistic_lccdf_functor = [](const auto& y, const auto& mu, const auto& sigma) {
-  return stan::math::logistic_lccdf(y, mu, sigma);
-};
+auto logistic_lccdf_functor
+    = [](const auto& y, const auto& mu, const auto& sigma) {
+        return stan::math::logistic_lccdf(y, mu, sigma);
+      };
 
 TEST(ProbDistributionsLogisticLccdf, opencl_matches_cpu_small) {
   int N = 3;
@@ -120,8 +121,8 @@ TEST(ProbDistributionsLogisticLccdf, opencl_broadcast_mu) {
   Eigen::VectorXd sigma(N);
   sigma << 0.3, 0.8, 1.0;
 
-  stan::math::test::test_opencl_broadcasting_prim_rev<1>(logistic_lccdf_functor, y,
-                                                         mu_scal, sigma);
+  stan::math::test::test_opencl_broadcasting_prim_rev<1>(logistic_lccdf_functor,
+                                                         y, mu_scal, sigma);
   stan::math::test::test_opencl_broadcasting_prim_rev<1>(
       logistic_lccdf_functor, y.transpose().eval(), mu_scal, sigma);
 }
@@ -135,8 +136,8 @@ TEST(ProbDistributionsLogisticLccdf, opencl_broadcast_sigma) {
   mu << 0.3, 0.8, 1.0;
   double sigma_scal = 12.3;
 
-  stan::math::test::test_opencl_broadcasting_prim_rev<2>(logistic_lccdf_functor, y,
-                                                         mu, sigma_scal);
+  stan::math::test::test_opencl_broadcasting_prim_rev<2>(logistic_lccdf_functor,
+                                                         y, mu, sigma_scal);
   stan::math::test::test_opencl_broadcasting_prim_rev<2>(
       logistic_lccdf_functor, y.transpose().eval(), mu, sigma_scal);
 }

--- a/test/unit/math/opencl/rev/logistic_lcdf_test.cpp
+++ b/test/unit/math/opencl/rev/logistic_lcdf_test.cpp
@@ -56,9 +56,10 @@ TEST(ProbDistributionsLogisticLcdf, error_checking) {
                std::domain_error);
 }
 
-auto logistic_lcdf_functor = [](const auto& y, const auto& mu, const auto& sigma) {
-  return stan::math::logistic_lcdf(y, mu, sigma);
-};
+auto logistic_lcdf_functor
+    = [](const auto& y, const auto& mu, const auto& sigma) {
+        return stan::math::logistic_lcdf(y, mu, sigma);
+      };
 
 TEST(ProbDistributionsLogisticLcdf, opencl_matches_cpu_small) {
   int N = 3;
@@ -120,8 +121,8 @@ TEST(ProbDistributionsLogisticLcdf, opencl_broadcast_mu) {
   Eigen::VectorXd sigma(N);
   sigma << 0.3, 0.8, 1.0;
 
-  stan::math::test::test_opencl_broadcasting_prim_rev<1>(logistic_lcdf_functor, y,
-                                                         mu_scal, sigma);
+  stan::math::test::test_opencl_broadcasting_prim_rev<1>(logistic_lcdf_functor,
+                                                         y, mu_scal, sigma);
   stan::math::test::test_opencl_broadcasting_prim_rev<1>(
       logistic_lcdf_functor, y.transpose().eval(), mu_scal, sigma);
 }
@@ -135,8 +136,8 @@ TEST(ProbDistributionsLogisticLcdf, opencl_broadcast_sigma) {
   mu << 0.3, 0.8, 1.0;
   double sigma_scal = 12.3;
 
-  stan::math::test::test_opencl_broadcasting_prim_rev<2>(logistic_lcdf_functor, y,
-                                                         mu, sigma_scal);
+  stan::math::test::test_opencl_broadcasting_prim_rev<2>(logistic_lcdf_functor,
+                                                         y, mu, sigma_scal);
   stan::math::test::test_opencl_broadcasting_prim_rev<2>(
       logistic_lcdf_functor, y.transpose().eval(), mu, sigma_scal);
 }

--- a/test/unit/math/opencl/rev/logistic_lcdf_test.cpp
+++ b/test/unit/math/opencl/rev/logistic_lcdf_test.cpp
@@ -1,0 +1,160 @@
+#ifdef STAN_OPENCL
+#include <stan/math/opencl/rev.hpp>
+#include <stan/math.hpp>
+#include <gtest/gtest.h>
+#include <test/unit/math/opencl/util.hpp>
+#include <vector>
+
+TEST(ProbDistributionsLogisticLcdf, error_checking) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  Eigen::VectorXd y_size(N - 1);
+  y_size << 0.3, 0.8;
+  Eigen::VectorXd y_value(N);
+  y_value << 0.3, NAN, 0.5;
+
+  Eigen::VectorXd mu(N);
+  mu << 0.3, 0.8, 1.0;
+  Eigen::VectorXd mu_size(N - 1);
+  mu_size << 0.3, 0.8;
+  Eigen::VectorXd mu_value(N);
+  mu_value << 0.3, -INFINITY, 0.5;
+
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+  Eigen::VectorXd sigma_size(N - 1);
+  sigma_size << 0.3, 0.8;
+  Eigen::VectorXd sigma_value(N);
+  sigma_value << 0.3, 0, 0.5;
+
+  stan::math::matrix_cl<double> y_cl(y);
+  stan::math::matrix_cl<double> y_size_cl(y_size);
+  stan::math::matrix_cl<double> y_value_cl(y_value);
+  stan::math::matrix_cl<double> mu_cl(mu);
+  stan::math::matrix_cl<double> mu_size_cl(mu_size);
+  stan::math::matrix_cl<double> mu_value_cl(mu_value);
+  stan::math::matrix_cl<double> sigma_cl(sigma);
+  stan::math::matrix_cl<double> sigma_size_cl(sigma_size);
+  stan::math::matrix_cl<double> sigma_value_cl(sigma_value);
+
+  EXPECT_NO_THROW(stan::math::logistic_lcdf(y_cl, mu_cl, sigma_cl));
+
+  EXPECT_THROW(stan::math::logistic_lcdf(y_size_cl, mu_cl, sigma_cl),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::logistic_lcdf(y_cl, mu_size_cl, sigma_cl),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::logistic_lcdf(y_cl, mu_cl, sigma_size_cl),
+               std::invalid_argument);
+
+  EXPECT_THROW(stan::math::logistic_lcdf(y_value_cl, mu_cl, sigma_cl),
+               std::domain_error);
+  EXPECT_THROW(stan::math::logistic_lcdf(y_cl, mu_value_cl, sigma_cl),
+               std::domain_error);
+  EXPECT_THROW(stan::math::logistic_lcdf(y_cl, mu_cl, sigma_value_cl),
+               std::domain_error);
+}
+
+auto logistic_lcdf_functor = [](const auto& y, const auto& mu, const auto& sigma) {
+  return stan::math::logistic_lcdf(y, mu, sigma);
+};
+
+TEST(ProbDistributionsLogisticLcdf, opencl_matches_cpu_small) {
+  int N = 3;
+  int M = 2;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  Eigen::VectorXd mu(N);
+  mu << 0.3, 0.8, 1.0;
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+
+  stan::math::test::compare_cpu_opencl_prim_rev(logistic_lcdf_functor, y, mu,
+                                                sigma);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      logistic_lcdf_functor, y.transpose().eval(), mu.transpose().eval(),
+      sigma.transpose().eval());
+}
+
+TEST(ProbDistributionsLogisticLcdf, opencl_matches_cpu_small_y_neg_inf) {
+  int N = 3;
+  int M = 2;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, -INFINITY, 1.0;
+  Eigen::VectorXd mu(N);
+  mu << 0.3, 0.8, 1.0;
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+
+  stan::math::test::compare_cpu_opencl_prim_rev(logistic_lcdf_functor, y, mu,
+                                                sigma);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      logistic_lcdf_functor, y.transpose().eval(), mu.transpose().eval(),
+      sigma.transpose().eval());
+}
+
+TEST(ProbDistributionsLogisticLcdf, opencl_broadcast_y) {
+  int N = 3;
+
+  double y_scal = 12.3;
+  Eigen::VectorXd mu(N);
+  mu << 0.5, 1.2, 1.0;
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(logistic_lcdf_functor,
+                                                         y_scal, mu, sigma);
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(
+      logistic_lcdf_functor, y_scal, mu.transpose().eval(), sigma);
+}
+
+TEST(ProbDistributionsLogisticLcdf, opencl_broadcast_mu) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  double mu_scal = 12.3;
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<1>(logistic_lcdf_functor, y,
+                                                         mu_scal, sigma);
+  stan::math::test::test_opencl_broadcasting_prim_rev<1>(
+      logistic_lcdf_functor, y.transpose().eval(), mu_scal, sigma);
+}
+
+TEST(ProbDistributionsLogisticLcdf, opencl_broadcast_sigma) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  Eigen::VectorXd mu(N);
+  mu << 0.3, 0.8, 1.0;
+  double sigma_scal = 12.3;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<2>(logistic_lcdf_functor, y,
+                                                         mu, sigma_scal);
+  stan::math::test::test_opencl_broadcasting_prim_rev<2>(
+      logistic_lcdf_functor, y.transpose().eval(), mu, sigma_scal);
+}
+
+TEST(ProbDistributionsLogisticLcdf, opencl_matches_cpu_big) {
+  int N = 153;
+
+  Eigen::Matrix<double, Eigen::Dynamic, 1> y
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+  Eigen::Matrix<double, Eigen::Dynamic, 1> mu
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+  Eigen::Matrix<double, Eigen::Dynamic, 1> sigma
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+
+  stan::math::test::compare_cpu_opencl_prim_rev(logistic_lcdf_functor, y, mu,
+                                                sigma);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      logistic_lcdf_functor, y.transpose().eval(), mu.transpose().eval(),
+      sigma.transpose().eval());
+}
+#endif


### PR DESCRIPTION
## Summary

Added OpenCL implementations for functions `gumbel_cdf`, `gumbel_lcdf`, `gumbel_lccdf`, `logistic_cdf`, `logistic_lcdf` and `logistic_lccdf`. 

## Tests
New functions are tested.

## Side Effects
None.

## Release notes
OpenCL: Added OpenCL implementations for functions `gumbel_cdf`, `gumbel_lcdf`, `gumbel_lccdf`, `logistic_cdf`, `logistic_lcdf` and `logistic_lccdf`. 

## Checklist

- [ ] Math issue #2152 

- [ ] Copyright holder: Tadej Ciglarič

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [ ] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [ ] the code is written in idiomatic C++ and changes are documented in the doxygen

- [ ] the new changes are tested
