### PR TITLE
allow for tbb init to set the number of threads by an argument

### DIFF
--- a/runTests.py
+++ b/runTests.py
@@ -32,7 +32,7 @@ allowed_paths_with_jumbo = [
 ]
 
 jumbo_folders = [
-    "test/unit/math/prim/core",
+    #"test/unit/math/prim/core",
     "test/unit/math/prim/err",
     "test/unit/math/prim/fun",
     "test/unit/math/prim/functor",

--- a/stan/math/prim/core/init_threadpool_tbb.hpp
+++ b/stan/math/prim/core/init_threadpool_tbb.hpp
@@ -88,12 +88,20 @@ inline int get_num_threads() {
  * The function returns a reference to the static
  * tbb::global_control instance.
  *
+ * @param n_threads The maximum number of threads available to the tbb. If not
+ *  set will search for the environment variable `STAN_NUM_THREADS`. A value of
+ *  will assume all detectable threads are available for the process.
  * @return reference to the static tbb::global_control
  * @throws std::runtime_error if the value of STAN_NUM_THREADS env. variable
  * is invalid
  */
-inline tbb::task_arena& init_threadpool_tbb() {
-  int tbb_max_threads = internal::get_num_threads();
+inline tbb::task_arena& init_threadpool_tbb(size_t n_threads = 0) {
+  int tbb_max_threads;
+  if (n_threads == 0) {
+   tbb_max_threads = internal::get_num_threads();
+  } else {
+   tbb_max_threads = n_threads;
+  }
   static tbb::global_control tbb_gc(
       tbb::global_control::max_allowed_parallelism, tbb_max_threads);
 
@@ -118,18 +126,21 @@ inline tbb::task_arena& init_threadpool_tbb() {
  * The function returns a reference to the static
  * tbb::task_scheduler_init instance.
  *
- * @param stack_size sets the stack size of each thread; the default 0
- * let's the TBB choose the stack size
+ * @param n_threads The maximum number of threads available to the tbb. If not
+ *  set will search for the environment variable `STAN_NUM_THREADS`. A value of
+ *  will assume all detectable threads are available for the process.
  * @return reference to the static tbb::task_scheduler_init
  * @throws std::runtime_error if the value of STAN_NUM_THREADS env. variable
  * is invalid
  */
-inline tbb::task_scheduler_init& init_threadpool_tbb(
-    tbb::stack_size_type stack_size = 0) {
-  int tbb_max_threads = internal::get_num_threads();
-
-  static tbb::task_scheduler_init tbb_scheduler(tbb_max_threads, stack_size);
-
+inline tbb::task_scheduler_init& init_threadpool_tbb(size_t n_threads = 0) {
+  int tbb_max_threads;
+  if (n_threads == 0) {
+   tbb_max_threads = internal::get_num_threads();
+  } else {
+   tbb_max_threads = n_threads;
+  }
+  static tbb::task_scheduler_init tbb_scheduler(tbb_max_threads, 0);
   return tbb_scheduler;
 }
 #endif

--- a/stan/math/prim/core/init_threadpool_tbb.hpp
+++ b/stan/math/prim/core/init_threadpool_tbb.hpp
@@ -98,9 +98,9 @@ inline int get_num_threads() {
 inline tbb::task_arena& init_threadpool_tbb(size_t n_threads = 0) {
   int tbb_max_threads;
   if (n_threads == 0) {
-   tbb_max_threads = internal::get_num_threads();
+    tbb_max_threads = internal::get_num_threads();
   } else {
-   tbb_max_threads = n_threads;
+    tbb_max_threads = n_threads;
   }
   static tbb::global_control tbb_gc(
       tbb::global_control::max_allowed_parallelism, tbb_max_threads);
@@ -136,9 +136,9 @@ inline tbb::task_arena& init_threadpool_tbb(size_t n_threads = 0) {
 inline tbb::task_scheduler_init& init_threadpool_tbb(size_t n_threads = 0) {
   int tbb_max_threads;
   if (n_threads == 0) {
-   tbb_max_threads = internal::get_num_threads();
+    tbb_max_threads = internal::get_num_threads();
   } else {
-   tbb_max_threads = n_threads;
+    tbb_max_threads = n_threads;
   }
   static tbb::task_scheduler_init tbb_scheduler(tbb_max_threads, 0);
   return tbb_scheduler;

--- a/stan/math/prim/core/init_threadpool_tbb.hpp
+++ b/stan/math/prim/core/init_threadpool_tbb.hpp
@@ -90,21 +90,27 @@ inline int get_num_threads() {
  *
  * @param n_threads The maximum number of threads available to the tbb. If not
  *  set will search for the environment variable `STAN_NUM_THREADS`. A value of
- *  will assume all detectable threads are available for the process.
+ *  -1 will assume all detectable threads are available for the process.
  * @return reference to the static tbb::global_control
- * @throws std::runtime_error if the value of STAN_NUM_THREADS env. variable
- * is invalid
+ * @throws std::runtime_error if n_threads (defaults to zero) is not provided and
+ * the value of STAN_NUM_THREADS environment variable is invalid.
  */
-inline tbb::task_arena& init_threadpool_tbb(size_t n_threads = 0) {
+inline tbb::task_arena& init_threadpool_tbb(int n_threads = 0) {
   int tbb_max_threads;
   if (n_threads == 0) {
     tbb_max_threads = internal::get_num_threads();
-  } else {
+  } else if (n_threads > 0) {
     tbb_max_threads = n_threads;
+  } else if (n_threads == -1) {
+    tbb_max_threads = std::thread::hardware_concurrency();
+  } else {
+    invalid_argument("init_threadpool_tbb(int)", "n_threads",
+                     n_threads,
+                     "The number of threads is '",
+                     "' but it must be positive or -1");
   }
   static tbb::global_control tbb_gc(
       tbb::global_control::max_allowed_parallelism, tbb_max_threads);
-
   static tbb::task_arena tbb_arena(tbb_max_threads, 1);
   tbb_arena.initialize();
 
@@ -130,15 +136,22 @@ inline tbb::task_arena& init_threadpool_tbb(size_t n_threads = 0) {
  *  set will search for the environment variable `STAN_NUM_THREADS`. A value of
  *  will assume all detectable threads are available for the process.
  * @return reference to the static tbb::task_scheduler_init
- * @throws std::runtime_error if the value of STAN_NUM_THREADS env. variable
- * is invalid
+ * @throws std::runtime_error if n_threads (defaults to zero) is not provided and
+ * the value of STAN_NUM_THREADS environment variable is invalid.
  */
-inline tbb::task_scheduler_init& init_threadpool_tbb(size_t n_threads = 0) {
+inline tbb::task_scheduler_init& init_threadpool_tbb(int n_threads = 0) {
   int tbb_max_threads;
   if (n_threads == 0) {
     tbb_max_threads = internal::get_num_threads();
-  } else {
+  } else if (n_threads > 0) {
     tbb_max_threads = n_threads;
+  } else if (n_threads == -1) {
+    tbb_max_threads = std::thread::hardware_concurrency();
+  } else {
+    invalid_argument("init_threadpool_tbb(int)", "n_threads",
+                     n_threads,
+                     "The number of threads is '",
+                     "' but it must be positive or -1");
   }
   static tbb::task_scheduler_init tbb_scheduler(tbb_max_threads, 0);
   return tbb_scheduler;

--- a/test/unit/math/prim/core/init_threadpool_tbb_late_test.cpp
+++ b/test/unit/math/prim/core/init_threadpool_tbb_late_test.cpp
@@ -29,13 +29,13 @@ TEST(intel_tbb_new_late_init, set_threads) {
   const int num_threads = tbb::global_control::max_allowed_parallelism;
 
   if (num_threads > 1) {
-    tbb::task_arena& tbb_arena = stan::math::init_threadpool_tbb(num_threads);
+    tbb::task_arena& tbb_arena = stan::math::init_threadpool_tbb(num_threads - 1);
     tbb_arena.execute([&]() {
       EXPECT_TRUE(tbb_arena.is_active());
 
       // STAN_NUM_THREADS is not being honored if we have first
       // initialized the TBB scheduler outside of init_threadpool_tbb
-      EXPECT_EQ(num_threads, tbb::this_task_arena::max_concurrency());
+      EXPECT_EQ(num_threads, tbb::this_task_arena::max_concurrency() - 1);
     });
   }
 }
@@ -64,12 +64,12 @@ TEST(intel_tbb_late_init, set_threads) {
   const int num_threads = tbb::task_scheduler_init::default_num_threads();
   if (num_threads > 1) {
     tbb::task_scheduler_init tbb_scheduler;
-    tbb::task_scheduler_init& tbb_init = stan::math::init_threadpool_tbb(num_threads);
+    tbb::task_scheduler_init& tbb_init = stan::math::init_threadpool_tbb(num_threads - 1);
     EXPECT_TRUE(tbb_init.is_active());
 
     // STAN_NUM_THREADS is not being honored if we have first
     // initialized the TBB scheduler outside of init_threadpool_tbb
-    EXPECT_EQ(num_threads, tbb::this_task_arena::max_concurrency());
+    EXPECT_EQ(num_threads, tbb::this_task_arena::max_concurrency() - 1);
   }
 }
 

--- a/test/unit/math/prim/core/init_threadpool_tbb_late_test.cpp
+++ b/test/unit/math/prim/core/init_threadpool_tbb_late_test.cpp
@@ -25,6 +25,21 @@ TEST(intel_tbb_new_late_init, check_status) {
   }
 }
 
+TEST(intel_tbb_new_late_init, set_threads) {
+  const int num_threads = tbb::global_control::max_allowed_parallelism;
+
+  if (num_threads > 1) {
+    tbb::task_arena& tbb_arena = stan::math::init_threadpool_tbb(num_threads);
+    tbb_arena.execute([&]() {
+      EXPECT_TRUE(tbb_arena.is_active());
+
+      // STAN_NUM_THREADS is not being honored if we have first
+      // initialized the TBB scheduler outside of init_threadpool_tbb
+      EXPECT_EQ(num_threads, tbb::this_task_arena::max_concurrency());
+    });
+  }
+}
+
 #else
 
 #include <tbb/task_scheduler_init.h>
@@ -37,6 +52,19 @@ TEST(intel_tbb_late_init, check_status) {
   if (num_threads > 1) {
     set_n_threads(num_threads - 1);
     tbb::task_scheduler_init& tbb_init = stan::math::init_threadpool_tbb();
+    EXPECT_TRUE(tbb_init.is_active());
+
+    // STAN_NUM_THREADS is not being honored if we have first
+    // initialized the TBB scheduler outside of init_threadpool_tbb
+    EXPECT_EQ(num_threads, tbb::this_task_arena::max_concurrency());
+  }
+}
+
+TEST(intel_tbb_late_init, set_threads) {
+  const int num_threads = tbb::task_scheduler_init::default_num_threads();
+  if (num_threads > 1) {
+    tbb::task_scheduler_init tbb_scheduler;
+    tbb::task_scheduler_init& tbb_init = stan::math::init_threadpool_tbb(num_threads);
     EXPECT_TRUE(tbb_init.is_active());
 
     // STAN_NUM_THREADS is not being honored if we have first

--- a/test/unit/math/prim/core/init_threadpool_tbb_late_test.cpp
+++ b/test/unit/math/prim/core/init_threadpool_tbb_late_test.cpp
@@ -25,22 +25,6 @@ TEST(intel_tbb_new_late_init, check_status) {
   }
 }
 
-TEST(intel_tbb_new_late_init, set_threads) {
-  const int num_threads = tbb::global_control::max_allowed_parallelism;
-
-  if (num_threads > 1) {
-    tbb::task_arena& tbb_arena
-        = stan::math::init_threadpool_tbb(num_threads - 1);
-    tbb_arena.execute([&]() {
-      EXPECT_TRUE(tbb_arena.is_active());
-
-      // STAN_NUM_THREADS is not being honored if we have first
-      // initialized the TBB scheduler outside of init_threadpool_tbb
-      EXPECT_EQ(num_threads, tbb::this_task_arena::max_concurrency() - 1);
-    });
-  }
-}
-
 #else
 
 #include <tbb/task_scheduler_init.h>
@@ -58,20 +42,6 @@ TEST(intel_tbb_late_init, check_status) {
     // STAN_NUM_THREADS is not being honored if we have first
     // initialized the TBB scheduler outside of init_threadpool_tbb
     EXPECT_EQ(num_threads, tbb::this_task_arena::max_concurrency());
-  }
-}
-
-TEST(intel_tbb_late_init, set_threads) {
-  const int num_threads = tbb::task_scheduler_init::default_num_threads();
-  if (num_threads > 1) {
-    tbb::task_scheduler_init tbb_scheduler;
-    tbb::task_scheduler_init& tbb_init
-        = stan::math::init_threadpool_tbb(num_threads - 1);
-    EXPECT_TRUE(tbb_init.is_active());
-
-    // STAN_NUM_THREADS is not being honored if we have first
-    // initialized the TBB scheduler outside of init_threadpool_tbb
-    EXPECT_EQ(num_threads, tbb::this_task_arena::max_concurrency() - 1);
   }
 }
 

--- a/test/unit/math/prim/core/init_threadpool_tbb_late_test.cpp
+++ b/test/unit/math/prim/core/init_threadpool_tbb_late_test.cpp
@@ -29,7 +29,8 @@ TEST(intel_tbb_new_late_init, set_threads) {
   const int num_threads = tbb::global_control::max_allowed_parallelism;
 
   if (num_threads > 1) {
-    tbb::task_arena& tbb_arena = stan::math::init_threadpool_tbb(num_threads - 1);
+    tbb::task_arena& tbb_arena
+        = stan::math::init_threadpool_tbb(num_threads - 1);
     tbb_arena.execute([&]() {
       EXPECT_TRUE(tbb_arena.is_active());
 
@@ -64,7 +65,8 @@ TEST(intel_tbb_late_init, set_threads) {
   const int num_threads = tbb::task_scheduler_init::default_num_threads();
   if (num_threads > 1) {
     tbb::task_scheduler_init tbb_scheduler;
-    tbb::task_scheduler_init& tbb_init = stan::math::init_threadpool_tbb(num_threads - 1);
+    tbb::task_scheduler_init& tbb_init
+        = stan::math::init_threadpool_tbb(num_threads - 1);
     EXPECT_TRUE(tbb_init.is_active());
 
     // STAN_NUM_THREADS is not being honored if we have first

--- a/test/unit/math/prim/core/init_threadpool_tbb_test.cpp
+++ b/test/unit/math/prim/core/init_threadpool_tbb_test.cpp
@@ -4,43 +4,16 @@
 #include <test/unit/util.hpp>
 #include <test/unit/math/prim/functor/utils_threads.hpp>
 
-#ifdef TBB_INTERFACE_NEW
-
-#include <tbb/global_control.h>
-#include <tbb/task_arena.h>
-
 TEST(intel_tbb_new_init, check_status) {
   set_n_threads(-1);
-  tbb::task_arena& tbb_init = stan::math::init_threadpool_tbb();
+  auto& tbb_init = stan::math::init_threadpool_tbb();
   EXPECT_TRUE(tbb_init.is_active());
 
   EXPECT_EQ(std::thread::hardware_concurrency(), tbb_init.max_concurrency());
 
-  tbb::task_arena& tbb_reinit = stan::math::init_threadpool_tbb();
+  auto& tbb_reinit = stan::math::init_threadpool_tbb();
   EXPECT_TRUE(tbb_init.is_active());
 
   tbb_init.terminate();
   EXPECT_FALSE(tbb_init.is_active());
 }
-
-#else
-
-#include <tbb/task_scheduler_init.h>
-#include <tbb/task_arena.h>
-
-TEST(intel_tbb_init, check_status) {
-  set_n_threads(-1);
-  tbb::task_scheduler_init& tbb_init = stan::math::init_threadpool_tbb();
-  EXPECT_TRUE(tbb_init.is_active());
-
-  EXPECT_EQ(std::thread::hardware_concurrency(),
-            tbb::this_task_arena::max_concurrency());
-
-  tbb::task_scheduler_init& tbb_reinit = stan::math::init_threadpool_tbb();
-  EXPECT_TRUE(tbb_init.is_active());
-
-  tbb_init.terminate();
-  EXPECT_FALSE(tbb_init.is_active());
-}
-
-#endif

--- a/test/unit/math/prim/core/set_num_threads_test.cpp
+++ b/test/unit/math/prim/core/set_num_threads_test.cpp
@@ -1,0 +1,11 @@
+#include <stan/math/prim/core.hpp>
+#include <gtest/gtest.h>
+
+
+TEST(intel_tbb_new_init, set_threads) {
+  int num_threads = std::thread::hardware_concurrency() - 1;
+  auto& tbb_init = stan::math::init_threadpool_tbb(num_threads);
+  EXPECT_TRUE(tbb_init.is_active());
+
+  EXPECT_EQ(num_threads, tbb_init.max_concurrency());
+}

--- a/test/unit/math/prim/core/set_num_threads_test.cpp
+++ b/test/unit/math/prim/core/set_num_threads_test.cpp
@@ -3,8 +3,8 @@
 
 TEST(intel_tbb_new_init, set_threads) {
   int num_threads = std::thread::hardware_concurrency();
-  auto& tbb_init = stan::math::init_threadpool_tbb(num_threads);
+  auto& tbb_init = stan::math::init_threadpool_tbb(num_threads - 1);
   EXPECT_TRUE(tbb_init.is_active());
 
-  EXPECT_EQ(num_threads, tbb_init.max_concurrency());
+  EXPECT_EQ(num_threads - 1, tbb_init.max_concurrency());
 }

--- a/test/unit/math/prim/core/set_num_threads_test.cpp
+++ b/test/unit/math/prim/core/set_num_threads_test.cpp
@@ -3,7 +3,7 @@
 
 
 TEST(intel_tbb_new_init, set_threads) {
-  int num_threads = std::thread::hardware_concurrency() - 1;
+  int num_threads = std::thread::hardware_concurrency();
   auto& tbb_init = stan::math::init_threadpool_tbb(num_threads);
   EXPECT_TRUE(tbb_init.is_active());
 


### PR DESCRIPTION
## Summary

This adds an argument to `init_threadpool_tbb()` so we can set the number of threads by an argument

## Tests

Test added for passing the number of threads as an argument

## Release notes

Allow tbb init to set the number of threads by an argument.

## Checklist

- [ ] Math issue #(issue number)

- [x] Copyright holder: Steve Bronder

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
