### PR TITLE
Add kernel generator cast operation

### DIFF
--- a/stan/math/opencl/kernel_generator.hpp
+++ b/stan/math/opencl/kernel_generator.hpp
@@ -131,6 +131,7 @@
 #include <stan/math/opencl/kernel_generator/index.hpp>
 #include <stan/math/opencl/kernel_generator/indexing.hpp>
 #include <stan/math/opencl/kernel_generator/opencl_code.hpp>
+#include <stan/math/opencl/kernel_generator/cast.hpp>
 
 #include <stan/math/opencl/kernel_generator/multi_result_kernel.hpp>
 #include <stan/math/opencl/kernel_generator/get_kernel_source_for_evaluating_into.hpp>

--- a/stan/math/opencl/kernel_generator/cast.hpp
+++ b/stan/math/opencl/kernel_generator/cast.hpp
@@ -39,7 +39,7 @@ class cast_ : public operation_cl<cast_<Scal, T>, Scal, T> {
    * Constructor
    * @param args argument expression(s)
    */
-  cast_(T&& arg) : base(std::forward<T>(arg)) {}
+  explicit cast_(T&& arg) : base(std::forward<T>(arg)) {}
 
   /**
    * Generates kernel code for this expression.

--- a/stan/math/opencl/kernel_generator/cast.hpp
+++ b/stan/math/opencl/kernel_generator/cast.hpp
@@ -1,0 +1,102 @@
+#ifndef STAN_MATH_OPENCL_KERNEL_GENERATOR_CAST_HPP
+#define STAN_MATH_OPENCL_KERNEL_GENERATOR_CAST_HPP
+#ifdef STAN_OPENCL
+
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/opencl/matrix_cl_view.hpp>
+#include <stan/math/opencl/kernel_generator/common_return_scalar.hpp>
+#include <stan/math/opencl/kernel_generator/type_str.hpp>
+#include <stan/math/opencl/kernel_generator/name_generator.hpp>
+#include <stan/math/opencl/kernel_generator/operation_cl.hpp>
+#include <stan/math/opencl/kernel_generator/as_operation_cl.hpp>
+#include <array>
+#include <string>
+#include <type_traits>
+#include <set>
+#include <utility>
+
+namespace stan {
+namespace math {
+
+/** \addtogroup opencl_kernel_generator
+ *  @{
+ */
+
+/**
+ * Represents a typecast os scalar in kernel generator expressions.
+ * @tparam Derived derived type
+ * @tparam T type of argument
+ * @tparam Scal type of the scalar of result
+ */
+template <typename Scal, typename T>
+class cast_ : public operation_cl<cast_<Scal, T>, Scal, T> {
+ public:
+  using Scalar = Scal;
+  using base = operation_cl<cast_<Scal, T>, Scalar, T>;
+  using base::var_name_;
+
+  /**
+   * Constructor
+   * @param args argument expression(s)
+   */
+  cast_(T&& arg) : base(std::forward<T>(arg)) {}
+
+  /**
+   * Generates kernel code for this expression.
+   * @param row_index_name row index variable name
+   * @param col_index_name column index variable name
+   * @param view_handled whether whether caller already handled matrix view
+   * @param var_names_arg variable names of the nested expressions
+   * @return part of kernel with code for this expression
+   */
+  inline kernel_parts generate(const std::string& row_index_name,
+                               const std::string& col_index_name,
+                               const bool view_handled,
+                               const std::string& var_name_arg) const {
+    kernel_parts res{};
+
+    res.body = type_str<Scalar>() + " " + var_name_ + " = ("
+               + type_str<Scalar>() + ")" + var_name_arg + ";\n";
+    return res;
+  }
+
+  inline auto deep_copy() const {
+    auto&& arg_copy = this->template get_arg<0>().deep_copy();
+    return cast_<Scalar, std::remove_reference_t<decltype(arg_copy)>>{
+        std::move(arg_copy)};
+  }
+};
+
+/**
+ * Typecast a kernel generator expression scalar.
+ *
+ * @tparam T type of argument
+ * @param a input argument
+ * @return Typecast of given expression
+ */
+template <typename Scalar, typename T,
+          require_all_kernel_expressions_and_none_scalar_t<T>* = nullptr>
+inline auto cast(T&& a) {
+  auto&& a_operation = as_operation_cl(std::forward<T>(a)).deep_copy();
+  return cast_<Scalar, std::remove_reference_t<decltype(a_operation)>>(
+      std::move(a_operation));
+}
+
+/**
+ * Typecast a scalar.
+ *
+ * @tparam T type of argument
+ * @param a input argument
+ * @return Typecast of given expression
+ */
+template <typename Scalar, typename T,
+          require_stan_scalar_t<T>* = nullptr>
+inline Scalar cast(T a) {
+  return a;
+}
+
+/** @}*/
+}  // namespace math
+}  // namespace stan
+#endif
+#endif

--- a/stan/math/opencl/prim/bernoulli_cdf.hpp
+++ b/stan/math/opencl/prim/bernoulli_cdf.hpp
@@ -49,13 +49,13 @@ return_type_t<T_prob_cl> bernoulli_cdf(const T_n_cl& n,
                                       theta_val, "in the interval [0, 1]");
   auto theta_bounded_expr = 0.0 <= theta_val && theta_val <= 1.0;
 
-  auto any_n_negative = colwise_max(constant(0, N, 1) + (n < 0));
+  auto any_n_negative = colwise_max(cast<char>(n < 0));
   auto cond = n >= 1;
   auto Pi_uncond = 1.0 - theta_val;
   auto Pi = select(cond, INFTY, Pi_uncond);
   auto P_expr = colwise_prod(select(cond, 1.0, Pi_uncond));
 
-  matrix_cl<double> any_n_negative_cl;
+  matrix_cl<char> any_n_negative_cl;
   matrix_cl<double> Pi_cl;
   matrix_cl<double> P_cl;
 

--- a/stan/math/opencl/prim/bernoulli_lccdf.hpp
+++ b/stan/math/opencl/prim/bernoulli_lccdf.hpp
@@ -50,13 +50,13 @@ return_type_t<T_prob_cl> bernoulli_lccdf(const T_n_cl& n,
                                       theta_val, "in the interval [0, 1]");
   auto theta_bounded_expr = 0.0 <= theta_val && theta_val <= 1.0;
 
