### PR TITLE
Opencl std_normal and uniform (lc)cdf

### DIFF
--- a/stan/math/opencl/prim.hpp
+++ b/stan/math/opencl/prim.hpp
@@ -238,6 +238,9 @@
 #include <stan/math/opencl/prim/to_vector.hpp>
 #include <stan/math/opencl/prim/trace.hpp>
 #include <stan/math/opencl/prim/ub_constrain.hpp>
+#include <stan/math/opencl/prim/uniform_cdf.hpp>
+#include <stan/math/opencl/prim/uniform_lccdf.hpp>
+#include <stan/math/opencl/prim/uniform_lcdf.hpp>
 #include <stan/math/opencl/prim/uniform_lpdf.hpp>
 #include <stan/math/opencl/prim/unit_vector_constrain.hpp>
 #include <stan/math/opencl/prim/variance.hpp>

--- a/stan/math/opencl/prim.hpp
+++ b/stan/math/opencl/prim.hpp
@@ -220,6 +220,9 @@
 #include <stan/math/opencl/prim/squared_distance.hpp>
 #include <stan/math/opencl/prim/sub_col.hpp>
 #include <stan/math/opencl/prim/sub_row.hpp>
+#include <stan/math/opencl/prim/std_normal_cdf.hpp>
+#include <stan/math/opencl/prim/std_normal_lccdf.hpp>
+#include <stan/math/opencl/prim/std_normal_lcdf.hpp>
 #include <stan/math/opencl/prim/std_normal_lpdf.hpp>
 #include <stan/math/opencl/prim/student_t_lpdf.hpp>
 #include <stan/math/opencl/prim/skew_normal_lpdf.hpp>

--- a/stan/math/opencl/prim/std_normal_cdf.hpp
+++ b/stan/math/opencl/prim/std_normal_cdf.hpp
@@ -1,0 +1,73 @@
+#ifndef STAN_MATH_OPENCL_PRIM_STD_NORMAL_CDF_HPP
+#define STAN_MATH_OPENCL_PRIM_STD_NORMAL_CDF_HPP
+#ifdef STAN_OPENCL
+
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/err.hpp>
+#include <stan/math/prim/fun/constants.hpp>
+#include <stan/math/prim/fun/elt_divide.hpp>
+#include <stan/math/prim/fun/elt_multiply.hpp>
+#include <stan/math/opencl/kernel_generator.hpp>
+#include <stan/math/prim/functor/operands_and_partials.hpp>
+
+namespace stan {
+namespace math {
+
+/** \ingroup opencl
+ * Returns the standard normal cumulative distribution function.
+ *
+ * @tparam T_y_cl type of scalar outcome
+ * @param y (Sequence of) scalar(s).
+ * @return The log of the product of densities.
+ */
+template <typename T_y_cl,
+          require_all_prim_or_rev_kernel_expression_t<T_y_cl>* = nullptr,
+          require_any_not_stan_scalar_t<T_y_cl>* = nullptr>
+return_type_t<T_y_cl> std_normal_cdf(const T_y_cl& y) {
+  static const char* function = "std_normal_cdf(OpenCL)";
+  using T_partials_return = partials_return_t<T_y_cl>;
+  using std::isfinite;
+  using std::isnan;
+
+  const size_t N = size(y);
+  if (N == 0) {
+    return 1.0;
+  }
+
+  const auto& y_col = as_column_vector_or_scalar(y);
+  const auto& y_val = value_of(y_col);
+
+  auto check_y_not_nan
+      = check_cl(function, "Random variable", y_val, "not NaN");
+  auto y_not_nan_expr = !isnan(y_val);
+
+  auto scaled_y = y_val * INV_SQRT_TWO;
+  auto cdf_n
+      = select(y_val < -37.5, 0.0,
+               select(y_val < -5.0, 0.5 * erfc(-scaled_y),
+                      select(y_val > 8.25, 1.0, 0.5 * (1.0 + erf(scaled_y)))));
+  auto cdf_expr = colwise_prod(cdf_n);
+  auto y_deriv1
+      = select(y_val < -37.5, 0.0,
+               INV_SQRT_TWO_PI * elt_divide(exp(-square(scaled_y)), cdf_n));
+
+  matrix_cl<double> cdf_cl;
+  matrix_cl<double> y_deriv_cl;
+
+  results(check_y_not_nan, cdf_cl, y_deriv_cl) = expressions(
+      y_not_nan_expr, cdf_expr, calc_if<!is_constant<T_y_cl>::value>(y_deriv1));
+
+  T_partials_return cdf = (from_matrix_cl(cdf_cl)).prod();
+
+  operands_and_partials<decltype(y_col)> ops_partials(y_col);
+
+  if (!is_constant<T_y_cl>::value) {
+    ops_partials.edge1_.partials_ = y_deriv_cl * cdf;
+  }
+  return ops_partials.build(cdf);
+}
+
+}  // namespace math
+}  // namespace stan
+#endif
+#endif

--- a/stan/math/opencl/prim/std_normal_lccdf.hpp
+++ b/stan/math/opencl/prim/std_normal_lccdf.hpp
@@ -1,0 +1,75 @@
+#ifndef STAN_MATH_OPENCL_PRIM_STD_NORMAL_LCCDF_HPP
+#define STAN_MATH_OPENCL_PRIM_STD_NORMAL_LCCDF_HPP
+#ifdef STAN_OPENCL
+
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/err.hpp>
+#include <stan/math/prim/fun/constants.hpp>
+#include <stan/math/prim/fun/elt_divide.hpp>
+#include <stan/math/prim/fun/elt_multiply.hpp>
+#include <stan/math/opencl/kernel_generator.hpp>
+#include <stan/math/prim/functor/operands_and_partials.hpp>
+
+namespace stan {
+namespace math {
+
+/** \ingroup opencl
+ * Returns the log standard normal complementary cumulative distribution
+ * function.
+ *
+ * @tparam T_y_cl type of scalar outcome
+ * @param y (Sequence of) scalar(s).
+ * @return The log of the product of densities.
+ */
+template <typename T_y_cl,
+          require_all_prim_or_rev_kernel_expression_t<T_y_cl>* = nullptr,
+          require_any_not_stan_scalar_t<T_y_cl>* = nullptr>
+return_type_t<T_y_cl> std_normal_lccdf(const T_y_cl& y) {
+  static const char* function = "std_normal_lccdf(OpenCL)";
+  using T_partials_return = partials_return_t<T_y_cl>;
+  using std::isfinite;
+  using std::isnan;
+
+  const size_t N = size(y);
+  if (N == 0) {
+    return 1.0;
+  }
+
+  const auto& y_col = as_column_vector_or_scalar(y);
+  const auto& y_val = value_of(y_col);
+
+  auto check_y_not_nan
+      = check_cl(function, "Random variable", y_val, "not NaN");
+  auto y_not_nan_expr = !isnan(y_val);
+
+  auto scaled_y = y_val * INV_SQRT_TWO;
+  auto one_m_erf
+      = select(y_val < -37.5, 2.0,
+               select(y_val < -5.0, 2.0 - erfc(-scaled_y),
+                      select(y_val > 8.25, 0.0, 1.0 - erf(scaled_y))));
+  auto lccdf_expr = colwise_sum(log(one_m_erf));
+  auto y_deriv = -select(
+      y_val > 8.25, INFTY,
+      SQRT_TWO_OVER_SQRT_PI * elt_divide(exp(-square(scaled_y)), one_m_erf));
+
+  matrix_cl<double> lccdf_cl;
+  matrix_cl<double> y_deriv_cl;
+
+  results(check_y_not_nan, lccdf_cl, y_deriv_cl)
+      = expressions(y_not_nan_expr, lccdf_expr,
+                    calc_if<!is_constant<T_y_cl>::value>(y_deriv));
+
+  T_partials_return lccdf = from_matrix_cl(lccdf_cl).sum() + LOG_HALF * N;
+
+  operands_and_partials<decltype(y_col)> ops_partials(y_col);
+
+  if (!is_constant<T_y_cl>::value) {
+    ops_partials.edge1_.partials_ = std::move(y_deriv_cl);
+  }
+  return ops_partials.build(lccdf);
+}
+
+}  // namespace math
+}  // namespace stan
+#endif
+#endif

