### PR TITLE
Fix apply_scalar_unary with unsigned and long arithmetic types

### DIFF
--- a/stan/math/prim/functor/apply_scalar_unary.hpp
+++ b/stan/math/prim/functor/apply_scalar_unary.hpp
@@ -3,6 +3,7 @@
 
 #include <stan/math/prim/fun/Eigen.hpp>
 #include <stan/math/prim/meta/is_eigen.hpp>
+#include <stan/math/prim/meta/require_generics.hpp>
 #include <stan/math/prim/meta/is_vector.hpp>
 #include <stan/math/prim/meta/is_vector_like.hpp>
 #include <stan/math/prim/meta/plain_type.hpp>
@@ -80,8 +81,8 @@ struct apply_scalar_unary<F, T, require_eigen_t<T>> {
  *
  * @tparam F Type of function defining static apply function.
  */
-template <typename F>
-struct apply_scalar_unary<F, double> {
+template <typename F, typename T>
+struct apply_scalar_unary<F, T, require_floating_point_t<T>> {
   /**
    * The return type, double.
    */
@@ -96,7 +97,7 @@ struct apply_scalar_unary<F, double> {
    * @param x Argument scalar.
    * @return Result of applying F to the scalar.
    */
-  static inline return_t apply(double x) { return F::fun(x); }
+  static inline return_t apply(T x) { return F::fun(x); }
 };
 
 /**
@@ -107,8 +108,8 @@ struct apply_scalar_unary<F, double> {
  *
  * @tparam F Type of function defining static apply function.
  */
-template <typename F>
-struct apply_scalar_unary<F, int> {
+template <typename F, typename T>
+struct apply_scalar_unary<F, T, require_integral_t<T>> {
   /**
    * The return type, double.
    */
@@ -123,7 +124,7 @@ struct apply_scalar_unary<F, int> {
    * @param x Argument scalar.
    * @return Result of applying F to the scalar.
    */
-  static inline return_t apply(int x) { return F::fun(static_cast<double>(x)); }
+  static inline return_t apply(T x) { return F::fun(static_cast<double>(x)); }
 };
 
 /**

--- a/test/unit/math/prim/fun/sqrt_test.cpp
+++ b/test/unit/math/prim/fun/sqrt_test.cpp
@@ -6,4 +6,11 @@ TEST(MathFunctions, sqrtInt) {
   EXPECT_FLOAT_EQ(std::sqrt(3.0), sqrt(3));
   EXPECT_FLOAT_EQ(std::sqrt(3.1), sqrt(3.1));
   EXPECT_TRUE(stan::math::is_nan(sqrt(-2)));
+
+  uint32_t ulong = 1;
+  uint64_t ulonglong = 1;
+  long double ldouble = 1.5;
+  EXPECT_FLOAT_EQ(std::sqrt(ulong), sqrt(ulong));
+  EXPECT_FLOAT_EQ(std::sqrt(ulonglong), sqrt(ulonglong));
+  EXPECT_FLOAT_EQ(std::sqrt(ldouble), sqrt(ldouble));
 }


### PR DESCRIPTION
## Summary

Functions using `apply_scalar_unary` will fail to compile if a `long` / `unsigned long` type is passed. This is because `apply_scalar_unary` uses explicit specialisations for `double` and `int` types. This PR changes that to use `require_floating_point` and `require_integral`so that the appropriate specialisation is detected.

## Tests

Tests are added for `long double`, `uint32`, and `uint64` types.

## Side Effects

N/A

## Release notes

Fix compilation errors when using `unsigned` and `long` types with `apply_scalar_unary`

## Checklist

- [x] Math issue #2385 

- [x] Copyright holder: Andrew Johnson

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