-  auto any_n_negative = colwise_max(0 + (n < 0));
-  auto any_n_over_one = colwise_max(constant(0, N, 1) + (n >= 1));
+  auto any_n_negative = colwise_max(cast<char>(n < 0));
+  auto any_n_over_one = colwise_max(cast<char>(n >= 1));
   auto P_expr = colwise_sum(log(theta_val));
   auto deriv = elt_divide(1.0, theta_val);
 
-  matrix_cl<double> any_n_negative_cl;
-  matrix_cl<double> any_n_over_one_cl;
+  matrix_cl<char> any_n_negative_cl;
+  matrix_cl<char> any_n_over_one_cl;
   matrix_cl<double> P_cl;
   matrix_cl<double> deriv_cl;
 

--- a/stan/math/opencl/prim/bernoulli_lcdf.hpp
+++ b/stan/math/opencl/prim/bernoulli_lcdf.hpp
@@ -50,13 +50,13 @@ return_type_t<T_prob_cl> bernoulli_lcdf(const T_n_cl& n,
                                       theta_val, "in the interval [0, 1]");
   auto theta_bounded_expr = 0.0 <= theta_val && theta_val <= 1.0;
 
-  auto any_n_negative = colwise_max(0 + (n < 0));
+  auto any_n_negative = colwise_max(cast<char>(n < 0));
   auto Pi = 1.0 - theta_val;
   auto cond = n >= 1;
   auto P_expr = colwise_sum(select(cond, 0.0, log(Pi)));
   auto deriv = select(cond, 0.0, elt_divide(-1.0, Pi));
 
-  matrix_cl<double> any_n_negative_cl;
+  matrix_cl<char> any_n_negative_cl;
   matrix_cl<double> P_cl;
   matrix_cl<double> deriv_cl;
 