--- a/stan/math/opencl/prim/std_normal_lcdf.hpp
+++ b/stan/math/opencl/prim/std_normal_lcdf.hpp
@@ -1,0 +1,231 @@
+#ifndef STAN_MATH_OPENCL_PRIM_STD_NORMAL_LCDF_HPP
+#define STAN_MATH_OPENCL_PRIM_STD_NORMAL_LCDF_HPP
+#ifdef STAN_OPENCL
+
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/err.hpp>
+#include <stan/math/prim/fun/constants.hpp>
+#include <stan/math/prim/fun/elt_divide.hpp>
+#include <stan/math/prim/fun/elt_multiply.hpp>
+#include <stan/math/opencl/kernel_generator.hpp>
+#include <stan/math/prim/functor/operands_and_partials.hpp>
+
+namespace stan {
+namespace math {
+namespace internal {
+const char opencl_std_normal_lcdf_impl[] = STRINGIFY(
+    double std_normal_lcdf_lcdf_n; if (std_normal_lcdf_scaled_y > 0.0) {
+      // CDF(x) = 1/2 + 1/2erf(x) = 1 - 1/2erfc(x)
+      std_normal_lcdf_lcdf_n = log1p(-0.5 * erfc(std_normal_lcdf_scaled_y));
+      if (isnan(std_normal_lcdf_lcdf_n)) {
+        std_normal_lcdf_lcdf_n = 0;
+      }
+    } else if (std_normal_lcdf_scaled_y > -20.0) {
+      // CDF(x) = 1/2 - 1/2erf(-x) = 1/2erfc(-x)
+      std_normal_lcdf_lcdf_n = log(erfc(-std_normal_lcdf_scaled_y)) - M_LN2;
+    } else if (10.0 * log(fabs(std_normal_lcdf_scaled_y)) < log(DBL_MAX)) {
+      // entering territory where erfc(-x)~0
+      // need to use direct numerical approximation of lcdf instead
+      // the following based on W. J. Cody, Math. Comp. 23(107):631-638 (1969)
+      // CDF(x) = 1/2erfc(-x)
+      const double x4 = pow(std_normal_lcdf_scaled_y, 4);
+      const double x6 = pow(std_normal_lcdf_scaled_y, 6);
+      const double x8 = pow(std_normal_lcdf_scaled_y, 8);
+      const double x10 = pow(std_normal_lcdf_scaled_y, 10);
+      const double temp_p
+          = 0.000658749161529837803157
+            + 0.0160837851487422766278 / std_normal_lcdf_x2
+            + 0.125781726111229246204 / x4 + 0.360344899949804439429 / x6
+            + 0.305326634961232344035 / x8 + 0.0163153871373020978498 / x10;
+      const double temp_q = -0.00233520497626869185443
+                            - 0.0605183413124413191178 / std_normal_lcdf_x2
+                            - 0.527905102951428412248 / x4
+                            - 1.87295284992346047209 / x6
+                            - 2.56852019228982242072 / x8 - 1.0 / x10;
+      std_normal_lcdf_lcdf_n
+          += log(0.5 * M_2_SQRTPI + (temp_p / temp_q) / std_normal_lcdf_x2)
+             - M_LN2 - log(-std_normal_lcdf_scaled_y) - std_normal_lcdf_x2;
+    } else {
+      // std_normal_lcdf_scaled_y^10 term will overflow
+      std_normal_lcdf_lcdf_n = -INFINITY;
+    });
+const char opencl_std_normal_lcdf_dnlcdf[] = STRINGIFY(
+    // compute partial derivatives
+    // based on analytic form given by:
+    // dln(CDF)/dx = exp(-x^2)/(sqrt(pi)*(1/2+erf(x)/2)
+    double std_normal_lcdf_dnlcdf = 0.0; double t = 0.0; double t2 = 0.0;
+    double t4 = 0.0;
+
+    // calculate using piecewise function
+    // (due to instability / inaccuracy in the various approximations)
+    if (std_normal_lcdf_deriv_scaled_y > 2.9) {
+      // approximation derived from Abramowitz and Stegun (1964) 7.1.26
+      t = 1.0 / (1.0 + 0.3275911 * std_normal_lcdf_deriv_scaled_y);
+      t2 = t * t;
+      t4 = pow(t, 4);
+      std_normal_lcdf_dnlcdf
+          = 0.5 * M_2_SQRTPI
+            / (exp(std_normal_lcdf_deriv_x2) - 0.254829592 + 0.284496736 * t
+               - 1.421413741 * t2 + 1.453152027 * t2 * t - 1.061405429 * t4);
+    } else if (std_normal_lcdf_deriv_scaled_y > 2.5) {
+      // in the trouble area where all of the standard numerical
+      // approximations are unstable - bridge the gap using Taylor
+      // expansions of the analytic function
+      // use Taylor expansion centred around x=2.7
+      t = std_normal_lcdf_deriv_scaled_y - 2.7;
+      t2 = t * t;
+      t4 = pow(t, 4);
+      std_normal_lcdf_dnlcdf = 0.0003849882382 - 0.002079084702 * t
+                               + 0.005229340880 * t2 - 0.008029540137 * t2 * t
+                               + 0.008232190507 * t4 - 0.005692364250 * t4 * t
+                               + 0.002399496363 * pow(t, 6);
+    } else if (std_normal_lcdf_deriv_scaled_y > 2.1) {
+      // use Taylor expansion centred around x=2.3
+      t = std_normal_lcdf_deriv_scaled_y - 2.3;
+      t2 = t * t;
+      t4 = pow(t, 4);
+      std_normal_lcdf_dnlcdf = 0.002846135439 - 0.01310032351 * t
+                               + 0.02732189391 * t2 - 0.03326906904 * t2 * t
+                               + 0.02482478940 * t4 - 0.009883071924 * t4 * t
+                               - 0.0002771362254 * pow(t, 6);
+    } else if (std_normal_lcdf_deriv_scaled_y > 1.5) {
+      // use Taylor expansion centred around x=1.85
+      t = std_normal_lcdf_deriv_scaled_y - 1.85;
+      t2 = t * t;
+      t4 = pow(t, 4);
+      std_normal_lcdf_dnlcdf = 0.01849212058 - 0.06876280470 * t
+                               + 0.1099906382 * t2 - 0.09274533184 * t2 * t
+                               + 0.03543327418 * t4 + 0.005644855518 * t4 * t
+                               - 0.01111434424 * pow(t, 6);
+    } else if (std_normal_lcdf_deriv_scaled_y > 0.8) {
+      // use Taylor expansion centred around x=1.15
+      t = std_normal_lcdf_deriv_scaled_y - 1.15;
+      t2 = t * t;
+      t4 = pow(t, 4);
+      std_normal_lcdf_dnlcdf = 0.1585747034 - 0.3898677543 * t
+                               + 0.3515963775 * t2 - 0.09748053605 * t2 * t
+                               - 0.04347986191 * t4 + 0.02182506378 * t4 * t
+                               + 0.01074751427 * pow(t, 6);
+    } else if (std_normal_lcdf_deriv_scaled_y > 0.1) {
+      // use Taylor expansion centred around x=0.45
+      t = std_normal_lcdf_deriv_scaled_y - 0.45;
+      t2 = t * t;
+      t4 = pow(t, 4);
+      std_normal_lcdf_dnlcdf = 0.6245634904 - 0.9521866949 * t
+                               + 0.3986215682 * t2 + 0.04700850676 * t2 * t
+                               - 0.03478651979 * t4 - 0.01772675404 * t4 * t
+                               + 0.0006577254811 * pow(t, 6);
+    } else if (10.0 * log(fabs(std_normal_lcdf_deriv_scaled_y))
+               < log(DBL_MAX)) {
+      // approximation derived from Abramowitz and Stegun (1964) 7.1.26
+      // use fact that erf(x)=-erf(-x)
+      // Abramowitz and Stegun define this for -inf<x<0 but seems to be
+      // accurate for -inf<x<0.1
+      t = 1.0 / (1.0 - 0.3275911 * std_normal_lcdf_deriv_scaled_y);
+      t2 = t * t;
+      t4 = pow(t, 4);
+      std_normal_lcdf_dnlcdf
+          = M_2_SQRTPI
+            / (0.254829592 * t - 0.284496736 * t2 + 1.421413741 * t2 * t
+               - 1.453152027 * t4 + 1.061405429 * t4 * t);
+      // check if we need to add a correction term
+      // (from cubic fit of residuals)
+      if (std_normal_lcdf_deriv_scaled_y < -29.0) {
+        std_normal_lcdf_dnlcdf
+            += 0.0015065154280332 * std_normal_lcdf_deriv_x2
+               - 0.3993154819705530 * std_normal_lcdf_deriv_scaled_y
+               - 4.2919418242931700;
+      } else if (std_normal_lcdf_deriv_scaled_y < -17.0) {
+        std_normal_lcdf_dnlcdf
+            += 0.0001263257217272 * std_normal_lcdf_deriv_x2
+                   * std_normal_lcdf_deriv_scaled_y
+               + 0.0123586859488623 * std_normal_lcdf_deriv_x2
+               - 0.0860505264736028 * std_normal_lcdf_deriv_scaled_y
+               - 1.252783383752970;
+      } else if (std_normal_lcdf_deriv_scaled_y < -7.0) {
+        std_normal_lcdf_dnlcdf
+            += 0.000471585349920831 * std_normal_lcdf_deriv_x2
+                   * std_normal_lcdf_deriv_scaled_y
+               + 0.0296839305424034 * std_normal_lcdf_deriv_x2
+               + 0.207402143352332 * std_normal_lcdf_deriv_scaled_y
+               + 0.425316974683324;
+      } else if (std_normal_lcdf_deriv_scaled_y < -3.9) {
+        std_normal_lcdf_dnlcdf
+            += -0.0006972280656443 * std_normal_lcdf_deriv_x2
+                   * std_normal_lcdf_deriv_scaled_y
+               + 0.0068218494628567 * std_normal_lcdf_deriv_x2
+               + 0.0585761964460277 * std_normal_lcdf_deriv_scaled_y
+               + 0.1034397670201370;
+      } else if (std_normal_lcdf_deriv_scaled_y < -2.1) {
+        std_normal_lcdf_dnlcdf
+            += -0.0018742199480885 * std_normal_lcdf_deriv_x2
+                   * std_normal_lcdf_deriv_scaled_y
+               - 0.0097119598291202 * std_normal_lcdf_deriv_x2
+               - 0.0170137970924080 * std_normal_lcdf_deriv_scaled_y
+               - 0.0100428567412041;
+      }
+    } else { std_normal_lcdf_dnlcdf = INFINITY; });
+}  // namespace internal
+
+/** \ingroup opencl
+ * Returns the log standard normal complementary cumulative distribution
+ * function.
+ *
+ * @tparam T_y_cl type of scalar outcome
+ * @param y (Sequence of) scalar(s).
+ * @return The log of the product of densities.
+ */
+template <typename T_y_cl,
+          require_all_prim_or_rev_kernel_expression_t<T_y_cl>* = nullptr,
+          require_any_not_stan_scalar_t<T_y_cl>* = nullptr>
+return_type_t<T_y_cl> std_normal_lcdf(const T_y_cl& y) {
+  static const char* function = "std_normal_lcdf(OpenCL)";
+  using std::isfinite;
+  using std::isnan;
+
+  const size_t N = size(y);
+  if (N == 0) {
+    return 1.0;
+  }
+
+  const auto& y_col = as_column_vector_or_scalar(y);
+  const auto& y_val = value_of(y_col);
+
+  auto check_y_not_nan
+      = check_cl(function, "Random variable", y_val, "not NaN");
+  auto y_not_nan_expr = !isnan(y_val);
+
+  auto scaled_y = y_val * INV_SQRT_TWO;
+  auto x2 = square(scaled_y);
+  auto lcdf_expr = colwise_sum(
+      opencl_code<internal::opencl_std_normal_lcdf_impl>(
+          std::make_tuple("std_normal_lcdf_scaled_y", "std_normal_lcdf_x2"),
+          scaled_y, x2)
+          .template output<double>("std_normal_lcdf_lcdf_n"));
+  auto dnlcdf = opencl_code<internal::opencl_std_normal_lcdf_dnlcdf>(
+                    std::make_tuple("std_normal_lcdf_deriv_scaled_y",
+                                    "std_normal_lcdf_deriv_x2"),
+                    scaled_y, x2)
+                    .template output<double>("std_normal_lcdf_dnlcdf");
+  auto y_deriv = dnlcdf * INV_SQRT_TWO;
+
+  matrix_cl<double> lcdf_cl;
+  matrix_cl<double> y_deriv_cl;
+
+  results(check_y_not_nan, lcdf_cl, y_deriv_cl) = expressions(
+      y_not_nan_expr, lcdf_expr, calc_if<!is_constant<T_y_cl>::value>(y_deriv));
+
+  double lcdf = from_matrix_cl(lcdf_cl).sum();
+
+  operands_and_partials<decltype(y_col)> ops_partials(y_col);
+
+  if (!is_constant<T_y_cl>::value) {
+    ops_partials.edge1_.partials_ = std::move(y_deriv_cl);
+  }
+  return ops_partials.build(lcdf);
+}
+
+}  // namespace math
+}  // namespace stan
+#endif
+#endif

