### PR TITLE
added OpenCL Weibull (lc)cdf

### DIFF
--- a/stan/math/opencl/prim.hpp
+++ b/stan/math/opencl/prim.hpp
@@ -245,6 +245,9 @@
 #include <stan/math/opencl/prim/uniform_lpdf.hpp>
 #include <stan/math/opencl/prim/unit_vector_constrain.hpp>
 #include <stan/math/opencl/prim/variance.hpp>
+#include <stan/math/opencl/prim/weibull_cdf.hpp>
+#include <stan/math/opencl/prim/weibull_lccdf.hpp>
+#include <stan/math/opencl/prim/weibull_lcdf.hpp>
 #include <stan/math/opencl/prim/weibull_lpdf.hpp>
 
 #include <stan/math/opencl/err.hpp>

--- a/stan/math/opencl/prim/weibull_cdf.hpp
+++ b/stan/math/opencl/prim/weibull_cdf.hpp
@@ -1,0 +1,121 @@
+#ifndef STAN_MATH_OPENCL_PRIM_WEIBULL_CDF_HPP
+#define STAN_MATH_OPENCL_PRIM_WEIBULL_CDF_HPP
+#ifdef STAN_OPENCL
+
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/err.hpp>
+#include <stan/math/prim/fun/constants.hpp>
+#include <stan/math/prim/fun/elt_divide.hpp>
+#include <stan/math/prim/fun/elt_multiply.hpp>
+#include <stan/math/opencl/kernel_generator.hpp>
+#include <stan/math/prim/functor/operands_and_partials.hpp>
+
+namespace stan {
+namespace math {
+
+/** \ingroup opencl
+ * Returns the weibull cumulative distribution function for the given
+ * location, and scale. If given containers of matching sizes
+ * returns the product of probabilities.
+ *
+ * @tparam T_y_cl type of scalar outcome
+ * @tparam T_shape_cl type of location
+ * @tparam T_scale_cl type of scale
+ * @param y (Sequence of) scalar(s).
+ * @param alpha (Sequence of) location(s).
+ * @param sigma (Sequence of) scale(s).
+ * @return The log of the product of densities.
+ */
+template <
+    typename T_y_cl, typename T_shape_cl, typename T_scale_cl,
+    require_all_prim_or_rev_kernel_expression_t<T_y_cl, T_shape_cl,
+                                                T_scale_cl>* = nullptr,
+    require_any_not_stan_scalar_t<T_y_cl, T_shape_cl, T_scale_cl>* = nullptr>
+return_type_t<T_y_cl, T_shape_cl, T_scale_cl> weibull_cdf(
+    const T_y_cl& y, const T_shape_cl& alpha, const T_scale_cl& sigma) {
+  static const char* function = "weibull_cdf(OpenCL)";
+  using T_partials_return = partials_return_t<T_y_cl, T_shape_cl, T_scale_cl>;
+  using std::isfinite;
+  using std::isnan;
+
+  check_consistent_sizes(function, "Random variable", y, "Shape parameter",
+                         alpha, "Scale parameter", sigma);
+  const size_t N = max_size(y, alpha, sigma);
+  if (N == 0) {
+    return 1.0;
+  }
+
+  const auto& y_col = as_column_vector_or_scalar(y);
+  const auto& alpha_col = as_column_vector_or_scalar(alpha);
+  const auto& sigma_col = as_column_vector_or_scalar(sigma);
+
+  const auto& y_val = value_of(y_col);
+  const auto& alpha_val = value_of(alpha_col);
+  const auto& sigma_val = value_of(sigma_col);
+
+  auto check_y_nonnegative
+      = check_cl(function, "Random variable", y_val, "not NaN");
+  auto y_nonnegative = y_val >= 0.0;
+  auto check_alpha_positive_finite
+      = check_cl(function, "Shape parameter", alpha_val, "positive finite");
+  auto alpha_positive_finite_expr = alpha_val > 0 && isfinite(alpha_val);
+  auto check_sigma_positive_finite
+      = check_cl(function, "Scale parameter", sigma_val, "positive finite");
+  auto sigma_positive_finite_expr = 0 < sigma_val && isfinite(sigma_val);
+
+  auto pow_n = pow(elt_divide(y_val, sigma_val), alpha_val);
+  auto exp_n = exp(-pow_n);
+  auto cdf_n = 1.0 - exp_n;
+  auto cdf_expr = colwise_prod(cdf_n);
+
+  auto rep_deriv = elt_multiply(exp_n, elt_divide(pow_n, cdf_n));
+  auto deriv_y_sigma = elt_multiply(rep_deriv, alpha_val);
+  auto y_deriv_tmp = elt_divide(deriv_y_sigma, y_val);
+  auto sigma_deriv_tmp = elt_divide(deriv_y_sigma, -sigma_val);
+  auto alpha_deriv_tmp = elt_multiply(rep_deriv, log(elt_divide(y_val, sigma_val)));
+
+  matrix_cl<double> cdf_cl;
+  matrix_cl<double> alpha_deriv_cl;
+  matrix_cl<double> y_deriv_cl;
+  matrix_cl<double> sigma_deriv_cl;
+
+  results(check_y_nonnegative, check_alpha_positive_finite, check_sigma_positive_finite,
+          cdf_cl, y_deriv_cl, alpha_deriv_cl, sigma_deriv_cl)
+      = expressions(
+          y_nonnegative, alpha_positive_finite_expr, sigma_positive_finite_expr,
+          cdf_expr,
+        calc_if<!is_constant<T_y_cl>::value>(y_deriv_tmp),
+        calc_if<!is_constant<T_shape_cl>::value>(alpha_deriv_tmp),
+          calc_if<!is_constant<T_scale_cl>::value>(sigma_deriv_tmp));
+
+  T_partials_return cdf = (from_matrix_cl(cdf_cl)).prod();
+
+  auto alpha_deriv = alpha_deriv_cl * cdf;
+  auto y_deriv = y_deriv_cl * cdf;
+  auto sigma_deriv = sigma_deriv_cl * cdf;
+
+  results(alpha_deriv_cl, y_deriv_cl, sigma_deriv_cl)
+      = expressions(calc_if<!is_constant<T_shape_cl>::value>(alpha_deriv),
+                    calc_if<!is_constant<T_y_cl>::value>(y_deriv),
+                    calc_if<!is_constant<T_scale_cl>::value>(sigma_deriv));
+
+  operands_and_partials<decltype(y_col), decltype(alpha_col),
+                        decltype(sigma_col)>
+      ops_partials(y_col, alpha_col, sigma_col);
+
+  if (!is_constant<T_y_cl>::value) {
+    ops_partials.edge1_.partials_ = std::move(y_deriv_cl);
+  }
+  if (!is_constant<T_shape_cl>::value) {
+    ops_partials.edge2_.partials_ = std::move(alpha_deriv_cl);
+  }
+  if (!is_constant<T_scale_cl>::value) {
+    ops_partials.edge3_.partials_ = std::move(sigma_deriv_cl);
+  }
+  return ops_partials.build(cdf);
+}
+
+}  // namespace math
+}  // namespace stan
+#endif
+#endif