--- a/stan/math/opencl/prim/cauchy_cdf.hpp
+++ b/stan/math/opencl/prim/cauchy_cdf.hpp
@@ -64,7 +64,7 @@ return_type_t<T_y_cl, T_loc_cl, T_scale_cl> cauchy_cdf(
   auto sigma_positive_finite_expr = 0 < sigma_val && isfinite(sigma_val);
 
   auto any_y_neg_inf
-      = colwise_max(constant(0, N, 1) + (y_val == NEGATIVE_INFTY));
+      = colwise_max(cast<char>(y_val == NEGATIVE_INFTY));
   auto cond = y_val == INFTY;
   auto sigma_inv = elt_divide(1.0, sigma_val);
   auto z = elt_multiply(y_val - mu_val, sigma_inv);
@@ -76,7 +76,7 @@ return_type_t<T_y_cl, T_loc_cl, T_scale_cl> cauchy_cdf(
       elt_divide(sigma_inv, -pi() * elt_multiply(1.0 + square(z), Pn)));
   auto sigma_deriv_tmp = elt_multiply(z, mu_deriv_tmp);
 
-  matrix_cl<double> any_y_neg_inf_cl;
+  matrix_cl<char> any_y_neg_inf_cl;
   matrix_cl<double> P_cl;
   matrix_cl<double> mu_deriv_cl;
   matrix_cl<double> y_deriv_cl;

--- a/stan/math/opencl/prim/exp_mod_normal_cdf.hpp
+++ b/stan/math/opencl/prim/exp_mod_normal_cdf.hpp
@@ -73,7 +73,7 @@ return_type_t<T_y_cl, T_loc_cl, T_scale_cl, T_inv_scale_cl> exp_mod_normal_cdf(
   auto lambda_positive_finite_expr = 0 < lambda_val && isfinite(lambda_val);
 
   auto any_y_neg_inf
-      = colwise_max(constant(0, N, 1) + (y_val == NEGATIVE_INFTY));
+      = colwise_max(cast<char>(y_val == NEGATIVE_INFTY));
   auto inv_sigma = elt_divide(1.0, sigma_val);
   auto diff = y_val - mu_val;
   auto v = elt_multiply(lambda_val, sigma_val);
@@ -102,7 +102,7 @@ return_type_t<T_y_cl, T_loc_cl, T_scale_cl, T_inv_scale_cl> exp_mod_normal_cdf(
               - elt_multiply(elt_multiply(v, sigma_val) - diff, erf_calc)),
       cdf_n);
 
-  matrix_cl<double> any_y_neg_inf_cl;
+  matrix_cl<char> any_y_neg_inf_cl;
   matrix_cl<double> cdf_cl;
   matrix_cl<double> y_deriv_cl;
   matrix_cl<double> mu_deriv_cl;

--- a/stan/math/opencl/prim/exp_mod_normal_lccdf.hpp
+++ b/stan/math/opencl/prim/exp_mod_normal_lccdf.hpp
@@ -74,8 +74,8 @@ exp_mod_normal_lccdf(const T_y_cl& y, const T_loc_cl& mu,
   auto lambda_positive_finite_expr = 0 < lambda_val && isfinite(lambda_val);
 
   auto any_y_neg_inf
-      = colwise_max(constant(0, N, 1) + (y_val == NEGATIVE_INFTY));
-  auto any_y_pos_inf = colwise_max(constant(0, N, 1) + (y_val == INFTY));
+      = colwise_max(cast<char>(y_val == NEGATIVE_INFTY));
+  auto any_y_pos_inf = colwise_max(cast<char>(y_val == INFTY));
   auto inv_sigma = elt_divide(1.0, sigma_val);
   auto diff = y_val - mu_val;
   auto scaled_diff = elt_multiply(diff, inv_sigma * INV_SQRT_TWO);
@@ -104,8 +104,8 @@ exp_mod_normal_lccdf(const T_y_cl& y, const T_loc_cl& mu,
                        - INV_SQRT_TWO_PI * elt_multiply(sigma_val, exp_term_2)),
       ccdf_n);
 
-  matrix_cl<double> any_y_neg_inf_cl;
-  matrix_cl<double> any_y_pos_inf_cl;
+  matrix_cl<char> any_y_neg_inf_cl;
+  matrix_cl<char> any_y_pos_inf_cl;
   matrix_cl<double> ccdf_log_cl;
   matrix_cl<double> mu_deriv_cl;
   matrix_cl<double> y_deriv_cl;

--- a/stan/math/opencl/prim/exp_mod_normal_lcdf.hpp
+++ b/stan/math/opencl/prim/exp_mod_normal_lcdf.hpp
@@ -74,8 +74,8 @@ return_type_t<T_y_cl, T_loc_cl, T_scale_cl, T_inv_scale_cl> exp_mod_normal_lcdf(
   auto lambda_positive_finite_expr = 0 < lambda_val && isfinite(lambda_val);
 
   auto any_y_neg_inf
-      = colwise_max(constant(0, N, 1) + (y_val == NEGATIVE_INFTY));
-  auto any_y_pos_inf = colwise_max(constant(0, N, 1) + (y_val == INFTY));
+      = colwise_max(cast<char>(y_val == NEGATIVE_INFTY));
+  auto any_y_pos_inf = colwise_max(cast<char>(y_val == INFTY));
   auto sigma_inv = elt_divide(1.0, sigma_val);
   auto diff = y_val - mu_val;
   auto scaled_diff = elt_multiply(diff * INV_SQRT_TWO, sigma_inv);
@@ -105,8 +105,8 @@ return_type_t<T_y_cl, T_loc_cl, T_scale_cl, T_inv_scale_cl> exp_mod_normal_lcdf(
               - elt_multiply(elt_multiply(v, sigma_val) - diff, erf_calc)),
       cdf_n);
 
-  matrix_cl<double> any_y_neg_inf_cl;
-  matrix_cl<double> any_y_pos_inf_cl;
+  matrix_cl<char> any_y_neg_inf_cl;
+  matrix_cl<char> any_y_pos_inf_cl;
   matrix_cl<double> cdf_log_cl;
   matrix_cl<double> mu_deriv_cl;
   matrix_cl<double> y_deriv_cl;

--- a/stan/math/opencl/prim/gamma_lpdf.hpp
+++ b/stan/math/opencl/prim/gamma_lpdf.hpp
@@ -80,7 +80,7 @@ return_type_t<T_y_cl, T_shape_cl, T_inv_scale_cl> gamma_lpdf(
                                         beta_val, "positive finite");
   auto beta_pos_finite_expr = beta_val > 0 && isfinite(beta_val);
 
-  auto any_y_negative_expr = colwise_max(constant(0, N, 1) + (y_val < 0));
+  auto any_y_negative_expr = colwise_max(cast<char>(y_val < 0));
   auto log_y_expr = log(y_val);
   auto log_beta_expr = log(beta_val);
   auto logp1_expr = static_select<include_summand<propto, T_shape_cl>::value>(
@@ -99,7 +99,7 @@ return_type_t<T_y_cl, T_shape_cl, T_inv_scale_cl> gamma_lpdf(
   auto alpha_deriv_expr = log_beta_expr + log_y_expr - digamma(alpha_val);
   auto beta_deriv_expr = elt_divide(alpha_val, beta_val) - y_val;
 
-  matrix_cl<int> any_y_negative_cl;
+  matrix_cl<char> any_y_negative_cl;
   matrix_cl<double> logp_cl;
   matrix_cl<double> y_deriv_cl;
   matrix_cl<double> alpha_deriv_cl;

--- a/stan/math/opencl/prim/inv_chi_square_lpdf.hpp
+++ b/stan/math/opencl/prim/inv_chi_square_lpdf.hpp
@@ -74,7 +74,7 @@ return_type_t<T_y_cl, T_dof_cl> inv_chi_square_lpdf(const T_y_cl& y,
       = check_cl(function, "Random variable", y_val, "not NaN");
   auto y_not_nan = !isnan(y_val);
 
-  auto any_y_nonpositive = colwise_max(constant(0, N, 1) + (y_val <= 0));
+  auto any_y_nonpositive = colwise_max(cast<char>(y_val <= 0));
   auto log_y = log(y_val);
   auto half_nu = nu_val * 0.5;
   auto two_over_y = elt_divide(0.5, y_val);
@@ -89,7 +89,7 @@ return_type_t<T_y_cl, T_dof_cl> inv_chi_square_lpdf(const T_y_cl& y,
   auto y_deriv = elt_divide(two_over_y - half_nu - 1.0, y_val);
   auto nu_deriv = -HALF_LOG_TWO - (digamma(half_nu) + log_y) * 0.5;
 
-  matrix_cl<int> any_y_nonpositive_cl;
+  matrix_cl<char> any_y_nonpositive_cl;
   matrix_cl<double> logp_cl;
   matrix_cl<double> y_deriv_cl;
   matrix_cl<double> nu_deriv_cl;

--- a/stan/math/opencl/prim/inv_gamma_lpdf.hpp
+++ b/stan/math/opencl/prim/inv_gamma_lpdf.hpp
@@ -76,7 +76,7 @@ return_type_t<T_y_cl, T_shape_cl, T_scale_cl> inv_gamma_lpdf(
       = check_cl(function, "Scale parameter", beta_val, "positive finite");
   auto beta_pos_finite = beta_val > 0 && isfinite(beta_val);
 
-  auto any_y_nonpositive = colwise_max(constant(0, N, 1) + (y_val <= 0));
+  auto any_y_nonpositive = colwise_max(cast<char>(y_val <= 0));
   auto log_y = log(y_val);
   auto log_beta = log(beta_val);
   auto inv_y = elt_divide(1.0, y_val);
@@ -98,7 +98,7 @@ return_type_t<T_y_cl, T_shape_cl, T_scale_cl> inv_gamma_lpdf(
   auto alpha_deriv = log_beta - digamma(alpha_val) - log_y;
   auto beta_deriv = elt_divide(alpha_val, beta_val) - inv_y;
 
-  matrix_cl<int> any_y_nonpositive_cl;
+  matrix_cl<char> any_y_nonpositive_cl;
   matrix_cl<double> logp_cl;
   matrix_cl<double> y_deriv_cl;
   matrix_cl<double> alpha_deriv_cl;

--- a/stan/math/opencl/prim/inv_gamma_lpdf.hpp
+++ b/stan/math/opencl/prim/inv_gamma_lpdf.hpp
@@ -105,13 +105,15 @@ return_type_t<T_y_cl, T_shape_cl, T_scale_cl> inv_gamma_lpdf(
   matrix_cl<double> beta_deriv_cl;
 
   results(check_alpha_pos_finite, check_beta_pos_finite, check_y_not_nan,
-          logp_cl, y_deriv_cl, alpha_deriv_cl, beta_deriv_cl)
-      = expressions(alpha_pos_finite, beta_pos_finite, y_not_nan, logp_expr,
+          any_y_nonpositive_cl, logp_cl, y_deriv_cl, alpha_deriv_cl,
+          beta_deriv_cl)
+      = expressions(alpha_pos_finite, beta_pos_finite, y_not_nan,
+                    any_y_nonpositive, logp_expr,
                     calc_if<!is_constant<T_y_cl>::value>(y_deriv),
                     calc_if<!is_constant<T_shape_cl>::value>(alpha_deriv),
                     calc_if<!is_constant<T_scale_cl>::value>(beta_deriv));
 
-  if (from_matrix_cl(any_y_nonpositive).any()) {
+  if (from_matrix_cl(any_y_nonpositive_cl).any()) {
     return LOG_ZERO;
   }
 

--- a/stan/math/opencl/prim/logistic_cdf.hpp
+++ b/stan/math/opencl/prim/logistic_cdf.hpp
@@ -64,7 +64,7 @@ return_type_t<T_y_cl, T_loc_cl, T_scale_cl> logistic_cdf(
   auto sigma_positive_finite_expr = 0 < sigma_val && isfinite(sigma_val);
 
   auto any_y_neg_inf
-      = colwise_max(constant(0, N, 1) + (y_val == NEGATIVE_INFTY));
+      = colwise_max(cast<char>(y_val == NEGATIVE_INFTY));
   auto cond = y_val == INFTY;
   auto inv_sigma = elt_divide(1.0, sigma_val);
   auto mu_minus_y_div_sigma = elt_multiply(mu_val - y_val, inv_sigma);
@@ -78,7 +78,7 @@ return_type_t<T_y_cl, T_loc_cl, T_scale_cl> logistic_cdf(
                                        Pn));
   auto sigma_deriv_tmp = elt_multiply(y_deriv_tmp, mu_minus_y_div_sigma);
 
-  matrix_cl<double> any_y_neg_inf_cl;
+  matrix_cl<char> any_y_neg_inf_cl;
   matrix_cl<double> P_cl;
   matrix_cl<double> mu_deriv_cl;
   matrix_cl<double> y_deriv_cl;

--- a/stan/math/opencl/prim/logistic_lccdf.hpp
+++ b/stan/math/opencl/prim/logistic_lccdf.hpp
@@ -64,8 +64,8 @@ return_type_t<T_y_cl, T_loc_cl, T_scale_cl> logistic_lccdf(
   auto sigma_positive_finite_expr = 0 < sigma_val && isfinite(sigma_val);
 
   auto any_y_neg_inf
-      = colwise_max(constant(0, N, 1) + (y_val == NEGATIVE_INFTY));
-  auto any_y_pos_inf = colwise_max(constant(0, N, 1) + (y_val == INFTY));
+      = colwise_max(cast<char>(y_val == NEGATIVE_INFTY));
+  auto any_y_pos_inf = colwise_max(cast<char>(y_val == INFTY));
   auto inv_sigma = elt_divide(1.0, sigma_val);
   auto mu_minus_y_div_sigma = elt_multiply(mu_val - y_val, inv_sigma);
   auto exp_scaled_diff = exp(mu_minus_y_div_sigma);
@@ -78,8 +78,8 @@ return_type_t<T_y_cl, T_loc_cl, T_scale_cl> logistic_lccdf(
   auto y_deriv = -mu_deriv;
   auto sigma_deriv = elt_multiply(-mu_deriv, mu_minus_y_div_sigma);
 
-  matrix_cl<double> any_y_neg_inf_cl;
-  matrix_cl<double> any_y_pos_inf_cl;
+  matrix_cl<char> any_y_neg_inf_cl;
+  matrix_cl<char> any_y_pos_inf_cl;
   matrix_cl<double> P_cl;
   matrix_cl<double> mu_deriv_cl;
   matrix_cl<double> y_deriv_cl;

--- a/stan/math/opencl/prim/logistic_lcdf.hpp
+++ b/stan/math/opencl/prim/logistic_lcdf.hpp
@@ -64,7 +64,7 @@ return_type_t<T_y_cl, T_loc_cl, T_scale_cl> logistic_lcdf(
   auto sigma_positive_finite_expr = 0 < sigma_val && isfinite(sigma_val);
 
   auto any_y_neg_inf
-      = colwise_max(constant(0, N, 1) + (y_val == NEGATIVE_INFTY));
+      = colwise_max(cast<char>(y_val == NEGATIVE_INFTY));
   auto cond = y_val == INFTY;
   auto inv_sigma = elt_divide(1.0, sigma_val);
   auto mu_minus_y_div_sigma = elt_multiply(mu_val - y_val, inv_sigma);
@@ -78,7 +78,7 @@ return_type_t<T_y_cl, T_loc_cl, T_scale_cl> logistic_lcdf(
   auto mu_deriv = -y_deriv;
   auto sigma_deriv = elt_multiply(y_deriv, mu_minus_y_div_sigma);
 
-  matrix_cl<double> any_y_neg_inf_cl;
+  matrix_cl<char> any_y_neg_inf_cl;
   matrix_cl<double> P_cl;
   matrix_cl<double> mu_deriv_cl;
   matrix_cl<double> y_deriv_cl;

--- a/stan/math/opencl/prim/lognormal_cdf.hpp
+++ b/stan/math/opencl/prim/lognormal_cdf.hpp
@@ -63,7 +63,7 @@ return_type_t<T_y_cl, T_loc_cl, T_scale_cl> lognormal_cdf(
       = check_cl(function, "Scale parameter", sigma_val, "positive finite");
   auto sigma_positive_finite_expr = 0 < sigma_val && isfinite(sigma_val);
 
-  auto any_y_zero = colwise_max(constant(0, N, 1) + (y_val == 0.0));
+  auto any_y_zero = colwise_max(cast<char>(y_val == 0.0));
   auto log_y = log(y_val);
   auto scaled_diff = elt_divide(log_y - mu_val, sigma_val * SQRT_TWO);
   auto erfc_m_diff = erfc(-scaled_diff);
@@ -75,7 +75,7 @@ return_type_t<T_y_cl, T_loc_cl, T_scale_cl> lognormal_cdf(
   auto y_deriv_tmp = elt_divide(-mu_deriv_tmp, y_val);
   auto sigma_deriv_tmp = elt_multiply(mu_deriv_tmp, scaled_diff * SQRT_TWO);
 
-  matrix_cl<double> any_y_zero_cl;
+  matrix_cl<char> any_y_zero_cl;
   matrix_cl<double> cdf_cl;
   matrix_cl<double> mu_deriv_cl;
   matrix_cl<double> y_deriv_cl;

--- a/stan/math/opencl/prim/lognormal_lccdf.hpp
+++ b/stan/math/opencl/prim/lognormal_lccdf.hpp
@@ -63,7 +63,7 @@ return_type_t<T_y_cl, T_loc_cl, T_scale_cl> lognormal_lccdf(
       = check_cl(function, "Scale parameter", sigma_val, "positive finite");
   auto sigma_positive_finite_expr = 0 < sigma_val && isfinite(sigma_val);
 
-  auto any_y_zero = colwise_max(constant(0, N, 1) + (y_val == 0.0));
+  auto any_y_zero = colwise_max(cast<char>(y_val == 0.0));
   auto log_y = log(y_val);
   auto scaled_diff = elt_divide(log_y - mu_val, sigma_val * SQRT_TWO);
   auto erfc_calc = erfc(scaled_diff);
@@ -73,7 +73,7 @@ return_type_t<T_y_cl, T_loc_cl, T_scale_cl> lognormal_lccdf(
   auto y_deriv = elt_divide(mu_deriv, -y_val);
   auto sigma_deriv = elt_multiply(mu_deriv, scaled_diff * SQRT_TWO);
 
-  matrix_cl<double> any_y_zero_cl;
+  matrix_cl<char> any_y_zero_cl;
   matrix_cl<double> lccdf_cl;
   matrix_cl<double> y_deriv_cl;
   matrix_cl<double> mu_deriv_cl;

--- a/stan/math/opencl/prim/lognormal_lcdf.hpp
+++ b/stan/math/opencl/prim/lognormal_lcdf.hpp
@@ -63,7 +63,7 @@ return_type_t<T_y_cl, T_loc_cl, T_scale_cl> lognormal_lcdf(
       = check_cl(function, "Scale parameter", sigma_val, "positive finite");
   auto sigma_positive_finite_expr = 0 < sigma_val && isfinite(sigma_val);
 
-  auto any_y_zero = colwise_max(constant(0, N, 1) + (y_val == 0.0));
+  auto any_y_zero = colwise_max(cast<char>(y_val == 0.0));
   auto log_y = log(y_val);
   auto scaled_diff = elt_divide(log_y - mu_val, sigma_val * SQRT_TWO);
   auto erfc_calc = erfc(-scaled_diff);
@@ -73,7 +73,7 @@ return_type_t<T_y_cl, T_loc_cl, T_scale_cl> lognormal_lcdf(
   auto y_deriv = elt_divide(mu_deriv, -y_val);
   auto sigma_deriv = elt_multiply(mu_deriv, scaled_diff * SQRT_TWO);
 
-  matrix_cl<double> any_y_zero_cl;
+  matrix_cl<char> any_y_zero_cl;
   matrix_cl<double> lcdf_cl;
   matrix_cl<double> y_deriv_cl;
   matrix_cl<double> mu_deriv_cl;

--- a/stan/math/opencl/prim/lognormal_lpdf.hpp
+++ b/stan/math/opencl/prim/lognormal_lpdf.hpp
@@ -74,7 +74,7 @@ return_type_t<T_y_cl, T_loc_cl, T_scale_cl> lognormal_lpdf(
       = check_cl(function, "Scale parameter", sigma_val, "positive finite");
   auto sigma_pos_finite = sigma_val > 0 && isfinite(sigma_val);
 
-  auto any_y_zero = colwise_max(constant(0, N, 1) + (y_val == 0.0));
+  auto any_y_zero = colwise_max(cast<char>(y_val == 0.0));
   auto inv_sigma = elt_divide(1.0, sigma_val);
   auto inv_sigma_sq = elt_multiply(inv_sigma, inv_sigma);
   auto log_y = log(y_val);
@@ -93,7 +93,7 @@ return_type_t<T_y_cl, T_loc_cl, T_scale_cl> lognormal_lpdf(
   auto sigma_deriv_expr = elt_multiply(
       elt_multiply(logy_m_mu_div_sigma, logy_m_mu) - 1.0, inv_sigma);
 
-  matrix_cl<int> any_y_zero_cl;
+  matrix_cl<char> any_y_zero_cl;
   matrix_cl<double> logp_cl;
   matrix_cl<double> y_deriv_cl;
   matrix_cl<double> mu_deriv_cl;

--- a/stan/math/opencl/prim/pareto_cdf.hpp
+++ b/stan/math/opencl/prim/pareto_cdf.hpp
@@ -63,7 +63,7 @@ return_type_t<T_y_cl, T_scale_cl, T_shape_cl> pareto_cdf(
   auto alpha_positive_finite_expr = 0 < alpha_val && isfinite(alpha_val);
 
   auto any_y_lower_than_y_min
-      = colwise_max(constant(0, N, 1) + (y_val < y_min_val));
+      = colwise_max(cast<char>(y_val < y_min_val));
   auto cond = y_val == INFTY;
   auto log_dbl = log(elt_divide(y_min_val, y_val));
   auto y_min_inv = elt_divide(1.0, y_min_val);
@@ -80,7 +80,7 @@ return_type_t<T_y_cl, T_scale_cl, T_shape_cl> pareto_cdf(
   auto alpha_deriv = elt_multiply(y_min_alpha_deriv, -log_dbl);
 
   matrix_cl<double> cdf_cl;
-  matrix_cl<double> any_y_lower_than_y_min_cl;
+  matrix_cl<char> any_y_lower_than_y_min_cl;
   matrix_cl<double> y_min_deriv_cl;
   matrix_cl<double> y_deriv_cl;
   matrix_cl<double> alpha_deriv_cl;

--- a/stan/math/opencl/prim/pareto_lccdf.hpp
+++ b/stan/math/opencl/prim/pareto_lccdf.hpp
@@ -64,8 +64,8 @@ return_type_t<T_y_cl, T_scale_cl, T_shape_cl> pareto_lccdf(
   auto alpha_positive_finite_expr = 0 < alpha_val && isfinite(alpha_val);
 
   auto any_y_lower_than_y_min
-      = colwise_max(constant(0, N, 1) + (y_val < y_min_val));
-  auto any_y_inf = colwise_max(constant(0, N, 1) + isinf(y_val));
+      = colwise_max(cast<char>(y_val < y_min_val));
+  auto any_y_inf = colwise_max(cast<char>(isinf(y_val)));
 
   auto log_quot = log(elt_divide(y_min_val, y_val));
   auto lccdf_expr = colwise_sum(elt_multiply(alpha_val, log_quot));
@@ -75,8 +75,8 @@ return_type_t<T_y_cl, T_scale_cl, T_shape_cl> pareto_lccdf(
   auto y_deriv = elt_multiply(-y_min_deriv, exp(log_quot));
 
   matrix_cl<double> lccdf_cl;
-  matrix_cl<double> any_y_lower_than_y_min_cl;
-  matrix_cl<double> any_y_inf_cl;
+  matrix_cl<char> any_y_lower_than_y_min_cl;
+  matrix_cl<char> any_y_inf_cl;
   matrix_cl<double> y_min_deriv_cl;
   matrix_cl<double> y_deriv_cl;
   matrix_cl<double> alpha_deriv_cl;

--- a/stan/math/opencl/prim/pareto_lcdf.hpp
+++ b/stan/math/opencl/prim/pareto_lcdf.hpp
@@ -64,8 +64,8 @@ return_type_t<T_y_cl, T_scale_cl, T_shape_cl> pareto_lcdf(
   auto alpha_positive_finite_expr = 0 < alpha_val && isfinite(alpha_val);
 
   auto any_y_lower_than_y_min
-      = colwise_max(constant(0, N, 1) + (y_val < y_min_val));
-  auto any_y_inf = colwise_max(constant(0, N, 1) + isinf(y_val));
+      = colwise_max(cast<char>(y_val < y_min_val));
+  auto any_y_inf = colwise_max(cast<char>(isinf(y_val)));
 
   auto log_quot = log(elt_divide(y_min_val, y_val));
   auto exp_prod = exp(elt_multiply(alpha_val, log_quot));
@@ -79,8 +79,8 @@ return_type_t<T_y_cl, T_scale_cl, T_shape_cl> pareto_lcdf(
   auto alpha_deriv = elt_multiply(-common_deriv, log_quot);
 
   matrix_cl<double> lcdf_cl;
-  matrix_cl<double> any_y_lower_than_y_min_cl;
-  matrix_cl<double> any_y_inf_cl;
+  matrix_cl<char> any_y_lower_than_y_min_cl;
+  matrix_cl<char> any_y_inf_cl;
   matrix_cl<double> y_min_deriv_cl;
   matrix_cl<double> y_deriv_cl;
   matrix_cl<double> alpha_deriv_cl;

--- a/stan/math/opencl/prim/pareto_lpdf.hpp
+++ b/stan/math/opencl/prim/pareto_lpdf.hpp
@@ -70,7 +70,7 @@ return_type_t<T_y_cl, T_scale_cl, T_shape_cl> pareto_lpdf(
       = check_cl(function, "Shape parameter", alpha_val, "positive finite");
   auto alpha_positive_finite = 0 < alpha_val && isfinite(alpha_val);
 
-  auto y_less_than_y_min = colwise_max(constant(0, N, 1) + (y_val < y_min_val));
+  auto y_less_than_y_min = colwise_max(cast<char>(y_val < y_min_val));
   auto log_y = log(y_val);
   auto inv_y = elt_divide(1.0, y_val);
   auto log_y_min = log(y_min_val);
@@ -87,7 +87,7 @@ return_type_t<T_y_cl, T_scale_cl, T_shape_cl> pareto_lpdf(
   auto y_min_deriv = elt_divide(alpha_val, y_min_val);
   auto alpha_deriv = elt_divide(1.0, alpha_val) + log_y_min - log_y;
 
-  matrix_cl<int> y_less_than_y_min_cl;
+  matrix_cl<char> y_less_than_y_min_cl;
   matrix_cl<double> logp_cl;
   matrix_cl<double> y_min_deriv_cl;
   matrix_cl<double> y_deriv_cl;

--- a/stan/math/opencl/prim/poisson_log_lpmf.hpp
+++ b/stan/math/opencl/prim/poisson_log_lpmf.hpp
@@ -61,7 +61,7 @@ return_type_t<T_log_rate_cl> poisson_log_lpmf(const T_n_cl& n,
   auto alpha_not_nan = !isnan(alpha_val);
 
   auto return_log_zero = colwise_max(
-      constant(0, N, 1) + (isinf(alpha_val) && (alpha_val > 0 || n != 0)));
+      cast<char>(isinf(alpha_val) && (alpha_val > 0 || n != 0)));
   auto exp_alpha = exp(alpha_val);
 
   auto logp1 = elt_multiply(n, alpha_val);
@@ -72,7 +72,7 @@ return_type_t<T_log_rate_cl> poisson_log_lpmf(const T_n_cl& n,
 
   auto deriv = n - exp_alpha;
 
-  matrix_cl<int> return_log_zero_cl;
+  matrix_cl<char> return_log_zero_cl;
   matrix_cl<double> logp_cl;
   matrix_cl<double> deriv_cl;
 

--- a/stan/math/opencl/prim/poisson_lpmf.hpp
+++ b/stan/math/opencl/prim/poisson_lpmf.hpp
@@ -60,7 +60,7 @@ return_type_t<T_rate_cl> poisson_lpmf(const T_n_cl& n,
   auto lambda_nonnegative = 0.0 <= lambda_val;
 
   auto return_log_zero = colwise_max(
-      constant(0, N, 1) + (isinf(lambda_val) || (lambda_val == 0 && n != 0)));
+      cast<char> (isinf(lambda_val) || (lambda_val == 0 && n != 0)));
 
   auto logp1 = multiply_log(n, lambda_val);
   auto logp2 = static_select<include_summand<propto, T_rate_cl>::value>(
@@ -70,7 +70,7 @@ return_type_t<T_rate_cl> poisson_lpmf(const T_n_cl& n,
 
   auto deriv = elt_divide(n, lambda_val) - 1.0;
 
-  matrix_cl<int> return_log_zero_cl;
+  matrix_cl<char> return_log_zero_cl;
   matrix_cl<double> logp_cl;
   matrix_cl<double> deriv_cl;
 

--- a/stan/math/opencl/prim/scaled_inv_chi_square_lpdf.hpp
+++ b/stan/math/opencl/prim/scaled_inv_chi_square_lpdf.hpp
@@ -76,7 +76,7 @@ inline return_type_t<T_y_cl, T_dof_cl, T_scale_cl> scaled_inv_chi_square_lpdf(
       = check_cl(function, "Scale parameter", s_val, "positive finite");
   auto s_positive_finite = isfinite(s_val) && 0 < s_val;
 
-  auto any_y_nonpositive = colwise_max(constant(0, N, 1) + (y_val <= 0.0));
+  auto any_y_nonpositive = colwise_max(cast<char>(y_val <= 0.0));
   auto half_nu = 0.5 * nu_val;
   auto log_y = log(y_val);
   auto inv_y = elt_divide(1.0, y_val);
@@ -106,7 +106,7 @@ inline return_type_t<T_y_cl, T_dof_cl, T_scale_cl> scaled_inv_chi_square_lpdf(
   auto s_deriv = elt_divide(nu_val, s_val)
                  - elt_multiply(elt_multiply(nu_val, inv_y), s_val);
 
-  matrix_cl<int> any_y_nonpositive_cl;
+  matrix_cl<char> any_y_nonpositive_cl;
   matrix_cl<double> logp_cl;
   matrix_cl<double> nu_deriv_cl;
   matrix_cl<double> y_deriv_cl;

--- a/stan/math/opencl/prim/uniform_cdf.hpp
+++ b/stan/math/opencl/prim/uniform_cdf.hpp
@@ -69,7 +69,7 @@ return_type_t<T_y_cl, T_low_cl, T_high_cl> uniform_cdf(const T_y_cl& y,
   auto diff_positive_expr = b_minus_a > 0.0;
 
   auto any_y_out_of_bounds = colwise_max(
-      constant(0, N, 1) + (y_val < alpha_val || y_val > beta_val));
+      cast<char>(y_val < alpha_val || y_val > beta_val));
   auto cdf_n = elt_divide(y_val - alpha_val, b_minus_a);
   auto cdf_expr = colwise_prod(cdf_n);
 
@@ -78,7 +78,7 @@ return_type_t<T_y_cl, T_low_cl, T_high_cl> uniform_cdf(const T_y_cl& y,
   auto low_deriv1
       = elt_multiply(y_val - beta_val, elt_divide(y_deriv1, b_minus_a));
 
-  matrix_cl<double> any_y_out_of_bounds_cl;
+  matrix_cl<char> any_y_out_of_bounds_cl;
   matrix_cl<double> cdf_cl;
   matrix_cl<double> alpha_deriv_cl;
   matrix_cl<double> y_deriv_cl;

--- a/stan/math/opencl/prim/uniform_lccdf.hpp
+++ b/stan/math/opencl/prim/uniform_lccdf.hpp
@@ -68,7 +68,7 @@ return_type_t<T_y_cl, T_low_cl, T_high_cl> uniform_lccdf(
   auto diff_positive_expr = b_minus_a > 0.0;
 
   auto any_y_out_of_bounds = colwise_max(
-      constant(0, N, 1) + (y_val < alpha_val || y_val > beta_val));
+      cast<char>(y_val < alpha_val || y_val > beta_val));
   auto y_minus_alpha = y_val - alpha_val;
   auto ccdf_n = 1.0 - elt_divide(y_minus_alpha, b_minus_a);
   auto lccdf_expr = colwise_sum(log(ccdf_n));
@@ -78,7 +78,7 @@ return_type_t<T_y_cl, T_low_cl, T_high_cl> uniform_lccdf(
   auto low_deriv = elt_multiply(beta_val - y_val, rep_deriv);
   auto high_deriv = elt_multiply(y_minus_alpha, rep_deriv);
 
-  matrix_cl<double> any_y_out_of_bounds_cl;
+  matrix_cl<char> any_y_out_of_bounds_cl;
   matrix_cl<double> lccdf_cl;
   matrix_cl<double> alpha_deriv_cl;
   matrix_cl<double> y_deriv_cl;

--- a/stan/math/opencl/prim/uniform_lcdf.hpp
+++ b/stan/math/opencl/prim/uniform_lcdf.hpp
@@ -69,7 +69,7 @@ return_type_t<T_y_cl, T_low_cl, T_high_cl> uniform_lcdf(const T_y_cl& y,
   auto diff_positive_expr = b_minus_a > 0.0;
 
   auto any_y_out_of_bounds = colwise_max(
-      constant(0, N, 1) + (y_val < alpha_val || y_val > beta_val));
+      cast<char> (y_val < alpha_val || y_val > beta_val));
   auto y_minus_alpha = y_val - alpha_val;
   auto cdf_n = elt_divide(y_minus_alpha, b_minus_a);
   auto lcdf_expr = colwise_sum(log(cdf_n));
@@ -79,7 +79,7 @@ return_type_t<T_y_cl, T_low_cl, T_high_cl> uniform_lcdf(const T_y_cl& y,
       = elt_divide(y_val - beta_val, elt_multiply(b_minus_a, y_minus_alpha));
   auto high_deriv = elt_divide(-1.0, b_minus_a);
 
-  matrix_cl<double> any_y_out_of_bounds_cl;
+  matrix_cl<char> any_y_out_of_bounds_cl;
   matrix_cl<double> lcdf_cl;
   matrix_cl<double> alpha_deriv_cl;
   matrix_cl<double> y_deriv_cl;

--- a/stan/math/opencl/prim/uniform_lpdf.hpp
+++ b/stan/math/opencl/prim/uniform_lpdf.hpp
@@ -81,8 +81,7 @@ inline return_type_t<T_y_cl, T_low_cl, T_high_cl> uniform_lpdf(
       function, "Difference between upper and lower bound", diff, "positive");
   auto diff_positive = diff > 0;
 
-  auto y_out_of_bounds = colwise_max(constant(0, N, 1)
-                                     + (y_val < alpha_val || beta_val < y_val));
+  auto y_out_of_bounds = colwise_max(cast<char>(y_val < alpha_val || beta_val < y_val));
 
   auto logp_expr = colwise_sum(
       static_select<include_summand<propto, T_low_cl, T_high_cl>::value>(
@@ -90,7 +89,7 @@ inline return_type_t<T_y_cl, T_low_cl, T_high_cl> uniform_lpdf(
 
   auto inv_beta_minus_alpha = elt_divide(1.0, diff);
 
-  matrix_cl<int> y_out_of_bounds_cl;
+  matrix_cl<char> y_out_of_bounds_cl;
   matrix_cl<double> logp_cl;
   matrix_cl<double> alpha_deriv_cl;
   matrix_cl<double> beta_deriv_cl;

--- a/stan/math/opencl/prim/weibull_lpdf.hpp
+++ b/stan/math/opencl/prim/weibull_lpdf.hpp
@@ -66,7 +66,7 @@ inline return_type_t<T_y_cl, T_shape_cl, T_scale_cl> weibull_lpdf(
       = check_cl(function, "Scale parameter", sigma_val, "positive finite");
   auto sigma_positive_finite = isfinite(sigma_val) && 0 < sigma_val;
 
-  auto any_y_negative = colwise_max(constant(0, N, 1) + (y_val < 0));
+  auto any_y_negative = colwise_max(cast<char> (y_val < 0));
   auto log_y = log(y_val);
   auto log_sigma = log(sigma_val);
   auto inv_sigma = elt_divide(1., sigma_val);
@@ -91,7 +91,7 @@ inline return_type_t<T_y_cl, T_shape_cl, T_scale_cl> weibull_lpdf(
   auto sigma_deriv = elt_multiply(elt_multiply(alpha_val, inv_sigma),
                                   -one_m_y_div_sigma_pow_alpha);
 
-  matrix_cl<int> any_y_negative_cl;
+  matrix_cl<char> any_y_negative_cl;
   matrix_cl<double> logp_cl;
   matrix_cl<double> alpha_deriv_cl;
   matrix_cl<double> y_deriv_cl;

--- a/test/unit/math/opencl/kernel_generator/cast_test.cpp
+++ b/test/unit/math/opencl/kernel_generator/cast_test.cpp
@@ -1,0 +1,70 @@
+#ifdef STAN_OPENCL
+
+#include <stan/math/opencl/kernel_generator.hpp>
+#include <stan/math/opencl/matrix_cl.hpp>
+#include <stan/math/opencl/copy.hpp>
+#include <test/unit/math/opencl/kernel_generator/reference_kernel.hpp>
+#include <test/unit/util.hpp>
+#include <Eigen/Dense>
+#include <gtest/gtest.h>
+#include <string>
+
+using Eigen::Matrix;
+using Eigen::MatrixXd;
+using Eigen::MatrixXi;
+using stan::math::matrix_cl;
+
+TEST(KernelGenerator, cast_zero_size) {
+  matrix_cl<double> m_zero(0, 0);
+
+  EXPECT_NO_THROW(stan::math::cast<int>(m_zero));
+}
+
+TEST(KernelGenerator, cast_test) {
+  using stan::math::cast;
+  MatrixXd m1(2, 3);
+  m1 << 1, 2.5, 3.4, 4.7, 5.9, 6.3;
+
+  matrix_cl<double> m1_cl(m1);
+
+  matrix_cl<int> res_cl = cast<int>(m1_cl);
+
+  MatrixXi res = stan::math::from_matrix_cl(res_cl);
+
+  MatrixXi correct = m1.cast<int>();
+  EXPECT_MATRIX_NEAR(res, correct, 1e-9);
+}
+
+TEST(KernelGenerator, multiple_operations) {
+  using stan::math::cast;
+  MatrixXd m1(2, 3);
+  m1 << 1, 2.5, 3.4, 4.7, 5.9, 6.3;
+
+  matrix_cl<double> m1_cl(m1);
+  auto tmp = cast<double>(cast<int>(m1_cl));
+  matrix_cl<double> res_cl = tmp;
+
+  MatrixXd res = stan::math::from_matrix_cl(res_cl);
+
+  MatrixXd correct = m1.cast<int>().template cast<double>();
+  EXPECT_MATRIX_NEAR(res, correct, 1e-9);
+}
+
+TEST(KernelGenerator, multiple_operations_lvalue) {
+  using stan::math::cast;
+  MatrixXd m1(2, 3);
+  m1 << 1, 2.5, 3.4, 4.7, 5.9, 6.3;
+
+  matrix_cl<double> m1_cl(m1);
+  auto tmp = cast<int>(m1_cl);
+  matrix_cl<double> res_cl = cast<double>(tmp);
+
+  MatrixXd res = stan::math::from_matrix_cl(res_cl);
+
+  MatrixXd correct = m1.cast<int>().template cast<double>();
+  EXPECT_MATRIX_NEAR(res, correct, 1e-9);
+}
+
+
+
+#endif

--- a/test/unit/math/opencl/kernel_generator/cast_test.cpp
+++ b/test/unit/math/opencl/kernel_generator/cast_test.cpp
@@ -35,7 +35,7 @@ TEST(KernelGenerator, cast_test) {
   EXPECT_MATRIX_NEAR(res, correct, 1e-9);
 }
 
-TEST(KernelGenerator, multiple_operations) {
+TEST(KernelGenerator, cast_multiple_operations) {
   using stan::math::cast;
   MatrixXd m1(2, 3);
   m1 << 1, 2.5, 3.4, 4.7, 5.9, 6.3;
@@ -50,7 +50,7 @@ TEST(KernelGenerator, multiple_operations) {
   EXPECT_MATRIX_NEAR(res, correct, 1e-9);
 }
 
-TEST(KernelGenerator, multiple_operations_lvalue) {
+TEST(KernelGenerator, cast_multiple_operations_lvalue) {
   using stan::math::cast;
   MatrixXd m1(2, 3);
   m1 << 1, 2.5, 3.4, 4.7, 5.9, 6.3;


### PR DESCRIPTION
## Summary

Adds typecast operation to kernel generator and uses it in distributions instead of forcing type promotions by adding zero.

## Tests
Added tests for cast. Reminder of this PR is just refactor.

## Side Effects
None.

## Release notes

Adds typecast operation to kernel generator.

## Checklist

- [ ] Math issue #(issue number)

- [ ] Copyright holder: Tadej Ciglarič

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [ ] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [ ] the code is written in idiomatic C++ and changes are documented in the doxygen

- [ ] the new changes are tested