--- a/stan/math/opencl/prim/uniform_cdf.hpp
+++ b/stan/math/opencl/prim/uniform_cdf.hpp
@@ -1,0 +1,130 @@
+#ifndef STAN_MATH_OPENCL_PRIM_UNIFORM_CDF_HPP
+#define STAN_MATH_OPENCL_PRIM_UNIFORM_CDF_HPP
+#ifdef STAN_OPENCL
+
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/err.hpp>
+#include <stan/math/prim/fun/constants.hpp>
+#include <stan/math/prim/fun/elt_divide.hpp>
+#include <stan/math/prim/fun/elt_multiply.hpp>
+#include <stan/math/opencl/kernel_generator.hpp>
+#include <stan/math/prim/functor/operands_and_partials.hpp>
+
+namespace stan {
+namespace math {
+
+/** \ingroup opencl
+ * Returns the uniform cumulative distribution function for the given
+ * location, and scale. If given containers of matching sizes
+ * returns the product of probabilities.
+ *
+ * @tparam T_y_cl type of scalar outcome
+ * @tparam T_low_cl type of low bounds
+ * @tparam T_high_cl type of high bounds
+ * @param y (Sequence of) scalar(s).
+ * @param alpha Sequence of low bounds.
+ * @param beta Sequence of high bounds.
+ * @return The product of densities.
+ */
+template <typename T_y_cl, typename T_low_cl, typename T_high_cl,
+          require_all_prim_or_rev_kernel_expression_t<T_y_cl, T_low_cl,
+                                                      T_high_cl>* = nullptr,
+          require_any_not_stan_scalar_t<T_y_cl, T_low_cl, T_high_cl>* = nullptr>
+return_type_t<T_y_cl, T_low_cl, T_high_cl> uniform_cdf(const T_y_cl& y,
+                                                       const T_low_cl& alpha,
+                                                       const T_high_cl& beta) {
+  static const char* function = "uniform_cdf(OpenCL)";
+  using T_partials_return = partials_return_t<T_y_cl, T_low_cl, T_high_cl>;
+  using std::isfinite;
+  using std::isnan;
+
+  check_consistent_sizes(function, "Random variable", y, "Location parameter",
+                         alpha, "Scale parameter", beta);
+  const size_t N = max_size(y, alpha, beta);
+  if (N == 0) {
+    return 1.0;
+  }
+
+  const auto& y_col = as_column_vector_or_scalar(y);
+  const auto& alpha_col = as_column_vector_or_scalar(alpha);
+  const auto& beta_col = as_column_vector_or_scalar(beta);
+
+  const auto& y_val = value_of(y_col);
+  const auto& alpha_val = value_of(alpha_col);
+  const auto& beta_val = value_of(beta_col);
+
+  auto check_y_not_nan
+      = check_cl(function, "Random variable", y_val, "not NaN");
+  auto y_not_nan_expr = !isnan(y_val);
+  auto check_alpha_finite
+      = check_cl(function, "Lower bound parameter", alpha_val, "finite");
+  auto alpha_finite_expr = isfinite(alpha_val);
+  auto check_beta_finite
+      = check_cl(function, "Upper bound parameter", beta_val, "finite");
+  auto beta_finite_expr = isfinite(beta_val);
+  auto b_minus_a = beta_val - alpha_val;
+  auto check_diff_positive = check_cl(
+      function, "Difference between upper and lower bound parameters", beta_val,
+      "positive");
+  auto diff_positive_expr = b_minus_a > 0.0;
+
+  auto any_y_out_of_bounds = colwise_max(
+      constant(0, N, 1) + (y_val < alpha_val || y_val > beta_val));
+  auto cdf_n = elt_divide(y_val - alpha_val, b_minus_a);
+  auto cdf_expr = colwise_prod(cdf_n);
+
+  auto high_deriv1 = elt_divide(1.0, b_minus_a);
+  auto y_deriv1 = elt_divide(high_deriv1, cdf_n);
+  auto low_deriv1
+      = elt_multiply(y_val - beta_val, elt_divide(y_deriv1, b_minus_a));
+
+  matrix_cl<double> any_y_out_of_bounds_cl;
+  matrix_cl<double> cdf_cl;
+  matrix_cl<double> alpha_deriv_cl;
+  matrix_cl<double> y_deriv_cl;
+  matrix_cl<double> beta_deriv_cl;
+
+  results(check_y_not_nan, check_alpha_finite, check_beta_finite,
+          check_diff_positive, any_y_out_of_bounds_cl, cdf_cl, y_deriv_cl,
+          alpha_deriv_cl, beta_deriv_cl)
+      = expressions(y_not_nan_expr, alpha_finite_expr, beta_finite_expr,
+                    diff_positive_expr, any_y_out_of_bounds, cdf_expr,
+                    calc_if<!is_constant<T_y_cl>::value>(y_deriv1),
+                    calc_if<!is_constant<T_low_cl>::value>(low_deriv1),
+                    calc_if<!is_constant<T_high_cl>::value>(high_deriv1));
+
+  if (from_matrix_cl(any_y_out_of_bounds_cl).maxCoeff()) {
+    return 0.0;
+  }
+
+  T_partials_return cdf = (from_matrix_cl(cdf_cl)).prod();
+
+  auto alpha_deriv = alpha_deriv_cl * cdf;
+  auto y_deriv = y_deriv_cl * cdf;
+  auto beta_deriv = beta_deriv_cl * -cdf;
+
+  results(alpha_deriv_cl, y_deriv_cl, beta_deriv_cl)
+      = expressions(calc_if<!is_constant<T_low_cl>::value>(alpha_deriv),
+                    calc_if<!is_constant<T_y_cl>::value>(y_deriv),
+                    calc_if<!is_constant<T_high_cl>::value>(beta_deriv));
+
+  operands_and_partials<decltype(y_col), decltype(alpha_col),
+                        decltype(beta_col)>
+      ops_partials(y_col, alpha_col, beta_col);
+
+  if (!is_constant<T_y_cl>::value) {
+    ops_partials.edge1_.partials_ = std::move(y_deriv_cl);
+  }
+  if (!is_constant<T_low_cl>::value) {
+    ops_partials.edge2_.partials_ = std::move(alpha_deriv_cl);
+  }
+  if (!is_constant<T_high_cl>::value) {
+    ops_partials.edge3_.partials_ = std::move(beta_deriv_cl);
+  }
+  return ops_partials.build(cdf);
+}
+
+}  // namespace math
+}  // namespace stan
+#endif
+#endif

