### PR TITLE
Make constants constexpr (where possible)

### DIFF
--- a/stan/math/prim/fun/constants.hpp
+++ b/stan/math/prim/fun/constants.hpp
@@ -17,46 +17,53 @@ namespace math {
  *
  * @return Base of natural logarithm.
  */
-inline double e() { return boost::math::constants::e<double>(); }
+static constexpr double e() { return boost::math::constants::e<double>(); }
+
+/**
+ * Return the Euler's gamma constant.
+ *
+ * @return Euler's Gamma.
+ */
+static constexpr double egamma() { return boost::math::constants::euler<double>(); }
 
 /**
  * Return the value of pi.
  *
  * @return Pi.
  */
-inline double pi() { return boost::math::constants::pi<double>(); }
+static constexpr double pi() { return boost::math::constants::pi<double>(); }
 
 /**
  * Smallest positive value.
  */
-constexpr double EPSILON = std::numeric_limits<double>::epsilon();
+static constexpr double EPSILON = std::numeric_limits<double>::epsilon();
 
 /**
  * Positive infinity.
  */
-constexpr double INFTY = std::numeric_limits<double>::infinity();
+static constexpr double INFTY = std::numeric_limits<double>::infinity();
 
 /**
  * Negative infinity.
  */
-constexpr double NEGATIVE_INFTY = -INFTY;
+static constexpr double NEGATIVE_INFTY = -INFTY;
 
 /**
  * (Quiet) not-a-number value.
  */
-constexpr double NOT_A_NUMBER = std::numeric_limits<double>::quiet_NaN();
+static constexpr double NOT_A_NUMBER = std::numeric_limits<double>::quiet_NaN();
 
 /**
  * Twice the value of \f$ \pi \f$,
  * \f$ 2\pi \f$.
  */
-const double TWO_PI = 2.0 * pi();
+static constexpr double TWO_PI = boost::math::constants::two_pi<double>();
 
 /**
  * The natural logarithm of 0,
  * \f$ \log 0 \f$.
  */
-const double LOG_ZERO = std::log(0.0);
+static constexpr double LOG_ZERO = -INFTY;
 
 /**
  * The natural logarithm of machine precision \f$ \epsilon \f$,
@@ -71,16 +78,16 @@ const double LOG_EPSILON = std::log(EPSILON);
 const double LOG_PI = std::log(pi());
 
 /**
- * The natural logarithm of 0.5,
- * \f$ \log 0.5 \f$.
- */
-const double LOG_HALF = std::log(0.5);
-
-/**
  * The natural logarithm of 2,
  * \f$ \log 2 \f$.
  */
-const double LOG_TWO = std::log(2.0);
+static constexpr double LOG_TWO = boost::math::constants::ln_two<double>();
+
+/**
+ * The natural logarithm of 0.5,
+ * \f$ \log 0.5 = \log 1 - \log 2 \f$.
+ */
+static constexpr double LOG_HALF = -LOG_TWO;
 
 /**
  * The natural logarithm of 2 plus the natural logarithm of \f$ \pi \f$,
@@ -98,67 +105,67 @@ const double LOG_PI_OVER_FOUR = 0.25 * LOG_PI;
  * The natural logarithm of the square root of \f$ \pi \f$,
  * \f$ \log(sqrt{\pi}) \f$.
  */
-const double LOG_SQRT_PI = std::log(std::sqrt(pi()));
+const double LOG_SQRT_PI = std::log(boost::math::constants::root_pi<double>());
 
 /**
  * The natural logarithm of 10,
  * \f$ \log 10 \f$.
  */
-const double LOG_TEN = std::log(10.0);
+static constexpr double LOG_TEN = boost::math::constants::ln_ten<double>();
 
 /**
  * The value of the square root of 2,
  * \f$ \sqrt{2} \f$.
  */
-const double SQRT_TWO = std::sqrt(2.0);
+static constexpr double SQRT_TWO = boost::math::constants::root_two<double>();
 
 /**
  * The value of the square root of \f$ \pi \f$,
  * \f$ \sqrt{\pi} \f$.
  */
-const double SQRT_PI = std::sqrt(pi());
+static constexpr double SQRT_PI = boost::math::constants::root_pi<double>();
 
 /**
  * The value of the square root of \f$ 2\pi \f$,
  * \f$ \sqrt{2\pi} \f$.
  */
-const double SQRT_TWO_PI = std::sqrt(TWO_PI);
+static constexpr double SQRT_TWO_PI = boost::math::constants::root_two_pi<double>();
 
 /**
  * The square root of 2 divided by the square root of \f$ \pi \f$,
  * \f$ \sqrt{2} / \sqrt{\pi} \f$.
  */
-const double SQRT_TWO_OVER_SQRT_PI = SQRT_TWO / SQRT_PI;
+static constexpr double SQRT_TWO_OVER_SQRT_PI = SQRT_TWO / SQRT_PI;
 
 /**
  * The value of 1 over the square root of 2,
  * \f$ 1 / \sqrt{2} \f$.
  */
-const double INV_SQRT_TWO = inv(SQRT_TWO);
+static constexpr double INV_SQRT_TWO = boost::math::constants::one_div_root_two<double>();
 
 /**
  * The value of 1 over the square root of \f$ \pi \f$,
  * \f$ 1 / \sqrt{\pi} \f$.
  */
-const double INV_SQRT_PI = inv(SQRT_PI);
+static constexpr double INV_SQRT_PI = boost::math::constants::one_div_root_pi<double>();
 
 /**
  * The value of 1 over the square root of \f$ 2\pi \f$,
  * \f$ 1 / \sqrt{2\pi} \f$.
  */
-const double INV_SQRT_TWO_PI = inv(SQRT_TWO_PI);
+static constexpr double INV_SQRT_TWO_PI = boost::math::constants::one_div_root_two_pi<double>();
 
 /**
  * The value of 2 over the square root of \f$ \pi \f$,
  * \f$ 2 / \sqrt{\pi} \f$.
  */
-const double TWO_OVER_SQRT_PI = 2.0 / SQRT_PI;
+static constexpr double TWO_OVER_SQRT_PI = boost::math::constants::two_div_root_pi <double>();
 
 /**
  * The value of half the natural logarithm 2,
  * \f$ \log(2) / 2 \f$.
  */
-const double HALF_LOG_TWO = 0.5 * LOG_TWO;
+static constexpr double HALF_LOG_TWO = 0.5 * LOG_TWO;
 
 /**
  * The value of half the natural logarithm \f$ 2\pi \f$,
@@ -211,14 +218,14 @@ static constexpr inline double machine_precision() { return EPSILON; }
  *
  * @return Natural logarithm of ten.
  */
-inline double log10() { return LOG_TEN; }
+static constexpr inline double log10() { return LOG_TEN; }
 
 /**
  * Returns the square root of two.
  *
  * @return Square root of two.
  */
-inline double sqrt2() { return SQRT_TWO; }
+static constexpr inline double sqrt2() { return SQRT_TWO; }
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/prim/fun/constants.hpp
+++ b/stan/math/prim/fun/constants.hpp
@@ -24,7 +24,9 @@ static constexpr double e() { return boost::math::constants::e<double>(); }
  *
  * @return Euler's Gamma.
  */
-static constexpr double egamma() { return boost::math::constants::euler<double>(); }
+static constexpr double egamma() {
+    return boost::math::constants::euler<double>();
+}
 
 /**
  * Return the value of pi.
@@ -129,7 +131,8 @@ static constexpr double SQRT_PI = boost::math::constants::root_pi<double>();
  * The value of the square root of \f$ 2\pi \f$,
  * \f$ \sqrt{2\pi} \f$.
  */
-static constexpr double SQRT_TWO_PI = boost::math::constants::root_two_pi<double>();
+static constexpr double SQRT_TWO_PI
+  = boost::math::constants::root_two_pi<double>();
 
 /**
  * The square root of 2 divided by the square root of \f$ \pi \f$,
@@ -141,25 +144,29 @@ static constexpr double SQRT_TWO_OVER_SQRT_PI = SQRT_TWO / SQRT_PI;
  * The value of 1 over the square root of 2,
  * \f$ 1 / \sqrt{2} \f$.
  */
-static constexpr double INV_SQRT_TWO = boost::math::constants::one_div_root_two<double>();
+static constexpr double INV_SQRT_TWO
+  = boost::math::constants::one_div_root_two<double>();
 
 /**
  * The value of 1 over the square root of \f$ \pi \f$,
  * \f$ 1 / \sqrt{\pi} \f$.
  */
-static constexpr double INV_SQRT_PI = boost::math::constants::one_div_root_pi<double>();
+static constexpr double INV_SQRT_PI
+  = boost::math::constants::one_div_root_pi<double>();
 
 /**
  * The value of 1 over the square root of \f$ 2\pi \f$,
  * \f$ 1 / \sqrt{2\pi} \f$.
  */
-static constexpr double INV_SQRT_TWO_PI = boost::math::constants::one_div_root_two_pi<double>();
+static constexpr double INV_SQRT_TWO_PI
+  = boost::math::constants::one_div_root_two_pi<double>();
 
 /**
  * The value of 2 over the square root of \f$ \pi \f$,
  * \f$ 2 / \sqrt{\pi} \f$.
  */
-static constexpr double TWO_OVER_SQRT_PI = boost::math::constants::two_div_root_pi <double>();
+static constexpr double TWO_OVER_SQRT_PI
+  = boost::math::constants::two_div_root_pi <double>();
 
 /**
  * The value of half the natural logarithm 2,

--- a/test/unit/math/prim/fun/constants_test.cpp
+++ b/test/unit/math/prim/fun/constants_test.cpp
@@ -54,3 +54,6 @@ TEST(MathsConstants, two_over_sqrt_pi) {
 TEST(MathsConstants, inv_sqrt_two_pi) {
   EXPECT_FLOAT_EQ(.39894228040, stan::math::INV_SQRT_TWO_PI);
 }
+TEST(MathsConstants, egamma) {
+  EXPECT_FLOAT_EQ(-stan::math::digamma(1), stan::math::egamma());
+}


### PR DESCRIPTION
## Summary

This PR changes the declaration of constants to use `static constexpr` where supported.

`static constexpr` was used over plain `constexpr` as it compiles to more efficient assembly. Examples provided on godbolt below:

 - `constexpr`: https://godbolt.org/z/9q9cx38z6
 - `static constexpr`: https://godbolt.org/z/1hds8EKKe
 - `const double`: https://godbolt.org/z/MvWj73eY7

Additionally the Euler's Gamma constant was added after a request [on the forum](https://discourse.mc-stan.org/t/mathematical-constants/21834)

## Tests

Added test for `egamma`, and existing tests for constants all pass

## Side Effects

N/A

## Release notes

Changed constants to `static constexpr` for efficiency, added Euler's Gamma constant

## Checklist

- [ ] Math issue #(issue number)

- [x] Copyright holder: Andrew Johnson

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