--- a/stan/math/opencl/prim/weibull_cdf.hpp
+++ b/stan/math/opencl/prim/weibull_cdf.hpp
@@ -72,21 +72,22 @@ return_type_t<T_y_cl, T_shape_cl, T_scale_cl> weibull_cdf(
   auto deriv_y_sigma = elt_multiply(rep_deriv, alpha_val);
   auto y_deriv_tmp = elt_divide(deriv_y_sigma, y_val);
   auto sigma_deriv_tmp = elt_divide(deriv_y_sigma, -sigma_val);
-  auto alpha_deriv_tmp = elt_multiply(rep_deriv, log(elt_divide(y_val, sigma_val)));
+  auto alpha_deriv_tmp
+      = elt_multiply(rep_deriv, log(elt_divide(y_val, sigma_val)));
 
   matrix_cl<double> cdf_cl;
   matrix_cl<double> alpha_deriv_cl;
   matrix_cl<double> y_deriv_cl;
   matrix_cl<double> sigma_deriv_cl;
 
-  results(check_y_nonnegative, check_alpha_positive_finite, check_sigma_positive_finite,
-          cdf_cl, y_deriv_cl, alpha_deriv_cl, sigma_deriv_cl)
-      = expressions(
-          y_nonnegative, alpha_positive_finite_expr, sigma_positive_finite_expr,
-          cdf_expr,
-        calc_if<!is_constant<T_y_cl>::value>(y_deriv_tmp),
-        calc_if<!is_constant<T_shape_cl>::value>(alpha_deriv_tmp),
-          calc_if<!is_constant<T_scale_cl>::value>(sigma_deriv_tmp));
+  results(check_y_nonnegative, check_alpha_positive_finite,
+          check_sigma_positive_finite, cdf_cl, y_deriv_cl, alpha_deriv_cl,
+          sigma_deriv_cl)
+      = expressions(y_nonnegative, alpha_positive_finite_expr,
+                    sigma_positive_finite_expr, cdf_expr,
+                    calc_if<!is_constant<T_y_cl>::value>(y_deriv_tmp),
+                    calc_if<!is_constant<T_shape_cl>::value>(alpha_deriv_tmp),
+                    calc_if<!is_constant<T_scale_cl>::value>(sigma_deriv_tmp));
 
   T_partials_return cdf = (from_matrix_cl(cdf_cl)).prod();
 

--- a/stan/math/opencl/prim/weibull_lccdf.hpp
+++ b/stan/math/opencl/prim/weibull_lccdf.hpp
@@ -1,0 +1,108 @@
+#ifndef STAN_MATH_OPENCL_PRIM_WEIBULL_LCCDF_HPP
+#define STAN_MATH_OPENCL_PRIM_WEIBULL_LCCDF_HPP
+#ifdef STAN_OPENCL
+
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/err.hpp>
+#include <stan/math/prim/fun/constants.hpp>
+#include <stan/math/prim/fun/elt_divide.hpp>
+#include <stan/math/prim/fun/elt_multiply.hpp>
+#include <stan/math/opencl/kernel_generator.hpp>
+#include <stan/math/prim/functor/operands_and_partials.hpp>
+
+namespace stan {
+namespace math {
+
+/** \ingroup opencl
+ * Returns the weibull log cumulative complementary distribution function for
+ * the given location, and scale. If given containers of matching sizes returns
+ * the product of probabilities.
+ *
+ * @tparam T_y_cl type of scalar outcome
+ * @tparam T_shape_cl type of location
+ * @tparam T_scale_cl type of scale
+ * @param y (Sequence of) scalar(s).
+ * @param alpha (Sequence of) location(s).
+ * @param sigma (Sequence of) scale(s).
+ * @return The log of the product of densities.
+ */
+template <
+    typename T_y_cl, typename T_shape_cl, typename T_scale_cl,
+    require_all_prim_or_rev_kernel_expression_t<T_y_cl, T_shape_cl,
+                                                T_scale_cl>* = nullptr,
+    require_any_not_stan_scalar_t<T_y_cl, T_shape_cl, T_scale_cl>* = nullptr>
+return_type_t<T_y_cl, T_shape_cl, T_scale_cl> weibull_lccdf(
+    const T_y_cl& y, const T_shape_cl& alpha, const T_scale_cl& sigma) {
+  static const char* function = "weibull_lccdf(OpenCL)";
+  using T_partials_return = partials_return_t<T_y_cl, T_shape_cl, T_scale_cl>;
+  using std::isfinite;
+  using std::isnan;
+
+  check_consistent_sizes(function, "Random variable", y, "Shape parameter",
+                         alpha, "Scale parameter", sigma);
+  const size_t N = max_size(y, alpha, sigma);
+  if (N == 0) {
+    return 1.0;
+  }
+
+  const auto& y_col = as_column_vector_or_scalar(y);
+  const auto& alpha_col = as_column_vector_or_scalar(alpha);
+  const auto& sigma_col = as_column_vector_or_scalar(sigma);
+
+  const auto& y_val = value_of(y_col);
+  const auto& alpha_val = value_of(alpha_col);
+  const auto& sigma_val = value_of(sigma_col);
+
+  auto check_y_nonnegative
+      = check_cl(function, "Random variable", y_val, "not NaN");
+  auto y_nonnegative = y_val >= 0.0;
+  auto check_alpha_positive_finite
+      = check_cl(function, "Shape parameter", alpha_val, "positive finite");
+  auto alpha_positive_finite_expr = alpha_val > 0 && isfinite(alpha_val);
+  auto check_sigma_positive_finite
+      = check_cl(function, "Scale parameter", sigma_val, "positive finite");
+  auto sigma_positive_finite_expr = 0 < sigma_val && isfinite(sigma_val);
+
+  auto pow_n = pow(elt_divide(y_val, sigma_val), alpha_val);
+  auto lccdf_expr = colwise_sum(pow_n);
+
+  auto y_deriv = elt_divide(elt_multiply(-alpha_val, pow_n), y_val);
+  auto alpha_deriv = elt_multiply(-log(elt_divide(y_val, sigma_val)), pow_n);
+  auto sigma_deriv = elt_multiply(elt_divide(alpha_val, sigma_val), pow_n);
+
+  matrix_cl<double> lccdf_cl;
+  matrix_cl<double> alpha_deriv_cl;
+  matrix_cl<double> y_deriv_cl;
+  matrix_cl<double> sigma_deriv_cl;
+
+  results(check_y_nonnegative, check_alpha_positive_finite,
+          check_sigma_positive_finite, lccdf_cl, y_deriv_cl, alpha_deriv_cl,
+          sigma_deriv_cl)
+      = expressions(y_nonnegative, alpha_positive_finite_expr,
+                    sigma_positive_finite_expr, lccdf_expr,
+                    calc_if<!is_constant<T_y_cl>::value>(y_deriv),
+                    calc_if<!is_constant<T_shape_cl>::value>(alpha_deriv),
+                    calc_if<!is_constant<T_scale_cl>::value>(sigma_deriv));
+
+  T_partials_return lccdf = -from_matrix_cl(lccdf_cl).sum();
+
+  operands_and_partials<decltype(y_col), decltype(alpha_col),
+                        decltype(sigma_col)>
+      ops_partials(y_col, alpha_col, sigma_col);
+
+  if (!is_constant<T_y_cl>::value) {
+    ops_partials.edge1_.partials_ = std::move(y_deriv_cl);
+  }
+  if (!is_constant<T_shape_cl>::value) {
+    ops_partials.edge2_.partials_ = std::move(alpha_deriv_cl);
+  }
+  if (!is_constant<T_scale_cl>::value) {
+    ops_partials.edge3_.partials_ = std::move(sigma_deriv_cl);
+  }
+  return ops_partials.build(lccdf);
+}
+
+}  // namespace math
+}  // namespace stan
+#endif
+#endif

--- a/stan/math/opencl/prim/weibull_lcdf.hpp
+++ b/stan/math/opencl/prim/weibull_lcdf.hpp
@@ -1,0 +1,111 @@
+#ifndef STAN_MATH_OPENCL_PRIM_WEIBULL_LCDF_HPP
+#define STAN_MATH_OPENCL_PRIM_WEIBULL_LCDF_HPP
+#ifdef STAN_OPENCL
+
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/err.hpp>
+#include <stan/math/prim/fun/constants.hpp>
+#include <stan/math/prim/fun/elt_divide.hpp>
+#include <stan/math/prim/fun/elt_multiply.hpp>
+#include <stan/math/opencl/kernel_generator.hpp>
+#include <stan/math/prim/functor/operands_and_partials.hpp>
+
+namespace stan {
+namespace math {
+
+/** \ingroup opencl
+ * Returns the weibull log cumulative distribution function for
+ * the given location, and scale. If given containers of matching sizes returns
+ * the product of probabilities.
+ *
+ * @tparam T_y_cl type of scalar outcome
+ * @tparam T_shape_cl type of location
+ * @tparam T_scale_cl type of scale
+ * @param y (Sequence of) scalar(s).
+ * @param alpha (Sequence of) location(s).
+ * @param sigma (Sequence of) scale(s).
+ * @return The log of the product of densities.
+ */
+template <
+    typename T_y_cl, typename T_shape_cl, typename T_scale_cl,
+    require_all_prim_or_rev_kernel_expression_t<T_y_cl, T_shape_cl,
+                                                T_scale_cl>* = nullptr,
+    require_any_not_stan_scalar_t<T_y_cl, T_shape_cl, T_scale_cl>* = nullptr>
+return_type_t<T_y_cl, T_shape_cl, T_scale_cl> weibull_lcdf(
+    const T_y_cl& y, const T_shape_cl& alpha, const T_scale_cl& sigma) {
+  static const char* function = "weibull_lcdf(OpenCL)";
+  using T_partials_return = partials_return_t<T_y_cl, T_shape_cl, T_scale_cl>;
+  using std::isfinite;
+  using std::isnan;
+
+  check_consistent_sizes(function, "Random variable", y, "Shape parameter",
+                         alpha, "Scale parameter", sigma);
+  const size_t N = max_size(y, alpha, sigma);
+  if (N == 0) {
+    return 1.0;
+  }
+
+  const auto& y_col = as_column_vector_or_scalar(y);
+  const auto& alpha_col = as_column_vector_or_scalar(alpha);
+  const auto& sigma_col = as_column_vector_or_scalar(sigma);
+
+  const auto& y_val = value_of(y_col);
+  const auto& alpha_val = value_of(alpha_col);
+  const auto& sigma_val = value_of(sigma_col);
+
+  auto check_y_nonnegative
+      = check_cl(function, "Random variable", y_val, "not NaN");
+  auto y_nonnegative = y_val >= 0.0;
+  auto check_alpha_positive_finite
+      = check_cl(function, "Shape parameter", alpha_val, "positive finite");
+  auto alpha_positive_finite_expr = alpha_val > 0 && isfinite(alpha_val);
+  auto check_sigma_positive_finite
+      = check_cl(function, "Scale parameter", sigma_val, "positive finite");
+  auto sigma_positive_finite_expr = 0 < sigma_val && isfinite(sigma_val);
+
+  auto pow_n = pow(elt_divide(y_val, sigma_val), alpha_val);
+  auto exp_n = exp(-pow_n);
+  auto lcdf_expr = colwise_sum(log(1.0 - exp_n));
+
+  auto rep_deriv = elt_divide(pow_n, elt_divide(1.0, exp_n) - 1.0);
+  auto deriv_y_sigma = elt_multiply(rep_deriv, alpha_val);
+  auto y_deriv = elt_divide(deriv_y_sigma, y_val);
+  auto sigma_deriv = elt_divide(deriv_y_sigma, -sigma_val);
+  auto alpha_deriv = elt_multiply(rep_deriv, log(elt_divide(y_val, sigma_val)));
+
+  matrix_cl<double> lcdf_cl;
+  matrix_cl<double> alpha_deriv_cl;
+  matrix_cl<double> y_deriv_cl;
+  matrix_cl<double> sigma_deriv_cl;
+
+  results(check_y_nonnegative, check_alpha_positive_finite,
+          check_sigma_positive_finite, lcdf_cl, y_deriv_cl, alpha_deriv_cl,
+          sigma_deriv_cl)
+      = expressions(y_nonnegative, alpha_positive_finite_expr,
+                    sigma_positive_finite_expr, lcdf_expr,
+                    calc_if<!is_constant<T_y_cl>::value>(y_deriv),
+                    calc_if<!is_constant<T_shape_cl>::value>(alpha_deriv),
+                    calc_if<!is_constant<T_scale_cl>::value>(sigma_deriv));
+
+  T_partials_return lcdf = from_matrix_cl(lcdf_cl).sum();
+
+  operands_and_partials<decltype(y_col), decltype(alpha_col),
+                        decltype(sigma_col)>
+      ops_partials(y_col, alpha_col, sigma_col);
+
+  if (!is_constant<T_y_cl>::value) {
+    ops_partials.edge1_.partials_ = std::move(y_deriv_cl);
+  }
+  if (!is_constant<T_shape_cl>::value) {
+    ops_partials.edge2_.partials_ = std::move(alpha_deriv_cl);
+  }
+  if (!is_constant<T_scale_cl>::value) {
+    ops_partials.edge3_.partials_ = std::move(sigma_deriv_cl);
+  }
+  return ops_partials.build(lcdf);
+}
+
+}  // namespace math
+}  // namespace stan
+#endif
+#endif

--- a/stan/math/prim/prob/weibull_cdf.hpp
+++ b/stan/math/prim/prob/weibull_cdf.hpp
@@ -33,7 +33,9 @@ namespace math {
  * @return probability or product of probabilities
  * @throw std::domain_error if y is negative, alpha sigma is nonpositive
  */
-template <typename T_y, typename T_shape, typename T_scale>
+template <typename T_y, typename T_shape, typename T_scale,
+          require_all_not_nonscalar_prim_or_rev_kernel_expression_t<
+              T_y, T_shape, T_scale>* = nullptr>
 return_type_t<T_y, T_shape, T_scale> weibull_cdf(const T_y& y,
                                                  const T_shape& alpha,
                                                  const T_scale& sigma) {

--- a/stan/math/prim/prob/weibull_lccdf.hpp
+++ b/stan/math/prim/prob/weibull_lccdf.hpp
@@ -31,7 +31,9 @@ namespace math {
  * @return log probability or log sum of probabilities
  * @throw std::domain_error if y is negative, alpha sigma is nonpositive
  */
-template <typename T_y, typename T_shape, typename T_scale>
+template <typename T_y, typename T_shape, typename T_scale,
+          require_all_not_nonscalar_prim_or_rev_kernel_expression_t<
+              T_y, T_shape, T_scale>* = nullptr>
 return_type_t<T_y, T_shape, T_scale> weibull_lccdf(const T_y& y,
                                                    const T_shape& alpha,
                                                    const T_scale& sigma) {

--- a/stan/math/prim/prob/weibull_lcdf.hpp
+++ b/stan/math/prim/prob/weibull_lcdf.hpp
@@ -32,7 +32,9 @@ namespace math {
  * @return log probability or log sum of probabilities
  * @throw std::domain_error if y is negative, alpha sigma is nonpositive
  */
-template <typename T_y, typename T_shape, typename T_scale>
+template <typename T_y, typename T_shape, typename T_scale,
+          require_all_not_nonscalar_prim_or_rev_kernel_expression_t<
+              T_y, T_shape, T_scale>* = nullptr>
 return_type_t<T_y, T_shape, T_scale> weibull_lcdf(const T_y& y,
                                                   const T_shape& alpha,
                                                   const T_scale& sigma) {

--- a/test/unit/math/opencl/rev/weibull_cdf_test.cpp
+++ b/test/unit/math/opencl/rev/weibull_cdf_test.cpp
@@ -1,0 +1,142 @@
+#ifdef STAN_OPENCL
+#include <stan/math/opencl/rev.hpp>
+#include <stan/math.hpp>
+#include <gtest/gtest.h>
+#include <test/unit/math/opencl/util.hpp>
+#include <vector>
+
+TEST(ProbDistributionsWeibullCdf, error_checking) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  Eigen::VectorXd y_size(N - 1);
+  y_size << 0.3, 0.8;
+  Eigen::VectorXd y_value(N);
+  y_value << 0.3, -0.9, 0.5;
+
+  Eigen::VectorXd alpha(N);
+  alpha << 0.3, 0.8, 1.0;
+  Eigen::VectorXd alpha_size(N - 1);
+  alpha_size << 0.3, 0.8;
+  Eigen::VectorXd alpha_value(N);
+  alpha_value << 0.3, 0, 0.5;
+
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+  Eigen::VectorXd sigma_size(N - 1);
+  sigma_size << 0.3, 0.8;
+  Eigen::VectorXd sigma_value(N);
+  sigma_value << 0.3, 0, 0.5;
+
+  stan::math::matrix_cl<double> y_cl(y);
+  stan::math::matrix_cl<double> y_size_cl(y_size);
+  stan::math::matrix_cl<double> y_value_cl(y_value);
+  stan::math::matrix_cl<double> alpha_cl(alpha);
+  stan::math::matrix_cl<double> alpha_size_cl(alpha_size);
+  stan::math::matrix_cl<double> alpha_value_cl(alpha_value);
+  stan::math::matrix_cl<double> sigma_cl(sigma);
+  stan::math::matrix_cl<double> sigma_size_cl(sigma_size);
+  stan::math::matrix_cl<double> sigma_value_cl(sigma_value);
+
+  EXPECT_NO_THROW(stan::math::weibull_cdf(y_cl, alpha_cl, sigma_cl));
+
+  EXPECT_THROW(stan::math::weibull_cdf(y_size_cl, alpha_cl, sigma_cl),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::weibull_cdf(y_cl, alpha_size_cl, sigma_cl),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::weibull_cdf(y_cl, alpha_cl, sigma_size_cl),
+               std::invalid_argument);
+
+  EXPECT_THROW(stan::math::weibull_cdf(y_value_cl, alpha_cl, sigma_cl),
+               std::domain_error);
+  EXPECT_THROW(stan::math::weibull_cdf(y_cl, alpha_value_cl, sigma_cl),
+               std::domain_error);
+  EXPECT_THROW(stan::math::weibull_cdf(y_cl, alpha_cl, sigma_value_cl),
+               std::domain_error);
+}
+
+auto weibull_cdf_functor = [](const auto& y, const auto& alpha, const auto& sigma) {
+  return stan::math::weibull_cdf(y, alpha, sigma);
+};
+
+TEST(ProbDistributionsWeibullCdf, opencl_matches_cpu_small) {
+  int N = 3;
+  int M = 2;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  Eigen::VectorXd alpha(N);
+  alpha << 0.3, 0.8, 1.0;
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+
+  stan::math::test::compare_cpu_opencl_prim_rev(weibull_cdf_functor, y, alpha,
+                                                sigma);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      weibull_cdf_functor, y.transpose().eval(), alpha.transpose().eval(),
+      sigma.transpose().eval());
+}
+
+TEST(ProbDistributionsWeibullCdf, opencl_broadcast_y) {
+  int N = 3;
+
+  double y_scal = 12.3;
+  Eigen::VectorXd alpha(N);
+  alpha << 0.5, 1.2, 1.0;
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(weibull_cdf_functor,
+                                                         y_scal, alpha, sigma);
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(
+      weibull_cdf_functor, y_scal, alpha.transpose().eval(), sigma);
+}
+
+TEST(ProbDistributionsWeibullCdf, opencl_broadcast_alpha) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  double alpha_scal = 12.3;
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<1>(weibull_cdf_functor, y,
+                                                         alpha_scal, sigma);
+  stan::math::test::test_opencl_broadcasting_prim_rev<1>(
+      weibull_cdf_functor, y.transpose().eval(), alpha_scal, sigma);
+}
+
+TEST(ProbDistributionsWeibullCdf, opencl_broadcast_sigma) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  Eigen::VectorXd alpha(N);
+  alpha << 0.3, 0.8, 1.0;
+  double sigma_scal = 12.3;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<2>(weibull_cdf_functor, y,
+                                                         alpha, sigma_scal);
+  stan::math::test::test_opencl_broadcasting_prim_rev<2>(
+      weibull_cdf_functor, y.transpose().eval(), alpha, sigma_scal);
+}
+
+TEST(ProbDistributionsWeibullCdf, opencl_matches_cpu_big) {
+  int N = 153;
+
+  Eigen::Matrix<double, Eigen::Dynamic, 1> y
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+  Eigen::Matrix<double, Eigen::Dynamic, 1> alpha
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+  Eigen::Matrix<double, Eigen::Dynamic, 1> sigma
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+
+  stan::math::test::compare_cpu_opencl_prim_rev(weibull_cdf_functor, y, alpha,
+                                                sigma);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      weibull_cdf_functor, y.transpose().eval(), alpha.transpose().eval(),
+      sigma.transpose().eval());
+}
+#endif

--- a/test/unit/math/opencl/rev/weibull_cdf_test.cpp
+++ b/test/unit/math/opencl/rev/weibull_cdf_test.cpp
@@ -56,9 +56,10 @@ TEST(ProbDistributionsWeibullCdf, error_checking) {
                std::domain_error);
 }
 
-auto weibull_cdf_functor = [](const auto& y, const auto& alpha, const auto& sigma) {
-  return stan::math::weibull_cdf(y, alpha, sigma);
-};
+auto weibull_cdf_functor
+    = [](const auto& y, const auto& alpha, const auto& sigma) {
+        return stan::math::weibull_cdf(y, alpha, sigma);
+      };
 
 TEST(ProbDistributionsWeibullCdf, opencl_matches_cpu_small) {
   int N = 3;

--- a/test/unit/math/opencl/rev/weibull_lccdf_test.cpp
+++ b/test/unit/math/opencl/rev/weibull_lccdf_test.cpp
@@ -56,9 +56,10 @@ TEST(ProbDistributionsWeibullLccdf, error_checking) {
                std::domain_error);
 }
 
-auto weibull_lccdf_functor = [](const auto& y, const auto& alpha, const auto& sigma) {
-  return stan::math::weibull_lccdf(y, alpha, sigma);
-};
+auto weibull_lccdf_functor
+    = [](const auto& y, const auto& alpha, const auto& sigma) {
+        return stan::math::weibull_lccdf(y, alpha, sigma);
+      };
 
 TEST(ProbDistributionsWeibullLccdf, opencl_matches_cpu_small) {
   int N = 3;
@@ -102,8 +103,8 @@ TEST(ProbDistributionsWeibullLccdf, opencl_broadcast_alpha) {
   Eigen::VectorXd sigma(N);
   sigma << 0.3, 0.8, 1.0;
 
-  stan::math::test::test_opencl_broadcasting_prim_rev<1>(weibull_lccdf_functor, y,
-                                                         alpha_scal, sigma);
+  stan::math::test::test_opencl_broadcasting_prim_rev<1>(weibull_lccdf_functor,
+                                                         y, alpha_scal, sigma);
   stan::math::test::test_opencl_broadcasting_prim_rev<1>(
       weibull_lccdf_functor, y.transpose().eval(), alpha_scal, sigma);
 }
@@ -117,8 +118,8 @@ TEST(ProbDistributionsWeibullLccdf, opencl_broadcast_sigma) {
   alpha << 0.3, 0.8, 1.0;
   double sigma_scal = 12.3;
 
-  stan::math::test::test_opencl_broadcasting_prim_rev<2>(weibull_lccdf_functor, y,
-                                                         alpha, sigma_scal);
+  stan::math::test::test_opencl_broadcasting_prim_rev<2>(weibull_lccdf_functor,
+                                                         y, alpha, sigma_scal);
   stan::math::test::test_opencl_broadcasting_prim_rev<2>(
       weibull_lccdf_functor, y.transpose().eval(), alpha, sigma_scal);
 }

--- a/test/unit/math/opencl/rev/weibull_lccdf_test.cpp
+++ b/test/unit/math/opencl/rev/weibull_lccdf_test.cpp
@@ -1,0 +1,142 @@
+#ifdef STAN_OPENCL
+#include <stan/math/opencl/rev.hpp>
+#include <stan/math.hpp>
+#include <gtest/gtest.h>
+#include <test/unit/math/opencl/util.hpp>
+#include <vector>
+
+TEST(ProbDistributionsWeibullLccdf, error_checking) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  Eigen::VectorXd y_size(N - 1);
+  y_size << 0.3, 0.8;
+  Eigen::VectorXd y_value(N);
+  y_value << 0.3, -0.9, 0.5;
+
+  Eigen::VectorXd alpha(N);
+  alpha << 0.3, 0.8, 1.0;
+  Eigen::VectorXd alpha_size(N - 1);
+  alpha_size << 0.3, 0.8;
+  Eigen::VectorXd alpha_value(N);
+  alpha_value << 0.3, 0, 0.5;
+
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+  Eigen::VectorXd sigma_size(N - 1);
+  sigma_size << 0.3, 0.8;
+  Eigen::VectorXd sigma_value(N);
+  sigma_value << 0.3, 0, 0.5;
+
+  stan::math::matrix_cl<double> y_cl(y);
+  stan::math::matrix_cl<double> y_size_cl(y_size);
+  stan::math::matrix_cl<double> y_value_cl(y_value);
+  stan::math::matrix_cl<double> alpha_cl(alpha);
+  stan::math::matrix_cl<double> alpha_size_cl(alpha_size);
+  stan::math::matrix_cl<double> alpha_value_cl(alpha_value);
+  stan::math::matrix_cl<double> sigma_cl(sigma);
+  stan::math::matrix_cl<double> sigma_size_cl(sigma_size);
+  stan::math::matrix_cl<double> sigma_value_cl(sigma_value);
+
+  EXPECT_NO_THROW(stan::math::weibull_lccdf(y_cl, alpha_cl, sigma_cl));
+
+  EXPECT_THROW(stan::math::weibull_lccdf(y_size_cl, alpha_cl, sigma_cl),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::weibull_lccdf(y_cl, alpha_size_cl, sigma_cl),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::weibull_lccdf(y_cl, alpha_cl, sigma_size_cl),
+               std::invalid_argument);
+
+  EXPECT_THROW(stan::math::weibull_lccdf(y_value_cl, alpha_cl, sigma_cl),
+               std::domain_error);
+  EXPECT_THROW(stan::math::weibull_lccdf(y_cl, alpha_value_cl, sigma_cl),
+               std::domain_error);
+  EXPECT_THROW(stan::math::weibull_lccdf(y_cl, alpha_cl, sigma_value_cl),
+               std::domain_error);
+}
+
+auto weibull_lccdf_functor = [](const auto& y, const auto& alpha, const auto& sigma) {
+  return stan::math::weibull_lccdf(y, alpha, sigma);
+};
+
+TEST(ProbDistributionsWeibullLccdf, opencl_matches_cpu_small) {
+  int N = 3;
+  int M = 2;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  Eigen::VectorXd alpha(N);
+  alpha << 0.3, 0.8, 1.0;
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+
+  stan::math::test::compare_cpu_opencl_prim_rev(weibull_lccdf_functor, y, alpha,
+                                                sigma);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      weibull_lccdf_functor, y.transpose().eval(), alpha.transpose().eval(),
+      sigma.transpose().eval());
+}
+
+TEST(ProbDistributionsWeibullLccdf, opencl_broadcast_y) {
+  int N = 3;
+
+  double y_scal = 12.3;
+  Eigen::VectorXd alpha(N);
+  alpha << 0.5, 1.2, 1.0;
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(weibull_lccdf_functor,
+                                                         y_scal, alpha, sigma);
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(
+      weibull_lccdf_functor, y_scal, alpha.transpose().eval(), sigma);
+}
+
+TEST(ProbDistributionsWeibullLccdf, opencl_broadcast_alpha) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  double alpha_scal = 12.3;
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<1>(weibull_lccdf_functor, y,
+                                                         alpha_scal, sigma);
+  stan::math::test::test_opencl_broadcasting_prim_rev<1>(
+      weibull_lccdf_functor, y.transpose().eval(), alpha_scal, sigma);
+}
+
+TEST(ProbDistributionsWeibullLccdf, opencl_broadcast_sigma) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  Eigen::VectorXd alpha(N);
+  alpha << 0.3, 0.8, 1.0;
+  double sigma_scal = 12.3;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<2>(weibull_lccdf_functor, y,
+                                                         alpha, sigma_scal);
+  stan::math::test::test_opencl_broadcasting_prim_rev<2>(
+      weibull_lccdf_functor, y.transpose().eval(), alpha, sigma_scal);
+}
+
+TEST(ProbDistributionsWeibullLccdf, opencl_matches_cpu_big) {
+  int N = 153;
+
+  Eigen::Matrix<double, Eigen::Dynamic, 1> y
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+  Eigen::Matrix<double, Eigen::Dynamic, 1> alpha
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+  Eigen::Matrix<double, Eigen::Dynamic, 1> sigma
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+
+  stan::math::test::compare_cpu_opencl_prim_rev(weibull_lccdf_functor, y, alpha,
+                                                sigma);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      weibull_lccdf_functor, y.transpose().eval(), alpha.transpose().eval(),
+      sigma.transpose().eval());
+}
+#endif