--- a/stan/math/opencl/prim/uniform_lccdf.hpp
+++ b/stan/math/opencl/prim/uniform_lccdf.hpp
@@ -1,0 +1,121 @@
+#ifndef STAN_MATH_OPENCL_PRIM_UNIFORM_LCCDF_HPP
+#define STAN_MATH_OPENCL_PRIM_UNIFORM_LCCDF_HPP
+#ifdef STAN_OPENCL
+
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/err.hpp>
+#include <stan/math/prim/fun/constants.hpp>
+#include <stan/math/prim/fun/elt_divide.hpp>
+#include <stan/math/prim/fun/elt_multiply.hpp>
+#include <stan/math/opencl/kernel_generator.hpp>
+#include <stan/math/prim/functor/operands_and_partials.hpp>
+
+namespace stan {
+namespace math {
+
+/** \ingroup opencl
+ * Returns the log uniform complementary cumulative distribution function for
+ * the given location, and scale. If given containers of matching sizes returns
+ * the product of probabilities.
+ *
+ * @tparam T_y_cl type of scalar outcome
+ * @tparam T_low_cl type of location
+ * @tparam T_high_cl type of scale
+ * @param y (Sequence of) scalar(s).
+ * @param alpha (Sequence of) location(s).
+ * @param beta (Sequence of) scale(s).
+ * @return The log of the product of densities.
+ */
+template <typename T_y_cl, typename T_low_cl, typename T_high_cl,
+          require_all_prim_or_rev_kernel_expression_t<T_y_cl, T_low_cl,
+                                                      T_high_cl>* = nullptr,
+          require_any_not_stan_scalar_t<T_y_cl, T_low_cl, T_high_cl>* = nullptr>
+return_type_t<T_y_cl, T_low_cl, T_high_cl> uniform_lccdf(
+    const T_y_cl& y, const T_low_cl& alpha, const T_high_cl& beta) {
+  static const char* function = "uniform_lccdf(OpenCL)";
+  using T_partials_return = partials_return_t<T_y_cl, T_low_cl, T_high_cl>;
+  using std::isfinite;
+  using std::isnan;
+
+  check_consistent_sizes(function, "Random variable", y, "Location parameter",
+                         alpha, "Scale parameter", beta);
+  const size_t N = max_size(y, alpha, beta);
+  if (N == 0) {
+    return 0.0;
+  }
+
+  const auto& y_col = as_column_vector_or_scalar(y);
+  const auto& alpha_col = as_column_vector_or_scalar(alpha);
+  const auto& beta_col = as_column_vector_or_scalar(beta);
+
+  const auto& y_val = value_of(y_col);
+  const auto& alpha_val = value_of(alpha_col);
+  const auto& beta_val = value_of(beta_col);
+
+  auto check_y_not_nan
+      = check_cl(function, "Random variable", y_val, "not NaN");
+  auto y_not_nan_expr = !isnan(y_val);
+  auto check_alpha_finite
+      = check_cl(function, "Lower bound parameter", alpha_val, "finite");
+  auto alpha_finite_expr = isfinite(alpha_val);
+  auto check_beta_finite
+      = check_cl(function, "Upper bound parameter", beta_val, "finite");
+  auto beta_finite_expr = isfinite(beta_val);
+  auto b_minus_a = beta_val - alpha_val;
+  auto check_diff_positive = check_cl(
+      function, "Difference between upper and lower bound parameters", beta_val,
+      "positive");
+  auto diff_positive_expr = b_minus_a > 0.0;
+
+  auto any_y_out_of_bounds = colwise_max(
+      constant(0, N, 1) + (y_val < alpha_val || y_val > beta_val));
+  auto y_minus_alpha = y_val - alpha_val;
+  auto ccdf_n = 1.0 - elt_divide(y_minus_alpha, b_minus_a);
+  auto lccdf_expr = colwise_sum(log(ccdf_n));
+
+  auto y_deriv = elt_divide(1.0, -elt_multiply(b_minus_a, ccdf_n));
+  auto rep_deriv = elt_divide(1.0, elt_multiply(square(b_minus_a), ccdf_n));
+  auto low_deriv = elt_multiply(beta_val - y_val, rep_deriv);
+  auto high_deriv = elt_multiply(y_minus_alpha, rep_deriv);
+
+  matrix_cl<double> any_y_out_of_bounds_cl;
+  matrix_cl<double> lccdf_cl;
+  matrix_cl<double> alpha_deriv_cl;
+  matrix_cl<double> y_deriv_cl;
+  matrix_cl<double> beta_deriv_cl;
+
+  results(check_y_not_nan, check_alpha_finite, check_beta_finite,
+          check_diff_positive, any_y_out_of_bounds_cl, lccdf_cl, y_deriv_cl,
+          alpha_deriv_cl, beta_deriv_cl)
+      = expressions(y_not_nan_expr, alpha_finite_expr, beta_finite_expr,
+                    diff_positive_expr, any_y_out_of_bounds, lccdf_expr,
+                    calc_if<!is_constant<T_y_cl>::value>(y_deriv),
+                    calc_if<!is_constant<T_low_cl>::value>(low_deriv),
+                    calc_if<!is_constant<T_high_cl>::value>(high_deriv));
+
+  if (from_matrix_cl(any_y_out_of_bounds_cl).maxCoeff()) {
+    return 0.0;
+  }
+
+  T_partials_return lccdf = from_matrix_cl(lccdf_cl).sum();
+
+  operands_and_partials<decltype(y_col), decltype(alpha_col),
+                        decltype(beta_col)>
+      ops_partials(y_col, alpha_col, beta_col);
+
+  if (!is_constant<T_y_cl>::value) {
+    ops_partials.edge1_.partials_ = std::move(y_deriv_cl);
+  }
+  if (!is_constant<T_low_cl>::value) {
+    ops_partials.edge2_.partials_ = std::move(alpha_deriv_cl);
+  }
+  if (!is_constant<T_high_cl>::value) {
+    ops_partials.edge3_.partials_ = std::move(beta_deriv_cl);
+  }
+  return ops_partials.build(lccdf);
+}
+
+}  // namespace math
+}  // namespace stan
+#endif
+#endif

--- a/stan/math/opencl/prim/uniform_lcdf.hpp
+++ b/stan/math/opencl/prim/uniform_lcdf.hpp
@@ -1,0 +1,122 @@
+#ifndef STAN_MATH_OPENCL_PRIM_UNIFORM_LCDF_HPP
+#define STAN_MATH_OPENCL_PRIM_UNIFORM_LCDF_HPP
+#ifdef STAN_OPENCL
+
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/err.hpp>
+#include <stan/math/prim/fun/constants.hpp>
+#include <stan/math/prim/fun/elt_divide.hpp>
+#include <stan/math/prim/fun/elt_multiply.hpp>
+#include <stan/math/opencl/kernel_generator.hpp>
+#include <stan/math/prim/functor/operands_and_partials.hpp>
+
+namespace stan {
+namespace math {
+
+/** \ingroup opencl
+ * Returns the log uniform cumulative distribution function for
+ * the given location, and scale. If given containers of matching sizes returns
+ * the product of probabilities.
+ *
+ * @tparam T_y_cl type of scalar outcome
+ * @tparam T_low_cl type of location
+ * @tparam T_high_cl type of scale
+ * @param y (Sequence of) scalar(s).
+ * @param alpha (Sequence of) location(s).
+ * @param beta (Sequence of) scale(s).
+ * @return The log of the product of densities.
+ */
+template <typename T_y_cl, typename T_low_cl, typename T_high_cl,
+          require_all_prim_or_rev_kernel_expression_t<T_y_cl, T_low_cl,
+                                                      T_high_cl>* = nullptr,
+          require_any_not_stan_scalar_t<T_y_cl, T_low_cl, T_high_cl>* = nullptr>
+return_type_t<T_y_cl, T_low_cl, T_high_cl> uniform_lcdf(const T_y_cl& y,
+                                                        const T_low_cl& alpha,
+                                                        const T_high_cl& beta) {
+  static const char* function = "uniform_lcdf(OpenCL)";
+  using T_partials_return = partials_return_t<T_y_cl, T_low_cl, T_high_cl>;
+  using std::isfinite;
+  using std::isnan;
+
+  check_consistent_sizes(function, "Random variable", y, "Location parameter",
+                         alpha, "Scale parameter", beta);
+  const size_t N = max_size(y, alpha, beta);
+  if (N == 0) {
+    return 0.0;
+  }
+
+  const auto& y_col = as_column_vector_or_scalar(y);
+  const auto& alpha_col = as_column_vector_or_scalar(alpha);
+  const auto& beta_col = as_column_vector_or_scalar(beta);
+
+  const auto& y_val = value_of(y_col);
+  const auto& alpha_val = value_of(alpha_col);
+  const auto& beta_val = value_of(beta_col);
+
+  auto check_y_not_nan
+      = check_cl(function, "Random variable", y_val, "not NaN");
+  auto y_not_nan_expr = !isnan(y_val);
+  auto check_alpha_finite
+      = check_cl(function, "Lower bound parameter", alpha_val, "finite");
+  auto alpha_finite_expr = isfinite(alpha_val);
+  auto check_beta_finite
+      = check_cl(function, "Upper bound parameter", beta_val, "finite");
+  auto beta_finite_expr = isfinite(beta_val);
+  auto b_minus_a = beta_val - alpha_val;
+  auto check_diff_positive = check_cl(
+      function, "Difference between upper and lower bound parameters", beta_val,
+      "positive");
+  auto diff_positive_expr = b_minus_a > 0.0;
+
+  auto any_y_out_of_bounds = colwise_max(
+      constant(0, N, 1) + (y_val < alpha_val || y_val > beta_val));
+  auto y_minus_alpha = y_val - alpha_val;
+  auto cdf_n = elt_divide(y_minus_alpha, b_minus_a);
+  auto lcdf_expr = colwise_sum(log(cdf_n));
+
+  auto y_deriv = elt_divide(1.0, y_minus_alpha);
+  auto low_deriv
+      = elt_divide(y_val - beta_val, elt_multiply(b_minus_a, y_minus_alpha));
+  auto high_deriv = elt_divide(-1.0, b_minus_a);
+
+  matrix_cl<double> any_y_out_of_bounds_cl;
+  matrix_cl<double> lcdf_cl;
+  matrix_cl<double> alpha_deriv_cl;
+  matrix_cl<double> y_deriv_cl;
+  matrix_cl<double> beta_deriv_cl;
+
+  results(check_y_not_nan, check_alpha_finite, check_beta_finite,
+          check_diff_positive, any_y_out_of_bounds_cl, lcdf_cl, y_deriv_cl,
+          alpha_deriv_cl, beta_deriv_cl)
+      = expressions(y_not_nan_expr, alpha_finite_expr, beta_finite_expr,
+                    diff_positive_expr, any_y_out_of_bounds, lcdf_expr,
+                    calc_if<!is_constant<T_y_cl>::value>(y_deriv),
+                    calc_if<!is_constant<T_low_cl>::value>(low_deriv),
+                    calc_if<!is_constant<T_high_cl>::value>(high_deriv));
+
+  if (from_matrix_cl(any_y_out_of_bounds_cl).maxCoeff()) {
+    return -INFINITY;
+  }
+
+  T_partials_return lcdf = from_matrix_cl(lcdf_cl).sum();
+
+  operands_and_partials<decltype(y_col), decltype(alpha_col),
+                        decltype(beta_col)>
+      ops_partials(y_col, alpha_col, beta_col);
+
+  if (!is_constant<T_y_cl>::value) {
+    ops_partials.edge1_.partials_ = std::move(y_deriv_cl);
+  }
+  if (!is_constant<T_low_cl>::value) {
+    ops_partials.edge2_.partials_ = std::move(alpha_deriv_cl);
+  }
+  if (!is_constant<T_high_cl>::value) {
+    ops_partials.edge3_.partials_ = std::move(beta_deriv_cl);
+  }
+  return ops_partials.build(lcdf);
+}
+
+}  // namespace math
+}  // namespace stan
+#endif
+#endif

