### PR TITLE
README: example: Update to oneTBB 2021.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ To build the development version of `math` with [`oneTBB`](https://github.com/on
 
 For example, installing [`oneTBB`](https://github.com/oneapi-src/oneTBB) on Linux 64-bit (`x86_64`) to `$HOME` directory (change if needed!):
 ```bash
-TBB_VERSION="2021.1.1"
+TBB_VERSION="2021.2.0"
 
 wget https://github.com/oneapi-src/oneTBB/releases/download/v${TBB_VERSION}/oneapi-tbb-${TBB_VERSION}-lin.tgz
 tar zxvf oneapi-tbb-$TBB_VERSION-lin.tgz -C $HOME

--- a/README.md
+++ b/README.md
@@ -119,13 +119,16 @@ To build the development version of `math` with [`oneTBB`](https://github.com/on
 
 For example, installing [`oneTBB`](https://github.com/oneapi-src/oneTBB) on Linux 64-bit (`x86_64`) to `$HOME` directory (change if needed!):
 ```bash
-TBB_VERSION="2021.2.0"
+TBB_RELEASE="https://api.github.com/repos/oneapi-src/oneTBB/releases/latest"
+TBB_TAG=$(curl --silent $TBB_RELEASE | grep -Po '"tag_name": "\K.*?(?=")')
+TBB_VERSION=${TBB_TAG#?}
 
 wget https://github.com/oneapi-src/oneTBB/releases/download/v${TBB_VERSION}/oneapi-tbb-${TBB_VERSION}-lin.tgz
 tar zxvf oneapi-tbb-$TBB_VERSION-lin.tgz -C $HOME
 
 export TBB="$HOME/oneapi-tbb-$TBB_VERSION"
 ```
+Note that you may replace `TBB_VERSION=${TBB_TAG#?}` with a custom version number if needed ( check available releases [here](https://github.com/oneapi-src/oneTBB/releases) ).
 
 - Set the TBB environment variables (specifically: `TBB` for the installation prefix, `TBB_INC` for the directory that includes the header files, and `TBB_LIB` for the libraries directory).
 


### PR DESCRIPTION
Use [the latest release of `oneTBB`](https://github.com/oneapi-src/oneTBB/releases/tag/v2021.2.0) in the README example.