--- a/test/unit/math/opencl/rev/weibull_lcdf_test.cpp
+++ b/test/unit/math/opencl/rev/weibull_lcdf_test.cpp
@@ -56,9 +56,10 @@ TEST(ProbDistributionsWeibullLcdf, error_checking) {
                std::domain_error);
 }
 
-auto weibull_lcdf_functor = [](const auto& y, const auto& alpha, const auto& sigma) {
-  return stan::math::weibull_lcdf(y, alpha, sigma);
-};
+auto weibull_lcdf_functor
+    = [](const auto& y, const auto& alpha, const auto& sigma) {
+        return stan::math::weibull_lcdf(y, alpha, sigma);
+      };
 
 TEST(ProbDistributionsWeibullLcdf, opencl_matches_cpu_small) {
   int N = 3;
@@ -102,8 +103,8 @@ TEST(ProbDistributionsWeibullLcdf, opencl_broadcast_alpha) {
   Eigen::VectorXd sigma(N);
   sigma << 0.3, 0.8, 1.0;
 
-  stan::math::test::test_opencl_broadcasting_prim_rev<1>(weibull_lcdf_functor, y,
-                                                         alpha_scal, sigma);
+  stan::math::test::test_opencl_broadcasting_prim_rev<1>(weibull_lcdf_functor,
+                                                         y, alpha_scal, sigma);
   stan::math::test::test_opencl_broadcasting_prim_rev<1>(
       weibull_lcdf_functor, y.transpose().eval(), alpha_scal, sigma);
 }
@@ -117,8 +118,8 @@ TEST(ProbDistributionsWeibullLcdf, opencl_broadcast_sigma) {
   alpha << 0.3, 0.8, 1.0;
   double sigma_scal = 12.3;
 
-  stan::math::test::test_opencl_broadcasting_prim_rev<2>(weibull_lcdf_functor, y,
-                                                         alpha, sigma_scal);
+  stan::math::test::test_opencl_broadcasting_prim_rev<2>(weibull_lcdf_functor,
+                                                         y, alpha, sigma_scal);
   stan::math::test::test_opencl_broadcasting_prim_rev<2>(
       weibull_lcdf_functor, y.transpose().eval(), alpha, sigma_scal);
 }

--- a/test/unit/math/opencl/rev/weibull_lcdf_test.cpp
+++ b/test/unit/math/opencl/rev/weibull_lcdf_test.cpp
@@ -1,0 +1,142 @@
+#ifdef STAN_OPENCL
+#include <stan/math/opencl/rev.hpp>
+#include <stan/math.hpp>
+#include <gtest/gtest.h>
+#include <test/unit/math/opencl/util.hpp>
+#include <vector>
+
+TEST(ProbDistributionsWeibullLcdf, error_checking) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  Eigen::VectorXd y_size(N - 1);
+  y_size << 0.3, 0.8;
+  Eigen::VectorXd y_value(N);
+  y_value << 0.3, -0.9, 0.5;
+
+  Eigen::VectorXd alpha(N);
+  alpha << 0.3, 0.8, 1.0;
+  Eigen::VectorXd alpha_size(N - 1);
+  alpha_size << 0.3, 0.8;
+  Eigen::VectorXd alpha_value(N);
+  alpha_value << 0.3, 0, 0.5;
+
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+  Eigen::VectorXd sigma_size(N - 1);
+  sigma_size << 0.3, 0.8;
+  Eigen::VectorXd sigma_value(N);
+  sigma_value << 0.3, 0, 0.5;
+
+  stan::math::matrix_cl<double> y_cl(y);
+  stan::math::matrix_cl<double> y_size_cl(y_size);
+  stan::math::matrix_cl<double> y_value_cl(y_value);
+  stan::math::matrix_cl<double> alpha_cl(alpha);
+  stan::math::matrix_cl<double> alpha_size_cl(alpha_size);
+  stan::math::matrix_cl<double> alpha_value_cl(alpha_value);
+  stan::math::matrix_cl<double> sigma_cl(sigma);
+  stan::math::matrix_cl<double> sigma_size_cl(sigma_size);
+  stan::math::matrix_cl<double> sigma_value_cl(sigma_value);
+
+  EXPECT_NO_THROW(stan::math::weibull_lcdf(y_cl, alpha_cl, sigma_cl));
+
+  EXPECT_THROW(stan::math::weibull_lcdf(y_size_cl, alpha_cl, sigma_cl),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::weibull_lcdf(y_cl, alpha_size_cl, sigma_cl),
+               std::invalid_argument);
+  EXPECT_THROW(stan::math::weibull_lcdf(y_cl, alpha_cl, sigma_size_cl),
+               std::invalid_argument);
+
+  EXPECT_THROW(stan::math::weibull_lcdf(y_value_cl, alpha_cl, sigma_cl),
+               std::domain_error);
+  EXPECT_THROW(stan::math::weibull_lcdf(y_cl, alpha_value_cl, sigma_cl),
+               std::domain_error);
+  EXPECT_THROW(stan::math::weibull_lcdf(y_cl, alpha_cl, sigma_value_cl),
+               std::domain_error);
+}
+
+auto weibull_lcdf_functor = [](const auto& y, const auto& alpha, const auto& sigma) {
+  return stan::math::weibull_lcdf(y, alpha, sigma);
+};
+
+TEST(ProbDistributionsWeibullLcdf, opencl_matches_cpu_small) {
+  int N = 3;
+  int M = 2;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  Eigen::VectorXd alpha(N);
+  alpha << 0.3, 0.8, 1.0;
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+
+  stan::math::test::compare_cpu_opencl_prim_rev(weibull_lcdf_functor, y, alpha,
+                                                sigma);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      weibull_lcdf_functor, y.transpose().eval(), alpha.transpose().eval(),
+      sigma.transpose().eval());
+}
+
+TEST(ProbDistributionsWeibullLcdf, opencl_broadcast_y) {
+  int N = 3;
+
+  double y_scal = 12.3;
+  Eigen::VectorXd alpha(N);
+  alpha << 0.5, 1.2, 1.0;
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(weibull_lcdf_functor,
+                                                         y_scal, alpha, sigma);
+  stan::math::test::test_opencl_broadcasting_prim_rev<0>(
+      weibull_lcdf_functor, y_scal, alpha.transpose().eval(), sigma);
+}
+
+TEST(ProbDistributionsWeibullLcdf, opencl_broadcast_alpha) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  double alpha_scal = 12.3;
+  Eigen::VectorXd sigma(N);
+  sigma << 0.3, 0.8, 1.0;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<1>(weibull_lcdf_functor, y,
+                                                         alpha_scal, sigma);
+  stan::math::test::test_opencl_broadcasting_prim_rev<1>(
+      weibull_lcdf_functor, y.transpose().eval(), alpha_scal, sigma);
+}
+
+TEST(ProbDistributionsWeibullLcdf, opencl_broadcast_sigma) {
+  int N = 3;
+
+  Eigen::VectorXd y(N);
+  y << 0.3, 0.8, 1.0;
+  Eigen::VectorXd alpha(N);
+  alpha << 0.3, 0.8, 1.0;
+  double sigma_scal = 12.3;
+
+  stan::math::test::test_opencl_broadcasting_prim_rev<2>(weibull_lcdf_functor, y,
+                                                         alpha, sigma_scal);
+  stan::math::test::test_opencl_broadcasting_prim_rev<2>(
+      weibull_lcdf_functor, y.transpose().eval(), alpha, sigma_scal);
+}
+
+TEST(ProbDistributionsWeibullLcdf, opencl_matches_cpu_big) {
+  int N = 153;
+
+  Eigen::Matrix<double, Eigen::Dynamic, 1> y
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+  Eigen::Matrix<double, Eigen::Dynamic, 1> alpha
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+  Eigen::Matrix<double, Eigen::Dynamic, 1> sigma
+      = Eigen::Array<double, Eigen::Dynamic, 1>::Random(N, 1).abs();
+
+  stan::math::test::compare_cpu_opencl_prim_rev(weibull_lcdf_functor, y, alpha,
+                                                sigma);
+  stan::math::test::compare_cpu_opencl_prim_rev(
+      weibull_lcdf_functor, y.transpose().eval(), alpha.transpose().eval(),
+      sigma.transpose().eval());
+}
+#endif


### PR DESCRIPTION
## Summary

Added OpenCL implementations for functions `weibull_cdf`, `weibull_lccdf` and `weibull_lcdf`.

## Tests

New functions are tested.

## Side Effects
None.

## Release notes

OpenCL: Added OpenCL implementations for functions `weibull_cdf`, `weibull_lccdf` and `weibull_lcdf`.

## Checklist

- [ ] Math issue #2152

- [ ] Copyright holder: Tadej Ciglarič

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [ ] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [ ] the code is written in idiomatic C++ and changes are documented in the doxygen

- [ ] the new changes are tested