--- a/stan/math/prim/prob/std_normal_cdf.hpp
+++ b/stan/math/prim/prob/std_normal_cdf.hpp
@@ -27,7 +27,9 @@ namespace math {
  * @param y scalar variate
  * @return The standard normal cdf evaluated at the specified argument.
  */
-template <typename T_y>
+template <
+    typename T_y,
+    require_all_not_nonscalar_prim_or_rev_kernel_expression_t<T_y>* = nullptr>
 inline return_type_t<T_y> std_normal_cdf(const T_y& y) {
   using T_partials_return = partials_return_t<T_y>;
   using std::exp;

--- a/stan/math/prim/prob/std_normal_lccdf.hpp
+++ b/stan/math/prim/prob/std_normal_lccdf.hpp
@@ -18,7 +18,9 @@
 namespace stan {
 namespace math {
 
-template <typename T_y>
+template <
+    typename T_y,
+    require_all_not_nonscalar_prim_or_rev_kernel_expression_t<T_y>* = nullptr>
 inline return_type_t<T_y> std_normal_lccdf(const T_y& y) {
   using T_partials_return = partials_return_t<T_y>;
   using std::exp;

--- a/stan/math/prim/prob/std_normal_lcdf.hpp
+++ b/stan/math/prim/prob/std_normal_lcdf.hpp
@@ -21,7 +21,9 @@
 namespace stan {
 namespace math {
 
-template <typename T_y>
+template <
+    typename T_y,
+    require_all_not_nonscalar_prim_or_rev_kernel_expression_t<T_y>* = nullptr>
 inline return_type_t<T_y> std_normal_lcdf(const T_y& y) {
   using T_partials_return = partials_return_t<T_y>;
   using std::exp;

--- a/stan/math/prim/prob/uniform_cdf.hpp
+++ b/stan/math/prim/prob/uniform_cdf.hpp
@@ -17,7 +17,9 @@
 namespace stan {
 namespace math {
 
-template <typename T_y, typename T_low, typename T_high>
+template <typename T_y, typename T_low, typename T_high,
+          require_all_not_nonscalar_prim_or_rev_kernel_expression_t<
+              T_y, T_low, T_high>* = nullptr>
 return_type_t<T_y, T_low, T_high> uniform_cdf(const T_y& y, const T_low& alpha,
                                               const T_high& beta) {
   using T_partials_return = partials_return_t<T_y, T_low, T_high>;

--- a/stan/math/prim/prob/uniform_lccdf.hpp
+++ b/stan/math/prim/prob/uniform_lccdf.hpp
@@ -19,7 +19,9 @@
 namespace stan {
 namespace math {
 
-template <typename T_y, typename T_low, typename T_high>
+template <typename T_y, typename T_low, typename T_high,
+          require_all_not_nonscalar_prim_or_rev_kernel_expression_t<
+              T_y, T_low, T_high>* = nullptr>
 return_type_t<T_y, T_low, T_high> uniform_lccdf(const T_y& y,
                                                 const T_low& alpha,
                                                 const T_high& beta) {

--- a/stan/math/prim/prob/uniform_lcdf.hpp
+++ b/stan/math/prim/prob/uniform_lcdf.hpp
@@ -19,7 +19,9 @@
 namespace stan {
 namespace math {
 
-template <typename T_y, typename T_low, typename T_high>
+template <typename T_y, typename T_low, typename T_high,
+          require_all_not_nonscalar_prim_or_rev_kernel_expression_t<
+              T_y, T_low, T_high>* = nullptr>
 return_type_t<T_y, T_low, T_high> uniform_lcdf(const T_y& y, const T_low& alpha,
                                                const T_high& beta) {
   using T_partials_return = partials_return_t<T_y, T_low, T_high>;

--- a/test/unit/math/opencl/rev/std_normal_cdf_test.cpp
+++ b/test/unit/math/opencl/rev/std_normal_cdf_test.cpp
@@ -1,0 +1,49 @@
+#ifdef STAN_OPENCL
+#include <stan/math/opencl/rev.hpp>
+#include <stan/math.hpp>
+#include <gtest/gtest.h>
+#include <test/unit/math/opencl/util.hpp>
+#include <vector>
+
+TEST(ProbDistributionsStdNormalCdf, error_checking) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  Eigen::VectorXd y_value(N);
+  y_value << 0.3, NAN, 0.5;
+
+  stan::math::matrix_cl<double> y_cl(y);
+  stan::math::matrix_cl<double> y_value_cl(y_value);
+
+  EXPECT_NO_THROW(stan::math::std_normal_cdf(y_cl));
+
+  EXPECT_THROW(stan::math::std_normal_cdf(y_value_cl), std::domain_error);
+}
+
+auto std_normal_cdf_functor
+    = [](const auto& y) { return stan::math::std_normal_cdf(y); };
+
+TEST(ProbDistributionsStdNormalCdf, opencl_matches_cpu_small) {
+  int N = 3;
+  int M = 2;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+
+  stan::math::test::compare_cpu_opencl_prim_rev(std_normal_cdf_functor, y);
+  stan::math::test::compare_cpu_opencl_prim_rev(std_normal_cdf_functor,
+                                                y.transpose().eval());
+}
+
+TEST(ProbDistributionsStdNormalCdf, opencl_matches_cpu_big) {
+  int N = 153;
+
+  Eigen::Matrix<double, Eigen::Dynamic, 1> y
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1);
+
+  stan::math::test::compare_cpu_opencl_prim_rev(std_normal_cdf_functor, y);
+  stan::math::test::compare_cpu_opencl_prim_rev(std_normal_cdf_functor,
+                                                y.transpose().eval());
+}
+#endif

--- a/test/unit/math/opencl/rev/std_normal_lccdf_test.cpp
+++ b/test/unit/math/opencl/rev/std_normal_lccdf_test.cpp
@@ -1,0 +1,49 @@
+#ifdef STAN_OPENCL
+#include <stan/math/opencl/rev.hpp>
+#include <stan/math.hpp>
+#include <gtest/gtest.h>
+#include <test/unit/math/opencl/util.hpp>
+#include <vector>
+
+TEST(ProbDistributionsStdNormalLccdf, error_checking) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  Eigen::VectorXd y_value(N);
+  y_value << 0.3, NAN, 0.5;
+
+  stan::math::matrix_cl<double> y_cl(y);
+  stan::math::matrix_cl<double> y_value_cl(y_value);
+
+  EXPECT_NO_THROW(stan::math::std_normal_lccdf(y_cl));
+
+  EXPECT_THROW(stan::math::std_normal_lccdf(y_value_cl), std::domain_error);
+}
+
+auto std_normal_lccdf_functor
+    = [](const auto& y) { return stan::math::std_normal_lccdf(y); };
+
+TEST(ProbDistributionsStdNormalLccdf, opencl_matches_cpu_small) {
+  int N = 3;
+  int M = 2;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+
+  stan::math::test::compare_cpu_opencl_prim_rev(std_normal_lccdf_functor, y);
+  stan::math::test::compare_cpu_opencl_prim_rev(std_normal_lccdf_functor,
+                                                y.transpose().eval());
+}
+
+TEST(ProbDistributionsStdNormalLccdf, opencl_matches_cpu_big) {
+  int N = 153;
+
+  Eigen::Matrix<double, Eigen::Dynamic, 1> y
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1);
+
+  stan::math::test::compare_cpu_opencl_prim_rev(std_normal_lccdf_functor, y);
+  stan::math::test::compare_cpu_opencl_prim_rev(std_normal_lccdf_functor,
+                                                y.transpose().eval());
+}
+#endif

--- a/test/unit/math/opencl/rev/std_normal_lcdf_test.cpp
+++ b/test/unit/math/opencl/rev/std_normal_lcdf_test.cpp
@@ -1,0 +1,49 @@
+#ifdef STAN_OPENCL
+#include <stan/math/opencl/rev.hpp>
+#include <stan/math.hpp>
+#include <gtest/gtest.h>
+#include <test/unit/math/opencl/util.hpp>
+#include <vector>
+
+TEST(ProbDistributionsStdNormalLcdf, error_checking) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  Eigen::VectorXd y_value(N);
+  y_value << 0.3, NAN, 0.5;
+
+  stan::math::matrix_cl<double> y_cl(y);
+  stan::math::matrix_cl<double> y_value_cl(y_value);
+
+  EXPECT_NO_THROW(stan::math::std_normal_lcdf(y_cl));
+
+  EXPECT_THROW(stan::math::std_normal_lcdf(y_value_cl), std::domain_error);
+}
+
+auto std_normal_lcdf_functor
+    = [](const auto& y) { return stan::math::std_normal_lcdf(y); };
+
+TEST(ProbDistributionsStdNormalLcdf, opencl_matches_cpu_small) {
+  int N = 3;
+  int M = 2;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+
+  stan::math::test::compare_cpu_opencl_prim_rev(std_normal_lcdf_functor, y);
+  stan::math::test::compare_cpu_opencl_prim_rev(std_normal_lcdf_functor,
+                                                y.transpose().eval());
+}
+
+TEST(ProbDistributionsStdNormalLcdf, opencl_matches_cpu_big) {
+  int N = 153;
+
+  Eigen::Matrix<double, Eigen::Dynamic, 1> y
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1);
+
+  stan::math::test::compare_cpu_opencl_prim_rev(std_normal_lcdf_functor, y);
+  stan::math::test::compare_cpu_opencl_prim_rev(std_normal_lcdf_functor,
+                                                y.transpose().eval());
+}
+#endif

--- a/test/unit/math/opencl/rev/uniform_cdf_test.cpp
+++ b/test/unit/math/opencl/rev/uniform_cdf_test.cpp
@@ -56,9 +56,10 @@ TEST(ProbDistributionsUniformCdf, error_checking) {
                std::domain_error);
 }
 
-auto uniform_cdf_functor = [](const auto& y, const auto& alpha, const auto& beta) {
-  return stan::math::uniform_cdf(y, alpha, beta);
-};
+auto uniform_cdf_functor
+    = [](const auto& y, const auto& alpha, const auto& beta) {
+        return stan::math::uniform_cdf(y, alpha, beta);
+      };
 
 TEST(ProbDistributionsUniformCdf, opencl_matches_cpu_small) {
   int N = 3;
@@ -149,7 +150,8 @@ TEST(ProbDistributionsUniformCdf, opencl_matches_cpu_big) {
   Eigen::Matrix<double, Eigen::Dynamic, 1> alpha
       = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1);
   Eigen::Matrix<double, Eigen::Dynamic, 1> beta
-      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs() + alpha.array();
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs()
+        + alpha.array();
 
   stan::math::test::compare_cpu_opencl_prim_rev(uniform_cdf_functor, y, alpha,
                                                 beta);

--- a/test/unit/math/opencl/rev/uniform_cdf_test.cpp
+++ b/test/unit/math/opencl/rev/uniform_cdf_test.cpp
@@ -1,0 +1,160 @@
+#ifdef STAN_OPENCL
+#include <stan/math/opencl/rev.hpp>
+#include <stan/math.hpp>
+#include <gtest/gtest.h>
+#include <test/unit/math/opencl/util.hpp>
+#include <vector>
+
+TEST(ProbDistributionsUniformCdf, error_checking) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  Eigen::VectorXd y_size(N - 1);
+  y_size << 0.3, 0.8;
+  Eigen::VectorXd y_value(N);
+  y_value << 0.3, NAN, 0.5;
+
+  Eigen::VectorXd alpha(N);
+  alpha << 0.1, 0.8, -1.0;
+  Eigen::VectorXd alpha_size(N - 1);
+  alpha_size << 0.3, 0.8;
+  Eigen::VectorXd alpha_value(N);
+  alpha_value << 0.1, -INFINITY, 0.5;
+
+  Eigen::VectorXd beta(N);
+  beta << 0.3, 1.8, 1.0;
+  Eigen::VectorXd beta_size(N - 1);
+  beta_size << 0.3, 0.8;
+  Eigen::VectorXd beta_value(N);
+  beta_value << 0.3, 0.8, INFINITY;
+
+  stan::math::matrix_cl<double> y_cl(y);
+  stan::math::matrix_cl<double> y_size_cl(y_size);
+  stan::math::matrix_cl<double> y_value_cl(y_value);
+  stan::math::matrix_cl<double> alpha_cl(alpha);
+  stan::math::matrix_cl<double> alpha_size_cl(alpha_size);
+  stan::math::matrix_cl<double> alpha_value_cl(alpha_value);
+  stan::math::matrix_cl<double> beta_cl(beta);
+  stan::math::matrix_cl<double> beta_size_cl(beta_size);
+  stan::math::matrix_cl<double> beta_value_cl(beta_value);
+
+  EXPECT_NO_THROW(stan::math::uniform_cdf(y_cl, alpha_cl, beta_cl));
+
+  EXPECT_THROW(stan::math::uniform_cdf(y_size_cl, alpha_cl, beta_cl),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::uniform_cdf(y_cl, alpha_size_cl, beta_cl),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::uniform_cdf(y_cl, alpha_cl, beta_size_cl),
+               std::invalid_argument);
+
+  EXPECT_THROW(stan::math::uniform_cdf(y_value_cl, alpha_cl, beta_cl),
+               std::domain_error);
+  EXPECT_THROW(stan::math::uniform_cdf(y_cl, alpha_value_cl, beta_cl),
+               std::domain_error);
+  EXPECT_THROW(stan::math::uniform_cdf(y_cl, alpha_cl, beta_value_cl),
+               std::domain_error);
+}
+
+auto uniform_cdf_functor = [](const auto& y, const auto& alpha, const auto& beta) {
+  return stan::math::uniform_cdf(y, alpha, beta);
+};
+
+TEST(ProbDistributionsUniformCdf, opencl_matches_cpu_small) {
+  int N = 3;
+  int M = 2;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  Eigen::VectorXd alpha(N);
+  alpha << 0.1, 0.5, -1.0;
+  Eigen::VectorXd beta(N);
+  beta << 0.3, 0.8, 1.0;
+
+  stan::math::test::compare_cpu_opencl_prim_rev(uniform_cdf_functor, y, alpha,
+                                                beta);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      uniform_cdf_functor, y.transpose().eval(), alpha.transpose().eval(),
+      beta.transpose().eval());
+}
+
+TEST(ProbDistributionsUniformCdf, opencl_matches_cpu_small_y_neg_inf) {
+  int N = 3;
+  int M = 2;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, -INFINITY, 1.0;
+  Eigen::VectorXd alpha(N);
+  alpha << 0.1, 0.5, -1.0;
+  Eigen::VectorXd beta(N);
+  beta << 0.3, 0.8, 1.0;
+
+  stan::math::test::compare_cpu_opencl_prim_rev(uniform_cdf_functor, y, alpha,
+                                                beta);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      uniform_cdf_functor, y.transpose().eval(), alpha.transpose().eval(),
+      beta.transpose().eval());
+}
+
+TEST(ProbDistributionsUniformCdf, opencl_broadcast_y) {
+  int N = 3;
+
+  double y_scal = 12.3;
+  Eigen::VectorXd alpha(N);
+  alpha << 0.1, 0.5, -1.0;
+  Eigen::VectorXd beta(N);
+  beta << 0.3, 0.8, 1.0;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(uniform_cdf_functor,
+                                                         y_scal, alpha, beta);
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(
+      uniform_cdf_functor, y_scal, alpha.transpose().eval(), beta);
+}
+
+TEST(ProbDistributionsUniformCdf, opencl_broadcast_alpha) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  double alpha_scal = -0.1;
+  Eigen::VectorXd beta(N);
+  beta << 0.3, 0.8, 1.0;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<1>(uniform_cdf_functor, y,
+                                                         alpha_scal, beta);
+  stan::math::test::test_opencl_broadcasting_prim_rev<1>(
+      uniform_cdf_functor, y.transpose().eval(), alpha_scal, beta);
+}
+
+TEST(ProbDistributionsUniformCdf, opencl_broadcast_beta) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  Eigen::VectorXd alpha(N);
+  alpha << 0.1, 0.5, -1.0;
+  double beta_scal = 12.3;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<2>(uniform_cdf_functor, y,
+                                                         alpha, beta_scal);
+  stan::math::test::test_opencl_broadcasting_prim_rev<2>(
+      uniform_cdf_functor, y.transpose().eval(), alpha, beta_scal);
+}
+
+TEST(ProbDistributionsUniformCdf, opencl_matches_cpu_big) {
+  int N = 153;
+
+  Eigen::Matrix<double, Eigen::Dynamic, 1> y
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+  Eigen::Matrix<double, Eigen::Dynamic, 1> alpha
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1);
+  Eigen::Matrix<double, Eigen::Dynamic, 1> beta
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs() + alpha.array();
+
+  stan::math::test::compare_cpu_opencl_prim_rev(uniform_cdf_functor, y, alpha,
+                                                beta);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      uniform_cdf_functor, y.transpose().eval(), alpha.transpose().eval(),
+      beta.transpose().eval());
+}
+#endif

--- a/test/unit/math/opencl/rev/uniform_lccdf_test.cpp
+++ b/test/unit/math/opencl/rev/uniform_lccdf_test.cpp
@@ -56,9 +56,10 @@ TEST(ProbDistributionsUniformLccdf, error_checking) {
                std::domain_error);
 }
 
-auto uniform_lccdf_functor = [](const auto& y, const auto& alpha, const auto& beta) {
-  return stan::math::uniform_lccdf(y, alpha, beta);
-};
+auto uniform_lccdf_functor
+    = [](const auto& y, const auto& alpha, const auto& beta) {
+        return stan::math::uniform_lccdf(y, alpha, beta);
+      };
 
 TEST(ProbDistributionsUniformLccdf, opencl_matches_cpu_small) {
   int N = 3;
@@ -120,8 +121,8 @@ TEST(ProbDistributionsUniformLccdf, opencl_broadcast_alpha) {
   Eigen::VectorXd beta(N);
   beta << 0.3, 0.8, 1.0;
 
-  stan::math::test::test_opencl_broadcasting_prim_rev<1>(uniform_lccdf_functor, y,
-                                                         alpha_scal, beta);
+  stan::math::test::test_opencl_broadcasting_prim_rev<1>(uniform_lccdf_functor,
+                                                         y, alpha_scal, beta);
   stan::math::test::test_opencl_broadcasting_prim_rev<1>(
       uniform_lccdf_functor, y.transpose().eval(), alpha_scal, beta);
 }
@@ -135,8 +136,8 @@ TEST(ProbDistributionsUniformLccdf, opencl_broadcast_beta) {
   alpha << 0.1, 0.5, -1.0;
   double beta_scal = 12.3;
 
-  stan::math::test::test_opencl_broadcasting_prim_rev<2>(uniform_lccdf_functor, y,
-                                                         alpha, beta_scal);
+  stan::math::test::test_opencl_broadcasting_prim_rev<2>(uniform_lccdf_functor,
+                                                         y, alpha, beta_scal);
   stan::math::test::test_opencl_broadcasting_prim_rev<2>(
       uniform_lccdf_functor, y.transpose().eval(), alpha, beta_scal);
 }
@@ -149,7 +150,8 @@ TEST(ProbDistributionsUniformLccdf, opencl_matches_cpu_big) {
   Eigen::Matrix<double, Eigen::Dynamic, 1> alpha
       = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1);
   Eigen::Matrix<double, Eigen::Dynamic, 1> beta
-      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs() + alpha.array();
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs()
+        + alpha.array();
 
   stan::math::test::compare_cpu_opencl_prim_rev(uniform_lccdf_functor, y, alpha,
                                                 beta);

--- a/test/unit/math/opencl/rev/uniform_lccdf_test.cpp
+++ b/test/unit/math/opencl/rev/uniform_lccdf_test.cpp
@@ -1,0 +1,160 @@
+#ifdef STAN_OPENCL
+#include <stan/math/opencl/rev.hpp>
+#include <stan/math.hpp>
+#include <gtest/gtest.h>
+#include <test/unit/math/opencl/util.hpp>
+#include <vector>
+
+TEST(ProbDistributionsUniformLccdf, error_checking) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  Eigen::VectorXd y_size(N - 1);
+  y_size << 0.3, 0.8;
+  Eigen::VectorXd y_value(N);
+  y_value << 0.3, NAN, 0.5;
+
+  Eigen::VectorXd alpha(N);
+  alpha << 0.1, 0.8, -1.0;
+  Eigen::VectorXd alpha_size(N - 1);
+  alpha_size << 0.3, 0.8;
+  Eigen::VectorXd alpha_value(N);
+  alpha_value << 0.1, -INFINITY, 0.5;
+
+  Eigen::VectorXd beta(N);
+  beta << 0.3, 1.8, 1.0;
+  Eigen::VectorXd beta_size(N - 1);
+  beta_size << 0.3, 0.8;
+  Eigen::VectorXd beta_value(N);
+  beta_value << 0.3, 0.8, INFINITY;
+
+  stan::math::matrix_cl<double> y_cl(y);
+  stan::math::matrix_cl<double> y_size_cl(y_size);
+  stan::math::matrix_cl<double> y_value_cl(y_value);
+  stan::math::matrix_cl<double> alpha_cl(alpha);
+  stan::math::matrix_cl<double> alpha_size_cl(alpha_size);
+  stan::math::matrix_cl<double> alpha_value_cl(alpha_value);
+  stan::math::matrix_cl<double> beta_cl(beta);
+  stan::math::matrix_cl<double> beta_size_cl(beta_size);
+  stan::math::matrix_cl<double> beta_value_cl(beta_value);
+
+  EXPECT_NO_THROW(stan::math::uniform_lccdf(y_cl, alpha_cl, beta_cl));
+
+  EXPECT_THROW(stan::math::uniform_lccdf(y_size_cl, alpha_cl, beta_cl),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::uniform_lccdf(y_cl, alpha_size_cl, beta_cl),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::uniform_lccdf(y_cl, alpha_cl, beta_size_cl),
+               std::invalid_argument);
+
+  EXPECT_THROW(stan::math::uniform_lccdf(y_value_cl, alpha_cl, beta_cl),
+               std::domain_error);
+  EXPECT_THROW(stan::math::uniform_lccdf(y_cl, alpha_value_cl, beta_cl),
+               std::domain_error);
+  EXPECT_THROW(stan::math::uniform_lccdf(y_cl, alpha_cl, beta_value_cl),
+               std::domain_error);
+}
+
+auto uniform_lccdf_functor = [](const auto& y, const auto& alpha, const auto& beta) {
+  return stan::math::uniform_lccdf(y, alpha, beta);
+};
+
+TEST(ProbDistributionsUniformLccdf, opencl_matches_cpu_small) {
+  int N = 3;
+  int M = 2;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  Eigen::VectorXd alpha(N);
+  alpha << 0.1, 0.5, -1.0;
+  Eigen::VectorXd beta(N);
+  beta << 0.3, 0.8, 1.0;
+
+  stan::math::test::compare_cpu_opencl_prim_rev(uniform_lccdf_functor, y, alpha,
+                                                beta);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      uniform_lccdf_functor, y.transpose().eval(), alpha.transpose().eval(),
+      beta.transpose().eval());
+}
+
+TEST(ProbDistributionsUniformLccdf, opencl_matches_cpu_small_y_neg_inf) {
+  int N = 3;
+  int M = 2;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, -INFINITY, 1.0;
+  Eigen::VectorXd alpha(N);
+  alpha << 0.1, 0.5, -1.0;
+  Eigen::VectorXd beta(N);
+  beta << 0.3, 0.8, 1.0;
+
+  stan::math::test::compare_cpu_opencl_prim_rev(uniform_lccdf_functor, y, alpha,
+                                                beta);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      uniform_lccdf_functor, y.transpose().eval(), alpha.transpose().eval(),
+      beta.transpose().eval());
+}
+
+TEST(ProbDistributionsUniformLccdf, opencl_broadcast_y) {
+  int N = 3;
+
+  double y_scal = 12.3;
+  Eigen::VectorXd alpha(N);
+  alpha << 0.1, 0.5, -1.0;
+  Eigen::VectorXd beta(N);
+  beta << 0.3, 0.8, 1.0;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(uniform_lccdf_functor,
+                                                         y_scal, alpha, beta);
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(
+      uniform_lccdf_functor, y_scal, alpha.transpose().eval(), beta);
+}
+
+TEST(ProbDistributionsUniformLccdf, opencl_broadcast_alpha) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  double alpha_scal = -0.1;
+  Eigen::VectorXd beta(N);
+  beta << 0.3, 0.8, 1.0;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<1>(uniform_lccdf_functor, y,
+                                                         alpha_scal, beta);
+  stan::math::test::test_opencl_broadcasting_prim_rev<1>(
+      uniform_lccdf_functor, y.transpose().eval(), alpha_scal, beta);
+}
+
+TEST(ProbDistributionsUniformLccdf, opencl_broadcast_beta) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  Eigen::VectorXd alpha(N);
+  alpha << 0.1, 0.5, -1.0;
+  double beta_scal = 12.3;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<2>(uniform_lccdf_functor, y,
+                                                         alpha, beta_scal);
+  stan::math::test::test_opencl_broadcasting_prim_rev<2>(
+      uniform_lccdf_functor, y.transpose().eval(), alpha, beta_scal);
+}
+
+TEST(ProbDistributionsUniformLccdf, opencl_matches_cpu_big) {
+  int N = 153;
+
+  Eigen::Matrix<double, Eigen::Dynamic, 1> y
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+  Eigen::Matrix<double, Eigen::Dynamic, 1> alpha
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1);
+  Eigen::Matrix<double, Eigen::Dynamic, 1> beta
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs() + alpha.array();
+
+  stan::math::test::compare_cpu_opencl_prim_rev(uniform_lccdf_functor, y, alpha,
+                                                beta);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      uniform_lccdf_functor, y.transpose().eval(), alpha.transpose().eval(),
+      beta.transpose().eval());
+}
+#endif

