### PR TITLE
Fix external oneTBB after #2447

### DIFF
--- a/stan/math/prim/core/init_threadpool_tbb.hpp
+++ b/stan/math/prim/core/init_threadpool_tbb.hpp
@@ -5,11 +5,13 @@
 
 #include <boost/lexical_cast.hpp>
 
+#ifndef TBB_INTERFACE_NEW
 #include <tbb/tbb_stddef.h>
 
 #if TBB_VERSION_MAJOR >= 2020
 #ifndef TBB_INTERFACE_NEW
 #define TBB_INTERFACE_NEW
+#endif
 #endif
 #endif
 

--- a/stan/math/prim/core/init_threadpool_tbb.hpp
+++ b/stan/math/prim/core/init_threadpool_tbb.hpp
@@ -9,9 +9,7 @@
 #include <tbb/tbb_stddef.h>
 
 #if TBB_VERSION_MAJOR >= 2020
-#ifndef TBB_INTERFACE_NEW
 #define TBB_INTERFACE_NEW
-#endif
 #endif
 #endif
 


### PR DESCRIPTION
## Summary

#2447 breaks external `oneTBB` because`tbb/tbb_stddef.h` is not found (`TBB_VERSION_MAJOR` is now defined in `tbb/version.h`):
```bash
stan/math/prim/core/init_threadpool_tbb.hpp(8):
  catastrophic error: cannot open source file "tbb/tbb_stddef.h"
  #include <tbb/tbb_stddef.h>
```



Also, there's no need to redefine `TBB_INTERFACE_NEW` if it's already defined.

## Tests

The development version if `rstan` is built successfully after this patch.

## Side Effects

N/A

## Release notes

N/A

## Checklist

- [X] Copyright holder: Hamada S. Badr <badr@jhu.edu>

- [X] the basic tests are passing

- [X] the code is written in idiomatic C++ and changes are documented in the doxygen

- [X] the new changes are tested