--- a/test/unit/math/opencl/rev/uniform_lcdf_test.cpp
+++ b/test/unit/math/opencl/rev/uniform_lcdf_test.cpp
@@ -56,9 +56,10 @@ TEST(ProbDistributionsUniformLcdf, error_checking) {
                std::domain_error);
 }
 
-auto uniform_lcdf_functor = [](const auto& y, const auto& alpha, const auto& beta) {
-  return stan::math::uniform_lcdf(y, alpha, beta);
-};
+auto uniform_lcdf_functor
+    = [](const auto& y, const auto& alpha, const auto& beta) {
+        return stan::math::uniform_lcdf(y, alpha, beta);
+      };
 
 TEST(ProbDistributionsUniformLcdf, opencl_matches_cpu_small) {
   int N = 3;
@@ -120,8 +121,8 @@ TEST(ProbDistributionsUniformLcdf, opencl_broadcast_alpha) {
   Eigen::VectorXd beta(N);
   beta << 0.3, 0.8, 1.0;
 
-  stan::math::test::test_opencl_broadcasting_prim_rev<1>(uniform_lcdf_functor, y,
-                                                         alpha_scal, beta);
+  stan::math::test::test_opencl_broadcasting_prim_rev<1>(uniform_lcdf_functor,
+                                                         y, alpha_scal, beta);
   stan::math::test::test_opencl_broadcasting_prim_rev<1>(
       uniform_lcdf_functor, y.transpose().eval(), alpha_scal, beta);
 }
@@ -135,8 +136,8 @@ TEST(ProbDistributionsUniformLcdf, opencl_broadcast_beta) {
   alpha << 0.1, 0.5, -1.0;
   double beta_scal = 12.3;
 
-  stan::math::test::test_opencl_broadcasting_prim_rev<2>(uniform_lcdf_functor, y,
-                                                         alpha, beta_scal);
+  stan::math::test::test_opencl_broadcasting_prim_rev<2>(uniform_lcdf_functor,
+                                                         y, alpha, beta_scal);
   stan::math::test::test_opencl_broadcasting_prim_rev<2>(
       uniform_lcdf_functor, y.transpose().eval(), alpha, beta_scal);
 }
@@ -149,7 +150,8 @@ TEST(ProbDistributionsUniformLcdf, opencl_matches_cpu_big) {
   Eigen::Matrix<double, Eigen::Dynamic, 1> alpha
       = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1);
   Eigen::Matrix<double, Eigen::Dynamic, 1> beta
-      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs() + alpha.array();
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs()
+        + alpha.array();
 
   stan::math::test::compare_cpu_opencl_prim_rev(uniform_lcdf_functor, y, alpha,
                                                 beta);

--- a/test/unit/math/opencl/rev/uniform_lcdf_test.cpp
+++ b/test/unit/math/opencl/rev/uniform_lcdf_test.cpp
@@ -1,0 +1,160 @@
+#ifdef STAN_OPENCL
+#include <stan/math/opencl/rev.hpp>
+#include <stan/math.hpp>
+#include <gtest/gtest.h>
+#include <test/unit/math/opencl/util.hpp>
+#include <vector>
+
+TEST(ProbDistributionsUniformLcdf, error_checking) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  Eigen::VectorXd y_size(N - 1);
+  y_size << 0.3, 0.8;
+  Eigen::VectorXd y_value(N);
+  y_value << 0.3, NAN, 0.5;
+
+  Eigen::VectorXd alpha(N);
+  alpha << 0.1, 0.8, -1.0;
+  Eigen::VectorXd alpha_size(N - 1);
+  alpha_size << 0.3, 0.8;
+  Eigen::VectorXd alpha_value(N);
+  alpha_value << 0.1, -INFINITY, 0.5;
+
+  Eigen::VectorXd beta(N);
+  beta << 0.3, 1.8, 1.0;
+  Eigen::VectorXd beta_size(N - 1);
+  beta_size << 0.3, 0.8;
+  Eigen::VectorXd beta_value(N);
+  beta_value << 0.3, 0.8, INFINITY;
+
+  stan::math::matrix_cl<double> y_cl(y);
+  stan::math::matrix_cl<double> y_size_cl(y_size);
+  stan::math::matrix_cl<double> y_value_cl(y_value);
+  stan::math::matrix_cl<double> alpha_cl(alpha);
+  stan::math::matrix_cl<double> alpha_size_cl(alpha_size);
+  stan::math::matrix_cl<double> alpha_value_cl(alpha_value);
+  stan::math::matrix_cl<double> beta_cl(beta);
+  stan::math::matrix_cl<double> beta_size_cl(beta_size);
+  stan::math::matrix_cl<double> beta_value_cl(beta_value);
+
+  EXPECT_NO_THROW(stan::math::uniform_lcdf(y_cl, alpha_cl, beta_cl));
+
+  EXPECT_THROW(stan::math::uniform_lcdf(y_size_cl, alpha_cl, beta_cl),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::uniform_lcdf(y_cl, alpha_size_cl, beta_cl),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::uniform_lcdf(y_cl, alpha_cl, beta_size_cl),
+               std::invalid_argument);
+
+  EXPECT_THROW(stan::math::uniform_lcdf(y_value_cl, alpha_cl, beta_cl),
+               std::domain_error);
+  EXPECT_THROW(stan::math::uniform_lcdf(y_cl, alpha_value_cl, beta_cl),
+               std::domain_error);
+  EXPECT_THROW(stan::math::uniform_lcdf(y_cl, alpha_cl, beta_value_cl),
+               std::domain_error);
+}
+
+auto uniform_lcdf_functor = [](const auto& y, const auto& alpha, const auto& beta) {
+  return stan::math::uniform_lcdf(y, alpha, beta);
+};
+
+TEST(ProbDistributionsUniformLcdf, opencl_matches_cpu_small) {
+  int N = 3;
+  int M = 2;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  Eigen::VectorXd alpha(N);
+  alpha << 0.1, 0.5, -1.0;
+  Eigen::VectorXd beta(N);
+  beta << 0.3, 0.8, 1.0;
+
+  stan::math::test::compare_cpu_opencl_prim_rev(uniform_lcdf_functor, y, alpha,
+                                                beta);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      uniform_lcdf_functor, y.transpose().eval(), alpha.transpose().eval(),
+      beta.transpose().eval());
+}
+
+TEST(ProbDistributionsUniformLcdf, opencl_matches_cpu_small_y_neg_inf) {
+  int N = 3;
+  int M = 2;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, -INFINITY, 1.0;
+  Eigen::VectorXd alpha(N);
+  alpha << 0.1, 0.5, -1.0;
+  Eigen::VectorXd beta(N);
+  beta << 0.3, 0.8, 1.0;
+
+  stan::math::test::compare_cpu_opencl_prim_rev(uniform_lcdf_functor, y, alpha,
+                                                beta);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      uniform_lcdf_functor, y.transpose().eval(), alpha.transpose().eval(),
+      beta.transpose().eval());
+}
+
+TEST(ProbDistributionsUniformLcdf, opencl_broadcast_y) {
+  int N = 3;
+
+  double y_scal = 12.3;
+  Eigen::VectorXd alpha(N);
+  alpha << 0.1, 0.5, -1.0;
+  Eigen::VectorXd beta(N);
+  beta << 0.3, 0.8, 1.0;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(uniform_lcdf_functor,
+                                                         y_scal, alpha, beta);
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(
+      uniform_lcdf_functor, y_scal, alpha.transpose().eval(), beta);
+}
+
+TEST(ProbDistributionsUniformLcdf, opencl_broadcast_alpha) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  double alpha_scal = -0.1;
+  Eigen::VectorXd beta(N);
+  beta << 0.3, 0.8, 1.0;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<1>(uniform_lcdf_functor, y,
+                                                         alpha_scal, beta);
+  stan::math::test::test_opencl_broadcasting_prim_rev<1>(
+      uniform_lcdf_functor, y.transpose().eval(), alpha_scal, beta);
+}
+
+TEST(ProbDistributionsUniformLcdf, opencl_broadcast_beta) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  Eigen::VectorXd alpha(N);
+  alpha << 0.1, 0.5, -1.0;
+  double beta_scal = 12.3;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<2>(uniform_lcdf_functor, y,
+                                                         alpha, beta_scal);
+  stan::math::test::test_opencl_broadcasting_prim_rev<2>(
+      uniform_lcdf_functor, y.transpose().eval(), alpha, beta_scal);
+}
+
+TEST(ProbDistributionsUniformLcdf, opencl_matches_cpu_big) {
+  int N = 153;
+
+  Eigen::Matrix<double, Eigen::Dynamic, 1> y
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+  Eigen::Matrix<double, Eigen::Dynamic, 1> alpha
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1);
+  Eigen::Matrix<double, Eigen::Dynamic, 1> beta
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs() + alpha.array();
+
+  stan::math::test::compare_cpu_opencl_prim_rev(uniform_lcdf_functor, y, alpha,
+                                                beta);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      uniform_lcdf_functor, y.transpose().eval(), alpha.transpose().eval(),
+      beta.transpose().eval());
+}
+#endif


### PR DESCRIPTION
## Summary

Added OpenCL implementations for functions `std_normal_cdf`, `std_normal_lccdf`, `std_normal_lcdf`, `uniform_cdf`, `uniform_lccdf` and `uniform_lcdf`.

## Tests
New functions are tested.

## Side Effects
None.

## Release notes

OpenCL: Added OpenCL implementations for functions `std_normal_cdf`, `std_normal_lccdf`, `std_normal_lcdf`, `uniform_cdf`, `uniform_lccdf` and `uniform_lcdf`.

## Checklist

- [ ] Math issue #2152

- [ ] Copyright holder: Tadej Ciglarič

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [ ] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [ ] the code is written in idiomatic C++ and changes are documented in the doxygen

- [ ] the new changes are tested
